### PR TITLE
fix: Certik audit fixes (GEB-61)

### DIFF
--- a/inference-chain/testutil/keeper/expected_keepers_mocks.go
+++ b/inference-chain/testutil/keeper/expected_keepers_mocks.go
@@ -1298,6 +1298,21 @@ func (mr *MockBlsKeeperMockRecorder) GetEpochBLSData(ctx, epochID any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpochBLSData", reflect.TypeOf((*MockBlsKeeper)(nil).GetEpochBLSData), ctx, epochID)
 }
 
+// GetParams mocks base method.
+func (m *MockBlsKeeper) GetParams(ctx context.Context) (types4.Params, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetParams", ctx)
+	ret0, _ := ret[0].(types4.Params)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetParams indicates an expected call of GetParams.
+func (mr *MockBlsKeeperMockRecorder) GetParams(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParams", reflect.TypeOf((*MockBlsKeeper)(nil).GetParams), ctx)
+}
+
 // GetSigningStatus mocks base method.
 func (m *MockBlsKeeper) GetSigningStatus(ctx types1.Context, requestID []byte) (*types4.ThresholdSigningRequest, error) {
 	m.ctrl.T.Helper()

--- a/inference-chain/x/bls/keeper/dkg_initiation.go
+++ b/inference-chain/x/bls/keeper/dkg_initiation.go
@@ -54,6 +54,21 @@ func (k Keeper) InitiateKeyGenerationForEpoch(ctx sdk.Context, epochID uint64, f
 		return fmt.Errorf("failed to assign slots: %w", err)
 	}
 
+	// Validate shape constraints before initiating
+	if len(blsParticipants) > types.MaxEncryptedSharesParticipantsCount {
+		return fmt.Errorf("number of participants %d exceeds maximum %d", len(blsParticipants), types.MaxEncryptedSharesParticipantsCount)
+	}
+	if tSlotsDegree+1 > uint32(types.MaxDealerPartCommitmentsCount) {
+		return fmt.Errorf("tSlotsDegree+1 (%d) exceeds maximum commitments count %d", tSlotsDegree+1, types.MaxDealerPartCommitmentsCount)
+	}
+
+	for _, p := range blsParticipants {
+		_, err := expectedEncryptedSharesCount(p)
+		if err != nil {
+			return fmt.Errorf("failed to validate encrypted share bounds for %s: %w", p.Address, err)
+		}
+	}
+
 	// Calculate phase deadlines
 	currentHeight := ctx.BlockHeight()
 	dealingPhaseDeadline := currentHeight + params.DealingPhaseDurationBlocks

--- a/inference-chain/x/bls/keeper/dkg_initiation_test.go
+++ b/inference-chain/x/bls/keeper/dkg_initiation_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -407,4 +408,49 @@ func TestAssignSlotsWithMoreParticipantsThanSlotsDeterminism(t *testing.T) {
 		require.Equal(t, result[i].SlotStartIndex, result2[i].SlotStartIndex)
 		require.Equal(t, result[i].SlotEndIndex, result2[i].SlotEndIndex)
 	}
+}
+func TestInitiateKeyGenerationForEpoch_RejectsOversizeShape(t *testing.T) {
+	k, ctx := keepertest.BlsKeeper(t)
+
+	params, _ := k.GetParams(ctx)
+	params.ITotalSlots = 200
+	k.SetParams(ctx, params)
+
+	participants := []types.ParticipantWithWeightAndKey{
+		{
+			Address:            "cosmos1val",
+			PercentageWeight:   math.LegacyNewDec(100),
+			Secp256k1PublicKey: []byte("val_key"),
+			AllowedSecp256k1PublicKeys: make([][]byte, 100),
+		},
+	}
+	
+	for i := range participants[0].AllowedSecp256k1PublicKeys {
+		participants[0].AllowedSecp256k1PublicKeys[i] = []byte(fmt.Sprintf("warm_key_%d", i))
+	}
+
+	err := k.InitiateKeyGenerationForEpoch(ctx, 1, participants)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestInitiateKeyGenerationForEpoch_RejectsOversizeParticipantsOrCommitments(t *testing.T) {
+	k, ctx := keepertest.BlsKeeper(t)
+
+	params, _ := k.GetParams(ctx)
+	params.ITotalSlots = types.MaxDealerPartCommitmentsCount // 4096 => degree 4096 => commits 4097 => reject
+	params.TSlotsDegreeOffset = 0
+	k.SetParams(ctx, params)
+
+	participants := []types.ParticipantWithWeightAndKey{
+		{
+			Address:            "cosmos1val",
+			PercentageWeight:   math.LegacyNewDec(100),
+			Secp256k1PublicKey: []byte("val_key"),
+		},
+	}
+
+	err := k.InitiateKeyGenerationForEpoch(ctx, 1, participants)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum commitments count")
 }

--- a/inference-chain/x/bls/keeper/encrypted_shares_shape.go
+++ b/inference-chain/x/bls/keeper/encrypted_shares_shape.go
@@ -23,6 +23,9 @@ func expectedEncryptedSharesCount(participant types.BLSParticipantInfo) (int, er
 	if expected > uint64(maxInt) {
 		return 0, fmt.Errorf("expected encrypted shares count overflow for participant %s", participant.Address)
 	}
+	if expected > uint64(types.MaxEncryptedSharesPerParticipantCount) {
+		return 0, fmt.Errorf("expected encrypted shares count %d exceeds maximum %d for participant %s", expected, types.MaxEncryptedSharesPerParticipantCount, participant.Address)
+	}
 
 	return int(expected), nil
 }

--- a/inference-chain/x/bls/types/message_submit_dealer_part.go
+++ b/inference-chain/x/bls/types/message_submit_dealer_part.go
@@ -10,9 +10,9 @@ var _ sdk.Msg = &MsgSubmitDealerPart{}
 
 const (
 	commitmentCompressedG2Len             = 96
-	maxDealerPartCommitmentsCount         = 4096
-	maxEncryptedSharesParticipantsCount   = 4096
-	maxEncryptedSharesPerParticipantCount = 16384
+	MaxDealerPartCommitmentsCount         = 4096
+	MaxEncryptedSharesParticipantsCount   = 4096
+	MaxEncryptedSharesPerParticipantCount = 16384
 	maxEncryptedShareCiphertextLen        = 1024
 )
 
@@ -29,7 +29,7 @@ func (m *MsgSubmitDealerPart) ValidateBasic() error {
 	if len(m.Commitments) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "commitments must be non-empty")
 	}
-	if len(m.Commitments) > maxDealerPartCommitmentsCount {
+	if len(m.Commitments) > MaxDealerPartCommitmentsCount {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "commitments exceeds maximum allowed count")
 	}
 	for i, commitment := range m.Commitments {
@@ -51,14 +51,14 @@ func (m *MsgSubmitDealerPart) ValidateBasic() error {
 	if len(m.EncryptedSharesForParticipants) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "encrypted_shares_for_participants must be non-empty")
 	}
-	if len(m.EncryptedSharesForParticipants) > maxEncryptedSharesParticipantsCount {
+	if len(m.EncryptedSharesForParticipants) > MaxEncryptedSharesParticipantsCount {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "encrypted_shares_for_participants exceeds maximum allowed count")
 	}
 	for i, participantShares := range m.EncryptedSharesForParticipants {
 		if len(participantShares.EncryptedShares) == 0 {
 			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "encrypted_shares_for_participants[%d].encrypted_shares must be non-empty", i)
 		}
-		if len(participantShares.EncryptedShares) > maxEncryptedSharesPerParticipantCount {
+		if len(participantShares.EncryptedShares) > MaxEncryptedSharesPerParticipantCount {
 			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "encrypted_shares_for_participants[%d].encrypted_shares exceeds maximum allowed count", i)
 		}
 		for j, shareCiphertext := range participantShares.EncryptedShares {

--- a/inference-chain/x/inference/module/bls_integration_test.go
+++ b/inference-chain/x/inference/module/bls_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	keepertest "github.com/productscience/inference/testutil/keeper"
+	blskeeper "github.com/productscience/inference/x/bls/keeper"
 	blstypes "github.com/productscience/inference/x/bls/types"
 	"github.com/productscience/inference/x/inference/keeper"
 	inference "github.com/productscience/inference/x/inference/module"
@@ -444,4 +445,76 @@ func TestBLSIntegrationAllowsConcurrentDKG(t *testing.T) {
 	// Both epochs should have valid participant data
 	require.Len(t, epochBLSData1.Participants, 2, "Epoch 1 should have 2 participants")
 	require.Len(t, epochBLSData2.Participants, 2, "Epoch 2 should have 2 participants")
+}
+
+func TestBLSKeyGenerationPrunesExcessWarmKeys(t *testing.T) {
+	setupSDKConfig()
+	k, ctx, mocks := keepertest.InferenceKeeperReturningMocks(t)
+
+	alicePrivKey := secp256k1.GenPrivKey()
+	aliceAccAddr := sdk.AccAddress(alicePrivKey.PubKey().Address())
+	aliceAccAddrStr := aliceAccAddr.String()
+
+	// Setup account mock
+	participantDetails := map[string]string{
+		aliceAccAddrStr: hex.EncodeToString(alicePrivKey.PubKey().Bytes()),
+	}
+	_ = setupMockAccountExpectations(t, mocks.AccountKeeper, participantDetails)
+
+	// Mock BLS params to limit maximum additional keys
+	blsParams, err := k.BlsKeeper.GetParams(ctx)
+	require.NoError(t, err)
+	blsParams.ITotalSlots = 4096 // 16384 total shares / 4096 slots = 4 keys/slot => 1 primary + 3 additional
+	err = k.BlsKeeper.(blskeeper.Keeper).SetParams(ctx, blsParams)
+	require.NoError(t, err)
+
+	numGrants := 5 // We simulate 5 grants, pruning to 3
+	grants := make([]*authztypes.GrantAuthorization, numGrants)
+	for i := 0; i < numGrants; i++ {
+		warmKey := secp256k1.GenPrivKey()
+		granteeAddr := sdk.AccAddress(warmKey.PubKey().Address())
+		authAny, err := codectypes.NewAnyWithValue(authztypes.NewGenericAuthorization("/inference.bls.MsgSubmitDealerPart"))
+		require.NoError(t, err)
+		grants[i] = &authztypes.GrantAuthorization{
+			Granter: aliceAccAddrStr,
+			Grantee: granteeAddr.String(),
+			Authorization: authAny,
+		}
+		baseAcc := authtypes.NewBaseAccount(granteeAddr, warmKey.PubKey(), 0, 0)
+		mocks.AccountKeeper.EXPECT().GetAccount(gomock.Any(), granteeAddr).Return(baseAcc).AnyTimes()
+	}
+
+	mocks.AuthzKeeper.EXPECT().
+		GranterGrants(gomock.Any(), gomock.Any()).
+		Return(&authztypes.QueryGranterGrantsResponse{
+			Grants: grants,
+		}, nil).
+		AnyTimes()
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+
+	// Setup participant
+	storedParticipant := types.Participant{
+		Index:           aliceAccAddrStr,
+		Address:         aliceAccAddrStr,
+		Weight:          100,
+		Status:          types.ParticipantStatus_ACTIVE,
+	}
+	k.SetParticipant(ctx, storedParticipant)
+
+	activeParticipants := []*types.ActiveParticipant{
+		{Index: aliceAccAddrStr, Weight: 100},
+	}
+
+	appModule := inference.NewAppModule(cdc, k, mocks.AccountKeeper, nil, nil, nil)
+	epochID := uint64(50)
+	appModule.InitiateBLSKeyGeneration(ctx, epochID, activeParticipants)
+
+	epochBLSData, err := k.BlsKeeper.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
+	require.Len(t, epochBLSData.Participants, 1)
+
+	// Max allowed should be 3
+	require.Len(t, epochBLSData.Participants[0].AllowedSecp256K1PublicKeys, 3)
 }

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -1510,6 +1510,23 @@ func (am AppModule) InitiateBLSKeyGeneration(ctx context.Context, epochID uint64
 	// Compute adjusted percentages if genesis guardian reservation applies
 	adjustedPercentages := ApplyBLSGuardianSlotReservation(ctx, am.keeper, activeParticipants)
 
+	// Fetch BLS params to compute maximum allowed warm keys per participant
+	blsParams, err := am.keeper.BlsKeeper.GetParams(ctx)
+	var maxAdditionalKeys int
+	if err != nil || blsParams.ITotalSlots == 0 {
+		am.LogError("Failed to get BLS params or ITotalSlots is zero, defaulting to minimal allowed keys", types.EpochGroup, "epochID", epochID, "error", err)
+		maxAdditionalKeys = 0
+	} else {
+		// Cap keys so that slotCount * (1 + additionalKeys) <= MaxEncryptedSharesPerParticipantCount.
+		// Since slotCount can be at most ITotalSlots, dividing the max limit by ITotalSlots gives
+		// the safe upper bound per slot.
+		maxKeysPerSlot := blstypes.MaxEncryptedSharesPerParticipantCount / int(blsParams.ITotalSlots)
+		maxAdditionalKeys = maxKeysPerSlot - 1
+		if maxAdditionalKeys < 0 {
+			maxAdditionalKeys = 0 // Paranoia fallback
+		}
+	}
+
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	for _, ap := range activeParticipants {
 		accAddr, err := sdk.AccAddressFromBech32(ap.Index)
@@ -1540,7 +1557,7 @@ func (am AppModule) InitiateBLSKeyGeneration(ctx context.Context, epochID uint64
 			am.LogError("Participant secp256k1 public key bytes are empty for BLS", types.EpochGroup, "participantAddress", ap.Index, "epochID", epochID)
 			continue
 		}
-		additionalPubKeys := am.collectAdditionalBLSParticipantPubKeys(ctx, ap.Index, pubKeyBytes)
+		additionalPubKeys := am.collectAdditionalBLSParticipantPubKeys(ctx, ap.Index, pubKeyBytes, maxAdditionalKeys)
 
 		// Determine percentage weight: use adjusted reservation if present, else raw share
 		var percentage math.LegacyDec
@@ -1578,7 +1595,7 @@ func (am AppModule) InitiateBLSKeyGeneration(ctx context.Context, epochID uint64
 	}
 
 	// Call the BLS module to initiate key generation
-	err := am.keeper.BlsKeeper.InitiateKeyGenerationForEpoch(sdkCtx, epochID, finalizedParticipants)
+	err = am.keeper.BlsKeeper.InitiateKeyGenerationForEpoch(sdkCtx, epochID, finalizedParticipants)
 	if err != nil {
 		am.LogError("Failed to initiate BLS key generation", types.EpochGroup, "epochID", epochID, "error", err.Error())
 		return
@@ -1589,7 +1606,7 @@ func (am AppModule) InitiateBLSKeyGeneration(ctx context.Context, epochID uint64
 		"participantCount", len(finalizedParticipants))
 }
 
-func (am AppModule) collectAdditionalBLSParticipantPubKeys(ctx context.Context, participantAddress string, primaryPubKey []byte) [][]byte {
+func (am AppModule) collectAdditionalBLSParticipantPubKeys(ctx context.Context, participantAddress string, primaryPubKey []byte, maxAdditionalKeys int) [][]byte {
 	const blsDealerPartMsgTypeURL = "/inference.bls.MsgSubmitDealerPart"
 
 	resp, err := am.keeper.GranteesByMessageType(ctx, &types.QueryGranteesByMessageTypeRequest{
@@ -1649,6 +1666,14 @@ func (am AppModule) collectAdditionalBLSParticipantPubKeys(ctx context.Context, 
 	slices.SortFunc(additionalPubKeys, func(a, b []byte) int {
 		return bytes.Compare(a, b)
 	})
+
+	if len(additionalPubKeys) > maxAdditionalKeys {
+		am.LogWarn("Pruning excess additional BLS participant public keys", types.EpochGroup,
+			"participant", participantAddress,
+			"found", len(additionalPubKeys),
+			"max_allowed", maxAdditionalKeys)
+		additionalPubKeys = additionalPubKeys[:maxAdditionalKeys]
+	}
 
 	return additionalPubKeys
 }

--- a/inference-chain/x/inference/types/expected_keepers.go
+++ b/inference-chain/x/inference/types/expected_keepers.go
@@ -136,6 +136,9 @@ type BlsKeeper interface {
 	// DKG methods
 	InitiateKeyGenerationForEpoch(ctx sdk.Context, epochID uint64, finalizedParticipants []blstypes.ParticipantWithWeightAndKey) error
 	GetEpochBLSData(ctx sdk.Context, epochID uint64) (blstypes.EpochBLSData, error)
+	// Params
+	GetParams(ctx context.Context) (blstypes.Params, error)
+
 	// ActiveEpochID tracks the epoch that is currently undergoing the DKG process
 	SetActiveEpochID(ctx sdk.Context, epochID uint64)
 	GetActiveEpochID(ctx sdk.Context) (uint64, bool)


### PR DESCRIPTION
From audit report:

The BLS snapshot includes one primary secp256k1 key plus every authz-derived warm key in AllowedSecp256K1PublicKeys, with no independent cap in the collection path. Dealer generation then emits one encrypted share per slot per allowed key, while chain-side shape validation requires that exact snapshot-derived count. At the same time, MsgSubmitDealerPart.ValidateBasic() enforces a hard limit of 16384 encrypted shares for each participant row.

This creates a hard liveness failure. If an active participant accumulates enough warm keys that slotCount * (1 + len(AllowedSecp256K1PublicKeys)) > 16384, every dealer is forced to build an oversized ciphertext array for that participant, and the dealer part becomes invalid before execution. Because all dealers must include shares for every participant, a single participant with excessive warm-key fanout can block dealer-part submission and stall the DKG round.

- Snapshot pruning in module.go (line 1513) prevents oversized warm-key fanout from entering the epoch snapshot.
- Keeper-side preflight in dkg_initiation.go (line 57) refuses DKG if the derived shape is still impossible.
- The shared bound in encrypted_shares_shape.go (line 26) keeps dealer-path validation aligned with the message limit.