### PR TITLE
perf(inference): move hot-path logs from INFO to DEBUG

### DIFF
--- a/inference-chain/x/inference/keeper/developer_stats_aggregation.go
+++ b/inference-chain/x/inference/keeper/developer_stats_aggregation.go
@@ -27,7 +27,7 @@ func (k Keeper) SetDeveloperStats(ctx context.Context, inference types.Inference
 		epochId = effectiveEpoch.Index
 	}
 
-	k.LogInfo("SetDeveloperStats: got stat", types.Stat,
+	k.LogDebug("SetDeveloperStats: got stat", types.Stat,
 		"inference_id", inference.InferenceId,
 		"inference_status", inference.Status.String(),
 		"developer", inference.RequestedBy,

--- a/inference-chain/x/inference/keeper/developer_stats_store.go
+++ b/inference-chain/x/inference/keeper/developer_stats_store.go
@@ -23,7 +23,7 @@ func (k Keeper) setOrUpdateInferenceStatByTime(ctx context.Context, developer st
 	timeKey := byInferenceStore.Get([]byte(infStats.InferenceId))
 	if timeKey == nil {
 		// completely new record
-		k.LogInfo("completely new record, create record by time", types.Stat, "inference_id", infStats.InferenceId, "developer", developer)
+		k.LogDebug("completely new record, create record by time", types.Stat, "inference_id", infStats.InferenceId, "developer", developer)
 		timeKey = developerByTimeAndInferenceKey(developer, uint64(inferenceTime), infStats.InferenceId)
 		bz, err := k.cdc.Marshal(&types.DeveloperStatsByTime{
 			EpochId:   epochId,
@@ -44,7 +44,7 @@ func (k Keeper) setOrUpdateInferenceStatByTime(ctx context.Context, developer st
 	)
 
 	if val := byTimeStore.Get(timeKey); val != nil {
-		k.LogInfo("record found by time key", types.Stat, "inference_id", infStats.InferenceId, "developer", developer)
+		k.LogDebug("record found by time key", types.Stat, "inference_id", infStats.InferenceId, "developer", developer)
 		err := k.cdc.Unmarshal(val, &statsByTime)
 		if err != nil {
 			return 0, err
@@ -64,7 +64,7 @@ func (k Keeper) setOrUpdateInferenceStatByTime(ctx context.Context, developer st
 		statsByTime.Inference.EpochId = infStats.EpochId
 		statsByTime.Inference.ActualCostInCoins = infStats.ActualCostInCoins
 	} else {
-		k.LogInfo("time key exists, record DO NOT exist", types.Stat, "inference_id", infStats.InferenceId, "developer", developer)
+		k.LogDebug("time key exists, record DO NOT exist", types.Stat, "inference_id", infStats.InferenceId, "developer", developer)
 		statsByTime = types.DeveloperStatsByTime{
 			EpochId:   epochId,
 			Timestamp: inferenceTime,

--- a/inference-chain/x/inference/keeper/dynamic_pricing.go
+++ b/inference-chain/x/inference/keeper/dynamic_pricing.go
@@ -281,7 +281,7 @@ func (k *Keeper) RecordInferencePrice(
 	}
 	if inference.Model == "" {
 		k.LogError("RecordInferencePrice called with empty model ID", types.Pricing,
-			"inferenceId", inference.InferenceId, "inference", inference)
+			"inferenceId", inference.InferenceId, "status", inference.Status.String())
 	}
 	// Fast path: check if price is already stored (already locked in)
 	if inference.PerTokenPrice > 0 {
@@ -303,7 +303,7 @@ func (k *Keeper) RecordInferencePrice(
 	// This eliminates the need for complex fallback logic in calculation functions
 	inference.PerTokenPrice = currentPrice
 
-	k.LogInfo("Recorded inference price", types.Pricing,
+	k.LogDebug("Recorded inference price", types.Pricing,
 		"inferenceId", inferenceId, "modelId", inference.Model, "lockedPrice", currentPrice)
 }
 

--- a/inference-chain/x/inference/keeper/inference.go
+++ b/inference-chain/x/inference/keeper/inference.go
@@ -20,7 +20,7 @@ func (k Keeper) SetInference(ctx context.Context, inference types.Inference) err
 	if err != nil {
 		k.LogError("error setting developer stat", types.Stat, "err", err)
 	} else {
-		k.LogInfo("updated developer stat", types.Stat, "inference_id", inference.InferenceId, "inference_status", inference.Status.String(), "developer", inference.RequestedBy)
+		k.LogDebug("updated developer stat", types.Stat, "inference_id", inference.InferenceId, "inference_status", inference.Status.String(), "developer", inference.RequestedBy)
 	}
 	return nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -13,7 +13,7 @@ import (
 func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishInference) (*types.MsgFinishInferenceResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	k.LogInfo("FinishInference", types.Inferences, "inference_id", msg.InferenceId, "executed_by", msg.ExecutedBy, "created_by", msg.Creator)
+	k.LogDebug("FinishInference", types.Inferences, "inference_id", msg.InferenceId, "executed_by", msg.ExecutedBy, "created_by", msg.Creator)
 
 	if msg.PromptTokenCount > types.MaxAllowedTokens {
 		return failedFinish(ctx, sdkerrors.Wrapf(types.ErrTokenCountOutOfRange, "prompt_token_count exceeds limit (%d > %d)", msg.PromptTokenCount, types.MaxAllowedTokens), msg), nil

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -14,7 +14,7 @@ import (
 
 func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInference) (*types.MsgStartInferenceResponse, error) {
 	var ctx sdk.Context = sdk.UnwrapSDKContext(goCtx)
-	k.LogInfo("StartInference", types.Inferences, "inferenceId", msg.InferenceId, "creator", msg.Creator, "requestedBy", msg.RequestedBy, "model", msg.Model)
+	k.LogDebug("StartInference", types.Inferences, "inferenceId", msg.InferenceId, "creator", msg.Creator, "requestedBy", msg.RequestedBy, "model", msg.Model)
 
 	// Developer access gating: before the cutoff height, only allowlisted developers may request inferences.
 	if k.IsDeveloperAccessRestricted(ctx, ctx.BlockHeight()) && !k.IsAllowedDeveloper(ctx, msg.RequestedBy) {
@@ -46,8 +46,8 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 		return failedStart(ctx, sdkerrors.Wrap(types.ErrParticipantNotFound, msg.RequestedBy), msg), nil
 	}
 
-	k.LogInfo("DevPubKey", types.Inferences, "DevPubKey", dev.WorkerPublicKey, "DevAddress", dev.Address)
-	k.LogInfo("TransferAgentPubKey", types.Inferences, "TransferAgentPubKey", transferAgent.WorkerPublicKey, "TransferAgentAddress", transferAgent.Address)
+	k.LogDebug("DevPubKey", types.Inferences, "DevPubKey", dev.WorkerPublicKey, "DevAddress", dev.Address)
+	k.LogDebug("TransferAgentPubKey", types.Inferences, "TransferAgentPubKey", transferAgent.WorkerPublicKey, "TransferAgentAddress", transferAgent.Address)
 
 	err := k.verifyKeys(ctx, msg, transferAgent, dev)
 	if err != nil {
@@ -148,7 +148,7 @@ func (k msgServer) validateTimestamp(
 		k.LogError("StartInference: validateTimestamp failed to get params", types.Inferences, "error", err)
 		return err
 	}
-	k.LogInfo("Validating timestamp for StartInference:", types.Inferences,
+	k.LogDebug("Validating timestamp for StartInference:", types.Inferences,
 		"timestamp", components.Timestamp,
 		"inferenceId", inferenceId,
 		"currentBlockTime", ctx.BlockTime().UnixNano(),
@@ -189,7 +189,7 @@ func (k msgServer) addTimeout(ctx sdk.Context, inference *types.Inference) {
 		k.LogError("Unable to set inference timeout", types.Inferences, err)
 	}
 
-	k.LogInfo("Inference Timeout Set:", types.Inferences,
+	k.LogDebug("Inference Timeout Set:", types.Inferences,
 		"InferenceId", inference.InferenceId,
 		"ExpirationHeight", inference.StartBlockHeight+expirationBlocks)
 }

--- a/inference-chain/x/inference/keeper/payment_handler.go
+++ b/inference-chain/x/inference/keeper/payment_handler.go
@@ -25,7 +25,7 @@ func (k *Keeper) PutPaymentInEscrow(ctx context.Context, inference *types.Infere
 		return 0,
 			sdkerrors.Wrap(err, types.ErrRequesterCannotPay.Error())
 	}
-	k.LogInfo("Sent coins to escrow", types.Payments, "inference", inference.InferenceId, "coins", cost, "payee", payeeAddress)
+	k.LogDebug("Sent coins to escrow", types.Payments, "inference", inference.InferenceId, "coins", cost, "payee", payeeAddress)
 	return cost, nil
 }
 
@@ -37,7 +37,7 @@ func (k *Keeper) MintRewardCoins(ctx context.Context, newCoins int64, memo strin
 		k.LogError("Cannot mint negative coins", types.Payments, "coins", newCoins)
 		return sdkerrors.Wrapf(types.ErrCannotMintNegativeCoins, "coins: %d", newCoins)
 	}
-	k.LogInfo("Minting coins", types.Payments, "coins", newCoins, "moduleAccount", types.ModuleName)
+	k.LogDebug("Minting coins", types.Payments, "coins", newCoins, "moduleAccount", types.ModuleName)
 	coins, err := types.GetCoins(newCoins)
 	if err != nil {
 		return err
@@ -55,12 +55,12 @@ func (k *Keeper) PayParticipantFromModule(ctx context.Context, address string, a
 		return err
 	}
 	if amount == 0 {
-		k.LogInfo("No amount to pay", types.Payments, "participant", participantAddress, "amount", amount, "address", address, "module", moduleName, "vestingPeriods", vestingPeriods)
+		k.LogDebug("No amount to pay", types.Payments, "participant", participantAddress, "amount", amount, "address", address, "module", moduleName, "vestingPeriods", vestingPeriods)
 		return nil
 	}
 
 	vestingEpochs := vestingPeriods
-	k.LogInfo("Paying participant", types.Payments, "participant", participantAddress, "amount", amount, "address", address, "module", moduleName, "vestingPeriods", vestingPeriods)
+	k.LogDebug("Paying participant", types.Payments, "participant", participantAddress, "amount", amount, "address", address, "module", moduleName, "vestingPeriods", vestingPeriods)
 
 	if vestingPeriods != nil && *vestingPeriods > 0 {
 		// Route through streamvesting system
@@ -87,10 +87,10 @@ func (k *Keeper) PayParticipantFromModule(ctx context.Context, address string, a
 
 func (k *Keeper) BurnModuleCoins(ctx context.Context, burnCoins int64, memo string) error {
 	if burnCoins <= 0 {
-		k.LogInfo("No coins to burn", types.Payments, "coins", burnCoins)
+		k.LogDebug("No coins to burn", types.Payments, "coins", burnCoins)
 		return nil
 	}
-	k.LogInfo("Burning coins", types.Payments, "coins", burnCoins)
+	k.LogDebug("Burning coins", types.Payments, "coins", burnCoins)
 	coins, err := types.GetCoins(burnCoins)
 	if err != nil {
 		return err
@@ -103,7 +103,7 @@ func (k *Keeper) BurnModuleCoins(ctx context.Context, burnCoins int64, memo stri
 }
 
 func (k *Keeper) IssueRefund(ctx context.Context, refundAmount int64, address string, memo string) error {
-	k.LogInfo("Issuing refund", types.Payments, "address", address, "amount", refundAmount)
+	k.LogDebug("Issuing refund", types.Payments, "address", address, "amount", refundAmount)
 	err := k.PayParticipantFromEscrow(ctx, address, refundAmount, memo, nil) // Refunds should be direct payment
 	if err != nil {
 		k.LogError("Error issuing refund", types.Payments, "error", err)


### PR DESCRIPTION
## Summary

Addresses the logging overhead identified in #780 (I.3: Move most logs of StartInference/FinishInference to DEBUG level).

Profiling showed ~11% of handler time spent in logging at INFO level, with `processInferencePayments` logging accounting for 25-48% of its execution time.

### Changes

**StartInference hot path:**
- Entry log, DevPubKey/TransferAgentPubKey logs -> DEBUG
- `validateTimestamp` verbose parameter log -> DEBUG
- `addTimeout` confirmation log -> DEBUG

**FinishInference hot path:**
- Entry log -> DEBUG

**Payment handling (`processInferencePayments` and downstream):**
- `PutPaymentInEscrow` success log -> DEBUG
- `PayParticipantFromModule` logs -> DEBUG
- `IssueRefund` log -> DEBUG
- `MintRewardCoins`, `BurnModuleCoins` logs -> DEBUG

**Stats recording (called per inference via `SetInference`):**
- `SetDeveloperStats` got-stat log -> DEBUG
- `setOrUpdateInferenceStatByTime` record tracking logs (3 calls) -> DEBUG
- `SetInference` updated-developer-stat success log -> DEBUG

**Dynamic pricing:**
- `RecordInferencePrice` success log -> DEBUG
- Removed heavy `inference` struct serialization from error log (replaced with lightweight fields)

### What is NOT changed
- All ERROR and WARN level logs remain unchanged for operational visibility
- Per-block logs in `UpdateDynamicPricing` (BeginBlocker) remain at INFO since they run once per block, not per inference
- Bookkeeper `LogSubAccountTransaction` has its own configurable log level

### Impact
With `log_level=info` (production default), this eliminates ~20 log calls per inference transaction. Combined with `log_format=json` (recommended), this should reduce logging overhead from ~11% to <1% of handler time.

Operators can still see all details by setting `log_level=debug`.

Closes #780

**Author:** AlexeySamosadov