### PR TITLE
Performance improvements for ClaimRewards

### DIFF
--- a/decentralized-api/internal/validation/inference_validation.go
+++ b/decentralized-api/internal/validation/inference_validation.go
@@ -105,7 +105,8 @@ func (s *InferenceValidator) shouldValidateInference(
 		uint32(inferenceDetails.TotalPower),
 		uint32(validatorPower),
 		uint32(inferenceDetails.ExecutorPower),
-		validationParams)
+		validationParams,
+		false)
 
 	return shouldValidate, message
 }

--- a/inference-chain/x/inference/calculations/min_validation_average.go
+++ b/inference-chain/x/inference/calculations/min_validation_average.go
@@ -36,6 +36,9 @@ func betweenFullAndHalf(recentRequestCount decimal.Decimal, validationParams val
 }
 
 func CalculateMinimumValidationAverage(recentRequestCount int64, validationParams *types.ValidationParams) decimal.Decimal {
+	if recentRequestCount > validationParams.FullValidationTrafficCutoff {
+		return validationParams.MinValidationAverage.ToDecimal()
+	}
 	return calculateMinimumValidationAverage(decimal.NewFromInt(recentRequestCount), validationParamsDecimal{
 		FullValidationTrafficCutoff: decimal.NewFromInt(validationParams.FullValidationTrafficCutoff),
 		MinValidationAverage:        validationParams.MinValidationAverage.ToDecimal(),

--- a/inference-chain/x/inference/calculations/should_validate.go
+++ b/inference-chain/x/inference/calculations/should_validate.go
@@ -27,7 +27,7 @@ func ShouldValidate(
 	rangeSize := maxValidationAverage.Sub(minValidationAverage)
 	// algebraic simplification/removal of temp variables
 	targetValidations := maxValidationAverage.Sub(rangeSize.Mul(executorReputation))
-	// 100% rep will be 0, 0% rep will be rangeSize
+	// 100% rep will be minValidationAverage, 0% rep will be maxValidationAverage
 	ourProbability := targetValidations.Mul(decimal.NewFromInt(int64(validatorPower))).Div(decimal.NewFromInt(int64(totalPower - executorPower)))
 	if ourProbability.GreaterThan(one) {
 		ourProbability = one

--- a/inference-chain/x/inference/calculations/should_validate.go
+++ b/inference-chain/x/inference/calculations/should_validate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"strconv"
 
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/shopspring/decimal"
@@ -17,24 +18,33 @@ func ShouldValidate(
 	validatorPower uint32,
 	executorPower uint32,
 	validationParams *types.ValidationParams,
+	debug bool,
 ) (bool, string) {
-	executorReputation := decimal.NewFromInt32(inferenceDetails.ExecutorReputation).Div(decimal.NewFromInt32(100))
+	// Creating with exponent vs dividing
+	executorReputation := decimal.New(int64(inferenceDetails.ExecutorReputation), -2)
 	maxValidationAverage := validationParams.MaxValidationAverage.ToDecimal()
 	minValidationAverage := CalculateMinimumValidationAverage(int64(inferenceDetails.TrafficBasis), validationParams)
 	rangeSize := maxValidationAverage.Sub(minValidationAverage)
-	executorAdjustment := rangeSize.Mul(one.Sub(executorReputation))
+	// algebraic simplification/removal of temp variables
+	targetValidations := maxValidationAverage.Sub(rangeSize.Mul(executorReputation))
 	// 100% rep will be 0, 0% rep will be rangeSize
-	targetValidations := minValidationAverage.Add(executorAdjustment)
 	ourProbability := targetValidations.Mul(decimal.NewFromInt(int64(validatorPower))).Div(decimal.NewFromInt(int64(totalPower - executorPower)))
 	if ourProbability.GreaterThan(one) {
 		ourProbability = one
 	}
 	randFloat := DeterministicFloat(seed, inferenceDetails.InferenceId)
 	shouldValidate := randFloat.LessThan(ourProbability)
-	return shouldValidate, fmt.Sprintf(
-		"Should Validate: %v randFloat: %v ourProbability: %v, rangeSize: %v, executorAdjustment: %v, targetValidations: %v",
-		shouldValidate, randFloat, ourProbability, rangeSize, executorAdjustment, targetValidations,
-	)
+	// The debug string was very expensive to create
+	// But we shouldn't return "", empty strings can cause issues in logging
+	if debug {
+		return shouldValidate, fmt.Sprintf(
+			"Should Validate: %v randFloat: %v ourProbability: %v, rangeSize: %v, targetValidations: %v",
+			shouldValidate, randFloat, ourProbability, rangeSize, targetValidations,
+		)
+	} else if !shouldValidate {
+		return shouldValidate, "ShouldValidate:false"
+	}
+	return shouldValidate, "ShouldValidate:true"
 }
 
 // DeterministicFloat generates a deterministic random float [0,1) from a seed and identifier.
@@ -42,19 +52,18 @@ func ShouldValidate(
 // This is more or less as random as using a seed in a deterministic random seed determined by this same hash, and has
 // the advantage of being 100% deterministic regardless of platform and also faster to compute.
 func DeterministicFloat(seed int64, identifier string) decimal.Decimal {
-	// Concatenate the seed and identifier into a single string
-	input := fmt.Sprintf("%d:%s", seed, identifier)
+	// Build the exact same bytes as fmt.Sprintf("%d:%s", seed, identifier)
+	// but without fmt. This must stay base-10 to preserve the legacy hash.
+	b := make([]byte, 0, 21+1+len(identifier)) // 21 is enough for int64 in base10 with sign
+	b = strconv.AppendInt(b, seed, 10)
+	b = append(b, ':')
+	b = append(b, identifier...)
 
-	// Use a cryptographic hash (SHA-256)
-	h := sha256.New()
-	h.Write([]byte(input))
-	hash := h.Sum(nil)
+	sum := sha256.Sum256(b)
+	hashInt := binary.BigEndian.Uint64(sum[:8])
 
-	// Convert the first 8 bytes of the hash into a uint64
-	hashInt := binary.BigEndian.Uint64(hash[:8])
-
-	// Normalize the uint64 value to a decimal.Decimal in the range [0, 1)
-	maxUint64 := decimal.NewFromUint64(math.MaxUint64)
 	hashDecimal := decimal.NewFromUint64(hashInt)
-	return hashDecimal.Div(maxUint64)
+	return hashDecimal.Div(maxUint64Decimal)
 }
+
+var maxUint64Decimal = decimal.NewFromUint64(math.MaxUint64)

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -409,7 +409,7 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 
 		k.LogDebug("Getting validation", types.Claims, "seed", msg.Seed, "totalWeight", totalWeight, "executorPower", executorPower, "validatorPower", validatorPowerForModel)
 		shouldValidate, s := calculations.ShouldValidate(msg.Seed, &inference, uint32(totalWeight), uint32(validatorPowerForModel.Weight), uint32(executorPower.Weight),
-			k.Keeper.GetParams(ctx).ValidationParams)
+			k.Keeper.GetParams(ctx).ValidationParams, false)
 		k.LogDebug(s, types.Claims, "inference", inference.InferenceId, "seed", msg.Seed, "model", modelId, "validator", msg.Creator)
 		if shouldValidate {
 			mustBeValidated = append(mustBeValidated, inference.InferenceId)

--- a/inference-chain/x/inference/keeper/msg_server_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,7 +12,7 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-func setupMsgServer(t testing.TB) (keeper.Keeper, types.MsgServer, context.Context) {
+func setupMsgServer(t testing.TB) (keeper.Keeper, types.MsgServer, sdk.Context) {
 	k, ctx := keepertest.InferenceKeeper(t)
 	return k, setupMsgServerWithKeeper(k), ctx
 }


### PR DESCRIPTION
Focused (this round) on the ShouldValidate call. The base for testing was around 2800ns. All usual "micro-benchmarks aren't perfect" warnings apply, but perf should improve a lot:
1. Create the debug message for tests only (1070ns)
2. Pre calculate maxUint64Decimal (40ns)
3. optimize id for DeterministicFloat (avoid string fmt) (120ns)
3. Create ExecutorRep directly from power, instead of using Div (290ns!)
4. Simplify calculations (130ns)
5. Full traffic calculation skips Decimal (120ns when at full traffic (most of the time now))

All totaled, we went from 2800ns to 1030ns, which should help ClaimRewards quite a bit.

Also fixed unit tests