### PR TITLE
fix: prevent uint64 wrap in settle amount sums 

### DIFF
--- a/decentralized-api/internal/startup/reward_recovery.go
+++ b/decentralized-api/internal/startup/reward_recovery.go
@@ -8,6 +8,8 @@ import (
 	"decentralized-api/internal/seed"
 	"decentralized-api/internal/validation"
 	"decentralized-api/logging"
+	"math"
+	"math/bits"
 	"sync/atomic"
 	"time"
 
@@ -137,7 +139,11 @@ func (c *RewardRecoveryChecker) AutoRewardRecovery() {
 	}
 
 	settleAmount := settleAmountResp.SettleAmount
-	totalAmount := settleAmount.RewardCoins + settleAmount.WorkCoins
+	sum, carry := bits.Add64(settleAmount.RewardCoins, settleAmount.WorkCoins, 0)
+	totalAmount := sum
+	if carry != 0 {
+		totalAmount = math.MaxUint64
+	}
 	logging.Info("[AutoRewardRecovery] Found settle amount for participant", types.Claims,
 		"address", address,
 		"rewardCoins", settleAmount.RewardCoins,
@@ -146,7 +152,7 @@ func (c *RewardRecoveryChecker) AutoRewardRecovery() {
 		"epochIndex", settleAmount.EpochIndex)
 
 	// Check if we have unclaimed rewards (totalAmount > 0 indicates pending rewards)
-	if totalAmount <= 0 {
+	if totalAmount == 0 {
 		logging.Info("[AutoRewardRecovery] No unclaimed rewards found", types.Claims, "address", address, "totalAmount", totalAmount)
 		return
 	}

--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"math/bits"
 
 	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -256,8 +257,9 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 			k.LogError("Error calculating settle amounts", types.Settle, "error", amount.Error, "participant", amount.Settle.Participant)
 			continue
 		}
-		totalPayment := amount.Settle.WorkCoins + amount.Settle.RewardCoins
-		if totalPayment == 0 {
+		// checked add: a wrapping sum to 0 would skip a real payout
+		paymentSum, paymentCarry := bits.Add64(amount.Settle.WorkCoins, amount.Settle.RewardCoins, 0)
+		if paymentCarry == 0 && paymentSum == 0 {
 			k.LogDebug("No payment needed for participant", types.Settle, "address", amount.Settle.Participant)
 			continue
 		}

--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -739,8 +739,13 @@ func CalculateParticipantBitcoinRewards(
 				if result.IsUint64() {
 					rewardCoins = result.Uint64()
 				} else {
-					// If still too large, participant gets maximum possible uint64
-					rewardCoins = ^uint64(0) // Max uint64
+					// cap to MaxInt64 — MaxUint64 sentinel would wrap to 0 when summed with WorkCoins downstream
+					logger.Error("bitcoin reward division exceeded uint64; capping to MaxInt64",
+						"participant", participant.Address,
+						"participantWeight", participantWeight,
+						"fixedEpochReward", fixedEpochReward,
+						"totalFullWeight", totalPoCWeightBeforeDowntime)
+					rewardCoins = uint64(math.MaxInt64)
 				}
 				totalDistributed += rewardCoins
 			}

--- a/inference-chain/x/inference/keeper/settle_amount_extreme_test.go
+++ b/inference-chain/x/inference/keeper/settle_amount_extreme_test.go
@@ -1,0 +1,54 @@
+package keeper_test
+
+import (
+	"math"
+	"math/bits"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/testutil"
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+// GetTotalCoins must saturate to MaxInt64 when RewardCoins+WorkCoins overflows uint64.
+func TestSettleAmount_StoredExtremeCoins_GetTotalCoinsSaturates(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	sa := types.SettleAmount{
+		Participant:   testutil.Creator,
+		EpochIndex:    1,
+		RewardCoins:   math.MaxUint64,
+		WorkCoins:     1,
+		SeedSignature: "",
+	}
+	require.NoError(t, k.SetSettleAmount(sdkCtx, sa))
+	loaded, found := k.GetSettleAmount(sdkCtx, testutil.Creator)
+	require.True(t, found)
+	require.Equal(t, uint64(math.MaxUint64), loaded.RewardCoins)
+	require.Equal(t, uint64(1), loaded.WorkCoins)
+	require.Equal(t, int64(math.MaxInt64), loaded.GetTotalCoins())
+}
+
+// SettleAccounts must distinguish a genuine zero payout (skip) from a uint64
+// wrap-to-zero (real payout owed). The bits.Add64 carry is the discriminator
+// the post-fix guard relies on at accountsettle.go:262
+// (`if paymentCarry == 0 && paymentSum == 0`).
+func TestSettleAmount_PaymentGuard_DistinguishesWrapFromGenuineZero(t *testing.T) {
+	// Wrap case: MaxUint64 + 1 yields paymentSum=0 with a real carry.
+	// The naive pre-fix check `WorkCoins+RewardCoins == 0` would skip; the
+	// post-fix `carry == 0 && sum == 0` does not.
+	wrapSum, wrapCarry := bits.Add64(math.MaxUint64, 1, 0)
+	require.Equal(t, uint64(0), wrapSum, "naive uint64 sum wraps to zero")
+	require.Equal(t, uint64(1), wrapCarry, "carry signals real overflow")
+	require.False(t, wrapCarry == 0 && wrapSum == 0,
+		"post-fix guard must NOT skip wrap-to-zero participant")
+
+	// Genuine zero: 0 + 0 yields paymentSum=0 with no carry. The guard skips.
+	zeroSum, zeroCarry := bits.Add64(0, 0, 0)
+	require.Equal(t, uint64(0), zeroSum)
+	require.Equal(t, uint64(0), zeroCarry)
+	require.True(t, zeroCarry == 0 && zeroSum == 0,
+		"post-fix guard must still skip genuine-zero participant")
+}

--- a/inference-chain/x/inference/types/settle_amount.go
+++ b/inference-chain/x/inference/types/settle_amount.go
@@ -1,10 +1,14 @@
 package types
 
-import "math"
+import (
+	"math"
+	"math/bits"
+)
 
+// saturate to MaxInt64 on overflow — a wrapped sum can silently zero a real payout downstream.
 func (sa *SettleAmount) GetTotalCoins() int64 {
-	sum := sa.RewardCoins + sa.WorkCoins
-	if sum > math.MaxInt64 {
+	sum, carry := bits.Add64(sa.RewardCoins, sa.WorkCoins, 0)
+	if carry != 0 || sum > math.MaxInt64 {
 		return math.MaxInt64
 	}
 	return int64(sum)


### PR DESCRIPTION
RewardCoins + WorkCoins gets summed as raw uint64 in three places. if the pair grows past MaxUint64 the sum wraps and you either skip a participant whose payout looks like 0, return a small wrapped total from `GetTotalCoins`, or have dapi recovery silently decide there are no unclaimed rewards. the int64 cap in `GetTotalCoins` doesn't help — wrap already happened in uint64 space.

producer side `bitcoin_rewards.go` writes `^uint64(0)` into RewardCoins when the big.Int division can't fit. unreachable under default params but the sentinel wires the wrap-trap into
the type.

fix: cap producer to MaxInt64 instead of the MaxUint64 sentinel, switch the three sum sites to `bits.Add64` and saturate on carry. `accountsettle.go` only skips when the sum is genuinely 0, never on overflow.