### PR TITLE
fix: stop stale PoC validation promptly

### DIFF
--- a/decentralized-api/poc/phase_test.go
+++ b/decentralized-api/poc/phase_test.go
@@ -158,6 +158,46 @@ func TestShouldAcceptValidatedArtifacts_NilOrNotSynced(t *testing.T) {
 	assert.False(t, ShouldAcceptValidatedArtifacts(notSynced))
 }
 
+func TestShouldStopValidationForStage(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       *chainphase.EpochState
+		stageHeight int64
+		expect      bool
+	}{
+		{
+			name:        "nil state waits for next tracker update",
+			state:       nil,
+			stageHeight: 100,
+			expect:      false,
+		},
+		{
+			name:        "current validation stage continues",
+			state:       createTestEpochState(types.PoCValidatePhase, 200, 100),
+			stageHeight: 100,
+			expect:      false,
+		},
+		{
+			name:        "non-validation phase stops immediately",
+			state:       createTestEpochState(types.InferencePhase, 500, 100),
+			stageHeight: 100,
+			expect:      true,
+		},
+		{
+			name:        "different PoC stage stops immediately",
+			state:       createTestEpochState(types.PoCValidatePhase, 200, 120),
+			stageHeight: 100,
+			expect:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, shouldStopValidationForStage(tt.state, tt.stageHeight))
+		})
+	}
+}
+
 func TestGetCurrentPocStageHeight_RegularPoC(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -53,19 +53,21 @@ type OffChainValidator struct {
 
 // ValidationConfig contains configuration for off-chain validation.
 type ValidationConfig struct {
-	WorkerCount    int
-	RequestTimeout time.Duration
-	MaxRetries     int
-	RetryBackoff   time.Duration
+	WorkerCount        int
+	RequestTimeout     time.Duration
+	MaxRetries         int
+	RetryBackoff       time.Duration
+	PhaseCheckInterval time.Duration
 }
 
 // DefaultValidationConfig returns the default configuration.
 func DefaultValidationConfig() ValidationConfig {
 	return ValidationConfig{
-		WorkerCount:    10,
-		RequestTimeout: 20 * time.Second,
-		MaxRetries:     15,
-		RetryBackoff:   3 * time.Second,
+		WorkerCount:        10,
+		RequestTimeout:     20 * time.Second,
+		MaxRetries:         15,
+		RetryBackoff:       3 * time.Second,
+		PhaseCheckInterval: 3 * time.Second,
 	}
 }
 
@@ -368,9 +370,11 @@ func (v *OffChainValidator) ValidateAll(pocStageStartBlockHeight int64, pocStart
 	failCount := 0
 	pendingCount := len(workItems)
 
-	// Context for coordinating shutdown
+	// Context for coordinating shutdown. The phase watcher cancels as soon
+	// as the chain stops accepting validation results for this PoC stage.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	v.cancelWhenValidationPhaseEnds(ctx, cancel, pocStageStartBlockHeight)
 
 	// Start workers
 	numWorkers := v.config.WorkerCount
@@ -417,6 +421,54 @@ func (v *OffChainValidator) ValidateAll(pocStageStartBlockHeight int64, pocStart
 		"failed", failCount)
 }
 
+func (v *OffChainValidator) cancelWhenValidationPhaseEnds(ctx context.Context, cancel context.CancelFunc, pocStageStartBlockHeight int64) {
+	phaseCheckInterval := v.config.PhaseCheckInterval
+	if phaseCheckInterval <= 0 {
+		phaseCheckInterval = 3 * time.Second
+	}
+
+	go func() {
+		if v.cancelIfValidationPhaseEnded(cancel, pocStageStartBlockHeight) {
+			return
+		}
+
+		ticker := time.NewTicker(phaseCheckInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if v.cancelIfValidationPhaseEnded(cancel, pocStageStartBlockHeight) {
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (v *OffChainValidator) cancelIfValidationPhaseEnded(cancel context.CancelFunc, pocStageStartBlockHeight int64) bool {
+	state := v.phaseTracker.GetCurrentEpochState()
+	if !shouldStopValidationForStage(state, pocStageStartBlockHeight) {
+		return false
+	}
+
+	logging.Info("OffChainValidator: validation phase ended, stopping workers", types.PoC,
+		"currentPhase", state.CurrentPhase,
+		"blockHeight", state.CurrentBlock.Height,
+		"pocStageStartBlockHeight", pocStageStartBlockHeight)
+	cancel()
+	return true
+}
+
+func shouldStopValidationForStage(state *chainphase.EpochState, pocStageStartBlockHeight int64) bool {
+	if state == nil {
+		return false
+	}
+	return !ShouldAcceptValidatedArtifacts(state) || GetCurrentPocStageHeight(state) != pocStageStartBlockHeight
+}
+
 // worker processes participants from the work channel.
 // Failed items are re-queued for retry instead of blocking on retries.
 func (v *OffChainValidator) worker(
@@ -447,13 +499,24 @@ func (v *OffChainValidator) worker(
 				return
 			}
 
-			// Not ready yet? Put back at end of queue
+			// Not ready yet? Put back at end of queue and sleep briefly to avoid busy-wait spin.
 			if time.Now().Before(work.retryAfter) {
-				workChan <- work
+				select {
+				case workChan <- work:
+				case <-ctx.Done():
+					return
+				}
+
+				select {
+				case <-time.After(100 * time.Millisecond):
+				case <-ctx.Done():
+					return
+				}
 				continue
 			}
 
 			result := v.validateParticipant(
+				ctx,
 				workerID,
 				work,
 				proofClient,
@@ -500,10 +563,8 @@ func (v *OffChainValidator) worker(
 				} else {
 					*failCount++
 					*pendingCount--
-					logging.Warn("OffChainValidator: max retries exceeded, reporting as invalid", types.PoC,
+					logging.Warn("OffChainValidator: max retries exceeded for transient validation failure", types.PoC,
 						"participant", work.address, "attempts", work.attempt+1)
-					// Report participant as invalid to chain. We probably should separate only to report failed network requests.
-					// reportAddr = work.address
 				}
 			}
 
@@ -527,6 +588,7 @@ func (v *OffChainValidator) worker(
 // samplingBlockHash: fresh hash for random sampling (anti-cheat)
 // pocStartBlockHash: original PoC start block hash (must match generation for MLNode)
 func (v *OffChainValidator) validateParticipant(
+	ctx context.Context,
 	workerID int,
 	work participantWork,
 	proofClient proofFetcher,
@@ -538,7 +600,6 @@ func (v *OffChainValidator) validateParticipant(
 	pocParams *types.PocParams,
 	sampleSize int,
 ) validateResult {
-	ctx := context.Background()
 	modelNodes := filterValidationNodesForModel(nodes, work.modelId)
 	if len(modelNodes) == 0 {
 		logging.Warn("OffChainValidator: no validation executors for model", types.PoC,

--- a/decentralized-api/poc/validator_rng_test.go
+++ b/decentralized-api/poc/validator_rng_test.go
@@ -83,6 +83,7 @@ func runValidateParticipant(t *testing.T, pocStrongerRng bool) *mlnodeclient.PoC
 
 	nodeCounter := 0
 	result := v.validateParticipant(
+		context.Background(),
 		0, work, stub,
 		[]broker.NodeResponse{testNode}, &nodeCounter,
 		1000, "sampling-hash", "start-hash",


### PR DESCRIPTION
## Summary
- Replaces #827 with a clean branch based directly on upgrade-v0.2.12
- Cancels off-chain PoC validation when the validation phase ends or the PoC stage changes, and propagates cancellation into proof fetch / ML-node validation work.
- Keeps retry requeue handling cancellable and avoids treating exhausted transient failures as invalid participants.
