### PR TITLE
dynamic resolve for docker address

### DIFF
--- a/deploy/join/nginx.conf
+++ b/deploy/join/nginx.conf
@@ -2,8 +2,12 @@ events {}
 
 http {
 
+    resolver 127.0.0.11 valid=10s;
+    resolver_timeout 5s;
+
     upstream mlnode_v308 {
-        server mlnode-308:8080;
+        zone mlnode_v308 64k;
+        server mlnode-308:8080 resolve;
     }
 
     server {
@@ -33,7 +37,8 @@ http {
     }
 
     upstream mlnode_v308_port5000 {
-        server mlnode-308:5000;
+        zone mlnode_v308_port5000 64k;
+        server mlnode-308:5000 resolve;
     }
 
     server {

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25-alpine
+FROM nginx:1.28-alpine
 
 # Install curl and gettext (for envsubst)
 RUN apk add --no-cache curl gettext

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -46,7 +46,8 @@ if [ "$DASHBOARD_ENABLED" = "true" ]; then
     
     # Set up dashboard upstream and root location for enabled dashboard
     export DASHBOARD_UPSTREAM="upstream dashboard_backend {
-        server ${FINAL_EXPLORER_SERVICE}:${DASHBOARD_PORT};
+        zone upstream_dynamic 64k;
+        server ${FINAL_EXPLORER_SERVICE}:${DASHBOARD_PORT} resolve;
     }"
     
     export ROOT_LOCATION="location / {

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -6,22 +6,22 @@ http {
     resolver 127.0.0.11 valid=10s;
     resolver_timeout 5s;
     upstream api_backend {
-        zone upstream_dynamic 64k; 
+        zone api_backend 64k; 
         server ${FINAL_API_SERVICE}:${API_PORT} resolve;
     }
 
     upstream chain_rpc_backend {
-        zone upstream_dynamic 64k;
+        zone chain_rpc_backend 64k;
         server ${FINAL_NODE_SERVICE}:${CHAIN_RPC_PORT} resolve;
     }
 
     upstream chain_api_backend {
-        zone upstream_dynamic 64k;
+        zone chain_api_backend 64k;
         server ${FINAL_NODE_SERVICE}:${CHAIN_API_PORT} resolve;
     }
 
     upstream chain_grpc_backend {
-        zone upstream_dynamic 64k;
+        zone chain_grpc_backend 64k;
         server ${FINAL_NODE_SERVICE}:${CHAIN_GRPC_PORT} resolve;
     }
 

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -3,20 +3,26 @@ events {
 }
 
 http {
+    resolver 127.0.0.11 valid=10s;
+    resolver_timeout 5s;
     upstream api_backend {
-        server ${FINAL_API_SERVICE}:${API_PORT};
+        zone upstream_dynamic 64k; 
+        server ${FINAL_API_SERVICE}:${API_PORT} resolve;
     }
 
     upstream chain_rpc_backend {
-        server ${FINAL_NODE_SERVICE}:${CHAIN_RPC_PORT};
+        zone upstream_dynamic 64k;
+        server ${FINAL_NODE_SERVICE}:${CHAIN_RPC_PORT} resolve;
     }
 
     upstream chain_api_backend {
-        server ${FINAL_NODE_SERVICE}:${CHAIN_API_PORT};
+        zone upstream_dynamic 64k;
+        server ${FINAL_NODE_SERVICE}:${CHAIN_API_PORT} resolve;
     }
 
     upstream chain_grpc_backend {
-        server ${FINAL_NODE_SERVICE}:${CHAIN_GRPC_PORT};
+        zone upstream_dynamic 64k;
+        server ${FINAL_NODE_SERVICE}:${CHAIN_GRPC_PORT} resolve;
     }
 
     # Dashboard upstream - only included if DASHBOARD_PORT is set


### PR DESCRIPTION
# Problem:
- If a container is recreated, its IP in the Docker network might change.
- The current nginx doesn't re-resolve the container's new IP, resulting in 502.

## Example:
```
curl http://gonka.spv.re:8000/v1/models
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.25.5</center>
</body>
</html>
```

## To reproduce:
```
docker network disconnect join_default api && docker run -d --rm --network join_default alpine sleep 300 && docker network connect join_default api
```

# Fix:
- Newest open-source nginx (since 1.27.3) resolves upstream dynamically.
- PR enables that behavior in the proxy.

