### PR TITLE
Missed Inferences

### DIFF
--- a/decentralized-api/internal/server/public/server.go
+++ b/decentralized-api/internal/server/public/server.go
@@ -18,7 +18,7 @@ import (
 	echomw "github.com/labstack/echo/v4/middleware"
 )
 
-const httpClientTimeout = 5 * time.Minute
+const httpClientTimeout = 20 * time.Minute
 
 type Server struct {
 	e                   *echo.Echo

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -700,8 +700,8 @@ func (v *OffChainValidator) getNodesWithRetryConfig(
 
 // filterNodesForValidation returns nodes available for PoC validation.
 // - Accept nodes in POC status with any sub-status
-// - Accept nodes in INFERENCE status
-// - Exclude FAILED or administratively disabled nodes
+// - Accept nodes in INFERENCE status (unless preserved for inference via POC_SLOT)
+// - Exclude FAILED, administratively disabled, or POC_SLOT-preserved nodes
 func filterNodesForValidation(nodes []broker.NodeResponse) []broker.NodeResponse {
 	filtered := make([]broker.NodeResponse, 0, len(nodes))
 	for _, node := range nodes {
@@ -720,6 +720,12 @@ func filterNodesForValidation(nodes []broker.NodeResponse) []broker.NodeResponse
 		// Exclude administratively disabled nodes
 		if !node.State.AdminState.Enabled {
 			logging.Debug("filterNodesForValidation: Skipping administratively disabled node", types.PoC, "node_id", node.Node.Id)
+			continue
+		}
+
+		// Exclude nodes preserved for inference (POC_SLOT allocation)
+		if node.State.ShouldContinueInference() {
+			logging.Debug("filterNodesForValidation: Skipping node preserved for inference", types.PoC, "node_id", node.Node.Id)
 			continue
 		}
 

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -385,7 +385,7 @@ func (v *OffChainValidator) worker(
 				*pendingCount--
 				// Report participant as invalid to chain
 				// Uncomment when stabilized
-				// reportAddr = work.address
+				reportAddr = work.address
 			case validateFailRetry:
 				// Re-queue for retry if under max attempts
 				if work.attempt < v.config.MaxRetries-1 {

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tmkms:
-    image: ghcr.io/product-science/tmkms-softsign-with-keygen:0.2.10
+    image: ghcr.io/product-science/tmkms-softsign-with-keygen:0.2.10-post3
     container_name: tmkms
     restart: unless-stopped
     environment:
@@ -10,7 +10,7 @@ services:
 
   node:
     container_name: node
-    image: ghcr.io/product-science/inferenced:0.2.10
+    image: ghcr.io/product-science/inferenced:0.2.10-post3
     command: ["sh", "./init-docker.sh"]
     volumes:
       - .inference:/root/.inference
@@ -44,7 +44,7 @@ services:
 
   api:
     container_name: api
-    image: ghcr.io/product-science/api:0.2.10
+    image: ghcr.io/product-science/api:0.2.10-post3
     volumes:
       - .inference:/root/.inference
       - .dapi:/root/.dapi
@@ -99,7 +99,7 @@ services:
   
   proxy:
     container_name: proxy
-    image: ghcr.io/product-science/proxy:0.2.10
+    image: ghcr.io/product-science/proxy:0.2.10-post3
     ports:
       - "${API_PORT:-8000}:80"
       - "${API_SSL_PORT:-8443}:443"
@@ -145,7 +145,7 @@ services:
 
   proxy-ssl:
     container_name: proxy-ssl
-    image: ghcr.io/product-science/proxy-ssl:0.2.10
+    image: ghcr.io/product-science/proxy-ssl:0.2.10-post3
     profiles:
       - ssl
     environment:


### PR DESCRIPTION
This PR solves several issues:
1. 5 minutes is to strict timeout for Executor -> MLNode connections, some requests are considerably longer
2. The request retry system retries inference even if it failed with processing timeout (not TLS timeout). Server-side retry for long request is essentially useless as in most cases it uses to the same scenario with timeout faillure. At the same time client gets weird output
3. Preserved MLNodes, which doesn't participate in POC generation currently still used for POC validation. That might cause missed inferences. Filter this node before validation
4. Add additional checks for POC validation pipeline

# Build: 
https://github.com/product-science/race-releases/releases/download/release%2Fv0.2.10-post3/decentralized-api-amd64.zip

To apply:
```
# Pre-check: Ensure no confirmation PoC is active (fails entire script if not false)
echo "--- Pre-flight Check: Confirmation PoC Status ---" && \
CONFIRMATION_POC_ACTIVE=$(curl -sf "https://node3.gonka.ai/v1/epochs/latest" | jq -r '.is_confirmation_poc_active') && \
[ "$CONFIRMATION_POC_ACTIVE" = "false" ] && \
echo "OK: No confirmation PoC active" && \

# Download Binary
sudo rm -rf decentralized-api.zip .dapi/cosmovisor/upgrades/v0.2.10-post3/ .dapi/data/upgrade-info.json && \
sudo mkdir -p  .dapi/cosmovisor/upgrades/v0.2.10-post3/bin/ && \
wget -q -O  decentralized-api.zip 'https://github.com/product-science/race-releases/releases/download/release%2Fv0.2.10-post3/decentralized-api-amd64.zip' && \
echo "1b75f2785c7884dc24f3c1e39d5ed10f4afcbe5fc677f5569d90d75c752ec150 decentralized-api.zip" | sha256sum --check && \
sudo unzip -o -j  decentralized-api.zip -d .dapi/cosmovisor/upgrades/v0.2.10-post3/bin/ && \
sudo chmod +x .dapi/cosmovisor/upgrades/v0.2.10-post3/bin/decentralized-api && \
echo "API Installed and Verified"  && \

# Link Binary
echo "--- Final Verification ---" && \
sudo rm -rf .dapi/cosmovisor/current && \
sudo ln -sf upgrades/v0.2.10-post3 .dapi/cosmovisor/current && \
echo "de72c665ff71de904210c5472cebb248d163c1398141868e1a1fe198055b5886 .dapi/cosmovisor/current/bin/decentralized-api" | sudo sha256sum --check && \
# Restart 
source config.env && docker compose up api --no-deps --force-recreate -d
```
   