### PR TITLE
Move up the config update

### DIFF
--- a/decentralized-api/internal/event_listener/event_listener.go
+++ b/decentralized-api/internal/event_listener/event_listener.go
@@ -291,7 +291,7 @@ func (el *EventListener) processEvent(event *chainevents.JSONRPCResponse, worker
 
 		// Process using the new dispatcher
 		ctx := context.Background() // We could pass this from caller if needed
-		err = el.dispatcher.ProcessNewBlock(ctx, *blockInfo)
+		err = el.dispatcher.ProcessNewBlock(ctx, *blockInfo, el.configManager.GetHeight())
 		if err != nil {
 			logging.Error("Failed to process new block", types.EventProcessing, "error", err, "worker", workerName)
 		}

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -400,7 +400,7 @@ func (setup *IntegrationTestSetup) simulateBlock(height int64) error {
 		Block:   chainevents.Block{Header: chainevents.Header{Height: fmt.Sprintf("%v", height)}},
 		BlockId: chainevents.BlockId{Hash: fmt.Sprintf("hash-%d", height)},
 	}
-	return setup.Dispatcher.ProcessNewBlock(context.Background(), blockInfo)
+	return setup.Dispatcher.ProcessNewBlock(context.Background(), blockInfo, height-1)
 }
 
 func (setup *IntegrationTestSetup) getNodeClient(nodeId string, port int) *mlnodeclient.MockClient {


### PR DESCRIPTION
events are stuck in a queue until we update the config height. We don't want to wait around for all the additional verification to process the new events.