### PR TITLE
Experimental refactor of tx_manager

### DIFF
--- a/decentralized-api/chainphase/phase_tracker.go
+++ b/decentralized-api/chainphase/phase_tracker.go
@@ -2,6 +2,7 @@ package chainphase
 
 import (
 	"sync"
+	"time"
 
 	"github.com/productscience/inference/x/inference/types"
 )
@@ -23,6 +24,7 @@ type ChainPhaseTracker struct {
 type BlockInfo struct {
 	Height int64
 	Hash   string
+	Time   time.Time
 }
 
 // NewChainPhaseTracker creates a new ChainPhaseTracker instance.

--- a/decentralized-api/cosmosclient/tx_manager/broadcaster.go
+++ b/decentralized-api/cosmosclient/tx_manager/broadcaster.go
@@ -1,0 +1,182 @@
+package tx_manager
+
+import (
+	"context"
+	"decentralized-api/apiconfig"
+	"decentralized-api/logging"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+//type Broadcaster interface {
+//	BroadcastTx(is string, rawTx sdk.Msg) (*sdk.TxResponse, time.Time, error)
+//}
+
+type TimestampCreator interface {
+	GetLatestBlockTime(ctx context.Context) time.Time
+}
+
+type Broadcaster struct {
+	txFactory        *tx.Factory
+	apiAccount       *apiconfig.ApiAccount
+	accountRetriever client.AccountRetriever
+	client           *cosmosclient.Client
+	timestampCreator TimestampCreator
+}
+
+func NewBroadcaster(account *apiconfig.ApiAccount, client *cosmosclient.Client, timestampCreator TimestampCreator) *Broadcaster {
+	return &Broadcaster{
+		apiAccount:       account,
+		accountRetriever: authtypes.AccountRetriever{},
+		client:           client,
+		timestampCreator: timestampCreator,
+	}
+}
+
+func (b *Broadcaster) getOrCreateFactory() (*tx.Factory, error) {
+	// Only need to create the factory once
+	if b.txFactory != nil {
+		return b.txFactory, nil
+	}
+	address, err := b.apiAccount.SignerAddress()
+	if err != nil {
+		logging.Error("Failed to get account address", types.Messages, "error", err)
+		return nil, err
+	}
+	accountNumber, _, err := b.accountRetriever.GetAccountNumberSequence(b.client.Context(), address)
+	if err != nil {
+		logging.Error("Failed to get account number and sequence", types.Messages, "error", err)
+		return nil, err
+	}
+	factory := b.client.TxFactory.
+		WithAccountNumber(accountNumber).
+		WithGasAdjustment(10).
+		WithFees("").
+		WithGasPrices("").
+		WithGas(0).
+		WithUnordered(true).
+		WithKeybase(b.client.AccountRegistry.Keyring)
+	b.txFactory = &factory
+	return &factory, nil
+}
+
+func (b *Broadcaster) Broadcast(ctx context.Context, id string, rawTx sdk.Msg) (*sdk.TxResponse, time.Time, error) {
+	factory, err := b.getOrCreateFactory()
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	var finalMsg sdk.Msg = rawTx
+	originalMsgType := sdk.MsgTypeURL(rawTx)
+	if !b.apiAccount.IsSignerTheMainAccount() {
+		granteeAddress, err := b.apiAccount.SignerAddress()
+		if err != nil {
+			return nil, time.Time{}, fmt.Errorf("failed to get signer address: %w", err)
+		}
+
+		execMsg := authztypes.NewMsgExec(granteeAddress, []sdk.Msg{rawTx})
+		finalMsg = &execMsg
+		logging.Debug("Using authz MsgExec", types.Messages, "grantee", granteeAddress.String(), "originalMsgType", originalMsgType)
+	}
+
+	unsignedTx, err := factory.BuildUnsignedTx(finalMsg)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	txBytes, timeoutTimestamp, err := b.getSignedBytes(ctx, id, unsignedTx)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	resp, err := b.client.Context().BroadcastTxSync(txBytes)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	if resp.Code != 0 {
+		logging.Error("Broadcast failed immediately", types.Messages, "code", resp.Code, "rawLog", resp.RawLog, "tx_id", id, "originalMsgType", originalMsgType)
+	} else {
+		logging.Debug("Broadcast successful", types.Messages, "tx_id", id, "originalMsgType", originalMsgType, "resp", resp)
+	}
+	return resp, timeoutTimestamp, nil
+}
+
+func (b *Broadcaster) getSignedBytes(ctx context.Context, id string, unsignedTx client.TxBuilder) ([]byte, time.Time, error) {
+	factory, err := b.getOrCreateFactory()
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	timestamp := b.timestampCreator.GetLatestBlockTime(ctx)
+
+	// Gas is not charged, but without a high gas limit the transactions fail
+	unsignedTx.SetGasLimit(1000000000)
+	unsignedTx.SetFeeAmount(sdk.Coins{})
+	unsignedTx.SetUnordered(true)
+	unsignedTx.SetTimeoutTimestamp(timestamp)
+	name := b.apiAccount.SignerAccount.Name
+	logging.Debug("Signing transaction", types.Messages, "tx_id", id, "timeout", timestamp.String(), "name", name)
+
+	err = tx.Sign(ctx, *factory, name, unsignedTx, false)
+	if err != nil {
+		logging.Error("Failed to sign transaction", types.Messages, "tx_id", id, "error", err)
+		return nil, time.Time{}, err
+	}
+	txBytes, err := b.client.Context().TxConfig.TxEncoder()(unsignedTx.GetTx())
+	if err != nil {
+		logging.Error("Failed to encode transaction", types.Messages, "tx_id", id, "error", err)
+		return nil, time.Time{}, err
+	}
+	return txBytes, timestamp, nil
+}
+
+func (b *Broadcaster) WaitForResponse(ctx context.Context, hash string) (*ctypes.ResultTx, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*15)
+	defer cancel()
+
+	transactionAppliedResult, err := b.client.WaitForTx(ctx, hash)
+	if err != nil {
+		logging.Error("Failed to wait for transaction", types.Messages, "error", err, "result", transactionAppliedResult)
+		return nil, err
+	}
+
+	txResult := transactionAppliedResult.TxResult
+	if txResult.Code != 0 {
+		logging.Error("Transaction failed on-chain", types.Messages, "txHash", hash, "code", txResult.Code, "codespace", txResult.Codespace, "rawLog", txResult.Log)
+		return nil, NewTransactionErrorFromResult(transactionAppliedResult)
+	}
+	return transactionAppliedResult, nil
+
+}
+
+func (b *Broadcaster) FindTxStatus(ctx context.Context, hash string) (bool, error) {
+	bz, err := hex.DecodeString(hash)
+	if err != nil {
+		logging.Error("findTxStatus: error decoding tx hash", types.Messages, "err", err)
+		return false, ErrDecodingTxHash
+	}
+
+	resp, err := b.client.Context().Client.Tx(ctx, bz, false)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return false, ErrTxNotFound
+		}
+		return false, err
+	}
+
+	if resp.TxResult.Code != 0 {
+		logging.Error("findTxStatus: tx failed on-chain", types.Messages, "txHash", hash, "code", resp.TxResult.Code, "codespace", resp.TxResult.Codespace, "rawLog", resp.TxResult.Log)
+	}
+	logging.Debug("findTxStatus: found tx result", types.Messages, "txHash", hash, "resp", resp)
+	return true, nil
+
+}

--- a/decentralized-api/cosmosclient/tx_manager/chain_tracker.go
+++ b/decentralized-api/cosmosclient/tx_manager/chain_tracker.go
@@ -1,0 +1,99 @@
+package tx_manager
+
+import (
+	"context"
+	"decentralized-api/chainphase"
+	"decentralized-api/logging"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+type ChainTracker struct {
+	latestBlockTime   atomic.Value
+	latestBlockHeight int64
+	lastUpdatedAt     time.Time
+	maxBlockTimeout   time.Duration
+	chainHalt         bool
+	mtx               sync.Mutex
+	client            *cosmosclient.Client
+}
+
+func NewChainTracker(client *cosmosclient.Client, maxBlockTimeout time.Duration) *ChainTracker {
+	value := atomic.Value{}
+	value.Store(time.Time{})
+	return &ChainTracker{
+		latestBlockTime:   value,
+		latestBlockHeight: 0,
+		lastUpdatedAt:     time.Now(),
+		maxBlockTimeout:   maxBlockTimeout,
+		chainHalt:         false,
+		client:            client,
+	}
+}
+
+func (ct *ChainTracker) GetLatestBlockTime(ctx context.Context) time.Time {
+	blockTs := ct.latestBlockTime.Load().(time.Time)
+	if blockTs.IsZero() {
+		_, err := ct.UpdateFromClient(ctx)
+		if err != nil {
+			return time.Time{}
+		}
+	}
+	return blockTs
+}
+
+func (ct *ChainTracker) UpdateFromEvent(blockInfo *chainphase.BlockInfo) {
+	ct.mtx.Lock()
+	logging.Info("UpdateFromEvent", types.Messages, "block_height", blockInfo.Height, "block_time", blockInfo.Time.String())
+	defer ct.mtx.Unlock()
+	if blockInfo.Time.After(ct.latestBlockTime.Load().(time.Time)) &&
+		blockInfo.Height > ct.latestBlockHeight {
+		ct.latestBlockHeight = blockInfo.Height
+		ct.latestBlockTime.Store(blockInfo.Time)
+		ct.chainHalt = false
+	}
+
+	ct.lastUpdatedAt = time.Now()
+	return
+}
+
+func (ct *ChainTracker) UpdateFromClient(ctx context.Context) (bool, error) {
+	now := time.Now()
+	// Under operation, this should rarely be called, as the new block event will update proactively
+	if now.Sub(ct.lastUpdatedAt) < time.Second*6 {
+		return ct.chainHalt, nil
+	}
+
+	status, err := ct.client.Status(ctx)
+	if err != nil {
+		logging.Error("error getting blockchain status", types.Messages, "err", err)
+		return false, err
+	}
+
+	ct.mtx.Lock()
+	defer ct.mtx.Unlock()
+
+	if status.SyncInfo.LatestBlockTime.Equal(ct.latestBlockTime.Load().(time.Time)) &&
+		status.SyncInfo.LatestBlockHeight == ct.latestBlockHeight &&
+		!ct.lastUpdatedAt.IsZero() && now.Sub(ct.lastUpdatedAt) > ct.maxBlockTimeout {
+		// same block, and we sow it more than N seconds ago -> chain halt
+		ct.chainHalt = true
+	}
+
+	if status.SyncInfo.LatestBlockTime.After(ct.latestBlockTime.Load().(time.Time)) &&
+		status.SyncInfo.LatestBlockHeight > ct.latestBlockHeight {
+		ct.latestBlockHeight = status.SyncInfo.LatestBlockHeight
+		ct.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
+		ct.chainHalt = false
+	}
+
+	ct.lastUpdatedAt = now
+	if ct.chainHalt {
+		logging.Error("Chain halt or slowdown", types.Messages, "latest_block_time", ct.latestBlockTime.Load().(time.Time), "latest_block_height", ct.latestBlockHeight)
+	}
+	return ct.chainHalt, nil
+}

--- a/decentralized-api/cosmosclient/tx_manager/errors.go
+++ b/decentralized-api/cosmosclient/tx_manager/errors.go
@@ -14,7 +14,8 @@ var (
 	ErrDecodingTxHash     = errors.New("error decoding transaction hash")
 	ErrInvalidAddress     = errors.New("invalid bech32 string")
 
-	ErrTxFailedToBroadcastAndPutOnRetry = errors.New("failed to broadcast and put on retry")
+	ErrTxFailedToBroadcastAndPutOnRetry = errors.New("failed to broadcast but put on retry")
+	ErrTxFailedToBroadcastAndRetry      = errors.New("failed to broadcast and failed to put on retry")
 	ErrTxNotFound                       = errors.New("tx not found")
 )
 

--- a/decentralized-api/cosmosclient/tx_manager/transaction_queue.go
+++ b/decentralized-api/cosmosclient/tx_manager/transaction_queue.go
@@ -1,0 +1,234 @@
+package tx_manager
+
+import (
+	"decentralized-api/internal/nats/server"
+	"decentralized-api/logging"
+	"encoding/json"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+const (
+	txSenderConsumer   = "tx-sender"
+	txObserverConsumer = "tx-observer"
+
+	defaultSenderNackDelay   = time.Second * 7
+	defaultObserverNackDelay = time.Second * 5
+)
+
+type QueueAction int
+
+const (
+	Terminate QueueAction = iota
+	Redeliver
+	Acknowledge
+)
+
+type TransactionQueue struct {
+	MaxAttempts       int
+	Codec             codec.Codec
+	natsJetStream     nats.JetStreamContext
+	senderNackDelay   time.Duration
+	observerNackDelay time.Duration
+}
+
+func NewTransactionQueue(
+	maxAttempts int,
+	natsConnection *nats.Conn,
+	codec codec.Codec,
+) *TransactionQueue {
+	js, err := natsConnection.JetStream()
+	if err != nil {
+		panic(err)
+	}
+	queue := TransactionQueue{
+		MaxAttempts:       maxAttempts,
+		Codec:             codec,
+		natsJetStream:     js,
+		senderNackDelay:   defaultSenderNackDelay,
+		observerNackDelay: defaultObserverNackDelay,
+	}
+	return &queue
+}
+
+func terminate(msg *nats.Msg) {
+	err := msg.Term()
+	if err != nil {
+		logging.Error("error terminating message", types.Messages, "err", err)
+	}
+}
+
+func acknowledge(msg *nats.Msg) {
+	err := msg.Ack()
+	if err != nil {
+		logging.Error("error acknowledging message", types.Messages, "err", err)
+	}
+}
+
+func redeliver(msg *nats.Msg) {
+	err := msg.NakWithDelay(defaultSenderNackDelay)
+	if err != nil {
+		logging.Error("error redelivering message", types.Messages, "err", err)
+	}
+}
+
+func (q *TransactionQueue) RegisterSendHandler(handler func(txToSend, sdk.Msg) (QueueAction, error)) error {
+	_, err := q.natsJetStream.Subscribe(server.TxsToSendStream, func(msg *nats.Msg) {
+		var tx txToSend
+		if err := json.Unmarshal(msg.Data, &tx); err != nil {
+			logging.Error("error unmarshaling tx_to_send", types.Messages, "err", err)
+			terminate(msg)
+			return
+		}
+		logging.Debug("got tx to send", types.Messages, "id", tx.TxInfo.Id)
+		rawTx, err := q.unpackTx(tx.TxInfo.RawTx)
+		if err != nil {
+			logging.Error("error unpacking raw tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
+			terminate(msg)
+			return
+		}
+
+		action, err := handler(tx, rawTx)
+		if err != nil {
+			logging.Error("error processing tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
+			terminate(msg)
+			return
+		}
+		switch action {
+		case Acknowledge:
+			acknowledge(msg)
+			break
+		case Redeliver:
+			redeliver(msg)
+			break
+		case Terminate:
+			terminate(msg)
+		}
+	}, nats.Durable(txSenderConsumer), nats.ManualAck())
+	return err
+}
+
+func (q *TransactionQueue) RegisterObserveHandler(handler func(txInfo, sdk.Msg) (QueueAction, error)) error {
+	_, err := q.natsJetStream.Subscribe(server.TxsToObserveStream, func(msg *nats.Msg) {
+		var tx txInfo
+		if err := json.Unmarshal(msg.Data, &tx); err != nil {
+			logging.Error("error unmarshaling tx_to_observe", types.Messages, "err", err)
+			terminate(msg)
+			return
+		}
+		logging.Debug("got tx to observe", types.Messages, "id", tx.Id)
+		rawTx, err := q.unpackTx(tx.RawTx)
+		if err != nil {
+			logging.Error("error unpacking raw tx", types.Messages, "id", tx.Id, "err", err)
+			terminate(msg)
+			return
+		}
+		action, err := handler(tx, rawTx)
+		if err != nil {
+			logging.Error("error processing tx", types.Messages, "id", tx.Id, "err", err)
+			terminate(msg)
+			return
+		}
+		switch action {
+		case Acknowledge:
+			acknowledge(msg)
+			break
+		case Redeliver:
+			redeliver(msg)
+			break
+		case Terminate:
+			terminate(msg)
+		}
+	}, nats.Durable(txObserverConsumer), nats.ManualAck())
+	return err
+}
+
+func (q *TransactionQueue) AddToRetryQueue(
+	id,
+	txHash string,
+	timeout time.Time,
+	rawTx sdk.Msg,
+	attempts int,
+	sent bool) error {
+	logging.Debug("putOnRetry: tx with params", types.Messages,
+		"tx_id", id,
+		"tx_hash", txHash,
+		"timeout", timeout.String(),
+		"sent", sent,
+	)
+
+	if attempts >= maxAttempts {
+		logging.Warn("tx reached max attempts", types.Messages, "tx_id", id)
+		return nil
+	}
+
+	bz, err := q.Codec.MarshalInterfaceJSON(rawTx)
+	if err != nil {
+		return err
+	}
+
+	if id == "" {
+		id = uuid.New().String()
+	}
+
+	b, err := json.Marshal(&txToSend{
+		TxInfo: txInfo{
+			Id:      id,
+			RawTx:   bz,
+			TxHash:  txHash,
+			Timeout: timeout,
+		},
+		Sent:     sent,
+		Attempts: attempts,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = q.natsJetStream.Publish(server.TxsToSendStream, b)
+	return err
+}
+
+func (q *TransactionQueue) AddToObserveQueue(id string, rawTx sdk.Msg, txHash string, timeout time.Time, attempts int) error {
+	logging.Debug(" putTxToObserve: tx with params", types.Messages,
+		"tx_id", id,
+		"tx_hash", txHash,
+		"timeout", timeout.String(),
+	)
+
+	bz, err := q.Codec.MarshalInterfaceJSON(rawTx)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(&txInfo{
+		Id:       id,
+		RawTx:    bz,
+		TxHash:   txHash,
+		Timeout:  timeout,
+		Attempts: attempts,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = q.natsJetStream.Publish(server.TxsToObserveStream, b)
+	return err
+}
+
+func (q *TransactionQueue) unpackTx(bz []byte) (sdk.Msg, error) {
+	var unpackedAny codectypes.Any
+	if err := q.Codec.UnmarshalJSON(bz, &unpackedAny); err != nil {
+		return nil, err
+	}
+
+	var rawTx sdk.Msg
+	if err := q.Codec.UnpackAny(&unpackedAny, &rawTx); err != nil {
+		return nil, err
+	}
+	return rawTx, nil
+}

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -3,29 +3,15 @@ package tx_manager
 import (
 	"context"
 	"decentralized-api/apiconfig"
-	"decentralized-api/internal/nats/server"
 	"decentralized-api/logging"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/tx"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient"
-
-	"strings"
 
 	"github.com/nats-io/nats.go"
 
@@ -39,58 +25,28 @@ import (
 	restrictionstypes "github.com/productscience/inference/x/restrictions/types"
 )
 
-const (
-	txSenderConsumer   = "tx-sender"
-	txObserverConsumer = "tx-observer"
-
-	defaultSenderNackDelay   = time.Second * 7
-	defaultObserverNackDelay = time.Second * 5
-)
-
 type TxManager interface {
 	SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse, error)
 	SendTransactionAsyncNoRetry(rawTx sdk.Msg) (*sdk.TxResponse, error)
 	SendTransactionSyncNoRetry(msg proto.Message) (*ctypes.ResultTx, error)
-	GetClientContext() client.Context
-	GetKeyring() *keyring.Keyring
-	GetApiAccount() apiconfig.ApiAccount
-	Status(ctx context.Context) (*ctypes.ResultStatus, error)
-	BankBalances(ctx context.Context, address string) ([]sdk.Coin, error)
-}
-
-type blockTimeTracker struct {
-	latestBlockTime   atomic.Value
-	latestBlockHeight int64
-	lastUpdatedAt     time.Time
-	maxBlockTimeout   time.Duration
-	chainHalt         bool
-	mtx               sync.Mutex
 }
 
 type manager struct {
 	ctx              context.Context
 	client           *cosmosclient.Client
 	apiAccount       *apiconfig.ApiAccount
-	txFactory        *tx.Factory
-	accountRetriever client.AccountRetriever
-	address          string
-	defaultTimeout   time.Duration
-	natsConnection   *nats.Conn
-	natsJetStream    nats.JetStreamContext
-	blockTimeTracker *blockTimeTracker
+	chainTracker     *ChainTracker
+	broadcaster      *Broadcaster
+	transactionQueue *TransactionQueue
 }
 
 func StartTxManager(
 	ctx context.Context,
 	client *cosmosclient.Client,
 	account *apiconfig.ApiAccount,
-	defaultTimeout time.Duration,
 	natsConnection *nats.Conn,
-	address string) (*manager, error) {
-	js, err := natsConnection.JetStream()
-	if err != nil {
-		return nil, err
-	}
+	chainTracker *ChainTracker,
+	broadcaster *Broadcaster) (*manager, error) {
 
 	// Register all module interfaces to match admin server codec
 	app.RegisterLegacyModules(client.Context().InterfaceRegistry)
@@ -102,28 +58,26 @@ func StartTxManager(
 	restrictionstypes.RegisterInterfaces(client.Context().InterfaceRegistry)
 	blstypes.RegisterInterfaces(client.Context().InterfaceRegistry)
 
-	ts := atomic.Value{}
-	ts.Store(time.Time{})
-
+	tq := NewTransactionQueue(
+		maxAttempts,
+		natsConnection,
+		client.Context().Codec,
+	)
 	m := &manager{
 		ctx:              ctx,
 		client:           client,
-		address:          address,
 		apiAccount:       account,
-		accountRetriever: authtypes.AccountRetriever{},
-		defaultTimeout:   defaultTimeout,
-		natsConnection:   natsConnection,
-		natsJetStream:    js,
-		blockTimeTracker: &blockTimeTracker{
-			latestBlockTime: ts,
-			maxBlockTimeout: 10 * time.Second,
-		},
-	}
-	if err := m.sendTxs(); err != nil {
-		return nil, err
+		chainTracker:     chainTracker,
+		broadcaster:      broadcaster,
+		transactionQueue: tq,
 	}
 
-	if err := m.observeTxs(); err != nil {
+	err := tq.RegisterSendHandler(m.handleSendStream)
+	if err != nil {
+		return nil, err
+	}
+	err = tq.RegisterObserveHandler(m.handleObserveStream)
+	if err != nil {
 		return nil, err
 	}
 
@@ -146,42 +100,33 @@ type txInfo struct {
 	Attempts int
 }
 
-func (m *manager) GetApiAccount() apiconfig.ApiAccount {
-	return *m.apiAccount
-}
-
-func (m *manager) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
-	return m.client.Status(ctx)
-}
-
 func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse, error) {
 	id := uuid.New().String()
 	logging.Debug("SendTransactionAsyncWithRetry: sending tx", types.Messages, "tx_id", id)
 
-	if halt, err := m.updateChainHalt(); err != nil || halt {
-		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-
-		if err := m.putOnRetry(id, "", time.Time{}, rawTx, 0, false); err != nil {
+	if halt, err := m.chainTracker.UpdateFromClient(m.ctx); err != nil || halt {
+		if err := m.transactionQueue.AddToRetryQueue(id, "", time.Time{}, rawTx, 0, false); err != nil {
 			logging.Error("failed to put in queue", types.Messages, "tx_id", id, "resend_err", err)
 			return nil, ErrTxFailedToBroadcastAndPutOnRetry
 		}
 		return &sdk.TxResponse{}, nil
 	}
 
-	resp, timeout, broadcastErr := m.broadcastMessage(id, rawTx)
+	resp, timeoutTimestamp, broadcastErr := m.broadcaster.Broadcast(m.ctx, id, rawTx)
 	if broadcastErr != nil {
 		if isTxErrorCritical(broadcastErr) {
 			logging.Error("SendTransactionAsyncWithRetry: critical error sending tx", types.Messages, "tx_id", id, "err", broadcastErr)
 			return nil, broadcastErr
 		}
 
-		err := m.putOnRetry(id, "", timeout, rawTx, 1, false)
+		err := m.transactionQueue.AddToRetryQueue(id, "", timeoutTimestamp, rawTx, 1, false)
 		if err != nil {
 			logging.Error("tx failed to broadcast, failed to put in queue", types.Messages, "tx_id", id, "broadcast_err", broadcastErr, "resend_err", err)
+			return nil, ErrTxFailedToBroadcastAndRetry
 		}
 		return nil, ErrTxFailedToBroadcastAndPutOnRetry
 	}
-	if err := m.putOnRetry(id, resp.TxHash, timeout, rawTx, 1, true); err != nil {
+	if err := m.transactionQueue.AddToRetryQueue(id, resp.TxHash, timeoutTimestamp, rawTx, 1, true); err != nil {
 		logging.Error("tx broadcast, but failed to put in queue", types.Messages, "tx_id", id, "err", err)
 	}
 	return resp, nil
@@ -190,28 +135,28 @@ func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse,
 func (m *manager) SendTransactionAsyncNoRetry(rawTx sdk.Msg) (*sdk.TxResponse, error) {
 	id := uuid.New().String()
 	logging.Debug("SendTransactionAsyncNoRetry: sending tx", types.Messages, "tx_id", id, "originalMsgType", sdk.MsgTypeURL(rawTx))
-	_, err := m.updateChainHalt()
+	_, err := m.chainTracker.UpdateFromClient(m.ctx)
 	if err != nil {
 		return nil, err
 	}
-	resp, _, broadcastErr := m.broadcastMessage(id, rawTx)
+	resp, _, broadcastErr := m.broadcaster.Broadcast(m.ctx, id, rawTx)
 	return resp, broadcastErr
 }
 
 func (m *manager) SendTransactionSyncNoRetry(msg proto.Message) (*ctypes.ResultTx, error) {
 	id := uuid.New().String()
 	logging.Debug("SendTransactionSyncNoRetry: sending tx", types.Messages, "tx_id", id)
-	_, err := m.updateChainHalt()
+	_, err := m.chainTracker.UpdateFromClient(m.ctx)
 	if err != nil {
 		return nil, err
 	}
-	resp, _, err := m.broadcastMessage(id, msg)
+	resp, _, err := m.broadcaster.Broadcast(m.ctx, id, msg)
 	if err != nil {
 		return nil, err
 	}
 
 	logging.Debug("Transaction broadcast successful", types.Messages, "tx_id", id, "tx_hash", resp.TxHash)
-	result, err := m.WaitForResponse(resp.TxHash)
+	result, err := m.broadcaster.WaitForResponse(m.ctx, resp.TxHash)
 	if err != nil {
 		logging.Error("Failed to wait for transaction", types.Messages, "tx_id", id, "tx_hash", resp.TxHash, "error", err)
 		return nil, err
@@ -219,391 +164,68 @@ func (m *manager) SendTransactionSyncNoRetry(msg proto.Message) (*ctypes.ResultT
 	return result, nil
 }
 
-func (m *manager) GetKeyring() *keyring.Keyring {
-	return &m.client.AccountRegistry.Keyring
-}
-
-func (m *manager) putOnRetry(
-	id,
-	txHash string,
-	timeout time.Time,
-	rawTx sdk.Msg,
-	attempts int,
-	sent bool) error {
-	logging.Debug("putOnRetry: tx with params", types.Messages,
-		"tx_id", id,
-		"tx_hash", txHash,
-		"timeout", timeout.String(),
-		"sent", sent,
-	)
-
-	if attempts >= maxAttempts {
-		logging.Warn("tx reached max attempts", types.Messages, "tx_id", id)
-		return nil
+func (m *manager) handleSendStream(tx txToSend, msg sdk.Msg) (QueueAction, error) {
+	if halt, err := m.chainTracker.UpdateFromClient(m.ctx); err != nil || halt {
+		// Slow everything down, the chain is halted or slow!
+		time.Sleep(3 * time.Second)
+		return Redeliver, nil
 	}
 
-	bz, err := m.client.Context().Codec.MarshalInterfaceJSON(rawTx)
-	if err != nil {
-		return err
-	}
-
-	if id == "" {
-		id = uuid.New().String()
-	}
-
-	b, err := json.Marshal(&txToSend{
-		TxInfo: txInfo{
-			Id:      id,
-			RawTx:   bz,
-			TxHash:  txHash,
-			Timeout: timeout,
-		},
-		Sent:     sent,
-		Attempts: attempts,
-	})
-	if err != nil {
-		return err
-	}
-	_, err = m.natsJetStream.Publish(server.TxsToSendStream, b)
-	return err
-}
-
-func (m *manager) putTxToObserve(id string, rawTx sdk.Msg, txHash string, timeout time.Time, attempts int) error {
-	logging.Debug(" putTxToObserve: tx with params", types.Messages,
-		"tx_id", id,
-		"tx_hash", txHash,
-		"timeout", timeout.String(),
-	)
-
-	bz, err := m.client.Context().Codec.MarshalInterfaceJSON(rawTx)
-	if err != nil {
-		return err
-	}
-
-	b, err := json.Marshal(&txInfo{
-		Id:       id,
-		RawTx:    bz,
-		TxHash:   txHash,
-		Timeout:  timeout,
-		Attempts: attempts,
-	})
-	if err != nil {
-		return err
-	}
-	_, err = m.natsJetStream.Publish(server.TxsToObserveStream, b)
-	return err
-}
-
-func (m *manager) sendTxs() error {
-	logging.Info("Tx manager: sending txs: run in background", types.Messages)
-
-	_, err := m.natsJetStream.Subscribe(server.TxsToSendStream, func(msg *nats.Msg) {
-		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-			time.Sleep(3 * time.Second)
-			return
-		}
-
-		var tx txToSend
-		if err := json.Unmarshal(msg.Data, &tx); err != nil {
-			logging.Error("error unmarshaling tx_to_send", types.Messages, "err", err)
-			msg.Term() // malformed, drop it
-			return
-		}
-
-		logging.Debug("SendTxs: got tx", types.Messages, "id", tx.TxInfo.Id)
-
-		rawTx, err := m.unpackTx(tx.TxInfo.RawTx)
+	if !tx.Sent {
+		logging.Debug("start broadcast tx async", types.Messages, "id", tx.TxInfo.Id)
+		resp, timeout, err := m.broadcaster.Broadcast(m.ctx, tx.TxInfo.Id, msg)
 		if err != nil {
-			logging.Error("error unpacking raw tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
-			msg.Term() // malformed, drop it
-			return
-		}
-
-		if !tx.Sent {
-			logging.Debug("start broadcast tx async", types.Messages, "id", tx.TxInfo.Id)
-			resp, timeout, err := m.broadcastMessage(tx.TxInfo.Id, rawTx)
-			if err != nil {
-				if isTxErrorCritical(err) {
-					logging.Error("got critical error sending tx", types.Messages, "id", tx.TxInfo.Id)
-					msg.Term() // invalid tx, drop it
-					return
-				}
-				msg.NakWithDelay(defaultSenderNackDelay)
-				return
+			if isTxErrorCritical(err) {
+				logging.Error("got critical error sending tx", types.Messages, "id", tx.TxInfo.Id)
+				return Terminate, nil
 			}
-			tx.TxInfo.Timeout = timeout
-			tx.TxInfo.TxHash = resp.TxHash
-			tx.Sent = true
+			return Redeliver, nil
 		}
+		tx.TxInfo.Timeout = timeout
+		tx.TxInfo.TxHash = resp.TxHash
+		tx.Sent = true
+	}
 
-		logging.Debug("tx broadcast, put to observe", types.Messages, "id", tx.TxInfo.Id, "tx_hash", tx.TxInfo.TxHash, "timeout", tx.TxInfo.Timeout.String())
+	logging.Debug("tx broadcast, moving to observe", types.Messages, "id", tx.TxInfo.Id, "tx_hash", tx.TxInfo.TxHash, "timeout", tx.TxInfo.Timeout.String())
 
-		if err := m.putTxToObserve(tx.TxInfo.Id, rawTx, tx.TxInfo.TxHash, tx.TxInfo.Timeout, tx.Attempts); err != nil {
-			logging.Error("error pushing to observe queue", types.Messages, "id", tx.TxInfo.Id, "err", err)
-			msg.NakWithDelay(defaultSenderNackDelay)
-		} else {
-			msg.Ack()
-		}
-	}, nats.Durable(txSenderConsumer), nats.ManualAck())
-	return err
+	if err := m.transactionQueue.AddToObserveQueue(tx.TxInfo.Id, msg, tx.TxInfo.TxHash, tx.TxInfo.Timeout, tx.Attempts); err != nil {
+		logging.Error("error pushing to observe queue", types.Messages, "id", tx.TxInfo.Id, "err", err)
+		return Redeliver, nil
+	}
+	return Acknowledge, nil
 }
 
-func (m *manager) observeTxs() error {
-	logging.Info("Tx manager: observeTxs txs: run in background", types.Messages)
-	_, err := m.natsJetStream.Subscribe(server.TxsToObserveStream, func(msg *nats.Msg) {
-		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+func (m *manager) handleObserveStream(tx txInfo, msg sdk.Msg) (QueueAction, error) {
+	if tx.TxHash == "" {
+		logging.Warn("tx hash is empty", types.Messages, "tx_id", tx.Id)
+		tx.Attempts++
+		if err := m.transactionQueue.AddToRetryQueue(tx.Id, "", time.Time{}, msg, tx.Attempts, false); err != nil {
+			return Redeliver, err
 		}
+		return Acknowledge, nil
+	}
 
-		var tx txInfo
-		if err := json.Unmarshal(msg.Data, &tx); err != nil {
-			logging.Error("error unmarshaling tx_to_observe", types.Messages, "err", err)
-			msg.Term()
-			return
-		}
+	found, err := m.broadcaster.FindTxStatus(m.ctx, tx.TxHash)
+	if found {
+		logging.Debug("tx found, remove tx from observer queue", types.Messages, "tx_id", tx.Id, "txHash", tx.TxHash)
+		return Acknowledge, nil
+	}
 
-		rawTx, err := m.unpackTx(tx.RawTx)
-		if err != nil {
-			msg.Term()
-			return
-		}
+	if errors.Is(err, ErrDecodingTxHash) {
+		return Terminate, nil
+	}
 
-		if tx.TxHash == "" {
-			logging.Warn("tx hash is empty", types.Messages, "tx_id", tx.Id)
-
+	if errors.Is(err, ErrTxNotFound) {
+		latestBlockTime := m.chainTracker.GetLatestBlockTime(m.ctx)
+		if latestBlockTime.After(tx.Timeout) {
+			logging.Debug("tx expired", types.Messages, "tx_id", tx.Id, "tx_hash", tx.TxHash, "tx_timestamp", tx.Timeout, "latest_block_timestamp", latestBlockTime)
 			tx.Attempts++
-			if err := m.putOnRetry(tx.Id, "", time.Time{}, rawTx, tx.Attempts, false); err != nil {
-				msg.NakWithDelay(defaultObserverNackDelay)
-				return
+			if err := m.transactionQueue.AddToRetryQueue(tx.Id, "", time.Time{}, msg, tx.Attempts, false); err != nil {
+				return Redeliver, err
 			}
-			msg.Ack()
-			return
+			return Acknowledge, nil
 		}
-
-		found, err := m.checkTxStatus(tx.TxHash)
-		if found {
-			logging.Debug("tx found, remove tx from observer queue", types.Messages, "tx_id", tx.Id, "txHash", tx.TxHash)
-			if err := msg.Ack(); err != nil {
-				logging.Error("ack error", types.Messages, "tx_id", tx.Id, "err", err)
-			}
-			return
-		}
-
-		if errors.Is(err, ErrDecodingTxHash) {
-			msg.Term()
-			return
-		}
-
-		if errors.Is(err, ErrTxNotFound) {
-			if m.blockTimeTracker.latestBlockTime.Load().(time.Time).After(tx.Timeout) {
-				logging.Debug("tx expired", types.Messages, "tx_id", tx.Id, "tx_hash", tx.TxHash, "tx_timestamp", tx.Timeout, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
-				tx.Attempts++
-				if err := m.putOnRetry(tx.Id, "", time.Time{}, rawTx, tx.Attempts, false); err != nil {
-					msg.NakWithDelay(defaultObserverNackDelay)
-					return
-				}
-				msg.Ack()
-				return
-			}
-		}
-
-		msg.NakWithDelay(defaultObserverNackDelay)
-		return
-	}, nats.Durable(txObserverConsumer), nats.ManualAck())
-	return err
-}
-
-func (m *manager) GetClientContext() client.Context {
-	return m.client.Context()
-}
-
-func (m *manager) checkTxStatus(hash string) (bool, error) {
-	bz, err := hex.DecodeString(hash)
-	if err != nil {
-		logging.Error("checkTxStatus: error decoding tx hash", types.Messages, "err", err)
-		return false, ErrDecodingTxHash
 	}
 
-	resp, err := m.client.Context().Client.Tx(m.ctx, bz, false)
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return false, ErrTxNotFound
-		}
-		return false, err
-	}
-
-	if resp.TxResult.Code != 0 {
-		logging.Error("checkTxStatus: tx failed on-chain", types.Messages, "txHash", hash, "code", resp.TxResult.Code, "codespace", resp.TxResult.Codespace, "rawLog", resp.TxResult.Log)
-	}
-	logging.Debug("checkTxStatus: found tx result", types.Messages, "txHash", hash, "resp", resp)
-	return true, nil
-}
-
-func (m *manager) WaitForResponse(txHash string) (*ctypes.ResultTx, error) {
-	ctx, cancel := context.WithTimeout(m.ctx, time.Second*15)
-	defer cancel()
-
-	transactionAppliedResult, err := m.client.WaitForTx(ctx, txHash)
-	if err != nil {
-		logging.Error("Failed to wait for transaction", types.Messages, "error", err, "result", transactionAppliedResult)
-		return nil, err
-	}
-
-	txResult := transactionAppliedResult.TxResult
-	if txResult.Code != 0 {
-		logging.Error("Transaction failed on-chain", types.Messages, "txHash", txHash, "code", txResult.Code, "codespace", txResult.Codespace, "rawLog", txResult.Log)
-		return nil, NewTransactionErrorFromResult(transactionAppliedResult)
-	}
-	return transactionAppliedResult, nil
-}
-
-func (m *manager) BankBalances(ctx context.Context, address string) ([]sdk.Coin, error) {
-	return m.client.BankBalances(ctx, address, nil)
-}
-
-func (m *manager) broadcastMessage(id string, rawTx sdk.Msg) (*sdk.TxResponse, time.Time, error) {
-	factory, err := m.getFactory(id)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-
-	var finalMsg sdk.Msg = rawTx
-	originalMsgType := sdk.MsgTypeURL(rawTx)
-	if !m.apiAccount.IsSignerTheMainAccount() {
-		granteeAddress, err := m.apiAccount.SignerAddress()
-		if err != nil {
-			return nil, time.Time{}, fmt.Errorf("failed to get signer address: %w", err)
-		}
-
-		execMsg := authztypes.NewMsgExec(granteeAddress, []sdk.Msg{rawTx})
-		finalMsg = &execMsg
-		logging.Debug("Using authz MsgExec", types.Messages, "grantee", granteeAddress.String(), "originalMsgType", originalMsgType)
-	}
-
-	unsignedTx, err := factory.BuildUnsignedTx(finalMsg)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-	txBytes, timestamp, err := m.getSignedBytes(id, unsignedTx, factory)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-
-	resp, err := m.client.Context().BroadcastTxSync(txBytes)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-	if resp.Code != 0 {
-		logging.Error("Broadcast failed immediately", types.Messages, "code", resp.Code, "rawLog", resp.RawLog, "tx_id", id, "originalMsgType", originalMsgType)
-	} else {
-		logging.Debug("Broadcast successful", types.Messages, "tx_id", id, "originalMsgType", originalMsgType, "resp", resp)
-	}
-	return resp, timestamp, nil
-}
-
-func (m *manager) unpackTx(bz []byte) (sdk.Msg, error) {
-	var unpackedAny codectypes.Any
-	if err := m.client.Context().Codec.UnmarshalJSON(bz, &unpackedAny); err != nil {
-		return nil, err
-	}
-
-	var rawTx sdk.Msg
-	if err := m.client.Context().Codec.UnpackAny(&unpackedAny, &rawTx); err != nil {
-		return nil, err
-	}
-	return rawTx, nil
-}
-
-func (m *manager) getFactory(id string) (*tx.Factory, error) {
-	// Now that we don't need the sequence, we only need to create the factory if it doesn't exist
-	if m.txFactory != nil {
-		return m.txFactory, nil
-	}
-	address, err := m.apiAccount.SignerAddress()
-	if err != nil {
-		logging.Error("Failed to get account address", types.Messages, "tx_id", id, "error", err)
-		return nil, err
-	}
-	accountNumber, _, err := m.accountRetriever.GetAccountNumberSequence(m.client.Context(), address)
-	if err != nil {
-		logging.Error("Failed to get account number and sequence", types.Messages, "tx_id", id, "error", err)
-		return nil, err
-	}
-	factory := m.client.TxFactory.
-		WithAccountNumber(accountNumber).
-		WithGasAdjustment(10).
-		WithFees("").
-		WithGasPrices("").
-		WithGas(0).
-		WithUnordered(true).
-		WithKeybase(*m.GetKeyring())
-	m.txFactory = &factory
-	return &factory, nil
-}
-
-func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory *tx.Factory) ([]byte, time.Time, error) {
-	blockTs := m.blockTimeTracker.latestBlockTime.Load().(time.Time)
-	if blockTs.IsZero() {
-		_, err := m.updateChainHalt()
-		if err != nil {
-			return nil, time.Time{}, err
-		}
-		blockTs = m.blockTimeTracker.latestBlockTime.Load().(time.Time)
-	}
-
-	timestamp := getTimestamp(blockTs.UnixNano(), m.defaultTimeout)
-
-	// Gas is not charged, but without a high gas limit the transactions fail
-	unsignedTx.SetGasLimit(1000000000)
-	unsignedTx.SetFeeAmount(sdk.Coins{})
-	unsignedTx.SetUnordered(true)
-	unsignedTx.SetTimeoutTimestamp(timestamp)
-	name := m.apiAccount.SignerAccount.Name
-	logging.Debug("Signing transaction", types.Messages, "tx_id", id, "timeout", timestamp.String(), "name", name)
-
-	err := tx.Sign(m.ctx, *factory, name, unsignedTx, false)
-	if err != nil {
-		logging.Error("Failed to sign transaction", types.Messages, "tx_id", id, "error", err)
-		return nil, time.Time{}, err
-	}
-	txBytes, err := m.client.Context().TxConfig.TxEncoder()(unsignedTx.GetTx())
-	if err != nil {
-		logging.Error("Failed to encode transaction", types.Messages, "tx_id", id, "error", err)
-		return nil, time.Time{}, err
-	}
-	return txBytes, timestamp, nil
-}
-
-func (m *manager) updateChainHalt() (bool, error) {
-	now := time.Now()
-	if now.Sub(m.blockTimeTracker.lastUpdatedAt) < time.Second*3 {
-		return m.blockTimeTracker.chainHalt, nil
-	}
-
-	status, err := m.client.Status(m.ctx)
-	if err != nil {
-		logging.Error("error getting blockchain status", types.Messages, "err", err)
-		return false, err
-	}
-
-	m.blockTimeTracker.mtx.Lock()
-	defer m.blockTimeTracker.mtx.Unlock()
-
-	if status.SyncInfo.LatestBlockTime.Equal(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
-		status.SyncInfo.LatestBlockHeight == m.blockTimeTracker.latestBlockHeight &&
-		!m.blockTimeTracker.lastUpdatedAt.IsZero() && now.Sub(m.blockTimeTracker.lastUpdatedAt) > m.blockTimeTracker.maxBlockTimeout {
-		// same block, and we sow it more than N seconds ago -> chain halt
-		m.blockTimeTracker.chainHalt = true
-	}
-
-	if status.SyncInfo.LatestBlockTime.After(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
-		status.SyncInfo.LatestBlockHeight > m.blockTimeTracker.latestBlockHeight {
-		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
-		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
-		m.blockTimeTracker.chainHalt = false
-	}
-
-	m.blockTimeTracker.lastUpdatedAt = now
-	return m.blockTimeTracker.chainHalt, nil
+	return Redeliver, nil
 }

--- a/decentralized-api/internal/event_listener/event_listener.go
+++ b/decentralized-api/internal/event_listener/event_listener.go
@@ -305,6 +305,7 @@ func (el *EventListener) processEvent(event *chainevents.JSONRPCResponse, worker
 
 		// Update BlockObserver with latest height and sync status
 		el.blockObserver.updateStatus(blockInfo.Height, el.isNodeSynced())
+		el.transactionRecorder.UpdateCurrentBlockInfo(blockInfo)
 
 		// Process using the new dispatcher
 		ctx := context.Background() // We could pass this from caller if needed

--- a/decentralized-api/internal/event_listener/new_block_dispatcher_test.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher_test.go
@@ -2,9 +2,10 @@ package event_listener
 
 import (
 	"decentralized-api/chainphase"
-	"github.com/productscience/inference/x/inference/types"
 	"testing"
 	"time"
+
+	"github.com/productscience/inference/x/inference/types"
 
 	"decentralized-api/internal/event_listener/chainevents"
 
@@ -100,6 +101,7 @@ func TestParseNewBlockInfo(t *testing.T) {
 		"block": map[string]interface{}{
 			"header": map[string]interface{}{
 				"height": "12345",
+				"time":   "2025-10-15T05:57:37.79431638Z",
 			},
 		},
 		"block_id": map[string]interface{}{
@@ -125,4 +127,5 @@ func TestParseNewBlockInfo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(12345), blockInfo.Height)
 	assert.Equal(t, "ABCDEF123456", blockInfo.Hash)
+	assert.Equal(t, time.Date(2025, 10, 15, 5, 57, 37, 794316380, time.UTC), blockInfo.Time)
 }


### PR DESCRIPTION
Break up tx_manager into major components:
1. ChainTracker - tracks chain height and time
2. Broadcaster - signs and broadcasts messages
3. TransactionQueue - manages the queue for send/observing

Got rid of some unecessary code and flattened the heirarchy