### PR TITLE
Negative coin balance for settle

### DIFF
--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -536,9 +536,9 @@ func CalculateParticipantBitcoinRewards(
 
 		// Handle error cases
 		var settleError error
-		if participant.CoinBalance < 0 {
-			settleError = types.ErrNegativeCoinBalance
-		}
+		//if participant.CoinBalance < 0 {
+		//	settleError = types.ErrNegativeCoinBalance
+		//}
 
 		// Calculate WorkCoins (UNCHANGED from current system - direct user fees)
 		workCoins := uint64(0)
@@ -573,6 +573,16 @@ func CalculateParticipantBitcoinRewards(
 			}
 		}
 		settleAmount.RewardCoins = rewardCoins
+		if participant.CoinBalance < 0 {
+			// tricky math here for making sure we don't overflow
+			debt := uint64(-participant.CoinBalance)
+			if settleAmount.RewardCoins >= debt {
+				settleAmount.RewardCoins -= debt
+			} else {
+				settleAmount.RewardCoins = 0
+				settleError = types.ErrNegativeCoinBalance
+			}
+		}
 
 		// Create SettleResult
 		settleResults = append(settleResults, &SettleResult{

--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -536,9 +536,6 @@ func CalculateParticipantBitcoinRewards(
 
 		// Handle error cases
 		var settleError error
-		//if participant.CoinBalance < 0 {
-		//	settleError = types.ErrNegativeCoinBalance
-		//}
 
 		// Calculate WorkCoins (UNCHANGED from current system - direct user fees)
 		workCoins := uint64(0)
@@ -574,7 +571,6 @@ func CalculateParticipantBitcoinRewards(
 		}
 		settleAmount.RewardCoins = rewardCoins
 		if participant.CoinBalance < 0 {
-			// tricky math here for making sure we don't overflow
 			debt := uint64(-participant.CoinBalance)
 			if settleAmount.RewardCoins >= debt {
 				settleAmount.RewardCoins -= debt


### PR DESCRIPTION
Edge cases have seen some negative CoinBalance with a reward that could have covered it. Instead of err (no reward), subtract out the negative balance