### PR TITLE
fix(devshard): clamp temperature and force validation logprobs

### DIFF
--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -11,6 +11,7 @@ import (
 
 const MaxChatRequestBodySize = 10 * 1024 * 1024
 const MaxChatRequestChoices = 5
+const MaxTemperature = 2.0
 const kimiK26ModelID = "moonshotai/Kimi-K2.6"
 
 type chatRequest struct {
@@ -137,6 +138,8 @@ func normalizeChatRequestForAuthAndLimits(body []byte, adminAuthenticated bool, 
 		raw["max_tokens"] = req.MaxTokens
 	}
 	stripMinTokensAboveMax(raw, req.MaxTokens)
+	stripTemperatureAboveMax(raw)
+	forceValidationLogprobs(raw)
 	if _, hasN := raw["n"]; hasN {
 		req.N = capChatRequestChoices(req.N)
 		raw["n"] = req.N
@@ -254,6 +257,21 @@ func stripMinTokensAboveMax(request map[string]any, maxTokens uint64) {
 	if value > maxTokens {
 		request["min_tokens"] = maxTokens
 	}
+}
+
+func stripTemperatureAboveMax(request map[string]any) {
+	value, ok := request["temperature"].(float64)
+	if !ok {
+		return
+	}
+	if value > MaxTemperature {
+		request["temperature"] = MaxTemperature
+	}
+}
+
+func forceValidationLogprobs(request map[string]any) {
+	request["logprobs"] = true
+	request["top_logprobs"] = 5
 }
 
 func numericJSONValueAsUint64(value any) (uint64, bool) {

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -189,6 +189,44 @@ func TestNormalizeChatRequestKeepsMinTokensWithinEffectiveMax(t *testing.T) {
 	require.EqualValues(t, 128, raw["min_tokens"])
 }
 
+func TestNormalizeChatRequestStripsTemperatureAboveMax(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hi"}],
+		"temperature": 999999
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 2.0, raw["temperature"])
+}
+
+func TestNormalizeChatRequestKeepsTemperatureWithinMax(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hi"}],
+		"temperature": 1.5
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 1.5, raw["temperature"])
+}
+
+func TestNormalizeChatRequestForcesValidationLogprobs(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hi"}],
+		"logprobs": false,
+		"top_logprobs": 20
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.Equal(t, true, raw["logprobs"])
+	require.EqualValues(t, 5, raw["top_logprobs"])
+}
+
 func TestNormalizeChatRequestStripsEmptyTools(t *testing.T) {
 	body, _, err := normalizeChatRequest([]byte(`{
 		"tool_choice": "auto",


### PR DESCRIPTION
Two related request-normalization hardening changes for the devshard gateway. Both attack the same surface — client-controllable sampling parameters that either burn cluster resources or break OpenAI compatibility — and follow the existing patterns (`stripMinTokensAboveMax`, `capChatRequestChoices`, etc.).

## 1. Clamp `temperature` to OpenAI spec max (2.0)

### Problem

OpenAI Chat Completions spec defines `temperature ∈ [0, 2]`. vLLM accepts arbitrary positive values and treats them numerically: at `temperature: 999999` the sampler is effectively uniform-random over the full ~163k Kimi vocabulary, producing garbage tokens.

Observed in production:
```bash
curl -X POST https://node4.gonka.ai/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"moonshotai/Kimi-K2.6","messages":[{"role":"user","content":"ping"}],"temperature":999999}'
# → "inference: no non-empty response after retrying with reduced max_tokens"
```

Without `max_tokens` the gateway default kicks in (~3072), the sampler emits ~random tokens including occasional EOS, the response is classified as empty by the broker, the broker retries with reduced `max_tokens`, and so on — for minutes, burning GPU until it gives up. This is a cost/DoS vector, not a crash.

### Fix

Silent clamp to `MaxTemperature = 2.0`. Negative values are intentionally left alone (vLLM already 400-rejects them).

```go
func stripTemperatureAboveMax(request map[string]any) {
    value, ok := request["temperature"].(float64)
    if !ok {
        return
    }
    if value > MaxTemperature {
        request["temperature"] = MaxTemperature
    }
}
```

This matches the in-place clamper style of `stripMinTokensAboveMax` precisely.

## 2. Force `logprobs=true, top_logprobs=5` at gateway (defense-in-depth)

### Problem

`logprobs` and `top_logprobs` are not client-facing features in the Gonka context — they're **validation infrastructure**. The `enforced_tokens` validation flow requires both values to be set on every executed request, otherwise `GetEnforcedTokens` fails on the validator with "choice has no logprobs content".

Currently `decentralized-api/completionapi/request.go::ModifyRequestBody` forces these values (lines 39 and 44). devshard relies on the dapi upstream having done this (per the comment in `devshard/engine.go`: "Implemented by dapi using existing broker + completionapi"). devshard itself does not force them.

### Fix

Add an explicit force in devshard normalization. This is **defense-in-depth**, not a behavior change in the current topology:

- If dapi runs upstream of devshard: `forceValidationLogprobs` is idempotent with what dapi already did.
- If devshard ever serves traffic without dapi in front: validation still works.
- Client cannot influence these fields under any topology.

```go
func forceValidationLogprobs(request map[string]any) {
    request["logprobs"] = true
    request["top_logprobs"] = 5
}
```

Costs: clients that legitimately request `top_logprobs` in (5, 20] for classifier/RAG-reranking use cases lose that capability through devshard. In practice they already lose it because of a latent type-assertion bug in `getOriginalTopLogprobs` (`json.Unmarshal` to `map[string]interface{}` produces `float64`, but the function does `.(int)` which always fails → always falls through to force=5). Making the behavior explicit here doesn't regress any working use case.

## Test plan

- [x] Unit test: `TestNormalizeChatRequestStripsTemperatureAboveMax` — `temperature: 999999` clamped to `2.0`.
- [x] Unit test: `TestNormalizeChatRequestKeepsTemperatureWithinMax` — `temperature: 1.5` preserved.
- [x] Unit test: `TestNormalizeChatRequestForcesValidationLogprobs` — sends `logprobs: false, top_logprobs: 20`, expects forced `true / 5`.
- [x] Existing min_tokens / output_tokens / N tests remain green (same function, same pattern).
- [x] Manually verified the temperature DoS reproduction against `https://node4.gonka.ai` — request without `max_tokens` and `temperature: 999999` hangs for ~minutes then returns the retry error; request with `max_tokens: 20` returns garbage immediately. Both paths fixed by the clamp.

## Out of scope

- Top-end `top_logprobs` enforcement for clients that intentionally request 0 < N < 5: dapi already floors to 5, devshard now also overrides to 5.
- Other OpenAI spec bounds (`top_p`, `presence_penalty`/`frequency_penalty`): `top_p > 1` is silently ignored by vLLM (no DoS), penalties already stripped entirely by `stripUnsupportedChatRequestParameters`.
