### PR TITLE
Allow standard completion request fields

### DIFF
--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -115,14 +115,19 @@ func normalizeContent(body []byte) ([]byte, error) {
 			continue
 		}
 		var texts []string
+		allSimpleText := true
 		for partIndex, p := range parts {
-			text, err := requiredTextContentPart(p, partIndex)
+			text, ok, err := simpleTextContentPart(p, partIndex)
 			if err != nil {
 				return nil, badChatRequest("messages[%d].content%v", i, err)
 			}
+			if !ok {
+				allSimpleText = false
+				break
+			}
 			texts = append(texts, text)
 		}
-		if len(texts) > 0 {
+		if allSimpleText && len(texts) > 0 {
 			combined, _ := json.Marshal(strings.Join(texts, "\n"))
 			msgs[i]["content"] = combined
 			changed = true

--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -456,18 +456,31 @@ func validateToolCallsField(message map[string]any, messageIndex int) ([]string,
 		if err != nil {
 			return nil, true, badChatRequest("messages[%d].tool_calls[%d].type: %v", messageIndex, callIndex, err)
 		}
-		if callType != "function" {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].type must be \"function\"", messageIndex, callIndex)
-		}
-		function, ok := call["function"].(map[string]any)
-		if !ok {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].function must be an object", messageIndex, callIndex)
-		}
-		if _, err := requiredNonEmptyString(function, "name"); err != nil {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].function.name: %v", messageIndex, callIndex, err)
-		}
-		if err := optionalStringField(function, "arguments"); err != nil {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].function.arguments: %v", messageIndex, callIndex, err)
+		switch callType {
+		case "function":
+			function, ok := call["function"].(map[string]any)
+			if !ok {
+				return nil, true, badChatRequest("messages[%d].tool_calls[%d].function must be an object", messageIndex, callIndex)
+			}
+			if _, err := requiredNonEmptyString(function, "name"); err != nil {
+				return nil, true, badChatRequest("messages[%d].tool_calls[%d].function.name: %v", messageIndex, callIndex, err)
+			}
+			if err := optionalStringField(function, "arguments"); err != nil {
+				return nil, true, badChatRequest("messages[%d].tool_calls[%d].function.arguments: %v", messageIndex, callIndex, err)
+			}
+		case "custom":
+			custom, ok := call["custom"].(map[string]any)
+			if !ok {
+				return nil, true, badChatRequest("messages[%d].tool_calls[%d].custom must be an object", messageIndex, callIndex)
+			}
+			if _, err := requiredNonEmptyString(custom, "name"); err != nil {
+				return nil, true, badChatRequest("messages[%d].tool_calls[%d].custom.name: %v", messageIndex, callIndex, err)
+			}
+			if _, err := requiredNonEmptyString(custom, "input"); err != nil {
+				return nil, true, badChatRequest("messages[%d].tool_calls[%d].custom.input: %v", messageIndex, callIndex, err)
+			}
+		default:
+			return nil, true, badChatRequest("messages[%d].tool_calls[%d].type has unsupported value %q", messageIndex, callIndex, callType)
 		}
 		ids = append(ids, id)
 	}
@@ -527,12 +540,8 @@ func validateNonEmptyContent(content any) error {
 			if !ok {
 				return fmt.Errorf("[%d] must be an object", i)
 			}
-			text, err := requiredTextContentPart(part, i)
-			if err != nil {
+			if err := validateStandardContentPart(part, i); err != nil {
 				return err
-			}
-			if strings.TrimSpace(text) == "" {
-				return fmt.Errorf("[%d].text must not be empty", i)
 			}
 		}
 		return nil
@@ -541,22 +550,152 @@ func validateNonEmptyContent(content any) error {
 	}
 }
 
-func requiredTextContentPart(part map[string]any, partIndex int) (string, error) {
+func simpleTextContentPart(part map[string]any, partIndex int) (string, bool, error) {
 	if len(part) != 2 {
-		return "", fmt.Errorf("[%d] must only include type and text", partIndex)
+		return "", false, nil
 	}
+	partType, ok := part["type"].(string)
+	if !ok || partType != "text" {
+		return "", false, nil
+	}
+	text, ok := part["text"].(string)
+	if !ok {
+		return "", false, fmt.Errorf("[%d].text must be a string", partIndex)
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", false, fmt.Errorf("[%d].text must not be empty", partIndex)
+	}
+	return text, true, nil
+}
+
+func validateStandardContentPart(part map[string]any, partIndex int) error {
 	partType, err := requiredNonEmptyString(part, "type")
 	if err != nil {
-		return "", fmt.Errorf("[%d].type: %w", partIndex, err)
+		return fmt.Errorf("[%d].type: %w", partIndex, err)
 	}
-	if partType != "text" {
-		return "", fmt.Errorf("[%d].type has unsupported value %q", partIndex, partType)
+
+	switch partType {
+	case "text":
+		if err := ensureOnlyFields(part, "type", "text", "cache_control", "citations"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "text"); err != nil {
+			return fmt.Errorf("[%d].text: %w", partIndex, err)
+		}
+	case "image_url":
+		if err := ensureOnlyFields(part, "type", "image_url"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if err := requiredObjectField(part, "image_url"); err != nil {
+			return fmt.Errorf("[%d].image_url: %w", partIndex, err)
+		}
+	case "input_audio":
+		if err := ensureOnlyFields(part, "type", "input_audio"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if err := requiredObjectField(part, "input_audio"); err != nil {
+			return fmt.Errorf("[%d].input_audio: %w", partIndex, err)
+		}
+	case "file":
+		if err := ensureOnlyFields(part, "type", "file"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if err := requiredObjectField(part, "file"); err != nil {
+			return fmt.Errorf("[%d].file: %w", partIndex, err)
+		}
+	case "refusal":
+		if err := ensureOnlyFields(part, "type", "refusal"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "refusal"); err != nil {
+			return fmt.Errorf("[%d].refusal: %w", partIndex, err)
+		}
+	case "image":
+		if err := ensureOnlyFields(part, "type", "source", "cache_control"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if err := requiredObjectField(part, "source"); err != nil {
+			return fmt.Errorf("[%d].source: %w", partIndex, err)
+		}
+	case "document":
+		if err := ensureOnlyFields(part, "type", "source", "cache_control", "citations", "context", "title"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if err := requiredObjectField(part, "source"); err != nil {
+			return fmt.Errorf("[%d].source: %w", partIndex, err)
+		}
+	case "search_result":
+		if err := ensureOnlyFields(part, "type", "content", "source", "title", "cache_control", "citations"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, exists := part["content"]; !exists {
+			return fmt.Errorf("[%d].content: is required", partIndex)
+		}
+	case "thinking":
+		if err := ensureOnlyFields(part, "type", "thinking", "signature"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "thinking"); err != nil {
+			return fmt.Errorf("[%d].thinking: %w", partIndex, err)
+		}
+	case "redacted_thinking":
+		if err := ensureOnlyFields(part, "type", "data"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "data"); err != nil {
+			return fmt.Errorf("[%d].data: %w", partIndex, err)
+		}
+	case "tool_use", "server_tool_use":
+		if err := ensureOnlyFields(part, "type", "id", "name", "input", "cache_control", "caller"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "id"); err != nil {
+			return fmt.Errorf("[%d].id: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "name"); err != nil {
+			return fmt.Errorf("[%d].name: %w", partIndex, err)
+		}
+		if err := requiredObjectField(part, "input"); err != nil {
+			return fmt.Errorf("[%d].input: %w", partIndex, err)
+		}
+	case "tool_result":
+		if err := ensureOnlyFields(part, "type", "tool_use_id", "content", "is_error", "cache_control"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "tool_use_id"); err != nil {
+			return fmt.Errorf("[%d].tool_use_id: %w", partIndex, err)
+		}
+	case "web_search_tool_result", "web_fetch_tool_result":
+		if err := ensureOnlyFields(part, "type", "tool_use_id", "content", "cache_control", "caller"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "tool_use_id"); err != nil {
+			return fmt.Errorf("[%d].tool_use_id: %w", partIndex, err)
+		}
+		if _, exists := part["content"]; !exists {
+			return fmt.Errorf("[%d].content: is required", partIndex)
+		}
+	case "code_execution_tool_result", "bash_code_execution_tool_result", "text_editor_code_execution_tool_result", "tool_search_tool_result":
+		if err := ensureOnlyFields(part, "type", "tool_use_id", "content", "cache_control"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "tool_use_id"); err != nil {
+			return fmt.Errorf("[%d].tool_use_id: %w", partIndex, err)
+		}
+		if _, exists := part["content"]; !exists {
+			return fmt.Errorf("[%d].content: is required", partIndex)
+		}
+	case "container_upload":
+		if err := ensureOnlyFields(part, "type", "file_id", "cache_control"); err != nil {
+			return fmt.Errorf("[%d]: %w", partIndex, err)
+		}
+		if _, err := requiredNonEmptyString(part, "file_id"); err != nil {
+			return fmt.Errorf("[%d].file_id: %w", partIndex, err)
+		}
+	default:
+		return fmt.Errorf("[%d].type has unsupported value %q", partIndex, partType)
 	}
-	text, err := requiredNonEmptyString(part, "text")
-	if err != nil {
-		return "", fmt.Errorf("[%d].text: %w", partIndex, err)
-	}
-	return text, nil
+	return nil
 }
 
 func ensureFieldsAbsent(values map[string]any, fields ...string) error {
@@ -564,6 +703,30 @@ func ensureFieldsAbsent(values map[string]any, fields ...string) error {
 		if _, exists := values[field]; exists {
 			return fmt.Errorf("%s is not allowed for this role", field)
 		}
+	}
+	return nil
+}
+
+func ensureOnlyFields(values map[string]any, fields ...string) error {
+	allowed := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		allowed[field] = struct{}{}
+	}
+	for field := range values {
+		if _, ok := allowed[field]; !ok {
+			return fmt.Errorf("%s is not allowed for this content type", field)
+		}
+	}
+	return nil
+}
+
+func requiredObjectField(values map[string]any, field string) error {
+	rawValue, exists := values[field]
+	if !exists || rawValue == nil {
+		return fmt.Errorf("is required")
+	}
+	if _, ok := rawValue.(map[string]any); !ok {
+		return fmt.Errorf("must be an object")
 	}
 	return nil
 }

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -240,7 +240,7 @@ func TestNormalizeChatRequestStripsPromptLogprobs(t *testing.T) {
 	require.False(t, exists)
 }
 
-TestNormalizeChatRequestStripsMinTokensWhenStopTokenIdsPresent(t *testing.T) {
+func TestNormalizeChatRequestStripsMinTokensWhenStopTokenIdsPresent(t *testing.T) {
 	body, _, err := normalizeChatRequest([]byte(`{
 		"messages": [{"role": "user", "content": "hi"}],
 		"stop_token_ids": [163586, 9999999],
@@ -278,6 +278,98 @@ func TestNormalizeChatRequestStripsEmptyTools(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &raw))
 	require.NotContains(t, raw, "tools")
 	require.NotContains(t, raw, "tool_choice")
+}
+
+func TestNormalizeChatRequestKeepsStandardCompletionRequestFields(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"model": "Qwen/Test",
+		"audio": {"format": "mp3", "voice": "alloy"},
+		"cache_control": {"type": "ephemeral"},
+		"container": "container-1",
+		"frequency_penalty": 0.5,
+		"function_call": "auto",
+		"functions": [{"name": "legacy_function"}],
+		"inference_geo": "us",
+		"logit_bias": {"42": -1},
+		"logprobs": false,
+		"metadata": {"trace": "abc"},
+		"modalities": ["text", "audio"],
+		"n": 2,
+		"output_config": {"type": "json"},
+		"parallel_tool_calls": false,
+		"prediction": {"type": "content", "content": [{"type": "text", "text": "predicted"}]},
+		"presence_penalty": 0.5,
+		"prompt_cache_key": "cache-key",
+		"prompt_cache_retention": "24h",
+		"prompt_logprobs": 2,
+		"reasoning_effort": "low",
+		"response_format": {"type": "json_schema", "json_schema": {"name": "answer", "schema": {"type": "object"}}},
+		"safety_identifier": "safe-user",
+		"seed": 123,
+		"service_tier": "auto",
+		"stop": ["\n"],
+		"stop_sequences": ["END"],
+		"store": false,
+		"stream": true,
+		"stream_options": {"include_usage": true, "include_obfuscation": false},
+		"system": [{"type": "text", "text": "system", "cache_control": {"type": "ephemeral"}}],
+		"temperature": 1.5,
+		"thinking": {"type": "enabled", "budget_tokens": 1024},
+		"tool_choice": "auto",
+		"tools": [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}],
+		"top_k": 5,
+		"top_logprobs": 20,
+		"top_p": 0.9,
+		"user": "user-1",
+		"verbosity": "low",
+		"web_search_options": {"search_context_size": "low"},
+		"messages": [{"role": "user", "content": "hello"}]
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	for _, field := range []string{
+		"audio",
+		"cache_control",
+		"container",
+		"function_call",
+		"functions",
+		"inference_geo",
+		"logit_bias",
+		"metadata",
+		"modalities",
+		"output_config",
+		"parallel_tool_calls",
+		"prediction",
+		"prompt_cache_key",
+		"prompt_cache_retention",
+		"reasoning_effort",
+		"response_format",
+		"safety_identifier",
+		"seed",
+		"service_tier",
+		"stop",
+		"stop_sequences",
+		"store",
+		"stream_options",
+		"system",
+		"thinking",
+		"tool_choice",
+		"tools",
+		"top_k",
+		"top_p",
+		"user",
+		"verbosity",
+		"web_search_options",
+	} {
+		require.Contains(t, raw, field)
+	}
+	require.NotContains(t, raw, "frequency_penalty")
+	require.NotContains(t, raw, "presence_penalty")
+	require.NotContains(t, raw, "prompt_logprobs")
+	require.Equal(t, true, raw["logprobs"])
+	require.EqualValues(t, 5, raw["top_logprobs"])
 }
 
 func TestApplyKimiRequestOverrides(t *testing.T) {
@@ -516,7 +608,7 @@ func TestNormalizeChatRequestRejectsMalformedMessages(t *testing.T) {
 		`{"messages":[{"content":"hello"}]}`,
 		`{"messages":[{"role":"user","content":123}]}`,
 		`{"messages":[{"role":"user","content":[{"type":"text"}]}]}`,
-		`{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}]}`,
+		`{"messages":[{"role":"user","content":[{"type":"image_url"}]}]}`,
 		`{"messages":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}]}`,
 		`{"messages":[{"role":"tool","tool_call_id":"missing","content":"hello"}]}`,
 	}
@@ -549,6 +641,78 @@ func TestPrepareChatRequestBodyNormalizesTextContentParts(t *testing.T) {
 	messages := raw["messages"].([]any)
 	message := messages[0].(map[string]any)
 	require.Equal(t, "hello\nworld", message["content"])
+}
+
+func TestPrepareChatRequestBodyKeepsStandardOpenAIContentParts(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "describe this"},
+				{"type": "image_url", "image_url": {"url": "https://example.com/image.png", "detail": "high"}},
+				{"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}},
+				{"type": "file", "file": {"file_id": "file_123", "filename": "notes.txt"}}
+			]},
+			{"role": "assistant", "name": "assistant_a", "audio": {"id": "audio_1"}, "refusal": "cannot", "content": [
+				{"type": "refusal", "refusal": "cannot"}
+			]},
+			{"role": "assistant", "tool_calls": [{
+				"id": "call_custom",
+				"type": "custom",
+				"custom": {"name": "run_code", "input": "print(1)"}
+			}]}
+		]
+	}`))
+
+	body, _, err := prepareChatRequestBody(req)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	messages := raw["messages"].([]any)
+	user := messages[0].(map[string]any)
+	require.IsType(t, []any{}, user["content"])
+	parts := user["content"].([]any)
+	require.Equal(t, "image_url", parts[1].(map[string]any)["type"])
+	require.Equal(t, "custom", messages[2].(map[string]any)["tool_calls"].([]any)[0].(map[string]any)["type"])
+}
+
+func TestPrepareChatRequestBodyKeepsStandardAnthropicContentBlocks(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}, "citations": []},
+				{"type": "image", "source": {"type": "url", "url": "https://example.com/image.png"}},
+				{"type": "document", "source": {"type": "text", "media_type": "text/plain", "data": "doc"}, "title": "Doc", "context": "ctx", "citations": {"enabled": true}},
+				{"type": "search_result", "content": [{"type": "text", "text": "result"}], "source": "web", "title": "Result"},
+				{"type": "tool_result", "tool_use_id": "toolu_1", "content": "ok", "is_error": false}
+			]},
+			{"role": "assistant", "content": [
+				{"type": "thinking", "thinking": "hmm", "signature": "sig"},
+				{"type": "redacted_thinking", "data": "secret"},
+				{"type": "tool_use", "id": "toolu_1", "name": "lookup", "input": {}},
+				{"type": "server_tool_use", "id": "srv_1", "name": "web_search", "input": {}, "caller": {"type": "direct"}},
+				{"type": "web_search_tool_result", "tool_use_id": "srv_1", "content": {"type": "web_search_result", "encrypted_content": "x"}, "caller": {"type": "direct"}},
+				{"type": "web_fetch_tool_result", "tool_use_id": "srv_2", "content": {"type": "web_fetch_result", "url": "https://example.com", "content": "x"}},
+				{"type": "code_execution_tool_result", "tool_use_id": "srv_3", "content": {"type": "code_execution_result", "stdout": "x"}},
+				{"type": "bash_code_execution_tool_result", "tool_use_id": "srv_4", "content": {"type": "bash_code_execution_result", "stdout": "x"}},
+				{"type": "text_editor_code_execution_tool_result", "tool_use_id": "srv_5", "content": {"type": "text_editor_code_execution_view_result", "file_text": "x"}},
+				{"type": "tool_search_tool_result", "tool_use_id": "srv_6", "content": {"type": "tool_search_tool_search_result", "content": []}},
+				{"type": "container_upload", "file_id": "file_1"}
+			]}
+		]
+	}`))
+
+	body, _, err := prepareChatRequestBody(req)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	messages := raw["messages"].([]any)
+	user := messages[0].(map[string]any)
+	require.IsType(t, []any{}, user["content"])
+	require.Equal(t, "text", user["content"].([]any)[0].(map[string]any)["type"])
+	assistant := messages[1].(map[string]any)
+	require.Len(t, assistant["content"], 11)
 }
 
 func TestPrepareChatRequestBodyNormalizesEmptyAssistantToolCallContent(t *testing.T) {
@@ -624,16 +788,16 @@ func TestPrepareChatRequestBodyNormalizesEmptyToolContent(t *testing.T) {
 	}
 }
 
-func TestPrepareChatRequestBodyRejectsNonTextContentParts(t *testing.T) {
+func TestPrepareChatRequestBodyRejectsMalformedContentParts(t *testing.T) {
 	tests := []struct {
 		name string
 		body string
 		want string
 	}{
 		{
-			name: "image_url",
-			body: `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}]}`,
-			want: `unsupported value "image_url"`,
+			name: "image_url missing object",
+			body: `{"messages":[{"role":"user","content":[{"type":"image_url"}]}]}`,
+			want: `image_url: is required`,
 		},
 		{
 			name: "input_text",
@@ -648,7 +812,12 @@ func TestPrepareChatRequestBodyRejectsNonTextContentParts(t *testing.T) {
 		{
 			name: "text with extra field",
 			body: `{"messages":[{"role":"user","content":[{"type":"text","text":"hello","image_url":{"url":"https://example.com/image.png"}}]}]}`,
-			want: `must only include type and text`,
+			want: `image_url is not allowed`,
+		},
+		{
+			name: "tool use missing input",
+			body: `{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"lookup"}]}]}`,
+			want: `input: is required`,
 		},
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Preserve standard OpenAI and Anthropic completion request fields through devshard gateway normalization.
- Allow standard OpenAI multipart content parts and custom tool calls.
- Allow standard Anthropic content block types while retaining existing explicit strips/rejections.

## Testing
- `go test ./cmd/devshardctl`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ebfb5ac-2ad3-4b90-ab03-cedf6cd0c0de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ebfb5ac-2ad3-4b90-ab03-cedf6cd0c0de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

