### PR TITLE
Prepare tmkms state in template dir during Docrkerfile build stage

### DIFF
--- a/tmkms/docker/Dockerfile_import_keys
+++ b/tmkms/docker/Dockerfile_import_keys
@@ -12,19 +12,19 @@ RUN cargo install tmkms --features=softsign --version=0.12.0
 
 WORKDIR /root
 
-RUN tmkms init .tmkms
+RUN tmkms init /app/tmkms_init_data
 
 ARG TMKMS_TOML=tmkms.toml
 ARG PRIV_VALIDATOR_KEY=priv_validator_key.json
 ARG PRIV_VALIDATOR_STATE=priv_validator_state.json
 
-COPY ${TMKMS_TOML} /root/.tmkms/tmkms.toml
-COPY ${PRIV_VALIDATOR_KEY} /root/.tmkms/secrets/priv_validator_key.json
-COPY ${PRIV_VALIDATOR_STATE} /root/.tmkms/state/priv_validator_state.json
+COPY ${TMKMS_TOML} /app/tmkms_init_data/tmkms.toml
+COPY ${PRIV_VALIDATOR_KEY} /app/tmkms_init_data/secrets/priv_validator_key.json
+COPY ${PRIV_VALIDATOR_STATE} /app/tmkms_init_data/state/priv_validator_state.json
 
 COPY docker/init.sh /root/init.sh
 RUN chmod +x /root/init.sh
 
-RUN tmkms softsign import /root/.tmkms/secrets/priv_validator_key.json /root/.tmkms/secrets/priv_validator_key.softsign
+RUN tmkms softsign import /app/tmkms_init_data/secrets/priv_validator_key.json /app/tmkms_init_data/secrets/priv_validator_key.softsign
 
 ENTRYPOINT ["/root/init.sh"]

--- a/tmkms/docker/Dockerfile_keygen
+++ b/tmkms/docker/Dockerfile_keygen
@@ -12,10 +12,10 @@ RUN cargo install tmkms --features=softsign --version=0.12.0
 
 WORKDIR /root
 
-RUN tmkms init .tmkms
+RUN tmkms init /app/tmkms_init_data
 
 ARG TMKMS_TOML=tmkms.toml
-COPY ${TMKMS_TOML} /root/.tmkms/tmkms.toml
+COPY ${TMKMS_TOML} /app/tmkms_init_data/tmkms.toml
 COPY docker/init.sh /root/init.sh
 RUN chmod +x /root/init.sh
 

--- a/tmkms/docker/init.sh
+++ b/tmkms/docker/init.sh
@@ -1,9 +1,32 @@
 #!/bin/sh
 set -eu
-TOML_FILE="/root/.tmkms/tmkms.toml"
+
+TEMPLATE_DIR="/app/tmkms_init_data" # Where we initialized in the Dockerfile
+TARGET_DIR="/root/.tmkms"         # Where the volume is mounted
+TOML_FILE="$TARGET_DIR/tmkms.toml"
+
+if [ ! -d "$TARGET_DIR/secrets" ]; then
+  mkdir -p "$TARGET_DIR/secrets"
+fi
+if [ ! -d "$TARGET_DIR/state" ]; then
+  mkdir -p "$TARGET_DIR/state"
+fi
+
+if [ ! -f "$TOML_FILE" ]; then
+  echo "Initializing $TARGET_DIR from template $TEMPLATE_DIR..."
+  # Copy all contents, including hidden files. The dot at the end of TEMPLATE_DIR/. is important.
+  if [ -n "$(ls -A $TEMPLATE_DIR)" ]; then # Check if TEMPLATE_DIR is not empty
+    cp -R "$TEMPLATE_DIR/." "$TARGET_DIR/"
+    echo "Initialization complete."
+  else
+    echo "Warning: Template directory $TEMPLATE_DIR is empty. Skipping copy."
+  fi
+else
+  echo "$TARGET_DIR already initialized."
+fi
 
 if [ ! -w "$TOML_FILE" ]; then
-  echo "Error: Cannot write to $TOML_FILE"
+  echo "Error: Cannot write to $TOML_FILE. Check volume permissions and ensure it's not empty if this is the first run."
   exit 1
 fi
 
@@ -16,9 +39,21 @@ escaped_addr=$(printf '%s' "$VALIDATOR_LISTEN_ADDRESS" | sed 's/[\/&]/\\&/g')
 sed -i "s/^addr *= *\".*\"/addr = \"$escaped_addr\"/" "$TOML_FILE"
 
 echo "Set addr to \"$VALIDATOR_LISTEN_ADDRESS\" in $TOML_FILE"
+echo "Contents of $TOML_FILE:"
+cat "$TOML_FILE"
 
-if [ ! -f "/root/.tmkms/secrets/priv_validator_key.softsign" ]; then
-  tmkms softsign keygen /root/.tmkms/secrets/priv_validator_key.softsign
+if [ "${WITHKEYGEN:-false}" = "true" ] && [ ! -f "$TARGET_DIR/secrets/priv_validator_key.softsign" ]; then
+  echo "Generating new key in $TARGET_DIR/secrets/priv_validator_key.softsign as WITHKEYGEN is true and key is missing."
+  tmkms softsign keygen "$TARGET_DIR/secrets/priv_validator_key.softsign"
+elif [ "${WITHKEYGEN:-false}" = "true" ] && [ -f "$TARGET_DIR/secrets/priv_validator_key.softsign" ]; then
+  echo "Key $TARGET_DIR/secrets/priv_validator_key.softsign already exists. WITHKEYGEN is true, but skipping generation."
 fi
 
-tmkms start -c /root/.tmkms/tmkms.toml
+# For the import_keys case, the priv_validator_key.softsign should have been copied from TEMPLATE_DIR.
+# If it's not there, and we are not in keygen mode, it's an issue.
+if [ "${WITHKEYGEN:-false}" = "false" ] && [ ! -f "$TARGET_DIR/secrets/priv_validator_key.softsign" ]; then
+  echo "Error: Key $TARGET_DIR/secrets/priv_validator_key.softsign not found, and not in key generation mode. Ensure keys were imported correctly into the image's template directory."
+  exit 1
+fi
+
+tmkms start -c "$TOML_FILE"

--- a/tmkms/docker/init.sh
+++ b/tmkms/docker/init.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 set -eu
 
-TEMPLATE_DIR="/app/tmkms_init_data" # Where we initialized in the Dockerfile
-TARGET_DIR="/root/.tmkms"         # Where the volume is mounted
+# Copy file from TEMPLATE_DIR (used at docker build stage for initializing tmkms)
+#   to TARGET_DIR (where we mount the volume)
+TEMPLATE_DIR="/app/tmkms_init_data"
+TARGET_DIR="/root/.tmkms"
 TOML_FILE="$TARGET_DIR/tmkms.toml"
 
 if [ ! -d "$TARGET_DIR/secrets" ]; then
@@ -14,7 +16,6 @@ fi
 
 if [ ! -f "$TOML_FILE" ]; then
   echo "Initializing $TARGET_DIR from template $TEMPLATE_DIR..."
-  # Copy all contents, including hidden files. The dot at the end of TEMPLATE_DIR/. is important.
   if [ -n "$(ls -A $TEMPLATE_DIR)" ]; then # Check if TEMPLATE_DIR is not empty
     cp -R "$TEMPLATE_DIR/." "$TARGET_DIR/"
     echo "Initialization complete."


### PR DESCRIPTION
When building an image we initialize tmkms with state, config and keys using .tmkms directory. Then when running a container we mount a volume into that directory since we want to persist the key. Docker just copies the pre-existing content of the directory into the volume, but kubernetes overrides it.

Here's a more robust solution that makes the container work independently of the details of how a volume is mounted