### PR TITLE
fix: prevent same node from always getting safe inference slot

### DIFF
--- a/inference-chain/x/inference/module/model_assignment.go
+++ b/inference-chain/x/inference/module/model_assignment.go
@@ -460,7 +460,7 @@ func (ma *ModelAssigner) AllocateMLNodesForPoC(ctx context.Context, upcomingEpoc
 
 	for _, modelId := range sortedModelIds {
 		ma.LogInfo("Processing model for PoC allocation", types.Allocation, "flow_context", FlowContext, "sub_flow_context", SubFlowContext, "step", "model_loop_start", "model_id", modelId)
-		ma.allocateMLNodePerPoCForModel(modelId, currentEpochData, eligibleNodesData, allocationFraction)
+		ma.allocateMLNodePerPoCForModel(modelId, currentEpochData, eligibleNodesData, previousEpochData, allocationFraction)
 	}
 }
 
@@ -663,6 +663,7 @@ func (ma *ModelAssigner) allocateMLNodePerPoCForModel(
 	modelId string,
 	currentEpochData *EpochMLNodeData,
 	eligibleNodesData *EpochMLNodeData,
+	previousEpochData *EpochMLNodeData,
 	fraction *types.Decimal,
 ) {
 	ma.LogInfo("Starting allocation for model", types.Allocation, "flow_context", FlowContext, "sub_flow_context", SubFlowContext, "step", "model_allocation_start", "model_id", modelId)
@@ -685,6 +686,11 @@ func (ma *ModelAssigner) allocateMLNodePerPoCForModel(
 		return
 	}
 
+	// Build a set of node IDs that were in the safe slot (POC_SLOT=false) in the previous epoch.
+	// These nodes should be prioritized for PoC allocation in the current epoch to ensure rotation.
+	previousSafeSlotNodes := buildPreviousSafeSlotNodeSet(previousEpochData, modelId)
+	ma.LogInfo("Built previous safe slot node set for rotation", types.Allocation, "flow_context", FlowContext, "sub_flow_context", SubFlowContext, "step", "build_safe_slot_set", "model_id", modelId, "safe_slot_node_count", len(previousSafeSlotNodes))
+
 	var currentWeight int64
 	currentParticipantIdx := 0
 	allocatedInRound := false
@@ -693,7 +699,10 @@ func (ma *ModelAssigner) allocateMLNodePerPoCForModel(
 		participantAddr := eligibleParticipantAddrs[currentParticipantIdx]
 		nodes := eligibleNodesData.GetForParticipant(modelId, participantAddr)
 
-		nextMLNode := getSmallestMLNodeWithPOCSLotFalse(nodes)
+		// Fix for issue #706: Prioritize nodes that were in the safe slot (POC_SLOT=false)
+		// in the previous epoch. This ensures rotation and prevents the same nodes from
+		// always avoiding PoC verification.
+		nextMLNode := getSmallestMLNodeWithPOCSLotFalseWithRotation(nodes, previousSafeSlotNodes)
 
 		if nextMLNode == nil {
 			currentParticipantIdx = (currentParticipantIdx + 1) % len(eligibleParticipantAddrs)
@@ -751,6 +760,77 @@ func getSmallestMLNodeWithPOCSLotFalse(nodes []*types.MLNodeInfo) *types.MLNodeI
 		}
 	}
 	return smallest
+}
+
+// getSmallestMLNodeWithPOCSLotFalseWithRotation selects the next node to allocate to PoC slot,
+// prioritizing nodes that were in the safe slot (POC_SLOT=false) in the previous epoch.
+// This ensures rotation and prevents the same nodes from always avoiding PoC verification.
+//
+// Selection priority:
+// 1. Nodes that were in safe slot in previous epoch (smallest weight first)
+// 2. Other nodes (smallest weight first, for tie-breaking)
+//
+// Fixes issue #706: Inference Slot Hogging
+func getSmallestMLNodeWithPOCSLotFalseWithRotation(nodes []*types.MLNodeInfo, previousSafeSlotNodes map[string]bool) *types.MLNodeInfo {
+	var smallestFromSafeSlot *types.MLNodeInfo
+	var smallestOther *types.MLNodeInfo
+
+	for _, node := range nodes {
+		// Skip nodes that already have POC_SLOT=true
+		if len(node.TimeslotAllocation) <= 1 || node.TimeslotAllocation[1] {
+			continue
+		}
+
+		// Check if this node was in the safe slot in the previous epoch
+		if previousSafeSlotNodes[node.NodeId] {
+			// Prioritize nodes from the previous safe slot
+			if smallestFromSafeSlot == nil || node.PocWeight < smallestFromSafeSlot.PocWeight {
+				smallestFromSafeSlot = node
+			}
+		} else {
+			// Track other eligible nodes as fallback
+			if smallestOther == nil || node.PocWeight < smallestOther.PocWeight {
+				smallestOther = node
+			}
+		}
+	}
+
+	// Return node from previous safe slot if available (ensures rotation)
+	if smallestFromSafeSlot != nil {
+		return smallestFromSafeSlot
+	}
+	// Fall back to other nodes (for new nodes or first epoch)
+	return smallestOther
+}
+
+// buildPreviousSafeSlotNodeSet builds a set of node IDs that were in the safe slot
+// (POC_SLOT=false) in the previous epoch for a specific model.
+// These nodes should be prioritized for PoC allocation in the current epoch.
+func buildPreviousSafeSlotNodeSet(previousEpochData *EpochMLNodeData, modelId string) map[string]bool {
+	safeSlotNodes := make(map[string]bool)
+
+	if previousEpochData == nil {
+		return safeSlotNodes
+	}
+
+	participantNodes := previousEpochData.GetForModel(modelId)
+	if participantNodes == nil {
+		return safeSlotNodes
+	}
+
+	for _, nodes := range participantNodes {
+		for _, node := range nodes {
+			if node == nil {
+				continue
+			}
+			// A node was in the safe slot if POC_SLOT was false
+			if len(node.TimeslotAllocation) > 1 && !node.TimeslotAllocation[1] {
+				safeSlotNodes[node.NodeId] = true
+			}
+		}
+	}
+
+	return safeSlotNodes
 }
 
 // calculateWeightThresholdWithCount calculates both the weight threshold and target node count.

--- a/inference-chain/x/inference/module/model_assignment.go
+++ b/inference-chain/x/inference/module/model_assignment.go
@@ -750,18 +750,6 @@ func (ma *ModelAssigner) allocateMLNodePerPoCForModel(
 	ma.LogInfo("Finished allocation for model", types.Allocation, "flow_context", FlowContext, "sub_flow_context", SubFlowContext, "step", "model_allocation_end", "model_id", modelId, "achieved_weight", currentWeight, "target_weight", targetPoCWeight, "total_weight", totalWeight)
 }
 
-func getSmallestMLNodeWithPOCSLotFalse(nodes []*types.MLNodeInfo) *types.MLNodeInfo {
-	var smallest *types.MLNodeInfo
-	for _, node := range nodes {
-		if len(node.TimeslotAllocation) > 1 && !node.TimeslotAllocation[1] {
-			if smallest == nil || node.PocWeight < smallest.PocWeight {
-				smallest = node
-			}
-		}
-	}
-	return smallest
-}
-
 // getSmallestMLNodeWithPOCSLotFalseWithRotation selects the next node to allocate to PoC slot,
 // prioritizing nodes that were in the safe slot (POC_SLOT=false) in the previous epoch.
 // This ensures rotation and prevents the same nodes from always avoiding PoC verification.
@@ -818,7 +806,8 @@ func buildPreviousSafeSlotNodeSet(previousEpochData *EpochMLNodeData, modelId st
 		return safeSlotNodes
 	}
 
-	for _, nodes := range participantNodes {
+	for _, participantAddr := range sortedKeys(participantNodes) {
+		nodes := participantNodes[participantAddr]
 		for _, node := range nodes {
 			if node == nil {
 				continue

--- a/inference-chain/x/inference/module/model_assignment_test.go
+++ b/inference-chain/x/inference/module/model_assignment_test.go
@@ -2105,6 +2105,22 @@ func TestAllocateMLNodesForPoC_RotationPreventsSlotHogging(t *testing.T) {
 	// than from the previous PoC slot (which already served their turn).
 	require.Greater(t, safeSlotNowInPoc, 0,
 		"At least some nodes from previous safe slot should be in PoC slot now (rotation should prioritize them)")
+
+	// Stronger assertion: nodes from previous safe slot should be prioritized over nodes
+	// that were already in PoC. Since safe slot nodes have lower weights (20 vs 50) and
+	// the rotation logic prioritizes them, they should be selected first.
+	require.Greater(t, safeSlotNowInPoc, pocSlotNowInPoc,
+		"Rotation should prioritize nodes from previous safe slot over nodes that were already in PoC")
+
+	// Verify that the rotation is actually happening: nodes that were in PoC slot before
+	// should NOT be selected when safe slot nodes are available (they already served their turn)
+	require.Equal(t, 0, pocSlotNowInPoc,
+		"Nodes that were already in PoC slot should not be selected when safe slot nodes are available")
+
+	// At least 2 safe slot nodes should be allocated (with 50% allocation and total weight 210,
+	// target is ~105 weight; 2 nodes at 20 each = 40 weight which triggers further allocation)
+	require.GreaterOrEqual(t, safeSlotNowInPoc, 2,
+		"Multiple nodes from previous safe slot should be allocated to PoC due to rotation priority")
 }
 
 // TestGetSmallestMLNodeWithPOCSLotFalseWithRotation tests the rotation-aware node selection

--- a/inference-chain/x/inference/module/model_assignment_test.go
+++ b/inference-chain/x/inference/module/model_assignment_test.go
@@ -1957,3 +1957,276 @@ func TestAllocateMLNodesForPoC_DedupesBeforeAllocation(t *testing.T) {
 	})
 	require.Equal(t, int64(50), participants[0].MlNodes[0].MlNodes[0].PocWeight)
 }
+
+// TestAllocateMLNodesForPoC_RotationPreventsSlotHogging tests that nodes which were
+// in the safe slot (POC_SLOT=false) in the previous epoch are prioritized for PoC
+// allocation in the current epoch. This ensures rotation and prevents the same nodes
+// from always avoiding PoC verification.
+//
+// Fixes issue #706: Inference Slot Hogging
+func TestAllocateMLNodesForPoC_RotationPreventsSlotHogging(t *testing.T) {
+	ctx := context.Background()
+	modelID := "model-rotation"
+
+	params := types.DefaultParams()
+	// Set 50% allocation - should allocate roughly half of nodes
+	params.EpochParams.PocSlotAllocation = &types.Decimal{Value: 5, Exponent: -1}
+
+	// Scenario: Multiple validators with 4 nodes each to ensure multiple nodes pass the 25% threshold.
+	// With 4 nodes at uniform weight, 25% rule selects 1 node, but we need the nodes to all be
+	// in the eligible set. Use varying weights where the "safe slot" nodes have LOWER weights
+	// so they pass the threshold filtering.
+	//
+	// In epoch 0: Nodes A1, C1, E1 (higher weight) were allocated to PoC;
+	//             Nodes B2, D2, F2 (lower weight) stayed in safe slot
+	// In epoch 1: B2, D2, F2 should be prioritized for PoC allocation due to rotation
+	mockKeeper := &mockKeeperForModelAssigner{
+		governanceModels: []types.Model{
+			{ProposedBy: "genesis", Id: modelID},
+		},
+		params: &params,
+		epochGroupData: map[string]map[uint64]types.EpochGroupData{
+			modelID: {
+				// Epoch 0 data: Higher weight nodes were in PoC, lower weight nodes in safe slot
+				0: {
+					ValidationWeights: []*types.ValidationWeight{
+						{
+							MemberAddress: "validator1",
+							MlNodes: []*types.MLNodeInfo{
+								{NodeId: "node-A1", PocWeight: 50, TimeslotAllocation: []bool{true, true}},  // Was in PoC (higher weight)
+								{NodeId: "node-B2", PocWeight: 20, TimeslotAllocation: []bool{true, false}}, // Was in safe slot (lower weight)
+							},
+						},
+						{
+							MemberAddress: "validator2",
+							MlNodes: []*types.MLNodeInfo{
+								{NodeId: "node-C1", PocWeight: 50, TimeslotAllocation: []bool{true, true}},  // Was in PoC
+								{NodeId: "node-D2", PocWeight: 20, TimeslotAllocation: []bool{true, false}}, // Was in safe slot
+							},
+						},
+						{
+							MemberAddress: "validator3",
+							MlNodes: []*types.MLNodeInfo{
+								{NodeId: "node-E1", PocWeight: 50, TimeslotAllocation: []bool{true, true}},  // Was in PoC
+								{NodeId: "node-F2", PocWeight: 20, TimeslotAllocation: []bool{true, false}}, // Was in safe slot
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Current epoch (epoch 1) participants - all nodes start with POC_SLOT=false
+	// Lower weight nodes (B2, D2, F2) should pass the threshold filter
+	participants := []*types.ActiveParticipant{
+		{
+			Index:  "validator1",
+			Models: []string{modelID},
+			Weight: 70, // Total weight of both nodes
+			MlNodes: []*types.ModelMLNodes{
+				{
+					MlNodes: []*types.MLNodeInfo{
+						{NodeId: "node-A1", PocWeight: 50, TimeslotAllocation: []bool{true, false}},
+						{NodeId: "node-B2", PocWeight: 20, TimeslotAllocation: []bool{true, false}},
+					},
+				},
+			},
+		},
+		{
+			Index:  "validator2",
+			Models: []string{modelID},
+			Weight: 70,
+			MlNodes: []*types.ModelMLNodes{
+				{
+					MlNodes: []*types.MLNodeInfo{
+						{NodeId: "node-C1", PocWeight: 50, TimeslotAllocation: []bool{true, false}},
+						{NodeId: "node-D2", PocWeight: 20, TimeslotAllocation: []bool{true, false}},
+					},
+				},
+			},
+		},
+		{
+			Index:  "validator3",
+			Models: []string{modelID},
+			Weight: 70,
+			MlNodes: []*types.ModelMLNodes{
+				{
+					MlNodes: []*types.MLNodeInfo{
+						{NodeId: "node-E1", PocWeight: 50, TimeslotAllocation: []bool{true, false}},
+						{NodeId: "node-F2", PocWeight: 20, TimeslotAllocation: []bool{true, false}},
+					},
+				},
+			},
+		},
+	}
+
+	modelAssigner := NewModelAssigner(mockKeeper, mockLogger{})
+	modelAssigner.AllocateMLNodesForPoC(ctx, types.Epoch{Index: 1}, participants)
+
+	// Collect all nodes that were in safe slot in previous epoch and check if they're now prioritized
+	// Nodes B2, D2, F2 (lower weight) were in safe slot (POC_SLOT=false) in epoch 0
+	previousSafeSlotNodes := []string{"node-B2", "node-D2", "node-F2"}
+	previousPocSlotNodes := []string{"node-A1", "node-C1", "node-E1"}
+
+	// Count how many nodes from each category got allocated to PoC slot
+	safeSlotNowInPoc := 0
+	pocSlotNowInPoc := 0
+
+	for _, participant := range participants {
+		if len(participant.MlNodes) == 0 {
+			continue
+		}
+		for _, node := range participant.MlNodes[0].MlNodes {
+			if len(node.TimeslotAllocation) > 1 && node.TimeslotAllocation[1] {
+				// Node is now in PoC slot
+				for _, safeNode := range previousSafeSlotNodes {
+					if node.NodeId == safeNode {
+						safeSlotNowInPoc++
+						t.Logf("Node %s (was in safe slot) -> now in PoC slot", node.NodeId)
+					}
+				}
+				for _, pocNode := range previousPocSlotNodes {
+					if node.NodeId == pocNode {
+						pocSlotNowInPoc++
+						t.Logf("Node %s (was in PoC slot) -> still in PoC slot", node.NodeId)
+					}
+				}
+			}
+		}
+	}
+
+	t.Logf("Rotation test results:")
+	t.Logf("  Nodes from previous safe slot now in PoC: %d/%d", safeSlotNowInPoc, len(previousSafeSlotNodes))
+	t.Logf("  Nodes from previous PoC slot now in PoC: %d/%d", pocSlotNowInPoc, len(previousPocSlotNodes))
+
+	// The rotation fix should prioritize nodes that were in the safe slot.
+	// With 50% allocation, we expect more nodes from the previous safe slot to be selected
+	// than from the previous PoC slot (which already served their turn).
+	require.Greater(t, safeSlotNowInPoc, 0,
+		"At least some nodes from previous safe slot should be in PoC slot now (rotation should prioritize them)")
+}
+
+// TestGetSmallestMLNodeWithPOCSLotFalseWithRotation tests the rotation-aware node selection
+func TestGetSmallestMLNodeWithPOCSLotFalseWithRotation(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		nodes                 []*types.MLNodeInfo
+		previousSafeSlotNodes map[string]bool
+		expectedNodeId        string
+		description           string
+	}{
+		{
+			name: "prioritizes node from previous safe slot",
+			nodes: []*types.MLNodeInfo{
+				{NodeId: "node-A", PocWeight: 10, TimeslotAllocation: []bool{true, false}},
+				{NodeId: "node-B", PocWeight: 20, TimeslotAllocation: []bool{true, false}},
+			},
+			previousSafeSlotNodes: map[string]bool{"node-B": true},
+			expectedNodeId:        "node-B",
+			description:           "Node B was in safe slot, should be prioritized despite higher weight",
+		},
+		{
+			name: "falls back to smallest when no previous safe slot data",
+			nodes: []*types.MLNodeInfo{
+				{NodeId: "node-A", PocWeight: 10, TimeslotAllocation: []bool{true, false}},
+				{NodeId: "node-B", PocWeight: 20, TimeslotAllocation: []bool{true, false}},
+			},
+			previousSafeSlotNodes: map[string]bool{},
+			expectedNodeId:        "node-A",
+			description:           "No previous data, fallback to smallest weight",
+		},
+		{
+			name: "picks smallest among multiple safe slot nodes",
+			nodes: []*types.MLNodeInfo{
+				{NodeId: "node-A", PocWeight: 10, TimeslotAllocation: []bool{true, false}},
+				{NodeId: "node-B", PocWeight: 20, TimeslotAllocation: []bool{true, false}},
+				{NodeId: "node-C", PocWeight: 15, TimeslotAllocation: []bool{true, false}},
+			},
+			previousSafeSlotNodes: map[string]bool{"node-B": true, "node-C": true},
+			expectedNodeId:        "node-C",
+			description:           "Both B and C were in safe slot, picks smaller (C)",
+		},
+		{
+			name: "skips already allocated nodes",
+			nodes: []*types.MLNodeInfo{
+				{NodeId: "node-A", PocWeight: 10, TimeslotAllocation: []bool{true, true}}, // Already allocated
+				{NodeId: "node-B", PocWeight: 20, TimeslotAllocation: []bool{true, false}},
+			},
+			previousSafeSlotNodes: map[string]bool{"node-A": true, "node-B": true},
+			expectedNodeId:        "node-B",
+			description:           "Node A is already allocated, picks B",
+		},
+		{
+			name: "returns nil when all nodes allocated",
+			nodes: []*types.MLNodeInfo{
+				{NodeId: "node-A", PocWeight: 10, TimeslotAllocation: []bool{true, true}},
+				{NodeId: "node-B", PocWeight: 20, TimeslotAllocation: []bool{true, true}},
+			},
+			previousSafeSlotNodes: map[string]bool{},
+			expectedNodeId:        "",
+			description:           "All nodes already have POC_SLOT=true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getSmallestMLNodeWithPOCSLotFalseWithRotation(tc.nodes, tc.previousSafeSlotNodes)
+
+			if tc.expectedNodeId == "" {
+				require.Nil(t, result, tc.description)
+			} else {
+				require.NotNil(t, result, tc.description)
+				require.Equal(t, tc.expectedNodeId, result.NodeId, tc.description)
+			}
+		})
+	}
+}
+
+// TestBuildPreviousSafeSlotNodeSet tests the helper function that builds the safe slot set
+func TestBuildPreviousSafeSlotNodeSet(t *testing.T) {
+	modelID := "test-model"
+
+	t.Run("extracts nodes with POC_SLOT=false", func(t *testing.T) {
+		epochData := NewEpochMLNodeData()
+		epochData.Set(modelID, "participant1", []*types.MLNodeInfo{
+			{NodeId: "node-A", TimeslotAllocation: []bool{true, true}},  // Was in PoC
+			{NodeId: "node-B", TimeslotAllocation: []bool{true, false}}, // Was in safe slot
+		})
+
+		result := buildPreviousSafeSlotNodeSet(epochData, modelID)
+
+		require.Len(t, result, 1)
+		require.True(t, result["node-B"])
+		require.False(t, result["node-A"])
+	})
+
+	t.Run("handles nil epoch data", func(t *testing.T) {
+		result := buildPreviousSafeSlotNodeSet(nil, modelID)
+		require.Empty(t, result)
+	})
+
+	t.Run("handles missing model", func(t *testing.T) {
+		epochData := NewEpochMLNodeData()
+		result := buildPreviousSafeSlotNodeSet(epochData, "non-existent-model")
+		require.Empty(t, result)
+	})
+
+	t.Run("aggregates across multiple participants", func(t *testing.T) {
+		epochData := NewEpochMLNodeData()
+		epochData.Set(modelID, "participant1", []*types.MLNodeInfo{
+			{NodeId: "node-A", TimeslotAllocation: []bool{true, false}}, // Safe slot
+		})
+		epochData.Set(modelID, "participant2", []*types.MLNodeInfo{
+			{NodeId: "node-B", TimeslotAllocation: []bool{true, false}}, // Safe slot
+			{NodeId: "node-C", TimeslotAllocation: []bool{true, true}},  // PoC slot
+		})
+
+		result := buildPreviousSafeSlotNodeSet(epochData, modelID)
+
+		require.Len(t, result, 2)
+		require.True(t, result["node-A"])
+		require.True(t, result["node-B"])
+		require.False(t, result["node-C"])
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes issue #706: Inference Slot Hogging
- Implements deterministic rotation for PoC slot allocation
- Nodes that were in "safe slot" (POC_SLOT=false) in previous epoch are now prioritized for PoC allocation
- Ensures fair distribution of PoC verification across all nodes over time

## Problem

The system always picks the node with the smallest weight for the "safe" inference slot. If a validator has multiple nodes, the same small node keeps getting the safe slot every epoch, avoiding PoC verification indefinitely.

This causes:
- **Verification Avoidance**: The smallest node is never checked because it stays in the safe slot
- **Guaranteed Rewards**: This node earns rewards every epoch without risk

## Solution

The fix introduces rotation by:
1. Building a set of node IDs that were in the safe slot (POC_SLOT=false) in the previous epoch
2. Prioritizing those nodes for PoC allocation using `getSmallestMLNodeWithPOCSLotFalseWithRotation`
3. Falling back to smallest weight selection for new nodes or first epoch

## Test plan

- [x] Added unit test `TestAllocateMLNodesForPoC_RotationPreventsSlotHogging` verifying rotation behavior
- [x] Added unit test `TestGetSmallestMLNodeWithPOCSLotFalseWithRotation` for the selection function
- [x] Added unit test `TestBuildPreviousSafeSlotNodeSet` for the helper function
- [x] All existing tests pass

Fixes #706

---
Generated with [Claude Code](https://claude.com/claude-code)