### PR TITLE
feat(sim): Cosmos SDK simulation runnable + first-wave x/inference ops (#982)

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -1,0 +1,48 @@
+name: Simulation Smoke (manual)
+
+# Manual trigger only; simulation runs add ~5-15 min to CI cost.
+# Maintainers may add `pull_request` / `push` triggers when sim coverage is
+# considered worth gating on. See docs/simulation.md for context.
+#
+# To activate auto-triggers, replace the `workflow_dispatch:` block below with:
+#
+#   pull_request:
+#     branches:
+#       - '**'
+#   push:
+#     branches:
+#       - main
+#
+# Or keep manual-only and trigger via the Actions tab / `gh workflow run`.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sim-smoke:
+    runs-on: ubuntu-24.04
+    name: Run sim-smoke-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.2'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('inference-chain/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run sim-smoke-test
+        working-directory: inference-chain
+        run: make sim-smoke-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build versiond-build-docker testapp-server-build-docker
+.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build versiond-build-docker testapp-server-build-docker node-sim-smoke-test node-sim-full-test
 
 VERSION ?= $(shell git describe --always)
 DEVSHARD_VERSION ?= dev
@@ -21,6 +21,13 @@ api-build-docker:
 
 node-build-docker:
 	@make -C inference-chain build-docker SET_LATEST=1 $(if $(GENESIS_OVERRIDES_FILE),GENESIS_OVERRIDES_FILE=$(GENESIS_OVERRIDES_FILE),)
+
+# Simulation dispatchers (issue #982 Phase 1)
+node-sim-smoke-test:
+	@make -C inference-chain sim-smoke-test
+
+node-sim-full-test:
+	@make -C inference-chain sim-full-test
 
 mock-server-build-docker:
 	@echo "Building mock-server JAR file..."

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -10,22 +10,23 @@ its phased implementation.
 From repo root:
 
 ```bash
-make sim-smoke-test   # 50 blocks × 20 ops, ~15 min
-make sim-full-test    # 500 blocks × 200 ops, ~120 min (Phase 2+ recommended)
+make sim-smoke-test   # 50 blocks × 20 ops, ~10 s
+make sim-full-test    # 500 blocks × 200 ops, ~35 s (Phase 2+ recommended)
 ```
 
-Both targets enter the `inference-chain` module and run `go test -run
-TestFullAppSimulation` with the `sims` build tag. The `*_Postrun` tests
-(see Test inventory) are not invoked by these targets; they call `t.Skip`
-with the reason and only run when invoked directly via
-`go test -tags sims ./app/...` without a `-run` filter.
+Both targets enter the `inference-chain` module and run
+`TestFullAppSimulation` with the `sims` build tag; `sim-smoke-test` also
+runs `TestFullSimulation_x_Inference_Integrated` (per-op state assertions).
+The `*_Postrun` tests (see Test inventory) are not invoked by these
+targets; they call `t.Skip` with the reason and only run when invoked
+directly via `go test -tags sims ./app/...` without a `-run` filter.
 
 ## Run modes
 
 | Target | Blocks × Ops | Seeds | Wall-clock | When to use |
 |---|---|---|---|---|
-| `sim-smoke-test` | 50 × 20 | 1 (`-Seed=99`) | ~15 min | Pre-PR sanity check; CI via [`.github/workflows/simulation.yml`](../.github/workflows/simulation.yml) (`workflow_dispatch` only, not a required PR check) |
-| `sim-full-test` | 500 × 200 | 1 (`-Seed=99`) | ~120 min | After Phase 2 real ops land. Informative only when ops are not NoOpMsg stubs |
+| `sim-smoke-test` | 50 × 20 | 1 (`-Seed=99`) | ~10 s | Pre-PR sanity check; CI via [`.github/workflows/simulation.yml`](../.github/workflows/simulation.yml) (`workflow_dispatch` only, not a required PR check) |
+| `sim-full-test` | 500 × 200 | 1 (`-Seed=99`) | ~35 s | After Phase 2 real ops land. Informative only when ops are not NoOpMsg stubs |
 | direct `go test` (with `-Seed=N`) | per `-NumBlocks` / `-BlockSize` flags | 1 (the supplied `-Seed`) | depends | Reproducing a specific seed, debugging |
 | direct `go test` (no `-Seed`) | per flags | simsx `defaultSeeds` (37 seeds, parallel subtests) | depends | Broad coverage sweep |
 
@@ -57,7 +58,50 @@ Read by `simcli.GetSimulatorFlags()` in `app/sim_test.go:init`:
 | `-NumBlocks` | (unset) | Number of blocks per simulation. |
 | `-BlockSize` | (unset) | Number of ops attempted per block. |
 | `-Seed` | (unset; falls back to simsx defaultSeeds list) | Specific seed to use. Override for reproducing failures. |
+| `-GenesisTime` | `time.Now().Unix()` at process start | UNIX timestamp of the simulated genesis. The default is the **wall clock**, so it differs every process; pin it for cross-process reproducibility (see [Reproducibility](#reproducibility)). |
 | `-Verbose` | `false` | Verbose logging. |
+
+## Reproducibility
+
+A simulation run is a pure function of **two** inputs, not one: the RNG
+`-Seed` *and* `-GenesisTime`. Pinning `-Seed` alone is not enough.
+
+`gonka-ai/cosmos-sdk@v0.53.3-ps17` registers `-GenesisTime` with a default
+of `time.Now().Unix()` (`x/simulation/client/cli/flags.go:62`), evaluated
+once per process. The genesis timestamp flows through `AppStateRandomizedFn`
+into time-gated chain logic (gov/group voting windows, access cutoffs), so
+two runs of the same `-Seed` minutes apart produce a different `opsCount`
+and a different AppHash.
+
+`TestAppStateDeterminism` does not catch this — it runs the same seed
+several times *inside one process*, where `-GenesisTime` is already fixed.
+
+`make sim-smoke-test` / `make sim-full-test` pin `-GenesisTime` (see
+`inference-chain/Makefile`, `SIM_GENESIS_TIME`) so their AppHash is
+reproducible across machines and CI. When reproducing a run with a direct
+`go test`, pass the **same** `-GenesisTime` as the original, not just
+`-Seed`.
+
+## Validator set in long runs
+
+A Cosmos simulation needs a non-empty validator set every block, or simsx
+aborts the run (`x/simulation/simulate.go:266` — `t.Skip("empty validator
+set")`).
+
+`inference-chain`'s validator set is managed by the PoC flow:
+`SetComputeValidators` (`cosmos-sdk/x/staking/keeper/compute.go`) rebuilds it
+every epoch from compute results. The simulation does not run PoC, so it never
+refreshes the set — while cosmos `x/slashing` keeps downtime-jailing validators
+on the random vote-info simsx feeds each block. Left alone the bonded set
+drains linearly to zero (observed ~block 135 of a seed-99 run) and the run
+skips.
+
+`EnsureComputeValidators` (`x/inference/simulation/bootstrap.go`) bridges the
+gap: when the bonded validator count falls below a floor it feeds every
+validator back through `SetComputeValidators`, which un-jails and re-bonds them
+— mimicking production's per-epoch refresh. The x/inference op factories call
+it, so `sim-full-test` completes a real 500-block run. Faithfully simulating
+the full PoC validator rotation is separate, larger work.
 
 ## Expected output
 
@@ -174,6 +218,7 @@ docker run --rm --network host \
 | Test | What it checks | Status |
 |---|---|---|
 | `TestFullAppSimulation` | Top-level simsx run: random genesis → simulate → CheckExportSimulation | Green |
+| `TestFullSimulation_x_Inference_Integrated` | Smoke simsx run + post-run keeper-state assertions: StartInference/FinishInference/MsgValidation each reached state mutation | Green |
 | `TestAppImportExport_Postrun` | Export → fresh app InitGenesis → KV-store diff | **Skipped** (tracks fork bonded-pool issue, see TODO and gonka-ai/gonka#1153) |
 | `TestAppSimulationAfterImport_Postrun` | Export → fresh app InitChain → second simulation | **Skipped** (same fork issue + post-import simulation step not yet wired) |
 | `TestAppStateDeterminism` | 3 seeds × 3 attempts: identical AppHash | Green |
@@ -181,13 +226,16 @@ docker run --rm --network host \
 | `TestDisabledOpsSimModule_*` | Wrapper produces empty WeightedOperations for staking/distribution/wasm | Green |
 | `TestBankGenesisFix_SupplyRecomputed` | `fixBankGenesisState` makes Supply match Balances | Green |
 
-## Phase status (as of 2026-05-08)
+## Phase status
 
-- **Phase 1** (this issue): simsx migration, smoke/full Make targets, disabled
-  upstream ops, restored test semantics, fixBankGenesisState. **In progress.**
-- **Phase 2**: first-wave x/inference real ops (SubmitNewParticipant,
+`#982` defines a four-phase roadmap. Phases 1 and 2 are implemented; both
+`sim-smoke-test` and `sim-full-test` exercise real `x/inference` operations.
+
+- **Phase 1** — simsx migration, smoke/full Make targets, disabled upstream
+  ops, restored test semantics, `fixBankGenesisState`. **Done.**
+- **Phase 2** — first-wave `x/inference` real ops (SubmitNewParticipant,
   StartInference, FinishInference, Validation, ClaimRewards) replacing
-  NoOpMsg stubs. After this phase, `sim-full-test` produces meaningful signal.
+  NoOpMsg stubs. **Done.**
 - **Phase 3**: weight tuning, store decoders, custom invariants,
   parameter-edge fuzzing. PoC-state determinism beyond AppHash.
 - **Phase 4**: simulation operations for other custom modules (bls,

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -1,0 +1,194 @@
+# Simulation and Fuzz Testing
+
+This document covers how to run, interpret, and extend Cosmos SDK simulation
+tests for `inference-chain`. It is the operator/developer reference for
+[issue gonka-ai/gonka#982](https://github.com/gonka-ai/gonka/issues/982) and
+its phased implementation.
+
+## Quick start
+
+From repo root:
+
+```bash
+make sim-smoke-test   # 50 blocks × 20 ops, ~15 min
+make sim-full-test    # 500 blocks × 200 ops, ~120 min (Phase 2+ recommended)
+```
+
+Both targets enter the `inference-chain` module and run `go test -run
+TestFullAppSimulation` with the `sims` build tag. The `*_Postrun` tests
+(see Test inventory) are not invoked by these targets; they call `t.Skip`
+with the reason and only run when invoked directly via
+`go test -tags sims ./app/...` without a `-run` filter.
+
+## Run modes
+
+| Target | Blocks × Ops | Seeds | Wall-clock | When to use |
+|---|---|---|---|---|
+| `sim-smoke-test` | 50 × 20 | 1 (`-Seed=99`) | ~15 min | Pre-PR sanity check; CI via [`.github/workflows/simulation.yml`](../.github/workflows/simulation.yml) (`workflow_dispatch` only, not a required PR check) |
+| `sim-full-test` | 500 × 200 | 1 (`-Seed=99`) | ~120 min | After Phase 2 real ops land. Informative only when ops are not NoOpMsg stubs |
+| direct `go test` (with `-Seed=N`) | per `-NumBlocks` / `-BlockSize` flags | 1 (the supplied `-Seed`) | depends | Reproducing a specific seed, debugging |
+| direct `go test` (no `-Seed`) | per flags | simsx `defaultSeeds` (37 seeds, parallel subtests) | depends | Broad coverage sweep |
+
+**Seed dispatch:** `TestFullAppSimulation` reads `-Seed` via `simcli.NewConfigFromFlags()`. When set, it calls `simsx.RunWithSeed` for a single-seed run (matches Make targets). When unset (CLI default sentinel), it falls through to `simsx.Run` which fans out the framework's default 37-seed list as parallel `t.Run("seed: N", ...)` subtests.
+
+## Build tags
+
+| Tag | Purpose |
+|---|---|
+| `sims` | Includes simulation test files (`sim_test.go`, `sim_bench_test.go`). Required for all simulation runs. |
+| `simsbench` | Includes benchmark variant (`BenchmarkFullAppSimulation`). Used for performance profiling, not correctness. |
+| `muslc` | Required when building under Alpine/musl (CI, canonical Docker). Links static `libwasmvm_muslc.x86_64.a`. |
+
+Combine with `,` or space:
+
+```bash
+go test -tags 'sims muslc' ./app/...                  # production-tag combo
+go test -tags 'sims simsbench muslc' ./app/...        # also picks up benchmark
+```
+
+## CLI flags
+
+Read by `simcli.GetSimulatorFlags()` in `app/sim_test.go:init`:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `-Enabled` | `false` | Master switch. Set to `true` to actually run simulation; without it the tests skip. |
+| `-Commit` | `false` | Commit blocks during simulation. Required for any meaningful run. |
+| `-NumBlocks` | (unset) | Number of blocks per simulation. |
+| `-BlockSize` | (unset) | Number of ops attempted per block. |
+| `-Seed` | (unset; falls back to simsx defaultSeeds list) | Specific seed to use. Override for reproducing failures. |
+| `-Verbose` | `false` | Verbose logging. |
+
+## Expected output
+
+Successful smoke run prints per-seed summaries:
+
+```
++++ DONE (seed: 99):
+... (operation stats per module)
+```
+
+A successful determinism run (`TestAppStateDeterminism`) is silent in
+non-verbose mode and exits 0. The test runs 3 seeds × 3 attempts each (9
+runs internally).
+
+A successful full run prints the same per-seed summary plus
+`PrintStats(testInstance.DB)` output (db-level statistics) when `-Commit=true`.
+
+## Failure interpretation
+
+### Determinism failure
+
+```
+non-determinism in seed N: attempt 0 vs M
+```
+
+Different AppHash across attempts of the same seed. Common causes:
+
+- Go map iteration in keeper code (use `Iterate` with `PrefixedPairRange`).
+- `time.Now()` or other system-clock reads in state code.
+- RNG used outside the `r *rand.Rand` provided by simulation.
+- Floating-point arithmetic in state code (use `shopspring/decimal`).
+
+Capture the failing seed and re-run `TestAppStateDeterminism` with `-Seed=N`
+to isolate it. The test honors `-Seed` and overrides its internal triplet
+(`defaultSimSeeds`) when a non-default seed is passed:
+
+```bash
+cd inference-chain
+go test -mod=readonly -tags 'sims muslc' \
+    -run TestAppStateDeterminism ./app/... \
+    -Enabled=true -Commit=true -Seed=42 -v
+```
+
+### Bonded-pool panic on import
+
+```
+panic: bonded pool balance is different from bonded coins:  <-> NNNNstake
+  at gonka-ai/cosmos-sdk@v0.53.3-ps17/x/staking/keeper/genesis.go:158
+```
+
+This is a **known fork-level inconsistency**, not a bug in the simulation.
+`TestAppImportExport_Postrun` and `TestAppSimulationAfterImport_Postrun`
+hit this panic by design; see the TODO blocks above each test in
+`app/sim_test.go`.
+
+Production avoids this path by using `x/upgrade` in-place handlers
+(`app/upgrades/v0_2_*`) rather than vanilla `inferenced export → init`.
+
+### Linker error: cannot find -lwasmvm_muslc.x86_64
+
+When running outside the canonical Docker:
+
+```
+ld: cannot find -lwasmvm_muslc.x86_64: No such file or directory
+```
+
+The static lib name MUST include the architecture suffix exactly:
+`libwasmvm_muslc.x86_64.a` (not `libwasmvm_muslc.a`). Download from
+[CosmWasm/wasmvm releases](https://github.com/CosmWasm/wasmvm/releases),
+match version with `inference-chain/go.mod`.
+
+## Reproducing failing seeds
+
+Smoke run prints `seed: N` for each parallelised sub-test. Re-run a single
+seed:
+
+```bash
+cd inference-chain
+go test -mod=readonly -tags 'sims muslc' \
+    -run 'TestFullAppSimulation/seed:_<N>' ./app/ \
+    -Enabled=true -Commit=true -NumBlocks=50 -BlockSize=20 -v
+```
+
+For `TestAppStateDeterminism`, the seed appears in the failure message
+directly.
+
+## Canonical Docker run
+
+Local environments often have ABI mismatches with `bytedance/sonic` or
+missing wasmvm libs. Canonical run uses Alpine + musl + static wasmvm. The
+`WASMVM_VERSION` is derived inside the container from `inference-chain/go.mod`
+so it stays in sync with the dependency:
+
+```bash
+docker run --rm --network host \
+  -v "$PWD":/src -w /src/inference-chain \
+  -v "$HOME/go/pkg/mod":/go/pkg/mod \
+  golang:1.24.2-alpine3.20 sh -c '
+    apk add --no-cache gcc musl-dev curl &&
+    WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v2 | awk "{print \$2}") &&
+    mkdir -p /lib/wasmvm-static &&
+    curl -sL -o /lib/wasmvm-static/libwasmvm_muslc.x86_64.a \
+      "https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.x86_64.a" &&
+    CGO_ENABLED=1 CGO_LDFLAGS="-L/lib/wasmvm-static" \
+      go test -mod=readonly -tags "sims muslc" ./app/...
+  '
+```
+
+`--network host` is required because Docker bridge often timeouts to
+`github.com` when downloading wasmvm.
+
+## Test inventory
+
+| Test | What it checks | Status |
+|---|---|---|
+| `TestFullAppSimulation` | Top-level simsx run: random genesis → simulate → CheckExportSimulation | Green |
+| `TestAppImportExport_Postrun` | Export → fresh app InitGenesis → KV-store diff | **Skipped** (tracks fork bonded-pool issue, see TODO and gonka-ai/gonka#1153) |
+| `TestAppSimulationAfterImport_Postrun` | Export → fresh app InitChain → second simulation | **Skipped** (same fork issue + post-import simulation step not yet wired) |
+| `TestAppStateDeterminism` | 3 seeds × 3 attempts: identical AppHash | Green |
+| `TestApp_GenesisInit_*` | Genesis init produces blocked module accounts + PoC validators | Green |
+| `TestDisabledOpsSimModule_*` | Wrapper produces empty WeightedOperations for staking/distribution/wasm | Green |
+| `TestBankGenesisFix_SupplyRecomputed` | `fixBankGenesisState` makes Supply match Balances | Green |
+
+## Phase status (as of 2026-05-08)
+
+- **Phase 1** (this issue): simsx migration, smoke/full Make targets, disabled
+  upstream ops, restored test semantics, fixBankGenesisState. **In progress.**
+- **Phase 2**: first-wave x/inference real ops (SubmitNewParticipant,
+  StartInference, FinishInference, Validation, ClaimRewards) replacing
+  NoOpMsg stubs. After this phase, `sim-full-test` produces meaningful signal.
+- **Phase 3**: weight tuning, store decoders, custom invariants,
+  parameter-edge fuzzing. PoC-state determinism beyond AppHash.
+- **Phase 4**: simulation operations for other custom modules (bls,
+  bookkeeper, collateral, genesistransfer, restrictions, streamvesting).

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -318,18 +318,24 @@ proto:
 
 SIM_PKG := ./app/
 
+# -GenesisTime is pinned: gonka-ai/cosmos-sdk registers it with a
+# time.Now() default (x/simulation/client/cli/flags.go:62), so an unpinned
+# run is reproducible only within a single process. Pinning it alongside
+# -Seed makes the AppHash reproducible across machines and CI runs.
+SIM_GENESIS_TIME := 1700000000
+
 sim-smoke-test:
-	@echo "--> Running smoke simulation: 50 blocks x 20 ops/block (~15 min)"
-	@go test -mod=readonly -tags sims $(SIM_PKG) \
-		-run TestFullAppSimulation \
+	@echo "--> Running smoke simulation: 50 blocks x 20 ops/block (~10 s)"
+	@go test -mod=readonly -tags "sims muslc" $(SIM_PKG) \
+		-run 'TestFullAppSimulation|TestFullSimulation_x_Inference_Integrated' \
 		-Enabled=true -Commit=true \
-		-NumBlocks=50 -BlockSize=20 -Seed=99 \
+		-NumBlocks=50 -BlockSize=20 -Seed=99 -GenesisTime=$(SIM_GENESIS_TIME) \
 		-v -timeout 30m
 
 sim-full-test:
-	@echo "--> Running full simulation: 500 blocks x 200 ops/block (~120 min)"
-	@go test -mod=readonly -tags sims $(SIM_PKG) \
+	@echo "--> Running full simulation: 500 blocks x 200 ops/block (~35 s)"
+	@go test -mod=readonly -tags "sims muslc" $(SIM_PKG) \
 		-run TestFullAppSimulation \
 		-Enabled=true -Commit=true \
-		-NumBlocks=500 -BlockSize=200 -Seed=99 \
+		-NumBlocks=500 -BlockSize=200 -Seed=99 -GenesisTime=$(SIM_GENESIS_TIME) \
 		-v -timeout 180m

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install build build-docker init clean-state mock-expected-keepers docker-push release build-all package deploy proto
+.PHONY: all install build build-docker init clean-state mock-expected-keepers docker-push release build-all package deploy proto sim-smoke-test sim-full-test
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
@@ -310,3 +310,26 @@ mock-expected-keepers:
 
 proto:
 	ignite generate proto-go
+
+#################################################
+# SIMULATION SECTION (issue #982 Phase 1)
+#################################################
+# Targets are no-ops until TestFullAppSimulation lands in Phase 1 item 1.A (sim_test.go migration).
+
+SIM_PKG := ./app/
+
+sim-smoke-test:
+	@echo "--> Running smoke simulation: 50 blocks x 20 ops/block (~15 min)"
+	@go test -mod=readonly -tags sims $(SIM_PKG) \
+		-run TestFullAppSimulation \
+		-Enabled=true -Commit=true \
+		-NumBlocks=50 -BlockSize=20 -Seed=99 \
+		-v -timeout 30m
+
+sim-full-test:
+	@echo "--> Running full simulation: 500 blocks x 200 ops/block (~120 min)"
+	@go test -mod=readonly -tags sims $(SIM_PKG) \
+		-run TestFullAppSimulation \
+		-Enabled=true -Commit=true \
+		-NumBlocks=500 -BlockSize=200 -Seed=99 \
+		-v -timeout 180m

--- a/inference-chain/app/app.go
+++ b/inference-chain/app/app.go
@@ -51,6 +51,7 @@ import (
 	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	_ "github.com/cosmos/cosmos-sdk/x/distribution" // import for side-effects
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
@@ -69,6 +70,7 @@ import (
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	_ "github.com/cosmos/cosmos-sdk/x/staking" // import for side-effects
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	_ "github.com/cosmos/ibc-go/modules/capability" // import for side-effects
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
@@ -321,8 +323,24 @@ func New(
 	// create the simulation manager and define the order of the modules for deterministic simulations
 	//
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing transactions
+	//
+	// staking/distribution/wasmd weighted ops are disabled - see app/simulation.go
+	// for rationale. Genesis state generation is preserved via Go embedding.
+	mustSimMod := func(name string) module.AppModuleSimulation {
+		sm, ok := app.ModuleManager.Modules[name].(module.AppModuleSimulation)
+		if !ok {
+			panic(fmt.Sprintf("module %q is missing or does not implement module.AppModuleSimulation: cannot wrap with disabledOpsSimModule", name))
+		}
+		return sm
+	}
+	stakingSimMod := mustSimMod(stakingtypes.ModuleName)
+	distrSimMod := mustSimMod(distrtypes.ModuleName)
+	wasmSimMod := mustSimMod(wasmtypes.ModuleName)
 	overrideModules := map[string]module.AppModuleSimulation{
-		authtypes.ModuleName: auth.NewAppModule(app.appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
+		authtypes.ModuleName:    auth.NewAppModule(app.appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
+		stakingtypes.ModuleName: disabledOpsSimModule{stakingSimMod},
+		distrtypes.ModuleName:   disabledOpsSimModule{distrSimMod},
+		wasmtypes.ModuleName:    disabledOpsSimModule{wasmSimMod},
 	}
 	app.sm = module.NewSimulationManagerFromAppModules(app.ModuleManager.Modules, overrideModules)
 	app.sm.RegisterStoreDecoders()
@@ -433,6 +451,18 @@ func (app *App) GetCapabilityScopedKeeper(moduleName string) capabilitykeeper.Sc
 // SimulationManager implements the SimulationApp interface.
 func (app *App) SimulationManager() *module.SimulationManager {
 	return app.sm
+}
+
+// TxConfig returns the App's TxConfig.
+// Implements simsx.SimulationApp interface required by simsx.Run.
+func (app *App) TxConfig() client.TxConfig {
+	return app.txConfig
+}
+
+// GetBaseApp returns the underlying *baseapp.BaseApp.
+// Implements simsx.SimulationApp interface required by simsx.Run.
+func (app *App) GetBaseApp() *baseapp.BaseApp {
+	return app.BaseApp
 }
 
 // RegisterAPIRoutes registers all application module routes with the provided

--- a/inference-chain/app/genesis_test.go
+++ b/inference-chain/app/genesis_test.go
@@ -1,0 +1,81 @@
+package app_test
+
+import (
+	"slices"
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApp_GenesisInit_ModuleAccountsAndPoCValidators verifies four
+// properties after a fresh InitGenesis on an app where staking,
+// distribution, and wasmd are wrapped in disabledOpsSimModule:
+//
+//	(a) InitGenesis runs without panic. Implicit: if it panicked,
+//	    createTestApp would not return.
+//	(b) The five blocked module accounts are populated (app_config.go
+//	    blockedModuleAccountAddrs).
+//	(c) New validators can be added via the gonka PoC compute path
+//	    (StakingKeeper.SetComputeValidators), since vanilla Cosmos token
+//	    delegation is disabled in this fork (docs/cosmos_changes.md).
+//	(d) The fee collector is a usable ModuleAccount, not a bare
+//	    BaseAccount.
+//
+// Reuses createTestApp from tally_integration_test.go (PR #496).
+// Subtests share testApp and ctx from the outer scope; one of them
+// mutates state via SetComputeValidators, so failures are isolated per
+// subtest but state is not.
+func TestApp_GenesisInit_ModuleAccountsAndPoCValidators(t *testing.T) {
+	testApp := createTestApp(t)
+	ctx := testApp.BaseApp.NewUncachedContext(false, cmtproto.Header{ChainID: TallyTestChainID, Height: 1})
+
+	t.Run("blocked module accounts populated", func(t *testing.T) {
+		blocked := []string{
+			authtypes.FeeCollectorName,
+			distrtypes.ModuleName,
+			minttypes.ModuleName,
+			stakingtypes.BondedPoolName,
+			stakingtypes.NotBondedPoolName,
+		}
+		for _, name := range blocked {
+			t.Run(name, func(t *testing.T) {
+				addr := testApp.AccountKeeper.GetModuleAddress(name)
+				require.NotNil(t, addr, "GetModuleAddress(%s) should not be nil", name)
+				acct := testApp.AccountKeeper.GetAccount(ctx, addr)
+				require.NotNil(t, acct, "module account %s should exist after InitGenesis", name)
+			})
+		}
+	})
+
+	t.Run("PoC compute validator can be added", func(t *testing.T) {
+		pocPub := ed25519.GenPrivKey().PubKey()
+		pocOpAddr := sdk.ValAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+		pocResults := []stakingkeeper.ComputeResult{{
+			Power:           100,
+			ValidatorPubKey: pocPub,
+			OperatorAddress: pocOpAddr,
+		}}
+
+		postPoC, err := testApp.StakingKeeper.SetComputeValidators(ctx, pocResults, true /* isTestnet */)
+		require.NoError(t, err)
+		require.True(t, slices.ContainsFunc(postPoC, func(v stakingtypes.Validator) bool {
+			return v.OperatorAddress == pocOpAddr && v.IsBonded()
+		}), "PoC compute validator must be present and bonded after SetComputeValidators")
+	})
+
+	t.Run("fee collector is ModuleAccount", func(t *testing.T) {
+		feeAddr := testApp.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+		feeAcct := testApp.AccountKeeper.GetAccount(ctx, feeAddr)
+		_, isModAcct := feeAcct.(sdk.ModuleAccountI)
+		require.True(t, isModAcct, "fee collector should implement ModuleAccountI")
+	})
+}

--- a/inference-chain/app/sdk_config.go
+++ b/inference-chain/app/sdk_config.go
@@ -1,0 +1,36 @@
+package app
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// CoinType is the SLIP-44 coin type used for HD key derivation on the Gonka chain.
+const CoinType = 1200
+
+// InitSDKConfig sets the chain's bech32 prefixes and coin type on the
+// global sdk.Config. Idempotent. Does not seal; production callers must
+// call SealSDKConfig after this.
+//
+// Tests call this without sealing so per-test helpers like createTestApp
+// can re-set the same prefixes from package init scope under the sims
+// build tag without hitting the sealed-config panic.
+func InitSDKConfig() {
+	accountPubKeyPrefix := AccountAddressPrefix + "pub"
+	validatorAddressPrefix := AccountAddressPrefix + "valoper"
+	validatorPubKeyPrefix := AccountAddressPrefix + "valoperpub"
+	consNodeAddressPrefix := AccountAddressPrefix + "valcons"
+	consNodePubKeyPrefix := AccountAddressPrefix + "valconspub"
+
+	config := sdk.GetConfig()
+	config.SetCoinType(CoinType) // TODO: change to custom coin type
+	config.SetBech32PrefixForAccount(AccountAddressPrefix, accountPubKeyPrefix)
+	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
+	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)
+}
+
+// SealSDKConfig seals the global sdk.Config so subsequent SetBech32 or
+// SetCoinType calls panic. Production callers (cmd/inferenced) call this
+// after InitSDKConfig at startup so address parsing stays strict for
+// the lifetime of the process. Tests do not call it; sealing breaks
+// createTestApp and other helpers that re-set prefixes per test.
+func SealSDKConfig() {
+	sdk.GetConfig().Seal()
+}

--- a/inference-chain/app/setup_test.go
+++ b/inference-chain/app/setup_test.go
@@ -1,0 +1,20 @@
+package app_test
+
+import (
+	"os"
+	"testing"
+
+	inferencemodule "github.com/productscience/inference/x/inference/module"
+)
+
+// TestMain enables a test-only escape hatch in x/inference/module that
+// suppresses the "denom <X> already registered" panic from
+// sdk.RegisterDenom when multiple tests in this package each spin up a
+// fresh *app.App via createTestApp, NewSimApp, or
+// NewSimulationAppInstance. `go test` compiles each package to its own
+// binary so the flag dies with the process; production semantics (flag
+// default=false) are unaffected. See x/inference/module/genesis.go:16-22.
+func TestMain(m *testing.M) {
+	inferencemodule.IgnoreDuplicateDenomRegistration = true
+	os.Exit(m.Run())
+}

--- a/inference-chain/app/setup_test.go
+++ b/inference-chain/app/setup_test.go
@@ -13,7 +13,7 @@ import (
 // fresh *app.App via createTestApp, NewSimApp, or
 // NewSimulationAppInstance. `go test` compiles each package to its own
 // binary so the flag dies with the process; production semantics (flag
-// default=false) are unaffected. See x/inference/module/genesis.go:16-22.
+// default=false) are unaffected. See x/inference/module/genesis.go.
 func TestMain(m *testing.M) {
 	inferencemodule.IgnoreDuplicateDenomRegistration = true
 	os.Exit(m.Run())

--- a/inference-chain/app/sim_bench_test.go
+++ b/inference-chain/app/sim_bench_test.go
@@ -1,155 +1,33 @@
+//go:build simsbench
+
 package app_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/server"
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
-	"github.com/stretchr/testify/require"
-
-	"github.com/productscience/inference/app"
 )
 
+// BenchmarkFullAppSimulation profiles a single full-simulation run.
+//
+// A full simulation takes minutes, so b.N looping is not meaningful and
+// the benchmark is single-iteration. Pass `-benchtime=1x`. Per-iteration
+// metrics (ns/op, allocs/op) are not useful; this benchmark exists for
+// `-cpuprofile`, `-memprofile`, and `-trace`.
+//
 // Profile with:
-// `go test -benchmem -run=^$ -bench ^BenchmarkFullAppSimulation ./app -Commit=true -cpuprofile cpu.out`
+//
+//	go test -tags 'sims simsbench' -run=^$ \
+//	    github.com/productscience/inference/app \
+//	    -bench ^BenchmarkFullAppSimulation$ -benchtime=1x -cpuprofile cpu.out
 func BenchmarkFullAppSimulation(b *testing.B) {
-	b.ReportAllocs()
-
 	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
+	config.ChainID = simsx.SimAppChainID
 
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "goleveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if err != nil {
-		b.Fatalf("simulation setup failed: %s", err.Error())
+	seed := config.Seed
+	if seed == simcli.DefaultSeedValue {
+		seed = defaultSimSeeds[0]
 	}
-
-	if skip {
-		b.Skip("skipping benchmark application simulation")
-	}
-
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, interBlockCacheOpt())
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	if err = simtestutil.CheckExportSimulation(bApp, config, simParams); err != nil {
-		b.Fatal(err)
-	}
-
-	if simErr != nil {
-		b.Fatal(simErr)
-	}
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-}
-
-func BenchmarkInvariants(b *testing.B) {
-	b.ReportAllocs()
-
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-invariant-bench", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if err != nil {
-		b.Fatalf("simulation setup failed: %s", err.Error())
-	}
-
-	if skip {
-		b.Skip("skipping benchmark application simulation")
-	}
-
-	config.AllInvariants = false
-
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, interBlockCacheOpt())
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	if err = simtestutil.CheckExportSimulation(bApp, config, simParams); err != nil {
-		b.Fatal(err)
-	}
-
-	if simErr != nil {
-		b.Fatal(simErr)
-	}
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-
-	ctx := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight() + 1})
-
-	// 3. Benchmark each invariant separately
-	//
-	// NOTE: We use the crisis keeper as it has all the invariants registered with
-	// their respective metadata which makes it useful for testing/benchmarking.
-	for _, cr := range bApp.CrisisKeeper.Routes() {
-		cr := cr
-		b.Run(fmt.Sprintf("%s/%s", cr.ModuleName, cr.Route), func(b *testing.B) {
-			if res, stop := cr.Invar(ctx); stop {
-				b.Fatalf(
-					"broken invariant at block %d of %d\n%s",
-					ctx.BlockHeight()-1, config.NumBlocks, res,
-				)
-			}
-		})
-	}
+	simsx.RunWithSeed(b, config, NewSimApp, setupStateFactory, seed, nil)
 }

--- a/inference-chain/app/sim_inference_test.go
+++ b/inference-chain/app/sim_inference_test.go
@@ -1,0 +1,92 @@
+//go:build sims
+
+package app_test
+
+import (
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/app"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
+)
+
+// TestFullSimulation_x_Inference_Integrated runs the smoke simulation and
+// asserts — by inspecting keeper state after the run — that the Phase 2
+// first-wave x/inference operations actually mutate chain state, not just
+// get delivered as txs.
+//
+// Why state inspection rather than the simsx report: the `+++ DONE` report
+// exposes a single combined `inference_completed` counter for all five
+// inference ops and itemises only *skips*, so it cannot show per-op success.
+// The keeper's Inferences collection is the ground truth.
+//
+// Asserted (one signal per op, each reachable only through that op's
+// state-mutating path):
+//   - StartInference  -> inferences with AssignedTo set (StartProcessed).
+//   - FinishInference -> inferences with ExecutedBy set (FinishedProcessed,
+//     types/inference.go).
+//   - MsgValidation   -> inferences in VALIDATED status, set only by the
+//     passing branch at msg_server_validation.go.
+//
+// Not asserted, by design:
+//   - MsgSubmitNewParticipant is idempotent; sim accounts are already
+//     genesis participants (BuildSimGenesisParticipants), so it takes the
+//     no-op update path and leaves no distinguishing state.
+//   - MsgClaimRewards runs against EffectiveEpochIndex=0, where the handler
+//     returns a graceful response without mutating state
+//     (msg_server_claim_rewards.go).
+//
+// Both ops are still exercised by the run — they have no state
+// fingerprint to assert on.
+//
+// Seed dispatch mirrors TestFullAppSimulation. Run via `make sim-smoke-test`,
+// which pins -Seed and -GenesisTime (see docs/simulation.md §Reproducibility).
+func TestFullSimulation_x_Inference_Integrated(t *testing.T) {
+	if !simcli.FlagEnabledValue {
+		t.Skip("pass -Enabled=true to run this; e.g. via make sim-smoke-test")
+	}
+	cfg := simcli.NewConfigFromFlags()
+	cfg.ChainID = simsx.SimAppChainID
+
+	assertInferenceLifecycle := func(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+		tb.Helper()
+		bApp := ti.App
+		ctx := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
+
+		infs, err := bApp.InferenceKeeper.GetAllInference(ctx)
+		require.NoError(tb, err)
+
+		var startProcessed, finishProcessed, validated int
+		for _, inf := range infs {
+			if inf.AssignedTo != "" {
+				startProcessed++
+			}
+			if inf.ExecutedBy != "" {
+				finishProcessed++
+			}
+			if inf.Status == inferencetypes.InferenceStatus_VALIDATED {
+				validated++
+			}
+		}
+		tb.Logf("x/inference lifecycle: total=%d startProcessed=%d finishProcessed=%d validated=%d",
+			len(infs), startProcessed, finishProcessed, validated)
+
+		require.Positivef(tb, startProcessed,
+			"MsgStartInference never reached SetInference (no inference has AssignedTo set)")
+		require.Positivef(tb, finishProcessed,
+			"MsgFinishInference never reached state mutation (no inference has ExecutedBy set)")
+		require.Positivef(tb, validated,
+			"MsgValidation never reached its passing-branch state mutation (no VALIDATED inference)")
+	}
+
+	if cfg.Seed != simcli.DefaultSeedValue {
+		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil, assertInferenceLifecycle)
+		return
+	}
+	simsx.Run(t, NewSimApp, setupStateFactory, assertInferenceLifecycle)
+}

--- a/inference-chain/app/sim_test.go
+++ b/inference-chain/app/sim_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"cosmossdk.io/log"
+	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/feegrant"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -21,6 +22,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
@@ -89,12 +91,25 @@ func setupStateFactory(bApp *app.App) simsx.SimStateFactory {
 //
 //  1. Add Gonka denom metadata, required by inference module init
 //     (app.initializeDenomMetadata reads BankKeeper.GetDenomMetaData(BaseCoin)).
-//  2. Recompute bank Supply from Balances. The randomized genesis sets
+//  2. Fund every sim account with ngonka: upstream
+//     simsx hardwires simState.BondDenom = sdk.DefaultBondDenom = "stake"
+//     (testutil/simsx/runner.go:286), so the randomized bank GenesisState
+//     funds accounts with `stake` but not the `ngonka` BaseCoin that
+//     StartInference's escrow flow requires (payment_handler.go).
+//     Without this, every StartInference fails at PutPaymentInEscrow with
+//     "insufficient spendable funds" and routes through failedStart — so
+//     no Inferences ever land in keeper and the rest of the first-wave
+//     ops never see paired state. We give each account simAccountNgonka
+//     coins of ngonka (~10^15 ≈ 10^6 GNK), well above the per-inference
+//     escrow even for the full-test 100K-op run.
+//  3. Recompute bank Supply from Balances. The randomized genesis sets
 //     Supply based on NumBonded staking validators, but with staking ops
 //     disabled the bonded pool is never funded, so the default Supply
-//     would fail the supply-vs-balance invariant at InitGenesis.
+//     would fail the supply-vs-balance invariant at InitGenesis. Same
+//     recompute keeps Supply in sync after the ngonka top-up.
 //
-// Ported from hleb-albau PR gonka-ai/gonka#995.
+// The denom-metadata + Supply-recompute steps are ported from hleb-albau
+// PR gonka-ai/gonka#995; the ngonka top-up is added on top.
 func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
 	bankStateBz, ok := rawState[banktypes.ModuleName]
 	if !ok {
@@ -117,6 +132,24 @@ func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
 		},
 	})
 
+	// Build the set of module-account addresses so we DON'T top them up
+	// with ngonka — staking InitGenesis verifies notBondedPool balance ==
+	// declared NotBondedCoins (stake only); adding ngonka there panics
+	// «not bonded pool balance is different from not bonded coins»
+	// (cosmos-sdk x/staking/keeper/genesis.go:174).
+	moduleAddrs := make(map[string]bool, 16)
+	for name := range app.GetMaccPerms() {
+		moduleAddrs[authtypes.NewModuleAddress(name).String()] = true
+	}
+
+	ngonkaTopUp := sdk.NewCoin(inferencetypes.BaseCoin, simAccountNgonka)
+	for i := range bankState.Balances {
+		if moduleAddrs[bankState.Balances[i].Address] {
+			continue
+		}
+		bankState.Balances[i].Coins = bankState.Balances[i].Coins.Add(ngonkaTopUp)
+	}
+
 	var actualSupply sdk.Coins
 	for _, balance := range bankState.Balances {
 		actualSupply = actualSupply.Add(balance.Coins...)
@@ -125,6 +158,12 @@ func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
 
 	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
 }
+
+// simAccountNgonka is the per-sim-account ngonka top-up amount applied by
+// fixBankGenesisState. 10^15 ngonka = 10^6 GNK — comfortable buffer
+// above the per-inference escrow (~6.3 × 10^5 ngonka in current sim) even
+// at the make sim-full-test scale of 500 blocks × 200 ops/block.
+var simAccountNgonka = sdkmath.NewInt(1_000_000_000_000_000)
 
 // TestFullAppSimulation is the simsx entry point for `make sim-smoke-test`
 // and `make sim-full-test`. CLI flags (-NumBlocks, -BlockSize, -Seed,
@@ -200,8 +239,7 @@ func checkImportExport(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simty
 		// Defensive: even with disabledOpsSimModule on staking we keep the
 		// upstream-known skip path for the rare case of an empty validator set.
 		if strings.Contains(err.Error(), "validator set is empty after InitGenesis") {
-			tb.Log("skipping import-export comparison: validator set empty")
-			return
+			tb.Skip("import-export comparison skipped: validator set empty")
 		}
 		tb.Fatalf("InitGenesis on newApp: %v", err)
 	}

--- a/inference-chain/app/sim_test.go
+++ b/inference-chain/app/sim_test.go
@@ -1,18 +1,14 @@
+//go:build sims || simsbench
+
 package app_test
 
 import (
 	"encoding/json"
-	"flag"
-	"fmt"
-	"math/rand"
-	"os"
-	"runtime/debug"
+	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"cosmossdk.io/log"
-	"cosmossdk.io/store"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/feegrant"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -20,191 +16,222 @@ import (
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/server"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	simulationtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	"github.com/productscience/inference/app"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
 
-const (
-	SimAppChainID = "inference-simapp"
-)
+// Compile-time check that *app.App satisfies simsx.SimulationApp.
+var _ simsx.SimulationApp = (*app.App)(nil)
 
-var FlagEnableStreamingValue bool
+// defaultSimSeeds is the canonical seed triplet shared by
+// TestAppStateDeterminism (full sweep) and BenchmarkFullAppSimulation
+// (uses [0] as the single-seed default).
+var defaultSimSeeds = []int64{1, 32, 123}
 
-// Get flags every time the simulator is run
 func init() {
 	simcli.GetSimulatorFlags()
-	flag.BoolVar(&FlagEnableStreamingValue, "EnableStreaming", false, "Enable streaming service")
+	app.InitSDKConfig()
 }
 
-// fauxMerkleModeOpt returns a BaseApp option to use a dbStoreAdapter instead of
-// an IAVLStore for faster simulation speed.
-func fauxMerkleModeOpt(bapp *baseapp.BaseApp) {
-	bapp.SetFauxMerkleMode()
-}
-
-// interBlockCacheOpt returns a BaseApp option function that sets the persistent
-// inter-block write-through cache.
-func interBlockCacheOpt() func(*baseapp.BaseApp) {
-	return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager())
-}
-
-// BenchmarkSimulation run the chain simulation
-// Running using starport command:
-// `ignite chain simulate -v --numBlocks 200 --blockSize 50`
-// Running as go benchmark test:
-// `go test -benchmem -run=^$ -bench ^BenchmarkSimulation ./app -NumBlocks=200 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true`
-func BenchmarkSimulation(b *testing.B) {
-	simcli.FlagSeedValue = time.Now().Unix()
-	simcli.FlagVerboseValue = true
-	simcli.FlagCommitValue = true
-	simcli.FlagEnabledValue = true
-
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		b.Skip("skipping application simulation")
+// NewSimApp adapts app.New to the simsx.Run appFactory signature by hiding the
+// wasmd opts argument required by gonka's constructor.
+func NewSimApp(
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	loadLatest bool,
+	appOpts servertypes.AppOptions,
+	baseAppOptions ...func(*baseapp.BaseApp),
+) *app.App {
+	bApp, err := app.New(logger, db, traceStore, loadLatest, appOpts, []wasmkeeper.Option{}, baseAppOptions...)
+	if err != nil {
+		panic(err)
 	}
-	require.NoError(b, err, "simulation setup failed")
+	return bApp
+}
 
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(b, err)
-	require.NoError(b, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
+// setupStateFactory builds the SimStateFactory consumed by simsx.Run for each
+// seed. AccountKeeper satisfies simsx.AccountSourceX (AccountSource +
+// ModuleAccountSource); BankKeeper satisfies simsx.BalanceSource.
+//
+// AppStateFnWithExtendedCb (rather than plain AppStateFn) lets fixBankGenesisState
+// patch the randomized rawState before InitGenesis runs.
+func setupStateFactory(bApp *app.App) simsx.SimStateFactory {
+	return simsx.SimStateFactory{
+		Codec: bApp.AppCodec(),
+		AppStateFn: simtestutil.AppStateFnWithExtendedCb(
+			bApp.AppCodec(),
+			bApp.SimulationManager(),
+			bApp.DefaultGenesis(),
+			func(rawState map[string]json.RawMessage) {
+				fixBankGenesisState(bApp, rawState)
+			},
+		),
+		BlockedAddr:   app.BlockedAddresses(),
+		AccountSource: bApp.AccountKeeper,
+		BalanceSource: bApp.BankKeeper,
 	}
 }
 
-func TestAppImportExport(t *testing.T) {
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		t.Skip("skipping application import/export simulation")
+// fixBankGenesisState patches the randomized sim genesis so InitGenesis succeeds:
+//
+//  1. Add Gonka denom metadata, required by inference module init
+//     (app.initializeDenomMetadata reads BankKeeper.GetDenomMetaData(BaseCoin)).
+//  2. Recompute bank Supply from Balances. The randomized genesis sets
+//     Supply based on NumBonded staking validators, but with staking ops
+//     disabled the bonded pool is never funded, so the default Supply
+//     would fail the supply-vs-balance invariant at InitGenesis.
+//
+// Ported from hleb-albau PR gonka-ai/gonka#995.
+func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
+	bankStateBz, ok := rawState[banktypes.ModuleName]
+	if !ok {
+		panic("bank genesis state missing from randomized state")
 	}
-	require.NoError(t, err, "simulation setup failed")
+	var bankState banktypes.GenesisState
+	bApp.AppCodec().MustUnmarshalJSON(bankStateBz, &bankState)
 
-	defer func() {
-		require.NoError(t, db.Close())
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	bankState.DenomMetadata = append(bankState.DenomMetadata, banktypes.Metadata{
+		Description: "Coins for the Gonka network.",
+		Base:        inferencetypes.BaseCoin,
+		Display:     inferencetypes.NativeCoin,
+		Name:        "Gonka",
+		Symbol:      "GNK",
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: inferencetypes.BaseCoin, Exponent: 0, Aliases: []string{"nanogonka"}},
+			{Denom: "ugonka", Exponent: 3, Aliases: []string{"microgonka"}},
+			{Denom: "mgonka", Exponent: 6, Aliases: []string{"milligonka"}},
+			{Denom: inferencetypes.NativeCoin, Exponent: 9},
+		},
+	})
 
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, bApp.Name())
-
-	// Run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
+	var actualSupply sdk.Coins
+	for _, balance := range bankState.Balances {
+		actualSupply = actualSupply.Add(balance.Coins...)
 	}
+	bankState.Supply = actualSupply
 
-	fmt.Printf("exporting genesis...\n")
+	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
+}
 
+// TestFullAppSimulation is the simsx entry point for `make sim-smoke-test`
+// and `make sim-full-test`. CLI flags (-NumBlocks, -BlockSize, -Seed,
+// -Enabled) come from simcli.GetSimulatorFlags() in init().
+//
+// Requires -Enabled=true. simsx does not gate on it the way legacy
+// simulation.SimulateFromSeed did; this test restores that gate so a
+// raw `go test -tags sims ./app/...` skips fast.
+//
+// With user-supplied -Seed=N (Make targets), dispatches to
+// simsx.RunWithSeed for a single-seed run. Without it, falls through to
+// simsx.Run which fans out the framework's defaultSeeds list (37 seeds
+// in this fork) as parallel subtests.
+func TestFullAppSimulation(t *testing.T) {
+	if !simcli.FlagEnabledValue {
+		t.Skip("pass -Enabled=true to run this; e.g. via make sim-smoke-test")
+	}
+	cfg := simcli.NewConfigFromFlags()
+	cfg.ChainID = simsx.SimAppChainID
+
+	if cfg.Seed != simcli.DefaultSeedValue {
+		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil)
+		return
+	}
+	simsx.Run(t, NewSimApp, setupStateFactory)
+}
+
+// TestAppImportExport_Postrun is t.Skip'd because InitGenesis on the
+// re-imported state panics at gonka-ai/cosmos-sdk@v0.53.3-ps17
+// x/staking/keeper/genesis.go:157-158 ("bonded pool balance is different
+// from bonded coins").
+//
+// The fork's PoC architecture (gonka/docs/cosmos_changes.md) disables
+// token bonding: SetComputeValidators creates bonded validators without
+// bank transfers, pool.go iterates manually, and delegation.go +
+// val_state_change.go skip the transfers. genesis.go:157 was not updated
+// to mirror that skip, so its upstream invariant bondedBalance.Equal(
+// bondedCoins) no longer holds against live state.
+//
+// Production sidesteps this by using x/upgrade in-place handlers (see
+// app/upgrades/v0_2_12) instead of `inferenced export -> init`. Funding
+// the bonded pool here to make the test green would mask the
+// inconsistency, so it stays skipped.
+//
+// Re-enable once gonka-ai/cosmos-sdk genesis.go applies the same
+// PoC-validator skip already in delegation.go. Fork fix proposal:
+// gonka-ai/gonka#1153. Broader Phase 1 work: gonka-ai/gonka#982.
+func TestAppImportExport_Postrun(t *testing.T) {
+	t.Skip("blocked on gonka-ai/cosmos-sdk genesis.go:157; see gonka-ai/gonka#1153 for the fork fix proposal")
+	simsx.Run(t, NewSimApp, setupStateFactory, checkImportExport)
+}
+
+func checkImportExport(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+	tb.Helper()
+	bApp := ti.App
+
+	tb.Logf("exporting genesis...")
 	exported, err := bApp.ExportAppStateAndValidators(false, []string{}, []string{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	fmt.Printf("importing genesis...\n")
-
-	newDB, newDir, _, _, err := simtestutil.SetupSimulation(config, "leveldb-app-sim-2", "Simulation-2", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	require.NoError(t, err, "simulation setup failed")
-
-	defer func() {
-		require.NoError(t, newDB.Close())
-		require.NoError(t, os.RemoveAll(newDir))
-	}()
-
-	newApp, err := app.New(logger, newDB, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, newApp.Name())
+	tb.Logf("importing genesis into fresh app...")
+	newTI := simsx.NewSimulationAppInstance(tb, ti.Cfg, NewSimApp)
+	newApp := newTI.App
+	defer func() { _ = newApp.Close() }()
 
 	var genesisState app.GenesisState
-	err = json.Unmarshal(exported.AppState, &genesisState)
-	require.NoError(t, err)
+	require.NoError(tb, json.Unmarshal(exported.AppState, &genesisState))
 
-	ctxA := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
-	ctxB := newApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
-	_, err = newApp.ModuleManager.InitGenesis(ctxB, bApp.AppCodec(), genesisState)
-
-	if err != nil {
+	header := cmtproto.Header{Height: bApp.LastBlockHeight()}
+	ctxA := bApp.NewContextLegacy(true, header)
+	ctxB := newApp.NewContextLegacy(true, header)
+	if _, err := newApp.ModuleManager.InitGenesis(ctxB, newApp.AppCodec(), genesisState); err != nil {
+		// Defensive: even with disabledOpsSimModule on staking we keep the
+		// upstream-known skip path for the rare case of an empty validator set.
 		if strings.Contains(err.Error(), "validator set is empty after InitGenesis") {
-			logger.Info("Skipping simulation as all validators have been unbonded")
-			logger.Info("err", err, "stacktrace", string(debug.Stack()))
+			tb.Log("skipping import-export comparison: validator set empty")
 			return
 		}
+		tb.Fatalf("InitGenesis on newApp: %v", err)
 	}
-	require.NoError(t, err)
-	err = newApp.StoreConsensusParams(ctxB, exported.ConsensusParams)
-	require.NoError(t, err)
-	fmt.Printf("comparing stores...\n")
+	require.NoError(tb, newApp.StoreConsensusParams(ctxB, exported.ConsensusParams))
 
-	// skip certain prefixes
-	skipPrefixes := map[string][][]byte{
+	tb.Logf("comparing stores...")
+	skipPrefixes := importExportSkipPrefixes()
+	storeKeys := bApp.GetStoreKeys()
+	require.NotEmpty(tb, storeKeys)
+	for _, appKeyA := range storeKeys {
+		if _, ok := appKeyA.(*storetypes.KVStoreKey); !ok {
+			continue
+		}
+		keyName := appKeyA.Name()
+		appKeyB := newApp.GetKey(keyName)
+		storeA := ctxA.KVStore(appKeyA)
+		storeB := ctxB.KVStore(appKeyB)
+		failedKVAs, failedKVBs := simtestutil.DiffKVStores(storeA, storeB, skipPrefixes[keyName])
+		require.Equalf(tb, len(failedKVAs), len(failedKVBs), "unequal failure sets for %s", keyName)
+		if len(failedKVAs) != 0 {
+			tb.Fatalf("KV diff for %s:\n%s", keyName,
+				simtestutil.GetSimulationLog(keyName, bApp.SimulationManager().StoreDecoders, failedKVAs, failedKVBs))
+		}
+	}
+}
+
+// importExportSkipPrefixes mirrors upstream cosmos-sdk simapp's skip set:
+// transient queues populated by runtime hooks, not by InitGenesis.
+func importExportSkipPrefixes() map[string][][]byte {
+	return map[string][][]byte{
 		stakingtypes.StoreKey: {
 			stakingtypes.UnbondingQueueKey, stakingtypes.RedelegationQueueKey, stakingtypes.ValidatorQueueKey,
 			stakingtypes.HistoricalInfoKey, stakingtypes.UnbondingIDKey, stakingtypes.UnbondingIndexKey,
@@ -214,224 +241,92 @@ func TestAppImportExport(t *testing.T) {
 		feegrant.StoreKey:      {feegrant.FeeAllowanceQueueKeyPrefix},
 		slashingtypes.StoreKey: {slashingtypes.ValidatorMissedBlockBitmapKeyPrefix},
 	}
-
-	storeKeys := bApp.GetStoreKeys()
-	require.NotEmpty(t, storeKeys)
-
-	for _, appKeyA := range storeKeys {
-		// only compare kvstores
-		if _, ok := appKeyA.(*storetypes.KVStoreKey); !ok {
-			continue
-		}
-
-		keyName := appKeyA.Name()
-		appKeyB := newApp.GetKey(keyName)
-
-		storeA := ctxA.KVStore(appKeyA)
-		storeB := ctxB.KVStore(appKeyB)
-
-		failedKVAs, failedKVBs := simtestutil.DiffKVStores(storeA, storeB, skipPrefixes[keyName])
-		require.Equal(t, len(failedKVAs), len(failedKVBs), "unequal sets of key-values to compare %s", keyName)
-
-		fmt.Printf("compared %d different key/value pairs between %s and %s\n", len(failedKVAs), appKeyA, appKeyB)
-
-		require.Equal(t, 0, len(failedKVAs), simtestutil.GetSimulationLog(keyName, bApp.SimulationManager().StoreDecoders, failedKVAs, failedKVBs))
-	}
 }
 
-func TestAppSimulationAfterImport(t *testing.T) {
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
+// TestAppSimulationAfterImport_Postrun is t.Skip'd. Two things must be
+// done before re-enabling, in order:
+//
+//  1. gonka-ai/cosmos-sdk genesis.go:157 bonded-pool fix per
+//     gonka-ai/gonka#1153 (InitChain on the imported state currently
+//     panics on the same fork asymmetry as TestAppImportExport_Postrun).
+//  2. Wire SimulateFromSeedX into checkSimulationAfterImport. The current
+//     body only verifies InitChain succeeds; the test name promises a
+//     second simulation step that is not yet implemented (TODO in the
+//     body).
+//
+// Removing t.Skip with only (1) cleared would make the test pass while
+// never exercising the second simulation step. Both must land first.
+func TestAppSimulationAfterImport_Postrun(t *testing.T) {
+	t.Skip("blocked on (1) gonka-ai/cosmos-sdk genesis.go:157 fix per gonka-ai/gonka#1153, and (2) wiring SimulateFromSeedX for the after-import simulation step")
+	simsx.Run(t, NewSimApp, setupStateFactory, checkSimulationAfterImport)
+}
 
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		t.Skip("skipping application simulation after import")
-	}
-	require.NoError(t, err, "simulation setup failed")
+func checkSimulationAfterImport(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+	tb.Helper()
+	bApp := ti.App
 
-	defer func() {
-		require.NoError(t, db.Close())
-		require.NoError(t, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, bApp.Name())
-
-	// Run randomized simulation
-	stopEarly, simParams, simErr := simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-
-	if stopEarly {
-		fmt.Println("can't export or import a zero-validator genesis, exiting test...")
-		return
-	}
-
-	fmt.Printf("exporting genesis...\n")
-
+	tb.Logf("exporting genesis (forZeroHeight=true)...")
 	exported, err := bApp.ExportAppStateAndValidators(true, []string{}, []string{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	fmt.Printf("importing genesis...\n")
-
-	newDB, newDir, _, _, err := simtestutil.SetupSimulation(config, "leveldb-app-sim-2", "Simulation-2", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	require.NoError(t, err, "simulation setup failed")
-
-	defer func() {
-		require.NoError(t, newDB.Close())
-		require.NoError(t, os.RemoveAll(newDir))
-	}()
-
-	newApp, err := app.New(logger, newDB, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, newApp.Name())
+	tb.Logf("importing genesis into fresh app via InitChain...")
+	newTI := simsx.NewSimulationAppInstance(tb, ti.Cfg, NewSimApp)
+	newApp := newTI.App
+	defer func() { _ = newApp.Close() }()
 
 	_, err = newApp.InitChain(&abci.RequestInitChain{
 		AppStateBytes: exported.AppState,
-		ChainId:       SimAppChainID,
+		ChainId:       ti.Cfg.ChainID,
 	})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	_, _, err = simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		newApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(newApp, newApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-	require.NoError(t, err)
+	// TODO: once import unblocks, run SimulateFromSeedX on newApp. Needs
+	// either a copy of simsx's unexported prepareWeightedOps or a minimal
+	// ops registry.
+	tb.Log("import succeeded; second-simulation step deferred (see TODO)")
 }
 
+// TestAppStateDeterminism asserts that running the same seed N times
+// produces an identical AppHash. Uses simsx.RunWithSeed directly because
+// simsx.Run fans out distinct seeds in parallel; determinism wants the
+// same seed sequentially. PoC-state determinism beyond AppHash
+// (EffectiveIndex, epoch-state collections) is Phase 3 territory per the
+// issue body.
 func TestAppStateDeterminism(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in -short mode")
+	}
 	if !simcli.FlagEnabledValue {
-		t.Skip("skipping application simulation")
+		t.Skip("pass -Enabled=true to run this; simsx does not gate on it")
 	}
+	cfg := simcli.NewConfigFromFlags()
+	cfg.ChainID = simsx.SimAppChainID
 
-	config := simcli.NewConfigFromFlags()
-	config.InitialBlockHeight = 1
-	config.ExportParamsPath = ""
-	config.OnOperation = true
-	config.AllInvariants = true
-
-	numSeeds := 3
-	numTimesToRunPerSeed := 3 // This used to be set to 5, but we've temporarily reduced it to 3 for the sake of faster CI.
-	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
-
-	// We will be overriding the random seed and just run a single simulation on the provided seed value
-	if config.Seed != simcli.DefaultSeedValue {
-		numSeeds = 1
+	// Block counts inherit from simcli flags.
+	// Honor user-supplied -Seed=N for single-seed reproduction of a failure.
+	seeds := defaultSimSeeds
+	if cfg.Seed != simcli.DefaultSeedValue {
+		seeds = []int64{cfg.Seed}
 	}
+	const attempts = 3
 
-	appOptions := viper.New()
-	if FlagEnableStreamingValue {
-		m := make(map[string]interface{})
-		m["streaming.abci.keys"] = []string{"*"}
-		m["streaming.abci.plugin"] = "abci_v1"
-		m["streaming.abci.stop-node-on-err"] = true
-		for key, value := range m {
-			appOptions.SetDefault(key, value)
+	for _, seed := range seeds {
+		// Pre-allocated indexed slots so a failure points at the specific
+		// attempt rather than a generic count mismatch. RunWithSeed invokes
+		// capture synchronously, so hashes[attempt] is populated before the
+		// next iteration.
+		hashes := make([][]byte, attempts)
+		for attempt := range attempts {
+			capture := func(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+				hashes[attempt] = ti.App.LastCommitID().Hash
+			}
+			simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, seed, nil, capture)
+			require.NotEmptyf(t, hashes[attempt],
+				"capture callback was not invoked for seed %d attempt %d", seed, attempt)
 		}
-	}
-	appOptions.SetDefault(flags.FlagHome, app.DefaultNodeHome)
-	appOptions.SetDefault(server.FlagInvCheckPeriod, simcli.FlagPeriodValue)
-	if simcli.FlagVerboseValue {
-		appOptions.SetDefault(flags.FlagLogLevel, "debug")
-	}
-
-	for i := 0; i < numSeeds; i++ {
-		if config.Seed == simcli.DefaultSeedValue {
-			config.Seed = rand.Int63()
-		}
-		fmt.Println("config.Seed: ", config.Seed)
-
-		for j := 0; j < numTimesToRunPerSeed; j++ {
-			var logger log.Logger
-			if simcli.FlagVerboseValue {
-				logger = log.NewTestLogger(t)
-			} else {
-				logger = log.NewNopLogger()
-			}
-			chainID := fmt.Sprintf("chain-id-%d-%d", i, j)
-			config.ChainID = chainID
-
-			db := dbm.NewMemDB()
-			var emptyWasmOpts []wasmkeeper.Option
-
-			bApp, err := app.New(
-				logger,
-				db,
-				nil,
-				true,
-				appOptions,
-				emptyWasmOpts,
-				interBlockCacheOpt(),
-				baseapp.SetChainID(chainID),
-			)
-			require.NoError(t, err)
-
-			fmt.Printf(
-				"running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",
-				config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
-			)
-
-			_, _, err = simulation.SimulateFromSeed(
-				t,
-				os.Stdout,
-				bApp.BaseApp,
-				simtestutil.AppStateFn(
-					bApp.AppCodec(),
-					bApp.SimulationManager(),
-					bApp.DefaultGenesis(),
-				),
-				simulationtypes.RandomAccounts,
-				simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-				app.BlockedAddresses(),
-				config,
-				bApp.AppCodec(),
-			)
-			require.NoError(t, err)
-
-			if config.Commit {
-				simtestutil.PrintStats(db)
-			}
-
-			appHash := bApp.LastCommitID().Hash
-			appHashList[j] = appHash
-
-			if j != 0 {
-				require.Equal(
-					t, string(appHashList[0]), string(appHashList[j]),
-					"non-determinism in seed %d: %d/%d, attempt: %d/%d\n", config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
-				)
-			}
+		for i := 1; i < attempts; i++ {
+			require.Equalf(t, hashes[0], hashes[i],
+				"non-determinism in seed %d: attempt 0 vs %d", seed, i)
 		}
 	}
 }

--- a/inference-chain/app/simulation.go
+++ b/inference-chain/app/simulation.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+)
+
+// disabledOpsSimModule wraps an AppModuleSimulation and returns nil from
+// WeightedOperations, so the wrapped module's sim ops are excluded from
+// the simulator while GenerateGenesisState and store decoders continue
+// to work through embedding. HasProposalMsgs and HasProposalContents are
+// not on AppModuleSimulation, so they are never promoted regardless of
+// the wrapped module.
+//
+// Used for:
+//   - staking/distribution: the PoC chain has no token bonding or
+//     traditional rewards (docs/cosmos_changes.md); the stock sim msgs
+//     target state machinery this fork has neutralised.
+//   - wasmd v0.54.2: BuildOperationInput uses a failingAddressCodec
+//     rather than the app codec, so all wasm sim ops fail. Fixed in
+//     v0.60.0+ (CosmWasm/wasmd#2250).
+//
+// Originally proposed by hleb-albau in gonka-ai/gonka#995.
+type disabledOpsSimModule struct {
+	module.AppModuleSimulation
+}
+
+// WeightedOperations always returns nil. See type doc.
+func (disabledOpsSimModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return nil
+}

--- a/inference-chain/app/simulation_test.go
+++ b/inference-chain/app/simulation_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSimModule is a non-nil AppModuleSimulation stub that returns a
+// non-empty WeightedOperations slice. Lets the test below show that
+// disabledOpsSimModule's override actually fires, instead of trivially
+// passing because of a nil embed.
+type stubSimModule struct {
+	module.AppModuleSimulation
+}
+
+func (stubSimModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return make([]simtypes.WeightedOperation, 1)
+}
+
+// TestDisabledOpsSimModule_SuppressesEmbeddedOps confirms the wrapper's
+// override takes precedence over the embedded module's
+// WeightedOperations.
+func TestDisabledOpsSimModule_SuppressesEmbeddedOps(t *testing.T) {
+	require.NotEmpty(t, stubSimModule{}.WeightedOperations(module.SimulationState{}))
+	wrapped := disabledOpsSimModule{stubSimModule{}}
+	require.Empty(t, wrapped.WeightedOperations(module.SimulationState{}))
+}

--- a/inference-chain/cmd/inferenced/cmd/config.go
+++ b/inference-chain/cmd/inferenced/cmd/config.go
@@ -3,31 +3,7 @@ package cmd
 import (
 	cmtcfg "github.com/cometbft/cometbft/config"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/productscience/inference/app"
 )
-
-const (
-	CoinType = 1200
-)
-
-func initSDKConfig() {
-	// Set prefixes
-	accountPubKeyPrefix := app.AccountAddressPrefix + "pub"
-	validatorAddressPrefix := app.AccountAddressPrefix + "valoper"
-	validatorPubKeyPrefix := app.AccountAddressPrefix + "valoperpub"
-	consNodeAddressPrefix := app.AccountAddressPrefix + "valcons"
-	consNodePubKeyPrefix := app.AccountAddressPrefix + "valconspub"
-
-	// Set and seal config
-	config := sdk.GetConfig()
-	config.SetCoinType(CoinType) // TODO: change to custom coin type
-	config.SetBech32PrefixForAccount(app.AccountAddressPrefix, accountPubKeyPrefix)
-	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
-	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)
-	config.Seal()
-}
 
 // initCometBFTConfig helps to override default CometBFT Config values.
 // return cmtcfg.DefaultConfig if no custom configuration is required for the application.

--- a/inference-chain/cmd/inferenced/cmd/root.go
+++ b/inference-chain/cmd/inferenced/cmd/root.go
@@ -29,7 +29,8 @@ import (
 
 // NewRootCmd creates a new root command for inferenced. It is called once in the main function.
 func NewRootCmd() *cobra.Command {
-	initSDKConfig()
+	app.InitSDKConfig()
+	app.SealSDKConfig()
 
 	var (
 		txConfigOpts       tx.ConfigOptions

--- a/inference-chain/testutil/keeper/inference.go
+++ b/inference-chain/testutil/keeper/inference.go
@@ -43,6 +43,11 @@ func InferenceKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	validatorSetMock := NewMockValidatorSet(ctrl)
 	groupMock := NewMockGroupMessageKeeper(ctrl)
 	stakingMock := NewMockStakingKeeper(ctrl)
+	// EnsureComputeValidators (x/inference/simulation, called by the op
+	// factories) invokes GetAllValidators; tolerate it with an empty set so
+	// it short-circuits before any SetComputeValidators round-trip.
+	stakingMock.EXPECT().GetAllValidators(gomock.Any()).
+		Return([]stakingtypes.Validator{}, nil).AnyTimes()
 	collateralMock := NewMockCollateralKeeper(ctrl)
 	streamvestingMock := NewMockStreamVestingKeeper(ctrl)
 	authzKeeper := NewMockAuthzKeeper(ctrl)

--- a/inference-chain/x/inference/module/simulation.go
+++ b/inference-chain/x/inference/module/simulation.go
@@ -3,6 +3,7 @@ package inference
 import (
 	"math/rand"
 
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -87,14 +88,22 @@ const (
 )
 
 // GenerateGenesisState creates a randomized GenState of the module.
+//
+//   - ParticipantList is pre-seeded so the four ActiveParticipant-gated ops
+//     (Start/Finish/Validation/ClaimRewards) have someone to promote via
+//     EnsureActiveParticipantsSeeded (x/inference/simulation/bootstrap.go).
+//   - ModelList is pre-seeded with Qwen + Kimi (mainnet-realistic values)
+//     so MsgStartInference's RecordInferencePrice has a
+//     governance-registered model to look up. EnsureModelsInEpochGroup
+//     (x/inference/simulation/bootstrap.go) promotes them into the genesis
+//     EpochGroup's SubGroupModels on first op invocation, which is the
+//     state BeginBlocker / UpdateDynamicPricing iterate.
 func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
-	accs := make([]string, len(simState.Accounts))
-	for i, acc := range simState.Accounts {
-		accs[i] = acc.Address.String()
-	}
 	inferenceGenesis := types.GenesisState{
 		Params:            types.DefaultParams(),
 		GenesisOnlyParams: types.DefaultGenesisOnlyParams(),
+		ParticipantList:   inferencesimulation.BuildSimGenesisParticipants(simState),
+		ModelList:         inferencesimulation.BuildSimGenesisModels(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&inferenceGenesis) //nolint:forbidigo // Simulation code
@@ -406,4 +415,23 @@ func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.Wei
 		),
 		// this line is used by starport scaffolding # simapp/module/OpMsg
 	}
+}
+
+// WeightedOperationsX registers the Phase 2 first-wave x/inference message
+// factories with the simsx runner. simsx.Run prefers this method over the
+// legacy WeightedOperations() when an AppModule implements HasWeightedOperationsX
+// (see fork testutil/simsx/runner.go:333). Phase 2 first-wave covers:
+// SubmitNewParticipant, StartInference, FinishInference, Validation, ClaimRewards.
+// Remaining ops stay on the legacy WeightedOperations() path until Phase 3.
+func (am AppModule) WeightedOperationsX(weights simsx.WeightSource, reg simsx.Registry) {
+	reg.Add(weights.Get(opWeightMsgSubmitNewParticipant, uint32(defaultWeightMsgSubmitNewParticipant)),
+		inferencesimulation.MsgSubmitNewParticipantFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgStartInference, uint32(defaultWeightMsgStartInference)),
+		inferencesimulation.MsgStartInferenceFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgFinishInference, uint32(defaultWeightMsgFinishInference)),
+		inferencesimulation.MsgFinishInferenceFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgValidation, uint32(defaultWeightMsgValidation)),
+		inferencesimulation.MsgValidationFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgClaimRewards, uint32(defaultWeightMsgClaimRewards)),
+		inferencesimulation.MsgClaimRewardsFactory(am.keeper))
 }

--- a/inference-chain/x/inference/module/simulation.go
+++ b/inference-chain/x/inference/module/simulation.go
@@ -93,7 +93,8 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		accs[i] = acc.Address.String()
 	}
 	inferenceGenesis := types.GenesisState{
-		Params: types.DefaultParams(),
+		Params:            types.DefaultParams(),
+		GenesisOnlyParams: types.DefaultGenesisOnlyParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&inferenceGenesis) //nolint:forbidigo // Simulation code

--- a/inference-chain/x/inference/simulation/active_participants_pick.go
+++ b/inference-chain/x/inference/simulation/active_participants_pick.go
@@ -1,0 +1,220 @@
+package simulation
+
+import (
+	"context"
+
+	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// collectInferencesByStatus returns every Inference in the keeper whose
+// Status matches. Iteration order is collections-sorted by InferenceId,
+// so a same-seed pick over the result is deterministic.
+func collectInferencesByStatus(
+	ctx context.Context,
+	k keeper.Keeper,
+	status types.InferenceStatus,
+) ([]types.Inference, error) {
+	iter, err := k.Inferences.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+	out := make([]types.Inference, 0, 16)
+	for ; iter.Valid(); iter.Next() {
+		val, err := iter.Value()
+		if err != nil {
+			return nil, err
+		}
+		if val.Status == status {
+			out = append(out, val)
+		}
+	}
+	return out, nil
+}
+
+// PickRandomFinishedInference returns a FINISHED-status Inference from the
+// on-chain Inferences collection. If none exists yet (no Start+Finish pair
+// has completed) the reporter is Skipped and (zero, false) is returned.
+//
+// Used by MsgValidationFactory: passing a STARTED-status inference to
+// MsgValidation triggers the hard ErrInferenceNotFinished path
+// (msg_server_validation.go) which would abort the simsx run.
+// Skip-on-empty keeps the simulation progressing until at least one
+// Start→Finish pair lands.
+//
+// Returns the full Inference, not just its ID — collectInferencesByStatus
+// already deserialized it, so the caller needs no second keeper read.
+func PickRandomFinishedInference(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+) (types.Inference, bool) {
+	finished, err := collectInferencesByStatus(ctx, k, types.InferenceStatus_FINISHED)
+	if err != nil {
+		reporter.Skipf("Inferences scan failed: %v", err)
+		return types.Inference{}, false
+	}
+	if len(finished) == 0 {
+		reporter.Skip("no FINISHED inferences in keeper yet")
+		return types.Inference{}, false
+	}
+	return finished[testData.Rand().Intn(len(finished))], true
+}
+
+// FindRandomStartedInference returns a random STARTED-status inference
+// whose AssignedTo address is a known sim account (so the Finish factory
+// can sign as it). Returns (zero, false) when none qualifies — the
+// caller then falls back to a fresh finish-first message rather than
+// Skipping. Does NOT touch the reporter.
+func FindRandomStartedInference(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+) (types.Inference, bool) {
+	started, err := collectInferencesByStatus(ctx, k, types.InferenceStatus_STARTED)
+	if err != nil || len(started) == 0 {
+		return types.Inference{}, false
+	}
+	eligible := started[:0]
+	for _, inf := range started {
+		if inf.AssignedTo != "" && testData.HasAccount(inf.AssignedTo) {
+			eligible = append(eligible, inf)
+		}
+	}
+	if len(eligible) == 0 {
+		return types.Inference{}, false
+	}
+	return eligible[testData.Rand().Intn(len(eligible))], true
+}
+
+// PickRandomGovernanceModelID returns a model Id from the on-chain
+// Models collection at random. If empty (no models registered) the
+// reporter is Skipped and ("", false) is returned. Deterministic across
+// same-seed runs because GetGovernanceModels returns the
+// collections-sorted (bech32-key string) view.
+func PickRandomGovernanceModelID(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+) (string, bool) {
+	models, err := k.GetGovernanceModels(ctx)
+	if err != nil {
+		reporter.Skipf("GetGovernanceModels failed: %v", err)
+		return "", false
+	}
+	if len(models) == 0 {
+		reporter.Skip("no governance models registered")
+		return "", false
+	}
+	return models[testData.Rand().Intn(len(models))].Id, true
+}
+
+// PickRandomActiveSimAccountExcluding behaves like PickRandomActiveSimAccount
+// but draws from a CALLER-SPECIFIED epoch's ActiveParticipantsSet and filters
+// out the given address. MsgValidationFactory must pick a validator from the
+// *inference's* epoch — not the current epoch — because the handler keys the
+// transient validation cache by inference.EpochId (GetCachedEpochDataModelWeight,
+// msg_server_validation.go). Drawing from the current epoch breaks after an
+// epoch transition: a current-epoch validator is absent from a previous-epoch
+// inference's cache and the handler hard-fails with ErrParticipantNotFound.
+// Also satisfies validator!=executor (msg_server_validation.go).
+func PickRandomActiveSimAccountExcluding(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+	epoch uint64,
+	excludeAddr string,
+) (simsx.SimAccount, bool) {
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](epoch))
+	if err != nil {
+		reporter.Skipf("ActiveParticipantsSet iterate failed: %v", err)
+		return simsx.SimAccount{}, false
+	}
+	defer iter.Close()
+
+	addrs := make([]sdk.AccAddress, 0, 8)
+	for ; iter.Valid(); iter.Next() {
+		key, err := iter.Key()
+		if err != nil {
+			reporter.Skipf("ActiveParticipantsSet key decode failed: %v", err)
+			return simsx.SimAccount{}, false
+		}
+		bech := key.K2().String()
+		if bech == excludeAddr {
+			continue
+		}
+		addrs = append(addrs, key.K2())
+	}
+	if len(addrs) == 0 {
+		reporter.Skipf("no active participants in epoch %d other than %s", epoch, excludeAddr)
+		return simsx.SimAccount{}, false
+	}
+	pick := addrs[testData.Rand().Intn(len(addrs))]
+	if !testData.HasAccount(pick.String()) {
+		reporter.Skipf("active participant %s not in sim accounts", pick.String())
+		return simsx.SimAccount{}, false
+	}
+	return testData.GetAccount(reporter, pick.String()), true
+}
+
+// PickRandomActiveSimAccount returns a sim account whose address is in
+// ActiveParticipantsSet[currentEpoch]. On any miss (empty set, address not
+// in sim accounts, keeper error) the reporter is Skipped with an
+// informative message and (zero, false) is returned.
+//
+// Determinism: ActiveParticipantsSet iteration is collections-sorted; the
+// pick index is drawn from testData.Rand() so the same seed reproduces the
+// same choice.
+//
+// Pairs with EnsureActiveParticipantsSeeded (bootstrap.go): factories
+// should call EnsureActiveParticipantsSeeded first so this picker has a
+// non-empty set to draw from.
+func PickRandomActiveSimAccount(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+) (simsx.SimAccount, bool) {
+	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+	if err != nil {
+		reporter.Skipf("EffectiveEpochIndex get failed: %v", err)
+		return simsx.SimAccount{}, false
+	}
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](currentEpoch))
+	if err != nil {
+		reporter.Skipf("ActiveParticipantsSet iterate failed: %v", err)
+		return simsx.SimAccount{}, false
+	}
+	defer iter.Close()
+
+	addrs := make([]sdk.AccAddress, 0, 8)
+	for ; iter.Valid(); iter.Next() {
+		key, err := iter.Key()
+		if err != nil {
+			reporter.Skipf("ActiveParticipantsSet key decode failed: %v", err)
+			return simsx.SimAccount{}, false
+		}
+		addrs = append(addrs, key.K2())
+	}
+	if len(addrs) == 0 {
+		reporter.Skip("no active participants in current epoch")
+		return simsx.SimAccount{}, false
+	}
+
+	pick := addrs[testData.Rand().Intn(len(addrs))]
+	if !testData.HasAccount(pick.String()) {
+		reporter.Skipf("active participant %s not in sim accounts", pick.String())
+		return simsx.SimAccount{}, false
+	}
+	return testData.GetAccount(reporter, pick.String()), true
+}

--- a/inference-chain/x/inference/simulation/active_participants_pick_test.go
+++ b/inference-chain/x/inference/simulation/active_participants_pick_test.go
@@ -1,0 +1,84 @@
+package simulation_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/simulation"
+)
+
+// TestPickRandomActiveSimAccount_PicksFromCurrentEpoch — with a non-empty
+// ActiveParticipantsSet for currentEpoch, the picker returns one of the
+// registered sim accounts and does not Skip the reporter.
+func TestPickRandomActiveSimAccount_PicksFromCurrentEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 4, 5)
+	registerAsParticipants(t, k, ctx, accs)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+
+	cds := simsx.NewChainDataSource(ctx, rand.New(rand.NewSource(99)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	got, ok := simulation.PickRandomActiveSimAccount(ctx, k, cds, reporter)
+	require.True(t, ok)
+	require.False(t, reporter.IsSkipped(), "reporter unexpectedly skipped")
+
+	addrs := map[string]bool{}
+	for _, a := range accs {
+		addrs[a.Address.String()] = true
+	}
+	require.True(t, addrs[got.AddressBech32],
+		"picked address %s not in seeded set", got.AddressBech32)
+}
+
+// TestPickRandomActiveSimAccount_EmptySet_Skips — without seeding, the
+// picker sets reporter.Skip and returns false.
+func TestPickRandomActiveSimAccount_EmptySet_Skips(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 5, 3)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+
+	cds := simsx.NewChainDataSource(ctx, rand.New(rand.NewSource(1)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	_, ok := simulation.PickRandomActiveSimAccount(ctx, k, cds, reporter)
+	require.False(t, ok)
+	require.True(t, reporter.IsSkipped(),
+		"empty ActiveParticipantsSet should cause Skip")
+}
+
+// TestPickRandomActiveSimAccount_DeterministicWithSeed — same seed in the
+// data-source's *rand.Rand must yield identical picks across calls. The
+// helper is sim-only and must be deterministic for replayable simulation.
+func TestPickRandomActiveSimAccount_DeterministicWithSeed(t *testing.T) {
+	k1, ctx1 := keepertest.InferenceKeeper(t)
+	k2, ctx2 := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 6, 5)
+	registerAsParticipants(t, k1, ctx1, accs)
+	registerAsParticipants(t, k2, ctx2, accs)
+	require.NoError(t, k1.SetEffectiveEpochIndex(ctx1, 0))
+	require.NoError(t, k2.SetEffectiveEpochIndex(ctx2, 0))
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx1, k1))
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx2, k2))
+
+	const seed = int64(123)
+	cds1 := simsx.NewChainDataSource(ctx1, rand.New(rand.NewSource(seed)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	cds2 := simsx.NewChainDataSource(ctx2, rand.New(rand.NewSource(seed)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	r1 := simsx.NewBasicSimulationReporter()
+	r2 := simsx.NewBasicSimulationReporter()
+
+	got1, ok1 := simulation.PickRandomActiveSimAccount(ctx1, k1, cds1, r1)
+	got2, ok2 := simulation.PickRandomActiveSimAccount(ctx2, k2, cds2, r2)
+	require.True(t, ok1)
+	require.True(t, ok2)
+	require.Equal(t, got1.AddressBech32, got2.AddressBech32)
+}

--- a/inference-chain/x/inference/simulation/bootstrap.go
+++ b/inference-chain/x/inference/simulation/bootstrap.go
@@ -1,0 +1,300 @@
+package simulation
+
+import (
+	"context"
+	"errors"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// simValidatorPower is the uniform consensus power EnsureComputeValidators
+// assigns to every validator on a refresh. gonka sets DefaultPowerReduction to
+// 1, so this is consensus power directly. The exact value is irrelevant — only
+// that it is positive and uniform (keeps the refresh deterministic).
+const simValidatorPower = 1_000_000
+
+// simBondedValidatorFloor is the bonded-validator count below which
+// EnsureComputeValidators refreshes the set. Kept well above zero so the
+// cometbft validator set cannot empty between two factory invocations even
+// across a stretch of non-x/inference blocks (downtime jailing was observed at
+// ~1.7 validators/block; this floor gives >25 blocks of grace).
+const simBondedValidatorFloor = 50
+
+// EnsureMembersInEpochGroup writes a sim-only ValidationWeights entry
+// for each ActiveParticipant into every sub-group's EpochGroupData. Used
+// by MsgValidationFactory so the handler's transient-cache lookup at
+// GetCachedEpochDataModelWeight (msg_server_validation.go) finds
+// the validator and routes through the normal validation logic instead
+// of returning ErrParticipantNotFound and aborting simsx.
+//
+// Approach: instead of calling EpochGroup.AddMember — which
+// dispatches through the cosmos `group` module via UpdateGroupMembers
+// and swallows sub-group AddMember errors at addToModelGroups:309-312 —
+// we mutate `EpochGroupData.ValidationWeights` directly via
+// SetEpochGroupData. The on-chain MsgValidation handler reads from the
+// transient cache, which BuildEpochDataTransientCache populates from
+// `EpochGroupData.ValidationWeights` (epoch_data_transient_cache.go).
+// Skipping the group-module roundtrip removes both an
+// unobservable failure path and the unnecessary write to GroupKeeper
+// state.
+//
+// Sim-only bridge over production's PoC validator-rotation flow
+// (activeparticipants.go addNewActiveParticipantsAsValidators) — no
+// production code change.
+//
+// Idempotent per sub-group: appends only addresses not already in
+// ValidationWeights.
+//
+// Weight=1, Reputation=0, VotingPower=1 chosen as the minimal non-zero
+// values required by the validation arithmetic (zero weight would
+// confuse vote-tallying division).
+//
+// After all sub-groups are updated, BuildEpochDataTransientCache is
+// invoked so MsgValidation in the SAME block sees the freshly-populated
+// cache (BeginBlocker rebuilds at block start; this mid-block rebuild
+// avoids the one-block latency window).
+//
+// Tolerance: no current epoch group ⇒ nil (unit-test path).
+func EnsureMembersInEpochGroup(ctx context.Context, k keeper.Keeper) error {
+	eg, err := k.GetCurrentEpochGroup(ctx)
+	if err != nil {
+		if errors.Is(err, types.ErrEffectiveEpochNotFound) || errors.Is(err, types.ErrEpochGroupDataNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	addrs := make([]string, 0, 8)
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](currentEpoch))
+	if err != nil {
+		return err
+	}
+	for ; iter.Valid(); iter.Next() {
+		key, err := iter.Key()
+		if err != nil {
+			iter.Close()
+			return err
+		}
+		addrs = append(addrs, key.K2().String())
+	}
+	if closeErr := iter.Close(); closeErr != nil {
+		return closeErr
+	}
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	// Update each sub-group's EpochGroupData ValidationWeights
+	// (the actual source the transient cache builds from). Plus
+	// the root group, so root-level meta lookups also work.
+	groupKeys := append([]string{""}, eg.GroupData.SubGroupModels...)
+	anyAdded := false
+	for _, modelID := range groupKeys {
+		data, found := k.GetEpochGroupData(ctx, currentEpoch, modelID)
+		if !found {
+			continue
+		}
+		have := make(map[string]bool, len(data.ValidationWeights))
+		for _, vw := range data.ValidationWeights {
+			if vw != nil {
+				have[vw.MemberAddress] = true
+			}
+		}
+		added := false
+		for _, addr := range addrs {
+			if have[addr] {
+				continue
+			}
+			data.ValidationWeights = append(data.ValidationWeights, &types.ValidationWeight{
+				MemberAddress: addr,
+				Weight:        1,
+				Reputation:    0,
+				VotingPower:   1,
+			})
+			data.TotalWeight += 1
+			added = true
+		}
+		if added {
+			k.SetEpochGroupData(ctx, data)
+			anyAdded = true
+		}
+	}
+
+	// Rebuild the transient cache only when ValidationWeights actually
+	// changed — MsgValidationFactory calls this per-op, and once the epoch's
+	// members are seeded every later call would otherwise rebuild for nothing.
+	if !anyAdded {
+		return nil
+	}
+	return k.BuildEpochDataTransientCache(ctx)
+}
+
+// EnsureModelsInEpochGroup promotes every model in the Models collection
+// into the current epoch group's SubGroupModels. Sim-only bridge over
+// the production gap that the PoC epoch flow normally closes: at sim
+// InitGenesis the inference module writes models to k.Models but the
+// genesis EpochGroup created by InitGenesisEpoch (module/genesis.go)
+// has an empty SubGroupModels list. UpdateDynamicPricing
+// (dynamic_pricing.go) iterates EpochGroup.SubGroupModels rather than
+// Models, so without this seeding BeginBlocker never computes a price
+// for the sim models and every StartInference fails with
+// «current price not found for model» at RecordInferencePrice.
+//
+// Idempotent: CreateSubGroup checks in-memory cache and on-chain state
+// before creating a new sub-group, so repeated calls are no-ops.
+//
+// Determinism: GetGovernanceModels returns models in collections-sorted
+// order (Models is a collections.Map keyed by string Id).
+//
+// Tolerance: if no current epoch group exists (unit-test contexts that
+// don't run the full InitGenesisEpochGroup wiring), returns nil without
+// touching state. Production sim app always has the genesis epoch group
+// via InitGenesisEpoch, so this branch only fires in the keeper-mock
+// tests in this package.
+//
+// No msg-server flow, no production semantics change.
+func EnsureModelsInEpochGroup(ctx context.Context, k keeper.Keeper) error {
+	eg, err := k.GetCurrentEpochGroup(ctx)
+	if err != nil {
+		if errors.Is(err, types.ErrEffectiveEpochNotFound) || errors.Is(err, types.ErrEpochGroupDataNotFound) {
+			return nil
+		}
+		return err
+	}
+	models, err := k.GetGovernanceModels(ctx)
+	if err != nil {
+		return err
+	}
+	for _, m := range models {
+		if _, err := eg.CreateSubGroup(ctx, m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnsureActiveParticipantsSeeded promotes all registered Participants into
+// ActiveParticipantsSet[currentEpoch] if it is currently empty. Sim-only
+// bridge from the Participants seeded at genesis over the gap that the
+// production PoC-epoch flow (activeparticipants.go) would normally
+// close — issue #982 demands operations «honor message preconditions»,
+// while faithfully simulating the full PoC epoch flow is a separate effort.
+//
+// Idempotent: any (currentEpoch, *) entry already present ⇒ no-op.
+//
+// Determinism: GetAllParticipant returns participants in bech32-sorted
+// order (collections.Map invariant), so the ActiveParticipants slice is
+// identical across same-seed runs.
+//
+// No msg-server flow, no production semantics change.
+func EnsureActiveParticipantsSeeded(ctx context.Context, k keeper.Keeper) error {
+	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](currentEpoch))
+	if err != nil {
+		return err
+	}
+	seeded := iter.Valid()
+	if closeErr := iter.Close(); closeErr != nil {
+		return closeErr
+	}
+	if seeded {
+		return nil
+	}
+
+	participants := k.GetAllParticipant(ctx)
+	if len(participants) == 0 {
+		return nil
+	}
+
+	active := make([]*types.ActiveParticipant, 0, len(participants))
+	for _, p := range participants {
+		active = append(active, &types.ActiveParticipant{
+			Index: p.Index,
+		})
+	}
+	return k.SetActiveParticipantsCache(ctx, types.ActiveParticipants{
+		EpochId:      currentEpoch,
+		Participants: active,
+	})
+}
+
+// EnsureComputeValidators keeps the cometbft validator set alive across long
+// simulation runs.
+//
+// Sim-only bridge over production's PoC validator-rotation flow. In production,
+// cosmos x/slashing downtime-jails offline validators, but every epoch
+// onSetNewValidatorsStage (module.go) calls SetComputeValidators, whose
+// updateValidator (cosmos-sdk x/staking/keeper/compute.go:492) sets
+// Jailed=false / Status=Bonded for every validator still doing PoC work — so the
+// validator set is continuously refreshed and never drains.
+//
+// The simulation does not run PoC, so SetComputeValidators is never invoked and
+// downtime-jailed validators are never un-jailed. Over a long run every
+// validator jails out, the set empties, and simsx aborts with "empty validator
+// set" (cosmos-sdk x/simulation/simulate.go:266) — observed draining bonded
+// validators 131->83->35->0 over blocks 56->110->~135.
+//
+// This helper mimics the production refresh: when the bonded validator count
+// falls below simBondedValidatorFloor it feeds every current validator back
+// through SetComputeValidators, which un-jails and re-bonds them. Idempotent —
+// above the floor it is a cheap no-op, and SetComputeValidators itself skips
+// validators already bonded at the target power (compute.go:176).
+//
+// Determinism: GetAllValidators returns collections-sorted output and
+// SetComputeValidators sorts its inputs internally (compute.go:140-163), so the
+// refresh reproduces across same-seed runs. No production code change.
+func EnsureComputeValidators(ctx context.Context, k keeper.Keeper) error {
+	validators, err := k.Staking.GetAllValidators(ctx)
+	if err != nil {
+		return err
+	}
+	if len(validators) == 0 {
+		return nil
+	}
+
+	bonded := 0
+	for i := range validators {
+		if validators[i].IsBonded() && !validators[i].IsJailed() {
+			bonded++
+		}
+	}
+	if bonded >= simBondedValidatorFloor {
+		return nil
+	}
+
+	results := make([]stakingkeeper.ComputeResult, 0, len(validators))
+	for i := range validators {
+		pubKey, err := validators[i].ConsPubKey()
+		if err != nil {
+			// A validator with an undecodable consensus key cannot be fed back;
+			// skip it rather than aborting the whole refresh.
+			continue
+		}
+		results = append(results, stakingkeeper.ComputeResult{
+			Power:           simValidatorPower,
+			ValidatorPubKey: pubKey,
+			OperatorAddress: validators[i].OperatorAddress,
+		})
+	}
+	// isTestnet=true selects the current SetComputeValidators path (the legacy
+	// pre-ValidatorIndexFixHeight branch only matters for mainnet's early
+	// history); matches what mainnet runs today.
+	_, err = k.Staking.SetComputeValidators(ctx, results, true)
+	return err
+}

--- a/inference-chain/x/inference/simulation/bootstrap_test.go
+++ b/inference-chain/x/inference/simulation/bootstrap_test.go
@@ -1,0 +1,115 @@
+package simulation_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/simulation"
+)
+
+// TestEnsureActiveParticipantsSeeded_SeedsCurrentEpoch — with N Participants
+// registered and ActiveParticipantsSet empty for currentEpoch, the helper
+// promotes all of them.
+func TestEnsureActiveParticipantsSeeded_SeedsCurrentEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 1, 5)
+	regs := registerAsParticipants(t, k, ctx, accs)
+	const epoch = uint64(7)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, epoch))
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+
+	got := collectActiveAddrs(t, ctx, k, epoch)
+	sort.Strings(got)
+	want := append([]string{}, regs...)
+	sort.Strings(want)
+	require.Equal(t, want, got)
+}
+
+// TestEnsureActiveParticipantsSeeded_Idempotent — a second call with
+// ActiveParticipantsSet non-empty for currentEpoch returns nil and does
+// not change the set.
+func TestEnsureActiveParticipantsSeeded_Idempotent(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 2, 3)
+	registerAsParticipants(t, k, ctx, accs)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+	first := collectActiveAddrs(t, ctx, k, 0)
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+	second := collectActiveAddrs(t, ctx, k, 0)
+
+	// collectActiveAddrs returns store-ordered (deterministic) addresses;
+	// first and second use the same helper, so a direct Equal is valid.
+	require.Equal(t, first, second)
+}
+
+// TestEnsureActiveParticipantsSeeded_NoParticipants_NoOp — empty Participants
+// collection ⇒ helper returns nil without populating ActiveParticipantsSet.
+func TestEnsureActiveParticipantsSeeded_NoParticipants_NoOp(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+
+	require.Empty(t, collectActiveAddrs(t, ctx, k, 0))
+}
+
+// TestEnsureModelsInEpochGroup_TolerantOnMissingEpoch — without an
+// EffectiveEpochIndex set, GetCurrentEpochGroup returns
+// ErrEffectiveEpochNotFound; the helper must treat that as a no-op
+// (returns nil) so unit-test keepers without full InitGenesisEpochGroup
+// wiring still let the factories run.
+func TestEnsureModelsInEpochGroup_TolerantOnMissingEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	// No SetEffectiveEpochIndex call — GetCurrentEpochGroup will fail.
+	require.NoError(t, simulation.EnsureModelsInEpochGroup(ctx, k))
+}
+
+// TestEnsureModelsInEpochGroup_TolerantOnMissingEpochGroupData — index
+// is set but no EpochGroupData exists yet; helper must also no-op for
+// this branch (ErrEpochGroupDataNotFound).
+func TestEnsureModelsInEpochGroup_TolerantOnMissingEpochGroupData(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+	require.NoError(t, simulation.EnsureModelsInEpochGroup(ctx, k))
+}
+
+// TestEnsureMembersInEpochGroup_TolerantOnMissingEpoch — no
+// EffectiveEpochIndex set ⇒ GetCurrentEpochGroup fails with
+// ErrEffectiveEpochNotFound; helper no-ops. Same tolerance contract as
+// EnsureModelsInEpochGroup.
+func TestEnsureMembersInEpochGroup_TolerantOnMissingEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	require.NoError(t, simulation.EnsureMembersInEpochGroup(ctx, k))
+}
+
+// TestEnsureMembersInEpochGroup_TolerantOnMissingEpochGroupData — index
+// is set but no EpochGroupData exists yet; helper no-ops.
+func TestEnsureMembersInEpochGroup_TolerantOnMissingEpochGroupData(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+	require.NoError(t, simulation.EnsureMembersInEpochGroup(ctx, k))
+}
+
+// TestEnsureActiveParticipantsSeeded_RespectsEffectiveEpoch — the helper
+// writes to currentEpoch (= EffectiveEpochIndex) and leaves other epoch
+// slots untouched.
+func TestEnsureActiveParticipantsSeeded_RespectsEffectiveEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 3, 4)
+	registerAsParticipants(t, k, ctx, accs)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 42))
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+
+	require.Len(t, collectActiveAddrs(t, ctx, k, 42), len(accs))
+	require.Empty(t, collectActiveAddrs(t, ctx, k, 0))
+	require.Empty(t, collectActiveAddrs(t, ctx, k, 41))
+	require.Empty(t, collectActiveAddrs(t, ctx, k, 43))
+}

--- a/inference-chain/x/inference/simulation/genesis.go
+++ b/inference-chain/x/inference/simulation/genesis.go
@@ -1,0 +1,94 @@
+package simulation
+
+import (
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// SimModelIDs is the canonical ordered list of model IDs registered at
+// sim genesis. Tests assert exact membership; factories pick from it.
+var SimModelIDs = []string{
+	"Qwen/Qwen2.5-7B-Instruct",
+	"moonshotai/Kimi-K2.6",
+}
+
+// BuildSimGenesisModels returns the Phase-2 sim model registry. Values
+// mirror real mainnet governance entries:
+//
+//   - Qwen/Qwen2.5-7B-Instruct: from x/inference/keeper/model_test.go
+//     (the canonical genesis-style example in the keeper's own tests).
+//   - moonshotai/Kimi-K2.6: from app/upgrades/v0_2_12/upgrades.go
+//     (kimiGovernanceModel) — installed on mainnet via the v0.2.12 upgrade
+//     handler.
+//
+// ProposedBy="genesis" is required by the production InitGenesis check at
+// module/genesis.go; InitGenesis then rewrites it to k.GetAuthority().
+// Using realistic mainnet parameters (Phase-2 issue text §«helper logic
+// for selecting valid accounts and valid preconditions … realistic
+// messages rather than mostly generating invalid transactions»).
+//
+// Sim-only — does not run on production chain init.
+func BuildSimGenesisModels() []types.Model {
+	return []types.Model{
+		{
+			ProposedBy:             "genesis",
+			Id:                     "Qwen/Qwen2.5-7B-Instruct",
+			UnitsOfComputePerToken: 100,
+			HfRepo:                 "Qwen/Qwen2.5-7B-Instruct",
+			HfCommit:               "a09a35458c702b33eeacc393d103063234e8bc28",
+			ModelArgs:              []string{"--quantization", "fp8"},
+			VRam:                   24,
+			ThroughputPerNonce:     10000,
+			ValidationThreshold:    &types.Decimal{Value: 85, Exponent: -2},
+		},
+		{
+			ProposedBy:             "genesis",
+			Id:                     "moonshotai/Kimi-K2.6",
+			UnitsOfComputePerToken: 10000,
+			HfRepo:                 "moonshotai/Kimi-K2.6",
+			HfCommit:               "5a49d036ab7472b7d5912ded487150ec1358c11d",
+			ModelArgs: []string{
+				"--max-model-len", "240000",
+				"--tool-call-parser", "kimi_k2",
+				"--reasoning-parser", "kimi_k2",
+			},
+			VRam:                720,
+			ThroughputPerNonce:  1500,
+			ValidationThreshold: &types.Decimal{Value: 920, Exponent: -3},
+		},
+	}
+}
+
+// NumSimGenesisParticipants is the count of sim accounts pre-registered as
+// Participants at sim genesis. The bootstrap helper (bootstrap.go) promotes
+// them into ActiveParticipantsSet[currentEpoch] on first call from any
+// active-participant-gated factory.
+const NumSimGenesisParticipants = 5
+
+// BuildSimGenesisParticipants picks N sim accounts and returns them as
+// Participant entries for GenesisState.ParticipantList. Status is left
+// zero — production InitGenesis runs the participant loop BEFORE SetParams,
+// so UpdateParticipantStatus → ComputeStatus hits its genesis fast path
+// (calculations/status.go) and assigns ACTIVE.
+//
+// Sim-only — no production code change. ActiveParticipantsSet promotion is
+// done lazily by EnsureActiveParticipantsSeeded (bootstrap.go).
+//
+// Determinism: simState.Accounts is generated from r *rand.Rand by simsx,
+// so the same seed yields the same prefix selection.
+func BuildSimGenesisParticipants(simState *module.SimulationState) []types.Participant {
+	n := NumSimGenesisParticipants
+	if len(simState.Accounts) < n {
+		n = len(simState.Accounts)
+	}
+	out := make([]types.Participant, 0, n)
+	for i := 0; i < n; i++ {
+		addr := simState.Accounts[i].Address.String()
+		out = append(out, types.Participant{
+			Index:   addr,
+			Address: addr,
+		})
+	}
+	return out
+}

--- a/inference-chain/x/inference/simulation/genesis_test.go
+++ b/inference-chain/x/inference/simulation/genesis_test.go
@@ -1,0 +1,72 @@
+package simulation_test
+
+import (
+	"encoding/json"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/simulation"
+)
+
+// TestBuildSimGenesisParticipants_PicksN verifies the helper extracts
+// exactly NumSimGenesisParticipants entries from a longer Accounts slice,
+// preserving the prefix order (deterministic given simState.Rand seed).
+func TestBuildSimGenesisParticipants_PicksN(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	accs := simtypes.RandomAccounts(r, simulation.NumSimGenesisParticipants+3)
+	simState := &module.SimulationState{
+		Accounts:     accs,
+		Rand:         r,
+		GenState:     map[string]json.RawMessage{},
+		GenTimestamp: time.Unix(0, 0),
+	}
+
+	got := simulation.BuildSimGenesisParticipants(simState)
+	require.Len(t, got, simulation.NumSimGenesisParticipants)
+	for i, p := range got {
+		require.Equal(t, accs[i].Address.String(), p.Index)
+		require.Equal(t, accs[i].Address.String(), p.Address)
+	}
+}
+
+// TestBuildSimGenesisParticipants_FewerAccountsAvailable caps the output
+// length at len(simState.Accounts) when that is below
+// NumSimGenesisParticipants — the helper must not panic or pad.
+func TestBuildSimGenesisParticipants_FewerAccountsAvailable(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	want := simulation.NumSimGenesisParticipants - 2
+	require.Greater(t, want, 0)
+	accs := simtypes.RandomAccounts(r, want)
+	simState := &module.SimulationState{
+		Accounts:     accs,
+		Rand:         r,
+		GenState:     map[string]json.RawMessage{},
+		GenTimestamp: time.Unix(0, 0),
+	}
+
+	got := simulation.BuildSimGenesisParticipants(simState)
+	require.Len(t, got, want)
+}
+
+// TestBuildSimGenesisModels_KimiAndQwen — sim genesis registers Qwen +
+// Kimi with ProposedBy="genesis" (required by production InitGenesis at
+// module/genesis.go). Values must match the canonical mainnet
+// entries so the simulation pressure-tests realistic chain config.
+func TestBuildSimGenesisModels_KimiAndQwen(t *testing.T) {
+	got := simulation.BuildSimGenesisModels()
+	require.Len(t, got, 2)
+	ids := []string{got[0].Id, got[1].Id}
+	require.ElementsMatch(t, simulation.SimModelIDs, ids)
+	for _, m := range got {
+		require.Equal(t, "genesis", m.ProposedBy,
+			"sim genesis model must set ProposedBy=genesis")
+		require.NotEmpty(t, m.HfRepo)
+		require.NotZero(t, m.UnitsOfComputePerToken)
+		require.NotNil(t, m.ValidationThreshold)
+	}
+}

--- a/inference-chain/x/inference/simulation/helpers_test.go
+++ b/inference-chain/x/inference/simulation/helpers_test.go
@@ -1,0 +1,122 @@
+package simulation_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/core/address"
+	sdkaddress "github.com/cosmos/cosmos-sdk/codec/address"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/simulation"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// newSimAccounts returns n deterministic sim accounts using seed.
+// Equivalent to simtypes.RandomAccounts with an explicit math/rand source.
+func newSimAccounts(t *testing.T, seed int64, n int) []simtypes.Account {
+	t.Helper()
+	return simtypes.RandomAccounts(rand.New(rand.NewSource(seed)), n)
+}
+
+// registerAsParticipants registers each sim account as a Participant in the
+// keeper. Status pre-set to ACTIVE and CurrentEpochStats initialized so
+// UpdateParticipantStatus → ComputeStatus does not flip status under
+// DefaultParams (matches the keeper_test.createNParticipant pattern at
+// inference-chain/x/inference/keeper/participant_test.go).
+func registerAsParticipants(t *testing.T, k keeper.Keeper, ctx context.Context, accs []simtypes.Account) []string {
+	t.Helper()
+	out := make([]string, 0, len(accs))
+	for _, a := range accs {
+		addr := a.Address.String()
+		require.NoError(t, k.SetParticipant(ctx, types.Participant{
+			Index:             addr,
+			Address:           addr,
+			Status:            types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: types.NewCurrentEpochStats(),
+		}))
+		out = append(out, addr)
+	}
+	return out
+}
+
+// registerSimGenesisModels writes the Phase-2 sim models into the keeper.
+// Unit-test analogue of what InitGenesis does (module/genesis.go)
+// when it consumes GenesisState.ModelList. Needed so factory tests can
+// successfully invoke PickRandomGovernanceModelID without running a full
+// app-level sim genesis.
+func registerSimGenesisModels(t *testing.T, k keeper.Keeper, ctx context.Context) {
+	t.Helper()
+	for _, m := range simulation.BuildSimGenesisModels() {
+		mm := m
+		mm.ProposedBy = k.GetAuthority()
+		k.SetModel(ctx, &mm)
+	}
+}
+
+// putFinishedInference writes a FINISHED-status Inference into the
+// keeper. Used by MsgValidation factory tests: PickRandomFinishedInference
+// filters by Status==FINISHED to avoid the hard ErrInferenceNotFinished
+// path at msg_server_validation.go.
+// ExecutedBy is required to satisfy validator!=executor at
+// msg_server_validation.go — pass any registered participant
+// address whose role you do NOT want drawn as the validator.
+func putFinishedInference(t *testing.T, k keeper.Keeper, ctx context.Context, id, executedBy string) {
+	t.Helper()
+	require.NoError(t, k.SetInference(ctx, types.Inference{
+		Index:       id,
+		InferenceId: id,
+		ExecutedBy:  executedBy,
+		Status:      types.InferenceStatus_FINISHED,
+	}))
+}
+
+// putStartedInference writes a STARTED-status Inference with the dev/TA
+// components the MsgFinishInference start-first pairing path compares
+// against (compareDevComponents / compareFinishTAComponents). assignedTo
+// is both the executor and the account the Finish factory signs as.
+func putStartedInference(t *testing.T, k keeper.Keeper, ctx context.Context, id, assignedTo, model string) {
+	t.Helper()
+	require.NoError(t, k.SetInference(ctx, types.Inference{
+		Index:              id,
+		InferenceId:        id,
+		AssignedTo:         assignedTo,
+		ExecutedBy:         assignedTo,
+		TransferredBy:      assignedTo,
+		RequestedBy:        assignedTo,
+		PromptHash:         "sim-prompt-hash",
+		OriginalPromptHash: "sim-original-prompt-hash",
+		Model:              model,
+		RequestTimestamp:   1_000_000,
+		Status:             types.InferenceStatus_STARTED,
+	}))
+}
+
+// collectActiveAddrs returns the bech32 addresses in ActiveParticipantsSet
+// for the given epoch, in iteration (collections-sorted) order.
+func collectActiveAddrs(t *testing.T, ctx context.Context, k keeper.Keeper, epoch uint64) []string {
+	t.Helper()
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](epoch))
+	require.NoError(t, err)
+	defer iter.Close()
+	out := make([]string, 0, 8)
+	for ; iter.Valid(); iter.Next() {
+		key, err := iter.Key()
+		require.NoError(t, err)
+		out = append(out, key.K2().String())
+	}
+	return out
+}
+
+// gonkaBech32Codec returns the address codec wired to the gonka account
+// prefix that keepertest.InferenceKeeper installs via
+// sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka").
+func gonkaBech32Codec() address.Codec {
+	return sdkaddress.NewBech32Codec("gonka")
+}

--- a/inference-chain/x/inference/simulation/msg_factory.go
+++ b/inference-chain/x/inference/simulation/msg_factory.go
@@ -1,0 +1,396 @@
+package simulation
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/shopspring/decimal"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// Phase 2 first-wave message factories for x/inference.
+//
+// Each factory returns a simsx.SimMsgFactoryFn[*types.MsgX] that, when
+// invoked, builds a single randomized but valid message instance plus the
+// signing accounts. The simsx runner handles tx assembly, signing, and
+// delivery — factories only produce the message.
+//
+// Each factory first runs the sim-only Ensure* bootstrap helpers
+// (bootstrap.go) so the message's on-chain preconditions hold, then
+// generates a message that clears ValidateBasic, the permission gate and
+// signature verification — so the tx reaches real keeper state mutation
+// instead of being rejected.
+
+// MsgSubmitNewParticipantFactory creates a factory for MsgSubmitNewParticipant.
+//
+// MsgSubmitNewParticipant has all-optional fields except Creator
+// (ValidateBasic: types/message_submit_new_participant.go). Minimal valid
+// msg = Creator only. Handler (keeper/msg_server_submit_new_participant.go)
+// is idempotent: if a participant with this address already exists, the msg
+// becomes a no-op update (all optional fields empty). On a fresh address a
+// new participant is created. Either path exercises the registration
+// permission check (OpenRegistrationPermission); if registration is closed
+// at this block height the tx will fail with ErrNewParticipantRegistrationClosed
+// — that is a legitimate simulation outcome, not a factory bug.
+func MsgSubmitNewParticipantFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgSubmitNewParticipant] {
+	return func(_ context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgSubmitNewParticipant) {
+		from := testData.AnyAccount(reporter)
+		if reporter.IsSkipped() {
+			return nil, nil
+		}
+		msg := &types.MsgSubmitNewParticipant{
+			Creator: from.Address.String(),
+		}
+		return []simsx.SimAccount{from}, msg
+	}
+}
+
+// MsgStartInferenceFactory creates a factory for MsgStartInference.
+//
+// Real-ECDSA path. Produces a ValidateBasic-passing msg with a
+// real ActiveParticipant as Creator (= RequestedBy = AssignedTo — same
+// sim account occupies all three roles, so the dev pubkey lookup matches
+// the TA). msg.InferenceId is a real secp256k1 dev signature of
+// (OriginalPromptHash || RequestTimestamp || Creator) produced by
+// SignDevStart, so the handler's verifyStartFirstMessageKeys
+// (msg_server_start_inference.go) passes its dev-signature check and
+// the inference is actually persisted via SetInference (line 133),
+// unblocking paired Finish/Validation state flow.
+//
+// TransferSignature is still a random 64-byte base64 payload — it is
+// not verified on the start-first path (deferred to FinishInference,
+// see msg_server_start_inference.go policy comment).
+//
+// Exercises: ValidateBasic, CheckPermission(ActiveParticipantPermission),
+// developer/transfer-agent access gating, GetParticipant lookup,
+// timestamp window, dev signature verification (PASS), participant
+// access gating, ProcessStartInference, RecordInferencePrice, SetInference,
+// addTimeout. Result: inference lands in keeper.
+func MsgStartInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgStartInference] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgStartInference) {
+		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("active-participants bootstrap failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureComputeValidators(ctx, k); err != nil {
+			reporter.Skipf("compute-validators refresh failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		ta, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		modelID, ok := PickRandomGovernanceModelID(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		timestamp := sdkCtx.BlockTime().UnixNano()
+
+		transferSigBytes := make([]byte, 64)
+		testData.Rand().Read(transferSigBytes)
+		promptHashBytes := make([]byte, 32)
+		testData.Rand().Read(promptHashBytes)
+		originalPromptHashBytes := make([]byte, 32)
+		testData.Rand().Read(originalPromptHashBytes)
+
+		msg := &types.MsgStartInference{
+			Creator:            ta.AddressBech32,
+			RequestedBy:        ta.AddressBech32,
+			AssignedTo:         ta.AddressBech32,
+			TransferSignature:  base64.StdEncoding.EncodeToString(transferSigBytes),
+			PromptHash:         base64.StdEncoding.EncodeToString(promptHashBytes),
+			OriginalPromptHash: base64.StdEncoding.EncodeToString(originalPromptHashBytes),
+			Model:              modelID,
+			PromptPayload:      "sim-prompt-payload",
+			RequestTimestamp:   timestamp,
+			MaxTokens:          uint64(testData.Rand().IntInRange(1, 1024)),
+			PromptTokenCount:   uint64(testData.Rand().IntInRange(1, 512)),
+		}
+		devSig, err := SignDevStart(ta, msg)
+		if err != nil {
+			reporter.Skipf("SignDevStart failed: %v", err)
+			return nil, nil
+		}
+		msg.InferenceId = devSig
+		return []simsx.SimAccount{ta}, msg
+	}
+}
+
+// MsgFinishInferenceFactory creates a factory for MsgFinishInference.
+//
+// Two paths, chosen by keeper state:
+//
+//  1. start-first pairing: when a STARTED-status inference
+//     exists whose AssignedTo is a known sim account, the factory
+//     finishes THAT inference — copying its InferenceId and dev/TA
+//     components so the handler's StartProcessed() branch
+//     (msg_server_finish_inference.go) takes the compare-only path
+//     (compareDevComponents / compareFinishTAComponents /
+//     compareFinishModelField) and transitions the inference
+//     STARTED → FINISHED. This is what produces FINISHED inferences
+//     for MsgValidation to act on. Signatures are NOT re-verified on
+//     this path, so InferenceId is reused verbatim and Transfer/Executor
+//     signatures are random-but-shape-valid.
+//
+//  2. fresh finish-first: when no STARTED inference qualifies,
+//     the factory builds a brand-new finish-first message with real
+//     secp256k1 dev (SignDevFinish) + TA (SignTAFinish) signatures so
+//     the handler's verifyFinishKeys path (line 102) passes its
+//     cryptographic check.
+//
+// ExecutorSignature is always random 64-byte base64 — executor signature
+// verification is disabled by policy on both paths
+// (msg_server_finish_inference.go).
+//
+// Creator == ExecutedBy is a hard invariant (line 28-32); the same sim
+// account occupies all four address roles.
+func MsgFinishInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgFinishInference] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgFinishInference) {
+		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("active-participants bootstrap failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureComputeValidators(ctx, k); err != nil {
+			reporter.Skipf("compute-validators refresh failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+
+		// Path 1: pair with an existing STARTED inference.
+		if started, ok := FindRandomStartedInference(ctx, k, testData); ok {
+			executor := testData.GetAccount(reporter, started.AssignedTo)
+			if reporter.IsSkipped() {
+				return nil, nil
+			}
+			executorSigBytes := make([]byte, 64)
+			testData.Rand().Read(executorSigBytes)
+			transferSigBytes := make([]byte, 64)
+			testData.Rand().Read(transferSigBytes)
+			responseHashBytes := make([]byte, 32)
+			testData.Rand().Read(responseHashBytes)
+			msg := &types.MsgFinishInference{
+				Creator:              started.AssignedTo,
+				ExecutedBy:           started.AssignedTo,
+				TransferredBy:        started.TransferredBy,
+				RequestedBy:          started.RequestedBy,
+				InferenceId:          started.InferenceId,
+				TransferSignature:    base64.StdEncoding.EncodeToString(transferSigBytes),
+				ExecutorSignature:    base64.StdEncoding.EncodeToString(executorSigBytes),
+				ResponseHash:         base64.StdEncoding.EncodeToString(responseHashBytes),
+				PromptHash:           started.PromptHash,
+				OriginalPromptHash:   started.OriginalPromptHash,
+				Model:                started.Model,
+				RequestTimestamp:     started.RequestTimestamp,
+				PromptTokenCount:     uint64(testData.Rand().IntInRange(1, 512)),
+				CompletionTokenCount: uint64(testData.Rand().IntInRange(1, 512)),
+			}
+			return []simsx.SimAccount{executor}, msg
+		}
+
+		// Path 2: fresh finish-first.
+		ta, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		modelID, ok := PickRandomGovernanceModelID(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		timestamp := sdkCtx.BlockTime().UnixNano()
+
+		executorSigBytes := make([]byte, 64)
+		testData.Rand().Read(executorSigBytes)
+		responseHashBytes := make([]byte, 32)
+		testData.Rand().Read(responseHashBytes)
+		promptHashBytes := make([]byte, 32)
+		testData.Rand().Read(promptHashBytes)
+		originalPromptHashBytes := make([]byte, 32)
+		testData.Rand().Read(originalPromptHashBytes)
+
+		msg := &types.MsgFinishInference{
+			Creator:              ta.AddressBech32,
+			ExecutedBy:           ta.AddressBech32,
+			TransferredBy:        ta.AddressBech32,
+			RequestedBy:          ta.AddressBech32,
+			ExecutorSignature:    base64.StdEncoding.EncodeToString(executorSigBytes),
+			ResponseHash:         base64.StdEncoding.EncodeToString(responseHashBytes),
+			PromptHash:           base64.StdEncoding.EncodeToString(promptHashBytes),
+			OriginalPromptHash:   base64.StdEncoding.EncodeToString(originalPromptHashBytes),
+			Model:                modelID,
+			RequestTimestamp:     timestamp,
+			PromptTokenCount:     uint64(testData.Rand().IntInRange(1, 512)),
+			CompletionTokenCount: uint64(testData.Rand().IntInRange(1, 512)),
+		}
+		devSig, err := SignDevFinish(ta, msg)
+		if err != nil {
+			reporter.Skipf("SignDevFinish failed: %v", err)
+			return nil, nil
+		}
+		msg.InferenceId = devSig
+		taSig, err := SignTAFinish(ta, msg)
+		if err != nil {
+			reporter.Skipf("SignTAFinish failed: %v", err)
+			return nil, nil
+		}
+		msg.TransferSignature = taSig
+		return []simsx.SimAccount{ta}, msg
+	}
+}
+
+// MsgValidationFactory creates a factory for MsgValidation.
+//
+// Paired-state rebind. The handler's GetInference branch
+// (msg_server_validation.go) returns ErrInferenceNotFound as a
+// HARD error; simsx treats hard-error tx as a fatal simulation failure
+// and aborts the run. To stay clear of that
+// path, this factory picks a random InferenceId from the Inferences
+// collection if any exist; if empty (early sim blocks, before Start has
+// landed any inference) it Skips the reporter so simsx counts the op as
+// «no eligible candidate» rather than failed.
+//
+// ValueDecimal is generated via shopspring/decimal (no float in op gen
+// per plan §145 determinism guards) and is always ABOVE the picked
+// model's ValidationThreshold so the handler takes the «passed» branch
+// (msg_server_validation.go): inference → VALIDATED, no group
+// proposal. The invalidation-voting branch (value ≤ threshold) submits
+// a cosmos `group` proposal requiring the validator to be a registered
+// group member — that membership path is deferred to Phase 3 (it needs
+// the full PoC validator-rotation flow, not a sim-only shortcut).
+//
+// Exercises: ValidateBasic; CheckPermission (Active ∨ PreviousActive,
+// permissions.go); GetParticipant lookup; GetInference (found
+// branch); transient validation cache lookup; the passing-validation
+// state transition.
+func MsgValidationFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgValidation] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgValidation) {
+		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("active-participants bootstrap failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureComputeValidators(ctx, k); err != nil {
+			reporter.Skipf("compute-validators refresh failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureMembersInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("members epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		inference, ok := PickRandomFinishedInference(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		// Validator is drawn from the inference's OWN epoch (not the current
+		// epoch): the handler keys the transient validation cache by
+		// inference.EpochId, so a current-epoch validator would miss the cache
+		// after an epoch transition and the handler would hard-fail with
+		// ErrParticipantNotFound. Excludes the executor —
+		// msg_server_validation.go hard-rejects self-validation.
+		validator, ok := PickRandomActiveSimAccountExcluding(ctx, k, testData, reporter, inference.EpochId, inference.ExecutedBy)
+		if !ok {
+			return nil, nil
+		}
+
+		valueDec := passingValidationValue(ctx, k, testData, inference.Model)
+
+		msg := &types.MsgValidation{
+			Creator:      validator.AddressBech32,
+			InferenceId:  inference.InferenceId,
+			ValueDecimal: types.DecimalFromDecimal(valueDec),
+		}
+		return []simsx.SimAccount{validator}, msg
+	}
+}
+
+// MsgClaimRewardsFactory creates a factory for MsgClaimRewards.
+//
+// Produces a ValidateBasic-passing msg with EpochIndex=1 (must be > 0
+// per message_claim_rewards.go) and a random Seed. At sim genesis
+// EffectiveEpochIndex=0, so handler's validateRequest hits the
+// currentEpoch==0 branch (msg_server_claim_rewards.go) and
+// returns a graceful response{Result: "..."} with nil error. Op
+// delivered, gas consumed, no state mutation.
+//
+// Real reward claiming requires SettleAmount records, which are
+// produced by upstream PoC/epoch flows or by completed inference
+// settlement — both outside this first-wave scope.
+//
+// Exercises: ValidateBasic; CheckPermission (Active ∨ PreviousActive,
+// permissions.go); validateRequest's currentEpoch==0 early-return
+// path.
+func MsgClaimRewardsFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgClaimRewards] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgClaimRewards) {
+		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("bootstrap failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureComputeValidators(ctx, k); err != nil {
+			reporter.Skipf("compute-validators refresh failed: %v", err)
+			return nil, nil
+		}
+		claimant, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+
+		msg := &types.MsgClaimRewards{
+			Creator:    claimant.AddressBech32,
+			Seed:       testData.Rand().Int63(),
+			EpochIndex: 1,
+		}
+		return []simsx.SimAccount{claimant}, msg
+	}
+}
+
+// passingValidationValue returns a ValueDecimal strictly above the given
+// model's ValidationThreshold, so MsgValidation routes through the
+// «passed» branch (msg_server_validation.go). Uses integer-percent
+// arithmetic over shopspring/decimal — no float, deterministic.
+//
+// Falls back to a fixed 0.99 when the model or its threshold can't be
+// resolved (the handler would then evaluate against whatever threshold
+// it loads; 0.99 clears every realistic mainnet threshold ≤ 0.98).
+func passingValidationValue(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	modelID string,
+) decimal.Decimal {
+	const maxPct = 100
+	minPct := 99
+	if model, found := k.GetGovernanceModel(ctx, modelID); found && model.ValidationThreshold != nil {
+		// threshold is in [0,1]; smallest integer percentage strictly
+		// above it = floor(threshold*100) + 1.
+		thresholdPct := model.ValidationThreshold.ToDecimal().
+			Mul(decimal.NewFromInt(100)).Floor().IntPart()
+		// Assigned unconditionally — int(thresholdPct)+1 IS the smallest
+		// integer percent strictly above the threshold. The old «p < minPct»
+		// guard left minPct at the 99 default for thresholds ≥ 0.99, letting
+		// IntInRange emit a value EQUAL to (not above) the threshold. The
+		// minPct>maxPct clamp below covers the degenerate threshold = 1.0 case.
+		minPct = int(thresholdPct) + 1
+	}
+	if minPct > maxPct {
+		minPct = maxPct
+	}
+	numerator := testData.Rand().IntInRange(minPct, maxPct+1)
+	return decimal.NewFromInt(int64(numerator)).Div(decimal.NewFromInt(100))
+}

--- a/inference-chain/x/inference/simulation/msg_factory_test.go
+++ b/inference-chain/x/inference/simulation/msg_factory_test.go
@@ -1,0 +1,235 @@
+package simulation_test
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/calculations"
+	"github.com/productscience/inference/x/inference/simulation"
+)
+
+func decimalOne() decimal.Decimal { return decimal.NewFromInt(1) }
+
+// Each factory test exercises the message-building closure end-to-end:
+// keeper seeded with N Participants → bootstrap + pick run inside the
+// factory → ValidateBasic must pass on the produced msg → signer in
+// returned []SimAccount must match msg.Creator. This is the unit-level
+// contract for these factories. Full simsx hit-rate behavior is covered
+// separately by the verification-gate smoke test.
+
+const factoryAccountCount = 5
+
+func TestMsgSubmitNewParticipantFactory_BuildsValidMsg(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 11, factoryAccountCount)
+	// SubmitNewParticipant does not require ActiveParticipantsSet — minimal
+	// setup. We still register accounts so they exist as sim accounts.
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(12)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgSubmitNewParticipantFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+}
+
+func TestMsgStartInferenceFactory_BuildsValidMsg(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 21, factoryAccountCount)
+	registerAsParticipants(t, kk, sdkCtx, accs)
+	registerSimGenesisModels(t, kk, sdkCtx)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(22)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgStartInferenceFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	// Same account in all three roles.
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+	require.Equal(t, msg.Creator, msg.RequestedBy)
+	require.Equal(t, msg.Creator, msg.AssignedTo)
+	// Bootstrap side effect — ActiveParticipantsSet[0] is now non-empty.
+	require.NotEmpty(t, collectActiveAddrs(t, sdkCtx, kk, 0))
+	// Picked Model is one of the genesis-registered sim models.
+	require.Contains(t, simulation.SimModelIDs, msg.Model)
+	// Real dev signature in msg.InferenceId. Verify against
+	// signer pubkey so the handler's verifyStartFirstMessageKeys would
+	// pass.
+	devComponents := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.Creator,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(devComponents, calculations.Developer,
+			pubKeyB64(t, signers[0].Account), msg.InferenceId))
+}
+
+// TestMsgFinishInferenceFactory_FinishFirst_BuildsValidMsg — with no
+// STARTED inference in keeper, the factory takes path 2 (fresh
+// finish-first) and produces a msg with real dev + TA signatures.
+func TestMsgFinishInferenceFactory_FinishFirst_BuildsValidMsg(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 31, factoryAccountCount)
+	registerAsParticipants(t, kk, sdkCtx, accs)
+	registerSimGenesisModels(t, kk, sdkCtx)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(32)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgFinishInferenceFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	// Creator == ExecutedBy (hard at msg_server_finish_inference.go)
+	// and same account occupies all four roles.
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+	require.Equal(t, msg.Creator, msg.ExecutedBy)
+	require.Equal(t, msg.Creator, msg.TransferredBy)
+	require.Equal(t, msg.Creator, msg.RequestedBy)
+	// Picked Model is one of the genesis-registered sim models.
+	require.Contains(t, simulation.SimModelIDs, msg.Model)
+	// Real dev signature in msg.InferenceId.
+	devComponents := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(devComponents, calculations.Developer,
+			pubKeyB64(t, signers[0].Account), msg.InferenceId))
+	// Real TA signature in msg.TransferSignature.
+	taComponents := calculations.SignatureComponents{
+		Payload:         msg.PromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+		ExecutorAddress: msg.ExecutedBy,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(taComponents, calculations.TransferAgent,
+			pubKeyB64(t, signers[0].Account), msg.TransferSignature))
+}
+
+// TestMsgFinishInferenceFactory_PairsStartedInference — with a
+// STARTED inference present whose AssignedTo is a sim account, the
+// factory takes path 1 and finishes THAT inference, copying its
+// InferenceId and the dev/TA components the start-first compare path
+// checks (compareDevComponents / compareFinishTAComponents).
+func TestMsgFinishInferenceFactory_PairsStartedInference(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 33, factoryAccountCount)
+	regAddrs := registerAsParticipants(t, kk, sdkCtx, accs)
+	registerSimGenesisModels(t, kk, sdkCtx)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	// InferenceId must be base64 of 64 bytes (utils.ValidateBase64RSig64,
+	// enforced by MsgFinishInference.ValidateBasic). Real Start inferences
+	// carry a 64-byte dev signature here; the test uses a fixed-byte
+	// stand-in.
+	startedID := base64.StdEncoding.EncodeToString(make([]byte, 64))
+	assignedTo := regAddrs[2]
+	putStartedInference(t, kk, sdkCtx, startedID, assignedTo, simulation.SimModelIDs[0])
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(34)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgFinishInferenceFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	// Finishes the seeded STARTED inference verbatim.
+	require.Equal(t, startedID, msg.InferenceId)
+	require.Equal(t, assignedTo, msg.Creator)
+	require.Equal(t, assignedTo, msg.ExecutedBy)
+	require.Equal(t, assignedTo, signers[0].AddressBech32)
+	// dev/TA components copied from the inference (compare-path inputs).
+	require.Equal(t, "sim-prompt-hash", msg.PromptHash)
+	require.Equal(t, "sim-original-prompt-hash", msg.OriginalPromptHash)
+	require.Equal(t, simulation.SimModelIDs[0], msg.Model)
+	require.Equal(t, int64(1_000_000), msg.RequestTimestamp)
+}
+
+// TestMsgValidationFactory_PicksExistingInference — with a pre-seeded
+// Inference in keeper whose ExecutedBy is one of the active sim
+// participants, the factory picks a DIFFERENT active sim participant as
+// validator (validator!=executor constraint) and produces a
+// ValidateBasic-passing msg referencing the seeded InferenceId.
+func TestMsgValidationFactory_PicksExistingInference(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 41, factoryAccountCount)
+	regAddrs := registerAsParticipants(t, kk, sdkCtx, accs)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(sdkCtx, kk))
+	const seededID = "sim-inference-001"
+	executor := regAddrs[0]
+	putFinishedInference(t, kk, sdkCtx, seededID, executor)
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(42)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgValidationFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+	require.Equal(t, seededID, msg.InferenceId)
+	require.NotEqual(t, executor, msg.Creator,
+		"validator must not equal executor (msg_server_validation.go)")
+	require.NotNil(t, msg.ValueDecimal)
+	v := msg.ValueDecimal.ToDecimal()
+	require.False(t, v.IsNegative())
+	require.True(t, v.LessThanOrEqual(decimalOne()))
+}
+
+// TestMsgValidationFactory_EmptyFinishedInferences_Skips — no FINISHED
+// inferences in keeper ⇒ reporter Skipped, no msg produced. Even if
+// STARTED inferences exist they're filtered out (factory uses
+// PickRandomFinishedInference so MsgValidation handler's
+// ErrInferenceNotFinished path at line 77-79 is never reached).
+func TestMsgValidationFactory_EmptyFinishedInferences_Skips(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 43, factoryAccountCount)
+	registerAsParticipants(t, kk, sdkCtx, accs)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(44)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	_, msg := simulation.MsgValidationFactory(kk)(sdkCtx, cds, reporter)
+	require.Nil(t, msg)
+	require.True(t, reporter.IsSkipped(), "expected Skip on empty Inferences")
+}
+
+func TestMsgClaimRewardsFactory_BuildsValidMsg(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 51, factoryAccountCount)
+	registerAsParticipants(t, kk, sdkCtx, accs)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(52)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgClaimRewardsFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+	require.Greater(t, msg.EpochIndex, uint64(0)) // ValidateBasic requirement
+}

--- a/inference-chain/x/inference/simulation/signing.go
+++ b/inference-chain/x/inference/simulation/signing.go
@@ -1,0 +1,77 @@
+package simulation
+
+import (
+	"encoding/base64"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+
+	"github.com/productscience/inference/x/inference/calculations"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// Sim-only signing helpers for Phase 2 first-wave factories.
+//
+// The on-chain signature scheme used by `verifyStartFirstMessageKeys`
+// (msg_server_start_inference.go) and `verifyFinishKeys`
+// (msg_server_finish_inference.go) is:
+//
+//   bytes = Payload || strconv(EpochId if>0) || strconv(Timestamp) ||
+//           TransferAddress (|| ExecutorAddress for TA/Executor)
+//   sig   = base64( secp256k1_sign(privKey, bytes) )  // r||s, 64 bytes
+//
+// Encoding lives in calculations/signature_validate.go. Factories
+// in this package generate the components from msg fields and sign with
+// the picked SimAccount's PrivKey so the produced tx clears the cryptographic
+// verify path and the inference actually lands in the keeper.
+
+// simAccountSigner adapts a simtypes.Account PrivKey to the
+// calculations.Signer interface (SignBytes returns base64-encoded sig).
+type simAccountSigner struct{ priv cryptotypes.PrivKey }
+
+func (s simAccountSigner) SignBytes(data []byte) (string, error) {
+	sig, err := s.priv.Sign(data)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// SignDevStart signs MsgStartInference dev components. Result goes in
+// msg.InferenceId (the field is named after the inference but is treated
+// by the handler as the dev signature — see
+// msg_server_start_inference.go calculations.SignatureData
+// `DevSignature: msg.InferenceId`).
+func SignDevStart(sa simsx.SimAccount, msg *types.MsgStartInference) (string, error) {
+	components := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.Creator,
+	}
+	return calculations.Sign(simAccountSigner{priv: sa.PrivKey}, components, calculations.Developer)
+}
+
+// SignDevFinish signs MsgFinishInference dev components. Result goes in
+// msg.InferenceId. Mirrors getFinishDevSignatureComponents at
+// msg_server_finish_inference.go.
+func SignDevFinish(sa simsx.SimAccount, msg *types.MsgFinishInference) (string, error) {
+	components := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+	}
+	return calculations.Sign(simAccountSigner{priv: sa.PrivKey}, components, calculations.Developer)
+}
+
+// SignTAFinish signs MsgFinishInference TA components. Result goes in
+// msg.TransferSignature. Mirrors getFinishTASignatureComponents at
+// msg_server_finish_inference.go (TA/Executor share bytes layout).
+func SignTAFinish(sa simsx.SimAccount, msg *types.MsgFinishInference) (string, error) {
+	components := calculations.SignatureComponents{
+		Payload:         msg.PromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+		ExecutorAddress: msg.ExecutedBy,
+	}
+	return calculations.Sign(simAccountSigner{priv: sa.PrivKey}, components, calculations.TransferAgent)
+}

--- a/inference-chain/x/inference/simulation/signing_test.go
+++ b/inference-chain/x/inference/simulation/signing_test.go
@@ -1,0 +1,138 @@
+package simulation_test
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/calculations"
+	"github.com/productscience/inference/x/inference/simulation"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// pubKeyB64 returns the standard-base64 encoding of the secp256k1 pubkey
+// bytes — the same format the on-chain GetAccountPubKey returns
+// (msg_server_start_inference.go).
+func pubKeyB64(t *testing.T, a simtypes.Account) string {
+	t.Helper()
+	return base64.StdEncoding.EncodeToString(a.PubKey.Bytes())
+}
+
+// TestSignDevStart_RoundTrip — SignDevStart's output decodes and
+// ValidateSignature(Developer) accepts it against the signing account's
+// pubkey. This verifies the helper plugs cleanly into the on-chain
+// VerifyKeys path used by verifyStartFirstMessageKeys.
+func TestSignDevStart_RoundTrip(t *testing.T) {
+	accs := simtypes.RandomAccounts(rand.New(rand.NewSource(1)), 1)
+	sa := simsx.SimAccount{Account: accs[0]}
+
+	msg := &types.MsgStartInference{
+		Creator:            accs[0].Address.String(),
+		RequestedBy:        accs[0].Address.String(),
+		AssignedTo:         accs[0].Address.String(),
+		OriginalPromptHash: "orig-hash",
+		PromptHash:         "prompt-hash",
+		Model:              "sim-model",
+		RequestTimestamp:   1234567890,
+	}
+
+	sig, err := simulation.SignDevStart(sa, msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, sig)
+
+	components := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.Creator,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(components, calculations.Developer,
+			pubKeyB64(t, accs[0]), sig))
+}
+
+// TestSignDevFinish_RoundTrip — same for Finish dev signature, using
+// MsgFinishInference's TransferredBy as TransferAddress.
+func TestSignDevFinish_RoundTrip(t *testing.T) {
+	accs := simtypes.RandomAccounts(rand.New(rand.NewSource(2)), 1)
+	sa := simsx.SimAccount{Account: accs[0]}
+
+	msg := &types.MsgFinishInference{
+		Creator:            accs[0].Address.String(),
+		ExecutedBy:         accs[0].Address.String(),
+		TransferredBy:      accs[0].Address.String(),
+		RequestedBy:        accs[0].Address.String(),
+		OriginalPromptHash: "orig-hash-finish",
+		PromptHash:         "prompt-hash-finish",
+		Model:              "sim-model",
+		RequestTimestamp:   2222222222,
+	}
+
+	sig, err := simulation.SignDevFinish(sa, msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, sig)
+
+	components := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(components, calculations.Developer,
+			pubKeyB64(t, accs[0]), sig))
+}
+
+// TestSignTAFinish_RoundTrip — TA signature includes ExecutorAddress in
+// the byte payload (getTransferBytes appends ExecutorAddress on top of
+// getDevBytes). Verified via ValidateSignature(TransferAgent).
+func TestSignTAFinish_RoundTrip(t *testing.T) {
+	accs := simtypes.RandomAccounts(rand.New(rand.NewSource(3)), 1)
+	sa := simsx.SimAccount{Account: accs[0]}
+
+	msg := &types.MsgFinishInference{
+		Creator:          accs[0].Address.String(),
+		ExecutedBy:       accs[0].Address.String(),
+		TransferredBy:    accs[0].Address.String(),
+		PromptHash:       "ta-prompt-hash",
+		RequestTimestamp: 3333333333,
+	}
+
+	sig, err := simulation.SignTAFinish(sa, msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, sig)
+
+	components := calculations.SignatureComponents{
+		Payload:         msg.PromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+		ExecutorAddress: msg.ExecutedBy,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(components, calculations.TransferAgent,
+			pubKeyB64(t, accs[0]), sig))
+}
+
+// TestSignDevStart_Deterministic — same key + same components → same
+// signature. cosmos-sdk secp256k1 uses deterministic ECDSA per RFC 6979,
+// so the helper must reproduce bit-identically. This guarantees
+// replay-determinism across simulator seeds.
+func TestSignDevStart_Deterministic(t *testing.T) {
+	accs := simtypes.RandomAccounts(rand.New(rand.NewSource(4)), 1)
+	sa := simsx.SimAccount{Account: accs[0]}
+
+	msg := &types.MsgStartInference{
+		Creator:            accs[0].Address.String(),
+		RequestedBy:        accs[0].Address.String(),
+		OriginalPromptHash: "det-hash",
+		RequestTimestamp:   9999999999,
+	}
+
+	sig1, err := simulation.SignDevStart(sa, msg)
+	require.NoError(t, err)
+	sig2, err := simulation.SignDevStart(sa, msg)
+	require.NoError(t, err)
+	require.Equal(t, sig1, sig2)
+}


### PR DESCRIPTION
## Summary

First milestone of #982 — Cosmos SDK simulation that is both **runnable** and
**exercises real `x/inference` logic**. The issue's "Proposed Next Step"
defines this milestone as exactly that pair: *"simulator run ergonomics, a
smoke run path, first-wave x/inference operation support, repeated seeded
runs"*.

**Supersedes #1156.** #1156 was opened as a standalone Phase-1 PR under an
initially proposed PR-A/B/C split; Phase 2 came together quickly, and since
the issue itself bundles ergonomics + first-wave ops into one milestone,
combining them is one self-contained, reviewable PR instead of a stacked
cross-fork pair — and gives a reviewer something that actually hammers chain
logic, not plumbing alone. Phase 3 (second-wave ops — `InvalidateInference` /
`RevalidateInference` / training / admin flows — plus operation-weight tuning,
custom invariants, store decoders, parameter-edge fuzzing) still follows as a
separate PR.

Built fresh from `main`, not on @hleb-albau's #995 (closed). The Make-target
naming and `fixBankGenesisState` helper are ported from #995, with credit.

## Phase 1 — make simulation runnable

- simsx integration in `app/sim_test.go` / `sim_bench_test.go`; `*App`
  satisfies `simsx.SimulationApp`.
- Make targets `node-sim-smoke-test` (50×20) and `node-sim-full-test`
  (500×200); root Makefile delegates to `inference-chain/Makefile`.
- `disabledOpsSimModule` wrapper — nil `WeightedOperations` for staking /
  distribution / wasmd while preserving `GenerateGenesisState`.
- `fixBankGenesisState` — recomputes Supply, adds Gonka denom metadata so
  InitGenesis succeeds with staking ops disabled (ported from #995).
- Upstream tests reimplemented in simsx idioms: `TestAppImportExport_Postrun`
  and `TestAppSimulationAfterImport_Postrun` (both `t.Skip`'d pending the fork
  bonded-pool fix proposed in #1153); `TestAppStateDeterminism`.
- SDK config split (`InitSDKConfig` / `SealSDKConfig`); `docs/simulation.md`;
  `workflow_dispatch` smoke CI.

## Phase 2 — first-wave x/inference ops

- The 5 operations named in the issue, registered via `HasWeightedOperationsX`:
  `MsgSubmitNewParticipant`, `MsgStartInference`, `MsgFinishInference`,
  `MsgValidation`, `MsgClaimRewards`. Real message generation honoring
  preconditions — valid accounts, epoch/model state, real ECDSA signatures.
- Sim-only bootstrap bridges over the PoC-epoch gap (`EnsureActiveParticipants
  Seeded`, `EnsureModelsInEpochGroup`, `EnsureMembersInEpochGroup`).
- `EnsureComputeValidators` — minimal validator-survival bridge so long seeded
  runs don't drain the cometbft validator set. This much is in #982 scope
  (Phase 1 asks for "a longer seeded run"); faithfully simulating the full PoC
  validator rotation is a separate, larger effort.
- `TestFullSimulation_x_Inference_Integrated` — smoke sim + post-run
  keeper-state assertions (Start/Finish/Validation each reach state).
- Unit tests for every bootstrap helper and factory.
- `MsgValidation` exercises the passing branch (→ VALIDATED). The
  invalidation-voting branch — and the second-wave `InvalidateInference` /
  `RevalidateInference` ops — is deferred to Phase 3: it needs epoch-group
  membership, not a sim-only shortcut.

## Test plan

Verified in canonical Docker (Alpine + musl + static wasmvm):

- [x] `go build -tags "sims muslc" ./...` clean
- [x] `go test ./...` and `go test -tags "sims muslc" ./x/inference/...` green
- [x] `make node-sim-smoke-test` green (`TestFullAppSimulation` +
      `TestFullSimulation_x_Inference_Integrated`)
- [x] `make node-sim-full-test` — real 500-block run, no skip
- [x] `TestAppStateDeterminism` green; determinism static checks clean
- [x] pre-PR review pass (per CONTRIBUTING.md)

## Out of scope (follow-up phases of #982)

- Phase 3 — second-wave x/inference ops (`InvalidateInference`,
  `RevalidateInference`, training-task and admin/allow-list flows);
  operation-weight tuning; custom invariants; parameter-edge fuzzing;
  store decoders.
- Phase 4 — sim ops for other custom modules (`bls`, `bookkeeper`,
  `collateral`, `genesistransfer`, `restrictions`, `streamvesting`).
- Full PoC epoch + validator-rotation simulation; devshard simulation.

## Notes for review

- The two `*_Postrun` tests `t.Skip` with explicit reasons — they hit a known
  fork-level bonded-pool inconsistency at
  `cosmos-sdk@v0.53.3-ps17/x/staking/keeper/genesis.go:157`; fork fix proposed
  in #1153.
- `docs/simulation.md` covers run modes, build tags, the canonical Docker run,
  and failure interpretation.
- **Simulation activity coverage caveat**: cosmos-sdk's default
  `BlockSizeTransitionMatrix` (`x/simulation/params.go`) has a sticky
  empty-block state (97% self-transition) designed for permissionless-chain
  fuzz coverage. In gonka's compressed 40-block sim epoch, this concentrates
  ops in the early blocks of the run rather than distributing them uniformly
  across 500 blocks. The first-wave ops still run and the assertions hold
  (`TestFullSimulation_x_Inference_Integrated` PASS with non-zero
  `startProcessed` / `finishProcessed` / `validated`), but reviewers should
  not read "500-block run" as "500 blocks of activity". Phase 3 will address
  this via cosmos-sdk's existing `HasFutureOpsRegistry` time-aware enforce
  primitive — no fork modification needed.

Part of #982. Phase 3 to follow as a separate PR.

cc @patimen