### PR TITLE
fix: unify epoch cache to single invalidation path

### DIFF
--- a/decentralized-api/internal/epoch_group_cache.go
+++ b/decentralized-api/internal/epoch_group_cache.go
@@ -36,40 +36,11 @@ func NewEpochGroupDataCache(recorder cosmosclient.CosmosMessageClient) *EpochGro
 	}
 }
 
+// GetCurrentEpochGroupData delegates to GetEpochGroupData to use a single
+// cache path. The legacy separate fields (cachedEpochIndex, cachedGroupData)
+// are no longer used — all caching goes through the unified epochCache map.
 func (c *EpochGroupDataCache) GetCurrentEpochGroupData(currentEpochIndex uint64) (*types.EpochGroupData, error) {
-	c.mu.RLock()
-	if c.cachedGroupData != nil && c.cachedEpochIndex == currentEpochIndex {
-		defer c.mu.RUnlock()
-		return c.cachedGroupData, nil
-	}
-	c.mu.RUnlock()
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.cachedGroupData != nil && c.cachedEpochIndex == currentEpochIndex {
-		return c.cachedGroupData, nil
-	}
-
-	logging.Info("Fetching new epoch group data", types.Config,
-		"cachedEpochIndex", c.cachedEpochIndex, "currentEpochIndex", currentEpochIndex)
-
-	queryClient := c.recorder.NewInferenceQueryClient()
-	req := &types.QueryCurrentEpochGroupDataRequest{}
-	resp, err := queryClient.CurrentEpochGroupData(context.Background(), req)
-	if err != nil {
-		logging.Warn("Failed to query current epoch group data", types.Config, "error", err)
-		return nil, err
-	}
-
-	c.cachedEpochIndex = currentEpochIndex
-	c.cachedGroupData = &resp.EpochGroupData
-
-	logging.Info("Updated epoch group data cache", types.Config,
-		"epochIndex", currentEpochIndex,
-		"validationWeights", len(resp.EpochGroupData.ValidationWeights))
-
-	return c.cachedGroupData, nil
+	return c.GetEpochGroupData(context.Background(), currentEpochIndex)
 }
 
 // GetEpochGroupData returns epoch group data for specific epoch.


### PR DESCRIPTION
EpochGroupDataCache has two cache systems:
- Legacy: cachedEpochIndex + cachedGroupData (for GetCurrentEpochGroupData)
- Multi-epoch: epochCache map (for GetEpochGroupData)

These two paths have independent invalidation logic that can diverge under rapid epoch transitions — legacy could serve stale data from epoch N while the multi-epoch cache has moved to N+1.

Fix: delegate GetCurrentEpochGroupData to GetEpochGroupData so all cache reads go through a single path.

File: decentralized-api/internal/epoch_group_cache.go
Severity: MEDIUM — cache inconsistency under rapid epoch transitions