### PR TITLE
Switch to bytes for storage

### DIFF
--- a/decentralized-api/completionapi/completionresponse.go
+++ b/decentralized-api/completionapi/completionresponse.go
@@ -51,7 +51,7 @@ func (r *JsonCompletionResponse) GetHash() (string, error) {
 	if len(r.Bytes) == 0 {
 		return "", errors.New("CompletionResponse: can't compute hash, empty bytes")
 	}
-	return utils.GenerateSHA256Hash(string(r.Bytes)), nil
+	return utils.GenerateSHA256HashBytes(r.Bytes), nil
 }
 
 func (r *JsonCompletionResponse) GetEnforcedStr() (string, error) {
@@ -232,7 +232,7 @@ func (r *StreamedCompletionResponse) GetHash() (string, error) {
 	if len(bodyBytes) == 0 {
 		return "", errors.New("StreamedCompletionResponse: can't compute hash, empty bytes")
 	}
-	return utils.GenerateSHA256Hash(string(bodyBytes)), nil
+	return utils.GenerateSHA256HashBytes(bodyBytes), nil
 }
 
 func (r *StreamedCompletionResponse) GetEnforcedStr() (string, error) {
@@ -321,7 +321,7 @@ func NewCompletionResponseFromLines(lines []string) (CompletionResponse, error) 
 	}, nil
 }
 
-func NewCompletionResponseFromLinesFromResponsePayload(payload string) (CompletionResponse, error) {
+func NewCompletionResponseFromLinesFromResponsePayload(payload []byte) (CompletionResponse, error) {
 	var genericMap map[string]interface{}
 	bytes := []byte(payload)
 	if err := json.Unmarshal(bytes, &genericMap); err != nil {

--- a/decentralized-api/completionapi/serialization_test.go
+++ b/decentralized-api/completionapi/serialization_test.go
@@ -655,9 +655,8 @@ func TestStreamedResponseSerialization(t *testing.T) {
 	require.IsType(t, &StreamedCompletionResponse{}, resp)
 
 	bytes, err := resp.GetBodyBytes()
-	bytesString := string(bytes)
 
-	resp2, err := NewCompletionResponseFromLinesFromResponsePayload(bytesString)
+	resp2, err := NewCompletionResponseFromLinesFromResponsePayload(bytes)
 	require.NoError(t, err)
 	require.IsType(t, &StreamedCompletionResponse{}, resp2)
 

--- a/decentralized-api/internal/server/admin/payload_handlers.go
+++ b/decentralized-api/internal/server/admin/payload_handlers.go
@@ -54,7 +54,7 @@ func (s *Server) storePayload(c echo.Context) error {
 	}
 
 	// Store payloads
-	if err := s.payloadStorage.Store(c.Request().Context(), inferenceId, epochId, req.PromptPayload, req.ResponsePayload); err != nil {
+	if err := s.payloadStorage.Store(c.Request().Context(), inferenceId, epochId, []byte(req.PromptPayload), []byte(req.ResponsePayload)); err != nil {
 		slog.Error("Failed to store payload", "inferenceId", inferenceId, "epochId", epochId, "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to store payload: " + err.Error()})
 	}

--- a/decentralized-api/payloadstorage/hash.go
+++ b/decentralized-api/payloadstorage/hash.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Matches getPromptHash in post_chat_handler.go
-func ComputePromptHash(promptPayload string) (string, error) {
+func ComputePromptHash(promptPayload []byte) (string, error) {
 	canonical, err := utils.CanonicalizeJSON([]byte(promptPayload))
 	if err != nil {
 		return "", err
@@ -15,11 +15,10 @@ func ComputePromptHash(promptPayload string) (string, error) {
 }
 
 // Hashes message content only, not full JSON
-func ComputeResponseHash(responsePayload string) (string, error) {
+func ComputeResponseHash(responsePayload []byte) (string, error) {
 	resp, err := completionapi.NewCompletionResponseFromLinesFromResponsePayload(responsePayload)
 	if err != nil {
 		return "", err
 	}
 	return resp.GetHash()
 }
-

--- a/decentralized-api/payloadstorage/hybrid_storage.go
+++ b/decentralized-api/payloadstorage/hybrid_storage.go
@@ -22,7 +22,7 @@ func NewHybridStorage(pg *PostgresStorage, file *FileStorage) *HybridStorage {
 	return &HybridStorage{pg: pg, file: file}
 }
 
-func (h *HybridStorage) Store(ctx context.Context, inferenceId string, epochId uint64, promptPayload, responsePayload string) error {
+func (h *HybridStorage) Store(ctx context.Context, inferenceId string, epochId uint64, promptPayload, responsePayload []byte) error {
 	err := h.pg.Store(ctx, inferenceId, epochId, promptPayload, responsePayload)
 	if err != nil {
 		logging.Warn("PostgreSQL store failed, falling back to file", types.PayloadStorage,
@@ -32,7 +32,7 @@ func (h *HybridStorage) Store(ctx context.Context, inferenceId string, epochId u
 	return nil
 }
 
-func (h *HybridStorage) Retrieve(ctx context.Context, inferenceId string, epochId uint64) (string, string, error) {
+func (h *HybridStorage) Retrieve(ctx context.Context, inferenceId string, epochId uint64) ([]byte, []byte, error) {
 	prompt, response, err := h.pg.Retrieve(ctx, inferenceId, epochId)
 	if err == nil {
 		return prompt, response, nil
@@ -52,9 +52,9 @@ func (h *HybridStorage) Retrieve(ctx context.Context, inferenceId string, epochI
 
 	// Both failed - return original PG error if it wasn't "not found"
 	if errors.Is(err, ErrNotFound) {
-		return "", "", ErrNotFound
+		return nil, nil, ErrNotFound
 	}
-	return "", "", err
+	return nil, nil, err
 }
 
 func (h *HybridStorage) PruneEpoch(ctx context.Context, epochId uint64) error {

--- a/decentralized-api/payloadstorage/storage.go
+++ b/decentralized-api/payloadstorage/storage.go
@@ -8,8 +8,7 @@ import (
 var ErrNotFound = errors.New("payload not found")
 
 type PayloadStorage interface {
-	Store(ctx context.Context, inferenceId string, epochId uint64, promptPayload, responsePayload string) error
-	Retrieve(ctx context.Context, inferenceId string, epochId uint64) (promptPayload, responsePayload string, err error)
+	Store(ctx context.Context, inferenceId string, epochId uint64, promptPayload, responsePayload []byte) error
+	Retrieve(ctx context.Context, inferenceId string, epochId uint64) (promptPayload, responsePayload []byte, err error)
 	PruneEpoch(ctx context.Context, epochId uint64) error
 }
-

--- a/decentralized-api/utils/hashing.go
+++ b/decentralized-api/utils/hashing.go
@@ -14,7 +14,6 @@ func CanonicalizeJSON(jsonBytes []byte) (string, error) {
 	if err := json.Unmarshal(jsonBytes, &jsonObj); err != nil {
 		return "", err
 	}
-	// add a random seed if it doesn't exist in jsonObj
 
 	buf := &bytes.Buffer{}
 	encoder := json.NewEncoder(buf)
@@ -65,6 +64,11 @@ func encodeCanonical(encoder *json.Encoder, jsonObj interface{}) error {
 	}
 
 	return nil
+}
+
+func GenerateSHA256HashBytes(bytes []byte) string {
+	hash := sha256.Sum256(bytes)
+	return hex.EncodeToString(hash[:])
 }
 
 func GenerateSHA256Hash(text string) string {


### PR DESCRIPTION
This will be especially important when we switch to storing original payloads. For now, it's an added layer of protection against encoding issues either in payloads given in the API or responses from LLMs, neither of which are completely controlled by the protocol, not generally predictable. Storage now goes to bytes. For the entire data flow for responses and requests, we keep everything in bytes except for:
1. CanonicalizedJSON for modified prompts. Here, JSON serialization is needed, and produces strings.
2. Test input - for simplicity.

There were also some name changes for clarity.

This protects especially against malicious attempts to use non-standard encoding in payloads to try and break inference validations, a potentially disastrous impact on the chain.