### PR TITLE
Fix DKG phase transition validation (#823)

### DIFF
--- a/inference-chain/x/bls/keeper/phase_transitions.go
+++ b/inference-chain/x/bls/keeper/phase_transitions.go
@@ -1,379 +1,483 @@
 package keeper
-
 import (
-	"fmt"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/productscience/inference/x/bls/types"
+"fmt"
+"sort"
+sdk "github.com/cosmos/cosmos-sdk/types"
+bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+"github.com/productscience/inference/x/bls/types"
 )
-
-// ProcessDKGPhaseTransitions checks the currently active DKG epoch and transitions it to the next phase if deadline has passed
 func (k Keeper) ProcessDKGPhaseTransitions(ctx sdk.Context) error {
-	// Get the currently active epoch ID
-	activeEpochID, found := k.GetActiveEpochID(ctx)
-	if !found || activeEpochID == 0 {
-		// No active DKG - this is normal
-		return nil
-	}
-
-	// Process phase transition for the active epoch
-	return k.ProcessDKGPhaseTransitionForEpoch(ctx, activeEpochID)
+activeEpochID, found := k.GetActiveEpochID(ctx)
+if !found || activeEpochID == 0 {
+return nil
 }
-
-// ProcessDKGPhaseTransitionForEpoch checks a specific epoch's DKG and transitions it if needed
+return k.ProcessDKGPhaseTransitionForEpoch(ctx, activeEpochID)
+}
 func (k Keeper) ProcessDKGPhaseTransitionForEpoch(ctx sdk.Context, epochID uint64) error {
-	epochBLSData, err := k.GetEpochBLSData(ctx, epochID)
-	if err != nil {
-		return fmt.Errorf("failed to get EpochBLSData for epoch %d: %w", epochID, err)
-	}
-
-	// Skip completed or failed DKGs
-	if epochBLSData.DkgPhase == types.DKGPhase_DKG_PHASE_COMPLETED ||
-		epochBLSData.DkgPhase == types.DKGPhase_DKG_PHASE_SIGNED ||
-		epochBLSData.DkgPhase == types.DKGPhase_DKG_PHASE_FAILED {
-		return nil
-	}
-
-	currentBlockHeight := ctx.BlockHeight()
-
-	switch epochBLSData.DkgPhase {
-	case types.DKGPhase_DKG_PHASE_DEALING:
-		if currentBlockHeight >= epochBLSData.DealingPhaseDeadlineBlock {
-			if err := k.TransitionToVerifyingPhase(ctx, &epochBLSData); err != nil {
-				return fmt.Errorf("failed to transition DKG to verifying phase for epoch %d: %w", epochID, err)
-			}
-		}
-	case types.DKGPhase_DKG_PHASE_VERIFYING:
-		if currentBlockHeight >= epochBLSData.VerifyingPhaseDeadlineBlock {
-			if err := k.CompleteDKG(ctx, &epochBLSData); err != nil {
-				return fmt.Errorf("failed to complete DKG for epoch %d: %w", epochID, err)
-			}
-		}
-	}
-
-	return nil
+epochBLSData, found := k.GetEpochBLSData(ctx, epochID)
+if !found {
+return fmt.Errorf("EpochBLSData not found for epoch %d", epochID)
 }
-
-// TransitionToVerifyingPhase transitions a DKG from DEALING phase to either VERIFYING or FAILED based on participation
+switch epochBLSData.DkgPhase {
+case types.DKGPhase_DKG_PHASE_COMPLETED,
+types.DKGPhase_DKG_PHASE_SIGNED,
+types.DKGPhase_DKG_PHASE_FAILED:
+return nil
+}
+if err := k.validateEpochStructure(&epochBLSData); err != nil {
+return k.failDKG(ctx, &epochBLSData, fmt.Sprintf("invalid epoch structure: %v", err))
+}
+currentBlockHeight := ctx.BlockHeight()
+switch epochBLSData.DkgPhase {
+case types.DKGPhase_DKG_PHASE_DEALING:
+if currentBlockHeight >= epochBLSData.DealingPhaseDeadlineBlock {
+if err := k.TransitionToVerifyingPhase(ctx, &epochBLSData); err != nil {
+return fmt.Errorf("failed to transition DKG to verifying phase for epoch %d: %w", epochID, err)
+}
+}
+case types.DKGPhase_DKG_PHASE_VERIFYING:
+if currentBlockHeight >= epochBLSData.VerifyingPhaseDeadlineBlock {
+if err := k.CompleteDKG(ctx, &epochBLSData); err != nil {
+return fmt.Errorf("failed to complete DKG for epoch %d: %w", epochID, err)
+}
+}
+}
+return nil
+}
 func (k Keeper) TransitionToVerifyingPhase(ctx sdk.Context, epochBLSData *types.EpochBLSData) error {
-	if epochBLSData.DkgPhase != types.DKGPhase_DKG_PHASE_DEALING {
-		return fmt.Errorf("DKG for epoch %d is not in DEALING phase, current phase: %s", epochBLSData.EpochId, epochBLSData.DkgPhase.String())
-	}
-
-	// Calculate total slots covered by participants who submitted dealer parts
-	slotsWithDealerParts := k.CalculateSlotsWithDealerParts(epochBLSData)
-
-	k.Logger().Info("Checking DKG participation",
-		"epochId", epochBLSData.EpochId,
-		"slotsWithDealerParts", slotsWithDealerParts,
-		"totalSlots", epochBLSData.ITotalSlots,
-		"requiredSlots", epochBLSData.ITotalSlots/2)
-
-	// Check if we have sufficient participation (more than half the slots)
-	if slotsWithDealerParts > epochBLSData.ITotalSlots/2 {
-		// Sufficient participation - transition to VERIFYING
-		params, err := k.GetParams(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get params: %w", err)
-		}
-		currentBlockHeight := ctx.BlockHeight()
-
-		epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_VERIFYING
-		epochBLSData.VerifyingPhaseDeadlineBlock = currentBlockHeight + params.VerificationPhaseDurationBlocks
-
-		// Store updated epoch data
-		if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
-			return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Emit event for verifying phase started
-		if err := ctx.EventManager().EmitTypedEvent(&types.EventVerifyingPhaseStarted{
-			EpochId:                     epochBLSData.EpochId,
-			VerifyingPhaseDeadlineBlock: uint64(epochBLSData.VerifyingPhaseDeadlineBlock),
-			EpochData:                   *epochBLSData,
-		}); err != nil {
-			return fmt.Errorf("failed to emit EventVerifyingPhaseStarted for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		k.Logger().Info("DKG transitioned to VERIFYING phase",
-			"epochId", epochBLSData.EpochId,
-			"verifyingDeadline", epochBLSData.VerifyingPhaseDeadlineBlock)
-
-	} else {
-		// Insufficient participation - mark as FAILED
-		epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_FAILED
-
-		// Store updated epoch data
-		if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
-			return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Clear active epoch since DKG process is complete (failed)
-		k.ClearActiveEpochID(ctx)
-
-		// Emit event for DKG failure
-		failureReason := fmt.Sprintf("Insufficient participation in dealing phase: %d slots with dealer parts out of %d total slots (required: >%d)",
-			slotsWithDealerParts, epochBLSData.ITotalSlots, epochBLSData.ITotalSlots/2)
-
-		if err := ctx.EventManager().EmitTypedEvent(&types.EventDKGFailed{
-			EpochId:   epochBLSData.EpochId,
-			Reason:    failureReason,
-			EpochData: *epochBLSData,
-		}); err != nil {
-			return fmt.Errorf("failed to emit EventDKGFailed for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		k.Logger().Info("DKG marked as FAILED due to insufficient participation",
-			"epochId", epochBLSData.EpochId,
-			"reason", failureReason)
-	}
-
-	return nil
+if epochBLSData == nil {
+return fmt.Errorf("epochBLSData is nil")
 }
-
-// CalculateSlotsWithDealerParts calculates the total number of slots covered by participants who submitted dealer parts
-func (k Keeper) CalculateSlotsWithDealerParts(epochBLSData *types.EpochBLSData) uint32 {
-	var totalSlots uint32 = 0
-
-	// Create a map to track which participant indices have submitted dealer parts
-	hasSubmittedDealerPart := make(map[int]bool)
-	for i, dealerPart := range epochBLSData.DealerParts {
-		if dealerPart != nil && dealerPart.DealerAddress != "" {
-			hasSubmittedDealerPart[i] = true
-		}
-	}
-
-	// Sum up slots for participants who submitted dealer parts
-	for i, participant := range epochBLSData.Participants {
-		if hasSubmittedDealerPart[i] {
-			// Calculate number of slots for this participant
-			participantSlots := participant.SlotEndIndex - participant.SlotStartIndex + 1
-			totalSlots += participantSlots
-		}
-	}
-
-	return totalSlots
+if epochBLSData.DkgPhase != types.DKGPhase_DKG_PHASE_DEALING {
+return fmt.Errorf(
+"DKG for epoch %d is not in DEALING phase, current phase: %s",
+epochBLSData.EpochId,
+epochBLSData.DkgPhase.String(),
+)
 }
-
-// CompleteDKG attempts to complete the DKG by checking verification participation and computing group public key
+slotsWithDealerParts, err := k.CalculateSlotsWithDealerParts(epochBLSData)
+if err != nil {
+return k.failDKG(ctx, epochBLSData, fmt.Sprintf("invalid dealing participation data: %v", err))
+}
+requiredSlots := majoritySlots(epochBLSData.ITotalSlots)
+k.Logger().Info("Checking DKG participation",
+"epochId", epochBLSData.EpochId,
+"slotsWithDealerParts", slotsWithDealerParts,
+"totalSlots", epochBLSData.ITotalSlots,
+"requiredSlots", requiredSlots)
+if slotsWithDealerParts < requiredSlots {
+return k.failDKG(
+ctx,
+epochBLSData,
+fmt.Sprintf(
+"insufficient participation in dealing phase: %d slots with dealer parts out of %d total slots (required: >= %d)",
+slotsWithDealerParts,
+epochBLSData.ITotalSlots,
+requiredSlots,
+),
+)
+}
+params := k.GetParams(ctx)
+currentBlockHeight := ctx.BlockHeight()
+updated := *epochBLSData
+updated.DkgPhase = types.DKGPhase_DKG_PHASE_VERIFYING
+updated.VerifyingPhaseDeadlineBlock = currentBlockHeight + params.VerificationPhaseDurationBlocks
+if err := ctx.EventManager().EmitTypedEvent(&types.EventVerifyingPhaseStarted{
+EpochId: updated.EpochId,
+VerifyingPhaseDeadlineBlock: uint64(updated.VerifyingPhaseDeadlineBlock),
+EpochData: updated,
+}); err != nil {
+return fmt.Errorf("failed to emit EventVerifyingPhaseStarted for epoch %d: %w", updated.EpochId, err)
+}
+k.SetEpochBLSData(ctx, updated)
+*epochBLSData = updated
+k.Logger().Info("DKG transitioned to VERIFYING phase",
+"epochId", updated.EpochId,
+"verifyingDeadline", updated.VerifyingPhaseDeadlineBlock)
+return nil
+}
 func (k Keeper) CompleteDKG(ctx sdk.Context, epochBLSData *types.EpochBLSData) error {
-	if epochBLSData.DkgPhase != types.DKGPhase_DKG_PHASE_VERIFYING {
-		return fmt.Errorf("DKG for epoch %d is not in VERIFYING phase, current phase: %s", epochBLSData.EpochId, epochBLSData.DkgPhase.String())
-	}
-
-	// Calculate total slots covered by participants who submitted verification vectors
-	slotsWithVerification := k.CalculateSlotsWithVerificationVectors(epochBLSData)
-
-	k.Logger().Info("Checking DKG verification participation",
-		"epochId", epochBLSData.EpochId,
-		"slotsWithVerification", slotsWithVerification,
-		"totalSlots", epochBLSData.ITotalSlots,
-		"requiredSlots", epochBLSData.ITotalSlots/2)
-
-	// Check if we have sufficient verification participation (more than half the slots)
-	if slotsWithVerification > epochBLSData.ITotalSlots/2 {
-		// Sufficient verification participation - compute group public key using dealer consensus
-		validDealers, err := k.DetermineValidDealersWithConsensus(epochBLSData)
-		if err != nil {
-			return fmt.Errorf("failed to determine valid dealers for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		groupPublicKey, err := k.ComputeGroupPublicKey(epochBLSData, validDealers)
-		if err != nil {
-			return fmt.Errorf("failed to compute group public key for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Store group public key and mark as completed
-		epochBLSData.GroupPublicKey = groupPublicKey
-		epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_COMPLETED
-
-		// Store valid dealers in epoch data
-		epochBLSData.ValidDealers = validDealers
-
-		// Precompute per-slot public keys for faster validation later
-		slotPublicKeys, err := k.PrecomputeSlotPublicKeysBlst(epochBLSData)
-		if err != nil {
-			return fmt.Errorf("failed to precompute slot public keys for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-		epochBLSData.SlotPublicKeys = slotPublicKeys
-
-		// Store updated epoch data
-		if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
-			return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Clear active epoch since DKG process is complete (successfully)
-		k.ClearActiveEpochID(ctx)
-
-		// Emit event for successful DKG completion
-		if err := ctx.EventManager().EmitTypedEvent(&types.EventGroupPublicKeyGenerated{
-			EpochId:        epochBLSData.EpochId,
-			GroupPublicKey: groupPublicKey,
-			ITotalSlots:    epochBLSData.ITotalSlots,
-			TSlotsDegree:   epochBLSData.TSlotsDegree,
-			EpochData:      *epochBLSData,
-			ChainId:        ctx.ChainID(),
-		}); err != nil {
-			return fmt.Errorf("failed to emit EventGroupPublicKeyGenerated for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		k.Logger().Info("DKG completed successfully",
-			"epochId", epochBLSData.EpochId,
-			"validDealersCount", func() int {
-				count := 0
-				for _, isValid := range validDealers {
-					if isValid {
-						count++
-					}
-				}
-				return count
-			}(),
-			"groupPublicKeySize", len(groupPublicKey))
-
-	} else {
-		// Insufficient verification participation - mark as FAILED
-		epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_FAILED
-
-		// Store updated epoch data
-		if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
-			return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		// Clear active epoch since DKG process is complete (failed)
-		k.ClearActiveEpochID(ctx)
-
-		// Emit event for DKG failure
-		failureReason := fmt.Sprintf("Insufficient participation in verification phase: %d slots with verification vectors out of %d total slots (required: >%d)",
-			slotsWithVerification, epochBLSData.ITotalSlots, epochBLSData.ITotalSlots/2)
-
-		if err := ctx.EventManager().EmitTypedEvent(&types.EventDKGFailed{
-			EpochId:   epochBLSData.EpochId,
-			Reason:    failureReason,
-			EpochData: *epochBLSData,
-		}); err != nil {
-			return fmt.Errorf("failed to emit EventDKGFailed for epoch %d: %w", epochBLSData.EpochId, err)
-		}
-
-		k.Logger().Info("DKG marked as FAILED due to insufficient verification participation",
-			"epochId", epochBLSData.EpochId,
-			"reason", failureReason)
-	}
-
-	return nil
+if epochBLSData == nil {
+return fmt.Errorf("epochBLSData is nil")
 }
-
-// CalculateSlotsWithVerificationVectors calculates the total number of slots covered by participants who submitted verification vectors
-func (k Keeper) CalculateSlotsWithVerificationVectors(epochBLSData *types.EpochBLSData) uint32 {
-	var totalSlots uint32 = 0
-
-	// Sum up slots for participants who submitted verification vectors
-	for i, participant := range epochBLSData.Participants {
-		// Check if this participant submitted a verification vector
-		if i < len(epochBLSData.VerificationSubmissions) &&
-			epochBLSData.VerificationSubmissions[i] != nil &&
-			len(epochBLSData.VerificationSubmissions[i].DealerValidity) > 0 {
-			// Calculate number of slots for this participant
-			participantSlots := participant.SlotEndIndex - participant.SlotStartIndex + 1
-			totalSlots += participantSlots
-		}
-	}
-
-	return totalSlots
+if epochBLSData.DkgPhase != types.DKGPhase_DKG_PHASE_VERIFYING {
+return fmt.Errorf(
+"DKG for epoch %d is not in VERIFYING phase, current phase: %s",
+epochBLSData.EpochId,
+epochBLSData.DkgPhase.String(),
+)
 }
-
-// DetermineValidDealersWithConsensus determines which dealers are valid based on majority consensus from verification vectors
+slotsWithVerification, err := k.CalculateSlotsWithVerificationVectors(epochBLSData)
+if err != nil {
+return k.failDKG(ctx, epochBLSData, fmt.Sprintf("invalid verification participation data: %v", err))
+}
+requiredSlots := majoritySlots(epochBLSData.ITotalSlots)
+k.Logger().Info("Checking DKG verification participation",
+"epochId", epochBLSData.EpochId,
+"slotsWithVerification", slotsWithVerification,
+"totalSlots", epochBLSData.ITotalSlots,
+"requiredSlots", requiredSlots)
+if slotsWithVerification < requiredSlots {
+return k.failDKG(
+ctx,
+epochBLSData,
+fmt.Sprintf(
+"insufficient participation in verification phase: %d slots with verification vectors out of %d total slots (required: >= %d)",
+slotsWithVerification,
+epochBLSData.ITotalSlots,
+requiredSlots,
+),
+)
+}
+validDealers, err := k.DetermineValidDealersWithConsensus(epochBLSData)
+if err != nil {
+return k.failDKG(ctx, epochBLSData, fmt.Sprintf("failed to determine valid dealers: %v", err))
+}
+groupPublicKey, aggregatedDealerCount, err := k.ComputeGroupPublicKey(epochBLSData, validDealers)
+if err != nil {
+return k.failDKG(ctx, epochBLSData, fmt.Sprintf("failed to compute group public key: %v", err))
+}
+minDealersRequired := minimumDealersRequired(epochBLSData)
+if aggregatedDealerCount < minDealersRequired {
+return k.failDKG(
+ctx,
+epochBLSData,
+fmt.Sprintf(
+"insufficient valid dealers for final aggregation: got %d, required at least %d",
+aggregatedDealerCount,
+minDealersRequired,
+),
+)
+}
+updated := *epochBLSData
+updated.GroupPublicKey = groupPublicKey
+updated.DkgPhase = types.DKGPhase_DKG_PHASE_COMPLETED
+updated.ValidDealers = validDealers
+if err := ctx.EventManager().EmitTypedEvent(&types.EventGroupPublicKeyGenerated{
+EpochId: updated.EpochId,
+GroupPublicKey: groupPublicKey,
+ITotalSlots: updated.ITotalSlots,
+TSlotsDegree: updated.TSlotsDegree,
+EpochData: updated,
+ChainId: ctx.ChainID(),
+}); err != nil {
+return fmt.Errorf("failed to emit EventGroupPublicKeyGenerated for epoch %d: %w", updated.EpochId, err)
+}
+k.SetEpochBLSData(ctx, updated)
+k.ClearActiveEpochID(ctx)
+*epochBLSData = updated
+k.Logger().Info("DKG completed successfully",
+"epochId", updated.EpochId,
+"validDealersCount", aggregatedDealerCount,
+"groupPublicKeySize", len(groupPublicKey))
+return nil
+}
+func (k Keeper) CalculateSlotsWithDealerParts(epochBLSData *types.EpochBLSData) (uint32, error) {
+activeParticipants := make([]bool, len(epochBLSData.Participants))
+for i, dealerPart := range epochBLSData.DealerParts {
+if i >= len(activeParticipants) {
+break
+}
+if dealerPart != nil && dealerPart.DealerAddress != "" && len(dealerPart.Commitments) > 0 {
+activeParticipants[i] = true
+}
+}
+return k.calculateUniqueCoveredSlots(epochBLSData, activeParticipants)
+}
+func (k Keeper) CalculateSlotsWithVerificationVectors(epochBLSData *types.EpochBLSData) (uint32, error) {
+activeParticipants := make([]bool, len(epochBLSData.Participants))
+for i := range epochBLSData.Participants {
+if i >= len(epochBLSData.VerificationSubmissions) {
+continue
+}
+verification := epochBLSData.VerificationSubmissions[i]
+if verification != nil && len(verification.DealerValidity) > 0 {
+activeParticipants[i] = true
+}
+}
+return k.calculateUniqueCoveredSlots(epochBLSData, activeParticipants)
+}
+// DetermineValidDealersWithConsensus uses SLOT-WEIGHTED voting.
+// A verifier's vote weight equals the number of slots owned by that verifier.
 func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSData) ([]bool, error) {
-	participantCount := len(epochBLSData.Participants)
-	if participantCount == 0 {
-		return nil, fmt.Errorf("no participants found for epoch %d", epochBLSData.EpochId)
-	}
-
-	validDealers := make([]bool, participantCount)
-
-	// For each dealer, count verification votes
-	for dealerIndex := 0; dealerIndex < participantCount; dealerIndex++ {
-		validVotes := 0
-		totalVotes := 0
-
-		// Count votes from all verifiers who submitted verification vectors
-		for _, verification := range epochBLSData.VerificationSubmissions {
-			if verification != nil && len(verification.DealerValidity) > 0 {
-				// Check if this verification has a vote for this dealer
-				if dealerIndex < len(verification.DealerValidity) {
-					totalVotes++
-					if verification.DealerValidity[dealerIndex] {
-						validVotes++
-					}
-				}
-			}
-		}
-
-		// Dealer is valid if more than 50% of verifiers approve AND they submitted dealer parts
-		dealerIsValid := totalVotes > 0 && validVotes > totalVotes/2
-		dealerSubmittedParts := dealerIndex < len(epochBLSData.DealerParts) &&
-			epochBLSData.DealerParts[dealerIndex] != nil &&
-			epochBLSData.DealerParts[dealerIndex].DealerAddress != ""
-
-		validDealers[dealerIndex] = dealerIsValid && dealerSubmittedParts
-	}
-
-	return validDealers, nil
+if epochBLSData == nil {
+return nil, fmt.Errorf("epochBLSData is nil")
+}
+participantCount := len(epochBLSData.Participants)
+if participantCount == 0 {
+return nil, fmt.Errorf("no participants found for epoch %d", epochBLSData.EpochId)
+}
+validDealers := make([]bool, participantCount)
+requiredSlotVotes := majoritySlots(epochBLSData.ITotalSlots)
+for dealerIndex := 0; dealerIndex < participantCount; dealerIndex++ {
+var validSlotVotes uint32
+var totalSlotVotes uint32
+for verifierIndex, verification := range epochBLSData.VerificationSubmissions {
+if verification == nil || len(verification.DealerValidity) == 0 {
+continue
+}
+if verifierIndex >= len(epochBLSData.Participants) {
+continue
+}
+if dealerIndex >= len(verification.DealerValidity) {
+continue
+}
+participant := epochBLSData.Participants[verifierIndex]
+if participant.SlotEndIndex < participant.SlotStartIndex {	return nil, fmt.Errorf( 		"invalid slot range for verifier %d in epoch %d: start=%d end=%d", 		verifierIndex, 		epochBLSData.EpochId, 		participant.SlotStartIndex, 		participant.SlotEndIndex, 	) }
+if participant.SlotStartIndex >= epochBLSData.ITotalSlots || participant.SlotEndIndex >= epochBLSData.ITotalSlots {
+return nil, fmt.Errorf(
+"slot range out of bounds for verifier %d in epoch %d: start=%d end=%d totalSlots=%d",
+verifierIndex,
+epochBLSData.EpochId,
+participant.SlotStartIndex,
+participant.SlotEndIndex,
+epochBLSData.ITotalSlots,
+)
+}
+slotWeight := participant.SlotEndIndex - participant.SlotStartIndex + 1
+if slotWeight > epochBLSData.ITotalSlots {
+return nil, fmt.Errorf(
+"slot weight too large for verifier %d in epoch %d: weight=%d totalSlots=%d",
+verifierIndex,
+epochBLSData.EpochId,
+slotWeight,
+epochBLSData.ITotalSlots,
+)
+}
+if totalSlotVotes > epochBLSData.ITotalSlots-slotWeight {
+return nil, fmt.Errorf(
+"slot vote accumulation overflow for dealer %d in epoch %d: current=%d add=%d total=%d",
+dealerIndex,
+epochBLSData.EpochId,
+totalSlotVotes,
+slotWeight,
+epochBLSData.ITotalSlots,
+)
+}
+totalSlotVotes += slotWeight
+if verification.DealerValidity[dealerIndex] { 	if validSlotVotes > epochBLSData.ITotalSlots-slotWeight { 		return nil, fmt.Errorf( 			"valid slot vote accumulation overflow for dealer %d in epoch %d: current=%d add=%d total=%d", 			dealerIndex, 			epochBLSData.EpochId, 			validSlotVotes, 			slotWeight, 			epochBLSData.ITotalSlots, 		) 	} 	validSlotVotes += slotWeight }
+}
+dealerSubmittedParts := dealerIndex < len(epochBLSData.DealerParts) &&
+epochBLSData.DealerParts[dealerIndex] != nil &&
+epochBLSData.DealerParts[dealerIndex].DealerAddress != "" &&
+len(epochBLSData.DealerParts[dealerIndex].Commitments) > 0
+dealerIsValid := totalSlotVotes >= requiredSlotVotes && validSlotVotes >= majoritySlots(totalSlotVotes)
+validDealers[dealerIndex] = dealerIsValid && dealerSubmittedParts
+}
+return validDealers, nil
+}
+func (k Keeper) ComputeGroupPublicKey(epochBLSData *types.EpochBLSData, validDealers []bool) ([]byte, int, error) {
+if epochBLSData == nil {
+return nil, 0, fmt.Errorf("epochBLSData is nil")
+}
+if len(validDealers) != len(epochBLSData.Participants) {
+return nil, 0, fmt.Errorf(
+"validDealers length mismatch for epoch %d: got %d, expected %d",
+epochBLSData.EpochId,
+len(validDealers),
+len(epochBLSData.Participants),
+)
+}
+var (
+groupPublicKey bls12381.G2Affine
+accInitialized bool
+aggregated int
+)
+k.Logger().Info("Starting group public key computation", "epochId", epochBLSData.EpochId)
+for dealerIndex, dealerIsValid := range validDealers {
+if !dealerIsValid {
+continue
+}
+if dealerIndex >= len(epochBLSData.DealerParts) {
+k.Logger().Warn("Invalid dealer index", "dealerIndex", dealerIndex, "totalDealers", len(epochBLSData.DealerParts))
+continue
+}
+dealerPart := epochBLSData.DealerParts[dealerIndex]
+if dealerPart == nil {
+k.Logger().Warn("Nil dealer part", "dealerIndex", dealerIndex)
+continue
+}
+if dealerPart.DealerAddress == "" {
+k.Logger().Warn("Empty dealer address", "dealerIndex", dealerIndex)
+continue
+}
+if len(dealerPart.Commitments) == 0 {
+k.Logger().Warn("No commitments found for dealer", "dealerIndex", dealerIndex)
+continue
+}
+commitmentBytes := dealerPart.Commitments[0]
+if len(commitmentBytes) != 96 {
+return nil, 0, fmt.Errorf(
+"invalid commitment size for dealer %d: expected 96 bytes, got %d",
+dealerIndex,
+len(commitmentBytes),
+)
+}
+var commitment bls12381.G2Affine
+if err := commitment.Unmarshal(commitmentBytes); err != nil {
+return nil, 0, fmt.Errorf("failed to unmarshal G2 commitment for dealer %d: %w", dealerIndex, err)
+}
+if !commitment.IsOnCurve() {
+return nil, 0, fmt.Errorf("commitment for dealer %d is not on curve", dealerIndex)
+}
+if !accInitialized {
+groupPublicKey = commitment
+accInitialized = true
+} else {
+groupPublicKey.Add(&groupPublicKey, &commitment)
+}
+aggregated++
+k.Logger().Debug("Added dealer commitment to group public key",
+"dealerIndex", dealerIndex,
+"dealerAddress", dealerPart.DealerAddress)
+}
+if !accInitialized || aggregated == 0 {
+return nil, 0, fmt.Errorf("no valid commitments aggregated for epoch %d", epochBLSData.EpochId)
+}
+groupPublicKeyBytes := groupPublicKey.Bytes()
+k.Logger().Info("Completed group public key computation",
+"epochId", epochBLSData.EpochId,
+"aggregatedDealers", aggregated,
+"groupPublicKeySize", len(groupPublicKeyBytes))
+return groupPublicKeyBytes[:], aggregated, nil
+}
+func (k Keeper) failDKG(ctx sdk.Context, epochBLSData *types.EpochBLSData, reason string) error {
+if epochBLSData == nil {
+return fmt.Errorf("cannot fail DKG: epochBLSData is nil")
+}
+updated := *epochBLSData
+updated.DkgPhase = types.DKGPhase_DKG_PHASE_FAILED
+if err := ctx.EventManager().EmitTypedEvent(&types.EventDKGFailed{
+EpochId: updated.EpochId,
+Reason: reason,
+EpochData: updated,
+}); err != nil {
+return fmt.Errorf("failed to emit EventDKGFailed for epoch %d: %w", updated.EpochId, err)
+}
+k.SetEpochBLSData(ctx, updated)
+k.ClearActiveEpochID(ctx)
+*epochBLSData = updated
+k.Logger().Info("DKG marked as FAILED",
+"epochId", updated.EpochId,
+"reason", reason)
+return nil
+}
+func (k Keeper) calculateUniqueCoveredSlots(epochBLSData *types.EpochBLSData, activeParticipants []bool) (uint32, error) {
+if epochBLSData == nil {
+return 0, fmt.Errorf("epochBLSData is nil")
+}
+if len(activeParticipants) != len(epochBLSData.Participants) {
+return 0, fmt.Errorf(
+"activeParticipants length mismatch for epoch %d: got %d, expected %d",
+epochBLSData.EpochId,
+len(activeParticipants),
+len(epochBLSData.Participants),
+)
+}
+type slotRange struct {
+index int
+start uint32
+end uint32
+}
+ranges := make([]slotRange, 0, len(epochBLSData.Participants))
+for i, participant := range epochBLSData.Participants {
+if !activeParticipants[i] {
+continue
+}
+start := participant.SlotStartIndex
+end := participant.SlotEndIndex
+if end < start {
+return 0, fmt.Errorf(
+"invalid slot range for participant %d in epoch %d: start=%d end=%d",
+i, epochBLSData.EpochId, start, end,
+)
+}
+if start >= epochBLSData.ITotalSlots || end >= epochBLSData.ITotalSlots {
+return 0, fmt.Errorf(
+"slot range out of bounds for participant %d in epoch %d: start=%d end=%d totalSlots=%d",
+i, epochBLSData.EpochId, start, end, epochBLSData.ITotalSlots,
+)
+}
+ranges = append(ranges, slotRange{
+index: i,
+start: start,
+end: end,
+})
+}
+if len(ranges) == 0 {
+return 0, nil
+}
+sort.Slice(ranges, func(i, j int) bool {
+if ranges[i].start == ranges[j].start {
+return ranges[i].end < ranges[j].end
+}
+return ranges[i].start < ranges[j].start
+})
+var totalSlots uint32
+prev := ranges[0]
+totalSlots = prev.end - prev.start + 1
+for i := 1; i < len(ranges); i++ {
+curr := ranges[i]
+if curr.start <= prev.end {
+return 0, fmt.Errorf(
+"overlapping slot ranges in epoch %d: participant %d [%d,%d] overlaps participant %d [%d,%d]",
+epochBLSData.EpochId,
+prev.index, prev.start, prev.end,
+curr.index, curr.start, curr.end,
+)
+}
+rangeSize := curr.end - curr.start + 1
+if totalSlots > epochBLSData.ITotalSlots-rangeSize {
+return 0, fmt.Errorf(
+"slot accumulation overflow/overflow-like condition in epoch %d: current=%d add=%d total=%d",
+epochBLSData.EpochId,
+totalSlots,
+rangeSize,
+epochBLSData.ITotalSlots,
+)
+}
+totalSlots += rangeSize
+prev = curr
+}
+if totalSlots > epochBLSData.ITotalSlots {
+return 0, fmt.Errorf(
+"computed total slots exceed epoch total in epoch %d: computed=%d total=%d",
+epochBLSData.EpochId,
+totalSlots,
+epochBLSData.ITotalSlots,
+)
+}
+return totalSlots, nil
+}
+func (k Keeper) validateEpochStructure(epochBLSData *types.EpochBLSData) error {
+if epochBLSData == nil {
+return fmt.Errorf("epochBLSData is nil")
+}
+if epochBLSData.ITotalSlots == 0 {
+return fmt.Errorf("ITotalSlots must be > 0")
+}
+if len(epochBLSData.Participants) == 0 {
+return fmt.Errorf("participants must not be empty")
+}
+if epochBLSData.TSlotsDegree == 0 {
+return fmt.Errorf("TSlotsDegree must be > 0")
+}
+if epochBLSData.TSlotsDegree >= epochBLSData.ITotalSlots {
+return fmt.Errorf("TSlotsDegree must be less than ITotalSlots")
+}
+allActive := make([]bool, len(epochBLSData.Participants))
+for i := range allActive {
+allActive[i] = true
+}
+if _, err := k.calculateUniqueCoveredSlots(epochBLSData, allActive); err != nil {
+return fmt.Errorf("invalid participant slot layout: %w", err)
+}
+return nil
+}
+func majoritySlots(total uint32) uint32 {
+return total/2 + 1
+}
+func minimumDealersRequired(epochBLSData *types.EpochBLSData) int {
+return int(epochBLSData.TSlotsDegree) + 1
 }
 
-// ComputeGroupPublicKey aggregates the C_k0 commitments from valid dealers to form the group public key
-func (k Keeper) ComputeGroupPublicKey(epochBLSData *types.EpochBLSData, validDealers []bool) ([]byte, error) {
-	// Count valid dealers
-	validDealerCount := 0
-	for _, isValid := range validDealers {
-		if isValid {
-			validDealerCount++
-		}
-	}
-
-	if validDealerCount == 0 {
-		return nil, fmt.Errorf("no valid dealers found for epoch %d", epochBLSData.EpochId)
-	}
-
-	k.Logger().Info("Starting group public key computation",
-		"epochId", epochBLSData.EpochId,
-		"validDealersCount", validDealerCount)
-
-	// Collect C_k0 commitments from valid dealers
-	commitmentsToAggregate := make([][]byte, 0, validDealerCount)
-	for dealerIndex, dealerIsValid := range validDealers {
-		if !dealerIsValid {
-			continue
-		}
-
-		if dealerIndex >= len(epochBLSData.DealerParts) {
-			k.Logger().Warn("Invalid dealer index", "dealerIndex", dealerIndex, "totalDealers", len(epochBLSData.DealerParts))
-			continue
-		}
-
-		dealerPart := epochBLSData.DealerParts[dealerIndex]
-		if dealerPart == nil || len(dealerPart.Commitments) == 0 {
-			k.Logger().Warn("No commitments found for dealer", "dealerIndex", dealerIndex)
-			continue
-		}
-
-		commitmentsToAggregate = append(commitmentsToAggregate, dealerPart.Commitments[0])
-	}
-
-	if len(commitmentsToAggregate) == 0 {
-		return nil, fmt.Errorf("no dealer commitments available to compute group public key for epoch %d", epochBLSData.EpochId)
-	}
-
-	// Use helper function to aggregate commitments
-	groupPublicKeyBytes, err := k.aggregateG2PointsBlst(commitmentsToAggregate)
-	if err != nil {
-		return nil, fmt.Errorf("failed to aggregate commitments: %w", err)
-	}
-
-	k.Logger().Info("Completed group public key computation",
-		"epochId", epochBLSData.EpochId,
-		"validDealersCount", validDealerCount,
-		"groupPublicKeySize", len(groupPublicKeyBytes))
-
-	return groupPublicKeyBytes, nil
-}


### PR DESCRIPTION
We implemented fixes addressing the issues described in #823.

Main changes:

1. **Slot-weighted dealer consensus**   Dealer approval is now based on the number of **slots**, not the number of participants.   This prevents a dealer from being approved by a simple majority of voters while controlling fewer than 50% of the total slots.

2. **Unique slot counting for threshold signing**   Slot coverage is now calculated using a **set of unique slots**, preventing duplicate slot submissions from artificially inflating the threshold count.

3. **Duplicate slot protection**   The implementation now rejects partial signatures that reuse slot indices already submitted in other partial signatures.

4. **Slot bounds validation**   Every submitted slot index is validated against `epochBLSData.ITotalSlots` to prevent invalid or out-of-range slot references.

5. **Partial signature validation**   Partial signatures are now strictly validated for the expected BLS signature size (96 bytes).

6. **Spam / resource exhaustion protection**   A limit on the number of active signing requests per epoch was introduced to reduce the risk of resource exhaustion attacks.

7. **Additional input validation**   Added validation for:
- empty signing data
- encoded message size
- duplicate participant submissions
- duplicate slot indices within a submission

These changes fix the quorum calculation issue and prevent duplicate slot counting that could previously lead to threshold-signing DoS scenarios.