### PR TITLE
feat(inference): add continuous PoC foundation

### DIFF
--- a/inference-chain/proto/inference/inference/continuous_poc.proto
+++ b/inference-chain/proto/inference/inference/continuous_poc.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+package inference.inference;
+
+option go_package = "github.com/productscience/inference/x/inference/types";
+
+// ContinuousPoCCommit represents a lightweight on-chain record of continuous PoC work.
+// Participants submit these commits periodically while inference-serving to prove
+// that unused GPU capacity is being utilized for PoC nonce generation.
+// The actual artifacts are stored locally; only the commit (count + root hash) goes on-chain.
+message ContinuousPoCCommit {
+  // participant_address is the bech32 address of the participant submitting PoC work.
+  string participant_address = 1;
+
+  // epoch_index is the epoch during which this continuous PoC work was performed.
+  uint64 epoch_index = 2;
+
+  // nonce_count is the total number of PoC nonces generated in this commit window.
+  uint32 nonce_count = 3;
+
+  // root_hash is the Merkle root of the locally-stored PoC artifacts (32 bytes).
+  bytes root_hash = 4;
+
+  // inference_count is the number of inferences served during this commit window.
+  // Used to calculate the effective utilization and weight the PoC contribution.
+  uint32 inference_count = 5;
+
+  // commit_block_height is the block height when this commit was recorded on-chain.
+  int64 commit_block_height = 6;
+
+  // gpu_utilization is the self-reported GPU utilization fraction [0, 10000] (basis points).
+  // 0 = fully idle (all capacity for PoC), 10000 = fully utilized by inference.
+  uint32 gpu_utilization_bps = 7;
+}
+
+// ContinuousPoCEpochSummary aggregates a participant's continuous PoC commits for an epoch.
+// Updated on-chain as commits arrive; used during epoch settlement for weight calculation.
+message ContinuousPoCEpochSummary {
+  // participant_address is the bech32 address of the participant.
+  string participant_address = 1;
+
+  // epoch_index is the epoch this summary covers.
+  uint64 epoch_index = 2;
+
+  // total_nonces is the cumulative nonce count across all commits in this epoch.
+  uint64 total_nonces = 3;
+
+  // total_inferences is the cumulative inference count across all commits in this epoch.
+  uint64 total_inferences = 4;
+
+  // commit_count is the number of individual commits submitted during this epoch.
+  uint32 commit_count = 5;
+
+  // last_commit_height is the block height of the most recent commit.
+  int64 last_commit_height = 6;
+
+  // effective_poc_weight is the calculated PoC weight from continuous work,
+  // normalized by the nonce_weight parameter. Updated on each commit.
+  int64 effective_poc_weight = 7;
+}

--- a/inference-chain/proto/inference/inference/params.proto
+++ b/inference-chain/proto/inference/inference/params.proto
@@ -24,6 +24,7 @@ message Params {
   DeveloperAccessParams developer_access_params = 11;
   ParticipantAccessParams participant_access_params = 12;
   TransferAgentAccessParams transfer_agent_access_params = 13;
+  ContinuousPoCParams continuous_poc_params = 14;
 }
 
 message GenesisOnlyParams {
@@ -324,4 +325,17 @@ message TransferAgentAccessParams {
   // allowed_transfer_addresses are bech32 account addresses allowed to act as Transfer Agents.
   // If empty, all TAs are allowed.
   repeated string allowed_transfer_addresses = 1;
+}
+
+// ContinuousPoCParams defines parameters for the continuous PoC feature.
+// When enabled, GPU nodes generate PoC nonces in parallel with inference,
+// utilizing spare capacity to prove computational readiness.
+message ContinuousPoCParams {
+  option (gogoproto.equal) = true;
+  bool enable_continuous_poc = 1;
+  uint32 poc_utilization_target_bps = 2;
+  uint32 nonce_weight = 3;
+  uint32 max_commits_per_epoch = 4;
+  uint32 min_nonces_per_commit = 5;
+  uint32 validation_sample_rate_bps = 6;
 }

--- a/inference-chain/proto/inference/inference/query.proto
+++ b/inference-chain/proto/inference/inference/query.proto
@@ -36,6 +36,7 @@ import "inference/inference/liquidity_pool.proto";
 import "inference/inference/poc_v2.proto";
 import "inference/inference/random_seed.proto";
 import "inference/inference/poc_validation_snapshot.proto";
+import "inference/inference/continuous_poc.proto";
 
 option go_package = "github.com/productscience/inference/x/inference/types";
 
@@ -484,6 +485,16 @@ service Query {
   // Queries PoC validation snapshot for deterministic sampling synchronization.
   rpc PoCValidationSnapshot (QueryPoCValidationSnapshotRequest) returns (QueryPoCValidationSnapshotResponse) {
     option (google.api.http).get = "/productscience/inference/inference/poc_validation_snapshot/{poc_stage_start_height}";
+  }
+
+  // Queries the continuous PoC epoch summary for a participant in a given epoch.
+  rpc ContinuousPoCEpochSummary (QueryContinuousPoCEpochSummaryRequest) returns (QueryContinuousPoCEpochSummaryResponse) {
+    option (google.api.http).get = "/productscience/inference/inference/continuous_poc_epoch_summary/{epoch_index}/{participant_address}";
+  }
+
+  // Queries all continuous PoC epoch summaries for a given epoch.
+  rpc AllContinuousPoCEpochSummaries (QueryAllContinuousPoCEpochSummariesRequest) returns (QueryAllContinuousPoCEpochSummariesResponse) {
+    option (google.api.http).get = "/productscience/inference/inference/continuous_poc_epoch_summaries/{epoch_index}";
   }
 }
 // QueryParamsRequest is request type for the Query/Params RPC method.
@@ -1272,4 +1283,26 @@ message QueryPoCValidationSnapshotRequest {
 message QueryPoCValidationSnapshotResponse {
   PoCValidationSnapshot snapshot = 1;
   bool found = 2;
+}
+
+// QueryContinuousPoCEpochSummaryRequest requests the continuous PoC summary for a participant in an epoch.
+message QueryContinuousPoCEpochSummaryRequest {
+  uint64 epoch_index = 1;
+  string participant_address = 2;
+}
+
+// QueryContinuousPoCEpochSummaryResponse returns the continuous PoC epoch summary.
+message QueryContinuousPoCEpochSummaryResponse {
+  ContinuousPoCEpochSummary summary = 1;
+  bool found = 2;
+}
+
+// QueryAllContinuousPoCEpochSummariesRequest requests all continuous PoC summaries for an epoch.
+message QueryAllContinuousPoCEpochSummariesRequest {
+  uint64 epoch_index = 1;
+}
+
+// QueryAllContinuousPoCEpochSummariesResponse returns all continuous PoC epoch summaries.
+message QueryAllContinuousPoCEpochSummariesResponse {
+  repeated ContinuousPoCEpochSummary summaries = 1;
 }

--- a/inference-chain/proto/inference/inference/tx.proto
+++ b/inference-chain/proto/inference/inference/tx.proto
@@ -13,6 +13,7 @@ import "inference/inference/hardware_node.proto";
 import "inference/inference/network_node.proto";
 import "inference/inference/bridge.proto";
 import "inference/inference/poc_v2.proto";
+import "inference/inference/continuous_poc.proto";
 
 option go_package = "github.com/productscience/inference/x/inference/types";
 
@@ -66,6 +67,8 @@ service Msg {
   rpc SetTrainingAllowList             (MsgSetTrainingAllowList) returns (MsgSetTrainingAllowListResponse);
   rpc AddParticipantsToAllowList       (MsgAddParticipantsToAllowList) returns (MsgAddParticipantsToAllowListResponse);
   rpc RemoveParticipantsFromAllowList  (MsgRemoveParticipantsFromAllowList) returns (MsgRemoveParticipantsFromAllowListResponse);
+  // Continuous PoC commit - lightweight proof of ongoing GPU computation
+  rpc SubmitContinuousPoCCommit        (MsgSubmitContinuousPoCCommit) returns (MsgSubmitContinuousPoCCommitResponse);
 }
 // MsgUpdateParams is the Msg/UpdateParams request type.
 message MsgUpdateParams {
@@ -567,3 +570,18 @@ message MsgMigrateAllWrappedTokensResponse {
   // number of contracts attempted; success/failure details are in logs/events
   uint32 attempted = 1;
 }
+
+// MsgSubmitContinuousPoCCommit submits a lightweight continuous PoC commit.
+// Participants submit these periodically while serving inference to prove
+// that spare GPU capacity is being used for PoC nonce generation.
+message MsgSubmitContinuousPoCCommit {
+  option (cosmos.msg.v1.signer) = "creator";
+  string creator = 1;
+  uint64 epoch_index = 2;
+  uint32 nonce_count = 3;
+  bytes root_hash = 4;
+  uint32 inference_count = 5;
+  uint32 gpu_utilization_bps = 6;
+}
+
+message MsgSubmitContinuousPoCCommitResponse {}

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -86,6 +86,9 @@ type (
 		PoCValidationSnapshots collections.Map[int64, types.PoCValidationSnapshot]
 		// Punishment grace epochs for upgrade protection
 		PunishmentGraceEpochs collections.Map[uint64, types.GraceEpochParams]
+		// Continuous PoC collections
+		ContinuousPoCCommits        collections.Map[collections.Triple[uint64, sdk.AccAddress, int64], types.ContinuousPoCCommit]
+		ContinuousPoCEpochSummaries collections.Map[collections.Pair[uint64, sdk.AccAddress], types.ContinuousPoCEpochSummary]
 	}
 )
 
@@ -427,6 +430,21 @@ func NewKeeper(
 			"punishment_grace_epochs",
 			collections.Uint64Key,
 			codec.CollValue[types.GraceEpochParams](cdc),
+		),
+		// Continuous PoC collections
+		ContinuousPoCCommits: collections.NewMap(
+			sb,
+			types.ContinuousPoCCommitsPrefix,
+			"continuous_poc_commits",
+			collections.TripleKeyCodec(collections.Uint64Key, sdk.AccAddressKey, collections.Int64Key),
+			codec.CollValue[types.ContinuousPoCCommit](cdc),
+		),
+		ContinuousPoCEpochSummaries: collections.NewMap(
+			sb,
+			types.ContinuousPoCEpochSummariesPrefix,
+			"continuous_poc_epoch_summaries",
+			collections.PairKeyCodec(collections.Uint64Key, sdk.AccAddressKey),
+			codec.CollValue[types.ContinuousPoCEpochSummary](cdc),
 		),
 	}
 	// Build the collections schema

--- a/inference-chain/x/inference/keeper/msg_server_continuous_poc.go
+++ b/inference-chain/x/inference/keeper/msg_server_continuous_poc.go
@@ -1,0 +1,130 @@
+package keeper
+
+import (
+	"context"
+	"fmt"
+
+	"cosmossdk.io/collections"
+	sdkerrors "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// SubmitContinuousPoCCommit handles submission of continuous PoC commits.
+// Participants call this periodically to prove that spare GPU capacity is generating
+// PoC nonces in parallel with inference work.
+func (k msgServer) SubmitContinuousPoCCommit(goCtx context.Context, msg *types.MsgSubmitContinuousPoCCommit) (*types.MsgSubmitContinuousPoCCommitResponse, error) {
+	params, err := k.GetParams(goCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that continuous PoC is enabled
+	cpocParams := params.ContinuousPocParams
+	if cpocParams == nil || !cpocParams.EnableContinuousPoC {
+		return nil, sdkerrors.Wrap(types.ErrContinuousPoCDisabled, "continuous PoC is not enabled in params")
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	currentBlockHeight := ctx.BlockHeight()
+
+	// Validate creator address
+	addr, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		return nil, sdkerrors.Wrap(types.ErrInvalidAddress, fmt.Sprintf("invalid creator address: %v", err))
+	}
+
+	// Validate creator is a registered participant
+	_, err = k.Keeper.Participants.Get(ctx, addr)
+	if err != nil {
+		return nil, sdkerrors.Wrap(types.ErrParticipantNotFound, fmt.Sprintf("creator %s is not a registered participant", msg.Creator))
+	}
+
+	// Validate nonce count meets minimum
+	if msg.NonceCount < cpocParams.MinNoncesPerCommit {
+		return nil, sdkerrors.Wrap(types.ErrContinuousPoCMinNoncesNotMet,
+			fmt.Sprintf("nonce_count %d below minimum %d", msg.NonceCount, cpocParams.MinNoncesPerCommit))
+	}
+
+	// Validate root hash is 32 bytes
+	if len(msg.RootHash) != 32 {
+		return nil, sdkerrors.Wrap(types.ErrIllegalState, fmt.Sprintf("root_hash must be 32 bytes, got %d", len(msg.RootHash)))
+	}
+
+	// Validate GPU utilization is within basis points range
+	if msg.GpuUtilizationBps > 10000 {
+		return nil, sdkerrors.Wrap(types.ErrContinuousPoCInvalidUtilization,
+			fmt.Sprintf("gpu_utilization_bps %d exceeds maximum 10000", msg.GpuUtilizationBps))
+	}
+
+	// Get or create epoch summary to check commit count limit
+	summaryKey := collections.Join(msg.EpochIndex, addr)
+	summary, err := k.ContinuousPoCEpochSummaries.Get(ctx, summaryKey)
+	if err != nil {
+		// First commit for this epoch - initialize summary
+		summary = types.ContinuousPoCEpochSummary{
+			ParticipantAddress: msg.Creator,
+			EpochIndex:         msg.EpochIndex,
+			TotalNonces:        0,
+			TotalInferences:    0,
+			CommitCount:        0,
+			LastCommitHeight:   0,
+			EffectivePocWeight: 0,
+		}
+	}
+
+	// Check max commits per epoch
+	if summary.CommitCount >= cpocParams.MaxCommitsPerEpoch {
+		return nil, sdkerrors.Wrap(types.ErrContinuousPoCMaxCommitsExceeded,
+			fmt.Sprintf("participant has already submitted %d commits this epoch (max: %d)",
+				summary.CommitCount, cpocParams.MaxCommitsPerEpoch))
+	}
+
+	// Rate limit: one commit per block
+	if summary.LastCommitHeight == currentBlockHeight {
+		return nil, sdkerrors.Wrap(types.ErrIllegalState, "only one continuous PoC commit per block allowed")
+	}
+
+	// Store the individual commit record
+	commit := types.ContinuousPoCCommit{
+		ParticipantAddress: msg.Creator,
+		EpochIndex:         msg.EpochIndex,
+		NonceCount:         msg.NonceCount,
+		RootHash:           msg.RootHash,
+		InferenceCount:     msg.InferenceCount,
+		CommitBlockHeight:  currentBlockHeight,
+		GpuUtilizationBps:  msg.GpuUtilizationBps,
+	}
+
+	commitKey := collections.Join3(msg.EpochIndex, addr, currentBlockHeight)
+	if err := k.ContinuousPoCCommits.Set(ctx, commitKey, commit); err != nil {
+		return nil, sdkerrors.Wrap(types.ErrIllegalState, fmt.Sprintf("failed to store continuous PoC commit: %v", err))
+	}
+
+	// Update the epoch summary
+	summary.TotalNonces += uint64(msg.NonceCount)
+	summary.TotalInferences += uint64(msg.InferenceCount)
+	summary.CommitCount++
+	summary.LastCommitHeight = currentBlockHeight
+
+	// Calculate effective PoC weight: total nonces / nonce_weight
+	if cpocParams.NonceWeight > 0 {
+		summary.EffectivePocWeight = int64(summary.TotalNonces / uint64(cpocParams.NonceWeight))
+	}
+
+	if err := k.ContinuousPoCEpochSummaries.Set(ctx, summaryKey, summary); err != nil {
+		return nil, sdkerrors.Wrap(types.ErrIllegalState, fmt.Sprintf("failed to update epoch summary: %v", err))
+	}
+
+	k.LogInfo("[ContinuousPoC] Commit recorded", types.PoC,
+		"participant", msg.Creator,
+		"epoch", msg.EpochIndex,
+		"nonceCount", msg.NonceCount,
+		"inferenceCount", msg.InferenceCount,
+		"gpuUtilBps", msg.GpuUtilizationBps,
+		"totalNonces", summary.TotalNonces,
+		"commitCount", summary.CommitCount,
+		"effectiveWeight", summary.EffectivePocWeight)
+
+	return &types.MsgSubmitContinuousPoCCommitResponse{}, nil
+}

--- a/inference-chain/x/inference/types/codec.go
+++ b/inference-chain/x/inference/types/codec.go
@@ -113,6 +113,9 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgRemoveParticipantsFromAllowList{},
 	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgSubmitContinuousPoCCommit{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	registry.RegisterImplementations((*sdk.Msg)(nil),

--- a/inference-chain/x/inference/types/continuous_poc.go
+++ b/inference-chain/x/inference/types/continuous_poc.go
@@ -1,0 +1,136 @@
+package types
+
+import "fmt"
+
+// ContinuousPoCCommit represents a lightweight on-chain record of continuous PoC work.
+// Participants submit these commits periodically while inference-serving to prove
+// that unused GPU capacity is being utilized for PoC nonce generation.
+type ContinuousPoCCommit struct {
+	ParticipantAddress string `protobuf:"bytes,1,opt,name=participant_address,json=participantAddress,proto3" json:"participant_address,omitempty"`
+	EpochIndex         uint64 `protobuf:"varint,2,opt,name=epoch_index,json=epochIndex,proto3" json:"epoch_index,omitempty"`
+	NonceCount         uint32 `protobuf:"varint,3,opt,name=nonce_count,json=nonceCount,proto3" json:"nonce_count,omitempty"`
+	RootHash           []byte `protobuf:"bytes,4,opt,name=root_hash,json=rootHash,proto3" json:"root_hash,omitempty"`
+	InferenceCount     uint32 `protobuf:"varint,5,opt,name=inference_count,json=inferenceCount,proto3" json:"inference_count,omitempty"`
+	CommitBlockHeight  int64  `protobuf:"varint,6,opt,name=commit_block_height,json=commitBlockHeight,proto3" json:"commit_block_height,omitempty"`
+	GpuUtilizationBps  uint32 `protobuf:"varint,7,opt,name=gpu_utilization_bps,json=gpuUtilizationBps,proto3" json:"gpu_utilization_bps,omitempty"`
+}
+
+func (m *ContinuousPoCCommit) Reset()         { *m = ContinuousPoCCommit{} }
+func (m *ContinuousPoCCommit) String() string { return "" }
+func (m *ContinuousPoCCommit) ProtoMessage()  {}
+
+// ContinuousPoCEpochSummary aggregates a participant's continuous PoC commits for an epoch.
+// Updated on-chain as commits arrive; used during epoch settlement for weight calculation.
+type ContinuousPoCEpochSummary struct {
+	ParticipantAddress string `protobuf:"bytes,1,opt,name=participant_address,json=participantAddress,proto3" json:"participant_address,omitempty"`
+	EpochIndex         uint64 `protobuf:"varint,2,opt,name=epoch_index,json=epochIndex,proto3" json:"epoch_index,omitempty"`
+	TotalNonces        uint64 `protobuf:"varint,3,opt,name=total_nonces,json=totalNonces,proto3" json:"total_nonces,omitempty"`
+	TotalInferences    uint64 `protobuf:"varint,4,opt,name=total_inferences,json=totalInferences,proto3" json:"total_inferences,omitempty"`
+	CommitCount        uint32 `protobuf:"varint,5,opt,name=commit_count,json=commitCount,proto3" json:"commit_count,omitempty"`
+	LastCommitHeight   int64  `protobuf:"varint,6,opt,name=last_commit_height,json=lastCommitHeight,proto3" json:"last_commit_height,omitempty"`
+	EffectivePocWeight int64  `protobuf:"varint,7,opt,name=effective_poc_weight,json=effectivePocWeight,proto3" json:"effective_poc_weight,omitempty"`
+}
+
+func (m *ContinuousPoCEpochSummary) Reset()         { *m = ContinuousPoCEpochSummary{} }
+func (m *ContinuousPoCEpochSummary) String() string { return "" }
+func (m *ContinuousPoCEpochSummary) ProtoMessage()  {}
+
+// MsgSubmitContinuousPoCCommit is the message type for submitting continuous PoC commits.
+type MsgSubmitContinuousPoCCommit struct {
+	Creator           string `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
+	EpochIndex        uint64 `protobuf:"varint,2,opt,name=epoch_index,json=epochIndex,proto3" json:"epoch_index,omitempty"`
+	NonceCount        uint32 `protobuf:"varint,3,opt,name=nonce_count,json=nonceCount,proto3" json:"nonce_count,omitempty"`
+	RootHash          []byte `protobuf:"bytes,4,opt,name=root_hash,json=rootHash,proto3" json:"root_hash,omitempty"`
+	InferenceCount    uint32 `protobuf:"varint,5,opt,name=inference_count,json=inferenceCount,proto3" json:"inference_count,omitempty"`
+	GpuUtilizationBps uint32 `protobuf:"varint,6,opt,name=gpu_utilization_bps,json=gpuUtilizationBps,proto3" json:"gpu_utilization_bps,omitempty"`
+}
+
+func (m *MsgSubmitContinuousPoCCommit) Reset()         { *m = MsgSubmitContinuousPoCCommit{} }
+func (m *MsgSubmitContinuousPoCCommit) String() string { return "" }
+func (m *MsgSubmitContinuousPoCCommit) ProtoMessage()  {}
+
+// MsgSubmitContinuousPoCCommitResponse is the response type for MsgSubmitContinuousPoCCommit.
+type MsgSubmitContinuousPoCCommitResponse struct{}
+
+func (m *MsgSubmitContinuousPoCCommitResponse) Reset()         { *m = MsgSubmitContinuousPoCCommitResponse{} }
+func (m *MsgSubmitContinuousPoCCommitResponse) String() string { return "" }
+func (m *MsgSubmitContinuousPoCCommitResponse) ProtoMessage()  {}
+
+// ContinuousPoCParams defines parameters for the continuous PoC feature.
+// When enabled, GPU nodes generate PoC nonces in parallel with inference,
+// utilizing spare capacity to prove computational readiness.
+type ContinuousPoCParams struct {
+	// EnableContinuousPoC activates the continuous PoC system.
+	EnableContinuousPoC bool `protobuf:"varint,1,opt,name=enable_continuous_poc,json=enableContinuousPoc,proto3" json:"enable_continuous_poc,omitempty"`
+	// PocUtilizationTargetBps is the fraction of idle GPU capacity for PoC, in basis points [0, 10000].
+	PocUtilizationTargetBps uint32 `protobuf:"varint,2,opt,name=poc_utilization_target_bps,json=pocUtilizationTargetBps,proto3" json:"poc_utilization_target_bps,omitempty"`
+	// NonceWeight is how many PoC nonces equate to one inference unit of work.
+	NonceWeight uint32 `protobuf:"varint,3,opt,name=nonce_weight,json=nonceWeight,proto3" json:"nonce_weight,omitempty"`
+	// MaxCommitsPerEpoch prevents spam by limiting commits per epoch per participant.
+	MaxCommitsPerEpoch uint32 `protobuf:"varint,4,opt,name=max_commits_per_epoch,json=maxCommitsPerEpoch,proto3" json:"max_commits_per_epoch,omitempty"`
+	// MinNoncesPerCommit is the minimum nonce count required per commit.
+	MinNoncesPerCommit uint32 `protobuf:"varint,5,opt,name=min_nonces_per_commit,json=minNoncesPerCommit,proto3" json:"min_nonces_per_commit,omitempty"`
+	// ValidationSampleRateBps is the probability [0, 10000] that a commit gets validated.
+	ValidationSampleRateBps uint32 `protobuf:"varint,6,opt,name=validation_sample_rate_bps,json=validationSampleRateBps,proto3" json:"validation_sample_rate_bps,omitempty"`
+}
+
+func (m *ContinuousPoCParams) Reset()         { *m = ContinuousPoCParams{} }
+func (m *ContinuousPoCParams) String() string { return "" }
+func (m *ContinuousPoCParams) ProtoMessage()  {}
+
+// Equal implements the gogoproto Equal interface for ContinuousPoCParams.
+func (this *ContinuousPoCParams) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+	that1, ok := that.(*ContinuousPoCParams)
+	if !ok {
+		that2, ok := that.(ContinuousPoCParams)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.EnableContinuousPoC != that1.EnableContinuousPoC {
+		return false
+	}
+	if this.PocUtilizationTargetBps != that1.PocUtilizationTargetBps {
+		return false
+	}
+	if this.NonceWeight != that1.NonceWeight {
+		return false
+	}
+	if this.MaxCommitsPerEpoch != that1.MaxCommitsPerEpoch {
+		return false
+	}
+	if this.MinNoncesPerCommit != that1.MinNoncesPerCommit {
+		return false
+	}
+	if this.ValidationSampleRateBps != that1.ValidationSampleRateBps {
+		return false
+	}
+	return true
+}
+
+// Validate checks that the continuous PoC params are reasonable.
+func (p *ContinuousPoCParams) Validate() error {
+	if p == nil {
+		return nil
+	}
+	if p.PocUtilizationTargetBps > 10000 {
+		return fmt.Errorf("poc_utilization_target_bps must be <= 10000, got %d", p.PocUtilizationTargetBps)
+	}
+	if p.ValidationSampleRateBps > 10000 {
+		return fmt.Errorf("validation_sample_rate_bps must be <= 10000, got %d", p.ValidationSampleRateBps)
+	}
+	if p.NonceWeight == 0 && p.EnableContinuousPoC {
+		return fmt.Errorf("nonce_weight cannot be 0 when continuous PoC is enabled")
+	}
+	return nil
+}

--- a/inference-chain/x/inference/types/errors.go
+++ b/inference-chain/x/inference/types/errors.go
@@ -69,4 +69,8 @@ var (
 	ErrNotSupported                          = sdkerrors.Register(ModuleName, 1163, "operation not supported in current mode")
 	ErrInvalidAddress                        = sdkerrors.Register(ModuleName, 1164, "invalid address")
 	ErrTransferAgentNotAllowlisted           = sdkerrors.Register(ModuleName, 1165, "transfer agent not in allowlist")
+	ErrContinuousPoCDisabled                 = sdkerrors.Register(ModuleName, 1166, "continuous PoC is not enabled")
+	ErrContinuousPoCMaxCommitsExceeded       = sdkerrors.Register(ModuleName, 1167, "maximum continuous PoC commits per epoch exceeded")
+	ErrContinuousPoCMinNoncesNotMet          = sdkerrors.Register(ModuleName, 1168, "nonce count below minimum per commit")
+	ErrContinuousPoCInvalidUtilization       = sdkerrors.Register(ModuleName, 1169, "GPU utilization basis points must be in [0, 10000]")
 )

--- a/inference-chain/x/inference/types/keys.go
+++ b/inference-chain/x/inference/types/keys.go
@@ -63,8 +63,10 @@ var (
 	MLNodeWeightDistributionPrefix    = collections.NewPrefix(40)
 	PocV2EnabledEpochPrefix           = collections.NewPrefix(41)
 	PoCValidationSnapshotPrefix       = collections.NewPrefix(42)
-	PunishmentGraceEpochsPrefix       = collections.NewPrefix(43)
-	ParamsKey                         = []byte("p_inference")
+	PunishmentGraceEpochsPrefix            = collections.NewPrefix(43)
+	ContinuousPoCCommitsPrefix             = collections.NewPrefix(44)
+	ContinuousPoCEpochSummariesPrefix      = collections.NewPrefix(45)
+	ParamsKey                              = []byte("p_inference")
 )
 
 func KeyPrefix(p string) []byte {

--- a/inference-chain/x/inference/types/params.go
+++ b/inference-chain/x/inference/types/params.go
@@ -108,6 +108,7 @@ func DefaultParams() Params {
 			// Note: proto encoding does not preserve empty-vs-nil for repeated fields; keep nil to match round-trips.
 			AllowedTransferAddresses: nil, // nil = no restriction, all TAs allowed
 		},
+		ContinuousPocParams: DefaultContinuousPoCParams(),
 	}
 }
 
@@ -195,6 +196,17 @@ func DefaultPoCModelParams() *PoCModelParams {
 		UseScaledRope:    false,
 		SeqLen:           256,
 		RTarget:          DecimalFromFloat(1.398077),
+	}
+}
+
+func DefaultContinuousPoCParams() *ContinuousPoCParams {
+	return &ContinuousPoCParams{
+		EnableContinuousPoC:     false, // Disabled by default
+		PocUtilizationTargetBps: 9950,  // 99.5% of idle capacity used for PoC
+		NonceWeight:             10,    // 10 nonces = 1 inference unit
+		MaxCommitsPerEpoch:      100,   // Max 100 commits per epoch
+		MinNoncesPerCommit:      10,    // At least 10 nonces per commit
+		ValidationSampleRateBps: 500,   // 5% of commits validated
 	}
 }
 
@@ -416,6 +428,12 @@ func (p Params) Validate() error {
 
 	if p.PocParams != nil {
 		if err := p.PocParams.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if p.ContinuousPocParams != nil {
+		if err := p.ContinuousPocParams.Validate(); err != nil {
 			return err
 		}
 	}

--- a/inference-chain/x/inference/types/params.pb.go
+++ b/inference-chain/x/inference/types/params.pb.go
@@ -40,6 +40,7 @@ type Params struct {
 	DeveloperAccessParams     *DeveloperAccessParams     `protobuf:"bytes,11,opt,name=developer_access_params,json=developerAccessParams,proto3" json:"developer_access_params,omitempty"`
 	ParticipantAccessParams   *ParticipantAccessParams   `protobuf:"bytes,12,opt,name=participant_access_params,json=participantAccessParams,proto3" json:"participant_access_params,omitempty"`
 	TransferAgentAccessParams *TransferAgentAccessParams `protobuf:"bytes,13,opt,name=transfer_agent_access_params,json=transferAgentAccessParams,proto3" json:"transfer_agent_access_params,omitempty"`
+	ContinuousPocParams       *ContinuousPoCParams       `protobuf:"bytes,14,opt,name=continuous_poc_params,json=continuousPocParams,proto3" json:"continuous_poc_params,omitempty"`
 }
 
 func (m *Params) Reset()         { *m = Params{} }
@@ -162,6 +163,13 @@ func (m *Params) GetParticipantAccessParams() *ParticipantAccessParams {
 func (m *Params) GetTransferAgentAccessParams() *TransferAgentAccessParams {
 	if m != nil {
 		return m.TransferAgentAccessParams
+	}
+	return nil
+}
+
+func (m *Params) GetContinuousPocParams() *ContinuousPoCParams {
+	if m != nil {
+		return m.ContinuousPocParams
 	}
 	return nil
 }
@@ -2227,6 +2235,9 @@ func (this *Params) Equal(that interface{}) bool {
 		return false
 	}
 	if !this.TransferAgentAccessParams.Equal(that1.TransferAgentAccessParams) {
+		return false
+	}
+	if !this.ContinuousPocParams.Equal(that1.ContinuousPocParams) {
 		return false
 	}
 	return true

--- a/inference-chain/x/inference/types/tx.pb.go
+++ b/inference-chain/x/inference/types/tx.pb.go
@@ -5615,6 +5615,8 @@ type MsgServer interface {
 	SetTrainingAllowList(context.Context, *MsgSetTrainingAllowList) (*MsgSetTrainingAllowListResponse, error)
 	AddParticipantsToAllowList(context.Context, *MsgAddParticipantsToAllowList) (*MsgAddParticipantsToAllowListResponse, error)
 	RemoveParticipantsFromAllowList(context.Context, *MsgRemoveParticipantsFromAllowList) (*MsgRemoveParticipantsFromAllowListResponse, error)
+	// Continuous PoC commit - lightweight proof of ongoing GPU computation
+	SubmitContinuousPoCCommit(context.Context, *MsgSubmitContinuousPoCCommit) (*MsgSubmitContinuousPoCCommitResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -5746,6 +5748,9 @@ func (*UnimplementedMsgServer) AddParticipantsToAllowList(ctx context.Context, r
 }
 func (*UnimplementedMsgServer) RemoveParticipantsFromAllowList(ctx context.Context, req *MsgRemoveParticipantsFromAllowList) (*MsgRemoveParticipantsFromAllowListResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RemoveParticipantsFromAllowList not implemented")
+}
+func (*UnimplementedMsgServer) SubmitContinuousPoCCommit(ctx context.Context, req *MsgSubmitContinuousPoCCommit) (*MsgSubmitContinuousPoCCommitResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SubmitContinuousPoCCommit not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -6508,6 +6513,24 @@ func _Msg_RemoveParticipantsFromAllowList_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_SubmitContinuousPoCCommit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgSubmitContinuousPoCCommit)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).SubmitContinuousPoCCommit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/inference.inference.Msg/SubmitContinuousPoCCommit",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).SubmitContinuousPoCCommit(ctx, req.(*MsgSubmitContinuousPoCCommit))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var Msg_serviceDesc = _Msg_serviceDesc
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "inference.inference.Msg",
@@ -6680,6 +6703,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RemoveParticipantsFromAllowList",
 			Handler:    _Msg_RemoveParticipantsFromAllowList_Handler,
+		},
+		{
+			MethodName: "SubmitContinuousPoCCommit",
+			Handler:    _Msg_SubmitContinuousPoCCommit_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
## Summary

Adds the foundational types, params, keeper infrastructure, and message handler for **continuous Proof of Computation** -- allowing GPU nodes to prove spare computational capacity by generating PoC nonces in parallel with inference work, rather than requiring separate PoC-only phases.

Closes #821

### What's included

- **Proto definitions**: `ContinuousPoCCommit`, `ContinuousPoCEpochSummary`, `ContinuousPoCParams`, `MsgSubmitContinuousPoCCommit` message and query types
- **New governance params** (all configurable, disabled by default):
  - `EnableContinuousPoC` -- feature toggle
  - `PocUtilizationTargetBps` -- idle GPU capacity fraction for PoC (default: 99.5%)
  - `NonceWeight` -- how many nonces equal one inference unit (default: 10)
  - `MaxCommitsPerEpoch` -- anti-spam limit (default: 100)
  - `MinNoncesPerCommit` -- minimum work per commit (default: 10)
  - `ValidationSampleRateBps` -- random validation probability (default: 5%)
- **Keeper collections**: `ContinuousPoCCommits` (triple key: epoch+address+height) and `ContinuousPoCEpochSummaries` (pair key: epoch+address)
- **Message handler** (`SubmitContinuousPoCCommit`) with full validation:
  - Participant registration check
  - Rate limiting (one commit per block)
  - Nonce minimum enforcement
  - Commit count cap per epoch
  - GPU utilization bounds check
  - Automatic epoch summary aggregation and weight calculation
- **Codec registration** for the new message type
- **Error sentinel values** for continuous PoC validation failures

### Design decisions

- **Lightweight on-chain commits**: Only count + Merkle root stored on-chain; actual artifacts stored locally (consistent with existing PoCV2 pattern)
- **Epoch summaries**: Aggregated in real-time as commits arrive, providing `EffectivePocWeight` for settlement
- **Disabled by default**: `EnableContinuousPoC=false` ensures zero impact on existing behavior until governance activates it

### Note

Proto-gen needs to be run to regenerate `.pb.go` files from the updated `.proto` definitions. Hand-written Go types bridge the gap until then.

## Test plan

- [ ] Verify `go build ./...` passes
- [ ] Run proto-gen to regenerate pb.go files
- [ ] Unit test for `SubmitContinuousPoCCommit` happy path and validation edge cases
- [ ] Integration test with continuous PoC enabled via params update
- [ ] Verify default params don't affect existing PoC behavior