### PR TITLE
governance-owned leftovers (settle + bitcoin rewards)

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -67,6 +67,10 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Set up Gradle (with caching)
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
       # This step uses Gradle tasks to scan for test classes that will actually run tests after filtering
       # The tasks properly handle both class-level and method-level tags:
       # 1. Classes with @Tag("exclude") or @Tag("unstable") at the class level are completely excluded
@@ -143,6 +147,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '19'
+
+      - name: Set up Gradle (with caching)
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
 
       - name: Make Docker Images
         env:
@@ -236,6 +245,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '19'
+
+      - name: Set up Gradle (with caching)
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
 
       - name: Download Upgrade Build Files
         if: ${{ inputs.enable_upgrades }}

--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/productscience/inference/x/inference/calculations"
 	"github.com/productscience/inference/x/inference/types"
 
@@ -191,6 +192,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 	}
 	var amounts []*SettleResult
 	var rewardAmount int64
+	var governanceRewardAmount int64
 	settleParameters, err := k.GetSettleParameters(ctx)
 	if err != nil {
 		k.LogError("Error getting settle parameters", types.Settle, "error", err)
@@ -217,6 +219,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 		}
 		k.LogInfo("Bitcoin reward amount", types.Settle, "amount", bitcoinResult.Amount)
 		rewardAmount = bitcoinResult.Amount
+		governanceRewardAmount = bitcoinResult.GovernanceAmount
 	} else {
 		// Use current WorkCoins-based variable reward system with its own parameters
 		k.LogInfo("Using current WorkCoins-based reward system", types.Settle)
@@ -247,6 +250,21 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 		return err
 	}
 	k.AddTokenomicsData(ctx, &types.TokenomicsData{TotalSubsidies: uint64(rewardAmount)})
+
+	// In Bitcoin reward system, any undistributed rewards (e.g. downtime punishments or rounding)
+	// are transferred to governance instead of being redistributed to other participants.
+	if params.BitcoinRewardParams.UseBitcoinRewards && governanceRewardAmount > 0 {
+		coins, err := types.GetCoins(governanceRewardAmount)
+		if err != nil {
+			return err
+		}
+		memo := fmt.Sprintf("bitcoin_reward_to_governance:epoch=%d", currentEpochIndex)
+		if err := k.BankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, govtypes.ModuleName, coins, memo); err != nil {
+			k.LogError("Error transferring undistributed bitcoin rewards to governance", types.Settle, "error", err, "amount", governanceRewardAmount)
+			return err
+		}
+		k.LogInfo("Transferred undistributed bitcoin rewards to governance", types.Settle, "amount", governanceRewardAmount)
+	}
 
 	k.LogInfo("Checking downtime for participants", types.Settle, "participants", len(allParticipants))
 

--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -320,15 +320,15 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 
 		amount.Settle.EpochIndex = currentEpochIndex
 		k.LogInfo("Settle for participant", types.Settle, "rewardCoins", amount.Settle.RewardCoins, "workCoins", amount.Settle.WorkCoins, "address", amount.Settle.Participant)
-		k.SetSettleAmountWithBurn(ctx, *amount.Settle)
+		k.SetSettleAmountWithGovernanceTransfer(ctx, *amount.Settle)
 	}
 
 	if previousEpochIndex == 0 {
 		return nil
 	}
 
-	k.LogInfo("Burning old settle amounts", types.Settle, "previousEpochIndex", previousEpochIndex)
-	err = k.BurnOldSettleAmounts(ctx, previousEpochIndex)
+	k.LogInfo("Transferring old settle amounts", types.Settle, "previousEpochIndex", previousEpochIndex)
+	err = k.TransferOldSettleAmountsToGovernance(ctx, previousEpochIndex)
 	if err != nil {
 		k.LogError("Error burning old settle amounts", types.Settle, "error", err)
 	}

--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -92,12 +92,27 @@ func GetBitcoinSettleAmounts(
 			// Any remainder due to integer division truncation (or downtime punishments already
 			// baked into settleResults) should go to governance.
 			remainder := uint64(bitcoinResult.Amount) - totalDistributed
-			bitcoinResult.GovernanceAmount = int64(remainder)
+			if uint64(bitcoinResult.Amount) < totalDistributed {
+				remainder = 0
+			}
+
+			bitcoinResult.GovernanceAmount = saturatingAddUint64Max(bitcoinResult.GovernanceAmount, remainder)
 		}
 	}
 	// If under cap, no adjustment needed - use full amount
 
 	return settleResults, bitcoinResult, err
+}
+
+func saturatingAddUint64Max(a int64, b uint64) int64 {
+	if a >= math.MaxInt64 {
+		return math.MaxInt64
+	}
+	headroom := uint64(math.MaxInt64 - a) // safe because a >= 0
+	if b >= headroom {
+		return math.MaxInt64
+	}
+	return a + int64(b) // safe because b < headroom <= MaxInt64
 }
 
 // CalculateFixedEpochReward implements the exponential decay reward calculation
@@ -569,6 +584,12 @@ func CalculateParticipantBitcoinRewards(
 	// 6. Any remainder (downtime punishment and/or integer division truncation) is undistributed
 	// and should be transferred to governance.
 	remainder := fixedEpochReward - totalDistributed
+	if fixedEpochReward < totalDistributed {
+		remainder = 0
+	}
+	if remainder > math.MaxInt64 {
+		remainder = math.MaxInt64
+	}
 
 	// 7. Create BitcoinResult (similar to SubsidyResult)
 	bitcoinResult := BitcoinResult{

--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -16,6 +16,10 @@ type BitcoinResult struct {
 	Amount       int64  // Total epoch reward amount minted
 	EpochNumber  uint64 // Current epoch number for tracking
 	DecayApplied bool   // Whether decay was applied this epoch
+	// GovernanceAmount is the portion of Amount that is NOT distributed to participants
+	// (e.g. due to downtime punishment or integer division truncation) and should be
+	// transferred to the governance module account by the caller.
+	GovernanceAmount int64
 }
 
 // GetBitcoinSettleAmounts is the main entry point for Bitcoin-style reward calculation.
@@ -59,6 +63,7 @@ func GetBitcoinSettleAmounts(
 	if settleParams.TotalSubsidyPaid >= settleParams.TotalSubsidySupply {
 		// Supply cap already reached - stop all minting
 		bitcoinResult.Amount = 0
+		bitcoinResult.GovernanceAmount = 0
 		// Zero out all participant reward amounts since no rewards can be minted
 		for _, amount := range settleResults {
 			if amount.Settle != nil {
@@ -84,18 +89,10 @@ func GetBitcoinSettleAmounts(
 				}
 			}
 
-			// Distribute any remainder due to integer division truncation
-			// This ensures the exact available supply amount is distributed
+			// Any remainder due to integer division truncation (or downtime punishments already
+			// baked into settleResults) should go to governance.
 			remainder := uint64(bitcoinResult.Amount) - totalDistributed
-			if remainder > 0 && len(settleResults) > 0 {
-				// Assign undistributed coins to first participant with valid rewards
-				for i, result := range settleResults {
-					if result.Error == nil && result.Settle != nil && result.Settle.RewardCoins > 0 {
-						settleResults[i].Settle.RewardCoins += remainder
-						break
-					}
-				}
-			}
+			bitcoinResult.GovernanceAmount = int64(remainder)
 		}
 	}
 	// If under cap, no adjustment needed - use full amount
@@ -499,6 +496,7 @@ func CalculateParticipantBitcoinRewards(
 	for _, weight := range participantWeights {
 		totalPoCWeight += weight
 	}
+	totalPoCWeightBeforeDowntime := totalPoCWeight
 
 	// 4. Check and punish for downtime
 	logger.Info("Bitcoin Rewards: Checking downtime for participants", "participants", len(participants))
@@ -508,14 +506,8 @@ func CalculateParticipantBitcoinRewards(
 	}
 	CheckAndPunishForDowntimeForParticipants(participants, participantWeights, p0, logger)
 	logger.Info("Bitcoin Rewards: weights after downtime check", "participants", participantWeights)
-
-	// Recalculate total weight after downtime punishment
-	// This ensures fair distribution based on actual eligible weights
-	totalPoCWeight = uint64(0)
-	for _, weight := range participantWeights {
-		totalPoCWeight += weight
-	}
-	logger.Info("Bitcoin Rewards: total weight after downtime punishment", "totalPoCWeight", totalPoCWeight)
+	// IMPORTANT: We intentionally DO NOT renormalize totalPoCWeight after downtime punishment.
+	// Any "missed" share becomes undistributed and should be transferred to governance.
 
 	// 5. Create settle results for each participant
 	settleResults := make([]*SettleResult, 0, len(participants))
@@ -542,14 +534,14 @@ func CalculateParticipantBitcoinRewards(
 
 		// Calculate RewardCoins (NEW Bitcoin-style distribution by PoC weight)
 		rewardCoins := uint64(0)
-		if participant.Status == types.ParticipantStatus_ACTIVE && totalPoCWeight > 0 {
+		if participant.Status == types.ParticipantStatus_ACTIVE && totalPoCWeightBeforeDowntime > 0 {
 			participantWeight := participantWeights[participant.Address]
 			if participantWeight > 0 {
 				// Use big.Int to prevent overflow with large numbers
 				// Proportional distribution: (participant_weight / total_weight) × fixed_epoch_reward
 				participantBig := new(big.Int).SetUint64(participantWeight)
 				rewardBig := new(big.Int).SetUint64(fixedEpochReward)
-				totalWeightBig := new(big.Int).SetUint64(totalPoCWeight)
+				totalWeightBig := new(big.Int).SetUint64(totalPoCWeightBeforeDowntime)
 
 				// Calculate: (participantWeight * fixedEpochReward) / totalPoCWeight
 				result := new(big.Int).Mul(participantBig, rewardBig)
@@ -574,25 +566,16 @@ func CalculateParticipantBitcoinRewards(
 		})
 	}
 
-	// 6. Distribute any remainder due to integer division truncation
-	// This ensures the complete fixed epoch reward is always distributed
+	// 6. Any remainder (downtime punishment and/or integer division truncation) is undistributed
+	// and should be transferred to governance.
 	remainder := fixedEpochReward - totalDistributed
-	if remainder > 0 && len(settleResults) > 0 {
-		// Simple approach: assign undistributed coins to first participant
-		// This ensures complete distribution while keeping logic minimal
-		for i, result := range settleResults {
-			if result.Error == nil && result.Settle.RewardCoins > 0 {
-				settleResults[i].Settle.RewardCoins += remainder
-				break
-			}
-		}
-	}
 
 	// 7. Create BitcoinResult (similar to SubsidyResult)
 	bitcoinResult := BitcoinResult{
-		Amount:       int64(fixedEpochReward),
-		EpochNumber:  currentEpoch,
-		DecayApplied: epochsSinceGenesis > 0, // Decay applied if past genesis epoch
+		Amount:           int64(fixedEpochReward),
+		EpochNumber:      currentEpoch,
+		DecayApplied:     epochsSinceGenesis > 0, // Decay applied if past genesis epoch
+		GovernanceAmount: int64(remainder),
 	}
 
 	return settleResults, bitcoinResult, nil

--- a/inference-chain/x/inference/keeper/settle_amount.go
+++ b/inference-chain/x/inference/keeper/settle_amount.go
@@ -75,7 +75,7 @@ func (k Keeper) transferUnclaimedSettleAmountToGovernance(ctx context.Context, s
 			k.LogError("Error transferring unclaimed settle amount coins to governance", types.Settle, "error", err, "participant", settleAmount.Participant, "amount", totalCoins)
 			return err
 		}
-		k.SafeLogSubAccountTransaction(ctx, govtypes.ModuleName, types.ModuleName, types.SettleSubAccount, int64(totalCoins), reason)
+		k.SafeLogSubAccountTransaction(ctx, types.ModuleName, settleAmount.Participant, types.SettleSubAccount, totalCoins, reason)
 		k.LogInfo("Transferred unclaimed settle amount to governance", types.Settle, "participant", settleAmount.Participant, "amount", totalCoins, "reason", reason)
 	}
 	return nil

--- a/inference-chain/x/inference/keeper/settle_amount.go
+++ b/inference-chain/x/inference/keeper/settle_amount.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	"github.com/productscience/inference/x/inference/types"
 )
@@ -60,27 +61,32 @@ func (k Keeper) GetAllSettleAmount(ctx context.Context) (list []types.SettleAmou
 	return vals
 }
 
-// burnSettleAmount burns coins from a settle amount (internal helper)
-func (k Keeper) burnSettleAmount(ctx context.Context, settleAmount types.SettleAmount, reason string) error {
+// transferUnclaimedSettleAmountToGovernance transfers coins from an unclaimed settle amount to governance (internal helper).
+func (k Keeper) transferUnclaimedSettleAmountToGovernance(ctx context.Context, settleAmount types.SettleAmount, reason string) error {
 	totalCoins := settleAmount.GetTotalCoins()
 	if totalCoins > 0 {
-		err := k.BurnModuleCoins(ctx, int64(totalCoins), reason+":"+settleAmount.Participant)
+		coins, err := types.GetCoins(int64(totalCoins))
 		if err != nil {
-			k.LogError("Error burning settle amount coins", types.Settle, "error", err, "participant", settleAmount.Participant, "amount", totalCoins)
 			return err
 		}
-		k.SafeLogSubAccountTransaction(ctx, types.ModuleName, settleAmount.Participant, types.SettleSubAccount, totalCoins, reason)
-		k.LogInfo("Burned settle amount", types.Settle, "participant", settleAmount.Participant, "amount", totalCoins, "reason", reason)
+		memo := reason + ":" + settleAmount.Participant
+		err = k.BankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, govtypes.ModuleName, coins, memo)
+		if err != nil {
+			k.LogError("Error transferring unclaimed settle amount coins to governance", types.Settle, "error", err, "participant", settleAmount.Participant, "amount", totalCoins)
+			return err
+		}
+		k.SafeLogSubAccountTransaction(ctx, govtypes.ModuleName, types.ModuleName, types.SettleSubAccount, int64(totalCoins), reason)
+		k.LogInfo("Transferred unclaimed settle amount to governance", types.Settle, "participant", settleAmount.Participant, "amount", totalCoins, "reason", reason)
 	}
 	return nil
 }
 
-// SetSettleAmountWithBurn sets a settle amount, burning any existing unclaimed amount first
+// SetSettleAmountWithBurn sets a settle amount, transferring any existing unclaimed amount to governance first.
 func (k Keeper) SetSettleAmountWithBurn(ctx context.Context, settleAmount types.SettleAmount) error {
-	// Burn existing settle amount if it exists
+	// Transfer existing settle amount if it exists
 	existingSettle, found := k.GetSettleAmount(ctx, settleAmount.Participant)
 	if found {
-		err := k.burnSettleAmount(ctx, existingSettle, "expired claim")
+		err := k.transferUnclaimedSettleAmountToGovernance(ctx, existingSettle, "expired claim")
 		if err != nil {
 			return err
 		}
@@ -93,12 +99,12 @@ func (k Keeper) SetSettleAmountWithBurn(ctx context.Context, settleAmount types.
 	return nil
 }
 
-// BurnOldSettleAmounts burns and removes all settle amounts older than the specified epoch
+// BurnOldSettleAmounts transfers and removes all settle amounts older than the specified epoch.
 func (k Keeper) BurnOldSettleAmounts(ctx context.Context, beforeEpochIndex uint64) error {
 	allSettleAmounts := k.GetAllSettleAmount(ctx)
 	for _, settleAmount := range allSettleAmounts {
 		if settleAmount.EpochIndex < beforeEpochIndex {
-			err := k.burnSettleAmount(ctx, settleAmount, "expired")
+			err := k.transferUnclaimedSettleAmountToGovernance(ctx, settleAmount, "expired")
 			if err != nil {
 				return err
 			}

--- a/inference-chain/x/inference/keeper/settle_amount.go
+++ b/inference-chain/x/inference/keeper/settle_amount.go
@@ -81,8 +81,8 @@ func (k Keeper) transferUnclaimedSettleAmountToGovernance(ctx context.Context, s
 	return nil
 }
 
-// SetSettleAmountWithBurn sets a settle amount, transferring any existing unclaimed amount to governance first.
-func (k Keeper) SetSettleAmountWithBurn(ctx context.Context, settleAmount types.SettleAmount) error {
+// SetSettleAmountWithGovernanceTransfer sets a settle amount, transferring any existing unclaimed amount to governance first.
+func (k Keeper) SetSettleAmountWithGovernanceTransfer(ctx context.Context, settleAmount types.SettleAmount) error {
 	// Transfer existing settle amount if it exists
 	existingSettle, found := k.GetSettleAmount(ctx, settleAmount.Participant)
 	if found {
@@ -99,8 +99,8 @@ func (k Keeper) SetSettleAmountWithBurn(ctx context.Context, settleAmount types.
 	return nil
 }
 
-// BurnOldSettleAmounts transfers and removes all settle amounts older than the specified epoch.
-func (k Keeper) BurnOldSettleAmounts(ctx context.Context, beforeEpochIndex uint64) error {
+// TransferOldSettleAmountsToGovernance transfers and removes all settle amounts older than the specified epoch.
+func (k Keeper) TransferOldSettleAmountsToGovernance(ctx context.Context, beforeEpochIndex uint64) error {
 	allSettleAmounts := k.GetAllSettleAmount(ctx)
 	for _, settleAmount := range allSettleAmounts {
 		if settleAmount.EpochIndex < beforeEpochIndex {

--- a/testermint/src/main/kotlin/RewardCalculations.kt
+++ b/testermint/src/main/kotlin/RewardCalculations.kt
@@ -77,13 +77,11 @@ fun calculateCumulativeEpochRewards(
             totalDistributed += participantReward
         }
         
-        // Distribute any remainder due to integer division truncation (same as bitcoin_rewards.go)
+        // Any remainder due to integer division truncation is NOT redistributed to participants.
+        // On-chain, it is transferred to the governance module account.
         val remainder = epochReward - totalDistributed
         if (remainder > 0 && participants.isNotEmpty()) {
-            // Assign remainder to first participant (matches blockchain logic)
-            val firstParticipant = participants.first()
-            epochRewards[firstParticipant.id] = (epochRewards[firstParticipant.id] ?: 0L) + remainder
-            Logger.info("Epoch $epoch - Distributed remainder $remainder to first participant: ${firstParticipant.id}")
+            Logger.info("Epoch $epoch - Undistributed remainder $remainder goes to governance (not participants)")
         }
         
         // Add epoch rewards to cumulative totals
@@ -136,13 +134,11 @@ fun calculateBitcoinEpochRewards(
         Logger.info("Bitcoin Epoch Settlement - Participant: ${participant.id}, PoC Weight: $participantPocWeight, Reward: $participantReward")
     }
     
-    // Distribute any remainder due to integer division truncation (same as bitcoin_rewards.go)
+    // Any remainder due to integer division truncation is NOT redistributed to participants.
+    // On-chain, it is transferred to the governance module account.
     val remainder = currentEpochReward - totalDistributed
     if (remainder > 0 && participants.isNotEmpty()) {
-        // Assign remainder to first participant (matches blockchain logic)
-        val firstParticipant = participants.first()
-        rewards[firstParticipant.id] = (rewards[firstParticipant.id] ?: 0L) + remainder
-        Logger.info("Bitcoin Epoch Settlement - Distributed remainder $remainder to first participant: ${firstParticipant.id}")
+        Logger.info("Bitcoin Epoch Settlement - Undistributed remainder $remainder goes to governance (not participants)")
     }
     
     Logger.info("Bitcoin Epoch Settlement - Epochs Since Genesis: $epochsSinceGenesis, Current Epoch Reward: $currentEpochReward, Total Participants: ${participants.size}")


### PR DESCRIPTION
Settlement: expired/unclaimed SettleAmount is transferred to the gov module account instead of burned.

Bitcoin rewards: missed-share + rounding remainder are not redistributed; transferred to governance and tracked via BitcoinResult.GovernanceAmount.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements governance ownership of leftover rewards and unclaimed settlements.
> 
> - Bitcoin rewards: do not redistribute downtime/rounding remainders; expose `BitcoinResult.GovernanceAmount` and, when `UseBitcoinRewards`, transfer that amount from `inference` module to `gov` (`accountsettle.go`, `bitcoin_rewards.go`)
> - Settlement: replace burn of existing/expired unclaimed `SettleAmount` with transfer to `gov` (`settle_amount.go`); update helper to `transferUnclaimedSettleAmountToGovernance`
> - Tests updated to assert conservation via participants + `GovernanceAmount`, and no remainder redistribution (`bitcoin_rewards_test.go`)
> - E2E test helpers updated to log remainder to governance instead of assigning to a participant (`RewardCalculations.kt`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d58cbb4cdefded1c25e45a529d6de1fdc694b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->