### PR TITLE
Change RTarget and scale all weight by 2.5

### DIFF
--- a/decentralized-api/mlnodeclient/poc.go
+++ b/decentralized-api/mlnodeclient/poc.go
@@ -17,7 +17,7 @@ const (
 	InitValidatePath  = "/api/v1/pow/init/validate"
 	ValidateBatchPath = "/api/v1/pow/validate"
 
-	DefaultRTarget        = 1.4013564660458173
+	DefaultRTarget        = 1.398077
 	DefaultBatchSize      = 100
 	DefaultFraudThreshold = 1e-7
 )

--- a/inference-chain/x/inference/module/chainvalidation.go
+++ b/inference-chain/x/inference/module/chainvalidation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math"
 	"sort"
 	"strconv"
 
@@ -20,6 +21,8 @@ type WeightCalculator struct {
 	EpochStartBlockHeight   int64
 	Logger                  types.InferenceLogger
 }
+
+const WeightScaleFactor = 2.5
 
 // NewWeightCalculator creates a new WeightCalculator instance
 func NewWeightCalculator(
@@ -676,6 +679,7 @@ func calculateParticipantWeight(batches []types.PoCBatch) ([]nodeWeight, int64) 
 			}
 		}
 
+		weight = int64(math.Round(WeightScaleFactor * float64(weight)))
 		nodeId := batch.NodeId // Keep empty string for legacy batches without node_id
 		nodeWeights[nodeId] += weight
 		totalWeight += weight

--- a/inference-chain/x/inference/module/chainvalidation.go
+++ b/inference-chain/x/inference/module/chainvalidation.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"math"
 	"sort"
 	"strconv"
 
+	mathsdk "cosmossdk.io/math"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -22,7 +22,7 @@ type WeightCalculator struct {
 	Logger                  types.InferenceLogger
 }
 
-const WeightScaleFactor = 2.5
+var WeightScaleFactor = mathsdk.LegacyNewDecWithPrec(25, 1) // 2.5
 
 // NewWeightCalculator creates a new WeightCalculator instance
 func NewWeightCalculator(
@@ -679,7 +679,7 @@ func calculateParticipantWeight(batches []types.PoCBatch) ([]nodeWeight, int64) 
 			}
 		}
 
-		weight = int64(math.Round(WeightScaleFactor * float64(weight)))
+		weight = mathsdk.LegacyNewDec(weight).Mul(WeightScaleFactor).TruncateInt64()
 		nodeId := batch.NodeId // Keep empty string for legacy batches without node_id
 		nodeWeights[nodeId] += weight
 		totalWeight += weight


### PR DESCRIPTION
Changing `RTarget` to increase the difficulty of PoC challenge in approximately 2.5 times, meaning participants are expected to generate 2.5 nonces less in the allotted time. To keep absolute values of PoC weights we scale all the weight by 2.5