### PR TITLE
Use a portable build of BLST for macos (test) builds

### DIFF
--- a/decentralized-api/Dockerfile
+++ b/decentralized-api/Dockerfile
@@ -8,6 +8,7 @@ FROM golang:1.24.2-alpine3.20 AS builder
 ARG BUILD_FLAGS
 ARG GOOS
 ARG GOARCH
+ARG BLST_PORTABLE=0
 
 ENV GOOS=${GOOS} \
     GOARCH=${GOARCH} \
@@ -15,8 +16,10 @@ ENV GOOS=${GOOS} \
     GO111MODULE=on \
     GOCACHE=/root/.cache/go-build \
     GOMODCACHE=/go/pkg/mod \
-    CGO_CFLAGS="-I/lib" \
+    CGO_CFLAGS="-I/lib -O2" \
+    CGO_CFLAGS_ALLOW=".*" \
     CGO_LDFLAGS="-L/lib" \
+    BLST_PORTABLE=${BLST_PORTABLE} \
     # Override the wasmvm library path to use our musl version
     LD_LIBRARY_PATH=/lib
 
@@ -50,6 +53,7 @@ COPY decentralized-api/. .
 # ARG LDFLAGS
 RUN --mount=type=cache,id=go-build-cache3,target=/root/.cache/go-build \
     --mount=type=cache,id=go-mod-cache3,target=/go/pkg/mod \
+    if [ "$BLST_PORTABLE" = "1" ]; then export CGO_CFLAGS="$CGO_CFLAGS -D__BLST_PORTABLE__"; fi; \
     CGO_ENABLED=1 CC=gcc \
     go build -mod=readonly -tags muslc -ldflags "$LDFLAGS" \
     -o ./build/dapi \
@@ -59,6 +63,7 @@ RUN --mount=type=cache,id=go-build-cache3,target=/root/.cache/go-build \
 RUN --mount=type=cache,id=go-build-cache3,target=/root/.cache/go-build \
     --mount=type=cache,id=go-mod-cache3,target=/go/pkg/mod \
     cd /app/inference-chain && \
+    if [ "$BLST_PORTABLE" = "1" ]; then export CGO_CFLAGS="$CGO_CFLAGS -D__BLST_PORTABLE__"; fi; \
     CGO_ENABLED=1 CC=gcc \
     go build -mod=readonly -tags muslc -ldflags "-X github.com/cosmos/cosmos-sdk/version.Name=inference-chain -X github.com/cosmos/cosmos-sdk/version.AppName=inference-chaind" \
     -o ./build/inferenced ./cmd/inferenced/main.go \

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -4,6 +4,7 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
 
 VERSION ?= $(shell git describe --always)
+BLST_PORTABLE ?= 0
 SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
 
@@ -29,6 +30,7 @@ define DOCKER_BUILD
 		--build-arg BUILD_FLAGS="$(BUILD_FLAGS)" \
 		--build-arg GOOS=$(GOOS) \
 		--build-arg GOARCH=$(GOARCH) \
+		--build-arg BLST_PORTABLE=$(BLST_PORTABLE) \
 		-f $(DOCKER_FILE) \
 		.. \
 		-t $(DOCKER_TAG)

--- a/inference-chain/Dockerfile
+++ b/inference-chain/Dockerfile
@@ -7,6 +7,7 @@ FROM golang:1.24.2-alpine3.20 AS builder
 
 ARG GOOS=linux
 ARG GOARCH=amd64
+ARG BLST_PORTABLE=0
 
 ENV GOOS=${GOOS} \
     GOARCH=${GOARCH} \
@@ -14,9 +15,10 @@ ENV GOOS=${GOOS} \
     GO111MODULE=on \
     GOCACHE=/root/.cache/go-build \
     GOMODCACHE=/go/pkg/mod \
-    CGO_CFLAGS="-I/lib" \
+    CGO_CFLAGS="-I/lib -O2" \
+    CGO_CFLAGS_ALLOW=".*" \
     CGO_LDFLAGS="-L/lib" \
-    # Override the wasmvm library path to use our musl version
+    BLST_PORTABLE=${BLST_PORTABLE} \
     LD_LIBRARY_PATH=/lib
 
 RUN apk add --no-cache make gcc musl-dev git patchelf
@@ -51,6 +53,7 @@ ARG LDFLAGS
 ARG TAGS=""
 RUN --mount=type=cache,id=go-build-cache,target=/root/.cache/go-build \
     --mount=type=cache,id=go-mod-cache,target=/go/pkg/mod \
+    if [ "$BLST_PORTABLE" = "1" ]; then export CGO_CFLAGS="$CGO_CFLAGS -D__BLST_PORTABLE__"; fi; \
     CGO_ENABLED=1 CC=gcc \
     go build -mod=readonly -tags="muslc ${TAGS}" -ldflags "${LDFLAGS}" \
     -o ./build/inferenced \

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -4,6 +4,7 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
 
 VERSION ?= $(shell git describe --always)
+BLST_PORTABLE ?= 0
 SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
 
@@ -86,6 +87,7 @@ define DOCKER_BUILD
 		--build-arg LDFLAGS='$(ldflags)' \
 		--build-arg GOOS=$(GOOS) \
 		--build-arg GOARCH=$(GOARCH) \
+		--build-arg BLST_PORTABLE=$(BLST_PORTABLE) \
 		--build-arg GENESIS_OVERRIDES_FILE=$(GENESIS_OVERRIDES_FILE) \
 		-f $(DOCKER_FILE) \
 		.docker-context \

--- a/local-test-net/stop-rebuild.sh
+++ b/local-test-net/stop-rebuild.sh
@@ -4,5 +4,6 @@ set -e
 
 # Don't need to make path relative to ./local-test-net, becayse make is run with root as workdir
 export GENESIS_OVERRIDES_FILE="inference-chain/test_genesis_overrides.json"
+export BLST_PORTABLE=1
 export SET_LATEST=1
 make -C ../. build-docker


### PR DESCRIPTION
Running the binaries with the blst binary will cause a SIGILL error when run in an AMD64 container on an ARM64 machine. But we still want native perf for production, so we added a flag so the portable build is only for local/test builds