### PR TITLE
perf: enable gRPC

### DIFF
--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -69,6 +69,8 @@ type ApiConfig struct {
 
 type ChainNodeConfig struct {
 	Url              string `koanf:"url" json:"url"`
+	GrpcEnabled      bool   `koanf:"grpc_enabled" json:"grpc_enabled"`
+	GrpcPort         int    `koanf:"grpc_port" json:"grpc_port"`
 	IsGenesis        bool   `koanf:"is_genesis" json:"is_genesis"`
 	SeedApiUrl       string `koanf:"seed_api_url" json:"seed_api_url"`
 	AccountPublicKey string `koanf:"account_public_key" json:"account_public_key"`

--- a/decentralized-api/broker/broker.go
+++ b/decentralized-api/broker/broker.go
@@ -19,6 +19,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	cmbytes "github.com/cometbft/cometbft/libs/bytes"
+	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -67,6 +69,16 @@ func (b *BrokerChainBridgeImpl) SubmitHardwareDiff(diff *types.MsgSubmitHardware
 }
 
 func (b *BrokerChainBridgeImpl) GetBlockHash(height int64) (string, error) {
+	if b.client.GetClientContext().GRPCClient != nil {
+		resp, err := b.client.NewCometQueryClient().GetBlockByHeight(
+			context.Background(),
+			&cmtservice.GetBlockByHeightRequest{Height: height},
+		)
+		if err == nil && resp != nil && resp.BlockId != nil && len(resp.BlockId.Hash) > 0 {
+			return cmbytes.HexBytes(resp.BlockId.Hash).String(), nil
+		}
+	}
+
 	client, err := cosmosclient.NewRpcClient(b.chainNodeUrl)
 	if err != nil {
 		return "", err

--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -163,6 +163,10 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		if err != nil {
 			return nil, err
 		}
+		go func() {
+			<-ctx.Done()
+			_ = grpcConn.Close()
+		}()
 	}
 	clientCtx := cosmoclient.Context()
 	if grpcConn != nil {
@@ -202,6 +206,9 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 	defer func() {
 		if !success {
 			natsConn.Close()
+			if grpcConn != nil {
+				_ = grpcConn.Close()
+			}
 		}
 	}()
 

--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -11,8 +11,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
+	"net/url"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,6 +38,8 @@ import (
 	blstypes "github.com/productscience/inference/x/bls/types"
 	"github.com/productscience/inference/x/inference/types"
 	restrictionstypes "github.com/productscience/inference/x/restrictions/types"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type InferenceCosmosClient struct {
@@ -76,6 +81,27 @@ func expandPath(path string) (string, error) {
 		path = filepath.Join(usr.HomeDir, path[2:])
 	}
 	return filepath.Abs(path)
+}
+
+func grpcTargetFromNodeURL(nodeURL string, port int) (string, error) {
+	parsed, err := url.Parse(nodeURL)
+	if err != nil {
+		parsed, err = url.Parse("http://" + nodeURL)
+		if err != nil {
+			return "", err
+		}
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		host = parsed.Host
+	}
+	if host == "" {
+		return "", fmt.Errorf("invalid node url: %s", nodeURL)
+	}
+	if port == 0 {
+		port = 9090
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port)), nil
 }
 
 // 'file' keyring backend to automatically provide interactive prompts for signing
@@ -127,6 +153,26 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		log.Printf("Error creating cosmos client: %s", err)
 		return nil, err
 	}
+	var grpcConn *grpc.ClientConn
+	if nodeConfig.GrpcEnabled {
+		target, err := grpcTargetFromNodeURL(nodeConfig.Url, nodeConfig.GrpcPort)
+		if err != nil {
+			return nil, err
+		}
+		grpcConn, err = grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, err
+		}
+	}
+	clientCtx := cosmoclient.Context()
+	if grpcConn != nil {
+		clientCtx = clientCtx.WithGRPCClient(grpcConn)
+	}
+	grpcEnabled := clientCtx.GRPCClient != nil
+	logging.Info("Cosmos gRPC enabled", types.System, "enabled", grpcEnabled)
+	if grpcEnabled {
+		logging.Info("Cosmos gRPC target", types.System, "target", clientCtx.GRPCClient.Target())
+	}
 	err = updateKeyringIfNeeded(&cosmoclient, keyringDir, config)
 	if err != nil {
 		log.Printf("Error updating keyring: %s", err)
@@ -159,7 +205,7 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		}
 	}()
 
-	mn, err := tx_manager.StartTxManager(ctx, &cosmoclient, apiAccount, time.Second*60, natsConn, accAddress, config.GetHeight)
+	mn, err := tx_manager.StartTxManager(ctx, &cosmoclient, clientCtx, apiAccount, time.Second*60, natsConn, accAddress, config.GetHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/decentralized-api/cosmosclient/rpcclient.go
+++ b/decentralized-api/cosmosclient/rpcclient.go
@@ -1,25 +1,10 @@
 package cosmosclient
 
 import (
-	"context"
 	"github.com/cometbft/cometbft/rpc/client/http"
-	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 )
-
-type TendermintClient struct {
-	ChainNodeUrl string
-}
 
 // NewRpcClient Can be used to query Block, Validators, and other data from the Cosmos SDK node.
 func NewRpcClient(address string) (*http.HTTP, error) {
 	return http.New(address, "/websocket")
-}
-
-func (c *TendermintClient) Status() (*coretypes.ResultStatus, error) {
-	client, err := NewRpcClient(c.ChainNodeUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	return client.Status(context.Background())
 }

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -77,6 +77,7 @@ type blockTimeTracker struct {
 type manager struct {
 	ctx              context.Context
 	client           *cosmosclient.Client
+	clientCtx        client.Context
 	apiAccount       *apiconfig.ApiAccount
 	txFactory        *tx.Factory
 	accountRetriever client.AccountRetriever
@@ -91,6 +92,7 @@ type manager struct {
 func StartTxManager(
 	ctx context.Context,
 	client *cosmosclient.Client,
+	clientCtx client.Context,
 	account *apiconfig.ApiAccount,
 	defaultTimeout time.Duration,
 	natsConnection *nats.Conn,
@@ -114,6 +116,7 @@ func StartTxManager(
 	m := &manager{
 		ctx:              ctx,
 		client:           client,
+		clientCtx:        clientCtx,
 		address:          address,
 		apiAccount:       account,
 		accountRetriever: authtypes.AccountRetriever{},
@@ -728,7 +731,7 @@ func (m *manager) observeTxs() error {
 }
 
 func (m *manager) GetClientContext() client.Context {
-	return m.client.Context()
+	return m.clientCtx
 }
 
 func (m *manager) checkTxStatus(hash string) (bool, error) {

--- a/decentralized-api/internal/event_listener/event_listener.go
+++ b/decentralized-api/internal/event_listener/event_listener.go
@@ -243,14 +243,13 @@ func (el *EventListener) listen(ctx context.Context, blockQueue, mainQueue *Unbo
 }
 
 func (el *EventListener) startSyncStatusChecker() {
-	chainNodeUrl := el.configManager.GetChainNodeConfig().Url
 	hasTriedVersionSync := false
 
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		status, err := getStatus(chainNodeUrl)
+		status, err := el.transactionRecorder.Status(context.Background())
 		if err != nil {
 			logging.Error("Error getting node status", types.EventProcessing, "error", err)
 			continue

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -137,8 +137,7 @@ func NewOnNewBlockDispatcherFromCosmosClient(
 		return configManager.SetHeight(blockHeight)
 	}
 	getStatusFunc := func() (*coretypes.ResultStatus, error) {
-		url := configManager.GetChainNodeConfig().Url
-		return getStatus(url)
+		return cosmosClient.Status(context.Background())
 	}
 
 	randomSeedManager := seed.NewRandomSeedManager(cosmosClient, configManager)

--- a/decentralized-api/internal/event_listener/utils.go
+++ b/decentralized-api/internal/event_listener/utils.go
@@ -1,11 +1,8 @@
 package event_listener
 
 import (
-	"context"
-	"decentralized-api/cosmosclient"
 	"decentralized-api/logging"
 	"fmt"
-	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/gorilla/websocket"
 	"github.com/productscience/inference/x/inference/types"
 	"log"
@@ -31,13 +28,4 @@ func getWebsocketUrl(chainNodeUrl string) string {
 	u.Path = "/websocket"
 
 	return u.String()
-}
-
-func getStatus(chainNodeUrl string) (*coretypes.ResultStatus, error) {
-	client, err := cosmosclient.NewRpcClient(chainNodeUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	return client.Status(context.Background())
 }

--- a/decentralized-api/internal/server/admin/setup_report.go
+++ b/decentralized-api/internal/server/admin/setup_report.go
@@ -629,17 +629,7 @@ func (s *Server) checkMLNodes(ctx context.Context) []Check {
 }
 
 func (s *Server) checkBlockSync(ctx context.Context) Check {
-	chainNodeUrl := s.configManager.GetChainNodeConfig().Url
-	rpcClient, err := cosmosclient.NewRpcClient(chainNodeUrl)
-	if err != nil {
-		return Check{
-			ID:      "block_sync",
-			Status:  UNAVAILABLE,
-			Message: fmt.Sprintf("Failed to connect to chain node: %s", err.Error()),
-		}
-	}
-
-	status, err := rpcClient.Status(context.Background())
+	status, err := s.recorder.Status(context.Background())
 	if err != nil {
 		return Check{
 			ID:      "block_sync",

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -263,7 +263,7 @@ func getParams(ctx context.Context, transactionRecorder cosmosclient.InferenceCo
 			return params, nil
 		}
 
-		if strings.HasPrefix(err.Error(), "rpc error: code = Unknown desc = inference is not ready") {
+		if strings.Contains(err.Error(), "inference is not ready") {
 			logging.Info("Inference not ready, retrying...", types.System, "attempt", i+1, "error", err)
 			time.Sleep(2 * time.Second) // Try a longer wait for specific inference delays
 			continue

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -65,13 +65,16 @@ func main() {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	natssrv := server.NewServer(config.GetNatsConfig())
 	if err := natssrv.Start(); err != nil {
 		panic(err)
 	}
 
 	recorder, err := cosmosclient.NewInferenceCosmosClientWithRetry(
-		context.Background(),
+		ctx,
 		"gonka",
 		20,
 		5*time.Second,
@@ -86,7 +89,7 @@ func main() {
 
 	chainPhaseTracker := chainphase.NewChainPhaseTracker()
 	// NOTE: getParams is waiting for rpc to be ready, don't add request before it
-	params, err := getParams(context.Background(), *recorder)
+	params, err := getParams(ctx, *recorder)
 	if err != nil {
 		logging.Error("Failed to get params", types.System, "error", err)
 		return
@@ -137,17 +140,10 @@ func main() {
 	)
 	logging.Info("PoC orchestrator initialized", types.PoC)
 
-	tendermintClient := cosmosclient.TendermintClient{
-		ChainNodeUrl: config.GetChainNodeConfig().Url,
-	}
-	// Create a cancellable context for the entire system
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel() // Ensure resources are cleaned up
-
 	// Start periodic config auto-flush of dynamic data to DB
 	config.StartAutoFlush(ctx, 60*time.Second)
 
-	training.NewAssigner(recorder, &tendermintClient, ctx)
+	training.NewAssigner(recorder, ctx)
 	trainingExecutor := training.NewExecutor(ctx, nodeBroker, recorder)
 
 	validator := validation.NewInferenceValidator(nodeBroker, config, recorder, chainPhaseTracker)

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -16,6 +16,8 @@ import (
 	"decentralized-api/logging"
 	"decentralized-api/mlnodeclient"
 
+	cmbytes "github.com/cometbft/cometbft/libs/bytes"
+	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"github.com/productscience/inference/api/inference/inference"
 	"github.com/productscience/inference/x/inference/types"
 )
@@ -541,15 +543,25 @@ func (v *OffChainValidator) getSamplingBlockHash(epochState *chainphase.EpochSta
 		return ""
 	}
 
-	client, err := cosmosclient.NewRpcClient(v.chainNodeUrl)
-	if err != nil {
-		logging.Error("OffChainValidator: failed to create RPC client", types.PoC, "error", err)
-		return ""
-	}
-
 	freshBlockHeight := epochState.CurrentBlock.Height
 	if freshBlockHeight <= 0 {
 		logging.Error("OffChainValidator: current block height not available", types.PoC)
+		return ""
+	}
+
+	if v.recorder.GetClientContext().GRPCClient != nil {
+		resp, err := v.recorder.NewCometQueryClient().GetBlockByHeight(
+			context.Background(),
+			&cmtservice.GetBlockByHeightRequest{Height: freshBlockHeight},
+		)
+		if err == nil && resp != nil && resp.BlockId != nil && len(resp.BlockId.Hash) > 0 {
+			return cmbytes.HexBytes(resp.BlockId.Hash).String()
+		}
+	}
+
+	client, err := cosmosclient.NewRpcClient(v.chainNodeUrl)
+	if err != nil {
+		logging.Error("OffChainValidator: failed to create RPC client", types.PoC, "error", err)
 		return ""
 	}
 

--- a/decentralized-api/poc/validator_v1.go
+++ b/decentralized-api/poc/validator_v1.go
@@ -16,6 +16,8 @@ import (
 	"decentralized-api/logging"
 	"decentralized-api/mlnodeclient"
 
+	cmbytes "github.com/cometbft/cometbft/libs/bytes"
+	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -383,15 +385,25 @@ func (v *OnChainValidator) getSamplingBlockHash(epochState *chainphase.EpochStat
 		return ""
 	}
 
-	client, err := cosmosclient.NewRpcClient(v.chainNodeUrl)
-	if err != nil {
-		logging.Error("OnChainValidator: failed to create RPC client", types.PoC, "error", err)
-		return ""
-	}
-
 	freshBlockHeight := epochState.CurrentBlock.Height
 	if freshBlockHeight <= 0 {
 		logging.Error("OnChainValidator: current block height not available", types.PoC)
+		return ""
+	}
+
+	if v.recorder.GetClientContext().GRPCClient != nil {
+		resp, err := v.recorder.NewCometQueryClient().GetBlockByHeight(
+			context.Background(),
+			&cmtservice.GetBlockByHeightRequest{Height: freshBlockHeight},
+		)
+		if err == nil && resp != nil && resp.BlockId != nil && len(resp.BlockId.Hash) > 0 {
+			return cmbytes.HexBytes(resp.BlockId.Hash).String()
+		}
+	}
+
+	client, err := cosmosclient.NewRpcClient(v.chainNodeUrl)
+	if err != nil {
+		logging.Error("OnChainValidator: failed to create RPC client", types.PoC, "error", err)
 		return ""
 	}
 

--- a/decentralized-api/training/assigner.go
+++ b/decentralized-api/training/assigner.go
@@ -6,21 +6,21 @@ import (
 	"decentralized-api/logging"
 	"decentralized-api/utils"
 	"fmt"
-	"github.com/cometbft/cometbft/libs/rand"
-	"github.com/productscience/inference/api/inference/inference"
-	"github.com/productscience/inference/x/inference/keeper"
-	"github.com/productscience/inference/x/inference/types"
 	"log/slog"
 	"net/http"
 	"sort"
 	"time"
+
+	"github.com/cometbft/cometbft/libs/rand"
+	"github.com/productscience/inference/api/inference/inference"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
 )
 
 type Assigner struct {
-	cosmosClient     cosmosclient.CosmosMessageClient
-	tendermintClient *cosmosclient.TendermintClient
-	ctx              context.Context
-	task             *taskToAssignState
+	cosmosClient cosmosclient.CosmosMessageClient
+	ctx          context.Context
+	task         *taskToAssignState
 }
 
 type taskToAssignState struct {
@@ -29,12 +29,11 @@ type taskToAssignState struct {
 
 const logTag = "[training-task-assigner] "
 
-func NewAssigner(client cosmosclient.CosmosMessageClient, tendermintClient *cosmosclient.TendermintClient, ctx context.Context) *Assigner {
+func NewAssigner(client cosmosclient.CosmosMessageClient, ctx context.Context) *Assigner {
 	assigner := &Assigner{
-		cosmosClient:     client,
-		tendermintClient: tendermintClient,
-		ctx:              ctx,
-		task:             nil,
+		cosmosClient: client,
+		ctx:          ctx,
+		task:         nil,
 	}
 
 	// TODO: on startup do some queries to restore state (like tasks I was assigned)
@@ -66,7 +65,7 @@ func (a *Assigner) claimTasksForAssignment() {
 }
 
 func (a *Assigner) tryClaimingTaskToAssign() {
-	chainStatus, err := a.tendermintClient.Status()
+	chainStatus, err := a.cosmosClient.Status(a.ctx)
 	if err != nil {
 		slog.Error(logTag+"Failed to query chain status", "err", err)
 	}

--- a/inference-chain/app_overrides.toml
+++ b/inference-chain/app_overrides.toml
@@ -5,3 +5,7 @@ enable = true
 
 # Address defines the API server to listen on.
 address = "tcp://0.0.0.0:1317"
+
+[grpc]
+enable = true
+address = "0.0.0.0:9090"


### PR DESCRIPTION
It optionally enables grpc for chain queries instead of always falling back to RPC.
grpc improve performance and reduce rpc load

DAPI_CHAIN_NODE__GRPC_ENABLED=true - enable grpc