### PR TITLE
fix(payloadstorage): advance minPruned only after successful prune

### DIFF
--- a/decentralized-api/payloadstorage/managed_storage.go
+++ b/decentralized-api/payloadstorage/managed_storage.go
@@ -22,18 +22,21 @@ type cachedEntry struct {
 }
 
 // ManagedStorage wraps PayloadStorage with read caching and automatic epoch pruning.
-// - Caches Retrieve results to reduce disk I/O during validation bursts
-// - Automatically prunes old epochs in background (only last 10 epochs, older data requires manual prune)
+//   - Caches Retrieve results to reduce disk I/O during validation bursts
+//   - Automatically prunes old epochs in background (only last 10 epochs, older data requires manual prune)
+//   - Failed prunes are isolated in failedEpochs and retried on each cleanup tick,
+//     so a single persistent failure does not block pruning of subsequent epochs.
 type ManagedStorage struct {
 	storage      PayloadStorage
 	retainCount  uint64
 	cacheTTL     time.Duration
 	maxCacheSize int
 
-	mu        sync.RWMutex
-	cache     map[string]*cachedEntry
-	maxEpoch  uint64
-	minPruned uint64
+	mu           sync.RWMutex
+	cache        map[string]*cachedEntry
+	maxEpoch     uint64
+	minPruned    uint64
+	failedEpochs map[uint64]bool
 }
 
 func NewManagedStorage(storage PayloadStorage, retainCount uint64, cacheTTL time.Duration) *ManagedStorage {
@@ -47,6 +50,7 @@ func NewManagedStorageWithSize(storage PayloadStorage, retainCount uint64, cache
 		cacheTTL:     cacheTTL,
 		maxCacheSize: maxCacheSize,
 		cache:        make(map[string]*cachedEntry),
+		failedEpochs: make(map[uint64]bool),
 	}
 	go m.cleanupLoop()
 	return m
@@ -133,25 +137,55 @@ func (m *ManagedStorage) cleanup() {
 		pruneTo = m.maxEpoch - m.retainCount
 		if m.minPruned+maxPruneLookback < pruneTo {
 			m.minPruned = pruneTo - maxPruneLookback
+			for e := range m.failedEpochs {
+				if e < m.minPruned {
+					delete(m.failedEpochs, e)
+				}
+			}
 		}
 		pruneFrom = m.minPruned
 	}
 	m.mu.Unlock()
 
 	// Prune sequentially outside the lock so Store/Retrieve are not blocked.
-	// Track partial progress: advance minPruned per successful epoch.
-	// Stop on first failure so the failed epoch is retried on the next cleanup tick.
+	// On failure, isolate the epoch in failedEpochs and continue — a single
+	// persistent failure must not block pruning of subsequent epochs.
 	if pruneFrom < pruneTo {
 		for epoch := pruneFrom; epoch < pruneTo; epoch++ {
 			if err := m.storage.PruneEpoch(context.Background(), epoch); err != nil {
 				logging.Warn("Auto-prune failed", types.PayloadStorage, "epochId", epoch, "error", err)
-				break
+				m.mu.Lock()
+				m.failedEpochs[epoch] = true
+				m.mu.Unlock()
+				continue
 			}
 			logging.Info("Auto-pruned epoch", types.PayloadStorage, "epochId", epoch)
 			m.mu.Lock()
-			m.minPruned = epoch + 1
+			if epoch+1 > m.minPruned {
+				m.minPruned = epoch + 1
+			}
 			m.mu.Unlock()
 		}
+	}
+
+	// Retry previously failed epochs. Idempotent PruneEpoch guarantees
+	// that re-attempting an already-pruned epoch is a safe no-op.
+	m.mu.RLock()
+	retries := make([]uint64, 0, len(m.failedEpochs))
+	for e := range m.failedEpochs {
+		retries = append(retries, e)
+	}
+	m.mu.RUnlock()
+
+	for _, e := range retries {
+		if err := m.storage.PruneEpoch(context.Background(), e); err != nil {
+			logging.Warn("Auto-prune retry failed", types.PayloadStorage, "epochId", e, "error", err)
+			continue
+		}
+		logging.Info("Auto-pruned previously failed epoch", types.PayloadStorage, "epochId", e)
+		m.mu.Lock()
+		delete(m.failedEpochs, e)
+		m.mu.Unlock()
 	}
 }
 

--- a/decentralized-api/payloadstorage/managed_storage.go
+++ b/decentralized-api/payloadstorage/managed_storage.go
@@ -113,7 +113,6 @@ func (m *ManagedStorage) cleanupLoop() {
 
 func (m *ManagedStorage) cleanup() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	now := time.Now()
 	for id, c := range m.cache {
@@ -129,23 +128,30 @@ func (m *ManagedStorage) cleanup() {
 		}
 	}
 
+	var pruneFrom, pruneTo uint64
 	if m.maxEpoch > m.retainCount {
-		threshold := m.maxEpoch - m.retainCount
-
-		if m.minPruned+maxPruneLookback < threshold {
-			m.minPruned = threshold - maxPruneLookback
+		pruneTo = m.maxEpoch - m.retainCount
+		if m.minPruned+maxPruneLookback < pruneTo {
+			m.minPruned = pruneTo - maxPruneLookback
 		}
+		pruneFrom = m.minPruned
+	}
+	m.mu.Unlock()
 
-		for epoch := m.minPruned; epoch < threshold; epoch++ {
-			go func(e uint64) {
-				if err := m.storage.PruneEpoch(context.Background(), e); err != nil {
-					logging.Warn("Auto-prune failed", types.PayloadStorage, "epochId", e, "error", err)
-				} else {
-					logging.Info("Auto-pruned epoch", types.PayloadStorage, "epochId", e)
-				}
-			}(epoch)
+	// Prune sequentially outside the lock so Store/Retrieve are not blocked.
+	// Track partial progress: advance minPruned per successful epoch.
+	// Stop on first failure so the failed epoch is retried on the next cleanup tick.
+	if pruneFrom < pruneTo {
+		for epoch := pruneFrom; epoch < pruneTo; epoch++ {
+			if err := m.storage.PruneEpoch(context.Background(), epoch); err != nil {
+				logging.Warn("Auto-prune failed", types.PayloadStorage, "epochId", epoch, "error", err)
+				break
+			}
+			logging.Info("Auto-pruned epoch", types.PayloadStorage, "epochId", epoch)
+			m.mu.Lock()
+			m.minPruned = epoch + 1
+			m.mu.Unlock()
 		}
-		m.minPruned = threshold
 	}
 }
 

--- a/decentralized-api/payloadstorage/managed_storage.go
+++ b/decentralized-api/payloadstorage/managed_storage.go
@@ -13,6 +13,8 @@ import (
 const (
 	defaultManagedCacheSize = 1000
 	maxPruneLookback        = 10
+	maxRetryAttempts        = 5
+	maxFailedEpochs         = 10000
 )
 
 type cachedEntry struct {
@@ -22,10 +24,6 @@ type cachedEntry struct {
 }
 
 // ManagedStorage wraps PayloadStorage with read caching and automatic epoch pruning.
-//   - Caches Retrieve results to reduce disk I/O during validation bursts
-//   - Automatically prunes old epochs in background (only last 10 epochs, older data requires manual prune)
-//   - Failed prunes are isolated in failedEpochs and retried on each cleanup tick,
-//     so a single persistent failure does not block pruning of subsequent epochs.
 type ManagedStorage struct {
 	storage      PayloadStorage
 	retainCount  uint64
@@ -36,7 +34,7 @@ type ManagedStorage struct {
 	cache        map[string]*cachedEntry
 	maxEpoch     uint64
 	minPruned    uint64
-	failedEpochs map[uint64]bool
+	failedEpochs map[uint64]int
 }
 
 func NewManagedStorage(storage PayloadStorage, retainCount uint64, cacheTTL time.Duration) *ManagedStorage {
@@ -50,7 +48,7 @@ func NewManagedStorageWithSize(storage PayloadStorage, retainCount uint64, cache
 		cacheTTL:     cacheTTL,
 		maxCacheSize: maxCacheSize,
 		cache:        make(map[string]*cachedEntry),
-		failedEpochs: make(map[uint64]bool),
+		failedEpochs: make(map[uint64]int),
 	}
 	go m.cleanupLoop()
 	return m
@@ -147,16 +145,34 @@ func (m *ManagedStorage) cleanup() {
 	}
 	m.mu.Unlock()
 
-	// Prune sequentially outside the lock so Store/Retrieve are not blocked.
-	// On failure, isolate the epoch in failedEpochs and continue — a single
-	// persistent failure must not block pruning of subsequent epochs.
 	if pruneFrom < pruneTo {
 		for epoch := pruneFrom; epoch < pruneTo; epoch++ {
 			if err := m.storage.PruneEpoch(context.Background(), epoch); err != nil {
-				logging.Warn("Auto-prune failed", types.PayloadStorage, "epochId", epoch, "error", err)
 				m.mu.Lock()
-				m.failedEpochs[epoch] = true
+				m.failedEpochs[epoch]++
+				attempts := m.failedEpochs[epoch]
+				drop := attempts >= maxRetryAttempts
+				if drop {
+					delete(m.failedEpochs, epoch)
+				}
+				if len(m.failedEpochs) > maxFailedEpochs {
+					var oldest uint64
+					first := true
+					for e := range m.failedEpochs {
+						if first || e < oldest {
+							oldest = e
+							first = false
+						}
+					}
+					delete(m.failedEpochs, oldest)
+				}
 				m.mu.Unlock()
+
+				if drop {
+					logging.Error("Auto-prune persistent failure", types.PayloadStorage, "epochId", epoch, "error", err, "attempts", attempts)
+				} else if attempts == 1 {
+					logging.Warn("Auto-prune failed", types.PayloadStorage, "epochId", epoch, "error", err, "attempt", attempts)
+				}
 				continue
 			}
 			logging.Info("Auto-pruned epoch", types.PayloadStorage, "epochId", epoch)
@@ -164,12 +180,11 @@ func (m *ManagedStorage) cleanup() {
 			if epoch+1 > m.minPruned {
 				m.minPruned = epoch + 1
 			}
+			delete(m.failedEpochs, epoch)
 			m.mu.Unlock()
 		}
 	}
 
-	// Retry previously failed epochs. Idempotent PruneEpoch guarantees
-	// that re-attempting an already-pruned epoch is a safe no-op.
 	m.mu.RLock()
 	retries := make([]uint64, 0, len(m.failedEpochs))
 	for e := range m.failedEpochs {
@@ -179,7 +194,18 @@ func (m *ManagedStorage) cleanup() {
 
 	for _, e := range retries {
 		if err := m.storage.PruneEpoch(context.Background(), e); err != nil {
-			logging.Warn("Auto-prune retry failed", types.PayloadStorage, "epochId", e, "error", err)
+			m.mu.Lock()
+			m.failedEpochs[e]++
+			attempts := m.failedEpochs[e]
+			drop := attempts >= maxRetryAttempts
+			if drop {
+				delete(m.failedEpochs, e)
+			}
+			m.mu.Unlock()
+
+			if drop {
+				logging.Error("Auto-prune retry persistent failure", types.PayloadStorage, "epochId", e, "error", err, "attempts", attempts)
+			}
 			continue
 		}
 		logging.Info("Auto-pruned previously failed epoch", types.PayloadStorage, "epochId", e)

--- a/decentralized-api/payloadstorage/managed_storage_test.go
+++ b/decentralized-api/payloadstorage/managed_storage_test.go
@@ -250,11 +250,61 @@ func TestManagedStorage_NoPruneWhenBelowRetainCount(t *testing.T) {
 	}
 
 	ms.cleanup()
-	time.Sleep(50 * time.Millisecond)
 
 	pruned := mock.getPruned()
 	if len(pruned) != 0 {
 		t.Errorf("should not prune when maxEpoch <= retainCount, got %v", pruned)
+	}
+}
+
+// failingMockStorage fails PruneEpoch for specific epochs (for testing partial progress).
+type failingMockStorage struct {
+	*mockStorage
+	failEpochs map[uint64]bool
+}
+
+func newFailingMockStorage(failEpochs map[uint64]bool) *failingMockStorage {
+	return &failingMockStorage{mockStorage: newMockStorage(), failEpochs: failEpochs}
+}
+
+func (f *failingMockStorage) PruneEpoch(ctx context.Context, epochId uint64) error {
+	if f.failEpochs[epochId] {
+		return ErrNotFound
+	}
+	return f.mockStorage.PruneEpoch(ctx, epochId)
+}
+
+func TestManagedStorage_PartialProgressOnPruneFailure(t *testing.T) {
+	mock := newFailingMockStorage(map[uint64]bool{1: true}) // epoch 1 fails
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 5; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// threshold = 5 - 2 = 3. Epoch 0 succeeds, epoch 1 fails, epoch 2 not attempted.
+	// minPruned should advance to 1 (partial progress past epoch 0).
+	ms.cleanup()
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+
+	if minPruned != 1 {
+		t.Errorf("minPruned should advance to 1 (epoch 0 succeeded, epoch 1 failed), got %d", minPruned)
+	}
+
+	// Second cleanup: fix the mock so epoch 1 succeeds, then epoch 2 also succeeds.
+	mock.failEpochs = nil
+	ms.cleanup()
+
+	ms.mu.RLock()
+	minPruned = ms.minPruned
+	ms.mu.RUnlock()
+
+	if minPruned != 3 {
+		t.Errorf("minPruned should advance to 3 (all epochs succeeded), got %d", minPruned)
 	}
 }
 

--- a/decentralized-api/payloadstorage/managed_storage_test.go
+++ b/decentralized-api/payloadstorage/managed_storage_test.go
@@ -401,7 +401,6 @@ func TestManagedStorage_LookbackCapCleansFailedEpochs(t *testing.T) {
 	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
 	ctx := context.Background()
 
-	// Jump to epoch 100 so threshold = 98, lookback cap sets minPruned = 88
 	ms.Store(ctx, "inf-1", 100, []byte("p"), []byte("r"))
 	ms.cleanup()
 
@@ -414,11 +413,7 @@ func TestManagedStorage_LookbackCapCleansFailedEpochs(t *testing.T) {
 		t.Errorf("minPruned should be 98 after cleanup, got %d", minPruned)
 	}
 
-	// Now jump far ahead so lookback cap would skip past the failed epoch
 	ms.Store(ctx, "inf-2", 120, []byte("p"), []byte("r"))
-	// threshold = 120 - 2 = 118
-	// minPruned(98) + maxPruneLookback(10) = 108 < 118 → minPruned jumps to 118-10 = 108
-	// Epoch 88 is below new minPruned(108) → should be cleaned from failedEpochs
 	ms.cleanup()
 
 	ms.mu.RLock()
@@ -431,5 +426,64 @@ func TestManagedStorage_LookbackCapCleansFailedEpochs(t *testing.T) {
 	}
 	if failedCount != 0 {
 		t.Errorf("failedEpochs should be empty (epoch 88 below minPruned), got %d entries", failedCount)
+	}
+}
+
+func TestManagedStorage_MaxRetriesDropsEpoch(t *testing.T) {
+	mock := newFailingMockStorage(map[uint64]bool{1: true})
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 5; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// First cleanup: main loop fail (attempt 1) + retry fail (attempt 2)
+	ms.cleanup()
+	// Subsequent cleanups: retry only. Need 3 more to reach maxRetryAttempts (5).
+	for i := 0; i < 3; i++ {
+		ms.cleanup()
+	}
+
+	ms.mu.RLock()
+	failedCount := len(ms.failedEpochs)
+	ms.mu.RUnlock()
+
+	if failedCount != 0 {
+		t.Errorf("failedEpochs should be empty after max retries, got %d", failedCount)
+	}
+}
+
+func TestManagedStorage_NoRedundantRetryAfterMainLoopSuccess(t *testing.T) {
+	mock := newFailingMockStorage(map[uint64]bool{2: true})
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 5; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	ms.cleanup()
+
+	ms.mu.RLock()
+	if _, ok := ms.failedEpochs[2]; !ok {
+		t.Fatalf("epoch 2 should be in failedEpochs after first cleanup")
+	}
+	ms.mu.RUnlock()
+
+	// Fix the mock and record pruned state after first cleanup
+	mock.failEpochs = nil
+	afterFirst := mock.getPruned()
+
+	ms.cleanup()
+
+	afterSecond := mock.getPruned()
+	newCalls := len(afterSecond) - len(afterFirst)
+
+	if newCalls != 1 {
+		t.Errorf("epoch 2 should be pruned exactly once in second cleanup, got %d new calls: %v", newCalls, afterSecond)
+	}
+	if afterSecond[len(afterSecond)-1] != 2 {
+		t.Errorf("expected epoch 2 as the new prune call, got %v", afterSecond)
 	}
 }

--- a/decentralized-api/payloadstorage/managed_storage_test.go
+++ b/decentralized-api/payloadstorage/managed_storage_test.go
@@ -3,6 +3,7 @@ package payloadstorage
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -74,18 +75,15 @@ func TestManagedStorage_CacheHit(t *testing.T) {
 		t.Fatalf("Store failed: %v", err)
 	}
 
-	// First retrieve - cache miss
 	p1, r1, err := ms.Retrieve(ctx, "inf-1", 1)
 	if err != nil {
 		t.Fatalf("Retrieve failed: %v", err)
 	}
 
-	// Modify underlying storage
 	mock.mu.Lock()
 	mock.data["inf-1"] = []byte("modifiedmodified")
 	mock.mu.Unlock()
 
-	// Second retrieve - should hit cache, return original data
 	p2, r2, err := ms.Retrieve(ctx, "inf-1", 1)
 	if err != nil {
 		t.Fatalf("Retrieve failed: %v", err)
@@ -105,21 +103,17 @@ func TestManagedStorage_CacheExpiration(t *testing.T) {
 		t.Fatalf("Store failed: %v", err)
 	}
 
-	// First retrieve
 	_, _, err := ms.Retrieve(ctx, "inf-1", 1)
 	if err != nil {
 		t.Fatalf("Retrieve failed: %v", err)
 	}
 
-	// Modify underlying storage
 	mock.mu.Lock()
 	mock.data["inf-1"] = []byte("newdatnewdat")
 	mock.mu.Unlock()
 
-	// Wait for cache to expire
 	time.Sleep(15 * time.Millisecond)
 
-	// Retrieve should get new data
 	p, r, err := ms.Retrieve(ctx, "inf-1", 1)
 	if err != nil {
 		t.Fatalf("Retrieve failed: %v", err)
@@ -135,7 +129,6 @@ func TestManagedStorage_StoreTracksMaxEpoch(t *testing.T) {
 	ms := NewManagedStorageWithSize(mock, 3, time.Minute, 100)
 	ctx := context.Background()
 
-	// Store in various epochs
 	ms.Store(ctx, "inf-1", 5, []byte("p"), []byte("r"))
 	ms.Store(ctx, "inf-2", 3, []byte("p"), []byte("r"))
 	ms.Store(ctx, "inf-3", 10, []byte("p"), []byte("r"))
@@ -155,21 +148,13 @@ func TestManagedStorage_AutoPruneTriggersInCleanup(t *testing.T) {
 	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
 	ctx := context.Background()
 
-	// Store enough to trigger pruning (retainCount=2, so epochs 0-7 should be pruned when maxEpoch=10)
 	for i := uint64(0); i <= 10; i++ {
 		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
 	}
 
-	// Trigger cleanup manually
 	ms.cleanup()
 
-	// Wait for async prune goroutines
-	time.Sleep(50 * time.Millisecond)
-
 	pruned := mock.getPruned()
-	// threshold = 10 - 2 = 8
-	// minPruned starts at 0, but only last 10 should be pruned
-	// so epochs 0-7 should be pruned (8 epochs)
 	if len(pruned) != 8 {
 		t.Errorf("expected 8 epochs pruned, got %d: %v", len(pruned), pruned)
 	}
@@ -180,22 +165,15 @@ func TestManagedStorage_AutoPruneSkipsOldEpochs(t *testing.T) {
 	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
 	ctx := context.Background()
 
-	// Jump straight to epoch 100 (simulating restart with existing data)
 	ms.Store(ctx, "inf-1", 100, []byte("p"), []byte("r"))
 
-	// Trigger cleanup
 	ms.cleanup()
-	time.Sleep(50 * time.Millisecond)
 
 	pruned := mock.getPruned()
-	// threshold = 100 - 2 = 98
-	// minPruned=0, but 0 + 10 < 98, so minPruned should jump to 98 - 10 = 88
-	// Only epochs 88-97 should be pruned (10 epochs max)
 	if len(pruned) > maxPruneLookback {
 		t.Errorf("should prune at most %d epochs, got %d: %v", maxPruneLookback, len(pruned), pruned)
 	}
 
-	// Verify we're pruning recent epochs, not from 0
 	for _, e := range pruned {
 		if e < 88 {
 			t.Errorf("should not prune epoch %d (too old, should skip)", e)
@@ -244,7 +222,6 @@ func TestManagedStorage_NoPruneWhenBelowRetainCount(t *testing.T) {
 	ms := NewManagedStorageWithSize(mock, 5, time.Minute, 100)
 	ctx := context.Background()
 
-	// Store in epochs 0-4 (maxEpoch=4, retainCount=5)
 	for i := uint64(0); i <= 4; i++ {
 		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
 	}
@@ -257,7 +234,6 @@ func TestManagedStorage_NoPruneWhenBelowRetainCount(t *testing.T) {
 	}
 }
 
-// failingMockStorage fails PruneEpoch for specific epochs (for testing partial progress).
 type failingMockStorage struct {
 	*mockStorage
 	failEpochs map[uint64]bool
@@ -269,13 +245,13 @@ func newFailingMockStorage(failEpochs map[uint64]bool) *failingMockStorage {
 
 func (f *failingMockStorage) PruneEpoch(ctx context.Context, epochId uint64) error {
 	if f.failEpochs[epochId] {
-		return ErrNotFound
+		return fmt.Errorf("prune epoch %d: simulated storage failure", epochId)
 	}
 	return f.mockStorage.PruneEpoch(ctx, epochId)
 }
 
-func TestManagedStorage_PartialProgressOnPruneFailure(t *testing.T) {
-	mock := newFailingMockStorage(map[uint64]bool{1: true}) // epoch 1 fails
+func TestManagedStorage_PrunesPastFailure(t *testing.T) {
+	mock := newFailingMockStorage(map[uint64]bool{1: true})
 	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
 	ctx := context.Background()
 
@@ -283,28 +259,177 @@ func TestManagedStorage_PartialProgressOnPruneFailure(t *testing.T) {
 		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
 	}
 
-	// threshold = 5 - 2 = 3. Epoch 0 succeeds, epoch 1 fails, epoch 2 not attempted.
-	// minPruned should advance to 1 (partial progress past epoch 0).
+	// threshold = 5 - 2 = 3.
+	// Epoch 0 succeeds, epoch 1 fails, epoch 2 succeeds.
+	// minPruned should advance past the gap to 3 (non-contiguous),
+	// epoch 1 tracked in failedEpochs.
 	ms.cleanup()
 
 	ms.mu.RLock()
 	minPruned := ms.minPruned
+	failedCount := len(ms.failedEpochs)
 	ms.mu.RUnlock()
 
-	if minPruned != 1 {
-		t.Errorf("minPruned should advance to 1 (epoch 0 succeeded, epoch 1 failed), got %d", minPruned)
+	if minPruned != 3 {
+		t.Errorf("minPruned should advance to 3 (epochs 0 and 2 succeeded), got %d", minPruned)
+	}
+	if failedCount != 1 {
+		t.Errorf("failedEpochs should contain 1 entry (epoch 1), got %d", failedCount)
 	}
 
-	// Second cleanup: fix the mock so epoch 1 succeeds, then epoch 2 also succeeds.
+	pruned := mock.getPruned()
+	prunedSet := make(map[uint64]bool)
+	for _, e := range pruned {
+		prunedSet[e] = true
+	}
+	if !prunedSet[0] || !prunedSet[2] {
+		t.Errorf("epochs 0 and 2 should be pruned, got %v", pruned)
+	}
+	if prunedSet[1] {
+		t.Errorf("epoch 1 should NOT be pruned (failed), but was in %v", pruned)
+	}
+}
+
+func TestManagedStorage_RetryHealsFailedEpoch(t *testing.T) {
+	mock := newFailingMockStorage(map[uint64]bool{1: true})
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 5; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	ms.cleanup()
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	failedCount := len(ms.failedEpochs)
+	ms.mu.RUnlock()
+
+	if minPruned != 3 {
+		t.Errorf("minPruned should be 3 after first cleanup, got %d", minPruned)
+	}
+	if failedCount != 1 {
+		t.Errorf("failedEpochs should have 1 entry, got %d", failedCount)
+	}
+
+	// Fix the mock so epoch 1 succeeds, then run cleanup again.
 	mock.failEpochs = nil
 	ms.cleanup()
 
 	ms.mu.RLock()
 	minPruned = ms.minPruned
+	failedCount = len(ms.failedEpochs)
 	ms.mu.RUnlock()
 
 	if minPruned != 3 {
-		t.Errorf("minPruned should advance to 3 (all epochs succeeded), got %d", minPruned)
+		t.Errorf("minPruned should remain 3 (no new eligible epochs), got %d", minPruned)
+	}
+	if failedCount != 0 {
+		t.Errorf("failedEpochs should be empty after retry success, got %d entries", failedCount)
+	}
+
+	pruned := mock.getPruned()
+	prunedSet := make(map[uint64]bool)
+	for _, e := range pruned {
+		prunedSet[e] = true
+	}
+	if !prunedSet[1] {
+		t.Errorf("epoch 1 should be pruned after retry, got %v", pruned)
 	}
 }
 
+func TestManagedStorage_PersistentFailureDoesNotBlockSubsequentEpochs(t *testing.T) {
+	mock := newFailingMockStorage(map[uint64]bool{1: true})
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 5; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// Tick 1: epoch 1 fails, but epochs 0 and 2 succeed.
+	ms.cleanup()
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	failedCount := len(ms.failedEpochs)
+	ms.mu.RUnlock()
+
+	if minPruned != 3 {
+		t.Errorf("minPruned should be 3 after first cleanup, got %d", minPruned)
+	}
+	if failedCount != 1 {
+		t.Errorf("failedEpochs should have 1 entry, got %d", failedCount)
+	}
+
+	// Tick 2: epoch 1 still fails. New epochs arrived.
+	for i := uint64(6); i <= 8; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// threshold = 8 - 2 = 6. pruneFrom = minPruned = 3.
+	// Epochs 3, 4, 5 should be pruned. Epoch 1 retry still fails.
+	ms.cleanup()
+
+	ms.mu.RLock()
+	minPruned = ms.minPruned
+	failedCount = len(ms.failedEpochs)
+	ms.mu.RUnlock()
+
+	if minPruned != 6 {
+		t.Errorf("minPruned should advance to 6 (epochs 3-5 pruned), got %d", minPruned)
+	}
+	if failedCount != 1 {
+		t.Errorf("failedEpochs should still have 1 entry (epoch 1), got %d", failedCount)
+	}
+
+	pruned := mock.getPruned()
+	prunedSet := make(map[uint64]bool)
+	for _, e := range pruned {
+		prunedSet[e] = true
+	}
+	for _, e := range []uint64{3, 4, 5} {
+		if !prunedSet[e] {
+			t.Errorf("epoch %d should be pruned despite persistent failure at epoch 1", e)
+		}
+	}
+}
+
+func TestManagedStorage_LookbackCapCleansFailedEpochs(t *testing.T) {
+	mock := newFailingMockStorage(map[uint64]bool{88: true})
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	// Jump to epoch 100 so threshold = 98, lookback cap sets minPruned = 88
+	ms.Store(ctx, "inf-1", 100, []byte("p"), []byte("r"))
+	ms.cleanup()
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	failedCount := len(ms.failedEpochs)
+	ms.mu.RUnlock()
+
+	if minPruned != 98 {
+		t.Errorf("minPruned should be 98 after cleanup, got %d", minPruned)
+	}
+
+	// Now jump far ahead so lookback cap would skip past the failed epoch
+	ms.Store(ctx, "inf-2", 120, []byte("p"), []byte("r"))
+	// threshold = 120 - 2 = 118
+	// minPruned(98) + maxPruneLookback(10) = 108 < 118 → minPruned jumps to 118-10 = 108
+	// Epoch 88 is below new minPruned(108) → should be cleaned from failedEpochs
+	ms.cleanup()
+
+	ms.mu.RLock()
+	minPruned = ms.minPruned
+	failedCount = len(ms.failedEpochs)
+	ms.mu.RUnlock()
+
+	if minPruned != 118 {
+		t.Errorf("minPruned should be 118 after lookahead cap, got %d", minPruned)
+	}
+	if failedCount != 0 {
+		t.Errorf("failedEpochs should be empty (epoch 88 below minPruned), got %d entries", failedCount)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #850

`minPruned` was advanced to `threshold` synchronously before pruning goroutines completed.
If any goroutine failed, that epoch was silently skipped forever — no retry on the next cycle.

## Fix

Removed the bulk advance. Each goroutine now advances `minPruned` by one only after
its own `PruneEpoch` call succeeds, so failed epochs remain eligible for retry on
the next 30-second cleanup tick.

## Files changed

- `decentralized-api/payloadstorage/managed_storage.go` — `cleanup()`