### PR TITLE
fix: deterministic query responses, defensive PoC error handling, overflow check

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_poc_validation_v1.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_validation_v1.go
@@ -41,7 +41,9 @@ func (k msgServer) submitPocValidationV1(goCtx context.Context, msg *types.MsgSu
 	activeEvent, isActive, err := k.Keeper.GetActiveConfirmationPoCEvent(ctx)
 	if err != nil {
 		k.LogError(PocFailureTag+"[SubmitPocValidation] Error checking confirmation PoC event", types.PoC, "error", err)
-		// Continue with regular PoC check
+		// Reset values to ensure we fall through to regular PoC logic safely
+		activeEvent = nil
+		isActive = false
 	}
 
 	// Route to confirmation PoC handler if active and in VALIDATION phase

--- a/inference-chain/x/inference/keeper/query_dynamic_pricing.go
+++ b/inference-chain/x/inference/keeper/query_dynamic_pricing.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/productscience/inference/x/inference/types"
 	"google.golang.org/grpc/codes"
@@ -56,6 +58,10 @@ func (k Keeper) GetAllModelPerTokenPrices(goCtx context.Context, req *types.Quer
 			Price:   price,
 		})
 	}
+	// Sort by ModelId for deterministic query responses across nodes
+	slices.SortFunc(modelPrices, func(a, b types.ModelPrice) int {
+		return strings.Compare(a.ModelId, b.ModelId)
+	})
 
 	k.LogInfo("Retrieved all model prices", types.Pricing,
 		"totalModels", len(modelPrices),

--- a/inference-chain/x/inference/types/settle_amount.go
+++ b/inference-chain/x/inference/types/settle_amount.go
@@ -4,6 +4,10 @@ import "math"
 
 func (sa *SettleAmount) GetTotalCoins() int64 {
 	sum := sa.RewardCoins + sa.WorkCoins
+	// Check for uint64 addition overflow (wrap-around)
+	if sum < sa.RewardCoins || sum < sa.WorkCoins {
+		return math.MaxInt64
+	}
 	if sum > math.MaxInt64 {
 		return math.MaxInt64
 	}

--- a/inference-chain/x/inference/types/settle_amount_test.go
+++ b/inference-chain/x/inference/types/settle_amount_test.go
@@ -1,0 +1,72 @@
+package types_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTotalCoins(t *testing.T) {
+	tests := []struct {
+		name        string
+		rewardCoins uint64
+		workCoins   uint64
+		expected    int64
+	}{
+		{
+			name:        "normal values",
+			rewardCoins: 100,
+			workCoins:   200,
+			expected:    300,
+		},
+		{
+			name:        "zero values",
+			rewardCoins: 0,
+			workCoins:   0,
+			expected:    0,
+		},
+		{
+			name:        "sum exceeds MaxInt64",
+			rewardCoins: math.MaxInt64,
+			workCoins:   1,
+			expected:    math.MaxInt64,
+		},
+		{
+			name:        "both at MaxInt64 triggers overflow cap",
+			rewardCoins: math.MaxInt64,
+			workCoins:   math.MaxInt64,
+			expected:    math.MaxInt64,
+		},
+		{
+			name:        "uint64 overflow wraps around",
+			rewardCoins: math.MaxUint64,
+			workCoins:   1,
+			expected:    math.MaxInt64,
+		},
+		{
+			name:        "large values near uint64 max",
+			rewardCoins: math.MaxUint64 - 5,
+			workCoins:   10,
+			expected:    math.MaxInt64,
+		},
+		{
+			name:        "exactly MaxInt64",
+			rewardCoins: math.MaxInt64 - 100,
+			workCoins:   100,
+			expected:    math.MaxInt64,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sa := &types.SettleAmount{
+				RewardCoins: tc.rewardCoins,
+				WorkCoins:   tc.workCoins,
+			}
+			result := sa.GetTotalCoins()
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three minor safety improvements found during code review:

1. **Deterministic query response**: `GetAllModelPerTokenPrices` now sorts results by `ModelId` to ensure consistent gRPC responses across nodes. Go map iteration order is non-deterministic, so without sorting, different nodes return models in different order for the same query.
   - File: `inference-chain/x/inference/keeper/query_dynamic_pricing.go`

2. **Defensive PoC error handling**: `SubmitPocValidation` now explicitly resets `activeEvent` and `isActive` when `GetActiveConfirmationPoCEvent` returns an error. Per Go convention, return values are not guaranteed when `err != nil`, so the subsequent routing logic could use partially initialized values.
   - File: `inference-chain/x/inference/keeper/msg_server_poc_validation_v1.go`

3. **Overflow protection**: `GetTotalCoins` now checks for uint64 addition overflow before comparing against `MaxInt64`. Without this check, if `RewardCoins + WorkCoins` wraps around, the result silently returns an incorrect small value.
   - File: `inference-chain/x/inference/types/settle_amount.go`

## Testing

- Added unit tests for `GetTotalCoins` covering overflow edge cases
- Changes are minimal and localized — no behavioral changes in the happy path

Fixes #883