### PR TITLE
fix: reject zero completion tokens in FinishInference

### DIFF
--- a/inference-chain/x/inference/calculations/inference_state.go
+++ b/inference-chain/x/inference/calculations/inference_state.go
@@ -170,7 +170,7 @@ func ProcessFinishInference(
 		logger.LogWarn("PromptTokens is 0 when FinishInference is called!", types.Inferences, "inferenceId", currentInference.InferenceId)
 	}
 	if currentInference.CompletionTokenCount == 0 {
-		logger.LogWarn("CompletionTokens is 0 when FinishInference is called!", types.Inferences, "inferenceId", currentInference.InferenceId)
+		return nil, nil, sdkerrors.Wrapf(types.ErrTokenCountOutOfRange, "completion_token_count must be positive for finished inference (%d)", currentInference.CompletionTokenCount)
 	}
 	actualCost, err := CalculateCost(currentInference)
 	if err != nil {

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -37,6 +37,10 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 	if msg.CompletionTokenCount > types.MaxAllowedTokens {
 		return failedFinish(ctx, sdkerrors.Wrapf(types.ErrTokenCountOutOfRange, "completion_token_count exceeds limit (%d > %d)", msg.CompletionTokenCount, types.MaxAllowedTokens), msg), nil
 	}
+	if msg.CompletionTokenCount == 0 {
+		return failedFinish(ctx, sdkerrors.Wrapf(types.ErrTokenCountOutOfRange, "completion_token_count must be positive (%d)", msg.CompletionTokenCount), msg), nil
+	}
+
 
 	// Developer access gating: until cutoff height only allowlisted developers may run inference flows.
 	// We gate by the original requester (developer), not the executor/TA.


### PR DESCRIPTION
When CompletionTokenCount is 0, CalculateCost returns 0, causing:
- executor receives 0 payment
- escrow refunded in full to user
- financial inconsistency

Added validation at both msg_server and calculations level:
- msg_server: reject CompletionTokenCount == 0 early
- inference_state: return error instead of LogWarn

PromptTokenCount == 0 case preserved as LogWarn since streaming/interrupted inferences legitimately use the StartInference value as fallback.