### PR TITLE
perf(devshard): reduce allocations + thread-safe ChatRequestDocument

### DIFF
--- a/devshard/cmd/devshardctl/paramvalidators/schema_bounds.go
+++ b/devshard/cmd/devshardctl/paramvalidators/schema_bounds.go
@@ -61,18 +61,18 @@ func (b SchemaBounds) Walk(schema map[string]any) error {
 	return b.walk(schema, 1, &nodes)
 }
 
-// CheckSize marshals the schema and rejects when the serialized size exceeds MaxSize. Run
-// AFTER Walk so depth/breadth attacks rejected by the walker never pay for the marshal.
+// CheckSize rejects when the serialized size exceeds MaxSize. Run AFTER Walk so
+// depth/breadth attacks rejected by the walker never pay for serialization.
 // MaxSize=0 disables the check.
 func (b SchemaBounds) CheckSize(schema map[string]any) error {
 	if b.MaxSize <= 0 {
 		return nil
 	}
-	serialized, err := json.Marshal(schema)
+	size, err := jsonMarshaledSize(schema)
 	if err != nil {
 		return fmt.Errorf("cannot be serialized: %v", err)
 	}
-	if len(serialized) > b.MaxSize {
+	if size > b.MaxSize {
 		return fmt.Errorf("%w: limit %d bytes", ErrSchemaSize, b.MaxSize)
 	}
 	return nil
@@ -159,14 +159,31 @@ func (b ObjectBounds) CheckSize(obj map[string]any) error {
 	if b.MaxSize <= 0 {
 		return nil
 	}
-	serialized, err := json.Marshal(obj)
+	size, err := jsonMarshaledSize(obj)
 	if err != nil {
 		return fmt.Errorf("cannot be serialized: %v", err)
 	}
-	if len(serialized) > b.MaxSize {
+	if size > b.MaxSize {
 		return fmt.Errorf("%w: limit %d bytes", ErrSchemaSize, b.MaxSize)
 	}
 	return nil
+}
+
+type countingWriter struct{ n int }
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.n += len(p)
+	return len(p), nil
+}
+
+// jsonMarshaledSize returns len(json.Marshal(v)) without allocating the output
+// slice. Encoder.Encode trails a newline that Marshal omits, so subtract one.
+func jsonMarshaledSize(v any) (int, error) {
+	var cw countingWriter
+	if err := json.NewEncoder(&cw).Encode(v); err != nil {
+		return 0, err
+	}
+	return cw.n - 1, nil
 }
 
 func (b ObjectBounds) walk(value any, depth int, nodes *int) error {

--- a/devshard/cmd/devshardctl/paramvalidators/schema_bounds_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/schema_bounds_test.go
@@ -1,0 +1,54 @@
+package paramvalidators
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Pins jsonMarshaledSize byte-for-byte against json.Marshal so a future
+// encoding/json change can't drift CheckSize at the boundary.
+func TestJSONMarshaledSizeMatchesJSONMarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		v    any
+	}{
+		{"empty object", map[string]any{}},
+		{"nested object", map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"city": map[string]any{"type": "string"}},
+			"required":   []any{"city"},
+		}},
+		{"array of mixed values", map[string]any{"enum": []any{"a", json.Number("1"), nil, true, false}}},
+		{"strings with html-unsafe chars", map[string]any{"description": `<script>"&"</script>`}},
+		{"strings with control chars", map[string]any{"k": "tab\there\nnewlinectrl"}},
+		{"string with U+2028 line separator", map[string]any{"k": "before after"}},
+		{"string with U+2029 paragraph separator", map[string]any{"k": "before after"}},
+		{"string with backslash and quote", map[string]any{"k": `quoted "value" and \backslash`}},
+		{"json.Number values", map[string]any{"n": json.Number("123"), "f": json.Number("1.5e2"), "neg": json.Number("-42")}},
+		{"large schema", map[string]any{
+			"type":       "object",
+			"properties": map[string]any{strings.Repeat("a", 100): map[string]any{"type": "string"}},
+		}},
+		{"nil value", map[string]any{"absent": nil}},
+		{"deeply nested", map[string]any{"a": map[string]any{"b": map[string]any{"c": map[string]any{"d": "x"}}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expected, err := json.Marshal(tc.v)
+			require.NoError(t, err)
+			got, err := jsonMarshaledSize(tc.v)
+			require.NoError(t, err)
+			require.Equal(t, len(expected), got, "jsonMarshaledSize must equal len(json.Marshal(v))")
+		})
+	}
+}
+
+func TestJSONMarshaledSizePropagatesEncoderError(t *testing.T) {
+	// Must error, not return 0 — otherwise CheckSize would silently accept.
+	bad := map[string]any{"chan": make(chan int)}
+	_, err := jsonMarshaledSize(bad)
+	require.Error(t, err)
+}

--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -92,7 +92,7 @@ func (p ChatRequestPipeline) Normalize(body []byte, adminAuthenticated bool, lim
 	if err := p.parameters.Apply(RequestFilterStagePreValidation, ctx); err != nil {
 		return nil, chatRequest{}, err
 	}
-	if err := p.messages.ValidateDocument(ctx.Document); err != nil {
+	if err := p.messages.ValidateDocument(&ctx.Document); err != nil {
 		return nil, chatRequest{}, err
 	}
 	if err := ctx.DecodeRequest(); err != nil {
@@ -120,7 +120,7 @@ func (p ChatRequestPipeline) ApplyModelOverrides(body []byte, req chatRequest, m
 	if err != nil {
 		return nil, chatRequest{}, err
 	}
-	translateKimiThinkingForVLLM(ctx.Document.raw)
+	ctx.Document.LockedScope(translateKimiThinkingForVLLM)
 	updatedBody, err := ctx.Document.Marshal()
 	if err != nil {
 		return nil, chatRequest{}, err

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -6,9 +6,14 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 
 	"devshard/cmd/devshardctl/paramvalidators"
 )
+
+var bytesReaderPool = sync.Pool{
+	New: func() any { return new(bytes.Reader) },
+}
 
 type RequestFilterStage int
 
@@ -176,7 +181,7 @@ type CapUintParameterHandler struct {
 }
 
 func (h CapUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	value, ok := numericJSONValueAsUint64FromDocument(ctx.Document, parameter.Name)
+	value, ok := numericJSONValueAsUint64FromDocument(&ctx.Document, parameter.Name)
 	if !ok {
 		return nil
 	}
@@ -191,11 +196,11 @@ type ClampUintToFieldParameterHandler struct {
 }
 
 func (h ClampUintToFieldParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	value, ok := numericJSONValueAsUint64FromDocument(ctx.Document, parameter.Name)
+	value, ok := numericJSONValueAsUint64FromDocument(&ctx.Document, parameter.Name)
 	if !ok {
 		return nil
 	}
-	maxValue, ok := numericJSONValueAsUint64FromDocument(ctx.Document, h.MaxField)
+	maxValue, ok := numericJSONValueAsUint64FromDocument(&ctx.Document, h.MaxField)
 	if !ok || maxValue == 0 {
 		return nil
 	}
@@ -281,22 +286,43 @@ func (h DocumentValidatorHandler) Apply(ctx *RequestFilterContext, _ VLLMParamet
 	if h.Validator == nil {
 		return nil
 	}
-	if err := h.Validator.Validate(ctx.Document.Raw()); err != nil {
-		return wrapBadChatRequest(err)
+	var validateErr error
+	ctx.Document.RLockedScope(func(raw map[string]any) {
+		validateErr = h.Validator.Validate(raw)
+	})
+	if validateErr != nil {
+		return wrapBadChatRequest(validateErr)
 	}
 	return nil
 }
 
+// ChatRequestDocument is not safe to share across goroutines without the mutex;
+// use LockedScope / RLockedScope for multi-key access.
 type ChatRequestDocument struct {
+	mu  sync.RWMutex
 	raw map[string]any
 }
 
 func (d *ChatRequestDocument) Keys() []string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	keys := make([]string, 0, len(d.raw))
 	for key := range d.raw {
 		keys = append(keys, key)
 	}
 	return keys
+}
+
+func (d *ChatRequestDocument) LockedScope(fn func(map[string]any)) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	fn(d.raw)
+}
+
+func (d *ChatRequestDocument) RLockedScope(fn func(map[string]any)) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	fn(d.raw)
 }
 
 // MaxRequestNestingDepth bounds JSON nesting before we hand the bytes to encoding/json.
@@ -311,16 +337,31 @@ func (d *ChatRequestDocument) Keys() []string {
 const MaxRequestNestingDepth = 32
 
 func decodeChatRequestDocument(body []byte) (*ChatRequestDocument, error) {
+	raw, err := decodeChatRequestRaw(body)
+	if err != nil {
+		return nil, err
+	}
+	return &ChatRequestDocument{raw: raw}, nil
+}
+
+func decodeChatRequestRaw(body []byte) (map[string]any, error) {
 	if err := ensureRequestNestingDepth(body, MaxRequestNestingDepth); err != nil {
 		return nil, err
 	}
+	reader := bytesReaderPool.Get().(*bytes.Reader)
+	reader.Reset(body)
+	defer func() {
+		// Drop body reference so the pool doesn't pin 10 MiB slices.
+		reader.Reset(nil)
+		bytesReaderPool.Put(reader)
+	}()
 	var raw map[string]any
-	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder := json.NewDecoder(reader)
 	decoder.UseNumber()
 	if err := decoder.Decode(&raw); err != nil {
 		return nil, badChatRequest("parse request: %v", err)
 	}
-	return &ChatRequestDocument{raw: raw}, nil
+	return raw, nil
 }
 
 // ensureRequestNestingDepth performs a byte-level scan that bounds JSON nesting before any
@@ -369,6 +410,8 @@ func ensureRequestNestingDepth(body []byte, maxDepth int) error {
 }
 
 func (d *ChatRequestDocument) Marshal() ([]byte, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	updatedBody, err := json.Marshal(d.raw)
 	if err != nil {
 		return nil, badChatRequest("marshal request: %v", err)
@@ -377,59 +420,68 @@ func (d *ChatRequestDocument) Marshal() ([]byte, error) {
 }
 
 func (d *ChatRequestDocument) Has(name string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	_, ok := d.raw[name]
 	return ok
 }
 
-// Raw exposes the underlying decoded map for handlers (in this package or external) that
-// need direct access to inspect or mutate the top-level fields. The returned map is the live
-// document -- modifications are reflected in subsequent reads and the final marshal.
-func (d *ChatRequestDocument) Raw() map[string]any {
-	return d.raw
-}
-
 func (d *ChatRequestDocument) Get(name string) (any, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	value, ok := d.raw[name]
 	return value, ok
 }
 
 func (d *ChatRequestDocument) Set(name string, value any) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.raw[name] = value
 }
 
 func (d *ChatRequestDocument) Delete(name string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	delete(d.raw, name)
 }
 
 func (d *ChatRequestDocument) String(name string) (string, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	value, ok := d.raw[name].(string)
 	return value, ok
 }
 
+// Object and Array return references into the document; do not retain them past
+// the immediate use or mutate them concurrently with other writers.
 func (d *ChatRequestDocument) Object(name string) (map[string]any, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	value, ok := d.raw[name].(map[string]any)
 	return value, ok
 }
 
 func (d *ChatRequestDocument) Array(name string) ([]any, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	value, ok := d.raw[name].([]any)
 	return value, ok
 }
 
 type RequestFilterContext struct {
-	Document           *ChatRequestDocument
+	Document           ChatRequestDocument
 	OutputLimits       outputTokenLimits
 	AdminAuthenticated bool
 	Request            chatRequest
 }
 
 func newRequestFilterContext(body []byte, adminAuthenticated bool, limits outputTokenLimits) (*RequestFilterContext, error) {
-	document, err := decodeChatRequestDocument(body)
+	raw, err := decodeChatRequestRaw(body)
 	if err != nil {
 		return nil, err
 	}
 	return &RequestFilterContext{
-		Document:           document,
+		Document:           ChatRequestDocument{raw: raw},
 		OutputLimits:       normalizedOutputTokenLimits(limits),
 		AdminAuthenticated: adminAuthenticated,
 	}, nil
@@ -441,7 +493,7 @@ func newRequestFilterContext(body []byte, adminAuthenticated bool, limits output
 // the behavior (strict types, null-tolerant) but skip the round-trip.
 func (ctx *RequestFilterContext) DecodeRequest() error {
 	var req chatRequest
-	if err := readChatRequestFields(ctx.Document, &req); err != nil {
+	if err := readChatRequestFields(&ctx.Document, &req); err != nil {
 		return err
 	}
 	ctx.Request = req
@@ -465,7 +517,7 @@ func (ctx *RequestFilterContext) DecodeRequest() error {
 // CapUintParameterHandler) propagate into the projection.
 func (ctx *RequestFilterContext) SyncRequestView() error {
 	var req chatRequest
-	if err := readChatRequestFields(ctx.Document, &req); err != nil {
+	if err := readChatRequestFields(&ctx.Document, &req); err != nil {
 		return err
 	}
 	req.MaxTokens = ctx.Request.MaxTokens
@@ -637,16 +689,24 @@ func (c VLLMParameterCatalog) Apply(stage RequestFilterStage, ctx *RequestFilter
 }
 
 func (c VLLMParameterCatalog) rejectUnknownParameters(ctx *RequestFilterContext) error {
-	if ctx == nil || ctx.Document == nil {
+	if ctx == nil {
 		return nil
 	}
-	for key := range ctx.Document.raw {
-		if _, ok := c.known[key]; ok {
-			continue
+	var rejectErr error
+	ctx.Document.RLockedScope(func(raw map[string]any) {
+		for key := range raw {
+			if _, ok := c.known[key]; ok {
+				continue
+			}
+			if key == "" {
+				rejectErr = badChatRequest("request body contains a field with an empty name")
+				return
+			}
+			rejectErr = badChatRequest("%s", unsupportedChatParameterMessage(key))
+			return
 		}
-		return badChatRequest("%s", unsupportedChatParameterMessage(key))
-	}
-	return nil
+	})
+	return rejectErr
 }
 
 func newParameter(name string) VLLMParameter {

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -744,6 +745,12 @@ func TestNormalizeChatRequestRejectsUnsupportedFields(t *testing.T) {
 			want: "custom_param",
 		},
 		{
+			// JSON accepts "" as a key; the whitelist rejects it with a dedicated message
+			name: "empty string key",
+			body: `{"":"slip","messages":[{"role":"user","content":"hello"}]}`,
+			want: "field with an empty name",
+		},
+		{
 			name: "enforced tokens",
 			body: `{"enforced_tokens":["x"],"messages":[{"role":"user","content":"hello"}]}`,
 			want: "enforced_tokens",
@@ -1238,4 +1245,46 @@ func TestNormalizeChatRequestRejectsBodyAtNestingLimit(t *testing.T) {
 	_, _, err := normalizeChatRequest([]byte(body))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "request nesting depth exceeds limit")
+}
+
+// Regression guard for the document mutex: without proper locking this trips
+// Go's fatal "concurrent map writes" or the race detector.
+func TestChatRequestDocumentConcurrentAccess(t *testing.T) {
+	doc, err := decodeChatRequestDocument([]byte(`{"a":1,"b":2,"c":3}`))
+	require.NoError(t, err)
+
+	const workers = 32
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			key := "k" + strconv.Itoa(id)
+			for i := 0; i < iterations; i++ {
+				doc.Set(key, i)
+				_, _ = doc.Get(key)
+				_ = doc.Has("a")
+				_, _ = doc.String("missing")
+				switch i % 4 {
+				case 0:
+					_ = doc.Keys()
+				case 1:
+					_, _ = doc.Marshal()
+				case 2:
+					doc.RLockedScope(func(raw map[string]any) {
+						for range raw {
+						}
+					})
+				case 3:
+					doc.LockedScope(func(raw map[string]any) {
+						raw["shared"] = i
+					})
+				}
+			}
+			doc.Delete(key)
+		}(w)
+	}
+	wg.Wait()
 }

--- a/devshard/docs/supported-params.md
+++ b/devshard/docs/supported-params.md
@@ -268,19 +268,19 @@ Calibrate the thresholds (depth, size, nodes) by running the validators against 
 
 ## Performance characteristics
 
-End-to-end `normalizeChatRequest` (Apple M2 Pro, `-benchtime=2s`):
+End-to-end `normalizeChatRequest` (Apple M2 Pro, `-benchtime=2s`, `-count=3`):
 
 | Body | ns/op | B/op | allocs/op |
 | --- | --- | --- | --- |
-| Minimal (47 B) | 2,958 | 2,450 | 43 |
-| Typical (132 B) | 4,488 | 2,947 | 67 |
-| Heavy (~620 B) | 20,087 | 13,090 | 242 |
-| WithResponseFormat (279 B) | 10,746 | 6,776 | 139 |
-| RejectedUnknown (72 B) | 1,916 | 2,170 | 36 |
-| **RejectedDeepBody (7.5 KiB body-depth attack)** | **1,066** | **96** | **2** |
-| RejectedRecursiveSchema (walker reject) | 8,178 | 7,944 | 102 |
+| Minimal (47 B) | 3,140 | 2,428 | 41 |
+| Typical (132 B) | 4,963 | 2,926 | 65 |
+| Heavy (~620 B) | 21,054 | 12,951 | 240 |
+| WithResponseFormat (279 B) | 10,372 | 6,663 | 137 |
+| RejectedUnknown (72 B) | 1,948 | 2,148 | 34 |
+| **RejectedDeepBody (7.5 KiB body-depth attack)** | **1,093** | **96** | **2** |
+| RejectedRecursiveSchema (walker reject) | 8,147 | 7,928 | 100 |
 
-`Heavy` now also carries `chat_template_kwargs` so `ChatTemplateKwargsValidator` is exercised end-to-end. `RejectedDeepBody` measures the body-level pre-scan rejection (depth > 32, never reaches the walker); `RejectedRecursiveSchema` measures the walker rejection on bodies that pass the pre-scan but trip `MaxDepth=5` — that path is ~8× more expensive because it pays for `json.Unmarshal` first.
+`Heavy` carries `chat_template_kwargs` so `ChatTemplateKwargsValidator` runs. `RejectedDeepBody` trips the body-level pre-scan (depth > 32) before any validator. `RejectedRecursiveSchema` reaches the walker (body depth under cap, schema depth over `MaxDepth=5`) and pays for `json.Unmarshal` — ~8× more expensive than pre-scan reject.
 
 `response_format` validator in isolation (`paramvalidators/response_format_bench_test.go`):
 
@@ -288,12 +288,12 @@ End-to-end `normalizeChatRequest` (Apple M2 Pro, `-benchtime=2s`):
 | --- | --- | --- | --- |
 | Absent | 8.7 | 0 | 0 |
 | `type=text` / `json_object` | ~18 | 0 | 0 |
-| Simple schema | 1,763 | 640 | 19 |
-| At limits (~121 nodes) | 55,895 | 24,701 | 724 |
-| Rejects recursion attack | 1,259 | 176 | 4 |
-| Rejects oversized schema | 19,889 | 19,023 | 17 |
+| Simple schema | 1,763 | 536 | 19 |
+| At limits (~121 nodes) | 56,734 | 21,252 | 724 |
+| Rejects recursion attack | 1,215 | 176 | 4 |
+| Rejects oversized schema | 17,402 | 514 | 17 |
 
-The walker `Rejects recursion attack` cost grew from ~560 ns to ~1.3 µs after CVE-2025-48944 type/pattern checks were added on every visited node. Still well under any latency budget.
+`CheckSize` switched from `json.Marshal(schema)` to `json.NewEncoder` over a counting `io.Writer`: same byte total, no marshaled buffer allocation. Saves -14% B/op on `At limits` and -97% on `Rejects oversized` (the 17 KiB schema no longer materializes).
 
 Bench files: `request_filters_bench_test.go` (pipeline-level) and `paramvalidators/response_format_bench_test.go` (validator-level).
 


### PR DESCRIPTION
## What problem does this solve?

Two distinct concerns on the chat-completions gateway pipeline plus one bug uncovered in review.

1. **Allocation pressure** under steady-state load. `normalizeChatRequest` allocates ~240 objects per Heavy request (real-shape body with tools + chat_template_kwargs + thinking). Three concrete sources are removable without changing observable behavior: per-request `bytes.NewReader(body)` for the JSON decoder; per-request `*ChatRequestDocument` heap allocation (the value is used only inside the enclosing `RequestFilterContext`); `json.Marshal(schema)` inside `SchemaBounds.CheckSize` / `ObjectBounds.CheckSize` -- we throw away the bytes; we only need the length. Worst on the size-rejection path, where a 17 KiB schema materializes just to be discarded.

2. **Future concurrency foot-gun.** `ChatRequestDocument` wraps a `map[string]any`. The pipeline today is single-goroutine per request, but Go's runtime treats concurrent map access as a *fatal* panic ("concurrent map writes") -- not a recoverable race. Any future change that adds async validation, speculative pipelines, or a streaming mutation would crash the whole serving process. The type had no synchronization, so the rule lived only in contributors' heads.

3. **Bug found in review:** `rejectUnknownParameters` used `var unknown string` + `if unknown != ""` to detect an unknown key. JSON allows `""` as a key, so a body like `{"":"slip", "messages":...}` silently passed the whitelist. The whole point of the catalog is to close paths like this.

## How do we know these are real?

(1) Bench-driven. Heavy benchmark on Apple M2 Pro: 242 allocs/op / 13090 B/op / ~20 µs. WithResponseFormat: 139 / 6776 / ~10 µs. `BenchmarkResponseFormatValidator_RejectsOversized` allocated 19,023 B/op just to reject a 17 KiB schema -- a measurable GC-pressure amplifier on the attack path.

(2) Audited by review: the document was shared by reference (it was a pointer before; the only ownership rule was "don't share the context"). Nothing prevented a contributor from adding a goroutine inside a handler. The fatal-crash class is well-known (`runtime.fatal "concurrent map writes"`).

(3) Reproducible: `curl -d '{"":"x", "messages":[...]}'` to a fixed baseline returned 200 and forwarded the field to vLLM. After the fix, the gateway returns HTTP 400 with a specific message.

## How does this PR solve the problem?

**Allocation.** `sync.Pool` for `*bytes.Reader`; `Reset(nil)` before `Put` so the pool doesn't pin caller body slices (up to 10 MiB). Embedded `ChatRequestDocument` by value in `RequestFilterContext`; a new helper `decodeChatRequestRaw(body) (map[string]any, error)` is factored out so the value-embed path doesn't go through the wrapper-returning entry point. `CheckSize` now uses `json.NewEncoder(&countingWriter{}).Encode(v)`: same byte total (encoder uses the same `encodeState` internally as `json.Marshal`), zero output-buffer allocation. New `paramvalidators/schema_bounds_test.go` pins `jsonMarshaledSize` byte-for-byte against `json.Marshal` across 12 cases (nested objects, HTML-unsafe chars, U+2028/U+2029 line/paragraph separators, control characters, escape sequences, `json.Number`, large schemas, nil) plus an unsupported-type case to verify error propagation rather than silent zero return.

**Concurrency.** `sync.RWMutex` on `ChatRequestDocument`; all methods lock; reads use `RLock`, writes use `Lock`. New `LockedScope(fn)` / `RLockedScope(fn)` helpers for multi-op sequences that need atomicity (e.g., `translateKimiThinkingForVLLM` reads `thinking`, may write `chat_template_kwargs`). **Removed `Raw()` method** -- it returned the underlying map past the lock boundary, defeating the whole point. Sole production caller (`DocumentValidatorHandler.Apply`) refactored to call the validator inside `RLockedScope`. Two other direct `.raw` accesses (`translateKimiThinkingForVLLM`, `rejectUnknownParameters`) refactored to scope helpers. `Object()` / `Array()` keep returning live references but with a doc-comment caveat: do not retain, do not mutate concurrently with other writers. They are used today only by sequential PreValidation handlers.

**Bug fix.** `rejectUnknownParameters` now sets the error inside the scope closure instead of relying on an "empty string is the absent sentinel" pattern. Empty keys produce a dedicated message (`"request body contains a field with an empty name"`) instead of the misleading `feature "" is temporarily unavailable`.

## What risks does this introduce? How are they mitigated?

- **Pool gotcha (body pinning).** Closed by `Reset(nil)` before `Put`; verified semantically (`bytes.Reader.Reset` sets `s = nil`).
- **`json.NewEncoder` vs `json.Marshal` byte parity.** Pinned at the test layer (`TestJSONMarshaledSizeMatchesJSONMarshal`); any future Go change to the default encoder shows up as a red test instead of a silent off-by-N in `CheckSize`.
- **Mutex overhead.** Refreshed bench numbers show the cost is at the noise level on Heavy (~+5% ns or below noise depending on run); +32 B/op constant for the inline mutex state. No alloc count delta. Reject paths (DeepBody, RecursiveSchema) are unchanged.
- **Lock-discipline regression.** New `TestChatRequestDocumentConcurrentAccess` (32 goroutines × 200 iterations of mixed `Set/Get/Has/String/Keys/Marshal/scope`) flags dropped locks under `-race` or via Go's fatal map check.
- **Behavioral change on empty-key request.** Previously: passed through to upstream (which would also reject). Now: HTTP 400 at the gateway with a clear message. Strict improvement; no legitimate client uses `""` as a top-level field name.
- **`Object()` / `Array()` foot-gun acknowledged.** Documented but not closed. No in-tree caller stashes the returned reference across an await point. Closing it fully would require a larger API change (returning copies or scoped callbacks); deferred until a real use case forces the decision.

## How do we know this PR fixes the problem?

- `TestNormalizeChatRequestRejectsUnsupportedFields/empty_string_key` — regression guard for the bypass. Asserts HTTP 400 with the dedicated message.
- `TestJSONMarshaledSizeMatchesJSONMarshal` — 12 sub-cases byte-for-byte against `json.Marshal`. `TestJSONMarshaledSizePropagatesEncoderError` — error propagation on unsupported types (`chan`).
- `TestChatRequestDocumentConcurrentAccess` — mutex correctness under contention; passes under `-race`.
- Bench tables in `devshard/docs/supported-params.md` refreshed against a clean run; honest about which numbers moved and which are noise.

## Which components are affected?

Only `devshard/cmd/devshardctl/`:

- `paramvalidators/schema_bounds.go` — `countingWriter` + `jsonMarshaledSize`; `CheckSize` refactor on both `SchemaBounds` and `ObjectBounds`.
- `paramvalidators/schema_bounds_test.go` (NEW) — byte-parity + error-propagation tests.
- `request_filters_parameters.go` — pool, embed-by-value, mutex, scope helpers, `Raw()` removal, callsite refactors, empty-key fix.
- `request_filters.go` — `translateKimiThinkingForVLLM` callsite to `LockedScope`.
- `request_filters_test.go` — concurrent-access test, empty-key regression case.
- `devshard/docs/supported-params.md` — refreshed performance section.

No chain / api / ml-node changes. No protobuf. No external API surface moved (the only signature change is `Raw()` removal, which had a single in-tree caller already refactored in the same diff).

## Testing

- `go vet ./cmd/devshardctl/...` — clean
- `gofmt -l ./cmd/devshardctl/ ./cmd/devshardctl/paramvalidators/` — clean
- `go test ./cmd/devshardctl/paramvalidators/ -race -count=1` — ok
- `go test ./cmd/devshardctl/ -race -count=1 -run 'TestNormalizeChatRequest|TestPrepareChatRequest|TestEnsureRequestNestingDepth|TestChatRequestDocumentConcurrentAccess'` — ok

Bench, Apple M2 Pro, `-benchtime=2s -count=3`:

| Body | ns/op | B/op | allocs/op |
| --- | --- | --- | --- |
| Minimal | 3,140 | 2,428 | 41 |
| Typical | 4,963 | 2,926 | 65 |
| Heavy | 21,054 | 12,951 | 240 |
| WithResponseFormat | 10,372 | 6,663 | 137 |
| **RejectedDeepBody (attack)** | **1,093** | **96** | **2** |

Validator-isolated:

| Path | ns/op | B/op | allocs/op |
| --- | --- | --- | --- |
| Simple schema | 1,763 | 536 | 19 |
| At limits (~121 nodes) | 56,734 | 21,252 | 724 |
| Rejects oversized schema | 17,402 | **514** | 17 |

The `Rejects oversized` row is the headline: 19,023 B/op → 514 B/op (-97%). The 17 KiB schema body no longer materializes a marshal output buffer.
