### PR TITLE
Weight Scaling

### DIFF
--- a/inference-chain/app/upgrades/v0_2_13/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_13/upgrades.go
@@ -32,6 +32,10 @@ const (
 	// These are standard constants and do not need to be passed via Plan.Info.
 	USDCContractAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 	USDTContractAddress = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+
+	kimiModelID        = "moonshotai/Kimi-K2.6"
+	minimaxModelID     = "MiniMaxAI/MiniMax-M2.7"
+	minimaxModelCommit = "d494266a4affc0d2995ba1fa35c8481cbd84294b"
 )
 
 // BridgeSetupData is parsed from the upgrade proposal's Plan.Info JSON field.
@@ -67,6 +71,9 @@ func CreateUpgradeHandler(
 			return nil, err
 		}
 		if err := backfillConfirmationWeightScales(ctx, k); err != nil {
+			return nil, err
+		}
+		if err := updateModelParams(ctx, k); err != nil {
 			return nil, err
 		}
 		if err := grantRespondDealerComplaintsAuthz(ctx, authzKeeper, k); err != nil {
@@ -108,6 +115,127 @@ func setDevshardEscrowParams(ctx context.Context, k keeper.Keeper) error {
 		"max_escrows_per_epoch", MaxEscrowsPerEpoch,
 		"max_nonce", MaxNonce)
 	return nil
+}
+
+func updateModelParams(ctx context.Context, k keeper.Keeper) error {
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return err
+	}
+	if params.PocParams == nil {
+		return fmt.Errorf("poc params not found")
+	}
+
+	updatedKimi := setPoCModelWeightScale(params.PocParams, kimiModelID, kimiWeightScaleFactor())
+	upsertPoCModelConfig(params.PocParams, minimaxPoCModelConfig(modelPenaltyStartEpoch(ctx, k)))
+
+	if err := k.SetParams(ctx, params); err != nil {
+		return err
+	}
+	updateKimiGovernanceModelArgs(ctx, k)
+	k.SetModel(ctx, minimaxGovernanceModel(k.GetAuthority()))
+	k.LogInfo("updated model params", types.Upgrades,
+		"kimi_model_id", kimiModelID,
+		"kimi_updated", updatedKimi,
+		"minimax_model_id", minimaxModelID)
+	return nil
+}
+
+func updateKimiGovernanceModelArgs(ctx context.Context, k keeper.Keeper) {
+	model, found := k.GetGovernanceModel(ctx, kimiModelID)
+	if !found || model == nil {
+		return
+	}
+	if hasModelArg(model.ModelArgs, "--enable-auto-tool-choice") {
+		return
+	}
+	model.ModelArgs = append([]string{"--enable-auto-tool-choice"}, model.ModelArgs...)
+	k.SetModel(ctx, model)
+}
+
+func hasModelArg(args []string, arg string) bool {
+	for _, existing := range args {
+		if existing == arg {
+			return true
+		}
+	}
+	return false
+}
+
+func setPoCModelWeightScale(poc *types.PocParams, modelID string, weightScaleFactor *types.Decimal) bool {
+	for _, model := range poc.Models {
+		if model == nil || model.ModelId != modelID {
+			continue
+		}
+		model.WeightScaleFactor = weightScaleFactor
+		return true
+	}
+	return false
+}
+
+func upsertPoCModelConfig(poc *types.PocParams, config *types.PoCModelConfig) {
+	for i, model := range poc.Models {
+		if model == nil || model.ModelId != config.ModelId {
+			continue
+		}
+		poc.Models[i] = config
+		return
+	}
+	poc.Models = append(poc.Models, config)
+}
+
+func kimiWeightScaleFactor() *types.Decimal {
+	return &types.Decimal{Value: 78, Exponent: -2}
+}
+
+func minimaxWeightScaleFactor() *types.Decimal {
+	return &types.Decimal{Value: 3024, Exponent: -4}
+}
+
+func minimaxValidationThreshold() *types.Decimal {
+	return &types.Decimal{Value: 920, Exponent: -3}
+}
+
+func minimaxPoCModelConfig(penaltyStartEpoch uint64) *types.PoCModelConfig {
+	return &types.PoCModelConfig{
+		ModelId: minimaxModelID,
+		SeqLen:  1024,
+		StatTest: &types.PoCStatTestParams{
+			DistThreshold:   &types.Decimal{Value: 75, Exponent: -2}, // 0.75
+			PMismatch:       &types.Decimal{Value: 1, Exponent: -1},  // 0.10
+			PValueThreshold: &types.Decimal{Value: 5, Exponent: -2},  // 0.05
+		},
+		WeightScaleFactor: minimaxWeightScaleFactor(),
+		PenaltyStartEpoch: penaltyStartEpoch,
+	}
+}
+
+func modelPenaltyStartEpoch(ctx context.Context, k keeper.Keeper) uint64 {
+	epochIndex, found := k.GetEffectiveEpochIndex(ctx)
+	if !found {
+		k.LogInfo("no effective epoch for model penalty start; using fallback", types.Upgrades,
+			"penalty_start_epoch", 5)
+		return 5
+	}
+	return epochIndex + 5
+}
+
+func minimaxGovernanceModel(authority string) *types.Model {
+	return &types.Model{
+		ProposedBy:             authority,
+		Id:                     minimaxModelID,
+		UnitsOfComputePerToken: 10000,
+		HfRepo:                 minimaxModelID,
+		HfCommit:               minimaxModelCommit,
+		ModelArgs: []string{
+			"--enable-auto-tool-choice",
+			"--tool-call-parser", "minimax_m2",
+			"--reasoning-parser", "minimax_m2_append_think",
+		},
+		VRam:                320,
+		ThroughputPerNonce:  5000,
+		ValidationThreshold: minimaxValidationThreshold(),
+	}
 }
 
 func backfillConfirmationWeightScales(ctx context.Context, k keeper.Keeper) error {

--- a/inference-chain/app/upgrades/v0_2_13/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_13/upgrades.go
@@ -33,9 +33,11 @@ const (
 	USDCContractAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 	USDTContractAddress = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
 
+	qwenModelID        = "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
 	kimiModelID        = "moonshotai/Kimi-K2.6"
 	minimaxModelID     = "MiniMaxAI/MiniMax-M2.7"
 	minimaxModelCommit = "d494266a4affc0d2995ba1fa35c8481cbd84294b"
+	minimaxStartEpoch  = uint64(271)
 )
 
 // BridgeSetupData is parsed from the upgrade proposal's Plan.Info JSON field.
@@ -127,12 +129,13 @@ func updateModelParams(ctx context.Context, k keeper.Keeper) error {
 	}
 
 	updatedKimi := setPoCModelWeightScale(params.PocParams, kimiModelID, kimiWeightScaleFactor())
-	upsertPoCModelConfig(params.PocParams, minimaxPoCModelConfig(modelPenaltyStartEpoch(ctx, k)))
+	upsertPoCModelConfig(params.PocParams, minimaxPoCModelConfig())
 
 	if err := k.SetParams(ctx, params); err != nil {
 		return err
 	}
-	updateKimiGovernanceModelArgs(ctx, k)
+	setGovernanceModelValidationThreshold(ctx, k, qwenModelID, qwenValidationThreshold())
+	updateKimiGovernanceModel(ctx, k)
 	k.SetModel(ctx, minimaxGovernanceModel(k.GetAuthority()))
 	k.LogInfo("updated model params", types.Upgrades,
 		"kimi_model_id", kimiModelID,
@@ -141,15 +144,29 @@ func updateModelParams(ctx context.Context, k keeper.Keeper) error {
 	return nil
 }
 
-func updateKimiGovernanceModelArgs(ctx context.Context, k keeper.Keeper) {
+func setGovernanceModelValidationThreshold(
+	ctx context.Context,
+	k keeper.Keeper,
+	modelID string,
+	threshold *types.Decimal,
+) {
+	model, found := k.GetGovernanceModel(ctx, modelID)
+	if !found || model == nil {
+		return
+	}
+	model.ValidationThreshold = threshold
+	k.SetModel(ctx, model)
+}
+
+func updateKimiGovernanceModel(ctx context.Context, k keeper.Keeper) {
 	model, found := k.GetGovernanceModel(ctx, kimiModelID)
 	if !found || model == nil {
 		return
 	}
-	if hasModelArg(model.ModelArgs, "--enable-auto-tool-choice") {
-		return
+	model.ValidationThreshold = kimiValidationThreshold()
+	if !hasModelArg(model.ModelArgs, "--enable-auto-tool-choice") {
+		model.ModelArgs = append([]string{"--enable-auto-tool-choice"}, model.ModelArgs...)
 	}
-	model.ModelArgs = append([]string{"--enable-auto-tool-choice"}, model.ModelArgs...)
 	k.SetModel(ctx, model)
 }
 
@@ -188,15 +205,23 @@ func kimiWeightScaleFactor() *types.Decimal {
 	return &types.Decimal{Value: 78, Exponent: -2}
 }
 
+func qwenValidationThreshold() *types.Decimal {
+	return &types.Decimal{Value: 940, Exponent: -3}
+}
+
+func kimiValidationThreshold() *types.Decimal {
+	return &types.Decimal{Value: 900, Exponent: -3}
+}
+
 func minimaxWeightScaleFactor() *types.Decimal {
 	return &types.Decimal{Value: 3024, Exponent: -4}
 }
 
 func minimaxValidationThreshold() *types.Decimal {
-	return &types.Decimal{Value: 920, Exponent: -3}
+	return &types.Decimal{Value: 922, Exponent: -3}
 }
 
-func minimaxPoCModelConfig(penaltyStartEpoch uint64) *types.PoCModelConfig {
+func minimaxPoCModelConfig() *types.PoCModelConfig {
 	return &types.PoCModelConfig{
 		ModelId: minimaxModelID,
 		SeqLen:  1024,
@@ -206,18 +231,8 @@ func minimaxPoCModelConfig(penaltyStartEpoch uint64) *types.PoCModelConfig {
 			PValueThreshold: &types.Decimal{Value: 5, Exponent: -2},  // 0.05
 		},
 		WeightScaleFactor: minimaxWeightScaleFactor(),
-		PenaltyStartEpoch: penaltyStartEpoch,
+		PenaltyStartEpoch: minimaxStartEpoch,
 	}
-}
-
-func modelPenaltyStartEpoch(ctx context.Context, k keeper.Keeper) uint64 {
-	epochIndex, found := k.GetEffectiveEpochIndex(ctx)
-	if !found {
-		k.LogInfo("no effective epoch for model penalty start; using fallback", types.Upgrades,
-			"penalty_start_epoch", 5)
-		return 5
-	}
-	return epochIndex + 5
 }
 
 func minimaxGovernanceModel(authority string) *types.Model {
@@ -229,6 +244,7 @@ func minimaxGovernanceModel(authority string) *types.Model {
 		HfCommit:               minimaxModelCommit,
 		ModelArgs: []string{
 			"--enable-auto-tool-choice",
+			"--kv-cache-dtype", "fp8",
 			"--tool-call-parser", "minimax_m2",
 			"--reasoning-parser", "minimax_m2_append_think",
 		},

--- a/inference-chain/app/upgrades/v0_2_13/upgrades_test.go
+++ b/inference-chain/app/upgrades/v0_2_13/upgrades_test.go
@@ -114,8 +114,14 @@ func TestUpdateModelParamsSetsKimiAndAddsMiniMax(t *testing.T) {
 	require.NoError(t, k.SetParams(ctx, params))
 	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 11))
 	k.SetModel(ctx, &inferencetypes.Model{
-		Id:     kimiModelID,
-		HfRepo: kimiModelID,
+		Id:                  qwenModelID,
+		HfRepo:              qwenModelID,
+		ValidationThreshold: &inferencetypes.Decimal{Value: 958, Exponent: -3},
+	})
+	k.SetModel(ctx, &inferencetypes.Model{
+		Id:                  kimiModelID,
+		HfRepo:              kimiModelID,
+		ValidationThreshold: &inferencetypes.Decimal{Value: 920, Exponent: -3},
 		ModelArgs: []string{
 			"--max-model-len", "240000",
 			"--tool-call-parser", "kimi_k2",
@@ -124,6 +130,10 @@ func TestUpdateModelParamsSetsKimiAndAddsMiniMax(t *testing.T) {
 	})
 
 	require.NoError(t, updateModelParams(ctx, k))
+
+	qwenModel, found := k.GetGovernanceModel(ctx, qwenModelID)
+	require.True(t, found)
+	require.Equal(t, &inferencetypes.Decimal{Value: 940, Exponent: -3}, qwenModel.ValidationThreshold)
 
 	got, err := k.GetParams(ctx)
 	require.NoError(t, err)
@@ -139,6 +149,7 @@ func TestUpdateModelParamsSetsKimiAndAddsMiniMax(t *testing.T) {
 		"--tool-call-parser", "kimi_k2",
 		"--reasoning-parser", "kimi_k2",
 	}, kimiModel.ModelArgs)
+	require.Equal(t, &inferencetypes.Decimal{Value: 900, Exponent: -3}, kimiModel.ValidationThreshold)
 
 	minimax := requirePoCModelConfig(t, got.PocParams.Models, minimaxModelID)
 	require.Equal(t, int64(1024), minimax.SeqLen)
@@ -147,7 +158,7 @@ func TestUpdateModelParamsSetsKimiAndAddsMiniMax(t *testing.T) {
 	require.Equal(t, &inferencetypes.Decimal{Value: 1, Exponent: -1}, minimax.StatTest.PMismatch)
 	require.Equal(t, &inferencetypes.Decimal{Value: 5, Exponent: -2}, minimax.StatTest.PValueThreshold)
 	require.Equal(t, &inferencetypes.Decimal{Value: 3024, Exponent: -4}, minimax.WeightScaleFactor)
-	require.Equal(t, uint64(16), minimax.PenaltyStartEpoch)
+	require.Equal(t, uint64(271), minimax.PenaltyStartEpoch)
 
 	model, found := k.GetGovernanceModel(ctx, minimaxModelID)
 	require.True(t, found)
@@ -155,9 +166,10 @@ func TestUpdateModelParamsSetsKimiAndAddsMiniMax(t *testing.T) {
 	require.Equal(t, "d494266a4affc0d2995ba1fa35c8481cbd84294b", model.HfCommit)
 	require.Equal(t, uint64(320), model.VRam)
 	require.Equal(t, uint64(5000), model.ThroughputPerNonce)
-	require.Equal(t, &inferencetypes.Decimal{Value: 920, Exponent: -3}, model.ValidationThreshold)
+	require.Equal(t, &inferencetypes.Decimal{Value: 922, Exponent: -3}, model.ValidationThreshold)
 	require.Equal(t, []string{
 		"--enable-auto-tool-choice",
+		"--kv-cache-dtype", "fp8",
 		"--tool-call-parser", "minimax_m2",
 		"--reasoning-parser", "minimax_m2_append_think",
 	}, model.ModelArgs)

--- a/inference-chain/app/upgrades/v0_2_13/upgrades_test.go
+++ b/inference-chain/app/upgrades/v0_2_13/upgrades_test.go
@@ -99,3 +99,94 @@ func TestBackfillConfirmationWeightScales(t *testing.T) {
 	require.Equal(t, int64(50), root.ValidationWeights[0].ConfirmationWeight)
 	require.Equal(t, int64(5), root.ValidationWeights[1].ConfirmationWeight)
 }
+
+func TestUpdateModelParamsSetsKimiAndAddsMiniMax(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	params.PocParams.Models = []*inferencetypes.PoCModelConfig{
+		{
+			ModelId:           kimiModelID,
+			WeightScaleFactor: inferencetypes.DecimalFromFloat(1),
+		},
+	}
+	require.NoError(t, k.SetParams(ctx, params))
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 11))
+	k.SetModel(ctx, &inferencetypes.Model{
+		Id:     kimiModelID,
+		HfRepo: kimiModelID,
+		ModelArgs: []string{
+			"--max-model-len", "240000",
+			"--tool-call-parser", "kimi_k2",
+			"--reasoning-parser", "kimi_k2",
+		},
+	})
+
+	require.NoError(t, updateModelParams(ctx, k))
+
+	got, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	require.Len(t, got.PocParams.Models, 2)
+
+	kimi := requirePoCModelConfig(t, got.PocParams.Models, kimiModelID)
+	require.Equal(t, &inferencetypes.Decimal{Value: 78, Exponent: -2}, kimi.WeightScaleFactor)
+	kimiModel, found := k.GetGovernanceModel(ctx, kimiModelID)
+	require.True(t, found)
+	require.Equal(t, []string{
+		"--enable-auto-tool-choice",
+		"--max-model-len", "240000",
+		"--tool-call-parser", "kimi_k2",
+		"--reasoning-parser", "kimi_k2",
+	}, kimiModel.ModelArgs)
+
+	minimax := requirePoCModelConfig(t, got.PocParams.Models, minimaxModelID)
+	require.Equal(t, int64(1024), minimax.SeqLen)
+	require.NotNil(t, minimax.StatTest)
+	require.Equal(t, &inferencetypes.Decimal{Value: 75, Exponent: -2}, minimax.StatTest.DistThreshold)
+	require.Equal(t, &inferencetypes.Decimal{Value: 1, Exponent: -1}, minimax.StatTest.PMismatch)
+	require.Equal(t, &inferencetypes.Decimal{Value: 5, Exponent: -2}, minimax.StatTest.PValueThreshold)
+	require.Equal(t, &inferencetypes.Decimal{Value: 3024, Exponent: -4}, minimax.WeightScaleFactor)
+	require.Equal(t, uint64(16), minimax.PenaltyStartEpoch)
+
+	model, found := k.GetGovernanceModel(ctx, minimaxModelID)
+	require.True(t, found)
+	require.Equal(t, minimaxModelID, model.Id)
+	require.Equal(t, "d494266a4affc0d2995ba1fa35c8481cbd84294b", model.HfCommit)
+	require.Equal(t, uint64(320), model.VRam)
+	require.Equal(t, uint64(5000), model.ThroughputPerNonce)
+	require.Equal(t, &inferencetypes.Decimal{Value: 920, Exponent: -3}, model.ValidationThreshold)
+	require.Equal(t, []string{
+		"--enable-auto-tool-choice",
+		"--tool-call-parser", "minimax_m2",
+		"--reasoning-parser", "minimax_m2_append_think",
+	}, model.ModelArgs)
+
+	require.NoError(t, updateModelParams(ctx, k))
+	got, err = k.GetParams(ctx)
+	require.NoError(t, err)
+	require.Len(t, got.PocParams.Models, 2)
+	kimiModel, found = k.GetGovernanceModel(ctx, kimiModelID)
+	require.True(t, found)
+	require.Equal(t, []string{
+		"--enable-auto-tool-choice",
+		"--max-model-len", "240000",
+		"--tool-call-parser", "kimi_k2",
+		"--reasoning-parser", "kimi_k2",
+	}, kimiModel.ModelArgs)
+}
+
+func requirePoCModelConfig(
+	t *testing.T,
+	models []*inferencetypes.PoCModelConfig,
+	modelID string,
+) *inferencetypes.PoCModelConfig {
+	t.Helper()
+	for _, model := range models {
+		if model != nil && model.ModelId == modelID {
+			return model
+		}
+	}
+	require.Failf(t, "missing PoC model config", "model_id=%s", modelID)
+	return nil
+}


### PR DESCRIPTION
Adds the MiniMax-M2.7 governance model and rebalances `WeightScaleFactor` and `ValidationThreshold` across Qwen, Kimi, and MiniMax. All changes are applied in the `v0_2_13` upgrade handler (`updateModelParams`).

## New model: MiniMax-M2.7

Governance model `MiniMaxAI/MiniMax-M2.7`:

| Field | Value |
| --- | --- |
| `Id` / `HfRepo` | `MiniMaxAI/MiniMax-M2.7` |
| `HfCommit` | `d494266a4affc0d2995ba1fa35c8481cbd84294b` |
| `UnitsOfComputePerToken` | 10000 |
| `VRam` | 320 |
| `ThroughputPerNonce` | 5000 |
| `ValidationThreshold` | 0.922 |
| `ModelArgs` | `--enable-auto-tool-choice`, `--kv-cache-dtype fp8`, `--tool-call-parser minimax_m2`, `--reasoning-parser minimax_m2_append_think` |

PoC config (`PocParams.Models[MiniMax]`):

| Field | Value |
| --- | --- |
| `SeqLen` | 1024 |
| `WeightScaleFactor` | 0.3024 |
| `StatTest.DistThreshold` | 0.75 |
| `StatTest.PMismatch` | 0.10 |
| `StatTest.PValueThreshold` | 0.05 |
| `PenaltyStartEpoch` | 271 (`minimaxStartEpoch`, MiniMax bootstrap activation epoch) |

## Weight adjustments

After the vLLM 0.20.1 release, cross-version benchmarks (https://docs.google.com/spreadsheets/d/1dHHlbhW1_hVgd7Q6MtmcVSOpmnl7NnynoTzPHJ1oU-g/edit?gid=0#gid=0) show Kimi's effective weight on B* GPUs running too high relative to Qwen. The `WeightScaleFactor` values are recalibrated against the Qwen reference on B200:

- Kimi `WeightScaleFactor` = Qwen-on-B200 weight + 10% (top-tier premium).
- MiniMax `WeightScaleFactor` = Qwen-on-B200 weight.

Resulting `PocParams.Models[*].WeightScaleFactor`:

| Model | WeightScaleFactor |
| --- | --- |
| Kimi (`moonshotai/Kimi-K2.6`) | 0.78 |
| MiniMax (`MiniMaxAI/MiniMax-M2.7`) | 0.3024 |

Outcome: MiniMax becomes the most profitable model on H* GPUs; Kimi remains most profitable on B* but without gap.

## Validation thresholds

`Model.ValidationThreshold` is adjusted based on cross-version vLLM validation results:

| Model | ValidationThreshold |
| --- | --- |
| Qwen (`Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`) | 0.940 |
| Kimi (`moonshotai/Kimi-K2.6`) | 0.900 |
| MiniMax (`MiniMaxAI/MiniMax-M2.7`) | 0.922 |

## Other governance changes

- Kimi gains `--enable-auto-tool-choice` in `ModelArgs` if not already present.
