### PR TITLE
fix: run gas simulation in grant-ml-ops-permissions when --gas auto i…

### DIFF
--- a/inference-chain/x/inference/module/commands.go
+++ b/inference-chain/x/inference/module/commands.go
@@ -49,11 +49,15 @@ Example:
     gonka-account-key \
     gonka1rk52j24xj9ej87jas4zqpvjuhrgpnd7h3feqmm \
     --from gonka-account-key \
+    --gas auto --gas-adjustment 1.5 \
     --gas-prices 10ngonka \
     --node http://node2.gonka.ai:8000/chain-rpc/
 
 Note: Chain ID will be auto-detected from the chain if not specified with --chain-id.
-      Use --gas-prices 10ngonka (or higher) to set transaction fees.`,
+      Use --gas-prices 10ngonka (or higher) to set transaction fees.
+      This tx bundles ~20 authz grants plus a feegrant allowance, so it is
+      larger than typical — passing --gas auto --gas-adjustment 1.5 is the
+      easiest way to size it correctly.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)

--- a/inference-chain/x/inference/permissions.go
+++ b/inference-chain/x/inference/permissions.go
@@ -132,6 +132,19 @@ func GrantMLOperationalKeyPermissionsToAccount(
 			"Run `inferenced tx feegrant revoke <warm-address>` first if you want to refresh it.")
 	}
 
+	// This command bypasses GenerateOrBroadcastTxCLI, so we replicate its
+	// --gas auto handling here: when the factory is set to simulate, run
+	// CalculateGas and apply the adjustment before building the tx. Without
+	// this, --gas auto produces a tx with gasWanted=0 and OOGs immediately.
+	if txFactory.SimulateAndExecute() {
+		_, adjusted, err := tx.CalculateGas(clientCtx, txFactory, grantMsgs...)
+		if err != nil {
+			return fmt.Errorf("failed to simulate gas: %w", err)
+		}
+		txFactory = txFactory.WithGas(adjusted)
+		fmt.Printf("gas estimate: %d\n", adjusted)
+	}
+
 	txb, err := txFactory.BuildUnsignedTx(grantMsgs...)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

`inferenced tx inference grant-ml-ops-permissions` ignores `--gas auto`. The command builds and broadcasts the tx manually (`txFactory.BuildUnsignedTx` → `tx.Sign` → `clientCtx.BroadcastTx`) instead of going through `tx.GenerateOrBroadcastTxCLI`, so the SDK's standard simulation step is skipped. With `--gas auto`, the factory's `Gas` field stays at the zero default and the tx broadcasts with `gasWanted=0`, failing immediately:

```
out of gas in location: ReadFlat; gasWanted: 0, gasUsed: 1000: out of gas
```

This is the only user-facing CLI command in the repo with this pattern (verified by audit — see below), so the fix is localized to one site.

## Changes

- `inference-chain/x/inference/permissions.go` — when `txFactory.SimulateAndExecute()` is true (i.e. `--gas auto` was passed), call `tx.CalculateGas` and write the adjusted value back via `WithGas` before `BuildUnsignedTx`. Mirrors what `tx.BroadcastTx` does internally at [`client/tx/tx.go:79-93`](https://github.com/cosmos/cosmos-sdk/blob/main/client/tx/tx.go#L79-L93). When the user passes a fixed `--gas N`, `SimulateAndExecute()` is false and the new block is a no-op — no behavior change for that path.
- `inference-chain/x/inference/module/commands.go` — updated the `Example:` and `Note:` blocks to recommend `--gas auto --gas-adjustment 1.5`. The tx bundles ~20 authz grants plus an optional `MsgGrantAllowance`, so the static `--gas` default (200000) is way under the actual cost (~1M with v0.2.12 per-byte gas) — auto is the right answer here.

## Why this matters

A real host hit this on testnet. Without the fix, the only workaround is binary search on `--gas` until the tx fits. After the fix, `--gas auto --gas-adjustment 1.5` works the same way it does on every other `inferenced tx` command.

## Audit scope

Searched the repo for the same anti-pattern (manual `BuildUnsignedTx` + `Sign` + broadcast that skips simulation). Findings:

- **Confirmed bug**: `grant-ml-ops-permissions` (this PR).
- **Safe — uses `tx.GenerateOrBroadcastTxCLI`**: `settle-devshard-escrow` (`commands.go:204`), `publish-pubkey` (`publish_pubkey_command.go:48`), all autocli-generated `tx` commands (autocli routes through `GenerateOrBroadcastTxCLI` in `cosmossdk.io/client/v2/autocli/msg.go:152`).
- **Not applicable**: `gentx` writes signed files offline (no chain to simulate against); DAPI's `tx_manager.go` uses a fixed `BatchGasLimit` by design and isn't user-facing; `devshardd` / `devshardctl` are query-only.

## Test plan

- [ ] `inferenced tx inference grant-ml-ops-permissions <cold> <warm> --from <cold> --gas auto --gas-adjustment 1.5 --gas-prices 10ngonka --node <NODE>` succeeds and prints the simulated gas estimate.
- [ ] Same command with explicit `--gas 1000000` still works (regression check that the simulation block is skipped when `SimulateAndExecute()` is false).
- [ ] Same command run twice — second invocation skips `MsgGrantAllowance` and only re-grants authz, with simulation still producing a sensible (smaller) gas estimate.
- [ ] `go build ./...` clean (already verified locally with Go 1.24).
