### PR TITLE
run archive node

### DIFF
--- a/inference-chain/scripts/init-docker.sh
+++ b/inference-chain/scripts/init-docker.sh
@@ -193,6 +193,11 @@ if $FIRST_RUN; then
       run "$APP_NAME" set-statesync-trusted-block "$STATE_DIR/config/config.toml" \
           "$SEED_NODE_RPC_URL" "$TRUSTED_BLOCK_PERIOD"
     fi
+
+    if [ "${ARCHIVE_NODE:-false}" = "true" ]; then
+        echo "ARCHIVE_NODE=true → disable state pruning"
+        sed -i -E 's|^[[:space:]]*pruning *=.*|pruning = "nothing"|' "$STATE_DIR/config/app.toml"
+    fi
   else
     cp /root/genesis.json "$GENESIS_FILE"
     


### PR DESCRIPTION
Problem: By default, a node stores the last 362,880 states. This usually does not cause issues, since the node continues to keep blocks in blockstore.db. However, generating a Merkle proof requires access to the full application state.

Solution: Run 1–2 archive nodes that retain all states.
To achieve this, set pruning = "nothing" in app.toml if the environment variable ARCHIVE_NODE=true. Do not sync with snapshots. 