### PR TITLE
fix: Certik audit fixes (GEB-62)

### DIFF
--- a/inference-chain/x/bls/keeper/dispute_resolution.go
+++ b/inference-chain/x/bls/keeper/dispute_resolution.go
@@ -19,53 +19,81 @@ const (
 	dkgShareBytesLen  = 32
 )
 
-// applyDealerComplaintOutcomes applies complaint outcomes to the candidate valid dealer set.
+// applyDealerComplaintOutcomes applies complaint outcomes to the provided dealer set
 // Current policy:
 // - missing/invalid dealer response => dealer fault (dealer removed)
-// - valid dealer response => false complaint (complainer removed if in candidate set)
+// - valid dealer response => false complaint (complainer removed)
 func (k Keeper) applyDealerComplaintOutcomes(epochBLSData *types.EpochBLSData, candidateValidDealers []bool) ([]bool, error) {
 	finalValidDealers := make([]bool, len(candidateValidDealers))
 	copy(finalValidDealers, candidateValidDealers)
 
+	dealerFaults, falseComplainersByDealer, err := k.adjudicateDealerComplaints(epochBLSData)
+	if err != nil {
+		return nil, err
+	}
+
+	complainerFaults := flattenFalseComplainers(falseComplainersByDealer)
+	applyComplaintFaultMaps(finalValidDealers, dealerFaults, complainerFaults)
+	return finalValidDealers, nil
+}
+
+// adjudicateDealerComplaints evaluates all stored complaints and returns fault sets
+func (k Keeper) adjudicateDealerComplaints(epochBLSData *types.EpochBLSData) (map[int]struct{}, map[int]map[int]struct{}, error) {
 	dealerFaults := make(map[int]struct{})
-	complainerFaults := make(map[int]struct{})
+	falseComplainersByDealer := make(map[int]map[int]struct{})
+	participantCount := len(epochBLSData.Participants)
 
 	for i := range epochBLSData.DealerComplaints {
 		complaint := epochBLSData.DealerComplaints[i]
 		dealerIndex := int(complaint.DealerIndex)
 		complainerIndex := int(complaint.ComplainerIndex)
 
-		if dealerIndex < 0 || dealerIndex >= len(finalValidDealers) {
+		if dealerIndex < 0 || dealerIndex >= participantCount {
 			continue
 		}
-		if complainerIndex < 0 || complainerIndex >= len(finalValidDealers) {
-			continue
-		}
-		if !candidateValidDealers[dealerIndex] {
-			// Complaints against non-candidate dealers do not affect final set.
+		if complainerIndex < 0 || complainerIndex >= participantCount {
 			continue
 		}
 
 		ok, err := k.verifyDealerComplaintResponse(epochBLSData, &complaint)
 		if err != nil {
-			return nil, fmt.Errorf("failed to verify complaint for dealer %d and complainer %d: %w", dealerIndex, complainerIndex, err)
+			return nil, nil, fmt.Errorf("failed to verify complaint for dealer %d and complainer %d: %w", dealerIndex, complainerIndex, err)
 		}
 
 		if ok {
-			complainerFaults[complainerIndex] = struct{}{}
+			if falseComplainersByDealer[dealerIndex] == nil {
+				falseComplainersByDealer[dealerIndex] = make(map[int]struct{})
+			}
+			falseComplainersByDealer[dealerIndex][complainerIndex] = struct{}{}
 		} else {
 			dealerFaults[dealerIndex] = struct{}{}
 		}
 	}
 
+	return dealerFaults, falseComplainersByDealer, nil
+}
+
+func flattenFalseComplainers(falseComplainersByDealer map[int]map[int]struct{}) map[int]struct{} {
+	complainerFaults := make(map[int]struct{})
+	for _, complainers := range falseComplainersByDealer {
+		for complainerIndex := range complainers {
+			complainerFaults[complainerIndex] = struct{}{}
+		}
+	}
+	return complainerFaults
+}
+
+func applyComplaintFaultMaps(validDealers []bool, dealerFaults map[int]struct{}, complainerFaults map[int]struct{}) {
 	for dealerIndex := range dealerFaults {
-		finalValidDealers[dealerIndex] = false
+		if dealerIndex >= 0 && dealerIndex < len(validDealers) {
+			validDealers[dealerIndex] = false
+		}
 	}
 	for complainerIndex := range complainerFaults {
-		finalValidDealers[complainerIndex] = false
+		if complainerIndex >= 0 && complainerIndex < len(validDealers) {
+			validDealers[complainerIndex] = false
+		}
 	}
-
-	return finalValidDealers, nil
 }
 
 func (k Keeper) verifyDealerComplaintResponse(epochBLSData *types.EpochBLSData, complaint *types.DealerComplaint) (bool, error) {

--- a/inference-chain/x/bls/keeper/dispute_resolution_test.go
+++ b/inference-chain/x/bls/keeper/dispute_resolution_test.go
@@ -35,6 +35,10 @@ func TestApplyDealerComplaintOutcomes_MissingResponseRemovesDealer(t *testing.T)
 	final, err := k.applyDealerComplaintOutcomes(&epoch, []bool{true, true})
 	require.NoError(t, err)
 	require.Equal(t, []bool{true, false}, final)
+
+	finalWithNonCandidateDealer, err := k.applyDealerComplaintOutcomes(&epoch, []bool{false, true})
+	require.NoError(t, err)
+	require.Equal(t, []bool{false, false}, finalWithNonCandidateDealer)
 }
 
 func TestApplyDealerComplaintOutcomes_ValidResponseRemovesComplainer(t *testing.T) {
@@ -135,6 +139,150 @@ func TestApplyDealerComplaintOutcomes_ValidResponseRemovesComplainer(t *testing.
 	final, err := k.applyDealerComplaintOutcomes(&epoch, []bool{true, true})
 	require.NoError(t, err)
 	require.Equal(t, []bool{true, false}, final)
+}
+
+func TestAdjudicateComplaints_RecomputeCandidatesAfterFalseComplainerExclusion(t *testing.T) {
+	k := Keeper{}
+
+	dealerPriv, err := secp256k1.GeneratePrivateKey()
+	require.NoError(t, err)
+	complainerPriv, err := secp256k1.GeneratePrivateKey()
+	require.NoError(t, err)
+	observerPriv, err := secp256k1.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	share := fr.NewElement(5)
+	shareBytes := share.Bytes()
+	seed := make([]byte, dkgOpeningSeedLen)
+	for i := range seed {
+		seed[i] = byte(i + 11)
+	}
+
+	ciphertext, err := encryptWithSeedForParticipant(shareBytes[:], complainerPriv.PubKey().SerializeCompressed(), seed)
+	require.NoError(t, err)
+
+	sharesForComplainer := make([][]byte, 20)
+	for i := range sharesForComplainer {
+		sharesForComplainer[i] = ciphertext
+	}
+
+	epoch := types.EpochBLSData{
+		EpochId:     77,
+		ITotalSlots: 100,
+		Participants: []types.BLSParticipantInfo{
+			{
+				Address:            "p0",
+				Secp256K1PublicKey: dealerPriv.PubKey().SerializeCompressed(),
+				SlotStartIndex:     0,
+				SlotEndIndex:       29,
+			},
+			{
+				Address:            "p1",
+				Secp256K1PublicKey: complainerPriv.PubKey().SerializeCompressed(),
+				SlotStartIndex:     30,
+				SlotEndIndex:       49,
+			},
+			{
+				Address:            "p2",
+				Secp256K1PublicKey: observerPriv.PubKey().SerializeCompressed(),
+				SlotStartIndex:     50,
+				SlotEndIndex:       99,
+			},
+		},
+		DealerParts: []*types.DealerPartStorage{
+			{
+				DealerAddress: "p0",
+				Commitments:   [][]byte{mustMakeG2CommitmentForScalar(t, 5)},
+				ParticipantShares: []*types.EncryptedSharesForParticipant{
+					{EncryptedShares: [][]byte{}},
+					{EncryptedShares: sharesForComplainer},
+					{EncryptedShares: [][]byte{}},
+				},
+			},
+			{
+				DealerAddress: "p1",
+				Commitments:   [][]byte{mustMakeG2CommitmentForScalar(t, 7)},
+			},
+			{
+				DealerAddress: "p2",
+				Commitments:   [][]byte{},
+			},
+		},
+		VerificationSubmissions: []*types.VerificationVectorSubmission{
+			{DealerValidity: []bool{true, false, true}},
+			{DealerValidity: []bool{false, true, true}},
+			{DealerValidity: []bool{true, false, true}},
+		},
+		DealerComplaints: []types.DealerComplaint{
+			{
+				DealerIndex:             0,
+				ComplainerIndex:         1,
+				DisputedSlotIndex:       30,
+				DisputedCiphertextIndex: 0,
+				ResponseSubmitted:       true,
+				ResponseShareBytes:      shareBytes[:],
+				ResponseOpeningMaterial: seed,
+			},
+		},
+	}
+
+	initialCandidates, err := k.determineValidDealersWithConsensus(&epoch, nil)
+	require.NoError(t, err)
+	require.Equal(t, []bool{false, false, false}, initialCandidates)
+
+	dealerFaults, falseComplainersByDealer, err := k.adjudicateDealerComplaints(&epoch)
+	require.NoError(t, err)
+	require.Empty(t, dealerFaults)
+	require.Contains(t, falseComplainersByDealer, 0)
+	require.Contains(t, falseComplainersByDealer[0], 1)
+
+	recomputedCandidates, err := k.determineValidDealersWithConsensus(&epoch, falseComplainersByDealer)
+	require.NoError(t, err)
+	require.Equal(t, []bool{true, false, false}, recomputedCandidates)
+
+	finalValidDealers := make([]bool, len(recomputedCandidates))
+	copy(finalValidDealers, recomputedCandidates)
+	complainerFaults := flattenFalseComplainers(falseComplainersByDealer)
+	applyComplaintFaultMaps(finalValidDealers, dealerFaults, complainerFaults)
+	require.Equal(t, []bool{true, false, false}, finalValidDealers)
+}
+
+func TestDetermineValidDealersWithConsensus_ExcludedVerifiersAreDealerScoped(t *testing.T) {
+	k := Keeper{}
+
+	epoch := types.EpochBLSData{
+		EpochId:     88,
+		ITotalSlots: 100,
+		Participants: []types.BLSParticipantInfo{
+			{Address: "p0", SlotStartIndex: 0, SlotEndIndex: 29},
+			{Address: "p1", SlotStartIndex: 30, SlotEndIndex: 49},
+			{Address: "p2", SlotStartIndex: 50, SlotEndIndex: 59},
+			{Address: "p3", SlotStartIndex: 60, SlotEndIndex: 99},
+		},
+		DealerParts: []*types.DealerPartStorage{
+			{DealerAddress: "p0", Commitments: [][]byte{mustMakeG2CommitmentForScalar(t, 5)}},
+			{DealerAddress: "p1", Commitments: [][]byte{mustMakeG2CommitmentForScalar(t, 7)}},
+			{DealerAddress: "p2", Commitments: [][]byte{mustMakeG2CommitmentForScalar(t, 9)}},
+			{DealerAddress: "p3", Commitments: [][]byte{mustMakeG2CommitmentForScalar(t, 11)}},
+		},
+		VerificationSubmissions: []*types.VerificationVectorSubmission{
+			{DealerValidity: []bool{true, false, false, false}},
+			{DealerValidity: []bool{true, true, true, false}},
+			{DealerValidity: []bool{false, false, true, false}},
+			{DealerValidity: []bool{true, false, true, true}},
+		},
+	}
+
+	baseline, err := k.determineValidDealersWithConsensus(&epoch, nil)
+	require.NoError(t, err)
+	require.Equal(t, []bool{true, false, true, false}, baseline)
+
+	excludedByDealer := map[int]map[int]struct{}{
+		0: map[int]struct{}{1: {}},
+	}
+	recomputed, err := k.determineValidDealersWithConsensus(&epoch, excludedByDealer)
+	require.NoError(t, err)
+	require.Equal(t, []bool{false, false, true, false}, recomputed)
 }
 
 func mustMakeG2CommitmentForScalar(t *testing.T, scalar uint64) []byte {

--- a/inference-chain/x/bls/keeper/msg_server_verification_test.go
+++ b/inference-chain/x/bls/keeper/msg_server_verification_test.go
@@ -540,6 +540,38 @@ func TestSubmitVerificationVector_MalformedSharesDoNotRequireComplaintEvidence(t
 	require.Empty(t, storedData.DealerComplaints)
 }
 
+func TestSubmitVerificationVector_SelfComplaintRejected(t *testing.T) {
+	k, msgServer, goCtx := setupMsgServerVerification(t)
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	epochID := uint64(117)
+	epochBLSData := createTestEpochBLSDataInVerifyingPhase(epochID, 3)
+	k.SetEpochBLSData(ctx, epochBLSData)
+
+	participant := epochBLSData.Participants[0]
+	msg := &types.MsgSubmitVerificationVector{
+		Creator:        participant.Address,
+		EpochId:        epochID,
+		DealerValidity: []bool{false, false, false},
+		DealerComplaints: []types.VerificationDealerComplaint{
+			{
+				DealerIndex:             0,
+				DisputedSlotIndex:       participant.SlotStartIndex,
+				DisputedCiphertextIndex: 0,
+			},
+		},
+	}
+
+	resp, err := msgServer.SubmitVerificationVector(goCtx, msg)
+	require.Error(t, err)
+	require.Nil(t, resp)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+	require.Contains(t, st.Message(), "self complaint is not allowed")
+}
+
 func TestSubmitVerificationVector_InvalidComplaintSlotRejected(t *testing.T) {
 	k, msgServer, goCtx := setupMsgServerVerification(t)
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/inference-chain/x/bls/keeper/msg_server_verifier.go
+++ b/inference-chain/x/bls/keeper/msg_server_verifier.go
@@ -278,6 +278,9 @@ func validateComplaintIndices(epochBLSData *types.EpochBLSData, dealerIndex, com
 	if complainerIndex < 0 || complainerIndex >= len(epochBLSData.Participants) {
 		return fmt.Errorf("complainer index %d out of range", complainerIndex)
 	}
+	if dealerIndex == complainerIndex {
+		return fmt.Errorf("self complaint is not allowed for dealer %d", dealerIndex)
+	}
 
 	participant := epochBLSData.Participants[complainerIndex]
 	if participant.SlotEndIndex < participant.SlotStartIndex {

--- a/inference-chain/x/bls/keeper/phase_transitions.go
+++ b/inference-chain/x/bls/keeper/phase_transitions.go
@@ -164,14 +164,8 @@ func (k Keeper) transitionFromVerifyingToDisputing(ctx sdk.Context, epochBLSData
 		return k.MarkDKGAsFailed(ctx, epochBLSData, fmt.Sprintf("failed to determine candidate valid dealers: %v", err))
 	}
 
-	// Calculate total slots covered by candidate valid dealers
-	var candidateDealerSlots uint32 = 0
-	for i, participant := range epochBLSData.Participants {
-		if i < len(candidateValidDealers) && candidateValidDealers[i] {
-			participantSlots := participant.SlotEndIndex - participant.SlotStartIndex + 1
-			candidateDealerSlots += participantSlots
-		}
-	}
+	// Snapshot candidate dealers from raw verification votes before complaint adjudication
+	candidateDealerSlots := sumDealerSlots(epochBLSData.Participants, candidateValidDealers)
 
 	k.Logger().Info("Checking candidate valid dealers slots",
 		"epochId", epochBLSData.EpochId,
@@ -180,9 +174,10 @@ func (k Keeper) transitionFromVerifyingToDisputing(ctx sdk.Context, epochBLSData
 		"requiredSlots", epochBLSData.ITotalSlots/2)
 
 	if candidateDealerSlots <= epochBLSData.ITotalSlots/2 {
-		failureReason := fmt.Sprintf("Insufficient candidate valid dealer slots: %d slots out of %d total slots (required: >%d)",
-			candidateDealerSlots, epochBLSData.ITotalSlots, epochBLSData.ITotalSlots/2)
-		return k.MarkDKGAsFailed(ctx, epochBLSData, failureReason)
+		k.Logger().Info("Candidate dealers below quorum before complaint adjudication; continuing to DISPUTING",
+			"epochId", epochBLSData.EpochId,
+			"candidateDealerSlots", candidateDealerSlots,
+			"totalSlots", epochBLSData.ITotalSlots)
 	}
 
 	params, err := k.GetParams(ctx)
@@ -193,42 +188,14 @@ func (k Keeper) transitionFromVerifyingToDisputing(ctx sdk.Context, epochBLSData
 
 	epochBLSData.CandidateValidDealers = candidateValidDealers
 
-	filteredComplaints := make([]types.DealerComplaint, 0, len(epochBLSData.DealerComplaints))
-	for _, complaint := range epochBLSData.DealerComplaints {
-		dealerIdx := complaint.DealerIndex
-		if dealerIdx >= uint32(len(candidateValidDealers)) {
-			continue
-		}
-		// Keep only complaints against dealers that passed vote-based candidacy.
-		if candidateValidDealers[int(dealerIdx)] {
-			filteredComplaints = append(filteredComplaints, complaint)
-		}
-	}
-	// Wipe all existing complaint sub-keys so filtered-out entries don't
-	// linger. SetEpochBLSData below will resync the kept subset via its
-	// inline sync loop.
-	if err := k.DeleteDealerComplaintsForEpoch(ctx, epochBLSData.EpochId); err != nil {
-		return fmt.Errorf("failed to clear dealer complaint sub-keys for epoch %d: %w", epochBLSData.EpochId, err)
-	}
-	epochBLSData.DealerComplaints = filteredComplaints
-
 	epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_DISPUTING
 	epochBLSData.DisputingPhaseDeadlineBlock = currentBlockHeight + params.DisputePhaseDurationBlocks
 
-	// NOT SetEpochBLSDataBaseOnly here: filteredComplaints above plus the
-	// DeleteDealerComplaintsForEpoch call cleared every complaint sub-key,
-	// so SetEpochBLSData's DealerComplaints sync loop MUST re-write the
-	// filtered subset. Null only the other two before Set; restore after
-	// so the event below still carries the full state.
-	dealerParts := epochBLSData.DealerParts
-	verSubs := epochBLSData.VerificationSubmissions
-	epochBLSData.DealerParts = nil
-	epochBLSData.VerificationSubmissions = nil
-	if err := k.SetEpochBLSData(ctx, *epochBLSData); err != nil {
+	// Persist only base fields. Dealer parts, verifier submissions, and
+	// complaints are already stored under sub-keys and remain untouched
+	if err := k.SetEpochBLSDataBaseOnly(ctx, *epochBLSData); err != nil {
 		return fmt.Errorf("failed to set EpochBLSData for epoch %d: %w", epochBLSData.EpochId, err)
 	}
-	epochBLSData.DealerParts = dealerParts
-	epochBLSData.VerificationSubmissions = verSubs
 
 	if err := ctx.EventManager().EmitTypedEvent(&types.EventDisputePhaseStarted{
 		EpochId:                     epochBLSData.EpochId,
@@ -255,33 +222,28 @@ func (k Keeper) CompleteDKG(ctx sdk.Context, epochBLSData *types.EpochBLSData) e
 }
 
 func (k Keeper) finalizeDisputingPhase(ctx sdk.Context, epochBLSData *types.EpochBLSData) error {
-	finalValidDealers := epochBLSData.CandidateValidDealers
-	if len(finalValidDealers) != len(epochBLSData.Participants) {
-		return fmt.Errorf(
-			"invalid candidate valid dealers length for epoch %d: got %d, expected %d",
-			epochBLSData.EpochId,
-			len(finalValidDealers),
-			len(epochBLSData.Participants),
-		)
-	}
-
-	var err error
-	finalValidDealers, err = k.applyDealerComplaintOutcomes(epochBLSData, finalValidDealers)
+	dealerFaults, falseComplainersByDealer, err := k.adjudicateDealerComplaints(epochBLSData)
 	if err != nil {
 		return k.MarkDKGAsFailed(ctx, epochBLSData, fmt.Sprintf("failed to apply complaint outcomes: %v", err))
 	}
 
-	// Calculate total slots covered by final valid dealers
-	var finalDealerSlots uint32 = 0
-	for i, participant := range epochBLSData.Participants {
-		if i < len(finalValidDealers) && finalValidDealers[i] {
-			participantSlots := participant.SlotEndIndex - participant.SlotStartIndex + 1
-			finalDealerSlots += participantSlots
-		}
+	candidateValidDealers, err := k.determineValidDealersWithConsensus(epochBLSData, falseComplainersByDealer)
+	if err != nil {
+		return k.MarkDKGAsFailed(ctx, epochBLSData, fmt.Sprintf("failed to determine final candidate dealers: %v", err))
 	}
+	epochBLSData.CandidateValidDealers = candidateValidDealers
+
+	finalValidDealers := make([]bool, len(candidateValidDealers))
+	copy(finalValidDealers, candidateValidDealers)
+	complainerFaults := flattenFalseComplainers(falseComplainersByDealer)
+	applyComplaintFaultMaps(finalValidDealers, dealerFaults, complainerFaults)
+
+	finalDealerSlots := sumDealerSlots(epochBLSData.Participants, finalValidDealers)
 
 	k.Logger().Info("Checking final valid dealers slots",
 		"epochId", epochBLSData.EpochId,
+		"dealerFaultCount", len(dealerFaults),
+		"falseComplainerCount", len(complainerFaults),
 		"finalDealerSlots", finalDealerSlots,
 		"totalSlots", epochBLSData.ITotalSlots,
 		"requiredSlots", epochBLSData.ITotalSlots/2)
@@ -377,6 +339,11 @@ func (k Keeper) CalculateSlotsWithVerificationVectors(epochBLSData *types.EpochB
 
 // DetermineValidDealersWithConsensus determines which dealers are valid under weighted slot quorum
 func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSData) ([]bool, error) {
+	return k.determineValidDealersWithConsensus(epochBLSData, nil)
+}
+
+// determineValidDealersWithConsensus determines valid dealers with optional per-dealer verifier exclusions
+func (k Keeper) determineValidDealersWithConsensus(epochBLSData *types.EpochBLSData, excludedVerifiersByDealer map[int]map[int]struct{}) ([]bool, error) {
 	participantCount := len(epochBLSData.Participants)
 	if participantCount == 0 {
 		return nil, fmt.Errorf("no participants found for epoch %d", epochBLSData.EpochId)
@@ -384,18 +351,49 @@ func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSD
 
 	validDealers := make([]bool, participantCount)
 	totalSlots := uint64(epochBLSData.ITotalSlots)
-	quorumSlots := totalSlots/2 + 1
 
 	for dealerIndex := 0; dealerIndex < participantCount; dealerIndex++ {
+		excludedVerifiers := map[int]struct{}(nil)
+		if excludedVerifiersByDealer != nil {
+			excludedVerifiers = excludedVerifiersByDealer[dealerIndex]
+		}
+
+		effectiveTotalSlots := totalSlots
+		if len(excludedVerifiers) > 0 {
+			var excludedSlots uint64
+			for verifierIndex := range excludedVerifiers {
+				if verifierIndex < 0 || verifierIndex >= participantCount {
+					continue
+				}
+				participant := epochBLSData.Participants[verifierIndex]
+				if participant.SlotEndIndex < participant.SlotStartIndex {
+					return nil, fmt.Errorf("invalid slot range for participant %d in epoch %d", verifierIndex, epochBLSData.EpochId)
+				}
+				excludedSlots += uint64(participant.SlotEndIndex-participant.SlotStartIndex) + 1
+			}
+			if excludedSlots >= effectiveTotalSlots {
+				effectiveTotalSlots = 0
+			} else {
+				effectiveTotalSlots -= excludedSlots
+			}
+		}
+		quorumSlots := effectiveTotalSlots/2 + 1
+
 		dealerParticipant := epochBLSData.Participants[dealerIndex]
 		if dealerParticipant.SlotEndIndex < dealerParticipant.SlotStartIndex {
 			return nil, fmt.Errorf("invalid slot range for dealer %d in epoch %d", dealerIndex, epochBLSData.EpochId)
 		}
 		dealerOwnSlots := uint64(dealerParticipant.SlotEndIndex-dealerParticipant.SlotStartIndex) + 1
-		dealerOwnSlotsAtLeastHalf := totalSlots > 0 && dealerOwnSlots*2 >= totalSlots
+		dealerSlotsInDenominator := dealerOwnSlots
+		if excludedVerifiers != nil {
+			if _, excluded := excludedVerifiers[dealerIndex]; excluded {
+				dealerSlotsInDenominator = 0
+			}
+		}
+		dealerOwnSlotsAtLeastHalf := dealerSlotsInDenominator > 0 && effectiveTotalSlots > 0 && dealerSlotsInDenominator*2 >= effectiveTotalSlots
 		maxPossibleNonSelfVotingSlots := uint64(0)
-		if dealerOwnSlots <= totalSlots {
-			maxPossibleNonSelfVotingSlots = totalSlots - dealerOwnSlots
+		if dealerSlotsInDenominator <= effectiveTotalSlots {
+			maxPossibleNonSelfVotingSlots = effectiveTotalSlots - dealerSlotsInDenominator
 		}
 
 		var validVotingSlotsExcludingDealer uint64
@@ -406,6 +404,11 @@ func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSD
 			}
 			if verifierIndex >= participantCount {
 				continue
+			}
+			if excludedVerifiers != nil {
+				if _, excluded := excludedVerifiers[verifierIndex]; excluded {
+					continue
+				}
 			}
 			if verifierIndex == dealerIndex {
 				continue
@@ -422,13 +425,13 @@ func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSD
 			validVotingSlotsExcludingDealer += verifierSlots
 		}
 
-		dealerIsValid := totalSlots > 0 && validVotingSlotsExcludingDealer >= quorumSlots
+		dealerIsValid := effectiveTotalSlots > 0 && validVotingSlotsExcludingDealer >= quorumSlots
 		dealerSubmittedParts := dealerIndex < len(epochBLSData.DealerParts) &&
 			epochBLSData.DealerParts[dealerIndex] != nil &&
 			epochBLSData.DealerParts[dealerIndex].DealerAddress != "" &&
 			len(epochBLSData.DealerParts[dealerIndex].Commitments) > 0
 
-		if dealerSubmittedParts && totalSlots > 0 && maxPossibleNonSelfVotingSlots < quorumSlots {
+		if dealerSubmittedParts && effectiveTotalSlots > 0 && maxPossibleNonSelfVotingSlots < quorumSlots {
 			k.Logger().Warn("Dealer cannot reach weighted quorum with self-vote excluded",
 				"epochId", epochBLSData.EpochId,
 				"dealerIndex", dealerIndex,
@@ -436,7 +439,9 @@ func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSD
 				"dealerOwnSlotsAtLeastHalf", dealerOwnSlotsAtLeastHalf,
 				"maxNonSelfVotingSlots", maxPossibleNonSelfVotingSlots,
 				"quorumSlots", quorumSlots,
-				"totalSlots", totalSlots,
+				"effectiveTotalSlots", effectiveTotalSlots,
+				"totalSlots", epochBLSData.ITotalSlots,
+				"excludedVerifierCount", len(excludedVerifiers),
 				"receivedVotingSlotsExcludingDealer", validVotingSlotsExcludingDealer)
 		}
 
@@ -444,6 +449,16 @@ func (k Keeper) DetermineValidDealersWithConsensus(epochBLSData *types.EpochBLSD
 	}
 
 	return validDealers, nil
+}
+
+func sumDealerSlots(participants []types.BLSParticipantInfo, validDealers []bool) uint32 {
+	var totalSlots uint32
+	for i, participant := range participants {
+		if i < len(validDealers) && validDealers[i] {
+			totalSlots += participant.SlotEndIndex - participant.SlotStartIndex + 1
+		}
+	}
+	return totalSlots
 }
 
 func countTrueBooleans(values []bool) int {
@@ -512,4 +527,3 @@ func (k Keeper) ComputeGroupPublicKey(epochBLSData *types.EpochBLSData, validDea
 
 	return groupPublicKeyBytes, nil
 }
-

--- a/inference-chain/x/bls/keeper/phase_transitions_test.go
+++ b/inference-chain/x/bls/keeper/phase_transitions_test.go
@@ -324,6 +324,9 @@ func TestCompleteDKG_SufficientVerification(t *testing.T) {
 	epochBLSData.DealerParts[0].Commitments = [][]byte{testCommitment}
 	epochBLSData.DealerParts[1].DealerAddress = "participant2"
 	epochBLSData.DealerParts[1].Commitments = [][]byte{testCommitment}
+	epochBLSData.VerificationSubmissions[0].DealerValidity = []bool{true, true, false}
+	epochBLSData.VerificationSubmissions[1].DealerValidity = []bool{true, true, false}
+	epochBLSData.VerificationSubmissions[2].DealerValidity = []bool{true, true, false}
 
 	k.SetEpochBLSData(ctx, epochBLSData)
 	k.SetActiveEpochID(ctx, epochID)
@@ -394,16 +397,27 @@ func TestCompleteDKG_WrongPhase(t *testing.T) {
 	require.Contains(t, err.Error(), "not in DISPUTING phase")
 }
 
-func TestCompleteDKG_InvalidCandidateValidDealersLength(t *testing.T) {
+func TestCompleteDKG_RecomputesCandidatesWhenStoredSnapshotIsMalformed(t *testing.T) {
 	k, ctx := keepertest.BlsKeeper(t)
 
 	epochBLSData := createTestEpochBLSData(uint64(29), 3)
 	epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_DISPUTING
+	// Simulate stale/corrupted snapshot from an older phase.
 	epochBLSData.CandidateValidDealers = []bool{true, true}
+	testCommitment := createTestG2Commitment()
+	epochBLSData.DealerParts[0].DealerAddress = "participant1"
+	epochBLSData.DealerParts[0].Commitments = [][]byte{testCommitment}
+	epochBLSData.DealerParts[1].DealerAddress = "participant2"
+	epochBLSData.DealerParts[1].Commitments = [][]byte{testCommitment}
+	epochBLSData.VerificationSubmissions[0].DealerValidity = []bool{true, true, false}
+	epochBLSData.VerificationSubmissions[1].DealerValidity = []bool{true, true, false}
+	epochBLSData.VerificationSubmissions[2].DealerValidity = []bool{true, true, false}
 
 	err := k.CompleteDKG(ctx, &epochBLSData)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid candidate valid dealers length")
+	require.NoError(t, err)
+	require.Equal(t, types.DKGPhase_DKG_PHASE_COMPLETED, epochBLSData.DkgPhase)
+	require.Equal(t, []bool{true, true, false}, epochBLSData.CandidateValidDealers)
+	require.Equal(t, []bool{true, true, false}, epochBLSData.ValidDealers)
 }
 
 func TestDetermineValidDealersWithConsensus(t *testing.T) {
@@ -577,6 +591,54 @@ func TestProcessDKGPhaseTransitionForEpoch_VerifyingToCompleted(t *testing.T) {
 	activeEpoch, found := k.GetActiveEpochID(ctx)
 	require.False(t, found)
 	require.Equal(t, uint64(0), activeEpoch)
+}
+
+func TestProcessDKGPhaseTransitionForEpoch_VerifyingToDisputing_PreservesComplaintsForNonCandidateDealers(t *testing.T) {
+	k, ctx := keepertest.BlsKeeper(t)
+
+	epochID := uint64(31)
+	epochBLSData := createTestEpochBLSData(epochID, 3)
+	epochBLSData.DkgPhase = types.DKGPhase_DKG_PHASE_VERIFYING
+
+	testCommitment := createTestG2Commitment()
+	for i := 0; i < 3; i++ {
+		epochBLSData.DealerParts[i].DealerAddress = "participant" + string(rune('1'+i))
+		epochBLSData.DealerParts[i].Commitments = [][]byte{testCommitment}
+	}
+
+	// Two verifiers submit vectors (>50% verification participation),
+	// but no dealer reaches weighted quorum before disputes.
+	epochBLSData.VerificationSubmissions[0].DealerValidity = []bool{false, false, false}
+	epochBLSData.VerificationSubmissions[1].DealerValidity = []bool{false, false, false}
+
+	// Complaint targets dealer 0, who is not in the pre-dispute candidate set.
+	epochBLSData.DealerComplaints = []types.DealerComplaint{
+		{
+			DealerIndex:             0,
+			ComplainerIndex:         1,
+			DisputedSlotIndex:       33,
+			DisputedCiphertextIndex: 0,
+		},
+	}
+
+	k.SetEpochBLSData(ctx, epochBLSData)
+	k.SetActiveEpochID(ctx, epochID)
+
+	ctx = ctx.WithBlockHeight(epochBLSData.VerifyingPhaseDeadlineBlock)
+	err := k.ProcessDKGPhaseTransitionForEpoch(ctx, epochID)
+	require.NoError(t, err)
+
+	storedData, err := k.GetEpochBLSData(ctx, epochID)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGPhase_DKG_PHASE_DISPUTING, storedData.DkgPhase)
+	require.Equal(t, []bool{false, false, false}, storedData.CandidateValidDealers)
+	require.Len(t, storedData.DealerComplaints, 1)
+	require.Equal(t, uint32(0), storedData.DealerComplaints[0].DealerIndex)
+	require.Equal(t, uint32(1), storedData.DealerComplaints[0].ComplainerIndex)
+
+	activeEpoch, found := k.GetActiveEpochID(ctx)
+	require.True(t, found)
+	require.Equal(t, epochID, activeEpoch)
 }
 
 func TestProcessDKGPhaseTransitionForEpoch_VerifyingToFailed(t *testing.T) {


### PR DESCRIPTION
From audit report:

> Description
> 
> During the VERIFYING-to-DISPUTING transition, dealer candidacy is determined solely from raw verifier votes in phase_transitions.go and stored as CandidateValidDealers in phase_transitions.go. Complaints against dealers that do not make this vote-based candidate set are then filtered out and deleted in phase_transitions.go, while dealers can only respond to complaints that still exist in msg_server_dispute.go. The substantive truth check for a complaint is deferred until verifyDealerComplaintResponse in dispute_resolution.go and is only applied later during finalization in phase_transitions.go.
> 
> As a result, verifiers with sufficient slot weight can submit dealer_validity=false together with an admissible complaint selector, push an honest dealer below quorum before the dispute is adjudicated, and cause that dealer’s complaint to be discarded before the dealer has any chance to disprove it. Because the dealer’s candidacy is never recomputed after complaint resolution, false complaint-driven votes can remain decisive, removing honest dealers from the final set or causing DKG failure due to insufficient candidate dealer slots.
> 
> Recommendation
> 
> Do not treat vote-based dealer candidacy as final before complaint resolution. Preserve all admitted complaints through the disputing phase, allow dealers to respond even if they initially miss vote-based candidacy, and only finalize dealer eligibility after complaint adjudication.
> 
> In practice, this means moving complaint filtering and quorum/failure checks until after dispute resolution, or recomputing dealer validity once false complaints have been disproven.
> 

We no longer remove complaints before the dispute phase. After disputes are checked, we recalculate which dealers are valid, and only then make the final quorum decision