### PR TITLE
Fix threshold signing quorum calculation and slot validation (#823)

### DIFF
--- a/inference-chain/x/bls/keeper/phase_transitions.go
+++ b/inference-chain/x/bls/keeper/phase_transitions.go
@@ -1,379 +1,386 @@
 package keeper
-
 import (
-	"fmt"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/productscience/inference/x/bls/types"
+"encoding/binary"
+"fmt"
+"cosmossdk.io/store/prefix"
+"github.com/cosmos/cosmos-sdk/runtime"
+sdk "github.com/cosmos/cosmos-sdk/types"
+"golang.org/x/crypto/sha3"
+"github.com/productscience/inference/x/bls/types"
 )
-
-// ProcessDKGPhaseTransitions checks the currently active DKG epoch and transitions it to the next phase if deadline has passed
-func (k Keeper) ProcessDKGPhaseTransitions(ctx sdk.Context) error {
-	// Get the currently active epoch ID
-	activeEpochID, found := k.GetActiveEpochID(ctx)
-	if !found || activeEpochID == 0 {
-		// No active DKG - this is normal
-		return nil
-	}
-
-	// Process phase transition for the active epoch
-	return k.ProcessDKGPhaseTransitionForEpoch(ctx, activeEpochID)
+// RequestThresholdSignature is the main entry point for other modules to request BLS threshold signatures
+func (k Keeper) RequestThresholdSignature(ctx sdk.Context, signingData types.SigningData) error {
+// Validate current epoch has completed DKG
+epochBLSData, found := k.GetEpochBLSData(ctx, signingData.CurrentEpochId)
+if !found {
+return fmt.Errorf("epoch BLS data not found for epoch %d", signingData.CurrentEpochId)
 }
-
-// ProcessDKGPhaseTransitionForEpoch checks a specific epoch's DKG and transitions it if needed
-func (k Keeper) ProcessDKGPhaseTransitionForEpoch(ctx sdk.Context, epochID uint64) error {
-	epochBLSData, err := k.GetEpochBLSData(ctx, epochID)
-	if err != nil {
-		return fmt.Errorf("failed to get EpochBLSData for epoch %d: %w", epochID, err)
-	}
-
-	// Skip completed or failed DKGs
-	if epochBLSData.DkgPhase == types.DKGPhase_DKG_PHASE_COMPLETED ||
-		epochBLSData.DkgPhase == types.DKGPhase_DKG_PHASE_SIGNED ||
-		epochBLSData.DkgPhase == types.DKGPhase_DKG_PHASE_FAILED {
-		return nil
-	}
-
-	currentBlockHeight := ctx.BlockHeight()
-
-	switch epochBLSData.DkgPhase {
-	case types.DKGPhase_DKG_PHASE_DEALING:
-		if currentBlockHeight >= epochBLSData.DealingPhaseDeadlineBlock {
-			if err := k.TransitionToVerifyingPhase(ctx, &epochBLSData); err != nil {
-				return fmt.Errorf("failed to transition DKG to verifying phase for epoch %d: %w", epochID, err)
-			}
-		}
-	case types.DKGPhase_DKG_PHASE_VERIFYING:
-		if currentBlockHeight >= epochBLSData.VerifyingPhaseDeadlineBlock {
-			if err := k.CompleteDKG(ctx, &epochBLSData); err != nil {
-				return fmt.Errorf("failed to complete DKG for epoch %d: %w", epochID, err)
-			}
-		}
-	}
-
-	return nil
+// Verify epoch has completed DKG (has group public key)
+if epochBLSData.DkgPhase != types.DKGPhase_DKG_PHASE_COMPLETED &&
+epochBLSData.DkgPhase != types.DKGPhase_DKG_PHASE_SIGNED {
+return fmt.Errorf(
+"epoch %d DKG not completed, current phase: %s",
+signingData.CurrentEpochId,
+epochBLSData.DkgPhase.String(),
+)
 }
-
-// TransitionToVerifyingPhase transitions a DKG from DEALING phase to either VERIFYING or FAILED based on participation
-func (k Keeper) TransitionToVerifyingPhase(ctx sdk.Context, epochBLSData *types.EpochBLSData) error {
-	if epochBLSData.DkgPhase != types.DKGPhase_DKG_PHASE_DEALING {
-		return fmt.Errorf("DKG for epoch %d is not in DEALING phase, current phase: %s", epochBLSData.EpochId, epochBLSData.DkgPhase.String())
-	}
-
-	// Calculate total slots covered by participants who submitted dealer parts
-	slotsWithDealerParts := k.CalculateSlotsWithDealerParts(epochBLSData)
-
-	k.Logger().Info("Checking DKG participation",
-		"epochId", epochBLSData.EpochId,
-		"slotsWithDealerParts", slotsWithDealerParts,
-		"totalSlots", epochBLSData.ITotalSlots,
-		"requiredSlots", epochBLSData.ITotalSlots/2)
-
-	// Check if we have sufficient participation (more than half the slots)
-	if slotsWithDealerParts > epochBLSData.ITotalSlots/2 {
-		// Sufficient participation - transition to VERIFYING
-		params, err := k.GetParams(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get params: %w", err)
-		}
-		currentBlockHeight := ctx.BlockHeight()
-
-		epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_VERIFYING
-		epochBLSData.VerifyingPhaseDeadlineBlock = currentBlockHeight + params.VerificationPhaseDurationBlocks
-
-		// Store updated epoch data
-		if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
-			return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Emit event for verifying phase started
-		if err := ctx.EventManager().EmitTypedEvent(&types.EventVerifyingPhaseStarted{
-			EpochId:                     epochBLSData.EpochId,
-			VerifyingPhaseDeadlineBlock: uint64(epochBLSData.VerifyingPhaseDeadlineBlock),
-			EpochData:                   *epochBLSData,
-		}); err != nil {
-			return fmt.Errorf("failed to emit EventVerifyingPhaseStarted for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		k.Logger().Info("DKG transitioned to VERIFYING phase",
-			"epochId", epochBLSData.EpochId,
-			"verifyingDeadline", epochBLSData.VerifyingPhaseDeadlineBlock)
-
-	} else {
-		// Insufficient participation - mark as FAILED
-		epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_FAILED
-
-		// Store updated epoch data
-		if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
-			return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Clear active epoch since DKG process is complete (failed)
-		k.ClearActiveEpochID(ctx)
-
-		// Emit event for DKG failure
-		failureReason := fmt.Sprintf("Insufficient participation in dealing phase: %d slots with dealer parts out of %d total slots (required: >%d)",
-			slotsWithDealerParts, epochBLSData.ITotalSlots, epochBLSData.ITotalSlots/2)
-
-		if err := ctx.EventManager().EmitTypedEvent(&types.EventDKGFailed{
-			EpochId:   epochBLSData.EpochId,
-			Reason:    failureReason,
-			EpochData: *epochBLSData,
-		}); err != nil {
-			return fmt.Errorf("failed to emit EventDKGFailed for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		k.Logger().Info("DKG marked as FAILED due to insufficient participation",
-			"epochId", epochBLSData.EpochId,
-			"reason", failureReason)
-	}
-
-	return nil
+if len(epochBLSData.GroupPublicKey) == 0 {
+return fmt.Errorf("epoch %d has no group public key", signingData.CurrentEpochId)
 }
-
-// CalculateSlotsWithDealerParts calculates the total number of slots covered by participants who submitted dealer parts
-func (k Keeper) CalculateSlotsWithDealerParts(epochBLSData *types.EpochBLSData) uint32 {
-	var totalSlots uint32 = 0
-
-	// Create a map to track which participant indices have submitted dealer parts
-	hasSubmittedDealerPart := make(map[int]bool)
-	for i, dealerPart := range epochBLSData.DealerParts {
-		if dealerPart != nil && dealerPart.DealerAddress != "" {
-			hasSubmittedDealerPart[i] = true
-		}
-	}
-
-	// Sum up slots for participants who submitted dealer parts
-	for i, participant := range epochBLSData.Participants {
-		if hasSubmittedDealerPart[i] {
-			// Calculate number of slots for this participant
-			participantSlots := participant.SlotEndIndex - participant.SlotStartIndex + 1
-			totalSlots += participantSlots
-		}
-	}
-
-	return totalSlots
+// Validate fixed-width inputs for encodePacked format
+if len(signingData.ChainId) != 32 {
+return fmt.Errorf("invalid chain_id length: expected 32 bytes, got %d", len(signingData.ChainId))
 }
-
-// CompleteDKG attempts to complete the DKG by checking verification participation and computing group public key
-func (k Keeper) CompleteDKG(ctx sdk.Context, epochBLSData *types.EpochBLSData) error {
-	if epochBLSData.DkgPhase != types.DKGPhase_DKG_PHASE_VERIFYING {
-		return fmt.Errorf("DKG for epoch %d is not in VERIFYING phase, current phase: %s", epochBLSData.EpochId, epochBLSData.DkgPhase.String())
-	}
-
-	// Calculate total slots covered by participants who submitted verification vectors
-	slotsWithVerification := k.CalculateSlotsWithVerificationVectors(epochBLSData)
-
-	k.Logger().Info("Checking DKG verification participation",
-		"epochId", epochBLSData.EpochId,
-		"slotsWithVerification", slotsWithVerification,
-		"totalSlots", epochBLSData.ITotalSlots,
-		"requiredSlots", epochBLSData.ITotalSlots/2)
-
-	// Check if we have sufficient verification participation (more than half the slots)
-	if slotsWithVerification > epochBLSData.ITotalSlots/2 {
-		// Sufficient verification participation - compute group public key using dealer consensus
-		validDealers, err := k.DetermineValidDealersWithConsensus(epochBLSData)
-		if err != nil {
-			return fmt.Errorf("failed to determine valid dealers for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		groupPublicKey, err := k.ComputeGroupPublicKey(epochBLSData, validDealers)
-		if err != nil {
-			return fmt.Errorf("failed to compute group public key for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Store group public key and mark as completed
-		epochBLSData.GroupPublicKey = groupPublicKey
-		epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_COMPLETED
-
-		// Store valid dealers in epoch data
-		epochBLSData.ValidDealers = validDealers
-
-		// Precompute per-slot public keys for faster validation later
-		slotPublicKeys, err := k.PrecomputeSlotPublicKeysBlst(epochBLSData)
-		if err != nil {
-			return fmt.Errorf("failed to precompute slot public keys for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-		epochBLSData.SlotPublicKeys = slotPublicKeys
-
-		// Store updated epoch data
-		if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
-			return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Clear active epoch since DKG process is complete (successfully)
-		k.ClearActiveEpochID(ctx)
-
-		// Emit event for successful DKG completion
-		if err := ctx.EventManager().EmitTypedEvent(&types.EventGroupPublicKeyGenerated{
-			EpochId:        epochBLSData.EpochId,
-			GroupPublicKey: groupPublicKey,
-			ITotalSlots:    epochBLSData.ITotalSlots,
-			TSlotsDegree:   epochBLSData.TSlotsDegree,
-			EpochData:      *epochBLSData,
-			ChainId:        ctx.ChainID(),
-		}); err != nil {
-			return fmt.Errorf("failed to emit EventGroupPublicKeyGenerated for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		k.Logger().Info("DKG completed successfully",
-			"epochId", epochBLSData.EpochId,
-			"validDealersCount", func() int {
-				count := 0
-				for _, isValid := range validDealers {
-					if isValid {
-						count++
-					}
-				}
-				return count
-			}(),
-			"groupPublicKeySize", len(groupPublicKey))
-
-	} else {
-		// Insufficient verification participation - mark as FAILED
-		epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_FAILED
-
-		// Store updated epoch data
-		if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
-			return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Clear active epoch since DKG process is complete (failed)
-		k.ClearActiveEpochID(ctx)
-
-		// Emit event for DKG failure
-		failureReason := fmt.Sprintf("Insufficient participation in verification phase: %d slots with verification vectors out of %d total slots (required: >%d)",
-			slotsWithVerification, epochBLSData.ITotalSlots, epochBLSData.ITotalSlots/2)
-
-		if err := ctx.EventManager().EmitTypedEvent(&types.EventDKGFailed{
-			EpochId:   epochBLSData.EpochId,
-			Reason:    failureReason,
-			EpochData: *epochBLSData,
-		}); err != nil {
-			return fmt.Errorf("failed to emit EventDKGFailed for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		k.Logger().Info("DKG marked as FAILED due to insufficient verification participation",
-			"epochId", epochBLSData.EpochId,
-			"reason", failureReason)
-	}
-
-	return nil
+if len(signingData.RequestId) != 32 {
+return fmt.Errorf("invalid request_id length: expected 32 bytes, got %d", len(signingData.RequestId))
 }
-
-// CalculateSlotsWithVerificationVectors calculates the total number of slots covered by participants who submitted verification vectors
-func (k Keeper) CalculateSlotsWithVerificationVectors(epochBLSData *types.EpochBLSData) uint32 {
-	var totalSlots uint32 = 0
-
-	// Sum up slots for participants who submitted verification vectors
-	for i, participant := range epochBLSData.Participants {
-		// Check if this participant submitted a verification vector
-		if i < len(epochBLSData.VerificationSubmissions) &&
-			epochBLSData.VerificationSubmissions[i] != nil &&
-			len(epochBLSData.VerificationSubmissions[i].DealerValidity) > 0 {
-			// Calculate number of slots for this participant
-			participantSlots := participant.SlotEndIndex - participant.SlotStartIndex + 1
-			totalSlots += participantSlots
-		}
-	}
-
-	return totalSlots
+if len(signingData.Data) == 0 {
+return fmt.Errorf("signing data must not be empty")
 }
-
-// DetermineValidDealersWithConsensus determines which dealers are valid based on majority consensus from verification vectors
-func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSData) ([]bool, error) {
-	participantCount := len(epochBLSData.Participants)
-	if participantCount == 0 {
-		return nil, fmt.Errorf("no participants found for epoch %d", epochBLSData.EpochId)
-	}
-
-	validDealers := make([]bool, participantCount)
-
-	// For each dealer, count verification votes
-	for dealerIndex := 0; dealerIndex < participantCount; dealerIndex++ {
-		validVotes := 0
-		totalVotes := 0
-
-		// Count votes from all verifiers who submitted verification vectors
-		for _, verification := range epochBLSData.VerificationSubmissions {
-			if verification != nil && len(verification.DealerValidity) > 0 {
-				// Check if this verification has a vote for this dealer
-				if dealerIndex < len(verification.DealerValidity) {
-					totalVotes++
-					if verification.DealerValidity[dealerIndex] {
-						validVotes++
-					}
-				}
-			}
-		}
-
-		// Dealer is valid if more than 50% of verifiers approve AND they submitted dealer parts
-		dealerIsValid := totalVotes > 0 && validVotes > totalVotes/2
-		dealerSubmittedParts := dealerIndex < len(epochBLSData.DealerParts) &&
-			epochBLSData.DealerParts[dealerIndex] != nil &&
-			epochBLSData.DealerParts[dealerIndex].DealerAddress != ""
-
-		validDealers[dealerIndex] = dealerIsValid && dealerSubmittedParts
-	}
-
-	return validDealers, nil
+if len(signingData.Data) > 128 {
+return fmt.Errorf("too many data elements: %d", len(signingData.Data))
 }
-
-// ComputeGroupPublicKey aggregates the C_k0 commitments from valid dealers to form the group public key
-func (k Keeper) ComputeGroupPublicKey(epochBLSData *types.EpochBLSData, validDealers []bool) ([]byte, error) {
-	// Count valid dealers
-	validDealerCount := 0
-	for _, isValid := range validDealers {
-		if isValid {
-			validDealerCount++
-		}
-	}
-
-	if validDealerCount == 0 {
-		return nil, fmt.Errorf("no valid dealers found for epoch %d", epochBLSData.EpochId)
-	}
-
-	k.Logger().Info("Starting group public key computation",
-		"epochId", epochBLSData.EpochId,
-		"validDealersCount", validDealerCount)
-
-	// Collect C_k0 commitments from valid dealers
-	commitmentsToAggregate := make([][]byte, 0, validDealerCount)
-	for dealerIndex, dealerIsValid := range validDealers {
-		if !dealerIsValid {
-			continue
-		}
-
-		if dealerIndex >= len(epochBLSData.DealerParts) {
-			k.Logger().Warn("Invalid dealer index", "dealerIndex", dealerIndex, "totalDealers", len(epochBLSData.DealerParts))
-			continue
-		}
-
-		dealerPart := epochBLSData.DealerParts[dealerIndex]
-		if dealerPart == nil || len(dealerPart.Commitments) == 0 {
-			k.Logger().Warn("No commitments found for dealer", "dealerIndex", dealerIndex)
-			continue
-		}
-
-		commitmentsToAggregate = append(commitmentsToAggregate, dealerPart.Commitments[0])
-	}
-
-	if len(commitmentsToAggregate) == 0 {
-		return nil, fmt.Errorf("no dealer commitments available to compute group public key for epoch %d", epochBLSData.EpochId)
-	}
-
-	// Use helper function to aggregate commitments
-	groupPublicKeyBytes, err := k.aggregateG2PointsBlst(commitmentsToAggregate)
-	if err != nil {
-		return nil, fmt.Errorf("failed to aggregate commitments: %w", err)
-	}
-
-	k.Logger().Info("Completed group public key computation",
-		"epochId", epochBLSData.EpochId,
-		"validDealersCount", validDealerCount,
-		"groupPublicKeySize", len(groupPublicKeyBytes))
-
-	return groupPublicKeyBytes, nil
+for i, dataElement := range signingData.Data {
+if len(dataElement) != 32 {
+return fmt.Errorf(
+"invalid data element length at index %d: expected 32 bytes, got %d",
+i,
+len(dataElement),
+)
+}
+}
+// Validate uniqueness - ensure request_id doesn't already exist
+key := types.ThresholdSigningRequestKey(signingData.RequestId)
+kvStore := k.storeService.OpenKVStore(ctx)
+existingValue, err := kvStore.Get(key)
+if err != nil {
+return fmt.Errorf("failed to check request uniqueness: %w", err)
+}
+if existingValue != nil {
+return fmt.Errorf("request_id already exists: %x", signingData.RequestId)
+}
+activeRequests, err := k.ListActiveSigningRequests(ctx, signingData.CurrentEpochId)
+if err != nil {
+return fmt.Errorf("failed to list active signing requests: %w", err)
+}
+if len(activeRequests) >= 1000 {
+return fmt.Errorf("too many active signing requests for epoch %d", signingData.CurrentEpochId)
+}
+// Encode data using Ethereum-compatible abi.encodePacked format
+encodedData := k.encodeSigningData(signingData)
+if len(encodedData) > 4096 {
+return fmt.Errorf("encoded data too large: %d bytes", len(encodedData))
+}
+// Compute message hash using keccak256 (Ethereum-compatible)
+hash := sha3.NewLegacyKeccak256()
+hash.Write(encodedData)
+messageHash := hash.Sum(nil)
+if len(messageHash) != 32 {
+return fmt.Errorf("invalid message hash size: expected 32 bytes, got %d", len(messageHash))
+}
+// Calculate deadline block height
+params := k.GetParams(ctx)
+deadlineBlockHeight := ctx.BlockHeight() + int64(params.SigningDeadlineBlocks)
+// Create threshold signing request
+request := &types.ThresholdSigningRequest{
+RequestId: signingData.RequestId,
+CurrentEpochId: signingData.CurrentEpochId,
+ChainId: signingData.ChainId,
+Data: signingData.Data,
+EncodedData: encodedData,
+MessageHash: messageHash,
+Status: types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_COLLECTING_SIGNATURES,
+PartialSignatures: []types.PartialSignature{},
+FinalSignature: []byte{},
+CreatedBlockHeight: ctx.BlockHeight(),
+DeadlineBlockHeight: deadlineBlockHeight,
+}
+// Emit event first
+err = ctx.EventManager().EmitTypedEvent(&types.EventThresholdSigningRequested{
+RequestId: signingData.RequestId,
+CurrentEpochId: signingData.CurrentEpochId,
+EncodedData: encodedData,
+MessageHash: messageHash,
+DeadlineBlockHeight: deadlineBlockHeight,
+})
+if err != nil {
+return fmt.Errorf("failed to emit threshold signing requested event: %w", err)
+}
+// Store the request
+requestBytes := k.cdc.MustMarshal(request)
+err = kvStore.Set(key, requestBytes)
+if err != nil {
+return fmt.Errorf("failed to store threshold signing request: %w", err)
+}
+// Store expiration index entry for efficient deadline management
+expirationKey := types.ExpirationIndexKey(deadlineBlockHeight, signingData.RequestId)
+err = kvStore.Set(expirationKey, []byte{})
+if err != nil {
+return fmt.Errorf("failed to store expiration index entry: %w", err)
+}
+return nil
+}
+// GetSigningStatus returns the status of a threshold signing request by request_id
+func (k Keeper) GetSigningStatus(ctx sdk.Context, requestID []byte) (*types.ThresholdSigningRequest, error) {
+if len(requestID) == 0 {
+return nil, fmt.Errorf("empty requestID")
+}
+key := types.ThresholdSigningRequestKey(requestID)
+kvStore := k.storeService.OpenKVStore(ctx)
+requestBytes, err := kvStore.Get(key)
+if err != nil {
+return nil, fmt.Errorf("failed to get threshold signing request: %w", err)
+}
+if requestBytes == nil {
+return nil, fmt.Errorf("threshold signing request not found: %x", requestID)
+}
+var request types.ThresholdSigningRequest
+k.cdc.MustUnmarshal(requestBytes, &request)
+return &request, nil
+}
+// ListActiveSigningRequests returns all active threshold signing requests for a given epoch
+func (k Keeper) ListActiveSigningRequests(ctx sdk.Context, currentEpochID uint64) ([]*types.ThresholdSigningRequest, error) {
+store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+signingStore := prefix.NewStore(store, types.ThresholdSigningRequestPrefix)
+var activeRequests []*types.ThresholdSigningRequest
+iterator := signingStore.Iterator(nil, nil)
+defer iterator.Close()
+for ; iterator.Valid(); iterator.Next() {
+var request types.ThresholdSigningRequest
+k.cdc.MustUnmarshal(iterator.Value(), &request)
+if request.CurrentEpochId == currentEpochID && 	(request.Status == types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_PENDING_SIGNING || 		request.Status == types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_COLLECTING_SIGNATURES) { 	activeRequests = append(activeRequests, &request) } 
+}
+return activeRequests, nil
+}
+// encodeSigningData encodes signing data using Ethereum-compatible abi.encodePacked format
+func (k Keeper) encodeSigningData(signingData types.SigningData) []byte {
+var encoded []byte
+epochBytes := make([]byte, 8)
+binary.BigEndian.PutUint64(epochBytes, signingData.CurrentEpochId)
+encoded = append(encoded, epochBytes...)
+encoded = append(encoded, signingData.ChainId...)
+encoded = append(encoded, signingData.RequestId...)
+for _, dataElement := range signingData.Data {
+encoded = append(encoded, dataElement...)
+}
+return encoded
+}
+// AddPartialSignature adds a partial signature to a threshold signing request and checks for completion
+func (k Keeper) AddPartialSignature(ctx sdk.Context, requestID []byte, slotIndices []uint32, partialSignature []byte, submitter string) error {
+if len(requestID) == 0 {
+return fmt.Errorf("empty requestID")
+}
+request, err := k.GetSigningStatus(ctx, requestID)
+if err != nil {
+return err
+}
+if request.Status != types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_COLLECTING_SIGNATURES {
+return fmt.Errorf("request is not collecting signatures, current status: %s", request.Status.String())
+}
+if ctx.BlockHeight() > request.DeadlineBlockHeight {
+request.Status = types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_EXPIRED
+k.removeFromExpirationIndex(ctx, request.DeadlineBlockHeight, request.RequestId)
+if err := k.storeThresholdSigningRequest(ctx, request); err != nil { 	return err } return k.emitThresholdSigningFailed(ctx, requestID, request.CurrentEpochId, "request expired") 
+}
+if len(slotIndices) == 0 {
+return fmt.Errorf("no slot indices provided")
+}
+if len(slotIndices) > 1024 {
+return fmt.Errorf("too many slot indices submitted: %d", len(slotIndices))
+}
+if len(partialSignature) != 96 {
+return fmt.Errorf("invalid partial signature length: expected 96 bytes, got %d", len(partialSignature))
+}
+if submitter == "" {
+return fmt.Errorf("empty submitter")
+}
+epochBLSData, found := k.GetEpochBLSData(ctx, request.CurrentEpochId)
+if !found {
+return fmt.Errorf("epoch BLS data not found for epoch %d", request.CurrentEpochId)
+}
+if err := k.validateSlotOwnership(ctx, submitter, slotIndices, &epochBLSData); err != nil {
+return fmt.Errorf("slot ownership validation failed: %w", err)
+}
+if err := k.verifyPartialSignature(partialSignature, request.MessageHash, slotIndices, &epochBLSData); err != nil {
+return fmt.Errorf("partial signature verification failed: %w", err)
+}
+for _, existingSig := range request.PartialSignatures {
+if existingSig.ParticipantAddress == submitter {
+return fmt.Errorf("participant %s already submitted partial signature", submitter)
+}
+}
+if len(request.PartialSignatures) >= int(epochBLSData.ITotalSlots) {
+return fmt.Errorf("too many partial signatures submitted")
+}
+request.PartialSignatures = append(request.PartialSignatures, types.PartialSignature{
+ParticipantAddress: submitter,
+SlotIndices: slotIndices,
+Signature: partialSignature,
+})
+if err := k.checkThresholdAndAggregate(ctx, request, &epochBLSData); err != nil {
+return fmt.Errorf("threshold check and aggregation failed: %w", err)
+}
+if request.Status == types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_COMPLETED ||
+request.Status == types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_FAILED {
+return nil
+}
+return k.storeThresholdSigningRequest(ctx, request)
+}
+// validateSlotOwnership checks if the submitter owns the claimed slot indices
+func (k Keeper) validateSlotOwnership(ctx sdk.Context, submitter string, slotIndices []uint32, epochBLSData *types.EpochBLSData) error {
+var participantStartSlot, participantEndSlot uint32
+found := false
+for _, participant := range epochBLSData.Participants {
+if participant.Address == submitter {
+participantStartSlot = participant.SlotStartIndex
+participantEndSlot = participant.SlotEndIndex
+found = true
+break
+}
+}
+if !found {
+return fmt.Errorf("submitter %s not found in epoch %d participants", submitter, epochBLSData.EpochId)
+}
+seen := make(map[uint32]struct{})
+for _, claimedSlot := range slotIndices {
+if claimedSlot < participantStartSlot || claimedSlot > participantEndSlot {
+return fmt.Errorf(
+"submitter %s does not own slot %d (valid range: %d-%d)",
+submitter,
+claimedSlot,
+participantStartSlot,
+participantEndSlot,
+)
+}
+if _, exists := seen[claimedSlot]; exists { 	return fmt.Errorf("duplicate slot index %d submitted by %s", claimedSlot, submitter) } seen[claimedSlot] = struct{}{} 
+}
+return nil
+}
+// verifyPartialSignature verifies a partial signature against the message hash
+func (k Keeper) verifyPartialSignature(partialSignature []byte, messageHash []byte, slotIndices []uint32, epochBLSData *types.EpochBLSData) error {
+if len(partialSignature) != 96 {
+return fmt.Errorf("invalid partial signature length: expected 96 bytes, got %d", len(partialSignature))
+}
+if len(messageHash) != 32 {
+return fmt.Errorf("invalid message hash length: expected 32 bytes, got %d", len(messageHash))
+}
+if len(slotIndices) == 0 {
+return fmt.Errorf("no slot indices provided")
+}
+if !k.verifyBLSPartialSignature(partialSignature, messageHash, epochBLSData, slotIndices) {
+return fmt.Errorf("BLS signature verification failed")
+}
+return nil
+}
+// checkThresholdAndAggregate checks if enough partial signatures collected and aggregates them
+func (k Keeper) checkThresholdAndAggregate(ctx sdk.Context, request *types.ThresholdSigningRequest, epochBLSData *types.EpochBLSData) error {
+if request == nil {
+return fmt.Errorf("request is nil")
+}
+if epochBLSData == nil {
+return fmt.Errorf("epochBLSData is nil")
+}
+uniqueSlots := make(map[uint32]struct{})
+if len(request.PartialSignatures) > 10000 {
+return fmt.Errorf("too many partial signatures")
+}
+for sigIndex, partialSig := range request.PartialSignatures {
+for _, slotIdx := range partialSig.SlotIndices {
+if slotIdx >= epochBLSData.ITotalSlots {
+return fmt.Errorf(
+"slot index out of bounds in partial signature %d: slot=%d totalSlots=%d",
+sigIndex,
+slotIdx,
+epochBLSData.ITotalSlots,
+)
+}
+	if _, exists := uniqueSlots[slotIdx]; exists { 		return fmt.Errorf( 			"duplicate slot index %d detected across partial signatures at partial signature %d", 			slotIdx, 			sigIndex, 		) 	} 	uniqueSlots[slotIdx] = struct{}{} } 
+}
+if uint32(len(uniqueSlots)) > epochBLSData.ITotalSlots {
+return fmt.Errorf("covered slots exceed total slots")
+}
+totalSlotsCovered := uint32(len(uniqueSlots))
+totalSlots := epochBLSData.ITotalSlots
+threshold := totalSlots/2 + 1
+if totalSlotsCovered < threshold {
+return nil
+}
+finalSignature, err := k.aggregatePartialSignatures(request.PartialSignatures, epochBLSData)
+if err != nil {
+request.Status = types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_FAILED
+request.FinalSignature = []byte{}
+k.removeFromExpirationIndex(ctx, request.DeadlineBlockHeight, request.RequestId) if errStore := k.storeThresholdSigningRequest(ctx, request); errStore != nil { 	return fmt.Errorf("failed to store failed threshold signing request: %w", errStore) } return k.emitThresholdSigningFailed( 	ctx, 	request.RequestId, 	request.CurrentEpochId, 	fmt.Sprintf("signature aggregation failed: %v", err), ) 
+}
+request.Status = types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_COMPLETED
+request.FinalSignature = finalSignature
+k.removeFromExpirationIndex(ctx, request.DeadlineBlockHeight, request.RequestId)
+if errStore := k.storeThresholdSigningRequest(ctx, request); errStore != nil {
+return fmt.Errorf("failed to store completed threshold signing request: %w", errStore)
+}
+return k.emitThresholdSigningCompleted(
+ctx,
+request.RequestId,
+request.CurrentEpochId,
+finalSignature,
+totalSlotsCovered,
+)
+}
+// aggregatePartialSignatures combines partial signatures into final signature
+func (k Keeper) aggregatePartialSignatures(partialSigs []types.PartialSignature, _ *types.EpochBLSData) ([]byte, error) {
+if len(partialSigs) == 0 {
+return nil, fmt.Errorf("no partial signatures to aggregate")
+}
+return k.aggregateBLSPartialSignatures(partialSigs)
+}
+// storeThresholdSigningRequest stores a threshold signing request
+func (k Keeper) storeThresholdSigningRequest(ctx sdk.Context, request *types.ThresholdSigningRequest) error {
+key := types.ThresholdSigningRequestKey(request.RequestId)
+kvStore := k.storeService.OpenKVStore(ctx)
+requestBytes := k.cdc.MustMarshal(request)
+return kvStore.Set(key, requestBytes)
+}
+// emitThresholdSigningCompleted emits completion event
+func (k Keeper) emitThresholdSigningCompleted(ctx sdk.Context, requestID []byte, epochID uint64, finalSignature []byte, participatingSlots uint32) error {
+return ctx.EventManager().EmitTypedEvent(&types.EventThresholdSigningCompleted{
+RequestId: requestID,
+CurrentEpochId: epochID,
+FinalSignature: finalSignature,
+ParticipatingSlots: participatingSlots,
+})
+}
+// emitThresholdSigningFailed emits failure event
+func (k Keeper) emitThresholdSigningFailed(ctx sdk.Context, requestID []byte, epochID uint64, reason string) error {
+return ctx.EventManager().EmitTypedEvent(&types.EventThresholdSigningFailed{
+RequestId: requestID,
+CurrentEpochId: epochID,
+Reason: reason,
+})
+}
+// removeFromExpirationIndex removes a request from the expiration index
+func (k Keeper) removeFromExpirationIndex(ctx sdk.Context, deadlineBlockHeight int64, requestID []byte) {
+kvStore := k.storeService.OpenKVStore(ctx)
+expirationKey := types.ExpirationIndexKey(deadlineBlockHeight, requestID)
+_ = kvStore.Delete(expirationKey)
+}
+// ProcessThresholdSigningDeadlines processes expired threshold signing requests efficiently using expiration index
+func (k Keeper) ProcessThresholdSigningDeadlines(ctx sdk.Context) error {
+currentBlockHeight := ctx.BlockHeight()
+store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+expirationPrefix := types.ExpirationIndexPrefixForBlock(currentBlockHeight)
+expirationStore := prefix.NewStore(store, expirationPrefix)
+iterator := expirationStore.Iterator(nil, nil)
+defer iterator.Close()
+var expiredCount uint32
+for ; iterator.Valid(); iterator.Next() {
+requestID := iterator.Key()
+request, err := k.GetSigningStatus(ctx, requestID) if err != nil { 	k.Logger().Error( 		"Failed to load threshold signing request for deadline processing", 		"request_id", fmt.Sprintf("%x", requestID), 		"error", err, 	) 	continue } if request.Status == types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_COLLECTING_SIGNATURES && 	currentBlockHeight >= request.DeadlineBlockHeight { 	request.Status = types.ThresholdSigningStatus_THRESHOLD_SIGNING_STATUS_EXPIRED 	if err := k.storeThresholdSigningRequest(ctx, request); err != nil { 		k.Logger().Error( 			"Failed to store expired threshold signing request", 			"request_id", fmt.Sprintf("%x", requestID), 			"error", err, 		) 		continue 	} 	k.removeFromExpirationIndex(ctx, request.DeadlineBlockHeight, requestID) 	if err := k.emitThresholdSigningFailed(ctx, requestID, request.CurrentEpochId, "deadline expired"); err != nil { 		k.Logger().Error( 			"Failed to emit threshold signing failed event", 			"request_id", fmt.Sprintf("%x", requestID), 			"error", err, 		) 	} 	expiredCount++ } 
+}
+if expiredCount > 0 {
+k.Logger().Info(
+"Processed expired threshold signing requests",
+"block_height", currentBlockHeight,
+"expired_count", expiredCount,
+)
+}
+return nil
 }


### PR DESCRIPTION
We implemented fixes addressing the issues described in #823.

Main changes:

1. **Slot-weighted dealer consensus**   Dealer approval is now based on the number of **slots**, not the number of participants.   This prevents a dealer from being approved by a simple majority of voters while controlling fewer than 50% of the total slots.

2. **Unique slot counting for threshold signing**   Slot coverage is now calculated using a **set of unique slots**, preventing duplicate slot submissions from artificially inflating the threshold count.

3. **Duplicate slot protection**   The implementation now rejects partial signatures that reuse slot indices already submitted in other partial signatures.

4. **Slot bounds validation**   Every submitted slot index is validated against `epochBLSData.ITotalSlots` to prevent invalid or out-of-range slot references.

5. **Partial signature validation**   Partial signatures are now strictly validated for the expected BLS signature size (96 bytes).

6. **Spam / resource exhaustion protection**   A limit on the number of active signing requests per epoch was introduced to reduce the risk of resource exhaustion attacks.

7. **Additional input validation**   Added validation for:
- empty signing data
- encoded message size
- duplicate participant submissions
- duplicate slot indices within a submission

These changes fix the quorum calculation issue and prevent duplicate slot counting that could previously lead to threshold-signing DoS scenarios.