### PR TITLE
fix: propagate storage errors in SubmitPocValidationsV2

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_poc_validations_v2.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_validations_v2.go
@@ -115,11 +115,7 @@ func (k msgServer) SubmitPocValidationsV2(goCtx context.Context, msg *types.MsgS
 		// Check for duplicate submission (prevents vote flipping)
 		exists, err := k.HasPocValidationV2(ctx, startBlockHeight, validation.ParticipantAddress, msg.Creator)
 		if err != nil {
-			k.LogWarn("[SubmitPocValidationsV2] Failed to check existing validation, skipping", types.PoC,
-				"validator", msg.Creator,
-				"participant", validation.ParticipantAddress,
-				"error", err)
-			continue
+			return nil, sdkerrors.Wrapf(err, "[SubmitPocValidationsV2] failed to check existing validation for participant %s", validation.ParticipantAddress)
 		}
 		if exists {
 			k.LogWarn("[SubmitPocValidationsV2] Validation already exists, skipping duplicate", types.PoC,
@@ -138,11 +134,7 @@ func (k msgServer) SubmitPocValidationsV2(goCtx context.Context, msg *types.MsgS
 		}
 
 		if err := k.SetPocValidationV2(ctx, storedValidation); err != nil {
-			k.LogWarn("[SubmitPocValidationsV2] Failed to store validation, skipping", types.PoC,
-				"validator", msg.Creator,
-				"participant", validation.ParticipantAddress,
-				"error", err)
-			continue
+			return nil, sdkerrors.Wrapf(err, "[SubmitPocValidationsV2] failed to store validation for participant %s", validation.ParticipantAddress)
 		}
 
 		storedCount++


### PR DESCRIPTION
HasPocValidationV2 and SetPocValidationV2 errors were swallowed with LogWarn+continue, causing:
1. HasPocValidationV2 error: potential duplicate vote if storage check fails silently
2. SetPocValidationV2 error: validator vote silently lost

Both now return errors immediately, preserving transactional integrity. Only business-level skips (duplicate validation) remain as LogWarn.