### PR TITLE
fix: use caller's module account for vested payments

### DIFF
--- a/inference-chain/x/inference/keeper/payment_handler.go
+++ b/inference-chain/x/inference/keeper/payment_handler.go
@@ -69,7 +69,7 @@ func (k *Keeper) PayParticipantFromModule(ctx context.Context, address string, a
 			return err
 		}
 		// Vesting keeper should move funds and create vesting schedule
-		err = k.GetStreamVestingKeeper().AddVestedRewards(ctx, address, types.ModuleName, vestingAmount, vestingEpochs, memo+"_vested")
+		err = k.GetStreamVestingKeeper().AddVestedRewards(ctx, address, moduleName, vestingAmount, vestingEpochs, memo+"_vested")
 		if err != nil {
 			k.LogError("Error adding vested payment", types.Payments, "error", err, "amount", vestingAmount)
 			return err

--- a/inference-chain/x/inference/keeper/streamvesting_integration_test.go
+++ b/inference-chain/x/inference/keeper/streamvesting_integration_test.go
@@ -150,7 +150,7 @@ func TestVestingIntegration_ParameterBased(t *testing.T) {
 
 	expectedRewardCoins := sdk.NewCoins(sdk.NewInt64Coin(types.BaseCoin, int64(rewardAmount)))
 	mocks.StreamVestingKeeper.EXPECT().
-		AddVestedRewards(ctx, participantAddrStr, "inference", expectedRewardCoins, &rewardVestingPeriod, gomock.Any()).
+		AddVestedRewards(ctx, participantAddrStr, types.TopRewardPoolAccName, expectedRewardCoins, &rewardVestingPeriod, gomock.Any()).
 		Return(nil)
 
 	// Execute payment from top reward pool module
@@ -278,7 +278,7 @@ func TestVestingIntegration_MixedVestingScenario(t *testing.T) {
 
 	expectedRewardCoins := sdk.NewCoins(sdk.NewInt64Coin(types.BaseCoin, int64(rewardAmount)))
 	mocks.StreamVestingKeeper.EXPECT().
-		AddVestedRewards(ctx, participantAddrStr, "inference", expectedRewardCoins, &rewardVestingPeriod, gomock.Any()).
+		AddVestedRewards(ctx, participantAddrStr, types.TopRewardPoolAccName, expectedRewardCoins, &rewardVestingPeriod, gomock.Any()).
 		Return(nil)
 
 	err = k.PayParticipantFromModule(ctx, participantAddrStr, rewardAmount, types.TopRewardPoolAccName, "reward-payment", &rewardVestingPeriod)
@@ -300,7 +300,7 @@ func TestVestingIntegration_TopMinerRewards(t *testing.T) {
 	expectedCoins := sdk.NewCoins(sdk.NewInt64Coin(types.BaseCoin, int64(rewardAmount)))
 
 	mocks.StreamVestingKeeper.EXPECT().
-		AddVestedRewards(ctx, participantAddrStr, "inference", expectedCoins, &topMinerVestingPeriod, gomock.Any()).
+		AddVestedRewards(ctx, participantAddrStr, types.TopRewardPoolAccName, expectedCoins, &topMinerVestingPeriod, gomock.Any()).
 		Return(nil)
 
 	// Execute top miner reward payment
@@ -340,7 +340,7 @@ func TestVestingIntegration_ErrorHandling(t *testing.T) {
 
 	// Test case 2: Vesting keeper failure should be handled
 	mocks.StreamVestingKeeper.EXPECT().
-		AddVestedRewards(ctx, participantAddrStr, types.ModuleName, expectedCoins, &vestingPeriod, gomock.Any()).
+		AddVestedRewards(ctx, participantAddrStr, types.TopRewardPoolAccName, expectedCoins, &vestingPeriod, gomock.Any()).
 		Return(fmt.Errorf("invalid request"))
 
 	err := k.PayParticipantFromModule(ctx, participantAddrStr, amount, types.TopRewardPoolAccName, "vesting-error-test", &vestingPeriod)


### PR DESCRIPTION
`PayParticipantFromModule` takes a `moduleName` param to control which module funds the payment. The direct path uses it correctly, but the vesting path hardcodes `types.ModuleName` ("inference") instead of the passed `moduleName`.

When `top_miners.go` calls with `"top_reward"` and `TopMinerVestingPeriod > 0`, vested top miner rewards get pulled from the inference module instead of the top_reward pool. Right person gets paid, wrong account debited. Drains the inference module while top_reward accumulates unspent funds.

One-line fix — `payment_handler.go:72`, `types.ModuleName` to `moduleName`. 
Test expectations updated to match.