### PR TITLE
bls: propagate caller context to BlsManager and add per-call timeouts

### DIFF
--- a/decentralized-api/internal/bls/dealer.go
+++ b/decentralized-api/internal/bls/dealer.go
@@ -389,7 +389,9 @@ func (bm *BlsManager) getAllowedPubKeysForParticipant(participantAddress string)
 	queryClient := bm.cosmosClient.NewInferenceQueryClient()
 
 	// Get all grantees (warm keys) allowed to act on behalf of this participant
-	grantees, err := queryClient.GranteesByMessageType(bm.ctx, &inferenceTypes.QueryGranteesByMessageTypeRequest{
+	granteesCtx, granteesCancel := context.WithTimeout(bm.ctx, 30*time.Second)
+	defer granteesCancel()
+	grantees, err := queryClient.GranteesByMessageType(granteesCtx, &inferenceTypes.QueryGranteesByMessageTypeRequest{
 		GranterAddress: participantAddress,
 		MessageTypeUrl: "/inference.bls.MsgSubmitDealerPart", // BLS operations
 	})
@@ -401,7 +403,9 @@ func (bm *BlsManager) getAllowedPubKeysForParticipant(participantAddress string)
 	}
 
 	// Get the participant's own public key
-	participant, err := queryClient.InferenceParticipant(bm.ctx, &inferenceTypes.QueryInferenceParticipantRequest{
+	participantCtx, participantCancel := context.WithTimeout(bm.ctx, 30*time.Second)
+	defer participantCancel()
+	participant, err := queryClient.InferenceParticipant(participantCtx, &inferenceTypes.QueryInferenceParticipantRequest{
 		Address: participantAddress,
 	})
 	if err != nil {

--- a/decentralized-api/internal/bls/manager.go
+++ b/decentralized-api/internal/bls/manager.go
@@ -127,10 +127,10 @@ type SlotAssignment struct {
 }
 
 // NewBlsManager creates a new unified BLS manager
-func NewBlsManager(cosmosClient cosmosclient.InferenceCosmosClient) *BlsManager {
+func NewBlsManager(ctx context.Context, cosmosClient cosmosclient.InferenceCosmosClient) *BlsManager {
 	return &BlsManager{
 		cosmosClient: cosmosClient,
-		ctx:          context.Background(), // Use background context for chain queries
+		ctx:          ctx,
 		cache:        NewVerificationCache(),
 	}
 }

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -165,7 +165,7 @@ func main() {
 	trainingExecutor := training.NewExecutor(ctx, nodeBroker, recorder)
 
 	validator := validation.NewInferenceValidator(nodeBroker, config, recorder, chainPhaseTracker)
-	blsManager := bls.NewBlsManager(*recorder)
+	blsManager := bls.NewBlsManager(ctx, *recorder)
 	listener := event_listener.NewEventListener(
 		config,
 		pocOrchestrator,


### PR DESCRIPTION
Closes #908

## Problem

`NewBlsManager` stored `context.Background()` as a struct field, making all gRPC calls through `bm.ctx` impossible to cancel on node shutdown or when the upstream chain RPC becomes unavailable.

Two calls in `getAllowedPubKeysForParticipant` had no timeout:

```go
// dealer.go — no timeout, hangs indefinitely on slow RPC
grantees, err := queryClient.GranteesByMessageType(bm.ctx, ...)
participant, err := queryClient.InferenceParticipant(bm.ctx, ...)
```

If the chain node is unreachable during `EventKeyGenerationInitiated`, the event listener worker blocks indefinitely. The node misses the entire DKG window and drops out of consensus for that epoch.

Contrast with the correctly-handled call in `manager.go` which already uses `context.WithTimeout(bm.ctx, 60*time.Second)` — the two calls in `dealer.go` were inconsistently left without protection.

## Changes

**`bls/manager.go`** — accept `ctx context.Context` as first argument:
```go
// before
func NewBlsManager(cosmosClient ...) *BlsManager {
    return &BlsManager{ctx: context.Background(), ...}
}
// after
func NewBlsManager(ctx context.Context, cosmosClient ...) *BlsManager {
    return &BlsManager{ctx: ctx, ...}
}
```

**`bls/dealer.go`** — add 30s timeouts on both unguarded gRPC calls:
```go
granteesCtx, granteesCancel := context.WithTimeout(bm.ctx, 30*time.Second)
defer granteesCancel()
grantees, err := queryClient.GranteesByMessageType(granteesCtx, ...)

participantCtx, participantCancel := context.WithTimeout(bm.ctx, 30*time.Second)
defer participantCancel()
participant, err := queryClient.InferenceParticipant(participantCtx, ...)
```

**`main.go`** — pass root application context:
```go
blsManager := bls.NewBlsManager(ctx, *recorder)
```

## Effect

- SIGINT propagates to all in-flight BLS gRPC queries via context cancellation
- Slow or unreachable chain RPC times out after 30s instead of blocking forever
- No behaviour change during normal operation