### PR TITLE
Disable future timestamp check for EA

### DIFF
--- a/decentralized-api/internal/server/public/post_chat_handler.go
+++ b/decentralized-api/internal/server/public/post_chat_handler.go
@@ -683,7 +683,8 @@ func (s *Server) validateTimestampNonce(request *ChatRequest) error {
 		logging.Warn("Request timestamp is in the future", types.Inferences,
 			"inferenceId", request.InferenceId,
 			"offset", time.Duration(requestOffset).String())
-		return echo.NewHTTPError(http.StatusBadRequest, "Request timestamp is in the future")
+		// For now, we do NOT return an error here. This is solely harmful to EA with the current
+		// scheme, and is happening during chain-slow periods regularly
 	}
 
 	if checkAndRecordAuthKey(request.AuthKey, currentBlockHeight, ExecutorContext) {


### PR DESCRIPTION
The EA can get behind the chain during high load periods, causing it to erroneously reject incoming requests from a TA, resulting in missed inferences.

This is a stop gap for a broader set of problems, but this solves this issue immediately to increase chain stability