### PR TITLE
test: add ValidateBasic tests for bookkeeper MsgUpdateParams

### DIFF
--- a/inference-chain/x/bookkeeper/types/msg_update_params_test.go
+++ b/inference-chain/x/bookkeeper/types/msg_update_params_test.go
@@ -1,0 +1,43 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/productscience/inference/testutil/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         MsgUpdateParams
+		expectError bool
+	}{
+		{
+			name: "invalid authority address",
+			msg: MsgUpdateParams{
+				Authority: "invalid_address",
+				Params:   DefaultParams(),
+			},
+			expectError: true,
+		}, {
+			name: "valid address with default params",
+			msg: MsgUpdateParams{
+				Authority: sample.AccAddress(),
+				Params:   DefaultParams(),
+			},
+			expectError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary
Adds missing unit tests for `MsgUpdateParams.ValidateBasic()` in the bookkeeper module.

## Changes
- Created `inference-chain/x/bookkeeper/types/msg_update_params_test.go`
- Added test cases for invalid authority address and valid address with default params

## Testing
- All tests pass: `go test ./x/bookkeeper/types/... -v`

## Related
Addresses TODO in `proposals/cleanup_1/validate_basic_todo.md`:
- [ ] Ensure ValidateBasic (bookkeeper module)