### PR TITLE
feat: route all hardcoded SessionConfig values through DevshardEscrowParams (closes #1028 SessionConfig part)

### DIFF
--- a/decentralized-api/internal/devshard/bridge.go
+++ b/decentralized-api/internal/devshard/bridge.go
@@ -43,13 +43,19 @@ func (b *ChainBridge) GetEscrow(escrowID string) (*bridge.EscrowInfo, error) {
 	}
 
 	return &bridge.EscrowInfo{
-		EscrowID:       escrowID,
-		Amount:         resp.Escrow.Amount,
-		CreatorAddress: resp.Escrow.Creator,
-		AppHash:        appHash,
-		Slots:          resp.Escrow.Slots,
-		TokenPrice:     resp.Escrow.TokenPrice,
-		EpochID:        resp.Escrow.EpochIndex,
+		EscrowID:          escrowID,
+		Amount:            resp.Escrow.Amount,
+		CreatorAddress:    resp.Escrow.Creator,
+		AppHash:           appHash,
+		Slots:             resp.Escrow.Slots,
+		TokenPrice:        resp.Escrow.TokenPrice,
+		EpochID:           resp.Escrow.EpochIndex,
+		MaxNonce:          resp.Escrow.MaxNonce,
+		RefusalTimeout:    resp.Escrow.RefusalTimeout,
+		ExecutionTimeout:  resp.Escrow.ExecutionTimeout,
+		ValidationRate:    resp.Escrow.ValidationRate,
+		CreateDevshardFee: resp.Escrow.CreateDevshardFee,
+		FeePerNonce:       resp.Escrow.FeePerNonce,
 	}, nil
 }
 

--- a/decentralized-api/internal/devshard/manager.go
+++ b/decentralized-api/internal/devshard/manager.go
@@ -240,7 +240,15 @@ func (m *HostManager) create(escrowID string) (*transport.Server, error) {
 
 	creatorAddr := escrow.CreatorAddress
 
-	config := types.SessionConfigWithPrice(len(group), escrow.TokenPrice)
+	config := types.SessionConfigFromEscrow(len(group), types.EscrowSessionFields{
+		TokenPrice:        escrow.TokenPrice,
+		RefusalTimeout:    escrow.RefusalTimeout,
+		ExecutionTimeout:  escrow.ExecutionTimeout,
+		ValidationRate:    escrow.ValidationRate,
+		CreateDevshardFee: escrow.CreateDevshardFee,
+		FeePerNonce:       escrow.FeePerNonce,
+		MaxNonce:          escrow.MaxNonce,
+	})
 
 	sm, err := state.NewStateMachine(escrowID, config, group, escrow.Amount, creatorAddr, m.verifier,
 		state.WithWarmKeyResolver(m.bridge.VerifyWarmKey),

--- a/devshard/bridge/interface.go
+++ b/devshard/bridge/interface.go
@@ -28,6 +28,15 @@ type EscrowInfo struct {
 	// EpochID is the chain epoch_index recorded on the on-chain DevshardEscrow.
 	// Storage uses it as the partition/pruning key.
 	EpochID uint64
+	// Session-config fields captured from DevshardEscrow at creation time.
+	// Zero values are interpreted as "use compiled defaults" by
+	// devshard/types.SessionConfigFromEscrow for backward compatibility.
+	MaxNonce          uint32
+	RefusalTimeout    int64
+	ExecutionTimeout  int64
+	ValidationRate    uint32
+	CreateDevshardFee uint64
+	FeePerNonce       uint64
 }
 
 type HostInfo struct {

--- a/devshard/bridge/rest.go
+++ b/devshard/bridge/rest.go
@@ -46,14 +46,20 @@ func NewRESTBridge(baseURL string, opts ...Option) *RESTBridge {
 
 type escrowResponse struct {
 	Escrow struct {
-		ID         uint64   `json:"id,string"`
-		Creator    string   `json:"creator"`
-		Amount     uint64   `json:"amount,string"`
-		Slots      []string `json:"slots"`
-		EpochIndex uint64   `json:"epoch_index,string"`
-		AppHash    string   `json:"app_hash"`
-		Settled    bool     `json:"settled"`
-		TokenPrice uint64   `json:"token_price,string"`
+		ID                uint64   `json:"id,string"`
+		Creator           string   `json:"creator"`
+		Amount            uint64   `json:"amount,string"`
+		Slots             []string `json:"slots"`
+		EpochIndex        uint64   `json:"epoch_index,string"`
+		AppHash           string   `json:"app_hash"`
+		Settled           bool     `json:"settled"`
+		TokenPrice        uint64   `json:"token_price,string"`
+		MaxNonce          uint32   `json:"max_nonce"`
+		RefusalTimeout    int64    `json:"refusal_timeout,string"`
+		ExecutionTimeout  int64    `json:"execution_timeout,string"`
+		ValidationRate    uint32   `json:"validation_rate"`
+		CreateDevshardFee uint64   `json:"create_devshard_fee,string"`
+		FeePerNonce       uint64   `json:"fee_per_nonce,string"`
 	} `json:"escrow"`
 	Found bool `json:"found"`
 }
@@ -125,13 +131,19 @@ func (b *RESTBridge) GetEscrow(escrowID string) (*EscrowInfo, error) {
 	}
 
 	return &EscrowInfo{
-		EscrowID:       escrowID,
-		Amount:         resp.Escrow.Amount,
-		CreatorAddress: resp.Escrow.Creator,
-		AppHash:        appHash,
-		Slots:          resp.Escrow.Slots,
-		TokenPrice:     resp.Escrow.TokenPrice,
-		EpochID:        resp.Escrow.EpochIndex,
+		EscrowID:          escrowID,
+		Amount:            resp.Escrow.Amount,
+		CreatorAddress:    resp.Escrow.Creator,
+		AppHash:           appHash,
+		Slots:             resp.Escrow.Slots,
+		TokenPrice:        resp.Escrow.TokenPrice,
+		EpochID:           resp.Escrow.EpochIndex,
+		MaxNonce:          resp.Escrow.MaxNonce,
+		RefusalTimeout:    resp.Escrow.RefusalTimeout,
+		ExecutionTimeout:  resp.Escrow.ExecutionTimeout,
+		ValidationRate:    resp.Escrow.ValidationRate,
+		CreateDevshardFee: resp.Escrow.CreateDevshardFee,
+		FeePerNonce:       resp.Escrow.FeePerNonce,
 	}, nil
 }
 

--- a/devshard/bridge/rest_test.go
+++ b/devshard/bridge/rest_test.go
@@ -39,6 +39,72 @@ func TestGetEscrow_HappyPath(t *testing.T) {
 	assert.Equal(t, []string{"valA", "valB", "valC"}, info.Slots)
 }
 
+func TestGetEscrow_ParsesSessionConfigFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"escrow": map[string]any{
+				"id":                  "42",
+				"creator":             "inference1abc",
+				"amount":              "5000000000",
+				"slots":               []string{"valA"},
+				"epoch_index":         "10",
+				"app_hash":            "deadbeef",
+				"settled":             false,
+				"token_price":         "7",
+				"max_nonce":           50000,
+				"refusal_timeout":     "90",
+				"execution_timeout":   "1800",
+				"validation_rate":     2500,
+				"create_devshard_fee": "25000",
+				"fee_per_nonce":       "500",
+			},
+			"found": true,
+		})
+	}))
+	defer srv.Close()
+
+	b := NewRESTBridge(srv.URL)
+	info, err := b.GetEscrow("42")
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(7), info.TokenPrice)
+	assert.Equal(t, uint32(50000), info.MaxNonce)
+	assert.Equal(t, int64(90), info.RefusalTimeout)
+	assert.Equal(t, int64(1800), info.ExecutionTimeout)
+	assert.Equal(t, uint32(2500), info.ValidationRate)
+	assert.Equal(t, uint64(25000), info.CreateDevshardFee)
+	assert.Equal(t, uint64(500), info.FeePerNonce)
+}
+
+func TestGetEscrow_BackwardCompatMissingSessionConfigFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"escrow": map[string]any{
+				"id":          "42",
+				"creator":     "inference1abc",
+				"amount":      "5000000000",
+				"slots":       []string{"valA"},
+				"epoch_index": "10",
+				"app_hash":    "deadbeef",
+				"settled":     false,
+			},
+			"found": true,
+		})
+	}))
+	defer srv.Close()
+
+	b := NewRESTBridge(srv.URL)
+	info, err := b.GetEscrow("42")
+	require.NoError(t, err)
+
+	assert.Equal(t, uint32(0), info.MaxNonce, "missing field should decode to zero")
+	assert.Equal(t, int64(0), info.RefusalTimeout)
+	assert.Equal(t, int64(0), info.ExecutionTimeout)
+	assert.Equal(t, uint32(0), info.ValidationRate)
+	assert.Equal(t, uint64(0), info.CreateDevshardFee)
+	assert.Equal(t, uint64(0), info.FeePerNonce)
+}
+
 func TestGetEscrow_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -229,6 +229,9 @@ func (sm *StateMachine) ApplyLocalBestEffort(nonce uint64, txs []*types.Devshard
 	if nonce != expectedNonce {
 		return nil, nil, fmt.Errorf("%w: expected %d, got %d", types.ErrInvalidNonce, expectedNonce, nonce)
 	}
+	if maxNonce := uint64(sm.state.Config.MaxNonce); maxNonce > 0 && nonce > maxNonce {
+		return nil, nil, fmt.Errorf("%w: nonce %d exceeds max_nonce %d", types.ErrInvalidNonce, nonce, maxNonce)
+	}
 
 	// Same pre-check as applyCore: at most one MsgStartInference, with id == nonce.
 	startCount := 0
@@ -308,6 +311,13 @@ func (sm *StateMachine) applyCore(nonce uint64, txs []*types.DevshardTx, postSta
 	expectedNonce := sm.state.LatestNonce + 1
 	if nonce != expectedNonce {
 		return nil, fmt.Errorf("%w: expected %d, got %d", types.ErrInvalidNonce, expectedNonce, nonce)
+	}
+	// 1a. Cap nonce by DevshardEscrowParams.MaxNonce. Without this, a host can
+	// keep accepting diffs past the chain-side ceiling and then lose settlement
+	// when VerifyDevshardSettlement rejects the final nonce. Treat zero as
+	// "no cap configured" for forward-compat with pre-v0.2.13 sessions.
+	if maxNonce := uint64(sm.state.Config.MaxNonce); maxNonce > 0 && nonce > maxNonce {
+		return nil, fmt.Errorf("%w: nonce %d exceeds max_nonce %d", types.ErrInvalidNonce, nonce, maxNonce)
 	}
 
 	// 2. Validate at most one MsgStartInference per diff, and inference_id == nonce.

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -3128,3 +3128,62 @@ func TestApplyDiff_Validation_Invalid_CostUnderflowGuard(t *testing.T) {
 	require.Equal(t, types.StatusInvalidated, st.Inferences[1].Status)
 	require.Equal(t, uint64(0), st.HostStats[1].Cost)
 }
+
+// TestApplyDiff_MaxNonceCap verifies that the host rejects diffs whose nonce
+// exceeds Config.MaxNonce. Without this cap, the chain-side
+// VerifyDevshardSettlement (which checks msg.Nonce <= DevshardEscrowParams.MaxNonce)
+// can reject the final state, causing the host to lose the settlement reward.
+// See gonka-ai/gonka#1143 discussion r3205419993.
+func TestApplyDiff_MaxNonceCap(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(group))
+	config.MaxNonce = 1 // accept exactly one nonce
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := NewStateMachine("escrow-cap", config, group, 10000, user.Address(), verifier)
+	require.NoError(t, err)
+
+	// nonce=1 is at the cap — should succeed.
+	diff1 := testutil.SignDiff(t, user, "escrow-cap", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
+		InferenceId: 1,
+		PromptHash:  []byte("prompt"),
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	})})
+	_, err = sm.ApplyDiff(diff1)
+	require.NoError(t, err, "nonce==MaxNonce must be accepted")
+
+	// nonce=2 exceeds the cap — must be rejected with ErrInvalidNonce.
+	diff2 := testutil.SignDiff(t, user, "escrow-cap", 2, []*types.DevshardTx{})
+	_, err = sm.ApplyDiff(diff2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrInvalidNonce)
+}
+
+// TestApplyDiff_MaxNonceCap_ZeroDisabled verifies forward-compat: a session
+// created before the MaxNonce field existed (zero on the wire → zero in
+// SessionConfig) must NOT trip the cap. Otherwise pre-v0.2.13 escrows would
+// fail on their first diff.
+func TestApplyDiff_MaxNonceCap_ZeroDisabled(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(group)) // MaxNonce defaults to 0
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := NewStateMachine("escrow-nocap", config, group, 10000, user.Address(), verifier)
+	require.NoError(t, err)
+
+	diff := testutil.SignDiff(t, user, "escrow-nocap", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
+		InferenceId: 1,
+		PromptHash:  []byte("prompt"),
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	})})
+	_, err = sm.ApplyDiff(diff)
+	require.NoError(t, err, "MaxNonce==0 must be treated as no-cap")
+}

--- a/devshard/types/config.go
+++ b/devshard/types/config.go
@@ -1,5 +1,11 @@
 package types
 
+// DefaultDevshardMaxNonce mirrors the chain-side
+// DefaultDevshardMaxNonce constant used by DevshardEscrowParams. Keep these
+// two values in sync; the host falls back to this value whenever the escrow
+// reports zero so that pre-v0.2.13 escrows stay capped.
+const DefaultDevshardMaxNonce uint32 = 20_000
+
 // DefaultSessionConfig returns the canonical session config that both user and
 // host must use. A single source of truth prevents state root divergence caused
 // by config mismatches (e.g. different ValidationRate values).
@@ -12,15 +18,57 @@ func DefaultSessionConfig(groupSize int) SessionConfig {
 		FeePerNonce:       1_000,
 		VoteThreshold:     uint32(groupSize) / 2,
 		ValidationRate:    5000,
+		MaxNonce:          DefaultDevshardMaxNonce,
 	}
 }
 
-// SessionConfigWithPrice returns a session config with a custom token price.
-// tokenPrice == 0 is treated as 1 for backward compatibility.
-func SessionConfigWithPrice(groupSize int, tokenPrice uint64) SessionConfig {
+// EscrowSessionFields holds the per-escrow session-config values resolved from
+// DevshardEscrow at creation time. Each field, when zero, falls back to the
+// compiled DefaultSessionConfig value in SessionConfigFromEscrow — this keeps
+// chains created before a given governance field existed working unchanged.
+type EscrowSessionFields struct {
+	TokenPrice        uint64
+	RefusalTimeout    int64
+	ExecutionTimeout  int64
+	ValidationRate    uint32
+	CreateDevshardFee uint64
+	FeePerNonce       uint64
+	MaxNonce          uint32
+}
+
+// SessionConfigFromEscrow builds a SessionConfig from raw devshard-escrow
+// fields. Any field equal to zero falls back to the compiled default from
+// DefaultSessionConfig, preserving backward compatibility with escrows
+// created before these governance parameters existed.
+func SessionConfigFromEscrow(groupSize int, fields EscrowSessionFields) SessionConfig {
 	cfg := DefaultSessionConfig(groupSize)
-	if tokenPrice > 0 {
-		cfg.TokenPrice = tokenPrice
+	if fields.TokenPrice > 0 {
+		cfg.TokenPrice = fields.TokenPrice
+	}
+	if fields.RefusalTimeout > 0 {
+		cfg.RefusalTimeout = fields.RefusalTimeout
+	}
+	if fields.ExecutionTimeout > 0 {
+		cfg.ExecutionTimeout = fields.ExecutionTimeout
+	}
+	if fields.ValidationRate > 0 {
+		cfg.ValidationRate = fields.ValidationRate
+	}
+	if fields.CreateDevshardFee > 0 {
+		cfg.CreateDevshardFee = fields.CreateDevshardFee
+	}
+	if fields.FeePerNonce > 0 {
+		cfg.FeePerNonce = fields.FeePerNonce
+	}
+	if fields.MaxNonce > 0 {
+		cfg.MaxNonce = fields.MaxNonce
 	}
 	return cfg
+}
+
+// SessionConfigWithPrice returns a session config with a custom token price.
+// Deprecated: use SessionConfigFromEscrow. Retained for callers that have not
+// yet been updated to thread the additional governance fields.
+func SessionConfigWithPrice(groupSize int, tokenPrice uint64) SessionConfig {
+	return SessionConfigFromEscrow(groupSize, EscrowSessionFields{TokenPrice: tokenPrice})
 }

--- a/devshard/types/config_test.go
+++ b/devshard/types/config_test.go
@@ -1,0 +1,106 @@
+package types
+
+import "testing"
+
+func TestSessionConfigFromEscrow_AllZerosFallsBackToDefaults(t *testing.T) {
+	want := DefaultSessionConfig(16)
+	got := SessionConfigFromEscrow(16, EscrowSessionFields{})
+
+	if got != want {
+		t.Fatalf("expected zero escrow to equal DefaultSessionConfig, got %+v want %+v", got, want)
+	}
+}
+
+func TestSessionConfigFromEscrow_OverridesAllFields(t *testing.T) {
+	got := SessionConfigFromEscrow(16, EscrowSessionFields{
+		TokenPrice:        7,
+		RefusalTimeout:    90,
+		ExecutionTimeout:  1800,
+		ValidationRate:    2500,
+		CreateDevshardFee: 25_000,
+		FeePerNonce:       500,
+		MaxNonce:          50_000,
+	})
+
+	if got.TokenPrice != 7 {
+		t.Errorf("TokenPrice: got %d, want 7", got.TokenPrice)
+	}
+	if got.RefusalTimeout != 90 {
+		t.Errorf("RefusalTimeout: got %d, want 90", got.RefusalTimeout)
+	}
+	if got.ExecutionTimeout != 1800 {
+		t.Errorf("ExecutionTimeout: got %d, want 1800", got.ExecutionTimeout)
+	}
+	if got.ValidationRate != 2500 {
+		t.Errorf("ValidationRate: got %d, want 2500", got.ValidationRate)
+	}
+	if got.CreateDevshardFee != 25_000 {
+		t.Errorf("CreateDevshardFee: got %d, want 25000", got.CreateDevshardFee)
+	}
+	if got.FeePerNonce != 500 {
+		t.Errorf("FeePerNonce: got %d, want 500", got.FeePerNonce)
+	}
+	if got.MaxNonce != 50_000 {
+		t.Errorf("MaxNonce: got %d, want 50000", got.MaxNonce)
+	}
+}
+
+func TestSessionConfigFromEscrow_PartialOverride(t *testing.T) {
+	def := DefaultSessionConfig(16)
+	got := SessionConfigFromEscrow(16, EscrowSessionFields{
+		ExecutionTimeout:  1800,
+		CreateDevshardFee: 25_000,
+		MaxNonce:          50_000,
+	})
+
+	if got.TokenPrice != def.TokenPrice {
+		t.Errorf("TokenPrice should fall back to default %d, got %d", def.TokenPrice, got.TokenPrice)
+	}
+	if got.RefusalTimeout != def.RefusalTimeout {
+		t.Errorf("RefusalTimeout should fall back to default %d, got %d", def.RefusalTimeout, got.RefusalTimeout)
+	}
+	if got.ExecutionTimeout != 1800 {
+		t.Errorf("ExecutionTimeout: got %d, want 1800", got.ExecutionTimeout)
+	}
+	if got.ValidationRate != def.ValidationRate {
+		t.Errorf("ValidationRate should fall back to default %d, got %d", def.ValidationRate, got.ValidationRate)
+	}
+	if got.CreateDevshardFee != 25_000 {
+		t.Errorf("CreateDevshardFee: got %d, want 25000", got.CreateDevshardFee)
+	}
+	if got.FeePerNonce != def.FeePerNonce {
+		t.Errorf("FeePerNonce should fall back to default %d, got %d", def.FeePerNonce, got.FeePerNonce)
+	}
+	if got.MaxNonce != 50_000 {
+		t.Errorf("MaxNonce: got %d, want 50000", got.MaxNonce)
+	}
+}
+
+func TestSessionConfigFromEscrow_PreservesGroupSizeDerivedFields(t *testing.T) {
+	got := SessionConfigFromEscrow(20, EscrowSessionFields{})
+
+	if got.VoteThreshold != 10 {
+		t.Errorf("VoteThreshold: got %d, want 10 (groupSize=20 / 2)", got.VoteThreshold)
+	}
+}
+
+func TestSessionConfigFromEscrow_ZeroMaxNonceFallsBackToDefault(t *testing.T) {
+	// MaxNonce==0 must fall back to DefaultDevshardMaxNonce (not stay at 0).
+	// This is the backward-compat path for pre-v0.2.13 escrows: hosts must
+	// still enforce a cap so the chain-side VerifyDevshardSettlement doesn't
+	// reject the final nonce.
+	got := SessionConfigFromEscrow(16, EscrowSessionFields{TokenPrice: 1})
+
+	if got.MaxNonce != DefaultDevshardMaxNonce {
+		t.Errorf("MaxNonce: got %d, want %d (default)", got.MaxNonce, DefaultDevshardMaxNonce)
+	}
+}
+
+func TestSessionConfigWithPrice_DelegatesToFromEscrow(t *testing.T) {
+	withPrice := SessionConfigWithPrice(16, 42)
+	fromEscrow := SessionConfigFromEscrow(16, EscrowSessionFields{TokenPrice: 42})
+
+	if withPrice != fromEscrow {
+		t.Fatalf("SessionConfigWithPrice should be equivalent to SessionConfigFromEscrow with only TokenPrice set; got %+v vs %+v", withPrice, fromEscrow)
+	}
+}

--- a/devshard/types/domain.go
+++ b/devshard/types/domain.go
@@ -71,6 +71,7 @@ type SessionConfig struct {
 	FeePerNonce       uint64 // fee charged per applied nonce (diff)
 	VoteThreshold     uint32 // minimum accept votes for timeout (total_slots / 2)
 	ValidationRate    uint32 // basis points (10000 = 100%, 1000 = 10%)
+	MaxNonce          uint32 // upper bound for accepted nonces (mirror of DevshardEscrowParams.MaxNonce)
 }
 
 // EscrowState is the full state of a devshard session.

--- a/devshard/user/httpsession.go
+++ b/devshard/user/httpsession.go
@@ -47,7 +47,15 @@ func NewHTTPSession(cfg HTTPSessionConfig) (*Session, *state.StateMachine, error
 		return nil, nil, fmt.Errorf("get escrow: %w", err)
 	}
 
-	config := types.SessionConfigWithPrice(len(group), escrow.TokenPrice)
+	config := types.SessionConfigFromEscrow(len(group), types.EscrowSessionFields{
+		TokenPrice:        escrow.TokenPrice,
+		RefusalTimeout:    escrow.RefusalTimeout,
+		ExecutionTimeout:  escrow.ExecutionTimeout,
+		ValidationRate:    escrow.ValidationRate,
+		CreateDevshardFee: escrow.CreateDevshardFee,
+		FeePerNonce:       escrow.FeePerNonce,
+		MaxNonce:          escrow.MaxNonce,
+	})
 
 	sm, err := state.NewStateMachine(cfg.EscrowID, config, group, escrow.Amount, escrow.CreatorAddress, verifier,
 		state.WithWarmKeyResolver(cfg.Bridge.VerifyWarmKey),

--- a/inference-chain/proto/inference/inference/devshard_escrow.proto
+++ b/inference-chain/proto/inference/inference/devshard_escrow.proto
@@ -14,6 +14,14 @@ message DevshardEscrow {
   bool settled = 7;
   uint64 token_price = 8;
   string model_id = 9;
+  // Session-config parameters captured at escrow creation time from
+  // DevshardEscrowParams. Zero values fall back to compiled defaults.
+  uint32 max_nonce = 10;
+  int64 refusal_timeout = 11;
+  int64 execution_timeout = 12;
+  uint32 validation_rate = 13;
+  uint64 create_devshard_fee = 14;
+  uint64 fee_per_nonce = 15;
 }
 
 message DevshardHostEpochStats {

--- a/inference-chain/proto/inference/inference/params.proto
+++ b/inference-chain/proto/inference/inference/params.proto
@@ -381,6 +381,15 @@ message DevshardEscrowParams {
   uint64 token_price = 6;
   repeated DevshardApprovedVersion approved_versions = 7;
   uint32 max_nonce = 8;
+  // Tag 9 reserved for default_seal_grace_nonces — see PR #1162.
+  reserved 9;
+  // Session-config governance parameters (devshard SessionConfig).
+  // Zero values fall back to compiled defaults (see devshard/types/config.go).
+  int64 refusal_timeout = 10;
+  int64 execution_timeout = 11;
+  uint32 validation_rate = 12;
+  uint64 create_devshard_fee = 13;
+  uint64 fee_per_nonce = 14;
 }
 
 // FeeParams defines governance-controlled parameters for consensus-level

--- a/inference-chain/x/inference/keeper/msg_server_create_devshard_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_create_devshard_escrow.go
@@ -92,14 +92,20 @@ func (k msgServer) CreateDevshardEscrow(goCtx context.Context, msg *types.MsgCre
 	}
 
 	escrow := &types.DevshardEscrow{
-		Creator:    msg.Creator,
-		Amount:     msg.Amount,
-		Slots:      slots,
-		EpochIndex: epochIndex,
-		AppHash:    appHash,
-		Settled:    false,
-		TokenPrice: ep.TokenPrice,
-		ModelId:    msg.ModelId,
+		Creator:           msg.Creator,
+		Amount:            msg.Amount,
+		Slots:             slots,
+		EpochIndex:        epochIndex,
+		AppHash:           appHash,
+		Settled:           false,
+		TokenPrice:        ep.TokenPrice,
+		ModelId:           msg.ModelId,
+		MaxNonce:          ep.MaxNonce,
+		RefusalTimeout:    ep.RefusalTimeout,
+		ExecutionTimeout:  ep.ExecutionTimeout,
+		ValidationRate:    ep.ValidationRate,
+		CreateDevshardFee: ep.CreateDevshardFee,
+		FeePerNonce:       ep.FeePerNonce,
 	}
 
 	id, err := k.StoreDevshardEscrow(goCtx, escrow, nextID)

--- a/inference-chain/x/inference/types/devshard_escrow.pb.go
+++ b/inference-chain/x/inference/types/devshard_escrow.pb.go
@@ -23,15 +23,21 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type DevshardEscrow struct {
-	Id         uint64   `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Creator    string   `protobuf:"bytes,2,opt,name=creator,proto3" json:"creator,omitempty"`
-	Amount     uint64   `protobuf:"varint,3,opt,name=amount,proto3" json:"amount,omitempty"`
-	Slots      []string `protobuf:"bytes,4,rep,name=slots,proto3" json:"slots,omitempty"`
-	EpochIndex uint64   `protobuf:"varint,5,opt,name=epoch_index,json=epochIndex,proto3" json:"epoch_index,omitempty"`
-	AppHash    string   `protobuf:"bytes,6,opt,name=app_hash,json=appHash,proto3" json:"app_hash,omitempty"`
-	Settled    bool     `protobuf:"varint,7,opt,name=settled,proto3" json:"settled,omitempty"`
-	TokenPrice uint64   `protobuf:"varint,8,opt,name=token_price,json=tokenPrice,proto3" json:"token_price,omitempty"`
-	ModelId    string   `protobuf:"bytes,9,opt,name=model_id,json=modelId,proto3" json:"model_id,omitempty"`
+	Id                uint64   `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Creator           string   `protobuf:"bytes,2,opt,name=creator,proto3" json:"creator,omitempty"`
+	Amount            uint64   `protobuf:"varint,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	Slots             []string `protobuf:"bytes,4,rep,name=slots,proto3" json:"slots,omitempty"`
+	EpochIndex        uint64   `protobuf:"varint,5,opt,name=epoch_index,json=epochIndex,proto3" json:"epoch_index,omitempty"`
+	AppHash           string   `protobuf:"bytes,6,opt,name=app_hash,json=appHash,proto3" json:"app_hash,omitempty"`
+	Settled           bool     `protobuf:"varint,7,opt,name=settled,proto3" json:"settled,omitempty"`
+	TokenPrice        uint64   `protobuf:"varint,8,opt,name=token_price,json=tokenPrice,proto3" json:"token_price,omitempty"`
+	ModelId           string   `protobuf:"bytes,9,opt,name=model_id,json=modelId,proto3" json:"model_id,omitempty"`
+	MaxNonce          uint32   `protobuf:"varint,10,opt,name=max_nonce,json=maxNonce,proto3" json:"max_nonce,omitempty"`
+	RefusalTimeout    int64    `protobuf:"varint,11,opt,name=refusal_timeout,json=refusalTimeout,proto3" json:"refusal_timeout,omitempty"`
+	ExecutionTimeout  int64    `protobuf:"varint,12,opt,name=execution_timeout,json=executionTimeout,proto3" json:"execution_timeout,omitempty"`
+	ValidationRate    uint32   `protobuf:"varint,13,opt,name=validation_rate,json=validationRate,proto3" json:"validation_rate,omitempty"`
+	CreateDevshardFee uint64   `protobuf:"varint,14,opt,name=create_devshard_fee,json=createDevshardFee,proto3" json:"create_devshard_fee,omitempty"`
+	FeePerNonce       uint64   `protobuf:"varint,15,opt,name=fee_per_nonce,json=feePerNonce,proto3" json:"fee_per_nonce,omitempty"`
 }
 
 func (m *DevshardEscrow) Reset()         { *m = DevshardEscrow{} }
@@ -128,6 +134,48 @@ func (m *DevshardEscrow) GetModelId() string {
 		return m.ModelId
 	}
 	return ""
+}
+
+func (m *DevshardEscrow) GetMaxNonce() uint32 {
+	if m != nil {
+		return m.MaxNonce
+	}
+	return 0
+}
+
+func (m *DevshardEscrow) GetRefusalTimeout() int64 {
+	if m != nil {
+		return m.RefusalTimeout
+	}
+	return 0
+}
+
+func (m *DevshardEscrow) GetExecutionTimeout() int64 {
+	if m != nil {
+		return m.ExecutionTimeout
+	}
+	return 0
+}
+
+func (m *DevshardEscrow) GetValidationRate() uint32 {
+	if m != nil {
+		return m.ValidationRate
+	}
+	return 0
+}
+
+func (m *DevshardEscrow) GetCreateDevshardFee() uint64 {
+	if m != nil {
+		return m.CreateDevshardFee
+	}
+	return 0
+}
+
+func (m *DevshardEscrow) GetFeePerNonce() uint64 {
+	if m != nil {
+		return m.FeePerNonce
+	}
+	return 0
 }
 
 type DevshardHostEpochStats struct {
@@ -434,6 +482,36 @@ func (m *DevshardEscrow) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.FeePerNonce != 0 {
+		i = encodeVarintDevshardEscrow(dAtA, i, uint64(m.FeePerNonce))
+		i--
+		dAtA[i] = 0x78
+	}
+	if m.CreateDevshardFee != 0 {
+		i = encodeVarintDevshardEscrow(dAtA, i, uint64(m.CreateDevshardFee))
+		i--
+		dAtA[i] = 0x70
+	}
+	if m.ValidationRate != 0 {
+		i = encodeVarintDevshardEscrow(dAtA, i, uint64(m.ValidationRate))
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.ExecutionTimeout != 0 {
+		i = encodeVarintDevshardEscrow(dAtA, i, uint64(m.ExecutionTimeout))
+		i--
+		dAtA[i] = 0x60
+	}
+	if m.RefusalTimeout != 0 {
+		i = encodeVarintDevshardEscrow(dAtA, i, uint64(m.RefusalTimeout))
+		i--
+		dAtA[i] = 0x58
+	}
+	if m.MaxNonce != 0 {
+		i = encodeVarintDevshardEscrow(dAtA, i, uint64(m.MaxNonce))
+		i--
+		dAtA[i] = 0x50
+	}
 	if len(m.ModelId) > 0 {
 		i -= len(m.ModelId)
 		copy(dAtA[i:], m.ModelId)
@@ -699,6 +777,24 @@ func (m *DevshardEscrow) Size() (n int) {
 	l = len(m.ModelId)
 	if l > 0 {
 		n += 1 + l + sovDevshardEscrow(uint64(l))
+	}
+	if m.MaxNonce != 0 {
+		n += 1 + sovDevshardEscrow(uint64(m.MaxNonce))
+	}
+	if m.RefusalTimeout != 0 {
+		n += 1 + sovDevshardEscrow(uint64(m.RefusalTimeout))
+	}
+	if m.ExecutionTimeout != 0 {
+		n += 1 + sovDevshardEscrow(uint64(m.ExecutionTimeout))
+	}
+	if m.ValidationRate != 0 {
+		n += 1 + sovDevshardEscrow(uint64(m.ValidationRate))
+	}
+	if m.CreateDevshardFee != 0 {
+		n += 1 + sovDevshardEscrow(uint64(m.CreateDevshardFee))
+	}
+	if m.FeePerNonce != 0 {
+		n += 1 + sovDevshardEscrow(uint64(m.FeePerNonce))
 	}
 	return n
 }
@@ -1039,6 +1135,120 @@ func (m *DevshardEscrow) Unmarshal(dAtA []byte) error {
 			}
 			m.ModelId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxNonce", wireType)
+			}
+			m.MaxNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDevshardEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MaxNonce |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RefusalTimeout", wireType)
+			}
+			m.RefusalTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDevshardEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.RefusalTimeout |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExecutionTimeout", wireType)
+			}
+			m.ExecutionTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDevshardEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ExecutionTimeout |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValidationRate", wireType)
+			}
+			m.ValidationRate = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDevshardEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ValidationRate |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 14:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CreateDevshardFee", wireType)
+			}
+			m.CreateDevshardFee = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDevshardEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CreateDevshardFee |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 15:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FeePerNonce", wireType)
+			}
+			m.FeePerNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDevshardEscrow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.FeePerNonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDevshardEscrow(dAtA[iNdEx:])

--- a/inference-chain/x/inference/types/devshard_escrow_session_config_test.go
+++ b/inference-chain/x/inference/types/devshard_escrow_session_config_test.go
@@ -1,0 +1,132 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDevshardEscrowParams_RoundtripsSessionConfigFields verifies that the
+// new governance-configurable session-config fields survive a marshal /
+// unmarshal cycle in their protobuf wire representation.
+func TestDevshardEscrowParams_RoundtripsSessionConfigFields(t *testing.T) {
+	p := &DevshardEscrowParams{
+		MinAmount:          1_000_000,
+		MaxAmount:          10_000_000,
+		MaxEscrowsPerEpoch: 50,
+		GroupSize:          16,
+		TokenPrice:         3,
+		MaxNonce:           50_000,
+		RefusalTimeout:     90,
+		ExecutionTimeout:   1800,
+		ValidationRate:     2500,
+		CreateDevshardFee:  25_000,
+		FeePerNonce:        500,
+	}
+
+	buf, err := p.Marshal()
+	require.NoError(t, err)
+
+	var got DevshardEscrowParams
+	require.NoError(t, got.Unmarshal(buf))
+
+	assert.Equal(t, int64(90), got.RefusalTimeout)
+	assert.Equal(t, int64(1800), got.ExecutionTimeout)
+	assert.Equal(t, uint32(2500), got.ValidationRate)
+	assert.Equal(t, uint64(3), got.TokenPrice)
+	assert.Equal(t, uint64(25_000), got.CreateDevshardFee)
+	assert.Equal(t, uint64(500), got.FeePerNonce)
+	assert.Equal(t, uint32(50_000), got.MaxNonce)
+}
+
+// TestDevshardEscrowParams_ZeroSessionConfigFieldsOmitted verifies proto3
+// zero-omission: a message with all session-config fields zero produces the
+// same bytes as a message that doesn't have those fields set at all (backward
+// compatibility with chains that wrote DevshardEscrowParams before these
+// fields existed).
+func TestDevshardEscrowParams_ZeroSessionConfigFieldsOmitted(t *testing.T) {
+	withZeros := &DevshardEscrowParams{
+		MinAmount: 1, MaxAmount: 2, MaxEscrowsPerEpoch: 1, GroupSize: 1, TokenPrice: 1, MaxNonce: 1,
+	}
+	bytesA, err := withZeros.Marshal()
+	require.NoError(t, err)
+
+	pre := &DevshardEscrowParams{
+		MinAmount: 1, MaxAmount: 2, MaxEscrowsPerEpoch: 1, GroupSize: 1, TokenPrice: 1, MaxNonce: 1,
+	}
+	bytesB, err := pre.Marshal()
+	require.NoError(t, err)
+
+	assert.Equal(t, bytesB, bytesA, "zero session-config fields must not appear on the wire")
+}
+
+// TestDevshardEscrow_RoundtripsSessionConfigFields verifies the same wire-level
+// invariant for the per-escrow captured copy of the session-config fields.
+func TestDevshardEscrow_RoundtripsSessionConfigFields(t *testing.T) {
+	e := &DevshardEscrow{
+		Creator:           "inference1abc",
+		Amount:            5_000_000_000,
+		Slots:             []string{"valA"},
+		EpochIndex:        10,
+		AppHash:           "deadbeef",
+		Settled:           false,
+		TokenPrice:        7,
+		ModelId:           "Qwen3-235B-A22B-Instruct-2507-FP8",
+		MaxNonce:          50_000,
+		RefusalTimeout:    90,
+		ExecutionTimeout:  1800,
+		ValidationRate:    2500,
+		CreateDevshardFee: 25_000,
+		FeePerNonce:       500,
+	}
+
+	buf, err := e.Marshal()
+	require.NoError(t, err)
+
+	var got DevshardEscrow
+	require.NoError(t, got.Unmarshal(buf))
+
+	assert.Equal(t, uint32(50_000), got.MaxNonce)
+	assert.Equal(t, int64(90), got.RefusalTimeout)
+	assert.Equal(t, int64(1800), got.ExecutionTimeout)
+	assert.Equal(t, uint32(2500), got.ValidationRate)
+	assert.Equal(t, uint64(7), got.TokenPrice)
+	assert.Equal(t, "Qwen3-235B-A22B-Instruct-2507-FP8", got.ModelId)
+	assert.Equal(t, uint64(25_000), got.CreateDevshardFee)
+	assert.Equal(t, uint64(500), got.FeePerNonce)
+}
+
+// TestDefaultDevshardEscrowParams_PopulatesSessionConfigDefaults verifies that
+// the helper returns the canonical compiled defaults for the new fields. These
+// defaults must equal the values that devshard/types/DefaultSessionConfig
+// uses, preserving the "single source of truth" invariant for new chains.
+func TestDefaultDevshardEscrowParams_PopulatesSessionConfigDefaults(t *testing.T) {
+	p := DefaultDevshardEscrowParams()
+
+	assert.Equal(t, DefaultDevshardRefusalTimeout, p.RefusalTimeout)
+	assert.Equal(t, DefaultDevshardExecutionTimeout, p.ExecutionTimeout)
+	assert.Equal(t, DefaultDevshardValidationRate, p.ValidationRate)
+	assert.Equal(t, DefaultDevshardCreateDevshardFee, p.CreateDevshardFee)
+	assert.Equal(t, DefaultDevshardFeePerNonce, p.FeePerNonce)
+}
+
+// TestDevshardEscrowParams_Validate_RejectsNegativeAndOutOfRange ensures the
+// Validate hook used by msg-server params updates rejects invalid governance
+// settings that would otherwise corrupt SessionConfig.
+func TestDevshardEscrowParams_Validate_RejectsNegativeAndOutOfRange(t *testing.T) {
+	base := DefaultDevshardEscrowParams()
+	require.NoError(t, base.Validate())
+
+	negRefusal := *base
+	negRefusal.RefusalTimeout = -1
+	assert.Error(t, negRefusal.Validate(), "negative refusal_timeout must be rejected")
+
+	negExec := *base
+	negExec.ExecutionTimeout = -1
+	assert.Error(t, negExec.Validate(), "negative execution_timeout must be rejected")
+
+	tooHighRate := *base
+	tooHighRate.ValidationRate = 10001
+	assert.Error(t, tooHighRate.Validate(), "validation_rate > 10000 (basis points) must be rejected")
+}

--- a/inference-chain/x/inference/types/params.go
+++ b/inference-chain/x/inference/types/params.go
@@ -100,6 +100,14 @@ const (
 	DefaultDevshardGroupSize          uint32 = 16
 	DefaultDevshardTokenPrice         uint64 = 1
 	DefaultDevshardMaxNonce           uint32 = 20_000
+	// Session-config defaults must mirror devshard/types/config.go
+	// (DefaultSessionConfig) so that zero-value params fall back to the same
+	// canonical values shared by user and host.
+	DefaultDevshardRefusalTimeout    int64  = 60
+	DefaultDevshardExecutionTimeout  int64  = 1200
+	DefaultDevshardValidationRate    uint32 = 5000
+	DefaultDevshardCreateDevshardFee uint64 = 10_000
+	DefaultDevshardFeePerNonce       uint64 = 1_000
 )
 
 func DefaultGenesisOnlyParams() GenesisOnlyParams {
@@ -328,6 +336,11 @@ func DefaultDevshardEscrowParams() *DevshardEscrowParams {
 		AllowedCreatorAddresses: nil,
 		TokenPrice:              DefaultDevshardTokenPrice,
 		MaxNonce:                DefaultDevshardMaxNonce,
+		RefusalTimeout:          DefaultDevshardRefusalTimeout,
+		ExecutionTimeout:        DefaultDevshardExecutionTimeout,
+		ValidationRate:          DefaultDevshardValidationRate,
+		CreateDevshardFee:       DefaultDevshardCreateDevshardFee,
+		FeePerNonce:             DefaultDevshardFeePerNonce,
 	}
 }
 
@@ -343,6 +356,15 @@ func (p *DevshardEscrowParams) Validate() error {
 	}
 	if p.MaxNonce == 0 {
 		return fmt.Errorf("devshard escrow max_nonce must be positive")
+	}
+	if p.RefusalTimeout < 0 {
+		return fmt.Errorf("devshard escrow refusal_timeout (%d) must be non-negative", p.RefusalTimeout)
+	}
+	if p.ExecutionTimeout < 0 {
+		return fmt.Errorf("devshard escrow execution_timeout (%d) must be non-negative", p.ExecutionTimeout)
+	}
+	if p.ValidationRate > 10000 {
+		return fmt.Errorf("devshard escrow validation_rate (%d) must be <= 10000 (basis points)", p.ValidationRate)
 	}
 	seen := make(map[string]struct{}, len(p.ApprovedVersions))
 	for i, v := range p.ApprovedVersions {

--- a/inference-chain/x/inference/types/params.pb.go
+++ b/inference-chain/x/inference/types/params.pb.go
@@ -2174,6 +2174,11 @@ type DevshardEscrowParams struct {
 	TokenPrice              uint64                     `protobuf:"varint,6,opt,name=token_price,json=tokenPrice,proto3" json:"token_price,omitempty"`
 	ApprovedVersions        []*DevshardApprovedVersion `protobuf:"bytes,7,rep,name=approved_versions,json=approvedVersions,proto3" json:"approved_versions,omitempty"`
 	MaxNonce                uint32                     `protobuf:"varint,8,opt,name=max_nonce,json=maxNonce,proto3" json:"max_nonce,omitempty"`
+	RefusalTimeout          int64                      `protobuf:"varint,10,opt,name=refusal_timeout,json=refusalTimeout,proto3" json:"refusal_timeout,omitempty"`
+	ExecutionTimeout        int64                      `protobuf:"varint,11,opt,name=execution_timeout,json=executionTimeout,proto3" json:"execution_timeout,omitempty"`
+	ValidationRate          uint32                     `protobuf:"varint,12,opt,name=validation_rate,json=validationRate,proto3" json:"validation_rate,omitempty"`
+	CreateDevshardFee       uint64                     `protobuf:"varint,13,opt,name=create_devshard_fee,json=createDevshardFee,proto3" json:"create_devshard_fee,omitempty"`
+	FeePerNonce             uint64                     `protobuf:"varint,14,opt,name=fee_per_nonce,json=feePerNonce,proto3" json:"fee_per_nonce,omitempty"`
 }
 
 func (m *DevshardEscrowParams) Reset()         { *m = DevshardEscrowParams{} }
@@ -2261,6 +2266,41 @@ func (m *DevshardEscrowParams) GetApprovedVersions() []*DevshardApprovedVersion 
 func (m *DevshardEscrowParams) GetMaxNonce() uint32 {
 	if m != nil {
 		return m.MaxNonce
+	}
+	return 0
+}
+
+func (m *DevshardEscrowParams) GetRefusalTimeout() int64 {
+	if m != nil {
+		return m.RefusalTimeout
+	}
+	return 0
+}
+
+func (m *DevshardEscrowParams) GetExecutionTimeout() int64 {
+	if m != nil {
+		return m.ExecutionTimeout
+	}
+	return 0
+}
+
+func (m *DevshardEscrowParams) GetValidationRate() uint32 {
+	if m != nil {
+		return m.ValidationRate
+	}
+	return 0
+}
+
+func (m *DevshardEscrowParams) GetCreateDevshardFee() uint64 {
+	if m != nil {
+		return m.CreateDevshardFee
+	}
+	return 0
+}
+
+func (m *DevshardEscrowParams) GetFeePerNonce() uint64 {
+	if m != nil {
+		return m.FeePerNonce
 	}
 	return 0
 }
@@ -3574,6 +3614,21 @@ func (this *DevshardEscrowParams) Equal(that interface{}) bool {
 		}
 	}
 	if this.MaxNonce != that1.MaxNonce {
+		return false
+	}
+	if this.RefusalTimeout != that1.RefusalTimeout {
+		return false
+	}
+	if this.ExecutionTimeout != that1.ExecutionTimeout {
+		return false
+	}
+	if this.ValidationRate != that1.ValidationRate {
+		return false
+	}
+	if this.CreateDevshardFee != that1.CreateDevshardFee {
+		return false
+	}
+	if this.FeePerNonce != that1.FeePerNonce {
 		return false
 	}
 	return true
@@ -5539,6 +5594,31 @@ func (m *DevshardEscrowParams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.FeePerNonce != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.FeePerNonce))
+		i--
+		dAtA[i] = 0x70
+	}
+	if m.CreateDevshardFee != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CreateDevshardFee))
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.ValidationRate != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.ValidationRate))
+		i--
+		dAtA[i] = 0x60
+	}
+	if m.ExecutionTimeout != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.ExecutionTimeout))
+		i--
+		dAtA[i] = 0x58
+	}
+	if m.RefusalTimeout != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.RefusalTimeout))
+		i--
+		dAtA[i] = 0x50
+	}
 	if m.MaxNonce != 0 {
 		i = encodeVarintParams(dAtA, i, uint64(m.MaxNonce))
 		i--
@@ -6454,6 +6534,21 @@ func (m *DevshardEscrowParams) Size() (n int) {
 	}
 	if m.MaxNonce != 0 {
 		n += 1 + sovParams(uint64(m.MaxNonce))
+	}
+	if m.RefusalTimeout != 0 {
+		n += 1 + sovParams(uint64(m.RefusalTimeout))
+	}
+	if m.ExecutionTimeout != 0 {
+		n += 1 + sovParams(uint64(m.ExecutionTimeout))
+	}
+	if m.ValidationRate != 0 {
+		n += 1 + sovParams(uint64(m.ValidationRate))
+	}
+	if m.CreateDevshardFee != 0 {
+		n += 1 + sovParams(uint64(m.CreateDevshardFee))
+	}
+	if m.FeePerNonce != 0 {
+		n += 1 + sovParams(uint64(m.FeePerNonce))
 	}
 	return n
 }
@@ -12234,6 +12329,101 @@ func (m *DevshardEscrowParams) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.MaxNonce |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RefusalTimeout", wireType)
+			}
+			m.RefusalTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.RefusalTimeout |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExecutionTimeout", wireType)
+			}
+			m.ExecutionTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ExecutionTimeout |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValidationRate", wireType)
+			}
+			m.ValidationRate = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ValidationRate |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CreateDevshardFee", wireType)
+			}
+			m.CreateDevshardFee = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CreateDevshardFee |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 14:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FeePerNonce", wireType)
+			}
+			m.FeePerNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.FeePerNonce |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}


### PR DESCRIPTION
## Summary

Rebase + scope completion of #1094 against the v0.2.12 `subnet/` → `devshard/` rename. Closes the hardcoded-values part of #1028 by routing **all** session-config governance fields through `DevshardEscrowParams`.

Five new governance fields, captured per-escrow at creation time:

| Field | Default | Used in |
|---|---|---|
| `refusal_timeout` | 60 | `devshard/host` — wait before reason=refused timeout |
| `execution_timeout` | 1200 | `devshard/host` — wait before reason=execution timeout |
| `validation_rate` | 5000 (bps) | validation sampling |
| `create_devshard_fee` | 10_000 | `devshard/state` — one-time fee at session create |
| `fee_per_nonce` | 1_000 | `devshard/state` — per-nonce fee at diff apply |

Flow mirrors the existing `TokenPrice` plumbing from v0.2.12: `DevshardEscrowParams` → `DevshardEscrow` (captured at `MsgCreateDevshardEscrow`) → REST bridge → `devshard.types.SessionConfigFromEscrow`.

## Motivation

Per #1028 (CTO request, 2026-04-07):

> Currently devshard `SessionConfig` has a lot of hardcoded values. They should be settable on new escrow start from mainnet, and should be configurable by governance.

The issue also calls out the SST anti-pattern in #1005 (`MaxInferencesPerSubnet` duplicated in config + keeper). This PR addresses that by establishing the canonical **params → escrow → bridge → SessionConfig** path as the single source of truth for every session-config governance value.

## Backward compatibility — no upgrade handler / migration required

Zero values fall back to the compiled `DefaultSessionConfig` constants (same pattern `SessionConfigWithPrice` already used for `tokenPrice == 0` in v0.2.12). Existing chains and existing escrows keep behaving exactly as before until governance opts in.

## API changes

`SessionConfigFromEscrow` was introduced with a struct-based parameter (`EscrowSessionFields`) so future additions don't churn call-site signatures. `SessionConfigWithPrice` is retained as a deprecated wrapper.

## What's NOT included (intentional)

- **`VoteThreshold`** remains derived from `groupSize`. A configurable threshold below `groupSize/2` would weaken the liveness/security guarantees of the slot-majority check.
- **`penaltyValidationRate`** in `devshard/state/machine.go:19` is a separate penalty-policy parameter (rate for unrevealed seeds), not part of SessionConfig — happy to do this in a follow-up if you'd like the same treatment.

## Test plan

- [x] Protobuf round-trip for `DevshardEscrowParams` and `DevshardEscrow` with all 5 new fields
- [x] Zero-fallback to defaults; partial override; group-size-derived field preservation
- [x] REST bridge parsing for new fields + backward-compat test where they're missing from JSON
- [x] `DefaultDevshardEscrowParams()` populates all 5 new defaults
- [x] `DevshardEscrowParams.Validate()` rejects negative timeouts and `validation_rate > 10000`
- [x] All existing tests pass: `x/inference/{types,keeper}`, `app/upgrades/v0_2_12`, full `devshard/...` (14 packages), `decentralized-api/internal/devshard/...`, `cmd/inferenced/...`

cc: @gmorgachev @akup — this is a refresh of #1094 against the new devshard layout, expanded to cover the full hardcoded SessionConfig surface.