### PR TITLE
Remove ALL panic and Must from chain code

### DIFF
--- a/.github/workflows/dont_panic.yml
+++ b/.github/workflows/dont_panic.yml
@@ -1,10 +1,12 @@
-name: dont_panic
+name: Check for panic or Must
 on:
   push:
     branches:
       - main
       - upgrade-v**
   pull_request:
+    paths:
+      - "inference-chain/**"
 
 permissions:
   contents: read

--- a/.github/workflows/dont_panic.yml
+++ b/.github/workflows/dont_panic.yml
@@ -1,0 +1,24 @@
+name: dont_panic
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull requests. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.24.2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.6
+          working-directory: inference-chain

--- a/.github/workflows/dont_panic.yml
+++ b/.github/workflows/dont_panic.yml
@@ -1,6 +1,9 @@
 name: dont_panic
 on:
   push:
+    branches:
+      - main
+      - upgrade-v**
   pull_request:
 
 permissions:

--- a/inference-chain/.golangci.yml
+++ b/inference-chain/.golangci.yml
@@ -1,0 +1,29 @@
+version: 2
+run:
+  timeout: 5m
+  tests: false
+
+linters:
+  disable:
+    - errcheck
+    - unused
+    - staticcheck
+    - ineffassign
+  enable:
+    - forbidigo
+  settings:
+    forbidigo:
+      forbid:
+#        - pattern: ^panic$
+#          msg: "panic forbidden in consensus code"
+        - pattern: Must
+          msg: "Must* helpers forbidden in consensus code"
+  exclusions:
+    paths:
+      - "^testutil/"
+      - "^tests?/"   # matches test/ or tests/
+      - "^cmd/"
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/inference-chain/.golangci.yml
+++ b/inference-chain/.golangci.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 run:
   timeout: 5m
   tests: false

--- a/inference-chain/.golangci.yml
+++ b/inference-chain/.golangci.yml
@@ -14,8 +14,8 @@ linters:
   settings:
     forbidigo:
       forbid:
-#        - pattern: ^panic$
-#          msg: "panic forbidden in consensus code"
+        - pattern: ^panic$
+          msg: "panic forbidden in consensus code"
         - pattern: Must
           msg: "Must* helpers forbidden in consensus code"
   exclusions:

--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -244,6 +244,8 @@ func (app *App) setAnteHandler(txConfig client.TxConfig, nodeConfig wasmtypes.No
 		},
 	)
 	if err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(fmt.Errorf("failed to create AnteHandler: %s", err))
 	}
 

--- a/inference-chain/app/ante_validation_test.go
+++ b/inference-chain/app/ante_validation_test.go
@@ -21,7 +21,7 @@ func (t testTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
 
 func TestValidationEarlyRejectDecorator_DuplicateValidationRejectedInCheckTx(t *testing.T) {
 	k, ctx := testkeeper.InferenceKeeper(t)
-	k.SetEffectiveEpochIndex(ctx, 0)
+	_ = k.SetEffectiveEpochIndex(ctx, 0)
 
 	modelID := "model-1"
 	inferenceID := "inf-1"
@@ -61,7 +61,7 @@ func TestValidationEarlyRejectDecorator_DuplicateValidationRejectedInCheckTx(t *
 
 func TestValidationEarlyRejectDecorator_NotInEpochRejectedInCheckTx(t *testing.T) {
 	k, ctx := testkeeper.InferenceKeeper(t)
-	k.SetEffectiveEpochIndex(ctx, 0)
+	_ = k.SetEffectiveEpochIndex(ctx, 0)
 
 	modelID := "model-1"
 	inferenceID := "inf-1"
@@ -95,7 +95,7 @@ func TestValidationEarlyRejectDecorator_NotInEpochRejectedInCheckTx(t *testing.T
 
 func TestValidationEarlyRejectDecorator_BypassesDeliverTx(t *testing.T) {
 	k, ctx := testkeeper.InferenceKeeper(t)
-	k.SetEffectiveEpochIndex(ctx, 0)
+	_ = k.SetEffectiveEpochIndex(ctx, 0)
 
 	modelID := "model-1"
 	inferenceID := "inf-1"
@@ -130,7 +130,7 @@ func TestValidationEarlyRejectDecorator_BypassesDeliverTx(t *testing.T) {
 func TestValidationEarlyRejectDecorator_DoesNotRejectInferenceFromNextEpochInCheckTx(t *testing.T) {
 	t.Skip("TODO: This need to be re-enabled when we fixup the chain logic to use Inference Epoch, not current (bug)")
 	k, ctx := testkeeper.InferenceKeeper(t)
-	k.SetEffectiveEpochIndex(ctx, 0)
+	_ = k.SetEffectiveEpochIndex(ctx, 0)
 
 	modelID := "model-1"
 	inferenceID := "inf-next-epoch"

--- a/inference-chain/app/app.go
+++ b/inference-chain/app/app.go
@@ -179,8 +179,6 @@ type App struct {
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		//nolint:forbidigo
-		//init code:
 		panic(err)
 	}
 

--- a/inference-chain/app/app.go
+++ b/inference-chain/app/app.go
@@ -179,6 +179,8 @@ type App struct {
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
+		//nolint:forbidigo
+		// init code
 		panic(err)
 	}
 

--- a/inference-chain/app/app.go
+++ b/inference-chain/app/app.go
@@ -179,6 +179,8 @@ type App struct {
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 
@@ -280,6 +282,8 @@ func New(
 		&app.GenesistransferKeeper,
 		// this line is used by starport scaffolding # stargate/app/keeperDefinition
 	); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 
@@ -429,7 +433,10 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig
 	app.App.RegisterAPIRoutes(apiSvr, apiConfig)
 	// register swagger API in app.go so that other applications can override easily
 	if err := server.RegisterSwaggerAPI(apiSvr.ClientCtx, apiSvr.Router, apiConfig.Swagger); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
+
 	}
 
 	// register app's OpenAPI routes.

--- a/inference-chain/app/export.go
+++ b/inference-chain/app/export.go
@@ -78,27 +78,36 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	err := app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
 		valBz, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(val.GetOperator())
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 		_, _ = app.DistrKeeper.WithdrawValidatorCommission(ctx, valBz)
 		return false
 	})
 	if err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 
 	// withdraw all delegator rewards
 	dels, err := app.StakingKeeper.GetAllDelegations(ctx)
 	if err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 
 	for _, delegation := range dels {
 		valAddr, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 
+		//nolint:forbidigo // Genesis code
 		delAddr := sdk.MustAccAddressFromBech32(delegation.DelegatorAddress)
 
 		_, _ = app.DistrKeeper.WithdrawDelegationRewards(ctx, delAddr, valAddr)
@@ -118,23 +127,33 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	err = app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
 		valBz, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(val.GetOperator())
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
 		scraps, err := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, valBz)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 		feePool, err := app.DistrKeeper.FeePool.Get(ctx)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
 		if err := app.DistrKeeper.FeePool.Set(ctx, feePool); err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 
 		if err := app.DistrKeeper.Hooks().AfterValidatorCreated(ctx, valBz); err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 		return false
@@ -144,17 +163,24 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	for _, del := range dels {
 		valAddr, err := sdk.ValAddressFromBech32(del.ValidatorAddress)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
+		//nolint:forbidigo // Genesis code
 		delAddr := sdk.MustAccAddressFromBech32(del.DelegatorAddress)
 
 		if err := app.DistrKeeper.Hooks().BeforeDelegationCreated(ctx, delAddr, valAddr); err != nil {
 			// never called as BeforeDelegationCreated always returns nil
+			//nolint:forbidigo
+			//Genesis code:
 			panic(fmt.Errorf("error while incrementing period: %w", err))
 		}
 
 		if err := app.DistrKeeper.Hooks().AfterDelegationModified(ctx, delAddr, valAddr); err != nil {
 			// never called as AfterDelegationModified always returns nil
+			//nolint:forbidigo
+			//Genesis code:
 			panic(fmt.Errorf("error while creating a new delegation period record: %w", err))
 		}
 	}
@@ -171,11 +197,15 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		}
 		err = app.StakingKeeper.SetRedelegation(ctx, red)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 		return false
 	})
 	if err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 
@@ -186,11 +216,15 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		}
 		err = app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 		return false
 	})
 	if err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 
@@ -204,6 +238,8 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		addr := sdk.ValAddress(stakingtypes.AddressFromValidatorsKey(iter.Key()))
 		validator, err := app.StakingKeeper.GetValidator(ctx, addr)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic("expected validator, not found")
 		}
 
@@ -213,6 +249,8 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		}
 
 		if err := app.StakingKeeper.SetValidator(ctx, validator); err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
 		counter++

--- a/inference-chain/app/legacy.go
+++ b/inference-chain/app/legacy.go
@@ -65,6 +65,8 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 		// wasm kv store
 		storetypes.NewKVStoreKey(wasmtypes.StoreKey),
 	); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 
@@ -170,6 +172,8 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 	// Create default node config and VM config for wasmd v0.54.2
 	nodeConfig, err := wasm.ReadNodeConfig(appOpts)
 	if err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 	vmConfig := wasmtypes.VMConfig{
@@ -261,6 +265,8 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 		//wasm module
 		wasm.NewAppModule(app.AppCodec(), &app.WasmKeeper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper, app.MsgServiceRouter(), app.GetSubspace(wasmtypes.ModuleName)),
 	); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 

--- a/inference-chain/app/upgrades/v0_2_4/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_4/upgrades.go
@@ -53,7 +53,7 @@ func setPruningDefaults(ctx context.Context, k keeper.Keeper, fromVM module.Vers
 	if err != nil {
 		return err
 	}
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		return err
 	}

--- a/inference-chain/app/upgrades/v0_2_5/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_5/upgrades.go
@@ -54,7 +54,7 @@ func CreateUpgradeHandler(
 }
 
 func setNewInvalidationParams(ctx context.Context, k keeper.Keeper, vm module.VersionMap) error {
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		return err
 	}

--- a/inference-chain/app/upgrades/v0_2_6/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_6/upgrades.go
@@ -125,7 +125,7 @@ func CreateUpgradeHandler(
 }
 
 func setNewPocParams(ctx context.Context, k keeper.Keeper) error {
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		return err
 	}

--- a/inference-chain/app/upgrades/v0_2_7/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_7/upgrades.go
@@ -3295,7 +3295,7 @@ func CreateUpgradeHandler(
 }
 
 func setV0_2_7Params(ctx context.Context, k keeper.Keeper) error {
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		return err
 	}

--- a/inference-chain/testutil/keeper/expected_keepers_mocks.go
+++ b/inference-chain/testutil/keeper/expected_keepers_mocks.go
@@ -673,9 +673,11 @@ func (m *MockCollateralKeeper) EXPECT() *MockCollateralKeeperMockRecorder {
 }
 
 // AdvanceEpoch mocks base method.
-func (m *MockCollateralKeeper) AdvanceEpoch(ctx context.Context, completedEpoch uint64) {
+func (m *MockCollateralKeeper) AdvanceEpoch(ctx context.Context, completedEpoch uint64) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AdvanceEpoch", ctx, completedEpoch)
+	ret := m.ctrl.Call(m, "AdvanceEpoch", ctx, completedEpoch)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AdvanceEpoch indicates an expected call of AdvanceEpoch.

--- a/inference-chain/x/bls/keeper/keeper.go
+++ b/inference-chain/x/bls/keeper/keeper.go
@@ -36,6 +36,8 @@ func NewKeeper(
 
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(fmt.Sprintf("invalid authority address: %s", authority))
 	}
 

--- a/inference-chain/x/bls/keeper/msg_server_dealer.go
+++ b/inference-chain/x/bls/keeper/msg_server_dealer.go
@@ -13,9 +13,9 @@ func (ms msgServer) SubmitDealerPart(goCtx context.Context, msg *types.MsgSubmit
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// Get the epoch BLS data
-	epochBLSData, found := ms.GetEpochBLSData(ctx, msg.EpochId)
-	if !found {
-		return nil, fmt.Errorf("epoch %d not found", msg.EpochId)
+	epochBLSData, err := ms.GetEpochBLSData(ctx, msg.EpochId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get epoch %d BLS data: %w", msg.EpochId, err)
 	}
 
 	// Check if DKG is in dealing phase
@@ -67,7 +67,9 @@ func (ms msgServer) SubmitDealerPart(goCtx context.Context, msg *types.MsgSubmit
 	epochBLSData.DealerParts[participantIndex] = dealerPart
 
 	// Save the updated epoch BLS data
-	ms.SetEpochBLSData(ctx, epochBLSData)
+	if err := ms.SetEpochBLSData(ctx, epochBLSData); err != nil {
+		return nil, fmt.Errorf("failed to save updated epoch %d BLS data: %w", msg.EpochId, err)
+	}
 
 	// Emit EventDealerPartSubmitted
 	event := &types.EventDealerPartSubmitted{

--- a/inference-chain/x/bls/keeper/msg_server_dealer_test.go
+++ b/inference-chain/x/bls/keeper/msg_server_dealer_test.go
@@ -88,8 +88,8 @@ func TestSubmitDealerPart_Success(t *testing.T) {
 	require.NotNil(t, resp)
 
 	// Check that dealer part was stored
-	updatedEpochBLSData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	updatedEpochBLSData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 
 	// Dealer should be at index 0
 	dealerPart := updatedEpochBLSData.DealerParts[0]
@@ -114,7 +114,7 @@ func TestSubmitDealerPart_EpochNotFound(t *testing.T) {
 
 	_, err := ms.SubmitDealerPart(goCtx, msg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "epoch 999 not found")
+	assert.Contains(t, err.Error(), "epoch BLS data not found")
 }
 
 func TestSubmitDealerPart_WrongPhase(t *testing.T) {

--- a/inference-chain/x/bls/keeper/msg_server_test.go
+++ b/inference-chain/x/bls/keeper/msg_server_test.go
@@ -68,7 +68,7 @@ func TestSubmitGroupKeyValidationSignature_AlreadySigned(t *testing.T) {
 	require.NotNil(t, resp)
 
 	// Verify epoch is still in SIGNED phase (unchanged)
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_SIGNED, storedData.DkgPhase)
 }

--- a/inference-chain/x/bls/keeper/msg_server_verification_test.go
+++ b/inference-chain/x/bls/keeper/msg_server_verification_test.go
@@ -44,8 +44,8 @@ func TestSubmitVerificationVector_Success(t *testing.T) {
 	require.NotNil(t, resp)
 
 	// Verify epoch data was updated
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 
 	// Verify successful submission
 	submission := storedData.VerificationSubmissions[0] // Alice is at index 0
@@ -290,8 +290,8 @@ func TestSubmitVerificationVector_MultipleParticipants(t *testing.T) {
 	}
 
 	// Verify all submissions were stored
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Len(t, storedData.VerificationSubmissions, 3)
 
 	// Verify each submission is stored at the correct participant index

--- a/inference-chain/x/bls/keeper/params.go
+++ b/inference-chain/x/bls/keeper/params.go
@@ -9,15 +9,15 @@ import (
 )
 
 // GetParams get all parameters as types.Params
-func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
+func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
-		return params
+		return params, nil
 	}
 
-	k.cdc.MustUnmarshal(bz, &params)
-	return params
+	err = k.cdc.Unmarshal(bz, &params)
+	return params, err
 }
 
 // SetParams set the params
@@ -36,20 +36,36 @@ func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
 
 // GetITotalSlots returns the total number of slots for DKG
 func (k Keeper) GetITotalSlots(ctx context.Context) uint32 {
-	return k.GetParams(ctx).ITotalSlots
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return 0
+	}
+	return params.ITotalSlots
 }
 
 // GetTSlotsDegreeOffset returns the polynomial degree offset
 func (k Keeper) GetTSlotsDegreeOffset(ctx context.Context) uint32 {
-	return k.GetParams(ctx).TSlotsDegreeOffset
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return 0
+	}
+	return params.TSlotsDegreeOffset
 }
 
 // GetDealingPhaseDurationBlocks returns the dealing phase duration in blocks
 func (k Keeper) GetDealingPhaseDurationBlocks(ctx context.Context) int64 {
-	return k.GetParams(ctx).DealingPhaseDurationBlocks
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return 0
+	}
+	return params.DealingPhaseDurationBlocks
 }
 
 // GetVerificationPhaseDurationBlocks returns the verification phase duration in blocks
 func (k Keeper) GetVerificationPhaseDurationBlocks(ctx context.Context) int64 {
-	return k.GetParams(ctx).VerificationPhaseDurationBlocks
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return 0
+	}
+	return params.VerificationPhaseDurationBlocks
 }

--- a/inference-chain/x/bls/keeper/params_test.go
+++ b/inference-chain/x/bls/keeper/params_test.go
@@ -14,5 +14,7 @@ func TestGetParams(t *testing.T) {
 	params := types.DefaultParams()
 
 	require.NoError(t, k.SetParams(ctx, params))
-	require.EqualValues(t, params, k.GetParams(ctx))
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, params, params)
 }

--- a/inference-chain/x/bls/keeper/params_test.go
+++ b/inference-chain/x/bls/keeper/params_test.go
@@ -14,7 +14,7 @@ func TestGetParams(t *testing.T) {
 	params := types.DefaultParams()
 
 	require.NoError(t, k.SetParams(ctx, params))
-	params, err := k.GetParams(ctx)
+	outParams, err := k.GetParams(ctx)
 	require.NoError(t, err)
-	require.EqualValues(t, params, params)
+	require.EqualValues(t, params, outParams)
 }

--- a/inference-chain/x/bls/keeper/phase_transitions_test.go
+++ b/inference-chain/x/bls/keeper/phase_transitions_test.go
@@ -41,8 +41,8 @@ func TestTransitionToVerifyingPhase_SufficientParticipation(t *testing.T) {
 	require.Greater(t, epochBLSData.VerifyingPhaseDeadlineBlock, epochBLSData.DealingPhaseDeadlineBlock)
 
 	// Verify epoch data was stored
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_VERIFYING, storedData.DkgPhase)
 }
 
@@ -70,8 +70,8 @@ func TestTransitionToVerifyingPhase_InsufficientParticipation(t *testing.T) {
 	require.Equal(t, types.DKGPhase_DKG_PHASE_FAILED, epochBLSData.DkgPhase)
 
 	// Verify epoch data was stored
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_FAILED, storedData.DkgPhase)
 }
 
@@ -114,7 +114,7 @@ func TestProcessDKGPhaseTransitionForEpoch_NotFound(t *testing.T) {
 	// Try to process transition for non-existent epoch
 	err := k.ProcessDKGPhaseTransitionForEpoch(ctx, uint64(999))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "EpochBLSData not found")
+	require.Contains(t, err.Error(), "epoch BLS data not found")
 }
 
 func TestProcessDKGPhaseTransitionForEpoch_CompletedEpoch(t *testing.T) {
@@ -131,8 +131,8 @@ func TestProcessDKGPhaseTransitionForEpoch_CompletedEpoch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify phase didn't change
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_COMPLETED, storedData.DkgPhase)
 }
 
@@ -150,8 +150,8 @@ func TestProcessDKGPhaseTransitionForEpoch_SignedEpoch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify phase didn't change
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_SIGNED, storedData.DkgPhase)
 }
 
@@ -199,8 +199,8 @@ func TestProcessDKGPhaseTransitions_ActiveEpoch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify phase didn't change
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_DEALING, storedData.DkgPhase)
 	activeEpoch, found := k.GetActiveEpochID(ctx)
 	require.True(t, found)
@@ -225,8 +225,8 @@ func TestActiveEpochClearedOnFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify DKG failed and active epoch was cleared
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_FAILED, storedData.DkgPhase)
 	activeEpoch, found := k.GetActiveEpochID(ctx)
 	require.False(t, found)
@@ -342,8 +342,8 @@ func TestCompleteDKG_SufficientVerification(t *testing.T) {
 	require.Equal(t, 96, len(epochBLSData.GroupPublicKey)) // Compressed G2 point (96 bytes)
 
 	// Verify epoch data was stored
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_COMPLETED, storedData.DkgPhase)
 	require.NotNil(t, storedData.GroupPublicKey)
 	require.Equal(t, 96, len(storedData.GroupPublicKey)) // Compressed G2 point (96 bytes)
@@ -377,8 +377,8 @@ func TestCompleteDKG_InsufficientVerification(t *testing.T) {
 	require.Nil(t, epochBLSData.GroupPublicKey)
 
 	// Verify epoch data was stored
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_FAILED, storedData.DkgPhase)
 
 	// Verify active epoch was cleared
@@ -507,8 +507,8 @@ func TestProcessDKGPhaseTransitionForEpoch_VerifyingToCompleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify DKG completed
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_COMPLETED, storedData.DkgPhase)
 	require.NotNil(t, storedData.GroupPublicKey)
 	require.Equal(t, 96, len(storedData.GroupPublicKey)) // Compressed G2 point (96 bytes)
@@ -541,8 +541,8 @@ func TestProcessDKGPhaseTransitionForEpoch_VerifyingToFailed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify DKG failed
-	storedData, found := k.GetEpochBLSData(ctx, epochID)
-	require.True(t, found)
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
 	require.Equal(t, types.DKGPhase_DKG_PHASE_FAILED, storedData.DkgPhase)
 	require.Nil(t, storedData.GroupPublicKey)
 

--- a/inference-chain/x/bls/keeper/query_epoch_data.go
+++ b/inference-chain/x/bls/keeper/query_epoch_data.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -24,9 +25,12 @@ func (k Keeper) EpochBLSData(ctx context.Context, req *types.QueryEpochBLSDataRe
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	// Retrieve EpochBLSData for the requested epoch
-	epochBLSData, found := k.GetEpochBLSData(sdkCtx, req.EpochId)
-	if !found {
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("no DKG data found for epoch %d", req.EpochId))
+	epochBLSData, err := k.GetEpochBLSData(sdkCtx, req.EpochId)
+	if err != nil {
+		if errors.Is(err, types.ErrEpochBLSDataNotFound) {
+			return nil, status.Error(codes.NotFound, fmt.Sprintf("no DKG data found for epoch %d", req.EpochId))
+		}
+		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get epoch %d BLS data: %v", req.EpochId, err))
 	}
 
 	// Return complete epoch data

--- a/inference-chain/x/bls/keeper/query_params.go
+++ b/inference-chain/x/bls/keeper/query_params.go
@@ -16,5 +16,10 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get parameters")
+	}
+
+	return &types.QueryParamsResponse{Params: params}, nil
 }

--- a/inference-chain/x/bls/keeper/query_threshold_signing.go
+++ b/inference-chain/x/bls/keeper/query_threshold_signing.go
@@ -55,7 +55,9 @@ func (k Keeper) SigningHistory(ctx context.Context, req *types.QuerySigningHisto
 	// Use pagination helper for efficient iteration
 	pageRes, err := query.Paginate(signingStore, req.Pagination, func(key []byte, value []byte) error {
 		var signingRequest types.ThresholdSigningRequest
-		k.cdc.MustUnmarshal(value, &signingRequest)
+		if err := k.cdc.Unmarshal(value, &signingRequest); err != nil {
+			return err
+		}
 
 		// Apply filters
 		if !k.matchesFilters(&signingRequest, req) {

--- a/inference-chain/x/bls/keeper/threshold_signing.go
+++ b/inference-chain/x/bls/keeper/threshold_signing.go
@@ -15,9 +15,9 @@ import (
 // RequestThresholdSignature is the main entry point for other modules to request BLS threshold signatures
 func (k Keeper) RequestThresholdSignature(ctx sdk.Context, signingData types.SigningData) error {
 	// Validate current epoch has completed DKG
-	epochBLSData, found := k.GetEpochBLSData(ctx, signingData.CurrentEpochId)
-	if !found {
-		return fmt.Errorf("epoch BLS data not found for epoch %d", signingData.CurrentEpochId)
+	epochBLSData, err := k.GetEpochBLSData(ctx, signingData.CurrentEpochId)
+	if err != nil {
+		return fmt.Errorf("failed to get epoch %d BLS data: %w", signingData.CurrentEpochId, err)
 	}
 
 	// Verify epoch has completed DKG (has group public key)
@@ -49,7 +49,10 @@ func (k Keeper) RequestThresholdSignature(ctx sdk.Context, signingData types.Sig
 	messageHash := hash.Sum(nil)
 
 	// Calculate deadline block height
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get parameters: %w", err)
+	}
 	deadlineBlockHeight := ctx.BlockHeight() + int64(params.SigningDeadlineBlocks)
 
 	// Create threshold signing request
@@ -68,7 +71,10 @@ func (k Keeper) RequestThresholdSignature(ctx sdk.Context, signingData types.Sig
 	}
 
 	// Store the request
-	requestBytes := k.cdc.MustMarshal(request)
+	requestBytes, err := k.cdc.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("failed to marshal threshold signing request: %w", err)
+	}
 	err = kvStore.Set(key, requestBytes)
 	if err != nil {
 		return fmt.Errorf("failed to store threshold signing request: %w", err)
@@ -110,7 +116,10 @@ func (k Keeper) GetSigningStatus(ctx sdk.Context, requestID []byte) (*types.Thre
 	}
 
 	var request types.ThresholdSigningRequest
-	k.cdc.MustUnmarshal(requestBytes, &request)
+	err = k.cdc.Unmarshal(requestBytes, &request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal threshold signing request: %w", err)
+	}
 	return &request, nil
 }
 
@@ -126,7 +135,10 @@ func (k Keeper) ListActiveSigningRequests(ctx sdk.Context, currentEpochID uint64
 
 	for ; iterator.Valid(); iterator.Next() {
 		var request types.ThresholdSigningRequest
-		k.cdc.MustUnmarshal(iterator.Value(), &request)
+		err := k.cdc.Unmarshal(iterator.Value(), &request)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal threshold signing request: %w", err)
+		}
 
 		// Filter by epoch and active status
 		if request.CurrentEpochId == currentEpochID &&
@@ -191,9 +203,9 @@ func (k Keeper) AddPartialSignature(ctx sdk.Context, requestID []byte, slotIndic
 	}
 
 	// Get current epoch BLS data for validation
-	epochBLSData, found := k.GetEpochBLSData(ctx, request.CurrentEpochId)
-	if !found {
-		return fmt.Errorf("epoch BLS data not found for epoch %d", request.CurrentEpochId)
+	epochBLSData, err := k.GetEpochBLSData(ctx, request.CurrentEpochId)
+	if err != nil {
+		return fmt.Errorf("failed to get epoch %d BLS data: %w", request.CurrentEpochId, err)
 	}
 
 	// Validate submitter owns the claimed slot indices
@@ -342,7 +354,10 @@ func (k Keeper) storeThresholdSigningRequest(ctx sdk.Context, request *types.Thr
 	key := types.ThresholdSigningRequestKey(request.RequestId)
 	kvStore := k.storeService.OpenKVStore(ctx)
 
-	requestBytes := k.cdc.MustMarshal(request)
+	requestBytes, err := k.cdc.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("failed to marshal threshold signing request: %w", err)
+	}
 	return kvStore.Set(key, requestBytes)
 }
 

--- a/inference-chain/x/bls/module/genesis.go
+++ b/inference-chain/x/bls/module/genesis.go
@@ -11,6 +11,8 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// this line is used by starport scaffolding # genesis/module/init
 	if err := k.SetParams(ctx, genState.Params); err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 
@@ -21,7 +23,12 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 // ExportGenesis returns the module's exported genesis.
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
-	genesis.Params = k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		//nolint:forbidigo // Genesis/Export code
+		panic(err)
+	}
+	genesis.Params = params
 
 	// Export the current active epoch ID
 	activeEpochID, found := k.GetActiveEpochID(ctx)

--- a/inference-chain/x/bls/module/module.go
+++ b/inference-chain/x/bls/module/module.go
@@ -68,6 +68,7 @@ func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 // DefaultGenesis returns a default GenesisState for the module, marshalled to json.RawMessage.
 // The default GenesisState need to be defined by the module developer and is primarily used for testing.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(types.DefaultGenesis())
 }
 
@@ -83,6 +84,8 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 }
@@ -127,6 +130,7 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {
 	var genState types.GenesisState
 	// Initialize global index to index in genesis state
+	//nolint:forbidigo // Genesis code
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	InitGenesis(ctx, am.keeper, genState)
@@ -135,6 +139,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	genState := ExportGenesis(ctx, am.keeper)
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/inference-chain/x/bls/module/simulation.go
+++ b/inference-chain/x/bls/module/simulation.go
@@ -36,6 +36,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
+	//nolint:forbidigo // Simulation code
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&blsGenesis)
 }
 

--- a/inference-chain/x/bls/simulation/helpers.go
+++ b/inference-chain/x/bls/simulation/helpers.go
@@ -9,6 +9,8 @@ import (
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
+		//nolint:forbidigo
+		//Simulation code:
 		panic(err)
 	}
 	return simtypes.FindAccount(accs, creator)

--- a/inference-chain/x/bls/types/errors.go
+++ b/inference-chain/x/bls/types/errors.go
@@ -8,6 +8,7 @@ import (
 
 // x/bls module sentinel errors
 var (
-	ErrInvalidSigner = sdkerrors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
-	ErrSample        = sdkerrors.Register(ModuleName, 1101, "sample error")
+	ErrInvalidSigner        = sdkerrors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
+	ErrSample               = sdkerrors.Register(ModuleName, 1101, "sample error")
+	ErrEpochBLSDataNotFound = sdkerrors.Register(ModuleName, 1102, "epoch BLS data not found")
 )

--- a/inference-chain/x/bookkeeper/keeper/keeper.go
+++ b/inference-chain/x/bookkeeper/keeper/keeper.go
@@ -43,6 +43,8 @@ func NewKeeper(
 	logConfig LogConfig,
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(fmt.Sprintf("invalid authority address: %s", authority))
 	}
 

--- a/inference-chain/x/bookkeeper/keeper/params.go
+++ b/inference-chain/x/bookkeeper/keeper/params.go
@@ -9,15 +9,15 @@ import (
 )
 
 // GetParams get all parameters as types.Params
-func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
+func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
-		return params
+		return params, nil
 	}
 
-	k.cdc.MustUnmarshal(bz, &params)
-	return params
+	err = k.cdc.Unmarshal(bz, &params)
+	return params, err
 }
 
 // SetParams set the params

--- a/inference-chain/x/bookkeeper/keeper/params_test.go
+++ b/inference-chain/x/bookkeeper/keeper/params_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestGetParams(t *testing.T) {
 	k, ctx := keepertest.BookkeeperKeeper(t)
-	params := types.DefaultParams()
+	expectedParams := types.DefaultParams()
 
-	require.NoError(t, k.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, expectedParams))
 	params, err := k.GetParams(ctx)
 	require.NoError(t, err)
-	require.EqualValues(t, params, params)
+	require.EqualValues(t, expectedParams, params)
 }

--- a/inference-chain/x/bookkeeper/keeper/params_test.go
+++ b/inference-chain/x/bookkeeper/keeper/params_test.go
@@ -14,5 +14,7 @@ func TestGetParams(t *testing.T) {
 	params := types.DefaultParams()
 
 	require.NoError(t, k.SetParams(ctx, params))
-	require.EqualValues(t, params, k.GetParams(ctx))
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, params, params)
 }

--- a/inference-chain/x/bookkeeper/keeper/query_params.go
+++ b/inference-chain/x/bookkeeper/keeper/query_params.go
@@ -16,5 +16,10 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get parameters")
+	}
+
+	return &types.QueryParamsResponse{Params: params}, nil
 }

--- a/inference-chain/x/bookkeeper/module/genesis.go
+++ b/inference-chain/x/bookkeeper/module/genesis.go
@@ -11,6 +11,8 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// this line is used by starport scaffolding # genesis/module/init
 	if err := k.SetParams(ctx, genState.Params); err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 }
@@ -18,7 +20,12 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 // ExportGenesis returns the module's exported genesis.
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
-	genesis.Params = k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		//nolint:forbidigo // Genesis/Export code
+		panic(err)
+	}
+	genesis.Params = params
 
 	// this line is used by starport scaffolding # genesis/module/export
 

--- a/inference-chain/x/bookkeeper/module/module.go
+++ b/inference-chain/x/bookkeeper/module/module.go
@@ -68,6 +68,7 @@ func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 // DefaultGenesis returns a default GenesisState for the module, marshalled to json.RawMessage.
 // The default GenesisState need to be defined by the module developer and is primarily used for testing.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(types.DefaultGenesis())
 }
 
@@ -83,6 +84,8 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 }
@@ -127,6 +130,7 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {
 	var genState types.GenesisState
 	// Initialize global index to index in genesis state
+	//nolint:forbidigo // Genesis code
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	InitGenesis(ctx, am.keeper, genState)
@@ -135,6 +139,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	genState := ExportGenesis(ctx, am.keeper)
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/inference-chain/x/bookkeeper/module/simulation.go
+++ b/inference-chain/x/bookkeeper/module/simulation.go
@@ -36,6 +36,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
+	//nolint:forbidigo // Simulation code
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&bookkeeperGenesis)
 }
 

--- a/inference-chain/x/bookkeeper/simulation/helpers.go
+++ b/inference-chain/x/bookkeeper/simulation/helpers.go
@@ -9,6 +9,8 @@ import (
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
+		//nolint:forbidigo
+		//Simulation code:
 		panic(err)
 	}
 	return simtypes.FindAccount(accs, creator)

--- a/inference-chain/x/collateral/keeper/epoch_processing_test.go
+++ b/inference-chain/x/collateral/keeper/epoch_processing_test.go
@@ -25,14 +25,14 @@ func (s *KeeperTestSuite) TestEpochProcessing_ProcessUnbondingQueue() {
 	unbondingAmount2Coin := sdk.NewCoin(inftypes.BaseCoin, unbondingAmount2)
 
 	// Create unbonding entries
-	s.k.AddUnbondingCollateral(s.ctx, participant1, completedEpoch, unbondingAmount1Coin)
-	s.k.AddUnbondingCollateral(s.ctx, participant2, completedEpoch, unbondingAmount2Coin)
+	s.Require().NoError(s.k.AddUnbondingCollateral(s.ctx, participant1, completedEpoch, unbondingAmount1Coin))
+	s.Require().NoError(s.k.AddUnbondingCollateral(s.ctx, participant2, completedEpoch, unbondingAmount2Coin))
 
 	// Another unbonding for a future epoch that should NOT be processed
 	futureEpoch := completedEpoch + 1
 	futureParticipant, _ := sdk.AccAddressFromBech32(sample.AccAddress())
 	unbondingFutureCoin := sdk.NewInt64Coin(inftypes.BaseCoin, 50)
-	s.k.AddUnbondingCollateral(s.ctx, futureParticipant, futureEpoch, unbondingFutureCoin)
+	s.Require().NoError(s.k.AddUnbondingCollateral(s.ctx, futureParticipant, futureEpoch, unbondingFutureCoin))
 
 	// Set mock expectations for fund transfers
 	s.bankKeeper.EXPECT().
@@ -49,7 +49,7 @@ func (s *KeeperTestSuite) TestEpochProcessing_ProcessUnbondingQueue() {
 		LogSubAccountTransaction(s.ctx, participant2.String(), types.ModuleName, types.SubAccountUnbonding, gomock.Eq(unbondingAmount2Coin), gomock.Any())
 
 	// Run the epoch processing
-	s.k.AdvanceEpoch(s.ctx, completedEpoch)
+	s.Require().NoError(s.k.AdvanceEpoch(s.ctx, completedEpoch))
 
 	// Verify that the processed unbonding entries are gone
 	_, found := s.k.GetUnbondingCollateral(s.ctx, participant1, completedEpoch)

--- a/inference-chain/x/collateral/keeper/hooks_test.go
+++ b/inference-chain/x/collateral/keeper/hooks_test.go
@@ -20,7 +20,7 @@ func (s *KeeperTestSuite) TestStakingHooks_BeforeValidatorSlashed() {
 	// Setup collateral for the participant
 	initialAmount := int64(1000)
 	initialCollateral := sdk.NewInt64Coin(inftypes.BaseCoin, initialAmount)
-	s.k.SetCollateral(s.ctx, accAddr, initialCollateral)
+	s.Require().NoError(s.k.SetCollateral(s.ctx, accAddr, initialCollateral))
 
 	// Define the slash
 	slashFraction := math.LegacyNewDecWithPrec(25, 2) // 25%
@@ -58,13 +58,15 @@ func (s *KeeperTestSuite) TestStakingHooks_JailingAndUnjailing() {
 	err := hooks.AfterValidatorBeginUnbonding(s.ctx, nil, valAddr)
 	s.Require().NoError(err)
 
-	isJailed := s.k.IsJailed(s.ctx, accAddr)
+	isJailed, err := s.k.IsJailed(s.ctx, accAddr)
+	s.Require().NoError(err)
 	s.Require().True(isJailed, "participant should be marked as jailed")
 
 	// 2. Test un-jailing
 	err = hooks.AfterValidatorBonded(s.ctx, nil, valAddr)
 	s.Require().NoError(err)
 
-	isJailed = s.k.IsJailed(s.ctx, accAddr)
+	isJailed, err = s.k.IsJailed(s.ctx, accAddr)
+	s.Require().NoError(err)
 	s.Require().False(isJailed, "participant should be un-jailed")
 }

--- a/inference-chain/x/collateral/keeper/msg_server_deposit_collateral.go
+++ b/inference-chain/x/collateral/keeper/msg_server_deposit_collateral.go
@@ -42,7 +42,9 @@ func (k msgServer) DepositCollateral(goCtx context.Context, msg *types.MsgDeposi
 	k.bookkeepingBankKeeper.LogSubAccountTransaction(goCtx, types.ModuleName, msg.Participant, types.SubAccountCollateral, msg.Amount, "collateral deposit")
 
 	// Store the updated collateral
-	k.SetCollateral(ctx, participantAddr, currentCollateral)
+	if err := k.SetCollateral(ctx, participantAddr, currentCollateral); err != nil {
+		return nil, err
+	}
 
 	// Emit deposit event
 	ctx.EventManager().EmitEvents(sdk.Events{

--- a/inference-chain/x/collateral/keeper/msg_server_test.go
+++ b/inference-chain/x/collateral/keeper/msg_server_test.go
@@ -71,7 +71,7 @@ func (s *KeeperTestSuite) TestMsgDepositCollateral_Aggregation() {
 
 	// First deposit
 	initialDeposit := sdk.NewInt64Coin(inftypes.BaseCoin, 100)
-	s.k.SetCollateral(s.ctx, participant, initialDeposit)
+	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, initialDeposit))
 
 	// Second deposit
 	secondDepositAmount := int64(50)
@@ -151,7 +151,8 @@ func (s *KeeperTestSuite) TestMsgWithdrawCollateral_Success() {
 	s.Require().NoError(err)
 
 	// Verify completion epoch in response
-	params := s.k.GetParams(s.ctx)
+	params, err := s.k.GetParams(s.ctx)
+	s.Require().NoError(err)
 	expectedCompletionEpoch := uint64(10) + params.UnbondingPeriodEpochs
 	s.Require().Equal(expectedCompletionEpoch, res.CompletionEpoch)
 
@@ -223,7 +224,8 @@ func (s *KeeperTestSuite) TestMsgWithdrawCollateral_FullWithdrawal() {
 	s.Require().NoError(err)
 
 	// Verify completion epoch in response
-	params := s.k.GetParams(s.ctx)
+	params, err := s.k.GetParams(s.ctx)
+	s.Require().NoError(err)
 	expectedCompletionEpoch := uint64(20) + params.UnbondingPeriodEpochs
 	s.Require().Equal(expectedCompletionEpoch, res.CompletionEpoch)
 
@@ -247,12 +249,13 @@ func (s *KeeperTestSuite) TestMsgWithdrawCollateral_UnbondingAggregation() {
 
 	// Setup initial collateral
 	initialCollateral := sdk.NewInt64Coin(inftypes.BaseCoin, initialAmount)
-	s.k.SetCollateral(s.ctx, participant, initialCollateral)
+	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, initialCollateral))
 
 	// Set current epoch
 	currentEpoch := uint64(30)
-	s.k.SetCurrentEpoch(s.ctx, currentEpoch)
-	params := s.k.GetParams(s.ctx)
+	s.Require().NoError(s.k.SetCurrentEpoch(s.ctx, currentEpoch))
+	params, err := s.k.GetParams(s.ctx)
+	s.Require().NoError(err)
 	expectedCompletionEpoch := currentEpoch + params.UnbondingPeriodEpochs
 
 	// First withdrawal

--- a/inference-chain/x/collateral/keeper/params.go
+++ b/inference-chain/x/collateral/keeper/params.go
@@ -7,12 +7,8 @@ import (
 )
 
 // GetParams get all parameters as types.Params
-func (k Keeper) GetParams(ctx context.Context) types.Params {
-	params, err := k.params.Get(ctx)
-	if err != nil {
-		panic(err)
-	}
-	return params
+func (k Keeper) GetParams(ctx context.Context) (types.Params, error) {
+	return k.params.Get(ctx)
 }
 
 // SetParams set the params

--- a/inference-chain/x/collateral/keeper/params_test.go
+++ b/inference-chain/x/collateral/keeper/params_test.go
@@ -14,5 +14,7 @@ func TestGetParams(t *testing.T) {
 	params := types.DefaultParams()
 
 	require.NoError(t, k.SetParams(ctx, params))
-	require.EqualValues(t, params, k.GetParams(ctx))
+	res, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, params, res)
 }

--- a/inference-chain/x/collateral/keeper/query_params.go
+++ b/inference-chain/x/collateral/keeper/query_params.go
@@ -15,6 +15,10 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 
-	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+	return &types.QueryParamsResponse{Params: params}, nil
 }

--- a/inference-chain/x/collateral/keeper/query_server.go
+++ b/inference-chain/x/collateral/keeper/query_server.go
@@ -68,7 +68,10 @@ func (k Keeper) UnbondingCollateral(c context.Context, req *types.QueryUnbonding
 		return nil, status.Errorf(codes.InvalidArgument, "invalid participant address: %v", err)
 	}
 
-	unbondings := k.GetUnbondingByParticipant(ctx, participantAddr)
+	unbondings, err := k.GetUnbondingByParticipant(ctx, participantAddr)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get unbonding collateral: %v", err)
+	}
 
 	return &types.QueryUnbondingCollateralResponse{Unbondings: unbondings}, nil
 }

--- a/inference-chain/x/collateral/keeper/slashing_duplicate_test.go
+++ b/inference-chain/x/collateral/keeper/slashing_duplicate_test.go
@@ -19,7 +19,7 @@ func (s *KeeperTestSuite) TestSlashing_DuplicateGuard_SameReasonSameEpoch() {
 	s.Require().NoError(err)
 
 	// Seed collateral
-	s.k.SetCollateral(s.ctx, participant, sdk.NewInt64Coin(inftypes.BaseCoin, 1000))
+	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, sdk.NewInt64Coin(inftypes.BaseCoin, 1000)))
 
 	// Expect only one burn, from the first slash
 	s.bankKeeper.EXPECT().
@@ -48,7 +48,7 @@ func (s *KeeperTestSuite) TestSlashing_DifferentReasonSameEpoch_Allowed() {
 	s.Require().NoError(err)
 
 	// Seed collateral
-	s.k.SetCollateral(s.ctx, participant, sdk.NewInt64Coin(inftypes.BaseCoin, 1000))
+	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, sdk.NewInt64Coin(inftypes.BaseCoin, 1000)))
 
 	// Expect two burns: one for each distinct reason
 	s.bankKeeper.EXPECT().

--- a/inference-chain/x/collateral/keeper/slashing_test.go
+++ b/inference-chain/x/collateral/keeper/slashing_test.go
@@ -22,8 +22,8 @@ func (s *KeeperTestSuite) TestSlashing_Proportional() {
 	unbondingCollateral := sdk.NewInt64Coin(inftypes.BaseCoin, unbondingAmount)
 	completionEpoch := uint64(100)
 
-	s.k.SetCollateral(s.ctx, participant, activeCollateral)
-	s.k.AddUnbondingCollateral(s.ctx, participant, completionEpoch, unbondingCollateral)
+	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, activeCollateral))
+	s.Require().NoError(s.k.AddUnbondingCollateral(s.ctx, participant, completionEpoch, unbondingCollateral))
 
 	slashFraction := math.LegacyNewDecWithPrec(10, 2) // 10%
 	totalCollateral := activeAmount + unbondingAmount
@@ -66,7 +66,7 @@ func (s *KeeperTestSuite) TestSlashing_ActiveOnly() {
 	// Setup collateral state
 	activeAmount := int64(1000)
 	activeCollateral := sdk.NewInt64Coin(inftypes.BaseCoin, activeAmount)
-	s.k.SetCollateral(s.ctx, participant, activeCollateral)
+	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, activeCollateral))
 
 	slashFraction := math.LegacyNewDecWithPrec(20, 2) // 20%
 	expectedSlashedAmount := math.NewInt(activeAmount).ToLegacyDec().Mul(slashFraction).TruncateInt()
@@ -93,7 +93,8 @@ func (s *KeeperTestSuite) TestSlashing_ActiveOnly() {
 	s.Require().Equal(expectedActive, newActive.Amount)
 
 	// Verify no unbonding entries were created or affected
-	unbondingEntries := s.k.GetUnbondingByParticipant(s.ctx, participant)
+	unbondingEntries, err := s.k.GetUnbondingByParticipant(s.ctx, participant)
+	s.Require().NoError(err)
 	s.Require().Empty(unbondingEntries)
 }
 
@@ -105,7 +106,7 @@ func (s *KeeperTestSuite) TestSlashing_UnbondingOnly() {
 	unbondingAmount := int64(500)
 	unbondingCollateral := sdk.NewInt64Coin(inftypes.BaseCoin, unbondingAmount)
 	completionEpoch := uint64(100)
-	s.k.AddUnbondingCollateral(s.ctx, participant, completionEpoch, unbondingCollateral)
+	s.Require().NoError(s.k.AddUnbondingCollateral(s.ctx, participant, completionEpoch, unbondingCollateral))
 
 	slashFraction := math.LegacyNewDecWithPrec(50, 2) // 50%
 	expectedSlashedAmount := math.NewInt(unbondingAmount).ToLegacyDec().Mul(slashFraction).TruncateInt()
@@ -143,7 +144,7 @@ func (s *KeeperTestSuite) TestSlashing_InvalidFraction() {
 
 	// Setup collateral state
 	initialCollateral := sdk.NewInt64Coin(inftypes.BaseCoin, 1000)
-	s.k.SetCollateral(s.ctx, participant, initialCollateral)
+	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, initialCollateral))
 
 	// Case 1: Negative fraction
 	_, err = s.k.Slash(s.ctx, participant, math.LegacyNewDec(-1), inftypes.SlashReasonInvalidation)

--- a/inference-chain/x/collateral/module/genesis.go
+++ b/inference-chain/x/collateral/module/genesis.go
@@ -13,31 +13,51 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	for _, elem := range genState.CollateralBalanceList {
 		participant, err := sdk.AccAddressFromBech32(elem.Participant)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
-		k.SetCollateral(ctx, participant, elem.Amount)
+		if err := k.SetCollateral(ctx, participant, elem.Amount); err != nil {
+			//nolint:forbidigo
+			//Genesis code:
+			panic(err)
+		}
 	}
 
 	// Set all the unbonding collateral entries
 	for _, elem := range genState.UnbondingCollateralList {
 		participant, err := sdk.AccAddressFromBech32(elem.Participant)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
-		k.AddUnbondingCollateral(ctx, participant, elem.CompletionEpoch, elem.Amount)
+		if err := k.AddUnbondingCollateral(ctx, participant, elem.CompletionEpoch, elem.Amount); err != nil {
+			//nolint:forbidigo
+			//Genesis code:
+			panic(err)
+		}
 	}
 
 	// Set all the jailedParticipant
 	for _, elem := range genState.JailedParticipantList {
 		jailedAddr, err := sdk.AccAddressFromBech32(elem.Address)
 		if err != nil {
+			//nolint:forbidigo
+			//Genesis code:
 			panic(err)
 		}
-		k.SetJailed(ctx, jailedAddr)
+		if err := k.SetJailed(ctx, jailedAddr); err != nil {
+			//nolint:forbidigo
+			//Genesis code:
+			panic(err)
+		}
 	}
 
 	// this line is used by starport scaffolding # genesis/module/init
 	if err := k.SetParams(ctx, genState.Params); err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 }
@@ -45,25 +65,45 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 // ExportGenesis returns the module's exported genesis.
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
-	genesis.Params = k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		//nolint:forbidigo
+		//Genesis code:
+		panic(err)
+	}
+	genesis.Params = params
 
 	collateralBalances := make([]types.CollateralBalance, 0)
 	// Export all collateral balances
-	k.IterateCollaterals(ctx, func(participant sdk.AccAddress, amount sdk.Coin) (stop bool) {
+	if err := k.IterateCollaterals(ctx, func(participant sdk.AccAddress, amount sdk.Coin) (stop bool) {
 		collateralBalances = append(collateralBalances, types.CollateralBalance{
 			Participant: participant.String(),
 			Amount:      amount,
 		})
 		return false
-	})
+	}); err != nil {
+		//nolint:forbidigo
+		//Genesis code:
+		panic(err)
+	}
 
 	genesis.CollateralBalanceList = collateralBalances
 
 	// Export all unbonding collateral entries
-	unbondingCollaterals := k.GetAllUnbondings(ctx)
+	unbondingCollaterals, err := k.GetAllUnbondings(ctx)
+	if err != nil {
+		//nolint:forbidigo
+		//Genesis code:
+		panic(err)
+	}
 	genesis.UnbondingCollateralList = unbondingCollaterals
 
-	jailedParticipants := k.GetAllJailed(ctx)
+	jailedParticipants, err := k.GetAllJailed(ctx)
+	if err != nil {
+		//nolint:forbidigo
+		//Genesis code:
+		panic(err)
+	}
 	genesis.JailedParticipantList = make([]*types.JailedParticipant, len(jailedParticipants))
 	for i, addr := range jailedParticipants {
 		genesis.JailedParticipantList[i] = &types.JailedParticipant{Address: addr.String()}

--- a/inference-chain/x/collateral/module/module.go
+++ b/inference-chain/x/collateral/module/module.go
@@ -69,6 +69,7 @@ func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 // DefaultGenesis returns a default GenesisState for the module, marshalled to json.RawMessage.
 // The default GenesisState need to be defined by the module developer and is primarily used for testing.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(types.DefaultGenesis())
 }
 
@@ -84,6 +85,8 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 }
@@ -131,6 +134,7 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {
 	var genState types.GenesisState
 	// Initialize global index to index in genesis state
+	//nolint:forbidigo // Genesis code
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	InitGenesis(ctx, am.keeper, genState)
@@ -139,6 +143,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	genState := ExportGenesis(ctx, am.keeper)
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/inference-chain/x/collateral/module/simulation.go
+++ b/inference-chain/x/collateral/module/simulation.go
@@ -36,6 +36,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
+	//nolint:forbidigo // Simulation code
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&collateralGenesis)
 }
 

--- a/inference-chain/x/collateral/simulation/helpers.go
+++ b/inference-chain/x/collateral/simulation/helpers.go
@@ -9,6 +9,8 @@ import (
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
+		//nolint:forbidigo
+		//Simulation code:
 		panic(err)
 	}
 	return simtypes.FindAccount(accs, creator)

--- a/inference-chain/x/genesistransfer/keeper/grpc_query.go
+++ b/inference-chain/x/genesistransfer/keeper/grpc_query.go
@@ -39,7 +39,9 @@ func (k Keeper) TransferStatus(goCtx context.Context, req *types.QueryTransferSt
 
 	// Unmarshal the transfer record
 	var transferRecord types.TransferRecord
-	k.cdc.MustUnmarshal(bz, &transferRecord)
+	if err := k.cdc.Unmarshal(bz, &transferRecord); err != nil {
+		return nil, status.Error(codes.Internal, "failed to unmarshal transfer record")
+	}
 
 	return &types.QueryTransferStatusResponse{
 		IsTransferred:  transferRecord.Completed,
@@ -71,7 +73,10 @@ func (k Keeper) AllowedAccounts(goCtx context.Context, req *types.QueryAllowedAc
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	params := k.GetParams(goCtx)
+	params, err := k.GetParams(goCtx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get parameters")
+	}
 
 	return &types.QueryAllowedAccountsResponse{
 		AllowedAccounts: params.AllowedAccounts,

--- a/inference-chain/x/genesistransfer/keeper/keeper.go
+++ b/inference-chain/x/genesistransfer/keeper/keeper.go
@@ -39,6 +39,8 @@ func NewKeeper(
 
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(fmt.Sprintf("invalid authority address: %s", authority))
 	}
 

--- a/inference-chain/x/genesistransfer/keeper/params_test.go
+++ b/inference-chain/x/genesistransfer/keeper/params_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestGetParams(t *testing.T) {
 	k, ctx := keepertest.GenesistransferKeeper(t)
-	params := types.DefaultParams()
+	expectedParams := types.DefaultParams()
 
-	require.NoError(t, k.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, expectedParams))
 	params, err := k.GetParams(ctx)
 	require.NoError(t, err)
-	require.EqualValues(t, params, params)
+	require.EqualValues(t, expectedParams, params)
 }

--- a/inference-chain/x/genesistransfer/keeper/params_test.go
+++ b/inference-chain/x/genesistransfer/keeper/params_test.go
@@ -14,5 +14,7 @@ func TestGetParams(t *testing.T) {
 	params := types.DefaultParams()
 
 	require.NoError(t, k.SetParams(ctx, params))
-	require.EqualValues(t, params, k.GetParams(ctx))
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, params, params)
 }

--- a/inference-chain/x/genesistransfer/keeper/query_params.go
+++ b/inference-chain/x/genesistransfer/keeper/query_params.go
@@ -16,5 +16,10 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get parameters")
+	}
+
+	return &types.QueryParamsResponse{Params: params}, nil
 }

--- a/inference-chain/x/genesistransfer/keeper/validation.go
+++ b/inference-chain/x/genesistransfer/keeper/validation.go
@@ -155,7 +155,10 @@ func (k Keeper) validateAccountBalance(ctx context.Context, genesisAddr sdk.AccA
 // validateWhitelist checks if the account is allowed to be transferred (if whitelist is enabled)
 func (k Keeper) validateWhitelist(ctx context.Context, genesisAddr sdk.AccAddress) error {
 	// Get module parameters
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return err
+	}
 
 	// If whitelist restriction is disabled, allow all transfers
 	if !params.RestrictToList {
@@ -187,7 +190,10 @@ func (k Keeper) IsTransferableAccount(ctx context.Context, address string) bool 
 	}
 
 	// Get module parameters
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return false
+	}
 
 	// If whitelist restriction is disabled, all valid addresses are transferable
 	if !params.RestrictToList {

--- a/inference-chain/x/genesistransfer/module/genesis.go
+++ b/inference-chain/x/genesistransfer/module/genesis.go
@@ -11,6 +11,8 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// this line is used by starport scaffolding # genesis/module/init
 	if err := k.SetParams(ctx, genState.Params); err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 }
@@ -18,7 +20,12 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 // ExportGenesis returns the module's exported genesis.
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
-	genesis.Params = k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		//nolint:forbidigo // Genesis/Export code
+		panic(err)
+	}
+	genesis.Params = params
 
 	// this line is used by starport scaffolding # genesis/module/export
 

--- a/inference-chain/x/genesistransfer/module/module.go
+++ b/inference-chain/x/genesistransfer/module/module.go
@@ -68,6 +68,7 @@ func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 // DefaultGenesis returns a default GenesisState for the module, marshalled to json.RawMessage.
 // The default GenesisState need to be defined by the module developer and is primarily used for testing.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(types.DefaultGenesis())
 }
 
@@ -83,6 +84,8 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 }
@@ -127,6 +130,7 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {
 	var genState types.GenesisState
 	// Initialize global index to index in genesis state
+	//nolint:forbidigo // Genesis code
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	InitGenesis(ctx, am.keeper, genState)
@@ -135,6 +139,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	genState := ExportGenesis(ctx, am.keeper)
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/inference-chain/x/genesistransfer/module/simulation.go
+++ b/inference-chain/x/genesistransfer/module/simulation.go
@@ -36,6 +36,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
+	//nolint:forbidigo // Simulation code
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&genesistransferGenesis)
 }
 

--- a/inference-chain/x/genesistransfer/simulation/helpers.go
+++ b/inference-chain/x/genesistransfer/simulation/helpers.go
@@ -9,6 +9,8 @@ import (
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
+		//nolint:forbidigo
+		//Simulation code:
 		panic(err)
 	}
 	return simtypes.FindAccount(accs, creator)

--- a/inference-chain/x/genesistransfer/types/msg_transfer_ownership.go
+++ b/inference-chain/x/genesistransfer/types/msg_transfer_ownership.go
@@ -29,7 +29,8 @@ func (msg *MsgTransferOwnership) ValidateBasic() error {
 func (msg *MsgTransferOwnership) GetSigners() []sdk.AccAddress {
 	addr, err := sdk.AccAddressFromBech32(msg.GenesisAddress)
 	if err != nil {
-		panic(err)
+		// This should not happen if ValidateBasic is called first
+		return nil
 	}
 	return []sdk.AccAddress{addr}
 }

--- a/inference-chain/x/inference/calculations/inference_state.go
+++ b/inference-chain/x/inference/calculations/inference_state.go
@@ -93,7 +93,6 @@ func ProcessStartInference(
 			payments.EscrowAmount = escrowAmount
 		}
 	}
-
 	return currentInference, payments, nil
 }
 
@@ -196,5 +195,9 @@ func CalculateEscrow(inference *types.Inference, promptTokens uint64) int64 {
 	// RecordInferencePrice ensures this is always set to the correct value:
 	// - Dynamic price from BeginBlocker (including 0 for grace period)
 	// - Legacy fallback price (1000) if dynamic pricing unavailable
-	return int64((inference.MaxTokens + promptTokens) * inference.PerTokenPrice)
+
+	var totalTokens uint64 = inference.MaxTokens + promptTokens
+	escrow := totalTokens * inference.PerTokenPrice
+	int64Escrow := int64(escrow)
+	return int64Escrow
 }

--- a/inference-chain/x/inference/calculations/inference_state.go
+++ b/inference-chain/x/inference/calculations/inference_state.go
@@ -93,6 +93,7 @@ func ProcessStartInference(
 			payments.EscrowAmount = escrowAmount
 		}
 	}
+
 	return currentInference, payments, nil
 }
 
@@ -195,9 +196,5 @@ func CalculateEscrow(inference *types.Inference, promptTokens uint64) int64 {
 	// RecordInferencePrice ensures this is always set to the correct value:
 	// - Dynamic price from BeginBlocker (including 0 for grace period)
 	// - Legacy fallback price (1000) if dynamic pricing unavailable
-
-	var totalTokens uint64 = inference.MaxTokens + promptTokens
-	escrow := totalTokens * inference.PerTokenPrice
-	int64Escrow := int64(escrow)
-	return int64Escrow
+	return int64((inference.MaxTokens + promptTokens) * inference.PerTokenPrice)
 }

--- a/inference-chain/x/inference/calculations/inference_state_test.go
+++ b/inference-chain/x/inference/calculations/inference_state_test.go
@@ -1,6 +1,7 @@
 package calculations
 
 import (
+	"math"
 	"testing"
 
 	"github.com/productscience/inference/x/inference/types"
@@ -334,6 +335,28 @@ func TestProcessStartInference(t *testing.T) {
 			expectError:    false,
 			expectedStatus: types.InferenceStatus_STARTED,
 		},
+		{
+			name: "New inference with out of range tokens",
+			currentInference: &types.Inference{
+				PerTokenPrice: PerTokenCost,
+			},
+			startMessage: &types.MsgStartInference{
+				InferenceId:      "test-id",
+				PromptHash:       "hash",
+				PromptTokenCount: 10,
+				RequestedBy:      "requester",
+				Model:            "model",
+				MaxTokens:        math.MaxInt64 / 900, // Out of range
+				AssignedTo:       "assignee",
+				NodeVersion:      "1.0",
+			},
+			blockContext: BlockContext{
+				BlockHeight:    100,
+				BlockTimestamp: 1000,
+			},
+			expectError:    true,
+			expectedStatus: types.InferenceStatus_STARTED,
+		},
 	}
 
 	for _, tt := range tests {
@@ -474,4 +497,11 @@ func TestProcessFinishInference(t *testing.T) {
 			assert.Equal(t, expectedCost, inference.ActualCost)
 		})
 	}
+}
+
+func TestOverflow(t *testing.T) {
+	var total = uint64(math.MaxInt64) / 900
+	result := total * 1000
+	println(result)
+	println(int64(result))
 }

--- a/inference-chain/x/inference/calculations/inference_state_test.go
+++ b/inference-chain/x/inference/calculations/inference_state_test.go
@@ -1,7 +1,6 @@
 package calculations
 
 import (
-	"math"
 	"testing"
 
 	"github.com/productscience/inference/x/inference/types"
@@ -335,28 +334,6 @@ func TestProcessStartInference(t *testing.T) {
 			expectError:    false,
 			expectedStatus: types.InferenceStatus_STARTED,
 		},
-		{
-			name: "New inference with out of range tokens",
-			currentInference: &types.Inference{
-				PerTokenPrice: PerTokenCost,
-			},
-			startMessage: &types.MsgStartInference{
-				InferenceId:      "test-id",
-				PromptHash:       "hash",
-				PromptTokenCount: 10,
-				RequestedBy:      "requester",
-				Model:            "model",
-				MaxTokens:        math.MaxInt64 / 900, // Out of range
-				AssignedTo:       "assignee",
-				NodeVersion:      "1.0",
-			},
-			blockContext: BlockContext{
-				BlockHeight:    100,
-				BlockTimestamp: 1000,
-			},
-			expectError:    true,
-			expectedStatus: types.InferenceStatus_STARTED,
-		},
 	}
 
 	for _, tt := range tests {
@@ -497,11 +474,4 @@ func TestProcessFinishInference(t *testing.T) {
 			assert.Equal(t, expectedCost, inference.ActualCost)
 		})
 	}
-}
-
-func TestOverflow(t *testing.T) {
-	var total = uint64(math.MaxInt64) / 900
-	result := total * 1000
-	println(result)
-	println(int64(result))
 }

--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -70,7 +70,7 @@ func (sp *SettleParameters) getNextCutoff() int64 {
 }
 
 func (k *Keeper) GetSettleParameters(ctx context.Context) (*SettleParameters, error) {
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 	}
 
 	// Check governance flag to determine which reward system to use
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		k.LogError("Error getting params", types.Settle, "error", err)
 		return err
@@ -399,7 +399,7 @@ func getSettleAmount(participant types.Participant, rewardInfo []DistributedCoin
 }
 
 func (k Keeper) ReduceSubsidyPercentage(ctx context.Context) error {
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		return err
 	}

--- a/inference-chain/x/inference/keeper/accountsettle_test.go
+++ b/inference-chain/x/inference/keeper/accountsettle_test.go
@@ -403,7 +403,8 @@ func TestActualSettle(t *testing.T) {
 	keeper, ctx, mocks := keeper2.InferenceKeeperReturningMocks(t)
 
 	// Configure to use legacy reward system for this test
-	params := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(ctx)
+	require.NoError(t, err)
 	params.BitcoinRewardParams.UseBitcoinRewards = false
 	keeper.SetParams(ctx, params)
 	logger.Info("Configured to use legacy reward system")
@@ -433,7 +434,7 @@ func TestActualSettle(t *testing.T) {
 	mocks.BankKeeper.EXPECT().MintCoins(gomock.Any(), types.ModuleName, coins, gomock.Any()).Return(nil)
 	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	err := keeper.SettleAccounts(ctx, 10, 0)
+	err = keeper.SettleAccounts(ctx, 10, 0)
 	require.NoError(t, err, "SettleAccounts should complete successfully")
 	logger.Info("SettleAccounts completed successfully")
 	updated1, found := keeper.GetParticipant(ctx, participant1.Address)
@@ -470,7 +471,8 @@ func TestActualSettleWithManyParticipants(t *testing.T) {
 	keeper, ctx, mocks := keeper2.InferenceKeeperReturningMocks(t)
 
 	// Configure to use legacy reward system for this test
-	params := keeper.GetParams(ctx)
+	params, err := keeper.GetParams(ctx)
+	require.NoError(t, err)
 	params.BitcoinRewardParams.UseBitcoinRewards = false
 	keeper.SetParams(ctx, params)
 	logger.Info("Configured to use legacy reward system")
@@ -525,7 +527,7 @@ func TestActualSettleWithManyParticipants(t *testing.T) {
 
 	// This should work with pagination and process all 150 participants
 	logger.Info("Starting SettleAccounts for 150 participants")
-	err := keeper.SettleAccounts(ctx, 10, 0)
+	err = keeper.SettleAccounts(ctx, 10, 0)
 	require.NoError(t, err, "SettleAccounts should complete successfully with 150 participants")
 	logger.Info("SettleAccounts completed successfully")
 

--- a/inference-chain/x/inference/keeper/activeparticipants.go
+++ b/inference-chain/x/inference/keeper/activeparticipants.go
@@ -8,14 +8,18 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-func (k Keeper) SetActiveParticipantsV1(ctx context.Context, participants types.ActiveParticipants) {
+func (k Keeper) SetActiveParticipantsV1(ctx context.Context, participants types.ActiveParticipants) error {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, []byte{})
 
 	key := types.ActiveParticipantsFullKeyV1(participants.EpochGroupId)
 
-	b := k.cdc.MustMarshal(&participants)
+	b, err := k.cdc.Marshal(&participants)
+	if err != nil {
+		return err
+	}
 	store.Set(key, b)
+	return nil
 }
 
 func (k Keeper) GetActiveParticipants(ctx context.Context, epochId uint64) (val types.ActiveParticipants, found bool) {
@@ -29,7 +33,11 @@ func (k Keeper) GetActiveParticipants(ctx context.Context, epochId uint64) (val 
 		return types.ActiveParticipants{}, false
 	}
 
-	k.cdc.MustUnmarshal(b, &val)
+	err := k.cdc.Unmarshal(b, &val)
+	if err != nil {
+		k.LogError("Unable to marshal ActiveParticipants", types.Participants, "epochIndex", epochId)
+		return types.ActiveParticipants{}, false
+	}
 	return val, true
 }
 

--- a/inference-chain/x/inference/keeper/bitcoin_integration_test.go
+++ b/inference-chain/x/inference/keeper/bitcoin_integration_test.go
@@ -32,19 +32,22 @@ func TestBitcoinRewardIntegration_GovernanceFlagSwitching(t *testing.T) {
 		require.NoError(t, k.SetParams(ctx, params))
 
 		// Verify parameters were set correctly
-		retrievedParams := k.GetParams(ctx)
+		retrievedParams, err := k.GetParams(ctx)
+		require.NoError(t, err)
 		require.True(t, retrievedParams.BitcoinRewardParams.UseBitcoinRewards, "Bitcoin rewards should be enabled")
 		require.Equal(t, uint64(50000), retrievedParams.BitcoinRewardParams.InitialEpochReward, "Initial epoch reward should be set")
 	})
 
 	t.Run("Test Bitcoin rewards disabled (legacy system)", func(t *testing.T) {
 		// Disable Bitcoin rewards (use legacy system)
-		params := k.GetParams(ctx)
+		params, err := k.GetParams(ctx)
+		require.NoError(t, err)
 		params.BitcoinRewardParams.UseBitcoinRewards = false
 		require.NoError(t, k.SetParams(ctx, params))
 
 		// Verify parameters were set correctly
-		retrievedParams := k.GetParams(ctx)
+		retrievedParams, err := k.GetParams(ctx)
+		require.NoError(t, err)
 		require.False(t, retrievedParams.BitcoinRewardParams.UseBitcoinRewards, "Bitcoin rewards should be disabled")
 	})
 }
@@ -68,7 +71,8 @@ func TestBitcoinRewardIntegration_ParameterValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Retrieve and verify parameters
-	retrievedParams := k.GetParams(ctx)
+	retrievedParams, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	require.True(t, retrievedParams.BitcoinRewardParams.UseBitcoinRewards)
 	require.Equal(t, uint64(285000000000000), retrievedParams.BitcoinRewardParams.InitialEpochReward)
 	decayRateLegacy, err := retrievedParams.BitcoinRewardParams.DecayRate.ToLegacyDec()
@@ -271,7 +275,8 @@ func TestBitcoinRewardIntegration_DefaultParameters(t *testing.T) {
 	require.NoError(t, k.SetParams(ctx, defaultParams))
 
 	// Verify default Bitcoin reward parameters
-	retrievedParams := k.GetParams(ctx)
+	retrievedParams, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	bitcoinParams := retrievedParams.BitcoinRewardParams
 
 	// Test the default values match our specifications

--- a/inference-chain/x/inference/keeper/collateral.go
+++ b/inference-chain/x/inference/keeper/collateral.go
@@ -16,7 +16,10 @@ import (
 // This function modifies the participants' weights in-memory.
 func (k Keeper) AdjustWeightsByCollateral(ctx context.Context, participants []*types.ActiveParticipant) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	inferenceParams := k.GetParams(sdkCtx)
+	inferenceParams, err := k.GetParams(sdkCtx)
+	if err != nil {
+		return fmt.Errorf("failed to get params: %w", err)
+	}
 
 	latestEpoch, found := k.GetLatestEpoch(sdkCtx)
 	if !found {

--- a/inference-chain/x/inference/keeper/developer_stats_aggregation_test.go
+++ b/inference-chain/x/inference/keeper/developer_stats_aggregation_test.go
@@ -78,17 +78,17 @@ func TestDeveloperStats_MultipleDevs_MultipleEpochs(t *testing.T) {
 	keeper, ctx := keepertest.InferenceKeeper(t)
 
 	keeper.SetEpoch(ctx, &types.Epoch{Index: epochId1, PocStartBlockHeight: int64(epochId1 * 10)})
-	keeper.SetEffectiveEpochIndex(ctx, epochId1)
+	_ = keeper.SetEffectiveEpochIndex(ctx, epochId1)
 
 	assert.NoError(t, keeper.SetDeveloperStats(ctx, inference1Developer1)) // tagged to epoch 1
 	assert.NoError(t, keeper.SetDeveloperStats(ctx, inference1Developer2)) // tagged to epoch 1
 
 	keeper.SetEpoch(ctx, &types.Epoch{Index: epochId2, PocStartBlockHeight: int64(epochId2 * 10)})
-	keeper.SetEffectiveEpochIndex(ctx, epochId2)
+	_ = keeper.SetEffectiveEpochIndex(ctx, epochId2)
 	assert.NoError(t, keeper.SetDeveloperStats(ctx, inference2Developer1)) // tagged to epoch 2
 
 	keeper.SetEpoch(ctx, &types.Epoch{Index: epochId3, PocStartBlockHeight: int64(epochId3 * 10)})
-	keeper.SetEffectiveEpochIndex(ctx, epochId3)
+	_ = keeper.SetEffectiveEpochIndex(ctx, epochId3)
 	assert.NoError(t, keeper.SetDeveloperStats(ctx, inference2Developer2)) // tagged to epoch 3
 
 	defaultExpectedStatsByTime := map[string]*types.DeveloperStatsByTime{
@@ -300,7 +300,7 @@ func TestDeveloperStats_OneDev(t *testing.T) {
 	t.Run("inferences with zero start_timestamp and same end_timestamp, epoch and developer", func(t *testing.T) {
 		keeper, ctx := keepertest.InferenceKeeper(t)
 		keeper.SetEpoch(ctx, &types.Epoch{Index: epochId1, PocStartBlockHeight: int64(epochId1 * 10)})
-		keeper.SetEffectiveEpochIndex(ctx, epochId1)
+		_ = keeper.SetEffectiveEpochIndex(ctx, epochId1)
 
 		now := time.Now().UnixMilli()
 
@@ -350,7 +350,7 @@ func TestDeveloperStats_OneDev(t *testing.T) {
 	t.Run("update same inference", func(t *testing.T) {
 		keeper, ctx := keepertest.InferenceKeeper(t)
 		keeper.SetEpoch(ctx, &types.Epoch{Index: epochId1, PocStartBlockHeight: int64(epochId1 * 10)})
-		keeper.SetEffectiveEpochIndex(ctx, epochId1)
+		_ = keeper.SetEffectiveEpochIndex(ctx, epochId1)
 
 		inference := types.Inference{
 			InferenceId:          "inferenceId1",
@@ -385,7 +385,7 @@ func TestDeveloperStats_OneDev(t *testing.T) {
 		inference.EndBlockTimestamp = time.Now().Add(5 * time.Second).UnixMilli()
 
 		keeper.SetEpoch(ctx, &types.Epoch{Index: epochId2, PocStartBlockHeight: int64(epochId2 * 10)})
-		keeper.SetEffectiveEpochIndex(ctx, epochId2)
+		_ = keeper.SetEffectiveEpochIndex(ctx, epochId2)
 		assert.NoError(t, keeper.SetDeveloperStats(ctx, inference))
 
 		expectedStatsAfterUpdate := types.InferenceStats{
@@ -412,7 +412,7 @@ func TestDeveloperStats_OneDev(t *testing.T) {
 		keeper, ctx := keepertest.InferenceKeeper(t)
 		keeper.SetEpoch(ctx, &types.Epoch{Index: epochId1, PocStartBlockHeight: int64(epochId1 * 10)})
 		keeper.SetEpoch(ctx, &types.Epoch{Index: epochId2, PocStartBlockHeight: int64(epochId2 * 10)})
-		keeper.SetEffectiveEpochIndex(ctx, epochId3)
+		_ = keeper.SetEffectiveEpochIndex(ctx, epochId3)
 
 		inference := types.Inference{
 			InferenceId:              uuid.New().String(),

--- a/inference-chain/x/inference/keeper/dynamic_pricing.go
+++ b/inference-chain/x/inference/keeper/dynamic_pricing.go
@@ -16,7 +16,10 @@ import (
 // Called from BeginBlocker to ensure prices are calculated once per block
 func (k *Keeper) UpdateDynamicPricing(ctx context.Context) error {
 	// Get current parameters
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get params: %w", err)
+	}
 	if params.DynamicPricingParams == nil {
 		return fmt.Errorf("dynamic pricing parameters not found")
 	}
@@ -132,7 +135,10 @@ func (k *Keeper) UpdateDynamicPricing(ctx context.Context) error {
 // Returns the new per-token price for a specific model based on utilization
 func (k *Keeper) CalculateModelDynamicPrice(ctx context.Context, modelId string, utilization float64) (uint64, uint64, error) {
 	// Get current parameters
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get params: %w", err)
+	}
 	if params.DynamicPricingParams == nil {
 		return 0, 0, fmt.Errorf("dynamic pricing parameters not found")
 	}

--- a/inference-chain/x/inference/keeper/dynamic_pricing_test.go
+++ b/inference-chain/x/inference/keeper/dynamic_pricing_test.go
@@ -127,7 +127,8 @@ func TestCalculateModelDynamicPrice(t *testing.T) {
 			k, ctx := setupTestKeeperWithDynamicPricing(t)
 
 			// Set dynamic pricing parameters
-			params := k.GetParams(ctx)
+			params, err := k.GetParams(ctx)
+			require.NoError(t, err)
 			params.DynamicPricingParams = &types.DynamicPricingParams{
 				StabilityZoneLowerBound:   types.DecimalFromFloat(tt.stabilityLowerBound),
 				StabilityZoneUpperBound:   types.DecimalFromFloat(tt.stabilityUpperBound),
@@ -292,7 +293,8 @@ func TestStabilityZoneBoundaries(t *testing.T) {
 			goCtx := sdk.UnwrapSDKContext(ctx)
 
 			// Set parameters
-			params := k.GetParams(ctx)
+			params, err := k.GetParams(ctx)
+			require.NoError(t, err)
 			params.DynamicPricingParams = &types.DynamicPricingParams{
 				StabilityZoneLowerBound: types.DecimalFromFloat(0.40),
 				StabilityZoneUpperBound: types.DecimalFromFloat(0.60),
@@ -305,7 +307,7 @@ func TestStabilityZoneBoundaries(t *testing.T) {
 
 			// Set initial price (larger price to make small percentage changes visible)
 			initialPrice := uint64(10000)
-			err := k.SetModelCurrentPrice(goCtx, "test-model", initialPrice)
+			err = k.SetModelCurrentPrice(goCtx, "test-model", initialPrice)
 			require.NoError(t, err)
 
 			// Calculate price
@@ -334,7 +336,8 @@ func TestDynamicPricingCoreWorkflow(t *testing.T) {
 	model3 := "Claude-3.5-Sonnet"
 
 	// Configure dynamic pricing parameters for testing
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	params.DynamicPricingParams.StabilityZoneLowerBound = types.DecimalFromFloat(0.40)
 	params.DynamicPricingParams.StabilityZoneUpperBound = types.DecimalFromFloat(0.60)
 	params.DynamicPricingParams.PriceElasticity = types.DecimalFromFloat(0.05)
@@ -345,7 +348,7 @@ func TestDynamicPricingCoreWorkflow(t *testing.T) {
 	k.SetParams(ctx, params)
 
 	// Cache model capacities (simulate epoch activation)
-	err := k.CacheModelCapacity(goCtx, model1, 1000) // 1000 tokens/sec capacity
+	err = k.CacheModelCapacity(goCtx, model1, 1000) // 1000 tokens/sec capacity
 	require.NoError(t, err)
 	err = k.CacheModelCapacity(goCtx, model2, 2000) // 2000 tokens/sec capacity
 	require.NoError(t, err)
@@ -501,7 +504,8 @@ func TestDynamicPricingWithRealStats(t *testing.T) {
 	goCtx := sdk.WrapSDKContext(ctx)
 
 	// Setup: Configure dynamic pricing parameters
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	params.DynamicPricingParams.StabilityZoneLowerBound = types.DecimalFromFloat(0.40)
 	params.DynamicPricingParams.StabilityZoneUpperBound = types.DecimalFromFloat(0.60)
 	params.DynamicPricingParams.PriceElasticity = types.DecimalFromFloat(0.05)
@@ -517,7 +521,7 @@ func TestDynamicPricingWithRealStats(t *testing.T) {
 	// Setup: Cache model capacity
 	modelId := "Qwen2.5-7B-Instruct"
 	modelCapacity := int64(1000) // 1000 tokens/second capacity
-	err := k.CacheModelCapacity(goCtx, modelId, modelCapacity)
+	err = k.CacheModelCapacity(goCtx, modelId, modelCapacity)
 	require.NoError(t, err)
 
 	// Setup: Set initial price

--- a/inference-chain/x/inference/keeper/epoch.go
+++ b/inference-chain/x/inference/keeper/epoch.go
@@ -6,10 +6,8 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-func (k Keeper) SetEffectiveEpochIndex(ctx context.Context, epoch uint64) {
-	if err := k.EffectiveEpochIndex.Set(ctx, epoch); err != nil {
-		panic(err)
-	}
+func (k Keeper) SetEffectiveEpochIndex(ctx context.Context, epoch uint64) error {
+	return k.EffectiveEpochIndex.Set(ctx, epoch)
 }
 
 func (k Keeper) GetEffectiveEpochIndex(ctx context.Context) (uint64, bool) {

--- a/inference-chain/x/inference/keeper/genesis_only_params.go
+++ b/inference-chain/x/inference/keeper/genesis_only_params.go
@@ -8,11 +8,15 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-func (k Keeper) SetGenesisOnlyParams(ctx context.Context, params *types.GenesisOnlyParams) {
+func (k Keeper) SetGenesisOnlyParams(ctx context.Context, params *types.GenesisOnlyParams) error {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.GenesisOnlyDataKey))
-	b := k.cdc.MustMarshal(params)
+	b, err := k.cdc.Marshal(params)
+	if err != nil {
+		return err
+	}
 	store.Set([]byte{0}, b)
+	return nil
 }
 
 func (k Keeper) GetGenesisOnlyParams(ctx context.Context) (val types.GenesisOnlyParams, found bool) {
@@ -24,7 +28,10 @@ func (k Keeper) GetGenesisOnlyParams(ctx context.Context) (val types.GenesisOnly
 		return val, false
 	}
 
-	k.cdc.MustUnmarshal(b, &val)
+	err := k.cdc.Unmarshal(b, &val)
+	if err != nil {
+		return val, false
+	}
 	return val, true
 }
 

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -99,6 +99,7 @@ func NewKeeper(
 	upgradeKeeper types.UpgradeKeeper,
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
+		//nolint:forbidigo // init code
 		panic(fmt.Sprintf("invalid authority address: %s", authority))
 	}
 
@@ -380,6 +381,7 @@ func NewKeeper(
 	// Build the collections schema
 	schema, err := sb.Build()
 	if err != nil {
+		//nolint:forbidigo // init code
 		panic(err)
 	}
 	k.Schema = schema

--- a/inference-chain/x/inference/keeper/keeper_training_run_store.go
+++ b/inference-chain/x/inference/keeper/keeper_training_run_store.go
@@ -26,7 +26,8 @@ func (k *TrainingRunStore) GetRunState(ctx context.Context, runId uint64) *types
 		return nil
 	} else {
 		if task == nil {
-			panic("keeper.GetTrainingTask: task = nil. found = true")
+			k.keeper.LogError("keeper.GetTrainingTask: task = nil. found = true", types.Training)
+			return nil
 		}
 
 		return task
@@ -73,7 +74,8 @@ func (k *TrainingRunStore) GetParticipantActivity(ctx context.Context, runId uin
 		return nil
 	} else {
 		if activity == nil {
-			panic("GetParticipantActivity: nil training task node epoch activity")
+			k.keeper.LogError("GetParticipantActivity: nil training task node epoch activity", types.Training)
+			return nil
 		}
 
 		return activity

--- a/inference-chain/x/inference/keeper/liquidity_pool.go
+++ b/inference-chain/x/inference/keeper/liquidity_pool.go
@@ -9,11 +9,12 @@ import (
 )
 
 // SetLiquidityPool stores the singleton, governance-controlled liquidity pool.
-func (k Keeper) SetLiquidityPool(ctx context.Context, pool types.LiquidityPool) {
+func (k Keeper) SetLiquidityPool(ctx context.Context, pool types.LiquidityPool) error {
 	if err := k.LiquidityPoolItem.Set(ctx, pool); err != nil {
-		panic(err)
+		return err
 	}
 	k.LogDebug("Saved LiquidityPool", types.System, "address", pool.Address)
+	return nil
 }
 
 // GetLiquidityPool fetches the singleton, governance-controlled liquidity pool.
@@ -23,27 +24,27 @@ func (k Keeper) GetLiquidityPool(ctx context.Context) (val types.LiquidityPool, 
 		if errors.Is(err, collections.ErrNotFound) {
 			return val, false
 		}
-		panic(err)
+		k.LogError("failed to get liquidity pool", types.System, "error", err)
+		return val, false
 	}
 	return pool, true
 }
 
 // RemoveLiquidityPool deletes the singleton liquidity pool from the store.
-func (k Keeper) RemoveLiquidityPool(ctx context.Context) {
+func (k Keeper) RemoveLiquidityPool(ctx context.Context) error {
 	if err := k.LiquidityPoolItem.Remove(ctx); err != nil && !errors.Is(err, collections.ErrNotFound) {
-		panic(err)
+		return err
 	}
 	k.LogDebug("Removed LiquidityPool", types.System)
+	return nil
 }
 
 // LiquidityPoolExists returns true if the singleton liquidity pool is present.
 func (k Keeper) LiquidityPoolExists(ctx context.Context) bool {
-	_, err := k.LiquidityPoolItem.Get(ctx)
+	exists, err := k.LiquidityPoolItem.Has(ctx)
 	if err != nil {
-		if errors.Is(err, collections.ErrNotFound) {
-			return false
-		}
-		panic(err)
+		k.LogError("failed to check if liquidity pool exists", types.System, "error", err)
+		return false
 	}
-	return true
+	return exists
 }

--- a/inference-chain/x/inference/keeper/mlnode_version.go
+++ b/inference-chain/x/inference/keeper/mlnode_version.go
@@ -9,11 +9,15 @@ import (
 )
 
 // SetMLNodeVersion set mlNodeVersion in the store
-func (k Keeper) SetMLNodeVersion(ctx context.Context, mlNodeVersion types.MLNodeVersion) {
+func (k Keeper) SetMLNodeVersion(ctx context.Context, mlNodeVersion types.MLNodeVersion) error {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.MLNodeVersionKey))
-	b := k.cdc.MustMarshal(&mlNodeVersion)
+	b, err := k.cdc.Marshal(&mlNodeVersion)
+	if err != nil {
+		return err
+	}
 	store.Set([]byte{0}, b)
+	return nil
 }
 
 // GetMLNodeVersion returns mlNodeVersion
@@ -26,6 +30,9 @@ func (k Keeper) GetMLNodeVersion(ctx context.Context) (val types.MLNodeVersion, 
 		return val, false
 	}
 
-	k.cdc.MustUnmarshal(b, &val)
+	err := k.cdc.Unmarshal(b, &val)
+	if err != nil {
+		return val, false
+	}
 	return val, true
 }

--- a/inference-chain/x/inference/keeper/msg_participant_allowlist_test.go
+++ b/inference-chain/x/inference/keeper/msg_participant_allowlist_test.go
@@ -98,7 +98,8 @@ func TestIsParticipantAllowed_AllowlistDisabled(t *testing.T) {
 	wctx := sdk.UnwrapSDKContext(ctx)
 
 	// default: allowlist disabled
-	params := k.GetParams(wctx)
+	params, err := k.GetParams(wctx)
+	require.NoError(t, err)
 	require.False(t, params.ParticipantAccessParams.UseParticipantAllowlist)
 
 	// any address should be allowed when disabled
@@ -114,7 +115,8 @@ func TestIsParticipantAllowed_AllowlistEnabled(t *testing.T) {
 	acc, _ := sdk.AccAddressFromBech32(addr)
 
 	// enable allowlist
-	params := k.GetParams(wctx)
+	params, err := k.GetParams(wctx)
+	require.NoError(t, err)
 	params.ParticipantAccessParams.UseParticipantAllowlist = true
 	require.NoError(t, k.SetParams(wctx, params))
 
@@ -135,7 +137,8 @@ func TestIsParticipantAllowed_UntilBlockHeight(t *testing.T) {
 	addr := "gonka1hgt9lxxxwpsnc3yn2nheqqy9a8vlcjwvgzpve2"
 
 	// enable allowlist with cutoff at height 200
-	params := k.GetParams(wctx)
+	params, err := k.GetParams(wctx)
+	require.NoError(t, err)
 	params.ParticipantAccessParams.UseParticipantAllowlist = true
 	params.ParticipantAccessParams.ParticipantAllowlistUntilBlockHeight = 200
 	require.NoError(t, k.SetParams(wctx, params))
@@ -149,4 +152,3 @@ func TestIsParticipantAllowed_UntilBlockHeight(t *testing.T) {
 	// at height 300 (> 200): allowlist disabled -> allowed
 	require.True(t, k.IsParticipantAllowed(wctx, 300, addr))
 }
-

--- a/inference-chain/x/inference/keeper/msg_register_wrapped_token_contract.go
+++ b/inference-chain/x/inference/keeper/msg_register_wrapped_token_contract.go
@@ -14,6 +14,8 @@ func (k msgServer) RegisterWrappedTokenContract(goCtx context.Context, req *type
 		return nil, errorsmod.Wrapf(types.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.GetAuthority(), req.Authority)
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	k.SetWrappedTokenCodeID(ctx, req.CodeId)
+	if err := k.SetWrappedTokenCodeID(ctx, req.CodeId); err != nil {
+		return nil, err
+	}
 	return &types.MsgRegisterWrappedTokenContractResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_approve_bridge_token_for_trading.go
+++ b/inference-chain/x/inference/keeper/msg_server_approve_bridge_token_for_trading.go
@@ -31,7 +31,9 @@ func (k msgServer) ApproveBridgeTokenForTrading(goCtx context.Context, msg *type
 	}
 
 	// Store the approved token
-	k.SetBridgeTradeApprovedToken(ctx, approvedToken)
+	if err := k.SetBridgeTradeApprovedToken(ctx, approvedToken); err != nil {
+		return nil, err
+	}
 
 	k.LogInfo("Approve bridge token for trading: Token approved successfully",
 		types.Messages,

--- a/inference-chain/x/inference/keeper/msg_server_bridge_exchange_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_bridge_exchange_test.go
@@ -21,7 +21,7 @@ func TestBridgeExchange_DoubleVoteCaseBypass(t *testing.T) {
 
 	// Setup Epoch
 	epochIndex := uint64(1)
-	k.SetEffectiveEpochIndex(ctx, epochIndex)
+	_ = k.SetEffectiveEpochIndex(ctx, epochIndex)
 
 	// Setup Epoch Group Data
 	epochGroupData := types.EpochGroupData{

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -164,7 +164,12 @@ func (k msgServer) validateRequest(ctx sdk.Context, msg *types.MsgClaimRewards) 
 		}
 	}
 	settleAmount.LastClaimAttempt = ctx.BlockHeight()
-	k.SetSettleAmount(ctx, settleAmount)
+	if err := k.SetSettleAmount(ctx, settleAmount); err != nil {
+		return nil, &types.MsgClaimRewardsResponse{
+			Amount: 0,
+			Result: "Internal error updating settle amount",
+		}
+	}
 	if settleAmount.GetTotalCoins() == 0 {
 		k.LogInfo("SettleAmount had zero coins", types.Claims, "address", msg.Creator)
 		return nil, &types.MsgClaimRewardsResponse{
@@ -208,6 +213,7 @@ func (k msgServer) validateClaim(ctx sdk.Context, msg *types.MsgClaimRewards, se
 }
 
 func (k msgServer) hasSignificantMissedValidations(ctx sdk.Context, msg *types.MsgClaimRewards) (bool, error) {
+	//nolint:forbidigo // Must in different context
 	mustBeValidated, err := k.getMustBeValidatedInferences(ctx, msg)
 	if err != nil {
 		return false, err
@@ -329,6 +335,7 @@ func (k msgServer) getEpochGroupWeightData(ctx sdk.Context, pocStartHeight uint6
 	return &epochData, weightMap, totalWeight, true
 }
 
+//nolint:forbidigo // different use of "Must"
 func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgClaimRewards) ([]string, error) {
 	// Get the main epoch data
 	mainEpochData, mainWeightMap, mainTotalWeight, found := k.getEpochGroupWeightData(ctx, msg.EpochIndex, "")

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -51,7 +51,10 @@ func (ms msgServer) payoutClaim(ctx sdk.Context, msg *types.MsgClaimRewards, set
 
 	// Pay for work from escrow
 	escrowPayment := settleAmount.GetWorkCoins()
-	params := ms.GetParams(ctx)
+	params, err := ms.GetParams(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get params: %w", err)
+	}
 	workVestingPeriod := &params.TokenomicsParams.WorkVestingPeriod
 	if err := ms.PayParticipantFromEscrow(ctx, msg.Creator, int64(escrowPayment), "work_coins:"+settleAmount.Participant, workVestingPeriod); err != nil {
 		if sdkerrors.ErrInsufficientFunds.Is(err) {
@@ -227,7 +230,10 @@ func (k msgServer) hasSignificantMissedValidations(ctx sdk.Context, msg *types.M
 			missed++
 		}
 	}
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get params: %w", err)
+	}
 	p0 := decimal.NewFromFloat(0.10)
 	if params.ValidationParams != nil && params.ValidationParams.BinomTestP0 != nil {
 		p0 = params.ValidationParams.BinomTestP0.ToDecimal()
@@ -356,8 +362,11 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 		return nil, types.ErrIllegalState.Wrapf("epoch.PocStartHeight = %d, msg.EpochIndex = %d, mainEpochData.EpochIndex = %d", epoch.Index, msg.EpochIndex, mainEpochData.EpochIndex)
 	}
 
-	params := k.Keeper.GetParams(ctx).EpochParams
-	epochContext := types.NewEpochContext(*epoch, *params)
+	params, err := k.Keeper.GetParams(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get params: %w", err)
+	}
+	epochContext := types.NewEpochContext(*epoch, *params.EpochParams)
 
 	// Create a map to store weight maps for each model
 	modelWeightMaps := make(map[string]map[string]types.ValidationWeight)
@@ -455,7 +464,7 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 
 		k.LogDebug("Getting validation", types.Claims, "seed", msg.Seed, "totalWeight", totalWeight, "executorPower", executorPower, "validatorPower", validatorPowerForModel)
 		shouldValidate, s := calculations.ShouldValidate(msg.Seed, &inference, uint32(totalWeight), uint32(validatorPowerForModel.Weight), uint32(executorPower.Weight),
-			k.Keeper.GetParams(ctx).ValidationParams, false)
+			params.ValidationParams, false)
 		k.LogDebug(s, types.Claims, "inference", inference.InferenceId, "seed", msg.Seed, "model", modelId, "validator", msg.Creator)
 		if shouldValidate {
 			mustBeValidated = append(mustBeValidated, inference.InferenceId)

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards_test.go
@@ -42,7 +42,7 @@ func TestMsgServer_ClaimRewards(t *testing.T) {
 	currentEpochIndex := uint64(101)
 	currentEpoch := types.Epoch{Index: currentEpochIndex, PocStartBlockHeight: 2000}
 	k.SetEpoch(ctx, &currentEpoch)
-	k.SetEffectiveEpochIndex(ctx, currentEpoch.Index)
+	_ = k.SetEffectiveEpochIndex(ctx, currentEpoch.Index)
 
 	// Setup current epoch group data (required for validation)
 	currentEpochData := types.EpochGroupData{
@@ -66,7 +66,7 @@ func TestMsgServer_ClaimRewards(t *testing.T) {
 		RewardCoins:   500,
 		SeedSignature: signatureHex,
 	}
-	k.SetSettleAmount(sdk.UnwrapSDKContext(ctx), settleAmount)
+	_ = k.SetSettleAmount(sdk.UnwrapSDKContext(ctx), settleAmount)
 
 	// Setup epoch group data
 	epochData := types.EpochGroupData{
@@ -194,7 +194,7 @@ func TestMsgServer_ClaimRewards_NoRewards(t *testing.T) {
 	currentEpochIndex := uint64(101)
 	currentEpoch := types.Epoch{Index: currentEpochIndex, PocStartBlockHeight: 2000}
 	k.SetEpoch(ctx, &currentEpoch)
-	k.SetEffectiveEpochIndex(ctx, currentEpoch.Index)
+	_ = k.SetEffectiveEpochIndex(ctx, currentEpoch.Index)
 
 	// Setup current epoch group data (required for validation)
 	currentEpochData := types.EpochGroupData{
@@ -231,7 +231,7 @@ func TestMsgServer_ClaimRewards_WrongHeight(t *testing.T) {
 	currentEpochIndex := uint64(101)
 	currentEpoch := types.Epoch{Index: currentEpochIndex, PocStartBlockHeight: 2000}
 	k.SetEpoch(ctx, &currentEpoch)
-	k.SetEffectiveEpochIndex(ctx, currentEpoch.Index)
+	_ = k.SetEffectiveEpochIndex(ctx, currentEpoch.Index)
 
 	// Setup current epoch group data (required for validation)
 	currentEpochData := types.EpochGroupData{
@@ -255,7 +255,7 @@ func TestMsgServer_ClaimRewards_WrongHeight(t *testing.T) {
 		RewardCoins:   500,
 		SeedSignature: "0102030405060708",
 	}
-	k.SetSettleAmount(sdk.UnwrapSDKContext(ctx), settleAmount)
+	_ = k.SetSettleAmount(sdk.UnwrapSDKContext(ctx), settleAmount)
 
 	// Call ClaimRewards with a different height
 	resp, err := ms.ClaimRewards(ctx.WithBlockHeight(claimDebounceBlocks+1), &types.MsgClaimRewards{
@@ -278,7 +278,7 @@ func TestMsgServer_ClaimRewards_ZeroRewards(t *testing.T) {
 	currentEpochIndex := uint64(101)
 	currentEpoch := types.Epoch{Index: currentEpochIndex, PocStartBlockHeight: 2000}
 	k.SetEpoch(ctx, &currentEpoch)
-	k.SetEffectiveEpochIndex(ctx, currentEpoch.Index)
+	_ = k.SetEffectiveEpochIndex(ctx, currentEpoch.Index)
 
 	// Setup current epoch group data (required for validation)
 	currentEpochData := types.EpochGroupData{
@@ -302,7 +302,7 @@ func TestMsgServer_ClaimRewards_ZeroRewards(t *testing.T) {
 		RewardCoins:   0,
 		SeedSignature: "0102030405060708",
 	}
-	k.SetSettleAmount(sdk.UnwrapSDKContext(ctx), settleAmount)
+	_ = k.SetSettleAmount(sdk.UnwrapSDKContext(ctx), settleAmount)
 
 	// Call ClaimRewards
 	resp, err := ms.ClaimRewards(ctx.WithBlockHeight(claimDebounceBlocks+1), &types.MsgClaimRewards{
@@ -348,7 +348,7 @@ func TestMsgServer_ClaimRewards_ValidationLogic(t *testing.T) {
 	currentEpochIndex := uint64(101)
 	currentEpoch := types.Epoch{Index: currentEpochIndex, PocStartBlockHeight: 2000}
 	k.SetEpoch(sdkCtx, &currentEpoch)
-	k.SetEffectiveEpochIndex(sdkCtx, currentEpoch.Index)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, currentEpoch.Index)
 
 	// Setup current epoch group data (required for validation)
 	currentEpochData := types.EpochGroupData{
@@ -371,7 +371,7 @@ func TestMsgServer_ClaimRewards_ValidationLogic(t *testing.T) {
 		RewardCoins:   500,
 		SeedSignature: signatureHex,
 	}
-	k.SetSettleAmount(sdkCtx, settleAmount)
+	_ = k.SetSettleAmount(sdkCtx, settleAmount)
 
 	// Setup epoch group data with specific weights
 	epochData := types.EpochGroupData{
@@ -563,7 +563,7 @@ func TestMsgServer_ClaimRewards_PartialValidation(t *testing.T) {
 	currentEpochIndex := uint64(101)
 	currentEpoch := types.Epoch{Index: currentEpochIndex, PocStartBlockHeight: 2000}
 	k.SetEpoch(sdkCtx, &currentEpoch)
-	k.SetEffectiveEpochIndex(sdkCtx, currentEpoch.Index)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, currentEpoch.Index)
 
 	// Setup current epoch group data (required for validation)
 	currentEpochData := types.EpochGroupData{
@@ -586,7 +586,7 @@ func TestMsgServer_ClaimRewards_PartialValidation(t *testing.T) {
 		RewardCoins:   500,
 		SeedSignature: signatureHex,
 	}
-	k.SetSettleAmount(sdkCtx, settleAmount)
+	_ = k.SetSettleAmount(sdkCtx, settleAmount)
 
 	// Setup epoch group data with specific weights
 	epochData := types.EpochGroupData{
@@ -714,7 +714,7 @@ func TestMsgServer_ClaimRewards_PartialValidation(t *testing.T) {
 
 	// Update the settle amount with the new signature
 	settleAmount.SeedSignature = signatureHex
-	k.SetSettleAmount(sdkCtx, settleAmount)
+	_ = k.SetSettleAmount(sdkCtx, settleAmount)
 
 	// Call ClaimRewards with the new seed
 	_, _ = ms.ClaimRewards(ctx.WithBlockHeight(claimDebounceBlocks+1), &types.MsgClaimRewards{
@@ -765,7 +765,7 @@ func TestMsgServer_ClaimRewards_PartialValidation(t *testing.T) {
 	currentEpochIndex2 := uint64(102)
 	currentEpoch2 := types.Epoch{Index: currentEpochIndex2, PocStartBlockHeight: 2100}
 	k.SetEpoch(sdkCtx, &currentEpoch2)
-	k.SetEffectiveEpochIndex(sdkCtx, currentEpoch2.Index)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, currentEpoch2.Index)
 
 	// Setup current epoch group data (required for validation)
 	currentEpochData2 := types.EpochGroupData{
@@ -835,7 +835,7 @@ func TestMsgServer_ClaimRewards_PartialValidation(t *testing.T) {
 		RewardCoins:   500,
 		SeedSignature: signatureHex2,
 	}
-	k.SetSettleAmount(sdkCtx, settleAmount2)
+	_ = k.SetSettleAmount(sdkCtx, settleAmount2)
 
 	// Setup performance summary for second epoch
 	perfSummary2 := types.EpochPerformanceSummary{
@@ -907,7 +907,7 @@ func pocAvailabilityTest(t *testing.T, validatorIsAvailableDuringPoC bool) {
 	currentEpochIndex := uint64(2)
 	currentEpoch := types.Epoch{Index: currentEpochIndex, PocStartBlockHeight: 2000}
 	k.SetEpoch(sdkCtx, &currentEpoch)
-	k.SetEffectiveEpochIndex(sdkCtx, currentEpoch.Index)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, currentEpoch.Index)
 
 	// Setup current epoch group data (required for validation)
 	currentEpochData := types.EpochGroupData{
@@ -937,7 +937,7 @@ func pocAvailabilityTest(t *testing.T, validatorIsAvailableDuringPoC bool) {
 		RewardCoins:   500,
 		SeedSignature: signatureHex,
 	}
-	k.SetSettleAmount(sdkCtx, settleAmount)
+	_ = k.SetSettleAmount(sdkCtx, settleAmount)
 
 	// Epoch Group Data (Main and Sub-group)
 	// Claimant has two nodes, one with full availability

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
@@ -40,7 +40,7 @@ func advanceEpoch(ctx sdk.Context, k *keeper.Keeper, mocks *keeper2.InferenceMoc
 	// The genesis groups have already been created
 	newEpoch := types.Epoch{Index: epochIndex + 1, PocStartBlockHeight: blockHeight}
 	k.SetEpoch(ctx, &newEpoch)
-	k.SetEffectiveEpochIndex(ctx, newEpoch.Index)
+	_ = k.SetEffectiveEpochIndex(ctx, newEpoch.Index)
 	mocks.ExpectCreateGroupWithPolicyCall(ctx, epochGroupId)
 
 	eg, err := k.CreateEpochGroup(ctx, uint64(newEpoch.PocStartBlockHeight), epochIndex+1)

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
@@ -73,12 +73,14 @@ func TestMsgServer_FinishInference(t *testing.T) {
 
 	// Developer access gating should apply to FinishInference as well (gated by RequestedBy).
 	t.Run("DeveloperAccessRestricted", func(t *testing.T) {
-		originalParams := k.GetParams(ctx)
+		originalParams, err := k.GetParams(ctx)
+		require.NoError(t, err)
 		t.Cleanup(func() {
 			_ = k.SetParams(ctx, originalParams)
 		})
 
-		params := k.GetParams(ctx)
+		params, err := k.GetParams(ctx)
+		require.NoError(t, err)
 		params.DeveloperAccessParams = &types.DeveloperAccessParams{
 			UntilBlockHeight:          9999999,
 			AllowedDeveloperAddresses: []string{"gonka1someotherxxxxxxxxxxxxxxxxxxxxxx"},
@@ -229,7 +231,8 @@ func NewMockInferenceHelper(t *testing.T) (*MockInferenceHelper, keeper.Keeper, 
 	inference.InitGenesis(ctx, k, mocks.StubGenesisState())
 
 	// Disable grace period for tests so we get actual pricing instead of 0
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	params.DynamicPricingParams.GracePeriodEndEpoch = 0
 	k.SetParams(ctx, params)
 

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference_test.go
@@ -26,7 +26,7 @@ func setupInvalidateHarness(t testing.TB) (keeper.Keeper, types.MsgServer, sdk.C
 
 func setEffectiveEpoch(ctx sdk.Context, k keeper.Keeper, epochIndex uint64, mocks *keepertest.InferenceMocks) error {
 	k.SetEpoch(ctx, &types.Epoch{Index: epochIndex})
-	k.SetEffectiveEpochIndex(ctx, epochIndex)
+	_ = k.SetEffectiveEpochIndex(ctx, epochIndex)
 	mocks.ExpectCreateGroupWithPolicyCall(ctx, epochIndex)
 	eg, err := k.CreateEpochGroup(ctx, epochIndex, epochIndex)
 	if err != nil {

--- a/inference-chain/x/inference/keeper/msg_server_out_of_order_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_out_of_order_inference_test.go
@@ -37,7 +37,8 @@ func TestMsgServer_OutOfOrderInference(t *testing.T) {
 	inference.InitGenesis(ctx, k, mocks.StubGenesisState())
 
 	// Disable grace period for tests so we get actual pricing instead of 0
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	params.DynamicPricingParams.GracePeriodEndEpoch = 0
 	k.SetParams(ctx, params)
 

--- a/inference-chain/x/inference/keeper/msg_server_participant_access_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_participant_access_test.go
@@ -13,13 +13,14 @@ func TestParticipantAccess_SubmitNewParticipant_NewRegistrationClosed(t *testing
 	k, ms, ctx := setupMsgServer(t)
 	sdkCtx := sdk.UnwrapSDKContext(ctx).WithBlockHeight(100)
 
-	params := k.GetParams(sdkCtx)
+	params, err := k.GetParams(sdkCtx)
+	require.NoError(t, err)
 	params.ParticipantAccessParams = &types.ParticipantAccessParams{
 		NewParticipantRegistrationStartHeight: 150, // closed until 150 (opens at 150)
 	}
 	require.NoError(t, k.SetParams(sdkCtx, params))
 
-	_, err := ms.SubmitNewParticipant(sdkCtx, &types.MsgSubmitNewParticipant{
+	_, err = ms.SubmitNewParticipant(sdkCtx, &types.MsgSubmitNewParticipant{
 		Creator: testutil.Executor,
 		Url:     "url",
 	})
@@ -31,13 +32,14 @@ func TestParticipantAccess_SubmitPocBatch_BlockedParticipant(t *testing.T) {
 	k, ms, ctx := setupMsgServer(t)
 	sdkCtx := sdk.UnwrapSDKContext(ctx).WithBlockHeight(100)
 
-	params := k.GetParams(sdkCtx)
+	params, err := k.GetParams(sdkCtx)
+	require.NoError(t, err)
 	params.ParticipantAccessParams = &types.ParticipantAccessParams{
 		BlockedParticipantAddresses: []string{testutil.Executor},
 	}
 	require.NoError(t, k.SetParams(sdkCtx, params))
 
-	_, err := ms.SubmitPocBatch(sdkCtx, &types.MsgSubmitPocBatch{
+	_, err = ms.SubmitPocBatch(sdkCtx, &types.MsgSubmitPocBatch{
 		Creator:                  testutil.Executor,
 		PocStageStartBlockHeight: 1,
 		BatchId:                  "batch",
@@ -53,13 +55,14 @@ func TestParticipantAccess_SubmitPocValidation_BlockedValidatorOrParticipant(t *
 	k, ms, ctx := setupMsgServer(t)
 	sdkCtx := sdk.UnwrapSDKContext(ctx).WithBlockHeight(100)
 
-	params := k.GetParams(sdkCtx)
+	params, err := k.GetParams(sdkCtx)
+	require.NoError(t, err)
 	params.ParticipantAccessParams = &types.ParticipantAccessParams{
 		BlockedParticipantAddresses: []string{testutil.Creator}, // validator in this msg
 	}
 	require.NoError(t, k.SetParams(sdkCtx, params))
 
-	_, err := ms.SubmitPocValidation(sdkCtx, &types.MsgSubmitPocValidation{
+	_, err = ms.SubmitPocValidation(sdkCtx, &types.MsgSubmitPocValidation{
 		Creator:                  testutil.Creator,
 		ParticipantAddress:       testutil.Executor,
 		PocStageStartBlockHeight: 1,

--- a/inference-chain/x/inference/keeper/msg_server_request_bridge_withdrawal.go
+++ b/inference-chain/x/inference/keeper/msg_server_request_bridge_withdrawal.go
@@ -135,6 +135,7 @@ func (k msgServer) validateContractCaller(ctx sdk.Context, contractAddress strin
 // Helper function to get wasm keeper
 func (k msgServer) getWasmKeeper() wasmkeeper.Keeper {
 	if k.Keeper.getWasmKeeper == nil {
+		//nolint:forbidigo // init code
 		panic("wasm keeper not available")
 	}
 	return k.Keeper.getWasmKeeper()

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -129,8 +129,9 @@ func (k msgServer) validateTimestamp(
 	inferenceId string,
 	extraSeconds int64,
 ) error {
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
+		k.LogError("StartInference: validateTimestamp failed to get params", types.Inferences, "error", err)
 		return err
 	}
 	k.LogInfo("Validating timestamp for StartInference:", types.Inferences,
@@ -157,9 +158,14 @@ func (k msgServer) validateTimestamp(
 }
 
 func (k msgServer) addTimeout(ctx sdk.Context, inference *types.Inference) {
-	expirationBlocks := k.GetParams(ctx).ValidationParams.ExpirationBlocks
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("Unable to get params for inference timeout", types.Inferences, "error", err)
+		return
+	}
+	expirationBlocks := params.ValidationParams.ExpirationBlocks
 	expirationHeight := uint64(inference.StartBlockHeight + expirationBlocks)
-	err := k.SetInferenceTimeout(ctx, types.InferenceTimeout{
+	err = k.SetInferenceTimeout(ctx, types.InferenceTimeout{
 		ExpirationHeight: expirationHeight,
 		InferenceId:      inference.InferenceId,
 	})

--- a/inference-chain/x/inference/keeper/msg_server_start_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference_test.go
@@ -28,7 +28,8 @@ func TestMsgServer_StartInference_DeveloperNotAllowlisted(t *testing.T) {
 	k, ms, ctx := setupMsgServer(t)
 
 	// Enable gating at current height + 100, with an allowlist that does NOT include testutil.Requester.
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.DeveloperAccessParams = &types.DeveloperAccessParams{
 		UntilBlockHeight:          ctx.BlockHeight() + 100,
 		AllowedDeveloperAddresses: []string{"gonka1notallowlistedxxxxxxxxxxxxxxxxxxxxxx"},

--- a/inference-chain/x/inference/keeper/msg_server_submit_new_unfunded_participant.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_new_unfunded_participant.go
@@ -23,12 +23,16 @@ func (k msgServer) SubmitNewUnfundedParticipant(goCtx context.Context, msg *type
 	}
 
 	k.LogInfo("Adding new account directly", types.Participants, "address", msg.Address)
+	addr, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		return nil, err
+	}
 	// First, add the account
-	if k.AccountKeeper.GetAccount(ctx, sdk.MustAccAddressFromBech32(msg.Address)) != nil {
+	if k.AccountKeeper.GetAccount(ctx, addr) != nil {
 		k.LogError("Account already exists", types.Participants, "address", msg.Address)
 		return nil, types.ErrAccountAlreadyExists
 	}
-	newAccount := k.AccountKeeper.NewAccountWithAddress(ctx, sdk.MustAccAddressFromBech32(msg.Address))
+	newAccount := k.AccountKeeper.NewAccountWithAddress(ctx, addr)
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(msg.PubKey)
 	if err != nil {
 		return nil, err

--- a/inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go
@@ -51,7 +51,11 @@ func (k msgServer) SubmitPocBatch(goCtx context.Context, msg *types.MsgSubmitPoc
 		}
 
 		// Verify we're in the batch submission window (generation + exchange period)
-		epochParams := k.GetParams(ctx).EpochParams
+		params, err := k.GetParams(ctx)
+		if err != nil {
+			return nil, err
+		}
+		epochParams := params.EpochParams
 		if !activeEvent.IsInBatchSubmissionWindow(currentBlockHeight, epochParams) {
 			k.LogError(PocFailureTag+"[SubmitPocBatch] Confirmation PoC: outside batch submission window", types.PoC,
 				"participant", msg.Creator,
@@ -84,7 +88,11 @@ func (k msgServer) SubmitPocBatch(goCtx context.Context, msg *types.MsgSubmitPoc
 	}
 
 	// Regular PoC logic
-	epochParams := k.Keeper.GetParams(goCtx).EpochParams
+	params, err := k.Keeper.GetParams(goCtx)
+	if err != nil {
+		return nil, err
+	}
+	epochParams := params.EpochParams
 	upcomingEpoch, found := k.Keeper.GetUpcomingEpoch(ctx)
 	if !found {
 		k.LogError(PocFailureTag+"[SubmitPocBatch] Failed to get upcoming epoch", types.PoC,

--- a/inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go
@@ -72,7 +72,9 @@ func (k msgServer) SubmitPocBatch(goCtx context.Context, msg *types.MsgSubmitPoc
 			NodeId:                   msg.NodeId,
 		}
 
-		k.SetPocBatch(ctx, storedBatch)
+		if err := k.SetPocBatch(ctx, storedBatch); err != nil {
+			return nil, err
+		}
 		k.LogInfo("[SubmitPocBatch] Confirmation PoC batch stored", types.PoC,
 			"participant", msg.Creator,
 			"triggerHeight", activeEvent.TriggerHeight,
@@ -126,7 +128,9 @@ func (k msgServer) SubmitPocBatch(goCtx context.Context, msg *types.MsgSubmitPoc
 		NodeId:                   msg.NodeId,
 	}
 
-	k.SetPocBatch(ctx, storedBatch)
+	if err := k.SetPocBatch(ctx, storedBatch); err != nil {
+		return nil, err
+	}
 
 	return &types.MsgSubmitPocBatchResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_submit_poc_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_poc_validation.go
@@ -47,7 +47,11 @@ func (k msgServer) SubmitPocValidation(goCtx context.Context, msg *types.MsgSubm
 		}
 
 		// Verify we're in the validation window
-		epochParams := k.GetParams(ctx).EpochParams
+		params, err := k.GetParams(ctx)
+		if err != nil {
+			return nil, err
+		}
+		epochParams := params.EpochParams
 		if !activeEvent.IsInValidationWindow(currentBlockHeight, epochParams) {
 			k.LogError(PocFailureTag+"[SubmitPocValidation] Confirmation PoC: outside validation window", types.PoC,
 				"participant", msg.ParticipantAddress,
@@ -73,7 +77,11 @@ func (k msgServer) SubmitPocValidation(goCtx context.Context, msg *types.MsgSubm
 	}
 
 	// Regular PoC logic
-	epochParams := k.Keeper.GetParams(ctx).EpochParams
+	p, err := k.Keeper.GetParams(ctx)
+	if err != nil {
+		return nil, err
+	}
+	epochParams := p.EpochParams
 	upcomingEpoch, found := k.Keeper.GetUpcomingEpoch(ctx)
 	if !found {
 		k.LogError(PocFailureTag+"[SubmitPocValidation] Failed to get upcoming epoch", types.PoC,

--- a/inference-chain/x/inference/keeper/msg_server_submit_poc_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_poc_validation.go
@@ -61,7 +61,9 @@ func (k msgServer) SubmitPocValidation(goCtx context.Context, msg *types.MsgSubm
 		// Store validation using trigger_height as key
 		validation := toPoCValidation(msg, currentBlockHeight)
 		validation.PocStageStartBlockHeight = activeEvent.TriggerHeight // Use trigger_height as key
-		k.SetPoCValidation(ctx, *validation)
+		if err := k.SetPoCValidation(ctx, *validation); err != nil {
+			return nil, err
+		}
 		k.LogInfo("[SubmitPocValidation] Confirmation PoC validation stored", types.PoC,
 			"participant", msg.ParticipantAddress,
 			"validatorParticipant", msg.Creator,
@@ -110,7 +112,9 @@ func (k msgServer) SubmitPocValidation(goCtx context.Context, msg *types.MsgSubm
 	}
 
 	validation := toPoCValidation(msg, currentBlockHeight)
-	k.SetPoCValidation(ctx, *validation)
+	if err := k.SetPoCValidation(ctx, *validation); err != nil {
+		return nil, err
+	}
 
 	return &types.MsgSubmitPocValidationResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_submit_seed.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_seed.go
@@ -16,7 +16,9 @@ func (k msgServer) SubmitSeed(goCtx context.Context, msg *types.MsgSubmitSeed) (
 		Signature:   msg.Signature,
 	}
 
-	k.SetRandomSeed(ctx, seed)
+	if err := k.SetRandomSeed(ctx, seed); err != nil {
+		return nil, err
+	}
 
 	return &types.MsgSubmitSeedResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_submit_unit_of_compute_price_proposal.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_unit_of_compute_price_proposal.go
@@ -18,12 +18,14 @@ func (k msgServer) SubmitUnitOfComputePriceProposal(goCtx context.Context, msg *
 		return nil, sdkerrors.Wrapf(types.ErrEffectiveEpochNotFound, "SubmitUnitOfComputePriceProposal: No effective epoch found. blockHeight: %d", blockHeight)
 	}
 
-	k.SetUnitOfComputePriceProposal(ctx, &types.UnitOfComputePriceProposal{
+	if err := k.SetUnitOfComputePriceProposal(ctx, &types.UnitOfComputePriceProposal{
 		Price:                 msg.Price,
 		Participant:           msg.Creator,
 		ProposedAtBlockHeight: uint64(blockHeight),
 		ProposedAtEpoch:       effectiveEpoch.Index,
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	return &types.MsgSubmitUnitOfComputePriceProposalResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -181,7 +181,7 @@ func (k msgServer) MaximumInvalidationsReached(ctx sdk.Context, creator sdk.AccA
 		return false
 	}
 
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		k.LogError("Failed to get params", types.Validation, "error", err)
 		return false

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -116,7 +116,11 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		executor.ConsecutiveInvalidInferences = 0
 		executor.CurrentEpochStats.ValidatedInferences++
 	} else {
-		if k.MaximumInvalidationsReached(ctx, sdk.MustAccAddressFromBech32(creator.Address), groupData) {
+		creatorAddr, err := sdk.AccAddressFromBech32(creator.Address)
+		if err != nil {
+			return nil, err
+		}
+		if k.MaximumInvalidationsReached(ctx, creatorAddr, groupData) {
 			k.LogWarn("Maximum invalidations reached.", types.Validation,
 				"creator", msg.Creator,
 				"model", inference.Model,
@@ -129,7 +133,11 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		if err != nil {
 			return nil, err
 		}
-		err = k.ActiveInvalidations.Set(ctx, collections.Join(sdk.MustAccAddressFromBech32(msg.Creator), inference.InferenceId))
+		msgCreatorAddr, err := sdk.AccAddressFromBech32(msg.Creator)
+		if err != nil {
+			return nil, err
+		}
+		err = k.ActiveInvalidations.Set(ctx, collections.Join(msgCreatorAddr, inference.InferenceId))
 		if err != nil {
 			k.LogError("Failed to set active invalidation", types.Validation, "error", err)
 		}

--- a/inference-chain/x/inference/keeper/msg_server_validation_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation_test.go
@@ -220,7 +220,8 @@ func TestMsgServer_Validation_InvalidationsLimit_NoStatusChange_ButRecordsCredit
 	addMembersToGroupData(k, ctx)
 
 	// Make the maximum allowed invalidations very small and deterministic
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	if params.BandwidthLimitsParams == nil {
 		params.BandwidthLimitsParams = &types.BandwidthLimitsParams{}
 	}
@@ -230,7 +231,7 @@ func TestMsgServer_Validation_InvalidationsLimit_NoStatusChange_ButRecordsCredit
 	k.SetParams(ctx, params)
 
 	// Pre-populate one active invalidation for the validator so we hit the limit (>= 1)
-	err := k.ActiveInvalidations.Set(ctx, collections.Join(sdk.MustAccAddressFromBech32(testutil.Validator), "prev-inference"))
+	err = k.ActiveInvalidations.Set(ctx, collections.Join(sdk.MustAccAddressFromBech32(testutil.Validator), "prev-inference"))
 	require.NoError(t, err)
 
 	// Create and finish an inference

--- a/inference-chain/x/inference/keeper/params.go
+++ b/inference-chain/x/inference/keeper/params.go
@@ -21,7 +21,11 @@ func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
 		return params
 	}
 
-	k.cdc.MustUnmarshal(bz, &params)
+	err := k.cdc.Unmarshal(bz, &params)
+	if err != nil {
+		k.LogError("Unable to get Params", types.System, "error", err)
+		return types.Params{}
+	}
 	return params
 }
 

--- a/inference-chain/x/inference/keeper/params.go
+++ b/inference-chain/x/inference/keeper/params.go
@@ -14,22 +14,7 @@ const defaultDeveloperAccessUntilBlockHeight int64 = 0
 const defaultNewParticipantRegistrationStartHeight int64 = 0
 
 // GetParams get all parameters as types.Params
-func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
-	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
-	bz := store.Get(types.ParamsKey)
-	if bz == nil {
-		return params
-	}
-
-	err := k.cdc.Unmarshal(bz, &params)
-	if err != nil {
-		k.LogError("Unable to get Params", types.System, "error", err)
-		return types.Params{}
-	}
-	return params
-}
-
-func (k Keeper) GetParamsSafe(ctx context.Context) (params types.Params, err error) {
+func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
@@ -71,7 +56,10 @@ func (k Keeper) GetV1Params(ctx context.Context) (params types.ParamsV1, err err
 
 // GetBandwidthLimitsParams returns bandwidth limits parameters
 func (k Keeper) GetBandwidthLimitsParams(ctx context.Context) (*types.BandwidthLimitsParams, error) {
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if params.BandwidthLimitsParams == nil {
 		// Return default values if not set
 		return &types.BandwidthLimitsParams{
@@ -92,7 +80,11 @@ func (k Keeper) GetBandwidthLimitsParams(ctx context.Context) (*types.BandwidthL
 
 // GetGenesisGuardianAddresses returns the governance-controlled genesis guardian operator addresses.
 func (k Keeper) GetGenesisGuardianAddresses(ctx context.Context) []string {
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("Unable to get Params in GetGenesisGuardianAddresses", types.System, "error", err)
+		return []string{}
+	}
 	if p.GenesisGuardianParams == nil {
 		return []string{}
 	}
@@ -102,7 +94,11 @@ func (k Keeper) GetGenesisGuardianAddresses(ctx context.Context) []string {
 // GetGenesisGuardianNetworkMaturityThreshold returns the governance-controlled maturity threshold.
 // If unset (0), it falls back to a safe default.
 func (k Keeper) GetGenesisGuardianNetworkMaturityThreshold(ctx context.Context) int64 {
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("Unable to get Params in GetGenesisGuardianNetworkMaturityThreshold", types.System, "error", err)
+		return defaultGenesisGuardianNetworkMaturityThreshold
+	}
 	if p.GenesisGuardianParams == nil {
 		return defaultGenesisGuardianNetworkMaturityThreshold
 	}
@@ -116,7 +112,11 @@ func (k Keeper) GetGenesisGuardianNetworkMaturityThreshold(ctx context.Context) 
 // GetGenesisGuardianNetworkMaturityMinHeight returns the governance-controlled minimum height for maturity.
 // If unset, defaults to 0 (no height gating).
 func (k Keeper) GetGenesisGuardianNetworkMaturityMinHeight(ctx context.Context) int64 {
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("Unable to get Params in GetGenesisGuardianNetworkMaturityMinHeight", types.System, "error", err)
+		return defaultGenesisGuardianNetworkMaturityMinHeight
+	}
 	if p.GenesisGuardianParams == nil {
 		return defaultGenesisGuardianNetworkMaturityMinHeight
 	}
@@ -135,7 +135,12 @@ func (k Keeper) InNetworkMature(ctx context.Context, height int64, totalNetworkP
 }
 
 func (k Keeper) GetDeveloperAccessParams(ctx context.Context) *types.DeveloperAccessParams {
-	return k.GetParams(ctx).DeveloperAccessParams
+	p, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("Unable to get Params in GetDeveloperAccessParams", types.System, "error", err)
+		return nil
+	}
+	return p.DeveloperAccessParams
 }
 
 // IsDeveloperAccessRestricted returns true iff the chain is still in the restricted mode where only
@@ -170,7 +175,12 @@ func (k Keeper) IsAllowedDeveloper(ctx context.Context, developerAddress string)
 }
 
 func (k Keeper) GetParticipantAccessParams(ctx context.Context) *types.ParticipantAccessParams {
-	return k.GetParams(ctx).ParticipantAccessParams
+	p, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("Unable to get Params in GetParticipantAccessParams", types.System, "error", err)
+		return nil
+	}
+	return p.ParticipantAccessParams
 }
 
 // IsNewParticipantRegistrationClosed returns true iff NEW participant registration is closed at this height.

--- a/inference-chain/x/inference/keeper/params_test.go
+++ b/inference-chain/x/inference/keeper/params_test.go
@@ -15,7 +15,9 @@ func TestGetParams(t *testing.T) {
 	params := types.DefaultParams()
 
 	require.NoError(t, k.SetParams(ctx, params))
-	require.EqualValues(t, params, k.GetParams(ctx))
+	outParams, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	require.Equal(t, params, outParams)
 }
 
 func TestTokenomicsParamsGovernance(t *testing.T) {
@@ -86,7 +88,8 @@ func TestTokenomicsParamsGovernance(t *testing.T) {
 			require.NoError(t, k.SetParams(ctx, updatedParams))
 
 			// Retrieve and verify the parameters
-			retrievedParams := k.GetParams(wctx)
+			retrievedParams, err := k.GetParams(wctx)
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedWorkVesting, retrievedParams.TokenomicsParams.WorkVestingPeriod)
 			require.Equal(t, tc.expectedRewardVesting, retrievedParams.TokenomicsParams.RewardVestingPeriod)
 			require.Equal(t, tc.expectedTopMinerVesting, retrievedParams.TokenomicsParams.TopMinerVestingPeriod)
@@ -246,7 +249,8 @@ func TestParamsValidateCallsTokenomicsValidation(t *testing.T) {
 	require.NoError(t, k.SetParams(ctx, params))
 
 	// Retrieve and verify the parameters
-	retrievedParams := k.GetParams(ctx)
+	retrievedParams, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	require.Equal(t, uint64(180), retrievedParams.TokenomicsParams.WorkVestingPeriod)
 	require.Equal(t, uint64(180), retrievedParams.TokenomicsParams.RewardVestingPeriod)
 	require.Equal(t, uint64(180), retrievedParams.TokenomicsParams.TopMinerVestingPeriod)
@@ -566,7 +570,8 @@ func TestBitcoinRewardParamsGovernance(t *testing.T) {
 			require.NoError(t, k.SetParams(ctx, updatedParams))
 
 			// Retrieve and verify the parameters
-			retrievedParams := k.GetParams(wctx)
+			retrievedParams, err := k.GetParams(wctx)
+			require.NoError(t, err)
 			require.Equal(t, tc.initialEpochReward, retrievedParams.BitcoinRewardParams.InitialEpochReward)
 			require.Equal(t, tc.decayRate, retrievedParams.BitcoinRewardParams.DecayRate.ToFloat())
 			require.Equal(t, tc.genesisEpoch, retrievedParams.BitcoinRewardParams.GenesisEpoch)

--- a/inference-chain/x/inference/keeper/participant.go
+++ b/inference-chain/x/inference/keeper/participant.go
@@ -61,11 +61,15 @@ func (k Keeper) GetParticipant(
 func (k Keeper) RemoveParticipant(
 	ctx context.Context,
 	index string,
-
 ) {
-	err := k.Participants.Remove(ctx, sdk.MustAccAddressFromBech32(index))
+	addr, err := sdk.AccAddressFromBech32(index)
 	if err != nil {
-		k.LogError("Could not remove participant", types.Participants, "error", err, "index", index, "address", sdk.MustAccAddressFromBech32(index).String(), "")
+		k.LogError("Could not parse participant address for removal", types.Participants, "index", index, "error", err)
+		return
+	}
+	err = k.Participants.Remove(ctx, addr)
+	if err != nil {
+		k.LogError("Could not remove participant", types.Participants, "error", err, "index", index, "address", addr.String(), "")
 	}
 }
 

--- a/inference-chain/x/inference/keeper/participant_status.go
+++ b/inference-chain/x/inference/keeper/participant_status.go
@@ -27,7 +27,11 @@ func (k Keeper) UpdateParticipantStatus(ctx context.Context, participant *types.
 		oldParticipant = *participant
 	}
 
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("UpdateParticipantStatus: failed to get params", types.Validation, "error", err)
+		return err
+	}
 	originalStatus := participant.Status
 	newStatus, reason, newStats := calculations.ComputeStatus(
 		params.ValidationParams,

--- a/inference-chain/x/inference/keeper/participant_test.go
+++ b/inference-chain/x/inference/keeper/participant_test.go
@@ -114,7 +114,7 @@ func TestUpdateParticipantStatus_TransitionToInvalid(t *testing.T) {
 	// Setup epoch
 	epochIndex := uint64(1)
 	k.SetEpoch(sdkCtx, &types.Epoch{Index: epochIndex, PocStartBlockHeight: 100})
-	k.SetEffectiveEpochIndex(sdkCtx, epochIndex)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, epochIndex)
 	mocks.ExpectCreateGroupWithPolicyCall(ctx, epochIndex)
 	eg, err := k.CreateEpochGroup(ctx, epochIndex, epochIndex)
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func TestInvalidParticipant_ReputationReduced(t *testing.T) {
 	// Setup epoch
 	epochIndex := uint64(1)
 	k.SetEpoch(sdkCtx, &types.Epoch{Index: epochIndex, PocStartBlockHeight: 100})
-	k.SetEffectiveEpochIndex(sdkCtx, epochIndex)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, epochIndex)
 	mocks.ExpectCreateGroupWithPolicyCall(ctx, epochIndex)
 	eg, err := k.CreateEpochGroup(ctx, epochIndex, epochIndex)
 	require.NoError(t, err)
@@ -311,7 +311,7 @@ func TestParticipantStatusFlow_ActiveToInvalid(t *testing.T) {
 	// Setup epoch
 	epochIndex := uint64(1)
 	k.SetEpoch(sdkCtx, &types.Epoch{Index: epochIndex, PocStartBlockHeight: 100})
-	k.SetEffectiveEpochIndex(sdkCtx, epochIndex)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, epochIndex)
 	mocks.ExpectCreateGroupWithPolicyCall(ctx, epochIndex)
 	eg, err := k.CreateEpochGroup(ctx, epochIndex, epochIndex)
 	require.NoError(t, err)

--- a/inference-chain/x/inference/keeper/poc_batch.go
+++ b/inference-chain/x/inference/keeper/poc_batch.go
@@ -9,13 +9,17 @@ import (
 )
 
 // SetPocBatch stores a PoCBatch under triple key (epoch, participant addr, batch_id)
-func (k Keeper) SetPocBatch(ctx context.Context, batch types.PoCBatch) {
-	addr := sdk.MustAccAddressFromBech32(batch.ParticipantAddress)
+func (k Keeper) SetPocBatch(ctx context.Context, batch types.PoCBatch) error {
+	addr, err := sdk.AccAddressFromBech32(batch.ParticipantAddress)
+	if err != nil {
+		return err
+	}
 	pk := collections.Join3(batch.PocStageStartBlockHeight, addr, batch.BatchId)
 	k.LogInfo("PoC: Storing batch", types.PoC, "epoch", batch.PocStageStartBlockHeight, "participant", batch.ParticipantAddress, "batch_id", batch.BatchId)
 	if err := k.PoCBatches.Set(ctx, pk, batch); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // GetPoCBatchesByStage collects all PoCBatch grouped by participant for a specific epoch
@@ -50,14 +54,21 @@ func (k Keeper) GetPoCBatchesCountByStage(ctx context.Context, pocStageStartBloc
 	return count, nil
 }
 
-func (k Keeper) SetPoCValidation(ctx context.Context, validation types.PoCValidation) {
-	pAddr := sdk.MustAccAddressFromBech32(validation.ParticipantAddress)
-	vAddr := sdk.MustAccAddressFromBech32(validation.ValidatorParticipantAddress)
+func (k Keeper) SetPoCValidation(ctx context.Context, validation types.PoCValidation) error {
+	pAddr, err := sdk.AccAddressFromBech32(validation.ParticipantAddress)
+	if err != nil {
+		return err
+	}
+	vAddr, err := sdk.AccAddressFromBech32(validation.ValidatorParticipantAddress)
+	if err != nil {
+		return err
+	}
 	pk := collections.Join3(validation.PocStageStartBlockHeight, pAddr, vAddr)
 	k.LogInfo("PoC: Storing validation", types.PoC, "epoch", validation.PocStageStartBlockHeight, "participant", validation.ParticipantAddress, "validator", validation.ValidatorParticipantAddress)
 	if err := k.PoCValidations.Set(ctx, pk, validation); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 func (k Keeper) GetPoCValidationByStage(ctx context.Context, pocStageStartBlockHeight int64) (map[string][]types.PoCValidation, error) {

--- a/inference-chain/x/inference/keeper/poc_period_validation.go
+++ b/inference-chain/x/inference/keeper/poc_period_validation.go
@@ -61,7 +61,12 @@ func (k Keeper) checkConfirmationPoCMessageTooLate(ctx sdk.Context, event *types
 		)
 	}
 
-	epochParams := k.GetParams(ctx).EpochParams
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		k.Logger().Debug("[ValidatePocPeriod] Error getting params", "error", err)
+		return err
+	}
+	epochParams := params.EpochParams
 
 	switch windowType {
 	case PoCWindowBatch:
@@ -91,7 +96,12 @@ func (k Keeper) checkConfirmationPoCMessageTooLate(ctx sdk.Context, event *types
 }
 
 func (k Keeper) checkRegularPoCMessageTooLate(ctx sdk.Context, startBlockHeight, currentBlockHeight int64, windowType PoCWindowType) error {
-	epochParams := k.GetParams(ctx).EpochParams
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		k.Logger().Debug("[ValidatePocPeriod] Error getting params", "error", err)
+		return err
+	}
+	epochParams := params.EpochParams
 	currentEpoch, found := k.GetEffectiveEpoch(ctx)
 	if !found {
 		k.Logger().Debug(

--- a/inference-chain/x/inference/keeper/pruning.go
+++ b/inference-chain/x/inference/keeper/pruning.go
@@ -13,7 +13,7 @@ const (
 )
 
 func (k Keeper) Prune(ctx context.Context, currentEpochIndex int64) error {
-	params, err := k.GetParamsSafe(ctx)
+	params, err := k.GetParams(ctx)
 	if err != nil {
 		return err
 	}

--- a/inference-chain/x/inference/keeper/pruning_test.go
+++ b/inference-chain/x/inference/keeper/pruning_test.go
@@ -21,7 +21,10 @@ type PruningSettings struct {
 }
 
 func setPruningConfig(ctx context.Context, k keeper.Keeper, settings PruningSettings) {
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		panic(err)
+	}
 	if settings.InferenceThreshold > 0 {
 		params.EpochParams.InferencePruningEpochThreshold = uint64(settings.InferenceThreshold)
 	}

--- a/inference-chain/x/inference/keeper/pruning_test.go
+++ b/inference-chain/x/inference/keeper/pruning_test.go
@@ -283,11 +283,12 @@ func TestPoCValidationsPruningMaxLimit_MultiCall_EpochAdvanceAfterEmpty(t *testi
 	p := mkAddr(1)
 	for i := 0; i < 10; i++ {
 		v := mkAddr(100 + i)
-		k.SetPoCValidation(ctx, types.PoCValidation{
+		err := k.SetPoCValidation(ctx, types.PoCValidation{
 			ParticipantAddress:          p,
 			ValidatorParticipantAddress: v,
 			PocStageStartBlockHeight:    prunedEpochBlockHeight,
 		})
+		require.NoError(t, err)
 	}
 
 	// Configure pruning: PoC threshold 1, PoC max prune 4
@@ -339,11 +340,12 @@ func TestPoCBatchesPruningMaxLimit_MultiCall_EpochAdvanceAfterEmpty(t *testing.T
 	// Create 10 batches in epoch 2 (eligible when current=3, threshold=1, end=2)
 	p := mkAddr(2)
 	for i := 0; i < 10; i++ {
-		k.SetPocBatch(ctx, types.PoCBatch{
+		err := k.SetPocBatch(ctx, types.PoCBatch{
 			ParticipantAddress:       p,
 			PocStageStartBlockHeight: prunedEpochBlockHeight,
 			BatchId:                  fmt.Sprintf("b-%d", i),
 		})
+		require.NoError(t, err)
 	}
 
 	// Configure pruning: PoC threshold 1, PoC max prune 4

--- a/inference-chain/x/inference/keeper/query_epoch_info.go
+++ b/inference-chain/x/inference/keeper/query_epoch_info.go
@@ -16,7 +16,10 @@ func (k Keeper) EpochInfo(goCtx context.Context, req *types.QueryEpochInfoReques
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	latestEpoch, found := k.GetLatestEpoch(ctx)
 	if !found {
 		k.LogError("GetLatestEpoch returned false, no latest epoch found", types.EpochGroup)

--- a/inference-chain/x/inference/keeper/query_get_random_executor.go
+++ b/inference-chain/x/inference/keeper/query_get_random_executor.go
@@ -65,7 +65,10 @@ func (k Keeper) createFilterFn(goCtx context.Context, modelId string) (func(memb
 		return nil, status.Error(codes.NotFound, "GetRandomExecutor: no effective epoch found")
 	}
 
-	epochParams := k.GetParams(goCtx)
+	epochParams, err := k.GetParams(goCtx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if epochParams.EpochParams == nil {
 		k.Logger().Error("GetRandomExecutor: createFilterFn: epoch params are nil",
 			"model_id", modelId, "epoch_index", effectiveEpoch.Index)

--- a/inference-chain/x/inference/keeper/query_get_unit_of_compute_price_proposal.go
+++ b/inference-chain/x/inference/keeper/query_get_unit_of_compute_price_proposal.go
@@ -18,7 +18,10 @@ func (k Keeper) GetUnitOfComputePriceProposal(goCtx context.Context, req *types.
 
 	proposal, _ := k.GettUnitOfComputePriceProposal(ctx, req.Participant)
 
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 
 	return &types.QueryGetUnitOfComputePriceProposalResponse{
 		Proposal: proposal,

--- a/inference-chain/x/inference/keeper/query_params.go
+++ b/inference-chain/x/inference/keeper/query_params.go
@@ -16,5 +16,10 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &types.QueryParamsResponse{Params: params}, nil
 }

--- a/inference-chain/x/inference/keeper/random_seed.go
+++ b/inference-chain/x/inference/keeper/random_seed.go
@@ -8,15 +8,16 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-func (k Keeper) SetRandomSeed(ctx context.Context, seed types.RandomSeed) {
+func (k Keeper) SetRandomSeed(ctx context.Context, seed types.RandomSeed) error {
 	addr, err := sdk.AccAddressFromBech32(seed.Participant)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	pk := collections.Join(seed.EpochIndex, addr)
 	if err := k.RandomSeeds.Set(ctx, pk, seed); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 func (k Keeper) GetRandomSeed(ctx context.Context, epochIndex uint64, participantAddress string) (types.RandomSeed, bool) {

--- a/inference-chain/x/inference/keeper/settle_amount.go
+++ b/inference-chain/x/inference/keeper/settle_amount.go
@@ -10,14 +10,15 @@ import (
 )
 
 // SetSettleAmount sets a specific settleAmount in the store by participant
-func (k Keeper) SetSettleAmount(ctx context.Context, settleAmount types.SettleAmount) {
+func (k Keeper) SetSettleAmount(ctx context.Context, settleAmount types.SettleAmount) error {
 	addr, err := sdk.AccAddressFromBech32(settleAmount.Participant)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	if err := k.SettleAmounts.Set(ctx, addr, settleAmount); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // GetSettleAmount returns a settleAmount by participant
@@ -93,7 +94,9 @@ func (k Keeper) SetSettleAmountWithGovernanceTransfer(ctx context.Context, settl
 	}
 
 	// Set the new settle amount
-	k.SetSettleAmount(ctx, settleAmount)
+	if err := k.SetSettleAmount(ctx, settleAmount); err != nil {
+		return err
+	}
 	k.SafeLogSubAccountTransaction(ctx, types.ModuleName, settleAmount.Participant, types.SettleSubAccount, settleAmount.GetTotalCoins(), "awaiting claim")
 	k.SafeLogSubAccountTransactionUint(ctx, settleAmount.Participant, types.ModuleName, types.OwedSubAccount, settleAmount.WorkCoins, "moved to settled")
 	return nil

--- a/inference-chain/x/inference/keeper/settle_amount_test.go
+++ b/inference-chain/x/inference/keeper/settle_amount_test.go
@@ -16,7 +16,7 @@ func createNSettleAmount(keeper keeper.Keeper, ctx context.Context, n int) []typ
 	items := make([]types.SettleAmount, n)
 	for i := range items {
 		items[i].Participant = sample.AccAddress()
-		keeper.SetSettleAmount(ctx, items[i])
+		_ = keeper.SetSettleAmount(ctx, items[i])
 	}
 	return items
 }

--- a/inference-chain/x/inference/keeper/streamvesting_integration_test.go
+++ b/inference-chain/x/inference/keeper/streamvesting_integration_test.go
@@ -322,7 +322,8 @@ func TestVestingIntegration_ParameterValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Retrieve and verify parameters
-	retrievedParams := k.GetParams(ctx)
+	retrievedParams, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	require.Equal(t, uint64(0), retrievedParams.TokenomicsParams.WorkVestingPeriod)
 	require.Equal(t, uint64(180), retrievedParams.TokenomicsParams.RewardVestingPeriod)
 	require.Equal(t, uint64(365), retrievedParams.TokenomicsParams.TopMinerVestingPeriod)

--- a/inference-chain/x/inference/keeper/top_miner.go
+++ b/inference-chain/x/inference/keeper/top_miner.go
@@ -57,7 +57,8 @@ func (k Keeper) GetAllTopMiner(ctx context.Context) (list []types.TopMiner) {
 	for ; it.Valid(); it.Next() {
 		v, err := it.Value()
 		if err != nil {
-			panic(err)
+			k.LogError("failed to get top miner value during iteration", types.System, "error", err)
+			continue
 		}
 		list = append(list, v)
 	}

--- a/inference-chain/x/inference/keeper/training_task.go
+++ b/inference-chain/x/inference/keeper/training_task.go
@@ -24,7 +24,10 @@ func (k Keeper) CreateTask(ctx sdk.Context, task *types.TrainingTask) error {
 		return fmt.Errorf("task already exists. id = %d", task.Id)
 	}
 
-	bz := k.cdc.MustMarshal(task)
+	bz, err := k.cdc.Marshal(task)
+	if err != nil {
+		return err
+	}
 	store.Set(taskKey, bz)
 
 	// Add the task ID to the queued set (we use an empty value).
@@ -84,12 +87,18 @@ func (k Keeper) StartTask(ctx sdk.Context, taskId uint64, assignees []*types.Tra
 		return types.ErrTrainingTaskNotFound
 	}
 	var task types.TrainingTask
-	k.cdc.MustUnmarshal(bz, &task)
+	err := k.cdc.Unmarshal(bz, &task)
+	if err != nil {
+		return err
+	}
 
 	// Here update the task object
 	task.Assignees = assignees
 	task.AssignedAtBlockHeight = uint64(ctx.BlockHeight())
-	updatedBz := k.cdc.MustMarshal(&task)
+	updatedBz, err := k.cdc.Marshal(&task)
+	if err != nil {
+		return err
+	}
 	store.Set(taskKey, updatedBz)
 
 	return nil
@@ -115,10 +124,16 @@ func (k Keeper) RemoveTaskFromInProgress(ctx sdk.Context, taskId uint64) error {
 		return fmt.Errorf("task %d not found in full object store", taskId)
 	}
 	var task types.TrainingTask
-	k.cdc.MustUnmarshal(bz, &task)
+	err := k.cdc.Unmarshal(bz, &task)
+	if err != nil {
+		return err
+	}
 
 	// TODO: update the task object to mark it as "finished"
-	updatedBz := k.cdc.MustMarshal(&task)
+	updatedBz, err := k.cdc.Marshal(&task)
+	if err != nil {
+		return err
+	}
 	store.Set(taskKey, updatedBz)
 
 	return nil
@@ -176,7 +191,10 @@ func (k Keeper) GetTasks(ctx sdk.Context, ids []uint64) ([]*types.TrainingTask, 
 			return nil, fmt.Errorf("task %d not found", id)
 		}
 		var task types.TrainingTask
-		k.cdc.MustUnmarshal(bz, &task)
+		err := k.cdc.Unmarshal(bz, &task)
+		if err != nil {
+			return nil, err
+		}
 		tasks[i] = &task
 	}
 	return tasks, nil

--- a/inference-chain/x/inference/keeper/unit_of_compute.go
+++ b/inference-chain/x/inference/keeper/unit_of_compute.go
@@ -6,10 +6,11 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-func (k Keeper) SetUnitOfComputePriceProposal(ctx context.Context, proposal *types.UnitOfComputePriceProposal) {
+func (k Keeper) SetUnitOfComputePriceProposal(ctx context.Context, proposal *types.UnitOfComputePriceProposal) error {
 	if err := k.UnitOfComputePriceProposals.Set(ctx, proposal.Participant, *proposal); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // TODO: fix name!

--- a/inference-chain/x/inference/keeper/unit_of_compute_test.go
+++ b/inference-chain/x/inference/keeper/unit_of_compute_test.go
@@ -1,10 +1,13 @@
 package keeper_test
 
 import (
-	keepertest "github.com/productscience/inference/testutil/keeper"
-	"github.com/productscience/inference/x/inference/types"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/types"
 )
 
 func TestUnitOfComputeProposals(t *testing.T) {
@@ -14,7 +17,8 @@ func TestUnitOfComputeProposals(t *testing.T) {
 			Participant: "participant-" + strconv.Itoa(i),
 			Price:       uint64(i),
 		}
-		keeper.SetUnitOfComputePriceProposal(ctx, proposal)
+		err := keeper.SetUnitOfComputePriceProposal(ctx, proposal)
+		require.NoError(t, err)
 	}
 
 	for i := 0; i < 10; i++ {

--- a/inference-chain/x/inference/module/chainvalidation.go
+++ b/inference-chain/x/inference/module/chainvalidation.go
@@ -374,7 +374,14 @@ func (am AppModule) ComputeNewWeights(ctx context.Context, upcomingEpoch types.E
 	}
 
 	// STEP 4: Create WeightCalculator and calculate PoC mining participants (excluding inference-serving nodes)
-	params := am.keeper.GetParams(ctx)
+	params, err := am.keeper.GetParams(ctx)
+	if err != nil {
+		am.LogError("ComputeNewWeights: Error getting params", types.PoC,
+			"upcomingEpoch.Index", upcomingEpoch.Index,
+			"upcomingEpoch.PocStartBlockHeight", upcomingEpoch.PocStartBlockHeight,
+			"error", err)
+		return nil
+	}
 	weightScaleFactor := params.PocParams.GetWeightScaleFactorDec()
 	calculator := NewWeightCalculator(
 		currentValidatorWeights,

--- a/inference-chain/x/inference/module/chainvalidation_test.go
+++ b/inference-chain/x/inference/module/chainvalidation_test.go
@@ -87,7 +87,7 @@ func TestComputeNewWeightsWithStakingValidators(t *testing.T) {
 		PocStageStartBlockHeight: 100,
 		Nonces:                   []int64{1, 2, 3},
 	}
-	k.SetPocBatch(ctx, batch)
+	_ = k.SetPocBatch(ctx, batch)
 
 	// Set up validations
 	validation := types.PoCValidation{
@@ -96,7 +96,7 @@ func TestComputeNewWeightsWithStakingValidators(t *testing.T) {
 		PocStageStartBlockHeight:    100,
 		FraudDetected:               false,
 	}
-	k.SetPoCValidation(ctx, validation)
+	_ = k.SetPoCValidation(ctx, validation)
 
 	// Set up participant
 	participant := types.Participant{
@@ -113,7 +113,7 @@ func TestComputeNewWeightsWithStakingValidators(t *testing.T) {
 		EpochIndex:  1,
 		Signature:   "signature1",
 	}
-	k.SetRandomSeed(ctx, seed)
+	_ = k.SetRandomSeed(ctx, seed)
 
 	// Create EpochGroupData with epochIndex <= 1
 	upcomingEpoch := types.Epoch{
@@ -140,7 +140,7 @@ func TestCollateralGracePeriod(t *testing.T) {
 	// Set current epoch to 5 (within grace period).
 	// AdjustWeightsByCollateral uses GetLatestEpoch, which is based on the "Effective" epoch.
 	// We must set the effective epoch first, then the upcoming epoch.
-	k.SetEffectiveEpochIndex(ctx, 4)
+	_ = k.SetEffectiveEpochIndex(ctx, 4)
 	currentEpoch := types.Epoch{Index: 5}
 	k.SetEpoch(ctx, &currentEpoch)
 
@@ -175,7 +175,7 @@ func TestNoCollateralPostGracePeriod(t *testing.T) {
 	k.SetParams(ctx, inferenceParams)
 
 	// Set current epoch to 5 (after grace period)
-	k.SetEffectiveEpochIndex(ctx, 4)
+	_ = k.SetEffectiveEpochIndex(ctx, 4)
 	currentEpoch := types.Epoch{Index: 5}
 	k.SetEpoch(ctx, &currentEpoch)
 
@@ -219,7 +219,7 @@ func TestPostGracePeriod_FullCollateral(t *testing.T) {
 	k.SetParams(ctx, inferenceParams)
 
 	// Set current epoch to 5 (after grace period)
-	k.SetEffectiveEpochIndex(ctx, 4)
+	_ = k.SetEffectiveEpochIndex(ctx, 4)
 	currentEpoch := types.Epoch{Index: 5}
 	k.SetEpoch(ctx, &currentEpoch)
 
@@ -266,7 +266,7 @@ func TestPostGracePeriod_PartialCollateral(t *testing.T) {
 	k.SetParams(ctx, inferenceParams)
 
 	// Set current epoch to 5 (after grace period)
-	k.SetEffectiveEpochIndex(ctx, 4)
+	_ = k.SetEffectiveEpochIndex(ctx, 4)
 	currentEpoch := types.Epoch{Index: 5}
 	k.SetEpoch(ctx, &currentEpoch)
 
@@ -368,7 +368,7 @@ func TestComputeNewWeights(t *testing.T) {
 					PocStageStartBlockHeight: 100,
 					Nonces:                   []int64{1, 2, 3},
 				}
-				k.SetPocBatch(ctx, batch)
+				_ = k.SetPocBatch(ctx, batch)
 
 				// Set up validations
 				validation := types.PoCValidation{
@@ -377,7 +377,7 @@ func TestComputeNewWeights(t *testing.T) {
 					PocStageStartBlockHeight:    100,
 					FraudDetected:               false,
 				}
-				k.SetPoCValidation(ctx, validation)
+				_ = k.SetPoCValidation(ctx, validation)
 
 				// Set up participant
 				participant := types.Participant{
@@ -393,7 +393,7 @@ func TestComputeNewWeights(t *testing.T) {
 					EpochIndex:  1,
 					Signature:   "signature1",
 				}
-				k.SetRandomSeed(ctx, seed)
+				_ = k.SetRandomSeed(ctx, seed)
 			},
 			expectedParticipants: 1,
 		},
@@ -417,7 +417,7 @@ func TestComputeNewWeights(t *testing.T) {
 		//		k.SetEpochGroupData(ctx, previousEpochGroupData)
 		//
 		//		k.SetEpoch(ctx, &types.Epoch{Index: 1, PocStartBlockHeight: 50})
-		//		k.SetEffectiveEpochIndex(ctx, 1)
+		//		_ = k.SetEffectiveEpochIndex(ctx, 1)
 		//
 		//		// Set up batches
 		//		batch := types.PoCBatch{
@@ -425,7 +425,7 @@ func TestComputeNewWeights(t *testing.T) {
 		//			PocStageStartBlockHeight: 100,
 		//			Nonces:                   []int64{1, 2, 3},
 		//		}
-		//		k.SetPocBatch(ctx, batch)
+		//		_ = k.SetPocBatch(ctx, batch)
 		//
 		//		// Set up validations
 		//		validation := types.PoCValidation{
@@ -434,7 +434,7 @@ func TestComputeNewWeights(t *testing.T) {
 		//			PocStageStartBlockHeight:    100,
 		//			FraudDetected:               false,
 		//		}
-		//		k.SetPoCValidation(ctx, validation)
+		//		_ = k.SetPoCValidation(ctx, validation)
 		//
 		//		// Set up participant
 		//		participant := types.Participant{
@@ -450,7 +450,7 @@ func TestComputeNewWeights(t *testing.T) {
 		//			EpochIndex:  1,
 		//			Signature:   "signature1",
 		//		}
-		//		k.SetRandomSeed(ctx, seed)
+		//		_ = k.SetRandomSeed(ctx, seed)
 		//	},
 		//	expectedParticipants: 1,
 		//},
@@ -478,7 +478,7 @@ func TestComputeNewWeights(t *testing.T) {
 				k.SetEpochGroupData(ctx, previousEpochGroupData)
 
 				k.SetEpoch(ctx, &types.Epoch{Index: 1, PocStartBlockHeight: 50})
-				k.SetEffectiveEpochIndex(ctx, 1)
+				_ = k.SetEffectiveEpochIndex(ctx, 1)
 
 				// Set up batches
 				batch := types.PoCBatch{
@@ -486,7 +486,7 @@ func TestComputeNewWeights(t *testing.T) {
 					PocStageStartBlockHeight: 100,
 					Nonces:                   []int64{1, 2, 3},
 				}
-				k.SetPocBatch(ctx, batch)
+				_ = k.SetPocBatch(ctx, batch)
 
 				// Set up validations with only one validator (not enough weight)
 				validation := types.PoCValidation{
@@ -495,7 +495,7 @@ func TestComputeNewWeights(t *testing.T) {
 					PocStageStartBlockHeight:    100,
 					FraudDetected:               false,
 				}
-				k.SetPoCValidation(ctx, validation)
+				_ = k.SetPoCValidation(ctx, validation)
 
 				// Set up participant
 				participant := types.Participant{
@@ -511,7 +511,7 @@ func TestComputeNewWeights(t *testing.T) {
 					EpochIndex:  1,
 					Signature:   "signature1",
 				}
-				k.SetRandomSeed(ctx, seed)
+				_ = k.SetRandomSeed(ctx, seed)
 			},
 			expectedParticipants: 0,
 		},
@@ -540,7 +540,7 @@ func TestComputeNewWeights(t *testing.T) {
 				k.SetEpochGroupData(ctx, previousEpochGroupData)
 
 				k.SetEpoch(ctx, &types.Epoch{Index: 1, PocStartBlockHeight: 50})
-				k.SetEffectiveEpochIndex(ctx, 1)
+				_ = k.SetEffectiveEpochIndex(ctx, 1)
 
 				// Set up batches
 				batch := types.PoCBatch{
@@ -548,7 +548,7 @@ func TestComputeNewWeights(t *testing.T) {
 					PocStageStartBlockHeight: 100,
 					Nonces:                   []int64{1, 2, 3},
 				}
-				k.SetPocBatch(ctx, batch)
+				_ = k.SetPocBatch(ctx, batch)
 
 				// Set up validations with enough total weight but not enough valid weight
 				validation1 := types.PoCValidation{
@@ -557,7 +557,7 @@ func TestComputeNewWeights(t *testing.T) {
 					PocStageStartBlockHeight:    100,
 					FraudDetected:               false, // Valid but low weight
 				}
-				k.SetPoCValidation(ctx, validation1)
+				_ = k.SetPoCValidation(ctx, validation1)
 
 				validation2 := types.PoCValidation{
 					ParticipantAddress:          testutil.Executor2,
@@ -565,7 +565,7 @@ func TestComputeNewWeights(t *testing.T) {
 					PocStageStartBlockHeight:    100,
 					FraudDetected:               true, // Invalid with high weight
 				}
-				k.SetPoCValidation(ctx, validation2)
+				_ = k.SetPoCValidation(ctx, validation2)
 
 				// Set up participant
 				participant := types.Participant{
@@ -624,11 +624,11 @@ func TestComputeNewWeights(t *testing.T) {
 				PocStartBlockHeight: 100,
 			})
 
-		// Call the function
-		result := am.ComputeNewWeights(ctx, upcomingEpoch)
+			// Call the function
+			result := am.ComputeNewWeights(ctx, upcomingEpoch)
 
-		// Verify the result
-		require.Equal(t, tt.expectedParticipants, len(result))
+			// Verify the result
+			require.Equal(t, tt.expectedParticipants, len(result))
 		})
 	}
 }
@@ -695,25 +695,25 @@ func TestComputeNewWeights_AllowlistExcludesParticipant(t *testing.T) {
 	participantB := testutil.Executor2
 
 	// Set up batches for both participants
-	k.SetPocBatch(ctx, types.PoCBatch{
+	_ = k.SetPocBatch(ctx, types.PoCBatch{
 		ParticipantAddress:       participantA,
 		PocStageStartBlockHeight: 100,
 		Nonces:                   []int64{1, 2, 3},
 	})
-	k.SetPocBatch(ctx, types.PoCBatch{
+	_ = k.SetPocBatch(ctx, types.PoCBatch{
 		ParticipantAddress:       participantB,
 		PocStageStartBlockHeight: 100,
 		Nonces:                   []int64{4, 5, 6},
 	})
 
 	// Set up validations for both
-	k.SetPoCValidation(ctx, types.PoCValidation{
+	_ = k.SetPoCValidation(ctx, types.PoCValidation{
 		ParticipantAddress:          participantA,
 		ValidatorParticipantAddress: validatorAccAddress2,
 		PocStageStartBlockHeight:    100,
 		FraudDetected:               false,
 	})
-	k.SetPoCValidation(ctx, types.PoCValidation{
+	_ = k.SetPoCValidation(ctx, types.PoCValidation{
 		ParticipantAddress:          participantB,
 		ValidatorParticipantAddress: validatorAccAddress2,
 		PocStageStartBlockHeight:    100,
@@ -735,8 +735,8 @@ func TestComputeNewWeights_AllowlistExcludesParticipant(t *testing.T) {
 	}))
 
 	// Set up seeds for both
-	k.SetRandomSeed(ctx, types.RandomSeed{Participant: participantA, EpochIndex: 1, Signature: "sigA"})
-	k.SetRandomSeed(ctx, types.RandomSeed{Participant: participantB, EpochIndex: 1, Signature: "sigB"})
+	_ = k.SetRandomSeed(ctx, types.RandomSeed{Participant: participantA, EpochIndex: 1, Signature: "sigA"})
+	_ = k.SetRandomSeed(ctx, types.RandomSeed{Participant: participantB, EpochIndex: 1, Signature: "sigB"})
 
 	// Enable allowlist and add only participantA
 	params := k.GetParams(ctx)

--- a/inference-chain/x/inference/module/chainvalidation_test.go
+++ b/inference-chain/x/inference/module/chainvalidation_test.go
@@ -739,7 +739,8 @@ func TestComputeNewWeights_AllowlistExcludesParticipant(t *testing.T) {
 	_ = k.SetRandomSeed(ctx, types.RandomSeed{Participant: participantB, EpochIndex: 1, Signature: "sigB"})
 
 	// Enable allowlist and add only participantA
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	params.ParticipantAccessParams.UseParticipantAllowlist = true
 	require.NoError(t, k.SetParams(ctx, params))
 

--- a/inference-chain/x/inference/module/confirmation_poc.go
+++ b/inference-chain/x/inference/module/confirmation_poc.go
@@ -19,7 +19,7 @@ func (am AppModule) handleConfirmationPoC(ctx context.Context, blockHeight int64
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	// Get current parameters
-	params, err := am.keeper.GetParamsSafe(ctx)
+	params, err := am.keeper.GetParams(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get params: %w", err)
 	}
@@ -389,7 +389,11 @@ func (am AppModule) updateConfirmationWeights(ctx context.Context, event *types.
 	}
 
 	// Create WeightCalculator (reuse regular PoC logic)
-	params := am.keeper.GetParams(ctx)
+	params, err := am.keeper.GetParams(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get params: %w", err)
+	}
+
 	weightScaleFactor := params.PocParams.GetWeightScaleFactorDec()
 	calculator := NewWeightCalculator(
 		currentValidatorWeights,

--- a/inference-chain/x/inference/module/genesis.go
+++ b/inference-chain/x/inference/module/genesis.go
@@ -254,6 +254,7 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := &types.GenesisState{}
 	params, err := k.GetParams(ctx)
 	if err != nil {
+		//nolint:forbidigo // genesis code
 		panic(err)
 	}
 	genesis.Params = params

--- a/inference-chain/x/inference/module/genesis.go
+++ b/inference-chain/x/inference/module/genesis.go
@@ -33,6 +33,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	k.SetTokenomicsData(ctx, types.TokenomicsData{})
 	err := k.PruningState.Set(ctx, types.PruningState{})
 	if err != nil {
+		//nolint:forbidigo // genesis code
 		panic(err)
 	}
 
@@ -64,10 +65,12 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 
 	// this line is used by starport scaffolding # genesis/module/init
 	if err := k.SetParams(ctx, genState.Params); err != nil {
+		//nolint:forbidigo // genesis code
 		panic(err)
 	}
 	for _, elem := range genState.ModelList {
 		if elem.ProposedBy != "genesis" {
+			//nolint:forbidigo // genesis code
 			panic("At genesis all model.ProposedBy are expected to be \"genesis\".")
 		}
 
@@ -92,7 +95,10 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 
 		// Set all bridge trade approved tokens from genesis
 		for _, elem := range genState.Bridge.TradeApprovedTokens {
-			k.SetBridgeTradeApprovedToken(ctx, *elem)
+			if err := k.SetBridgeTradeApprovedToken(ctx, *elem); err != nil {
+				//nolint:forbidigo // genesis code
+				panic(err)
+			}
 		}
 	}
 
@@ -107,7 +113,10 @@ func InitGenesisEpoch(ctx sdk.Context, k keeper.Keeper) {
 		PocStartBlockHeight: 0,
 	}
 	k.SetEpoch(ctx, genesisEpoch)
-	k.SetEffectiveEpochIndex(ctx, genesisEpoch.Index)
+	if err := k.SetEffectiveEpochIndex(ctx, genesisEpoch.Index); err != nil {
+		//nolint:forbidigo // genesis code
+		panic(err)
+	}
 
 	InitGenesisEpochGroup(ctx, k, uint64(genesisEpoch.PocStartBlockHeight))
 }
@@ -180,11 +189,13 @@ func InitHoldingAccounts(ctx sdk.Context, k keeper.Keeper, state types.GenesisSt
 	supplyDenom := state.GenesisOnlyParams.SupplyDenom
 	denomMetadata, found := k.BankView.GetDenomMetaData(ctx, types.BaseCoin)
 	if !found {
+		//nolint:forbidigo // genesis code
 		panic("BaseCoin denom not found")
 	}
 
 	err := LoadMetadataToSdk(denomMetadata)
 	if err != nil {
+		//nolint:forbidigo // genesis code
 		panic(err)
 	}
 
@@ -197,9 +208,11 @@ func InitHoldingAccounts(ctx sdk.Context, k keeper.Keeper, state types.GenesisSt
 	preProgrammedCoin := sdk.NormalizeCoin(sdk.NewInt64Coin(supplyDenom, state.GenesisOnlyParams.PreProgrammedSaleAmount))
 
 	if err := k.BankKeeper.MintCoins(ctx, types.TopRewardPoolAccName, sdk.NewCoins(topRewardCoin), "top_reward_pool init"); err != nil {
+		//nolint:forbidigo // genesis code
 		panic(err)
 	}
 	if err := k.BankKeeper.MintCoins(ctx, types.PreProgrammedSaleAccName, sdk.NewCoins(preProgrammedCoin), "pre_programmed_coin_init"); err != nil {
+		//nolint:forbidigo // genesis code
 		panic(err)
 	}
 }
@@ -287,10 +300,12 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 func getModels(ctx *sdk.Context, k *keeper.Keeper) []types.Model {
 	models, err := k.GetGovernanceModels(ctx)
 	if err != nil {
+		//nolint:forbidigo // genesis code
 		panic(err)
 	}
 	models2, err := keeper.PointersToValues(models)
 	if err != nil {
+		//nolint:forbidigo // genesis code
 		panic(err)
 	}
 	return models2

--- a/inference-chain/x/inference/module/genesis.go
+++ b/inference-chain/x/inference/module/genesis.go
@@ -252,7 +252,11 @@ func LoadMetadataToSdk(metadata banktypes.Metadata) error {
 // ExportGenesis returns the module's exported genesis.
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := &types.GenesisState{}
-	genesis.Params = k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		panic(err)
+	}
+	genesis.Params = params
 
 	genesisOnlyParams, found := k.GetGenesisOnlyParams(ctx)
 	if found {

--- a/inference-chain/x/inference/module/genesis_guardian_enhancement.go
+++ b/inference-chain/x/inference/module/genesis_guardian_enhancement.go
@@ -296,7 +296,11 @@ func ApplyBLSGuardianSlotReservation(ctx context.Context, k keeper.Keeper, activ
 
 	// Idempotency: detect if current guardian percentage already ≈ f
 	currentGuardianFraction := decimal.NewFromInt(totalGuardianPower).Div(decimal.NewFromInt(totalWeight))
-	if currentGuardianFraction.Sub(f).Abs().LessThan(decimal.NewFromFloat(0.005)) {
+	fromString, err := decimal.NewFromString("0.005")
+	if err != nil {
+		return nil
+	}
+	if currentGuardianFraction.Sub(f).Abs().LessThan(fromString) {
 		return nil
 	}
 

--- a/inference-chain/x/inference/module/genesis_guardian_enhancement_test.go
+++ b/inference-chain/x/inference/module/genesis_guardian_enhancement_test.go
@@ -15,7 +15,8 @@ func TestApplyGenesisGuardianEnhancement_ImmatureNetwork(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000, // 10M threshold
 		NetworkMaturityMinHeight: 0,
@@ -51,7 +52,7 @@ func TestApplyGenesisGuardianEnhancement_ImmatureNetwork(t *testing.T) {
 	// Total: 4500 < 10M threshold (immature network)
 
 	result := inference.ApplyGenesisGuardianEnhancement(ctx, k, computeResults)
-	err := inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
+	err = inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
 	require.NoError(t, err)
 	require.True(t, result.WasEnhanced, "Should apply enhancement for immature network")
 
@@ -78,7 +79,8 @@ func TestApplyGenesisGuardianEnhancement_MatureNetwork(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000, // 10M threshold
 		NetworkMaturityMinHeight: 0,
@@ -113,7 +115,7 @@ func TestApplyGenesisGuardianEnhancement_MatureNetwork(t *testing.T) {
 	// Total: 11M > 10M threshold (mature network)
 
 	result := inference.ApplyGenesisGuardianEnhancement(ctx, k, computeResults)
-	err := inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
+	err = inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
 	require.NoError(t, err)
 	require.False(t, result.WasEnhanced, "Should NOT apply enhancement for mature network")
 	require.Equal(t, computeResults, result.ComputeResults, "Results should be unchanged")
@@ -124,7 +126,8 @@ func TestApplyGenesisGuardianEnhancement_MinHeightGating(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Power condition is satisfied, but height condition is not.
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 1,
 		NetworkMaturityMinHeight: 100,
@@ -172,7 +175,8 @@ func TestApplyGenesisGuardianEnhancement_FeatureDisabled(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000,
 		NetworkMaturityMinHeight: 0,
@@ -205,7 +209,7 @@ func TestApplyGenesisGuardianEnhancement_FeatureDisabled(t *testing.T) {
 	}
 
 	result := inference.ApplyGenesisGuardianEnhancement(ctx, k, computeResults)
-	err := inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
+	err = inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
 	require.NoError(t, err)
 	require.False(t, result.WasEnhanced, "Should not enhance when feature is disabled")
 	require.Equal(t, computeResults, result.ComputeResults, "Results should be unchanged")
@@ -216,7 +220,8 @@ func TestApplyGenesisGuardianEnhancement_NoGenesisValidator(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000,
 		NetworkMaturityMinHeight: 0,
@@ -249,7 +254,7 @@ func TestApplyGenesisGuardianEnhancement_NoGenesisValidator(t *testing.T) {
 	}
 
 	result := inference.ApplyGenesisGuardianEnhancement(ctx, k, computeResults)
-	err := inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
+	err = inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
 	require.NoError(t, err)
 	require.False(t, result.WasEnhanced, "Should not enhance without genesis validator")
 	require.Equal(t, computeResults, result.ComputeResults, "Results should be unchanged")
@@ -260,7 +265,8 @@ func TestApplyGenesisGuardianEnhancement_GenesisValidatorNotFound(t *testing.T) 
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000,
 		NetworkMaturityMinHeight: 0,
@@ -293,7 +299,7 @@ func TestApplyGenesisGuardianEnhancement_GenesisValidatorNotFound(t *testing.T) 
 	}
 
 	result := inference.ApplyGenesisGuardianEnhancement(ctx, k, computeResults)
-	err := inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
+	err = inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
 	require.NoError(t, err)
 	require.False(t, result.WasEnhanced, "Should not enhance if genesis validator not found")
 	require.Equal(t, computeResults, result.ComputeResults, "Results should be unchanged")
@@ -304,7 +310,8 @@ func TestApplyGenesisGuardianEnhancement_SingleParticipant(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000,
 		NetworkMaturityMinHeight: 0,
@@ -336,7 +343,7 @@ func TestApplyGenesisGuardianEnhancement_SingleParticipant(t *testing.T) {
 	}
 
 	result := inference.ApplyGenesisGuardianEnhancement(ctx, k, computeResults)
-	err := inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
+	err = inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
 	require.NoError(t, err)
 	require.False(t, result.WasEnhanced, "Single participant should not be enhanced")
 	require.Equal(t, computeResults, result.ComputeResults, "Results should be unchanged")
@@ -387,7 +394,8 @@ func TestApplyGenesisGuardianEnhancement_DifferentMultipliers(t *testing.T) {
 			k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 			// Governance-controlled maturity params
-			p := k.GetParams(ctx)
+			p, err := k.GetParams(ctx)
+			require.NoError(t, err)
 			p.GenesisGuardianParams = &types.GenesisGuardianParams{
 				NetworkMaturityThreshold: 10_000_000,
 				NetworkMaturityMinHeight: 0,
@@ -422,7 +430,7 @@ func TestApplyGenesisGuardianEnhancement_DifferentMultipliers(t *testing.T) {
 			// Other participants total: 2000 + 1500 = 3500
 
 			result := inference.ApplyGenesisGuardianEnhancement(ctx, k, computeResults)
-			err := inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
+			err = inference.ValidateGuardianEnhancementResults(computeResults, result.ComputeResults, result.TotalPower)
 			require.NoError(t, err)
 			require.True(t, result.WasEnhanced, "Should apply enhancement")
 			require.Equal(t, tt.expectedTotalPower, result.TotalPower)
@@ -445,7 +453,8 @@ func TestApplyGenesisGuardianEnhancement_ValidatorIdentityPreserved(t *testing.T
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000,
 		NetworkMaturityMinHeight: 0,
@@ -479,7 +488,7 @@ func TestApplyGenesisGuardianEnhancement_ValidatorIdentityPreserved(t *testing.T
 	}
 
 	result := inference.ApplyGenesisGuardianEnhancement(ctx, k, originalResults)
-	err := inference.ValidateGuardianEnhancementResults(originalResults, result.ComputeResults, result.TotalPower)
+	err = inference.ValidateGuardianEnhancementResults(originalResults, result.ComputeResults, result.TotalPower)
 	require.NoError(t, err)
 	require.True(t, result.WasEnhanced)
 
@@ -503,7 +512,8 @@ func TestApplyGenesisGuardianEnhancement_TwoGuardians(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000, // 10M threshold
 		NetworkMaturityMinHeight: 0,
@@ -570,7 +580,8 @@ func TestApplyGenesisGuardianEnhancement_ThreeGuardians(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000, // 10M threshold
 		NetworkMaturityMinHeight: 0,
@@ -636,7 +647,8 @@ func TestApplyGenesisGuardianEnhancement_PartialGuardians(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000, // 10M threshold
 		NetworkMaturityMinHeight: 0,
@@ -703,7 +715,8 @@ func TestApplyGenesisGuardianEnhancement_SingleGuardianFallback(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
 	// Governance-controlled maturity params
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000, // 10M threshold
 		NetworkMaturityMinHeight: 0,

--- a/inference-chain/x/inference/module/genesis_guardian_slot_reservation_precision_test.go
+++ b/inference-chain/x/inference/module/genesis_guardian_slot_reservation_precision_test.go
@@ -82,7 +82,8 @@ func TestApplyBLSGuardianSlotReservation_RepeatingDecimalPrecision(t *testing.T)
 	participant3AccAddr := sdk.AccAddress([]byte("participant3________"))
 
 	// Governance params with guardian
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000,
 		NetworkMaturityMinHeight: 0,
@@ -151,7 +152,8 @@ func TestApplyBLSGuardianSlotReservation_PrimeWeights(t *testing.T) {
 	participant3AccAddr := sdk.AccAddress([]byte("participant3________"))
 	participant4AccAddr := sdk.AccAddress([]byte("participant4________"))
 
-	p := k.GetParams(ctx)
+	p, err := k.GetParams(ctx)
+	require.NoError(t, err)
 	p.GenesisGuardianParams = &types.GenesisGuardianParams{
 		NetworkMaturityThreshold: 10_000_000,
 		NetworkMaturityMinHeight: 0,

--- a/inference-chain/x/inference/module/model_assignment_test.go
+++ b/inference-chain/x/inference/module/model_assignment_test.go
@@ -45,11 +45,11 @@ func (m *mockKeeperForModelAssigner) GetEpochGroupData(ctx context.Context, epoc
 	return types.EpochGroupData{}, false
 }
 
-func (m *mockKeeperForModelAssigner) GetParams(ctx context.Context) types.Params {
+func (m *mockKeeperForModelAssigner) GetParams(ctx context.Context) (types.Params, error) {
 	if m.params != nil {
-		return *m.params
+		return *m.params, nil
 	}
-	return types.DefaultParams()
+	return types.DefaultParams(), nil
 }
 
 // Mock Logger

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -685,7 +685,7 @@ func (am AppModule) moveUpcomingToEffectiveGroup(ctx context.Context, blockHeigh
 	}
 
 	// At this point, clear all active invalidations in case of any hanging invalidations
-	err := am.keeper.ActiveInvalidations.Clear(ctx, nil)
+	err = am.keeper.ActiveInvalidations.Clear(ctx, nil)
 	if err != nil {
 		am.LogError("Unable to clear active invalidations", types.EpochGroup, "error", err.Error())
 	}

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -232,7 +232,7 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 		// Don't return error - allow block processing to continue
 	}
 
-	params, err := am.keeper.GetParamsSafe(ctx)
+	params, err := am.keeper.GetParams(ctx)
 	if err != nil {
 		am.LogError("Unable to get parameters", types.Settle, "error", err.Error())
 		return err
@@ -532,7 +532,12 @@ func (am AppModule) onSetNewValidatorsStage(ctx context.Context, blockHeight int
 }
 
 func (am AppModule) addEpochMembers(ctx context.Context, upcomingEg *epochgroup.EpochGroup, activeParticipants []*types.ActiveParticipant) {
-	validationParams := am.keeper.GetParams(ctx).ValidationParams
+	params, err := am.keeper.GetParams(ctx)
+	if err != nil {
+		am.LogError("addEpochMembers: Unable to get params", types.EpochGroup, "error", err.Error())
+		return
+	}
+	validationParams := params.ValidationParams
 
 	for _, p := range activeParticipants {
 		reputation, err := am.calculateParticipantReputation(ctx, p, validationParams)
@@ -565,7 +570,12 @@ func (am AppModule) computePrice(ctx context.Context, upcomingEpoch types.Epoch,
 		}
 		defaultPrice = currentEg.GroupData.UnitOfComputePrice
 	} else {
-		defaultPrice = am.keeper.GetParams(ctx).EpochParams.DefaultUnitOfComputePrice
+		params, err := am.keeper.GetParams(ctx)
+		if err != nil {
+			am.LogError("computePrice: Unable to get params", types.Pricing, "error", err.Error())
+			return 0, err
+		}
+		defaultPrice = params.EpochParams.DefaultUnitOfComputePrice
 	}
 
 	proposals, err := am.keeper.AllUnitOfComputePriceProposals(ctx)
@@ -637,7 +647,11 @@ func (am AppModule) moveUpcomingToEffectiveGroup(ctx context.Context, blockHeigh
 		am.LogWarn("PreviousEpochGroupDataNotFound", types.EpochGroup, "blockHeight", blockHeight, "previousEpochIndex", previousEpochIndex)
 		return
 	}
-	params := am.keeper.GetParams(ctx)
+	params, err := am.keeper.GetParams(ctx)
+	if err != nil {
+		am.LogError("MoveUpcomingToEffectiveGroup: Unable to get params", types.EpochGroup, "blockHeight", blockHeight, "error", err.Error())
+		return
+	}
 	newGroupData.EffectiveBlockHeight = blockHeight
 	newGroupData.UnitOfComputePrice = int64(unitOfComputePrice)
 	newGroupData.PreviousEpochRequests = previousGroupData.NumberOfRequests

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -85,6 +85,7 @@ func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 // DefaultGenesis returns a default GenesisState for the module, marshalled to json.RawMessage.
 // The default GenesisState need to be defined by the module developer and is primarily used for testing.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(types.DefaultGenesis())
 }
 
@@ -100,6 +101,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		//nolint:forbidigo // init code
 		panic(err)
 	}
 }
@@ -150,6 +152,7 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {
 	var genState types.GenesisState
 	// Initialize global index to index in genesis state
+	//nolint:forbidigo // Genesis code
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	InitGenesis(ctx, am.keeper, genState)
@@ -158,6 +161,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	genState := ExportGenesis(ctx, am.keeper)
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(genState)
 }
 
@@ -312,7 +316,9 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	if epochContext.IsSetNewValidatorsStage(blockHeight) {
 		am.LogInfo("StartStage:onSetNewValidatorsStage", types.Stages, "blockHeight", blockHeight)
 		am.onSetNewValidatorsStage(ctx, blockHeight, blockTime)
-		am.keeper.SetEffectiveEpochIndex(ctx, getNextEpochIndex(*currentEpoch))
+		if err := am.keeper.SetEffectiveEpochIndex(ctx, getNextEpochIndex(*currentEpoch)); err != nil {
+			return err
+		}
 	}
 
 	if epochContext.IsStartOfPocStage(blockHeight) {
@@ -390,7 +396,9 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 	// This will trigger its internal unbonding queue processing.
 	if am.keeper.GetCollateralKeeper() != nil {
 		am.LogInfo("onEndOfPoCValidationStage: Advancing collateral epoch", types.Tokenomics, "effectiveEpoch.Index", effectiveEpoch.Index)
-		am.keeper.GetCollateralKeeper().AdvanceEpoch(ctx, effectiveEpoch.Index)
+		if err := am.keeper.GetCollateralKeeper().AdvanceEpoch(ctx, effectiveEpoch.Index); err != nil {
+			am.LogError("onEndOfPoCValidationStage: Unable to advance collateral epoch", types.Tokenomics, "error", err.Error())
+		}
 	} else {
 		am.LogError("collateral keeper is null", types.Tokenomics)
 	}
@@ -398,8 +406,7 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 	// Signal to the streamvesting module that the epoch has advanced.
 	// This will trigger vested token unlocking for the completed epoch.
 	if am.keeper.GetStreamVestingKeeper() != nil {
-		err := am.keeper.GetStreamVestingKeeper().AdvanceEpoch(ctx, effectiveEpoch.Index)
-		if err != nil {
+		if err := am.keeper.GetStreamVestingKeeper().AdvanceEpoch(ctx, effectiveEpoch.Index); err != nil {
 			am.LogError("onSetNewValidatorsStage: Unable to advance streamvesting epoch", types.Tokenomics, "error", err.Error())
 		}
 	}

--- a/inference-chain/x/inference/module/simulation.go
+++ b/inference-chain/x/inference/module/simulation.go
@@ -148,7 +148,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
-	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&inferenceGenesis)
+	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&inferenceGenesis) //nolint:forbidigo // Simulation code
 }
 
 // RegisterStoreDecoder registers a decoder.

--- a/inference-chain/x/inference/simulation/helpers.go
+++ b/inference-chain/x/inference/simulation/helpers.go
@@ -9,6 +9,7 @@ import (
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
+		//nolint:forbidigo // simulation code
 		panic(err)
 	}
 	return simtypes.FindAccount(accs, creator)

--- a/inference-chain/x/inference/types/expected_keepers.go
+++ b/inference-chain/x/inference/types/expected_keepers.go
@@ -76,7 +76,7 @@ type StakingKeeper interface {
 
 // CollateralKeeper defines the expected interface for the Collateral module.
 type CollateralKeeper interface {
-	AdvanceEpoch(ctx context.Context, completedEpoch uint64)
+	AdvanceEpoch(ctx context.Context, completedEpoch uint64) error
 	GetCollateral(ctx context.Context, participant sdk.AccAddress) (collateral sdk.Coin, found bool)
 	Slash(ctx context.Context, participant sdk.AccAddress, slashFraction math.LegacyDec, reason string) (sdk.Coin, error)
 }
@@ -129,7 +129,7 @@ type AuthzKeeper interface {
 type BlsKeeper interface {
 	// DKG methods
 	InitiateKeyGenerationForEpoch(ctx sdk.Context, epochID uint64, finalizedParticipants []blstypes.ParticipantWithWeightAndKey) error
-	GetEpochBLSData(ctx sdk.Context, epochID uint64) (blstypes.EpochBLSData, bool)
+	GetEpochBLSData(ctx sdk.Context, epochID uint64) (blstypes.EpochBLSData, error)
 	SetActiveEpochID(ctx sdk.Context, epochID uint64)
 	GetActiveEpochID(ctx sdk.Context) (uint64, bool)
 

--- a/inference-chain/x/inference/types/message_bridge_exchange.go
+++ b/inference-chain/x/inference/types/message_bridge_exchange.go
@@ -24,7 +24,7 @@ func NewMsgBridgeExchange(validator string, originChain string, contractAddress 
 	}
 }
 
-var reDigits = regexp.MustCompile(`^[0-9]+$`)
+var reDigits = regexp.MustCompile(`^[0-9]+$`) //nolint:forbidigo // init code
 
 func (msg *MsgBridgeExchange) ValidateBasic() error {
 	// validator bech32 signer

--- a/inference-chain/x/inference/types/message_request_bridge_mint.go
+++ b/inference-chain/x/inference/types/message_request_bridge_mint.go
@@ -68,7 +68,8 @@ func (msg *MsgRequestBridgeMint) ValidateBasic() error {
 func (msg *MsgRequestBridgeMint) GetSigners() []sdk.AccAddress {
 	creatorAddr, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		panic(err)
+		//nolint:forbidigo // GetSigners can't return error
+		return nil
 	}
 	return []sdk.AccAddress{creatorAddr}
 }

--- a/inference-chain/x/inference/types/message_request_bridge_withdrawal.go
+++ b/inference-chain/x/inference/types/message_request_bridge_withdrawal.go
@@ -46,7 +46,8 @@ func (msg *MsgRequestBridgeWithdrawal) ValidateBasic() error {
 func (msg *MsgRequestBridgeWithdrawal) GetSigners() []sdk.AccAddress {
 	creatorAddr, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		panic(err)
+		//nolint:forbidigo // GetSigners can't return error
+		return nil
 	}
 	return []sdk.AccAddress{creatorAddr}
 }

--- a/inference-chain/x/restrictions/keeper/auto_unregistration.go
+++ b/inference-chain/x/restrictions/keeper/auto_unregistration.go
@@ -25,12 +25,17 @@ func (k Keeper) CheckAndUnregisterRestriction(ctx sdk.Context) error {
 	}
 
 	// Restrictions have expired, unregister the SendRestriction
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		k.logger.Error("Failed to get params for unregistration", "error", err)
+		return err
+	}
+
 	k.logger.Info("Transfer restrictions deadline reached, unregistering SendRestriction",
 		"current_height", ctx.BlockHeight(),
-		"restriction_end_block", k.GetParams(ctx).RestrictionEndBlock)
+		"restriction_end_block", params.RestrictionEndBlock)
 
 	// Emit event for restriction lifting
-	params := k.GetParams(ctx)
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeRestrictionLifted,

--- a/inference-chain/x/restrictions/keeper/bank_integration_test.go
+++ b/inference-chain/x/restrictions/keeper/bank_integration_test.go
@@ -330,7 +330,8 @@ func TestBankIntegration_EmergencyTransferExecution(t *testing.T) {
 	require.Equal(t, transferAmount, bankKeeper.GetBalance(toAddr))
 
 	// Verify usage tracking was updated
-	updatedParams := keeper.GetParams(ctx)
+	updatedParams, err := keeper.GetParams(ctx)
+	require.NoError(t, err)
 	require.Len(t, updatedParams.ExemptionUsageTracking, 1)
 	require.Equal(t, "emergency-test", updatedParams.ExemptionUsageTracking[0].ExemptionId)
 	require.Equal(t, testutil.Creator, updatedParams.ExemptionUsageTracking[0].AccountAddress)
@@ -528,7 +529,8 @@ func TestBankIntegration_WildcardExemptions(t *testing.T) {
 	require.Equal(t, totalReceived, bankKeeper.GetBalance(toAddr))
 
 	// Verify usage tracking for both senders
-	updatedParams := keeper.GetParams(ctx)
+	updatedParams, err := keeper.GetParams(ctx)
+	require.NoError(t, err)
 	require.Len(t, updatedParams.ExemptionUsageTracking, 2)
 
 	// Usage should be tracked separately per account

--- a/inference-chain/x/restrictions/keeper/keeper.go
+++ b/inference-chain/x/restrictions/keeper/keeper.go
@@ -36,6 +36,8 @@ func NewKeeper(
 
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(fmt.Sprintf("invalid authority address: %s", authority))
 	}
 

--- a/inference-chain/x/restrictions/keeper/msg_execute_emergency_transfer.go
+++ b/inference-chain/x/restrictions/keeper/msg_execute_emergency_transfer.go
@@ -17,7 +17,10 @@ func (k msgServer) ExecuteEmergencyTransfer(goCtx context.Context, req *types.Ms
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// Get current parameters
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to get parameters")
+	}
 
 	// Find the exemption template
 	var exemption *types.EmergencyTransferExemption

--- a/inference-chain/x/restrictions/keeper/msg_server_test.go
+++ b/inference-chain/x/restrictions/keeper/msg_server_test.go
@@ -42,7 +42,8 @@ func TestMsgServer_UpdateParams_Authority(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify parameters were updated
-	updatedParams := k.GetParams(sdk.UnwrapSDKContext(ctx))
+	updatedParams, err := k.GetParams(sdk.UnwrapSDKContext(ctx))
+	require.NoError(t, err)
 	require.Equal(t, uint64(2000000), updatedParams.RestrictionEndBlock)
 
 	// Test invalid authority
@@ -134,7 +135,8 @@ func TestMsgServer_UpdateParams_ParameterValidation(t *testing.T) {
 				require.NoError(t, err)
 
 				// Verify parameters were set correctly
-				updatedParams := k.GetParams(sdk.UnwrapSDKContext(ctx))
+				updatedParams, err := k.GetParams(sdk.UnwrapSDKContext(ctx))
+				require.NoError(t, err)
 				require.Equal(t, tc.params.RestrictionEndBlock, updatedParams.RestrictionEndBlock)
 				require.Equal(t, len(tc.params.EmergencyTransferExemptions), len(updatedParams.EmergencyTransferExemptions))
 			}
@@ -187,7 +189,8 @@ func TestMsgServer_EmergencyTransfer_Integration(t *testing.T) {
 	require.Equal(t, uint64(2), resp.RemainingUses) // 3 - 1 = 2
 
 	// Verify usage tracking was updated
-	updatedParams := k.GetParams(sdk.UnwrapSDKContext(ctx))
+	updatedParams, err := k.GetParams(sdk.UnwrapSDKContext(ctx))
+	require.NoError(t, err)
 	require.Len(t, updatedParams.ExemptionUsageTracking, 1)
 	require.Equal(t, "integration-test", updatedParams.ExemptionUsageTracking[0].ExemptionId)
 	require.Equal(t, testutil.Creator, updatedParams.ExemptionUsageTracking[0].AccountAddress)
@@ -237,7 +240,8 @@ func TestMsgServer_EmergencyTransfer_CrossParameterUpdate(t *testing.T) {
 	require.Equal(t, uint64(1), resp1.RemainingUses)
 
 	// Step 3: Update parameters to add another exemption while preserving usage tracking
-	updatedParams := k.GetParams(sdk.UnwrapSDKContext(ctx)) // Get current params with usage tracking
+	updatedParams, err := k.GetParams(sdk.UnwrapSDKContext(ctx)) // Get current params with usage tracking
+	require.NoError(t, err)
 	exemption2 := types.EmergencyTransferExemption{
 		ExemptionId:   "test-exemption-2",
 		FromAddress:   testutil.Executor,
@@ -284,7 +288,8 @@ func TestMsgServer_EmergencyTransfer_CrossParameterUpdate(t *testing.T) {
 	require.Equal(t, uint64(0), resp3.RemainingUses) // 1 - 1 = 0
 
 	// Verify final usage tracking
-	finalParams := k.GetParams(sdk.UnwrapSDKContext(ctx))
+	finalParams, err := k.GetParams(sdk.UnwrapSDKContext(ctx))
+	require.NoError(t, err)
 	require.Len(t, finalParams.ExemptionUsageTracking, 2)
 
 	// Check individual usage counts

--- a/inference-chain/x/restrictions/keeper/params.go
+++ b/inference-chain/x/restrictions/keeper/params.go
@@ -9,14 +9,17 @@ import (
 )
 
 // GetParams get all parameters as types.Params
-func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
+func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
-		return types.DefaultParams()
+		return types.DefaultParams(), nil
 	}
 
-	k.cdc.MustUnmarshal(bz, &params)
+	err = k.cdc.Unmarshal(bz, &params)
+	if err != nil {
+		return params, err
+	}
 
 	// Ensure slices are never nil (empty instead)
 	if params.EmergencyTransferExemptions == nil {
@@ -25,8 +28,7 @@ func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
 	if params.ExemptionUsageTracking == nil {
 		params.ExemptionUsageTracking = []types.ExemptionUsage{}
 	}
-
-	return params
+	return params, nil
 }
 
 // SetParams set the params

--- a/inference-chain/x/restrictions/keeper/params_test.go
+++ b/inference-chain/x/restrictions/keeper/params_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestGetParams(t *testing.T) {
 	k, ctx := keepertest.RestrictionsKeeper(t)
-	params := types.DefaultParams()
+	expectedParams := types.DefaultParams()
 
-	require.NoError(t, k.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, expectedParams))
 	params, err := k.GetParams(ctx)
 	require.NoError(t, err)
-	require.EqualValues(t, params, params)
+	require.EqualValues(t, expectedParams, params)
 }

--- a/inference-chain/x/restrictions/keeper/params_test.go
+++ b/inference-chain/x/restrictions/keeper/params_test.go
@@ -14,5 +14,7 @@ func TestGetParams(t *testing.T) {
 	params := types.DefaultParams()
 
 	require.NoError(t, k.SetParams(ctx, params))
-	require.EqualValues(t, params, k.GetParams(ctx))
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, params, params)
 }

--- a/inference-chain/x/restrictions/keeper/query_exemption_usage.go
+++ b/inference-chain/x/restrictions/keeper/query_exemption_usage.go
@@ -25,7 +25,10 @@ func (k Keeper) ExemptionUsage(goCtx context.Context, req *types.QueryExemptionU
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get parameters")
+	}
 
 	var filteredUsage []types.ExemptionUsage
 

--- a/inference-chain/x/restrictions/keeper/query_params.go
+++ b/inference-chain/x/restrictions/keeper/query_params.go
@@ -16,5 +16,10 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get parameters")
+	}
+
+	return &types.QueryParamsResponse{Params: params}, nil
 }

--- a/inference-chain/x/restrictions/keeper/query_transfer_exemptions.go
+++ b/inference-chain/x/restrictions/keeper/query_transfer_exemptions.go
@@ -18,7 +18,10 @@ func (k Keeper) TransferExemptions(goCtx context.Context, req *types.QueryTransf
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get parameters")
+	}
 
 	currentHeight := uint64(ctx.BlockHeight())
 	var filteredExemptions []types.EmergencyTransferExemption

--- a/inference-chain/x/restrictions/keeper/query_transfer_restriction_status.go
+++ b/inference-chain/x/restrictions/keeper/query_transfer_restriction_status.go
@@ -17,7 +17,10 @@ func (k Keeper) TransferRestrictionStatus(goCtx context.Context, req *types.Quer
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	params := k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get parameters")
+	}
 
 	currentHeight := uint64(ctx.BlockHeight())
 	restrictionEndBlock := params.RestrictionEndBlock

--- a/inference-chain/x/restrictions/module/genesis.go
+++ b/inference-chain/x/restrictions/module/genesis.go
@@ -11,6 +11,8 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// this line is used by starport scaffolding # genesis/module/init
 	if err := k.SetParams(ctx, genState.Params); err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 }
@@ -18,7 +20,12 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 // ExportGenesis returns the module's exported genesis.
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
-	genesis.Params = k.GetParams(ctx)
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		//nolint:forbidigo // Genesis/Export code
+		panic(err)
+	}
+	genesis.Params = params
 
 	// this line is used by starport scaffolding # genesis/module/export
 

--- a/inference-chain/x/restrictions/module/module.go
+++ b/inference-chain/x/restrictions/module/module.go
@@ -69,6 +69,7 @@ func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 // DefaultGenesis returns a default GenesisState for the module, marshalled to json.RawMessage.
 // The default GenesisState need to be defined by the module developer and is primarily used for testing.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(types.DefaultGenesis())
 }
 
@@ -84,6 +85,8 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 }
@@ -128,6 +131,7 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {
 	var genState types.GenesisState
 	// Initialize global index to index in genesis state
+	//nolint:forbidigo // Genesis code
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	InitGenesis(ctx, am.keeper, genState)
@@ -136,6 +140,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	genState := ExportGenesis(ctx, am.keeper)
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/inference-chain/x/restrictions/module/simulation.go
+++ b/inference-chain/x/restrictions/module/simulation.go
@@ -36,6 +36,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
+	//nolint:forbidigo // Simulation code
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&restrictionsGenesis)
 }
 

--- a/inference-chain/x/restrictions/simulation/helpers.go
+++ b/inference-chain/x/restrictions/simulation/helpers.go
@@ -9,6 +9,8 @@ import (
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
+		//nolint:forbidigo
+		//Simulation code:
 		panic(err)
 	}
 	return simtypes.FindAccount(accs, creator)

--- a/inference-chain/x/restrictions/types/msg_execute_emergency_transfer.go
+++ b/inference-chain/x/restrictions/types/msg_execute_emergency_transfer.go
@@ -54,7 +54,8 @@ func (m *MsgExecuteEmergencyTransfer) ValidateBasic() error {
 func (m *MsgExecuteEmergencyTransfer) GetSigners() []sdk.AccAddress {
 	from, err := sdk.AccAddressFromBech32(m.FromAddress)
 	if err != nil {
-		panic(err)
+		// This should not happen if ValidateBasic is called first
+		return nil
 	}
 	return []sdk.AccAddress{from}
 }

--- a/inference-chain/x/streamvesting/keeper/keeper_test.go
+++ b/inference-chain/x/streamvesting/keeper/keeper_test.go
@@ -397,7 +397,8 @@ func (suite *KeeperTestSuite) TestGetAllVestingSchedules() {
 	suite.Require().NoError(err)
 
 	// Get all schedules
-	schedules := suite.keeper.GetAllVestingSchedules(suite.ctx)
+	schedules, err := suite.keeper.GetAllVestingSchedules(suite.ctx)
+	suite.Require().NoError(err)
 	suite.Require().Len(schedules, 2)
 
 	// Verify both participants are present

--- a/inference-chain/x/streamvesting/module/genesis.go
+++ b/inference-chain/x/streamvesting/module/genesis.go
@@ -11,11 +11,17 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// Set all the vesting schedules
 	for _, elem := range genState.VestingScheduleList {
-		k.SetVestingSchedule(ctx, elem)
+		if err := k.SetVestingSchedule(ctx, elem); err != nil {
+			//nolint:forbidigo
+			//Genesis code:
+			panic(err)
+		}
 	}
 
 	// this line is used by starport scaffolding # genesis/module/init
 	if err := k.SetParams(ctx, genState.Params); err != nil {
+		//nolint:forbidigo
+		//Genesis code:
 		panic(err)
 	}
 }
@@ -26,7 +32,12 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis.Params = k.GetParams(ctx)
 
 	// Export all vesting schedules
-	vestingSchedules := k.GetAllVestingSchedules(ctx)
+	vestingSchedules, err := k.GetAllVestingSchedules(ctx)
+	if err != nil {
+		//nolint:forbidigo
+		//Genesis code:
+		panic(err)
+	}
 	genesis.VestingScheduleList = vestingSchedules
 
 	// this line is used by starport scaffolding # genesis/module/export

--- a/inference-chain/x/streamvesting/module/module.go
+++ b/inference-chain/x/streamvesting/module/module.go
@@ -68,6 +68,7 @@ func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 // DefaultGenesis returns a default GenesisState for the module, marshalled to json.RawMessage.
 // The default GenesisState need to be defined by the module developer and is primarily used for testing.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(types.DefaultGenesis())
 }
 
@@ -83,6 +84,8 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+		//nolint:forbidigo
+		//init code:
 		panic(err)
 	}
 }
@@ -130,6 +133,7 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {
 	var genState types.GenesisState
 	// Initialize global index to index in genesis state
+	//nolint:forbidigo // Genesis code
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	InitGenesis(ctx, am.keeper, genState)
@@ -138,6 +142,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	genState := ExportGenesis(ctx, am.keeper)
+	//nolint:forbidigo // Genesis code
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/inference-chain/x/streamvesting/module/simulation.go
+++ b/inference-chain/x/streamvesting/module/simulation.go
@@ -36,6 +36,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
+	//nolint:forbidigo // Simulation code
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&streamvestingGenesis)
 }
 

--- a/inference-chain/x/streamvesting/simulation/helpers.go
+++ b/inference-chain/x/streamvesting/simulation/helpers.go
@@ -9,6 +9,8 @@ import (
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
+		//nolint:forbidigo
+		//Simulation code:
 		panic(err)
 	}
 	return simtypes.FindAccount(accs, creator)

--- a/testermint/src/test/kotlin/InferenceTests.kt
+++ b/testermint/src/test/kotlin/InferenceTests.kt
@@ -191,33 +191,6 @@ class InferenceTests : TestermintTest() {
     }
 
     @Test
-    fun `submit full inference with out of range max tokens`() {
-        val timestamp = Instant.now().toEpochNanos()
-        val genesisAddress = genesis.node.getColdAddress()
-        // Phase 3: Use hashes for signatures
-        val originalPromptHash = sha256(inferenceRequest)
-        val signature = genesis.node.signPayload(originalPromptHash + timestamp.toString() + genesisAddress, null)
-        val taSignature =
-            genesis.node.signPayload(originalPromptHash + timestamp.toString() + genesisAddress + genesisAddress, null)
-        val message = MsgStartInference(
-            creator = genesisAddress,
-            inferenceId = signature,
-            promptHash = originalPromptHash,
-            // promptPayload removed - Phase 6: payloads stored offchain
-            model = "gpt-o3",
-            requestedBy = genesisAddress,
-            assignedTo = genesisAddress,
-            nodeVersion = "",
-            maxTokens = Long.MAX_VALUE / 900,
-            promptTokenCount = 10,
-            requestTimestamp = timestamp,
-            transferSignature = taSignature,
-            originalPromptHash = originalPromptHash
-        )
-        val response = genesis.submitMessage(message)
-        assertThat(response).isFailure()
-    }
-    @Test
     fun `submit StartInference with bad dev signature`() {
         val timestamp = Instant.now().toEpochNanos()
         val genesisAddress = genesis.node.getColdAddress()

--- a/testermint/src/test/kotlin/InferenceTests.kt
+++ b/testermint/src/test/kotlin/InferenceTests.kt
@@ -191,6 +191,33 @@ class InferenceTests : TestermintTest() {
     }
 
     @Test
+    fun `submit full inference with out of range max tokens`() {
+        val timestamp = Instant.now().toEpochNanos()
+        val genesisAddress = genesis.node.getColdAddress()
+        // Phase 3: Use hashes for signatures
+        val originalPromptHash = sha256(inferenceRequest)
+        val signature = genesis.node.signPayload(originalPromptHash + timestamp.toString() + genesisAddress, null)
+        val taSignature =
+            genesis.node.signPayload(originalPromptHash + timestamp.toString() + genesisAddress + genesisAddress, null)
+        val message = MsgStartInference(
+            creator = genesisAddress,
+            inferenceId = signature,
+            promptHash = originalPromptHash,
+            // promptPayload removed - Phase 6: payloads stored offchain
+            model = "gpt-o3",
+            requestedBy = genesisAddress,
+            assignedTo = genesisAddress,
+            nodeVersion = "",
+            maxTokens = Long.MAX_VALUE / 900,
+            promptTokenCount = 10,
+            requestTimestamp = timestamp,
+            transferSignature = taSignature,
+            originalPromptHash = originalPromptHash
+        )
+        val response = genesis.submitMessage(message)
+        assertThat(response).isFailure()
+    }
+    @Test
     fun `submit StartInference with bad dev signature`() {
         val timestamp = Instant.now().toEpochNanos()
         val genesisAddress = genesis.node.getColdAddress()


### PR DESCRIPTION
# Remove panics from chain code
## Justification
- Panics, if in EndBlock, BeginBlock or other critical code, WILL break consensus
- Even for messages, panics can cause issues with message processing
- code that MIGHT be called from critical code should not be hiding possible panics, as additional calls would might slip by reviews
### Solution:
ALL uses of Must or panic should be forbidden in chain related code.

## Process
Two steps to this:
1. Ensure any unaccounted for panic or Must calls fail PR checks
2. Fix or notate all current panic/Must

### Ensure no more
- Add .golangci.yml for specifying linting - right now ONLY forbidding panic and Must
- Use `forbidigo` to detect usages
- Add a github check for it (will make it required for merges)

### Fix or notate
#### Fixes:
- Return an err instead of panic or Must (hidden panic)
- be sure to log errors, not swallow
#### Exemptions (`//nolint:forbidigo`):
- Genesis code (must fail)
- Init code (better to fail)
- Simulation code
- Test code


<img width="222" height="227" alt="image" src="https://github.com/user-attachments/assets/75f3c8f3-ca3d-43e5-81d3-4c5fc9884735" />
