### PR TITLE
fix(keeper): propagate InjectParamsIntoContext error in Validation handler

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"cosmossdk.io/collections"
@@ -24,6 +25,7 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 	ctx, err := k.Keeper.InjectParamsIntoContext(sdk.UnwrapSDKContext(goCtx))
 	if err != nil {
 		k.LogWarn("Validation: failed to inject params", types.Validation, "error", err)
+		return nil, fmt.Errorf("validation: failed to inject params into context: %w", err)
 	}
 
 	k.LogInfo("Received MsgValidation", types.Validation,


### PR DESCRIPTION
## Problem

In , when  fails, the code logs a warning but **continues executing** with a potentially stale or zero-value context:

```go
ctx, err := k.Keeper.InjectParamsIntoContext(sdk.UnwrapSDKContext(goCtx))
if err != nil {
    k.LogWarn("Validation: failed to inject params", types.Validation, "error", err)
    // no return — continues with broken ctx
}
```

All subsequent calls (, , , etc.) use this broken context, operating without the injected params and potentially producing incorrect validation results.

## Fix

Return the error immediately when  fails, so the transaction is rejected at the earliest safe point:

```go
if err != nil {
    k.LogWarn("Validation: failed to inject params", types.Validation, "error", err)
    return nil, fmt.Errorf("validation: failed to inject params into context: %w", err)
}
```

## Impact

- Prevents silent wrong-context execution in the critical validation path
- The failure is already logged via , so observability is unchanged
- The change is a 2-line addition with no behaviour change on the happy path