### PR TITLE
security: fix race condition in AuthKey check (TOCTOU)

### DIFF
--- a/decentralized-api/internal/server/public/post_chat_handler.go
+++ b/decentralized-api/internal/server/public/post_chat_handler.go
@@ -118,10 +118,15 @@ func emptyButParseableResponsePayload(inferenceId, model string, promptTokens ui
 
 // checkAndRecordAuthKey checks if an AuthKey has been used before and records it if not
 // Returns true if the key has been used before in the specified context, false otherwise
+//
+// This function uses a single Lock for the entire check-and-record operation to prevent
+// race conditions (TOCTOU). Previously, using RLock for check followed by Lock for write
+// created a window where another goroutine could record the same key.
 func checkAndRecordAuthKey(authKey string, currentBlockHeight int64, context AuthKeyContext) bool {
-	authKeysMutex.RLock()
+	authKeysMutex.Lock()
+	defer authKeysMutex.Unlock()
+
 	existingContext, exists := usedAuthKeys[authKey]
-	authKeysMutex.RUnlock()
 
 	if exists {
 		// If the key exists, check if it's been used in the current context
@@ -130,18 +135,11 @@ func checkAndRecordAuthKey(authKey string, currentBlockHeight int64, context Aut
 		}
 
 		// Key exists but hasn't been used in this context, update the context
-		authKeysMutex.Lock()
-		defer authKeysMutex.Unlock()
-
-		// Update the context to include the new context
 		usedAuthKeys[authKey] = existingContext | context
 		return false // Key wasn't used before in this context
 	}
 
 	// Key doesn't exist, add it with the current context
-	authKeysMutex.Lock()
-	defer authKeysMutex.Unlock()
-
 	usedAuthKeys[authKey] = context
 
 	authKeysByBlock[currentBlockHeight] = append(authKeysByBlock[currentBlockHeight], authKey)

--- a/decentralized-api/internal/server/public/post_chat_handler_test.go
+++ b/decentralized-api/internal/server/public/post_chat_handler_test.go
@@ -164,3 +164,76 @@ func TestEmptyButParseableResponsePayload_EnforcedTokensEmptySlice(t *testing.T)
 	// With our synthetic logprobs, enforced tokens should be present and parseable.
 	require.NotEmpty(t, enforcedTokens.Tokens)
 }
+
+// TestCheckAndRecordAuthKey_Basic tests basic AuthKey recording functionality
+func TestCheckAndRecordAuthKey_Basic(t *testing.T) {
+	// Clear state before test
+	clearAuthKeyState()
+
+	authKey := "test-key-basic"
+	blockHeight := int64(100)
+
+	// First call should return false (not used before)
+	used := checkAndRecordAuthKey(authKey, blockHeight, TransferContext)
+	require.False(t, used, "First use of AuthKey should return false")
+
+	// Second call with same context should return true (already used)
+	used = checkAndRecordAuthKey(authKey, blockHeight, TransferContext)
+	require.True(t, used, "Second use of AuthKey in same context should return true")
+
+	// Same key with different context should return false
+	used = checkAndRecordAuthKey(authKey, blockHeight, ExecutorContext)
+	require.False(t, used, "Same AuthKey in different context should return false")
+
+	// Now both contexts used, either should return true
+	used = checkAndRecordAuthKey(authKey, blockHeight, TransferContext)
+	require.True(t, used, "AuthKey should be marked as used in TransferContext")
+
+	used = checkAndRecordAuthKey(authKey, blockHeight, ExecutorContext)
+	require.True(t, used, "AuthKey should be marked as used in ExecutorContext")
+}
+
+// TestCheckAndRecordAuthKey_Concurrent tests that concurrent calls are handled safely
+func TestCheckAndRecordAuthKey_Concurrent(t *testing.T) {
+	// Clear state before test
+	clearAuthKeyState()
+
+	authKey := "test-key-concurrent"
+	blockHeight := int64(100)
+	numGoroutines := 100
+
+	// Channel to count how many goroutines got "not used" (false) response
+	resultChan := make(chan bool, numGoroutines)
+
+	// Launch concurrent goroutines all trying to record the same key
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			used := checkAndRecordAuthKey(authKey, blockHeight, TransferContext)
+			resultChan <- used
+		}()
+	}
+
+	// Collect results
+	falseCount := 0
+	trueCount := 0
+	for i := 0; i < numGoroutines; i++ {
+		if <-resultChan {
+			trueCount++
+		} else {
+			falseCount++
+		}
+	}
+
+	// Exactly one goroutine should have gotten false (first to record)
+	require.Equal(t, 1, falseCount, "Exactly one goroutine should successfully record the key first")
+	require.Equal(t, numGoroutines-1, trueCount, "All other goroutines should see key as already used")
+}
+
+// clearAuthKeyState clears the global auth key state for testing
+func clearAuthKeyState() {
+	authKeysMutex.Lock()
+	defer authKeysMutex.Unlock()
+	usedAuthKeys = make(map[string]AuthKeyContext)
+	authKeysByBlock = make(map[int64][]string)
+	oldestBlockHeight = 0
+}


### PR DESCRIPTION
## Summary

Fix time-of-check to time-of-use (TOCTOU) race condition in `checkAndRecordAuthKey` that could allow replay attacks.

## Problem

The `checkAndRecordAuthKey` function had a race condition between checking if an AuthKey exists and recording it:

```go
func checkAndRecordAuthKey(...) bool {
    authKeysMutex.RLock()
    existingContext, exists := usedAuthKeys[authKey]  // CHECK
    authKeysMutex.RUnlock()
    // <-- RACE WINDOW: another goroutine can add the same key here

    authKeysMutex.Lock()
    usedAuthKeys[authKey] = context  // USE
    // ...
}
```

In the window between releasing `RLock` and acquiring `Lock`, another goroutine could record the same key, potentially allowing:
- Replay attacks with the same AuthKey
- Duplicate inference requests

## Solution

Use a single `Lock` for the entire check-and-record operation:

```go
func checkAndRecordAuthKey(...) bool {
    authKeysMutex.Lock()
    defer authKeysMutex.Unlock()

    existingContext, exists := usedAuthKeys[authKey]
    // ... rest of logic under same lock
}
```

## Changes

- `decentralized-api/internal/server/public/post_chat_handler.go`
  - Replace `RLock` + `Lock` pattern with single `Lock`
  - Add explanatory comment about the fix

## Test plan

- [x] Add basic unit test for AuthKey recording
- [x] Add concurrent test with 100 goroutines
- [x] Verify exactly one goroutine records the key first
- [x] Verify all other goroutines see key as already used