### PR TITLE
Burn extra pool coins, fix ValueDecimal validation

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -172,10 +172,7 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 }
 
 func getValidationValue(msg *types.MsgValidation) decimal.Decimal {
-	if msg.Value == 0 && msg.ValueDecimal.Value == 0 {
-		return decimal.NewFromInt(0)
-	}
-	if msg.ValueDecimal.Value != 0 {
+	if msg.ValueDecimal != nil {
 		return msg.ValueDecimal.ToDecimal()
 	}
 	return decimal.NewFromFloat(msg.Value)

--- a/inference-chain/x/inference/types/message_validation.go
+++ b/inference-chain/x/inference/types/message_validation.go
@@ -41,11 +41,16 @@ func (msg *MsgValidation) ValidateBasic() error {
 	if msg.ResponseHash != "" && strings.TrimSpace(msg.ResponseHash) == "" {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "response_hash cannot be only whitespace")
 	}
-
-	decimalValue := msg.ValueDecimal.ToDecimal()
-	// value in [0,1]
-	if decimalValue.IsNegative() || decimalValue.GreaterThan(shopspring.NewFromInt(1)) {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "value must be in [0,1]")
+	if msg.ValueDecimal != nil {
+		decimalValue := msg.ValueDecimal.ToDecimal()
+		// value in [0,1]
+		if decimalValue.IsNegative() || decimalValue.GreaterThan(shopspring.NewFromInt(1)) {
+			return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "value must be in [0,1]")
+		}
+	} else {
+		if msg.Value < 0 || msg.Value > 1 {
+			return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "value must be in [0,1]")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
- Burn all the coins in an inadvertently created account. 
- ValueDecimal is `nil`, not 0 if it is unspecified, fix bug for older messages that may not use it.