### PR TITLE
Empty nodeId

### DIFF
--- a/decentralized-api/internal/validation/inference_validation.go
+++ b/decentralized-api/internal/validation/inference_validation.go
@@ -685,7 +685,10 @@ func compareLogits(
 	baseComparisonResult BaseValidationResult,
 ) ValidationResult {
 	if len(originalLogits) != len(validationLogits) {
-		logging.Error("Different length of logits", types.Validation, "originalLogits", originalLogits, "validationLogits", validationLogits, "lengthOriginal", len(originalLogits), "lengthValidation", len(validationLogits))
+		logging.Warn("Different length of logits", types.Validation, "originalLogits", originalLogits, "validationLogits", validationLogits, "lengthOriginal", len(originalLogits), "lengthValidation", len(validationLogits))
+	}
+	if len(validationLogits) < len(originalLogits) {
+		logging.Warn("Validation logits are shorter than original logits", types.Validation, "originalLogits", originalLogits, "validationLogits", validationLogits, "lengthOriginal", len(originalLogits), "lengthValidation", len(validationLogits))
 		return &DifferentLengthValidationResult{baseComparisonResult}
 	}
 

--- a/inference-chain/x/inference/calculations/stats.go
+++ b/inference-chain/x/inference/calculations/stats.go
@@ -1,0 +1,150 @@
+package calculations
+
+import (
+	"errors"
+	"sort"
+)
+
+// Threshold represents a critical value for a given sample size.
+type Threshold struct {
+	Total          int
+	CriticalMisses int
+}
+
+// The values here correspond to p0=0.10 and alpha=0.05.
+var criticalValueTable = []Threshold{
+	{2, 2},
+	{3, 2},
+	{4, 2},
+	{5, 3},
+	{10, 4},
+	{20, 5},
+	{30, 7},
+	{40, 8},
+	{50, 10},
+	{60, 11},
+	{70, 12},
+	{80, 14},
+	{90, 15},
+	{100, 16},
+	{110, 17},
+	{120, 19},
+	{130, 20},
+	{140, 21},
+	{150, 22},
+	{160, 23},
+	{170, 25},
+	{180, 26},
+	{190, 27},
+	{200, 28},
+	{210, 29},
+	{220, 31},
+	{230, 32},
+	{240, 33},
+	{250, 34},
+	{260, 35},
+	{270, 36},
+	{280, 37},
+	{290, 39},
+	{300, 40},
+	{310, 41},
+	{320, 42},
+	{330, 43},
+	{340, 44},
+	{350, 45},
+	{360, 47},
+	{370, 48},
+	{380, 49},
+	{390, 50},
+	{400, 51},
+	{410, 52},
+	{420, 53},
+	{430, 54},
+	{440, 56},
+	{450, 57},
+	{460, 58},
+	{470, 59},
+	{480, 60},
+	{490, 61},
+	{500, 62},
+	{510, 63},
+	{520, 64},
+	{530, 66},
+	{540, 67},
+	{550, 68},
+	{560, 69},
+	{570, 70},
+	{580, 71},
+	{590, 72},
+	{600, 73},
+	{610, 74},
+	{620, 76},
+	{630, 77},
+	{640, 78},
+	{650, 79},
+	{660, 80},
+	{670, 81},
+	{680, 82},
+	{690, 83},
+	{700, 84},
+	{710, 85},
+	{720, 86},
+	{730, 88},
+	{740, 89},
+	{750, 90},
+	{760, 91},
+	{770, 92},
+	{780, 93},
+	{790, 94},
+	{800, 95},
+	{810, 96},
+	{820, 97},
+	{830, 98},
+	{840, 100},
+	{850, 101},
+	{860, 102},
+	{870, 103},
+	{880, 104},
+	{890, 105},
+	{900, 106},
+	{910, 107},
+	{920, 108},
+	{930, 109},
+	{940, 110},
+	{950, 111},
+	{960, 113},
+	{970, 114},
+	{980, 115},
+	{990, 116},
+}
+
+// MissedStatTest performs a deterministic, on-chain safe check using a pre-computed lookup table.
+// It returns 'true' if the number of misses is acceptable (test passes).
+func MissedStatTest(nMissed, nTotal int) (bool, error) {
+	if nMissed < 0 || nTotal <= 0 || nMissed > nTotal {
+		return false, errors.New("invalid input: requires 0 <= nMissed <= nTotal and nTotal > 0")
+	}
+
+	if nTotal > 990 {
+		return nMissed*10 <= nTotal, nil
+	}
+
+	// Find the critical number of misses for the given nTotal using a binary search.
+	idx := sort.Search(len(criticalValueTable), func(i int) bool {
+		return criticalValueTable[i].Total > nTotal
+	})
+
+	// idx is the index of the first element with Total > nTotal.
+	// We need the "floor" value, which is the element at idx - 1.
+	if idx == 0 {
+		// nTotal is smaller than the first entry in the table
+		return true, nil
+	}
+
+	// The relevant threshold is the one for the largest total that is still <= nTotal.
+	criticalValue := criticalValueTable[idx-1].CriticalMisses
+
+	// The test passes if the observed number of misses is LESS THAN OR EQUAL TO the critical value.
+	// If nMissed is greater than the critical value, the test fails.
+	return nMissed <= criticalValue, nil
+}

--- a/inference-chain/x/inference/calculations/stats.go
+++ b/inference-chain/x/inference/calculations/stats.go
@@ -124,7 +124,7 @@ func MissedStatTest(nMissed, nTotal int) (bool, error) {
 	if nTotal == 0 {
 		return true, nil
 	}
-	if nMissed < 0 || nTotal <= 0 || nMissed > nTotal {
+	if nMissed < 0 || nTotal < 0 || nMissed > nTotal {
 		return false, errors.New("invalid input: requires 0 <= nMissed <= nTotal and nTotal > 0")
 	}
 

--- a/inference-chain/x/inference/calculations/stats.go
+++ b/inference-chain/x/inference/calculations/stats.go
@@ -121,6 +121,9 @@ var criticalValueTable = []Threshold{
 // MissedStatTest performs a deterministic, on-chain safe check using a pre-computed lookup table.
 // It returns 'true' if the number of misses is acceptable (test passes).
 func MissedStatTest(nMissed, nTotal int) (bool, error) {
+	if nTotal == 0 {
+		return true, nil
+	}
 	if nMissed < 0 || nTotal <= 0 || nMissed > nTotal {
 		return false, errors.New("invalid input: requires 0 <= nMissed <= nTotal and nTotal > 0")
 	}

--- a/inference-chain/x/inference/calculations/stats_test.go
+++ b/inference-chain/x/inference/calculations/stats_test.go
@@ -1,0 +1,575 @@
+package calculations
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMissedStatTestErrorConditions(t *testing.T) {
+	tests := []struct {
+		name     string
+		nMissed  int
+		nTotal   int
+		expected bool
+		wantErr  bool
+	}{
+		{
+			name:     "negative missed count",
+			nMissed:  -1,
+			nTotal:   10,
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "zero total",
+			nMissed:  0,
+			nTotal:   0,
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "negative total",
+			nMissed:  0,
+			nTotal:   -5,
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "missed greater than total",
+			nMissed:  15,
+			nTotal:   10,
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "both negative",
+			nMissed:  -1,
+			nTotal:   -1,
+			expected: false,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MissedStatTest(tt.nMissed, tt.nTotal)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MissedStatTest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("MissedStatTest() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMissedStatTest(t *testing.T) {
+	tests := []struct {
+		name     string
+		nMissed  int
+		nTotal   int
+		expected bool
+		wantErr  bool
+	}{
+		// Test cases with exact lookup map values
+		{
+			name:     "exact lookup - 10 total, 3 missed (passes)",
+			nMissed:  3,
+			nTotal:   10,
+			expected: true, // 3 <= 4 (critical value), so passes
+		},
+		{
+			name:     "exact lookup - 10 total, 4 missed (boundary - passes)",
+			nMissed:  4,
+			nTotal:   10,
+			expected: true, // 4 <= 4 (critical value), so passes
+		},
+		{
+			name:     "exact lookup - 10 total, 5 missed (exceeds)",
+			nMissed:  5,
+			nTotal:   10,
+			expected: false, // 5 > 4 (critical value), so fails
+		},
+		{
+			name:     "exact lookup - 20 total, 4 missed (passes)",
+			nMissed:  4,
+			nTotal:   20,
+			expected: true, // 4 <= 5 (critical value), so passes
+		},
+		{
+			name:     "exact lookup - 20 total, 5 missed (boundary - passes)",
+			nMissed:  5,
+			nTotal:   20,
+			expected: true, // 5 <= 5 (critical value), so passes
+		},
+		{
+			name:     "exact lookup - 20 total, 6 missed (exceeds)",
+			nMissed:  6,
+			nTotal:   20,
+			expected: false, // 6 >= 5 (critical value), so fails
+		},
+		{
+			name:     "exact lookup - 100 total, 15 missed (passes)",
+			nMissed:  15,
+			nTotal:   100,
+			expected: true, // 15 < 16 (critical value), so passes
+		},
+		{
+			name:     "exact lookup - 100 total, 16 missed (boundary - passes)",
+			nMissed:  16,
+			nTotal:   100,
+			expected: true, // 16 <= 16 (critical value), so passes
+		},
+		{
+			name:     "exact lookup - 100 total, 17 missed (exceeds)",
+			nMissed:  17,
+			nTotal:   100,
+			expected: false, // 17 >= 16 (critical value), so fails
+		},
+		{
+			name:     "exact lookup - 500 total, 61 missed (passes)",
+			nMissed:  61,
+			nTotal:   500,
+			expected: true, // 61 < 62 (critical value), so passes
+		},
+		{
+			name:     "exact lookup - 500 total, 62 missed (boundary - passes)",
+			nMissed:  62,
+			nTotal:   500,
+			expected: true, // 62 <= 62 (critical value), so passes
+		},
+		{
+			name:     "exact lookup - 500 total, 63 missed (boundary - fails)",
+			nMissed:  63,
+			nTotal:   500,
+			expected: false, // 63 >= 62 (critical value), so fails
+		},
+		{
+			name:     "exact 990 - uses 10% rule, 98 missed (passes)",
+			nMissed:  98,
+			nTotal:   990,
+			expected: true, // 98*10 = 980 <= 990, so passes
+		},
+		{
+			name:     "exact 990 - uses 10% rule, 99 missed (boundary - passes)",
+			nMissed:  99,
+			nTotal:   990,
+			expected: true, // 99*10 = 990 <= 990, so passes
+		},
+		{
+			name:     "exact 990 - uses 10% rule, 100 missed (boundary - passes)",
+			nMissed:  100,
+			nTotal:   990,
+			expected: true,
+		},
+
+		// Test cases with values between lookup map entries
+		{
+			name:     "between lookup values - 15 total, uses 10's critical value",
+			nMissed:  3,
+			nTotal:   15,
+			expected: true, // Uses critical value for 10 (4), so 3 < 4 = true
+		},
+		{
+			name:     "between lookup values - 15 total, 4 missed",
+			nMissed:  4,
+			nTotal:   15,
+			expected: true, // Uses critical value for 10 (4), so 4 <= 4 = true
+		},
+		{
+			name:     "between lookup values - 75 total, uses 70's critical value",
+			nMissed:  10,
+			nTotal:   75,
+			expected: true, // Uses critical value for 70 (12), so 10 < 12 = true
+		},
+		{
+			name:     "between lookup values - 75 total, 12 missed",
+			nMissed:  12,
+			nTotal:   75,
+			expected: true, // Uses critical value for 70 (12), so 12 <= 12 = true
+		},
+
+		// Edge cases
+		{
+			name:     "zero missed",
+			nMissed:  0,
+			nTotal:   10,
+			expected: true, // 0/10 = 0, which is always <= critical rate
+		},
+		{
+			name:     "zero missed, large total",
+			nMissed:  0,
+			nTotal:   1000,
+			expected: true, // 0/1000 = 0, which is always <= critical rate
+		},
+		{
+			name:     "all missed",
+			nMissed:  10,
+			nTotal:   10,
+			expected: false, // 10/10 = 1.0, which exceeds any critical rate
+		},
+		{
+			name:     "small total below lookup range",
+			nMissed:  1,
+			nTotal:   5,
+			expected: true, // Uses critical value for 5 (3), so 1 < 3 = true
+		},
+		{
+			name:     "small total below lookup range - high miss rate",
+			nMissed:  3,
+			nTotal:   5,
+			expected: true, // Uses critical value for 5 (3), so 3 <= 3 = true
+		},
+		{
+			name:     "small total below lookup range - low miss rate",
+			nMissed:  2,
+			nTotal:   5,
+			expected: true, // Uses critical value for 5 (3), so 2 < 3 = true
+		},
+		{
+			name:     "very small total",
+			nMissed:  1,
+			nTotal:   1,
+			expected: true, // idx=0, so returns true regardless
+		},
+		{
+			name:     "large total above lookup range",
+			nMissed:  120,
+			nTotal:   1000,
+			expected: false, // Uses critical value for 990 (116), so 120/1000 = 0.12, 116/990 ≈ 0.117, 0.12 > 0.117 = false
+		},
+		{
+			name:     "large total above lookup range - passes",
+			nMissed:  99,
+			nTotal:   1000,
+			expected: true, // Uses 10% rule: 99*10 = 990 <= 1000, so passes
+		},
+		{
+			name:     "large total above lookup range - boundary",
+			nMissed:  100,
+			nTotal:   1000,
+			expected: true, // Uses 10% rule: 100*10 = 1000 <= 1000, so passes
+		},
+		{
+			name:     "large total above lookup range - fails",
+			nMissed:  101,
+			nTotal:   1000,
+			expected: false, // Uses 10% rule: 101*10 = 1010 > 1000, so fails
+		},
+
+		// Boundary conditions at the edges of the lookup map
+		{
+			name:     "minimum lookup value - 10 total",
+			nMissed:  3,
+			nTotal:   10,
+			expected: true, // 3/10 = 0.3, 4/10 = 0.4, 0.3 <= 0.4 = true
+		},
+		{
+			name:     "maximum lookup value - 989 total",
+			nMissed:  114,
+			nTotal:   989,
+			expected: true, // Uses table lookup for 980 (115), 114 < 115 so passes
+		},
+		{
+			name:     "990 total uses 10% rule - boundary passes",
+			nMissed:  100,
+			nTotal:   990,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MissedStatTest(tt.nMissed, tt.nTotal)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MissedStatTest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("MissedStatTest() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMissedStatTestSpecialCase990(t *testing.T) {
+	// Test the special case where nTotal >= 990 uses the 10% rule
+	tests := []struct {
+		name     string
+		nMissed  int
+		nTotal   int
+		expected bool
+	}{
+		{
+			name:     "exactly 990 - uses 10% rule",
+			nMissed:  99,
+			nTotal:   990,
+			expected: true, // 99*10 = 990 <= 990, so passes
+		},
+		{
+			name:     "exactly 990 - boundary fails",
+			nMissed:  100,
+			nTotal:   990,
+			expected: true,
+		},
+		{
+			name:     "exactly 1000 - uses 10% rule",
+			nMissed:  100,
+			nTotal:   1000,
+			expected: true, // 100*10 = 1000 <= 1000, so passes
+		},
+		{
+			name:     "exactly 1000 - boundary fails",
+			nMissed:  101,
+			nTotal:   1000,
+			expected: false, // 101*10 = 1010 > 1000, so fails
+		},
+		{
+			name:     "large number - 10% rule passes",
+			nMissed:  500,
+			nTotal:   5000,
+			expected: true, // 500*10 = 5000 <= 5000, so passes
+		},
+		{
+			name:     "large number - 10% rule fails",
+			nMissed:  501,
+			nTotal:   5000,
+			expected: false, // 501*10 = 5010 > 5000, so fails
+		},
+		{
+			name:     "very large number - 9.9% passes",
+			nMissed:  99,
+			nTotal:   1000,
+			expected: true, // 99*10 = 990 <= 1000, so passes
+		},
+		{
+			name:     "very large number - exactly 10%",
+			nMissed:  1000,
+			nTotal:   10000,
+			expected: true, // 1000*10 = 10000 <= 10000, so passes
+		},
+		{
+			name:     "very large number - more than 10%",
+			nMissed:  1001,
+			nTotal:   10000,
+			expected: false, // 1001*10 = 10010 > 10000, so fails
+		},
+		{
+			name:     "very large number - boundary exact",
+			nMissed:  116,
+			nTotal:   990,
+			expected: true, // 116*10 = 1160 <= 990, so passes
+		},
+		{
+			name:     "very large number - boundary exceeds",
+			nMissed:  117,
+			nTotal:   990,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MissedStatTest(tt.nMissed, tt.nTotal)
+			if err != nil {
+				t.Errorf("MissedStatTest() unexpected error = %v", err)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("MissedStatTest() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMissedStatTestLookupMapBoundaries(t *testing.T) {
+	// Test that the lookup map is used correctly for boundary values
+	testCases := []struct {
+		total          int
+		expectedLookup int
+		description    string
+	}{
+		{5, 10, "below minimum should use 10"},
+		{10, 10, "exact match should use 10"},
+		{15, 20, "between 10 and 20 should use 20"},
+		{20, 20, "exact match should use 20"},
+		{25, 30, "between 20 and 30 should use 30"},
+		{990, 990, "exact match should use 990"},
+		{1000, 990, "above maximum should use 990"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			// We'll test this by checking that the critical rate calculation is consistent
+			// For nMissed = 0, the test should always pass regardless of the lookup value used
+			result, err := MissedStatTest(0, tc.total)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if !result {
+				t.Errorf("Expected test to pass for 0 missed out of %d total", tc.total)
+			}
+		})
+	}
+}
+
+func TestMissedStatTestEdgeCasesSmallValues(t *testing.T) {
+	// Test edge cases for very small values that fall below the first table entry
+	tests := []struct {
+		name     string
+		nMissed  int
+		nTotal   int
+		expected bool
+	}{
+		{
+			name:     "total 1 - always returns true when idx=0",
+			nMissed:  0,
+			nTotal:   1,
+			expected: true, // idx=0, so returns true
+		},
+		{
+			name:     "total 1 - with 1 miss returns true",
+			nMissed:  1,
+			nTotal:   1,
+			expected: true, // idx=0, so returns true
+		},
+		{
+			name:     "total 2 - no misses",
+			nMissed:  0,
+			nTotal:   2,
+			expected: true, // idx=0, so returns true
+		},
+		{
+			name:     "total 2 - with misses",
+			nMissed:  2,
+			nTotal:   2,
+			expected: true, // 2 <= 2 (critical value), so passes
+		},
+		{
+			name:     "total 4 - below first table entry",
+			nMissed:  2,
+			nTotal:   4,
+			expected: true, // 2 <= 2 (critical value for 4), so passes
+		},
+		{
+			name:     "total 5 - exactly first table entry",
+			nMissed:  2,
+			nTotal:   5,
+			expected: true, // 2 < 3 (critical value for 5), so passes
+		},
+		{
+			name:     "total 5 - boundary",
+			nMissed:  3,
+			nTotal:   5,
+			expected: true, // 3 <= 3 (critical value for 5), so passes
+		},
+		{
+			name:     "total 6 - uses 5's critical value",
+			nMissed:  2,
+			nTotal:   6,
+			expected: true, // Uses critical value for 5 (3), so 2 < 3 = true
+		},
+		{
+			name:     "total 6 - boundary passes",
+			nMissed:  3,
+			nTotal:   6,
+			expected: true, // Uses critical value for 5 (3), so 3 <= 3 = true
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MissedStatTest(tt.nMissed, tt.nTotal)
+			if err != nil {
+				t.Errorf("MissedStatTest() unexpected error = %v", err)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("MissedStatTest() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMissedStatTestConsistency(t *testing.T) {
+	// Test that the function is consistent - if a test passes for a given rate,
+	// it should also pass for lower rates with the same total
+	testTotals := []int{10, 50, 100, 500}
+
+	for _, total := range testTotals {
+		t.Run(fmt.Sprintf("consistency_test_total_%d", total), func(t *testing.T) {
+			// Find the boundary where the test starts failing
+			var lastPassingMissed int = -1
+			for missed := 0; missed <= total; missed++ {
+				result, err := MissedStatTest(missed, total)
+				if err != nil {
+					t.Errorf("Unexpected error for missed=%d, total=%d: %v", missed, total, err)
+					continue
+				}
+
+				if result {
+					lastPassingMissed = missed
+				} else {
+					// Once we find a failing case, all higher values should also fail
+					for higherMissed := missed + 1; higherMissed <= total && higherMissed <= missed+5; higherMissed++ {
+						higherResult, err := MissedStatTest(higherMissed, total)
+						if err != nil {
+							t.Errorf("Unexpected error for missed=%d, total=%d: %v", higherMissed, total, err)
+							continue
+						}
+						if higherResult {
+							t.Errorf("Inconsistency: missed=%d passes but missed=%d fails for total=%d", higherMissed, missed, total)
+						}
+					}
+					break
+				}
+			}
+
+			// Verify that all values up to lastPassingMissed pass
+			for missed := 0; missed <= lastPassingMissed; missed++ {
+				result, err := MissedStatTest(missed, total)
+				if err != nil {
+					t.Errorf("Unexpected error for missed=%d, total=%d: %v", missed, total, err)
+					continue
+				}
+				if !result {
+					t.Errorf("Expected missed=%d to pass for total=%d (lastPassing=%d)", missed, total, lastPassingMissed)
+				}
+			}
+		})
+	}
+}
+
+// Benchmark tests to ensure the function performs well
+func BenchmarkMissedStatTest(b *testing.B) {
+	// Test various scenarios to ensure consistent performance
+	testCases := []struct {
+		name    string
+		nMissed int
+		nTotal  int
+	}{
+		{"small_values", 3, 10},
+		{"medium_values", 50, 500},
+		{"large_values_table", 100, 990},
+		{"large_values_formula", 100, 1000},
+		{"very_large_values", 1000, 10000},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = MissedStatTest(tc.nMissed, tc.nTotal)
+			}
+		})
+	}
+}
+
+func BenchmarkMissedStatTestWorstCase(b *testing.B) {
+	// Benchmark the worst case scenario - searching through the entire table
+	b.Run("worst_case_search", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = MissedStatTest(115, 989) // Just below 990, uses table lookup
+		}
+	})
+}

--- a/inference-chain/x/inference/calculations/stats_test.go
+++ b/inference-chain/x/inference/calculations/stats_test.go
@@ -24,8 +24,8 @@ func TestMissedStatTestErrorConditions(t *testing.T) {
 			name:     "zero total",
 			nMissed:  0,
 			nTotal:   0,
-			expected: false,
-			wantErr:  true,
+			expected: true,
+			wantErr:  false,
 		},
 		{
 			name:     "negative total",

--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -99,9 +99,9 @@ func CheckAndPunishForDowntimeForParticipants(participants []types.Participant, 
 func CheckAndPunishForDowntimeForParticipant(participant types.Participant, reward uint64, logger log.Logger) uint64 {
 	totalRequests := participant.CurrentEpochStats.InferenceCount + participant.CurrentEpochStats.MissedRequests
 	missedRequests := participant.CurrentEpochStats.MissedRequests
-	logger.Info("Checking downtime for participant", types.Tokenomics, "participant", participant.Address, "totalRequests", totalRequests, "missedRequests", missedRequests, "reward", reward)
+	logger.Info("Checking downtime for participant", "participant", participant.Address, "totalRequests", totalRequests, "missedRequests", missedRequests, "reward", reward)
 	finalReward := CheckAndPunishForDowntime(totalRequests, missedRequests, reward)
-	logger.Info("Final reward after downtime check", types.Tokenomics, "participant", participant.Address, "finalReward", finalReward)
+	logger.Info("Final reward after downtime check", "participant", participant.Address, "finalReward", finalReward)
 	return finalReward
 }
 
@@ -164,6 +164,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 			k.LogError("Bitcoin reward amount is negative", types.Settle, "amount", bitcoinResult.Amount)
 			return types.ErrNegativeRewardAmount
 		}
+		k.LogInfo("Bitcoin reward amount", types.Settle, "amount", bitcoinResult.Amount)
 		rewardAmount = bitcoinResult.Amount
 	} else {
 		// Use current WorkCoins-based variable reward system with its own parameters

--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 
+	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/calculations"
 	"github.com/productscience/inference/x/inference/types"
@@ -89,16 +90,19 @@ func (k *Keeper) GetSettleParameters(ctx context.Context) *SettleParameters {
 	}
 }
 
-func CheckAndPunishForDowntimeForParticipants(participants []types.Participant, rewards map[string]uint64) {
+func CheckAndPunishForDowntimeForParticipants(participants []types.Participant, rewards map[string]uint64, logger log.Logger) {
 	for _, participant := range participants {
-		rewards[participant.Address] = CheckAndPunishForDowntimeForParticipant(participant, rewards[participant.Address])
+		rewards[participant.Address] = CheckAndPunishForDowntimeForParticipant(participant, rewards[participant.Address], logger)
 	}
 }
 
-func CheckAndPunishForDowntimeForParticipant(participant types.Participant, reward uint64) uint64 {
+func CheckAndPunishForDowntimeForParticipant(participant types.Participant, reward uint64, logger log.Logger) uint64 {
 	totalRequests := participant.CurrentEpochStats.InferenceCount + participant.CurrentEpochStats.MissedRequests
 	missedRequests := participant.CurrentEpochStats.MissedRequests
-	return CheckAndPunishForDowntime(totalRequests, missedRequests, reward)
+	logger.Info("Checking downtime for participant", types.Tokenomics, "participant", participant.Address, "totalRequests", totalRequests, "missedRequests", missedRequests, "reward", reward)
+	finalReward := CheckAndPunishForDowntime(totalRequests, missedRequests, reward)
+	logger.Info("Final reward after downtime check", types.Tokenomics, "participant", participant.Address, "finalReward", finalReward)
+	return finalReward
 }
 
 func CheckAndPunishForDowntime(total, missed, reward uint64) uint64 {
@@ -152,7 +156,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 		k.LogInfo("Using Bitcoin-style reward system", types.Settle)
 		var bitcoinResult BitcoinResult
 		var err error
-		amounts, bitcoinResult, err = GetBitcoinSettleAmounts(allParticipants, &data, params.BitcoinRewardParams, settleParameters)
+		amounts, bitcoinResult, err = GetBitcoinSettleAmounts(allParticipants, &data, params.BitcoinRewardParams, settleParameters, k.Logger())
 		if err != nil {
 			k.LogError("Error getting Bitcoin settle amounts", types.Settle, "error", err)
 		}
@@ -166,7 +170,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 		k.LogInfo("Using current WorkCoins-based reward system", types.Settle)
 		var subsidyResult SubsidyResult
 		var err error
-		amounts, subsidyResult, err = GetSettleAmounts(allParticipants, settleParameters)
+		amounts, subsidyResult, err = GetSettleAmounts(allParticipants, settleParameters, k.Logger())
 		if err != nil {
 			k.LogError("Error getting settle amounts", types.Settle, "error", err)
 		}
@@ -258,8 +262,8 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 	return nil
 }
 
-func GetSettleAmounts(participants []types.Participant, tokenParams *SettleParameters) ([]*SettleResult, SubsidyResult, error) {
-	totalWork, _ := getWorkTotals(participants)
+func GetSettleAmounts(participants []types.Participant, tokenParams *SettleParameters, logger log.Logger) ([]*SettleResult, SubsidyResult, error) {
+	totalWork, _ := getWorkTotals(participants, logger)
 	subsidyResult := tokenParams.GetTotalSubsidy(totalWork)
 	rewardDistribution := DistributedCoinInfo{
 		totalWork:       totalWork,
@@ -269,7 +273,7 @@ func GetSettleAmounts(participants []types.Participant, tokenParams *SettleParam
 	distributions := make([]DistributedCoinInfo, 0)
 	distributions = append(distributions, rewardDistribution)
 	for _, p := range participants {
-		settle, err := getSettleAmount(p, distributions)
+		settle, err := getSettleAmount(p, distributions, logger)
 		// We have to create amount record for each participant in the same order as participants
 		amounts = append(amounts, &SettleResult{
 			Settle: settle,
@@ -282,13 +286,13 @@ func GetSettleAmounts(participants []types.Participant, tokenParams *SettleParam
 	return amounts, subsidyResult, nil
 }
 
-func getWorkTotals(participants []types.Participant) (int64, int64) {
+func getWorkTotals(participants []types.Participant, logger log.Logger) (int64, int64) {
 	totalWork := int64(0)
 	invalidatedBalance := int64(0)
 	for _, p := range participants {
 		// Do not count invalid participants work as "work", since it should not be part of the distributions
 		if p.CoinBalance > 0 && p.Status != types.ParticipantStatus_INVALID {
-			newCoinBalance := CheckAndPunishForDowntimeForParticipant(p, uint64(p.CoinBalance))
+			newCoinBalance := CheckAndPunishForDowntimeForParticipant(p, uint64(p.CoinBalance), logger)
 			totalWork += int64(newCoinBalance)
 		}
 		if p.CoinBalance > 0 && p.Status == types.ParticipantStatus_INVALID {
@@ -298,7 +302,7 @@ func getWorkTotals(participants []types.Participant) (int64, int64) {
 	return totalWork, invalidatedBalance
 }
 
-func getSettleAmount(participant types.Participant, rewardInfo []DistributedCoinInfo) (*types.SettleAmount, error) {
+func getSettleAmount(participant types.Participant, rewardInfo []DistributedCoinInfo, logger log.Logger) (*types.SettleAmount, error) {
 	settle := &types.SettleAmount{
 		Participant: participant.Address,
 	}
@@ -308,7 +312,7 @@ func getSettleAmount(participant types.Participant, rewardInfo []DistributedCoin
 	if participant.Status == types.ParticipantStatus_INVALID {
 		return settle, nil
 	}
-	workCoins := int64(CheckAndPunishForDowntimeForParticipant(participant, uint64(participant.CoinBalance)))
+	workCoins := int64(CheckAndPunishForDowntimeForParticipant(participant, uint64(participant.CoinBalance), logger))
 	rewardCoins := int64(0)
 	for _, distribution := range rewardInfo {
 		if participant.Status == types.ParticipantStatus_INVALID {

--- a/inference-chain/x/inference/keeper/accountsettle_test.go
+++ b/inference-chain/x/inference/keeper/accountsettle_test.go
@@ -157,6 +157,10 @@ func TestSingleSettle(t *testing.T) {
 		Address:     "participant1",
 		CoinBalance: 1000,
 		Status:      types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 	expectedRewardCoin := calcExpectedRewards([]types.Participant{participant1})
 	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1}, &defaultSettleParameters)
@@ -173,11 +177,19 @@ func TestEvenSettle(t *testing.T) {
 		Address:     "participant1",
 		CoinBalance: 1000,
 		Status:      types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 	participant2 := types.Participant{
 		Address:     "participant2",
 		CoinBalance: 1000,
 		Status:      types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 	expectedRewardCoin := calcExpectedRewards([]types.Participant{participant1, participant2})
 	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1, participant2}, &defaultSettleParameters)
@@ -197,16 +209,28 @@ func TestEvenAmong3(t *testing.T) {
 		Address:     "participant1",
 		CoinBalance: 255000,
 		Status:      types.ParticipantStatus_RAMPING,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 	participant2 := types.Participant{
 		Address:     "participant2",
 		CoinBalance: 340000,
 		Status:      types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 	participant3 := types.Participant{
 		Address:     "participant3",
 		CoinBalance: 255000,
 		Status:      types.ParticipantStatus_RAMPING,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1, participant2, participant3}, &defaultSettleParameters)
 	require.NoError(t, err)
@@ -250,23 +274,33 @@ func newParticipant(coinBalance int64, refundBalance int64, id string) types.Par
 		Address:     "participant" + id,
 		CoinBalance: coinBalance,
 		Status:      types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 }
 
 func TestActualSettle(t *testing.T) {
 	participant1 := types.Participant{
-		Index:             testutil.Executor,
-		Address:           testutil.Executor,
-		CoinBalance:       1000,
-		Status:            types.ParticipantStatus_ACTIVE,
-		CurrentEpochStats: &types.CurrentEpochStats{},
+		Index:       testutil.Executor,
+		Address:     testutil.Executor,
+		CoinBalance: 1000,
+		Status:      types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 	participant2 := types.Participant{
-		Index:             testutil.Executor2,
-		Address:           testutil.Executor2,
-		CoinBalance:       1000,
-		Status:            types.ParticipantStatus_ACTIVE,
-		CurrentEpochStats: &types.CurrentEpochStats{},
+		Index:       testutil.Executor2,
+		Address:     testutil.Executor2,
+		CoinBalance: 1000,
+		Status:      types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 100,
+			MissedRequests: 0,
+		},
 	}
 	keeper, ctx, mocks := keeper2.InferenceKeeperReturningMocks(t)
 
@@ -319,11 +353,14 @@ func TestActualSettleWithManyParticipants(t *testing.T) {
 	for i := 0; i < 150; i++ {
 		address := testutil.Bech32Addr(i)
 		participant := types.Participant{
-			Index:             address,
-			Address:           address,
-			CoinBalance:       1000,
-			Status:            types.ParticipantStatus_ACTIVE,
-			CurrentEpochStats: &types.CurrentEpochStats{},
+			Index:       address,
+			Address:     address,
+			CoinBalance: 1000,
+			Status:      types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: 100,
+				MissedRequests: 0,
+			},
 		}
 		participants[i] = participant
 		keeper.SetParticipant(ctx, participant)

--- a/inference-chain/x/inference/keeper/accountsettle_test.go
+++ b/inference-chain/x/inference/keeper/accountsettle_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	"cosmossdk.io/log"
 	"github.com/productscience/inference/testutil"
 	"go.uber.org/mock/gomock"
 
@@ -22,6 +23,11 @@ var defaultSettleParameters = inference.SettleParameters{
 	TotalSubsidySupply:       600000000000,
 }
 
+// createTestLogger creates a logger for testing
+func createTestLogger(t *testing.T) log.Logger {
+	return log.NewTestLogger(t)
+}
+
 func calcExpectedRewards(participants []types.Participant) int64 {
 	totalWorkCoins := int64(0)
 	for _, p := range participants {
@@ -37,12 +43,18 @@ func calcExpectedRewards(participants []types.Participant) int64 {
 }
 
 func TestReduceSubsidy(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestReduceSubsidy")
+
 	oParams := types.TokenomicsParams{
 		SubsidyReductionAmount:   types.DecimalFromFloat(0.20),
 		SubsidyReductionInterval: types.DecimalFromFloat(0.05),
 		CurrentSubsidyPercentage: types.DecimalFromFloat(0.90),
 	}
+	logger.Info("Initial tokenomics params", "subsidyPercentage", oParams.CurrentSubsidyPercentage.ToFloat32())
+
 	params := oParams.ReduceSubsidyPercentage()
+	logger.Info("After first reduction", "subsidyPercentage", params.CurrentSubsidyPercentage.ToFloat32())
 	require.Equal(t, float32(0.72), params.CurrentSubsidyPercentage.ToFloat32())
 	params2 := oParams.ReduceSubsidyPercentage()
 	require.Equal(t, float32(0.576), params2.CurrentSubsidyPercentage.ToFloat32())
@@ -67,12 +79,20 @@ func TestReduceSubsidy(t *testing.T) {
 }
 
 func TestRewardsNoCrossover(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestRewardsNoCrossover", "workCoins", 1000)
+
 	subsidy := defaultSettleParameters.GetTotalSubsidy(1000)
+	logger.Info("Calculated subsidy", "amount", subsidy.Amount, "crossedCutoff", subsidy.CrossedCutoff)
+
 	require.Equal(t, int64(10000), subsidy.Amount)
 	require.False(t, subsidy.CrossedCutoff)
 }
 
 func TestRewardsNoCrossover2(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestRewardsNoCrossover2")
+
 	params := inference.SettleParameters{
 		CurrentSubsidyPercentage: 0.90,
 		TotalSubsidyPaid:         0,
@@ -80,12 +100,19 @@ func TestRewardsNoCrossover2(t *testing.T) {
 		StageDecrease:            0.20,
 		TotalSubsidySupply:       200000000,
 	}
+	logger.Info("Test parameters", "totalSubsidySupply", params.TotalSubsidySupply, "workCoins", 340000)
+
 	subsidy := params.GetTotalSubsidy(340000)
+	logger.Info("Calculated subsidy", "amount", subsidy.Amount, "crossedCutoff", subsidy.CrossedCutoff)
+
 	require.Equal(t, int64(3400000), subsidy.Amount)
 	require.False(t, subsidy.CrossedCutoff)
 }
 
 func TestRewardsCrossover(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestRewardsCrossover - testing subsidy cutoff crossing")
+
 	params := inference.SettleParameters{
 		CurrentSubsidyPercentage: 0.90,
 		TotalSubsidyPaid:         9500,
@@ -93,11 +120,14 @@ func TestRewardsCrossover(t *testing.T) {
 		StageDecrease:            0.20,
 		TotalSubsidySupply:       200000,
 	}
+	logger.Info("Test parameters", "totalSubsidyPaid", params.TotalSubsidyPaid, "totalSubsidySupply", params.TotalSubsidySupply)
+
 	subsidy := params.GetTotalSubsidy(1000)
+	logger.Info("Calculated subsidy with crossover", "amount", subsidy.Amount, "crossedCutoff", subsidy.CrossedCutoff)
+
 	// A note: 3892 is if we truncate, 3893 is if we round
 	require.Equal(t, int64(3892), subsidy.Amount)
 	require.True(t, subsidy.CrossedCutoff)
-
 }
 
 func TestRewardsSecondCrossover(t *testing.T) {
@@ -153,6 +183,9 @@ func TestNoCrossoverAtZero(t *testing.T) {
 }
 
 func TestSingleSettle(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestSingleSettle")
+
 	participant1 := types.Participant{
 		Address:     "participant1",
 		CoinBalance: 1000,
@@ -162,17 +195,29 @@ func TestSingleSettle(t *testing.T) {
 			MissedRequests: 0,
 		},
 	}
+	logger.Info("Created participant", "address", participant1.Address, "coinBalance", participant1.CoinBalance, "status", participant1.Status)
+
 	expectedRewardCoin := calcExpectedRewards([]types.Participant{participant1})
-	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1}, &defaultSettleParameters)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(result))
-	require.Equal(t, expectedRewardCoin, newCoin.Amount)
+	logger.Info("Calculated expected reward", "amount", expectedRewardCoin)
+
+	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1}, &defaultSettleParameters, logger)
+	require.NoError(t, err, "GetSettleAmounts should not return error")
+	require.Equal(t, 1, len(result), "Should have exactly 1 settle result")
+	require.Equal(t, expectedRewardCoin, newCoin.Amount, "New coin amount should match expected reward")
+
 	p1Result := result[0]
+	require.NotNil(t, p1Result.Settle, "Settle result should not be nil")
+	require.Nil(t, p1Result.Error, "Should not have settle error")
+	logger.Info("Settle result", "workCoins", p1Result.Settle.WorkCoins, "rewardCoins", p1Result.Settle.RewardCoins)
+
 	require.Equal(t, uint64(1000), p1Result.Settle.WorkCoins)
 	require.Equal(t, uint64(expectedRewardCoin), p1Result.Settle.RewardCoins)
 }
 
 func TestEvenSettle(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestEvenSettle - testing equal distribution between two participants")
+
 	participant1 := types.Participant{
 		Address:     "participant1",
 		CoinBalance: 1000,
@@ -191,20 +236,35 @@ func TestEvenSettle(t *testing.T) {
 			MissedRequests: 0,
 		},
 	}
+	logger.Info("Created participants", "count", 2, "coinBalance1", participant1.CoinBalance, "coinBalance2", participant2.CoinBalance)
+
 	expectedRewardCoin := calcExpectedRewards([]types.Participant{participant1, participant2})
-	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1, participant2}, &defaultSettleParameters)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(result))
-	require.Equal(t, expectedRewardCoin, newCoin.Amount)
+	logger.Info("Calculated total expected reward", "amount", expectedRewardCoin, "perParticipant", expectedRewardCoin/2)
+
+	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1, participant2}, &defaultSettleParameters, logger)
+	require.NoError(t, err, "GetSettleAmounts should not return error")
+	require.Equal(t, 2, len(result), "Should have exactly 2 settle results")
+	require.Equal(t, expectedRewardCoin, newCoin.Amount, "Total reward should match expected")
+
 	p1Result := result[0]
+	require.NotNil(t, p1Result.Settle, "Participant 1 settle result should not be nil")
+	require.Nil(t, p1Result.Error, "Participant 1 should not have settle error")
 	require.Equal(t, uint64(1000), p1Result.Settle.WorkCoins)
 	require.Equal(t, uint64(expectedRewardCoin/2), p1Result.Settle.RewardCoins)
+
 	p2Result := result[1]
+	require.NotNil(t, p2Result.Settle, "Participant 2 settle result should not be nil")
+	require.Nil(t, p2Result.Error, "Participant 2 should not have settle error")
 	require.Equal(t, uint64(1000), p2Result.Settle.WorkCoins)
 	require.Equal(t, uint64(expectedRewardCoin/2), p2Result.Settle.RewardCoins)
+
+	logger.Info("Settlement verification complete", "p1Reward", p1Result.Settle.RewardCoins, "p2Reward", p2Result.Settle.RewardCoins)
 }
 
 func TestEvenAmong3(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestEvenAmong3 - testing distribution among 3 participants with different balances")
+
 	participant1 := types.Participant{
 		Address:     "participant1",
 		CoinBalance: 255000,
@@ -232,41 +292,74 @@ func TestEvenAmong3(t *testing.T) {
 			MissedRequests: 0,
 		},
 	}
-	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1, participant2, participant3}, &defaultSettleParameters)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(result))
-	require.Equal(t, int64(8500000), newCoin.Amount)
+	logger.Info("Created 3 participants", "p1Balance", participant1.CoinBalance, "p1Status", participant1.Status, "p2Balance", participant2.CoinBalance, "p2Status", participant2.Status, "p3Balance", participant3.CoinBalance, "p3Status", participant3.Status)
+
+	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1, participant2, participant3}, &defaultSettleParameters, logger)
+	require.NoError(t, err, "GetSettleAmounts should not return error")
+	require.Equal(t, 3, len(result), "Should have exactly 3 settle results")
+	require.Equal(t, int64(8500000), newCoin.Amount, "Total reward should be 8500000")
+
 	p1Result := result[0]
+	require.NotNil(t, p1Result.Settle, "Participant 1 settle should not be nil")
+	require.Nil(t, p1Result.Error, "Participant 1 should not have error")
 	require.Equal(t, uint64(255000), p1Result.Settle.WorkCoins)
 	require.Equal(t, uint64(2550000), p1Result.Settle.RewardCoins)
+
 	p2Result := result[1]
+	require.NotNil(t, p2Result.Settle, "Participant 2 settle should not be nil")
+	require.Nil(t, p2Result.Error, "Participant 2 should not have error")
 	require.Equal(t, uint64(340000), p2Result.Settle.WorkCoins)
 	require.Equal(t, uint64(3400000), p2Result.Settle.RewardCoins)
+
 	p3Result := result[2]
+	require.NotNil(t, p3Result.Settle, "Participant 3 settle should not be nil")
+	require.Nil(t, p3Result.Error, "Participant 3 should not have error")
 	require.Equal(t, uint64(255000), p3Result.Settle.WorkCoins)
 	require.Equal(t, uint64(2550000), p3Result.Settle.RewardCoins)
+
+	logger.Info("3-participant settlement verified", "totalReward", newCoin.Amount, "p1Reward", p1Result.Settle.RewardCoins, "p2Reward", p2Result.Settle.RewardCoins, "p3Reward", p3Result.Settle.RewardCoins)
 }
 
 func TestNoWorkBalance(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestNoWorkBalance - testing zero work scenario")
+
 	participant1 := newParticipant(0, 0, "1")
-	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1}, &defaultSettleParameters)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(result))
+	logger.Info("Created participant with zero balance", "address", participant1.Address, "coinBalance", participant1.CoinBalance)
+
+	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1}, &defaultSettleParameters, logger)
+	require.NoError(t, err, "GetSettleAmounts should not return error even with zero work")
+	require.Equal(t, 1, len(result), "Should have exactly 1 settle result")
+
 	// If no one works, no coin
-	require.Equal(t, int64(0), newCoin.Amount)
+	require.Equal(t, int64(0), newCoin.Amount, "No work should result in zero new coins")
+
 	p1Result := result[0]
-	require.Zero(t, p1Result.Settle.WorkCoins)
-	require.Zero(t, p1Result.Settle.RewardCoins)
+	require.NotNil(t, p1Result.Settle, "Settle result should not be nil")
+	require.Nil(t, p1Result.Error, "Should not have error for zero work")
+	require.Zero(t, p1Result.Settle.WorkCoins, "Work coins should be zero")
+	require.Zero(t, p1Result.Settle.RewardCoins, "Reward coins should be zero")
+
+	logger.Info("Zero work test completed successfully")
 }
 
 func TestNegativeCoinBalance(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestNegativeCoinBalance - testing error handling for negative balance")
+
 	participant1 := newParticipant(-1, 0, "1")
-	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1}, &defaultSettleParameters)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(result))
-	require.Equal(t, int64(0), newCoin.Amount)
+	logger.Info("Created participant with negative balance", "address", participant1.Address, "coinBalance", participant1.CoinBalance)
+
+	result, newCoin, err := inference.GetSettleAmounts([]types.Participant{participant1}, &defaultSettleParameters, logger)
+	require.NoError(t, err, "GetSettleAmounts should not return top-level error for negative balance")
+	require.Equal(t, 1, len(result), "Should have exactly 1 settle result")
+	require.Equal(t, int64(0), newCoin.Amount, "Negative balance should result in zero new coins")
+
 	p1Result := result[0]
-	require.Equal(t, types.ErrNegativeCoinBalance, p1Result.Error)
+	require.NotNil(t, p1Result.Settle, "Settle result should not be nil")
+	require.Equal(t, types.ErrNegativeCoinBalance, p1Result.Error, "Should have negative coin balance error")
+
+	logger.Info("Negative balance error handling verified", "error", p1Result.Error)
 }
 
 func newParticipant(coinBalance int64, refundBalance int64, id string) types.Participant {
@@ -282,6 +375,9 @@ func newParticipant(coinBalance int64, refundBalance int64, id string) types.Par
 }
 
 func TestActualSettle(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestActualSettle - testing full settlement integration")
+
 	participant1 := types.Participant{
 		Index:       testutil.Executor,
 		Address:     testutil.Executor,
@@ -302,54 +398,79 @@ func TestActualSettle(t *testing.T) {
 			MissedRequests: 0,
 		},
 	}
+	logger.Info("Created test participants", "p1Address", participant1.Address, "p2Address", participant2.Address, "coinBalance", participant1.CoinBalance)
+
 	keeper, ctx, mocks := keeper2.InferenceKeeperReturningMocks(t)
 
 	// Configure to use legacy reward system for this test
 	params := keeper.GetParams(ctx)
 	params.BitcoinRewardParams.UseBitcoinRewards = false
 	keeper.SetParams(ctx, params)
+	logger.Info("Configured to use legacy reward system")
+
 	keeper.SetParticipant(ctx, participant1)
 	keeper.SetParticipant(ctx, participant2)
 	keeper.SetEpochGroupData(ctx, types.EpochGroupData{
 		EpochIndex: 10,
 	})
+	logger.Info("Set participants and epoch data", "epochIndex", 10)
+
 	expectedRewardCoin := calcExpectedRewards([]types.Participant{participant1, participant2})
+	logger.Info("Calculated expected reward", "totalReward", expectedRewardCoin, "perParticipant", expectedRewardCoin/2)
 
 	coins, err2 := types.GetCoins(expectedRewardCoin)
-	require.NoError(t, err2)
+	require.NoError(t, err2, "Should be able to create coins from reward amount")
+	logger.Info("Created coins for minting", "coins", coins)
+
 	mocks.BankKeeper.EXPECT().MintCoins(ctx, types.ModuleName, coins, gomock.Any()).Return(nil)
 	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
 	err := keeper.SettleAccounts(ctx, 10, 0)
-	require.NoError(t, err)
+	require.NoError(t, err, "SettleAccounts should complete successfully")
+	logger.Info("SettleAccounts completed successfully")
 	updated1, found := keeper.GetParticipant(ctx, participant1.Address)
-	require.True(t, found)
-	require.Equal(t, int64(0), updated1.CoinBalance)
-	require.Equal(t, uint32(1), updated1.EpochsCompleted)
+	require.True(t, found, "Participant 1 should be found after settlement")
+	require.Equal(t, int64(0), updated1.CoinBalance, "Participant 1 coin balance should be reset to 0")
+	require.Equal(t, uint32(1), updated1.EpochsCompleted, "Participant 1 should have 1 epoch completed")
+	logger.Info("Verified participant 1 updates", "coinBalance", updated1.CoinBalance, "epochsCompleted", updated1.EpochsCompleted)
+
 	updated2, found := keeper.GetParticipant(ctx, participant2.Address)
-	require.True(t, found)
-	require.Equal(t, int64(0), updated2.CoinBalance)
-	require.Equal(t, uint32(1), updated2.EpochsCompleted)
+	require.True(t, found, "Participant 2 should be found after settlement")
+	require.Equal(t, int64(0), updated2.CoinBalance, "Participant 2 coin balance should be reset to 0")
+	require.Equal(t, uint32(1), updated2.EpochsCompleted, "Participant 2 should have 1 epoch completed")
+	logger.Info("Verified participant 2 updates", "coinBalance", updated2.CoinBalance, "epochsCompleted", updated2.EpochsCompleted)
 	settleAmount1, found := keeper.GetSettleAmount(ctx, participant1.Address)
-	require.True(t, found)
-	require.Equal(t, uint64(1000), settleAmount1.WorkCoins)
-	require.Equal(t, uint64(expectedRewardCoin/2), settleAmount1.RewardCoins)
-	require.Equal(t, uint64(10), settleAmount1.EpochIndex)
+	require.True(t, found, "Settle amount for participant 1 should be found")
+	require.Equal(t, uint64(1000), settleAmount1.WorkCoins, "Participant 1 work coins should be 1000")
+	require.Equal(t, uint64(expectedRewardCoin/2), settleAmount1.RewardCoins, "Participant 1 reward coins should be half of total")
+	require.Equal(t, uint64(10), settleAmount1.EpochIndex, "Epoch index should be 10")
+	logger.Info("Verified participant 1 settle amount", "workCoins", settleAmount1.WorkCoins, "rewardCoins", settleAmount1.RewardCoins)
+
 	settleAmount2, found := keeper.GetSettleAmount(ctx, participant2.Address)
-	require.True(t, found)
-	require.Equal(t, uint64(1000), settleAmount2.WorkCoins)
-	require.Equal(t, uint64(expectedRewardCoin/2), settleAmount2.RewardCoins)
+	require.True(t, found, "Settle amount for participant 2 should be found")
+	require.Equal(t, uint64(1000), settleAmount2.WorkCoins, "Participant 2 work coins should be 1000")
+	require.Equal(t, uint64(expectedRewardCoin/2), settleAmount2.RewardCoins, "Participant 2 reward coins should be half of total")
+	logger.Info("Verified participant 2 settle amount", "workCoins", settleAmount2.WorkCoins, "rewardCoins", settleAmount2.RewardCoins)
+
+	logger.Info("TestActualSettle completed successfully")
 }
 
 func TestActualSettleWithManyParticipants(t *testing.T) {
+	logger := createTestLogger(t)
+	logger.Info("Starting TestActualSettleWithManyParticipants - testing settlement with 150 participants")
+
 	keeper, ctx, mocks := keeper2.InferenceKeeperReturningMocks(t)
 
 	// Configure to use legacy reward system for this test
 	params := keeper.GetParams(ctx)
 	params.BitcoinRewardParams.UseBitcoinRewards = false
 	keeper.SetParams(ctx, params)
+	logger.Info("Configured to use legacy reward system")
 
 	// Create 150 participants to test pagination (>100 default page size)
 	participants := make([]types.Participant, 150)
+	logger.Info("Creating 150 participants to test pagination")
+
 	for i := 0; i < 150; i++ {
 		address := testutil.Bech32Addr(i)
 		participant := types.Participant{
@@ -364,24 +485,34 @@ func TestActualSettleWithManyParticipants(t *testing.T) {
 		}
 		participants[i] = participant
 		keeper.SetParticipant(ctx, participant)
+		if i%50 == 0 {
+			logger.Info("Created participants", "count", i+1)
+		}
 	}
+	logger.Info("Completed creating all participants", "total", 150)
 
 	keeper.SetEpochGroupData(ctx, types.EpochGroupData{
 		EpochIndex: 10,
 	})
+	logger.Info("Set epoch data", "epochIndex", 10)
 
 	expectedRewardCoin := calcExpectedRewards(participants)
+	logger.Info("Calculated expected total reward", "totalReward", expectedRewardCoin, "perParticipant", expectedRewardCoin/150)
+
 	coins, err2 := types.GetCoins(expectedRewardCoin)
-	require.NoError(t, err2)
+	require.NoError(t, err2, "Should be able to create coins from reward amount")
 	mocks.BankKeeper.EXPECT().MintCoins(ctx, types.ModuleName, coins, gomock.Any()).Return(nil)
 	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	// This should work with pagination and process all 150 participants
+	logger.Info("Starting SettleAccounts for 150 participants")
 	err := keeper.SettleAccounts(ctx, 10, 0)
-	require.NoError(t, err)
+	require.NoError(t, err, "SettleAccounts should complete successfully with 150 participants")
+	logger.Info("SettleAccounts completed successfully")
 
 	// Verify all participants were processed
 	expectedRewardPerParticipant := expectedRewardCoin / 150
+	logger.Info("Starting verification of all 150 participants", "expectedRewardPerParticipant", expectedRewardPerParticipant)
 	for i := 0; i < 150; i++ {
 		address := testutil.Bech32Addr(i)
 		updated, found := keeper.GetParticipant(ctx, address)
@@ -394,5 +525,11 @@ func TestActualSettleWithManyParticipants(t *testing.T) {
 		require.Equal(t, uint64(1000), settleAmount.WorkCoins, "Participant %d work coins", i)
 		require.Equal(t, uint64(expectedRewardPerParticipant), settleAmount.RewardCoins, "Participant %d reward coins", i)
 		require.Equal(t, uint64(10), settleAmount.EpochIndex, "Participant %d epoch index", i)
+
+		if i%50 == 49 {
+			logger.Info("Verified participants", "count", i+1, "total", 150)
+		}
 	}
+
+	logger.Info("TestActualSettleWithManyParticipants completed successfully", "totalParticipants", 150, "totalReward", expectedRewardCoin)
 }

--- a/inference-chain/x/inference/keeper/bitcoin_integration_test.go
+++ b/inference-chain/x/inference/keeper/bitcoin_integration_test.go
@@ -158,11 +158,19 @@ func TestBitcoinRewardIntegration_DistributionLogic(t *testing.T) {
 			Address:     "participant1",
 			CoinBalance: 2000, // WorkCoins from user fees
 			Status:      types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: 100,
+				MissedRequests: 0,
+			},
 		},
 		{
 			Address:     "participant2",
 			CoinBalance: 6000, // WorkCoins from user fees
 			Status:      types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: 100,
+				MissedRequests: 0,
+			},
 		},
 	}
 
@@ -271,6 +279,10 @@ func TestBitcoinRewardIntegration_Phase2Stubs(t *testing.T) {
 		{
 			Address: "participant1",
 			Status:  types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: 100,
+				MissedRequests: 0,
+			},
 		},
 	}
 

--- a/inference-chain/x/inference/keeper/bitcoin_integration_test.go
+++ b/inference-chain/x/inference/keeper/bitcoin_integration_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
@@ -190,7 +191,8 @@ func TestBitcoinRewardIntegration_DistributionLogic(t *testing.T) {
 		}
 
 		// Test GetBitcoinSettleAmounts function
-		settleResults, bitcoinResult, err := keeper.GetBitcoinSettleAmounts(participants, epochGroupData, params.BitcoinRewardParams, settleParams)
+		logger := log.NewTestLogger(t)
+		settleResults, bitcoinResult, err := keeper.GetBitcoinSettleAmounts(participants, epochGroupData, params.BitcoinRewardParams, settleParams, logger)
 		require.NoError(t, err, "Bitcoin settle amounts calculation should succeed")
 		require.Len(t, settleResults, 2, "Should have settle results for both participants")
 

--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -239,6 +239,8 @@ func CalculateParticipantBitcoinRewards(participants []types.Participant, epochG
 		totalPoCWeight += pocWeight
 	}
 
+	CheckAndPunishForDowntimeForParticipants(participants, participantWeights)
+
 	// 3. Create settle results for each participant
 	settleResults := make([]*SettleResult, 0, len(participants))
 	var totalDistributed uint64 = 0

--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 
+	"cosmossdk.io/log"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/shopspring/decimal"
 )
@@ -19,7 +20,13 @@ type BitcoinResult struct {
 
 // GetBitcoinSettleAmounts is the main entry point for Bitcoin-style reward calculation.
 // It replaces GetSettleAmounts() while preserving WorkCoins and only changing RewardCoins calculation.
-func GetBitcoinSettleAmounts(participants []types.Participant, epochGroupData *types.EpochGroupData, bitcoinParams *types.BitcoinRewardParams, settleParams *SettleParameters) ([]*SettleResult, BitcoinResult, error) {
+func GetBitcoinSettleAmounts(
+	participants []types.Participant,
+	epochGroupData *types.EpochGroupData,
+	bitcoinParams *types.BitcoinRewardParams,
+	settleParams *SettleParameters,
+	logger log.Logger,
+) ([]*SettleResult, BitcoinResult, error) {
 	if participants == nil {
 		return nil, BitcoinResult{Amount: 0}, fmt.Errorf("participants cannot be nil")
 	}
@@ -40,8 +47,9 @@ func GetBitcoinSettleAmounts(participants []types.Participant, epochGroupData *t
 	// 3. Complete distribution with remainder handling
 	// 4. Invalid participant handling
 	// 5. Error management
-	settleResults, bitcoinResult, err := CalculateParticipantBitcoinRewards(participants, epochGroupData, bitcoinParams)
+	settleResults, bitcoinResult, err := CalculateParticipantBitcoinRewards(participants, epochGroupData, bitcoinParams, logger)
 	if err != nil {
+		logger.Error("Error calculating participant bitcoin rewards", types.Tokenomics, "error", err)
 		return settleResults, bitcoinResult, err
 	}
 
@@ -204,7 +212,12 @@ func GetParticipantPoCWeight(participant string, epochGroupData *types.EpochGrou
 
 // CalculateParticipantBitcoinRewards implements the main Bitcoin reward distribution logic
 // Preserves WorkCoins distribution while implementing fixed RewardCoins based on PoC weight
-func CalculateParticipantBitcoinRewards(participants []types.Participant, epochGroupData *types.EpochGroupData, bitcoinParams *types.BitcoinRewardParams) ([]*SettleResult, BitcoinResult, error) {
+func CalculateParticipantBitcoinRewards(
+	participants []types.Participant,
+	epochGroupData *types.EpochGroupData,
+	bitcoinParams *types.BitcoinRewardParams,
+	logger log.Logger,
+) ([]*SettleResult, BitcoinResult, error) {
 	// Parameter validation
 	if participants == nil {
 		return nil, BitcoinResult{}, fmt.Errorf("participants cannot be nil")
@@ -230,6 +243,7 @@ func CalculateParticipantBitcoinRewards(participants []types.Participant, epochG
 	for _, participant := range participants {
 		// Skip invalid participants from PoC weight calculations
 		if participant.Status == types.ParticipantStatus_INVALID {
+			logger.Info("Invalid participant found in PoC weight calculations, skipping", types.Tokenomics, "participant", participant.Address)
 			participantWeights[participant.Address] = 0
 			continue
 		}
@@ -239,7 +253,8 @@ func CalculateParticipantBitcoinRewards(participants []types.Participant, epochG
 		totalPoCWeight += pocWeight
 	}
 
-	CheckAndPunishForDowntimeForParticipants(participants, participantWeights)
+	logger.Info("Bitcoin Rewards: Checking downtime for participants", types.Tokenomics, "participants", len(participants))
+	CheckAndPunishForDowntimeForParticipants(participants, participantWeights, logger)
 
 	// 3. Create settle results for each participant
 	settleResults := make([]*SettleResult, 0, len(participants))

--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -49,7 +49,7 @@ func GetBitcoinSettleAmounts(
 	// 5. Error management
 	settleResults, bitcoinResult, err := CalculateParticipantBitcoinRewards(participants, epochGroupData, bitcoinParams, logger)
 	if err != nil {
-		logger.Error("Error calculating participant bitcoin rewards", types.Tokenomics, "error", err)
+		logger.Error("Error calculating participant bitcoin rewards", "error", err)
 		return settleResults, bitcoinResult, err
 	}
 
@@ -243,7 +243,7 @@ func CalculateParticipantBitcoinRewards(
 	for _, participant := range participants {
 		// Skip invalid participants from PoC weight calculations
 		if participant.Status == types.ParticipantStatus_INVALID {
-			logger.Info("Invalid participant found in PoC weight calculations, skipping", types.Tokenomics, "participant", participant.Address)
+			logger.Info("Invalid participant found in PoC weight calculations, skipping", "participant", participant.Address)
 			participantWeights[participant.Address] = 0
 			continue
 		}
@@ -253,8 +253,9 @@ func CalculateParticipantBitcoinRewards(
 		totalPoCWeight += pocWeight
 	}
 
-	logger.Info("Bitcoin Rewards: Checking downtime for participants", types.Tokenomics, "participants", len(participants))
+	logger.Info("Bitcoin Rewards: Checking downtime for participants", "participants", len(participants))
 	CheckAndPunishForDowntimeForParticipants(participants, participantWeights, logger)
+	logger.Info("Bitcoin Rewards: weights after downtime check", "participants", participantWeights)
 
 	// 3. Create settle results for each participant
 	settleResults := make([]*SettleResult, 0, len(participants))

--- a/inference-chain/x/inference/keeper/bitcoin_rewards_test.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards_test.go
@@ -5,9 +5,15 @@ import (
 	"math/big"
 	"testing"
 
+	"cosmossdk.io/log"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/require"
 )
+
+// createTestLogger creates a logger for testing
+func createTestLogger(t *testing.T) log.Logger {
+	return log.NewTestLogger(t)
+}
 
 func TestCalculateFixedEpochReward(t *testing.T) {
 	// Test parameters matching Bitcoin proposal defaults
@@ -197,7 +203,8 @@ func TestCalculateParticipantBitcoinRewards(t *testing.T) {
 	}
 
 	t.Run("Successful Bitcoin reward distribution", func(t *testing.T) {
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(participants, epochGroupData, bitcoinParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(participants, epochGroupData, bitcoinParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 3, len(results))
 
@@ -281,7 +288,8 @@ func TestCalculateParticipantBitcoinRewards(t *testing.T) {
 			},
 		}
 
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(participantsWithDowntime, epochGroupData, bitcoinParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(participantsWithDowntime, epochGroupData, bitcoinParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 3, len(results))
 
@@ -342,7 +350,8 @@ func TestCalculateParticipantBitcoinRewards(t *testing.T) {
 			},
 		}
 
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(invalidParticipants, epochGroupData, bitcoinParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(invalidParticipants, epochGroupData, bitcoinParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(results))
 
@@ -376,7 +385,8 @@ func TestCalculateParticipantBitcoinRewards(t *testing.T) {
 			},
 		}
 
-		results, _, err := CalculateParticipantBitcoinRewards(negativeParticipants, epochGroupData, bitcoinParams)
+		logger := createTestLogger(t)
+		results, _, err := CalculateParticipantBitcoinRewards(negativeParticipants, epochGroupData, bitcoinParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(results))
 
@@ -424,7 +434,8 @@ func TestCalculateParticipantBitcoinRewards(t *testing.T) {
 			},
 		}
 
-		results, _, err := CalculateParticipantBitcoinRewards(zeroWeightParticipants, zeroWeightEpochData, bitcoinParams)
+		logger := createTestLogger(t)
+		results, _, err := CalculateParticipantBitcoinRewards(zeroWeightParticipants, zeroWeightEpochData, bitcoinParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(results))
 
@@ -442,18 +453,20 @@ func TestCalculateParticipantBitcoinRewards(t *testing.T) {
 	})
 
 	t.Run("Parameter validation", func(t *testing.T) {
+		logger := createTestLogger(t)
+
 		// Nil participants
-		_, _, err := CalculateParticipantBitcoinRewards(nil, epochGroupData, bitcoinParams)
+		_, _, err := CalculateParticipantBitcoinRewards(nil, epochGroupData, bitcoinParams, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "participants cannot be nil")
 
 		// Nil epoch group data
-		_, _, err = CalculateParticipantBitcoinRewards(participants, nil, bitcoinParams)
+		_, _, err = CalculateParticipantBitcoinRewards(participants, nil, bitcoinParams, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "epoch group data cannot be nil")
 
 		// Nil bitcoin params
-		_, _, err = CalculateParticipantBitcoinRewards(participants, epochGroupData, nil)
+		_, _, err = CalculateParticipantBitcoinRewards(participants, epochGroupData, nil, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "bitcoin parameters cannot be nil")
 	})
@@ -483,7 +496,8 @@ func TestCalculateParticipantBitcoinRewards(t *testing.T) {
 			},
 		}
 
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(genesisParticipants, genesisEpochData, bitcoinParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(genesisParticipants, genesisEpochData, bitcoinParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(results))
 
@@ -560,7 +574,8 @@ func TestCalculateParticipantBitcoinRewards(t *testing.T) {
 			},
 		}
 
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(remainderParticipants, remainderEpochData, oddRewardParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(remainderParticipants, remainderEpochData, oddRewardParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 3, len(results))
 
@@ -643,12 +658,13 @@ func TestGetBitcoinSettleAmounts(t *testing.T) {
 
 	t.Run("Main entry point function works correctly", func(t *testing.T) {
 		// Call the main entry point function
-		results, bitcoinResult, err := GetBitcoinSettleAmounts(participants, epochGroupData, bitcoinParams, settleParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := GetBitcoinSettleAmounts(participants, epochGroupData, bitcoinParams, settleParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(results))
 
 		// Verify it returns same results as the underlying function
-		expectedResults, expectedBitcoinResult, expectedErr := CalculateParticipantBitcoinRewards(participants, epochGroupData, bitcoinParams)
+		expectedResults, expectedBitcoinResult, expectedErr := CalculateParticipantBitcoinRewards(participants, epochGroupData, bitcoinParams, logger)
 		require.Equal(t, expectedErr, err)
 		require.Equal(t, expectedBitcoinResult, bitcoinResult)
 		require.Equal(t, len(expectedResults), len(results))
@@ -674,23 +690,25 @@ func TestGetBitcoinSettleAmounts(t *testing.T) {
 	})
 
 	t.Run("Parameter validation in main entry point", func(t *testing.T) {
+		logger := createTestLogger(t)
+
 		// Nil participants
-		_, _, err := GetBitcoinSettleAmounts(nil, epochGroupData, bitcoinParams, settleParams)
+		_, _, err := GetBitcoinSettleAmounts(nil, epochGroupData, bitcoinParams, settleParams, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "participants cannot be nil")
 
 		// Nil epoch group data
-		_, _, err = GetBitcoinSettleAmounts(participants, nil, bitcoinParams, settleParams)
+		_, _, err = GetBitcoinSettleAmounts(participants, nil, bitcoinParams, settleParams, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "epochGroupData cannot be nil")
 
 		// Nil bitcoin params
-		_, _, err = GetBitcoinSettleAmounts(participants, epochGroupData, nil, settleParams)
+		_, _, err = GetBitcoinSettleAmounts(participants, epochGroupData, nil, settleParams, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "bitcoinParams cannot be nil")
 
 		// Nil settle params
-		_, _, err = GetBitcoinSettleAmounts(participants, epochGroupData, bitcoinParams, nil)
+		_, _, err = GetBitcoinSettleAmounts(participants, epochGroupData, bitcoinParams, nil, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "settleParams cannot be nil")
 	})
@@ -703,7 +721,8 @@ func TestGetBitcoinSettleAmounts(t *testing.T) {
 		}
 
 		// Call with supply cap constraints
-		results, bitcoinResult, err := GetBitcoinSettleAmounts(participants, epochGroupData, bitcoinParams, supplyCappedParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := GetBitcoinSettleAmounts(participants, epochGroupData, bitcoinParams, supplyCappedParams, logger)
 		require.NoError(t, err)
 
 		// Verify the amount was reduced to fit within cap
@@ -732,7 +751,8 @@ func TestGetBitcoinSettleAmounts(t *testing.T) {
 		}
 
 		// Call with supply cap already reached
-		results, bitcoinResult, err := GetBitcoinSettleAmounts(participants, epochGroupData, bitcoinParams, capReachedParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := GetBitcoinSettleAmounts(participants, epochGroupData, bitcoinParams, capReachedParams, logger)
 		require.NoError(t, err)
 
 		// Verify no rewards are minted
@@ -977,7 +997,8 @@ func TestLargeValueEdgeCases(t *testing.T) {
 		}
 
 		// Should handle large number of participants efficiently
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(largeParticipants, largeEpochData, bitcoinParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(largeParticipants, largeEpochData, bitcoinParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, numParticipants, len(results))
 
@@ -1046,7 +1067,8 @@ func TestLargeValueEdgeCases(t *testing.T) {
 
 		largeWeightData.EpochIndex = 1 // First reward epoch for no decay (epochsSinceGenesis = 1 - 1 = 0)
 
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(largeParticipants, largeWeightData, bitcoinParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(largeParticipants, largeWeightData, bitcoinParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(results))
 
@@ -1138,7 +1160,8 @@ func TestMathematicalPrecision(t *testing.T) {
 			{Address: "participant3", CoinBalance: 300, Status: types.ParticipantStatus_ACTIVE, CurrentEpochStats: &types.CurrentEpochStats{InferenceCount: 100, MissedRequests: 0}},
 		}
 
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(primeParticipants, primeEpochData, primeRewardParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(primeParticipants, primeEpochData, primeRewardParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 3, len(results))
 
@@ -1194,7 +1217,8 @@ func TestMathematicalPrecision(t *testing.T) {
 			{Address: "participant2", CoinBalance: 200, Status: types.ParticipantStatus_ACTIVE, CurrentEpochStats: &types.CurrentEpochStats{InferenceCount: 100, MissedRequests: 0}},
 		}
 
-		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(evenParticipants, evenEpochData, evenRewardParams)
+		logger := createTestLogger(t)
+		results, bitcoinResult, err := CalculateParticipantBitcoinRewards(evenParticipants, evenEpochData, evenRewardParams, logger)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(results))
 

--- a/inference-chain/x/inference/keeper/collateral.go
+++ b/inference-chain/x/inference/keeper/collateral.go
@@ -37,11 +37,13 @@ func (k Keeper) AdjustWeightsByCollateral(ctx context.Context, participants []*t
 
 	baseWeightRatio, err := collateralParams.BaseWeightRatio.ToLegacyDec()
 	if err != nil {
-		panic(fmt.Sprintf("invalid base_weight_ratio: %v", err))
+		k.LogError("invalid base_weight_ratio:", types.Tokenomics, "error", err)
+		return err
 	}
 	collateralPerWeightUnit, err := collateralParams.CollateralPerWeightUnit.ToLegacyDec()
 	if err != nil {
-		panic(fmt.Sprintf("invalid collateral_per_weight_unit: %v", err))
+		k.LogError("invalid collateral_per_weight_unit:", types.Tokenomics, "error", err)
+		return err
 	}
 
 	if collateralPerWeightUnit.IsZero() {
@@ -106,7 +108,8 @@ func (k Keeper) CheckAndSlashForInvalidStatus(ctx context.Context, originalStatu
 		params := k.GetParams(sdkCtx)
 		slashFraction, err := params.CollateralParams.SlashFractionInvalid.ToLegacyDec()
 		if err != nil {
-			panic(fmt.Sprintf("invalid slash_fraction_invalid: %v", err))
+			k.LogError("invalid slash_fraction_invalid:", types.Tokenomics, "error", err)
+			return
 		}
 
 		participantAddress, err := sdk.AccAddressFromBech32(participant.Address)
@@ -140,7 +143,8 @@ func (k Keeper) CheckAndSlashForDowntime(ctx context.Context, participant *types
 	params := k.GetParams(sdkCtx)
 	downtimeThreshold, err := params.CollateralParams.DowntimeMissedPercentageThreshold.ToLegacyDec()
 	if err != nil {
-		panic(fmt.Sprintf("invalid downtime_missed_percentage_threshold: %v", err))
+		k.LogError("nvalid downtime_missed_percentage_threshold", types.Tokenomics, err)
+
 	}
 
 	missedPercentage := math.LegacyNewDec(int64(participant.CurrentEpochStats.MissedRequests)).Quo(
@@ -150,7 +154,7 @@ func (k Keeper) CheckAndSlashForDowntime(ctx context.Context, participant *types
 	if missedPercentage.GT(downtimeThreshold) {
 		slashFraction, err := params.CollateralParams.SlashFractionDowntime.ToLegacyDec()
 		if err != nil {
-			panic(fmt.Sprintf("invalid slash_fraction_downtime: %v", err))
+			k.LogError("invalid slash_fraction_downtime:", types.Tokenomics, err)
 		}
 		participantAddress, err := sdk.AccAddressFromBech32(participant.Address)
 		if err != nil {

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -155,7 +155,7 @@ func (k msgServer) validateClaim(ctx sdk.Context, msg *types.MsgClaimRewards, se
 	}
 
 	// Check for missed validations
-	if validationMissedSignificance, err := k.checkMissedValidationsSignificance(ctx, msg); err != nil {
+	if validationMissedSignificance, err := k.hasSignificantMissedValidations(ctx, msg); err != nil {
 		k.LogError("Failed to check for missed validations", types.Claims, "error", err)
 		return &types.MsgClaimRewardsResponse{
 			Amount: 0,
@@ -173,7 +173,7 @@ func (k msgServer) validateClaim(ctx sdk.Context, msg *types.MsgClaimRewards, se
 	return nil, nil
 }
 
-func (k msgServer) checkMissedValidationsSignificance(ctx sdk.Context, msg *types.MsgClaimRewards) (bool, error) {
+func (k msgServer) hasSignificantMissedValidations(ctx sdk.Context, msg *types.MsgClaimRewards) (bool, error) {
 	mustBeValidated, err := k.getMustBeValidatedInferences(ctx, msg)
 	if err != nil {
 		return false, err

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -20,8 +20,10 @@ func (k msgServer) ClaimRewards(goCtx context.Context, msg *types.MsgClaimReward
 
 	settleAmount, response := k.validateRequest(ctx, msg)
 	if response != nil {
+		k.LogInfo("Validate request failed", types.Claims, "error", response.Result, "account", msg.Creator)
 		return response, nil
 	}
+	k.LogInfo("Validate request succeeded", types.Claims, "account", msg.Creator, "settleAmount", settleAmount)
 
 	response, err := k.validateClaim(ctx, msg, settleAmount)
 	if err != nil {

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -187,8 +187,9 @@ func (k msgServer) hasSignificantMissedValidations(ctx sdk.Context, msg *types.M
 			missed++
 		}
 	}
-
 	passed, err := calculations.MissedStatTest(missed, total)
+	k.LogInfo("Missed validations", types.Claims, "missed", missed, "totalToBeValidated", total, "passed", passed)
+
 	if err != nil {
 		return false, err
 	}

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -155,13 +155,13 @@ func (k msgServer) validateClaim(ctx sdk.Context, msg *types.MsgClaimRewards, se
 	}
 
 	// Check for missed validations
-	if validationMissedSignificanct, err := k.checkMissedValidationsSignificance(ctx, msg); err != nil {
+	if validationMissedSignificance, err := k.checkMissedValidationsSignificance(ctx, msg); err != nil {
 		k.LogError("Failed to check for missed validations", types.Claims, "error", err)
 		return &types.MsgClaimRewardsResponse{
 			Amount: 0,
 			Result: "Failed to check for missed validations",
 		}, err
-	} else if validationMissedSignificanct {
+	} else if validationMissedSignificance {
 		k.LogError("Inference validation missed significantly", types.Claims, "account", msg.Creator)
 		// TODO: Report that validator has missed validations
 		return &types.MsgClaimRewardsResponse{

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -37,6 +37,11 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 
 	existingInference, found := k.GetInference(ctx, msg.InferenceId)
 
+	if found && existingInference.StartProcessed() {
+		k.LogError("StartInference: inference already started", types.Inferences, "inferenceId", msg.InferenceId)
+		return nil, sdkerrors.Wrap(types.ErrInferenceStartProcessed, "inference has already start processed")
+	}
+
 	// Record the current price only if this is the first message (FinishInference not processed yet)
 	// This ensures consistent pricing regardless of message arrival order
 	if !existingInference.FinishedProcessed() {
@@ -133,8 +138,6 @@ func (k msgServer) processInferencePayments(
 		}
 		executor.CoinBalance += payments.ExecutorPayment
 		executor.CurrentEpochStats.EarnedCoins += uint64(payments.ExecutorPayment)
-		executor.CurrentEpochStats.InferenceCount++
-		executor.LastInferenceTime = inference.EndBlockTimestamp
 		k.SafeLogSubAccountTransaction(ctx, executor.Address, types.ModuleName, types.OwedSubAccount, executor.CoinBalance, "inference_started:"+inference.InferenceId)
 		k.SetParticipant(ctx, executor)
 	}

--- a/inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go
@@ -12,6 +12,13 @@ import (
 func (k msgServer) SubmitPocBatch(goCtx context.Context, msg *types.MsgSubmitPocBatch) (*types.MsgSubmitPocBatchResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	if msg.NodeId == "" {
+		k.LogError(PocFailureTag+"[SubmitPocBatch] NodeId is empty", types.PoC,
+			"participant", msg.Creator,
+			"msg.NodeId", msg.NodeId)
+		return nil, sdkerrors.Wrap(types.ErrPocNodeIdEmpty, "NodeId is empty")
+	}
+
 	currentBlockHeight := ctx.BlockHeight()
 	startBlockHeight := msg.PocStageStartBlockHeight
 	epochParams := k.Keeper.GetParams(goCtx).EpochParams

--- a/inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go
@@ -55,6 +55,7 @@ func (k msgServer) SubmitPocBatch(goCtx context.Context, msg *types.MsgSubmitPoc
 		Nonces:                   msg.Nonces,
 		Dist:                     msg.Dist,
 		BatchId:                  msg.BatchId,
+		NodeId:                   msg.NodeId,
 	}
 
 	k.SetPocBatch(ctx, storedBatch)

--- a/inference-chain/x/inference/module/chainvalidation.go
+++ b/inference-chain/x/inference/module/chainvalidation.go
@@ -100,6 +100,10 @@ func (am AppModule) GetPreviousEpochMLNodesWithInferenceAllocation(ctx context.C
 		"len(validationWeight)", len(currentEpochGroup.GroupData.ValidationWeights))
 
 	preservedNodesByParticipant, err := am.GetPreservedNodesByParticipant(ctx, currentEpochGroup.GroupData.EpochIndex)
+	if err != nil {
+		am.LogError("GetPreviousEpochMLNodesWithInferenceAllocation: Error getting preserved nodes by participant", types.PoC, "error", err)
+		return nil
+	}
 
 	// Iterate through all validation weights in current epoch to find inference-serving MLNodes
 	for _, validationWeight := range currentEpochGroup.GroupData.ValidationWeights {
@@ -131,13 +135,18 @@ func (am AppModule) GetPreviousEpochMLNodesWithInferenceAllocation(ctx context.C
 
 		// Calculate total weight from preserved MLNodes
 		totalWeight := int64(0)
+		filteredInferenceMLNodes := make([]*types.MLNodeInfo, 0)
 		for _, mlNode := range inferenceMLNodes {
+			if mlNode.NodeId == "" {
+				continue
+			}
 			totalWeight += mlNode.PocWeight
+			filteredInferenceMLNodes = append(filteredInferenceMLNodes, mlNode)
 		}
 
 		// Create the double repeated structure with all MLNodes in the first array (index 0)
 		firstMLNodeArray := &types.ModelMLNodes{
-			MlNodes: inferenceMLNodes,
+			MlNodes: filteredInferenceMLNodes,
 		}
 		modelMLNodesArray := []*types.ModelMLNodes{firstMLNodeArray}
 
@@ -157,7 +166,7 @@ func (am AppModule) GetPreviousEpochMLNodesWithInferenceAllocation(ctx context.C
 		am.LogInfo("GetPreviousEpochMLNodesWithInferenceAllocation: Created preserved participant", types.PoC,
 			"participantAddress", participantAddress,
 			"totalWeight", totalWeight,
-			"numMLNodes", len(inferenceMLNodes))
+			"numMLNodes", len(filteredInferenceMLNodes))
 	}
 
 	am.LogInfo("GetPreviousEpochMLNodesWithInferenceAllocation: Summary", types.PoC,
@@ -353,8 +362,11 @@ func (am AppModule) ComputeNewWeights(ctx context.Context, upcomingEpoch types.E
 		// Check if this participant also has PoC mining activity
 		if pocParticipant := findParticipantByAddress(pocMiningParticipants, participantAddress); pocParticipant != nil {
 			// Merge: combine weights and MLNodes from both sources
-			combinedWeight := preservedParticipant.Weight + pocParticipant.Weight
 			combinedMLNodes := mergeMLNodeArrays(preservedParticipant.MlNodes, pocParticipant.MlNodes)
+			combinedWeight := int64(0)
+			for _, mlNode := range combinedMLNodes[0].MlNodes {
+				combinedWeight += mlNode.PocWeight
+			}
 
 			mergedParticipant := &types.ActiveParticipant{
 				Index:        participantAddress,
@@ -372,7 +384,8 @@ func (am AppModule) ComputeNewWeights(ctx context.Context, upcomingEpoch types.E
 				"participantAddress", participantAddress,
 				"preservedWeight", preservedParticipant.Weight,
 				"pocWeight", pocParticipant.Weight,
-				"combinedWeight", combinedWeight)
+				"combinedWeight", combinedWeight,
+				"combinedMLNodes", combinedMLNodes)
 		} else {
 			// Only preserved participant (no PoC mining activity)
 			allActiveParticipants = append(allActiveParticipants, preservedParticipant)
@@ -448,8 +461,33 @@ func mergeMLNodeArrays(preservedMLNodes, pocMLNodes []*types.ModelMLNodes) []*ty
 		}
 	}
 
+	filteredMergedMLNodes := make([]*types.MLNodeInfo, 0)
+	for _, mlNode := range mergedMLNodes {
+		if mlNode.NodeId == "" {
+			continue
+		}
+		filteredMergedMLNodes = append(filteredMergedMLNodes, mlNode)
+	}
+
 	// Return merged array in the first position
-	return []*types.ModelMLNodes{{MlNodes: mergedMLNodes}}
+	return []*types.ModelMLNodes{{MlNodes: filteredMergedMLNodes}}
+}
+
+func RecalculateWeight(p *types.ActiveParticipant) int64 {
+	weight := int64(0)
+	countedNodeIds := make(map[string]bool)
+	for _, nodeMLNodes := range p.MlNodes {
+		for _, mlNode := range nodeMLNodes.MlNodes {
+			if mlNode.NodeId == "" {
+				continue
+			}
+			if _, ok := countedNodeIds[mlNode.NodeId]; !ok {
+				countedNodeIds[mlNode.NodeId] = true
+				weight += mlNode.PocWeight
+			}
+		}
+	}
+	return weight
 }
 
 // Calculate computes the new weights for active participants based on the data in the WeightCalculator
@@ -521,6 +559,8 @@ func (wc *WeightCalculator) validatedParticipant(participantAddress string) *typ
 			PocWeight: n.weight,
 		})
 	}
+
+	wc.Logger.LogInfo("Calculate: mlNodes", types.PoC, "mlNodes", mlNodes)
 
 	// Create the double repeated structure with all MLNodes in the first array (index 0)
 	firstMLNodeArray := &types.ModelMLNodes{

--- a/inference-chain/x/inference/module/model_assignment.go
+++ b/inference-chain/x/inference/module/model_assignment.go
@@ -75,6 +75,9 @@ func (ma *ModelAssigner) setModelsForParticipants(ctx context.Context, participa
 		var newMLNodeArrays []*types.ModelMLNodes
 
 		supportedModelsByNode := supportedModelsByNode(hardwareNodes, governanceModels)
+		for nodeId, supportedModels := range supportedModelsByNode {
+			ma.LogInfo("Supported models by node", types.EpochGroup, "flow_context", flowContext, "step", "supported_models_by_node", "node_id", nodeId, "supported_models", supportedModels)
+		}
 
 		// For each governance model, pick the available MLNodes that have the model as first supported model
 		for _, model := range governanceModels {

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -403,6 +403,9 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 		return
 	}
 
+	modelAssigner := NewModelAssigner(am.keeper, am.keeper)
+	modelAssigner.setModelsForParticipants(ctx, activeParticipants, *upcomingEpoch)
+
 	// Adjust weights based on collateral after the grace period. This modifies the weights in-place.
 	if err := am.keeper.AdjustWeightsByCollateral(ctx, activeParticipants); err != nil {
 		am.LogError("onSetNewValidatorsStage: failed to adjust weights by collateral", types.Tokenomics, "error", err)
@@ -412,9 +415,6 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 
 	// Apply universal power capping to epoch powers
 	activeParticipants = am.applyEpochPowerCapping(ctx, activeParticipants)
-
-	modelAssigner := NewModelAssigner(am.keeper, am.keeper)
-	modelAssigner.setModelsForParticipants(ctx, activeParticipants, *upcomingEpoch)
 
 	err = am.RegisterTopMiners(ctx, activeParticipants, blockTime)
 	if err != nil {

--- a/inference-chain/x/inference/types/errors.go
+++ b/inference-chain/x/inference/types/errors.go
@@ -49,4 +49,5 @@ var (
 	ErrInvalidValidationThreshold              = sdkerrors.Register(ModuleName, 1138, "validation threshold must be in [0, 100] range")
 	ErrNegativeRewardAmount                    = sdkerrors.Register(ModuleName, 1139, "negative reward amount")
 	ErrDuplicateValidation                     = sdkerrors.Register(ModuleName, 1140, "participant has already validated this inference")
+	ErrPocNodeIdEmpty                          = sdkerrors.Register(ModuleName, 1141, "node id is empty")
 )

--- a/inference-chain/x/inference/types/errors.go
+++ b/inference-chain/x/inference/types/errors.go
@@ -50,4 +50,6 @@ var (
 	ErrNegativeRewardAmount                    = sdkerrors.Register(ModuleName, 1139, "negative reward amount")
 	ErrDuplicateValidation                     = sdkerrors.Register(ModuleName, 1140, "participant has already validated this inference")
 	ErrPocNodeIdEmpty                          = sdkerrors.Register(ModuleName, 1141, "node id is empty")
+	ErrInferenceFinishProcessed                = sdkerrors.Register(ModuleName, 1142, "inference has already finished processed")
+	ErrInferenceStartProcessed                 = sdkerrors.Register(ModuleName, 1143, "inference has already started processed")
 )

--- a/testermint/mock_server/src/main/kotlin/com/productscience/mockserver/service/ResponseService.kt
+++ b/testermint/mock_server/src/main/kotlin/com/productscience/mockserver/service/ResponseService.kt
@@ -212,6 +212,7 @@ class ResponseService {
               "public_key": "$publicKey",
               "block_hash": "$blockHash",
               "block_height": $blockHeight,
+              "node_id": $nodeNumber,
               "nonces": $nonces,
               "dist": $dist,
               "received_dist": $dist

--- a/testermint/src/main/resources/alternative-mappings/generate_poc.json
+++ b/testermint/src/main/resources/alternative-mappings/generate_poc.json
@@ -23,7 +23,7 @@
         "type": "fixed",
         "milliseconds": 1000
       },
-      "body": "{ \"public_key\": \"{{jsonPath originalRequest.body '$.public_key'}}\",\"block_hash\": \"{{jsonPath originalRequest.body '$.block_hash'}}\",\"block_height\": {{jsonPath originalRequest.body '$.block_height'}},\"nonces\": [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],\"dist\": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}"
+      "body": "{ \"public_key\": \"{{jsonPath originalRequest.body '$.public_key'}}\",\"node_id\": \"{{jsonPath originalRequest.body '$.node_id'}}\",\"block_hash\": \"{{jsonPath originalRequest.body '$.block_hash'}}\",\"block_height\": {{jsonPath originalRequest.body '$.block_height'}},\"nonces\": [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],\"dist\": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}"
     }
   }
 }

--- a/testermint/src/main/resources/mappings/generate_poc.json
+++ b/testermint/src/main/resources/mappings/generate_poc.json
@@ -23,7 +23,7 @@
         "type": "fixed",
         "milliseconds": 1000
       },
-      "body": "{ \"public_key\": \"{{jsonPath originalRequest.body '$.public_key'}}\",\"block_hash\": \"{{jsonPath originalRequest.body '$.block_hash'}}\",\"block_height\": {{jsonPath originalRequest.body '$.block_height'}},\"nonces\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],\"dist\": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}"
+      "body": "{ \"public_key\": \"{{jsonPath originalRequest.body '$.public_key'}}\",\"node_id\": \"{{jsonPath originalRequest.body '$.node_id'}}\",\"block_hash\": \"{{jsonPath originalRequest.body '$.block_hash'}}\",\"block_height\": {{jsonPath originalRequest.body '$.block_height'}},\"nonces\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],\"dist\": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}"
     }
   }
 }

--- a/testermint/src/test/kotlin/BLSDKGSuccessTest.kt
+++ b/testermint/src/test/kotlin/BLSDKGSuccessTest.kt
@@ -88,6 +88,10 @@ class BLSDKGSuccessTest : TestermintTest() {
         
         val (cluster, genesis) = initCluster(joinCount = 4)
         val allPairs = listOf(genesis) + cluster.joinPairs
+
+        genesis.waitForStage(EpochStage.CLAIM_REWARDS, offset = 10)
+        genesis.waitForStage(EpochStage.CLAIM_REWARDS, 2)
+
         
         // Trigger complete DKG flow
         logSection("Triggering DKG Init")


### PR DESCRIPTION
### Multiple Fixes and Security Improvements

The PR introduces multiple fixes and security improvements:


#### Missed `node_id` to PoCBatch (`inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go`)

`node_id` is used to detect which node produced the nonce's batch


#### Remove legacy weight distribution from batches without `node_id`

`inference-chain/x/inference/module/model_assignment.go` distributed before batches without `node_id` between another nodes. As now all MLNodes returns `node_id` => that it not needed anymore


#### Remove MLNodes without HardwareNodes or models supported by Governance

`unassignedMLNodes` from `inference-chain/x/inference/module/model_assignment.go` are not counted in total weight anymore
Total weight of participant is recomputed after all filtering 

#### Statistical Validation for Missed inference and validation

Binom test `inference-chain/x/inference/calculations/stats.go` is now used for:   
- not pay reward if statistically signigicant > 10% of requests are missed (`inference-chain/x/inference/keeper/accountsettle.go`) 
- not pay claim if statistically signigicant > 10% of validations are missed (`inference-chain/x/inference/keeper/msg_server_claim_rewards.go`) instead of hard check for all validations

#### Set Participant status to `ACTIVE` for all ActiveParticipant when switch epoch

`inference-chain/x/inference/module/module.go:moveUpcomingToEffectiveGroup`

#### Fix counter for successful inferences

`inference-chain/x/inference/keeper/msg_server_start_inference.go`  
`inference-chain/x/inference/keeper/msg_server_finish_inference.go`  

#### Fix for interrupted inference validation


#### Logging 