### PR TITLE
Special allowance for Status endpoint

### DIFF
--- a/proxy/nginx.unified.conf.template
+++ b/proxy/nginx.unified.conf.template
@@ -124,6 +124,25 @@ http {
             proxy_read_timeout ${CHAIN_RPC_TRANSFER_TIMEOUT}s;
         }
 
+        # Status endpoint without limits
+        location /chain-rpc/status {
+            ${LIMIT_REQ_RULE_CHAIN_RPC}
+            ${CHAIN_RPC_STATUS}
+            proxy_pass http://chain_rpc_backend/status;
+            proxy_set_header Host $$host;
+            proxy_set_header X-Real-IP $$remote_addr;
+            proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $$scheme;
+
+            ${CORS_CONFIG}
+            ${STREAMING_CONFIG}
+
+            # Standard timeouts for chain API
+            proxy_connect_timeout ${CHAIN_RPC_CONNECT_TIMEOUT}s;
+            proxy_send_timeout ${CHAIN_RPC_TRANSFER_TIMEOUT}s;
+            proxy_read_timeout ${CHAIN_RPC_TRANSFER_TIMEOUT}s;
+        }
+
         # Chain API endpoint (REST API)
         location /chain-api/ {
             ${LIMIT_REQ_RULE_CHAIN_API}

--- a/proxy/nginx.unified.conf.template
+++ b/proxy/nginx.unified.conf.template
@@ -127,7 +127,6 @@ http {
         # Status endpoint without limits
         location /chain-rpc/status {
             ${LIMIT_REQ_RULE_CHAIN_RPC}
-            ${CHAIN_RPC_STATUS}
             proxy_pass http://chain_rpc_backend/status;
             proxy_set_header Host $$host;
             proxy_set_header X-Real-IP $$remote_addr;


### PR DESCRIPTION
This PR adds an explicit route for the status endpoint (bypassing the general RPC block).
This allows external observers to see the sync status of the node and thus evaluate the health of the network.
Overall load on this particular endpoint is negligible in comparison to other RPC calls