### PR TITLE
Ak issue783 0.2.11

### DIFF
--- a/decentralized-api/go.mod
+++ b/decentralized-api/go.mod
@@ -82,8 +82,9 @@ require (
 	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.22.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/bytedance/sonic v1.14.0 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/decentralized-api/go.sum
+++ b/decentralized-api/go.sum
@@ -313,10 +313,12 @@ github.com/btcsuite/btcd/btcutil v1.1.6 h1:zFL2+c3Lb9gEgqKNzowKUPQNb8jV7v5Oaodi/
 github.com/btcsuite/btcd/btcutil v1.1.6/go.mod h1:9dFymx8HpuLqBnsPELrImQeTQfKBQqzqGbbV3jK55aE=
 github.com/bufbuild/protocompile v0.14.2-0.20251120233202-3f9009bcd6c8 h1:l4PKzJ7Usff8j5/e+YaWZPaM+rJHIghgDxRn8vDNxNo=
 github.com/bufbuild/protocompile v0.14.2-0.20251120233202-3f9009bcd6c8/go.mod h1:HKN246DRQwavs64sr2xYmSL+RFOFxmLti+WGCZ2jh9U=
-github.com/bytedance/sonic v1.14.0 h1:/OfKt8HFw0kh2rj8N0F6C/qPGRESq0BbaNZgcNXXzQQ=
-github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxlNUO24NhA=
-github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
-github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
+github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
@@ -1156,6 +1158,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=

--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -38,6 +38,41 @@ type HandlerOptions struct {
 	InferenceKeeper       *inferencemodulekeeper.Keeper
 }
 
+// ParamsDraftDecorator attaches a tx-scoped params draft to context so GetParams/SetParams use it when INFERENCE_PARAMS_CACHE_MODE=tx.
+// CommitParamsDraftFromContext is called from the PostHandler on tx success.
+type ParamsDraftDecorator struct {
+	InferenceKeeper *inferencemodulekeeper.Keeper
+}
+
+// AnteHandle injects WithParamsDraft into the context for the rest of the tx when mode is "tx"; skipped in "block" mode for performance.
+func (d ParamsDraftDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if d.InferenceKeeper == nil || d.InferenceKeeper.GetParamsCacheMode() != inferencemodulekeeper.ParamsCacheModeTx {
+		return next(ctx, tx, simulate)
+	}
+	newCtx := ctx.WithContext(inferencemodulekeeper.WithParamsDraft(ctx.Context()))
+	return next(newCtx, tx, simulate)
+}
+
+// ParamsDraftCommitPostDecorator commits the tx-scoped params draft to store when the tx succeeded.
+// Only runs when success is true. Use with INFERENCE_PARAMS_CACHE_MODE=tx.
+type ParamsDraftCommitPostDecorator struct {
+	InferenceKeeper *inferencemodulekeeper.Keeper
+}
+
+// PostHandle runs the rest of the post chain, then on success commits the params draft to store (tx mode only).
+func (d ParamsDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
+	newCtx, err := next(ctx, tx, simulate, success)
+	if err != nil {
+		return newCtx, err
+	}
+	if success && d.InferenceKeeper != nil && d.InferenceKeeper.GetParamsCacheMode() == inferencemodulekeeper.ParamsCacheModeTx {
+		if commitErr := d.InferenceKeeper.CommitParamsDraftFromContext(newCtx); commitErr != nil {
+			return newCtx, commitErr
+		}
+	}
+	return newCtx, nil
+}
+
 // Gas is still charged against the tx's gas limit; this only bypasses fee checks.
 type LiquidityPoolFeeBypassDecorator struct {
 	// Dynamic sources from chain state
@@ -192,6 +227,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		ParamsDraftDecorator{InferenceKeeper: options.InferenceKeeper}, // tx-scoped params draft for GetParams/SetParams when INFERENCE_PARAMS_CACHE_MODE=tx
 		wasmkeeper.NewLimitSimulationGasDecorator(options.NodeConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		wasmkeeper.NewGasRegisterDecorator(options.WasmKeeper.GetGasRegister()),
@@ -251,4 +287,9 @@ func (app *App) setAnteHandler(txConfig client.TxConfig, nodeConfig wasmtypes.No
 
 	// Set the AnteHandler for the app
 	app.SetAnteHandler(anteHandler)
+
+	// Commit tx-scoped params draft to store on tx success; only register when INFERENCE_PARAMS_CACHE_MODE=tx
+	if app.InferenceKeeper.GetParamsCacheMode() == inferencemodulekeeper.ParamsCacheModeTx {
+		app.SetPostHandler(sdk.ChainPostDecorators(ParamsDraftCommitPostDecorator{InferenceKeeper: &app.InferenceKeeper}))
+	}
 }

--- a/inference-chain/go.mod
+++ b/inference-chain/go.mod
@@ -134,8 +134,9 @@ require (
 	github.com/bufbuild/protoplugin v0.0.0-20250218205857-750e09ce93e1 // indirect
 	github.com/butuzov/ireturn v0.3.0 // indirect
 	github.com/butuzov/mirror v1.2.0 // indirect
-	github.com/bytedance/sonic v1.14.0 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/catenacyber/perfsprint v0.7.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.2 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect

--- a/inference-chain/go.sum
+++ b/inference-chain/go.sum
@@ -407,10 +407,12 @@ github.com/butuzov/ireturn v0.3.0 h1:hTjMqWw3y5JC3kpnC5vXmFJAWI/m31jaCYQqzkS6PL0
 github.com/butuzov/ireturn v0.3.0/go.mod h1:A09nIiwiqzN/IoVo9ogpa0Hzi9fex1kd9PSD6edP5ZA=
 github.com/butuzov/mirror v1.2.0 h1:9YVK1qIjNspaqWutSv8gsge2e/Xpq1eqEkslEUHy5cs=
 github.com/butuzov/mirror v1.2.0/go.mod h1:DqZZDtzm42wIAIyHXeN8W/qb1EPlb9Qn/if9icBOpdQ=
-github.com/bytedance/sonic v1.14.0 h1:/OfKt8HFw0kh2rj8N0F6C/qPGRESq0BbaNZgcNXXzQQ=
-github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxlNUO24NhA=
-github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
-github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
+github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/catenacyber/perfsprint v0.7.1 h1:PGW5G/Kxn+YrN04cRAZKC+ZuvlVwolYMrIyyTJ/rMmc=
 github.com/catenacyber/perfsprint v0.7.1/go.mod h1:/wclWYompEyjUD2FuIIDVKNkqz7IgBIWXIH3V0Zol50=
@@ -1425,6 +1427,7 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=

--- a/inference-chain/testutil/keeper/expected_keepers_mocks.go
+++ b/inference-chain/testutil/keeper/expected_keepers_mocks.go
@@ -865,17 +865,17 @@ func (mr *MockParticipantKeeperMockRecorder) RemoveParticipant(ctx, index any) *
 }
 
 // SetParticipant mocks base method.
-func (m *MockParticipantKeeper) SetParticipant(ctx context.Context, participant types4.Participant) error {
+func (m *MockParticipantKeeper) SetParticipant(ctx context.Context, participant types4.Participant, reason types4.SetParticipantReason) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetParticipant", ctx, participant)
+	ret := m.ctrl.Call(m, "SetParticipant", ctx, participant, reason)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetParticipant indicates an expected call of SetParticipant.
-func (mr *MockParticipantKeeperMockRecorder) SetParticipant(ctx, participant any) *gomock.Call {
+func (mr *MockParticipantKeeperMockRecorder) SetParticipant(ctx, participant, reason any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParticipant", reflect.TypeOf((*MockParticipantKeeper)(nil).SetParticipant), ctx, participant)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParticipant", reflect.TypeOf((*MockParticipantKeeper)(nil).SetParticipant), ctx, participant, reason)
 }
 
 // MockHardwareNodeKeeper is a mock of HardwareNodeKeeper interface.

--- a/inference-chain/testutil/keeper/in_memory_mocks.go
+++ b/inference-chain/testutil/keeper/in_memory_mocks.go
@@ -109,7 +109,7 @@ func (keeper *InMemoryParticipantKeeper) ParticipantAll(ctx context.Context, req
 }
 
 // SetParticipant stores or updates the given Participant.
-func (keeper *InMemoryParticipantKeeper) SetParticipant(ctx context.Context, participant types.Participant) error {
+func (keeper *InMemoryParticipantKeeper) SetParticipant(ctx context.Context, participant types.Participant, reason types.SetParticipantReason) error {
 	keeper.mu.Lock()
 	defer keeper.mu.Unlock()
 	keeper.data[participant.Index] = participant

--- a/inference-chain/x/inference/calculations/sprt.go
+++ b/inference-chain/x/inference/calculations/sprt.go
@@ -2,6 +2,7 @@ package calculations
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/shopspring/decimal"
 )
@@ -13,6 +14,13 @@ const (
 	Pass
 	Fail
 	Error
+)
+
+const maxLnCacheEntries = 8
+
+var (
+	lnCacheMu sync.RWMutex
+	lnCache   = make(map[string]struct{ logFail, logPass decimal.Decimal })
 )
 
 type SPRT struct {
@@ -27,6 +35,44 @@ type SPRT struct {
 	logPass decimal.Decimal
 }
 
+func lnCacheKey(p0, p1 decimal.Decimal) string {
+	return p0.String() + "|" + p1.String()
+}
+
+func getOrComputeLn(p0, p1 decimal.Decimal, prec int32) (logFail, logPass decimal.Decimal, err error) {
+	key := lnCacheKey(p0, p1)
+	lnCacheMu.RLock()
+	if c, ok := lnCache[key]; ok {
+		logFail, logPass = c.logFail, c.logPass
+		lnCacheMu.RUnlock()
+		return logFail, logPass, nil
+	}
+	lnCacheMu.RUnlock()
+
+	rFail := p1.Div(p0)
+	logFail, err = rFail.Ln(prec)
+	if err != nil {
+		return decimal.Decimal{}, decimal.Decimal{}, fmt.Errorf("ln(P1/P0): %w", err)
+	}
+	rPass := one.Sub(p1).Div(one.Sub(p0))
+	logPass, err = rPass.Ln(prec)
+	if err != nil {
+		return decimal.Decimal{}, decimal.Decimal{}, fmt.Errorf("ln((1-P1)/(1-P0)): %w", err)
+	}
+
+	lnCacheMu.Lock()
+	if len(lnCache) >= maxLnCacheEntries {
+		// Evict one arbitrary entry to avoid unbounded growth
+		for k := range lnCache {
+			delete(lnCache, k)
+			break
+		}
+	}
+	lnCache[key] = struct{ logFail, logPass decimal.Decimal }{logFail: logFail, logPass: logPass}
+	lnCacheMu.Unlock()
+	return logFail, logPass, nil
+}
+
 func NewSPRT(p0, p1, h, llr decimal.Decimal, prec int32) (*SPRT, error) {
 
 	// Basic sanity: keep probs in (0,1)
@@ -35,16 +81,9 @@ func NewSPRT(p0, p1, h, llr decimal.Decimal, prec int32) (*SPRT, error) {
 		return nil, fmt.Errorf("P0 and P1 must be in (0,1)")
 	}
 
-	rFail := p1.Div(p0)
-	logFail, err := rFail.Ln(prec)
+	logFail, logPass, err := getOrComputeLn(p0, p1, prec)
 	if err != nil {
-		return nil, fmt.Errorf("ln(P1/P0): %w", err)
-	}
-
-	rPass := one.Sub(p1).Div(one.Sub(p0))
-	logPass, err := rPass.Ln(prec)
-	if err != nil {
-		return nil, fmt.Errorf("ln((1-P1)/(1-P0)): %w", err)
+		return nil, err
 	}
 
 	return &SPRT{

--- a/inference-chain/x/inference/calculations/status.go
+++ b/inference-chain/x/inference/calculations/status.go
@@ -31,12 +31,41 @@ const (
 	LogPrecision = 12
 )
 
-// Note that newValue is passed in BY VALUE, so changes to newValue directly will not pass back
+// StatusCheckScope is a bitmask for which status checks to run in ComputeStatus.
+// When 0 (RunAll), all checks are run. Otherwise only the set bits are evaluated in order.
+type StatusCheckScope int
+
+const (
+	OnlyConsecutiveFailures StatusCheckScope = 1 << iota
+	OnlyInvalidation
+	OnlyInactive
+	OnlyConfirmationPoC
+	// RunAll (0) means run all checks; used when scope is not specified.
+)
+
+// ScopeFromReason maps SetParticipantReason to StatusCheckScope.
+// None returns RunAll. Otherwise only the matching check(s) run.
+func ScopeFromReason(reason types.SetParticipantReason) StatusCheckScope {
+	switch reason {
+	case types.SetParticipantReasonMissedInference:
+		return OnlyInactive
+	case types.SetParticipantReasonInvalidation:
+		return OnlyConsecutiveFailures | OnlyInvalidation
+	case types.SetParticipantReasonConfirmationPoC:
+		return OnlyConfirmationPoC
+	default:
+		return 0 // RunAll
+	}
+}
+
+// Note that newValue is passed in BY VALUE, so changes to newValue directly will not pass back.
+// scope: when 0 (RunAll), all checks run; otherwise only the checks in the bitmask run.
 func ComputeStatus(
 	validationParameters *types.ValidationParams,
 	confirmationPocParams *types.ConfirmationPoCParams,
 	newValue types.Participant,
 	oldStats types.CurrentEpochStats,
+	scope StatusCheckScope,
 ) (status types.ParticipantStatus, reason ParticipantStatusReason, stats types.CurrentEpochStats) {
 	// Genesis only (for tests)
 	newStats := getStats(&newValue)
@@ -49,32 +78,42 @@ func ComputeStatus(
 		return newValue.Status, AlreadySet, newStats
 	}
 
-	// If we have consecutive failures with a likelihood of less than 1 in a million times, we're assuming bad
-	falsePositiveRate := validationParameters.FalsePositiveRate.ToDecimal()
-	consecutiveFailureCutoff := validationParameters.QuickFailureThreshold.ToDecimal()
-	if probabilityOfConsecutiveFailures(falsePositiveRate, newValue.ConsecutiveInvalidInferences).LessThan(consecutiveFailureCutoff) {
-		return types.ParticipantStatus_INVALID, ConsecutiveFailures, newStats
+	runAll := scope == 0
+
+	if runAll || (scope&OnlyConsecutiveFailures != 0) {
+		// If we have consecutive failures with a likelihood of less than 1 in a million times, we're assuming bad
+		falsePositiveRate := validationParameters.FalsePositiveRate.ToDecimal()
+		consecutiveFailureCutoff := validationParameters.QuickFailureThreshold.ToDecimal()
+		if probabilityOfConsecutiveFailures(falsePositiveRate, newValue.ConsecutiveInvalidInferences).LessThan(consecutiveFailureCutoff) {
+			return types.ParticipantStatus_INVALID, ConsecutiveFailures, newStats
+		}
 	}
 
-	invalidationDecision := getInvalidationStatus(&newStats, oldStats, validationParameters)
-	if invalidationDecision == Fail {
-		return types.ParticipantStatus_INVALID, StatisticalInvalidations, newStats
-	} else if invalidationDecision == Error {
-		return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
+	if runAll || (scope&OnlyInvalidation != 0) {
+		invalidationDecision := getInvalidationStatus(&newStats, oldStats, validationParameters)
+		if invalidationDecision == Fail {
+			return types.ParticipantStatus_INVALID, StatisticalInvalidations, newStats
+		} else if invalidationDecision == Error {
+			return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
+		}
 	}
 
-	inactiveDecision := getInactiveStatus(&newStats, oldStats, validationParameters)
-	if inactiveDecision == Fail {
-		return types.ParticipantStatus_INACTIVE, Downtime, newStats
-	} else if inactiveDecision == Error {
-		return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
+	if runAll || (scope&OnlyInactive != 0) {
+		inactiveDecision := getInactiveStatus(&newStats, oldStats, validationParameters)
+		if inactiveDecision == Fail {
+			return types.ParticipantStatus_INACTIVE, Downtime, newStats
+		} else if inactiveDecision == Error {
+			return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
+		}
 	}
 
-	failedConfirmationPoCDecision := getConfirmationPoCStatus(&newStats, confirmationPocParams)
-	if failedConfirmationPoCDecision == Fail {
-		return types.ParticipantStatus_INACTIVE, FailedConfirmationPoC, newStats
-	} else if failedConfirmationPoCDecision == Error {
-		return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
+	if runAll || (scope&OnlyConfirmationPoC != 0) {
+		failedConfirmationPoCDecision := getConfirmationPoCStatus(&newStats, confirmationPocParams)
+		if failedConfirmationPoCDecision == Fail {
+			return types.ParticipantStatus_INACTIVE, FailedConfirmationPoC, newStats
+		} else if failedConfirmationPoCDecision == Error {
+			return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
+		}
 	}
 
 	return types.ParticipantStatus_ACTIVE, NoReason, newStats

--- a/inference-chain/x/inference/calculations/status.go
+++ b/inference-chain/x/inference/calculations/status.go
@@ -36,10 +36,10 @@ const (
 type StatusCheckScope int
 
 const (
-	OnlyConsecutiveFailures StatusCheckScope = 1 << iota
-	OnlyInvalidation
-	OnlyInactive
-	OnlyConfirmationPoC
+	CheckConsecutiveFailures StatusCheckScope = 1 << iota
+	CheckInvalidation
+	CheckInactive
+	CheckConfirmationPoC
 	// RunAll (0) means run all checks; used when scope is not specified.
 )
 
@@ -47,12 +47,14 @@ const (
 // None returns RunAll. Otherwise only the matching check(s) run.
 func ScopeFromReason(reason types.SetParticipantReason) StatusCheckScope {
 	switch reason {
+	case types.SetParticipantReasonCompletedInference:
+		return CheckInactive
 	case types.SetParticipantReasonMissedInference:
-		return OnlyInactive
+		return CheckInactive
 	case types.SetParticipantReasonInvalidation:
-		return OnlyConsecutiveFailures | OnlyInvalidation
+		return CheckConsecutiveFailures | CheckInvalidation
 	case types.SetParticipantReasonConfirmationPoC:
-		return OnlyConfirmationPoC
+		return CheckConfirmationPoC
 	default:
 		return 0 // RunAll
 	}
@@ -80,7 +82,7 @@ func ComputeStatus(
 
 	runAll := scope == 0
 
-	if runAll || (scope&OnlyConsecutiveFailures != 0) {
+	if runAll || (scope&CheckConsecutiveFailures != 0) {
 		// If we have consecutive failures with a likelihood of less than 1 in a million times, we're assuming bad
 		falsePositiveRate := validationParameters.FalsePositiveRate.ToDecimal()
 		consecutiveFailureCutoff := validationParameters.QuickFailureThreshold.ToDecimal()
@@ -89,29 +91,32 @@ func ComputeStatus(
 		}
 	}
 
-	if runAll || (scope&OnlyInvalidation != 0) {
+	if runAll || (scope&CheckInvalidation != 0) {
 		invalidationDecision := getInvalidationStatus(&newStats, oldStats, validationParameters)
-		if invalidationDecision == Fail {
+		switch invalidationDecision {
+		case Fail:
 			return types.ParticipantStatus_INVALID, StatisticalInvalidations, newStats
-		} else if invalidationDecision == Error {
+		case Error:
 			return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
 		}
 	}
 
-	if runAll || (scope&OnlyInactive != 0) {
+	if runAll || (scope&CheckInactive != 0) {
 		inactiveDecision := getInactiveStatus(&newStats, oldStats, validationParameters)
-		if inactiveDecision == Fail {
+		switch inactiveDecision {
+		case Fail:
 			return types.ParticipantStatus_INACTIVE, Downtime, newStats
-		} else if inactiveDecision == Error {
+		case Error:
 			return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
 		}
 	}
 
-	if runAll || (scope&OnlyConfirmationPoC != 0) {
+	if runAll || (scope&CheckConfirmationPoC != 0) {
 		failedConfirmationPoCDecision := getConfirmationPoCStatus(&newStats, confirmationPocParams)
-		if failedConfirmationPoCDecision == Fail {
+		switch failedConfirmationPoCDecision {
+		case Fail:
 			return types.ParticipantStatus_INACTIVE, FailedConfirmationPoC, newStats
-		} else if failedConfirmationPoCDecision == Error {
+		case Error:
 			return types.ParticipantStatus_ACTIVE, AlgorithmError, newStats
 		}
 	}

--- a/inference-chain/x/inference/calculations/status_test.go
+++ b/inference-chain/x/inference/calculations/status_test.go
@@ -176,3 +176,95 @@ func TestGetStats(t *testing.T) {
 	require.Equal(t, int64(0), result2.InvalidLLR.Value)
 	require.Equal(t, int64(0), result2.InactiveLLR.Value)
 }
+
+// TestSkipComputeStatusOnCompletionBreaksLLR shows that if we skip calling ComputeStatus on
+// successful completions (e.g. SetParticipantReasonNone from MsgFinishInference), the inactive
+// LLR is wrong when we later run ComputeStatus on a miss: we only apply miss deltas, not the
+// completion deltas, so the LLR can flip from ACTIVE to INACTIVE for the same event sequence.
+func TestSkipComputeStatusOnCompletionBreaksLLR(t *testing.T) {
+	params := types.DefaultValidationParams()
+	completions := 50
+	misses := 6
+
+	emptyStats := func() types.CurrentEpochStats {
+		return types.CurrentEpochStats{
+			InvalidLLR:  types.DecimalFromFloat(0),
+			InactiveLLR: types.DecimalFromFloat(0),
+		}
+	}
+
+	scope := StatusCheckScope(0) // RunAll so inactive check runs
+
+	// A: simulate 50 successful inferences + 6 misses (calling ComputeStatus every time)
+	stored := emptyStats()
+	for i := 0; i < completions; i++ {
+		_, _, stored = ComputeStatus(params, nil, types.Participant{
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount:  stored.InferenceCount + 1,
+				MissedRequests:  stored.MissedRequests,
+				InactiveLLR:     stored.InactiveLLR,
+				InvalidLLR:      stored.InvalidLLR,
+			},
+		}, stored, scope)
+	}
+	var st types.ParticipantStatus
+	for i := 0; i < misses; i++ {
+		st, _, stored = ComputeStatus(params, nil, types.Participant{
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount:  stored.InferenceCount,
+				MissedRequests:  stored.MissedRequests + 1,
+				InactiveLLR:     stored.InactiveLLR,
+				InvalidLLR:      stored.InvalidLLR,
+			},
+		}, stored, scope)
+	}
+	t.Logf("always compute: LLR=%s status=%s", stored.InactiveLLR.ToDecimal(), st)
+	require.Equal(t, types.ParticipantStatus_ACTIVE, st)
+
+	// B: same event sequence but skip ComputeStatus on completions (only run on misses)
+	skipped := emptyStats()
+	skipped.InferenceCount = uint64(completions)
+	var st2 types.ParticipantStatus
+	for i := 0; i < misses; i++ {
+		st2, _, skipped = ComputeStatus(params, nil, types.Participant{
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: uint64(completions),
+				MissedRequests: skipped.MissedRequests + 1,
+				InactiveLLR:    skipped.InactiveLLR,
+				InvalidLLR:     skipped.InvalidLLR,
+			},
+		}, skipped, scope)
+	}
+	t.Logf("skip completions: LLR=%s status=%s", skipped.InactiveLLR.ToDecimal(), st2)
+
+	// Same participant, same event sequence (50 completions, 6 misses), but B is marked INACTIVE
+	// because InactiveLLR never received the 50 * logPass contributions from completions.
+	require.Equal(t, types.ParticipantStatus_INACTIVE, st2)
+
+	// C: batch 50 completions (one ComputeStatus with delta (50,0)), then apply 6 misses.
+	// Same net deltas as A, so InactiveLLR and status must match A.
+	skipped2 := emptyStats()
+	var st3 types.ParticipantStatus
+	st3, _, skipped2 = ComputeStatus(params, nil, types.Participant{
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: uint64(completions),
+			MissedRequests: 0,
+			InactiveLLR:    skipped2.InactiveLLR,
+			InvalidLLR:     skipped2.InvalidLLR,
+		},
+	}, skipped2, scope)
+	for i := 0; i < misses; i++ {
+		st3, _, skipped2 = ComputeStatus(params, nil, types.Participant{
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: skipped2.InferenceCount,
+				MissedRequests: skipped2.MissedRequests + 1,
+				InactiveLLR:    skipped2.InactiveLLR,
+				InvalidLLR:     skipped2.InvalidLLR,
+			},
+		}, skipped2, scope)
+	}
+	t.Logf("batch completions then misses: LLR=%s status=%s", skipped2.InactiveLLR.ToDecimal(), st3)
+	require.Equal(t, types.ParticipantStatus_ACTIVE, st3, "same event sequence as A should stay ACTIVE")
+	require.Equal(t, stored.InactiveLLR.ToDecimal().String(), skipped2.InactiveLLR.ToDecimal().String(),
+		"InactiveLLR should equal case A when we batch completions then apply misses")
+}

--- a/inference-chain/x/inference/calculations/status_test.go
+++ b/inference-chain/x/inference/calculations/status_test.go
@@ -88,7 +88,7 @@ func TestComputeStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status, reason, _ := ComputeStatus(tt.params, nil, tt.participant, zeroStats)
+			status, reason, _ := ComputeStatus(tt.params, nil, tt.participant, zeroStats, 0)
 			require.Equal(t, tt.wantStatus, status)
 			require.Equal(t, tt.wantReason, reason)
 		})
@@ -115,7 +115,7 @@ func TestDowntimeTriggersInactive(t *testing.T) {
 		},
 	}
 
-	status, reason, _ := ComputeStatus(params, nil, participant, zeroStats)
+	status, reason, _ := ComputeStatus(params, nil, participant, zeroStats, 0)
 	require.Equal(t, types.ParticipantStatus_INACTIVE, status)
 	require.Equal(t, Downtime, reason)
 }
@@ -141,7 +141,7 @@ func TestDowntimeParamsOutOfRangeReturnAlgorithmError(t *testing.T) {
 			QuickFailureThreshold:          types.DecimalFromFloat(0.000001),
 		}
 		participant := types.Participant{CurrentEpochStats: &types.CurrentEpochStats{}}
-		status, reason, _ := ComputeStatus(params, nil, participant, zeroStats)
+		status, reason, _ := ComputeStatus(params, nil, participant, zeroStats, 0)
 		require.Equal(t, types.ParticipantStatus_ACTIVE, status)
 		require.Equal(t, AlgorithmError, reason)
 	}

--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -225,7 +225,7 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 			return err
 		}
 		participant.CurrentEpochStats = types.NewCurrentEpochStats()
-		err := k.SetParticipant(ctx, participant)
+		err := k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 		if err != nil {
 			return err
 		}

--- a/inference-chain/x/inference/keeper/accountsettle_test.go
+++ b/inference-chain/x/inference/keeper/accountsettle_test.go
@@ -56,8 +56,8 @@ func TestActualSettle(t *testing.T) {
 	params, err := keeper.GetParams(ctx)
 	require.NoError(t, err)
 
-	keeper.SetParticipant(ctx, participant1)
-	keeper.SetParticipant(ctx, participant2)
+	keeper.SetParticipant(ctx, participant1, types.SetParticipantReasonNone)
+	keeper.SetParticipant(ctx, participant2, types.SetParticipantReasonNone)
 	keeper.SetEpochGroupData(ctx, types.EpochGroupData{
 		EpochIndex: 10,
 		ValidationWeights: []*types.ValidationWeight{
@@ -183,7 +183,7 @@ func TestActualSettleWithManyParticipants(t *testing.T) {
 			},
 		}
 		participants[i] = participant
-		keeper.SetParticipant(ctx, participant)
+		keeper.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 		if i%50 == 0 {
 			logger.Info("Created participants", "count", i+1)
 		}
@@ -286,7 +286,7 @@ func TestSettleWithGraceEpoch(t *testing.T) {
 		},
 	}
 
-	keeper.SetParticipant(ctx, participantHighMiss)
+	keeper.SetParticipant(ctx, participantHighMiss, types.SetParticipantReasonMissedInference)
 	keeper.SetEpochGroupData(ctx, types.EpochGroupData{
 		EpochIndex: epochIndex,
 		ValidationWeights: []*types.ValidationWeight{
@@ -354,7 +354,7 @@ func TestSettleWithoutGraceEpoch(t *testing.T) {
 		},
 	}
 
-	keeper.SetParticipant(ctx, participantHighMiss)
+	keeper.SetParticipant(ctx, participantHighMiss, types.SetParticipantReasonMissedInference)
 	keeper.SetEpochGroupData(ctx, types.EpochGroupData{
 		EpochIndex: epochIndex,
 		ValidationWeights: []*types.ValidationWeight{

--- a/inference-chain/x/inference/keeper/collateral_integration_test.go
+++ b/inference-chain/x/inference/keeper/collateral_integration_test.go
@@ -235,16 +235,17 @@ func TestInvalidateInference_FullFlow_WithStatefulMock(t *testing.T) {
 		}).Times(1)
 	// --- End Stateful Mock Logic ---
 
-	// Set up the participant with 4 consecutive failures, just under the threshold
+	// Set up the participant with 4 consecutive failures, just under the threshold.
+	// Use Invalidation reason so status is computed with invalidation scope (still ACTIVE at 4).
 	k.SetParticipant(ctx, types.Participant{
 		Index:                        participantAddrStr,
 		Address:                      participantAddrStr,
 		Status:                       types.ParticipantStatus_ACTIVE,
 		ConsecutiveInvalidInferences: 4,
 		CurrentEpochStats:            &types.CurrentEpochStats{},
-	})
+	}, types.SetParticipantReasonInvalidation)
 	// The authority also needs to be a registered participant to invalidate
-	k.SetParticipant(ctx, types.Participant{Index: authority, Address: authority, CurrentEpochStats: &types.CurrentEpochStats{}})
+	k.SetParticipant(ctx, types.Participant{Index: authority, Address: authority, CurrentEpochStats: &types.CurrentEpochStats{}}, types.SetParticipantReasonNone)
 
 	// Mock bank keeper for the refund logic, even though cost is 0
 	mocks.BankKeeper.EXPECT().SendCoinsFromModuleToAccount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
@@ -316,7 +317,7 @@ func TestDoubleJeopardy_DowntimeThenInvalidSlash(t *testing.T) {
 	require.NoError(t, ee)
 
 	// --- 1. First Jeopardy: Downtime Slash ---
-	// Set the participant's epoch stats to trigger downtime slashing.
+	// Store participant with bad epoch stats; then run downtime slash explicitly (same as before reason parameter).
 	k.SetParticipant(ctx, types.Participant{
 		Index:   participantAddrStr,
 		Address: participantAddrStr,
@@ -325,7 +326,7 @@ func TestDoubleJeopardy_DowntimeThenInvalidSlash(t *testing.T) {
 			InferenceCount: 10,
 			MissedRequests: 90, // 90% missed requests
 		},
-	})
+	}, types.SetParticipantReasonNone)
 	participant, found := k.GetParticipant(ctx, participantAddrStr)
 	require.True(t, found)
 
@@ -351,10 +352,10 @@ func TestDoubleJeopardy_DowntimeThenInvalidSlash(t *testing.T) {
 	participant.Status = types.ParticipantStatus_ACTIVE
 	participant.ConsecutiveInvalidInferences = 4
 	participant.CurrentEpochStats = &types.CurrentEpochStats{} // Reset for the new epoch
-	k.SetParticipant(ctx, participant)
+	k.SetParticipant(ctx, participant, types.SetParticipantReasonInvalidation)
 
 	// The authority also needs to be a registered participant to invalidate
-	k.SetParticipant(ctx, types.Participant{Index: authority, Address: authority, CurrentEpochStats: &types.CurrentEpochStats{}})
+	k.SetParticipant(ctx, types.Participant{Index: authority, Address: authority, CurrentEpochStats: &types.CurrentEpochStats{}}, types.SetParticipantReasonNone)
 
 	// Setup the inference object to be invalidated
 	inferenceId := "double-jeopardy-inference"

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -2,6 +2,9 @@ package keeper
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"sync"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/store"
@@ -11,6 +14,19 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
 )
+
+// ParamsCacheMode is the mode for GetParams caching. See INFERENCE_PARAMS_CACHE_MODE.
+const (
+	ParamsCacheModeTx   = "tx"   // tx-bound draft; commit to store on tx success
+	ParamsCacheModeBlock = "block" // per-block cache; always return value at block start
+)
+
+// paramsBlockCache holds params at block start for ParamsCacheModeBlock. Cleared in BeginBlock.
+type paramsBlockCache struct {
+	mu     sync.RWMutex
+	p      *types.Params
+	inited bool
+}
 
 type (
 	Keeper struct {
@@ -86,6 +102,9 @@ type (
 		PoCValidationSnapshots collections.Map[int64, types.PoCValidationSnapshot]
 		// Punishment grace epochs for upgrade protection
 		PunishmentGraceEpochs collections.Map[uint64, types.GraceEpochParams]
+		// Params cache: mode "tx" = tx-bound draft (commit on tx); "block" = per-block cache (value at block start only). Default: block.
+		paramsCacheMode  string
+		paramsBlockCache *paramsBlockCache
 	}
 )
 
@@ -428,6 +447,8 @@ func NewKeeper(
 			collections.Uint64Key,
 			codec.CollValue[types.GraceEpochParams](cdc),
 		),
+		paramsCacheMode:  getParamsCacheMode(),
+		paramsBlockCache: &paramsBlockCache{},
 	}
 	// Build the collections schema
 	schema, err := sb.Build()
@@ -439,9 +460,23 @@ func NewKeeper(
 	return k
 }
 
+// getParamsCacheMode returns INFERENCE_PARAMS_CACHE_MODE ("tx" or "block"); default "block".
+func getParamsCacheMode() string {
+	mode := strings.TrimSpace(strings.ToLower(os.Getenv("INFERENCE_PARAMS_CACHE_MODE")))
+	if mode == ParamsCacheModeTx {
+		return ParamsCacheModeTx
+	}
+	return ParamsCacheModeBlock
+}
+
 // GetAuthority returns the module's authority.
 func (k Keeper) GetAuthority() string {
 	return k.authority
+}
+
+// GetParamsCacheMode returns the params cache mode ("tx" or "block") from INFERENCE_PARAMS_CACHE_MODE.
+func (k Keeper) GetParamsCacheMode() string {
+	return k.paramsCacheMode
 }
 
 // GetWasmKeeper returns the WASM keeper

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -232,7 +232,7 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 	} else {
 		executor.CurrentEpochStats.InferenceCount++
 		executor.LastInferenceTime = existingInference.EndBlockTimestamp
-		if err := k.SetParticipant(ctx, executor); err != nil {
+		if err := k.SetParticipant(ctx, executor, types.SetParticipantReasonNone); err != nil {
 			return err
 		}
 

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -232,7 +232,7 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 	} else {
 		executor.CurrentEpochStats.InferenceCount++
 		executor.LastInferenceTime = existingInference.EndBlockTimestamp
-		if err := k.SetParticipant(ctx, executor, types.SetParticipantReasonNone); err != nil {
+		if err := k.SetParticipant(ctx, executor, types.SetParticipantReasonCompletedInference); err != nil {
 			return err
 		}
 

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
@@ -39,7 +39,7 @@ func (k msgServer) InvalidateInference(ctx context.Context, msg *types.MsgInvali
 
 	k.LogInfo("Inference invalidated", types.Inferences, "inferenceId", inference.InferenceId, "executor", executor.Address, "actualCost", inference.ActualCost)
 
-	err = k.SetParticipant(ctx, *executor)
+	err = k.SetParticipant(ctx, *executor, types.SetParticipantReasonInvalidation)
 	if err != nil {
 		return nil, err
 	}

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference_test.go
@@ -64,11 +64,11 @@ func TestInvalidateInference_RefundsRequesterAndChargesExecutor_NoSlash(t *testi
 		CurrentEpochStats:            &types.CurrentEpochStats{},
 		CoinBalance:                  1_000, // arbitrary internal balance field used by keeper
 	}
-	k.SetParticipant(ctx, executor)
+	k.SetParticipant(ctx, executor, types.SetParticipantReasonInvalidation)
 
 	// Register payer (requester)
 	payer := types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}}
-	k.SetParticipant(ctx, payer)
+	k.SetParticipant(ctx, payer, types.SetParticipantReasonNone)
 
 	// Inference with non-zero cost
 	inferenceID := "refund-no-slash"
@@ -131,11 +131,11 @@ func TestInvalidateInference_RefundsRequesterAndChargesExecutor_WithSlash(t *tes
 		CurrentEpochStats:            &types.CurrentEpochStats{},
 		CoinBalance:                  5_000,
 	}
-	k.SetParticipant(ctx, executor)
+	k.SetParticipant(ctx, executor, types.SetParticipantReasonInvalidation)
 
 	// Register payer
 	payer := types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}}
-	k.SetParticipant(ctx, payer)
+	k.SetParticipant(ctx, payer, types.SetParticipantReasonNone)
 
 	// Non-zero cost
 	inferenceID := "refund-with-slash"
@@ -202,10 +202,10 @@ func TestInvalidateInference_NextEpoch_NoRefundNoCharge_NoSlash(t *testing.T) {
 		CurrentEpochStats:            &types.CurrentEpochStats{},
 		CoinBalance:                  initialBalance,
 	}
-	k.SetParticipant(ctx, executor)
+	k.SetParticipant(ctx, executor, types.SetParticipantReasonInvalidation)
 
 	payer := types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}}
-	k.SetParticipant(ctx, payer)
+	k.SetParticipant(ctx, payer, types.SetParticipantReasonNone)
 
 	inferenceID := "invalidate-next-epoch"
 	actualCost := int64(777)
@@ -253,8 +253,8 @@ func TestInvalidateInference_FailsWithWrongPolicyAddress(t *testing.T) {
 	payerAddr := sample.AccAddress()
 	wrongCreator := sample.AccAddress()
 
-	k.SetParticipant(ctx, types.Participant{Index: executorAddr, Address: executorAddr, CurrentEpochStats: &types.CurrentEpochStats{}})
-	k.SetParticipant(ctx, types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}})
+	k.SetParticipant(ctx, types.Participant{Index: executorAddr, Address: executorAddr, CurrentEpochStats: &types.CurrentEpochStats{}}, types.SetParticipantReasonInvalidation)
+	k.SetParticipant(ctx, types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}}, types.SetParticipantReasonNone)
 
 	inferenceID := "wrong-policy"
 	k.SetInference(ctx, types.Inference{
@@ -282,8 +282,8 @@ func TestInvalidateInference_RemovesActiveInvalidations(t *testing.T) {
 	executorAddr := sample.AccAddress()
 	payerAddr := sample.AccAddress()
 	invalidator := sample.AccAddress()
-	k.SetParticipant(ctx, types.Participant{Index: executorAddr, Address: executorAddr, CurrentEpochStats: &types.CurrentEpochStats{}})
-	k.SetParticipant(ctx, types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}})
+	k.SetParticipant(ctx, types.Participant{Index: executorAddr, Address: executorAddr, CurrentEpochStats: &types.CurrentEpochStats{}}, types.SetParticipantReasonInvalidation)
+	k.SetParticipant(ctx, types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}}, types.SetParticipantReasonNone)
 
 	inferenceID := "remove-active-invalidations"
 	k.SetInference(ctx, types.Inference{
@@ -326,8 +326,8 @@ func TestInvalidateInference_AlreadyInvalidated_RemovesActiveInvalidations(t *te
 	executorAddr := sample.AccAddress()
 	payerAddr := sample.AccAddress()
 	invalidator := sample.AccAddress()
-	k.SetParticipant(ctx, types.Participant{Index: executorAddr, Address: executorAddr, CurrentEpochStats: &types.CurrentEpochStats{}})
-	k.SetParticipant(ctx, types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}})
+	k.SetParticipant(ctx, types.Participant{Index: executorAddr, Address: executorAddr, CurrentEpochStats: &types.CurrentEpochStats{}}, types.SetParticipantReasonInvalidation)
+	k.SetParticipant(ctx, types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}}, types.SetParticipantReasonNone)
 
 	inferenceID := "already-invalidated-removes"
 	k.SetInference(ctx, types.Inference{

--- a/inference-chain/x/inference/keeper/msg_server_revalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_revalidate_inference.go
@@ -21,7 +21,7 @@ func (k msgServer) RevalidateInference(ctx context.Context, msg *types.MsgRevali
 	executor.ConsecutiveInvalidInferences = 0
 	executor.CurrentEpochStats.ValidatedInferences++
 
-	err = k.SetParticipant(ctx, *executor)
+	err = k.SetParticipant(ctx, *executor, types.SetParticipantReasonNone)
 	if err != nil {
 		return nil, err
 	}

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -225,7 +225,7 @@ func (k msgServer) processInferencePayments(
 		executor.CoinBalance += payments.ExecutorPayment
 		executor.CurrentEpochStats.EarnedCoins += uint64(payments.ExecutorPayment)
 		k.SafeLogSubAccountTransaction(ctx, executor.Address, types.ModuleName, types.OwedSubAccount, executor.CoinBalance, "inference_started:"+inference.InferenceId)
-		err := k.SetParticipant(ctx, executor)
+		err := k.SetParticipant(ctx, executor, types.SetParticipantReasonNone)
 		if err != nil {
 			return nil, err
 		}

--- a/inference-chain/x/inference/keeper/msg_server_submit_new_participant.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_new_participant.go
@@ -24,7 +24,7 @@ func (k msgServer) SubmitNewParticipant(goCtx context.Context, msg *types.MsgSub
 		if msg.WorkerKey != "" {
 			existing.WorkerPublicKey = msg.WorkerKey
 		}
-		if err := k.SetParticipant(ctx, existing); err != nil {
+		if err := k.SetParticipant(ctx, existing, types.SetParticipantReasonNone); err != nil {
 			return nil, err
 		}
 		return &types.MsgSubmitNewParticipantResponse{}, nil
@@ -40,7 +40,7 @@ func (k msgServer) SubmitNewParticipant(goCtx context.Context, msg *types.MsgSub
 
 	// If participant does not exist yet, create a new one
 	newParticipant := createNewParticipant(ctx, msg)
-	if err := k.SetParticipant(ctx, newParticipant); err != nil {
+	if err := k.SetParticipant(ctx, newParticipant, types.SetParticipantReasonNone); err != nil {
 		return nil, err
 	}
 	return &types.MsgSubmitNewParticipantResponse{}, nil

--- a/inference-chain/x/inference/keeper/msg_server_submit_new_unfunded_participant.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_new_unfunded_participant.go
@@ -59,7 +59,7 @@ func (k msgServer) SubmitNewUnfundedParticipant(goCtx context.Context, msg *type
 			WorkerKey:    msg.GetWorkerKey(),
 		})
 	k.LogDebug("Adding new participant", types.Participants, "participant", newParticipant)
-	err = k.SetParticipant(ctx, newParticipant)
+	err = k.SetParticipant(ctx, newParticipant, types.SetParticipantReasonNone)
 	if err != nil {
 		return nil, err
 	}

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -161,7 +161,7 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		inference.Status = types.InferenceStatus_FINISHED
 	}
 
-	err = k.SetParticipant(ctx, executor)
+	err = k.SetParticipant(ctx, executor, types.SetParticipantReasonNone)
 	if err != nil {
 		k.LogError("Failed to set executor", types.Validation, "executor", executor.Address, "error", err)
 		return nil, err
@@ -303,7 +303,7 @@ func (k msgServer) shareWorkWithValidators(ctx sdk.Context, inference types.Infe
 			if adjustment.WorkAdjustment < 0 {
 				k.SafeLogSubAccountTransaction(ctx, msg.Creator, adjustment.ParticipantId, types.OwedSubAccount, -adjustment.WorkAdjustment, "share_validation_worker:"+inference.InferenceId)
 			}
-			err := k.SetParticipant(ctx, worker)
+			err := k.SetParticipant(ctx, worker, types.SetParticipantReasonNone)
 			if err != nil {
 				k.LogError("Unable to update participant to share work", types.Validation, "worker", worker.Address)
 			}

--- a/inference-chain/x/inference/keeper/params.go
+++ b/inference-chain/x/inference/keeper/params.go
@@ -13,14 +13,13 @@ const defaultGenesisGuardianNetworkMaturityMinHeight int64 = 0
 const defaultDeveloperAccessUntilBlockHeight int64 = 0
 const defaultNewParticipantRegistrationStartHeight int64 = 0
 
-// GetParams get all parameters as types.Params
-func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) {
+// getParamsFromStore reads params from the KV store only (no cache).
+func (k Keeper) getParamsFromStore(ctx context.Context) (params types.Params, err error) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
 		return params, nil
 	}
-
 	err = k.cdc.Unmarshal(bz, &params)
 	if err != nil {
 		return types.Params{}, err
@@ -28,16 +27,86 @@ func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) 
 	return params, nil
 }
 
-// SetParams set the params
-func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
-	oldParams, _ := k.GetParams(ctx)
-
+// setParamsToStore writes params to the KV store only (no cache update).
+func (k Keeper) setParamsToStore(ctx context.Context, params types.Params) error {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	bz, err := k.cdc.Marshal(&params)
 	if err != nil {
 		return err
 	}
 	store.Set(types.ParamsKey, bz)
+	return nil
+}
+
+// GetParams returns all parameters. Behavior depends on INFERENCE_PARAMS_CACHE_MODE (default "block"):
+//   - "tx": use tx-bound draft if present (AnteHandler attached); else store.
+//   - "block": always return params at block start (cache cleared in BeginBlock); SetParams in block does not change value returned by GetParams until next block.
+func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) {
+	// Tx mode: use draft if attached to context
+	if k.paramsCacheMode == ParamsCacheModeTx {
+		d := getParamsDraftFromContext(ctx)
+		if d != nil {
+			if !d.loaded {
+				params, err = k.getParamsFromStore(ctx)
+				if err != nil {
+					return types.Params{}, err
+				}
+				d.p = &params
+				d.loaded = true
+				return params, nil
+			}
+			if d.p != nil {
+				return *d.p, nil
+			}
+			return types.Params{}, nil
+		}
+	}
+
+	// Block mode: use per-block cache (value at block start only)
+	if k.paramsCacheMode == ParamsCacheModeBlock && k.paramsBlockCache != nil {
+		k.paramsBlockCache.mu.Lock()
+		if !k.paramsBlockCache.inited {
+			params, err = k.getParamsFromStore(ctx)
+			if err != nil {
+				k.paramsBlockCache.mu.Unlock()
+				return types.Params{}, err
+			}
+			k.paramsBlockCache.p = &params
+			k.paramsBlockCache.inited = true
+			k.paramsBlockCache.mu.Unlock()
+			return params, nil
+		}
+		p := k.paramsBlockCache.p
+		k.paramsBlockCache.mu.Unlock()
+		if p != nil {
+			return *p, nil
+		}
+		return types.Params{}, nil
+	}
+
+	return k.getParamsFromStore(ctx)
+}
+
+// SetParams sets the params. In tx mode with draft: updates draft only (committed in PostHandler).
+// In block mode: writes to store but GetParams keeps returning block-start value until next block.
+func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
+	// Tx mode with draft: write to draft only
+	if k.paramsCacheMode == ParamsCacheModeTx {
+		d := getParamsDraftFromContext(ctx)
+		if d != nil {
+			dup := params
+			d.p = &dup
+			d.loaded = true
+			// Grace-epoch logic runs when we commit to store in CommitParamsDraftFromContext
+			return nil
+		}
+	}
+
+	// Block mode or no draft: write to store. For block mode we do not update paramsBlockCache.
+	oldParams, _ := k.getParamsFromStore(ctx)
+	if err := k.setParamsToStore(ctx, params); err != nil {
+		return err
+	}
 
 	// Auto-set grace epoch when poc_v2_enabled transitions false -> true
 	if params.PocParams != nil && params.PocParams.PocV2Enabled {
@@ -50,7 +119,6 @@ func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/inference-chain/x/inference/keeper/params_cache.go
+++ b/inference-chain/x/inference/keeper/params_cache.go
@@ -1,0 +1,68 @@
+package keeper
+
+import (
+	"context"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+type ctxKeyParamsDraft struct{}
+
+// paramsDraft holds params for the current tx. Used when paramsCacheMode == ParamsCacheModeTx.
+type paramsDraft struct {
+	p      *types.Params
+	loaded bool
+}
+
+// WithParamsDraft attaches a new tx-scoped params draft to ctx. Call from AnteHandler at tx start.
+// When present, GetParams/SetParams use the draft; CommitParamsDraftFromContext persists it on tx success.
+func WithParamsDraft(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeyParamsDraft{}, &paramsDraft{})
+}
+
+// getParamsDraftFromContext returns the tx-scoped draft, or nil if not in a params-draft tx.
+func getParamsDraftFromContext(ctx context.Context) *paramsDraft {
+	v := ctx.Value(ctxKeyParamsDraft{})
+	if v == nil {
+		return nil
+	}
+	d, _ := v.(*paramsDraft)
+	return d
+}
+
+// CommitParamsDraftFromContext writes the tx-scoped params draft to store if it was changed this tx.
+// Call from PostHandler on tx success. No-op if ctx has no draft or draft was never set.
+// Applies PocV2 grace-epoch logic when committing (same as SetParams).
+func (k Keeper) CommitParamsDraftFromContext(ctx context.Context) error {
+	d := getParamsDraftFromContext(ctx)
+	if d == nil || !d.loaded || d.p == nil {
+		return nil
+	}
+	params := *d.p
+	oldParams, _ := k.getParamsFromStore(ctx)
+	if err := k.setParamsToStore(ctx, params); err != nil {
+		return err
+	}
+	if params.PocParams != nil && params.PocParams.PocV2Enabled {
+		wasV2Disabled := oldParams.PocParams == nil || !oldParams.PocParams.PocV2Enabled
+		if wasV2Disabled {
+			if _, exists := k.GetPocV2EnabledEpoch(ctx); !exists {
+				if epoch, found := k.GetEffectiveEpochIndex(ctx); found {
+					_ = k.SetPocV2EnabledEpoch(ctx, epoch)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// InvalidateParamsBlockCache clears the per-block params cache. Call from BeginBlock when paramsCacheMode == ParamsCacheModeBlock.
+func (k Keeper) InvalidateParamsBlockCache() {
+	if k.paramsBlockCache == nil {
+		return
+	}
+	k.paramsBlockCache.mu.Lock()
+	defer k.paramsBlockCache.mu.Unlock()
+	k.paramsBlockCache.p = nil
+	k.paramsBlockCache.inited = false
+}

--- a/inference-chain/x/inference/keeper/participant.go
+++ b/inference-chain/x/inference/keeper/participant.go
@@ -7,13 +7,20 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-// SetParticipant set a specific participant in the store from its index
-func (k Keeper) SetParticipant(ctx context.Context, participant types.Participant) error {
-	// Compute new status and delegate transition handling to a unified method.
-	err := k.UpdateParticipantStatus(ctx, &participant)
-	if err != nil {
-		k.LogError("Failed to update participant status", types.Validation, "error", err)
-		return err
+// SetParticipant set a specific participant in the store from its index.
+// reason: SetParticipantReasonNone to skip status computation and only ensure CurrentEpochStats is set;
+// pass MissedInference, Invalidation, or ConfirmationPoC to run only the corresponding status check(s).
+func (k Keeper) SetParticipant(ctx context.Context, participant types.Participant, reason types.SetParticipantReason) error {
+	if reason != types.SetParticipantReasonNone {
+		err := k.UpdateParticipantStatus(ctx, &participant, reason)
+		if err != nil {
+			k.LogError("Failed to update participant status", types.Validation, "error", err)
+			return err
+		}
+	} else {
+		if participant.CurrentEpochStats == nil {
+			participant.CurrentEpochStats = &types.CurrentEpochStats{}
+		}
 	}
 
 	participantAddress, err := sdk.AccAddressFromBech32(participant.Index)

--- a/inference-chain/x/inference/keeper/participant_status.go
+++ b/inference-chain/x/inference/keeper/participant_status.go
@@ -14,7 +14,8 @@ import (
 // It detects transitions and applies side-effects exactly once. Currently, when transitioning
 // to INVALID it will: slash collateral, record an exclusion entry for the current epoch,
 // and invoke removal from EpochGroup memberships for the current epoch.
-func (k Keeper) UpdateParticipantStatus(ctx context.Context, participant *types.Participant) error {
+// reason: only the check(s) for that call site run (caller must not pass None; that path skips UpdateParticipantStatus).
+func (k Keeper) UpdateParticipantStatus(ctx context.Context, participant *types.Participant, reason types.SetParticipantReason) error {
 	if participant == nil {
 		return nil
 	}
@@ -32,16 +33,18 @@ func (k Keeper) UpdateParticipantStatus(ctx context.Context, participant *types.
 		k.LogError("UpdateParticipantStatus: failed to get params", types.Validation, "error", err)
 		return err
 	}
+	scope := calculations.ScopeFromReason(reason)
 	originalStatus := participant.Status
-	newStatus, reason, newStats := calculations.ComputeStatus(
+	newStatus, statusReason, newStats := calculations.ComputeStatus(
 		params.ValidationParams,
 		params.ConfirmationPocParams,
 		*participant,
 		*oldParticipant.CurrentEpochStats,
+		scope,
 	)
 	participant.CurrentEpochStats = &newStats
 
-	k.LogInfo("Participant status updated", types.Validation, "address", participant.Address, "original", originalStatus, "new", newStatus, "reason", reason, "stats", participant.CurrentEpochStats)
+	k.LogInfo("Participant status updated", types.Validation, "address", participant.Address, "original", originalStatus, "new", newStatus, "reason", statusReason, "stats", participant.CurrentEpochStats)
 
 	if originalStatus == newStatus {
 		return nil
@@ -52,11 +55,11 @@ func (k Keeper) UpdateParticipantStatus(ctx context.Context, participant *types.
 
 	// Handle transition to INVALID once.
 	if originalStatus != types.ParticipantStatus_INVALID && newStatus == types.ParticipantStatus_INVALID {
-		return k.invalidateParticipant(ctx, participant, reason, params)
+		return k.invalidateParticipant(ctx, participant, statusReason, params)
 	}
 
 	if originalStatus != types.ParticipantStatus_INACTIVE && newStatus == types.ParticipantStatus_INACTIVE {
-		return k.deactiveParticipant(ctx, participant, reason, params)
+		return k.deactiveParticipant(ctx, participant, statusReason, params)
 	}
 
 	return nil

--- a/inference-chain/x/inference/keeper/participant_test.go
+++ b/inference-chain/x/inference/keeper/participant_test.go
@@ -26,7 +26,7 @@ func createNParticipant(keeper keeper.Keeper, ctx context.Context, n int) []type
 		// To test counter
 		items[i].Status = types.ParticipantStatus_ACTIVE
 		items[i].CurrentEpochStats = types.NewCurrentEpochStats()
-		keeper.SetParticipant(ctx, items[i])
+		keeper.SetParticipant(ctx, items[i], types.SetParticipantReasonNone)
 	}
 	return items
 }
@@ -98,7 +98,7 @@ func TestUpdateParticipantStatus_NoTransition(t *testing.T) {
 	}
 
 	// Call UpdateParticipantStatus
-	err := k.UpdateParticipantStatus(ctx, &participant)
+	err := k.UpdateParticipantStatus(ctx, &participant, types.SetParticipantReasonInvalidation)
 	require.NoError(t, err)
 
 	// Status should remain ACTIVE
@@ -160,7 +160,7 @@ func TestUpdateParticipantStatus_TransitionToInvalid(t *testing.T) {
 		Times(1)
 
 	// Call UpdateParticipantStatus
-	err = k.UpdateParticipantStatus(ctx, &participant)
+	err = k.UpdateParticipantStatus(ctx, &participant, types.SetParticipantReasonInvalidation)
 	require.NoError(t, err)
 
 	// Status should transition to INVALID
@@ -197,7 +197,7 @@ func TestUpdateParticipantStatus_AlreadyInvalid(t *testing.T) {
 		Times(0)
 
 	// Call UpdateParticipantStatus
-	err := k.UpdateParticipantStatus(ctx, &participant)
+	err := k.UpdateParticipantStatus(ctx, &participant, types.SetParticipantReasonInvalidation)
 	require.NoError(t, err)
 
 	// Status should remain INVALID
@@ -235,7 +235,7 @@ func TestUpdateParticipantStatus_AlreadyInactive(t *testing.T) {
 		Times(0)
 
 	// Call UpdateParticipantStatus
-	err := k.UpdateParticipantStatus(ctx, &participant)
+	err := k.UpdateParticipantStatus(ctx, &participant, types.SetParticipantReasonInvalidation)
 	require.NoError(t, err)
 
 	// Status should remain INACTIVE
@@ -296,7 +296,7 @@ func TestInvalidParticipant_ReputationReduced(t *testing.T) {
 		Times(1)
 
 	// Call UpdateParticipantStatus (which calls invalidateParticipant)
-	err = k.UpdateParticipantStatus(ctx, &participant)
+	err = k.UpdateParticipantStatus(ctx, &participant, types.SetParticipantReasonInvalidation)
 	require.NoError(t, err)
 
 	// EpochsCompleted should be reduced: 50 * 0.6 = 30
@@ -356,8 +356,8 @@ func TestParticipantStatusFlow_ActiveToInvalid(t *testing.T) {
 		Return(&group.MsgUpdateGroupMembersResponse{}, nil).
 		Times(1)
 
-	// Save participant (triggers status update)
-	err = k.SetParticipant(ctx, participant)
+	// Save participant (triggers status update with invalidation scope)
+	err = k.SetParticipant(ctx, participant, types.SetParticipantReasonInvalidation)
 	require.NoError(t, err)
 
 	// Retrieve and verify
@@ -397,7 +397,7 @@ func TestParticipantStatusFlow_InactiveStaysInactive(t *testing.T) {
 		Times(0)
 
 	// Save participant
-	err := k.SetParticipant(ctx, participant)
+	err := k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 	require.NoError(t, err)
 
 	// Retrieve and verify - should remain INACTIVE despite good stats

--- a/inference-chain/x/inference/module/bls_integration_test.go
+++ b/inference-chain/x/inference/module/bls_integration_test.go
@@ -131,7 +131,7 @@ func TestBLSKeyGenerationIntegration(t *testing.T) {
 		{Index: charlieAccAddrStr, Address: charlieAccAddrStr, ValidatorKey: "valKeyCharlie", WorkerPublicKey: "ignoredWKeyCharlie", Weight: 20, Status: types.ParticipantStatus_ACTIVE},
 	}
 	for _, p := range participants {
-		k.SetParticipant(ctx, *p)
+		k.SetParticipant(ctx, *p, types.SetParticipantReasonNone)
 	}
 
 	activeParticipants := []*types.ActiveParticipant{
@@ -200,7 +200,7 @@ func TestBLSKeyGenerationWithAccountKeyIssues(t *testing.T) {
 		{Index: charlieAccAddrStr, Address: charlieAccAddrStr, Weight: 40, Status: types.ParticipantStatus_ACTIVE},
 	}
 	for _, p := range storedParticipants {
-		k.SetParticipant(ctx, *p)
+		k.SetParticipant(ctx, *p, types.SetParticipantReasonNone)
 	}
 
 	activeParticipants := []*types.ActiveParticipant{
@@ -247,7 +247,7 @@ func TestBLSKeyGenerationUsesAccountPubKeyOverWorkerOrValidatorKey(t *testing.T)
 		Weight:          100,
 		Status:          types.ParticipantStatus_ACTIVE,
 	}
-	k.SetParticipant(ctx, storedParticipant)
+	k.SetParticipant(ctx, storedParticipant, types.SetParticipantReasonNone)
 
 	activeParticipants := []*types.ActiveParticipant{
 		{Index: aliceAccAddrStr, Weight: 100},
@@ -326,7 +326,7 @@ func TestBLSKeyGenerationWithInvalidStoredWorkerKeyAndNoAccountKey(t *testing.T)
 		Weight:          100,
 		Status:          types.ParticipantStatus_ACTIVE,
 	}
-	k.SetParticipant(ctx, storedParticipantWithBadWKey)
+	k.SetParticipant(ctx, storedParticipantWithBadWKey, types.SetParticipantReasonNone)
 
 	registry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(registry)

--- a/inference-chain/x/inference/module/chainvalidation_test.go
+++ b/inference-chain/x/inference/module/chainvalidation_test.go
@@ -104,7 +104,7 @@ func TestComputeNewWeightsWithStakingValidators(t *testing.T) {
 		ValidatorKey: "validatorKey1",
 		InferenceUrl: "http://www.yahoo.com/",
 	}
-	err = k.SetParticipant(ctx, participant)
+	err = k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 	require.NoError(t, err)
 
 	// Set up random seed
@@ -384,7 +384,7 @@ func TestComputeNewWeights(t *testing.T) {
 					ValidatorKey: "validatorKey1",
 					InferenceUrl: "inferenceUrl1",
 				}
-				k.SetParticipant(ctx, participant)
+				k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 
 				// Set up random seed
 				seed := types.RandomSeed{
@@ -444,7 +444,7 @@ func TestComputeNewWeights(t *testing.T) {
 					ValidatorKey: "validatorKey1",
 					InferenceUrl: "inferenceUrl1",
 				}
-				k.SetParticipant(ctx, participant)
+				k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 
 				// Set up random seed
 				seed := types.RandomSeed{
@@ -515,7 +515,7 @@ func TestComputeNewWeights(t *testing.T) {
 					ValidatorKey: "validatorKey1",
 					InferenceUrl: "inferenceUrl1",
 				}
-				k.SetParticipant(ctx, participant)
+				k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 			},
 			expectedParticipants: 0, // Should be rejected due to not enough valid validations
 		},
@@ -702,13 +702,13 @@ func TestComputeNewWeights_AllowlistExcludesParticipant(t *testing.T) {
 		Address:      participantA,
 		ValidatorKey: "validatorKeyA",
 		InferenceUrl: "http://a.example.com/",
-	}))
+	}, types.SetParticipantReasonNone))
 	require.NoError(t, k.SetParticipant(ctx, types.Participant{
 		Index:        participantB,
 		Address:      participantB,
 		ValidatorKey: "validatorKeyB",
 		InferenceUrl: "http://b.example.com/",
-	}))
+	}, types.SetParticipantReasonNone))
 
 	// Set up seeds for both
 	k.SetRandomSeed(ctx, types.RandomSeed{Participant: participantA, EpochIndex: 1, Signature: "sigA"})

--- a/inference-chain/x/inference/module/chainvalidation_v1_test.go
+++ b/inference-chain/x/inference/module/chainvalidation_v1_test.go
@@ -97,7 +97,7 @@ func TestComputeNewWeightsV1WithStakingValidators(t *testing.T) {
 		ValidatorKey: "validatorKey1",
 		InferenceUrl: "http://www.yahoo.com/",
 	}
-	err = k.SetParticipant(ctx, participant)
+	err = k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 	require.NoError(t, err)
 
 	// Set up random seed
@@ -195,7 +195,7 @@ func TestComputeNewWeightsV1_FirstEpoch(t *testing.T) {
 		ValidatorKey: "validatorKey1",
 		InferenceUrl: "inferenceUrl1",
 	}
-	k.SetParticipant(ctx, participant)
+	k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 
 	// Set up random seed
 	seed := types.RandomSeed{
@@ -271,7 +271,7 @@ func TestComputeNewWeightsV1_NotEnoughValidations(t *testing.T) {
 		ValidatorKey: "validatorKey1",
 		InferenceUrl: "inferenceUrl1",
 	}
-	k.SetParticipant(ctx, participant)
+	k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 
 	// Set up random seed
 	seed := types.RandomSeed{
@@ -356,7 +356,7 @@ func TestComputeNewWeightsV1_FraudDetected(t *testing.T) {
 		ValidatorKey: "validatorKey1",
 		InferenceUrl: "inferenceUrl1",
 	}
-	k.SetParticipant(ctx, participant)
+	k.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 
 	upcomingEpoch := types.Epoch{
 		Index:               2,
@@ -442,13 +442,13 @@ func TestComputeNewWeightsV1_AllowlistExclusion(t *testing.T) {
 		Address:      participantA,
 		ValidatorKey: "validatorKeyA",
 		InferenceUrl: "http://a.example.com/",
-	}))
+	}, types.SetParticipantReasonNone))
 	require.NoError(t, k.SetParticipant(ctx, types.Participant{
 		Index:        participantB,
 		Address:      participantB,
 		ValidatorKey: "validatorKeyB",
 		InferenceUrl: "http://b.example.com/",
-	}))
+	}, types.SetParticipantReasonNone))
 
 	// Set up seeds for both
 	k.SetRandomSeed(ctx, types.RandomSeed{Participant: participantA, EpochIndex: 1, Signature: "sigA"})

--- a/inference-chain/x/inference/module/confirmation_poc.go
+++ b/inference-chain/x/inference/module/confirmation_poc.go
@@ -637,7 +637,7 @@ func (am AppModule) checkConfirmationSlashing(
 			ratio = decimal.Min(ratio.Div(pocDeviationCoeff), decimal.NewFromInt(1))
 			participant.CurrentEpochStats.ConfirmationPoCRatio = types.DecimalFromDecimal(ratio)
 		}
-		am.keeper.SetParticipant(ctx, participant)
+		am.keeper.SetParticipant(ctx, participant, types.SetParticipantReasonConfirmationPoC)
 	}
 	return nil
 }

--- a/inference-chain/x/inference/module/confirmation_poc_v1_test.go
+++ b/inference-chain/x/inference/module/confirmation_poc_v1_test.go
@@ -54,13 +54,13 @@ func TestUpdateConfirmationWeightsV1_BasicCalculation(t *testing.T) {
 	}
 	k.SetPoCValidation(ctx, validation)
 
-	// Create participant
+	// Create participant (PoC test)
 	require.NoError(t, k.SetParticipant(ctx, types.Participant{
 		Index:        testutil.Executor,
 		Address:      testutil.Executor,
 		ValidatorKey: "validatorKey",
 		InferenceUrl: "http://example.com/",
-	}))
+	}, types.SetParticipantReasonConfirmationPoC))
 
 	// Create seed
 	k.SetRandomSeed(ctx, types.RandomSeed{
@@ -193,17 +193,17 @@ func TestUpdateConfirmationWeightsV1_MultipleParticipants(t *testing.T) {
 		FraudDetected:               false,
 	})
 
-	// Create participants
+	// Create participants (PoC test)
 	require.NoError(t, k.SetParticipant(ctx, types.Participant{
 		Index:        testutil.Executor,
 		Address:      testutil.Executor,
 		ValidatorKey: "validatorKey1",
-	}))
+	}, types.SetParticipantReasonConfirmationPoC))
 	require.NoError(t, k.SetParticipant(ctx, types.Participant{
 		Index:        testutil.Executor2,
 		Address:      testutil.Executor2,
 		ValidatorKey: "validatorKey2",
-	}))
+	}, types.SetParticipantReasonConfirmationPoC))
 
 	// Create seeds
 	k.SetRandomSeed(ctx, types.RandomSeed{Participant: testutil.Executor, EpochIndex: 2, Signature: "sig1"})
@@ -285,12 +285,12 @@ func TestUpdateConfirmationWeightsV1_FraudRejection(t *testing.T) {
 		FraudDetected:               true, // Fraud detected by majority
 	})
 
-	// Create participant
+	// Create participant (PoC test)
 	require.NoError(t, k.SetParticipant(ctx, types.Participant{
 		Index:        testutil.Executor,
 		Address:      testutil.Executor,
 		ValidatorKey: "validatorKey",
-	}))
+	}, types.SetParticipantReasonConfirmationPoC))
 
 	// Create seed
 	k.SetRandomSeed(ctx, types.RandomSeed{Participant: testutil.Executor, EpochIndex: 2, Signature: "sig"})

--- a/inference-chain/x/inference/module/genesis.go
+++ b/inference-chain/x/inference/module/genesis.go
@@ -57,7 +57,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 
 	// Import participants provided in genesis
 	for _, p := range genState.ParticipantList {
-		err := k.SetParticipant(ctx, p)
+		err := k.SetParticipant(ctx, p, types.SetParticipantReasonNone)
 		if err != nil {
 			k.LogWarn("Error importing participant", types.System, "error", err, "participant", p)
 		}

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -301,7 +301,7 @@ func (am AppModule) handleExpiredInferenceWithContext(ctx context.Context, infer
 	inference = am.expireInferenceAndIssueRefund(ctx, inference)
 
 	executor.CurrentEpochStats.MissedRequests++
-	err := am.keeper.SetParticipant(ctx, executor)
+	err := am.keeper.SetParticipant(ctx, executor, types.SetParticipantReasonMissedInference)
 	if err != nil {
 		am.LogError("Error updating participant for expired inference", types.Participants, "error", err)
 	}
@@ -861,7 +861,7 @@ func (am AppModule) moveUpcomingToEffectiveGroup(ctx context.Context, blockHeigh
 	am.LogInfo("Setting participants to active", types.EpochGroup, "len(participants)", len(participants))
 	for _, participant := range participants {
 		participant.Status = types.ParticipantStatus_ACTIVE
-		err := am.keeper.SetParticipant(ctx, participant)
+		err := am.keeper.SetParticipant(ctx, participant, types.SetParticipantReasonNone)
 		if err != nil {
 			am.LogError("Unable to set participant to active", types.EpochGroup, "participantIndex", participant.Index, "error", err.Error())
 			continue

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -174,6 +174,9 @@ func (AppModule) ConsensusVersion() uint64 { return 12 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 func (am AppModule) BeginBlock(ctx context.Context) error {
+	// Per-block params cache: clear so GetParams returns params at block start for the rest of the block.
+	am.keeper.InvalidateParamsBlockCache()
+
 	// Update dynamic pricing for all models at the start of each block
 	// This ensures consistent pricing for all inferences processed in this block
 	err := am.keeper.UpdateDynamicPricing(ctx)

--- a/inference-chain/x/inference/types/expected_keepers.go
+++ b/inference-chain/x/inference/types/expected_keepers.go
@@ -91,7 +91,7 @@ type StreamVestingKeeper interface {
 
 type ParticipantKeeper interface {
 	GetParticipant(ctx context.Context, index string) (val Participant, found bool)
-	SetParticipant(ctx context.Context, participant Participant) error
+	SetParticipant(ctx context.Context, participant Participant, reason SetParticipantReason) error
 	RemoveParticipant(ctx context.Context, index string)
 	GetAllParticipant(ctx context.Context) []Participant
 	ParticipantAll(ctx context.Context, req *QueryAllParticipantRequest) (*QueryAllParticipantResponse, error)

--- a/inference-chain/x/inference/types/types.go
+++ b/inference-chain/x/inference/types/types.go
@@ -1,1 +1,13 @@
 package types
+
+// SetParticipantReason indicates why SetParticipant was called.
+// Use SetParticipantReasonNone for validation/finish/start/epoch/genesis — skip status computation, only ensure CurrentEpochStats is set.
+// Use a specific reason to run only the corresponding status check(s).
+type SetParticipantReason int
+
+const (
+	SetParticipantReasonNone SetParticipantReason = iota
+	SetParticipantReasonMissedInference
+	SetParticipantReasonInvalidation
+	SetParticipantReasonConfirmationPoC
+)

--- a/inference-chain/x/inference/types/types.go
+++ b/inference-chain/x/inference/types/types.go
@@ -7,6 +7,7 @@ type SetParticipantReason int
 
 const (
 	SetParticipantReasonNone SetParticipantReason = iota
+	SetParticipantReasonCompletedInference
 	SetParticipantReasonMissedInference
 	SetParticipantReasonInvalidation
 	SetParticipantReasonConfirmationPoC


### PR DESCRIPTION
[Issue 783](https://github.com/gonka-ai/gonka/issues/783)

Implemented caches for Ln calculations for ComputeStats. As we are using values from params that do not change often we could calculate Decimal.Ln once and cache it.

Added reason parameter to SetParticipant to know where it was called from to shorten `ComputeStats`:
- SetParticipantReasonCompletedInference => CheckInactive
- SetParticipantReasonMissedInference => CheckInactive
- SetParticipantReasonInvalidation => CheckConsecutiveFailures | CheckInvalidation
- SetParticipantReasonConfirmationPoC => CheckConfirmationPoC

Now we don't run all possible status computations on each participant set, but only related to update operation.

Added 2 modes for GetParams caching:
- tx caching using AnteDecorator and PostHandler (enabled when env var INFERENCE_PARAMS_CACHE_MODE = 'tx')
- per block params caching (by default)