### PR TITLE
BUGFIX: persisten storage for `api-config.yml`

### DIFF
--- a/decentralized-api/scripts/init-docker.sh
+++ b/decentralized-api/scripts/init-docker.sh
@@ -70,9 +70,11 @@ fi
 mkdir -p /root/.dapi
 initial_config_file="/root/api-config.yaml"
 yaml_file="/root/.dapi/api-config.yaml"
-if [ -f "$initial_config_file" ]; then
+if [ ! -f "$yaml_file" ]; then
   echo "Copying initial config file to $yaml_file"
   cp "$initial_config_file" "$yaml_file"
+else
+  echo "Config file $yaml_file already exists"
 fi
 
 

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tmkms:
-    image: ghcr.io/product-science/tmkms-softsign-with-keygen:0.2.0
+    image: ghcr.io/product-science/tmkms-softsign-with-keygen:0.2.1
     container_name: tmkms
     restart: unless-stopped
     environment:
@@ -10,7 +10,7 @@ services:
 
   node:
     container_name: node
-    image: ghcr.io/product-science/inferenced:0.2.0
+    image: ghcr.io/product-science/inferenced:0.2.1
     command: ["sh", "./init-docker.sh"]
     volumes:
       - .inference:/root/.inference
@@ -45,7 +45,7 @@ services:
 
   api:
     container_name: api
-    image: ghcr.io/product-science/api:0.2.0
+    image: ghcr.io/product-science/api:0.2.1
     volumes:
       - .inference:/root/.inference
       - .dapi:/root/.dapi
@@ -73,7 +73,7 @@ services:
   
   proxy:
     container_name: proxy
-    image: ghcr.io/product-science/proxy:0.2.0
+    image: ghcr.io/product-science/proxy:0.2.1
     ports:
       - "${API_PORT:-8000}:80"
     environment:


### PR DESCRIPTION
## Problem

The `0.2.0` release contains a bug that causes the `/root/.dapi/api-config.yml` file in the `api` container to be reset upon restart.

This file is critical as it contains:
- The seed required to claim the epoch reward
- A list of registered MLNodes

If this file's state is lost, claiming the reward for the current epoch becomes impossible, and all MLNodes must be re-registered.

## Proposal

This pull request introduces a fix to the `api` container's entrypoint script. The script will now check if the configuration file already exists before initialization, preventing it from being reset.

### Release Process

We propose to apply this fix off-chain by creating a new `0.2.1` release from the following branch: https://github.com/gonka-ai/gonka/tree/gm/release-v0.2.1

The binaries in this release are identical to those in `0.2.0`, the only change is to the init-docker.sh script.

This process only affects the container infrastructure and preserves the existing on-chain behavior. This allows miners to apply the fix individually without a governance vote by pulling the changes and restarting the api container:

```
source config.env
docker compose pull
docker compose up api -d --no-deps
```
