### PR TITLE
fix: widen ShouldValidate to uint64 to prevent silent validation skip

### DIFF
--- a/decentralized-api/internal/validation/inference_validation.go
+++ b/decentralized-api/internal/validation/inference_validation.go
@@ -106,9 +106,9 @@ func (s *InferenceValidator) shouldValidateInference(
 	shouldValidate, message := calculations.ShouldValidate(
 		seed,
 		inferenceDetails,
-		uint32(inferenceDetails.TotalPower),
-		uint32(validatorPower),
-		uint32(inferenceDetails.ExecutorPower),
+		inferenceDetails.TotalPower,
+		validatorPower,
+		inferenceDetails.ExecutorPower,
 		validationParams,
 		false)
 

--- a/inference-chain/x/inference/calculations/should_validate.go
+++ b/inference-chain/x/inference/calculations/should_validate.go
@@ -14,9 +14,9 @@ import (
 func ShouldValidate(
 	seed int64,
 	inferenceDetails *types.InferenceValidationDetails,
-	totalPower uint32,
-	validatorPower uint32,
-	executorPower uint32,
+	totalPower uint64,
+	validatorPower uint64,
+	executorPower uint64,
 	validationParams *types.ValidationParams,
 	debug bool,
 ) (bool, string) {
@@ -31,7 +31,7 @@ func ShouldValidate(
 	// algebraic simplification/removal of temp variables
 	targetValidations := maxValidationAverage.Sub(rangeSize.Mul(executorReputation))
 	// 100% rep will be minValidationAverage, 0% rep will be maxValidationAverage
-	ourProbability := targetValidations.Mul(decimal.NewFromInt(int64(validatorPower))).Div(decimal.NewFromInt(int64(totalPower - executorPower)))
+	ourProbability := targetValidations.Mul(decimal.NewFromUint64(validatorPower)).Div(decimal.NewFromUint64(totalPower - executorPower))
 	if ourProbability.GreaterThan(one) {
 		ourProbability = one
 	}

--- a/inference-chain/x/inference/calculations/should_validate_test.go
+++ b/inference-chain/x/inference/calculations/should_validate_test.go
@@ -18,9 +18,9 @@ func TestShouldValidate(t *testing.T) {
 		name                 string
 		seed                 int64
 		inferenceDetails     *types.InferenceValidationDetails
-		totalPower           uint32
-		validatorPower       uint32
-		executorPower        uint32
+		totalPower           uint64
+		validatorPower       uint64
+		executorPower        uint64
 		expectedResult       bool
 		expectedProbability  float64
 		minValidationAverage float64

--- a/inference-chain/x/inference/keeper/claim_rewards_weight_overflow_test.go
+++ b/inference-chain/x/inference/keeper/claim_rewards_weight_overflow_test.go
@@ -1,0 +1,57 @@
+package keeper_test
+
+import (
+	"math"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/testutil"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Validation sampling must not silently drop an inference when summed epoch weights exceed uint32.
+func TestClaimRewards_WeightAggregationAboveUint32_StillSamples(t *testing.T) {
+	k, ms, ctx, _ := setupKeeperWithMocks(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	epochIndex := uint64(100)
+	epoch := types.Epoch{Index: epochIndex, PocStartBlockHeight: 1000}
+	k.SetEpoch(sdkCtx, &epoch)
+	require.NoError(t, k.SetParams(sdkCtx, types.DefaultParams()))
+
+	const each = int64(2_200_000_000)
+	require.LessOrEqual(t, each, int64(math.MaxUint32))
+	require.Greater(t, each+each, int64(math.MaxUint32))
+
+	epochData := types.EpochGroupData{
+		EpochIndex:          epochIndex,
+		EpochGroupId:        100,
+		PocStartBlockHeight: epochIndex,
+		ValidationWeights: []*types.ValidationWeight{
+			{MemberAddress: testutil.Creator, Weight: each},
+			{MemberAddress: testutil.Executor, Weight: each},
+		},
+	}
+	k.SetEpochGroupData(sdkCtx, epochData)
+
+	inf := types.InferenceValidationDetails{
+		EpochId:              epochIndex,
+		InferenceId:          "inf-weight-sum-above-uint32",
+		ExecutorId:           testutil.Executor,
+		ExecutorReputation:   50,
+		TrafficBasis:         1000,
+		Model:                "",
+		CreatedAtBlockHeight: 0,
+	}
+	k.SetInferenceValidationDetails(sdkCtx, inf)
+
+	got, err := keeper.GetMustBeValidatedInferencesForTesting(ms, sdkCtx, &types.MsgClaimRewards{
+		Creator:    testutil.Creator,
+		EpochIndex: epochIndex,
+		Seed:       42,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, got, "validation sampling must not silently drop the inference when summed weights exceed uint32")
+	require.Contains(t, got, "inf-weight-sum-above-uint32")
+}

--- a/inference-chain/x/inference/keeper/export_test.go
+++ b/inference-chain/x/inference/keeper/export_test.go
@@ -1,0 +1,12 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// GetMustBeValidatedInferencesForTesting exposes the unexported handler method
+// for direct unit testing of validation-sampling overflow behaviour.
+func GetMustBeValidatedInferencesForTesting(ms types.MsgServer, ctx sdk.Context, msg *types.MsgClaimRewards) ([]string, error) {
+	return ms.(*msgServer).getMustBeValidatedInferences(ctx, msg)
+}

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -482,21 +482,21 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 		}
 
 		k.LogDebug("Getting validation", types.Claims, "seed", msg.Seed, "totalWeight", totalWeight, "executorPower", executorPower, "validatorPower", validatorPowerForModel)
-		safeTotalWeight, err := safeUint32FromInt64(totalWeight)
+		safeTotalWeight, err := safeUint64FromInt64(totalWeight)
 		if err != nil {
-			k.LogError("Weight overflow in validation sampling", types.Claims,
+			k.LogError("Negative weight in validation sampling", types.Claims,
 				"totalWeight", totalWeight, "error", err, "inference", inference.InferenceId)
 			continue // Skip this inference -- can't compute validation probability safely
 		}
-		safeValidatorWeight, err := safeUint32FromInt64(validatorPowerForModel.Weight)
+		safeValidatorWeight, err := safeUint64FromInt64(validatorPowerForModel.Weight)
 		if err != nil {
-			k.LogError("Weight overflow in validation sampling", types.Claims,
+			k.LogError("Negative weight in validation sampling", types.Claims,
 				"validatorWeight", validatorPowerForModel.Weight, "error", err, "inference", inference.InferenceId)
 			continue
 		}
-		safeExecutorWeight, err := safeUint32FromInt64(executorPower.Weight)
+		safeExecutorWeight, err := safeUint64FromInt64(executorPower.Weight)
 		if err != nil {
-			k.LogError("Weight overflow in validation sampling", types.Claims,
+			k.LogError("Negative weight in validation sampling", types.Claims,
 				"executorWeight", executorPower.Weight, "error", err, "inference", inference.InferenceId)
 			continue
 		}

--- a/inference-chain/x/inference/keeper/safecast.go
+++ b/inference-chain/x/inference/keeper/safecast.go
@@ -24,6 +24,15 @@ func safeUint32FromInt64(v int64) (uint32, error) {
 	return uint32(v), nil
 }
 
+// safeUint64FromInt64 converts int64 to uint64, returning error if the value
+// is negative.
+func safeUint64FromInt64(v int64) (uint64, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("int64 value %d cannot be cast to uint64 (negative)", v)
+	}
+	return uint64(v), nil
+}
+
 // safeUint32FromUint64 converts uint64 to uint32, returning error if the value
 // exceeds MaxUint32.
 func safeUint32FromUint64(v uint64) (uint32, error) {

--- a/inference-chain/x/inference/keeper/safecast_test.go
+++ b/inference-chain/x/inference/keeper/safecast_test.go
@@ -67,6 +67,36 @@ func TestSafeUint32FromInt64(t *testing.T) {
 	}
 }
 
+func TestSafeUint64FromInt64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   int64
+		want    uint64
+		wantErr bool
+	}{
+		{"zero", 0, 0, false},
+		{"one", 1, 1, false},
+		{"negative one", -1, 0, true},
+		{"MaxUint32", math.MaxUint32, math.MaxUint32, false},
+		{"MaxUint32+1", math.MaxUint32 + 1, math.MaxUint32 + 1, false},
+		{"MaxInt64", math.MaxInt64, math.MaxInt64, false},
+		{"negative MaxInt64", -math.MaxInt64, 0, true},
+		{"MinInt64", math.MinInt64, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeUint64FromInt64(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, uint64(0), got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestSafeUint32FromUint64(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
`getMustBeValidatedInferences` runs `safeUint32FromInt64` on `totalWeight`, validator weight, and executor weight before passing them to `calculations.ShouldValidate`. if the per-model summed weight crosses MaxUint32 (~4.29e9) the cast errors and the inference gets `continue`d — the claim still succeeds with an empty mustBeValidated, so the validator sidesteps validation duty without failing the message.

`ShouldValidate` itself only ever does decimal math on those values, the uint32 cap is type-choice not algorithmic. widen the signature to uint64 and let the sampling proceed at the real width. `decimal.NewFromUint64` instead of `decimal.NewFromInt(int64(x))` — the latter wraps negative once x crosses MaxInt64. dapi caller in `inference_validation.go` had the same uint32 truncation on uint64 fields, fixed there too.

added `safeUint64FromInt64` to keep negative-weight rejection at the call site (ValidationWeight.Weight is signed int64). regression test in keeper sets summed weight to 4.4e9 and asserts the inference IS sampled — was empty before.

ground for fix is the `MaxIndividualPowerPercentage = 0.25` per-host cap from #1068. it limits per-host concentration but multiple hosts can still aggregate the per-model totalWeight past MaxUint32 as the network grows.