### PR TITLE
fix(bls): remove self-validation fallback in group key validation

### DIFF
--- a/inference-chain/x/bls/keeper/msg_server_group_validation.go
+++ b/inference-chain/x/bls/keeper/msg_server_group_validation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
-	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -60,22 +59,14 @@ func (ms msgServer) SubmitGroupKeyValidationSignature(goCtx context.Context, msg
 		return &types.MsgSubmitGroupKeyValidationSignatureResponse{}, nil
 	}
 
-	// Get the previous epoch's BLS data for slot validation and signature verification
+	// Get the previous epoch's BLS data for slot validation and signature verification.
+	// This data is mandatory: falling back to the new epoch's own data would allow a new
+	// epoch to self-certify its group key, completely bypassing the chain of trust.
 	previousEpochBLSData, err := ms.GetEpochBLSData(ctx, previousEpochId)
 	if err != nil {
-		if errors.Is(err, types.ErrEpochBLSDataNotFound) {
-			// Emit a searchable event and continue using current epoch data as fallback
-			ms.Keeper.LogWarn("Previous epoch not found - using current epoch for validation", "previous_epoch_id", previousEpochId, "new_epoch_id", msg.NewEpochId)
-			ctx.EventManager().EmitTypedEvent(&types.EventGroupKeyValidationFailed{
-				NewEpochId: msg.NewEpochId,
-				Reason:     fmt.Sprintf("previous_epoch_missing_fallback:%d", previousEpochId),
-			})
-
-			previousEpochBLSData = newEpochBLSData
-		} else {
-			ms.Keeper.LogError("Failed to get previous epoch BLS data", "previous_epoch_id", previousEpochId, "error", err.Error())
-			return nil, fmt.Errorf("failed to get previous epoch %d BLS data: %w", previousEpochId, err)
-		}
+		ms.Keeper.LogError("Cannot validate group key: previous epoch BLS data unavailable",
+			"previous_epoch_id", previousEpochId, "new_epoch_id", msg.NewEpochId, "error", err.Error())
+		return nil, fmt.Errorf("previous epoch %d BLS data required for group key validation: %w", previousEpochId, err)
 	}
 
 	// Find the participant in the previous epoch


### PR DESCRIPTION
When previous epoch BLS data was not found, the handler silently reassigned previousEpochBLSData = newEpochBLSData, allowing an epoch to certify its own group key against its own participant keys and its own group public key. This bypasses the entire chain-of-trust that cross-epoch validation is designed to enforce.

The fallback is removed. When previous epoch data is unavailable for any reason, the handler now returns an explicit error, which is the only correct and safe behavior.

Fixes #848

