### PR TITLE
fix: skip disabled nodes from governance model population

### DIFF
--- a/decentralized-api/broker/broker.go
+++ b/decentralized-api/broker/broker.go
@@ -1469,11 +1469,22 @@ func (b *Broker) UpdateNodeWithEpochData(epochState *chainphase.EpochState) erro
 		}
 	}
 
-	// 6. Populate governance models for nodes not in epoch data (disabled nodes)
+	// 6. Populate governance models for nodes not in epoch data
+	// Skip nodes that are administratively disabled and past their grace period
 	b.mu.RLock()
 	nodeIds := make([]string, 0, len(b.nodes))
-	for nodeId := range b.nodes {
+	for nodeId, node := range b.nodes {
 		if !nodesInEpoch[nodeId] {
+			// Check if node should still be operational
+			// Disabled nodes should not be populated with governance models after their grace period
+			if !ShouldBeOperational(node.State.AdminState, epochState.LatestEpoch.EpochIndex, epochState.CurrentPhase) {
+				logging.Info("Skipping disabled node from governance model population", types.Nodes,
+					"node_id", nodeId,
+					"admin_enabled", node.State.AdminState.Enabled,
+					"admin_epoch", node.State.AdminState.Epoch,
+					"current_epoch", epochState.LatestEpoch.EpochIndex)
+				continue
+			}
 			nodeIds = append(nodeIds, nodeId)
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixed bug where disabled MLNodes were still being scheduled for inference after their grace period

## Problem
When MLNodes are disabled via `POST /admin/v1/nodes/<id>/disable`:
1. They should work till end of current epoch
2. Serve inference during next PoC if POC_SLOT is true (on-duty nodes)
3. **After end of next PoC, have weight 0 and NOT be used anymore**

But disabled nodes were keeping their previous weight and being scheduled for the next epoch because:
- When a node is not in ValidationWeights (disabled nodes aren't), the code would populate it with governance models
- This made the node available for inference scheduling despite being administratively disabled

## Root Cause
In `UpdateNodeWithEpochData()` (broker/broker.go), section 6 populates governance models for nodes not in epoch data WITHOUT checking if the node is administratively disabled.

## Solution
Added a check using `ShouldBeOperational()` before populating governance models:
- If node is disabled (`AdminState.Enabled = false`) AND past grace period (`AdminState.Epoch < latestEpoch`)
- Skip populating governance models for this node
- Node will not be available for inference scheduling

## Code Change
```go
// Before populating governance models, check if node should be operational
if !ShouldBeOperational(node.State.AdminState, epochState.LatestEpoch.EpochIndex, epochState.CurrentPhase) {
    logging.Info("Skipping disabled node from governance model population", ...)
    continue
}
```

## Test plan
- [x] Code compiles successfully
- [x] Existing broker tests pass
- [ ] Manual test: disable node, wait for epoch transition, verify node has weight 0 in `/v1/epochs/{epoch}/participants`

Fixes #310