### PR TITLE
fix(devshard): strip prompt_logprobs to mitigate vLLM OOM crash

### DIFF
--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -290,6 +290,7 @@ func stripUnsupportedChatRequestParameters(request map[string]any) {
 	delete(request, "presence_penalty")
 	delete(request, "frequency_penalty")
 	delete(request, "structured_outputs")
+	delete(request, "prompt_logprobs")
 	if tools, ok := request["tools"].([]any); ok && len(tools) == 0 {
 		delete(request, "tools")
 		delete(request, "tool_choice")

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -189,6 +189,19 @@ func TestNormalizeChatRequestKeepsMinTokensWithinEffectiveMax(t *testing.T) {
 	require.EqualValues(t, 128, raw["min_tokens"])
 }
 
+func TestNormalizeChatRequestStripsPromptLogprobs(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hi"}],
+		"prompt_logprobs": 20
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	_, exists := raw["prompt_logprobs"]
+	require.False(t, exists)
+}
+
 func TestNormalizeChatRequestStripsEmptyTools(t *testing.T) {
 	body, _, err := normalizeChatRequest([]byte(`{
 		"tool_choice": "auto",


### PR DESCRIPTION
## Problem

vLLM v1 (confirmed on **0.20.0**, on Kimi-K2.6 with TP=4 on both **4×B300** and **4×B200**) **OOMs and brings down the engine** when a chat completion request includes the `prompt_logprobs` parameter on a sufficiently long prompt (~6000 tokens or more for Kimi-K2.6).

Traceback (always identical):
```
gpu_model_runner.py:3471, in _bookkeeping_sync
    prompt_logprobs_dict = self._get_prompt_logprobs_dict(
gpu_model_runner.py:5121, in _get_prompt_logprobs_dict
    logits = self.model.compute_logits(prompt_hidden_states)
...
logits_processor.py:83, in _gather_logits
    logits = tensor_model_parallel_all_gather(logits)
...
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 3.82 GiB.
GPU has total 178.35 GiB, 3.22 GiB free, 175.11 GiB in use.
```

The TP `all_gather` over per-token vocab-sized logits (`prompt_length × vocab_size`) exhausts GPU memory on Kimi (vocab 163,840) at typical production memory utilization (`--gpu-memory-utilization 0.95`).

Worker dies → `EngineDeadError` → HTTP 500 → engine STOPPED for ~6–12 min (`api.app` itself crashes too on the larger setup).

Observed in production: 8 distinct fatal engine crashes over 24h on one mlnode, all from the same path — roughly one every 3 hours, ~40 min of downtime per day per node from this single bug.

## Reproduction (verified read-only)

```http
POST /v1/chat/completions
{
  "model": "moonshotai/Kimi-K2.6",
  "messages": [{"role":"user","content":"ping ping ping ... (×6000)"}],
  "max_tokens": 4,
  "prompt_logprobs": 20
}
```

- 3000-token prompt: succeeds (no OOM)
- 6000-token prompt: **HTTP 500, EngineDeadError**, engine down
- Same crash with `prompt_logprobs: 1` (value of the parameter does not matter — any non-null triggers the path)
- Same crash on both 4×B300 (mlnode-201) and 4×B200 (mlnode-031), TP=4 in both cases
- Qwen3-235B on PP=4 (4×RTX PRO 6000) is **not** vulnerable at the same sizes — PP doesn't all_gather over vocab dim

## Approach

Strip `prompt_logprobs` from incoming requests in `stripUnsupportedChatRequestParameters`, alongside the existing strips of `presence_penalty`, `frequency_penalty`, and `structured_outputs`.

**Why strip and not 400-reject:** matches the existing pattern for vLLM-only extensions that are not part of the OpenAI Chat Completions API. Strict 400 is reserved for security-sensitive fields (`enforced_tokens`, `guided_regex`, `guided_grammar`, `json_object`).

## OpenAI API compatibility

`prompt_logprobs` is a **vLLM extension** — it is **not part of the OpenAI Chat Completions API**. The OpenAI API only exposes logprobs for generated tokens (`logprobs`, `top_logprobs`), never for input tokens. Stripping this field at the gateway therefore **improves** strict OpenAI compatibility: the response will contain `prompt_logprobs: null` (which is what OpenAI SDK clients expect by default), and strict pydantic-based clients with `extra='forbid'` will no longer choke on a non-OpenAI field.

## Validation flow not affected

Gonka inference validation compares logprobs of **generated** tokens via the `enforced_tokens` mechanism, which uses `response.choices[].logprobs.content[]`. It never reads `response.prompt_logprobs[]`. Confirmed by `git grep` across `decentralized-api/` and `devshard/`: no Go code sets `prompt_logprobs` in any request body, and the response type (`Choice.Logprobs.Content`) doesn't include a `PromptLogprobs` field at all.

## Removal

Remove once vLLM upstream fixes `_get_prompt_logprobs_dict` to chunk the per-token logits computation so it fits in available GPU memory. Upstream issue to be filed separately.

## Test plan

- [x] Unit test added: `TestNormalizeChatRequestStripsPromptLogprobs` — payload with `prompt_logprobs: 20`, expects the field to be absent in the normalized output.
- [x] Existing tests for `presence_penalty` / `frequency_penalty` / `structured_outputs` strips remain green (same function, same pattern).
- [x] Manually reproduced the crash three times on two different Kimi configs (4×B300 and 4×B200, both TP=4) with prompts of ~6000 tokens.
- [x] Confirmed Qwen3-PP node is not vulnerable to the same payloads, supporting the conclusion that the bug is specific to TP × large-vocab combinations.