### PR TITLE
feat: make devshard SessionConfig governance-configurable

### DIFF
--- a/inference-chain/proto/inference/inference/params.proto
+++ b/inference-chain/proto/inference/inference/params.proto
@@ -337,4 +337,7 @@ message SubnetEscrowParams {
   uint32 group_size = 4;
   repeated string allowed_creator_addresses = 5;
   uint64 token_price = 6;
+  int64 refusal_timeout = 7;
+  int64 execution_timeout = 8;
+  uint32 validation_rate = 9;
 }

--- a/inference-chain/proto/inference/inference/subnet_escrow.proto
+++ b/inference-chain/proto/inference/inference/subnet_escrow.proto
@@ -13,6 +13,9 @@ message SubnetEscrow {
   string app_hash = 6;
   bool settled = 7;
   uint64 token_price = 8;
+  int64 refusal_timeout = 9;
+  int64 execution_timeout = 10;
+  uint32 validation_rate = 11;
 }
 
 message SubnetHostEpochStats {

--- a/inference-chain/x/inference/keeper/msg_server_create_subnet_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_create_subnet_escrow.go
@@ -81,13 +81,16 @@ func (k msgServer) CreateSubnetEscrow(goCtx context.Context, msg *types.MsgCreat
 	}
 
 	escrow := &types.SubnetEscrow{
-		Creator:    msg.Creator,
-		Amount:     msg.Amount,
-		Slots:      slots,
-		EpochIndex: epochIndex,
-		AppHash:    appHash,
-		Settled:    false,
-		TokenPrice: ep.TokenPrice,
+		Creator:          msg.Creator,
+		Amount:           msg.Amount,
+		Slots:            slots,
+		EpochIndex:       epochIndex,
+		AppHash:          appHash,
+		Settled:          false,
+		TokenPrice:       ep.TokenPrice,
+		RefusalTimeout:   ep.RefusalTimeout,
+		ExecutionTimeout: ep.ExecutionTimeout,
+		ValidationRate:   ep.ValidationRate,
 	}
 
 	id, err := k.StoreSubnetEscrow(goCtx, escrow, nextID)

--- a/inference-chain/x/inference/types/params.pb.go
+++ b/inference-chain/x/inference/types/params.pb.go
@@ -1950,6 +1950,9 @@ type SubnetEscrowParams struct {
 	GroupSize               uint32   `protobuf:"varint,4,opt,name=group_size,json=groupSize,proto3" json:"group_size,omitempty"`
 	AllowedCreatorAddresses []string `protobuf:"bytes,5,rep,name=allowed_creator_addresses,json=allowedCreatorAddresses,proto3" json:"allowed_creator_addresses,omitempty"`
 	TokenPrice              uint64   `protobuf:"varint,6,opt,name=token_price,json=tokenPrice,proto3" json:"token_price,omitempty"`
+	RefusalTimeout          int64    `protobuf:"varint,7,opt,name=refusal_timeout,json=refusalTimeout,proto3" json:"refusal_timeout,omitempty"`
+	ExecutionTimeout        int64    `protobuf:"varint,8,opt,name=execution_timeout,json=executionTimeout,proto3" json:"execution_timeout,omitempty"`
+	ValidationRate          uint32   `protobuf:"varint,9,opt,name=validation_rate,json=validationRate,proto3" json:"validation_rate,omitempty"`
 }
 
 func (m *SubnetEscrowParams) Reset()         { *m = SubnetEscrowParams{} }
@@ -2023,6 +2026,27 @@ func (m *SubnetEscrowParams) GetAllowedCreatorAddresses() []string {
 func (m *SubnetEscrowParams) GetTokenPrice() uint64 {
 	if m != nil {
 		return m.TokenPrice
+	}
+	return 0
+}
+
+func (m *SubnetEscrowParams) GetRefusalTimeout() int64 {
+	if m != nil {
+		return m.RefusalTimeout
+	}
+	return 0
+}
+
+func (m *SubnetEscrowParams) GetExecutionTimeout() int64 {
+	if m != nil {
+		return m.ExecutionTimeout
+	}
+	return 0
+}
+
+func (m *SubnetEscrowParams) GetValidationRate() uint32 {
+	if m != nil {
+		return m.ValidationRate
 	}
 	return 0
 }
@@ -4810,6 +4834,21 @@ func (m *SubnetEscrowParams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.ValidationRate != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.ValidationRate))
+		i--
+		dAtA[i] = 0x48
+	}
+	if m.ExecutionTimeout != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.ExecutionTimeout))
+		i--
+		dAtA[i] = 0x40
+	}
+	if m.RefusalTimeout != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.RefusalTimeout))
+		i--
+		dAtA[i] = 0x38
+	}
 	if m.TokenPrice != 0 {
 		i = encodeVarintParams(dAtA, i, uint64(m.TokenPrice))
 		i--
@@ -5575,6 +5614,15 @@ func (m *SubnetEscrowParams) Size() (n int) {
 	}
 	if m.TokenPrice != 0 {
 		n += 1 + sovParams(uint64(m.TokenPrice))
+	}
+	if m.RefusalTimeout != 0 {
+		n += 1 + sovParams(uint64(m.RefusalTimeout))
+	}
+	if m.ExecutionTimeout != 0 {
+		n += 1 + sovParams(uint64(m.ExecutionTimeout))
+	}
+	if m.ValidationRate != 0 {
+		n += 1 + sovParams(uint64(m.ValidationRate))
 	}
 	return n
 }
@@ -10640,6 +10688,63 @@ func (m *SubnetEscrowParams) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.TokenPrice |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RefusalTimeout", wireType)
+			}
+			m.RefusalTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.RefusalTimeout |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExecutionTimeout", wireType)
+			}
+			m.ExecutionTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ExecutionTimeout |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValidationRate", wireType)
+			}
+			m.ValidationRate = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ValidationRate |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/inference-chain/x/inference/types/subnet_escrow.pb.go
+++ b/inference-chain/x/inference/types/subnet_escrow.pb.go
@@ -30,7 +30,10 @@ type SubnetEscrow struct {
 	EpochIndex uint64   `protobuf:"varint,5,opt,name=epoch_index,json=epochIndex,proto3" json:"epoch_index,omitempty"`
 	AppHash    string   `protobuf:"bytes,6,opt,name=app_hash,json=appHash,proto3" json:"app_hash,omitempty"`
 	Settled    bool     `protobuf:"varint,7,opt,name=settled,proto3" json:"settled,omitempty"`
-	TokenPrice uint64   `protobuf:"varint,8,opt,name=token_price,json=tokenPrice,proto3" json:"token_price,omitempty"`
+	TokenPrice       uint64   `protobuf:"varint,8,opt,name=token_price,json=tokenPrice,proto3" json:"token_price,omitempty"`
+	RefusalTimeout   int64    `protobuf:"varint,9,opt,name=refusal_timeout,json=refusalTimeout,proto3" json:"refusal_timeout,omitempty"`
+	ExecutionTimeout int64    `protobuf:"varint,10,opt,name=execution_timeout,json=executionTimeout,proto3" json:"execution_timeout,omitempty"`
+	ValidationRate   uint32   `protobuf:"varint,11,opt,name=validation_rate,json=validationRate,proto3" json:"validation_rate,omitempty"`
 }
 
 func (m *SubnetEscrow) Reset()         { *m = SubnetEscrow{} }
@@ -118,6 +121,27 @@ func (m *SubnetEscrow) GetSettled() bool {
 func (m *SubnetEscrow) GetTokenPrice() uint64 {
 	if m != nil {
 		return m.TokenPrice
+	}
+	return 0
+}
+
+func (m *SubnetEscrow) GetRefusalTimeout() int64 {
+	if m != nil {
+		return m.RefusalTimeout
+	}
+	return 0
+}
+
+func (m *SubnetEscrow) GetExecutionTimeout() int64 {
+	if m != nil {
+		return m.ExecutionTimeout
+	}
+	return 0
+}
+
+func (m *SubnetEscrow) GetValidationRate() uint32 {
+	if m != nil {
+		return m.ValidationRate
 	}
 	return 0
 }
@@ -425,6 +449,21 @@ func (m *SubnetEscrow) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.ValidationRate != 0 {
+		i = encodeVarintSubnetEscrow(dAtA, i, uint64(m.ValidationRate))
+		i--
+		dAtA[i] = 0x58
+	}
+	if m.ExecutionTimeout != 0 {
+		i = encodeVarintSubnetEscrow(dAtA, i, uint64(m.ExecutionTimeout))
+		i--
+		dAtA[i] = 0x50
+	}
+	if m.RefusalTimeout != 0 {
+		i = encodeVarintSubnetEscrow(dAtA, i, uint64(m.RefusalTimeout))
+		i--
+		dAtA[i] = 0x48
+	}
 	if m.TokenPrice != 0 {
 		i = encodeVarintSubnetEscrow(dAtA, i, uint64(m.TokenPrice))
 		i--
@@ -679,6 +718,15 @@ func (m *SubnetEscrow) Size() (n int) {
 	}
 	if m.TokenPrice != 0 {
 		n += 1 + sovSubnetEscrow(uint64(m.TokenPrice))
+	}
+	if m.RefusalTimeout != 0 {
+		n += 1 + sovSubnetEscrow(uint64(m.RefusalTimeout))
+	}
+	if m.ExecutionTimeout != 0 {
+		n += 1 + sovSubnetEscrow(uint64(m.ExecutionTimeout))
+	}
+	if m.ValidationRate != 0 {
+		n += 1 + sovSubnetEscrow(uint64(m.ValidationRate))
 	}
 	return n
 }
@@ -983,6 +1031,63 @@ func (m *SubnetEscrow) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.TokenPrice |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RefusalTimeout", wireType)
+			}
+			m.RefusalTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubnetEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.RefusalTimeout |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExecutionTimeout", wireType)
+			}
+			m.ExecutionTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubnetEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ExecutionTimeout |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValidationRate", wireType)
+			}
+			m.ValidationRate = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubnetEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ValidationRate |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/inference-chain/x/inference/types/subnet_escrow_session_config_test.go
+++ b/inference-chain/x/inference/types/subnet_escrow_session_config_test.go
@@ -1,0 +1,155 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubnetEscrow_SessionConfigFields_RoundTrip(t *testing.T) {
+	original := &SubnetEscrow{
+		Id:               42,
+		Creator:          "inference1abc",
+		Amount:           5000,
+		Slots:            []string{"valA", "valB"},
+		EpochIndex:       10,
+		AppHash:          "deadbeef",
+		Settled:          false,
+		TokenPrice:       99,
+		RefusalTimeout:   30,
+		ExecutionTimeout: 900,
+		ValidationRate:   8000,
+	}
+
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	decoded := &SubnetEscrow{}
+	err = decoded.Unmarshal(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Id, decoded.Id)
+	assert.Equal(t, original.Creator, decoded.Creator)
+	assert.Equal(t, original.TokenPrice, decoded.TokenPrice)
+	assert.Equal(t, original.RefusalTimeout, decoded.RefusalTimeout)
+	assert.Equal(t, original.ExecutionTimeout, decoded.ExecutionTimeout)
+	assert.Equal(t, original.ValidationRate, decoded.ValidationRate)
+}
+
+func TestSubnetEscrow_SessionConfigFields_ZeroValues(t *testing.T) {
+	// Escrow with zero session config fields (backward compat).
+	original := &SubnetEscrow{
+		Id:         1,
+		Creator:    "inference1old",
+		Amount:     100,
+		TokenPrice: 10,
+	}
+
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	decoded := &SubnetEscrow{}
+	err = decoded.Unmarshal(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), decoded.RefusalTimeout)
+	assert.Equal(t, int64(0), decoded.ExecutionTimeout)
+	assert.Equal(t, uint32(0), decoded.ValidationRate)
+}
+
+func TestSubnetEscrow_SessionConfigFields_Size(t *testing.T) {
+	withFields := &SubnetEscrow{
+		Id:               1,
+		TokenPrice:       10,
+		RefusalTimeout:   60,
+		ExecutionTimeout: 1200,
+		ValidationRate:   5000,
+	}
+	withoutFields := &SubnetEscrow{
+		Id:         1,
+		TokenPrice: 10,
+	}
+
+	// Size with fields must be larger than without.
+	assert.Greater(t, withFields.Size(), withoutFields.Size())
+}
+
+func TestSubnetEscrowParams_SessionConfigFields_RoundTrip(t *testing.T) {
+	original := &SubnetEscrowParams{
+		MinAmount:          100,
+		MaxAmount:          10000,
+		MaxEscrowsPerEpoch: 5,
+		GroupSize:          3,
+		TokenPrice:         42,
+		RefusalTimeout:     30,
+		ExecutionTimeout:   600,
+		ValidationRate:     8000,
+	}
+
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	decoded := &SubnetEscrowParams{}
+	err = decoded.Unmarshal(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.TokenPrice, decoded.TokenPrice)
+	assert.Equal(t, original.RefusalTimeout, decoded.RefusalTimeout)
+	assert.Equal(t, original.ExecutionTimeout, decoded.ExecutionTimeout)
+	assert.Equal(t, original.ValidationRate, decoded.ValidationRate)
+}
+
+func TestSubnetEscrowParams_SessionConfigFields_ZeroValues(t *testing.T) {
+	original := &SubnetEscrowParams{
+		MinAmount:  100,
+		TokenPrice: 10,
+	}
+
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	decoded := &SubnetEscrowParams{}
+	err = decoded.Unmarshal(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), decoded.RefusalTimeout)
+	assert.Equal(t, int64(0), decoded.ExecutionTimeout)
+	assert.Equal(t, uint32(0), decoded.ValidationRate)
+}
+
+func TestSubnetEscrow_Getters(t *testing.T) {
+	e := &SubnetEscrow{
+		RefusalTimeout:   45,
+		ExecutionTimeout: 900,
+		ValidationRate:   7500,
+	}
+	assert.Equal(t, int64(45), e.GetRefusalTimeout())
+	assert.Equal(t, int64(900), e.GetExecutionTimeout())
+	assert.Equal(t, uint32(7500), e.GetValidationRate())
+}
+
+func TestSubnetEscrow_Getters_Nil(t *testing.T) {
+	var e *SubnetEscrow
+	assert.Equal(t, int64(0), e.GetRefusalTimeout())
+	assert.Equal(t, int64(0), e.GetExecutionTimeout())
+	assert.Equal(t, uint32(0), e.GetValidationRate())
+}
+
+func TestSubnetEscrowParams_Getters(t *testing.T) {
+	p := &SubnetEscrowParams{
+		RefusalTimeout:   30,
+		ExecutionTimeout: 600,
+		ValidationRate:   8000,
+	}
+	assert.Equal(t, int64(30), p.GetRefusalTimeout())
+	assert.Equal(t, int64(600), p.GetExecutionTimeout())
+	assert.Equal(t, uint32(8000), p.GetValidationRate())
+}
+
+func TestSubnetEscrowParams_Getters_Nil(t *testing.T) {
+	var p *SubnetEscrowParams
+	assert.Equal(t, int64(0), p.GetRefusalTimeout())
+	assert.Equal(t, int64(0), p.GetExecutionTimeout())
+	assert.Equal(t, uint32(0), p.GetValidationRate())
+}

--- a/subnet/bridge/interface.go
+++ b/subnet/bridge/interface.go
@@ -18,12 +18,15 @@ type MainnetBridge interface {
 }
 
 type EscrowInfo struct {
-	EscrowID       string
-	Amount         uint64
-	CreatorAddress string
-	AppHash        []byte
-	Slots          []string // host addresses, len == SubnetGroupSize
-	TokenPrice     uint64
+	EscrowID         string
+	Amount           uint64
+	CreatorAddress   string
+	AppHash          []byte
+	Slots            []string // host addresses, len == SubnetGroupSize
+	TokenPrice       uint64
+	RefusalTimeout   int64
+	ExecutionTimeout int64
+	ValidationRate   uint32
 }
 
 type HostInfo struct {

--- a/subnet/bridge/rest.go
+++ b/subnet/bridge/rest.go
@@ -46,14 +46,17 @@ func NewRESTBridge(baseURL string, opts ...Option) *RESTBridge {
 
 type escrowResponse struct {
 	Escrow struct {
-		ID         uint64   `json:"id,string"`
-		Creator    string   `json:"creator"`
-		Amount     uint64   `json:"amount,string"`
-		Slots      []string `json:"slots"`
-		EpochIndex uint64   `json:"epoch_index,string"`
-		AppHash    string   `json:"app_hash"`
-		Settled    bool     `json:"settled"`
-		TokenPrice uint64   `json:"token_price,string"`
+		ID               uint64   `json:"id,string"`
+		Creator          string   `json:"creator"`
+		Amount           uint64   `json:"amount,string"`
+		Slots            []string `json:"slots"`
+		EpochIndex       uint64   `json:"epoch_index,string"`
+		AppHash          string   `json:"app_hash"`
+		Settled          bool     `json:"settled"`
+		TokenPrice       uint64   `json:"token_price,string"`
+		RefusalTimeout   int64    `json:"refusal_timeout,string"`
+		ExecutionTimeout int64    `json:"execution_timeout,string"`
+		ValidationRate   uint32   `json:"validation_rate"`
 	} `json:"escrow"`
 	Found bool `json:"found"`
 }
@@ -117,12 +120,15 @@ func (b *RESTBridge) GetEscrow(escrowID string) (*EscrowInfo, error) {
 	}
 
 	return &EscrowInfo{
-		EscrowID:       escrowID,
-		Amount:         resp.Escrow.Amount,
-		CreatorAddress: resp.Escrow.Creator,
-		AppHash:        appHash,
-		Slots:          resp.Escrow.Slots,
-		TokenPrice:     resp.Escrow.TokenPrice,
+		EscrowID:         escrowID,
+		Amount:           resp.Escrow.Amount,
+		CreatorAddress:   resp.Escrow.Creator,
+		AppHash:          appHash,
+		Slots:            resp.Escrow.Slots,
+		TokenPrice:       resp.Escrow.TokenPrice,
+		RefusalTimeout:   resp.Escrow.RefusalTimeout,
+		ExecutionTimeout: resp.Escrow.ExecutionTimeout,
+		ValidationRate:   resp.Escrow.ValidationRate,
 	}, nil
 }
 

--- a/subnet/bridge/rest_test.go
+++ b/subnet/bridge/rest_test.go
@@ -39,6 +39,66 @@ func TestGetEscrow_HappyPath(t *testing.T) {
 	assert.Equal(t, []string{"valA", "valB", "valC"}, info.Slots)
 }
 
+func TestGetEscrow_SessionConfigFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"escrow": map[string]any{
+				"id":                "7",
+				"creator":           "inference1xyz",
+				"amount":            "1000",
+				"slots":             []string{"valA"},
+				"epoch_index":       "1",
+				"app_hash":          "aabb",
+				"settled":           false,
+				"token_price":       "42",
+				"refusal_timeout":   "30",
+				"execution_timeout": "900",
+				"validation_rate":   8000,
+			},
+			"found": true,
+		})
+	}))
+	defer srv.Close()
+
+	b := NewRESTBridge(srv.URL)
+	info, err := b.GetEscrow("7")
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(42), info.TokenPrice)
+	assert.Equal(t, int64(30), info.RefusalTimeout)
+	assert.Equal(t, int64(900), info.ExecutionTimeout)
+	assert.Equal(t, uint32(8000), info.ValidationRate)
+}
+
+func TestGetEscrow_MissingSessionConfigFields(t *testing.T) {
+	// Backward compatibility: old escrows without new fields should parse fine.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"escrow": map[string]any{
+				"id":          "1",
+				"creator":     "inference1old",
+				"amount":      "500",
+				"slots":       []string{"valA"},
+				"epoch_index": "1",
+				"app_hash":    "cc",
+				"settled":     false,
+				"token_price": "10",
+			},
+			"found": true,
+		})
+	}))
+	defer srv.Close()
+
+	b := NewRESTBridge(srv.URL)
+	info, err := b.GetEscrow("1")
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(10), info.TokenPrice)
+	assert.Equal(t, int64(0), info.RefusalTimeout)
+	assert.Equal(t, int64(0), info.ExecutionTimeout)
+	assert.Equal(t, uint32(0), info.ValidationRate)
+}
+
 func TestGetEscrow_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{

--- a/subnet/types/config.go
+++ b/subnet/types/config.go
@@ -22,3 +22,23 @@ func SessionConfigWithPrice(groupSize int, tokenPrice uint64) SessionConfig {
 	}
 	return cfg
 }
+
+// SessionConfigFromEscrow returns a session config with governance-controlled
+// values propagated from the on-chain escrow. Zero values fall back to defaults,
+// ensuring backward compatibility with escrows created before these fields existed.
+func SessionConfigFromEscrow(groupSize int, tokenPrice uint64, refusalTimeout, executionTimeout int64, validationRate uint32) SessionConfig {
+	cfg := DefaultSessionConfig(groupSize)
+	if tokenPrice > 0 {
+		cfg.TokenPrice = tokenPrice
+	}
+	if refusalTimeout > 0 {
+		cfg.RefusalTimeout = refusalTimeout
+	}
+	if executionTimeout > 0 {
+		cfg.ExecutionTimeout = executionTimeout
+	}
+	if validationRate > 0 {
+		cfg.ValidationRate = validationRate
+	}
+	return cfg
+}

--- a/subnet/types/config_test.go
+++ b/subnet/types/config_test.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultSessionConfig(t *testing.T) {
+	cfg := DefaultSessionConfig(6)
+	assert.Equal(t, int64(60), cfg.RefusalTimeout)
+	assert.Equal(t, int64(1200), cfg.ExecutionTimeout)
+	assert.Equal(t, uint64(1), cfg.TokenPrice)
+	assert.Equal(t, uint32(3), cfg.VoteThreshold)
+	assert.Equal(t, uint32(5000), cfg.ValidationRate)
+}
+
+func TestSessionConfigWithPrice(t *testing.T) {
+	t.Run("overrides non-zero price", func(t *testing.T) {
+		cfg := SessionConfigWithPrice(4, 42)
+		assert.Equal(t, uint64(42), cfg.TokenPrice)
+		// other fields remain at defaults
+		assert.Equal(t, int64(60), cfg.RefusalTimeout)
+		assert.Equal(t, int64(1200), cfg.ExecutionTimeout)
+		assert.Equal(t, uint32(5000), cfg.ValidationRate)
+	})
+
+	t.Run("zero price keeps default", func(t *testing.T) {
+		cfg := SessionConfigWithPrice(4, 0)
+		assert.Equal(t, uint64(1), cfg.TokenPrice)
+	})
+}
+
+func TestSessionConfigFromEscrow(t *testing.T) {
+	t.Run("all values from escrow", func(t *testing.T) {
+		cfg := SessionConfigFromEscrow(6, 99, 30, 600, 8000)
+		assert.Equal(t, uint64(99), cfg.TokenPrice)
+		assert.Equal(t, int64(30), cfg.RefusalTimeout)
+		assert.Equal(t, int64(600), cfg.ExecutionTimeout)
+		assert.Equal(t, uint32(8000), cfg.ValidationRate)
+		assert.Equal(t, uint32(3), cfg.VoteThreshold) // groupSize/2
+	})
+
+	t.Run("zero values fall back to defaults", func(t *testing.T) {
+		cfg := SessionConfigFromEscrow(4, 0, 0, 0, 0)
+		assert.Equal(t, uint64(1), cfg.TokenPrice)
+		assert.Equal(t, int64(60), cfg.RefusalTimeout)
+		assert.Equal(t, int64(1200), cfg.ExecutionTimeout)
+		assert.Equal(t, uint32(5000), cfg.ValidationRate)
+	})
+
+	t.Run("partial override", func(t *testing.T) {
+		cfg := SessionConfigFromEscrow(6, 50, 0, 900, 0)
+		assert.Equal(t, uint64(50), cfg.TokenPrice)
+		assert.Equal(t, int64(60), cfg.RefusalTimeout)    // default
+		assert.Equal(t, int64(900), cfg.ExecutionTimeout)  // overridden
+		assert.Equal(t, uint32(5000), cfg.ValidationRate)  // default
+	})
+
+	t.Run("backward compat with SessionConfigWithPrice", func(t *testing.T) {
+		// When all new fields are zero, result must match SessionConfigWithPrice
+		fromEscrow := SessionConfigFromEscrow(6, 42, 0, 0, 0)
+		fromPrice := SessionConfigWithPrice(6, 42)
+		assert.Equal(t, fromPrice, fromEscrow)
+	})
+}

--- a/subnet/user/httpsession.go
+++ b/subnet/user/httpsession.go
@@ -41,7 +41,7 @@ func NewHTTPSession(cfg HTTPSessionConfig) (*Session, *state.StateMachine, error
 		return nil, nil, fmt.Errorf("get escrow: %w", err)
 	}
 
-	config := types.SessionConfigWithPrice(len(group), escrow.TokenPrice)
+	config := types.SessionConfigFromEscrow(len(group), escrow.TokenPrice, escrow.RefusalTimeout, escrow.ExecutionTimeout, escrow.ValidationRate)
 
 	sm := state.NewStateMachine(cfg.EscrowID, config, group, escrow.Amount, escrow.CreatorAddress, verifier,
 		state.WithWarmKeyResolver(cfg.Bridge.VerifyWarmKey),


### PR DESCRIPTION
Closes #1028

## Problem

`SessionConfig` values (`RefusalTimeout=60`, `ExecutionTimeout=1200`, `ValidationRate=5000`) are hardcoded in `subnet/types/config.go`. Governance cannot tune timeout behavior or validation sampling rate without a code deploy, breaking the single-source-of-truth rule.

## Solution

Thread `RefusalTimeout`, `ExecutionTimeout`, and `ValidationRate` through the same governance -> escrow -> subnet pipeline that `TokenPrice` already uses.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Proto | `params.proto` | +3 fields to `SubnetEscrowParams` (fields 7-9) |
| Proto | `subnet_escrow.proto` | +3 fields to `SubnetEscrow` (fields 9-11) |
| pb.go | `params.pb.go`, `subnet_escrow.pb.go` | Struct, getters, Marshal, Size, Unmarshal |
| Keeper | `msg_server_create_subnet_escrow.go` | Copy params to escrow at creation |
| Bridge | `interface.go`, `rest.go` | Parse + forward new fields |
| Subnet | `config.go` | New `SessionConfigFromEscrow()` factory |
| Subnet | `httpsession.go` | Use `SessionConfigFromEscrow` |

## Backward compatibility

All new fields default to zero. `SessionConfigFromEscrow` falls back to existing hardcoded defaults for zero values. Escrows created before this change work identically — no migration needed.

## Tests

- `subnet_escrow_session_config_test.go` — protobuf round-trip, zero-value backward compat, size encoding, getters (9 tests)
- `config_test.go` — `SessionConfigFromEscrow` full override, zero fallback, partial override, backward compat with `SessionConfigWithPrice` (7 tests)
- `rest_test.go` — REST response parsing with and without new fields (2 tests)

```
ok  subnet/types     0.003s  (7 tests)
ok  subnet/bridge    0.006s  (2 new + existing)
ok  x/inference/types 0.031s (9 tests)
```