### PR TITLE
Remove unused deprecated computeParticipantPublicKey()

### DIFF
--- a/inference-chain/x/bls/keeper/bls_crypto.go
+++ b/inference-chain/x/bls/keeper/bls_crypto.go
@@ -16,34 +16,6 @@ import (
 // Thanks for this optimizations inspiration to prof. Dan Boneh & Ash Vardanian
 // from Alex Petrov aka sysman.
 
-// computeParticipantPublicKey computes individual BLS public key for participant's slots.
-//
-// Deprecated: use computeParticipantPublicKeyBlst. The gnark-crypto implementation is kept only
-// for legacy/reference purposes and is intended to be removed in a future cleanup.
-func (k Keeper) computeParticipantPublicKey(epochBLSData *types.EpochBLSData, slotIndices []uint32) ([]byte, error) {
-	// Initialize aggregated public key as G2 identity
-	var aggregatedPubKey bls12381.G2Affine
-	aggregatedPubKey.SetInfinity()
-
-	// For each slot assigned to this participant
-	for _, slotIndex := range slotIndices {
-		if len(epochBLSData.SlotPublicKeys) <= int(slotIndex) {
-			return nil, fmt.Errorf("precomputed slot public key missing for slot %d", slotIndex)
-		}
-
-		// Use precomputed slot public key
-		var slotPubKey bls12381.G2Affine
-		if err := slotPubKey.Unmarshal(epochBLSData.SlotPublicKeys[slotIndex]); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal precomputed slot public key %d: %w", slotIndex, err)
-		}
-		aggregatedPubKey.Add(&aggregatedPubKey, &slotPubKey)
-	}
-
-	// Return compressed public key bytes
-	pubKeyBytes := aggregatedPubKey.Bytes()
-	return pubKeyBytes[:], nil
-}
-
 // computeParticipantPublicKeyBlst computes individual BLS public key for participant's slots using blst.
 func (k Keeper) computeParticipantPublicKeyBlst(epochBLSData *types.EpochBLSData, slotIndices []uint32) ([]byte, error) {
 	if len(slotIndices) == 0 {

--- a/inference-chain/x/bls/keeper/msg_server_group_validation_timing_test.go
+++ b/inference-chain/x/bls/keeper/msg_server_group_validation_timing_test.go
@@ -542,23 +542,13 @@ func TestComputeParticipantPublicKey_TimingComparison(t *testing.T) {
 		slotIndices[i] = i
 	}
 
-	// 1. Measure gnark
-	startGnark := time.Now()
-	resGnark, err := k.computeParticipantPublicKey(&epochData, slotIndices)
-	durationGnark := time.Since(startGnark)
-	require.NoError(t, err)
-
-	// 2. Measure blst
 	startBlst := time.Now()
 	resBlst, err := k.computeParticipantPublicKeyBlst(&epochData, slotIndices)
 	durationBlst := time.Since(startBlst)
 	require.NoError(t, err)
+	require.NotEmpty(t, resBlst)
 
-	// Compare results
-	require.Equal(t, resGnark, resBlst, "Participant public keys must match")
-
-	t.Logf("computeParticipantPublicKey (gnark-crypto): %s", durationGnark)
-	t.Logf("computeParticipantPublicKeyBlst (blst):      %s", durationBlst)
+	t.Logf("computeParticipantPublicKeyBlst (blst): %s", durationBlst)
 }
 
 func TestDecompressG2To256_TimingComparison(t *testing.T) {


### PR DESCRIPTION
Certik audit finding GEB-50: `computeParticipantPublicKey()` (gnark-crypto) was marked deprecated in favor of `computeParticipantPublicKeyBlst()` and has no production callers. Remove it to reduce dead code surface.

The timing comparison test is updated to exercise the blst path only.

Closes #758