### PR TITLE
fix(subnet): add overflow guards for all uint32 fields in SubnetHostEpochStats

### DIFF
--- a/inference-chain/x/inference/keeper/subnet_host_stats.go
+++ b/inference-chain/x/inference/keeper/subnet_host_stats.go
@@ -27,14 +27,31 @@ func (k Keeper) AggregateSubnetHostStats(ctx context.Context, epochIndex uint64,
 			EpochIndex:  epochIndex,
 		}
 	}
+	if existing.Missed > math.MaxUint32-slotStats.Missed {
+		return fmt.Errorf("missed overflow aggregating subnet host stats: existing=%d add=%d", existing.Missed, slotStats.Missed)
+	}
 	existing.Missed += slotStats.Missed
+
+	if existing.Invalid > math.MaxUint32-slotStats.Invalid {
+		return fmt.Errorf("invalid overflow aggregating subnet host stats: existing=%d add=%d", existing.Invalid, slotStats.Invalid)
+	}
 	existing.Invalid += slotStats.Invalid
+
 	if existing.Cost > math.MaxUint64-slotStats.Cost {
 		return fmt.Errorf("cost overflow aggregating subnet host stats")
 	}
 	existing.Cost += slotStats.Cost
+
+	if existing.RequiredValidations > math.MaxUint32-slotStats.RequiredValidations {
+		return fmt.Errorf("required_validations overflow aggregating subnet host stats: existing=%d add=%d", existing.RequiredValidations, slotStats.RequiredValidations)
+	}
 	existing.RequiredValidations += slotStats.RequiredValidations
+
+	if existing.CompletedValidations > math.MaxUint32-slotStats.CompletedValidations {
+		return fmt.Errorf("completed_validations overflow aggregating subnet host stats: existing=%d add=%d", existing.CompletedValidations, slotStats.CompletedValidations)
+	}
 	existing.CompletedValidations += slotStats.CompletedValidations
+
 	return k.SubnetHostEpochStatsMap.Set(ctx, key, existing)
 }
 
@@ -46,6 +63,9 @@ func (k Keeper) IncrementSubnetHostEscrowCount(ctx context.Context, epochIndex u
 			Participant: participant.String(),
 			EpochIndex:  epochIndex,
 		}
+	}
+	if existing.EscrowCount == math.MaxUint32 {
+		return fmt.Errorf("escrow count overflow for participant %s epoch %d", participant.String(), epochIndex)
 	}
 	existing.EscrowCount++
 	return k.SubnetHostEpochStatsMap.Set(ctx, key, existing)

--- a/inference-chain/x/inference/keeper/subnet_host_stats.go
+++ b/inference-chain/x/inference/keeper/subnet_host_stats.go
@@ -38,7 +38,7 @@ func (k Keeper) AggregateSubnetHostStats(ctx context.Context, epochIndex uint64,
 	existing.Invalid += slotStats.Invalid
 
 	if existing.Cost > math.MaxUint64-slotStats.Cost {
-		return fmt.Errorf("cost overflow aggregating subnet host stats")
+		return fmt.Errorf("cost overflow aggregating subnet host stats: existing=%d add=%d", existing.Cost, slotStats.Cost)
 	}
 	existing.Cost += slotStats.Cost
 

--- a/inference-chain/x/inference/keeper/subnet_host_stats_test.go
+++ b/inference-chain/x/inference/keeper/subnet_host_stats_test.go
@@ -150,3 +150,41 @@ func TestAggregateSubnetHostStats_HappyPath(t *testing.T) {
 	require.Equal(t, uint32(100), stats.RequiredValidations)
 	require.Equal(t, uint32(95), stats.CompletedValidations)
 }
+
+func TestAggregateSubnetHostStats_LargeButNotOverflow(t *testing.T) {
+	// MaxUint32/2 + MaxUint32/2 should succeed because the sum equals MaxUint32 (no wrap).
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	participant := hostStatsParticipant(0x08)
+	epochIndex := uint64(1)
+
+	half := math.MaxUint32 / 2
+	err := k.SubnetHostEpochStatsMap.Set(ctx, collections.Join(epochIndex, participant), types.SubnetHostEpochStats{
+		Participant:          participant.String(),
+		EpochIndex:           epochIndex,
+		Missed:               half,
+		Invalid:              half,
+		RequiredValidations:  half,
+		CompletedValidations: half,
+		Cost:                 math.MaxUint64 / 2,
+	})
+	require.NoError(t, err)
+
+	err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{
+		Missed:               half,
+		Invalid:              half,
+		Cost:                 math.MaxUint64/2 + 1,
+		RequiredValidations:  half,
+		CompletedValidations: half,
+	})
+	require.NoError(t, err, "MaxUint32/2 + MaxUint32/2 should not overflow")
+
+	stats, found := k.GetSubnetHostEpochStats(ctx, epochIndex, participant)
+	require.True(t, found)
+	require.Equal(t, uint32(math.MaxUint32), stats.Missed)
+	require.Equal(t, uint32(math.MaxUint32), stats.Invalid)
+	require.Equal(t, uint32(math.MaxUint32), stats.RequiredValidations)
+	require.Equal(t, uint32(math.MaxUint32), stats.CompletedValidations)
+	// Cost: MaxUint64/2 + (MaxUint64/2 + 1) = MaxUint64
+	require.Equal(t, uint64(math.MaxUint64), stats.Cost)
+}

--- a/inference-chain/x/inference/keeper/subnet_host_stats_test.go
+++ b/inference-chain/x/inference/keeper/subnet_host_stats_test.go
@@ -1,0 +1,152 @@
+package keeper_test
+
+import (
+	"math"
+	"testing"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+func hostStatsParticipant(seed byte) sdk.AccAddress {
+	addr := sdk.AccAddress(make([]byte, 20))
+	addr[0] = seed
+	return addr
+}
+
+
+func TestAggregateSubnetHostStats_MissedOverflow(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	participant := hostStatsParticipant(0x01)
+	epochIndex := uint64(1)
+
+	err := k.SubnetHostEpochStatsMap.Set(ctx, collections.Join(epochIndex, participant), types.SubnetHostEpochStats{
+		Participant: participant.String(),
+		EpochIndex:  epochIndex,
+		Missed:      math.MaxUint32,
+	})
+	require.NoError(t, err)
+
+	err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{Missed: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missed overflow")
+}
+
+func TestAggregateSubnetHostStats_InvalidOverflow(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	participant := hostStatsParticipant(0x02)
+	epochIndex := uint64(1)
+
+	err := k.SubnetHostEpochStatsMap.Set(ctx, collections.Join(epochIndex, participant), types.SubnetHostEpochStats{
+		Participant: participant.String(),
+		EpochIndex:  epochIndex,
+		Invalid:     math.MaxUint32,
+	})
+	require.NoError(t, err)
+
+	err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{Invalid: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid overflow")
+}
+
+func TestAggregateSubnetHostStats_RequiredValidationsOverflow(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	participant := hostStatsParticipant(0x03)
+	epochIndex := uint64(1)
+
+	err := k.SubnetHostEpochStatsMap.Set(ctx, collections.Join(epochIndex, participant), types.SubnetHostEpochStats{
+		Participant:         participant.String(),
+		EpochIndex:          epochIndex,
+		RequiredValidations: math.MaxUint32,
+	})
+	require.NoError(t, err)
+
+	err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{RequiredValidations: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "required_validations overflow")
+}
+
+func TestAggregateSubnetHostStats_CompletedValidationsOverflow(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	participant := hostStatsParticipant(0x04)
+	epochIndex := uint64(1)
+
+	err := k.SubnetHostEpochStatsMap.Set(ctx, collections.Join(epochIndex, participant), types.SubnetHostEpochStats{
+		Participant:          participant.String(),
+		EpochIndex:           epochIndex,
+		CompletedValidations: math.MaxUint32,
+	})
+	require.NoError(t, err)
+
+	err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{CompletedValidations: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "completed_validations overflow")
+}
+
+func TestIncrementSubnetHostEscrowCount_Overflow(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	participant := hostStatsParticipant(0x05)
+	epochIndex := uint64(1)
+
+	err := k.SubnetHostEpochStatsMap.Set(ctx, collections.Join(epochIndex, participant), types.SubnetHostEpochStats{
+		Participant: participant.String(),
+		EpochIndex:  epochIndex,
+		EscrowCount: math.MaxUint32,
+	})
+	require.NoError(t, err)
+
+	err = k.IncrementSubnetHostEscrowCount(ctx, epochIndex, participant)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "escrow count overflow")
+}
+
+func TestAggregateSubnetHostStats_CostOverflow(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	participant := hostStatsParticipant(0x06)
+	epochIndex := uint64(1)
+
+	err := k.SubnetHostEpochStatsMap.Set(ctx, collections.Join(epochIndex, participant), types.SubnetHostEpochStats{
+		Participant: participant.String(),
+		EpochIndex:  epochIndex,
+		Cost:        math.MaxUint64,
+	})
+	require.NoError(t, err)
+
+	err = k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{Cost: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cost overflow")
+}
+
+func TestAggregateSubnetHostStats_HappyPath(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	participant := hostStatsParticipant(0x07)
+	epochIndex := uint64(1)
+
+	err := k.AggregateSubnetHostStats(ctx, epochIndex, participant, types.SubnetSettlementHostStats{
+		Missed:               10,
+		Invalid:              5,
+		Cost:                 1_000_000_000,
+		RequiredValidations:  100,
+		CompletedValidations: 95,
+	})
+	require.NoError(t, err)
+
+	stats, found := k.GetSubnetHostEpochStats(ctx, epochIndex, participant)
+	require.True(t, found)
+	require.Equal(t, uint32(10), stats.Missed)
+	require.Equal(t, uint32(5), stats.Invalid)
+	require.Equal(t, uint64(1_000_000_000), stats.Cost)
+	require.Equal(t, uint32(100), stats.RequiredValidations)
+	require.Equal(t, uint32(95), stats.CompletedValidations)
+}


### PR DESCRIPTION
## Problem

`AggregateSubnetHostStats` guards `Cost` (uint64) against overflow (existing guard from PR #544) but leaves four uint32 fields unprotected:
- `Missed` — no guard
- `Invalid` — no guard
- `RequiredValidations` — no guard
- `CompletedValidations` — no guard

`IncrementSubnetHostEscrowCount` increments `EscrowCount` (uint32) with no bound check.

uint32 wraps at 4,294,967,295. If `RequiredValidations` wraps to 0 while `CompletedValidations` remains non-zero, downstream completion-rate logic produces division-by-zero or inflated ratios. Severity escalates to HIGH when issues #976/#977 integrate these stats into the punishment/reward pipeline.

Closes #979

## Fix

Add `math.MaxUint32` subtraction guards for all five uint32 accumulation sites, following the established pattern from PR #544:

```go
if existing.Missed > math.MaxUint32-slotStats.Missed {
    return fmt.Errorf("missed overflow: existing=%d add=%d", existing.Missed, slotStats.Missed)
}
existing.Missed += slotStats.Missed
```

For `EscrowCount` increment:
```go
if existing.EscrowCount == math.MaxUint32 {
    return fmt.Errorf("escrow count overflow for participant %s epoch %d", ...)
}
existing.EscrowCount++
```

## Impact

**Before:** uint32 counters silently wrap to zero on overflow — corrupted stats stored on-chain with no error signal.

**After:** any accumulation that would overflow returns an error, halting stats aggregation for that slot. No impact on current punishment pipeline (stats not yet wired to INACTIVE/INVALID logic). **Must be merged before #976/#977.**

If `AggregateSubnetHostStats` returns an error from within `SettleSubnetEscrow`, Cosmos SDK rolls back the full tx via CacheContext — no partial bank payments are committed.

**Tests added:** `subnet_host_stats_test.go` — 7 tests covering all 5 fields (Missed, Invalid, RequiredValidations, CompletedValidations, EscrowCount overflow) + happy path.

Run with: `CGO_CFLAGS='-D__BLST_PORTABLE__' go test ./x/inference/keeper/... -run TestAggregateSubnetHostStats`