### PR TITLE
feat(sim): enable Cosmos SDK simulation (Phase 1 of #982)

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -1,0 +1,48 @@
+name: Simulation Smoke (manual)
+
+# Manual trigger only; simulation runs add ~5-15 min to CI cost.
+# Maintainers may add `pull_request` / `push` triggers when sim coverage is
+# considered worth gating on. See docs/simulation.md for context.
+#
+# To activate auto-triggers, replace the `workflow_dispatch:` block below with:
+#
+#   pull_request:
+#     branches:
+#       - '**'
+#   push:
+#     branches:
+#       - main
+#
+# Or keep manual-only and trigger via the Actions tab / `gh workflow run`.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sim-smoke:
+    runs-on: ubuntu-24.04
+    name: Run sim-smoke-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.2'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('inference-chain/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run sim-smoke-test
+        working-directory: inference-chain
+        run: make sim-smoke-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build versiond-build-docker testapp-server-build-docker
+.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build versiond-build-docker testapp-server-build-docker node-sim-smoke-test node-sim-full-test
 
 VERSION ?= $(shell git describe --always)
 DEVSHARD_VERSION ?= dev
@@ -21,6 +21,13 @@ api-build-docker:
 
 node-build-docker:
 	@make -C inference-chain build-docker SET_LATEST=1 $(if $(GENESIS_OVERRIDES_FILE),GENESIS_OVERRIDES_FILE=$(GENESIS_OVERRIDES_FILE),)
+
+# Simulation dispatchers (issue #982 Phase 1)
+node-sim-smoke-test:
+	@make -C inference-chain sim-smoke-test
+
+node-sim-full-test:
+	@make -C inference-chain sim-full-test
 
 mock-server-build-docker:
 	@echo "Building mock-server JAR file..."

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -1,0 +1,194 @@
+# Simulation and Fuzz Testing
+
+This document covers how to run, interpret, and extend Cosmos SDK simulation
+tests for `inference-chain`. It is the operator/developer reference for
+[issue gonka-ai/gonka#982](https://github.com/gonka-ai/gonka/issues/982) and
+its phased implementation.
+
+## Quick start
+
+From repo root:
+
+```bash
+make sim-smoke-test   # 50 blocks × 20 ops, ~15 min
+make sim-full-test    # 500 blocks × 200 ops, ~120 min (Phase 2+ recommended)
+```
+
+Both targets enter the `inference-chain` module and run `go test -run
+TestFullAppSimulation` with the `sims` build tag. The `*_Postrun` tests
+(see Test inventory) are not invoked by these targets; they call `t.Skip`
+with the reason and only run when invoked directly via
+`go test -tags sims ./app/...` without a `-run` filter.
+
+## Run modes
+
+| Target | Blocks × Ops | Seeds | Wall-clock | When to use |
+|---|---|---|---|---|
+| `sim-smoke-test` | 50 × 20 | 1 (`-Seed=99`) | ~15 min | Pre-PR sanity check; CI via [`.github/workflows/simulation.yml`](../.github/workflows/simulation.yml) (`workflow_dispatch` only, not a required PR check) |
+| `sim-full-test` | 500 × 200 | 1 (`-Seed=99`) | ~120 min | After Phase 2 real ops land. Informative only when ops are not NoOpMsg stubs |
+| direct `go test` (with `-Seed=N`) | per `-NumBlocks` / `-BlockSize` flags | 1 (the supplied `-Seed`) | depends | Reproducing a specific seed, debugging |
+| direct `go test` (no `-Seed`) | per flags | simsx `defaultSeeds` (37 seeds, parallel subtests) | depends | Broad coverage sweep |
+
+**Seed dispatch:** `TestFullAppSimulation` reads `-Seed` via `simcli.NewConfigFromFlags()`. When set, it calls `simsx.RunWithSeed` for a single-seed run (matches Make targets). When unset (CLI default sentinel), it falls through to `simsx.Run` which fans out the framework's default 37-seed list as parallel `t.Run("seed: N", ...)` subtests.
+
+## Build tags
+
+| Tag | Purpose |
+|---|---|
+| `sims` | Includes simulation test files (`sim_test.go`, `sim_bench_test.go`). Required for all simulation runs. |
+| `simsbench` | Includes benchmark variant (`BenchmarkFullAppSimulation`). Used for performance profiling, not correctness. |
+| `muslc` | Required when building under Alpine/musl (CI, canonical Docker). Links static `libwasmvm_muslc.x86_64.a`. |
+
+Combine with `,` or space:
+
+```bash
+go test -tags 'sims muslc' ./app/...                  # production-tag combo
+go test -tags 'sims simsbench muslc' ./app/...        # also picks up benchmark
+```
+
+## CLI flags
+
+Read by `simcli.GetSimulatorFlags()` in `app/sim_test.go:init`:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `-Enabled` | `false` | Master switch. Set to `true` to actually run simulation; without it the tests skip. |
+| `-Commit` | `false` | Commit blocks during simulation. Required for any meaningful run. |
+| `-NumBlocks` | (unset) | Number of blocks per simulation. |
+| `-BlockSize` | (unset) | Number of ops attempted per block. |
+| `-Seed` | (unset; falls back to simsx defaultSeeds list) | Specific seed to use. Override for reproducing failures. |
+| `-Verbose` | `false` | Verbose logging. |
+
+## Expected output
+
+Successful smoke run prints per-seed summaries:
+
+```
++++ DONE (seed: 99):
+... (operation stats per module)
+```
+
+A successful determinism run (`TestAppStateDeterminism`) is silent in
+non-verbose mode and exits 0. The test runs 3 seeds × 3 attempts each (9
+runs internally).
+
+A successful full run prints the same per-seed summary plus
+`PrintStats(testInstance.DB)` output (db-level statistics) when `-Commit=true`.
+
+## Failure interpretation
+
+### Determinism failure
+
+```
+non-determinism in seed N: attempt 0 vs M
+```
+
+Different AppHash across attempts of the same seed. Common causes:
+
+- Go map iteration in keeper code (use `Iterate` with `PrefixedPairRange`).
+- `time.Now()` or other system-clock reads in state code.
+- RNG used outside the `r *rand.Rand` provided by simulation.
+- Floating-point arithmetic in state code (use `shopspring/decimal`).
+
+Capture the failing seed and re-run `TestAppStateDeterminism` with `-Seed=N`
+to isolate it. The test honors `-Seed` and overrides its internal triplet
+(`defaultSimSeeds`) when a non-default seed is passed:
+
+```bash
+cd inference-chain
+go test -mod=readonly -tags 'sims muslc' \
+    -run TestAppStateDeterminism ./app/... \
+    -Enabled=true -Commit=true -Seed=42 -v
+```
+
+### Bonded-pool panic on import
+
+```
+panic: bonded pool balance is different from bonded coins:  <-> NNNNstake
+  at gonka-ai/cosmos-sdk@v0.53.3-ps17/x/staking/keeper/genesis.go:158
+```
+
+This is a **known fork-level inconsistency**, not a bug in the simulation.
+`TestAppImportExport_Postrun` and `TestAppSimulationAfterImport_Postrun`
+hit this panic by design; see the TODO blocks above each test in
+`app/sim_test.go`.
+
+Production avoids this path by using `x/upgrade` in-place handlers
+(`app/upgrades/v0_2_*`) rather than vanilla `inferenced export → init`.
+
+### Linker error: cannot find -lwasmvm_muslc.x86_64
+
+When running outside the canonical Docker:
+
+```
+ld: cannot find -lwasmvm_muslc.x86_64: No such file or directory
+```
+
+The static lib name MUST include the architecture suffix exactly:
+`libwasmvm_muslc.x86_64.a` (not `libwasmvm_muslc.a`). Download from
+[CosmWasm/wasmvm releases](https://github.com/CosmWasm/wasmvm/releases),
+match version with `inference-chain/go.mod`.
+
+## Reproducing failing seeds
+
+Smoke run prints `seed: N` for each parallelised sub-test. Re-run a single
+seed:
+
+```bash
+cd inference-chain
+go test -mod=readonly -tags 'sims muslc' \
+    -run 'TestFullAppSimulation/seed:_<N>' ./app/ \
+    -Enabled=true -Commit=true -NumBlocks=50 -BlockSize=20 -v
+```
+
+For `TestAppStateDeterminism`, the seed appears in the failure message
+directly.
+
+## Canonical Docker run
+
+Local environments often have ABI mismatches with `bytedance/sonic` or
+missing wasmvm libs. Canonical run uses Alpine + musl + static wasmvm. The
+`WASMVM_VERSION` is derived inside the container from `inference-chain/go.mod`
+so it stays in sync with the dependency:
+
+```bash
+docker run --rm --network host \
+  -v "$PWD":/src -w /src/inference-chain \
+  -v "$HOME/go/pkg/mod":/go/pkg/mod \
+  golang:1.24.2-alpine3.20 sh -c '
+    apk add --no-cache gcc musl-dev curl &&
+    WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v2 | awk "{print \$2}") &&
+    mkdir -p /lib/wasmvm-static &&
+    curl -sL -o /lib/wasmvm-static/libwasmvm_muslc.x86_64.a \
+      "https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.x86_64.a" &&
+    CGO_ENABLED=1 CGO_LDFLAGS="-L/lib/wasmvm-static" \
+      go test -mod=readonly -tags "sims muslc" ./app/...
+  '
+```
+
+`--network host` is required because Docker bridge often timeouts to
+`github.com` when downloading wasmvm.
+
+## Test inventory
+
+| Test | What it checks | Status |
+|---|---|---|
+| `TestFullAppSimulation` | Top-level simsx run: random genesis → simulate → CheckExportSimulation | Green |
+| `TestAppImportExport_Postrun` | Export → fresh app InitGenesis → KV-store diff | **Skipped** (tracks fork bonded-pool issue, see TODO and gonka-ai/gonka#1153) |
+| `TestAppSimulationAfterImport_Postrun` | Export → fresh app InitChain → second simulation | **Skipped** (same fork issue + post-import simulation step not yet wired) |
+| `TestAppStateDeterminism` | 3 seeds × 3 attempts: identical AppHash | Green |
+| `TestApp_GenesisInit_*` | Genesis init produces blocked module accounts + PoC validators | Green |
+| `TestDisabledOpsSimModule_*` | Wrapper produces empty WeightedOperations for staking/distribution/wasm | Green |
+| `TestBankGenesisFix_SupplyRecomputed` | `fixBankGenesisState` makes Supply match Balances | Green |
+
+## Phase status (as of 2026-05-08)
+
+- **Phase 1** (this issue): simsx migration, smoke/full Make targets, disabled
+  upstream ops, restored test semantics, fixBankGenesisState. **In progress.**
+- **Phase 2**: first-wave x/inference real ops (SubmitNewParticipant,
+  StartInference, FinishInference, Validation, ClaimRewards) replacing
+  NoOpMsg stubs. After this phase, `sim-full-test` produces meaningful signal.
+- **Phase 3**: weight tuning, store decoders, custom invariants,
+  parameter-edge fuzzing. PoC-state determinism beyond AppHash.
+- **Phase 4**: simulation operations for other custom modules (bls,
+  bookkeeper, collateral, genesistransfer, restrictions, streamvesting).

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install build build-docker init clean-state mock-expected-keepers docker-push release build-all package deploy proto
+.PHONY: all install build build-docker init clean-state mock-expected-keepers docker-push release build-all package deploy proto sim-smoke-test sim-full-test
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
@@ -310,3 +310,26 @@ mock-expected-keepers:
 
 proto:
 	ignite generate proto-go
+
+#################################################
+# SIMULATION SECTION (issue #982 Phase 1)
+#################################################
+# Targets are no-ops until TestFullAppSimulation lands in Phase 1 item 1.A (sim_test.go migration).
+
+SIM_PKG := ./app/
+
+sim-smoke-test:
+	@echo "--> Running smoke simulation: 50 blocks x 20 ops/block (~15 min)"
+	@go test -mod=readonly -tags sims $(SIM_PKG) \
+		-run TestFullAppSimulation \
+		-Enabled=true -Commit=true \
+		-NumBlocks=50 -BlockSize=20 -Seed=99 \
+		-v -timeout 30m
+
+sim-full-test:
+	@echo "--> Running full simulation: 500 blocks x 200 ops/block (~120 min)"
+	@go test -mod=readonly -tags sims $(SIM_PKG) \
+		-run TestFullAppSimulation \
+		-Enabled=true -Commit=true \
+		-NumBlocks=500 -BlockSize=200 -Seed=99 \
+		-v -timeout 180m

--- a/inference-chain/app/app.go
+++ b/inference-chain/app/app.go
@@ -51,6 +51,7 @@ import (
 	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	_ "github.com/cosmos/cosmos-sdk/x/distribution" // import for side-effects
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
@@ -69,6 +70,7 @@ import (
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	_ "github.com/cosmos/cosmos-sdk/x/staking" // import for side-effects
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	_ "github.com/cosmos/ibc-go/modules/capability" // import for side-effects
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
@@ -321,8 +323,24 @@ func New(
 	// create the simulation manager and define the order of the modules for deterministic simulations
 	//
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing transactions
+	//
+	// staking/distribution/wasmd weighted ops are disabled - see app/simulation.go
+	// for rationale. Genesis state generation is preserved via Go embedding.
+	mustSimMod := func(name string) module.AppModuleSimulation {
+		sm, ok := app.ModuleManager.Modules[name].(module.AppModuleSimulation)
+		if !ok {
+			panic(fmt.Sprintf("module %q is missing or does not implement module.AppModuleSimulation: cannot wrap with disabledOpsSimModule", name))
+		}
+		return sm
+	}
+	stakingSimMod := mustSimMod(stakingtypes.ModuleName)
+	distrSimMod := mustSimMod(distrtypes.ModuleName)
+	wasmSimMod := mustSimMod(wasmtypes.ModuleName)
 	overrideModules := map[string]module.AppModuleSimulation{
-		authtypes.ModuleName: auth.NewAppModule(app.appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
+		authtypes.ModuleName:    auth.NewAppModule(app.appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
+		stakingtypes.ModuleName: disabledOpsSimModule{stakingSimMod},
+		distrtypes.ModuleName:   disabledOpsSimModule{distrSimMod},
+		wasmtypes.ModuleName:    disabledOpsSimModule{wasmSimMod},
 	}
 	app.sm = module.NewSimulationManagerFromAppModules(app.ModuleManager.Modules, overrideModules)
 	app.sm.RegisterStoreDecoders()
@@ -433,6 +451,18 @@ func (app *App) GetCapabilityScopedKeeper(moduleName string) capabilitykeeper.Sc
 // SimulationManager implements the SimulationApp interface.
 func (app *App) SimulationManager() *module.SimulationManager {
 	return app.sm
+}
+
+// TxConfig returns the App's TxConfig.
+// Implements simsx.SimulationApp interface required by simsx.Run.
+func (app *App) TxConfig() client.TxConfig {
+	return app.txConfig
+}
+
+// GetBaseApp returns the underlying *baseapp.BaseApp.
+// Implements simsx.SimulationApp interface required by simsx.Run.
+func (app *App) GetBaseApp() *baseapp.BaseApp {
+	return app.BaseApp
 }
 
 // RegisterAPIRoutes registers all application module routes with the provided

--- a/inference-chain/app/genesis_test.go
+++ b/inference-chain/app/genesis_test.go
@@ -1,0 +1,81 @@
+package app_test
+
+import (
+	"slices"
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApp_GenesisInit_ModuleAccountsAndPoCValidators verifies four
+// properties after a fresh InitGenesis on an app where staking,
+// distribution, and wasmd are wrapped in disabledOpsSimModule:
+//
+//	(a) InitGenesis runs without panic. Implicit: if it panicked,
+//	    createTestApp would not return.
+//	(b) The five blocked module accounts are populated (app_config.go
+//	    blockedModuleAccountAddrs).
+//	(c) New validators can be added via the gonka PoC compute path
+//	    (StakingKeeper.SetComputeValidators), since vanilla Cosmos token
+//	    delegation is disabled in this fork (docs/cosmos_changes.md).
+//	(d) The fee collector is a usable ModuleAccount, not a bare
+//	    BaseAccount.
+//
+// Reuses createTestApp from tally_integration_test.go (PR #496).
+// Subtests share testApp and ctx from the outer scope; one of them
+// mutates state via SetComputeValidators, so failures are isolated per
+// subtest but state is not.
+func TestApp_GenesisInit_ModuleAccountsAndPoCValidators(t *testing.T) {
+	testApp := createTestApp(t)
+	ctx := testApp.BaseApp.NewUncachedContext(false, cmtproto.Header{ChainID: TallyTestChainID, Height: 1})
+
+	t.Run("blocked module accounts populated", func(t *testing.T) {
+		blocked := []string{
+			authtypes.FeeCollectorName,
+			distrtypes.ModuleName,
+			minttypes.ModuleName,
+			stakingtypes.BondedPoolName,
+			stakingtypes.NotBondedPoolName,
+		}
+		for _, name := range blocked {
+			t.Run(name, func(t *testing.T) {
+				addr := testApp.AccountKeeper.GetModuleAddress(name)
+				require.NotNil(t, addr, "GetModuleAddress(%s) should not be nil", name)
+				acct := testApp.AccountKeeper.GetAccount(ctx, addr)
+				require.NotNil(t, acct, "module account %s should exist after InitGenesis", name)
+			})
+		}
+	})
+
+	t.Run("PoC compute validator can be added", func(t *testing.T) {
+		pocPub := ed25519.GenPrivKey().PubKey()
+		pocOpAddr := sdk.ValAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+		pocResults := []stakingkeeper.ComputeResult{{
+			Power:           100,
+			ValidatorPubKey: pocPub,
+			OperatorAddress: pocOpAddr,
+		}}
+
+		postPoC, err := testApp.StakingKeeper.SetComputeValidators(ctx, pocResults, true /* isTestnet */)
+		require.NoError(t, err)
+		require.True(t, slices.ContainsFunc(postPoC, func(v stakingtypes.Validator) bool {
+			return v.OperatorAddress == pocOpAddr && v.IsBonded()
+		}), "PoC compute validator must be present and bonded after SetComputeValidators")
+	})
+
+	t.Run("fee collector is ModuleAccount", func(t *testing.T) {
+		feeAddr := testApp.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+		feeAcct := testApp.AccountKeeper.GetAccount(ctx, feeAddr)
+		_, isModAcct := feeAcct.(sdk.ModuleAccountI)
+		require.True(t, isModAcct, "fee collector should implement ModuleAccountI")
+	})
+}

--- a/inference-chain/app/sdk_config.go
+++ b/inference-chain/app/sdk_config.go
@@ -1,0 +1,36 @@
+package app
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// CoinType is the SLIP-44 coin type used for HD key derivation on the Gonka chain.
+const CoinType = 1200
+
+// InitSDKConfig sets the chain's bech32 prefixes and coin type on the
+// global sdk.Config. Idempotent. Does not seal; production callers must
+// call SealSDKConfig after this.
+//
+// Tests call this without sealing so per-test helpers like createTestApp
+// can re-set the same prefixes from package init scope under the sims
+// build tag without hitting the sealed-config panic.
+func InitSDKConfig() {
+	accountPubKeyPrefix := AccountAddressPrefix + "pub"
+	validatorAddressPrefix := AccountAddressPrefix + "valoper"
+	validatorPubKeyPrefix := AccountAddressPrefix + "valoperpub"
+	consNodeAddressPrefix := AccountAddressPrefix + "valcons"
+	consNodePubKeyPrefix := AccountAddressPrefix + "valconspub"
+
+	config := sdk.GetConfig()
+	config.SetCoinType(CoinType) // TODO: change to custom coin type
+	config.SetBech32PrefixForAccount(AccountAddressPrefix, accountPubKeyPrefix)
+	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
+	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)
+}
+
+// SealSDKConfig seals the global sdk.Config so subsequent SetBech32 or
+// SetCoinType calls panic. Production callers (cmd/inferenced) call this
+// after InitSDKConfig at startup so address parsing stays strict for
+// the lifetime of the process. Tests do not call it; sealing breaks
+// createTestApp and other helpers that re-set prefixes per test.
+func SealSDKConfig() {
+	sdk.GetConfig().Seal()
+}

--- a/inference-chain/app/setup_test.go
+++ b/inference-chain/app/setup_test.go
@@ -1,0 +1,20 @@
+package app_test
+
+import (
+	"os"
+	"testing"
+
+	inferencemodule "github.com/productscience/inference/x/inference/module"
+)
+
+// TestMain enables a test-only escape hatch in x/inference/module that
+// suppresses the "denom <X> already registered" panic from
+// sdk.RegisterDenom when multiple tests in this package each spin up a
+// fresh *app.App via createTestApp, NewSimApp, or
+// NewSimulationAppInstance. `go test` compiles each package to its own
+// binary so the flag dies with the process; production semantics (flag
+// default=false) are unaffected. See x/inference/module/genesis.go:16-22.
+func TestMain(m *testing.M) {
+	inferencemodule.IgnoreDuplicateDenomRegistration = true
+	os.Exit(m.Run())
+}

--- a/inference-chain/app/sim_bench_test.go
+++ b/inference-chain/app/sim_bench_test.go
@@ -1,155 +1,33 @@
+//go:build simsbench
+
 package app_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/server"
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
-	"github.com/stretchr/testify/require"
-
-	"github.com/productscience/inference/app"
 )
 
+// BenchmarkFullAppSimulation profiles a single full-simulation run.
+//
+// A full simulation takes minutes, so b.N looping is not meaningful and
+// the benchmark is single-iteration. Pass `-benchtime=1x`. Per-iteration
+// metrics (ns/op, allocs/op) are not useful; this benchmark exists for
+// `-cpuprofile`, `-memprofile`, and `-trace`.
+//
 // Profile with:
-// `go test -benchmem -run=^$ -bench ^BenchmarkFullAppSimulation ./app -Commit=true -cpuprofile cpu.out`
+//
+//	go test -tags 'sims simsbench' -run=^$ \
+//	    github.com/productscience/inference/app \
+//	    -bench ^BenchmarkFullAppSimulation$ -benchtime=1x -cpuprofile cpu.out
 func BenchmarkFullAppSimulation(b *testing.B) {
-	b.ReportAllocs()
-
 	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
+	config.ChainID = simsx.SimAppChainID
 
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "goleveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if err != nil {
-		b.Fatalf("simulation setup failed: %s", err.Error())
+	seed := config.Seed
+	if seed == simcli.DefaultSeedValue {
+		seed = defaultSimSeeds[0]
 	}
-
-	if skip {
-		b.Skip("skipping benchmark application simulation")
-	}
-
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, interBlockCacheOpt())
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	if err = simtestutil.CheckExportSimulation(bApp, config, simParams); err != nil {
-		b.Fatal(err)
-	}
-
-	if simErr != nil {
-		b.Fatal(simErr)
-	}
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-}
-
-func BenchmarkInvariants(b *testing.B) {
-	b.ReportAllocs()
-
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-invariant-bench", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if err != nil {
-		b.Fatalf("simulation setup failed: %s", err.Error())
-	}
-
-	if skip {
-		b.Skip("skipping benchmark application simulation")
-	}
-
-	config.AllInvariants = false
-
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, interBlockCacheOpt())
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	if err = simtestutil.CheckExportSimulation(bApp, config, simParams); err != nil {
-		b.Fatal(err)
-	}
-
-	if simErr != nil {
-		b.Fatal(simErr)
-	}
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-
-	ctx := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight() + 1})
-
-	// 3. Benchmark each invariant separately
-	//
-	// NOTE: We use the crisis keeper as it has all the invariants registered with
-	// their respective metadata which makes it useful for testing/benchmarking.
-	for _, cr := range bApp.CrisisKeeper.Routes() {
-		cr := cr
-		b.Run(fmt.Sprintf("%s/%s", cr.ModuleName, cr.Route), func(b *testing.B) {
-			if res, stop := cr.Invar(ctx); stop {
-				b.Fatalf(
-					"broken invariant at block %d of %d\n%s",
-					ctx.BlockHeight()-1, config.NumBlocks, res,
-				)
-			}
-		})
-	}
+	simsx.RunWithSeed(b, config, NewSimApp, setupStateFactory, seed, nil)
 }

--- a/inference-chain/app/sim_test.go
+++ b/inference-chain/app/sim_test.go
@@ -1,18 +1,14 @@
+//go:build sims || simsbench
+
 package app_test
 
 import (
 	"encoding/json"
-	"flag"
-	"fmt"
-	"math/rand"
-	"os"
-	"runtime/debug"
+	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"cosmossdk.io/log"
-	"cosmossdk.io/store"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/feegrant"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -20,191 +16,222 @@ import (
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/server"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	simulationtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	"github.com/productscience/inference/app"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
 
-const (
-	SimAppChainID = "inference-simapp"
-)
+// Compile-time check that *app.App satisfies simsx.SimulationApp.
+var _ simsx.SimulationApp = (*app.App)(nil)
 
-var FlagEnableStreamingValue bool
+// defaultSimSeeds is the canonical seed triplet shared by
+// TestAppStateDeterminism (full sweep) and BenchmarkFullAppSimulation
+// (uses [0] as the single-seed default).
+var defaultSimSeeds = []int64{1, 32, 123}
 
-// Get flags every time the simulator is run
 func init() {
 	simcli.GetSimulatorFlags()
-	flag.BoolVar(&FlagEnableStreamingValue, "EnableStreaming", false, "Enable streaming service")
+	app.InitSDKConfig()
 }
 
-// fauxMerkleModeOpt returns a BaseApp option to use a dbStoreAdapter instead of
-// an IAVLStore for faster simulation speed.
-func fauxMerkleModeOpt(bapp *baseapp.BaseApp) {
-	bapp.SetFauxMerkleMode()
-}
-
-// interBlockCacheOpt returns a BaseApp option function that sets the persistent
-// inter-block write-through cache.
-func interBlockCacheOpt() func(*baseapp.BaseApp) {
-	return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager())
-}
-
-// BenchmarkSimulation run the chain simulation
-// Running using starport command:
-// `ignite chain simulate -v --numBlocks 200 --blockSize 50`
-// Running as go benchmark test:
-// `go test -benchmem -run=^$ -bench ^BenchmarkSimulation ./app -NumBlocks=200 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true`
-func BenchmarkSimulation(b *testing.B) {
-	simcli.FlagSeedValue = time.Now().Unix()
-	simcli.FlagVerboseValue = true
-	simcli.FlagCommitValue = true
-	simcli.FlagEnabledValue = true
-
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		b.Skip("skipping application simulation")
+// NewSimApp adapts app.New to the simsx.Run appFactory signature by hiding the
+// wasmd opts argument required by gonka's constructor.
+func NewSimApp(
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	loadLatest bool,
+	appOpts servertypes.AppOptions,
+	baseAppOptions ...func(*baseapp.BaseApp),
+) *app.App {
+	bApp, err := app.New(logger, db, traceStore, loadLatest, appOpts, []wasmkeeper.Option{}, baseAppOptions...)
+	if err != nil {
+		panic(err)
 	}
-	require.NoError(b, err, "simulation setup failed")
+	return bApp
+}
 
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(b, err)
-	require.NoError(b, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
+// setupStateFactory builds the SimStateFactory consumed by simsx.Run for each
+// seed. AccountKeeper satisfies simsx.AccountSourceX (AccountSource +
+// ModuleAccountSource); BankKeeper satisfies simsx.BalanceSource.
+//
+// AppStateFnWithExtendedCb (rather than plain AppStateFn) lets fixBankGenesisState
+// patch the randomized rawState before InitGenesis runs.
+func setupStateFactory(bApp *app.App) simsx.SimStateFactory {
+	return simsx.SimStateFactory{
+		Codec: bApp.AppCodec(),
+		AppStateFn: simtestutil.AppStateFnWithExtendedCb(
+			bApp.AppCodec(),
+			bApp.SimulationManager(),
+			bApp.DefaultGenesis(),
+			func(rawState map[string]json.RawMessage) {
+				fixBankGenesisState(bApp, rawState)
+			},
+		),
+		BlockedAddr:   app.BlockedAddresses(),
+		AccountSource: bApp.AccountKeeper,
+		BalanceSource: bApp.BankKeeper,
 	}
 }
 
-func TestAppImportExport(t *testing.T) {
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		t.Skip("skipping application import/export simulation")
+// fixBankGenesisState patches the randomized sim genesis so InitGenesis succeeds:
+//
+//  1. Add Gonka denom metadata, required by inference module init
+//     (app.initializeDenomMetadata reads BankKeeper.GetDenomMetaData(BaseCoin)).
+//  2. Recompute bank Supply from Balances. The randomized genesis sets
+//     Supply based on NumBonded staking validators, but with staking ops
+//     disabled the bonded pool is never funded, so the default Supply
+//     would fail the supply-vs-balance invariant at InitGenesis.
+//
+// Ported from hleb-albau PR gonka-ai/gonka#995.
+func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
+	bankStateBz, ok := rawState[banktypes.ModuleName]
+	if !ok {
+		panic("bank genesis state missing from randomized state")
 	}
-	require.NoError(t, err, "simulation setup failed")
+	var bankState banktypes.GenesisState
+	bApp.AppCodec().MustUnmarshalJSON(bankStateBz, &bankState)
 
-	defer func() {
-		require.NoError(t, db.Close())
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	bankState.DenomMetadata = append(bankState.DenomMetadata, banktypes.Metadata{
+		Description: "Coins for the Gonka network.",
+		Base:        inferencetypes.BaseCoin,
+		Display:     inferencetypes.NativeCoin,
+		Name:        "Gonka",
+		Symbol:      "GNK",
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: inferencetypes.BaseCoin, Exponent: 0, Aliases: []string{"nanogonka"}},
+			{Denom: "ugonka", Exponent: 3, Aliases: []string{"microgonka"}},
+			{Denom: "mgonka", Exponent: 6, Aliases: []string{"milligonka"}},
+			{Denom: inferencetypes.NativeCoin, Exponent: 9},
+		},
+	})
 
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, bApp.Name())
-
-	// Run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
+	var actualSupply sdk.Coins
+	for _, balance := range bankState.Balances {
+		actualSupply = actualSupply.Add(balance.Coins...)
 	}
+	bankState.Supply = actualSupply
 
-	fmt.Printf("exporting genesis...\n")
+	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
+}
 
+// TestFullAppSimulation is the simsx entry point for `make sim-smoke-test`
+// and `make sim-full-test`. CLI flags (-NumBlocks, -BlockSize, -Seed,
+// -Enabled) come from simcli.GetSimulatorFlags() in init().
+//
+// Requires -Enabled=true. simsx does not gate on it the way legacy
+// simulation.SimulateFromSeed did; this test restores that gate so a
+// raw `go test -tags sims ./app/...` skips fast.
+//
+// With user-supplied -Seed=N (Make targets), dispatches to
+// simsx.RunWithSeed for a single-seed run. Without it, falls through to
+// simsx.Run which fans out the framework's defaultSeeds list (37 seeds
+// in this fork) as parallel subtests.
+func TestFullAppSimulation(t *testing.T) {
+	if !simcli.FlagEnabledValue {
+		t.Skip("pass -Enabled=true to run this; e.g. via make sim-smoke-test")
+	}
+	cfg := simcli.NewConfigFromFlags()
+	cfg.ChainID = simsx.SimAppChainID
+
+	if cfg.Seed != simcli.DefaultSeedValue {
+		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil)
+		return
+	}
+	simsx.Run(t, NewSimApp, setupStateFactory)
+}
+
+// TestAppImportExport_Postrun is t.Skip'd because InitGenesis on the
+// re-imported state panics at gonka-ai/cosmos-sdk@v0.53.3-ps17
+// x/staking/keeper/genesis.go:157-158 ("bonded pool balance is different
+// from bonded coins").
+//
+// The fork's PoC architecture (gonka/docs/cosmos_changes.md) disables
+// token bonding: SetComputeValidators creates bonded validators without
+// bank transfers, pool.go iterates manually, and delegation.go +
+// val_state_change.go skip the transfers. genesis.go:157 was not updated
+// to mirror that skip, so its upstream invariant bondedBalance.Equal(
+// bondedCoins) no longer holds against live state.
+//
+// Production sidesteps this by using x/upgrade in-place handlers (see
+// app/upgrades/v0_2_12) instead of `inferenced export -> init`. Funding
+// the bonded pool here to make the test green would mask the
+// inconsistency, so it stays skipped.
+//
+// Re-enable once gonka-ai/cosmos-sdk genesis.go applies the same
+// PoC-validator skip already in delegation.go. Fork fix proposal:
+// gonka-ai/gonka#1153. Broader Phase 1 work: gonka-ai/gonka#982.
+func TestAppImportExport_Postrun(t *testing.T) {
+	t.Skip("blocked on gonka-ai/cosmos-sdk genesis.go:157; see gonka-ai/gonka#1153 for the fork fix proposal")
+	simsx.Run(t, NewSimApp, setupStateFactory, checkImportExport)
+}
+
+func checkImportExport(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+	tb.Helper()
+	bApp := ti.App
+
+	tb.Logf("exporting genesis...")
 	exported, err := bApp.ExportAppStateAndValidators(false, []string{}, []string{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	fmt.Printf("importing genesis...\n")
-
-	newDB, newDir, _, _, err := simtestutil.SetupSimulation(config, "leveldb-app-sim-2", "Simulation-2", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	require.NoError(t, err, "simulation setup failed")
-
-	defer func() {
-		require.NoError(t, newDB.Close())
-		require.NoError(t, os.RemoveAll(newDir))
-	}()
-
-	newApp, err := app.New(logger, newDB, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, newApp.Name())
+	tb.Logf("importing genesis into fresh app...")
+	newTI := simsx.NewSimulationAppInstance(tb, ti.Cfg, NewSimApp)
+	newApp := newTI.App
+	defer func() { _ = newApp.Close() }()
 
 	var genesisState app.GenesisState
-	err = json.Unmarshal(exported.AppState, &genesisState)
-	require.NoError(t, err)
+	require.NoError(tb, json.Unmarshal(exported.AppState, &genesisState))
 
-	ctxA := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
-	ctxB := newApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
-	_, err = newApp.ModuleManager.InitGenesis(ctxB, bApp.AppCodec(), genesisState)
-
-	if err != nil {
+	header := cmtproto.Header{Height: bApp.LastBlockHeight()}
+	ctxA := bApp.NewContextLegacy(true, header)
+	ctxB := newApp.NewContextLegacy(true, header)
+	if _, err := newApp.ModuleManager.InitGenesis(ctxB, newApp.AppCodec(), genesisState); err != nil {
+		// Defensive: even with disabledOpsSimModule on staking we keep the
+		// upstream-known skip path for the rare case of an empty validator set.
 		if strings.Contains(err.Error(), "validator set is empty after InitGenesis") {
-			logger.Info("Skipping simulation as all validators have been unbonded")
-			logger.Info("err", err, "stacktrace", string(debug.Stack()))
+			tb.Log("skipping import-export comparison: validator set empty")
 			return
 		}
+		tb.Fatalf("InitGenesis on newApp: %v", err)
 	}
-	require.NoError(t, err)
-	err = newApp.StoreConsensusParams(ctxB, exported.ConsensusParams)
-	require.NoError(t, err)
-	fmt.Printf("comparing stores...\n")
+	require.NoError(tb, newApp.StoreConsensusParams(ctxB, exported.ConsensusParams))
 
-	// skip certain prefixes
-	skipPrefixes := map[string][][]byte{
+	tb.Logf("comparing stores...")
+	skipPrefixes := importExportSkipPrefixes()
+	storeKeys := bApp.GetStoreKeys()
+	require.NotEmpty(tb, storeKeys)
+	for _, appKeyA := range storeKeys {
+		if _, ok := appKeyA.(*storetypes.KVStoreKey); !ok {
+			continue
+		}
+		keyName := appKeyA.Name()
+		appKeyB := newApp.GetKey(keyName)
+		storeA := ctxA.KVStore(appKeyA)
+		storeB := ctxB.KVStore(appKeyB)
+		failedKVAs, failedKVBs := simtestutil.DiffKVStores(storeA, storeB, skipPrefixes[keyName])
+		require.Equalf(tb, len(failedKVAs), len(failedKVBs), "unequal failure sets for %s", keyName)
+		if len(failedKVAs) != 0 {
+			tb.Fatalf("KV diff for %s:\n%s", keyName,
+				simtestutil.GetSimulationLog(keyName, bApp.SimulationManager().StoreDecoders, failedKVAs, failedKVBs))
+		}
+	}
+}
+
+// importExportSkipPrefixes mirrors upstream cosmos-sdk simapp's skip set:
+// transient queues populated by runtime hooks, not by InitGenesis.
+func importExportSkipPrefixes() map[string][][]byte {
+	return map[string][][]byte{
 		stakingtypes.StoreKey: {
 			stakingtypes.UnbondingQueueKey, stakingtypes.RedelegationQueueKey, stakingtypes.ValidatorQueueKey,
 			stakingtypes.HistoricalInfoKey, stakingtypes.UnbondingIDKey, stakingtypes.UnbondingIndexKey,
@@ -214,224 +241,92 @@ func TestAppImportExport(t *testing.T) {
 		feegrant.StoreKey:      {feegrant.FeeAllowanceQueueKeyPrefix},
 		slashingtypes.StoreKey: {slashingtypes.ValidatorMissedBlockBitmapKeyPrefix},
 	}
-
-	storeKeys := bApp.GetStoreKeys()
-	require.NotEmpty(t, storeKeys)
-
-	for _, appKeyA := range storeKeys {
-		// only compare kvstores
-		if _, ok := appKeyA.(*storetypes.KVStoreKey); !ok {
-			continue
-		}
-
-		keyName := appKeyA.Name()
-		appKeyB := newApp.GetKey(keyName)
-
-		storeA := ctxA.KVStore(appKeyA)
-		storeB := ctxB.KVStore(appKeyB)
-
-		failedKVAs, failedKVBs := simtestutil.DiffKVStores(storeA, storeB, skipPrefixes[keyName])
-		require.Equal(t, len(failedKVAs), len(failedKVBs), "unequal sets of key-values to compare %s", keyName)
-
-		fmt.Printf("compared %d different key/value pairs between %s and %s\n", len(failedKVAs), appKeyA, appKeyB)
-
-		require.Equal(t, 0, len(failedKVAs), simtestutil.GetSimulationLog(keyName, bApp.SimulationManager().StoreDecoders, failedKVAs, failedKVBs))
-	}
 }
 
-func TestAppSimulationAfterImport(t *testing.T) {
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
+// TestAppSimulationAfterImport_Postrun is t.Skip'd. Two things must be
+// done before re-enabling, in order:
+//
+//  1. gonka-ai/cosmos-sdk genesis.go:157 bonded-pool fix per
+//     gonka-ai/gonka#1153 (InitChain on the imported state currently
+//     panics on the same fork asymmetry as TestAppImportExport_Postrun).
+//  2. Wire SimulateFromSeedX into checkSimulationAfterImport. The current
+//     body only verifies InitChain succeeds; the test name promises a
+//     second simulation step that is not yet implemented (TODO in the
+//     body).
+//
+// Removing t.Skip with only (1) cleared would make the test pass while
+// never exercising the second simulation step. Both must land first.
+func TestAppSimulationAfterImport_Postrun(t *testing.T) {
+	t.Skip("blocked on (1) gonka-ai/cosmos-sdk genesis.go:157 fix per gonka-ai/gonka#1153, and (2) wiring SimulateFromSeedX for the after-import simulation step")
+	simsx.Run(t, NewSimApp, setupStateFactory, checkSimulationAfterImport)
+}
 
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		t.Skip("skipping application simulation after import")
-	}
-	require.NoError(t, err, "simulation setup failed")
+func checkSimulationAfterImport(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+	tb.Helper()
+	bApp := ti.App
 
-	defer func() {
-		require.NoError(t, db.Close())
-		require.NoError(t, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, bApp.Name())
-
-	// Run randomized simulation
-	stopEarly, simParams, simErr := simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-
-	if stopEarly {
-		fmt.Println("can't export or import a zero-validator genesis, exiting test...")
-		return
-	}
-
-	fmt.Printf("exporting genesis...\n")
-
+	tb.Logf("exporting genesis (forZeroHeight=true)...")
 	exported, err := bApp.ExportAppStateAndValidators(true, []string{}, []string{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	fmt.Printf("importing genesis...\n")
-
-	newDB, newDir, _, _, err := simtestutil.SetupSimulation(config, "leveldb-app-sim-2", "Simulation-2", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	require.NoError(t, err, "simulation setup failed")
-
-	defer func() {
-		require.NoError(t, newDB.Close())
-		require.NoError(t, os.RemoveAll(newDir))
-	}()
-
-	newApp, err := app.New(logger, newDB, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, newApp.Name())
+	tb.Logf("importing genesis into fresh app via InitChain...")
+	newTI := simsx.NewSimulationAppInstance(tb, ti.Cfg, NewSimApp)
+	newApp := newTI.App
+	defer func() { _ = newApp.Close() }()
 
 	_, err = newApp.InitChain(&abci.RequestInitChain{
 		AppStateBytes: exported.AppState,
-		ChainId:       SimAppChainID,
+		ChainId:       ti.Cfg.ChainID,
 	})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	_, _, err = simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		newApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(newApp, newApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-	require.NoError(t, err)
+	// TODO: once import unblocks, run SimulateFromSeedX on newApp. Needs
+	// either a copy of simsx's unexported prepareWeightedOps or a minimal
+	// ops registry.
+	tb.Log("import succeeded; second-simulation step deferred (see TODO)")
 }
 
+// TestAppStateDeterminism asserts that running the same seed N times
+// produces an identical AppHash. Uses simsx.RunWithSeed directly because
+// simsx.Run fans out distinct seeds in parallel; determinism wants the
+// same seed sequentially. PoC-state determinism beyond AppHash
+// (EffectiveIndex, epoch-state collections) is Phase 3 territory per the
+// issue body.
 func TestAppStateDeterminism(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in -short mode")
+	}
 	if !simcli.FlagEnabledValue {
-		t.Skip("skipping application simulation")
+		t.Skip("pass -Enabled=true to run this; simsx does not gate on it")
 	}
+	cfg := simcli.NewConfigFromFlags()
+	cfg.ChainID = simsx.SimAppChainID
 
-	config := simcli.NewConfigFromFlags()
-	config.InitialBlockHeight = 1
-	config.ExportParamsPath = ""
-	config.OnOperation = true
-	config.AllInvariants = true
-
-	numSeeds := 3
-	numTimesToRunPerSeed := 3 // This used to be set to 5, but we've temporarily reduced it to 3 for the sake of faster CI.
-	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
-
-	// We will be overriding the random seed and just run a single simulation on the provided seed value
-	if config.Seed != simcli.DefaultSeedValue {
-		numSeeds = 1
+	// Block counts inherit from simcli flags.
+	// Honor user-supplied -Seed=N for single-seed reproduction of a failure.
+	seeds := defaultSimSeeds
+	if cfg.Seed != simcli.DefaultSeedValue {
+		seeds = []int64{cfg.Seed}
 	}
+	const attempts = 3
 
-	appOptions := viper.New()
-	if FlagEnableStreamingValue {
-		m := make(map[string]interface{})
-		m["streaming.abci.keys"] = []string{"*"}
-		m["streaming.abci.plugin"] = "abci_v1"
-		m["streaming.abci.stop-node-on-err"] = true
-		for key, value := range m {
-			appOptions.SetDefault(key, value)
+	for _, seed := range seeds {
+		// Pre-allocated indexed slots so a failure points at the specific
+		// attempt rather than a generic count mismatch. RunWithSeed invokes
+		// capture synchronously, so hashes[attempt] is populated before the
+		// next iteration.
+		hashes := make([][]byte, attempts)
+		for attempt := range attempts {
+			capture := func(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+				hashes[attempt] = ti.App.LastCommitID().Hash
+			}
+			simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, seed, nil, capture)
+			require.NotEmptyf(t, hashes[attempt],
+				"capture callback was not invoked for seed %d attempt %d", seed, attempt)
 		}
-	}
-	appOptions.SetDefault(flags.FlagHome, app.DefaultNodeHome)
-	appOptions.SetDefault(server.FlagInvCheckPeriod, simcli.FlagPeriodValue)
-	if simcli.FlagVerboseValue {
-		appOptions.SetDefault(flags.FlagLogLevel, "debug")
-	}
-
-	for i := 0; i < numSeeds; i++ {
-		if config.Seed == simcli.DefaultSeedValue {
-			config.Seed = rand.Int63()
-		}
-		fmt.Println("config.Seed: ", config.Seed)
-
-		for j := 0; j < numTimesToRunPerSeed; j++ {
-			var logger log.Logger
-			if simcli.FlagVerboseValue {
-				logger = log.NewTestLogger(t)
-			} else {
-				logger = log.NewNopLogger()
-			}
-			chainID := fmt.Sprintf("chain-id-%d-%d", i, j)
-			config.ChainID = chainID
-
-			db := dbm.NewMemDB()
-			var emptyWasmOpts []wasmkeeper.Option
-
-			bApp, err := app.New(
-				logger,
-				db,
-				nil,
-				true,
-				appOptions,
-				emptyWasmOpts,
-				interBlockCacheOpt(),
-				baseapp.SetChainID(chainID),
-			)
-			require.NoError(t, err)
-
-			fmt.Printf(
-				"running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",
-				config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
-			)
-
-			_, _, err = simulation.SimulateFromSeed(
-				t,
-				os.Stdout,
-				bApp.BaseApp,
-				simtestutil.AppStateFn(
-					bApp.AppCodec(),
-					bApp.SimulationManager(),
-					bApp.DefaultGenesis(),
-				),
-				simulationtypes.RandomAccounts,
-				simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-				app.BlockedAddresses(),
-				config,
-				bApp.AppCodec(),
-			)
-			require.NoError(t, err)
-
-			if config.Commit {
-				simtestutil.PrintStats(db)
-			}
-
-			appHash := bApp.LastCommitID().Hash
-			appHashList[j] = appHash
-
-			if j != 0 {
-				require.Equal(
-					t, string(appHashList[0]), string(appHashList[j]),
-					"non-determinism in seed %d: %d/%d, attempt: %d/%d\n", config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
-				)
-			}
+		for i := 1; i < attempts; i++ {
+			require.Equalf(t, hashes[0], hashes[i],
+				"non-determinism in seed %d: attempt 0 vs %d", seed, i)
 		}
 	}
 }

--- a/inference-chain/app/simulation.go
+++ b/inference-chain/app/simulation.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+)
+
+// disabledOpsSimModule wraps an AppModuleSimulation and returns nil from
+// WeightedOperations, so the wrapped module's sim ops are excluded from
+// the simulator while GenerateGenesisState and store decoders continue
+// to work through embedding. HasProposalMsgs and HasProposalContents are
+// not on AppModuleSimulation, so they are never promoted regardless of
+// the wrapped module.
+//
+// Used for:
+//   - staking/distribution: the PoC chain has no token bonding or
+//     traditional rewards (docs/cosmos_changes.md); the stock sim msgs
+//     target state machinery this fork has neutralised.
+//   - wasmd v0.54.2: BuildOperationInput uses a failingAddressCodec
+//     rather than the app codec, so all wasm sim ops fail. Fixed in
+//     v0.60.0+ (CosmWasm/wasmd#2250).
+//
+// Originally proposed by hleb-albau in gonka-ai/gonka#995.
+type disabledOpsSimModule struct {
+	module.AppModuleSimulation
+}
+
+// WeightedOperations always returns nil. See type doc.
+func (disabledOpsSimModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return nil
+}

--- a/inference-chain/app/simulation_test.go
+++ b/inference-chain/app/simulation_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSimModule is a non-nil AppModuleSimulation stub that returns a
+// non-empty WeightedOperations slice. Lets the test below show that
+// disabledOpsSimModule's override actually fires, instead of trivially
+// passing because of a nil embed.
+type stubSimModule struct {
+	module.AppModuleSimulation
+}
+
+func (stubSimModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return make([]simtypes.WeightedOperation, 1)
+}
+
+// TestDisabledOpsSimModule_SuppressesEmbeddedOps confirms the wrapper's
+// override takes precedence over the embedded module's
+// WeightedOperations.
+func TestDisabledOpsSimModule_SuppressesEmbeddedOps(t *testing.T) {
+	require.NotEmpty(t, stubSimModule{}.WeightedOperations(module.SimulationState{}))
+	wrapped := disabledOpsSimModule{stubSimModule{}}
+	require.Empty(t, wrapped.WeightedOperations(module.SimulationState{}))
+}

--- a/inference-chain/cmd/inferenced/cmd/config.go
+++ b/inference-chain/cmd/inferenced/cmd/config.go
@@ -3,31 +3,7 @@ package cmd
 import (
 	cmtcfg "github.com/cometbft/cometbft/config"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/productscience/inference/app"
 )
-
-const (
-	CoinType = 1200
-)
-
-func initSDKConfig() {
-	// Set prefixes
-	accountPubKeyPrefix := app.AccountAddressPrefix + "pub"
-	validatorAddressPrefix := app.AccountAddressPrefix + "valoper"
-	validatorPubKeyPrefix := app.AccountAddressPrefix + "valoperpub"
-	consNodeAddressPrefix := app.AccountAddressPrefix + "valcons"
-	consNodePubKeyPrefix := app.AccountAddressPrefix + "valconspub"
-
-	// Set and seal config
-	config := sdk.GetConfig()
-	config.SetCoinType(CoinType) // TODO: change to custom coin type
-	config.SetBech32PrefixForAccount(app.AccountAddressPrefix, accountPubKeyPrefix)
-	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
-	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)
-	config.Seal()
-}
 
 // initCometBFTConfig helps to override default CometBFT Config values.
 // return cmtcfg.DefaultConfig if no custom configuration is required for the application.

--- a/inference-chain/cmd/inferenced/cmd/root.go
+++ b/inference-chain/cmd/inferenced/cmd/root.go
@@ -29,7 +29,8 @@ import (
 
 // NewRootCmd creates a new root command for inferenced. It is called once in the main function.
 func NewRootCmd() *cobra.Command {
-	initSDKConfig()
+	app.InitSDKConfig()
+	app.SealSDKConfig()
 
 	var (
 		txConfigOpts       tx.ConfigOptions

--- a/inference-chain/x/inference/module/simulation.go
+++ b/inference-chain/x/inference/module/simulation.go
@@ -93,7 +93,8 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		accs[i] = acc.Address.String()
 	}
 	inferenceGenesis := types.GenesisState{
-		Params: types.DefaultParams(),
+		Params:            types.DefaultParams(),
+		GenesisOnlyParams: types.DefaultGenesisOnlyParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&inferenceGenesis) //nolint:forbidigo // Simulation code


### PR DESCRIPTION
## Summary

Phase 1 of #982: make Cosmos SDK simulation runnable on `inference-chain` end-to-end so subsequent phases (real `x/inference` ops, weight tuning, parameter-edge fuzzing) have a working harness to land on. Scope is intentionally "make it run"; real ops and deeper coverage are deferred per the issue's phased plan.

## What's added

- **simsx integration** in `app/sim_test.go` and `app/sim_bench_test.go`. `*App` satisfies `simsx.SimulationApp` (added `TxConfig`, `GetBaseApp`).
- **Make targets**: `node-sim-smoke-test` (50×20, ~15 min, `-Seed=99`) and `node-sim-full-test` (500×200, ~120 min). Root Makefile delegates to `inference-chain/Makefile` via `make -C`.
- **`disabledOpsSimModule`** wrapper (`app/simulation.go`): returns nil from `WeightedOperations` while preserving `GenerateGenesisState` via embedding. Applied to staking, distribution, wasmd. Type assertion via `mustSimMod` panics with a clear message if a future SDK upgrade drops `AppModuleSimulation`.
- **`fixBankGenesisState`**: recomputes Supply from Balances + adds Gonka denom metadata so InitGenesis succeeds with staking ops disabled (ported from PR #995).
- **`TestApp_GenesisInit_ModuleAccountsAndPoCValidators`**: verifies blocked module accounts populate, PoC compute path adds validators, fee collector is a real ModuleAccount.
- **Three tests reimplemented** in simsx idioms (PR #995 deletions):
  - `TestAppImportExport_Postrun` — postRunAction; `t.Skip`'d pending the fork bonded-pool fix proposed in #1153.
  - `TestAppSimulationAfterImport_Postrun` — postRunAction; `t.Skip`'d pending the bonded-pool fix and `SimulateFromSeedX` wiring.
  - `TestAppStateDeterminism` — 3 seeds × 3 attempts identical AppHash via `RunWithSeed` loop.
- **`TestDisabledOpsSimModule_SuppressesEmbeddedOps`**: confirms the wrapper override fires against a non-nil stub embed.
- **`GenesisOnlyParams`** seeded in `x/inference/module/simulation.go` (PR #995).
- **SDK config refactor**: `InitSDKConfig` (extracted to `app/sdk_config.go`, idempotent, no seal) + new `SealSDKConfig` (production-only). Production calls both; tests call only `InitSDKConfig`.
- **`docs/simulation.md`**: operator/dev reference covering run modes, build tags, CLI flags, failure interpretation, canonical Docker run, test inventory, phase status.
- **`.github/workflows/simulation.yml`**: `workflow_dispatch` smoke job on ubuntu-24.04. Manual trigger only.

## Test plan

Verified in canonical Docker (Go 1.24.2-alpine + muslc):

- [x] `go build ./...` and `go build -tags sims ./app/...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` (no sims tag): 34 packages OK, 0 FAIL
- [x] `go test -tags 'sims muslc' ./app/...` (no `-Enabled`): sim tests skip cleanly, no panic
- [x] `go test -tags 'sims muslc' -Enabled=true -Seed=99 ./app/`: `TestFullAppSimulation` PASS in 1.07s

## Out of scope (per plan)

- Real `x/inference` operations replacing NoOpMsg stubs → Phase 2
- Custom invariants, parameter-edge fuzzing, store decoders, weight tuning → Phase 3
- Custom-module sim ops for `bls`/`bookkeeper`/`collateral`/`genesistransfer`/`restrictions`/`streamvesting` → Phase 4 of issue roadmap
- PoC epoch + validator-set sim → out of #982 entirely
- Devshard simulation → separate Go module

## Notes for review

- `simsx.Run` does not honor `-Enabled=false` the way legacy `simulation.SimulateFromSeed` did, so `TestFullAppSimulation` and `TestAppStateDeterminism` restore that gate via explicit `if !FlagEnabledValue { t.Skip }`. This matches `docs/simulation.md` flag table.
- `mustSimMod` helper guards against silent NPE risk if an SDK upgrade drops `AppModuleSimulation` from one of staking/distribution/wasm.
- The `*_Postrun` tests skip with explicit reasons; see comments above each test and #1153 for the fork fix proposal.

Part of #982 (Phase 1 of 4; Phases 2-4 to follow as separate PRs).

cc @patimen — single-target review request as #982 author; happy to iterate on scope or sequencing.
