### PR TITLE
Security Fix: Expose 9200 port to localhost

### DIFF
--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - DAPI_API__ADMIN_SERVER_PORT=9200
     ports:
       - "9100:9100"
-      - "9200:9200"
+      - "127.0.0.1:9200:9200"
     restart: always
   
   bridge:


### PR DESCRIPTION
The network node’s administrative port is highly sensitive. By binding it to 127.0.0.1 out‑of‑the‑box we prevent unintended exposure on a public network. Users who need broader access must explicitly change the binding (e.g., via an environment variable or by editing the compose file).