### PR TITLE
fix: settlement atomicity and error handling in SettleAccounts (#784)

### DIFF
--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -165,6 +165,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 	amounts, bitcoinResult, err = GetBitcoinSettleAmounts(allParticipants, &data, params.BitcoinRewardParams, validationParams, settleParameters, participantMLNodes, k.Logger())
 	if err != nil {
 		k.LogError("Error getting Bitcoin settle amounts", types.Settle, "error", err)
+		return err
 	}
 	if bitcoinResult.Amount < 0 {
 		k.LogError("Bitcoin reward amount is negative", types.Settle, "amount", bitcoinResult.Amount)
@@ -174,12 +175,21 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 	rewardAmount = bitcoinResult.Amount
 	governanceRewardAmount = bitcoinResult.GovernanceAmount
 
-	err = k.MintRewardCoins(ctx, rewardAmount, "reward_distribution")
+	// Use CacheContext so all current-epoch state mutations are atomic.
+	// If any step fails (minting, balance resets, settle writes),
+	// nothing is committed and the caller sees a clean error with no partial state.
+	// Old settle cleanup runs after commit on the real context.
+	cacheCtx, writeFn := sdkCtx.CacheContext()
+
+	err = k.MintRewardCoins(cacheCtx, rewardAmount, "reward_distribution")
 	if err != nil {
 		k.LogError("Error minting reward coins", types.Settle, "error", err)
 		return err
 	}
-	k.AddTokenomicsData(ctx, &types.TokenomicsData{TotalSubsidies: uint64(rewardAmount)})
+	if err := k.AddTokenomicsData(cacheCtx, &types.TokenomicsData{TotalSubsidies: uint64(rewardAmount)}); err != nil {
+		k.LogError("Error updating tokenomics data", types.Settle, "error", err)
+		return err
+	}
 
 	// In Bitcoin reward system, any undistributed rewards (e.g. downtime punishments or rounding)
 	// are transferred to governance instead of being redistributed to other participants.
@@ -189,7 +199,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 			return err
 		}
 		memo := fmt.Sprintf("bitcoin_reward_to_governance:epoch=%d", currentEpochIndex)
-		if err := k.BankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, govtypes.ModuleName, coins, memo); err != nil {
+		if err := k.BankKeeper.SendCoinsFromModuleToModule(cacheCtx, types.ModuleName, govtypes.ModuleName, coins, memo); err != nil {
 			k.LogError("Error transferring undistributed bitcoin rewards to governance", types.Settle, "error", err, "amount", governanceRewardAmount)
 			return err
 		}
@@ -205,7 +215,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 		if participant.Status == types.ParticipantStatus_ACTIVE {
 			participant.EpochsCompleted += 1
 		}
-		k.SafeLogSubAccountTransaction(ctx, types.ModuleName, participant.Address, "balance", participant.CoinBalance, "settling")
+		k.SafeLogSubAccountTransaction(cacheCtx, types.ModuleName, participant.Address, "balance", participant.CoinBalance, "settling")
 		participant.CoinBalance = 0
 		participant.CurrentEpochStats.EarnedCoins = 0
 		k.LogInfo("Participant CoinBalance reset", types.Balances, "address", participant.Address)
@@ -220,12 +230,12 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 			InvalidatedInferences: participant.CurrentEpochStats.InvalidatedInferences,
 			Claimed:               false,
 		}
-		err = k.SetEpochPerformanceSummary(ctx, epochPerformance)
+		err = k.SetEpochPerformanceSummary(cacheCtx, epochPerformance)
 		if err != nil {
 			return err
 		}
 		participant.CurrentEpochStats = types.NewCurrentEpochStats()
-		err := k.SetParticipant(ctx, participant)
+		err := k.SetParticipant(cacheCtx, participant)
 		if err != nil {
 			return err
 		}
@@ -250,18 +260,25 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 
 		amount.Settle.EpochIndex = currentEpochIndex
 		k.LogInfo("Settle for participant", types.Settle, "rewardCoins", amount.Settle.RewardCoins, "workCoins", amount.Settle.WorkCoins, "address", amount.Settle.Participant)
-		k.SetSettleAmountWithGovernanceTransfer(ctx, *amount.Settle)
+		if err := k.SetSettleAmountWithGovernanceTransfer(cacheCtx, *amount.Settle); err != nil {
+			k.LogError("Error writing settle amount", types.Settle, "error", err, "participant", amount.Settle.Participant)
+			return err
+		}
 	}
 
-	if previousEpochIndex == 0 {
-		return nil
+	// All current-epoch mutations succeeded — commit atomically.
+	writeFn()
+
+	// Old settle cleanup is independent of current-epoch settlement.
+	// A failure here should not roll back current participants' rewards.
+	if previousEpochIndex > 0 {
+		k.LogInfo("Transferring old settle amounts", types.Settle, "previousEpochIndex", previousEpochIndex)
+		if err := k.TransferOldSettleAmountsToGovernance(ctx, previousEpochIndex); err != nil {
+			k.LogError("Error transferring old settle amounts to governance", types.Settle, "error", err)
+			return err
+		}
 	}
 
-	k.LogInfo("Transferring old settle amounts", types.Settle, "previousEpochIndex", previousEpochIndex)
-	err = k.TransferOldSettleAmountsToGovernance(ctx, previousEpochIndex)
-	if err != nil {
-		k.LogError("Error burning old settle amounts", types.Settle, "error", err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Addresses #784 Task 2 — settlement error handling in `accountsettle.go`. 
Finding IDs reference the Task 1 analysis on #784.

---

**[F-01]** `GetBitcoinSettleAmounts` error was logged but not returned. On error the amounts slice is nil, so `amounts[i]` in the settlement loop panics. In EndBlock that's a permanent node crash. Now returns early.

**[F-02]** `SettleAccounts` does mint, balance resets, perf summaries, and settle writes as independent KV operations. If something fails mid-way (e.g. `SetParticipant` or a bank send), earlier writes are already committed. Participants can end up with zeroed balances but no settle record. Wrapped the mutation section in `CacheContext` — either everything commits or nothing does.

**[F-03]** `SetSettleAmountWithGovernanceTransfer` return value was discarded. That function transfers any existing unclaimed settle to governance before writing the new one. If the governance transfer fails, the function returns before writing the new settle. The old settle remains, but the current-epoch settle write is skipped. With the balance already reset earlier in the loop, the participant loses their current-epoch earnings silently. Now checked.

**[F-04]** `TransferOldSettleAmountsToGovernance` error logged not returned. Old settles stuck but records persist for retry. Low severity on its own, but it was inside the atomic section so a failure here would roll back current-epoch settlement too. Separated it out — see below.

**[F-05]** `SettleAccounts` error swallowed by the orchestrator in `module.go`. Even when the function correctly returns an error, it gets thrown away. Now safe because CacheContext guarantees no partial state on failure, but the error is still properly propagated.

Also fixed: `AddTokenomicsData` return value was discarded — coins could be minted but subsidy counter not incremented.

Old settle cleanup separated — `TransferOldSettleAmountsToGovernance` was inside the same code path as current-epoch settlement. With CacheContext, a failure transferring a stale unclaimed settle from a previous epoch would roll back the entire current epoch settlement. Moved it to run after the atomic commit on the real context so current epoch participants aren't affected by old cleanup failures.

---

**What this does NOT fix (pre-existing, unchanged)**

Participants with `amount.Error` (from reward calculation) still get their balance reset in loop 1 but skipped in loop 2 (no settle record written). CacheContext makes this atomic but doesn't change the per-participant logic — that's a broader design question.

`GetActiveParticipants` not found returns nil (silent skip). Original design choice.

---

**Error semantics note**: 
if `SettleAccounts` returns an error after `writeFn()` (only possible from old-settle cleanup), current-epoch settlement is already committed. The error means old unclaimed settles weren't cleaned up. The caller (`onEndOfPoCValidationStage`) logs this and continues, which is correct.