### PR TITLE
fix: skip proof query when CreatedAtBlockHeight is 0 for old epochs

### DIFF
--- a/decentralized-api/internal/server/public/get_participants_handler.go
+++ b/decentralized-api/internal/server/public/get_participants_handler.go
@@ -281,6 +281,15 @@ func queryActiveParticipants(rpcClient *rpcclient.HTTP, cdc *codec.ProtoCodec, e
 	// 2. The implemented proof system has a bug anyway and needs to be revisited
 
 	blockHeight := activeParticipants.CreatedAtBlockHeight
+
+	// If CreatedAtBlockHeight is 0 (old epochs before this field was populated),
+	// skip the proof query — CometBFT rejects height=0 with an error.
+	// Return the first query result directly instead.
+	if blockHeight == 0 {
+		logging.Warn("CreatedAtBlockHeight is 0 for epoch, skipping proof query", types.Participants)
+		return result, nil
+	}
+
 	result, err = cosmos_client.QueryByKeyWithOptions(rpcClient, "inference", dataKey, blockHeight, true)
 	if err != nil {
 		logging.Error("Failed to query active participant. Req 2", types.Participants, "error", err)


### PR DESCRIPTION
Closes #983

## Problem

`GET /api/v1/epochs/{N}/participants` returns 500 Internal Server Error for past epochs:

```
height must be greater than 0, but got 0
```

Repro: http://node1.gonka.ai:8000/api/v1/epochs/215/participants

Current epoch works fine. Past epochs (where data was stored before the `CreatedAtBlockHeight` field was introduced) fail.

## Root Cause

In `queryActiveParticipants` (`get_participants_handler.go`):

1. First query (no height) fetches `activeParticipants`
2. `blockHeight := activeParticipants.CreatedAtBlockHeight` — for old epochs this is **0** (field not populated at the time of storage)
3. Second call `QueryByKeyWithOptions(..., height=0, prove=true)` — CometBFT rejects height=0

## Fix

Check if `blockHeight == 0` before the second query. If so, skip the proof query and return the first result directly. A `Warn` log is emitted for observability.

## Testing

Verified against epoch 215 (previously returned 500) and epoch 216 (current, unaffected).