### PR TITLE
security: require previous epoch rewards for POC_SLOT eligibility

### DIFF
--- a/inference-chain/x/inference/module/model_assignment.go
+++ b/inference-chain/x/inference/module/model_assignment.go
@@ -276,6 +276,7 @@ type KeeperForModelAssigner interface {
 	GetActiveParticipants(ctx context.Context, epochId uint64) (val types.ActiveParticipants, found bool)
 	GetEpochGroupData(ctx context.Context, epochIndex uint64, modelId string) (val types.EpochGroupData, found bool)
 	GetParams(ctx context.Context) (types.Params, error)
+	GetEpochPerformanceSummary(ctx context.Context, epochIndex uint64, participantId string) (val types.EpochPerformanceSummary, found bool)
 }
 
 func (ma *ModelAssigner) setModelsForParticipants(ctx context.Context, participants []*types.ActiveParticipant, upcomingEpoch types.Epoch) {
@@ -455,7 +456,7 @@ func (ma *ModelAssigner) AllocateMLNodesForPoC(ctx context.Context, upcomingEpoc
 	}
 	ma.LogInfo("Built current epoch data map", types.Allocation, "flow_context", FlowContext, "sub_flow_context", SubFlowContext, "step", "build_current_epoch_data", "num_models", len(currentEpochData.Models()))
 
-	eligibleNodesData := ma.filterEligibleMLNodes(upcomingEpoch, previousEpochData, currentEpochData, totalCurrentEpochWeight)
+	eligibleNodesData := ma.filterEligibleMLNodes(ctx, upcomingEpoch, previousEpochData, currentEpochData, totalCurrentEpochWeight)
 	ma.LogInfo("Filtered eligible nodes for all models", types.Allocation, "flow_context", FlowContext, "sub_flow_context", SubFlowContext, "step", "filter_all_eligible", "num_models", len(eligibleNodesData.Models()))
 
 	for _, modelId := range sortedModelIds {
@@ -548,6 +549,7 @@ func buildEligibleParticipantSet(currentEpochData *EpochMLNodeData, thresholds t
 //
 //	Selects N/2+1 participants with previous epoch history deterministically per model to rotate eligibility.
 func (ma *ModelAssigner) filterEligibleMLNodes(
+	ctx context.Context,
 	upcomingEpoch types.Epoch,
 	previousEpochData *EpochMLNodeData,
 	currentEpochData *EpochMLNodeData,
@@ -585,6 +587,7 @@ func (ma *ModelAssigner) filterEligibleMLNodes(
 
 		// Sample N/2+1 participants with history for rotation (deterministic per epoch+model)
 		eligibleParticipantsPerModel := ma.sampleEligibleParticipantsWithHistory(
+			ctx,
 			filteredParticipantAddrs,
 			previousEpochData,
 			modelId,
@@ -1015,6 +1018,7 @@ func calculateEffectiveNodeThreshold(participantThreshold, globalThreshold int64
 }
 
 func (ma *ModelAssigner) sampleEligibleParticipantsWithHistory(
+	ctx context.Context,
 	sortedParticipantAddrs []string,
 	previousEpochData *EpochMLNodeData,
 	modelId string,
@@ -1022,10 +1026,29 @@ func (ma *ModelAssigner) sampleEligibleParticipantsWithHistory(
 	allParticipantsHashStr string,
 ) []string {
 	participantsWithHistory := make([]string, 0)
+	previousEpochIndex := upcomingEpoch.Index - 1
+
 	for _, participantAddr := range sortedParticipantAddrs {
 		previousValidationWeight := previousEpochData.GetForParticipant(modelId, participantAddr)
 
 		if previousValidationWeight == nil {
+			continue
+		}
+
+		// Security fix for POC_SLOT attack (#658):
+		// Only participants who received rewards in the previous epoch are eligible for POC_SLOT.
+		// This prevents attackers from farming POC_SLOT positions with nodes that don't actually
+		// participate in PoC validation.
+		perfSummary, found := ma.keeper.GetEpochPerformanceSummary(ctx, previousEpochIndex, participantAddr)
+		if !found {
+			ma.LogDebug("Participant excluded from POC_SLOT eligibility: no performance summary",
+				types.Allocation, "participant", participantAddr, "previous_epoch", previousEpochIndex)
+			continue
+		}
+		if perfSummary.RewardedCoins == 0 {
+			ma.LogDebug("Participant excluded from POC_SLOT eligibility: no rewards in previous epoch",
+				types.Allocation, "participant", participantAddr, "previous_epoch", previousEpochIndex,
+				"rewarded_coins", perfSummary.RewardedCoins)
 			continue
 		}
 

--- a/inference-chain/x/inference/module/model_assignment_test.go
+++ b/inference-chain/x/inference/module/model_assignment_test.go
@@ -13,10 +13,11 @@ import (
 
 // Mock Keeper
 type mockKeeperForModelAssigner struct {
-	hardwareNodes    map[string]*types.HardwareNodes
-	governanceModels []types.Model
-	epochGroupData   map[string]map[uint64]types.EpochGroupData // modelId -> epochIndex -> data
-	params           *types.Params
+	hardwareNodes           map[string]*types.HardwareNodes
+	governanceModels        []types.Model
+	epochGroupData          map[string]map[uint64]types.EpochGroupData // modelId -> epochIndex -> data
+	params                  *types.Params
+	epochPerformanceSummary map[string]map[uint64]types.EpochPerformanceSummary // participantId -> epochIndex -> summary
 }
 
 func (m *mockKeeperForModelAssigner) GetGovernanceModelsSorted(ctx context.Context) ([]*types.Model, error) {
@@ -50,6 +51,23 @@ func (m *mockKeeperForModelAssigner) GetParams(ctx context.Context) (types.Param
 		return *m.params, nil
 	}
 	return types.DefaultParams(), nil
+}
+
+func (m *mockKeeperForModelAssigner) GetEpochPerformanceSummary(ctx context.Context, epochIndex uint64, participantId string) (val types.EpochPerformanceSummary, found bool) {
+	if m.epochPerformanceSummary == nil {
+		// Default behavior: return summary with rewards to maintain backward compatibility with existing tests
+		return types.EpochPerformanceSummary{
+			EpochIndex:    epochIndex,
+			ParticipantId: participantId,
+			RewardedCoins: 1000, // Non-zero to pass eligibility check
+		}, true
+	}
+	if participantData, ok := m.epochPerformanceSummary[participantId]; ok {
+		if summary, ok := participantData[epochIndex]; ok {
+			return summary, true
+		}
+	}
+	return types.EpochPerformanceSummary{}, false
 }
 
 // Mock Logger


### PR DESCRIPTION
## Summary
Fix POC_SLOT attack vulnerability where attackers could farm POC_SLOT=true positions with nodes that don't actually participate in PoC validation.

## Problem (Issue #658)
An attacker could:
1. Register many participant addresses before PoC phase
2. Temporarily rent hardware to pass PoC and enter epoch group
3. Stop hardware after entry (no rewards earned)
4. Next epoch: pass PoC again and get elected for POC_SLOT=true
5. Serve inference with much less hardware than honest participants

The root cause: system did not check whether participant was **reward-eligible** in the previous epoch when selecting for POC_SLOT=true.

## Solution
Add check in `sampleEligibleParticipantsWithHistory()` that participant must have:
1. `EpochPerformanceSummary` record for previous epoch
2. `RewardedCoins > 0` in that epoch

This enforces the invariant: **only participants who received rewards in the previous epoch are eligible for POC_SLOT=true**.

## Changes
- Add `GetEpochPerformanceSummary` to `KeeperForModelAssigner` interface
- Add reward eligibility check in `sampleEligibleParticipantsWithHistory()`
- Update mock keeper in tests with backward-compatible default behavior

## Test plan
- [x] All existing tests pass
- [x] Code compiles successfully
- [ ] Manual verification of POC_SLOT allocation behavior

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)