### PR TITLE
fix(devshard): strip min_tokens when stop_token_ids present (vLLM crash mitigation)

### DIFF
--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -290,6 +290,9 @@ func stripUnsupportedChatRequestParameters(request map[string]any) {
 	delete(request, "presence_penalty")
 	delete(request, "frequency_penalty")
 	delete(request, "structured_outputs")
+	if _, hasStopIDs := request["stop_token_ids"]; hasStopIDs {
+		delete(request, "min_tokens")
+	}
 	if tools, ok := request["tools"].([]any); ok && len(tools) == 0 {
 		delete(request, "tools")
 		delete(request, "tool_choice")

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -189,6 +189,32 @@ func TestNormalizeChatRequestKeepsMinTokensWithinEffectiveMax(t *testing.T) {
 	require.EqualValues(t, 128, raw["min_tokens"])
 }
 
+func TestNormalizeChatRequestStripsMinTokensWhenStopTokenIdsPresent(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hi"}],
+		"stop_token_ids": [163586, 9999999],
+		"min_tokens": 1
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	_, exists := raw["min_tokens"]
+	require.False(t, exists)
+}
+
+func TestNormalizeChatRequestKeepsMinTokensWithoutStopTokenIds(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hi"}],
+		"min_tokens": 5
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 5, raw["min_tokens"])
+}
+
 func TestNormalizeChatRequestStripsEmptyTools(t *testing.T) {
 	body, _, err := normalizeChatRequest([]byte(`{
 		"tool_choice": "auto",


### PR DESCRIPTION
## Problem

vLLM v1 (confirmed on **0.15.1** and **0.20.0**, **model-agnostic**) CUDA-asserts and brings down the engine when a chat completion request combines:

- `stop_token_ids` containing any value `>= vocab_size` (or negative), **AND**
- `min_tokens >= 1`

Root cause is in vLLM's sampler — `apply_top_k_only` performs a `gather` against a per-vocab index tensor that receives an out-of-bounds value derived from the OOB stop-token. The assert is asynchronous and surfaces in different traces depending on the model architecture:

- Kimi-K2.6 (MoE): `fused_moe/runner/shared_experts.py:133` on stream sync
- Qwen3-235B (dense FP8): `v1/sample/ops/topk_topp_sampler.py:304` directly

Either way: workers die, NCCL ProcessGroup watchdog terminates, EngineCore fails with `EngineDeadError`, client receives HTTP 500, engine stays STOPPED until orchestrator restarts (~5 min).

Observed in production fleet on **2026-05-14 17:41-18:05 UTC**: 16 crashes across 12 of 14 mlnodes from a single repeated payload signature. Engine restarts fleet-wide on the new image: 264.

## Reproduction (verified read-only, both Kimi + Qwen3 nodes)

```http
POST /v1/chat/completions
{
  "model": "moonshotai/Kimi-K2.6",
  "messages": [{"role":"user","content":"ping"}],
  "temperature": 1.0, "max_tokens": 4, "min_tokens": 1,
  "stop_token_ids": [163586, 9999999],
  "logprobs": true, "top_logprobs": 5,
  "skip_special_tokens": false
}
```

Without this patch: engine dies in ~3s, HTTP 500 (`EngineDeadError`), ~5min recovery.

With this patch: `min_tokens` stripped at the gateway, request returns 200 OK in <1s.

## Approach

Strip `min_tokens` whenever `stop_token_ids` is present in the request body. This removes the crash combination at the gateway, requires no per-model vocab knowledge, and protects every model on every vLLM v1 version.

`stop_token_ids` is preserved as-is for legitimate stop-token use; `min_tokens` is preserved for requests that do not set `stop_token_ids`.

### Considered and rejected

- **Per-model vocab-size registry + strip OOB ids** — requires hardcoded vocab per model (Kimi=163840, Qwen3=151936, MiniMax-M2.7=200064). Breaks silently when a new model is added without updating the map; vocab can drift between model revisions.
- **Reject with 400** — silent strip keeps existing client integrations working; this is purely a mitigation against a vLLM bug, not a contract change.

### Removal

Remove once vLLM upstream validates `stop_token_ids` against vocab in `SamplingParams.__post_init__`. Upstream issue to be filed separately.

## Test plan

- [x] Unit test added: `TestNormalizeChatRequestStripsMinTokensWhenStopTokenIdsPresent` — payload with both fields, expects `min_tokens` removed.
- [x] Unit test added: `TestNormalizeChatRequestKeepsMinTokensWithoutStopTokenIds` — payload with only `min_tokens`, expects it preserved.
- [x] Existing `TestNormalizeChatRequestClampsMinTokensAboveEffectiveMax` / `TestNormalizeChatRequestKeepsMinTokensWithinEffectiveMax` remain green (those payloads have no `stop_token_ids`).
- [x] Manually reproduced the crash on Kimi-K2.6 / vLLM 0.20.0 and Qwen3 / vLLM 0.15.1.
- [x] Manually verified that filtered payload returns 200 OK on both models.
- [x] Replayed all 14 distinct crashing payloads from earlier fuzz through the filter — 14/14 returned 200 OK with engine remaining healthy.