### PR TITLE
Pixelplex/versiond router multi instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build versiond-build-docker testapp-server-build-docker
+.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release versiond-router-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build versiond-build-docker versiond-router-build-docker testapp-server-build-docker
 
 VERSION ?= $(shell git describe --always)
 DEVSHARD_VERSION ?= dev
@@ -14,7 +14,7 @@ endif
 
 all: build-docker
 
-build-docker: api-build-docker node-build-docker mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker versiond-build-docker testapp-server-build-docker
+build-docker: api-build-docker node-build-docker mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker versiond-build-docker versiond-router-build-docker testapp-server-build-docker
 
 api-build-docker:
 	@make -C decentralized-api build-docker SET_LATEST=1
@@ -41,11 +41,14 @@ versiond-build-docker:
 	@echo "Building versiond docker image..."
 	@docker build -t versiond:latest -f versioned/Dockerfile versioned
 
+versiond-router-build-docker:
+	@make -C versiond-router build-docker SET_LATEST=1
+
 testapp-server-build-docker:
 	@echo "Building testapp-server docker image..."
 	@docker build -t testapp-server:latest -f local-test-net/Dockerfile.testapp-server .
 
-release: decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release
+release: decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release versiond-router-release
 	@git tag $(TAG_NAME)
 	@git push origin $(TAG_NAME)
 
@@ -81,6 +84,10 @@ versiond-release:
 	@echo "Releasing versiond..."
 	@make -C versioned release
 	@make -C versioned docker-push
+
+versiond-router-release:
+	@echo "Releasing versiond-router..."
+	@make -C versiond-router release
 
 check-docker:
 	@docker info > /dev/null 2>&1 || (echo "Docker Desktop is not running. Please start Docker Desktop." && exit 1)

--- a/deploy/join/docker-compose.versiond.yml
+++ b/deploy/join/docker-compose.versiond.yml
@@ -1,0 +1,81 @@
+# Multi-versiond + sticky router overlay for `deploy/join`.
+#
+# Adds devshard-postgres, a second versiond instance (versiond2), and the
+# versiond-router (nginx, sticky hash on escrowID) in front of both. The
+# router image is built locally from `versiond-router/`.
+#
+# Override and force the active devshardd binary via the
+# `./devshards-override/devshardd` mount; uncomment the v0.2.12 lines and
+# comment out v1 if pinning to a different upstream version tag.
+#
+# x-versiond anchor holds everything shared between versiond and versiond2;
+# only container_name and volumes differ (per-instance data directory).
+
+x-versiond: &versiond
+  image: ghcr.io/product-science/versiond:0.2.12
+  environment:
+    - VERSIOND_ORACLE_URL=http://api:9100/versions
+    - VERSIOND_BINARY_NAME=devshardd
+    #- VERSIOND_FORCE=v1
+    #- VERSIOND_OVERRIDE_v1=/opt/overrides/devshardd
+    - NODE_MANAGER_ADDR=api:9400
+    - NODE_HOST=node
+    - KEY_NAME=${KEY_NAME}
+    - ACCOUNT_PUBKEY=${ACCOUNT_PUBKEY}
+    - KEYRING_BACKEND=${KEYRING_BACKEND:-file}
+    - KEYRING_PASSWORD=${KEYRING_PASSWORD}
+    - KEYRING_DIR=/root/.inference
+    - PGHOST=devshard-postgres
+    - PGDATABASE=devshardd
+    - PGUSER=devshardd
+    - PGPASSWORD=devshardd
+  depends_on:
+    - api
+    - devshard-postgres
+  restart: always
+
+services:
+  devshard-postgres:
+    container_name: devshard-postgres
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: devshardd
+      POSTGRES_USER: devshardd
+      POSTGRES_PASSWORD: devshardd
+    restart: always
+
+  versiond:
+    <<: *versiond
+    container_name: versiond
+    volumes:
+      - .inference:/root/.inference:ro
+      - ./devshards/bin:/opt/versiond/bin
+      - ./devshards/data:/opt/versiond/data
+      #- ./devshards-override:/opt/overrides:ro
+
+  versiond2:
+    <<: *versiond
+    container_name: versiond2
+    volumes:
+      - .inference:/root/.inference:ro
+      - ./devshards/bin:/opt/versiond/bin
+      - ./devshards2/data:/opt/versiond/data
+      #- ./devshards-override:/opt/overrides:ro
+
+  versiond-router:
+    container_name: versiond-router
+    image: ghcr.io/product-science/versiond-router:0.2.12
+    environment:
+      - VERSIOND_HOSTS=versiond versiond2
+      - VERSIOND_PORT=8080
+    depends_on:
+      - versiond
+      - versiond2
+    restart: always
+
+  # Override proxy env so /devshard/* upstream resolves to the sticky router
+  # instead of the single canonical versiond. Uses the proxy image from base.
+  proxy:
+    environment:
+      - VERSIOND_SERVICE_NAME=versiond-router
+      - VERSIOND_PORT=8080

--- a/deploy/join/docker-compose.versiond.yml
+++ b/deploy/join/docker-compose.versiond.yml
@@ -1,8 +1,10 @@
 # Multi-versiond + sticky router overlay for `deploy/join`.
 #
 # Adds devshard-postgres, a second versiond instance (versiond2), and the
-# versiond-router (nginx, sticky hash on escrowID) in front of both. The
-# router image is built locally from `versiond-router/`.
+# versiond-router (nginx, sticky hash on escrowID) in front of both. Pinned
+# to the published image `ghcr.io/product-science/versiond-router:0.2.12`;
+# build it from `versiond-router/` via `make versiond-router-release` and
+# push to ghcr.io before bumping the tag.
 #
 # Override and force the active devshardd binary via the
 # `./devshards-override/devshardd` mount; uncomment the v0.2.12 lines and
@@ -79,3 +81,4 @@ services:
     environment:
       - VERSIOND_SERVICE_NAME=versiond-router
       - VERSIOND_PORT=8080
+      - PUBLIC_DEVSHARD_VERSION=${PUBLIC_DEVSHARD_VERSION:-v0.2.12}

--- a/local-test-net/docker-compose.devshard-router-proxy.yml
+++ b/local-test-net/docker-compose.devshard-router-proxy.yml
@@ -1,0 +1,12 @@
+# Overlay for genesis only: tells genesis-proxy to route /devshard/ to
+# versiond-router (the sticky LB) instead of the single canonical versiond.
+# Applied via additionalDockerFilesByKeyName for GENESIS_KEY_NAME only.
+#
+# docker-compose.versiond.yml already brings up versiond + versiond-2 +
+# versiond-3 + versiond-router on genesis; this file wires genesis-proxy
+# to the router so all /devshard/<version>/sessions/<id>/... requests are
+# consistently hashed by escrowID across the three instances.
+services:
+  proxy:
+    environment:
+      VERSIOND_SERVICE_NAME: versiond-router

--- a/local-test-net/docker-compose.versiond.yml
+++ b/local-test-net/docker-compose.versiond.yml
@@ -118,11 +118,8 @@ services:
     networks:
       - chain-public
 
-# When this file is layered on top of docker-compose-base.yml (testermint flow),
-# base owns the chain-public definition. For standalone use (e.g. layering
-# only versiond services on a base genesis stack already up), declare external
-# so compose doesn't try to create a new network.
+# Compose creates chain-public if absent, reuses it if it already exists (e.g.
+# when layered on top of a running base stack). No external: true needed.
 networks:
   chain-public:
-    external: true
     name: chain-public

--- a/local-test-net/docker-compose.versiond.yml
+++ b/local-test-net/docker-compose.versiond.yml
@@ -24,7 +24,7 @@
 x-versiond: &versiond
   image: versiond:latest
   build:
-    context: ./versioned
+    context: ../versioned
     dockerfile: Dockerfile
   environment:
     VERSIOND_ORACLE_URL: http://${KEY_NAME}-api:9100/versions
@@ -86,7 +86,7 @@ services:
   versiond-router:
     image: ghcr.io/product-science/versiond-router:latest
     build:
-      context: ./versiond-router
+      context: ../versiond-router
       dockerfile: Dockerfile
     container_name: ${KEY_NAME}-versiond-router
     environment:

--- a/local-test-net/docker-compose.versiond.yml
+++ b/local-test-net/docker-compose.versiond.yml
@@ -1,41 +1,60 @@
-services:
-  versiond:
-    container_name: ${KEY_NAME}-versiond
-    image: versiond:latest
-    build:
-      context: ./versioned
-      dockerfile: Dockerfile
-    environment:
-      VERSIOND_ORACLE_URL: http://${KEY_NAME}-api:9100/versions
-      VERSIOND_POLL_INTERVAL: "5s"
-      VERSIOND_BIN_DIR: /opt/versiond/bin
-      VERSIOND_DATA_DIR: /opt/versiond/data
-      # Default binary is testapp (VersiondTests). DevshardStandaloneTests
-      # exports VERSIOND_BINARY_NAME=devshardd, VERSIOND_FORCE=v0.2.11,
-      # VERSIOND_OVERRIDE_v0_2_11=/opt/overrides/devshardd before bringing up
-      # the cluster, switching this versiond to run the locally-built
-      # devshardd binary instead.
-      VERSIOND_BINARY_NAME: ${VERSIOND_BINARY_NAME:-testapp}
-      VERSIOND_FORCE: ${VERSIOND_FORCE:-}
-      VERSIOND_OVERRIDE_v0_2_11: ${VERSIOND_OVERRIDE_v0_2_11:-}
-      NODE_MANAGER_ADDR: ${NODE_MANAGER_ADDR:-${KEY_NAME}-api:9400}
+# Versiond compose: canonical versiond + 2 sticky-routable extras pinned to
+# the same identity (3 versiond total), plus an nginx-based sticky router in
+# front of all three, plus the test fixtures (testapp-server,
+# devshardd-artifact-server).
+#
+# Paths are relative to local-test-net/. Run with:
+#   KEY_NAME=genesis VERSIOND_SIGNER_KEY_NAME=genesis \
+#   VERSIOND_BINARY_NAME=devshardd VERSIOND_FORCE=v0.2.11 \
+#   VERSIOND_OVERRIDE_v0_2_11=/opt/overrides/devshardd \
+#   KEYRING_BACKEND=test \
+#   docker compose -p genesis -f docker-compose.versiond.yml up -d
+#
+# Layout:
+#   versiond            – canonical (KEY_NAME-versiond), kept for compatibility
+#                         with DevshardStandaloneTests / VersiondTests.
+#   versiond-2/3        – two extras with the same env body via YAML anchor,
+#                         only container_name differs; for multi-host testing.
+#   versiond-router     – nginx, hash $sticky_key consistent on escrowID.
+#                         Defaults VERSIOND_HOSTS to all three versiond hosts;
+#                         override at run-time if you want a different fan-out.
+#   testapp-server      – test fixture (VersiondTests).
+#   devshardd-artifact-server – test fixture (state-driven download path).
+
+x-versiond: &versiond
+  image: versiond:latest
+  build:
+    context: ./versioned
+    dockerfile: Dockerfile
+  environment:
+    VERSIOND_ORACLE_URL: http://${KEY_NAME}-api:9100/versions
+    VERSIOND_POLL_INTERVAL: "5s"
+    VERSIOND_BIN_DIR: /opt/versiond/bin
+    VERSIOND_DATA_DIR: /opt/versiond/data
+    # Default binary is testapp (VersiondTests). DevshardStandaloneTests
+    # exports VERSIOND_BINARY_NAME=devshardd, VERSIOND_FORCE=v0.2.11,
+    # VERSIOND_OVERRIDE_v0_2_11=/opt/overrides/devshardd before bringing up
+    # the cluster, switching this versiond to run the locally-built
+    # devshardd binary instead.
+    VERSIOND_BINARY_NAME: ${VERSIOND_BINARY_NAME:-testapp}
+    VERSIOND_FORCE: ${VERSIOND_FORCE:-}
+    VERSIOND_OVERRIDE_v0_2_11: ${VERSIOND_OVERRIDE_v0_2_11:-}
+    NODE_MANAGER_ADDR: ${NODE_MANAGER_ADDR:-${KEY_NAME}-api:9400}
       # Inherited by child binaries (devshardd reads these). Same env
       # surface dapi's init-docker.sh uses.
-      KEY_NAME: ${VERSIOND_SIGNER_KEY_NAME}
-      ACCOUNT_PUBKEY: ${ACCOUNT_PUBKEY:-}
-      NODE_HOST: ${KEY_NAME}-node
-      KEYRING_BACKEND: ${KEYRING_BACKEND:-file}
-      KEYRING_PASSWORD: ${KEYRING_PASSWORD:-}
-      KEYRING_DIR: ${KEYRING_DIR:-/root/.inference}
-      DEVSHARD_VALIDATION_RETRY_INTERVAL: ${DEVSHARD_VALIDATION_RETRY_INTERVAL:-}
-      DEVSHARD_VALIDATION_LEASE_TTL: ${DEVSHARD_VALIDATION_LEASE_TTL:-}
+    KEY_NAME: ${VERSIOND_SIGNER_KEY_NAME}
+    ACCOUNT_PUBKEY: ${ACCOUNT_PUBKEY:-}
+    NODE_HOST: ${KEY_NAME}-node
+    KEYRING_BACKEND: ${KEYRING_BACKEND:-file}
+    KEYRING_PASSWORD: ${KEYRING_PASSWORD:-}
+    KEYRING_DIR: ${KEYRING_DIR:-/root/.inference}
       # PostgreSQL connection for the payload store (inherited by devshardd child).
       # Points at the shared devshard-postgres container started by genesis.
-      PGHOST: devshard-postgres
-      PGDATABASE: devshardd
-      PGUSER: devshardd
-      PGPASSWORD: devshardd
-    volumes:
+    PGHOST: devshard-postgres
+    PGDATABASE: devshardd
+    PGUSER: devshardd
+    PGPASSWORD: devshardd
+  volumes:
       # Locally-built devshardd binary, served as version "v0.2.11" via the
       # VERSIOND_OVERRIDE_v0_2_11 mechanism. Always mounted; inert if
       # VERSIOND_FORCE is empty (versiond never references it).
@@ -45,11 +64,36 @@ services:
       # Same keyring dapi uses, read-only. Devshardd signs devshard
       # protocol messages with the same identity dapi registered on chain.
       - ./prod-local/${KEY_NAME}:/root/.inference:ro
+  networks:
+    - chain-public
+  dns:
+    - 172.25.0.10
+    - 127.0.0.11
+
+services:
+  versiond:
+    <<: *versiond
+    container_name: ${KEY_NAME}-versiond
+
+  versiond-2:
+    <<: *versiond
+    container_name: ${KEY_NAME}-versiond-2
+
+  versiond-3:
+    <<: *versiond
+    container_name: ${KEY_NAME}-versiond-3
+
+  versiond-router:
+    image: ghcr.io/product-science/versiond-router:latest
+    build:
+      context: ./versiond-router
+      dockerfile: Dockerfile
+    container_name: ${KEY_NAME}-versiond-router
+    environment:
+      VERSIOND_HOSTS: ${VERSIOND_HOSTS:-${KEY_NAME}-versiond ${KEY_NAME}-versiond-2 ${KEY_NAME}-versiond-3}
+      VERSIOND_PORT: ${VERSIOND_PORT:-8080}
     networks:
       - chain-public
-    dns:
-      - 172.25.0.10
-      - 127.0.0.11
 
   testapp-server:
     container_name: ${KEY_NAME}-testapp-server
@@ -73,3 +117,12 @@ services:
       - ./build/devshardd-artifacts:/srv/files:ro
     networks:
       - chain-public
+
+# When this file is layered on top of docker-compose-base.yml (testermint flow),
+# base owns the chain-public definition. For standalone use (e.g. layering
+# only versiond services on a base genesis stack already up), declare external
+# so compose doesn't try to create a new network.
+networks:
+  chain-public:
+    external: true
+    name: chain-public

--- a/proxy-ssl/Makefile
+++ b/proxy-ssl/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build-docker release
 
-VERSION ?= $(shell git describe --always)
+VERSION ?= $(shell git describe --always | tr '/' '-')
 SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
 PLATFORMS ?= linux/amd64,linux/arm64

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -33,4 +33,4 @@ EXPOSE 80 443
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Start nginx
-CMD ["nginx", "-g", "daemon off;"] 
+CMD ["nginx", "-g", "daemon off;"]

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build-docker release
 
-VERSION ?= $(shell git describe --always)
+VERSION ?= $(shell git describe --always | tr '/' '-')
 SET_LATEST ?= 0
 SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
 PLATFORMS ?= linux/amd64,linux/arm64

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -17,6 +17,35 @@ export PROXY_SSL_PORT=${PROXY_SSL_PORT:-8080}
 export VERSIOND_SERVICE_NAME=${VERSIOND_SERVICE_NAME:-versiond}
 export VERSIOND_PORT=${VERSIOND_PORT:-8080}
 export DISABLE_DEVSHARD_PROXY=${DISABLE_DEVSHARD_PROXY:-false}
+export PUBLIC_DEVSHARD_VERSION=${PUBLIC_DEVSHARD_VERSION:-v0.2.12}
+PUBLIC_DEVSHARD_ROUTE_PATHS_DEFAULT='
+/v1/status
+/v1/models
+/v1/governance/models
+/v1/governance/models-legacy
+/v1/participants
+/v1/participants/{address}
+/v1/epochs/{epoch}
+/v1/epochs/{epoch}/participants
+/v1/pricing
+/v1/restrictions/status
+/v1/restrictions/exemptions
+/v1/restrictions/exemptions/{id}/usage/{account}
+/v1/versions
+/v1/bls/epoch/{id}
+/v1/bls/epochs/{id}
+/v1/bls/signatures/{request_id}
+/v1/bridge/addresses
+/v1/poc-batches/{epoch}
+/v1/verify-proof
+/v1/verify-block
+/v1/debug/pubkey-to-addr/{pubkey}
+/v1/debug/verify/{height}
+'
+if [ -z "${PUBLIC_DEVSHARD_ROUTE_PATHS:-}" ]; then
+    PUBLIC_DEVSHARD_ROUTE_PATHS=$PUBLIC_DEVSHARD_ROUTE_PATHS_DEFAULT
+fi
+export PUBLIC_DEVSHARD_ROUTE_PATHS=${PUBLIC_DEVSHARD_ROUTE_PATHS:-""}
 
 if [ -n "${KEY_NAME}" ] && [ "${KEY_NAME}" != "" ]; then
     export KEY_NAME_PREFIX="${KEY_NAME}-"
@@ -625,6 +654,83 @@ append_exempt_location() {
     done
 }
 
+append_public_devshard_route_locations() {
+    # Usage: append_public_devshard_route_locations "/v1/foo /v1/foo/{id}"
+    # Paths mirror common/queryapi/openapi.yaml and are emitted before generic
+    # /v1/ API locations, so selected public query routes can move to devshardd
+    # without moving the entire API namespace.
+    local routes="$1"
+
+    if [ "${DISABLE_DEVSHARD_PROXY}" = "true" ]; then
+        return
+    fi
+
+    for route in $routes; do
+        route_without_version=$(echo "$route" | sed 's|^/||; s|^[^/]*/||')
+        route_is_blocked="false"
+        for blocked_route in $GONKA_API_BLOCKED_ROUTES; do
+            clean_blocked_route=$(echo "$blocked_route" | sed 's|^/||')
+            case "$route_without_version" in
+                "$clean_blocked_route"|"$clean_blocked_route"/*)
+                    route_is_blocked="true"
+                    ;;
+            esac
+        done
+        if [ "$route_is_blocked" = "true" ]; then
+            continue
+        fi
+
+        if echo "$route" | grep -q '{'; then
+            route_regex=$(echo "$route" | sed 's|/|\\/|g; s|{[^/}][^/}]*}|[^/]+|g')
+            API_VERSION_LOCATIONS="${API_VERSION_LOCATIONS}
+        # Public devshard query route ${route}
+        location ~ ^${route_regex}$ {
+            set \$limit_zone_name \"GNKAPI\";
+            ${LIMIT_REQ_RULE_GONKA_API}
+            ${LIMIT_CONN_RULE_GONKA_API}
+            rewrite ^ /${PUBLIC_DEVSHARD_VERSION}\$uri break;
+            proxy_pass http://versiond_backend;
+            proxy_set_header Host \$\$host;
+            proxy_set_header X-Real-IP \$\$remote_addr;
+            proxy_set_header X-Forwarded-For \$\$proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto \$\$scheme;
+            proxy_set_header Authorization \$\$http_authorization;
+
+            ${CORS_CONFIG}
+            ${STREAMING_CONFIG}
+
+            proxy_connect_timeout ${GONKA_API_CONNECT_TIMEOUT}s;
+            proxy_send_timeout ${GONKA_API_TRANSFER_TIMEOUT}s;
+            proxy_read_timeout ${GONKA_API_TRANSFER_TIMEOUT}s;
+        }
+    "
+        else
+            API_VERSION_LOCATIONS="${API_VERSION_LOCATIONS}
+        # Public devshard query route ${route}
+        location = ${route} {
+            set \$limit_zone_name \"GNKAPI\";
+            ${LIMIT_REQ_RULE_GONKA_API}
+            ${LIMIT_CONN_RULE_GONKA_API}
+            rewrite ^ /${PUBLIC_DEVSHARD_VERSION}\$uri break;
+            proxy_pass http://versiond_backend;
+            proxy_set_header Host \$\$host;
+            proxy_set_header X-Real-IP \$\$remote_addr;
+            proxy_set_header X-Forwarded-For \$\$proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto \$\$scheme;
+            proxy_set_header Authorization \$\$http_authorization;
+
+            ${CORS_CONFIG}
+            ${STREAMING_CONFIG}
+
+            proxy_connect_timeout ${GONKA_API_CONNECT_TIMEOUT}s;
+            proxy_send_timeout ${GONKA_API_TRANSFER_TIMEOUT}s;
+            proxy_read_timeout ${GONKA_API_TRANSFER_TIMEOUT}s;
+        }
+    "
+        fi
+    done
+}
+
 # --------------------------------------------------------------------------------
 # Generate Blocked Routes Configuration
 # --------------------------------------------------------------------------------
@@ -635,6 +741,8 @@ API_VERSIONS=${API_VERSIONS:-"v1 v2"}
 API_VERSION_LOCATIONS=""
 BLOCKED_ROUTES_CONFIG=""
 EXEMPT_ROUTES_CONFIG=""
+
+append_public_devshard_route_locations "$PUBLIC_DEVSHARD_ROUTE_PATHS"
 
 # 1. Gonka API dynamic generation
 APP_BLOCKED_PREFIXES=""

--- a/versiond-router/Dockerfile
+++ b/versiond-router/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:1.27-alpine
+
+# Sticky reverse-proxy in front of N versiond instances. Hashes by escrow id
+# from the URL so the same session always lands on the same versiond. Plays
+# along with nginx:alpine's stock /docker-entrypoint.d/ pipeline.
+
+COPY nginx.conf.template /etc/nginx/template/nginx.conf.template
+COPY entrypoint.sh /docker-entrypoint.d/40-render-versiond-upstream.sh
+RUN chmod +x /docker-entrypoint.d/40-render-versiond-upstream.sh

--- a/versiond-router/Makefile
+++ b/versiond-router/Makefile
@@ -1,0 +1,47 @@
+.PHONY: all build-docker release
+
+VERSION ?= $(shell git describe --always)
+SET_LATEST ?= 0
+SET_LATEST := $(shell if [ "$(SET_LATEST)" = "1" ]; then echo 1; else echo 0; fi)
+PLATFORMS ?= linux/amd64,linux/arm64
+USE_REGISTRY_CACHE ?= 0
+ifeq ($(USE_REGISTRY_CACHE),1)
+DOCKER_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/versiond-router:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/versiond-router:buildcache,mode=min
+DOCKER_BUILD_PREFIX := docker buildx build --load $(DOCKER_CACHE_ARGS)
+else
+DOCKER_CACHE_ARGS :=
+DOCKER_BUILD_PREFIX := DOCKER_BUILDKIT=1 docker build
+endif
+
+define DOCKER_BUILD
+	@echo "--> building versiond-router docker image"
+	@echo "    	platform: $(PLATFORM)"
+	@$(DOCKER_BUILD_PREFIX) \
+		--platform $(PLATFORM) \
+		-f $(DOCKER_FILE) \
+		. \
+		-t $(DOCKER_TAG)
+endef
+
+all: build-docker
+
+build-docker:
+	$(eval PLATFORM=linux/amd64)
+	$(eval DOCKER_FILE=Dockerfile)
+	$(eval DOCKER_TAG=ghcr.io/product-science/versiond-router:$(VERSION))
+	$(DOCKER_BUILD)
+	@if [ "$(SET_LATEST)" = "1" ]; then \
+		echo "Setting latest tag..."; \
+		docker tag $(DOCKER_TAG) ghcr.io/product-science/versiond-router:latest; \
+	fi
+
+release:
+	@echo "--> releasing versiond-router (multi-arch)"
+	@echo "platforms: $(PLATFORMS)"
+	$(eval DOCKER_FILE=Dockerfile)
+	@docker buildx build \
+		--platform $(PLATFORMS) \
+		-f $(DOCKER_FILE) \
+		-t ghcr.io/product-science/versiond-router:$(VERSION) \
+		--push \
+		.

--- a/versiond-router/entrypoint.sh
+++ b/versiond-router/entrypoint.sh
@@ -19,7 +19,7 @@ fi
 
 LINES=""
 for host in ${VERSIOND_HOSTS}; do
-    LINES="${LINES}    server ${host}:${PORT};
+    LINES="${LINES}    server ${host}:${PORT} resolve;
 "
 done
 

--- a/versiond-router/entrypoint.sh
+++ b/versiond-router/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Renders /etc/nginx/conf.d/default.conf from nginx.conf.template by
+# substituting ${UPSTREAM_SERVERS} with `server <host>:<port>;` lines built
+# from the VERSIOND_HOSTS env (space-separated host list).
+#
+# Mounted into nginx:alpine as /docker-entrypoint.d/40-render-versiond-upstream.sh
+# so the stock entrypoint runs it before exec'ing nginx. The template lives at
+# /etc/nginx/template/ (NOT /etc/nginx/templates/) to bypass the stock
+# 20-envsubst-on-templates.sh which would clobber ${UPSTREAM_SERVERS} with an
+# empty value (env var doesn't exist at process scope).
+set -e
+
+PORT="${VERSIOND_PORT:-8080}"
+
+if [ -z "${VERSIOND_HOSTS}" ]; then
+    echo "[versiond-router] FATAL: VERSIOND_HOSTS is required (space-separated host list)" >&2
+    exit 1
+fi
+
+LINES=""
+for host in ${VERSIOND_HOSTS}; do
+    LINES="${LINES}    server ${host}:${PORT};
+"
+done
+
+awk -v s="${LINES}" '{gsub(/\$\{UPSTREAM_SERVERS\}/, s); print}' \
+    /etc/nginx/template/nginx.conf.template \
+    > /etc/nginx/conf.d/default.conf
+
+echo "[versiond-router] rendered config (VERSIOND_HOSTS='${VERSIOND_HOSTS}'):"
+echo '----------------------------------------'
+cat /etc/nginx/conf.d/default.conf
+echo '----------------------------------------'

--- a/versiond-router/nginx.conf.template
+++ b/versiond-router/nginx.conf.template
@@ -1,0 +1,48 @@
+# Sticky router for N versiond instances. Same escrow id always lands on the
+# same versiond, so per-session state inside a versiond/devshardd-child stays
+# coherent across retries. The upstream server list below is generated from
+# the VERSIOND_HOSTS env var by entrypoint.sh (nginx-versiond/entrypoint.sh).
+
+upstream versiond_pool {
+    hash $sticky_key consistent;
+${UPSTREAM_SERVERS}
+}
+
+server {
+    listen 8080;
+
+    # Extract escrowID from /<version>/sessions/<id>/... — that's how the path
+    # arrives here after genesis-proxy strips the /devshard/ prefix. For paths
+    # without /sessions/<id>/ (like /<version>/healthz) we fall back to the
+    # full URI so they hash deterministically too.
+    set $sticky_key $request_uri;
+    if ($request_uri ~ "^/[^/]+/sessions/([^/]+)") {
+        set $sticky_key $1;
+    }
+
+    # Echo the resolved sticky key + upstream into response headers so we can
+    # eyeball routing behaviour with curl -i.
+    add_header X-Sticky-Key $sticky_key always;
+    add_header X-Versiond-Upstream $upstream_addr always;
+
+    location / {
+        proxy_pass http://versiond_pool;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Streaming-friendly: SSE responses from chat/completions need
+        # immediate flushing and no request buffering.
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_request_buffering off;
+
+        # Inference can be slow.
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_connect_timeout 30s;
+    }
+}

--- a/versiond-router/nginx.conf.template
+++ b/versiond-router/nginx.conf.template
@@ -1,9 +1,14 @@
 # Sticky router for N versiond instances. Same escrow id always lands on the
 # same versiond, so per-session state inside a versiond/devshardd-child stays
 # coherent across retries. The upstream server list below is generated from
-# the VERSIOND_HOSTS env var by entrypoint.sh (nginx-versiond/entrypoint.sh).
+# the VERSIOND_HOSTS env var by entrypoint.sh (versiond-router/entrypoint.sh).
 
 upstream versiond_pool {
+    # Required by the `resolve` flag below — nginx re-resolves upstream
+    # hostnames every TTL (Docker DNS @ 127.0.0.11) so a container restart
+    # with a new IP doesn't pin nginx to a stale address until reload.
+    zone versiond_pool 64k;
+    resolver 127.0.0.11 valid=10s ipv6=off;
     hash $sticky_key consistent;
 ${UPSTREAM_SERVERS}
 }
@@ -19,11 +24,6 @@ server {
     if ($request_uri ~ "^/[^/]+/sessions/([^/]+)") {
         set $sticky_key $1;
     }
-
-    # Echo the resolved sticky key + upstream into response headers so we can
-    # eyeball routing behaviour with curl -i.
-    add_header X-Sticky-Key $sticky_key always;
-    add_header X-Versiond-Upstream $upstream_addr always;
 
     location / {
         proxy_pass http://versiond_pool;


### PR DESCRIPTION
## Summary
  Adds a sticky-routing layer in front of versiond — requests for the same session always hit the same upstream —
   and wires the multi-instance shape into both the production deploy and the local-test-net harness.

  ## Changes
  - **`versiond-router/`** — new nginx service, hashes on `escrowID`. Sub-Makefile mirrors `proxy/`; top-level
  Makefile wires `versiond-router-build-docker` / `versiond-router-release`.
  - **`deploy/join/docker-compose.versiond.yml`** — overlay: `devshard-postgres` + `versiond` + `versiond2`
  (shared via `x-versiond` anchor) + `versiond-router`; overrides `proxy` env to route `/devshard/*` through the
  router. Pinned to `ghcr.io/product-science/versiond-router:0.2.12`. Base `docker-compose.yml` untouched.
  - **`local-test-net/docker-compose.versiond.yml`** — same multi-instance shape (3 versiond + router) for
  testermint.