### PR TITLE
Change default mlnode state to INFERENCE

### DIFF
--- a/decentralized-api/broker/broker_test.go
+++ b/decentralized-api/broker/broker_test.go
@@ -486,26 +486,14 @@ func TestImmediateClientRefreshLogic(t *testing.T) {
 
 	initialStopCalled := mockClient.StopCalled
 
-	// Test the immediate refresh directly - this should call stop on the old client immediately
+	// Dynamic client creation means refresh is effectively a no-op for the HTTP client.
 	worker.RefreshClientImmediate("v3.0.8", "v3.1.0")
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, initialStopCalled, mockClient.StopCalled, "Stop should not be invoked when clients are created per request")
 
-	// Give some time for the async stop call to complete
-	time.Sleep(50 * time.Millisecond)
-
-	// Verify stop was called on the old client
-	assert.Greater(t, mockClient.StopCalled, initialStopCalled, "Stop should have been called on old client")
-
-	// Test the full immediate refresh flow again
-	previousStopCalled := mockClient.StopCalled
-
-	// Call immediate refresh again with different version
 	worker.RefreshClientImmediate("v3.1.0", "v3.2.0")
-
-	// Give some time for async stop calls to complete
-	time.Sleep(50 * time.Millisecond)
-
-	// Should have called stop again
-	assert.Greater(t, mockClient.StopCalled, previousStopCalled, "Stop should have been called again during second refresh")
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, initialStopCalled, mockClient.StopCalled, "Stop should remain unchanged on repeated refreshes")
 }
 
 func TestUpdateNodeConfiguration(t *testing.T) {

--- a/decentralized-api/broker/node_admin_commands.go
+++ b/decentralized-api/broker/node_admin_commands.go
@@ -152,8 +152,7 @@ func (c RegisterNode) Execute(b *Broker) {
 		b.nodes[c.Node.Id] = nodeWithState
 
 		// Create and register a worker for this node
-		client := b.NewNodeClient(&node)
-		worker := NewNodeWorkerWithClient(c.Node.Id, nodeWithState, client, b)
+		worker := NewNodeWorker(c.Node.Id, nodeWithState, b)
 		b.nodeWorkGroup.AddWorker(c.Node.Id, worker)
 	}()
 

--- a/decentralized-api/broker/node_worker_commands.go
+++ b/decentralized-api/broker/node_worker_commands.go
@@ -212,6 +212,7 @@ func (c InferenceUpNodeCommand) Execute(ctx context.Context, worker *NodeWorker)
 		return result
 	}
 
+	var selectedModel *types.Model
 	if len(worker.node.State.EpochModels) == 0 {
 		govModels, err := worker.broker.chainBridge.GetGovernanceModels()
 		if err != nil {
@@ -226,6 +227,7 @@ func (c InferenceUpNodeCommand) Execute(ctx context.Context, worker *NodeWorker)
 		for _, govModel := range govModels.Model {
 			if _, ok := worker.node.Node.Models[govModel.Id]; ok {
 				hasIntersection = true
+				selectedModel = &govModel
 				break
 			}
 		}
@@ -238,23 +240,15 @@ func (c InferenceUpNodeCommand) Execute(ctx context.Context, worker *NodeWorker)
 			return result
 		}
 
-		// Node has models that match governance but not yet assigned to epoch, skip for now
-		result.Succeeded = true
-		result.FinalStatus = types.HardwareNodeStatus_STOPPED
-		result.FinalPocStatus = PocStatusIdle
-		logging.Info("Node has governance models configured but not yet assigned to epoch, skipping inference start", types.Nodes, "node_id", worker.nodeId)
-		return result
+		logging.Info("No epoch models configured for this node, using a governance model from one the supported by the node", types.Nodes, "node_id", worker.nodeId, "selectedModel", selectedModel)
+	} else {
+		for _, m := range worker.node.State.EpochModels {
+			selectedModel = &m
+			break
+		}
 	}
 
-	var modelId string
-	var epochModel types.Model
-	for id, m := range worker.node.State.EpochModels {
-		modelId = id
-		epochModel = m
-		break
-	}
-
-	if modelId == "" {
+	if selectedModel == nil || selectedModel.Id == "" {
 		result.Succeeded = false
 		result.Error = "Could not select a model from epoch models"
 		result.FinalStatus = types.HardwareNodeStatus_FAILED
@@ -262,14 +256,16 @@ func (c InferenceUpNodeCommand) Execute(ctx context.Context, worker *NodeWorker)
 		return result
 	}
 
+	logging.Info("Selected model for inference", types.Nodes, "node_id", worker.nodeId, "selectedModel", selectedModel)
+
 	// Merge epoch model args with local ones
-	localArgs := []string{}
-	if localModelConfig, ok := worker.node.Node.Models[modelId]; ok {
+	var localArgs []string
+	if localModelConfig, ok := worker.node.Node.Models[selectedModel.Id]; ok {
 		localArgs = localModelConfig.Args
 	}
-	mergedArgs := worker.broker.MergeModelArgs(epochModel.ModelArgs, localArgs)
+	mergedArgs := worker.broker.MergeModelArgs(selectedModel.ModelArgs, localArgs)
 
-	if err := worker.GetClient().InferenceUp(ctx, epochModel.Id, mergedArgs); err != nil {
+	if err := worker.GetClient().InferenceUp(ctx, selectedModel.Id, mergedArgs); err != nil {
 		logging.Error("Failed to bring up inference", types.Nodes, "node_id", worker.nodeId, "error", err)
 		result.Succeeded = false
 		result.Error = err.Error()

--- a/decentralized-api/broker/state_commands.go
+++ b/decentralized-api/broker/state_commands.go
@@ -75,7 +75,7 @@ func (c StartPocCommand) Execute(b *Broker) {
 				"admin_epoch", node.State.AdminState.Epoch,
 				"current_epoch", epochState,
 				"current_phase", epochState.CurrentPhase)
-			node.State.IntendedStatus = types.HardwareNodeStatus_STOPPED
+			node.State.IntendedStatus = types.HardwareNodeStatus_INFERENCE
 		} else if node.State.ShouldContinueInference() {
 			// Node should continue inference service based on POC_SLOT allocation
 			// TODO: change logs to debug
@@ -101,6 +101,7 @@ func (c StartPocCommand) shouldMutateState(b *Broker, epochState *chainphase.Epo
 	for _, node := range b.nodes {
 		if !node.State.ShouldBeOperational(epochState.LatestEpoch.EpochIndex, epochState.CurrentPhase) &&
 			node.State.IntendedStatus != types.HardwareNodeStatus_STOPPED {
+
 			return true
 		}
 
@@ -190,7 +191,7 @@ func (c InitValidateCommand) Execute(b *Broker) {
 				"admin_epoch", node.State.AdminState.Epoch,
 				"current_epoch", epochState,
 				"current_phase", epochState.CurrentPhase)
-			node.State.IntendedStatus = types.HardwareNodeStatus_STOPPED
+			node.State.IntendedStatus = types.HardwareNodeStatus_INFERENCE
 		} else if node.State.ShouldContinueInference() {
 			// Node should continue inference service based on POC_SLOT allocation
 			logging.Info("Keeping node in inference service mode due to POC_SLOT allocation", types.PoC,
@@ -286,7 +287,7 @@ func (c InferenceUpAllCommand) Execute(b *Broker) {
 				"admin_epoch", node.State.AdminState.Epoch,
 				"current_epoch", epochState,
 				"current_phase", epochState.CurrentPhase)
-			node.State.IntendedStatus = types.HardwareNodeStatus_STOPPED
+			node.State.IntendedStatus = types.HardwareNodeStatus_INFERENCE
 		} else if node.State.IntendedStatus == types.HardwareNodeStatus_TRAINING {
 			logging.Info("Skipping inference up for node in training state", types.PoC,
 				"node_id", node.Node.Id,

--- a/decentralized-api/broker/state_commands_test.go
+++ b/decentralized-api/broker/state_commands_test.go
@@ -128,7 +128,7 @@ func TestStartPocCommand_AdminDisabled(t *testing.T) {
 	success := <-cmd.Response
 	require.True(t, success, "Command should succeed")
 
-	require.Equal(t, node1.State.IntendedStatus, types.HardwareNodeStatus_STOPPED)
+	require.Equal(t, node1.State.IntendedStatus, types.HardwareNodeStatus_INFERENCE)
 	require.Equal(t, node2.State.IntendedStatus, types.HardwareNodeStatus_POC)
 	require.Equal(t, node2.State.PocIntendedStatus, PocStatusGenerating)
 }

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -746,10 +746,11 @@ func TestNodeDisableScenario_Integration(t *testing.T) {
 		assert.Equal(t, 1, node2Client.InitValidateCalled, "Enabled node-2 should receive InitGenerate call")
 	})
 
-	node1Expected := NodeClientAssertion{StopCalled: 0, InitGenerateCalled: 0, InitValidateCalled: 0, InferenceUpCalled: 0}
+	node1Expected := NodeClientAssertion{StopCalled: 1, InitGenerateCalled: 0, InitValidateCalled: 0, InferenceUpCalled: 1}
 	assertNodeClient(t, node1Expected, node1Client)
 	setup.assertNode("node-1", func(n broker.NodeResponse) {
-		require.Equal(t, types.HardwareNodeStatus_STOPPED, n.State.CurrentStatus)
+		// Default state is inference
+		require.Equal(t, types.HardwareNodeStatus_INFERENCE, n.State.CurrentStatus)
 	})
 
 	node2Expected := NodeClientAssertion{StopCalled: 1, InitGenerateCalled: 1, InitValidateCalled: 1, InferenceUpCalled: 1}
@@ -797,7 +798,7 @@ func TestNodeEnableScenario_Integration(t *testing.T) {
 	require.Equal(t, 0, node1Client.InitGenerateCalled, "Disabled node-1 should NOT receive InitGenerate call")
 	require.Equal(t, 1, node2Client.InitGenerateCalled, "Enabled node-2 should receive InitGenerate call")
 	setup.assertNode("node-1", func(n broker.NodeResponse) {
-		require.Equal(t, types.HardwareNodeStatus_STOPPED, n.State.CurrentStatus)
+		require.Equal(t, types.HardwareNodeStatus_INFERENCE, n.State.CurrentStatus)
 	})
 	setup.assertNode("node-2", func(n broker.NodeResponse) {
 		require.Equal(t, types.HardwareNodeStatus_POC, n.State.CurrentStatus)


### PR DESCRIPTION
This PR addresses 2 issues:

1. Default state for ML nodes is changed from STOPPED to INFERENCE, ensuring that nodes always default to inference mode instead of being stopped when they are administratively disabled or lack epoch model assignments. This allows to validate missed inferences for claming a reward even if a node is disabled for the next epoch

* Administratively disabled nodes now default to INFERENCE state instead of STOPPED
* Nodes without epoch models assigned now serve any of the models that they can both support and which is on the list of governance models

2. Fixed a bug: ML node host and port updates are now correctly propagated, previously old addresses were cached and even after editing them via admin API PoC start requests would be sent to the old address