### PR TITLE
Add porosity and negativity check

### DIFF
--- a/decentralized-api/poc/porosity_test.go
+++ b/decentralized-api/poc/porosity_test.go
@@ -1,0 +1,163 @@
+package poc
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbsInt32(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int32
+		want int64
+	}{
+		{"zero", 0, 0},
+		{"positive", 42, 42},
+		{"negative", -42, 42},
+		{"max_int32", math.MaxInt32, math.MaxInt32},
+		{"min_int32", math.MinInt32, math.MaxInt32 + 1},
+		{"minus_one", -1, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, absInt32(tt.in))
+		})
+	}
+}
+
+func TestMaxNonceValue(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Equal(t, int64(0), maxNonceValue(nil))
+		assert.Equal(t, int64(0), maxNonceValue([]VerifiedArtifact{}))
+	})
+
+	t.Run("single_positive", func(t *testing.T) {
+		assert.Equal(t, int64(10), maxNonceValue([]VerifiedArtifact{{Nonce: 10}}))
+	})
+
+	t.Run("single_negative", func(t *testing.T) {
+		assert.Equal(t, int64(10), maxNonceValue([]VerifiedArtifact{{Nonce: -10}}))
+	})
+
+	t.Run("picks_largest_abs_from_negative", func(t *testing.T) {
+		arts := []VerifiedArtifact{{Nonce: 5}, {Nonce: -100}, {Nonce: 50}}
+		assert.Equal(t, int64(100), maxNonceValue(arts))
+	})
+
+	t.Run("min_int32", func(t *testing.T) {
+		arts := []VerifiedArtifact{{Nonce: 1}, {Nonce: math.MinInt32}}
+		assert.Equal(t, int64(math.MaxInt32)+1, maxNonceValue(arts))
+	})
+}
+
+func makeArtifacts(nonces []int32) []VerifiedArtifact {
+	arts := make([]VerifiedArtifact, len(nonces))
+	for i, n := range nonces {
+		arts[i] = VerifiedArtifact{LeafIndex: uint32(i), Nonce: n}
+	}
+	return arts
+}
+
+func TestIsPorosityTooHigh_SequentialNonces(t *testing.T) {
+	nonces := make([]int32, 100)
+	for i := range nonces {
+		nonces[i] = int32(i + 1)
+	}
+	arts := makeArtifacts(nonces)
+	maxNonce, porosity, tooHigh := isPorosityTooHigh(arts, 100)
+	assert.False(t, tooHigh)
+	assert.Equal(t, int64(100), maxNonce)
+	assert.InDelta(t, 1.0, porosity, 0.001)
+}
+
+func TestIsPorosityTooHigh_SparseNonces(t *testing.T) {
+	nonces := []int32{1, 10, 11, 15, 20, 25, 30, 40, 55, 60}
+	remaining := 100 - len(nonces)
+	for i := 0; i < remaining; i++ {
+		nonces = append(nonces, int32(70+i*3))
+	}
+	arts := makeArtifacts(nonces)
+
+	maxN := maxNonceValue(arts)
+	require.Greater(t, maxN, int64(200))
+
+	_, porosity, tooHigh := isPorosityTooHigh(arts, 100)
+	assert.False(t, tooHigh)
+	assert.Less(t, porosity, porosityThreshold)
+}
+
+func TestIsPorosityTooHigh_PositiveNonces(t *testing.T) {
+	nonces := make([]int32, 100)
+	for i := range nonces {
+		nonces[i] = int32(1_000_000_000 + i)
+	}
+	arts := makeArtifacts(nonces)
+	_, porosity, tooHigh := isPorosityTooHigh(arts, 100)
+	assert.True(t, tooHigh)
+	assert.GreaterOrEqual(t, porosity, porosityThreshold)
+}
+
+func TestIsPorosityTooHigh_NegativeNonces(t *testing.T) {
+	nonces := make([]int32, 100)
+	for i := range nonces {
+		nonces[i] = int32(-1_000_000_000 - i)
+	}
+	arts := makeArtifacts(nonces)
+	_, porosity, tooHigh := isPorosityTooHigh(arts, 100)
+	assert.True(t, tooHigh)
+	assert.GreaterOrEqual(t, porosity, porosityThreshold)
+}
+
+func TestIsPorosityTooHigh_MinInt32(t *testing.T) {
+	arts := makeArtifacts([]int32{1, 2, math.MinInt32})
+	_, porosity, tooHigh := isPorosityTooHigh(arts, 100)
+	assert.True(t, tooHigh)
+	assert.GreaterOrEqual(t, porosity, porosityThreshold)
+}
+
+func TestIsPorosityTooHigh_MixedPositiveNegative(t *testing.T) {
+	nonces := make([]int32, 100)
+	for i := range nonces {
+		if i%2 == 0 {
+			nonces[i] = int32(i + 1)
+		} else {
+			nonces[i] = -int32(i + 1)
+		}
+	}
+	arts := makeArtifacts(nonces)
+	_, porosity, tooHigh := isPorosityTooHigh(arts, uint32(len(nonces)))
+	assert.False(t, tooHigh, "small mixed positive/negative nonces should pass")
+	assert.InDelta(t, 1.0, porosity, 0.01)
+}
+
+func TestIsPorosityTooHigh_EdgeCases(t *testing.T) {
+	t.Run("empty_artifacts", func(t *testing.T) {
+		_, porosity, tooHigh := isPorosityTooHigh(nil, 100)
+		assert.False(t, tooHigh)
+		assert.Equal(t, 0.0, porosity)
+	})
+
+	t.Run("zero_count", func(t *testing.T) {
+		arts := makeArtifacts([]int32{1})
+		_, porosity, tooHigh := isPorosityTooHigh(arts, 0)
+		assert.False(t, tooHigh)
+		assert.Equal(t, 0.0, porosity)
+	})
+
+	t.Run("exactly_at_threshold", func(t *testing.T) {
+		arts := makeArtifacts([]int32{10000})
+		_, porosity, tooHigh := isPorosityTooHigh(arts, 100)
+		assert.True(t, tooHigh)
+		assert.Equal(t, porosityThreshold, porosity)
+	})
+
+	t.Run("just_below_threshold", func(t *testing.T) {
+		arts := makeArtifacts([]int32{9999})
+		_, porosity, tooHigh := isPorosityTooHigh(arts, 100)
+		assert.False(t, tooHigh)
+		assert.Less(t, porosity, porosityThreshold)
+	})
+}

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -60,6 +60,7 @@ const (
 	validateSuccess       validateResult = iota // Validation succeeded
 	validateFailPermanent                       // Permanent failure (fraud, invalid proof) - no retry
 	validateFailRetry                           // Transient failure (network, ML node) - can retry
+	porosityThreshold     = 100.0
 )
 
 // participantWork represents a single participant to validate.
@@ -71,6 +72,36 @@ type participantWork struct {
 	rootHash   []byte
 	attempt    int       // current attempt number (0-based)
 	retryAfter time.Time // don't process before this time
+}
+
+// absInt32 returns the absolute value of an int32 as int64,
+// safely handling math.MinInt32 which overflows when negated in int32.
+func absInt32(n int32) int64 {
+	v := int64(n)
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func maxNonceValue(artifacts []VerifiedArtifact) int64 {
+	var maxAbs int64
+	for _, artifact := range artifacts {
+		if a := absInt32(artifact.Nonce); a > maxAbs {
+			maxAbs = a
+		}
+	}
+	return maxAbs
+}
+
+func isPorosityTooHigh(artifacts []VerifiedArtifact, totalCount uint32) (maxNonce int64, porosity float64, tooHigh bool) {
+	if len(artifacts) == 0 || totalCount == 0 {
+		return 0, 0, false
+	}
+
+	maxNonce = maxNonceValue(artifacts)
+	porosity = float64(maxNonce) / float64(totalCount)
+	return maxNonce, porosity, porosity >= porosityThreshold
 }
 
 // NewOffChainValidator creates a new off-chain validator.
@@ -474,6 +505,15 @@ func (v *OffChainValidator) validateParticipant(
 	if err := CheckDuplicateNonces(verified); err != nil {
 		logging.Warn("OffChainValidator: duplicate nonces detected (fraud)", types.PoC,
 			"participant", work.address, "error", err)
+		return validateFailPermanent
+	}
+
+	if maxNonce, porosity, invalid := isPorosityTooHigh(verified, work.count); invalid {
+		logging.Warn("OffChainValidator: porosity too high", types.PoC,
+			"participant", work.address,
+			"maxNonce", maxNonce,
+			"count", work.count,
+			"porosity", porosity)
 		return validateFailPermanent
 	}
 

--- a/testermint/mock_server/src/main/kotlin/com/productscience/mockserver/routes/ResponseRoutes.kt
+++ b/testermint/mock_server/src/main/kotlin/com/productscience/mockserver/routes/ResponseRoutes.kt
@@ -3,6 +3,7 @@ package com.productscience.mockserver.routes
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.productscience.mockserver.model.latestNonce
 import com.productscience.mockserver.service.HostName
 import com.productscience.mockserver.service.ModelName
 import com.productscience.mockserver.service.ResponseService
@@ -58,6 +59,10 @@ data class SetPocResponseRequest(
     val hostName: String? = null,
     @JsonProperty("scenario_name")
     val scenarioName: String = "ModelState"
+)
+
+data class SetPocNonceRequest(
+    val nonce: Long
 )
 
 /**
@@ -166,6 +171,31 @@ fun Route.responseRoutes(responseService: ResponseService) {
                 mapOf(
                     "status" to "error",
                     "message" to "Failed to set POC response: ${e.message}"
+                )
+            )
+        }
+    }
+
+    // POST /api/v1/responses/poc/nonce - Sets the global nonce counter for PoC artifact generation
+    post("/api/v1/responses/poc/nonce") {
+        try {
+            val request = call.receive<SetPocNonceRequest>()
+            logger.info("Setting latestNonce to ${request.nonce}")
+            latestNonce.set(request.nonce)
+            call.respond(
+                HttpStatusCode.OK,
+                mapOf(
+                    "status" to "success",
+                    "message" to "PoC nonce counter set to ${request.nonce}",
+                    "nonce" to request.nonce
+                )
+            )
+        } catch (e: Exception) {
+            call.respond(
+                HttpStatusCode.BadRequest,
+                mapOf(
+                    "status" to "error",
+                    "message" to "Failed to set PoC nonce: ${e.message}"
                 )
             )
         }

--- a/testermint/mock_server/src/main/kotlin/com/productscience/mockserver/service/WebhookService.kt
+++ b/testermint/mock_server/src/main/kotlin/com/productscience/mockserver/service/WebhookService.kt
@@ -179,11 +179,14 @@ class WebhookService(private val responseService: ResponseService) {
                 // Get the weight from the ResponseService, default to 10 if not set
                 val weight = responseService.getPocResponseWeight(hostName) ?: 10L
 
-                // Generate unique nonces: atomic counter + nodeId offset
-                // Each mock-server container has its own counter, so nodeId ensures uniqueness across nodes
-                val start = latestNonce.getAndAdd(weight) + (nodeId * 1_000_000L)
+                // Sequential nonce assignment via atomic counter.
+                // In prod, nodes use a strided pattern (nonce % nodeCount == nodeId),
+                // but since mock nodes arrive as separate HTTP calls with advancing counters,
+                // simple sequential nonces are sufficient — the validator only checks
+                // uniqueness and porosity (maxNonce / count < 100), not the stride pattern.
+                val base = latestNonce.getAndAdd(weight)
                 val artifacts = (0 until weight.toInt()).map { i ->
-                    val nonce = start + i
+                    val nonce = base + i
                     // Generate valid FP16 vectors (24 bytes = 12 FP16 values)
                     // FP16 NaN/Inf have exponent bits = 31 (0x7C00-0x7FFF, 0xFC00-0xFFFF)
                     // To avoid these, we mask the high byte to keep exponent < 31

--- a/testermint/src/main/kotlin/InferenceMock.kt
+++ b/testermint/src/main/kotlin/InferenceMock.kt
@@ -44,6 +44,7 @@ interface IInferenceMock {
     // PoC v2 (artifact-based) methods
     fun setPocV2Response(weight: Long, hostName: String? = null, scenarioName: String = "ModelState")
     fun setPocV2ValidationResponse(weight: Long, scenarioName: String = "ModelState")
+    fun setLatestPocNonce(nonce: Long) {}
     fun getLastInferenceRequest(): InferenceRequestPayload?
     fun hasRequestsToVersionedEndpoint(segment: String): Boolean
     fun resetMocks()

--- a/testermint/src/main/kotlin/MockServerInferenceMock.kt
+++ b/testermint/src/main/kotlin/MockServerInferenceMock.kt
@@ -219,6 +219,21 @@ class MockServerInferenceMock(private val baseUrl: String, val name: String) : I
         setPocResponse(weight, scenarioName)
     }
 
+    override fun setLatestPocNonce(nonce: Long) {
+        try {
+            val (_, response, _) = Fuel.post("$baseUrl/api/v1/responses/poc/nonce")
+                .jsonBody("""{"nonce": $nonce}""")
+                .responseString()
+            if (response.statusCode != 200) {
+                Logger.error("Failed to set latest PoC nonce: ${response.statusCode} ${response.responseMessage}")
+            } else {
+                Logger.info("Set latest PoC nonce to $nonce")
+            }
+        } catch (e: Exception) {
+            Logger.error("Failed to set latest PoC nonce: ${e.message}")
+        }
+    }
+
     override fun hasRequestsToVersionedEndpoint(segment: String): Boolean {
         // For MockServerInferenceMock, we can't easily verify WireMock-style request patterns
         // Since this is primarily used in tests with the original WireMock-based InferenceMock,

--- a/testermint/src/test/kotlin/PoCOffChainTests.kt
+++ b/testermint/src/test/kotlin/PoCOffChainTests.kt
@@ -167,6 +167,70 @@ class PoCOffChainTests : TestermintTest() {
         logSection("TEST PASSED: All store commits query works correctly")
     }
 
+    @Test
+    fun `poc offchain validation - cheating via high nonce porosity is detected and participant excluded`() {
+        logSection("=== TEST: PoC Porosity Cheating Detection ===")
+
+        val (cluster, genesis) = initCluster(reboot = true, config = bandwidthConfig)
+        cluster.allPairs.forEach { it.waitForMlNodesToLoad() }
+        val cheater = cluster.joinPairs.first()
+        val cheaterAddress = cheater.node.getColdAddress()
+
+        // === Phase 1: Let all 3 participants complete a normal PoC epoch ===
+        logSection("Phase 1: Normal PoC epoch — all participants honest")
+
+        genesis.waitForStage(EpochStage.CLAIM_REWARDS, offset = 2)
+
+        val activeBeforeCheating = genesis.api.getActiveParticipants()
+        val cheaterBefore = activeBeforeCheating.activeParticipants.getParticipant(cheater)
+        Logger.info("Active participants before cheating: ${activeBeforeCheating.activeParticipants.participants.map { it.index }}")
+        assertThat(cheaterBefore)
+            .describedAs("Cheater $cheaterAddress should be active before cheating")
+            .isNotNull
+
+        // === Phase 2: Make one participant cheat by using billion-range nonces ===
+        logSection("Phase 2: Setting cheater nonce to 1 billion (simulating brute-force nonce search)")
+        cheater.mock?.setLatestPocNonce(1_000_000_000L)
+
+        // Wait for the next PoC generation + validation + new validators cycle
+        genesis.waitForStage(EpochStage.START_OF_POC)
+        Logger.info("PoC generation started — cheater will produce billion-range nonces")
+        genesis.waitForStage(EpochStage.END_OF_POC_VALIDATION, offset = 2)
+        Logger.info("PoC validation ended")
+
+        // Verify the cheater's store commit has high nonces
+        val epochData = genesis.getEpochData()
+        val pocStartHeight = epochData.latestEpoch.pocStartBlockHeight
+        val cheaterCommit = genesis.node.getPoCV2StoreCommit(pocStartHeight, cheaterAddress)
+        Logger.info("Cheater store commit: found=${cheaterCommit.found}, count=${cheaterCommit.count}")
+
+        // === Phase 3: After validation, cheater should be excluded ===
+        logSection("Phase 3: Waiting for new validators to be set after porosity check")
+        genesis.waitForStage(EpochStage.CLAIM_REWARDS, offset = 2)
+
+        val activeAfterCheating = genesis.api.getActiveParticipants()
+        Logger.info("Active participants after cheating: ${activeAfterCheating.activeParticipants.participants.map { it.index }}")
+        Logger.info("Excluded participants: ${activeAfterCheating.excludedParticipants.map { it.address }}")
+
+        val cheaterAfter = activeAfterCheating.activeParticipants.getParticipant(cheater)
+        val cheaterExcluded = activeAfterCheating.excludedParticipants.any { it.address == cheaterAddress }
+
+        assertThat(cheaterAfter == null || cheaterExcluded)
+            .describedAs(
+                "Cheater $cheaterAddress should be removed from active participants " +
+                "or appear in excluded list after porosity violation"
+            )
+            .isTrue()
+
+        // Verify the honest participants are still active
+        val genesisStillActive = activeAfterCheating.activeParticipants.getParticipant(genesis)
+        assertThat(genesisStillActive)
+            .describedAs("Honest genesis participant should still be active")
+            .isNotNull
+
+        logSection("TEST PASSED: Porosity cheating detected — cheater excluded from active set")
+    }
+
     companion object {
         /**
          * Builds the binary payload for PoC proofs signature verification.


### PR DESCRIPTION
# Porosity protection (PoC v2 off-chain validation)

**What it does:** Rejects participants whose sampled nonces imply they reverse-searched for nonces for known output vectors instead of performing the intended LLM-based PoC work.

**How:** Porosity = `max(|nonce|) / count`. If porosity ≥ 100, the participant is reported as invalid (`ValidatedWeight = -1`) and can be excluded from the active set at epoch formation.

**Details:**
- Max nonce is taken by **absolute value** so cheating in the negative nonce range is also caught.
- `math.MinInt32` is handled safely (no overflow when negating).
- Threshold is configurable via `PorosityThreshold` (default 100).