### PR TITLE
[#977] `Devshards`: limit inference count

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
@@ -54,6 +54,22 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 		}
 		addr := escrow.Slots[hs.SlotId]
 
+		// IFF the subnet is being settled in a different epoch than it was created,
+		// and the validator was punished in the previous epoch, then they shouldn't be paid.
+		//
+		// We're inferring that `RewardedCoins` being 0 means the validator was punished.
+		if !isSameEpochSettlement {
+			summary, summaryFound := k.GetEpochPerformanceSummary(goCtx, escrow.EpochIndex, addr)
+			if !summaryFound || summary.RewardedCoins == 0 {
+				k.LogInfo("Skipping subnet escrow payout: host was punished in previous epoch", types.Settle,
+					"participant", addr,
+					"escrow_id", escrow.Id,
+					"escrow_epoch", escrow.EpochIndex,
+				)
+				continue
+			}
+		}
+
 		// Assign cost of running inferences to this slot's validator
 		nextValidatorPayout, carry := bits.Add64(validatorPayouts[addr], hs.Cost, 0)
 		if carry != 0 {

--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
@@ -33,6 +33,13 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 		return nil, fmt.Errorf("escrow %d has no slots", escrow.Id)
 	}
 
+	// Check if the subnet is being settled in the same epoch it was created.
+	currentEpochIndex, epochFound := k.GetEffectiveEpochIndex(goCtx)
+	if !epochFound {
+		return nil, fmt.Errorf("failed to get effective epoch index")
+	}
+	isSameEpochSettlement := escrow.EpochIndex == currentEpochIndex
+
 	totalSlots := uint64(len(escrow.Slots))
 	// How much of the total fees will be assigned to each slot
 	feePerSlot := msg.Fees / totalSlots
@@ -96,11 +103,14 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 		}
 		totalPayout = nextTotalPayout
 
-		// Apply payout to participant balances (ledger-style, no bank transfer).
-		participant, found := k.GetParticipant(ctx, addr)
-		// If the subnet is settled on a different epoch, it's possible a subnet's host is no longer a participant on this epoch.
-		// In this case, we skip payment to this host
-		if found {
+		if isSameEpochSettlement {
+			// If the subnet is being settled in the same epoch it was created,
+			// we treat the payout the same as onchain inferences: we use [processParticipantPayment]
+			// to increment [participant.CurrentEpochStats.EarnedCoins], claimable at the end of the epoch.
+			participant, found := k.GetParticipant(ctx, addr)
+			if !found {
+				return nil, fmt.Errorf("participant %s not found", addr)
+			}
 			if payout > math.MaxInt64 {
 				return nil, fmt.Errorf("validator payout out of range for %s", addr)
 			}
@@ -109,6 +119,24 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 			}
 			if err := k.SetParticipant(ctx, participant); err != nil {
 				return nil, fmt.Errorf("failed to update participant %s: %w", addr, err)
+			}
+		} else {
+			// If the subnet is being settled in a different epoch than it was created,
+			// we perform a direct bank transfer to the validator's account.
+			recipientAddr, err := sdk.AccAddressFromBech32(addr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid validator address %s: %w", addr, err)
+			}
+			if payout > math.MaxInt64 {
+				return nil, fmt.Errorf("validator payout out of range for %s", addr)
+			}
+			coins, err := types.GetCoins(int64(payout))
+			if err != nil {
+				return nil, fmt.Errorf("invalid payout amount: %w", err)
+			}
+			err = k.BankKeeper.SendCoinsFromModuleToAccount(goCtx, types.ModuleName, recipientAddr, coins, "subnet_escrow_payment")
+			if err != nil {
+				return nil, fmt.Errorf("failed to pay validator %s: %w", addr, err)
 			}
 		}
 	}
@@ -150,16 +178,27 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 			}
 		}
 
-		// Update the participant's `CurrentEpochStats`
-		participant, found := k.GetParticipant(ctx, addr)
-		// If the subnet is settled on a different epoch, it's possible a subnet's host is no longer a participant on this epoch.
-		// In this case, we skip updating their stats.
-		if found {
-			if err := AggregateSubnetHostStatsIntoParticipantEpochStats(&participant, *hs); err != nil {
+		if isSameEpochSettlement {
+			// If the subnet is being settled in the same epoch it was created,
+			// we treat it the same as onchain inferences: we update [participant.CurrentEpochStats], which will:
+			// * be reflected in the epoch performance summary at the end of the epoch, which is used for reputation calculations.
+			// * be taken into account when calculating punishments WorkCoins/RewardCoins (see `bitcoin_rewards.go`)
+			// * be taken into account when calculating participant's inactivity status (see `status.go` -> `ComputeStatus`)
+			participant, found := k.GetParticipant(ctx, addr)
+			if !found {
+				return nil, fmt.Errorf("participant %s not found", addr)
+			}
+			if err := AggregateSubnetHostStatsIntoCurrentEpochStats(&participant, *hs); err != nil {
 				return nil, fmt.Errorf("failed to aggregate host stats into participant epoch stats: %w", err)
 			}
 			if err := k.SetParticipant(ctx, participant); err != nil {
 				return nil, fmt.Errorf("failed to update participant %s: %w", addr, err)
+			}
+		} else {
+			// If the subnet is being settled in a different epoch,
+			// we update the epoch performance summary for that epoch, which is used for reputation calculations.
+			if err := k.AggregateSubnetHostStatsIntoPreviousEpochStats(goCtx, escrow, *hs, addr); err != nil {
+				return nil, fmt.Errorf("failed to aggregate host stats into participant previous epoch stats: %w", err)
 			}
 		}
 

--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
@@ -51,6 +51,7 @@ func TestSettleSubnetEscrow_FeesSplitBySlotCount(t *testing.T) {
 		EpochIndex: 5,
 		Settled:    false,
 	}
+	setupEpochGroupForSubnet(ctx, k, escrow.EpochIndex)
 	_, err = k.StoreSubnetEscrow(ctx, &escrow, 1)
 	require.NoError(t, err)
 
@@ -128,6 +129,7 @@ func TestSettleSubnetEscrow_HappyPath(t *testing.T) {
 		EpochIndex: 5,
 		Settled:    false,
 	}
+	setupEpochGroupForSubnet(ctx, k, escrow.EpochIndex)
 	_, err := k.StoreSubnetEscrow(ctx, &escrow, 1)
 	require.NoError(t, err)
 
@@ -245,6 +247,7 @@ func TestSettleSubnetEscrow_ZeroCostSettlement(t *testing.T) {
 		EpochIndex: 5,
 		Settled:    false,
 	}
+	setupEpochGroupForSubnet(ctx, k, escrow.EpochIndex)
 	_, err := k.StoreSubnetEscrow(ctx, &escrow, 1)
 	require.NoError(t, err)
 
@@ -306,6 +309,7 @@ func TestSettleSubnetEscrow_UpdatesCurrentEpochStats(t *testing.T) {
 		EpochIndex: 5,
 		Settled:    false,
 	}
+	setupEpochGroupForSubnet(ctx, k, escrow.EpochIndex)
 	_, err = k.StoreSubnetEscrow(ctx, &escrow, 1)
 	require.NoError(t, err)
 	msg := buildSettlementTestData(t, escrow, keys, hostStats, 0)
@@ -373,6 +377,7 @@ func TestSettleSubnetEscrow_UpdatesSubnetHostEpochStats(t *testing.T) {
 		EpochIndex: 7,
 		Settled:    false,
 	}
+	setupEpochGroupForSubnet(ctx, k, escrow.EpochIndex)
 	_, err = k.StoreSubnetEscrow(ctx, &escrow, 1)
 	require.NoError(t, err)
 	msg := buildSettlementTestData(t, escrow, keys, hostStats, 0)

--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
@@ -415,7 +415,7 @@ func TestSettleSubnetEscrow_UpdatesCurrentEpochStats(t *testing.T) {
 		SlotId:         0,
 		Missed:         1,
 		Invalid:        2,
-		InferenceCount: 3,
+		InferenceCount: 6,
 		Validated:      4,
 	}
 	hostStats := []*types.SubnetSettlementHostStats{&fixtureHostStats}
@@ -483,7 +483,7 @@ func TestSettleSubnetEscrow_UpdatesSubnetHostEpochStats(t *testing.T) {
 		Cost:                 7,
 		RequiredValidations:  5,
 		CompletedValidations: 4,
-		InferenceCount:       10,
+		InferenceCount:       14,
 		Validated:            11,
 	}
 	hostStats := []*types.SubnetSettlementHostStats{&fixtureHostStats}

--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
@@ -269,6 +269,128 @@ func TestSettleSubnetEscrow_ZeroCostSettlement(t *testing.T) {
 	require.True(t, settled.Settled)
 }
 
+// This test checks that if a subnet was created on an epoch X and settled on a different epoch Y, and
+// if the host was punished on epoch X, then they should not be paid in the settlement of this subnet.
+// The payment should be refunded to the user instead.
+func TestSettleSubnetEscrow_CrossEpochSkipsTransferWithoutRewardedCoins(t *testing.T) {
+	k, ms, ctx, mocks := setupSubnetEscrowTest(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	key, err := dcrdsecp.GeneratePrivateKey()
+	require.NoError(t, err)
+	addr := cosmosAddressFromDcrdKey(key).String()
+
+	creator := sdk.AccAddress(make([]byte, 20))
+	creator[0] = 0x77
+	escrow := types.SubnetEscrow{
+		Id:         1,
+		Creator:    creator.String(),
+		Amount:     1_000,
+		Slots:      []string{addr},
+		EpochIndex: 5,
+		Settled:    false,
+	}
+
+	// Set current epoch to 6 so settlement is cross-epoch with escrow epoch 5.
+	setupEpochGroupForSubnet(ctx, k, 6)
+
+	_, err = k.StoreSubnetEscrow(ctx, &escrow, 1)
+	require.NoError(t, err)
+
+	// Summary exists but has no rewarded coins, so transfer should be skipped.
+	err = k.SetEpochPerformanceSummary(ctx, types.EpochPerformanceSummary{
+		EpochIndex:    escrow.EpochIndex,
+		ParticipantId: addr,
+		RewardedCoins: 0,
+	})
+	require.NoError(t, err)
+
+	hostStats := []*types.SubnetSettlementHostStats{{
+		SlotId: 0,
+		Cost:   100,
+	}}
+	msg := buildSettlementTestData(t, escrow, []*dcrdsecp.PrivateKey{key}, hostStats, 0)
+
+	// No payout transfer expected; full escrow should be refunded to creator.
+	mocks.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, creator, gomock.Any(), gomock.Eq("subnet_escrow_refund")).
+		DoAndReturn(func(_ context.Context, _ string, _ sdk.AccAddress, coins sdk.Coins, _ string) error {
+			require.Len(t, coins, 1)
+			require.Equal(t, escrow.Amount, coins[0].Amount.Uint64())
+			return nil
+		})
+
+	resp, err := ms.SettleSubnetEscrow(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// This test checks that if a subnet was created on an epoch X and settled on a different epoch Y, and
+// if the host was NOT punished on epoch X,
+// then the payout is immediately transferred directly to the host.
+func TestSettleSubnetEscrow_CrossEpochTransfersWithRewardedCoins(t *testing.T) {
+	k, ms, ctx, mocks := setupSubnetEscrowTest(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	key, err := dcrdsecp.GeneratePrivateKey()
+	require.NoError(t, err)
+	addr := cosmosAddressFromDcrdKey(key).String()
+	recipient, err := sdk.AccAddressFromBech32(addr)
+	require.NoError(t, err)
+
+	creator := sdk.AccAddress(make([]byte, 20))
+	creator[0] = 0x88
+	escrow := types.SubnetEscrow{
+		Id:         1,
+		Creator:    creator.String(),
+		Amount:     1_000,
+		Slots:      []string{addr},
+		EpochIndex: 5,
+		Settled:    false,
+	}
+
+	// Set current epoch to 6 so settlement is cross-epoch with escrow epoch 5.
+	setupEpochGroupForSubnet(ctx, k, 6)
+
+	_, err = k.StoreSubnetEscrow(ctx, &escrow, 1)
+	require.NoError(t, err)
+
+	// Positive rewarded coins allows payout transfer.
+	err = k.SetEpochPerformanceSummary(ctx, types.EpochPerformanceSummary{
+		EpochIndex:    escrow.EpochIndex,
+		ParticipantId: addr,
+		RewardedCoins: 1,
+	})
+	require.NoError(t, err)
+
+	hostStats := []*types.SubnetSettlementHostStats{{
+		SlotId: 0,
+		Cost:   100,
+	}}
+	msg := buildSettlementTestData(t, escrow, []*dcrdsecp.PrivateKey{key}, hostStats, 0)
+
+	// Since this subnet is being settled in a different epoch than it was created,
+	// we expect a direct bank transfer to the validator's account.
+	mocks.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, recipient, gomock.Any(), gomock.Eq("subnet_escrow_payment")).
+		DoAndReturn(func(_ context.Context, _ string, _ sdk.AccAddress, coins sdk.Coins, _ string) error {
+			require.Len(t, coins, 1)
+			require.Equal(t, uint64(100), coins[0].Amount.Uint64())
+			return nil
+		})
+	mocks.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, creator, gomock.Any(), gomock.Eq("subnet_escrow_refund")).
+		DoAndReturn(func(_ context.Context, _ string, _ sdk.AccAddress, coins sdk.Coins, _ string) error {
+			require.Len(t, coins, 1)
+			require.Equal(t, escrow.Amount-100, coins[0].Amount.Uint64())
+			return nil
+		})
+
+	resp, err := ms.SettleSubnetEscrow(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
 // TestSettleSubnetEscrow_UpdatesCurrentEpochStats verifies settlement aggregates host stats into CurrentEpochStats.
 func TestSettleSubnetEscrow_UpdatesCurrentEpochStats(t *testing.T) {
 	// Setup keeper, message server, and bech32 config.

--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
@@ -532,6 +532,44 @@ func TestSettleSubnetEscrow_UpdatesSubnetHostEpochStats(t *testing.T) {
 	require.Equal(t, uint32(1), statsA.EscrowCount)
 }
 
+func TestSettleSubnetEscrow_RejectsInferenceCountOverCap(t *testing.T) {
+	k, ms, ctx, _ := setupSubnetEscrowTest(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	keyA, err := dcrdsecp.GeneratePrivateKey()
+	require.NoError(t, err)
+	addrA := cosmosAddressFromDcrdKey(keyA).String()
+	err = k.SetParticipant(ctx, types.Participant{
+		Address: addrA,
+		Index:   addrA,
+		Status:  types.ParticipantStatus_ACTIVE,
+	})
+	require.NoError(t, err)
+
+	creator := sdk.AccAddress(make([]byte, 20))
+	creator[0] = 0x44
+	escrow := types.SubnetEscrow{
+		Id:         1,
+		Creator:    creator.String(),
+		Amount:     10_000_000,
+		Slots:      []string{addrA},
+		EpochIndex: 7,
+		Settled:    false,
+	}
+	_, err = k.StoreSubnetEscrow(ctx, &escrow, 1)
+	require.NoError(t, err)
+
+	hostStats := []*types.SubnetSettlementHostStats{{
+		SlotId:         0,
+		InferenceCount: uint32(keeper.MaxSettlementInferenceCount + 1),
+	}}
+	msg := buildSettlementTestData(t, escrow, []*dcrdsecp.PrivateKey{keyA}, hostStats, 0)
+
+	_, err = ms.SettleSubnetEscrow(ctx, msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds max")
+}
+
 func TestSettleSubnetEscrow_AllowlistBlocks(t *testing.T) {
 	k, ms, ctx, _ := setupSubnetEscrowTest(t)
 	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")

--- a/inference-chain/x/inference/keeper/subnet_host_stats.go
+++ b/inference-chain/x/inference/keeper/subnet_host_stats.go
@@ -41,8 +41,8 @@ func (k Keeper) AggregateSubnetHostStats(ctx context.Context, epochIndex uint64,
 	return k.SubnetHostEpochStatsMap.Set(ctx, key, existing)
 }
 
-// AggregateSubnetHostStatsIntoParticipantEpochStats merges subnet settlement stats into a participant's epoch stats.
-func AggregateSubnetHostStatsIntoParticipantEpochStats(participant *types.Participant, slotStats types.SubnetSettlementHostStats) error {
+// Merges subnet settlement stats into a participant's *current* epoch stats.
+func AggregateSubnetHostStatsIntoCurrentEpochStats(participant *types.Participant, slotStats types.SubnetSettlementHostStats) error {
 	// Validate input participant.
 	if participant == nil {
 		return fmt.Errorf("participant is nil")
@@ -78,6 +78,49 @@ func AggregateSubnetHostStatsIntoParticipantEpochStats(participant *types.Partic
 		return fmt.Errorf("participant validated inferences overflow for %s", participant.Address)
 	}
 	participant.CurrentEpochStats.ValidatedInferences = nextValidated
+
+	return nil
+}
+
+// Merges subnet settlement stats into a participant's *previous* epoch stats.
+func (k *Keeper) AggregateSubnetHostStatsIntoPreviousEpochStats(
+	goCtx context.Context,
+	escrow types.SubnetEscrow,
+	hs types.SubnetSettlementHostStats,
+	addr string,
+) error {
+	summary, summaryFound := k.GetEpochPerformanceSummary(goCtx, escrow.EpochIndex, addr)
+	if !summaryFound {
+		return nil
+	}
+
+	nextMissedRequests, carry := bits.Add64(summary.MissedRequests, uint64(hs.Missed), 0)
+	if carry != 0 {
+		return fmt.Errorf("epoch performance summary missed requests overflow for %s", addr)
+	}
+	summary.MissedRequests = nextMissedRequests
+
+	nextInvalidated, carry := bits.Add64(summary.InvalidatedInferences, uint64(hs.Invalid), 0)
+	if carry != 0 {
+		return fmt.Errorf("epoch performance summary invalidated inferences overflow for %s", addr)
+	}
+	summary.InvalidatedInferences = nextInvalidated
+
+	nextInferenceCount, carry := bits.Add64(summary.InferenceCount, uint64(hs.InferenceCount), 0)
+	if carry != 0 {
+		return fmt.Errorf("epoch performance summary inference count overflow for %s", addr)
+	}
+	summary.InferenceCount = nextInferenceCount
+
+	nextValidated, carry := bits.Add64(summary.ValidatedInferences, uint64(hs.Validated), 0)
+	if carry != 0 {
+		return fmt.Errorf("epoch performance summary validated inferences overflow for %s", addr)
+	}
+	summary.ValidatedInferences = nextValidated
+
+	if err := k.SetEpochPerformanceSummary(goCtx, summary); err != nil {
+		return fmt.Errorf("failed to update epoch performance summary for %s: %w", addr, err)
+	}
 
 	return nil
 }

--- a/inference-chain/x/inference/keeper/subnet_settlement.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement.go
@@ -139,10 +139,11 @@ func VerifySubnetSettlement(escrow types.SubnetEscrow, msg *types.MsgSettleSubne
 	return nil
 }
 
-// verifyHostStatsIntegrity validates host stats entries and returns total cost.
+// verifyHostStatsIntegrity validates host stats entries.
 func verifyHostStatsIntegrity(hostStats []*types.SubnetSettlementHostStats) error {
 	seenStatSlots := make(map[uint32]bool, len(hostStats))
 	var totalInferenceCount uint64
+	var totalMissedInferences uint64
 
 	for _, hs := range hostStats {
 
@@ -152,16 +153,16 @@ func verifyHostStatsIntegrity(hostStats []*types.SubnetSettlementHostStats) erro
 		}
 		seenStatSlots[hs.SlotId] = true
 
-		// NOTE: It's important that we check that the sum of `Validated/Invalid/Missed` for all hosts
+		// NOTE: It's important that we check that the sum of `Validated/Invalid` for all hosts
 		// does not exceed [MaxSettlementInferenceCount]
 		// in order to limit the amount of damage a hijacked subnet could cause by reporting fake stats.
 		//
 		// See: https://github.com/gonka-ai/gonka/issues/914#issuecomment-4090483233
 
-		// Per-host consistency: validated + invalid + missed must not exceed inference_count
-		sumCounts := uint64(hs.Validated) + uint64(hs.Invalid) + uint64(hs.Missed)
+		// Per-host consistency: validated + invalid must not exceed inference_count
+		sumCounts := uint64(hs.Validated) + uint64(hs.Invalid)
 		if sumCounts > uint64(hs.InferenceCount) {
-			return fmt.Errorf("host_stats slot_id %d: validated+invalid+missed (%d) exceeds inference_count %d", hs.SlotId, sumCounts, hs.InferenceCount)
+			return fmt.Errorf("host_stats slot_id %d: validated+invalid (%d) exceeds inference_count %d", hs.SlotId, sumCounts, hs.InferenceCount)
 		}
 
 		// Check if the total inference count exceeds the max allowed.
@@ -172,6 +173,17 @@ func verifyHostStatsIntegrity(hostStats []*types.SubnetSettlementHostStats) erro
 		totalInferenceCount = nextInferenceCount
 		if totalInferenceCount > MaxSettlementInferenceCount {
 			return fmt.Errorf("total inference count %d exceeds max %d", totalInferenceCount, MaxSettlementInferenceCount)
+		}
+
+		// NOTE: for the same reason as above, we also check that the total missed inference count acros
+		// all hosts does not exceed [MaxSettlementInferenceCount].
+		nextMissed, carryMissed := bits.Add64(totalMissedInferences, uint64(hs.Missed), 0)
+		if carryMissed != 0 {
+			return fmt.Errorf("total missed inference count overflow")
+		}
+		totalMissedInferences = nextMissed
+		if totalMissedInferences > MaxSettlementInferenceCount {
+			return fmt.Errorf("total missed inference count %d exceeds max %d", totalMissedInferences, MaxSettlementInferenceCount)
 		}
 	}
 

--- a/inference-chain/x/inference/keeper/subnet_settlement.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement.go
@@ -20,6 +20,8 @@ import (
 const (
 	SubnetGroupSize   = 16
 	SubnetQuorumSlots = 2*SubnetGroupSize/3 + 1
+	// MaxSettlementInferenceCount is the hard cap on total inferences in one settlement.
+	MaxSettlementInferenceCount = uint64(2000)
 	// SubnetSettlementPhase is the phase byte appended to the state root preimage.
 	// The chain hardcodes 0x02 (Settlement) so only fully-finalized subnet states
 	// can pass verification. States at phase Active (0x00) or Finalizing (0x01)
@@ -111,14 +113,15 @@ func VerifySubnetSettlement(escrow types.SubnetEscrow, msg *types.MsgSettleSubne
 		return fmt.Errorf("insufficient quorum: %d slot votes, need %d", slotVotes, requiredQuorum)
 	}
 
+	// Verify host stats integrity
+	err = verifyHostStatsIntegrity(msg.HostStats)
+	if err != nil {
+		return err
+	}
+
 	// Verify total cost + fees does not exceed escrow amount
-	seenStatSlots := make(map[uint32]bool, len(msg.HostStats))
 	var totalCost uint64
 	for _, hs := range msg.HostStats {
-		if seenStatSlots[hs.SlotId] {
-			return fmt.Errorf("duplicate host_stats slot_id %d", hs.SlotId)
-		}
-		seenStatSlots[hs.SlotId] = true
 		nextTotalCost, carry := bits.Add64(totalCost, hs.Cost, 0)
 		if carry != 0 {
 			return fmt.Errorf("total cost overflow")
@@ -131,6 +134,33 @@ func VerifySubnetSettlement(escrow types.SubnetEscrow, msg *types.MsgSettleSubne
 	}
 	if totalDebit > escrow.Amount {
 		return fmt.Errorf("total debit %d (cost %d + fees %d) exceeds escrow amount %d", totalDebit, totalCost, msg.Fees, escrow.Amount)
+	}
+
+	return nil
+}
+
+// verifyHostStatsIntegrity validates host stats entries and returns total cost.
+func verifyHostStatsIntegrity(hostStats []*types.SubnetSettlementHostStats) error {
+	seenStatSlots := make(map[uint32]bool, len(hostStats))
+	var totalInferenceCount uint64
+
+	for _, hs := range hostStats {
+
+		// Check for duplicate Slot IDs
+		if seenStatSlots[hs.SlotId] {
+			return fmt.Errorf("duplicate host_stats slot_id %d", hs.SlotId)
+		}
+		seenStatSlots[hs.SlotId] = true
+
+		// Check if the total inference count exceeds the max allowed.
+		nextInferenceCount, carry := bits.Add64(totalInferenceCount, uint64(hs.InferenceCount), 0)
+		if carry != 0 {
+			return fmt.Errorf("total inference count overflow")
+		}
+		totalInferenceCount = nextInferenceCount
+		if totalInferenceCount > MaxSettlementInferenceCount {
+			return fmt.Errorf("total inference count %d exceeds max %d", totalInferenceCount, MaxSettlementInferenceCount)
+		}
 	}
 
 	return nil

--- a/inference-chain/x/inference/keeper/subnet_settlement.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement.go
@@ -152,6 +152,18 @@ func verifyHostStatsIntegrity(hostStats []*types.SubnetSettlementHostStats) erro
 		}
 		seenStatSlots[hs.SlotId] = true
 
+		// NOTE: It's important that we check that the sum of `Validated/Invalid/Missed` for all hosts
+		// does not exceed [MaxSettlementInferenceCount]
+		// in order to limit the amount of damage a hijacked subnet could cause by reporting fake stats.
+		//
+		// See: https://github.com/gonka-ai/gonka/issues/914#issuecomment-4090483233
+
+		// Per-host consistency: validated + invalid + missed must not exceed inference_count
+		sumCounts := uint64(hs.Validated) + uint64(hs.Invalid) + uint64(hs.Missed)
+		if sumCounts > uint64(hs.InferenceCount) {
+			return fmt.Errorf("host_stats slot_id %d: validated+invalid+missed (%d) exceeds inference_count %d", hs.SlotId, sumCounts, hs.InferenceCount)
+		}
+
 		// Check if the total inference count exceeds the max allowed.
 		nextInferenceCount, carry := bits.Add64(totalInferenceCount, uint64(hs.InferenceCount), 0)
 		if carry != 0 {

--- a/inference-chain/x/inference/keeper/subnet_settlement_test.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement_test.go
@@ -219,6 +219,42 @@ func TestVerifySubnetSettlement_FeesExceedAmount(t *testing.T) {
 	require.Contains(t, err.Error(), "exceeds escrow amount")
 }
 
+func TestVerifySubnetSettlement_InferenceCountAtCapAllowed(t *testing.T) {
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	keys, slots := generateSubnetKeys(t, keeper.SubnetGroupSize)
+	escrow := types.SubnetEscrow{
+		Id: 1, Creator: "gonka1creator", Amount: 7_000_000_000, Slots: slots,
+	}
+	hostStats := makeHostStats(keeper.SubnetGroupSize, 0)
+	for i := range hostStats {
+		hostStats[i].InferenceCount = 125 // 16 * 125 = 2000
+	}
+	msg := buildSettlementTestData(t, escrow, keys, hostStats, 0)
+
+	err := keeper.VerifySubnetSettlement(escrow, msg, nil)
+	require.NoError(t, err)
+}
+
+func TestVerifySubnetSettlement_InferenceCountOverCapRejected(t *testing.T) {
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	keys, slots := generateSubnetKeys(t, keeper.SubnetGroupSize)
+	escrow := types.SubnetEscrow{
+		Id: 1, Creator: "gonka1creator", Amount: 7_000_000_000, Slots: slots,
+	}
+	hostStats := makeHostStats(keeper.SubnetGroupSize, 0)
+	for i := range hostStats {
+		hostStats[i].InferenceCount = 125 // baseline total 2000
+	}
+	hostStats[0].InferenceCount = 126 // total 2001
+	msg := buildSettlementTestData(t, escrow, keys, hostStats, 0)
+
+	err := keeper.VerifySubnetSettlement(escrow, msg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds max")
+}
+
 func TestVerifySubnetSettlement_InvalidSignature(t *testing.T) {
 	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
 

--- a/inference-chain/x/inference/keeper/subnet_settlement_test.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement_test.go
@@ -135,8 +135,10 @@ func makeHostStats(n int, costPerSlot uint64) []*types.SubnetSettlementHostStats
 			Cost:                 costPerSlot,
 			RequiredValidations:  10,
 			CompletedValidations: 9,
-			InferenceCount:       11,
+			InferenceCount:       12,
 			Validated:            12,
+			Missed:               0,
+			Invalid:              0,
 		}
 	}
 	return stats

--- a/subnet/cmd/subnetctl/proxy_test.go
+++ b/subnet/cmd/subnetctl/proxy_test.go
@@ -151,12 +151,11 @@ func setupTestProxy(t *testing.T, numHosts int, engines []subnet.InferenceEngine
 	}
 	userKey := testutil.MustGenerateKey(t)
 	group := testutil.MakeGroup(hostSigners)
-	config := types.SessionConfig{
-		RefusalTimeout:   1,
-		ExecutionTimeout: 1,
-		TokenPrice:       1,
-		VoteThreshold:    uint32(numHosts) / 2,
-	}
+	config := testutil.DefaultConfig(numHosts)
+	config.RefusalTimeout = 1
+	config.ExecutionTimeout = 1
+	config.TokenPrice = 1
+
 	verifier := signing.NewSecp256k1Verifier()
 
 	killables := make([]*killableClient, numHosts)

--- a/subnet/host/host_test.go
+++ b/subnet/host/host_test.go
@@ -920,13 +920,10 @@ func TestHost_ValidationTriggersOnFinishedInference(t *testing.T) {
 	user := testutil.MustGenerateKey(t)
 	group := testutil.MakeGroup(hosts)
 	// Use 100% validation rate so ShouldValidate always returns true.
-	config := types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    1,
-		ValidationRate:   10000,
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.VoteThreshold = 1
+	config.ValidationRate = 10000
+
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
 	require.NoError(t, err)

--- a/subnet/internal/testutil/testutil.go
+++ b/subnet/internal/testutil/testutil.go
@@ -57,13 +57,14 @@ func MakeGroup(signers []*signing.Secp256k1Signer) []types.SlotAssignment {
 // and ValidationRate = 5000 (50%).
 func DefaultConfig(numHosts int) types.SessionConfig {
 	return types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    uint32(numHosts) / 2,
-		ValidationRate:   5000,
-		CreateSubnetFee:  0,
-		FeePerNonce:      0,
+		RefusalTimeout:         60,
+		ExecutionTimeout:       1200,
+		TokenPrice:             1,
+		MaxInferencesPerSubnet: 2000,
+		VoteThreshold:          uint32(numHosts) / 2,
+		ValidationRate:         5000,
+		CreateSubnetFee:        0,
+		FeePerNonce:            0,
 	}
 }
 

--- a/subnet/state/machine.go
+++ b/subnet/state/machine.go
@@ -550,6 +550,11 @@ func (sm *StateMachine) applyStartInference(msg *types.MsgStartInference) error 
 		return types.ErrDuplicateInferenceID
 	}
 
+	// Enforce hard session-wide inference cap before mutating state.
+	if len(sm.state.Inferences) >= int(sm.state.Config.MaxInferencesPerSubnet) {
+		return fmt.Errorf("%w: max %d", types.ErrInferenceLimitReached, sm.state.Config.MaxInferencesPerSubnet)
+	}
+
 	// Executor slot: group[inference_id % len(group)].SlotID
 	executorSlot := sm.state.Group[msg.InferenceId%uint64(len(sm.state.Group))].SlotID
 

--- a/subnet/state/machine_test.go
+++ b/subnet/state/machine_test.go
@@ -105,8 +105,17 @@ func TestApplyDiff_StartInference(t *testing.T) {
 // TestApplyDiff_StartInference_MaxPerSubnetCap verifies the 2000-inference hard cap.
 func TestApplyDiff_StartInference_MaxPerSubnetCap(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
-	sm, user := newTestSM(t, hosts, 10000)
-	maxInferences := sm.SnapshotState().Config.MaxInferencesPerSubnet
+
+	maxInferences := uint32(4)
+
+	config := testutil.DefaultConfig(len(hosts))
+	config.MaxInferencesPerSubnet = maxInferences
+
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier)
+	require.NoError(t, err)
 
 	for nonce := uint64(1); nonce <= uint64(maxInferences); nonce++ {
 		diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.SubnetTx{txStart(&types.MsgStartInference{
@@ -117,7 +126,7 @@ func TestApplyDiff_StartInference_MaxPerSubnetCap(t *testing.T) {
 			MaxTokens:   0,
 			StartedAt:   1000,
 		})})
-		_, err := sm.ApplyDiff(diff)
+		_, err = sm.ApplyDiff(diff)
 		require.NoError(t, err)
 	}
 
@@ -131,7 +140,7 @@ func TestApplyDiff_StartInference_MaxPerSubnetCap(t *testing.T) {
 		MaxTokens:   0,
 		StartedAt:   1000,
 	})})
-	_, err := sm.ApplyDiff(diff)
+	_, err = sm.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrInferenceLimitReached)
 
 	state := sm.SnapshotState()

--- a/subnet/state/machine_test.go
+++ b/subnet/state/machine_test.go
@@ -102,6 +102,42 @@ func TestApplyDiff_StartInference(t *testing.T) {
 	require.Equal(t, uint32(1), rec.ExecutorSlot)
 }
 
+// TestApplyDiff_StartInference_MaxPerSubnetCap verifies the 2000-inference hard cap.
+func TestApplyDiff_StartInference_MaxPerSubnetCap(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	sm, user := newTestSM(t, hosts, 10000)
+	maxInferences := sm.SnapshotState().Config.MaxInferencesPerSubnet
+
+	for nonce := uint64(1); nonce <= uint64(maxInferences); nonce++ {
+		diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.SubnetTx{txStart(&types.MsgStartInference{
+			InferenceId: nonce,
+			PromptHash:  []byte("prompt"),
+			Model:       "llama",
+			InputLength: 0,
+			MaxTokens:   0,
+			StartedAt:   1000,
+		})})
+		_, err := sm.ApplyDiff(diff)
+		require.NoError(t, err)
+	}
+
+	// The 2001st accepted inference is rejected.
+	overCapNonce := uint64(maxInferences) + 1
+	diff := testutil.SignDiff(t, user, "escrow-1", overCapNonce, []*types.SubnetTx{txStart(&types.MsgStartInference{
+		InferenceId: overCapNonce,
+		PromptHash:  []byte("prompt"),
+		Model:       "llama",
+		InputLength: 0,
+		MaxTokens:   0,
+		StartedAt:   1000,
+	})})
+	_, err := sm.ApplyDiff(diff)
+	require.ErrorIs(t, err, types.ErrInferenceLimitReached)
+
+	state := sm.SnapshotState()
+	require.Len(t, state.Inferences, int(maxInferences))
+}
+
 func TestApplyDiff_ConfirmStart(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	sm, user := newTestSM(t, hosts, 10000)

--- a/subnet/state/machine_test.go
+++ b/subnet/state/machine_test.go
@@ -1271,7 +1271,9 @@ func TestApplyDiff_CostOverflow_StartInference(t *testing.T) {
 		InputLength: math.MaxUint64 / 2, MaxTokens: 1, StartedAt: 1000,
 	})})
 	// With TokenPrice=1, the mul won't overflow. Use a custom SM with higher price.
-	config := types.SessionConfig{TokenPrice: 3, VoteThreshold: 1}
+	config := testutil.DefaultConfig(len(hosts))
+	config.TokenPrice = 3
+	config.VoteThreshold = 1
 	group := testutil.MakeGroup(hosts)
 	verifier := signing.NewSecp256k1Verifier()
 	smHigh, err := NewStateMachine("escrow-1", config, group, math.MaxUint64, user.Address(), verifier)
@@ -1846,13 +1848,13 @@ func TestApplyDiff_RevealSeed_ComplianceComputed(t *testing.T) {
 	hosts := fixedSigners(t)
 	user := testutil.MustSignerFromHex(t, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    uint32(len(hosts)) / 2,
-		ValidationRate:   10000, // 100%
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.RefusalTimeout = 60
+	config.ExecutionTimeout = 1200
+	config.TokenPrice = 1
+	config.VoteThreshold = uint32(len(hosts)) / 2
+	config.ValidationRate = 10000 // 100%
+
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
 	require.NoError(t, err)
@@ -1898,13 +1900,13 @@ func TestApplyDiff_RevealSeed_CompletedValidationsCounted(t *testing.T) {
 	hosts := fixedSigners(t)
 	user := testutil.MustSignerFromHex(t, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    uint32(len(hosts)) / 2,
-		ValidationRate:   10000,
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.RefusalTimeout = 60
+	config.ExecutionTimeout = 1200
+	config.TokenPrice = 1
+	config.VoteThreshold = uint32(len(hosts)) / 2
+	config.ValidationRate = 10000
+
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
 	require.NoError(t, err)
@@ -1952,13 +1954,13 @@ func TestApplyDiff_Validation_MultipleValidators_ComplianceCredit(t *testing.T) 
 	hosts := fixedSigners(t)
 	user := testutil.MustSignerFromHex(t, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    uint32(len(hosts)) / 2,
-		ValidationRate:   10000, // 100%
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.RefusalTimeout = 60
+	config.ExecutionTimeout = 1200
+	config.TokenPrice = 1
+	config.VoteThreshold = uint32(len(hosts)) / 2
+	config.ValidationRate = 10000 // 100%
+
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
 	require.NoError(t, err)
@@ -2023,13 +2025,13 @@ func TestApplyDiff_RevealSeed_ZeroRateNoRequirements(t *testing.T) {
 	hosts := fixedSigners(t)
 	user := testutil.MustSignerFromHex(t, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    uint32(len(hosts)) / 2,
-		ValidationRate:   0, // 0% -- no validations required
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.RefusalTimeout = 60
+	config.ExecutionTimeout = 1200
+	config.TokenPrice = 1
+	config.VoteThreshold = uint32(len(hosts)) / 2
+	config.ValidationRate = 0 // 0% -- no validations required
+
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
 	require.NoError(t, err)
@@ -2060,10 +2062,13 @@ func TestApplyDiff_RevealSeed_MultipleRevealers(t *testing.T) {
 	hosts := fixedSigners(t)
 	user := testutil.MustSignerFromHex(t, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout: 60, ExecutionTimeout: 1200, TokenPrice: 1,
-		VoteThreshold: uint32(len(hosts)) / 2, ValidationRate: 10000,
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.RefusalTimeout = 60
+	config.ExecutionTimeout = 1200
+	config.TokenPrice = 1
+	config.VoteThreshold = uint32(len(hosts)) / 2
+	config.ValidationRate = 10000
+
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
 	require.NoError(t, err)
@@ -2118,13 +2123,13 @@ func TestApplyDiff_RevealSeed_ExecutorSkipsSelf(t *testing.T) {
 	}
 	user := testutil.MustGenerateKey(t)
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    uint32(len(hosts)) / 2,
-		ValidationRate:   10000,
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.RefusalTimeout = 60
+	config.ExecutionTimeout = 1200
+	config.TokenPrice = 1
+	config.VoteThreshold = uint32(len(hosts)) / 2
+	config.ValidationRate = 10000
+
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
 	require.NoError(t, err)
@@ -2568,10 +2573,13 @@ func TestCompliance_FinishAfterReveal(t *testing.T) {
 	hosts := fixedSigners(t)
 	user := testutil.MustSignerFromHex(t, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout: 60, ExecutionTimeout: 1200, TokenPrice: 1,
-		VoteThreshold: uint32(len(hosts)) / 2, ValidationRate: 10000,
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.RefusalTimeout = 60
+	config.ExecutionTimeout = 1200
+	config.TokenPrice = 1
+	config.VoteThreshold = uint32(len(hosts)) / 2
+	config.ValidationRate = 10000
+
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
 	require.NoError(t, err)

--- a/subnet/types/config.go
+++ b/subnet/types/config.go
@@ -5,13 +5,14 @@ package types
 // by config mismatches (e.g. different ValidationRate values).
 func DefaultSessionConfig(groupSize int) SessionConfig {
 	return SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		CreateSubnetFee:  10_000,
-		FeePerNonce:      1_000,
-		VoteThreshold:    uint32(groupSize) / 2,
-		ValidationRate:   5000,
+		RefusalTimeout:         60,
+		ExecutionTimeout:       1200,
+		TokenPrice:             1,
+		MaxInferencesPerSubnet: 2000,
+		CreateSubnetFee:        10_000,
+		FeePerNonce:            1_000,
+		VoteThreshold:          uint32(groupSize) / 2,
+		ValidationRate:         5000,
 	}
 }
 

--- a/subnet/types/domain.go
+++ b/subnet/types/domain.go
@@ -65,10 +65,12 @@ type SessionConfig struct {
 	RefusalTimeout   int64  // seconds before reason=refused timeout
 	ExecutionTimeout int64  // seconds before reason=execution timeout
 	TokenPrice       uint64 // price per input / output token (flat per session)
-	CreateSubnetFee  uint64 // one-time fee charged when creating a subnet session
-	FeePerNonce      uint64 // fee charged per applied nonce (diff)
-	VoteThreshold    uint32 // minimum accept votes for timeout (total_slots / 2)
-	ValidationRate   uint32 // basis points (10000 = 100%, 1000 = 10%)
+	// MaxInferencesPerSubnet is the hard cap on total accepted inferences in one subnet session.
+	MaxInferencesPerSubnet uint32
+	CreateSubnetFee        uint64 // one-time fee charged when creating a subnet session
+	FeePerNonce            uint64 // fee charged per applied nonce (diff)
+	VoteThreshold          uint32 // minimum accept votes for timeout (total_slots / 2)
+	ValidationRate         uint32 // basis points (10000 = 100%, 1000 = 10%)
 }
 
 // EscrowState is the full state of a subnet session.

--- a/subnet/types/errors.go
+++ b/subnet/types/errors.go
@@ -40,4 +40,5 @@ var (
 	ErrSessionSettlement     = errors.New("session is in settlement: seeds are final")
 	ErrInvalidGroup          = errors.New("invalid group")
 	ErrEscrowIDMismatch      = errors.New("escrow_id does not match session")
+	ErrInferenceLimitReached = errors.New("inference limit reached for subnet session")
 )

--- a/subnet/user/user_test.go
+++ b/subnet/user/user_test.go
@@ -436,13 +436,9 @@ func TestUser_Finalize_SeedRevealAndSettlement(t *testing.T) {
 	}
 	userKey := testutil.MustSignerFromHex(t, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    uint32(numHosts) / 2,
-		ValidationRate:   10000, // 100%
-	}
+	config := testutil.DefaultConfig(len(hosts))
+	config.ValidationRate = 10000 // 100%
+
 	verifier := signing.NewSecp256k1Verifier()
 
 	clients := make([]HostClient, numHosts)


### PR DESCRIPTION
This PR adds a limit of 2k inferences per subnet.

As such, the "Invalid" / "Missed" stats cannot have a total above 2k either. This creates a limit on how much damage a hijacked subnet can cause on the network.

Fixes #977