### PR TITLE
Fix wrong error message for unsupported models in /chat/completions

### DIFF
--- a/decentralized-api/internal/server/public/errors.go
+++ b/decentralized-api/internal/server/public/errors.go
@@ -18,4 +18,5 @@ var (
 	ErrEpochIsNotReached    = echo.NewHTTPError(http.StatusBadRequest, "Epoch is not reached")
 	ErrInferenceNotFound    = echo.NewHTTPError(http.StatusNotFound, "Inference not found")
 	ErrNoModelSpecified     = echo.NewHTTPError(http.StatusBadRequest, "No model specified")
+	ErrModelNotSupported    = echo.NewHTTPError(http.StatusBadRequest, "Model not supported")
 )

--- a/decentralized-api/internal/server/public/post_chat_handler.go
+++ b/decentralized-api/internal/server/public/post_chat_handler.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -317,7 +318,14 @@ func (s *Server) handleTransferRequest(ctx echo.Context, request *ChatRequest) e
 
 	executor, err := s.getExecutorForRequest(ctx.Request().Context(), request.OpenAiRequest.Model)
 	if err != nil {
-		logging.Error("Failed to get executor", types.Inferences, "error", err)
+		logging.Error("Failed to get executor", types.Inferences, "error", err, "model", request.OpenAiRequest.Model)
+		// Check if the error is due to model not being supported
+		errStr := err.Error()
+		if strings.Contains(errStr, "epoch group data not found") ||
+			strings.Contains(errStr, "sub-group") ||
+			strings.Contains(errStr, "After filtering participants the length is 0") {
+			return ErrModelNotSupported
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- Adds new `ErrModelNotSupported` error returning HTTP 400 Bad Request with message "Model not supported"
- Detects when `getExecutorForRequest()` fails due to model not being supported
- Returns proper error instead of misleading 402 Payment Required or 500 Internal Server Error

## Problem
When requesting inference for an unsupported model via `/chat/completions`, the API was returning:
- `HTTP 402 Payment Required` (if balance check happened first with legacy pricing)
- `HTTP 500 Internal Server Error` (if balance was sufficient but model subgroup not found)

Both responses were confusing for users who expected a clear "model not supported" message.

## Solution
Added explicit error handling in `handleTransferRequest()` that checks error messages from `getExecutorForRequest()` for patterns indicating model is not supported:
- "epoch group data not found" - model doesn't have a subgroup
- "sub-group" - error getting sub-group for model  
- "After filtering participants the length is 0" - no participants serving the model

When detected, returns `ErrModelNotSupported` (HTTP 400 Bad Request, "Model not supported").

## Test plan
- [x] Code compiles successfully
- [x] Existing tests pass
- [ ] Manual test: request inference with unsupported model, verify 400 response with "Model not supported" message

Fixes #351