### PR TITLE
add v0.2.12 upgrade handler skeleton

### DIFF
--- a/inference-chain/app/upgrades.go
+++ b/inference-chain/app/upgrades.go
@@ -14,6 +14,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/productscience/inference/app/upgrades/v0_2_10"
 	"github.com/productscience/inference/app/upgrades/v0_2_11"
+	"github.com/productscience/inference/app/upgrades/v0_2_12"
 	v0_2_2 "github.com/productscience/inference/app/upgrades/v0_2_2"
 	v0_2_3 "github.com/productscience/inference/app/upgrades/v0_2_3"
 	"github.com/productscience/inference/app/upgrades/v0_2_4"
@@ -63,6 +64,7 @@ func (app *App) setupUpgradeHandlers() {
 	app.UpgradeKeeper.SetUpgradeHandler(v0_2_9.UpgradeName, v0_2_9.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper))
 	app.UpgradeKeeper.SetUpgradeHandler(v0_2_10.UpgradeName, v0_2_10.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.DistrKeeper))
 	app.UpgradeKeeper.SetUpgradeHandler(v0_2_11.UpgradeName, v0_2_11.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.DistrKeeper, app.BlsKeeper))
+	app.UpgradeKeeper.SetUpgradeHandler(v0_2_12.UpgradeName, v0_2_12.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper))
 }
 
 func (app *App) registerMigrations() {

--- a/inference-chain/app/upgrades/v0_2_12/constants.go
+++ b/inference-chain/app/upgrades/v0_2_12/constants.go
@@ -1,0 +1,3 @@
+package v0_2_12
+
+const UpgradeName = "v0.2.12"

--- a/inference-chain/app/upgrades/v0_2_12/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_12/upgrades.go
@@ -1,0 +1,32 @@
+package v0_2_12
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	k keeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		k.LogInfo("starting upgrade", types.Upgrades, "version", UpgradeName)
+
+		if _, ok := fromVM["capability"]; !ok {
+			fromVM["capability"] = mm.Modules["capability"].(module.HasConsensusVersion).ConsensusVersion()
+		}
+
+		toVM, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return toVM, err
+		}
+
+		k.LogInfo("successfully upgraded", types.Upgrades, "version", UpgradeName)
+		return toVM, nil
+	}
+}


### PR DESCRIPTION
Registers the v0.2.12 upgrade handler with capability version fix and module migrations. This is the minimal handler — feature-specific logic will be added by feature branches.