### PR TITLE
Allow standard OpenAI/Anthropic completion fields in gateway filter

### DIFF
--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -305,8 +305,8 @@ func numericJSONValueAsUint64(value any) (uint64, bool) {
 }
 
 func stripUnsupportedChatRequestParameters(request map[string]any) {
-	delete(request, "presence_penalty")
-	delete(request, "frequency_penalty")
+	// Keep standard OpenAI/Anthropic request fields and only strip known
+	// non-standard or currently unsupported gateway additions.
 	delete(request, "structured_outputs")
 	delete(request, "prompt_logprobs")
 	if _, hasStopIDs := request["stop_token_ids"]; hasStopIDs {

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -240,7 +240,7 @@ func TestNormalizeChatRequestStripsPromptLogprobs(t *testing.T) {
 	require.False(t, exists)
 }
 
-TestNormalizeChatRequestStripsMinTokensWhenStopTokenIdsPresent(t *testing.T) {
+func TestNormalizeChatRequestStripsMinTokensWhenStopTokenIdsPresent(t *testing.T) {
 	body, _, err := normalizeChatRequest([]byte(`{
 		"messages": [{"role": "user", "content": "hi"}],
 		"stop_token_ids": [163586, 9999999],
@@ -457,7 +457,7 @@ func TestNormalizeChatRequestStripsStructuredOutputsBeforeValidation(t *testing.
 	require.NotContains(t, raw, "structured_outputs")
 }
 
-func TestNormalizeChatRequestStripsUnsupportedPenaltyFields(t *testing.T) {
+func TestNormalizeChatRequestKeepsStandardPenaltyFields(t *testing.T) {
 	body, _, err := normalizeChatRequest([]byte(`{
 		"presence_penalty": 1.2,
 		"frequency_penalty": 0.8,
@@ -467,8 +467,42 @@ func TestNormalizeChatRequestStripsUnsupportedPenaltyFields(t *testing.T) {
 
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(body, &raw))
-	require.NotContains(t, raw, "presence_penalty")
-	require.NotContains(t, raw, "frequency_penalty")
+	require.EqualValues(t, 1.2, raw["presence_penalty"])
+	require.EqualValues(t, 0.8, raw["frequency_penalty"])
+}
+
+func TestNormalizeChatRequestPreservesStandardOpenAIAndAnthropicTopLevelFields(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hello"}],
+		"metadata": {"trace_id": "abc123"},
+		"service_tier": "auto",
+		"top_k": 40,
+		"stop_sequences": ["\n\nHuman:"],
+		"system": "use concise answers",
+		"thinking": {"type": "enabled"},
+		"tool_choice": "auto",
+		"tools": [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}],
+		"stream_options": {"include_usage": true},
+		"response_format": {"type": "json_schema", "json_schema": {"name": "payload", "schema": {"type": "object"}}},
+		"prompt_cache_key": "cache-key-1",
+		"inference_geo": "us"
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.Equal(t, "abc123", raw["metadata"].(map[string]any)["trace_id"])
+	require.Equal(t, "auto", raw["service_tier"])
+	require.EqualValues(t, 40, raw["top_k"])
+	require.Equal(t, "use concise answers", raw["system"])
+	require.Equal(t, "enabled", raw["thinking"].(map[string]any)["type"])
+	require.Equal(t, "auto", raw["tool_choice"])
+	require.Len(t, raw["tools"].([]any), 1)
+	require.Equal(t, true, raw["stream_options"].(map[string]any)["include_usage"])
+	require.Equal(t, "json_schema", raw["response_format"].(map[string]any)["type"])
+	require.Equal(t, "cache-key-1", raw["prompt_cache_key"])
+	require.Equal(t, "us", raw["inference_geo"])
+	require.Equal(t, "\n\nHuman:", raw["stop_sequences"].([]any)[0])
 }
 
 func TestNormalizeChatRequestRejectsUnsupportedFields(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve standard OpenAI penalty fields (`presence_penalty`, `frequency_penalty`) in devshard gateway request normalization instead of stripping them
- keep the existing explicit blocklist behavior unchanged (`enforced_tokens`, `response_format.type=json_object`, `guided_regex`, `guided_grammar`)
- add request-filter tests to assert standard OpenAI/Anthropic top-level request fields are preserved through normalization
- fix the missing `func` declaration on `TestNormalizeChatRequestStripsMinTokensWhenStopTokenIdsPresent` so the test file compiles/runs cleanly

## Validation
- `go test ./cmd/devshardctl -run 'TestNormalizeChatRequest|TestPrepareChatRequestBody|TestApplyKimiRequestOverrides'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f9da16b-e821-43f3-a800-13c63e7e4200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f9da16b-e821-43f3-a800-13c63e7e4200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

