### PR TITLE
fix: add VALIDATED/VOTING status guards in validation handler

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -74,6 +74,14 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		k.LogInfo("Inference already invalidated", types.Validation, "inference", inference)
 		return &types.MsgValidationResponse{}, nil
 	}
+	if inference.Status == types.InferenceStatus_VALIDATED {
+		k.LogInfo("Inference already validated, skipping", types.Validation, "inferenceId", inference.InferenceId)
+		return &types.MsgValidationResponse{}, nil
+	}
+	if !msg.Revalidation && inference.Status == types.InferenceStatus_VOTING {
+		k.LogInfo("Inference already in voting, skipping", types.Validation, "inferenceId", inference.InferenceId)
+		return &types.MsgValidationResponse{}, nil
+	}
 	if inference.Status == types.InferenceStatus_STARTED {
 		k.LogError("Inference not finished", types.Validation, "status", inference.Status, "inference", inference)
 		return nil, types.ErrInferenceNotFinished

--- a/inference-chain/x/inference/keeper/validation_accounting_test.go
+++ b/inference-chain/x/inference/keeper/validation_accounting_test.go
@@ -1,0 +1,98 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/testutil"
+	"github.com/productscience/inference/x/inference/calculations"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// TestValidationStatusGuard_PreventsDoubleShareWork verifies that once an inference
+// is VALIDATED by one validator, a second validator calling Validation is rejected.
+// Without the status guard, the second validator could overwrite VALIDATED to VOTING,
+// leaving the shareWorkWithValidators redistribution irreversible if voting resolves
+// to INVALIDATED — causing the executor to lose more than ActualCost.
+func TestValidationStatusGuard_PreventsDoubleShareWork(t *testing.T) {
+	inferenceHelper, k, ctx := NewMockInferenceHelper(t)
+	createParticipants(t, inferenceHelper.MessageServer, ctx)
+
+	model := &types.Model{Id: MODEL_ID, ValidationThreshold: &types.Decimal{Value: 85, Exponent: -2}}
+	k.SetModel(ctx, model)
+	StubModelSubgroup(t, ctx, k, inferenceHelper.Mocks, model)
+	addMembersToGroupData(k, ctx)
+
+	// Full inference lifecycle: Start -> Finish
+	expected, err := inferenceHelper.StartInference("promptPayload", model.Id, time.Now().UnixNano(), calculations.DefaultMaxTokens)
+	require.NoError(t, err)
+	_, err = inferenceHelper.FinishInference()
+	require.NoError(t, err)
+	buildValidationCacheForTest(t, k, ctx)
+
+	// Record executor CoinBalance after FinishInference
+	executorBefore, found := k.GetParticipant(ctx, testutil.Executor)
+	require.True(t, found)
+	initialExecutorBalance := executorBefore.CoinBalance
+	t.Logf("Executor CoinBalance after FinishInference: %d", initialExecutorBalance)
+
+	inference, found := k.GetInference(ctx, expected.InferenceId)
+	require.True(t, found)
+	actualCost := inference.ActualCost
+	require.Greater(t, actualCost, int64(0))
+
+	validatorBefore, found := k.GetParticipant(ctx, testutil.Validator)
+	require.True(t, found)
+	initialValidatorBalance := validatorBefore.CoinBalance
+
+	// === STEP 1: Validator passes the inference ===
+	// shareWorkWithValidators runs, redistributing CoinBalance
+	_, err = inferenceHelper.MessageServer.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Validator,
+		ValueDecimal: types.DecimalFromFloat(0.9999),
+	})
+	require.NoError(t, err)
+
+	inf, found := k.GetInference(ctx, expected.InferenceId)
+	require.True(t, found)
+	require.Equal(t, types.InferenceStatus_VALIDATED, inf.Status)
+
+	executorAfterShare, _ := k.GetParticipant(ctx, testutil.Executor)
+	validatorAfterShare, _ := k.GetParticipant(ctx, testutil.Validator)
+
+	shareDeducted := initialExecutorBalance - executorAfterShare.CoinBalance
+	shareGiven := validatorAfterShare.CoinBalance - initialValidatorBalance
+	t.Logf("After validation pass: executor lost %d, validator gained %d via shareWork", shareDeducted, shareGiven)
+	require.Greater(t, shareGiven, int64(0))
+
+	// === STEP 2: Second validator tries to fail the same inference ===
+	// With the status guard, this should be rejected (no-op return)
+	// Without the guard, it would overwrite VALIDATED→VOTING
+	resp, err := inferenceHelper.MessageServer.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Requester,
+		ValueDecimal: types.DecimalFromFloat(0.50), // fails threshold
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Status should still be VALIDATED, NOT overwritten to VOTING
+	inf, found = k.GetInference(ctx, expected.InferenceId)
+	require.True(t, found)
+	require.Equal(t, types.InferenceStatus_VALIDATED, inf.Status,
+		"Status guard should prevent overwriting VALIDATED to VOTING")
+
+	// Executor and validator balances should be unchanged from after shareWork
+	executorFinal, _ := k.GetParticipant(ctx, testutil.Executor)
+	validatorFinal, _ := k.GetParticipant(ctx, testutil.Validator)
+
+	require.Equal(t, executorAfterShare.CoinBalance, executorFinal.CoinBalance,
+		"Executor CoinBalance should not change — second validation was rejected")
+	require.Equal(t, validatorAfterShare.CoinBalance, validatorFinal.CoinBalance,
+		"Validator CoinBalance should not change — second validation was rejected")
+
+	t.Logf("Status guard working: second validation correctly rejected, no accounting damage")
+}


### PR DESCRIPTION
the validation handler at `msg_server_validation.go` only guards against INVALIDATED and STARTED statuses. nothing stops a second validator from processing an inference that's already VALIDATED or in VOTING. 
when that happens, shareWorkWithValidators has already redistributed CoinBalance — and if the second validator's failure triggers a vote that resolves to invalidation, the executor gets hit twice: 
once from shareWork,
once from the full ActualCost deduction in InvalidateInference.

concrete sequence:
inference finishes, executor gets CoinBalance = 30000 (ActualCost).
validator A passes it, shareWork splits the balance — executor drops to 15000, validator A gets 15000.
validator B fails the same inference, no guard blocks it, overwrites status from VALIDATED to VOTING.
voting resolves INVALIDATED, refundInvalidatedInference deducts full ActualCost (30000) from executor.
executor ends at -15000, lost 45000 instead of 30000. validator A keeps 15000 they shouldn't have.
this isn't a forced edge case — it happens naturally whenever two validators disagree on the same inference within the same epoch (one passes threshold, the other doesn't). 
the negative CoinBalance becomes debt at settlement since WorkCoins = CoinBalance, so the executor also loses rewards earned from completely unrelated inferences.

added status guards for VALIDATED and VOTING after the existing INVALIDATED guard. revalidation calls (from group voting) are exempted since they need to process on VOTING-status inferences — the guard only blocks first-time validation attempts on already-decided inferences.

test in `validation_accounting_test.go` confirms the guard correctly rejects the second validation and prevents the accounting mismatch.