### PR TITLE
More retries for k8s, workaround for missed TxResp

### DIFF
--- a/testermint/src/main/kotlin/ApplicationAPI.kt
+++ b/testermint/src/main/kotlin/ApplicationAPI.kt
@@ -107,14 +107,27 @@ data class ApplicationAPI(
     }
 
     fun getNodes(): List<NodeResponse> =
-        wrapLog("GetNodes", false) {
+        wrapLog("getNodes", false) {
             val url = urlFor(SERVER_TYPE_ADMIN)
-            val response = Fuel.get("$url/admin/v1/nodes")
-                .timeout(1000 * 10)  // 10 seconds connection timeout
-                .timeoutRead(1000 * 10)  // 10 seconds read timeout
-                .responseObject<List<NodeResponse>>(gsonDeserializer(cosmosJson))
-            logResponse(response)
-            response.third.get()
+            var lastException: Exception? = null
+            for (attempt in 1..3) {
+                try {
+                    val response = Fuel.get("$url/admin/v1/nodes")
+                        .timeout(1000 * 10)  // 10 seconds connection timeout
+                        .timeoutRead(1000 * 10)  // 10 seconds read timeout
+                        .responseObject<List<NodeResponse>>(gsonDeserializer(cosmosJson))
+                    logResponse(response)
+                    return@wrapLog response.third.get()
+                } catch (e: Exception) {
+                    lastException = e
+                    Logger.warn(e, "Exception during getNodes, retrying")
+                    if (attempt < 3) {
+                        Thread.sleep(5000) // 5 seconds delay
+                        continue
+                    }
+                }
+            }
+            throw lastException ?: Exception("Failed to get nodes after 3 attempts")
         }
 
     fun addNode(node: InferenceNode): InferenceNode = wrapLog("AddNode", true) {

--- a/testermint/src/main/kotlin/K8sInferencePair.kt
+++ b/testermint/src/main/kotlin/K8sInferencePair.kt
@@ -485,5 +485,11 @@ private fun sendLogLineToOutput(
     line: String,
     logOutput: LogOutput
 ) {
-    Logger.info(line)
+    // We can't just log directly, as this skips essential processing in
+    // The LogOutput class
+    val frame = com.github.dockerjava.api.model.Frame(
+        com.github.dockerjava.api.model.StreamType.STDOUT,
+        line.toByteArray()
+    )
+    logOutput.onNext(frame)
 }

--- a/testermint/src/main/kotlin/LocalInferencePair.kt
+++ b/testermint/src/main/kotlin/LocalInferencePair.kt
@@ -3,6 +3,7 @@ package com.productscience
 import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.api.model.*
 import com.github.dockerjava.core.DockerClientBuilder
+import com.github.kittinunf.fuel.core.FuelError
 import com.productscience.data.*
 import org.tinylog.kotlin.Logger
 import java.io.File
@@ -243,8 +244,24 @@ data class LocalInferencePair(
     }
 
     fun submitTransaction(args: List<String>, waitForProcessed: Boolean = true): TxResponse {
+        val start = Instant.now()
         val json = this.node.getTransactionJson(args)
-        val submittedTransaction = this.api.submitTransaction(json)
+        val submittedTransaction = try {
+            this.api.submitTransaction(json)
+        } catch (e: FuelError) {
+            Logger.info("Checking for read timeout in " + e.toString())
+            // We are seeing in k8s (remote) connections this timesout, even though the submit worked. This should pick
+            // up the TXHash from the api logs instead.
+            if (e.toString().contains("Read timed out")) {
+                Logger.info("Found read timeout, checking node logs for TX hash in " +
+                        this.api.logOutput.mostRecentTxResp)
+                this.api.logOutput.mostRecentTxResp?.takeIf { it.time.isAfter(start) }?.let {
+                    TxResponse(0, it.hash, "", 0, "", "", "", 0, 0, null, null, listOf())
+                } ?: throw e
+            } else {
+                throw e
+            }
+        }
         return if (waitForProcessed) {
             this.node.waitForTxProcessed(submittedTransaction.txhash)
         } else {

--- a/testermint/src/main/kotlin/Logging.kt
+++ b/testermint/src/main/kotlin/Logging.kt
@@ -50,11 +50,17 @@ interface HasConfig {
         }
 }
 
+data class TxResp(
+    val hash: String,
+    val time: Instant,
+)
+
 class LogOutput(val name: String, val type: String) : ResultCallback.Adapter<Frame>() {
     var currentHeight = 0L
     var minimumHeight = Long.MAX_VALUE
     val currentMessage = StringBuilder()
     val currentTimestamp: Instant? = null
+    var mostRecentTxResp: TxResp? = null
 
     override fun onNext(frame: Frame) = logContext(
         mapOf(
@@ -87,18 +93,7 @@ class LogOutput(val name: String, val type: String) : ResultCallback.Adapter<Fra
     }
 
     private fun log(logEntry: String) {
-        if (logEntry.contains("indexed block events")) {
-            "height=?.+\\[0m(\\d+)".toRegex().find(logEntry)?.let {
-                val height = it.groupValues[1].toLong()
-                if (height > currentHeight) {
-                    Logger.info("New block, height={}", height)
-                    currentHeight = height
-                    if (currentHeight < minimumHeight) {
-                        minimumHeight = currentHeight
-                    }
-                }
-            }
-        }
+        extractData(logEntry)
 
         val (level, message) = parseEntry(logEntry)
         if (level.startsWith("INF")) {
@@ -111,6 +106,33 @@ class LogOutput(val name: String, val type: String) : ResultCallback.Adapter<Fra
             Logger.warn(message)
         } else {
             Logger.trace(message)
+        }
+    }
+
+    private fun extractData(logEntry: String) {
+        if (logEntry.contains("indexed block events")) {
+            "height=?.+\\[0m(\\d+)".toRegex().find(logEntry)?.let {
+                val height = it.groupValues[1].toLong()
+                if (height > currentHeight) {
+                    Logger.info("New block, height={}", height)
+                    currentHeight = height
+                    if (currentHeight < minimumHeight) {
+                        minimumHeight = currentHeight
+                    }
+                }
+            }
+        }
+        if (logEntry.contains("TxResp")) {
+            Logger.info("TxResp received, height={}", currentHeight)
+            val txHashPattern = "txhash: ([A-F0-9]+)".toRegex()
+            val txHash = txHashPattern.find(logEntry)?.groupValues?.get(1)
+
+            if (txHash != null) {
+                mostRecentTxResp = TxResp(
+                    hash = txHash,
+                    time = Instant.now()
+                )
+            }
         }
     }
 

--- a/testermint/src/test/kotlin/KubernetesTests.kt
+++ b/testermint/src/test/kotlin/KubernetesTests.kt
@@ -85,7 +85,7 @@ class KubernetesTests : TestermintTest() {
     @Test
     fun k8sUpgrade() {
         val releaseTag = System.getenv("RELEASE_TAG") ?: "v0.1.4-25"
-
+//        val releaseTag = "v0.1.4-28"
         getK8sInferencePairs(inferenceConfig).use { k8sPairs ->
             val genesis = k8sPairs.first { it.name == "genesis" }
             val govParams = genesis.node.getGovParams()
@@ -131,6 +131,10 @@ class KubernetesTests : TestermintTest() {
             genesis.node.waitForMinimumBlock(upgradeBlock - 2, "upgradeBlock")
             logSection("Waiting for upgrade to finish")
             Thread.sleep(Duration.ofMinutes(5))
+        }
+        // After 5 minutes and a reboot, we need to reconnect
+        getK8sInferencePairs(inferenceConfig).use { k8sPairs ->
+            val genesis = k8sPairs.first { it.name == "genesis" }
             logSection("Verifying upgrade")
             genesis.node.waitForNextBlock(1)
             // Some other action?


### PR DESCRIPTION
We were getting timeouts a lot, especially on sending to the API via HTTP.
But I could see that the problem is on the response, the API does indeed get the message, so retries on message sending would mean duplicating messages.

Instead, I try to catch the message response as logged by the API and use that. It's very roundabout, but works reliably.
Need to figure out why the responses are timing out so frequently, though. It's not a matter of enough time, something is missing.