### PR TITLE
Fix possible panics for negative coins

### DIFF
--- a/decentralized-api/cosmosclient/governance.go
+++ b/decentralized-api/cosmosclient/governance.go
@@ -16,9 +16,11 @@ type ProposalData struct {
 }
 
 func SubmitProposal(cosmosClient CosmosMessageClient, msg sdk.Msg, proposalData *ProposalData) error {
+	// cannot return err with fixed amount
+	coins, _ := types.GetCoins(100000000)
 	proposalMsg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{msg},
-		types.GetCoins(100000000), // FIXME: this should be equal to min deposit
+		coins, // FIXME: this should be equal to min deposit
 		cosmosClient.GetAccountAddress(),
 		proposalData.Metadata,
 		proposalData.Title,

--- a/inference-chain/x/inference/keeper/accountsettle_test.go
+++ b/inference-chain/x/inference/keeper/accountsettle_test.go
@@ -29,7 +29,11 @@ func calcExpectedRewards(participants []types.Participant) int64 {
 	}
 	w := decimal.NewFromInt(totalWorkCoins)
 	r := decimal.NewFromInt(1).Sub(decimal.NewFromFloat32(defaultSettleParameters.CurrentSubsidyPercentage))
-	return w.Div(r).IntPart()
+	rewardAmount := w.Div(r).IntPart()
+	if rewardAmount < 0 {
+		panic("Negative reward amount")
+	}
+	return rewardAmount
 }
 
 func TestReduceSubsidy(t *testing.T) {
@@ -158,7 +162,7 @@ func TestSingleSettle(t *testing.T) {
 	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1}, &defaultSettleParameters)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(result))
-	require.Equal(t, expectedRewardCoin, newCoin.Amount)
+	require.Equal(t, expectedRewardCoin, uint64(newCoin.Amount))
 	p1Result := result[0]
 	require.Equal(t, uint64(1000), p1Result.Settle.WorkCoins)
 	require.Equal(t, uint64(expectedRewardCoin), p1Result.Settle.RewardCoins)
@@ -179,7 +183,7 @@ func TestEvenSettle(t *testing.T) {
 	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1, participant2}, &defaultSettleParameters)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(result))
-	require.Equal(t, expectedRewardCoin, newCoin.Amount)
+	require.Equal(t, expectedRewardCoin, uint64(newCoin.Amount))
 	p1Result := result[0]
 	require.Equal(t, uint64(1000), p1Result.Settle.WorkCoins)
 	require.Equal(t, uint64(expectedRewardCoin/2), p1Result.Settle.RewardCoins)
@@ -277,7 +281,9 @@ func TestActualSettle(t *testing.T) {
 	})
 	expectedRewardCoin := calcExpectedRewards([]types.Participant{participant1, participant2})
 
-	mocks.BankKeeper.EXPECT().MintCoins(ctx, types.ModuleName, types.GetCoins(expectedRewardCoin), gomock.Any()).Return(nil)
+	coins, err2 := types.GetCoins(expectedRewardCoin)
+	require.NoError(t, err2)
+	mocks.BankKeeper.EXPECT().MintCoins(ctx, types.ModuleName, coins, gomock.Any()).Return(nil)
 	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	err := keeper.SettleAccounts(ctx, 10, 0)
 	require.NoError(t, err)

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
@@ -55,7 +55,7 @@ func (k msgServer) markInferenceAsInvalid(executor *types.Participant, inference
 	executor.CurrentEpochStats.InvalidatedInferences++
 	executor.ConsecutiveInvalidInferences++
 	executor.CoinBalance -= inference.ActualCost
-	k.BankKeeper.LogSubAccountTransaction(ctx, types.ModuleName, executor.Address, types.OwedSubAccount, sdk.NewInt64Coin(types.BaseCoin, inference.ActualCost), "inference_invalidated:"+inference.InferenceId)
+	k.SafeLogSubAccountTransaction(ctx, types.ModuleName, executor.Address, types.OwedSubAccount, inference.ActualCost, "inference_invalidated:"+inference.InferenceId)
 	k.LogInfo("Invalid Inference subtracted from Executor CoinBalance ", types.Balances, "inferenceId", inference.InferenceId, "executor", executor.Address, "actualCost", inference.ActualCost, "coinBalance", executor.CoinBalance)
 	// We need to refund the cost, so we have to lookup the person who paid
 	payer, found := k.GetParticipant(ctx, inference.RequestedBy)
@@ -63,7 +63,7 @@ func (k msgServer) markInferenceAsInvalid(executor *types.Participant, inference
 		k.LogError("Payer not found", types.Validation, "address", inference.RequestedBy)
 		return types.ErrParticipantNotFound
 	}
-	err := k.IssueRefund(ctx, uint64(inference.ActualCost), payer.Address, "invalidated_inference:"+inference.InferenceId)
+	err := k.IssueRefund(ctx, inference.ActualCost, payer.Address, "invalidated_inference:"+inference.InferenceId)
 	if err != nil {
 		k.LogError("Refund failed", types.Validation, "error", err)
 	}

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -120,7 +120,7 @@ func (k msgServer) processInferencePayments(
 		inference.EscrowAmount = escrowAmount
 	}
 	if payments.EscrowAmount < 0 {
-		err := k.IssueRefund(ctx, uint64(-payments.EscrowAmount), inference.RequestedBy, "inference_refund:"+inference.InferenceId)
+		err := k.IssueRefund(ctx, -payments.EscrowAmount, inference.RequestedBy, "inference_refund:"+inference.InferenceId)
 		if err != nil {
 			k.LogError("Unable to Issue Refund for started inference", types.Payments, err)
 		}
@@ -135,7 +135,7 @@ func (k msgServer) processInferencePayments(
 		executor.CurrentEpochStats.EarnedCoins += uint64(payments.ExecutorPayment)
 		executor.CurrentEpochStats.InferenceCount++
 		executor.LastInferenceTime = inference.EndBlockTimestamp
-		k.BankKeeper.LogSubAccountTransaction(ctx, executor.Address, types.ModuleName, types.OwedSubAccount, types.GetCoin(executor.CoinBalance), "inference_finished:"+inference.InferenceId)
+		k.SafeLogSubAccountTransaction(ctx, executor.Address, types.ModuleName, types.OwedSubAccount, executor.CoinBalance, "inference_started:"+inference.InferenceId)
 		k.SetParticipant(ctx, executor)
 	}
 	return inference, nil

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -92,7 +92,7 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 				k.LogInfo("Adjusting executor balance for validation", types.Validation, "executor", executor.Address, "adjustment", adjustment.WorkAdjustment)
 				k.LogInfo("Adjusting executor CoinBalance for validation", types.Balances, "executor", executor.Address, "adjustment", adjustment.WorkAdjustment, "coin_balance", executor.CoinBalance)
 				if adjustment.WorkAdjustment < 0 {
-					k.BankKeeper.LogSubAccountTransaction(ctx, msg.Creator, adjustment.ParticipantId, types.OwedSubAccount, types.GetCoin(-adjustment.WorkAdjustment), "share_validation_executor:"+inference.InferenceId)
+					k.SafeLogSubAccountTransaction(ctx, msg.Creator, adjustment.ParticipantId, types.OwedSubAccount, -adjustment.WorkAdjustment, "share_validation_executor:"+inference.InferenceId)
 				}
 			} else {
 				worker, found := k.GetParticipant(ctx, adjustment.ParticipantId)
@@ -104,7 +104,7 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 				k.LogInfo("Adjusting worker balance for validation", types.Validation, "worker", worker.Address, "adjustment", adjustment.WorkAdjustment)
 				k.LogInfo("Adjusting worker CoinBalance for validation", types.Balances, "worker", worker.Address, "adjustment", adjustment.WorkAdjustment, "coin_balance", worker.CoinBalance)
 				if adjustment.WorkAdjustment < 0 {
-					k.BankKeeper.LogSubAccountTransaction(ctx, msg.Creator, adjustment.ParticipantId, types.OwedSubAccount, types.GetCoin(-adjustment.WorkAdjustment), "share_validation_executor:"+inference.InferenceId)
+					k.SafeLogSubAccountTransaction(ctx, msg.Creator, adjustment.ParticipantId, types.OwedSubAccount, -adjustment.WorkAdjustment, "share_validation_executor:"+inference.InferenceId)
 				}
 				k.SetParticipant(ctx, worker)
 			}

--- a/inference-chain/x/inference/keeper/payment_handler.go
+++ b/inference-chain/x/inference/keeper/payment_handler.go
@@ -2,17 +2,12 @@ package keeper
 
 import (
 	"context"
+	"math"
 
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
 )
-
-type PaymentHandler interface {
-	PutPaymentInEscrow(ctx context.Context, inference *types.Inference) (int64, error)
-	MintRewardCoins(ctx context.Context, newCoins int64) error
-	PayParticipantFromEscrow(ctx context.Context, address string, amount uint64, memo string, vestingPeriods *uint64) error
-}
 
 func (k *Keeper) PutPaymentInEscrow(ctx context.Context, inference *types.Inference, cost int64) (int64, error) {
 	payeeAddress, err := sdk.AccAddressFromBech32(inference.RequestedBy)
@@ -20,7 +15,11 @@ func (k *Keeper) PutPaymentInEscrow(ctx context.Context, inference *types.Infere
 		return 0, err
 	}
 	k.LogDebug("Sending coins to escrow", types.Payments, "inference", inference.InferenceId, "coins", cost, "payee", payeeAddress)
-	err = k.BankKeeper.SendCoinsFromAccountToModule(ctx, payeeAddress, types.ModuleName, types.GetCoins(cost), "escrow for inferenceId:"+inference.InferenceId)
+	coins, err := types.GetCoins(cost)
+	if err != nil {
+		return 0, err
+	}
+	err = k.BankKeeper.SendCoinsFromAccountToModule(ctx, payeeAddress, types.ModuleName, coins, "escrow for inferenceId:"+inference.InferenceId)
 	if err != nil {
 		k.LogError("Error sending coins to escrow", types.Payments, "error", err)
 		return 0,
@@ -39,14 +38,18 @@ func (k *Keeper) MintRewardCoins(ctx context.Context, newCoins int64, memo strin
 		return sdkerrors.Wrapf(types.ErrCannotMintNegativeCoins, "coins: %d", newCoins)
 	}
 	k.LogInfo("Minting coins", types.Payments, "coins", newCoins, "moduleAccount", types.ModuleName)
-	return k.BankKeeper.MintCoins(ctx, types.ModuleName, types.GetCoins(newCoins), memo)
+	coins, err := types.GetCoins(newCoins)
+	if err != nil {
+		return err
+	}
+	return k.BankKeeper.MintCoins(ctx, types.ModuleName, coins, memo)
 }
 
-func (k *Keeper) PayParticipantFromEscrow(ctx context.Context, address string, amount uint64, memo string, vestingPeriods *uint64) error {
+func (k *Keeper) PayParticipantFromEscrow(ctx context.Context, address string, amount int64, memo string, vestingPeriods *uint64) error {
 	return k.PayParticipantFromModule(ctx, address, amount, types.ModuleName, memo, vestingPeriods)
 }
 
-func (k *Keeper) PayParticipantFromModule(ctx context.Context, address string, amount uint64, moduleName string, memo string, vestingPeriods *uint64) error {
+func (k *Keeper) PayParticipantFromModule(ctx context.Context, address string, amount int64, moduleName string, memo string, vestingPeriods *uint64) error {
 	participantAddress, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
 		return err
@@ -61,7 +64,10 @@ func (k *Keeper) PayParticipantFromModule(ctx context.Context, address string, a
 
 	if vestingPeriods != nil && *vestingPeriods > 0 {
 		// Route through streamvesting system
-		vestingAmount := types.GetCoins(int64(amount))
+		vestingAmount, err := types.GetCoins(amount)
+		if err != nil {
+			return err
+		}
 		// Vesting keeper should move funds and create vesting schedule
 		err = k.GetStreamVestingKeeper().AddVestedRewards(ctx, address, types.ModuleName, vestingAmount, vestingEpochs, memo+"_vested")
 		if err != nil {
@@ -70,7 +76,11 @@ func (k *Keeper) PayParticipantFromModule(ctx context.Context, address string, a
 		}
 	} else {
 		// Direct payment (existing logic)
-		err = k.BankKeeper.SendCoinsFromModuleToAccount(ctx, moduleName, participantAddress, types.GetCoins(int64(amount)), memo)
+		coins, err := types.GetCoins(amount)
+		if err != nil {
+			return err
+		}
+		err = k.BankKeeper.SendCoinsFromModuleToAccount(ctx, moduleName, participantAddress, coins, memo)
 	}
 	return err
 }
@@ -81,20 +91,41 @@ func (k *Keeper) BurnModuleCoins(ctx context.Context, burnCoins int64, memo stri
 		return nil
 	}
 	k.LogInfo("Burning coins", types.Payments, "coins", burnCoins)
-	err := k.BankKeeper.BurnCoins(ctx, types.ModuleName, types.GetCoins(burnCoins), memo)
+	coins, err := types.GetCoins(burnCoins)
+	if err != nil {
+		return err
+	}
+	err = k.BankKeeper.BurnCoins(ctx, types.ModuleName, coins, memo)
 	if err == nil {
 		k.AddTokenomicsData(ctx, &types.TokenomicsData{TotalBurned: uint64(burnCoins)})
 	}
 	return err
 }
 
-func (k *Keeper) IssueRefund(ctx context.Context, refundAmount uint64, address string, memo string) error {
+func (k *Keeper) IssueRefund(ctx context.Context, refundAmount int64, address string, memo string) error {
 	k.LogInfo("Issuing refund", types.Payments, "address", address, "amount", refundAmount)
 	err := k.PayParticipantFromEscrow(ctx, address, refundAmount, memo, nil) // Refunds should be direct payment
 	if err != nil {
 		k.LogError("Error issuing refund", types.Payments, "error", err)
 		return err
 	}
-	k.AddTokenomicsData(ctx, &types.TokenomicsData{TotalRefunded: refundAmount})
+	k.AddTokenomicsData(ctx, &types.TokenomicsData{TotalRefunded: uint64(refundAmount)})
 	return nil
+}
+
+func (k *Keeper) SafeLogSubAccountTransaction(ctx context.Context, recipient, sender, subaccount string, amount int64, memo string) {
+	coin, err := types.GetCoin(amount)
+	if err != nil {
+		k.LogError("Negative coins", types.Payments, "recipient", recipient, "sender", sender, "amount", amount, "memo", memo)
+	} else {
+		k.BankKeeper.LogSubAccountTransaction(ctx, recipient, sender, subaccount, coin, memo)
+	}
+}
+
+func (k *Keeper) SafeLogSubAccountTransactionUint(ctx context.Context, recipient, sender, subaccount string, amount uint64, memo string) {
+	if amount > uint64(math.MaxInt64) {
+		k.LogError("Amount exceeds int64 max", types.Payments, "recipient", recipient, "sender", sender, "amount", amount, "memo", memo)
+		return
+	}
+	k.SafeLogSubAccountTransaction(ctx, recipient, sender, subaccount, int64(amount), memo)
 }

--- a/inference-chain/x/inference/keeper/settle_amount.go
+++ b/inference-chain/x/inference/keeper/settle_amount.go
@@ -69,7 +69,7 @@ func (k Keeper) burnSettleAmount(ctx context.Context, settleAmount types.SettleA
 			k.LogError("Error burning settle amount coins", types.Settle, "error", err, "participant", settleAmount.Participant, "amount", totalCoins)
 			return err
 		}
-		k.BankKeeper.LogSubAccountTransaction(ctx, types.ModuleName, settleAmount.Participant, types.SettleSubAccount, sdk.NewInt64Coin(types.BaseCoin, int64(totalCoins)), reason)
+		k.SafeLogSubAccountTransaction(ctx, types.ModuleName, settleAmount.Participant, types.SettleSubAccount, totalCoins, reason)
 		k.LogInfo("Burned settle amount", types.Settle, "participant", settleAmount.Participant, "amount", totalCoins, "reason", reason)
 	}
 	return nil
@@ -88,8 +88,8 @@ func (k Keeper) SetSettleAmountWithBurn(ctx context.Context, settleAmount types.
 
 	// Set the new settle amount
 	k.SetSettleAmount(ctx, settleAmount)
-	k.BankKeeper.LogSubAccountTransaction(ctx, types.ModuleName, settleAmount.Participant, types.SettleSubAccount, sdk.NewInt64Coin(types.BaseCoin, int64(settleAmount.GetTotalCoins())), "awaiting claim")
-	k.BankKeeper.LogSubAccountTransaction(ctx, settleAmount.Participant, types.ModuleName, types.OwedSubAccount, sdk.NewInt64Coin(types.BaseCoin, int64(settleAmount.WorkCoins)), "moved to settled")
+	k.SafeLogSubAccountTransaction(ctx, types.ModuleName, settleAmount.Participant, types.SettleSubAccount, settleAmount.GetTotalCoins(), "awaiting claim")
+	k.SafeLogSubAccountTransactionUint(ctx, settleAmount.Participant, types.ModuleName, types.OwedSubAccount, settleAmount.WorkCoins, "moved to settler")
 	return nil
 }
 

--- a/inference-chain/x/inference/keeper/settle_amount.go
+++ b/inference-chain/x/inference/keeper/settle_amount.go
@@ -89,7 +89,7 @@ func (k Keeper) SetSettleAmountWithBurn(ctx context.Context, settleAmount types.
 	// Set the new settle amount
 	k.SetSettleAmount(ctx, settleAmount)
 	k.SafeLogSubAccountTransaction(ctx, types.ModuleName, settleAmount.Participant, types.SettleSubAccount, settleAmount.GetTotalCoins(), "awaiting claim")
-	k.SafeLogSubAccountTransactionUint(ctx, settleAmount.Participant, types.ModuleName, types.OwedSubAccount, settleAmount.WorkCoins, "moved to settler")
+	k.SafeLogSubAccountTransactionUint(ctx, settleAmount.Participant, types.ModuleName, types.OwedSubAccount, settleAmount.WorkCoins, "moved to settled")
 	return nil
 }
 

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -201,7 +201,7 @@ func (am AppModule) handleExpiredInference(ctx context.Context, inference types.
 	am.LogInfo("Inference expired, not finished. Issuing refund", types.Inferences, "inferenceId", inference.InferenceId, "executor", inference.AssignedTo)
 	inference.Status = types.InferenceStatus_EXPIRED
 	inference.ActualCost = 0
-	err := am.keeper.IssueRefund(ctx, uint64(inference.EscrowAmount), inference.RequestedBy, "expired_inference:"+inference.InferenceId)
+	err := am.keeper.IssueRefund(ctx, inference.EscrowAmount, inference.RequestedBy, "expired_inference:"+inference.InferenceId)
 	if err != nil {
 		am.LogError("Error issuing refund", types.Inferences, "error", err)
 	}

--- a/inference-chain/x/inference/module/top_miners.go
+++ b/inference-chain/x/inference/module/top_miners.go
@@ -42,7 +42,7 @@ func (am AppModule) RegisterTopMiners(ctx context.Context, participants []*types
 			am.keeper.SetTopMiner(ctx, typedAction.Miner)
 			params := am.keeper.GetParams(ctx)
 			topMinerVestingPeriod := &params.TokenomicsParams.TopMinerVestingPeriod
-			err := am.keeper.PayParticipantFromModule(ctx, typedAction.Miner.Address, uint64(typedAction.Payout), types.TopRewardPoolAccName, "top_miner", topMinerVestingPeriod)
+			err := am.keeper.PayParticipantFromModule(ctx, typedAction.Miner.Address, typedAction.Payout, types.TopRewardPoolAccName, "top_miner", topMinerVestingPeriod)
 			if err != nil {
 				return err
 			}

--- a/inference-chain/x/inference/types/coin.go
+++ b/inference-chain/x/inference/types/coin.go
@@ -11,9 +11,15 @@ const (
 )
 
 // NOTE: In ALL cases, if we represent coins as an int, they should be in BaseCoin units
-func GetCoins(coins int64) sdk.Coins {
-	return sdk.NewCoins(GetCoin(coins))
+func GetCoins(coins int64) (sdk.Coins, error) {
+	coin, err := GetCoin(coins)
+	return sdk.NewCoins(coin), err
 }
-func GetCoin(coin int64) sdk.Coin {
-	return sdk.NewInt64Coin(BaseCoin, coin)
+
+// Negative coins will cause a panic!
+func GetCoin(coin int64) (sdk.Coin, error) {
+	if coin < 0 {
+		return sdk.Coin{}, ErrNegativeCoinBalance
+	}
+	return sdk.NewInt64Coin(BaseCoin, coin), nil
 }

--- a/inference-chain/x/inference/types/errors.go
+++ b/inference-chain/x/inference/types/errors.go
@@ -47,4 +47,5 @@ var (
 	ErrEpochNotFound                           = sdkerrors.Register(ModuleName, 1136, "epoch not found")
 	ErrIllegalState                            = sdkerrors.Register(ModuleName, 1137, "illegal state for the operation requested")
 	ErrInvalidValidationThreshold              = sdkerrors.Register(ModuleName, 1138, "validation threshold must be in [0, 100] range")
+	ErrNegativeRewardAmount                    = sdkerrors.Register(ModuleName, 1139, "negative reward amount")
 )

--- a/inference-chain/x/inference/types/settle_amount.go
+++ b/inference-chain/x/inference/types/settle_amount.go
@@ -1,5 +1,11 @@
 package types
 
-func (sa *SettleAmount) GetTotalCoins() uint64 {
-	return sa.RewardCoins + sa.WorkCoins
+import "math"
+
+func (sa *SettleAmount) GetTotalCoins() int64 {
+	sum := sa.RewardCoins + sa.WorkCoins
+	if sum > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(sum)
 }


### PR DESCRIPTION
### Motivation
Panics in our EndBlock Go code will cause a consensus failure, halting the change and requiring a difficult chain reboot.

Even the most unlikely panic needs to be prevented. This PR focuses on possible panics that come from situations where there are negative coin balances at various points. While these negative balances should not happen, there are some edge cases where they might, and a consensus failure if far too risky to ignore.

Additionally, we use `uint64` in places inside our code, which could present dangerous roll-over errors when the value might go negative. We should start removing such code. 

### Solution

`sdk.NewInt64Coin` WILL panic if it gets a negative value. 

- Add error checking for every instance where we use NewInt64Coin (minus a few in Genesis we can ignore) 
- Add a Safe method for logging subaccount transactions to reduce the (now) needed boilerplate 
- Move from using uint64 in our interior methods. In the future, we need to strictly use uint64 at the edges (messages, apis) only. The risk of 0 - 1 = uint64.Max is real, and Go idioms avoid uints in general.

Of course, in most cases a negative balance is a serious problem that needs to be addressed, but causing a consensus failure needs to be impossible.