### PR TITLE
feat: Add Transfer Agent reward sharing for inference fees

### DIFF
--- a/inference-chain/x/inference/calculations/inference_state.go
+++ b/inference-chain/x/inference/calculations/inference_state.go
@@ -16,6 +16,11 @@ type StartInferenceMessage struct {
 const (
 	DefaultMaxTokens = 5000
 	PerTokenCost     = 1000 // Legacy fallback price
+
+	// TransferAgentRewardBasisPoints defines the percentage of executor payment
+	// that goes to the Transfer Agent (in basis points, 1000 = 10%).
+	// This incentivizes running TA nodes as entry points for inference requests.
+	TransferAgentRewardBasisPoints = 1000 // 10%
 )
 
 const maxInt64Uint64 = uint64(math.MaxInt64)
@@ -26,8 +31,9 @@ type BlockContext struct {
 }
 
 type Payments struct {
-	EscrowAmount    int64
-	ExecutorPayment int64
+	EscrowAmount         int64
+	ExecutorPayment      int64
+	TransferAgentPayment int64
 }
 
 func ProcessStartInference(
@@ -117,8 +123,34 @@ func setEscrowForFinished(currentInference *types.Inference, escrowAmount int64,
 	// to be the same as the amount actually paid, not the cost of the inference by itself.
 	currentInference.ActualCost = amountToPay
 	payments.EscrowAmount = amountToPay
-	payments.ExecutorPayment = amountToPay
+
+	// Split payment between executor and transfer agent
+	splitPayments(payments, amountToPay)
 	return nil
+}
+
+// splitPayments divides the total payment between executor and transfer agent
+// based on TransferAgentRewardBasisPoints (10000 basis points = 100%)
+func splitPayments(payments *Payments, totalPayment int64) {
+	if totalPayment <= 0 {
+		payments.ExecutorPayment = 0
+		payments.TransferAgentPayment = 0
+		return
+	}
+
+	// Overflow check: ensure totalPayment * TransferAgentRewardBasisPoints won't overflow int64
+	if totalPayment > math.MaxInt64/TransferAgentRewardBasisPoints {
+		// Fallback: use division-first approach to avoid overflow (slightly less precise but safe)
+		taPayment := totalPayment / 10000 * TransferAgentRewardBasisPoints
+		payments.TransferAgentPayment = taPayment
+		payments.ExecutorPayment = totalPayment - taPayment
+		return
+	}
+
+	// Calculate TA share: totalPayment * basisPoints / 10000
+	taPayment := (totalPayment * TransferAgentRewardBasisPoints) / 10000
+	payments.TransferAgentPayment = taPayment
+	payments.ExecutorPayment = totalPayment - taPayment
 }
 
 func ProcessFinishInference(
@@ -175,13 +207,16 @@ func ProcessFinishInference(
 	currentInference.ActualCost = actualCost
 	if startProcessed(currentInference) {
 		escrowAmount := currentInference.EscrowAmount
+		var totalPayment int64
 		if currentInference.ActualCost >= escrowAmount {
-			payments.ExecutorPayment = escrowAmount
+			totalPayment = escrowAmount
 		} else {
-			payments.ExecutorPayment = currentInference.ActualCost
+			totalPayment = currentInference.ActualCost
 			// Will be a negative number, meaning a refund
 			payments.EscrowAmount = currentInference.ActualCost - escrowAmount
 		}
+		// Split payment between executor and transfer agent
+		splitPayments(&payments, totalPayment)
 	}
 	return currentInference, &payments, nil
 }

--- a/inference-chain/x/inference/calculations/inference_state_test.go
+++ b/inference-chain/x/inference/calculations/inference_state_test.go
@@ -241,13 +241,14 @@ func TestCalculateEscrow_TokenCountOverflow(t *testing.T) {
 
 func TestSetEscrowForFinished(t *testing.T) {
 	tests := []struct {
-		name            string
-		inference       *types.Inference
-		escrowAmount    int64
-		payments        *Payments
-		expectedActual  int64
-		expectedEscrow  int64
-		expectedPayment int64
+		name                    string
+		inference               *types.Inference
+		escrowAmount            int64
+		payments                *Payments
+		expectedActual          int64
+		expectedEscrow          int64
+		expectedExecutorPayment int64
+		expectedTAPayment       int64
 	}{
 		{
 			name: "Actual cost less than escrow",
@@ -256,11 +257,12 @@ func TestSetEscrowForFinished(t *testing.T) {
 				CompletionTokenCount: 10,
 				PerTokenPrice:        PerTokenCost, // Simulate dynamic pricing setting legacy fallback
 			},
-			escrowAmount:    30 * PerTokenCost,
-			payments:        &Payments{},
-			expectedActual:  20 * PerTokenCost,
-			expectedEscrow:  20 * PerTokenCost,
-			expectedPayment: 20 * PerTokenCost,
+			escrowAmount:            30 * PerTokenCost,
+			payments:                &Payments{},
+			expectedActual:          20 * PerTokenCost,
+			expectedEscrow:          20 * PerTokenCost,
+			expectedExecutorPayment: 18 * PerTokenCost, // 90% of 20 * PerTokenCost
+			expectedTAPayment:       2 * PerTokenCost,  // 10% of 20 * PerTokenCost
 		},
 		{
 			name: "Actual cost more than escrow",
@@ -269,11 +271,12 @@ func TestSetEscrowForFinished(t *testing.T) {
 				CompletionTokenCount: 20,
 				PerTokenPrice:        PerTokenCost, // Simulate dynamic pricing setting legacy fallback
 			},
-			escrowAmount:    30 * PerTokenCost,
-			payments:        &Payments{},
-			expectedActual:  30 * PerTokenCost,
-			expectedEscrow:  30 * PerTokenCost,
-			expectedPayment: 30 * PerTokenCost,
+			escrowAmount:            30 * PerTokenCost,
+			payments:                &Payments{},
+			expectedActual:          30 * PerTokenCost,
+			expectedEscrow:          30 * PerTokenCost,
+			expectedExecutorPayment: 27 * PerTokenCost, // 90% of 30 * PerTokenCost
+			expectedTAPayment:       3 * PerTokenCost,  // 10% of 30 * PerTokenCost
 		},
 	}
 
@@ -283,7 +286,57 @@ func TestSetEscrowForFinished(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedActual, tt.inference.ActualCost)
 			assert.Equal(t, tt.expectedEscrow, tt.payments.EscrowAmount)
-			assert.Equal(t, tt.expectedPayment, tt.payments.ExecutorPayment)
+			assert.Equal(t, tt.expectedExecutorPayment, tt.payments.ExecutorPayment)
+			assert.Equal(t, tt.expectedTAPayment, tt.payments.TransferAgentPayment)
+		})
+	}
+}
+
+func TestSplitPayments(t *testing.T) {
+	tests := []struct {
+		name                    string
+		totalPayment            int64
+		expectedExecutorPayment int64
+		expectedTAPayment       int64
+	}{
+		{
+			name:                    "Zero payment",
+			totalPayment:            0,
+			expectedExecutorPayment: 0,
+			expectedTAPayment:       0,
+		},
+		{
+			name:                    "Negative payment",
+			totalPayment:            -100,
+			expectedExecutorPayment: 0,
+			expectedTAPayment:       0,
+		},
+		{
+			name:                    "Normal payment - 10000",
+			totalPayment:            10000,
+			expectedExecutorPayment: 9000, // 90%
+			expectedTAPayment:       1000, // 10%
+		},
+		{
+			name:                    "Small payment - 100",
+			totalPayment:            100,
+			expectedExecutorPayment: 90, // 90%
+			expectedTAPayment:       10, // 10%
+		},
+		{
+			name:                    "Very small payment - 9",
+			totalPayment:            9,
+			expectedExecutorPayment: 9, // Remaining after TA gets 0
+			expectedTAPayment:       0, // 10% of 9 = 0 (integer division)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payments := &Payments{}
+			splitPayments(payments, tt.totalPayment)
+			assert.Equal(t, tt.expectedExecutorPayment, payments.ExecutorPayment)
+			assert.Equal(t, tt.expectedTAPayment, payments.TransferAgentPayment)
 		})
 	}
 }

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -224,14 +224,52 @@ func (k msgServer) processInferencePayments(
 		}
 		executor.CoinBalance += payments.ExecutorPayment
 		executor.CurrentEpochStats.EarnedCoins += uint64(payments.ExecutorPayment)
-		k.SafeLogSubAccountTransaction(ctx, executor.Address, types.ModuleName, types.OwedSubAccount, executor.CoinBalance, "inference_started:"+inference.InferenceId)
+		k.SafeLogSubAccountTransaction(ctx, executor.Address, types.ModuleName, types.OwedSubAccount, executor.CoinBalance, "inference_executor_payment:"+inference.InferenceId)
 		err := k.SetParticipant(ctx, executor)
 		if err != nil {
 			return nil, err
 		}
 	}
+	// Pay the Transfer Agent their share of the inference fee
+	if payments.TransferAgentPayment > 0 {
+		transferredBy := inference.TransferredBy
+		transferAgent, found := k.GetParticipant(ctx, transferredBy)
+		if !found {
+			// TA not found - return their share to the executor so funds are not lost
+			k.LogWarn("Transfer Agent not found for payment, returning share to executor", types.Payments,
+				"transfer_agent", transferredBy,
+				"inference_id", inference.InferenceId,
+				"payment_amount", payments.TransferAgentPayment)
+			executor, executorFound := k.GetParticipant(ctx, inference.ExecutedBy)
+			if executorFound {
+				executor.CoinBalance += payments.TransferAgentPayment
+				executor.CurrentEpochStats.EarnedCoins += uint64(payments.TransferAgentPayment)
+				k.SafeLogSubAccountTransaction(ctx, executor.Address, types.ModuleName, types.OwedSubAccount, executor.CoinBalance, "inference_ta_share_to_executor:"+inference.InferenceId)
+				if err := k.SetParticipant(ctx, executor); err != nil {
+					return nil, err
+				}
+			} else {
+				k.LogError("Executor also not found as participant, TA share lost", types.Payments,
+					"executor", inference.ExecutedBy,
+					"transfer_agent", transferredBy,
+					"inference_id", inference.InferenceId,
+					"lost_amount", payments.TransferAgentPayment)
+			}
+		} else {
+			transferAgent.CoinBalance += payments.TransferAgentPayment
+			transferAgent.CurrentEpochStats.EarnedCoins += uint64(payments.TransferAgentPayment)
+			k.SafeLogSubAccountTransaction(ctx, transferAgent.Address, types.ModuleName, types.OwedSubAccount, transferAgent.CoinBalance, "inference_ta_payment:"+inference.InferenceId)
+			err := k.SetParticipant(ctx, transferAgent)
+			if err != nil {
+				return nil, err
+			}
+			k.LogInfo("Transfer Agent payment processed", types.Payments,
+				"transfer_agent", transferredBy,
+				"inference_id", inference.InferenceId,
+				"payment_amount", payments.TransferAgentPayment)
+		}
+	}
 	return inference, nil
-
 }
 
 // getDevSignatureComponents returns components for dev signature verification

--- a/proposals/GIP-RELAY-FEE.md
+++ b/proposals/GIP-RELAY-FEE.md
@@ -1,0 +1,206 @@
+# GIP-XXX: Transfer Agent Reward Sharing
+
+## Summary
+
+This proposal enables automatic reward sharing for Transfer Agents (TAs), allowing aggregators and gateway operators to earn a portion of inference fees by running their own TA node.
+
+## Abstract
+
+Currently, 100% of inference fees go to executors. This proposal adds a mechanism where Transfer Agents — which already serve as entry points for inference requests — receive a portion (10%) of executor payments. This incentivizes the creation of user-friendly API gateways, SDKs, and aggregators that expand Gonka's reach.
+
+## Motivation
+
+### Problem
+
+1. **High barrier to entry for developers**: Using Gonka directly requires understanding ECDSA signing, endpoint selection, and key management
+2. **No incentive for aggregators**: Building API gateways is valuable but currently unrewarded
+3. **Underutilized infrastructure**: Transfer Agents already proxy requests but have no economic incentive beyond altruism
+
+### Solution
+
+Leverage the existing Transfer Agent system to automatically split fees:
+
+```
+Current flow:
+User → Transfer Agent → Executor → Executor gets 100%
+
+Proposed flow:
+User → Transfer Agent → Executor → Executor gets 90%, TA gets 10%
+```
+
+### Benefits
+
+1. **For Developers**: Easier onboarding through user-friendly TAs
+2. **For TA Operators**: Sustainable revenue model aligned with network usage
+3. **For Executors**: More traffic through better distribution
+4. **For Network**: Expanded ecosystem without adding module complexity
+
+## Specification
+
+### Changes to x/inference
+
+This proposal modifies the existing inference payment system rather than introducing a new module.
+
+#### New Constant
+
+```go
+// TransferAgentRewardBasisPoints defines the percentage of executor payment
+// that goes to the Transfer Agent (1000 = 10%)
+const TransferAgentRewardBasisPoints = 1000
+```
+
+#### Updated Payments Struct
+
+```go
+type Payments struct {
+    ExecutorPayment      int64
+    TransferAgentPayment int64 // NEW: TA's share of the payment
+    // ... other existing fields remain unchanged
+}
+```
+
+#### Payment Splitting Logic
+
+```go
+func splitPayments(payments *Payments, totalPayment int64) {
+    if totalPayment <= 0 {
+        payments.ExecutorPayment = 0
+        payments.TransferAgentPayment = 0
+        return
+    }
+
+    // TA share: totalPayment * basisPoints / 10000, with explicit overflow protection.
+    if totalPayment > math.MaxInt64/TransferAgentRewardBasisPoints {
+        // Division-first fallback to avoid int64 overflow.
+        taPayment := (totalPayment / 10000) * TransferAgentRewardBasisPoints
+        payments.TransferAgentPayment = taPayment
+        payments.ExecutorPayment = totalPayment - taPayment
+        return
+    }
+
+    taPayment := (totalPayment * TransferAgentRewardBasisPoints) / 10000
+    payments.TransferAgentPayment = taPayment
+    payments.ExecutorPayment = totalPayment - taPayment
+}
+```
+
+#### Payment Processing
+
+When an inference completes:
+1. Calculate total executor payment as before
+2. Split payment: 90% to executor, 10% to Transfer Agent
+3. Pay executor through existing mechanism
+4. Pay TA through their participant balance (if registered)
+5. If TA is not a registered participant, log warning and return the TA share back to the executor (graceful degradation)
+
+### Parameters
+
+| Parameter | Type | Default | Governance |
+|-----------|------|---------|------------|
+| `transfer_agent_reward_basis_points` | int64 | 1000 (10%) | Future PR |
+
+Note: Currently implemented as a constant. A follow-up PR will make this a governable parameter in `TokenomicsParams`.
+
+### No API Changes Required
+
+Transfer Agents are already tracked in inference requests. No changes to the API or message formats are needed.
+
+## Rationale
+
+### Why Use Transfer Agents Instead of a New Module?
+
+- **TAs already exist**: They serve as the entry point for inference requests
+- **No registration needed**: TAs are already registered in the system
+- **Simpler implementation**: Reuse existing infrastructure
+- **Feedback-driven**: Based on review from @gmorgachev
+
+### Why 10% Default?
+
+- Higher than original 5% proposal to make TA operation more attractive
+- Still leaves 90% for executors who do the computational work
+- Uses basis points (1000/10000) for precision and future adjustability
+
+### Why Basis Points?
+
+- Industry standard for fee calculations
+- Allows fine-grained control (0.01% precision)
+- Avoids floating-point issues
+
+### Backward Compatibility
+
+- Inferences without a Transfer Agent work exactly as before (100% to executor)
+- Existing TA implementations continue to work
+- No breaking changes to APIs or message formats
+
+## Implementation
+
+Reference implementation in this PR:
+
+Key files:
+- `x/inference/calculations/inference_state.go` - `splitPayments()` function and constants
+- `x/inference/calculations/inference_state_test.go` - Unit tests for payment splitting
+- `x/inference/keeper/msg_server_start_inference.go` - Integration with payment flow
+
+### Test Coverage
+
+- Unit tests for `splitPayments()` with various edge cases
+- Unit tests for `setEscrowForFinished()` with TA payment
+- All existing inference calculation tests pass
+
+## Security Considerations
+
+1. **Integer overflow**: Explicit overflow protection in `splitPayments()` to avoid `int64` overflow
+2. **Invalid TA addresses**: Graceful degradation if TA not registered as participant
+3. **Zero/negative amounts**: Explicit checks in `splitPayments()`
+4. **No custody risk**: Fees go directly to participant balances
+
+## Future Improvements
+
+1. Make `TransferAgentRewardBasisPoints` a governable parameter in `TokenomicsParams`
+2. Allow different reward tiers based on TA reputation/stake
+3. Add TA statistics tracking (requests proxied, fees earned)
+
+## Timeline
+
+1. **Review period**: 7 days for community feedback
+2. **Testnet deployment**: 14 days testing on testnet
+3. **Mainnet activation**: After successful testnet validation
+
+## Voting
+
+- **Yes**: Approve Transfer Agent reward sharing
+- **No**: Reject the proposal
+- **Abstain**: Decline to vote
+- **NoWithVeto**: Reject and burn deposit
+
+## References
+
+- [Tokenomics Document](https://gonka.ai/tokenomics.pdf)
+- [Transfer Agent Documentation](https://docs.gonka.ai/transfer-agents)
+- [Original x/relay proposal discussion](https://github.com/gonka-ai/gonka/pull/633)
+
+---
+
+## Appendix: How It Works
+
+### For TA Operators
+
+Simply run a Transfer Agent node. When users send inference requests through your TA, you automatically receive 10% of the executor payment.
+
+```
+User Request → Your TA → Executor
+                 ↓
+         10% of payment goes to your participant balance
+```
+
+### For Developers
+
+No changes needed. Continue using the Gonka API as before. If you route through a Transfer Agent, that TA earns rewards automatically.
+
+### Example Payment Flow
+
+```
+Inference completes with 1000 GONKA executor payment:
+├── Executor receives: 900 GONKA (90%)
+└── Transfer Agent receives: 100 GONKA (10%)
+```


### PR DESCRIPTION
## Summary

This PR implements reward sharing for Transfer Agents (TAs), allowing aggregators and gateway owners to earn a portion of inference fees by running their own TA node.

**Changes:**
- Add `TransferAgentRewardBasisPoints` constant (1000 = 10%) to split executor payments
- Add `TransferAgentPayment` field to `Payments` struct
- Implement `splitPayments()` function for fair distribution
- Update `processInferencePayments()` to pay TAs their share
- Add comprehensive tests for payment splitting edge cases

**How it works:**
- When an inference completes, the total payment is split: 90% to executor, 10% to Transfer Agent
- TAs receive payment through their existing participant balance
- If TA is not a registered participant, a warning is logged (graceful degradation)

**Future improvements:**
- Make `TransferAgentRewardBasisPoints` a governable parameter in `TokenomicsParams`

## Test plan
- [x] Unit tests for `splitPayments()` function
- [x] Unit tests for `setEscrowForFinished()` with TA payment
- [x] All existing inference calculation tests pass
- [ ] Integration test with full inference flow