### PR TITLE
fix: prevent fund loss in unsettled escrow pruning and add missing overflow guards

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
@@ -34,6 +35,9 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 			return nil, fmt.Errorf("host_stats slot_id %d out of range", hs.SlotId)
 		}
 		addr := escrow.Slots[hs.SlotId]
+		if validatorCosts[addr] > math.MaxUint64-hs.Cost {
+			return nil, fmt.Errorf("cost overflow for validator %s", addr)
+		}
 		validatorCosts[addr] += hs.Cost
 	}
 

--- a/inference-chain/x/inference/keeper/pruning.go
+++ b/inference-chain/x/inference/keeper/pruning.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -134,17 +135,17 @@ func (k Keeper) GetSubnetPruner(params types.Params) Pruner[collections.Pair[uin
 			escrow, found := k.GetSubnetEscrow(ctx, escrowID)
 			if found && !escrow.Settled {
 				if err := k.distributeUnsettledEscrow(ctx, escrow); err != nil {
-					k.LogError("failed to distribute unsettled escrow", types.Pruning,
-						"escrow_id", escrowID, "error", err)
+					// Do not delete the escrow — it must be retried next block.
+					return fmt.Errorf("failed to distribute unsettled escrow %d: %w", escrowID, err)
 				}
 			}
 
 			// Delete escrow and index entry
 			if err := k.SubnetEscrows.Remove(ctx, escrowID); err != nil {
-				k.LogError("failed to remove subnet escrow", types.Pruning, "escrow_id", escrowID, "error", err)
+				return fmt.Errorf("failed to remove subnet escrow %d: %w", escrowID, err)
 			}
 			if err := k.SubnetEscrowsByEpoch.Remove(ctx, collections.Join(epochIndex, escrowID)); err != nil {
-				k.LogError("failed to remove subnet escrow index", types.Pruning, "escrow_id", escrowID, "error", err)
+				return fmt.Errorf("failed to remove subnet escrow index %d: %w", escrowID, err)
 			}
 			return nil
 		},

--- a/inference-chain/x/inference/keeper/subnet_host_stats.go
+++ b/inference-chain/x/inference/keeper/subnet_host_stats.go
@@ -27,13 +27,25 @@ func (k Keeper) AggregateSubnetHostStats(ctx context.Context, epochIndex uint64,
 			EpochIndex:  epochIndex,
 		}
 	}
+	if existing.Missed > math.MaxUint32-slotStats.Missed {
+		return fmt.Errorf("missed overflow aggregating subnet host stats")
+	}
 	existing.Missed += slotStats.Missed
+	if existing.Invalid > math.MaxUint32-slotStats.Invalid {
+		return fmt.Errorf("invalid overflow aggregating subnet host stats")
+	}
 	existing.Invalid += slotStats.Invalid
 	if existing.Cost > math.MaxUint64-slotStats.Cost {
 		return fmt.Errorf("cost overflow aggregating subnet host stats")
 	}
 	existing.Cost += slotStats.Cost
+	if existing.RequiredValidations > math.MaxUint32-slotStats.RequiredValidations {
+		return fmt.Errorf("required_validations overflow aggregating subnet host stats")
+	}
 	existing.RequiredValidations += slotStats.RequiredValidations
+	if existing.CompletedValidations > math.MaxUint32-slotStats.CompletedValidations {
+		return fmt.Errorf("completed_validations overflow aggregating subnet host stats")
+	}
 	existing.CompletedValidations += slotStats.CompletedValidations
 	return k.SubnetHostEpochStatsMap.Set(ctx, key, existing)
 }

--- a/inference-chain/x/inference/keeper/subnet_host_stats_test.go
+++ b/inference-chain/x/inference/keeper/subnet_host_stats_test.go
@@ -1,0 +1,121 @@
+package keeper_test
+
+import (
+	"math"
+	"testing"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+func TestAggregateSubnetHostStats_OverflowProtection(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	participant := sdk.AccAddress(make([]byte, 20))
+	participant[0] = 0x01
+	epochIndex := uint64(5)
+	key := collections.Join(epochIndex, participant)
+
+	t.Run("Missed overflow", func(t *testing.T) {
+		// Seed existing stats with Missed near max uint32
+		err := k.SubnetHostEpochStatsMap.Set(ctx, key, types.SubnetHostEpochStats{
+			Participant: participant.String(),
+			EpochIndex:  epochIndex,
+			Missed:      math.MaxUint32 - 1,
+		})
+		require.NoError(t, err)
+
+		err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{
+			Missed: 2, // would overflow: (MaxUint32-1) + 2 > MaxUint32
+		})
+		require.Error(t, err, "Missed overflow must be detected")
+		require.Contains(t, err.Error(), "overflow")
+	})
+
+	t.Run("Invalid overflow", func(t *testing.T) {
+		err := k.SubnetHostEpochStatsMap.Set(ctx, key, types.SubnetHostEpochStats{
+			Participant: participant.String(),
+			EpochIndex:  epochIndex,
+			Invalid:     math.MaxUint32 - 1,
+		})
+		require.NoError(t, err)
+
+		err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{
+			Invalid: 2,
+		})
+		require.Error(t, err, "Invalid overflow must be detected")
+		require.Contains(t, err.Error(), "overflow")
+	})
+
+	t.Run("RequiredValidations overflow", func(t *testing.T) {
+		err := k.SubnetHostEpochStatsMap.Set(ctx, key, types.SubnetHostEpochStats{
+			Participant:         participant.String(),
+			EpochIndex:          epochIndex,
+			RequiredValidations: math.MaxUint32 - 1,
+		})
+		require.NoError(t, err)
+
+		err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{
+			RequiredValidations: 2,
+		})
+		require.Error(t, err, "RequiredValidations overflow must be detected")
+		require.Contains(t, err.Error(), "overflow")
+	})
+
+	t.Run("CompletedValidations overflow", func(t *testing.T) {
+		err := k.SubnetHostEpochStatsMap.Set(ctx, key, types.SubnetHostEpochStats{
+			Participant:          participant.String(),
+			EpochIndex:           epochIndex,
+			CompletedValidations: math.MaxUint32 - 1,
+		})
+		require.NoError(t, err)
+
+		err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{
+			CompletedValidations: 2,
+		})
+		require.Error(t, err, "CompletedValidations overflow must be detected")
+		require.Contains(t, err.Error(), "overflow")
+	})
+
+	t.Run("Cost overflow still works", func(t *testing.T) {
+		err := k.SubnetHostEpochStatsMap.Set(ctx, key, types.SubnetHostEpochStats{
+			Participant: participant.String(),
+			EpochIndex:  epochIndex,
+			Cost:        math.MaxUint64 - 1,
+		})
+		require.NoError(t, err)
+
+		err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{
+			Cost: 2,
+		})
+		require.Error(t, err, "Cost overflow must be detected")
+		require.Contains(t, err.Error(), "overflow")
+	})
+
+	t.Run("No overflow when within bounds", func(t *testing.T) {
+		err := k.SubnetHostEpochStatsMap.Set(ctx, key, types.SubnetHostEpochStats{
+			Participant:          participant.String(),
+			EpochIndex:           epochIndex,
+			Missed:               100,
+			Invalid:              50,
+			Cost:                 1000,
+			RequiredValidations:  200,
+			CompletedValidations: 150,
+		})
+		require.NoError(t, err)
+
+		err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{
+			Missed:               10,
+			Invalid:              5,
+			Cost:                 100,
+			RequiredValidations:  20,
+			CompletedValidations: 15,
+		})
+		require.NoError(t, err, "aggregation within bounds must succeed")
+	})
+}

--- a/inference-chain/x/inference/keeper/subnet_pruning.go
+++ b/inference-chain/x/inference/keeper/subnet_pruning.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
@@ -52,8 +53,7 @@ func (k Keeper) distributeUnsettledEscrow(ctx context.Context, escrow types.Subn
 		}
 		err = k.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, recipient, coins, "subnet_escrow_unsettled_distribution")
 		if err != nil {
-			k.LogError("failed to distribute unsettled escrow funds", types.Pruning,
-				"escrow_id", escrow.Id, "address", addr, "error", err)
+			return fmt.Errorf("failed to distribute unsettled escrow %d to %s: %w", escrow.Id, addr, err)
 		}
 	}
 

--- a/inference-chain/x/inference/keeper/subnet_pruning_test.go
+++ b/inference-chain/x/inference/keeper/subnet_pruning_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"cosmossdk.io/collections"
@@ -218,6 +220,73 @@ func TestPruneSubnetData_UnsettledDistributionAmounts(t *testing.T) {
 	}
 
 	require.NoError(t, pruneSubnet(k, ctx, 5))
+}
+
+func TestPruneSubnetData_UnsettledEscrowPreservedOnPartialSendFailure(t *testing.T) {
+	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
+
+	// Create 4 unique validators in 16 slots (4 slots each)
+	addrs := make([]sdk.AccAddress, 4)
+	for i := range addrs {
+		addrs[i] = sdk.AccAddress(make([]byte, 20))
+		addrs[i][0] = byte(i + 1)
+	}
+
+	slots := make([]string, keeper.SubnetGroupSize)
+	for i := 0; i < 4; i++ {
+		slots[i] = addrs[0].String()
+	}
+	for i := 4; i < 8; i++ {
+		slots[i] = addrs[1].String()
+	}
+	for i := 8; i < 12; i++ {
+		slots[i] = addrs[2].String()
+	}
+	for i := 12; i < 16; i++ {
+		slots[i] = addrs[3].String()
+	}
+
+	escrow := &types.SubnetEscrow{
+		Creator:    "gonka1creator",
+		Amount:     8_000_000_000, // 8 GNK
+		Slots:      slots,
+		EpochIndex: 3,
+		Settled:    false, // unsettled
+	}
+	id, err := k.StoreSubnetEscrow(ctx, escrow, 1)
+	require.NoError(t, err)
+
+	// Validators are paid in slot order (deterministic): addr1, addr2, addr3, addr4.
+	// First 2 succeed, 3rd fails — distribution should abort with error.
+	sendCallCount := 0
+	mock.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, gomock.Any(), gomock.Any(), gomock.Eq("subnet_escrow_unsettled_distribution")).
+		DoAndReturn(func(_ context.Context, _ string, _ sdk.AccAddress, _ sdk.Coins, _ string) error {
+			sendCallCount++
+			if sendCallCount == 3 {
+				return fmt.Errorf("simulated bank send failure")
+			}
+			return nil
+		}).
+		Times(3) // called 3 times: 2 succeed, 3rd fails, 4th never reached
+
+	// The Remover should NOT delete the escrow when distribution fails.
+	// The Pruner framework logs the error and continues, so pruneSubnet returns nil.
+	// But the escrow must be preserved for retry on the next block.
+	err = pruneSubnet(k, ctx, 5)
+	require.NoError(t, err)
+
+	// Escrow must still exist so it can be retried next block.
+	_, found := k.GetSubnetEscrow(ctx, id)
+	require.True(t, found, "escrow must be preserved when distribution fails — fund loss bug")
+
+	// Pruning state must NOT advance past this epoch (epoch 3 is not fully pruned).
+	st, err := k.PruningState.Get(ctx)
+	require.NoError(t, err)
+	require.Less(t, st.SubnetPrunedEpoch, int64(3),
+		"pruning state must not advance past epoch with failed distribution")
 }
 
 func TestPruneSubnetData_TracksProgress(t *testing.T) {


### PR DESCRIPTION
Closes #979

## Summary

Three related fixes in subnet escrow code introduced in v0.2.11:

### 1. Fund loss in unsettled escrow pruning

`distributeUnsettledEscrow` logged `SendCoinsFromModuleToAccount` failures but returned nil. The Remover then deleted the escrow, permanently locking the failed validators' share in the module account.

**Fix**: `distributeUnsettledEscrow` now returns error on any send failure. The Remover propagates the error (escrow preserved for retry on next block). Also propagates `SubnetEscrows.Remove` and `SubnetEscrowsByEpoch.Remove` errors instead of swallowing them.

### 2. Inconsistent overflow guards in `AggregateSubnetHostStats`

`Cost` (uint64) had an overflow check, but `Missed`, `Invalid`, `RequiredValidations`, `CompletedValidations` (all uint32) did not.

**Fix**: Added `math.MaxUint32` overflow checks to all four fields, matching the existing `Cost` pattern.

### 3. Missing overflow check in `SettleSubnetEscrow`

`validatorCosts[addr] += hs.Cost` accumulated per-validator costs without overflow protection.

**Fix**: Added `math.MaxUint64` overflow check before accumulation.

## Files changed

| File | Change |
|------|--------|
| `subnet_pruning.go` | Return error from `distributeUnsettledEscrow` on send failure |
| `pruning.go` | Remover propagates errors, preserves escrow on failure |
| `subnet_host_stats.go` | Overflow guards for 4 uint32 fields |
| `msg_server_settle_subnet_escrow.go` | Overflow guard for validator cost aggregation |
| `subnet_pruning_test.go` | Regression test: escrow preserved on partial send failure |
| `subnet_host_stats_test.go` | Overflow protection tests (6 sub-tests) |

## Test plan

- `TestPruneSubnetData_UnsettledEscrowPreservedOnPartialSendFailure` — mocks SendCoins to fail on 3rd validator; verifies escrow is NOT deleted and pruning state does not advance (red-green: fails without fix, passes with fix)
- `TestAggregateSubnetHostStats_OverflowProtection` — verifies overflow detection for Missed, Invalid, RequiredValidations, CompletedValidations, Cost, and happy path (red-green: 4 sub-tests fail without fix)
- Existing tests (`TestPruneSubnetData_UnsettledEscrowDistributesFunds`, `TestPruneSubnetData_UnsettledDistributionAmounts`) — verify successful distribution path is unchanged