### PR TITLE
fix: add missing return after error in tryClaimingTaskToAssign

### DIFF
--- a/decentralized-api/training/assigner.go
+++ b/decentralized-api/training/assigner.go
@@ -69,6 +69,7 @@ func (a *Assigner) tryClaimingTaskToAssign() {
 	chainStatus, err := a.tendermintClient.Status()
 	if err != nil {
 		slog.Error(logTag+"Failed to query chain status", "err", err)
+		return
 	}
 
 	if chainStatus.SyncInfo.CatchingUp {


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference crash when chain node is temporarily unreachable
- Add missing `return` statement after error logging in `tryClaimingTaskToAssign()`

## Problem
When `tendermintClient.Status()` fails (e.g., during network outage), the error was logged but execution continued, causing a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x140 pc=0x42d18e2]

goroutine 10 [running]:
decentralized-api/training.(*Assigner).tryClaimingTaskToAssign(0xc0017a8090)
  /app/decentralized-api/training/assigner.go:74 +0xc2
```

## Solution
Add `return` after error logging to prevent accessing nil `chainStatus`.

## Test plan
- [x] Code review confirms fix is correct
- [ ] Manual test with network interruption

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)