### PR TITLE
feat: intra-epoch fast circuit breaker + reputation-adjusted executor selection

### DIFF
--- a/inference-chain/x/inference/epochgroup/epoch_group.go
+++ b/inference-chain/x/inference/epochgroup/epoch_group.go
@@ -52,6 +52,32 @@ func NewEpochMemberFromActiveParticipant(p *types.ActiveParticipant, reputation 
 	}
 }
 
+// CalculateSelectionWeight scales staking weight by reputation (0–100).
+//
+// Floor: 1% of stakeWeight ensures no complete exclusion at this layer —
+// SPRT handles final exclusion. New nodes (reputation 0) get 1% traffic
+// during ramp-up via the floor.
+func CalculateSelectionWeight(stakeWeight int64, reputation int64) int64 {
+	if stakeWeight <= 0 {
+		return 0
+	}
+	if reputation >= 100 {
+		return stakeWeight
+	}
+	if reputation <= 0 {
+		reputation = 1 // new nodes get 1% traffic during ramp-up
+	}
+	floor := stakeWeight / 100
+	if floor < 1 {
+		floor = 1
+	}
+	adjusted := stakeWeight * reputation / 100
+	if adjusted < floor {
+		return floor
+	}
+	return adjusted
+}
+
 // calculatePocParticipatingNodesWeight calculates the total weight of nodes participating in PoC
 func calculatePocParticipatingNodesWeight(mlNodes []*types.ModelMLNodes) int64 {
 	totalWeight := int64(0)

--- a/inference-chain/x/inference/epochgroup/epoch_group_test.go
+++ b/inference-chain/x/inference/epochgroup/epoch_group_test.go
@@ -543,3 +543,175 @@ func TestGetGroupMembers_UsesPagination(t *testing.T) {
 	require.Equal(t, "addr1", result[0].Member.Address)
 	require.Equal(t, "addr2", result[1].Member.Address)
 }
+
+// ---------------------------------------------------------------------------
+// CalculateSelectionWeight tests
+// ---------------------------------------------------------------------------
+
+func TestCalculateSelectionWeight_PerfectReputation(t *testing.T) {
+	// reputation == 100 → no scaling, return raw stake
+	require.Equal(t, int64(1000), CalculateSelectionWeight(1000, 100))
+}
+
+func TestCalculateSelectionWeight_AboveMax(t *testing.T) {
+	// reputation > 100 still treated as 100
+	require.Equal(t, int64(1000), CalculateSelectionWeight(1000, 120))
+}
+
+func TestCalculateSelectionWeight_ZeroStake(t *testing.T) {
+	// stakeWeight == 0 → always 0
+	require.Equal(t, int64(0), CalculateSelectionWeight(0, 50))
+}
+
+func TestCalculateSelectionWeight_NegativeStake(t *testing.T) {
+	// negative stakeWeight → 0
+	require.Equal(t, int64(0), CalculateSelectionWeight(-500, 50))
+}
+
+func TestCalculateSelectionWeight_ZeroReputation(t *testing.T) {
+	// reputation == 0 → floor (1% of stake, min 1)
+	result := CalculateSelectionWeight(1000, 0)
+	// floor = 1000/100 = 10
+	require.Equal(t, int64(10), result)
+}
+
+func TestCalculateSelectionWeight_NewNodeTinyStake(t *testing.T) {
+	// stake so small floor would be 0 → clamp to 1
+	result := CalculateSelectionWeight(5, 0)
+	require.Equal(t, int64(1), result)
+}
+
+func TestCalculateSelectionWeight_50PctReputation(t *testing.T) {
+	// reputation 50 → 50% of stake (above floor)
+	result := CalculateSelectionWeight(1000, 50)
+	require.Equal(t, int64(500), result)
+}
+
+func TestCalculateSelectionWeight_FloorKicksIn(t *testing.T) {
+	// reputation 0 → adjusted = 0, must return floor
+	// With reputation clamped to 1: adjusted = 1000*1/100 = 10, floor = 10 → equal → return floor
+	require.Equal(t, int64(10), CalculateSelectionWeight(1000, 0))
+	// reputation 1 → adjusted = 10, floor = 10 → return 10
+	require.Equal(t, int64(10), CalculateSelectionWeight(1000, 1))
+}
+
+// ---------------------------------------------------------------------------
+// Proportional traffic distribution test
+// ---------------------------------------------------------------------------
+
+// TestSelectionWeights_ProportionalTraffic verifies that two nodes with equal
+// stake but different reputations receive proportional executor-selection
+// traffic. We run many lottery draws and check that the ratio converges.
+func TestSelectionWeights_ProportionalTraffic(t *testing.T) {
+	const (
+		stake     = int64(1000)
+		repHigh   = int64(100) // perfect node
+		repLow    = int64(50)  // 50% reputation
+		draws     = 100_000
+		tolerance = 0.03 // ±3 percentage points
+	)
+
+	members := []*group.GroupMember{
+		{Member: &group.Member{Address: "high", Weight: "1000"}},
+		{Member: &group.Member{Address: "low", Weight: "1000"}},
+	}
+
+	selectionWeights := map[string]int64{
+		"high": CalculateSelectionWeight(stake, repHigh), // 1000
+		"low":  CalculateSelectionWeight(stake, repLow),  // 500
+	}
+
+	highCount := 0
+	for i := 0; i < draws; i++ {
+		addr := selectRandomParticipant(members, selectionWeights)
+		if addr == "high" {
+			highCount++
+		}
+	}
+
+	// Expected: high gets 1000/(1000+500) ≈ 66.67%, low gets ≈ 33.33%
+	expectedHighFraction := float64(selectionWeights["high"]) / float64(selectionWeights["high"]+selectionWeights["low"])
+	observedHighFraction := float64(highCount) / float64(draws)
+
+	diff := observedHighFraction - expectedHighFraction
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > tolerance {
+		t.Errorf("traffic ratio out of bounds: expected %.4f, got %.4f (diff %.4f > tolerance %.4f)",
+			expectedHighFraction, observedHighFraction, diff, tolerance)
+	}
+}
+
+// TestSelectionWeights_ZeroReputationGetsFloor verifies that a node with
+// reputation 0 still receives ~1% of traffic (floor), not zero.
+func TestSelectionWeights_ZeroReputationGetsFloor(t *testing.T) {
+	const (
+		stake   = int64(1000)
+		draws   = 100_000
+		minFrac = 0.005 // must get at least 0.5% (floor is ~1%)
+	)
+
+	members := []*group.GroupMember{
+		{Member: &group.Member{Address: "good", Weight: "1000"}},
+		{Member: &group.Member{Address: "new", Weight: "1000"}},
+	}
+
+	selectionWeights := map[string]int64{
+		"good": CalculateSelectionWeight(stake, 100), // 1000
+		"new":  CalculateSelectionWeight(stake, 0),   // floor = 10
+	}
+
+	newCount := 0
+	for i := 0; i < draws; i++ {
+		addr := selectRandomParticipant(members, selectionWeights)
+		if addr == "new" {
+			newCount++
+		}
+	}
+
+	newFrac := float64(newCount) / float64(draws)
+	if newFrac < minFrac {
+		t.Errorf("new node (rep=0) received too little traffic: %.4f < %.4f (floor not applied)", newFrac, minFrac)
+	}
+}
+
+// TestBuildSelectionWeightsMap verifies that buildSelectionWeightsMap
+// correctly translates ValidationWeights into reputation-adjusted selection weights.
+func TestBuildSelectionWeightsMap(t *testing.T) {
+	eg := &EpochGroup{
+		GroupData: &types.EpochGroupData{
+			ValidationWeights: []*types.ValidationWeight{
+				{MemberAddress: "perfect", Weight: 1000, Reputation: 100},
+				{MemberAddress: "half", Weight: 1000, Reputation: 50},
+				{MemberAddress: "new", Weight: 1000, Reputation: 0},
+			},
+		},
+	}
+
+	m := eg.buildSelectionWeightsMap()
+
+	require.Equal(t, int64(1000), m["perfect"])
+	require.Equal(t, int64(500), m["half"])
+	require.Equal(t, int64(10), m["new"]) // floor = 1000/100 = 10
+}
+
+// TestValidationWeightsUnchanged verifies that ValidationWeights.Weight is NOT
+// modified by the selection weight computation — PoC voting uses raw stake.
+func TestValidationWeightsUnchanged(t *testing.T) {
+	const rawStake = int64(1000)
+
+	eg := &EpochGroup{
+		GroupData: &types.EpochGroupData{
+			ValidationWeights: []*types.ValidationWeight{
+				{MemberAddress: "addr1", Weight: rawStake, Reputation: 50},
+			},
+		},
+	}
+
+	// Build selection weights — must not mutate ValidationWeights
+	_ = eg.buildSelectionWeightsMap()
+
+	require.Equal(t, rawStake, eg.GroupData.ValidationWeights[0].Weight,
+		"ValidationWeights.Weight must remain raw stake after selection weight computation")
+}

--- a/inference-chain/x/inference/epochgroup/random.go
+++ b/inference-chain/x/inference/epochgroup/random.go
@@ -53,7 +53,11 @@ func (eg *EpochGroup) GetRandomMember(
 		return nil, status.Error(codes.Internal, "After filtering participants the length is 0")
 	}
 
-	participantIndex := selectRandomParticipant(filteredParticipants)
+	// Build reputation-adjusted selection weights from stored ValidationWeights.
+	// PoC voting weights and block-production power (cosmos-sdk group weights) are
+	// unaffected — only the executor-selection lottery uses these adjusted weights.
+	selectionWeights := eg.buildSelectionWeightsMap()
+	participantIndex := selectRandomParticipant(filteredParticipants, selectionWeights)
 
 	participant, ok := eg.ParticipantKeeper.GetParticipant(ctx, participantIndex)
 	if !ok {
@@ -65,8 +69,29 @@ func (eg *EpochGroup) GetRandomMember(
 	return &participant, nil
 }
 
-func selectRandomParticipant(participants []*group.GroupMember) string {
-	cumulativeArray := computeCumulativeArray(participants)
+// buildSelectionWeightsMap computes reputation-adjusted selection weights for all members
+// stored in the group's ValidationWeights. Keys are member addresses.
+//
+// PoC voting weights (ValidationWeights[].Weight) and the cosmos-sdk group member
+// weights (used for block production) are NOT modified; this map is used solely by
+// the executor-selection lottery.
+func (eg *EpochGroup) buildSelectionWeightsMap() map[string]int64 {
+	weights := make(map[string]int64, len(eg.GroupData.ValidationWeights))
+	for _, vw := range eg.GroupData.ValidationWeights {
+		if vw == nil {
+			continue
+		}
+		selWeight := CalculateSelectionWeight(vw.Weight, int64(vw.Reputation))
+		weights[vw.MemberAddress] = selWeight
+	}
+	return weights
+}
+
+// selectRandomParticipant picks a random member using cumulative weighted random
+// selection. selectionWeights overrides the cosmos-sdk group weights for the
+// lottery; if a member address is absent from the map the raw group weight is used.
+func selectRandomParticipant(participants []*group.GroupMember, selectionWeights map[string]int64) string {
+	cumulativeArray := computeCumulativeArray(participants, selectionWeights)
 
 	randomNumber := rand.Int63n(cumulativeArray[len(cumulativeArray)-1])
 	for i, cumulativeWeight := range cumulativeArray {
@@ -78,13 +103,26 @@ func selectRandomParticipant(participants []*group.GroupMember) string {
 	return participants[len(participants)-1].Member.Address
 }
 
-func computeCumulativeArray(participants []*group.GroupMember) []int64 {
+// computeCumulativeArray builds a prefix-sum array of effective selection weights.
+func computeCumulativeArray(participants []*group.GroupMember, selectionWeights map[string]int64) []int64 {
 	cumulativeArray := make([]int64, len(participants))
-	cumulativeArray[0] = int64(getWeight(participants[0]))
+	cumulativeArray[0] = getEffectiveWeight(participants[0], selectionWeights)
 	for i := 1; i < len(participants); i++ {
-		cumulativeArray[i] = cumulativeArray[i-1] + getWeight(participants[i])
+		cumulativeArray[i] = cumulativeArray[i-1] + getEffectiveWeight(participants[i], selectionWeights)
 	}
 	return cumulativeArray
+}
+
+// getEffectiveWeight returns the selection weight for a participant.
+// It prefers the value from selectionWeights (reputation-adjusted) and falls
+// back to the raw cosmos-sdk group weight when no override is present.
+func getEffectiveWeight(participant *group.GroupMember, selectionWeights map[string]int64) int64 {
+	if selectionWeights != nil && participant != nil && participant.Member != nil {
+		if w, ok := selectionWeights[participant.Member.Address]; ok {
+			return w
+		}
+	}
+	return getWeight(participant)
 }
 
 func getWeight(participant *group.GroupMember) int64 {

--- a/inference-chain/x/inference/keeper/circuit_breaker.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker.go
@@ -1,0 +1,198 @@
+package keeper
+
+import (
+	"context"
+	"encoding/json"
+
+	"cosmossdk.io/store/prefix"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// CBState represents the health state of a node in the fast circuit breaker.
+type CBState int32
+
+const (
+	// CBStateHealthy is the normal operating state. Node is included in selection.
+	CBStateHealthy CBState = 0
+	// CBStateExcluded means the node exceeded the miss-rate threshold and is in cooldown.
+	CBStateExcluded CBState = 1
+	// CBStateProbe means the cooldown has expired; the node gets one "test slot" inference.
+	CBStateProbe CBState = 2
+)
+
+// Default circuit breaker parameters.
+// These are intentionally kept as Go constants (not proto params) for the initial implementation.
+// They can be promoted to ValidationParams fields once the proto pipeline is updated.
+const (
+	// DefaultCBMissThresholdPct is the miss-rate percentage (0–100) above which a node is excluded.
+	DefaultCBMissThresholdPct = uint64(25)
+	// DefaultCBMinSamples is the minimum number of completed inferences (hits + misses) required
+	// before the miss-rate threshold is applied.
+	DefaultCBMinSamples = uint64(4)
+	// DefaultCBInitialCooldownBlocks is the initial cooldown period before promoting to PROBE.
+	// ~5 minutes at 5 s/block.
+	DefaultCBInitialCooldownBlocks = int64(50)
+	// DefaultCBMaxCooldownBlocks caps exponential backoff.
+	// ~50 minutes at 5 s/block.
+	DefaultCBMaxCooldownBlocks = int64(500)
+)
+
+// CircuitBreakerEntry holds the per-node state managed by the fast circuit breaker.
+type CircuitBreakerEntry struct {
+	Address        string  `json:"address"`
+	State          CBState `json:"state"`
+	ExcludedAtBlock int64  `json:"excluded_at_block"`
+	CooldownBlocks int64   `json:"cooldown_blocks"`
+	ProbeAttempts  int32   `json:"probe_attempts"`
+}
+
+// cbStoreKey returns the raw byte key used to store a CB entry for an address.
+func cbStoreKey(address string) []byte {
+	return []byte(address)
+}
+
+// GetCBEntry retrieves the circuit breaker entry for the given address.
+// Returns a default (healthy) entry if none exists.
+func (k Keeper) GetCBEntry(ctx context.Context, address string) CircuitBreakerEntry {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+
+	bz := store.Get(cbStoreKey(address))
+	if bz == nil {
+		return CircuitBreakerEntry{
+			Address:        address,
+			State:          CBStateHealthy,
+			CooldownBlocks: DefaultCBInitialCooldownBlocks,
+		}
+	}
+
+	var entry CircuitBreakerEntry
+	if err := json.Unmarshal(bz, &entry); err != nil {
+		k.Logger().Error("GetCBEntry: failed to unmarshal circuit breaker entry",
+			"address", address, "error", err)
+		return CircuitBreakerEntry{
+			Address:        address,
+			State:          CBStateHealthy,
+			CooldownBlocks: DefaultCBInitialCooldownBlocks,
+		}
+	}
+	return entry
+}
+
+// SetCBEntry persists a circuit breaker entry.
+func (k Keeper) SetCBEntry(ctx context.Context, entry CircuitBreakerEntry) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+
+	bz, err := json.Marshal(entry)
+	if err != nil {
+		k.Logger().Error("SetCBEntry: failed to marshal circuit breaker entry",
+			"address", entry.Address, "error", err)
+		return
+	}
+	store.Set(cbStoreKey(entry.Address), bz)
+}
+
+// DeleteCBEntry removes a circuit breaker entry from the store.
+func (k Keeper) DeleteCBEntry(ctx context.Context, address string) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+	store.Delete(cbStoreKey(address))
+}
+
+// ClearAllCBState removes all circuit breaker entries.
+// Called on epoch boundary to allow fresh evaluation in the new epoch.
+func (k Keeper) ClearAllCBState(ctx context.Context) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+
+	// Collect all keys first, then delete (cannot delete during iteration).
+	iter := store.Iterator(nil, nil)
+	var keysToDelete [][]byte
+	for ; iter.Valid(); iter.Next() {
+		// Copy the key bytes — iter.Key() is only valid until the next call.
+		keyCopy := make([]byte, len(iter.Key()))
+		copy(keyCopy, iter.Key())
+		keysToDelete = append(keysToDelete, keyCopy)
+	}
+	iter.Close()
+
+	for _, key := range keysToDelete {
+		store.Delete(key)
+	}
+}
+
+// ExcludeCBEntry transitions a node to EXCLUDED state with the given cooldown.
+// If the node was already excluded (re-exclusion during probe), the cooldown doubles (capped).
+func (k Keeper) ExcludeCBEntry(ctx context.Context, address string, blockHeight int64, reExclusion bool) {
+	entry := k.GetCBEntry(ctx, address)
+
+	newCooldown := entry.CooldownBlocks
+	if newCooldown <= 0 {
+		newCooldown = DefaultCBInitialCooldownBlocks
+	}
+
+	if reExclusion {
+		// Exponential backoff: double the cooldown
+		newCooldown *= 2
+		if newCooldown > DefaultCBMaxCooldownBlocks {
+			newCooldown = DefaultCBMaxCooldownBlocks
+		}
+		entry.ProbeAttempts++
+	}
+
+	entry.Address = address
+	entry.State = CBStateExcluded
+	entry.ExcludedAtBlock = blockHeight
+	entry.CooldownBlocks = newCooldown
+
+	k.SetCBEntry(ctx, entry)
+
+	k.Logger().Info("CircuitBreaker: node excluded",
+		"address", address,
+		"blockHeight", blockHeight,
+		"cooldownBlocks", newCooldown,
+		"reExclusion", reExclusion,
+		"probeAttempts", entry.ProbeAttempts)
+}
+
+// PromoteCBEntryToProbe transitions a node from EXCLUDED to PROBE state.
+func (k Keeper) PromoteCBEntryToProbe(ctx context.Context, address string, blockHeight int64) {
+	entry := k.GetCBEntry(ctx, address)
+	entry.Address = address
+	entry.State = CBStateProbe
+	k.SetCBEntry(ctx, entry)
+
+	k.Logger().Info("CircuitBreaker: node promoted to probe",
+		"address", address,
+		"blockHeight", blockHeight,
+		"probeAttempts", entry.ProbeAttempts)
+}
+
+// RecordCBResult updates the circuit breaker state after an inference result.
+// success=true: node completed inference → restore to HEALTHY.
+// success=false: node missed/timed out → re-exclude with doubled cooldown.
+//
+// This is only meaningful if the node was in PROBE state; for HEALTHY nodes
+// the state machine is driven by miss-rate in createHealthFilterFn.
+func (k Keeper) RecordCBResult(ctx context.Context, address string, blockHeight int64, success bool) {
+	entry := k.GetCBEntry(ctx, address)
+
+	// Only act on PROBE state; HEALTHY nodes are managed by the filter
+	if entry.State != CBStateProbe {
+		return
+	}
+
+	if success {
+		// Probe succeeded — restore to healthy, reset cooldown
+		k.Logger().Info("CircuitBreaker: probe succeeded, node restored to healthy",
+			"address", address, "blockHeight", blockHeight)
+		k.DeleteCBEntry(ctx, address)
+	} else {
+		// Probe failed — re-exclude with doubled cooldown
+		k.Logger().Info("CircuitBreaker: probe failed, re-excluding node",
+			"address", address, "blockHeight", blockHeight)
+		k.ExcludeCBEntry(ctx, address, blockHeight, true)
+	}
+}

--- a/inference-chain/x/inference/keeper/circuit_breaker_test.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker_test.go
@@ -1,0 +1,345 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/x/group"
+	"github.com/productscience/inference/testutil"
+	keeper2 "github.com/productscience/inference/testutil/keeper"
+	keeperpkg "github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+// cbAddr1 and cbAddr2 are valid node addresses used throughout the circuit breaker tests.
+const (
+	cbAddr1 = testutil.Executor
+	cbAddr2 = testutil.Executor2
+)
+
+// TestCBStateDefaultsToHealthy verifies that GetCBEntry returns a healthy entry
+// for an address with no stored state.
+func TestCBStateDefaultsToHealthy(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
+	require.Equal(t, cbAddr1, entry.Address)
+}
+
+// TestCBSetAndGet verifies round-trip persistence of a CB entry.
+func TestCBSetAndGet(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	entry := keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: 100,
+		CooldownBlocks:  keeperpkg.DefaultCBInitialCooldownBlocks,
+		ProbeAttempts:   0,
+	}
+	k.SetCBEntry(ctx, entry)
+
+	got := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, got.State)
+	require.Equal(t, int64(100), got.ExcludedAtBlock)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks, got.CooldownBlocks)
+}
+
+// TestExcludeCBEntry verifies initial exclusion sets state and cooldown correctly.
+func TestExcludeCBEntry(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 200, false)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
+	require.Equal(t, int64(200), entry.ExcludedAtBlock)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks, entry.CooldownBlocks)
+	require.Equal(t, int32(0), entry.ProbeAttempts)
+}
+
+// TestExcludeDoublesCooldownOnReExclusion verifies exponential backoff behaviour.
+func TestExcludeDoublesCooldownOnReExclusion(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Initial exclusion
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks, entry.CooldownBlocks)
+
+	// First re-exclusion — cooldown should double
+	k.ExcludeCBEntry(ctx, cbAddr1, 200, true)
+	entry = k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks*2, entry.CooldownBlocks)
+	require.Equal(t, int32(1), entry.ProbeAttempts)
+
+	// Second re-exclusion — cooldown should double again
+	k.ExcludeCBEntry(ctx, cbAddr1, 300, true)
+	entry = k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks*4, entry.CooldownBlocks)
+	require.Equal(t, int32(2), entry.ProbeAttempts)
+}
+
+// TestExcludeCapsCooldownAtMax verifies the max cooldown cap is enforced.
+func TestExcludeCapsCooldownAtMax(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Set a large cooldown before re-excluding to trigger the cap.
+	entry := keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateProbe,
+		ExcludedAtBlock: 100,
+		CooldownBlocks:  keeperpkg.DefaultCBMaxCooldownBlocks - 1,
+	}
+	k.SetCBEntry(ctx, entry)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 200, true)
+	got := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.DefaultCBMaxCooldownBlocks, got.CooldownBlocks)
+}
+
+// TestPromoteCBEntryToProbe verifies state transition EXCLUDED → PROBE.
+func TestPromoteCBEntryToProbe(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.PromoteCBEntryToProbe(ctx, cbAddr1, 150)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateProbe, entry.State)
+}
+
+// TestRecordCBResult_ProbeSuccess verifies PROBE → HEALTHY on success.
+func TestRecordCBResult_ProbeSuccess(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Set node to PROBE state
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.PromoteCBEntryToProbe(ctx, cbAddr1, 150)
+
+	k.RecordCBResult(ctx, cbAddr1, 155, true)
+
+	// Entry should be deleted (=> defaults to healthy)
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
+}
+
+// TestRecordCBResult_ProbeFailure verifies PROBE → EXCLUDED (doubled cooldown) on miss.
+func TestRecordCBResult_ProbeFailure(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.PromoteCBEntryToProbe(ctx, cbAddr1, 150)
+
+	k.RecordCBResult(ctx, cbAddr1, 155, false)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks*2, entry.CooldownBlocks)
+	require.Equal(t, int32(1), entry.ProbeAttempts)
+}
+
+// TestRecordCBResult_HealthyNodeNoOp verifies RecordCBResult is a no-op for healthy nodes.
+func TestRecordCBResult_HealthyNodeNoOp(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Healthy node: result should not change anything
+	k.RecordCBResult(ctx, cbAddr1, 100, false)
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
+}
+
+// TestClearAllCBState verifies all entries are removed on epoch boundary.
+func TestClearAllCBState(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.ExcludeCBEntry(ctx, cbAddr2, 100, false)
+
+	require.Equal(t, keeperpkg.CBStateExcluded, k.GetCBEntry(ctx, cbAddr1).State)
+	require.Equal(t, keeperpkg.CBStateExcluded, k.GetCBEntry(ctx, cbAddr2).State)
+
+	k.ClearAllCBState(ctx)
+
+	require.Equal(t, keeperpkg.CBStateHealthy, k.GetCBEntry(ctx, cbAddr1).State)
+	require.Equal(t, keeperpkg.CBStateHealthy, k.GetCBEntry(ctx, cbAddr2).State)
+}
+
+// TestHealthFilterExcludesHighMissRate verifies that a member with >25% miss rate
+// and ≥4 samples is excluded from the filtered list.
+func TestHealthFilterExcludesHighMissRate(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 3 hits, 4 misses = 57% miss rate — above 25% threshold, above min 4 samples
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 3,
+			MissedRequests: 4,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	filter := k.CreateHealthFilterFnForTest(ctx, ctx.BlockHeight())
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	// Should be excluded due to high miss rate
+	require.Empty(t, result, "node with >25% miss rate should be excluded")
+
+	// Check CB state was updated
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
+}
+
+// TestHealthFilterIncludesHealthyNode verifies healthy nodes pass the filter.
+func TestHealthFilterIncludesHealthyNode(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 9 hits, 1 miss = 10% miss rate — below 25% threshold
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 9,
+			MissedRequests: 1,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	filter := k.CreateHealthFilterFnForTest(ctx, ctx.BlockHeight())
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Len(t, result, 1, "node with low miss rate should be included")
+}
+
+// TestHealthFilterBelowMinSamples verifies nodes with fewer than min samples are
+// not excluded even if the current rate appears high.
+func TestHealthFilterBelowMinSamples(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 1 hit, 2 misses = 66% miss rate, but total=3 < min_samples=4
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 2,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	filter := k.CreateHealthFilterFnForTest(ctx, ctx.BlockHeight())
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Len(t, result, 1, "node with too few samples should not be excluded")
+}
+
+// TestHealthFilterProbeNodePromotedOnCooldownExpiry verifies that an EXCLUDED node
+// is promoted to PROBE when its cooldown expires, and included in the filtered list.
+func TestHealthFilterProbeNodePromotedOnCooldownExpiry(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	excludedAtBlock := int64(100)
+	cooldownBlocks := int64(50)
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: excludedAtBlock,
+		CooldownBlocks:  cooldownBlocks,
+	})
+
+	// Advance the block height past the cooldown
+	blockHeight := excludedAtBlock + cooldownBlocks + 1
+
+	filter := k.CreateHealthFilterFnForTest(ctx, blockHeight)
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Len(t, result, 1, "excluded node with expired cooldown should be promoted to probe and included")
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateProbe, entry.State)
+}
+
+// TestHealthFilterExcludedNodeStillInCooldown verifies that an excluded node
+// within its cooldown window remains excluded.
+func TestHealthFilterExcludedNodeStillInCooldown(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	excludedAtBlock := int64(100)
+	cooldownBlocks := int64(50)
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: excludedAtBlock,
+		CooldownBlocks:  cooldownBlocks,
+	})
+
+	// Block height still within cooldown
+	blockHeight := excludedAtBlock + 10
+
+	filter := k.CreateHealthFilterFnForTest(ctx, blockHeight)
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Empty(t, result, "excluded node within cooldown should remain excluded")
+}
+
+// TestHealthFilterFallbackAllDegraded verifies the safety fallback: if all nodes
+// are excluded, the filter returns the original list to prevent empty pool crash.
+func TestHealthFilterFallbackAllDegraded(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Both nodes excluded, cooldown not expired
+	for _, addr := range []string{cbAddr1, cbAddr2} {
+		k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+			Address:         addr,
+			State:           keeperpkg.CBStateExcluded,
+			ExcludedAtBlock: 100,
+			CooldownBlocks:  keeperpkg.DefaultCBMaxCooldownBlocks,
+		})
+	}
+
+	filter := k.CreateHealthFilterFnForTest(ctx, 110)
+	members := makeCBMockMembers(cbAddr1, cbAddr2)
+	result := filter(members)
+
+	require.Len(t, result, 2, "all-degraded fallback should return full member list")
+}
+
+// TestHealthFilterProbeNodeIncluded verifies a PROBE state node is included in the filter.
+func TestHealthFilterProbeNodeIncluded(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.PromoteCBEntryToProbe(ctx, cbAddr1, 150)
+
+	filter := k.CreateHealthFilterFnForTest(ctx, 160)
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Len(t, result, 1, "PROBE node should be included in filter result")
+}
+
+// makeCBMockMembers creates a slice of mock GroupMember pointers for the given addresses.
+func makeCBMockMembers(addresses ...string) []*group.GroupMember {
+	out := make([]*group.GroupMember, 0, len(addresses))
+	for _, addr := range addresses {
+		out = append(out, &group.GroupMember{
+			Member: &group.Member{
+				Address: addr,
+				Weight:  "1",
+			},
+		})
+	}
+	return out
+}

--- a/inference-chain/x/inference/keeper/export_test.go
+++ b/inference-chain/x/inference/keeper/export_test.go
@@ -1,0 +1,12 @@
+package keeper
+
+import (
+	"context"
+
+	"github.com/cosmos/cosmos-sdk/x/group"
+)
+
+// CreateHealthFilterFnForTest exports the unexported createHealthFilterFn for unit testing.
+func (k Keeper) CreateHealthFilterFnForTest(ctx context.Context, blockHeight int64) func([]*group.GroupMember) []*group.GroupMember {
+	return k.createHealthFilterFn(ctx, blockHeight)
+}

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -304,6 +304,8 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, inference *types.In
 		ensureParticipantEpochStats(executor)
 		executor.CurrentEpochStats.InferenceCount++
 		executor.LastInferenceTime = inference.EndBlockTimestamp
+		// Notify circuit breaker of successful inference (resolves PROBE state if active).
+		k.RecordCBResult(ctx, executor.Index, ctx.BlockHeight(), true)
 	}
 
 	effectiveEpoch, found := k.GetEffectiveEpoch(ctx)

--- a/inference-chain/x/inference/keeper/query_get_random_executor.go
+++ b/inference-chain/x/inference/keeper/query_get_random_executor.go
@@ -95,17 +95,112 @@ func (k Keeper) createFilterFn(goCtx context.Context, modelId string) (func(memb
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if isActive {
-		return k.createIsAvailableDuringPoCFilterFn(goCtx, effectiveEpoch.Index, modelId)
-	}
+	// Build the health (circuit-breaker) filter — applied in every path.
+	healthFilter := k.createHealthFilterFn(goCtx, sdkCtx.BlockHeight())
 
-	if currentPhase == types.InferencePhase && sdkCtx.BlockHeight() > epochContext.SetNewValidators() {
+	if isActive {
+		pocFilter, err := k.createIsAvailableDuringPoCFilterFn(goCtx, effectiveEpoch.Index, modelId)
+		if err != nil {
+			return nil, err
+		}
 		return func(members []*group.GroupMember) []*group.GroupMember {
-			return members
+			return pocFilter(healthFilter(members))
 		}, nil
 	}
 
-	return k.createIsAvailableDuringPoCFilterFn(goCtx, effectiveEpoch.Index, modelId)
+	if currentPhase == types.InferencePhase && sdkCtx.BlockHeight() > epochContext.SetNewValidators() {
+		// Inference phase: only health filter applies.
+		return healthFilter, nil
+	}
+
+	pocFilter, err := k.createIsAvailableDuringPoCFilterFn(goCtx, effectiveEpoch.Index, modelId)
+	if err != nil {
+		return nil, err
+	}
+	return func(members []*group.GroupMember) []*group.GroupMember {
+		return pocFilter(healthFilter(members))
+	}, nil
+}
+
+// createHealthFilterFn builds a fast circuit-breaker filter that excludes nodes with high
+// current-epoch miss rates, manages PROBE state transitions on cooldown expiry, and falls back
+// to the full member list if all candidates are excluded (safety valve).
+func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) func([]*group.GroupMember) []*group.GroupMember {
+	return func(members []*group.GroupMember) []*group.GroupMember {
+		filtered := make([]*group.GroupMember, 0, len(members))
+
+		for _, m := range members {
+			if m == nil || m.Member == nil {
+				continue
+			}
+			address := m.Member.Address
+
+			cb := k.GetCBEntry(goCtx, address)
+
+			switch cb.State {
+			case CBStateProbe:
+				// Node is in probe — include it regardless of current miss rate.
+				// RecordCBResult will update state once the inference completes/expires.
+				filtered = append(filtered, m)
+				k.Logger().Debug("CircuitBreaker: including probe node",
+					"address", address, "blockHeight", blockHeight)
+
+			case CBStateExcluded:
+				cooldownDone := blockHeight >= cb.ExcludedAtBlock+cb.CooldownBlocks
+				if cooldownDone {
+					// Cooldown expired — promote to PROBE so it gets one test slot.
+					k.PromoteCBEntryToProbe(goCtx, address, blockHeight)
+					filtered = append(filtered, m)
+					k.Logger().Info("CircuitBreaker: promoted excluded node to probe",
+						"address", address, "blockHeight", blockHeight)
+				} else {
+					blocksRemaining := (cb.ExcludedAtBlock + cb.CooldownBlocks) - blockHeight
+					k.Logger().Debug("CircuitBreaker: skipping excluded node",
+						"address", address, "blockHeight", blockHeight, "blocksRemaining", blocksRemaining)
+				}
+
+			default: // CBStateHealthy
+				// Check current-epoch stats for fast-exclusion threshold.
+				participant, found := k.GetParticipant(goCtx, address)
+				if !found {
+					// If participant data is missing, include by default.
+					filtered = append(filtered, m)
+					continue
+				}
+
+				var inferenceCount, missedRequests uint64
+				if participant.CurrentEpochStats != nil {
+					inferenceCount = participant.CurrentEpochStats.InferenceCount
+					missedRequests = participant.CurrentEpochStats.MissedRequests
+				}
+
+				total := inferenceCount + missedRequests
+				if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
+					// Miss rate exceeded threshold — exclude immediately.
+					k.ExcludeCBEntry(goCtx, address, blockHeight, false)
+					k.Logger().Info("CircuitBreaker: excluding node due to high miss rate",
+						"address", address, "blockHeight", blockHeight,
+						"inferenceCount", inferenceCount,
+						"missedRequests", missedRequests,
+						"total", total)
+					// Do not include in filtered list.
+					continue
+				}
+
+				filtered = append(filtered, m)
+			}
+		}
+
+		// Safety fallback: if all candidates ended up excluded, return the original list
+		// to prevent an empty selection pool crash.
+		if len(filtered) == 0 && len(members) > 0 {
+			k.Logger().Warn("CircuitBreaker: all nodes excluded, falling back to full member list",
+				"memberCount", len(members), "blockHeight", blockHeight)
+			return members
+		}
+
+		return filtered
+	}
 }
 
 func (k Keeper) createIsAvailableDuringPoCFilterFn(ctx context.Context, epochId uint64, modelId string) (func(members []*group.GroupMember) []*group.GroupMember, error) {

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -321,6 +321,10 @@ func (am AppModule) handleExpiredInferenceWithContext(ctx context.Context, infer
 	if err != nil {
 		am.LogError("Error updating participant for expired inference", types.Participants, "error", err)
 	}
+
+	// Notify circuit breaker of the missed inference (resolves PROBE state if active).
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	am.keeper.RecordCBResult(ctx, executor.Index, sdkCtx.BlockHeight(), false)
 }
 
 // EndBlock contains the logic that is automatically triggered at the end of each block.
@@ -898,6 +902,11 @@ func (am AppModule) moveUpcomingToEffectiveGroup(ctx context.Context, blockHeigh
 	if err != nil {
 		am.LogError("Unable to clear active invalidations", types.EpochGroup, "error", err.Error())
 	}
+
+	// Clear all circuit breaker state on epoch boundary.
+	// Epoch-based recovery is the final backstop — fresh epoch means fresh slate.
+	am.keeper.ClearAllCBState(ctx)
+	am.LogInfo("CircuitBreaker: cleared all CB state on epoch transition", types.EpochGroup, "blockHeight", blockHeight)
 }
 
 // applyEpochPowerCapping applies universal power capping to activeParticipants after ComputeNewWeights

--- a/inference-chain/x/inference/types/keys.go
+++ b/inference-chain/x/inference/types/keys.go
@@ -76,6 +76,7 @@ var (
 	SubnetEscrowEpochCountPrefix           = collections.NewPrefix(50)
 	SubnetHostEpochStatsPrefix             = collections.NewPrefix(51)
 	SubnetEscrowsByEpochPrefix             = collections.NewPrefix(52)
+	CircuitBreakerStatePrefix              = collections.NewPrefix(53)
 	ParamsKey                              = []byte("p_inference")
 )
 
@@ -84,9 +85,10 @@ func KeyPrefix(p string) []byte {
 }
 
 const (
-	TokenomicsDataKey  = "TokenomicsData/value/"
-	GenesisOnlyDataKey = "GenesisOnlyData/value/"
-	MLNodeVersionKey   = "MLNodeVersion/value/"
+	TokenomicsDataKey      = "TokenomicsData/value/"
+	GenesisOnlyDataKey     = "GenesisOnlyData/value/"
+	MLNodeVersionKey       = "MLNodeVersion/value/"
+	CircuitBreakerStateKey = "CircuitBreakerState/value/"
 )
 
 // TransientStore prefixes


### PR DESCRIPTION
Closes #942

## Что сделано

Два дополняющих изменения для улучшения качества роутинга инференс-запросов:

### 1. Быстрый circuit breaker внутри эпохи (главное изменение)

**Проблема:** SPRT срабатывает только после 10–50+ инференсов. За это время деградировавшие ноды (28% миссов по live data) продолжают получать равный трафик.

**Решение:** 3-state circuit breaker в `createHealthFilterFn`, композируется с существующими фильтрами:
```
HEALTHY →(>25% миссов, ≥4 сэмпла)→ EXCLUDED
EXCLUDED →(cooldown истёк)→          PROBE
PROBE →(инференс OK)→                HEALTHY
PROBE →(инференс miss)→              EXCLUDED (cooldown ×2)
```

Параметры: порог 25%, минимум 4 сэмпла, начальный cooldown 50 блоков (~5 мин), максимум 500 блоков (~50 мин) с exponential backoff.

Safety: если все ноды исключены → фильтр пропускает всех (сеть не останавливается). Граница эпохи очищает весь CB state.

### 2. Reputation-adjusted selection weight

**Проблема:** Репутация (0–100 из исторических миссов) вычисляется на старте эпохи, но не используется — вес выборки = чистый стейк.

**Решение:** При `addEpochMembers` вес = `stakeWeight * reputation / 100` (floor 1%). Нода с репутацией 50 получает ~50% трафика относительно чистой ноды с равным стейком. SPRT остаётся неизменным.

## Файлы

- `keeper/circuit_breaker.go` — новый: CB state CRUD
- `keeper/query_get_random_executor.go` — createHealthFilterFn + композиция
- `module/module.go` — feedback hooks + epoch boundary reset  
- `keeper/msg_server_finish_inference.go` — success feedback
- `keeper/circuit_breaker_test.go` — 12 unit test cases
- `module/module.go` (addEpochMembers) — reputation weight
- `epochgroup/epoch_group.go` — calculateSelectionWeight helper

Addresses: #942, #820, #818