### PR TITLE
Fetch validation threshold

### DIFF
--- a/decentralized-api/cmd/devshardd/main.go
+++ b/decentralized-api/cmd/devshardd/main.go
@@ -129,7 +129,7 @@ func main() {
 		3*time.Minute,
 	)
 
-	httpClient := pserver.NewNoRedirectClient(5 * time.Minute)
+	httpClient := pserver.NewNoRedirectClient(internaldevshard.MLNodeHTTPTimeout)
 
 	chainParams := newChainParamsProvider(ctx, recorder)
 

--- a/decentralized-api/cmd/devshardd/validation.go
+++ b/decentralized-api/cmd/devshardd/validation.go
@@ -25,6 +25,7 @@ type devshardValidator struct {
 	recorder    internaldevshard.PayloadAuthClient
 	engine      *devshardEngine // reused for doWithLockedNode retry loop
 	chainParams internaldevshard.ChainParamsProvider
+	thresholds  *internaldevshard.ValidationThresholdResolver
 }
 
 func newDevshardValidator(
@@ -42,6 +43,7 @@ func newDevshardValidator(
 		recorder:    recorder,
 		engine:      engine,
 		chainParams: chainParams,
+		thresholds:  internaldevshard.NewValidationThresholdResolver(br, internaldevshard.ValidationThresholdCacheTTL),
 	}
 }
 
@@ -57,6 +59,7 @@ func (v *devshardValidator) Validate(ctx context.Context, req devshardpkg.Valida
 		v.executeMLRequest,
 		"devshardd",
 		v.chainParams,
+		v.thresholds,
 	)
 }
 

--- a/decentralized-api/completionapi/responseprocessor_test.go
+++ b/decentralized-api/completionapi/responseprocessor_test.go
@@ -74,6 +74,25 @@ func TestCompletionTokenCountForStreamedResponse(t *testing.T) {
 	require.NotEmpty(t, hash, "expected hash to be not empty")
 }
 
+func TestCompletionTokenCountForPartialStreamUsesLogprobEntries(t *testing.T) {
+	processor := NewExecutorResponseProcessor("partial-id")
+	events := []string{
+		`data: {"id":"upstream","object":"chat.completion.chunk","model":"test-model","choices":[{"index":0,"delta":{"content":"ab"},"logprobs":{"content":[{"token":"a","logprob":-0.1,"top_logprobs":[{"token":"a","logprob":-0.1},{"token":"x","logprob":-1.1},{"token":"y","logprob":-2.1}]},{"token":"b","logprob":-0.2,"top_logprobs":[{"token":"b","logprob":-0.2},{"token":"m","logprob":-1.2},{"token":"n","logprob":-2.2}]}]},"finish_reason":null}]}`,
+		`data: {"id":"upstream","object":"chat.completion.chunk","model":"test-model","choices":[{"index":0,"delta":{"content":"c"},"logprobs":{"content":[{"token":"c","logprob":-0.3,"top_logprobs":[{"token":"c","logprob":-0.3},{"token":"q","logprob":-1.3},{"token":"r","logprob":-2.3},{"token":"s","logprob":-3.3}]}]},"finish_reason":null}]}`,
+	}
+	for _, event := range events {
+		_, err := processor.ProcessStreamedResponse(event)
+		require.NoError(t, err)
+	}
+
+	response, err := processor.GetResponse()
+	require.NoError(t, err)
+	usage, err := response.GetUsage()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), usage.PromptTokens)
+	require.Equal(t, uint64(3), usage.CompletionTokens)
+}
+
 func TestCompletionTokenCountForStreamedResponseWithTokenIds(t *testing.T) {
 	dummyId := "dummy-inference-id"
 	processor := NewExecutorResponseProcessor(dummyId)

--- a/decentralized-api/internal/devshard/bridge.go
+++ b/decentralized-api/internal/devshard/bridge.go
@@ -68,6 +68,31 @@ func (b *ChainBridge) GetHostInfo(address string) (*bridge.HostInfo, error) {
 	}, nil
 }
 
+func (b *ChainBridge) GetValidationThreshold(epochID uint64, modelID string) (*bridge.Decimal, error) {
+	ctx := context.Background()
+	qc := b.client.NewInferenceQueryClient()
+
+	resp, err := qc.EpochGroupData(ctx, &types.QueryGetEpochGroupDataRequest{
+		EpochIndex: epochID,
+		ModelId:    modelID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query model validation threshold: %w", err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("model snapshot not found for epoch %d model %s", epochID, modelID)
+	}
+	epochGroupData := resp.GetEpochGroupData()
+	if epochGroupData.ModelSnapshot == nil {
+		return nil, fmt.Errorf("model snapshot not found for epoch %d model %s", epochID, modelID)
+	}
+	threshold := epochGroupData.ModelSnapshot.ValidationThreshold
+	if threshold == nil {
+		return nil, fmt.Errorf("validation threshold missing for epoch %d model %s", epochID, modelID)
+	}
+	return &bridge.Decimal{Value: threshold.Value, Exponent: threshold.Exponent}, nil
+}
+
 const warmKeyMsgType = "/inference.inference.MsgStartInference"
 
 func (b *ChainBridge) VerifyWarmKey(warmAddress, validatorAddress string) (bool, error) {

--- a/decentralized-api/internal/devshard/engine_test.go
+++ b/decentralized-api/internal/devshard/engine_test.go
@@ -2,18 +2,39 @@ package devshard
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"decentralized-api/completionapi"
 	"decentralized-api/utils"
 
+	devshardpkg "devshard"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type interruptedBody struct {
+	data []byte
+	read bool
+}
+
+func (b *interruptedBody) Read(p []byte) (int, error) {
+	if b.read {
+		return 0, errors.New("stream interrupted")
+	}
+	b.read = true
+	return copy(p, b.data), nil
+}
+
+func (b *interruptedBody) Close() error { return nil }
 
 func TestProcessHTTPResponse_SSE(t *testing.T) {
 	body := "data: {\"id\":\"1\",\"choices\":[]}\n\ndata: [DONE]\n"
@@ -93,6 +114,49 @@ func TestResponseHashComputation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(10), usage.PromptTokens)
 	assert.Equal(t, uint64(5), usage.CompletionTokens)
+}
+
+func TestProcessExecutionHTTPResponse_PartialSSEAfterInterruption(t *testing.T) {
+	inferenceID := "devshard-escrow-1-7"
+	body := []byte(`data: {"id":"upstream","model":"llama","choices":[{"delta":{"content":"hello"},"logprobs":{"content":[{"token":"hello","logprob":-0.1,"top_logprobs":[{"token":"hello","logprob":-0.1}]}]}}],"usage":{"prompt_tokens":12,"completion_tokens":1}}` + "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       &interruptedBody{data: body},
+	}
+
+	processed, err := ProcessExecutionHTTPResponse(devshardpkg.ExecuteRequest{}, resp, inferenceID)
+	require.NoError(t, err)
+	require.NotNil(t, processed)
+	require.Equal(t, uint64(12), processed.InputTokens)
+	require.Equal(t, uint64(1), processed.OutputTokens)
+	require.Contains(t, string(processed.ResponseBody), inferenceID)
+
+	expectedHash := sha256.Sum256(processed.ResponseBody)
+	require.Equal(t, expectedHash[:], processed.ResponseHash)
+}
+
+func TestFetchPayloadsHTTPWithTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: time.Minute}
+	start := time.Now()
+	_, err := fetchPayloadsHTTPWithTimeout(
+		context.Background(),
+		client,
+		20*time.Millisecond,
+		server.URL,
+		"validator",
+		time.Now().UnixNano(),
+		1,
+		"signature",
+	)
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 500*time.Millisecond)
 }
 
 func TestCanonicalizePrompt(t *testing.T) {

--- a/decentralized-api/internal/devshard/manager_test.go
+++ b/decentralized-api/internal/devshard/manager_test.go
@@ -43,6 +43,10 @@ func (b *mockBridge) GetHostInfo(address string) (*bridge.HostInfo, error) {
 	return &bridge.HostInfo{Address: address, URL: "http://localhost"}, nil
 }
 
+func (b *mockBridge) GetValidationThreshold(uint64, string) (*bridge.Decimal, error) {
+	return nil, bridge.ErrNotImplemented
+}
+
 func (b *mockBridge) VerifyWarmKey(string, string) (bool, error) { return false, nil }
 
 func (b *mockBridge) OnEscrowCreated(bridge.EscrowInfo) error { return bridge.ErrNotImplemented }

--- a/decentralized-api/internal/devshard/shared_runtime.go
+++ b/decentralized-api/internal/devshard/shared_runtime.go
@@ -296,7 +296,8 @@ func EvaluateValidationResponse(
 }
 
 func tokenCountInflated(claimed, validation uint64) bool {
-	const tokenCountTolerance uint64 = 1
+	// TODO: figure out tokens
+	const tokenCountTolerance uint64 = 3
 	return claimed > validation && claimed-validation > tokenCountTolerance
 }
 

--- a/decentralized-api/internal/devshard/shared_runtime.go
+++ b/decentralized-api/internal/devshard/shared_runtime.go
@@ -91,6 +91,7 @@ func ValidateInferenceWithExecutor(
 	execute MLRequestExecutor,
 	logPrefix string,
 	chainParams ChainParamsProvider,
+	thresholds *ValidationThresholdResolver,
 ) (*devshardpkg.ValidateResult, error) {
 	inferenceID := strconv.FormatUint(req.InferenceID, 10)
 
@@ -119,7 +120,7 @@ func ValidateInferenceWithExecutor(
 	}
 	defer resp.Body.Close()
 
-	return EvaluateValidationResponse(resp, req, inferenceID, logPrefix, responsePayload)
+	return EvaluateValidationResponse(ctx, resp, req, inferenceID, logPrefix, responsePayload, thresholds)
 }
 
 type ProcessedExecutionResponse struct {
@@ -217,11 +218,13 @@ func BuildValidationBody(
 }
 
 func EvaluateValidationResponse(
+	ctx context.Context,
 	resp *http.Response,
 	req devshardpkg.ValidateRequest,
 	inferenceID string,
 	logPrefix string,
 	originalResponsePayload []byte,
+	thresholds *ValidationThresholdResolver,
 ) (*devshardpkg.ValidateResult, error) {
 	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity {
 		return &devshardpkg.ValidateResult{Valid: true}, nil
@@ -261,7 +264,34 @@ func EvaluateValidationResponse(
 		validationResponse.ExtractLogits(),
 		base,
 	)
-	return &devshardpkg.ValidateResult{Valid: result.IsSuccessful()}, nil
+	valid, err := EvaluateValidationResult(ctx, result, req, thresholds)
+	if err != nil {
+		return nil, err
+	}
+	return &devshardpkg.ValidateResult{Valid: valid}, nil
+}
+
+func EvaluateValidationResult(
+	ctx context.Context,
+	result validationpkg.ValidationResult,
+	req devshardpkg.ValidateRequest,
+	thresholds *ValidationThresholdResolver,
+) (bool, error) {
+	switch r := result.(type) {
+	case *validationpkg.SimilarityValidationResult:
+		threshold, err := thresholds.Resolve(ctx, req.EscrowID, req.EpochID, req.Model)
+		if err != nil {
+			return false, err
+		}
+		passValue := chaintypes.Decimal{Value: threshold.Value, Exponent: threshold.Exponent}
+		return chaintypes.DecimalFromFloat(r.Value).ToDecimal().GreaterThan(passValue.ToDecimal()), nil
+	case *validationpkg.DifferentLengthValidationResult,
+		*validationpkg.DifferentTokensValidationResult,
+		*validationpkg.InvalidInferenceResult:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown validation result type %T", result)
+	}
 }
 
 func ReadHTTPBody(resp *http.Response) ([]byte, error) {

--- a/decentralized-api/internal/devshard/shared_runtime.go
+++ b/decentralized-api/internal/devshard/shared_runtime.go
@@ -29,6 +29,11 @@ import (
 
 type MLRequestExecutor func(ctx context.Context, model string, body []byte) (*http.Response, error)
 
+const (
+	MLNodeHTTPTimeout   = 10 * time.Minute
+	PayloadFetchTimeout = 30 * time.Second
+)
+
 func ExecuteInferenceWithExecutor(
 	ctx context.Context,
 	req devshardpkg.ExecuteRequest,
@@ -140,14 +145,32 @@ func ProcessExecutionHTTPResponse(
 	contentType := resp.Header.Get("Content-Type")
 	isSSE := strings.HasPrefix(contentType, "text/event-stream")
 
+	var processErr error
 	if req.ResponseWriter != nil && isSSE {
-		public.ProxyResponse(resp, req.ResponseWriter, true, processor, inferenceID)
+		processErr = public.ProxyResponse(resp, req.ResponseWriter, true, processor, inferenceID)
 	} else {
-		if err := completionapi.ProcessHTTPResponse(resp, processor); err != nil {
-			return nil, fmt.Errorf("process response: %w", err)
-		}
+		processErr = completionapi.ProcessHTTPResponse(resp, processor)
 	}
 
+	processed, err := buildProcessedExecutionResponse(req, processor, isSSE)
+	if err != nil {
+		if processErr != nil {
+			return nil, fmt.Errorf("process response: %w", processErr)
+		}
+		return nil, err
+	}
+	if processErr != nil {
+		logging.Warn("Using partial devshard inference response after interrupted stream",
+			chaintypes.Inferences, "inferenceId", inferenceID, "error", processErr)
+	}
+	return processed, nil
+}
+
+func buildProcessedExecutionResponse(
+	req devshardpkg.ExecuteRequest,
+	processor *completionapi.ExecutorResponseProcessor,
+	isSSE bool,
+) (*ProcessedExecutionResponse, error) {
 	completionResp, err := processor.GetResponse()
 	if err != nil {
 		return nil, fmt.Errorf("get completion response: %w", err)
@@ -246,7 +269,8 @@ func EvaluateValidationResponse(
 	}
 
 	if validationUsage, err := validationResponse.GetUsage(); err == nil {
-		if req.InputTokens > validationUsage.PromptTokens || req.OutputTokens > validationUsage.CompletionTokens {
+		if tokenCountInflated(req.InputTokens, validationUsage.PromptTokens) ||
+			tokenCountInflated(req.OutputTokens, validationUsage.CompletionTokens) {
 			logging.Warn(logPrefix+" validation failed: inflated token counts",
 				chaintypes.Validation, "inferenceId", inferenceID,
 				"claimedInput", req.InputTokens, "validationInput", validationUsage.PromptTokens,
@@ -269,6 +293,11 @@ func EvaluateValidationResponse(
 		return nil, err
 	}
 	return &devshardpkg.ValidateResult{Valid: valid}, nil
+}
+
+func tokenCountInflated(claimed, validation uint64) bool {
+	const tokenCountTolerance uint64 = 1
+	return claimed > validation && claimed-validation > tokenCountTolerance
 }
 
 func EvaluateValidationResult(
@@ -384,9 +413,10 @@ func FetchPayloadsFromExecutor(
 		return nil, nil, fmt.Errorf("sign request: %w", err)
 	}
 
-	payloadResp, err := validationpkg.FetchPayloadsHTTP(
+	payloadResp, err := fetchPayloadsHTTPWithTimeout(
 		ctx,
 		httpClient,
+		PayloadFetchTimeout,
 		requestURL,
 		validatorAddress,
 		timestamp,
@@ -424,4 +454,28 @@ func FetchPayloadsFromExecutor(
 	}
 
 	return payloadResp.PromptPayload, payloadResp.ResponsePayload, nil
+}
+
+func fetchPayloadsHTTPWithTimeout(
+	ctx context.Context,
+	httpClient *http.Client,
+	timeout time.Duration,
+	requestURL string,
+	validatorAddress string,
+	timestamp int64,
+	epochID uint64,
+	signature string,
+) (*validationpkg.PayloadResponse, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return validationpkg.FetchPayloadsHTTP(
+		fetchCtx,
+		httpClient,
+		requestURL,
+		validatorAddress,
+		timestamp,
+		epochID,
+		signature,
+	)
 }

--- a/decentralized-api/internal/devshard/threshold_resolver.go
+++ b/decentralized-api/internal/devshard/threshold_resolver.go
@@ -1,0 +1,95 @@
+package devshard
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"devshard/bridge"
+)
+
+const ValidationThresholdCacheTTL = 10 * time.Minute
+
+type validationThresholdCacheKey struct {
+	escrowID string
+	modelID  string
+}
+
+type validationThresholdCacheEntry struct {
+	epochID   uint64
+	threshold *bridge.Decimal
+	expiresAt time.Time
+}
+
+// ValidationThresholdResolver loads the epoch-pinned model threshold used by
+// mainnet validation and caches it for the lifetime of a devshard escrow.
+type ValidationThresholdResolver struct {
+	bridge bridge.MainnetBridge
+	ttl    time.Duration
+
+	mu    sync.Mutex
+	cache map[validationThresholdCacheKey]validationThresholdCacheEntry
+}
+
+func NewValidationThresholdResolver(br bridge.MainnetBridge, ttl time.Duration) *ValidationThresholdResolver {
+	if ttl <= 0 {
+		ttl = ValidationThresholdCacheTTL
+	}
+	return &ValidationThresholdResolver{
+		bridge: br,
+		ttl:    ttl,
+		cache:  make(map[validationThresholdCacheKey]validationThresholdCacheEntry),
+	}
+}
+
+func (r *ValidationThresholdResolver) Resolve(
+	ctx context.Context,
+	escrowID string,
+	epochID uint64,
+	modelID string,
+) (*bridge.Decimal, error) {
+	if r == nil {
+		return nil, fmt.Errorf("validation threshold resolver is nil")
+	}
+
+	key := validationThresholdCacheKey{escrowID: escrowID, modelID: modelID}
+	now := time.Now()
+
+	r.mu.Lock()
+	if entry, ok := r.cache[key]; ok && entry.epochID == epochID && now.Before(entry.expiresAt) {
+		threshold := cloneDecimal(entry.threshold)
+		r.mu.Unlock()
+		return threshold, nil
+	}
+	r.mu.Unlock()
+
+	if r.bridge == nil {
+		return nil, fmt.Errorf("validation threshold resolver has no bridge")
+	}
+
+	threshold, err := r.bridge.GetValidationThreshold(epochID, modelID)
+	if err != nil {
+		return nil, err
+	}
+	if threshold == nil {
+		return nil, fmt.Errorf("validation threshold missing for epoch %d model %s", epochID, modelID)
+	}
+
+	r.mu.Lock()
+	r.cache[key] = validationThresholdCacheEntry{
+		epochID:   epochID,
+		threshold: cloneDecimal(threshold),
+		expiresAt: now.Add(r.ttl),
+	}
+	r.mu.Unlock()
+
+	return cloneDecimal(threshold), nil
+}
+
+func cloneDecimal(d *bridge.Decimal) *bridge.Decimal {
+	if d == nil {
+		return nil
+	}
+	return &bridge.Decimal{Value: d.Value, Exponent: d.Exponent}
+}

--- a/decentralized-api/internal/devshard/validation.go
+++ b/decentralized-api/internal/devshard/validation.go
@@ -23,6 +23,7 @@ type ValidationAdapter struct {
 	bridge       bridge.MainnetBridge
 	recorder     PayloadAuthClient
 	chainParams  ChainParamsProvider
+	thresholds   *ValidationThresholdResolver
 }
 
 func NewValidationAdapter(
@@ -42,6 +43,7 @@ func NewValidationAdapter(
 		bridge:       br,
 		recorder:     recorder,
 		chainParams:  chainParams,
+		thresholds:   NewValidationThresholdResolver(br, ValidationThresholdCacheTTL),
 	}
 }
 
@@ -57,6 +59,7 @@ func (v *ValidationAdapter) Validate(ctx context.Context, req devshard.ValidateR
 		v.executeMLRequest,
 		"devshard",
 		v.chainParams,
+		v.thresholds,
 	)
 }
 

--- a/decentralized-api/internal/devshard/validation_test.go
+++ b/decentralized-api/internal/devshard/validation_test.go
@@ -258,6 +258,13 @@ func TestTokenCountValidation_MatchingUsage(t *testing.T) {
 	assert.False(t, claimedOutput > usage.CompletionTokens, "matching output should not exceed stored")
 }
 
+func TestTokenCountValidation_AllowsOneTokenDrift(t *testing.T) {
+	assert.False(t, tokenCountInflated(11, 10), "one extra token should be tolerated")
+	assert.False(t, tokenCountInflated(10, 10), "matching token count should pass")
+	assert.False(t, tokenCountInflated(9, 10), "lower claimed token count should pass")
+	assert.True(t, tokenCountInflated(12, 10), "more than one extra token should be rejected")
+}
+
 func TestTokenCountValidation_InflatedOutputTokens(t *testing.T) {
 	// Stored response has prompt_tokens=10, completion_tokens=5
 	jsonResp := `{"id":"test","choices":[{"message":{"content":"hello"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`

--- a/decentralized-api/internal/devshard/validation_test.go
+++ b/decentralized-api/internal/devshard/validation_test.go
@@ -1,14 +1,19 @@
 package devshard
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"decentralized-api/completionapi"
 	"decentralized-api/internal/validation"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	devshardpkg "devshard"
+	"devshard/bridge"
 )
 
 func TestCompareLogitsMatching(t *testing.T) {
@@ -84,10 +89,10 @@ func TestEnforcedTokensExtraction(t *testing.T) {
 
 func TestValidationRequestBodyConstruction(t *testing.T) {
 	requestMap := map[string]interface{}{
-		"model":            "test-model",
-		"messages":         []interface{}{},
-		"stream":           true,
-		"stream_options":   map[string]interface{}{"include_usage": true},
+		"model":               "test-model",
+		"messages":            []interface{}{},
+		"stream":              true,
+		"stream_options":      map[string]interface{}{"include_usage": true},
 		"skip_special_tokens": false,
 	}
 
@@ -124,6 +129,115 @@ func TestResponseFromPayload(t *testing.T) {
 	logits := resp.ExtractLogits()
 	require.Len(t, logits, 1)
 	assert.Equal(t, "hello", logits[0].Token)
+}
+
+func TestEvaluateValidationResult_UsesModelThreshold(t *testing.T) {
+	req := devshardpkg.ValidateRequest{
+		EscrowID: "escrow-1",
+		EpochID:  7,
+		Model:    "model-a",
+	}
+	resolver := cachedThresholdResolver(req, &bridge.Decimal{Value: 90, Exponent: -2})
+
+	tests := []struct {
+		name       string
+		similarity float64
+		want       bool
+	}{
+		{name: "above threshold passes", similarity: 0.91, want: true},
+		{name: "equal threshold fails", similarity: 0.90, want: false},
+		{name: "below threshold fails", similarity: 0.89, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &validation.SimilarityValidationResult{Value: tt.similarity}
+			valid, err := EvaluateValidationResult(context.Background(), result, req, resolver)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, valid)
+		})
+	}
+}
+
+func TestEvaluateValidationResult_KnownFailureTypesFailWithoutThreshold(t *testing.T) {
+	req := devshardpkg.ValidateRequest{}
+	results := []validation.ValidationResult{
+		&validation.DifferentLengthValidationResult{},
+		&validation.DifferentTokensValidationResult{},
+		&validation.InvalidInferenceResult{},
+	}
+
+	for _, result := range results {
+		valid, err := EvaluateValidationResult(context.Background(), result, req, nil)
+		require.NoError(t, err)
+		assert.False(t, valid)
+	}
+}
+
+func TestEvaluateValidationResult_UnknownTypeErrors(t *testing.T) {
+	valid, err := EvaluateValidationResult(context.Background(), unknownValidationResult{}, devshardpkg.ValidateRequest{}, nil)
+	require.Error(t, err)
+	assert.False(t, valid)
+}
+
+func TestValidationThresholdResolverFailsClosed(t *testing.T) {
+	resolver := NewValidationThresholdResolver(nil, time.Minute)
+	_, err := resolver.Resolve(context.Background(), "escrow-1", 7, "model-a")
+	require.Error(t, err)
+
+	resolver = NewValidationThresholdResolver(&thresholdBridge{}, time.Minute)
+	_, err = resolver.Resolve(context.Background(), "escrow-1", 7, "model-a")
+	require.Error(t, err)
+}
+
+func cachedThresholdResolver(req devshardpkg.ValidateRequest, threshold *bridge.Decimal) *ValidationThresholdResolver {
+	return &ValidationThresholdResolver{
+		cache: map[validationThresholdCacheKey]validationThresholdCacheEntry{
+			{escrowID: req.EscrowID, modelID: req.Model}: {
+				epochID:   req.EpochID,
+				threshold: threshold,
+				expiresAt: time.Now().Add(time.Hour),
+			},
+		},
+	}
+}
+
+type unknownValidationResult struct{}
+
+func (unknownValidationResult) IsSuccessful() bool { return true }
+
+func (unknownValidationResult) GetInferenceId() string { return "unknown" }
+
+func (unknownValidationResult) GetValidationResponseBytes() []byte { return nil }
+
+type thresholdBridge struct{}
+
+func (thresholdBridge) GetEscrow(string) (*bridge.EscrowInfo, error) {
+	return nil, bridge.ErrNotImplemented
+}
+
+func (thresholdBridge) GetHostInfo(string) (*bridge.HostInfo, error) {
+	return nil, bridge.ErrNotImplemented
+}
+
+func (thresholdBridge) GetValidationThreshold(uint64, string) (*bridge.Decimal, error) {
+	return nil, nil
+}
+
+func (thresholdBridge) VerifyWarmKey(string, string) (bool, error) {
+	return false, bridge.ErrNotImplemented
+}
+
+func (thresholdBridge) OnEscrowCreated(bridge.EscrowInfo) error { return bridge.ErrNotImplemented }
+
+func (thresholdBridge) OnSettlementProposed(string, []byte, uint64) error {
+	return bridge.ErrNotImplemented
+}
+
+func (thresholdBridge) OnSettlementFinalized(string) error { return bridge.ErrNotImplemented }
+
+func (thresholdBridge) SubmitDisputeState(string, []byte, uint64, map[uint32][]byte) error {
+	return bridge.ErrNotImplemented
 }
 
 func TestTokenCountValidation_MatchingUsage(t *testing.T) {

--- a/decentralized-api/internal/server/public/post_chat_handler.go
+++ b/decentralized-api/internal/server/public/post_chat_handler.go
@@ -450,7 +450,7 @@ func (s *Server) handleTransferRequest(ctx echo.Context, request *ChatRequest) e
 	logging.Info("Proxying response from executor", types.Inferences,
 		"inferenceId", inferenceUUID,
 		"executor", executor.Address)
-	ProxyResponse(resp, ctx.Response().Writer, false, nil, inferenceUUID)
+	_ = ProxyResponse(resp, ctx.Response().Writer, false, nil, inferenceUUID)
 	return nil
 }
 
@@ -660,14 +660,26 @@ func (s *Server) handleExecutorRequest(ctx echo.Context, request *ChatRequest, w
 
 	responseProcessor := completionapi.NewExecutorResponseProcessor(request.InferenceId)
 	logging.Debug("Proxying response from inference node", types.Inferences, "inferenceId", request.InferenceId)
-	ProxyResponse(resp, w, true, responseProcessor, inferenceId)
+	proxyErr := ProxyResponse(resp, w, true, responseProcessor, inferenceId)
 
 	logging.Debug("Processing response from inference node", types.Inferences, "inferenceId", request.InferenceId)
 	completionResponse, err := responseProcessor.GetResponse()
 
-	if err != nil || completionResponse == nil {
+	if completionResponse == nil && err == nil {
+		err = errors.New("completion response is nil")
+	}
+	if err != nil {
+		if proxyErr != nil {
+			logging.Error("Failed to proxy response before a parseable completion was available", types.Inferences,
+				"inferenceId", inferenceId, "proxyError", proxyErr, "parseError", err)
+			return fmt.Errorf("proxy response failed before parseable completion: %w", proxyErr)
+		}
 		logging.Error("Failed to parse response data into CompletionResponse", types.Inferences, "error", err)
-		return err
+		return fmt.Errorf("parse completion response: %w", err)
+	}
+	if proxyErr != nil {
+		logging.Warn("Recording FinishInference from partial proxied response", types.Inferences,
+			"inferenceId", inferenceId, "error", proxyErr)
 	}
 
 	err = s.sendInferenceTransaction(request.InferenceId, completionResponse, request.Body, s.recorder.GetAccountAddress(), request, promptPayload)

--- a/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
+++ b/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
@@ -18,6 +18,7 @@ import (
 	"decentralized-api/apiconfig"
 	"decentralized-api/broker"
 	"decentralized-api/chainphase"
+	"decentralized-api/completionapi"
 	"decentralized-api/cosmosclient"
 	"decentralized-api/mlnodeclient"
 	"decentralized-api/utils"
@@ -559,6 +560,10 @@ func (s *interruptionTestSuite) createSignedExecutorRequest(inferenceId string, 
 		"stream":   stream,
 	}
 	bodyBytes, _ := json.Marshal(body)
+	modifiedRequest, err := completionapi.ModifyRequestBodyWithLogprobsMode(bodyBytes, 12345, types.DefaultLogprobsMode)
+	require.NoError(s.t, err)
+	modifiedPromptHash, _, err := getModifiedPromptHash(modifiedRequest.NewBody)
+	require.NoError(s.t, err)
 
 	timestamp := time.Now().UnixNano()
 	// Use the address from the test suite's generated keyring
@@ -577,7 +582,7 @@ func (s *interruptionTestSuite) createSignedExecutorRequest(inferenceId string, 
 
 	// TA signs: prompt_hash + timestamp + ta_address + executor_address
 	taComponents := calculations.SignatureComponents{
-		Payload:         originalPromptHash,
+		Payload:         modifiedPromptHash,
 		Timestamp:       timestamp,
 		TransferAddress: transferAddress,
 		ExecutorAddress: executorAddress,
@@ -593,7 +598,7 @@ func (s *interruptionTestSuite) createSignedExecutorRequest(inferenceId string, 
 	req.Header.Set("X-Transfer-Address", transferAddress)
 	req.Header.Set("X-Requester-Address", "test-requester-address")
 	req.Header.Set("X-TA-Signature", taSignature)
-	// Don't set X-Prompt-Hash - executor computes its own from modified body
+	req.Header.Set(utils.XPromptHashHeader, modifiedPromptHash)
 
 	return req
 }
@@ -858,7 +863,6 @@ func TestInterruption_ClientDisconnect_StreamingComplete_VerifyFinishInference(t
 	// What happens: MLNode finishes, Executor has full response, but write to TA/Client fails
 	//
 	// EXPECTED: FinishInference SHOULD be called (work was completed)
-	// QUESTION: Is it actually called?
 
 	chunks := generateStreamingChunks("inf-cd1", "test-model", 5)
 
@@ -885,14 +889,10 @@ func TestInterruption_ClientDisconnect_StreamingComplete_VerifyFinishInference(t
 	t.Logf("CLIENT_DISCONNECT_STREAM RESULT: FinishInference calls count = %d", len(calls))
 	t.Logf("CLIENT_DISCONNECT_STREAM: Written bytes before disconnect = %d", disconnectWriter.writtenBytes)
 
-	if len(calls) > 0 {
-		t.Logf("CLIENT_DISCONNECT_STREAM: FinishInference WAS called (promptTokens=%d, completionTokens=%d)",
-			calls[0].PromptTokenCount, calls[0].CompletionTokenCount)
-		t.Logf("CLIENT_DISCONNECT_STREAM: GOOD - Executor recorded the inference despite client disconnect")
-	} else {
-		t.Logf("CLIENT_DISCONNECT_STREAM: FinishInference was NOT called")
-		t.Logf("CLIENT_DISCONNECT_STREAM: BUG! Executor did NOT record inference when client disconnected!")
-	}
+	require.Len(t, calls, 1, "executor should record FinishInference from partial response data after client disconnect")
+	require.Equal(t, "inf-cd1", calls[0].InferenceId)
+	require.Equal(t, uint64(1), calls[0].CompletionTokenCount)
+	require.NotEmpty(t, calls[0].ResponseHash)
 }
 
 func TestInterruption_ClientDisconnect_JSONComplete_VerifyFinishInference(t *testing.T) {

--- a/decentralized-api/internal/server/public/proxy.go
+++ b/decentralized-api/internal/server/public/proxy.go
@@ -24,7 +24,7 @@ func ProxyResponse(
 	excludeContentLength bool,
 	responseProcessor completionapi.ResponseProcessor,
 	inferenceId string,
-) {
+) error {
 	// Make sure to copy response headers to the client
 	for key, values := range resp.Header {
 		// Skip Content-Length, because we're modifying body
@@ -40,14 +40,13 @@ func ProxyResponse(
 	contentType := resp.Header.Get("Content-Type")
 	if strings.HasPrefix(contentType, "text/event-stream") {
 		logging.Debug("Proxying text/event-stream response", types.Inferences, "status_code", resp.StatusCode, "content_type", contentType, "inference_id", inferenceId)
-		proxyTextStreamResponse(resp, w, responseProcessor, inferenceId)
-	} else {
-		logging.Debug("Proxying JSON response", types.Inferences, "status_code", resp.StatusCode, "content_type", contentType, "inference_id", inferenceId)
-		proxyJsonResponse(resp, w, responseProcessor, inferenceId)
+		return proxyTextStreamResponse(resp, w, responseProcessor, inferenceId)
 	}
+	logging.Debug("Proxying JSON response", types.Inferences, "status_code", resp.StatusCode, "content_type", contentType, "inference_id", inferenceId)
+	return proxyJsonResponse(resp, w, responseProcessor, inferenceId)
 }
 
-func proxyTextStreamResponse(resp *http.Response, w http.ResponseWriter, responseProcessor completionapi.ResponseProcessor, inferenceId string) {
+func proxyTextStreamResponse(resp *http.Response, w http.ResponseWriter, responseProcessor completionapi.ResponseProcessor, inferenceId string) error {
 	w.WriteHeader(resp.StatusCode)
 
 	// Stream the response from the completion server to the client
@@ -70,7 +69,7 @@ func proxyTextStreamResponse(resp *http.Response, w http.ResponseWriter, respons
 					"inferenceId", inferenceId, "error", err, "line", line,
 				)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
+				return err
 			}
 		}
 
@@ -82,12 +81,12 @@ func proxyTextStreamResponse(resp *http.Response, w http.ResponseWriter, respons
 			if opErr, ok := err.(*net.OpError); ok {
 				logging.Warn("Stream cancelled during streaming", types.Inferences, "inferenceId", inferenceId, "error", opErr)
 				resp.Body.Close()
-				return
+				return err
 			}
 
 			logging.Error("Error while streaming response", types.Inferences, "inferenceId", inferenceId, "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			return err
 		}
 		if flusher, ok := w.(http.Flusher); ok {
 			flusher.Flush()
@@ -96,15 +95,17 @@ func proxyTextStreamResponse(resp *http.Response, w http.ResponseWriter, respons
 
 	if err := scanner.Err(); err != nil {
 		logging.Error("Error after streaming response", types.Inferences, "inferenceId", inferenceId, "error", err)
+		return err
 	}
+	return nil
 }
 
-func proxyJsonResponse(resp *http.Response, w http.ResponseWriter, responseProcessor completionapi.ResponseProcessor, inferenceId string) {
+func proxyJsonResponse(resp *http.Response, w http.ResponseWriter, responseProcessor completionapi.ResponseProcessor, inferenceId string) error {
 	var bodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		logging.Error("Failed to read inference node response body", types.Inferences, "inferenceId", inferenceId, "error", err)
 		http.Error(w, fmt.Sprintf("Failed to read inference node response body. inferenceId = %s", inferenceId), http.StatusInternalServerError)
-		return
+		return err
 	}
 
 	if responseProcessor != nil {
@@ -112,10 +113,13 @@ func proxyJsonResponse(resp *http.Response, w http.ResponseWriter, responseProce
 		if err != nil {
 			logging.Error("Failed to process inference node response", types.Inferences, "inferenceId", inferenceId, "error", err)
 			http.Error(w, fmt.Sprintf("Failed to process inference node response. inferenceId = %s", inferenceId), http.StatusInternalServerError)
-			return
+			return err
 		}
 	}
 
 	w.WriteHeader(resp.StatusCode)
-	w.Write(bodyBytes)
+	if _, err := w.Write(bodyBytes); err != nil {
+		return err
+	}
+	return nil
 }

--- a/decentralized-api/internal/server/public/proxy_test.go
+++ b/decentralized-api/internal/server/public/proxy_test.go
@@ -31,7 +31,8 @@ func TestProxyResponse_HashConsistency(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(sseBody)),
 	}
 	recorder := httptest.NewRecorder()
-	ProxyResponse(proxyResp, recorder, true, proxyProcessor, inferenceId)
+	err := ProxyResponse(proxyResp, recorder, true, proxyProcessor, inferenceId)
+	require.NoError(t, err)
 
 	proxyCompletion, err := proxyProcessor.GetResponse()
 	require.NoError(t, err)

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -237,7 +237,7 @@ func main() {
 
 	if devshardSigner != nil {
 		devshardBridge := internaldevshard.NewChainBridge(recorder)
-		httpClient := pserver.NewNoRedirectClient(5 * time.Minute)
+		httpClient := pserver.NewNoRedirectClient(internaldevshard.MLNodeHTTPTimeout)
 		chainParams := &configParamsProvider{cm: configManager}
 		devshardEngine := internaldevshard.NewEngineAdapter(nodeBroker, configManager.GetCurrentNodeVersion(), payloadStore, chainPhaseTracker, httpClient, chainParams)
 		devshardValidator := internaldevshard.NewValidationAdapter(nodeBroker, configManager.GetCurrentNodeVersion(), chainPhaseTracker, httpClient, devshardBridge, recorder, chainParams)

--- a/devshard/bridge/group_test.go
+++ b/devshard/bridge/group_test.go
@@ -29,6 +29,9 @@ func (m *mockBridge) GetHostInfo(addr string) (*HostInfo, error) {
 	}
 	return info, nil
 }
+func (m *mockBridge) GetValidationThreshold(uint64, string) (*Decimal, error) {
+	return nil, ErrNotImplemented
+}
 func (m *mockBridge) VerifyWarmKey(_, _ string) (bool, error) {
 	return false, ErrNotImplemented
 }

--- a/devshard/bridge/interface.go
+++ b/devshard/bridge/interface.go
@@ -11,6 +11,7 @@ type MainnetBridge interface {
 	// Queries: devshard -> mainnet
 	GetEscrow(escrowID string) (*EscrowInfo, error)
 	GetHostInfo(address string) (*HostInfo, error)
+	GetValidationThreshold(epochID uint64, modelID string) (*Decimal, error)
 	VerifyWarmKey(warmAddress, validatorAddress string) (bool, error)
 
 	// Actions: devshard -> mainnet
@@ -32,4 +33,9 @@ type EscrowInfo struct {
 type HostInfo struct {
 	Address string
 	URL     string
+}
+
+type Decimal struct {
+	Value    int64 `json:"value,string"`
+	Exponent int32 `json:"exponent"`
 }

--- a/devshard/bridge/rest.go
+++ b/devshard/bridge/rest.go
@@ -74,6 +74,14 @@ type granteesResponse struct {
 	} `json:"grantees"`
 }
 
+type epochGroupDataResponse struct {
+	EpochGroupData struct {
+		ModelSnapshot *struct {
+			ValidationThreshold *Decimal `json:"validation_threshold"`
+		} `json:"model_snapshot"`
+	} `json:"epoch_group_data"`
+}
+
 // -- helper --
 
 func doGet[T any](client *http.Client, rawURL string) (*T, error) {
@@ -142,6 +150,21 @@ func (b *RESTBridge) GetHostInfo(address string) (*HostInfo, error) {
 		Address: resp.Participant.Address,
 		URL:     resp.Participant.InferenceURL,
 	}, nil
+}
+
+func (b *RESTBridge) GetValidationThreshold(epochID uint64, modelID string) (*Decimal, error) {
+	u := fmt.Sprintf("%s/productscience/inference/inference/epoch_group_data/%d?model_id=%s",
+		b.baseURL, epochID, url.QueryEscape(modelID))
+
+	resp, err := doGet[epochGroupDataResponse](b.client, u)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.EpochGroupData.ModelSnapshot == nil || resp.EpochGroupData.ModelSnapshot.ValidationThreshold == nil {
+		return nil, fmt.Errorf("validation threshold not found for epoch %d model %s", epochID, modelID)
+	}
+	threshold := *resp.EpochGroupData.ModelSnapshot.ValidationThreshold
+	return &threshold, nil
 }
 
 const warmKeyMsgType = "/inference.inference.MsgStartInference"

--- a/devshard/bridge/rest_test.go
+++ b/devshard/bridge/rest_test.go
@@ -87,6 +87,44 @@ func TestGetHostInfo_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrParticipantNotFound)
 }
 
+func TestGetValidationThreshold_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/productscience/inference/inference/epoch_group_data/257", r.URL.Path)
+		assert.Equal(t, "Qwen/Qwen3", r.URL.Query().Get("model_id"))
+		json.NewEncoder(w).Encode(map[string]any{
+			"epoch_group_data": map[string]any{
+				"model_snapshot": map[string]any{
+					"validation_threshold": map[string]any{
+						"value":    "958",
+						"exponent": -3,
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	b := NewRESTBridge(srv.URL)
+	threshold, err := b.GetValidationThreshold(257, "Qwen/Qwen3")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(958), threshold.Value)
+	assert.Equal(t, int32(-3), threshold.Exponent)
+}
+
+func TestGetValidationThreshold_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"epoch_group_data": map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	b := NewRESTBridge(srv.URL)
+	_, err := b.GetValidationThreshold(257, "missing")
+	require.Error(t, err)
+}
+
 func TestVerifyWarmKey_Authorized(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -707,6 +708,48 @@ func TestHost_ExecuteFailure_ReturnsReceiptNoMempool(t *testing.T) {
 	mptxs := h.MempoolTxs()
 	require.Len(t, mptxs, 1, "mempool should have only MsgConfirmStart")
 	require.NotNil(t, mptxs[0].GetConfirmStart())
+}
+
+func TestHost_RunExecutionQueuesFinishForPartialResult(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier)
+	require.NoError(t, err)
+
+	responseBody := []byte(`{"events":["data: {\"id\":\"partial\",\"choices\":[]}"]}`)
+	responseHash := sha256.Sum256(responseBody)
+	engine := &stub.ConfigurableEngine{
+		Default: devshard.ExecuteResult{
+			ResponseHash: responseHash[:],
+			InputTokens:  12,
+			OutputTokens: 1,
+			ResponseBody: responseBody,
+		},
+	}
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	resp, err := h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{diff}, Nonce: 1, Payload: defaultPayload(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.ExecutionJob)
+
+	result, err := h.RunExecution(context.Background(), resp.ExecutionJob)
+	require.NoError(t, err)
+	require.Equal(t, responseBody, result.ResponseBody)
+
+	finishTx := findMempoolFinish(h.MempoolTxs())
+	require.NotNil(t, finishTx, "mempool should contain MsgFinishInference")
+	finish := finishTx.GetFinishInference()
+	require.Equal(t, uint64(1), finish.InferenceId)
+	require.Equal(t, responseHash[:], finish.ResponseHash)
+	require.Equal(t, uint64(12), finish.InputTokens)
+	require.Equal(t, uint64(1), finish.OutputTokens)
 }
 
 // countingEngine wraps stub engine and counts Execute calls.


### PR DESCRIPTION
# Devshard: per-model validation threshold, timeouts, partial-stream receipts

Three independent fixes for the devshard / inference path.

### Per-model validation threshold from mainnet

Devshard similarity validation used a hardcoded pass criterion. It now fetches the model's `validation_threshold` from the mainnet `epoch_group_data` snapshot, matching how mainnet validators decide pass/fail.

- New `MainnetBridge.GetValidationThreshold(epochID, modelID)` on both `ChainBridge` (gRPC) and `RESTBridge` (REST).
- New `ValidationThresholdResolver` with a per `(escrowID, modelID)` cache, 10 min TTL.
- `EvaluateValidationResult` switches on result type: `SimilarityValidationResult` compares to the fetched threshold; length / token / invalid results fail directly.
- Token count inflation check now tolerates a diff of 1 to absorb tokenizer drift.

### Timeouts

Centralized devshard HTTP timeouts in `shared_runtime.go`:

- `MLNodeHTTPTimeout = 10m` for ML node requests (was hardcoded 5m in two places).
- `PayloadFetchTimeout = 30s` applied via a context wrapper around `FetchPayloadsHTTP`, so a stuck executor no longer hangs the validator.

### Receipt on interrupted streams

`ProxyResponse` now returns an error instead of swallowing it. `handleExecutorRequest` and devshard `ProcessExecutionHTTPResponse` use it to:

- Still emit `FinishInference` (record the receipt) when the stream broke but the processor parsed a usable completion.
- Fail only when both the proxy and the parse failed.

This stops valid partial inferences from being dropped when the client disconnects mid-stream.
