### PR TITLE
Minor fixes for gonka

### DIFF
--- a/decentralized-api/cosmosclient/account_client.go
+++ b/decentralized-api/cosmosclient/account_client.go
@@ -30,7 +30,7 @@ func PubKeyToAddress(pubKeyHex string) (string, error) {
 	ripemdHash := ripemdHasher.Sum(nil)
 
 	// Step 3: Bech32 encode
-	prefix := "cosmos"
+	prefix := "gonka"
 	fiveBitData, err := bech32.ConvertBits(ripemdHash, 8, 5, true)
 	if err != nil {
 		logging.Error("Failed to convert bits", types.Participants, "err", err)

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	recorder, err := cosmosclient.NewInferenceCosmosClientWithRetry(
 		context.Background(),
-		"cosmos",
+		"gonka",
 		10,
 		5*time.Second,
 		config,

--- a/inference-chain/scripts/init-docker-genesis.sh
+++ b/inference-chain/scripts/init-docker-genesis.sh
@@ -15,7 +15,6 @@ APP_NAME="inferenced"
 CHAIN_ID="gonka-testnet-1"
 COIN_DENOM="nicoin"
 STATE_DIR="/root/.inference"
-
 # Init the chain:
 # I'm using prod-sim as the chain name (production simulation)
 #   and icoin (intelligence coin) as the default denomination

--- a/local-test-net/docker-compose-local-genesis.yml
+++ b/local-test-net/docker-compose-local-genesis.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - KEY_NAME=${KEY_NAME}
       - IS_GENESIS=true
-      - INIT_TGBOT=true
+      - INIT_TGBOT=false
       - TGBOT_PRIVATE_KEY_PASS=${TGBOT_PRIVATE_KEY_PASS:-defaultpassword}
     networks:
       - chain-public


### PR DESCRIPTION
For now, turn off TGBOT (will need to regenerate key).
 Couple other catches for "gonka" vs "cosmos" prefix