### PR TITLE
fix(inference): preserve funding module in vested payout flow

### DIFF
--- a/inference-chain/x/inference/keeper/payment_handler.go
+++ b/inference-chain/x/inference/keeper/payment_handler.go
@@ -69,7 +69,7 @@ func (k *Keeper) PayParticipantFromModule(ctx context.Context, address string, a
 			return err
 		}
 		// Vesting keeper should move funds and create vesting schedule
-		err = k.GetStreamVestingKeeper().AddVestedRewards(ctx, address, types.ModuleName, vestingAmount, vestingEpochs, memo+"_vested")
+		err = k.GetStreamVestingKeeper().AddVestedRewards(ctx, address, moduleName, vestingAmount, vestingEpochs, memo+"_vested")
 		if err != nil {
 			k.LogError("Error adding vested payment", types.Payments, "error", err, "amount", vestingAmount)
 			return err

--- a/inference-chain/x/inference/keeper/streamvesting_integration_test.go
+++ b/inference-chain/x/inference/keeper/streamvesting_integration_test.go
@@ -150,7 +150,7 @@ func TestVestingIntegration_ParameterBased(t *testing.T) {
 
 	expectedRewardCoins := sdk.NewCoins(sdk.NewInt64Coin(types.BaseCoin, int64(rewardAmount)))
 	mocks.StreamVestingKeeper.EXPECT().
-		AddVestedRewards(ctx, participantAddrStr, "inference", expectedRewardCoins, &rewardVestingPeriod, gomock.Any()).
+		AddVestedRewards(ctx, participantAddrStr, types.TopRewardPoolAccName, expectedRewardCoins, &rewardVestingPeriod, gomock.Any()).
 		Return(nil)
 
 	// Execute payment from top reward pool module
@@ -278,7 +278,7 @@ func TestVestingIntegration_MixedVestingScenario(t *testing.T) {
 
 	expectedRewardCoins := sdk.NewCoins(sdk.NewInt64Coin(types.BaseCoin, int64(rewardAmount)))
 	mocks.StreamVestingKeeper.EXPECT().
-		AddVestedRewards(ctx, participantAddrStr, "inference", expectedRewardCoins, &rewardVestingPeriod, gomock.Any()).
+		AddVestedRewards(ctx, participantAddrStr, types.TopRewardPoolAccName, expectedRewardCoins, &rewardVestingPeriod, gomock.Any()).
 		Return(nil)
 
 	err = k.PayParticipantFromModule(ctx, participantAddrStr, rewardAmount, types.TopRewardPoolAccName, "reward-payment", &rewardVestingPeriod)
@@ -300,7 +300,7 @@ func TestVestingIntegration_TopMinerRewards(t *testing.T) {
 	expectedCoins := sdk.NewCoins(sdk.NewInt64Coin(types.BaseCoin, int64(rewardAmount)))
 
 	mocks.StreamVestingKeeper.EXPECT().
-		AddVestedRewards(ctx, participantAddrStr, "inference", expectedCoins, &topMinerVestingPeriod, gomock.Any()).
+		AddVestedRewards(ctx, participantAddrStr, types.TopRewardPoolAccName, expectedCoins, &topMinerVestingPeriod, gomock.Any()).
 		Return(nil)
 
 	// Execute top miner reward payment
@@ -340,7 +340,7 @@ func TestVestingIntegration_ErrorHandling(t *testing.T) {
 
 	// Test case 2: Vesting keeper failure should be handled
 	mocks.StreamVestingKeeper.EXPECT().
-		AddVestedRewards(ctx, participantAddrStr, types.ModuleName, expectedCoins, &vestingPeriod, gomock.Any()).
+		AddVestedRewards(ctx, participantAddrStr, types.TopRewardPoolAccName, expectedCoins, &vestingPeriod, gomock.Any()).
 		Return(fmt.Errorf("invalid request"))
 
 	err := k.PayParticipantFromModule(ctx, participantAddrStr, amount, types.TopRewardPoolAccName, "vesting-error-test", &vestingPeriod)


### PR DESCRIPTION
## What
Fix vested payout funding source in `x/inference` by forwarding caller `moduleName` to `streamvesting.AddVestedRewards`.

## Why
Previously the vested path hardcoded `inference`, which could debit the wrong module account (e.g. `top_reward` payouts).

## Commits
1. `test(inference): add failing regression for vested funding module forwarding`
2. `fix(inference): forward caller funding module for vested payouts`

## Files changed
- `inference-chain/x/inference/keeper/streamvesting_integration_test.go`
- `inference-chain/x/inference/keeper/payment_handler.go`

## Validation
- `go test ./x/inference/keeper -run "VestingIntegration_TopMinerRewards|PayParticipantFromModule_VestedPath_ForwardsFundingModule" -count=1`
- `go test ./x/inference/keeper -run "VestingIntegration|PayParticipantFromModule|ClaimRewards" -count=1`
- `go test ./x/inference/keeper -count=1`
- `go test ./x/streamvesting/keeper -count=1`

All passing after fix.

This fixes https://github.com/gonka-ai/gonka/issues/746