### PR TITLE
fix: enable gRPC for chain queries instead of RPC fallback

### DIFF
--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -68,6 +68,8 @@ type ApiConfig struct {
 
 type ChainNodeConfig struct {
 	Url              string `koanf:"url" json:"url"`
+	GrpcEnabled      bool   `koanf:"grpc_enabled" json:"grpc_enabled"`
+	GrpcPort         int    `koanf:"grpc_port" json:"grpc_port"`
 	IsGenesis        bool   `koanf:"is_genesis" json:"is_genesis"`
 	SeedApiUrl       string `koanf:"seed_api_url" json:"seed_api_url"`
 	AccountPublicKey string `koanf:"account_public_key" json:"account_public_key"`

--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -69,7 +69,7 @@ type ApiConfig struct {
 type ChainNodeConfig struct {
 	Url              string `koanf:"url" json:"url"`
 	GrpcEnabled      bool   `koanf:"grpc_enabled" json:"grpc_enabled"`
-	GrpcPort         int    `koanf:"grpc_port" json:"grpc_port"`
+	GrpcPort         int32  `koanf:"grpc_port" json:"grpc_port"`
 	IsGenesis        bool   `koanf:"is_genesis" json:"is_genesis"`
 	SeedApiUrl       string `koanf:"seed_api_url" json:"seed_api_url"`
 	AccountPublicKey string `koanf:"account_public_key" json:"account_public_key"`

--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -83,7 +83,7 @@ func expandPath(path string) (string, error) {
 	return filepath.Abs(path)
 }
 
-func grpcTargetFromNodeURL(nodeURL string, port int) (string, error) {
+func grpcTargetFromNodeURL(nodeURL string, port int32) (string, error) {
 	parsed, err := url.Parse(nodeURL)
 	if err != nil {
 		parsed, err = url.Parse("http://" + nodeURL)
@@ -101,7 +101,7 @@ func grpcTargetFromNodeURL(nodeURL string, port int) (string, error) {
 	if port == 0 {
 		port = 9090
 	}
-	return net.JoinHostPort(host, strconv.Itoa(port)), nil
+	return net.JoinHostPort(host, strconv.Itoa(int(port))), nil
 }
 
 // 'file' keyring backend to automatically provide interactive prompts for signing
@@ -160,6 +160,7 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 	}
 
 	var grpcConn *grpc.ClientConn
+	var grpcCancel context.CancelFunc
 	if nodeConfig.GrpcEnabled {
 		target, err := grpcTargetFromNodeURL(nodeConfig.Url, nodeConfig.GrpcPort)
 		if err != nil {
@@ -169,8 +170,10 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
 		}
+		var grpcCtx context.Context
+		grpcCtx, grpcCancel = context.WithCancel(ctx)
 		go func() {
-			<-ctx.Done()
+			<-grpcCtx.Done()
 			_ = grpcConn.Close()
 		}()
 	}
@@ -208,8 +211,8 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 	defer func() {
 		if !success {
 			natsConn.Close()
-			if grpcConn != nil {
-				_ = grpcConn.Close()
+			if grpcCancel != nil {
+				grpcCancel()
 			}
 		}
 	}()

--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -11,13 +11,18 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
+	"net/url"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
@@ -78,6 +83,27 @@ func expandPath(path string) (string, error) {
 	return filepath.Abs(path)
 }
 
+func grpcTargetFromNodeURL(nodeURL string, port int) (string, error) {
+	parsed, err := url.Parse(nodeURL)
+	if err != nil {
+		parsed, err = url.Parse("http://" + nodeURL)
+		if err != nil {
+			return "", err
+		}
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		host = parsed.Host
+	}
+	if host == "" {
+		return "", fmt.Errorf("invalid node url: %s", nodeURL)
+	}
+	if port == 0 {
+		port = 9090
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port)), nil
+}
+
 // 'file' keyring backend to automatically provide interactive prompts for signing
 func updateKeyringIfNeeded(client *cosmosclient.Client, keyringDir string, config *apiconfig.ConfigManager) error {
 	nodeConfig := config.GetChainNodeConfig()
@@ -133,6 +159,32 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		return nil, err
 	}
 
+	var grpcConn *grpc.ClientConn
+	if nodeConfig.GrpcEnabled {
+		target, err := grpcTargetFromNodeURL(nodeConfig.Url, nodeConfig.GrpcPort)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build gRPC target: %w", err)
+		}
+		grpcConn, err = grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
+		}
+		go func() {
+			<-ctx.Done()
+			_ = grpcConn.Close()
+		}()
+	}
+
+	clientCtx := cosmoclient.Context()
+	if grpcConn != nil {
+		clientCtx = clientCtx.WithGRPCClient(grpcConn)
+	}
+	grpcEnabled := clientCtx.GRPCClient != nil
+	logging.Info("Cosmos gRPC status", types.System, "enabled", grpcEnabled)
+	if grpcEnabled {
+		logging.Info("Cosmos gRPC target", types.System, "target", clientCtx.GRPCClient.Target())
+	}
+
 	apiAccount, err := apiconfig.NewApiAccount(addressPrefix, nodeConfig, &cosmoclient)
 	if err != nil {
 		log.Printf("Error creating api account: %s", err)
@@ -151,15 +203,18 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		return nil, err
 	}
 
-	// Ensure natsConn is closed on any error to unbind consumers
+	// Ensure resources are closed on any error
 	var success bool
 	defer func() {
 		if !success {
 			natsConn.Close()
+			if grpcConn != nil {
+				_ = grpcConn.Close()
+			}
 		}
 	}()
 
-	mn, err := tx_manager.StartTxManager(ctx, &cosmoclient, apiAccount, time.Second*60, natsConn, accAddress, config.GetHeight)
+	mn, err := tx_manager.StartTxManager(ctx, &cosmoclient, clientCtx, apiAccount, time.Second*60, natsConn, accAddress, config.GetHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -77,6 +77,7 @@ type blockTimeTracker struct {
 type manager struct {
 	ctx              context.Context
 	client           *cosmosclient.Client
+	clientCtx        client.Context
 	apiAccount       *apiconfig.ApiAccount
 	txFactory        *tx.Factory
 	accountRetriever client.AccountRetriever
@@ -90,7 +91,8 @@ type manager struct {
 
 func StartTxManager(
 	ctx context.Context,
-	client *cosmosclient.Client,
+	cosmosClient *cosmosclient.Client,
+	clientCtx client.Context,
 	account *apiconfig.ApiAccount,
 	defaultTimeout time.Duration,
 	natsConnection *nats.Conn,
@@ -102,18 +104,19 @@ func StartTxManager(
 	}
 
 	// Register all module interfaces to match admin server codec
-	app.RegisterLegacyModules(client.Context().InterfaceRegistry)
-	types.RegisterInterfaces(client.Context().InterfaceRegistry)
-	banktypes.RegisterInterfaces(client.Context().InterfaceRegistry)
-	v1.RegisterInterfaces(client.Context().InterfaceRegistry)
-	upgradetypes.RegisterInterfaces(client.Context().InterfaceRegistry)
-	collateraltypes.RegisterInterfaces(client.Context().InterfaceRegistry)
-	restrictionstypes.RegisterInterfaces(client.Context().InterfaceRegistry)
-	blstypes.RegisterInterfaces(client.Context().InterfaceRegistry)
+	app.RegisterLegacyModules(clientCtx.InterfaceRegistry)
+	types.RegisterInterfaces(clientCtx.InterfaceRegistry)
+	banktypes.RegisterInterfaces(clientCtx.InterfaceRegistry)
+	v1.RegisterInterfaces(clientCtx.InterfaceRegistry)
+	upgradetypes.RegisterInterfaces(clientCtx.InterfaceRegistry)
+	collateraltypes.RegisterInterfaces(clientCtx.InterfaceRegistry)
+	restrictionstypes.RegisterInterfaces(clientCtx.InterfaceRegistry)
+	blstypes.RegisterInterfaces(clientCtx.InterfaceRegistry)
 
 	m := &manager{
 		ctx:              ctx,
-		client:           client,
+		client:           cosmosClient,
+		clientCtx:        clientCtx,
 		address:          address,
 		apiAccount:       account,
 		accountRetriever: authtypes.AccountRetriever{},
@@ -728,7 +731,7 @@ func (m *manager) observeTxs() error {
 }
 
 func (m *manager) GetClientContext() client.Context {
-	return m.client.Context()
+	return m.clientCtx
 }
 
 func (m *manager) checkTxStatus(hash string) (bool, error) {


### PR DESCRIPTION
## Summary
- Add optional gRPC transport for chain queries (`grpc_enabled` / `grpc_port` in config)
- When enabled, creates a persistent `grpc.ClientConn` and sets it on the Cosmos SDK `client.Context`
- All query clients (inference, BLS, restrictions, upgrade) automatically use gRPC instead of CometBFT RPC fallback

## Problem (Issue #672)
gRPC is enabled on chain nodes, but the API always falls back to RPC for queries. This adds unnecessary overhead: HTTP/1.1 → CometBFT RPC → ABCI Query instead of direct gRPC (HTTP/2 + protobuf).

## Changes
- `apiconfig/config.go` — add `GrpcEnabled` and `GrpcPort` to `ChainNodeConfig`
- `cosmosclient/cosmosclient.go` — create gRPC connection when enabled, pass enriched `client.Context` to tx_manager
- `cosmosclient/tx_manager/tx_manager.go` — accept and store `client.Context`, return it from `GetClientContext()`

## Configuration
```json
{
  "chain_node": {
    "url": "tcp://localhost:26657",
    "grpc_enabled": true,
    "grpc_port": 9090
  }
}
```

When `grpc_enabled` is `false` or omitted, behavior is unchanged (RPC fallback).

## Test plan
- [x] All existing tests pass (`go test ./cosmosclient/... ./apiconfig/...`)
- [x] `go vet` clean
- [x] `go build ./...` compiles
- [ ] Manual verification with gRPC-enabled chain node

Closes #672