### PR TITLE
[#976] Distribute `devshard` rewards at the end of epoch

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/bits"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -87,23 +88,28 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 			continue
 		}
 		paidValidators[addr] = true
+
+		// Track total payout for remainder/refund calculation.
 		nextTotalPayout, carry := bits.Add64(totalPayout, payout, 0)
 		if carry != 0 {
 			return nil, fmt.Errorf("total validator payout overflow")
 		}
 		totalPayout = nextTotalPayout
 
-		recipientAddr, err := sdk.AccAddressFromBech32(addr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid validator address %s: %w", addr, err)
-		}
-		coins, err := types.GetCoins(int64(payout))
-		if err != nil {
-			return nil, fmt.Errorf("invalid payout amount: %w", err)
-		}
-		err = k.BankKeeper.SendCoinsFromModuleToAccount(goCtx, types.ModuleName, recipientAddr, coins, "subnet_escrow_payment")
-		if err != nil {
-			return nil, fmt.Errorf("failed to pay validator %s: %w", addr, err)
+		// Apply payout to participant balances (ledger-style, no bank transfer).
+		participant, found := k.GetParticipant(ctx, addr)
+		// If the subnet is settled on a different epoch, it's possible a subnet's host is no longer a participant on this epoch.
+		// In this case, we skip payment to this host
+		if found {
+			if payout > math.MaxInt64 {
+				return nil, fmt.Errorf("validator payout out of range for %s", addr)
+			}
+			if err := k.processParticipantPayment(ctx, &participant, int64(payout), "subnet_escrow_payment"); err != nil {
+				return nil, err
+			}
+			if err := k.SetParticipant(ctx, participant); err != nil {
+				return nil, fmt.Errorf("failed to update participant %s: %w", addr, err)
+			}
 		}
 	}
 

--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
@@ -28,6 +28,15 @@ func TestSettleSubnetEscrow_FeesSplitBySlotCount(t *testing.T) {
 	addrH2 := cosmosAddressFromDcrdKey(keyH2).String()
 	addrH3 := cosmosAddressFromDcrdKey(keyH3).String()
 
+	for _, addr := range []string{addrH1, addrH2, addrH3} {
+		err = k.SetParticipant(ctx, types.Participant{
+			Address: addr,
+			Index:   addr,
+			Status:  types.ParticipantStatus_ACTIVE,
+		})
+		require.NoError(t, err)
+	}
+
 	initialAmount := uint64(1_000)
 	fees := uint64(403)
 	expectedUserRefund := initialAmount - fees
@@ -53,16 +62,7 @@ func TestSettleSubnetEscrow_FeesSplitBySlotCount(t *testing.T) {
 	}
 	msg := buildSettlementTestData(t, escrow, []*dcrdsecp.PrivateKey{keyH1, keyH1, keyH2, keyH3}, hostStats, fees)
 
-	payouts := make(map[string]uint64)
-	mocks.BankKeeper.EXPECT().
-		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, gomock.Any(), gomock.Any(), gomock.Eq("subnet_escrow_payment")).
-		DoAndReturn(func(_ context.Context, _ string, recipient sdk.AccAddress, coins sdk.Coins, _ string) error {
-			require.Len(t, coins, 1)
-			payouts[recipient.String()] = coins[0].Amount.Uint64()
-			return nil
-		}).
-		Times(3)
-
+	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	mocks.BankKeeper.EXPECT().
 		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, creator, gomock.Any(), gomock.Eq("subnet_escrow_refund")).
 		DoAndReturn(func(_ context.Context, _ string, _ sdk.AccAddress, coins sdk.Coins, _ string) error {
@@ -80,9 +80,23 @@ func TestSettleSubnetEscrow_FeesSplitBySlotCount(t *testing.T) {
 	//
 	// Remainder fees are distributed 1 coin per slot, starting from the first slot.
 	// H1 gets 2 remainder coins for its two slots, H2 gets 1 coin, and H3 gets 0 coins.
-	require.Equal(t, uint64(202), payouts[addrH1])
-	require.Equal(t, uint64(101), payouts[addrH2])
-	require.Equal(t, uint64(100), payouts[addrH3])
+	participantH1, found := k.GetParticipant(ctx, addrH1)
+	require.True(t, found)
+	require.Equal(t, int64(202), participantH1.CoinBalance)
+	require.NotNil(t, participantH1.CurrentEpochStats)
+	require.Equal(t, uint64(202), participantH1.CurrentEpochStats.EarnedCoins)
+
+	participantH2, found := k.GetParticipant(ctx, addrH2)
+	require.True(t, found)
+	require.Equal(t, int64(101), participantH2.CoinBalance)
+	require.NotNil(t, participantH2.CurrentEpochStats)
+	require.Equal(t, uint64(101), participantH2.CurrentEpochStats.EarnedCoins)
+
+	participantH3, found := k.GetParticipant(ctx, addrH3)
+	require.True(t, found)
+	require.Equal(t, int64(100), participantH3.CoinBalance)
+	require.NotNil(t, participantH3.CurrentEpochStats)
+	require.Equal(t, uint64(100), participantH3.CurrentEpochStats.EarnedCoins)
 }
 
 func TestSettleSubnetEscrow_HappyPath(t *testing.T) {
@@ -96,6 +110,12 @@ func TestSettleSubnetEscrow_HappyPath(t *testing.T) {
 		require.NoError(t, err)
 		keys[i] = key
 		slots[i] = cosmosAddressFromDcrdKey(key).String()
+		err = k.SetParticipant(ctx, types.Participant{
+			Address: slots[i],
+			Index:   slots[i],
+			Status:  types.ParticipantStatus_ACTIVE,
+		})
+		require.NoError(t, err)
 	}
 
 	creator := sdk.AccAddress(make([]byte, 20))
@@ -116,12 +136,6 @@ func TestSettleSubnetEscrow_HappyPath(t *testing.T) {
 	fees := uint64(200_000_000)
 	msg := buildSettlementTestData(t, escrow, keys, hostStats, fees)
 
-	// Expect payments to validators (deduplicated by address)
-	mocks.BankKeeper.EXPECT().
-		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, gomock.Any(), gomock.Any(), gomock.Eq("subnet_escrow_payment")).
-		Return(nil).
-		Times(keeper.SubnetGroupSize) // 16 unique validators
-
 	// Expect refund to creator
 	// Refund is reduced by fees; exact amount is verified in mock callback.
 	expectedRefund := escrow.Amount - uint64(keeper.SubnetGroupSize)*100_000_000 - fees
@@ -132,6 +146,7 @@ func TestSettleSubnetEscrow_HappyPath(t *testing.T) {
 			require.Equal(t, expectedRefund, coins[0].Amount.Uint64())
 			return nil
 		})
+	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	resp, err := ms.SettleSubnetEscrow(ctx, msg)
 	require.NoError(t, err)
@@ -141,6 +156,15 @@ func TestSettleSubnetEscrow_HappyPath(t *testing.T) {
 	settled, found := k.GetSubnetEscrow(ctx, 1)
 	require.True(t, found)
 	require.True(t, settled.Settled)
+
+	expectedPayout := int64(costPerSlot + (fees / uint64(keeper.SubnetGroupSize)))
+	for _, addr := range slots {
+		participant, found := k.GetParticipant(ctx, addr)
+		require.True(t, found)
+		require.Equal(t, expectedPayout, participant.CoinBalance)
+		require.NotNil(t, participant.CurrentEpochStats)
+		require.Equal(t, uint64(expectedPayout), participant.CurrentEpochStats.EarnedCoins)
+	}
 }
 
 func TestSettleSubnetEscrow_AlreadySettled(t *testing.T) {

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -358,7 +358,7 @@ func (k msgServer) processInferencePayments(
 // * Update CoinBalance
 // * Update EpochStats
 // * Log the owed-subaccount transaction
-func (k msgServer) processParticipantPayment(
+func (k *Keeper) processParticipantPayment(
 	ctx sdk.Context,
 	participant *types.Participant,
 	payout int64,

--- a/inference-chain/x/inference/keeper/msg_server_start_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_start_inference.go
@@ -2,6 +2,9 @@ package keeper
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"math/bits"
 	"time"
 
 	"encoding/base64"
@@ -343,12 +346,52 @@ func (k msgServer) processInferencePayments(
 		if executor == nil {
 			return nil, sdkerrors.Wrap(types.ErrParticipantNotFound, inference.ExecutedBy)
 		}
-		ensureParticipantEpochStats(executor)
-		executor.CoinBalance += payments.ExecutorPayment
-		executor.CurrentEpochStats.EarnedCoins += uint64(payments.ExecutorPayment)
-		k.SafeLogSubAccountTransaction(ctx, executor.Address, types.ModuleName, types.OwedSubAccount, executor.CoinBalance, "inference_started:"+inference.InferenceId)
+		if err := k.processParticipantPayment(ctx, executor, payments.ExecutorPayment, "inference_started:"+inference.InferenceId); err != nil {
+			return nil, err
+		}
 	}
 	return inference, nil
+}
+
+// processParticipantPayment updates a participant's ledger balances for a positive payout without bank transfers.
+//
+// * Update CoinBalance
+// * Update EpochStats
+// * Log the owed-subaccount transaction
+func (k msgServer) processParticipantPayment(
+	ctx sdk.Context,
+	participant *types.Participant,
+	payout int64,
+	memo string,
+) error {
+	// Validate inputs and short-circuit for zero payouts.
+	if participant == nil {
+		return fmt.Errorf("participant is nil")
+	}
+	if payout == 0 {
+		return nil
+	}
+	if payout < 0 {
+		return fmt.Errorf("payout must be positive for %s: %d", participant.Address, payout)
+	}
+
+	// Update CoinBalance with overflow checks.
+	if participant.CoinBalance > math.MaxInt64-payout {
+		return fmt.Errorf("participant balance overflow for %s", participant.Address)
+	}
+	participant.CoinBalance += payout
+
+	// Update EpochStats with overflow checks.
+	ensureParticipantEpochStats(participant)
+	nextEarnedCoins, carry := bits.Add64(participant.CurrentEpochStats.EarnedCoins, uint64(payout), 0)
+	if carry != 0 {
+		return fmt.Errorf("participant earned coins overflow for %s", participant.Address)
+	}
+	participant.CurrentEpochStats.EarnedCoins = nextEarnedCoins
+
+	// Log the owed-subaccount transaction
+	k.SafeLogSubAccountTransaction(ctx, participant.Address, types.ModuleName, types.OwedSubAccount, participant.CoinBalance, memo)
+	return nil
 }
 
 func shouldPersistParticipant(inference *types.Inference, payments *calculations.Payments, executor *types.Participant) bool {

--- a/testermint/src/test/kotlin/SubnetTests.kt
+++ b/testermint/src/test/kotlin/SubnetTests.kt
@@ -90,6 +90,11 @@ class SubnetTests : TestermintTest() {
         val txResp = genesis.createSubnetEscrow(escrowAmount, from = userKeyName)
         assertThat(txResp.code).isEqualTo(0)
 
+        // Fetch the initial onchain balances for each host before the session begins.
+        val createdEscrow = genesis.node.querySubnetEscrow(1)
+        val slotAddresses = createdEscrow.escrow!!.slots.distinct()
+        val hostBalancesBeforeSettlement = slotAddresses.associateWith { genesis.getBalance(it) }
+
         logSection("Starting subnet proxy")
         val handle = genesis.startSubnetProxy(escrowId = 1, keyName = userKeyName)
 
@@ -148,6 +153,46 @@ class SubnetTests : TestermintTest() {
             logSection("Verifying user got refund")
             val balanceAfter = genesis.getBalance(userAddress)
             assertThat(balanceAfter).isEqualTo(fundAmount - totalPayout)
+
+            // Rewards should not be distributed to hosts upon settlement.
+            // That's done only at the end of the epoch.
+            logSection("Verifying host balances unchanged after settlement")
+            val hostBalancesAfterSettlement = slotAddresses.associateWith { genesis.getBalance(it) }
+            slotAddresses.forEach { address ->
+                assertThat(hostBalancesAfterSettlement[address])
+                    .withFailMessage("Host $address balance changed immediately after settlement")
+                    .isEqualTo(hostBalancesBeforeSettlement[address])
+            }
+
+            // Wait for the end of the epoch, and then claim rewards for the host in the first slot.
+            // We should see the balance increase by the reward amount after claiming.
+            val hostAddress = slotAddresses.firstOrNull()
+                ?: error("No host addresses found in escrow slots")
+            val hostPair = cluster.allPairs.firstOrNull { it.node.getColdAddress() == hostAddress }
+                ?: error("No host pair found for address $hostAddress")
+            val rewardSeed = hostPair.api.getConfig().currentSeed
+
+            genesis.markNeedsReboot()
+            hostPair.stopApiContainer()
+
+            logSection("Waiting for epoch end to claim host rewards")
+            genesis.waitForStage(EpochStage.CLAIM_REWARDS, offset = 2)
+
+            val hostBalanceBeforeClaim = hostPair.node.getSelfBalance()
+            val claimResponse = hostPair.submitTransaction(
+                listOf(
+                    "inference",
+                    "claim-rewards",
+                    rewardSeed.seed.toString(),
+                    rewardSeed.epochIndex.toString(),
+                )
+            )
+            assertThat(claimResponse.code).isEqualTo(0)
+
+            val hostBalanceAfterClaim = hostPair.node.getSelfBalance()
+            assertThat(hostBalanceAfterClaim)
+                .withFailMessage("Host $hostAddress did not receive rewards after epoch end")
+                .isGreaterThan(hostBalanceBeforeClaim)
         } finally {
             genesis.stopSubnetProxy(1)
         }


### PR DESCRIPTION
Distribute `WorkCoins` at the end of the epoch, instead of upon settlement.
