### PR TITLE
fix: bridge safety - numeric block comparison, address validation, chain ID consistency

### DIFF
--- a/inference-chain/x/inference/keeper/bridge_chain_id_test.go
+++ b/inference-chain/x/inference/keeper/bridge_chain_id_test.go
@@ -1,0 +1,22 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainIdMappings_Consistent(t *testing.T) {
+	// Verify that mintChainIdMapping and chainIdMapping contain the same chains.
+	// If they diverge, users could withdraw to a chain they cannot mint back from.
+	for chain, id := range mintChainIdMapping {
+		withdrawId, found := chainIdMapping[chain]
+		require.True(t, found, "chain %q exists in mintChainIdMapping but not in withdrawal chainIdMapping", chain)
+		require.Equal(t, id, withdrawId, "chain ID mismatch for %q: mint=%s, withdrawal=%s", chain, id, withdrawId)
+	}
+	for chain, id := range chainIdMapping {
+		mintId, found := mintChainIdMapping[chain]
+		require.True(t, found, "chain %q exists in withdrawal chainIdMapping but not in mintChainIdMapping", chain)
+		require.Equal(t, id, mintId, "chain ID mismatch for %q: mint=%s, withdrawal=%s", chain, mintId, id)
+	}
+}

--- a/inference-chain/x/inference/keeper/bridge_transaction.go
+++ b/inference-chain/x/inference/keeper/bridge_transaction.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"cosmossdk.io/collections"
@@ -94,9 +95,14 @@ func (k Keeper) GetBridgeTransactionsByReceipt(ctx context.Context, chainId, blo
 	return matchingTransactions
 }
 
-// CleanupOldBridgeTransactions removes bridge transactions older than the specified block number
-// This is efficient because block numbers are included in the key prefix
+// CleanupOldBridgeTransactions removes bridge transactions older than the specified block number.
+// Block numbers are compared numerically to ensure correct ordering (e.g., block 9 < block 10).
 func (k Keeper) CleanupOldBridgeTransactions(ctx context.Context, chainId string, maxBlockNumber string) (int, error) {
+	maxBlock, err := strconv.ParseUint(maxBlockNumber, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid maxBlockNumber %q: %w", maxBlockNumber, err)
+	}
+
 	iter, err := k.BridgeTransactionsMap.Iterate(ctx, collections.NewPrefixedTripleRange[string, string, string](chainId))
 	if err != nil {
 		return 0, err
@@ -111,7 +117,11 @@ func (k Keeper) CleanupOldBridgeTransactions(ctx context.Context, chainId string
 	var deletedCount int
 	var firstErr error
 	for _, tx := range values {
-		if tx.BlockNumber < maxBlockNumber {
+		txBlock, err := strconv.ParseUint(tx.BlockNumber, 10, 64)
+		if err != nil {
+			continue // skip entries with non-numeric block numbers
+		}
+		if txBlock < maxBlock {
 			if err := k.removeBridgeTransactionByID(ctx, tx.Id); err != nil {
 				if firstErr == nil {
 					firstErr = err

--- a/inference-chain/x/inference/keeper/bridge_transaction_test.go
+++ b/inference-chain/x/inference/keeper/bridge_transaction_test.go
@@ -1,0 +1,38 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupOldBridgeTransactions_NumericComparison(t *testing.T) {
+	k, _, ctx, _ := setupKeeperWithMocks(t)
+
+	// Store transactions with block numbers that would sort incorrectly as strings
+	// String sort: "10" < "9" (wrong), Numeric sort: 9 < 10 (correct)
+	txs := []types.BridgeTransaction{
+		{ChainId: "ethereum", BlockNumber: "2", ReceiptIndex: "0", ContractAddress: "0xaaa", OwnerAddress: "owner1", Amount: "100", ReceiptsRoot: "root1"},
+		{ChainId: "ethereum", BlockNumber: "9", ReceiptIndex: "0", ContractAddress: "0xbbb", OwnerAddress: "owner2", Amount: "200", ReceiptsRoot: "root2"},
+		{ChainId: "ethereum", BlockNumber: "10", ReceiptIndex: "0", ContractAddress: "0xccc", OwnerAddress: "owner3", Amount: "300", ReceiptsRoot: "root3"},
+		{ChainId: "ethereum", BlockNumber: "100", ReceiptIndex: "0", ContractAddress: "0xddd", OwnerAddress: "owner4", Amount: "400", ReceiptsRoot: "root4"},
+	}
+
+	for i := range txs {
+		k.SetBridgeTransaction(ctx, &txs[i])
+	}
+
+	// Cleanup blocks older than block 10 (should delete blocks 2 and 9, NOT 10 or 100)
+	deleted, err := k.CleanupOldBridgeTransactions(ctx, "ethereum", "10")
+	require.NoError(t, err)
+	require.Equal(t, 2, deleted, "should delete blocks 2 and 9 (both < 10)")
+}
+
+func TestCleanupOldBridgeTransactions_InvalidMaxBlockNumber(t *testing.T) {
+	k, _, ctx, _ := setupKeeperWithMocks(t)
+
+	_, err := k.CleanupOldBridgeTransactions(ctx, "ethereum", "not-a-number")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid maxBlockNumber")
+}

--- a/inference-chain/x/inference/keeper/bridge_utils.go
+++ b/inference-chain/x/inference/keeper/bridge_utils.go
@@ -21,36 +21,31 @@ func keccak256Hash(data []byte) [32]byte {
 	return result
 }
 
-// ethereumAddressToBytes converts an Ethereum hex address string to 20 bytes
-// Handles addresses with or without 0x prefix and preserves case (matching Solidity abi.encodePacked behavior)
-func ethereumAddressToBytes(address string) []byte {
+// ethereumAddressToBytes converts an Ethereum hex address string to 20 bytes.
+// Handles addresses with or without 0x prefix and preserves case (matching Solidity abi.encodePacked behavior).
+// Returns an error if the address is empty or contains invalid hex characters.
+func ethereumAddressToBytes(address string) ([]byte, error) {
 	// Remove 0x prefix if present
 	addr := address
 	if len(addr) >= 2 && addr[:2] == "0x" {
 		addr = addr[2:]
 	}
 
-	// Convert hex string to 20 bytes using encoding/hex
-	// Truncate to at most 40 hex chars and ensure even length (ignore dangling nibble)
-	maxLen := 40
-	n := len(addr)
-	if n > maxLen {
-		n = maxLen
-	}
-	if n%2 == 1 {
-		n--
+	if len(addr) == 0 {
+		return nil, fmt.Errorf("empty ethereum address")
 	}
 
-	addrBytes := make([]byte, 20)
-	if n <= 0 {
-		return addrBytes
+	// Ethereum addresses must be exactly 40 hex characters (20 bytes)
+	if len(addr) != 40 {
+		return nil, fmt.Errorf("invalid ethereum address length: expected 40 hex chars, got %d", len(addr))
 	}
-	decoded := make([]byte, n/2)
-	if _, err := hex.Decode(decoded, []byte(addr[:n])); err != nil {
-		return addrBytes
+
+	decoded, err := hex.DecodeString(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid hex in ethereum address %q: %w", address, err)
 	}
-	copy(addrBytes, decoded)
-	return addrBytes
+
+	return decoded, nil
 }
 
 // chainIdToBytes32 converts a numeric chain ID string to bytes32 format (uint256)

--- a/inference-chain/x/inference/keeper/bridge_utils_test.go
+++ b/inference-chain/x/inference/keeper/bridge_utils_test.go
@@ -1,0 +1,64 @@
+package keeper
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEthereumAddressToBytes_ValidAddress(t *testing.T) {
+	// Standard 40-char hex address without prefix
+	addr := "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+	result, err := ethereumAddressToBytes(addr)
+	require.NoError(t, err)
+	require.Len(t, result, 20)
+
+	expected, _ := hex.DecodeString(addr)
+	require.Equal(t, expected, result)
+}
+
+func TestEthereumAddressToBytes_WithPrefix(t *testing.T) {
+	addr := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+	result, err := ethereumAddressToBytes(addr)
+	require.NoError(t, err)
+	require.Len(t, result, 20)
+}
+
+func TestEthereumAddressToBytes_EmptyAddress(t *testing.T) {
+	_, err := ethereumAddressToBytes("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty ethereum address")
+}
+
+func TestEthereumAddressToBytes_EmptyAfterPrefix(t *testing.T) {
+	_, err := ethereumAddressToBytes("0x")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty ethereum address")
+}
+
+func TestEthereumAddressToBytes_InvalidHex(t *testing.T) {
+	// 40 chars but contains non-hex character 'Z'
+	_, err := ethereumAddressToBytes("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid hex")
+}
+
+func TestEthereumAddressToBytes_TooShort(t *testing.T) {
+	_, err := ethereumAddressToBytes("0xdead")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid ethereum address length")
+}
+
+func TestEthereumAddressToBytes_TooLong(t *testing.T) {
+	_, err := ethereumAddressToBytes("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA960450000")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid ethereum address length")
+}
+
+func TestEthereumAddressToBytes_ZeroAddress(t *testing.T) {
+	// Valid zero address (40 zeros)
+	result, err := ethereumAddressToBytes("0x0000000000000000000000000000000000000000")
+	require.NoError(t, err)
+	require.Equal(t, make([]byte, 20), result)
+}

--- a/inference-chain/x/inference/keeper/msg_server_request_bridge_mint.go
+++ b/inference-chain/x/inference/keeper/msg_server_request_bridge_mint.go
@@ -16,13 +16,14 @@ var (
 	// MINT_OPERATION hash - calculated once at package initialization using keccak256
 	mintOperationHash = keccak256Hash([]byte("MINT_OPERATION"))
 
-	// Chain ID mapping for mint operations (same as withdrawal)
+	// Chain ID mapping for mint operations (must match withdrawal chainIdMapping)
 	mintChainIdMapping = map[string]string{
 		"ethereum": "1",        // Ethereum mainnet
 		"sepolia":  "11155111", // Ethereum Sepolia testnet
 		"polygon":  "137",      // Polygon mainnet
 		"mumbai":   "80001",    // Polygon Mumbai testnet
 		"arbitrum": "42161",    // Arbitrum One
+		"optimism": "10",       // Optimism mainnet
 	}
 )
 
@@ -94,11 +95,19 @@ func (k msgServer) RequestBridgeMint(goCtx context.Context, msg *types.MsgReques
 
 	// Prepare BLS signature data for WGNK mint command
 	// Only prepare the data portion - BLS system will prepend epochId, gonkaChainId, requestId
-	blsData := k.prepareBridgeMintSignatureData(
+	blsData, err := k.prepareBridgeMintSignatureData(
 		destinationChainId,     // Numeric chain ID (e.g., "1", "137")
 		msg.DestinationAddress, // Ethereum address to receive WGNK
 		msg.Amount,             // Amount as string
 	)
+	if err != nil {
+		// Rollback the escrow transfer
+		rollbackErr := k.ReleaseFromEscrow(ctx, userAddr, nativeCoins)
+		if rollbackErr != nil {
+			k.LogError("Bridge mint: Failed to rollback escrow transfer", types.Messages, "rollbackError", rollbackErr)
+		}
+		return nil, fmt.Errorf("failed to prepare BLS signature data: %v", err)
+	}
 
 	// 8. Request BLS threshold signature for WGNK minting
 	// Use the actual Gonka chain ID from context (source chain)
@@ -159,14 +168,17 @@ func (k msgServer) RequestBridgeMint(goCtx context.Context, msg *types.MsgReques
 }
 
 // prepareBridgeMintSignatureData prepares the data for BLS signature according to Ethereum bridge format
-func (k Keeper) prepareBridgeMintSignatureData(chainId, recipient, amount string) [][]byte {
+func (k Keeper) prepareBridgeMintSignatureData(chainId, recipient, amount string) ([][]byte, error) {
 	// This function only prepares the data that comes AFTER epochId, gonkaChainId, and requestId
 	// Final message format: [epochId, gonkaChainId, requestId, ethereumChainId, MINT_OPERATION, recipient, amount]
 	// BLS system will prepend: epochId (8 bytes) + gonkaChainId (32 bytes) + requestId (32 bytes)
 
 	// Use helper functions for consistent encoding
 	ethereumChainIdBytes := chainIdToBytes32(chainId)
-	recipientBytes := ethereumAddressToBytes(recipient)
+	recipientBytes, err := ethereumAddressToBytes(recipient)
+	if err != nil {
+		return nil, fmt.Errorf("invalid recipient address: %w", err)
+	}
 	amountBytes := amountToBytes32(amount)
 
 	// Return the data fields that come after epochId, gonkaChainId, requestId
@@ -178,5 +190,5 @@ func (k Keeper) prepareBridgeMintSignatureData(chainId, recipient, amount string
 		amountBytes,          // Amount as uint256 (32 bytes)
 	}
 
-	return data
+	return data, nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_request_bridge_withdrawal.go
+++ b/inference-chain/x/inference/keeper/msg_server_request_bridge_withdrawal.go
@@ -69,12 +69,15 @@ func (k msgServer) RequestBridgeWithdrawal(goCtx context.Context, msg *types.Msg
 	// Prepare data for BLS signing - only the parts after epochId/chainId/requestId
 	// The BLS system will prepend: epochId (8 bytes) + gonkaChainId (32 bytes) + requestId (32 bytes)
 	// We need to provide: ethereumChainId + WITHDRAW_OPERATION + recipient + tokenContract + amount
-	blsData := k.prepareBridgeWithdrawalSignatureData(
+	blsData, err := k.prepareBridgeWithdrawalSignatureData(
 		destinationChainId,                         // Numeric chain ID (e.g., "1", "137")
 		msg.DestinationAddress,                     // Ethereum address to receive tokens
 		bridgeWrappedTokenContract.ContractAddress, // Original token address on destination chain
 		msg.Amount, // Amount as string
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare BLS signature data: %v", err)
+	}
 
 	// 8. Request BLS threshold signature
 	// Use the actual Gonka chain ID from context (source chain)
@@ -135,11 +138,17 @@ func (k msgServer) generateRequestID(ctx sdk.Context) string {
 // prepareBridgeWithdrawalSignatureData prepares the data portion for BLS signature according to Ethereum bridge format
 // This function only prepares the data that comes AFTER epochId, gonkaChainId, and requestId
 // Final message format: [epochId, gonkaChainId, requestId, ethereumChainId, WITHDRAW_OPERATION, recipient, tokenContract, amount]
-func (k msgServer) prepareBridgeWithdrawalSignatureData(chainId, recipient, tokenContract, amount string) [][]byte {
+func (k msgServer) prepareBridgeWithdrawalSignatureData(chainId, recipient, tokenContract, amount string) ([][]byte, error) {
 	// Use helper functions for consistent encoding
 	ethereumChainIdBytes := chainIdToBytes32(chainId)
-	recipientBytes := ethereumAddressToBytes(recipient)
-	tokenBytes := ethereumAddressToBytes(tokenContract)
+	recipientBytes, err := ethereumAddressToBytes(recipient)
+	if err != nil {
+		return nil, fmt.Errorf("invalid recipient address: %w", err)
+	}
+	tokenBytes, err := ethereumAddressToBytes(tokenContract)
+	if err != nil {
+		return nil, fmt.Errorf("invalid token contract address: %w", err)
+	}
 	amountBytes := amountToBytes32(amount)
 
 	// Return the data fields that come after epochId, gonkaChainId, requestId
@@ -152,5 +161,5 @@ func (k msgServer) prepareBridgeWithdrawalSignatureData(chainId, recipient, toke
 		amountBytes,              // Amount as uint256 (32 bytes)
 	}
 
-	return data
+	return data, nil
 }


### PR DESCRIPTION
Fixes #931

## Changes

### 1. Numeric block number comparison in `CleanupOldBridgeTransactions`
- **Before:** `tx.BlockNumber < maxBlockNumber` — lexicographic string comparison (`"9" > "10"`)
- **After:** Parse both values as `uint64` before comparison
- Returns error for non-numeric `maxBlockNumber`

### 2. `ethereumAddressToBytes` returns error on invalid input
- **Before:** Silently returns 20 zero bytes for empty/invalid addresses
- **After:** Returns `([]byte, error)` — validates length (exactly 40 hex chars) and hex format
- Updated all 3 callers (`prepareBridgeMintSignatureData`, `prepareBridgeWithdrawalSignatureData`) to propagate errors
- Mint handler rolls back escrow on address validation failure

### 3. Consistent chain ID mapping
- Added `"optimism": "10"` to `mintChainIdMapping` (was already in withdrawal `chainIdMapping`)
- Fixed misleading comment ("same as withdrawal" when it wasn't)

## Tests

- `TestEthereumAddressToBytes_*` — 8 test cases covering valid addresses, 0x prefix, empty, invalid hex, wrong length, zero address
- `TestCleanupOldBridgeTransactions_NumericComparison` — verifies blocks 2,9 are deleted when maxBlock=10 (blocks 10,100 preserved)
- `TestCleanupOldBridgeTransactions_InvalidMaxBlockNumber` — verifies error on non-numeric input
- `TestChainIdMappings_Consistent` — verifies mint and withdrawal mappings contain identical chains

All existing bridge tests pass without modification.