### PR TITLE
Proposal: Enable tooling proposal

### DIFF
--- a/proposals/tool-calling/enable-tool-calling.md
+++ b/proposals/tool-calling/enable-tool-calling.md
@@ -98,7 +98,7 @@ This proposal does **not** mandate a specific implementation approach and intent
 
 This proposal is considered successful if:
 
-- IDE clients can reliably enable agent / apply modes when selecting `Qwen/Qwen3-32B-FP8` and`Qwen/QwQ-32B`
+- IDE clients can reliably enable agent / apply modes when selecting `Qwen/Qwen3-32B-FP8` and `Qwen/QwQ-32B`
 - Tool-calling requests follow OpenAI-compatible schemas without workarounds
 - Chat-only usage remains unchanged
 - The network gains support for IDE-driven agent workloads


### PR DESCRIPTION
### Summary

This PR introduces an off-chain improvement proposal to enable OpenAI-compatible tool/function calling for `Qwen/QwQ-32B` and `Qwen/Qwen3-32B-FP8`  modesl in the Gonka inference network.

The proposal is intended to gather feedback and reach consensus before proceeding to on-chain governance.

### Motivation

Modern IDE-integrated AI tools (e.g. Continue, Cursor, VS Code extensions) rely on structured tool/function calling to operate in agent mode.

While Gonka already provides an OpenAI-compatible inference gateway, `Qwen/Qwen3-32B-FP8`  and `Qwen/QwQ-32B` models are currently not exposed as tool-capable. As a result, IDE clients fall back to chat-only usage and cannot enable agent workflows such as code application, file edits, or command execution.

Enabling tool calling unlocks a new class of higher-value, developer-driven inference workloads for the network.

### What This PR Does

- Adds an off-chain proposal describing the motivation and scope for enabling tool/function calling
- Documents expected behavior, compatibility considerations, and open questions
- Does not introduce any code or runtime changes

### Next Steps
If consensus is reached on this proposal:

- Submit an on-chain TextProposal referencing this PR
- If required, follow up with a SoftwareUpgradeProposal to implement runtime changes


### Request for Feedback

Feedback is requested from:

- Core maintainers
- Hosts / validators
- Contributors familiar with inference runtime and gateway behavior