### PR TITLE
Feat/deploy sentry overlays

### DIFF
--- a/deploy/join/README.md
+++ b/deploy/join/README.md
@@ -1,0 +1,205 @@
+# `deploy/join`
+
+Compose stack for joining the gonka network. The base `docker-compose.yml`
+is a single-node setup; optional overlays change the topology.
+
+## Setup A — single node (default)
+
+Standard validator with public P2P. Run as-is:
+
+```bash
+docker compose up -d
+```
+
+This is the original layout — unchanged. Optional overlays
+`docker-compose.mlnode.yml` and `docker-compose.postgres.yml` can be
+combined with the base in any order.
+
+## Setup B — validator behind sentry node(s)
+
+Setup B places the validator in a private P2P network behind one or
+more public-facing sentry relays. Recommended for production
+validators that should not expose their P2P address publicly.
+
+What changes vs Setup A:
+
+- Validator P2P (host port 5000) is no longer published.
+- Validator only peers with the configured sentry/sentries
+  (`pex=false`, fixed `persistent_peers`).
+- Validator's `seeds` and state-sync RPC URLs point to sentry, not to
+  public seed nodes. This prevents the validator's IP from being
+  exposed during init or state-sync.
+- Public chain-RPC/API/gRPC arriving at the proxy is forwarded to
+  sentry instead of node.
+
+Three overlays are provided: `docker-compose.sentry.yml`,
+`docker-compose.sentry-2.yml`, `docker-compose.sentry-3.yml`. They are
+additive — apply only as many as you need.
+
+### Bootstrap workflow (two-phase)
+
+The validator-sentry topology has a chicken-and-egg dependency: the
+validator's `persistent_peers` needs each sentry's node id, and each
+sentry's `private_peer_ids` (which prevents PEX leakage of the
+validator) needs the validator's node id. The fix is two `up -d`
+rounds — first to generate node-ids, second to apply the final P2P
+configuration.
+
+#### One sentry
+
+```bash
+# 1. First up: brings sentry + validator + tmkms up. Both nodes init,
+#    generate keys, advertise their node-ids. P2P configuration is
+#    intentionally incomplete on this round (peer ids are empty).
+source config.env
+docker compose -f docker-compose.yml -f docker-compose.sentry.yml up -d
+
+# 2. Read the generated node-ids.
+docker exec node    inferenced tendermint show-node-id   # -> VALIDATOR_ID
+docker exec sentry  inferenced tendermint show-node-id   # -> SENTRY_NODE_ID
+
+# 3. Append to config.env:
+#      export VALIDATOR_ID=<id-from-node>
+#      export SENTRY_NODE_ID=<id-from-sentry>
+#      export SENTRY_PERSISTENT_PEERS=${VALIDATOR_ID}@node:26656
+#      export NODE_PERSISTENT_PEERS=${SENTRY_NODE_ID}@sentry:26656
+#      export NODE_UNCONDITIONAL_PEER_IDS=${SENTRY_NODE_ID}
+
+# 4. Second up: Compose recreates containers with the new env. On
+#    container start init-docker.sh writes the final P2P settings into
+#    config.toml.
+source config.env
+docker compose -f docker-compose.yml -f docker-compose.sentry.yml up -d
+```
+
+#### Two/three sentries
+
+Same two-phase flow with the additional overlays:
+
+```bash
+# Phase 1
+docker compose -f docker-compose.yml \
+               -f docker-compose.sentry.yml \
+               -f docker-compose.sentry-2.yml \
+               -f docker-compose.sentry-3.yml up -d
+
+# Read all four node-ids
+docker exec node     inferenced tendermint show-node-id
+docker exec sentry   inferenced tendermint show-node-id
+docker exec sentry-2 inferenced tendermint show-node-id
+docker exec sentry-3 inferenced tendermint show-node-id
+
+# Fill config.env (example for three sentries)
+#   export VALIDATOR_ID=<id>
+#   export SENTRY_NODE_ID=<id>
+#   export SENTRY2_NODE_ID=<id>
+#   export SENTRY3_NODE_ID=<id>
+#   export SENTRY_PERSISTENT_PEERS=${VALIDATOR_ID}@node:26656
+#   export NODE_PERSISTENT_PEERS=${SENTRY_NODE_ID}@sentry:26656,${SENTRY2_NODE_ID}@sentry-2:26656,${SENTRY3_NODE_ID}@sentry-3:26656
+#   export NODE_UNCONDITIONAL_PEER_IDS=${SENTRY_NODE_ID},${SENTRY2_NODE_ID},${SENTRY3_NODE_ID}
+
+# Phase 2
+source config.env
+docker compose -f docker-compose.yml \
+               -f docker-compose.sentry.yml \
+               -f docker-compose.sentry-2.yml \
+               -f docker-compose.sentry-3.yml up -d
+```
+
+`config.env.template` lists every sentry-related variable with
+commented examples.
+
+### What each P2P setting does
+
+After phase 2, the validator and sentry config.toml files should
+contain the following (this is the security envelope of the topology):
+
+- **Validator:** `pex=false`, `persistent_peers=<all sentries>`,
+  `unconditional_peer_ids=<all sentry ids>`, `addr_book_strict=false`.
+  Validator only dials/accepts its sentries.
+- **Sentry:** `pex=true` (relay role), `persistent_peers=<validator>`,
+  `private_peer_ids=<validator id>`, `unconditional_peer_ids=<validator id>`,
+  `addr_book_strict=false`. **`private_peer_ids` is the critical one —
+  without it the sentry would advertise the validator's node-id to
+  the public network through PEX gossip.**
+
+### Tuning app.toml (pruning, fastnode, snapshots)
+
+`init-docker.sh` exposes an `APP_*` env prefix that mirrors the
+existing `CONFIG_*` prefix but writes into `app.toml`. Substitution
+rules:
+
+  `__`  →  `.`   (nested keys: `APP_state__sync__snapshot_interval`)
+  `_`   →  `-`   (kebab keys:   `APP_pruning_keep_recent`)
+
+The sentry overlay sets the validator-side defaults so it prunes
+aggressively and keeps fastnode on (fastnode delivers ~99% lag
+reduction during pruning). Override in config.env if needed:
+
+```bash
+# Validator app.toml defaults wired in docker-compose.sentry.yml:
+#   APP_pruning=custom
+#   APP_pruning_keep_recent=100
+#   APP_pruning_interval=1500
+#   APP_min_retain_blocks=0
+#   APP_iavl_disable_fastnode=false
+#
+# To deviate, set NODE_PRUNING / NODE_PRUNING_INTERVAL / etc in config.env.
+```
+
+The same APP_* mechanism works for any service that runs init-docker.sh
+— set the env var on a service and the value lands in its app.toml.
+
+### Adding a fourth+ sentry
+
+Copy `docker-compose.sentry-3.yml` to `docker-compose.sentry-4.yml`,
+replace `3 → 4` and `5003 → 5004` everywhere, add the corresponding
+`SENTRY4_*` block to `config.env`, and append
+`${SENTRY4_NODE_ID}@sentry-4:26656` to `NODE_PERSISTENT_PEERS`.
+
+### Verifying isolation
+
+After Setup B is up, the validator should be unreachable from outside
+on its P2P port and its `seeds` should point only at sentry:
+
+```bash
+# Validator P2P closed:
+nc -vz <host> 5000   # connection refused / closed
+
+# Sentry P2P open:
+nc -vz <host> 5001   # open
+
+# Validator seeds in config.toml point at sentry, not public seeds:
+docker exec node grep -E "^seeds|^persistent_peers" /root/.inference/config/config.toml
+# seeds = "...@sentry:26656"
+# persistent_peers = "...@sentry:26656"
+```
+
+### Public RPC routing through sentry
+
+Stopping sentry should make the public chain-RPC fail — this is the
+quickest way to confirm the proxy is forwarding to sentry rather than
+to the validator:
+
+```bash
+docker stop sentry
+curl -i http://<host>:8000/chain-rpc/status
+# expected: 502 Bad Gateway / connection refused
+docker start sentry
+```
+
+## Requirements
+
+- Docker Compose `>= 2.20` for the `ports: !reset []` directive used
+  in `docker-compose.sentry.yml` to detach the validator from its
+  public P2P port.
+
+## Image pinning
+
+By default both `node` and the sentry services use
+`ghcr.io/product-science/inferenced:0.2.11`. To pin a different
+version, export `INFERENCED_IMAGE` in `config.env`:
+
+```bash
+export INFERENCED_IMAGE=ghcr.io/product-science/inferenced:<tag>
+```

--- a/deploy/join/config.env.template
+++ b/deploy/join/config.env.template
@@ -30,3 +30,60 @@ export KEYRING_BACKEND=file
 # export POSTGRES_MIN_WAL_SIZE=4GB
 # export POSTGRES_MAX_WAL_SIZE=16GB
 # export POSTGRES_CHECKPOINT_TIMEOUT=15min
+
+# Sentry setup (optional). See docker-compose.sentry.yml and README.md
+# for the full bootstrap flow.
+#
+# Two-phase bootstrap: variables below are filled AFTER the first
+# `docker compose ... up -d`, when validator/sentries have generated
+# their node-ids. Then a second `up -d` recreates containers with the
+# final P2P configuration.
+#
+#   docker exec node     inferenced tendermint show-node-id   -> VALIDATOR_ID
+#   docker exec sentry   inferenced tendermint show-node-id   -> SENTRY_NODE_ID
+#   docker exec sentry-2 inferenced tendermint show-node-id   -> SENTRY2_NODE_ID  (if used)
+#   docker exec sentry-3 inferenced tendermint show-node-id   -> SENTRY3_NODE_ID  (if used)
+
+# --- single sentry ---
+# export VALIDATOR_ID=<id>
+# export SENTRY_NODE_ID=<id>
+# export SENTRY_P2P_PORT=5001
+# export SENTRY_P2P_EXTERNAL_ADDRESS=tcp://<HOST>:5001
+# export SENTRY_KEY_NAME=sentry
+# export SENTRY_PERSISTENT_PEERS=${VALIDATOR_ID}@node:26656
+# export NODE_PERSISTENT_PEERS=${SENTRY_NODE_ID}@sentry:26656
+# export NODE_UNCONDITIONAL_PEER_IDS=${SENTRY_NODE_ID}
+
+# --- two sentries ---
+# export SENTRY2_NODE_ID=<id>
+# export SENTRY2_P2P_PORT=5002
+# export SENTRY2_P2P_EXTERNAL_ADDRESS=tcp://<HOST>:5002
+# export SENTRY2_KEY_NAME=sentry-2
+# export NODE_PERSISTENT_PEERS=${SENTRY_NODE_ID}@sentry:26656,${SENTRY2_NODE_ID}@sentry-2:26656
+# export NODE_UNCONDITIONAL_PEER_IDS=${SENTRY_NODE_ID},${SENTRY2_NODE_ID}
+
+# --- three sentries ---
+# export SENTRY3_NODE_ID=<id>
+# export SENTRY3_P2P_PORT=5003
+# export SENTRY3_P2P_EXTERNAL_ADDRESS=tcp://<HOST>:5003
+# export SENTRY3_KEY_NAME=sentry-3
+# export NODE_PERSISTENT_PEERS=${SENTRY_NODE_ID}@sentry:26656,${SENTRY2_NODE_ID}@sentry-2:26656,${SENTRY3_NODE_ID}@sentry-3:26656
+# export NODE_UNCONDITIONAL_PEER_IDS=${SENTRY_NODE_ID},${SENTRY2_NODE_ID},${SENTRY3_NODE_ID}
+
+# Optional P2P tuning (defaults are fine for most deployments).
+# export NODE_MAX_INBOUND=2          # default tracks number of sentries (1/2/3)
+# export NODE_MAX_OUTBOUND=2
+# export SENTRY_MAX_INBOUND=100      # default 100
+# export SENTRY_MAX_OUTBOUND=50      # default 50
+
+# Optional pruning / state tuning for the validator (app.toml). Defaults
+# match a "fast pruning, small state" profile — enough recovery blocks
+# kept, fastnode ON. Override here only if you need different behaviour.
+# export NODE_PRUNING=custom
+# export NODE_PRUNING_KEEP_RECENT=100
+# export NODE_PRUNING_INTERVAL=1500
+# export NODE_MIN_RETAIN_BLOCKS=0
+# export NODE_IAVL_DISABLE_FASTNODE=false
+
+# Optional: pin the inferenced image used across node + sentries.
+# export INFERENCED_IMAGE=ghcr.io/product-science/inferenced:0.2.11

--- a/deploy/join/docker-compose.sentry-2.yml
+++ b/deploy/join/docker-compose.sentry-2.yml
@@ -1,0 +1,70 @@
+# Setup B+ — second sentry in front of the validator.
+#
+# Use:
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.sentry.yml \
+#                  -f docker-compose.sentry-2.yml up -d
+#
+# Bootstrap is two-phase (see README and docker-compose.sentry.yml header).
+#
+# Required in config.env when using this overlay:
+#   SENTRY2_NODE_ID                 - sentry-2's node id
+#   NODE_PERSISTENT_PEERS           - extended list including sentry-2, e.g.
+#       "${SENTRY_NODE_ID}@sentry:26656,${SENTRY2_NODE_ID}@sentry-2:26656"
+#   NODE_UNCONDITIONAL_PEER_IDS     - extended (e.g. "${SENTRY_NODE_ID},${SENTRY2_NODE_ID}")
+#
+# Optional:
+#   SENTRY2_KEY_NAME                - keyring entry (default: sentry-2)
+#   SENTRY2_P2P_PORT                - host port (default: 5002)
+#   SENTRY2_P2P_EXTERNAL_ADDRESS    - public P2P address (defaults to ${P2P_EXTERNAL_ADDRESS})
+
+services:
+  sentry-2:
+    image: ${INFERENCED_IMAGE:-ghcr.io/product-science/inferenced:0.2.11}
+    container_name: sentry-2
+    command: ["sh", "./init-docker.sh"]
+    volumes:
+      - .inference-sentry-2:/root/.inference
+      - ../../genesis/genesis.json:/root/genesis.json
+    environment:
+      # STATE_DIR omitted (see note in docker-compose.sentry.yml).
+      - KEY_NAME=${SENTRY2_KEY_NAME:-sentry-2}
+      - SEED_NODE_RPC_URL=${SEED_NODE_RPC_URL}
+      - SEED_NODE_P2P_URL=${SEED_NODE_P2P_URL}
+      - P2P_EXTERNAL_ADDRESS=${SENTRY2_P2P_EXTERNAL_ADDRESS:-${P2P_EXTERNAL_ADDRESS}}
+      - SYNC_WITH_SNAPSHOTS=${SYNC_WITH_SNAPSHOTS:-true}
+      - RPC_SERVER_URL_1=${RPC_SERVER_URL_1}
+      - RPC_SERVER_URL_2=${RPC_SERVER_URL_2}
+      - REST_API_ACTIVE=true
+      - INIT_ONLY=false
+      - IS_GENESIS=false
+      - SNAPSHOT_INTERVAL=${SNAPSHOT_INTERVAL:-1000}
+      - SNAPSHOT_KEEP_RECENT=${SNAPSHOT_KEEP_RECENT:-5}
+      - TRUSTED_BLOCK_PERIOD=${TRUSTED_BLOCK_PERIOD:-2000}
+      - CONFIG_p2p__allow_duplicate_ip=true
+      - CONFIG_p2p__handshake_timeout=30s
+      - CONFIG_p2p__dial_timeout=30s
+      # Same security stance as sentry: protect validator id from PEX
+      # leaks, give validator unconditional acceptance.
+      - CONFIG_p2p__pex=true
+      - CONFIG_p2p__addr_book_strict=false
+      - CONFIG_p2p__persistent_peers=${SENTRY_PERSISTENT_PEERS:-}
+      - CONFIG_p2p__private_peer_ids=${VALIDATOR_ID:-}
+      - CONFIG_p2p__unconditional_peer_ids=${VALIDATOR_ID:-}
+      - CONFIG_p2p__max_num_inbound_peers=${SENTRY_MAX_INBOUND:-100}
+      - CONFIG_p2p__max_num_outbound_peers=${SENTRY_MAX_OUTBOUND:-50}
+    ports:
+      - "${SENTRY2_P2P_PORT:-5002}:26656"
+    restart: always
+
+  # persistent_peers stays in NODE_PERSISTENT_PEERS (config.env). This
+  # overlay adds the second sentry service, routes the second state-sync
+  # upstream to sentry-2, and bumps validator's peer limits to 2.
+  node:
+    environment:
+      - RPC_SERVER_URL_2=http://sentry-2:26657
+      - CONFIG_p2p__max_num_inbound_peers=${NODE_MAX_INBOUND:-2}
+      - CONFIG_p2p__max_num_outbound_peers=${NODE_MAX_OUTBOUND:-2}
+    depends_on:
+      sentry-2:
+        condition: service_started

--- a/deploy/join/docker-compose.sentry-3.yml
+++ b/deploy/join/docker-compose.sentry-3.yml
@@ -1,0 +1,68 @@
+# Setup B++ — third sentry in front of the validator.
+#
+# Use:
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.sentry.yml \
+#                  -f docker-compose.sentry-2.yml \
+#                  -f docker-compose.sentry-3.yml up -d
+#
+# Bootstrap is two-phase (see README and docker-compose.sentry.yml header).
+#
+# Required in config.env:
+#   SENTRY3_NODE_ID                 - sentry-3's node id
+#   NODE_PERSISTENT_PEERS           - extended list including sentry-3
+#   NODE_UNCONDITIONAL_PEER_IDS     - extended list including sentry-3 id
+#
+# Optional:
+#   SENTRY3_KEY_NAME                - keyring entry (default: sentry-3)
+#   SENTRY3_P2P_PORT                - host port (default: 5003)
+#   SENTRY3_P2P_EXTERNAL_ADDRESS    - public P2P address
+
+services:
+  sentry-3:
+    image: ${INFERENCED_IMAGE:-ghcr.io/product-science/inferenced:0.2.11}
+    container_name: sentry-3
+    command: ["sh", "./init-docker.sh"]
+    volumes:
+      - .inference-sentry-3:/root/.inference
+      - ../../genesis/genesis.json:/root/genesis.json
+    environment:
+      # STATE_DIR omitted (see note in docker-compose.sentry.yml).
+      - KEY_NAME=${SENTRY3_KEY_NAME:-sentry-3}
+      - SEED_NODE_RPC_URL=${SEED_NODE_RPC_URL}
+      - SEED_NODE_P2P_URL=${SEED_NODE_P2P_URL}
+      - P2P_EXTERNAL_ADDRESS=${SENTRY3_P2P_EXTERNAL_ADDRESS:-${P2P_EXTERNAL_ADDRESS}}
+      - SYNC_WITH_SNAPSHOTS=${SYNC_WITH_SNAPSHOTS:-true}
+      - RPC_SERVER_URL_1=${RPC_SERVER_URL_1}
+      - RPC_SERVER_URL_2=${RPC_SERVER_URL_2}
+      - REST_API_ACTIVE=true
+      - INIT_ONLY=false
+      - IS_GENESIS=false
+      - SNAPSHOT_INTERVAL=${SNAPSHOT_INTERVAL:-1000}
+      - SNAPSHOT_KEEP_RECENT=${SNAPSHOT_KEEP_RECENT:-5}
+      - TRUSTED_BLOCK_PERIOD=${TRUSTED_BLOCK_PERIOD:-2000}
+      - CONFIG_p2p__allow_duplicate_ip=true
+      - CONFIG_p2p__handshake_timeout=30s
+      - CONFIG_p2p__dial_timeout=30s
+      - CONFIG_p2p__pex=true
+      - CONFIG_p2p__addr_book_strict=false
+      - CONFIG_p2p__persistent_peers=${SENTRY_PERSISTENT_PEERS:-}
+      - CONFIG_p2p__private_peer_ids=${VALIDATOR_ID:-}
+      - CONFIG_p2p__unconditional_peer_ids=${VALIDATOR_ID:-}
+      - CONFIG_p2p__max_num_inbound_peers=${SENTRY_MAX_INBOUND:-100}
+      - CONFIG_p2p__max_num_outbound_peers=${SENTRY_MAX_OUTBOUND:-50}
+    ports:
+      - "${SENTRY3_P2P_PORT:-5003}:26656"
+    restart: always
+
+  # Third sentry adds the service, the dependency, and bumps validator's
+  # peer limits to 3. State-sync upstreams (RPC_SERVER_URL_1/2) are
+  # already pointed at sentry/sentry-2 by previous overlays — no third
+  # state-sync upstream is needed.
+  node:
+    environment:
+      - CONFIG_p2p__max_num_inbound_peers=${NODE_MAX_INBOUND:-3}
+      - CONFIG_p2p__max_num_outbound_peers=${NODE_MAX_OUTBOUND:-3}
+    depends_on:
+      sentry-3:
+        condition: service_started

--- a/deploy/join/docker-compose.sentry.yml
+++ b/deploy/join/docker-compose.sentry.yml
@@ -1,0 +1,157 @@
+# Setup B — sentry as a public P2P relay in front of the validator.
+#
+# Use:
+#   docker compose -f docker-compose.yml -f docker-compose.sentry.yml up -d
+#
+# Bootstrap is two-phase (see README): first `up -d` lets every node
+# generate its key and node-id with empty peer settings; the operator
+# then collects all node-ids, fills the variables below in config.env,
+# and runs `up -d` again to apply the final P2P configuration.
+#
+# Required in config.env when using this overlay (filled in phase 2):
+#   VALIDATOR_ID                    - validator's node id
+#                                     (docker exec node inferenced tendermint show-node-id)
+#   SENTRY_NODE_ID                  - sentry's node id
+#                                     (docker exec sentry inferenced tendermint show-node-id)
+#   SENTRY_PERSISTENT_PEERS         - sentry's persistent_peers
+#                                     (e.g. "${VALIDATOR_ID}@node:26656" — `node` is the
+#                                     upstream service name for the validator)
+#   NODE_PERSISTENT_PEERS           - validator's persistent_peers
+#                                     (e.g. "${SENTRY_NODE_ID}@sentry:26656")
+#   NODE_UNCONDITIONAL_PEER_IDS     - validator unconditional peers (e.g. "${SENTRY_NODE_ID}")
+#
+# Optional:
+#   SENTRY_KEY_NAME                 - keyring entry name (default: sentry)
+#   SENTRY_P2P_PORT                 - host port for sentry P2P (default: 5001)
+#   SENTRY_P2P_EXTERNAL_ADDRESS     - public P2P address advertised by sentry
+#                                     (defaults to ${P2P_EXTERNAL_ADDRESS})
+#   SENTRY_MAX_INBOUND/OUTBOUND     - peer-count tuning (defaults 100/50)
+#   NODE_MAX_INBOUND/OUTBOUND       - validator peer-count limit (defaults to N sentries)
+#   NODE_PRUNING / NODE_PRUNING_*   - app.toml pruning profile (see README)
+#   NODE_IAVL_DISABLE_FASTNODE      - default false (fastnode ON for fast pruning)
+
+services:
+  sentry:
+    image: ${INFERENCED_IMAGE:-ghcr.io/product-science/inferenced:0.2.11}
+    container_name: sentry
+    command: ["sh", "./init-docker.sh"]
+    volumes:
+      - .inference-sentry:/root/.inference
+      - ../../genesis/genesis.json:/root/genesis.json
+    environment:
+      # STATE_DIR not set on purpose: upstream init-docker.sh runs
+      # `inferenced init` without `--home`, so it always writes to the
+      # default /root/.inference. Per-sentry isolation is achieved via
+      # the volume bind (.inference-sentry vs .inference-sentry-2/3).
+      - KEY_NAME=${SENTRY_KEY_NAME:-sentry}
+      # Sentry talks to the public network — it is the relay.
+      - SEED_NODE_RPC_URL=${SEED_NODE_RPC_URL}
+      - SEED_NODE_P2P_URL=${SEED_NODE_P2P_URL}
+      - P2P_EXTERNAL_ADDRESS=${SENTRY_P2P_EXTERNAL_ADDRESS:-${P2P_EXTERNAL_ADDRESS}}
+      - SYNC_WITH_SNAPSHOTS=${SYNC_WITH_SNAPSHOTS:-true}
+      - RPC_SERVER_URL_1=${RPC_SERVER_URL_1}
+      - RPC_SERVER_URL_2=${RPC_SERVER_URL_2}
+      - REST_API_ACTIVE=true
+      - INIT_ONLY=false
+      - IS_GENESIS=false
+      # GENESIS_SEEDS not passed: it is only used when IS_GENESIS=true
+      # (init-docker.sh line 49,199). Setting it here would be dead config.
+      - SNAPSHOT_INTERVAL=${SNAPSHOT_INTERVAL:-1000}
+      - SNAPSHOT_KEEP_RECENT=${SNAPSHOT_KEEP_RECENT:-5}
+      - TRUSTED_BLOCK_PERIOD=${TRUSTED_BLOCK_PERIOD:-2000}
+      # P2P tuning (carried over from base, kept here for clarity).
+      - CONFIG_p2p__allow_duplicate_ip=true
+      - CONFIG_p2p__handshake_timeout=30s
+      - CONFIG_p2p__dial_timeout=30s
+      # Sentry-specific P2P configuration.
+      # SENTRY_PERSISTENT_PEERS / VALIDATOR_ID are filled in config.env
+      # AFTER the first up -d (when validator's node-id is known) — the
+      # second up -d picks them up via init-docker.sh:230-236 on container
+      # restart. See README for the two-phase bootstrap workflow.
+      - CONFIG_p2p__pex=true
+      - CONFIG_p2p__addr_book_strict=false
+      - CONFIG_p2p__persistent_peers=${SENTRY_PERSISTENT_PEERS:-}
+      # private_peer_ids prevents sentry from leaking validator's node-id
+      # to the public network through PEX gossip. CRITICAL for the sentry
+      # topology — without it the public mesh learns the validator id even
+      # though its port is closed.
+      - CONFIG_p2p__private_peer_ids=${VALIDATOR_ID:-}
+      - CONFIG_p2p__unconditional_peer_ids=${VALIDATOR_ID:-}
+      - CONFIG_p2p__max_num_inbound_peers=${SENTRY_MAX_INBOUND:-100}
+      - CONFIG_p2p__max_num_outbound_peers=${SENTRY_MAX_OUTBOUND:-50}
+    ports:
+      - "${SENTRY_P2P_PORT:-5001}:26656"
+    restart: always
+
+  # Validator goes private behind sentry.
+  #
+  # 1) `ports: !reset []` removes the public 5000:26656 mapping from the
+  #    base compose. Requires Docker Compose >= 2.20.
+  # 2) persistent_peers comes from NODE_PERSISTENT_PEERS in config.env;
+  #    `:-` keeps Compose quiet on the bootstrap step where the variable
+  #    is not set yet.
+  # 3) SEED_NODE_*/RPC_SERVER_URL_* are redirected to sentry so the
+  #    validator never contacts public seed nodes during init or
+  #    state-sync (init-docker.sh lines 182-195).
+  # 4) `tmkms` is re-declared in long form: Compose merge replaces the
+  #    short list from base wholesale, so the dependency must be stated
+  #    here explicitly.
+  node:
+    ports: !reset []
+    environment:
+      # Discovery and state-sync upstreams point at sentry — validator
+      # never contacts public seed nodes during init or state-sync.
+      - SEED_NODE_RPC_URL=http://sentry:26657
+      - SEED_NODE_P2P_URL=tcp://sentry:26656
+      - RPC_SERVER_URL_1=http://sentry:26657
+      - RPC_SERVER_URL_2=http://sentry:26657
+      # GENESIS_SEEDS explicitly emptied — defence in depth. The variable
+      # is dead for non-genesis nodes (init-docker.sh:49,199), but
+      # clearing it removes any chance of a future regression that would
+      # let the validator fall back to public seeds.
+      - GENESIS_SEEDS=
+      # Validator stays in private mode. NODE_PERSISTENT_PEERS and
+      # NODE_UNCONDITIONAL_PEER_IDS are filled in config.env AFTER the
+      # first up -d (sentries' node-ids are known by then).
+      - CONFIG_p2p__pex=false
+      - CONFIG_p2p__addr_book_strict=false
+      - CONFIG_p2p__persistent_peers=${NODE_PERSISTENT_PEERS:-}
+      - CONFIG_p2p__unconditional_peer_ids=${NODE_UNCONDITIONAL_PEER_IDS:-}
+      # Tighten peer limits so the validator only accepts/dials its
+      # configured sentries. Default 1 — bump to 2/3 when bringing up
+      # sentry-2 / sentry-3 overlays (handled in those overlays).
+      - CONFIG_p2p__max_num_inbound_peers=${NODE_MAX_INBOUND:-1}
+      - CONFIG_p2p__max_num_outbound_peers=${NODE_MAX_OUTBOUND:-1}
+      # app.toml tuning via APP_* prefix (handled by init-docker.sh).
+      # Substitution rules: __ -> . (nested keys), _ -> - (kebab keys).
+      # Defaults below are conservative for a sentry-fronted validator —
+      # frequent pruning, only the most recent state kept, fastnode ON
+      # for fast pruning operations (must override init-docker.sh's
+      # static iavl-disable-fastnode=true).
+      - APP_pruning=${NODE_PRUNING:-custom}
+      - APP_pruning_keep_recent=${NODE_PRUNING_KEEP_RECENT:-100}
+      - APP_pruning_interval=${NODE_PRUNING_INTERVAL:-1500}
+      - APP_min_retain_blocks=${NODE_MIN_RETAIN_BLOCKS:-0}
+      - APP_iavl_disable_fastnode=${NODE_IAVL_DISABLE_FASTNODE:-false}
+    depends_on:
+      tmkms:
+        condition: service_started
+      sentry:
+        condition: service_started
+
+  api:
+    environment:
+      - DAPI_CHAIN_NODE__URL=http://sentry:26657
+      - DAPI_CHAIN_NODE__P2P_URL=tcp://sentry:26656
+    depends_on:
+      - sentry
+
+  # Public chain-RPC/API/gRPC routed through sentry.
+  # proxy/entrypoint.sh:12 already supports overriding the upstream
+  # service via NODE_SERVICE_NAME (default: node).
+  proxy:
+    environment:
+      - NODE_SERVICE_NAME=sentry
+    depends_on:
+      sentry:
+        condition: service_started

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   node:
     container_name: node
-    image: ghcr.io/product-science/inferenced:0.2.11
+    image: ${INFERENCED_IMAGE:-ghcr.io/product-science/inferenced:0.2.11}
     command: ["sh", "./init-docker.sh"]
     volumes:
       - .inference:/root/.inference

--- a/inference-chain/scripts/init-docker.sh
+++ b/inference-chain/scripts/init-docker.sh
@@ -235,6 +235,25 @@ kv app iavl-disable-fastnode true
   kv config "$key" "$raw_val" --skip-validate
 done
 
+# APP_* environment overrides -------------------------------------------------
+# Mirror of the CONFIG_* block above, but for app.toml. This lets operators
+# tune pruning, iavl-disable-fastnode, snapshot intervals etc through
+# compose env vars instead of post-init shell pokes. Substitutions:
+#   __  -> .   (nested keys, e.g. APP_state__sync__snapshot_interval)
+#   _   -> -   (kebab-case keys, e.g. APP_pruning_keep_recent)
+# Applied in this order, so nested kebab keys like state-sync.snapshot-interval
+# survive: APP_state__sync__snapshot_interval -> state.sync.snapshot-interval.
+# These overrides run AFTER the hardcoded `kv app` lines above, so an env
+# value wins over the static defaults (e.g. iavl-disable-fastnode).
+(
+  env | grep '^APP_' || true
+) | while IFS='=' read -r raw_key raw_val; do
+  key=${raw_key#APP_}
+  key=${key//__/.}
+  key=${key//_/-}
+  kv app "$key" "$raw_val" --skip-validate
+done
+
 update_configs
 
 ###############################################################################


### PR DESCRIPTION
feat(deploy/join): sentry overlay architecture for validator isolation
                                                
Adds stackable docker-compose overlays (sentry, sentry-2, sentry-3)         
implementing Tendermint sentry pattern. Validator runs private, public      
P2P/RPC routed through sentry nodes with private_peer_ids hardening.        

Also: APP_* env handler in init-docker.sh (mirrors CONFIG_*), bootstrap     
docs, fix for SENTRY_PERSISTENT_PEERS service name.