### PR TITLE
fix(poc): fix concurrent artifact read race causing data corruption

### DIFF
--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -320,6 +320,8 @@ func (v *OffChainValidator) worker(
 				sampleSize,
 			)
 
+			var reportAddr string
+
 			statsMu.Lock()
 			switch result {
 			case validateSuccess:
@@ -330,7 +332,7 @@ func (v *OffChainValidator) worker(
 				*pendingCount--
 				// Report participant as invalid to chain
 				// Uncomment when stabilized
-				// v.reportInvalidParticipant(pocHeight, work.address)
+				// reportAddr = work.address
 			case validateFailRetry:
 				// Re-queue for retry if under max attempts
 				if work.attempt < v.config.MaxRetries-1 {
@@ -346,22 +348,23 @@ func (v *OffChainValidator) worker(
 						*pendingCount--
 						logging.Warn("OffChainValidator: queue full, marking as failed", types.PoC,
 							"participant", work.address)
-						// Report participant as invalid to chain
-						v.reportInvalidParticipant(pocHeight, work.address)
 					}
 				} else {
 					*failCount++
 					*pendingCount--
 					logging.Warn("OffChainValidator: max retries exceeded, reporting as invalid", types.PoC,
 						"participant", work.address, "attempts", work.attempt+1)
-					// Report participant as invalid to chain
-					v.reportInvalidParticipant(pocHeight, work.address)
+					// Report participant as invalid to chain. We probably should separate only to report failed network requests.
+					// reportAddr = work.address
 				}
 			}
 
-			// Check if all work is done
 			done := *pendingCount <= 0
 			statsMu.Unlock()
+
+			if reportAddr != "" {
+				v.reportInvalidParticipant(pocHeight, reportAddr)
+			}
 
 			if done {
 				cancel()

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -16,6 +16,7 @@ import (
 	"decentralized-api/logging"
 	"decentralized-api/mlnodeclient"
 
+	"github.com/productscience/inference/api/inference/inference"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -327,6 +328,9 @@ func (v *OffChainValidator) worker(
 			case validateFailPermanent:
 				*failCount++
 				*pendingCount--
+				// Report participant as invalid to chain
+				// Uncomment when stabilized
+				// v.reportInvalidParticipant(pocHeight, work.address)
 			case validateFailRetry:
 				// Re-queue for retry if under max attempts
 				if work.attempt < v.config.MaxRetries-1 {
@@ -342,12 +346,16 @@ func (v *OffChainValidator) worker(
 						*pendingCount--
 						logging.Warn("OffChainValidator: queue full, marking as failed", types.PoC,
 							"participant", work.address)
+						// Report participant as invalid to chain
+						v.reportInvalidParticipant(pocHeight, work.address)
 					}
 				} else {
 					*failCount++
 					*pendingCount--
-					logging.Warn("OffChainValidator: max retries exceeded", types.PoC,
+					logging.Warn("OffChainValidator: max retries exceeded, reporting as invalid", types.PoC,
 						"participant", work.address, "attempts", work.attempt+1)
+					// Report participant as invalid to chain
+					v.reportInvalidParticipant(pocHeight, work.address)
 				}
 			}
 
@@ -675,4 +683,25 @@ func filterNodesForValidation(nodes []broker.NodeResponse) []broker.NodeResponse
 			"node_id", node.Node.Id, "status", node.State.CurrentStatus.String())
 	}
 	return filtered
+}
+
+// reportInvalidParticipant submits a validation result with ValidatedWeight=-1 (invalid) to chain.
+// This is called when validation fails permanently (e.g., retry exhaustion).
+func (v *OffChainValidator) reportInvalidParticipant(pocHeight int64, participantAddress string) {
+	msg := &inference.MsgSubmitPocValidationsV2{
+		PocStageStartBlockHeight: pocHeight,
+		Validations: []*inference.PoCValidationPayloadV2{
+			{
+				ParticipantAddress: participantAddress,
+				ValidatedWeight:    -1, // Invalid
+			},
+		},
+	}
+	if err := v.recorder.SubmitPocValidationsV2(msg); err != nil {
+		logging.Error("OffChainValidator: failed to report invalid participant", types.PoC,
+			"participant", participantAddress, "error", err)
+	} else {
+		logging.Info("OffChainValidator: reported participant as invalid", types.PoC,
+			"participant", participantAddress)
+	}
 }

--- a/deploy/join/docker-compose.mlnode.yml
+++ b/deploy/join/docker-compose.mlnode.yml
@@ -1,7 +1,7 @@
 services:
   mlnode-308:
-    # ghcr.io/product-science/mlnode:3.0.12-post1-blackwell
-    image: ghcr.io/product-science/mlnode:3.0.12-post1
+    # ghcr.io/product-science/mlnode:3.0.12-post2-blackwell
+    image: ghcr.io/product-science/mlnode:3.0.12-post2
     hostname: mlnode-308
     volumes:
       - ${HF_HOME:-${HOME}/.cache}:/root/.cache

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tmkms:
-    image: ghcr.io/product-science/tmkms-softsign-with-keygen:0.2.8
+    image: ghcr.io/product-science/tmkms-softsign-with-keygen:0.2.9-post1
     container_name: tmkms
     restart: unless-stopped
     environment:
@@ -10,7 +10,7 @@ services:
 
   node:
     container_name: node
-    image: ghcr.io/product-science/inferenced:0.2.8
+    image: ghcr.io/product-science/inferenced:0.2.9-post1
     command: ["sh", "./init-docker.sh"]
     volumes:
       - .inference:/root/.inference
@@ -44,7 +44,7 @@ services:
 
   api:
     container_name: api
-    image: ghcr.io/product-science/api:0.2.8
+    image: ghcr.io/product-science/api:0.2.9-post1
     volumes:
       - .inference:/root/.inference
       - .dapi:/root/.dapi
@@ -99,7 +99,7 @@ services:
   
   proxy:
     container_name: proxy
-    image: ghcr.io/product-science/proxy:0.2.8
+    image: ghcr.io/product-science/proxy:0.2.9-post1
     ports:
       - "${API_PORT:-8000}:80"
       - "${API_SSL_PORT:-8443}:443"
@@ -145,7 +145,7 @@ services:
 
   proxy-ssl:
     container_name: proxy-ssl
-    image: ghcr.io/product-science/proxy-ssl:0.2.8
+    image: ghcr.io/product-science/proxy-ssl:0.2.9-post1
     profiles:
       - ssl
     environment:

--- a/mlnode/packages/api/Dockerfile
+++ b/mlnode/packages/api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 ################################################################################
-FROM ghcr.io/gonka-ai/vllm:v0.9.1-poc-v2-post1 AS base
+FROM ghcr.io/gonka-ai/vllm:v0.9.1-poc-v2-post2-blackwell-sm120 AS base
 
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     --mount=type=cache,target=/root/.cache/pip \

--- a/mlnode/packages/pow/Dockerfile
+++ b/mlnode/packages/pow/Dockerfile
@@ -1,5 +1,5 @@
 ################################################################################
-FROM ghcr.io/gonka-ai/vllm:v0.9.1-poc-v2-blackwell AS builder
+FROM ghcr.io/gonka-ai/vllm:v0.9.1-poc-v2-post2-blackwell-sm120 AS builder
 
 ENV POETRY_VERSION=2.0.1 \
     PYTHONUNBUFFERED=1 \
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ################################################################################
 
 ARG USERNAME=pow
-FROM ghcr.io/gonka-ai/vllm:v0.9.1-poc-v2-blackwell AS app
+FROM ghcr.io/gonka-ai/vllm:v0.9.1-poc-v2-post2-blackwell-sm120 AS app
 
 ARG USERNAME
 ENV PYTHONUNBUFFERED=1 \

--- a/mlnode/packages/train/Dockerfile
+++ b/mlnode/packages/train/Dockerfile
@@ -1,5 +1,5 @@
 ################################################################################
-FROM ghcr.io/gonka-ai/vllm:v0.9.1-poc-v2-blackwell AS app
+FROM ghcr.io/gonka-ai/vllm:v0.9.1-poc-v2-post2-blackwell-sm120 AS app
 
 ENV APP_PATH=/app/packages/train
 


### PR DESCRIPTION
- Use ReadAt instead of Seek+ReadFull for thread-safe concurrent reads
- Add signed response with signer_address, timestamp, signature fields
- Report participants as invalid when validation retries exhausted