### PR TITLE
fix: improve error messages for invalid governance models

### DIFF
--- a/decentralized-api/broker/node_admin_commands.go
+++ b/decentralized-api/broker/node_admin_commands.go
@@ -89,8 +89,13 @@ func (c RegisterNode) Execute(b *Broker) {
 
 	for modelId := range c.Node.Models {
 		if _, ok := modelMap[modelId]; !ok {
-			logging.Error("RegisterNode. Model is not a valid governance model", types.Nodes, "model_id", modelId)
-			c.Response <- NodeCommandResponse{Node: nil, Error: err}
+			availableModels := make([]string, 0, len(modelMap))
+			for m := range modelMap {
+				availableModels = append(availableModels, m)
+			}
+			errMsg := fmt.Sprintf("model '%s' is not a valid governance model. Available models: %v", modelId, availableModels)
+			logging.Error("RegisterNode. Model is not a valid governance model", types.Nodes, "model_id", modelId, "available_models", availableModels)
+			c.Response <- NodeCommandResponse{Node: nil, Error: fmt.Errorf(errMsg)}
 			return
 		}
 	}
@@ -224,8 +229,13 @@ func (c UpdateNode) Execute(b *Broker) {
 
 	for modelId := range c.Node.Models {
 		if _, ok := modelMap[modelId]; !ok {
-			logging.Error("UpdateNode. Model is not a valid governance model", types.Nodes, "model_id", modelId)
-			c.Response <- NodeCommandResponse{Node: nil, Error: fmt.Errorf("model %s is not a valid governance model", modelId)}
+			availableModels := make([]string, 0, len(modelMap))
+			for m := range modelMap {
+				availableModels = append(availableModels, m)
+			}
+			errMsg := fmt.Sprintf("model '%s' is not a valid governance model. Available models: %v", modelId, availableModels)
+			logging.Error("UpdateNode. Model is not a valid governance model", types.Nodes, "model_id", modelId, "available_models", availableModels)
+			c.Response <- NodeCommandResponse{Node: nil, Error: fmt.Errorf(errMsg)}
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixed bug where RegisterNode returned nil error when model not found (was using wrong error variable)
- Added list of available governance models to error messages in both RegisterNode and UpdateNode
- Helps users identify the correct model ID when there are typos or name collisions

## Problem
When registering a node with an invalid model ID (e.g., typo or wrong model name), the error message was confusing or missing because:
1. `RegisterNode` was returning the error from `GetGovernanceModels()` call instead of creating a new error for the invalid model
2. No information about available models was provided, making it hard for users to know what models they could use

## Solution
- Create proper error with `fmt.Errorf()` when model is not found
- Include the list of available governance models in the error message
- Apply the same improvement to `UpdateNode` for consistency

## Example Error (Before)
```
ERROR: Failed to get governance models: model not found
```

## Example Error (After)
```
ERROR: model 'Qwen/Qwen2.5-7B-Instruct' is not a valid governance model. Available models: [RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a16, ...]
```

## Test plan
- [x] Code compiles successfully
- [x] Existing tests pass
- [ ] Manual test: register node with invalid model, verify helpful error message

Fixes #438