### PR TITLE
fix: validation silently dropped when model group data missing

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -105,7 +105,7 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 	groupData, found := k.GetEpochGroupData(ctx, epochGroup.GroupData.EpochIndex, inference.Model)
 	if !found {
 		k.LogError("Failed to get epoch group data", types.Validation, "epochIndex", epochGroup.GroupData.EpochIndex, "model", inference.Model)
-		return nil, err
+		return nil, types.ErrEpochGroupDataNotFound
 	}
 
 	if groupData.ValidationWeight(msg.Creator) == nil {


### PR DESCRIPTION
GetEpochGroupData returns (data, found) but the error path reuses err from the previous GetEpochGroup call which already succeeded. when found=false the handler returns nil,nil — sdk treats it as success, validation silently lost. 
validator gets no error back, thinks everything went through.

return ErrEpochGroupDataNotFound instead of the stale nil.
