### PR TITLE
Disable stats storage by default

### DIFF
--- a/decentralized-api/statsstorage/disabled_storage.go
+++ b/decentralized-api/statsstorage/disabled_storage.go
@@ -1,0 +1,51 @@
+package statsstorage
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrStatsDisabled = errors.New("stats storage is disabled")
+
+// DisabledStorage is a no-op implementation of StatsStorage that returns an error for all operations.
+type DisabledStorage struct{}
+
+func (d *DisabledStorage) UpsertInference(ctx context.Context, rec InferenceRecord) error {
+	return ErrStatsDisabled
+}
+
+func (d *DisabledStorage) UpdateInferenceStatus(ctx context.Context, inferenceID, status string) error {
+	return ErrStatsDisabled
+}
+
+func (d *DisabledStorage) GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo UnixMillis) ([]InferenceRecord, error) {
+	return nil, ErrStatsDisabled
+}
+
+func (d *DisabledStorage) GetSummaryByDeveloperEpochsBackwards(ctx context.Context, developer string, epochsN int32) (Summary, error) {
+	return Summary{}, ErrStatsDisabled
+}
+
+func (d *DisabledStorage) GetSummaryByEpochsBackwards(ctx context.Context, epochsN int32) (Summary, error) {
+	return Summary{}, ErrStatsDisabled
+}
+
+func (d *DisabledStorage) GetSummaryByTimePeriod(ctx context.Context, timeFrom, timeTo UnixMillis) (Summary, error) {
+	return Summary{}, ErrStatsDisabled
+}
+
+func (d *DisabledStorage) GetModelStatsByTime(ctx context.Context, timeFrom, timeTo UnixMillis) ([]ModelSummary, error) {
+	return nil, ErrStatsDisabled
+}
+
+func (d *DisabledStorage) GetDebugStats(ctx context.Context) (DebugStats, error) {
+	return DebugStats{}, ErrStatsDisabled
+}
+
+func (d *DisabledStorage) PruneOlderThan(ctx context.Context, cutoffTimestamp UnixMillis) error {
+	return ErrStatsDisabled
+}
+
+func (d *DisabledStorage) Close() {}
+
+var _ StatsStorage = (*DisabledStorage)(nil)

--- a/decentralized-api/statsstorage/disabled_storage.go
+++ b/decentralized-api/statsstorage/disabled_storage.go
@@ -11,11 +11,11 @@ var ErrStatsDisabled = errors.New("stats storage is disabled")
 type DisabledStorage struct{}
 
 func (d *DisabledStorage) UpsertInference(ctx context.Context, rec InferenceRecord) error {
-	return ErrStatsDisabled
+	return nil
 }
 
 func (d *DisabledStorage) UpdateInferenceStatus(ctx context.Context, inferenceID, status string) error {
-	return ErrStatsDisabled
+	return nil
 }
 
 func (d *DisabledStorage) GetDeveloperInferencesByTime(ctx context.Context, developer string, timeFrom, timeTo UnixMillis) ([]InferenceRecord, error) {

--- a/decentralized-api/statsstorage/disabled_storage.go
+++ b/decentralized-api/statsstorage/disabled_storage.go
@@ -43,7 +43,7 @@ func (d *DisabledStorage) GetDebugStats(ctx context.Context) (DebugStats, error)
 }
 
 func (d *DisabledStorage) PruneOlderThan(ctx context.Context, cutoffTimestamp UnixMillis) error {
-	return ErrStatsDisabled
+	return nil
 }
 
 func (d *DisabledStorage) Close() {}

--- a/decentralized-api/statsstorage/factory.go
+++ b/decentralized-api/statsstorage/factory.go
@@ -11,30 +11,34 @@ import (
 )
 
 // NewStatsStorage creates a stats storage backend.
-// Uses PostgreSQL when configured and reachable, otherwise falls back to file storage.
+// Uses PostgreSQL when configured and reachable.
+// File storage is only used if DAPI_STATS_FILE_STORAGE_ENABLED is set to "true".
+// Otherwise, returns a disabled storage that returns errors for all stats operations.
 func NewStatsStorage(ctx context.Context) (StatsStorage, error) {
-	fileBasePath := os.Getenv("DAPI_STATS_STORAGE_PATH")
-	if fileBasePath == "" {
-		fileBasePath = "/root/.dapi/data/stats"
-	}
 	retentionDays := parseRetentionDays()
 
-	fileStorage := NewFileStorage(fileBasePath)
-
 	pgHost := os.Getenv("PGHOST")
-	if pgHost == "" {
-		logging.Info("PGHOST not set for stats storage, using file storage only", types.System,
-			"path", fileBasePath, "retention_days", retentionDays)
+	if pgHost != "" {
+		pgStorage, err := NewPostgresStorage(ctx)
+		if err == nil {
+			logging.Info("Using PostgreSQL stats storage", types.System, "host", pgHost, "retention_days", retentionDays)
+			return NewManagedStorage(pgStorage, retentionDays), nil
+		}
+		logging.Warn("PostgreSQL stats storage init failed", types.System, "host", pgHost, "error", err)
+	}
+
+	if os.Getenv("DAPI_STATS_FILE_STORAGE_ENABLED") == "true" {
+		fileBasePath := os.Getenv("DAPI_STATS_STORAGE_PATH")
+		if fileBasePath == "" {
+			fileBasePath = "/root/.dapi/data/stats"
+		}
+		logging.Warn("CRITICAL: File-based stats storage is ENABLED. This is risky and NOT RECOMMENDED for high-volume nodes as it can cause performance degradation and crashes.", types.System, "path", fileBasePath)
+		fileStorage := NewFileStorage(fileBasePath)
 		return NewManagedStorage(fileStorage, retentionDays), nil
 	}
 
-	pgStorage, err := NewPostgresStorage(ctx)
-	if err != nil {
-		logging.Warn("PostgreSQL stats storage init failed, using file storage fallback", types.System, "host", pgHost, "error", err)
-		return NewManagedStorage(fileStorage, retentionDays), nil
-	}
-	logging.Info("Using PostgreSQL stats storage", types.System, "host", pgHost, "retention_days", retentionDays)
-	return NewManagedStorage(pgStorage, retentionDays), nil
+	logging.Info("Stats storage is disabled (no PostgreSQL configured and DAPI_STATS_FILE_STORAGE_ENABLED not set)", types.System)
+	return &DisabledStorage{}, nil
 }
 
 func parseRetentionDays() int {

--- a/decentralized-api/statsstorage/factory.go
+++ b/decentralized-api/statsstorage/factory.go
@@ -24,7 +24,6 @@ func NewStatsStorage(ctx context.Context) (StatsStorage, error) {
 			logging.Info("Using PostgreSQL stats storage", types.System, "host", pgHost, "retention_days", retentionDays)
 			return NewManagedStorage(pgStorage, retentionDays), nil
 		}
-		logging.Error("PostgreSQL stats storage init failed", types.System, "host", pgHost, "error", err)
 		// Fail. If they want to be running PostgreSQL and init fails, better to stop and allow them to fix the feature than continue
 		// and lose data silently
 		return nil, err
@@ -40,7 +39,7 @@ func NewStatsStorage(ctx context.Context) (StatsStorage, error) {
 		return NewManagedStorage(fileStorage, retentionDays), nil
 	}
 
-	logging.Info("Stats storage is disabled (no PostgreSQL configured and DAPI_STATS_FILE_STORAGE_ENABLED not set)", types.System)
+	logging.Info("Stats storage is disabled", types.System)
 	return &DisabledStorage{}, nil
 }
 

--- a/decentralized-api/statsstorage/factory.go
+++ b/decentralized-api/statsstorage/factory.go
@@ -24,7 +24,10 @@ func NewStatsStorage(ctx context.Context) (StatsStorage, error) {
 			logging.Info("Using PostgreSQL stats storage", types.System, "host", pgHost, "retention_days", retentionDays)
 			return NewManagedStorage(pgStorage, retentionDays), nil
 		}
-		logging.Warn("PostgreSQL stats storage init failed", types.System, "host", pgHost, "error", err)
+		logging.Error("PostgreSQL stats storage init failed", types.System, "host", pgHost, "error", err)
+		// Fail. If they want to be running PostgreSQL and init fails, better to stop and allow them to fix the feature than continue
+		// and lose data silently
+		return nil, err
 	}
 
 	if os.Getenv("DAPI_STATS_FILE_STORAGE_ENABLED") == "true" {
@@ -32,7 +35,7 @@ func NewStatsStorage(ctx context.Context) (StatsStorage, error) {
 		if fileBasePath == "" {
 			fileBasePath = "/root/.dapi/data/stats"
 		}
-		logging.Warn("CRITICAL: File-based stats storage is ENABLED. This is risky and NOT RECOMMENDED for high-volume nodes as it can cause performance degradation and crashes.", types.System, "path", fileBasePath)
+		logging.Warn("CRITICAL: File-based stats storage is ENABLED. Use at your own peril.", types.System, "path", fileBasePath)
 		fileStorage := NewFileStorage(fileBasePath)
 		return NewManagedStorage(fileStorage, retentionDays), nil
 	}

--- a/decentralized-api/statsstorage/statsstorage.md
+++ b/decentralized-api/statsstorage/statsstorage.md
@@ -1,0 +1,35 @@
+---
+id: statsstorage
+title: implementation
+paths_filter: ["./decentralized-api/statsstorage/**"]
+---
+# Stats Storage
+
+The `statsstorage` package provides an off-chain storage system for tracking inference metrics and performance data. It is managed by a `ManagedStorage` wrapper that handles automatic data pruning based on a retention policy (default: 30 days).
+
+## Architecture
+- **StatsStorage (Interface)**: Defines operations for recording and querying inference records.
+- **ManagedStorage**: Wraps any `StatsStorage` implementation to provide automated pruning and periodic cleanup.
+- **PostgresStorage**: Recommended production backend. Stores data in a relational database with optimized indexing.
+- **FileStorage**: Experimental backend that stores each record as an individual JSON file.
+- **DisabledStorage**: Default fallback that returns errors for all stats operations.
+
+## Configuration
+
+### PostgreSQL (Recommended)
+Enabled automatically if `PGHOST` is set. Uses standard PostgreSQL environment variables (`PGUSER`, `PGPASSWORD`, etc.).
+
+### File Storage (Experimental)
+- **Status**: Disabled by default.
+- **Activation**: Set `DAPI_STATS_FILE_STORAGE_ENABLED=true`.
+- **Warning**: Enabling `FileStorage` is **NOT RECOMMENDED** for high-volume nodes. It can lead to inode exhaustion, performance degradation, and system crashes. Use at your own risk.
+- **Path**: Configurable via `DAPI_STATS_STORAGE_PATH` (defaults to `/root/.dapi/data/stats`).
+
+### Retention
+- **Policy**: Controlled by `DAPI_STATS_RETENTION_DAYS` (default: 30).
+- **Cleanup**: Runs automatically every 24 hours.
+
+## Developer Guide for AI Agents
+- **Factory**: Use `NewStatsStorage(ctx)` to instantiate the appropriate backend based on environment variables.
+- **Interfaces**: Always code against the `StatsStorage` interface.
+- **Errors**: Expect `ErrStatsDisabled` if no storage backend is configured.

--- a/inference-chain/test_genesis_overrides.json
+++ b/inference-chain/test_genesis_overrides.json
@@ -58,7 +58,8 @@
           "kb_per_output_token": {
             "value": "64",
             "exponent": "-2"
-          }
+          },
+          "invalidations_sample_period": "1"
         }
       },
       "genesis_only_params": {

--- a/local-test-net/docker-compose-base.yml
+++ b/local-test-net/docker-compose-base.yml
@@ -50,6 +50,7 @@ services:
       - DEBUG=true
       - IS_TEST_NET=true
       - ENFORCED_MODEL_ID=disabled
+      - DAPI_STATS_FILE_STORAGE_ENABLED=true
     networks:
       - chain-public
 

--- a/testermint/src/main/kotlin/DockerGroup.kt
+++ b/testermint/src/main/kotlin/DockerGroup.kt
@@ -243,6 +243,7 @@ data class DockerGroup(
             put("DAPI_TX_BATCHING__VALIDATION_V2_FLUSH_SIZE", "1")
             put("DAPI_TX_BATCHING__VALIDATION_V2_FLUSH_TIMEOUT_SECONDS", "1")
             put("DAPI_TX_BATCHING__POC_COMMIT_INTERVAL_SECONDS", "1")
+            put("DAPI_STATS_FILE_STORAGE_ENABLED", "true")
             put("NODE_CONFIG_PATH", "/root/node_config.json")
             put("NODE_CONFIG", nodeConfigFile)
             put("PUBLIC_URL", publicUrl)

--- a/testermint/src/main/kotlin/data/AppExport.kt
+++ b/testermint/src/main/kotlin/data/AppExport.kt
@@ -222,7 +222,7 @@ data class BandwidthLimitsParams(
     @SerializedName("invalidations_limit")
     val invalidationsLimit: Long,
     @SerializedName("invalidations_sample_period")
-    val invalidationsSamplePeriod: Long,
+    val invalidationsSamplePeriod: Long = 1,
     @SerializedName("invalidations_limit_curve")
     val invalidationsLimitCurve: Long,
     @SerializedName("minimum_concurrent_invalidations")


### PR DESCRIPTION
FileStorage for stats is more of an emergency/experimental feature than something we should enable by default. Preferably those wanting to heavily use stats on their nodes use the DB, but we offer the option of enabling filestorage anyhow.

1. Implement `DisabledStorage` to provide a stats storage backend that returns errors for all operations, ensuring seamless handling when stats functionality is disabled.
2. Update `NewStatsStorage` to use `DisabledStorage` when PostgreSQL and file storage are unavailable, improving fallback handling.
3. Add warnings for enabling file-based stats storage due to its potential risks in high-volume deployments.