### PR TITLE
fix: validate bridge contract address in BridgeExchange handler

### DIFF
--- a/inference-chain/x/inference/keeper/bridge.go
+++ b/inference-chain/x/inference/keeper/bridge.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"cosmossdk.io/collections"
 	"github.com/productscience/inference/x/inference/types"
@@ -17,6 +18,9 @@ func (k Keeper) generateBridgeAddressKey(_ context.Context, chainId, address str
 
 // SetBridgeContractAddress stores a bridge contract address
 func (k Keeper) SetBridgeContractAddress(ctx context.Context, address types.BridgeContractAddress) {
+	// Normalize to lowercase for case-insensitive matching
+	address.ChainId = strings.ToLower(address.ChainId)
+	address.Address = strings.ToLower(address.Address)
 	address.Id = k.generateBridgeAddressKey(ctx, address.ChainId, address.Address)
 	if err := k.BridgeContractAddresses.Set(ctx, collections.Join(address.ChainId, address.Address), address); err != nil {
 		k.LogError("Bridge exchange: Failed to set bridge contract address",

--- a/inference-chain/x/inference/keeper/msg_server_bridge_exchange.go
+++ b/inference-chain/x/inference/keeper/msg_server_bridge_exchange.go
@@ -34,6 +34,15 @@ func (k msgServer) BridgeExchange(goCtx context.Context, msg *types.MsgBridgeExc
 		"blockNumber", msg.BlockNumber,
 		"receiptIndex", msg.ReceiptIndex)
 
+	// Validate that the contract address is a registered bridge contract for this chain
+	normalizedChain := strings.ToLower(msg.OriginChain)
+	normalizedContract := strings.ToLower(msg.ContractAddress)
+	if !k.HasBridgeContractAddress(ctx, normalizedChain, normalizedContract) {
+		k.LogError("Bridge exchange: Unregistered bridge contract address", types.Messages,
+			"originChain", msg.OriginChain, "contractAddress", msg.ContractAddress)
+		return nil, fmt.Errorf("unregistered bridge contract address %s for chain %s", msg.ContractAddress, msg.OriginChain)
+	}
+
 	// Parse the amount to ensure it's valid
 	_, ok := new(big.Int).SetString(msg.Amount, 10)
 	if !ok {
@@ -59,9 +68,10 @@ func (k msgServer) BridgeExchange(goCtx context.Context, msg *types.MsgBridgeExc
 	}
 
 	// Create transaction object with all the content for secure validation
+	// Use normalized chain/contract values to prevent case-variant duplicate transactions
 	proposedTx := &types.BridgeTransaction{
-		ChainId:         msg.OriginChain,
-		ContractAddress: msg.ContractAddress,
+		ChainId:         normalizedChain,
+		ContractAddress: normalizedContract,
 		OwnerAddress:    msg.OwnerAddress,
 		Amount:          msg.Amount,
 		BlockNumber:     msg.BlockNumber,

--- a/inference-chain/x/inference/keeper/msg_server_bridge_exchange_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_bridge_exchange_test.go
@@ -58,6 +58,12 @@ func TestBridgeExchange_DoubleVoteCaseBypass(t *testing.T) {
 		}, nil,
 	).AnyTimes()
 
+	// Register the bridge contract address
+	k.SetBridgeContractAddress(ctx, types.BridgeContractAddress{
+		ChainId: "ethereum",
+		Address: "0x123",
+	})
+
 	// First Vote (Lowercase)
 	msg1 := &types.MsgBridgeExchange{
 		OriginChain:     "ethereum",
@@ -91,4 +97,84 @@ func TestBridgeExchange_DoubleVoteCaseBypass(t *testing.T) {
 	if err != nil {
 		require.Contains(t, err.Error(), "validator has already validated this transaction")
 	}
+}
+
+func TestBridgeExchange_CaseInsensitiveContractAddress(t *testing.T) {
+	k, ms, ctx, mocks := setupKeeperWithMocks(t)
+
+	// Register bridge contract with lowercase values
+	k.SetBridgeContractAddress(ctx, types.BridgeContractAddress{
+		ChainId: "ethereum",
+		Address: "0x123",
+	})
+
+	// Setup Validator
+	validatorAddr := "gonka13779rkgy6ke7cdj8f097pdvx34uvrlcqq8nq2w"
+
+	// Setup Epoch
+	epochIndex := uint64(1)
+	_ = k.SetEffectiveEpochIndex(ctx, epochIndex)
+
+	// Setup Epoch Group Data
+	epochGroupData := types.EpochGroupData{
+		EpochIndex:   epochIndex,
+		ModelId:      "",
+		EpochGroupId: 1,
+		TotalWeight:  20,
+	}
+	k.SetEpochGroupData(ctx, epochGroupData)
+
+	// Setup Mocks
+	accAddr, _ := sdk.AccAddressFromBech32(validatorAddr)
+
+	mocks.AccountKeeper.EXPECT().GetAccount(ctx, accAddr).Return(
+		&authtypes.BaseAccount{Address: validatorAddr},
+	).AnyTimes()
+
+	member := &group.GroupMember{
+		GroupId: 1,
+		Member: &group.Member{
+			Address: validatorAddr,
+			Weight:  "10",
+		},
+	}
+
+	mocks.GroupKeeper.EXPECT().GroupMembers(ctx, gomock.Any()).Return(
+		&group.QueryGroupMembersResponse{
+			Members: []*group.GroupMember{member},
+		}, nil,
+	).AnyTimes()
+
+	// Submit with MIXED CASE contract address and chain — should still match
+	msg := &types.MsgBridgeExchange{
+		OriginChain:     "Ethereum",  // uppercase E
+		ContractAddress: "0X123",     // uppercase X
+		OwnerAddress:    "0xabc",
+		Amount:          "100",
+		BlockNumber:     "1000",
+		ReceiptIndex:    "1",
+		Validator:       validatorAddr,
+	}
+
+	_, err := ms.BridgeExchange(ctx, msg)
+	require.NoError(t, err, "Case-insensitive contract address should be accepted")
+}
+
+func TestBridgeExchange_UnregisteredContractAddress(t *testing.T) {
+	_, ms, ctx, _ := setupKeeperWithMocks(t)
+
+	// Submit a bridge exchange with an unregistered contract address
+	msg := &types.MsgBridgeExchange{
+		OriginChain:     "ethereum",
+		ContractAddress: "0xUnregistered",
+		OwnerAddress:    "0xabc",
+		Amount:          "100",
+		BlockNumber:     "1000",
+		ReceiptIndex:    "1",
+		Validator:       "gonka13779rkgy6ke7cdj8f097pdvx34uvrlcqq8nq2w",
+	}
+
+	_, err := ms.BridgeExchange(ctx, msg)
+	require.Error(t, err, "Should reject unregistered contract address")
+	require.Contains(t, err.Error(), "unregistered bridge contract address")
 }


### PR DESCRIPTION
## Security Vulnerability: Unvalidated Bridge Contract Address

### What's the problem?

The bridge handler (`BridgeExchange`) accepts transactions from **any** contract address — without checking if that contract is actually a registered Gonka bridge.

In simple terms: **the front door to the bridge is wide open.** A malicious validator or compromised bridge service can claim "I deposited tokens through the bridge" by referencing any contract — real or fake — and the system will process it.

### What can an attacker do?

1. Deploy a cheap contract on Ethereum that mimics bridge deposit events
2. Submit a `MsgBridgeExchange` to Gonka referencing that fake contract
3. The handler processes it as a legitimate bridge transaction
4. If enough validators in the epoch group confirm it, `handleCompletedBridgeTransaction` **mints real GONKA tokens**
5. Repeat with different `blockNumber`/`receiptIndex` values — **token supply inflation**

### Impact

- **Direct threat to token supply** — attacker can inflate GONKA supply
- **Bridge trust compromised** — the bridge is the primary entry point for cross-chain value
- **All bridged funds at risk** — inflated supply devalues every legitimate holder's tokens
- The validation function `HasBridgeContractAddress` already exists in the codebase but **was never called** in the bridge handler

### Severity: HIGH

This is a defense-in-depth vulnerability affecting the bridge — the most security-sensitive component of any cross-chain system. Exploitation requires validator-level access or bridge service compromise, combined with majority validator confirmation.

---

## Technical Details

**Root cause:** `msg_server_bridge_exchange.go` — the `BridgeExchange` function processes bridge transactions without calling `HasBridgeContractAddress()` (defined in `bridge.go`). The whitelist check exists but is simply not wired into the handler.

**Affected code path:**
- `BridgeExchange()` → creates `BridgeTransaction` → validators confirm → `handleCompletedBridgeTransaction()` → token minting
- No contract address validation at any point in this chain

**Fix (3 parts):**

1. **Whitelist validation**: Added `HasBridgeContractAddress(ctx, normalizedChain, normalizedContract)` check at the entry point of `BridgeExchange`, before any processing. Unregistered contracts are immediately rejected.

2. **Write-time normalization**: `SetBridgeContractAddress()` now normalizes `ChainId` and `Address` to lowercase before storing. This ensures consistent case-insensitive matching regardless of how governance proposals or genesis data format the addresses (Ethereum addresses are case-insensitive per EIP-55).

3. **Transaction content normalization**: The `BridgeTransaction` object is constructed with normalized (lowercase) chain ID and contract address, preventing validators from accidentally creating duplicate transaction records due to case differences.

**Test coverage:**
- `TestBridgeExchange_UnregisteredContractAddress` — confirms unregistered contracts are rejected
- `TestBridgeExchange_CaseInsensitiveContractAddress` — confirms case-insensitive matching works correctly  
- `TestBridgeExchange_DoubleVoteCaseBypass` — updated to register contract, confirms existing behavior preserved