### PR TITLE
`devshard` Finish gossip on missed diff

### DIFF
--- a/decentralized-api/cosmosclient/tx_manager/errors.go
+++ b/decentralized-api/cosmosclient/tx_manager/errors.go
@@ -67,6 +67,10 @@ var retryablePatterns = []string{
 
 	"unordered transaction has a timeout_timestamp that has already passed",
 	"unordered tx ttl exceeds",
+	// Out-of-gas: the per-msg-type estimate underestimated this batch's
+	// real consumption. Retry with a bumped gasWanted (estimateBatchGas
+	// applies a multiplier per attempt, see gas_estimate.go).
+	"out of gas",
 }
 
 // isRetryableRawLog checks if the raw log contains any retryable error patterns

--- a/decentralized-api/cosmosclient/tx_manager/gas_estimate.go
+++ b/decentralized-api/cosmosclient/tx_manager/gas_estimate.go
@@ -1,0 +1,186 @@
+package tx_manager
+
+import (
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	blstypes "github.com/productscience/inference/x/bls/types"
+	collateraltypes "github.com/productscience/inference/x/collateral/types"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
+)
+
+// applyGasAndFee writes gasWanted (capped at BatchGasLimit) onto the tx
+// builder and computes the matching fee from minGasPriceNgonka. Extracted
+// for unit testing without keyring/signing setup.
+func applyGasAndFee(tx client.TxBuilder, gasWanted uint64, minGasPriceNgonka int64) {
+	if gasWanted == 0 || gasWanted > BatchGasLimit {
+		gasWanted = BatchGasLimit
+	}
+	tx.SetGasLimit(gasWanted)
+	if minGasPriceNgonka > 0 {
+		feeAmount := math.NewIntFromUint64(gasWanted).MulRaw(minGasPriceNgonka)
+		tx.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(inferencetypes.BaseCoin, feeAmount)))
+	} else {
+		tx.SetFeeAmount(sdk.Coins{})
+	}
+}
+
+// Per-message gas estimates. Cosmos charges fees on gasWanted (not gasUsed),
+// so over-sizing inflates routine costs and under-sizing causes OOG.
+//
+// Numbers are p99 of observed gasUsed × ~1.5 from a 24h mainnet sample
+// (see /tmp/gonka-gas-analysis/report.md). The headroom expects ~1% of txs
+// to OOG; estimateBatchGas doubles per attempt to escape the retry loop.
+//
+// Two messages have linear-scaling formulas mirroring their on-chain
+// ConsumeGas: MsgPoCV2StoreCommit (per-Count) and MsgMLNodeWeightDistribution
+// (per-entry). Re-tune from a fresh sample after a handler change, a new
+// msg type, or a FeeParams.{base_validation_gas,gas_per_poc_count} change.
+const (
+	// Tx-level fixed cost: ante decorators + authz MsgExec unwrap. Mainnet
+	// hosts almost always run in authz mode, so this absorbs the wrap cost.
+	txOverheadGas = uint64(50_000)
+
+	// Doubled per retry attempt so OOG-on-underestimate eventually fits.
+	gasRetryMultiplier = 2.0
+
+	// Inference lifecycle (bypass-exempt).
+	gasStartInference  = uint64(250_000)
+	gasFinishInference = uint64(250_000)
+	gasValidation      = uint64(1_500_000) // outliers up to 2.1M observed
+
+	// PoC duty messages.
+	gasSubmitPocBatch         = uint64(500_000)
+	gasSubmitPocValidationsV2 = uint64(250_000)
+	gasInvalidateInference    = uint64(500_000)
+	gasRevalidateInference    = uint64(500_000)
+
+	// PoCV2StoreCommit linear formula. WARN: gasPoCV2Base mirrors
+	// FeeParams.base_validation_gas (default 500K), gasPoCV2PerCount
+	// mirrors FeeParams.gas_per_poc_count (default 100). If governance
+	// bumps either, retune both — OOG retry will limp along but at the
+	// cost of wasted block time. Future work: read FeeParams at startup.
+	gasPoCV2Base     = uint64(600_000) // 500K base + 50K sdk + 50% headroom
+	gasPoCV2PerCount = uint64(150)     // 100 on-chain + 50%
+
+	// MLNodeWeightDistribution: linear in total node entries.
+	gasMLNodeBase    = uint64(100_000)
+	gasMLNodePerNode = uint64(50_000)
+
+	// Routine host duties (bypass-exempt).
+	gasSubmitHardwareDiff = uint64(500_000) // observed max 435K
+	gasClaimRewards       = uint64(700_000) // scales w/ epoch inferences
+
+	// Other host operations.
+	gasSubmitSeed                   = uint64(80_000)
+	gasSubmitNewParticipant         = uint64(150_000)
+	gasSubmitNewUnfundedParticipant = uint64(150_000)
+	gasBridgeExchange               = uint64(500_000)
+
+	// BLS DKG (bypass-exempt). Sized at observed max + 30% to absorb
+	// network-size growth without OOG-retry storms during DKG.
+	gasSubmitDealerPart                  = uint64(140_000_000)
+	gasSubmitVerificationVector          = uint64(140_000_000)
+	gasSubmitGroupKeyValidationSignature = uint64(160_000_000) // max 116M, p99 33M
+	gasRespondDealerComplaints           = uint64(150_000_000)
+	gasRequestThresholdSignature         = uint64(2_000_000)
+	gasSubmitPartialSignature            = uint64(5_000_000)
+
+	// Cosmos-SDK / cosmwasm.
+	gasBankSend          = uint64(150_000)
+	gasGovVote           = uint64(80_000)
+	gasDepositCollateral = uint64(100_000)
+	gasWasmExecute       = uint64(300_000)
+
+	// Catch-all for unrecognized types. OOG retry covers the under-estimated case.
+	gasDefaultEstimate = uint64(500_000)
+)
+
+// estimateMsgGas returns the gas estimate for a single message.
+func estimateMsgGas(msg sdk.Msg) uint64 {
+	v, _ := lookupMsgGas(msg)
+	return v
+}
+
+// lookupMsgGas returns (estimate, true) for an explicit case in the switch
+// or (gasDefaultEstimate, false) otherwise. Tests use the bool to assert
+// every msg in InferenceOperationKeyPerms has an explicit case — the value
+// alone can't tell us, since several legit estimates equal the default.
+func lookupMsgGas(msg sdk.Msg) (uint64, bool) {
+	switch m := msg.(type) {
+	case *inferencetypes.MsgStartInference:
+		return gasStartInference, true
+	case *inferencetypes.MsgFinishInference:
+		return gasFinishInference, true
+	case *inferencetypes.MsgValidation:
+		return gasValidation, true
+	case *inferencetypes.MsgInvalidateInference:
+		return gasInvalidateInference, true
+	case *inferencetypes.MsgRevalidateInference:
+		return gasRevalidateInference, true
+	case *inferencetypes.MsgSubmitPocBatch:
+		return gasSubmitPocBatch, true
+	case *inferencetypes.MsgSubmitPocValidationsV2:
+		return gasSubmitPocValidationsV2, true
+	case *inferencetypes.MsgPoCV2StoreCommit:
+		var totalCount uint64
+		for _, e := range m.Entries {
+			totalCount += uint64(e.Count)
+		}
+		return gasPoCV2Base + totalCount*gasPoCV2PerCount, true
+	case *inferencetypes.MsgMLNodeWeightDistribution:
+		var totalNodes uint64
+		for _, e := range m.Entries {
+			totalNodes += uint64(len(e.Weights))
+		}
+		return gasMLNodeBase + totalNodes*gasMLNodePerNode, true
+	case *inferencetypes.MsgSubmitHardwareDiff:
+		return gasSubmitHardwareDiff, true
+	case *inferencetypes.MsgClaimRewards:
+		return gasClaimRewards, true
+	case *inferencetypes.MsgSubmitSeed:
+		return gasSubmitSeed, true
+	case *inferencetypes.MsgSubmitNewParticipant:
+		return gasSubmitNewParticipant, true
+	case *inferencetypes.MsgSubmitNewUnfundedParticipant:
+		return gasSubmitNewUnfundedParticipant, true
+	case *inferencetypes.MsgBridgeExchange:
+		return gasBridgeExchange, true
+	case *blstypes.MsgSubmitDealerPart:
+		return gasSubmitDealerPart, true
+	case *blstypes.MsgSubmitVerificationVector:
+		return gasSubmitVerificationVector, true
+	case *blstypes.MsgSubmitGroupKeyValidationSignature:
+		return gasSubmitGroupKeyValidationSignature, true
+	case *blstypes.MsgRespondDealerComplaints:
+		return gasRespondDealerComplaints, true
+	case *blstypes.MsgRequestThresholdSignature:
+		return gasRequestThresholdSignature, true
+	case *blstypes.MsgSubmitPartialSignature:
+		return gasSubmitPartialSignature, true
+	case *collateraltypes.MsgDepositCollateral:
+		return gasDepositCollateral, true
+	default:
+		return gasDefaultEstimate, false
+	}
+}
+
+// estimateBatchGas sums per-msg estimates + tx overhead, then doubles per
+// retry attempt (capped at BatchGasLimit) so OOG retries escape the loop.
+func estimateBatchGas(msgs []sdk.Msg, attempt int) uint64 {
+	gas := txOverheadGas
+	for _, m := range msgs {
+		gas += estimateMsgGas(m)
+	}
+	for i := 0; i < attempt; i++ {
+		gas = uint64(float64(gas) * gasRetryMultiplier)
+		if gas > BatchGasLimit {
+			break
+		}
+	}
+	if gas > BatchGasLimit {
+		return BatchGasLimit
+	}
+	return gas
+}

--- a/decentralized-api/cosmosclient/tx_manager/gas_estimate_test.go
+++ b/decentralized-api/cosmosclient/tx_manager/gas_estimate_test.go
@@ -1,0 +1,284 @@
+package tx_manager
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+	"github.com/stretchr/testify/require"
+
+	inferencepkg "github.com/productscience/inference/x/inference"
+	blstypes "github.com/productscience/inference/x/bls/types"
+	collateraltypes "github.com/productscience/inference/x/collateral/types"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
+)
+
+// TestEstimateMsgGas_KnownTypes pins the per-msg-type estimates so that
+// any silent change to the lookup table fails CI rather than shipping a
+// surprise. Numbers come from gas_estimate.go constants; if you intentionally
+// retune a value, update the test in the same commit.
+func TestEstimateMsgGas_KnownTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  sdk.Msg
+		want uint64
+	}{
+		// Inference lifecycle (all bypass-exempt, but still sized).
+		{"MsgStartInference", &inferencetypes.MsgStartInference{}, gasStartInference},
+		{"MsgFinishInference", &inferencetypes.MsgFinishInference{}, gasFinishInference},
+		{"MsgValidation", &inferencetypes.MsgValidation{}, gasValidation},
+		{"MsgInvalidateInference", &inferencetypes.MsgInvalidateInference{}, gasInvalidateInference},
+		{"MsgRevalidateInference", &inferencetypes.MsgRevalidateInference{}, gasRevalidateInference},
+
+		// PoC duty.
+		{"MsgSubmitPocBatch", &inferencetypes.MsgSubmitPocBatch{}, gasSubmitPocBatch},
+		{"MsgSubmitPocValidationsV2", &inferencetypes.MsgSubmitPocValidationsV2{}, gasSubmitPocValidationsV2},
+
+		// Routine host duties (now bypass-exempt).
+		{"MsgSubmitHardwareDiff", &inferencetypes.MsgSubmitHardwareDiff{}, gasSubmitHardwareDiff},
+		{"MsgClaimRewards", &inferencetypes.MsgClaimRewards{}, gasClaimRewards},
+
+		// Other host operations.
+		{"MsgSubmitSeed", &inferencetypes.MsgSubmitSeed{}, gasSubmitSeed},
+		{"MsgSubmitNewParticipant", &inferencetypes.MsgSubmitNewParticipant{}, gasSubmitNewParticipant},
+		{"MsgSubmitNewUnfundedParticipant", &inferencetypes.MsgSubmitNewUnfundedParticipant{}, gasSubmitNewUnfundedParticipant},
+		{"MsgBridgeExchange", &inferencetypes.MsgBridgeExchange{}, gasBridgeExchange},
+
+		// BLS DKG (bypass-exempt).
+		{"MsgSubmitDealerPart", &blstypes.MsgSubmitDealerPart{}, gasSubmitDealerPart},
+		{"MsgSubmitVerificationVector", &blstypes.MsgSubmitVerificationVector{}, gasSubmitVerificationVector},
+		{"MsgSubmitGroupKeyValidationSignature", &blstypes.MsgSubmitGroupKeyValidationSignature{}, gasSubmitGroupKeyValidationSignature},
+		{"MsgRespondDealerComplaints", &blstypes.MsgRespondDealerComplaints{}, gasRespondDealerComplaints},
+		{"MsgRequestThresholdSignature", &blstypes.MsgRequestThresholdSignature{}, gasRequestThresholdSignature},
+		{"MsgSubmitPartialSignature", &blstypes.MsgSubmitPartialSignature{}, gasSubmitPartialSignature},
+
+		// Collateral.
+		{"MsgDepositCollateral", &collateraltypes.MsgDepositCollateral{}, gasDepositCollateral},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := estimateMsgGas(tc.msg)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestEstimateMsgGas_DefaultFallback confirms that an unknown message type
+// (one not in the switch) falls through to the conservative default and is
+// flagged as not explicit.
+func TestEstimateMsgGas_DefaultFallback(t *testing.T) {
+	// A message type that intentionally isn't in the per-type switch.
+	type unknownMsg struct{ sdk.Msg }
+	got, explicit := lookupMsgGas(&unknownMsg{})
+	require.Equal(t, gasDefaultEstimate, got)
+	require.False(t, explicit)
+	// And the public estimateMsgGas wrapper returns the same value.
+	require.Equal(t, gasDefaultEstimate, estimateMsgGas(&unknownMsg{}))
+}
+
+// TestEstimateMsgGas_PoCV2_LinearInCount asserts the on-chain formula is
+// mirrored: gas should grow base + sum(entry.Count) * per_count.
+func TestEstimateMsgGas_PoCV2_LinearInCount(t *testing.T) {
+	zero := &inferencetypes.MsgPoCV2StoreCommit{}
+	require.Equal(t, gasPoCV2Base, estimateMsgGas(zero), "no entries = base only")
+
+	for _, count := range []uint32{1, 100, 10_000, 1_000_000} {
+		msg := &inferencetypes.MsgPoCV2StoreCommit{
+			Entries: []*inferencetypes.PoCV2CommitEntry{{Count: count}},
+		}
+		want := gasPoCV2Base + uint64(count)*gasPoCV2PerCount
+		require.Equal(t, want, estimateMsgGas(msg),
+			"count=%d should yield base + count*per_count", count)
+	}
+
+	// Multi-entry: per_count applies to summed Count.
+	multi := &inferencetypes.MsgPoCV2StoreCommit{
+		Entries: []*inferencetypes.PoCV2CommitEntry{{Count: 100}, {Count: 200}, {Count: 300}},
+	}
+	want := gasPoCV2Base + uint64(600)*gasPoCV2PerCount
+	require.Equal(t, want, estimateMsgGas(multi))
+}
+
+// TestEstimateMsgGas_MLNodeDistribution_LinearInNodes asserts the gas grows
+// linearly with the total number of node entries summed across all model
+// entries.
+func TestEstimateMsgGas_MLNodeDistribution_LinearInNodes(t *testing.T) {
+	zero := &inferencetypes.MsgMLNodeWeightDistribution{}
+	require.Equal(t, gasMLNodeBase, estimateMsgGas(zero), "no entries = base only")
+
+	// 5 nodes spread across 2 model entries.
+	msg := &inferencetypes.MsgMLNodeWeightDistribution{
+		Entries: []*inferencetypes.MLNodeDistributionEntry{
+			{Weights: []*inferencetypes.MLNodeWeight{{}, {}, {}}},
+			{Weights: []*inferencetypes.MLNodeWeight{{}, {}}},
+		},
+	}
+	want := gasMLNodeBase + uint64(5)*gasMLNodePerNode
+	require.Equal(t, want, estimateMsgGas(msg))
+}
+
+// TestEstimateBatchGas_SumsPlusOverhead confirms the batch-level estimator
+// adds the tx-level overhead and sums per-msg estimates.
+func TestEstimateBatchGas_SumsPlusOverhead(t *testing.T) {
+	msgs := []sdk.Msg{
+		&inferencetypes.MsgFinishInference{}, // gasFinishInference
+		&inferencetypes.MsgFinishInference{}, // gasFinishInference
+		&inferencetypes.MsgSubmitSeed{},      // gasSubmitSeed
+	}
+	want := txOverheadGas + 2*gasFinishInference + gasSubmitSeed
+	require.Equal(t, want, estimateBatchGas(msgs, 0))
+}
+
+// TestEstimateBatchGas_RetryMultiplier asserts each retry attempt doubles
+// gasWanted up to the BatchGasLimit ceiling. This is what lets an OOG-on-
+// underestimate eventually succeed instead of looping at the same gas.
+func TestEstimateBatchGas_RetryMultiplier(t *testing.T) {
+	msgs := []sdk.Msg{&inferencetypes.MsgSubmitSeed{}}
+	base := estimateBatchGas(msgs, 0)
+
+	for attempt := 1; attempt <= 5; attempt++ {
+		expected := base
+		for i := 0; i < attempt; i++ {
+			expected = uint64(float64(expected) * gasRetryMultiplier)
+		}
+		got := estimateBatchGas(msgs, attempt)
+		if expected > BatchGasLimit {
+			require.Equal(t, uint64(BatchGasLimit), got, "attempt=%d should cap at BatchGasLimit", attempt)
+		} else {
+			require.Equal(t, expected, got, "attempt=%d should double base estimate", attempt)
+		}
+	}
+}
+
+// TestEstimateBatchGas_CapsAtBatchGasLimit confirms we never request more
+// gas than the chain's NetworkDutyFeeBypassDecorator GasCap can accommodate
+// (currently 3B; BatchGasLimit is 1B, well within).
+func TestEstimateBatchGas_CapsAtBatchGasLimit(t *testing.T) {
+	// A large PoCV2 commit can naturally exceed BatchGasLimit at high count.
+	huge := &inferencetypes.MsgPoCV2StoreCommit{
+		Entries: []*inferencetypes.PoCV2CommitEntry{{Count: ^uint32(0)}}, // max uint32
+	}
+	got := estimateBatchGas([]sdk.Msg{huge}, 0)
+	require.Equal(t, uint64(BatchGasLimit), got, "should cap, not overflow")
+
+	// Also via retry escalation on a moderate batch.
+	moderate := []sdk.Msg{&inferencetypes.MsgClaimRewards{}}
+	got = estimateBatchGas(moderate, 100) // way more retries than realistic
+	require.Equal(t, uint64(BatchGasLimit), got)
+}
+
+// TestEstimateBatchGas_EmptyBatch returns just the tx-level overhead — no
+// crash on a zero-msg batch.
+func TestEstimateBatchGas_EmptyBatch(t *testing.T) {
+	require.Equal(t, txOverheadGas, estimateBatchGas(nil, 0))
+	require.Equal(t, txOverheadGas, estimateBatchGas([]sdk.Msg{}, 0))
+}
+
+// newTestTxBuilder spins up a real TxBuilder backed by the standard cosmos
+// proto codec. Real builder is cheaper to set up than to stub correctly,
+// since TxBuilder is an interface with several internal-state methods.
+func newTestTxBuilder(t *testing.T) client.TxBuilder {
+	t.Helper()
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+	cfg := tx.NewTxConfig(cdc, tx.DefaultSignModes)
+	return cfg.NewTxBuilder()
+}
+
+// TestApplyGasAndFee_SetsGasLimitAndZeroFee covers the v0.2.12 mainnet
+// configuration: minGasPriceNgonka=0, so fees are always empty regardless
+// of gasWanted, and the gas limit reflects the per-batch estimate.
+func TestApplyGasAndFee_SetsGasLimitAndZeroFee(t *testing.T) {
+	b := newTestTxBuilder(t)
+
+	applyGasAndFee(b, 250_000, 0)
+	require.Equal(t, uint64(250_000), b.GetTx().GetGas())
+	require.True(t, b.GetTx().GetFee().IsZero(), "fees must be empty when minGasPrice=0")
+}
+
+// TestApplyGasAndFee_ComputesFeeFromMinGasPrice verifies that when
+// min_gas_price is non-zero (post-v0.2.12), fee = gasWanted × minGasPrice.
+func TestApplyGasAndFee_ComputesFeeFromMinGasPrice(t *testing.T) {
+	b := newTestTxBuilder(t)
+
+	const gasWanted, minGasPrice = uint64(250_000), int64(10)
+	applyGasAndFee(b, gasWanted, minGasPrice)
+
+	require.Equal(t, gasWanted, b.GetTx().GetGas())
+	fees := b.GetTx().GetFee()
+	require.Len(t, fees, 1)
+	require.Equal(t, "ngonka", fees[0].Denom)
+	expected := math.NewIntFromUint64(gasWanted).MulRaw(minGasPrice)
+	require.True(t, fees[0].Amount.Equal(expected),
+		"fee should be gasWanted × minGasPrice, got %s expected %s", fees[0].Amount, expected)
+}
+
+// TestApplyGasAndFee_CapsAtBatchGasLimit confirms we never set gasWanted
+// above the chain's NetworkDutyFeeBypassDecorator GasCap can accommodate.
+// Both 0 and "exceeds limit" should clamp to BatchGasLimit.
+func TestApplyGasAndFee_CapsAtBatchGasLimit(t *testing.T) {
+	// Zero -> use BatchGasLimit (defensive default).
+	b := newTestTxBuilder(t)
+	applyGasAndFee(b, 0, 0)
+	require.Equal(t, uint64(BatchGasLimit), b.GetTx().GetGas())
+
+	// Above limit -> cap at BatchGasLimit.
+	b2 := newTestTxBuilder(t)
+	applyGasAndFee(b2, BatchGasLimit*2, 0)
+	require.Equal(t, uint64(BatchGasLimit), b2.GetTx().GetGas())
+}
+
+// TestBroadcastMessages_EmptyBatch_NoOp pins the early-return guard at
+// the top of broadcastMessagesAtAttempt: a zero-message batch returns
+// (nil, zero-time, nil) without touching the factory or the wire. Without
+// this guard a refactor could route an empty batch into BuildUnsignedTx,
+// which produces a confusing chain-side decode error far from the
+// cause. The guard fields none of the manager's other state, so a zero-
+// value manager is enough to exercise the path.
+func TestBroadcastMessages_EmptyBatch_NoOp(t *testing.T) {
+	m := &manager{}
+
+	resp, ts, err := m.BroadcastMessages("test-id")
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.True(t, ts.IsZero())
+
+	// Same for the internal helper that retry uses, with a non-zero attempt.
+	resp, ts, err = m.broadcastMessagesAtAttempt("test-id", 5, nil)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.True(t, ts.IsZero())
+
+	resp, ts, err = m.broadcastMessagesAtAttempt("test-id", 0, []sdk.Msg{})
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.True(t, ts.IsZero())
+}
+
+// TestEstimateMsgGas_AllInferenceOperationKeyPermsHaveExplicitEstimate
+// catches the case where someone adds a new message type to the warm key's
+// authz permission list (InferenceOperationKeyPerms) but forgets to add it
+// to the gas estimator switch. Without this guard, the new message would
+// silently fall through to gasDefaultEstimate, which may not be enough to
+// cover its real consumption.
+//
+// We use lookupMsgGas (which returns explicit=true iff the type has a
+// case in the switch) rather than comparing values, because several
+// legitimate per-type estimates happen to coincide with gasDefaultEstimate.
+//
+// If this test fails, add the missing case to lookupMsgGas in
+// gas_estimate.go with a number sized from a fresh mainnet sample.
+func TestEstimateMsgGas_AllInferenceOperationKeyPermsHaveExplicitEstimate(t *testing.T) {
+	for _, msg := range inferencepkg.InferenceOperationKeyPerms {
+		t.Run(sdk.MsgTypeURL(msg), func(t *testing.T) {
+			_, explicit := lookupMsgGas(msg)
+			require.True(t, explicit,
+				"%T is in InferenceOperationKeyPerms but has no explicit gas estimate; "+
+					"add a case to lookupMsgGas in gas_estimate.go", msg)
+		})
+	}
+}

--- a/decentralized-api/cosmosclient/tx_manager/tx_manager.go
+++ b/decentralized-api/cosmosclient/tx_manager/tx_manager.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"cosmossdk.io/math"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -571,8 +570,8 @@ func (m *manager) sendTxs() error {
 			}
 
 			if !tx.Sent {
-				logging.Debug("start broadcast batch async", types.Messages, "id", tx.TxInfo.Id)
-				resp, timeout, broadcastErr = m.BroadcastMessages(tx.TxInfo.Id, msgs...)
+				logging.Debug("start broadcast batch async", types.Messages, "id", tx.TxInfo.Id, "attempt", tx.TxInfo.Attempts)
+				resp, timeout, broadcastErr = m.broadcastMessagesAtAttempt(tx.TxInfo.Id, tx.TxInfo.Attempts, msgs)
 			}
 		} else {
 			rawTx, err := m.unpackTx(tx.TxInfo.RawTx)
@@ -583,8 +582,8 @@ func (m *manager) sendTxs() error {
 			}
 
 			if !tx.Sent {
-				logging.Debug("start broadcast tx async", types.Messages, "id", tx.TxInfo.Id)
-				resp, timeout, broadcastErr = m.broadcastMessage(tx.TxInfo.Id, rawTx)
+				logging.Debug("start broadcast tx async", types.Messages, "id", tx.TxInfo.Id, "attempt", tx.TxInfo.Attempts)
+				resp, timeout, broadcastErr = m.broadcastMessageAtAttempt(tx.TxInfo.Id, tx.TxInfo.Attempts, rawTx)
 			}
 		}
 
@@ -795,19 +794,23 @@ func (m *manager) GetJetStream() nats.JetStreamContext {
 }
 
 func (m *manager) BroadcastMessages(id string, msgs ...sdk.Msg) (*sdk.TxResponse, time.Time, error) {
+	return m.broadcastMessagesAtAttempt(id, 0, msgs)
+}
+
+// broadcastMessagesAtAttempt is the single broadcast path used by all
+// callers (single-msg, batch, first attempt, retry). attempt=0 sizes
+// gasWanted from the per-msg-type estimate; subsequent attempts bump
+// gasWanted to escape OOG loops. See estimateBatchGas in gas_estimate.go.
+func (m *manager) broadcastMessagesAtAttempt(id string, attempt int, msgs []sdk.Msg) (*sdk.TxResponse, time.Time, error) {
 	if len(msgs) == 0 {
 		return nil, time.Time{}, nil
 	}
-	if len(msgs) == 1 {
-		return m.broadcastMessage(id, msgs[0])
-	}
-
 	factory, err := m.getFactory(id)
 	if err != nil {
 		return nil, time.Time{}, err
 	}
 
-	var finalMsgs []sdk.Msg
+	finalMsgs := msgs
 	if !m.apiAccount.IsSignerTheMainAccount() {
 		granteeAddress, err := m.apiAccount.SignerAddress()
 		if err != nil {
@@ -815,16 +818,16 @@ func (m *manager) BroadcastMessages(id string, msgs ...sdk.Msg) (*sdk.TxResponse
 		}
 		execMsg := authztypes.NewMsgExec(granteeAddress, msgs)
 		finalMsgs = []sdk.Msg{&execMsg}
-		logging.Debug("Using authz MsgExec for batch", types.Messages, "grantee", granteeAddress.String(), "msgCount", len(msgs))
-	} else {
-		finalMsgs = msgs
+		logging.Debug("Using authz MsgExec", types.Messages, "grantee", granteeAddress.String(), "msgCount", len(msgs))
 	}
 
 	unsignedTx, err := factory.BuildUnsignedTx(finalMsgs...)
 	if err != nil {
 		return nil, time.Time{}, err
 	}
-	txBytes, timestamp, err := m.getSignedBytes(id, unsignedTx, factory)
+	// gasWanted is sized from the inner messages, not the authz wrapper.
+	gasWanted := estimateBatchGas(msgs, attempt)
+	txBytes, timestamp, err := m.getSignedBytes(id, unsignedTx, factory, gasWanted)
 	if err != nil {
 		return nil, time.Time{}, err
 	}
@@ -834,10 +837,19 @@ func (m *manager) BroadcastMessages(id string, msgs ...sdk.Msg) (*sdk.TxResponse
 		return nil, time.Time{}, err
 	}
 	if resp.Code != 0 {
-		logging.Error("Batch broadcast failed", types.Messages, "code", resp.Code, "rawLog", resp.RawLog, "tx_id", id, "msgCount", len(msgs))
+		logging.Error("Broadcast failed", types.Messages, "code", resp.Code, "rawLog", resp.RawLog,
+			"tx_id", id, "msgCount", len(msgs), "attempt", attempt, "gasWanted", gasWanted)
 		logFeeRelatedHint(resp.RawLog)
 	} else {
-		logging.Debug("Batch broadcast successful", types.Messages, "tx_id", id, "msgCount", len(msgs))
+		// Surface OOG-retry recoveries so we can spot when the static gas
+		// table needs re-tuning. attempt > 0 means a previous broadcast
+		// hit an OOG (or other retryable error) and we doubled gas.
+		if attempt > 0 {
+			logging.Warn("Broadcast succeeded after retry; static gas estimate may be too low",
+				types.Messages, "tx_id", id, "msgCount", len(msgs), "attempt", attempt, "gasWanted", gasWanted)
+		} else {
+			logging.Debug("Broadcast successful", types.Messages, "tx_id", id, "msgCount", len(msgs))
+		}
 	}
 	return resp, timestamp, nil
 }
@@ -879,43 +891,14 @@ func containsAny(s string, substrs ...string) bool {
 }
 
 func (m *manager) broadcastMessage(id string, rawTx sdk.Msg) (*sdk.TxResponse, time.Time, error) {
-	factory, err := m.getFactory(id)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
+	return m.broadcastMessagesAtAttempt(id, 0, []sdk.Msg{rawTx})
+}
 
-	var finalMsg sdk.Msg = rawTx
-	originalMsgType := sdk.MsgTypeURL(rawTx)
-	if !m.apiAccount.IsSignerTheMainAccount() {
-		granteeAddress, err := m.apiAccount.SignerAddress()
-		if err != nil {
-			return nil, time.Time{}, fmt.Errorf("failed to get signer address: %w", err)
-		}
-
-		execMsg := authztypes.NewMsgExec(granteeAddress, []sdk.Msg{rawTx})
-		finalMsg = &execMsg
-		logging.Debug("Using authz MsgExec", types.Messages, "grantee", granteeAddress.String(), "originalMsgType", originalMsgType)
-	}
-
-	unsignedTx, err := factory.BuildUnsignedTx(finalMsg)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-	txBytes, timestamp, err := m.getSignedBytes(id, unsignedTx, factory)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-
-	resp, err := m.client.Context().BroadcastTxSync(txBytes)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-	if resp.Code != 0 {
-		logging.Error("Broadcast failed immediately", types.Messages, "code", resp.Code, "rawLog", resp.RawLog, "tx_id", id, "originalMsgType", originalMsgType)
-	} else {
-		logging.Debug("Broadcast successful", types.Messages, "tx_id", id, "originalMsgType", originalMsgType, "resp", resp)
-	}
-	return resp, timestamp, nil
+// broadcastMessageAtAttempt is the retry-aware single-message entry point.
+// Thin wrapper around broadcastMessagesAtAttempt with a one-element slice;
+// kept for symmetry with how the retry loop dispatches.
+func (m *manager) broadcastMessageAtAttempt(id string, attempt int, rawTx sdk.Msg) (*sdk.TxResponse, time.Time, error) {
+	return m.broadcastMessagesAtAttempt(id, attempt, []sdk.Msg{rawTx})
 }
 
 func (m *manager) unpackTx(bz []byte) (sdk.Msg, error) {
@@ -973,7 +956,7 @@ func (m *manager) getFactory(id string) (*tx.Factory, error) {
 	return &factory, nil
 }
 
-func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory *tx.Factory) ([]byte, time.Time, error) {
+func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory *tx.Factory, gasWanted uint64) ([]byte, time.Time, error) {
 	blockTs := m.blockTimeTracker.latestBlockTime
 	if blockTs.IsZero() {
 		_, err := m.updateChainHalt()
@@ -985,15 +968,13 @@ func (m *manager) getSignedBytes(id string, unsignedTx client.TxBuilder, factory
 
 	timestamp := getTimestamp(blockTs.UnixNano(), m.defaultTimeout)
 
-	// Fee amount = gas limit × gas price. Network-duty messages (validations,
-	// PoC, inference) are fee-exempt via the bypass decorator, so this fee
-	// will not be charged for exempt messages.
-	unsignedTx.SetGasLimit(BatchGasLimit)
-	if m.minGasPriceNgonka > 0 {
-		unsignedTx.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("ngonka", math.NewInt(BatchGasLimit*m.minGasPriceNgonka))))
-	} else {
-		unsignedTx.SetFeeAmount(sdk.Coins{})
-	}
+	// Fee amount = gasWanted × gas price. gasWanted is sized per-batch by
+	// estimateBatchGas (see gas_estimate.go) instead of a constant, so
+	// routine txs aren't billed at the worst-case PoC commit ceiling.
+	// Network-duty messages (PoC, inference, validation, hardware-diff,
+	// claim-rewards, BLS DKG) are fee-exempt via NetworkDutyFeeBypassDecorator
+	// and pay nothing regardless of gasWanted.
+	applyGasAndFee(unsignedTx, gasWanted, m.minGasPriceNgonka)
 
 	// When the warm key signs on behalf of the cold account (authz mode),
 	// set the cold account as the fee granter so fees are deducted from the

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -46,7 +46,7 @@ type HostResponse struct {
 	ConfirmedAt        int64  // executor wall-clock timestamp, 0 if not executor
 	Mempool            []*types.DevshardTx
 	ExecutionJob       *devshard.ExecuteRequest // non-nil if this host is the executor and execution is deferred
-	CachedResponseBody []byte                 // non-nil when reconnecting to a completed inference
+	CachedResponseBody []byte                   // non-nil when reconnecting to a completed inference
 }
 
 // AcceptanceChecker is an optional hook that lets the host withhold its
@@ -269,12 +269,14 @@ func (h *Host) HandleRequest(ctx context.Context, req HostRequest) (*HostRespons
 
 	// (a) Apply all new diffs.
 	var lastAppliedTxs []*types.DevshardTx
+	diffsApplied := false
 	for _, diff := range req.Diffs {
 		if err := h.applyAndPersist(diff); err != nil {
 			h.mu.Unlock()
 			return nil, err
 		}
 		lastAppliedTxs = diff.Txs
+		diffsApplied = true
 	}
 
 	// (b) Sign executor receipt (sync, under mutex).
@@ -297,15 +299,29 @@ func (h *Host) HandleRequest(ctx context.Context, req HostRequest) (*HostRespons
 	// (e) Collect validation candidates under mutex.
 	validationJobs := h.collectValidationJobs()
 
+	// (f) Collect locally-proposed Finish txs that the user has not yet
+	// absorbed into a diff. Computed under mutex; broadcast outside it.
+	var staleFinishes []*types.DevshardTx
+	if diffsApplied {
+		staleFinishes = h.collectStaleFinishesLocked()
+	}
+
 	h.mu.Unlock()
 
-	// (f) Execution job for caller to run via RunExecution.
+	// (g) Execution job for caller to run via RunExecution.
 	// Execution is always deferred so the caller can send the receipt
 	// before inference starts (SSE flow).
 
-	// (g) Validate other hosts' inferences outside mutex.
+	// (h) Validate other hosts' inferences outside mutex.
 	for _, vj := range validationJobs {
 		go h.validateAsync(context.Background(), vj)
+	}
+
+	// (i) Recovery gossip: re-broadcast locally produced Finish that the
+	// user sequencer skipped. gossip.BroadcastTxs dedups by tx hash so
+	// repeated triggers across diffs are harmless.
+	if len(staleFinishes) > 0 && h.gsp != nil {
+		go h.gsp.BroadcastTxs(context.Background(), staleFinishes)
 	}
 
 	return &HostResponse{
@@ -363,10 +379,38 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 // Already-applied diffs (nonce <= current) are silently skipped.
 func (h *Host) ApplyCatchUpDiffs(diffs []types.Diff) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	for _, diff := range diffs {
 		_ = h.applyAndPersist(diff)
 	}
+	staleFinishes := h.collectStaleFinishesLocked()
+	h.mu.Unlock()
+
+	if len(staleFinishes) > 0 && h.gsp != nil {
+		go h.gsp.BroadcastTxs(context.Background(), staleFinishes)
+	}
+}
+
+// finishGossipGraceRotations is the number of full slot rotations to wait
+// before re-broadcasting a locally-proposed MsgFinishInference that the user
+// sequencer has not yet included in a diff. With round-robin host selection
+// (nonce % len(group)), one rotation = len(group) nonces, so the effective
+// grace is finishGossipGraceRotations * len(group) nonces.
+//
+// Two rotations gives the user two natural chances to pick up the Finish
+// from the executor host's devshard_meta tail (once per rotation) before we
+// fall back to peer-to-peer recovery gossip. Increase if direct-contact
+// recovery should be preferred more strongly; decrease for snappier gossip.
+const finishGossipGraceRotations uint64 = 2
+
+// collectStaleFinishesLocked returns locally proposed MsgFinishInference txs
+// that the user sequencer has not yet included in a diff after the grace
+// period. Caller must hold h.mu. See Mempool.StaleFinishes for the criterion.
+func (h *Host) collectStaleFinishesLocked() []*types.DevshardTx {
+	if h.gsp == nil {
+		return nil
+	}
+	grace := finishGossipGraceRotations * uint64(len(h.group))
+	return h.mempool.StaleFinishes(h.sm.LatestNonce(), grace)
 }
 
 // signIfAccepted computes state root, checks acceptance, signs if allowed,

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"devshard"
+	"devshard/gossip"
 	"devshard/internal/testutil"
 	"devshard/signing"
 	"devshard/state"
@@ -18,6 +20,52 @@ import (
 	"devshard/stub"
 	"devshard/types"
 )
+
+// recordingPeer implements gossip.PeerClient and records GossipTxs calls.
+// Used by tests that exercise the host's recovery-gossip trigger.
+type recordingPeer struct {
+	mu       sync.Mutex
+	txsCalls [][]*types.DevshardTx
+	txsCount atomic.Int32
+}
+
+func (p *recordingPeer) GossipNonce(_ context.Context, _ uint64, _, _ []byte, _ uint32) error {
+	return nil
+}
+
+func (p *recordingPeer) GossipTxs(_ context.Context, txs []*types.DevshardTx) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.txsCalls = append(p.txsCalls, txs)
+	p.txsCount.Add(1)
+	return nil
+}
+
+func (p *recordingPeer) Calls() [][]*types.DevshardTx {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([][]*types.DevshardTx, len(p.txsCalls))
+	copy(out, p.txsCalls)
+	return out
+}
+
+// awaitTxsCall polls until the recordingPeer has at least one GossipTxs call.
+func awaitTxsCall(t *testing.T, p *recordingPeer, deadline time.Duration) [][]*types.DevshardTx {
+	t.Helper()
+	timeout := time.NewTimer(deadline)
+	defer timeout.Stop()
+	for {
+		if p.txsCount.Load() > 0 {
+			return p.Calls()
+		}
+		select {
+		case <-timeout.C:
+			t.Fatalf("expected at least one GossipTxs call within %s, got 0", deadline)
+			return nil
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
 
 // --- Package-specific test helpers ---
 
@@ -1140,4 +1188,156 @@ func TestAccumulateGossipSig_WarmKey(t *testing.T) {
 	sigs, err := store.GetSignatures("escrow-1", 2)
 	require.NoError(t, err)
 	require.Equal(t, warmSig, sigs[1])
+}
+
+// --- finish-gossip recovery tests ---
+
+// newExecutorHostWithGossip wires host index 1 (executor for inference 1, since
+// 1 % 3 = 1) with a real *gossip.Gossip instance backed by recordingPeer so we
+// can observe the host's recovery-gossip dispatch.
+func newExecutorHostWithGossip(t *testing.T) (*Host, []*signing.Secp256k1Signer, *signing.Secp256k1Signer, *recordingPeer) {
+	t.Helper()
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 100_000, user.Address(), verifier)
+	require.NoError(t, err)
+
+	engine := stub.NewInferenceEngine()
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil,
+		WithGrace(100),
+	)
+	require.NoError(t, err)
+
+	// Build gossip with the host's own mempool as MempoolSink; attach it
+	// to the host afterward to avoid the chicken-and-egg of WithGossip
+	// inside NewHost needing the live mempool.
+	peer := &recordingPeer{}
+	g := gossip.NewGossip("escrow-1", 1 /* slotID */, []gossip.PeerClient{peer}, h.HostMempool())
+	WithGossip(g)(h)
+
+	return h, hosts, user, peer
+}
+
+// TestHost_FinishGossipRecovery_TriggersOnMissedDiff is the core recovery test:
+// after the executor produces a Finish, if the user's subsequent diffs do not
+// include it for more than `finishGossipGraceRotations * len(group)` nonces,
+// the host must broadcast the Finish via tx gossip.
+func TestHost_FinishGossipRecovery_TriggersOnMissedDiff(t *testing.T) {
+	h, _, user, peer := newExecutorHostWithGossip(t)
+	groupSize := uint64(len(h.Group()))
+	grace := finishGossipGraceRotations * groupSize
+
+	// Diff 1: StartTx for inference 1; host 1 executes (1 % 3 = 1).
+	diff1 := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	resp, err := h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{diff1}, Nonce: 1, Payload: defaultPayload(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.ExecutionJob, "host 1 should be the executor")
+
+	// Run execution; this adds MsgFinishInference to mempool with ProposedAt=1.
+	_, err = h.RunExecution(context.Background(), resp.ExecutionJob)
+	require.NoError(t, err)
+	require.NotNil(t, findMempoolFinish(h.MempoolTxs()),
+		"Finish should be in mempool after RunExecution")
+
+	// Apply empty diffs up to (but not past) the grace threshold. The Finish
+	// has ProposedAt=1, so it becomes stale once currentNonce > 1 + grace.
+	// At currentNonce == 1 + grace the trigger must NOT fire yet.
+	for nonce := uint64(2); nonce <= 1+grace; nonce++ {
+		diff := testutil.SignDiff(t, user, "escrow-1", nonce, nil)
+		_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
+		require.NoError(t, err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), peer.txsCount.Load(),
+		"recovery gossip must not fire until ProposedAt + grace < currentNonce")
+
+	// One more empty diff crosses the threshold: 1 + grace < currentNonce.
+	crossing := testutil.SignDiff(t, user, "escrow-1", 2+grace, nil)
+	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{crossing}})
+	require.NoError(t, err)
+
+	// Recovery gossip is dispatched in a goroutine; await the call.
+	calls := awaitTxsCall(t, peer, 2*time.Second)
+	require.GreaterOrEqual(t, len(calls), 1)
+
+	// The broadcasted batch must contain the Finish for inference 1.
+	var found bool
+	for _, batch := range calls {
+		for _, tx := range batch {
+			if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == 1 {
+				found = true
+			}
+		}
+	}
+	require.True(t, found, "broadcast must include MsgFinishInference for inference 1")
+}
+
+// TestHost_FinishGossipRecovery_NoTriggerWhenIncluded verifies that if the
+// next user diff actually includes the Finish, no recovery gossip is sent.
+func TestHost_FinishGossipRecovery_NoTriggerWhenIncluded(t *testing.T) {
+	h, _, user, peer := newExecutorHostWithGossip(t)
+
+	diff1 := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	resp, err := h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{diff1}, Nonce: 1, Payload: defaultPayload(),
+	})
+	require.NoError(t, err)
+
+	_, err = h.RunExecution(context.Background(), resp.ExecutionJob)
+	require.NoError(t, err)
+
+	confirmTx := findMempoolConfirm(h.MempoolTxs())
+	finishTxFromMempool := findMempoolFinish(h.MempoolTxs())
+	require.NotNil(t, confirmTx)
+	require.NotNil(t, finishTxFromMempool)
+
+	// Diff 2 includes confirm, diff 3 includes Finish. The Finish never has
+	// a "missed" applied-diff in this sequence: applyAndPersist removes it
+	// from mempool the moment diff 3 lands.
+	diff2 := testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{confirmTx})
+	diff3 := testutil.SignDiff(t, user, "escrow-1", 3, []*types.DevshardTx{finishTxFromMempool})
+	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff2, diff3}})
+	require.NoError(t, err)
+
+	// Give a goroutine slot for any spurious broadcast to land.
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), peer.txsCount.Load(),
+		"no recovery gossip should fire when the user includes Finish in time")
+}
+
+// TestHost_FinishGossipRecovery_PeerImportedFinishNotAmplified guards the
+// ProposedAt > 0 filter: a Finish that arrived from a peer (added via
+// gossip.OnTxsReceived → mempool.AddTx, ProposedAt=0) must not be re-broadcast
+// even after the staleness threshold would otherwise mark it stale.
+func TestHost_FinishGossipRecovery_PeerImportedFinishNotAmplified(t *testing.T) {
+	h, _, user, peer := newExecutorHostWithGossip(t)
+	groupSize := uint64(len(h.Group()))
+	grace := finishGossipGraceRotations * groupSize
+
+	// Inject a peer-imported Finish for an inference this host did not execute.
+	imported := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{
+		FinishInference: &types.MsgFinishInference{InferenceId: 999},
+	}}
+	h.HostMempool().AddTx(imported) // ProposedAt=0 sentinel.
+
+	// Advance well past 0 + grace so the only thing keeping this tx out of
+	// the broadcast set is the ProposedAt > 0 filter.
+	for nonce := uint64(1); nonce <= grace+2; nonce++ {
+		diff := testutil.SignDiff(t, user, "escrow-1", nonce, nil)
+		_, err := h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
+		require.NoError(t, err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), peer.txsCount.Load(),
+		"peer-imported Finish (ProposedAt=0) must not be re-broadcast")
 }

--- a/devshard/host/mempool.go
+++ b/devshard/host/mempool.go
@@ -51,6 +51,51 @@ func (m *Mempool) HasStaleEntry(currentNonce, grace uint64) bool {
 	return false
 }
 
+// StaleFinishes returns locally-proposed MsgFinishInference txs (ProposedAt > 0)
+// that have been sitting in the mempool for more than `grace` nonces past
+// their proposal point (e.ProposedAt + grace < currentNonce).
+//
+// RemoveIncluded clears any entry whose tx hash is in an applied diff, so an
+// entry still present after applyAndPersist at nonce N was, by definition,
+// not included in any diff up to and including N. The `grace` adds a buffer
+// on top of that: callers typically set it to two full slot rotations
+// (2 * len(group)) so the user has at least two chances to pick up the
+// Finish via natural round-robin contact with the executor host before we
+// resort to peer-to-peer recovery gossip.
+//
+// Used by the host to recover from "user as sole sequencer" stalls: if the
+// user diff failed to absorb our Finish (e.g. because the OpenAI client at
+// devshardctl disconnected before reading devshard_meta, or the proxy
+// crashed mid-drain), we re-broadcast it via tx gossip so peers can learn
+// about it and -- crucially -- include it in their own mempool returns to
+// the user, giving the user another path to sequence it into a signed diff.
+//
+// Peer-imported entries (ProposedAt == 0, set by AddTx via gossip.OnTxsReceived)
+// are intentionally excluded so we don't amplify other hosts' broadcasts.
+//
+// Iteration order is unspecified; consumers (gossip broadcast dedups by tx
+// hash, user re-sorts pending txs) are order-insensitive.
+func (m *Mempool) StaleFinishes(currentNonce, grace uint64) []*types.DevshardTx {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.entries) == 0 {
+		return nil
+	}
+	var out []*types.DevshardTx
+	for _, e := range m.entries {
+		if e.ProposedAt == 0 {
+			continue
+		}
+		if e.Tx.GetFinishInference() == nil {
+			continue
+		}
+		if e.ProposedAt+grace < currentNonce {
+			out = append(out, e.Tx)
+		}
+	}
+	return out
+}
+
 func (m *Mempool) Txs() []*types.DevshardTx {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -74,5 +119,3 @@ func (m *Mempool) Len() int {
 func (m *Mempool) AddTx(tx *types.DevshardTx) {
 	m.Add(MempoolEntry{Tx: tx, ProposedAt: 0})
 }
-
-

--- a/devshard/host/mempool_test.go
+++ b/devshard/host/mempool_test.go
@@ -80,3 +80,42 @@ func TestMempool_DuplicateAdd(t *testing.T) {
 
 	require.Equal(t, 1, m.Len(), "duplicate tx should overwrite, not double-add")
 }
+
+func TestMempool_StaleFinishes(t *testing.T) {
+	m := NewMempool()
+	require.Nil(t, m.StaleFinishes(10, 0), "empty mempool returns nil")
+
+	localFinish := finishTx(1)
+	peerFinish := finishTx(2)
+	val := validationTx(1, 0)
+	m.Add(MempoolEntry{Tx: localFinish, ProposedAt: 5})
+	m.Add(MempoolEntry{Tx: val, ProposedAt: 5})
+	m.AddTx(peerFinish) // ProposedAt: 0 -- gossip-imported sentinel.
+
+	// grace=0, currentNonce == ProposedAt: not yet stale.
+	require.Empty(t, m.StaleFinishes(5, 0))
+
+	// grace=0, currentNonce > ProposedAt: locally-proposed Finish is stale.
+	stale := m.StaleFinishes(6, 0)
+	require.Len(t, stale, 1, "only the local Finish should be returned")
+	require.NotNil(t, stale[0].GetFinishInference())
+	require.Equal(t, uint64(1), stale[0].GetFinishInference().InferenceId)
+
+	// grace > 0 buffers the trigger: at ProposedAt+grace we are still not
+	// stale (5+2 < 7 is false); only past that point.
+	require.Empty(t, m.StaleFinishes(7, 2), "ProposedAt+grace not yet exceeded")
+	require.Len(t, m.StaleFinishes(8, 2), 1, "exceeding ProposedAt+grace marks stale")
+
+	// Peer-imported Finish (ProposedAt=0) must never be reported, regardless
+	// of currentNonce or grace, to avoid amplifying other hosts' broadcasts.
+	for n := uint64(1); n < 100; n++ {
+		for _, tx := range m.StaleFinishes(n, 0) {
+			require.NotEqual(t, uint64(2), tx.GetFinishInference().InferenceId,
+				"peer-imported Finish must be excluded")
+		}
+	}
+
+	// Validations and other non-Finish tx types are never returned, even when
+	// locally proposed and past their proposal nonce.
+	require.Len(t, m.StaleFinishes(99, 0), 1, "only Finish txs are eligible")
+}

--- a/inference-chain/app/ante_fee.go
+++ b/inference-chain/app/ante_fee.go
@@ -135,6 +135,15 @@ func isExemptMessageType(msg sdk.Msg) bool {
 		*inferencetypes.MsgRevalidateInference:
 		return true
 
+	// Routine host duties on a fixed schedule. Not user-discretionary, not a
+	// sybil-attack vector. Rate-limited implicitly: hardware diff fires only
+	// on changes / per-block heartbeat, claim rewards is once per epoch per
+	// host. Excluding these from fees keeps the per-host yearly budget from
+	// being dominated by mechanical chain bookkeeping.
+	case *inferencetypes.MsgSubmitHardwareDiff,
+		*inferencetypes.MsgClaimRewards:
+		return true
+
 	// BLS DKG protocol messages (epoch-scoped, duplicate-checked, deadline-enforced)
 	case *blstypes.MsgSubmitDealerPart,
 		*blstypes.MsgSubmitVerificationVector,

--- a/inference-chain/app/ante_fee_test.go
+++ b/inference-chain/app/ante_fee_test.go
@@ -50,6 +50,8 @@ func TestNetworkDutyBypass_AllExemptMessages(t *testing.T) {
 		"MsgRevalidateInference":               &inferencetypes.MsgRevalidateInference{},
 		"MsgMLNodeWeightDistribution":          &inferencetypes.MsgMLNodeWeightDistribution{},
 		"MsgSubmitPocValidationsV2":            &inferencetypes.MsgSubmitPocValidationsV2{},
+		"MsgSubmitHardwareDiff":                &inferencetypes.MsgSubmitHardwareDiff{},
+		"MsgClaimRewards":                      &inferencetypes.MsgClaimRewards{},
 		"MsgSubmitDealerPart":                  &blstypes.MsgSubmitDealerPart{},
 		"MsgSubmitVerificationVector":          &blstypes.MsgSubmitVerificationVector{},
 		"MsgSubmitGroupKeyValidationSignature": &blstypes.MsgSubmitGroupKeyValidationSignature{},
@@ -89,7 +91,9 @@ func TestNetworkDutyBypass_NonExemptMessages(t *testing.T) {
 	nonExemptMsgs := []sdk.Msg{
 		&banktypes.MsgSend{},
 		&stakingtypes.MsgDelegate{},
-		&inferencetypes.MsgClaimRewards{},
+		// MsgPoCV2StoreCommit is intentionally non-exempt: it carries the
+		// count-proportional sybil-defense fee defined in FeeParams. See
+		// chargePoCV2StoreCommitGas in msg_server_poc_v2_commit.go.
 		&inferencetypes.MsgPoCV2StoreCommit{},
 		&inferencetypes.MsgSubmitNewParticipant{},
 	}
@@ -174,11 +178,12 @@ func TestIsExemptMessageType(t *testing.T) {
 	require.True(t, isExemptMessageType(&blstypes.MsgSubmitVerificationVector{}))
 	require.True(t, isExemptMessageType(&blstypes.MsgSubmitGroupKeyValidationSignature{}))
 	require.True(t, isExemptMessageType(&blstypes.MsgSubmitPartialSignature{}))
+	require.True(t, isExemptMessageType(&inferencetypes.MsgSubmitHardwareDiff{}))
+	require.True(t, isExemptMessageType(&inferencetypes.MsgClaimRewards{}))
 
 	// Not exempt
 	require.False(t, isExemptMessageType(&blstypes.MsgRequestThresholdSignature{})) // open to anyone, no rate limit
-	require.False(t, isExemptMessageType(&inferencetypes.MsgPoCV2StoreCommit{}))
-	require.False(t, isExemptMessageType(&inferencetypes.MsgClaimRewards{}))
+	require.False(t, isExemptMessageType(&inferencetypes.MsgPoCV2StoreCommit{}))    // intentional sybil-defense fee
 	require.False(t, isExemptMessageType(&inferencetypes.MsgSubmitNewParticipant{}))
 	require.False(t, isExemptMessageType(&banktypes.MsgSend{}))
 	require.False(t, isExemptMessageType(&stakingtypes.MsgDelegate{}))
@@ -225,7 +230,7 @@ func TestIsNetworkDuty_MsgExec_FailsClosed(t *testing.T) {
 func TestIsNetworkDuty_NonExecNonExempt(t *testing.T) {
 	// Non-MsgExec, non-exempt message
 	require.False(t, isNetworkDuty(&banktypes.MsgSend{}, nil))
-	require.False(t, isNetworkDuty(&inferencetypes.MsgClaimRewards{}, nil))
+	require.False(t, isNetworkDuty(&inferencetypes.MsgPoCV2StoreCommit{}, nil))
 }
 
 func TestIsNetworkDuty_ExemptDirectMessage(t *testing.T) {

--- a/inference-chain/app/upgrades.go
+++ b/inference-chain/app/upgrades.go
@@ -15,6 +15,7 @@ import (
 	"github.com/productscience/inference/app/upgrades/v0_2_10"
 	"github.com/productscience/inference/app/upgrades/v0_2_11"
 	"github.com/productscience/inference/app/upgrades/v0_2_12"
+	"github.com/productscience/inference/app/upgrades/v0_2_13"
 	v0_2_2 "github.com/productscience/inference/app/upgrades/v0_2_2"
 	v0_2_3 "github.com/productscience/inference/app/upgrades/v0_2_3"
 	"github.com/productscience/inference/app/upgrades/v0_2_4"
@@ -65,6 +66,7 @@ func (app *App) setupUpgradeHandlers() {
 	app.UpgradeKeeper.SetUpgradeHandler(v0_2_10.UpgradeName, v0_2_10.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.DistrKeeper))
 	app.UpgradeKeeper.SetUpgradeHandler(v0_2_11.UpgradeName, v0_2_11.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.DistrKeeper, app.BlsKeeper))
 	app.UpgradeKeeper.SetUpgradeHandler(v0_2_12.UpgradeName, v0_2_12.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.DistrKeeper, app.BlsKeeper, app.AuthzKeeper, app.FeeGrantKeeper))
+	app.UpgradeKeeper.SetUpgradeHandler(v0_2_13.UpgradeName, v0_2_13.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper))
 }
 
 func (app *App) registerMigrations() {

--- a/inference-chain/app/upgrades/v0_2_13/constants.go
+++ b/inference-chain/app/upgrades/v0_2_13/constants.go
@@ -1,0 +1,7 @@
+package v0_2_13
+
+// UpgradeName MUST exactly match the on-chain governance proposal name.
+// Cosmovisor matches the announced name to this string when scheduling
+// the binary swap; any drift between proposal text and this constant
+// silently bypasses the upgrade handler.
+const UpgradeName = "v0.2.13"

--- a/inference-chain/app/upgrades/v0_2_13/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_13/upgrades.go
@@ -1,0 +1,63 @@
+// Package v0_2_13 holds the upgrade handler for the v0.2.13 release.
+//
+// At branch-creation time this is a minimal scaffold: capability-version
+// fix + RunMigrations. As state-affecting features land for v0.2.13,
+// add small single-purpose migration steps below the capability fix and
+// above RunMigrations, in dependency order. Each step should:
+//
+//   - Be a top-level function in this file (or a sibling _migrations file
+//     for the larger multi-step ones, like v0.2.12 does).
+//   - Read state, mutate, write state. Avoid stashing state in package
+//     globals or carrying it across step boundaries.
+//   - Return an error and let the handler bubble it up. A failed migration
+//     halts the chain at the upgrade height; that's the correct behavior.
+//   - Have its own unit test in upgrades_test.go.
+//
+// If the migration touches the InferenceModule's state in a way that needs
+// a ConsensusVersion bump, also:
+//   - Bump InferenceModule.ConsensusVersion() in x/inference/module/module.go.
+//   - Register a corresponding migration in app/upgrades.go's
+//     registerMigrations() (the pattern there is `RegisterMigration(name,
+//     fromVersion, handler)` registering N → N+1).
+//
+// If a new keeper is needed (BlsKeeper, AuthzKeeper, FeeGrantKeeper, etc.),
+// add it to CreateUpgradeHandler's signature and thread it through the
+// SetUpgradeHandler call in app/upgrades.go.
+package v0_2_13
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	k keeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		k.LogInfo("starting upgrade", types.Upgrades, "version", UpgradeName)
+
+		// Capability module's version is sometimes missing from the version
+		// map. Set it explicitly so RunMigrations doesn't re-run InitGenesis
+		// on a chain where capability state already exists.
+		if _, ok := fromVM["capability"]; !ok {
+			fromVM["capability"] = mm.Modules["capability"].(module.HasConsensusVersion).ConsensusVersion()
+		}
+
+		// === migration steps land below this line as v0.2.13 features merge ===
+
+		toVM, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return toVM, err
+		}
+
+		k.LogInfo("successfully upgraded", types.Upgrades, "version", UpgradeName)
+		return toVM, nil
+	}
+}

--- a/inference-chain/app/upgrades/v0_2_13/upgrades_test.go
+++ b/inference-chain/app/upgrades/v0_2_13/upgrades_test.go
@@ -1,0 +1,15 @@
+package v0_2_13
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpgradeName pins the on-chain proposal name. If the v0.2.13 governance
+// proposal is announced under a different string, change either the proposal
+// or this constant — but they MUST match exactly. Cosmovisor uses the name
+// to schedule the binary swap; a mismatch silently bypasses the handler.
+func TestUpgradeName(t *testing.T) {
+	require.Equal(t, "v0.2.13", UpgradeName)
+}

--- a/inference-chain/x/inference/keeper/msg_server_submit_hardware_diff.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_hardware_diff.go
@@ -71,6 +71,17 @@ func (k msgServer) SubmitHardwareDiff(goCtx context.Context, msg *types.MsgSubmi
 		return strings.Compare(a.LocalId, b.LocalId)
 	})
 
+	// Skip the write when the resulting node set is operationally identical
+	// to what's already stored. Catches the chatty-DAPI case where the same
+	// diff fires every block. NOT a security control — a malicious sender
+	// can defeat this by flipping any compared field. The point is to stop
+	// honest no-op spam, not to rate-limit.
+	if HardwareNodesUnchanged(updatedNodes.HardwareNodes, existingNodes.HardwareNodes) {
+		k.LogDebug("SubmitHardwareDiff no-op: skipping write", types.Nodes,
+			"participant", msg.Creator, "nodeCount", len(updatedNodes.HardwareNodes))
+		return &types.MsgSubmitHardwareDiffResponse{}, nil
+	}
+
 	k.LogInfo("Updating hardware nodes", types.Nodes, "nodes", updatedNodes)
 	if err := k.SetHardwareNodes(ctx, updatedNodes); err != nil {
 		k.LogError("Error setting hardware nodes", types.Nodes, "err", err)
@@ -78,4 +89,56 @@ func (k msgServer) SubmitHardwareDiff(goCtx context.Context, msg *types.MsgSubmi
 	}
 
 	return &types.MsgSubmitHardwareDiffResponse{}, nil
+}
+
+// HardwareNodesUnchanged reports whether two sorted hardware-node lists are
+// equivalent in their *operational* fields: local_id, status, models,
+// hardware, host, port. The Version field is excluded because it's
+// explicitly informational (see hardware_node.proto) and a flapping value
+// shouldn't trigger spurious writes.
+//
+// This is a best-effort idempotency check, not a security boundary. A
+// caller that wants to bypass it can flip any operational field.
+// Exported for testing.
+func HardwareNodesUnchanged(after, before []*types.HardwareNode) bool {
+	if len(after) != len(before) {
+		return false
+	}
+	for i := range after {
+		if !hardwareNodeOperationalEqual(after[i], before[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// hardwareNodeOperationalEqual compares the load-bearing fields of two
+// HardwareNode protos. Add to this list if hardware_node.proto adds new
+// state-affecting fields.
+func hardwareNodeOperationalEqual(a, b *types.HardwareNode) bool {
+	if a == b {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.LocalId != b.LocalId ||
+		a.Status != b.Status ||
+		a.Host != b.Host ||
+		a.Port != b.Port {
+		return false
+	}
+	if !slices.Equal(a.Models, b.Models) {
+		return false
+	}
+	if len(a.Hardware) != len(b.Hardware) {
+		return false
+	}
+	for i := range a.Hardware {
+		if a.Hardware[i].Type != b.Hardware[i].Type ||
+			a.Hardware[i].Count != b.Hardware[i].Count {
+			return false
+		}
+	}
+	return true
 }

--- a/inference-chain/x/inference/keeper/msg_server_submit_hardware_diff_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_hardware_diff_test.go
@@ -217,3 +217,121 @@ func TestMsgServer_SubmitHardwareDiff_RemoveAll(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, 0, len(hardwareNodes.HardwareNodes))
 }
+
+// TestHardwareNodesUnchanged is a focused unit test for the helper that
+// gates the SubmitHardwareDiff no-op skip. Compares operational fields
+// only — see hardwareNodeOperationalEqual — so flapping informational
+// fields like Version don't trigger spurious writes.
+func TestHardwareNodesUnchanged(t *testing.T) {
+	n1 := &types.HardwareNode{LocalId: "n1", Status: types.HardwareNodeStatus_INFERENCE}
+	n2 := &types.HardwareNode{LocalId: "n2", Status: types.HardwareNodeStatus_POC,
+		Models: []string{"model1"}, Host: "h", Port: "8080",
+		Hardware: []*types.Hardware{{Type: "GPU", Count: 2}}}
+
+	// Both empty: equal.
+	require.True(t, keeper.HardwareNodesUnchanged(nil, nil))
+	require.True(t, keeper.HardwareNodesUnchanged([]*types.HardwareNode{}, []*types.HardwareNode{}))
+
+	// Identical content, identical order.
+	require.True(t, keeper.HardwareNodesUnchanged(
+		[]*types.HardwareNode{n1, n2}, []*types.HardwareNode{n1, n2}))
+
+	// Different lengths.
+	require.False(t, keeper.HardwareNodesUnchanged(
+		[]*types.HardwareNode{n1}, []*types.HardwareNode{n1, n2}))
+
+	// Operational field differs: detected.
+	n2DiffStatus := &types.HardwareNode{LocalId: "n2", Status: types.HardwareNodeStatus_INFERENCE,
+		Models: n2.Models, Host: n2.Host, Port: n2.Port, Hardware: n2.Hardware}
+	require.False(t, keeper.HardwareNodesUnchanged(
+		[]*types.HardwareNode{n1, n2DiffStatus}, []*types.HardwareNode{n1, n2}))
+
+	// Models reordered: detected (slices.Equal is positional).
+	n2DiffModels := &types.HardwareNode{LocalId: "n2", Status: n2.Status,
+		Models: []string{"model2"}, Host: n2.Host, Port: n2.Port, Hardware: n2.Hardware}
+	require.False(t, keeper.HardwareNodesUnchanged(
+		[]*types.HardwareNode{n1, n2DiffModels}, []*types.HardwareNode{n1, n2}))
+
+	// Hardware count differs: detected.
+	n2DiffHW := &types.HardwareNode{LocalId: "n2", Status: n2.Status,
+		Models: n2.Models, Host: n2.Host, Port: n2.Port,
+		Hardware: []*types.Hardware{{Type: "GPU", Count: 4}}}
+	require.False(t, keeper.HardwareNodesUnchanged(
+		[]*types.HardwareNode{n1, n2DiffHW}, []*types.HardwareNode{n1, n2}))
+
+	// Version differs but everything else identical: NOT detected (the
+	// version field is informational only — flipping it shouldn't defeat
+	// the no-op check).
+	n2VerA := &types.HardwareNode{LocalId: "n2", Status: n2.Status,
+		Models: n2.Models, Host: n2.Host, Port: n2.Port, Hardware: n2.Hardware,
+		Version: "v1"}
+	n2VerB := &types.HardwareNode{LocalId: "n2", Status: n2.Status,
+		Models: n2.Models, Host: n2.Host, Port: n2.Port, Hardware: n2.Hardware,
+		Version: "v2"}
+	require.True(t, keeper.HardwareNodesUnchanged(
+		[]*types.HardwareNode{n1, n2VerA}, []*types.HardwareNode{n1, n2VerB}),
+		"flapping the informational Version field should NOT count as a change")
+}
+
+// TestMsgServer_SubmitHardwareDiff_IdempotentOnNoChange exercises the
+// happy path of the no-op skip end-to-end: a participant submits a diff
+// once, then submits an identical (no-op) diff. Both calls succeed and
+// the stored state matches the original write.
+//
+// We can't directly assert "SetHardwareNodes was not called the second
+// time" without a keeper spy, so this test pairs with TestHardwareNodesUnchanged
+// (unit-level) for full coverage.
+func TestMsgServer_SubmitHardwareDiff_IdempotentOnNoChange(t *testing.T) {
+	k, ms, ctx := setupMsgServer(t)
+
+	mockCreator := NewMockAccount(testutil.Creator)
+	MustAddParticipant(t, ms, ctx, *mockCreator)
+	registerTestModels(t, k, ms, ctx, "model1")
+
+	node := &types.HardwareNode{
+		LocalId:  "node1",
+		Status:   types.HardwareNodeStatus_INFERENCE,
+		Models:   []string{"model1"},
+		Hardware: []*types.Hardware{{Type: "GPU", Count: 1}},
+		Host:     "localhost",
+		Port:     "8080",
+	}
+
+	// First submit: writes the node.
+	_, err := ms.SubmitHardwareDiff(ctx, &types.MsgSubmitHardwareDiff{
+		Creator:       testutil.Creator,
+		NewOrModified: []*types.HardwareNode{node},
+	})
+	require.NoError(t, err)
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	got, found := k.GetHardwareNodes(sdkCtx, testutil.Creator)
+	require.True(t, found)
+	require.Equal(t, 1, len(got.HardwareNodes))
+
+	// Second submit with the identical node: no-op path. Must still succeed
+	// and leave state untouched.
+	_, err = ms.SubmitHardwareDiff(ctx, &types.MsgSubmitHardwareDiff{
+		Creator:       testutil.Creator,
+		NewOrModified: []*types.HardwareNode{node},
+	})
+	require.NoError(t, err)
+
+	gotAgain, found := k.GetHardwareNodes(sdkCtx, testutil.Creator)
+	require.True(t, found)
+	require.Equal(t, 1, len(gotAgain.HardwareNodes))
+	require.Equal(t, got.HardwareNodes[0].LocalId, gotAgain.HardwareNodes[0].LocalId)
+	require.Equal(t, got.HardwareNodes[0].Status, gotAgain.HardwareNodes[0].Status)
+
+	// Empty diff (no add, no remove) is also a no-op.
+	_, err = ms.SubmitHardwareDiff(ctx, &types.MsgSubmitHardwareDiff{
+		Creator:       testutil.Creator,
+		NewOrModified: []*types.HardwareNode{},
+		Removed:       []*types.HardwareNode{},
+	})
+	require.NoError(t, err)
+
+	stillThere, found := k.GetHardwareNodes(sdkCtx, testutil.Creator)
+	require.True(t, found)
+	require.Equal(t, 1, len(stillThere.HardwareNodes))
+}


### PR DESCRIPTION
## Summary

- wait two full slot round-robin rotations before gossiping a locally produced `MsgFinishInference` that the user did not include in a diff
- make stale-finish gossip grace a fixed host policy (`2 * len(group)`) instead of a configurable option
- update recovery tests to cover the grace threshold and confirm peer-imported finishes are still not amplified