### PR TITLE
fix: Certik audit fixes (GEB-29) + Selfvote

### DIFF
--- a/inference-chain/x/bls/keeper/phase_transitions.go
+++ b/inference-chain/x/bls/keeper/phase_transitions.go
@@ -392,13 +392,10 @@ func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSD
 			return nil, fmt.Errorf("invalid slot range for dealer %d in epoch %d", dealerIndex, epochBLSData.EpochId)
 		}
 		dealerOwnSlots := uint64(dealerParticipant.SlotEndIndex-dealerParticipant.SlotStartIndex) + 1
-		dealerOwnSlotsAtLeastHalf := totalSlots > 0 && dealerOwnSlots*2 >= totalSlots
-		maxPossibleNonSelfVotingSlots := uint64(0)
-		if dealerOwnSlots <= totalSlots {
-			maxPossibleNonSelfVotingSlots = totalSlots - dealerOwnSlots
-		}
 
-		var validVotingSlotsExcludingDealer uint64
+		var validVotingSlots uint64
+		// Implicitly, the dealer considers its own parts valid
+		validVotingSlots = dealerOwnSlots
 
 		for verifierIndex, verification := range epochBLSData.VerificationSubmissions {
 			if verification == nil || len(verification.DealerValidity) == 0 {
@@ -419,26 +416,14 @@ func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSD
 				return nil, fmt.Errorf("invalid slot range for participant %d in epoch %d", verifierIndex, epochBLSData.EpochId)
 			}
 			verifierSlots := uint64(participant.SlotEndIndex-participant.SlotStartIndex) + 1
-			validVotingSlotsExcludingDealer += verifierSlots
+			validVotingSlots += verifierSlots
 		}
 
-		dealerIsValid := totalSlots > 0 && validVotingSlotsExcludingDealer >= quorumSlots
+		dealerIsValid := totalSlots > 0 && validVotingSlots >= quorumSlots
 		dealerSubmittedParts := dealerIndex < len(epochBLSData.DealerParts) &&
 			epochBLSData.DealerParts[dealerIndex] != nil &&
 			epochBLSData.DealerParts[dealerIndex].DealerAddress != "" &&
 			len(epochBLSData.DealerParts[dealerIndex].Commitments) > 0
-
-		if dealerSubmittedParts && totalSlots > 0 && maxPossibleNonSelfVotingSlots < quorumSlots {
-			k.Logger().Warn("Dealer cannot reach weighted quorum with self-vote excluded",
-				"epochId", epochBLSData.EpochId,
-				"dealerIndex", dealerIndex,
-				"dealerOwnSlots", dealerOwnSlots,
-				"dealerOwnSlotsAtLeastHalf", dealerOwnSlotsAtLeastHalf,
-				"maxNonSelfVotingSlots", maxPossibleNonSelfVotingSlots,
-				"quorumSlots", quorumSlots,
-				"totalSlots", totalSlots,
-				"receivedVotingSlotsExcludingDealer", validVotingSlotsExcludingDealer)
-		}
 
 		validDealers[dealerIndex] = dealerIsValid && dealerSubmittedParts
 	}

--- a/inference-chain/x/bls/keeper/phase_transitions_test.go
+++ b/inference-chain/x/bls/keeper/phase_transitions_test.go
@@ -508,10 +508,10 @@ func TestDetermineValidDealersWithConsensus_ShortVectorsCountAsNo(t *testing.T) 
 	validDealers, err := k.DetermineValidDealersWithConsensus(&epochBLSData)
 	require.NoError(t, err)
 
-	// Under slot-weighted quorum including dealer self:
-	// Dealer 0: gets votes from verifier 0 (33), verifier 1 (33), and implicitly self-votes (34) = 100 slots (Valid)
-	// Dealer 1: gets votes from verifier 0 (33), missing from verifier 1, implicitly self-votes (33) = 66 slots (Valid)
-	// Dealer 2: gets votes from verifier 0 (33), missing from verifier 1, implicitly self-votes (33) = 66 slots (Valid)
+	// Under slot-weighted quorum including implicit dealer self weight:
+	// Dealer 0: verifier 1 votes yes (33), verifier 2 abstains, and dealer 0 implicitly contributes self weight (33) = 66 slots (Valid)
+	// Dealer 1: verifier 0 votes yes (33), verifier 2 abstains, and dealer 1 implicitly contributes self weight (33) = 66 slots (Valid)
+	// Dealer 2: verifier 0 votes yes (33), verifier 1's short vector omits dealer 2, and dealer 2 implicitly contributes self weight (34) = 67 slots (Valid)
 	expectedValidDealers := []bool{true, true, true}
 	require.Equal(t, expectedValidDealers, validDealers)
 }

--- a/inference-chain/x/bls/keeper/phase_transitions_test.go
+++ b/inference-chain/x/bls/keeper/phase_transitions_test.go
@@ -429,10 +429,14 @@ func TestDetermineValidDealersWithConsensus(t *testing.T) {
 	validDealers, err := k.DetermineValidDealersWithConsensus(&epochBLSData)
 	require.NoError(t, err)
 
-	// Expected results under slot-weighted quorum excluding dealer self.
-	// With only participants 0..2 submitting, dealer 0 only gets votes from 1 and 2.
-	// That covers 40/100 slots, which is below >50%.
-	expectedValidDealers := []bool{false, false, false, false, false}
+	// Expected results under slot-weighted quorum implicitly including dealer self.
+	// Quorum is 51/100 slots.
+	// Dealer 0: gets votes from verifier 1 (20) and 2 (20), plus implicitly self (20). Total = 60 slots (>= 51) -> true
+	// Dealer 1: gets votes from verifier 0 (20), plus implicitly self (20). Total = 40 slots (< 51) -> false
+	// Dealer 2: gets votes from verifier 0 (20), plus implicitly self (20). Total = 40 slots (< 51) -> false
+	// Dealer 3: gets votes from verifier 2 (20), plus implicitly self (20). Total = 40 slots (< 51) -> false
+	// Dealer 4: implicitly self (20), but no dealer part submitted -> false
+	expectedValidDealers := []bool{true, false, false, false, false}
 	require.Equal(t, expectedValidDealers, validDealers)
 }
 
@@ -449,6 +453,7 @@ func TestDetermineValidDealersWithConsensus_TieVotes(t *testing.T) {
 	epochBLSData.DealerParts[1].Commitments = [][]byte{createTestG2Commitment()}
 
 	// Set up verification submissions with tie votes (1/2 each)
+	// Because of implicit self-vote, each gets 50/100 slots approval. Quorum is 51/100 slots (totalSlots/2 + 1).
 	epochBLSData.VerificationSubmissions[0].DealerValidity = []bool{true, false}
 	epochBLSData.VerificationSubmissions[1].DealerValidity = []bool{false, true}
 
@@ -472,14 +477,16 @@ func TestDetermineValidDealersWithConsensus_DealerOwnsExactlyHalfSlots(t *testin
 	epochBLSData.DealerParts[1].DealerAddress = "participant2"
 	epochBLSData.DealerParts[1].Commitments = [][]byte{createTestG2Commitment()}
 
-	// Everyone votes "true" for dealer 0 (including dealer 0 itself).
-	// Because self vote is excluded, dealer 0 can only get 50 non-self slots, while quorum is 51.
+	// Everyone votes "true" for dealer 0.
+	// With self vote included, dealer 0 gets 50 (self) + 50 (peer) = 100 slots. Total passes quorum.
+	// For dealer 1, everyone votes "false" or abstains from submitting it, but dealer 1 still has 50 self votes.
+	// Since 50 < 51, dealer 1 is invalid.
 	epochBLSData.VerificationSubmissions[0].DealerValidity = []bool{true, false}
-	epochBLSData.VerificationSubmissions[1].DealerValidity = []bool{true, true}
+	epochBLSData.VerificationSubmissions[1].DealerValidity = []bool{true, false}
 
 	validDealers, err := k.DetermineValidDealersWithConsensus(&epochBLSData)
 	require.NoError(t, err)
-	require.Equal(t, []bool{false, false}, validDealers)
+	require.Equal(t, []bool{true, false}, validDealers)
 }
 
 func TestDetermineValidDealersWithConsensus_ShortVectorsCountAsNo(t *testing.T) {
@@ -501,8 +508,11 @@ func TestDetermineValidDealersWithConsensus_ShortVectorsCountAsNo(t *testing.T) 
 	validDealers, err := k.DetermineValidDealersWithConsensus(&epochBLSData)
 	require.NoError(t, err)
 
-	// Under slot-weighted quorum excluding dealer self, dealer 0 only gets 33/100 slots.
-	expectedValidDealers := []bool{false, false, false}
+	// Under slot-weighted quorum including dealer self:
+	// Dealer 0: gets votes from verifier 0 (33), verifier 1 (33), and implicitly self-votes (34) = 100 slots (Valid)
+	// Dealer 1: gets votes from verifier 0 (33), missing from verifier 1, implicitly self-votes (33) = 66 slots (Valid)
+	// Dealer 2: gets votes from verifier 0 (33), missing from verifier 1, implicitly self-votes (33) = 66 slots (Valid)
+	expectedValidDealers := []bool{true, true, true}
 	require.Equal(t, expectedValidDealers, validDealers)
 }
 


### PR DESCRIPTION
Per Certik audit:
In the commit [a1119b819e0ced3383f0b272b7c04487d24d12f5](https://github.com/gonka-ai/gonka/commit/a1119b819e0ced3383f0b272b7c04487d24d12f5), the changes made to DetermineValidDealersWithConsensus() require a strict majority of total slots (totalSlots/2 + 1) to approve each dealer, but it always excludes the dealer’s own verification vote. As a result, any dealer controlling at least half of the total slots cannot mathematically reach quorum even if every non-self verifier approves and the dealer submitted valid parts.

This invalid result flows into transitionFromVerifyingToDisputing(), which sums the slots of candidateValidDealers and fails the epoch when they do not exceed half of total slots. In skewed slot distributions such as 50/50 or 60/40, an honest high-weight dealer can be excluded for arithmetic reasons alone, causing the DKG epoch to enter FAILED instead of progressing to DISPUTING.

We would narrow the fix recommendation a bit:

- Counting the dealer’s own vote is the cleaner fix. That aligns the approval threshold with the available voting weight and removes the impossible-to-satisfy case.

- Not lower the downstream candidateDealerSlots > totalSlots/2 rule by itself. That threshold intentional, because later threshold signing requires t+1 slots, and with default params that is also a strict majority: threshold_signing.go (line 563).

So: fix dealer validation to include self weight; keep the candidate/final dealer slot threshold unless there is a broader protocol change.

