### PR TITLE
fix: claw back validator shares on invalidation

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
@@ -6,6 +6,7 @@ import (
 	"cosmossdk.io/collections"
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/x/inference/calculations"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -69,19 +70,91 @@ func (k msgServer) refundInvalidatedInference(executor *types.Participant, infer
 		return types.ErrParticipantNotFound
 	}
 
+	clawbackAdjustments, clawbacks, err := k.loadInvalidatedInferenceClawbacks(ctx, executor, inference)
+	if err != nil {
+		return err
+	}
+
 	// Attempt refund BEFORE modifying executor balance
 	// If refund fails (e.g. underfunded escrow), don't corrupt state
-	err := k.IssueRefund(ctx, inference.ActualCost, payer.Address, "invalidated_inference:"+inference.InferenceId)
+	err = k.IssueRefund(ctx, inference.ActualCost, payer.Address, "invalidated_inference:"+inference.InferenceId)
 	if err != nil {
 		k.LogError("Refund failed", types.Validation, "error", err)
 		return err
 	}
 
-	// Only deduct from executor after successful refund
-	executor.CoinBalance -= inference.ActualCost
-	k.SafeLogSubAccountTransaction(ctx, types.ModuleName, executor.Address, types.OwedSubAccount, inference.ActualCost, "invalidated_inference:"+inference.InferenceId)
-	k.LogInfo("Invalid Inference subtracted from Executor CoinBalance ", types.Balances, "inferenceId", inference.InferenceId, "executor", executor.Address, "actualCost", inference.ActualCost, "coinBalance", executor.CoinBalance)
+	if err := k.applyInvalidatedInferenceClawbacks(ctx, executor, inference, clawbackAdjustments, clawbacks); err != nil {
+		return err
+	}
 
+	return nil
+}
+
+func (k msgServer) loadInvalidatedInferenceClawbacks(ctx context.Context, executor *types.Participant, inference *types.Inference) ([]calculations.Adjustment, map[string]*types.Participant, error) {
+	if inference.ActualCost < 0 {
+		return nil, nil, errorsmod.Wrapf(types.ErrIllegalState, "inference %s has negative actual cost %d", inference.InferenceId, inference.ActualCost)
+	}
+
+	clawbackAdjustments, err := invalidatedInferenceClawbackAdjustments(inference)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clawbacks := make(map[string]*types.Participant, len(clawbackAdjustments))
+	for _, adjustment := range clawbackAdjustments {
+		if adjustment.WorkAdjustment == 0 || adjustment.ParticipantId == executor.Address {
+			continue
+		}
+		if _, loaded := clawbacks[adjustment.ParticipantId]; loaded {
+			continue
+		}
+		participant, found := k.GetParticipant(ctx, adjustment.ParticipantId)
+		if !found {
+			return nil, nil, errorsmod.Wrapf(types.ErrParticipantNotFound, "validated inference worker %s not found", adjustment.ParticipantId)
+		}
+		participantCopy := participant
+		clawbacks[adjustment.ParticipantId] = &participantCopy
+	}
+
+	return clawbackAdjustments, clawbacks, nil
+}
+
+func invalidatedInferenceClawbackAdjustments(inference *types.Inference) ([]calculations.Adjustment, error) {
+	workers := append([]string{inference.ExecutedBy}, inference.ValidatedBy...)
+	adjustments := calculations.ShareWork(nil, workers, inference.ActualCost)
+	for _, adjustment := range adjustments {
+		if adjustment.WorkAdjustment < 0 {
+			return nil, errorsmod.Wrapf(types.ErrIllegalState, "invalidated inference clawback for %s cannot be negative: %d", adjustment.ParticipantId, adjustment.WorkAdjustment)
+		}
+	}
+	return adjustments, nil
+}
+
+func (k msgServer) applyInvalidatedInferenceClawbacks(ctx context.Context, executor *types.Participant, inference *types.Inference, clawbackAdjustments []calculations.Adjustment, clawbacks map[string]*types.Participant) error {
+	for _, adjustment := range clawbackAdjustments {
+		participantID := adjustment.ParticipantId
+		amount := adjustment.WorkAdjustment
+		if amount == 0 {
+			continue
+		}
+		if participantID == executor.Address {
+			executor.CoinBalance -= amount
+			k.SafeLogSubAccountTransaction(ctx, types.ModuleName, executor.Address, types.OwedSubAccount, amount, "invalidated_inference:"+inference.InferenceId)
+			k.LogInfo("Invalid inference clawed back from executor CoinBalance", types.Balances, "inferenceId", inference.InferenceId, "executor", executor.Address, "amount", amount, "coinBalance", executor.CoinBalance)
+			continue
+		}
+
+		participant, found := clawbacks[participantID]
+		if !found {
+			return errorsmod.Wrapf(types.ErrParticipantNotFound, "validated inference worker %s not found", participantID)
+		}
+		participant.CoinBalance -= amount
+		k.SafeLogSubAccountTransaction(ctx, types.ModuleName, participant.Address, types.OwedSubAccount, amount, "invalidated_inference:"+inference.InferenceId)
+		k.LogInfo("Invalid inference clawed back from validator CoinBalance", types.Balances, "inferenceId", inference.InferenceId, "validator", participant.Address, "amount", amount, "coinBalance", participant.CoinBalance)
+		if err := k.SetParticipant(ctx, *participant); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference_test.go
@@ -107,6 +107,76 @@ func TestInvalidateInference_RefundsRequesterAndChargesExecutor_NoSlash(t *testi
 	require.Equal(t, types.InferenceStatus_INVALIDATED, updatedInf.Status)
 }
 
+func TestInvalidateInference_ClawsBackValidatorShares(t *testing.T) {
+	k, ms, ctx, mocks := setupInvalidateHarness(t)
+
+	params := types.DefaultParams()
+	k.SetParams(ctx, params)
+	require.NoError(t, setEffectiveEpoch(ctx, k, 1, mocks))
+
+	executorAddr := sample.AccAddress()
+	payerAddr := sample.AccAddress()
+	validatorOneAddr := sample.AccAddress()
+	validatorTwoAddr := sample.AccAddress()
+
+	actualCost := int64(101)
+	executorShare := int64(35)
+	validatorShare := int64(33)
+
+	executor := types.Participant{
+		Index:                        executorAddr,
+		Address:                      executorAddr,
+		Status:                       types.ParticipantStatus_ACTIVE,
+		ConsecutiveInvalidInferences: 0,
+		CurrentEpochStats:            &types.CurrentEpochStats{},
+		CoinBalance:                  1_000 + executorShare,
+	}
+	payer := types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}}
+	validatorOne := types.Participant{Index: validatorOneAddr, Address: validatorOneAddr, CurrentEpochStats: &types.CurrentEpochStats{}, CoinBalance: 2_000 + validatorShare}
+	validatorTwo := types.Participant{Index: validatorTwoAddr, Address: validatorTwoAddr, CurrentEpochStats: &types.CurrentEpochStats{}, CoinBalance: 3_000 + validatorShare}
+	k.SetParticipant(ctx, executor)
+	k.SetParticipant(ctx, payer)
+	k.SetParticipant(ctx, validatorOne)
+	k.SetParticipant(ctx, validatorTwo)
+	k.SetActiveParticipants(ctx, ParticipantsToActive(1, payer, executor, validatorOne, validatorTwo))
+
+	inferenceID := "refund-claws-back-validator-shares"
+	k.SetInference(ctx, types.Inference{
+		Index:           inferenceID,
+		InferenceId:     inferenceID,
+		ExecutedBy:      executorAddr,
+		RequestedBy:     payerAddr,
+		Status:          types.InferenceStatus_VALIDATED,
+		ActualCost:      actualCost,
+		ProposalDetails: &types.ProposalDetails{PolicyAddress: payerAddr},
+		EpochId:         1,
+		ValidatedBy:     []string{validatorOneAddr, validatorTwoAddr},
+	})
+
+	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mocks.BankKeeper.EXPECT().SendCoinsFromModuleToAccount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	mocks.CollateralKeeper.EXPECT().Slash(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := ms.InvalidateInference(ctx, &types.MsgInvalidateInference{Creator: payerAddr, InferenceId: inferenceID})
+	require.NoError(t, err)
+
+	updatedExecutor, ok := k.GetParticipant(ctx, executorAddr)
+	require.True(t, ok)
+	require.Equal(t, int64(1_000), updatedExecutor.CoinBalance)
+
+	updatedValidatorOne, ok := k.GetParticipant(ctx, validatorOneAddr)
+	require.True(t, ok)
+	require.Equal(t, int64(2_000), updatedValidatorOne.CoinBalance)
+
+	updatedValidatorTwo, ok := k.GetParticipant(ctx, validatorTwoAddr)
+	require.True(t, ok)
+	require.Equal(t, int64(3_000), updatedValidatorTwo.CoinBalance)
+
+	updatedInf, found := k.GetInference(ctx, inferenceID)
+	require.True(t, found)
+	require.Equal(t, types.InferenceStatus_INVALIDATED, updatedInf.Status)
+}
+
 func TestInvalidateInference_RefundsRequesterAndChargesExecutor_WithSlash(t *testing.T) {
 	k, ms, ctx, mocks := setupInvalidateHarness(t)
 

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -63,6 +63,15 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		return &types.MsgValidationResponse{}, nil
 	}
 
+	if inference.Status == types.InferenceStatus_INVALIDATED {
+		k.LogInfo("Inference already invalidated", types.Validation, "inference", inference)
+		return &types.MsgValidationResponse{}, nil
+	}
+	if inference.Status == types.InferenceStatus_STARTED {
+		k.LogError("Inference not finished", types.Validation, "status", inference.Status, "inference", inference)
+		return nil, types.ErrInferenceNotFinished
+	}
+
 	if !msg.Revalidation {
 		alreadyValidated, err := k.EpochGroupValidationEntry.Has(ctx, collections.Join3(inference.EpochId, msg.Creator, msg.InferenceId))
 		if err != nil {
@@ -74,14 +83,6 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		}
 	}
 
-	if inference.Status == types.InferenceStatus_INVALIDATED {
-		k.LogInfo("Inference already invalidated", types.Validation, "inference", inference)
-		return &types.MsgValidationResponse{}, nil
-	}
-	if inference.Status == types.InferenceStatus_STARTED {
-		k.LogError("Inference not finished", types.Validation, "status", inference.Status, "inference", inference)
-		return nil, types.ErrInferenceNotFinished
-	}
 	if !msg.Revalidation && inference.Status != types.InferenceStatus_FINISHED {
 		k.LogInfo("Ignoring validation for inference that is no longer finish-pending", types.Validation, "inferenceId", inference.InferenceId, "status", inference.Status)
 		return &types.MsgValidationResponse{}, nil

--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/group"
 	"github.com/productscience/inference/x/inference/calculations"
@@ -63,10 +64,13 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 	}
 
 	if !msg.Revalidation {
-		err := k.addInferenceToEpochGroupValidations(ctx, msg, inference)
+		alreadyValidated, err := k.EpochGroupValidationEntry.Has(ctx, collections.Join3(inference.EpochId, msg.Creator, msg.InferenceId))
 		if err != nil {
-			k.LogError("Failed to add inference to epoch group validations", types.Validation, "inferenceId", msg.InferenceId, "error", err)
 			return nil, err
+		}
+		if alreadyValidated {
+			k.LogInfo("Inference already validated", types.Validation, "inferenceId", msg.InferenceId)
+			return nil, types.ErrDuplicateValidation
 		}
 	}
 
@@ -78,6 +82,19 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		k.LogError("Inference not finished", types.Validation, "status", inference.Status, "inference", inference)
 		return nil, types.ErrInferenceNotFinished
 	}
+	if !msg.Revalidation && inference.Status != types.InferenceStatus_FINISHED {
+		k.LogInfo("Ignoring validation for inference that is no longer finish-pending", types.Validation, "inferenceId", inference.InferenceId, "status", inference.Status)
+		return &types.MsgValidationResponse{}, nil
+	}
+
+	if !msg.Revalidation {
+		err := k.addInferenceToEpochGroupValidations(ctx, msg, inference)
+		if err != nil {
+			k.LogError("Failed to add inference to epoch group validations", types.Validation, "inferenceId", msg.InferenceId, "error", err)
+			return nil, err
+		}
+	}
+
 	previousStatus := inference.Status
 
 	executor, found := k.GetParticipant(ctx, inference.ExecutedBy)
@@ -156,7 +173,9 @@ func (k msgServer) Validation(goCtx context.Context, msg *types.MsgValidation) (
 		shouldShare, information := k.inferenceIsBeforeClaimsSet(ctx, inference, currentEpochIndex)
 		k.LogInfo("Validation sharing decision", types.Validation, "inferenceId", inference.InferenceId, "validator", msg.Creator, "shouldShare", shouldShare, "information", information)
 		if shouldShare {
-			k.shareWorkWithValidators(ctx, inference, msg, &executor)
+			if err := k.shareWorkWithValidators(ctx, inference, msg, &executor); err != nil {
+				return nil, err
+			}
 			inference.ValidatedBy = append(inference.ValidatedBy, msg.Creator)
 		}
 		executor.ConsecutiveInvalidInferences = 0
@@ -432,10 +451,12 @@ func (k msgServer) inferenceIsBeforeClaimsSet(ctx context.Context, inference typ
 	}
 }
 
-func (k msgServer) shareWorkWithValidators(ctx sdk.Context, inference types.Inference, msg *types.MsgValidation, executor *types.Participant) {
+func (k msgServer) shareWorkWithValidators(ctx sdk.Context, inference types.Inference, msg *types.MsgValidation, executor *types.Participant) error {
 	originalWorkers := append([]string{inference.ExecutedBy}, inference.ValidatedBy...)
 	adjustments := calculations.ShareWork(originalWorkers, []string{msg.Creator}, inference.ActualCost)
-	k.validateAdjustments(adjustments, msg)
+	if err := k.validateAdjustments(adjustments, msg); err != nil {
+		return err
+	}
 	for _, adjustment := range adjustments {
 		// A note about the bookkeeping here:
 		// ShareWork will return negative adjustments for all existing shareholders, and a positive for the new (msg.Creator)
@@ -463,18 +484,21 @@ func (k msgServer) shareWorkWithValidators(ctx sdk.Context, inference types.Infe
 			err := k.SetParticipant(ctx, worker)
 			if err != nil {
 				k.LogError("Unable to update participant to share work", types.Validation, "worker", worker.Address)
+				return err
 			}
 		}
 	}
+	return nil
 }
 
-func (k msgServer) validateAdjustments(adjustments []calculations.Adjustment, msg *types.MsgValidation) {
+func (k msgServer) validateAdjustments(adjustments []calculations.Adjustment, msg *types.MsgValidation) error {
 	positiveAdjustmentTotal := int64(0)
 	negativeAdjustmentTotal := int64(0)
 	for _, adjustment := range adjustments {
 		if adjustment.ParticipantId == msg.Creator {
 			if adjustment.WorkAdjustment < 0 {
 				k.LogError("Validation adjustment for new validator cannot be negative", types.Validation, "adjustment", adjustment)
+				return errorsmod.Wrapf(types.ErrIllegalState, "validation adjustment for new validator %s cannot be negative: %d", msg.Creator, adjustment.WorkAdjustment)
 			} else {
 				// must be a positive number or zero
 				positiveAdjustmentTotal += adjustment.WorkAdjustment
@@ -482,6 +506,7 @@ func (k msgServer) validateAdjustments(adjustments []calculations.Adjustment, ms
 		} else {
 			if adjustment.WorkAdjustment > 0 {
 				k.LogError("Validation adjustment for existing validator cannot be positive", types.Validation, "adjustment", adjustment)
+				return errorsmod.Wrapf(types.ErrIllegalState, "validation adjustment for existing validator %s cannot be positive: %d", adjustment.ParticipantId, adjustment.WorkAdjustment)
 			} else {
 				// must be a negative number or zero
 				negativeAdjustmentTotal += -adjustment.WorkAdjustment
@@ -490,7 +515,9 @@ func (k msgServer) validateAdjustments(adjustments []calculations.Adjustment, ms
 	}
 	if positiveAdjustmentTotal != negativeAdjustmentTotal {
 		k.LogError("Validation adjustment totals do not match", types.Validation, "positiveAdjustmentTotal", positiveAdjustmentTotal, "negativeAdjustmentTotal", negativeAdjustmentTotal)
+		return errorsmod.Wrapf(types.ErrIllegalState, "validation adjustment totals do not match: positive %d negative %d", positiveAdjustmentTotal, negativeAdjustmentTotal)
 	}
+	return nil
 }
 
 func (k msgServer) addInferenceToEpochGroupValidations(ctx sdk.Context, msg *types.MsgValidation, inference types.Inference) error {

--- a/inference-chain/x/inference/keeper/msg_server_validation_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation_test.go
@@ -46,6 +46,45 @@ func TestMsgServer_Validation(t *testing.T) {
 	require.Equal(t, types.InferenceStatus_VALIDATED, inference.Status)
 }
 
+func TestMsgServer_Validation_IgnoresNonRevalidationAfterValidated(t *testing.T) {
+	inferenceHelper, k, ctx := NewMockInferenceHelper(t)
+	createParticipants(t, inferenceHelper.MessageServer, ctx)
+
+	model := &types.Model{Id: MODEL_ID, ValidationThreshold: &types.Decimal{Value: 85, Exponent: -2}}
+	k.SetModel(ctx, model)
+	StubModelSubgroup(t, ctx, k, inferenceHelper.Mocks, model)
+	addMembersToGroupData(k, ctx)
+
+	expected, err := inferenceHelper.StartInference("promptPayload", model.Id, time.Now().UnixNano(), calculations.DefaultMaxTokens)
+	require.NoError(t, err)
+	_, err = inferenceHelper.FinishInference()
+	require.NoError(t, err)
+	buildValidationCacheForTest(t, k, ctx)
+
+	_, err = inferenceHelper.MessageServer.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Validator,
+		ValueDecimal: types.DecimalFromFloat(0.9999),
+	})
+	require.NoError(t, err)
+
+	_, err = inferenceHelper.MessageServer.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Requester,
+		ValueDecimal: types.DecimalFromFloat(0.10),
+	})
+	require.NoError(t, err)
+
+	inference, found := k.GetInference(ctx, expected.InferenceId)
+	require.True(t, found)
+	require.Equal(t, types.InferenceStatus_VALIDATED, inference.Status)
+	require.Equal(t, []string{testutil.Validator}, inference.ValidatedBy)
+
+	has, err := k.EpochGroupValidationEntry.Has(ctx, collections.Join3(inference.EpochId, testutil.Requester, expected.InferenceId))
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
 func createParticipants(t *testing.T, ms types.MsgServer, ctx context.Context) {
 	mockRequester := NewMockAccount(testutil.Requester)
 	mockExecutor := NewMockAccount(testutil.Executor)
@@ -118,6 +157,42 @@ func TestMsgServer_Validation_Invalidate(t *testing.T) {
 	has, err := k.ActiveInvalidations.Has(ctx, collections.Join(sdk.MustAccAddressFromBech32(testutil.Validator), expected.InferenceId))
 	require.NoError(t, err)
 	require.True(t, has)
+}
+
+func TestMsgServer_Validation_IgnoresNonRevalidationWhileVoting(t *testing.T) {
+	inferenceHelper, k, ctx := NewMockInferenceHelper(t)
+	createParticipants(t, inferenceHelper.MessageServer, ctx)
+	model := &types.Model{Id: MODEL_ID, ValidationThreshold: &types.Decimal{Value: 85, Exponent: -2}}
+	k.SetModel(ctx, model)
+	StubModelSubgroup(t, ctx, k, inferenceHelper.Mocks, model)
+	addMembersToGroupData(k, ctx)
+
+	expected, err := inferenceHelper.StartInference("promptPayload", model.Id, time.Now().UnixNano(), calculations.DefaultMaxTokens)
+	require.NoError(t, err)
+	_, err = inferenceHelper.FinishInference()
+	require.NoError(t, err)
+	buildValidationCacheForTest(t, k, ctx)
+
+	inferenceHelper.Mocks.GroupKeeper.EXPECT().SubmitProposal(gomock.Any(), gomock.Any()).Return(&group.MsgSubmitProposalResponse{ProposalId: 1}, nil)
+	inferenceHelper.Mocks.GroupKeeper.EXPECT().SubmitProposal(gomock.Any(), gomock.Any()).Return(&group.MsgSubmitProposalResponse{ProposalId: 2}, nil)
+	_, err = inferenceHelper.MessageServer.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Validator,
+		ValueDecimal: types.DecimalFromFloat(0.10),
+	})
+	require.NoError(t, err)
+
+	_, err = inferenceHelper.MessageServer.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Requester,
+		ValueDecimal: types.DecimalFromFloat(0.9999),
+	})
+	require.NoError(t, err)
+
+	inference, found := k.GetInference(ctx, expected.InferenceId)
+	require.True(t, found)
+	require.Equal(t, types.InferenceStatus_VOTING, inference.Status)
+	require.Empty(t, inference.ValidatedBy)
 }
 
 func addMembersToGroupData(k keeper.Keeper, ctx sdk.Context) {

--- a/inference-chain/x/inference/keeper/msg_server_validation_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation_test.go
@@ -195,6 +195,31 @@ func TestMsgServer_Validation_IgnoresNonRevalidationWhileVoting(t *testing.T) {
 	require.Empty(t, inference.ValidatedBy)
 }
 
+func TestMsgServer_Validation_InvalidatedInferenceDoesNotRecordCredit(t *testing.T) {
+	inferenceHelper, k, ctx := NewMockInferenceHelper(t)
+	createParticipants(t, inferenceHelper.MessageServer, ctx)
+
+	expected, err := inferenceHelper.StartInference("promptPayload", MODEL_ID, time.Now().UnixNano(), calculations.DefaultMaxTokens)
+	require.NoError(t, err)
+	_, err = inferenceHelper.FinishInference()
+	require.NoError(t, err)
+
+	inference, found := k.GetInference(ctx, expected.InferenceId)
+	require.True(t, found)
+	inference.Status = types.InferenceStatus_INVALIDATED
+	require.NoError(t, k.SetInference(ctx, inference))
+
+	_, err = inferenceHelper.MessageServer.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Validator,
+		ValueDecimal: types.DecimalFromFloat(0.9999),
+	})
+	require.NoError(t, err)
+
+	_, found = k.GetEpochGroupValidations(ctx, testutil.Validator, inference.EpochId)
+	require.False(t, found, "already invalidated inferences must not grant validation credit")
+}
+
 func addMembersToGroupData(k keeper.Keeper, ctx sdk.Context) {
 	groupData, _ := k.GetEpochGroupData(ctx, 0, MODEL_ID)
 	groupData.ValidationWeights = []*types.ValidationWeight{


### PR DESCRIPTION
## Summary
This fixes a consensus-accounting bug where validator work shares credited by `MsgValidation{passed=true}` could remain claimable even if the same inference was later invalidated. In that case, only the executor was charged for the refund, while validator `CoinBalance` stayed intact and could still be claimed as `WorkCoins`, creating an unbacked, repeatable drain on the inference module account.

## Root Cause
`MsgValidation` allowed normal, non-revalidation validations to run after the inference had already left `FINISHED`, including `VALIDATED` and `VOTING`. Separately, `refundInvalidatedInference` debited only the executor by `ActualCost` and never reversed the `ShareWork` distribution already recorded for validators in `inference.ValidatedBy`.

## Fix
- Restrict normal `MsgValidation` processing to `FINISHED` inferences only. `INVALIDATED` remains idempotent, `STARTED` remains an error, and duplicate validations still return `ErrDuplicateValidation`.
- Prevent already `INVALIDATED` inferences from recording validation credit.
- On same-epoch invalidation, recompute the exact executor plus validator work distribution using the existing `ShareWork` algorithm and claw back every credited worker's share before settlement can make stale positive balances claimable.
- Preflight all validated-worker participant lookups before issuing the refund, then apply clawbacks in deterministic worker order.
- Make validation share accounting fail closed if `ShareWork` produces invalid or imbalanced adjustments.

## Why This Closes The Vulnerability
The exploit required two conditions: a normal validation could move a `VALIDATED` inference into invalidation voting, and invalidation left prior validator shares untouched. This PR removes the invalid state transition and also fixes the accounting invariant by reversing all previously assigned shares when an invalidation refund is issued.