### PR TITLE
ci: add Docker registry cache via GHCR for faster CI builds

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      packages: write
 
     with:
       test_name: "Integration Tests"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      packages: write
 
     uses: ./.github/workflows/test-workflow.yml
     secrets: inherit

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -141,15 +141,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        run: |
-          sudo mkdir -p /root/.docker
-          AUTH=$(echo -n "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" | base64 -w 0)
-          echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"${AUTH}\"}}}" | sudo tee /root/.docker/config.json > /dev/null
-
-      - name: Create Buildx builder accessible from sudo
-        run: |
-          sudo docker buildx create --name ci-builder --driver docker-container --use
-          sudo docker buildx inspect --bootstrap ci-builder
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Make
         run: |
@@ -171,9 +167,9 @@ jobs:
         env:
           GENESIS_OVERRIDES_FILE: "inference-chain/test_genesis_overrides.json"
         run: |
-          sudo -E make build-docker USE_REGISTRY_CACHE=1
+          make build-docker USE_REGISTRY_CACHE=1
           echo "=== Images immediately after build ==="
-          sudo docker images | head -20
+          docker images | head -20
 
       - name: Save Docker Images
         run: |

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -239,6 +239,7 @@ jobs:
           sudo docker load -i docker-images/decentralized-api.tar || true
           sudo docker load -i docker-images/inference-mock-server.tar || true
           sudo docker load -i docker-images/proxy.tar || true
+          rm -rf docker-images/
 
       - name: Install Make
         run: |

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Make Upgrade Build
         if: ${{ inputs.enable_upgrades }}
         run: |
-          sudo make build-for-upgrade-tests
+          make build-for-upgrade-tests USE_REGISTRY_CACHE=1
           # Fix ownership of upgrade build files
           sudo chown -R $USER:$USER public-html/ || true
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -137,6 +137,17 @@ jobs:
           docker --version
           docker compose version
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Create Buildx builder accessible from sudo
+        run: |
+          sudo docker buildx create --name ci-builder --driver docker-container --use
+          sudo docker buildx inspect --bootstrap ci-builder
+
       - name: Install Make
         run: |
           sudo apt-get update
@@ -157,7 +168,7 @@ jobs:
         env:
           GENESIS_OVERRIDES_FILE: "inference-chain/test_genesis_overrides.json"
         run: |
-          sudo make build-docker
+          sudo -E make build-docker USE_REGISTRY_CACHE=1
           echo "=== Images immediately after build ==="
           sudo docker images | head -20
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -174,14 +174,11 @@ jobs:
       - name: Save Docker Images
         run: |
           mkdir -p docker-images
-          sudo docker save -o docker-images/inference-chain.tar ghcr.io/product-science/inferenced:latest
-          sudo docker save -o docker-images/decentralized-api.tar ghcr.io/product-science/api:latest
-          sudo docker save -o docker-images/inference-mock-server.tar inference-mock-server:latest
-          sudo docker save -o docker-images/proxy.tar ghcr.io/product-science/proxy:latest
-          # Compress images to save storage space
-          sudo gzip docker-images/*.tar
-          # Fix ownership so upload-artifact can access files
-          sudo chown -R $USER:$USER docker-images/
+          docker save -o docker-images/inference-chain.tar ghcr.io/product-science/inferenced:latest
+          docker save -o docker-images/decentralized-api.tar ghcr.io/product-science/api:latest
+          docker save -o docker-images/inference-mock-server.tar inference-mock-server:latest
+          docker save -o docker-images/proxy.tar ghcr.io/product-science/proxy:latest
+          gzip docker-images/*.tar
           echo "=== Created files ==="
           ls -la docker-images/
 
@@ -237,13 +234,11 @@ jobs:
 
       - name: Load Docker Images
         run: |
-          # Decompress first
-          sudo gunzip docker-images/*.tar.gz || true
-          # Load images with :latest tags
-          sudo docker load -i docker-images/inference-chain.tar || true
-          sudo docker load -i docker-images/decentralized-api.tar || true
-          sudo docker load -i docker-images/inference-mock-server.tar || true
-          sudo docker load -i docker-images/proxy.tar || true
+          gunzip docker-images/*.tar.gz || true
+          docker load -i docker-images/inference-chain.tar || true
+          docker load -i docker-images/decentralized-api.tar || true
+          docker load -i docker-images/inference-mock-server.tar || true
+          docker load -i docker-images/proxy.tar || true
 
       - name: Install Make
         run: |

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -235,10 +235,10 @@ jobs:
       - name: Load Docker Images
         run: |
           gunzip docker-images/*.tar.gz || true
-          docker load -i docker-images/inference-chain.tar || true
-          docker load -i docker-images/decentralized-api.tar || true
-          docker load -i docker-images/inference-mock-server.tar || true
-          docker load -i docker-images/proxy.tar || true
+          sudo docker load -i docker-images/inference-chain.tar || true
+          sudo docker load -i docker-images/decentralized-api.tar || true
+          sudo docker load -i docker-images/inference-mock-server.tar || true
+          sudo docker load -i docker-images/proxy.tar || true
 
       - name: Install Make
         run: |

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -141,7 +141,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: |
+          sudo mkdir -p /root/.docker
+          AUTH=$(echo -n "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" | base64 -w 0)
+          echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"${AUTH}\"}}}" | sudo tee /root/.docker/config.json > /dev/null
 
       - name: Create Buildx builder accessible from sudo
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION ?= $(shell git describe --always)
 TAG_NAME := "release/v$(VERSION)"
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-_MOCK_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/mock-server:buildcache --cache-to type=registry,ref=ghcr.io/product-science/mock-server:buildcache,mode=max
+_MOCK_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/mock-server:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/mock-server:buildcache,mode=max
 else
 _MOCK_CACHE_ARGS :=
 endif

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION ?= $(shell git describe --always)
 TAG_NAME := "release/v$(VERSION)"
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-_MOCK_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/mock-server:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/mock-server:buildcache,mode=max
+_MOCK_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/mock-server:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/mock-server:buildcache,mode=min
 else
 _MOCK_CACHE_ARGS :=
 endif

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 
 VERSION ?= $(shell git describe --always)
 TAG_NAME := "release/v$(VERSION)"
+USE_REGISTRY_CACHE ?= 0
+ifeq ($(USE_REGISTRY_CACHE),1)
+_MOCK_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/mock-server:buildcache --cache-to type=registry,ref=ghcr.io/product-science/mock-server:buildcache,mode=max
+else
+_MOCK_CACHE_ARGS :=
+endif
 
 all: build-docker
 
@@ -17,7 +23,7 @@ mock-server-build-docker:
 	@echo "Building mock-server JAR file..."
 	@cd testermint/mock_server && ./gradlew clean && ./gradlew shadowJar
 	@echo "Building mock-server docker image..."
-	@DOCKER_BUILDKIT=1 docker build --load -t inference-mock-server -f testermint/Dockerfile testermint
+	@docker buildx build --load $(_MOCK_CACHE_ARGS) -t inference-mock-server -f testermint/Dockerfile testermint
 
 proxy-build-docker:
 	@make -C proxy build-docker SET_LATEST=1

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -5,7 +5,7 @@ SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/bridge:buildcache --cache-to type=registry,ref=ghcr.io/product-science/bridge:buildcache,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/bridge:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/bridge:buildcache,mode=max
 else
 DOCKER_CACHE_ARGS ?=
 endif

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -5,7 +5,7 @@ SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/bridge:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/bridge:buildcache,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/bridge:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/bridge:buildcache,mode=min
 else
 DOCKER_CACHE_ARGS :=
 endif

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -7,7 +7,7 @@ USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
 DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/bridge:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/bridge:buildcache,mode=max
 else
-DOCKER_CACHE_ARGS ?=
+DOCKER_CACHE_ARGS :=
 endif
 
 define DOCKER_BUILD

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -3,11 +3,19 @@
 VERSION ?= $(shell git describe --always)
 SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
+USE_REGISTRY_CACHE ?= 0
+ifeq ($(USE_REGISTRY_CACHE),1)
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/bridge:buildcache --cache-to type=registry,ref=ghcr.io/product-science/bridge:buildcache,mode=max
+else
+DOCKER_CACHE_ARGS ?=
+endif
 
 define DOCKER_BUILD
 	@echo "--> building bridge docker image"
 	@echo "    platform: $(PLATFORM)"
-	@docker build \
+	@docker buildx build \
+		--load \
+		$(DOCKER_CACHE_ARGS) \
 		--platform $(PLATFORM) \
 		-f $(DOCKER_FILE) \
 		. \

--- a/decentralized-api/Dockerfile
+++ b/decentralized-api/Dockerfile
@@ -5,7 +5,6 @@
 ################################################################################
 FROM golang:1.24.2-alpine3.20 AS builder
 
-ARG BUILD_FLAGS
 ARG GOOS
 ARG GOARCH
 ARG BLST_PORTABLE=0

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -20,8 +20,10 @@ WASMVM_STATIC_LINUX_X64_URL := https://github.com/CosmWasm/wasmvm/releases/downl
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
 DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache,mode=max
+DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache-upgrade,mode=max
 else
 DOCKER_CACHE_ARGS ?=
+DOCKER_CACHE_ARGS_UPGRADE ?=
 endif
 
 define DOCKER_BUILD
@@ -50,7 +52,7 @@ define DOCKER_BUILD_UPGRADE
 	@echo "    	GOOS: $(GOOS)"
 	@echo "    	GOARCH: $(GOARCH)"
 	@docker buildx build \
-		$(DOCKER_CACHE_ARGS) \
+		$(DOCKER_CACHE_ARGS_UPGRADE) \
 		--platform $(PLATFORM) \
 		--build-arg BUILD_FLAGS="$(BUILD_FLAGS)" \
 		--build-arg GOOS=$(GOOS) \

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -17,15 +17,22 @@ BUILD_FLAGS ?= -ldflags '$(ldflags)'
 
 WASMVM_STATIC_LINUX_X64_URL := https://github.com/CosmWasm/wasmvm/releases/download/v2.2.4/libwasmvm_muslc.x86_64.a
 
+USE_REGISTRY_CACHE ?= 0
+ifeq ($(USE_REGISTRY_CACHE),1)
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/api:buildcache --cache-to type=registry,ref=ghcr.io/product-science/api:buildcache,mode=max
+else
+DOCKER_CACHE_ARGS ?=
+endif
+
 define DOCKER_BUILD
 	@echo "--> building decentralized-api docker image"
 	@echo "    	platform: $(PLATFORM)"
 	@echo "    	BUILD_FLAGS: $(BUILD_FLAGS)"
 	@echo "    	GOOS: $(GOOS)"
 	@echo "    	GOARCH: $(GOARCH)"
-	@DOCKER_BUILDKIT=1 \
-	docker build \
+	@docker buildx build \
 		--load \
+		$(DOCKER_CACHE_ARGS) \
 		--platform $(PLATFORM) \
 		--build-arg BUILD_FLAGS="$(BUILD_FLAGS)" \
 		--build-arg GOOS=$(GOOS) \
@@ -42,7 +49,8 @@ define DOCKER_BUILD_UPGRADE
 	@echo "    	BUILD_FLAGS: $(BUILD_FLAGS)"
 	@echo "    	GOOS: $(GOOS)"
 	@echo "    	GOARCH: $(GOARCH)"
-	@docker build \
+	@docker buildx build \
+		$(DOCKER_CACHE_ARGS) \
 		--platform $(PLATFORM) \
 		--build-arg BUILD_FLAGS="$(BUILD_FLAGS)" \
 		--build-arg GOOS=$(GOOS) \

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -22,8 +22,8 @@ ifeq ($(USE_REGISTRY_CACHE),1)
 DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache,mode=max
 DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache-upgrade,mode=max
 else
-DOCKER_CACHE_ARGS ?=
-DOCKER_CACHE_ARGS_UPGRADE ?=
+DOCKER_CACHE_ARGS :=
+DOCKER_CACHE_ARGS_UPGRADE :=
 endif
 
 define DOCKER_BUILD

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -29,14 +29,12 @@ endif
 define DOCKER_BUILD
 	@echo "--> building decentralized-api docker image"
 	@echo "    	platform: $(PLATFORM)"
-	@echo "    	BUILD_FLAGS: $(BUILD_FLAGS)"
 	@echo "    	GOOS: $(GOOS)"
 	@echo "    	GOARCH: $(GOARCH)"
 	@docker buildx build \
 		--load \
 		$(DOCKER_CACHE_ARGS) \
 		--platform $(PLATFORM) \
-		--build-arg BUILD_FLAGS="$(BUILD_FLAGS)" \
 		--build-arg GOOS=$(GOOS) \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg BLST_PORTABLE=$(BLST_PORTABLE) \
@@ -48,13 +46,11 @@ endef
 define DOCKER_BUILD_UPGRADE
 	@echo "--> building decentralized-api docker image"
 	@echo "    	platform: $(PLATFORM)"
-	@echo "    	BUILD_FLAGS: $(BUILD_FLAGS)"
 	@echo "    	GOOS: $(GOOS)"
 	@echo "    	GOARCH: $(GOARCH)"
 	@docker buildx build \
 		$(DOCKER_CACHE_ARGS_UPGRADE) \
 		--platform $(PLATFORM) \
-		--build-arg BUILD_FLAGS="$(BUILD_FLAGS)" \
 		--build-arg GOOS=$(GOOS) \
 		--build-arg GOARCH=$(GOARCH) \
 		--target binary-exporter \

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -19,7 +19,7 @@ WASMVM_STATIC_LINUX_X64_URL := https://github.com/CosmWasm/wasmvm/releases/downl
 
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/api:buildcache --cache-to type=registry,ref=ghcr.io/product-science/api:buildcache,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache,mode=max
 else
 DOCKER_CACHE_ARGS ?=
 endif

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -19,8 +19,8 @@ WASMVM_STATIC_LINUX_X64_URL := https://github.com/CosmWasm/wasmvm/releases/downl
 
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache,mode=max
-DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache-upgrade,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache,mode=min
+DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/gonka-ai/api:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/gonka-ai/api:buildcache-upgrade,mode=min
 else
 DOCKER_CACHE_ARGS :=
 DOCKER_CACHE_ARGS_UPGRADE :=

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -24,6 +24,13 @@ WASMVM_STATIC_DARWIN_URL := https://github.com/CosmWasm/wasmvm/releases/download
 WASMVM_STATIC_LINUX_X64_URL := https://github.com/CosmWasm/wasmvm/releases/download/$(WASMVM_VERSION)/libwasmvm_muslc.x86_64.a
 WASMVM_STATIC_LINUX_ARM64_URL := https://github.com/CosmWasm/wasmvm/releases/download/$(WASMVM_VERSION)/libwasmvm_muslc.aarch64.a
 
+USE_REGISTRY_CACHE ?= 0
+ifeq ($(USE_REGISTRY_CACHE),1)
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/inferenced:buildcache --cache-to type=registry,ref=ghcr.io/product-science/inferenced:buildcache,mode=max
+else
+DOCKER_CACHE_ARGS ?=
+endif
+
 install:
 	@echo "Installing locally with ldflags..."
 	@go install -ldflags "$(ldflags)" -mod=readonly ./cmd/inferenced/main.go
@@ -80,9 +87,9 @@ define DOCKER_BUILD
 	@cp -r .[^.]* .docker-context/inference-chain/ 2>/dev/null || true
 	@rm -rf .docker-context/inference-chain/.docker-context
 	@mkdir -p .docker-context/cosmovisor && cp -r ../cosmovisor/* .docker-context/cosmovisor/
-	@DOCKER_BUILDKIT=1 \
-	docker build \
+	@docker buildx build \
 		--load \
+		$(DOCKER_CACHE_ARGS) \
 		--platform $(PLATFORM) \
 		--build-arg LDFLAGS='$(ldflags)' \
 		--build-arg GOOS=$(GOOS) \
@@ -109,8 +116,8 @@ define DOCKER_BUILD_UPGRADE
 	@cp -r .[^.]* .docker-context/inference-chain/ 2>/dev/null || true
 	@rm -rf .docker-context/inference-chain/.docker-context
 	@mkdir -p .docker-context/cosmovisor && cp -r ../cosmovisor/* .docker-context/cosmovisor/
-	@DOCKER_BUILDKIT=1 \
-	docker build \
+	@docker buildx build \
+		$(DOCKER_CACHE_ARGS) \
 		--platform $(PLATFORM) \
 		--build-arg LDFLAGS='$(ldflags)' \
 		--build-arg GOOS=$(GOOS) \

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -27,8 +27,10 @@ WASMVM_STATIC_LINUX_ARM64_URL := https://github.com/CosmWasm/wasmvm/releases/dow
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
 DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/inferenced:buildcache --cache-to type=registry,ref=ghcr.io/product-science/inferenced:buildcache,mode=max
+DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/product-science/inferenced:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/product-science/inferenced:buildcache-upgrade,mode=max
 else
-DOCKER_CACHE_ARGS ?=
+DOCKER_CACHE_ARGS :=
+DOCKER_CACHE_ARGS_UPGRADE :=
 endif
 
 install:
@@ -117,7 +119,7 @@ define DOCKER_BUILD_UPGRADE
 	@rm -rf .docker-context/inference-chain/.docker-context
 	@mkdir -p .docker-context/cosmovisor && cp -r ../cosmovisor/* .docker-context/cosmovisor/
 	@docker buildx build \
-		$(DOCKER_CACHE_ARGS) \
+		$(DOCKER_CACHE_ARGS_UPGRADE) \
 		--platform $(PLATFORM) \
 		--build-arg LDFLAGS='$(ldflags)' \
 		--build-arg GOOS=$(GOOS) \

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -26,8 +26,8 @@ WASMVM_STATIC_LINUX_ARM64_URL := https://github.com/CosmWasm/wasmvm/releases/dow
 
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/inferenced:buildcache --cache-to type=registry,ref=ghcr.io/product-science/inferenced:buildcache,mode=max
-DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/product-science/inferenced:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/product-science/inferenced:buildcache-upgrade,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache,mode=max
+DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache-upgrade,mode=max
 else
 DOCKER_CACHE_ARGS :=
 DOCKER_CACHE_ARGS_UPGRADE :=

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -26,8 +26,8 @@ WASMVM_STATIC_LINUX_ARM64_URL := https://github.com/CosmWasm/wasmvm/releases/dow
 
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache,mode=max
-DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache-upgrade,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache,mode=min
+DOCKER_CACHE_ARGS_UPGRADE := --cache-from type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache-upgrade --cache-to type=registry,ref=ghcr.io/gonka-ai/inferenced:buildcache-upgrade,mode=min
 else
 DOCKER_CACHE_ARGS :=
 DOCKER_CACHE_ARGS_UPGRADE :=

--- a/proxy-ssl/Makefile
+++ b/proxy-ssl/Makefile
@@ -6,7 +6,7 @@ SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi
 PLATFORMS ?= linux/amd64,linux/arm64
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/proxy-ssl:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/proxy-ssl:buildcache,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/proxy-ssl:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/proxy-ssl:buildcache,mode=min
 else
 DOCKER_CACHE_ARGS :=
 endif

--- a/proxy-ssl/Makefile
+++ b/proxy-ssl/Makefile
@@ -8,7 +8,7 @@ USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
 DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/proxy-ssl:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/proxy-ssl:buildcache,mode=max
 else
-DOCKER_CACHE_ARGS ?=
+DOCKER_CACHE_ARGS :=
 endif
 
 define DOCKER_BUILD

--- a/proxy-ssl/Makefile
+++ b/proxy-ssl/Makefile
@@ -4,11 +4,19 @@ VERSION ?= $(shell git describe --always)
 SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
 PLATFORMS ?= linux/amd64,linux/arm64
+USE_REGISTRY_CACHE ?= 0
+ifeq ($(USE_REGISTRY_CACHE),1)
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/proxy-ssl:buildcache --cache-to type=registry,ref=ghcr.io/product-science/proxy-ssl:buildcache,mode=max
+else
+DOCKER_CACHE_ARGS ?=
+endif
 
 define DOCKER_BUILD
 	@echo "--> building proxy-ssl docker image"
 	@echo "    	platform: $(PLATFORM)"
-	@docker build \
+	@docker buildx build \
+		--load \
+		$(DOCKER_CACHE_ARGS) \
 		--platform $(PLATFORM) \
 		-f $(DOCKER_FILE) \
 		. \

--- a/proxy-ssl/Makefile
+++ b/proxy-ssl/Makefile
@@ -6,7 +6,7 @@ SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi
 PLATFORMS ?= linux/amd64,linux/arm64
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/proxy-ssl:buildcache --cache-to type=registry,ref=ghcr.io/product-science/proxy-ssl:buildcache,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/proxy-ssl:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/proxy-ssl:buildcache,mode=max
 else
 DOCKER_CACHE_ARGS ?=
 endif

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -6,7 +6,7 @@ SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi
 PLATFORMS ?= linux/amd64,linux/arm64
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/proxy:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/proxy:buildcache,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/proxy:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/proxy:buildcache,mode=min
 else
 DOCKER_CACHE_ARGS :=
 endif

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -4,11 +4,19 @@ VERSION ?= $(shell git describe --always)
 SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
 PLATFORMS ?= linux/amd64,linux/arm64
+USE_REGISTRY_CACHE ?= 0
+ifeq ($(USE_REGISTRY_CACHE),1)
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/proxy:buildcache --cache-to type=registry,ref=ghcr.io/product-science/proxy:buildcache,mode=max
+else
+DOCKER_CACHE_ARGS ?=
+endif
 
 define DOCKER_BUILD
 	@echo "--> building proxy docker image"
 	@echo "    	platform: $(PLATFORM)"
-	@docker build \
+	@docker buildx build \
+		--load \
+		$(DOCKER_CACHE_ARGS) \
 		--platform $(PLATFORM) \
 		-f $(DOCKER_FILE) \
 		. \

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -8,7 +8,7 @@ USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
 DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/proxy:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/proxy:buildcache,mode=max
 else
-DOCKER_CACHE_ARGS ?=
+DOCKER_CACHE_ARGS :=
 endif
 
 define DOCKER_BUILD

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -6,7 +6,7 @@ SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi
 PLATFORMS ?= linux/amd64,linux/arm64
 USE_REGISTRY_CACHE ?= 0
 ifeq ($(USE_REGISTRY_CACHE),1)
-DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/product-science/proxy:buildcache --cache-to type=registry,ref=ghcr.io/product-science/proxy:buildcache,mode=max
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/proxy:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/proxy:buildcache,mode=max
 else
 DOCKER_CACHE_ARGS ?=
 endif


### PR DESCRIPTION
# Docker registry cache for GitHub Actions

## What problem does this solve?
CI builds cold-start every run - Docker layers are rebuilt from scratch each time, making the build-images job unnecessarily slow. Issue #338.

## How do you know this is a real problem?
build-images is the bottleneck in CI; no layer reuse happens between runs on ephemeral GitHub-hosted runners.

## How does this solve the problem?
Switches all component Makefiles from `docker build` to `docker buildx build` and adds a `USE_REGISTRY_CACHE` flag. When set to `1`, each build passes `--cache-from` and `--cache-to` pointing at a dedicated
`ghcr.io/gonka-ai/<component>:buildcache` tag. The CI workflow authenticates to GHCR before building and passes `USE_REGISTRY_CACHE=1`.

## What risks does this introduce? How can we mitigate those risks?
- Stale cache could theoretically serve outdated layers. Mitigated by `mode=max` which stores all layers and by the fact that cache misses fall back to a full build.

## How do you know this PR fixes the problem?
In the second run make images in integration tests took 5.5 minutes instead of 14.5 minutes on the first run.