### PR TITLE
Improve TXManager reliability, add block-based deadlines, don't send invalid TXs

### DIFF
--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -159,7 +159,7 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		}
 	}()
 
-	mn, err := tx_manager.StartTxManager(ctx, &cosmoclient, apiAccount, time.Second*60, natsConn, accAddress)
+	mn, err := tx_manager.StartTxManager(ctx, &cosmoclient, apiAccount, time.Second*60, natsConn, accAddress, config.GetHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -218,7 +218,7 @@ type CosmosMessageClient interface {
 	NewInferenceQueryClient() types.QueryClient
 	NewCometQueryClient() cmtservice.ServiceClient
 	BankBalances(ctx context.Context, address string) ([]sdk.Coin, error)
-	SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse, error)
+	SendTransactionAsyncWithRetry(rawTx sdk.Msg, deadlineBlock ...int64) (*sdk.TxResponse, error)
 	SendTransactionAsyncNoRetry(rawTx sdk.Msg) (*sdk.TxResponse, error)
 	SendTransactionSyncNoRetry(transaction proto.Message, dstMsg proto.Message) error
 	Status(ctx context.Context) (*ctypes.ResultStatus, error)
@@ -439,8 +439,8 @@ func (icc *InferenceCosmosClient) GetBridgeAddresses(ctx context.Context, chainI
 	return resp.Addresses, nil
 }
 
-func (icc *InferenceCosmosClient) SendTransactionAsyncWithRetry(msg sdk.Msg) (*sdk.TxResponse, error) {
-	return icc.manager.SendTransactionAsyncWithRetry(msg)
+func (icc *InferenceCosmosClient) SendTransactionAsyncWithRetry(msg sdk.Msg, deadlineBlock ...int64) (*sdk.TxResponse, error) {
+	return icc.manager.SendTransactionAsyncWithRetry(msg, deadlineBlock...)
 }
 
 func (icc *InferenceCosmosClient) SendTransactionAsyncNoRetry(msg sdk.Msg) (*sdk.TxResponse, error) {

--- a/decentralized-api/cosmosclient/mock_cosmos_message_client.go
+++ b/decentralized-api/cosmosclient/mock_cosmos_message_client.go
@@ -163,7 +163,7 @@ func (m *MockCosmosMessageClient) GetBridgeAddresses(ctx context.Context, chainI
 	return args.Get(0).([]types.BridgeContractAddress), args.Error(1)
 }
 
-func (m *MockCosmosMessageClient) SendTransactionAsyncWithRetry(msg sdk.Msg) (*sdk.TxResponse, error) {
+func (m *MockCosmosMessageClient) SendTransactionAsyncWithRetry(msg sdk.Msg, deadlineBlock ...int64) (*sdk.TxResponse, error) {
 	args := m.Called(msg)
 	return args.Get(0).(*sdk.TxResponse), args.Error(1)
 }

--- a/decentralized-api/cosmosclient/tx_manager/batch_consumer_test.go
+++ b/decentralized-api/cosmosclient/tx_manager/batch_consumer_test.go
@@ -29,7 +29,7 @@ type mockTxManager struct {
 	mu             sync.Mutex
 }
 
-func (m *mockTxManager) SendBatchAsyncWithRetry(msgs []sdk.Msg) error {
+func (m *mockTxManager) SendBatchAsyncWithRetry(msgs []sdk.Msg, deadlineBlock ...int64) error {
 	m.mu.Lock()
 	m.sendBatchCalls = append(m.sendBatchCalls, msgs)
 	m.mu.Unlock()
@@ -42,7 +42,7 @@ func (m *mockTxManager) getBatchCalls() [][]sdk.Msg {
 	return m.sendBatchCalls
 }
 
-func (m *mockTxManager) SendTransactionAsyncWithRetry(sdk.Msg) (*sdk.TxResponse, error) {
+func (m *mockTxManager) SendTransactionAsyncWithRetry(sdk.Msg, ...int64) (*sdk.TxResponse, error) {
 	return &sdk.TxResponse{}, nil
 }
 func (m *mockTxManager) SendTransactionAsyncNoRetry(sdk.Msg) (*sdk.TxResponse, error) {

--- a/decentralized-api/cosmosclient/tx_manager/errors.go
+++ b/decentralized-api/cosmosclient/tx_manager/errors.go
@@ -45,9 +45,7 @@ var retryablePatterns = []string{
 	"no such host",
 	"network is unreachable",
 	"no route to host",
-	"tls:",
 	"certificate",
-	"dns",
 	// HTTP gateway errors
 	"post failed",
 	"bad gateway",
@@ -63,6 +61,9 @@ var retryablePatterns = []string{
 	// Sequence errors (safety net for non-unordered scenarios)
 	"account sequence mismatch",
 	"incorrect account sequence",
+
+	"unordered transaction has a timeout_timestamp that has already passed",
+	"unordered tx ttl exceeds",
 }
 
 // isRetryableRawLog checks if the raw log contains any retryable error patterns

--- a/decentralized-api/cosmosclient/tx_manager/errors.go
+++ b/decentralized-api/cosmosclient/tx_manager/errors.go
@@ -3,6 +3,8 @@ package tx_manager
 import (
 	"errors"
 	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var (
@@ -17,6 +19,97 @@ var (
 	ErrTxFailedToBroadcastAndPutOnRetry = errors.New("failed to broadcast and put on retry")
 	ErrTxNotFound                       = errors.New("tx not found")
 )
+
+// TxResponseAction defines the action to take after broadcast based on response classification
+type TxResponseAction int
+
+const (
+	// TxActionObserve means the TX is pending/success, observe it via the observer queue
+	TxActionObserve TxResponseAction = iota
+	// TxActionRetry means a transient error occurred, retry later
+	TxActionRetry
+	// TxActionFail means a permanent failure occurred, fail immediately without retry
+	TxActionFail
+)
+
+// retryablePatterns contains error patterns that indicate transient/infrastructure errors
+// which should be retried. All other errors are treated as permanent business logic failures.
+var retryablePatterns = []string{
+	// Network/transport errors
+	"connection refused",
+	"connection reset",
+	"i/o timeout",
+	"context deadline exceeded",
+	"broken pipe",
+	"eof",
+	"no such host",
+	"network is unreachable",
+	"no route to host",
+	"tls:",
+	"certificate",
+	"dns",
+	// HTTP gateway errors
+	"post failed",
+	"bad gateway",
+	"service unavailable",
+	"gateway timeout",
+	// RPC errors
+	"rpc error",
+	"aborted",
+	// OS resource exhaustion
+	"too many open files",
+	// Cosmos SDK transient errors
+	"mempool is full",
+	// Sequence errors (safety net for non-unordered scenarios)
+	"account sequence mismatch",
+	"incorrect account sequence",
+}
+
+// isRetryableRawLog checks if the raw log contains any retryable error patterns
+func isRetryableRawLog(rawLog string) bool {
+	lower := strings.ToLower(rawLog)
+	for _, pattern := range retryablePatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// isRetryableBroadcastError checks if a broadcast error is retryable
+func isRetryableBroadcastError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isRetryableRawLog(err.Error())
+}
+
+// classifyBroadcastResponse determines the action to take based on the broadcast response
+// - Code 0: success, observe the tx
+// - Code 19 (ErrTxInMempoolCache): tx already in mempool, observe it
+// - Code 20 (ErrMempoolIsFull): mempool full, retry
+// - Other codes with retryable RawLog: retry
+// - Other codes: permanent business logic failure, fail immediately
+func classifyBroadcastResponse(resp *sdk.TxResponse) TxResponseAction {
+	if resp == nil {
+		return TxActionRetry
+	}
+
+	switch resp.Code {
+	case 0: // Success
+		return TxActionObserve
+	case 19: // ErrTxInMempoolCache - tx is already pending in mempool
+		return TxActionObserve
+	case 20: // ErrMempoolIsFull - transient, retry
+		return TxActionRetry
+	default:
+		// Check RawLog for transient patterns
+		if isRetryableRawLog(resp.RawLog) {
+			return TxActionRetry
+		}
+		return TxActionFail
+	}
+}
 
 func isTxErrorCritical(err error) bool {
 	errString := strings.ToLower(err.Error())

--- a/decentralized-api/cosmosclient/tx_manager/errors_test.go
+++ b/decentralized-api/cosmosclient/tx_manager/errors_test.go
@@ -1,0 +1,282 @@
+package tx_manager
+
+import (
+	"errors"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func TestClassifyBroadcastResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		resp     *sdk.TxResponse
+		expected TxResponseAction
+	}{
+		{
+			name:     "nil response should retry",
+			resp:     nil,
+			expected: TxActionRetry,
+		},
+		{
+			name: "Code 0 (success) should observe",
+			resp: &sdk.TxResponse{
+				Code:   0,
+				TxHash: "ABC123",
+			},
+			expected: TxActionObserve,
+		},
+		{
+			name: "Code 19 (tx already in mempool) should observe",
+			resp: &sdk.TxResponse{
+				Code:   19,
+				RawLog: "tx already in mempool",
+			},
+			expected: TxActionObserve,
+		},
+		{
+			name: "Code 20 (mempool full) should retry",
+			resp: &sdk.TxResponse{
+				Code:   20,
+				RawLog: "mempool is full",
+			},
+			expected: TxActionRetry,
+		},
+		{
+			name: "Code 1143 (ErrDuplicateValidation) should fail",
+			resp: &sdk.TxResponse{
+				Code:      1143,
+				Codespace: "inference",
+				RawLog:    "participant has already validated this inference",
+			},
+			expected: TxActionFail,
+		},
+		{
+			name: "Code 1103 (ErrParticipantNotFound) should fail",
+			resp: &sdk.TxResponse{
+				Code:      1103,
+				Codespace: "inference",
+				RawLog:    "participant not found",
+			},
+			expected: TxActionFail,
+		},
+		{
+			name: "Code 1146 (ErrInferenceFinishProcessed) should fail",
+			resp: &sdk.TxResponse{
+				Code:      1146,
+				Codespace: "inference",
+				RawLog:    "inference has already finished processed",
+			},
+			expected: TxActionFail,
+		},
+		{
+			name: "Code 1147 (ErrInferenceStartProcessed) should fail",
+			resp: &sdk.TxResponse{
+				Code:      1147,
+				Codespace: "inference",
+				RawLog:    "inference has already started processed",
+			},
+			expected: TxActionFail,
+		},
+		{
+			name: "Unknown code with connection refused in RawLog should retry",
+			resp: &sdk.TxResponse{
+				Code:   99,
+				RawLog: "connection refused: dial tcp 127.0.0.1:26657",
+			},
+			expected: TxActionRetry,
+		},
+		{
+			name: "Unknown code with timeout in RawLog should retry",
+			resp: &sdk.TxResponse{
+				Code:   99,
+				RawLog: "i/o timeout",
+			},
+			expected: TxActionRetry,
+		},
+		{
+			name: "Unknown code with non-retryable RawLog should fail",
+			resp: &sdk.TxResponse{
+				Code:   99,
+				RawLog: "some unknown error",
+			},
+			expected: TxActionFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyBroadcastResponse(tt.resp)
+			if result != tt.expected {
+				t.Errorf("classifyBroadcastResponse() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsRetryableRawLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawLog   string
+		expected bool
+	}{
+		// Network/transport errors - should be retryable
+		{name: "connection refused", rawLog: "connection refused", expected: true},
+		{name: "connection reset", rawLog: "connection reset by peer", expected: true},
+		{name: "i/o timeout", rawLog: "read tcp: i/o timeout", expected: true},
+		{name: "context deadline exceeded", rawLog: "context deadline exceeded", expected: true},
+		{name: "broken pipe", rawLog: "write: broken pipe", expected: true},
+		{name: "eof", rawLog: "unexpected eof", expected: true},
+		{name: "no such host", rawLog: "dial tcp: no such host", expected: true},
+		{name: "network is unreachable", rawLog: "network is unreachable", expected: true},
+		{name: "no route to host", rawLog: "no route to host", expected: true},
+		{name: "tls error", rawLog: "tls: handshake failure", expected: true},
+		{name: "certificate error", rawLog: "x509: certificate signed by unknown authority", expected: true},
+		{name: "dns error", rawLog: "dns lookup failed", expected: true},
+
+		// HTTP gateway errors - should be retryable
+		{name: "post failed", rawLog: "post failed: connection refused", expected: true},
+		{name: "bad gateway", rawLog: "bad gateway", expected: true},
+		{name: "service unavailable", rawLog: "service unavailable", expected: true},
+		{name: "gateway timeout", rawLog: "gateway timeout", expected: true},
+
+		// RPC errors - should be retryable
+		{name: "rpc error", rawLog: "rpc error: code = Unavailable", expected: true},
+		{name: "aborted", rawLog: "transaction aborted", expected: true},
+
+		// OS resource errors - should be retryable
+		{name: "too many open files", rawLog: "too many open files", expected: true},
+
+		// Cosmos SDK transient errors - should be retryable
+		{name: "mempool is full", rawLog: "mempool is full", expected: true},
+
+		// Sequence errors - should be retryable
+		{name: "account sequence mismatch", rawLog: "account sequence mismatch, expected 5, got 4", expected: true},
+		{name: "incorrect account sequence", rawLog: "incorrect account sequence", expected: true},
+
+		// Business logic errors - should NOT be retryable
+		{name: "participant not found", rawLog: "participant not found", expected: false},
+		{name: "duplicate validation", rawLog: "participant has already validated this inference", expected: false},
+		{name: "inference not found", rawLog: "inference with id not found", expected: false},
+		{name: "inference already processed", rawLog: "inference has already finished processed", expected: false},
+		{name: "invalid signature", rawLog: "invalid keys provided for StartInference", expected: false},
+		{name: "empty string", rawLog: "", expected: false},
+		{name: "random error", rawLog: "something went wrong", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRetryableRawLog(tt.rawLog)
+			if result != tt.expected {
+				t.Errorf("isRetryableRawLog(%q) = %v, want %v", tt.rawLog, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsRetryableBroadcastError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error should not be retryable",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "connection refused error should be retryable",
+			err:      errors.New("dial tcp 127.0.0.1:26657: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "timeout error should be retryable",
+			err:      errors.New("context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "mempool full error should be retryable",
+			err:      errors.New("mempool is full"),
+			expected: true,
+		},
+		{
+			name:     "business logic error should not be retryable",
+			err:      errors.New("participant not found"),
+			expected: false,
+		},
+		{
+			name:     "unknown error should not be retryable",
+			err:      errors.New("something unexpected happened"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRetryableBroadcastError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isRetryableBroadcastError(%v) = %v, want %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsTxErrorCritical(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "ErrBuildingUnsignedTx should be critical",
+			err:      ErrBuildingUnsignedTx,
+			expected: true,
+		},
+		{
+			name:     "ErrFailedToSignTx should be critical",
+			err:      ErrFailedToSignTx,
+			expected: true,
+		},
+		{
+			name:     "ErrFailedToEncodeTx should be critical",
+			err:      ErrFailedToEncodeTx,
+			expected: true,
+		},
+		{
+			name:     "tx too large should be critical",
+			err:      errors.New("tx too large"),
+			expected: true,
+		},
+		{
+			name:     "key not found should be critical",
+			err:      errors.New("key not found"),
+			expected: true,
+		},
+		{
+			name:     "invalid bech32 string should be critical",
+			err:      errors.New("invalid bech32 string"),
+			expected: true,
+		},
+		{
+			name:     "random error should not be critical",
+			err:      errors.New("some random error"),
+			expected: false,
+		},
+		{
+			name:     "connection refused should not be critical",
+			err:      errors.New("connection refused"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTxErrorCritical(tt.err)
+			if result != tt.expected {
+				t.Errorf("isTxErrorCritical(%v) = %v, want %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+

--- a/decentralized-api/cosmosclient/tx_manager/errors_test.go
+++ b/decentralized-api/cosmosclient/tx_manager/errors_test.go
@@ -130,9 +130,7 @@ func TestIsRetryableRawLog(t *testing.T) {
 		{name: "no such host", rawLog: "dial tcp: no such host", expected: true},
 		{name: "network is unreachable", rawLog: "network is unreachable", expected: true},
 		{name: "no route to host", rawLog: "no route to host", expected: true},
-		{name: "tls error", rawLog: "tls: handshake failure", expected: true},
 		{name: "certificate error", rawLog: "x509: certificate signed by unknown authority", expected: true},
-		{name: "dns error", rawLog: "dns lookup failed", expected: true},
 
 		// HTTP gateway errors - should be retryable
 		{name: "post failed", rawLog: "post failed: connection refused", expected: true},

--- a/decentralized-api/cosmosclient/tx_manager/tx_deadline_config.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_deadline_config.go
@@ -1,7 +1,7 @@
 package tx_manager
 
 // defaultMaxBlocks is the default deadline in blocks (500 blocks ≈ 40 minutes at 5s/block)
-const defaultMaxBlocks int64 = 500
+const defaultMaxBlocks int64 = 30
 
 // deadlineByMsgType defines message-specific deadlines based on chain epoch parameters
 var deadlineByMsgType = map[string]int64{

--- a/decentralized-api/cosmosclient/tx_manager/tx_deadline_config.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_deadline_config.go
@@ -1,0 +1,22 @@
+package tx_manager
+
+// defaultMaxBlocks is the default deadline in blocks (500 blocks ≈ 40 minutes at 5s/block)
+const defaultMaxBlocks int64 = 500
+
+// deadlineByMsgType defines message-specific deadlines based on chain epoch parameters
+var deadlineByMsgType = map[string]int64{
+	"/inference.inference.MsgSubmitPocBatch":      240,
+	"/inference.inference.MsgSubmitPocValidation": 240,
+	"/inference.inference.MsgFinishInference":     150,
+	"/inference.inference.MsgValidation":          150,
+	"/inference.inference.MsgStartInference":      150,
+}
+
+// getMaxBlocksForType returns the maximum blocks a transaction type can wait before expiring.
+// Returns defaultMaxBlocks if the message type is not in the configuration.
+func getMaxBlocksForType(msgType string) int64 {
+	if blocks, ok := deadlineByMsgType[msgType]; ok {
+		return blocks
+	}
+	return defaultMaxBlocks
+}

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -48,6 +48,8 @@ const (
 
 	hashHeader = "TX_HASH"
 	idHeader   = "TX_ID"
+
+	maxBlockTimeDrift = 120 * time.Second
 )
 
 type TxManager interface {
@@ -69,7 +71,7 @@ type blockTimeTracker struct {
 	latestBlockHeight int64
 	lastUpdatedAt     time.Time
 	maxBlockTimeout   time.Duration
-	chainHalt         bool
+	pauseSending      bool
 	mtx               sync.Mutex
 }
 
@@ -474,8 +476,9 @@ func (m *manager) sendTxs() error {
 
 	_, err := m.natsJetStream.Subscribe(server.TxsToSendStream, func(msg *nats.Msg) {
 		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-			time.Sleep(3 * time.Second)
+			logging.Warn("node paused, delaying tx processing", types.Messages,
+				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+			msg.NakWithDelay(5 * time.Second)
 			return
 		}
 		txId := msg.Header.Get(idHeader)
@@ -592,7 +595,10 @@ func (m *manager) observeTxs() error {
 	logging.Info("Tx manager: observeTxs txs: run in background", types.Messages)
 	_, err := m.natsJetStream.Subscribe(server.TxsToObserveStream, func(msg *nats.Msg) {
 		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+			logging.Warn("node paused, delaying tx observation", types.Messages,
+				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+			msg.NakWithDelay(5 * time.Second)
+			return
 		}
 
 		var tx txInfo
@@ -921,11 +927,33 @@ func (m *manager) getLatestBlockHeight() int64 {
 	return m.blockTimeTracker.latestBlockHeight
 }
 
+func (m *manager) isNodeBehind(syncInfo ctypes.SyncInfo) bool {
+	if syncInfo.CatchingUp {
+		logging.Warn("node is catching up", types.Messages,
+			"height", syncInfo.LatestBlockHeight)
+		return true
+	}
+
+	drift := time.Since(syncInfo.LatestBlockTime)
+	if drift > maxBlockTimeDrift {
+		logging.Warn("node block time is stale", types.Messages,
+			"latestBlockTime", syncInfo.LatestBlockTime,
+			"drift", drift)
+		return true
+	}
+
+	return false
+}
+
 func (m *manager) updateChainHalt() (bool, error) {
+	m.blockTimeTracker.mtx.Lock()
 	now := time.Now()
 	if now.Sub(m.blockTimeTracker.lastUpdatedAt) < time.Second*3 {
-		return m.blockTimeTracker.chainHalt, nil
+		result := m.blockTimeTracker.pauseSending
+		m.blockTimeTracker.mtx.Unlock()
+		return result, nil
 	}
+	m.blockTimeTracker.mtx.Unlock()
 
 	status, err := m.client.Status(m.ctx)
 	if err != nil {
@@ -936,20 +964,34 @@ func (m *manager) updateChainHalt() (bool, error) {
 	m.blockTimeTracker.mtx.Lock()
 	defer m.blockTimeTracker.mtx.Unlock()
 
+	// Priority 1: Chain halt detection (chain stopped producing blocks)
 	if status.SyncInfo.LatestBlockTime.Equal(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
 		status.SyncInfo.LatestBlockHeight == m.blockTimeTracker.latestBlockHeight &&
 		!m.blockTimeTracker.lastUpdatedAt.IsZero() && now.Sub(m.blockTimeTracker.lastUpdatedAt) > m.blockTimeTracker.maxBlockTimeout {
-		// same block, and we sow it more than N seconds ago -> chain halt
-		m.blockTimeTracker.chainHalt = true
+		m.blockTimeTracker.pauseSending = true
+		m.blockTimeTracker.lastUpdatedAt = now
+		return true, nil
 	}
 
+	// Priority 2: Node behind (catching up or stale block time)
+	if m.isNodeBehind(status.SyncInfo) {
+		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
+		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
+		m.blockTimeTracker.pauseSending = true
+		m.blockTimeTracker.lastUpdatedAt = now
+		return true, nil
+	}
+
+	// Recovery: passed both checks, safe to send
+	m.blockTimeTracker.pauseSending = false
+
+	// Update tracker if newer block seen
 	if status.SyncInfo.LatestBlockTime.After(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
 		status.SyncInfo.LatestBlockHeight > m.blockTimeTracker.latestBlockHeight {
 		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
 		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
-		m.blockTimeTracker.chainHalt = false
 	}
 
 	m.blockTimeTracker.lastUpdatedAt = now
-	return m.blockTimeTracker.chainHalt, nil
+	return m.blockTimeTracker.pauseSending, nil
 }

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -475,12 +475,17 @@ func (m *manager) sendTxs() error {
 	logging.Info("Tx manager: sending txs: run in background", types.Messages)
 
 	_, err := m.natsJetStream.Subscribe(server.TxsToSendStream, func(msg *nats.Msg) {
-		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Warn("node paused, delaying tx processing", types.Messages,
-				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-			msg.NakWithDelay(5 * time.Second)
-			return
+		for {
+			if halt, err := m.updateChainHalt(); err != nil || halt {
+				logging.Warn("node paused, waiting to process tx", types.Messages,
+					"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+				msg.InProgress()
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			break
 		}
+
 		txId := msg.Header.Get(idHeader)
 		txHash := msg.Header.Get(hashHeader)
 
@@ -594,11 +599,15 @@ func (m *manager) sendTxs() error {
 func (m *manager) observeTxs() error {
 	logging.Info("Tx manager: observeTxs txs: run in background", types.Messages)
 	_, err := m.natsJetStream.Subscribe(server.TxsToObserveStream, func(msg *nats.Msg) {
-		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Warn("node paused, delaying tx observation", types.Messages,
-				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-			msg.NakWithDelay(5 * time.Second)
-			return
+		for {
+			if halt, err := m.updateChainHalt(); err != nil || halt {
+				logging.Warn("node paused, waiting to observe tx", types.Messages,
+					"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+				msg.InProgress()
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			break
 		}
 
 		var tx txInfo

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -67,12 +66,11 @@ type TxManager interface {
 }
 
 type blockTimeTracker struct {
-	latestBlockTime   atomic.Value
-	latestBlockHeight int64
-	lastUpdatedAt     time.Time
-	maxBlockTimeout   time.Duration
-	pauseSending      bool
-	mtx               sync.Mutex
+	latestBlockTime time.Time
+	lastUpdatedAt   time.Time
+	maxBlockTimeout time.Duration
+	pauseSending    bool
+	mtx             sync.Mutex
 }
 
 type manager struct {
@@ -86,6 +84,7 @@ type manager struct {
 	natsConnection   *nats.Conn
 	natsJetStream    nats.JetStreamContext
 	blockTimeTracker *blockTimeTracker
+	getHeightFunc    func() int64
 }
 
 func StartTxManager(
@@ -94,7 +93,8 @@ func StartTxManager(
 	account *apiconfig.ApiAccount,
 	defaultTimeout time.Duration,
 	natsConnection *nats.Conn,
-	address string) (*manager, error) {
+	address string,
+	getHeight func() int64) (*manager, error) {
 	js, err := natsConnection.JetStream()
 	if err != nil {
 		return nil, err
@@ -110,9 +110,6 @@ func StartTxManager(
 	restrictionstypes.RegisterInterfaces(client.Context().InterfaceRegistry)
 	blstypes.RegisterInterfaces(client.Context().InterfaceRegistry)
 
-	ts := atomic.Value{}
-	ts.Store(time.Time{})
-
 	m := &manager{
 		ctx:              ctx,
 		client:           client,
@@ -122,8 +119,8 @@ func StartTxManager(
 		defaultTimeout:   defaultTimeout,
 		natsConnection:   natsConnection,
 		natsJetStream:    js,
+		getHeightFunc:    getHeight,
 		blockTimeTracker: &blockTimeTracker{
-			latestBlockTime: ts,
 			maxBlockTimeout: 10 * time.Second,
 		},
 	}
@@ -141,9 +138,10 @@ func StartTxManager(
 const maxAttempts = 3
 
 type txToSend struct {
-	TxInfo   txInfo
-	Sent     bool
-	Attempts int
+	TxInfo      txInfo
+	Sent        bool
+	Attempts    int
+	RequeueTime time.Time `json:",omitempty"`
 }
 
 type txInfo struct {
@@ -181,7 +179,7 @@ func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg, deadlineBlockOpt 
 	}
 
 	if halt, err := m.updateChainHalt(); err != nil || halt {
-		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
 
 		if err := m.putOnRetry(id, "", time.Time{}, rawTx, 0, false, deadlineBlock); err != nil {
 			logging.Error("failed to put in queue", types.Messages, "tx_id", id, "resend_err", err)
@@ -258,7 +256,7 @@ func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg, deadlineBlockOpt ...in
 	logging.Debug("SendBatchAsyncWithRetry: sending batch", types.Messages, "tx_id", id, "count", len(msgs))
 
 	if halt, err := m.updateChainHalt(); err != nil || halt {
-		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
 
 		if err := m.putBatchOnRetry(id, msgs, "", time.Time{}, 0, false, deadlineBlock); err != nil {
 			logging.Error("failed to put batch in queue", types.Messages, "tx_id", id, "resend_err", err)
@@ -471,33 +469,38 @@ func (m *manager) putInfoToObserve(info txInfo) error {
 	return err
 }
 
+func (m *manager) requeue(tx *txToSend) error {
+	tx.Attempts++
+	tx.RequeueTime = time.Now()
+	if tx.Attempts >= maxAttempts {
+		logging.Warn("tx max attempts reached", types.Messages, "id", tx.TxInfo.Id)
+		return nil
+	}
+	b, err := json.Marshal(tx)
+	if err != nil {
+		return err
+	}
+	msg := &nats.Msg{Subject: server.TxsToSendStream, Data: b, Header: nats.Header{}}
+	msg.Header.Set(idHeader, tx.TxInfo.Id)
+	msg.Header.Set(hashHeader, tx.TxInfo.TxHash)
+	_, err = m.natsJetStream.PublishMsg(msg)
+	return err
+}
+
 func (m *manager) sendTxs() error {
 	logging.Info("Tx manager: sending txs: run in background", types.Messages)
 
 	_, err := m.natsJetStream.Subscribe(server.TxsToSendStream, func(msg *nats.Msg) {
-		for {
-			if halt, err := m.updateChainHalt(); err != nil || halt {
-				logging.Warn("node paused, waiting to process tx", types.Messages,
-					"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-				msg.InProgress()
-				time.Sleep(5 * time.Second)
-				continue
-			}
-			break
+		if halt, _ := m.updateChainHalt(); halt {
+			logging.Warn("node paused, delaying tx", types.Messages,
+				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
+			msg.NakWithDelay(defaultSenderNackDelay)
+			return
 		}
 
 		txId := msg.Header.Get(idHeader)
 		txHash := msg.Header.Get(hashHeader)
-
-		md, err := msg.Metadata()
-		if err == nil {
-			logging.Info("sendTxs metadata", types.Messages, "delivered", md.NumDelivered, "pending", md.NumPending, "id", txId, "hash", txHash)
-			if md.NumDelivered >= maxAttempts {
-				logging.Warn("tx retry max attempts failed", types.Messages, "delivered", md.NumDelivered, "id", txId, "hash", txHash)
-				msg.Term()
-				return
-			}
-		}
+		logging.Debug("sendTxs processing", types.Messages, "id", txId, "hash", txHash)
 
 		var tx txToSend
 		if err := json.Unmarshal(msg.Data, &tx); err != nil {
@@ -506,7 +509,21 @@ func (m *manager) sendTxs() error {
 			return
 		}
 
-		logging.Debug("SendTxs: got tx", types.Messages, "id", tx.TxInfo.Id)
+		logging.Debug("SendTxs: got tx", types.Messages, "id", tx.TxInfo.Id, "attempts", tx.Attempts)
+
+		if tx.Attempts >= maxAttempts {
+			logging.Warn("tx max attempts reached", types.Messages, "id", tx.TxInfo.Id)
+			msg.Term()
+			return
+		}
+
+		if !tx.RequeueTime.IsZero() {
+			elapsed := time.Since(tx.RequeueTime)
+			if elapsed < defaultSenderNackDelay {
+				msg.NakWithDelay(defaultSenderNackDelay - elapsed)
+				return
+			}
+		}
 
 		currentHeight := m.getLatestBlockHeight()
 		if tx.TxInfo.DeadlineBlock > 0 && currentHeight > tx.TxInfo.DeadlineBlock {
@@ -553,8 +570,11 @@ func (m *manager) sendTxs() error {
 			if broadcastErr != nil {
 				// Check if broadcast error is retryable
 				if isRetryableBroadcastError(broadcastErr) {
-					logging.Warn("retryable broadcast error in sendTxs, will retry", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr)
-					msg.NakWithDelay(defaultSenderNackDelay)
+					logging.Warn("retryable broadcast error, requeuing", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr)
+					if err := m.requeue(&tx); err != nil {
+						logging.Error("requeue failed, dropping tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
+					}
+					msg.Ack()
 					return
 				}
 				// Non-retryable broadcast error - drop permanently
@@ -572,9 +592,12 @@ func (m *manager) sendTxs() error {
 				msg.Term()
 				return
 			case TxActionRetry:
-				logging.Warn("Retryable response error in sendTxs, will retry", types.Messages,
+				logging.Warn("Retryable response error, requeuing", types.Messages,
 					"id", tx.TxInfo.Id, "code", resp.Code, "rawLog", resp.RawLog)
-				msg.NakWithDelay(defaultSenderNackDelay)
+				if err := m.requeue(&tx); err != nil {
+					logging.Error("requeue failed, dropping tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
+				}
+				msg.Ack()
 				return
 			case TxActionObserve:
 				// Success or tx-in-mempool - continue to observer
@@ -587,11 +610,10 @@ func (m *manager) sendTxs() error {
 		logging.Debug("tx broadcast, put to observe", types.Messages, "id", tx.TxInfo.Id, "tx_hash", tx.TxInfo.TxHash, "timeout", tx.TxInfo.Timeout.String())
 
 		if err := m.putInfoToObserve(tx.TxInfo); err != nil {
-			logging.Error("error pushing to observe queue", types.Messages, "id", tx.TxInfo.Id, "err", err)
-			msg.NakWithDelay(defaultSenderNackDelay)
-		} else {
-			msg.Ack()
+			logging.Error("error pushing to observe queue, tx broadcast but untracked",
+				types.Messages, "id", tx.TxInfo.Id, "txHash", tx.TxInfo.TxHash, "err", err)
 		}
+		msg.Ack()
 	}, nats.Durable(txSenderConsumer), nats.ManualAck())
 	return err
 }
@@ -599,15 +621,11 @@ func (m *manager) sendTxs() error {
 func (m *manager) observeTxs() error {
 	logging.Info("Tx manager: observeTxs txs: run in background", types.Messages)
 	_, err := m.natsJetStream.Subscribe(server.TxsToObserveStream, func(msg *nats.Msg) {
-		for {
-			if halt, err := m.updateChainHalt(); err != nil || halt {
-				logging.Warn("node paused, waiting to observe tx", types.Messages,
-					"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-				msg.InProgress()
-				time.Sleep(5 * time.Second)
-				continue
-			}
-			break
+		if halt, _ := m.updateChainHalt(); halt {
+			logging.Warn("node paused, delaying observe", types.Messages,
+				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
+			msg.NakWithDelay(defaultObserverNackDelay)
+			return
 		}
 
 		var tx txInfo
@@ -676,7 +694,7 @@ func (m *manager) observeTxs() error {
 		}
 
 		if errors.Is(err, ErrTxNotFound) {
-			if m.blockTimeTracker.latestBlockTime.Load().(time.Time).After(tx.Timeout) {
+			if m.blockTimeTracker.latestBlockTime.After(tx.Timeout) {
 				logging.Debug("tx expired", types.Messages, "tx_id", tx.Id, "tx_hash", tx.TxHash, "tx_timestamp", tx.Timeout, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
 				tx.Attempts++
 
@@ -898,13 +916,13 @@ func (m *manager) getFactory(id string) (*tx.Factory, error) {
 }
 
 func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory *tx.Factory) ([]byte, time.Time, error) {
-	blockTs := m.blockTimeTracker.latestBlockTime.Load().(time.Time)
+	blockTs := m.blockTimeTracker.latestBlockTime
 	if blockTs.IsZero() {
 		_, err := m.updateChainHalt()
 		if err != nil {
 			return nil, time.Time{}, err
 		}
-		blockTs = m.blockTimeTracker.latestBlockTime.Load().(time.Time)
+		blockTs = m.blockTimeTracker.latestBlockTime
 	}
 
 	timestamp := getTimestamp(blockTs.UnixNano(), m.defaultTimeout)
@@ -931,9 +949,7 @@ func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory
 }
 
 func (m *manager) getLatestBlockHeight() int64 {
-	m.blockTimeTracker.mtx.Lock()
-	defer m.blockTimeTracker.mtx.Unlock()
-	return m.blockTimeTracker.latestBlockHeight
+	return m.getHeightFunc()
 }
 
 func (m *manager) isNodeBehind(syncInfo ctypes.SyncInfo) bool {
@@ -974,8 +990,7 @@ func (m *manager) updateChainHalt() (bool, error) {
 	defer m.blockTimeTracker.mtx.Unlock()
 
 	// Priority 1: Chain halt detection (chain stopped producing blocks)
-	if status.SyncInfo.LatestBlockTime.Equal(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
-		status.SyncInfo.LatestBlockHeight == m.blockTimeTracker.latestBlockHeight &&
+	if status.SyncInfo.LatestBlockTime.Equal(m.blockTimeTracker.latestBlockTime) &&
 		!m.blockTimeTracker.lastUpdatedAt.IsZero() && now.Sub(m.blockTimeTracker.lastUpdatedAt) > m.blockTimeTracker.maxBlockTimeout {
 		m.blockTimeTracker.pauseSending = true
 		m.blockTimeTracker.lastUpdatedAt = now
@@ -984,8 +999,7 @@ func (m *manager) updateChainHalt() (bool, error) {
 
 	// Priority 2: Node behind (catching up or stale block time)
 	if m.isNodeBehind(status.SyncInfo) {
-		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
-		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
+		m.blockTimeTracker.latestBlockTime = status.SyncInfo.LatestBlockTime
 		m.blockTimeTracker.pauseSending = true
 		m.blockTimeTracker.lastUpdatedAt = now
 		return true, nil
@@ -994,11 +1008,9 @@ func (m *manager) updateChainHalt() (bool, error) {
 	// Recovery: passed both checks, safe to send
 	m.blockTimeTracker.pauseSending = false
 
-	// Update tracker if newer block seen
-	if status.SyncInfo.LatestBlockTime.After(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
-		status.SyncInfo.LatestBlockHeight > m.blockTimeTracker.latestBlockHeight {
-		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
-		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
+	// Update block time for halt detection
+	if status.SyncInfo.LatestBlockTime.After(m.blockTimeTracker.latestBlockTime) {
+		m.blockTimeTracker.latestBlockTime = status.SyncInfo.LatestBlockTime
 	}
 
 	m.blockTimeTracker.lastUpdatedAt = now

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -178,21 +178,43 @@ func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse,
 
 	resp, timeout, broadcastErr := m.broadcastMessage(id, rawTx)
 	if broadcastErr != nil {
-		if isTxErrorCritical(broadcastErr) {
-			logging.Error("SendTransactionAsyncWithRetry: critical error sending tx", types.Messages, "tx_id", id, "err", broadcastErr)
-			return nil, broadcastErr
+		// Check if broadcast error is retryable
+		if isRetryableBroadcastError(broadcastErr) {
+			if err := m.putOnRetry(id, "", timeout, rawTx, 1, false); err != nil {
+				logging.Error("tx failed to broadcast, failed to put in queue", types.Messages, "tx_id", id, "broadcast_err", broadcastErr, "resend_err", err)
+			}
+			return nil, ErrTxFailedToBroadcastAndPutOnRetry
 		}
+		// Non-retryable broadcast error - fail immediately
+		logging.Error("SendTransactionAsyncWithRetry: non-retryable broadcast error", types.Messages, "tx_id", id, "err", broadcastErr)
+		return nil, broadcastErr
+	}
 
-		err := m.putOnRetry(id, "", timeout, rawTx, 1, false)
-		if err != nil {
-			logging.Error("tx failed to broadcast, failed to put in queue", types.Messages, "tx_id", id, "broadcast_err", broadcastErr, "resend_err", err)
+	// Classify the response to determine action
+	action := classifyBroadcastResponse(resp)
+	switch action {
+	case TxActionFail:
+		logging.Warn("Non-retryable business error, failing immediately", types.Messages,
+			"tx_id", id, "code", resp.Code, "codespace", resp.Codespace, "rawLog", resp.RawLog)
+		return nil, NewTransactionErrorFromResponse(resp)
+	case TxActionRetry:
+		logging.Warn("Retryable response error, queuing for retry", types.Messages,
+			"tx_id", id, "code", resp.Code, "rawLog", resp.RawLog)
+		if err := m.putOnRetry(id, "", timeout, rawTx, 1, false); err != nil {
+			logging.Error("tx failed, failed to put in queue for retry", types.Messages, "tx_id", id, "err", err)
 		}
 		return nil, ErrTxFailedToBroadcastAndPutOnRetry
+	case TxActionObserve:
+		// Success or tx-in-mempool - queue for observation
+		if err := m.putOnRetry(id, resp.TxHash, timeout, rawTx, 1, true); err != nil {
+			logging.Error("tx broadcast, but failed to put in queue", types.Messages, "tx_id", id, "err", err)
+		}
+		return resp, nil
 	}
-	if err := m.putOnRetry(id, resp.TxHash, timeout, rawTx, 1, true); err != nil {
-		logging.Error("tx broadcast, but failed to put in queue", types.Messages, "tx_id", id, "err", err)
-	}
-	return resp, nil
+
+	// Should never reach here, but fail safe
+	logging.Error("Unexpected classification result", types.Messages, "tx_id", id)
+	return nil, ErrTxFailedToBroadcastAndPutOnRetry
 }
 
 func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg) error {
@@ -219,22 +241,43 @@ func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg) error {
 
 	resp, timeout, broadcastErr := m.BroadcastMessages(id, msgs...)
 	if broadcastErr != nil {
-		if isTxErrorCritical(broadcastErr) {
-			logging.Error("SendBatchAsyncWithRetry: critical error sending batch", types.Messages, "tx_id", id, "err", broadcastErr)
-			return broadcastErr
+		// Check if broadcast error is retryable
+		if isRetryableBroadcastError(broadcastErr) {
+			if err := m.putBatchOnRetry(id, msgs, "", timeout, 1, false); err != nil {
+				logging.Error("batch failed to broadcast, failed to put in queue", types.Messages, "tx_id", id, "broadcast_err", broadcastErr, "resend_err", err)
+			}
+			return ErrTxFailedToBroadcastAndPutOnRetry
 		}
+		// Non-retryable broadcast error - fail immediately
+		logging.Error("SendBatchAsyncWithRetry: non-retryable broadcast error", types.Messages, "tx_id", id, "err", broadcastErr)
+		return broadcastErr
+	}
 
-		err := m.putBatchOnRetry(id, msgs, "", timeout, 1, false)
-		if err != nil {
-			logging.Error("batch failed to broadcast, failed to put in queue", types.Messages, "tx_id", id, "broadcast_err", broadcastErr, "resend_err", err)
+	// Classify the response to determine action
+	action := classifyBroadcastResponse(resp)
+	switch action {
+	case TxActionFail:
+		logging.Warn("Non-retryable business error in batch, failing immediately", types.Messages,
+			"tx_id", id, "code", resp.Code, "codespace", resp.Codespace, "rawLog", resp.RawLog)
+		return NewTransactionErrorFromResponse(resp)
+	case TxActionRetry:
+		logging.Warn("Retryable response error in batch, queuing for retry", types.Messages,
+			"tx_id", id, "code", resp.Code, "rawLog", resp.RawLog)
+		if err := m.putBatchOnRetry(id, msgs, "", timeout, 1, false); err != nil {
+			logging.Error("batch failed, failed to put in queue for retry", types.Messages, "tx_id", id, "err", err)
 		}
 		return ErrTxFailedToBroadcastAndPutOnRetry
+	case TxActionObserve:
+		// Success or tx-in-mempool - queue for observation
+		if err := m.putBatchOnRetry(id, msgs, resp.TxHash, timeout, 1, true); err != nil {
+			logging.Error("batch broadcast, but failed to put in queue", types.Messages, "tx_id", id, "err", err)
+		}
+		return nil
 	}
 
-	if err := m.putBatchOnRetry(id, msgs, resp.TxHash, timeout, 1, true); err != nil {
-		logging.Error("batch broadcast, but failed to put in queue", types.Messages, "tx_id", id, "err", err)
-	}
-	return nil
+	// Should never reach here, but fail safe
+	logging.Error("Unexpected classification result for batch", types.Messages, "tx_id", id)
+	return ErrTxFailedToBroadcastAndPutOnRetry
 }
 
 func (m *manager) SendTransactionAsyncNoRetry(rawTx sdk.Msg) (*sdk.TxResponse, error) {
@@ -435,17 +478,37 @@ func (m *manager) sendTxs() error {
 
 		if !tx.Sent {
 			if broadcastErr != nil {
-				if isTxErrorCritical(broadcastErr) {
-					logging.Error("got critical error sending tx", types.Messages, "id", tx.TxInfo.Id)
-					msg.Term() // invalid tx, drop it
+				// Check if broadcast error is retryable
+				if isRetryableBroadcastError(broadcastErr) {
+					logging.Warn("retryable broadcast error in sendTxs, will retry", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr)
+					msg.NakWithDelay(defaultSenderNackDelay)
 					return
 				}
-				msg.NakWithDelay(defaultSenderNackDelay)
+				// Non-retryable broadcast error - drop permanently
+				logging.Error("non-retryable broadcast error in sendTxs, dropping", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr)
+				msg.Term()
 				return
 			}
-			tx.TxInfo.Timeout = timeout
-			tx.TxInfo.TxHash = resp.TxHash
-			tx.Sent = true
+
+			// Classify the response to determine action
+			action := classifyBroadcastResponse(resp)
+			switch action {
+			case TxActionFail:
+				logging.Warn("Non-retryable business error in sendTxs, dropping", types.Messages,
+					"id", tx.TxInfo.Id, "code", resp.Code, "codespace", resp.Codespace, "rawLog", resp.RawLog)
+				msg.Term()
+				return
+			case TxActionRetry:
+				logging.Warn("Retryable response error in sendTxs, will retry", types.Messages,
+					"id", tx.TxInfo.Id, "code", resp.Code, "rawLog", resp.RawLog)
+				msg.NakWithDelay(defaultSenderNackDelay)
+				return
+			case TxActionObserve:
+				// Success or tx-in-mempool - continue to observer
+				tx.TxInfo.Timeout = timeout
+				tx.TxInfo.TxHash = resp.TxHash
+				tx.Sent = true
+			}
 		}
 
 		logging.Debug("tx broadcast, put to observe", types.Messages, "id", tx.TxInfo.Id, "tx_hash", tx.TxInfo.TxHash, "timeout", tx.TxInfo.Timeout.String())

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -457,6 +457,16 @@ func (m *manager) putInfoToObserve(info txInfo) error {
 	return err
 }
 
+func (m *manager) republishTxWithDelay(tx txToSend, delay time.Duration) error {
+	time.Sleep(delay)
+	b, err := json.Marshal(&tx)
+	if err != nil {
+		return err
+	}
+	_, err = m.natsJetStream.Publish(server.TxsToSendStream, b)
+	return err
+}
+
 func (m *manager) sendTxs() error {
 	logging.Info("Tx manager: sending txs: run in background", types.Messages)
 
@@ -520,8 +530,17 @@ func (m *manager) sendTxs() error {
 			if broadcastErr != nil {
 				// Check if broadcast error is retryable
 				if isRetryableBroadcastError(broadcastErr) {
-					logging.Warn("retryable broadcast error in sendTxs, will retry", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr)
-					msg.NakWithDelay(defaultSenderNackDelay)
+					tx.Attempts++
+					if tx.Attempts >= maxAttempts {
+						logging.Warn("tx reached max attempts after broadcast error, dropping", types.Messages, "id", tx.TxInfo.Id, "attempts", tx.Attempts)
+						msg.Term()
+						return
+					}
+					logging.Warn("retryable broadcast error in sendTxs, will retry", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr, "attempts", tx.Attempts)
+					if err := m.republishTxWithDelay(tx, defaultSenderNackDelay); err != nil {
+						logging.Error("failed to republish tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
+					}
+					msg.Ack()
 					return
 				}
 				// Non-retryable broadcast error - drop permanently
@@ -539,9 +558,18 @@ func (m *manager) sendTxs() error {
 				msg.Term()
 				return
 			case TxActionRetry:
+				tx.Attempts++
+				if tx.Attempts >= maxAttempts {
+					logging.Warn("tx reached max attempts after response error, dropping", types.Messages, "id", tx.TxInfo.Id, "attempts", tx.Attempts)
+					msg.Term()
+					return
+				}
 				logging.Warn("Retryable response error in sendTxs, will retry", types.Messages,
-					"id", tx.TxInfo.Id, "code", resp.Code, "rawLog", resp.RawLog)
-				msg.NakWithDelay(defaultSenderNackDelay)
+					"id", tx.TxInfo.Id, "code", resp.Code, "rawLog", resp.RawLog, "attempts", tx.Attempts)
+				if err := m.republishTxWithDelay(tx, defaultSenderNackDelay); err != nil {
+					logging.Error("failed to republish tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
+				}
+				msg.Ack()
 				return
 			case TxActionObserve:
 				// Success or tx-in-mempool - continue to observer

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -135,7 +136,12 @@ func StartTxManager(
 	return m, nil
 }
 
-const maxAttempts = 3
+const maxAttempts = 100
+
+func getJitteredDelay(base time.Duration) time.Duration {
+	jitterFactor := 0.7 + rand.Float64()*0.6
+	return time.Duration(float64(base) * jitterFactor)
+}
 
 type txToSend struct {
 	TxInfo      txInfo
@@ -494,7 +500,7 @@ func (m *manager) sendTxs() error {
 		if halt, _ := m.updateChainHalt(); halt {
 			logging.Warn("node paused, delaying tx", types.Messages,
 				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
-			msg.NakWithDelay(defaultSenderNackDelay)
+			msg.NakWithDelay(getJitteredDelay(defaultSenderNackDelay))
 			return
 		}
 
@@ -519,8 +525,9 @@ func (m *manager) sendTxs() error {
 
 		if !tx.RequeueTime.IsZero() {
 			elapsed := time.Since(tx.RequeueTime)
-			if elapsed < defaultSenderNackDelay {
-				msg.NakWithDelay(defaultSenderNackDelay - elapsed)
+			jitteredDelay := getJitteredDelay(defaultSenderNackDelay)
+			if elapsed < jitteredDelay {
+				msg.NakWithDelay(jitteredDelay - elapsed)
 				return
 			}
 		}

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -45,6 +45,9 @@ const (
 
 	defaultSenderNackDelay   = time.Second * 7
 	defaultObserverNackDelay = time.Second * 5
+
+	hashHeader = "TX_HASH"
+	idHeader   = "TX_ID"
 )
 
 type TxManager interface {
@@ -384,7 +387,10 @@ func (m *manager) putOnRetry(
 	if err != nil {
 		return err
 	}
-	_, err = m.natsJetStream.Publish(server.TxsToSendStream, b)
+	msg := &nats.Msg{Subject: server.TxsToSendStream, Data: b, Header: nats.Header{}}
+	msg.Header.Set(idHeader, id)
+	msg.Header.Set(hashHeader, txHash)
+	_, err = m.natsJetStream.PublishMsg(msg)
 	return err
 }
 
@@ -438,7 +444,10 @@ func (m *manager) putBatchOnRetry(
 	if err != nil {
 		return err
 	}
-	_, err = m.natsJetStream.Publish(server.TxsToSendStream, b)
+	msg := &nats.Msg{Subject: server.TxsToSendStream, Data: b, Header: nats.Header{}}
+	msg.Header.Set(idHeader, id)
+	msg.Header.Set(hashHeader, txHash)
+	_, err = m.natsJetStream.PublishMsg(msg)
 	return err
 }
 
@@ -453,17 +462,10 @@ func (m *manager) putInfoToObserve(info txInfo) error {
 	if err != nil {
 		return err
 	}
-	_, err = m.natsJetStream.Publish(server.TxsToObserveStream, b)
-	return err
-}
-
-func (m *manager) republishTxWithDelay(tx txToSend, delay time.Duration) error {
-	time.Sleep(delay)
-	b, err := json.Marshal(&tx)
-	if err != nil {
-		return err
-	}
-	_, err = m.natsJetStream.Publish(server.TxsToSendStream, b)
+	msg := &nats.Msg{Subject: server.TxsToObserveStream, Data: b, Header: nats.Header{}}
+	msg.Header.Set(idHeader, info.Id)
+	msg.Header.Set(hashHeader, info.TxHash)
+	_, err = m.natsJetStream.PublishMsg(msg)
 	return err
 }
 
@@ -476,10 +478,22 @@ func (m *manager) sendTxs() error {
 			time.Sleep(3 * time.Second)
 			return
 		}
+		txId := msg.Header.Get(idHeader)
+		txHash := msg.Header.Get(hashHeader)
+
+		md, err := msg.Metadata()
+		if err == nil {
+			logging.Info("sendTxs metadata", types.Messages, "delivered", md.NumDelivered, "pending", md.NumPending, "id", txId, "hash", txHash)
+			if md.NumDelivered >= maxAttempts {
+				logging.Warn("tx retry max attempts failed", types.Messages, "delivered", md.NumDelivered, "id", txId, "hash", txHash)
+				msg.Term()
+				return
+			}
+		}
 
 		var tx txToSend
 		if err := json.Unmarshal(msg.Data, &tx); err != nil {
-			logging.Error("error unmarshaling tx_to_send", types.Messages, "err", err)
+			logging.Error("error unmarshaling tx_to_send", types.Messages, "err", err, "id", txId, "hash", txHash)
 			msg.Term() // malformed, drop it
 			return
 		}
@@ -490,6 +504,7 @@ func (m *manager) sendTxs() error {
 		if tx.TxInfo.DeadlineBlock > 0 && currentHeight > tx.TxInfo.DeadlineBlock {
 			logging.Warn("tx expired by block deadline, dropping", types.Messages,
 				"id", tx.TxInfo.Id,
+				"hash", tx.TxInfo.TxHash,
 				"deadline", tx.TxInfo.DeadlineBlock,
 				"currentHeight", currentHeight)
 			msg.Term()
@@ -530,17 +545,8 @@ func (m *manager) sendTxs() error {
 			if broadcastErr != nil {
 				// Check if broadcast error is retryable
 				if isRetryableBroadcastError(broadcastErr) {
-					tx.Attempts++
-					if tx.Attempts >= maxAttempts {
-						logging.Warn("tx reached max attempts after broadcast error, dropping", types.Messages, "id", tx.TxInfo.Id, "attempts", tx.Attempts)
-						msg.Term()
-						return
-					}
-					logging.Warn("retryable broadcast error in sendTxs, will retry", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr, "attempts", tx.Attempts)
-					if err := m.republishTxWithDelay(tx, defaultSenderNackDelay); err != nil {
-						logging.Error("failed to republish tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
-					}
-					msg.Ack()
+					logging.Warn("retryable broadcast error in sendTxs, will retry", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr)
+					msg.NakWithDelay(defaultSenderNackDelay)
 					return
 				}
 				// Non-retryable broadcast error - drop permanently
@@ -558,18 +564,9 @@ func (m *manager) sendTxs() error {
 				msg.Term()
 				return
 			case TxActionRetry:
-				tx.Attempts++
-				if tx.Attempts >= maxAttempts {
-					logging.Warn("tx reached max attempts after response error, dropping", types.Messages, "id", tx.TxInfo.Id, "attempts", tx.Attempts)
-					msg.Term()
-					return
-				}
 				logging.Warn("Retryable response error in sendTxs, will retry", types.Messages,
-					"id", tx.TxInfo.Id, "code", resp.Code, "rawLog", resp.RawLog, "attempts", tx.Attempts)
-				if err := m.republishTxWithDelay(tx, defaultSenderNackDelay); err != nil {
-					logging.Error("failed to republish tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
-				}
-				msg.Ack()
+					"id", tx.TxInfo.Id, "code", resp.Code, "rawLog", resp.RawLog)
+				msg.NakWithDelay(defaultSenderNackDelay)
 				return
 			case TxActionObserve:
 				// Success or tx-in-mempool - continue to observer
@@ -684,6 +681,7 @@ func (m *manager) observeTxs() error {
 			}
 		}
 
+		// Likely: The tx is not (yet) found, and the tx hasn't expired
 		msg.NakWithDelay(defaultObserverNackDelay)
 	}, nats.Durable(txObserverConsumer), nats.ManualAck())
 	return err

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -48,9 +48,9 @@ const (
 )
 
 type TxManager interface {
-	SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse, error)
+	SendTransactionAsyncWithRetry(rawTx sdk.Msg, deadlineBlock ...int64) (*sdk.TxResponse, error)
 	SendTransactionAsyncNoRetry(rawTx sdk.Msg) (*sdk.TxResponse, error)
-	SendBatchAsyncWithRetry(msgs []sdk.Msg) error
+	SendBatchAsyncWithRetry(msgs []sdk.Msg, deadlineBlock ...int64) error
 	SendTransactionSyncNoRetry(msg proto.Message) (*ctypes.ResultTx, error)
 	BroadcastMessages(id string, msgs ...sdk.Msg) (*sdk.TxResponse, time.Time, error)
 	GetClientContext() client.Context
@@ -142,12 +142,13 @@ type txToSend struct {
 }
 
 type txInfo struct {
-	Id       string
-	RawTx    []byte
-	RawBatch [][]byte
-	TxHash   string
-	Timeout  time.Time
-	Attempts int
+	Id            string
+	RawTx         []byte
+	RawBatch      [][]byte
+	TxHash        string
+	Timeout       time.Time
+	Attempts      int
+	DeadlineBlock int64 `json:",omitempty"` // Block after which tx is stale
 }
 
 func (t *txInfo) IsBatch() bool {
@@ -162,14 +163,22 @@ func (m *manager) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
 	return m.client.Status(ctx)
 }
 
-func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse, error) {
+func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg, deadlineBlockOpt ...int64) (*sdk.TxResponse, error) {
 	id := uuid.New().String()
 	logging.Debug("SendTransactionAsyncWithRetry: sending tx", types.Messages, "tx_id", id)
+
+	var deadlineBlock int64
+	if len(deadlineBlockOpt) > 0 && deadlineBlockOpt[0] > 0 {
+		deadlineBlock = deadlineBlockOpt[0]
+	} else {
+		msgType := sdk.MsgTypeURL(rawTx)
+		deadlineBlock = m.getLatestBlockHeight() + getMaxBlocksForType(msgType)
+	}
 
 	if halt, err := m.updateChainHalt(); err != nil || halt {
 		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
 
-		if err := m.putOnRetry(id, "", time.Time{}, rawTx, 0, false); err != nil {
+		if err := m.putOnRetry(id, "", time.Time{}, rawTx, 0, false, deadlineBlock); err != nil {
 			logging.Error("failed to put in queue", types.Messages, "tx_id", id, "resend_err", err)
 			return nil, ErrTxFailedToBroadcastAndPutOnRetry
 		}
@@ -180,7 +189,7 @@ func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse,
 	if broadcastErr != nil {
 		// Check if broadcast error is retryable
 		if isRetryableBroadcastError(broadcastErr) {
-			if err := m.putOnRetry(id, "", timeout, rawTx, 1, false); err != nil {
+			if err := m.putOnRetry(id, "", timeout, rawTx, 1, false, deadlineBlock); err != nil {
 				logging.Error("tx failed to broadcast, failed to put in queue", types.Messages, "tx_id", id, "broadcast_err", broadcastErr, "resend_err", err)
 			}
 			return nil, ErrTxFailedToBroadcastAndPutOnRetry
@@ -200,13 +209,13 @@ func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse,
 	case TxActionRetry:
 		logging.Warn("Retryable response error, queuing for retry", types.Messages,
 			"tx_id", id, "code", resp.Code, "rawLog", resp.RawLog)
-		if err := m.putOnRetry(id, "", timeout, rawTx, 1, false); err != nil {
+		if err := m.putOnRetry(id, "", timeout, rawTx, 1, false, deadlineBlock); err != nil {
 			logging.Error("tx failed, failed to put in queue for retry", types.Messages, "tx_id", id, "err", err)
 		}
 		return nil, ErrTxFailedToBroadcastAndPutOnRetry
 	case TxActionObserve:
 		// Success or tx-in-mempool - queue for observation
-		if err := m.putOnRetry(id, resp.TxHash, timeout, rawTx, 1, true); err != nil {
+		if err := m.putOnRetry(id, resp.TxHash, timeout, rawTx, 1, true, deadlineBlock); err != nil {
 			logging.Error("tx broadcast, but failed to put in queue", types.Messages, "tx_id", id, "err", err)
 		}
 		return resp, nil
@@ -217,12 +226,26 @@ func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg) (*sdk.TxResponse,
 	return nil, ErrTxFailedToBroadcastAndPutOnRetry
 }
 
-func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg) error {
+func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg, deadlineBlockOpt ...int64) error {
 	if len(msgs) == 0 {
 		return nil
 	}
+
+	var deadlineBlock int64
+	if len(deadlineBlockOpt) > 0 && deadlineBlockOpt[0] > 0 {
+		deadlineBlock = deadlineBlockOpt[0]
+	} else {
+		var minBlocks int64 = defaultMaxBlocks
+		for _, msg := range msgs {
+			if blocks := getMaxBlocksForType(sdk.MsgTypeURL(msg)); blocks < minBlocks {
+				minBlocks = blocks
+			}
+		}
+		deadlineBlock = m.getLatestBlockHeight() + minBlocks
+	}
+
 	if len(msgs) == 1 {
-		_, err := m.SendTransactionAsyncWithRetry(msgs[0])
+		_, err := m.SendTransactionAsyncWithRetry(msgs[0], deadlineBlock)
 		return err
 	}
 
@@ -232,7 +255,7 @@ func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg) error {
 	if halt, err := m.updateChainHalt(); err != nil || halt {
 		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
 
-		if err := m.putBatchOnRetry(id, msgs, "", time.Time{}, 0, false); err != nil {
+		if err := m.putBatchOnRetry(id, msgs, "", time.Time{}, 0, false, deadlineBlock); err != nil {
 			logging.Error("failed to put batch in queue", types.Messages, "tx_id", id, "resend_err", err)
 			return ErrTxFailedToBroadcastAndPutOnRetry
 		}
@@ -243,7 +266,7 @@ func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg) error {
 	if broadcastErr != nil {
 		// Check if broadcast error is retryable
 		if isRetryableBroadcastError(broadcastErr) {
-			if err := m.putBatchOnRetry(id, msgs, "", timeout, 1, false); err != nil {
+			if err := m.putBatchOnRetry(id, msgs, "", timeout, 1, false, deadlineBlock); err != nil {
 				logging.Error("batch failed to broadcast, failed to put in queue", types.Messages, "tx_id", id, "broadcast_err", broadcastErr, "resend_err", err)
 			}
 			return ErrTxFailedToBroadcastAndPutOnRetry
@@ -263,13 +286,13 @@ func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg) error {
 	case TxActionRetry:
 		logging.Warn("Retryable response error in batch, queuing for retry", types.Messages,
 			"tx_id", id, "code", resp.Code, "rawLog", resp.RawLog)
-		if err := m.putBatchOnRetry(id, msgs, "", timeout, 1, false); err != nil {
+		if err := m.putBatchOnRetry(id, msgs, "", timeout, 1, false, deadlineBlock); err != nil {
 			logging.Error("batch failed, failed to put in queue for retry", types.Messages, "tx_id", id, "err", err)
 		}
 		return ErrTxFailedToBroadcastAndPutOnRetry
 	case TxActionObserve:
 		// Success or tx-in-mempool - queue for observation
-		if err := m.putBatchOnRetry(id, msgs, resp.TxHash, timeout, 1, true); err != nil {
+		if err := m.putBatchOnRetry(id, msgs, resp.TxHash, timeout, 1, true, deadlineBlock); err != nil {
 			logging.Error("batch broadcast, but failed to put in queue", types.Messages, "tx_id", id, "err", err)
 		}
 		return nil
@@ -322,12 +345,15 @@ func (m *manager) putOnRetry(
 	timeout time.Time,
 	rawTx sdk.Msg,
 	attempts int,
-	sent bool) error {
+	sent bool,
+	deadlineBlock int64,
+) error {
 	logging.Debug("putOnRetry: tx with params", types.Messages,
 		"tx_id", id,
 		"tx_hash", txHash,
 		"timeout", timeout.String(),
 		"sent", sent,
+		"deadlineBlock", deadlineBlock,
 	)
 
 	if attempts >= maxAttempts {
@@ -346,10 +372,11 @@ func (m *manager) putOnRetry(
 
 	b, err := json.Marshal(&txToSend{
 		TxInfo: txInfo{
-			Id:      id,
-			RawTx:   bz,
-			TxHash:  txHash,
-			Timeout: timeout,
+			Id:            id,
+			RawTx:         bz,
+			TxHash:        txHash,
+			Timeout:       timeout,
+			DeadlineBlock: deadlineBlock,
 		},
 		Sent:     sent,
 		Attempts: attempts,
@@ -367,14 +394,16 @@ func (m *manager) putBatchOnRetry(
 	txHash string,
 	timeout time.Time,
 	attempts int,
-	sent bool) error {
-
+	sent bool,
+	deadlineBlock int64,
+) error {
 	logging.Debug("putBatchOnRetry: batch with params", types.Messages,
 		"tx_id", id,
 		"tx_hash", txHash,
 		"timeout", timeout.String(),
 		"sent", sent,
 		"count", len(msgs),
+		"deadlineBlock", deadlineBlock,
 	)
 
 	if attempts >= maxAttempts {
@@ -397,10 +426,11 @@ func (m *manager) putBatchOnRetry(
 
 	b, err := json.Marshal(&txToSend{
 		TxInfo: txInfo{
-			Id:       id,
-			RawBatch: rawBatch,
-			TxHash:   txHash,
-			Timeout:  timeout,
+			Id:            id,
+			RawBatch:      rawBatch,
+			TxHash:        txHash,
+			Timeout:       timeout,
+			DeadlineBlock: deadlineBlock,
 		},
 		Sent:     sent,
 		Attempts: attempts,
@@ -445,6 +475,16 @@ func (m *manager) sendTxs() error {
 		}
 
 		logging.Debug("SendTxs: got tx", types.Messages, "id", tx.TxInfo.Id)
+
+		currentHeight := m.getLatestBlockHeight()
+		if tx.TxInfo.DeadlineBlock > 0 && currentHeight > tx.TxInfo.DeadlineBlock {
+			logging.Warn("tx expired by block deadline, dropping", types.Messages,
+				"id", tx.TxInfo.Id,
+				"deadline", tx.TxInfo.DeadlineBlock,
+				"currentHeight", currentHeight)
+			msg.Term()
+			return
+		}
 
 		var resp *sdk.TxResponse
 		var timeout time.Time
@@ -537,6 +577,16 @@ func (m *manager) observeTxs() error {
 			return
 		}
 
+		currentHeight := m.getLatestBlockHeight()
+		if tx.DeadlineBlock > 0 && currentHeight > tx.DeadlineBlock {
+			logging.Warn("tx expired by block deadline in observer, dropping", types.Messages,
+				"id", tx.Id,
+				"deadline", tx.DeadlineBlock,
+				"currentHeight", currentHeight)
+			msg.Term()
+			return
+		}
+
 		var rawTx sdk.Msg
 		var msgs []sdk.Msg
 		var err error
@@ -558,9 +608,9 @@ func (m *manager) observeTxs() error {
 			tx.Attempts++
 			var retryErr error
 			if tx.IsBatch() {
-				retryErr = m.putBatchOnRetry(tx.Id, msgs, "", time.Time{}, tx.Attempts, false)
+				retryErr = m.putBatchOnRetry(tx.Id, msgs, "", time.Time{}, tx.Attempts, false, tx.DeadlineBlock)
 			} else {
-				retryErr = m.putOnRetry(tx.Id, "", time.Time{}, rawTx, tx.Attempts, false)
+				retryErr = m.putOnRetry(tx.Id, "", time.Time{}, rawTx, tx.Attempts, false, tx.DeadlineBlock)
 			}
 
 			if retryErr != nil {
@@ -592,9 +642,9 @@ func (m *manager) observeTxs() error {
 
 				var retryErr error
 				if tx.IsBatch() {
-					retryErr = m.putBatchOnRetry(tx.Id, msgs, "", time.Time{}, tx.Attempts, false)
+					retryErr = m.putBatchOnRetry(tx.Id, msgs, "", time.Time{}, tx.Attempts, false, tx.DeadlineBlock)
 				} else {
-					retryErr = m.putOnRetry(tx.Id, "", time.Time{}, rawTx, tx.Attempts, false)
+					retryErr = m.putOnRetry(tx.Id, "", time.Time{}, rawTx, tx.Attempts, false, tx.DeadlineBlock)
 				}
 
 				if retryErr != nil {
@@ -837,6 +887,12 @@ func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory
 		return nil, time.Time{}, err
 	}
 	return txBytes, timestamp, nil
+}
+
+func (m *manager) getLatestBlockHeight() int64 {
+	m.blockTimeTracker.mtx.Lock()
+	defer m.blockTimeTracker.mtx.Unlock()
+	return m.blockTimeTracker.latestBlockHeight
 }
 
 func (m *manager) updateChainHalt() (bool, error) {

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -133,7 +133,7 @@ func StartTxManager(
 	return m, nil
 }
 
-const maxAttempts = 100
+const maxAttempts = 3
 
 type txToSend struct {
 	TxInfo   txInfo

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager_test.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager_test.go
@@ -1,17 +1,23 @@
 package tx_manager
 
 import (
+	"context"
+	"decentralized-api/internal/nats/server"
 	"encoding/json"
+	"testing"
+	"time"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/google/uuid"
 	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient/mocks"
+	natssrv "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
 	"github.com/productscience/inference/api/inference/inference"
 	testutil "github.com/productscience/inference/testutil/cosmoclient"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPack_Unpack_Msg(t *testing.T) {
@@ -124,4 +130,328 @@ func TestPack_Unpack_Batch(t *testing.T) {
 		assert.Equal(t, msgs[i].InferenceId, result.InferenceId)
 		assert.Equal(t, msgs[i].Model, result.Model)
 	}
+}
+
+// ============================================================================
+// Test helpers for retry logic tests
+// ============================================================================
+
+func startTestNatsServerForTxManager(t *testing.T) (*natssrv.Server, nats.JetStreamContext, *nats.Conn) {
+	opts := &natssrv.Options{
+		Host:      "127.0.0.1",
+		Port:      -1, // random port
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+	}
+
+	ns, err := natssrv.NewServer(opts)
+	require.NoError(t, err)
+
+	go ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second))
+
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+
+	// Create TxsToSendStream
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     server.TxsToSendStream,
+		Subjects: []string{server.TxsToSendStream},
+		Storage:  nats.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	// Create TxsToObserveStream
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     server.TxsToObserveStream,
+		Subjects: []string{server.TxsToObserveStream},
+		Storage:  nats.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		nc.Close()
+		ns.Shutdown()
+	})
+
+	return ns, js, nc
+}
+
+func createTestManager(t *testing.T, js nats.JetStreamContext) *manager {
+	return &manager{
+		ctx:           context.Background(),
+		natsJetStream: js,
+		blockTimeTracker: &blockTimeTracker{
+			latestBlockTime: time.Now(),
+			lastUpdatedAt:   time.Now(),
+			maxBlockTimeout: 10 * time.Second,
+			pauseSending:    false,
+		},
+	}
+}
+
+// ============================================================================
+// Unit tests for requeue helper
+// ============================================================================
+
+func TestRequeue_IncrementsAttemptsAndSetsTime(t *testing.T) {
+	_, js, _ := startTestNatsServerForTxManager(t)
+	m := createTestManager(t, js)
+
+	tx := &txToSend{
+		TxInfo: txInfo{
+			Id: "test-tx-1",
+		},
+		Attempts:    0,
+		RequeueTime: time.Time{}, // zero value
+	}
+
+	beforeRequeue := time.Now()
+	err := m.requeue(tx)
+	afterRequeue := time.Now()
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, tx.Attempts, "Attempts should be incremented")
+	assert.False(t, tx.RequeueTime.IsZero(), "RequeueTime should be set")
+	assert.True(t, tx.RequeueTime.After(beforeRequeue) || tx.RequeueTime.Equal(beforeRequeue),
+		"RequeueTime should be >= beforeRequeue")
+	assert.True(t, tx.RequeueTime.Before(afterRequeue) || tx.RequeueTime.Equal(afterRequeue),
+		"RequeueTime should be <= afterRequeue")
+}
+
+func TestRequeue_MaxAttemptsReturnsNil(t *testing.T) {
+	_, js, _ := startTestNatsServerForTxManager(t)
+	m := createTestManager(t, js)
+
+	tx := &txToSend{
+		TxInfo: txInfo{
+			Id: "test-tx-max",
+		},
+		Attempts: 2, // Will become 3 after requeue, hitting maxAttempts
+	}
+
+	// Get initial stream info
+	streamInfo, err := js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	initialMsgs := streamInfo.State.Msgs
+
+	err = m.requeue(tx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, tx.Attempts, "Attempts should be incremented to 3")
+
+	// Verify no message was published
+	streamInfo, err = js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	assert.Equal(t, initialMsgs, streamInfo.State.Msgs, "No message should be published when max attempts reached")
+}
+
+func TestRequeue_PublishesToSendStream(t *testing.T) {
+	_, js, _ := startTestNatsServerForTxManager(t)
+	m := createTestManager(t, js)
+
+	tx := &txToSend{
+		TxInfo: txInfo{
+			Id:     "test-tx-publish",
+			TxHash: "abc123",
+		},
+		Attempts: 0,
+	}
+
+	// Get initial stream info
+	streamInfo, err := js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	initialMsgs := streamInfo.State.Msgs
+
+	err = m.requeue(tx)
+	require.NoError(t, err)
+
+	// Verify message was published
+	streamInfo, err = js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	assert.Equal(t, initialMsgs+1, streamInfo.State.Msgs, "One message should be published")
+
+	// Verify message content
+	sub, err := js.SubscribeSync(server.TxsToSendStream, nats.DeliverLast())
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	msg, err := sub.NextMsg(time.Second)
+	require.NoError(t, err)
+
+	var receivedTx txToSend
+	err = json.Unmarshal(msg.Data, &receivedTx)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-tx-publish", receivedTx.TxInfo.Id)
+	assert.Equal(t, 1, receivedTx.Attempts)
+	assert.False(t, receivedTx.RequeueTime.IsZero())
+}
+
+// ============================================================================
+// Unit tests for RequeueTime JSON serialization
+// ============================================================================
+
+func TestTxToSend_RequeueTimeSerializes(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond) // JSON loses nanosecond precision
+
+	original := txToSend{
+		TxInfo: txInfo{
+			Id: "serialize-test",
+		},
+		Sent:        false,
+		Attempts:    2,
+		RequeueTime: now,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// Unmarshal back
+	var restored txToSend
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.TxInfo.Id, restored.TxInfo.Id)
+	assert.Equal(t, original.Attempts, restored.Attempts)
+	assert.Equal(t, original.Sent, restored.Sent)
+	// Compare with truncated time since JSON loses some precision
+	assert.True(t, restored.RequeueTime.Sub(original.RequeueTime).Abs() < time.Second,
+		"RequeueTime should be preserved within 1 second precision")
+}
+
+func TestTxToSend_ZeroRequeueTimePreserved(t *testing.T) {
+	tx := txToSend{
+		TxInfo: txInfo{
+			Id: "zero-time-test",
+		},
+		Attempts:    0,
+		RequeueTime: time.Time{}, // zero value
+	}
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	// Unmarshal and verify zero time is preserved
+	var restored txToSend
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+	assert.True(t, restored.RequeueTime.IsZero(), "RequeueTime should remain zero after round-trip")
+}
+
+// ============================================================================
+// Unit tests for delay check logic
+// ============================================================================
+
+func TestDelayCheck_RecentRequeueShouldBeDelayed(t *testing.T) {
+	// Test the logic that checks if a requeued message should be delayed
+	tx := txToSend{
+		TxInfo:      txInfo{Id: "delay-test"},
+		Attempts:    1,
+		RequeueTime: time.Now(), // Just now - should be delayed
+	}
+
+	// Simulate the delay check logic from sendTxs
+	if !tx.RequeueTime.IsZero() {
+		elapsed := time.Since(tx.RequeueTime)
+		shouldDelay := elapsed < defaultSenderNackDelay
+		assert.True(t, shouldDelay, "Recently requeued message should be delayed")
+	}
+}
+
+func TestDelayCheck_OldRequeueProcessedImmediately(t *testing.T) {
+	// Test that old requeued messages are processed immediately
+	tx := txToSend{
+		TxInfo:      txInfo{Id: "old-requeue-test"},
+		Attempts:    1,
+		RequeueTime: time.Now().Add(-10 * time.Second), // 10 seconds ago
+	}
+
+	// Simulate the delay check logic from sendTxs
+	if !tx.RequeueTime.IsZero() {
+		elapsed := time.Since(tx.RequeueTime)
+		shouldDelay := elapsed < defaultSenderNackDelay
+		assert.False(t, shouldDelay, "Old requeued message should be processed immediately")
+	}
+}
+
+func TestDelayCheck_FirstAttemptNoDelay(t *testing.T) {
+	// First attempt has zero RequeueTime - should not delay
+	tx := txToSend{
+		TxInfo:      txInfo{Id: "first-attempt-test"},
+		Attempts:    0,
+		RequeueTime: time.Time{}, // zero - first attempt
+	}
+
+	// Zero RequeueTime means first attempt, should not delay
+	assert.True(t, tx.RequeueTime.IsZero(), "First attempt should have zero RequeueTime")
+}
+
+// ============================================================================
+// Integration test for max attempts terminates
+// ============================================================================
+
+func TestMaxAttemptsCheck(t *testing.T) {
+	// Test the max attempts check logic directly
+	testCases := []struct {
+		name            string
+		attempts        int
+		shouldTerminate bool
+	}{
+		{"attempts 0", 0, false},
+		{"attempts 1", 1, false},
+		{"attempts 2", 2, false},
+		{"attempts 3 (max)", 3, true},
+		{"attempts 4 (over max)", 4, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := txToSend{
+				Attempts: tc.attempts,
+			}
+
+			shouldTerminate := tx.Attempts >= maxAttempts
+			assert.Equal(t, tc.shouldTerminate, shouldTerminate,
+				"Attempts=%d should terminate=%v", tc.attempts, tc.shouldTerminate)
+		})
+	}
+}
+
+func TestRequeueIntegration_MultipleRequeues(t *testing.T) {
+	_, js, _ := startTestNatsServerForTxManager(t)
+	m := createTestManager(t, js)
+
+	tx := &txToSend{
+		TxInfo: txInfo{
+			Id: "multi-requeue-test",
+		},
+		Attempts: 0,
+	}
+
+	// First requeue
+	err := m.requeue(tx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, tx.Attempts)
+	firstRequeueTime := tx.RequeueTime
+
+	// Second requeue
+	time.Sleep(10 * time.Millisecond) // Ensure time difference
+	err = m.requeue(tx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, tx.Attempts)
+	assert.True(t, tx.RequeueTime.After(firstRequeueTime), "RequeueTime should be updated")
+
+	// Third requeue - should hit max attempts
+	err = m.requeue(tx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, tx.Attempts)
+
+	// Verify 2 messages published (third was at max, not published)
+	streamInfo, err := js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), streamInfo.State.Msgs, "Only 2 messages should be published (3rd hit max)")
 }

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager_test.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager_test.go
@@ -230,7 +230,7 @@ func TestRequeue_MaxAttemptsReturnsNil(t *testing.T) {
 		TxInfo: txInfo{
 			Id: "test-tx-max",
 		},
-		Attempts: 2, // Will become 3 after requeue, hitting maxAttempts
+		Attempts: 99, // Will become 100 after requeue, hitting maxAttempts
 	}
 
 	// Get initial stream info
@@ -240,7 +240,7 @@ func TestRequeue_MaxAttemptsReturnsNil(t *testing.T) {
 
 	err = m.requeue(tx)
 	require.NoError(t, err)
-	assert.Equal(t, 3, tx.Attempts, "Attempts should be incremented to 3")
+	assert.Equal(t, 100, tx.Attempts, "Attempts should be incremented to 100")
 
 	// Verify no message was published
 	streamInfo, err = js.StreamInfo(server.TxsToSendStream)
@@ -402,10 +402,10 @@ func TestMaxAttemptsCheck(t *testing.T) {
 		shouldTerminate bool
 	}{
 		{"attempts 0", 0, false},
-		{"attempts 1", 1, false},
-		{"attempts 2", 2, false},
-		{"attempts 3 (max)", 3, true},
-		{"attempts 4 (over max)", 4, true},
+		{"attempts 50", 50, false},
+		{"attempts 99", 99, false},
+		{"attempts 100 (max)", 100, true},
+		{"attempts 101 (over max)", 101, true},
 	}
 
 	for _, tc := range testCases {
@@ -429,26 +429,26 @@ func TestRequeueIntegration_MultipleRequeues(t *testing.T) {
 		TxInfo: txInfo{
 			Id: "multi-requeue-test",
 		},
-		Attempts: 0,
+		Attempts: 97, // Start near max to test boundary
 	}
 
-	// First requeue
+	// First requeue (97 -> 98)
 	err := m.requeue(tx)
 	require.NoError(t, err)
-	assert.Equal(t, 1, tx.Attempts)
+	assert.Equal(t, 98, tx.Attempts)
 	firstRequeueTime := tx.RequeueTime
 
-	// Second requeue
+	// Second requeue (98 -> 99)
 	time.Sleep(10 * time.Millisecond) // Ensure time difference
 	err = m.requeue(tx)
 	require.NoError(t, err)
-	assert.Equal(t, 2, tx.Attempts)
+	assert.Equal(t, 99, tx.Attempts)
 	assert.True(t, tx.RequeueTime.After(firstRequeueTime), "RequeueTime should be updated")
 
-	// Third requeue - should hit max attempts
+	// Third requeue (99 -> 100) - should hit max attempts
 	err = m.requeue(tx)
 	require.NoError(t, err)
-	assert.Equal(t, 3, tx.Attempts)
+	assert.Equal(t, 100, tx.Attempts)
 
 	// Verify 2 messages published (third was at max, not published)
 	streamInfo, err := js.StreamInfo(server.TxsToSendStream)

--- a/decentralized-api/internal/poc/node_orchestrator.go
+++ b/decentralized-api/internal/poc/node_orchestrator.go
@@ -177,6 +177,12 @@ func (o *NodePoCOrchestratorImpl) ValidateReceivedBatches(pocStageStartBlockHeig
 		samplesPerBatch = POC_VALIDATE_SAMPLES_PER_BATCH
 	}
 
+	samplingBlockHash := epochState.CurrentBlock.Hash
+	if samplingBlockHash == "" {
+		logging.Warn("Current block hash unavailable, falling back to PoC start hash", types.PoC)
+		samplingBlockHash = blockHash
+	}
+
 	attemptCounter := 0
 	successfulValidations := 0
 	failedValidations := 0
@@ -214,7 +220,7 @@ func (o *NodePoCOrchestratorImpl) ValidateReceivedBatches(pocStageStartBlockHeig
 			}
 		}
 
-		batchToValidate := joinedBatch.SampleNoncesToValidate(o.pubKey, samplesPerBatch)
+		batchToValidate := joinedBatch.SampleNoncesToValidate(o.pubKey, samplesPerBatch, samplingBlockHash)
 
 		validationSucceeded := false
 		for attempt := range POC_VALIDATE_BATCH_RETRIES {

--- a/decentralized-api/internal/validation/inference_validation.go
+++ b/decentralized-api/internal/validation/inference_validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"bytes"
+	"context"
 	"decentralized-api/apiconfig"
 	"decentralized-api/broker"
 	"decentralized-api/chainphase"
@@ -388,6 +389,12 @@ func (s *InferenceValidator) DetectMissedValidations(epochIndex uint64, seed int
 // This function uses the inference data already obtained and executes validations in parallel goroutines
 // It waits for all validations to complete before returning
 func (s *InferenceValidator) ExecuteRecoveryValidations(missedInferences []types.Inference) (int, error) {
+	// TODO: allow to send validation for previous epoch and then rollback changes
+	// Chain requires validator to be active in CURRENT epoch
+	if !s.isActiveInCurrentEpoch() {
+		logging.Info("Skipping validation recovery: not active participant in current epoch", types.ValidationRecovery)
+		return 0, nil
+	}
 
 	availableModels, err := s.getCurrentSupportedModels()
 	if err != nil {
@@ -644,6 +651,21 @@ func (s *InferenceValidator) isEpochStale(inferenceEpochId uint64) bool {
 		return false // Conservative: continue if state unknown
 	}
 	return epochState.LatestEpoch.EpochIndex >= inferenceEpochId+2
+}
+
+func (s *InferenceValidator) isActiveInCurrentEpoch() bool {
+	queryClient := s.recorder.NewInferenceQueryClient()
+	resp, err := queryClient.CurrentEpochGroupData(context.Background(), &types.QueryCurrentEpochGroupDataRequest{})
+	if err != nil {
+		return false
+	}
+	address := s.recorder.GetAddress()
+	for _, vw := range resp.EpochGroupData.ValidationWeights {
+		if vw.MemberAddress == address {
+			return true
+		}
+	}
+	return false
 }
 
 // isAlreadyValidated checks if this validator already submitted validation for the inference.

--- a/decentralized-api/internal/validation/inference_validation.go
+++ b/decentralized-api/internal/validation/inference_validation.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"sort"
@@ -710,9 +711,10 @@ func (s *InferenceValidator) retrievePayloadsWithRetry(inf types.Inference) ([]b
 			"maxRetries", maxRetries,
 			"error", err)
 
-		// Wait between retries (skip sleep on final attempt since we're done)
+		// Wait between retries with random jitter (skip sleep on final attempt since we're done)
 		if attempt < maxRetries {
-			time.Sleep(retryInterval)
+			jitter := time.Duration(1+rand.Intn(120)) * time.Second
+			time.Sleep(retryInterval + jitter)
 		}
 	}
 

--- a/decentralized-api/mlnodeclient/poc.go
+++ b/decentralized-api/mlnodeclient/poc.go
@@ -189,11 +189,10 @@ type ValidatedBatch struct {
 	FraudDetected     bool      `json:"fraud_detected"`
 }
 
-// This sample doesn't have to be cryptographically secure as it's only used for sampling nonces to validate.
-// If it can't be reproduced on another machine, it's also not causing any harm as it's not validated on-chain.
 func (pb ProofBatch) SampleNoncesToValidate(
 	validatorPublicKey string,
 	nNonces int64,
+	samplingBlockHash string,
 ) ProofBatch {
 	totalNonces := int64(len(pb.Nonces))
 	if nNonces >= totalNonces {
@@ -202,7 +201,7 @@ func (pb ProofBatch) SampleNoncesToValidate(
 
 	nonceIndexes := deterministicSampleIndices(
 		validatorPublicKey,
-		pb.BlockHash,
+		samplingBlockHash,
 		pb.BlockHeight,
 		nNonces,
 		totalNonces,


### PR DESCRIPTION
## feat(tx_manager, validation): improve tx reliability and add block-based deadlines

Overhaul transaction management to prevent wasteful retries, add deadline expiration, and fix validation edge cases for inactive participants.

### Changes

**tx_manager: transaction deadlines**
- Add `DeadlineBlock` field to track when transactions become meaningless
- Configure per-message-type limits: PoC ~240 blocks, inference ~150 blocks
- Drop expired transactions before processing instead of retrying for hours
- Auto-calculate deadline from message type, allow caller override

**tx_manager: error classification**
- Implement three-way response classification (Observe/Retry/Fail)
- Allow-list approach: only transient errors (mempool full, timeout, sequence mismatch) retry
- Business errors (duplicate validation, POC too late, etc.) fail immediately
- Before: 100 retries over 12+ hours; After: instant failure for invalid txs

**tx_manager: retry improvements**
- Replace `NumDelivered` with payload-based `Attempts` tracking
- Add `RequeueTime` field to prevent tight retry loops
- Add jittered delays (±30%) to prevent thundering herd
- Increase max attempts to 100 for transient errors

**validation: skip inactive participants**
- Add `isActiveInCurrentEpoch()` check before recovery validations
- Skip confirmation PoC for non-active participants
- Prevents `ErrParticipantNotFound` errors

**poc: security fix**
- Use fresh block hash for nonce sampling instead of PoC start hash
- Prevents attacker from precomputing sampled nonces

### Files Changed

- `tx_manager/tx_manager.go` - core retry/deadline logic
- `tx_manager/errors.go` - response classification
- `tx_manager/tx_deadline_config.go` - per-message deadlines
- `validation/inference_validation.go` - epoch activity checks
- `event_listener/new_block_dispatcher.go` - PoC skip logic
- `poc/node_orchestrator.go` - fresh hash for sampling

