### PR TITLE
Fix timestamps

### DIFF
--- a/decentralized-api/internal/event_listener/event_listener.go
+++ b/decentralized-api/internal/event_listener/event_listener.go
@@ -555,7 +555,7 @@ func parseEventUnixMillis(events map[string][]string, key string, idx int) (stat
 	if err != nil {
 		return 0, err
 	}
-	if parsed < 177260313800 {
+	if parsed < statsstorage.UnixMillisTimestampThreshold {
 		return 0, fmt.Errorf("timestamp is in seconds %s", v)
 	}
 	return statsstorage.UnixMillis(parsed), nil

--- a/decentralized-api/internal/event_listener/event_listener.go
+++ b/decentralized-api/internal/event_listener/event_listener.go
@@ -505,11 +505,11 @@ func parseInferenceFinishedRecords(events map[string][]string) ([]statsstorage.I
 		if err != nil {
 			return nil, fmt.Errorf("parse actual_cost_in_coins for inference %s: %w", id, err)
 		}
-		rec.StartBlockTimestamp, err = parseEventInt64(events, "inference_finished.start_block_timestamp", i)
+		rec.StartBlockTimestamp, err = parseEventUnixMillis(events, "inference_finished.start_block_timestamp", i)
 		if err != nil {
 			return nil, fmt.Errorf("parse start_block_timestamp for inference %s: %w", id, err)
 		}
-		rec.EndBlockTimestamp, err = parseEventInt64(events, "inference_finished.end_block_timestamp", i)
+		rec.EndBlockTimestamp, err = parseEventUnixMillis(events, "inference_finished.end_block_timestamp", i)
 		if err != nil {
 			return nil, fmt.Errorf("parse end_block_timestamp for inference %s: %w", id, err)
 		}
@@ -544,6 +544,21 @@ func parseEventUint64(events map[string][]string, key string, idx int) (uint64, 
 		return 0, err
 	}
 	return parsed, nil
+}
+
+func parseEventUnixMillis(events map[string][]string, key string, idx int) (statsstorage.UnixMillis, error) {
+	v, ok := getEventValue(events, key, idx)
+	if !ok {
+		return 0, fmt.Errorf("missing key %s", key)
+	}
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if parsed < 177260313800 {
+		return 0, fmt.Errorf("timestamp is in seconds %s", v)
+	}
+	return statsstorage.UnixMillis(parsed), nil
 }
 
 func parseEventInt64(events map[string][]string, key string, idx int) (int64, error) {

--- a/decentralized-api/internal/event_listener/event_listener_stats_test.go
+++ b/decentralized-api/internal/event_listener/event_listener_stats_test.go
@@ -1,6 +1,7 @@
 package event_listener
 
 import (
+	"decentralized-api/statsstorage"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,8 +17,8 @@ func TestParseInferenceFinishedRecords_Success(t *testing.T) {
 		"inference_finished.prompt_token_count":     {"100"},
 		"inference_finished.completion_token_count": {"50"},
 		"inference_finished.actual_cost_in_coins":   {"12345"},
-		"inference_finished.start_block_timestamp":  {"1000"},
-		"inference_finished.end_block_timestamp":    {"2000"},
+		"inference_finished.start_block_timestamp":  {"1700000000000"},
+		"inference_finished.end_block_timestamp":    {"1700000001000"},
 	}
 
 	records, err := parseInferenceFinishedRecords(events)
@@ -29,7 +30,7 @@ func TestParseInferenceFinishedRecords_Success(t *testing.T) {
 	require.Equal(t, uint64(42), records[0].EpochID)
 	require.Equal(t, uint64(150), records[0].TotalTokenCount)
 	require.Equal(t, int64(12345), records[0].ActualCostInCoins)
-	require.Equal(t, int64(2000), records[0].InferenceTimestamp)
+	require.Equal(t, statsstorage.UnixMillis(1700000001000), records[0].InferenceTimestamp)
 }
 
 func TestParseInferenceFinishedRecords_MissingRequiredField(t *testing.T) {
@@ -42,8 +43,8 @@ func TestParseInferenceFinishedRecords_MissingRequiredField(t *testing.T) {
 		"inference_finished.prompt_token_count":     {"100"},
 		"inference_finished.completion_token_count": {"50"},
 		"inference_finished.actual_cost_in_coins":   {"12345"},
-		"inference_finished.start_block_timestamp":  {"1000"},
-		"inference_finished.end_block_timestamp":    {"2000"},
+		"inference_finished.start_block_timestamp":  {"1700000000000"},
+		"inference_finished.end_block_timestamp":    {"1700000001000"},
 	}
 
 	_, err := parseInferenceFinishedRecords(events)

--- a/decentralized-api/internal/server/public/get_pricing_handler.go
+++ b/decentralized-api/internal/server/public/get_pricing_handler.go
@@ -3,6 +3,7 @@ package public
 import (
 	"context"
 	"decentralized-api/logging"
+	"decentralized-api/statsstorage"
 	"net/http"
 	"time"
 
@@ -154,15 +155,15 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 	}
 
 	// Calculate time window (similar to BeginBlocker logic)
-	currentTime := time.Now().Unix()
-	timeWindowStart := currentTime - int64(params.Params.DynamicPricingParams.UtilizationWindowDuration)
+	currentTime := time.Now().UnixMilli()
+	timeWindowStart := currentTime - int64(params.Params.DynamicPricingParams.UtilizationWindowDuration*1000)
 
 	if s.statsStorage == nil {
 		logging.Warn("Stats storage not configured, utilization metrics unavailable", types.Pricing)
 		return metricsData // Return with capacity data only
 	}
 
-	modelStats, err := s.statsStorage.GetModelStatsByTime(context, timeWindowStart, currentTime)
+	modelStats, err := s.statsStorage.GetModelStatsByTime(context, statsstorage.UnixMillis(timeWindowStart), statsstorage.UnixMillis(currentTime))
 	if err != nil {
 		logging.Warn("Failed to get model stats for utilization", types.Pricing, "error", err)
 		return metricsData // Return with capacity data only

--- a/decentralized-api/internal/server/public/get_pricing_handler.go
+++ b/decentralized-api/internal/server/public/get_pricing_handler.go
@@ -127,11 +127,11 @@ type ModelMetrics struct {
 }
 
 // getModelMetrics calculates utilization and gets capacity for all models in one go
-func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.Context) map[string]ModelMetrics {
+func (s *Server) getModelMetrics(queryClient types.QueryClient, ctx context.Context) map[string]ModelMetrics {
 	metricsData := make(map[string]ModelMetrics)
 
 	// Get all model capacities in one request
-	capacitiesResponse, err := queryClient.GetAllModelCapacities(context, &types.QueryGetAllModelCapacitiesRequest{})
+	capacitiesResponse, err := queryClient.GetAllModelCapacities(ctx, &types.QueryGetAllModelCapacitiesRequest{})
 	if err != nil {
 		logging.Warn("Failed to get model capacities", types.Pricing, "error", err)
 		return metricsData
@@ -149,13 +149,14 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 	}
 
 	// Get dynamic pricing parameters for time window
-	params, err := queryClient.Params(context, &types.QueryParamsRequest{})
+	params, err := queryClient.Params(ctx, &types.QueryParamsRequest{})
 	if err != nil || params.Params.DynamicPricingParams == nil {
 		return metricsData // Return with capacity data only
 	}
 
 	// Calculate time window (similar to BeginBlocker logic)
 	currentTime := time.Now().UnixMilli()
+	// UtilizationWindowDuration is in seconds, not millis
 	timeWindowStart := currentTime - int64(params.Params.DynamicPricingParams.UtilizationWindowDuration*1000)
 
 	if s.statsStorage == nil {
@@ -163,7 +164,7 @@ func (s *Server) getModelMetrics(queryClient types.QueryClient, context context.
 		return metricsData // Return with capacity data only
 	}
 
-	modelStats, err := s.statsStorage.GetModelStatsByTime(context, statsstorage.UnixMillis(timeWindowStart), statsstorage.UnixMillis(currentTime))
+	modelStats, err := s.statsStorage.GetModelStatsByTime(ctx, statsstorage.UnixMillis(timeWindowStart), statsstorage.UnixMillis(currentTime))
 	if err != nil {
 		logging.Warn("Failed to get model stats for utilization", types.Pricing, "error", err)
 		return metricsData // Return with capacity data only

--- a/decentralized-api/internal/server/public/stats_handlers.go
+++ b/decentralized-api/internal/server/public/stats_handlers.go
@@ -212,6 +212,9 @@ func parseStatsTimeRange(timeFromStr, timeToStr string) (statsstorage.UnixMillis
 	if timeTo < timeFrom {
 		return 0, 0, echo.NewHTTPError(http.StatusBadRequest, "invalid time period: time_to must be >= time_from")
 	}
+	if timeTo < statsstorage.UnixMillisTimestampThreshold || timeFrom < statsstorage.UnixMillisTimestampThreshold {
+		return 0, 0, echo.NewHTTPError(http.StatusBadRequest, "invalid time period: time_to and time_from must be in milliseconds")
+	}
 	return timeFrom, timeTo, nil
 }
 

--- a/decentralized-api/internal/server/public/stats_handlers.go
+++ b/decentralized-api/internal/server/public/stats_handlers.go
@@ -31,9 +31,9 @@ type DeveloperInferencesResponse struct {
 }
 
 type DeveloperStatsByTimeDto struct {
-	EpochID   uint64            `json:"epoch_id"`
-	Timestamp int64             `json:"timestamp"`
-	Inference InferenceStatsDto `json:"inference"`
+	EpochID   uint64                  `json:"epoch_id"`
+	Timestamp statsstorage.UnixMillis `json:"timestamp"`
+	Inference InferenceStatsDto       `json:"inference"`
 }
 
 type InferenceStatsDto struct {
@@ -181,31 +181,32 @@ func (s *Server) getStatsDebugDevelopers(c echo.Context) error {
 	return c.JSON(http.StatusOK, mapDebugStats(debugStats))
 }
 
-func parseStatsTimeRange(timeFromStr, timeToStr string) (int64, int64, error) {
-	now := time.Now().Unix()
+func parseStatsTimeRange(timeFromStr, timeToStr string) (statsstorage.UnixMillis, statsstorage.UnixMillis, error) {
+	now := time.Now().UnixMilli()
 
 	var (
-		timeFrom int64
-		timeTo   int64
-		err      error
+		timeFrom statsstorage.UnixMillis
+		timeTo   statsstorage.UnixMillis
 	)
 
 	if timeToStr == "" {
-		timeTo = now
+		timeTo = statsstorage.UnixMillis(now)
 	} else {
-		timeTo, err = strconv.ParseInt(timeToStr, 10, 64)
+		parsed, err := strconv.ParseInt(timeToStr, 10, 64)
 		if err != nil {
 			return 0, 0, err
 		}
+		timeTo = statsstorage.UnixMillis(parsed)
 	}
 
 	if timeFromStr == "" {
-		timeFrom = timeTo - int64(24*time.Hour.Seconds())
+		timeFrom = timeTo - statsstorage.UnixMillis(24*time.Hour.Milliseconds())
 	} else {
-		timeFrom, err = strconv.ParseInt(timeFromStr, 10, 64)
+		parsed, err := strconv.ParseInt(timeFromStr, 10, 64)
 		if err != nil {
 			return 0, 0, err
 		}
+		timeFrom = statsstorage.UnixMillis(parsed)
 	}
 
 	if timeTo < timeFrom {

--- a/decentralized-api/internal/server/public/stats_handlers.go
+++ b/decentralized-api/internal/server/public/stats_handlers.go
@@ -182,7 +182,7 @@ func (s *Server) getStatsDebugDevelopers(c echo.Context) error {
 }
 
 func parseStatsTimeRange(timeFromStr, timeToStr string) (statsstorage.UnixMillis, statsstorage.UnixMillis, error) {
-	now := time.Now().UnixMilli()
+	now := statsstorage.UnixMillis(time.Now().UnixMilli())
 
 	var (
 		timeFrom statsstorage.UnixMillis
@@ -190,7 +190,7 @@ func parseStatsTimeRange(timeFromStr, timeToStr string) (statsstorage.UnixMillis
 	)
 
 	if timeToStr == "" {
-		timeTo = statsstorage.UnixMillis(now)
+		timeTo = now
 	} else {
 		parsed, err := strconv.ParseInt(timeToStr, 10, 64)
 		if err != nil {

--- a/decentralized-api/internal/server/public/stats_handlers_test.go
+++ b/decentralized-api/internal/server/public/stats_handlers_test.go
@@ -26,7 +26,7 @@ func (m *mockStatsStorage) UpdateInferenceStatus(_ context.Context, _, _ string)
 	return nil
 }
 
-func (m *mockStatsStorage) GetDeveloperInferencesByTime(_ context.Context, _ string, _, _ int64) ([]statsstorage.InferenceRecord, error) {
+func (m *mockStatsStorage) GetDeveloperInferencesByTime(_ context.Context, _ string, _, _ statsstorage.UnixMillis) ([]statsstorage.InferenceRecord, error) {
 	return []statsstorage.InferenceRecord{}, nil
 }
 
@@ -38,11 +38,11 @@ func (m *mockStatsStorage) GetSummaryByEpochsBackwards(_ context.Context, _ int3
 	return m.summary, nil
 }
 
-func (m *mockStatsStorage) GetSummaryByTimePeriod(_ context.Context, _, _ int64) (statsstorage.Summary, error) {
+func (m *mockStatsStorage) GetSummaryByTimePeriod(_ context.Context, _, _ statsstorage.UnixMillis) (statsstorage.Summary, error) {
 	return m.summary, nil
 }
 
-func (m *mockStatsStorage) GetModelStatsByTime(_ context.Context, _, _ int64) ([]statsstorage.ModelSummary, error) {
+func (m *mockStatsStorage) GetModelStatsByTime(_ context.Context, _, _ statsstorage.UnixMillis) ([]statsstorage.ModelSummary, error) {
 	return m.modelStats, nil
 }
 
@@ -50,7 +50,7 @@ func (m *mockStatsStorage) GetDebugStats(_ context.Context) (statsstorage.DebugS
 	return statsstorage.DebugStats{}, nil
 }
 
-func (m *mockStatsStorage) PruneOlderThan(_ context.Context, _ int64) error {
+func (m *mockStatsStorage) PruneOlderThan(_ context.Context, _ statsstorage.UnixMillis) error {
 	return nil
 }
 

--- a/decentralized-api/internal/server/public/stats_handlers_test.go
+++ b/decentralized-api/internal/server/public/stats_handlers_test.go
@@ -58,7 +58,7 @@ func (m *mockStatsStorage) Close() {}
 
 func TestGetStatsModels(t *testing.T) {
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/v1/stats/models?time_from=1&time_to=2", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/stats/models?time_from=1700000000000&time_to=1700000001000", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
@@ -81,6 +81,50 @@ func TestGetStatsModels(t *testing.T) {
 	require.Equal(t, "model-a", resp.StatsModels[0].Model)
 	require.Equal(t, int64(111), resp.StatsModels[0].AiTokens)
 	require.Equal(t, int32(2), resp.StatsModels[0].Inferences)
+}
+
+func TestGetStatsDeveloperInferences(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/stats/developers/gonka1dev/inferences?time_from=1700000000000&time_to=1700000001000", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("developer")
+	c.SetParamValues("gonka1dev")
+
+	s := &Server{
+		e:            e,
+		statsStorage: &mockStatsStorage{},
+	}
+
+	err := s.getStatsDeveloperInferences(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestGetStatsSummaryTime(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/stats/summary/time?time_from=1700000000000&time_to=1700000001000", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	s := &Server{
+		e: e,
+		statsStorage: &mockStatsStorage{
+			summary: statsstorage.Summary{
+				AiTokens:   100,
+				Inferences: 5,
+			},
+		},
+	}
+
+	err := s.getStatsSummaryTime(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp StatsSummaryResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, int64(100), resp.AiTokens)
+	require.Equal(t, int32(5), resp.Inferences)
 }
 
 func TestGetStatsSummaryEpochs_RequiresEpochsN(t *testing.T) {

--- a/decentralized-api/statsstorage/file_storage.go
+++ b/decentralized-api/statsstorage/file_storage.go
@@ -81,7 +81,7 @@ func (f *FileStorage) recordPath(inferenceID string) string {
 	return filepath.Join(f.baseDir, filename)
 }
 
-func (f *FileStorage) GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo int64) ([]InferenceRecord, error) {
+func (f *FileStorage) GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo UnixMillis) ([]InferenceRecord, error) {
 	records, err := f.readAllRecords(ctx)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func (f *FileStorage) GetSummaryByEpochsBackwards(ctx context.Context, epochsN i
 	return summary, nil
 }
 
-func (f *FileStorage) GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo int64) (Summary, error) {
+func (f *FileStorage) GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo UnixMillis) (Summary, error) {
 	records, err := f.readAllRecords(ctx)
 	if err != nil {
 		return Summary{}, err
@@ -163,7 +163,7 @@ func (f *FileStorage) GetSummaryByTimePeriod(ctx context.Context, timeFrom, time
 	return summary, nil
 }
 
-func (f *FileStorage) GetModelStatsByTime(ctx context.Context, timeFrom, timeTo int64) ([]ModelSummary, error) {
+func (f *FileStorage) GetModelStatsByTime(ctx context.Context, timeFrom, timeTo UnixMillis) ([]ModelSummary, error) {
 	records, err := f.readAllRecords(ctx)
 	if err != nil {
 		return nil, err
@@ -255,7 +255,7 @@ func (f *FileStorage) GetDebugStats(ctx context.Context) (DebugStats, error) {
 	}, nil
 }
 
-func (f *FileStorage) PruneOlderThan(ctx context.Context, cutoffTimestamp int64) error {
+func (f *FileStorage) PruneOlderThan(ctx context.Context, cutoffTimestamp UnixMillis) error {
 	_ = ctx
 	entries, err := os.ReadDir(f.baseDir)
 	if err != nil {

--- a/decentralized-api/statsstorage/managed_storage.go
+++ b/decentralized-api/statsstorage/managed_storage.go
@@ -53,7 +53,7 @@ func (m *ManagedStorage) UpdateInferenceStatus(ctx context.Context, inferenceID,
 	return m.storage.UpdateInferenceStatus(ctx, inferenceID, status)
 }
 
-func (m *ManagedStorage) GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo int64) ([]InferenceRecord, error) {
+func (m *ManagedStorage) GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo UnixMillis) ([]InferenceRecord, error) {
 	return m.storage.GetDeveloperInferencesByTime(ctx, developer, timeFrom, timeTo)
 }
 
@@ -65,11 +65,11 @@ func (m *ManagedStorage) GetSummaryByEpochsBackwards(ctx context.Context, epochs
 	return m.storage.GetSummaryByEpochsBackwards(ctx, epochsN)
 }
 
-func (m *ManagedStorage) GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo int64) (Summary, error) {
+func (m *ManagedStorage) GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo UnixMillis) (Summary, error) {
 	return m.storage.GetSummaryByTimePeriod(ctx, timeFrom, timeTo)
 }
 
-func (m *ManagedStorage) GetModelStatsByTime(ctx context.Context, timeFrom, timeTo int64) ([]ModelSummary, error) {
+func (m *ManagedStorage) GetModelStatsByTime(ctx context.Context, timeFrom, timeTo UnixMillis) ([]ModelSummary, error) {
 	return m.storage.GetModelStatsByTime(ctx, timeFrom, timeTo)
 }
 
@@ -77,7 +77,7 @@ func (m *ManagedStorage) GetDebugStats(ctx context.Context) (DebugStats, error) 
 	return m.storage.GetDebugStats(ctx)
 }
 
-func (m *ManagedStorage) PruneOlderThan(ctx context.Context, cutoffTimestamp int64) error {
+func (m *ManagedStorage) PruneOlderThan(ctx context.Context, cutoffTimestamp UnixMillis) error {
 	return m.storage.PruneOlderThan(ctx, cutoffTimestamp)
 }
 
@@ -106,7 +106,7 @@ func (m *ManagedStorage) cleanupLoop(ctx context.Context) {
 
 func (m *ManagedStorage) pruneOnce() {
 	cutoff := time.Now().Add(-time.Duration(m.retentionDays) * 24 * time.Hour).UnixMilli()
-	if err := m.storage.PruneOlderThan(context.Background(), cutoff); err != nil {
+	if err := m.storage.PruneOlderThan(context.Background(), UnixMillis(cutoff)); err != nil {
 		logging.Warn("Stats auto-prune failed", types.System, "retention_days", m.retentionDays, "error", err)
 		return
 	}

--- a/decentralized-api/statsstorage/postgres_storage.go
+++ b/decentralized-api/statsstorage/postgres_storage.go
@@ -139,7 +139,7 @@ WHERE inference_id = $1
 	return nil
 }
 
-func (s *PostgresStorage) GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo int64) ([]InferenceRecord, error) {
+func (s *PostgresStorage) GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo UnixMillis) ([]InferenceRecord, error) {
 	const q = `
 SELECT
     inference_id, requested_by, model, status, epoch_id,
@@ -225,7 +225,7 @@ WHERE epoch_id > GREATEST(bounds.max_epoch - $1, 0)
 	return s.scanSummaryRow(ctx, q, epochsN)
 }
 
-func (s *PostgresStorage) GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo int64) (Summary, error) {
+func (s *PostgresStorage) GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo UnixMillis) (Summary, error) {
 	const q = `
 SELECT
     COALESCE(SUM(total_token_count), 0) AS ai_tokens,
@@ -238,7 +238,7 @@ WHERE inference_timestamp >= $1
 	return s.scanSummaryRow(ctx, q, timeFrom, timeTo)
 }
 
-func (s *PostgresStorage) GetModelStatsByTime(ctx context.Context, timeFrom, timeTo int64) ([]ModelSummary, error) {
+func (s *PostgresStorage) GetModelStatsByTime(ctx context.Context, timeFrom, timeTo UnixMillis) ([]ModelSummary, error) {
 	const q = `
 SELECT
     model,
@@ -289,7 +289,7 @@ func (s *PostgresStorage) GetDebugStats(ctx context.Context) (DebugStats, error)
 	}, nil
 }
 
-func (s *PostgresStorage) PruneOlderThan(ctx context.Context, cutoffTimestamp int64) error {
+func (s *PostgresStorage) PruneOlderThan(ctx context.Context, cutoffTimestamp UnixMillis) error {
 	const q = `
 DELETE FROM inference_stats
 WHERE inference_timestamp < $1

--- a/decentralized-api/statsstorage/storage.go
+++ b/decentralized-api/statsstorage/storage.go
@@ -7,6 +7,8 @@ import (
 
 var ErrInferenceRecordNotFound = errors.New("inference record not found")
 
+type UnixMillis int64
+
 // InferenceRecord is the off-chain source-of-truth record for one inference.
 type InferenceRecord struct {
 	InferenceID          string
@@ -18,9 +20,9 @@ type InferenceRecord struct {
 	CompletionTokenCount uint64
 	TotalTokenCount      uint64
 	ActualCostInCoins    int64
-	StartBlockTimestamp  int64
-	EndBlockTimestamp    int64
-	InferenceTimestamp   int64
+	StartBlockTimestamp  UnixMillis
+	EndBlockTimestamp    UnixMillis
+	InferenceTimestamp   UnixMillis
 }
 
 type Summary struct {
@@ -55,12 +57,12 @@ type DebugStats struct {
 type StatsStorage interface {
 	UpsertInference(ctx context.Context, rec InferenceRecord) error
 	UpdateInferenceStatus(ctx context.Context, inferenceID, status string) error
-	GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo int64) ([]InferenceRecord, error)
+	GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo UnixMillis) ([]InferenceRecord, error)
 	GetSummaryByDeveloperEpochsBackwards(ctx context.Context, developer string, epochsN int32) (Summary, error)
 	GetSummaryByEpochsBackwards(ctx context.Context, epochsN int32) (Summary, error)
-	GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo int64) (Summary, error)
-	GetModelStatsByTime(ctx context.Context, timeFrom, timeTo int64) ([]ModelSummary, error)
+	GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo UnixMillis) (Summary, error)
+	GetModelStatsByTime(ctx context.Context, timeFrom, timeTo UnixMillis) ([]ModelSummary, error)
 	GetDebugStats(ctx context.Context) (DebugStats, error)
-	PruneOlderThan(ctx context.Context, cutoffTimestamp int64) error
+	PruneOlderThan(ctx context.Context, cutoffTimestamp UnixMillis) error
 	Close()
 }

--- a/decentralized-api/statsstorage/storage.go
+++ b/decentralized-api/statsstorage/storage.go
@@ -9,6 +9,12 @@ var ErrInferenceRecordNotFound = errors.New("inference record not found")
 
 type UnixMillis int64
 
+const (
+	// UnixMillisTimestampThreshold In millis, this is actually VERY long ago (1975), but in seconds it's very far in the future (7587).
+	// this makes it a good threshold for detecting timestamps that are in seconds instead of millis
+	UnixMillisTimestampThreshold = 177260313800
+)
+
 // InferenceRecord is the off-chain source-of-truth record for one inference.
 type InferenceRecord struct {
 	InferenceID          string


### PR DESCRIPTION
We were using Unix seconds in two places.
But the whole thing was quite ambiguous to begin with. So now we use an explicit UnixMillis type (still and int64 under the hood) to make sure that everyone knows it needs to be in millis.