### PR TITLE
Bug Bounty: bridge double voting

### DIFF
--- a/inference-chain/app/upgrades/v0_2_6/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_6/upgrades.go
@@ -87,6 +87,9 @@ var (
 		// Bug Bounty: Vulnerability in Confirmation PoC
 		// https://github.com/gonka-ai/gonka/pull/459/commits/b44d51e0cce56f7d8ea35122e1b49cd4be9dd287
 		{"gonka1gmuxdcxlsxn5z72elx77w9zym7yrgfxqgzg6ry", 20000000000000},
+
+		// Bug Bounty: Bridge Exchange Double Vote Case Bypass
+		{"gonka1s8szs7n43jxgz4a4xaxmzm5emh7fmjxhach7w8", 10000000000000},
 	}
 )
 

--- a/inference-chain/x/inference/keeper/msg_server_bridge_exchange_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_bridge_exchange_test.go
@@ -1,0 +1,94 @@
+package keeper_test
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/group"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestBridgeExchange_DoubleVoteCaseBypass(t *testing.T) {
+	k, ms, ctx, mocks := setupKeeperWithMocks(t)
+
+	// Setup Validator
+	validatorLower := "gonka13779rkgy6ke7cdj8f097pdvx34uvrlcqq8nq2w"
+	validatorUpper := strings.ToUpper(validatorLower)
+
+	// Setup Epoch
+	epochIndex := uint64(1)
+	k.SetEffectiveEpochIndex(ctx, epochIndex)
+
+	// Setup Epoch Group Data
+	epochGroupData := types.EpochGroupData{
+		EpochIndex:   epochIndex,
+		ModelId:      "", // Default for main group
+		EpochGroupId: 1,
+		TotalWeight:  20,
+	}
+	k.SetEpochGroupData(ctx, epochGroupData)
+
+	// Setup Mocks
+
+	// 1. AccountKeeper.GetAccount for Validator (both lower and upper)
+	accAddr, _ := sdk.AccAddressFromBech32(validatorLower)
+
+	// We expect GetAccount to be called. It just checks if account exists (not nil).
+	mocks.AccountKeeper.EXPECT().GetAccount(ctx, accAddr).Return(
+		&authtypes.BaseAccount{Address: validatorLower},
+	).AnyTimes()
+
+	// 2. GroupKeeper.GroupMembers
+	// Called when checking if validator is in epoch group.
+	member := &group.GroupMember{
+		GroupId: 1,
+		Member: &group.Member{
+			Address: validatorLower,
+			Weight:  "10",
+		},
+	}
+
+	mocks.GroupKeeper.EXPECT().GroupMembers(ctx, gomock.Any()).Return(
+		&group.QueryGroupMembersResponse{
+			Members: []*group.GroupMember{member},
+		}, nil,
+	).AnyTimes()
+
+	// First Vote (Lowercase)
+	msg1 := &types.MsgBridgeExchange{
+		OriginChain:     "ethereum",
+		ContractAddress: "0x123",
+		OwnerAddress:    "0xabc",
+		Amount:          "100",
+		BlockNumber:     "1000",
+		ReceiptIndex:    "1",
+		Validator:       validatorLower,
+	}
+
+	_, err := ms.BridgeExchange(ctx, msg1)
+	require.NoError(t, err, "First vote should succeed")
+
+	// Second Vote (Uppercase)
+	msg2 := &types.MsgBridgeExchange{
+		OriginChain:     "ethereum",
+		ContractAddress: "0x123",
+		OwnerAddress:    "0xabc",
+		Amount:          "100",
+		BlockNumber:     "1000",
+		ReceiptIndex:    "1",
+		Validator:       validatorUpper, // Uppercase
+	}
+
+	// This should fail if fixed, but succeeds if vulnerable
+	_, err = ms.BridgeExchange(ctx, msg2)
+
+	// We assert that it fails (expecting the fix to prevent this)
+	require.Error(t, err, "Second vote should fail as duplicate")
+	if err != nil {
+		require.Contains(t, err.Error(), "validator has already validated this transaction")
+	}
+}


### PR DESCRIPTION
# Double Voting in Bridge

The `MsgBridgeExchange` handler contains a logic bug where the duplicate vote check uses case-sensitive string comparison on bech32 addresses. Since bech32 is case-insensitive by design (uppercase and lowercase decode to identical bytes), a validator can vote multiple times on the same bridge transaction by submitting their address with different casing. This inflates their validation power and can allow a single validator to reach majority consensus alone, triggering premature token release from the bridge escrow.

--
Proposed by `yapion`