### PR TITLE
fix: return error when InjectParamsIntoContext fails in Validation

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"cosmossdk.io/collections"
@@ -24,6 +25,7 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 	ctx, err := k.Keeper.InjectParamsIntoContext(sdk.UnwrapSDKContext(goCtx))
 	if err != nil {
 		k.LogWarn("Validation: failed to inject params", types.Validation, "error", err)
+		return nil, fmt.Errorf("cannot validate with stale params: %w", err)
 	}
 
 	k.LogInfo("Received MsgValidation", types.Validation,


### PR DESCRIPTION
If InjectParamsIntoContext fails, the Validation handler currently logs a warning but continues with potentially stale or missing chain parameters. This can lead to wrong validation decisions (wrong thresholds, wrong epoch policies, wrong weights).

Return an error immediately instead of proceeding with stale data.

File: msg_server_validation.go:24-26
Severity: HIGH — wrong validation decisions with stale params