### PR TITLE
Fix seed

### DIFF
--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -142,6 +142,11 @@ func (m *MockRandomSeedManager) ChangeCurrentSeed() {
 	m.Called()
 }
 
+func (m *MockRandomSeedManager) GetSeedForEpoch(epochIndex uint64) apiconfig.SeedInfo {
+	m.Called()
+	return apiconfig.SeedInfo{}
+}
+
 func (m *MockRandomSeedManager) RequestMoney(epochIndex uint64) {
 	m.Called()
 }
@@ -289,6 +294,7 @@ func createIntegrationTestSetup(reconcilialtionConfig *MlNodeReconciliationConfi
 	mockSeedManager.On("RequestMoney").Return()
 	mockSeedManager.On("GenerateSeedInfo", mock.AnythingOfType("uint64")).Return()
 	mockSeedManager.On("CreateNewSeed", mock.AnythingOfType("uint64")).Return()
+	mockSeedManager.On("GetSeedForEpoch").Return(apiconfig.SeedInfo{})
 
 	var finalReconciliationConfig MlNodeReconciliationConfig
 	if reconcilialtionConfig == nil {

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -138,10 +138,6 @@ type MockRandomSeedManager struct {
 	mock.Mock
 }
 
-func (m *MockRandomSeedManager) GenerateSeed(blockHeight uint64) {
-	m.Called(blockHeight)
-}
-
 func (m *MockRandomSeedManager) ChangeCurrentSeed() {
 	m.Called()
 }

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -289,7 +289,6 @@ func createIntegrationTestSetup(reconcilialtionConfig *MlNodeReconciliationConfi
 	}, nil)
 
 	// Setup mock expectations for RandomSeedManager
-	mockSeedManager.On("GenerateSeed", mock.AnythingOfType("uint64")).Return()
 	mockSeedManager.On("ChangeCurrentSeed").Return()
 	mockSeedManager.On("RequestMoney").Return()
 	mockSeedManager.On("GenerateSeedInfo", mock.AnythingOfType("uint64")).Return()

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -150,6 +150,15 @@ func (m *MockRandomSeedManager) RequestMoney() {
 	m.Called()
 }
 
+func (m *MockRandomSeedManager) CreateNewSeed(epoch uint64) (*apiconfig.SeedInfo, error) {
+	m.Called()
+	return nil, nil
+}
+
+func (m *MockRandomSeedManager) GenerateSeedInfo(epochIndex uint64) {
+	m.Called(epochIndex)
+}
+
 type MockQueryClient struct {
 	mock.Mock
 }
@@ -283,6 +292,8 @@ func createIntegrationTestSetup(reconcilialtionConfig *MlNodeReconciliationConfi
 	mockSeedManager.On("GenerateSeed", mock.AnythingOfType("uint64")).Return()
 	mockSeedManager.On("ChangeCurrentSeed").Return()
 	mockSeedManager.On("RequestMoney").Return()
+	mockSeedManager.On("GenerateSeedInfo", mock.AnythingOfType("uint64")).Return()
+	mockSeedManager.On("CreateNewSeed", mock.AnythingOfType("uint64")).Return()
 
 	var finalReconciliationConfig MlNodeReconciliationConfig
 	if reconcilialtionConfig == nil {

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -142,11 +142,11 @@ func (m *MockRandomSeedManager) ChangeCurrentSeed() {
 	m.Called()
 }
 
-func (m *MockRandomSeedManager) RequestMoney() {
+func (m *MockRandomSeedManager) RequestMoney(epochIndex uint64) {
 	m.Called()
 }
 
-func (m *MockRandomSeedManager) CreateNewSeed(epoch uint64) (*apiconfig.SeedInfo, error) {
+func (m *MockRandomSeedManager) CreateNewSeed(epochIndex uint64) (*apiconfig.SeedInfo, error) {
 	m.Called()
 	return nil, nil
 }

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -352,11 +352,10 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 	if epochContext.IsClaimMoneyStage(blockHeight) {
 		logging.Info("DapiStage:IsClaimMoneyStage", types.Stages, "blockHeight", blockHeight, "blockHash", blockHash)
 
-		// Get the previous epoch seed for validation recovery
-		previousSeed := d.configManager.GetPreviousSeed()
-
 		// Calculate previous epoch index
 		expectedPreviousEpochIndex := epochContext.EpochIndex - 1
+		// Get the previous epoch seed for validation recovery
+		previousSeed := d.randomSeedManager.GetSeedForEpoch(expectedPreviousEpochIndex)
 
 		// Verify the seed is from the correct epoch
 		if previousSeed.EpochIndex != expectedPreviousEpochIndex {
@@ -372,7 +371,7 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 			d.executeMissedValidationRecoveryWithSeed(expectedPreviousEpochIndex, previousSeed)
 
 			// Then, claim rewards (this ensures we've validated everything before claiming)
-			d.randomSeedManager.RequestMoney()
+			d.randomSeedManager.RequestMoney(expectedPreviousEpochIndex)
 
 			// Mark the seed as claimed to prevent duplicate claims
 			err := d.configManager.MarkPreviousSeedClaimed()

--- a/decentralized-api/internal/poc/random_seed.go
+++ b/decentralized-api/internal/poc/random_seed.go
@@ -137,7 +137,7 @@ func (rsm *RandomSeedManagerImpl) createSeedForEpoch(epoch uint64) (int64, error
 	signed, err := rsm.transactionRecorder.SignBytes(initialSeedBytes)
 	if err != nil {
 		logging.Error("Failed to sign bytes", types.Claims, "error", err)
-		return nil, err
+		return 0, err
 	}
 
 	signed8bytes := signed[:8]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch to epoch-signed deterministic seeds, add seed retrieval/regeneration APIs, update dispatcher flow and tests to use new interfaces.
> 
> - **PoC/Seed Management**:
>   - Replace `GenerateSeed` with `GenerateSeedInfo` and introduce deterministic seed generation via signing epoch bytes (`createSeedForEpoch`), removing `crypto/rand` usage.
>   - Add `GetSeedForEpoch(epochIndex)` and `CreateNewSeed(epochIndex)`; change `RequestMoney()` to `RequestMoney(epochIndex)`.
>   - Implement `GetSeedForEpoch` fallback to create seed when missing; `RequestMoney` now fetches seed for the given epoch.
> - **Dispatcher (`internal/event_listener/new_block_dispatcher.go`)**:
>   - On PoC start, call `GenerateSeedInfo(epochIndex)`.
>   - During Claim Money stage, fetch previous seed via `GetSeedForEpoch(expectedPreviousEpochIndex)` and call `RequestMoney(expectedPreviousEpochIndex)`.
>   - In missed validation recovery, regenerate empty seeds via `CreateNewSeed` before proceeding.
> - **Tests (`internal/event_listener/integration_test.go`)**:
>   - Update `MockRandomSeedManager` and expectations to new methods (`GenerateSeedInfo`, `GetSeedForEpoch`, `CreateNewSeed`, `RequestMoney(epochIndex)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad883ed7219df5cb13de93c1e7669c65ee25b446. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->