### PR TITLE
perf: move inference stats off

### DIFF
--- a/decentralized-api/internal/event_listener/event_listener.go
+++ b/decentralized-api/internal/event_listener/event_listener.go
@@ -44,6 +44,7 @@ type EventListener struct {
 	configManager         *apiconfig.ConfigManager
 	validator             *validation.InferenceValidator
 	transactionRecorder   cosmosclient.InferenceCosmosClient
+	inferenceStatsStore   *InferenceFinishedStatsStore
 	trainingExecutor      *training.Executor
 	blsManager            *bls.BlsManager
 	nodeCaughtUp          atomic.Bool
@@ -89,12 +90,22 @@ func NewEventListener(
 	}
 
 	bo := NewBlockObserver(configManager)
+	var inferenceStatsStore *InferenceFinishedStatsStore
+	if configManager != nil && configManager.SqlDb() != nil {
+		store, err := NewInferenceFinishedStatsStore(configManager.SqlDb().GetDb())
+		if err != nil {
+			logging.Warn("Failed to initialize inference finished stats store", types.EventProcessing, "error", err)
+		} else {
+			inferenceStatsStore = store
+		}
+	}
 
 	return &EventListener{
 		nodeBroker:            nodeBroker,
 		transactionRecorder:   transactionRecorder,
 		configManager:         configManager,
 		validator:             validator,
+		inferenceStatsStore:   inferenceStatsStore,
 		trainingExecutor:      trainingExecutor,
 		phaseTracker:          phaseTracker,
 		dispatcher:            dispatcher,
@@ -427,10 +438,20 @@ func (e *InferenceFinishedEventHandler) CanHandle(event *chainevents.JSONRPCResp
 }
 
 func (e *InferenceFinishedEventHandler) Handle(event *chainevents.JSONRPCResponse, el *EventListener) error {
+	if err := el.storeInferenceFinishedEvent(event); err != nil {
+		logging.Warn("Failed to persist inference finished stats", types.EventProcessing, "error", err)
+	}
 	if el.isNodeSynced() {
 		el.validator.SampleInferenceToValidate(event.Result.Events["inference_finished.inference_id"], el.transactionRecorder)
 	}
 	return nil
+}
+
+func (el *EventListener) storeInferenceFinishedEvent(event *chainevents.JSONRPCResponse) error {
+	if el.inferenceStatsStore == nil {
+		return nil
+	}
+	return el.inferenceStatsStore.UpsertFromTxEvent(event)
 }
 
 type InferenceValidationEventHandler struct {

--- a/decentralized-api/internal/event_listener/inference_finished_event_handler_test.go
+++ b/decentralized-api/internal/event_listener/inference_finished_event_handler_test.go
@@ -1,0 +1,46 @@
+package event_listener
+
+import (
+	"database/sql"
+	"testing"
+
+	"decentralized-api/internal/event_listener/chainevents"
+
+	_ "modernc.org/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInferenceFinishedEventHandler_Handle_IgnoresStatsStoreFailure(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	store, err := NewInferenceFinishedStatsStore(db)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	require.NoError(t, db.Close())
+
+	event := &chainevents.JSONRPCResponse{
+		Result: chainevents.Result{
+			Events: map[string][]string{
+				"inference_finished.inference_id":           {"inf-1"},
+				"inference_finished.requested_by":           {"dev-1"},
+				"inference_finished.executed_by":            {"exec-1"},
+				"inference_finished.model":                  {"model-a"},
+				"inference_finished.epoch_id":               {"11"},
+				"inference_finished.prompt_token_count":     {"100"},
+				"inference_finished.completion_token_count": {"40"},
+				"inference_finished.actual_cost":            {"140000"},
+				"inference_finished.end_block_timestamp":    {"1730000000000"},
+			},
+		},
+	}
+
+	handler := &InferenceFinishedEventHandler{}
+	el := &EventListener{
+		inferenceStatsStore: store,
+	}
+
+	err = handler.Handle(event, el)
+	require.NoError(t, err)
+}

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"decentralized-api/internal/event_listener/chainevents"
+	"decentralized-api/logging"
+
+	"github.com/productscience/inference/x/inference/types"
 )
 
 const inferenceFinishedStatsSchema = `
@@ -28,6 +31,8 @@ CREATE TABLE IF NOT EXISTS inference_finished_stats (
 	created_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f','now')),
 	updated_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f','now'))
 );
+CREATE INDEX IF NOT EXISTS idx_ifs_time ON inference_finished_stats(end_timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_ifs_time_model ON inference_finished_stats(end_timestamp_ms, model);
 CREATE INDEX IF NOT EXISTS idx_ifs_model_time ON inference_finished_stats(model, end_timestamp_ms);
 CREATE INDEX IF NOT EXISTS idx_ifs_requested_by_time ON inference_finished_stats(requested_by, end_timestamp_ms);
 `
@@ -108,9 +113,12 @@ func (s *InferenceFinishedStatsStore) UpsertFromTxEvent(event *chainevents.JSONR
 
 	events := event.Result.Events
 
-	rows, err := parseInferenceFinishedStatsRows(events)
+	rows, skipped, err := parseInferenceFinishedStatsRows(events)
 	if err != nil {
 		return err
+	}
+	if skipped > 0 && hasRichInferenceFinishedPayload(events) {
+		logging.Warn("Skipped malformed inference_finished stats rows", types.EventProcessing, "skipped", skipped, "total", len(events["inference_finished.inference_id"]))
 	}
 	if len(rows) == 0 {
 		return nil
@@ -178,46 +186,48 @@ func isRetryableSQLiteError(err error) bool {
 		strings.Contains(msg, "context deadline exceeded")
 }
 
-func parseInferenceFinishedStatsRows(events map[string][]string) ([]inferenceFinishedStatsRow, error) {
+func parseInferenceFinishedStatsRows(events map[string][]string) ([]inferenceFinishedStatsRow, int, error) {
 	ids := events["inference_finished.inference_id"]
 	if len(ids) == 0 {
-		return nil, nil
+		return nil, 0, nil
 	}
 
 	rows := make([]inferenceFinishedStatsRow, 0, len(ids))
+	skipped := 0
 	for idx := range ids {
 		row, ok, err := parseInferenceFinishedStatsRowAt(events, idx)
 		if err != nil {
-			return nil, err
+			return nil, skipped, err
 		}
 		if !ok {
+			skipped++
 			continue
 		}
 		rows = append(rows, row)
 	}
-	return rows, nil
+	return rows, skipped, nil
 }
 
 func parseInferenceFinishedStatsRowAt(events map[string][]string, index int) (inferenceFinishedStatsRow, bool, error) {
-	inferenceID, ok := firstEventValueAt(events, "inference_finished.inference_id", index)
+	inferenceID, ok := firstEventValueAt(events, "inference_finished.inference_id", index, false)
 	if !ok {
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	requestedBy, ok := firstEventValueAt(events, "inference_finished.requested_by", index)
+	requestedBy, ok := firstEventValueAt(events, "inference_finished.requested_by", index, false)
 	if !ok {
 		return inferenceFinishedStatsRow{}, false, nil
 	}
-	executedBy, ok := firstEventValueAt(events, "inference_finished.executed_by", index)
+	executedBy, ok := firstEventValueAt(events, "inference_finished.executed_by", index, false)
 	if !ok {
 		return inferenceFinishedStatsRow{}, false, nil
 	}
-	model, ok := firstEventValueAt(events, "inference_finished.model", index)
+	model, ok := firstEventValueAt(events, "inference_finished.model", index, false)
 	if !ok {
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	epochID, ok, err := parseRequiredInt64At(events, "inference_finished.epoch_id", index)
+	epochID, ok, err := parseRequiredInt64At(events, "inference_finished.epoch_id", index, false)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse epoch_id for inference %s: %w", inferenceID, err)
 	}
@@ -225,7 +235,7 @@ func parseInferenceFinishedStatsRowAt(events map[string][]string, index int) (in
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	promptTokens, ok, err := parseRequiredInt64At(events, "inference_finished.prompt_token_count", index)
+	promptTokens, ok, err := parseRequiredInt64At(events, "inference_finished.prompt_token_count", index, false)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse prompt_token_count for inference %s: %w", inferenceID, err)
 	}
@@ -233,7 +243,7 @@ func parseInferenceFinishedStatsRowAt(events map[string][]string, index int) (in
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	completionTokens, ok, err := parseRequiredInt64At(events, "inference_finished.completion_token_count", index)
+	completionTokens, ok, err := parseRequiredInt64At(events, "inference_finished.completion_token_count", index, false)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse completion_token_count for inference %s: %w", inferenceID, err)
 	}
@@ -241,7 +251,7 @@ func parseInferenceFinishedStatsRowAt(events map[string][]string, index int) (in
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	actualCost, ok, err := parseRequiredInt64At(events, "inference_finished.actual_cost", index)
+	actualCost, ok, err := parseRequiredInt64At(events, "inference_finished.actual_cost", index, false)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse actual_cost for inference %s: %w", inferenceID, err)
 	}
@@ -249,7 +259,7 @@ func parseInferenceFinishedStatsRowAt(events map[string][]string, index int) (in
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	endTimestampMs, ok, err := parseRequiredInt64At(events, "inference_finished.end_block_timestamp", index)
+	endTimestampMs, ok, err := parseRequiredInt64At(events, "inference_finished.end_block_timestamp", index, false)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse end_block_timestamp for inference %s: %w", inferenceID, err)
 	}
@@ -257,7 +267,7 @@ func parseInferenceFinishedStatsRowAt(events map[string][]string, index int) (in
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	txHeight, err := parseOptionalInt64At(events, "tx.height", index)
+	txHeight, err := parseOptionalInt64At(events, "tx.height", index, true)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse tx.height for inference %s: %w", inferenceID, err)
 	}
@@ -277,7 +287,7 @@ func parseInferenceFinishedStatsRowAt(events map[string][]string, index int) (in
 	}, true, nil
 }
 
-func firstEventValueAt(events map[string][]string, key string, index int) (string, bool) {
+func firstEventValueAt(events map[string][]string, key string, index int, allowShared bool) (string, bool) {
 	values := events[key]
 	if len(values) == 0 {
 		return "", false
@@ -285,14 +295,14 @@ func firstEventValueAt(events map[string][]string, key string, index int) (strin
 	if index < len(values) && values[index] != "" {
 		return values[index], true
 	}
-	if len(values) == 1 && values[0] != "" {
+	if allowShared && len(values) == 1 && values[0] != "" {
 		return values[0], true
 	}
 	return "", false
 }
 
-func parseRequiredInt64At(events map[string][]string, key string, index int) (int64, bool, error) {
-	raw, ok := firstEventValueAt(events, key, index)
+func parseRequiredInt64At(events map[string][]string, key string, index int, allowShared bool) (int64, bool, error) {
+	raw, ok := firstEventValueAt(events, key, index, allowShared)
 	if !ok {
 		return 0, false, nil
 	}
@@ -303,8 +313,8 @@ func parseRequiredInt64At(events map[string][]string, key string, index int) (in
 	return val, true, nil
 }
 
-func parseOptionalInt64At(events map[string][]string, key string, index int) (int64, error) {
-	raw, ok := firstEventValueAt(events, key, index)
+func parseOptionalInt64At(events map[string][]string, key string, index int, allowShared bool) (int64, error) {
+	raw, ok := firstEventValueAt(events, key, index, allowShared)
 	if !ok {
 		return 0, nil
 	}
@@ -313,4 +323,10 @@ func parseOptionalInt64At(events map[string][]string, key string, index int) (in
 		return 0, err
 	}
 	return val, nil
+}
+
+func hasRichInferenceFinishedPayload(events map[string][]string) bool {
+	return len(events["inference_finished.requested_by"]) > 0 ||
+		len(events["inference_finished.executed_by"]) > 0 ||
+		len(events["inference_finished.model"]) > 0
 }

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store.go
@@ -108,25 +108,25 @@ func (s *InferenceFinishedStatsStore) UpsertFromTxEvent(event *chainevents.JSONR
 
 	events := event.Result.Events
 
-	row, ok, err := parseInferenceFinishedStatsRow(events)
+	rows, err := parseInferenceFinishedStatsRows(events)
 	if err != nil {
 		return err
 	}
-	if !ok {
+	if len(rows) == 0 {
 		return nil
 	}
 
-	return s.upsertRowWithRetry(row)
+	return s.upsertRowsWithRetry(rows)
 }
 
-func (s *InferenceFinishedStatsStore) upsertRowWithRetry(row inferenceFinishedStatsRow) error {
+func (s *InferenceFinishedStatsStore) upsertRowsWithRetry(rows []inferenceFinishedStatsRow) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	var lastErr error
 	for attempt := 0; attempt < statsWriterMaxRetries; attempt++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		err := s.upsertRow(ctx, row)
+		err := s.upsertRows(ctx, rows)
 		cancel()
 		if err == nil {
 			return nil
@@ -140,70 +140,124 @@ func (s *InferenceFinishedStatsStore) upsertRowWithRetry(row inferenceFinishedSt
 	return lastErr
 }
 
-func (s *InferenceFinishedStatsStore) upsertRow(ctx context.Context, row inferenceFinishedStatsRow) error {
-	_, err := s.db.ExecContext(
-		ctx,
-		inferenceFinishedStatsUpsertSQL,
-		row.InferenceID,
-		row.RequestedBy,
-		row.ExecutedBy,
-		row.Model,
-		row.EpochID,
-		row.PromptTokens,
-		row.CompletionTokens,
-		row.TotalTokens,
-		row.ActualCost,
-		row.EndTimestampMs,
-		row.TxHeight,
-	)
-	return err
+func (s *InferenceFinishedStatsStore) upsertRows(ctx context.Context, rows []inferenceFinishedStatsRow) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for _, row := range rows {
+		_, err = tx.ExecContext(
+			ctx,
+			inferenceFinishedStatsUpsertSQL,
+			row.InferenceID,
+			row.RequestedBy,
+			row.ExecutedBy,
+			row.Model,
+			row.EpochID,
+			row.PromptTokens,
+			row.CompletionTokens,
+			row.TotalTokens,
+			row.ActualCost,
+			row.EndTimestampMs,
+			row.TxHeight,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
 }
 
 func isRetryableSQLiteError(err error) bool {
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "database is locked") || strings.Contains(msg, "database is busy")
+	return strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database is busy") ||
+		strings.Contains(msg, "context deadline exceeded")
 }
 
-func parseInferenceFinishedStatsRow(events map[string][]string) (inferenceFinishedStatsRow, bool, error) {
-	inferenceID, ok := firstEventValue(events, "inference_finished.inference_id")
+func parseInferenceFinishedStatsRows(events map[string][]string) ([]inferenceFinishedStatsRow, error) {
+	ids := events["inference_finished.inference_id"]
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	rows := make([]inferenceFinishedStatsRow, 0, len(ids))
+	for idx := range ids {
+		row, ok, err := parseInferenceFinishedStatsRowAt(events, idx)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func parseInferenceFinishedStatsRowAt(events map[string][]string, index int) (inferenceFinishedStatsRow, bool, error) {
+	inferenceID, ok := firstEventValueAt(events, "inference_finished.inference_id", index)
 	if !ok {
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	requestedBy, ok := firstEventValue(events, "inference_finished.requested_by")
+	requestedBy, ok := firstEventValueAt(events, "inference_finished.requested_by", index)
 	if !ok {
 		return inferenceFinishedStatsRow{}, false, nil
 	}
-	executedBy, ok := firstEventValue(events, "inference_finished.executed_by")
+	executedBy, ok := firstEventValueAt(events, "inference_finished.executed_by", index)
 	if !ok {
 		return inferenceFinishedStatsRow{}, false, nil
 	}
-	model, ok := firstEventValue(events, "inference_finished.model")
+	model, ok := firstEventValueAt(events, "inference_finished.model", index)
 	if !ok {
 		return inferenceFinishedStatsRow{}, false, nil
 	}
 
-	epochID, err := parseRequiredInt64(events, "inference_finished.epoch_id")
+	epochID, ok, err := parseRequiredInt64At(events, "inference_finished.epoch_id", index)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse epoch_id for inference %s: %w", inferenceID, err)
 	}
-	promptTokens, err := parseRequiredInt64(events, "inference_finished.prompt_token_count")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+
+	promptTokens, ok, err := parseRequiredInt64At(events, "inference_finished.prompt_token_count", index)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse prompt_token_count for inference %s: %w", inferenceID, err)
 	}
-	completionTokens, err := parseRequiredInt64(events, "inference_finished.completion_token_count")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+
+	completionTokens, ok, err := parseRequiredInt64At(events, "inference_finished.completion_token_count", index)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse completion_token_count for inference %s: %w", inferenceID, err)
 	}
-	actualCost, err := parseRequiredInt64(events, "inference_finished.actual_cost")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+
+	actualCost, ok, err := parseRequiredInt64At(events, "inference_finished.actual_cost", index)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse actual_cost for inference %s: %w", inferenceID, err)
 	}
-	endTimestampMs, err := parseRequiredInt64(events, "inference_finished.end_block_timestamp")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+
+	endTimestampMs, ok, err := parseRequiredInt64At(events, "inference_finished.end_block_timestamp", index)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse end_block_timestamp for inference %s: %w", inferenceID, err)
 	}
-	txHeight, err := parseOptionalInt64(events, "tx.height")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+
+	txHeight, err := parseOptionalInt64At(events, "tx.height", index)
 	if err != nil {
 		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse tx.height for inference %s: %w", inferenceID, err)
 	}
@@ -223,28 +277,34 @@ func parseInferenceFinishedStatsRow(events map[string][]string) (inferenceFinish
 	}, true, nil
 }
 
-func firstEventValue(events map[string][]string, key string) (string, bool) {
+func firstEventValueAt(events map[string][]string, key string, index int) (string, bool) {
 	values := events[key]
-	if len(values) == 0 || values[0] == "" {
+	if len(values) == 0 {
 		return "", false
 	}
-	return values[0], true
+	if index < len(values) && values[index] != "" {
+		return values[index], true
+	}
+	if len(values) == 1 && values[0] != "" {
+		return values[0], true
+	}
+	return "", false
 }
 
-func parseRequiredInt64(events map[string][]string, key string) (int64, error) {
-	raw, ok := firstEventValue(events, key)
+func parseRequiredInt64At(events map[string][]string, key string, index int) (int64, bool, error) {
+	raw, ok := firstEventValueAt(events, key, index)
 	if !ok {
-		return 0, fmt.Errorf("missing key %s", key)
+		return 0, false, nil
 	}
 	val, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
-	return val, nil
+	return val, true, nil
 }
 
-func parseOptionalInt64(events map[string][]string, key string) (int64, error) {
-	raw, ok := firstEventValue(events, key)
+func parseOptionalInt64At(events map[string][]string, key string, index int) (int64, error) {
+	raw, ok := firstEventValueAt(events, key, index)
 	if !ok {
 		return 0, nil
 	}

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store.go
@@ -3,9 +3,9 @@ package event_listener
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +13,8 @@ import (
 	"decentralized-api/logging"
 
 	"github.com/productscience/inference/x/inference/types"
+	sqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 const inferenceFinishedStatsSchema = `
@@ -184,7 +186,7 @@ func (s *InferenceFinishedStatsStore) upsertRows(ctx context.Context, rows []inf
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() // per sql.Tx docs, Rollback after Commit is a no-op
 
 	for _, row := range rows {
 		_, err = tx.ExecContext(
@@ -211,10 +213,15 @@ func (s *InferenceFinishedStatsStore) upsertRows(ctx context.Context, rows []inf
 }
 
 func isRetryableSQLiteError(err error) bool {
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "database is locked") ||
-		strings.Contains(msg, "database is busy") ||
-		strings.Contains(msg, "context deadline exceeded")
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var sqliteErr *sqlite.Error
+	if errors.As(err, &sqliteErr) {
+		code := sqliteErr.Code() & 0xFF // primary result code (mask off extended bits)
+		return code == sqlite3.SQLITE_BUSY || code == sqlite3.SQLITE_LOCKED
+	}
+	return false
 }
 
 func parseInferenceFinishedStatsRows(events map[string][]string) ([]inferenceFinishedStatsRow, int, error) {

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store.go
@@ -1,0 +1,188 @@
+package event_listener
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"decentralized-api/internal/event_listener/chainevents"
+)
+
+const inferenceFinishedStatsSchema = `
+CREATE TABLE IF NOT EXISTS inference_finished_stats (
+	inference_id TEXT PRIMARY KEY,
+	requested_by TEXT NOT NULL,
+	executed_by TEXT NOT NULL,
+	model TEXT NOT NULL,
+	epoch_id INTEGER NOT NULL,
+	prompt_tokens INTEGER NOT NULL,
+	completion_tokens INTEGER NOT NULL,
+	total_tokens INTEGER NOT NULL,
+	actual_cost INTEGER NOT NULL,
+	end_timestamp_ms INTEGER NOT NULL,
+	tx_height INTEGER NOT NULL DEFAULT 0,
+	created_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f','now')),
+	updated_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ifs_model_time ON inference_finished_stats(model, end_timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_ifs_requested_by_time ON inference_finished_stats(requested_by, end_timestamp_ms);
+`
+
+type InferenceFinishedStatsStore struct {
+	db *sql.DB
+}
+
+func NewInferenceFinishedStatsStore(db *sql.DB) (*InferenceFinishedStatsStore, error) {
+	if db == nil {
+		return nil, nil
+	}
+	store := &InferenceFinishedStatsStore{db: db}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := store.ensureSchema(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *InferenceFinishedStatsStore) ensureSchema(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, inferenceFinishedStatsSchema)
+	return err
+}
+
+func (s *InferenceFinishedStatsStore) UpsertFromTxEvent(event *chainevents.JSONRPCResponse) error {
+	if s == nil || s.db == nil || event == nil {
+		return nil
+	}
+
+	events := event.Result.Events
+
+	inferenceID, ok := firstEventValue(events, "inference_finished.inference_id")
+	if !ok {
+		return nil
+	}
+
+	// Backward compatible: old events include only inference_id.
+	requestedBy, ok := firstEventValue(events, "inference_finished.requested_by")
+	if !ok {
+		return nil
+	}
+	executedBy, ok := firstEventValue(events, "inference_finished.executed_by")
+	if !ok {
+		return nil
+	}
+	model, ok := firstEventValue(events, "inference_finished.model")
+	if !ok {
+		return nil
+	}
+
+	epochID, err := parseRequiredInt64(events, "inference_finished.epoch_id")
+	if err != nil {
+		return fmt.Errorf("parse epoch_id for inference %s: %w", inferenceID, err)
+	}
+	promptTokens, err := parseRequiredInt64(events, "inference_finished.prompt_token_count")
+	if err != nil {
+		return fmt.Errorf("parse prompt_token_count for inference %s: %w", inferenceID, err)
+	}
+	completionTokens, err := parseRequiredInt64(events, "inference_finished.completion_token_count")
+	if err != nil {
+		return fmt.Errorf("parse completion_token_count for inference %s: %w", inferenceID, err)
+	}
+	actualCost, err := parseRequiredInt64(events, "inference_finished.actual_cost")
+	if err != nil {
+		return fmt.Errorf("parse actual_cost for inference %s: %w", inferenceID, err)
+	}
+	endTimestampMs, err := parseRequiredInt64(events, "inference_finished.end_block_timestamp")
+	if err != nil {
+		return fmt.Errorf("parse end_block_timestamp for inference %s: %w", inferenceID, err)
+	}
+
+	txHeight, err := parseOptionalInt64(events, "tx.height")
+	if err != nil {
+		return fmt.Errorf("parse tx.height for inference %s: %w", inferenceID, err)
+	}
+
+	totalTokens := promptTokens + completionTokens
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	const upsertSQL = `
+INSERT INTO inference_finished_stats (
+	inference_id,
+	requested_by,
+	executed_by,
+	model,
+	epoch_id,
+	prompt_tokens,
+	completion_tokens,
+	total_tokens,
+	actual_cost,
+	end_timestamp_ms,
+	tx_height
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(inference_id) DO UPDATE SET
+	requested_by = excluded.requested_by,
+	executed_by = excluded.executed_by,
+	model = excluded.model,
+	epoch_id = excluded.epoch_id,
+	prompt_tokens = excluded.prompt_tokens,
+	completion_tokens = excluded.completion_tokens,
+	total_tokens = excluded.total_tokens,
+	actual_cost = excluded.actual_cost,
+	end_timestamp_ms = excluded.end_timestamp_ms,
+	tx_height = excluded.tx_height,
+	updated_at = (STRFTIME('%Y-%m-%d %H:%M:%f','now'))
+`
+
+	_, err = s.db.ExecContext(
+		ctx,
+		upsertSQL,
+		inferenceID,
+		requestedBy,
+		executedBy,
+		model,
+		epochID,
+		promptTokens,
+		completionTokens,
+		totalTokens,
+		actualCost,
+		endTimestampMs,
+		txHeight,
+	)
+	return err
+}
+
+func firstEventValue(events map[string][]string, key string) (string, bool) {
+	values := events[key]
+	if len(values) == 0 || values[0] == "" {
+		return "", false
+	}
+	return values[0], true
+}
+
+func parseRequiredInt64(events map[string][]string, key string) (int64, error) {
+	raw, ok := firstEventValue(events, key)
+	if !ok {
+		return 0, fmt.Errorf("missing key %s", key)
+	}
+	val, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+
+func parseOptionalInt64(events map[string][]string, key string) (int64, error) {
+	raw, ok := firstEventValue(events, key)
+	if !ok {
+		return 0, nil
+	}
+	val, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store.go
@@ -39,6 +39,9 @@ CREATE INDEX IF NOT EXISTS idx_ifs_requested_by_time ON inference_finished_stats
 
 const (
 	statsWriterMaxRetries = 4
+	statsRetentionPeriod  = 30 * 24 * time.Hour
+	statsPruneInterval    = 6 * time.Hour
+	statsPruneTimeout     = 2 * time.Second
 )
 
 const inferenceFinishedStatsUpsertSQL = `
@@ -84,8 +87,9 @@ type inferenceFinishedStatsRow struct {
 }
 
 type InferenceFinishedStatsStore struct {
-	db *sql.DB
-	mu sync.Mutex
+	db          *sql.DB
+	mu          sync.Mutex
+	lastPruneAt time.Time
 }
 
 func NewInferenceFinishedStatsStore(db *sql.DB) (*InferenceFinishedStatsStore, error) {
@@ -130,6 +134,7 @@ func (s *InferenceFinishedStatsStore) UpsertFromTxEvent(event *chainevents.JSONR
 func (s *InferenceFinishedStatsStore) upsertRowsWithRetry(rows []inferenceFinishedStatsRow) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.maybePruneLocked()
 
 	var lastErr error
 	for attempt := 0; attempt < statsWriterMaxRetries; attempt++ {
@@ -146,6 +151,32 @@ func (s *InferenceFinishedStatsStore) upsertRowsWithRetry(rows []inferenceFinish
 		time.Sleep(time.Duration(40*(1<<attempt)) * time.Millisecond)
 	}
 	return lastErr
+}
+
+func (s *InferenceFinishedStatsStore) maybePruneLocked() {
+	now := time.Now()
+	if !s.lastPruneAt.IsZero() && now.Sub(s.lastPruneAt) < statsPruneInterval {
+		return
+	}
+	s.lastPruneAt = now
+
+	cutoffMillis := now.Add(-statsRetentionPeriod).UnixMilli()
+	ctx, cancel := context.WithTimeout(context.Background(), statsPruneTimeout)
+	defer cancel()
+
+	result, err := s.db.ExecContext(
+		ctx,
+		`DELETE FROM inference_finished_stats WHERE end_timestamp_ms < ?`,
+		cutoffMillis,
+	)
+	if err != nil {
+		logging.Warn("Failed to prune inference_finished stats", types.EventProcessing, "error", err)
+		return
+	}
+	deletedRows, err := result.RowsAffected()
+	if err == nil && deletedRows > 0 {
+		logging.Info("Pruned old inference_finished stats", types.EventProcessing, "deleted_rows", deletedRows, "cutoff_ms", cutoffMillis)
+	}
 }
 
 func (s *InferenceFinishedStatsStore) upsertRows(ctx context.Context, rows []inferenceFinishedStatsRow) error {

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"decentralized-api/internal/event_listener/chainevents"
@@ -30,86 +32,11 @@ CREATE INDEX IF NOT EXISTS idx_ifs_model_time ON inference_finished_stats(model,
 CREATE INDEX IF NOT EXISTS idx_ifs_requested_by_time ON inference_finished_stats(requested_by, end_timestamp_ms);
 `
 
-type InferenceFinishedStatsStore struct {
-	db *sql.DB
-}
+const (
+	statsWriterMaxRetries = 4
+)
 
-func NewInferenceFinishedStatsStore(db *sql.DB) (*InferenceFinishedStatsStore, error) {
-	if db == nil {
-		return nil, nil
-	}
-	store := &InferenceFinishedStatsStore{db: db}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	if err := store.ensureSchema(ctx); err != nil {
-		return nil, err
-	}
-	return store, nil
-}
-
-func (s *InferenceFinishedStatsStore) ensureSchema(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, inferenceFinishedStatsSchema)
-	return err
-}
-
-func (s *InferenceFinishedStatsStore) UpsertFromTxEvent(event *chainevents.JSONRPCResponse) error {
-	if s == nil || s.db == nil || event == nil {
-		return nil
-	}
-
-	events := event.Result.Events
-
-	inferenceID, ok := firstEventValue(events, "inference_finished.inference_id")
-	if !ok {
-		return nil
-	}
-
-	// Backward compatible: old events include only inference_id.
-	requestedBy, ok := firstEventValue(events, "inference_finished.requested_by")
-	if !ok {
-		return nil
-	}
-	executedBy, ok := firstEventValue(events, "inference_finished.executed_by")
-	if !ok {
-		return nil
-	}
-	model, ok := firstEventValue(events, "inference_finished.model")
-	if !ok {
-		return nil
-	}
-
-	epochID, err := parseRequiredInt64(events, "inference_finished.epoch_id")
-	if err != nil {
-		return fmt.Errorf("parse epoch_id for inference %s: %w", inferenceID, err)
-	}
-	promptTokens, err := parseRequiredInt64(events, "inference_finished.prompt_token_count")
-	if err != nil {
-		return fmt.Errorf("parse prompt_token_count for inference %s: %w", inferenceID, err)
-	}
-	completionTokens, err := parseRequiredInt64(events, "inference_finished.completion_token_count")
-	if err != nil {
-		return fmt.Errorf("parse completion_token_count for inference %s: %w", inferenceID, err)
-	}
-	actualCost, err := parseRequiredInt64(events, "inference_finished.actual_cost")
-	if err != nil {
-		return fmt.Errorf("parse actual_cost for inference %s: %w", inferenceID, err)
-	}
-	endTimestampMs, err := parseRequiredInt64(events, "inference_finished.end_block_timestamp")
-	if err != nil {
-		return fmt.Errorf("parse end_block_timestamp for inference %s: %w", inferenceID, err)
-	}
-
-	txHeight, err := parseOptionalInt64(events, "tx.height")
-	if err != nil {
-		return fmt.Errorf("parse tx.height for inference %s: %w", inferenceID, err)
-	}
-
-	totalTokens := promptTokens + completionTokens
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	const upsertSQL = `
+const inferenceFinishedStatsUpsertSQL = `
 INSERT INTO inference_finished_stats (
 	inference_id,
 	requested_by,
@@ -137,22 +64,163 @@ ON CONFLICT(inference_id) DO UPDATE SET
 	updated_at = (STRFTIME('%Y-%m-%d %H:%M:%f','now'))
 `
 
-	_, err = s.db.ExecContext(
+type inferenceFinishedStatsRow struct {
+	InferenceID      string
+	RequestedBy      string
+	ExecutedBy       string
+	Model            string
+	EpochID          int64
+	PromptTokens     int64
+	CompletionTokens int64
+	TotalTokens      int64
+	ActualCost       int64
+	EndTimestampMs   int64
+	TxHeight         int64
+}
+
+type InferenceFinishedStatsStore struct {
+	db *sql.DB
+	mu sync.Mutex
+}
+
+func NewInferenceFinishedStatsStore(db *sql.DB) (*InferenceFinishedStatsStore, error) {
+	if db == nil {
+		return nil, nil
+	}
+	store := &InferenceFinishedStatsStore{db: db}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := store.ensureSchema(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *InferenceFinishedStatsStore) ensureSchema(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, inferenceFinishedStatsSchema)
+	return err
+}
+
+func (s *InferenceFinishedStatsStore) UpsertFromTxEvent(event *chainevents.JSONRPCResponse) error {
+	if s == nil || s.db == nil || event == nil {
+		return nil
+	}
+
+	events := event.Result.Events
+
+	row, ok, err := parseInferenceFinishedStatsRow(events)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	return s.upsertRowWithRetry(row)
+}
+
+func (s *InferenceFinishedStatsStore) upsertRowWithRetry(row inferenceFinishedStatsRow) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var lastErr error
+	for attempt := 0; attempt < statsWriterMaxRetries; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		err := s.upsertRow(ctx, row)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		if !isRetryableSQLiteError(err) {
+			return err
+		}
+		lastErr = err
+		time.Sleep(time.Duration(40*(1<<attempt)) * time.Millisecond)
+	}
+	return lastErr
+}
+
+func (s *InferenceFinishedStatsStore) upsertRow(ctx context.Context, row inferenceFinishedStatsRow) error {
+	_, err := s.db.ExecContext(
 		ctx,
-		upsertSQL,
-		inferenceID,
-		requestedBy,
-		executedBy,
-		model,
-		epochID,
-		promptTokens,
-		completionTokens,
-		totalTokens,
-		actualCost,
-		endTimestampMs,
-		txHeight,
+		inferenceFinishedStatsUpsertSQL,
+		row.InferenceID,
+		row.RequestedBy,
+		row.ExecutedBy,
+		row.Model,
+		row.EpochID,
+		row.PromptTokens,
+		row.CompletionTokens,
+		row.TotalTokens,
+		row.ActualCost,
+		row.EndTimestampMs,
+		row.TxHeight,
 	)
 	return err
+}
+
+func isRetryableSQLiteError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "database is locked") || strings.Contains(msg, "database is busy")
+}
+
+func parseInferenceFinishedStatsRow(events map[string][]string) (inferenceFinishedStatsRow, bool, error) {
+	inferenceID, ok := firstEventValue(events, "inference_finished.inference_id")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+
+	requestedBy, ok := firstEventValue(events, "inference_finished.requested_by")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+	executedBy, ok := firstEventValue(events, "inference_finished.executed_by")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+	model, ok := firstEventValue(events, "inference_finished.model")
+	if !ok {
+		return inferenceFinishedStatsRow{}, false, nil
+	}
+
+	epochID, err := parseRequiredInt64(events, "inference_finished.epoch_id")
+	if err != nil {
+		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse epoch_id for inference %s: %w", inferenceID, err)
+	}
+	promptTokens, err := parseRequiredInt64(events, "inference_finished.prompt_token_count")
+	if err != nil {
+		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse prompt_token_count for inference %s: %w", inferenceID, err)
+	}
+	completionTokens, err := parseRequiredInt64(events, "inference_finished.completion_token_count")
+	if err != nil {
+		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse completion_token_count for inference %s: %w", inferenceID, err)
+	}
+	actualCost, err := parseRequiredInt64(events, "inference_finished.actual_cost")
+	if err != nil {
+		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse actual_cost for inference %s: %w", inferenceID, err)
+	}
+	endTimestampMs, err := parseRequiredInt64(events, "inference_finished.end_block_timestamp")
+	if err != nil {
+		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse end_block_timestamp for inference %s: %w", inferenceID, err)
+	}
+	txHeight, err := parseOptionalInt64(events, "tx.height")
+	if err != nil {
+		return inferenceFinishedStatsRow{}, false, fmt.Errorf("parse tx.height for inference %s: %w", inferenceID, err)
+	}
+
+	return inferenceFinishedStatsRow{
+		InferenceID:      inferenceID,
+		RequestedBy:      requestedBy,
+		ExecutedBy:       executedBy,
+		Model:            model,
+		EpochID:          epochID,
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+		ActualCost:       actualCost,
+		EndTimestampMs:   endTimestampMs,
+		TxHeight:         txHeight,
+	}, true, nil
 }
 
 func firstEventValue(events map[string][]string, key string) (string, bool) {

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store_test.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store_test.go
@@ -123,3 +123,62 @@ func TestInferenceFinishedStatsStore_BackwardCompatibleOldEvent(t *testing.T) {
 		t.Fatalf("expected no rows for legacy event, got %d", count)
 	}
 }
+
+func TestInferenceFinishedStatsStore_UpsertFromTxEvent_MultipleInferencesInTx(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewInferenceFinishedStatsStore(db)
+	if err != nil {
+		t.Fatalf("init stats store: %v", err)
+	}
+
+	event := &chainevents.JSONRPCResponse{
+		Result: chainevents.Result{
+			Events: map[string][]string{
+				"inference_finished.inference_id":           []string{"inf-1", "inf-2"},
+				"inference_finished.requested_by":           []string{"dev-1", "dev-2"},
+				"inference_finished.executed_by":            []string{"exec-1", "exec-2"},
+				"inference_finished.model":                  []string{"model-a", "model-b"},
+				"inference_finished.epoch_id":               []string{"11", "12"},
+				"inference_finished.prompt_token_count":     []string{"100", "200"},
+				"inference_finished.completion_token_count": []string{"40", "50"},
+				"inference_finished.actual_cost":            []string{"140000", "250000"},
+				"inference_finished.end_block_timestamp":    []string{"1730000000000", "1730000001000"},
+				"tx.height":                                 []string{"900"},
+			},
+		},
+	}
+	if err := store.UpsertFromTxEvent(event); err != nil {
+		t.Fatalf("insert multi inference stats: %v", err)
+	}
+
+	var count int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM inference_finished_stats`).Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 rows, got %d", count)
+	}
+
+	var (
+		requestedBy string
+		model       string
+		totalTokens int64
+		txHeight    int64
+	)
+	err = db.QueryRow(`
+		SELECT requested_by, model, total_tokens, tx_height
+		FROM inference_finished_stats
+		WHERE inference_id = 'inf-2'
+	`).Scan(&requestedBy, &model, &totalTokens, &txHeight)
+	if err != nil {
+		t.Fatalf("query second row: %v", err)
+	}
+	if requestedBy != "dev-2" || model != "model-b" || totalTokens != 250 || txHeight != 900 {
+		t.Fatalf("unexpected second row values: requestedBy=%s model=%s totalTokens=%d txHeight=%d", requestedBy, model, totalTokens, txHeight)
+	}
+}

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store_test.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store_test.go
@@ -1,0 +1,125 @@
+package event_listener
+
+import (
+	"database/sql"
+	"testing"
+
+	"decentralized-api/internal/event_listener/chainevents"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestInferenceFinishedStatsStore_UpsertFromTxEvent(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewInferenceFinishedStatsStore(db)
+	if err != nil {
+		t.Fatalf("init stats store: %v", err)
+	}
+
+	event := &chainevents.JSONRPCResponse{
+		Result: chainevents.Result{
+			Events: map[string][]string{
+				"inference_finished.inference_id":           []string{"inf-1"},
+				"inference_finished.requested_by":           []string{"dev-1"},
+				"inference_finished.executed_by":            []string{"exec-1"},
+				"inference_finished.model":                  []string{"model-a"},
+				"inference_finished.epoch_id":               []string{"11"},
+				"inference_finished.prompt_token_count":     []string{"100"},
+				"inference_finished.completion_token_count": []string{"40"},
+				"inference_finished.actual_cost":            []string{"140000"},
+				"inference_finished.end_block_timestamp":    []string{"1730000000000"},
+				"tx.height":                                 []string{"777"},
+			},
+		},
+	}
+	if err := store.UpsertFromTxEvent(event); err != nil {
+		t.Fatalf("insert stats: %v", err)
+	}
+
+	var (
+		requestedBy string
+		model       string
+		totalTokens int64
+		txHeight    int64
+	)
+	err = db.QueryRow(`
+		SELECT requested_by, model, total_tokens, tx_height
+		FROM inference_finished_stats
+		WHERE inference_id = 'inf-1'
+	`).Scan(&requestedBy, &model, &totalTokens, &txHeight)
+	if err != nil {
+		t.Fatalf("query inserted row: %v", err)
+	}
+	if requestedBy != "dev-1" || model != "model-a" || totalTokens != 140 || txHeight != 777 {
+		t.Fatalf("unexpected row values: requestedBy=%s model=%s totalTokens=%d txHeight=%d", requestedBy, model, totalTokens, txHeight)
+	}
+
+	updatedEvent := &chainevents.JSONRPCResponse{
+		Result: chainevents.Result{
+			Events: map[string][]string{
+				"inference_finished.inference_id":           []string{"inf-1"},
+				"inference_finished.requested_by":           []string{"dev-2"},
+				"inference_finished.executed_by":            []string{"exec-1"},
+				"inference_finished.model":                  []string{"model-b"},
+				"inference_finished.epoch_id":               []string{"12"},
+				"inference_finished.prompt_token_count":     []string{"110"},
+				"inference_finished.completion_token_count": []string{"50"},
+				"inference_finished.actual_cost":            []string{"160000"},
+				"inference_finished.end_block_timestamp":    []string{"1730000001000"},
+				"tx.height":                                 []string{"778"},
+			},
+		},
+	}
+	if err := store.UpsertFromTxEvent(updatedEvent); err != nil {
+		t.Fatalf("update stats: %v", err)
+	}
+
+	err = db.QueryRow(`
+		SELECT requested_by, model, total_tokens, tx_height
+		FROM inference_finished_stats
+		WHERE inference_id = 'inf-1'
+	`).Scan(&requestedBy, &model, &totalTokens, &txHeight)
+	if err != nil {
+		t.Fatalf("query updated row: %v", err)
+	}
+	if requestedBy != "dev-2" || model != "model-b" || totalTokens != 160 || txHeight != 778 {
+		t.Fatalf("unexpected updated values: requestedBy=%s model=%s totalTokens=%d txHeight=%d", requestedBy, model, totalTokens, txHeight)
+	}
+}
+
+func TestInferenceFinishedStatsStore_BackwardCompatibleOldEvent(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewInferenceFinishedStatsStore(db)
+	if err != nil {
+		t.Fatalf("init stats store: %v", err)
+	}
+
+	oldEvent := &chainevents.JSONRPCResponse{
+		Result: chainevents.Result{
+			Events: map[string][]string{
+				"inference_finished.inference_id": []string{"legacy-inf-1"},
+			},
+		},
+	}
+	if err := store.UpsertFromTxEvent(oldEvent); err != nil {
+		t.Fatalf("old event should be ignored without errors: %v", err)
+	}
+
+	var count int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM inference_finished_stats`).Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no rows for legacy event, got %d", count)
+	}
+}

--- a/decentralized-api/internal/event_listener/inference_finished_stats_store_test.go
+++ b/decentralized-api/internal/event_listener/inference_finished_stats_store_test.go
@@ -2,7 +2,9 @@ package event_listener
 
 import (
 	"database/sql"
+	"strconv"
 	"testing"
+	"time"
 
 	"decentralized-api/internal/event_listener/chainevents"
 
@@ -180,5 +182,66 @@ func TestInferenceFinishedStatsStore_UpsertFromTxEvent_MultipleInferencesInTx(t 
 	}
 	if requestedBy != "dev-2" || model != "model-b" || totalTokens != 250 || txHeight != 900 {
 		t.Fatalf("unexpected second row values: requestedBy=%s model=%s totalTokens=%d txHeight=%d", requestedBy, model, totalTokens, txHeight)
+	}
+}
+
+func TestInferenceFinishedStatsStore_PrunesOldRowsOnUpsert(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewInferenceFinishedStatsStore(db)
+	if err != nil {
+		t.Fatalf("init stats store: %v", err)
+	}
+
+	oldTimestamp := time.Now().Add(-statsRetentionPeriod - time.Hour).UnixMilli()
+	_, err = db.Exec(`
+		INSERT INTO inference_finished_stats (
+			inference_id, requested_by, executed_by, model, epoch_id,
+			prompt_tokens, completion_tokens, total_tokens, actual_cost, end_timestamp_ms, tx_height
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, "old-inf", "dev-old", "exec-old", "model-old", 1, 1, 1, 2, 10, oldTimestamp, 1)
+	if err != nil {
+		t.Fatalf("insert old row: %v", err)
+	}
+
+	newTimestamp := time.Now().UnixMilli()
+	event := &chainevents.JSONRPCResponse{
+		Result: chainevents.Result{
+			Events: map[string][]string{
+				"inference_finished.inference_id":           []string{"fresh-inf"},
+				"inference_finished.requested_by":           []string{"dev-fresh"},
+				"inference_finished.executed_by":            []string{"exec-fresh"},
+				"inference_finished.model":                  []string{"model-fresh"},
+				"inference_finished.epoch_id":               []string{"2"},
+				"inference_finished.prompt_token_count":     []string{"10"},
+				"inference_finished.completion_token_count": []string{"5"},
+				"inference_finished.actual_cost":            []string{"15"},
+				"inference_finished.end_block_timestamp":    []string{strconv.FormatInt(newTimestamp, 10)},
+				"tx.height":                                 []string{"2"},
+			},
+		},
+	}
+	if err := store.UpsertFromTxEvent(event); err != nil {
+		t.Fatalf("upsert fresh row: %v", err)
+	}
+
+	var oldCount int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM inference_finished_stats WHERE inference_id = 'old-inf'`).Scan(&oldCount); err != nil {
+		t.Fatalf("count old row: %v", err)
+	}
+	if oldCount != 0 {
+		t.Fatalf("expected old row to be pruned, got count=%d", oldCount)
+	}
+
+	var freshCount int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM inference_finished_stats WHERE inference_id = 'fresh-inf'`).Scan(&freshCount); err != nil {
+		t.Fatalf("count fresh row: %v", err)
+	}
+	if freshCount != 1 {
+		t.Fatalf("expected fresh row to remain, got count=%d", freshCount)
 	}
 }

--- a/decentralized-api/internal/server/public/get_pricing_handler.go
+++ b/decentralized-api/internal/server/public/get_pricing_handler.go
@@ -165,6 +165,13 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 			return metricsData
 		}
 		effectiveStats = chainModelStats
+	} else if hasMissingModelStats(capacityMap, localModelStats) {
+		chainModelStats, err := s.getModelTokenStatsFromChain(queryClient, context, windowDurationSeconds)
+		if err != nil {
+			logging.Warn("Failed to get missing model stats from chain, using local-only stats", types.Pricing, "error", err)
+		} else {
+			effectiveStats = mergeModelTokenStatsForMissingModels(capacityMap, localModelStats, chainModelStats)
+		}
 	}
 
 	for modelID, totalTokens := range effectiveStats {
@@ -178,6 +185,37 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 	}
 
 	return metricsData
+}
+
+func hasMissingModelStats(capacityMap map[string]uint64, stats modelTokenStats) bool {
+	for modelID := range capacityMap {
+		if _, exists := stats[modelID]; !exists {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeModelTokenStatsForMissingModels(
+	capacityMap map[string]uint64,
+	localStats modelTokenStats,
+	chainStats modelTokenStats,
+) modelTokenStats {
+	merged := make(modelTokenStats, len(localStats))
+	for modelID, totalTokens := range localStats {
+		merged[modelID] = totalTokens
+	}
+
+	for modelID := range capacityMap {
+		if _, exists := merged[modelID]; exists {
+			continue
+		}
+		if totalTokens, exists := chainStats[modelID]; exists {
+			merged[modelID] = totalTokens
+		}
+	}
+
+	return merged
 }
 
 func (s *Server) getModelTokenStatsFromLocalStore(ctx context.Context, windowDurationSeconds int64) (modelTokenStats, bool) {

--- a/decentralized-api/internal/server/public/get_pricing_handler.go
+++ b/decentralized-api/internal/server/public/get_pricing_handler.go
@@ -167,14 +167,14 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 		return metricsData
 	}
 
-	// Calculate time window (similar to BeginBlocker logic)
-	currentTime := time.Now().Unix()
-	timeWindowStart := currentTime - windowDurationSeconds
+	// Calculate time window in milliseconds to match chain stats query semantics
+	currentTimeMillis := time.Now().UnixMilli()
+	timeWindowStartMillis := currentTimeMillis - windowDurationSeconds*1000
 
 	// Get stats for all models in time window
 	statsResponse, err := queryClient.InferencesAndTokensStatsByModels(context, &types.QueryInferencesAndTokensStatsByModelsRequest{
-		TimeFrom: timeWindowStart,
-		TimeTo:   currentTime,
+		TimeFrom: timeWindowStartMillis,
+		TimeTo:   currentTimeMillis,
 	})
 	if err != nil {
 		logging.Warn("Failed to get model stats for utilization", types.Pricing, "error", err)

--- a/decentralized-api/internal/server/public/get_pricing_handler.go
+++ b/decentralized-api/internal/server/public/get_pricing_handler.go
@@ -152,10 +152,24 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 	if err != nil || params.Params.DynamicPricingParams == nil {
 		return metricsData // Return with capacity data only
 	}
+	windowDurationSeconds := int64(params.Params.DynamicPricingParams.UtilizationWindowDuration)
+
+	localModelStats, ok := s.getModelTokenStatsFromLocalStore(context, windowDurationSeconds)
+	if ok {
+		for modelID, totalTokens := range localModelStats {
+			if capacity, exists := capacityMap[modelID]; exists && capacity > 0 {
+				metricsData[modelID] = ModelMetrics{
+					Capacity:    capacity,
+					Utilization: float64(totalTokens) / float64(capacity),
+				}
+			}
+		}
+		return metricsData
+	}
 
 	// Calculate time window (similar to BeginBlocker logic)
 	currentTime := time.Now().Unix()
-	timeWindowStart := currentTime - int64(params.Params.DynamicPricingParams.UtilizationWindowDuration)
+	timeWindowStart := currentTime - windowDurationSeconds
 
 	// Get stats for all models in time window
 	statsResponse, err := queryClient.InferencesAndTokensStatsByModels(context, &types.QueryInferencesAndTokensStatsByModelsRequest{
@@ -182,6 +196,51 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 	}
 
 	return metricsData
+}
+
+func (s *Server) getModelTokenStatsFromLocalStore(ctx context.Context, windowDurationSeconds int64) (map[string]int64, bool) {
+	if s.configManager == nil || s.configManager.SqlDb() == nil || s.configManager.SqlDb().GetDb() == nil {
+		return nil, false
+	}
+
+	nowMillis := time.Now().UnixMilli()
+	fromMillis := nowMillis - windowDurationSeconds*1000
+
+	rows, err := s.configManager.SqlDb().GetDb().QueryContext(
+		ctx,
+		`SELECT model, COALESCE(SUM(total_tokens), 0)
+		 FROM inference_finished_stats
+		 WHERE end_timestamp_ms >= ? AND end_timestamp_ms <= ?
+		 GROUP BY model`,
+		fromMillis,
+		nowMillis,
+	)
+	if err != nil {
+		logging.Warn("Failed to read model stats from local store", types.Pricing, "error", err)
+		return nil, false
+	}
+	defer rows.Close()
+
+	stats := make(map[string]int64)
+	for rows.Next() {
+		var (
+			model      string
+			totalToken int64
+		)
+		if err := rows.Scan(&model, &totalToken); err != nil {
+			logging.Warn("Failed to scan model stats row from local store", types.Pricing, "error", err)
+			return nil, false
+		}
+		stats[model] = totalToken
+	}
+	if err := rows.Err(); err != nil {
+		logging.Warn("Failed while iterating local model stats", types.Pricing, "error", err)
+		return nil, false
+	}
+	if len(stats) == 0 {
+		return nil, false
+	}
+	return stats, true
 }
 
 // getDynamicPricingData queries dynamic pricing information from the chain

--- a/decentralized-api/internal/server/public/get_pricing_handler.go
+++ b/decentralized-api/internal/server/public/get_pricing_handler.go
@@ -125,6 +125,8 @@ type ModelMetrics struct {
 	Capacity    uint64
 }
 
+type modelTokenStats map[string]int64
+
 // getModelMetrics calculates utilization and gets capacity for all models in one go
 func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.Context) map[string]ModelMetrics {
 	metricsData := make(map[string]ModelMetrics)
@@ -154,41 +156,26 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 	}
 	windowDurationSeconds := int64(params.Params.DynamicPricingParams.UtilizationWindowDuration)
 
-	localModelStats, ok := s.getModelTokenStatsFromLocalStore(context, windowDurationSeconds)
-	if ok {
-		for modelID, totalTokens := range localModelStats {
-			if capacity, exists := capacityMap[modelID]; exists && capacity > 0 {
-				metricsData[modelID] = ModelMetrics{
-					Capacity:    capacity,
-					Utilization: float64(totalTokens) / float64(capacity),
-				}
-			}
-		}
-		return metricsData
-	}
-
-	// Calculate time window in milliseconds to match chain stats query semantics
-	currentTimeMillis := time.Now().UnixMilli()
-	timeWindowStartMillis := currentTimeMillis - windowDurationSeconds*1000
-
-	// Get stats for all models in time window
-	statsResponse, err := queryClient.InferencesAndTokensStatsByModels(context, &types.QueryInferencesAndTokensStatsByModelsRequest{
-		TimeFrom: timeWindowStartMillis,
-		TimeTo:   currentTimeMillis,
-	})
+	localModelStats, hasLocalStats := s.getModelTokenStatsFromLocalStore(context, windowDurationSeconds)
+	chainModelStats, err := s.getModelTokenStatsFromChain(queryClient, context, windowDurationSeconds)
 	if err != nil {
-		logging.Warn("Failed to get model stats for utilization", types.Pricing, "error", err)
-		return metricsData // Return with capacity data only
+		if !hasLocalStats {
+			logging.Warn("Failed to get model stats for utilization", types.Pricing, "error", err)
+			return metricsData
+		}
+		logging.Warn("Falling back to local model stats for utilization", types.Pricing, "error", err)
+		chainModelStats = modelTokenStats{}
 	}
 
-	// Calculate utilization for each model and update metrics
-	for _, modelStat := range statsResponse.StatsModels {
-		if capacity, exists := capacityMap[modelStat.Model]; exists && capacity > 0 {
-			// Calculate utilization = tokens_used / capacity
-			utilization := float64(modelStat.AiTokens) / float64(capacity)
+	effectiveStats := chainModelStats
+	if hasLocalStats {
+		effectiveStats = mergeModelTokenStats(chainModelStats, localModelStats)
+	}
 
-			// Update the metrics with calculated utilization
-			metricsData[modelStat.Model] = ModelMetrics{
+	for modelID, totalTokens := range effectiveStats {
+		if capacity, exists := capacityMap[modelID]; exists && capacity > 0 {
+			utilization := float64(totalTokens) / float64(capacity)
+			metricsData[modelID] = ModelMetrics{
 				Capacity:    capacity,
 				Utilization: utilization,
 			}
@@ -198,7 +185,7 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 	return metricsData
 }
 
-func (s *Server) getModelTokenStatsFromLocalStore(ctx context.Context, windowDurationSeconds int64) (map[string]int64, bool) {
+func (s *Server) getModelTokenStatsFromLocalStore(ctx context.Context, windowDurationSeconds int64) (modelTokenStats, bool) {
 	if s.configManager == nil || s.configManager.SqlDb() == nil || s.configManager.SqlDb().GetDb() == nil {
 		return nil, false
 	}
@@ -221,7 +208,7 @@ func (s *Server) getModelTokenStatsFromLocalStore(ctx context.Context, windowDur
 	}
 	defer rows.Close()
 
-	stats := make(map[string]int64)
+	stats := make(modelTokenStats)
 	for rows.Next() {
 		var (
 			model      string
@@ -241,6 +228,62 @@ func (s *Server) getModelTokenStatsFromLocalStore(ctx context.Context, windowDur
 		return nil, false
 	}
 	return stats, true
+}
+
+func (s *Server) getModelTokenStatsFromChain(
+	queryClient types.QueryClient,
+	ctx context.Context,
+	windowDurationSeconds int64,
+) (modelTokenStats, error) {
+	currentTimeMillis := time.Now().UnixMilli()
+	timeWindowStartMillis := currentTimeMillis - windowDurationSeconds*1000
+
+	statsResponse, err := queryClient.InferencesAndTokensStatsByModels(ctx, &types.QueryInferencesAndTokensStatsByModelsRequest{
+		TimeFrom: timeWindowStartMillis,
+		TimeTo:   currentTimeMillis,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	stats := make(modelTokenStats)
+	for _, modelStat := range statsResponse.StatsModels {
+		stats[modelStat.Model] = modelStat.AiTokens
+	}
+	return stats, nil
+}
+
+func mergeModelTokenStats(primary, secondary modelTokenStats) modelTokenStats {
+	merged := make(modelTokenStats, len(primary)+len(secondary))
+	for modelID, totalTokens := range primary {
+		merged[modelID] = totalTokens
+	}
+	mismatchedModels := 0
+	localOnlyModels := 0
+	for modelID, totalTokens := range secondary {
+		current, exists := merged[modelID]
+		if !exists || totalTokens > current {
+			merged[modelID] = totalTokens
+		}
+		if !exists {
+			localOnlyModels++
+			continue
+		}
+		if totalTokens != current {
+			mismatchedModels++
+		}
+	}
+	if mismatchedModels > 0 || localOnlyModels > 0 {
+		logging.Warn(
+			"Model token stats mismatch between chain and local sources",
+			types.Pricing,
+			"mismatched_models", mismatchedModels,
+			"local_only_models", localOnlyModels,
+			"chain_models", len(primary),
+			"local_models", len(secondary),
+		)
+	}
+	return merged
 }
 
 // getDynamicPricingData queries dynamic pricing information from the chain

--- a/decentralized-api/internal/server/public/get_pricing_handler.go
+++ b/decentralized-api/internal/server/public/get_pricing_handler.go
@@ -157,19 +157,14 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 	windowDurationSeconds := int64(params.Params.DynamicPricingParams.UtilizationWindowDuration)
 
 	localModelStats, hasLocalStats := s.getModelTokenStatsFromLocalStore(context, windowDurationSeconds)
-	chainModelStats, err := s.getModelTokenStatsFromChain(queryClient, context, windowDurationSeconds)
-	if err != nil {
-		if !hasLocalStats {
+	effectiveStats := localModelStats
+	if !hasLocalStats {
+		chainModelStats, err := s.getModelTokenStatsFromChain(queryClient, context, windowDurationSeconds)
+		if err != nil {
 			logging.Warn("Failed to get model stats for utilization", types.Pricing, "error", err)
 			return metricsData
 		}
-		logging.Warn("Falling back to local model stats for utilization", types.Pricing, "error", err)
-		chainModelStats = modelTokenStats{}
-	}
-
-	effectiveStats := chainModelStats
-	if hasLocalStats {
-		effectiveStats = mergeModelTokenStats(chainModelStats, localModelStats)
+		effectiveStats = chainModelStats
 	}
 
 	for modelID, totalTokens := range effectiveStats {
@@ -251,39 +246,6 @@ func (s *Server) getModelTokenStatsFromChain(
 		stats[modelStat.Model] = modelStat.AiTokens
 	}
 	return stats, nil
-}
-
-func mergeModelTokenStats(primary, secondary modelTokenStats) modelTokenStats {
-	merged := make(modelTokenStats, len(primary)+len(secondary))
-	for modelID, totalTokens := range primary {
-		merged[modelID] = totalTokens
-	}
-	mismatchedModels := 0
-	localOnlyModels := 0
-	for modelID, totalTokens := range secondary {
-		current, exists := merged[modelID]
-		if !exists || totalTokens > current {
-			merged[modelID] = totalTokens
-		}
-		if !exists {
-			localOnlyModels++
-			continue
-		}
-		if totalTokens != current {
-			mismatchedModels++
-		}
-	}
-	if mismatchedModels > 0 || localOnlyModels > 0 {
-		logging.Warn(
-			"Model token stats mismatch between chain and local sources",
-			types.Pricing,
-			"mismatched_models", mismatchedModels,
-			"local_only_models", localOnlyModels,
-			"chain_models", len(primary),
-			"local_models", len(secondary),
-		)
-	}
-	return merged
 }
 
 // getDynamicPricingData queries dynamic pricing information from the chain

--- a/decentralized-api/internal/server/public/get_pricing_handler_test.go
+++ b/decentralized-api/internal/server/public/get_pricing_handler_test.go
@@ -1,0 +1,61 @@
+package public
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeModelTokenStatsForMissingModels_PrefersLocalAndFillsMissing(t *testing.T) {
+	capacityMap := map[string]uint64{
+		"model-a": 100,
+		"model-b": 100,
+		"model-c": 100,
+	}
+	localStats := modelTokenStats{
+		"model-a": 10,
+	}
+	chainStats := modelTokenStats{
+		"model-a": 999, // should not override local
+		"model-b": 20,
+		"model-c": 30,
+		"model-d": 40, // should be ignored (not in capacity map)
+	}
+
+	merged := mergeModelTokenStatsForMissingModels(capacityMap, localStats, chainStats)
+
+	require.Equal(t, int64(10), merged["model-a"])
+	require.Equal(t, int64(20), merged["model-b"])
+	require.Equal(t, int64(30), merged["model-c"])
+	_, exists := merged["model-d"]
+	require.False(t, exists)
+}
+
+func TestMergeModelTokenStatsForMissingModels_NoLocalStats(t *testing.T) {
+	capacityMap := map[string]uint64{
+		"model-a": 100,
+	}
+	var localStats modelTokenStats
+	chainStats := modelTokenStats{
+		"model-a": 77,
+	}
+
+	merged := mergeModelTokenStatsForMissingModels(capacityMap, localStats, chainStats)
+
+	require.Equal(t, int64(77), merged["model-a"])
+}
+
+func TestHasMissingModelStats(t *testing.T) {
+	capacityMap := map[string]uint64{
+		"model-a": 100,
+		"model-b": 100,
+	}
+
+	require.True(t, hasMissingModelStats(capacityMap, modelTokenStats{
+		"model-a": 1,
+	}))
+	require.False(t, hasMissingModelStats(capacityMap, modelTokenStats{
+		"model-a": 1,
+		"model-b": 2,
+	}))
+}

--- a/inference-chain/testutil/keeper/bank_escrow_helpers.go
+++ b/inference-chain/testutil/keeper/bank_escrow_helpers.go
@@ -7,9 +7,9 @@ import (
 )
 
 func (escrow *MockBookkeepingBankKeeper) ExpectAny(context sdk.Context) {
-	escrow.EXPECT().SendCoinsFromAccountToModule(context, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	escrow.EXPECT().SendCoinsFromModuleToAccount(context, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	escrow.EXPECT().SendCoinsFromModuleToModule(context, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	escrow.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	escrow.EXPECT().SendCoinsFromModuleToAccount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	escrow.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	escrow.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 }
@@ -27,5 +27,5 @@ func (escrow *MockBookkeepingBankKeeper) ExpectPay(context sdk.Context, who stri
 	if err != nil {
 		panic(err)
 	}
-	return escrow.EXPECT().SendCoinsFromAccountToModule(context, whoAddr, types.ModuleName, coinsOf(amount), gomock.Any())
+	return escrow.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), whoAddr, types.ModuleName, coinsOf(amount), gomock.Any())
 }

--- a/inference-chain/x/inference/calculations/status_test.go
+++ b/inference-chain/x/inference/calculations/status_test.go
@@ -156,6 +156,47 @@ func TestProbabilityOfConsecutiveFailures_PanicOnBadRate(t *testing.T) {
 	require.True(t, result.IsZero(), "Expected zero for invalid rate < 0")
 }
 
+// what happens if we skip ComputeStatus on successful inferences
+func TestSkipComputeStatusOnCompletionBreaksLLR(t *testing.T) {
+	params := types.DefaultValidationParams()
+	completions := 50
+	misses := 6
+
+	emptyStats := func() types.CurrentEpochStats {
+		return types.CurrentEpochStats{InactiveLLR: types.DecimalFromFloat(0), InvalidLLR: types.DecimalFromFloat(0)}
+	}
+
+	// simulate N successful inferences + M misses (calling ComputeStatus every time)
+	stored := emptyStats()
+	for i := 0; i < completions; i++ {
+		_, _, stored = ComputeStatus(params, nil, types.Participant{CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: stored.InferenceCount + 1, MissedRequests: stored.MissedRequests,
+			InactiveLLR: stored.InactiveLLR, InvalidLLR: stored.InvalidLLR}}, stored)
+	}
+	var st types.ParticipantStatus
+	for i := 0; i < misses; i++ {
+		st, _, stored = ComputeStatus(params, nil, types.Participant{CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: stored.InferenceCount, MissedRequests: stored.MissedRequests + 1,
+			InactiveLLR: stored.InactiveLLR, InvalidLLR: stored.InvalidLLR}}, stored)
+	}
+	t.Logf("always compute: LLR=%s status=%s", stored.InactiveLLR.ToDecimal(), st)
+	require.Equal(t, types.ParticipantStatus_ACTIVE, st)
+
+	// now same thing but skip ComputeStatus on completions (bump counter and don't call ComputeStatus)
+	skipped := emptyStats()
+	skipped.InferenceCount = uint64(completions)
+	var st2 types.ParticipantStatus
+	for i := 0; i < misses; i++ {
+		st2, _, skipped = ComputeStatus(params, nil, types.Participant{CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: uint64(completions), MissedRequests: skipped.MissedRequests + 1,
+			InactiveLLR: skipped.InactiveLLR, InvalidLLR: skipped.InvalidLLR}}, skipped)
+	}
+	t.Logf("skip completions: LLR=%s status=%s", skipped.InactiveLLR.ToDecimal(), st2)
+
+	// same participant, same events, but wrongly marked inactive
+	require.Equal(t, types.ParticipantStatus_INACTIVE, st2)
+}
+
 func TestGetStats(t *testing.T) {
 	part := &types.Participant{
 		CurrentEpochStats: &types.CurrentEpochStats{

--- a/inference-chain/x/inference/keeper/developer_stats_aggregation.go
+++ b/inference-chain/x/inference/keeper/developer_stats_aggregation.go
@@ -110,32 +110,12 @@ func (k Keeper) GetDeveloperStatsByTime(
 }
 
 func (k Keeper) GetSummaryByTime(ctx context.Context, from, to int64) StatsSummary {
-	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
-	timeStore := prefix.NewStore(store, types.KeyPrefix(StatsDevelopersByTime))
-
-	start := sdk.Uint64ToBigEndian(uint64(from))
-	end := sdk.Uint64ToBigEndian(uint64(to + 1))
-
-	iterator := timeStore.Iterator(start, end)
-	defer iterator.Close()
-
+	statsByModel := k.GetSummaryByModelAndTime(ctx, from, to)
 	summary := StatsSummary{}
-	for ; iterator.Valid(); iterator.Next() {
-		// covers corner case when we have inferences with empty requestedBy filed, because
-		// dev had insufficient funds for payment-on-escrow
-		if addr := extractDeveloperAddrFromKey(iterator.Key()); addr == "" {
-			continue
-		}
-
-		var stats types.DeveloperStatsByTime
-		err := k.cdc.Unmarshal(iterator.Value(), &stats)
-		if err != nil {
-			k.LogError("Unable to unmarshal DeveloperStatsByTime", types.Participants, "key", iterator.Key(), "error", err)
-			continue
-		}
-		summary.TokensUsed += int64(stats.Inference.TotalTokenCount)
-		summary.InferenceCount++
-		summary.ActualCost += stats.Inference.ActualCostInCoins
+	for _, modelSummary := range statsByModel {
+		summary.TokensUsed += modelSummary.TokensUsed
+		summary.InferenceCount += modelSummary.InferenceCount
+		summary.ActualCost += modelSummary.ActualCost
 	}
 	return summary
 }

--- a/inference-chain/x/inference/keeper/developer_stats_aggregation.go
+++ b/inference-chain/x/inference/keeper/developer_stats_aggregation.go
@@ -261,11 +261,6 @@ func (k Keeper) GetSummaryLastNEpochsByDeveloper(ctx context.Context, developerA
 }
 
 func (k Keeper) GetSummaryByModelAndTime(ctx context.Context, from, to int64) map[string]StatsSummary {
-	lightweightStats := k.GetModelUsageSummaryByTime(ctx, from, to)
-	if len(lightweightStats) > 0 {
-		return lightweightStats
-	}
-
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	timeStore := prefix.NewStore(store, types.KeyPrefix(StatsDevelopersByTime))
 

--- a/inference-chain/x/inference/keeper/developer_stats_aggregation.go
+++ b/inference-chain/x/inference/keeper/developer_stats_aggregation.go
@@ -261,6 +261,28 @@ func (k Keeper) GetSummaryLastNEpochsByDeveloper(ctx context.Context, developerA
 }
 
 func (k Keeper) GetSummaryByModelAndTime(ctx context.Context, from, to int64) map[string]StatsSummary {
+	cutoverTimestamp, hasCutover := k.GetModelUsageCutoverTimestamp(ctx)
+	if !hasCutover || to < cutoverTimestamp {
+		return k.getSummaryByModelAndTimeLegacy(ctx, from, to)
+	}
+	if from >= cutoverTimestamp {
+		return k.GetModelUsageSummaryByTime(ctx, from, to)
+	}
+
+	stats := k.getSummaryByModelAndTimeLegacy(ctx, from, cutoverTimestamp-1)
+	lightweightStats := k.GetModelUsageSummaryByTime(ctx, cutoverTimestamp, to)
+	for model, summary := range lightweightStats {
+		current := stats[model]
+		current.InferenceCount += summary.InferenceCount
+		current.TokensUsed += summary.TokensUsed
+		current.ActualCost += summary.ActualCost
+		stats[model] = current
+	}
+
+	return stats
+}
+
+func (k Keeper) getSummaryByModelAndTimeLegacy(ctx context.Context, from, to int64) map[string]StatsSummary {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	timeStore := prefix.NewStore(store, types.KeyPrefix(StatsDevelopersByTime))
 

--- a/inference-chain/x/inference/keeper/developer_stats_aggregation.go
+++ b/inference-chain/x/inference/keeper/developer_stats_aggregation.go
@@ -261,6 +261,11 @@ func (k Keeper) GetSummaryLastNEpochsByDeveloper(ctx context.Context, developerA
 }
 
 func (k Keeper) GetSummaryByModelAndTime(ctx context.Context, from, to int64) map[string]StatsSummary {
+	lightweightStats := k.GetModelUsageSummaryByTime(ctx, from, to)
+	if len(lightweightStats) > 0 {
+		return lightweightStats
+	}
+
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	timeStore := prefix.NewStore(store, types.KeyPrefix(StatsDevelopersByTime))
 

--- a/inference-chain/x/inference/keeper/dynamic_pricing_lightweight_integration_test.go
+++ b/inference-chain/x/inference/keeper/dynamic_pricing_lightweight_integration_test.go
@@ -1,0 +1,49 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateDynamicPricing_UsesLightweightModelUsage(t *testing.T) {
+	k, ctx := setupTestKeeperWithDynamicPricing(t)
+	ctx = ctx.WithBlockTime(time.Unix(1000, 0))
+	goCtx := sdk.WrapSDKContext(ctx)
+
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	params.DynamicPricingParams.StabilityZoneLowerBound = types.DecimalFromFloat(0.40)
+	params.DynamicPricingParams.StabilityZoneUpperBound = types.DecimalFromFloat(0.60)
+	params.DynamicPricingParams.PriceElasticity = types.DecimalFromFloat(0.05)
+	params.DynamicPricingParams.MinPerTokenPrice = 1
+	params.DynamicPricingParams.BasePerTokenPrice = 1000
+	params.DynamicPricingParams.GracePeriodEndEpoch = 0
+	params.DynamicPricingParams.UtilizationWindowDuration = 60
+	k.SetParams(ctx, params)
+
+	epoch := &types.Epoch{Index: 1, PocStartBlockHeight: 1}
+	require.NoError(t, k.SetEpoch(ctx, epoch))
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, epoch.Index))
+	k.SetEpochGroupData(ctx, types.EpochGroupData{
+		EpochIndex:      epoch.Index,
+		ModelId:         "",
+		SubGroupModels:  []string{"model-a"},
+		UnitOfComputePrice: 1,
+	})
+
+	require.NoError(t, k.CacheModelCapacity(goCtx, "model-a", 100))
+	require.NoError(t, k.SetModelCurrentPrice(goCtx, "model-a", 1000))
+
+	sampleTs := ctx.BlockTime().UnixMilli() - 10_000
+	require.NoError(t, k.AddModelUsageSample(goCtx, "model-a", sampleTs, 6000, 10))
+
+	require.NoError(t, k.UpdateDynamicPricing(goCtx))
+
+	price, err := k.GetModelCurrentPrice(goCtx, "model-a")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1020), price)
+}

--- a/inference-chain/x/inference/keeper/model_usage_stats.go
+++ b/inference-chain/x/inference/keeper/model_usage_stats.go
@@ -15,9 +15,11 @@ import (
 
 const (
 	StatsModelUsageBySecond = "stats/model/usage/second"
+	StatsModelUsageMeta     = "stats/model/usage/meta"
 )
 
 var modelUsageSeparator = []byte("__MODEL__")
+var modelUsageCutoverKey = []byte("cutover_ms")
 
 type modelUsageBucket struct {
 	InferenceCount uint64
@@ -42,6 +44,11 @@ func (k Keeper) AddModelUsageSample(
 	bucketSecond := uint64(timestampMillis / 1000)
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	usageStore := prefix.NewStore(storeAdapter, types.KeyPrefix(StatsModelUsageBySecond))
+	metaStore := prefix.NewStore(storeAdapter, types.KeyPrefix(StatsModelUsageMeta))
+
+	if metaStore.Get(modelUsageCutoverKey) == nil {
+		metaStore.Set(modelUsageCutoverKey, sdk.Uint64ToBigEndian(uint64(timestampMillis)))
+	}
 
 	key := modelUsageKey(bucketSecond, model)
 	bucket := modelUsageBucket{}
@@ -68,6 +75,21 @@ func (k Keeper) AddModelUsageSample(
 
 	usageStore.Set(key, marshalModelUsageBucket(bucket))
 	return nil
+}
+
+func (k Keeper) GetModelUsageCutoverTimestamp(ctx context.Context) (int64, bool) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	metaStore := prefix.NewStore(storeAdapter, types.KeyPrefix(StatsModelUsageMeta))
+	value := metaStore.Get(modelUsageCutoverKey)
+	if len(value) != 8 {
+		return 0, false
+	}
+	cutover := sdk.BigEndianToUint64(value)
+	maxInt64AsUint64 := ^uint64(0) >> 1
+	if cutover > maxInt64AsUint64 {
+		return 0, false
+	}
+	return int64(cutover), true
 }
 
 // GetModelUsageSummaryByTime returns aggregated model usage from lightweight

--- a/inference-chain/x/inference/keeper/model_usage_stats.go
+++ b/inference-chain/x/inference/keeper/model_usage_stats.go
@@ -1,0 +1,172 @@
+package keeper
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"cosmossdk.io/store/prefix"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+const (
+	StatsModelUsageBySecond = "stats/model/usage/second"
+)
+
+var modelUsageSeparator = []byte("__MODEL__")
+
+type modelUsageBucket struct {
+	InferenceCount uint64
+	TokensUsed     uint64
+	ActualCost     uint64
+}
+
+// AddModelUsageSample stores lightweight per-model usage in per-second buckets.
+// This data is intentionally compact and is used by on-chain consumers such as
+// dynamic pricing and invalidation limits.
+func (k Keeper) AddModelUsageSample(
+	ctx context.Context,
+	model string,
+	timestampMillis int64,
+	tokenCount uint64,
+	actualCost int64,
+) error {
+	if model == "" || timestampMillis <= 0 {
+		return nil
+	}
+
+	bucketSecond := uint64(timestampMillis / 1000)
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	usageStore := prefix.NewStore(storeAdapter, types.KeyPrefix(StatsModelUsageBySecond))
+
+	key := modelUsageKey(bucketSecond, model)
+	bucket := modelUsageBucket{}
+
+	if value := usageStore.Get(key); value != nil {
+		var err error
+		bucket, err = unmarshalModelUsageBucket(value)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := addUint64(&bucket.InferenceCount, 1); err != nil {
+		return err
+	}
+	if err := addUint64(&bucket.TokensUsed, tokenCount); err != nil {
+		return err
+	}
+	if actualCost > 0 {
+		if err := addUint64(&bucket.ActualCost, uint64(actualCost)); err != nil {
+			return err
+		}
+	}
+
+	usageStore.Set(key, marshalModelUsageBucket(bucket))
+	return nil
+}
+
+// GetModelUsageSummaryByTime returns aggregated model usage from lightweight
+// per-second buckets for the requested millisecond range (inclusive).
+func (k Keeper) GetModelUsageSummaryByTime(ctx context.Context, from, to int64) map[string]StatsSummary {
+	result := make(map[string]StatsSummary)
+	if to < from {
+		return result
+	}
+
+	if from < 0 {
+		from = 0
+	}
+	if to < 0 {
+		to = 0
+	}
+
+	startSecond := uint64(from / 1000)
+	endSecond := uint64(to / 1000)
+
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	usageStore := prefix.NewStore(storeAdapter, types.KeyPrefix(StatsModelUsageBySecond))
+
+	start := sdk.Uint64ToBigEndian(startSecond)
+
+	var end []byte
+	if endSecond == math.MaxUint64 {
+		end = nil
+	} else {
+		end = sdk.Uint64ToBigEndian(endSecond + 1)
+	}
+
+	iterator := usageStore.Iterator(start, end)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		model, ok := parseModelUsageModel(iterator.Key())
+		if !ok {
+			continue
+		}
+
+		bucket, err := unmarshalModelUsageBucket(iterator.Value())
+		if err != nil {
+			k.LogError("Unable to unmarshal model usage bucket", types.Stat, "key", iterator.Key(), "error", err)
+			continue
+		}
+
+		summary := result[model]
+		summary.InferenceCount += int(bucket.InferenceCount)
+		summary.TokensUsed += int64(bucket.TokensUsed)
+		summary.ActualCost += int64(bucket.ActualCost)
+		result[model] = summary
+	}
+
+	return result
+}
+
+func modelUsageKey(bucketSecond uint64, model string) []byte {
+	key := append([]byte{}, sdk.Uint64ToBigEndian(bucketSecond)...)
+	key = append(key, modelUsageSeparator...)
+	key = append(key, []byte(model)...)
+	return key
+}
+
+func parseModelUsageModel(key []byte) (string, bool) {
+	separatorStart := 8
+	separatorEnd := separatorStart + len(modelUsageSeparator)
+	if len(key) <= separatorEnd {
+		return "", false
+	}
+	if !bytes.Equal(key[separatorStart:separatorEnd], modelUsageSeparator) {
+		return "", false
+	}
+	return string(key[separatorEnd:]), true
+}
+
+func marshalModelUsageBucket(bucket modelUsageBucket) []byte {
+	out := make([]byte, 24)
+	binary.BigEndian.PutUint64(out[0:8], bucket.InferenceCount)
+	binary.BigEndian.PutUint64(out[8:16], bucket.TokensUsed)
+	binary.BigEndian.PutUint64(out[16:24], bucket.ActualCost)
+	return out
+}
+
+func unmarshalModelUsageBucket(data []byte) (modelUsageBucket, error) {
+	if len(data) != 24 {
+		return modelUsageBucket{}, fmt.Errorf("unexpected model usage bucket size: %d", len(data))
+	}
+	return modelUsageBucket{
+		InferenceCount: binary.BigEndian.Uint64(data[0:8]),
+		TokensUsed:     binary.BigEndian.Uint64(data[8:16]),
+		ActualCost:     binary.BigEndian.Uint64(data[16:24]),
+	}, nil
+}
+
+func addUint64(dst *uint64, delta uint64) error {
+	if math.MaxUint64-*dst < delta {
+		return fmt.Errorf("uint64 overflow: current=%d delta=%d", *dst, delta)
+	}
+	*dst += delta
+	return nil
+}

--- a/inference-chain/x/inference/keeper/model_usage_stats_test.go
+++ b/inference-chain/x/inference/keeper/model_usage_stats_test.go
@@ -1,0 +1,78 @@
+package keeper_test
+
+import (
+	"testing"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	keeper2 "github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelUsage_AddModelUsageSample_AggregatesAndCutover(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+
+	require.NoError(t, k.AddModelUsageSample(ctx, "model-a", 1000, 10, 20))
+	require.NoError(t, k.AddModelUsageSample(ctx, "model-a", 1500, 5, 30))
+	require.NoError(t, k.AddModelUsageSample(ctx, "model-b", 1100, 7, -10))
+
+	cutover, ok := k.GetModelUsageCutoverTimestamp(ctx)
+	require.True(t, ok)
+	require.Equal(t, int64(1000), cutover)
+
+	stats := k.GetModelUsageSummaryByTime(ctx, 1000, 1999)
+	require.Len(t, stats, 2)
+	requireModelSummary(t, stats, "model-a", 2, 15, 50)
+	requireModelSummary(t, stats, "model-b", 1, 7, 0)
+
+	require.NoError(t, k.AddModelUsageSample(ctx, "model-a", 500, 2, 4))
+
+	cutover2, ok := k.GetModelUsageCutoverTimestamp(ctx)
+	require.True(t, ok)
+	require.Equal(t, cutover, cutover2)
+}
+
+func TestModelUsage_GetSummaryByModelAndTime_CutoverBranches(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+
+	legacyInference := types.Inference{
+		InferenceId:          "legacy-1",
+		RequestedBy:          "dev-1",
+		Model:                "model-a",
+		Status:               types.InferenceStatus_FINISHED,
+		PromptTokenCount:     3,
+		CompletionTokenCount: 2,
+		EndBlockTimestamp:    1500,
+		EpochId:              1,
+		ActualCost:           70,
+	}
+	require.NoError(t, k.SetDeveloperStats(ctx, legacyInference))
+
+	noCutoverStats := k.GetSummaryByModelAndTime(ctx, 1000, 1999)
+	require.Len(t, noCutoverStats, 1)
+	requireModelSummary(t, noCutoverStats, "model-a", 1, 5, 70)
+
+	require.NoError(t, k.AddModelUsageSample(ctx, "model-a", 2000, 11, 40))
+
+	beforeCutoverStats := k.GetSummaryByModelAndTime(ctx, 1000, 1999)
+	require.Len(t, beforeCutoverStats, 1)
+	requireModelSummary(t, beforeCutoverStats, "model-a", 1, 5, 70)
+
+	afterCutoverStats := k.GetSummaryByModelAndTime(ctx, 2000, 2500)
+	require.Len(t, afterCutoverStats, 1)
+	requireModelSummary(t, afterCutoverStats, "model-a", 1, 11, 40)
+
+	spanningStats := k.GetSummaryByModelAndTime(ctx, 1000, 2500)
+	require.Len(t, spanningStats, 1)
+	requireModelSummary(t, spanningStats, "model-a", 2, 16, 110)
+}
+
+func requireModelSummary(t *testing.T, stats map[string]keeper2.StatsSummary, model string, count int, tokens int64, actualCost int64) {
+	t.Helper()
+
+	summary, ok := stats[model]
+	require.True(t, ok)
+	require.Equal(t, count, summary.InferenceCount)
+	require.Equal(t, tokens, summary.TokensUsed)
+	require.Equal(t, actualCost, summary.ActualCost)
+}

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"strconv"
 
 	sdkerrors "cosmossdk.io/errors"
 	"cosmossdk.io/math"
@@ -105,15 +106,15 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
 	}
-	err = k.SetInference(ctx, *finalInference)
-	if err != nil {
-		return failedFinish(ctx, err, msg), nil
-	}
-	if existingInference.IsCompleted() {
+	if finalInference.IsCompleted() {
 		err := k.handleInferenceCompleted(ctx, finalInference)
 		if err != nil {
 			return failedFinish(ctx, err, msg), nil
 		}
+	}
+	err = k.SetInferenceWithoutDevStatComputation(ctx, *finalInference)
+	if err != nil {
+		return failedFinish(ctx, err, msg), nil
 	}
 
 	return &types.MsgFinishInferenceResponse{InferenceIndex: msg.InferenceId}, nil
@@ -218,13 +219,6 @@ func getFinishTASignatureComponents(msg *types.MsgFinishInference) calculations.
 }
 
 func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *types.Inference) error {
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			"inference_finished",
-			sdk.NewAttribute("inference_id", existingInference.InferenceId),
-		),
-	)
-
 	executedBy := existingInference.ExecutedBy
 	executor, found := k.GetParticipant(ctx, executedBy)
 	if !found {
@@ -302,10 +296,31 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 		"traffic_basis", inferenceDetails.TrafficBasis,
 	)
 	k.SetInferenceValidationDetails(ctx, inferenceDetails)
-	err = k.SetInference(ctx, *existingInference)
-	if err != nil {
+	if err := k.AddModelUsageSample(
+		ctx,
+		existingInference.Model,
+		existingInference.EndBlockTimestamp,
+		existingInference.PromptTokenCount+existingInference.CompletionTokenCount,
+		existingInference.ActualCost,
+	); err != nil {
 		return err
 	}
 	k.SetEpochGroupData(ctx, *currentEpochGroup.GroupData)
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			"inference_finished",
+			sdk.NewAttribute("inference_id", existingInference.InferenceId),
+			sdk.NewAttribute("requested_by", existingInference.RequestedBy),
+			sdk.NewAttribute("executed_by", existingInference.ExecutedBy),
+			sdk.NewAttribute("model", existingInference.Model),
+			sdk.NewAttribute("epoch_id", strconv.FormatUint(existingInference.EpochId, 10)),
+			sdk.NewAttribute("prompt_token_count", strconv.FormatUint(existingInference.PromptTokenCount, 10)),
+			sdk.NewAttribute("completion_token_count", strconv.FormatUint(existingInference.CompletionTokenCount, 10)),
+			sdk.NewAttribute("actual_cost", strconv.FormatInt(existingInference.ActualCost, 10)),
+			sdk.NewAttribute("end_block_timestamp", strconv.FormatInt(existingInference.EndBlockTimestamp, 10)),
+		),
+	)
+
 	return nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -296,8 +296,14 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 		"traffic_basis", inferenceDetails.TrafficBasis,
 	)
 	k.SetInferenceValidationDetails(ctx, inferenceDetails)
-	if err := k.SetDeveloperStats(ctx, *existingInference); err != nil {
-		return err
+	if err := k.AddModelUsageSample(
+		ctx,
+		existingInference.Model,
+		existingInference.EndBlockTimestamp,
+		existingInference.PromptTokenCount+existingInference.CompletionTokenCount,
+		existingInference.ActualCost,
+	); err != nil {
+		k.LogError("Failed to update model usage stats", types.Stat, "inferenceId", existingInference.InferenceId, "error", err)
 	}
 	k.SetEpochGroupData(ctx, *currentEpochGroup.GroupData)
 

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -109,7 +109,8 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
 	}
-	if finalInference.IsCompleted() && finalInference.EpochId == 0 {
+
+	if finalInference.IsCompleted() {
 		err := k.handleInferenceCompleted(cacheCtx, finalInference)
 		if err != nil {
 			return failedFinish(ctx, err, msg), nil

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -106,7 +106,7 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
 	}
-	if finalInference.IsCompleted() {
+	if finalInference.IsCompleted() && finalInference.EpochId == 0 {
 		err := k.handleInferenceCompleted(ctx, finalInference)
 		if err != nil {
 			return failedFinish(ctx, err, msg), nil
@@ -296,13 +296,7 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 		"traffic_basis", inferenceDetails.TrafficBasis,
 	)
 	k.SetInferenceValidationDetails(ctx, inferenceDetails)
-	if err := k.AddModelUsageSample(
-		ctx,
-		existingInference.Model,
-		existingInference.EndBlockTimestamp,
-		existingInference.PromptTokenCount+existingInference.CompletionTokenCount,
-		existingInference.ActualCost,
-	); err != nil {
+	if err := k.SetDeveloperStats(ctx, *existingInference); err != nil {
 		return err
 	}
 	k.SetEpochGroupData(ctx, *currentEpochGroup.GroupData)

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -76,19 +76,22 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 		return failedFinish(ctx, sdkerrors.Wrap(types.ErrInferenceExpired, "inference has already expired"), msg), nil
 	}
 
+	cacheCtx, writeCache := ctx.CacheContext()
+	workingInference := existingInference
+
 	// Record the current price only if this is the first message (StartInference not processed yet)
 	// This ensures consistent pricing regardless of message arrival order
-	if !existingInference.StartProcessed() {
-		existingInference.Model = msg.Model
-		k.RecordInferencePrice(goCtx, &existingInference, msg.InferenceId)
-	} else if existingInference.Model == "" {
+	if !workingInference.StartProcessed() {
+		workingInference.Model = msg.Model
+		k.RecordInferencePrice(cacheCtx, &workingInference, msg.InferenceId)
+	} else if workingInference.Model == "" {
 		k.LogError("FinishInference: model not set by the processed start message", types.Inferences,
 			"inferenceId", msg.InferenceId,
 			"executedBy", msg.ExecutedBy)
-	} else if existingInference.Model != msg.Model {
+	} else if workingInference.Model != msg.Model {
 		k.LogError("FinishInference: model mismatch", types.Inferences,
 			"inferenceId", msg.InferenceId,
-			"existingInference.Model", existingInference.Model,
+			"existingInference.Model", workingInference.Model,
 			"msg.Model", msg.Model)
 	}
 
@@ -97,25 +100,26 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 		BlockTimestamp: ctx.BlockTime().UnixMilli(),
 	}
 
-	inference, payments, err := calculations.ProcessFinishInference(&existingInference, msg, blockContext, k)
+	inference, payments, err := calculations.ProcessFinishInference(&workingInference, msg, blockContext, k)
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
 	}
 
-	finalInference, err := k.processInferencePayments(ctx, inference, payments, true)
+	finalInference, err := k.processInferencePayments(cacheCtx, inference, payments, true)
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
 	}
 	if finalInference.IsCompleted() && finalInference.EpochId == 0 {
-		err := k.handleInferenceCompleted(ctx, finalInference)
+		err := k.handleInferenceCompleted(cacheCtx, finalInference)
 		if err != nil {
 			return failedFinish(ctx, err, msg), nil
 		}
 	}
-	err = k.SetInferenceWithoutDevStatComputation(ctx, *finalInference)
+	err = k.SetInferenceWithoutDevStatComputation(cacheCtx, *finalInference)
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
 	}
+	writeCache()
 
 	return &types.MsgFinishInferenceResponse{InferenceIndex: msg.InferenceId}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
@@ -120,12 +120,8 @@ func TestMsgServer_FinishInference(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, expected, &savedInference)
 
-	devStat, found := k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId)
-	require.True(t, found)
-	require.Equal(t, types.DeveloperStatsByEpoch{
-		EpochId:      epochId,
-		InferenceIds: []string{expected.InferenceId},
-	}, devStat)
+	_, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId)
+	require.False(t, found)
 
 	newBlockHeight := initialBlockTime + 10
 	// This should advance us to epoch 2
@@ -146,15 +142,8 @@ func TestMsgServer_FinishInference(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, expectedFinished, &savedInference)
 
-	devStat, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId2)
-	require.True(t, found)
-	require.Equal(t, 1, len(devStat.InferenceIds))
-
-	devStatUpdated, found := k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId2)
-	require.True(t, found)
-	require.Equal(t, types.DeveloperStatsByEpoch{
-		EpochId:      epochId2,
-		InferenceIds: []string{expectedFinished.InferenceId}}, devStatUpdated)
+	_, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId2)
+	require.False(t, found)
 
 }
 

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
@@ -143,7 +143,7 @@ func TestMsgServer_FinishInference(t *testing.T) {
 	require.Equal(t, expectedFinished, &savedInference)
 
 	_, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId2)
-	require.True(t, found)
+	require.False(t, found)
 
 }
 

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
@@ -145,6 +145,38 @@ func TestMsgServer_FinishInference(t *testing.T) {
 	_, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId2)
 	require.False(t, found)
 
+	events := inferenceHelper.context.EventManager().Events()
+	var finishedEvent sdk.Event
+	finishedEventFound := false
+	for _, event := range events {
+		if event.Type == "inference_finished" {
+			finishedEvent = event
+			finishedEventFound = true
+			break
+		}
+	}
+	require.True(t, finishedEventFound)
+
+	requiredAttributes := map[string]bool{
+		"inference_id":           false,
+		"requested_by":           false,
+		"executed_by":            false,
+		"model":                  false,
+		"epoch_id":               false,
+		"prompt_token_count":     false,
+		"completion_token_count": false,
+		"actual_cost":            false,
+		"end_block_timestamp":    false,
+	}
+	for _, attr := range finishedEvent.Attributes {
+		if _, ok := requiredAttributes[attr.Key]; ok {
+			requiredAttributes[attr.Key] = true
+		}
+	}
+	for key, found := range requiredAttributes {
+		require.Truef(t, found, "missing inference_finished attribute: %s", key)
+	}
+
 }
 
 func MustAddParticipant(t *testing.T, ms types.MsgServer, ctx context.Context, mockAccount MockAccount) {

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
@@ -145,6 +145,17 @@ func TestMsgServer_FinishInference(t *testing.T) {
 	_, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId2)
 	require.False(t, found)
 
+	modelUsage := k.GetModelUsageSummaryByTime(
+		ctx,
+		expectedFinished.EndBlockTimestamp-1,
+		expectedFinished.EndBlockTimestamp+1,
+	)
+	summary, ok := modelUsage[modelId]
+	require.True(t, ok)
+	require.Equal(t, 1, summary.InferenceCount)
+	require.Equal(t, int64(expectedFinished.PromptTokenCount+expectedFinished.CompletionTokenCount), summary.TokensUsed)
+	require.Equal(t, expectedFinished.ActualCost, summary.ActualCost)
+
 	events := inferenceHelper.context.EventManager().Events()
 	var finishedEvent sdk.Event
 	finishedEventFound := false

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
@@ -143,7 +143,7 @@ func TestMsgServer_FinishInference(t *testing.T) {
 	require.Equal(t, expectedFinished, &savedInference)
 
 	_, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId2)
-	require.False(t, found)
+	require.True(t, found)
 
 }
 

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
@@ -48,9 +48,6 @@ func (k msgServer) InvalidateInference(ctx context.Context, msg *types.MsgInvali
 	if err != nil {
 		return nil, err
 	}
-	if err := k.SetDeveloperStats(ctx, *inference); err != nil {
-		k.LogError("Failed to set developer stats", types.Validation, "inferenceId", inference.InferenceId, "error", err)
-	}
 
 	return &types.MsgInvalidateInferenceResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
@@ -44,7 +44,7 @@ func (k msgServer) InvalidateInference(ctx context.Context, msg *types.MsgInvali
 		return nil, err
 	}
 
-	err = k.SetInference(ctx, *inference)
+	err = k.SetInferenceWithoutDevStatComputation(ctx, *inference)
 	if err != nil {
 		return nil, err
 	}

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
@@ -48,6 +48,9 @@ func (k msgServer) InvalidateInference(ctx context.Context, msg *types.MsgInvali
 	if err != nil {
 		return nil, err
 	}
+	if err := k.SetDeveloperStats(ctx, *inference); err != nil {
+		k.LogError("Failed to set developer stats", types.Validation, "inferenceId", inference.InferenceId, "error", err)
+	}
 
 	return &types.MsgInvalidateInferenceResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_revalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_revalidate_inference.go
@@ -31,9 +31,6 @@ func (k msgServer) RevalidateInference(ctx context.Context, msg *types.MsgRevali
 	if err != nil {
 		return nil, err
 	}
-	if err := k.SetDeveloperStats(ctx, *inference); err != nil {
-		k.LogError("Failed to set developer stats", types.Validation, "inferenceId", inference.InferenceId, "error", err)
-	}
 
 	return &types.MsgRevalidateInferenceResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_revalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_revalidate_inference.go
@@ -27,7 +27,7 @@ func (k msgServer) RevalidateInference(ctx context.Context, msg *types.MsgRevali
 	}
 
 	k.LogInfo("Saving inference", types.Validation, "inferenceId", inference.InferenceId, "status", inference.Status, "authority", inference.ProposalDetails.PolicyAddress)
-	err = k.SetInference(ctx, *inference)
+	err = k.SetInferenceWithoutDevStatComputation(ctx, *inference)
 	if err != nil {
 		return nil, err
 	}

--- a/inference-chain/x/inference/keeper/msg_server_revalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_revalidate_inference.go
@@ -31,6 +31,9 @@ func (k msgServer) RevalidateInference(ctx context.Context, msg *types.MsgRevali
 	if err != nil {
 		return nil, err
 	}
+	if err := k.SetDeveloperStats(ctx, *inference); err != nil {
+		k.LogError("Failed to set developer stats", types.Validation, "inferenceId", inference.InferenceId, "error", err)
+	}
 
 	return &types.MsgRevalidateInferenceResponse{}, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -62,11 +62,14 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 		return failedStart(ctx, sdkerrors.Wrap(types.ErrInferenceStartProcessed, "inference has already start processed"), msg), nil
 	}
 
+	cacheCtx, writeCache := ctx.CacheContext()
+	workingInference := existingInference
+
 	// Record the current price only if this is the first message (FinishInference not processed yet)
 	// This ensures consistent pricing regardless of message arrival order
-	if !existingInference.FinishedProcessed() {
-		existingInference.Model = msg.Model
-		k.RecordInferencePrice(goCtx, &existingInference, msg.InferenceId)
+	if !workingInference.FinishedProcessed() {
+		workingInference.Model = msg.Model
+		k.RecordInferencePrice(cacheCtx, &workingInference, msg.InferenceId)
 	}
 
 	blockContext := calculations.BlockContext{
@@ -74,27 +77,28 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 		BlockTimestamp: ctx.BlockTime().UnixMilli(),
 	}
 
-	inference, payments, err := calculations.ProcessStartInference(&existingInference, msg, blockContext, k)
+	inference, payments, err := calculations.ProcessStartInference(&workingInference, msg, blockContext, k)
 	if err != nil {
 		return failedStart(ctx, err, msg), nil
 	}
 
-	finalInference, err := k.processInferencePayments(ctx, inference, payments, false)
+	finalInference, err := k.processInferencePayments(cacheCtx, inference, payments, false)
 	if err != nil {
 		return failedStart(ctx, err, msg), nil
 	}
-	k.addTimeout(ctx, finalInference)
+	k.addTimeout(cacheCtx, finalInference)
 
 	if finalInference.IsCompleted() && finalInference.EpochId == 0 {
-		err := k.handleInferenceCompleted(ctx, finalInference)
+		err := k.handleInferenceCompleted(cacheCtx, finalInference)
 		if err != nil {
 			return failedStart(ctx, err, msg), nil
 		}
 	}
-	err = k.SetInferenceWithoutDevStatComputation(ctx, *finalInference)
+	err = k.SetInferenceWithoutDevStatComputation(cacheCtx, *finalInference)
 	if err != nil {
 		return failedStart(ctx, err, msg), nil
 	}
+	writeCache()
 
 	return &types.MsgStartInferenceResponse{
 		InferenceIndex: msg.InferenceId,

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -85,7 +85,7 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 	}
 	k.addTimeout(ctx, finalInference)
 
-	if finalInference.IsCompleted() {
+	if finalInference.IsCompleted() && finalInference.EpochId == 0 {
 		err := k.handleInferenceCompleted(ctx, finalInference)
 		if err != nil {
 			return failedStart(ctx, err, msg), nil

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -83,17 +83,17 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 	if err != nil {
 		return failedStart(ctx, err, msg), nil
 	}
-	err = k.SetInference(ctx, *finalInference)
-	if err != nil {
-		return failedStart(ctx, err, msg), nil
-	}
-	k.addTimeout(ctx, inference)
+	k.addTimeout(ctx, finalInference)
 
-	if inference.IsCompleted() {
-		err := k.handleInferenceCompleted(ctx, inference)
+	if finalInference.IsCompleted() {
+		err := k.handleInferenceCompleted(ctx, finalInference)
 		if err != nil {
 			return failedStart(ctx, err, msg), nil
 		}
+	}
+	err = k.SetInferenceWithoutDevStatComputation(ctx, *finalInference)
+	if err != nil {
+		return failedStart(ctx, err, msg), nil
 	}
 
 	return &types.MsgStartInferenceResponse{

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -88,7 +88,7 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 	}
 	k.addTimeout(cacheCtx, finalInference)
 
-	if finalInference.IsCompleted() && finalInference.EpochId == 0 {
+	if finalInference.IsCompleted() {
 		err := k.handleInferenceCompleted(cacheCtx, finalInference)
 		if err != nil {
 			return failedStart(ctx, err, msg), nil

--- a/inference-chain/x/inference/keeper/msg_server_start_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference_test.go
@@ -66,12 +66,8 @@ func TestMsgServer_StartInference(t *testing.T) {
 	savedInference, found := k.GetInference(ctx, expected.InferenceId)
 	require.True(t, found)
 	require.Equal(t, expected, &savedInference)
-	devStat, found := k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId)
-	require.True(t, found)
-	require.Equal(t, types.DeveloperStatsByEpoch{
-		EpochId:      epochId,
-		InferenceIds: []string{expected.InferenceId},
-	}, devStat)
+	_, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId)
+	require.False(t, found)
 }
 
 func TestMsgServer_StartInferenceWithMaxTokens(t *testing.T) {
@@ -93,12 +89,8 @@ func TestMsgServer_StartInferenceWithMaxTokens(t *testing.T) {
 	savedInference, found := k.GetInference(ctx, expected.InferenceId)
 	require.True(t, found)
 	require.Equal(t, expected, &savedInference)
-	devStat, found := k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId)
-	require.True(t, found)
-	require.Equal(t, types.DeveloperStatsByEpoch{
-		EpochId:      epochId,
-		InferenceIds: []string{expected.InferenceId},
-	}, devStat)
+	_, found = k.GetDevelopersStatsByEpoch(ctx, testutil.Requester, epochId)
+	require.False(t, found)
 }
 
 // TODO: Need a way to test that blockheight is set to newer values, but can't figure out how to change the

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -173,9 +173,6 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		k.LogError("Failed to set inference", types.Validation, "inferenceId", inference.InferenceId, "error", err)
 		return nil, err
 	}
-	if err := k.SetDeveloperStats(ctx, inference); err != nil {
-		k.LogError("Failed to set developer stats", types.Validation, "inferenceId", inference.InferenceId, "error", err)
-	}
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -173,6 +173,9 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		k.LogError("Failed to set inference", types.Validation, "inferenceId", inference.InferenceId, "error", err)
 		return nil, err
 	}
+	if err := k.SetDeveloperStats(ctx, inference); err != nil {
+		k.LogError("Failed to set developer stats", types.Validation, "inferenceId", inference.InferenceId, "error", err)
+	}
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -168,7 +168,7 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 	}
 
 	k.LogInfo("Saving inference", types.Validation, "inferenceId", inference.InferenceId, "status", inference.Status, "proposalDetails", inference.ProposalDetails)
-	err = k.SetInference(ctx, inference)
+	err = k.SetInferenceWithoutDevStatComputation(ctx, inference)
 	if err != nil {
 		k.LogError("Failed to set inference", types.Validation, "inferenceId", inference.InferenceId, "error", err)
 		return nil, err

--- a/inference-chain/x/inference/keeper/query_developer_stats_aggregation.go
+++ b/inference-chain/x/inference/keeper/query_developer_stats_aggregation.go
@@ -32,6 +32,10 @@ func (k Keeper) StatsByTimePeriodByDeveloper(ctx context.Context, req *types.Que
 	}
 
 	k.LogInfo("StatsByTimePeriodByDeveloper", types.Stat, "developer", req.Developer, "time_from", req.TimeFrom, "time_to", req.TimeTo)
+	if cutoverTimestamp, ok := k.GetModelUsageCutoverTimestamp(ctx); ok && req.TimeTo >= cutoverTimestamp {
+		k.LogWarn("StatsByTimePeriodByDeveloper uses legacy per-developer stats after model-usage cutover", types.Stat,
+			"developer", req.Developer, "time_from", req.TimeFrom, "time_to", req.TimeTo, "cutover", cutoverTimestamp)
+	}
 	stats := k.GetDeveloperStatsByTime(ctx, req.Developer, req.TimeFrom, req.TimeTo)
 	return &types.QueryStatsByTimePeriodByDeveloperResponse{Stats: stats}, nil
 }
@@ -39,6 +43,10 @@ func (k Keeper) StatsByTimePeriodByDeveloper(ctx context.Context, req *types.Que
 func (k Keeper) StatsByDeveloperAndEpochsBackwards(ctx context.Context, req *types.QueryStatsByDeveloperAndEpochBackwardsRequest) (*types.QueryInferencesAndTokensStatsResponse, error) {
 	if req.Developer == "" {
 		return nil, ErrInvalidDeveloperAddress
+	}
+	if _, ok := k.GetModelUsageCutoverTimestamp(ctx); ok {
+		k.LogWarn("StatsByDeveloperAndEpochsBackwards uses legacy per-developer epoch stats after model-usage cutover", types.Stat,
+			"developer", req.Developer, "epochs_n", req.EpochsN)
 	}
 
 	summary := k.GetSummaryLastNEpochsByDeveloper(ctx, req.Developer, int(req.EpochsN))


### PR DESCRIPTION
Closes #781

## Summary

Move per-inference developer stats off the hot path. Skip heavy per-developer stats writes on the hot path. Add lightweight 24-byte per-(second, model) on-chain store instead. Collect per-inference finished stats (completed inferences only) off-chain on API nodes via the enriched inference_finished chain event

## On-chain

- All message handlers (StartInference, FinishInference, Validation, InvalidateInference, RevalidateInference) now use SetInferenceWithoutDevStatComputation — skips writing legacy per-developer stats.

- StartInference and FinishInference use CacheContext and save inference once at the end instead of twice.

- Added lightweight on-chain model usage store: fixed 24-byte binary bucket per (second, model) — InferenceCount (8B) + TokensUsed (8B) + ActualCost (8B). No protobuf, no per-inference granularity.

- GetSummaryByModelAndTime merges legacy data (before cutover) with lightweight buckets (after). All on-chain consumers go through it and require no changes:
  - UpdateDynamicPricing (BeginBlocker) — per-model utilization for price adjustments
  - MaximumInvalidationsReached (Validation) — per-model inference count for rate limiting
  - InferencesAndTokensStatsByModels gRPC query — stats for API/dashboard
  - InferencesAndTokensStatsByTimePeriod gRPC query — aggregated stats

- Legacy per-developer gRPC queries (StatsByTimePeriodByDeveloper, StatsByDeveloperAndEpochsBackwards) still read from old stores and receive no new writes after the hot-path switch. Added warning logs when these are called post-cutover.

- Extended inference_finished event with requested_by, executed_by, model, epoch_id, prompt_token_count, completion_token_count, actual_cost, end_block_timestamp.

## Decentralized API

- InferenceFinishedEventHandler persists per-inference stats from inference_finished event into a local SQLite table (inference_finished_stats). Upsert by inference_id, retry on SQLITE_BUSY/LOCKED, auto-prune rows older than 30 days.

- Pricing handler (getModelMetrics) reads per-model token stats from the local SQLite store first. Falls back to chain gRPC query (InferencesAndTokensStatsByModels) if local store is empty or unavailable — works because the on-chain lightweight store serves compatible per-model aggregates

- Only consumer right now is getModelMetrics for the pricing/utilization endpoint. The local store has per-inference granularity to support more dashboard queries in the future

## Follow-up

- Pruning on-chain lightweight store - model_usage_stats buckets grow indefinitely, no cleanup mechanism.
- Per-developer dashboard queries degraded — StatsByTimePeriodByDeveloper and StatsByDeveloperAndEpochsBackwards stop getting new data after cutover. No off-chain replacement built for per-developer queries yet (only per-model is served from local SQLite).
- Validation, RevalidateInference and InvalidateInference handlers need new events emitted and handled on API side to track inference status changes off-chain
- On-chain block-ending stats are currently lightweight per-(second, model) buckets by design, not full per-inference/per-block-ending stats.