### PR TITLE
Handle EmitTypedEvent() errors in bls keeper

### DIFF
--- a/inference-chain/x/bls/keeper/dkg_initiation.go
+++ b/inference-chain/x/bls/keeper/dkg_initiation.go
@@ -79,7 +79,9 @@ func (k Keeper) InitiateKeyGenerationForEpoch(ctx sdk.Context, epochID uint64, f
 		Participants: blsParticipants,
 	}
 
-	ctx.EventManager().EmitTypedEvent(&event)
+	if err := ctx.EventManager().EmitTypedEvent(&event); err != nil {
+		return fmt.Errorf("failed to emit EventKeyGenerationInitiated for epoch %d: %w", epochID, err)
+	}
 
 	k.Logger().Info(
 		"DKG initiated for epoch",

--- a/inference-chain/x/bls/keeper/msg_server_group_validation.go
+++ b/inference-chain/x/bls/keeper/msg_server_group_validation.go
@@ -66,10 +66,12 @@ func (ms msgServer) SubmitGroupKeyValidationSignature(goCtx context.Context, msg
 		if errors.Is(err, types.ErrEpochBLSDataNotFound) {
 			// Emit a searchable event and continue using current epoch data as fallback
 			ms.Keeper.LogWarn("Previous epoch not found - using current epoch for validation", "previous_epoch_id", previousEpochId, "new_epoch_id", msg.NewEpochId)
-			ctx.EventManager().EmitTypedEvent(&types.EventGroupKeyValidationFailed{
+			if err := ctx.EventManager().EmitTypedEvent(&types.EventGroupKeyValidationFailed{
 				NewEpochId: msg.NewEpochId,
 				Reason:     fmt.Sprintf("previous_epoch_missing_fallback:%d", previousEpochId),
-			})
+			}); err != nil {
+				ms.Keeper.LogWarn("Failed to emit EventGroupKeyValidationFailed", "new_epoch_id", msg.NewEpochId, "error", err.Error())
+			}
 
 			previousEpochBLSData = newEpochBLSData
 		} else {

--- a/inference-chain/x/bls/keeper/msg_server_verifier.go
+++ b/inference-chain/x/bls/keeper/msg_server_verifier.go
@@ -75,7 +75,9 @@ func (ms msgServer) SubmitVerificationVector(ctx context.Context, msg *types.Msg
 		ParticipantAddress: msg.Creator,
 	}
 
-	sdkCtx.EventManager().EmitTypedEvent(&event)
+	if err := sdkCtx.EventManager().EmitTypedEvent(&event); err != nil {
+		return nil, fmt.Errorf("failed to emit EventVerificationVectorSubmitted for epoch %d: %w", msg.EpochId, err)
+	}
 
 	ms.Logger().Info(
 		"Verification vector submitted",


### PR DESCRIPTION
Certik audit finding GEB-42: three `EmitTypedEvent()` calls in the bls keeper silently discarded errors.

Fixed by propagating the error to callers in `msg_server_verifier.go` and `dkg_initiation.go`, and logging a warning in `msg_server_group_validation.go` (fallback path where we continue execution).

Follows the existing pattern from `phase_transitions.go`.

Closes #757