### PR TITLE
fix(inference): diagnostic logging and events for missed inference (#820)

### DIFF
--- a/inference-chain/x/inference/keeper/inference_diagnostics.go
+++ b/inference-chain/x/inference/keeper/inference_diagnostics.go
@@ -1,0 +1,130 @@
+package keeper
+
+import (
+	"context"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// ExecutorMissStats tracks missed inference counts per executor for diagnostics.
+type ExecutorMissStats struct {
+	Address        string
+	MissedRequests uint64
+	InferenceCount uint64
+}
+
+// LogInferenceHealthSummary logs a periodic health summary of the inference system.
+// Called from EndBlock at configurable intervals to help operators monitor inference health.
+func (k Keeper) LogInferenceHealthSummary(ctx context.Context, blockHeight int64) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	// Only log every 100 blocks to avoid log spam
+	if blockHeight%100 != 0 {
+		return
+	}
+
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("InferenceHealthSummary: failed to get params", types.Inferences, "error", err)
+		return
+	}
+
+	effectiveEpoch, found := k.GetEffectiveEpoch(ctx)
+	if !found || effectiveEpoch == nil {
+		return
+	}
+
+	// Count pending inference timeouts (inferences waiting to expire)
+	allTimeouts := k.GetAllInferenceTimeout(ctx)
+	pendingCount := 0
+	for _, t := range allTimeouts {
+		if t.ExpirationHeight > uint64(blockHeight) {
+			pendingCount++
+		}
+	}
+
+	// Get participant miss stats from current epoch group
+	currentEpochGroup, err := k.GetEpochGroupForEpoch(ctx, *effectiveEpoch)
+	if err != nil {
+		k.LogError("InferenceHealthSummary: failed to get epoch group", types.Inferences, "error", err)
+		return
+	}
+
+	activeCount := 0
+	if currentEpochGroup.GroupData != nil {
+		activeCount = len(currentEpochGroup.GroupData.ValidationWeights)
+	}
+
+	// Find executors with highest missed request counts this epoch
+	topMissed := k.getTopMissedExecutors(ctx, currentEpochGroup.GroupData, 5)
+
+	k.LogInfo("InferenceHealthSummary", types.Inferences,
+		"blockHeight", blockHeight,
+		"blockTime", sdkCtx.BlockTime().UTC().String(),
+		"epochIndex", effectiveEpoch.Index,
+		"pendingInferenceTimeouts", pendingCount,
+		"totalTimeoutsInStore", len(allTimeouts),
+		"activeParticipants", activeCount,
+		"expirationBlocks", params.ValidationParams.ExpirationBlocks,
+		"topMissedExecutors", formatMissedExecutors(topMissed))
+}
+
+// getTopMissedExecutors returns the top N executors by missed request count in the current epoch.
+func (k Keeper) getTopMissedExecutors(ctx context.Context, groupData *types.EpochGroupData, limit int) []ExecutorMissStats {
+	if groupData == nil {
+		return nil
+	}
+
+	var stats []ExecutorMissStats
+	for _, weight := range groupData.ValidationWeights {
+		participant, found := k.GetParticipant(ctx, weight.MemberAddress)
+		if !found {
+			continue
+		}
+		if participant.CurrentEpochStats.MissedRequests > 0 {
+			stats = append(stats, ExecutorMissStats{
+				Address:        weight.MemberAddress,
+				MissedRequests: participant.CurrentEpochStats.MissedRequests,
+				InferenceCount: participant.CurrentEpochStats.InferenceCount,
+			})
+		}
+	}
+
+	// Sort by missed requests descending (simple insertion sort for small N)
+	for i := 1; i < len(stats); i++ {
+		j := i
+		for j > 0 && stats[j].MissedRequests > stats[j-1].MissedRequests {
+			stats[j], stats[j-1] = stats[j-1], stats[j]
+			j--
+		}
+	}
+
+	if len(stats) > limit {
+		stats = stats[:limit]
+	}
+
+	return stats
+}
+
+func formatMissedExecutors(stats []ExecutorMissStats) string {
+	if len(stats) == 0 {
+		return "none"
+	}
+	result := ""
+	for i, s := range stats {
+		if i > 0 {
+			result += "; "
+		}
+		result += fmt.Sprintf("%s(missed=%d,total=%d)", truncateAddress(s.Address), s.MissedRequests, s.InferenceCount)
+	}
+	return result
+}
+
+func truncateAddress(addr string) string {
+	if len(addr) <= 20 {
+		return addr
+	}
+	return addr[:10] + "..." + addr[len(addr)-6:]
+}

--- a/inference-chain/x/inference/keeper/inference_diagnostics_test.go
+++ b/inference-chain/x/inference/keeper/inference_diagnostics_test.go
@@ -1,0 +1,76 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatMissedExecutors_Empty(t *testing.T) {
+	result := formatMissedExecutors(nil)
+	assert.Equal(t, "none", result)
+
+	result = formatMissedExecutors([]ExecutorMissStats{})
+	assert.Equal(t, "none", result)
+}
+
+func TestFormatMissedExecutors_SingleEntry(t *testing.T) {
+	stats := []ExecutorMissStats{
+		{Address: "gonka1abc123def456ghi789jkl012mno345pqr678stu", MissedRequests: 5, InferenceCount: 100},
+	}
+	result := formatMissedExecutors(stats)
+	assert.Contains(t, result, "missed=5")
+	assert.Contains(t, result, "total=100")
+}
+
+func TestFormatMissedExecutors_MultipleEntries(t *testing.T) {
+	stats := []ExecutorMissStats{
+		{Address: "gonka1abc123def456ghi789jkl012mno345pqr678stu", MissedRequests: 10, InferenceCount: 200},
+		{Address: "gonka1xyz789uvw456rst123opq012mnl345ijk678ghi", MissedRequests: 3, InferenceCount: 50},
+	}
+	result := formatMissedExecutors(stats)
+	assert.Contains(t, result, ";")
+	assert.Contains(t, result, "missed=10")
+	assert.Contains(t, result, "missed=3")
+}
+
+func TestTruncateAddress(t *testing.T) {
+	// Short address stays as-is
+	short := "short"
+	assert.Equal(t, "short", truncateAddress(short))
+
+	// Long address is truncated
+	long := "gonka1abc123def456ghi789jkl012mno345pqr678stu"
+	result := truncateAddress(long)
+	assert.True(t, len(result) < len(long), "truncated address should be shorter")
+	assert.Contains(t, result, "...")
+	assert.Equal(t, long[:10], result[:10])
+}
+
+func TestGetTopMissedExecutors_NilGroupData(t *testing.T) {
+	k := Keeper{}
+	result := k.getTopMissedExecutors(nil, nil, 5)
+	assert.Nil(t, result)
+}
+
+func TestGetTopMissedExecutors_Sorting(t *testing.T) {
+	// Test the sorting logic directly with the helper
+	stats := []ExecutorMissStats{
+		{Address: "addr1", MissedRequests: 1, InferenceCount: 10},
+		{Address: "addr2", MissedRequests: 5, InferenceCount: 20},
+		{Address: "addr3", MissedRequests: 3, InferenceCount: 15},
+	}
+
+	// Sort by missed requests descending (replicating the sort logic)
+	for i := 1; i < len(stats); i++ {
+		j := i
+		for j > 0 && stats[j].MissedRequests > stats[j-1].MissedRequests {
+			stats[j], stats[j-1] = stats[j-1], stats[j]
+			j--
+		}
+	}
+
+	assert.Equal(t, uint64(5), stats[0].MissedRequests)
+	assert.Equal(t, uint64(3), stats[1].MissedRequests)
+	assert.Equal(t, uint64(1), stats[2].MissedRequests)
+}

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -68,10 +68,31 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 	}
 
 	if found && existingInference.Status == types.InferenceStatus_EXPIRED {
-		k.LogWarn("FinishInference: cannot finish expired inference", types.Inferences,
+		// This is a key diagnostic signal: the inference was executed by the node but the
+		// FinishInference message arrived after the timeout expired. This could indicate:
+		// - The node was too slow to complete the inference
+		// - Network propagation delays caused the message to arrive late
+		// - The timeout duration (ExpirationBlocks) is too short for this model
+		blocksLate := ctx.BlockHeight() - int64(existingInference.StartBlockHeight)
+		k.LogWarn("FinishInference: late arrival for expired inference - node completed but message arrived after timeout",
+			types.Inferences,
 			"inferenceId", msg.InferenceId,
-			"currentStatus", existingInference.Status,
-			"executedBy", msg.ExecutedBy)
+			"executedBy", msg.ExecutedBy,
+			"assignedTo", existingInference.AssignedTo,
+			"model", existingInference.Model,
+			"startBlockHeight", existingInference.StartBlockHeight,
+			"currentBlockHeight", ctx.BlockHeight(),
+			"blocksElapsedSinceStart", blocksLate,
+			"requestedBy", existingInference.RequestedBy)
+
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent("inference_finish_late",
+				sdk.NewAttribute("inference_id", msg.InferenceId),
+				sdk.NewAttribute("executed_by", msg.ExecutedBy),
+				sdk.NewAttribute("model", existingInference.Model),
+			),
+		)
+
 		return failedFinish(ctx, sdkerrors.Wrap(types.ErrInferenceExpired, "inference has already expired"), msg), nil
 	}
 
@@ -122,7 +143,12 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 func failedFinish(ctx sdk.Context, err error, msg *types.MsgFinishInference) *types.MsgFinishInferenceResponse {
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent("finish_inference",
-			sdk.NewAttribute("result", "failed")))
+			sdk.NewAttribute("result", "failed"),
+			sdk.NewAttribute("inference_id", msg.InferenceId),
+			sdk.NewAttribute("executed_by", msg.ExecutedBy),
+			sdk.NewAttribute("model", msg.Model),
+			sdk.NewAttribute("error", err.Error()),
+		))
 	return &types.MsgFinishInferenceResponse{
 		InferenceIndex: msg.InferenceId,
 		ErrorMessage:   err.Error(),

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -14,7 +14,13 @@ import (
 
 func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInference) (*types.MsgStartInferenceResponse, error) {
 	var ctx sdk.Context = sdk.UnwrapSDKContext(goCtx)
-	k.LogInfo("StartInference", types.Inferences, "inferenceId", msg.InferenceId, "creator", msg.Creator, "requestedBy", msg.RequestedBy, "model", msg.Model)
+	k.LogInfo("StartInference", types.Inferences,
+		"inferenceId", msg.InferenceId,
+		"creator", msg.Creator,
+		"requestedBy", msg.RequestedBy,
+		"assignedTo", msg.AssignedTo,
+		"model", msg.Model,
+		"blockHeight", ctx.BlockHeight())
 
 	// Developer access gating: before the cutoff height, only allowlisted developers may request inferences.
 	if k.IsDeveloperAccessRestricted(ctx, ctx.BlockHeight()) && !k.IsAllowedDeveloper(ctx, msg.RequestedBy) {
@@ -96,6 +102,16 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 		}
 	}
 
+	// Emit structured event for inference lifecycle tracking
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent("inference_started",
+			sdk.NewAttribute("inference_id", msg.InferenceId),
+			sdk.NewAttribute("assigned_to", msg.AssignedTo),
+			sdk.NewAttribute("model", msg.Model),
+			sdk.NewAttribute("requested_by", msg.RequestedBy),
+		),
+	)
+
 	return &types.MsgStartInferenceResponse{
 		InferenceIndex: msg.InferenceId,
 	}, nil
@@ -104,7 +120,12 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 func failedStart(ctx sdk.Context, error error, message *types.MsgStartInference) *types.MsgStartInferenceResponse {
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent("start_inference",
-			sdk.NewAttribute("result", "failed")))
+			sdk.NewAttribute("result", "failed"),
+			sdk.NewAttribute("inference_id", message.InferenceId),
+			sdk.NewAttribute("assigned_to", message.AssignedTo),
+			sdk.NewAttribute("model", message.Model),
+			sdk.NewAttribute("error", error.Error()),
+		))
 	return &types.MsgStartInferenceResponse{
 		InferenceIndex: message.InferenceId,
 		ErrorMessage:   error.Error(),
@@ -174,7 +195,12 @@ func (k msgServer) validateTimestamp(
 func (k msgServer) addTimeout(ctx sdk.Context, inference *types.Inference) {
 	params, err := k.GetParams(ctx)
 	if err != nil {
-		k.LogError("Unable to get params for inference timeout", types.Inferences, "error", err)
+		k.LogError("Unable to get params for inference timeout - inference may hang without expiry",
+			types.Inferences,
+			"error", err,
+			"inferenceId", inference.InferenceId,
+			"assignedTo", inference.AssignedTo,
+			"model", inference.Model)
 		return
 	}
 	expirationBlocks := params.ValidationParams.ExpirationBlocks
@@ -185,13 +211,24 @@ func (k msgServer) addTimeout(ctx sdk.Context, inference *types.Inference) {
 	})
 
 	if err != nil {
-		// Not fatal, we try to continue
-		k.LogError("Unable to set inference timeout", types.Inferences, err)
+		// This is a critical issue: without a timeout, the inference could hang indefinitely
+		k.LogError("Unable to set inference timeout - inference may hang without expiry",
+			types.Inferences,
+			"error", err,
+			"inferenceId", inference.InferenceId,
+			"assignedTo", inference.AssignedTo,
+			"model", inference.Model,
+			"expirationHeight", expirationHeight)
+		return
 	}
 
-	k.LogInfo("Inference Timeout Set:", types.Inferences,
-		"InferenceId", inference.InferenceId,
-		"ExpirationHeight", inference.StartBlockHeight+expirationBlocks)
+	k.LogInfo("Inference timeout set", types.Inferences,
+		"inferenceId", inference.InferenceId,
+		"assignedTo", inference.AssignedTo,
+		"model", inference.Model,
+		"startBlockHeight", inference.StartBlockHeight,
+		"expirationHeight", expirationHeight,
+		"expirationBlocks", expirationBlocks)
 }
 
 func (k msgServer) processInferencePayments(

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -196,6 +196,11 @@ func (am AppModule) expireInferences(
 		return nil
 	}
 
+	am.LogInfo("Processing inference timeouts", types.Inferences,
+		"blockHeight", blockHeight,
+		"timeoutCount", len(timeouts),
+		"epochIndex", currentEpoch.Index)
+
 	// Create expiry context once for efficiency (reuse already-loaded params and epoch data)
 	expiryCtx, err := am.NewInferenceExpiryContextWithEpoch(ctx, blockHeight, currentEpoch, params)
 	if err != nil {
@@ -203,41 +208,95 @@ func (am AppModule) expireInferences(
 		return err
 	}
 
+	expiredCount := 0
+	alreadyFinishedCount := 0
+	notFoundCount := 0
+
 	for _, i := range timeouts {
 		inference, found := am.keeper.GetInference(ctx, i.InferenceId)
 		if !found {
+			notFoundCount++
+			am.LogWarn("Inference timeout triggered but inference not found in store", types.Inferences,
+				"inferenceId", i.InferenceId,
+				"expirationHeight", i.ExpirationHeight,
+				"blockHeight", blockHeight)
 			continue
 		}
 		if inference.Status == types.InferenceStatus_STARTED {
 			am.handleExpiredInferenceWithContext(ctx, inference, expiryCtx)
+			expiredCount++
+		} else {
+			alreadyFinishedCount++
+			am.LogDebug("Inference timeout triggered but inference already processed", types.Inferences,
+				"inferenceId", i.InferenceId,
+				"status", inference.Status.String(),
+				"assignedTo", inference.AssignedTo,
+				"blockHeight", blockHeight)
 		}
 	}
+
+	if expiredCount > 0 || notFoundCount > 0 {
+		am.LogInfo("Inference timeout processing complete", types.Inferences,
+			"blockHeight", blockHeight,
+			"totalTimeouts", len(timeouts),
+			"expired", expiredCount,
+			"alreadyFinished", alreadyFinishedCount,
+			"notFound", notFoundCount)
+	}
+
 	return nil
 }
 
 // expireInferenceAndIssueRefund marks an inference as expired and issues a refund
 // Returns the updated inference
 func (am AppModule) expireInferenceAndIssueRefund(ctx context.Context, inference types.Inference) types.Inference {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
 	inference.Status = types.InferenceStatus_EXPIRED
 	inference.ActualCost = 0
 
 	err := am.keeper.IssueRefund(ctx, inference.EscrowAmount, inference.RequestedBy, "expired_inference:"+inference.InferenceId)
 	if err != nil {
-		am.LogError("Error issuing refund", types.Inferences, "error", err)
+		am.LogError("Error issuing refund for expired inference", types.Inferences,
+			"error", err,
+			"inferenceId", inference.InferenceId,
+			"requestedBy", inference.RequestedBy,
+			"escrowAmount", inference.EscrowAmount)
 	}
 
 	err = am.keeper.SetInference(ctx, inference)
 	if err != nil {
-		am.LogError("Error updating inference", types.Inferences, "error", err)
+		am.LogError("Error updating expired inference", types.Inferences,
+			"error", err,
+			"inferenceId", inference.InferenceId)
 	}
+
+	// Emit event for inference expiry so operators and indexers can track missed inferences
+	sdkCtx.EventManager().EmitEvent(
+		sdk.NewEvent("inference_expired",
+			sdk.NewAttribute("inference_id", inference.InferenceId),
+			sdk.NewAttribute("assigned_to", inference.AssignedTo),
+			sdk.NewAttribute("model", inference.Model),
+			sdk.NewAttribute("requested_by", inference.RequestedBy),
+		),
+	)
 
 	return inference
 }
 
 func (am AppModule) handleExpiredInferenceWithContext(ctx context.Context, inference types.Inference, expiryCtx *InferenceExpiryContext) {
+	blocksElapsed := expiryCtx.CurrentBlockHeight - inference.StartBlockHeight
+
 	executor, found := am.keeper.GetParticipant(ctx, inference.AssignedTo)
 	if !found {
-		am.LogWarn("Unable to find participant for expired inference", types.Inferences, "inferenceId", inference.InferenceId, "executedBy", inference.ExecutedBy)
+		am.LogWarn("Unable to find participant for expired inference", types.Inferences,
+			"inferenceId", inference.InferenceId,
+			"assignedTo", inference.AssignedTo,
+			"model", inference.Model,
+			"startBlockHeight", inference.StartBlockHeight,
+			"blocksElapsed", blocksElapsed,
+			"reason", "executor_not_found")
+		am.expireInferenceAndIssueRefund(ctx, inference)
 		return
 	}
 
@@ -245,7 +304,13 @@ func (am AppModule) handleExpiredInferenceWithContext(ctx context.Context, infer
 	// This may lazy-load previous epoch data if the inference started before current epoch
 	epochToCheck := expiryCtx.GetEpochForInference(ctx, am.keeper, inference)
 	if epochToCheck == nil {
-		am.LogWarn("No epoch available for expired inference check", types.Inferences, "inferenceId", inference.InferenceId)
+		am.LogWarn("No epoch available for expired inference check", types.Inferences,
+			"inferenceId", inference.InferenceId,
+			"assignedTo", inference.AssignedTo,
+			"model", inference.Model,
+			"startBlockHeight", inference.StartBlockHeight,
+			"blocksElapsed", blocksElapsed,
+			"reason", "no_epoch_available")
 		am.expireInferenceAndIssueRefund(ctx, inference)
 		return
 	}
@@ -260,7 +325,13 @@ func (am AppModule) handleExpiredInferenceWithContext(ctx context.Context, infer
 
 	if activeParticipants == nil {
 		am.LogWarn("No active participants available for expired inference check", types.Inferences,
-			"inferenceId", inference.InferenceId, "epochIndex", epochToCheck.Index)
+			"inferenceId", inference.InferenceId,
+			"assignedTo", inference.AssignedTo,
+			"model", inference.Model,
+			"epochIndex", epochToCheck.Index,
+			"startBlockHeight", inference.StartBlockHeight,
+			"blocksElapsed", blocksElapsed,
+			"reason", "no_active_participants")
 		am.expireInferenceAndIssueRefund(ctx, inference)
 		return
 	}
@@ -274,16 +345,19 @@ func (am AppModule) handleExpiredInferenceWithContext(ctx context.Context, infer
 	if !hasNode {
 		nodeType := "mlnode"
 		if checkPreserveNode {
-			nodeType = "preserve node"
+			nodeType = "preserve_node"
 		}
 		am.LogWarn("Executor doesn't have required node for expired inference, skipping penalty",
 			types.Inferences,
 			"inferenceId", inference.InferenceId,
-			"executor", inference.AssignedTo,
+			"assignedTo", inference.AssignedTo,
 			"model", inference.Model,
 			"nodeType", nodeType,
 			"epochIndex", epochToCheck.Index,
-			"inPoCRange", expiryCtx.IsBlockInPoCRange(inference.StartBlockHeight) || expiryCtx.IsBlockInPoCRange(expiryCtx.CurrentBlockHeight))
+			"startBlockHeight", inference.StartBlockHeight,
+			"blocksElapsed", blocksElapsed,
+			"inPoCRange", expiryCtx.IsBlockInPoCRange(inference.StartBlockHeight) || expiryCtx.IsBlockInPoCRange(expiryCtx.CurrentBlockHeight),
+			"reason", "executor_missing_node")
 
 		// Still issue refund and mark as expired, but don't penalize executor
 		am.expireInferenceAndIssueRefund(ctx, inference)
@@ -291,19 +365,26 @@ func (am AppModule) handleExpiredInferenceWithContext(ctx context.Context, infer
 	}
 
 	// Executor has the required node, proceed with normal expiry handling (with penalty)
-	am.LogInfo("Inference expired, not finished. Issuing refund and penalizing executor",
+	am.LogWarn("Inference expired with penalty: executor had node but did not finish in time",
 		types.Inferences,
 		"inferenceId", inference.InferenceId,
-		"executor", inference.AssignedTo,
+		"assignedTo", inference.AssignedTo,
 		"model", inference.Model,
-		"epochIndex", epochToCheck.Index)
+		"epochIndex", epochToCheck.Index,
+		"startBlockHeight", inference.StartBlockHeight,
+		"blocksElapsed", blocksElapsed,
+		"missedRequestsBefore", executor.CurrentEpochStats.MissedRequests,
+		"reason", "executor_timeout")
 
 	inference = am.expireInferenceAndIssueRefund(ctx, inference)
 
 	executor.CurrentEpochStats.MissedRequests++
 	err := am.keeper.SetParticipant(ctx, executor)
 	if err != nil {
-		am.LogError("Error updating participant for expired inference", types.Participants, "error", err)
+		am.LogError("Error updating participant for expired inference", types.Participants,
+			"error", err,
+			"inferenceId", inference.InferenceId,
+			"assignedTo", inference.AssignedTo)
 	}
 }
 
@@ -346,11 +427,17 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	timeouts := am.keeper.GetAllInferenceTimeoutForHeight(ctx, uint64(blockHeight))
 	err = am.expireInferences(ctx, timeouts, blockHeight, currentEpoch, &params)
 	if err != nil {
-		am.LogError("Error expiring inferences", types.Inferences)
+		am.LogError("Error expiring inferences", types.Inferences,
+			"error", err,
+			"blockHeight", blockHeight,
+			"timeoutCount", len(timeouts))
 	}
 	for _, t := range timeouts {
 		am.keeper.RemoveInferenceTimeout(ctx, t.ExpirationHeight, t.InferenceId)
 	}
+
+	// Periodic inference health summary for operator diagnostics
+	am.keeper.LogInferenceHealthSummary(ctx, blockHeight)
 
 	err = am.keeper.Prune(ctx, int64(currentEpoch.Index))
 	if err != nil {


### PR DESCRIPTION
## Summary

Investigates and mitigates missed inference events on nodes (Closes #820).

**Root causes identified:**
- Silent expiry when executor not found - inference stayed in STARTED state forever
- No events emitted for inference expiry - operators had no visibility
- Late FinishInference arrivals were poorly logged - couldn't distinguish slow nodes vs network issues
- Timeout setup failures not clearly flagged - inference could hang without expiry
- Missing error context in expiry error logs

**Mitigations implemented:**
- Added `inference_expired` event with inference_id, assigned_to, model, requested_by for indexer tracking
- Added `inference_finish_late` event when FinishInference arrives after timeout - key signal for slow nodes vs short timeouts
- Added `inference_started` event for complete lifecycle tracking
- Fixed silent failure: expire inference with refund when executor participant not found
- Enhanced all failure events (`start_inference`, `finish_inference`) with inference_id, model, error details
- Added periodic `InferenceHealthSummary` log (every 100 blocks) showing pending timeouts, active participants, and top executors by missed request count
- Improved structured logging with consistent fields: inferenceId, assignedTo, model, blocksElapsed, reason codes
- Clear ERROR-level warnings when timeout cannot be set ("inference may hang without expiry")

**Files changed:**
- `inference-chain/x/inference/keeper/msg_server_start_inference.go` - enriched logging, improved addTimeout error handling, added inference_started event
- `inference-chain/x/inference/keeper/msg_server_finish_inference.go` - diagnostic logging for late arrivals, enriched failure events
- `inference-chain/x/inference/module/module.go` - expiry tracking with counters, inference_expired events, fixed silent executor-not-found bug
- `inference-chain/x/inference/keeper/inference_diagnostics.go` - new periodic health summary with top missed executors
- `inference-chain/x/inference/keeper/inference_diagnostics_test.go` - unit tests for diagnostic helpers

## Test plan

- [x] All existing inference keeper tests pass
- [x] All existing inference module tests pass  
- [x] All existing calculation tests pass
- [x] New diagnostic helper tests pass
- [x] Full `go build ./...` succeeds
- [ ] Verify events appear in block results on testnet
- [ ] Verify InferenceHealthSummary appears in node logs every 100 blocks
- [ ] Monitor `inference_expired` and `inference_finish_late` events to correlate with operator reports