### PR TITLE
bls: add epoch-level idempotency guard to ProcessKeyGenerationInitiated

### DIFF
--- a/decentralized-api/internal/bls/dealer.go
+++ b/decentralized-api/internal/bls/dealer.go
@@ -59,6 +59,18 @@ func (bm *BlsManager) ProcessKeyGenerationInitiated(event *chainevents.JSONRPCRe
 		return fmt.Errorf("failed to parse epoch_id: %w", err)
 	}
 
+	// Idempotency guard: EventKeyGenerationInitiated can be re-delivered on WS reconnect.
+	// Same pattern as isAlreadyValidated in inference_validation.go.
+	bm.processedDKGMu.Lock()
+	if _, seen := bm.processedDKGEpochs[epochID]; seen {
+		bm.processedDKGMu.Unlock()
+		logging.Debug("DKG epoch already processed, skipping duplicate event", inferenceTypes.BLS,
+			"epochID", epochID, "dealer", bm.cosmosClient.GetAddress())
+		return nil
+	}
+	bm.processedDKGEpochs[epochID] = struct{}{}
+	bm.processedDKGMu.Unlock()
+
 	totalSlotsStrs, ok := event.Result.Events["inference.bls.EventKeyGenerationInitiated.i_total_slots"]
 	if !ok || len(totalSlotsStrs) == 0 {
 		return fmt.Errorf("i_total_slots not found in event")

--- a/decentralized-api/internal/bls/manager.go
+++ b/decentralized-api/internal/bls/manager.go
@@ -26,14 +26,16 @@ const (
 
 // BlsManager handles all BLS operations including DKG dealing, verification, and group key validation
 type BlsManager struct {
-	cosmosClient     cosmosclient.InferenceCosmosClient
-	ctx              context.Context
-	cache            *VerificationCache
-	recoverySF       singleflight.Group
-	maxCacheSize     uint64
-	dealerOpeningsMu sync.RWMutex
-	dealerOpenings   map[dealerOpeningKey]dealerOpeningRecord
-	dealerOpeningsDB *sql.DB
+	cosmosClient       cosmosclient.InferenceCosmosClient
+	ctx                context.Context
+	cache              *VerificationCache
+	recoverySF         singleflight.Group
+	maxCacheSize       uint64
+	dealerOpeningsMu   sync.RWMutex
+	dealerOpenings     map[dealerOpeningKey]dealerOpeningRecord
+	dealerOpeningsDB   *sql.DB
+	processedDKGMu     sync.Mutex
+	processedDKGEpochs map[uint64]struct{}
 }
 
 // VerificationResult holds the results of DKG verification for an epoch
@@ -172,10 +174,11 @@ type SlotAssignment struct {
 // NewBlsManager creates a new unified BLS manager
 func NewBlsManager(cosmosClient cosmosclient.InferenceCosmosClient) *BlsManager {
 	return &BlsManager{
-		cosmosClient:   cosmosClient,
-		ctx:            context.Background(), // Use background context for chain queries
-		cache:          NewVerificationCache(),
-		dealerOpenings: make(map[dealerOpeningKey]dealerOpeningRecord),
+		cosmosClient:       cosmosClient,
+		ctx:                context.Background(),
+		cache:              NewVerificationCache(),
+		dealerOpenings:     make(map[dealerOpeningKey]dealerOpeningRecord),
+		processedDKGEpochs: make(map[uint64]struct{}),
 	}
 }
 


### PR DESCRIPTION
## Problem

`ProcessKeyGenerationInitiated` has no guard against re-delivery of `EventKeyGenerationInitiated` for the same epoch.

The event listener subscribes to chain events over WebSocket (`block_observer.go`). When the connection drops and reconnects, the same block events can be re-delivered. For `EventKeyGenerationInitiated` this means:

1. `generateDealerPart` is called again for an already-processed epoch
2. `SubmitDealerPart` submits a second dealer part to the chain
3. The on-chain BLS keeper either rejects it or counts the node as double-participating in that DKG round

## Context

The same problem was already identified and solved for inference validation in this codebase:

```go
// inference_validation.go:686
// isAlreadyValidated checks if this validator already submitted validation for the inference.
// Used to avoid duplicate work when multiple sources trigger validation for same inference.
func (s *InferenceValidator) isAlreadyValidated(...) bool {
```

This PR applies the identical pattern to the DKG dealing path.

## Fix

Add `processedDKGEpochs map[uint64]struct{}` (protected by `processedDKGMu sync.Mutex`) to `BlsManager`. At the start of `ProcessKeyGenerationInitiated`, after `epochID` is parsed, check-and-set the flag atomically:

```go
bm.processedDKGMu.Lock()
if _, seen := bm.processedDKGEpochs[epochID]; seen {
    bm.processedDKGMu.Unlock()
    logging.Debug("DKG epoch already processed, skipping duplicate event", ...)
    return nil
}
bm.processedDKGEpochs[epochID] = struct{}{}
bm.processedDKGMu.Unlock()
```

Duplicate events return `nil` immediately — same conservative approach used in `isAlreadyValidated`. `sync` is already imported in `manager.go`.

## Diff

- `bls/manager.go`: +2 fields to struct, +1 map init in constructor (+8 lines)
- `bls/dealer.go`: +12 lines guard block in `ProcessKeyGenerationInitiated`
- No behaviour change during normal operation (each epoch fires once per session)