### PR TITLE
fix: validate baseWeightRatio range in AdjustWeightsByCollateral

### DIFF
--- a/inference-chain/x/inference/keeper/collateral.go
+++ b/inference-chain/x/inference/keeper/collateral.go
@@ -93,6 +93,9 @@ func (k Keeper) AdjustWeightsByCollateral(ctx context.Context, participants []*t
 		k.LogError("invalid base_weight_ratio:", types.Tokenomics, "error", err)
 		return err
 	}
+	if baseWeightRatio.IsNegative() || baseWeightRatio.GTE(math.LegacyOneDec()) {
+		return fmt.Errorf("base_weight_ratio %s is out of valid range [0, 1)", baseWeightRatio.String())
+	}
 	collateralPerWeightUnit, err := collateralParams.CollateralPerWeightUnit.ToLegacyDec()
 	if err != nil {
 		k.LogError("invalid collateral_per_weight_unit:", types.Tokenomics, "error", err)

--- a/inference-chain/x/inference/keeper/collateral_weight_ratio_test.go
+++ b/inference-chain/x/inference/keeper/collateral_weight_ratio_test.go
@@ -1,0 +1,52 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdjustWeightsByCollateral_RejectsInvalidBaseWeightRatio(t *testing.T) {
+	k, _, ctx, _ := setupKeeperWithMocksForIntegration(t)
+
+	params := types.DefaultParams()
+	// Set grace period to 0 so collateral logic is active
+	params.CollateralParams.GracePeriodEndEpoch = 0
+	require.NoError(t, k.SetParams(ctx, params))
+
+	// Setup epoch so grace period check passes
+	k.SetEffectiveEpochIndex(ctx, 10)
+	require.NoError(t, k.SetEpoch(ctx, &types.Epoch{Index: 10}))
+
+	participants := []*types.ActiveParticipant{
+		{Index: "gonka1qnk2n4nlkpw9xfqntladh74w6ujtulwnz7rf8", Weight: 100},
+	}
+
+	tests := []struct {
+		name  string
+		ratio float64
+		valid bool
+	}{
+		{"ratio 0.2 (default, valid)", 0.2, true},
+		{"ratio 0.0 (edge, valid)", 0.0, true},
+		{"ratio 0.99 (edge, valid)", 0.99, true},
+		{"ratio 1.0 (invalid, breaks invariant)", 1.0, false},
+		{"ratio 1.5 (invalid, inflates weights)", 1.5, false},
+		{"ratio -0.1 (negative, invalid)", -0.1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params.CollateralParams.BaseWeightRatio = types.DecimalFromFloat(tt.ratio)
+			require.NoError(t, k.SetParams(ctx, params))
+
+			err := k.AdjustWeightsByCollateral(ctx, participants)
+			if tt.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err, "baseWeightRatio=%v should be rejected", tt.ratio)
+			}
+		})
+	}
+}

--- a/inference-chain/x/inference/keeper/collateral_weight_ratio_test.go
+++ b/inference-chain/x/inference/keeper/collateral_weight_ratio_test.go
@@ -3,12 +3,18 @@ package keeper_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/testutil/sample"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestAdjustWeightsByCollateral_RejectsInvalidBaseWeightRatio(t *testing.T) {
-	k, _, ctx, _ := setupKeeperWithMocksForIntegration(t)
+	k, _, ctx, mocks := setupKeeperWithMocksForIntegration(t)
+
+	// Generate a valid bech32 address for the participant
+	participantAddr := sample.AccAddress()
 
 	params := types.DefaultParams()
 	// Set grace period to 0 so collateral logic is active
@@ -19,8 +25,14 @@ func TestAdjustWeightsByCollateral_RejectsInvalidBaseWeightRatio(t *testing.T) {
 	k.SetEffectiveEpochIndex(ctx, 10)
 	require.NoError(t, k.SetEpoch(ctx, &types.Epoch{Index: 10}))
 
+	// Mock collateral keeper — participant has no collateral
+	mocks.CollateralKeeper.EXPECT().
+		GetCollateral(gomock.Any(), gomock.Any()).
+		Return(sdk.Coin{}, false).
+		AnyTimes()
+
 	participants := []*types.ActiveParticipant{
-		{Index: "gonka1qnk2n4nlkpw9xfqntladh74w6ujtulwnz7rf8", Weight: 100},
+		{Index: participantAddr, Weight: 100},
 	}
 
 	tests := []struct {


### PR DESCRIPTION
Fixes #933

## Problem

`calculateRequiredCollateral` validates that `baseWeightRatio` is in [0, 1), but `AdjustWeightsByCollateral` does not. If governance sets `baseWeightRatio >= 1.0`, uncollateralized participants receive inflated weights, inverting the collateral incentive.

## Fix

Add the same `[0, 1)` range guard in `AdjustWeightsByCollateral` (1 line), matching the validation in `calculateRequiredCollateral`.

## Tests

`TestAdjustWeightsByCollateral_RejectsInvalidBaseWeightRatio` — 6 cases:
- `0.2` (default) — accepted
- `0.0` (edge) — accepted
- `0.99` (edge) — accepted
- `1.0` — rejected
- `1.5` — rejected
- `-0.1` — rejected

All existing collateral tests pass.