### PR TITLE
Cached storage and conflict-detection for optimistic mode

### DIFF
--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -25,6 +25,43 @@ import (
 	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
 
+// EpochGroupDraftDecorator binds a tx-scoped EpochGroupData draft to the request context at tx start.
+// PostHandler must call CommitEpochGroupDraftFromContext on success; block cache is flushed to store in EndBlock.
+type EpochGroupDraftDecorator struct {
+	InferenceKeeper *inferencemodulekeeper.Keeper
+}
+
+// AnteHandle attaches WithEpochGroupDraft to the context for the rest of the tx.
+func (d EpochGroupDraftDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if d.InferenceKeeper == nil {
+		return next(ctx, tx, simulate)
+	}
+	newCtx := ctx.WithContext(inferencemodulekeeper.WithEpochGroupDraft(ctx.Context()))
+	return next(newCtx, tx, simulate)
+}
+
+// EpochGroupDraftCommitPostDecorator merges the tx-scoped EpochGroupData draft into the block cache on tx success.
+type EpochGroupDraftCommitPostDecorator struct {
+	InferenceKeeper *inferencemodulekeeper.Keeper
+}
+
+// PostHandle runs the rest of the post chain, then on success commits the epoch group draft to the block cache; on failure releases the draft write lock.
+func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
+	newCtx, err := next(ctx, tx, simulate, success)
+	if err != nil {
+		return newCtx, err
+	}
+	if d.InferenceKeeper == nil {
+		return newCtx, nil
+	}
+	if success {
+		d.InferenceKeeper.CommitEpochGroupDraftFromContext(newCtx)
+	} else {
+		d.InferenceKeeper.ReleaseEpochGroupDraftFromContext(newCtx)
+	}
+	return newCtx, nil
+}
+
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
 // channel keeper.
 type HandlerOptions struct {
@@ -192,6 +229,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		EpochGroupDraftDecorator{InferenceKeeper: options.InferenceKeeper}, // tx-scoped EpochGroupData draft; committed to block cache in PostHandler, flushed in EndBlock
 		wasmkeeper.NewLimitSimulationGasDecorator(options.NodeConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		wasmkeeper.NewGasRegisterDecorator(options.WasmKeeper.GetGasRegister()),
@@ -251,4 +289,6 @@ func (app *App) setAnteHandler(txConfig client.TxConfig, nodeConfig wasmtypes.No
 
 	// Set the AnteHandler for the app
 	app.SetAnteHandler(anteHandler)
+	// Merge tx-scoped EpochGroupData draft into block cache on tx success (block cache flushed to store in EndBlock)
+	app.SetPostHandler(sdk.ChainPostDecorators(EpochGroupDraftCommitPostDecorator{InferenceKeeper: &app.InferenceKeeper}))
 }

--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -25,34 +25,30 @@ import (
 	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
 
-// EpochGroupDraftDecorator binds a tx-scoped EpochGroupData draft to the request context at tx start.
-// PostHandler must call CommitEpochGroupDraftFromContext on success; block cache is flushed to store in EndBlock.
-type EpochGroupDraftDecorator struct {
+// OptimisticStoreDraftDecorator attaches tx-scoped drafts for all optimistic stores and registers them for OCC.
+// PostHandler must call commit on success; block caches are flushed in EndBlock.
+type OptimisticStoreDraftDecorator struct {
 	InferenceKeeper *inferencemodulekeeper.Keeper
 }
 
-// AnteHandle attaches WithEpochGroupDraft to the context for the rest of the tx.
-// For CheckTx and simulate, also attaches WithCommittedStateOnly so the keeper uses only the store (last committed block), not the block cache.
-func (d EpochGroupDraftDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+// AnteHandle attaches drafts for all optimistic stores to the context and registers them for OCC.
+func (d OptimisticStoreDraftDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	if d.InferenceKeeper == nil {
 		return next(ctx, tx, simulate)
 	}
-	goCtx := inferencemodulekeeper.WithEpochGroupDraft(ctx.Context())
-	if ctx.IsCheckTx() || simulate {
-		goCtx = inferencemodulekeeper.WithCommittedStateOnly(goCtx)
-	}
-	newCtx := ctx.WithContext(goCtx)
+	g := d.InferenceKeeper.StoreGroup()
+	newCtx := ctx.WithContext(g.WithDraftAll(ctx.Context()))
+	g.RegisterTxAll(newCtx)
 	return next(newCtx, tx, simulate)
 }
 
-// EpochGroupDraftCommitPostDecorator merges the tx-scoped EpochGroupData draft into the block cache on tx success.
-type EpochGroupDraftCommitPostDecorator struct {
+// OptimisticStoreCommitPostDecorator commits or releases all optimistic store drafts.
+type OptimisticStoreCommitPostDecorator struct {
 	InferenceKeeper *inferencemodulekeeper.Keeper
 }
 
-// PostHandle runs the rest of the post chain, then on success commits the epoch group draft to the block cache; on failure releases the draft write lock.
-// During DeliverTx: commit on success, release lock on failure. During CheckTx/simulate: skip (we never take the block-cache draft writer lock there, so nothing to release or commit).
-func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
+// PostHandle commits all optimistic store drafts on success, releases on failure.
+func (d OptimisticStoreCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
 	newCtx, err := next(ctx, tx, simulate, success)
 	if err != nil {
 		return newCtx, err
@@ -61,13 +57,13 @@ func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.T
 		return newCtx, nil
 	}
 	if ctx.IsCheckTx() || simulate {
-		// We never take the block-cache draft writer lock during CheckTx/simulate, so nothing to release or commit.
 		return newCtx, nil
 	}
+	g := d.InferenceKeeper.StoreGroup()
 	if success {
-		d.InferenceKeeper.CommitEpochGroupDraftFromContext(newCtx)
+		g.CommitDraftAll(newCtx)
 	} else {
-		d.InferenceKeeper.ReleaseEpochGroupDraftFromContext(newCtx)
+		g.ReleaseDraftAll(newCtx)
 	}
 	return newCtx, nil
 }
@@ -239,7 +235,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(),                                                  // outermost AnteDecorator. SetUpContext must be called first
-		EpochGroupDraftDecorator{InferenceKeeper: options.InferenceKeeper},               // tx-scoped EpochGroupData draft; committed to block cache in PostHandler, flushed in EndBlock
+		OptimisticStoreDraftDecorator{InferenceKeeper: options.InferenceKeeper},            // tx-scoped drafts for all optimistic stores; committed in PostHandler, flushed in EndBlock
 		wasmkeeper.NewLimitSimulationGasDecorator(options.NodeConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		wasmkeeper.NewGasRegisterDecorator(options.WasmKeeper.GetGasRegister()),
@@ -300,5 +296,5 @@ func (app *App) setAnteHandler(txConfig client.TxConfig, nodeConfig wasmtypes.No
 	// Set the AnteHandler for the app
 	app.SetAnteHandler(anteHandler)
 	// Merge tx-scoped EpochGroupData draft into block cache on tx success (block cache flushed to store in EndBlock)
-	app.SetPostHandler(sdk.ChainPostDecorators(EpochGroupDraftCommitPostDecorator{InferenceKeeper: &app.InferenceKeeper}))
+	app.SetPostHandler(sdk.ChainPostDecorators(OptimisticStoreCommitPostDecorator{InferenceKeeper: &app.InferenceKeeper}))
 }

--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -32,11 +32,16 @@ type EpochGroupDraftDecorator struct {
 }
 
 // AnteHandle attaches WithEpochGroupDraft to the context for the rest of the tx.
+// For CheckTx and simulate, also attaches WithCommittedStateOnly so the keeper uses only the store (last committed block), not the block cache.
 func (d EpochGroupDraftDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	if d.InferenceKeeper == nil {
 		return next(ctx, tx, simulate)
 	}
-	newCtx := ctx.WithContext(inferencemodulekeeper.WithEpochGroupDraft(ctx.Context()))
+	goCtx := inferencemodulekeeper.WithEpochGroupDraft(ctx.Context())
+	if ctx.IsCheckTx() || simulate {
+		goCtx = inferencemodulekeeper.WithCommittedStateOnly(goCtx)
+	}
+	newCtx := ctx.WithContext(goCtx)
 	return next(newCtx, tx, simulate)
 }
 
@@ -46,12 +51,18 @@ type EpochGroupDraftCommitPostDecorator struct {
 }
 
 // PostHandle runs the rest of the post chain, then on success commits the epoch group draft to the block cache; on failure releases the draft write lock.
+// During DeliverTx: commit on success, release lock on failure. During CheckTx/simulate: always release the lock only (no commit),
+// so we never leak the block-cache draft writer lock; we still skip commit to avoid mutating the shared block cache.
 func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
 	newCtx, err := next(ctx, tx, simulate, success)
 	if err != nil {
 		return newCtx, err
 	}
 	if d.InferenceKeeper == nil {
+		return newCtx, nil
+	}
+	if ctx.IsCheckTx() || simulate {
+		d.InferenceKeeper.ReleaseEpochGroupDraftFromContext(newCtx)
 		return newCtx, nil
 	}
 	if success {

--- a/inference-chain/app/ante.go
+++ b/inference-chain/app/ante.go
@@ -51,8 +51,7 @@ type EpochGroupDraftCommitPostDecorator struct {
 }
 
 // PostHandle runs the rest of the post chain, then on success commits the epoch group draft to the block cache; on failure releases the draft write lock.
-// During DeliverTx: commit on success, release lock on failure. During CheckTx/simulate: always release the lock only (no commit),
-// so we never leak the block-cache draft writer lock; we still skip commit to avoid mutating the shared block cache.
+// During DeliverTx: commit on success, release lock on failure. During CheckTx/simulate: skip (we never take the block-cache draft writer lock there, so nothing to release or commit).
 func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
 	newCtx, err := next(ctx, tx, simulate, success)
 	if err != nil {
@@ -62,7 +61,7 @@ func (d EpochGroupDraftCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.T
 		return newCtx, nil
 	}
 	if ctx.IsCheckTx() || simulate {
-		d.InferenceKeeper.ReleaseEpochGroupDraftFromContext(newCtx)
+		// We never take the block-cache draft writer lock during CheckTx/simulate, so nothing to release or commit.
 		return newCtx, nil
 	}
 	if success {
@@ -239,8 +238,8 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	}
 
 	anteDecorators := []sdk.AnteDecorator{
-		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
-		EpochGroupDraftDecorator{InferenceKeeper: options.InferenceKeeper}, // tx-scoped EpochGroupData draft; committed to block cache in PostHandler, flushed in EndBlock
+		ante.NewSetUpContextDecorator(),                                                  // outermost AnteDecorator. SetUpContext must be called first
+		EpochGroupDraftDecorator{InferenceKeeper: options.InferenceKeeper},               // tx-scoped EpochGroupData draft; committed to block cache in PostHandler, flushed in EndBlock
 		wasmkeeper.NewLimitSimulationGasDecorator(options.NodeConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		wasmkeeper.NewGasRegisterDecorator(options.WasmKeeper.GetGasRegister()),

--- a/inference-chain/x/inference/keeper/CONCURRENCY.md
+++ b/inference-chain/x/inference/keeper/CONCURRENCY.md
@@ -1,0 +1,20 @@
+# Epoch group data concurrency
+
+The keeper’s epoch group cache and tx-scoped draft are designed to support **concurrent execution** of transactions. This is required for **Cosmos optimistic execution mode**, where multiple transactions can run in parallel before being committed.
+
+The concurrency tests in `epoch_group_data_concurrent_test.go` check that:
+
+1. **Multiple parallel reads** – Many read-only “transactions” see the same data and do not block each other.
+2. **One writer, many readers** – After a writer commits, all readers see the written value (block cache is updated correctly).
+3. **One writer, multiple Set/Get, many readers** – No deadlocks when a writer does several Set/Get in one tx while readers run in parallel (reentrant draft lock).
+4. **Multiple writers and readers** – Writes are serialized at commit time, and the final read sees the last committed value.
+
+## Running the tests
+
+Run the concurrency tests as usual:
+
+```bash
+go test ./x/inference/keeper/ -run EpochGroupDataConcurrent -v
+```
+
+**Note on `-race`:** The tests intentionally share a single `sdk.Context` across goroutines to stress the keeper’s locking. The Cosmos SDK store and gas meter are not safe for concurrent use from multiple goroutines. With `go test -race`, the race detector may report races in the SDK layer (e.g. `cosmossdk.io/store/types.(*infiniteGasMeter).ConsumeGas`). That is a limitation of the test harness, not of the keeper’s epoch group logic. In production, each transaction gets its own context, and the keeper’s cache and draft locking are what allow safe concurrent access to epoch group data under optimistic execution.

--- a/inference-chain/x/inference/keeper/CONCURRENCY.md
+++ b/inference-chain/x/inference/keeper/CONCURRENCY.md
@@ -14,7 +14,7 @@ The concurrency tests in `epoch_group_data_concurrent_test.go` check that:
 Run the concurrency tests as usual:
 
 ```bash
-go test ./x/inference/keeper/ -run EpochGroupDataConcurrent -v
+go test ./x/inference/keeper -run 'Test(ConcurrentReadsSameResult|OneWriterManyReaders_ReadersSeeWriteAfterCommit|OneWriterMultipleSetGet_NoDeadlock|MultipleWritersMultipleReaders_LastWriteWins)$' -v
 ```
 
 **Note on `-race`:** The tests intentionally share a single `sdk.Context` across goroutines to stress the keeper’s locking. The Cosmos SDK store and gas meter are not safe for concurrent use from multiple goroutines. With `go test -race`, the race detector may report races in the SDK layer (e.g. `cosmossdk.io/store/types.(*infiniteGasMeter).ConsumeGas`). That is a limitation of the test harness, not of the keeper’s epoch group logic. In production, each transaction gets its own context, and the keeper’s cache and draft locking are what allow safe concurrent access to epoch group data under optimistic execution.

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -1,544 +1,90 @@
 package keeper
 
 import (
-	"bytes"
 	"context"
-	"os"
-	"runtime"
-	"strconv"
-	"sync"
-	"sync/atomic"
 
 	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/gogoproto/proto"
 	"github.com/productscience/inference/x/inference/types"
 )
 
-// cosmosOptimisticCachesEnabled is set once at package init from COSMOS_OPTIMISTIC_CACHES=1.
-var cosmosOptimisticCachesEnabled bool
+// ---------- Keeper methods ----------
 
-func init() {
-	cosmosOptimisticCachesEnabled = os.Getenv("COSMOS_OPTIMISTIC_CACHES") == "1"
-}
-
-// getGID returns the current goroutine id (for reentrant lock holder identity). Uses runtime.Stack; for use in reentrant locking only.
-func getGID() int64 {
-	buf := make([]byte, 64)
-	n := runtime.Stack(buf, false)
-	buf = buf[:n]
-	idx := bytes.Index(buf, []byte("goroutine "))
-	if idx < 0 {
-		return 0
-	}
-	buf = buf[idx+len("goroutine "):]
-	idx = bytes.Index(buf, []byte(" "))
-	if idx < 0 {
-		return 0
-	}
-	gid, _ := strconv.ParseInt(string(buf[:idx]), 10, 64)
-	return gid
-}
-
-// lockDraftWrite on the block cache: while any tx is writing to its draft, no one can read from the block cache (draftWriterMu write lock).
-// Reentrant for the same goroutine; released only in PostHandler via releaseDraftWriteLock. No-op when COSMOS_OPTIMISTIC_CACHES != 1.
-func (c *epochGroupCache) lockDraftWrite() {
-	if !cosmosOptimisticCachesEnabled {
-		return
-	}
-	gid := getGID()
-	if atomic.LoadInt64(&c.draftWriteHolder) == gid {
-		atomic.AddInt32(&c.draftWriteCount, 1)
-		return
-	}
-	c.draftWriterMu.Lock()
-	atomic.StoreInt64(&c.draftWriteHolder, gid)
-	atomic.StoreInt32(&c.draftWriteCount, 1)
-}
-
-// It is never called as we are releasing the draft write lock when transaction completes
-// and we do not decrement the draft write count
-// It could be used if we want to unlock the reentrant write lock before the transaction completes
-func (c *epochGroupCache) unlockDraftWrite() {
-	if !cosmosOptimisticCachesEnabled {
-		return
-	}
-	if atomic.AddInt32(&c.draftWriteCount, -1) == 0 {
-		atomic.StoreInt64(&c.draftWriteHolder, 0)
-		c.draftWriterMu.Unlock()
-	}
-}
-
-// releaseDraftWriteLock fully releases the draft write lock (for PostHandler). Call on tx commit or failure.
-func (c *epochGroupCache) releaseDraftWriteLock() {
-	if !cosmosOptimisticCachesEnabled {
-		return
-	}
-	if atomic.LoadInt32(&c.draftWriteCount) > 0 {
-		atomic.StoreInt64(&c.draftWriteHolder, 0)
-		atomic.StoreInt32(&c.draftWriteCount, 0)
-		c.draftWriterMu.Unlock()
-	}
-}
-
-// ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
-type ctxKeyEpochGroupDraft struct{}
-
-// ctxKeyEpochGroupBranchDraft is the context key for a cache-branch-scoped EpochGroupData draft.
-// When set (e.g. via CacheContextWithEpochGroupBranch), reads/writes use this draft instead of the main draft.
-// The branch draft is merged into the parent draft when the branch's writeCache() is called.
-type ctxKeyEpochGroupBranchDraft struct{}
-
-// ctxKeyCommittedStateOnly is set when ctx is for CheckTx or simulate. When set, epoch group uses store for initial reads and a tx-scoped draft for writes (draft never merged to block cache).
-type ctxKeyCommittedStateOnly struct{}
-
-// WithCommittedStateOnly marks ctx so that Get/Set/Remove EpochGroupData use store + tx draft only (no block cache). Call from AnteHandler when IsCheckTx() or simulate.
-func WithCommittedStateOnly(ctx context.Context) context.Context {
-	return context.WithValue(ctx, ctxKeyCommittedStateOnly{}, true)
-}
-
-func isCommittedStateOnly(ctx context.Context) bool {
-	if ctx == nil {
-		return false
-	}
-	v, _ := ctx.Value(ctxKeyCommittedStateOnly{}).(bool)
-	return v
-}
-
-// lazyEpochGroupDraft defers allocation of the real draft until the first write (Set/Remove).
-// This avoids allocating a map for every tx when most txs only read epoch group data.
-type lazyEpochGroupDraft struct {
-	once sync.Once
-	d    *epochGroupDraft
-}
-
-func (l *lazyEpochGroupDraft) get() *epochGroupDraft {
-	return l.d
-}
-
-func (l *lazyEpochGroupDraft) getOrCreate() *epochGroupDraft {
-	l.once.Do(func() {
-		l.d = &epochGroupDraft{
-			m:       make(map[epochGroupCacheKey]types.EpochGroupData),
-			removed: make(map[epochGroupCacheKey]struct{}),
-		}
-	})
-	return l.d
-}
-
-// epochGroupDraft holds tx-scoped EpochGroupData writes for optimistic parallel execution.
-// The block cache's draftWriterMu is held while writing so no one reads uncommitted state; released in PostHandler (commit or failure).
-// removed records keys removed in this tx; deletions are applied to the block cache only on commit so rollback is consistent.
-type epochGroupDraft struct {
-	m       map[epochGroupCacheKey]types.EpochGroupData
-	removed map[epochGroupCacheKey]struct{}
-}
-
-// WithEpochGroupDraft attaches a lazy tx-scoped draft holder to ctx. Call at tx start (e.g. from AnteHandler).
-// The real draft (and its map) is created only on first SetEpochGroupData or RemoveEpochGroupData for current/previous epoch;
-// read-only txs never allocate it and always use the per-block cache (or store).
-func WithEpochGroupDraft(ctx context.Context) context.Context {
-	return context.WithValue(ctx, ctxKeyEpochGroupDraft{}, &lazyEpochGroupDraft{})
-}
-
-// getEpochGroupDraftFromContext returns the draft from ctx if it exists, or nil. Does not create the draft (for reads and for Commit/Release).
-// When ctx has a branch draft (e.g. from CacheContextWithEpochGroupBranch), that is preferred over the main tx draft.
-func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
-	if ctx == nil {
-		return nil
-	}
-	if d := getEpochGroupBranchDraftFromContext(ctx); d != nil {
-		return d
-	}
-	v := ctx.Value(ctxKeyEpochGroupDraft{})
-	if v == nil {
-		return nil
-	}
-	switch h := v.(type) {
-	case *lazyEpochGroupDraft:
-		return h.get()
-	case *epochGroupDraft:
-		return h
-	default:
-		return nil
-	}
-}
-
-// getEpochGroupBranchDraftFromContext returns only the branch draft from ctx (ctxKeyEpochGroupBranchDraft), or nil.
-// Does not create the draft. Used when merging a branch into the parent.
-func getEpochGroupBranchDraftFromContext(ctx context.Context) *epochGroupDraft {
-	if ctx == nil {
-		return nil
-	}
-	v := ctx.Value(ctxKeyEpochGroupBranchDraft{})
-	if v == nil {
-		return nil
-	}
-	switch h := v.(type) {
-	case *lazyEpochGroupDraft:
-		return h.get()
-	case *epochGroupDraft:
-		return h
-	default:
-		return nil
-	}
-}
-
-// getEpochGroupDraftForWriteFromContext returns the draft, creating it from the lazy holder on first write. Use in SetEpochGroupData and RemoveEpochGroupData.
-// When ctx has a branch draft (e.g. from CacheContextWithEpochGroupBranch), that is preferred over the main tx draft.
-func getEpochGroupDraftForWriteFromContext(ctx context.Context) *epochGroupDraft {
-	if ctx == nil {
-		return nil
-	}
-	if v := ctx.Value(ctxKeyEpochGroupBranchDraft{}); v != nil {
-		switch h := v.(type) {
-		case *lazyEpochGroupDraft:
-			return h.getOrCreate()
-		case *epochGroupDraft:
-			return h
-		}
-	}
-	v := ctx.Value(ctxKeyEpochGroupDraft{})
-	if v == nil {
-		return nil
-	}
-	switch h := v.(type) {
-	case *lazyEpochGroupDraft:
-		return h.getOrCreate()
-	case *epochGroupDraft:
-		return h
-	default:
-		return nil
-	}
-}
-
-// CommitEpochGroupDraftFromContext merges the draft from ctx into the block cache. Call from PostHandler on tx success.
-// Applies draft writes and draft removals (tombstones) to the block cache; does not write to store (FlushCurrentEpochGroupCache in EndBlock persists). Releases the block cache draft write lock if held.
-func (k Keeper) CommitEpochGroupDraftFromContext(ctx context.Context) {
-	draft := getEpochGroupDraftFromContext(ctx)
-	if draft == nil {
-		return
-	}
-	snapshot := make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
-	for key, val := range draft.m {
-		snapshot[key] = val
-	}
-	removedSnapshot := make(map[epochGroupCacheKey]struct{}, len(draft.removed))
-	for key := range draft.removed {
-		removedSnapshot[key] = struct{}{}
-	}
-	k.epochGroupCache.releaseDraftWriteLock()
-
-	c := k.epochGroupCache
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for _, epochGroupData := range snapshot {
-		epochIdx := epochGroupData.EpochIndex
-		modelId := epochGroupData.ModelId
-		key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
-		if c.inited && (epochIdx == c.current || epochIdx == c.previous) {
-			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
-			c.m[key] = *cloned
-			c.currentDirty = true
-			continue
-		}
-		// Non-current/previous epoch or cache not inited: write through to store.
-		_ = k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
-	}
-	for key := range removedSnapshot {
-		if c.inited && (key.Epoch == c.current || key.Epoch == c.previous) {
-			delete(c.m, key)
-			c.currentDirty = true
-		}
-	}
-}
-
-// ReleaseEpochGroupDraftFromContext releases the block cache draft write lock if held. Call from PostHandler on tx failure.
-func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
-	k.epochGroupCache.releaseDraftWriteLock()
-}
-
-// mergeEpochGroupBranchDraftIntoParent merges the branch draft (writes and removals) into the parent's draft.
-// Call before writeCache() when using CacheContextWithEpochGroupBranch. Caller holds block cache draft writer lock from branch writes.
-func mergeEpochGroupBranchDraftIntoParent(parentCtx, branchCtx context.Context) {
-	branchDraft := getEpochGroupBranchDraftFromContext(branchCtx)
-	if branchDraft == nil {
-		return
-	}
-	parentDraft := getEpochGroupDraftForWriteFromContext(parentCtx)
-	if parentDraft == nil {
-		return
-	}
-	for key, val := range branchDraft.m {
-		cloned := proto.Clone(&val).(*types.EpochGroupData)
-		parentDraft.m[key] = *cloned
-	}
-	for key := range branchDraft.removed {
-		parentDraft.removed[key] = struct{}{}
-		delete(parentDraft.m, key)
-	}
-}
-
-// CacheContextWithEpochGroupBranch returns a cached context that has its own EpochGroupData draft branch.
-// Use the returned cacheCtx for speculative work; any SetEpochGroupData/RemoveEpochGroupData on cacheCtx
-// go to the branch draft. Call the returned writeCache() on success to merge both the store cache and
-// the branch draft into the parent context. If you do not call writeCache(), both store and draft changes
-// are discarded. Safe to call writeCache() at most once (idempotent).
-func (k Keeper) CacheContextWithEpochGroupBranch(ctx sdk.Context) (sdk.Context, func()) {
-	cacheCtx, writeCache := ctx.CacheContext()
-	branchLazy := &lazyEpochGroupDraft{}
-	cacheCtx = cacheCtx.WithContext(context.WithValue(ctx.Context(), ctxKeyEpochGroupBranchDraft{}, branchLazy))
-	var written bool
-	return cacheCtx, func() {
-		if written {
-			return
-		}
-		written = true
-		mergeEpochGroupBranchDraftIntoParent(ctx.Context(), cacheCtx.Context())
-		writeCache()
-	}
-}
-
-// InvalidateEpochGroupCache clears the epoch group block cache. Call from BeginBlock each block.
-func (k Keeper) InvalidateEpochGroupCache() {
-	c := k.epochGroupCache
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.inited = false
-	c.m = make(map[epochGroupCacheKey]types.EpochGroupData)
-	c.currentEpochRequestCount.Store(0)
-	c.currentDirty = false
-}
-
-// ensureEpochGroupCacheInited lazily inits the block cache (current/previous epoch indices). Caller must hold no cache lock.
-func (k Keeper) ensureEpochGroupCacheInited(ctx context.Context) {
-	c := k.epochGroupCache
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.inited {
-		return
-	}
-	eff, ok := k.GetEffectiveEpochIndex(ctx)
-	if !ok {
-		return
-	}
-	c.current = eff
-	if eff > 0 {
-		c.previous = eff - 1
-	} else {
-		c.previous = 0
-	}
-	c.m = make(map[epochGroupCacheKey]types.EpochGroupData)
-	c.inited = true
-}
-
-// FlushCurrentEpochGroupCache persists cached EpochGroupData for the current epoch to the store. Call from EndBlock.
-// Merges currentEpochRequestCount into the current epoch root group's NumberOfRequests before persisting.
-func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
-	c := k.epochGroupCache
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.inited {
-		return
-	}
-	delta := c.currentEpochRequestCount.Swap(0)
-	if !c.currentDirty {
-		return
-	}
-
-	// We persist here if have changes in cache or have increments in currentEpochRequestCount
-	rootKey := epochGroupCacheKey{Epoch: c.current, ModelId: ""}
-	if val, inCache := c.m[rootKey]; inCache {
-		val.NumberOfRequests += delta
-		_ = k.EpochGroupDataMap.Set(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId), val)
-	} else if delta != 0 {
-		val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId))
-		if err == nil {
-			val.NumberOfRequests += delta
-			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId), val)
-		}
-	}
-
-	// We persist here all other cached EpochGroupData for the current epoch
-	for key, val := range c.m {
-		if key.Epoch == c.current && key != rootKey {
-			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(key.Epoch, key.ModelId), val)
-		}
-	}
-	c.currentDirty = false
-}
-
-// IncrementCurrentEpochGroupRequestCount increments the per-block atomic counter for the current epoch's NumberOfRequests. Committed to store in EndBlock.
-func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) int64 {
-	if isCommittedStateOnly(ctx) {
-		return 0
-	}
-	c := k.epochGroupCache
-	k.ensureEpochGroupCacheInited(ctx)
-	c.mu.Lock()
-	inited := c.inited
-	c.mu.Unlock()
-	if !inited {
-		return 0
-	}
-	count := c.currentEpochRequestCount.Add(1)
-	c.currentDirty = true
-	return count
-}
-
-// SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).
-// Draft is created lazily on first write so read-only txs do not allocate it.
+// SetEpochGroupData writes EpochGroupData through the optimistic store.
 func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
-	if isCommittedStateOnly(ctx) {
-		draft := getEpochGroupDraftForWriteFromContext(ctx)
-		if draft != nil {
-			key := epochGroupCacheKey{Epoch: epochGroupData.EpochIndex, ModelId: epochGroupData.ModelId}
-			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
-			draft.m[key] = *cloned
-		}
-		return
-	}
-	epochIdx := epochGroupData.EpochIndex
-	modelId := epochGroupData.ModelId
-	key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
-	draft := getEpochGroupDraftForWriteFromContext(ctx)
-
-	if draft != nil {
-		k.ensureEpochGroupCacheInited(ctx)
-		c := k.epochGroupCache
-		c.mu.RLock()
-		inited, current, previous := c.inited, c.current, c.previous
-		c.mu.RUnlock()
-		if inited && (epochIdx == current || epochIdx == previous) {
-			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
-			c.lockDraftWrite() // blocks block cache reads until PostHandler commit/release
-			draft.m[key] = *cloned
-			return
-		}
-		// Non-current: write through to store
-		k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
-		return
-	}
-
-	// No draft: update block cache or write through to store
-	c := k.epochGroupCache
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.inited || (epochIdx != c.current && epochIdx != c.previous) {
-		k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
-		return
-	}
-	cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
-	c.m[key] = *cloned
-	c.currentDirty = true
+	key := epochGroupCacheKey{Epoch: epochGroupData.EpochIndex, ModelId: epochGroupData.ModelId}
+	k.epochGroupStore.Set(ctx, key, epochGroupData)
 }
 
-// GetEpochGroupData returns EpochGroupData by epoch and model. Uses tx draft first (if present), then block cache for current/previous epoch, then store.
+// GetEpochGroupData reads EpochGroupData through the optimistic store.
 func (k Keeper) GetEpochGroupData(
 	ctx context.Context,
 	epochIndex uint64,
 	modelId string,
 ) (val types.EpochGroupData, found bool) {
-	if isCommittedStateOnly(ctx) {
-		key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
-		if draft := getEpochGroupDraftFromContext(ctx); draft != nil {
-			if _, removed := draft.removed[key]; removed {
-				return types.EpochGroupData{}, false
-			}
-			if cached, ok := draft.m[key]; ok {
-				cloned := proto.Clone(&cached).(*types.EpochGroupData)
-				return *cloned, true
-			}
-		}
-		val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
-		if err != nil {
-			return val, false
-		}
-		return val, true
-	}
-	k.ensureEpochGroupCacheInited(ctx)
-	c := k.epochGroupCache
 	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
-
-	draft := getEpochGroupDraftFromContext(ctx)
-	if draft != nil {
-		c.mu.RLock()
-		inited, current, previous := c.inited, c.current, c.previous
-		c.mu.RUnlock()
-		if inited && (epochIndex == current || epochIndex == previous) {
-			if _, removed := draft.removed[key]; removed {
-				return types.EpochGroupData{}, false
-			}
-			if cached, ok := draft.m[key]; ok {
-				cloned := proto.Clone(&cached).(*types.EpochGroupData)
-				return *cloned, true
-			}
-		}
-	}
-
-	c.draftWriterMu.RLock()
-	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
-		if cached, ok := c.m[key]; ok {
-			c.draftWriterMu.RUnlock()
-			cloned := proto.Clone(&cached).(*types.EpochGroupData)
-			return *cloned, true
-		}
-	}
-	c.draftWriterMu.RUnlock()
-
-	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
-	if err != nil {
-		return val, false
-	}
-	c.mu.Lock()
-	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
-		cloned := proto.Clone(&val).(*types.EpochGroupData)
-		c.m[key] = *cloned
-	}
-	c.mu.Unlock()
-	return val, true
+	return k.epochGroupStore.Get(ctx, key)
 }
 
-// RemoveEpochGroupData removes EpochGroupData from store and from block cache / tx draft when applicable.
-// Draft is created only when removing a current/previous-epoch key (same lazy rule as SetEpochGroupData).
+// RemoveEpochGroupData removes EpochGroupData through the optimistic store.
 func (k Keeper) RemoveEpochGroupData(
 	ctx context.Context,
 	epochIndex uint64,
 	modelId string,
 ) {
-	if isCommittedStateOnly(ctx) {
-		key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
-		if draft := getEpochGroupDraftForWriteFromContext(ctx); draft != nil {
-			draft.removed[key] = struct{}{}
-			delete(draft.m, key)
-		}
-		return
-	}
-	k.EpochGroupDataMap.Remove(ctx, collections.Join(epochIndex, modelId))
 	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
-	k.ensureEpochGroupCacheInited(ctx)
-	c := k.epochGroupCache
-	c.mu.RLock()
-	needDraft := c.inited && (epochIndex == c.current || epochIndex == c.previous)
-	c.mu.RUnlock()
-	if needDraft {
-		if draft := getEpochGroupDraftForWriteFromContext(ctx); draft != nil {
-			c.lockDraftWrite()
-			draft.removed[key] = struct{}{}
-			delete(draft.m, key)
-		}
-		return
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
-		delete(c.m, key)
-	}
+	k.epochGroupStore.Remove(ctx, key)
 }
 
-// GetAllEpochGroupData returns all EpochGroupData from the store.
+// CommitEpochGroupDraftFromContext merges the tx draft into the block cache.
+// Call from PostHandler on tx success.
+func (k Keeper) CommitEpochGroupDraftFromContext(ctx context.Context) {
+	k.epochGroupStore.CommitDraft(ctx)
+}
+
+// ReleaseEpochGroupDraftFromContext discards the tx draft. Call from PostHandler on tx failure.
+func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
+	k.epochGroupStore.ReleaseDraft(ctx)
+}
+
+// InvalidateEpochGroupCache clears the block cache and conflict tracker. Call from BeginBlock.
+func (k Keeper) InvalidateEpochGroupCache() {
+	k.epochGroupStore.Invalidate()
+}
+
+// FlushCurrentEpochGroupCache persists block-cache entries to the store. Call from EndBlock.
+func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
+	k.epochGroupStore.Flush(ctx)
+}
+
+// RegisterEpochGroupTx registers a tx for OCC tracking.
+func (k Keeper) RegisterEpochGroupTx(ctx context.Context) {
+	k.epochGroupStore.RegisterTx(ctx)
+}
+
+// DetectEpochGroupConflicts returns txIDs involved in read-write or write-write collisions.
+func (k Keeper) DetectEpochGroupConflicts() (conflictedReads, conflictedWrites []uintptr) {
+	return k.epochGroupStore.DetectConflicts()
+}
+
+// ResetEpochGroupConflictTracker clears all tracked read/write sets.
+func (k Keeper) ResetEpochGroupConflictTracker() {
+	k.epochGroupStore.ResetConflictTracker()
+}
+
+// CacheContextWithBranch returns a cached context with branch drafts for ALL optimistic stores.
+// Call writeCache() on success to merge both the SDK store cache and all branch drafts.
+func (k Keeper) CacheContext(ctx sdk.Context) (sdk.Context, func()) {
+	return k.storeGroup.CacheContext(ctx)
+}
+
+// GetAllEpochGroupData returns all EpochGroupData, preferring block-cache
+// contents when available, otherwise falling back to the underlying collection.
 func (k Keeper) GetAllEpochGroupData(ctx context.Context) (list []types.EpochGroupData) {
-	iter, err := k.EpochGroupDataMap.Iterate(ctx, nil)
+	if vals := k.epochGroupStore.BlockCacheValues(); len(vals) > 0 {
+		return vals
+	}
+	iter, err := k.epochGroupStore.Map.Iterate(ctx, nil)
 	if err != nil {
 		return nil
 	}
@@ -547,4 +93,10 @@ func (k Keeper) GetAllEpochGroupData(ctx context.Context) (list []types.EpochGro
 		return nil
 	}
 	return epochGroupDataList
+}
+
+// EpochGroupStore returns the underlying optimistic store for EpochGroupData.
+// Used by the AnteHandler to wire drafts.
+func (k Keeper) EpochGroupStore() *OptimisticCollMap[epochGroupCacheKey, collections.Pair[uint64, string], types.EpochGroupData] {
+	return k.epochGroupStore
 }

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -11,6 +11,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"github.com/cosmos/gogoproto/proto"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -41,6 +42,11 @@ func getGID() int64 {
 
 // ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
 type ctxKeyEpochGroupDraft struct{}
+
+// ctxKeyEpochGroupBranchDraft is the context key for a cache-branch-scoped EpochGroupData draft.
+// When set (e.g. via CacheContextWithEpochGroupBranch), reads/writes use this draft instead of the main draft.
+// The branch draft is merged into the parent draft when the branch's writeCache() is called.
+type ctxKeyEpochGroupBranchDraft struct{}
 
 // lazyEpochGroupDraft defers allocation of the real draft until the first write (Set/Remove).
 // This avoids allocating a map for every tx when most txs only read epoch group data.
@@ -117,9 +123,13 @@ func WithEpochGroupDraft(ctx context.Context) context.Context {
 }
 
 // getEpochGroupDraftFromContext returns the draft from ctx if it exists, or nil. Does not create the draft (for reads and for Commit/Release).
+// When ctx has a branch draft (e.g. from CacheContextWithEpochGroupBranch), that is preferred over the main tx draft.
 func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
 	if ctx == nil {
 		return nil
+	}
+	if d := getEpochGroupBranchDraftFromContext(ctx); d != nil {
+		return d
 	}
 	v := ctx.Value(ctxKeyEpochGroupDraft{})
 	if v == nil {
@@ -135,10 +145,39 @@ func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
 	}
 }
 
+// getEpochGroupBranchDraftFromContext returns only the branch draft from ctx (ctxKeyEpochGroupBranchDraft), or nil.
+// Does not create the draft. Used when merging a branch into the parent.
+func getEpochGroupBranchDraftFromContext(ctx context.Context) *epochGroupDraft {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(ctxKeyEpochGroupBranchDraft{})
+	if v == nil {
+		return nil
+	}
+	switch h := v.(type) {
+	case *lazyEpochGroupDraft:
+		return h.get()
+	case *epochGroupDraft:
+		return h
+	default:
+		return nil
+	}
+}
+
 // getEpochGroupDraftForWriteFromContext returns the draft, creating it from the lazy holder on first write. Use in SetEpochGroupData and RemoveEpochGroupData.
+// When ctx has a branch draft (e.g. from CacheContextWithEpochGroupBranch), that is preferred over the main tx draft.
 func getEpochGroupDraftForWriteFromContext(ctx context.Context) *epochGroupDraft {
 	if ctx == nil {
 		return nil
+	}
+	if v := ctx.Value(ctxKeyEpochGroupBranchDraft{}); v != nil {
+		switch h := v.(type) {
+		case *lazyEpochGroupDraft:
+			return h.getOrCreate()
+		case *epochGroupDraft:
+			return h
+		}
 	}
 	v := ctx.Value(ctxKeyEpochGroupDraft{})
 	if v == nil {
@@ -203,6 +242,61 @@ func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
 		return
 	}
 	draft.releaseWriteLock()
+}
+
+// mergeEpochGroupBranchDraftIntoParent snapshots the branch draft from branchCtx, releases its write lock,
+// and merges all entries into the parent's draft (from parentCtx). Call before writeCache() when using
+// CacheContextWithEpochGroupBranch so that branch draft writes are visible to the rest of the tx.
+func mergeEpochGroupBranchDraftIntoParent(parentCtx, branchCtx context.Context) {
+	branchDraft := getEpochGroupBranchDraftFromContext(branchCtx)
+	if branchDraft == nil {
+		return
+	}
+	var snapshot map[epochGroupCacheKey]types.EpochGroupData
+	if branchDraft.isWriteLocked() {
+		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(branchDraft.m))
+		for key, val := range branchDraft.m {
+			snapshot[key] = val
+		}
+		branchDraft.releaseWriteLock()
+	} else {
+		branchDraft.mu.RLock()
+		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(branchDraft.m))
+		for key, val := range branchDraft.m {
+			snapshot[key] = val
+		}
+		branchDraft.mu.RUnlock()
+	}
+	parentDraft := getEpochGroupDraftForWriteFromContext(parentCtx)
+	if parentDraft == nil {
+		return
+	}
+	parentDraft.lockWrite()
+	defer parentDraft.unlockWrite()
+	for key, val := range snapshot {
+		cloned := proto.Clone(&val).(*types.EpochGroupData)
+		parentDraft.m[key] = *cloned
+	}
+}
+
+// CacheContextWithEpochGroupBranch returns a cached context that has its own EpochGroupData draft branch.
+// Use the returned cacheCtx for speculative work; any SetEpochGroupData/RemoveEpochGroupData on cacheCtx
+// go to the branch draft. Call the returned writeCache() on success to merge both the store cache and
+// the branch draft into the parent context. If you do not call writeCache(), both store and draft changes
+// are discarded. Safe to call writeCache() at most once (idempotent).
+func (k Keeper) CacheContextWithEpochGroupBranch(ctx sdk.Context) (sdk.Context, func()) {
+	cacheCtx, writeCache := ctx.CacheContext()
+	branchLazy := &lazyEpochGroupDraft{}
+	cacheCtx = cacheCtx.WithContext(context.WithValue(ctx.Context(), ctxKeyEpochGroupBranchDraft{}, branchLazy))
+	var written bool
+	return cacheCtx, func() {
+		if written {
+			return
+		}
+		written = true
+		mergeEpochGroupBranchDraftIntoParent(ctx.Context(), cacheCtx.Context())
+		writeCache()
+	}
 }
 
 // InvalidateEpochGroupCache clears the epoch group block cache. Call from BeginBlock each block.

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 
 	"cosmossdk.io/collections"
-	"github.com/cosmos/gogoproto/proto"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -40,6 +40,39 @@ func getGID() int64 {
 	return gid
 }
 
+// lockDraftWrite on the block cache: while any tx is writing to its draft, no one can read from the block cache (draftWriterMu write lock).
+// Reentrant for the same goroutine; released only in PostHandler via releaseDraftWriteLock. No-op when COSMOS_OPTIMISTIC_CACHES != 1.
+func (c *epochGroupCache) lockDraftWrite() {
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
+	gid := getGID()
+	if atomic.LoadInt64(&c.draftWriteHolder) == gid {
+		atomic.AddInt32(&c.draftWriteCount, 1)
+		return
+	}
+	c.draftWriterMu.Lock()
+	atomic.StoreInt64(&c.draftWriteHolder, gid)
+	atomic.StoreInt32(&c.draftWriteCount, 1)
+}
+
+func (c *epochGroupCache) unlockDraftWrite() {
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
+	if atomic.AddInt32(&c.draftWriteCount, -1) == 0 {
+		atomic.StoreInt64(&c.draftWriteHolder, 0)
+		c.draftWriterMu.Unlock()
+	}
+}
+
+// releaseDraftWriteLock fully releases the draft write lock (for PostHandler). Call on tx commit or failure.
+func (c *epochGroupCache) releaseDraftWriteLock() {
+	for atomic.LoadInt32(&c.draftWriteCount) > 0 {
+		c.unlockDraftWrite()
+	}
+}
+
 // ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
 type ctxKeyEpochGroupDraft struct{}
 
@@ -47,6 +80,22 @@ type ctxKeyEpochGroupDraft struct{}
 // When set (e.g. via CacheContextWithEpochGroupBranch), reads/writes use this draft instead of the main draft.
 // The branch draft is merged into the parent draft when the branch's writeCache() is called.
 type ctxKeyEpochGroupBranchDraft struct{}
+
+// ctxKeyCommittedStateOnly is set when ctx is for CheckTx or simulate. When set, epoch group uses store for initial reads and a tx-scoped draft for writes (draft never merged to block cache).
+type ctxKeyCommittedStateOnly struct{}
+
+// WithCommittedStateOnly marks ctx so that Get/Set/Remove EpochGroupData use store + tx draft only (no block cache). Call from AnteHandler when IsCheckTx() or simulate.
+func WithCommittedStateOnly(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeyCommittedStateOnly{}, true)
+}
+
+func isCommittedStateOnly(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(ctxKeyCommittedStateOnly{}).(bool)
+	return v
+}
 
 // lazyEpochGroupDraft defers allocation of the real draft until the first write (Set/Remove).
 // This avoids allocating a map for every tx when most txs only read epoch group data.
@@ -61,58 +110,20 @@ func (l *lazyEpochGroupDraft) get() *epochGroupDraft {
 
 func (l *lazyEpochGroupDraft) getOrCreate() *epochGroupDraft {
 	l.once.Do(func() {
-		l.d = &epochGroupDraft{m: make(map[epochGroupCacheKey]types.EpochGroupData)}
+		l.d = &epochGroupDraft{
+			m:       make(map[epochGroupCacheKey]types.EpochGroupData),
+			removed: make(map[epochGroupCacheKey]struct{}),
+		}
 	})
 	return l.d
 }
 
 // epochGroupDraft holds tx-scoped EpochGroupData writes for optimistic parallel execution.
-// Uses a reentrant write lock: the same goroutine can write (or delete) multiple times; lock is released only in PostHandler (commit or failure).
+// The block cache's draftWriterMu is held while writing so no one reads uncommitted state; released in PostHandler (commit or failure).
+// removed records keys removed in this tx; deletions are applied to the block cache only on commit so rollback is consistent.
 type epochGroupDraft struct {
-	mu          sync.RWMutex
-	m           map[epochGroupCacheKey]types.EpochGroupData
-	writeHolder int64 // goroutine id of the writer (for reentrancy)
-	writeCount  int32 // number of Lock() calls not yet Unlock()ed by the holder
-}
-
-// lockWrite acquires the write lock; reentrant for the same goroutine (increments count). Release via unlockWrite or releaseWriteLock.
-// Only takes the lock when COSMOS_OPTIMISTIC_CACHES=1; otherwise no-op.
-func (d *epochGroupDraft) lockWrite() {
-	if !cosmosOptimisticCachesEnabled {
-		return
-	}
-	gid := getGID()
-	if atomic.LoadInt64(&d.writeHolder) == gid {
-		atomic.AddInt32(&d.writeCount, 1)
-		return
-	}
-	d.mu.Lock()
-	atomic.StoreInt64(&d.writeHolder, gid)
-	atomic.StoreInt32(&d.writeCount, 1)
-}
-
-// unlockWrite releases one level of the write lock; if count goes to 0, releases the underlying RWMutex.
-// No-op when COSMOS_OPTIMISTIC_CACHES is not 1.
-func (d *epochGroupDraft) unlockWrite() {
-	if !cosmosOptimisticCachesEnabled {
-		return
-	}
-	if atomic.AddInt32(&d.writeCount, -1) == 0 {
-		atomic.StoreInt64(&d.writeHolder, 0)
-		d.mu.Unlock()
-	}
-}
-
-// isWriteLocked returns true if any goroutine holds the write lock (for readers: if true and we are the holder we can read without RLock).
-func (d *epochGroupDraft) isWriteLocked() bool {
-	return atomic.LoadInt32(&d.writeCount) > 0
-}
-
-// releaseWriteLock fully releases the write lock (for PostHandler: unlock until count is 0).
-func (d *epochGroupDraft) releaseWriteLock() {
-	for atomic.LoadInt32(&d.writeCount) > 0 {
-		d.unlockWrite()
-	}
+	m       map[epochGroupCacheKey]types.EpochGroupData
+	removed map[epochGroupCacheKey]struct{}
 }
 
 // WithEpochGroupDraft attaches a lazy tx-scoped draft holder to ctx. Call at tx start (e.g. from AnteHandler).
@@ -194,28 +205,21 @@ func getEpochGroupDraftForWriteFromContext(ctx context.Context) *epochGroupDraft
 }
 
 // CommitEpochGroupDraftFromContext merges the draft from ctx into the block cache. Call from PostHandler on tx success.
-// Does not write to store; FlushCurrentEpochGroupCache in EndBlock persists. Releases the draft write lock if held.
+// Applies draft writes and draft removals (tombstones) to the block cache; does not write to store (FlushCurrentEpochGroupCache in EndBlock persists). Releases the block cache draft write lock if held.
 func (k Keeper) CommitEpochGroupDraftFromContext(ctx context.Context) {
 	draft := getEpochGroupDraftFromContext(ctx)
 	if draft == nil {
 		return
 	}
-	var snapshot map[epochGroupCacheKey]types.EpochGroupData
-	if draft.isWriteLocked() {
-		// This tx holds the write lock (same goroutine as PostHandler); read directly then release.
-		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
-		for key, val := range draft.m {
-			snapshot[key] = val
-		}
-		draft.releaseWriteLock()
-	} else {
-		draft.mu.RLock()
-		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
-		for key, val := range draft.m {
-			snapshot[key] = val
-		}
-		draft.mu.RUnlock()
+	snapshot := make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
+	for key, val := range draft.m {
+		snapshot[key] = val
 	}
+	removedSnapshot := make(map[epochGroupCacheKey]struct{}, len(draft.removed))
+	for key := range draft.removed {
+		removedSnapshot[key] = struct{}{}
+	}
+	k.epochGroupCache.releaseDraftWriteLock()
 
 	c := k.epochGroupCache
 	c.mu.Lock()
@@ -230,52 +234,40 @@ func (k Keeper) CommitEpochGroupDraftFromContext(ctx context.Context) {
 			c.currentDirty = true
 			continue
 		}
-		// Non-current epoch or cache not inited: write through to store.
+		// Non-current/previous epoch or cache not inited: write through to store.
 		_ = k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
 	}
-}
-
-// ReleaseEpochGroupDraftFromContext releases the draft write lock if held. Call from PostHandler on tx failure so the lock is released when the tx does not commit.
-func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
-	draft := getEpochGroupDraftFromContext(ctx)
-	if draft == nil || !draft.isWriteLocked() {
-		return
+	for key := range removedSnapshot {
+		if c.inited && (key.Epoch == c.current || key.Epoch == c.previous) {
+			delete(c.m, key)
+			c.currentDirty = true
+		}
 	}
-	draft.releaseWriteLock()
 }
 
-// mergeEpochGroupBranchDraftIntoParent snapshots the branch draft from branchCtx, releases its write lock,
-// and merges all entries into the parent's draft (from parentCtx). Call before writeCache() when using
-// CacheContextWithEpochGroupBranch so that branch draft writes are visible to the rest of the tx.
+// ReleaseEpochGroupDraftFromContext releases the block cache draft write lock if held. Call from PostHandler on tx failure.
+func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
+	k.epochGroupCache.releaseDraftWriteLock()
+}
+
+// mergeEpochGroupBranchDraftIntoParent merges the branch draft (writes and removals) into the parent's draft.
+// Call before writeCache() when using CacheContextWithEpochGroupBranch. Caller holds block cache draft writer lock from branch writes.
 func mergeEpochGroupBranchDraftIntoParent(parentCtx, branchCtx context.Context) {
 	branchDraft := getEpochGroupBranchDraftFromContext(branchCtx)
 	if branchDraft == nil {
 		return
 	}
-	var snapshot map[epochGroupCacheKey]types.EpochGroupData
-	if branchDraft.isWriteLocked() {
-		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(branchDraft.m))
-		for key, val := range branchDraft.m {
-			snapshot[key] = val
-		}
-		branchDraft.releaseWriteLock()
-	} else {
-		branchDraft.mu.RLock()
-		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(branchDraft.m))
-		for key, val := range branchDraft.m {
-			snapshot[key] = val
-		}
-		branchDraft.mu.RUnlock()
-	}
 	parentDraft := getEpochGroupDraftForWriteFromContext(parentCtx)
 	if parentDraft == nil {
 		return
 	}
-	parentDraft.lockWrite()
-	defer parentDraft.unlockWrite()
-	for key, val := range snapshot {
+	for key, val := range branchDraft.m {
 		cloned := proto.Clone(&val).(*types.EpochGroupData)
 		parentDraft.m[key] = *cloned
+	}
+	for key := range branchDraft.removed {
+		parentDraft.removed[key] = struct{}{}
+		delete(parentDraft.m, key)
 	}
 }
 
@@ -370,11 +362,15 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 
 // IncrementCurrentEpochGroupRequestCount increments the per-block atomic counter for the current epoch's NumberOfRequests. Committed to store in EndBlock.
 func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) int64 {
+	if isCommittedStateOnly(ctx) {
+		return 0
+	}
 	c := k.epochGroupCache
 	k.ensureEpochGroupCacheInited(ctx)
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.inited {
+	inited := c.inited
+	c.mu.Unlock()
+	if !inited {
 		return 0
 	}
 	count := c.currentEpochRequestCount.Add(1)
@@ -385,6 +381,15 @@ func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) int6
 // SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).
 // Draft is created lazily on first write so read-only txs do not allocate it.
 func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
+	if isCommittedStateOnly(ctx) {
+		draft := getEpochGroupDraftForWriteFromContext(ctx)
+		if draft != nil {
+			key := epochGroupCacheKey{Epoch: epochGroupData.EpochIndex, ModelId: epochGroupData.ModelId}
+			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
+			draft.m[key] = *cloned
+		}
+		return
+	}
 	epochIdx := epochGroupData.EpochIndex
 	modelId := epochGroupData.ModelId
 	key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
@@ -398,12 +403,11 @@ func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.Epoc
 		c.mu.RUnlock()
 		if inited && (epochIdx == current || epochIdx == previous) {
 			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
-			draft.lockWrite() // reentrant: same goroutine can write multiple times
+			c.lockDraftWrite() // blocks block cache reads until PostHandler commit/release
 			draft.m[key] = *cloned
-			// Do not unlock here; lock is released in PostHandler (commit or failure)
 			return
 		}
-		// Non-current/previous: write through to store
+		// Non-current: write through to store
 		k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
 		return
 	}
@@ -427,6 +431,23 @@ func (k Keeper) GetEpochGroupData(
 	epochIndex uint64,
 	modelId string,
 ) (val types.EpochGroupData, found bool) {
+	if isCommittedStateOnly(ctx) {
+		key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
+		if draft := getEpochGroupDraftFromContext(ctx); draft != nil {
+			if _, removed := draft.removed[key]; removed {
+				return types.EpochGroupData{}, false
+			}
+			if cached, ok := draft.m[key]; ok {
+				cloned := proto.Clone(&cached).(*types.EpochGroupData)
+				return *cloned, true
+			}
+		}
+		val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
+		if err != nil {
+			return val, false
+		}
+		return val, true
+	}
 	k.ensureEpochGroupCacheInited(ctx)
 	c := k.epochGroupCache
 	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
@@ -437,31 +458,28 @@ func (k Keeper) GetEpochGroupData(
 		inited, current, previous := c.inited, c.current, c.previous
 		c.mu.RUnlock()
 		if inited && (epochIndex == current || epochIndex == previous) {
-			var cached types.EpochGroupData
-			var ok bool
-			if draft.isWriteLocked() && atomic.LoadInt64(&draft.writeHolder) == getGID() {
-				cached, ok = draft.m[key]
-			} else {
-				draft.mu.RLock()
-				cached, ok = draft.m[key]
-				draft.mu.RUnlock()
+			if _, removed := draft.removed[key]; removed {
+				return types.EpochGroupData{}, false
 			}
-			if ok {
+			if cached, ok := draft.m[key]; ok {
 				cloned := proto.Clone(&cached).(*types.EpochGroupData)
 				return *cloned, true
 			}
 		}
 	}
 
+	c.draftWriterMu.RLock()
 	c.mu.RLock()
 	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
 		if cached, ok := c.m[key]; ok {
 			c.mu.RUnlock()
+			c.draftWriterMu.RUnlock()
 			cloned := proto.Clone(&cached).(*types.EpochGroupData)
 			return *cloned, true
 		}
 	}
 	c.mu.RUnlock()
+	c.draftWriterMu.RUnlock()
 
 	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
 	if err != nil {
@@ -483,6 +501,14 @@ func (k Keeper) RemoveEpochGroupData(
 	epochIndex uint64,
 	modelId string,
 ) {
+	if isCommittedStateOnly(ctx) {
+		key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
+		if draft := getEpochGroupDraftForWriteFromContext(ctx); draft != nil {
+			draft.removed[key] = struct{}{}
+			delete(draft.m, key)
+		}
+		return
+	}
 	k.EpochGroupDataMap.Remove(ctx, collections.Join(epochIndex, modelId))
 	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
 	k.ensureEpochGroupCacheInited(ctx)
@@ -492,10 +518,11 @@ func (k Keeper) RemoveEpochGroupData(
 	c.mu.RUnlock()
 	if needDraft {
 		if draft := getEpochGroupDraftForWriteFromContext(ctx); draft != nil {
-			draft.lockWrite()
+			c.lockDraftWrite()
+			draft.removed[key] = struct{}{}
 			delete(draft.m, key)
-			// Do not unlock here; released in PostHandler
 		}
+		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -39,8 +39,8 @@ type ctxKeyEpochGroupDraft struct{}
 type epochGroupDraft struct {
 	mu          sync.RWMutex
 	m           map[epochGroupCacheKey]types.EpochGroupData
-	writeHolder int64  // goroutine id of the writer (for reentrancy)
-	writeCount  int32  // number of Lock() calls not yet Unlock()ed by the holder
+	writeHolder int64 // goroutine id of the writer (for reentrancy)
+	writeCount  int32 // number of Lock() calls not yet Unlock()ed by the holder
 }
 
 // lockWrite acquires the write lock; reentrant for the same goroutine (increments count). Release via unlockWrite or releaseWriteLock.
@@ -188,6 +188,11 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 		return
 	}
 	delta := c.currentEpochRequestCount.Swap(0)
+	if !c.currentDirty && delta == 0 {
+		return
+	}
+
+	// We persist here if have changes in cache or have increments in currentEpochRequestCount
 	rootKey := epochGroupCacheKey{Epoch: c.current, ModelId: ""}
 	if val, inCache := c.m[rootKey]; inCache {
 		val.NumberOfRequests += delta
@@ -199,6 +204,8 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId), val)
 		}
 	}
+
+	// We persist here all other cached EpochGroupData for the current epoch
 	for key, val := range c.m {
 		if key.Epoch == c.current && key != rootKey {
 			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(key.Epoch, key.ModelId), val)

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -1,41 +1,340 @@
 package keeper
 
 import (
+	"bytes"
 	"context"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"cosmossdk.io/collections"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/productscience/inference/x/inference/types"
 )
 
-// SetEpochGroupData set a specific epochGroupData in the store from its index
-func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
-	k.EpochGroupDataMap.Set(ctx, collections.Join(epochGroupData.EpochIndex, epochGroupData.ModelId), epochGroupData)
+// getGID returns the current goroutine id (for reentrant lock holder identity). Uses runtime.Stack; for use in reentrant locking only.
+func getGID() int64 {
+	buf := make([]byte, 64)
+	n := runtime.Stack(buf, false)
+	buf = buf[:n]
+	idx := bytes.Index(buf, []byte("goroutine "))
+	if idx < 0 {
+		return 0
+	}
+	buf = buf[idx+len("goroutine "):]
+	idx = bytes.Index(buf, []byte(" "))
+	if idx < 0 {
+		return 0
+	}
+	gid, _ := strconv.ParseInt(string(buf[:idx]), 10, 64)
+	return gid
 }
 
-// GetEpochGroupData returns a epochGroupData from its index
+// ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
+type ctxKeyEpochGroupDraft struct{}
+
+// epochGroupDraft holds tx-scoped EpochGroupData writes for optimistic parallel execution.
+// Uses a reentrant write lock: the same goroutine can write (or delete) multiple times; lock is released only in PostHandler (commit or failure).
+type epochGroupDraft struct {
+	mu          sync.RWMutex
+	m           map[epochGroupCacheKey]types.EpochGroupData
+	writeHolder int64  // goroutine id of the writer (for reentrancy)
+	writeCount  int32  // number of Lock() calls not yet Unlock()ed by the holder
+}
+
+// lockWrite acquires the write lock; reentrant for the same goroutine (increments count). Release via unlockWrite or releaseWriteLock.
+func (d *epochGroupDraft) lockWrite() {
+	gid := getGID()
+	if atomic.LoadInt64(&d.writeHolder) == gid {
+		atomic.AddInt32(&d.writeCount, 1)
+		return
+	}
+	d.mu.Lock()
+	atomic.StoreInt64(&d.writeHolder, gid)
+	atomic.StoreInt32(&d.writeCount, 1)
+}
+
+// unlockWrite releases one level of the write lock; if count goes to 0, releases the underlying RWMutex.
+func (d *epochGroupDraft) unlockWrite() {
+	if atomic.AddInt32(&d.writeCount, -1) == 0 {
+		atomic.StoreInt64(&d.writeHolder, 0)
+		d.mu.Unlock()
+	}
+}
+
+// isWriteLocked returns true if any goroutine holds the write lock (for readers: if true and we are the holder we can read without RLock).
+func (d *epochGroupDraft) isWriteLocked() bool {
+	return atomic.LoadInt32(&d.writeCount) > 0
+}
+
+// releaseWriteLock fully releases the write lock (for PostHandler: unlock until count is 0).
+func (d *epochGroupDraft) releaseWriteLock() {
+	for atomic.LoadInt32(&d.writeCount) > 0 {
+		d.unlockWrite()
+	}
+}
+
+// WithEpochGroupDraft attaches a new tx-scoped draft to ctx. Call at tx start (e.g. from AnteHandler).
+func WithEpochGroupDraft(ctx context.Context) context.Context {
+	d := &epochGroupDraft{m: make(map[epochGroupCacheKey]types.EpochGroupData)}
+	return context.WithValue(ctx, ctxKeyEpochGroupDraft{}, d)
+}
+
+// getEpochGroupDraftFromContext returns the draft from ctx, or nil if no draft is bound.
+func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(ctxKeyEpochGroupDraft{})
+	if v == nil {
+		return nil
+	}
+	d, _ := v.(*epochGroupDraft)
+	return d
+}
+
+// CommitEpochGroupDraftFromContext merges the draft from ctx into the block cache. Call from PostHandler on tx success.
+// Does not write to store; FlushCurrentEpochGroupCache in EndBlock persists. Releases the draft write lock if held.
+func (k Keeper) CommitEpochGroupDraftFromContext(ctx context.Context) {
+	draft := getEpochGroupDraftFromContext(ctx)
+	if draft == nil {
+		return
+	}
+	var snapshot map[epochGroupCacheKey]types.EpochGroupData
+	if draft.isWriteLocked() {
+		// This tx holds the write lock (same goroutine as PostHandler); read directly then release.
+		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
+		for key, val := range draft.m {
+			snapshot[key] = val
+		}
+		draft.releaseWriteLock()
+	} else {
+		draft.mu.RLock()
+		snapshot = make(map[epochGroupCacheKey]types.EpochGroupData, len(draft.m))
+		for key, val := range draft.m {
+			snapshot[key] = val
+		}
+		draft.mu.RUnlock()
+	}
+
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, epochGroupData := range snapshot {
+		epochIdx := epochGroupData.EpochIndex
+		modelId := epochGroupData.ModelId
+		key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
+		if c.inited && (epochIdx == c.current || epochIdx == c.previous) {
+			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
+			c.m[key] = *cloned
+			c.currentDirty = true
+			continue
+		}
+		// Non-current epoch or cache not inited: write through to store.
+		_ = k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
+	}
+}
+
+// ReleaseEpochGroupDraftFromContext releases the draft write lock if held. Call from PostHandler on tx failure so the lock is released when the tx does not commit.
+func (k Keeper) ReleaseEpochGroupDraftFromContext(ctx context.Context) {
+	draft := getEpochGroupDraftFromContext(ctx)
+	if draft == nil || !draft.isWriteLocked() {
+		return
+	}
+	draft.releaseWriteLock()
+}
+
+// InvalidateEpochGroupCache clears the epoch group block cache. Call from BeginBlock each block.
+func (k Keeper) InvalidateEpochGroupCache() {
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inited = false
+	c.m = make(map[epochGroupCacheKey]types.EpochGroupData)
+	c.currentEpochRequestCount.Store(0)
+	c.currentDirty = false
+}
+
+// ensureEpochGroupCacheInited lazily inits the block cache (current/previous epoch indices). Caller must hold no cache lock.
+func (k Keeper) ensureEpochGroupCacheInited(ctx context.Context) {
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inited {
+		return
+	}
+	eff, ok := k.GetEffectiveEpochIndex(ctx)
+	if !ok {
+		return
+	}
+	c.current = eff
+	if eff > 0 {
+		c.previous = eff - 1
+	} else {
+		c.previous = 0
+	}
+	c.m = make(map[epochGroupCacheKey]types.EpochGroupData)
+	c.inited = true
+}
+
+// FlushCurrentEpochGroupCache persists cached EpochGroupData for the current epoch to the store. Call from EndBlock.
+// Merges currentEpochRequestCount into the current epoch root group's NumberOfRequests before persisting.
+func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.inited {
+		return
+	}
+	delta := c.currentEpochRequestCount.Swap(0)
+	rootKey := epochGroupCacheKey{Epoch: c.current, ModelId: ""}
+	if val, inCache := c.m[rootKey]; inCache {
+		val.NumberOfRequests += delta
+		_ = k.EpochGroupDataMap.Set(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId), val)
+	} else if delta != 0 {
+		val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId))
+		if err == nil {
+			val.NumberOfRequests += delta
+			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(rootKey.Epoch, rootKey.ModelId), val)
+		}
+	}
+	for key, val := range c.m {
+		if key.Epoch == c.current && key != rootKey {
+			_ = k.EpochGroupDataMap.Set(ctx, collections.Join(key.Epoch, key.ModelId), val)
+		}
+	}
+	c.currentDirty = false
+}
+
+// IncrementCurrentEpochGroupRequestCount increments the per-block atomic counter for the current epoch's NumberOfRequests. Committed to store in EndBlock.
+func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) {
+	c := k.epochGroupCache
+	k.ensureEpochGroupCacheInited(ctx)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.inited {
+		return
+	}
+	c.currentEpochRequestCount.Add(1)
+	c.currentDirty = true
+}
+
+// SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).
+func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
+	epochIdx := epochGroupData.EpochIndex
+	modelId := epochGroupData.ModelId
+	key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
+	draft := getEpochGroupDraftFromContext(ctx)
+
+	if draft != nil {
+		k.ensureEpochGroupCacheInited(ctx)
+		c := k.epochGroupCache
+		c.mu.RLock()
+		inited, current, previous := c.inited, c.current, c.previous
+		c.mu.RUnlock()
+		if inited && (epochIdx == current || epochIdx == previous) {
+			cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
+			draft.lockWrite() // reentrant: same goroutine can write multiple times
+			draft.m[key] = *cloned
+			// Do not unlock here; lock is released in PostHandler (commit or failure)
+			return
+		}
+		// Non-current/previous: write through to store
+		k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
+		return
+	}
+
+	// No draft: update block cache or write through to store
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.inited || (epochIdx != c.current && epochIdx != c.previous) {
+		k.EpochGroupDataMap.Set(ctx, collections.Join(epochIdx, modelId), epochGroupData)
+		return
+	}
+	cloned := proto.Clone(&epochGroupData).(*types.EpochGroupData)
+	c.m[key] = *cloned
+	c.currentDirty = true
+}
+
+// GetEpochGroupData returns EpochGroupData by epoch and model. Uses tx draft first (if present), then block cache for current/previous epoch, then store.
 func (k Keeper) GetEpochGroupData(
 	ctx context.Context,
 	epochIndex uint64,
 	modelId string,
 ) (val types.EpochGroupData, found bool) {
-	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
+	k.ensureEpochGroupCacheInited(ctx)
+	c := k.epochGroupCache
+	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
 
+	draft := getEpochGroupDraftFromContext(ctx)
+	if draft != nil {
+		c.mu.RLock()
+		inited, current, previous := c.inited, c.current, c.previous
+		c.mu.RUnlock()
+		if inited && (epochIndex == current || epochIndex == previous) {
+			var cached types.EpochGroupData
+			var ok bool
+			if draft.isWriteLocked() && atomic.LoadInt64(&draft.writeHolder) == getGID() {
+				cached, ok = draft.m[key]
+			} else {
+				draft.mu.RLock()
+				cached, ok = draft.m[key]
+				draft.mu.RUnlock()
+			}
+			if ok {
+				cloned := proto.Clone(&cached).(*types.EpochGroupData)
+				return *cloned, true
+			}
+		}
+	}
+
+	c.mu.RLock()
+	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
+		if cached, ok := c.m[key]; ok {
+			c.mu.RUnlock()
+			cloned := proto.Clone(&cached).(*types.EpochGroupData)
+			return *cloned, true
+		}
+	}
+	c.mu.RUnlock()
+
+	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))
 	if err != nil {
 		return val, false
 	}
+	c.mu.Lock()
+	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
+		cloned := proto.Clone(&val).(*types.EpochGroupData)
+		c.m[key] = *cloned
+	}
+	c.mu.Unlock()
 	return val, true
 }
 
-// RemoveEpochGroupData removes a epochGroupData from the store
+// RemoveEpochGroupData removes EpochGroupData from store and from block cache / tx draft when applicable.
 func (k Keeper) RemoveEpochGroupData(
 	ctx context.Context,
 	epochIndex uint64,
 	modelId string,
 ) {
 	k.EpochGroupDataMap.Remove(ctx, collections.Join(epochIndex, modelId))
+	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
+	if draft := getEpochGroupDraftFromContext(ctx); draft != nil {
+		draft.lockWrite()
+		delete(draft.m, key)
+		// Do not unlock here; released in PostHandler
+	}
+	c := k.epochGroupCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
+		delete(c.m, key)
+	}
 }
 
-// GetAllEpochGroupData returns all epochGroupData
+// GetAllEpochGroupData returns all EpochGroupData from the store.
 func (k Keeper) GetAllEpochGroupData(ctx context.Context) (list []types.EpochGroupData) {
 	iter, err := k.EpochGroupDataMap.Iterate(ctx, nil)
 	if err != nil {

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -56,6 +56,9 @@ func (c *epochGroupCache) lockDraftWrite() {
 	atomic.StoreInt32(&c.draftWriteCount, 1)
 }
 
+// It is never called as we are releasing the draft write lock when transaction completes
+// and we do not decrement the draft write count
+// It could be used if we want to unlock the reentrant write lock before the transaction completes
 func (c *epochGroupCache) unlockDraftWrite() {
 	if !cosmosOptimisticCachesEnabled {
 		return
@@ -68,8 +71,13 @@ func (c *epochGroupCache) unlockDraftWrite() {
 
 // releaseDraftWriteLock fully releases the draft write lock (for PostHandler). Call on tx commit or failure.
 func (c *epochGroupCache) releaseDraftWriteLock() {
-	for atomic.LoadInt32(&c.draftWriteCount) > 0 {
-		c.unlockDraftWrite()
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
+	if atomic.LoadInt32(&c.draftWriteCount) > 0 {
+		atomic.StoreInt64(&c.draftWriteHolder, 0)
+		atomic.StoreInt32(&c.draftWriteCount, 0)
+		c.draftWriterMu.Unlock()
 	}
 }
 

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -248,7 +248,7 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 		return
 	}
 	delta := c.currentEpochRequestCount.Swap(0)
-	if !c.currentDirty && delta == 0 {
+	if !c.currentDirty {
 		return
 	}
 
@@ -275,16 +275,17 @@ func (k Keeper) FlushCurrentEpochGroupCache(ctx context.Context) {
 }
 
 // IncrementCurrentEpochGroupRequestCount increments the per-block atomic counter for the current epoch's NumberOfRequests. Committed to store in EndBlock.
-func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) {
+func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) int64 {
 	c := k.epochGroupCache
 	k.ensureEpochGroupCacheInited(ctx)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.inited {
-		return
+		return 0
 	}
-	c.currentEpochRequestCount.Add(1)
+	count := c.currentEpochRequestCount.Add(1)
 	c.currentDirty = true
+	return count
 }
 
 // SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"bytes"
 	"context"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -12,6 +13,13 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/productscience/inference/x/inference/types"
 )
+
+// cosmosOptimisticCachesEnabled is set once at package init from COSMOS_OPTIMISTIC_CACHES=1.
+var cosmosOptimisticCachesEnabled bool
+
+func init() {
+	cosmosOptimisticCachesEnabled = os.Getenv("COSMOS_OPTIMISTIC_CACHES") == "1"
+}
 
 // getGID returns the current goroutine id (for reentrant lock holder identity). Uses runtime.Stack; for use in reentrant locking only.
 func getGID() int64 {
@@ -62,7 +70,11 @@ type epochGroupDraft struct {
 }
 
 // lockWrite acquires the write lock; reentrant for the same goroutine (increments count). Release via unlockWrite or releaseWriteLock.
+// Only takes the lock when COSMOS_OPTIMISTIC_CACHES=1; otherwise no-op.
 func (d *epochGroupDraft) lockWrite() {
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
 	gid := getGID()
 	if atomic.LoadInt64(&d.writeHolder) == gid {
 		atomic.AddInt32(&d.writeCount, 1)
@@ -74,7 +86,11 @@ func (d *epochGroupDraft) lockWrite() {
 }
 
 // unlockWrite releases one level of the write lock; if count goes to 0, releases the underlying RWMutex.
+// No-op when COSMOS_OPTIMISTIC_CACHES is not 1.
 func (d *epochGroupDraft) unlockWrite() {
+	if !cosmosOptimisticCachesEnabled {
+		return
+	}
 	if atomic.AddInt32(&d.writeCount, -1) == 0 {
 		atomic.StoreInt64(&d.writeHolder, 0)
 		d.mu.Unlock()

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -34,6 +34,24 @@ func getGID() int64 {
 // ctxKeyEpochGroupDraft is the context key for the tx-scoped EpochGroupData draft.
 type ctxKeyEpochGroupDraft struct{}
 
+// lazyEpochGroupDraft defers allocation of the real draft until the first write (Set/Remove).
+// This avoids allocating a map for every tx when most txs only read epoch group data.
+type lazyEpochGroupDraft struct {
+	once sync.Once
+	d    *epochGroupDraft
+}
+
+func (l *lazyEpochGroupDraft) get() *epochGroupDraft {
+	return l.d
+}
+
+func (l *lazyEpochGroupDraft) getOrCreate() *epochGroupDraft {
+	l.once.Do(func() {
+		l.d = &epochGroupDraft{m: make(map[epochGroupCacheKey]types.EpochGroupData)}
+	})
+	return l.d
+}
+
 // epochGroupDraft holds tx-scoped EpochGroupData writes for optimistic parallel execution.
 // Uses a reentrant write lock: the same goroutine can write (or delete) multiple times; lock is released only in PostHandler (commit or failure).
 type epochGroupDraft struct {
@@ -75,13 +93,14 @@ func (d *epochGroupDraft) releaseWriteLock() {
 	}
 }
 
-// WithEpochGroupDraft attaches a new tx-scoped draft to ctx. Call at tx start (e.g. from AnteHandler).
+// WithEpochGroupDraft attaches a lazy tx-scoped draft holder to ctx. Call at tx start (e.g. from AnteHandler).
+// The real draft (and its map) is created only on first SetEpochGroupData or RemoveEpochGroupData for current/previous epoch;
+// read-only txs never allocate it and always use the per-block cache (or store).
 func WithEpochGroupDraft(ctx context.Context) context.Context {
-	d := &epochGroupDraft{m: make(map[epochGroupCacheKey]types.EpochGroupData)}
-	return context.WithValue(ctx, ctxKeyEpochGroupDraft{}, d)
+	return context.WithValue(ctx, ctxKeyEpochGroupDraft{}, &lazyEpochGroupDraft{})
 }
 
-// getEpochGroupDraftFromContext returns the draft from ctx, or nil if no draft is bound.
+// getEpochGroupDraftFromContext returns the draft from ctx if it exists, or nil. Does not create the draft (for reads and for Commit/Release).
 func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
 	if ctx == nil {
 		return nil
@@ -90,8 +109,33 @@ func getEpochGroupDraftFromContext(ctx context.Context) *epochGroupDraft {
 	if v == nil {
 		return nil
 	}
-	d, _ := v.(*epochGroupDraft)
-	return d
+	switch h := v.(type) {
+	case *lazyEpochGroupDraft:
+		return h.get()
+	case *epochGroupDraft:
+		return h
+	default:
+		return nil
+	}
+}
+
+// getEpochGroupDraftForWriteFromContext returns the draft, creating it from the lazy holder on first write. Use in SetEpochGroupData and RemoveEpochGroupData.
+func getEpochGroupDraftForWriteFromContext(ctx context.Context) *epochGroupDraft {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(ctxKeyEpochGroupDraft{})
+	if v == nil {
+		return nil
+	}
+	switch h := v.(type) {
+	case *lazyEpochGroupDraft:
+		return h.getOrCreate()
+	case *epochGroupDraft:
+		return h
+	default:
+		return nil
+	}
 }
 
 // CommitEpochGroupDraftFromContext merges the draft from ctx into the block cache. Call from PostHandler on tx success.
@@ -228,11 +272,12 @@ func (k Keeper) IncrementCurrentEpochGroupRequestCount(ctx context.Context) {
 }
 
 // SetEpochGroupData sets EpochGroupData. When ctx has a tx-scoped draft, current/previous-epoch writes go to the draft only (merged to block cache on tx success, then flushed to store in EndBlock).
+// Draft is created lazily on first write so read-only txs do not allocate it.
 func (k Keeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
 	epochIdx := epochGroupData.EpochIndex
 	modelId := epochGroupData.ModelId
 	key := epochGroupCacheKey{Epoch: epochIdx, ModelId: modelId}
-	draft := getEpochGroupDraftFromContext(ctx)
+	draft := getEpochGroupDraftForWriteFromContext(ctx)
 
 	if draft != nil {
 		k.ensureEpochGroupCacheInited(ctx)
@@ -321,6 +366,7 @@ func (k Keeper) GetEpochGroupData(
 }
 
 // RemoveEpochGroupData removes EpochGroupData from store and from block cache / tx draft when applicable.
+// Draft is created only when removing a current/previous-epoch key (same lazy rule as SetEpochGroupData).
 func (k Keeper) RemoveEpochGroupData(
 	ctx context.Context,
 	epochIndex uint64,
@@ -328,12 +374,18 @@ func (k Keeper) RemoveEpochGroupData(
 ) {
 	k.EpochGroupDataMap.Remove(ctx, collections.Join(epochIndex, modelId))
 	key := epochGroupCacheKey{Epoch: epochIndex, ModelId: modelId}
-	if draft := getEpochGroupDraftFromContext(ctx); draft != nil {
-		draft.lockWrite()
-		delete(draft.m, key)
-		// Do not unlock here; released in PostHandler
-	}
+	k.ensureEpochGroupCacheInited(ctx)
 	c := k.epochGroupCache
+	c.mu.RLock()
+	needDraft := c.inited && (epochIndex == c.current || epochIndex == c.previous)
+	c.mu.RUnlock()
+	if needDraft {
+		if draft := getEpochGroupDraftForWriteFromContext(ctx); draft != nil {
+			draft.lockWrite()
+			delete(draft.m, key)
+			// Do not unlock here; released in PostHandler
+		}
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {

--- a/inference-chain/x/inference/keeper/epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data.go
@@ -469,16 +469,13 @@ func (k Keeper) GetEpochGroupData(
 	}
 
 	c.draftWriterMu.RLock()
-	c.mu.RLock()
 	if c.inited && (epochIndex == c.current || epochIndex == c.previous) {
 		if cached, ok := c.m[key]; ok {
-			c.mu.RUnlock()
 			c.draftWriterMu.RUnlock()
 			cloned := proto.Clone(&cached).(*types.EpochGroupData)
 			return *cloned, true
 		}
 	}
-	c.mu.RUnlock()
 	c.draftWriterMu.RUnlock()
 
 	val, err := k.EpochGroupDataMap.Get(ctx, collections.Join(epochIndex, modelId))

--- a/inference-chain/x/inference/keeper/epoch_group_data_cache_branch_test.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data_cache_branch_test.go
@@ -1,8 +1,11 @@
 package keeper_test
 
 import (
+	"sync"
 	"testing"
+	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/types"
@@ -14,10 +17,10 @@ var _ func(keeper.Keeper) = func(keeper.Keeper) {}
 
 const cacheBranchTestEpoch = 10
 
-// TestCacheContextWithEpochGroupBranch_WriteThenMerge verifies that writes on the branch
+// TestCacheContext_WriteThenMerge verifies that writes on the branch
 // are merged into the parent draft when writeCache() is called, and become visible after
 // CommitEpochGroupDraftFromContext (and thus to subsequent reads).
-func TestCacheContextWithEpochGroupBranch_WriteThenMerge(t *testing.T) {
+func TestCacheContext_WriteThenMerge(t *testing.T) {
 	k, sdkCtx := keepertest.InferenceKeeper(t)
 	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
 
@@ -25,14 +28,14 @@ func TestCacheContextWithEpochGroupBranch_WriteThenMerge(t *testing.T) {
 	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 1)
 
 	// Simulate AnteHandler: tx context with main draft
-	txCtx := txCtxWithDraft(sdkCtx)
+	txCtx := txCtxWithDraft(k, sdkCtx)
 
 	// Create branch, write only on branch, then merge
-	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	cacheCtx, writeCache := k.CacheContext(txCtx)
 	branchData := types.EpochGroupData{
-		EpochIndex:          cacheBranchTestEpoch,
-		ModelId:             "",
-		NumberOfRequests:    999,
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     999,
 		MemberSeedSignatures: []*types.SeedSignature{},
 	}
 	k.SetEpochGroupData(cacheCtx, branchData)
@@ -47,24 +50,24 @@ func TestCacheContextWithEpochGroupBranch_WriteThenMerge(t *testing.T) {
 	require.Equal(t, int64(999), val.NumberOfRequests)
 }
 
-// TestCacheContextWithEpochGroupBranch_NoWriteCache_Discarded verifies that when
+// TestCacheContext_NoWriteCache_Discarded verifies that when
 // writeCache() is not called, branch draft writes are discarded and the parent
 // (and store) remain unchanged.
-func TestCacheContextWithEpochGroupBranch_NoWriteCache_Discarded(t *testing.T) {
+func TestCacheContext_NoWriteCache_Discarded(t *testing.T) {
 	k, sdkCtx := keepertest.InferenceKeeper(t)
 	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
 
 	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 100)
 
-	txCtx := txCtxWithDraft(sdkCtx)
-	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	txCtx := txCtxWithDraft(k, sdkCtx)
+	cacheCtx, writeCache := k.CacheContext(txCtx)
 	_ = writeCache // intentionally not called
 
 	// Write only on branch
 	branchData := types.EpochGroupData{
-		EpochIndex:          cacheBranchTestEpoch,
-		ModelId:             "",
-		NumberOfRequests:    999,
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     999,
 		MemberSeedSignatures: []*types.SeedSignature{},
 	}
 	k.SetEpochGroupData(cacheCtx, branchData)
@@ -78,19 +81,19 @@ func TestCacheContextWithEpochGroupBranch_NoWriteCache_Discarded(t *testing.T) {
 	require.Equal(t, int64(100), val.NumberOfRequests)
 }
 
-// TestCacheContextWithEpochGroupBranch_WriteCacheIdempotent verifies that calling
+// TestCacheContext_WriteCacheIdempotent verifies that calling
 // writeCache() multiple times does not panic and does not double-merge (idempotent).
-func TestCacheContextWithEpochGroupBranch_WriteCacheIdempotent(t *testing.T) {
+func TestCacheContext_WriteCacheIdempotent(t *testing.T) {
 	k, sdkCtx := keepertest.InferenceKeeper(t)
 	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
 	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 0)
 
-	txCtx := txCtxWithDraft(sdkCtx)
-	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	txCtx := txCtxWithDraft(k, sdkCtx)
+	cacheCtx, writeCache := k.CacheContext(txCtx)
 	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
-		EpochIndex:          cacheBranchTestEpoch,
-		ModelId:             "",
-		NumberOfRequests:    42,
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     42,
 		MemberSeedSignatures: []*types.SeedSignature{},
 	})
 
@@ -104,21 +107,21 @@ func TestCacheContextWithEpochGroupBranch_WriteCacheIdempotent(t *testing.T) {
 	require.Equal(t, int64(42), val.NumberOfRequests)
 }
 
-// TestCacheContextWithEpochGroupBranch_GetSeesBranchDraft verifies that GetEpochGroupData
+// TestCacheContext_GetSeesBranchDraft verifies that GetEpochGroupData
 // on the branch context sees data written with SetEpochGroupData on that same branch.
-func TestCacheContextWithEpochGroupBranch_GetSeesBranchDraft(t *testing.T) {
+func TestCacheContext_GetSeesBranchDraft(t *testing.T) {
 	k, sdkCtx := keepertest.InferenceKeeper(t)
 	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
 	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 1)
 
-	txCtx := txCtxWithDraft(sdkCtx)
-	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	txCtx := txCtxWithDraft(k, sdkCtx)
+	cacheCtx, writeCache := k.CacheContext(txCtx)
 
 	// Set on branch
 	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
-		EpochIndex:          cacheBranchTestEpoch,
-		ModelId:             "",
-		NumberOfRequests:    777,
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     777,
 		MemberSeedSignatures: []*types.SeedSignature{},
 	})
 
@@ -138,28 +141,28 @@ func TestCacheContextWithEpochGroupBranch_GetSeesBranchDraft(t *testing.T) {
 	require.Equal(t, int64(777), valParent2.NumberOfRequests, "parent should see merged value after writeCache")
 }
 
-// TestCacheContextWithEpochGroupBranch_ParentAndBranchWrites verifies that when both
+// TestCacheContext_ParentAndBranchWrites verifies that when both
 // parent and branch write, merge combines them (branch writes merge into parent draft).
-func TestCacheContextWithEpochGroupBranch_ParentAndBranchWrites(t *testing.T) {
+func TestCacheContext_ParentAndBranchWrites(t *testing.T) {
 	k, sdkCtx := keepertest.InferenceKeeper(t)
 	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
 	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 0)
 
-	txCtx := txCtxWithDraft(sdkCtx)
+	txCtx := txCtxWithDraft(k, sdkCtx)
 	// Parent writes root group
 	k.SetEpochGroupData(txCtx, types.EpochGroupData{
-		EpochIndex:          cacheBranchTestEpoch,
-		ModelId:             "",
-		NumberOfRequests:    100,
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     100,
 		MemberSeedSignatures: []*types.SeedSignature{},
 	})
 
-	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	cacheCtx, writeCache := k.CacheContext(txCtx)
 	// Branch overwrites same key
 	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
-		EpochIndex:          cacheBranchTestEpoch,
-		ModelId:             "",
-		NumberOfRequests:    200,
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     200,
 		MemberSeedSignatures: []*types.SeedSignature{},
 	})
 	writeCache()
@@ -168,6 +171,247 @@ func TestCacheContextWithEpochGroupBranch_ParentAndBranchWrites(t *testing.T) {
 	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
 	require.True(t, found)
 	require.Equal(t, int64(200), val.NumberOfRequests, "branch write should override parent in same key")
+}
+
+// COSMOS_OCC_ENABLED=1 go test ./x/inference/keeper/ -run TestWriteWithoutMerge_Deadlock -timeout 10s -v
+func TestWriteWithoutMerge_Deadlock(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 100)
+
+	txCtx := txCtxWithDraft(k, sdkCtx)
+	cacheCtx, _ := k.CacheContext(txCtx)
+
+	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     999,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+		}(i)
+	}
+
+	go func() {
+		k.CommitEpochGroupDraftFromContext(txCtx)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("DEADLOCK")
+	}
+}
+
+// TestOCC_ConflictDetection validates that when two txs operate in parallel and
+// one reads a key that the other writes, DetectEpochGroupConflicts returns the reader.
+func TestOCC_ConflictDetection(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 50)
+
+	k.ResetEpochGroupConflictTracker()
+
+	tx1Ctx := txCtxWithDraft(k, sdkCtx)
+	tx2Ctx := txCtxWithDraft(k, sdkCtx)
+	k.RegisterEpochGroupTx(tx1Ctx)
+	k.RegisterEpochGroupTx(tx2Ctx)
+
+	// tx1 reads the key
+	val, found := k.GetEpochGroupData(tx1Ctx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(50), val.NumberOfRequests)
+
+	// tx2 writes the same key
+	k.SetEpochGroupData(tx2Ctx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     200,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	conflictedReads, conflictedWrites := k.DetectEpochGroupConflicts()
+	require.Len(t, conflictedReads, 1, "tx1 should be a conflicted reader")
+	require.Len(t, conflictedWrites, 1, "tx2 should be a conflicted writer")
+}
+
+// TestOCC_NoConflictWhenDifferentKeys validates that txs operating on different
+// keys produce no conflicts.
+func TestOCC_NoConflictWhenDifferentKeys(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 10)
+	k.SetEpochGroupData(sdkCtx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "modelB",
+		NumberOfRequests:     20,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	k.ResetEpochGroupConflictTracker()
+
+	tx1Ctx := txCtxWithDraft(k, sdkCtx)
+	tx2Ctx := txCtxWithDraft(k, sdkCtx)
+	k.RegisterEpochGroupTx(tx1Ctx)
+	k.RegisterEpochGroupTx(tx2Ctx)
+
+	// tx1 reads root key
+	_, _ = k.GetEpochGroupData(tx1Ctx, cacheBranchTestEpoch, "")
+
+	// tx2 writes modelB key (different key)
+	k.SetEpochGroupData(tx2Ctx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "modelB",
+		NumberOfRequests:     99,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	conflictedReads, conflictedWrites := k.DetectEpochGroupConflicts()
+	require.Len(t, conflictedReads, 0, "no read conflict when txs touch different keys")
+	require.Len(t, conflictedWrites, 0, "no write conflict when txs touch different keys")
+}
+
+// TestOCC_WriteWriteConflict validates that two txs writing the same key are
+// both reported as conflicted writers.
+func TestOCC_WriteWriteConflict(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 1)
+
+	k.ResetEpochGroupConflictTracker()
+
+	tx1Ctx := txCtxWithDraft(k, sdkCtx)
+	tx2Ctx := txCtxWithDraft(k, sdkCtx)
+	k.RegisterEpochGroupTx(tx1Ctx)
+	k.RegisterEpochGroupTx(tx2Ctx)
+
+	// Both txs write the same key
+	k.SetEpochGroupData(tx1Ctx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     100,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+	k.SetEpochGroupData(tx2Ctx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     200,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	conflictedReads, conflictedWrites := k.DetectEpochGroupConflicts()
+	require.Len(t, conflictedReads, 0, "no read conflicts — neither tx read")
+	require.Len(t, conflictedWrites, 2, "both txs should be conflicted writers (write-write on same key)")
+}
+
+// TestOCC_MultipleWriteTxs validates conflict detection across 3 txs:
+// tx1 reads key A, tx2 writes key A, tx3 writes key A.
+// Expected: tx1 is a conflicted reader, tx2 and tx3 are conflicted writers (read-write + write-write).
+func TestOCC_MultipleWriteTxs(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 10)
+
+	k.ResetEpochGroupConflictTracker()
+
+	tx1Ctx := txCtxWithDraft(k, sdkCtx)
+	tx2Ctx := txCtxWithDraft(k, sdkCtx)
+	tx3Ctx := txCtxWithDraft(k, sdkCtx)
+	k.RegisterEpochGroupTx(tx1Ctx)
+	k.RegisterEpochGroupTx(tx2Ctx)
+	k.RegisterEpochGroupTx(tx3Ctx)
+
+	// tx1 reads
+	_, _ = k.GetEpochGroupData(tx1Ctx, cacheBranchTestEpoch, "")
+
+	// tx2 writes the same key
+	k.SetEpochGroupData(tx2Ctx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     50,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	// tx3 also writes the same key
+	k.SetEpochGroupData(tx3Ctx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     75,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	conflictedReads, conflictedWrites := k.DetectEpochGroupConflicts()
+	require.Len(t, conflictedReads, 1, "tx1 is the only reader that conflicts")
+	require.Len(t, conflictedWrites, 2, "tx2 and tx3 are both conflicted writers (read-write from tx1 + write-write between them)")
+}
+
+// TestOCC_ResetClearsTracker validates that ResetEpochGroupConflictTracker
+// clears all prior read/write sets.
+func TestOCC_ResetClearsTracker(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 1)
+
+	tx1Ctx := txCtxWithDraft(k, sdkCtx)
+	tx2Ctx := txCtxWithDraft(k, sdkCtx)
+	k.RegisterEpochGroupTx(tx1Ctx)
+	k.RegisterEpochGroupTx(tx2Ctx)
+
+	_, _ = k.GetEpochGroupData(tx1Ctx, cacheBranchTestEpoch, "")
+	k.SetEpochGroupData(tx2Ctx, types.EpochGroupData{
+		EpochIndex:           cacheBranchTestEpoch,
+		ModelId:              "",
+		NumberOfRequests:     5,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	conflictedReads, _ := k.DetectEpochGroupConflicts()
+	require.Len(t, conflictedReads, 1)
+
+	// After reset, no conflicts
+	k.ResetEpochGroupConflictTracker()
+	r, w := k.DetectEpochGroupConflicts()
+	require.Len(t, r, 0)
+	require.Len(t, w, 0)
+}
+
+// TestOCC_MultipleReadsNoConflict validates that many txs reading the same key
+// without any writer produce zero conflicts (read-read is never a conflict).
+func TestOCC_MultipleReadsNoConflict(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 42)
+
+	k.ResetEpochGroupConflictTracker()
+
+	const numReaders = 10
+	txCtxs := make([]sdk.Context, numReaders)
+	for i := 0; i < numReaders; i++ {
+		txCtxs[i] = txCtxWithDraft(k, sdkCtx)
+		k.RegisterEpochGroupTx(txCtxs[i])
+	}
+
+	for i := 0; i < numReaders; i++ {
+		val, found := k.GetEpochGroupData(txCtxs[i], cacheBranchTestEpoch, "")
+		require.True(t, found, "reader %d", i)
+		require.Equal(t, int64(42), val.NumberOfRequests, "reader %d", i)
+	}
+
+	conflictedReads, conflictedWrites := k.DetectEpochGroupConflicts()
+	require.Len(t, conflictedReads, 0, "read-read should never conflict")
+	require.Len(t, conflictedWrites, 0, "no writers means no write conflicts")
 }
 
 // txCtxWithDraft and seedEpochGroupData are in epoch_group_data_concurrent_test.go;

--- a/inference-chain/x/inference/keeper/epoch_group_data_cache_branch_test.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data_cache_branch_test.go
@@ -1,0 +1,175 @@
+package keeper_test
+
+import (
+	"testing"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ensure keeper package is used (k from InferenceKeeper is keeper.Keeper)
+var _ func(keeper.Keeper) = func(keeper.Keeper) {}
+
+const cacheBranchTestEpoch = 10
+
+// TestCacheContextWithEpochGroupBranch_WriteThenMerge verifies that writes on the branch
+// are merged into the parent draft when writeCache() is called, and become visible after
+// CommitEpochGroupDraftFromContext (and thus to subsequent reads).
+func TestCacheContextWithEpochGroupBranch_WriteThenMerge(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+
+	// Seed initial data (no draft; goes to store/block cache)
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 1)
+
+	// Simulate AnteHandler: tx context with main draft
+	txCtx := txCtxWithDraft(sdkCtx)
+
+	// Create branch, write only on branch, then merge
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	branchData := types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    999,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	}
+	k.SetEpochGroupData(cacheCtx, branchData)
+	writeCache()
+
+	// Parent draft should now contain the branch write; commit it to block cache
+	k.CommitEpochGroupDraftFromContext(txCtx)
+
+	// Reads on base context should see the merged value (from block cache)
+	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(999), val.NumberOfRequests)
+}
+
+// TestCacheContextWithEpochGroupBranch_NoWriteCache_Discarded verifies that when
+// writeCache() is not called, branch draft writes are discarded and the parent
+// (and store) remain unchanged.
+func TestCacheContextWithEpochGroupBranch_NoWriteCache_Discarded(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 100)
+
+	txCtx := txCtxWithDraft(sdkCtx)
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	_ = writeCache // intentionally not called
+
+	// Write only on branch
+	branchData := types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    999,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	}
+	k.SetEpochGroupData(cacheCtx, branchData)
+
+	// Commit parent draft (empty; we never merged branch)
+	k.CommitEpochGroupDraftFromContext(txCtx)
+
+	// Should still see original value, not branch value
+	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(100), val.NumberOfRequests)
+}
+
+// TestCacheContextWithEpochGroupBranch_WriteCacheIdempotent verifies that calling
+// writeCache() multiple times does not panic and does not double-merge (idempotent).
+func TestCacheContextWithEpochGroupBranch_WriteCacheIdempotent(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 0)
+
+	txCtx := txCtxWithDraft(sdkCtx)
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    42,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	writeCache()
+	writeCache() // second call must be safe
+	writeCache()
+
+	k.CommitEpochGroupDraftFromContext(txCtx)
+	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(42), val.NumberOfRequests)
+}
+
+// TestCacheContextWithEpochGroupBranch_GetSeesBranchDraft verifies that GetEpochGroupData
+// on the branch context sees data written with SetEpochGroupData on that same branch.
+func TestCacheContextWithEpochGroupBranch_GetSeesBranchDraft(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 1)
+
+	txCtx := txCtxWithDraft(sdkCtx)
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+
+	// Set on branch
+	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    777,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	// Get on branch must see branch draft value before writeCache
+	val, found := k.GetEpochGroupData(cacheCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(777), val.NumberOfRequests)
+
+	// Parent (txCtx) should not see it until writeCache
+	valParent, foundParent := k.GetEpochGroupData(txCtx, cacheBranchTestEpoch, "")
+	require.True(t, foundParent)
+	require.Equal(t, int64(1), valParent.NumberOfRequests, "parent should still see seeded value before merge")
+
+	writeCache()
+	valParent2, foundParent2 := k.GetEpochGroupData(txCtx, cacheBranchTestEpoch, "")
+	require.True(t, foundParent2)
+	require.Equal(t, int64(777), valParent2.NumberOfRequests, "parent should see merged value after writeCache")
+}
+
+// TestCacheContextWithEpochGroupBranch_ParentAndBranchWrites verifies that when both
+// parent and branch write, merge combines them (branch writes merge into parent draft).
+func TestCacheContextWithEpochGroupBranch_ParentAndBranchWrites(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(sdkCtx, cacheBranchTestEpoch))
+	seedEpochGroupData(k, sdkCtx, cacheBranchTestEpoch, 0)
+
+	txCtx := txCtxWithDraft(sdkCtx)
+	// Parent writes root group
+	k.SetEpochGroupData(txCtx, types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    100,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+
+	cacheCtx, writeCache := k.CacheContextWithEpochGroupBranch(txCtx)
+	// Branch overwrites same key
+	k.SetEpochGroupData(cacheCtx, types.EpochGroupData{
+		EpochIndex:          cacheBranchTestEpoch,
+		ModelId:             "",
+		NumberOfRequests:    200,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	})
+	writeCache()
+
+	k.CommitEpochGroupDraftFromContext(txCtx)
+	val, found := k.GetEpochGroupData(sdkCtx, cacheBranchTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, int64(200), val.NumberOfRequests, "branch write should override parent in same key")
+}
+
+// txCtxWithDraft and seedEpochGroupData are in epoch_group_data_concurrent_test.go;
+// we reuse them. If this file is run in isolation, ensure same package and helpers.
+// Both are in keeper_test so they are available.

--- a/inference-chain/x/inference/keeper/epoch_group_data_concurrent_test.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data_concurrent_test.go
@@ -1,0 +1,213 @@
+package keeper_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = strconv.IntSize
+
+const (
+	concurrentTestEpoch   = 5
+	concurrentNumReaders = 20
+	concurrentNumWriters = 5
+)
+
+// txCtxWithDraft returns an sdk.Context that has a tx-scoped draft attached (simulating AnteHandler).
+func txCtxWithDraft(sdkCtx sdk.Context) sdk.Context {
+	stdCtx := sdkCtx.Context()
+	if stdCtx == nil {
+		stdCtx = context.Background()
+	}
+	return sdkCtx.WithContext(keeper.WithEpochGroupDraft(stdCtx))
+}
+
+// seedEpochGroupData writes one root group for the test epoch into the store (no draft).
+func seedEpochGroupData(k keeper.Keeper, ctx sdk.Context, epoch uint64, numberOfRequests int64) {
+	data := types.EpochGroupData{
+		EpochIndex:          epoch,
+		ModelId:             "",
+		NumberOfRequests:    numberOfRequests,
+		MemberSeedSignatures: []*types.SeedSignature{},
+	}
+	k.SetEpochGroupData(ctx, data)
+}
+
+// TestConcurrentReadsSameResult runs many read-only "transactions" in parallel.
+// All use the same epoch key; no draft. They must all see the same value and run without blocking each other.
+func TestConcurrentReadsSameResult(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, concurrentTestEpoch)
+	seedEpochGroupData(k, sdkCtx, concurrentTestEpoch, 100)
+
+	var wg sync.WaitGroup
+	results := make([]types.EpochGroupData, concurrentNumReaders)
+	for i := 0; i < concurrentNumReaders; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			val, found := k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+			require.True(t, found)
+			results[idx] = val
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < concurrentNumReaders; i++ {
+		require.Equal(t, int64(100), results[i].NumberOfRequests, "reader %d", i)
+		require.Equal(t, uint64(concurrentTestEpoch), results[i].EpochIndex)
+	}
+}
+
+// TestOneWriterManyReaders_ReadersSeeWriteAfterCommit: one writer tx (Set + Commit), then many readers.
+// Readers that run after the writer must see the written value (block cache updated by Commit).
+func TestOneWriterManyReaders_ReadersSeeWriteAfterCommit(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, concurrentTestEpoch)
+	seedEpochGroupData(k, sdkCtx, concurrentTestEpoch, 1)
+
+	writerDone := make(chan struct{})
+	go func() {
+		txCtx := txCtxWithDraft(sdkCtx)
+		data := types.EpochGroupData{
+			EpochIndex:          concurrentTestEpoch,
+			ModelId:             "",
+			NumberOfRequests:    999,
+			MemberSeedSignatures: []*types.SeedSignature{},
+		}
+		k.SetEpochGroupData(txCtx, data)
+		k.CommitEpochGroupDraftFromContext(txCtx)
+		close(writerDone)
+	}()
+
+	<-writerDone
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentNumReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			val, found := k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+			require.True(t, found)
+			require.Equal(t, int64(999), val.NumberOfRequests)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestOneWriterMultipleSetGet_NoDeadlock: one writer performs multiple Set/Get in one "tx" (reentrant draft lock),
+// while many readers run in parallel. Must not deadlock (run with -race and timeout).
+func TestOneWriterMultipleSetGet_NoDeadlock(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, concurrentTestEpoch)
+	seedEpochGroupData(k, sdkCtx, concurrentTestEpoch, 0)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		txCtx := txCtxWithDraft(sdkCtx)
+		for i := 0; i < 10; i++ {
+			data := types.EpochGroupData{
+				EpochIndex:          concurrentTestEpoch,
+				ModelId:             "",
+				NumberOfRequests:    int64(i),
+				MemberSeedSignatures: []*types.SeedSignature{},
+			}
+			k.SetEpochGroupData(txCtx, data)
+			_, _ = k.GetEpochGroupData(txCtx, concurrentTestEpoch, "")
+		}
+		k.CommitEpochGroupDraftFromContext(txCtx)
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentNumReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 5; j++ {
+				_, _ = k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+			}
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-done:
+		// writer finished
+	case <-time.After(5 * time.Second):
+		t.Fatal("writer or readers deadlocked (timeout)")
+	}
+}
+
+// TestMultipleWritersMultipleReaders: several writers commit in sequence (each takes block cache lock on Commit),
+// many readers run in parallel. After all writers finish, the last written value must be visible to readers.
+func TestMultipleWritersMultipleReaders_LastWriteWins(t *testing.T) {
+	k, sdkCtx := keepertest.InferenceKeeper(t)
+	_ = k.SetEffectiveEpochIndex(sdkCtx, concurrentTestEpoch)
+	seedEpochGroupData(k, sdkCtx, concurrentTestEpoch, 0)
+
+	// Writers commit one after another so "last" is well-defined
+	var writerOrder sync.Mutex
+	var lastCommittedValue int64
+
+	var wgWriters sync.WaitGroup
+	for w := 0; w < concurrentNumWriters; w++ {
+		val := int64(w + 1)
+		wgWriters.Add(1)
+		go func() {
+			defer wgWriters.Done()
+			txCtx := txCtxWithDraft(sdkCtx)
+			data := types.EpochGroupData{
+				EpochIndex:          concurrentTestEpoch,
+				ModelId:             "",
+				NumberOfRequests:    val,
+				MemberSeedSignatures: []*types.SeedSignature{},
+			}
+			k.SetEpochGroupData(txCtx, data)
+			writerOrder.Lock()
+			k.CommitEpochGroupDraftFromContext(txCtx)
+			lastCommittedValue = val
+			writerOrder.Unlock()
+		}()
+	}
+
+	var wgReaders sync.WaitGroup
+	readerResults := make([]int64, concurrentNumReaders)
+	for i := 0; i < concurrentNumReaders; i++ {
+		wgReaders.Add(1)
+		go func(idx int) {
+			defer wgReaders.Done()
+			// Readers run while writers are still committing
+			v, found := k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+			if found {
+				readerResults[idx] = v.NumberOfRequests
+			}
+		}(i)
+	}
+
+	wgWriters.Wait()
+	wgReaders.Wait()
+
+	// Final read must see the last committed value (last writer to hold the lock)
+	finalVal, found := k.GetEpochGroupData(sdkCtx, concurrentTestEpoch, "")
+	require.True(t, found)
+	require.Equal(t, lastCommittedValue, finalVal.NumberOfRequests,
+		"final read should see last committed value %d", lastCommittedValue)
+
+	// Every reader must have seen a value in [1, concurrentNumWriters] (some snapshot)
+	for i := 0; i < concurrentNumReaders; i++ {
+		if readerResults[i] != 0 {
+			require.GreaterOrEqual(t, readerResults[i], int64(1))
+			require.LessOrEqual(t, readerResults[i], int64(concurrentNumWriters))
+		}
+	}
+}

--- a/inference-chain/x/inference/keeper/epoch_group_data_concurrent_test.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data_concurrent_test.go
@@ -23,12 +23,13 @@ const (
 )
 
 // txCtxWithDraft returns an sdk.Context that has a tx-scoped draft attached (simulating AnteHandler).
-func txCtxWithDraft(sdkCtx sdk.Context) sdk.Context {
+func txCtxWithDraft(k keeper.Keeper, sdkCtx sdk.Context) sdk.Context {
 	stdCtx := sdkCtx.Context()
 	if stdCtx == nil {
 		stdCtx = context.Background()
 	}
-	return sdkCtx.WithContext(keeper.WithEpochGroupDraft(stdCtx))
+	stdCtx = k.EpochGroupStore().WithDraft(stdCtx)
+	return sdkCtx.WithContext(stdCtx)
 }
 
 // seedEpochGroupData writes one root group for the test epoch into the store (no draft).
@@ -77,7 +78,7 @@ func TestOneWriterManyReaders_ReadersSeeWriteAfterCommit(t *testing.T) {
 
 	writerDone := make(chan struct{})
 	go func() {
-		txCtx := txCtxWithDraft(sdkCtx)
+		txCtx := txCtxWithDraft(k, sdkCtx)
 		data := types.EpochGroupData{
 			EpochIndex:          concurrentTestEpoch,
 			ModelId:             "",
@@ -114,7 +115,7 @@ func TestOneWriterMultipleSetGet_NoDeadlock(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		txCtx := txCtxWithDraft(sdkCtx)
+		txCtx := txCtxWithDraft(k, sdkCtx)
 		for i := 0; i < 10; i++ {
 			data := types.EpochGroupData{
 				EpochIndex:          concurrentTestEpoch,
@@ -165,7 +166,7 @@ func TestMultipleWritersMultipleReaders_LastWriteWins(t *testing.T) {
 		wgWriters.Add(1)
 		go func() {
 			defer wgWriters.Done()
-			txCtx := txCtxWithDraft(sdkCtx)
+			txCtx := txCtxWithDraft(k, sdkCtx)
 			data := types.EpochGroupData{
 				EpochIndex:          concurrentTestEpoch,
 				ModelId:             "",

--- a/inference-chain/x/inference/keeper/epoch_group_data_test.go
+++ b/inference-chain/x/inference/keeper/epoch_group_data_test.go
@@ -52,8 +52,7 @@ func TestEpochGroupDataGet(t *testing.T) {
 			"",
 		)
 		require.True(t, found)
-		// This will be nil if MemberSeedSignature is empty!!
-		require.Nil(t, result.MemberSeedSignatures)
+		require.Empty(t, result.MemberSeedSignatures)
 		require.Equal(t,
 			nullify.Fill(&item),
 			nullify.Fill(&result),

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/store"
@@ -11,6 +13,25 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
 )
+
+// epochGroupCacheKey keys the hot cache by (epochIndex, modelId).
+type epochGroupCacheKey struct {
+	Epoch   uint64
+	ModelId string
+}
+
+// epochGroupCache holds EpochGroupData for current and previous effective epoch only.
+// Invalidated in BeginBlock; flushed to store in EndBlock.
+// currentEpochRequestCount is the per-block atomic counter for NumberOfRequests of the current epoch (root group); merged to store on flush.
+type epochGroupCache struct {
+	mu                      sync.RWMutex
+	inited                  bool
+	current                 uint64
+	previous                uint64
+	currentDirty            bool
+	m                       map[epochGroupCacheKey]types.EpochGroupData
+	currentEpochRequestCount atomic.Int64
+}
 
 type (
 	Keeper struct {
@@ -56,6 +77,8 @@ type (
 		InferenceValidationDetailsMap collections.Map[collections.Pair[uint64, string], types.InferenceValidationDetails]
 		UnitOfComputePriceProposals   collections.Map[string, types.UnitOfComputePriceProposal]
 		EpochGroupDataMap             collections.Map[collections.Pair[uint64, string], types.EpochGroupData]
+		// EpochGroupData hot cache: current and previous effective epoch; tx draft merged on tx success, flushed to store in EndBlock.
+		epochGroupCache *epochGroupCache
 		// Epoch collections
 		Epochs              collections.Map[uint64, types.Epoch]
 		EffectiveEpochIndex collections.Item[uint64]
@@ -270,6 +293,7 @@ func NewKeeper(
 			collections.PairKeyCodec(collections.Uint64Key, collections.StringKey),
 			codec.CollValue[types.EpochGroupData](cdc),
 		),
+		epochGroupCache: &epochGroupCache{},
 		// Epoch collections wiring
 		Epochs: collections.NewMap(
 			sb,

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -2,8 +2,6 @@ package keeper
 
 import (
 	"fmt"
-	"sync"
-	"sync/atomic"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/store"
@@ -18,23 +16,6 @@ import (
 type epochGroupCacheKey struct {
 	Epoch   uint64
 	ModelId string
-}
-
-// epochGroupCache holds EpochGroupData for current and previous effective epoch only.
-// Invalidated in BeginBlock; flushed to store in EndBlock.
-// currentEpochRequestCount is the per-block atomic counter for NumberOfRequests of the current epoch (root group); merged to store on flush.
-// draftWriterMu is held (write) while any tx is writing to its draft so that no one reads from the block cache until commit/release (deterministic, sequential).
-type epochGroupCache struct {
-	mu                       sync.RWMutex
-	draftWriterMu            sync.RWMutex // held by draft writers; block cache readers take RLock so they wait for no draft writer
-	draftWriteHolder         int64        // goroutine id of current draft writer (reentrancy)
-	draftWriteCount          int32        // reentrant lock count
-	inited                   bool
-	current                  uint64
-	previous                 uint64
-	currentDirty             bool
-	m                        map[epochGroupCacheKey]types.EpochGroupData
-	currentEpochRequestCount atomic.Int64
 }
 
 type (
@@ -80,9 +61,9 @@ type (
 		InferenceTimeouts             collections.Map[collections.Pair[uint64, string], types.InferenceTimeout]
 		InferenceValidationDetailsMap collections.Map[collections.Pair[uint64, string], types.InferenceValidationDetails]
 		UnitOfComputePriceProposals   collections.Map[string, types.UnitOfComputePriceProposal]
-		EpochGroupDataMap             collections.Map[collections.Pair[uint64, string], types.EpochGroupData]
-		// EpochGroupData hot cache: current and previous effective epoch; tx draft merged on tx success, flushed to store in EndBlock.
-		epochGroupCache *epochGroupCache
+		epochGroupStore               *OptimisticCollMap[epochGroupCacheKey, collections.Pair[uint64, string], types.EpochGroupData]
+		paramsStore                   *OptimisticItem[types.Params]
+		storeGroup                    OptimisticStoreGroup
 		// Epoch collections
 		Epochs              collections.Map[uint64, types.Epoch]
 		EffectiveEpochIndex collections.Item[uint64]
@@ -153,6 +134,8 @@ func NewKeeper(
 	}
 
 	sb := collections.NewSchemaBuilder(storeService)
+
+	cacheConfig := OptimisticStoreConfig{BlockCacheEnabled: true, TxDraftEnabled: true}
 
 	k := Keeper{
 		cdc:                   cdc,
@@ -290,14 +273,24 @@ func NewKeeper(
 			collections.PairKeyCodec(collections.Uint64Key, collections.StringKey),
 			codec.CollValue[types.InferenceTimeout](cdc),
 		),
-		EpochGroupDataMap: collections.NewMap(
+		epochGroupStore: NewOptimisticCollMap[epochGroupCacheKey, collections.Pair[uint64, string], types.EpochGroupData](
 			sb,
 			types.EpochGroupDataPrefix,
 			"epoch_group_data",
 			collections.PairKeyCodec(collections.Uint64Key, collections.StringKey),
 			codec.CollValue[types.EpochGroupData](cdc),
+			cacheConfig,
+			func(key epochGroupCacheKey) collections.Pair[uint64, string] {
+				return collections.Join(key.Epoch, key.ModelId)
+			},
 		),
-		epochGroupCache: &epochGroupCache{},
+		paramsStore: NewOptimisticProtoItem[types.Params](
+			storeService,
+			cdc,
+			types.ParamsKey,
+			"params",
+			cacheConfig,
+		),
 		// Epoch collections wiring
 		Epochs: collections.NewMap(
 			sb,
@@ -533,14 +526,25 @@ func NewKeeper(
 			collections.NoValue{},
 		),
 	}
-	// Build the collections schema
+
+	// Register all optimistic stores with the group
+	k.storeGroup.Register(k.epochGroupStore.OptimisticStore)
+	k.storeGroup.Register(k.paramsStore.Store())
+
+	// Build the collections schema (must happen after all NewMap/NewItem calls)
 	schema, err := sb.Build()
 	if err != nil {
 		//nolint:forbidigo // init code
 		panic(err)
 	}
 	k.Schema = schema
+
 	return k
+}
+
+// StoreGroup returns the group of all optimistic stores for batch lifecycle operations.
+func (k Keeper) StoreGroup() *OptimisticStoreGroup {
+	return &k.storeGroup
 }
 
 // GetAuthority returns the module's authority.

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -61,6 +61,7 @@ type (
 		InferenceTimeouts             collections.Map[collections.Pair[uint64, string], types.InferenceTimeout]
 		InferenceValidationDetailsMap collections.Map[collections.Pair[uint64, string], types.InferenceValidationDetails]
 		UnitOfComputePriceProposals   collections.Map[string, types.UnitOfComputePriceProposal]
+		EpochGroupDataMap             collections.Map[collections.Pair[uint64, string], types.EpochGroupData]
 		epochGroupStore               *OptimisticCollMap[epochGroupCacheKey, collections.Pair[uint64, string], types.EpochGroupData]
 		paramsStore                   *OptimisticItem[types.Params]
 		storeGroup                    OptimisticStoreGroup
@@ -526,6 +527,9 @@ func NewKeeper(
 			collections.NoValue{},
 		),
 	}
+
+	// Keep legacy direct map access while routing writes/reads through optimistic layer.
+	k.EpochGroupDataMap = k.epochGroupStore.Map
 
 	// Register all optimistic stores with the group
 	k.storeGroup.Register(k.epochGroupStore.OptimisticStore)

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -23,13 +23,17 @@ type epochGroupCacheKey struct {
 // epochGroupCache holds EpochGroupData for current and previous effective epoch only.
 // Invalidated in BeginBlock; flushed to store in EndBlock.
 // currentEpochRequestCount is the per-block atomic counter for NumberOfRequests of the current epoch (root group); merged to store on flush.
+// draftWriterMu is held (write) while any tx is writing to its draft so that no one reads from the block cache until commit/release (deterministic, sequential).
 type epochGroupCache struct {
-	mu                      sync.RWMutex
-	inited                  bool
-	current                 uint64
-	previous                uint64
-	currentDirty            bool
-	m                       map[epochGroupCacheKey]types.EpochGroupData
+	mu                       sync.RWMutex
+	draftWriterMu            sync.RWMutex // held by draft writers; block cache readers take RLock so they wait for no draft writer
+	draftWriteHolder         int64        // goroutine id of current draft writer (reentrancy)
+	draftWriteCount          int32        // reentrant lock count
+	inited                   bool
+	current                  uint64
+	previous                 uint64
+	currentDirty             bool
+	m                        map[epochGroupCacheKey]types.EpochGroupData
 	currentEpochRequestCount atomic.Int64
 }
 

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -23,10 +23,7 @@ func (k msgServer) ClaimRewards(goCtx context.Context, msg *types.MsgClaimReward
 	if err := k.CheckPermission(goCtx, msg, ActiveParticipantPermission, PreviousActiveParticipantPermission); err != nil {
 		return nil, err
 	}
-	ctx, err := k.Keeper.InjectParamsIntoContext(sdk.UnwrapSDKContext(goCtx))
-	if err != nil {
-		return nil, err
-	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	settleAmount, response := k.validateRequest(ctx, msg)
 	if response != nil {

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -2,18 +2,29 @@ package keeper
 
 import (
 	"context"
+	"strconv"
 
 	sdkerrors "cosmossdk.io/errors"
-	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/calculations"
 	"github.com/productscience/inference/x/inference/types"
 )
 
 func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishInference) (*types.MsgFinishInferenceResponse, error) {
+	if err := k.CheckPermission(goCtx, msg, ActiveParticipantPermission, PreviousActiveParticipantPermission); err != nil {
+		// do not return failedFinish here. The entire transaction should fail here since permissions will all
+		// have the same result
+		return nil, err
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	k.LogInfo("FinishInference", types.Inferences, "inference_id", msg.InferenceId, "executed_by", msg.ExecutedBy, "created_by", msg.Creator)
+	if msg.Creator != msg.ExecutedBy {
+		err := sdkerrors.Wrapf(types.ErrInferenceRoleMismatch, "creator (%s) must equal executed_by (%s)", msg.Creator, msg.ExecutedBy)
+		k.LogError("FinishInference: creator-role invariant failed", types.Inferences, "error", err)
+		return failedFinish(ctx, err, msg), nil
+	}
 
 	if msg.PromptTokenCount > types.MaxAllowedTokens {
 		return failedFinish(ctx, sdkerrors.Wrapf(types.ErrTokenCountOutOfRange, "prompt_token_count exceeds limit (%d > %d)", msg.PromptTokenCount, types.MaxAllowedTokens), msg), nil
@@ -54,12 +65,6 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 		return failedFinish(ctx, sdkerrors.Wrap(types.ErrParticipantNotFound, msg.TransferredBy), msg), nil
 	}
 
-	err := k.verifyFinishKeys(ctx, msg, &transferAgent, &requestor, &executor)
-	if err != nil {
-		k.LogError("FinishInference: verifyKeys failed", types.Inferences, "error", err)
-		return failedFinish(ctx, sdkerrors.Wrap(types.ErrInvalidSignature, err.Error()), msg), nil
-	}
-
 	existingInference, found := k.GetInference(ctx, msg.InferenceId)
 
 	if found && existingInference.FinishedProcessed() {
@@ -74,6 +79,34 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 			"executedBy", msg.ExecutedBy)
 		return failedFinish(ctx, sdkerrors.Wrap(types.ErrInferenceExpired, "inference has already expired"), msg), nil
 	}
+
+	// Signature verification policy:
+	// - Start first: finish performs equality checks only (no TA/dev re-verification).
+	// - Finish first: verify dev + TA signatures.
+	// - Executor signature verification is disabled by policy in both paths.
+	if existingInference.StartProcessed() {
+		if err := k.compareDevComponents(msg, &existingInference); err != nil {
+			k.LogError("FinishInference: dev component mismatch", types.Inferences, "error", err, "inferenceId", msg.InferenceId)
+			return failedFinish(ctx, err, msg), nil
+		}
+		if err := k.compareFinishTAComponents(msg, &existingInference); err != nil {
+			k.LogError("FinishInference: TA component mismatch", types.Inferences, "error", err, "inferenceId", msg.InferenceId)
+			return failedFinish(ctx, err, msg), nil
+		}
+		if err := k.compareFinishModelField(msg, &existingInference); err != nil {
+			k.LogError("FinishInference: model field mismatch", types.Inferences, "error", err, "inferenceId", msg.InferenceId)
+			return failedFinish(ctx, err, msg), nil
+		}
+		k.LogDebug("FinishInference: cryptographic signature verification skipped; dev and TA components compared for consistency", types.Inferences, "inferenceId", msg.InferenceId)
+	} else {
+		err := k.verifyFinishKeys(ctx, msg, &transferAgent, &requestor)
+		if err != nil {
+			k.LogError("FinishInference: verifyFinishKeys failed", types.Inferences, "error", err)
+			return failedFinish(ctx, sdkerrors.Wrap(types.ErrInvalidSignature, err.Error()), msg), nil
+		}
+		k.LogDebug("FinishInference: dev and TA signatures cryptographically verified", types.Inferences, "inferenceId", msg.InferenceId)
+	}
+	k.LogDebug("FinishInference: executor signature verification disabled by policy", types.Inferences, "inferenceId", msg.InferenceId)
 
 	// Record the current price only if this is the first message (StartInference not processed yet)
 	// This ensures consistent pricing regardless of message arrival order
@@ -101,19 +134,21 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 		return failedFinish(ctx, err, msg), nil
 	}
 
-	finalInference, err := k.processInferencePayments(ctx, inference, payments, true)
+	finalInference, err := k.processInferencePayments(ctx, inference, payments, true, &executor)
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
+	}
+	if finalInference.IsCompleted() {
+		k.handleInferenceCompleted(ctx, finalInference, &executor)
+	}
+	if shouldPersistParticipant(finalInference, payments, &executor) {
+		if err := k.SetParticipant(ctx, executor); err != nil {
+			return failedFinish(ctx, err, msg), nil
+		}
 	}
 	err = k.SetInference(ctx, *finalInference)
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
-	}
-	if existingInference.IsCompleted() {
-		err := k.handleInferenceCompleted(ctx, finalInference)
-		if err != nil {
-			return failedFinish(ctx, err, msg), nil
-		}
 	}
 
 	return &types.MsgFinishInferenceResponse{InferenceIndex: msg.InferenceId}, nil
@@ -129,11 +164,10 @@ func failedFinish(ctx sdk.Context, err error, msg *types.MsgFinishInference) *ty
 	}
 }
 
-func (k msgServer) verifyFinishKeys(ctx sdk.Context, msg *types.MsgFinishInference, transferAgent *types.Participant, requestor *types.Participant, executor *types.Participant) error {
+func (k msgServer) verifyFinishKeys(ctx sdk.Context, msg *types.MsgFinishInference, transferAgent *types.Participant, requestor *types.Participant) error {
 	// Hash-based signature verification (post-upgrade flow)
 	// Dev signs: original_prompt_hash + timestamp + ta_address
 	// TA signs: prompt_hash + timestamp + ta_address + executor_address
-	// Executor signs: prompt_hash + timestamp + ta_address + executor_address
 	devComponents := getFinishDevSignatureComponents(msg)
 	taComponents := getFinishTASignatureComponents(msg)
 
@@ -152,14 +186,6 @@ func (k msgServer) verifyFinishKeys(ctx sdk.Context, msg *types.MsgFinishInferen
 
 	// Verify TA signature (prompt_hash)
 	if err := k.verifyTASignature(ctx, msg, taComponents, transferAgent); err != nil {
-		return err
-	}
-
-	// Verify Executor signature (prompt_hash)
-	if err := calculations.VerifyKeys(ctx, taComponents, calculations.SignatureData{
-		ExecutorSignature: msg.ExecutorSignature, Executor: executor,
-	}, k); err != nil {
-		k.LogError("FinishInference: Executor signature failed", types.Inferences, "error", err)
 		return err
 	}
 
@@ -217,102 +243,102 @@ func getFinishTASignatureComponents(msg *types.MsgFinishInference) calculations.
 	}
 }
 
-func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *types.Inference) error {
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			"inference_finished",
-			sdk.NewAttribute("inference_id", existingInference.InferenceId),
-		),
-	)
+func (k msgServer) compareFinishTAComponents(msg *types.MsgFinishInference, inference *types.Inference) error {
+	if inference.PromptHash != msg.PromptHash {
+		return sdkerrors.Wrapf(
+			types.ErrTAComponentMismatch,
+			"prompt_hash mismatch: finish=%s start=%s",
+			msg.PromptHash,
+			inference.PromptHash,
+		)
+	}
+	if inference.RequestTimestamp != msg.RequestTimestamp {
+		return sdkerrors.Wrapf(
+			types.ErrTAComponentMismatch,
+			"request_timestamp mismatch: finish=%d start=%d",
+			msg.RequestTimestamp,
+			inference.RequestTimestamp,
+		)
+	}
+	if inference.TransferredBy != msg.TransferredBy {
+		return sdkerrors.Wrapf(
+			types.ErrTAComponentMismatch,
+			"transfer agent mismatch: finish=%s start=%s",
+			msg.TransferredBy,
+			inference.TransferredBy,
+		)
+	}
+	if inference.AssignedTo != msg.ExecutedBy {
+		return sdkerrors.Wrapf(
+			types.ErrTAComponentMismatch,
+			"executor mismatch: finish.executed_by=%s start.assigned_to=%s",
+			msg.ExecutedBy,
+			inference.AssignedTo,
+		)
+	}
+	return nil
+}
 
-	executedBy := existingInference.ExecutedBy
-	executor, found := k.GetParticipant(ctx, executedBy)
-	if !found {
-		k.LogError("handleInferenceCompleted: executor not found", types.Inferences, "executed_by", executedBy)
+func (k msgServer) compareFinishModelField(msg *types.MsgFinishInference, inference *types.Inference) error {
+	// inference.Model CANNOT be "" here, Model is a required field for StartInference message
+	if inference.Model != "" && inference.Model != msg.Model {
+		return sdkerrors.Wrapf(
+			types.ErrInferenceRoleMismatch,
+			"model mismatch: finish=%s start=%s",
+			msg.Model,
+			inference.Model,
+		)
+	}
+	return nil
+}
+
+func (k msgServer) handleInferenceCompleted(ctx sdk.Context, inference *types.Inference, executor *types.Participant) {
+	if executor == nil {
+		k.LogWarn("handleInferenceCompleted: executor not loaded, skipping participant updates", types.Inferences, "executed_by", inference.ExecutedBy)
 	} else {
+		ensureParticipantEpochStats(executor)
 		executor.CurrentEpochStats.InferenceCount++
-		executor.LastInferenceTime = existingInference.EndBlockTimestamp
-		if err := k.SetParticipant(ctx, executor); err != nil {
-			return err
-		}
-
+		executor.LastInferenceTime = inference.EndBlockTimestamp
 	}
 
 	effectiveEpoch, found := k.GetEffectiveEpoch(ctx)
 	if !found {
-		k.LogError("Effective Epoch Index not found", types.EpochGroup)
-		return types.ErrEffectiveEpochNotFound.Wrapf("handleInferenceCompleted: Effective Epoch Index not found")
+		k.LogWarn("handleInferenceCompleted: effective epoch not found, defaulting epoch fields to zero", types.EpochGroup)
+		inference.EpochPocStartBlockHeight = 0
+		inference.EpochId = 0
+	} else {
+		inference.EpochPocStartBlockHeight = uint64(effectiveEpoch.PocStartBlockHeight)
+		inference.EpochId = effectiveEpoch.Index
 	}
-	currentEpochGroup, err := k.GetEpochGroupForEpoch(ctx, *effectiveEpoch)
-	if err != nil {
-		k.LogError("Unable to get current Epoch Group", types.EpochGroup, "err", err)
-		return err
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		"inference_finished",
+		buildInferenceFinishedEventAttributes(inference)...,
+	))
+
+	if err := k.EnqueueFinishedInference(ctx, inference.InferenceId); err != nil {
+		k.LogError("Unable to enqueue pending inference validation", types.Validation, "inference_id", inference.InferenceId, "block_height", ctx.BlockHeight(), "err", err)
+		return
 	}
 
-	existingInference.EpochPocStartBlockHeight = uint64(effectiveEpoch.PocStartBlockHeight)
-	existingInference.EpochId = effectiveEpoch.Index
-
-	executorPower := uint64(0)
-	executorReputation := int32(0)
-	for _, weight := range currentEpochGroup.GroupData.ValidationWeights {
-		if weight.MemberAddress == existingInference.ExecutedBy {
-			executorPower = uint64(weight.Weight)
-			executorReputation = weight.Reputation
-			break
-		}
-	}
-
-	modelEpochGroup, err := currentEpochGroup.GetSubGroup(ctx, existingInference.Model)
-	if err != nil {
-		k.LogError("Unable to get model Epoch Group", types.EpochGroup, "err", err)
-		return err
-	}
-
-	// For TrafficBasis
-	// we don't use here precise (already incremented) number of requests because it's not yet committed to the store,
-	// and can cause non-deterministic results.
-	// Moreover we prefer performance and determinism over precision here,
-	// so we just use value from previous committed block.
-
-	//We can use here exact number: currentEpochGroup.GroupData.NumberOfRequests+epochRequestsCount
-	//But it can be undetermenistic in cosmos optimistic concurrent environment
-	inferenceDetails := types.InferenceValidationDetails{
-		InferenceId:          existingInference.InferenceId,
-		ExecutorId:           existingInference.ExecutedBy,
-		ExecutorReputation:   executorReputation,
-		TrafficBasis:         uint64(math.Max(currentEpochGroup.GroupData.NumberOfRequests, currentEpochGroup.GroupData.PreviousEpochRequests)),
-		ExecutorPower:        executorPower,
-		EpochId:              effectiveEpoch.Index,
-		Model:                existingInference.Model,
-		TotalPower:           uint64(modelEpochGroup.GroupData.TotalWeight),
-		CreatedAtBlockHeight: ctx.BlockHeight(),
-	}
-	if inferenceDetails.TotalPower == inferenceDetails.ExecutorPower {
-		k.LogWarn("Executor Power equals Total Power", types.Validation,
-			"model", existingInference.Model,
-			"epoch_id", currentEpochGroup.GroupData.EpochGroupId,
-			"epoch_start_block_height", currentEpochGroup.GroupData.PocStartBlockHeight,
-			"group_id", modelEpochGroup.GroupData.EpochGroupId,
-			"inference_id", existingInference.InferenceId,
-			"executor_id", inferenceDetails.ExecutorId,
-			"executor_power", inferenceDetails.ExecutorPower,
-		)
-	}
-	k.LogDebug(
-		"Adding Inference Validation Details",
-		types.Validation,
-		"inference_id", inferenceDetails.InferenceId,
-		"epoch_id", inferenceDetails.EpochId,
-		"executor_id", inferenceDetails.ExecutorId,
-		"executor_power", inferenceDetails.ExecutorPower,
-		"executor_reputation", inferenceDetails.ExecutorReputation,
-		"traffic_basis", inferenceDetails.TrafficBasis,
+	k.LogDebug("Queued inference for deferred validation details processing", types.Validation,
+		"inference_id", inference.InferenceId,
+		"epoch_id", inference.EpochId,
+		"block_height", ctx.BlockHeight(),
 	)
-	k.SetInferenceValidationDetails(ctx, inferenceDetails)
-	err = k.SetInference(ctx, *existingInference)
-	if err != nil {
-		return err
-	}
+}
 
-	return nil
+// buildInferenceFinishedEventAttributes emits only fields required for dev-stats off-chain migration.
+func buildInferenceFinishedEventAttributes(inference *types.Inference) []sdk.Attribute {
+	return []sdk.Attribute{
+		sdk.NewAttribute("inference_id", inference.InferenceId),
+		sdk.NewAttribute("requested_by", inference.RequestedBy),
+		sdk.NewAttribute("model", inference.Model),
+		sdk.NewAttribute("status", inference.Status.String()),
+		sdk.NewAttribute("epoch_id", strconv.FormatUint(inference.EpochId, 10)),
+		sdk.NewAttribute("prompt_token_count", strconv.FormatUint(inference.PromptTokenCount, 10)),
+		sdk.NewAttribute("completion_token_count", strconv.FormatUint(inference.CompletionTokenCount, 10)),
+		sdk.NewAttribute("actual_cost_in_coins", strconv.FormatInt(inference.ActualCost, 10)),
+		sdk.NewAttribute("start_block_timestamp", strconv.FormatInt(inference.StartBlockTimestamp, 10)),
+		sdk.NewAttribute("end_block_timestamp", strconv.FormatInt(inference.EndBlockTimestamp, 10)),
+	}
 }

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -274,6 +274,9 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 	// and can cause undeterministic results.
 	// Moreover we prefer performance and determenism over precision here,
 	// so we just use value from previous committed block.
+
+	//We can use here exact number: currentEpochGroup.GroupData.NumberOfRequests+epochRequestsCount
+	//But it can be undetermenistic in cosmos optimistic concurrent environment
 	inferenceDetails := types.InferenceValidationDetails{
 		InferenceId:          existingInference.InferenceId,
 		ExecutorId:           existingInference.ExecutedBy,

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -314,8 +314,5 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 		return err
 	}
 
-	// Increment current epoch group request count after all possible errors are returned that can cause rollback.
-	// This ensures that the number of requests is always accurate and consistent.
-	k.IncrementCurrentEpochGroupRequestCount(ctx)
 	return nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -251,7 +251,6 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 
 	existingInference.EpochPocStartBlockHeight = uint64(effectiveEpoch.PocStartBlockHeight)
 	existingInference.EpochId = effectiveEpoch.Index
-	k.IncrementCurrentEpochGroupRequestCount(ctx)
 
 	executorPower := uint64(0)
 	executorReputation := int32(0)
@@ -314,5 +313,9 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 	if err != nil {
 		return err
 	}
+
+	// Increment current epoch group request count after all possible errors are returned that can cause rollback.
+	// This ensures that the number of requests is always accurate and consistent.
+	k.IncrementCurrentEpochGroupRequestCount(ctx)
 	return nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -2,34 +2,18 @@ package keeper
 
 import (
 	"context"
-	"strconv"
 
 	sdkerrors "cosmossdk.io/errors"
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/calculations"
 	"github.com/productscience/inference/x/inference/types"
 )
 
 func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishInference) (*types.MsgFinishInferenceResponse, error) {
-	if err := k.CheckPermission(goCtx, msg, ActiveParticipantPermission, PreviousActiveParticipantPermission); err != nil {
-		// do not return failedFinish here. The entire transaction should fail here since permissions will all
-		// have the same result
-		return nil, err
-	}
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	// Inject cache once at the entry point
-	ctx, err := k.Keeper.InjectParamsIntoContext(sdk.UnwrapSDKContext(goCtx))
-	if err != nil {
-		k.LogWarn("FinishInference: failed to inject params", types.Inferences, "error", err)
-	}
 
 	k.LogInfo("FinishInference", types.Inferences, "inference_id", msg.InferenceId, "executed_by", msg.ExecutedBy, "created_by", msg.Creator)
-	if msg.Creator != msg.ExecutedBy {
-		err := sdkerrors.Wrapf(types.ErrInferenceRoleMismatch, "creator (%s) must equal executed_by (%s)", msg.Creator, msg.ExecutedBy)
-		k.LogError("FinishInference: creator-role invariant failed", types.Inferences, "error", err)
-		return failedFinish(ctx, err, msg), nil
-	}
 
 	if msg.PromptTokenCount > types.MaxAllowedTokens {
 		return failedFinish(ctx, sdkerrors.Wrapf(types.ErrTokenCountOutOfRange, "prompt_token_count exceeds limit (%d > %d)", msg.PromptTokenCount, types.MaxAllowedTokens), msg), nil
@@ -70,6 +54,12 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 		return failedFinish(ctx, sdkerrors.Wrap(types.ErrParticipantNotFound, msg.TransferredBy), msg), nil
 	}
 
+	err := k.verifyFinishKeys(ctx, msg, &transferAgent, &requestor, &executor)
+	if err != nil {
+		k.LogError("FinishInference: verifyKeys failed", types.Inferences, "error", err)
+		return failedFinish(ctx, sdkerrors.Wrap(types.ErrInvalidSignature, err.Error()), msg), nil
+	}
+
 	existingInference, found := k.GetInference(ctx, msg.InferenceId)
 
 	if found && existingInference.FinishedProcessed() {
@@ -84,34 +74,6 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 			"executedBy", msg.ExecutedBy)
 		return failedFinish(ctx, sdkerrors.Wrap(types.ErrInferenceExpired, "inference has already expired"), msg), nil
 	}
-
-	// Signature verification policy:
-	// - Start first: finish performs equality checks only (no TA/dev re-verification).
-	// - Finish first: verify dev + TA signatures.
-	// - Executor signature verification is disabled by policy in both paths.
-	if existingInference.StartProcessed() {
-		if err := k.compareDevComponents(msg, &existingInference); err != nil {
-			k.LogError("FinishInference: dev component mismatch", types.Inferences, "error", err, "inferenceId", msg.InferenceId)
-			return failedFinish(ctx, err, msg), nil
-		}
-		if err := k.compareFinishTAComponents(msg, &existingInference); err != nil {
-			k.LogError("FinishInference: TA component mismatch", types.Inferences, "error", err, "inferenceId", msg.InferenceId)
-			return failedFinish(ctx, err, msg), nil
-		}
-		if err := k.compareFinishModelField(msg, &existingInference); err != nil {
-			k.LogError("FinishInference: model field mismatch", types.Inferences, "error", err, "inferenceId", msg.InferenceId)
-			return failedFinish(ctx, err, msg), nil
-		}
-		k.LogDebug("FinishInference: cryptographic signature verification skipped; dev and TA components compared for consistency", types.Inferences, "inferenceId", msg.InferenceId)
-	} else {
-		err := k.verifyFinishKeys(ctx, msg, &transferAgent, &requestor)
-		if err != nil {
-			k.LogError("FinishInference: verifyFinishKeys failed", types.Inferences, "error", err)
-			return failedFinish(ctx, sdkerrors.Wrap(types.ErrInvalidSignature, err.Error()), msg), nil
-		}
-		k.LogDebug("FinishInference: dev and TA signatures cryptographically verified", types.Inferences, "inferenceId", msg.InferenceId)
-	}
-	k.LogDebug("FinishInference: executor signature verification disabled by policy", types.Inferences, "inferenceId", msg.InferenceId)
 
 	// Record the current price only if this is the first message (StartInference not processed yet)
 	// This ensures consistent pricing regardless of message arrival order
@@ -139,21 +101,19 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 		return failedFinish(ctx, err, msg), nil
 	}
 
-	finalInference, err := k.processInferencePayments(ctx, inference, payments, true, &executor)
+	finalInference, err := k.processInferencePayments(ctx, inference, payments, true)
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
-	}
-	if finalInference.IsCompleted() {
-		k.handleInferenceCompleted(ctx, finalInference, &executor)
-	}
-	if shouldPersistParticipant(finalInference, payments, &executor) {
-		if err := k.SetParticipant(ctx, executor); err != nil {
-			return failedFinish(ctx, err, msg), nil
-		}
 	}
 	err = k.SetInference(ctx, *finalInference)
 	if err != nil {
 		return failedFinish(ctx, err, msg), nil
+	}
+	if existingInference.IsCompleted() {
+		err := k.handleInferenceCompleted(ctx, finalInference)
+		if err != nil {
+			return failedFinish(ctx, err, msg), nil
+		}
 	}
 
 	return &types.MsgFinishInferenceResponse{InferenceIndex: msg.InferenceId}, nil
@@ -169,10 +129,11 @@ func failedFinish(ctx sdk.Context, err error, msg *types.MsgFinishInference) *ty
 	}
 }
 
-func (k msgServer) verifyFinishKeys(ctx sdk.Context, msg *types.MsgFinishInference, transferAgent *types.Participant, requestor *types.Participant) error {
+func (k msgServer) verifyFinishKeys(ctx sdk.Context, msg *types.MsgFinishInference, transferAgent *types.Participant, requestor *types.Participant, executor *types.Participant) error {
 	// Hash-based signature verification (post-upgrade flow)
 	// Dev signs: original_prompt_hash + timestamp + ta_address
 	// TA signs: prompt_hash + timestamp + ta_address + executor_address
+	// Executor signs: prompt_hash + timestamp + ta_address + executor_address
 	devComponents := getFinishDevSignatureComponents(msg)
 	taComponents := getFinishTASignatureComponents(msg)
 
@@ -191,6 +152,14 @@ func (k msgServer) verifyFinishKeys(ctx sdk.Context, msg *types.MsgFinishInferen
 
 	// Verify TA signature (prompt_hash)
 	if err := k.verifyTASignature(ctx, msg, taComponents, transferAgent); err != nil {
+		return err
+	}
+
+	// Verify Executor signature (prompt_hash)
+	if err := calculations.VerifyKeys(ctx, taComponents, calculations.SignatureData{
+		ExecutorSignature: msg.ExecutorSignature, Executor: executor,
+	}, k); err != nil {
+		k.LogError("FinishInference: Executor signature failed", types.Inferences, "error", err)
 		return err
 	}
 
@@ -248,102 +217,99 @@ func getFinishTASignatureComponents(msg *types.MsgFinishInference) calculations.
 	}
 }
 
-func (k msgServer) compareFinishTAComponents(msg *types.MsgFinishInference, inference *types.Inference) error {
-	if inference.PromptHash != msg.PromptHash {
-		return sdkerrors.Wrapf(
-			types.ErrTAComponentMismatch,
-			"prompt_hash mismatch: finish=%s start=%s",
-			msg.PromptHash,
-			inference.PromptHash,
-		)
-	}
-	if inference.RequestTimestamp != msg.RequestTimestamp {
-		return sdkerrors.Wrapf(
-			types.ErrTAComponentMismatch,
-			"request_timestamp mismatch: finish=%d start=%d",
-			msg.RequestTimestamp,
-			inference.RequestTimestamp,
-		)
-	}
-	if inference.TransferredBy != msg.TransferredBy {
-		return sdkerrors.Wrapf(
-			types.ErrTAComponentMismatch,
-			"transfer agent mismatch: finish=%s start=%s",
-			msg.TransferredBy,
-			inference.TransferredBy,
-		)
-	}
-	if inference.AssignedTo != msg.ExecutedBy {
-		return sdkerrors.Wrapf(
-			types.ErrTAComponentMismatch,
-			"executor mismatch: finish.executed_by=%s start.assigned_to=%s",
-			msg.ExecutedBy,
-			inference.AssignedTo,
-		)
-	}
-	return nil
-}
+func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *types.Inference) error {
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			"inference_finished",
+			sdk.NewAttribute("inference_id", existingInference.InferenceId),
+		),
+	)
 
-func (k msgServer) compareFinishModelField(msg *types.MsgFinishInference, inference *types.Inference) error {
-	// inference.Model CANNOT be "" here, Model is a required field for StartInference message
-	if inference.Model != "" && inference.Model != msg.Model {
-		return sdkerrors.Wrapf(
-			types.ErrInferenceRoleMismatch,
-			"model mismatch: finish=%s start=%s",
-			msg.Model,
-			inference.Model,
-		)
-	}
-	return nil
-}
-
-func (k msgServer) handleInferenceCompleted(ctx sdk.Context, inference *types.Inference, executor *types.Participant) {
-	if executor == nil {
-		k.LogWarn("handleInferenceCompleted: executor not loaded, skipping participant updates", types.Inferences, "executed_by", inference.ExecutedBy)
+	executedBy := existingInference.ExecutedBy
+	executor, found := k.GetParticipant(ctx, executedBy)
+	if !found {
+		k.LogError("handleInferenceCompleted: executor not found", types.Inferences, "executed_by", executedBy)
 	} else {
-		ensureParticipantEpochStats(executor)
 		executor.CurrentEpochStats.InferenceCount++
-		executor.LastInferenceTime = inference.EndBlockTimestamp
+		executor.LastInferenceTime = existingInference.EndBlockTimestamp
+		if err := k.SetParticipant(ctx, executor); err != nil {
+			return err
+		}
+
 	}
 
 	effectiveEpoch, found := k.GetEffectiveEpoch(ctx)
 	if !found {
-		k.LogWarn("handleInferenceCompleted: effective epoch not found, defaulting epoch fields to zero", types.EpochGroup)
-		inference.EpochPocStartBlockHeight = 0
-		inference.EpochId = 0
-	} else {
-		inference.EpochPocStartBlockHeight = uint64(effectiveEpoch.PocStartBlockHeight)
-		inference.EpochId = effectiveEpoch.Index
+		k.LogError("Effective Epoch Index not found", types.EpochGroup)
+		return types.ErrEffectiveEpochNotFound.Wrapf("handleInferenceCompleted: Effective Epoch Index not found")
 	}
-	ctx.EventManager().EmitEvent(sdk.NewEvent(
-		"inference_finished",
-		buildInferenceFinishedEventAttributes(inference)...,
-	))
-
-	if err := k.EnqueueFinishedInference(ctx, inference.InferenceId); err != nil {
-		k.LogError("Unable to enqueue pending inference validation", types.Validation, "inference_id", inference.InferenceId, "block_height", ctx.BlockHeight(), "err", err)
-		return
+	currentEpochGroup, err := k.GetEpochGroupForEpoch(ctx, *effectiveEpoch)
+	if err != nil {
+		k.LogError("Unable to get current Epoch Group", types.EpochGroup, "err", err)
+		return err
 	}
 
-	k.LogDebug("Queued inference for deferred validation details processing", types.Validation,
-		"inference_id", inference.InferenceId,
-		"epoch_id", inference.EpochId,
-		"block_height", ctx.BlockHeight(),
+	existingInference.EpochPocStartBlockHeight = uint64(effectiveEpoch.PocStartBlockHeight)
+	existingInference.EpochId = effectiveEpoch.Index
+	k.IncrementCurrentEpochGroupRequestCount(ctx)
+
+	executorPower := uint64(0)
+	executorReputation := int32(0)
+	for _, weight := range currentEpochGroup.GroupData.ValidationWeights {
+		if weight.MemberAddress == existingInference.ExecutedBy {
+			executorPower = uint64(weight.Weight)
+			executorReputation = weight.Reputation
+			break
+		}
+	}
+
+	modelEpochGroup, err := currentEpochGroup.GetSubGroup(ctx, existingInference.Model)
+	if err != nil {
+		k.LogError("Unable to get model Epoch Group", types.EpochGroup, "err", err)
+		return err
+	}
+
+	// For TrafficBasis
+	// we don't use here precise (already incremented) number of requests because it's not yet committed to the store,
+	// and can cause undeterministic results.
+	// Moreover we prefer performance and determenism over precision here,
+	// so we just use value from previous committed block.
+	inferenceDetails := types.InferenceValidationDetails{
+		InferenceId:          existingInference.InferenceId,
+		ExecutorId:           existingInference.ExecutedBy,
+		ExecutorReputation:   executorReputation,
+		TrafficBasis:         uint64(math.Max(currentEpochGroup.GroupData.NumberOfRequests, currentEpochGroup.GroupData.PreviousEpochRequests)),
+		ExecutorPower:        executorPower,
+		EpochId:              effectiveEpoch.Index,
+		Model:                existingInference.Model,
+		TotalPower:           uint64(modelEpochGroup.GroupData.TotalWeight),
+		CreatedAtBlockHeight: ctx.BlockHeight(),
+	}
+	if inferenceDetails.TotalPower == inferenceDetails.ExecutorPower {
+		k.LogWarn("Executor Power equals Total Power", types.Validation,
+			"model", existingInference.Model,
+			"epoch_id", currentEpochGroup.GroupData.EpochGroupId,
+			"epoch_start_block_height", currentEpochGroup.GroupData.PocStartBlockHeight,
+			"group_id", modelEpochGroup.GroupData.EpochGroupId,
+			"inference_id", existingInference.InferenceId,
+			"executor_id", inferenceDetails.ExecutorId,
+			"executor_power", inferenceDetails.ExecutorPower,
+		)
+	}
+	k.LogDebug(
+		"Adding Inference Validation Details",
+		types.Validation,
+		"inference_id", inferenceDetails.InferenceId,
+		"epoch_id", inferenceDetails.EpochId,
+		"executor_id", inferenceDetails.ExecutorId,
+		"executor_power", inferenceDetails.ExecutorPower,
+		"executor_reputation", inferenceDetails.ExecutorReputation,
+		"traffic_basis", inferenceDetails.TrafficBasis,
 	)
-}
-
-// buildInferenceFinishedEventAttributes emits only fields required for dev-stats off-chain migration.
-func buildInferenceFinishedEventAttributes(inference *types.Inference) []sdk.Attribute {
-	return []sdk.Attribute{
-		sdk.NewAttribute("inference_id", inference.InferenceId),
-		sdk.NewAttribute("requested_by", inference.RequestedBy),
-		sdk.NewAttribute("model", inference.Model),
-		sdk.NewAttribute("status", inference.Status.String()),
-		sdk.NewAttribute("epoch_id", strconv.FormatUint(inference.EpochId, 10)),
-		sdk.NewAttribute("prompt_token_count", strconv.FormatUint(inference.PromptTokenCount, 10)),
-		sdk.NewAttribute("completion_token_count", strconv.FormatUint(inference.CompletionTokenCount, 10)),
-		sdk.NewAttribute("actual_cost_in_coins", strconv.FormatInt(inference.ActualCost, 10)),
-		sdk.NewAttribute("start_block_timestamp", strconv.FormatInt(inference.StartBlockTimestamp, 10)),
-		sdk.NewAttribute("end_block_timestamp", strconv.FormatInt(inference.EndBlockTimestamp, 10)),
+	k.SetInferenceValidationDetails(ctx, inferenceDetails)
+	err = k.SetInference(ctx, *existingInference)
+	if err != nil {
+		return err
 	}
+	return nil
 }

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -270,8 +270,8 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, existingInference *
 
 	// For TrafficBasis
 	// we don't use here precise (already incremented) number of requests because it's not yet committed to the store,
-	// and can cause undeterministic results.
-	// Moreover we prefer performance and determenism over precision here,
+	// and can cause non-deterministic results.
+	// Moreover we prefer performance and determinism over precision here,
 	// so we just use value from previous committed block.
 
 	//We can use here exact number: currentEpochGroup.GroupData.NumberOfRequests+epochRequestsCount

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -18,10 +18,7 @@ func (k msgServer) StartInference(goCtx context.Context, msg *types.MsgStartInfe
 		return nil, err
 	}
 
-	ctx, err := k.Keeper.InjectParamsIntoContext(sdk.UnwrapSDKContext(goCtx))
-	if err != nil {
-		k.LogWarn("StartInference: failed to inject params", types.Inferences, "error", err)
-	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	k.LogInfo("StartInference", types.Inferences, "inferenceId", msg.InferenceId, "creator", msg.Creator, "requestedBy", msg.RequestedBy, "model", msg.Model)
 

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -21,10 +21,8 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		return nil, err
 	}
 
-	ctx, err := k.Keeper.InjectParamsIntoContext(sdk.UnwrapSDKContext(goCtx))
-	if err != nil {
-		k.LogWarn("Validation: failed to inject params", types.Validation, "error", err)
-	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	var err error
 
 	k.LogInfo("Received MsgValidation", types.Validation,
 		"msg.Creator", msg.Creator,

--- a/inference-chain/x/inference/keeper/optimistic_store.go
+++ b/inference-chain/x/inference/keeper/optimistic_store.go
@@ -1,0 +1,736 @@
+package keeper
+
+import (
+	"context"
+	"os"
+	"sync"
+	"unsafe"
+
+	"cosmossdk.io/collections"
+	collcodec "cosmossdk.io/collections/codec"
+	corestore "cosmossdk.io/core/store"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
+)
+
+var occConflictDetectionEnabled bool
+
+func init() {
+	occConflictDetectionEnabled = os.Getenv("COSMOS_OCC_ENABLED") == "1"
+}
+
+// IsOCCConflictDetectionEnabled reports whether COSMOS_OCC_ENABLED=1 is set.
+// When enabled, read/write sets are tracked per transaction so that
+// conflicts can be detected post-execution via DetectConflicts.
+func IsOCCConflictDetectionEnabled() bool {
+	return occConflictDetectionEnabled
+}
+
+// StoreBackend plugs an OptimisticStore into any persistent storage.
+type StoreBackend[K comparable, V any] struct {
+	Load   func(ctx context.Context, key K) (V, bool)
+	Save   func(ctx context.Context, key K, val V)
+	Delete func(ctx context.Context, key K)
+	Clone  func(val V) V
+}
+
+// OptimisticStoreConfig controls which cache layers are active.
+type OptimisticStoreConfig struct {
+	BlockCacheEnabled bool
+	TxDraftEnabled    bool
+}
+
+// OptimisticStore is a generic, OCC-aware cache wrapper for any keyed store.
+// K must be comparable (used as map key). V is the value type.
+//
+// Layers (checked in order on Get):
+//  1. Tx draft (per-tx, context-scoped, write-behind)
+//  2. Block cache (per-block, in-memory, flushed to store in EndBlock)
+//  3. Store backend (persistent)
+type OptimisticStore[K comparable, V any] struct {
+	mu        sync.RWMutex
+	m         map[K]V
+	dirty     bool
+	backend   StoreBackend[K, V]
+	config    OptimisticStoreConfig
+	conflicts conflictTracker[K]
+
+	ctxKeyDraft       any
+	ctxKeyBranchDraft any
+}
+
+// NewOptimisticStore creates an OptimisticStore with the given backend and config.
+// ctxKeyDraft and ctxKeyBranchDraft must be unique context key types per store instance.
+func NewOptimisticStore[K comparable, V any](
+	backend StoreBackend[K, V],
+	config OptimisticStoreConfig,
+	ctxKeyDraft any,
+	ctxKeyBranchDraft any,
+) *OptimisticStore[K, V] {
+	return &OptimisticStore[K, V]{
+		m:                 make(map[K]V),
+		backend:           backend,
+		config:            config,
+		ctxKeyDraft:       ctxKeyDraft,
+		ctxKeyBranchDraft: ctxKeyBranchDraft,
+	}
+}
+
+// ---------- conflict tracker ----------
+
+type conflictTracker[K comparable] struct {
+	mu        sync.Mutex
+	readSets  map[uintptr]map[K]struct{}
+	writeSets map[uintptr]map[K]struct{}
+}
+
+func (t *conflictTracker[K]) reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.readSets = make(map[uintptr]map[K]struct{})
+	t.writeSets = make(map[uintptr]map[K]struct{})
+}
+
+func (t *conflictTracker[K]) registerTx(txID uintptr) {
+	if txID == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.readSets == nil {
+		t.readSets = make(map[uintptr]map[K]struct{})
+		t.writeSets = make(map[uintptr]map[K]struct{})
+	}
+	if _, ok := t.readSets[txID]; !ok {
+		t.readSets[txID] = make(map[K]struct{})
+	}
+	if _, ok := t.writeSets[txID]; !ok {
+		t.writeSets[txID] = make(map[K]struct{})
+	}
+}
+
+func (t *conflictTracker[K]) recordRead(txID uintptr, key K) {
+	if !occConflictDetectionEnabled || txID == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if rs, ok := t.readSets[txID]; ok {
+		rs[key] = struct{}{}
+	}
+}
+
+func (t *conflictTracker[K]) recordWrite(txID uintptr, key K) {
+	if !occConflictDetectionEnabled || txID == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if ws, ok := t.writeSets[txID]; ok {
+		ws[key] = struct{}{}
+	}
+}
+
+func (t *conflictTracker[K]) unregisterTx(txID uintptr) {
+	if txID == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.readSets, txID)
+	delete(t.writeSets, txID)
+}
+
+func (t *conflictTracker[K]) detectConflicts() (conflictedReads, conflictedWrites []uintptr) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	seenR := make(map[uintptr]struct{})
+	seenW := make(map[uintptr]struct{})
+
+	for readerTx, readKeys := range t.readSets {
+		for writerTx, writeKeys := range t.writeSets {
+			if readerTx == writerTx {
+				continue
+			}
+			for key := range readKeys {
+				if _, written := writeKeys[key]; written {
+					if _, already := seenR[readerTx]; !already {
+						seenR[readerTx] = struct{}{}
+						conflictedReads = append(conflictedReads, readerTx)
+					}
+					if _, already := seenW[writerTx]; !already {
+						seenW[writerTx] = struct{}{}
+						conflictedWrites = append(conflictedWrites, writerTx)
+					}
+					break
+				}
+			}
+		}
+	}
+
+	txIDs := make([]uintptr, 0, len(t.writeSets))
+	for txID := range t.writeSets {
+		txIDs = append(txIDs, txID)
+	}
+	for i := 0; i < len(txIDs); i++ {
+		for j := i + 1; j < len(txIDs); j++ {
+			a, b := txIDs[i], txIDs[j]
+			for key := range t.writeSets[a] {
+				if _, ok := t.writeSets[b][key]; ok {
+					if _, already := seenW[a]; !already {
+						seenW[a] = struct{}{}
+						conflictedWrites = append(conflictedWrites, a)
+					}
+					if _, already := seenW[b]; !already {
+						seenW[b] = struct{}{}
+						conflictedWrites = append(conflictedWrites, b)
+					}
+					break
+				}
+			}
+		}
+	}
+	return
+}
+
+// ---------- draft (tx-scoped write-behind) ----------
+
+type storeDraft[K comparable, V any] struct {
+	m       map[K]V
+	removed map[K]struct{}
+}
+
+type lazyStoreDraft[K comparable, V any] struct {
+	once sync.Once
+	d    *storeDraft[K, V]
+}
+
+func (l *lazyStoreDraft[K, V]) get() *storeDraft[K, V] {
+	return l.d
+}
+
+func (l *lazyStoreDraft[K, V]) getOrCreate() *storeDraft[K, V] {
+	l.once.Do(func() {
+		l.d = &storeDraft[K, V]{
+			m:       make(map[K]V),
+			removed: make(map[K]struct{}),
+		}
+	})
+	return l.d
+}
+
+// ---------- context helpers ----------
+
+func (s *OptimisticStore[K, V]) txID(ctx context.Context) uintptr {
+	v := ctx.Value(s.ctxKeyDraft)
+	if v == nil {
+		return 0
+	}
+	if p, ok := v.(*lazyStoreDraft[K, V]); ok {
+		return uintptr(unsafe.Pointer(p))
+	}
+	return 0
+}
+
+// WithDraft attaches a lazy tx-scoped draft to ctx. Call at tx start (AnteHandler).
+func (s *OptimisticStore[K, V]) WithDraft(ctx context.Context) context.Context {
+	if !s.config.TxDraftEnabled {
+		return ctx
+	}
+	return context.WithValue(ctx, s.ctxKeyDraft, &lazyStoreDraft[K, V]{})
+}
+
+func (s *OptimisticStore[K, V]) getDraft(ctx context.Context) *storeDraft[K, V] {
+	if ctx == nil {
+		return nil
+	}
+	if d := s.getBranchDraft(ctx); d != nil {
+		return d
+	}
+	v := ctx.Value(s.ctxKeyDraft)
+	if v == nil {
+		return nil
+	}
+	if h, ok := v.(*lazyStoreDraft[K, V]); ok {
+		return h.get()
+	}
+	return nil
+}
+
+func (s *OptimisticStore[K, V]) getBranchDraft(ctx context.Context) *storeDraft[K, V] {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(s.ctxKeyBranchDraft)
+	if v == nil {
+		return nil
+	}
+	if h, ok := v.(*lazyStoreDraft[K, V]); ok {
+		return h.get()
+	}
+	return nil
+}
+
+func (s *OptimisticStore[K, V]) getDraftForWrite(ctx context.Context) *storeDraft[K, V] {
+	if ctx == nil {
+		return nil
+	}
+	if v := ctx.Value(s.ctxKeyBranchDraft); v != nil {
+		if h, ok := v.(*lazyStoreDraft[K, V]); ok {
+			return h.getOrCreate()
+		}
+	}
+	v := ctx.Value(s.ctxKeyDraft)
+	if v == nil {
+		return nil
+	}
+	if h, ok := v.(*lazyStoreDraft[K, V]); ok {
+		return h.getOrCreate()
+	}
+	return nil
+}
+
+// WithBranchDraft returns a new context with a branch draft layered on top.
+func (s *OptimisticStore[K, V]) WithBranchDraft(ctx context.Context) context.Context {
+	if !s.config.TxDraftEnabled {
+		return ctx
+	}
+	return context.WithValue(ctx, s.ctxKeyBranchDraft, &lazyStoreDraft[K, V]{})
+}
+
+// MergeBranch merges a branch draft into the parent draft.
+func (s *OptimisticStore[K, V]) MergeBranch(parentCtx, branchCtx context.Context) {
+	branch := s.getBranchDraft(branchCtx)
+	if branch == nil {
+		return
+	}
+	parent := s.getDraftForWrite(parentCtx)
+	if parent == nil {
+		return
+	}
+	for key, val := range branch.m {
+		parent.m[key] = s.backend.Clone(val)
+	}
+	for key := range branch.removed {
+		parent.removed[key] = struct{}{}
+		delete(parent.m, key)
+	}
+}
+
+// ---------- public CRUD ----------
+
+// Get reads the value for key. Layer order: draft → block cache → store backend.
+func (s *OptimisticStore[K, V]) Get(ctx context.Context, key K) (val V, found bool) {
+	if s.config.TxDraftEnabled {
+		if draft := s.getDraft(ctx); draft != nil {
+			if _, removed := draft.removed[key]; removed {
+				var zero V
+				return zero, false
+			}
+			if cached, ok := draft.m[key]; ok {
+				return s.backend.Clone(cached), true
+			}
+		}
+	}
+
+	if s.config.BlockCacheEnabled {
+		s.mu.RLock()
+		if cached, ok := s.m[key]; ok {
+			s.mu.RUnlock()
+			s.conflicts.recordRead(s.txID(ctx), key)
+			return s.backend.Clone(cached), true
+		}
+		s.mu.RUnlock()
+	}
+
+	val, found = s.backend.Load(ctx, key)
+	if !found {
+		var zero V
+		return zero, false
+	}
+	if s.config.BlockCacheEnabled {
+		s.mu.Lock()
+		s.m[key] = s.backend.Clone(val)
+		s.mu.Unlock()
+	}
+	s.conflicts.recordRead(s.txID(ctx), key)
+	return val, true
+}
+
+// Set writes a value. Goes to draft if available, otherwise to block cache or store.
+func (s *OptimisticStore[K, V]) Set(ctx context.Context, key K, val V) {
+	if s.config.TxDraftEnabled {
+		if draft := s.getDraftForWrite(ctx); draft != nil {
+			s.conflicts.recordWrite(s.txID(ctx), key)
+			draft.m[key] = s.backend.Clone(val)
+			delete(draft.removed, key)
+			return
+		}
+	}
+
+	if s.config.BlockCacheEnabled {
+		s.mu.Lock()
+		s.m[key] = s.backend.Clone(val)
+		s.dirty = true
+		s.mu.Unlock()
+		return
+	}
+
+	s.backend.Save(ctx, key, val)
+}
+
+// Remove deletes a value. Goes to draft tombstone if available, otherwise to block cache/store.
+func (s *OptimisticStore[K, V]) Remove(ctx context.Context, key K) {
+	if s.config.TxDraftEnabled {
+		if draft := s.getDraftForWrite(ctx); draft != nil {
+			s.conflicts.recordWrite(s.txID(ctx), key)
+			draft.removed[key] = struct{}{}
+			delete(draft.m, key)
+			return
+		}
+	}
+
+	if s.config.BlockCacheEnabled {
+		s.mu.Lock()
+		delete(s.m, key)
+		s.dirty = true
+		s.mu.Unlock()
+	}
+
+	s.backend.Delete(ctx, key)
+}
+
+// ---------- lifecycle ----------
+
+// RegisterTx registers a tx for OCC tracking.
+func (s *OptimisticStore[K, V]) RegisterTx(ctx context.Context) {
+	s.conflicts.registerTx(s.txID(ctx))
+}
+
+// CommitDraft merges the tx draft into the block cache. Call from PostHandler on success.
+func (s *OptimisticStore[K, V]) CommitDraft(ctx context.Context) {
+	txID := s.txID(ctx)
+	draft := s.getDraft(ctx)
+	if draft == nil {
+		s.conflicts.unregisterTx(txID)
+		return
+	}
+
+	if s.config.BlockCacheEnabled {
+		s.mu.Lock()
+		for key, val := range draft.m {
+			s.m[key] = s.backend.Clone(val)
+			s.dirty = true
+		}
+		for key := range draft.removed {
+			delete(s.m, key)
+			s.dirty = true
+		}
+		s.mu.Unlock()
+	} else {
+		for key, val := range draft.m {
+			s.backend.Save(ctx, key, val)
+		}
+		for key := range draft.removed {
+			s.backend.Delete(ctx, key)
+		}
+	}
+	s.conflicts.unregisterTx(txID)
+}
+
+// ReleaseDraft discards the tx draft. Call from PostHandler on failure.
+func (s *OptimisticStore[K, V]) ReleaseDraft(ctx context.Context) {
+	s.conflicts.unregisterTx(s.txID(ctx))
+}
+
+// Invalidate clears the block cache and conflict tracker. Call from BeginBlock.
+func (s *OptimisticStore[K, V]) Invalidate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m = make(map[K]V)
+	s.dirty = false
+	s.conflicts.reset()
+}
+
+// BlockCacheValues returns cloned copies of all values currently in the block cache.
+// Useful for queries that need to see uncommitted-to-store data without flushing.
+func (s *OptimisticStore[K, V]) BlockCacheValues() []V {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	vals := make([]V, 0, len(s.m))
+	for _, v := range s.m {
+		vals = append(vals, s.backend.Clone(v))
+	}
+	return vals
+}
+
+// Flush persists all dirty block-cache entries to the store backend. Call from EndBlock.
+func (s *OptimisticStore[K, V]) Flush(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.dirty {
+		return
+	}
+	for key, val := range s.m {
+		s.backend.Save(ctx, key, val)
+	}
+	s.dirty = false
+}
+
+// DetectConflicts returns txIDs involved in read-write or write-write collisions.
+func (s *OptimisticStore[K, V]) DetectConflicts() (conflictedReads, conflictedWrites []uintptr) {
+	return s.conflicts.detectConflicts()
+}
+
+// ResetConflictTracker clears all tracked read/write sets.
+func (s *OptimisticStore[K, V]) ResetConflictTracker() {
+	s.conflicts.reset()
+}
+
+// ---------- OptimisticItem (singleton sugar) ----------
+
+type singletonKey = struct{}
+
+// OptimisticItem is a singleton-keyed OptimisticStore. Use for stores like Params
+// that hold a single value rather than a map.
+type OptimisticItem[V any] struct {
+	inner *OptimisticStore[singletonKey, V]
+}
+
+func NewOptimisticItem[V any](
+	backend StoreBackend[singletonKey, V],
+	config OptimisticStoreConfig,
+	ctxKeyDraft any,
+	ctxKeyBranchDraft any,
+) *OptimisticItem[V] {
+	return &OptimisticItem[V]{
+		inner: NewOptimisticStore[singletonKey, V](backend, config, ctxKeyDraft, ctxKeyBranchDraft),
+	}
+}
+
+func (item *OptimisticItem[V]) Get(ctx context.Context) (V, bool) {
+	return item.inner.Get(ctx, singletonKey{})
+}
+
+func (item *OptimisticItem[V]) Set(ctx context.Context, val V) {
+	item.inner.Set(ctx, singletonKey{}, val)
+}
+
+func (item *OptimisticItem[V]) Store() *OptimisticStore[singletonKey, V] {
+	return item.inner
+}
+
+// ---------- OptimisticStoreGroup (batch lifecycle) ----------
+
+// optimisticStoreOps is the non-generic interface satisfied by every OptimisticStore,
+// enabling batch operations across stores with different key/value types.
+type optimisticStoreOps interface {
+	WithDraft(ctx context.Context) context.Context
+	RegisterTx(ctx context.Context)
+	CommitDraft(ctx context.Context)
+	ReleaseDraft(ctx context.Context)
+	Invalidate()
+	Flush(ctx context.Context)
+	WithBranchDraft(ctx context.Context) context.Context
+	MergeBranch(parentCtx, branchCtx context.Context)
+}
+
+// OptimisticStoreGroup collects all optimistic stores and provides batch lifecycle methods.
+type OptimisticStoreGroup struct {
+	stores []optimisticStoreOps
+}
+
+// Register adds a store to the group. Call during keeper init.
+func (g *OptimisticStoreGroup) Register(s optimisticStoreOps) {
+	g.stores = append(g.stores, s)
+}
+
+// WithDraftAll attaches tx-scoped drafts for every registered store. Call from AnteHandler.
+func (g *OptimisticStoreGroup) WithDraftAll(ctx context.Context) context.Context {
+	for _, s := range g.stores {
+		ctx = s.WithDraft(ctx)
+	}
+	return ctx
+}
+
+// RegisterTxAll registers the current tx for OCC tracking in every store.
+func (g *OptimisticStoreGroup) RegisterTxAll(ctx context.Context) {
+	for _, s := range g.stores {
+		s.RegisterTx(ctx)
+	}
+}
+
+// CommitDraftAll commits all tx drafts into the block caches. Call from PostHandler on success.
+func (g *OptimisticStoreGroup) CommitDraftAll(ctx context.Context) {
+	for _, s := range g.stores {
+		s.CommitDraft(ctx)
+	}
+}
+
+// ReleaseDraftAll discards all tx drafts. Call from PostHandler on failure.
+func (g *OptimisticStoreGroup) ReleaseDraftAll(ctx context.Context) {
+	for _, s := range g.stores {
+		s.ReleaseDraft(ctx)
+	}
+}
+
+// InvalidateAll clears all block caches and conflict trackers. Call from BeginBlock.
+func (g *OptimisticStoreGroup) InvalidateAll() {
+	for _, s := range g.stores {
+		s.Invalidate()
+	}
+}
+
+// FlushAll persists all dirty block caches to their backends. Call from EndBlock.
+func (g *OptimisticStoreGroup) FlushAll(ctx context.Context) {
+	for _, s := range g.stores {
+		s.Flush(ctx)
+	}
+}
+
+// CacheContext returns a cached SDK context with branch drafts for all registered stores.
+// Call writeCache() on success to merge both the SDK store cache and all branch drafts.
+func (g *OptimisticStoreGroup) CacheContext(ctx sdk.Context) (sdk.Context, func()) {
+	cacheCtx, writeSDKCache := ctx.CacheContext()
+	goCtx := cacheCtx.Context()
+	for _, s := range g.stores {
+		goCtx = s.WithBranchDraft(goCtx)
+	}
+	cacheCtx = cacheCtx.WithContext(goCtx)
+
+	var written bool
+	return cacheCtx, func() {
+		if written {
+			return
+		}
+		written = true
+		for _, s := range g.stores {
+			s.MergeBranch(ctx.Context(), cacheCtx.Context())
+		}
+		writeSDKCache()
+	}
+}
+
+// ---------- context key auto-generation ----------
+
+// storeCtxKey is used as a context key for drafts, auto-generated from the store name.
+type storeCtxKey struct {
+	name   string
+	branch bool
+}
+
+// ---------- smart constructors ----------
+
+// OptimisticCollMap bundles a collections.Map with an OptimisticStore that caches it.
+// CK is the comparable cache key, CollK is the collections key, V is the value (must be a proto.Message).
+type OptimisticCollMap[CK comparable, CollK, V any] struct {
+	*OptimisticStore[CK, V]
+	Map collections.Map[CollK, V]
+}
+
+// NewOptimisticCollMap creates a collections.Map AND an OptimisticStore wrapping it in one call.
+// toCollKey converts the cache key to the collections key for Load/Save/Delete.
+//
+// Usage (same params as collections.NewMap, plus config and key converter):
+//
+//	store := NewOptimisticCollMap(sb, prefix, name, keyCodec, valueCodec, config,
+//	    func(k MyCacheKey) collections.Pair[uint64, string] { return collections.Join(k.Epoch, k.ModelId) })
+func NewOptimisticCollMap[CK comparable, CollK, V any, PV interface {
+	*V
+	proto.Message
+}](
+	sb *collections.SchemaBuilder,
+	prefix collections.Prefix,
+	name string,
+	keyCodec collcodec.KeyCodec[CollK],
+	valueCodec collcodec.ValueCodec[V],
+	config OptimisticStoreConfig,
+	toCollKey func(CK) CollK,
+) *OptimisticCollMap[CK, CollK, V] {
+	collMap := collections.NewMap(sb, prefix, name, keyCodec, valueCodec)
+	backend := StoreBackend[CK, V]{
+		Load: func(ctx context.Context, key CK) (V, bool) {
+			val, err := collMap.Get(ctx, toCollKey(key))
+			if err != nil {
+				var zero V
+				return zero, false
+			}
+			return val, true
+		},
+		Save: func(ctx context.Context, key CK, val V) {
+			_ = collMap.Set(ctx, toCollKey(key), val)
+		},
+		Delete: func(ctx context.Context, key CK) {
+			_ = collMap.Remove(ctx, toCollKey(key))
+		},
+		Clone: func(val V) V {
+			pv := PV(&val)
+			cloned := proto.Clone(pv).(PV)
+			return *cloned
+		},
+	}
+	return &OptimisticCollMap[CK, CollK, V]{
+		OptimisticStore: NewOptimisticStore(backend, config,
+			storeCtxKey{name: name, branch: false},
+			storeCtxKey{name: name, branch: true},
+		),
+		Map: collMap,
+	}
+}
+
+// NewOptimisticProtoItem creates an OptimisticItem for a single proto value stored at a raw KV key.
+// Handles marshal/unmarshal and proto.Clone automatically.
+//
+// Usage:
+//
+//	paramsStore := NewOptimisticProtoItem[types.Params](storeService, cdc, types.ParamsKey, "params", config)
+func NewOptimisticProtoItem[V any, PV interface {
+	*V
+	proto.Message
+}](
+	storeService corestore.KVStoreService,
+	cdc codec.BinaryCodec,
+	kvKey []byte,
+	name string,
+	config OptimisticStoreConfig,
+) *OptimisticItem[V] {
+	backend := StoreBackend[singletonKey, V]{
+		Load: func(ctx context.Context, _ singletonKey) (V, bool) {
+			store := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+			bz := store.Get(kvKey)
+			if bz == nil {
+				var zero V
+				return zero, false
+			}
+			var val V
+			if err := cdc.Unmarshal(bz, PV(&val)); err != nil {
+				var zero V
+				return zero, false
+			}
+			return val, true
+		},
+		Save: func(ctx context.Context, _ singletonKey, val V) {
+			store := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+			bz, err := cdc.Marshal(PV(&val))
+			if err != nil {
+				return
+			}
+			store.Set(kvKey, bz)
+		},
+		Delete: func(ctx context.Context, _ singletonKey) {
+			store := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+			store.Delete(kvKey)
+		},
+		Clone: func(val V) V {
+			pv := PV(&val)
+			cloned := proto.Clone(pv).(PV)
+			return *cloned
+		},
+	}
+	return NewOptimisticItem(backend, config,
+		storeCtxKey{name: name, branch: false},
+		storeCtxKey{name: name, branch: true},
+	)
+}

--- a/inference-chain/x/inference/keeper/params.go
+++ b/inference-chain/x/inference/keeper/params.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -14,49 +13,21 @@ const defaultGenesisGuardianNetworkMaturityMinHeight int64 = 0
 const defaultDeveloperAccessUntilBlockHeight int64 = 0
 const defaultNewParticipantRegistrationStartHeight int64 = 0
 
-type paramsKey struct{}
-
-func (k Keeper) getParamsFromStore(ctx context.Context) (params types.Params, err error) {
-	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
-	bz := store.Get(types.ParamsKey)
-	if bz == nil {
-		return params, nil
-	}
-	if err := k.cdc.Unmarshal(bz, &params); err != nil {
-		return types.Params{}, err
-	}
-	return params, nil
-}
-
-// GetParams get all parameters as types.Params
+// GetParams reads parameters through the optimistic item cache.
 func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) {
-	if cached, ok := ctx.Value(paramsKey{}).(*types.Params); ok && cached != nil {
-		return *cached, nil
+	val, found := k.paramsStore.Get(ctx)
+	if !found {
+		return types.Params{}, nil
 	}
-	return k.getParamsFromStore(ctx)
+	return val, nil
 }
 
-// InjectParamsIntoContext returns a new context with the params cached.
-func (k Keeper) InjectParamsIntoContext(ctx sdk.Context) (sdk.Context, error) {
-	params, err := k.getParamsFromStore(ctx)
-	if err != nil {
-		return ctx, err
-	}
-	return ctx.WithValue(paramsKey{}, &params), nil
-}
-
-// SetParams set the params
+// SetParams writes parameters through the optimistic item cache and handles side-effects.
 func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
-	oldParams, _ := k.getParamsFromStore(ctx)
+	oldParams, _ := k.GetParams(ctx)
 
-	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
-	bz, err := k.cdc.Marshal(&params)
-	if err != nil {
-		return err
-	}
-	store.Set(types.ParamsKey, bz)
+	k.paramsStore.Set(ctx, params)
 
-	// Auto-set grace epoch when poc_v2_enabled transitions false -> true
 	if params.PocParams != nil && params.PocParams.PocV2Enabled {
 		wasV2Disabled := oldParams.PocParams == nil || !oldParams.PocParams.PocV2Enabled
 		if wasV2Disabled {
@@ -69,6 +40,11 @@ func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
 	}
 
 	return nil
+}
+
+// ParamsStore returns the underlying optimistic item for Params.
+func (k Keeper) ParamsStore() *OptimisticItem[types.Params] {
+	return k.paramsStore
 }
 
 func (k Keeper) GetV1Params(ctx context.Context) (params types.ParamsV1, err error) {
@@ -277,34 +253,6 @@ func (k Keeper) IsAllowedTransferAgent(ctx context.Context, taAddress string) bo
 	}
 	for _, a := range p.AllowedTransferAddresses {
 		if a == taAddress {
-			return true
-		}
-	}
-	return false
-}
-
-// GetSubnetEscrowParams returns subnet escrow params, falling back to defaults if unset.
-func (k Keeper) GetSubnetEscrowParams(ctx context.Context) *types.SubnetEscrowParams {
-	p, err := k.GetParams(ctx)
-	if err != nil {
-		k.LogError("Unable to get Params in GetSubnetEscrowParams", types.System, "error", err)
-		return types.DefaultSubnetEscrowParams()
-	}
-	if p.SubnetEscrowParams == nil {
-		return types.DefaultSubnetEscrowParams()
-	}
-	return p.SubnetEscrowParams
-}
-
-// IsAllowedEscrowCreator returns true if the address is allowed to create/settle subnet escrows.
-// An empty allowlist means everyone is allowed.
-func (k Keeper) IsAllowedEscrowCreator(ctx context.Context, address string) bool {
-	ep := k.GetSubnetEscrowParams(ctx)
-	if len(ep.AllowedCreatorAddresses) == 0 {
-		return true
-	}
-	for _, a := range ep.AllowedCreatorAddresses {
-		if a == address {
 			return true
 		}
 	}

--- a/inference-chain/x/inference/keeper/params.go
+++ b/inference-chain/x/inference/keeper/params.go
@@ -258,3 +258,31 @@ func (k Keeper) IsAllowedTransferAgent(ctx context.Context, taAddress string) bo
 	}
 	return false
 }
+
+// GetSubnetEscrowParams returns subnet escrow params, falling back to defaults if unset.
+func (k Keeper) GetSubnetEscrowParams(ctx context.Context) *types.SubnetEscrowParams {
+	p, err := k.GetParams(ctx)
+	if err != nil {
+		k.LogError("Unable to get Params in GetSubnetEscrowParams", types.System, "error", err)
+		return types.DefaultSubnetEscrowParams()
+	}
+	if p.SubnetEscrowParams == nil {
+		return types.DefaultSubnetEscrowParams()
+	}
+	return p.SubnetEscrowParams
+}
+
+// IsAllowedEscrowCreator returns true if the address is allowed to create/settle subnet escrows.
+// An empty allowlist means everyone is allowed.
+func (k Keeper) IsAllowedEscrowCreator(ctx context.Context, address string) bool {
+	ep := k.GetSubnetEscrowParams(ctx)
+	if len(ep.AllowedCreatorAddresses) == 0 {
+		return true
+	}
+	for _, a := range ep.AllowedCreatorAddresses {
+		if a == address {
+			return true
+		}
+	}
+	return false
+}

--- a/inference-chain/x/inference/keeper/query_epoch_group_data.go
+++ b/inference-chain/x/inference/keeper/query_epoch_group_data.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 
-	"cosmossdk.io/collections"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/productscience/inference/x/inference/types"
 	"google.golang.org/grpc/codes"
@@ -15,20 +14,37 @@ func (k Keeper) EpochGroupDataAll(ctx context.Context, req *types.QueryAllEpochG
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	epochGroupDatas, pageRes, err := query.CollectionPaginate(
-		ctx,
-		k.EpochGroupDataMap,
-		req.Pagination,
-		func(_ collections.Pair[uint64, string], value types.EpochGroupData) (types.EpochGroupData, error) {
-			return value, nil
-		},
-	)
+	all := k.GetAllEpochGroupData(ctx)
+	pageRes, start, end := paginateSlice(len(all), req.Pagination)
+	return &types.QueryAllEpochGroupDataResponse{EpochGroupData: all[start:end], Pagination: pageRes}, nil
+}
 
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+// paginateSlice computes a window [start, end) over a slice of the given length,
+// honouring the Offset / Limit / CountTotal fields of a PageRequest.
+func paginateSlice(total int, pg *query.PageRequest) (*query.PageResponse, int, int) {
+	if pg == nil {
+		pg = &query.PageRequest{}
 	}
-
-	return &types.QueryAllEpochGroupDataResponse{EpochGroupData: epochGroupDatas, Pagination: pageRes}, nil
+	offset := int(pg.Offset)
+	if offset > total {
+		offset = total
+	}
+	limit := int(pg.Limit)
+	if limit == 0 {
+		limit = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	resp := &query.PageResponse{}
+	if pg.CountTotal {
+		resp.Total = uint64(total)
+	}
+	if end < total {
+		resp.NextKey = []byte{1}
+	}
+	return resp, offset, end
 }
 
 func (k Keeper) EpochGroupData(ctx context.Context, req *types.QueryGetEpochGroupDataRequest) (*types.QueryGetEpochGroupDataResponse, error) {

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -316,7 +316,7 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	blockTime := sdkCtx.BlockTime().Unix()
 
 	// Persist epoch group block cache to store (tx drafts were merged to cache in PostHandler)
-	am.keeper.FlushCurrentEpochGroupCache(ctx)
+	defer am.keeper.FlushCurrentEpochGroupCache(ctx)
 	// Handle confirmation PoC trigger decisions and phase transitions
 	err := am.handleConfirmationPoC(ctx, blockHeight)
 	if err != nil {

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"slices"
 
-	"cosmossdk.io/collections"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
@@ -171,31 +170,18 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 
 // ConsensusVersion is a sequence number for state-breaking change of the module.
 // It should be incremented on each consensus-breaking change introduced by the module.
-func (AppModule) ConsensusVersion() uint64 { return 13 }
+func (AppModule) ConsensusVersion() uint64 { return 12 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 func (am AppModule) BeginBlock(ctx context.Context) error {
-	// Precompute SPRT values for the block
-	err := am.keeper.PrecomputeSPRTValues(ctx)
-	// We continue if there is something wrong with SPRT. Invalidation will effectively be turned off, but
-	// this will only happen if the governance values have been set wrong anyhow, so that's a rational choice
-	if err != nil {
-		am.LogError("Failed to precompute SPRT values", types.Validation, "error", err)
-	}
-
+	// Invalidate epoch group block cache so it is re-inited from store for this block
+	am.keeper.InvalidateEpochGroupCache()
 	// Update dynamic pricing for all models at the start of each block
 	// This ensures consistent pricing for all inferences processed in this block
-	err = am.keeper.UpdateDynamicPricing(ctx)
+	err := am.keeper.UpdateDynamicPricing(ctx)
 	if err != nil {
 		am.LogError("Failed to update dynamic pricing", types.Pricing, "error", err)
 		// Don't return error - allow block processing to continue even if pricing update fails
-	}
-
-	// Cache epoch model metadata in transient store.
-	// This avoids repeated heavy model-group reads in MsgValidation.
-	err = am.keeper.BuildEpochDataTransientCache(ctx)
-	if err != nil {
-		am.LogError("Failed to build epoch data transient cache", types.Validation, "error", err)
 	}
 
 	return nil
@@ -329,6 +315,8 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	blockHeight := sdkCtx.BlockHeight()
 	blockTime := sdkCtx.BlockTime().Unix()
 
+	// Persist epoch group block cache to store (tx drafts were merged to cache in PostHandler)
+	am.keeper.FlushCurrentEpochGroupCache(ctx)
 	// Handle confirmation PoC trigger decisions and phase transitions
 	err := am.handleConfirmationPoC(ctx, blockHeight)
 	if err != nil {
@@ -358,8 +346,6 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 		am.LogError("Unable to get current epoch group", types.EpochGroup, "error", err.Error())
 		return nil
 	}
-
-	am.processFinishedInferencesInBlock(ctx, blockHeight, currentEpoch, currentEpochGroup, &params)
 
 	timeouts := am.keeper.GetAllInferenceTimeoutForHeight(ctx, uint64(blockHeight))
 	err = am.expireInferences(ctx, timeouts, blockHeight, currentEpoch, &params)
@@ -546,7 +532,18 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 		return
 	}
 
-	activeParticipants := am.ComputeNewWeights(ctx, *upcomingEpoch)
+	// Dispatch to V1 or V2 weight calculation based on poc_v2_enabled flag
+	params, err := am.keeper.GetParams(ctx)
+	if err != nil {
+		am.LogError("onEndOfPoCValidationStage: Unable to get params", types.PoC, "error", err.Error())
+		return
+	}
+	var activeParticipants []*types.ActiveParticipant
+	if params.PocParams.PocV2Enabled {
+		activeParticipants = am.ComputeNewWeights(ctx, *upcomingEpoch)
+	} else {
+		activeParticipants = am.ComputeNewWeightsV1(ctx, *upcomingEpoch)
+	}
 	if activeParticipants == nil {
 		am.LogError("onEndOfPoCValidationStage: computeResult == nil && activeParticipants == nil", types.PoC)
 		return
@@ -591,13 +588,6 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 	if err != nil {
 		am.LogError("onEndOfPoCValidationStage: Unable to set active participants", types.EpochGroup, "error", err.Error())
 		return
-	}
-	if upcomingEpoch.Index > 3 {
-		outOfDateActiveParticipants := collections.NewPrefixedPairRange[uint64, sdk.AccAddress](upcomingEpoch.Index - 2)
-		err = am.keeper.ActiveParticipantsSet.Clear(ctx, outOfDateActiveParticipants)
-		if err != nil {
-			am.LogWarn("onEndOfPoCValidationStage: Unable to clear old active participants cache", types.EpochGroup, "epochIndex", upcomingEpoch.Index-2, "error", err.Error())
-		}
 	}
 
 	upcomingEg, err := am.keeper.GetEpochGroupForEpoch(ctx, *upcomingEpoch)
@@ -982,7 +972,6 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(GrantMLOpsPermissionsCmd())
-	cmd.AddCommand(SettleSubnetEscrowCmd())
 
 	return cmd
 }
@@ -1001,11 +990,10 @@ func init() {
 type ModuleInputs struct {
 	depinject.In
 
-	StoreService          store.KVStoreService
-	TransientStoreService store.TransientStoreService
-	Cdc                   codec.Codec
-	Config                *modulev1.Module
-	Logger                log.Logger
+	StoreService store.KVStoreService
+	Cdc          codec.Codec
+	Config       *modulev1.Module
+	Logger       log.Logger
 
 	AccountKeeper       types.AccountKeeper
 	BankKeeper          types.BankKeeper
@@ -1039,7 +1027,6 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 	k := keeper.NewKeeper(
 		in.Cdc,
 		in.StoreService,
-		in.TransientStoreService,
 		in.Logger,
 		authority.String(),
 		in.BankEscrowKeeper,

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -174,8 +174,8 @@ func (AppModule) ConsensusVersion() uint64 { return 12 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 func (am AppModule) BeginBlock(ctx context.Context) error {
-	// Invalidate epoch group block cache so it is re-inited from store for this block
-	am.keeper.InvalidateEpochGroupCache()
+	// Invalidate all optimistic store block caches so they are re-inited from store for this block
+	am.keeper.StoreGroup().InvalidateAll()
 	// Update dynamic pricing for all models at the start of each block
 	// This ensures consistent pricing for all inferences processed in this block
 	err := am.keeper.UpdateDynamicPricing(ctx)
@@ -315,8 +315,8 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	blockHeight := sdkCtx.BlockHeight()
 	blockTime := sdkCtx.BlockTime().Unix()
 
-	// Persist epoch group block cache to store (tx drafts were merged to cache in PostHandler)
-	defer am.keeper.FlushCurrentEpochGroupCache(ctx)
+	// Persist all optimistic store block caches to store (tx drafts were merged to cache in PostHandler)
+	defer am.keeper.StoreGroup().FlushAll(ctx)
 	// Handle confirmation PoC trigger decisions and phase transitions
 	err := am.handleConfirmationPoC(ctx, blockHeight)
 	if err != nil {

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 
+	"cosmossdk.io/collections"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
@@ -170,18 +171,34 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 
 // ConsensusVersion is a sequence number for state-breaking change of the module.
 // It should be incremented on each consensus-breaking change introduced by the module.
-func (AppModule) ConsensusVersion() uint64 { return 12 }
+func (AppModule) ConsensusVersion() uint64 { return 13 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 func (am AppModule) BeginBlock(ctx context.Context) error {
-	// Invalidate all optimistic store block caches so they are re-inited from store for this block
+	// Refresh optimistic block-level caches at block start.
 	am.keeper.StoreGroup().InvalidateAll()
+
+	// Precompute SPRT values for the block
+	err := am.keeper.PrecomputeSPRTValues(ctx)
+	// We continue if there is something wrong with SPRT. Invalidation will effectively be turned off, but
+	// this will only happen if the governance values have been set wrong anyhow, so that's a rational choice
+	if err != nil {
+		am.LogError("Failed to precompute SPRT values", types.Validation, "error", err)
+	}
+
 	// Update dynamic pricing for all models at the start of each block
 	// This ensures consistent pricing for all inferences processed in this block
-	err := am.keeper.UpdateDynamicPricing(ctx)
+	err = am.keeper.UpdateDynamicPricing(ctx)
 	if err != nil {
 		am.LogError("Failed to update dynamic pricing", types.Pricing, "error", err)
 		// Don't return error - allow block processing to continue even if pricing update fails
+	}
+
+	// Cache epoch model metadata in transient store.
+	// This avoids repeated heavy model-group reads in MsgValidation.
+	err = am.keeper.BuildEpochDataTransientCache(ctx)
+	if err != nil {
+		am.LogError("Failed to build epoch data transient cache", types.Validation, "error", err)
 	}
 
 	return nil
@@ -315,8 +332,9 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	blockHeight := sdkCtx.BlockHeight()
 	blockTime := sdkCtx.BlockTime().Unix()
 
-	// Persist all optimistic store block caches to store (tx drafts were merged to cache in PostHandler)
+	// Persist optimistic block caches after end-block processing.
 	defer am.keeper.StoreGroup().FlushAll(ctx)
+
 	// Handle confirmation PoC trigger decisions and phase transitions
 	err := am.handleConfirmationPoC(ctx, blockHeight)
 	if err != nil {
@@ -346,6 +364,8 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 		am.LogError("Unable to get current epoch group", types.EpochGroup, "error", err.Error())
 		return nil
 	}
+
+	am.processFinishedInferencesInBlock(ctx, blockHeight, currentEpoch, currentEpochGroup, &params)
 
 	timeouts := am.keeper.GetAllInferenceTimeoutForHeight(ctx, uint64(blockHeight))
 	err = am.expireInferences(ctx, timeouts, blockHeight, currentEpoch, &params)
@@ -532,18 +552,7 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 		return
 	}
 
-	// Dispatch to V1 or V2 weight calculation based on poc_v2_enabled flag
-	params, err := am.keeper.GetParams(ctx)
-	if err != nil {
-		am.LogError("onEndOfPoCValidationStage: Unable to get params", types.PoC, "error", err.Error())
-		return
-	}
-	var activeParticipants []*types.ActiveParticipant
-	if params.PocParams.PocV2Enabled {
-		activeParticipants = am.ComputeNewWeights(ctx, *upcomingEpoch)
-	} else {
-		activeParticipants = am.ComputeNewWeightsV1(ctx, *upcomingEpoch)
-	}
+	activeParticipants := am.ComputeNewWeights(ctx, *upcomingEpoch)
 	if activeParticipants == nil {
 		am.LogError("onEndOfPoCValidationStage: computeResult == nil && activeParticipants == nil", types.PoC)
 		return
@@ -588,6 +597,13 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 	if err != nil {
 		am.LogError("onEndOfPoCValidationStage: Unable to set active participants", types.EpochGroup, "error", err.Error())
 		return
+	}
+	if upcomingEpoch.Index > 3 {
+		outOfDateActiveParticipants := collections.NewPrefixedPairRange[uint64, sdk.AccAddress](upcomingEpoch.Index - 2)
+		err = am.keeper.ActiveParticipantsSet.Clear(ctx, outOfDateActiveParticipants)
+		if err != nil {
+			am.LogWarn("onEndOfPoCValidationStage: Unable to clear old active participants cache", types.EpochGroup, "epochIndex", upcomingEpoch.Index-2, "error", err.Error())
+		}
 	}
 
 	upcomingEg, err := am.keeper.GetEpochGroupForEpoch(ctx, *upcomingEpoch)
@@ -972,6 +988,7 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(GrantMLOpsPermissionsCmd())
+	cmd.AddCommand(SettleSubnetEscrowCmd())
 
 	return cmd
 }
@@ -990,10 +1007,11 @@ func init() {
 type ModuleInputs struct {
 	depinject.In
 
-	StoreService store.KVStoreService
-	Cdc          codec.Codec
-	Config       *modulev1.Module
-	Logger       log.Logger
+	StoreService          store.KVStoreService
+	TransientStoreService store.TransientStoreService
+	Cdc                   codec.Codec
+	Config                *modulev1.Module
+	Logger                log.Logger
 
 	AccountKeeper       types.AccountKeeper
 	BankKeeper          types.BankKeeper
@@ -1027,6 +1045,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 	k := keeper.NewKeeper(
 		in.Cdc,
 		in.StoreService,
+		in.TransientStoreService,
 		in.Logger,
 		authority.String(),
 		in.BankEscrowKeeper,

--- a/proposals/block-tx-cache-occ/README.md
+++ b/proposals/block-tx-cache-occ/README.md
@@ -1,4 +1,4 @@
-# Two-Level Block/Tx Cache with OCC Conflict Detection
+# Two-Level Block/Tx Cache with Conflict Detection for OCC
 
 ## Motivation
 
@@ -10,11 +10,11 @@ the same block.
 The goal of this proposal is twofold:
 
 1. **Phase 1 (current):** Introduce a two-level block/tx cache implemented by
-   `OptimisticStore` (name kept for code compatibility), eliminating redundant
+   `OptimisticStore` (name kept for code compatibility) to eliminate redundant
    marshal/unmarshal within a block while remaining fully deterministic and
    compatible with the existing sequential execution model.
 
-2. **Phase 2 (future):** Use the same conflict-tracking infrastructure to
+2. **Phase 2 (future):** Reuse the same conflict-tracking infrastructure to
    enable **Optimistic Concurrency Control (OCC)** — parallel execution of
    transactions with automatic conflict detection and rollback.
 
@@ -28,7 +28,7 @@ execute in parallel and touch overlapping store keys, the final state depends on
 execution timing rather than block ordering. This breaks consensus.
 
 The Cosmos SDK's optional optimistic execution mode is not a universal,
-one-size-fits-all feature. Its implementation is highly case-specific to each
+one-size-fits-all feature. Its implementation is highly case-specific to the
 module's access patterns. Gonka therefore implements its own OCC scheme tailored
 to inference-chain workloads.
 
@@ -68,12 +68,12 @@ validator makes the same choice deterministically.
 
 ### Grouping by Similarity
 
-Grouping criterion is the *predicted access pattern* of the message type. In
-Gonka, inference messages hit `EpochGroupData` keyed by `(epoch, model)` and
-`Params` (singleton). Two `MsgValidation` for the same model and epoch are
+Grouping criterion is the *predicted access pattern* of the message type.
+Two `MsgValidation` for the same model and epoch are
 "similar" — they access the same keys and take roughly the same time to execute.
-Static analysis per message type provides the access prediction; arbitrary
-message types fall back to a conservative "touches everything" group.
+Static analysis per message type provides the access prediction.
+Most of hot messages will be gone when shardchains start to work,
+but anyway this approach continues to work and will be useful.
 
 ### Gas for Rescheduled Transactions
 
@@ -84,10 +84,13 @@ successful execution, not to failed speculative attempts.
 
 ### High-Contention Liveness
 
-If a transaction keeps conflicting with a hot key, it could theoretically be
-rescheduled indefinitely. The safeguard: after **N retries** (configurable), the
-transaction is forced into **sequential execution** in a singleton batch. This
-guarantees forward progress even under extreme contention.
+By design, there should be no persistent hot keys. Shared data is mostly read
+and then written in deterministic flow, so sustained conflicts should not appear
+in normal operation.
+
+As a safety fallback only, if repeated conflicts still happen due to unexpected
+workload shape, a transaction can be forced into **sequential execution** after
+**N retries** (configurable), guaranteeing forward progress.
 
 ### Throughput Improvement
 
@@ -105,11 +108,11 @@ k approaches 1.0 and throughput scales nearly linearly with cores.
 ## Phase 1: Two-Level Block/Tx Cache (Current Implementation)
 
 Phase 1 is fully implemented and merged. There is **no parallel scheduler** yet.
-All transactions still execute sequentially. This is not an "optimistic mode"
-yet: it is a deterministic two-level cache (tx draft + block cache) with
-conflict detection that can be reused by a future OCC scheduler.
+All transactions still execute sequentially. This is not optimistic execution by
+itself; it is a deterministic 2-level cache (tx draft + block cache) with
+conflict detection that can be used later in optimistic concurrent mode.
 
-The current cache provides these benefits:
+This cache provides these benefits:
 
 1. **Eliminate repeated marshal/unmarshal** for store values accessed multiple
    times within a block (e.g. `Params`, `EpochGroupData`).
@@ -117,34 +120,29 @@ The current cache provides these benefits:
    transaction, so conflict detection can be enabled with a single environment
    variable (`COSMOS_OCC_ENABLED=1`).
 
-### Shared System Data Focus
+### Shared System Data and Cache Scope
 
-The two-level cache is used for shared system data that is read frequently:
+We use this 2-level block/tx cache for frequently read shared system data:
 
-- `Params` (singleton system configuration)
-- `EpochGroupData` (hot-path epoch/model state)
+- `Params`
+- `EpochGroupData`
 
-These values are frequently read by system flows, so avoiding repeated
-marshal/unmarshal provides meaningful latency and throughput wins.
+These are hot system reads, so caching removes repeated codec overhead on the
+same values inside a block and transaction flow.
 
-For `EpochGroupData`, this is also relevant for system protection checks, such
-as identifying participants slashed for missed inferences or missed cPoCs. Those
-checks are system-level checks and are acceptable to keep gas-free in this
-module's policy.
+### Protobuf Marshal/Unmarshal and Gas
 
-### Gas, Protobuf Encoding, and Why Caching Helps
+Cosmos SDK marshals/unmarshals protobuf data on store reads/writes, including as
+part of store gas accounting. When reads/writes are served from this cache,
+repeated codec operations are skipped and no extra gas is spent for those cached
+operations in these system paths.
 
-Cosmos SDK marshals and unmarshals protobuf values on each store write/read.
-This is also part of how store access gas costs are calculated.
-
-With this cache layer, repeated accesses can be served from in-memory draft/block
-cache, skipping repeated protobuf encode/decode for those hits. In practice,
-this means we avoid spending gas on those repeated codec operations in these
-system paths.
-
-This is acceptable in Gonka's design because system messages are already handled
-with no-gas or fixed-gas policies (for DDoS resistance), and the priority here
-is fast deterministic execution for shared system data.
+This is acceptable in our design because we already use no-gas or fixed-gas
+policies for system messages (to reduce DDoS spam risk while keeping deterministic
+execution). For example, `EpochGroupData` reads may be used by endpoint
+protection logic to identify participants slashed for missing inferences or
+missing cPoCs; this is a system check where fast execution is preferred over
+repeated marshalling/unmarshalling.
 
 ### Architecture
 
@@ -178,7 +176,7 @@ is fast deterministic execution for shared system data.
 During `CheckTx`, the SDK validates a transaction before it enters the mempool.
 The optimistic store **does not commit drafts** during `CheckTx`:
 
-```
+```go
 PostHandler:
   if ctx.IsCheckTx() || simulate {
       return  // skip commit — mempool validation only
@@ -231,7 +229,7 @@ store and returns a merged commit function.
 
 ---
 
-## How the Two-Level Cache Wraps Existing Storage
+## How OptimisticStore Works Around Existing Storage
 
 `OptimisticStore` is a **decorator** — it wraps existing storage without
 replacing it. The `StoreBackend` interface makes this explicit:

--- a/proposals/block-tx-cache-occ/README.md
+++ b/proposals/block-tx-cache-occ/README.md
@@ -1,0 +1,430 @@
+# Two-Level Block/Tx Cache with OCC Conflict Detection
+
+## Motivation
+
+Cosmos SDK processes transactions sequentially by default. Every read from the
+KV store requires protobuf unmarshalling, and every write requires marshalling —
+operations that are both CPU-intensive and repeated across transactions within
+the same block.
+
+The goal of this proposal is twofold:
+
+1. **Phase 1 (current):** Introduce a two-level block/tx cache implemented by
+   `OptimisticStore` (name kept for code compatibility), eliminating redundant
+   marshal/unmarshal within a block while remaining fully deterministic and
+   compatible with the existing sequential execution model.
+
+2. **Phase 2 (future):** Use the same conflict-tracking infrastructure to
+   enable **Optimistic Concurrency Control (OCC)** — parallel execution of
+   transactions with automatic conflict detection and rollback.
+
+---
+
+## Problem Statement
+
+The issue is **not** a classical race condition — it is a root of
+**non-determinism in optimistic (parallel) behaviour**. When two transactions
+execute in parallel and touch overlapping store keys, the final state depends on
+execution timing rather than block ordering. This breaks consensus.
+
+The Cosmos SDK's optional optimistic execution mode is not a universal,
+one-size-fits-all feature. Its implementation is highly case-specific to each
+module's access patterns. Gonka therefore implements its own OCC scheme tailored
+to inference-chain workloads.
+
+---
+
+## Design: OCC for Gonka
+
+### Scheduling
+
+A scheduler takes **N** messages from the mempool (where N scales with CPU
+cores). Messages are sorted and grouped by similarity — similar messages tend to
+access similar store keys and have comparable execution times.
+
+The selected N messages run as a **parallel batch**. The scheduler waits until
+all messages in the batch complete, then takes the next batch.
+
+### Conflict Detection
+
+During execution, each transaction's read-set and write-set are recorded by the
+`conflictTracker` inside every `OptimisticStore`. After the batch completes:
+
+- **Read-Write conflict:** Transaction A read key K, transaction B wrote key K
+  → A must be rolled back and rescheduled.
+- **Write-Write conflict:** Transactions A and B both wrote key K → all but one
+  (the one earlier in block order) must be rolled back and rescheduled.
+
+Only the *losing* transactions are rescheduled to the next batch. When ordering
+and batch-fill rules are deterministic, the entire parallel execution remains
+deterministic across all validators.
+
+### Conflict Resolution Ordering
+
+When two transactions in the same batch both write the same key, the winner is
+determined by **block order** — the transaction that appears earlier in the
+ordered block survives; the later one is rolled back. This ensures every
+validator makes the same choice deterministically.
+
+### Grouping by Similarity
+
+Grouping criterion is the *predicted access pattern* of the message type. In
+Gonka, inference messages hit `EpochGroupData` keyed by `(epoch, model)` and
+`Params` (singleton). Two `MsgValidation` for the same model and epoch are
+"similar" — they access the same keys and take roughly the same time to execute.
+Static analysis per message type provides the access prediction; arbitrary
+message types fall back to a conservative "touches everything" group.
+
+### Gas for Rescheduled Transactions
+
+When a transaction is rolled back due to a conflict, its **gas meter resets**.
+The rescheduled execution is a fresh attempt with a fresh meter. Cosmos gas
+accounting therefore remains correct — the user's gas limit applies to the
+successful execution, not to failed speculative attempts.
+
+### High-Contention Liveness
+
+If a transaction keeps conflicting with a hot key, it could theoretically be
+rescheduled indefinitely. The safeguard: after **N retries** (configurable), the
+transaction is forced into **sequential execution** in a singleton batch. This
+guarantees forward progress even under extreme contention.
+
+### Throughput Improvement
+
+Implementing this OCC scheme could yield **N × k** times better throughput for
+the mainchain, where:
+
+- **N** = number of CPU cores
+- **k** = efficiency coefficient (< 1.0, depends on conflict rate)
+
+For workloads with low key overlap (e.g. inferences touching different models),
+k approaches 1.0 and throughput scales nearly linearly with cores.
+
+---
+
+## Phase 1: Two-Level Block/Tx Cache (Current Implementation)
+
+Phase 1 is fully implemented and merged. There is **no parallel scheduler** yet.
+All transactions still execute sequentially. This is not an "optimistic mode"
+yet: it is a deterministic two-level cache (tx draft + block cache) with
+conflict detection that can be reused by a future OCC scheduler.
+
+The current cache provides these benefits:
+
+1. **Eliminate repeated marshal/unmarshal** for store values accessed multiple
+   times within a block (e.g. `Params`, `EpochGroupData`).
+2. **Lay the foundation for Phase 2** by tracking read/write sets per
+   transaction, so conflict detection can be enabled with a single environment
+   variable (`COSMOS_OCC_ENABLED=1`).
+
+### Shared System Data Focus
+
+The two-level cache is used for shared system data that is read frequently:
+
+- `Params` (singleton system configuration)
+- `EpochGroupData` (hot-path epoch/model state)
+
+These values are frequently read by system flows, so avoiding repeated
+marshal/unmarshal provides meaningful latency and throughput wins.
+
+For `EpochGroupData`, this is also relevant for system protection checks, such
+as identifying participants slashed for missed inferences or missed cPoCs. Those
+checks are system-level checks and are acceptable to keep gas-free in this
+module's policy.
+
+### Gas, Protobuf Encoding, and Why Caching Helps
+
+Cosmos SDK marshals and unmarshals protobuf values on each store write/read.
+This is also part of how store access gas costs are calculated.
+
+With this cache layer, repeated accesses can be served from in-memory draft/block
+cache, skipping repeated protobuf encode/decode for those hits. In practice,
+this means we avoid spending gas on those repeated codec operations in these
+system paths.
+
+This is acceptable in Gonka's design because system messages are already handled
+with no-gas or fixed-gas policies (for DDoS resistance), and the priority here
+is fast deterministic execution for shared system data.
+
+### Architecture
+
+```
+┌───────────────────────────────────────────────────┐
+│                   OptimisticStore                  │
+│                                                    │
+│  Layer 1: Tx Draft (context-scoped, per-tx)        │
+│           ↓ miss                                   │
+│  Layer 2: Block Cache (in-memory, per-block)       │
+│           ↓ miss                                   │
+│  Layer 3: Store Backend (persistent KV / protobuf) │
+│                                                    │
+│  + conflictTracker (read/write sets per tx)        │
+└───────────────────────────────────────────────────┘
+```
+
+- **Tx Draft:** Write-behind buffer scoped to a single transaction via
+  `context.Value`. Created in `AnteHandler`, committed to block cache on tx
+  success in `PostHandler`, discarded on failure.
+- **Block Cache:** Shared in-memory map for the current block. Populated on
+  first read (cache-aside pattern). Flushed to the persistent store backend in
+  `EndBlock`.
+- **Store Backend:** Pluggable interface (`Load`/`Save`/`Delete`/`Clone`) that
+  wraps any persistent storage (collections map, raw KV, etc.).
+
+### Lifecycle: CheckTx vs DeliverTx
+
+#### CheckTx (Mempool Validation)
+
+During `CheckTx`, the SDK validates a transaction before it enters the mempool.
+The optimistic store **does not commit drafts** during `CheckTx`:
+
+```
+PostHandler:
+  if ctx.IsCheckTx() || simulate {
+      return  // skip commit — mempool validation only
+  }
+```
+
+This means `CheckTx` sees the persistent store state (or block cache if already
+warm), but its writes are discarded. This is correct because `CheckTx` must be
+side-effect-free.
+
+#### DeliverTx (Block Execution)
+
+During `DeliverTx`, the full lifecycle executes:
+
+```
+AnteHandler (OptimisticStoreDraftDecorator):
+  → StoreGroup.WithDraftAll(ctx)    // attach per-tx drafts
+  → StoreGroup.RegisterTxAll(ctx)   // register for OCC tracking
+
+Message Execution:
+  → store.Get(ctx, key)  // reads: draft → block cache → backend
+  → store.Set(ctx, key)  // writes: go to draft
+
+PostHandler (OptimisticStoreCommitPostDecorator):
+  if success:
+      → StoreGroup.CommitDraftAll(ctx)   // merge draft → block cache
+  else:
+      → StoreGroup.ReleaseDraftAll(ctx)  // discard draft
+
+EndBlock:
+  → StoreGroup.FlushAll(ctx)             // block cache → persistent store
+
+BeginBlock (next block):
+  → StoreGroup.InvalidateAll()           // clear block cache + conflict tracker
+```
+
+### Branch Drafts
+
+For operations that need speculative execution within a single tx (e.g.
+`CacheContext` patterns), `OptimisticStore` supports **branch drafts**:
+
+```go
+cacheCtx, writeCache := keeper.CacheContext(ctx)
+// speculative work on cacheCtx...
+writeCache()  // merge branch draft into parent tx draft + SDK cache
+```
+
+The `StoreGroup.CacheContext` method creates branch drafts for every registered
+store and returns a merged commit function.
+
+---
+
+## How the Two-Level Cache Wraps Existing Storage
+
+`OptimisticStore` is a **decorator** — it wraps existing storage without
+replacing it. The `StoreBackend` interface makes this explicit:
+
+```go
+type StoreBackend[K comparable, V any] struct {
+    Load   func(ctx context.Context, key K) (V, bool)
+    Save   func(ctx context.Context, key K, val V)
+    Delete func(ctx context.Context, key K)
+    Clone  func(val V) V
+}
+```
+
+Any existing `collections.Map`, `collections.Item`, or raw KV store can be
+wrapped by providing these four functions.
+
+### Example: Wrapping a Collections Map
+
+For `EpochGroupData`, which is stored in a `collections.Map[Pair[uint64,string],
+EpochGroupData]`:
+
+```go
+// In keeper.go NewKeeper:
+epochGroupStore: NewOptimisticCollMap[
+    epochGroupCacheKey,
+    collections.Pair[uint64, string],
+    types.EpochGroupData,
+](
+    sb,
+    types.EpochGroupDataPrefix,
+    "epoch_group_data",
+    collections.PairKeyCodec(collections.Uint64Key, collections.StringKey),
+    codec.CollValue[types.EpochGroupData](cdc),
+    cacheConfig,
+    func(key epochGroupCacheKey) collections.Pair[uint64, string] {
+        return collections.Join(key.Epoch, key.ModelId)
+    },
+),
+```
+
+`NewOptimisticCollMap` creates the `collections.Map` AND wraps it with an
+`OptimisticStore` in one call. The `Load`/`Save`/`Delete` functions delegate to
+the collection; `Clone` uses `proto.Clone`.
+
+### Example: Wrapping a Singleton (Params)
+
+For `Params`, stored as a single protobuf blob at a fixed KV key:
+
+```go
+paramsStore: NewOptimisticProtoItem[types.Params](
+    storeService,
+    cdc,
+    types.ParamsKey,
+    "params",
+    cacheConfig,
+),
+```
+
+`NewOptimisticProtoItem` handles marshal/unmarshal internally. `GetParams` and
+`SetParams` simply call `paramsStore.Get(ctx)` / `paramsStore.Set(ctx, val)`.
+
+### Registering with the StoreGroup
+
+Every optimistic store must be registered with the keeper's `StoreGroup` so
+lifecycle methods (`InvalidateAll`, `FlushAll`, `WithDraftAll`, etc.) apply to
+all stores uniformly:
+
+```go
+k.storeGroup.Register(k.epochGroupStore.OptimisticStore)
+k.storeGroup.Register(k.paramsStore.Store())
+```
+
+### Adding a New Optimistic Store to the Keeper
+
+To wrap a new collection with optimistic caching:
+
+1. Define a cache key type (must be `comparable`):
+   ```go
+   type myNewCacheKey struct {
+       Field1 uint64
+       Field2 string
+   }
+   ```
+
+2. Add the optimistic store field to `Keeper`:
+   ```go
+   myNewStore *OptimisticCollMap[myNewCacheKey, collections.Pair[uint64, string], types.MyNewType]
+   ```
+
+3. Initialize in `NewKeeper` using `NewOptimisticCollMap` (or
+   `NewOptimisticProtoItem` for singletons).
+
+4. Register with the store group:
+   ```go
+   k.storeGroup.Register(k.myNewStore.OptimisticStore)
+   ```
+
+5. Write getter/setter methods on `Keeper` that delegate to the store:
+   ```go
+   func (k Keeper) GetMyNewData(ctx context.Context, key myNewCacheKey) (types.MyNewType, bool) {
+       return k.myNewStore.Get(ctx, key)
+   }
+   func (k Keeper) SetMyNewData(ctx context.Context, val types.MyNewType) {
+       key := myNewCacheKey{Field1: val.Field1, Field2: val.Field2}
+       k.myNewStore.Set(ctx, key, val)
+   }
+   ```
+
+No changes are needed to `AnteHandler`, `PostHandler`, `BeginBlock`, or
+`EndBlock` — the `StoreGroup` handles all registered stores automatically.
+
+---
+
+## Wiring: AnteHandler, PostHandler, BeginBlock, EndBlock
+
+### AnteHandler (`ante.go`)
+
+```go
+type OptimisticStoreDraftDecorator struct {
+    InferenceKeeper *inferencemodulekeeper.Keeper
+}
+
+func (d OptimisticStoreDraftDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+    g := d.InferenceKeeper.StoreGroup()
+    newCtx := ctx.WithContext(g.WithDraftAll(ctx.Context()))
+    g.RegisterTxAll(newCtx)
+    return next(newCtx, tx, simulate)
+}
+```
+
+### PostHandler (`ante.go`)
+
+```go
+func (d OptimisticStoreCommitPostDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
+    newCtx, err := next(ctx, tx, simulate, success)
+    if ctx.IsCheckTx() || simulate {
+        return newCtx, nil  // no side effects during CheckTx
+    }
+    g := d.InferenceKeeper.StoreGroup()
+    if success {
+        g.CommitDraftAll(newCtx)   // merge draft → block cache
+    } else {
+        g.ReleaseDraftAll(newCtx)  // discard draft
+    }
+    return newCtx, nil
+}
+```
+
+### BeginBlock (`module.go`)
+
+```go
+func (am AppModule) BeginBlock(ctx context.Context) error {
+    am.keeper.StoreGroup().InvalidateAll()  // clear block caches + conflict tracker
+    // ... rest of begin block
+}
+```
+
+### EndBlock (`module.go`)
+
+```go
+func (am AppModule) EndBlock(ctx context.Context) error {
+    defer am.keeper.StoreGroup().FlushAll(ctx)  // persist block caches to store
+    // ... rest of end block
+}
+```
+
+---
+
+## Phase 2 Roadmap: OCC Scheduler
+
+Phase 2 will add a deterministic parallel scheduler. The current
+`conflictTracker` inside `OptimisticStore` already tracks per-tx read/write sets
+and can detect conflicts via `DetectConflicts()`. What remains:
+
+1. **Batch Scheduler** — select N messages, group by predicted access pattern,
+   execute in parallel.
+2. **Conflict Resolution** — after batch completion, call `DetectConflicts()` on
+   each store, roll back losers (by block order), reschedule to next batch.
+3. **Retry Budget** — force sequential execution after N failed attempts.
+4. **Integration** — replace the sequential `DeliverTx` loop with the batched
+   scheduler; keep the same `AnteHandler`/`PostHandler` draft lifecycle.
+
+The `OptimisticStore` API is already designed for this:
+
+```go
+// Enable conflict detection at startup:
+// COSMOS_OCC_ENABLED=1
+
+// After parallel batch completes:
+conflictedReads, conflictedWrites := store.DetectConflicts()
+// Roll back and reschedule conflicted txIDs...
+store.ResetConflictTracker()
+```
+
+No changes to the store, keeper, or cache layer are expected for Phase 2 — only
+the addition of the scheduler and the `DeliverTx` loop replacement.


### PR DESCRIPTION
## Summary

This PR introduces a **two-level block/tx cache mechanism** for inference module system data, with built-in conflict tracking for future OCC (optimistic concurrent) execution support.

It is a part of a bigger proposal for optimistic parallel execution, that can significantly increase mainchain throughput:
https://github.com/gonka-ai/gonka/discussions/954
https://github.com/akup/gonka/blob/944925f58a357c0871e1f8e5b8c3fe26caad1e19/proposals/block-tx-cache-occ/README.md

Main points:

- Added a deterministic **store wrapper** (`OptimisticStore`) with:
  - **Tx draft layer** (per-transaction, context-scoped write-behind)
  - **Block cache layer** (shared in-memory cache for current block)
  - **Persistent backend layer** (collections/raw KV as source of truth)
- Added **conflict detection hooks** (read/write set tracking) to support future parallel scheduler work, while current execution remains sequential.
- Wired lifecycle through `AnteHandler` / `PostHandler` / `BeginBlock` / `EndBlock`:
  - create drafts in ante
  - commit/release drafts in post
  - invalidate block cache at block start
  - flush cache to persistent store at block end
- Applied this mechanism to shared frequently-read system data (`Params`, `EpochGroupData`).
- **Removed explicit ParamsInjection calls** from msg server handlers, because params are now handled automatically by the cache/store mechanism.

For full design and rationale, see:
`proposals/block-tx-cache-occ/README.md`

---

## Store Mechanism (How it Works)

1. **Read path**: `tx draft -> block cache -> persistent store`
2. **Write path**: writes go to tx draft first
3. **On tx success**: tx draft merges into block cache
4. **On tx failure**: tx draft is discarded
5. **EndBlock**: block cache flushes to persistent store
6. **BeginBlock**: block cache/conflict tracker reset for next block

This removes repeated protobuf marshal/unmarshal on hot reads/writes within the same block flow, especially for system data.

---

## Why ParamsInjection Was Removed

Previously, handlers manually injected params into context.
Now params are retrieved through the same cache-backed store flow, so explicit per-handler injection is unnecessary and was removed to simplify call sites and avoid duplication.

---

## When This Cache Should Be Used

Use this cache for data that is:

- shared across many txs in the same block
- frequently read in system flows
- expensive to repeatedly marshal/unmarshal
- deterministic and safe to stage in tx/block layers before final flush

Good examples in this PR: `Params`, `EpochGroupData`.

Avoid using it blindly for rarely-accessed or highly specialized one-off state unless there is a demonstrated performance need.

---

## Notes

- This PR does **not** enable parallel tx execution by itself.
- Conflict detection is included now to prepare for a future OCC scheduler phase.
- Current behavior remains deterministic and compatible with sequential execution.
