### PR TITLE
Fix division by zero in legacy weight distribution

### DIFF
--- a/inference-chain/x/inference/module/model_assignment.go
+++ b/inference-chain/x/inference/module/model_assignment.go
@@ -260,6 +260,11 @@ func (ma *ModelAssigner) distributeLegacyWeight(originalMLNodes []*types.MLNodeI
 	totalLegacyWeight := legacyMLNode.PocWeight
 	numHardwareNodes := int64(len(hardwareNodes.HardwareNodes))
 	numNodesToDistributeWeight := numHardwareNodes - numPreservedNodes
+	if numNodesToDistributeWeight <= 0 {
+		ma.LogInfo("No nodes to distribute weight to, returning original list.", types.PoC, "flow_context", flowContext, "sub_flow_context", subFlowContext, "step", "no_nodes_to_distribute_weight")
+		return newMLNodes
+	}
+
 	weightPerNode := totalLegacyWeight / numNodesToDistributeWeight
 	remainderWeight := totalLegacyWeight % numNodesToDistributeWeight
 	ma.LogInfo("Calculated weight distribution", types.PoC,


### PR DESCRIPTION
Someone turned off all of their nodes except for the preserved ones, thus `numHardwareNodes - numPreservedNodes == 0`. This caused a division by zero during weight distribution among preserved nodes.

Fixed by returning early from the function