### PR TITLE
fix: return HTTP 400 for unsupported models instead of raw gRPC error

### DIFF
--- a/decentralized-api/internal/server/public/post_chat_handler.go
+++ b/decentralized-api/internal/server/public/post_chat_handler.go
@@ -335,8 +335,8 @@ func (s *Server) handleTransferRequest(ctx echo.Context, request *ChatRequest) e
 
 	executor, err := s.getExecutorForRequest(ctx.Request().Context(), request.OpenAiRequest.Model)
 	if err != nil {
-		logging.Error("Failed to get executor", types.Inferences, "error", err)
-		return err
+		logging.Error("Failed to get executor", types.Inferences, "error", err, "model", request.OpenAiRequest.Model)
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("No executor available for model %q. The model may not be supported or no nodes are serving it.", request.OpenAiRequest.Model))
 	}
 
 	seed := rand.Int31()


### PR DESCRIPTION
Closes #351

## Problem

When a client requests inference for a model that has no executor (not served or doesn't exist), `getExecutorForRequest` returns a raw gRPC error (`codes.Internal`). Echo sees a non-`HTTPError` and returns **HTTP 500 Internal Server Error** with the gRPC details in the body.

The original issue (#351) reported HTTP 402 Payment Required, which was the old behavior. The current behavior is HTTP 500 with an opaque internal message — equally confusing for API consumers.

## Fix

Return a structured `echo.NewHTTPError(http.StatusBadRequest, ...)` with a clear message:

```
400 Bad Request: No executor available for model "nonexistent-model". The model may not be supported or no nodes are serving it.
```

Also added `model` to the error log for easier debugging.

## Changes

- `decentralized-api/internal/server/public/post_chat_handler.go` — 2 lines changed

## Why 400 and not 404

The model is a client-provided parameter in the request body. A 400 (Bad Request) is more appropriate than 404 because the resource path (`/v1/chat/completions`) exists — it's the model parameter that's invalid. This is consistent with the OpenAI API which returns 400 for invalid model names.