### PR TITLE
fix: add nil guards for gRPC responses in chat handler

### DIFF
--- a/decentralized-api/internal/server/public/nil_response_regression_test.go
+++ b/decentralized-api/internal/server/public/nil_response_regression_test.go
@@ -2,24 +2,30 @@ package public
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"decentralized-api/apiconfig"
 	"decentralized-api/cosmosclient"
 
+	"github.com/labstack/echo/v4"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
-// nilResponseQueryClient simulates a gRPC client that returns (nil, nil) for
-// specific queries. This reproduces the conditions that cause nil pointer
-// panics on mainnet when the chain RPC is slow or partially responsive.
+// nilResponseQueryClient returns (nil, nil) for gRPC queries, simulating the
+// condition when chain RPC is slow or partially responsive. This reproduces
+// the exact panic from issue #876.
 type nilResponseQueryClient struct {
-	types.QueryClient // embed — unoverridden methods will panic, but we only call overridden ones
+	types.QueryClient // embed — only overridden methods are called
 }
 
 func (c *nilResponseQueryClient) Params(ctx context.Context, in *types.QueryParamsRequest, opts ...grpc.CallOption) (*types.QueryParamsResponse, error) {
-	return nil, nil // simulate nil response with no error
+	return nil, nil
 }
 
 func (c *nilResponseQueryClient) GetModelPerTokenPrice(ctx context.Context, in *types.QueryGetModelPerTokenPriceRequest, opts ...grpc.CallOption) (*types.QueryGetModelPerTokenPriceResponse, error) {
@@ -30,10 +36,52 @@ func (c *nilResponseQueryClient) InferenceParticipant(ctx context.Context, in *t
 	return nil, nil
 }
 
-// TestEnforceDeveloperAccessGate_NilParamsResponse_NoPanic verifies that
-// enforceDeveloperAccessGate does not panic when the Params gRPC query
-// returns (nil, nil). Before the fix, paramsResp.Params.DeveloperAccessParams
-// would dereference a nil pointer.
+// TestPostChat_NilGRPCResponse_NoPanic is an integration test that reproduces
+// the full /v1/chat/completions failure path from issue #876. When the chain
+// RPC returns nil gRPC responses, the handler must return an error — not panic.
+//
+// Without the fix: panics at post_chat_handler.go:250
+//
+//	(paramsResp.Params.DeveloperAccessParams on nil paramsResp)
+//
+// With the fix: returns nil (developer gate passes), continues to next step.
+func TestPostChat_NilGRPCResponse_NoPanic(t *testing.T) {
+	e := echo.New()
+
+	// Build a signed-style request body
+	body, _ := json.Marshal(map[string]interface{}{
+		"model":      "Qwen3-235B-A22B-Instruct-2507-FP8",
+		"max_tokens": 100,
+		"messages":   []map[string]string{{"role": "user", "content": "hello"}},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "test-auth-key")
+	req.Header.Set("X-Requester-Address", "gonka1testaddr")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// Mock recorder: returns nil-response query client
+	mockRecorder := &cosmosclient.MockCosmosMessageClient{}
+	mockRecorder.On("GetAccountAddress").Return("gonka1taaddr")
+	mockRecorder.On("NewInferenceQueryClient").Return(&nilResponseQueryClient{})
+
+	s := &Server{
+		e:             e,
+		recorder:      mockRecorder,
+		configManager: &apiconfig.ConfigManager{}, // zero-value: TA whitelist disabled
+	}
+
+	// The handler must not panic. It may return an error (e.g. participant
+	// not found) but must never dereference a nil gRPC response.
+	require.NotPanics(t, func() {
+		_ = s.postChat(c)
+	})
+}
+
+// TestEnforceDeveloperAccessGate_NilParamsResponse_NoPanic directly tests
+// the function where the panic occurs. Confirms the nil guard works.
 func TestEnforceDeveloperAccessGate_NilParamsResponse_NoPanic(t *testing.T) {
 	mockRecorder := &cosmosclient.MockCosmosMessageClient{}
 	mockRecorder.On("NewInferenceQueryClient").Return(&nilResponseQueryClient{})
@@ -42,21 +90,18 @@ func TestEnforceDeveloperAccessGate_NilParamsResponse_NoPanic(t *testing.T) {
 
 	require.NotPanics(t, func() {
 		err := s.enforceDeveloperAccessGate(context.Background(), "gonka1test")
-		// Should return nil (gate passes) rather than panicking
 		require.NoError(t, err)
 	})
 }
 
-// TestValidateRequester_NilPriceResponse_NoPanic verifies that
-// validateRequester does not panic when GetModelPerTokenPrice returns (nil, nil).
-// Before the fix, priceResponse.Found would dereference a nil pointer.
+// TestValidateRequester_NilPriceResponse_NoPanic tests that validateRequester
+// does not panic when GetModelPerTokenPrice returns (nil, nil).
 func TestValidateRequester_NilPriceResponse_NoPanic(t *testing.T) {
 	mockRecorder := &cosmosclient.MockCosmosMessageClient{}
 	mockRecorder.On("NewInferenceQueryClient").Return(&nilResponseQueryClient{})
 
 	s := &Server{recorder: mockRecorder}
 
-	// Create a minimal valid requester with enough balance
 	requester := &types.QueryInferenceParticipantResponse{
 		Balance: 1000000000,
 		Pubkey:  "test-pubkey",
@@ -71,9 +116,6 @@ func TestValidateRequester_NilPriceResponse_NoPanic(t *testing.T) {
 	}
 
 	require.NotPanics(t, func() {
-		// Should use legacy pricing fallback instead of panicking
-		err := s.validateRequester(context.Background(), request, requester, 100)
-		// May return error (e.g. signature validation) but must NOT panic
-		_ = err
+		_ = s.validateRequester(context.Background(), request, requester, 100)
 	})
 }

--- a/decentralized-api/internal/server/public/nil_response_regression_test.go
+++ b/decentralized-api/internal/server/public/nil_response_regression_test.go
@@ -1,0 +1,79 @@
+package public
+
+import (
+	"context"
+	"testing"
+
+	"decentralized-api/cosmosclient"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// nilResponseQueryClient simulates a gRPC client that returns (nil, nil) for
+// specific queries. This reproduces the conditions that cause nil pointer
+// panics on mainnet when the chain RPC is slow or partially responsive.
+type nilResponseQueryClient struct {
+	types.QueryClient // embed — unoverridden methods will panic, but we only call overridden ones
+}
+
+func (c *nilResponseQueryClient) Params(ctx context.Context, in *types.QueryParamsRequest, opts ...grpc.CallOption) (*types.QueryParamsResponse, error) {
+	return nil, nil // simulate nil response with no error
+}
+
+func (c *nilResponseQueryClient) GetModelPerTokenPrice(ctx context.Context, in *types.QueryGetModelPerTokenPriceRequest, opts ...grpc.CallOption) (*types.QueryGetModelPerTokenPriceResponse, error) {
+	return nil, nil
+}
+
+func (c *nilResponseQueryClient) InferenceParticipant(ctx context.Context, in *types.QueryInferenceParticipantRequest, opts ...grpc.CallOption) (*types.QueryInferenceParticipantResponse, error) {
+	return nil, nil
+}
+
+// TestEnforceDeveloperAccessGate_NilParamsResponse_NoPanic verifies that
+// enforceDeveloperAccessGate does not panic when the Params gRPC query
+// returns (nil, nil). Before the fix, paramsResp.Params.DeveloperAccessParams
+// would dereference a nil pointer.
+func TestEnforceDeveloperAccessGate_NilParamsResponse_NoPanic(t *testing.T) {
+	mockRecorder := &cosmosclient.MockCosmosMessageClient{}
+	mockRecorder.On("NewInferenceQueryClient").Return(&nilResponseQueryClient{})
+
+	s := &Server{recorder: mockRecorder}
+
+	require.NotPanics(t, func() {
+		err := s.enforceDeveloperAccessGate(context.Background(), "gonka1test")
+		// Should return nil (gate passes) rather than panicking
+		require.NoError(t, err)
+	})
+}
+
+// TestValidateRequester_NilPriceResponse_NoPanic verifies that
+// validateRequester does not panic when GetModelPerTokenPrice returns (nil, nil).
+// Before the fix, priceResponse.Found would dereference a nil pointer.
+func TestValidateRequester_NilPriceResponse_NoPanic(t *testing.T) {
+	mockRecorder := &cosmosclient.MockCosmosMessageClient{}
+	mockRecorder.On("NewInferenceQueryClient").Return(&nilResponseQueryClient{})
+
+	s := &Server{recorder: mockRecorder}
+
+	// Create a minimal valid requester with enough balance
+	requester := &types.QueryInferenceParticipantResponse{
+		Balance: 1000000000,
+		Pubkey:  "test-pubkey",
+	}
+
+	request := &ChatRequest{
+		OpenAiRequest: OpenAiRequest{
+			Model:     "test-model",
+			MaxTokens: 100,
+		},
+		RequesterAddress: "gonka1test",
+	}
+
+	require.NotPanics(t, func() {
+		// Should use legacy pricing fallback instead of panicking
+		err := s.validateRequester(context.Background(), request, requester, 100)
+		// May return error (e.g. signature validation) but must NOT panic
+		_ = err
+	})
+}

--- a/decentralized-api/internal/server/public/post_chat_handler.go
+++ b/decentralized-api/internal/server/public/post_chat_handler.go
@@ -247,6 +247,9 @@ func (s *Server) enforceDeveloperAccessGate(ctx context.Context, requesterAddres
 	if err != nil {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "unable to fetch chain params")
 	}
+	if paramsResp == nil {
+		return nil
+	}
 	p := paramsResp.Params.DeveloperAccessParams
 	if p == nil || p.UntilBlockHeight == 0 {
 		return nil
@@ -291,7 +294,7 @@ func (s *Server) handleTransferRequest(ctx echo.Context, request *ChatRequest) e
 	requester, err := queryClient.InferenceParticipant(ctx.Request().Context(), &types.QueryInferenceParticipantRequest{Address: request.RequesterAddress})
 	if err != nil {
 		logging.Error("Failed to get inference requester", types.Inferences, "address", request.RequesterAddress, "error", err)
-		return err
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "unable to query inference participant")
 	}
 
 	promptText := ""
@@ -997,7 +1000,7 @@ func (s *Server) validateRequester(ctx context.Context, request *ChatRequest, re
 		ModelId: request.OpenAiRequest.Model,
 	})
 
-	if err == nil && priceResponse.Found {
+	if err == nil && priceResponse != nil && priceResponse.Found {
 		// Use dynamic pricing
 		perTokenPrice = priceResponse.Price
 


### PR DESCRIPTION
Fixes #876

## Problem

Three gRPC response accesses in `post_chat_handler.go` can panic with nil pointer dereference when chain RPC returns nil responses:

1. `enforceDeveloperAccessGate`: `paramsResp.Params.DeveloperAccessParams` without nil check on `paramsResp`
2. `handleTransferRequest`: raw gRPC error returned instead of `echo.NewHTTPError`
3. `validateRequester`: `priceResponse.Found` without nil check on `priceResponse`

## Fix

- Add `paramsResp == nil` guard before accessing Params fields
- Wrap gRPC error in `echo.NewHTTPError(http.StatusServiceUnavailable, ...)`
- Add `priceResponse != nil` to the dynamic pricing condition

3 lines changed across 3 locations in one file.