### PR TITLE
fix(subnetctl): propagate fatal HTTP errors instead of waiting on timeout

### DIFF
--- a/subnet/cmd/subnetctl/proxy.go
+++ b/subnet/cmd/subnetctl/proxy.go
@@ -14,6 +14,7 @@ import (
 
 	"subnet/host"
 	"subnet/state"
+	"subnet/transport"
 	"subnet/types"
 	"subnet/user"
 )
@@ -190,9 +191,18 @@ func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w
 // sendAndProcess sends the prepared inference and processes the response.
 // Returns finished=true when MsgFinishInference is in the host's mempool.
 // confirmedAt is the executor's receipt timestamp (0 if no receipt received).
+//
+// Fatal HTTP errors from the host (4xx other than 429) are propagated
+// immediately so the caller fails fast with a clear cause instead of
+// waiting through refusal/execution timeouts. Retryable errors (5xx,
+// 429, network failures) keep the existing behavior: no receipt is
+// returned and runInference falls through to its deadline-based retry.
 func (p *Proxy) sendAndProcess(ctx context.Context, prepared *user.PreparedInference, nonce uint64) (finished bool, confirmedAt int64, err error) {
 	resp, sendErr := p.session.SendOnly(ctx, prepared)
 	if sendErr != nil && resp == nil {
+		if transport.IsFatalHTTPError(sendErr) {
+			return false, 0, fmt.Errorf("host rejected inference: %w", sendErr)
+		}
 		return false, 0, nil
 	}
 

--- a/subnet/cmd/subnetctl/proxy_test.go
+++ b/subnet/cmd/subnetctl/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"subnet/signing"
 	"subnet/state"
 	"subnet/stub"
+	"subnet/transport"
 	"subnet/types"
 	"subnet/user"
 )
@@ -81,20 +83,31 @@ func TestHasMsgFinish(t *testing.T) {
 // --- Test infrastructure for proxy-level tests ---
 
 // killableClient wraps a HostClient. Kill/Revive toggle availability.
+// KillFatal simulates a non-retryable HTTP 4xx response from the host
+// (for example a 403 "sender not in group" from the auth layer).
 type killableClient struct {
 	inner  user.HostClient
 	killed atomic.Bool
+	fatal  atomic.Bool
 }
 
 func (c *killableClient) Send(ctx context.Context, req host.HostRequest) (*host.HostResponse, error) {
+	if c.fatal.Load() {
+		return nil, &transport.HTTPStatusError{
+			StatusCode: http.StatusForbidden,
+			Path:       "/sessions/escrow-proxy/chat/completions",
+			Body:       "sender not in group",
+		}
+	}
 	if c.killed.Load() {
 		return nil, fmt.Errorf("host killed")
 	}
 	return c.inner.Send(ctx, req)
 }
 
-func (c *killableClient) Kill()   { c.killed.Store(true) }
-func (c *killableClient) Revive() { c.killed.Store(false) }
+func (c *killableClient) Kill()      { c.killed.Store(true) }
+func (c *killableClient) Revive()    { c.killed.Store(false) }
+func (c *killableClient) KillFatal() { c.fatal.Store(true) }
 
 // verifierClient wraps killableClient and implements user.TimeoutVerifier.
 // This allows session.TimeoutVerifiers() to discover it.
@@ -337,3 +350,62 @@ func TestHandleTimeout_InsufficientVotes(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, types.StatusPending, rec.Status)
 }
+
+// TestRunInference_FatalHTTPErrorReturnsImmediately reproduces the behavior
+// described in #1019: when the host rejects an inference with a fatal 4xx
+// status (for example 403 "sender not in group" from the auth layer), the
+// proxy must surface that error immediately instead of blocking on
+// RefusalTimeout / ExecutionTimeout and then falling into timeout-vote
+// collection.
+//
+// Before the fix, sendAndProcess swallowed SendOnly errors whenever the
+// response was nil, so runInference waited through two deadline cycles and
+// eventually returned a misleading "insufficient timeout votes" / "timed
+// out" error. After the fix, 4xx statuses are propagated so the caller can
+// return 4xx/502 to the OpenAI client without the minute-long wait.
+func TestRunInference_FatalHTTPErrorReturnsImmediately(t *testing.T) {
+	zeroTimeoutBuffer(t)
+	env := setupTestProxy(t, 3, nil, true)
+	ctx := context.Background()
+
+	// Nonce 1 routes to host 1 % 3 = 1. Put that host in fatal mode so
+	// Send returns *transport.HTTPStatusError{StatusCode: 403}.
+	env.killables[1].KillFatal()
+
+	start := time.Now()
+	var buf bytes.Buffer
+	err := env.proxy.runInference(ctx, defaultParams(), &buf)
+	elapsed := time.Since(start)
+
+	// The fatal HTTP error must be surfaced — not converted into a timeout.
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host rejected inference",
+		"fatal HTTP errors must be propagated with a clear cause")
+	require.Contains(t, err.Error(), "403",
+		"status code must be preserved in the error chain")
+	require.NotContains(t, err.Error(), "timed out",
+		"fatal errors must not be reported as timeouts")
+	require.NotContains(t, err.Error(), "insufficient votes",
+		"fatal errors must not reach the timeout vote path")
+
+	// The cause must also be inspectable via errors.As for future callers
+	// that want to map status codes to HTTP responses.
+	require.True(t, transport.IsFatalHTTPError(err),
+		"error must unwrap to *transport.HTTPStatusError with a fatal status")
+
+	// Duration sanity: with zeroTimeoutBuffer the RefusalTimeout is 1s and
+	// ExecutionTimeout is 1s, so the old swallow-then-wait behavior burns
+	// at least ~2s before returning. A correct implementation returns in
+	// the low-millisecond range.
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"fatal HTTP errors must fail fast, not block on refusal/execution timeouts")
+
+	// The inference must NOT be marked as timed out — the timeout machinery
+	// was correctly bypassed.
+	st := env.sm.SnapshotState()
+	rec, ok := st.Inferences[1]
+	require.True(t, ok, "inference 1 should exist from PrepareInference")
+	require.Equal(t, types.StatusPending, rec.Status,
+		"inference must remain pending — fatal errors must not trigger timeout state transitions")
+}
+

--- a/subnet/transport/client.go
+++ b/subnet/transport/client.go
@@ -374,7 +374,11 @@ func (c *HTTPClient) doPostRaw(ctx context.Context, path string, body []byte) (*
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("http %s: status %d: %s", path, resp.StatusCode, string(respBody))
+		return nil, &HTTPStatusError{
+			StatusCode: resp.StatusCode,
+			Path:       path,
+			Body:       string(respBody),
+		}
 	}
 
 	return resp, nil

--- a/subnet/transport/errors.go
+++ b/subnet/transport/errors.go
@@ -1,0 +1,48 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// HTTPStatusError is returned by the HTTP transport layer when a host
+// responds with a non-200 status. Callers can inspect StatusCode to
+// classify the error as fatal (4xx — unlikely to succeed on retry)
+// or retryable (5xx, 429 — transient infrastructure issues).
+type HTTPStatusError struct {
+	StatusCode int
+	Path       string
+	Body       string
+}
+
+// Error implements the error interface.
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("http %s: status %d: %s", e.Path, e.StatusCode, e.Body)
+}
+
+// IsFatal reports whether the status indicates a non-retryable client error.
+// 4xx statuses (except 429 Too Many Requests) are treated as fatal — the
+// request will not succeed by simple retry and should be surfaced to the
+// caller immediately instead of blocking on refusal/execution timeouts.
+func (e *HTTPStatusError) IsFatal() bool {
+	if e == nil {
+		return false
+	}
+	// 429 Too Many Requests is retryable with backoff.
+	if e.StatusCode == http.StatusTooManyRequests {
+		return false
+	}
+	return e.StatusCode >= 400 && e.StatusCode < 500
+}
+
+// IsFatalHTTPError reports whether err wraps an HTTPStatusError with a
+// fatal (non-retryable) status code. Returns false for nil errors and
+// errors that do not wrap HTTPStatusError.
+func IsFatalHTTPError(err error) bool {
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	return httpErr.IsFatal()
+}

--- a/subnet/transport/errors_test.go
+++ b/subnet/transport/errors_test.go
@@ -1,0 +1,68 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPStatusError_IsFatal(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		wantFatal  bool
+	}{
+		{"400 BadRequest is fatal", http.StatusBadRequest, true},
+		{"401 Unauthorized is fatal", http.StatusUnauthorized, true},
+		{"403 Forbidden is fatal", http.StatusForbidden, true},
+		{"404 NotFound is fatal", http.StatusNotFound, true},
+		{"422 Unprocessable is fatal", http.StatusUnprocessableEntity, true},
+		{"429 TooManyRequests is retryable", http.StatusTooManyRequests, false},
+		{"500 InternalServerError is retryable", http.StatusInternalServerError, false},
+		{"502 BadGateway is retryable", http.StatusBadGateway, false},
+		{"503 ServiceUnavailable is retryable", http.StatusServiceUnavailable, false},
+		{"504 GatewayTimeout is retryable", http.StatusGatewayTimeout, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &HTTPStatusError{StatusCode: tc.statusCode, Path: "/test", Body: "x"}
+			require.Equal(t, tc.wantFatal, e.IsFatal())
+		})
+	}
+}
+
+func TestIsFatalHTTPError_UnwrapsViaErrorsAs(t *testing.T) {
+	root := &HTTPStatusError{StatusCode: http.StatusForbidden, Path: "/p", Body: "sender not in group"}
+
+	// Direct error.
+	require.True(t, IsFatalHTTPError(root))
+
+	// Wrapped with fmt.Errorf %w.
+	wrapped := fmt.Errorf("host rejected inference: %w", root)
+	require.True(t, IsFatalHTTPError(wrapped))
+
+	// Double wrapped.
+	double := fmt.Errorf("outer: %w", wrapped)
+	require.True(t, IsFatalHTTPError(double))
+
+	// Non-HTTP error is not fatal.
+	require.False(t, IsFatalHTTPError(errors.New("connection reset")))
+
+	// 5xx is not fatal even when wrapped.
+	retryable := fmt.Errorf("wrap: %w", &HTTPStatusError{StatusCode: http.StatusBadGateway})
+	require.False(t, IsFatalHTTPError(retryable))
+
+	// Nil is not fatal.
+	require.False(t, IsFatalHTTPError(nil))
+}
+
+func TestHTTPStatusError_ErrorIncludesStatusAndBody(t *testing.T) {
+	e := &HTTPStatusError{StatusCode: 403, Path: "/sessions/x/chat/completions", Body: "sender not in group"}
+	msg := e.Error()
+	require.Contains(t, msg, "403")
+	require.Contains(t, msg, "/sessions/x/chat/completions")
+	require.Contains(t, msg, "sender not in group")
+}


### PR DESCRIPTION
Closes #1019 (minimal fix — §1 of the issue).

## Problem

`sendAndProcess` in `subnet/cmd/subnetctl/proxy.go` swallowed any `SendOnly` error whose response was nil:

```go
resp, sendErr := p.session.SendOnly(ctx, prepared)
if sendErr != nil && resp == nil {
    return false, 0, nil   // fatal 403 is indistinguishable from a network blip
}
```

A **403 "sender not in group"** (the example from the issue — wrong creator key vs escrow ACL) was therefore indistinguishable from a transient network failure. `runInference` waited through `RefusalTimeout`, then `ExecutionTimeout`, and eventually returned a misleading `insufficient timeout votes` / `inference timed out: TIMEOUT_REASON_REFUSED` error.

Operators saw minute-long waits and confusing timeout messages instead of an immediate 4xx with the real cause.

## Fix

Classify HTTP transport errors by status code and fail fast on fatal 4xx responses. Retryable errors (5xx, 429, network) keep the existing deadline-based retry path so a transient blip still recovers.

### Scope

This PR implements **§1** of the issue (non-retryable fatal errors). The broader phase-aware retry policy (§2 post-start retries, §3 protocol continuation) is intentionally left for a follow-up — it is a larger design change that benefits from being reviewed on its own.

## Changes

- **`subnet/transport/errors.go`** (new): `HTTPStatusError` typed error with `StatusCode` / `Path` / `Body` and `IsFatal()` / `IsFatalHTTPError()` helpers. Fatal = 4xx except 429 (Too Many Requests is explicitly retryable).
- **`subnet/transport/client.go`**: `doPostRaw` returns `*HTTPStatusError` on non-200 instead of a plain `fmt.Errorf`, so callers can classify via `errors.As`.
- **`subnet/cmd/subnetctl/proxy.go`**: `sendAndProcess` now propagates fatal HTTP errors immediately with `host rejected inference: ...` wrapping. Retryable errors still return `(false, 0, nil)` to preserve the existing behavior.
- **Tests**:
  - `transport/errors_test.go`: unit tests for the fatal/retryable classification table and `errors.As` unwrapping.
  - `cmd/subnetctl/proxy_test.go`:
    - `killableClient` gains a `KillFatal()` method that makes `Send` return `*transport.HTTPStatusError{StatusCode: 403}`.
    - `TestRunInference_FatalHTTPErrorReturnsImmediately` is the red-green regression test for #1019.

## Red-green proof

**Without the fix** (stashed `proxy.go` change, ran the new test):

```
Error: "inference 1 timed out: TIMEOUT_REASON_REFUSED" does not contain "host rejected inference"
--- FAIL: TestRunInference_FatalHTTPErrorReturnsImmediately (1.00s)
```

The 1.00s is the `RefusalTimeout` the old code burned through before returning the misleading timeout error.

**With the fix**:

```
--- PASS: TestRunInference_FatalHTTPErrorReturnsImmediately (0.00s)
```

The test asserts:
- Error contains `"host rejected inference"` and `"403"`, and **not** `"timed out"` / `"insufficient votes"`.
- `transport.IsFatalHTTPError(err)` is true (error chain preserves the typed cause).
- `elapsed < 500ms` (would be 2s+ on the old path).
- Inference stays `StatusPending` — the timeout machinery is correctly bypassed.

## Test plan

- `go test ./cmd/subnetctl/ ./transport/` (all pass locally)
- Existing `TestRunInference_RefusalTimeout` unchanged — retryable errors still fall through to the timeout path.