### PR TITLE
fix(subnet): add overflow guards for cost accumulation in settlement

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"math"
 	"context"
 	"fmt"
 
@@ -34,6 +35,9 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 			return nil, fmt.Errorf("host_stats slot_id %d out of range", hs.SlotId)
 		}
 		addr := escrow.Slots[hs.SlotId]
+		if validatorCosts[addr] > math.MaxUint64-hs.Cost {
+			return nil, fmt.Errorf("validator cost overflow for slot %d addr %s", hs.SlotId, addr)
+		}
 		validatorCosts[addr] += hs.Cost
 	}
 
@@ -46,6 +50,9 @@ func (k msgServer) SettleSubnetEscrow(goCtx context.Context, msg *types.MsgSettl
 			continue
 		}
 		paidValidators[addr] = true
+		if totalCost > math.MaxUint64-cost {
+			return nil, fmt.Errorf("total cost overflow paying validator %s", addr)
+		}
 		totalCost += cost
 
 		recipientAddr, err := sdk.AccAddressFromBech32(addr)

--- a/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_subnet_escrow_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"math"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -189,4 +190,46 @@ func TestSettleSubnetEscrow_AllowlistBlocks(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "address is not allowed to create subnet escrows")
+}
+
+func TestSettleSubnetEscrow_ValidatorCostOverflow(t *testing.T) {
+	// Use 2-slot escrow so quorum=2 (both keys sign), keeping test setup minimal.
+	k, ms, ctx, _ := setupSubnetEscrowTest(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	keys, slots := generateSubnetKeys(t, 2)
+	creator := sdk.AccAddress(make([]byte, 20))
+	creator[0] = 0xCC
+
+	// Set group_size=2 in params to allow a 2-slot escrow
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	params.SubnetEscrowParams = &types.SubnetEscrowParams{
+		MinAmount:               1,
+		MaxAmount:               math.MaxInt64,
+		MaxEscrowsPerEpoch:      100,
+		GroupSize:               2,
+		AllowedCreatorAddresses: []string{},
+		TokenPrice:              types.DefaultSubnetTokenPrice,
+	}
+	require.NoError(t, k.SetParams(ctx, params))
+
+	escrow := types.SubnetEscrow{
+		Id: 1, Creator: creator.String(), Amount: math.MaxUint64, Slots: slots, Settled: false,
+	}
+	_, err = k.StoreSubnetEscrow(ctx, &escrow, 1)
+	require.NoError(t, err)
+
+	// slot[0] cost = MaxUint64, slot[1] cost = 1 → validatorCosts[addr0] overflows
+	hostStats := []*types.SubnetSettlementHostStats{
+		{SlotId: 0, Cost: math.MaxUint64, RequiredValidations: 10, CompletedValidations: 9},
+		{SlotId: 1, Cost: 1, RequiredValidations: 10, CompletedValidations: 9},
+	}
+	msg := buildSettlementTestData(t, escrow, keys, hostStats)
+
+	// VerifySubnetSettlement is called first and should catch the overflow,
+	// so SettleSubnetEscrow returns an error before any bank operations.
+	_, err = ms.SettleSubnetEscrow(ctx, msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "overflow")
 }

--- a/inference-chain/x/inference/keeper/subnet_settlement.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement.go
@@ -107,14 +107,26 @@ func VerifySubnetSettlement(escrow types.SubnetEscrow, msg *types.MsgSettleSubne
 		return fmt.Errorf("insufficient quorum: %d slot votes, need %d", slotVotes, requiredQuorum)
 	}
 
-	// Verify total cost does not exceed escrow amount
+	// Verify per-validator and total cost do not overflow, and total does not exceed escrow amount.
+	// Per-validator overflow check mirrors SettleSubnetEscrow's validatorCosts accumulation
+	// to prevent a malicious settler from splitting MaxUint64 across two slots of the same validator:
+	// Verify would pass but Settle would reject, creating an inconsistent validation gap.
 	seenStatSlots := make(map[uint32]bool, len(msg.HostStats))
+	validatorCosts := make(map[string]uint64)
 	var totalCost uint64
 	for _, hs := range msg.HostStats {
 		if seenStatSlots[hs.SlotId] {
 			return fmt.Errorf("duplicate host_stats slot_id %d", hs.SlotId)
 		}
 		seenStatSlots[hs.SlotId] = true
+		if int(hs.SlotId) >= len(escrow.Slots) {
+			return fmt.Errorf("host_stats slot_id %d out of range", hs.SlotId)
+		}
+		addr := escrow.Slots[hs.SlotId]
+		if validatorCosts[addr] > math.MaxUint64-hs.Cost {
+			return fmt.Errorf("validator cost overflow for slot %d addr %s: existing=%d add=%d", hs.SlotId, addr, validatorCosts[addr], hs.Cost)
+		}
+		validatorCosts[addr] += hs.Cost
 		if totalCost > math.MaxUint64-hs.Cost {
 			return fmt.Errorf("total cost overflow: accumulating slot %d cost %d would exceed uint64", hs.SlotId, hs.Cost)
 		}

--- a/inference-chain/x/inference/keeper/subnet_settlement.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"math"
 	"bytes"
 	"cmp"
 	"context"
@@ -16,8 +17,8 @@ import (
 )
 
 const (
-	SubnetGroupSize      = 16
-	SubnetQuorumSlots    = 2*SubnetGroupSize/3 + 1
+	SubnetGroupSize   = 16
+	SubnetQuorumSlots = 2*SubnetGroupSize/3 + 1
 	// SubnetSettlementPhase is the phase byte appended to the state root preimage.
 	// The chain hardcodes 0x02 (Settlement) so only fully-finalized subnet states
 	// can pass verification. States at phase Active (0x00) or Finalizing (0x01)
@@ -114,6 +115,9 @@ func VerifySubnetSettlement(escrow types.SubnetEscrow, msg *types.MsgSettleSubne
 			return fmt.Errorf("duplicate host_stats slot_id %d", hs.SlotId)
 		}
 		seenStatSlots[hs.SlotId] = true
+		if totalCost > math.MaxUint64-hs.Cost {
+			return fmt.Errorf("total cost overflow: accumulating slot %d cost %d would exceed uint64", hs.SlotId, hs.Cost)
+		}
 		totalCost += hs.Cost
 	}
 	if totalCost > escrow.Amount {

--- a/inference-chain/x/inference/keeper/subnet_settlement_test.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement_test.go
@@ -547,3 +547,27 @@ func TestVerifySubnetSettlement_TotalCostOverflow(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "overflow")
 }
+
+func TestVerifySubnetSettlement_PerValidatorCostOverflow(t *testing.T) {
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	// Use 2 slots mapped to the SAME validator address.
+	// A malicious settler could split MaxUint64 across two slots of the same validator:
+	// slot[0].Cost = MaxUint64/2, slot[1].Cost = MaxUint64/2 + 1 → validatorCosts[addr] wraps.
+	// VerifySubnetSettlement must catch this; previously it only checked totalCost overflow.
+	keys, slots := generateSubnetKeys(t, 2)
+	escrow := types.SubnetEscrow{
+		Id: 1, Creator: "gonka1creator", Amount: math.MaxUint64, Slots: slots,
+	}
+
+	halfPlusOne := math.MaxUint64/2 + 1
+	hostStats := []*types.SubnetSettlementHostStats{
+		{SlotId: 0, Cost: math.MaxUint64 / 2, RequiredValidations: 10, CompletedValidations: 9},
+		{SlotId: 1, Cost: halfPlusOne, RequiredValidations: 10, CompletedValidations: 9},
+	}
+	msg := buildSettlementTestData(t, escrow, keys, hostStats)
+
+	err := keeper.VerifySubnetSettlement(escrow, msg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validator cost overflow")
+}

--- a/inference-chain/x/inference/keeper/subnet_settlement_test.go
+++ b/inference-chain/x/inference/keeper/subnet_settlement_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"cmp"
+	"math"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -524,4 +525,25 @@ func TestSignatureFormatConversion(t *testing.T) {
 	s := new(big.Int).SetBytes(goEthSig[32:64])
 	require.True(t, r.Sign() > 0)
 	require.True(t, s.Sign() > 0)
+}
+
+func TestVerifySubnetSettlement_TotalCostOverflow(t *testing.T) {
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	// Use 2 slots: quorum for group_size=2 is 2/2 (100%), so both keys must sign.
+	keys, slots := generateSubnetKeys(t, 2)
+	escrow := types.SubnetEscrow{
+		Id: 1, Creator: "gonka1creator", Amount: math.MaxUint64, Slots: slots,
+	}
+
+	// slot[0].Cost = MaxUint64, slot[1].Cost = 1 → totalCost wraps to 0
+	hostStats := []*types.SubnetSettlementHostStats{
+		{SlotId: 0, Cost: math.MaxUint64, RequiredValidations: 10, CompletedValidations: 9},
+		{SlotId: 1, Cost: 1, RequiredValidations: 10, CompletedValidations: 9},
+	}
+	msg := buildSettlementTestData(t, escrow, keys, hostStats)
+
+	err := keeper.VerifySubnetSettlement(escrow, msg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "overflow")
 }


### PR DESCRIPTION
## Problem

`VerifySubnetSettlement` accumulates `totalCost += hs.Cost` (uint64) with no overflow guard, then checks `totalCost > escrow.Amount`.

Attack vector: a settler submits HostStats with `slot[0].Cost = math.MaxUint64` and `slot[1].Cost = 1`. `totalCost` wraps to `0`, bypassing the `escrow.Amount` bound check — an invalid settlement passes verification. With a wrapped `totalCost`, `remainder = escrow.Amount - totalCost` becomes nearly the full escrow amount, misallocating funds to the creator.

The same issue exists in `SettleSubnetEscrow` in two places:
- `validatorCosts[addr] += hs.Cost` (per-validator accumulation)
- `totalCost += cost` (aggregate accumulation)

Attack requires quorum of slot signers, but the vector is real and inconsistent with the `escrow.Amount ≤ MaxAmount` invariant established at creation.

Closes #979

## Fix

Add `math.MaxUint64` overflow guards before both accumulation sites (consistent with existing `Cost` guard in `subnet_host_stats.go`):

```go
if totalCost > math.MaxUint64-hs.Cost {
    return fmt.Errorf("total cost overflow: slot %d cost %d would exceed uint64", hs.SlotId, hs.Cost)
}
totalCost += hs.Cost
```

Two-layer defense: `VerifySubnetSettlement` (verification gate) and `SettleSubnetEscrow` (execution gate) both independently guard against overflow.

## Impact

**Before:** crafted HostStats could wrap `totalCost` → bypass escrow bound check → protocol fund misallocation to creator.

**After:** overflow in cost accumulation returns a hard error at both the verification and execution layers before any bank operations.

**Tests added:**
- `TestVerifySubnetSettlement_TotalCostOverflow` — uses `buildSettlementTestData + generateSubnetKeys(t, 2)` with valid signatures to reach the overflow check
- `TestSettleSubnetEscrow_ValidatorCostOverflow` — end-to-end through `MsgServer.SettleSubnetEscrow`

Run with: `CGO_CFLAGS='-D__BLST_PORTABLE__' go test ./x/inference/keeper/... -run TestVerifySubnetSettlement_TotalCostOverflow`