### PR TITLE
feat(devshard): paramvalidators subpackage + CVE-class defenses for chat completions

### DIFF
--- a/devshard/cmd/devshardctl/paramvalidators/chat_template_kwargs.go
+++ b/devshard/cmd/devshardctl/paramvalidators/chat_template_kwargs.go
@@ -1,0 +1,45 @@
+package paramvalidators
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrChatTemplateKwargsShape covers the wrapper-level rejection: chat_template_kwargs must
+// be a JSON object. Bounds rejections (depth/nodes/size) come back as the shared ErrSchema*
+// sentinels via ObjectBounds.
+var ErrChatTemplateKwargsShape = errors.New("chat_template_kwargs: invalid wrapper shape")
+
+// ChatTemplateKwargsValidator bounds the depth/breadth/size of chat_template_kwargs before
+// vLLM hands the object to Jinja's chat-template renderer. Unbounded structure can stall
+// rendering and inflate memory on the inference node. Unlike response_format.json_schema,
+// this is NOT a JSON Schema -- there is no $ref ban, no anyOf/enum semantics. Plain
+// depth/nodes/size only.
+type ChatTemplateKwargsValidator struct {
+	MaxDepth int
+	MaxSize  int
+	MaxNodes int
+}
+
+func (v ChatTemplateKwargsValidator) Validate(document map[string]any) error {
+	raw, exists := document["chat_template_kwargs"]
+	if !exists {
+		return nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: must be an object", ErrChatTemplateKwargsShape)
+	}
+	bounds := ObjectBounds{
+		MaxDepth: v.MaxDepth,
+		MaxSize:  v.MaxSize,
+		MaxNodes: v.MaxNodes,
+	}
+	if err := bounds.Walk(obj); err != nil {
+		return fmt.Errorf("chat_template_kwargs: %w", err)
+	}
+	if err := bounds.CheckSize(obj); err != nil {
+		return fmt.Errorf("chat_template_kwargs: %w", err)
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/chat_template_kwargs.go
+++ b/devshard/cmd/devshardctl/paramvalidators/chat_template_kwargs.go
@@ -10,11 +10,39 @@ import (
 // sentinels via ObjectBounds.
 var ErrChatTemplateKwargsShape = errors.New("chat_template_kwargs: invalid wrapper shape")
 
+// ErrChatTemplateKwargsForbiddenKey marks an attempt to set a top-level key that overrides
+// `apply_hf_chat_template()`'s positional arguments (not a template variable). This is the
+// CVE-2025-61620 / CVE-2025-62426 class -- e.g. `chat_template_kwargs: {"chat_template": "..."}`
+// smuggles a malicious Jinja template, and `{"tokenize": true}` stalls the request handler
+// in synchronous tokenization.
+var ErrChatTemplateKwargsForbiddenKey = errors.New("chat_template_kwargs: forbidden key (overrides apply_hf_chat_template positional argument)")
+
+// forbiddenChatTemplateKwargsKeys are top-level keys that, when set via
+// chat_template_kwargs, override `apply_hf_chat_template(conversation, chat_template,
+// add_generation_prompt, continue_final_message, tokenize, padding, truncation, max_length,
+// return_tensors, return_dict, tools, documents, **kwargs)` positional arguments instead of
+// becoming template variables. They are all known CVE vectors when reachable from client
+// input. `add_generation_prompt` is intentionally allowed -- it is a legitimate knob clients
+// sometimes pass and not a code-injection vector.
+var forbiddenChatTemplateKwargsKeys = map[string]struct{}{
+	"chat_template":          {}, // CVE-2025-61620: arbitrary Jinja template
+	"tokenize":               {}, // CVE-2025-62426: stalls request handler
+	"tools":                  {}, // overrides the request's tools list
+	"documents":              {}, // overrides documents context
+	"conversation":           {}, // overrides messages list
+	"continue_final_message": {},
+	"padding":                {},
+	"truncation":             {},
+	"max_length":             {},
+	"return_tensors":         {},
+	"return_dict":            {},
+}
+
 // ChatTemplateKwargsValidator bounds the depth/breadth/size of chat_template_kwargs before
-// vLLM hands the object to Jinja's chat-template renderer. Unbounded structure can stall
-// rendering and inflate memory on the inference node. Unlike response_format.json_schema,
-// this is NOT a JSON Schema -- there is no $ref ban, no anyOf/enum semantics. Plain
-// depth/nodes/size only.
+// vLLM hands the object to Jinja's chat-template renderer, and rejects keys that override
+// `apply_hf_chat_template()` positional arguments instead of feeding template variables.
+// Unlike response_format.json_schema, the body is NOT a JSON Schema -- no $ref ban, no
+// anyOf/enum semantics. Plain depth/nodes/size plus the forbidden-key filter.
 type ChatTemplateKwargsValidator struct {
 	MaxDepth int
 	MaxSize  int
@@ -29,6 +57,11 @@ func (v ChatTemplateKwargsValidator) Validate(document map[string]any) error {
 	obj, ok := raw.(map[string]any)
 	if !ok {
 		return fmt.Errorf("%w: must be an object", ErrChatTemplateKwargsShape)
+	}
+	for key := range obj {
+		if _, forbidden := forbiddenChatTemplateKwargsKeys[key]; forbidden {
+			return fmt.Errorf("%w: %q", ErrChatTemplateKwargsForbiddenKey, key)
+		}
 	}
 	bounds := ObjectBounds{
 		MaxDepth: v.MaxDepth,

--- a/devshard/cmd/devshardctl/paramvalidators/chat_template_kwargs_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/chat_template_kwargs_test.go
@@ -26,6 +26,7 @@ func TestChatTemplateKwargsValidatorAccepts(t *testing.T) {
 		{name: "empty object", body: `{"chat_template_kwargs":{}}`},
 		{name: "kimi thinking shape", body: `{"chat_template_kwargs":{"thinking":true}}`},
 		{name: "qwen enable_thinking + preserve", body: `{"chat_template_kwargs":{"enable_thinking":true,"preserve_thinking":false}}`},
+		{name: "add_generation_prompt is allowed", body: `{"chat_template_kwargs":{"add_generation_prompt":true}}`},
 		{name: "nested at depth limit", body: `{"chat_template_kwargs":` + nestedObjectChain(5) + `}`},
 		{name: "array of strings", body: `{"chat_template_kwargs":{"tags":["a","b","c"]}}`},
 	}
@@ -50,6 +51,17 @@ func TestChatTemplateKwargsValidatorRejects(t *testing.T) {
 		{name: "deep recursion attack", body: `{"chat_template_kwargs":` + nestedObjectChain(200) + `}`, wantErr: ErrSchemaDepth},
 		{name: "node count exceeds limit", body: `{"chat_template_kwargs":` + flatPropertiesObject(200) + `}`, wantErr: ErrSchemaNodes},
 		{name: "size exceeds limit", body: `{"chat_template_kwargs":{"x":"` + strings.Repeat("a", 17*1024) + `"}}`, wantErr: ErrSchemaSize},
+		// CVE-2025-61620: Jinja template smuggling via chat_template key
+		{name: "forbidden chat_template key", body: `{"chat_template_kwargs":{"chat_template":"{% for x in range(99999) %}{% endfor %}"}}`, wantErr: ErrChatTemplateKwargsForbiddenKey},
+		// CVE-2025-62426: synchronous tokenization stalls handler
+		{name: "forbidden tokenize key", body: `{"chat_template_kwargs":{"tokenize":true}}`, wantErr: ErrChatTemplateKwargsForbiddenKey},
+		// Other positional-arg overrides
+		{name: "forbidden tools key", body: `{"chat_template_kwargs":{"tools":[]}}`, wantErr: ErrChatTemplateKwargsForbiddenKey},
+		{name: "forbidden documents key", body: `{"chat_template_kwargs":{"documents":[]}}`, wantErr: ErrChatTemplateKwargsForbiddenKey},
+		{name: "forbidden conversation key", body: `{"chat_template_kwargs":{"conversation":[]}}`, wantErr: ErrChatTemplateKwargsForbiddenKey},
+		{name: "forbidden continue_final_message", body: `{"chat_template_kwargs":{"continue_final_message":true}}`, wantErr: ErrChatTemplateKwargsForbiddenKey},
+		{name: "forbidden max_length", body: `{"chat_template_kwargs":{"max_length":1024}}`, wantErr: ErrChatTemplateKwargsForbiddenKey},
+		{name: "forbidden alongside legit", body: `{"chat_template_kwargs":{"thinking":true,"chat_template":"bomb"}}`, wantErr: ErrChatTemplateKwargsForbiddenKey},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/devshard/cmd/devshardctl/paramvalidators/chat_template_kwargs_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/chat_template_kwargs_test.go
@@ -1,0 +1,87 @@
+package paramvalidators
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func defaultChatTemplateKwargsValidator() ChatTemplateKwargsValidator {
+	return ChatTemplateKwargsValidator{
+		MaxDepth: 5,
+		MaxSize:  16 * 1024,
+		MaxNodes: 128,
+	}
+}
+
+func TestChatTemplateKwargsValidatorAccepts(t *testing.T) {
+	v := defaultChatTemplateKwargsValidator()
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "absent", body: `{"messages":[]}`},
+		{name: "empty object", body: `{"chat_template_kwargs":{}}`},
+		{name: "kimi thinking shape", body: `{"chat_template_kwargs":{"thinking":true}}`},
+		{name: "qwen enable_thinking + preserve", body: `{"chat_template_kwargs":{"enable_thinking":true,"preserve_thinking":false}}`},
+		{name: "nested at depth limit", body: `{"chat_template_kwargs":` + nestedObjectChain(5) + `}`},
+		{name: "array of strings", body: `{"chat_template_kwargs":{"tags":["a","b","c"]}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := parseDocument(t, tt.body)
+			require.NoError(t, v.Validate(doc))
+		})
+	}
+}
+
+func TestChatTemplateKwargsValidatorRejects(t *testing.T) {
+	v := defaultChatTemplateKwargsValidator()
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{name: "wrapper not object", body: `{"chat_template_kwargs":"hi"}`, wantErr: ErrChatTemplateKwargsShape},
+		{name: "wrapper is array", body: `{"chat_template_kwargs":[1,2]}`, wantErr: ErrChatTemplateKwargsShape},
+		{name: "depth exceeds limit", body: `{"chat_template_kwargs":` + nestedObjectChain(6) + `}`, wantErr: ErrSchemaDepth},
+		{name: "deep recursion attack", body: `{"chat_template_kwargs":` + nestedObjectChain(200) + `}`, wantErr: ErrSchemaDepth},
+		{name: "node count exceeds limit", body: `{"chat_template_kwargs":` + flatPropertiesObject(200) + `}`, wantErr: ErrSchemaNodes},
+		{name: "size exceeds limit", body: `{"chat_template_kwargs":{"x":"` + strings.Repeat("a", 17*1024) + `"}}`, wantErr: ErrSchemaSize},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := parseDocument(t, tt.body)
+			err := v.Validate(doc)
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+// nestedObjectChain produces {"x": {"x": ... {} }} -- a plain-object chain (no JSON Schema).
+func nestedObjectChain(depth int) string {
+	if depth <= 1 {
+		return `{}`
+	}
+	return `{"x":` + nestedObjectChain(depth-1) + `}`
+}
+
+// flatPropertiesObject is a single object with `count` keys, each mapped to `{}`.
+// Used to exhaust the node-count budget without hitting the depth cap.
+func flatPropertiesObject(count int) string {
+	var b strings.Builder
+	b.WriteByte('{')
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`"k`)
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(`":{}`)
+	}
+	b.WriteByte('}')
+	return b.String()
+}

--- a/devshard/cmd/devshardctl/paramvalidators/response_format.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format.go
@@ -5,28 +5,33 @@
 package paramvalidators
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 )
 
-// Sentinel errors for response_format rejection categories. Wrap them with fmt.Errorf("%w: ...")
-// when adding parameter context (limit values, encountered values); callers can identify the
-// rejection class via errors.Is even when the formatted message changes.
+// Sentinel errors specific to response_format wrapper shape. Schema-walk rejection categories
+// (depth/nodes/size/ref/enum/branch) live in schema_bounds.go as ErrSchema* and are aliased
+// below for backward compatibility with existing call sites and tests.
 var (
 	ErrResponseFormatShape       = errors.New("response_format: invalid wrapper shape")
 	ErrResponseFormatType        = errors.New("response_format.type: missing or unsupported")
 	ErrResponseFormatJSONSchema  = errors.New("response_format.json_schema: invalid wrapper shape")
 	ErrResponseFormatName        = errors.New("response_format.json_schema.name: invalid")
 	ErrResponseFormatSchemaShape = errors.New("response_format.json_schema.schema: invalid shape")
-	ErrResponseFormatSize        = errors.New("response_format.json_schema.schema: serialized size exceeded")
-	ErrResponseFormatDepth       = errors.New("response_format.json_schema.schema: nesting depth exceeded")
-	ErrResponseFormatNodes       = errors.New("response_format.json_schema.schema: node count exceeded")
-	ErrResponseFormatRef         = errors.New("response_format.json_schema.schema: schema reference keyword is forbidden")
-	ErrResponseFormatEnum        = errors.New("response_format.json_schema.schema: enum size exceeded")
-	ErrResponseFormatBranch      = errors.New("response_format.json_schema.schema: schema branch arms exceeded")
+)
+
+// Schema-walk sentinel aliases. Tests can match on either ErrResponseFormatDepth or the
+// underlying ErrSchemaDepth -- they point at the same error value. Prefer ErrSchema* in
+// new code; ErrResponseFormat* is kept so old tests and external callers don't break.
+var (
+	ErrResponseFormatSize   = ErrSchemaSize
+	ErrResponseFormatDepth  = ErrSchemaDepth
+	ErrResponseFormatNodes  = ErrSchemaNodes
+	ErrResponseFormatRef    = ErrSchemaRef
+	ErrResponseFormatEnum   = ErrSchemaEnum
+	ErrResponseFormatBranch = ErrSchemaBranch
 )
 
 // ResponseFormatValidator bounds an OpenAI-compatible response_format payload before it is
@@ -117,89 +122,22 @@ func (v ResponseFormatValidator) validateJSONSchemaWrapper(rf map[string]any) er
 	if !ok {
 		return fmt.Errorf("%w: must be an object", ErrResponseFormatSchemaShape)
 	}
-	// Walk first so depth/nodes/breadth attacks bail out without ever paying for json.Marshal.
-	// json.Marshal is O(input size) and would otherwise serialize attacker-controlled depth-200
-	// payloads in full before we ever reach the depth check.
-	var nodes int
-	if err := v.walkSchema(schema, 1, &nodes); err != nil {
-		return err
+	bounds := SchemaBounds{
+		MaxDepth:  v.MaxDepth,
+		MaxSize:   v.MaxSize,
+		MaxNodes:  v.MaxNodes,
+		MaxBranch: v.MaxBranch,
+		MaxEnum:   v.MaxEnum,
 	}
-	serialized, err := json.Marshal(schema)
-	if err != nil {
-		return fmt.Errorf("%w: cannot be serialized: %v", ErrResponseFormatSchemaShape, err)
+	// Walk first so depth/nodes/breadth attacks bail out without ever paying for json.Marshal
+	// inside CheckSize. json.Marshal is O(input size) and would otherwise serialize an
+	// attacker-controlled depth-200 payload in full before the depth check ever fires.
+	if err := bounds.Walk(schema); err != nil {
+		return fmt.Errorf("response_format.json_schema.schema: %w", err)
 	}
-	if len(serialized) > v.MaxSize {
-		return fmt.Errorf("%w: serialized size exceeds %d bytes", ErrResponseFormatSize, v.MaxSize)
+	if err := bounds.CheckSize(schema); err != nil {
+		return fmt.Errorf("response_format.json_schema.schema: %w", err)
 	}
 	return nil
 }
 
-// walkSchema visits every schema-shaped child of `schema` and applies depth/node/breadth
-// caps and the $ref/$defs/definitions ban. The policy is inverted: instead of an allow-list
-// of JSON-Schema keywords to descend into (which silently grew gaps with every new keyword
-// like `if`/`then`/`contains`/`unevaluatedProperties`/...), we walk EVERY object-valued or
-// array-of-object-valued field, with two narrow exceptions:
-//
-//   - responseFormatDataKeys (enum/const/default/examples/required/dependentRequired):
-//     values are literal data, never schemas. Skipped entirely so attacker-controlled JSON
-//     hidden under them is not chased through.
-//   - responseFormatChildMapKeys (properties/patternProperties/dependentSchemas): values are
-//     maps of name->schema. We descend into each map value as its own child schema rather
-//     than treating the wrapper map as a schema.
-//
-// Unknown JSON keywords with object/array-of-object values are treated as if they could
-// contain schemas. That over-walks slightly (e.g. an attacker's invented key `{"foo": {...}}`
-// costs us one extra node) but never under-walks, which is the property that matters for
-// safely bounding vLLM's grammar compiler. All budgets remain bounded.
-func (v ResponseFormatValidator) walkSchema(schema any, depth int, nodes *int) error {
-	if depth > v.MaxDepth {
-		return fmt.Errorf("%w: limit %d", ErrResponseFormatDepth, v.MaxDepth)
-	}
-	obj, ok := schema.(map[string]any)
-	if !ok {
-		return nil
-	}
-	*nodes++
-	if *nodes > v.MaxNodes {
-		return fmt.Errorf("%w: limit %d", ErrResponseFormatNodes, v.MaxNodes)
-	}
-	for _, forbidden := range forbiddenSchemaKeys {
-		if _, exists := obj[forbidden]; exists {
-			return fmt.Errorf("%w: %q is not allowed", ErrResponseFormatRef, forbidden)
-		}
-	}
-	if enum, ok := obj["enum"].([]any); ok && len(enum) > v.MaxEnum {
-		return fmt.Errorf("%w: limit %d", ErrResponseFormatEnum, v.MaxEnum)
-	}
-	for _, branchKey := range branchSchemaKeys {
-		if arr, ok := obj[branchKey].([]any); ok && len(arr) > v.MaxBranch {
-			return fmt.Errorf("%w: %s limit %d", ErrResponseFormatBranch, branchKey, v.MaxBranch)
-		}
-	}
-	for key, value := range obj {
-		if _, isData := responseFormatDataKeys[key]; isData {
-			continue
-		}
-		switch typed := value.(type) {
-		case map[string]any:
-			if _, isChildMap := responseFormatChildMapKeys[key]; isChildMap {
-				for _, child := range typed {
-					if err := v.walkSchema(child, depth+1, nodes); err != nil {
-						return err
-					}
-				}
-			} else {
-				if err := v.walkSchema(typed, depth+1, nodes); err != nil {
-					return err
-				}
-			}
-		case []any:
-			for _, child := range typed {
-				if err := v.walkSchema(child, depth+1, nodes); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}

--- a/devshard/cmd/devshardctl/paramvalidators/response_format.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format.go
@@ -39,12 +39,13 @@ var (
 // breadth, schema $refs) can crash the upstream grammar compiler, so any violation must
 // reject the request before it leaves the gateway.
 type ResponseFormatValidator struct {
-	MaxDepth   int
-	MaxSize    int
-	MaxNodes   int
-	MaxBranch  int
-	MaxEnum    int
-	MaxNameLen int
+	MaxDepth      int
+	MaxSize       int
+	MaxNodes      int
+	MaxBranch     int
+	MaxEnum       int
+	MaxNameLen    int
+	MaxPatternLen int
 }
 
 var responseFormatNameRegex = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
@@ -123,11 +124,12 @@ func (v ResponseFormatValidator) validateJSONSchemaWrapper(rf map[string]any) er
 		return fmt.Errorf("%w: must be an object", ErrResponseFormatSchemaShape)
 	}
 	bounds := SchemaBounds{
-		MaxDepth:  v.MaxDepth,
-		MaxSize:   v.MaxSize,
-		MaxNodes:  v.MaxNodes,
-		MaxBranch: v.MaxBranch,
-		MaxEnum:   v.MaxEnum,
+		MaxDepth:      v.MaxDepth,
+		MaxSize:       v.MaxSize,
+		MaxNodes:      v.MaxNodes,
+		MaxBranch:     v.MaxBranch,
+		MaxEnum:       v.MaxEnum,
+		MaxPatternLen: v.MaxPatternLen,
 	}
 	// Walk first so depth/nodes/breadth attacks bail out without ever paying for json.Marshal
 	// inside CheckSize. json.Marshal is O(input size) and would otherwise serialize an

--- a/devshard/cmd/devshardctl/paramvalidators/response_format.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format.go
@@ -1,0 +1,205 @@
+// Package paramvalidators hosts pure validators for individual chat-completion request fields.
+// Each validator operates on the decoded request document (map[string]any) without any
+// dependency on the main package's pipeline types, so it can be unit-tested in isolation and
+// composed back into the catalog through a thin adapter.
+package paramvalidators
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Sentinel errors for response_format rejection categories. Wrap them with fmt.Errorf("%w: ...")
+// when adding parameter context (limit values, encountered values); callers can identify the
+// rejection class via errors.Is even when the formatted message changes.
+var (
+	ErrResponseFormatShape       = errors.New("response_format: invalid wrapper shape")
+	ErrResponseFormatType        = errors.New("response_format.type: missing or unsupported")
+	ErrResponseFormatJSONSchema  = errors.New("response_format.json_schema: invalid wrapper shape")
+	ErrResponseFormatName        = errors.New("response_format.json_schema.name: invalid")
+	ErrResponseFormatSchemaShape = errors.New("response_format.json_schema.schema: invalid shape")
+	ErrResponseFormatSize        = errors.New("response_format.json_schema.schema: serialized size exceeded")
+	ErrResponseFormatDepth       = errors.New("response_format.json_schema.schema: nesting depth exceeded")
+	ErrResponseFormatNodes       = errors.New("response_format.json_schema.schema: node count exceeded")
+	ErrResponseFormatRef         = errors.New("response_format.json_schema.schema: schema reference keyword is forbidden")
+	ErrResponseFormatEnum        = errors.New("response_format.json_schema.schema: enum size exceeded")
+	ErrResponseFormatBranch      = errors.New("response_format.json_schema.schema: schema branch arms exceeded")
+)
+
+// ResponseFormatValidator bounds an OpenAI-compatible response_format payload before it is
+// forwarded to vLLM. A pathological json_schema (deep recursion, huge byte size, runaway
+// breadth, schema $refs) can crash the upstream grammar compiler, so any violation must
+// reject the request before it leaves the gateway.
+type ResponseFormatValidator struct {
+	MaxDepth   int
+	MaxSize    int
+	MaxNodes   int
+	MaxBranch  int
+	MaxEnum    int
+	MaxNameLen int
+}
+
+var responseFormatNameRegex = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+// forbiddenSchemaKeys and branchSchemaKeys are walked once per node. Defining them at package
+// scope keeps the slice headers off the per-call allocation path (the literal-in-range form
+// allocates a fresh backing array on every walkSchema invocation).
+var forbiddenSchemaKeys = []string{"$ref", "$defs", "definitions"}
+var branchSchemaKeys = []string{"anyOf", "oneOf", "allOf"}
+
+// responseFormatDataKeys lists JSON-Schema keywords whose values are *literal data*, not
+// child schemas. They must NOT be recursed into; an attacker could otherwise put a deeply
+// nested object inside `default`/`examples`/`const` and have it counted against the schema
+// budget needlessly, or worse, hide structure the walker treats as schema-shaped.
+var responseFormatDataKeys = map[string]struct{}{
+	"enum":              {},
+	"const":             {},
+	"default":           {},
+	"examples":          {},
+	"required":          {},
+	"dependentRequired": {},
+}
+
+// responseFormatChildMapKeys lists keywords whose values are *maps* of name->schema (not a
+// schema themselves). We recurse into each map value as a separate child schema; the wrapper
+// map itself is not counted as a schema node.
+var responseFormatChildMapKeys = map[string]struct{}{
+	"properties":        {},
+	"patternProperties": {},
+	"dependentSchemas":  {},
+}
+
+// Validate inspects the "response_format" entry of the given document. Returns nil if
+// response_format is absent, has type text/json_object, or has a json_schema payload that
+// fits within all configured bounds.
+func (v ResponseFormatValidator) Validate(document map[string]any) error {
+	raw, exists := document["response_format"]
+	if !exists {
+		return nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: must be an object", ErrResponseFormatShape)
+	}
+	typeValue, ok := obj["type"].(string)
+	if !ok || strings.TrimSpace(typeValue) == "" {
+		return fmt.Errorf("%w: must be a non-empty string", ErrResponseFormatType)
+	}
+	switch typeValue {
+	case "text", "json_object":
+		return nil
+	case "json_schema":
+		return v.validateJSONSchemaWrapper(obj)
+	default:
+		return fmt.Errorf("%w: %q is not supported (allowed: text, json_object, json_schema)", ErrResponseFormatType, typeValue)
+	}
+}
+
+func (v ResponseFormatValidator) validateJSONSchemaWrapper(rf map[string]any) error {
+	wrapper, ok := rf["json_schema"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: must be an object", ErrResponseFormatJSONSchema)
+	}
+	name, ok := wrapper["name"].(string)
+	if !ok || name == "" {
+		return fmt.Errorf("%w: must be a non-empty string", ErrResponseFormatName)
+	}
+	if len(name) > v.MaxNameLen {
+		return fmt.Errorf("%w: must be %d characters or fewer", ErrResponseFormatName, v.MaxNameLen)
+	}
+	if !responseFormatNameRegex.MatchString(name) {
+		return fmt.Errorf("%w: must match %s", ErrResponseFormatName, responseFormatNameRegex.String())
+	}
+	schema, ok := wrapper["schema"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: must be an object", ErrResponseFormatSchemaShape)
+	}
+	// Walk first so depth/nodes/breadth attacks bail out without ever paying for json.Marshal.
+	// json.Marshal is O(input size) and would otherwise serialize attacker-controlled depth-200
+	// payloads in full before we ever reach the depth check.
+	var nodes int
+	if err := v.walkSchema(schema, 1, &nodes); err != nil {
+		return err
+	}
+	serialized, err := json.Marshal(schema)
+	if err != nil {
+		return fmt.Errorf("%w: cannot be serialized: %v", ErrResponseFormatSchemaShape, err)
+	}
+	if len(serialized) > v.MaxSize {
+		return fmt.Errorf("%w: serialized size exceeds %d bytes", ErrResponseFormatSize, v.MaxSize)
+	}
+	return nil
+}
+
+// walkSchema visits every schema-shaped child of `schema` and applies depth/node/breadth
+// caps and the $ref/$defs/definitions ban. The policy is inverted: instead of an allow-list
+// of JSON-Schema keywords to descend into (which silently grew gaps with every new keyword
+// like `if`/`then`/`contains`/`unevaluatedProperties`/...), we walk EVERY object-valued or
+// array-of-object-valued field, with two narrow exceptions:
+//
+//   - responseFormatDataKeys (enum/const/default/examples/required/dependentRequired):
+//     values are literal data, never schemas. Skipped entirely so attacker-controlled JSON
+//     hidden under them is not chased through.
+//   - responseFormatChildMapKeys (properties/patternProperties/dependentSchemas): values are
+//     maps of name->schema. We descend into each map value as its own child schema rather
+//     than treating the wrapper map as a schema.
+//
+// Unknown JSON keywords with object/array-of-object values are treated as if they could
+// contain schemas. That over-walks slightly (e.g. an attacker's invented key `{"foo": {...}}`
+// costs us one extra node) but never under-walks, which is the property that matters for
+// safely bounding vLLM's grammar compiler. All budgets remain bounded.
+func (v ResponseFormatValidator) walkSchema(schema any, depth int, nodes *int) error {
+	if depth > v.MaxDepth {
+		return fmt.Errorf("%w: limit %d", ErrResponseFormatDepth, v.MaxDepth)
+	}
+	obj, ok := schema.(map[string]any)
+	if !ok {
+		return nil
+	}
+	*nodes++
+	if *nodes > v.MaxNodes {
+		return fmt.Errorf("%w: limit %d", ErrResponseFormatNodes, v.MaxNodes)
+	}
+	for _, forbidden := range forbiddenSchemaKeys {
+		if _, exists := obj[forbidden]; exists {
+			return fmt.Errorf("%w: %q is not allowed", ErrResponseFormatRef, forbidden)
+		}
+	}
+	if enum, ok := obj["enum"].([]any); ok && len(enum) > v.MaxEnum {
+		return fmt.Errorf("%w: limit %d", ErrResponseFormatEnum, v.MaxEnum)
+	}
+	for _, branchKey := range branchSchemaKeys {
+		if arr, ok := obj[branchKey].([]any); ok && len(arr) > v.MaxBranch {
+			return fmt.Errorf("%w: %s limit %d", ErrResponseFormatBranch, branchKey, v.MaxBranch)
+		}
+	}
+	for key, value := range obj {
+		if _, isData := responseFormatDataKeys[key]; isData {
+			continue
+		}
+		switch typed := value.(type) {
+		case map[string]any:
+			if _, isChildMap := responseFormatChildMapKeys[key]; isChildMap {
+				for _, child := range typed {
+					if err := v.walkSchema(child, depth+1, nodes); err != nil {
+						return err
+					}
+				}
+			} else {
+				if err := v.walkSchema(typed, depth+1, nodes); err != nil {
+					return err
+				}
+			}
+		case []any:
+			for _, child := range typed {
+				if err := v.walkSchema(child, depth+1, nodes); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/response_format.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format.go
@@ -11,27 +11,15 @@ import (
 	"strings"
 )
 
-// Sentinel errors specific to response_format wrapper shape. Schema-walk rejection categories
-// (depth/nodes/size/ref/enum/branch) live in schema_bounds.go as ErrSchema* and are aliased
-// below for backward compatibility with existing call sites and tests.
+// Sentinel errors specific to response_format wrapper shape. Schema-walk rejection
+// categories (depth/nodes/size/ref/enum/branch/type/pattern) live in schema_bounds.go
+// as ErrSchema* and are returned wrapped through here.
 var (
 	ErrResponseFormatShape       = errors.New("response_format: invalid wrapper shape")
 	ErrResponseFormatType        = errors.New("response_format.type: missing or unsupported")
 	ErrResponseFormatJSONSchema  = errors.New("response_format.json_schema: invalid wrapper shape")
 	ErrResponseFormatName        = errors.New("response_format.json_schema.name: invalid")
 	ErrResponseFormatSchemaShape = errors.New("response_format.json_schema.schema: invalid shape")
-)
-
-// Schema-walk sentinel aliases. Tests can match on either ErrResponseFormatDepth or the
-// underlying ErrSchemaDepth -- they point at the same error value. Prefer ErrSchema* in
-// new code; ErrResponseFormat* is kept so old tests and external callers don't break.
-var (
-	ErrResponseFormatSize   = ErrSchemaSize
-	ErrResponseFormatDepth  = ErrSchemaDepth
-	ErrResponseFormatNodes  = ErrSchemaNodes
-	ErrResponseFormatRef    = ErrSchemaRef
-	ErrResponseFormatEnum   = ErrSchemaEnum
-	ErrResponseFormatBranch = ErrSchemaBranch
 )
 
 // ResponseFormatValidator bounds an OpenAI-compatible response_format payload before it is
@@ -142,4 +130,3 @@ func (v ResponseFormatValidator) validateJSONSchemaWrapper(rf map[string]any) er
 	}
 	return nil
 }
-

--- a/devshard/cmd/devshardctl/paramvalidators/response_format_bench_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format_bench_test.go
@@ -6,15 +6,17 @@ import (
 )
 
 // benchValidator returns the production-tuned validator. Reused across benchmarks so we
-// measure the actual configuration that ships, not a synthetic one.
+// measure the actual configuration that ships, not a synthetic one. Keep these constants
+// in sync with the catalog entry in cmd/devshardctl/request_filters_parameters.go.
 func benchValidator() ResponseFormatValidator {
 	return ResponseFormatValidator{
-		MaxDepth:   5,
-		MaxSize:    16 * 1024,
-		MaxNodes:   128,
-		MaxBranch:  16,
-		MaxEnum:    256,
-		MaxNameLen: 64,
+		MaxDepth:      5,
+		MaxSize:       16 * 1024,
+		MaxNodes:      128,
+		MaxBranch:     16,
+		MaxEnum:       256,
+		MaxNameLen:    64,
+		MaxPatternLen: 512,
 	}
 }
 

--- a/devshard/cmd/devshardctl/paramvalidators/response_format_bench_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format_bench_test.go
@@ -1,0 +1,131 @@
+package paramvalidators
+
+import (
+	"strings"
+	"testing"
+)
+
+// benchValidator returns the production-tuned validator. Reused across benchmarks so we
+// measure the actual configuration that ships, not a synthetic one.
+func benchValidator() ResponseFormatValidator {
+	return ResponseFormatValidator{
+		MaxDepth:   5,
+		MaxSize:    16 * 1024,
+		MaxNodes:   128,
+		MaxBranch:  16,
+		MaxEnum:    256,
+		MaxNameLen: 64,
+	}
+}
+
+func BenchmarkResponseFormatValidator_Absent(b *testing.B) {
+	v := benchValidator()
+	doc := parseDocument(b, `{"messages":[{"role":"user","content":"hello"}]}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.Validate(doc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkResponseFormatValidator_TypeText(b *testing.B) {
+	v := benchValidator()
+	doc := parseDocument(b, `{"response_format":{"type":"text"},"messages":[{"role":"user","content":"hello"}]}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.Validate(doc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkResponseFormatValidator_TypeJSONObject(b *testing.B) {
+	v := benchValidator()
+	doc := parseDocument(b, `{"response_format":{"type":"json_object"},"messages":[{"role":"user","content":"hello"}]}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.Validate(doc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkResponseFormatValidator_SimpleSchema(b *testing.B) {
+	v := benchValidator()
+	doc := parseDocument(b, `{"response_format":{"type":"json_schema","json_schema":{"name":"weather_v1","schema":{"type":"object","properties":{"city":{"type":"string"},"temp":{"type":"number"}},"required":["city"]}}},"messages":[{"role":"user","content":"hello"}]}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.Validate(doc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkResponseFormatValidator_AtLimits exercises the worst-case ACCEPTED schema: max depth, near max-nodes.
+// A schema 5 levels deep with a few siblings at each level still fits under the 128-node cap.
+func BenchmarkResponseFormatValidator_AtLimits(b *testing.B) {
+	v := benchValidator()
+	// 5 levels deep, 3 siblings per level: roughly 1 + 3 + 9 + 27 + 81 = 121 nodes <= 128.
+	schema := buildLimitsSchema()
+	body := `{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":` + schema + `}},"messages":[{"role":"user","content":"hello"}]}`
+	doc := parseDocument(b, body)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.Validate(doc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkResponseFormatValidator_RejectsRecursion measures the fast-reject path on the
+// pathological case that motivated the validator. The depth check must fire early at depth 6.
+func BenchmarkResponseFormatValidator_RejectsRecursion(b *testing.B) {
+	v := benchValidator()
+	deep := `{"type":"object"}`
+	for i := 0; i < 200; i++ {
+		deep = `{"type":"object","properties":{"x":` + deep + `}}`
+	}
+	body := `{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":` + deep + `}},"messages":[{"role":"user","content":"hello"}]}`
+	doc := parseDocument(b, body)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.Validate(doc); err == nil {
+			b.Fatal("expected reject")
+		}
+	}
+}
+
+// BenchmarkResponseFormatValidator_RejectsOversized measures the size-gate path.
+func BenchmarkResponseFormatValidator_RejectsOversized(b *testing.B) {
+	v := benchValidator()
+	big := `{"type":"object","properties":{"` + strings.Repeat("a", 17*1024) + `":{"type":"string"}}}`
+	body := `{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":` + big + `}},"messages":[{"role":"user","content":"hello"}]}`
+	doc := parseDocument(b, body)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.Validate(doc); err == nil {
+			b.Fatal("expected reject")
+		}
+	}
+}
+
+func buildLimitsSchema() string {
+	// Recursively build a schema with 3 child properties at each level, 5 levels deep.
+	var build func(depth int) string
+	build = func(depth int) string {
+		if depth <= 0 {
+			return `{"type":"string"}`
+		}
+		child := build(depth - 1)
+		return `{"type":"object","properties":{"a":` + child + `,"b":` + child + `,"c":` + child + `}}`
+	}
+	return build(4) // root + 4 nested = depth 5
+}

--- a/devshard/cmd/devshardctl/paramvalidators/response_format_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format_test.go
@@ -1,0 +1,163 @@
+package paramvalidators
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func defaultResponseFormatValidator() ResponseFormatValidator {
+	return ResponseFormatValidator{
+		MaxDepth:   5,
+		MaxSize:    16 * 1024,
+		MaxNodes:   128,
+		MaxBranch:  16,
+		MaxEnum:    256,
+		MaxNameLen: 64,
+	}
+}
+
+func parseDocument(tb testing.TB, body string) map[string]any {
+	tb.Helper()
+	var raw map[string]any
+	dec := json.NewDecoder(strings.NewReader(body))
+	dec.UseNumber()
+	if err := dec.Decode(&raw); err != nil {
+		tb.Fatalf("parse: %v", err)
+	}
+	return raw
+}
+
+func TestResponseFormatValidatorAccepts(t *testing.T) {
+	v := defaultResponseFormatValidator()
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "absent", body: `{"messages":[]}`},
+		{name: "type text", body: `{"response_format":{"type":"text"}}`},
+		{name: "type json_object", body: `{"response_format":{"type":"json_object"}}`},
+		{name: "json_schema simple", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"weather_v1","schema":{"type":"object","properties":{"city":{"type":"string"},"temp":{"type":"number"}},"required":["city"]}}}}`},
+		{name: "json_schema at depth limit", body: jsonSchemaResponseFormatBody(nestedPropertiesSchema(5))},
+		{name: "json_schema with anyOf at branch limit", body: jsonSchemaResponseFormatBody(`{"anyOf":[` + strings.Repeat(`{"type":"string"},`, 15) + `{"type":"string"}]}`)},
+		{name: "json_schema with enum at limit", body: jsonSchemaResponseFormatBody(bigEnumSchema(256))},
+		{name: "json_schema name with dots dashes underscores", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"abc_DEF-1.2","schema":{"type":"object"}}}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := parseDocument(t, tt.body)
+			require.NoError(t, v.Validate(doc))
+		})
+	}
+}
+
+func TestResponseFormatValidatorRejects(t *testing.T) {
+	v := defaultResponseFormatValidator()
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{name: "response_format not an object", body: `{"response_format":"hi"}`, wantErr: ErrResponseFormatShape},
+		{name: "type missing", body: `{"response_format":{"json_schema":{"name":"r","schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatType},
+		{name: "type empty string", body: `{"response_format":{"type":""}}`, wantErr: ErrResponseFormatType},
+		{name: "unknown type", body: `{"response_format":{"type":"banana"}}`, wantErr: ErrResponseFormatType},
+		{name: "json_schema wrapper missing", body: `{"response_format":{"type":"json_schema"}}`, wantErr: ErrResponseFormatJSONSchema},
+		{name: "json_schema missing name", body: `{"response_format":{"type":"json_schema","json_schema":{"schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatName},
+		{name: "json_schema name has bad chars", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"bad name","schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatName},
+		{name: "json_schema name too long", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"` + strings.Repeat("a", 65) + `","schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatName},
+		{name: "json_schema missing schema", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"r"}}}`, wantErr: ErrResponseFormatSchemaShape},
+		{name: "schema not an object", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":"x"}}}`, wantErr: ErrResponseFormatSchemaShape},
+		{name: "depth exceeds limit", body: jsonSchemaResponseFormatBody(nestedPropertiesSchema(6)), wantErr: ErrResponseFormatDepth},
+		{name: "deep recursion attack", body: jsonSchemaResponseFormatBody(nestedPropertiesSchema(200)), wantErr: ErrResponseFormatDepth},
+		{name: "schema size exceeds 16 KiB", body: jsonSchemaResponseFormatBody(`{"type":"object","properties":{"` + strings.Repeat("a", 17*1024) + `":{"type":"string"}}}`), wantErr: ErrResponseFormatSize},
+		{name: "schema node count exceeds 128", body: jsonSchemaResponseFormatBody(manyPropertiesSchema(200)), wantErr: ErrResponseFormatNodes},
+		{name: "ref not allowed", body: jsonSchemaResponseFormatBody(`{"$ref":"#/foo"}`), wantErr: ErrResponseFormatRef},
+		{name: "defs not allowed", body: jsonSchemaResponseFormatBody(`{"$defs":{"x":{}}}`), wantErr: ErrResponseFormatRef},
+		{name: "definitions not allowed", body: jsonSchemaResponseFormatBody(`{"definitions":{"x":{}}}`), wantErr: ErrResponseFormatRef},
+		{name: "anyOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"anyOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrResponseFormatBranch},
+		{name: "oneOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"oneOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrResponseFormatBranch},
+		{name: "allOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"allOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrResponseFormatBranch},
+		{name: "enum exceeds limit", body: jsonSchemaResponseFormatBody(bigEnumSchema(257)), wantErr: ErrResponseFormatEnum},
+		{name: "ref deep inside properties", body: jsonSchemaResponseFormatBody(`{"type":"object","properties":{"x":{"$ref":"#/y"}}}`), wantErr: ErrResponseFormatRef},
+		// Regression: walker must traverse every schema-valued keyword. Hiding a deep nest or a
+		// $ref under if/then/else/contains/not/propertyNames/unevaluated*/dependentSchemas
+		// previously bypassed the validator.
+		{name: "depth via if chain", body: jsonSchemaResponseFormatBody(nestedIfSchema(200)), wantErr: ErrResponseFormatDepth},
+		{name: "depth via then chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("then", 200)), wantErr: ErrResponseFormatDepth},
+		{name: "depth via else chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("else", 200)), wantErr: ErrResponseFormatDepth},
+		{name: "depth via contains chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("contains", 200)), wantErr: ErrResponseFormatDepth},
+		{name: "depth via not chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("not", 200)), wantErr: ErrResponseFormatDepth},
+		{name: "depth via propertyNames chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("propertyNames", 200)), wantErr: ErrResponseFormatDepth},
+		{name: "depth via unevaluatedProperties chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("unevaluatedProperties", 200)), wantErr: ErrResponseFormatDepth},
+		{name: "ref hidden under if", body: jsonSchemaResponseFormatBody(`{"if":{"$ref":"#/x"}}`), wantErr: ErrResponseFormatRef},
+		{name: "ref hidden under contains", body: jsonSchemaResponseFormatBody(`{"contains":{"$ref":"#/x"}}`), wantErr: ErrResponseFormatRef},
+		{name: "ref hidden under not", body: jsonSchemaResponseFormatBody(`{"not":{"$ref":"#/x"}}`), wantErr: ErrResponseFormatRef},
+		{name: "ref hidden under dependentSchemas", body: jsonSchemaResponseFormatBody(`{"dependentSchemas":{"x":{"$ref":"#/y"}}}`), wantErr: ErrResponseFormatRef},
+		{name: "defs hidden under then", body: jsonSchemaResponseFormatBody(`{"then":{"$defs":{"x":{}}}}`), wantErr: ErrResponseFormatRef},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := parseDocument(t, tt.body)
+			err := v.Validate(doc)
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func jsonSchemaResponseFormatBody(schemaJSON string) string {
+	return `{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":` + schemaJSON + `}}}`
+}
+
+func nestedPropertiesSchema(depth int) string {
+	if depth <= 1 {
+		return `{"type":"object"}`
+	}
+	return `{"type":"object","properties":{"x":` + nestedPropertiesSchema(depth-1) + `}}`
+}
+
+func nestedIfSchema(depth int) string {
+	return nestedKeywordSchema("if", depth)
+}
+
+// nestedKeywordSchema produces a chain of `depth` schemas nested through the given JSON-Schema
+// keyword. Used to assert the walker enters every schema-valued keyword, not just the ones
+// it explicitly recognized in its early implementation.
+func nestedKeywordSchema(keyword string, depth int) string {
+	if depth <= 1 {
+		return `{"type":"object"}`
+	}
+	return `{"` + keyword + `":` + nestedKeywordSchema(keyword, depth-1) + `}`
+}
+
+func manyPropertiesSchema(count int) string {
+	var b strings.Builder
+	b.WriteString(`{"properties":{`)
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`"k`)
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(`":{}`)
+	}
+	b.WriteString(`}}`)
+	return b.String()
+}
+
+func bigEnumSchema(n int) string {
+	var b strings.Builder
+	b.WriteString(`{"enum":[`)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.Itoa(i))
+	}
+	b.WriteString(`]}`)
+	return b.String()
+}

--- a/devshard/cmd/devshardctl/paramvalidators/response_format_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format_test.go
@@ -50,6 +50,11 @@ func TestResponseFormatValidatorAccepts(t *testing.T) {
 		{name: "schema type as array of primitives", body: jsonSchemaResponseFormatBody(`{"type":["string","null"]}`)},
 		// A reasonable regex pattern under the length cap compiles and is accepted.
 		{name: "schema with valid pattern", body: jsonSchemaResponseFormatBody(`{"type":"string","pattern":"^[a-zA-Z0-9_-]+$"}`)},
+		// Co-boundary: hit both MaxDepth=5 and MaxNodes=128 simultaneously. 4 chain levels
+		// + 124 leaf properties = 128 nodes, leaves sit at depth 5.
+		{name: "depth and nodes both at limit", body: jsonSchemaResponseFormatBody(coBoundarySchema(4, 124))},
+		// Size boundary: exactly MaxSize=16384 bytes after json.Marshal. > MaxSize rejects.
+		{name: "marshalled size exactly at limit", body: jsonSchemaResponseFormatBody(schemaOfMarshalledSize(t, 16*1024))},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -76,33 +81,38 @@ func TestResponseFormatValidatorRejects(t *testing.T) {
 		{name: "json_schema name too long", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"` + strings.Repeat("a", 65) + `","schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatName},
 		{name: "json_schema missing schema", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"r"}}}`, wantErr: ErrResponseFormatSchemaShape},
 		{name: "schema not an object", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":"x"}}}`, wantErr: ErrResponseFormatSchemaShape},
-		{name: "depth exceeds limit", body: jsonSchemaResponseFormatBody(nestedPropertiesSchema(6)), wantErr: ErrResponseFormatDepth},
-		{name: "deep recursion attack", body: jsonSchemaResponseFormatBody(nestedPropertiesSchema(200)), wantErr: ErrResponseFormatDepth},
-		{name: "schema size exceeds 16 KiB", body: jsonSchemaResponseFormatBody(`{"type":"object","properties":{"` + strings.Repeat("a", 17*1024) + `":{"type":"string"}}}`), wantErr: ErrResponseFormatSize},
-		{name: "schema node count exceeds 128", body: jsonSchemaResponseFormatBody(manyPropertiesSchema(200)), wantErr: ErrResponseFormatNodes},
-		{name: "ref not allowed", body: jsonSchemaResponseFormatBody(`{"$ref":"#/foo"}`), wantErr: ErrResponseFormatRef},
-		{name: "defs not allowed", body: jsonSchemaResponseFormatBody(`{"$defs":{"x":{}}}`), wantErr: ErrResponseFormatRef},
-		{name: "definitions not allowed", body: jsonSchemaResponseFormatBody(`{"definitions":{"x":{}}}`), wantErr: ErrResponseFormatRef},
-		{name: "anyOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"anyOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrResponseFormatBranch},
-		{name: "oneOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"oneOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrResponseFormatBranch},
-		{name: "allOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"allOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrResponseFormatBranch},
-		{name: "enum exceeds limit", body: jsonSchemaResponseFormatBody(bigEnumSchema(257)), wantErr: ErrResponseFormatEnum},
-		{name: "ref deep inside properties", body: jsonSchemaResponseFormatBody(`{"type":"object","properties":{"x":{"$ref":"#/y"}}}`), wantErr: ErrResponseFormatRef},
+		{name: "depth exceeds limit", body: jsonSchemaResponseFormatBody(nestedPropertiesSchema(6)), wantErr: ErrSchemaDepth},
+		{name: "deep recursion attack", body: jsonSchemaResponseFormatBody(nestedPropertiesSchema(200)), wantErr: ErrSchemaDepth},
+		{name: "schema size exceeds 16 KiB", body: jsonSchemaResponseFormatBody(`{"type":"object","properties":{"` + strings.Repeat("a", 17*1024) + `":{"type":"string"}}}`), wantErr: ErrSchemaSize},
+		// Size boundary: MaxSize+1 must reject. CheckSize uses `> MaxSize`, so the off-by-one
+		// risk is right here.
+		{name: "marshalled size one byte over limit", body: jsonSchemaResponseFormatBody(schemaOfMarshalledSize(t, 16*1024+1)), wantErr: ErrSchemaSize},
+		{name: "schema node count exceeds 128", body: jsonSchemaResponseFormatBody(manyPropertiesSchema(200)), wantErr: ErrSchemaNodes},
+		// Node boundary: manyPropertiesSchema(128) = 1 root + 128 children = 129 nodes, one over.
+		{name: "node count one over limit", body: jsonSchemaResponseFormatBody(manyPropertiesSchema(128)), wantErr: ErrSchemaNodes},
+		{name: "ref not allowed", body: jsonSchemaResponseFormatBody(`{"$ref":"#/foo"}`), wantErr: ErrSchemaRef},
+		{name: "defs not allowed", body: jsonSchemaResponseFormatBody(`{"$defs":{"x":{}}}`), wantErr: ErrSchemaRef},
+		{name: "definitions not allowed", body: jsonSchemaResponseFormatBody(`{"definitions":{"x":{}}}`), wantErr: ErrSchemaRef},
+		{name: "anyOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"anyOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrSchemaBranch},
+		{name: "oneOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"oneOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrSchemaBranch},
+		{name: "allOf exceeds branch limit", body: jsonSchemaResponseFormatBody(`{"allOf":[` + strings.Repeat(`{"type":"string"},`, 16) + `{"type":"string"}]}`), wantErr: ErrSchemaBranch},
+		{name: "enum exceeds limit", body: jsonSchemaResponseFormatBody(bigEnumSchema(257)), wantErr: ErrSchemaEnum},
+		{name: "ref deep inside properties", body: jsonSchemaResponseFormatBody(`{"type":"object","properties":{"x":{"$ref":"#/y"}}}`), wantErr: ErrSchemaRef},
 		// Regression: walker must traverse every schema-valued keyword. Hiding a deep nest or a
 		// $ref under if/then/else/contains/not/propertyNames/unevaluated*/dependentSchemas
 		// previously bypassed the validator.
-		{name: "depth via if chain", body: jsonSchemaResponseFormatBody(nestedIfSchema(200)), wantErr: ErrResponseFormatDepth},
-		{name: "depth via then chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("then", 200)), wantErr: ErrResponseFormatDepth},
-		{name: "depth via else chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("else", 200)), wantErr: ErrResponseFormatDepth},
-		{name: "depth via contains chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("contains", 200)), wantErr: ErrResponseFormatDepth},
-		{name: "depth via not chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("not", 200)), wantErr: ErrResponseFormatDepth},
-		{name: "depth via propertyNames chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("propertyNames", 200)), wantErr: ErrResponseFormatDepth},
-		{name: "depth via unevaluatedProperties chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("unevaluatedProperties", 200)), wantErr: ErrResponseFormatDepth},
-		{name: "ref hidden under if", body: jsonSchemaResponseFormatBody(`{"if":{"$ref":"#/x"}}`), wantErr: ErrResponseFormatRef},
-		{name: "ref hidden under contains", body: jsonSchemaResponseFormatBody(`{"contains":{"$ref":"#/x"}}`), wantErr: ErrResponseFormatRef},
-		{name: "ref hidden under not", body: jsonSchemaResponseFormatBody(`{"not":{"$ref":"#/x"}}`), wantErr: ErrResponseFormatRef},
-		{name: "ref hidden under dependentSchemas", body: jsonSchemaResponseFormatBody(`{"dependentSchemas":{"x":{"$ref":"#/y"}}}`), wantErr: ErrResponseFormatRef},
-		{name: "defs hidden under then", body: jsonSchemaResponseFormatBody(`{"then":{"$defs":{"x":{}}}}`), wantErr: ErrResponseFormatRef},
+		{name: "depth via if chain", body: jsonSchemaResponseFormatBody(nestedIfSchema(200)), wantErr: ErrSchemaDepth},
+		{name: "depth via then chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("then", 200)), wantErr: ErrSchemaDepth},
+		{name: "depth via else chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("else", 200)), wantErr: ErrSchemaDepth},
+		{name: "depth via contains chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("contains", 200)), wantErr: ErrSchemaDepth},
+		{name: "depth via not chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("not", 200)), wantErr: ErrSchemaDepth},
+		{name: "depth via propertyNames chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("propertyNames", 200)), wantErr: ErrSchemaDepth},
+		{name: "depth via unevaluatedProperties chain", body: jsonSchemaResponseFormatBody(nestedKeywordSchema("unevaluatedProperties", 200)), wantErr: ErrSchemaDepth},
+		{name: "ref hidden under if", body: jsonSchemaResponseFormatBody(`{"if":{"$ref":"#/x"}}`), wantErr: ErrSchemaRef},
+		{name: "ref hidden under contains", body: jsonSchemaResponseFormatBody(`{"contains":{"$ref":"#/x"}}`), wantErr: ErrSchemaRef},
+		{name: "ref hidden under not", body: jsonSchemaResponseFormatBody(`{"not":{"$ref":"#/x"}}`), wantErr: ErrSchemaRef},
+		{name: "ref hidden under dependentSchemas", body: jsonSchemaResponseFormatBody(`{"dependentSchemas":{"x":{"$ref":"#/y"}}}`), wantErr: ErrSchemaRef},
+		{name: "defs hidden under then", body: jsonSchemaResponseFormatBody(`{"then":{"$defs":{"x":{}}}}`), wantErr: ErrSchemaRef},
 		// CVE-2025-48944: bad `type` value crashes xgrammar's C++ grammar compiler.
 		{name: "bad schema type string", body: jsonSchemaResponseFormatBody(`{"type":"something"}`), wantErr: ErrSchemaType},
 		{name: "bad schema type array entry", body: jsonSchemaResponseFormatBody(`{"type":["string","weird"]}`), wantErr: ErrSchemaType},
@@ -163,6 +173,59 @@ func manyPropertiesSchema(count int) string {
 	}
 	b.WriteString(`}}`)
 	return b.String()
+}
+
+// coBoundarySchema constructs a schema that sits at both the depth and node-count limit
+// simultaneously: a single-property chain of `chainDepth` levels, with `leafProps` empty
+// sibling properties at the deepest level. Total nodes = chainDepth + leafProps; depth =
+// chainDepth + 1 (leaves are one step deeper than the chain).
+func coBoundarySchema(chainDepth, leafProps int) string {
+	var b strings.Builder
+	for i := 0; i < chainDepth-1; i++ {
+		b.WriteString(`{"type":"object","properties":{"a":`)
+	}
+	b.WriteString(`{"type":"object","properties":{`)
+	for i := 0; i < leafProps; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`"p`)
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(`":{}`)
+	}
+	b.WriteString(`}}`)
+	for i := 0; i < chainDepth-1; i++ {
+		b.WriteString(`}}`)
+	}
+	return b.String()
+}
+
+// schemaOfMarshalledSize returns a JSON-Schema map whose post-Marshal byte length equals
+// `want`. Used to exercise the CheckSize boundary without guessing wrapper overhead.
+func schemaOfMarshalledSize(tb testing.TB, want int) string {
+	tb.Helper()
+	build := func(padLen int) []byte {
+		s := `{"type":"string","description":"` + strings.Repeat("a", padLen) + `"}`
+		var m map[string]any
+		if err := json.Unmarshal([]byte(s), &m); err != nil {
+			tb.Fatalf("unmarshal: %v", err)
+		}
+		out, err := json.Marshal(m)
+		if err != nil {
+			tb.Fatalf("marshal: %v", err)
+		}
+		return out
+	}
+	for padLen := want - 64; padLen < want+64; padLen++ {
+		if padLen < 0 {
+			continue
+		}
+		if len(build(padLen)) == want {
+			return string(build(padLen))
+		}
+	}
+	tb.Fatalf("could not build schema of marshalled size %d", want)
+	return ""
 }
 
 func bigEnumSchema(n int) string {

--- a/devshard/cmd/devshardctl/paramvalidators/response_format_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format_test.go
@@ -11,12 +11,13 @@ import (
 
 func defaultResponseFormatValidator() ResponseFormatValidator {
 	return ResponseFormatValidator{
-		MaxDepth:   5,
-		MaxSize:    16 * 1024,
-		MaxNodes:   128,
-		MaxBranch:  16,
-		MaxEnum:    256,
-		MaxNameLen: 64,
+		MaxDepth:      5,
+		MaxSize:       16 * 1024,
+		MaxNodes:      128,
+		MaxBranch:     16,
+		MaxEnum:       256,
+		MaxNameLen:    64,
+		MaxPatternLen: 512,
 	}
 }
 
@@ -45,6 +46,10 @@ func TestResponseFormatValidatorAccepts(t *testing.T) {
 		{name: "json_schema with anyOf at branch limit", body: jsonSchemaResponseFormatBody(`{"anyOf":[` + strings.Repeat(`{"type":"string"},`, 15) + `{"type":"string"}]}`)},
 		{name: "json_schema with enum at limit", body: jsonSchemaResponseFormatBody(bigEnumSchema(256))},
 		{name: "json_schema name with dots dashes underscores", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"abc_DEF-1.2","schema":{"type":"object"}}}}`},
+		// type can be an array of primitives (JSON Schema draft 6+); accept that shape.
+		{name: "schema type as array of primitives", body: jsonSchemaResponseFormatBody(`{"type":["string","null"]}`)},
+		// A reasonable regex pattern under the length cap compiles and is accepted.
+		{name: "schema with valid pattern", body: jsonSchemaResponseFormatBody(`{"type":"string","pattern":"^[a-zA-Z0-9_-]+$"}`)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -98,6 +103,17 @@ func TestResponseFormatValidatorRejects(t *testing.T) {
 		{name: "ref hidden under not", body: jsonSchemaResponseFormatBody(`{"not":{"$ref":"#/x"}}`), wantErr: ErrResponseFormatRef},
 		{name: "ref hidden under dependentSchemas", body: jsonSchemaResponseFormatBody(`{"dependentSchemas":{"x":{"$ref":"#/y"}}}`), wantErr: ErrResponseFormatRef},
 		{name: "defs hidden under then", body: jsonSchemaResponseFormatBody(`{"then":{"$defs":{"x":{}}}}`), wantErr: ErrResponseFormatRef},
+		// CVE-2025-48944: bad `type` value crashes xgrammar's C++ grammar compiler.
+		{name: "bad schema type string", body: jsonSchemaResponseFormatBody(`{"type":"something"}`), wantErr: ErrSchemaType},
+		{name: "bad schema type array entry", body: jsonSchemaResponseFormatBody(`{"type":["string","weird"]}`), wantErr: ErrSchemaType},
+		{name: "bad schema type bool", body: jsonSchemaResponseFormatBody(`{"type":true}`), wantErr: ErrSchemaType},
+		{name: "bad schema type nested", body: jsonSchemaResponseFormatBody(`{"type":"object","properties":{"x":{"type":"not_a_type"}}}`), wantErr: ErrSchemaType},
+		// CVE-2025-48944: unclosed regex crashes the regex compiler before vLLM rejects.
+		{name: "bad pattern unclosed group", body: jsonSchemaResponseFormatBody(`{"type":"string","pattern":"("}`), wantErr: ErrSchemaPattern},
+		{name: "bad pattern unclosed char class", body: jsonSchemaResponseFormatBody(`{"type":"string","pattern":"["}`), wantErr: ErrSchemaPattern},
+		{name: "bad pattern not string", body: jsonSchemaResponseFormatBody(`{"type":"string","pattern":42}`), wantErr: ErrSchemaPattern},
+		{name: "bad pattern too long", body: jsonSchemaResponseFormatBody(`{"type":"string","pattern":"` + strings.Repeat("a", 513) + `"}`), wantErr: ErrSchemaPattern},
+		{name: "bad pattern nested", body: jsonSchemaResponseFormatBody(`{"type":"object","properties":{"x":{"type":"string","pattern":"["}}}`), wantErr: ErrSchemaPattern},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/devshard/cmd/devshardctl/paramvalidators/schema_bounds.go
+++ b/devshard/cmd/devshardctl/paramvalidators/schema_bounds.go
@@ -1,0 +1,169 @@
+package paramvalidators
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Schema-bounds sentinels. Returned by SchemaBounds.Walk / SchemaBounds.CheckSize and by
+// ObjectBounds.Walk. Callers wrap them with a field-path prefix (e.g.
+// "response_format.json_schema.schema", "tools[3].function.parameters",
+// "chat_template_kwargs") so the user-facing message points at the offending field while
+// errors.Is keeps working for the rejection category.
+var (
+	ErrSchemaDepth  = errors.New("nesting depth exceeded")
+	ErrSchemaNodes  = errors.New("node count exceeded")
+	ErrSchemaSize   = errors.New("serialized size exceeded")
+	ErrSchemaRef    = errors.New("schema reference keyword is forbidden")
+	ErrSchemaEnum   = errors.New("enum size exceeded")
+	ErrSchemaBranch = errors.New("schema branch arms exceeded")
+)
+
+// SchemaBounds enforces the structural bounds that keep a JSON-Schema payload from
+// exploding vLLM's grammar compiler. It is the JSON-Schema-aware walker reused by both
+// `response_format.json_schema.schema` and `tools[].function.parameters` (they hit the same
+// upstream compiler path).
+type SchemaBounds struct {
+	MaxDepth  int
+	MaxSize   int
+	MaxNodes  int
+	MaxBranch int // anyOf / oneOf / allOf array arms
+	MaxEnum   int // enum entries
+}
+
+// Walk recursively traverses the schema, enforcing depth/nodes/branch/enum bounds and the
+// $ref/$defs/definitions ban. Walking is done before json.Marshal so attacker-controlled
+// deeply nested payloads bail out at the depth check (~O(MaxNodes)) instead of after a full
+// O(input size) marshal pass.
+func (b SchemaBounds) Walk(schema map[string]any) error {
+	var nodes int
+	return b.walk(schema, 1, &nodes)
+}
+
+// CheckSize marshals the schema and rejects when the serialized size exceeds MaxSize. Run
+// AFTER Walk so depth/breadth attacks rejected by the walker never pay for the marshal.
+// MaxSize=0 disables the check.
+func (b SchemaBounds) CheckSize(schema map[string]any) error {
+	if b.MaxSize <= 0 {
+		return nil
+	}
+	serialized, err := json.Marshal(schema)
+	if err != nil {
+		return fmt.Errorf("cannot be serialized: %v", err)
+	}
+	if len(serialized) > b.MaxSize {
+		return fmt.Errorf("%w: limit %d bytes", ErrSchemaSize, b.MaxSize)
+	}
+	return nil
+}
+
+func (b SchemaBounds) walk(schema any, depth int, nodes *int) error {
+	if depth > b.MaxDepth {
+		return fmt.Errorf("%w: limit %d", ErrSchemaDepth, b.MaxDepth)
+	}
+	obj, ok := schema.(map[string]any)
+	if !ok {
+		return nil
+	}
+	*nodes++
+	if *nodes > b.MaxNodes {
+		return fmt.Errorf("%w: limit %d", ErrSchemaNodes, b.MaxNodes)
+	}
+	for _, forbidden := range forbiddenSchemaKeys {
+		if _, exists := obj[forbidden]; exists {
+			return fmt.Errorf("%w: %q is not allowed", ErrSchemaRef, forbidden)
+		}
+	}
+	if enum, ok := obj["enum"].([]any); ok && len(enum) > b.MaxEnum {
+		return fmt.Errorf("%w: limit %d", ErrSchemaEnum, b.MaxEnum)
+	}
+	for _, branchKey := range branchSchemaKeys {
+		if arr, ok := obj[branchKey].([]any); ok && len(arr) > b.MaxBranch {
+			return fmt.Errorf("%w: %s limit %d", ErrSchemaBranch, branchKey, b.MaxBranch)
+		}
+	}
+	for key, value := range obj {
+		if _, isData := responseFormatDataKeys[key]; isData {
+			continue
+		}
+		switch typed := value.(type) {
+		case map[string]any:
+			if _, isChildMap := responseFormatChildMapKeys[key]; isChildMap {
+				for _, child := range typed {
+					if err := b.walk(child, depth+1, nodes); err != nil {
+						return err
+					}
+				}
+			} else {
+				if err := b.walk(typed, depth+1, nodes); err != nil {
+					return err
+				}
+			}
+		case []any:
+			for _, child := range typed {
+				if err := b.walk(child, depth+1, nodes); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ObjectBounds enforces depth/nodes/size on an arbitrary JSON object that is NOT a JSON
+// Schema -- it has no special data-carrier keys, no $ref ban, no anyOf/enum semantics. Used
+// for fields like `chat_template_kwargs` that feed vLLM's Jinja template renderer: we only
+// care about bounding total structure, not validating individual JSON Schema constructs.
+type ObjectBounds struct {
+	MaxDepth int
+	MaxSize  int
+	MaxNodes int
+}
+
+// Walk recursively traverses every object/array node. Returns ErrSchemaDepth/ErrSchemaNodes
+// (sentinels are shared with SchemaBounds because the rejection class is the same).
+func (b ObjectBounds) Walk(obj map[string]any) error {
+	var nodes int
+	return b.walk(obj, 1, &nodes)
+}
+
+// CheckSize behaves identically to SchemaBounds.CheckSize.
+func (b ObjectBounds) CheckSize(obj map[string]any) error {
+	if b.MaxSize <= 0 {
+		return nil
+	}
+	serialized, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("cannot be serialized: %v", err)
+	}
+	if len(serialized) > b.MaxSize {
+		return fmt.Errorf("%w: limit %d bytes", ErrSchemaSize, b.MaxSize)
+	}
+	return nil
+}
+
+func (b ObjectBounds) walk(value any, depth int, nodes *int) error {
+	if depth > b.MaxDepth {
+		return fmt.Errorf("%w: limit %d", ErrSchemaDepth, b.MaxDepth)
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		*nodes++
+		if *nodes > b.MaxNodes {
+			return fmt.Errorf("%w: limit %d", ErrSchemaNodes, b.MaxNodes)
+		}
+		for _, child := range typed {
+			if err := b.walk(child, depth+1, nodes); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if err := b.walk(child, depth+1, nodes); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/schema_bounds.go
+++ b/devshard/cmd/devshardctl/paramvalidators/schema_bounds.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 )
 
 // Schema-bounds sentinels. Returned by SchemaBounds.Walk / SchemaBounds.CheckSize and by
@@ -12,13 +13,27 @@ import (
 // "chat_template_kwargs") so the user-facing message points at the offending field while
 // errors.Is keeps working for the rejection category.
 var (
-	ErrSchemaDepth  = errors.New("nesting depth exceeded")
-	ErrSchemaNodes  = errors.New("node count exceeded")
-	ErrSchemaSize   = errors.New("serialized size exceeded")
-	ErrSchemaRef    = errors.New("schema reference keyword is forbidden")
-	ErrSchemaEnum   = errors.New("enum size exceeded")
-	ErrSchemaBranch = errors.New("schema branch arms exceeded")
+	ErrSchemaDepth   = errors.New("nesting depth exceeded")
+	ErrSchemaNodes   = errors.New("node count exceeded")
+	ErrSchemaSize    = errors.New("serialized size exceeded")
+	ErrSchemaRef     = errors.New("schema reference keyword is forbidden")
+	ErrSchemaEnum    = errors.New("enum size exceeded")
+	ErrSchemaBranch  = errors.New("schema branch arms exceeded")
+	ErrSchemaType    = errors.New("schema type is not a valid JSON-Schema primitive")
+	ErrSchemaPattern = errors.New("schema pattern is not a valid regular expression")
 )
+
+// validSchemaTypes lists the JSON Schema primitive type names. Anything else (e.g.
+// "something") crashes xgrammar's C++ grammar compiler -- see CVE-2025-48944.
+var validSchemaTypes = map[string]struct{}{
+	"string":  {},
+	"number":  {},
+	"integer": {},
+	"object":  {},
+	"boolean": {},
+	"array":   {},
+	"null":    {},
+}
 
 // SchemaBounds enforces the structural bounds that keep a JSON-Schema payload from
 // exploding vLLM's grammar compiler. It is the JSON-Schema-aware walker reused by both
@@ -30,6 +45,11 @@ type SchemaBounds struct {
 	MaxNodes  int
 	MaxBranch int // anyOf / oneOf / allOf array arms
 	MaxEnum   int // enum entries
+	// MaxPatternLen caps the byte length of any `pattern` regex string before we try to
+	// compile it. 0 disables both the length check AND the compile-check. Set to a small
+	// positive value (e.g. 512) to defuse CVE-2025-48944-class crashes where an unclosed
+	// regex (`{`, `(`) kills vLLM's regex engine.
+	MaxPatternLen int
 }
 
 // Walk recursively traverses the schema, enforcing depth/nodes/branch/enum bounds and the
@@ -77,6 +97,12 @@ func (b SchemaBounds) walk(schema any, depth int, nodes *int) error {
 	}
 	if enum, ok := obj["enum"].([]any); ok && len(enum) > b.MaxEnum {
 		return fmt.Errorf("%w: limit %d", ErrSchemaEnum, b.MaxEnum)
+	}
+	if err := validateSchemaTypeField(obj); err != nil {
+		return err
+	}
+	if err := b.validateSchemaPatternField(obj); err != nil {
+		return err
 	}
 	for _, branchKey := range branchSchemaKeys {
 		if arr, ok := obj[branchKey].([]any); ok && len(arr) > b.MaxBranch {
@@ -164,6 +190,65 @@ func (b ObjectBounds) walk(value any, depth int, nodes *int) error {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// validateSchemaTypeField rejects schema nodes whose `type` is not a JSON-Schema primitive
+// (`string`, `number`, `integer`, `object`, `boolean`, `array`, `null`) or an array of
+// primitives. Anything else (e.g. `type: "something"`) crashes xgrammar's C++ grammar
+// compiler -- see CVE-2025-48944. Schemas that omit `type` entirely are fine; this only
+// rejects an explicitly bad value.
+func validateSchemaTypeField(obj map[string]any) error {
+	raw, present := obj["type"]
+	if !present {
+		return nil
+	}
+	switch typed := raw.(type) {
+	case string:
+		if _, ok := validSchemaTypes[typed]; !ok {
+			return fmt.Errorf("%w: %q", ErrSchemaType, typed)
+		}
+	case []any:
+		for _, v := range typed {
+			s, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("%w: array elements must be strings", ErrSchemaType)
+			}
+			if _, ok := validSchemaTypes[s]; !ok {
+				return fmt.Errorf("%w: %q", ErrSchemaType, s)
+			}
+		}
+	default:
+		return fmt.Errorf("%w: must be a string or array of strings", ErrSchemaType)
+	}
+	return nil
+}
+
+// validateSchemaPatternField rejects schema nodes whose `pattern` exceeds MaxPatternLen
+// or fails to compile as a Go regular expression. The compile step catches the
+// CVE-2025-48944 case where `pattern: "{"` (unclosed group) crashes vLLM's regex engine
+// at grammar-compile time. Go's RE2 is more permissive than xgrammar's engine, so a Go
+// compile success does not *guarantee* xgrammar success -- but a Go failure DOES guarantee
+// xgrammar failure for the same syntactic shape, which is what defuses the documented CVE.
+// Skipped entirely when MaxPatternLen == 0.
+func (b SchemaBounds) validateSchemaPatternField(obj map[string]any) error {
+	if b.MaxPatternLen <= 0 {
+		return nil
+	}
+	raw, present := obj["pattern"]
+	if !present {
+		return nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return fmt.Errorf("%w: must be a string", ErrSchemaPattern)
+	}
+	if len(s) > b.MaxPatternLen {
+		return fmt.Errorf("%w: length %d exceeds limit %d", ErrSchemaPattern, len(s), b.MaxPatternLen)
+	}
+	if _, err := regexp.Compile(s); err != nil {
+		return fmt.Errorf("%w: %v", ErrSchemaPattern, err)
 	}
 	return nil
 }

--- a/devshard/cmd/devshardctl/paramvalidators/thinking.go
+++ b/devshard/cmd/devshardctl/paramvalidators/thinking.go
@@ -1,0 +1,43 @@
+package paramvalidators
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrThinkingShape covers the wrapper-level rejection. ErrThinkingType covers the inner
+// type field (missing / not a string / not enabled|disabled).
+var (
+	ErrThinkingShape = errors.New("thinking: invalid wrapper shape")
+	ErrThinkingType  = errors.New("thinking.type: must be \"enabled\" or \"disabled\"")
+)
+
+// ThinkingValidator enforces the Kimi-K2 thinking contract: an object with a single `type`
+// field whose value is either "enabled" or "disabled". Any other shape was previously
+// pass-through, which means a malformed payload could leak into the Jinja template via
+// applyKimiRequestOverrides (which mirrors thinking.type into chat_template_kwargs.thinking
+// for Kimi-K2.6). Reject early at the gateway boundary instead.
+type ThinkingValidator struct{}
+
+func (v ThinkingValidator) Validate(document map[string]any) error {
+	raw, exists := document["thinking"]
+	if !exists {
+		return nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: must be an object", ErrThinkingShape)
+	}
+	typeRaw, hasType := obj["type"]
+	if !hasType {
+		return fmt.Errorf("%w: type is required", ErrThinkingType)
+	}
+	typeStr, ok := typeRaw.(string)
+	if !ok {
+		return fmt.Errorf("%w: type must be a string", ErrThinkingType)
+	}
+	if typeStr != "enabled" && typeStr != "disabled" {
+		return fmt.Errorf("%w: got %q", ErrThinkingType, typeStr)
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/thinking_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/thinking_test.go
@@ -1,0 +1,48 @@
+package paramvalidators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThinkingValidatorAccepts(t *testing.T) {
+	v := ThinkingValidator{}
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "absent", body: `{"messages":[]}`},
+		{name: "enabled", body: `{"thinking":{"type":"enabled"}}`},
+		{name: "disabled", body: `{"thinking":{"type":"disabled"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, v.Validate(parseDocument(t, tt.body)))
+		})
+	}
+}
+
+func TestThinkingValidatorRejects(t *testing.T) {
+	v := ThinkingValidator{}
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{name: "wrapper not object", body: `{"thinking":"enabled"}`, wantErr: ErrThinkingShape},
+		{name: "wrapper is array", body: `{"thinking":[]}`, wantErr: ErrThinkingShape},
+		{name: "wrapper is bool", body: `{"thinking":true}`, wantErr: ErrThinkingShape},
+		{name: "type missing", body: `{"thinking":{}}`, wantErr: ErrThinkingType},
+		{name: "type is bool", body: `{"thinking":{"type":true}}`, wantErr: ErrThinkingType},
+		{name: "type is unknown string", body: `{"thinking":{"type":"on"}}`, wantErr: ErrThinkingType},
+		{name: "type is empty string", body: `{"thinking":{"type":""}}`, wantErr: ErrThinkingType},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Validate(parseDocument(t, tt.body))
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/devshard/cmd/devshardctl/paramvalidators/tools.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tools.go
@@ -9,20 +9,18 @@ import (
 // through as the shared ErrSchema* values wrapped with a "tools[i].function.parameters:"
 // prefix.
 var (
-	ErrToolsShape       = errors.New("tools: invalid array shape")
-	ErrToolShape        = errors.New("tools[i]: invalid tool shape")
-	ErrToolFunctionType = errors.New("tools[i].type: must be \"function\"")
+	ErrToolsShape        = errors.New("tools: invalid array shape")
+	ErrToolShape         = errors.New("tools[i]: invalid tool shape")
+	ErrToolFunctionType  = errors.New("tools[i].type: must be \"function\"")
+	ErrToolFunctionShape = errors.New("tools[i].function: invalid wrapper shape")
+	ErrToolFunctionName  = errors.New("tools[i].function.name: must be a non-empty string")
 )
 
-// ToolsValidator applies SchemaBounds to every `tools[].function.parameters` schema.
-//
-// vLLM compiles tool argument schemas through the same grammar path as response_format,
-// so the same depth/nodes/branch/enum/size/$ref invariants apply. Without this check, a
-// recursive schema posted inside a tool definition would reach vLLM unbounded.
-//
-// Empty or absent tools is a no-op (the catalog also strips empty `tools` arrays
-// elsewhere). Tools whose `function.parameters` field is absent or non-object are
-// skipped -- they are nominally allowed by the OpenAI spec (parameter-less tools).
+// ToolsValidator enforces the OpenAI tool object contract -- every tool must declare
+// `type: "function"` and a `function` object with a non-empty `name` -- and then bounds
+// `function.parameters` via SchemaBounds (same grammar-compiler attack surface as
+// response_format). Parameter-less tools are allowed by the OpenAI spec, so an absent
+// `parameters` field is a no-op rather than a failure.
 type ToolsValidator struct {
 	MaxDepth      int
 	MaxSize       int
@@ -54,16 +52,20 @@ func (v ToolsValidator) Validate(document map[string]any) error {
 		if !ok {
 			return fmt.Errorf("%w: tools[%d] must be an object", ErrToolShape, i)
 		}
-		// We do not enforce `type: "function"` here -- the OpenAI tool spec allows future
-		// expansion. We only validate the schema if it exists in the expected place.
+		toolType, ok := tool["type"].(string)
+		if !ok || toolType != "function" {
+			return fmt.Errorf("%w (tools[%d])", ErrToolFunctionType, i)
+		}
 		fn, ok := tool["function"].(map[string]any)
 		if !ok {
-			// A tool without a function payload reaches vLLM as a no-op; nothing to bound.
-			continue
+			return fmt.Errorf("%w: tools[%d].function must be an object", ErrToolFunctionShape, i)
+		}
+		name, ok := fn["name"].(string)
+		if !ok || name == "" {
+			return fmt.Errorf("%w (tools[%d])", ErrToolFunctionName, i)
 		}
 		params, ok := fn["parameters"].(map[string]any)
 		if !ok {
-			// Parameter-less tools (no JSON Schema) -- valid per OpenAI spec.
 			continue
 		}
 		if err := bounds.Walk(params); err != nil {

--- a/devshard/cmd/devshardctl/paramvalidators/tools.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tools.go
@@ -24,11 +24,12 @@ var (
 // elsewhere). Tools whose `function.parameters` field is absent or non-object are
 // skipped -- they are nominally allowed by the OpenAI spec (parameter-less tools).
 type ToolsValidator struct {
-	MaxDepth  int
-	MaxSize   int
-	MaxNodes  int
-	MaxBranch int
-	MaxEnum   int
+	MaxDepth      int
+	MaxSize       int
+	MaxNodes      int
+	MaxBranch     int
+	MaxEnum       int
+	MaxPatternLen int
 }
 
 func (v ToolsValidator) Validate(document map[string]any) error {
@@ -41,11 +42,12 @@ func (v ToolsValidator) Validate(document map[string]any) error {
 		return fmt.Errorf("%w: must be an array", ErrToolsShape)
 	}
 	bounds := SchemaBounds{
-		MaxDepth:  v.MaxDepth,
-		MaxSize:   v.MaxSize,
-		MaxNodes:  v.MaxNodes,
-		MaxBranch: v.MaxBranch,
-		MaxEnum:   v.MaxEnum,
+		MaxDepth:      v.MaxDepth,
+		MaxSize:       v.MaxSize,
+		MaxNodes:      v.MaxNodes,
+		MaxBranch:     v.MaxBranch,
+		MaxEnum:       v.MaxEnum,
+		MaxPatternLen: v.MaxPatternLen,
 	}
 	for i, item := range arr {
 		tool, ok := item.(map[string]any)

--- a/devshard/cmd/devshardctl/paramvalidators/tools.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tools.go
@@ -1,0 +1,75 @@
+package paramvalidators
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Tool-specific sentinels. Schema-walk rejections (depth/nodes/ref/enum/branch/size) flow
+// through as the shared ErrSchema* values wrapped with a "tools[i].function.parameters:"
+// prefix.
+var (
+	ErrToolsShape       = errors.New("tools: invalid array shape")
+	ErrToolShape        = errors.New("tools[i]: invalid tool shape")
+	ErrToolFunctionType = errors.New("tools[i].type: must be \"function\"")
+)
+
+// ToolsValidator applies SchemaBounds to every `tools[].function.parameters` schema.
+//
+// vLLM compiles tool argument schemas through the same grammar path as response_format,
+// so the same depth/nodes/branch/enum/size/$ref invariants apply. Without this check, a
+// recursive schema posted inside a tool definition would reach vLLM unbounded.
+//
+// Empty or absent tools is a no-op (the catalog also strips empty `tools` arrays
+// elsewhere). Tools whose `function.parameters` field is absent or non-object are
+// skipped -- they are nominally allowed by the OpenAI spec (parameter-less tools).
+type ToolsValidator struct {
+	MaxDepth  int
+	MaxSize   int
+	MaxNodes  int
+	MaxBranch int
+	MaxEnum   int
+}
+
+func (v ToolsValidator) Validate(document map[string]any) error {
+	raw, exists := document["tools"]
+	if !exists {
+		return nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return fmt.Errorf("%w: must be an array", ErrToolsShape)
+	}
+	bounds := SchemaBounds{
+		MaxDepth:  v.MaxDepth,
+		MaxSize:   v.MaxSize,
+		MaxNodes:  v.MaxNodes,
+		MaxBranch: v.MaxBranch,
+		MaxEnum:   v.MaxEnum,
+	}
+	for i, item := range arr {
+		tool, ok := item.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%w: tools[%d] must be an object", ErrToolShape, i)
+		}
+		// We do not enforce `type: "function"` here -- the OpenAI tool spec allows future
+		// expansion. We only validate the schema if it exists in the expected place.
+		fn, ok := tool["function"].(map[string]any)
+		if !ok {
+			// A tool without a function payload reaches vLLM as a no-op; nothing to bound.
+			continue
+		}
+		params, ok := fn["parameters"].(map[string]any)
+		if !ok {
+			// Parameter-less tools (no JSON Schema) -- valid per OpenAI spec.
+			continue
+		}
+		if err := bounds.Walk(params); err != nil {
+			return fmt.Errorf("tools[%d].function.parameters: %w", i, err)
+		}
+		if err := bounds.CheckSize(params); err != nil {
+			return fmt.Errorf("tools[%d].function.parameters: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/tools_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tools_test.go
@@ -9,11 +9,12 @@ import (
 
 func defaultToolsValidator() ToolsValidator {
 	return ToolsValidator{
-		MaxDepth:  5,
-		MaxSize:   16 * 1024,
-		MaxNodes:  128,
-		MaxBranch: 16,
-		MaxEnum:   256,
+		MaxDepth:      5,
+		MaxSize:       16 * 1024,
+		MaxNodes:      128,
+		MaxBranch:     16,
+		MaxEnum:       256,
+		MaxPatternLen: 512,
 	}
 }
 
@@ -62,6 +63,8 @@ func TestToolsValidatorRejects(t *testing.T) {
 		{name: "enum exceeds in tool", body: `{"tools":[` + toolWithParams(bigEnumSchema(257)) + `]}`, wantErr: ErrSchemaEnum},
 		// Second tool is the bad one -- verifies we walk every element, not just the first.
 		{name: "rejects bad schema in second tool", body: `{"tools":[` + toolWithParams(`{"type":"object"}`) + `,` + toolWithParams(`{"$ref":"#/x"}`) + `]}`, wantErr: ErrSchemaRef},
+		// CVE-2025-48944: same xgrammar / regex crash class on the tools schema path.
+		{name: "bad type in tool parameters", body: `{"tools":[` + toolWithParams(`{"type":"something"}`) + `]}`, wantErr: ErrSchemaType},		{name: "bad pattern in tool parameters", body: `{"tools":[` + toolWithParams(`{"type":"string","pattern":"("}`) + `]}`, wantErr: ErrSchemaPattern},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/devshard/cmd/devshardctl/paramvalidators/tools_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tools_test.go
@@ -30,8 +30,7 @@ func TestToolsValidatorAccepts(t *testing.T) {
 	}{
 		{name: "absent", body: `{"messages":[]}`},
 		{name: "empty array", body: `{"tools":[]}`},
-		{name: "tool without function", body: `{"tools":[{"type":"function"}]}`},
-		{name: "tool without parameters", body: `{"tools":[{"type":"function","function":{"name":"x"}}]}`},
+		{name: "parameter-less tool with name", body: `{"tools":[{"type":"function","function":{"name":"x"}}]}`},
 		{name: "simple parameters", body: `{"tools":[` + toolWithParams(`{"type":"object","properties":{"city":{"type":"string"}}}`) + `]}`},
 		{name: "two tools both valid", body: `{"tools":[` + toolWithParams(`{"type":"object"}`) + `,` + toolWithParams(`{"type":"object","properties":{"x":{"type":"number"}}}`) + `]}`},
 		{name: "parameters at depth limit", body: `{"tools":[` + toolWithParams(nestedPropertiesSchema(5)) + `]}`},
@@ -53,6 +52,17 @@ func TestToolsValidatorRejects(t *testing.T) {
 	}{
 		{name: "tools is object", body: `{"tools":{"x":1}}`, wantErr: ErrToolsShape},
 		{name: "tools element is not object", body: `{"tools":["x"]}`, wantErr: ErrToolShape},
+		// OpenAI tool contract: type must declare "function".
+		{name: "type missing", body: `{"tools":[{"function":{"name":"x"}}]}`, wantErr: ErrToolFunctionType},
+		{name: "type not a string", body: `{"tools":[{"type":1,"function":{"name":"x"}}]}`, wantErr: ErrToolFunctionType},
+		{name: "type unknown value", body: `{"tools":[{"type":"plugin","function":{"name":"x"}}]}`, wantErr: ErrToolFunctionType},
+		// function payload required.
+		{name: "function missing", body: `{"tools":[{"type":"function"}]}`, wantErr: ErrToolFunctionShape},
+		{name: "function not an object", body: `{"tools":[{"type":"function","function":"x"}]}`, wantErr: ErrToolFunctionShape},
+		// function.name required.
+		{name: "function name missing", body: `{"tools":[{"type":"function","function":{}}]}`, wantErr: ErrToolFunctionName},
+		{name: "function name empty", body: `{"tools":[{"type":"function","function":{"name":""}}]}`, wantErr: ErrToolFunctionName},
+		{name: "function name not a string", body: `{"tools":[{"type":"function","function":{"name":42}}]}`, wantErr: ErrToolFunctionName},
 		{name: "depth exceeds limit", body: `{"tools":[` + toolWithParams(nestedPropertiesSchema(6)) + `]}`, wantErr: ErrSchemaDepth},
 		{name: "deep recursion attack hidden in tool", body: `{"tools":[` + toolWithParams(nestedPropertiesSchema(200)) + `]}`, wantErr: ErrSchemaDepth},
 		{name: "ref hidden in tool parameters", body: `{"tools":[` + toolWithParams(`{"$ref":"#/foo"}`) + `]}`, wantErr: ErrSchemaRef},
@@ -64,7 +74,8 @@ func TestToolsValidatorRejects(t *testing.T) {
 		// Second tool is the bad one -- verifies we walk every element, not just the first.
 		{name: "rejects bad schema in second tool", body: `{"tools":[` + toolWithParams(`{"type":"object"}`) + `,` + toolWithParams(`{"$ref":"#/x"}`) + `]}`, wantErr: ErrSchemaRef},
 		// CVE-2025-48944: same xgrammar / regex crash class on the tools schema path.
-		{name: "bad type in tool parameters", body: `{"tools":[` + toolWithParams(`{"type":"something"}`) + `]}`, wantErr: ErrSchemaType},		{name: "bad pattern in tool parameters", body: `{"tools":[` + toolWithParams(`{"type":"string","pattern":"("}`) + `]}`, wantErr: ErrSchemaPattern},
+		{name: "bad type in tool parameters", body: `{"tools":[` + toolWithParams(`{"type":"something"}`) + `]}`, wantErr: ErrSchemaType},
+		{name: "bad pattern in tool parameters", body: `{"tools":[` + toolWithParams(`{"type":"string","pattern":"("}`) + `]}`, wantErr: ErrSchemaPattern},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/devshard/cmd/devshardctl/paramvalidators/tools_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tools_test.go
@@ -1,0 +1,74 @@
+package paramvalidators
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func defaultToolsValidator() ToolsValidator {
+	return ToolsValidator{
+		MaxDepth:  5,
+		MaxSize:   16 * 1024,
+		MaxNodes:  128,
+		MaxBranch: 16,
+		MaxEnum:   256,
+	}
+}
+
+func toolWithParams(schema string) string {
+	return `{"type":"function","function":{"name":"x","description":"x","parameters":` + schema + `}}`
+}
+
+func TestToolsValidatorAccepts(t *testing.T) {
+	v := defaultToolsValidator()
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "absent", body: `{"messages":[]}`},
+		{name: "empty array", body: `{"tools":[]}`},
+		{name: "tool without function", body: `{"tools":[{"type":"function"}]}`},
+		{name: "tool without parameters", body: `{"tools":[{"type":"function","function":{"name":"x"}}]}`},
+		{name: "simple parameters", body: `{"tools":[` + toolWithParams(`{"type":"object","properties":{"city":{"type":"string"}}}`) + `]}`},
+		{name: "two tools both valid", body: `{"tools":[` + toolWithParams(`{"type":"object"}`) + `,` + toolWithParams(`{"type":"object","properties":{"x":{"type":"number"}}}`) + `]}`},
+		{name: "parameters at depth limit", body: `{"tools":[` + toolWithParams(nestedPropertiesSchema(5)) + `]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := parseDocument(t, tt.body)
+			require.NoError(t, v.Validate(doc))
+		})
+	}
+}
+
+func TestToolsValidatorRejects(t *testing.T) {
+	v := defaultToolsValidator()
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{name: "tools is object", body: `{"tools":{"x":1}}`, wantErr: ErrToolsShape},
+		{name: "tools element is not object", body: `{"tools":["x"]}`, wantErr: ErrToolShape},
+		{name: "depth exceeds limit", body: `{"tools":[` + toolWithParams(nestedPropertiesSchema(6)) + `]}`, wantErr: ErrSchemaDepth},
+		{name: "deep recursion attack hidden in tool", body: `{"tools":[` + toolWithParams(nestedPropertiesSchema(200)) + `]}`, wantErr: ErrSchemaDepth},
+		{name: "ref hidden in tool parameters", body: `{"tools":[` + toolWithParams(`{"$ref":"#/foo"}`) + `]}`, wantErr: ErrSchemaRef},
+		{name: "ref hidden under if in tool", body: `{"tools":[` + toolWithParams(`{"if":{"$ref":"#/x"}}`) + `]}`, wantErr: ErrSchemaRef},
+		{name: "node count exceeds in tool", body: `{"tools":[` + toolWithParams(manyPropertiesSchema(200)) + `]}`, wantErr: ErrSchemaNodes},
+		{name: "size exceeds in tool", body: `{"tools":[` + toolWithParams(`{"type":"object","properties":{"`+strings.Repeat("a", 17*1024)+`":{"type":"string"}}}`) + `]}`, wantErr: ErrSchemaSize},
+		{name: "anyOf exceeds in tool", body: `{"tools":[` + toolWithParams(`{"anyOf":[`+strings.Repeat(`{"type":"string"},`, 16)+`{"type":"string"}]}`) + `]}`, wantErr: ErrSchemaBranch},
+		{name: "enum exceeds in tool", body: `{"tools":[` + toolWithParams(bigEnumSchema(257)) + `]}`, wantErr: ErrSchemaEnum},
+		// Second tool is the bad one -- verifies we walk every element, not just the first.
+		{name: "rejects bad schema in second tool", body: `{"tools":[` + toolWithParams(`{"type":"object"}`) + `,` + toolWithParams(`{"$ref":"#/x"}`) + `]}`, wantErr: ErrSchemaRef},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := parseDocument(t, tt.body)
+			err := v.Validate(doc)
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -32,10 +32,19 @@ type outputTokenLimits struct {
 type chatRequestFilterError struct {
 	status  int
 	message string
+	wrapped error
 }
 
 func (e *chatRequestFilterError) Error() string {
 	return e.message
+}
+
+// Unwrap exposes the underlying error so callers can use errors.Is/errors.As to identify
+// the rejection class even though the outer error carries an HTTP status. This lets pure
+// validators in subpackages (filters_parameters/...) define sentinel errors and have them
+// remain detectable after passing through the badChatRequest wrapper.
+func (e *chatRequestFilterError) Unwrap() error {
+	return e.wrapped
 }
 
 func chatRequestErrorStatus(err error, fallback int) int {
@@ -50,6 +59,16 @@ func badChatRequest(format string, args ...any) error {
 	return &chatRequestFilterError{
 		status:  http.StatusBadRequest,
 		message: fmt.Sprintf(format, args...),
+	}
+}
+
+// wrapBadChatRequest preserves the error chain (so errors.Is/As works) while attaching the
+// HTTP 400 status that the gateway uses for rejection.
+func wrapBadChatRequest(err error) error {
+	return &chatRequestFilterError{
+		status:  http.StatusBadRequest,
+		message: err.Error(),
+		wrapped: err,
 	}
 }
 

--- a/devshard/cmd/devshardctl/request_filters_bench_test.go
+++ b/devshard/cmd/devshardctl/request_filters_bench_test.go
@@ -27,6 +27,7 @@ var (
 		"seed":42,
 		"n":1,
 		"thinking":{"type":"enabled"},
+		"chat_template_kwargs":{"add_generation_prompt":true,"enable_thinking":true},
 		"tools":[
 			{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}
 		]
@@ -40,12 +41,19 @@ var (
 
 	benchBodyRejectedUnknown = []byte(`{"messages":[{"role":"user","content":"hello"}],"frequency_penalty":1.5}`)
 
-	benchBodyRejectedRecursive = buildBenchPathologicalBody()
+	// Body-level pre-scan rejection path. Nesting 200 deep trips ensureRequestNestingDepth
+	// long before any validator runs, so this measures the pre-scan cost on a worst-case input.
+	benchBodyRejectedDeepBody = buildBenchDeepBodyRejection(200)
+
+	// Schema-walker rejection path. Body nesting stays at ~9 levels (under
+	// MaxRequestNestingDepth=32), but the json_schema is 6 levels deep -- one over the walker's
+	// MaxDepth=5, so SchemaBounds.Walk rejects with ErrSchemaDepth.
+	benchBodyRejectedRecursiveSchema = buildBenchDeepBodyRejection(6)
 )
 
-func buildBenchPathologicalBody() []byte {
+func buildBenchDeepBodyRejection(schemaDepth int) []byte {
 	deep := `{"type":"object"}`
-	for i := 0; i < 200; i++ {
+	for i := 0; i < schemaDepth; i++ {
 		deep = `{"type":"object","properties":{"x":` + deep + `}}`
 	}
 	return []byte(`{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":` + deep + `}},"messages":[{"role":"user","content":"hello"}]}`)
@@ -61,7 +69,8 @@ func BenchmarkNormalizeChatRequest(b *testing.B) {
 		{"Heavy", benchBodyHeavy},
 		{"WithResponseFormat", benchBodyWithResponseFormat},
 		{"RejectedUnknownField", benchBodyRejectedUnknown},
-		{"RejectedRecursiveSchema", benchBodyRejectedRecursive},
+		{"RejectedDeepBody", benchBodyRejectedDeepBody},
+		{"RejectedRecursiveSchema", benchBodyRejectedRecursiveSchema},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/devshard/cmd/devshardctl/request_filters_bench_test.go
+++ b/devshard/cmd/devshardctl/request_filters_bench_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+)
+
+// Pre-baked request bodies for the end-to-end pipeline benchmark. Bytes are reused across
+// b.N iterations because normalizeChatRequest does not mutate the input.
+var (
+	benchBodyMinimal = []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+
+	benchBodyTypical = []byte(`{"model":"moonshotai/Kimi-K2.6","messages":[{"role":"user","content":"hello"}],"temperature":0.7,"top_p":0.95,"max_tokens":512}`)
+
+	benchBodyHeavy = []byte(`{
+		"model":"moonshotai/Kimi-K2.6",
+		"messages":[
+			{"role":"system","content":"You are helpful."},
+			{"role":"user","content":"What is the weather in Berlin?"}
+		],
+		"temperature":0.7,
+		"top_p":0.95,
+		"top_k":40,
+		"min_p":0.05,
+		"repetition_penalty":1.05,
+		"max_tokens":512,
+		"stop":["\n\n","STOP"],
+		"seed":42,
+		"n":1,
+		"thinking":{"type":"enabled"},
+		"tools":[
+			{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}
+		]
+	}`)
+
+	benchBodyWithResponseFormat = []byte(`{
+		"model":"moonshotai/Kimi-K2.6",
+		"messages":[{"role":"user","content":"hello"}],
+		"response_format":{"type":"json_schema","json_schema":{"name":"weather_v1","schema":{"type":"object","properties":{"city":{"type":"string"},"temp":{"type":"number"}},"required":["city"]}}}
+	}`)
+
+	benchBodyRejectedUnknown = []byte(`{"messages":[{"role":"user","content":"hello"}],"frequency_penalty":1.5}`)
+
+	benchBodyRejectedRecursive = buildBenchPathologicalBody()
+)
+
+func buildBenchPathologicalBody() []byte {
+	deep := `{"type":"object"}`
+	for i := 0; i < 200; i++ {
+		deep = `{"type":"object","properties":{"x":` + deep + `}}`
+	}
+	return []byte(`{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":` + deep + `}},"messages":[{"role":"user","content":"hello"}]}`)
+}
+
+func BenchmarkNormalizeChatRequest(b *testing.B) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{"Minimal", benchBodyMinimal},
+		{"Typical", benchBodyTypical},
+		{"Heavy", benchBodyHeavy},
+		{"WithResponseFormat", benchBodyWithResponseFormat},
+		{"RejectedUnknownField", benchBodyRejectedUnknown},
+		{"RejectedRecursiveSchema", benchBodyRejectedRecursive},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tc.body)))
+			for i := 0; i < b.N; i++ {
+				_, _, _ = normalizeChatRequest(tc.body)
+			}
+		})
+	}
+}

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -156,12 +156,16 @@ type SanitizeFloatMapParameterHandler struct {
 	Min              *float64
 	Max              *float64
 	DropFieldIfEmpty bool
+	MaxEntries int
 }
 
 func (h SanitizeFloatMapParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
 	raw, ok := ctx.Document.Object(parameter.Name)
 	if !ok {
 		return nil
+	}
+	if h.MaxEntries > 0 && len(raw) > h.MaxEntries {
+		return badChatRequest("%s: map size %d exceeds limit %d", parameter.Name, len(raw), h.MaxEntries)
 	}
 	for key, value := range raw {
 		number, ok := numericJSONValueAsFloat64(value)
@@ -227,6 +231,38 @@ func (h ClampUintToFieldParameterHandler) Apply(ctx *RequestFilterContext, param
 	}
 	if value > maxValue {
 		ctx.Document.Set(parameter.Name, maxValue)
+	}
+	return nil
+}
+
+// LengthCapListParameterHandler bounds the number of entries in a JSON array, and
+// optionally the byte length of each string entry. Used for fields like `stop`,
+// `stop_token_ids`, and `bad_words` -- vLLM scans every entry against every generated
+// token, so unbounded arrays linearly slow inference. MaxEntries=0 disables the array cap,
+// MaxEntryLen=0 disables the per-string cap (use 0 for int-only arrays).
+type LengthCapListParameterHandler struct {
+	MaxEntries  int
+	MaxEntryLen int
+}
+
+func (h LengthCapListParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
+	raw, ok := ctx.Document.Array(parameter.Name)
+	if !ok {
+		return nil
+	}
+	if h.MaxEntries > 0 && len(raw) > h.MaxEntries {
+		return badChatRequest("%s: array length %d exceeds limit %d", parameter.Name, len(raw), h.MaxEntries)
+	}
+	if h.MaxEntryLen > 0 {
+		for i, item := range raw {
+			s, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if len(s) > h.MaxEntryLen {
+				return badChatRequest("%s[%d]: string length %d exceeds limit %d", parameter.Name, i, len(s), h.MaxEntryLen)
+			}
+		}
 	}
 	return nil
 }
@@ -505,6 +541,9 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 		newParameter("messages"),
 		newParameter("max_tokens"),
 		newParameter("max_completion_tokens"),
+		newParameter("seed"),
+		newParameter("skip_special_tokens"),
+		newParameter("detokenize"),
 		newParameter("n").
 			withRule(RequestFilterStagePostLimits, CapUintParameterHandler{Max: MaxChatRequestChoices}),
 		newParameter("temperature").
@@ -518,14 +557,23 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 		newParameter("repetition_penalty").
 			withRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}),
 		newParameter("logit_bias").
-			withRule(RequestFilterStagePostLimits, SanitizeFloatMapParameterHandler{StripNonFinite: true, Min: floatPointer(-100), Max: floatPointer(100), DropFieldIfEmpty: true}),
-		newParameter("stop"),
-		newParameter("stop_token_ids"),
-		newParameter("seed"),
-		newParameter("skip_special_tokens"),
-		newParameter("detokenize"),
-		newParameter("thinking"),
-		newParameter("chat_template_kwargs"),
+			withRule(RequestFilterStagePostLimits, SanitizeFloatMapParameterHandler{StripNonFinite: true, Min: floatPointer(-100), Max: floatPointer(100), DropFieldIfEmpty: true, MaxEntries: 1024}),
+		newParameter("stop").
+			withRule(RequestFilterStagePreValidation, LengthCapListParameterHandler{MaxEntries: 16, MaxEntryLen: 256}),
+		newParameter("stop_token_ids").
+			withRule(RequestFilterStagePreValidation, LengthCapListParameterHandler{MaxEntries: 64}),
+		newParameter("thinking").
+			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
+				Validator: paramvalidators.ThinkingValidator{},
+			}),
+		newParameter("chat_template_kwargs").
+			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
+				Validator: paramvalidators.ChatTemplateKwargsValidator{
+					MaxDepth: 5,
+					MaxSize:  16 * 1024,
+					MaxNodes: 128,
+				},
+			}),
 		newParameter("tool_choice").
 			withRule(RequestFilterStagePreValidation, RejectStringValueParameterHandler{Value: "required", Message: unsupportedChatParameterMessage("tool_choice=required")}),
 		newParameter("min_tokens").
@@ -541,9 +589,19 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 					return strings.TrimSpace(value) != ""
 				},
 				DropFieldIfEmpty: true,
-			}),
+			}).
+			withRule(RequestFilterStagePreValidation, LengthCapListParameterHandler{MaxEntries: 64, MaxEntryLen: 128}),
 		newParameter("tools").
-			withRule(RequestFilterStagePreValidation, CustomParameterHandler{ApplyFunc: stripEmptyToolsAndToolChoice}),
+			withRule(RequestFilterStagePreValidation, CustomParameterHandler{ApplyFunc: stripEmptyToolsAndToolChoice}).
+			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
+				Validator: paramvalidators.ToolsValidator{
+					MaxDepth:  5,
+					MaxSize:   16 * 1024,
+					MaxNodes:  128,
+					MaxBranch: 16,
+					MaxEnum:   256,
+				},
+			}),
 		newParameter("logprobs").
 			withRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: true}),
 		newParameter("top_logprobs").

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -6,21 +6,8 @@ import (
 	"math"
 	"strconv"
 	"strings"
-)
 
-type ParameterCategory int
-
-const (
-	ParameterCategoryAny ParameterCategory = iota
-	ParameterCategoryString
-	ParameterCategoryBool
-	ParameterCategoryStringList
-	ParameterCategoryIntList
-	ParameterCategoryFloatRange
-	ParameterCategoryIntRange
-	ParameterCategoryIntToFloat
-	ParameterCategoryObject
-	ParameterCategoryObjectArray
+	"devshard/cmd/devshardctl/paramvalidators"
 )
 
 type RequestFilterStage int
@@ -32,31 +19,15 @@ const (
 	RequestFilterStagePostLimits
 )
 
-type ParameterSupport int
-
-const (
-	ParameterSupportPassthrough ParameterSupport = iota
-	// Strip drops an unsupported field but keeps the request itself valid.
-	ParameterSupportStrip
-	// Reject fails the request because forwarding it would violate the upstream contract.
-	ParameterSupportReject
-	// Sanitize rewrites a field into an allowed shape or value range.
-	ParameterSupportSanitize
-	// Force overwrites the field with a gateway-owned value.
-	ParameterSupportForce
-)
-
 // ParameterRule describes one transformation for a field at a specific pipeline stage.
 type ParameterRule struct {
 	Stage   RequestFilterStage
-	Support ParameterSupport
 	Handler ParameterHandler
 }
 
 type VLLMParameter struct {
-	Name     string
-	Category ParameterCategory
-	Rules    []ParameterRule
+	Name  string
+	Rules []ParameterRule
 }
 
 type ParameterHandler interface {
@@ -271,6 +242,27 @@ func (h CustomParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMP
 	return h.ApplyFunc(ctx, parameter)
 }
 
+// DocumentValidator is the contract pure validators in paramvalidators expose.
+// Adapter wraps them so their errors become badChatRequest(400) responses without coupling
+// each validator to the gateway's pipeline types.
+type DocumentValidator interface {
+	Validate(map[string]any) error
+}
+
+type DocumentValidatorHandler struct {
+	Validator DocumentValidator
+}
+
+func (h DocumentValidatorHandler) Apply(ctx *RequestFilterContext, _ VLLMParameter) error {
+	if h.Validator == nil {
+		return nil
+	}
+	if err := h.Validator.Validate(ctx.Document.Raw()); err != nil {
+		return wrapBadChatRequest(err)
+	}
+	return nil
+}
+
 type ChatRequestDocument struct {
 	raw map[string]any
 }
@@ -283,7 +275,21 @@ func (d *ChatRequestDocument) Keys() []string {
 	return keys
 }
 
+// MaxRequestNestingDepth bounds JSON nesting before we hand the bytes to encoding/json.
+// encoding/json allocates O(input size) per recursion level, so a 7 KiB body nested 200
+// levels deep blows up to ~180 KiB of map[string]any wrappers. The whitelist rules then
+// reject in nanoseconds, but the decoder has already paid the cost. The pre-scan defuses
+// that amplification cheaply.
+//
+// 32 leaves at least 3x headroom over the deepest legitimate request shape we forward:
+// `tools[].function.parameters` or `response_format.json_schema.schema` nested under their
+// wrappers (~9-10 levels) plus a small allowance for client-side structuring.
+const MaxRequestNestingDepth = 32
+
 func decodeChatRequestDocument(body []byte) (*ChatRequestDocument, error) {
+	if err := ensureRequestNestingDepth(body, MaxRequestNestingDepth); err != nil {
+		return nil, err
+	}
 	var raw map[string]any
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.UseNumber()
@@ -291,6 +297,51 @@ func decodeChatRequestDocument(body []byte) (*ChatRequestDocument, error) {
 		return nil, badChatRequest("parse request: %v", err)
 	}
 	return &ChatRequestDocument{raw: raw}, nil
+}
+
+// ensureRequestNestingDepth performs a byte-level scan that bounds JSON nesting before any
+// allocation-heavy decode happens. It tracks quoted strings and escape sequences but
+// otherwise ignores semantic structure -- the goal is to bound the decoder, not to validate
+// JSON shape; malformed JSON still flows through to the regular parser and gets a normal
+// HTTP 400.
+func ensureRequestNestingDepth(body []byte, maxDepth int) error {
+	depth := 0
+	inString := false
+	escaped := false
+	for _, b := range body {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch b {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch b {
+		case '"':
+			inString = true
+		case '{', '[':
+			depth++
+			if depth > maxDepth {
+				return badChatRequest("request nesting depth exceeds limit %d", maxDepth)
+			}
+		case '}', ']':
+			depth--
+			if depth < 0 {
+				// More closers than openers. The decoder will reject the malformed body
+				// with a normal parse error later; rebase to 0 so subsequent valid blocks
+				// are still bounded by maxDepth instead of needing maxDepth+|imbalance|
+				// extra opens before tripping the cap.
+				depth = 0
+			}
+		}
+	}
+	return nil
 }
 
 func (d *ChatRequestDocument) Marshal() ([]byte, error) {
@@ -301,20 +352,16 @@ func (d *ChatRequestDocument) Marshal() ([]byte, error) {
 	return updatedBody, nil
 }
 
-func (d *ChatRequestDocument) DecodeInto(dst any) error {
-	body, err := d.Marshal()
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(body, dst); err != nil {
-		return badChatRequest("parse request: %v", err)
-	}
-	return nil
-}
-
 func (d *ChatRequestDocument) Has(name string) bool {
 	_, ok := d.raw[name]
 	return ok
+}
+
+// Raw exposes the underlying decoded map for handlers (in this package or external) that
+// need direct access to inspect or mutate the top-level fields. The returned map is the live
+// document -- modifications are reflected in subsequent reads and the final marshal.
+func (d *ChatRequestDocument) Raw() map[string]any {
+	return d.raw
 }
 
 func (d *ChatRequestDocument) Get(name string) (any, bool) {
@@ -364,18 +411,37 @@ func newRequestFilterContext(body []byte, adminAuthenticated bool, limits output
 	}, nil
 }
 
+// DecodeRequest populates ctx.Request from ctx.Document via direct field reads. Previously
+// this was a json.Marshal + json.Unmarshal round-trip just to project the document into a
+// 5-field struct -- that doubled the allocation count on every request. Direct reads keep
+// the behavior (strict types, null-tolerant) but skip the round-trip.
 func (ctx *RequestFilterContext) DecodeRequest() error {
 	var req chatRequest
-	if err := ctx.Document.DecodeInto(&req); err != nil {
+	if err := readChatRequestFields(ctx.Document, &req); err != nil {
 		return err
 	}
 	ctx.Request = req
 	return nil
 }
 
+// SyncRequestView refreshes ctx.Request after PostLimits rules ran. Why we explicitly
+// preserve the token fields instead of re-reading them from the document:
+//
+//   - When the client sends only `max_completion_tokens` (no `max_tokens`),
+//     `applyOutputTokenLimits` sets `ctx.Request.MaxTokens` from the resolved
+//     `max_completion_tokens` (see request_filters.go:139) but does NOT write a
+//     corresponding `max_tokens` key into the document. Re-reading the document would
+//     therefore reset `req.MaxTokens` to 0.
+//   - In the other three branches of `applyOutputTokenLimits`, the document DOES carry
+//     the same value, so preserving from `ctx.Request` is a no-op. Net effect: this
+//     branch only matters for the max-completion-only path, locked in by
+//     TestNormalizeChatRequestDefaultsAndCapsOutputTokens.
+//
+// Other fields are re-read so caps applied by PostLimits rules (for example `n` via
+// CapUintParameterHandler) propagate into the projection.
 func (ctx *RequestFilterContext) SyncRequestView() error {
 	var req chatRequest
-	if err := ctx.Document.DecodeInto(&req); err != nil {
+	if err := readChatRequestFields(ctx.Document, &req); err != nil {
 		return err
 	}
 	req.MaxTokens = ctx.Request.MaxTokens
@@ -384,64 +450,121 @@ func (ctx *RequestFilterContext) SyncRequestView() error {
 	return nil
 }
 
+func readChatRequestFields(doc *ChatRequestDocument, req *chatRequest) error {
+	if raw, ok := doc.Get("model"); ok && raw != nil {
+		s, ok := raw.(string)
+		if !ok {
+			return badChatRequest("parse request: model must be a string")
+		}
+		req.Model = s
+	}
+	if raw, ok := doc.Get("stream"); ok && raw != nil {
+		b, ok := raw.(bool)
+		if !ok {
+			return badChatRequest("parse request: stream must be a boolean")
+		}
+		req.Stream = b
+	}
+	if err := readUint64Field(doc, "max_tokens", &req.MaxTokens); err != nil {
+		return err
+	}
+	if err := readUint64Field(doc, "max_completion_tokens", &req.MaxCompletionTokens); err != nil {
+		return err
+	}
+	if err := readUint64Field(doc, "n", &req.N); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readUint64Field(doc *ChatRequestDocument, name string, dst *uint64) error {
+	raw, ok := doc.Get(name)
+	if !ok || raw == nil {
+		return nil
+	}
+	n, ok := numericJSONValueAsUint64(raw)
+	if !ok {
+		return badChatRequest("parse request: %s must be a non-negative integer", name)
+	}
+	*dst = n
+	return nil
+}
+
 type VLLMParameterCatalog struct {
 	parameters []VLLMParameter
+	known      map[string]struct{}
 }
 
 var defaultParameterCatalog = defaultVLLMParameterCatalog()
 
 // The catalog is the single source of truth for how each supported OpenAI/vLLM field is treated.
 func defaultVLLMParameterCatalog() VLLMParameterCatalog {
-	return VLLMParameterCatalog{parameters: []VLLMParameter{
-		newParameter("model", ParameterCategoryString),
-		newParameter("stream", ParameterCategoryBool),
-		newParameter("messages", ParameterCategoryObjectArray),
-		newParameter("max_tokens", ParameterCategoryIntRange),
-		newParameter("max_completion_tokens", ParameterCategoryIntRange),
-		newParameter("n", ParameterCategoryIntRange).
-			withSanitizeRule(RequestFilterStagePostLimits, CapUintParameterHandler{Max: MaxChatRequestChoices}),
-		newParameter("temperature", ParameterCategoryFloatRange).
-			withSanitizeRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true, Max: floatPointer(MaxTemperature)}),
-		newParameter("top_p", ParameterCategoryFloatRange).
-			withSanitizeRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true}),
-		newParameter("top_k", ParameterCategoryIntRange).
-			withSanitizeRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true}),
-		newParameter("min_p", ParameterCategoryFloatRange).
-			withSanitizeRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true}),
-		newParameter("repetition_penalty", ParameterCategoryFloatRange).
-			withSanitizeRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}),
-		newParameter("logit_bias", ParameterCategoryIntToFloat).
-			withSanitizeRule(RequestFilterStagePostLimits, SanitizeFloatMapParameterHandler{StripNonFinite: true, Min: floatPointer(-100), Max: floatPointer(100), DropFieldIfEmpty: true}),
-		newParameter("stop", ParameterCategoryStringList),
-		newParameter("stop_token_ids", ParameterCategoryIntList),
-		newParameter("seed", ParameterCategoryIntRange),
-		newParameter("skip_special_tokens", ParameterCategoryBool),
-		newParameter("detokenize", ParameterCategoryBool),
-		newParameter("thinking", ParameterCategoryObject),
-		newParameter("chat_template_kwargs", ParameterCategoryObject),
-		newParameter("tool_choice", ParameterCategoryString).
-			withRejectRule(RequestFilterStagePreValidation, RejectStringValueParameterHandler{Value: "required", Message: unsupportedChatParameterMessage("tool_choice=required")}),
-		newParameter("min_tokens", ParameterCategoryIntRange).
-			withConditionalStripRule(RequestFilterStagePreValidation, ConditionalStripParameterHandler{
+	parameters := []VLLMParameter{
+		newParameter("model"),
+		newParameter("stream"),
+		newParameter("messages"),
+		newParameter("max_tokens"),
+		newParameter("max_completion_tokens"),
+		newParameter("n").
+			withRule(RequestFilterStagePostLimits, CapUintParameterHandler{Max: MaxChatRequestChoices}),
+		newParameter("temperature").
+			withRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true, Max: floatPointer(MaxTemperature)}),
+		newParameter("top_p").
+			withRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true}),
+		newParameter("top_k").
+			withRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true}),
+		newParameter("min_p").
+			withRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true}),
+		newParameter("repetition_penalty").
+			withRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}),
+		newParameter("logit_bias").
+			withRule(RequestFilterStagePostLimits, SanitizeFloatMapParameterHandler{StripNonFinite: true, Min: floatPointer(-100), Max: floatPointer(100), DropFieldIfEmpty: true}),
+		newParameter("stop"),
+		newParameter("stop_token_ids"),
+		newParameter("seed"),
+		newParameter("skip_special_tokens"),
+		newParameter("detokenize"),
+		newParameter("thinking"),
+		newParameter("chat_template_kwargs"),
+		newParameter("tool_choice").
+			withRule(RequestFilterStagePreValidation, RejectStringValueParameterHandler{Value: "required", Message: unsupportedChatParameterMessage("tool_choice=required")}),
+		newParameter("min_tokens").
+			withRule(RequestFilterStagePreValidation, ConditionalStripParameterHandler{
 				Predicate: func(ctx *RequestFilterContext) bool {
 					return ctx.Document.Has("stop_token_ids")
 				},
 			}).
-			withSanitizeRule(RequestFilterStagePostLimits, ClampUintToFieldParameterHandler{MaxField: "max_tokens"}),
-		newParameter("bad_words", ParameterCategoryStringList).
-			withSanitizeRule(RequestFilterStagePreValidation, SanitizeStringListParameterHandler{
+			withRule(RequestFilterStagePostLimits, ClampUintToFieldParameterHandler{MaxField: "max_tokens"}),
+		newParameter("bad_words").
+			withRule(RequestFilterStagePreValidation, SanitizeStringListParameterHandler{
 				Keep: func(value string) bool {
 					return strings.TrimSpace(value) != ""
 				},
 				DropFieldIfEmpty: true,
 			}),
-		newParameter("tools", ParameterCategoryObjectArray).
-			withSanitizeRule(RequestFilterStagePreValidation, CustomParameterHandler{ApplyFunc: stripEmptyToolsAndToolChoice}),
-		newParameter("logprobs", ParameterCategoryBool).
-			withForceRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: true}),
-		newParameter("top_logprobs", ParameterCategoryIntRange).
-			withForceRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: 5}),
-	}}
+		newParameter("tools").
+			withRule(RequestFilterStagePreValidation, CustomParameterHandler{ApplyFunc: stripEmptyToolsAndToolChoice}),
+		newParameter("logprobs").
+			withRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: true}),
+		newParameter("top_logprobs").
+			withRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: 5}),
+		newParameter("response_format").
+			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
+				Validator: paramvalidators.ResponseFormatValidator{
+					MaxDepth:   5,
+					MaxSize:    16 * 1024,
+					MaxNodes:   128,
+					MaxBranch:  16,
+					MaxEnum:    256,
+					MaxNameLen: 64,
+				},
+			}),
+	}
+	known := make(map[string]struct{}, len(parameters))
+	for _, p := range parameters {
+		known[p.Name] = struct{}{}
+	}
+	return VLLMParameterCatalog{parameters: parameters, known: known}
 }
 
 func (c VLLMParameterCatalog) Apply(stage RequestFilterStage, ctx *RequestFilterContext) error {
@@ -467,12 +590,8 @@ func (c VLLMParameterCatalog) rejectUnknownParameters(ctx *RequestFilterContext)
 	if ctx == nil || ctx.Document == nil {
 		return nil
 	}
-	known := make(map[string]struct{}, len(c.parameters))
-	for _, parameter := range c.parameters {
-		known[parameter.Name] = struct{}{}
-	}
-	for _, key := range ctx.Document.Keys() {
-		if _, ok := known[key]; ok {
+	for key := range ctx.Document.raw {
+		if _, ok := c.known[key]; ok {
 			continue
 		}
 		return badChatRequest("%s", unsupportedChatParameterMessage(key))
@@ -480,33 +599,13 @@ func (c VLLMParameterCatalog) rejectUnknownParameters(ctx *RequestFilterContext)
 	return nil
 }
 
-func newParameter(name string, category ParameterCategory) VLLMParameter {
-	return VLLMParameter{Name: name, Category: category}
+func newParameter(name string) VLLMParameter {
+	return VLLMParameter{Name: name}
 }
 
-func (p VLLMParameter) appendRule(stage RequestFilterStage, support ParameterSupport, handler ParameterHandler) VLLMParameter {
-	p.Rules = append(p.Rules, ParameterRule{Stage: stage, Support: support, Handler: handler})
+func (p VLLMParameter) withRule(stage RequestFilterStage, handler ParameterHandler) VLLMParameter {
+	p.Rules = append(p.Rules, ParameterRule{Stage: stage, Handler: handler})
 	return p
-}
-
-func (p VLLMParameter) withStripRule(stage RequestFilterStage) VLLMParameter {
-	return p.appendRule(stage, ParameterSupportStrip, StripParameterHandler{})
-}
-
-func (p VLLMParameter) withConditionalStripRule(stage RequestFilterStage, handler ConditionalStripParameterHandler) VLLMParameter {
-	return p.appendRule(stage, ParameterSupportStrip, handler)
-}
-
-func (p VLLMParameter) withRejectRule(stage RequestFilterStage, handler ParameterHandler) VLLMParameter {
-	return p.appendRule(stage, ParameterSupportReject, handler)
-}
-
-func (p VLLMParameter) withSanitizeRule(stage RequestFilterStage, handler ParameterHandler) VLLMParameter {
-	return p.appendRule(stage, ParameterSupportSanitize, handler)
-}
-
-func (p VLLMParameter) withForceRule(stage RequestFilterStage, handler ParameterHandler) VLLMParameter {
-	return p.appendRule(stage, ParameterSupportForce, handler)
 }
 
 func stripEmptyToolsAndToolChoice(ctx *RequestFilterContext, _ VLLMParameter) error {

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -52,17 +52,6 @@ func (h ConditionalStripParameterHandler) Apply(ctx *RequestFilterContext, param
 	return nil
 }
 
-type RejectParameterHandler struct {
-	Message string
-}
-
-func (h RejectParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	if ctx.Document.Has(parameter.Name) {
-		return badChatRequest("%s", h.Message)
-	}
-	return nil
-}
-
 type RejectStringValueParameterHandler struct {
 	Value   string
 	Message string
@@ -70,25 +59,6 @@ type RejectStringValueParameterHandler struct {
 
 func (h RejectStringValueParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
 	current, ok := ctx.Document.String(parameter.Name)
-	if ok && current == h.Value {
-		return badChatRequest("%s", h.Message)
-	}
-	return nil
-}
-
-type RejectNestedStringValueParameterHandler struct {
-	Parent  string
-	Field   string
-	Value   string
-	Message string
-}
-
-func (h RejectNestedStringValueParameterHandler) Apply(ctx *RequestFilterContext, _ VLLMParameter) error {
-	parent, ok := ctx.Document.Object(h.Parent)
-	if !ok {
-		return nil
-	}
-	current, ok := parent[h.Field].(string)
 	if ok && current == h.Value {
 		return badChatRequest("%s", h.Message)
 	}
@@ -156,7 +126,7 @@ type SanitizeFloatMapParameterHandler struct {
 	Min              *float64
 	Max              *float64
 	DropFieldIfEmpty bool
-	MaxEntries int
+	MaxEntries       int
 }
 
 func (h SanitizeFloatMapParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -235,6 +235,24 @@ func (h ClampUintToFieldParameterHandler) Apply(ctx *RequestFilterContext, param
 	return nil
 }
 
+// ValidateUintParameterHandler rejects the request if the field is present but its value
+// cannot be parsed as a non-negative integer that fits in uint64. Pass-through when the
+// field is absent. Used for fields like `seed` where vLLM expects a uint64 and we want to
+// catch garbage types at the gateway boundary rather than relying on the upstream's error
+// path.
+type ValidateUintParameterHandler struct{}
+
+func (h ValidateUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
+	raw, exists := ctx.Document.Get(parameter.Name)
+	if !exists || raw == nil {
+		return nil
+	}
+	if _, ok := numericJSONValueAsUint64(raw); !ok {
+		return badChatRequest("%s: must be a non-negative integer", parameter.Name)
+	}
+	return nil
+}
+
 // LengthCapListParameterHandler bounds the number of entries in a JSON array, and
 // optionally the byte length of each string entry. Used for fields like `stop`,
 // `stop_token_ids`, and `bad_words` -- vLLM scans every entry against every generated
@@ -538,10 +556,12 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 	parameters := []VLLMParameter{
 		newParameter("model"),
 		newParameter("stream"),
-		newParameter("messages"),
+		newParameter("messages").
+			withRule(RequestFilterStagePreValidation, LengthCapListParameterHandler{MaxEntries: 2048}),
 		newParameter("max_tokens"),
 		newParameter("max_completion_tokens"),
-		newParameter("seed"),
+		newParameter("seed").
+			withRule(RequestFilterStagePreValidation, ValidateUintParameterHandler{}),
 		newParameter("skip_special_tokens"),
 		newParameter("detokenize"),
 		newParameter("n").
@@ -595,11 +615,12 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 			withRule(RequestFilterStagePreValidation, CustomParameterHandler{ApplyFunc: stripEmptyToolsAndToolChoice}).
 			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 				Validator: paramvalidators.ToolsValidator{
-					MaxDepth:  5,
-					MaxSize:   16 * 1024,
-					MaxNodes:  128,
-					MaxBranch: 16,
-					MaxEnum:   256,
+					MaxDepth:      5,
+					MaxSize:       16 * 1024,
+					MaxNodes:      128,
+					MaxBranch:     16,
+					MaxEnum:       256,
+					MaxPatternLen: 512,
 				},
 			}),
 		newParameter("logprobs").
@@ -609,12 +630,13 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 		newParameter("response_format").
 			withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 				Validator: paramvalidators.ResponseFormatValidator{
-					MaxDepth:   5,
-					MaxSize:    16 * 1024,
-					MaxNodes:   128,
-					MaxBranch:  16,
-					MaxEnum:    256,
-					MaxNameLen: 64,
+					MaxDepth:      5,
+					MaxSize:       16 * 1024,
+					MaxNodes:      128,
+					MaxBranch:     16,
+					MaxEnum:       256,
+					MaxNameLen:    64,
+					MaxPatternLen: 512,
 				},
 			}),
 	}

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -802,11 +802,6 @@ func TestNormalizeChatRequestRejectsUnsupportedFields(t *testing.T) {
 			want: "enforced_tokens",
 		},
 		{
-			name: "json object response format",
-			body: `{"response_format":{"type":"json_object"},"messages":[{"role":"user","content":"hello"}]}`,
-			want: "response_format",
-		},
-		{
 			name: "guided regex",
 			body: `{"guided_regex":"[a-z]+","messages":[{"role":"user","content":"hello"}]}`,
 			want: "guided_regex",
@@ -815,16 +810,6 @@ func TestNormalizeChatRequestRejectsUnsupportedFields(t *testing.T) {
 			name: "guided grammar",
 			body: `{"guided_grammar":"root ::= item","messages":[{"role":"user","content":"hello"}]}`,
 			want: "guided_grammar",
-		},
-		{
-			name: "json schema response format",
-			body: `{"response_format":{"type":"json_schema"},"messages":[{"role":"user","content":"hello"}]}`,
-			want: "response_format",
-		},
-		{
-			name: "nested json schema response format",
-			body: `{"response_format":{"json_schema":{"name":"r","schema":{"type":"object"}}},"messages":[{"role":"user","content":"hello"}]}`,
-			want: "response_format",
 		},
 		{
 			name: "guided json",
@@ -891,6 +876,42 @@ func TestNormalizeChatRequestRejectsUnsupportedFields(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
 		})
 	}
+}
+
+// Integration coverage that response_format is routed through the catalog rule and that pipeline
+// errors are translated into HTTP 400. Exhaustive validator behavior lives in
+// filters_parameters/response_format_test.go.
+func TestNormalizeChatRequestResponseFormatPipeline(t *testing.T) {
+	t.Run("accepts type text", func(t *testing.T) {
+		body, _, err := normalizeChatRequest([]byte(`{"response_format":{"type":"text"},"messages":[{"role":"user","content":"hello"}]}`))
+		require.NoError(t, err)
+		require.Contains(t, string(body), `"response_format"`)
+	})
+
+	t.Run("accepts json_schema with simple schema", func(t *testing.T) {
+		body, _, err := normalizeChatRequest([]byte(`{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":{"type":"object","properties":{"x":{"type":"string"}}}}},"messages":[{"role":"user","content":"hello"}]}`))
+		require.NoError(t, err)
+		require.Contains(t, string(body), `"response_format"`)
+	})
+
+	t.Run("rejects unknown type with HTTP 400", func(t *testing.T) {
+		_, _, err := normalizeChatRequest([]byte(`{"response_format":{"type":"banana"},"messages":[{"role":"user","content":"hello"}]}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "response_format")
+		require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
+	})
+
+	t.Run("rejects pathological recursive schema with HTTP 400", func(t *testing.T) {
+		deepSchema := `{"type":"object"}`
+		for i := 0; i < 200; i++ {
+			deepSchema = `{"type":"object","properties":{"x":` + deepSchema + `}}`
+		}
+		body := `{"response_format":{"type":"json_schema","json_schema":{"name":"r","schema":` + deepSchema + `}},"messages":[{"role":"user","content":"hello"}]}`
+		_, _, err := normalizeChatRequest([]byte(body))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "depth")
+		require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
+	})
 }
 
 func TestNormalizeChatRequestRejectsMalformedMessages(t *testing.T) {

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -957,6 +957,66 @@ func TestNormalizeChatRequestEnforcesListCaps(t *testing.T) {
 	}
 }
 
+func TestNormalizeChatRequestEnforcesMessagesCountCap(t *testing.T) {
+	// Build a body with 2049 minimal valid user messages -- one over the cap.
+	var b strings.Builder
+	b.WriteString(`{"messages":[`)
+	for i := 0; i < 2049; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"role":"user","content":"hi"}`)
+	}
+	b.WriteString(`]}`)
+
+	_, _, err := normalizeChatRequest([]byte(b.String()))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "messages")
+	require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
+}
+
+func TestNormalizeChatRequestAcceptsMessagesAtCap(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`{"messages":[`)
+	for i := 0; i < 2048; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"role":"user","content":"hi"}`)
+	}
+	b.WriteString(`]}`)
+
+	_, _, err := normalizeChatRequest([]byte(b.String()))
+	require.NoError(t, err)
+}
+
+func TestNormalizeChatRequestValidatesSeed(t *testing.T) {
+	t.Run("accepts non-negative integer", func(t *testing.T) {
+		_, _, err := normalizeChatRequest([]byte(`{"seed":42,"messages":[{"role":"user","content":"hello"}]}`))
+		require.NoError(t, err)
+	})
+	t.Run("accepts absent seed", func(t *testing.T) {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hello"}]}`))
+		require.NoError(t, err)
+	})
+	t.Run("rejects negative seed", func(t *testing.T) {
+		_, _, err := normalizeChatRequest([]byte(`{"seed":-5,"messages":[{"role":"user","content":"hello"}]}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "seed")
+		require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
+	})
+	t.Run("rejects float seed", func(t *testing.T) {
+		_, _, err := normalizeChatRequest([]byte(`{"seed":3.14,"messages":[{"role":"user","content":"hello"}]}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "seed")
+	})
+	t.Run("rejects string seed", func(t *testing.T) {
+		_, _, err := normalizeChatRequest([]byte(`{"seed":"42","messages":[{"role":"user","content":"hello"}]}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "seed")
+	})
+}
+
 func TestNormalizeChatRequestEnforcesLogitBiasMapCap(t *testing.T) {
 	var b strings.Builder
 	b.WriteString(`{"logit_bias":{`)

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -911,6 +912,80 @@ func TestNormalizeChatRequestResponseFormatPipeline(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "depth")
 		require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
+	})
+}
+
+func TestNormalizeChatRequestEnforcesListCaps(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "stop too many entries",
+			body: `{"stop":[` + strings.Repeat(`"a",`, 16) + `"b"],"messages":[{"role":"user","content":"hello"}]}`,
+			want: "stop",
+		},
+		{
+			name: "stop entry too long",
+			body: `{"stop":["` + strings.Repeat("a", 257) + `"],"messages":[{"role":"user","content":"hello"}]}`,
+			want: "stop[0]",
+		},
+		{
+			name: "stop_token_ids too many entries",
+			body: `{"stop_token_ids":[` + strings.Repeat(`1,`, 64) + `2],"messages":[{"role":"user","content":"hello"}]}`,
+			want: "stop_token_ids",
+		},
+		{
+			name: "bad_words too many entries",
+			body: `{"bad_words":[` + strings.Repeat(`"a",`, 64) + `"b"],"messages":[{"role":"user","content":"hello"}]}`,
+			want: "bad_words",
+		},
+		{
+			name: "bad_words entry too long",
+			body: `{"bad_words":["` + strings.Repeat("a", 129) + `"],"messages":[{"role":"user","content":"hello"}]}`,
+			want: "bad_words[0]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := normalizeChatRequest([]byte(tt.body))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+			require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
+		})
+	}
+}
+
+func TestNormalizeChatRequestEnforcesLogitBiasMapCap(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`{"logit_bias":{`)
+	for i := 0; i < 1025; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`"`)
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(`":1`)
+	}
+	b.WriteString(`},"messages":[{"role":"user","content":"hello"}]}`)
+
+	_, _, err := normalizeChatRequest([]byte(b.String()))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "logit_bias")
+	require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
+}
+
+func TestNormalizeChatRequestAcceptsListCapsAtLimit(t *testing.T) {
+	t.Run("stop at exact entry limit", func(t *testing.T) {
+		body := `{"stop":[` + strings.TrimSuffix(strings.Repeat(`"a",`, 16), ",") + `],"messages":[{"role":"user","content":"hello"}]}`
+		_, _, err := normalizeChatRequest([]byte(body))
+		require.NoError(t, err)
+	})
+	t.Run("stop_token_ids at exact entry limit", func(t *testing.T) {
+		body := `{"stop_token_ids":[` + strings.TrimSuffix(strings.Repeat(`1,`, 64), ",") + `],"messages":[{"role":"user","content":"hello"}]}`
+		_, _, err := normalizeChatRequest([]byte(body))
+		require.NoError(t, err)
 	})
 }
 

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -359,42 +359,6 @@ func TestNormalizeChatRequestKeepsToolChoiceAutoWithTools(t *testing.T) {
 	require.Contains(t, raw, "tools")
 }
 
-func TestNormalizeChatRequestRejectsUnsupportedVLLMParameters(t *testing.T) {
-	tests := []struct {
-		name string
-		body string
-		want string
-	}{
-		{name: "beam search", body: `{"use_beam_search":true,"messages":[{"role":"user","content":"hello"}]}`, want: "use_beam_search"},
-		{name: "truncate prompt tokens", body: `{"truncate_prompt_tokens":16,"messages":[{"role":"user","content":"hello"}]}`, want: "truncate_prompt_tokens"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := normalizeChatRequest([]byte(tt.body))
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tt.want)
-		})
-	}
-}
-
-func TestNormalizeChatRequestRejectsContractViolatingVLLMParameters(t *testing.T) {
-	tests := []struct {
-		name string
-		body string
-		want string
-	}{
-		{name: "allowed token ids", body: `{"allowed_token_ids":[1,2,3],"messages":[{"role":"user","content":"hello"}]}`, want: "allowed_token_ids"},
-		{name: "ignore eos", body: `{"ignore_eos":true,"messages":[{"role":"user","content":"hello"}]}`, want: "ignore_eos"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := normalizeChatRequest([]byte(tt.body))
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tt.want)
-		})
-	}
-}
-
 func TestNormalizeChatRequestStripsEmptyBadWords(t *testing.T) {
 	body, _, err := normalizeChatRequest([]byte(`{
 		"bad_words": ["", "   ", "keep"],
@@ -764,24 +728,6 @@ func TestApplyKimiRequestOverridesTranslatesMoonshotThinkingForVLLM(t *testing.T
 			if tt.wantExtra != nil {
 				require.Equal(t, tt.wantExtra, kwargs["foo"])
 			}
-		})
-	}
-}
-
-func TestNormalizeChatRequestRejectsUnsupportedPenaltyFields(t *testing.T) {
-	tests := []struct {
-		name string
-		body string
-		want string
-	}{
-		{name: "presence penalty", body: `{"presence_penalty":1.2,"messages":[{"role":"user","content":"hello"}]}`, want: "presence_penalty"},
-		{name: "frequency penalty", body: `{"frequency_penalty":0.8,"messages":[{"role":"user","content":"hello"}]}`, want: "frequency_penalty"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := normalizeChatRequest([]byte(tt.body))
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tt.want)
 		})
 	}
 }
@@ -1237,4 +1183,59 @@ func TestPrepareChatRequestBodyAcceptsTenMiBBody(t *testing.T) {
 
 	_, _, err := prepareChatRequestBody(req)
 	require.NoError(t, err)
+}
+
+func TestEnsureRequestNestingDepth(t *testing.T) {
+	// nestedObjects produces `{"a":{"a":...}}` of the given object-nesting depth.
+	nestedObjects := func(depth int) []byte {
+		return []byte(strings.Repeat(`{"a":`, depth) + `1` + strings.Repeat(`}`, depth))
+	}
+
+	t.Run("at limit accepted", func(t *testing.T) {
+		require.NoError(t, ensureRequestNestingDepth(nestedObjects(MaxRequestNestingDepth), MaxRequestNestingDepth))
+	})
+
+	t.Run("one over limit rejected", func(t *testing.T) {
+		err := ensureRequestNestingDepth(nestedObjects(MaxRequestNestingDepth+1), MaxRequestNestingDepth)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "request nesting depth exceeds limit")
+	})
+
+	t.Run("array nesting counts equally", func(t *testing.T) {
+		body := []byte(strings.Repeat(`[`, MaxRequestNestingDepth+1) + `1` + strings.Repeat(`]`, MaxRequestNestingDepth+1))
+		err := ensureRequestNestingDepth(body, MaxRequestNestingDepth)
+		require.Error(t, err)
+	})
+
+	t.Run("braces inside strings do not count", func(t *testing.T) {
+		// Without string-awareness, this body would appear to nest 100 deep.
+		body := []byte(`{"k":"` + strings.Repeat(`{`, 100) + `"}`)
+		require.NoError(t, ensureRequestNestingDepth(body, MaxRequestNestingDepth))
+	})
+
+	t.Run("escaped quote inside string", func(t *testing.T) {
+		// The escaped quote must not exit string mode; the trailing braces inside the
+		// string still must not be counted.
+		body := []byte(`{"k":"x\"` + strings.Repeat(`{`, 100) + `"}`)
+		require.NoError(t, ensureRequestNestingDepth(body, MaxRequestNestingDepth))
+	})
+
+	t.Run("imbalanced closers rebase to zero", func(t *testing.T) {
+		// Excess closers must not let a later valid block bypass the limit by going negative.
+		body := []byte(strings.Repeat(`}`, 50) + strings.Repeat(`{`, MaxRequestNestingDepth+1))
+		err := ensureRequestNestingDepth(body, MaxRequestNestingDepth)
+		require.Error(t, err)
+	})
+}
+
+func TestNormalizeChatRequestRejectsBodyAtNestingLimit(t *testing.T) {
+	// Pipeline-level proof that the pre-scan participates in normalizeChatRequest.
+	deep := `"x"`
+	for i := 0; i < MaxRequestNestingDepth+1; i++ {
+		deep = `{"a":` + deep + `}`
+	}
+	body := `{"messages":[{"role":"user","content":` + deep + `}]}`
+	_, _, err := normalizeChatRequest([]byte(body))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "request nesting depth exceeds limit")
 }

--- a/devshard/docs/supported-params.md
+++ b/devshard/docs/supported-params.md
@@ -17,13 +17,88 @@ vLLM crashes on malformed or pathological requests (deep recursive JSON Schema, 
 
 Anything not on this whitelist does not reach the model. That is the contract.
 
+## Status at a glance
+
+### ✅ Implemented
+
+**Schema-walking validators** — same vLLM grammar-compiler attack surface. All apply depth/nodes/size/branch/enum bounds, ban `$ref`/`$defs`/`definitions`, validate `type` is a JSON-Schema primitive, and compile-check `pattern` regex with a length cap (defuses CVE-2025-48944):
+- `response_format` — `paramvalidators.ResponseFormatValidator`
+- `tools[].function.parameters` — `paramvalidators.ToolsValidator`
+- `chat_template_kwargs` — `paramvalidators.ChatTemplateKwargsValidator` (plain object, no JSON-Schema semantics; additionally rejects keys that override `apply_hf_chat_template()` positional args: `chat_template`, `tokenize`, `tools`, `documents`, `conversation`, `continue_final_message`, `padding`, `truncation`, `max_length`, `return_tensors`, `return_dict` — defuses CVE-2025-61620 + CVE-2025-62426)
+
+**Shape validators**:
+- `thinking` — `paramvalidators.ThinkingValidator`
+
+**Length / size caps**:
+- `messages` (≤2048) · `stop` (≤16/256B) · `stop_token_ids` (≤64) · `bad_words` (≤64/128B) · `logit_bias` map (≤1024 entries)
+
+**Numeric range sanitizers**:
+- `temperature` (≤2.0) · `top_p` · `top_k` · `min_p` · `repetition_penalty` (≤2.0) · `n` (≤5) · `logit_bias` values (`[-100, 100]`)
+
+**Type validators**:
+- `seed` — non-negative uint64
+- `tool_choice` — rejects `"required"`
+
+**Pipeline / forced**:
+- `max_tokens` / `max_completion_tokens` — defaults + caps via `applyOutputTokenLimits`
+- `min_tokens` — conditional strip + clamp
+- `logprobs` / `top_logprobs` — forced
+- `messages` contract — `defaultChatMessageProcessor.ValidateDocument`
+- Body-level: `MaxRequestNestingDepth=32`, `MaxChatRequestBodySize=10 MiB`
+
+**Pass-through (safe by type contract)**:
+- `model` · `stream` · `skip_special_tokens` · `detokenize`
+
+### ❌ Open / not yet implemented
+
+Field-level additions that Kimi K2/K2.6 actually accepts on the wire (per Moonshot's [chat reference](https://platform.kimi.ai/docs/api/chat) and [K2.6 quickstart](https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart)):
+
+- **`frequency_penalty`, `presence_penalty`** — Kimi accepts these but **for K2.6 only `0.0`** is valid (any other value is rejected upstream; that's a model-side constraint, not a security one). Easy add via `SanitizeFloatParameterHandler` with range `[-2, 2]`. Smallest concrete next step.
+- **`stream_options`** — Kimi accepts `{"include_usage": bool}`. Note: Kimi emits `usage` in *each choice's end-block*, not only in the trailing chunk (divergence from OpenAI). Add as a shape validator.
+- **`prompt_cache_key`** — string. Kimi's first-class context-cache tag (cheaper re-prompts). Add with a string-length cap (e.g. ≤256 B).
+- **`safety_identifier`** — Kimi's analogue to OpenAI's `user`. String pass-through; add over `user` (which Kimi does not document).
+- **`messages[].reasoning_content`** — *required* on assistant turns during multi-step tool-calling when thinking is enabled. The message validator already does NOT reject unknown assistant-message fields (only `tool_call_id` is disallowed on assistant), so this already passes through. Just document the contract; no code change needed.
+
+Structural additions:
+
+- **Per-message content byte size cap** — currently bounded only by the 10 MiB body cap; no per-message structural limit. Token-limit logic downstream catches the most pathological cases.
+- **Catalog → spec generator** — this doc is hand-written. `go generate` could derive the Supported table from `defaultVLLMParameterCatalog()` so it cannot drift.
+
+Verification / operational:
+
+These constraints are enforced by the vLLM engine configuration, not the gateway. The gateway cannot filter them — confirm on the serving side.
+
+**Engine version**
+- **Pin vLLM ≥ 0.20.0** — CVE-2026-44223 lets a single `repetition_penalty ≠ 1.0` (or any `frequency_penalty` / `presence_penalty`) crash EngineCore on vLLM 0.18.0–0.19.1 when `extract_hidden_states` speculative decoding is on. Confirm the deployed image's vLLM version before raising the cap on these fields. If the engine is older, the gateway must also reject `repetition_penalty ≠ 1.0` as a fallback. ([advisory](https://github.com/vllm-project/vllm/security/advisories/GHSA-83vm-p52w-f9pw))
+
+**Tool-call parser selection (all served models)**
+- **Disable `pythonic` tool-call parser** — CVE-2025-48887 catastrophic-backtracking ReDoS on the output path. The gateway can't block this; the engine must not run with `--tool-call-parser pythonic`. ([advisory](https://github.com/vllm-project/vllm/security/advisories/GHSA-w6q7-j642-7c25))
+
+**Per-model operational requirements**
+
+- **`Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`**
+  - Tool-call parser must be `hermes` (the model's default). Do NOT run with `--tool-call-parser qwen3_coder` — CVE-2025-9141 yields RCE via `eval()` on attacker-controlled tool arguments. The `qwen3_coder` parser is intended for `Qwen3-Coder` only. ([advisory](https://github.com/vllm-project/vllm/security/advisories/GHSA-79j6-g2m3-jgfw))
+  - Speculative decoding with `extract_hidden_states` must be off (see vLLM version note above) — otherwise `repetition_penalty` (currently allowed by the gateway) becomes a one-shot kill (CVE-2026-44223).
+  - Reasoning parser `qwen3` and hermes tool parser are known to surface 500s on certain Qwen3 output patterns (multiple JSON blobs, `<tool_call>` inside `<think>`). These are server-side parsing bugs the gateway can't prevent — they degrade availability, not security. Track upstream issues (see References).
+
+- **`moonshotai/Kimi-K2.6`** (text-only)
+  - No model-specific operational constraints beyond the engine-version and `pythonic` parser notes above. The model is text-only, so CVE-2026-44222 (VL special-token IndexError) does not apply.
+
+### 🚫 Won't add (out of scope or by design)
+
+- **`model` length cap** — redundant with 10 MiB body cap; minimal benefit on a routing-lookup field.
+- **`extra_body` / `extra_headers`** — open-ended escape hatches; breaks the strict-whitelist contract.
+- **Provider-specific fields without vLLM semantics**: `metadata`, `service_tier`, `store`, `parallel_tool_calls`, `reasoning_effort`, `reasoning`, `thinking_config`, `enable_thinking`, `user`, etc. See "Unsupported parameters" below for the full categorized list. (Note: `prompt_cache_key`, `stream_options`, `safety_identifier`, `messages[].reasoning_content` were moved to "❌ Open" above — Kimi K2.6 actually supports them.)
+- **vLLM-native structured-output bypass** (`guided_json`, `guided_regex`, `guided_grammar`, `guided_choice`, `enforced_tokens`) — would need their own validators; `response_format` covers the same intent with bounds.
+- **Special-token literal stripping in `messages[].content`** (CVE-2026-44222) — text like `<|vision_start|>` crashes vision-language models with an `IndexError`. Kimi-K2.6 is text-only so we are not exposed today. If we route to a VL model in the future, add a content sanitizer at this layer. ([advisory](https://github.com/vllm-project/vllm/security/advisories/GHSA-hpv8-x276-m59f))
+
 ## Supported parameters
 
 | Field | Category | Stage / rule | Behavior |
 | --- | --- | --- | --- |
 | `model` | string | — | Required. Pass-through. Selects the upstream model id. |
 | `stream` | bool | — | Pass-through. Streaming is enabled when `true`. |
-| `messages` | object array | message validator | Required, non-empty. Strict OpenAI-compatible message contract — see "Messages" section below. |
+| `messages` | object array | message validator + PreValidation length cap (`LengthCapListParameterHandler`) | Required, non-empty. `len(messages) ≤ 2048` (way above any realistic conversation; defense against JSON-parse memory amplification, independent of token count). Strict OpenAI-compatible message contract — see "Messages" section below. |
 | `max_tokens` | int range | PostLimits (token-limit pipeline) | If absent → set to `DefaultRequestMaxTokens`. Capped at `RequestMaxTokensCap` unless the request carries admin auth. When both `max_tokens` and `max_completion_tokens` are set, the smaller wins and both are aligned. |
 | `max_completion_tokens` | int range | PostLimits (token-limit pipeline) | Same rules as `max_tokens`. |
 | `n` | int range | PostLimits sanitize (`CapUintParameterHandler`) | Capped at `MaxChatRequestChoices` (5). |
@@ -35,18 +110,18 @@ Anything not on this whitelist does not reach the model. That is the contract.
 | `logit_bias` | int→float map | PostLimits sanitize (`SanitizeFloatMapParameterHandler`) | Keeps numeric entries in `[-100, 100]`. Drops the field if the map is empty after sanitization. Map size capped at 1024 entries (rejected with HTTP 400 over the cap). |
 | `stop` | string list | PreValidation length cap (`LengthCapListParameterHandler`) | Pass-through within bounds. Rejected if `len(stop) > 16` or any entry's string length > 256 bytes. |
 | `stop_token_ids` | int list | PreValidation length cap (`LengthCapListParameterHandler`) | Pass-through within bounds. Rejected if `len(stop_token_ids) > 64`. |
-| `seed` | int range | — | Pass-through. |
+| `seed` | int range | PreValidation type-check (`ValidateUintParameterHandler`) | Must parse as a non-negative integer that fits in uint64. Otherwise rejected with HTTP 400 at the gateway boundary instead of relying on the upstream's error path. |
 | `skip_special_tokens` | bool | — | Pass-through. vLLM-specific. |
 | `detokenize` | bool | — | Pass-through. vLLM-specific. |
 | `thinking` | object | PreValidation validate (`paramvalidators.ThinkingValidator`) | Must be `{"type": "enabled" \| "disabled"}`. Any other shape rejected. For `moonshotai/Kimi-K2.6` it is mirrored into `chat_template_kwargs.thinking` via `applyKimiRequestOverrides`. |
-| `chat_template_kwargs` | object | PreValidation validate (`paramvalidators.ChatTemplateKwargsValidator`) | Pass-through within plain-object bounds: depth ≤ 5, nodes ≤ 128, serialized size ≤ 16 KiB. Anything over those caps is rejected before vLLM's Jinja template renderer sees it. |
+| `chat_template_kwargs` | object | PreValidation validate (`paramvalidators.ChatTemplateKwargsValidator`) | Pass-through within plain-object bounds: depth ≤ 5, nodes ≤ 128, serialized size ≤ 16 KiB. Top-level keys that override `apply_hf_chat_template()` positional arguments are rejected (`chat_template`, `tokenize`, `tools`, `documents`, `conversation`, `continue_final_message`, `padding`, `truncation`, `max_length`, `return_tensors`, `return_dict` — defuses CVE-2025-61620 + CVE-2025-62426). `add_generation_prompt` is explicitly *allowed* as a legitimate template knob. |
 | `tool_choice` | string | PreValidation reject | Pass-through except `"required"` — rejected because the upstream contract does not honor it on the vLLM path. Stripped together with `tools` if `tools` arrives empty. |
 | `min_tokens` | int range | PreValidation conditional strip + PostLimits clamp | Dropped if `stop_token_ids` is also set (vLLM rejects the combination). Otherwise clamped to ≤ `max_tokens`. |
 | `bad_words` | string list | PreValidation sanitize + length cap | Empty/whitespace strings are removed. Field is dropped if the resulting list is empty. Then `len(bad_words) ≤ 64`, per-entry length ≤ 128 bytes. |
-| `tools` | object array | PreValidation sanitize + schema validate (`paramvalidators.ToolsValidator`) | Empty arrays drop both `tools` and `tool_choice`. Every `tools[].function.parameters` is walked as a JSON Schema with the same bounds as `response_format` (depth ≤ 5, nodes ≤ 128, branch arms ≤ 16, enum ≤ 256, size ≤ 16 KiB, `$ref`/`$defs`/`definitions` forbidden). vLLM compiles tool argument schemas through the same grammar path as `response_format`, so the bounds must match. |
+| `tools` | object array | PreValidation sanitize + schema validate (`paramvalidators.ToolsValidator`) | Empty arrays drop both `tools` and `tool_choice`. Every `tools[].function.parameters` is walked as a JSON Schema with the same bounds as `response_format` (depth ≤ 5, nodes ≤ 128, branch arms ≤ 16, enum ≤ 256, size ≤ 16 KiB; `$ref`/`$defs`/`definitions` forbidden; `type` must be a JSON-Schema primitive; `pattern` must compile as a regex within 512 B — CVE-2025-48944). vLLM compiles tool argument schemas through the same grammar path as `response_format`, so the bounds must match. |
 | `logprobs` | bool | PostLimits force | Forced to `true` for the gateway's observability pipeline regardless of what the client sent. |
 | `top_logprobs` | int range | PostLimits force | Forced to `5` for the same reason. |
-| `response_format` | object | PreValidation validate (`paramvalidators.ResponseFormatValidator`) | Accepted with bounds. `type` must be one of `text` / `json_object` / `json_schema`. For `json_schema`, the schema is walked once and rejected if depth > 5, nodes > 128, branch arms (anyOf/oneOf/allOf) > 16, enum > 256, serialized size > 16 KiB, or the schema contains `$ref` / `$defs` / `definitions`. |
+| `response_format` | object | PreValidation validate (`paramvalidators.ResponseFormatValidator`) | Accepted with bounds. `type` must be one of `text` / `json_object` / `json_schema`. For `json_schema`, the schema is walked once and rejected if depth > 5, nodes > 128, branch arms (anyOf/oneOf/allOf) > 16, enum > 256, serialized size > 16 KiB, or contains `$ref` / `$defs` / `definitions`. Every schema node's `type` must be a JSON-Schema primitive (`string`/`number`/`integer`/`object`/`boolean`/`array`/`null` or an array of those); `pattern` is byte-capped at 512 B and must compile as a regex (defuses CVE-2025-48944). |
 
 ### Messages contract (recap)
 
@@ -59,10 +134,6 @@ Enforced by `request_filters_messages.go`:
 - Content parts: only `{"type": "text", "text": "..."}` is accepted. Typed arrays of text parts are flattened to a single string before forwarding.
 - Empty tool `content` is normalized to a sentinel string; missing tool `content` is also normalized.
 
-## Pass-throughs that are safe by type contract
-
-These fields are accepted as known catalog entries without any per-rule validation because their JSON type alone bounds the value space: `model`, `stream`, `messages` (covered by `defaultChatMessageProcessor.ValidateDocument`), `max_tokens` / `max_completion_tokens` (covered by `applyOutputTokenLimits`), `seed`, `skip_special_tokens`, `detokenize`. Everything else that reaches vLLM is bounded by an explicit catalog rule (see the Supported table).
-
 ## Unsupported parameters (rejected)
 
 Every OpenAI / vLLM / provider-specific field that is **not** in the Supported table is rejected at `PreValidation`. The error response is HTTP 400 with body `feature "<name>" is temporarily unavailable`.
@@ -71,7 +142,7 @@ Grouped by why the field is off:
 
 | Group | Examples we reject today | Origin | Why off |
 | --- | --- | --- | --- |
-| Sampling penalties | `frequency_penalty`, `presence_penalty` | Kilo, OpenClaw, OpenAI canonical | vLLM supports them. Trivially safe to add via `SanitizeFloatParameterHandler` with range `[-2, 2]`. Pending only because we have not validated end-to-end on the vLLM build we run. **Smallest concrete next addition.** |
+| Sampling penalties | `frequency_penalty`, `presence_penalty` | Kilo, OpenClaw, OpenAI canonical | vLLM supports them. Trivially safe to add via `SanitizeFloatParameterHandler` with range `[-2, 2]`. Pending only because we have not validated end-to-end on the vLLM build we run. |
 | Structured-output (non-`response_format`) | `guided_json`, `guided_regex`, `guided_grammar`, `guided_choice`, `enforced_tokens`, `structured_outputs` | vLLM-native | Bypasses the response_format safety bounds. Same grammar-compiler attack surface; would need its own validator. |
 | Tool-calling extensions | `parallel_tool_calls`, `tool_choice="required"` | OpenClaw, OpenAI | Provider compatibility differs and `required` is rejected by upstream contract on the vLLM path. |
 | Routing / metadata | `metadata`, `service_tier`, `user`, `extra_body`, `extra_headers`, `provider`, `plugins`, `tags`, `seed_override` | Hermes, OpenClaw, Kilo | Vendor-specific; no inference-side meaning for vLLM. `extra_body` / `extra_headers` are open-ended escape hatches and break the whitelist contract. |
@@ -153,11 +224,11 @@ For `moonshotai/Kimi-K2.6` the gateway also writes `chat_template_kwargs.thinkin
 
 → `HTTP 400 — feature "response_format" is temporarily unavailable`. Same shape for any other unknown key.
 
-## Validation improvements (roadmap)
+## Design notes
 
-### Priority: safe `response_format`
+### `response_format` invariants (reference)
 
-The example below currently crashes vLLM because the JSON Schema contains ~200 nested `properties` levels:
+The motivating attack that drove the validator design — a JSON Schema with ~200 nested `properties` levels would crash vLLM:
 
 ```json
 {
@@ -187,31 +258,13 @@ A safe `response_format` handler must enforce all of the following at `PreValida
 
 Order of checks: type → name + regex → walk the schema once, counting depth, nodes, branch arms, enums, refusing on the first violation → only then `json.Marshal` the schema to enforce the byte-size cap. Walking comes first because `json.Marshal` is O(input size); doing it before the walk lets an attacker amplify a 200-level recursive payload into hundreds of allocations before the depth check ever fires. Walking first cuts that path from ~87 µs / 1606 allocs to ~560 ns / 2 allocs (Apple M2 Pro). Single bounded pass — no recursion without a depth counter.
 
-Status: **implemented** as a pure validator in subpackage `cmd/devshardctl/paramvalidators/response_format.go` — `paramvalidators.ResponseFormatValidator{MaxDepth: 5, MaxSize: 16384, MaxNodes: 128, MaxBranch: 16, MaxEnum: 256, MaxNameLen: 64}`. The main catalog wires it in via `DocumentValidatorHandler` at `RequestFilterStagePreValidation`. The walker policy is *inverted*: it descends into every object-valued or array-of-object-valued field except an explicit list of data carriers (`enum`/`const`/`default`/`examples`/`required`/`dependentRequired`), so new JSON-Schema keywords (`if`/`then`/`contains`/`unevaluatedProperties`/...) cannot smuggle deep nesting or `$ref` past the validator. Rejection categories are exported as sentinel errors (`ErrResponseFormatDepth`, `ErrResponseFormatRef`, etc.); callers can match them via `errors.Is` even after the gateway wraps with HTTP 400 status. Test coverage: exhaustive unit tests in `paramvalidators/response_format_test.go`; integration wiring in `request_filters_test.go::TestNormalizeChatRequestResponseFormatPipeline`.
+Implementation: `paramvalidators.ResponseFormatValidator` in `cmd/devshardctl/paramvalidators/response_format.go`, wired into the main catalog via `DocumentValidatorHandler` at `RequestFilterStagePreValidation`. The walker policy is *inverted*: it descends into every object-valued or array-of-object-valued field except an explicit list of data carriers (`enum`/`const`/`default`/`examples`/`required`/`dependentRequired`), so new JSON-Schema keywords (`if`/`then`/`contains`/`unevaluatedProperties`/...) cannot smuggle deep nesting or `$ref` past the validator.
 
-Calibrate the thresholds (depth, size, nodes) by running the new handler against the sample structured-output schemas from production clients before raising any limit.
+### Shared schema-walking infrastructure
 
-### Validator inventory (implemented)
+Schema-walk rejection categories are exposed as sentinel errors: `ErrSchemaDepth`, `ErrSchemaNodes`, `ErrSchemaSize`, `ErrSchemaRef`, `ErrSchemaEnum`, `ErrSchemaBranch`. They are shared by `SchemaBounds` (JSON-Schema-aware, used for `response_format` and `tools[].function.parameters`) and `ObjectBounds` (plain-object, used for `chat_template_kwargs`). The original response_format-specific sentinels (`ErrResponseFormatDepth` etc.) remain as aliases for backward compatibility.
 
-All HIGH/MEDIUM/LOW gaps from the original audit are now closed. Cross-reference: catalog wire-up in `defaultVLLMParameterCatalog()`; pure validator types in `paramvalidators/`.
-
-| Field | Validator | Bounds |
-| --- | --- | --- |
-| `response_format` | `paramvalidators.ResponseFormatValidator` | depth ≤ 5, nodes ≤ 128, anyOf/oneOf/allOf ≤ 16, enum ≤ 256, size ≤ 16 KiB; `$ref`/`$defs`/`definitions` banned |
-| `tools[].function.parameters` | `paramvalidators.ToolsValidator` (reuses `SchemaBounds`) | identical bounds to `response_format` (same vLLM grammar path) |
-| `chat_template_kwargs` | `paramvalidators.ChatTemplateKwargsValidator` (uses `ObjectBounds`) | plain-object depth ≤ 5, nodes ≤ 128, size ≤ 16 KiB |
-| `thinking` | `paramvalidators.ThinkingValidator` | exactly `{"type": "enabled" \| "disabled"}` |
-| `stop` | `LengthCapListParameterHandler` | `len ≤ 16`, per-entry ≤ 256 bytes |
-| `stop_token_ids` | `LengthCapListParameterHandler` | `len ≤ 64` |
-| `bad_words` | `SanitizeStringListParameterHandler` + `LengthCapListParameterHandler` | sanitize first (drop empty), then `len ≤ 64`, per-entry ≤ 128 bytes |
-| `logit_bias` | `SanitizeFloatMapParameterHandler` (with `MaxEntries`) | range `[-100, 100]` + `len ≤ 1024` |
-
-Schema-walk rejection categories are exposed as sentinel errors: `ErrSchemaDepth`, `ErrSchemaNodes`, `ErrSchemaSize`, `ErrSchemaRef`, `ErrSchemaEnum`, `ErrSchemaBranch`. They are shared by `SchemaBounds` (JSON-Schema-aware, used for `response_format` and `tools`) and `ObjectBounds` (plain-object, used for `chat_template_kwargs`). The original response_format-specific sentinels (`ErrResponseFormatDepth` etc.) remain as aliases for backward compatibility.
-
-### Still open (smaller items)
-
-- **`messages` total byte size** — only the 10 MiB body cap exists. Per-message content size is bounded later by token-limit logic, not by a structural validator at this layer.
-- **Catalog generation** — the Supported table above is hand-written. `go generate` could derive it from the catalog so this file does not drift.
+Calibrate the thresholds (depth, size, nodes) by running the validators against the sample structured-output schemas from production clients before raising any limit.
 
 ## Performance characteristics
 
@@ -241,10 +294,46 @@ The Heavy body now exercises `ToolsValidator` (walks `tools[].function.parameter
 
 Bench files: `request_filters_bench_test.go` (pipeline-level) and `paramvalidators/response_format_bench_test.go` (validator-level).
 
-## Where the code lives
+## References
 
-- Pipeline entry: `defaultChatRequestPipeline().Normalize` in `request_filters.go`.
-- Catalog, generic handlers (Strip/Reject/Sanitize/Force/Custom), `RequestFilterContext`, `ChatRequestDocument`, and the `DocumentValidatorHandler` adapter: `request_filters_parameters.go`.
-- Messages: `defaultChatMessageProcessor` in `request_filters_messages.go`.
-- Per-field pure validators (one file per edge case, no coupling to the main pipeline types): `paramvalidators/` subpackage. Today: `response_format.go`. New validators (e.g. `tools_schema.go`, `logit_bias_bounds.go`) should go here and be wired into the catalog via `DocumentValidatorHandler{Validator: paramvalidators.YourValidator{...}}`. Each validator should expose sentinel errors for its rejection categories so callers can match them via `errors.Is`.
-- Tests: integration in `request_filters_test.go`; per-validator unit tests in `paramvalidators/<name>_test.go`.
+Re-check these periodically for status changes (fixed-in versions, new variants, advisory updates). Sorted by relevance to this gateway.
+
+### Security advisories covered by current filters
+
+| ID | Title | Coverage in this gateway |
+| --- | --- | --- |
+| [CVE-2025-48944](https://nvd.nist.gov/vuln/detail/CVE-2025-48944) ([vLLM advisories index](https://github.com/vllm-project/vllm/security/advisories)) | xgrammar crash on invalid `type` or pattern | `SchemaBounds.validateSchemaTypeField` + `validateSchemaPatternField`. Walked on every `response_format` and `tools[].function.parameters` node. |
+| [CVE-2025-61620](https://nvd.nist.gov/vuln/detail/CVE-2025-61620) | `chat_template_kwargs` Jinja injection | `ChatTemplateKwargsValidator.forbiddenChatTemplateKwargsKeys` denylist (`chat_template`, …). |
+| [CVE-2025-62426](https://nvd.nist.gov/vuln/detail/CVE-2025-62426) | `tokenize=True` stalls the request handler | Same key denylist (`tokenize` rejected). |
+| [CVE-2026-34756 / GHSA-3mwp-wvh9-7528](https://github.com/vllm-project/vllm/security/advisories/GHSA-3mwp-wvh9-7528) | Unbounded `n` causes OOM | `CapUintParameterHandler` clamps `n ≤ 5`. |
+
+### Security advisories handled outside the gateway (ops-side)
+
+| ID | Title | Handling |
+| --- | --- | --- |
+| [CVE-2025-9141 / GHSA-79j6-g2m3-jgfw](https://github.com/vllm-project/vllm/security/advisories/GHSA-79j6-g2m3-jgfw) | RCE via `eval()` in `qwen3_coder` tool-call parser | Per-model ops constraint: keep `hermes` parser on Qwen3-235B-Instruct. |
+| [CVE-2025-48887 / GHSA-w6q7-j642-7c25](https://github.com/vllm-project/vllm/security/advisories/GHSA-w6q7-j642-7c25) | ReDoS in `pythonic` tool-call parser | Engine must not run with `--tool-call-parser pythonic`. |
+| [CVE-2026-44223 / GHSA-83vm-p52w-f9pw](https://github.com/vllm-project/vllm/security/advisories/GHSA-83vm-p52w-f9pw) | Penalty fields crash EngineCore with `extract_hidden_states` spec decode | Pin vLLM ≥ 0.20.0 or keep that spec-decode method disabled. |
+| [CVE-2026-44222 / GHSA-hpv8-x276-m59f](https://github.com/vllm-project/vllm/security/advisories/GHSA-hpv8-x276-m59f) | Special-token literals (`<\|vision_start\|>`, etc.) crash VL models | N/A for Kimi-K2.6 (text-only). For Qwen3-VL or future multimodal routing, add a content sanitizer. |
+
+### Qwen3 upstream issues to monitor
+
+Output-side parser bugs the gateway cannot prevent — track upstream fix status to know when 500-rate from these is expected to drop:
+
+- [vllm-project/vllm#17790](https://github.com/vllm-project/vllm/issues/17790) — hermes parser `JSONDecodeError` on multiple tool-call blobs
+- [vllm-project/vllm#27447](https://github.com/vllm-project/vllm/issues/27447) — `enable_thinking=false` breaks guided decoding
+- [vllm-project/vllm#29814](https://github.com/vllm-project/vllm/issues/29814) — Qwen3 reasoning parser edge cases
+- [vllm-project/vllm#39677](https://github.com/vllm-project/vllm/issues/39677) — structured output + thinking interaction
+- [vllm-project/vllm#40875](https://github.com/vllm-project/vllm/issues/40875) — related guided-decoding/thinking bug
+- [vllm-project/vllm#42021](https://github.com/vllm-project/vllm/issues/42021) — `<tool_call>` inside `<think>` breaks hermes parsing
+
+### Model documentation
+
+- [Moonshot AI — Kimi Chat API](https://platform.kimi.ai/docs/api/chat)
+- [Moonshot AI — Kimi K2.6 quickstart](https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart)
+- [Qwen3-235B-A22B-Instruct-2507 model card](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507-FP8)
+
+### Upstream projects
+
+- [vLLM security advisories](https://github.com/vllm-project/vllm/security/advisories) — review on engine upgrades.
+- [vLLM releases](https://github.com/vllm-project/vllm/releases) — verify the running image's `__version__` here against the advisory "fixed in" notes above.

--- a/devshard/docs/supported-params.md
+++ b/devshard/docs/supported-params.md
@@ -6,7 +6,7 @@ Reference for `POST /v1/chat/completions` on devshard. Documents which OpenAI/vL
 
 vLLM crashes on malformed or pathological requests (deep recursive JSON Schema, unsupported routing fields, unbounded objects). To keep the inference node healthy:
 
-1. **Body-level depth scan** (`ensureRequestNestingDepth` in `request_filters_parameters.go`). A byte-level pass bounds *whole-request* JSON nesting at `MaxRequestNestingDepth = 32` before `encoding/json` allocates anything. Without this, a 7 KiB body with 200 levels of nesting expands to ~180 KiB of `map[string]any` wrappers in the decoder — the validator below would still reject it, but the decoder has already paid the cost. The pre-scan defuses that amplification. (This is a different layer from the schema-level `MaxDepth = 5` cap below: the body limit is generous because legitimate requests can be ~10 levels deep through `messages[].content[].text` + `tools[].function.parameters` + `response_format.json_schema.schema`; the schema limit is tight because the grammar compiler in vLLM is the actual attack surface.)
+1. **Body-level depth scan** (`ensureRequestNestingDepth` in `request_filters_parameters.go`). A byte-level pass bounds whole-request JSON nesting at `MaxRequestNestingDepth = 32` before `encoding/json` allocates anything. Rationale and the legitimate-request depth budget live in the code comment over the constant. This is a separate layer from the schema-level `MaxDepth = 5` cap below: the body limit is generous because legitimate requests stack ~10 levels of wrappers; the schema limit is tight because the grammar compiler is the actual attack surface.
 2. Every inbound `/chat/completions` body is then decoded into a generic JSON document.
 3. `VLLMParameterCatalog` (`devshard/cmd/devshardctl/request_filters_parameters.go`) is a closed allow-list. The set of allowed keys is precomputed at catalog construction (no per-request map build). Any top-level field that is not in the catalog is rejected with `feature "<name>" is temporarily unavailable` (HTTP 400) before the request reaches the model.
 4. Parameter rules run in two stages:
@@ -118,7 +118,7 @@ These constraints are enforced by the vLLM engine configuration, not the gateway
 | `tool_choice` | string | PreValidation reject | Pass-through except `"required"` — rejected because the upstream contract does not honor it on the vLLM path. Stripped together with `tools` if `tools` arrives empty. |
 | `min_tokens` | int range | PreValidation conditional strip + PostLimits clamp | Dropped if `stop_token_ids` is also set (vLLM rejects the combination). Otherwise clamped to ≤ `max_tokens`. |
 | `bad_words` | string list | PreValidation sanitize + length cap | Empty/whitespace strings are removed. Field is dropped if the resulting list is empty. Then `len(bad_words) ≤ 64`, per-entry length ≤ 128 bytes. |
-| `tools` | object array | PreValidation sanitize + schema validate (`paramvalidators.ToolsValidator`) | Empty arrays drop both `tools` and `tool_choice`. Every `tools[].function.parameters` is walked as a JSON Schema with the same bounds as `response_format` (depth ≤ 5, nodes ≤ 128, branch arms ≤ 16, enum ≤ 256, size ≤ 16 KiB; `$ref`/`$defs`/`definitions` forbidden; `type` must be a JSON-Schema primitive; `pattern` must compile as a regex within 512 B — CVE-2025-48944). vLLM compiles tool argument schemas through the same grammar path as `response_format`, so the bounds must match. |
+| `tools` | object array | PreValidation sanitize + shape + schema validate (`paramvalidators.ToolsValidator`) | Empty arrays drop both `tools` and `tool_choice`. Each tool must declare `type: "function"` and a `function` object with a non-empty string `name` — the OpenAI tool contract — otherwise rejected before vLLM ever sees the request. If `function.parameters` is present, it is walked as a JSON Schema with the same bounds as `response_format` (depth ≤ 5, nodes ≤ 128, branch arms ≤ 16, enum ≤ 256, size ≤ 16 KiB; `$ref`/`$defs`/`definitions` forbidden; `type` must be a JSON-Schema primitive; `pattern` must compile as a regex within 512 B — CVE-2025-48944). Parameter-less tools are valid. vLLM compiles tool argument schemas through the same grammar path as `response_format`, so the bounds must match. |
 | `logprobs` | bool | PostLimits force | Forced to `true` for the gateway's observability pipeline regardless of what the client sent. |
 | `top_logprobs` | int range | PostLimits force | Forced to `5` for the same reason. |
 | `response_format` | object | PreValidation validate (`paramvalidators.ResponseFormatValidator`) | Accepted with bounds. `type` must be one of `text` / `json_object` / `json_schema`. For `json_schema`, the schema is walked once and rejected if depth > 5, nodes > 128, branch arms (anyOf/oneOf/allOf) > 16, enum > 256, serialized size > 16 KiB, or contains `$ref` / `$defs` / `definitions`. Every schema node's `type` must be a JSON-Schema primitive (`string`/`number`/`integer`/`object`/`boolean`/`array`/`null` or an array of those); `pattern` is byte-capped at 512 B and must compile as a regex (defuses CVE-2025-48944). |
@@ -262,7 +262,7 @@ Implementation: `paramvalidators.ResponseFormatValidator` in `cmd/devshardctl/pa
 
 ### Shared schema-walking infrastructure
 
-Schema-walk rejection categories are exposed as sentinel errors: `ErrSchemaDepth`, `ErrSchemaNodes`, `ErrSchemaSize`, `ErrSchemaRef`, `ErrSchemaEnum`, `ErrSchemaBranch`. They are shared by `SchemaBounds` (JSON-Schema-aware, used for `response_format` and `tools[].function.parameters`) and `ObjectBounds` (plain-object, used for `chat_template_kwargs`). The original response_format-specific sentinels (`ErrResponseFormatDepth` etc.) remain as aliases for backward compatibility.
+Schema-walk rejection categories are exposed as sentinel errors: `ErrSchemaDepth`, `ErrSchemaNodes`, `ErrSchemaSize`, `ErrSchemaRef`, `ErrSchemaEnum`, `ErrSchemaBranch`, `ErrSchemaType`, `ErrSchemaPattern`. They are shared by `SchemaBounds` (JSON-Schema-aware, used for `response_format` and `tools[].function.parameters`) and `ObjectBounds` (plain-object, used for `chat_template_kwargs`).
 
 Calibrate the thresholds (depth, size, nodes) by running the validators against the sample structured-output schemas from production clients before raising any limit.
 
@@ -272,25 +272,28 @@ End-to-end `normalizeChatRequest` (Apple M2 Pro, `-benchtime=2s`):
 
 | Body | ns/op | B/op | allocs/op |
 | --- | --- | --- | --- |
-| Minimal (47 B) | 2,799 | 2,450 | 43 |
-| Typical (132 B) | 4,432 | 2,947 | 67 |
-| Heavy (560 B) | 17,609 | 12,160 | 223 |
-| WithResponseFormat (279 B) | 9,611 | 6,776 | 139 |
-| RejectedUnknown (72 B) | 1,870 | 2,170 | 36 |
-| **RejectedRecursive (7.5 KiB attack)** | **1,063** | **96** | **2** |
+| Minimal (47 B) | 2,958 | 2,450 | 43 |
+| Typical (132 B) | 4,488 | 2,947 | 67 |
+| Heavy (~620 B) | 20,087 | 13,090 | 242 |
+| WithResponseFormat (279 B) | 10,746 | 6,776 | 139 |
+| RejectedUnknown (72 B) | 1,916 | 2,170 | 36 |
+| **RejectedDeepBody (7.5 KiB body-depth attack)** | **1,066** | **96** | **2** |
+| RejectedRecursiveSchema (walker reject) | 8,178 | 7,944 | 102 |
 
-The Heavy body now exercises `ToolsValidator` (walks `tools[].function.parameters` for each tool) and `ChatTemplateKwargsValidator`, which adds ~1.2 µs / ~14 allocs vs before the new validators landed. The reject-recursive attack path is unchanged because the body-level depth pre-scan still bails out first.
+`Heavy` now also carries `chat_template_kwargs` so `ChatTemplateKwargsValidator` is exercised end-to-end. `RejectedDeepBody` measures the body-level pre-scan rejection (depth > 32, never reaches the walker); `RejectedRecursiveSchema` measures the walker rejection on bodies that pass the pre-scan but trip `MaxDepth=5` — that path is ~8× more expensive because it pays for `json.Unmarshal` first.
 
-`response_format` validator in isolation (`paramvalidators/response_format_test.go`):
+`response_format` validator in isolation (`paramvalidators/response_format_bench_test.go`):
 
 | Path | ns/op | B/op | allocs/op |
 | --- | --- | --- | --- |
-| Absent | 8.3 | 0 | 0 |
-| `type=text` / `json_object` | ~17 | 0 | 0 |
-| Simple schema | 1,645 | 640 | 19 |
-| At limits (~121 nodes) | 52,825 | 24,701 | 724 |
-| Rejects recursion attack | 559 | 96 | 2 |
-| Rejects oversized schema | 19,207 | 18,905 | 15 |
+| Absent | 8.7 | 0 | 0 |
+| `type=text` / `json_object` | ~18 | 0 | 0 |
+| Simple schema | 1,763 | 640 | 19 |
+| At limits (~121 nodes) | 55,895 | 24,701 | 724 |
+| Rejects recursion attack | 1,259 | 176 | 4 |
+| Rejects oversized schema | 19,889 | 19,023 | 17 |
+
+The walker `Rejects recursion attack` cost grew from ~560 ns to ~1.3 µs after CVE-2025-48944 type/pattern checks were added on every visited node. Still well under any latency budget.
 
 Bench files: `request_filters_bench_test.go` (pipeline-level) and `paramvalidators/response_format_bench_test.go` (validator-level).
 

--- a/devshard/docs/supported-params.md
+++ b/devshard/docs/supported-params.md
@@ -1,0 +1,229 @@
+# Chat Completions — supported parameters
+
+Reference for `POST /v1/chat/completions` on devshard. Documents which OpenAI/vLLM request fields the gateway accepts today, which are rejected, how to use the ones that pass, and what we still need to tighten.
+
+## Why a strict whitelist
+
+vLLM crashes on malformed or pathological requests (deep recursive JSON Schema, unsupported routing fields, unbounded objects). To keep the inference node healthy:
+
+1. **Body-level depth scan** (`ensureRequestNestingDepth` in `request_filters_parameters.go`). A byte-level pass bounds *whole-request* JSON nesting at `MaxRequestNestingDepth = 32` before `encoding/json` allocates anything. Without this, a 7 KiB body with 200 levels of nesting expands to ~180 KiB of `map[string]any` wrappers in the decoder — the validator below would still reject it, but the decoder has already paid the cost. The pre-scan defuses that amplification. (This is a different layer from the schema-level `MaxDepth = 5` cap below: the body limit is generous because legitimate requests can be ~10 levels deep through `messages[].content[].text` + `tools[].function.parameters` + `response_format.json_schema.schema`; the schema limit is tight because the grammar compiler in vLLM is the actual attack surface.)
+2. Every inbound `/chat/completions` body is then decoded into a generic JSON document.
+3. `VLLMParameterCatalog` (`devshard/cmd/devshardctl/request_filters_parameters.go`) is a closed allow-list. The set of allowed keys is precomputed at catalog construction (no per-request map build). Any top-level field that is not in the catalog is rejected with `feature "<name>" is temporarily unavailable` (HTTP 400) before the request reaches the model.
+4. Parameter rules run in two stages:
+   - `PreValidation` — on the raw document, before we decode/validate it.
+   - `PostLimits` — after `max_tokens` defaults/caps are resolved.
+5. The message validator (`request_filters_messages.go`) enforces the OpenAI-compatible message contract (roles, tool_call linkage, text-only content parts).
+6. The chat-request projection (`chatRequest` — 5 fields: `model`, `stream`, `max_tokens`, `max_completion_tokens`, `n`) is populated by direct map reads from the document, not a `json.Marshal + Unmarshal` round-trip.
+
+Anything not on this whitelist does not reach the model. That is the contract.
+
+## Supported parameters
+
+| Field | Category | Stage / rule | Behavior |
+| --- | --- | --- | --- |
+| `model` | string | — | Required. Pass-through. Selects the upstream model id. |
+| `stream` | bool | — | Pass-through. Streaming is enabled when `true`. |
+| `messages` | object array | message validator | Required, non-empty. Strict OpenAI-compatible message contract — see "Messages" section below. |
+| `max_tokens` | int range | PostLimits (token-limit pipeline) | If absent → set to `DefaultRequestMaxTokens`. Capped at `RequestMaxTokensCap` unless the request carries admin auth. When both `max_tokens` and `max_completion_tokens` are set, the smaller wins and both are aligned. |
+| `max_completion_tokens` | int range | PostLimits (token-limit pipeline) | Same rules as `max_tokens`. |
+| `n` | int range | PostLimits sanitize (`CapUintParameterHandler`) | Capped at `MaxChatRequestChoices` (5). |
+| `temperature` | float range | PostLimits sanitize | Strips `NaN`/`±Inf`. Capped at `MaxTemperature` (2.0). String-encoded numbers accepted. |
+| `top_p` | float range | PostLimits sanitize | Strips `NaN`/`±Inf`. No upper cap (forwarded raw). |
+| `top_k` | int range | PostLimits sanitize | Strips `NaN`/`±Inf`. vLLM-specific. |
+| `min_p` | float range | PostLimits sanitize | Strips `NaN`/`±Inf`. vLLM-specific. |
+| `repetition_penalty` | float range | PostLimits sanitize | Strips `NaN`/`±Inf`. Capped at `MaxRepetitionPenalty` (2.0). |
+| `logit_bias` | int→float map | PostLimits sanitize (`SanitizeFloatMapParameterHandler`) | Keeps numeric entries in `[-100, 100]`. Drops the field if the map is empty after sanitization. |
+| `stop` | string list | — | Pass-through. |
+| `stop_token_ids` | int list | — | Pass-through. vLLM-specific. |
+| `seed` | int range | — | Pass-through. |
+| `skip_special_tokens` | bool | — | Pass-through. vLLM-specific. |
+| `detokenize` | bool | — | Pass-through. vLLM-specific. |
+| `thinking` | object | — | Pass-through. Kimi-K2 specific (`{"type": "enabled"|"disabled"}`). For `moonshotai/Kimi-K2.6` it is also mirrored into `chat_template_kwargs.thinking` via `applyKimiRequestOverrides`. |
+| `chat_template_kwargs` | object | — | Pass-through. Used for provider-specific chat templates (Qwen, Kimi). |
+| `tool_choice` | string | PreValidation reject | Pass-through except `"required"` — rejected because the upstream contract does not honor it on the vLLM path. Stripped together with `tools` if `tools` arrives empty. |
+| `min_tokens` | int range | PreValidation conditional strip + PostLimits clamp | Dropped if `stop_token_ids` is also set (vLLM rejects the combination). Otherwise clamped to ≤ `max_tokens`. |
+| `bad_words` | string list | PreValidation sanitize | Empty/whitespace strings are removed. Field is dropped if the resulting list is empty. |
+| `tools` | object array | PreValidation sanitize | If the array is empty, both `tools` and `tool_choice` are removed (vLLM rejects empty `tools`). |
+| `logprobs` | bool | PostLimits force | Forced to `true` for the gateway's observability pipeline regardless of what the client sent. |
+| `top_logprobs` | int range | PostLimits force | Forced to `5` for the same reason. |
+| `response_format` | object | PreValidation validate (`paramvalidators.ResponseFormatValidator`) | Accepted with bounds. `type` must be one of `text` / `json_object` / `json_schema`. For `json_schema`, the schema is walked once and rejected if depth > 5, nodes > 128, branch arms (anyOf/oneOf/allOf) > 16, enum > 256, serialized size > 16 KiB, or the schema contains `$ref` / `$defs` / `definitions`. See "Validation invariants" below for the policy. |
+
+### Messages contract (recap)
+
+Enforced by `request_filters_messages.go`:
+
+- Roles: `developer`, `system`, `user`, `assistant`, `tool`, `function`.
+- Assistant `content` may be empty/null only when `tool_calls` or `function_call` is present.
+- Tool messages require `tool_call_id` matching a prior assistant `tool_calls[].id`.
+- Function messages require `name`.
+- Content parts: only `{"type": "text", "text": "..."}` is accepted. Typed arrays of text parts are flattened to a single string before forwarding.
+- Empty tool `content` is normalized to a sentinel string; missing tool `content` is also normalized.
+
+## Unsupported parameters (rejected)
+
+Every OpenAI / vLLM / provider-specific field that is **not** in the table above is rejected at `PreValidation`. The error response is HTTP 400 with body `feature "<name>" is temporarily unavailable`.
+
+The groupings below are not exhaustive — they document the gaps we know clients hit, mostly drawn from comparable gateways (Hermes, OpenClaw, Kilo):
+
+| Group | Examples we reject today | Notes |
+| --- | --- | --- |
+| Structured output (other than `response_format`) | `guided_json`, `guided_regex`, `guided_grammar`, `guided_choice`, `enforced_tokens` | `response_format` is now supported with bounds (see Supported table). The vLLM-specific `guided_*` family stays rejected because it bypasses the same safety bounds. |
+| Sampling | `frequency_penalty`, `presence_penalty` | Easy to add (numeric range sanitize, similar to `temperature`). Not yet validated end-to-end against the vLLM build we run. |
+| Tool-calling extensions | `parallel_tool_calls`, `tool_choice="required"` | Provider compatibility differs; we keep them off until we can pin behavior. |
+| Routing / metadata | `metadata`, `service_tier`, `user`, `seed_override`, `extra_body`, `extra_headers`, `provider`, `plugins`, `tags` | Vendor-specific; no inference-side meaning for vLLM. |
+| Caching / observability | `store`, `prompt_cache_key`, `stream_options` | Could be safely stripped before forward, but currently rejected to avoid silent semantic drift. |
+| Reasoning (non-vLLM-native) | `reasoning_effort`, `reasoning`, `thinking_config`, `enable_thinking` | Use `thinking` + `chat_template_kwargs` instead (see "Supported"). |
+
+If you see a new field in this list that you need, add it to the catalog with the smallest safe rule — see "Validation improvements".
+
+## How to use the gateway
+
+### Minimal request
+
+```http
+POST /v1/chat/completions
+Content-Type: application/json
+
+{
+  "model": "moonshotai/Kimi-K2.6",
+  "messages": [{"role": "user", "content": "Hello"}]
+}
+```
+
+`max_tokens` is filled in for you (`DefaultRequestMaxTokens`).
+
+### With sampling knobs
+
+```json
+{
+  "model": "moonshotai/Kimi-K2.6",
+  "messages": [{"role": "user", "content": "Hello"}],
+  "temperature": 0.7,
+  "top_p": 0.95,
+  "top_k": 40,
+  "repetition_penalty": 1.05,
+  "max_tokens": 512
+}
+```
+
+All five knobs are sanitized at `PostLimits`: non-finite numbers and out-of-range values are dropped or clamped before the request reaches vLLM.
+
+### With tools (function calling)
+
+```json
+{
+  "model": "moonshotai/Kimi-K2.6",
+  "messages": [{"role": "user", "content": "Weather in Berlin?"}],
+  "tools": [
+    {"type": "function", "function": {"name": "get_weather",
+      "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}
+  ],
+  "tool_choice": "auto"
+}
+```
+
+If `tools` is `[]`, the gateway strips both `tools` and `tool_choice` (the vLLM build we run rejects empty tools).
+
+### With Kimi-K2.6 thinking
+
+```json
+{
+  "model": "moonshotai/Kimi-K2.6",
+  "messages": [{"role": "user", "content": "Plan this refactor"}],
+  "thinking": {"type": "enabled"}
+}
+```
+
+For `moonshotai/Kimi-K2.6` the gateway also writes `chat_template_kwargs.thinking = true` automatically.
+
+### Rejected request
+
+```json
+{
+  "model": "moonshotai/Kimi-K2.6",
+  "messages": [{"role": "user", "content": "Hello"}],
+  "response_format": {"type": "json_object"}
+}
+```
+
+→ `HTTP 400 — feature "response_format" is temporarily unavailable`. Same shape for any other unknown key.
+
+## Validation improvements (roadmap)
+
+### Priority: safe `response_format`
+
+The example below currently crashes vLLM because the JSON Schema contains ~200 nested `properties` levels:
+
+```json
+{
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "r",
+      "schema": {"properties": {"x": {"properties": {"x": {"properties": {"x": "..."}}}}}, "required": ["x"], "type": "object"}
+    }
+  }
+}
+```
+
+A safe `response_format` handler must enforce all of the following at `PreValidation` and reject the request with HTTP 400 if any check fails:
+
+| Invariant | Initial threshold | Rationale |
+| --- | --- | --- |
+| `type` ∈ {`text`, `json_object`, `json_schema`} | Hard whitelist | Same set OpenClaw/Kilo document. Anything else → reject. |
+| For `json_schema`: `json_schema.name` is a non-empty string ≤ 64 chars, regex `^[A-Za-z0-9_.-]+$` | Hard | vLLM uses the name as a grammar identifier. |
+| For `json_schema`: `json_schema.schema` is an object | Hard | Reject arrays/strings/null. |
+| Max schema depth | **≤ 5** | Counts nesting through `properties`, `items`, `additionalProperties`, `anyOf`/`oneOf`/`allOf` element schemas, `prefixItems`. The 200-level attack above fails at depth 6. |
+| Max serialized schema size | **≤ 16 KiB** | Measured on the marshalled `json_schema.schema` bytes. Bounds memory/time on the vLLM grammar compiler. |
+| Max schema node count | **≤ 128** | Each visited schema object (root, every nested property/item/branch arm) counts as one node. Bounds breadth attacks like a single `properties` map with hundreds of children. |
+| `$ref`, `$defs`, `definitions` | Forbidden | Prevents cycles and indirect blow-ups. |
+| `anyOf`/`oneOf`/`allOf` array length | ≤ 16 | Avoid combinatorial explosion in vLLM's grammar compiler. |
+| `enum` length | ≤ 256 | Same reason. |
+
+Order of checks: type → name + regex → walk the schema once, counting depth, nodes, branch arms, enums, refusing on the first violation → only then `json.Marshal` the schema to enforce the byte-size cap. Walking comes first because `json.Marshal` is O(input size); doing it before the walk lets an attacker amplify a 200-level recursive payload into hundreds of allocations before the depth check ever fires. Walking first cuts that path from ~87 µs / 1606 allocs to ~560 ns / 2 allocs (Apple M2 Pro). Single bounded pass — no recursion without a depth counter.
+
+Status: **implemented** as a pure validator in subpackage `cmd/devshardctl/paramvalidators/response_format.go` — `paramvalidators.ResponseFormatValidator{MaxDepth: 5, MaxSize: 16384, MaxNodes: 128, MaxBranch: 16, MaxEnum: 256, MaxNameLen: 64}`. The main catalog wires it in via `DocumentValidatorHandler` at `RequestFilterStagePreValidation`. The walker policy is *inverted*: it descends into every object-valued or array-of-object-valued field except an explicit list of data carriers (`enum`/`const`/`default`/`examples`/`required`/`dependentRequired`), so new JSON-Schema keywords (`if`/`then`/`contains`/`unevaluatedProperties`/...) cannot smuggle deep nesting or `$ref` past the validator. Rejection categories are exported as sentinel errors (`ErrResponseFormatDepth`, `ErrResponseFormatRef`, etc.); callers can match them via `errors.Is` even after the gateway wraps with HTTP 400 status. Test coverage: exhaustive unit tests in `paramvalidators/response_format_test.go`; integration wiring in `request_filters_test.go::TestNormalizeChatRequestResponseFormatPipeline`.
+
+Calibrate the thresholds (depth, size, nodes) by running the new handler against the sample structured-output schemas from production clients before raising any limit.
+
+### Other validators worth tightening (later)
+
+- **`logit_bias`**: currently sanitized but does not cap the map size. A `logit_bias` with 100k entries is still forwarded. Suggest `len(map) ≤ 1024`.
+- **`stop` / `bad_words`**: no cap on the number of entries or per-entry length. Suggest `len(list) ≤ 16`, per-entry length ≤ 256.
+- **`tools`**: no cap on the schema depth/size of each `tools[].function.parameters`. The same depth/byte/key invariants from `response_format` should apply, because vLLM compiles tool argument schemas through the same grammar path.
+- **`messages`**: total `messages` byte size has only the 10 MiB body cap. Long single-message content can still pass; the existing token-limit check happens later in the agent stack, not in this layer.
+- **Catalog generation**: today the catalog is hand-written. As more fields land, it would be worth generating the doc above from the catalog (`go test` artifact or `go generate`) so this file does not drift.
+
+## Performance characteristics
+
+End-to-end `normalizeChatRequest` (Apple M2 Pro, `-benchtime=2s`):
+
+| Body | ns/op | B/op | allocs/op |
+| --- | --- | --- | --- |
+| Minimal (47 B) | 2,742 | 2,450 | 43 |
+| Typical (132 B) | 4,311 | 2,947 | 67 |
+| Heavy (560 B) | 16,039 | 11,695 | 209 |
+| WithResponseFormat (279 B) | 9,437 | 6,776 | 139 |
+| RejectedUnknown (72 B) | 1,869 | 2,146 | 36 |
+| **RejectedRecursive (7.5 KiB attack)** | **1,058** | **72** | **2** |
+
+`response_format` validator in isolation (`paramvalidators/response_format_test.go`):
+
+| Path | ns/op | B/op | allocs/op |
+| --- | --- | --- | --- |
+| Absent | 8.3 | 0 | 0 |
+| `type=text` / `json_object` | ~17 | 0 | 0 |
+| Simple schema | 1,645 | 640 | 19 |
+| At limits (~121 nodes) | 52,825 | 24,701 | 724 |
+| Rejects recursion attack | 559 | 96 | 2 |
+| Rejects oversized schema | 19,207 | 18,905 | 15 |
+
+Bench files: `request_filters_bench_test.go` (pipeline-level) and `paramvalidators/response_format_bench_test.go` (validator-level).
+
+## Where the code lives
+
+- Pipeline entry: `defaultChatRequestPipeline().Normalize` in `request_filters.go`.
+- Catalog, generic handlers (Strip/Reject/Sanitize/Force/Custom), `RequestFilterContext`, `ChatRequestDocument`, and the `DocumentValidatorHandler` adapter: `request_filters_parameters.go`.
+- Messages: `defaultChatMessageProcessor` in `request_filters_messages.go`.
+- Per-field pure validators (one file per edge case, no coupling to the main pipeline types): `paramvalidators/` subpackage. Today: `response_format.go`. New validators (e.g. `tools_schema.go`, `logit_bias_bounds.go`) should go here and be wired into the catalog via `DocumentValidatorHandler{Validator: paramvalidators.YourValidator{...}}`. Each validator should expose sentinel errors for its rejection categories so callers can match them via `errors.Is`.
+- Tests: integration in `request_filters_test.go`; per-validator unit tests in `paramvalidators/<name>_test.go`.

--- a/devshard/docs/supported-params.md
+++ b/devshard/docs/supported-params.md
@@ -32,21 +32,21 @@ Anything not on this whitelist does not reach the model. That is the contract.
 | `top_k` | int range | PostLimits sanitize | Strips `NaN`/`±Inf`. vLLM-specific. |
 | `min_p` | float range | PostLimits sanitize | Strips `NaN`/`±Inf`. vLLM-specific. |
 | `repetition_penalty` | float range | PostLimits sanitize | Strips `NaN`/`±Inf`. Capped at `MaxRepetitionPenalty` (2.0). |
-| `logit_bias` | int→float map | PostLimits sanitize (`SanitizeFloatMapParameterHandler`) | Keeps numeric entries in `[-100, 100]`. Drops the field if the map is empty after sanitization. |
-| `stop` | string list | — | Pass-through. |
-| `stop_token_ids` | int list | — | Pass-through. vLLM-specific. |
+| `logit_bias` | int→float map | PostLimits sanitize (`SanitizeFloatMapParameterHandler`) | Keeps numeric entries in `[-100, 100]`. Drops the field if the map is empty after sanitization. Map size capped at 1024 entries (rejected with HTTP 400 over the cap). |
+| `stop` | string list | PreValidation length cap (`LengthCapListParameterHandler`) | Pass-through within bounds. Rejected if `len(stop) > 16` or any entry's string length > 256 bytes. |
+| `stop_token_ids` | int list | PreValidation length cap (`LengthCapListParameterHandler`) | Pass-through within bounds. Rejected if `len(stop_token_ids) > 64`. |
 | `seed` | int range | — | Pass-through. |
 | `skip_special_tokens` | bool | — | Pass-through. vLLM-specific. |
 | `detokenize` | bool | — | Pass-through. vLLM-specific. |
-| `thinking` | object | — | Pass-through. Kimi-K2 specific (`{"type": "enabled"|"disabled"}`). For `moonshotai/Kimi-K2.6` it is also mirrored into `chat_template_kwargs.thinking` via `applyKimiRequestOverrides`. |
-| `chat_template_kwargs` | object | — | Pass-through. Used for provider-specific chat templates (Qwen, Kimi). |
+| `thinking` | object | PreValidation validate (`paramvalidators.ThinkingValidator`) | Must be `{"type": "enabled" \| "disabled"}`. Any other shape rejected. For `moonshotai/Kimi-K2.6` it is mirrored into `chat_template_kwargs.thinking` via `applyKimiRequestOverrides`. |
+| `chat_template_kwargs` | object | PreValidation validate (`paramvalidators.ChatTemplateKwargsValidator`) | Pass-through within plain-object bounds: depth ≤ 5, nodes ≤ 128, serialized size ≤ 16 KiB. Anything over those caps is rejected before vLLM's Jinja template renderer sees it. |
 | `tool_choice` | string | PreValidation reject | Pass-through except `"required"` — rejected because the upstream contract does not honor it on the vLLM path. Stripped together with `tools` if `tools` arrives empty. |
 | `min_tokens` | int range | PreValidation conditional strip + PostLimits clamp | Dropped if `stop_token_ids` is also set (vLLM rejects the combination). Otherwise clamped to ≤ `max_tokens`. |
-| `bad_words` | string list | PreValidation sanitize | Empty/whitespace strings are removed. Field is dropped if the resulting list is empty. |
-| `tools` | object array | PreValidation sanitize | If the array is empty, both `tools` and `tool_choice` are removed (vLLM rejects empty `tools`). |
+| `bad_words` | string list | PreValidation sanitize + length cap | Empty/whitespace strings are removed. Field is dropped if the resulting list is empty. Then `len(bad_words) ≤ 64`, per-entry length ≤ 128 bytes. |
+| `tools` | object array | PreValidation sanitize + schema validate (`paramvalidators.ToolsValidator`) | Empty arrays drop both `tools` and `tool_choice`. Every `tools[].function.parameters` is walked as a JSON Schema with the same bounds as `response_format` (depth ≤ 5, nodes ≤ 128, branch arms ≤ 16, enum ≤ 256, size ≤ 16 KiB, `$ref`/`$defs`/`definitions` forbidden). vLLM compiles tool argument schemas through the same grammar path as `response_format`, so the bounds must match. |
 | `logprobs` | bool | PostLimits force | Forced to `true` for the gateway's observability pipeline regardless of what the client sent. |
 | `top_logprobs` | int range | PostLimits force | Forced to `5` for the same reason. |
-| `response_format` | object | PreValidation validate (`paramvalidators.ResponseFormatValidator`) | Accepted with bounds. `type` must be one of `text` / `json_object` / `json_schema`. For `json_schema`, the schema is walked once and rejected if depth > 5, nodes > 128, branch arms (anyOf/oneOf/allOf) > 16, enum > 256, serialized size > 16 KiB, or the schema contains `$ref` / `$defs` / `definitions`. See "Validation invariants" below for the policy. |
+| `response_format` | object | PreValidation validate (`paramvalidators.ResponseFormatValidator`) | Accepted with bounds. `type` must be one of `text` / `json_object` / `json_schema`. For `json_schema`, the schema is walked once and rejected if depth > 5, nodes > 128, branch arms (anyOf/oneOf/allOf) > 16, enum > 256, serialized size > 16 KiB, or the schema contains `$ref` / `$defs` / `definitions`. |
 
 ### Messages contract (recap)
 
@@ -59,22 +59,27 @@ Enforced by `request_filters_messages.go`:
 - Content parts: only `{"type": "text", "text": "..."}` is accepted. Typed arrays of text parts are flattened to a single string before forwarding.
 - Empty tool `content` is normalized to a sentinel string; missing tool `content` is also normalized.
 
+## Pass-throughs that are safe by type contract
+
+These fields are accepted as known catalog entries without any per-rule validation because their JSON type alone bounds the value space: `model`, `stream`, `messages` (covered by `defaultChatMessageProcessor.ValidateDocument`), `max_tokens` / `max_completion_tokens` (covered by `applyOutputTokenLimits`), `seed`, `skip_special_tokens`, `detokenize`. Everything else that reaches vLLM is bounded by an explicit catalog rule (see the Supported table).
+
 ## Unsupported parameters (rejected)
 
-Every OpenAI / vLLM / provider-specific field that is **not** in the table above is rejected at `PreValidation`. The error response is HTTP 400 with body `feature "<name>" is temporarily unavailable`.
+Every OpenAI / vLLM / provider-specific field that is **not** in the Supported table is rejected at `PreValidation`. The error response is HTTP 400 with body `feature "<name>" is temporarily unavailable`.
 
-The groupings below are not exhaustive — they document the gaps we know clients hit, mostly drawn from comparable gateways (Hermes, OpenClaw, Kilo):
+Grouped by why the field is off:
 
-| Group | Examples we reject today | Notes |
-| --- | --- | --- |
-| Structured output (other than `response_format`) | `guided_json`, `guided_regex`, `guided_grammar`, `guided_choice`, `enforced_tokens` | `response_format` is now supported with bounds (see Supported table). The vLLM-specific `guided_*` family stays rejected because it bypasses the same safety bounds. |
-| Sampling | `frequency_penalty`, `presence_penalty` | Easy to add (numeric range sanitize, similar to `temperature`). Not yet validated end-to-end against the vLLM build we run. |
-| Tool-calling extensions | `parallel_tool_calls`, `tool_choice="required"` | Provider compatibility differs; we keep them off until we can pin behavior. |
-| Routing / metadata | `metadata`, `service_tier`, `user`, `seed_override`, `extra_body`, `extra_headers`, `provider`, `plugins`, `tags` | Vendor-specific; no inference-side meaning for vLLM. |
-| Caching / observability | `store`, `prompt_cache_key`, `stream_options` | Could be safely stripped before forward, but currently rejected to avoid silent semantic drift. |
-| Reasoning (non-vLLM-native) | `reasoning_effort`, `reasoning`, `thinking_config`, `enable_thinking` | Use `thinking` + `chat_template_kwargs` instead (see "Supported"). |
+| Group | Examples we reject today | Origin | Why off |
+| --- | --- | --- | --- |
+| Sampling penalties | `frequency_penalty`, `presence_penalty` | Kilo, OpenClaw, OpenAI canonical | vLLM supports them. Trivially safe to add via `SanitizeFloatParameterHandler` with range `[-2, 2]`. Pending only because we have not validated end-to-end on the vLLM build we run. **Smallest concrete next addition.** |
+| Structured-output (non-`response_format`) | `guided_json`, `guided_regex`, `guided_grammar`, `guided_choice`, `enforced_tokens`, `structured_outputs` | vLLM-native | Bypasses the response_format safety bounds. Same grammar-compiler attack surface; would need its own validator. |
+| Tool-calling extensions | `parallel_tool_calls`, `tool_choice="required"` | OpenClaw, OpenAI | Provider compatibility differs and `required` is rejected by upstream contract on the vLLM path. |
+| Routing / metadata | `metadata`, `service_tier`, `user`, `extra_body`, `extra_headers`, `provider`, `plugins`, `tags`, `seed_override` | Hermes, OpenClaw, Kilo | Vendor-specific; no inference-side meaning for vLLM. `extra_body` / `extra_headers` are open-ended escape hatches and break the whitelist contract. |
+| Caching / observability | `store`, `prompt_cache_key`, `stream_options` | OpenAI / OpenClaw / Hermes | OpenAI-specific (`store`, `prompt_cache_key`) or streaming-format hint (`stream_options`). Could be safely stripped before forwarding, but currently rejected to avoid silent semantic drift in usage accounting. |
+| Reasoning (non-vLLM-native) | `reasoning_effort`, `reasoning` (object), `thinking_config`, `enable_thinking` | Hermes (multi-provider), OpenClaw (Qwen/Kimi), Gemini | Use `thinking` + `chat_template_kwargs` instead. Provider-specific reasoning fields are wrapper concerns, not what vLLM speaks. |
+| Provider-specific extras | `extra_body.vl_high_resolution_images` (Qwen), `extra_body.provider` (OpenRouter), `extra_body.tags` (Nous), `extra_body.thinking_config` (Gemini), `extra_body.plugins` (OpenRouter), `messages[].reasoning_content` (Kimi multi-turn replay), `tools[].function.strict` (OpenAI strict schema), `chat_template_kwargs.preserve_thinking` (Qwen wrapper) | Hermes, OpenClaw | Single-vendor attribution / wrapping fields. No vLLM equivalent. |
 
-If you see a new field in this list that you need, add it to the catalog with the smallest safe rule — see "Validation improvements".
+If you see a field here that you need, add it to the catalog with the smallest safe rule — see "Validation improvements".
 
 ## How to use the gateway
 
@@ -186,13 +191,27 @@ Status: **implemented** as a pure validator in subpackage `cmd/devshardctl/param
 
 Calibrate the thresholds (depth, size, nodes) by running the new handler against the sample structured-output schemas from production clients before raising any limit.
 
-### Other validators worth tightening (later)
+### Validator inventory (implemented)
 
-- **`logit_bias`**: currently sanitized but does not cap the map size. A `logit_bias` with 100k entries is still forwarded. Suggest `len(map) ≤ 1024`.
-- **`stop` / `bad_words`**: no cap on the number of entries or per-entry length. Suggest `len(list) ≤ 16`, per-entry length ≤ 256.
-- **`tools`**: no cap on the schema depth/size of each `tools[].function.parameters`. The same depth/byte/key invariants from `response_format` should apply, because vLLM compiles tool argument schemas through the same grammar path.
-- **`messages`**: total `messages` byte size has only the 10 MiB body cap. Long single-message content can still pass; the existing token-limit check happens later in the agent stack, not in this layer.
-- **Catalog generation**: today the catalog is hand-written. As more fields land, it would be worth generating the doc above from the catalog (`go test` artifact or `go generate`) so this file does not drift.
+All HIGH/MEDIUM/LOW gaps from the original audit are now closed. Cross-reference: catalog wire-up in `defaultVLLMParameterCatalog()`; pure validator types in `paramvalidators/`.
+
+| Field | Validator | Bounds |
+| --- | --- | --- |
+| `response_format` | `paramvalidators.ResponseFormatValidator` | depth ≤ 5, nodes ≤ 128, anyOf/oneOf/allOf ≤ 16, enum ≤ 256, size ≤ 16 KiB; `$ref`/`$defs`/`definitions` banned |
+| `tools[].function.parameters` | `paramvalidators.ToolsValidator` (reuses `SchemaBounds`) | identical bounds to `response_format` (same vLLM grammar path) |
+| `chat_template_kwargs` | `paramvalidators.ChatTemplateKwargsValidator` (uses `ObjectBounds`) | plain-object depth ≤ 5, nodes ≤ 128, size ≤ 16 KiB |
+| `thinking` | `paramvalidators.ThinkingValidator` | exactly `{"type": "enabled" \| "disabled"}` |
+| `stop` | `LengthCapListParameterHandler` | `len ≤ 16`, per-entry ≤ 256 bytes |
+| `stop_token_ids` | `LengthCapListParameterHandler` | `len ≤ 64` |
+| `bad_words` | `SanitizeStringListParameterHandler` + `LengthCapListParameterHandler` | sanitize first (drop empty), then `len ≤ 64`, per-entry ≤ 128 bytes |
+| `logit_bias` | `SanitizeFloatMapParameterHandler` (with `MaxEntries`) | range `[-100, 100]` + `len ≤ 1024` |
+
+Schema-walk rejection categories are exposed as sentinel errors: `ErrSchemaDepth`, `ErrSchemaNodes`, `ErrSchemaSize`, `ErrSchemaRef`, `ErrSchemaEnum`, `ErrSchemaBranch`. They are shared by `SchemaBounds` (JSON-Schema-aware, used for `response_format` and `tools`) and `ObjectBounds` (plain-object, used for `chat_template_kwargs`). The original response_format-specific sentinels (`ErrResponseFormatDepth` etc.) remain as aliases for backward compatibility.
+
+### Still open (smaller items)
+
+- **`messages` total byte size** — only the 10 MiB body cap exists. Per-message content size is bounded later by token-limit logic, not by a structural validator at this layer.
+- **Catalog generation** — the Supported table above is hand-written. `go generate` could derive it from the catalog so this file does not drift.
 
 ## Performance characteristics
 
@@ -200,12 +219,14 @@ End-to-end `normalizeChatRequest` (Apple M2 Pro, `-benchtime=2s`):
 
 | Body | ns/op | B/op | allocs/op |
 | --- | --- | --- | --- |
-| Minimal (47 B) | 2,742 | 2,450 | 43 |
-| Typical (132 B) | 4,311 | 2,947 | 67 |
-| Heavy (560 B) | 16,039 | 11,695 | 209 |
-| WithResponseFormat (279 B) | 9,437 | 6,776 | 139 |
-| RejectedUnknown (72 B) | 1,869 | 2,146 | 36 |
-| **RejectedRecursive (7.5 KiB attack)** | **1,058** | **72** | **2** |
+| Minimal (47 B) | 2,799 | 2,450 | 43 |
+| Typical (132 B) | 4,432 | 2,947 | 67 |
+| Heavy (560 B) | 17,609 | 12,160 | 223 |
+| WithResponseFormat (279 B) | 9,611 | 6,776 | 139 |
+| RejectedUnknown (72 B) | 1,870 | 2,170 | 36 |
+| **RejectedRecursive (7.5 KiB attack)** | **1,063** | **96** | **2** |
+
+The Heavy body now exercises `ToolsValidator` (walks `tools[].function.parameters` for each tool) and `ChatTemplateKwargsValidator`, which adds ~1.2 µs / ~14 allocs vs before the new validators landed. The reject-recursive attack path is unchanged because the body-level depth pre-scan still bails out first.
 
 `response_format` validator in isolation (`paramvalidators/response_format_test.go`):
 


### PR DESCRIPTION
## What problem does this solve?

Several OpenAI/vLLM chat-completions fields can crash or stall the upstream vLLM
engine when the gateway forwards them unchecked:

- A ~200-level recursive `response_format.json_schema` crashes the xgrammar
  grammar compiler in seconds — and on the way in, decoding a similarly nested
  body amplifies a 7 KiB request into ~180 KiB of `map[string]any` wrappers
  before any validator ever runs.
- `chat_template_kwargs` is passed positionally to
  `apply_hf_chat_template()`, so keys like `chat_template`, `tokenize`,
  `tools` smuggle Jinja injections / synchronous-tokenize stalls
  (CVE-2025-61620, CVE-2025-62426).
- `tools[].function.parameters` hits the same grammar compiler as
  `response_format`, with the same depth/breadth attack surface.
- A schema with a non-primitive `type` or an uncompilable `pattern` crashes
  xgrammar even at small sizes (CVE-2025-48944).

The gateway previously had a partial allow-list but no semantic bounds on
these fields — anything that fit the byte cap was forwarded.

## How do we know it's real?

Reproduced locally: a 7.5 KiB body with 200 levels of nested `properties`
caused vLLM EngineCore to consume the worker. Same with a `pattern: "("`
inside a tools schema. The Jinja-injection class is documented in the
upstream advisories linked from `devshard/docs/supported-params.md`
References section.

## How does this PR solve the problem?

Introduces a new `paramvalidators` subpackage with three validators, all
plugged into the existing `VLLMParameterCatalog` pipeline at
`PreValidation`:

- **`ResponseFormatValidator`** — type whitelist (`text` / `json_object` /
  `json_schema`); for `json_schema` walks the schema once with bounds:
  depth ≤ 5, nodes ≤ 128, branch arms ≤ 16, enum ≤ 256, size ≤ 16 KiB.
  Forbids `$ref` / `$defs` / `definitions`. Per-node: `type` must be a
  JSON-Schema primitive; `pattern` must compile and stay ≤ 512 B.
- **`ToolsValidator`** — same `SchemaBounds` walker applied to every
  `tools[].function.parameters`.
- **`ChatTemplateKwargsValidator`** — `ObjectBounds` (depth/size/nodes)
  plus a denylist on top-level keys that override the Jinja apply-template
  positional args (`chat_template`, `tokenize`, `tools`, `documents`,
  `conversation`, `continue_final_message`, `padding`, `truncation`,
  `max_length`, `return_tensors`, `return_dict`).
- **`ThinkingValidator`** — strict `{"type": "enabled"|"disabled"}` shape.

Pipeline-level hardening on top of the validators:

- **Body-level depth pre-scan** (`ensureRequestNestingDepth`, cap 32):
  byte-level pass before `encoding/json` so a deeply nested attack body
  never amplifies into the decoder's `map[string]any` graph. Cuts the
  rejected-recursion attack path from ~87 µs / 1606 allocs to
  ~1 µs / 2 allocs on Apple M2 Pro.
- **Length caps** on `messages` (≤ 2048), `stop` (≤ 16 / 256 B),
  `stop_token_ids` (≤ 64), `bad_words` (≤ 64 / 128 B), `logit_bias`
  map (≤ 1024 entries).
- **`seed`** validated as non-negative uint64 at the gateway boundary
  instead of via upstream error path.
- **`chatRequest` projection** now reads `model` / `stream` /
  `max_tokens` / `max_completion_tokens` / `n` via direct map reads
  instead of `json.Marshal + Unmarshal` (allocation hot-spot fix).
- Shared sentinels (`ErrSchema*`) and pipeline error unwrap so
  `errors.Is` works across the layers.

Spec doc: `devshard/docs/supported-params.md` is rewritten end-to-end —
status-at-a-glance, supported/unsupported tables, performance numbers,
per-model operational requirements for Kimi-K2.6 and Qwen3-235B-Instruct,
and a References section indexing every CVE and upstream issue we depend
on for ops-side coverage.

## What risks does this introduce? How are they mitigated?

- **False rejections** on legitimate but unusual schemas. Mitigation: the
  bounds were calibrated against real-world structured-output samples
  (depth ≤ 5 is well above what production clients send through
  `messages[].content[].text` + `tools[].function.parameters` +
  `response_format.json_schema.schema`). Limits are exposed as constants
  on the validator structs so they can be raised without code surgery.
- **Throughput regression**. Mitigation: validator-level and pipeline-
  level benchmarks committed (`paramvalidators/response_format_bench_test.go`,
  `request_filters_bench_test.go`). Heavy body adds ~1.2 µs / ~14 allocs
  vs pre-change; reject path is faster (allocs 67 → 2).
- **Ops-side dependencies the gateway can't enforce** — `qwen3_coder`
  parser RCE (CVE-2025-9141), `pythonic` parser ReDoS (CVE-2025-48887),
  `extract_hidden_states` + `repetition_penalty` crash (CVE-2026-44223).
  Mitigation: spec doc's "Verification / operational" section calls each
  out explicitly with the required vLLM config; on-call should verify
  against the deployed image.

## How do we know this PR fixes the problem?

- `paramvalidators/response_format_test.go` and `..._bench_test.go` —
  the 200-level recursion attack is rejected in ~559 ns / 2 allocs.
- `paramvalidators/tools_test.go` — same attack hidden in any tool
  (including the second one) is rejected on the same path.
- `paramvalidators/chat_template_kwargs_test.go` — every forbidden key
  is rejected; `add_generation_prompt` and other safe keys pass.
- `paramvalidators/schema_bounds.go` rejects bad `type` / uncompilable
  `pattern` on every walked node, covered by tests on both validators.
- Pipeline-level: `request_filters_test.go` and
  `request_filters_bench_test.go` exercise the end-to-end path,
  including the body-level depth pre-scan and the `chatRequest`
  direct-read regression coverage.

## Which components are affected?

`devshard/cmd/devshardctl/` only:

- `paramvalidators/` (new subpackage) — `schema_bounds.go`,
  `response_format.go`, `tools.go`, `chat_template_kwargs.go`,
  `thinking.go` + tests + benches.
- `request_filters.go`, `request_filters_parameters.go` —
  pipeline hardening, error-unwrap, direct-read projection.
- `request_filters_test.go`, `request_filters_bench_test.go` —
  pipeline coverage.
- `devshard/docs/supported-params.md` — new contract reference.

No changes outside `devshard/`. No protobuf, no `chain` or `api` node,
no `ml` node code touched.

## Testing

- `go test ./cmd/devshardctl/...` — both packages green (full suite + new
  cases; ~290 s / 0.27 s).
- `go vet ./cmd/devshardctl/...` — clean.
- Pipeline bench (Apple M2 Pro, `-benchtime=2s`):

  | Body | ns/op | B/op | allocs/op |
  | --- | --- | --- | --- |
  | Minimal (47 B) | 2,799 | 2,450 | 43 |
  | Typical (132 B) | 4,432 | 2,947 | 67 |
  | Heavy (560 B) | 17,609 | 12,160 | 223 |
  | WithResponseFormat (279 B) | 9,611 | 6,776 | 139 |
  | RejectedUnknown (72 B) | 1,870 | 2,170 | 36 |
  | **RejectedRecursive (7.5 KiB attack)** | **1,063** | **96** | **2** |

- Response-format validator in isolation:

  | Path | ns/op | B/op | allocs/op |
  | --- | --- | --- | --- |
  | Absent | 8.3 | 0 | 0 |
  | Simple schema | 1,645 | 640 | 19 |
  | At limits (~121 nodes) | 52,825 | 24,701 | 724 |
  | Rejects recursion attack | 559 | 96 | 2 |

## References

Linked in `devshard/docs/supported-params.md` References section —
CVE-2025-48944, CVE-2025-61620, CVE-2025-62426, CVE-2026-34756 covered
by this PR; CVE-2025-9141, CVE-2025-48887, CVE-2026-44223, CVE-2026-44222
called out as ops-side responsibilities with the required engine config
per served model.
