### PR TITLE
feat: intra-epoch circuit breaker with reputation-adjusted executor selection

### DIFF
--- a/decentralized-api/internal/server/public/get_participants_handler.go
+++ b/decentralized-api/internal/server/public/get_participants_handler.go
@@ -281,6 +281,15 @@ func queryActiveParticipants(rpcClient *rpcclient.HTTP, cdc *codec.ProtoCodec, e
 	// 2. The implemented proof system has a bug anyway and needs to be revisited
 
 	blockHeight := activeParticipants.CreatedAtBlockHeight
+
+	// If CreatedAtBlockHeight is 0 (old epochs before this field was populated),
+	// skip the proof query — CometBFT rejects height=0 with an error.
+	// Return the first query result directly instead.
+	if blockHeight == 0 {
+		logging.Warn("CreatedAtBlockHeight is 0 for epoch, skipping proof query", types.Participants)
+		return result, nil
+	}
+
 	result, err = cosmos_client.QueryByKeyWithOptions(rpcClient, "inference", dataKey, blockHeight, true)
 	if err != nil {
 		logging.Error("Failed to query active participant. Req 2", types.Participants, "error", err)

--- a/docs/research/health-aware-executor-selection.md
+++ b/docs/research/health-aware-executor-selection.md
@@ -1,0 +1,96 @@
+# Research: Node Health-Aware Executor Selection
+
+**Issue:** #3  
+**Date:** 2026-03-24  
+**Status:** Complete — implementation tasks created (#4, #5, #6)
+
+---
+
+## Summary
+
+When a validator goes offline or degrades, it continues receiving inference requests via `GetRandomExecutor` (pure staking-weight random selection). This causes missed inferences (3.25% miss rate, 81k misses in epochs 161–191), validator penalties, and slow responses.
+
+## Key Findings
+
+### Miss Data Flow
+
+```
+Inference expires (EndBlock, module.go:319)
+  → executor.CurrentEpochStats.MissedRequests++
+  → UpdateParticipantStatus() → SPRT test (getInactiveStatus)
+      → INACTIVE/INVALID: removeFromEpochGroups() ← exits selection pool
+  
+Epoch end (accountsettle.go:227):
+  → EpochPerformanceSummary.MissedRequests persisted
+
+Next epoch start (addEpochMembers, module.go:743):
+  → calculateParticipantReputation() → Reputation score 0–100
+  → member.Weight = p.Weight  ← staking tokens, NOT reputation!
+  → ValidationWeights[].Reputation stored but UNUSED for selection
+```
+
+### Existing Circuit Breaker
+
+The SPRT (`getInactiveStatus`, `calculations/status.go`) IS plugged into selection — it removes nodes from EpochGroup when statistically flagged. However, SPRT is conservative and slow. A node going from 0% → 28% miss rate needs 10–50+ inferences before SPRT triggers.
+
+**Gap:** No fast intra-epoch circuit breaker for mid-epoch degradation.
+
+### Weighted Selection
+
+`selectRandomParticipant` (`epochgroup/random.go`) already uses cumulative-weight random selection. The weight is staking tokens. The reputation score (0–100, computed from historical miss data) is computed but never applied to selection weight.
+
+**The fix is surgical:** apply reputation as a weight multiplier at epoch start.
+
+### Latency
+
+No on-chain latency tracking. Must be handled off-chain in decentralized-api.
+
+---
+
+## Implementation Tasks
+
+| # | Title | Layer | Priority |
+|---|-------|-------|----------|
+| [#4](https://github.com/MinglesAI/gonka/issues/4) | Reputation-adjusted selection weight | On-chain, epoch start | High |
+| [#5](https://github.com/MinglesAI/gonka/issues/5) | Intra-epoch fast circuit breaker in createFilterFn | On-chain, intra-epoch | High |
+| [#6](https://github.com/MinglesAI/gonka/issues/6) | Off-chain latency-aware executor retry | Off-chain, decentralized-api | Medium |
+
+---
+
+## Architecture
+
+### Component A: Reputation-Weighted Selection (#4)
+
+At `addEpochMembers`, scale `member.Weight` by `reputation / 100`:
+- Node with reputation 50 → 50% traffic share relative to full-weight node
+- New nodes (reputation 0) → 1% floor (not zero)
+- Perfect nodes (reputation 100) → full stake weight
+
+### Component B: Fast Circuit Breaker (#5)
+
+In `createFilterFn`, add `createHealthFilterFn`:
+- Exclude nodes with `MissedRequests / Total > 25%` when `Total >= 4`
+- Compose with existing PoC filter
+- Safety fallback: if ALL nodes degraded, bypass filter (no empty pool)
+- New `ValidationParams` fields: `HealthCircuitBreakerMissThreshold`, `HealthCircuitBreakerMinSamples`
+
+### Component C: Latency Retry (#6)
+
+In `decentralized-api/internal/server/public/post_chat_handler.go`:
+- In-memory EMA latency tracker per executor
+- Retry selection if `EMA > 2× median` with ≥4 samples (max 2 retries)
+- No on-chain changes
+
+---
+
+## Files Referenced
+
+- `inference-chain/x/inference/keeper/query_get_random_executor.go` — selection entry point
+- `inference-chain/x/inference/epochgroup/random.go` — `selectRandomParticipant`
+- `inference-chain/x/inference/module/module.go` — `addEpochMembers`, `handleInferenceExpiry`
+- `inference-chain/x/inference/calculations/status.go` — SPRT circuit breaker
+- `inference-chain/x/inference/calculations/reputation.go` — reputation calculation
+- `inference-chain/x/inference/keeper/accountsettle.go` — epoch settlement, miss tracking
+- `inference-chain/x/inference/types/params.go` — `ValidationParams`
+- `subnet/host/timeout.go` — timeout verification (no changes needed)
+- `decentralized-api/internal/server/public/post_chat_handler.go` — API executor selection

--- a/inference-chain/proto/inference/inference/params.proto
+++ b/inference-chain/proto/inference/inference/params.proto
@@ -104,6 +104,12 @@ message ValidationParams {
   Decimal quick_failure_threshold = 23; // The threshold of probabilty of consecutive failures to cause a quick invalidation
   Decimal binom_test_p0 = 24; // The null hypothesis probability for the binomial test (default 0.10)
   bool claim_validation_enabled = 25; // Enables claim-time validation checks in MsgClaimRewards
+
+  // Circuit breaker parameters (governance-adjustable without a chain upgrade)
+  uint64 cb_miss_threshold_pct = 26;       // miss rate % (0–100) above which a node is excluded (default 25)
+  uint64 cb_min_samples = 27;              // minimum inferences before threshold applies (default 4)
+  int64  cb_initial_cooldown_blocks = 28;  // initial exclusion cooldown in blocks (~5 min at 5s/block; default 50)
+  int64  cb_max_cooldown_blocks = 29;      // max cooldown with exponential backoff (~50 min; default 500)
 }
 
 message PoCModelParams {

--- a/inference-chain/x/inference/epochgroup/epoch_group.go
+++ b/inference-chain/x/inference/epochgroup/epoch_group.go
@@ -52,6 +52,32 @@ func NewEpochMemberFromActiveParticipant(p *types.ActiveParticipant, reputation 
 	}
 }
 
+// CalculateSelectionWeight scales staking weight by reputation (0–100).
+//
+// Floor: 1% of stakeWeight ensures no complete exclusion at this layer —
+// SPRT handles final exclusion. New nodes (reputation 0) get 1% traffic
+// during ramp-up via the floor.
+func CalculateSelectionWeight(stakeWeight int64, reputation int64) int64 {
+	if stakeWeight <= 0 {
+		return 0
+	}
+	if reputation >= 100 {
+		return stakeWeight
+	}
+	if reputation <= 0 {
+		reputation = 1 // new nodes get 1% traffic during ramp-up
+	}
+	floor := stakeWeight / 100
+	if floor < 1 {
+		floor = 1
+	}
+	adjusted := stakeWeight * reputation / 100
+	if adjusted < floor {
+		return floor
+	}
+	return adjusted
+}
+
 // calculatePocParticipatingNodesWeight calculates the total weight of nodes participating in PoC
 func calculatePocParticipatingNodesWeight(mlNodes []*types.ModelMLNodes) int64 {
 	totalWeight := int64(0)

--- a/inference-chain/x/inference/epochgroup/epoch_group_test.go
+++ b/inference-chain/x/inference/epochgroup/epoch_group_test.go
@@ -543,3 +543,175 @@ func TestGetGroupMembers_UsesPagination(t *testing.T) {
 	require.Equal(t, "addr1", result[0].Member.Address)
 	require.Equal(t, "addr2", result[1].Member.Address)
 }
+
+// ---------------------------------------------------------------------------
+// CalculateSelectionWeight tests
+// ---------------------------------------------------------------------------
+
+func TestCalculateSelectionWeight_PerfectReputation(t *testing.T) {
+	// reputation == 100 → no scaling, return raw stake
+	require.Equal(t, int64(1000), CalculateSelectionWeight(1000, 100))
+}
+
+func TestCalculateSelectionWeight_AboveMax(t *testing.T) {
+	// reputation > 100 still treated as 100
+	require.Equal(t, int64(1000), CalculateSelectionWeight(1000, 120))
+}
+
+func TestCalculateSelectionWeight_ZeroStake(t *testing.T) {
+	// stakeWeight == 0 → always 0
+	require.Equal(t, int64(0), CalculateSelectionWeight(0, 50))
+}
+
+func TestCalculateSelectionWeight_NegativeStake(t *testing.T) {
+	// negative stakeWeight → 0
+	require.Equal(t, int64(0), CalculateSelectionWeight(-500, 50))
+}
+
+func TestCalculateSelectionWeight_ZeroReputation(t *testing.T) {
+	// reputation == 0 → floor (1% of stake, min 1)
+	result := CalculateSelectionWeight(1000, 0)
+	// floor = 1000/100 = 10
+	require.Equal(t, int64(10), result)
+}
+
+func TestCalculateSelectionWeight_NewNodeTinyStake(t *testing.T) {
+	// stake so small floor would be 0 → clamp to 1
+	result := CalculateSelectionWeight(5, 0)
+	require.Equal(t, int64(1), result)
+}
+
+func TestCalculateSelectionWeight_50PctReputation(t *testing.T) {
+	// reputation 50 → 50% of stake (above floor)
+	result := CalculateSelectionWeight(1000, 50)
+	require.Equal(t, int64(500), result)
+}
+
+func TestCalculateSelectionWeight_FloorKicksIn(t *testing.T) {
+	// reputation 0 → adjusted = 0, must return floor
+	// With reputation clamped to 1: adjusted = 1000*1/100 = 10, floor = 10 → equal → return floor
+	require.Equal(t, int64(10), CalculateSelectionWeight(1000, 0))
+	// reputation 1 → adjusted = 10, floor = 10 → return 10
+	require.Equal(t, int64(10), CalculateSelectionWeight(1000, 1))
+}
+
+// ---------------------------------------------------------------------------
+// Proportional traffic distribution test
+// ---------------------------------------------------------------------------
+
+// TestSelectionWeights_ProportionalTraffic verifies that two nodes with equal
+// stake but different reputations receive proportional executor-selection
+// traffic. We run many lottery draws and check that the ratio converges.
+func TestSelectionWeights_ProportionalTraffic(t *testing.T) {
+	const (
+		stake     = int64(1000)
+		repHigh   = int64(100) // perfect node
+		repLow    = int64(50)  // 50% reputation
+		draws     = 100_000
+		tolerance = 0.03 // ±3 percentage points
+	)
+
+	members := []*group.GroupMember{
+		{Member: &group.Member{Address: "high", Weight: "1000"}},
+		{Member: &group.Member{Address: "low", Weight: "1000"}},
+	}
+
+	selectionWeights := map[string]int64{
+		"high": CalculateSelectionWeight(stake, repHigh), // 1000
+		"low":  CalculateSelectionWeight(stake, repLow),  // 500
+	}
+
+	highCount := 0
+	for i := 0; i < draws; i++ {
+		addr := selectRandomParticipant(members, selectionWeights)
+		if addr == "high" {
+			highCount++
+		}
+	}
+
+	// Expected: high gets 1000/(1000+500) ≈ 66.67%, low gets ≈ 33.33%
+	expectedHighFraction := float64(selectionWeights["high"]) / float64(selectionWeights["high"]+selectionWeights["low"])
+	observedHighFraction := float64(highCount) / float64(draws)
+
+	diff := observedHighFraction - expectedHighFraction
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > tolerance {
+		t.Errorf("traffic ratio out of bounds: expected %.4f, got %.4f (diff %.4f > tolerance %.4f)",
+			expectedHighFraction, observedHighFraction, diff, tolerance)
+	}
+}
+
+// TestSelectionWeights_ZeroReputationGetsFloor verifies that a node with
+// reputation 0 still receives ~1% of traffic (floor), not zero.
+func TestSelectionWeights_ZeroReputationGetsFloor(t *testing.T) {
+	const (
+		stake   = int64(1000)
+		draws   = 100_000
+		minFrac = 0.005 // must get at least 0.5% (floor is ~1%)
+	)
+
+	members := []*group.GroupMember{
+		{Member: &group.Member{Address: "good", Weight: "1000"}},
+		{Member: &group.Member{Address: "new", Weight: "1000"}},
+	}
+
+	selectionWeights := map[string]int64{
+		"good": CalculateSelectionWeight(stake, 100), // 1000
+		"new":  CalculateSelectionWeight(stake, 0),   // floor = 10
+	}
+
+	newCount := 0
+	for i := 0; i < draws; i++ {
+		addr := selectRandomParticipant(members, selectionWeights)
+		if addr == "new" {
+			newCount++
+		}
+	}
+
+	newFrac := float64(newCount) / float64(draws)
+	if newFrac < minFrac {
+		t.Errorf("new node (rep=0) received too little traffic: %.4f < %.4f (floor not applied)", newFrac, minFrac)
+	}
+}
+
+// TestBuildSelectionWeightsMap verifies that buildSelectionWeightsMap
+// correctly translates ValidationWeights into reputation-adjusted selection weights.
+func TestBuildSelectionWeightsMap(t *testing.T) {
+	eg := &EpochGroup{
+		GroupData: &types.EpochGroupData{
+			ValidationWeights: []*types.ValidationWeight{
+				{MemberAddress: "perfect", Weight: 1000, Reputation: 100},
+				{MemberAddress: "half", Weight: 1000, Reputation: 50},
+				{MemberAddress: "new", Weight: 1000, Reputation: 0},
+			},
+		},
+	}
+
+	m := eg.buildSelectionWeightsMap()
+
+	require.Equal(t, int64(1000), m["perfect"])
+	require.Equal(t, int64(500), m["half"])
+	require.Equal(t, int64(10), m["new"]) // floor = 1000/100 = 10
+}
+
+// TestValidationWeightsUnchanged verifies that ValidationWeights.Weight is NOT
+// modified by the selection weight computation — PoC voting uses raw stake.
+func TestValidationWeightsUnchanged(t *testing.T) {
+	const rawStake = int64(1000)
+
+	eg := &EpochGroup{
+		GroupData: &types.EpochGroupData{
+			ValidationWeights: []*types.ValidationWeight{
+				{MemberAddress: "addr1", Weight: rawStake, Reputation: 50},
+			},
+		},
+	}
+
+	// Build selection weights — must not mutate ValidationWeights
+	_ = eg.buildSelectionWeightsMap()
+
+	require.Equal(t, rawStake, eg.GroupData.ValidationWeights[0].Weight,
+		"ValidationWeights.Weight must remain raw stake after selection weight computation")
+}

--- a/inference-chain/x/inference/epochgroup/random.go
+++ b/inference-chain/x/inference/epochgroup/random.go
@@ -53,7 +53,11 @@ func (eg *EpochGroup) GetRandomMember(
 		return nil, status.Error(codes.Internal, "After filtering participants the length is 0")
 	}
 
-	participantIndex := selectRandomParticipant(filteredParticipants)
+	// Build reputation-adjusted selection weights from stored ValidationWeights.
+	// PoC voting weights and block-production power (cosmos-sdk group weights) are
+	// unaffected — only the executor-selection lottery uses these adjusted weights.
+	selectionWeights := eg.buildSelectionWeightsMap()
+	participantIndex := selectRandomParticipant(filteredParticipants, selectionWeights)
 
 	participant, ok := eg.ParticipantKeeper.GetParticipant(ctx, participantIndex)
 	if !ok {
@@ -65,8 +69,29 @@ func (eg *EpochGroup) GetRandomMember(
 	return &participant, nil
 }
 
-func selectRandomParticipant(participants []*group.GroupMember) string {
-	cumulativeArray := computeCumulativeArray(participants)
+// buildSelectionWeightsMap computes reputation-adjusted selection weights for all members
+// stored in the group's ValidationWeights. Keys are member addresses.
+//
+// PoC voting weights (ValidationWeights[].Weight) and the cosmos-sdk group member
+// weights (used for block production) are NOT modified; this map is used solely by
+// the executor-selection lottery.
+func (eg *EpochGroup) buildSelectionWeightsMap() map[string]int64 {
+	weights := make(map[string]int64, len(eg.GroupData.ValidationWeights))
+	for _, vw := range eg.GroupData.ValidationWeights {
+		if vw == nil {
+			continue
+		}
+		selWeight := CalculateSelectionWeight(vw.Weight, int64(vw.Reputation))
+		weights[vw.MemberAddress] = selWeight
+	}
+	return weights
+}
+
+// selectRandomParticipant picks a random member using cumulative weighted random
+// selection. selectionWeights overrides the cosmos-sdk group weights for the
+// lottery; if a member address is absent from the map the raw group weight is used.
+func selectRandomParticipant(participants []*group.GroupMember, selectionWeights map[string]int64) string {
+	cumulativeArray := computeCumulativeArray(participants, selectionWeights)
 
 	randomNumber := rand.Int63n(cumulativeArray[len(cumulativeArray)-1])
 	for i, cumulativeWeight := range cumulativeArray {
@@ -78,13 +103,26 @@ func selectRandomParticipant(participants []*group.GroupMember) string {
 	return participants[len(participants)-1].Member.Address
 }
 
-func computeCumulativeArray(participants []*group.GroupMember) []int64 {
+// computeCumulativeArray builds a prefix-sum array of effective selection weights.
+func computeCumulativeArray(participants []*group.GroupMember, selectionWeights map[string]int64) []int64 {
 	cumulativeArray := make([]int64, len(participants))
-	cumulativeArray[0] = int64(getWeight(participants[0]))
+	cumulativeArray[0] = getEffectiveWeight(participants[0], selectionWeights)
 	for i := 1; i < len(participants); i++ {
-		cumulativeArray[i] = cumulativeArray[i-1] + getWeight(participants[i])
+		cumulativeArray[i] = cumulativeArray[i-1] + getEffectiveWeight(participants[i], selectionWeights)
 	}
 	return cumulativeArray
+}
+
+// getEffectiveWeight returns the selection weight for a participant.
+// It prefers the value from selectionWeights (reputation-adjusted) and falls
+// back to the raw cosmos-sdk group weight when no override is present.
+func getEffectiveWeight(participant *group.GroupMember, selectionWeights map[string]int64) int64 {
+	if selectionWeights != nil && participant != nil && participant.Member != nil {
+		if w, ok := selectionWeights[participant.Member.Address]; ok {
+			return w
+		}
+	}
+	return getWeight(participant)
 }
 
 func getWeight(participant *group.GroupMember) int64 {

--- a/inference-chain/x/inference/keeper/circuit_breaker.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker.go
@@ -78,11 +78,19 @@ func (k Keeper) getCBParams(ctx context.Context) cbParams {
 
 // CircuitBreakerEntry holds the per-node state managed by the fast circuit breaker.
 type CircuitBreakerEntry struct {
-	Address        string  `json:"address"`
-	State          CBState `json:"state"`
-	ExcludedAtBlock int64  `json:"excluded_at_block"`
-	CooldownBlocks int64   `json:"cooldown_blocks"`
-	ProbeAttempts  int32   `json:"probe_attempts"`
+	Address          string  `json:"address"`
+	State            CBState `json:"state"`
+	ExcludedAtBlock  int64   `json:"excluded_at_block"`
+	CooldownBlocks   int64   `json:"cooldown_blocks"`
+	ProbeAttempts    int32   `json:"probe_attempts"`
+	// LastRestoredBlock is the block height at which a probe succeeded and the node was
+	// restored to HEALTHY. UpdateCBStateForBlock Pass 2 skips nodes where
+	// ProbeRestored == true && blockHeight == LastRestoredBlock (one-block grace period).
+	LastRestoredBlock int64 `json:"last_restored_block,omitempty"`
+	// ProbeRestored is true when the node was just restored from a probe success.
+	// This flag gates the grace-period check to avoid false positives when both
+	// LastRestoredBlock and blockHeight are zero (e.g. in tests or genesis block).
+	ProbeRestored bool `json:"probe_restored,omitempty"`
 }
 
 // cbStoreKey returns the raw byte key used to store a CB entry for an address.
@@ -268,6 +276,15 @@ func (k Keeper) UpdateCBStateForBlock(ctx context.Context, blockHeight int64) {
 			continue
 		}
 
+		// Grace period: skip nodes that were just restored to HEALTHY by a probe success
+		// in this same block. Without this, EndBlock Pass 2 would immediately re-exclude
+		// them based on stale miss-rate stats before any new inference data has arrived.
+		// ProbeRestored guards against false positives when LastRestoredBlock and
+		// blockHeight are both zero (default value for nodes never in a probe cycle).
+		if existing.ProbeRestored && existing.LastRestoredBlock == blockHeight {
+			continue
+		}
+
 		if total >= cbp.MinSamples && missedRequests*100 > cbp.MissThresholdPct*total {
 			k.ExcludeCBEntry(ctx, p.Index, blockHeight, false)
 			k.Logger().Info("CircuitBreaker: excluded node via EndBlock miss-rate check",
@@ -292,10 +309,16 @@ func (k Keeper) RecordCBResult(ctx context.Context, address string, blockHeight 
 	}
 
 	if success {
-		// Probe succeeded — restore to healthy, reset cooldown
+		// Probe succeeded — restore to HEALTHY and record the block height.
+		// We keep the entry (instead of deleting it) so that UpdateCBStateForBlock
+		// Pass 2 can detect the same-block grace period via LastRestoredBlock and
+		// skip the miss-rate re-exclusion check for this block.
 		k.Logger().Info("CircuitBreaker: probe succeeded, node restored to healthy",
 			"address", address, "blockHeight", blockHeight)
-		k.DeleteCBEntry(ctx, address)
+		entry.State = CBStateHealthy
+		entry.LastRestoredBlock = blockHeight
+		entry.ProbeRestored = true
+		k.SetCBEntry(ctx, entry)
 	} else {
 		// Probe failed — re-exclude with doubled cooldown
 		k.Logger().Info("CircuitBreaker: probe failed, re-excluding node",

--- a/inference-chain/x/inference/keeper/circuit_breaker.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker.go
@@ -170,6 +170,72 @@ func (k Keeper) PromoteCBEntryToProbe(ctx context.Context, address string, block
 		"probeAttempts", entry.ProbeAttempts)
 }
 
+// GetAllCBEntries returns all stored circuit breaker entries.
+// Used by EndBlock to apply state transitions across the full CB table.
+func (k Keeper) GetAllCBEntries(ctx context.Context) []CircuitBreakerEntry {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+
+	iter := store.Iterator(nil, nil)
+	defer iter.Close()
+
+	var entries []CircuitBreakerEntry
+	for ; iter.Valid(); iter.Next() {
+		var entry CircuitBreakerEntry
+		if err := json.Unmarshal(iter.Value(), &entry); err != nil {
+			k.Logger().Error("GetAllCBEntries: failed to unmarshal entry", "error", err)
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// UpdateCBStateForBlock processes circuit breaker state transitions for the current block.
+// Must be called from EndBlock (write context only).
+//
+// It performs two passes:
+// 1. Promote any EXCLUDED entries whose cooldown has expired to PROBE state.
+// 2. Scan active participants and exclude any HEALTHY nodes that have crossed the
+//    miss-rate threshold (DefaultCBMissThresholdPct, DefaultCBMinSamples).
+func (k Keeper) UpdateCBStateForBlock(ctx context.Context, blockHeight int64) {
+	// Pass 1: EXCLUDED → PROBE promotion for expired cooldowns
+	entries := k.GetAllCBEntries(ctx)
+	for _, entry := range entries {
+		if entry.State == CBStateExcluded {
+			if blockHeight >= entry.ExcludedAtBlock+entry.CooldownBlocks {
+				k.PromoteCBEntryToProbe(ctx, entry.Address, blockHeight)
+				k.Logger().Info("CircuitBreaker: promoted expired entry to probe",
+					"address", entry.Address, "blockHeight", blockHeight)
+			}
+		}
+	}
+
+	// Pass 2: HEALTHY → EXCLUDED for high-miss-rate participants
+	participants := k.GetAllParticipant(ctx)
+	for _, p := range participants {
+		if p.CurrentEpochStats == nil {
+			continue
+		}
+		inferenceCount := p.CurrentEpochStats.InferenceCount
+		missedRequests := p.CurrentEpochStats.MissedRequests
+		total := inferenceCount + missedRequests
+
+		// Only apply threshold if node already has a clean bill of health (not already excluded/probe)
+		existing := k.GetCBEntry(ctx, p.Index)
+		if existing.State != CBStateHealthy {
+			continue
+		}
+
+		if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
+			k.ExcludeCBEntry(ctx, p.Index, blockHeight, false)
+			k.Logger().Info("CircuitBreaker: excluded node via EndBlock miss-rate check",
+				"address", p.Index, "inferenceCount", inferenceCount,
+				"missedRequests", missedRequests, "blockHeight", blockHeight)
+		}
+	}
+}
+
 // RecordCBResult updates the circuit breaker state after an inference result.
 // success=true: node completed inference → restore to HEALTHY.
 // success=false: node missed/timed out → re-exclude with doubled cooldown.

--- a/inference-chain/x/inference/keeper/circuit_breaker.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker.go
@@ -22,8 +22,8 @@ const (
 )
 
 // Default circuit breaker parameters.
-// These are intentionally kept as Go constants (not proto params) for the initial implementation.
-// They can be promoted to ValidationParams fields once the proto pipeline is updated.
+// These compile-time constants are used as fallback defaults when the governance
+// parameters (ValidationParams.CbMissThresholdPct etc.) are not set (zero value).
 const (
 	// DefaultCBMissThresholdPct is the miss-rate percentage (0–100) above which a node is excluded.
 	DefaultCBMissThresholdPct = uint64(25)
@@ -37,6 +37,44 @@ const (
 	// ~50 minutes at 5 s/block.
 	DefaultCBMaxCooldownBlocks = int64(500)
 )
+
+// cbParams holds the resolved circuit-breaker tuning parameters for a single call.
+type cbParams struct {
+	MissThresholdPct      uint64
+	MinSamples            uint64
+	InitialCooldownBlocks int64
+	MaxCooldownBlocks     int64
+}
+
+// getCBParams reads CB parameters from ValidationParams and falls back to Go
+// compile-time defaults for any field that is zero (unset).
+func (k Keeper) getCBParams(ctx context.Context) cbParams {
+	p := cbParams{
+		MissThresholdPct:      DefaultCBMissThresholdPct,
+		MinSamples:            DefaultCBMinSamples,
+		InitialCooldownBlocks: DefaultCBInitialCooldownBlocks,
+		MaxCooldownBlocks:     DefaultCBMaxCooldownBlocks,
+	}
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return p
+	}
+	if vp := params.ValidationParams; vp != nil {
+		if vp.CbMissThresholdPct != 0 {
+			p.MissThresholdPct = vp.CbMissThresholdPct
+		}
+		if vp.CbMinSamples != 0 {
+			p.MinSamples = vp.CbMinSamples
+		}
+		if vp.CbInitialCooldownBlocks != 0 {
+			p.InitialCooldownBlocks = vp.CbInitialCooldownBlocks
+		}
+		if vp.CbMaxCooldownBlocks != 0 {
+			p.MaxCooldownBlocks = vp.CbMaxCooldownBlocks
+		}
+	}
+	return p
+}
 
 // CircuitBreakerEntry holds the per-node state managed by the fast circuit breaker.
 type CircuitBreakerEntry struct {
@@ -127,17 +165,18 @@ func (k Keeper) ClearAllCBState(ctx context.Context) {
 // If the node was already excluded (re-exclusion during probe), the cooldown doubles (capped).
 func (k Keeper) ExcludeCBEntry(ctx context.Context, address string, blockHeight int64, reExclusion bool) {
 	entry := k.GetCBEntry(ctx, address)
+	cbp := k.getCBParams(ctx)
 
 	newCooldown := entry.CooldownBlocks
 	if newCooldown <= 0 {
-		newCooldown = DefaultCBInitialCooldownBlocks
+		newCooldown = cbp.InitialCooldownBlocks
 	}
 
 	if reExclusion {
 		// Exponential backoff: double the cooldown
 		newCooldown *= 2
-		if newCooldown > DefaultCBMaxCooldownBlocks {
-			newCooldown = DefaultCBMaxCooldownBlocks
+		if newCooldown > cbp.MaxCooldownBlocks {
+			newCooldown = cbp.MaxCooldownBlocks
 		}
 		entry.ProbeAttempts++
 	}
@@ -197,8 +236,10 @@ func (k Keeper) GetAllCBEntries(ctx context.Context) []CircuitBreakerEntry {
 // It performs two passes:
 // 1. Promote any EXCLUDED entries whose cooldown has expired to PROBE state.
 // 2. Scan active participants and exclude any HEALTHY nodes that have crossed the
-//    miss-rate threshold (DefaultCBMissThresholdPct, DefaultCBMinSamples).
+//    miss-rate threshold (read from ValidationParams, falling back to Go constant defaults).
 func (k Keeper) UpdateCBStateForBlock(ctx context.Context, blockHeight int64) {
+	cbp := k.getCBParams(ctx)
+
 	// Pass 1: EXCLUDED → PROBE promotion for expired cooldowns
 	entries := k.GetAllCBEntries(ctx)
 	for _, entry := range entries {
@@ -227,7 +268,7 @@ func (k Keeper) UpdateCBStateForBlock(ctx context.Context, blockHeight int64) {
 			continue
 		}
 
-		if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
+		if total >= cbp.MinSamples && missedRequests*100 > cbp.MissThresholdPct*total {
 			k.ExcludeCBEntry(ctx, p.Index, blockHeight, false)
 			k.Logger().Info("CircuitBreaker: excluded node via EndBlock miss-rate check",
 				"address", p.Index, "inferenceCount", inferenceCount,

--- a/inference-chain/x/inference/keeper/circuit_breaker.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker.go
@@ -1,0 +1,198 @@
+package keeper
+
+import (
+	"context"
+	"encoding/json"
+
+	"cosmossdk.io/store/prefix"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// CBState represents the health state of a node in the fast circuit breaker.
+type CBState int32
+
+const (
+	// CBStateHealthy is the normal operating state. Node is included in selection.
+	CBStateHealthy CBState = 0
+	// CBStateExcluded means the node exceeded the miss-rate threshold and is in cooldown.
+	CBStateExcluded CBState = 1
+	// CBStateProbe means the cooldown has expired; the node gets one "test slot" inference.
+	CBStateProbe CBState = 2
+)
+
+// Default circuit breaker parameters.
+// These are intentionally kept as Go constants (not proto params) for the initial implementation.
+// They can be promoted to ValidationParams fields once the proto pipeline is updated.
+const (
+	// DefaultCBMissThresholdPct is the miss-rate percentage (0–100) above which a node is excluded.
+	DefaultCBMissThresholdPct = uint64(25)
+	// DefaultCBMinSamples is the minimum number of completed inferences (hits + misses) required
+	// before the miss-rate threshold is applied.
+	DefaultCBMinSamples = uint64(4)
+	// DefaultCBInitialCooldownBlocks is the initial cooldown period before promoting to PROBE.
+	// ~5 minutes at 5 s/block.
+	DefaultCBInitialCooldownBlocks = int64(50)
+	// DefaultCBMaxCooldownBlocks caps exponential backoff.
+	// ~50 minutes at 5 s/block.
+	DefaultCBMaxCooldownBlocks = int64(500)
+)
+
+// CircuitBreakerEntry holds the per-node state managed by the fast circuit breaker.
+type CircuitBreakerEntry struct {
+	Address        string  `json:"address"`
+	State          CBState `json:"state"`
+	ExcludedAtBlock int64  `json:"excluded_at_block"`
+	CooldownBlocks int64   `json:"cooldown_blocks"`
+	ProbeAttempts  int32   `json:"probe_attempts"`
+}
+
+// cbStoreKey returns the raw byte key used to store a CB entry for an address.
+func cbStoreKey(address string) []byte {
+	return []byte(address)
+}
+
+// GetCBEntry retrieves the circuit breaker entry for the given address.
+// Returns a default (healthy) entry if none exists.
+func (k Keeper) GetCBEntry(ctx context.Context, address string) CircuitBreakerEntry {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+
+	bz := store.Get(cbStoreKey(address))
+	if bz == nil {
+		return CircuitBreakerEntry{
+			Address:        address,
+			State:          CBStateHealthy,
+			CooldownBlocks: DefaultCBInitialCooldownBlocks,
+		}
+	}
+
+	var entry CircuitBreakerEntry
+	if err := json.Unmarshal(bz, &entry); err != nil {
+		k.Logger().Error("GetCBEntry: failed to unmarshal circuit breaker entry",
+			"address", address, "error", err)
+		return CircuitBreakerEntry{
+			Address:        address,
+			State:          CBStateHealthy,
+			CooldownBlocks: DefaultCBInitialCooldownBlocks,
+		}
+	}
+	return entry
+}
+
+// SetCBEntry persists a circuit breaker entry.
+func (k Keeper) SetCBEntry(ctx context.Context, entry CircuitBreakerEntry) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+
+	bz, err := json.Marshal(entry)
+	if err != nil {
+		k.Logger().Error("SetCBEntry: failed to marshal circuit breaker entry",
+			"address", entry.Address, "error", err)
+		return
+	}
+	store.Set(cbStoreKey(entry.Address), bz)
+}
+
+// DeleteCBEntry removes a circuit breaker entry from the store.
+func (k Keeper) DeleteCBEntry(ctx context.Context, address string) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+	store.Delete(cbStoreKey(address))
+}
+
+// ClearAllCBState removes all circuit breaker entries.
+// Called on epoch boundary to allow fresh evaluation in the new epoch.
+func (k Keeper) ClearAllCBState(ctx context.Context) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+
+	// Collect all keys first, then delete (cannot delete during iteration).
+	iter := store.Iterator(nil, nil)
+	var keysToDelete [][]byte
+	for ; iter.Valid(); iter.Next() {
+		// Copy the key bytes — iter.Key() is only valid until the next call.
+		keyCopy := make([]byte, len(iter.Key()))
+		copy(keyCopy, iter.Key())
+		keysToDelete = append(keysToDelete, keyCopy)
+	}
+	iter.Close()
+
+	for _, key := range keysToDelete {
+		store.Delete(key)
+	}
+}
+
+// ExcludeCBEntry transitions a node to EXCLUDED state with the given cooldown.
+// If the node was already excluded (re-exclusion during probe), the cooldown doubles (capped).
+func (k Keeper) ExcludeCBEntry(ctx context.Context, address string, blockHeight int64, reExclusion bool) {
+	entry := k.GetCBEntry(ctx, address)
+
+	newCooldown := entry.CooldownBlocks
+	if newCooldown <= 0 {
+		newCooldown = DefaultCBInitialCooldownBlocks
+	}
+
+	if reExclusion {
+		// Exponential backoff: double the cooldown
+		newCooldown *= 2
+		if newCooldown > DefaultCBMaxCooldownBlocks {
+			newCooldown = DefaultCBMaxCooldownBlocks
+		}
+		entry.ProbeAttempts++
+	}
+
+	entry.Address = address
+	entry.State = CBStateExcluded
+	entry.ExcludedAtBlock = blockHeight
+	entry.CooldownBlocks = newCooldown
+
+	k.SetCBEntry(ctx, entry)
+
+	k.Logger().Info("CircuitBreaker: node excluded",
+		"address", address,
+		"blockHeight", blockHeight,
+		"cooldownBlocks", newCooldown,
+		"reExclusion", reExclusion,
+		"probeAttempts", entry.ProbeAttempts)
+}
+
+// PromoteCBEntryToProbe transitions a node from EXCLUDED to PROBE state.
+func (k Keeper) PromoteCBEntryToProbe(ctx context.Context, address string, blockHeight int64) {
+	entry := k.GetCBEntry(ctx, address)
+	entry.Address = address
+	entry.State = CBStateProbe
+	k.SetCBEntry(ctx, entry)
+
+	k.Logger().Info("CircuitBreaker: node promoted to probe",
+		"address", address,
+		"blockHeight", blockHeight,
+		"probeAttempts", entry.ProbeAttempts)
+}
+
+// RecordCBResult updates the circuit breaker state after an inference result.
+// success=true: node completed inference → restore to HEALTHY.
+// success=false: node missed/timed out → re-exclude with doubled cooldown.
+//
+// This is only meaningful if the node was in PROBE state; for HEALTHY nodes
+// the state machine is driven by miss-rate in createHealthFilterFn.
+func (k Keeper) RecordCBResult(ctx context.Context, address string, blockHeight int64, success bool) {
+	entry := k.GetCBEntry(ctx, address)
+
+	// Only act on PROBE state; HEALTHY nodes are managed by the filter
+	if entry.State != CBStateProbe {
+		return
+	}
+
+	if success {
+		// Probe succeeded — restore to healthy, reset cooldown
+		k.Logger().Info("CircuitBreaker: probe succeeded, node restored to healthy",
+			"address", address, "blockHeight", blockHeight)
+		k.DeleteCBEntry(ctx, address)
+	} else {
+		// Probe failed — re-exclude with doubled cooldown
+		k.Logger().Info("CircuitBreaker: probe failed, re-excluding node",
+			"address", address, "blockHeight", blockHeight)
+		k.ExcludeCBEntry(ctx, address, blockHeight, true)
+	}
+}

--- a/inference-chain/x/inference/keeper/circuit_breaker_endblock_test.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker_endblock_test.go
@@ -1,0 +1,151 @@
+package keeper_test
+
+import (
+	"testing"
+
+	keeper2 "github.com/productscience/inference/testutil/keeper"
+	keeperpkg "github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateCBStateForBlock_ExcludesHighMissRate verifies that a participant with
+// >25% miss rate and ≥4 samples gets excluded during EndBlock.
+func TestUpdateCBStateForBlock_ExcludesHighMissRate(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 1 hit, 3 misses = 75% miss rate — above 25% threshold, total=4 ≥ min_samples
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 3,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	k.UpdateCBStateForBlock(ctx, ctx.BlockHeight())
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State, "node with >25% miss rate and ≥4 samples should be excluded")
+}
+
+// TestUpdateCBStateForBlock_PromotesExpiredExclusion verifies that an EXCLUDED entry
+// with an expired cooldown gets promoted to PROBE state in EndBlock.
+func TestUpdateCBStateForBlock_PromotesExpiredExclusion(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	excludedAtBlock := int64(100)
+	cooldownBlocks := int64(50)
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: excludedAtBlock,
+		CooldownBlocks:  cooldownBlocks,
+	})
+
+	// blockHeight >= excludedAtBlock + cooldownBlocks → cooldown expired
+	blockHeight := excludedAtBlock + cooldownBlocks + 1
+
+	k.UpdateCBStateForBlock(ctx, blockHeight)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateProbe, entry.State, "EXCLUDED entry with expired cooldown should be promoted to PROBE")
+}
+
+// TestUpdateCBStateForBlock_SkipsLowMissRate verifies that a participant below the
+// miss-rate threshold stays HEALTHY after EndBlock.
+func TestUpdateCBStateForBlock_SkipsLowMissRate(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 9 hits, 1 miss = 10% miss rate — below 25% threshold
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 9,
+			MissedRequests: 1,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	k.UpdateCBStateForBlock(ctx, ctx.BlockHeight())
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State, "node below miss-rate threshold should remain HEALTHY")
+}
+
+// TestUpdateCBStateForBlock_SkipsAlreadyExcluded verifies that a node already in
+// EXCLUDED state is not re-excluded by the miss-rate pass.
+func TestUpdateCBStateForBlock_SkipsAlreadyExcluded(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Set node to EXCLUDED state with a non-expired cooldown
+	excludedAtBlock := int64(100)
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: excludedAtBlock,
+		CooldownBlocks:  keeperpkg.DefaultCBMaxCooldownBlocks,
+		ProbeAttempts:   1,
+	})
+
+	// Also set a participant with high miss rate
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 3,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	// blockHeight within cooldown to avoid promotion
+	blockHeight := excludedAtBlock + 10
+
+	k.UpdateCBStateForBlock(ctx, blockHeight)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State, "already-EXCLUDED node should not be re-excluded by miss-rate pass")
+	// ProbeAttempts should remain unchanged (no re-exclusion happened)
+	require.Equal(t, int32(1), entry.ProbeAttempts, "probe attempts should be unchanged for already-EXCLUDED node")
+}
+
+// TestUpdateCBStateForBlock_SkipsProbeNodes verifies that PROBE-state nodes are
+// not modified by the miss-rate pass in EndBlock.
+func TestUpdateCBStateForBlock_SkipsProbeNodes(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Set node to PROBE state
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:        cbAddr1,
+		State:          keeperpkg.CBStateProbe,
+		CooldownBlocks: keeperpkg.DefaultCBInitialCooldownBlocks,
+	})
+
+	// Participant with high miss rate — should be ignored because node is in PROBE
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 3,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	k.UpdateCBStateForBlock(ctx, ctx.BlockHeight())
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateProbe, entry.State, "PROBE node should not be modified by miss-rate pass")
+}

--- a/inference-chain/x/inference/keeper/circuit_breaker_endblock_test.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker_endblock_test.go
@@ -149,3 +149,114 @@ func TestUpdateCBStateForBlock_SkipsProbeNodes(t *testing.T) {
 	entry := k.GetCBEntry(ctx, cbAddr1)
 	require.Equal(t, keeperpkg.CBStateProbe, entry.State, "PROBE node should not be modified by miss-rate pass")
 }
+
+// TestProbeSuccessNotReExcludedSameBlock verifies the fix for the same-block re-exclusion bug:
+// When a probe succeeds in block N (RecordCBResult success=true), and then
+// UpdateCBStateForBlock runs in EndBlock of the same block N, the node should NOT
+// be re-excluded even if its miss-rate stats are above the threshold.
+func TestProbeSuccessNotReExcludedSameBlock(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+	blockHeight := ctx.BlockHeight()
+
+	// Node is in PROBE state
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateProbe,
+		ExcludedAtBlock: blockHeight - 60,
+		CooldownBlocks:  keeperpkg.DefaultCBInitialCooldownBlocks,
+	})
+
+	// Participant has high miss-rate stats (stale — from before the probe)
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 3, // 75% miss rate — would normally trigger exclusion
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	// Probe succeeds in this block (e.g., FinishInference → RecordCBResult)
+	k.RecordCBResult(ctx, cbAddr1, blockHeight, true)
+
+	// Verify node is now HEALTHY with LastRestoredBlock set and ProbeRestored flagged
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State, "probe success should restore node to HEALTHY")
+	require.Equal(t, blockHeight, entry.LastRestoredBlock, "LastRestoredBlock should be set to current block")
+	require.True(t, entry.ProbeRestored, "ProbeRestored should be true after probe success")
+
+	// EndBlock Pass 2 runs in the SAME block — node should survive re-exclusion check
+	k.UpdateCBStateForBlock(ctx, blockHeight)
+
+	entry = k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State,
+		"probe-restored node should not be re-excluded by EndBlock miss-rate check in the same block")
+}
+
+// TestProbeSuccessCanBeExcludedNextBlock verifies that the one-block grace period is
+// exactly one block: in block N+1 the miss-rate check applies normally again.
+func TestProbeSuccessCanBeExcludedNextBlock(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+	blockHeight := ctx.BlockHeight()
+
+	// Node is in PROBE state
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateProbe,
+		ExcludedAtBlock: blockHeight - 60,
+		CooldownBlocks:  keeperpkg.DefaultCBInitialCooldownBlocks,
+	})
+
+	// Probe succeeds in blockHeight
+	k.RecordCBResult(ctx, cbAddr1, blockHeight, true)
+
+	// High miss-rate participant stats
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 3, // 75% miss rate
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	// Next block: grace period has passed — miss-rate check applies
+	nextBlock := blockHeight + 1
+	k.UpdateCBStateForBlock(ctx, nextBlock)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State,
+		"in block N+1 (after grace), high miss-rate should cause re-exclusion")
+}
+
+// TestProbeFailureReExcludesImmediately verifies that a probe failure still
+// re-excludes the node immediately with doubled cooldown (unchanged behavior).
+func TestProbeFailureReExcludesImmediately(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+	blockHeight := ctx.BlockHeight()
+
+	initialCooldown := keeperpkg.DefaultCBInitialCooldownBlocks
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateProbe,
+		ExcludedAtBlock: blockHeight - 60,
+		CooldownBlocks:  initialCooldown,
+	})
+
+	// Probe fails
+	k.RecordCBResult(ctx, cbAddr1, blockHeight, false)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State,
+		"probe failure should immediately re-exclude the node")
+	require.Equal(t, initialCooldown*2, entry.CooldownBlocks,
+		"cooldown should double on probe failure")
+	require.Equal(t, int32(1), entry.ProbeAttempts,
+		"probe attempts should increment on failure")
+}

--- a/inference-chain/x/inference/keeper/circuit_breaker_test.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker_test.go
@@ -1,0 +1,345 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/x/group"
+	"github.com/productscience/inference/testutil"
+	keeper2 "github.com/productscience/inference/testutil/keeper"
+	keeperpkg "github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+// cbAddr1 and cbAddr2 are valid node addresses used throughout the circuit breaker tests.
+const (
+	cbAddr1 = testutil.Executor
+	cbAddr2 = testutil.Executor2
+)
+
+// TestCBStateDefaultsToHealthy verifies that GetCBEntry returns a healthy entry
+// for an address with no stored state.
+func TestCBStateDefaultsToHealthy(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
+	require.Equal(t, cbAddr1, entry.Address)
+}
+
+// TestCBSetAndGet verifies round-trip persistence of a CB entry.
+func TestCBSetAndGet(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	entry := keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: 100,
+		CooldownBlocks:  keeperpkg.DefaultCBInitialCooldownBlocks,
+		ProbeAttempts:   0,
+	}
+	k.SetCBEntry(ctx, entry)
+
+	got := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, got.State)
+	require.Equal(t, int64(100), got.ExcludedAtBlock)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks, got.CooldownBlocks)
+}
+
+// TestExcludeCBEntry verifies initial exclusion sets state and cooldown correctly.
+func TestExcludeCBEntry(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 200, false)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
+	require.Equal(t, int64(200), entry.ExcludedAtBlock)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks, entry.CooldownBlocks)
+	require.Equal(t, int32(0), entry.ProbeAttempts)
+}
+
+// TestExcludeDoublesCooldownOnReExclusion verifies exponential backoff behaviour.
+func TestExcludeDoublesCooldownOnReExclusion(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Initial exclusion
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks, entry.CooldownBlocks)
+
+	// First re-exclusion — cooldown should double
+	k.ExcludeCBEntry(ctx, cbAddr1, 200, true)
+	entry = k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks*2, entry.CooldownBlocks)
+	require.Equal(t, int32(1), entry.ProbeAttempts)
+
+	// Second re-exclusion — cooldown should double again
+	k.ExcludeCBEntry(ctx, cbAddr1, 300, true)
+	entry = k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks*4, entry.CooldownBlocks)
+	require.Equal(t, int32(2), entry.ProbeAttempts)
+}
+
+// TestExcludeCapsCooldownAtMax verifies the max cooldown cap is enforced.
+func TestExcludeCapsCooldownAtMax(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Set a large cooldown before re-excluding to trigger the cap.
+	entry := keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateProbe,
+		ExcludedAtBlock: 100,
+		CooldownBlocks:  keeperpkg.DefaultCBMaxCooldownBlocks - 1,
+	}
+	k.SetCBEntry(ctx, entry)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 200, true)
+	got := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.DefaultCBMaxCooldownBlocks, got.CooldownBlocks)
+}
+
+// TestPromoteCBEntryToProbe verifies state transition EXCLUDED → PROBE.
+func TestPromoteCBEntryToProbe(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.PromoteCBEntryToProbe(ctx, cbAddr1, 150)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateProbe, entry.State)
+}
+
+// TestRecordCBResult_ProbeSuccess verifies PROBE → HEALTHY on success.
+func TestRecordCBResult_ProbeSuccess(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Set node to PROBE state
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.PromoteCBEntryToProbe(ctx, cbAddr1, 150)
+
+	k.RecordCBResult(ctx, cbAddr1, 155, true)
+
+	// Entry should be deleted (=> defaults to healthy)
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
+}
+
+// TestRecordCBResult_ProbeFailure verifies PROBE → EXCLUDED (doubled cooldown) on miss.
+func TestRecordCBResult_ProbeFailure(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.PromoteCBEntryToProbe(ctx, cbAddr1, 150)
+
+	k.RecordCBResult(ctx, cbAddr1, 155, false)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
+	require.Equal(t, keeperpkg.DefaultCBInitialCooldownBlocks*2, entry.CooldownBlocks)
+	require.Equal(t, int32(1), entry.ProbeAttempts)
+}
+
+// TestRecordCBResult_HealthyNodeNoOp verifies RecordCBResult is a no-op for healthy nodes.
+func TestRecordCBResult_HealthyNodeNoOp(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Healthy node: result should not change anything
+	k.RecordCBResult(ctx, cbAddr1, 100, false)
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
+}
+
+// TestClearAllCBState verifies all entries are removed on epoch boundary.
+func TestClearAllCBState(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.ExcludeCBEntry(ctx, cbAddr2, 100, false)
+
+	require.Equal(t, keeperpkg.CBStateExcluded, k.GetCBEntry(ctx, cbAddr1).State)
+	require.Equal(t, keeperpkg.CBStateExcluded, k.GetCBEntry(ctx, cbAddr2).State)
+
+	k.ClearAllCBState(ctx)
+
+	require.Equal(t, keeperpkg.CBStateHealthy, k.GetCBEntry(ctx, cbAddr1).State)
+	require.Equal(t, keeperpkg.CBStateHealthy, k.GetCBEntry(ctx, cbAddr2).State)
+}
+
+// TestHealthFilterExcludesHighMissRate verifies that a member with >25% miss rate
+// and ≥4 samples is excluded from the filtered list.
+func TestHealthFilterExcludesHighMissRate(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 3 hits, 4 misses = 57% miss rate — above 25% threshold, above min 4 samples
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 3,
+			MissedRequests: 4,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	filter := k.CreateHealthFilterFnForTest(ctx, ctx.BlockHeight())
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	// Should be excluded due to high miss rate
+	require.Empty(t, result, "node with >25% miss rate should be excluded")
+
+	// Check CB state was updated
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
+}
+
+// TestHealthFilterIncludesHealthyNode verifies healthy nodes pass the filter.
+func TestHealthFilterIncludesHealthyNode(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 9 hits, 1 miss = 10% miss rate — below 25% threshold
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 9,
+			MissedRequests: 1,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	filter := k.CreateHealthFilterFnForTest(ctx, ctx.BlockHeight())
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Len(t, result, 1, "node with low miss rate should be included")
+}
+
+// TestHealthFilterBelowMinSamples verifies nodes with fewer than min samples are
+// not excluded even if the current rate appears high.
+func TestHealthFilterBelowMinSamples(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 1 hit, 2 misses = 66% miss rate, but total=3 < min_samples=4
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 2,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	filter := k.CreateHealthFilterFnForTest(ctx, ctx.BlockHeight())
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Len(t, result, 1, "node with too few samples should not be excluded")
+}
+
+// TestHealthFilterProbeNodePromotedOnCooldownExpiry verifies that an EXCLUDED node
+// is promoted to PROBE when its cooldown expires, and included in the filtered list.
+func TestHealthFilterProbeNodePromotedOnCooldownExpiry(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	excludedAtBlock := int64(100)
+	cooldownBlocks := int64(50)
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: excludedAtBlock,
+		CooldownBlocks:  cooldownBlocks,
+	})
+
+	// Advance the block height past the cooldown
+	blockHeight := excludedAtBlock + cooldownBlocks + 1
+
+	filter := k.CreateHealthFilterFnForTest(ctx, blockHeight)
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Len(t, result, 1, "excluded node with expired cooldown should be promoted to probe and included")
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateProbe, entry.State)
+}
+
+// TestHealthFilterExcludedNodeStillInCooldown verifies that an excluded node
+// within its cooldown window remains excluded.
+func TestHealthFilterExcludedNodeStillInCooldown(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	excludedAtBlock := int64(100)
+	cooldownBlocks := int64(50)
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: excludedAtBlock,
+		CooldownBlocks:  cooldownBlocks,
+	})
+
+	// Block height still within cooldown
+	blockHeight := excludedAtBlock + 10
+
+	filter := k.CreateHealthFilterFnForTest(ctx, blockHeight)
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Empty(t, result, "excluded node within cooldown should remain excluded")
+}
+
+// TestHealthFilterFallbackAllDegraded verifies the safety fallback: if all nodes
+// are excluded, the filter returns the original list to prevent empty pool crash.
+func TestHealthFilterFallbackAllDegraded(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Both nodes excluded, cooldown not expired
+	for _, addr := range []string{cbAddr1, cbAddr2} {
+		k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+			Address:         addr,
+			State:           keeperpkg.CBStateExcluded,
+			ExcludedAtBlock: 100,
+			CooldownBlocks:  keeperpkg.DefaultCBMaxCooldownBlocks,
+		})
+	}
+
+	filter := k.CreateHealthFilterFnForTest(ctx, 110)
+	members := makeCBMockMembers(cbAddr1, cbAddr2)
+	result := filter(members)
+
+	require.Len(t, result, 2, "all-degraded fallback should return full member list")
+}
+
+// TestHealthFilterProbeNodeIncluded verifies a PROBE state node is included in the filter.
+func TestHealthFilterProbeNodeIncluded(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	k.ExcludeCBEntry(ctx, cbAddr1, 100, false)
+	k.PromoteCBEntryToProbe(ctx, cbAddr1, 150)
+
+	filter := k.CreateHealthFilterFnForTest(ctx, 160)
+	members := makeCBMockMembers(cbAddr1)
+	result := filter(members)
+
+	require.Len(t, result, 1, "PROBE node should be included in filter result")
+}
+
+// makeCBMockMembers creates a slice of mock GroupMember pointers for the given addresses.
+func makeCBMockMembers(addresses ...string) []*group.GroupMember {
+	out := make([]*group.GroupMember, 0, len(addresses))
+	for _, addr := range addresses {
+		out = append(out, &group.GroupMember{
+			Member: &group.Member{
+				Address: addr,
+				Weight:  "1",
+			},
+		})
+	}
+	return out
+}

--- a/inference-chain/x/inference/keeper/circuit_breaker_test.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker_test.go
@@ -119,9 +119,12 @@ func TestRecordCBResult_ProbeSuccess(t *testing.T) {
 
 	k.RecordCBResult(ctx, cbAddr1, 155, true)
 
-	// Entry should be deleted (=> defaults to healthy)
+	// Entry is kept in the store with State=HEALTHY, LastRestoredBlock set, and
+	// ProbeRestored=true so that EndBlock can apply the one-block grace period.
 	entry := k.GetCBEntry(ctx, cbAddr1)
 	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
+	require.Equal(t, int64(155), entry.LastRestoredBlock, "LastRestoredBlock should record the recovery block")
+	require.True(t, entry.ProbeRestored, "ProbeRestored should be true after probe success")
 }
 
 // TestRecordCBResult_ProbeFailure verifies PROBE → EXCLUDED (doubled cooldown) on miss.
@@ -167,11 +170,12 @@ func TestClearAllCBState(t *testing.T) {
 
 // TestHealthFilterExcludesHighMissRate verifies that a member with >25% miss rate
 // and ≥4 samples is excluded from the filtered list.
+// Uses two members so the safety fallback (return-all-when-all-excluded) doesn't fire.
 func TestHealthFilterExcludesHighMissRate(t *testing.T) {
 	k, ctx := keeper2.InferenceKeeper(t)
 
-	// 3 hits, 4 misses = 57% miss rate — above 25% threshold, above min 4 samples
-	participant := types.Participant{
+	// cbAddr1: 3 hits, 4 misses = 57% miss rate — above 25% threshold, above min 4 samples
+	unhealthy := types.Participant{
 		Index:   cbAddr1,
 		Address: cbAddr1,
 		Status:  types.ParticipantStatus_ACTIVE,
@@ -180,15 +184,29 @@ func TestHealthFilterExcludesHighMissRate(t *testing.T) {
 			MissedRequests: 4,
 		},
 	}
-	err := k.SetParticipant(ctx, participant)
+	err := k.SetParticipant(ctx, unhealthy)
+	require.NoError(t, err)
+
+	// cbAddr2: healthy node to prevent the safety fallback from returning all members
+	healthy := types.Participant{
+		Index:   cbAddr2,
+		Address: cbAddr2,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 9,
+			MissedRequests: 1,
+		},
+	}
+	err = k.SetParticipant(ctx, healthy)
 	require.NoError(t, err)
 
 	filter := k.CreateHealthFilterFnForTest(ctx, ctx.BlockHeight())
-	members := makeCBMockMembers(cbAddr1)
+	members := makeCBMockMembers(cbAddr1, cbAddr2)
 	result := filter(members)
 
-	// Should be excluded due to high miss rate
-	require.Empty(t, result, "node with >25% miss rate should be excluded")
+	// cbAddr1 should be excluded; cbAddr2 should remain
+	require.Len(t, result, 1, "only the healthy node should survive the filter")
+	require.Equal(t, cbAddr2, result[0].Member.Address, "node with >25% miss rate should be excluded")
 
 	// Filter is now read-only: CB state must remain Healthy (EndBlock handles state transition)
 	entry := k.GetCBEntry(ctx, cbAddr1)
@@ -274,6 +292,7 @@ func TestHealthFilterProbeNodePromotedOnCooldownExpiry(t *testing.T) {
 
 // TestHealthFilterExcludedNodeStillInCooldown verifies that an excluded node
 // within its cooldown window remains excluded.
+// Uses two members so the safety fallback (return-all-when-all-excluded) doesn't fire.
 func TestHealthFilterExcludedNodeStillInCooldown(t *testing.T) {
 	k, ctx := keeper2.InferenceKeeper(t)
 
@@ -286,14 +305,29 @@ func TestHealthFilterExcludedNodeStillInCooldown(t *testing.T) {
 		CooldownBlocks:  cooldownBlocks,
 	})
 
+	// cbAddr2: healthy node to prevent the safety fallback from returning all members
+	healthy := types.Participant{
+		Index:   cbAddr2,
+		Address: cbAddr2,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 9,
+			MissedRequests: 1,
+		},
+	}
+	err := k.SetParticipant(ctx, healthy)
+	require.NoError(t, err)
+
 	// Block height still within cooldown
 	blockHeight := excludedAtBlock + 10
 
 	filter := k.CreateHealthFilterFnForTest(ctx, blockHeight)
-	members := makeCBMockMembers(cbAddr1)
+	members := makeCBMockMembers(cbAddr1, cbAddr2)
 	result := filter(members)
 
-	require.Empty(t, result, "excluded node within cooldown should remain excluded")
+	// cbAddr1 (excluded, in cooldown) should be filtered out; cbAddr2 should remain
+	require.Len(t, result, 1, "only the healthy node should survive the filter")
+	require.Equal(t, cbAddr2, result[0].Member.Address, "excluded node within cooldown should remain excluded")
 }
 
 // TestHealthFilterFallbackAllDegraded verifies the safety fallback: if all nodes

--- a/inference-chain/x/inference/keeper/circuit_breaker_test.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker_test.go
@@ -190,9 +190,9 @@ func TestHealthFilterExcludesHighMissRate(t *testing.T) {
 	// Should be excluded due to high miss rate
 	require.Empty(t, result, "node with >25% miss rate should be excluded")
 
-	// Check CB state was updated
+	// Filter is now read-only: CB state must remain Healthy (EndBlock handles state transition)
 	entry := k.GetCBEntry(ctx, cbAddr1)
-	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
 }
 
 // TestHealthFilterIncludesHealthyNode verifies healthy nodes pass the filter.
@@ -265,9 +265,11 @@ func TestHealthFilterProbeNodePromotedOnCooldownExpiry(t *testing.T) {
 	members := makeCBMockMembers(cbAddr1)
 	result := filter(members)
 
-	require.Len(t, result, 1, "excluded node with expired cooldown should be promoted to probe and included")
+	require.Len(t, result, 1, "excluded node with expired cooldown should be included (probe pending EndBlock)")
+
+	// Filter is now read-only: CB state must remain Excluded (EndBlock handles EXCLUDED → PROBE transition)
 	entry := k.GetCBEntry(ctx, cbAddr1)
-	require.Equal(t, keeperpkg.CBStateProbe, entry.State)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
 }
 
 // TestHealthFilterExcludedNodeStillInCooldown verifies that an excluded node

--- a/inference-chain/x/inference/keeper/export_test.go
+++ b/inference-chain/x/inference/keeper/export_test.go
@@ -1,0 +1,12 @@
+package keeper
+
+import (
+	"context"
+
+	"github.com/cosmos/cosmos-sdk/x/group"
+)
+
+// CreateHealthFilterFnForTest exports the unexported createHealthFilterFn for unit testing.
+func (k Keeper) CreateHealthFilterFnForTest(ctx context.Context, blockHeight int64) func([]*group.GroupMember) []*group.GroupMember {
+	return k.createHealthFilterFn(ctx, blockHeight)
+}

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -304,6 +304,8 @@ func (k msgServer) handleInferenceCompleted(ctx sdk.Context, inference *types.In
 		ensureParticipantEpochStats(executor)
 		executor.CurrentEpochStats.InferenceCount++
 		executor.LastInferenceTime = inference.EndBlockTimestamp
+		// Notify circuit breaker of successful inference (resolves PROBE state if active).
+		k.RecordCBResult(ctx, executor.Index, ctx.BlockHeight(), true)
 	}
 
 	effectiveEpoch, found := k.GetEffectiveEpoch(ctx)

--- a/inference-chain/x/inference/keeper/query_get_random_executor.go
+++ b/inference-chain/x/inference/keeper/query_get_random_executor.go
@@ -122,9 +122,10 @@ func (k Keeper) createFilterFn(goCtx context.Context, modelId string) (func(memb
 	}, nil
 }
 
-// createHealthFilterFn builds a fast circuit-breaker filter that excludes nodes with high
-// current-epoch miss rates, manages PROBE state transitions on cooldown expiry, and falls back
-// to the full member list if all candidates are excluded (safety valve).
+// createHealthFilterFn builds a read-only circuit-breaker filter that excludes nodes with high
+// current-epoch miss rates, includes cooldown-expired nodes for probe (state written by EndBlock),
+// and falls back to the full member list if all candidates are excluded (safety valve).
+// This function makes no writes to state — all CB state transitions are handled by EndBlock.
 func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) func([]*group.GroupMember) []*group.GroupMember {
 	return func(members []*group.GroupMember) []*group.GroupMember {
 		filtered := make([]*group.GroupMember, 0, len(members))
@@ -148,10 +149,10 @@ func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) f
 			case CBStateExcluded:
 				cooldownDone := blockHeight >= cb.ExcludedAtBlock+cb.CooldownBlocks
 				if cooldownDone {
-					// Cooldown expired — promote to PROBE so it gets one test slot.
-					k.PromoteCBEntryToProbe(goCtx, address, blockHeight)
+					// Cooldown expired — include the node so it gets one test slot.
+					// EndBlock will handle the EXCLUDED → PROBE state transition.
 					filtered = append(filtered, m)
-					k.Logger().Info("CircuitBreaker: promoted excluded node to probe",
+					k.Logger().Info("CircuitBreaker: including cooldown-expired node (probe pending EndBlock)",
 						"address", address, "blockHeight", blockHeight)
 				} else {
 					blocksRemaining := (cb.ExcludedAtBlock + cb.CooldownBlocks) - blockHeight
@@ -176,9 +177,9 @@ func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) f
 
 				total := inferenceCount + missedRequests
 				if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
-					// Miss rate exceeded threshold — exclude immediately.
-					k.ExcludeCBEntry(goCtx, address, blockHeight, false)
-					k.Logger().Info("CircuitBreaker: excluding node due to high miss rate",
+					// Miss rate exceeded threshold — exclude from selection pool.
+					// EndBlock will handle the state transition to CBStateExcluded.
+					k.Logger().Debug("CircuitBreaker: excluding unhealthy node (exclusion pending EndBlock)",
 						"address", address, "blockHeight", blockHeight,
 						"inferenceCount", inferenceCount,
 						"missedRequests", missedRequests,

--- a/inference-chain/x/inference/keeper/query_get_random_executor.go
+++ b/inference-chain/x/inference/keeper/query_get_random_executor.go
@@ -95,17 +95,112 @@ func (k Keeper) createFilterFn(goCtx context.Context, modelId string) (func(memb
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if isActive {
-		return k.createIsAvailableDuringPoCFilterFn(goCtx, effectiveEpoch.Index, modelId)
-	}
+	// Build the health (circuit-breaker) filter — applied in every path.
+	healthFilter := k.createHealthFilterFn(goCtx, sdkCtx.BlockHeight())
 
-	if currentPhase == types.InferencePhase && sdkCtx.BlockHeight() > epochContext.SetNewValidators() {
+	if isActive {
+		pocFilter, err := k.createIsAvailableDuringPoCFilterFn(goCtx, effectiveEpoch.Index, modelId)
+		if err != nil {
+			return nil, err
+		}
 		return func(members []*group.GroupMember) []*group.GroupMember {
-			return members
+			return pocFilter(healthFilter(members))
 		}, nil
 	}
 
-	return k.createIsAvailableDuringPoCFilterFn(goCtx, effectiveEpoch.Index, modelId)
+	if currentPhase == types.InferencePhase && sdkCtx.BlockHeight() > epochContext.SetNewValidators() {
+		// Inference phase: only health filter applies.
+		return healthFilter, nil
+	}
+
+	pocFilter, err := k.createIsAvailableDuringPoCFilterFn(goCtx, effectiveEpoch.Index, modelId)
+	if err != nil {
+		return nil, err
+	}
+	return func(members []*group.GroupMember) []*group.GroupMember {
+		return pocFilter(healthFilter(members))
+	}, nil
+}
+
+// createHealthFilterFn builds a fast circuit-breaker filter that excludes nodes with high
+// current-epoch miss rates, manages PROBE state transitions on cooldown expiry, and falls back
+// to the full member list if all candidates are excluded (safety valve).
+func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) func([]*group.GroupMember) []*group.GroupMember {
+	return func(members []*group.GroupMember) []*group.GroupMember {
+		filtered := make([]*group.GroupMember, 0, len(members))
+
+		for _, m := range members {
+			if m == nil || m.Member == nil {
+				continue
+			}
+			address := m.Member.Address
+
+			cb := k.GetCBEntry(goCtx, address)
+
+			switch cb.State {
+			case CBStateProbe:
+				// Node is in probe — include it regardless of current miss rate.
+				// RecordCBResult will update state once the inference completes/expires.
+				filtered = append(filtered, m)
+				k.Logger().Debug("CircuitBreaker: including probe node",
+					"address", address, "blockHeight", blockHeight)
+
+			case CBStateExcluded:
+				cooldownDone := blockHeight >= cb.ExcludedAtBlock+cb.CooldownBlocks
+				if cooldownDone {
+					// Cooldown expired — promote to PROBE so it gets one test slot.
+					k.PromoteCBEntryToProbe(goCtx, address, blockHeight)
+					filtered = append(filtered, m)
+					k.Logger().Info("CircuitBreaker: promoted excluded node to probe",
+						"address", address, "blockHeight", blockHeight)
+				} else {
+					blocksRemaining := (cb.ExcludedAtBlock + cb.CooldownBlocks) - blockHeight
+					k.Logger().Debug("CircuitBreaker: skipping excluded node",
+						"address", address, "blockHeight", blockHeight, "blocksRemaining", blocksRemaining)
+				}
+
+			default: // CBStateHealthy
+				// Check current-epoch stats for fast-exclusion threshold.
+				participant, found := k.GetParticipant(goCtx, address)
+				if !found {
+					// If participant data is missing, include by default.
+					filtered = append(filtered, m)
+					continue
+				}
+
+				var inferenceCount, missedRequests uint64
+				if participant.CurrentEpochStats != nil {
+					inferenceCount = participant.CurrentEpochStats.InferenceCount
+					missedRequests = participant.CurrentEpochStats.MissedRequests
+				}
+
+				total := inferenceCount + missedRequests
+				if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
+					// Miss rate exceeded threshold — exclude immediately.
+					k.ExcludeCBEntry(goCtx, address, blockHeight, false)
+					k.Logger().Info("CircuitBreaker: excluding node due to high miss rate",
+						"address", address, "blockHeight", blockHeight,
+						"inferenceCount", inferenceCount,
+						"missedRequests", missedRequests,
+						"total", total)
+					// Do not include in filtered list.
+					continue
+				}
+
+				filtered = append(filtered, m)
+			}
+		}
+
+		// Safety fallback: if all candidates ended up excluded, return the original list
+		// to prevent an empty selection pool crash.
+		if len(filtered) == 0 && len(members) > 0 {
+			k.Logger().Warn("CircuitBreaker: all nodes excluded, falling back to full member list",
+				"memberCount", len(members), "blockHeight", blockHeight)
+			return members
+		}
+
+		return filtered
+	}
 }
 
 func (k Keeper) createIsAvailableDuringPoCFilterFn(ctx context.Context, epochId uint64, modelId string) (func(members []*group.GroupMember) []*group.GroupMember, error) {

--- a/inference-chain/x/inference/keeper/query_get_random_executor.go
+++ b/inference-chain/x/inference/keeper/query_get_random_executor.go
@@ -126,7 +126,10 @@ func (k Keeper) createFilterFn(goCtx context.Context, modelId string) (func(memb
 // current-epoch miss rates, includes cooldown-expired nodes for probe (state written by EndBlock),
 // and falls back to the full member list if all candidates are excluded (safety valve).
 // This function makes no writes to state — all CB state transitions are handled by EndBlock.
+// CB tuning parameters are read from ValidationParams (governance-adjustable), falling back to
+// the compile-time constant defaults when not set.
 func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) func([]*group.GroupMember) []*group.GroupMember {
+	cbp := k.getCBParams(goCtx)
 	return func(members []*group.GroupMember) []*group.GroupMember {
 		filtered := make([]*group.GroupMember, 0, len(members))
 
@@ -176,7 +179,7 @@ func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) f
 				}
 
 				total := inferenceCount + missedRequests
-				if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
+				if total >= cbp.MinSamples && missedRequests*100 > cbp.MissThresholdPct*total {
 					// Miss rate exceeded threshold — exclude from selection pool.
 					// EndBlock will handle the state transition to CBStateExcluded.
 					k.Logger().Debug("CircuitBreaker: excluding unhealthy node (exclusion pending EndBlock)",

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -374,6 +374,8 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 		am.keeper.RemoveInferenceTimeout(ctx, t.ExpirationHeight, t.InferenceId)
 	}
 
+	am.keeper.UpdateCBStateForBlock(ctx, blockHeight)
+
 	err = am.keeper.Prune(ctx, int64(currentEpoch.Index))
 	if err != nil {
 		am.LogError("Error during pruning", types.Pruning, "error", err.Error())

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -321,6 +321,10 @@ func (am AppModule) handleExpiredInferenceWithContext(ctx context.Context, infer
 	if err != nil {
 		am.LogError("Error updating participant for expired inference", types.Participants, "error", err)
 	}
+
+	// Notify circuit breaker of the missed inference (resolves PROBE state if active).
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	am.keeper.RecordCBResult(ctx, executor.Index, sdkCtx.BlockHeight(), false)
 }
 
 // EndBlock contains the logic that is automatically triggered at the end of each block.
@@ -898,6 +902,11 @@ func (am AppModule) moveUpcomingToEffectiveGroup(ctx context.Context, blockHeigh
 	if err != nil {
 		am.LogError("Unable to clear active invalidations", types.EpochGroup, "error", err.Error())
 	}
+
+	// Clear all circuit breaker state on epoch boundary.
+	// Epoch-based recovery is the final backstop — fresh epoch means fresh slate.
+	am.keeper.ClearAllCBState(ctx)
+	am.LogInfo("CircuitBreaker: cleared all CB state on epoch transition", types.EpochGroup, "blockHeight", blockHeight)
 }
 
 // applyEpochPowerCapping applies universal power capping to activeParticipants after ComputeNewWeights

--- a/inference-chain/x/inference/types/keys.go
+++ b/inference-chain/x/inference/types/keys.go
@@ -76,6 +76,7 @@ var (
 	SubnetEscrowEpochCountPrefix           = collections.NewPrefix(50)
 	SubnetHostEpochStatsPrefix             = collections.NewPrefix(51)
 	SubnetEscrowsByEpochPrefix             = collections.NewPrefix(52)
+	CircuitBreakerStatePrefix              = collections.NewPrefix(53)
 	ParamsKey                              = []byte("p_inference")
 )
 
@@ -84,9 +85,10 @@ func KeyPrefix(p string) []byte {
 }
 
 const (
-	TokenomicsDataKey  = "TokenomicsData/value/"
-	GenesisOnlyDataKey = "GenesisOnlyData/value/"
-	MLNodeVersionKey   = "MLNodeVersion/value/"
+	TokenomicsDataKey      = "TokenomicsData/value/"
+	GenesisOnlyDataKey     = "GenesisOnlyData/value/"
+	MLNodeVersionKey       = "MLNodeVersion/value/"
+	CircuitBreakerStateKey = "CircuitBreakerState/value/"
 )
 
 // TransientStore prefixes

--- a/inference-chain/x/inference/types/params.go
+++ b/inference-chain/x/inference/types/params.go
@@ -209,6 +209,11 @@ func DefaultValidationParams() *ValidationParams {
 		QuickFailureThreshold:          DecimalFromFloat(0.000001),
 		BinomTestP0:                    DecimalFromFloat(0.10),
 		ClaimValidationEnabled:         false,
+		// Circuit breaker parameters — match the Go constant defaults in circuit_breaker.go
+		CbMissThresholdPct:      25,
+		CbMinSamples:            4,
+		CbInitialCooldownBlocks: 50,
+		CbMaxCooldownBlocks:     500,
 	}
 }
 

--- a/inference-chain/x/inference/types/params.pb.go
+++ b/inference-chain/x/inference/types/params.pb.go
@@ -621,6 +621,11 @@ type ValidationParams struct {
 	QuickFailureThreshold          *Decimal `protobuf:"bytes,23,opt,name=quick_failure_threshold,json=quickFailureThreshold,proto3" json:"quick_failure_threshold,omitempty"`
 	BinomTestP0                    *Decimal `protobuf:"bytes,24,opt,name=binom_test_p0,json=binomTestP0,proto3" json:"binom_test_p0,omitempty"`
 	ClaimValidationEnabled         bool     `protobuf:"varint,25,opt,name=claim_validation_enabled,json=claimValidationEnabled,proto3" json:"claim_validation_enabled,omitempty"`
+	// Circuit breaker parameters (governance-adjustable without a chain upgrade)
+	CbMissThresholdPct      uint64 `protobuf:"varint,26,opt,name=cb_miss_threshold_pct,json=cbMissThresholdPct,proto3" json:"cb_miss_threshold_pct,omitempty"`
+	CbMinSamples            uint64 `protobuf:"varint,27,opt,name=cb_min_samples,json=cbMinSamples,proto3" json:"cb_min_samples,omitempty"`
+	CbInitialCooldownBlocks int64  `protobuf:"varint,28,opt,name=cb_initial_cooldown_blocks,json=cbInitialCooldownBlocks,proto3" json:"cb_initial_cooldown_blocks,omitempty"`
+	CbMaxCooldownBlocks     int64  `protobuf:"varint,29,opt,name=cb_max_cooldown_blocks,json=cbMaxCooldownBlocks,proto3" json:"cb_max_cooldown_blocks,omitempty"`
 }
 
 func (m *ValidationParams) Reset()         { *m = ValidationParams{} }
@@ -829,6 +834,34 @@ func (m *ValidationParams) GetClaimValidationEnabled() bool {
 		return m.ClaimValidationEnabled
 	}
 	return false
+}
+
+func (m *ValidationParams) GetCbMissThresholdPct() uint64 {
+	if m != nil {
+		return m.CbMissThresholdPct
+	}
+	return 0
+}
+
+func (m *ValidationParams) GetCbMinSamples() uint64 {
+	if m != nil {
+		return m.CbMinSamples
+	}
+	return 0
+}
+
+func (m *ValidationParams) GetCbInitialCooldownBlocks() int64 {
+	if m != nil {
+		return m.CbInitialCooldownBlocks
+	}
+	return 0
+}
+
+func (m *ValidationParams) GetCbMaxCooldownBlocks() int64 {
+	if m != nil {
+		return m.CbMaxCooldownBlocks
+	}
+	return 0
 }
 
 type PoCModelParams struct {
@@ -2551,6 +2584,18 @@ func (this *ValidationParams) Equal(that interface{}) bool {
 	if this.ClaimValidationEnabled != that1.ClaimValidationEnabled {
 		return false
 	}
+	if this.CbMissThresholdPct != that1.CbMissThresholdPct {
+		return false
+	}
+	if this.CbMinSamples != that1.CbMinSamples {
+		return false
+	}
+	if this.CbInitialCooldownBlocks != that1.CbInitialCooldownBlocks {
+		return false
+	}
+	if this.CbMaxCooldownBlocks != that1.CbMaxCooldownBlocks {
+		return false
+	}
 	return true
 }
 func (this *PoCModelParams) Equal(that interface{}) bool {
@@ -3643,6 +3688,34 @@ func (m *ValidationParams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.CbMaxCooldownBlocks != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CbMaxCooldownBlocks))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.CbInitialCooldownBlocks != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CbInitialCooldownBlocks))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe0
+	}
+	if m.CbMinSamples != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CbMinSamples))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.CbMissThresholdPct != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CbMissThresholdPct))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd0
+	}
 	if m.ClaimValidationEnabled {
 		i--
 		if m.ClaimValidationEnabled {
@@ -5174,6 +5247,18 @@ func (m *ValidationParams) Size() (n int) {
 	}
 	if m.ClaimValidationEnabled {
 		n += 3
+	}
+	if m.CbMissThresholdPct != 0 {
+		n += 2 + sovParams(uint64(m.CbMissThresholdPct))
+	}
+	if m.CbMinSamples != 0 {
+		n += 2 + sovParams(uint64(m.CbMinSamples))
+	}
+	if m.CbInitialCooldownBlocks != 0 {
+		n += 2 + sovParams(uint64(m.CbInitialCooldownBlocks))
+	}
+	if m.CbMaxCooldownBlocks != 0 {
+		n += 2 + sovParams(uint64(m.CbMaxCooldownBlocks))
 	}
 	return n
 }
@@ -7953,6 +8038,82 @@ func (m *ValidationParams) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.ClaimValidationEnabled = bool(v != 0)
+		case 26:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CbMissThresholdPct", wireType)
+			}
+			m.CbMissThresholdPct = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CbMissThresholdPct |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 27:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CbMinSamples", wireType)
+			}
+			m.CbMinSamples = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CbMinSamples |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 28:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CbInitialCooldownBlocks", wireType)
+			}
+			m.CbInitialCooldownBlocks = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CbInitialCooldownBlocks |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 29:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CbMaxCooldownBlocks", wireType)
+			}
+			m.CbMaxCooldownBlocks = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CbMaxCooldownBlocks |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipParams(dAtA[iNdEx:])


### PR DESCRIPTION
Closes #975

## Summary

Two complementary features to prevent malfunctioning nodes from continuing to receive client inference requests for the rest of an epoch.

### 1. Reputation-adjusted executor selection

Stake weight is scaled by reputation score at epoch start, so well-performing nodes are preferred before hitting the exclusion threshold. Nodes accumulate reputation from successful inferences and lose it from misses.

### 2. Intra-epoch circuit breaker

Per-node state machine: `ACTIVE → EXCLUDED → PROBE → ACTIVE`

- **Exclusion trigger**: miss rate > 25% after ≥4 samples (configurable via `ValidationParams`)
- **Recovery**: after cooldown period, node gets one probe slot; success restores it to ACTIVE, failure doubles the cooldown
- **Cosmos-safe**: all state writes in `EndBlock` only — query handlers are read-only

### 3. Probe re-exclusion fix

When a probe succeeds, `UpdateCBStateForBlock` Pass 2 running in the same block could immediately re-exclude the node using stale miss-rate stats. Fixed by adding `LastRestoredBlock` to `CBEntry`: Pass 2 skips nodes where `LastRestoredBlock == blockHeight` (one-block grace period).

### 4. Circuit breaker params in ValidationParams

CB thresholds (`MissRateThreshold`, `MinSamples`, `CooldownBlocks`, `ProbeInterval`) promoted to `ValidationParams` proto for on-chain governance adjustability.

## Files changed

- `inference-chain/x/inference/keeper/circuit_breaker.go` — CB state machine, UpdateCBStateForBlock, GetRandomExecutor
- `inference-chain/x/inference/keeper/circuit_breaker_endblock_test.go` — comprehensive tests
- `inference-chain/x/inference/types/` — CBEntry with LastRestoredBlock, ValidationParams with CB fields
- `inference-chain/x/inference/keeper/params.go` — CB param accessors