### PR TITLE
[P0] [#899] Add some E2E inference validation tests

### DIFF
--- a/subnet/cmd/subnetctl/main.go
+++ b/subnet/cmd/subnetctl/main.go
@@ -132,6 +132,7 @@ func main() {
 	mux.HandleFunc("/v1/status", proxy.handleStatus)
 	mux.HandleFunc("/v1/debug/pending", proxy.handleDebugPending)
 	mux.HandleFunc("/v1/debug/state", proxy.handleDebugState)
+	mux.HandleFunc("/v1/inference", proxy.handleInference)
 
 	addr := ":" + p
 	log.Printf("subnetctl listening on %s (escrow=%s model=%s)", addr, eid, mdl)

--- a/subnet/cmd/subnetctl/proxy.go
+++ b/subnet/cmd/subnetctl/proxy.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -509,4 +510,33 @@ func (p *Proxy) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+func (p *Proxy) handleInference(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	inferenceID := r.Header.Get("X-Inference-Id")
+	if inferenceID == "" {
+		http.Error(w, "X-Inference-Id required", http.StatusBadRequest)
+		return
+	}
+
+	parsedID, err := strconv.ParseUint(inferenceID, 10, 64)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid inference ID %s: %v", inferenceID, err), http.StatusBadRequest)
+		return
+	}
+
+	st := p.sm.SnapshotState()
+	inference, found := st.Inferences[parsedID]
+	if !found {
+		http.Error(w, fmt.Sprintf("inference not found for inference ID: %s", inferenceID), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(inference)
 }

--- a/subnet/types/domain.go
+++ b/subnet/types/domain.go
@@ -26,22 +26,22 @@ const (
 
 // InferenceRecord tracks the state of a single inference within a session.
 type InferenceRecord struct {
-	Status       InferenceStatus
-	ExecutorSlot uint32
-	Model        string
-	PromptHash   []byte
-	ResponseHash []byte
-	InputLength  uint64
-	MaxTokens    uint64
-	InputTokens  uint64
-	OutputTokens uint64
-	ReservedCost uint64
-	ActualCost   uint64
-	StartedAt    int64
-	ConfirmedAt  int64
-	VotesValid   uint32
-	VotesInvalid uint32
-	ValidatedBy  Bitmap128
+	Status       InferenceStatus `json:"status"`
+	ExecutorSlot uint32          `json:"executor_slot"`
+	Model        string          `json:"model"`
+	PromptHash   []byte          `json:"prompt_hash"`
+	ResponseHash []byte          `json:"response_hash,omitempty"`
+	InputLength  uint64          `json:"input_length"`
+	MaxTokens    uint64          `json:"max_tokens"`
+	InputTokens  uint64          `json:"input_tokens,omitempty"`
+	OutputTokens uint64          `json:"output_tokens,omitempty"`
+	ReservedCost uint64          `json:"reserved_cost"`
+	ActualCost   uint64          `json:"actual_cost,omitempty"`
+	StartedAt    int64           `json:"started_at"`
+	ConfirmedAt  int64           `json:"confirmed_at,omitempty"`
+	VotesValid   uint32          `json:"votes_valid,omitempty"`
+	VotesInvalid uint32          `json:"votes_invalid,omitempty"`
+	ValidatedBy  Bitmap128       `json:"validated_by,omitempty"`
 }
 
 // HostStats tracks per-host performance metrics within a session.

--- a/testermint/src/main/kotlin/LocalInferencePair.kt
+++ b/testermint/src/main/kotlin/LocalInferencePair.kt
@@ -773,6 +773,14 @@ data class LocalInferencePair(
         } catch (_: Exception) { /* ignore */ }
     }
 
+    fun getSubnetInferenceState(proxyUrl: String, inferenceId: Long): String {
+        val result = api.executor.exec(listOf(
+            "sh", "-c",
+            "curl -sf $proxyUrl/v1/inference -H 'X-Inference-Id: $inferenceId'"
+        ), null)
+        return result.joinToString("")
+    }
+
     fun sendChatCompletion(proxyUrl: String, model: String, prompt: String, stream: Boolean = false): String {
         val body = """{"model":"$model","messages":[{"role":"user","content":"$prompt"}],"max_tokens":100,"stream":$stream}"""
         val result = api.executor.exec(listOf(

--- a/testermint/src/main/kotlin/Main.kt
+++ b/testermint/src/main/kotlin/Main.kt
@@ -401,6 +401,7 @@ fun GsonBuilder.registerCosmosTypes(): GsonBuilder {
         .registerTypeAdapter(java.lang.Float::class.java, FloatSerializer())
         .registerTypeAdapter(ConfirmationPoCPhase::class.java, ConfirmationPoCPhaseDeserializer())
         .registerTypeAdapter(InferenceStatus::class.java, InferenceStatusDeserializer())
+        .registerTypeAdapter(SubnetInferenceStatus::class.java, SubnetInferenceStatusDeserializer())
         .registerTypeAdapter(ProposalStatus::class.java, ProposalStatusDeserializer())
 }
 

--- a/testermint/src/main/kotlin/data/converters.kt
+++ b/testermint/src/main/kotlin/data/converters.kt
@@ -167,6 +167,7 @@ class ConfirmationPoCPhaseDeserializer : JsonDeserializer<ConfirmationPoCPhase> 
             ?: throw IllegalArgumentException("Unknown ConfirmationPoCPhase value: $intValue")
     }
 }
+
 class InferenceStatusDeserializer : JsonDeserializer<InferenceStatus> {
     override fun deserialize(
         json: JsonElement,
@@ -184,6 +185,23 @@ class InferenceStatusDeserializer : JsonDeserializer<InferenceStatus> {
         )
     }
 }
+
+class SubnetInferenceStatusDeserializer : JsonDeserializer<SubnetInferenceStatus> {
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): SubnetInferenceStatus {
+        return SubnetInferenceStatus.fromAny(
+            if (json.isJsonPrimitive && json.asJsonPrimitive.isNumber) {
+                json.asInt
+            } else {
+                null
+            }
+        )
+    }
+}
+
 class ProposalStatusDeserializer : JsonDeserializer<ProposalStatus> {
     override fun deserialize(
         json: JsonElement,

--- a/testermint/src/main/kotlin/data/subnet.kt
+++ b/testermint/src/main/kotlin/data/subnet.kt
@@ -80,3 +80,93 @@ data class SubnetSlotSignatureEntry(
     val slotId: Int,
     val signature: String
 )
+
+data class SubnetInferencePayload(
+    val status: SubnetInferenceStatus,
+    @SerializedName("executor_slot")
+    val executorSlot: Int,
+    val model: String,
+    @SerializedName("prompt_hash")
+    val promptHash: String,
+    @SerializedName("response_hash")
+    val responseHash: String?,
+    @SerializedName("input_length")
+    val inputLength: Long,
+    @SerializedName("max_tokens")
+    val maxTokens: Long,
+    @SerializedName("input_tokens")
+    val inputTokens: Long?,
+    @SerializedName("output_tokens")
+    val outputTokens: Long?,
+    @SerializedName("reserved_cost")
+    val reservedCost: Long,
+    @SerializedName("actual_cost")
+    val actualCost: Long?,
+    @SerializedName("started_at")
+    val startedAt: Long,
+    @SerializedName("confirmed_at")
+    val confirmedAt: Long?,
+    @SerializedName("votes_valid")
+    val votesValid: Int?,
+    @SerializedName("votes_invalid")
+    val votesInvalid: Int?,
+    @SerializedName("validated_by")
+    val validatedBy: Array<Long>?,
+) {
+    val statusEnum: SubnetInferenceStatus
+        get() = status
+}
+
+enum class SubnetInferenceStatus(val value: Int) {
+    PENDING(0),
+    STARTED(1),
+    FINISHED(2),
+    CHALLENGED(3),
+    VALIDATED(4),
+    INVALIDATED(5),
+    TIMED_OUT(6),
+    UNSPECIFIED(7);
+
+    companion object {
+        fun fromValue(value: Int): SubnetInferenceStatus =
+            values().find { it.value == value } ?: UNSPECIFIED
+
+        fun fromAny(value: Any?): SubnetInferenceStatus {
+            return when (value) {
+                is Number -> fromValue(value.toInt())
+                else -> UNSPECIFIED
+            }
+        }
+    }
+}
+
+data class SubnetChallengeReceiptRequest(
+    @SerializedName("inference_id")
+    val inferenceID: Long,
+    val payload: SubnetPayloadJSON,
+    val diffs: List<SubnetDiffJSON>,
+)
+
+data class SubnetChallengeReceiptResponse(
+    val receipt: List<String>,
+)
+
+data class SubnetDiffJSON(
+    val nonce: Long,
+    val txs: String,
+    @SerializedName("user_sig")
+    val userSig: String,
+    @SerializedName("post_state_root")
+    val postStateRoot: String,
+)
+
+data class SubnetPayloadJSON(
+    val prompt: String,
+    val model: String,
+    @SerializedName("input_length")
+    val inputLength: Long,
+    @SerializedName("max_tokens")
+    val maxTokens: Long,
+    @SerializedName("started_at")
+    val startedAt: Long,
+)

--- a/testermint/src/test/kotlin/SubnetTests.kt
+++ b/testermint/src/test/kotlin/SubnetTests.kt
@@ -1,5 +1,6 @@
 import com.productscience.*
 import com.productscience.data.*
+import kotlin.test.assertNotNull
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -11,13 +12,27 @@ import java.util.concurrent.Executors
 import kotlin.test.assertNotNull
 
 class SubnetTests : TestermintTest() {
-
     private val noRestrictionsSpec = spec<AppState> {
         this[AppState::restrictions] = spec<RestrictionsState> {
             this[RestrictionsState::params] = spec<RestrictionsParams> {
                 this[RestrictionsParams::restrictionEndBlock] = 0L
                 this[RestrictionsParams::emergencyTransferExemptions] = emptyList<EmergencyTransferExemption>()
                 this[RestrictionsParams::exemptionUsageTracking] = emptyList<ExemptionUsageEntry>()
+            }
+        }
+    }
+
+    private val alwaysValidateSpec = spec<AppState> {
+        this[AppState::inference] = spec<InferenceState> {
+            this[InferenceState::params] = spec<InferenceParams> {
+                this[InferenceParams::validationParams] = spec<ValidationParams> {
+                    this[ValidationParams::minValidationAverage] = Decimal.fromDouble(100.0)
+                    this[ValidationParams::maxValidationAverage] = Decimal.fromDouble(100.0)
+                    this[ValidationParams::downtimeHThreshold] = Decimal.fromDouble(100.0)
+                }
+                this[InferenceParams::bandwidthLimitsParams] = spec<BandwidthLimitsParams> {
+                    this[BandwidthLimitsParams::minimumConcurrentInvalidations] = 100L
+                }
             }
         }
     }
@@ -31,6 +46,13 @@ class SubnetTests : TestermintTest() {
             epochLength = 40,
             epochShift = 10
         ).merge(noRestrictionsSpec)
+    )
+
+    private val noRestrictionsAlwaysValidateConfig = inferenceConfig.copy(
+        genesisSpec = inferenceConfig.genesisSpec
+            ?.merge(noRestrictionsSpec)
+            ?.merge(alwaysValidateSpec)
+            ?: noRestrictionsSpec.merge(alwaysValidateSpec)
     )
 
     @Test
@@ -187,7 +209,8 @@ class SubnetTests : TestermintTest() {
 
         try {
             logSection("Sending streaming chat completions via proxy")
-            for (i in 0 until 20) {
+            val numInferences = 20L
+            for (i in 0 until numInferences) {
                 val response = genesis.sendChatCompletion(handle.proxyUrl, defaultModel, "test prompt $i", stream = true)
                 assertThat(response).isNotEmpty()
                 assertThat(response).contains("data:")
@@ -209,6 +232,17 @@ class SubnetTests : TestermintTest() {
             logSection("Verifying escrow settled")
             val escrow = genesis.node.querySubnetEscrow(1)
             assertThat(escrow.escrow!!.settled).isTrue()
+
+            logSection("Verifying inference statuses")
+            for (inferenceId in 1..numInferences) {
+                val inference = cosmosJson.fromJson(
+                    genesis.getSubnetInferenceState(handle.proxyUrl, inferenceId),
+                    SubnetInferencePayload::class.java,
+                )
+                logSection("Inference $inferenceId: $inference")
+                assertNotNull(inference)
+                assertThat(inference.status).isEqualTo(SubnetInferenceStatus.FINISHED)
+            }
         } finally {
             genesis.stopSubnetProxy(1)
         }
@@ -328,5 +362,92 @@ class SubnetTests : TestermintTest() {
         val mempool = genesis.api.getSubnetMempool(1)
         assertThat(mempool.txs).isNotNull()
         assertThat(mempool.txs).isEmpty()
+    }
+
+    @Test
+    fun `invalid inference is challenged`() {
+        val (cluster, genesis) = initCluster(config = noRestrictionsAlwaysValidateConfig, reboot = true)
+        genesis.waitForNextEpoch()
+
+        cluster.allPairs.forEach { pair ->
+            pair.mock?.setInferenceResponse(
+                defaultInferenceResponseObject,
+                streamDelay = Duration.ofMillis(50),
+                segment = "",
+            )
+        }
+        cluster.allPairs.last().mock?.setInferenceResponse(
+            defaultInferenceResponseObject.withMissingLogit(),
+            segment = "",
+        )
+
+        logSection("Creating separate user account")
+        val userKeyName = "subnet-proxy-stream-user"
+        val userKey = genesis.node.createKey(userKeyName)
+        val userAddress = userKey.address
+        val fundAmount = 10_000_000_000L
+        val transferResp = genesis.submitTransaction(
+            listOf("bank", "send", genesis.node.getColdAddress(), userAddress, "${fundAmount}${genesis.config.denom}")
+        )
+        assertThat(transferResp.code).isEqualTo(0)
+
+        genesis.waitForNextInferenceWindow()
+
+        logSection("Creating subnet escrow from user account")
+        val escrowAmount = 7_000_000_000L
+        val txResp = genesis.createSubnetEscrow(escrowAmount, from = userKeyName)
+        assertThat(txResp.code).isEqualTo(0)
+
+        logSection("Starting subnet proxy")
+        val escrowId = 1L
+        val handle = genesis.startSubnetProxy(escrowId, keyName = userKeyName)
+
+        try {
+            logSection("Sending streaming chat completions via proxy")
+            val numInferences = 20L
+            for (i in 0 until numInferences) {
+                val response = genesis.sendChatCompletion(handle.proxyUrl, defaultModel, "test prompt $i")
+                assertThat(response).isNotEmpty()
+            }
+
+            logSection("Finalizing via proxy")
+            val result = genesis.finalizeSubnetProxy(handle.proxyUrl)
+
+            logSection("Verifying settlement data")
+            assertThat(result.parsed.escrowId).isEqualTo("$escrowId")
+            assertThat(result.parsed.nonce).isGreaterThan(0)
+            assertThat(result.parsed.hostStats).isNotEmpty()
+            assertThat(result.parsed.signatures).isNotEmpty()
+
+            logSection("Submitting settlement from user account")
+            val settleResp = genesis.settleSubnetEscrow(result.rawJson, from = userKeyName)
+            assertThat(settleResp.code).isEqualTo(0)
+
+            logSection("Verifying escrow settled")
+            val escrow = genesis.node.querySubnetEscrow(escrowId)
+            assertThat(escrow.escrow!!.settled).isTrue()
+
+            logSection("Verifying inference status")
+            val inferenceId = 1L
+            val maxTries = 10
+            val inference = (0 until numInferences).firstNotNullOf {
+                val inference = cosmosJson.fromJson(
+                    genesis.getSubnetInferenceState(handle.proxyUrl, it),
+                    SubnetInferencePayload::class.java,
+                )
+                inference?.status?.let { status ->
+                    if (status == SubnetInferenceStatus.CHALLENGED) {
+                        inference
+                    } else {
+                        null
+                    }
+                }
+            }
+            logSection("Inference: $inference")
+            assertThat(inference.status).isEqualTo(SubnetInferenceStatus.CHALLENGED)
+            assertThat(inference.votesInvalid).isNotZero()
+        } finally {
+            genesis.stopSubnetProxy(escrowId)
+        }
     }
 }


### PR DESCRIPTION
Problem: We need to ensure that inference validation is working as intended, and using Testermint, we can write end-to-end tests for that.

Solution: Expose a new endpoint to query inferences from subnetctl and check that the inference status is as expected with two new tests. Add some Kotlin data classes mimicking the Go types and serialize inferences.