### PR TITLE
feat(poc-v2): add observation broadcasting and consensus-based PoC commits 

### DIFF
--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -375,6 +375,7 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 					logging.Error("Failed to rebuild propagation trees", types.PoC,
 						"epoch", epochContext.EpochIndex, "error", err)
 				} else if len(trees) > 0 {
+					d.propagationReceiver.ClearProcessedState()
 					d.propagationReceiver.SetTrees(trees)
 					d.propagationBundler.SetTrees(trees)
 					logging.Info("Propagation trees updated successfully", types.PoC,
@@ -400,6 +401,23 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 			logging.Error("Failed to send init validate command", types.PoC, "error", err)
 			return
 		}
+	}
+
+	observationBroadcastHeight := epochContext.PoCExchangeDeadline() - poc.DefaultObservationBuffer
+	minBroadcastHeight := epochContext.EndOfPoCGeneration() + 1
+	if observationBroadcastHeight < minBroadcastHeight {
+		observationBroadcastHeight = minBroadcastHeight
+	}
+	if blockHeight == observationBroadcastHeight && d.propagationBundler != nil {
+		logging.Info("DapiStage:ObservationBroadcast. Broadcasting observation", types.Stages,
+			"blockHeight", blockHeight, "pocHeight", epochContext.PocStartBlockHeight,
+			"deadline", epochContext.PoCExchangeDeadline())
+		go func() {
+			if err := d.propagationBundler.BroadcastObservation(epochContext.PocStartBlockHeight); err != nil {
+				logging.Error("Failed to broadcast observation", types.PoC,
+					"pocHeight", epochContext.PocStartBlockHeight, "error", err)
+			}
+		}()
 	}
 
 	if epochContext.IsStartOfPoCValidationStage(blockHeight) {

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -404,7 +404,11 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 	}
 
 	observationBroadcastHeight := epochContext.PoCExchangeDeadline() - poc.DefaultObservationBuffer
-	minBroadcastHeight := epochContext.EndOfPoCGeneration() + 1
+	maxBroadcastHeight := epochContext.EndOfPoCGeneration() - 1
+	if observationBroadcastHeight > maxBroadcastHeight {
+		observationBroadcastHeight = maxBroadcastHeight
+	}
+	minBroadcastHeight := epochContext.PocStartBlockHeight + 1
 	if observationBroadcastHeight < minBroadcastHeight {
 		observationBroadcastHeight = minBroadcastHeight
 	}

--- a/decentralized-api/internal/server/public/propagation_handler.go
+++ b/decentralized-api/internal/server/public/propagation_handler.go
@@ -9,8 +9,9 @@ import (
 )
 
 type PropagationHandlers struct {
-	transport *propagation.HTTPTransport
-	cache     *propagation.Cache
+	transport           *propagation.HTTPTransport
+	cache               *propagation.Cache
+	consensusCalculator *propagation.ConsensusCalculator
 }
 
 func NewPropagationHandlers(transport *propagation.HTTPTransport) *PropagationHandlers {
@@ -21,6 +22,7 @@ func NewPropagationHandlers(transport *propagation.HTTPTransport) *PropagationHa
 
 func (h *PropagationHandlers) SetCache(cache *propagation.Cache) {
 	h.cache = cache
+	h.consensusCalculator = propagation.NewConsensusCalculator(cache)
 }
 
 func (h *PropagationHandlers) HandleHeader(c echo.Context) error {
@@ -91,9 +93,102 @@ func (h *PropagationHandlers) HandleGetProofs(c echo.Context) error {
 	return c.JSON(http.StatusOK, response)
 }
 
+func (h *PropagationHandlers) HandleGetFirstArrivals(c echo.Context) error {
+	pocHeightStr := c.Param("poc_height")
+	pocHeight, err := strconv.ParseInt(pocHeightStr, 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid poc_height")
+	}
+
+	if h.cache == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "cache not available")
+	}
+
+	arrivals, err := h.cache.GetAllFirstArrivals(pocHeight)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get first arrivals")
+	}
+
+	response := map[string]interface{}{
+		"poc_height": pocHeight,
+		"arrivals":   arrivals,
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+func (h *PropagationHandlers) HandleObservation(c echo.Context) error {
+	h.transport.HandleObservationHTTP(c.Response().Writer, c.Request())
+	return nil
+}
+
+func (h *PropagationHandlers) HandleGetObservations(c echo.Context) error {
+	pocHeightStr := c.Param("poc_height")
+	pocHeight, err := strconv.ParseInt(pocHeightStr, 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid poc_height")
+	}
+
+	if h.cache == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "cache not available")
+	}
+
+	observations, err := h.cache.GetObservations(pocHeight)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get observations")
+	}
+
+	response := map[string]interface{}{
+		"poc_height":   pocHeight,
+		"observations": observations,
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+func (h *PropagationHandlers) HandleGetConsensus(c echo.Context) error {
+	pocHeightStr := c.Param("poc_height")
+	pocHeight, err := strconv.ParseInt(pocHeightStr, 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid poc_height")
+	}
+
+	deadlineStr := c.QueryParam("deadline")
+	var deadline int64
+	if deadlineStr != "" {
+		deadline, err = strconv.ParseInt(deadlineStr, 10, 64)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid deadline")
+		}
+	} else {
+		deadline = 0x7FFFFFFFFFFFFFFF
+	}
+
+	if h.consensusCalculator == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "consensus calculator not available")
+	}
+
+	results, err := h.consensusCalculator.Calculate(pocHeight, deadline)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to calculate consensus")
+	}
+
+	response := map[string]interface{}{
+		"poc_height": pocHeight,
+		"deadline":   deadline,
+		"consensus":  results,
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
 func (h *PropagationHandlers) RegisterRoutes(e *echo.Group) {
 	e.POST("propagation/header", h.HandleHeader)
 	e.POST("propagation/proofs", h.HandleProofs)
+	e.POST("propagation/observation", h.HandleObservation)
 	e.GET("propagation/cache/:poc_height", h.HandleGetCache)
 	e.GET("propagation/proofs/:bundle_id", h.HandleGetProofs)
+	e.GET("propagation/first-arrivals/:poc_height", h.HandleGetFirstArrivals)
+	e.GET("propagation/observations/:poc_height", h.HandleGetObservations)
+	e.GET("propagation/consensus/:poc_height", h.HandleGetConsensus)
 }

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -328,6 +328,11 @@ func main() {
 	)
 	defer commitWorker.Close()
 
+	if propagationCache != nil {
+		consensusCalculator := propagation.NewConsensusCalculator(propagationCache)
+		commitWorker.SetConsensusCalculator(consensusCalculator)
+	}
+
 	// Build server options
 	serverOpts := []pserver.ServerOption{pserver.WithArtifactStore(artifactStore)}
 	if propagationHandlers != nil {

--- a/decentralized-api/poc/commit_worker.go
+++ b/decentralized-api/poc/commit_worker.go
@@ -135,13 +135,19 @@ func (w *CommitWorker) tick() {
 	}
 
 	if pocHeight > 0 {
+		isPoCPhase := epochState.CurrentPhase == types.PoCGeneratePhase ||
+			epochState.CurrentPhase == types.PoCGenerateWindDownPhase
 		canCommit := ShouldAcceptStoreCommit(epochState, pocHeight)
 		logging.Debug("CommitWorker: tick", types.PoC,
 			"phase", epochState.CurrentPhase,
 			"pocHeight", pocHeight,
+			"isPoCPhase", isPoCPhase,
 			"canCommit", canCommit)
+		if isPoCPhase {
+			w.maybePublishHeaders(pocHeight)
+		}
 		if canCommit {
-			w.maybeSubmitCommit(pocHeight)
+			w.maybeSubmitConsensusCommit(pocHeight)
 		}
 	}
 
@@ -160,7 +166,67 @@ func (w *CommitWorker) tick() {
 	}
 }
 
-func (w *CommitWorker) maybeSubmitCommit(pocHeight int64) {
+func (w *CommitWorker) maybePublishHeaders(pocHeight int64) {
+	if !w.propagationEnabled || w.bundler == nil {
+		return
+	}
+
+	store, err := w.store.GetStore(pocHeight)
+	if err != nil || store == nil {
+		return
+	}
+
+	count, rootHash := store.GetFlushedRoot()
+	if count == 0 || rootHash == nil {
+		return
+	}
+
+	last := w.lastCommitted[pocHeight]
+	if last.count == count && bytes.Equal(last.rootHash, rootHash) {
+		return
+	}
+
+	bundleID := propagation.MakeBundleID(w.participantAddress, pocHeight, rootHash, count)
+
+	if err := w.bundler.Publish(pocHeight, w.participantAddress, w.pubKey, count, rootHash); err != nil {
+		logging.Warn("CommitWorker: propagation header publish failed", types.PoC,
+			"pocHeight", pocHeight, "error", err)
+	} else {
+		logging.Info("CommitWorker: header published via propagation", types.PoC,
+			"pocHeight", pocHeight, "count", count)
+
+		if err := w.bundler.StoreOwnArrival(pocHeight, w.participantAddress, count); err != nil {
+			logging.Warn("CommitWorker: failed to store own arrival", types.PoC,
+				"pocHeight", pocHeight, "error", err)
+		}
+
+		if err := w.publishProofsViaPropagation(store, bundleID, count); err != nil {
+			logging.Warn("CommitWorker: propagation proofs publish failed", types.PoC,
+				"pocHeight", pocHeight, "error", err)
+		}
+	}
+	w.lastCommitted[pocHeight] = commitState{count, rootHash}
+}
+
+func (w *CommitWorker) maybeSubmitConsensusCommit(pocHeight int64) {
+	if !w.propagationEnabled || w.consensusCalculator == nil {
+		store, err := w.store.GetStore(pocHeight)
+		if err != nil || store == nil {
+			return
+		}
+		count, rootHash := store.GetFlushedRoot()
+		if count == 0 || rootHash == nil {
+			return
+		}
+		logging.Warn("CommitWorker: propagation disabled, skipping commit", types.PoC,
+			"pocHeight", pocHeight, "count", count)
+		return
+	}
+
+	if w.consensusSubmitted[pocHeight] {
+		return
+	}
+
 	store, err := w.store.GetStore(pocHeight)
 	if err != nil || store == nil {
 		logging.Debug("CommitWorker: no store for height", types.PoC, "pocHeight", pocHeight)
@@ -173,105 +239,32 @@ func (w *CommitWorker) maybeSubmitCommit(pocHeight int64) {
 		return
 	}
 
-	epochState := w.tracker.GetCurrentEpochState()
-	if epochState == nil || !epochState.IsSynced {
+	agreedCount := w.getConsensusCount(pocHeight)
+
+	if agreedCount > 0 {
+		logging.Info("CommitWorker: submitting consensus-based commit", types.PoC,
+			"pocHeight", pocHeight, "localCount", count, "agreedCount", agreedCount)
+
+		msg := &inference.MsgPoCV2StoreCommit{
+			PocStageStartBlockHeight: pocHeight,
+			Count:                    agreedCount,
+			RootHash:                 rootHash,
+		}
+
+		if err := w.recorder.SubmitPoCV2StoreCommit(msg); err != nil {
+			logging.Warn("CommitWorker: consensus commit failed", types.PoC,
+				"pocHeight", pocHeight, "error", err)
+			return
+		}
+
+		w.consensusSubmitted[pocHeight] = true
+		logging.Info("CommitWorker: consensus committed", types.PoC,
+			"pocHeight", pocHeight, "agreedCount", agreedCount)
 		return
 	}
 
-	currentHeight := epochState.CurrentBlock.Height
-	deadline := epochState.LatestEpoch.PoCExchangeDeadline()
-	exchangeStart := epochState.LatestEpoch.EndOfPoCGeneration() + 1
-	exchangeWindowSize := deadline - exchangeStart + 1
-
-	// Calculate observation buffer as half the exchange window, minimum 1 block
-	observationBuffer := exchangeWindowSize / 2
-	if observationBuffer < 1 {
-		observationBuffer = 1
-	}
-
-	// Observation broadcast happens at the start of the second half of the exchange window
-	observationBroadcastHeight := exchangeStart + observationBuffer
-
-	// Phase 1: During generation, publish headers via propagation
-	if w.propagationEnabled && w.bundler != nil {
-		last := w.lastCommitted[pocHeight]
-		if last.count != count || !bytes.Equal(last.rootHash, rootHash) {
-			bundleID := propagation.MakeBundleID(w.participantAddress, pocHeight, rootHash, count)
-
-			if err := w.bundler.Publish(pocHeight, w.participantAddress, w.pubKey, count, rootHash); err != nil {
-				logging.Warn("CommitWorker: propagation header publish failed", types.PoC,
-					"pocHeight", pocHeight, "error", err)
-			} else {
-				logging.Info("CommitWorker: header published via propagation", types.PoC,
-					"pocHeight", pocHeight, "count", count)
-
-				if err := w.publishProofsViaPropagation(store, bundleID, count); err != nil {
-					logging.Warn("CommitWorker: propagation proofs publish failed", types.PoC,
-						"pocHeight", pocHeight, "error", err)
-				}
-			}
-			w.lastCommitted[pocHeight] = commitState{count, rootHash}
-		}
-	}
-
-	// Phase 2: Consensus-based commit (only path when consensus is enabled)
-	if w.propagationEnabled && w.consensusCalculator != nil {
-		if w.consensusSubmitted[pocHeight] {
-			return
-		}
-
-		// Calculate consensus at observation broadcast height
-		// Cap at deadline - 1 to ensure we're still in the commit window when phase changes at deadline
-		consensusReadyHeight := observationBroadcastHeight
-		if consensusReadyHeight > deadline-1 {
-			consensusReadyHeight = deadline - 1
-		}
-		if consensusReadyHeight < exchangeStart {
-			consensusReadyHeight = exchangeStart
-		}
-
-		if currentHeight < consensusReadyHeight {
-			logging.Debug("CommitWorker: waiting for observations", types.PoC,
-				"pocHeight", pocHeight, "currentHeight", currentHeight,
-				"consensusReadyHeight", consensusReadyHeight,
-				"exchangeWindow", exchangeWindowSize, "deadline", deadline)
-			return
-		}
-
-		// Try to get consensus count
-		agreedCount := w.getConsensusCount(pocHeight)
-
-		if agreedCount > 0 {
-			logging.Info("CommitWorker: submitting consensus-based commit", types.PoC,
-				"pocHeight", pocHeight, "localCount", count, "agreedCount", agreedCount)
-
-			msg := &inference.MsgPoCV2StoreCommit{
-				PocStageStartBlockHeight: pocHeight,
-				Count:                    agreedCount,
-				RootHash:                 rootHash,
-			}
-
-			if err := w.recorder.SubmitPoCV2StoreCommit(msg); err != nil {
-				logging.Warn("CommitWorker: consensus commit failed", types.PoC,
-					"pocHeight", pocHeight, "error", err)
-				return
-			}
-
-			w.consensusSubmitted[pocHeight] = true
-			logging.Info("CommitWorker: consensus committed", types.PoC,
-				"pocHeight", pocHeight, "agreedCount", agreedCount)
-			return
-		}
-
-		// No consensus yet, keep waiting (will retry next tick)
-		logging.Debug("CommitWorker: no consensus yet, will retry", types.PoC,
-			"pocHeight", pocHeight, "currentHeight", currentHeight, "deadline", deadline)
-		return
-	}
-
-	// Propagation disabled - this path should not be used in production
-	logging.Warn("CommitWorker: propagation disabled, skipping commit", types.PoC,
-		"pocHeight", pocHeight, "count", count)
+	logging.Debug("CommitWorker: waiting for consensus, will retry", types.PoC,
+		"pocHeight", pocHeight)
 }
 
 func (w *CommitWorker) getConsensusCount(pocHeight int64) uint32 {
@@ -286,11 +279,14 @@ func (w *CommitWorker) getConsensusCount(pocHeight int64) uint32 {
 		return 0
 	}
 
-	if result == nil {
-		return 0
+	if result != nil && result.AgreedCount > 0 {
+		logging.Info("CommitWorker: consensus reached", types.PoC,
+			"pocHeight", pocHeight, "agreedCount", result.AgreedCount,
+			"validators", result.TotalValidators, "agreeing", result.AgreeingCount)
+		return uint32(result.AgreedCount)
 	}
 
-	return uint32(result.AgreedCount)
+	return 0
 }
 
 func (w *CommitWorker) publishProofsViaPropagation(store *artifacts.ArtifactStore, bundleID [32]byte, count uint32) error {

--- a/decentralized-api/poc/commit_worker.go
+++ b/decentralized-api/poc/commit_worker.go
@@ -21,6 +21,7 @@ import (
 )
 
 const distributionRetryInterval = 30 * time.Second
+const DefaultObservationBuffer = int64(10)
 
 type commitState struct {
 	count    uint32
@@ -43,8 +44,10 @@ type CommitWorker struct {
 	lastDistributionAttempt time.Time
 	lastCommitted           map[int64]commitState
 
-	propagationEnabled bool
-	bundler            *propagation.Bundler
+	propagationEnabled  bool
+	bundler             *propagation.Bundler
+	consensusCalculator *propagation.ConsensusCalculator
+	consensusSubmitted  map[int64]bool
 }
 
 func NewCommitWorker(
@@ -69,6 +72,7 @@ func NewCommitWorker(
 		lastCommitted:      make(map[int64]commitState),
 		propagationEnabled: propagationEnabled,
 		bundler:            bundler,
+		consensusSubmitted: make(map[int64]bool),
 	}
 
 	// Start flush - always on (same interval as commits)
@@ -77,6 +81,12 @@ func NewCommitWorker(
 	go w.run()
 	logging.Info("CommitWorker started", types.PoC, "interval", interval)
 	return w
+}
+
+func (w *CommitWorker) SetConsensusCalculator(calc *propagation.ConsensusCalculator) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.consensusCalculator = calc
 }
 
 // Close stops the worker and waits for it to finish.
@@ -121,6 +131,7 @@ func (w *CommitWorker) tick() {
 		w.currentPocHeight = pocHeight
 		w.lastDistributionAttempt = time.Time{}
 		w.lastCommitted = make(map[int64]commitState)
+		w.consensusSubmitted = make(map[int64]bool)
 	}
 
 	if pocHeight > 0 {
@@ -162,16 +173,29 @@ func (w *CommitWorker) maybeSubmitCommit(pocHeight int64) {
 		return
 	}
 
-	// Skip if unchanged since last commit
-	last := w.lastCommitted[pocHeight]
-	if last.count == count && bytes.Equal(last.rootHash, rootHash) {
+	epochState := w.tracker.GetCurrentEpochState()
+	if epochState == nil || !epochState.IsSynced {
 		return
 	}
 
-	// If propagation is enabled, publish header and proofs off-chain
+	currentHeight := epochState.CurrentBlock.Height
+	deadline := epochState.LatestEpoch.PoCExchangeDeadline()
+	exchangeStart := epochState.LatestEpoch.EndOfPoCGeneration() + 1
+	exchangeWindowSize := deadline - exchangeStart + 1
+
+	// Calculate observation buffer as half the exchange window, minimum 1 block
+	observationBuffer := exchangeWindowSize / 2
+	if observationBuffer < 1 {
+		observationBuffer = 1
+	}
+
+	// Observation broadcast happens at the start of the second half of the exchange window
+	observationBroadcastHeight := exchangeStart + observationBuffer
+
+	// Phase 1: During generation, publish headers via propagation
 	if w.propagationEnabled && w.bundler != nil {
-		epochState := w.tracker.GetCurrentEpochState()
-		if epochState != nil && epochState.IsSynced {
+		last := w.lastCommitted[pocHeight]
+		if last.count != count || !bytes.Equal(last.rootHash, rootHash) {
 			bundleID := propagation.MakeBundleID(w.participantAddress, pocHeight, rootHash, count)
 
 			if err := w.bundler.Publish(pocHeight, w.participantAddress, w.pubKey, count, rootHash); err != nil {
@@ -186,25 +210,87 @@ func (w *CommitWorker) maybeSubmitCommit(pocHeight int64) {
 						"pocHeight", pocHeight, "error", err)
 				}
 			}
+			w.lastCommitted[pocHeight] = commitState{count, rootHash}
 		}
 	}
 
-	// Submit on-chain commit (always done for now, can be feature-flagged later)
-	msg := &inference.MsgPoCV2StoreCommit{
-		PocStageStartBlockHeight: pocHeight,
-		Count:                    count,
-		RootHash:                 rootHash,
-	}
+	// Phase 2: Consensus-based commit (only path when consensus is enabled)
+	if w.propagationEnabled && w.consensusCalculator != nil {
+		if w.consensusSubmitted[pocHeight] {
+			return
+		}
 
-	if err := w.recorder.SubmitPoCV2StoreCommit(msg); err != nil {
-		logging.Warn("CommitWorker: commit failed", types.PoC,
-			"pocHeight", pocHeight, "error", err)
+		// Calculate consensus at observation broadcast height
+		// Cap at deadline - 1 to ensure we're still in the commit window when phase changes at deadline
+		consensusReadyHeight := observationBroadcastHeight
+		if consensusReadyHeight > deadline-1 {
+			consensusReadyHeight = deadline - 1
+		}
+		if consensusReadyHeight < exchangeStart {
+			consensusReadyHeight = exchangeStart
+		}
+
+		if currentHeight < consensusReadyHeight {
+			logging.Debug("CommitWorker: waiting for observations", types.PoC,
+				"pocHeight", pocHeight, "currentHeight", currentHeight,
+				"consensusReadyHeight", consensusReadyHeight,
+				"exchangeWindow", exchangeWindowSize, "deadline", deadline)
+			return
+		}
+
+		// Try to get consensus count
+		agreedCount := w.getConsensusCount(pocHeight)
+
+		if agreedCount > 0 {
+			logging.Info("CommitWorker: submitting consensus-based commit", types.PoC,
+				"pocHeight", pocHeight, "localCount", count, "agreedCount", agreedCount)
+
+			msg := &inference.MsgPoCV2StoreCommit{
+				PocStageStartBlockHeight: pocHeight,
+				Count:                    agreedCount,
+				RootHash:                 rootHash,
+			}
+
+			if err := w.recorder.SubmitPoCV2StoreCommit(msg); err != nil {
+				logging.Warn("CommitWorker: consensus commit failed", types.PoC,
+					"pocHeight", pocHeight, "error", err)
+				return
+			}
+
+			w.consensusSubmitted[pocHeight] = true
+			logging.Info("CommitWorker: consensus committed", types.PoC,
+				"pocHeight", pocHeight, "agreedCount", agreedCount)
+			return
+		}
+
+		// No consensus yet, keep waiting (will retry next tick)
+		logging.Debug("CommitWorker: no consensus yet, will retry", types.PoC,
+			"pocHeight", pocHeight, "currentHeight", currentHeight, "deadline", deadline)
 		return
 	}
 
-	w.lastCommitted[pocHeight] = commitState{count, rootHash}
-	logging.Debug("CommitWorker: committed", types.PoC,
+	// Propagation disabled - this path should not be used in production
+	logging.Warn("CommitWorker: propagation disabled, skipping commit", types.PoC,
 		"pocHeight", pocHeight, "count", count)
+}
+
+func (w *CommitWorker) getConsensusCount(pocHeight int64) uint32 {
+	if w.consensusCalculator == nil {
+		return 0
+	}
+
+	result, err := w.consensusCalculator.CalculateForParticipantWithDeadlineFromObservations(pocHeight, w.participantAddress)
+	if err != nil {
+		logging.Warn("CommitWorker: failed to calculate consensus", types.PoC,
+			"pocHeight", pocHeight, "error", err)
+		return 0
+	}
+
+	if result == nil {
+		return 0
+	}
+
+	return uint32(result.AgreedCount)
 }
 
 func (w *CommitWorker) publishProofsViaPropagation(store *artifacts.ArtifactStore, bundleID [32]byte, count uint32) error {
@@ -398,3 +484,5 @@ func formatWeightDistribution(weights []*inference.MLNodeWeight) string {
 	}
 	return "{" + strings.Join(parts, ", ") + "}"
 }
+
+

--- a/decentralized-api/poc/commit_worker_test.go
+++ b/decentralized-api/poc/commit_worker_test.go
@@ -1,6 +1,7 @@
 package poc
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"decentralized-api/chainphase"
 	"decentralized-api/cosmosclient"
 	"decentralized-api/poc/artifacts"
+	"decentralized-api/poc/propagation"
 
 	"github.com/productscience/inference/api/inference/inference"
 	"github.com/productscience/inference/x/inference/types"
@@ -104,8 +106,7 @@ func TestCommitWorker_GetPocStageHeight_ConfirmationPoC(t *testing.T) {
 	assert.Equal(t, int64(450), height)
 }
 
-func TestCommitWorker_MaybeSubmitCommit_SkipsUnchanged(t *testing.T) {
-	// Create temp dir for artifact store
+func TestCommitWorker_MaybeSubmitConsensusCommit_SkipsUnchanged(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "commit_worker_test")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
@@ -115,15 +116,27 @@ func TestCommitWorker_MaybeSubmitCommit_SkipsUnchanged(t *testing.T) {
 
 	mockRecorder := &cosmosclient.MockCosmosMessageClient{}
 
+	bundleDir, err := os.MkdirTemp("", "bundle_storage_test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(bundleDir)
+
+	fileStorage, err := propagation.NewFileBundleStorage(bundleDir)
+	assert.NoError(t, err)
+	cache := propagation.NewCache(fileStorage)
+	consensusCalc := propagation.NewConsensusCalculator(cache)
+
 	worker := &CommitWorker{
-		store:         store,
-		recorder:      mockRecorder,
-		lastCommitted: make(map[int64]commitState),
+		store:               store,
+		recorder:            mockRecorder,
+		participantAddress:  "test_addr",
+		lastCommitted:       make(map[int64]commitState),
+		consensusSubmitted:  make(map[int64]bool),
+		propagationEnabled:  true,
+		consensusCalculator: consensusCalc,
 	}
 
 	pocHeight := int64(100)
 
-	// Get or create store and add an artifact
 	artifactStore, err := store.GetOrCreateStore(pocHeight)
 	assert.NoError(t, err)
 
@@ -132,15 +145,37 @@ func TestCommitWorker_MaybeSubmitCommit_SkipsUnchanged(t *testing.T) {
 	err = artifactStore.Flush()
 	assert.NoError(t, err)
 
-	// First commit should submit
+	count, rootHash := artifactStore.GetFlushedRoot()
+	assert.True(t, count > 0)
+	assert.NotNil(t, rootHash)
+
+	err = cache.StoreHeader(context.Background(), propagation.BundleHeader{
+		Participant: "test_addr",
+		PocHeight:   pocHeight,
+		Count:       count,
+		RootHash:    rootHash,
+		BundleID:    propagation.MakeBundleID("test_addr", pocHeight, rootHash, count),
+	})
+	assert.NoError(t, err)
+
+	obs := propagation.FirstArrivalObservation{
+		ValidatorAddress: "validator1",
+		PocHeight:        pocHeight,
+		Arrivals: map[string]propagation.ArrivalInfo{
+			"test_addr": {Time: time.Now().UnixMilli(), Count: count},
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+	err = cache.StoreObservation(obs)
+	assert.NoError(t, err)
+
 	mockRecorder.On("SubmitPoCV2StoreCommit", mock.AnythingOfType("*inference.MsgPoCV2StoreCommit")).Return(nil).Once()
 
-	worker.maybeSubmitCommit(pocHeight)
+	worker.maybeSubmitConsensusCommit(pocHeight)
 	mockRecorder.AssertExpectations(t)
 
-	// Second commit with same state should NOT submit
-	worker.maybeSubmitCommit(pocHeight)
-	mockRecorder.AssertExpectations(t) // No additional calls expected
+	worker.maybeSubmitConsensusCommit(pocHeight)
+	mockRecorder.AssertExpectations(t)
 }
 
 func TestCommitWorker_StartAndStop(t *testing.T) {

--- a/decentralized-api/poc/propagation/bundler.go
+++ b/decentralized-api/poc/propagation/bundler.go
@@ -263,6 +263,13 @@ func (b *Bundler) sendProofs(bundleID [32]byte, proofs []ProofItem) error {
 	return nil
 }
 
+func (b *Bundler) StoreOwnArrival(pocHeight int64, participant string, count uint32) error {
+	if b.cache == nil {
+		return fmt.Errorf("cache not available")
+	}
+	return b.cache.StoreFirstArrival(participant, pocHeight, time.Now().UnixMilli(), count)
+}
+
 func (b *Bundler) SetTrees(trees []*Tree) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/decentralized-api/poc/propagation/bundler.go
+++ b/decentralized-api/poc/propagation/bundler.go
@@ -268,3 +268,129 @@ func (b *Bundler) SetTrees(trees []*Tree) {
 	defer b.mu.Unlock()
 	b.trees = trees
 }
+
+func (b *Bundler) BroadcastObservation(pocHeight int64) error {
+	if b.cache == nil {
+		return fmt.Errorf("cache not available")
+	}
+
+	arrivals, err := b.cache.GetAllFirstArrivals(pocHeight)
+	if err != nil {
+		return fmt.Errorf("get first arrivals: %w", err)
+	}
+
+	if len(arrivals) == 0 {
+		logging.Debug("Bundler: no arrivals to broadcast", types.PoC,
+			"pocHeight", pocHeight, "validator", b.myAddr)
+		return nil
+	}
+
+	obs := FirstArrivalObservation{
+		ValidatorAddress: b.myAddr,
+		PocHeight:        pocHeight,
+		Arrivals:         arrivals,
+		Timestamp:        time.Now().UnixMilli(),
+	}
+
+	sig, err := SignObservationWith(obs, b.signer)
+	if err != nil {
+		return fmt.Errorf("sign observation: %w", err)
+	}
+	obs.Signature = sig
+
+	if err := b.cache.StoreObservation(obs); err != nil {
+		logging.Warn("Bundler: failed to cache own observation", types.PoC, "error", err)
+	}
+
+	logging.Info("Bundler: broadcasting observation", types.PoC,
+		"pocHeight", pocHeight, "validator", b.myAddr, "arrivals", len(arrivals))
+
+	if err := b.sendObservation(obs); err != nil {
+		logging.Warn("Bundler: failed to send observation", types.PoC, "error", err)
+		return fmt.Errorf("send observation: %w", err)
+	}
+
+	logging.Info("Bundler: observation broadcast complete", types.PoC,
+		"pocHeight", pocHeight, "validator", b.myAddr)
+
+	return nil
+}
+
+func (b *Bundler) sendObservation(obs FirstArrivalObservation) error {
+	b.mu.RLock()
+	trees := b.trees
+	b.mu.RUnlock()
+
+	obsSender, ok := b.sender.(ObservationSender)
+	if !ok {
+		return fmt.Errorf("sender does not support SendObservation")
+	}
+
+	var wg sync.WaitGroup
+	totalRecipients := 0
+
+	logging.Info("Bundler: checking trees for observation recipients", types.PoC,
+		"validator", b.myAddr, "totalTrees", len(trees),
+		"pocHeight", obs.PocHeight)
+
+	for _, tree := range trees {
+		if tree.Root == nil {
+			continue
+		}
+
+		if tree.Root.Address == b.myAddr {
+			continue
+		}
+
+		totalRecipients++
+
+		wg.Add(1)
+		go func(rootAddr string) {
+			defer wg.Done()
+			if err := obsSender.SendObservation(rootAddr, obs); err != nil {
+				logging.Warn("Bundler: failed to send observation to root", types.PoC,
+					"validator", b.myAddr, "root", rootAddr, "error", err)
+			} else {
+				logging.Debug("Bundler: sent observation to root", types.PoC,
+					"validator", b.myAddr, "root", rootAddr)
+			}
+		}(tree.Root.Address)
+	}
+
+	for _, tree := range trees {
+		node := tree.GetNode(b.myAddr)
+		if node == nil || node.Parent != nil {
+			continue
+		}
+
+		if len(node.Children) > 0 {
+			logging.Info("Bundler: broadcasting observation as root", types.PoC,
+				"validator", b.myAddr, "tree", tree.Index,
+				"children", len(node.Children))
+		}
+
+		for _, child := range node.Children {
+			totalRecipients++
+
+			wg.Add(1)
+			go func(childAddr string) {
+				defer wg.Done()
+				if err := obsSender.SendObservation(childAddr, obs); err != nil {
+					logging.Warn("Bundler: failed to send observation to child", types.PoC,
+						"validator", b.myAddr, "child", childAddr, "error", err)
+				} else {
+					logging.Debug("Bundler: sent observation to child", types.PoC,
+						"validator", b.myAddr, "child", childAddr)
+				}
+			}(child.Address)
+		}
+	}
+
+	wg.Wait()
+
+	logging.Info("Bundler: sent observation to all recipients", types.PoC,
+		"validator", b.myAddr, "totalRecipients", totalRecipients,
+		"trees", len(trees), "pocHeight", obs.PocHeight)
+
+	return nil
+}

--- a/decentralized-api/poc/propagation/cache.go
+++ b/decentralized-api/poc/propagation/cache.go
@@ -38,3 +38,23 @@ func (c *Cache) StoreProofs(ctx context.Context, bundleID [32]byte, proofs []Pro
 func (c *Cache) GetProofs(bundleID [32]byte) ([]ProofItem, error) {
 	return c.storage.GetProofs(context.Background(), bundleID)
 }
+
+func (c *Cache) StoreFirstArrival(participant string, pocHeight int64, arrivalTime int64, count uint32) error {
+	return c.storage.StoreFirstArrival(context.Background(), participant, pocHeight, arrivalTime, count)
+}
+
+func (c *Cache) GetFirstArrival(participant string, pocHeight int64) (ArrivalInfo, error) {
+	return c.storage.GetFirstArrival(context.Background(), participant, pocHeight)
+}
+
+func (c *Cache) GetAllFirstArrivals(pocHeight int64) (map[string]ArrivalInfo, error) {
+	return c.storage.GetAllFirstArrivals(context.Background(), pocHeight)
+}
+
+func (c *Cache) StoreObservation(obs FirstArrivalObservation) error {
+	return c.storage.StoreObservation(context.Background(), obs)
+}
+
+func (c *Cache) GetObservations(pocHeight int64) ([]FirstArrivalObservation, error) {
+	return c.storage.GetObservations(context.Background(), pocHeight)
+}

--- a/decentralized-api/poc/propagation/consensus.go
+++ b/decentralized-api/poc/propagation/consensus.go
@@ -1,0 +1,126 @@
+package propagation
+
+import (
+	"sort"
+)
+
+type ConsensusResult struct {
+	PocHeight       int64  `json:"poc_height"`
+	Participant     string `json:"participant"`
+	AgreedCount     int64  `json:"agreed_count"`
+	TotalValidators int    `json:"total_validators"`
+	AgreeingCount   int    `json:"agreeing_count"`
+}
+
+func CalculateConsensus(
+	observations []FirstArrivalObservation,
+	bundles []BundleHeader,
+	deadline int64,
+) map[string]ConsensusResult {
+	if len(observations) == 0 {
+		return make(map[string]ConsensusResult)
+	}
+
+	totalValidators := len(observations)
+	requiredAgreement := totalValidators/2 + 1
+
+	bundlesByParticipant := make(map[string][]BundleHeader)
+	for _, b := range bundles {
+		bundlesByParticipant[b.Participant] = append(bundlesByParticipant[b.Participant], b)
+	}
+
+	for participant := range bundlesByParticipant {
+		sort.Slice(bundlesByParticipant[participant], func(i, j int) bool {
+			return bundlesByParticipant[participant][i].Count < bundlesByParticipant[participant][j].Count
+		})
+	}
+
+	results := make(map[string]ConsensusResult)
+
+	for participant, headers := range bundlesByParticipant {
+		var agreedCount int64 = 0
+		var agreeingCount int = 0
+
+		for _, header := range headers {
+			targetCount := uint32(header.Count)
+			validatorsInTime := 0
+
+			for _, obs := range observations {
+				arrival, ok := obs.Arrivals[participant]
+				if ok && arrival.Time <= deadline && arrival.Count >= targetCount {
+					validatorsInTime++
+				}
+			}
+
+			if validatorsInTime >= requiredAgreement {
+				agreedCount = int64(targetCount)
+				agreeingCount = validatorsInTime
+			}
+		}
+
+		results[participant] = ConsensusResult{
+			PocHeight:       headers[0].PocHeight,
+			Participant:     participant,
+			AgreedCount:     agreedCount,
+			TotalValidators: totalValidators,
+			AgreeingCount:   agreeingCount,
+		}
+	}
+
+	return results
+}
+
+type ConsensusCalculator struct {
+	cache *Cache
+}
+
+func NewConsensusCalculator(cache *Cache) *ConsensusCalculator {
+	return &ConsensusCalculator{
+		cache: cache,
+	}
+}
+
+func (c *ConsensusCalculator) Calculate(pocHeight int64, deadline int64) (map[string]ConsensusResult, error) {
+	observations, err := c.cache.GetObservations(pocHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	bundles := c.cache.AllBundlesForHeight(pocHeight)
+
+	return CalculateConsensus(observations, bundles, deadline), nil
+}
+
+func (c *ConsensusCalculator) CalculateForParticipant(pocHeight int64, participant string, deadline int64) (*ConsensusResult, error) {
+	results, err := c.Calculate(pocHeight, deadline)
+	if err != nil {
+		return nil, err
+	}
+
+	result, ok := results[participant]
+	if !ok {
+		return nil, nil
+	}
+
+	return &result, nil
+}
+
+func (c *ConsensusCalculator) CalculateForParticipantWithDeadlineFromObservations(pocHeight int64, participant string) (*ConsensusResult, error) {
+	observations, err := c.cache.GetObservations(pocHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(observations) == 0 {
+		return nil, nil
+	}
+
+	deadline := observations[0].Timestamp
+	for _, obs := range observations[1:] {
+		if obs.Timestamp < deadline {
+			deadline = obs.Timestamp
+		}
+	}
+
+	return c.CalculateForParticipant(pocHeight, participant, deadline)
+}

--- a/decentralized-api/poc/propagation/consensus.go
+++ b/decentralized-api/poc/propagation/consensus.go
@@ -124,3 +124,4 @@ func (c *ConsensusCalculator) CalculateForParticipantWithDeadlineFromObservation
 
 	return c.CalculateForParticipant(pocHeight, participant, deadline)
 }
+

--- a/decentralized-api/poc/propagation/consensus_test.go
+++ b/decentralized-api/poc/propagation/consensus_test.go
@@ -1,0 +1,275 @@
+package propagation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateConsensus_EmptyObservations(t *testing.T) {
+	results := CalculateConsensus(nil, nil, 1000)
+	require.Empty(t, results)
+
+	results = CalculateConsensus([]FirstArrivalObservation{}, []BundleHeader{}, 1000)
+	require.Empty(t, results)
+}
+
+func TestCalculateConsensus_BasicMajority(t *testing.T) {
+	participant := "participant1"
+	pocHeight := int64(100)
+
+	bundles := []BundleHeader{
+		{Participant: participant, PocHeight: pocHeight, Count: 50},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 50},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 50},
+		}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 50},
+		}},
+	}
+
+	results := CalculateConsensus(observations, bundles, 1000)
+
+	require.Len(t, results, 1)
+	require.Equal(t, int64(50), results[participant].AgreedCount)
+	require.Equal(t, 3, results[participant].TotalValidators)
+	require.Equal(t, 3, results[participant].AgreeingCount)
+}
+
+func TestCalculateConsensus_NoMajority(t *testing.T) {
+	participant := "participant1"
+	pocHeight := int64(100)
+
+	bundles := []BundleHeader{
+		{Participant: participant, PocHeight: pocHeight, Count: 50},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 50},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{}},
+	}
+
+	results := CalculateConsensus(observations, bundles, 1000)
+
+	require.Len(t, results, 1)
+	require.Equal(t, int64(0), results[participant].AgreedCount)
+	require.Equal(t, 0, results[participant].AgreeingCount)
+}
+
+func TestCalculateConsensus_DeadlineFiltering(t *testing.T) {
+	participant := "participant1"
+	pocHeight := int64(100)
+	deadline := int64(500)
+
+	bundles := []BundleHeader{
+		{Participant: participant, PocHeight: pocHeight, Count: 50},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 400, Count: 50},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 600, Count: 50},
+		}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 700, Count: 50},
+		}},
+	}
+
+	results := CalculateConsensus(observations, bundles, deadline)
+
+	require.Len(t, results, 1)
+	require.Equal(t, int64(0), results[participant].AgreedCount)
+	require.Equal(t, 0, results[participant].AgreeingCount)
+}
+
+func TestCalculateConsensus_HigherCountNeedsMajority(t *testing.T) {
+	participant := "participant1"
+	pocHeight := int64(100)
+
+	bundles := []BundleHeader{
+		{Participant: participant, PocHeight: pocHeight, Count: 50},
+		{Participant: participant, PocHeight: pocHeight, Count: 100},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 100},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 100},
+		}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 50},
+		}},
+		{ValidatorAddress: "val4", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 50},
+		}},
+		{ValidatorAddress: "val5", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 50},
+		}},
+	}
+
+	results := CalculateConsensus(observations, bundles, 1000)
+
+	require.Len(t, results, 1)
+	require.Equal(t, int64(50), results[participant].AgreedCount)
+	require.Equal(t, 5, results[participant].AgreeingCount)
+}
+
+func TestCalculateConsensus_HigherCountWithMajority(t *testing.T) {
+	participant := "participant1"
+	pocHeight := int64(100)
+
+	bundles := []BundleHeader{
+		{Participant: participant, PocHeight: pocHeight, Count: 50},
+		{Participant: participant, PocHeight: pocHeight, Count: 100},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 100},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 100},
+		}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 100},
+		}},
+	}
+
+	results := CalculateConsensus(observations, bundles, 1000)
+
+	require.Len(t, results, 1)
+	require.Equal(t, int64(100), results[participant].AgreedCount)
+	require.Equal(t, 3, results[participant].AgreeingCount)
+}
+
+func TestCalculateConsensus_MultipleParticipants(t *testing.T) {
+	pocHeight := int64(100)
+
+	bundles := []BundleHeader{
+		{Participant: "p1", PocHeight: pocHeight, Count: 50},
+		{Participant: "p2", PocHeight: pocHeight, Count: 75},
+		{Participant: "p3", PocHeight: pocHeight, Count: 25},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			"p1": {Time: 100, Count: 50},
+			"p2": {Time: 100, Count: 75},
+			"p3": {Time: 100, Count: 25},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			"p1": {Time: 100, Count: 50},
+			"p2": {Time: 100, Count: 75},
+		}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			"p1": {Time: 100, Count: 50},
+			"p3": {Time: 100, Count: 25},
+		}},
+	}
+
+	results := CalculateConsensus(observations, bundles, 1000)
+
+	require.Len(t, results, 3)
+	require.Equal(t, int64(50), results["p1"].AgreedCount)
+	require.Equal(t, int64(75), results["p2"].AgreedCount)
+	require.Equal(t, int64(25), results["p3"].AgreedCount)
+}
+
+func TestCalculateConsensus_CountThreshold(t *testing.T) {
+	participant := "participant1"
+	pocHeight := int64(100)
+
+	bundles := []BundleHeader{
+		{Participant: participant, PocHeight: pocHeight, Count: 100},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 100},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 50},
+		}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 100, Count: 75},
+		}},
+	}
+
+	results := CalculateConsensus(observations, bundles, 1000)
+
+	require.Equal(t, int64(0), results[participant].AgreedCount)
+}
+
+func TestCalculateConsensus_ExactDeadline(t *testing.T) {
+	participant := "participant1"
+	pocHeight := int64(100)
+	deadline := int64(500)
+
+	bundles := []BundleHeader{
+		{Participant: participant, PocHeight: pocHeight, Count: 50},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 500, Count: 50},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 500, Count: 50},
+		}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 501, Count: 50},
+		}},
+	}
+
+	results := CalculateConsensus(observations, bundles, deadline)
+
+	require.Equal(t, int64(50), results[participant].AgreedCount)
+	require.Equal(t, 2, results[participant].AgreeingCount)
+}
+
+func TestCalculateConsensus_DeadlineFromObservations(t *testing.T) {
+	participant := "participant1"
+	pocHeight := int64(100)
+
+	bundles := []BundleHeader{
+		{Participant: participant, PocHeight: pocHeight, Count: 50},
+	}
+
+	observations := []FirstArrivalObservation{
+		{ValidatorAddress: "val1", PocHeight: pocHeight, Timestamp: 1000, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 900, Count: 50},
+		}},
+		{ValidatorAddress: "val2", PocHeight: pocHeight, Timestamp: 1100, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 950, Count: 50},
+		}},
+		{ValidatorAddress: "val3", PocHeight: pocHeight, Timestamp: 1050, Arrivals: map[string]ArrivalInfo{
+			participant: {Time: 1001, Count: 50},
+		}},
+	}
+
+	deadline := observations[0].Timestamp
+	for _, obs := range observations[1:] {
+		if obs.Timestamp < deadline {
+			deadline = obs.Timestamp
+		}
+	}
+	require.Equal(t, int64(1000), deadline)
+
+	results := CalculateConsensus(observations, bundles, deadline)
+
+	require.Equal(t, int64(50), results[participant].AgreedCount)
+	require.Equal(t, 2, results[participant].AgreeingCount)
+}

--- a/decentralized-api/poc/propagation/demo_test.go
+++ b/decentralized-api/poc/propagation/demo_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/stretchr/testify/require"
@@ -168,6 +169,8 @@ func testPropagationDemo(t *testing.T, numParticipants int, storageFactory propa
 	if err := bundlers[sender].Publish(pocHeight, sender, pubKeys[sender], senderCount, senderRoot); err != nil {
 		t.Fatalf("failed to publish: %v", err)
 	}
+
+	time.Sleep(100 * time.Millisecond)
 
 	bundleID := MakeBundleID(sender, pocHeight, senderRoot, senderCount)
 	receivedCount := 0

--- a/decentralized-api/poc/propagation/file_bundle_storage.go
+++ b/decentralized-api/poc/propagation/file_bundle_storage.go
@@ -15,10 +15,12 @@ import (
 )
 
 type FileBundleStorage struct {
-	baseDir string
-	mu      sync.RWMutex
-	bundles map[[32]byte]BundleHeader
-	proofs  map[[32]byte][]ProofItem
+	baseDir      string
+	mu           sync.RWMutex
+	bundles      map[[32]byte]BundleHeader
+	proofs       map[[32]byte][]ProofItem
+	arrivals     map[participantPocKey]ArrivalInfo
+	observations map[observationKey]FirstArrivalObservation
 }
 
 func NewFileBundleStorage(baseDir string) (*FileBundleStorage, error) {
@@ -31,9 +33,11 @@ func NewFileBundleStorage(baseDir string) (*FileBundleStorage, error) {
 	}
 
 	s := &FileBundleStorage{
-		baseDir: baseDir,
-		bundles: make(map[[32]byte]BundleHeader),
-		proofs:  make(map[[32]byte][]ProofItem),
+		baseDir:      baseDir,
+		bundles:      make(map[[32]byte]BundleHeader),
+		proofs:       make(map[[32]byte][]ProofItem),
+		arrivals:     make(map[participantPocKey]ArrivalInfo),
+		observations: make(map[observationKey]FirstArrivalObservation),
 	}
 
 	if err := s.loadBundles(); err != nil {
@@ -52,6 +56,21 @@ func (s *FileBundleStorage) bundleFilePath(bundleID [32]byte) string {
 func (s *FileBundleStorage) proofsFilePath(bundleID [32]byte) string {
 	filename := hex.EncodeToString(bundleID[:]) + "_proofs.json"
 	return filepath.Join(s.baseDir, filename)
+}
+
+func (s *FileBundleStorage) arrivalsFilePath() string {
+	return filepath.Join(s.baseDir, "arrivals.json")
+}
+
+func (s *FileBundleStorage) observationsFilePath() string {
+	return filepath.Join(s.baseDir, "observations.json")
+}
+
+type firstArrivalEntry struct {
+	Participant string `json:"participant"`
+	PocHeight   int64  `json:"poc_height"`
+	ArrivalTime int64  `json:"arrival_time"`
+	Count       uint32 `json:"count"`
 }
 
 func (s *FileBundleStorage) loadBundles() error {
@@ -112,7 +131,38 @@ func (s *FileBundleStorage) loadBundles() error {
 		s.bundles[header.BundleID] = header
 	}
 
-	logging.Info("Loaded bundles from disk", types.PoC, "count", len(s.bundles), "proofs", len(s.proofs))
+	if err := s.loadArrivals(); err != nil {
+		logging.Warn("Failed to load arrivals", types.PoC, "error", err)
+	}
+
+	if err := s.loadObservations(); err != nil {
+		logging.Warn("Failed to load observations", types.PoC, "error", err)
+	}
+
+	logging.Info("Loaded bundles from disk", types.PoC, "count", len(s.bundles), "proofs", len(s.proofs), "arrivals", len(s.arrivals), "observations", len(s.observations))
+	return nil
+}
+
+func (s *FileBundleStorage) loadArrivals() error {
+	filePath := s.arrivalsFilePath()
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read arrivals file: %w", err)
+	}
+
+	var entries []firstArrivalEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return fmt.Errorf("unmarshal arrivals: %w", err)
+	}
+
+	for _, entry := range entries {
+		key := participantPocKey{Participant: entry.Participant, PocHeight: entry.PocHeight}
+		s.arrivals[key] = ArrivalInfo{Time: entry.ArrivalTime, Count: entry.Count}
+	}
+
 	return nil
 }
 
@@ -221,6 +271,141 @@ func (s *FileBundleStorage) GetProofs(ctx context.Context, bundleID [32]byte) ([
 		return nil, ErrProofsNotFound
 	}
 	return proofs, nil
+}
+
+func (s *FileBundleStorage) StoreFirstArrival(ctx context.Context, participant string, pocHeight int64, arrivalTime int64, count uint32) error {
+	s.mu.Lock()
+	key := participantPocKey{Participant: participant, PocHeight: pocHeight}
+	if _, exists := s.arrivals[key]; exists {
+		s.mu.Unlock()
+		return nil
+	}
+	s.arrivals[key] = ArrivalInfo{Time: arrivalTime, Count: count}
+	entries := make([]firstArrivalEntry, 0, len(s.arrivals))
+	for k, info := range s.arrivals {
+		entries = append(entries, firstArrivalEntry{
+			Participant: k.Participant,
+			PocHeight:   k.PocHeight,
+			ArrivalTime: info.Time,
+			Count:       info.Count,
+		})
+	}
+	s.mu.Unlock()
+
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("marshal arrivals: %w", err)
+	}
+
+	filePath := s.arrivalsFilePath()
+	tempPath := filePath + ".tmp"
+
+	if err := os.WriteFile(tempPath, data, 0644); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	if err := os.Rename(tempPath, filePath); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("rename to target: %w", err)
+	}
+
+	return nil
+}
+
+func (s *FileBundleStorage) GetFirstArrival(ctx context.Context, participant string, pocHeight int64) (ArrivalInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := participantPocKey{Participant: participant, PocHeight: pocHeight}
+	info, exists := s.arrivals[key]
+	if !exists {
+		return ArrivalInfo{}, ErrArrivalNotFound
+	}
+	return info, nil
+}
+
+func (s *FileBundleStorage) GetAllFirstArrivals(ctx context.Context, pocHeight int64) (map[string]ArrivalInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make(map[string]ArrivalInfo)
+	for key, info := range s.arrivals {
+		if key.PocHeight == pocHeight {
+			result[key.Participant] = info
+		}
+	}
+	return result, nil
+}
+
+func (s *FileBundleStorage) loadObservations() error {
+	filePath := s.observationsFilePath()
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read observations file: %w", err)
+	}
+
+	var observations []FirstArrivalObservation
+	if err := json.Unmarshal(data, &observations); err != nil {
+		return fmt.Errorf("unmarshal observations: %w", err)
+	}
+
+	for _, obs := range observations {
+		key := observationKey{ValidatorAddress: obs.ValidatorAddress, PocHeight: obs.PocHeight}
+		s.observations[key] = obs
+	}
+
+	return nil
+}
+
+func (s *FileBundleStorage) StoreObservation(ctx context.Context, obs FirstArrivalObservation) error {
+	s.mu.Lock()
+	key := observationKey{ValidatorAddress: obs.ValidatorAddress, PocHeight: obs.PocHeight}
+	if _, exists := s.observations[key]; exists {
+		s.mu.Unlock()
+		return nil
+	}
+	s.observations[key] = obs
+
+	observations := make([]FirstArrivalObservation, 0, len(s.observations))
+	for _, o := range s.observations {
+		observations = append(observations, o)
+	}
+	s.mu.Unlock()
+
+	data, err := json.Marshal(observations)
+	if err != nil {
+		return fmt.Errorf("marshal observations: %w", err)
+	}
+
+	filePath := s.observationsFilePath()
+	tempPath := filePath + ".tmp"
+
+	if err := os.WriteFile(tempPath, data, 0644); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	if err := os.Rename(tempPath, filePath); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("rename to target: %w", err)
+	}
+
+	return nil
+}
+
+func (s *FileBundleStorage) GetObservations(ctx context.Context, pocHeight int64) ([]FirstArrivalObservation, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]FirstArrivalObservation, 0)
+	for key, obs := range s.observations {
+		if key.PocHeight == pocHeight {
+			result = append(result, obs)
+		}
+	}
+	return result, nil
 }
 
 func (s *FileBundleStorage) Close() error {

--- a/decentralized-api/poc/propagation/http_transport.go
+++ b/decentralized-api/poc/propagation/http_transport.go
@@ -247,3 +247,97 @@ type ProofsMessage struct {
 	Proofs   []ProofItem `json:"proofs"`
 	From     string      `json:"from,omitempty"`
 }
+
+func (t *HTTPTransport) SendObservation(to string, obs FirstArrivalObservation) error {
+	if to == t.localAddr {
+		return t.handleLocalObservation(obs, t.localAddr)
+	}
+
+	t.mu.RLock()
+	url := t.participantAddrs[to]
+	t.mu.RUnlock()
+
+	if url == "" {
+		return fmt.Errorf("no URL for participant %s", to)
+	}
+
+	payload := &ObservationMessage{
+		Observation: obs,
+		From:        t.localAddr,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal observation: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url+"/v1/propagation/observation", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (t *HTTPTransport) handleLocalObservation(obs FirstArrivalObservation, from string) error {
+	t.mu.RLock()
+	handler := t.receivers[t.localAddr]
+	t.mu.RUnlock()
+
+	if handler == nil {
+		return fmt.Errorf("no local receiver registered")
+	}
+
+	return handler.OnObservation(obs, from)
+}
+
+func (t *HTTPTransport) HandleObservationHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var msg ObservationMessage
+	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+		logging.Warn("HTTPTransport: failed to decode observation", types.PoC, "error", err)
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	t.mu.RLock()
+	handler := t.receivers[t.localAddr]
+	t.mu.RUnlock()
+
+	if handler == nil {
+		http.Error(w, "No receiver registered", http.StatusServiceUnavailable)
+		return
+	}
+
+	from := msg.From
+	if from == "" {
+		from = msg.Observation.ValidatorAddress
+	}
+
+	if err := handler.OnObservation(msg.Observation, from); err != nil {
+		logging.Warn("HTTPTransport: observation handler failed", types.PoC, "error", err)
+		http.Error(w, "Handler error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/decentralized-api/poc/propagation/hybrid_bundle_storage.go
+++ b/decentralized-api/poc/propagation/hybrid_bundle_storage.go
@@ -140,6 +140,71 @@ func (h *HybridBundleStorage) GetProofs(ctx context.Context, bundleID [32]byte) 
 	return h.file.GetProofs(ctx, bundleID)
 }
 
+func (h *HybridBundleStorage) StoreFirstArrival(ctx context.Context, participant string, pocHeight int64, arrivalTime int64, count uint32) error {
+	if pg := h.currentPg(); pg != nil {
+		err := pg.StoreFirstArrival(ctx, participant, pocHeight, arrivalTime, count)
+		if err == nil {
+			return nil
+		}
+		logging.Warn("PostgreSQL store first arrival failed, falling back to file", types.PoC,
+			"participant", participant, "pocHeight", pocHeight, "error", err)
+	}
+	return h.file.StoreFirstArrival(ctx, participant, pocHeight, arrivalTime, count)
+}
+
+func (h *HybridBundleStorage) GetFirstArrival(ctx context.Context, participant string, pocHeight int64) (ArrivalInfo, error) {
+	if pg := h.currentPg(); pg != nil {
+		info, err := pg.GetFirstArrival(ctx, participant, pocHeight)
+		if err == nil {
+			return info, nil
+		}
+		if err != ErrArrivalNotFound {
+			logging.Debug("PostgreSQL get first arrival failed, checking file", types.PoC,
+				"participant", participant, "pocHeight", pocHeight, "error", err)
+		}
+	}
+
+	return h.file.GetFirstArrival(ctx, participant, pocHeight)
+}
+
+func (h *HybridBundleStorage) GetAllFirstArrivals(ctx context.Context, pocHeight int64) (map[string]ArrivalInfo, error) {
+	if pg := h.currentPg(); pg != nil {
+		arrivals, err := pg.GetAllFirstArrivals(ctx, pocHeight)
+		if err == nil {
+			return arrivals, nil
+		}
+		logging.Debug("PostgreSQL get all first arrivals failed, checking file", types.PoC,
+			"pocHeight", pocHeight, "error", err)
+	}
+
+	return h.file.GetAllFirstArrivals(ctx, pocHeight)
+}
+
+func (h *HybridBundleStorage) StoreObservation(ctx context.Context, obs FirstArrivalObservation) error {
+	if pg := h.currentPg(); pg != nil {
+		err := pg.StoreObservation(ctx, obs)
+		if err == nil {
+			return nil
+		}
+		logging.Warn("PostgreSQL store observation failed, falling back to file", types.PoC,
+			"validatorAddress", obs.ValidatorAddress, "pocHeight", obs.PocHeight, "error", err)
+	}
+	return h.file.StoreObservation(ctx, obs)
+}
+
+func (h *HybridBundleStorage) GetObservations(ctx context.Context, pocHeight int64) ([]FirstArrivalObservation, error) {
+	if pg := h.currentPg(); pg != nil {
+		observations, err := pg.GetObservations(ctx, pocHeight)
+		if err == nil {
+			return observations, nil
+		}
+		logging.Debug("PostgreSQL get observations failed, checking file", types.PoC,
+			"pocHeight", pocHeight, "error", err)
+	}
+
+	return h.file.GetObservations(ctx, pocHeight)
+}
+
 func (h *HybridBundleStorage) Close() error {
 	var pgErr, fileErr error
 

--- a/decentralized-api/poc/propagation/mock_transport.go
+++ b/decentralized-api/poc/propagation/mock_transport.go
@@ -38,6 +38,18 @@ func (m *MockTransport) SendHeaderFrom(from string, treeIdx int, to string, h Bu
 	return receiver.OnHeader(h, treeIdx, from)
 }
 
+func (m *MockTransport) SendObservationFrom(from string, to string, obs FirstArrivalObservation) error {
+	m.mu.RLock()
+	receiver := m.receivers[to]
+	m.mu.RUnlock()
+
+	if receiver == nil {
+		return fmt.Errorf("receiver not found: %s", to)
+	}
+
+	return receiver.OnObservation(obs, from)
+}
+
 type PerParticipantSender struct {
 	transport *MockTransport
 	fromAddr  string
@@ -52,6 +64,10 @@ func (m *MockTransport) NewSenderFor(addr string) Sender {
 
 func (p *PerParticipantSender) SendHeader(treeIdx int, to string, h BundleHeader) error {
 	return p.transport.SendHeaderFrom(p.fromAddr, treeIdx, to, h)
+}
+
+func (p *PerParticipantSender) SendObservation(to string, obs FirstArrivalObservation) error {
+	return p.transport.SendObservationFrom(p.fromAddr, to, obs)
 }
 
 type MockPubKeyProvider struct {

--- a/decentralized-api/poc/propagation/postgres_bundle_storage.go
+++ b/decentralized-api/poc/propagation/postgres_bundle_storage.go
@@ -13,11 +13,13 @@ import (
 )
 
 type PostgresBundleStorage struct {
-	pool     *pgxpool.Pool
-	instance string
-	mu       sync.RWMutex
-	bundles  map[[32]byte]BundleHeader
-	proofs   map[[32]byte][]ProofItem
+	pool         *pgxpool.Pool
+	instance     string
+	mu           sync.RWMutex
+	bundles      map[[32]byte]BundleHeader
+	proofs       map[[32]byte][]ProofItem
+	arrivals     map[participantPocKey]ArrivalInfo
+	observations map[observationKey]FirstArrivalObservation
 }
 
 func NewPostgresBundleStorage(ctx context.Context, pool *pgxpool.Pool, instance string) (*PostgresBundleStorage, error) {
@@ -29,10 +31,12 @@ func NewPostgresBundleStorage(ctx context.Context, pool *pgxpool.Pool, instance 
 	}
 
 	s := &PostgresBundleStorage{
-		pool:     pool,
-		instance: instance,
-		bundles:  make(map[[32]byte]BundleHeader),
-		proofs:   make(map[[32]byte][]ProofItem),
+		pool:         pool,
+		instance:     instance,
+		bundles:      make(map[[32]byte]BundleHeader),
+		proofs:       make(map[[32]byte][]ProofItem),
+		arrivals:     make(map[participantPocKey]ArrivalInfo),
+		observations: make(map[observationKey]FirstArrivalObservation),
 	}
 
 	if err := s.ensureSchema(ctx); err != nil {
@@ -67,6 +71,25 @@ func (s *PostgresBundleStorage) ensureSchema(ctx context.Context) error {
 			bundle_id BYTEA NOT NULL,
 			proofs JSONB NOT NULL,
 			PRIMARY KEY (instance, bundle_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS poc_first_arrivals (
+			instance TEXT NOT NULL,
+			participant TEXT NOT NULL,
+			poc_height BIGINT NOT NULL,
+			arrival_time BIGINT NOT NULL,
+			arrival_count INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (instance, participant, poc_height)
+		);
+
+		CREATE TABLE IF NOT EXISTS poc_observations (
+			instance TEXT NOT NULL,
+			validator_address TEXT NOT NULL,
+			poc_height BIGINT NOT NULL,
+			arrivals JSONB NOT NULL,
+			timestamp BIGINT NOT NULL,
+			signature BYTEA NOT NULL,
+			PRIMARY KEY (instance, validator_address, poc_height)
 		);
 	`)
 	return err
@@ -130,8 +153,61 @@ func (s *PostgresBundleStorage) loadBundles(ctx context.Context) error {
 		s.proofs[bundleID] = proofs
 	}
 
-	logging.Info("Loaded bundles from PostgreSQL", types.PoC, "count", len(s.bundles), "proofs", len(s.proofs))
-	return proofsRows.Err()
+	if err := proofsRows.Err(); err != nil {
+		return err
+	}
+
+	arrivalsRows, err := s.pool.Query(ctx, `
+		SELECT participant, poc_height, arrival_time, COALESCE(arrival_count, 0)
+		FROM poc_first_arrivals
+		WHERE instance = $1
+	`, s.instance)
+	if err != nil {
+		return err
+	}
+	defer arrivalsRows.Close()
+
+	for arrivalsRows.Next() {
+		var participant string
+		var pocHeight, arrivalTime int64
+		var count uint32
+		if err := arrivalsRows.Scan(&participant, &pocHeight, &arrivalTime, &count); err != nil {
+			return err
+		}
+		key := participantPocKey{Participant: participant, PocHeight: pocHeight}
+		s.arrivals[key] = ArrivalInfo{Time: arrivalTime, Count: count}
+	}
+
+	if err := arrivalsRows.Err(); err != nil {
+		return err
+	}
+
+	observationsRows, err := s.pool.Query(ctx, `
+		SELECT validator_address, poc_height, arrivals, timestamp, signature
+		FROM poc_observations
+		WHERE instance = $1
+	`, s.instance)
+	if err != nil {
+		return err
+	}
+	defer observationsRows.Close()
+
+	for observationsRows.Next() {
+		var obs FirstArrivalObservation
+		var arrivalsJSON []byte
+		if err := observationsRows.Scan(&obs.ValidatorAddress, &obs.PocHeight, &arrivalsJSON, &obs.Timestamp, &obs.Signature); err != nil {
+			return err
+		}
+		if err := json.Unmarshal(arrivalsJSON, &obs.Arrivals); err != nil {
+			logging.Warn("Failed to unmarshal observation arrivals from PostgreSQL", types.PoC, "error", err)
+			continue
+		}
+		key := observationKey{ValidatorAddress: obs.ValidatorAddress, PocHeight: obs.PocHeight}
+		s.observations[key] = obs
+	}
+
+	logging.Info("Loaded bundles from PostgreSQL", types.PoC, "count", len(s.bundles), "proofs", len(s.proofs), "arrivals", len(s.arrivals), "observations", len(s.observations))
+	return observationsRows.Err()
 }
 
 func (s *PostgresBundleStorage) StoreHeader(ctx context.Context, h BundleHeader) error {
@@ -236,6 +312,93 @@ func (s *PostgresBundleStorage) GetProofs(ctx context.Context, bundleID [32]byte
 		return nil, ErrProofsNotFound
 	}
 	return proofs, nil
+}
+
+func (s *PostgresBundleStorage) StoreFirstArrival(ctx context.Context, participant string, pocHeight int64, arrivalTime int64, count uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := participantPocKey{Participant: participant, PocHeight: pocHeight}
+	if _, exists := s.arrivals[key]; exists {
+		return nil
+	}
+
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO poc_first_arrivals (instance, participant, poc_height, arrival_time, arrival_count)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (instance, participant, poc_height) DO NOTHING
+	`, s.instance, participant, pocHeight, arrivalTime, count)
+	if err != nil {
+		return fmt.Errorf("store first arrival: %w", err)
+	}
+
+	s.arrivals[key] = ArrivalInfo{Time: arrivalTime, Count: count}
+	return nil
+}
+
+func (s *PostgresBundleStorage) GetFirstArrival(ctx context.Context, participant string, pocHeight int64) (ArrivalInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := participantPocKey{Participant: participant, PocHeight: pocHeight}
+	info, exists := s.arrivals[key]
+	if !exists {
+		return ArrivalInfo{}, ErrArrivalNotFound
+	}
+	return info, nil
+}
+
+func (s *PostgresBundleStorage) GetAllFirstArrivals(ctx context.Context, pocHeight int64) (map[string]ArrivalInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make(map[string]ArrivalInfo)
+	for key, info := range s.arrivals {
+		if key.PocHeight == pocHeight {
+			result[key.Participant] = info
+		}
+	}
+	return result, nil
+}
+
+func (s *PostgresBundleStorage) StoreObservation(ctx context.Context, obs FirstArrivalObservation) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := observationKey{ValidatorAddress: obs.ValidatorAddress, PocHeight: obs.PocHeight}
+	if _, exists := s.observations[key]; exists {
+		return nil
+	}
+
+	arrivalsJSON, err := json.Marshal(obs.Arrivals)
+	if err != nil {
+		return fmt.Errorf("marshal arrivals: %w", err)
+	}
+
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO poc_observations (instance, validator_address, poc_height, arrivals, timestamp, signature)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (instance, validator_address, poc_height) DO NOTHING
+	`, s.instance, obs.ValidatorAddress, obs.PocHeight, arrivalsJSON, obs.Timestamp, obs.Signature)
+	if err != nil {
+		return fmt.Errorf("store observation: %w", err)
+	}
+
+	s.observations[key] = obs
+	return nil
+}
+
+func (s *PostgresBundleStorage) GetObservations(ctx context.Context, pocHeight int64) ([]FirstArrivalObservation, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]FirstArrivalObservation, 0)
+	for key, obs := range s.observations {
+		if key.PocHeight == pocHeight {
+			result = append(result, obs)
+		}
+	}
+	return result, nil
 }
 
 func (s *PostgresBundleStorage) Close() error {

--- a/decentralized-api/poc/propagation/propagation_test.go
+++ b/decentralized-api/poc/propagation/propagation_test.go
@@ -334,3 +334,335 @@ func (s *testKeySigner) Sign(msg []byte) ([]byte, error) {
 	privKey := ed25519.PrivKey(s.key)
 	return privKey.Sign(msg)
 }
+
+func TestFirstArrivalTimeRecordedOnce(t *testing.T) {
+	tempDir := t.TempDir()
+	storageDir := filepath.Join(tempDir, "bundles")
+	storage, err := NewFileBundleStorage(storageDir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	participant := "participant1"
+	pocHeight := int64(1000)
+
+	firstTime := int64(1000000)
+	firstCount := uint32(100)
+	err = storage.StoreFirstArrival(ctx, participant, pocHeight, firstTime, firstCount)
+	require.NoError(t, err)
+
+	retrieved, err := storage.GetFirstArrival(ctx, participant, pocHeight)
+	require.NoError(t, err)
+	require.Equal(t, firstTime, retrieved.Time)
+	require.Equal(t, firstCount, retrieved.Count)
+
+	secondTime := int64(2000000)
+	secondCount := uint32(200)
+	err = storage.StoreFirstArrival(ctx, participant, pocHeight, secondTime, secondCount)
+	require.NoError(t, err)
+
+	retrieved, err = storage.GetFirstArrival(ctx, participant, pocHeight)
+	require.NoError(t, err)
+	require.Equal(t, firstTime, retrieved.Time, "first arrival time should not change")
+	require.Equal(t, firstCount, retrieved.Count, "first arrival count should not change")
+}
+
+func TestFirstArrivalTimePersisted(t *testing.T) {
+	tempDir := t.TempDir()
+	storageDir := filepath.Join(tempDir, "bundles")
+
+	storage, err := NewFileBundleStorage(storageDir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	participant := "participant1"
+	pocHeight := int64(1000)
+	arrivalTime := int64(1234567890)
+	arrivalCount := uint32(50)
+
+	err = storage.StoreFirstArrival(ctx, participant, pocHeight, arrivalTime, arrivalCount)
+	require.NoError(t, err)
+
+	storage2, err := NewFileBundleStorage(storageDir)
+	require.NoError(t, err)
+
+	retrieved, err := storage2.GetFirstArrival(ctx, participant, pocHeight)
+	require.NoError(t, err)
+	require.Equal(t, arrivalTime, retrieved.Time, "arrival time should persist across storage reload")
+	require.Equal(t, arrivalCount, retrieved.Count, "arrival count should persist across storage reload")
+}
+
+func TestFirstArrivalTimeMultipleParticipants(t *testing.T) {
+	tempDir := t.TempDir()
+	storageDir := filepath.Join(tempDir, "bundles")
+	storage, err := NewFileBundleStorage(storageDir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	pocHeight := int64(1000)
+
+	arrivals := map[string]ArrivalInfo{
+		"participant1": {Time: 1000000, Count: 10},
+		"participant2": {Time: 2000000, Count: 20},
+		"participant3": {Time: 3000000, Count: 30},
+	}
+
+	for participant, info := range arrivals {
+		err = storage.StoreFirstArrival(ctx, participant, pocHeight, info.Time, info.Count)
+		require.NoError(t, err)
+	}
+
+	for participant, expected := range arrivals {
+		retrieved, err := storage.GetFirstArrival(ctx, participant, pocHeight)
+		require.NoError(t, err)
+		require.Equal(t, expected.Time, retrieved.Time)
+		require.Equal(t, expected.Count, retrieved.Count)
+	}
+
+	diffHeight := int64(2000)
+	err = storage.StoreFirstArrival(ctx, "participant1", diffHeight, 9999999, 999)
+	require.NoError(t, err)
+
+	retrieved, err := storage.GetFirstArrival(ctx, "participant1", pocHeight)
+	require.NoError(t, err)
+	require.Equal(t, arrivals["participant1"].Time, retrieved.Time, "different pocHeight should not affect original")
+}
+
+func TestGetAllFirstArrivals(t *testing.T) {
+	tempDir := t.TempDir()
+	storageDir := filepath.Join(tempDir, "bundles")
+	storage, err := NewFileBundleStorage(storageDir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	pocHeight1 := int64(1000)
+	pocHeight2 := int64(2000)
+
+	err = storage.StoreFirstArrival(ctx, "participant1", pocHeight1, 1000000, 10)
+	require.NoError(t, err)
+	err = storage.StoreFirstArrival(ctx, "participant2", pocHeight1, 2000000, 20)
+	require.NoError(t, err)
+	err = storage.StoreFirstArrival(ctx, "participant3", pocHeight1, 3000000, 30)
+	require.NoError(t, err)
+
+	err = storage.StoreFirstArrival(ctx, "participant1", pocHeight2, 5000000, 50)
+	require.NoError(t, err)
+
+	arrivals, err := storage.GetAllFirstArrivals(ctx, pocHeight1)
+	require.NoError(t, err)
+	require.Len(t, arrivals, 3)
+	require.Equal(t, int64(1000000), arrivals["participant1"].Time)
+	require.Equal(t, uint32(10), arrivals["participant1"].Count)
+	require.Equal(t, int64(2000000), arrivals["participant2"].Time)
+	require.Equal(t, uint32(20), arrivals["participant2"].Count)
+	require.Equal(t, int64(3000000), arrivals["participant3"].Time)
+	require.Equal(t, uint32(30), arrivals["participant3"].Count)
+
+	arrivals2, err := storage.GetAllFirstArrivals(ctx, pocHeight2)
+	require.NoError(t, err)
+	require.Len(t, arrivals2, 1)
+	require.Equal(t, int64(5000000), arrivals2["participant1"].Time)
+	require.Equal(t, uint32(50), arrivals2["participant1"].Count)
+
+	arrivals3, err := storage.GetAllFirstArrivals(ctx, int64(9999))
+	require.NoError(t, err)
+	require.Len(t, arrivals3, 0)
+}
+
+func TestFirstArrivalTimeNotFound(t *testing.T) {
+	tempDir := t.TempDir()
+	storageDir := filepath.Join(tempDir, "bundles")
+	storage, err := NewFileBundleStorage(storageDir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = storage.GetFirstArrival(ctx, "nonexistent", 1000)
+	require.ErrorIs(t, err, ErrArrivalNotFound)
+}
+
+func TestFirstArrivalTimeRecordedOnHeader(t *testing.T) {
+	numParticipants := 3
+	fanout := 2
+
+	participants := make([]string, numParticipants)
+	privKeys := make(map[string][]byte)
+	pubKeys := make(map[string]string)
+
+	for i := 0; i < numParticipants; i++ {
+		addr := fmt.Sprintf("participant%d", i)
+		participants[i] = addr
+
+		privKey := ed25519.GenPrivKey()
+		privKeys[addr] = privKey.Bytes()
+		pubKeys[addr] = base64.StdEncoding.EncodeToString(privKey.PubKey().Bytes())
+	}
+
+	blockHash := sha256.Sum256([]byte("test-block"))
+	pocHeight := int64(1000)
+
+	trees := BuildTrees(participants, blockHash[:], 1, fanout)
+
+	transport := NewMockTransport()
+	pubKeyProvider := NewMockPubKeyProvider()
+	for addr, pubKey := range pubKeys {
+		pubKeyProvider.RegisterKey(addr, pubKey)
+	}
+
+	tempDir := t.TempDir()
+
+	caches := make(map[string]*Cache)
+	bundlers := make(map[string]*Bundler)
+	stores := make(map[string]*artifacts.ArtifactStore)
+
+	for i, addr := range participants {
+		storageDir := filepath.Join(tempDir, addr, "bundles")
+		storage, err := NewFileBundleStorage(storageDir)
+		require.NoError(t, err)
+		cache := NewCache(storage)
+		caches[addr] = cache
+
+		perParticipantSender := transport.NewSenderFor(addr)
+		receiver := NewReceiver(cache, trees, pubKeyProvider, addr, perParticipantSender)
+		transport.RegisterReceiver(addr, receiver)
+
+		storeDir := filepath.Join(tempDir, addr, "store")
+		require.NoError(t, os.MkdirAll(storeDir, 0755))
+		store, err := artifacts.Open(storeDir)
+		require.NoError(t, err)
+		stores[addr] = store
+
+		for j := 0; j < 10; j++ {
+			nonce := int32(i*1000 + j)
+			vector := []byte(fmt.Sprintf("vector-%d-%d", i, j))
+			require.NoError(t, store.Add(nonce, vector))
+		}
+		require.NoError(t, store.Flush())
+
+		bundler := NewBundler(&testKeySigner{key: privKeys[addr]}, cache, trees, transport, addr)
+		bundlers[addr] = bundler
+	}
+
+	sender := participants[0]
+	senderCount := stores[sender].Count()
+	senderRoot := stores[sender].GetRoot()
+	err := bundlers[sender].Publish(pocHeight, sender, pubKeys[sender], senderCount, senderRoot)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	for _, addr := range participants {
+		if addr == sender {
+			continue
+		}
+
+		arrival, err := caches[addr].GetFirstArrival(sender, pocHeight)
+		require.NoError(t, err, "participant %s should have first arrival for sender", addr)
+		require.Greater(t, arrival.Time, int64(0), "arrival time should be positive")
+		require.Equal(t, senderCount, arrival.Count, "arrival count should match sender count")
+	}
+
+	for _, store := range stores {
+		store.Close()
+	}
+}
+
+func TestObservationBroadcastAndForwarding(t *testing.T) {
+	numParticipants := 3
+	fanout := 2
+
+	participants := make([]string, numParticipants)
+	privKeys := make(map[string][]byte)
+	pubKeys := make(map[string]string)
+
+	for i := 0; i < numParticipants; i++ {
+		addr := fmt.Sprintf("validator%d", i)
+		participants[i] = addr
+
+		privKey := ed25519.GenPrivKey()
+		privKeys[addr] = privKey.Bytes()
+		pubKeys[addr] = base64.StdEncoding.EncodeToString(privKey.PubKey().Bytes())
+	}
+
+	blockHash := sha256.Sum256([]byte("test-block"))
+	pocHeight := int64(1000)
+
+	trees := BuildTrees(participants, blockHash[:], 1, fanout)
+
+	transport := NewMockTransport()
+	pubKeyProvider := NewMockPubKeyProvider()
+	for addr, pubKey := range pubKeys {
+		pubKeyProvider.RegisterKey(addr, pubKey)
+	}
+
+	tempDir := t.TempDir()
+
+	caches := make(map[string]*Cache)
+	bundlers := make(map[string]*Bundler)
+
+	for _, addr := range participants {
+		storageDir := filepath.Join(tempDir, addr, "bundles")
+		storage, err := NewFileBundleStorage(storageDir)
+		require.NoError(t, err)
+		cache := NewCache(storage)
+		caches[addr] = cache
+
+		perParticipantSender := transport.NewSenderFor(addr)
+		receiver := NewReceiver(cache, trees, pubKeyProvider, addr, perParticipantSender)
+		transport.RegisterReceiver(addr, receiver)
+
+		bundler := NewBundler(&testKeySigner{key: privKeys[addr]}, cache, trees, perParticipantSender, addr)
+		bundlers[addr] = bundler
+	}
+
+	broadcaster := participants[0]
+	broadcasterCache := caches[broadcaster]
+
+	err := broadcasterCache.StoreFirstArrival("participant_a", pocHeight, 1000, 50)
+	require.NoError(t, err)
+	err = broadcasterCache.StoreFirstArrival("participant_b", pocHeight, 2000, 75)
+	require.NoError(t, err)
+
+	err = bundlers[broadcaster].BroadcastObservation(pocHeight)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	for _, addr := range participants {
+		observations, err := caches[addr].GetObservations(pocHeight)
+		require.NoError(t, err, "participant %s should be able to get observations", addr)
+		require.Len(t, observations, 1, "participant %s should have 1 observation", addr)
+
+		obs := observations[0]
+		require.Equal(t, broadcaster, obs.ValidatorAddress)
+		require.Equal(t, pocHeight, obs.PocHeight)
+		require.Len(t, obs.Arrivals, 2)
+		require.Equal(t, ArrivalInfo{Time: 1000, Count: 50}, obs.Arrivals["participant_a"])
+		require.Equal(t, ArrivalInfo{Time: 2000, Count: 75}, obs.Arrivals["participant_b"])
+	}
+}
+
+func TestReceiverClearProcessedState(t *testing.T) {
+	tempDir := t.TempDir()
+	storageDir := filepath.Join(tempDir, "bundles")
+	storage, err := NewFileBundleStorage(storageDir)
+	require.NoError(t, err)
+	cache := NewCache(storage)
+
+	transport := NewMockTransport()
+	pubKeyProvider := NewMockPubKeyProvider()
+
+	receiver := NewReceiver(cache, nil, pubKeyProvider, "test", transport.NewSenderFor("test"))
+
+	receiver.mu.Lock()
+	receiver.processedHeaders[[32]byte{1}] = true
+	receiver.processedProofs[[32]byte{2}] = true
+	receiver.processedObservations[[32]byte{3}] = true
+	receiver.mu.Unlock()
+
+	receiver.ClearProcessedState()
+
+	receiver.mu.RLock()
+	require.Empty(t, receiver.processedHeaders)
+	require.Empty(t, receiver.processedProofs)
+	require.Empty(t, receiver.processedObservations)
+	receiver.mu.RUnlock()
+}

--- a/decentralized-api/poc/propagation/receiver.go
+++ b/decentralized-api/poc/propagation/receiver.go
@@ -19,10 +19,12 @@ type Receiver struct {
 	myAddr   string
 	sender   Sender
 
-	mu               sync.RWMutex
-	processedHeaders map[[32]byte]bool
-	pendingHeaders   map[[32]byte]*BundleHeader
-	lastHeaderTime   map[[32]byte]time.Time
+	mu                    sync.RWMutex
+	processedHeaders      map[[32]byte]bool
+	processedProofs       map[[32]byte]bool
+	processedObservations map[[32]byte]bool
+	pendingHeaders        map[[32]byte]*BundleHeader
+	lastHeaderTime        map[[32]byte]time.Time
 }
 
 type PubKeyProvider interface {
@@ -31,14 +33,16 @@ type PubKeyProvider interface {
 
 func NewReceiver(cache *Cache, trees []*Tree, verifier PubKeyProvider, myAddr string, sender Sender) *Receiver {
 	return &Receiver{
-		cache:            cache,
-		trees:            trees,
-		verifier:         verifier,
-		myAddr:           myAddr,
-		sender:           sender,
-		processedHeaders: make(map[[32]byte]bool),
-		pendingHeaders:   make(map[[32]byte]*BundleHeader),
-		lastHeaderTime:   make(map[[32]byte]time.Time),
+		cache:                 cache,
+		trees:                 trees,
+		verifier:              verifier,
+		myAddr:                myAddr,
+		sender:                sender,
+		processedHeaders:      make(map[[32]byte]bool),
+		processedProofs:       make(map[[32]byte]bool),
+		processedObservations: make(map[[32]byte]bool),
+		pendingHeaders:        make(map[[32]byte]*BundleHeader),
+		lastHeaderTime:        make(map[[32]byte]time.Time),
 	}
 }
 
@@ -94,6 +98,18 @@ func (r *Receiver) OnHeader(h BundleHeader, treeIdx int, from string) error {
 		return fmt.Errorf("store header: %w", err)
 	}
 
+	arrivalTime := time.Now().UnixMilli()
+	arrivalCount := h.Count
+	go func() {
+		if err := r.cache.StoreFirstArrival(h.Participant, h.PocHeight, arrivalTime, arrivalCount); err != nil {
+			logging.Debug("Receiver: first arrival already recorded or error", types.PoC,
+				"participant", h.Participant, "pocHeight", h.PocHeight, "error", err)
+		} else {
+			logging.Info("Receiver: recorded first arrival time", types.PoC,
+				"participant", h.Participant, "pocHeight", h.PocHeight, "arrivalTime", arrivalTime, "count", arrivalCount)
+		}
+	}()
+
 	r.processedHeaders[h.BundleID] = true
 	r.pendingHeaders[h.BundleID] = &h
 	r.lastHeaderTime[h.BundleID] = time.Now()
@@ -145,9 +161,16 @@ func (r *Receiver) OnProofs(bundleID [32]byte, proofs []ProofItem, from string) 
 		"receiver", r.myAddr, "from", from, "bundleID", fmt.Sprintf("%x", bundleID[:8]),
 		"proofCount", len(proofs))
 
-	r.mu.RLock()
+	r.mu.Lock()
+	if r.processedProofs[bundleID] {
+		r.mu.Unlock()
+		logging.Debug("Receiver: duplicate proofs ignored (already processed)", types.PoC,
+			"receiver", r.myAddr, "bundleID", fmt.Sprintf("%x", bundleID[:8]))
+		return nil
+	}
+	r.processedProofs[bundleID] = true
 	trees := r.trees
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	go func() {
 		if err := r.cache.StoreProofs(context.Background(), bundleID, proofs); err != nil {
@@ -207,4 +230,95 @@ func (r *Receiver) SetTrees(trees []*Tree) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.trees = trees
+}
+
+func (r *Receiver) ClearProcessedState() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.processedHeaders = make(map[[32]byte]bool)
+	r.processedProofs = make(map[[32]byte]bool)
+	r.processedObservations = make(map[[32]byte]bool)
+	r.pendingHeaders = make(map[[32]byte]*BundleHeader)
+	r.lastHeaderTime = make(map[[32]byte]time.Time)
+}
+
+func (r *Receiver) OnObservation(obs FirstArrivalObservation, from string) error {
+	logging.Info("Receiver: received observation", types.PoC,
+		"receiver", r.myAddr, "from", from, "validator", obs.ValidatorAddress,
+		"pocHeight", obs.PocHeight, "arrivals", len(obs.Arrivals))
+
+	obsID := MakeObservationID(obs.ValidatorAddress, obs.PocHeight)
+
+	r.mu.Lock()
+	if r.processedObservations[obsID] {
+		r.mu.Unlock()
+		logging.Debug("Receiver: duplicate observation ignored (already processed)", types.PoC,
+			"receiver", r.myAddr, "validator", obs.ValidatorAddress, "pocHeight", obs.PocHeight)
+		return nil
+	}
+	r.processedObservations[obsID] = true
+	trees := r.trees
+	r.mu.Unlock()
+
+	pubKey, err := r.verifier.GetPubKey(obs.ValidatorAddress)
+	if err != nil {
+		logging.Warn("Receiver: failed to get public key for observation", types.PoC,
+			"validatorAddress", obs.ValidatorAddress, "error", err)
+		return fmt.Errorf("get pubkey: %w", err)
+	}
+
+	if err := VerifyObservation(obs, pubKey); err != nil {
+		logging.Warn("Receiver: observation signature verification failed", types.PoC,
+			"validatorAddress", obs.ValidatorAddress, "error", err)
+		return fmt.Errorf("verify observation: %w", err)
+	}
+
+	if err := r.cache.StoreObservation(obs); err != nil {
+		logging.Warn("Receiver: failed to store observation", types.PoC,
+			"validatorAddress", obs.ValidatorAddress, "error", err)
+		return fmt.Errorf("store observation: %w", err)
+	}
+
+	logging.Info("Receiver: observation stored", types.PoC,
+		"receiver", r.myAddr, "validator", obs.ValidatorAddress, "pocHeight", obs.PocHeight)
+
+	go r.forwardObservationAllTrees(obs, trees)
+
+	return nil
+}
+
+func (r *Receiver) forwardObservationAllTrees(obs FirstArrivalObservation, trees []*Tree) {
+	obsSender, ok := r.sender.(ObservationSender)
+	if !ok {
+		return
+	}
+
+	var wg sync.WaitGroup
+
+	for _, tree := range trees {
+		node := tree.GetNode(r.myAddr)
+		if node == nil || len(node.Children) == 0 {
+			continue
+		}
+
+		logging.Info("Receiver: forwarding observation to children", types.PoC,
+			"forwarder", r.myAddr, "validator", obs.ValidatorAddress,
+			"tree", tree.Index, "children", len(node.Children))
+
+		for _, child := range node.Children {
+			wg.Add(1)
+			go func(childAddr string) {
+				defer wg.Done()
+				if err := obsSender.SendObservation(childAddr, obs); err != nil {
+					logging.Warn("Receiver: failed to forward observation to child", types.PoC,
+						"forwarder", r.myAddr, "child", childAddr, "error", err)
+				} else {
+					logging.Debug("Receiver: forwarded observation to child", types.PoC,
+						"forwarder", r.myAddr, "child", childAddr)
+				}
+			}(child.Address)
+		}
+	}
+
+	wg.Wait()
 }

--- a/decentralized-api/poc/propagation/storage.go
+++ b/decentralized-api/poc/propagation/storage.go
@@ -6,8 +6,9 @@ import (
 )
 
 var (
-	ErrBundleNotFound = errors.New("bundle not found")
-	ErrProofsNotFound = errors.New("proofs not found")
+	ErrBundleNotFound  = errors.New("bundle not found")
+	ErrProofsNotFound  = errors.New("proofs not found")
+	ErrArrivalNotFound = errors.New("first arrival not found")
 )
 
 type ProofItem struct {
@@ -26,5 +27,22 @@ type BundleStorage interface {
 	StoreProofs(ctx context.Context, bundleID [32]byte, proofs []ProofItem) error
 	GetProofs(ctx context.Context, bundleID [32]byte) ([]ProofItem, error)
 
+	StoreFirstArrival(ctx context.Context, participant string, pocHeight int64, arrivalTime int64, count uint32) error
+	GetFirstArrival(ctx context.Context, participant string, pocHeight int64) (ArrivalInfo, error)
+	GetAllFirstArrivals(ctx context.Context, pocHeight int64) (map[string]ArrivalInfo, error)
+
+	StoreObservation(ctx context.Context, obs FirstArrivalObservation) error
+	GetObservations(ctx context.Context, pocHeight int64) ([]FirstArrivalObservation, error)
+
 	Close() error
+}
+
+type participantPocKey struct {
+	Participant string
+	PocHeight   int64
+}
+
+type observationKey struct {
+	ValidatorAddress string
+	PocHeight        int64
 }

--- a/decentralized-api/poc/propagation/transport.go
+++ b/decentralized-api/poc/propagation/transport.go
@@ -4,7 +4,12 @@ type Sender interface {
 	SendHeader(treeIdx int, to string, h BundleHeader) error
 }
 
+type ObservationSender interface {
+	SendObservation(to string, obs FirstArrivalObservation) error
+}
+
 type ReceiverHandler interface {
 	OnHeader(h BundleHeader, treeIdx int, from string) error
 	OnProofs(bundleID [32]byte, proofs []ProofItem, from string) error
+	OnObservation(obs FirstArrivalObservation, from string) error
 }

--- a/decentralized-api/poc/propagation/types.go
+++ b/decentralized-api/poc/propagation/types.go
@@ -1,0 +1,149 @@
+package propagation
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+
+	"github.com/cometbft/cometbft/crypto/ed25519"
+)
+
+type ArrivalInfo struct {
+	Time  int64  `json:"time"`
+	Count uint32 `json:"count"`
+}
+
+type FirstArrivalObservation struct {
+	ValidatorAddress string                 `json:"validator_address"`
+	PocHeight        int64                  `json:"poc_height"`
+	Arrivals         map[string]ArrivalInfo `json:"arrivals"`
+	Timestamp        int64                  `json:"timestamp"`
+	Signature        []byte                 `json:"signature"`
+}
+
+type firstArrivalObservationJSON struct {
+	ValidatorAddress string                 `json:"validator_address"`
+	PocHeight        int64                  `json:"poc_height"`
+	Arrivals         map[string]ArrivalInfo `json:"arrivals"`
+	Timestamp        int64                  `json:"timestamp"`
+	Signature        string                 `json:"signature"`
+}
+
+func (o FirstArrivalObservation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(firstArrivalObservationJSON{
+		ValidatorAddress: o.ValidatorAddress,
+		PocHeight:        o.PocHeight,
+		Arrivals:         o.Arrivals,
+		Timestamp:        o.Timestamp,
+		Signature:        hex.EncodeToString(o.Signature),
+	})
+}
+
+func (o *FirstArrivalObservation) UnmarshalJSON(data []byte) error {
+	var j firstArrivalObservationJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+
+	sig, err := hex.DecodeString(j.Signature)
+	if err != nil {
+		return err
+	}
+
+	o.ValidatorAddress = j.ValidatorAddress
+	o.PocHeight = j.PocHeight
+	o.Arrivals = j.Arrivals
+	o.Timestamp = j.Timestamp
+	o.Signature = sig
+
+	return nil
+}
+
+func MakeObservationID(validatorAddress string, pocHeight int64) [32]byte {
+	h := sha256.New()
+	h.Write([]byte(validatorAddress))
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(pocHeight))
+	h.Write(buf[:])
+	return sha256.Sum256(h.Sum(nil))
+}
+
+func observationSigningBytes(o FirstArrivalObservation) []byte {
+	buf := bytes.NewBuffer(nil)
+	buf.WriteString(o.ValidatorAddress)
+
+	var tmp [8]byte
+	binary.BigEndian.PutUint64(tmp[:], uint64(o.PocHeight))
+	buf.Write(tmp[:])
+
+	participants := make([]string, 0, len(o.Arrivals))
+	for p := range o.Arrivals {
+		participants = append(participants, p)
+	}
+	for i := 0; i < len(participants); i++ {
+		for j := i + 1; j < len(participants); j++ {
+			if participants[i] > participants[j] {
+				participants[i], participants[j] = participants[j], participants[i]
+			}
+		}
+	}
+	for _, p := range participants {
+		buf.WriteString(p)
+		arrival := o.Arrivals[p]
+		binary.BigEndian.PutUint64(tmp[:], uint64(arrival.Time))
+		buf.Write(tmp[:])
+		binary.BigEndian.PutUint32(tmp[:4], arrival.Count)
+		buf.Write(tmp[:4])
+	}
+
+	binary.BigEndian.PutUint64(tmp[:], uint64(o.Timestamp))
+	buf.Write(tmp[:])
+
+	return buf.Bytes()
+}
+
+func SignObservation(o FirstArrivalObservation, privKey []byte) ([]byte, error) {
+	if len(privKey) != 64 {
+		return nil, errors.New("invalid ed25519 private key length")
+	}
+	msg := observationSigningBytes(o)
+	key := ed25519.PrivKey(privKey)
+	return key.Sign(msg)
+}
+
+func SignObservationWith(o FirstArrivalObservation, signer HeaderSigner) ([]byte, error) {
+	return signer.Sign(observationSigningBytes(o))
+}
+
+func VerifyObservation(o FirstArrivalObservation, base64PubKey string) error {
+	if o.Signature == nil {
+		return errors.New("signature missing")
+	}
+
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(base64PubKey)
+	if err != nil {
+		return err
+	}
+
+	if len(pubKeyBytes) != 32 {
+		return errors.New("invalid ed25519 public key length")
+	}
+
+	msg := observationSigningBytes(o)
+	pubKey := ed25519.PubKey(pubKeyBytes)
+
+	if !pubKey.VerifySignature(msg, o.Signature) {
+		return errors.New("signature verification failed")
+	}
+
+	return nil
+}
+
+type ObservationMessage struct {
+	Observation FirstArrivalObservation `json:"observation"`
+	From        string                  `json:"from,omitempty"`
+}

--- a/proposals/poc/dev/multi-tree-propagation-observation-consensus.md
+++ b/proposals/poc/dev/multi-tree-propagation-observation-consensus.md
@@ -1,0 +1,275 @@
+# Multi-Tree Propagation - Observation & Consensus Layer
+
+## Status
+
+**Implemented** - Unit tests and integration tests pass.
+
+## Overview
+
+Builds on the multi-tree propagation system (see `multi-tree-propagation.md` and `multi-tree-propagation-phase1.md`) to add a consensus mechanism. Instead of each node submitting its own local artifact count on-chain, validators first exchange observations of what they saw, then compute a majority-agreed count and submit that.
+
+---
+
+## Problem
+
+In the base propagation system, each participant publishes headers with their artifact count and then submits that count on-chain independently. If different validators see different counts (due to propagation delays or network issues), there's no agreement on the canonical count. A node could also lie about its count with no way for others to contest.
+
+## Solution
+
+Three new concepts layered on top of header propagation:
+
+1. **First Arrival Tracking** - Each node records the timestamp and count from the first header it receives per participant per PoC height.
+
+2. **Observation Broadcasting** - At a computed block height, each validator signs and broadcasts its full arrival map to all peers via the overlay trees.
+
+3. **Consensus Calculation** - For each participant, find the highest count where a majority of validators saw at least that count before a deadline.
+
+On-chain commits now use the consensus-agreed count.
+
+---
+
+## Data Structures
+
+### ArrivalInfo
+
+Recorded when a node first receives a header from a participant:
+
+```go
+type ArrivalInfo struct {
+    Time  int64   // Unix timestamp (ms) when first heard
+    Count uint32  // Count in first header received
+}
+```
+
+Once stored, these never change. The node also stores its own arrival when it publishes its own header.
+
+### FirstArrivalObservation
+
+Signed attestation of what a validator saw:
+
+```go
+type FirstArrivalObservation struct {
+    ValidatorAddress string                 // Who created this observation
+    PocHeight        int64                  // PoC stage
+    Arrivals         map[string]ArrivalInfo // participant -> first arrival
+    Timestamp        int64                  // When this observation was created
+    Signature        []byte                 // ed25519 signature
+}
+```
+
+Signed over a canonical byte serialization of all fields (participants sorted alphabetically). Verified on receipt using the validator's public key from chain state.
+
+---
+
+## Consensus Algorithm
+
+`CalculateConsensus()` in `consensus.go`:
+
+```
+Input:
+  - observations: []FirstArrivalObservation (from all validators)
+  - bundles: []BundleHeader (published headers for this height)
+  - deadline: int64 (timestamp cutoff)
+
+For each participant:
+  1. Get all published headers, sorted by count ascending
+  2. For each header count (low to high):
+     - Count how many validators saw >= that count before the deadline
+     - If count >= majority (n/2 + 1), record it as the agreed count
+  3. The highest count that still has majority agreement wins
+
+Output: map[participant]ConsensusResult{AgreedCount, TotalValidators, AgreeingCount}
+```
+
+The agreed count is always <= the actual published count, since it requires majority attestation.
+
+### Deadline Derivation
+
+When computing consensus for on-chain commits, the deadline is derived from the observations themselves: the minimum `Timestamp` across all received observations. This avoids the block-height-to-wallclock-time conversion problem.
+
+---
+
+## Commit Flow
+
+Previously: `maybeSubmitCommit()` published headers and submitted on-chain commits in the same method.
+
+Now split into two phases:
+
+### Phase 1: Header Publishing (during PoCGenerate / PoCGenerateWindDown)
+
+`maybePublishHeaders()`:
+- Publishes headers and proofs via propagation trees
+- Stores own arrival time
+- Tracks last published state to avoid redundant publishes
+- Runs every tick during PoCGenerate phase
+
+### Phase 2: Consensus Commit (during exchange window)
+
+`maybeSubmitConsensusCommit()`:
+- Queries `ConsensusCalculator` for the agreed count for self
+- If consensus > 0, submits `MsgPoCV2StoreCommit` with the agreed count
+- If no consensus yet, logs and retries on next tick
+- Once submitted, marks height as done (no duplicate submissions)
+- If propagation is disabled, skips committing entirely
+
+---
+
+## Observation Broadcasting Timing
+
+Computed in `new_block_dispatcher.go`:
+
+```go
+observationBroadcastHeight := PoCExchangeDeadline - DefaultObservationBuffer(10)
+```
+
+Capped at `EndOfPoCGeneration - 1` (must fire before generation phase ends) and floored at `PocStartBlockHeight + 1` (must be after generation starts).
+
+In production (17280 blocks/epoch), this gives ~50 seconds between observation broadcast and the exchange deadline.
+
+### Broadcast Path
+
+Each validator:
+1. Collects all first arrivals from cache
+2. Signs the observation
+3. Stores own observation locally
+4. Sends to all tree roots (except self)
+5. Sends to own children in trees where it is root
+
+Receivers verify the signature, store the observation, and forward to their children.
+
+---
+
+## Storage
+
+### New BundleStorage Interface Methods
+
+```go
+StoreFirstArrival(ctx, participant, pocHeight, arrivalTime, count) error
+GetFirstArrival(ctx, participant, pocHeight) (ArrivalInfo, error)
+GetAllFirstArrivals(ctx, pocHeight) (map[string]ArrivalInfo, error)
+StoreObservation(ctx, obs FirstArrivalObservation) error
+GetObservations(ctx, pocHeight) ([]FirstArrivalObservation, error)
+```
+
+Implemented in all three backends:
+
+- **FileBundleStorage**: JSON files (`arrivals.json`, `observations.json`), atomic writes via temp+rename
+- **PostgresBundleStorage**: Two new tables (below), in-memory cache backed by DB
+- **HybridBundleStorage**: Tries Postgres first, falls back to file
+
+### Postgres Schema
+
+```sql
+CREATE TABLE poc_first_arrivals (
+    instance TEXT NOT NULL,
+    participant TEXT NOT NULL,
+    poc_height BIGINT NOT NULL,
+    arrival_time BIGINT NOT NULL,
+    arrival_count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (instance, participant, poc_height)
+);
+
+CREATE TABLE poc_observations (
+    instance TEXT NOT NULL,
+    validator_address TEXT NOT NULL,
+    poc_height BIGINT NOT NULL,
+    arrivals JSONB NOT NULL,
+    timestamp BIGINT NOT NULL,
+    signature BYTEA NOT NULL,
+    PRIMARY KEY (instance, validator_address, poc_height)
+);
+```
+
+---
+
+## HTTP Endpoints
+
+### Protocol (node-to-node)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/v1/propagation/observation` | Receive observation from peer |
+
+### Diagnostic (query only)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/v1/propagation/first-arrivals/:poc_height` | Query local arrival records |
+| `GET` | `/v1/propagation/observations/:poc_height` | Query stored observations |
+| `GET` | `/v1/propagation/consensus/:poc_height?deadline=X` | Calculate consensus on demand |
+
+The diagnostic endpoints are not used by the protocol. They exist for integration testing and runtime inspection.
+
+---
+
+## Transport
+
+New `ObservationSender` interface alongside existing `Sender`:
+
+```go
+type ObservationSender interface {
+    SendObservation(to string, obs FirstArrivalObservation) error
+}
+```
+
+Implemented by `HTTPTransport`, `MockTransport`, and `PerParticipantSender`.
+
+The `ReceiverHandler` interface gains `OnObservation()`:
+
+```go
+type ReceiverHandler interface {
+    OnHeader(h BundleHeader, treeIdx int, from string) error
+    OnProofs(bundleID [32]byte, proofs []ProofItem, from string) error
+    OnObservation(obs FirstArrivalObservation, from string) error
+}
+```
+
+### Deduplication
+
+The receiver tracks three separate processed-message maps:
+- `processedHeaders` - by bundle ID
+- `processedProofs` - by bundle ID
+- `processedObservations` - by `SHA256(validatorAddress || pocHeight)`
+
+All cleared at epoch boundary via `ClearProcessedState()`.
+
+---
+
+## Tests
+
+### Unit Tests
+
+`consensus_test.go` - Tests for `CalculateConsensus()`:
+- Single validator trivially agrees with itself
+- Three validators with majority agreement
+- Mixed arrival times with deadline filtering
+- No arrivals yields zero consensus
+- Multiple count levels (selects highest with majority)
+
+### Integration Tests
+
+`PropagationTests.kt` - Two new test cases:
+
+**First arrival time tracking**: 3-node cluster, verifies all nodes record arrival times for other participants, verifies times are static (don't change on re-query).
+
+**Consensus calculation**: 3-node cluster, verifies observations are broadcast and received, consensus produces positive counts bounded by actual artifact counts, results are present across all nodes.
+
+---
+
+## Known Limitations
+
+**No canonical observation set**: Different validators may compute consensus over different subsets of observations if some observations arrive late. In practice, the 50-second window in production is generous for small payloads to converge. For guaranteed correctness, observation commitments would need to be anchored on-chain (see below).
+
+**No fallback**: If consensus doesn't form before the exchange window closes, the participant misses that epoch. There's no fallback to submitting the local count.
+
+### Future: On-Chain Observation Anchoring
+
+To guarantee all validators compute over the same observation set, each validator could post a hash of their observation on-chain during the exchange window. The chain would define the canonical set. Validators would then compute consensus using exactly the observations whose hashes appeared on-chain. The bulk observation data stays off-chain, fetched from peers using the hash as key.
+
+---
+
+## Related Documents
+
+- `multi-tree-propagation.md` - Architecture overview
+- `multi-tree-propagation-phase1.md` - Phase 1 implementation (trees, headers, transport)
+- `offchain.md` - Off-chain PoC artifacts proposal

--- a/testermint/src/main/kotlin/ApplicationAPI.kt
+++ b/testermint/src/main/kotlin/ApplicationAPI.kt
@@ -469,6 +469,25 @@ data class ApplicationAPI(
         get(url, "v1/propagation/proofs/$bundleId")
     }
 
+    fun getPropagationFirstArrivals(pocHeight: Long): PropagationFirstArrivalsResponse = wrapLog("GetPropagationFirstArrivals", true) {
+        val url = urlFor(SERVER_TYPE_PUBLIC)
+        get(url, "v1/propagation/first-arrivals/$pocHeight")
+    }
+
+    fun getPropagationObservations(pocHeight: Long): PropagationObservationsResponse = wrapLog("GetPropagationObservations", true) {
+        val url = urlFor(SERVER_TYPE_PUBLIC)
+        get(url, "v1/propagation/observations/$pocHeight")
+    }
+
+    fun getPropagationConsensus(pocHeight: Long, deadline: Long? = null): PropagationConsensusResponse = wrapLog("GetPropagationConsensus", true) {
+        val url = urlFor(SERVER_TYPE_PUBLIC)
+        val path = if (deadline != null) {
+            "v1/propagation/consensus/$pocHeight?deadline=$deadline"
+        } else {
+            "v1/propagation/consensus/$pocHeight"
+        }
+        get(url, path)
+    }
 
 }
 

--- a/testermint/src/main/kotlin/data/propagation.kt
+++ b/testermint/src/main/kotlin/data/propagation.kt
@@ -51,3 +51,67 @@ data class PropagationProofsResponse(
     val bundleId: String,
     val proofs: List<PropagationProofItem>
 )
+
+/**
+ * Info about when and what count was first seen for a participant
+ */
+data class ArrivalInfo(
+    val time: Long,
+    val count: Long
+)
+
+/**
+ * Response from GET /v1/propagation/first-arrivals/{poc_height}
+ */
+data class PropagationFirstArrivalsResponse(
+    @SerializedName("poc_height")
+    val pocHeight: Long,
+    val arrivals: Map<String, ArrivalInfo>
+)
+
+/**
+ * Observation of first arrival times from a validator
+ */
+data class FirstArrivalObservation(
+    @SerializedName("validator_address")
+    val validatorAddress: String,
+    @SerializedName("poc_height")
+    val pocHeight: Long,
+    val arrivals: Map<String, ArrivalInfo>,
+    val timestamp: Long,
+    val signature: String
+)
+
+/**
+ * Response from GET /v1/propagation/observations/{poc_height}
+ */
+data class PropagationObservationsResponse(
+    @SerializedName("poc_height")
+    val pocHeight: Long,
+    val observations: List<FirstArrivalObservation>
+)
+
+/**
+ * Consensus result for a single participant
+ */
+data class ConsensusResult(
+    @SerializedName("poc_height")
+    val pocHeight: Long,
+    val participant: String,
+    @SerializedName("agreed_count")
+    val agreedCount: Long,
+    @SerializedName("total_validators")
+    val totalValidators: Int,
+    @SerializedName("agreeing_count")
+    val agreeingCount: Int
+)
+
+/**
+ * Response from GET /v1/propagation/consensus/{poc_height}
+ */
+data class PropagationConsensusResponse(
+    @SerializedName("poc_height")
+    val pocHeight: Long,
+    val deadline: Long,
+    val consensus: Map<String, ConsensusResult>
+)

--- a/testermint/src/test/kotlin/PropagationTests.kt
+++ b/testermint/src/test/kotlin/PropagationTests.kt
@@ -294,4 +294,260 @@ class PropagationTests : TestermintTest() {
         Logger.info("Total bundles propagated: $totalBundles")
         Logger.info("Propagation handled by bundler and tree manager - no manual intervention")
     }
+
+    @Test
+    fun `propagation - first arrival times are recorded for each participant`() {
+        logSection("=== TEST: First Arrival Time Tracking ===")
+
+        val (cluster, genesis) = initCluster(
+            joinCount = 2,
+            reboot = true
+        )
+
+        val join1 = cluster.joinPairs[0]
+        val join2 = cluster.joinPairs[1]
+
+        logSection("Cluster Initialized with 3 participants")
+        Logger.info("  Genesis: ${genesis.node.getColdAddress()}")
+        Logger.info("  Join1: ${join1.node.getColdAddress()}")
+        Logger.info("  Join2: ${join2.node.getColdAddress()}")
+
+        genesis.setPocWeight(10)
+        join1.setPocWeight(10)
+        join2.setPocWeight(10)
+
+        logSection("Waiting for PoC generation phase")
+        genesis.waitForStage(EpochStage.START_OF_POC)
+        genesis.node.waitForNextBlock(5)
+
+        val epochData = genesis.getEpochData()
+        val pocHeight = epochData.latestEpoch.pocStartBlockHeight
+
+        logSection("Verifying all participants generated artifacts")
+        val genesisState = genesis.api.getPocArtifactsState(pocHeight)
+        val join1State = join1.api.getPocArtifactsState(pocHeight)
+        val join2State = join2.api.getPocArtifactsState(pocHeight)
+
+        assertThat(genesisState.count).isGreaterThan(0)
+        assertThat(join1State.count).isGreaterThan(0)
+        assertThat(join2State.count).isGreaterThan(0)
+
+        logSection("Waiting for PoC exchange phase (propagation occurs)")
+        genesis.waitForStage(EpochStage.POC_EXCHANGE_DEADLINE)
+        genesis.node.waitForNextBlock(5)
+
+        logSection("Querying first arrival times from all nodes")
+        val genesisArrivals = genesis.api.getPropagationFirstArrivals(pocHeight)
+        val join1Arrivals = join1.api.getPropagationFirstArrivals(pocHeight)
+        val join2Arrivals = join2.api.getPropagationFirstArrivals(pocHeight)
+
+        Logger.info("Genesis recorded first arrivals for ${genesisArrivals.arrivals.size} participants")
+        genesisArrivals.arrivals.forEach { (participant, info) ->
+            Logger.info("  $participant -> time=${info.time}, count=${info.count}")
+        }
+
+        Logger.info("Join1 recorded first arrivals for ${join1Arrivals.arrivals.size} participants")
+        join1Arrivals.arrivals.forEach { (participant, info) ->
+            Logger.info("  $participant -> time=${info.time}, count=${info.count}")
+        }
+
+        Logger.info("Join2 recorded first arrivals for ${join2Arrivals.arrivals.size} participants")
+        join2Arrivals.arrivals.forEach { (participant, info) ->
+            Logger.info("  $participant -> time=${info.time}, count=${info.count}")
+        }
+
+        val genesisAddr = genesis.node.getColdAddress()
+        val join1Addr = join1.node.getColdAddress()
+        val join2Addr = join2.node.getColdAddress()
+
+        logSection("Verifying first arrival times are recorded")
+
+        assertThat(genesisArrivals.arrivals).containsKeys(join1Addr, join2Addr)
+            .describedAs("Genesis should have first arrival times for join1 and join2")
+        assertThat(join1Arrivals.arrivals).containsKeys(genesisAddr, join2Addr)
+            .describedAs("Join1 should have first arrival times for genesis and join2")
+        assertThat(join2Arrivals.arrivals).containsKeys(genesisAddr, join1Addr)
+            .describedAs("Join2 should have first arrival times for genesis and join1")
+
+        logSection("Verifying arrival times are positive (valid timestamps)")
+        genesisArrivals.arrivals.values.forEach { info ->
+            assertThat(info.time).isGreaterThan(0)
+        }
+        join1Arrivals.arrivals.values.forEach { info ->
+            assertThat(info.time).isGreaterThan(0)
+        }
+        join2Arrivals.arrivals.values.forEach { info ->
+            assertThat(info.time).isGreaterThan(0)
+        }
+
+        logSection("Verifying arrival times are consistent (static timer)")
+        genesis.node.waitForNextBlock(3)
+
+        val genesisArrivals2 = genesis.api.getPropagationFirstArrivals(pocHeight)
+
+        genesisArrivals.arrivals.forEach { (participant, originalInfo) ->
+            val newInfo = genesisArrivals2.arrivals[participant]
+            assertThat(newInfo?.time).isEqualTo(originalInfo.time)
+                .describedAs("First arrival time for $participant should not change (static timer)")
+            assertThat(newInfo?.count).isEqualTo(originalInfo.count)
+                .describedAs("First arrival count for $participant should not change (static timer)")
+        }
+
+        logSection("Test Complete - First arrival times recorded and static")
+        Logger.info("All nodes recorded first arrival times for other participants")
+        Logger.info("Arrival times remain constant (static timer verified)")
+    }
+
+    @Test
+    fun `propagation - consensus calculates correct agreed counts`() {
+        logSection("=== TEST: Consensus Calculation ===")
+
+        val (cluster, genesis) = initCluster(
+            joinCount = 2,
+            reboot = true
+        )
+
+        val join1 = cluster.joinPairs[0]
+        val join2 = cluster.joinPairs[1]
+
+        logSection("Cluster Initialized with 3 participants")
+        Logger.info("  Genesis: ${genesis.node.getColdAddress()}")
+        Logger.info("  Join1: ${join1.node.getColdAddress()}")
+        Logger.info("  Join2: ${join2.node.getColdAddress()}")
+
+        genesis.setPocWeight(10)
+        join1.setPocWeight(10)
+        join2.setPocWeight(10)
+
+        logSection("Waiting for PoC generation phase")
+        genesis.waitForStage(EpochStage.START_OF_POC)
+        genesis.node.waitForNextBlock(5)
+
+        val epochData = genesis.getEpochData()
+        val pocHeight = epochData.latestEpoch.pocStartBlockHeight
+
+        logSection("Verifying all participants generated artifacts")
+        val genesisState = genesis.api.getPocArtifactsState(pocHeight)
+        val join1State = join1.api.getPocArtifactsState(pocHeight)
+        val join2State = join2.api.getPocArtifactsState(pocHeight)
+
+        Logger.info("Genesis artifacts: count=${genesisState.count}")
+        Logger.info("Join1 artifacts: count=${join1State.count}")
+        Logger.info("Join2 artifacts: count=${join2State.count}")
+
+        assertThat(genesisState.count).isGreaterThan(0)
+        assertThat(join1State.count).isGreaterThan(0)
+        assertThat(join2State.count).isGreaterThan(0)
+
+        logSection("Waiting for PoC exchange deadline (observations broadcast)")
+        genesis.waitForStage(EpochStage.POC_EXCHANGE_DEADLINE)
+        genesis.node.waitForNextBlock(10)
+
+        val genesisAddr = genesis.node.getColdAddress()
+        val join1Addr = join1.node.getColdAddress()
+        val join2Addr = join2.node.getColdAddress()
+
+        logSection("Querying observations from all nodes")
+        val genesisObs = genesis.api.getPropagationObservations(pocHeight)
+        val join1Obs = join1.api.getPropagationObservations(pocHeight)
+        val join2Obs = join2.api.getPropagationObservations(pocHeight)
+
+        Logger.info("Genesis has ${genesisObs.observations.size} observations")
+        genesisObs.observations.forEach { obs ->
+            Logger.info("  From ${obs.validatorAddress}: ${obs.arrivals.size} arrivals")
+        }
+
+        Logger.info("Join1 has ${join1Obs.observations.size} observations")
+        join1Obs.observations.forEach { obs ->
+            Logger.info("  From ${obs.validatorAddress}: ${obs.arrivals.size} arrivals")
+        }
+
+        Logger.info("Join2 has ${join2Obs.observations.size} observations")
+        join2Obs.observations.forEach { obs ->
+            Logger.info("  From ${obs.validatorAddress}: ${obs.arrivals.size} arrivals")
+        }
+
+        logSection("Verifying observations were broadcast")
+        assertThat(genesisObs.observations.size).isGreaterThanOrEqualTo(1)
+            .describedAs("Genesis should have at least its own observation")
+        assertThat(join1Obs.observations.size).isGreaterThanOrEqualTo(1)
+            .describedAs("Join1 should have at least its own observation")
+        assertThat(join2Obs.observations.size).isGreaterThanOrEqualTo(1)
+            .describedAs("Join2 should have at least its own observation")
+
+        logSection("Querying consensus from all nodes")
+        val genesisConsensus = genesis.api.getPropagationConsensus(pocHeight)
+        val join1Consensus = join1.api.getPropagationConsensus(pocHeight)
+        val join2Consensus = join2.api.getPropagationConsensus(pocHeight)
+
+        Logger.info("Genesis consensus results:")
+        genesisConsensus.consensus.forEach { (participant, result) ->
+            Logger.info("  $participant: agreedCount=${result.agreedCount}, " +
+                "totalValidators=${result.totalValidators}, agreeingCount=${result.agreeingCount}")
+        }
+
+        Logger.info("Join1 consensus results:")
+        join1Consensus.consensus.forEach { (participant, result) ->
+            Logger.info("  $participant: agreedCount=${result.agreedCount}, " +
+                "totalValidators=${result.totalValidators}, agreeingCount=${result.agreeingCount}")
+        }
+
+        Logger.info("Join2 consensus results:")
+        join2Consensus.consensus.forEach { (participant, result) ->
+            Logger.info("  $participant: agreedCount=${result.agreedCount}, " +
+                "totalValidators=${result.totalValidators}, agreeingCount=${result.agreeingCount}")
+        }
+
+        logSection("Verifying consensus results are present")
+        assertThat(genesisConsensus.consensus).isNotEmpty
+            .describedAs("Genesis should have consensus results")
+
+        logSection("Verifying consensus agreed counts match actual artifact counts")
+
+        if (genesisConsensus.consensus.containsKey(genesisAddr)) {
+            val genesisResult = genesisConsensus.consensus[genesisAddr]!!
+            Logger.info("Genesis consensus for self: agreedCount=${genesisResult.agreedCount}, actualCount=${genesisState.count}")
+            assertThat(genesisResult.agreedCount).isGreaterThan(0)
+                .describedAs("Genesis should have positive agreed count for itself")
+            assertThat(genesisResult.agreedCount).isLessThanOrEqualTo(genesisState.count.toLong())
+                .describedAs("Agreed count should not exceed actual count")
+        }
+
+        if (genesisConsensus.consensus.containsKey(join1Addr)) {
+            val join1Result = genesisConsensus.consensus[join1Addr]!!
+            Logger.info("Genesis consensus for Join1: agreedCount=${join1Result.agreedCount}, actualCount=${join1State.count}")
+            assertThat(join1Result.agreedCount).isGreaterThan(0)
+                .describedAs("Genesis should have positive agreed count for Join1")
+            assertThat(join1Result.agreedCount).isLessThanOrEqualTo(join1State.count.toLong())
+                .describedAs("Agreed count should not exceed actual count")
+        }
+
+        if (genesisConsensus.consensus.containsKey(join2Addr)) {
+            val join2Result = genesisConsensus.consensus[join2Addr]!!
+            Logger.info("Genesis consensus for Join2: agreedCount=${join2Result.agreedCount}, actualCount=${join2State.count}")
+            assertThat(join2Result.agreedCount).isGreaterThan(0)
+                .describedAs("Genesis should have positive agreed count for Join2")
+            assertThat(join2Result.agreedCount).isLessThanOrEqualTo(join2State.count.toLong())
+                .describedAs("Agreed count should not exceed actual count")
+        }
+
+        logSection("Verifying consensus is consistent across nodes")
+        genesisConsensus.consensus.forEach { (participant, genesisResult) ->
+            val join1Result = join1Consensus.consensus[participant]
+            val join2Result = join2Consensus.consensus[participant]
+
+            if (join1Result != null) {
+                Logger.info("Comparing consensus for $participant: " +
+                    "genesis=${genesisResult.agreedCount}, join1=${join1Result.agreedCount}")
+            }
+            if (join2Result != null) {
+                Logger.info("Comparing consensus for $participant: " +
+                    "genesis=${genesisResult.agreedCount}, join2=${join2Result.agreedCount}")
+            }
+        }
+
+        logSection("Test Complete - Consensus calculation verified")
+        Logger.info("All nodes calculated consensus based on observations")
+        Logger.info("Agreed counts are positive and bounded by actual artifact counts")
+    }
 }


### PR DESCRIPTION
## Summary

Adds the observation and consensus layer to off-chain PoC propagation. Validators now agree on batch counts before submitting on-chain commits, instead of each node committing its own local count.

### What changed

- **First arrival tracking**: When a node first receives a header from a participant, it records the timestamp and count. These are immutable once stored.
- **Observation broadcasting**: At a computed block height before the PoC exchange deadline, each validator signs and broadcasts its full `{participant -> (time, count)}` map to peers via the overlay trees.
- **Consensus calculation**: For each participant, finds the highest count where a majority of validators saw >= that count before the deadline.
- **Commit flow split**: Header publishing (during PoCGenerate) is now separate from on-chain commit submission (during exchange window). On-chain commits use the consensus-agreed count, not the local count.

### New HTTP endpoints

- `POST /v1/propagation/observation` - receive observation from peer
- `GET /v1/propagation/first-arrivals/:poc_height` - query arrival records
- `GET /v1/propagation/observations/:poc_height` - query stored observations
- `GET /v1/propagation/consensus/:poc_height?deadline=X` - calculate consensus

### Storage

All three backends (file, postgres, hybrid) implement arrival and observation storage. Postgres adds `poc_first_arrivals` and `poc_observations` tables.

### Tests

- Unit tests for consensus calculation (`consensus_test.go`)
- Integration tests for first arrival tracking and consensus calculation (`PropagationTests.kt`)
