### PR TITLE
fix: propagate storage errors in UpdateDynamicPricing instead of defa…

### DIFF
--- a/inference-chain/x/inference/keeper/dynamic_pricing.go
+++ b/inference-chain/x/inference/keeper/dynamic_pricing.go
@@ -65,9 +65,7 @@ func (k *Keeper) UpdateDynamicPricing(ctx context.Context) error {
 		// Get cached capacity for this model
 		capacity, err := k.GetCachedModelCapacity(ctx, modelId)
 		if err != nil {
-			k.LogWarn("Failed to get cached capacity for model, skipping", types.Pricing,
-				"modelId", modelId, "error", err)
-			continue
+			return fmt.Errorf("failed to get cached capacity for model %s: %w", modelId, err)
 		}
 
 		averageLoadPerBlock, found, err := k.GetModelLoadRollingAveragePerBlock(
@@ -76,9 +74,7 @@ func (k *Keeper) UpdateDynamicPricing(ctx context.Context) error {
 			windowBlocks,
 		)
 		if err != nil {
-			k.LogWarn("Failed to get model load rolling average, defaulting to zero load", types.Pricing,
-				"modelId", modelId, "error", err)
-			averageLoadPerBlock = decimal.Zero
+			return fmt.Errorf("failed to get model load rolling average for model %s: %w", modelId, err)
 		}
 		if !found {
 			averageLoadPerBlock = decimal.Zero

--- a/inference-chain/x/inference/keeper/dynamic_pricing.go
+++ b/inference-chain/x/inference/keeper/dynamic_pricing.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	sdkerrors "cosmossdk.io/errors"
+
 	"github.com/productscience/inference/x/inference/calculations"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/shopspring/decimal"
@@ -65,7 +67,7 @@ func (k *Keeper) UpdateDynamicPricing(ctx context.Context) error {
 		// Get cached capacity for this model
 		capacity, err := k.GetCachedModelCapacity(ctx, modelId)
 		if err != nil {
-			return fmt.Errorf("failed to get cached capacity for model %s: %w", modelId, err)
+			return sdkerrors.Wrapf(err, "failed to get cached capacity for model %s", modelId)
 		}
 
 		averageLoadPerBlock, found, err := k.GetModelLoadRollingAveragePerBlock(
@@ -74,7 +76,7 @@ func (k *Keeper) UpdateDynamicPricing(ctx context.Context) error {
 			windowBlocks,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to get model load rolling average for model %s: %w", modelId, err)
+			return sdkerrors.Wrapf(err, "failed to get model load rolling average for model %s", modelId)
 		}
 		if !found {
 			averageLoadPerBlock = decimal.Zero


### PR DESCRIPTION
…ulting to zero

GetCachedModelCapacity error was swallowed with LogWarn+continue, leaving stale prices un-updated. GetModelLoadRollingAveragePerBlock error was swallowed with LogWarn+defaulting to zero load, causing incorrect utilization calculations (0% utilization) that would decrease prices incorrectly.

Both now return errors immediately, ensuring BeginBlocker retries on next block rather than silently corrupting pricing data.

Note: !found case (no load data yet) still defaults to zero — correct behavior for new/unused models.