### PR TITLE
security: add response body size limits to prevent DoS

### DIFF
--- a/decentralized-api/internal/server/public/post_chat_handler.go
+++ b/decentralized-api/internal/server/public/post_chat_handler.go
@@ -37,6 +37,13 @@ const (
 	ExecutorContext AuthKeyContext = 2
 	// BothContexts indicates the AuthKey was used for both transfer and executor requests
 	BothContexts = TransferContext | ExecutorContext
+
+	// MaxResponseBodySize is the maximum allowed size for response bodies (50 MB)
+	// This prevents memory exhaustion attacks from malicious executor responses
+	MaxResponseBodySize = 50 * 1024 * 1024
+
+	// MaxErrorResponseSize is the maximum size for error response bodies (1 MB)
+	MaxErrorResponseSize = 1 * 1024 * 1024
 )
 
 // Package-level variables for AuthKey reuse prevention
@@ -914,7 +921,9 @@ func createInferenceStartRequest(s *Server, request *ChatRequest, seed int32, in
 
 func getInferenceErrorMessage(resp *http.Response) string {
 	msg := fmt.Sprintf("Inference node response with an error. code = %d.", resp.StatusCode)
-	bodyBytes, err := io.ReadAll(resp.Body)
+	// Limit error response size to prevent memory exhaustion
+	limitedReader := io.LimitReader(resp.Body, MaxErrorResponseSize)
+	bodyBytes, err := io.ReadAll(limitedReader)
 	if err == nil {
 		return msg + fmt.Sprintf(" error = %s.", string(bodyBytes))
 	} else {

--- a/decentralized-api/internal/server/public/post_chat_handler_test.go
+++ b/decentralized-api/internal/server/public/post_chat_handler_test.go
@@ -1,8 +1,11 @@
 package public
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
 	"decentralized-api/chainphase"
@@ -164,3 +167,129 @@ func TestEmptyButParseableResponsePayload_EnforcedTokensEmptySlice(t *testing.T)
 	// With our synthetic logprobs, enforced tokens should be present and parseable.
 	require.NotEmpty(t, enforcedTokens.Tokens)
 }
+
+// TestMaxResponseBodySizeWithinReasonableBounds verifies the constant is within acceptable range
+func TestMaxResponseBodySizeWithinReasonableBounds(t *testing.T) {
+	oneMB := 1024 * 1024
+	hundredMB := 100 * 1024 * 1024
+	require.Greater(t, MaxResponseBodySize, oneMB,
+		"MaxResponseBodySize should be greater than 1 MB to allow realistic responses")
+	require.Less(t, MaxResponseBodySize, hundredMB,
+		"MaxResponseBodySize should be less than 100 MB to prevent memory exhaustion")
+}
+
+// TestMaxErrorResponseSizeWithinReasonableBounds verifies the constant is within acceptable range
+func TestMaxErrorResponseSizeWithinReasonableBounds(t *testing.T) {
+	oneKB := 1024
+	tenMB := 10 * 1024 * 1024
+	require.Greater(t, MaxErrorResponseSize, oneKB,
+		"MaxErrorResponseSize should be greater than 1 KB to hold meaningful error messages")
+	require.Less(t, MaxErrorResponseSize, tenMB,
+		"MaxErrorResponseSize should be less than 10 MB to prevent memory exhaustion on errors")
+	require.Less(t, MaxErrorResponseSize, MaxResponseBodySize,
+		"MaxErrorResponseSize should be smaller than MaxResponseBodySize")
+}
+
+// TestGetInferenceErrorMessage_NormalSize tests that normal error messages are read
+func TestGetInferenceErrorMessage_NormalSize(t *testing.T) {
+	errorBody := []byte(`{"error": "something went wrong"}`)
+	resp := &http.Response{
+		StatusCode: 500,
+		Body:       io.NopCloser(bytes.NewReader(errorBody)),
+	}
+
+	msg := getInferenceErrorMessage(resp)
+	require.Contains(t, msg, "code = 500")
+	require.Contains(t, msg, "something went wrong")
+}
+
+// TestGetInferenceErrorMessage_OversizedResponse tests that oversized responses are truncated
+func TestGetInferenceErrorMessage_OversizedResponse(t *testing.T) {
+	// Create an error body larger than MaxErrorResponseSize (1 MB)
+	oversizedBody := bytes.Repeat([]byte("x"), MaxErrorResponseSize+1000)
+	resp := &http.Response{
+		StatusCode: 500,
+		Body:       io.NopCloser(bytes.NewReader(oversizedBody)),
+	}
+
+	msg := getInferenceErrorMessage(resp)
+	require.Contains(t, msg, "code = 500")
+	// The message should be truncated to MaxErrorResponseSize
+	// Check that we don't have the full oversized body
+	require.LessOrEqual(t, len(msg), MaxErrorResponseSize+100, "Error message should be truncated")
+}
+
+// TestGetInferenceErrorMessage_EmptyBody tests handling of empty error body
+func TestGetInferenceErrorMessage_EmptyBody(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 404,
+		Body:       io.NopCloser(bytes.NewReader([]byte{})),
+	}
+
+	msg := getInferenceErrorMessage(resp)
+	require.Contains(t, msg, "code = 404")
+}
+
+// TestGetInferenceErrorMessage_ExactlyAtLimit tests that a body at exactly the limit is fully included
+func TestGetInferenceErrorMessage_ExactlyAtLimit(t *testing.T) {
+	exactBody := bytes.Repeat([]byte("A"), MaxErrorResponseSize)
+	resp := &http.Response{
+		StatusCode: 502,
+		Body:       io.NopCloser(bytes.NewReader(exactBody)),
+	}
+
+	msg := getInferenceErrorMessage(resp)
+	require.Contains(t, msg, "code = 502")
+	// The full body should be present since it's exactly at the limit
+	require.Contains(t, msg, string(exactBody))
+}
+
+// TestGetInferenceErrorMessage_TruncatesOversizedBody verifies the handler's LimitReader
+// integration actually caps how much data is read from the response body.
+func TestGetInferenceErrorMessage_TruncatesOversizedBody(t *testing.T) {
+	// Build a body that is 2x the error limit. The first half is 'A', the second half is 'B'.
+	// After truncation, only 'A' bytes should appear.
+	halfSize := MaxErrorResponseSize
+	body := append(bytes.Repeat([]byte("A"), halfSize), bytes.Repeat([]byte("B"), halfSize)...)
+
+	resp := &http.Response{
+		StatusCode: 500,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+
+	msg := getInferenceErrorMessage(resp)
+	// The message must NOT contain 'B' bytes, proving truncation happened
+	require.NotContains(t, msg, "B",
+		"Message should not contain bytes beyond MaxErrorResponseSize limit")
+	require.Contains(t, msg, "code = 500")
+}
+
+// TestProxyJsonResponse_TruncatesOversizedBody verifies that proxyJsonResponse uses
+// MaxResponseBodySize to cap how much data is read from the upstream response.
+func TestProxyJsonResponse_TruncatesOversizedBody(t *testing.T) {
+	// Create a response body that exceeds MaxResponseBodySize
+	oversizedBody := bytes.Repeat([]byte("z"), MaxResponseBodySize+4096)
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(oversizedBody)),
+	}
+
+	recorder := &fakeResponseWriter{header: http.Header{}, body: &bytes.Buffer{}}
+	proxyJsonResponse(resp, recorder, nil, "test-inf-truncate")
+
+	// The written body should be capped at MaxResponseBodySize
+	require.Equal(t, MaxResponseBodySize, recorder.body.Len(),
+		"proxyJsonResponse should truncate body to MaxResponseBodySize")
+}
+
+// fakeResponseWriter is a minimal http.ResponseWriter for testing proxy output.
+type fakeResponseWriter struct {
+	header     http.Header
+	body       *bytes.Buffer
+	statusCode int
+}
+
+func (f *fakeResponseWriter) Header() http.Header         { return f.header }
+func (f *fakeResponseWriter) WriteHeader(statusCode int)   { f.statusCode = statusCode }
+func (f *fakeResponseWriter) Write(b []byte) (int, error)  { return f.body.Write(b) }

--- a/decentralized-api/internal/server/public/proxy.go
+++ b/decentralized-api/internal/server/public/proxy.go
@@ -88,7 +88,9 @@ func proxyTextStreamResponse(resp *http.Response, w http.ResponseWriter, respons
 }
 
 func proxyJsonResponse(resp *http.Response, w http.ResponseWriter, responseProcessor completionapi.ResponseProcessor, inferenceId string) {
-	var bodyBytes, err = io.ReadAll(resp.Body)
+	// Limit response body size to prevent memory exhaustion from malicious executors
+	limitedReader := io.LimitReader(resp.Body, MaxResponseBodySize)
+	var bodyBytes, err = io.ReadAll(limitedReader)
 	if err != nil {
 		logging.Error("Failed to read inference node response body", types.Inferences, "inferenceId", inferenceId, "error", err)
 		http.Error(w, fmt.Sprintf("Failed to read inference node response body. inferenceId = %s", inferenceId), http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

Add response body size limits to prevent memory exhaustion DoS attacks from malicious executor nodes.

## Problem

Multiple locations use `io.ReadAll(resp.Body)` without size limits:

```go
// post_chat_handler.go:908
bodyBytes, err := io.ReadAll(resp.Body)  // NO SIZE LIMIT

// proxy.go:91
var bodyBytes, err = io.ReadAll(resp.Body)  // NO SIZE LIMIT
```

A malicious executor node could return extremely large responses, causing Transfer Agent nodes to allocate unbounded memory and crash from OOM.

## Solution

- Add `MaxResponseBodySize` constant (50 MB) for normal responses
- Add `MaxErrorResponseSize` constant (1 MB) for error messages
- Use `io.LimitReader` to enforce limits before `io.ReadAll`

## Changes

- `decentralized-api/internal/server/public/post_chat_handler.go`
  - Add `MaxResponseBodySize` and `MaxErrorResponseSize` constants
  - Use `io.LimitReader` in `getInferenceErrorMessage`

- `decentralized-api/internal/server/public/proxy.go`
  - Use `io.LimitReader` in `proxyJsonResponse`

## Test plan

- [ ] Manual test with normal responses
- [ ] Verify responses over 50 MB are truncated
- [ ] Verify error responses over 1 MB are truncated