### PR TITLE
fix: return errors from OverlapsWithPoC instead of swallowing them

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -480,7 +480,11 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 
 		totalWeight := modelTotalWeights[modelId]
 
-		if k.OverlapsWithPoC(&inference, epochContext) && !k.isActiveDuringPoC(&validatorPowerForModel) {
+		overlapsWithPoC, err := k.OverlapsWithPoC(&inference, epochContext)
+		if err != nil {
+			return mustBeValidated, types.ErrInvalidValidationDetails.Wrapf("claim rewards: failed PoC overlap check for inference %s: %v", inference.InferenceId, err)
+		}
+		if overlapsWithPoC && !k.isActiveDuringPoC(&validatorPowerForModel) {
 			skipped++
 			continue
 		}
@@ -503,22 +507,19 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 	return mustBeValidated, nil
 }
 
-func (k msgServer) OverlapsWithPoC(inferenceDetails *types.InferenceValidationDetails, epochContext types.EpochContext) bool {
+func (k msgServer) OverlapsWithPoC(inferenceDetails *types.InferenceValidationDetails, epochContext types.EpochContext) (bool, error) {
 	if inferenceDetails == nil {
-		k.LogError("MsgClaimReward. OverlapsWithPoC. Inference details is nil", types.Claims, "inferenceDetails", inferenceDetails)
-		return false
+		return false, types.ErrInvalidValidationDetails.Wrap("OverlapsWithPoC: inference details is nil")
 	}
 
 	if inferenceDetails.CreatedAtBlockHeight == 0 {
-		k.LogWarn("MsgClaimReward. OverlapsWithPoC. CreatedAtBlockHeight is not set", types.Claims, "inferenceDetails", inferenceDetails)
-		return false
+		return false, types.ErrInvalidValidationDetails.Wrap("OverlapsWithPoC: CreatedAtBlockHeight is not set")
 	} else if inferenceDetails.CreatedAtBlockHeight < 0 {
-		k.LogError("MsgClaimReward. OverlapsWithPoC. CreatedAtBlockHeight is negative!", types.Claims, "inferenceDetails", inferenceDetails)
-		return false
+		return false, types.ErrInvalidValidationDetails.Wrap("OverlapsWithPoC: CreatedAtBlockHeight is negative")
 	}
 
 	happenedAfterCutoff := inferenceDetails.CreatedAtBlockHeight >= epochContext.InferenceValidationCutoff()
-	return happenedAfterCutoff
+	return happenedAfterCutoff, nil
 }
 
 func (k msgServer) isActiveDuringPoC(weight *types.ValidationWeight) bool {

--- a/inference-chain/x/inference/types/errors.go
+++ b/inference-chain/x/inference/types/errors.go
@@ -77,4 +77,5 @@ var (
 	ErrTAComponentMismatch                   = sdkerrors.Register(ModuleName, 1171, "transfer agent signature components mismatch")
 	ErrInferenceRoleMismatch                 = sdkerrors.Register(ModuleName, 1172, "inference role/address invariant mismatch")
 	ErrNotAllowedEscrowCreator               = sdkerrors.Register(ModuleName, 1173, "address is not allowed to create subnet escrows for subnets")
+	ErrInvalidValidationDetails               = sdkerrors.Register(ModuleName, 1174, "invalid validation details")
 )


### PR DESCRIPTION
CreatedAtBlockHeight == 0 in OverlapsWithPoC caused it to return false, allowing claim_rewards to skip PoC validation for inferences with missing block height data. This enables reward claims for inferences that should require PoC validation.

OverlapsWithPoC now returns (bool, error):
- nil inference details -> error
- CreatedAtBlockHeight == 0 -> error (unset field)
- CreatedAtBlockHeight < 0 -> error (negative)

Also added ErrInvalidValidationDetails error type.