### PR TITLE
Don't send TX if node is behind

### DIFF
--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -159,7 +159,7 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		}
 	}()
 
-	mn, err := tx_manager.StartTxManager(ctx, &cosmoclient, apiAccount, time.Second*60, natsConn, accAddress)
+	mn, err := tx_manager.StartTxManager(ctx, &cosmoclient, apiAccount, time.Second*60, natsConn, accAddress, config.GetHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -48,6 +48,8 @@ const (
 
 	hashHeader = "TX_HASH"
 	idHeader   = "TX_ID"
+
+	maxBlockTimeDrift = 120 * time.Second
 )
 
 type TxManager interface {
@@ -69,7 +71,7 @@ type blockTimeTracker struct {
 	latestBlockHeight int64
 	lastUpdatedAt     time.Time
 	maxBlockTimeout   time.Duration
-	chainHalt         bool
+	pauseSending      bool
 	mtx               sync.Mutex
 }
 
@@ -474,8 +476,9 @@ func (m *manager) sendTxs() error {
 
 	_, err := m.natsJetStream.Subscribe(server.TxsToSendStream, func(msg *nats.Msg) {
 		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-			time.Sleep(3 * time.Second)
+			logging.Warn("node paused, delaying tx processing", types.Messages,
+				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+			msg.NakWithDelay(5 * time.Second)
 			return
 		}
 		txId := msg.Header.Get(idHeader)
@@ -592,7 +595,10 @@ func (m *manager) observeTxs() error {
 	logging.Info("Tx manager: observeTxs txs: run in background", types.Messages)
 	_, err := m.natsJetStream.Subscribe(server.TxsToObserveStream, func(msg *nats.Msg) {
 		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+			logging.Warn("node paused, delaying tx observation", types.Messages,
+				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+			msg.NakWithDelay(5 * time.Second)
+			return
 		}
 
 		var tx txInfo
@@ -921,11 +927,33 @@ func (m *manager) getLatestBlockHeight() int64 {
 	return m.blockTimeTracker.latestBlockHeight
 }
 
+func (m *manager) isNodeBehind(syncInfo ctypes.SyncInfo) bool {
+	if syncInfo.CatchingUp {
+		logging.Warn("node is catching up", types.Messages,
+			"height", syncInfo.LatestBlockHeight)
+		return true
+	}
+
+	drift := time.Since(syncInfo.LatestBlockTime)
+	if drift > maxBlockTimeDrift {
+		logging.Warn("node block time is stale", types.Messages,
+			"latestBlockTime", syncInfo.LatestBlockTime,
+			"drift", drift)
+		return true
+	}
+
+	return false
+}
+
 func (m *manager) updateChainHalt() (bool, error) {
+	m.blockTimeTracker.mtx.Lock()
 	now := time.Now()
 	if now.Sub(m.blockTimeTracker.lastUpdatedAt) < time.Second*3 {
-		return m.blockTimeTracker.chainHalt, nil
+		result := m.blockTimeTracker.pauseSending
+		m.blockTimeTracker.mtx.Unlock()
+		return result, nil
 	}
+	m.blockTimeTracker.mtx.Unlock()
 
 	status, err := m.client.Status(m.ctx)
 	if err != nil {
@@ -936,20 +964,34 @@ func (m *manager) updateChainHalt() (bool, error) {
 	m.blockTimeTracker.mtx.Lock()
 	defer m.blockTimeTracker.mtx.Unlock()
 
+	// Priority 1: Chain halt detection (chain stopped producing blocks)
 	if status.SyncInfo.LatestBlockTime.Equal(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
 		status.SyncInfo.LatestBlockHeight == m.blockTimeTracker.latestBlockHeight &&
 		!m.blockTimeTracker.lastUpdatedAt.IsZero() && now.Sub(m.blockTimeTracker.lastUpdatedAt) > m.blockTimeTracker.maxBlockTimeout {
-		// same block, and we sow it more than N seconds ago -> chain halt
-		m.blockTimeTracker.chainHalt = true
+		m.blockTimeTracker.pauseSending = true
+		m.blockTimeTracker.lastUpdatedAt = now
+		return true, nil
 	}
 
+	// Priority 2: Node behind (catching up or stale block time)
+	if m.isNodeBehind(status.SyncInfo) {
+		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
+		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
+		m.blockTimeTracker.pauseSending = true
+		m.blockTimeTracker.lastUpdatedAt = now
+		return true, nil
+	}
+
+	// Recovery: passed both checks, safe to send
+	m.blockTimeTracker.pauseSending = false
+
+	// Update tracker if newer block seen
 	if status.SyncInfo.LatestBlockTime.After(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
 		status.SyncInfo.LatestBlockHeight > m.blockTimeTracker.latestBlockHeight {
 		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
 		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
-		m.blockTimeTracker.chainHalt = false
 	}
 
 	m.blockTimeTracker.lastUpdatedAt = now
-	return m.blockTimeTracker.chainHalt, nil
+	return m.blockTimeTracker.pauseSending, nil
 }

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -475,12 +475,17 @@ func (m *manager) sendTxs() error {
 	logging.Info("Tx manager: sending txs: run in background", types.Messages)
 
 	_, err := m.natsJetStream.Subscribe(server.TxsToSendStream, func(msg *nats.Msg) {
-		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Warn("node paused, delaying tx processing", types.Messages,
-				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-			msg.NakWithDelay(5 * time.Second)
-			return
+		for {
+			if halt, err := m.updateChainHalt(); err != nil || halt {
+				logging.Warn("node paused, waiting to process tx", types.Messages,
+					"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+				msg.InProgress()
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			break
 		}
+
 		txId := msg.Header.Get(idHeader)
 		txHash := msg.Header.Get(hashHeader)
 
@@ -594,11 +599,15 @@ func (m *manager) sendTxs() error {
 func (m *manager) observeTxs() error {
 	logging.Info("Tx manager: observeTxs txs: run in background", types.Messages)
 	_, err := m.natsJetStream.Subscribe(server.TxsToObserveStream, func(msg *nats.Msg) {
-		if halt, err := m.updateChainHalt(); err != nil || halt {
-			logging.Warn("node paused, delaying tx observation", types.Messages,
-				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-			msg.NakWithDelay(5 * time.Second)
-			return
+		for {
+			if halt, err := m.updateChainHalt(); err != nil || halt {
+				logging.Warn("node paused, waiting to observe tx", types.Messages,
+					"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+				msg.InProgress()
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			break
 		}
 
 		var tx txInfo

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -67,12 +66,11 @@ type TxManager interface {
 }
 
 type blockTimeTracker struct {
-	latestBlockTime   atomic.Value
-	latestBlockHeight int64
-	lastUpdatedAt     time.Time
-	maxBlockTimeout   time.Duration
-	pauseSending      bool
-	mtx               sync.Mutex
+	latestBlockTime time.Time
+	lastUpdatedAt   time.Time
+	maxBlockTimeout time.Duration
+	pauseSending    bool
+	mtx             sync.Mutex
 }
 
 type manager struct {
@@ -86,6 +84,7 @@ type manager struct {
 	natsConnection   *nats.Conn
 	natsJetStream    nats.JetStreamContext
 	blockTimeTracker *blockTimeTracker
+	getHeightFunc    func() int64
 }
 
 func StartTxManager(
@@ -94,7 +93,8 @@ func StartTxManager(
 	account *apiconfig.ApiAccount,
 	defaultTimeout time.Duration,
 	natsConnection *nats.Conn,
-	address string) (*manager, error) {
+	address string,
+	getHeight func() int64) (*manager, error) {
 	js, err := natsConnection.JetStream()
 	if err != nil {
 		return nil, err
@@ -110,9 +110,6 @@ func StartTxManager(
 	restrictionstypes.RegisterInterfaces(client.Context().InterfaceRegistry)
 	blstypes.RegisterInterfaces(client.Context().InterfaceRegistry)
 
-	ts := atomic.Value{}
-	ts.Store(time.Time{})
-
 	m := &manager{
 		ctx:              ctx,
 		client:           client,
@@ -122,8 +119,8 @@ func StartTxManager(
 		defaultTimeout:   defaultTimeout,
 		natsConnection:   natsConnection,
 		natsJetStream:    js,
+		getHeightFunc:    getHeight,
 		blockTimeTracker: &blockTimeTracker{
-			latestBlockTime: ts,
 			maxBlockTimeout: 10 * time.Second,
 		},
 	}
@@ -141,9 +138,10 @@ func StartTxManager(
 const maxAttempts = 3
 
 type txToSend struct {
-	TxInfo   txInfo
-	Sent     bool
-	Attempts int
+	TxInfo      txInfo
+	Sent        bool
+	Attempts    int
+	RequeueTime time.Time `json:",omitempty"`
 }
 
 type txInfo struct {
@@ -181,7 +179,7 @@ func (m *manager) SendTransactionAsyncWithRetry(rawTx sdk.Msg, deadlineBlockOpt 
 	}
 
 	if halt, err := m.updateChainHalt(); err != nil || halt {
-		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
 
 		if err := m.putOnRetry(id, "", time.Time{}, rawTx, 0, false, deadlineBlock); err != nil {
 			logging.Error("failed to put in queue", types.Messages, "tx_id", id, "resend_err", err)
@@ -258,7 +256,7 @@ func (m *manager) SendBatchAsyncWithRetry(msgs []sdk.Msg, deadlineBlockOpt ...in
 	logging.Debug("SendBatchAsyncWithRetry: sending batch", types.Messages, "tx_id", id, "count", len(msgs))
 
 	if halt, err := m.updateChainHalt(); err != nil || halt {
-		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
+		logging.Error("chain is slowing down or couldn't fetch actual chain status", types.Messages, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
 
 		if err := m.putBatchOnRetry(id, msgs, "", time.Time{}, 0, false, deadlineBlock); err != nil {
 			logging.Error("failed to put batch in queue", types.Messages, "tx_id", id, "resend_err", err)
@@ -471,33 +469,38 @@ func (m *manager) putInfoToObserve(info txInfo) error {
 	return err
 }
 
+func (m *manager) requeue(tx *txToSend) error {
+	tx.Attempts++
+	tx.RequeueTime = time.Now()
+	if tx.Attempts >= maxAttempts {
+		logging.Warn("tx max attempts reached", types.Messages, "id", tx.TxInfo.Id)
+		return nil
+	}
+	b, err := json.Marshal(tx)
+	if err != nil {
+		return err
+	}
+	msg := &nats.Msg{Subject: server.TxsToSendStream, Data: b, Header: nats.Header{}}
+	msg.Header.Set(idHeader, tx.TxInfo.Id)
+	msg.Header.Set(hashHeader, tx.TxInfo.TxHash)
+	_, err = m.natsJetStream.PublishMsg(msg)
+	return err
+}
+
 func (m *manager) sendTxs() error {
 	logging.Info("Tx manager: sending txs: run in background", types.Messages)
 
 	_, err := m.natsJetStream.Subscribe(server.TxsToSendStream, func(msg *nats.Msg) {
-		for {
-			if halt, err := m.updateChainHalt(); err != nil || halt {
-				logging.Warn("node paused, waiting to process tx", types.Messages,
-					"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-				msg.InProgress()
-				time.Sleep(5 * time.Second)
-				continue
-			}
-			break
+		if halt, _ := m.updateChainHalt(); halt {
+			logging.Warn("node paused, delaying tx", types.Messages,
+				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
+			msg.NakWithDelay(defaultSenderNackDelay)
+			return
 		}
 
 		txId := msg.Header.Get(idHeader)
 		txHash := msg.Header.Get(hashHeader)
-
-		md, err := msg.Metadata()
-		if err == nil {
-			logging.Info("sendTxs metadata", types.Messages, "delivered", md.NumDelivered, "pending", md.NumPending, "id", txId, "hash", txHash)
-			if md.NumDelivered >= maxAttempts {
-				logging.Warn("tx retry max attempts failed", types.Messages, "delivered", md.NumDelivered, "id", txId, "hash", txHash)
-				msg.Term()
-				return
-			}
-		}
+		logging.Debug("sendTxs processing", types.Messages, "id", txId, "hash", txHash)
 
 		var tx txToSend
 		if err := json.Unmarshal(msg.Data, &tx); err != nil {
@@ -506,7 +509,21 @@ func (m *manager) sendTxs() error {
 			return
 		}
 
-		logging.Debug("SendTxs: got tx", types.Messages, "id", tx.TxInfo.Id)
+		logging.Debug("SendTxs: got tx", types.Messages, "id", tx.TxInfo.Id, "attempts", tx.Attempts)
+
+		if tx.Attempts >= maxAttempts {
+			logging.Warn("tx max attempts reached", types.Messages, "id", tx.TxInfo.Id)
+			msg.Term()
+			return
+		}
+
+		if !tx.RequeueTime.IsZero() {
+			elapsed := time.Since(tx.RequeueTime)
+			if elapsed < defaultSenderNackDelay {
+				msg.NakWithDelay(defaultSenderNackDelay - elapsed)
+				return
+			}
+		}
 
 		currentHeight := m.getLatestBlockHeight()
 		if tx.TxInfo.DeadlineBlock > 0 && currentHeight > tx.TxInfo.DeadlineBlock {
@@ -553,8 +570,11 @@ func (m *manager) sendTxs() error {
 			if broadcastErr != nil {
 				// Check if broadcast error is retryable
 				if isRetryableBroadcastError(broadcastErr) {
-					logging.Warn("retryable broadcast error in sendTxs, will retry", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr)
-					msg.NakWithDelay(defaultSenderNackDelay)
+					logging.Warn("retryable broadcast error, requeuing", types.Messages, "id", tx.TxInfo.Id, "err", broadcastErr)
+					if err := m.requeue(&tx); err != nil {
+						logging.Error("requeue failed, dropping tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
+					}
+					msg.Ack()
 					return
 				}
 				// Non-retryable broadcast error - drop permanently
@@ -572,9 +592,12 @@ func (m *manager) sendTxs() error {
 				msg.Term()
 				return
 			case TxActionRetry:
-				logging.Warn("Retryable response error in sendTxs, will retry", types.Messages,
+				logging.Warn("Retryable response error, requeuing", types.Messages,
 					"id", tx.TxInfo.Id, "code", resp.Code, "rawLog", resp.RawLog)
-				msg.NakWithDelay(defaultSenderNackDelay)
+				if err := m.requeue(&tx); err != nil {
+					logging.Error("requeue failed, dropping tx", types.Messages, "id", tx.TxInfo.Id, "err", err)
+				}
+				msg.Ack()
 				return
 			case TxActionObserve:
 				// Success or tx-in-mempool - continue to observer
@@ -587,11 +610,10 @@ func (m *manager) sendTxs() error {
 		logging.Debug("tx broadcast, put to observe", types.Messages, "id", tx.TxInfo.Id, "tx_hash", tx.TxInfo.TxHash, "timeout", tx.TxInfo.Timeout.String())
 
 		if err := m.putInfoToObserve(tx.TxInfo); err != nil {
-			logging.Error("error pushing to observe queue", types.Messages, "id", tx.TxInfo.Id, "err", err)
-			msg.NakWithDelay(defaultSenderNackDelay)
-		} else {
-			msg.Ack()
+			logging.Error("error pushing to observe queue, tx broadcast but untracked",
+				types.Messages, "id", tx.TxInfo.Id, "txHash", tx.TxInfo.TxHash, "err", err)
 		}
+		msg.Ack()
 	}, nats.Durable(txSenderConsumer), nats.ManualAck())
 	return err
 }
@@ -599,15 +621,11 @@ func (m *manager) sendTxs() error {
 func (m *manager) observeTxs() error {
 	logging.Info("Tx manager: observeTxs txs: run in background", types.Messages)
 	_, err := m.natsJetStream.Subscribe(server.TxsToObserveStream, func(msg *nats.Msg) {
-		for {
-			if halt, err := m.updateChainHalt(); err != nil || halt {
-				logging.Warn("node paused, waiting to observe tx", types.Messages,
-					"latest_block_timestamp", m.blockTimeTracker.latestBlockTime.Load().(time.Time))
-				msg.InProgress()
-				time.Sleep(5 * time.Second)
-				continue
-			}
-			break
+		if halt, _ := m.updateChainHalt(); halt {
+			logging.Warn("node paused, delaying observe", types.Messages,
+				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
+			msg.NakWithDelay(defaultObserverNackDelay)
+			return
 		}
 
 		var tx txInfo
@@ -676,7 +694,7 @@ func (m *manager) observeTxs() error {
 		}
 
 		if errors.Is(err, ErrTxNotFound) {
-			if m.blockTimeTracker.latestBlockTime.Load().(time.Time).After(tx.Timeout) {
+			if m.blockTimeTracker.latestBlockTime.After(tx.Timeout) {
 				logging.Debug("tx expired", types.Messages, "tx_id", tx.Id, "tx_hash", tx.TxHash, "tx_timestamp", tx.Timeout, "latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
 				tx.Attempts++
 
@@ -898,13 +916,13 @@ func (m *manager) getFactory(id string) (*tx.Factory, error) {
 }
 
 func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory *tx.Factory) ([]byte, time.Time, error) {
-	blockTs := m.blockTimeTracker.latestBlockTime.Load().(time.Time)
+	blockTs := m.blockTimeTracker.latestBlockTime
 	if blockTs.IsZero() {
 		_, err := m.updateChainHalt()
 		if err != nil {
 			return nil, time.Time{}, err
 		}
-		blockTs = m.blockTimeTracker.latestBlockTime.Load().(time.Time)
+		blockTs = m.blockTimeTracker.latestBlockTime
 	}
 
 	timestamp := getTimestamp(blockTs.UnixNano(), m.defaultTimeout)
@@ -931,9 +949,7 @@ func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory
 }
 
 func (m *manager) getLatestBlockHeight() int64 {
-	m.blockTimeTracker.mtx.Lock()
-	defer m.blockTimeTracker.mtx.Unlock()
-	return m.blockTimeTracker.latestBlockHeight
+	return m.getHeightFunc()
 }
 
 func (m *manager) isNodeBehind(syncInfo ctypes.SyncInfo) bool {
@@ -974,8 +990,7 @@ func (m *manager) updateChainHalt() (bool, error) {
 	defer m.blockTimeTracker.mtx.Unlock()
 
 	// Priority 1: Chain halt detection (chain stopped producing blocks)
-	if status.SyncInfo.LatestBlockTime.Equal(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
-		status.SyncInfo.LatestBlockHeight == m.blockTimeTracker.latestBlockHeight &&
+	if status.SyncInfo.LatestBlockTime.Equal(m.blockTimeTracker.latestBlockTime) &&
 		!m.blockTimeTracker.lastUpdatedAt.IsZero() && now.Sub(m.blockTimeTracker.lastUpdatedAt) > m.blockTimeTracker.maxBlockTimeout {
 		m.blockTimeTracker.pauseSending = true
 		m.blockTimeTracker.lastUpdatedAt = now
@@ -984,8 +999,7 @@ func (m *manager) updateChainHalt() (bool, error) {
 
 	// Priority 2: Node behind (catching up or stale block time)
 	if m.isNodeBehind(status.SyncInfo) {
-		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
-		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
+		m.blockTimeTracker.latestBlockTime = status.SyncInfo.LatestBlockTime
 		m.blockTimeTracker.pauseSending = true
 		m.blockTimeTracker.lastUpdatedAt = now
 		return true, nil
@@ -994,11 +1008,9 @@ func (m *manager) updateChainHalt() (bool, error) {
 	// Recovery: passed both checks, safe to send
 	m.blockTimeTracker.pauseSending = false
 
-	// Update tracker if newer block seen
-	if status.SyncInfo.LatestBlockTime.After(m.blockTimeTracker.latestBlockTime.Load().(time.Time)) &&
-		status.SyncInfo.LatestBlockHeight > m.blockTimeTracker.latestBlockHeight {
-		m.blockTimeTracker.latestBlockHeight = status.SyncInfo.LatestBlockHeight
-		m.blockTimeTracker.latestBlockTime.Store(status.SyncInfo.LatestBlockTime)
+	// Update block time for halt detection
+	if status.SyncInfo.LatestBlockTime.After(m.blockTimeTracker.latestBlockTime) {
+		m.blockTimeTracker.latestBlockTime = status.SyncInfo.LatestBlockTime
 	}
 
 	m.blockTimeTracker.lastUpdatedAt = now

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -135,7 +136,12 @@ func StartTxManager(
 	return m, nil
 }
 
-const maxAttempts = 3
+const maxAttempts = 100
+
+func getJitteredDelay(base time.Duration) time.Duration {
+	jitterFactor := 0.7 + rand.Float64()*0.6
+	return time.Duration(float64(base) * jitterFactor)
+}
 
 type txToSend struct {
 	TxInfo      txInfo
@@ -494,7 +500,7 @@ func (m *manager) sendTxs() error {
 		if halt, _ := m.updateChainHalt(); halt {
 			logging.Warn("node paused, delaying tx", types.Messages,
 				"latest_block_timestamp", m.blockTimeTracker.latestBlockTime)
-			msg.NakWithDelay(defaultSenderNackDelay)
+			msg.NakWithDelay(getJitteredDelay(defaultSenderNackDelay))
 			return
 		}
 
@@ -519,8 +525,9 @@ func (m *manager) sendTxs() error {
 
 		if !tx.RequeueTime.IsZero() {
 			elapsed := time.Since(tx.RequeueTime)
-			if elapsed < defaultSenderNackDelay {
-				msg.NakWithDelay(defaultSenderNackDelay - elapsed)
+			jitteredDelay := getJitteredDelay(defaultSenderNackDelay)
+			if elapsed < jitteredDelay {
+				msg.NakWithDelay(jitteredDelay - elapsed)
 				return
 			}
 		}

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager_test.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager_test.go
@@ -1,17 +1,23 @@
 package tx_manager
 
 import (
+	"context"
+	"decentralized-api/internal/nats/server"
 	"encoding/json"
+	"testing"
+	"time"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/google/uuid"
 	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient/mocks"
+	natssrv "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
 	"github.com/productscience/inference/api/inference/inference"
 	testutil "github.com/productscience/inference/testutil/cosmoclient"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPack_Unpack_Msg(t *testing.T) {
@@ -124,4 +130,328 @@ func TestPack_Unpack_Batch(t *testing.T) {
 		assert.Equal(t, msgs[i].InferenceId, result.InferenceId)
 		assert.Equal(t, msgs[i].Model, result.Model)
 	}
+}
+
+// ============================================================================
+// Test helpers for retry logic tests
+// ============================================================================
+
+func startTestNatsServerForTxManager(t *testing.T) (*natssrv.Server, nats.JetStreamContext, *nats.Conn) {
+	opts := &natssrv.Options{
+		Host:      "127.0.0.1",
+		Port:      -1, // random port
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+	}
+
+	ns, err := natssrv.NewServer(opts)
+	require.NoError(t, err)
+
+	go ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second))
+
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+
+	// Create TxsToSendStream
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     server.TxsToSendStream,
+		Subjects: []string{server.TxsToSendStream},
+		Storage:  nats.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	// Create TxsToObserveStream
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     server.TxsToObserveStream,
+		Subjects: []string{server.TxsToObserveStream},
+		Storage:  nats.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		nc.Close()
+		ns.Shutdown()
+	})
+
+	return ns, js, nc
+}
+
+func createTestManager(t *testing.T, js nats.JetStreamContext) *manager {
+	return &manager{
+		ctx:           context.Background(),
+		natsJetStream: js,
+		blockTimeTracker: &blockTimeTracker{
+			latestBlockTime: time.Now(),
+			lastUpdatedAt:   time.Now(),
+			maxBlockTimeout: 10 * time.Second,
+			pauseSending:    false,
+		},
+	}
+}
+
+// ============================================================================
+// Unit tests for requeue helper
+// ============================================================================
+
+func TestRequeue_IncrementsAttemptsAndSetsTime(t *testing.T) {
+	_, js, _ := startTestNatsServerForTxManager(t)
+	m := createTestManager(t, js)
+
+	tx := &txToSend{
+		TxInfo: txInfo{
+			Id: "test-tx-1",
+		},
+		Attempts:    0,
+		RequeueTime: time.Time{}, // zero value
+	}
+
+	beforeRequeue := time.Now()
+	err := m.requeue(tx)
+	afterRequeue := time.Now()
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, tx.Attempts, "Attempts should be incremented")
+	assert.False(t, tx.RequeueTime.IsZero(), "RequeueTime should be set")
+	assert.True(t, tx.RequeueTime.After(beforeRequeue) || tx.RequeueTime.Equal(beforeRequeue),
+		"RequeueTime should be >= beforeRequeue")
+	assert.True(t, tx.RequeueTime.Before(afterRequeue) || tx.RequeueTime.Equal(afterRequeue),
+		"RequeueTime should be <= afterRequeue")
+}
+
+func TestRequeue_MaxAttemptsReturnsNil(t *testing.T) {
+	_, js, _ := startTestNatsServerForTxManager(t)
+	m := createTestManager(t, js)
+
+	tx := &txToSend{
+		TxInfo: txInfo{
+			Id: "test-tx-max",
+		},
+		Attempts: 2, // Will become 3 after requeue, hitting maxAttempts
+	}
+
+	// Get initial stream info
+	streamInfo, err := js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	initialMsgs := streamInfo.State.Msgs
+
+	err = m.requeue(tx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, tx.Attempts, "Attempts should be incremented to 3")
+
+	// Verify no message was published
+	streamInfo, err = js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	assert.Equal(t, initialMsgs, streamInfo.State.Msgs, "No message should be published when max attempts reached")
+}
+
+func TestRequeue_PublishesToSendStream(t *testing.T) {
+	_, js, _ := startTestNatsServerForTxManager(t)
+	m := createTestManager(t, js)
+
+	tx := &txToSend{
+		TxInfo: txInfo{
+			Id:     "test-tx-publish",
+			TxHash: "abc123",
+		},
+		Attempts: 0,
+	}
+
+	// Get initial stream info
+	streamInfo, err := js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	initialMsgs := streamInfo.State.Msgs
+
+	err = m.requeue(tx)
+	require.NoError(t, err)
+
+	// Verify message was published
+	streamInfo, err = js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	assert.Equal(t, initialMsgs+1, streamInfo.State.Msgs, "One message should be published")
+
+	// Verify message content
+	sub, err := js.SubscribeSync(server.TxsToSendStream, nats.DeliverLast())
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	msg, err := sub.NextMsg(time.Second)
+	require.NoError(t, err)
+
+	var receivedTx txToSend
+	err = json.Unmarshal(msg.Data, &receivedTx)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-tx-publish", receivedTx.TxInfo.Id)
+	assert.Equal(t, 1, receivedTx.Attempts)
+	assert.False(t, receivedTx.RequeueTime.IsZero())
+}
+
+// ============================================================================
+// Unit tests for RequeueTime JSON serialization
+// ============================================================================
+
+func TestTxToSend_RequeueTimeSerializes(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond) // JSON loses nanosecond precision
+
+	original := txToSend{
+		TxInfo: txInfo{
+			Id: "serialize-test",
+		},
+		Sent:        false,
+		Attempts:    2,
+		RequeueTime: now,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// Unmarshal back
+	var restored txToSend
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.TxInfo.Id, restored.TxInfo.Id)
+	assert.Equal(t, original.Attempts, restored.Attempts)
+	assert.Equal(t, original.Sent, restored.Sent)
+	// Compare with truncated time since JSON loses some precision
+	assert.True(t, restored.RequeueTime.Sub(original.RequeueTime).Abs() < time.Second,
+		"RequeueTime should be preserved within 1 second precision")
+}
+
+func TestTxToSend_ZeroRequeueTimePreserved(t *testing.T) {
+	tx := txToSend{
+		TxInfo: txInfo{
+			Id: "zero-time-test",
+		},
+		Attempts:    0,
+		RequeueTime: time.Time{}, // zero value
+	}
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	// Unmarshal and verify zero time is preserved
+	var restored txToSend
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+	assert.True(t, restored.RequeueTime.IsZero(), "RequeueTime should remain zero after round-trip")
+}
+
+// ============================================================================
+// Unit tests for delay check logic
+// ============================================================================
+
+func TestDelayCheck_RecentRequeueShouldBeDelayed(t *testing.T) {
+	// Test the logic that checks if a requeued message should be delayed
+	tx := txToSend{
+		TxInfo:      txInfo{Id: "delay-test"},
+		Attempts:    1,
+		RequeueTime: time.Now(), // Just now - should be delayed
+	}
+
+	// Simulate the delay check logic from sendTxs
+	if !tx.RequeueTime.IsZero() {
+		elapsed := time.Since(tx.RequeueTime)
+		shouldDelay := elapsed < defaultSenderNackDelay
+		assert.True(t, shouldDelay, "Recently requeued message should be delayed")
+	}
+}
+
+func TestDelayCheck_OldRequeueProcessedImmediately(t *testing.T) {
+	// Test that old requeued messages are processed immediately
+	tx := txToSend{
+		TxInfo:      txInfo{Id: "old-requeue-test"},
+		Attempts:    1,
+		RequeueTime: time.Now().Add(-10 * time.Second), // 10 seconds ago
+	}
+
+	// Simulate the delay check logic from sendTxs
+	if !tx.RequeueTime.IsZero() {
+		elapsed := time.Since(tx.RequeueTime)
+		shouldDelay := elapsed < defaultSenderNackDelay
+		assert.False(t, shouldDelay, "Old requeued message should be processed immediately")
+	}
+}
+
+func TestDelayCheck_FirstAttemptNoDelay(t *testing.T) {
+	// First attempt has zero RequeueTime - should not delay
+	tx := txToSend{
+		TxInfo:      txInfo{Id: "first-attempt-test"},
+		Attempts:    0,
+		RequeueTime: time.Time{}, // zero - first attempt
+	}
+
+	// Zero RequeueTime means first attempt, should not delay
+	assert.True(t, tx.RequeueTime.IsZero(), "First attempt should have zero RequeueTime")
+}
+
+// ============================================================================
+// Integration test for max attempts terminates
+// ============================================================================
+
+func TestMaxAttemptsCheck(t *testing.T) {
+	// Test the max attempts check logic directly
+	testCases := []struct {
+		name            string
+		attempts        int
+		shouldTerminate bool
+	}{
+		{"attempts 0", 0, false},
+		{"attempts 1", 1, false},
+		{"attempts 2", 2, false},
+		{"attempts 3 (max)", 3, true},
+		{"attempts 4 (over max)", 4, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := txToSend{
+				Attempts: tc.attempts,
+			}
+
+			shouldTerminate := tx.Attempts >= maxAttempts
+			assert.Equal(t, tc.shouldTerminate, shouldTerminate,
+				"Attempts=%d should terminate=%v", tc.attempts, tc.shouldTerminate)
+		})
+	}
+}
+
+func TestRequeueIntegration_MultipleRequeues(t *testing.T) {
+	_, js, _ := startTestNatsServerForTxManager(t)
+	m := createTestManager(t, js)
+
+	tx := &txToSend{
+		TxInfo: txInfo{
+			Id: "multi-requeue-test",
+		},
+		Attempts: 0,
+	}
+
+	// First requeue
+	err := m.requeue(tx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, tx.Attempts)
+	firstRequeueTime := tx.RequeueTime
+
+	// Second requeue
+	time.Sleep(10 * time.Millisecond) // Ensure time difference
+	err = m.requeue(tx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, tx.Attempts)
+	assert.True(t, tx.RequeueTime.After(firstRequeueTime), "RequeueTime should be updated")
+
+	// Third requeue - should hit max attempts
+	err = m.requeue(tx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, tx.Attempts)
+
+	// Verify 2 messages published (third was at max, not published)
+	streamInfo, err := js.StreamInfo(server.TxsToSendStream)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), streamInfo.State.Msgs, "Only 2 messages should be published (3rd hit max)")
 }

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager_test.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager_test.go
@@ -230,7 +230,7 @@ func TestRequeue_MaxAttemptsReturnsNil(t *testing.T) {
 		TxInfo: txInfo{
 			Id: "test-tx-max",
 		},
-		Attempts: 2, // Will become 3 after requeue, hitting maxAttempts
+		Attempts: 99, // Will become 100 after requeue, hitting maxAttempts
 	}
 
 	// Get initial stream info
@@ -240,7 +240,7 @@ func TestRequeue_MaxAttemptsReturnsNil(t *testing.T) {
 
 	err = m.requeue(tx)
 	require.NoError(t, err)
-	assert.Equal(t, 3, tx.Attempts, "Attempts should be incremented to 3")
+	assert.Equal(t, 100, tx.Attempts, "Attempts should be incremented to 100")
 
 	// Verify no message was published
 	streamInfo, err = js.StreamInfo(server.TxsToSendStream)
@@ -402,10 +402,10 @@ func TestMaxAttemptsCheck(t *testing.T) {
 		shouldTerminate bool
 	}{
 		{"attempts 0", 0, false},
-		{"attempts 1", 1, false},
-		{"attempts 2", 2, false},
-		{"attempts 3 (max)", 3, true},
-		{"attempts 4 (over max)", 4, true},
+		{"attempts 50", 50, false},
+		{"attempts 99", 99, false},
+		{"attempts 100 (max)", 100, true},
+		{"attempts 101 (over max)", 101, true},
 	}
 
 	for _, tc := range testCases {
@@ -429,26 +429,26 @@ func TestRequeueIntegration_MultipleRequeues(t *testing.T) {
 		TxInfo: txInfo{
 			Id: "multi-requeue-test",
 		},
-		Attempts: 0,
+		Attempts: 97, // Start near max to test boundary
 	}
 
-	// First requeue
+	// First requeue (97 -> 98)
 	err := m.requeue(tx)
 	require.NoError(t, err)
-	assert.Equal(t, 1, tx.Attempts)
+	assert.Equal(t, 98, tx.Attempts)
 	firstRequeueTime := tx.RequeueTime
 
-	// Second requeue
+	// Second requeue (98 -> 99)
 	time.Sleep(10 * time.Millisecond) // Ensure time difference
 	err = m.requeue(tx)
 	require.NoError(t, err)
-	assert.Equal(t, 2, tx.Attempts)
+	assert.Equal(t, 99, tx.Attempts)
 	assert.True(t, tx.RequeueTime.After(firstRequeueTime), "RequeueTime should be updated")
 
-	// Third requeue - should hit max attempts
+	// Third requeue (99 -> 100) - should hit max attempts
 	err = m.requeue(tx)
 	require.NoError(t, err)
-	assert.Equal(t, 3, tx.Attempts)
+	assert.Equal(t, 100, tx.Attempts)
 
 	// Verify 2 messages published (third was at max, not published)
 	streamInfo, err := js.StreamInfo(server.TxsToSendStream)

--- a/decentralized-api/internal/validation/inference_validation.go
+++ b/decentralized-api/internal/validation/inference_validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"bytes"
+	"context"
 	"decentralized-api/apiconfig"
 	"decentralized-api/broker"
 	"decentralized-api/chainphase"
@@ -388,6 +389,12 @@ func (s *InferenceValidator) DetectMissedValidations(epochIndex uint64, seed int
 // This function uses the inference data already obtained and executes validations in parallel goroutines
 // It waits for all validations to complete before returning
 func (s *InferenceValidator) ExecuteRecoveryValidations(missedInferences []types.Inference) (int, error) {
+	// TODO: allow to send validation for previous epoch and then rollback changes
+	// Chain requires validator to be active in CURRENT epoch
+	if !s.isActiveInCurrentEpoch() {
+		logging.Info("Skipping validation recovery: not active participant in current epoch", types.ValidationRecovery)
+		return 0, nil
+	}
 
 	availableModels, err := s.getCurrentSupportedModels()
 	if err != nil {
@@ -644,6 +651,21 @@ func (s *InferenceValidator) isEpochStale(inferenceEpochId uint64) bool {
 		return false // Conservative: continue if state unknown
 	}
 	return epochState.LatestEpoch.EpochIndex >= inferenceEpochId+2
+}
+
+func (s *InferenceValidator) isActiveInCurrentEpoch() bool {
+	queryClient := s.recorder.NewInferenceQueryClient()
+	resp, err := queryClient.CurrentEpochGroupData(context.Background(), &types.QueryCurrentEpochGroupDataRequest{})
+	if err != nil {
+		return false
+	}
+	address := s.recorder.GetAddress()
+	for _, vw := range resp.EpochGroupData.ValidationWeights {
+		if vw.MemberAddress == address {
+			return true
+		}
+	}
+	return false
 }
 
 // isAlreadyValidated checks if this validator already submitted validation for the inference.


### PR DESCRIPTION
feat(tx_manager): add node sync detection to pause sending when node is behind

Detect when node is catching up or has stale block time and pause tx
processing until node recovers. Prevents wasteful retries from outdated
block heights.

Changes:
- Add maxBlockTimeDrift constant (120s) for stale block detection
- Rename chainHalt to pauseSending for clarity
- Add isNodeBehind() helper to check CatchingUp flag and block time drift
- Fix race condition: acquire mutex before reading rate limit fields
- Refactor updateChainHalt() with priority-based pause logic:
  - Priority 1: Chain halt (same block > 10s)
  - Priority 2: Node behind (catching up or stale block time)
  - Recovery: unpause when both checks pass
- Replace sleep+return with loop+InProgress+sleep in sendTxs/observeTxs
  to avoid incrementing NumDelivered while waiting for node recovery

