### PR TITLE
Ak issue782 0.2.11

### DIFF
--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -25,6 +25,43 @@ import (
 	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
 
+// EpochGroupDraftDecorator binds a tx-scoped EpochGroupData draft to the request context at tx start.
+// PostHandler must call CommitEpochGroupDraftFromContext on success; block cache is flushed to store in EndBlock.
+type EpochGroupDraftDecorator struct {
+	InferenceKeeper *inferencemodulekeeper.Keeper
+}
+
+// AnteHandle attaches WithEpochGroupDraft to the context for the rest of the tx.
+func (d EpochGroupDraftDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if d.InferenceKeeper == nil {
+		return next(ctx, tx, simulate)
+	}
+	newCtx := ctx.WithContext(inferencemodulekeeper.WithEpochGroupDraft(ctx.Context()))
+	return next(newCtx, tx, simulate)
+}
+
+// EpochGroupDraftCommitPostDecorator merges the tx-scoped EpochGroupData draft into the block cache on tx success.
+type EpochGroupDraftCommitPostDecorator struct {
+	InferenceKeeper *inferencemodulekeeper.Keeper
+}
+
+// PostHandle runs the rest of the post chain, then on success commits the epoch group draft to the block cache; on failure releases the draft write lock.
+func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
+	newCtx, err := next(ctx, tx, simulate, success)
+	if err != nil {
+		return newCtx, err
+	}
+	if d.InferenceKeeper == nil {
+		return newCtx, nil
+	}
+	if success {
+		d.InferenceKeeper.CommitEpochGroupDraftFromContext(newCtx)
+	} else {
+		d.InferenceKeeper.ReleaseEpochGroupDraftFromContext(newCtx)
+	}
+	return newCtx, nil
+}
+
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
 // channel keeper.
 type HandlerOptions struct {
@@ -192,6 +229,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		EpochGroupDraftDecorator{InferenceKeeper: options.InferenceKeeper}, // tx-scoped EpochGroupData draft; committed to block cache in PostHandler, flushed in EndBlock
 		wasmkeeper.NewLimitSimulationGasDecorator(options.NodeConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		wasmkeeper.NewGasRegisterDecorator(options.WasmKeeper.GetGasRegister()),
@@ -251,4 +289,6 @@ func (app *App) setAnteHandler(txConfig client.TxConfig, nodeConfig wasmtypes.No
 
 	// Set the AnteHandler for the app
 	app.SetAnteHandler(anteHandler)
+	// Merge tx-scoped EpochGroupData draft into block cache on tx success (block cache flushed to store in EndBlock)
+	app.SetPostHandler(sdk.ChainPostDecorators(EpochGroupDraftCommitPostDecorator{InferenceKeeper: &app.InferenceKeeper}))
 }

--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -32,11 +32,16 @@ type EpochGroupDraftDecorator struct {
 }
 
 // AnteHandle attaches WithEpochGroupDraft to the context for the rest of the tx.
+// For CheckTx and simulate, also attaches WithCommittedStateOnly so the keeper uses only the store (last committed block), not the block cache.
 func (d EpochGroupDraftDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	if d.InferenceKeeper == nil {
 		return next(ctx, tx, simulate)
 	}
-	newCtx := ctx.WithContext(inferencemodulekeeper.WithEpochGroupDraft(ctx.Context()))
+	goCtx := inferencemodulekeeper.WithEpochGroupDraft(ctx.Context())
+	if ctx.IsCheckTx() || simulate {
+		goCtx = inferencemodulekeeper.WithCommittedStateOnly(goCtx)
+	}
+	newCtx := ctx.WithContext(goCtx)
 	return next(newCtx, tx, simulate)
 }
 
@@ -46,12 +51,18 @@ type EpochGroupDraftCommitPostDecorator struct {
 }
 
 // PostHandle runs the rest of the post chain, then on success commits the epoch group draft to the block cache; on failure releases the draft write lock.
+// During DeliverTx: commit on success, release lock on failure. During CheckTx/simulate: always release the lock only (no commit),
+// so we never leak the block-cache draft writer lock; we still skip commit to avoid mutating the shared block cache.
 func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
 	newCtx, err := next(ctx, tx, simulate, success)
 	if err != nil {
 		return newCtx, err
 	}
 	if d.InferenceKeeper == nil {
+		return newCtx, nil
+	}
+	if ctx.IsCheckTx() || simulate {
+		d.InferenceKeeper.ReleaseEpochGroupDraftFromContext(newCtx)
 		return newCtx, nil
 	}
 	if success {

--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -51,8 +51,7 @@ type EpochGroupDraftCommitPostDecorator struct {
 }
 
 // PostHandle runs the rest of the post chain, then on success commits the epoch group draft to the block cache; on failure releases the draft write lock.
-// During DeliverTx: commit on success, release lock on failure. During CheckTx/simulate: always release the lock only (no commit),
-// so we never leak the block-cache draft writer lock; we still skip commit to avoid mutating the shared block cache.
+// During DeliverTx: commit on success, release lock on failure. During CheckTx/simulate: skip (we never take the block-cache draft writer lock there, so nothing to release or commit).
 func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
 	newCtx, err := next(ctx, tx, simulate, success)
 	if err != nil {
@@ -62,7 +61,7 @@ func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.T
 		return newCtx, nil
 	}
 	if ctx.IsCheckTx() || simulate {
-		d.InferenceKeeper.ReleaseEpochGroupDraftFromContext(newCtx)
+		// We never take the block-cache draft writer lock during CheckTx/simulate, so nothing to release or commit.
 		return newCtx, nil
 	}
 	if success {
@@ -239,8 +238,8 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	}
 
 	anteDecorators := []sdk.AnteDecorator{
-		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
-		EpochGroupDraftDecorator{InferenceKeeper: options.InferenceKeeper}, // tx-scoped EpochGroupData draft; committed to block cache in PostHandler, flushed in EndBlock
+		ante.NewSetUpContextDecorator(),                                                  // outermost AnteDecorator. SetUpContext must be called first
+		EpochGroupDraftDecorator{InferenceKeeper: options.InferenceKeeper},               // tx-scoped EpochGroupData draft; committed to block cache in PostHandler, flushed in EndBlock
 		wasmkeeper.NewLimitSimulationGasDecorator(options.NodeConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		wasmkeeper.NewGasRegisterDecorator(options.WasmKeeper.GetGasRegister()),

--- a/inference-chain/x/inference/keeper/CONCURRENCY.md
+++ b/inference-chain/x/inference/keeper/CONCURRENCY.md
@@ -1,0 +1,20 @@
+# Epoch group data concurrency
+
+The keeper’s epoch group cache and tx-scoped draft are designed to support **concurrent execution** of transactions. This is required for **Cosmos optimistic execution mode**, where multiple transactions can run in parallel before being committed.
+
+The concurrency tests in `epoch_group_data_concurrent_test.go` check that:
+
+1. **Multiple parallel reads** – Many read-only “transactions” see the same data and do not block each other.
+2. **One writer, many readers** – After a writer commits, all readers see the written value (block cache is updated correctly).
+3. **One writer, multiple Set/Get, many readers** – No deadlocks when a writer does several Set/Get in one tx while readers run in parallel (reentrant draft lock).
+4. **Multiple writers and readers** – Writes are serialized at commit time, and the final read sees the last committed value.
+
+## Running the tests
+
+Run the concurrency tests as usual:
+
+```bash
+go test ./x/inference/keeper/ -run EpochGroupDataConcurrent -v
+```
+
+**Note on `-race`:** The tests intentionally share a single `sdk.Context` across goroutines to stress the keeper’s locking. The Cosmos SDK store and gas meter are not safe for concurrent use from multiple goroutines. With `go test -race`, the race detector may report races in the SDK layer (e.g. `cosmossdk.io/store/types.(*infiniteGasMeter).ConsumeGas`). That is a limitation of the test harness, not of the keeper’s epoch group logic. In production, each transaction gets its own context, and the keeper’s cache and draft locking are what allow safe concurrent access to epoch group data under optimistic execution.

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -11,6 +11,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"github.com/cosmos/gogoproto/proto"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -41,6 +42,11 @@ func getGID() int64 {
 
 // ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
 type ctxKeyEpochGroupDraft struct{}
+
+// ctxKeyEpochGroupBranchDraft is the context key for a cache-branch-scoped EpochGroupData draft.
+// When set (e.g. via CacheContextWithEpochGroupBranch), reads/writes use this draft instead of the main draft.
+// The branch draft is merged into the parent draft when the branch's writeCache() is called.
+type ctxKeyEpochGroupBranchDraft struct{}
 
 // lazyEpochGroupDraft defers allocation of the real draft until the first write (Set/Remove).
 // This avoids allocating a map for every tx when most txs only read epoch group data.
@@ -117,9 +123,13 @@ func WithEpochGroupDraft(ctx context.Context) context.Context {
 }
 
 // getEpochGroupDraftFromContext returns the draft from ctx if it exists, or nil. Does not create the draft (for reads and for Commit/Release).
+// When ctx has a branch draft (e.g. from CacheContextWithEpochGroupBranch), that is preferred over the main tx draft.
 func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
 	if ctx == nil {
 		return nil
+	}
+	if d := getEpochGroupBranchDraftFromContext(ctx); d != nil {
+		return d
 	}
 	v := ctx.Value(ctxKeyEpochGroupDraft{})
 	if v == nil {
@@ -135,10 +145,39 @@ func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
 	}
 }
 
+// getEpochGroupBranchDraftFromContext returns only the branch draft from ctx (ctxKeyEpochGroupBranchDraft), or nil.
+// Does not create the draft. Used when merging a branch into the parent.
+func getEpochGroupBranchDraftFromContext(ctx context.Context) *epochGroupDraft {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(ctxKeyEpochGroupBranchDraft{})
+	if v == nil {
+		return nil
+	}
+	switch h := v.(type) {
+	case *lazyEpochGroupDraft:
+		return h.get()
+	case *epochGroupDraft:
+		return h
+	default:
+		return nil
+	}
+}
+
 // getEpochGroupDraftForWriteFromContext returns the draft, creating it from the lazy holder on first write. Use in SetEpochGroupData and RemoveEpochGroupData.
+// When ctx has a branch draft (e.g. from CacheContextWithEpochGroupBranch), that is preferred over the main tx draft.
 func getEpochGroupDraftForWriteFromContext(ctx context.Context) *epochGroupDraft {
 	if ctx == nil {
 		return nil
+	}
+	if v := ctx.Value(ctxKeyEpochGroupBranchDraft{}); v != nil {
+		switch h := v.(type) {
+		case *lazyEpochGroupDraft:
+			return h.getOrCreate()
+		case *epochGroupDraft:
+			return h
+		}
 	}
 	v := ctx.Value(ctxKeyEpochGroupDraft{})
 	if v == nil {
@@ -203,6 +242,61 @@ func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
 		return
 	}
 	draft.releaseWriteLock()
+}
+
+// mergeEpochGroupBranchDraftIntoParent snapshots the branch draft from branchCtx, releases its write lock,
+// and merges all entries into the parent's draft (from parentCtx). Call before writeCache() when using
+// CacheContextWithEpochGroupBranch so that branch draft writes are visible to the rest of the tx.
+func mergeEpochGroupBranchDraftIntoParent(parentCtx, branchCtx context.Context) {
+	branchDraft := getEpochGroupBranchDraftFromContext(branchCtx)
+	if branchDraft == nil {
+		return
+	}
+	var snapshot map[epochGroupCacheKey]types.EpochGroupData
+	if branchDraft.isWriteLocked() {
+		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(branchDraft.m))
+		for key, val := range branchDraft.m {
+			snapshot[key] = val
+		}
+		branchDraft.releaseWriteLock()
+	} else {
+		branchDraft.mu.RLock()
+		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(branchDraft.m))
+		for key, val := range branchDraft.m {
+			snapshot[key] = val
+		}
+		branchDraft.mu.RUnlock()
+	}
+	parentDraft := getEpochGroupDraftForWriteFromContext(parentCtx)
+	if parentDraft == nil {
+		return
+	}
+	parentDraft.lockWrite()
+	defer parentDraft.unlockWrite()
+	for key, val := range snapshot {
+		cloned := proto.Clone(&val).(*types.EpochGroupData)
+		parentDraft.m[key] = *cloned
+	}
+}
+
+// CacheContextWithEpochGroupBranch returns a cached context that has its own EpochGroupData draft branch.
+// Use the returned cacheCtx for speculative work; any SetEpochGroupData/RemoveEpochGroupData on cacheCtx
+// go to the branch draft. Call the returned writeCache() on success to merge both the store cache and
+// the branch draft into the parent context. If you do not call writeCache(), both store and draft changes
+// are discarded. Safe to call writeCache() at most once (idempotent).
+func (k Keeper) CacheContextWithEpochGroupBranch(ctx sdk.Context) (sdk.Context, func()) {
+	cacheCtx, writeCache := ctx.CacheContext()
+	branchLazy := &lazyEpochGroupDraft{}
+	cacheCtx = cacheCtx.WithContext(context.WithValue(ctx.Context(), ctxKeyEpochGroupBranchDraft{}, branchLazy))
+	var written bool
+	return cacheCtx, func() {
+		if written {
+			return
+		}
+		written = true
+		mergeEpochGroupBranchDraftIntoParent(ctx.Context(), cacheCtx.Context())
+		writeCache()
+	}
 }
 
 // InvalidateEpochGroupCache clears the epoch group block cache. Call from BeginBlock each block.

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 
 	"cosmossdk.io/collections"
-	"github.com/cosmos/gogoproto/proto"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -40,6 +40,39 @@ func getGID() int64 {
 	return gid
 }
 
+// lockDraftWrite on the block cache: while any tx is writing to its draft, no one can read from the block cache (draftWriterMu write lock).
+// Reentrant for the same goroutine; released only in PostHandler via releaseDraftWriteLock. No-op when COSMOS_OPTIMISTIC_CACHES != 1.
+func (c *epochGroupCache) lockDraftWrite() {
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
+	gid := getGID()
+	if atomic.LoadInt64(&c.draftWriteHolder) == gid {
+		atomic.AddInt32(&c.draftWriteCount, 1)
+		return
+	}
+	c.draftWriterMu.Lock()
+	atomic.StoreInt64(&c.draftWriteHolder, gid)
+	atomic.StoreInt32(&c.draftWriteCount, 1)
+}
+
+func (c *epochGroupCache) unlockDraftWrite() {
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
+	if atomic.AddInt32(&c.draftWriteCount, -1) == 0 {
+		atomic.StoreInt64(&c.draftWriteHolder, 0)
+		c.draftWriterMu.Unlock()
+	}
+}
+
+// releaseDraftWriteLock fully releases the draft write lock (for PostHandler). Call on tx commit or failure.
+func (c *epochGroupCache) releaseDraftWriteLock() {
+	for atomic.LoadInt32(&c.draftWriteCount) > 0 {
+		c.unlockDraftWrite()
+	}
+}
+
 // ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
 type ctxKeyEpochGroupDraft struct{}
 
@@ -47,6 +80,22 @@ type ctxKeyEpochGroupDraft struct{}
 // When set (e.g. via CacheContextWithEpochGroupBranch), reads/writes use this draft instead of the main draft.
 // The branch draft is merged into the parent draft when the branch's writeCache() is called.
 type ctxKeyEpochGroupBranchDraft struct{}
+
+// ctxKeyCommittedStateOnly is set when ctx is for CheckTx or simulate. When set, epoch group uses store for initial reads and a tx-scoped draft for writes (draft never merged to block cache).
+type ctxKeyCommittedStateOnly struct{}
+
+// WithCommittedStateOnly marks ctx so that Get/Set/Remove EpochGroupData use store + tx draft only (no block cache). Call from AnteHandler when IsCheckTx() or simulate.
+func WithCommittedStateOnly(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeyCommittedStateOnly{}, true)
+}
+
+func isCommittedStateOnly(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(ctxKeyCommittedStateOnly{}).(bool)
+	return v
+}
 
 // lazyEpochGroupDraft defers allocation of the real draft until the first write (Set/Remove).
 // This avoids allocating a map for every tx when most txs only read epoch group data.
@@ -61,58 +110,20 @@ func (l *lazyEpochGroupDraft) get() *epochGroupDraft {
 
 func (l *lazyEpochGroupDraft) getOrCreate() *epochGroupDraft {
 	l.once.Do(func() {
-		l.d = &epochGroupDraft{m: make(map[epochGroupCacheKey]types.EpochGroupData)}
+		l.d = &epochGroupDraft{
+			m:       make(map[epochGroupCacheKey]types.EpochGroupData),
+			removed: make(map[epochGroupCacheKey]struct{}),
+		}
 	})
 	return l.d
 }
 
 // epochGroupDraft holds tx-scoped EpochGroupData writes for optimistic parallel execution.
-// Uses a reentrant write lock: the same goroutine can write (or delete) multiple times; lock is released only in PostHandler (commit or failure).
+// The block cache's draftWriterMu is held while writing so no one reads uncommitted state; released in PostHandler (commit or failure).
+// removed records keys removed in this tx; deletions are applied to the block cache only on commit so rollback is consistent.
 type epochGroupDraft struct {
-	mu          sync.RWMutex
-	m           map[epochGroupCacheKey]types.EpochGroupData
-	writeHolder int64 // goroutine id of the writer (for reentrancy)
-	writeCount  int32 // number of Lock() calls not yet Unlock()ed by the holder
-}
-
-// lockWrite acquires the write lock; reentrant for the same goroutine (increments count). Release via unlockWrite or releaseWriteLock.
-// Only takes the lock when COSMOS_OPTIMISTIC_CACHES=1; otherwise no-op.
-func (d *epochGroupDraft) lockWrite() {
-	if !cosmosOptimisticCachesEnabled {
-		return
-	}
-	gid := getGID()
-	if atomic.LoadInt64(&d.writeHolder) == gid {
-		atomic.AddInt32(&d.writeCount, 1)
-		return
-	}
-	d.mu.Lock()
-	atomic.StoreInt64(&d.writeHolder, gid)
-	atomic.StoreInt32(&d.writeCount, 1)
-}
-
-// unlockWrite releases one level of the write lock; if count goes to 0, releases the underlying RWMutex.
-// No-op when COSMOS_OPTIMISTIC_CACHES is not 1.
-func (d *epochGroupDraft) unlockWrite() {
-	if !cosmosOptimisticCachesEnabled {
-		return
-	}
-	if atomic.AddInt32(&d.writeCount, -1) == 0 {
-		atomic.StoreInt64(&d.writeHolder, 0)
-		d.mu.Unlock()
-	}
-}
-
-// isWriteLocked returns true if any goroutine holds the write lock (for readers: if true and we are the holder we can read without RLock).
-func (d *epochGroupDraft) isWriteLocked() bool {
-	return atomic.LoadInt32(&d.writeCount) > 0
-}
-
-// releaseWriteLock fully releases the write lock (for PostHandler: unlock until count is 0).
-func (d *epochGroupDraft) releaseWriteLock() {
-	for atomic.LoadInt32(&d.writeCount) > 0 {
-		d.unlockWrite()
-	}
+	m       map[epochGroupCacheKey]types.EpochGroupData
+	removed map[epochGroupCacheKey]struct{}
 }
 
 // WithEpochGroupDraft attaches a lazy tx-scoped draft holder to ctx. Call at tx start (e.g. from AnteHandler).
@@ -194,28 +205,21 @@ func getEpochGroupDraftForWriteFromContext(ctx context.Context) *epochGroupDraft
 }
 
 // CommitEpochGroupDraftFromContext merges the draft from ctx into the block cache. Call from PostHandler on tx success.
-// Does not write to store; FlushCurrentEpochGroupCache in EndBlock persists. Releases the draft write lock if held.
+// Applies draft writes and draft removals (tombstones) to the block cache; does not write to store (FlushCurrentEpochGroupCache in EndBlock persists). Releases the block cache draft write lock if held.
 func (k Keeper) CommitEpochGroupDraftFromContext(ctx context.Context) {
 	draft := getEpochGroupDraftFromContext(ctx)
 	if draft == nil {
 		return
 	}
-	var snapshot map[epochGroupCacheKey]types.EpochGroupData
-	if draft.isWriteLocked() {
-		// This tx holds the write lock (same goroutine as PostHandler); read directly then release.
-		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
-		for key, val := range draft.m {
-			snapshot[key] = val
-		}
-		draft.releaseWriteLock()
-	} else {
-		draft.mu.RLock()
-		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
-		for key, val := range draft.m {
-			snapshot[key] = val
-		}
-		draft.mu.RUnlock()
+	snapshot := make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
+	for key, val := range draft.m {
+		snapshot[key] = val
 	}
+	removedSnapshot := make(map[epochGroupCacheKey]struct{}, len(draft.removed))
+	for key := range draft.removed {
+		removedSnapshot[key] = struct{}{}
+	}
+	k.epochGroupCache.releaseDraftWriteLock()
 
 	c := k.epochGroupCache
 	c.mu.Lock()
@@ -230,52 +234,40 @@ func (k Keeper) CommitEpochGroupDraftFromContext(ctx context.Context) {
 			c.currentDirty = true
 			continue
 		}
-		// Non-current epoch or cache not inited: write through to store.
+		// Non-current/previous epoch or cache not inited: write through to store.
 		_ = k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
 	}
-}
-
-// ReleaseEpochGroupDraftFromContext releases the draft write lock if held. Call from PostHandler on tx failure so the lock is released when the tx does not commit.
-func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
-	draft := getEpochGroupDraftFromContext(ctx)
-	if draft == nil || !draft.isWriteLocked() {
-		return
+	for key := range removedSnapshot {
+		if c.inited && (key.Epoch == c.current || key.Epoch == c.previous) {
+			delete(c.m, key)
+			c.currentDirty = true
+		}
 	}
-	draft.releaseWriteLock()
 }
 
-// mergeEpochGroupBranchDraftIntoParent snapshots the branch draft from branchCtx, releases its write lock,
-// and merges all entries into the parent's draft (from parentCtx). Call before writeCache() when using
-// CacheContextWithEpochGroupBranch so that branch draft writes are visible to the rest of the tx.
+// ReleaseEpochGroupDraftFromContext releases the block cache draft write lock if held. Call from PostHandler on tx failure.
+func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
+	k.epochGroupCache.releaseDraftWriteLock()
+}
+
+// mergeEpochGroupBranchDraftIntoParent merges the branch draft (writes and removals) into the parent's draft.
+// Call before writeCache() when using CacheContextWithEpochGroupBranch. Caller holds block cache draft writer lock from branch writes.
 func mergeEpochGroupBranchDraftIntoParent(parentCtx, branchCtx context.Context) {
 	branchDraft := getEpochGroupBranchDraftFromContext(branchCtx)
 	if branchDraft == nil {
 		return
 	}
-	var snapshot map[epochGroupCacheKey]types.EpochGroupData
-	if branchDraft.isWriteLocked() {
-		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(branchDraft.m))
-		for key, val := range branchDraft.m {
-			snapshot[key] = val
-		}
-		branchDraft.releaseWriteLock()
-	} else {
-		branchDraft.mu.RLock()
-		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(branchDraft.m))
-		for key, val := range branchDraft.m {
-			snapshot[key] = val
-		}
-		branchDraft.mu.RUnlock()
-	}
 	parentDraft := getEpochGroupDraftForWriteFromContext(parentCtx)
 	if parentDraft == nil {
 		return
 	}
-	parentDraft.lockWrite()
-	defer parentDraft.unlockWrite()
-	for key, val := range snapshot {
+	for key, val := range branchDraft.m {
 		cloned := proto.Clone(&val).(*types.EpochGroupData)
 		parentDraft.m[key] = *cloned
+	}
+	for key := range branchDraft.removed {
+		parentDraft.removed[key] = struct{}{}
+		delete(parentDraft.m, key)
 	}
 }
 
@@ -370,11 +362,15 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 
 // IncrementCurrentEpochGroupRequestCount increments the per-block atomic counter for the current epoch's NumberOfRequests. Committed to store in EndBlock.
 func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) int64 {
+	if isCommittedStateOnly(ctx) {
+		return 0
+	}
 	c := k.epochGroupCache
 	k.ensureEpochGroupCacheInited(ctx)
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.inited {
+	inited := c.inited
+	c.mu.Unlock()
+	if !inited {
 		return 0
 	}
 	count := c.currentEpochRequestCount.Add(1)
@@ -385,6 +381,15 @@ func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) int6
 // SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).
 // Draft is created lazily on first write so read-only txs do not allocate it.
 func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
+	if isCommittedStateOnly(ctx) {
+		draft := getEpochGroupDraftForWriteFromContext(ctx)
+		if draft != nil {
+			key := epochGroupCacheKey{Epoch: epochGroupData.EpochIndex, ModelId: epochGroupData.ModelId}
+			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
+			draft.m[key] = *cloned
+		}
+		return
+	}
 	epochIdx := epochGroupData.EpochIndex
 	modelId := epochGroupData.ModelId
 	key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
@@ -398,12 +403,11 @@ func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.Epoc
 		c.mu.RUnlock()
 		if inited && (epochIdx == current || epochIdx == previous) {
 			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
-			draft.lockWrite() // reentrant: same goroutine can write multiple times
+			c.lockDraftWrite() // blocks block cache reads until PostHandler commit/release
 			draft.m[key] = *cloned
-			// Do not unlock here; lock is released in PostHandler (commit or failure)
 			return
 		}
-		// Non-current/previous: write through to store
+		// Non-current: write through to store
 		k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
 		return
 	}
@@ -427,6 +431,23 @@ func (k Keeper) GetEpochGroupData(
 	epochIndex uint64,
 	modelId string,
 ) (val types.EpochGroupData, found bool) {
+	if isCommittedStateOnly(ctx) {
+		key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
+		if draft := getEpochGroupDraftFromContext(ctx); draft != nil {
+			if _, removed := draft.removed[key]; removed {
+				return types.EpochGroupData{}, false
+			}
+			if cached, ok := draft.m[key]; ok {
+				cloned := proto.Clone(&cached).(*types.EpochGroupData)
+				return *cloned, true
+			}
+		}
+		val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
+		if err != nil {
+			return val, false
+		}
+		return val, true
+	}
 	k.ensureEpochGroupCacheInited(ctx)
 	c := k.epochGroupCache
 	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
@@ -437,31 +458,28 @@ func (k Keeper) GetEpochGroupData(
 		inited, current, previous := c.inited, c.current, c.previous
 		c.mu.RUnlock()
 		if inited && (epochIndex == current || epochIndex == previous) {
-			var cached types.EpochGroupData
-			var ok bool
-			if draft.isWriteLocked() && atomic.LoadInt64(&draft.writeHolder) == getGID() {
-				cached, ok = draft.m[key]
-			} else {
-				draft.mu.RLock()
-				cached, ok = draft.m[key]
-				draft.mu.RUnlock()
+			if _, removed := draft.removed[key]; removed {
+				return types.EpochGroupData{}, false
 			}
-			if ok {
+			if cached, ok := draft.m[key]; ok {
 				cloned := proto.Clone(&cached).(*types.EpochGroupData)
 				return *cloned, true
 			}
 		}
 	}
 
+	c.draftWriterMu.RLock()
 	c.mu.RLock()
 	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
 		if cached, ok := c.m[key]; ok {
 			c.mu.RUnlock()
+			c.draftWriterMu.RUnlock()
 			cloned := proto.Clone(&cached).(*types.EpochGroupData)
 			return *cloned, true
 		}
 	}
 	c.mu.RUnlock()
+	c.draftWriterMu.RUnlock()
 
 	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
 	if err != nil {
@@ -483,6 +501,14 @@ func (k Keeper) RemoveEpochGroupData(
 	epochIndex uint64,
 	modelId string,
 ) {
+	if isCommittedStateOnly(ctx) {
+		key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
+		if draft := getEpochGroupDraftForWriteFromContext(ctx); draft != nil {
+			draft.removed[key] = struct{}{}
+			delete(draft.m, key)
+		}
+		return
+	}
 	k.EpochGroupDataMap.Remove(ctx, collections.Join(epochIndex, modelId))
 	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
 	k.ensureEpochGroupCacheInited(ctx)
@@ -492,10 +518,11 @@ func (k Keeper) RemoveEpochGroupData(
 	c.mu.RUnlock()
 	if needDraft {
 		if draft := getEpochGroupDraftForWriteFromContext(ctx); draft != nil {
-			draft.lockWrite()
+			c.lockDraftWrite()
+			draft.removed[key] = struct{}{}
 			delete(draft.m, key)
-			// Do not unlock here; released in PostHandler
 		}
+		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -39,8 +39,8 @@ type ctxKeyEpochGroupDraft struct{}
 type epochGroupDraft struct {
 	mu          sync.RWMutex
 	m           map[epochGroupCacheKey]types.EpochGroupData
-	writeHolder int64  // goroutine id of the writer (for reentrancy)
-	writeCount  int32  // number of Lock() calls not yet Unlock()ed by the holder
+	writeHolder int64 // goroutine id of the writer (for reentrancy)
+	writeCount  int32 // number of Lock() calls not yet Unlock()ed by the holder
 }
 
 // lockWrite acquires the write lock; reentrant for the same goroutine (increments count). Release via unlockWrite or releaseWriteLock.
@@ -188,6 +188,11 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 		return
 	}
 	delta := c.currentEpochRequestCount.Swap(0)
+	if !c.currentDirty && delta == 0 {
+		return
+	}
+
+	// We persist here if have changes in cache or have increments in currentEpochRequestCount
 	rootKey := epochGroupCacheKey{Epoch: c.current, ModelId: ""}
 	if val, inCache := c.m[rootKey]; inCache {
 		val.NumberOfRequests += delta
@@ -199,6 +204,8 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId), val)
 		}
 	}
+
+	// We persist here all other cached EpochGroupData for the current epoch
 	for key, val := range c.m {
 		if key.Epoch == c.current && key != rootKey {
 			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(key.Epoch, key.ModelId), val)

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -1,41 +1,340 @@
 package keeper
 
 import (
+	"bytes"
 	"context"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"cosmossdk.io/collections"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/productscience/inference/x/inference/types"
 )
 
-// SetEpochGroupData set a specific epochGroupData in the store from its index
-func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
-	k.EpochGroupDataMap.Set(ctx, collections.Join(epochGroupData.EpochIndex, epochGroupData.ModelId), epochGroupData)
+// getGID returns the current goroutine id (for reentrant lock holder identity). Uses runtime.Stack; for use in reentrant locking only.
+func getGID() int64 {
+	buf := make([]byte, 64)
+	n := runtime.Stack(buf, false)
+	buf = buf[:n]
+	idx := bytes.Index(buf, []byte("goroutine "))
+	if idx < 0 {
+		return 0
+	}
+	buf = buf[idx+len("goroutine "):]
+	idx = bytes.Index(buf, []byte(" "))
+	if idx < 0 {
+		return 0
+	}
+	gid, _ := strconv.ParseInt(string(buf[:idx]), 10, 64)
+	return gid
 }
 
-// GetEpochGroupData returns a epochGroupData from its index
+// ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
+type ctxKeyEpochGroupDraft struct{}
+
+// epochGroupDraft holds tx-scoped EpochGroupData writes for optimistic parallel execution.
+// Uses a reentrant write lock: the same goroutine can write (or delete) multiple times; lock is released only in PostHandler (commit or failure).
+type epochGroupDraft struct {
+	mu          sync.RWMutex
+	m           map[epochGroupCacheKey]types.EpochGroupData
+	writeHolder int64  // goroutine id of the writer (for reentrancy)
+	writeCount  int32  // number of Lock() calls not yet Unlock()ed by the holder
+}
+
+// lockWrite acquires the write lock; reentrant for the same goroutine (increments count). Release via unlockWrite or releaseWriteLock.
+func (d *epochGroupDraft) lockWrite() {
+	gid := getGID()
+	if atomic.LoadInt64(&d.writeHolder) == gid {
+		atomic.AddInt32(&d.writeCount, 1)
+		return
+	}
+	d.mu.Lock()
+	atomic.StoreInt64(&d.writeHolder, gid)
+	atomic.StoreInt32(&d.writeCount, 1)
+}
+
+// unlockWrite releases one level of the write lock; if count goes to 0, releases the underlying RWMutex.
+func (d *epochGroupDraft) unlockWrite() {
+	if atomic.AddInt32(&d.writeCount, -1) == 0 {
+		atomic.StoreInt64(&d.writeHolder, 0)
+		d.mu.Unlock()
+	}
+}
+
+// isWriteLocked returns true if any goroutine holds the write lock (for readers: if true and we are the holder we can read without RLock).
+func (d *epochGroupDraft) isWriteLocked() bool {
+	return atomic.LoadInt32(&d.writeCount) > 0
+}
+
+// releaseWriteLock fully releases the write lock (for PostHandler: unlock until count is 0).
+func (d *epochGroupDraft) releaseWriteLock() {
+	for atomic.LoadInt32(&d.writeCount) > 0 {
+		d.unlockWrite()
+	}
+}
+
+// WithEpochGroupDraft attaches a new tx-scoped draft to ctx. Call at tx start (e.g. from AnteHandler).
+func WithEpochGroupDraft(ctx context.Context) context.Context {
+	d := &epochGroupDraft{m: make(map[epochGroupCacheKey]types.EpochGroupData)}
+	return context.WithValue(ctx, ctxKeyEpochGroupDraft{}, d)
+}
+
+// getEpochGroupDraftFromContext returns the draft from ctx, or nil if no draft is bound.
+func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(ctxKeyEpochGroupDraft{})
+	if v == nil {
+		return nil
+	}
+	d, _ := v.(*epochGroupDraft)
+	return d
+}
+
+// CommitEpochGroupDraftFromContext merges the draft from ctx into the block cache. Call from PostHandler on tx success.
+// Does not write to store; FlushCurrentEpochGroupCache in EndBlock persists. Releases the draft write lock if held.
+func (k Keeper) CommitEpochGroupDraftFromContext(ctx context.Context) {
+	draft := getEpochGroupDraftFromContext(ctx)
+	if draft == nil {
+		return
+	}
+	var snapshot map[epochGroupCacheKey]types.EpochGroupData
+	if draft.isWriteLocked() {
+		// This tx holds the write lock (same goroutine as PostHandler); read directly then release.
+		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
+		for key, val := range draft.m {
+			snapshot[key] = val
+		}
+		draft.releaseWriteLock()
+	} else {
+		draft.mu.RLock()
+		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
+		for key, val := range draft.m {
+			snapshot[key] = val
+		}
+		draft.mu.RUnlock()
+	}
+
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, epochGroupData := range snapshot {
+		epochIdx := epochGroupData.EpochIndex
+		modelId := epochGroupData.ModelId
+		key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
+		if c.inited && (epochIdx == c.current || epochIdx == c.previous) {
+			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
+			c.m[key] = *cloned
+			c.currentDirty = true
+			continue
+		}
+		// Non-current epoch or cache not inited: write through to store.
+		_ = k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
+	}
+}
+
+// ReleaseEpochGroupDraftFromContext releases the draft write lock if held. Call from PostHandler on tx failure so the lock is released when the tx does not commit.
+func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
+	draft := getEpochGroupDraftFromContext(ctx)
+	if draft == nil || !draft.isWriteLocked() {
+		return
+	}
+	draft.releaseWriteLock()
+}
+
+// InvalidateEpochGroupCache clears the epoch group block cache. Call from BeginBlock each block.
+func (k Keeper) InvalidateEpochGroupCache() {
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inited = false
+	c.m = make(map[epochGroupCacheKey]types.EpochGroupData)
+	c.currentEpochRequestCount.Store(0)
+	c.currentDirty = false
+}
+
+// ensureEpochGroupCacheInited lazily inits the block cache (current/previous epoch indices). Caller must hold no cache lock.
+func (k Keeper) ensureEpochGroupCacheInited(ctx context.Context) {
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inited {
+		return
+	}
+	eff, ok := k.GetEffectiveEpochIndex(ctx)
+	if !ok {
+		return
+	}
+	c.current = eff
+	if eff > 0 {
+		c.previous = eff - 1
+	} else {
+		c.previous = 0
+	}
+	c.m = make(map[epochGroupCacheKey]types.EpochGroupData)
+	c.inited = true
+}
+
+// FlushCurrentEpochGroupCache persists cached EpochGroupData for the current epoch to the store. Call from EndBlock.
+// Merges currentEpochRequestCount into the current epoch root group's NumberOfRequests before persisting.
+func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.inited {
+		return
+	}
+	delta := c.currentEpochRequestCount.Swap(0)
+	rootKey := epochGroupCacheKey{Epoch: c.current, ModelId: ""}
+	if val, inCache := c.m[rootKey]; inCache {
+		val.NumberOfRequests += delta
+		_ = k.EpochGroupDataMap.Set(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId), val)
+	} else if delta != 0 {
+		val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId))
+		if err == nil {
+			val.NumberOfRequests += delta
+			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId), val)
+		}
+	}
+	for key, val := range c.m {
+		if key.Epoch == c.current && key != rootKey {
+			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(key.Epoch, key.ModelId), val)
+		}
+	}
+	c.currentDirty = false
+}
+
+// IncrementCurrentEpochGroupRequestCount increments the per-block atomic counter for the current epoch's NumberOfRequests. Committed to store in EndBlock.
+func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) {
+	c := k.epochGroupCache
+	k.ensureEpochGroupCacheInited(ctx)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.inited {
+		return
+	}
+	c.currentEpochRequestCount.Add(1)
+	c.currentDirty = true
+}
+
+// SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).
+func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
+	epochIdx := epochGroupData.EpochIndex
+	modelId := epochGroupData.ModelId
+	key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
+	draft := getEpochGroupDraftFromContext(ctx)
+
+	if draft != nil {
+		k.ensureEpochGroupCacheInited(ctx)
+		c := k.epochGroupCache
+		c.mu.RLock()
+		inited, current, previous := c.inited, c.current, c.previous
+		c.mu.RUnlock()
+		if inited && (epochIdx == current || epochIdx == previous) {
+			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
+			draft.lockWrite() // reentrant: same goroutine can write multiple times
+			draft.m[key] = *cloned
+			// Do not unlock here; lock is released in PostHandler (commit or failure)
+			return
+		}
+		// Non-current/previous: write through to store
+		k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
+		return
+	}
+
+	// No draft: update block cache or write through to store
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.inited || (epochIdx != c.current && epochIdx != c.previous) {
+		k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
+		return
+	}
+	cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
+	c.m[key] = *cloned
+	c.currentDirty = true
+}
+
+// GetEpochGroupData returns EpochGroupData by epoch and model. Uses tx draft first (if present), then block cache for current/previous epoch, then store.
 func (k Keeper) GetEpochGroupData(
 	ctx context.Context,
 	epochIndex uint64,
 	modelId string,
 ) (val types.EpochGroupData, found bool) {
-	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
+	k.ensureEpochGroupCacheInited(ctx)
+	c := k.epochGroupCache
+	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
 
+	draft := getEpochGroupDraftFromContext(ctx)
+	if draft != nil {
+		c.mu.RLock()
+		inited, current, previous := c.inited, c.current, c.previous
+		c.mu.RUnlock()
+		if inited && (epochIndex == current || epochIndex == previous) {
+			var cached types.EpochGroupData
+			var ok bool
+			if draft.isWriteLocked() && atomic.LoadInt64(&draft.writeHolder) == getGID() {
+				cached, ok = draft.m[key]
+			} else {
+				draft.mu.RLock()
+				cached, ok = draft.m[key]
+				draft.mu.RUnlock()
+			}
+			if ok {
+				cloned := proto.Clone(&cached).(*types.EpochGroupData)
+				return *cloned, true
+			}
+		}
+	}
+
+	c.mu.RLock()
+	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
+		if cached, ok := c.m[key]; ok {
+			c.mu.RUnlock()
+			cloned := proto.Clone(&cached).(*types.EpochGroupData)
+			return *cloned, true
+		}
+	}
+	c.mu.RUnlock()
+
+	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
 	if err != nil {
 		return val, false
 	}
+	c.mu.Lock()
+	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
+		cloned := proto.Clone(&val).(*types.EpochGroupData)
+		c.m[key] = *cloned
+	}
+	c.mu.Unlock()
 	return val, true
 }
 
-// RemoveEpochGroupData removes a epochGroupData from the store
+// RemoveEpochGroupData removes EpochGroupData from store and from block cache / tx draft when applicable.
 func (k Keeper) RemoveEpochGroupData(
 	ctx context.Context,
 	epochIndex uint64,
 	modelId string,
 ) {
 	k.EpochGroupDataMap.Remove(ctx, collections.Join(epochIndex, modelId))
+	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
+	if draft := getEpochGroupDraftFromContext(ctx); draft != nil {
+		draft.lockWrite()
+		delete(draft.m, key)
+		// Do not unlock here; released in PostHandler
+	}
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
+		delete(c.m, key)
+	}
 }
 
-// GetAllEpochGroupData returns all epochGroupData
+// GetAllEpochGroupData returns all EpochGroupData from the store.
 func (k Keeper) GetAllEpochGroupData(ctx context.Context) (list []types.EpochGroupData) {
 	iter, err := k.EpochGroupDataMap.Iterate(ctx, nil)
 	if err != nil {

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -56,6 +56,9 @@ func (c *epochGroupCache) lockDraftWrite() {
 	atomic.StoreInt32(&c.draftWriteCount, 1)
 }
 
+// It is never called as we are releasing the draft write lock when transaction completes
+// and we do not decrement the draft write count
+// It could be used if we want to unlock the reentrant write lock before the transaction completes
 func (c *epochGroupCache) unlockDraftWrite() {
 	if !cosmosOptimisticCachesEnabled {
 		return
@@ -68,8 +71,13 @@ func (c *epochGroupCache) unlockDraftWrite() {
 
 // releaseDraftWriteLock fully releases the draft write lock (for PostHandler). Call on tx commit or failure.
 func (c *epochGroupCache) releaseDraftWriteLock() {
-	for atomic.LoadInt32(&c.draftWriteCount) > 0 {
-		c.unlockDraftWrite()
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
+	if atomic.LoadInt32(&c.draftWriteCount) > 0 {
+		atomic.StoreInt64(&c.draftWriteHolder, 0)
+		atomic.StoreInt32(&c.draftWriteCount, 0)
+		c.draftWriterMu.Unlock()
 	}
 }
 

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -248,7 +248,7 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 		return
 	}
 	delta := c.currentEpochRequestCount.Swap(0)
-	if !c.currentDirty && delta == 0 {
+	if !c.currentDirty {
 		return
 	}
 
@@ -275,16 +275,17 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 }
 
 // IncrementCurrentEpochGroupRequestCount increments the per-block atomic counter for the current epoch's NumberOfRequests. Committed to store in EndBlock.
-func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) {
+func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) int64 {
 	c := k.epochGroupCache
 	k.ensureEpochGroupCacheInited(ctx)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.inited {
-		return
+		return 0
 	}
-	c.currentEpochRequestCount.Add(1)
+	count := c.currentEpochRequestCount.Add(1)
 	c.currentDirty = true
+	return count
 }
 
 // SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"bytes"
 	"context"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -12,6 +13,13 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/productscience/inference/x/inference/types"
 )
+
+// cosmosOptimisticCachesEnabled is set once at package init from COSMOS_OPTIMISTIC_CACHES=1.
+var cosmosOptimisticCachesEnabled bool
+
+func init() {
+	cosmosOptimisticCachesEnabled = os.Getenv("COSMOS_OPTIMISTIC_CACHES") == "1"
+}
 
 // getGID returns the current goroutine id (for reentrant lock holder identity). Uses runtime.Stack; for use in reentrant locking only.
 func getGID() int64 {
@@ -62,7 +70,11 @@ type epochGroupDraft struct {
 }
 
 // lockWrite acquires the write lock; reentrant for the same goroutine (increments count). Release via unlockWrite or releaseWriteLock.
+// Only takes the lock when COSMOS_OPTIMISTIC_CACHES=1; otherwise no-op.
 func (d *epochGroupDraft) lockWrite() {
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
 	gid := getGID()
 	if atomic.LoadInt64(&d.writeHolder) == gid {
 		atomic.AddInt32(&d.writeCount, 1)
@@ -74,7 +86,11 @@ func (d *epochGroupDraft) lockWrite() {
 }
 
 // unlockWrite releases one level of the write lock; if count goes to 0, releases the underlying RWMutex.
+// No-op when COSMOS_OPTIMISTIC_CACHES is not 1.
 func (d *epochGroupDraft) unlockWrite() {
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
 	if atomic.AddInt32(&d.writeCount, -1) == 0 {
 		atomic.StoreInt64(&d.writeHolder, 0)
 		d.mu.Unlock()

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -34,6 +34,24 @@ func getGID() int64 {
 // ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
 type ctxKeyEpochGroupDraft struct{}
 
+// lazyEpochGroupDraft defers allocation of the real draft until the first write (Set/Remove).
+// This avoids allocating a map for every tx when most txs only read epoch group data.
+type lazyEpochGroupDraft struct {
+	once sync.Once
+	d    *epochGroupDraft
+}
+
+func (l *lazyEpochGroupDraft) get() *epochGroupDraft {
+	return l.d
+}
+
+func (l *lazyEpochGroupDraft) getOrCreate() *epochGroupDraft {
+	l.once.Do(func() {
+		l.d = &epochGroupDraft{m: make(map[epochGroupCacheKey]types.EpochGroupData)}
+	})
+	return l.d
+}
+
 // epochGroupDraft holds tx-scoped EpochGroupData writes for optimistic parallel execution.
 // Uses a reentrant write lock: the same goroutine can write (or delete) multiple times; lock is released only in PostHandler (commit or failure).
 type epochGroupDraft struct {
@@ -75,13 +93,14 @@ func (d *epochGroupDraft) releaseWriteLock() {
 	}
 }
 
-// WithEpochGroupDraft attaches a new tx-scoped draft to ctx. Call at tx start (e.g. from AnteHandler).
+// WithEpochGroupDraft attaches a lazy tx-scoped draft holder to ctx. Call at tx start (e.g. from AnteHandler).
+// The real draft (and its map) is created only on first SetEpochGroupData or RemoveEpochGroupData for current/previous epoch;
+// read-only txs never allocate it and always use the per-block cache (or store).
 func WithEpochGroupDraft(ctx context.Context) context.Context {
-	d := &epochGroupDraft{m: make(map[epochGroupCacheKey]types.EpochGroupData)}
-	return context.WithValue(ctx, ctxKeyEpochGroupDraft{}, d)
+	return context.WithValue(ctx, ctxKeyEpochGroupDraft{}, &lazyEpochGroupDraft{})
 }
 
-// getEpochGroupDraftFromContext returns the draft from ctx, or nil if no draft is bound.
+// getEpochGroupDraftFromContext returns the draft from ctx if it exists, or nil. Does not create the draft (for reads and for Commit/Release).
 func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
 	if ctx == nil {
 		return nil
@@ -90,8 +109,33 @@ func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
 	if v == nil {
 		return nil
 	}
-	d, _ := v.(*epochGroupDraft)
-	return d
+	switch h := v.(type) {
+	case *lazyEpochGroupDraft:
+		return h.get()
+	case *epochGroupDraft:
+		return h
+	default:
+		return nil
+	}
+}
+
+// getEpochGroupDraftForWriteFromContext returns the draft, creating it from the lazy holder on first write. Use in SetEpochGroupData and RemoveEpochGroupData.
+func getEpochGroupDraftForWriteFromContext(ctx context.Context) *epochGroupDraft {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(ctxKeyEpochGroupDraft{})
+	if v == nil {
+		return nil
+	}
+	switch h := v.(type) {
+	case *lazyEpochGroupDraft:
+		return h.getOrCreate()
+	case *epochGroupDraft:
+		return h
+	default:
+		return nil
+	}
 }
 
 // CommitEpochGroupDraftFromContext merges the draft from ctx into the block cache. Call from PostHandler on tx success.
@@ -228,11 +272,12 @@ func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) {
 }
 
 // SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).
+// Draft is created lazily on first write so read-only txs do not allocate it.
 func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
 	epochIdx := epochGroupData.EpochIndex
 	modelId := epochGroupData.ModelId
 	key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
-	draft := getEpochGroupDraftFromContext(ctx)
+	draft := getEpochGroupDraftForWriteFromContext(ctx)
 
 	if draft != nil {
 		k.ensureEpochGroupCacheInited(ctx)
@@ -321,6 +366,7 @@ func (k Keeper) GetEpochGroupData(
 }
 
 // RemoveEpochGroupData removes EpochGroupData from store and from block cache / tx draft when applicable.
+// Draft is created only when removing a current/previous-epoch key (same lazy rule as SetEpochGroupData).
 func (k Keeper) RemoveEpochGroupData(
 	ctx context.Context,
 	epochIndex uint64,
@@ -328,12 +374,18 @@ func (k Keeper) RemoveEpochGroupData(
 ) {
 	k.EpochGroupDataMap.Remove(ctx, collections.Join(epochIndex, modelId))
 	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
-	if draft := getEpochGroupDraftFromContext(ctx); draft != nil {
-		draft.lockWrite()
-		delete(draft.m, key)
-		// Do not unlock here; released in PostHandler
-	}
+	k.ensureEpochGroupCacheInited(ctx)
 	c := k.epochGroupCache
+	c.mu.RLock()
+	needDraft := c.inited && (epochIndex == c.current || epochIndex == c.previous)
+	c.mu.RUnlock()
+	if needDraft {
+		if draft := getEpochGroupDraftForWriteFromContext(ctx); draft != nil {
+			draft.lockWrite()
+			delete(draft.m, key)
+			// Do not unlock here; released in PostHandler
+		}
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -469,16 +469,13 @@ func (k Keeper) GetEpochGroupData(
 	}
 
 	c.draftWriterMu.RLock()
-	c.mu.RLock()
 	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
 		if cached, ok := c.m[key]; ok {
-			c.mu.RUnlock()
 			c.draftWriterMu.RUnlock()
 			cloned := proto.Clone(&cached).(*types.EpochGroupData)
 			return *cloned, true
 		}
 	}
-	c.mu.RUnlock()
 	c.draftWriterMu.RUnlock()
 
 	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))

--- a/inference-chain/x/inference/keeper/epoch_group_data_cache_branch_test.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data_cache_branch_test.go
@@ -1,0 +1,175 @@
+package keeper_test
+
+import (
+	"testing"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ensure keeper package is used (k from InferenceKeeper is keeper.Keeper)
+var _ func(keeper.Keeper) = func(keeper.Keeper) {}
+
+const cacheBranchTestEpoch = 10
+
+// TestCacheContextWithEpochGroupBranch_WriteThenMerge verifies that writes on the branch
+// are merged into the parent draft when writeCache() is called, and become visible after
+// CommitEpochGroupDraftFromContext (and thus to subsequent reads).
+func TestCacheContextWithEpochGroupBranch_WriteThenMerge(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+
+	// Seed initial data (no draft; goes to store/block cache)
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 1)
+
+	// Simulate AnteHandler: tx context with main draft
+	txCtx := txCtxWithDraft(sdkCtx)
+
+	// Create branch, write only on branch, then merge
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	branchData := types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    999,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	}
+	k.SetEpochGroupData(cacheCtx, branchData)
+	writeCache()
+
+	// Parent draft should now contain the branch write; commit it to block cache
+	k.CommitEpochGroupDraftFromContext(txCtx)
+
+	// Reads on base context should see the merged value (from block cache)
+	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(999), val.NumberOfRequests)
+}
+
+// TestCacheContextWithEpochGroupBranch_NoWriteCache_Discarded verifies that when
+// writeCache() is not called, branch draft writes are discarded and the parent
+// (and store) remain unchanged.
+func TestCacheContextWithEpochGroupBranch_NoWriteCache_Discarded(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 100)
+
+	txCtx := txCtxWithDraft(sdkCtx)
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	_ = writeCache // intentionally not called
+
+	// Write only on branch
+	branchData := types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    999,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	}
+	k.SetEpochGroupData(cacheCtx, branchData)
+
+	// Commit parent draft (empty; we never merged branch)
+	k.CommitEpochGroupDraftFromContext(txCtx)
+
+	// Should still see original value, not branch value
+	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(100), val.NumberOfRequests)
+}
+
+// TestCacheContextWithEpochGroupBranch_WriteCacheIdempotent verifies that calling
+// writeCache() multiple times does not panic and does not double-merge (idempotent).
+func TestCacheContextWithEpochGroupBranch_WriteCacheIdempotent(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 0)
+
+	txCtx := txCtxWithDraft(sdkCtx)
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    42,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	writeCache()
+	writeCache() // second call must be safe
+	writeCache()
+
+	k.CommitEpochGroupDraftFromContext(txCtx)
+	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(42), val.NumberOfRequests)
+}
+
+// TestCacheContextWithEpochGroupBranch_GetSeesBranchDraft verifies that GetEpochGroupData
+// on the branch context sees data written with SetEpochGroupData on that same branch.
+func TestCacheContextWithEpochGroupBranch_GetSeesBranchDraft(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 1)
+
+	txCtx := txCtxWithDraft(sdkCtx)
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+
+	// Set on branch
+	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    777,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	// Get on branch must see branch draft value before writeCache
+	val, found := k.GetEpochGroupData(cacheCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(777), val.NumberOfRequests)
+
+	// Parent (txCtx) should not see it until writeCache
+	valParent, foundParent := k.GetEpochGroupData(txCtx, cacheBranchTestEpoch, "")
+	require.True(t, foundParent)
+	require.Equal(t, int64(1), valParent.NumberOfRequests, "parent should still see seeded value before merge")
+
+	writeCache()
+	valParent2, foundParent2 := k.GetEpochGroupData(txCtx, cacheBranchTestEpoch, "")
+	require.True(t, foundParent2)
+	require.Equal(t, int64(777), valParent2.NumberOfRequests, "parent should see merged value after writeCache")
+}
+
+// TestCacheContextWithEpochGroupBranch_ParentAndBranchWrites verifies that when both
+// parent and branch write, merge combines them (branch writes merge into parent draft).
+func TestCacheContextWithEpochGroupBranch_ParentAndBranchWrites(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 0)
+
+	txCtx := txCtxWithDraft(sdkCtx)
+	// Parent writes root group
+	k.SetEpochGroupData(txCtx, types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    100,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	// Branch overwrites same key
+	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    200,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+	writeCache()
+
+	k.CommitEpochGroupDraftFromContext(txCtx)
+	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(200), val.NumberOfRequests, "branch write should override parent in same key")
+}
+
+// txCtxWithDraft and seedEpochGroupData are in epoch_group_data_concurrent_test.go;
+// we reuse them. If this file is run in isolation, ensure same package and helpers.
+// Both are in keeper_test so they are available.

--- a/inference-chain/x/inference/keeper/epoch_group_data_concurrent_test.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data_concurrent_test.go
@@ -1,0 +1,213 @@
+package keeper_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = strconv.IntSize
+
+const (
+	concurrentTestEpoch   = 5
+	concurrentNumReaders = 20
+	concurrentNumWriters = 5
+)
+
+// txCtxWithDraft returns an sdk.Context that has a tx-scoped draft attached (simulating AnteHandler).
+func txCtxWithDraft(sdkCtx sdk.Context) sdk.Context {
+	stdCtx := sdkCtx.Context()
+	if stdCtx == nil {
+		stdCtx = context.Background()
+	}
+	return sdkCtx.WithContext(keeper.WithEpochGroupDraft(stdCtx))
+}
+
+// seedEpochGroupData writes one root group for the test epoch into the store (no draft).
+func seedEpochGroupData(k keeper.Keeper, ctx sdk.Context, epoch uint64, numberOfRequests int64) {
+	data := types.EpochGroupData{
+		EpochIndex:          epoch,
+		ModelId:             "",
+		NumberOfRequests:    numberOfRequests,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	}
+	k.SetEpochGroupData(ctx, data)
+}
+
+// TestConcurrentReadsSameResult runs many read-only "transactions" in parallel.
+// All use the same epoch key; no draft. They must all see the same value and run without blocking each other.
+func TestConcurrentReadsSameResult(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, concurrentTestEpoch)
+	seedEpochGroupData(k, sdkCtx, concurrentTestEpoch, 100)
+
+	var wg sync.WaitGroup
+	results := make([]types.EpochGroupData, concurrentNumReaders)
+	for i := 0; i < concurrentNumReaders; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			val, found := k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+			require.True(t, found)
+			results[idx] = val
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < concurrentNumReaders; i++ {
+		require.Equal(t, int64(100), results[i].NumberOfRequests, "reader %d", i)
+		require.Equal(t, uint64(concurrentTestEpoch), results[i].EpochIndex)
+	}
+}
+
+// TestOneWriterManyReaders_ReadersSeeWriteAfterCommit: one writer tx (Set + Commit), then many readers.
+// Readers that run after the writer must see the written value (block cache updated by Commit).
+func TestOneWriterManyReaders_ReadersSeeWriteAfterCommit(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, concurrentTestEpoch)
+	seedEpochGroupData(k, sdkCtx, concurrentTestEpoch, 1)
+
+	writerDone := make(chan struct{})
+	go func() {
+		txCtx := txCtxWithDraft(sdkCtx)
+		data := types.EpochGroupData{
+			EpochIndex:          concurrentTestEpoch,
+			ModelId:             "",
+			NumberOfRequests:    999,
+			MemberSeedSignatures: []*types.SeedSignature{},
+		}
+		k.SetEpochGroupData(txCtx, data)
+		k.CommitEpochGroupDraftFromContext(txCtx)
+		close(writerDone)
+	}()
+
+	<-writerDone
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentNumReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			val, found := k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+			require.True(t, found)
+			require.Equal(t, int64(999), val.NumberOfRequests)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestOneWriterMultipleSetGet_NoDeadlock: one writer performs multiple Set/Get in one "tx" (reentrant draft lock),
+// while many readers run in parallel. Must not deadlock (run with -race and timeout).
+func TestOneWriterMultipleSetGet_NoDeadlock(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, concurrentTestEpoch)
+	seedEpochGroupData(k, sdkCtx, concurrentTestEpoch, 0)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		txCtx := txCtxWithDraft(sdkCtx)
+		for i := 0; i < 10; i++ {
+			data := types.EpochGroupData{
+				EpochIndex:          concurrentTestEpoch,
+				ModelId:             "",
+				NumberOfRequests:    int64(i),
+				MemberSeedSignatures: []*types.SeedSignature{},
+			}
+			k.SetEpochGroupData(txCtx, data)
+			_, _ = k.GetEpochGroupData(txCtx, concurrentTestEpoch, "")
+		}
+		k.CommitEpochGroupDraftFromContext(txCtx)
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentNumReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 5; j++ {
+				_, _ = k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+			}
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-done:
+		// writer finished
+	case <-time.After(5 * time.Second):
+		t.Fatal("writer or readers deadlocked (timeout)")
+	}
+}
+
+// TestMultipleWritersMultipleReaders: several writers commit in sequence (each takes block cache lock on Commit),
+// many readers run in parallel. After all writers finish, the last written value must be visible to readers.
+func TestMultipleWritersMultipleReaders_LastWriteWins(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, concurrentTestEpoch)
+	seedEpochGroupData(k, sdkCtx, concurrentTestEpoch, 0)
+
+	// Writers commit one after another so "last" is well-defined
+	var writerOrder sync.Mutex
+	var lastCommittedValue int64
+
+	var wgWriters sync.WaitGroup
+	for w := 0; w < concurrentNumWriters; w++ {
+		val := int64(w + 1)
+		wgWriters.Add(1)
+		go func() {
+			defer wgWriters.Done()
+			txCtx := txCtxWithDraft(sdkCtx)
+			data := types.EpochGroupData{
+				EpochIndex:          concurrentTestEpoch,
+				ModelId:             "",
+				NumberOfRequests:    val,
+				MemberSeedSignatures: []*types.SeedSignature{},
+			}
+			k.SetEpochGroupData(txCtx, data)
+			writerOrder.Lock()
+			k.CommitEpochGroupDraftFromContext(txCtx)
+			lastCommittedValue = val
+			writerOrder.Unlock()
+		}()
+	}
+
+	var wgReaders sync.WaitGroup
+	readerResults := make([]int64, concurrentNumReaders)
+	for i := 0; i < concurrentNumReaders; i++ {
+		wgReaders.Add(1)
+		go func(idx int) {
+			defer wgReaders.Done()
+			// Readers run while writers are still committing
+			v, found := k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+			if found {
+				readerResults[idx] = v.NumberOfRequests
+			}
+		}(i)
+	}
+
+	wgWriters.Wait()
+	wgReaders.Wait()
+
+	// Final read must see the last committed value (last writer to hold the lock)
+	finalVal, found := k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, lastCommittedValue, finalVal.NumberOfRequests,
+		"final read should see last committed value %d", lastCommittedValue)
+
+	// Every reader must have seen a value in [1, concurrentNumWriters] (some snapshot)
+	for i := 0; i < concurrentNumReaders; i++ {
+		if readerResults[i] != 0 {
+			require.GreaterOrEqual(t, readerResults[i], int64(1))
+			require.LessOrEqual(t, readerResults[i], int64(concurrentNumWriters))
+		}
+	}
+}

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -23,13 +23,17 @@ type epochGroupCacheKey struct {
 // epochGroupCache holds EpochGroupData for current and previous effective epoch only.
 // Invalidated in BeginBlock; flushed to store in EndBlock.
 // currentEpochRequestCount is the per-block atomic counter for NumberOfRequests of the current epoch (root group); merged to store on flush.
+// draftWriterMu is held (write) while any tx is writing to its draft so that no one reads from the block cache until commit/release (deterministic, sequential).
 type epochGroupCache struct {
-	mu                      sync.RWMutex
-	inited                  bool
-	current                 uint64
-	previous                uint64
-	currentDirty            bool
-	m                       map[epochGroupCacheKey]types.EpochGroupData
+	mu                       sync.RWMutex
+	draftWriterMu            sync.RWMutex // held by draft writers; block cache readers take RLock so they wait for no draft writer
+	draftWriteHolder         int64        // goroutine id of current draft writer (reentrancy)
+	draftWriteCount          int32        // reentrant lock count
+	inited                   bool
+	current                  uint64
+	previous                 uint64
+	currentDirty             bool
+	m                        map[epochGroupCacheKey]types.EpochGroupData
 	currentEpochRequestCount atomic.Int64
 }
 

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/store"
@@ -11,6 +13,25 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
 )
+
+// epochGroupCacheKey keys the hot cache by (epochIndex, modelId).
+type epochGroupCacheKey struct {
+	Epoch   uint64
+	ModelId string
+}
+
+// epochGroupCache holds EpochGroupData for current and previous effective epoch only.
+// Invalidated in BeginBlock; flushed to store in EndBlock.
+// currentEpochRequestCount is the per-block atomic counter for NumberOfRequests of the current epoch (root group); merged to store on flush.
+type epochGroupCache struct {
+	mu                      sync.RWMutex
+	inited                  bool
+	current                 uint64
+	previous                uint64
+	currentDirty            bool
+	m                       map[epochGroupCacheKey]types.EpochGroupData
+	currentEpochRequestCount atomic.Int64
+}
 
 type (
 	Keeper struct {
@@ -53,6 +74,8 @@ type (
 		InferenceValidationDetailsMap collections.Map[collections.Pair[uint64, string], types.InferenceValidationDetails]
 		UnitOfComputePriceProposals   collections.Map[string, types.UnitOfComputePriceProposal]
 		EpochGroupDataMap             collections.Map[collections.Pair[uint64, string], types.EpochGroupData]
+		// EpochGroupData hot cache: current and previous effective epoch; tx draft merged on tx success, flushed to store in EndBlock.
+		epochGroupCache *epochGroupCache
 		// Epoch collections
 		Epochs                    collections.Map[uint64, types.Epoch]
 		EffectiveEpochIndex       collections.Item[uint64]
@@ -242,6 +265,7 @@ func NewKeeper(
 			collections.PairKeyCodec(collections.Uint64Key, collections.StringKey),
 			codec.CollValue[types.EpochGroupData](cdc),
 		),
+		epochGroupCache: &epochGroupCache{},
 		// Epoch collections wiring
 		Epochs: collections.NewMap(
 			sb,

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -274,6 +274,9 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 	// and can cause undeterministic results.
 	// Moreover we prefer performance and determenism over precision here,
 	// so we just use value from previous committed block.
+
+	//We can use here exact number: currentEpochGroup.GroupData.NumberOfRequests+epochRequestsCount
+	//But it can be undetermenistic in cosmos optimistic concurrent environment
 	inferenceDetails := types.InferenceValidationDetails{
 		InferenceId:          existingInference.InferenceId,
 		ExecutorId:           existingInference.ExecutedBy,

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -251,7 +251,6 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 
 	existingInference.EpochPocStartBlockHeight = uint64(effectiveEpoch.PocStartBlockHeight)
 	existingInference.EpochId = effectiveEpoch.Index
-	k.IncrementCurrentEpochGroupRequestCount(ctx)
 
 	executorPower := uint64(0)
 	executorReputation := int32(0)
@@ -314,5 +313,9 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 	if err != nil {
 		return err
 	}
+
+	// Increment current epoch group request count after all possible errors are returned that can cause rollback.
+	// This ensures that the number of requests is always accurate and consistent.
+	k.IncrementCurrentEpochGroupRequestCount(ctx)
 	return nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -270,8 +270,8 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 
 	// For TrafficBasis
 	// we don't use here precise (already incremented) number of requests because it's not yet committed to the store,
-	// and can cause undeterministic results.
-	// Moreover we prefer performance and determenism over precision here,
+	// and can cause non-deterministic results.
+	// Moreover we prefer performance and determinism over precision here,
 	// so we just use value from previous committed block.
 
 	//We can use here exact number: currentEpochGroup.GroupData.NumberOfRequests+epochRequestsCount

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -251,7 +251,7 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 
 	existingInference.EpochPocStartBlockHeight = uint64(effectiveEpoch.PocStartBlockHeight)
 	existingInference.EpochId = effectiveEpoch.Index
-	currentEpochGroup.GroupData.NumberOfRequests++
+	k.IncrementCurrentEpochGroupRequestCount(ctx)
 
 	executorPower := uint64(0)
 	executorReputation := int32(0)
@@ -269,6 +269,11 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 		return err
 	}
 
+	// For TrafficBasis
+	// we don't use here precise (already incremented) number of requests because it's not yet committed to the store,
+	// and can cause undeterministic results.
+	// Moreover we prefer performance and determenism over precision here,
+	// so we just use value from previous committed block.
 	inferenceDetails := types.InferenceValidationDetails{
 		InferenceId:          existingInference.InferenceId,
 		ExecutorId:           existingInference.ExecutedBy,
@@ -306,6 +311,5 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 	if err != nil {
 		return err
 	}
-	k.SetEpochGroupData(ctx, *currentEpochGroup.GroupData)
 	return nil
 }

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -316,7 +316,7 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	blockTime := sdkCtx.BlockTime().Unix()
 
 	// Persist epoch group block cache to store (tx drafts were merged to cache in PostHandler)
-	am.keeper.FlushCurrentEpochGroupCache(ctx)
+	defer am.keeper.FlushCurrentEpochGroupCache(ctx)
 	// Handle confirmation PoC trigger decisions and phase transitions
 	err := am.handleConfirmationPoC(ctx, blockHeight)
 	if err != nil {

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -174,6 +174,8 @@ func (AppModule) ConsensusVersion() uint64 { return 12 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 func (am AppModule) BeginBlock(ctx context.Context) error {
+	// Invalidate epoch group block cache so it is re-inited from store for this block
+	am.keeper.InvalidateEpochGroupCache()
 	// Update dynamic pricing for all models at the start of each block
 	// This ensures consistent pricing for all inferences processed in this block
 	err := am.keeper.UpdateDynamicPricing(ctx)
@@ -313,6 +315,8 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	blockHeight := sdkCtx.BlockHeight()
 	blockTime := sdkCtx.BlockTime().Unix()
 
+	// Persist epoch group block cache to store (tx drafts were merged to cache in PostHandler)
+	am.keeper.FlushCurrentEpochGroupCache(ctx)
 	// Handle confirmation PoC trigger decisions and phase transitions
 	err := am.handleConfirmationPoC(ctx, blockHeight)
 	if err != nil {


### PR DESCRIPTION
[Issue 782](https://github.com/gonka-ai/gonka/issues/782)

Add inference keeper caches: epoch group block cache (current/previous epoch) with tx draft and single atomic current-epoch request counter; invalidate in BeginBlock, flush in EndBlock.

**Motivation:**
It is more generic approach as we should read EpochGroupData in a lot of places. For example we should read it on every epoch participant operation since we need to check it is initiated by participant. Currently we don't do it, but this is a bunch of vulnerabilities: anyone can send StartInferenceMsg (from any developer account), anyone can validate or invalidate anything and so on. This vulnerabilities will be closed in a next PRs. Ability to anyone send StartInferenceMsg is a huge risk, as any participant could be slashed by this attack (it is not possible while we have TA white list, but it will be removed and vulnerability will be reopened)

So I've implemented more generic approach using caches for EpochGroupData, that solves problem to read/write once per block.
For NumberOfRequests I use atomic integer to increment it during the block in parallel and commit on endBlocker

**Lifecycle:** during transaction we have EpochGroupData draft cache, we read it always once, it will be committed to per-block cache if we made a write operations when we successfully commit transaction. We also have per-block cache (cleared on block start and committed to store on endBlocker)

**Preparation for cosmos optimistic mode:**
**Disabled by default can be enabled by environment variable flag** `COSMOS_OPTIMISTIC_CACHES=1`

`lockWrite` and `unlockWrite` are dummy when flag is not enabled, so there is no locking, and `isWriteLocked` also is always false.

In CosmosSDK it is possible to have optimistic mode for parallel transactions execution, it is important to speedup on multi-CPU cores. Optimistic transactions run in parallel and if there was multiple tx that write to same store key, only one tx will success and other will be reverted and retryed. It means that store should be optimized to do not have too shared keys, like NumberOfRequests in EpochGroupData, that is touched by every inference.

I've implemented for EpochGroupData reentrant read/write locking: if any routine writes to it, write lock will be aquired and released on transaction end (commit or revert), so it is not possible to write from different threads to EpochGroupData even when optimistic mode is enabled.

**Important! Status**:
Checked on real blocks that caches generate exactly same data.

Point to discuss is use of `InferenceValidationDetails.TrafficBasis:         uint64(math.Max(currentEpochGroup.GroupData.NumberOfRequests, currentEpochGroup.GroupData.PreviousEpochRequests))`

Previous version used incremented NumberOfRequests here, but actually I think that it is not so important for traffic basis to get very precise data here and we can use the value that is fixed on the beginning of the block. `NumberOfRequests` will be updated by incrementing total number of requests during the block.