### PR TITLE
feat(devshard): add OpenAI observability fields (user/metadata/parallel_tool_calls/stream_options)

### DIFF
--- a/devshard/cmd/devshardctl/paramvalidators/metadata.go
+++ b/devshard/cmd/devshardctl/paramvalidators/metadata.go
@@ -1,0 +1,77 @@
+package paramvalidators
+
+import (
+	"errors"
+	"fmt"
+)
+
+// MetadataValidator enforces the OpenAI Chat Completions `metadata` contract: an optional
+// object with at most 16 string-keyed entries, keys up to 64 characters, values that are
+// strings up to 512 characters. The field has no inference-side meaning for vLLM (it is
+// ignored upstream) — clients use it for distributed tracing (LangSmith, OpenAI tracing,
+// W3C trace-context propagation) and A/B test tagging. Validating at the gateway boundary
+// keeps the same bounds the OpenAI API itself enforces, so the field is bounded surface
+// rather than an unbounded passthrough.
+//
+// Zero-valued limit fields fall back to the OpenAI-documented defaults.
+type MetadataValidator struct {
+	MaxKeys     int
+	MaxKeyLen   int
+	MaxValueLen int
+}
+
+// ErrMetadataShape covers the wrapper-level rejection: metadata must be a JSON object.
+// ErrMetadataKeyCount, ErrMetadataKey, ErrMetadataValue mark the OpenAI-spec bound
+// violations.
+var (
+	ErrMetadataShape    = errors.New("metadata: invalid wrapper shape")
+	ErrMetadataKeyCount = errors.New("metadata: key count exceeded")
+	ErrMetadataKey      = errors.New("metadata: key invalid")
+	ErrMetadataValue    = errors.New("metadata: value invalid")
+)
+
+// OpenAI's documented bounds — see https://platform.openai.com/docs/api-reference/chat
+const (
+	defaultMetadataMaxKeys     = 16
+	defaultMetadataMaxKeyLen   = 64
+	defaultMetadataMaxValueLen = 512
+)
+
+func (v MetadataValidator) Validate(document map[string]any) error {
+	raw, exists := document["metadata"]
+	if !exists {
+		return nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: must be an object", ErrMetadataShape)
+	}
+	maxKeys := v.MaxKeys
+	if maxKeys == 0 {
+		maxKeys = defaultMetadataMaxKeys
+	}
+	maxKeyLen := v.MaxKeyLen
+	if maxKeyLen == 0 {
+		maxKeyLen = defaultMetadataMaxKeyLen
+	}
+	maxValueLen := v.MaxValueLen
+	if maxValueLen == 0 {
+		maxValueLen = defaultMetadataMaxValueLen
+	}
+	if len(obj) > maxKeys {
+		return fmt.Errorf("%w: %d > %d", ErrMetadataKeyCount, len(obj), maxKeys)
+	}
+	for key, val := range obj {
+		if len(key) > maxKeyLen {
+			return fmt.Errorf("%w: key length %d > %d", ErrMetadataKey, len(key), maxKeyLen)
+		}
+		s, ok := val.(string)
+		if !ok {
+			return fmt.Errorf("%w: value for %q must be a string", ErrMetadataValue, key)
+		}
+		if len(s) > maxValueLen {
+			return fmt.Errorf("%w: value for %q length %d > %d", ErrMetadataValue, key, len(s), maxValueLen)
+		}
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/metadata_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/metadata_test.go
@@ -1,0 +1,92 @@
+package paramvalidators
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataValidatorAccepts(t *testing.T) {
+	v := MetadataValidator{}
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "absent", body: `{"messages":[]}`},
+		{name: "empty object", body: `{"metadata":{}}`},
+		{name: "single entry", body: `{"metadata":{"trace_id":"abc"}}`},
+		{name: "tracing payload", body: `{"metadata":{"trace_id":"abc","span_id":"def","user_segment":"beta"}}`},
+		{name: "exactly at key limit", body: `{"metadata":` + buildKeys(t, 16) + `}`},
+		{name: "exactly at key length", body: `{"metadata":{"` + strings.Repeat("k", 64) + `":"v"}}`},
+		{name: "exactly at value length", body: `{"metadata":{"k":"` + strings.Repeat("v", 512) + `"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, v.Validate(parseDocument(t, tt.body)))
+		})
+	}
+}
+
+func TestMetadataValidatorRejects(t *testing.T) {
+	v := MetadataValidator{}
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{name: "wrapper is string", body: `{"metadata":"v"}`, wantErr: ErrMetadataShape},
+		{name: "wrapper is array", body: `{"metadata":[]}`, wantErr: ErrMetadataShape},
+		{name: "wrapper is bool", body: `{"metadata":true}`, wantErr: ErrMetadataShape},
+		{name: "key count over limit", body: `{"metadata":` + buildKeys(t, 17) + `}`, wantErr: ErrMetadataKeyCount},
+		{name: "key length over limit", body: `{"metadata":{"` + strings.Repeat("k", 65) + `":"v"}}`, wantErr: ErrMetadataKey},
+		{name: "value not a string (number)", body: `{"metadata":{"k":42}}`, wantErr: ErrMetadataValue},
+		{name: "value not a string (object)", body: `{"metadata":{"k":{}}}`, wantErr: ErrMetadataValue},
+		{name: "value not a string (array)", body: `{"metadata":{"k":["v"]}}`, wantErr: ErrMetadataValue},
+		{name: "value length over limit", body: `{"metadata":{"k":"` + strings.Repeat("v", 513) + `"}}`, wantErr: ErrMetadataValue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Validate(parseDocument(t, tt.body))
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+// Custom limits override the OpenAI-documented defaults.
+func TestMetadataValidatorRespectsCustomLimits(t *testing.T) {
+	v := MetadataValidator{MaxKeys: 1, MaxKeyLen: 4, MaxValueLen: 4}
+
+	require.NoError(t, v.Validate(parseDocument(t, `{"metadata":{"key":"val"}}`)))
+
+	err := v.Validate(parseDocument(t, `{"metadata":{"k1":"v","k2":"v"}}`))
+	require.ErrorIs(t, err, ErrMetadataKeyCount)
+
+	err = v.Validate(parseDocument(t, `{"metadata":{"keyy":"v"}}`))
+	require.NoError(t, err) // 4 chars exactly
+	err = v.Validate(parseDocument(t, `{"metadata":{"keyyy":"v"}}`))
+	require.ErrorIs(t, err, ErrMetadataKey)
+}
+
+// buildKeys returns a JSON object literal with n distinct string-valued entries.
+func buildKeys(tb testing.TB, n int) string {
+	tb.Helper()
+	var b strings.Builder
+	b.WriteByte('{')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt := `"k` + strings.Repeat("0", 0)
+		_ = fmt
+		b.WriteString(`"k`)
+		// distinct keys k0..kN-1
+		for _, c := range []byte{byte('0' + (i / 10)), byte('0' + (i % 10))} {
+			b.WriteByte(c)
+		}
+		b.WriteString(`":"v"`)
+	}
+	b.WriteByte('}')
+	return b.String()
+}

--- a/devshard/cmd/devshardctl/paramvalidators/stream_options.go
+++ b/devshard/cmd/devshardctl/paramvalidators/stream_options.go
@@ -1,0 +1,53 @@
+package paramvalidators
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrStreamOptionsShape covers the wrapper-level rejection: stream_options must be a JSON
+// object when present.
+var ErrStreamOptionsShape = errors.New("stream_options: invalid wrapper shape")
+
+// streamOptionsWhitelist lists the sub-fields of `stream_options` that survive the
+// sanitizer. `include_usage` is the OpenAI-documented field that opts the client into a
+// final-chunk `usage` object during streaming — clients need it for token accounting and
+// billing. Every other sub-field is dropped:
+//
+//   - `continuous_usage_stats`: triggers vLLM-project/vllm#9028 (per-chunk usage counter is
+//     wrong under chunked prefill). Clients don't know about the upstream bug; the gateway
+//     is the right place to neutralize it.
+//   - any other / future sub-field: default-deny keeps the surface narrow as upstream vLLM
+//     adds new options. Worst-case the client loses access to a niche feature; never a
+//     correctness regression.
+var streamOptionsWhitelist = map[string]struct{}{
+	"include_usage": {},
+}
+
+// StreamOptionsValidator enforces a strict sub-field whitelist on the OpenAI
+// `stream_options` object. The Validator interface allows in-place mutation of the document
+// (Raw() returns the live map), so this validator both rejects malformed wrappers and
+// rewrites the object to contain only whitelisted keys. If the rewrite leaves the object
+// empty, the field is dropped from the document entirely so it does not reach the upstream
+// as `{}`.
+type StreamOptionsValidator struct{}
+
+func (v StreamOptionsValidator) Validate(document map[string]any) error {
+	raw, exists := document["stream_options"]
+	if !exists {
+		return nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: must be an object", ErrStreamOptionsShape)
+	}
+	for key := range obj {
+		if _, allowed := streamOptionsWhitelist[key]; !allowed {
+			delete(obj, key)
+		}
+	}
+	if len(obj) == 0 {
+		delete(document, "stream_options")
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/stream_options_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/stream_options_test.go
@@ -1,0 +1,88 @@
+package paramvalidators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamOptionsValidatorAccepts(t *testing.T) {
+	v := StreamOptionsValidator{}
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "absent", body: `{"messages":[]}`},
+		{name: "include_usage true", body: `{"stream_options":{"include_usage":true}}`},
+		{name: "include_usage false", body: `{"stream_options":{"include_usage":false}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, v.Validate(parseDocument(t, tt.body)))
+		})
+	}
+}
+
+func TestStreamOptionsValidatorRejects(t *testing.T) {
+	v := StreamOptionsValidator{}
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{name: "wrapper is string", body: `{"stream_options":"include"}`, wantErr: ErrStreamOptionsShape},
+		{name: "wrapper is array", body: `{"stream_options":[]}`, wantErr: ErrStreamOptionsShape},
+		{name: "wrapper is bool", body: `{"stream_options":true}`, wantErr: ErrStreamOptionsShape},
+		{name: "wrapper is number", body: `{"stream_options":42}`, wantErr: ErrStreamOptionsShape},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Validate(parseDocument(t, tt.body))
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+// continuous_usage_stats is the vLLM-project/vllm#9028 trigger; clients send it innocently
+// (it's an OpenAI-documented stream option) and the upstream produces a broken counter.
+// The gateway strips it so the rest of the payload still goes through.
+func TestStreamOptionsValidatorStripsContinuousUsageStats(t *testing.T) {
+	v := StreamOptionsValidator{}
+	doc := parseDocument(t, `{"stream_options":{"include_usage":true,"continuous_usage_stats":true}}`)
+	require.NoError(t, v.Validate(doc))
+
+	so, ok := doc["stream_options"].(map[string]any)
+	require.True(t, ok, "stream_options should survive when include_usage remains")
+	require.Equal(t, true, so["include_usage"])
+	require.NotContains(t, so, "continuous_usage_stats")
+}
+
+// Future-proofing: an unknown sub-field added by upstream vLLM is also stripped, but does
+// not reject the whole request (clients carrying it for unrelated features keep working).
+func TestStreamOptionsValidatorStripsUnknownSubField(t *testing.T) {
+	v := StreamOptionsValidator{}
+	doc := parseDocument(t, `{"stream_options":{"include_usage":true,"fancy_new_field":42}}`)
+	require.NoError(t, v.Validate(doc))
+
+	so := doc["stream_options"].(map[string]any)
+	require.Equal(t, true, so["include_usage"])
+	require.NotContains(t, so, "fancy_new_field")
+}
+
+// If the rewrite empties the object, the field is dropped from the document so it never
+// reaches the upstream as a meaningless `{}`.
+func TestStreamOptionsValidatorDropsEmptyObject(t *testing.T) {
+	v := StreamOptionsValidator{}
+	doc := parseDocument(t, `{"stream_options":{"continuous_usage_stats":true}}`)
+	require.NoError(t, v.Validate(doc))
+	require.NotContains(t, doc, "stream_options")
+}
+
+// Already-empty object is treated the same as the previous case (no include_usage to keep).
+func TestStreamOptionsValidatorDropsEmptyInput(t *testing.T) {
+	v := StreamOptionsValidator{}
+	doc := parseDocument(t, `{"stream_options":{}}`)
+	require.NoError(t, v.Validate(doc))
+	require.NotContains(t, doc, "stream_options")
+}

--- a/devshard/cmd/devshardctl/paramvalidators/user.go
+++ b/devshard/cmd/devshardctl/paramvalidators/user.go
@@ -1,0 +1,49 @@
+package paramvalidators
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUserShape covers the wrapper-level rejection: `user` must be a string when present.
+// ErrUserLength marks a violation of the byte-length cap.
+var (
+	ErrUserShape  = errors.New("user: invalid wrapper shape")
+	ErrUserLength = errors.New("user: length exceeded")
+)
+
+// defaultUserMaxLen is the gateway-side cap on the `user` identifier when no explicit
+// limit is configured. OpenAI does not document an upper bound, but production identifiers
+// observed in the wild are short (OpenAI's own `user_<random>`, UUIDs, hashed ids,
+// email-shaped strings, framework session ids) and stay well under 512 bytes. We pick 512 B
+// to fit those use cases comfortably while preventing the field from being used as a 10 MiB
+// body-size carrier.
+const defaultUserMaxLen = 512
+
+// UserValidator enforces a string type and a byte-length cap on the OpenAI Chat Completions
+// `user` field. The field has no inference-side semantics (vLLM ignores it) — clients send
+// it for abuse-tracking and observability. Type-checking at the gateway boundary catches
+// garbage payloads (`user: 12345`, `user: {...}`) early, and the length cap keeps the field
+// from being abused as an unbounded payload carrier despite its no-op upstream behavior.
+type UserValidator struct {
+	MaxLen int
+}
+
+func (v UserValidator) Validate(document map[string]any) error {
+	raw, exists := document["user"]
+	if !exists {
+		return nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return fmt.Errorf("%w: must be a string", ErrUserShape)
+	}
+	maxLen := v.MaxLen
+	if maxLen == 0 {
+		maxLen = defaultUserMaxLen
+	}
+	if len(s) > maxLen {
+		return fmt.Errorf("%w: %d > %d", ErrUserLength, len(s), maxLen)
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/user_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/user_test.go
@@ -1,0 +1,60 @@
+package paramvalidators
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserValidatorAccepts(t *testing.T) {
+	v := UserValidator{}
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "absent", body: `{"messages":[]}`},
+		{name: "empty string", body: `{"user":""}`},
+		{name: "typical openai shape", body: `{"user":"user_abc123"}`},
+		{name: "uuid", body: `{"user":"550e8400-e29b-41d4-a716-446655440000"}`},
+		{name: "email shape", body: `{"user":"user@example.com"}`},
+		{name: "base64-ish", body: `{"user":"YWJjZA+/=="}`},
+		{name: "session id with colons", body: `{"user":"langchain:session:42"}`},
+		{name: "exactly at length", body: `{"user":"` + strings.Repeat("x", 512) + `"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, v.Validate(parseDocument(t, tt.body)))
+		})
+	}
+}
+
+func TestUserValidatorRejects(t *testing.T) {
+	v := UserValidator{}
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{name: "number", body: `{"user":42}`, wantErr: ErrUserShape},
+		{name: "boolean", body: `{"user":true}`, wantErr: ErrUserShape},
+		{name: "object", body: `{"user":{}}`, wantErr: ErrUserShape},
+		{name: "array", body: `{"user":[]}`, wantErr: ErrUserShape},
+		{name: "null", body: `{"user":null}`, wantErr: ErrUserShape},
+		{name: "length over limit", body: `{"user":"` + strings.Repeat("x", 513) + `"}`, wantErr: ErrUserLength},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Validate(parseDocument(t, tt.body))
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestUserValidatorRespectsCustomLimit(t *testing.T) {
+	v := UserValidator{MaxLen: 8}
+	require.NoError(t, v.Validate(parseDocument(t, `{"user":"abcdefgh"}`)))
+	err := v.Validate(parseDocument(t, `{"user":"abcdefghi"}`))
+	require.ErrorIs(t, err, ErrUserLength)
+}

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -593,6 +593,32 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 					MaxPatternLen: 512,
 				},
 			}),
+		// OpenAI Chat Completions standard observability fields. No inference-side
+		// semantics on the vLLM upstream; clients send them for end-user tracking,
+		// distributed tracing, agent control, and streaming token accounting.
+		// `user`: type-checked and byte-capped at the gateway boundary so a non-string
+		// payload (number, object, …) and an over-long string are caught early instead
+		// of being forwarded as a no-op carrier under the 10 MiB body cap.
+		newParameter("user").
+			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
+				Validator: paramvalidators.UserValidator{},
+			}),
+		newParameter("parallel_tool_calls"),
+		// metadata: OpenAI bounds it to 16 keys × 64-char keys × 512-char string values;
+		// we enforce the same bounds at the gateway boundary as a free defensive cap.
+		newParameter("metadata").
+			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
+				Validator: paramvalidators.MetadataValidator{},
+			}),
+		// stream_options: sub-field whitelist. Only `include_usage` survives;
+		// `continuous_usage_stats` is stripped to neutralize vLLM-project/vllm#9028
+		// (per-chunk usage counter is wrong under chunked prefill), and any other /
+		// future sub-field is default-stripped. If nothing remains the field is dropped
+		// so the upstream does not receive an empty `{}` object.
+		newParameter("stream_options").
+			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
+				Validator: paramvalidators.StreamOptionsValidator{},
+			}),
 		newParameter("logprobs").
 			withRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: true}),
 		newParameter("top_logprobs").

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -1239,3 +1239,72 @@ func TestNormalizeChatRequestRejectsBodyAtNestingLimit(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "request nesting depth exceeds limit")
 }
+
+// End-to-end coverage that the four OpenAI Chat Completions observability fields survive
+// the catalog's unknown-key gate, with `metadata` bounded and `stream_options` sanitized.
+// Without these catalog entries the gate would 400 every legitimate OpenAI-built client
+// (official SDK with `user=...`, LangChain with `metadata={...}`, any streaming client
+// asking for final-chunk usage).
+func TestNormalizeChatRequestAcceptsOpenAIObservabilityFields(t *testing.T) {
+	body := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"user":"alice",
+		"metadata":{"trace_id":"abc","span_id":"def"},
+		"parallel_tool_calls":false,
+		"stream_options":{"include_usage":true}
+	}`)
+	out, _, err := normalizeChatRequest(body)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.Equal(t, "alice", raw["user"])
+	require.Equal(t, map[string]any{"trace_id": "abc", "span_id": "def"}, raw["metadata"])
+	require.Equal(t, false, raw["parallel_tool_calls"])
+	so, ok := raw["stream_options"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, true, so["include_usage"])
+}
+
+// Pipeline-level coverage of StreamOptionsValidator: `continuous_usage_stats` drops out
+// (vLLM-project/vllm#9028), `include_usage` survives.
+func TestNormalizeChatRequestStripsContinuousUsageStats(t *testing.T) {
+	body := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"stream_options":{"include_usage":true,"continuous_usage_stats":true}
+	}`)
+	out, _, err := normalizeChatRequest(body)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	so := raw["stream_options"].(map[string]any)
+	require.Equal(t, true, so["include_usage"])
+	require.NotContains(t, so, "continuous_usage_stats")
+}
+
+// Pipeline-level coverage: stream_options that empties out after sanitize is dropped.
+func TestNormalizeChatRequestDropsEmptiedStreamOptions(t *testing.T) {
+	body := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"stream_options":{"continuous_usage_stats":true}
+	}`)
+	out, _, err := normalizeChatRequest(body)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.NotContains(t, raw, "stream_options")
+}
+
+// Pipeline-level coverage of MetadataValidator: too many keys / oversize values are
+// rejected.
+func TestNormalizeChatRequestRejectsOversizedMetadata(t *testing.T) {
+	body := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"metadata":{"k":"` + strings.Repeat("v", 513) + `"}
+	}`)
+	_, _, err := normalizeChatRequest(body)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "metadata")
+}

--- a/devshard/docs/supported-params.md
+++ b/devshard/docs/supported-params.md
@@ -28,6 +28,9 @@ Anything not on this whitelist does not reach the model. That is the contract.
 
 **Shape validators**:
 - `thinking` — `paramvalidators.ThinkingValidator`
+- `stream_options` — `paramvalidators.StreamOptionsValidator` (whitelist `include_usage`; strip `continuous_usage_stats` for vLLM-project/vllm#9028 + any other sub-field; drop the field if it empties out)
+- `metadata` — `paramvalidators.MetadataValidator` (OpenAI bounds: ≤16 keys × 64-char keys × 512-char string values)
+- `user` — `paramvalidators.UserValidator` (must be a string, byte-length ≤ 512)
 
 **Length / size caps**:
 - `messages` (≤2048) · `stop` (≤16/256B) · `stop_token_ids` (≤64) · `bad_words` (≤64/128B) · `logit_bias` map (≤1024 entries)
@@ -47,14 +50,13 @@ Anything not on this whitelist does not reach the model. That is the contract.
 - Body-level: `MaxRequestNestingDepth=32`, `MaxChatRequestBodySize=10 MiB`
 
 **Pass-through (safe by type contract)**:
-- `model` · `stream` · `skip_special_tokens` · `detokenize`
+- `model` · `stream` · `skip_special_tokens` · `detokenize` · `parallel_tool_calls`
 
 ### ❌ Open / not yet implemented
 
 Field-level additions that Kimi K2/K2.6 actually accepts on the wire (per Moonshot's [chat reference](https://platform.kimi.ai/docs/api/chat) and [K2.6 quickstart](https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart)):
 
 - **`frequency_penalty`, `presence_penalty`** — Kimi accepts these but **for K2.6 only `0.0`** is valid (any other value is rejected upstream; that's a model-side constraint, not a security one). Easy add via `SanitizeFloatParameterHandler` with range `[-2, 2]`. Smallest concrete next step.
-- **`stream_options`** — Kimi accepts `{"include_usage": bool}`. Note: Kimi emits `usage` in *each choice's end-block*, not only in the trailing chunk (divergence from OpenAI). Add as a shape validator.
 - **`prompt_cache_key`** — string. Kimi's first-class context-cache tag (cheaper re-prompts). Add with a string-length cap (e.g. ≤256 B).
 - **`safety_identifier`** — Kimi's analogue to OpenAI's `user`. String pass-through; add over `user` (which Kimi does not document).
 - **`messages[].reasoning_content`** — *required* on assistant turns during multi-step tool-calling when thinking is enabled. The message validator already does NOT reject unknown assistant-message fields (only `tool_call_id` is disallowed on assistant), so this already passes through. Just document the contract; no code change needed.
@@ -88,7 +90,7 @@ These constraints are enforced by the vLLM engine configuration, not the gateway
 
 - **`model` length cap** — redundant with 10 MiB body cap; minimal benefit on a routing-lookup field.
 - **`extra_body` / `extra_headers`** — open-ended escape hatches; breaks the strict-whitelist contract.
-- **Provider-specific fields without vLLM semantics**: `metadata`, `service_tier`, `store`, `parallel_tool_calls`, `reasoning_effort`, `reasoning`, `thinking_config`, `enable_thinking`, `user`, etc. See "Unsupported parameters" below for the full categorized list. (Note: `prompt_cache_key`, `stream_options`, `safety_identifier`, `messages[].reasoning_content` were moved to "❌ Open" above — Kimi K2.6 actually supports them.)
+- **Provider-specific fields without vLLM semantics**: `service_tier`, `store`, `reasoning_effort`, `reasoning`, `thinking_config`, `enable_thinking`, etc. See "Unsupported parameters" below for the full categorized list. (Note: `user`, `metadata`, `parallel_tool_calls`, and `stream_options` are now in the Supported table above — they are OpenAI Chat Completions standard observability fields with no inference-side semantics and no DoS vector; rejecting them broke every OpenAI-built client without security gain. `prompt_cache_key`, `safety_identifier`, `messages[].reasoning_content` remain in "❌ Open" — Kimi K2.6 actually supports them, pending validator work.)
 - **vLLM-native structured-output bypass** (`guided_json`, `guided_regex`, `guided_grammar`, `guided_choice`, `enforced_tokens`) — would need their own validators; `response_format` covers the same intent with bounds.
 - **Special-token literal stripping in `messages[].content`** (CVE-2026-44222) — text like `<|vision_start|>` crashes vision-language models with an `IndexError`. Kimi-K2.6 is text-only so we are not exposed today. If we route to a VL model in the future, add a content sanitizer at this layer. ([advisory](https://github.com/vllm-project/vllm/security/advisories/GHSA-hpv8-x276-m59f))
 
@@ -122,6 +124,10 @@ These constraints are enforced by the vLLM engine configuration, not the gateway
 | `logprobs` | bool | PostLimits force | Forced to `true` for the gateway's observability pipeline regardless of what the client sent. |
 | `top_logprobs` | int range | PostLimits force | Forced to `5` for the same reason. |
 | `response_format` | object | PreValidation validate (`paramvalidators.ResponseFormatValidator`) | Accepted with bounds. `type` must be one of `text` / `json_object` / `json_schema`. For `json_schema`, the schema is walked once and rejected if depth > 5, nodes > 128, branch arms (anyOf/oneOf/allOf) > 16, enum > 256, serialized size > 16 KiB, or contains `$ref` / `$defs` / `definitions`. Every schema node's `type` must be a JSON-Schema primitive (`string`/`number`/`integer`/`object`/`boolean`/`array`/`null` or an array of those); `pattern` is byte-capped at 512 B and must compile as a regex (defuses CVE-2025-48944). |
+| `user` | string | PreValidation validate (`paramvalidators.UserValidator`) | OpenAI-standard end-user identifier for abuse tracking; no inference-side semantics on the vLLM upstream, ignored on the wire. Must be a string; byte-length ≤ 512 (covers production identifiers — `user_<random>`, UUIDs, hashed ids, email-shaped, framework session ids — while preventing the field from being used as a 10 MiB body-size carrier). |
+| `metadata` | object | PreValidation validate (`paramvalidators.MetadataValidator`) | OpenAI-standard tracking object (LangSmith, distributed tracing, A/B tagging). Bounded to ≤16 keys × 64-char keys × 512-char string values — the same limits the OpenAI API itself enforces. Values must be strings; any other type rejected. |
+| `parallel_tool_calls` | bool | — | Pass-through. OpenAI-standard tool-calling control. Some vLLM versions honor it, some ignore it — the client opted in to that behavioral divergence; no DoS surface. |
+| `stream_options` | object | PreValidation validate (`paramvalidators.StreamOptionsValidator`) | Sub-field whitelist. Only `include_usage` survives — the OpenAI-documented opt-in for a final-chunk `usage` object, required by any streaming client that needs token accounting. `continuous_usage_stats` is stripped (triggers vLLM-project/vllm#9028: per-chunk usage counter is wrong under chunked prefill). Any other / future sub-field is also stripped. If the object empties out, the field is dropped entirely so it never reaches the upstream as `{}`. |
 
 ### Messages contract (recap)
 
@@ -144,9 +150,9 @@ Grouped by why the field is off:
 | --- | --- | --- | --- |
 | Sampling penalties | `frequency_penalty`, `presence_penalty` | Kilo, OpenClaw, OpenAI canonical | vLLM supports them. Trivially safe to add via `SanitizeFloatParameterHandler` with range `[-2, 2]`. Pending only because we have not validated end-to-end on the vLLM build we run. |
 | Structured-output (non-`response_format`) | `guided_json`, `guided_regex`, `guided_grammar`, `guided_choice`, `enforced_tokens`, `structured_outputs` | vLLM-native | Bypasses the response_format safety bounds. Same grammar-compiler attack surface; would need its own validator. |
-| Tool-calling extensions | `parallel_tool_calls`, `tool_choice="required"` | OpenClaw, OpenAI | Provider compatibility differs and `required` is rejected by upstream contract on the vLLM path. |
-| Routing / metadata | `metadata`, `service_tier`, `user`, `extra_body`, `extra_headers`, `provider`, `plugins`, `tags`, `seed_override` | Hermes, OpenClaw, Kilo | Vendor-specific; no inference-side meaning for vLLM. `extra_body` / `extra_headers` are open-ended escape hatches and break the whitelist contract. |
-| Caching / observability | `store`, `prompt_cache_key`, `stream_options` | OpenAI / OpenClaw / Hermes | OpenAI-specific (`store`, `prompt_cache_key`) or streaming-format hint (`stream_options`). Could be safely stripped before forwarding, but currently rejected to avoid silent semantic drift in usage accounting. |
+| Tool-calling extensions | `tool_choice="required"` | OpenClaw, OpenAI | `required` is rejected by upstream contract on the vLLM path (cost-amplifier + engine-wedge on Kimi-K2). `parallel_tool_calls` is now passthrough — see Supported table. |
+| Routing / metadata | `service_tier`, `extra_body`, `extra_headers`, `provider`, `plugins`, `tags`, `seed_override` | Hermes, OpenClaw, Kilo | Vendor-specific. `extra_body` / `extra_headers` are open-ended escape hatches and break the whitelist contract. (`user` and `metadata` were moved to Supported — they are OpenAI Chat Completions standard observability fields, not vendor-specific.) |
+| Caching | `store`, `prompt_cache_key` | OpenAI / OpenClaw | OpenAI-specific server-side state hints. No vLLM semantics. (`stream_options` was moved to Supported with a sub-field whitelist validator — it is required for OpenAI-compatible streaming-with-usage and the only known-bad sub-field, `continuous_usage_stats`, is stripped at the gateway.) |
 | Reasoning (non-vLLM-native) | `reasoning_effort`, `reasoning` (object), `thinking_config`, `enable_thinking` | Hermes (multi-provider), OpenClaw (Qwen/Kimi), Gemini | Use `thinking` + `chat_template_kwargs` instead. Provider-specific reasoning fields are wrapper concerns, not what vLLM speaks. |
 | Provider-specific extras | `extra_body.vl_high_resolution_images` (Qwen), `extra_body.provider` (OpenRouter), `extra_body.tags` (Nous), `extra_body.thinking_config` (Gemini), `extra_body.plugins` (OpenRouter), `messages[].reasoning_content` (Kimi multi-turn replay), `tools[].function.strict` (OpenAI strict schema), `chat_template_kwargs.preserve_thinking` (Qwen wrapper) | Hermes, OpenClaw | Single-vendor attribution / wrapping fields. No vLLM equivalent. |
 


### PR DESCRIPTION
## Summary

After #1174's strict-whitelist gate and #1180's `paramvalidators` framework, the catalog rejects four OpenAI Chat Completions standard fields that every OpenAI-built client sends: `user`, `metadata`, `parallel_tool_calls`, `stream_options`. This PR moves them into the supported set as bounded passthroughs / sanitizers, using the same `paramvalidators` framework #1180 introduced.

These four fields are **observability/tracking**, not security-relevant — no inference-side semantics on the vLLM upstream, no DoS vector, no parser invoked. Treating them with the same strict-reject as `response_format.json_schema.schema` was over-application of the principle: it broke every legitimate OpenAI-compatible client (official SDK with `user=...`, LangChain `metadata={...}`, agents with `parallel_tool_calls`, any streaming client asking for final-chunk token usage via `stream_options.include_usage`) without preventing any attack.

## What changes

### Two new validators

- **`paramvalidators.StreamOptionsValidator`** — sub-field whitelist. Only `include_usage` survives. `continuous_usage_stats` is stripped (vLLM-project/vllm#9028 — per-chunk usage counter is wrong under chunked prefill). Any other / future sub-field is also stripped. If the object empties out, the field is dropped so the upstream never receives `{}`. The validator mutates the live document via `Raw()` — the existing in-place sanitize pattern.
- **`paramvalidators.MetadataValidator`** — OpenAI-documented bounds: ≤16 keys × 64-char keys × 512-char string values. Non-string values rejected. Sentinel errors (`ErrMetadataShape`, `ErrMetadataKeyCount`, `ErrMetadataKey`, `ErrMetadataValue`) match #1180's error-style.

### Four catalog entries

Registered alongside the other passthrough fields, before the `logprobs` force rules:

```go
newParameter("user"),
newParameter("parallel_tool_calls"),
newParameter("metadata").
    withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
        Validator: paramvalidators.MetadataValidator{},
    }),
newParameter("stream_options").
    withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
        Validator: paramvalidators.StreamOptionsValidator{},
    }),
```

### Spec doc update

`devshard/docs/supported-params.md` moves the four fields from the "Unsupported parameters" table to the "Supported parameters" table, with per-field rationale documenting why these are OpenAI-standard observability fields and not provider-specific. The "🚫 Won't add" note is updated. `tool_choice="required"` rejection rationale stays separate from `parallel_tool_calls` (different fields, different reasons).

## Tests

- `paramvalidators/stream_options_test.go` (8 cases): wrapper shape accepts/rejects, strips `continuous_usage_stats`, strips unknown sub-field, drops empty object, drops empty input.
- `paramvalidators/metadata_test.go` (15+ cases): wrapper shape, key count, key length, value type, value length boundaries; custom-limits respect.
- `request_filters_test.go` (4 cases): pipeline-level end-to-end coverage that all four fields survive the catalog gate, sanitizer mutates the forwarded body correctly, metadata bound enforcement reaches the pipeline error path.

## Why this categorization is right

OpenAI's own spec, Kilo Gateway, OpenRouter, Together AI, Azure OpenAI, and all three reference agent clients (OpenClaw, Hermes, Kilo) accept these four fields. Gonka rejecting them would be the outlier:

| Gateway | `user` | `metadata` | `parallel_tool_calls` | `stream_options` |
|---|---|---|---|---|
| OpenAI direct | accept | accept | accept | accept |
| Azure OpenAI | accept | accept | accept | accept |
| OpenRouter | accept | accept | accept | accept |
| Together AI | accept | accept | accept | accept |
| Kilo Gateway | accept | — | — | auto-injects `{include_usage: true}` |
| Gonka (this PR) | passthrough | bounded passthrough | passthrough | sanitized passthrough |

Security stays intact — #1180's bounds on `response_format`, `tools[].function.parameters`, `chat_template_kwargs`, body-level depth pre-scan, length caps, `pattern` regex compile-check, CVE coverage — all unchanged.

## Risk

Low. Two new validators (~130 LOC) following the existing `paramvalidators` pattern, four catalog entries, ~70 LOC of pipeline tests. No existing handler modified. `metadata` enforces strictly tighter bounds than the body-level cap, so it cannot make a previously-rejected request succeed.

## Test plan

- [x] `go test ./cmd/devshardctl/paramvalidators/` — green (new validators).
- [x] `go test ./cmd/devshardctl/...` — full suite green (~294s).
- [ ] Post-deploy probe against the real devshardctl binary on the Kimi-K2.6 stand: confirm `stream_options.include_usage` reaches the upstream and elicits a final-chunk `usage` object; confirm `user` / `metadata` / `parallel_tool_calls` are forwarded; confirm `continuous_usage_stats` is stripped before vLLM sees it.
