### PR TITLE
fix: canonicalize bridge deposit keys and add global completion dedup

### DIFF
--- a/inference-chain/x/inference/keeper/bridge_canonical.go
+++ b/inference-chain/x/inference/keeper/bridge_canonical.go
@@ -1,0 +1,88 @@
+package keeper
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// buildCanonicalBridgeTransaction normalizes MsgBridgeExchange fields before they
+// are hashed, stored, or used for quorum aggregation.
+func buildCanonicalBridgeTransaction(msg *types.MsgBridgeExchange) (*types.BridgeTransaction, error) {
+	blockNumber, err := canonicalDecimalString(msg.BlockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("invalid blockNumber: %w", err)
+	}
+	receiptIndex, err := canonicalDecimalString(msg.ReceiptIndex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid receiptIndex: %w", err)
+	}
+	amount, err := canonicalDecimalString(msg.Amount)
+	if err != nil {
+		return nil, fmt.Errorf("invalid amount: %w", err)
+	}
+	if bi, ok := new(big.Int).SetString(amount, 10); !ok || bi.Sign() <= 0 {
+		return nil, fmt.Errorf("amount must be > 0")
+	}
+
+	ownerAddr, err := sdk.AccAddressFromBech32(msg.OwnerAddress)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ownerAddress: %w", err)
+	}
+
+	receiptsRoot := strings.ToLower(msg.ReceiptsRoot)
+
+	return &types.BridgeTransaction{
+		ChainId:         strings.ToLower(msg.OriginChain),
+		ContractAddress: strings.ToLower(msg.ContractAddress),
+		OwnerAddress:    ownerAddr.String(),
+		Amount:          amount,
+		BlockNumber:     blockNumber,
+		ReceiptIndex:    receiptIndex,
+		ReceiptsRoot:    receiptsRoot,
+	}, nil
+}
+
+// canonicalDecimalString strips leading zeros while preserving a single "0" digit.
+func canonicalDecimalString(s string) (string, error) {
+	bi, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return "", fmt.Errorf("not a base-10 integer")
+	}
+	if bi.Sign() < 0 {
+		return "", fmt.Errorf("must be non-negative")
+	}
+	return bi.String(), nil
+}
+
+// canonicalBridgeDepositEventID identifies one L1 deposit receipt independent of
+// ReceiptsRoot string variants used in the vote-aggregation key.
+func canonicalBridgeDepositEventID(tx *types.BridgeTransaction) string {
+	canon := fmt.Sprintf(
+		"%s|%s|%s|%s|%s|%s",
+		strings.ToLower(tx.ChainId),
+		tx.BlockNumber,
+		tx.ReceiptIndex,
+		strings.ToLower(tx.ContractAddress),
+		tx.OwnerAddress,
+		tx.Amount,
+	)
+	hash := sha256.Sum256([]byte(canon))
+	return hex.EncodeToString(hash[:])
+}
+
+func (k Keeper) isBridgeDepositEventCompleted(ctx context.Context, tx *types.BridgeTransaction) (bool, error) {
+	eventID := canonicalBridgeDepositEventID(tx)
+	return k.BridgeCompletedDepositEvents.Has(ctx, eventID)
+}
+
+func (k Keeper) markBridgeDepositEventCompleted(ctx context.Context, tx *types.BridgeTransaction) error {
+	eventID := canonicalBridgeDepositEventID(tx)
+	return k.BridgeCompletedDepositEvents.Set(ctx, eventID)
+}

--- a/inference-chain/x/inference/keeper/bridge_canonical.go
+++ b/inference-chain/x/inference/keeper/bridge_canonical.go
@@ -64,17 +64,38 @@ func canonicalDecimalString(s string) (string, error) {
 // canonicalBridgeDepositEventID identifies one L1 deposit receipt independent of
 // ReceiptsRoot string variants used in the vote-aggregation key.
 func canonicalBridgeDepositEventID(tx *types.BridgeTransaction) string {
+	blockNumber := canonicalDecimalStringOrOriginal(tx.BlockNumber)
+	receiptIndex := canonicalDecimalStringOrOriginal(tx.ReceiptIndex)
+	amount := canonicalDecimalStringOrOriginal(tx.Amount)
+	ownerAddress := canonicalAccAddressOrOriginal(tx.OwnerAddress)
+
 	canon := fmt.Sprintf(
 		"%s|%s|%s|%s|%s|%s",
 		strings.ToLower(tx.ChainId),
-		tx.BlockNumber,
-		tx.ReceiptIndex,
+		blockNumber,
+		receiptIndex,
 		strings.ToLower(tx.ContractAddress),
-		tx.OwnerAddress,
-		tx.Amount,
+		ownerAddress,
+		amount,
 	)
 	hash := sha256.Sum256([]byte(canon))
 	return hex.EncodeToString(hash[:])
+}
+
+func canonicalDecimalStringOrOriginal(s string) string {
+	canonical, err := canonicalDecimalString(s)
+	if err != nil {
+		return s
+	}
+	return canonical
+}
+
+func canonicalAccAddressOrOriginal(s string) string {
+	addr, err := sdk.AccAddressFromBech32(s)
+	if err != nil {
+		return s
+	}
+	return addr.String()
 }
 
 func (k Keeper) isBridgeDepositEventCompleted(ctx context.Context, tx *types.BridgeTransaction) (bool, error) {

--- a/inference-chain/x/inference/keeper/bridge_canonical_export_test.go
+++ b/inference-chain/x/inference/keeper/bridge_canonical_export_test.go
@@ -1,0 +1,16 @@
+package keeper
+
+import "github.com/productscience/inference/x/inference/types"
+
+// Test-only exports for bridge canonicalization regression tests.
+func BuildCanonicalBridgeTransactionForTest(msg *types.MsgBridgeExchange) (*types.BridgeTransaction, error) {
+	return buildCanonicalBridgeTransaction(msg)
+}
+
+func GenerateSecureBridgeTransactionKeyForTest(tx *types.BridgeTransaction) string {
+	return generateSecureBridgeTransactionKey(tx)
+}
+
+func CanonicalBridgeDepositEventIDForTest(tx *types.BridgeTransaction) string {
+	return canonicalBridgeDepositEventID(tx)
+}

--- a/inference-chain/x/inference/keeper/bridge_canonical_test.go
+++ b/inference-chain/x/inference/keeper/bridge_canonical_test.go
@@ -1,0 +1,47 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCanonicalBridgeTransaction_KeyCollapsesLeadingZerosAndReceiptsRootCasing(t *testing.T) {
+	owner := "gonka13779rkgy6ke7cdj8f097pdvx34uvrlcqq8nq2w"
+	receiptsLower := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	receiptsMixed := "0xAbCdEf1234567890aBcDeF1234567890aBcDeF1234567890aBcDeF1234567890"
+
+	msgA := &types.MsgBridgeExchange{
+		Validator:       owner,
+		OriginChain:     "Ethereum",
+		ContractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+		OwnerAddress:    owner,
+		OwnerPubKey:     "pk",
+		Amount:          "01000",
+		BlockNumber:     "021000000",
+		ReceiptIndex:    "05",
+		ReceiptsRoot:    receiptsMixed,
+	}
+	msgB := &types.MsgBridgeExchange{
+		Validator:       owner,
+		OriginChain:     "ethereum",
+		ContractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		OwnerAddress:    owner,
+		OwnerPubKey:     "pk",
+		Amount:          "1000",
+		BlockNumber:     "21000000",
+		ReceiptIndex:    "5",
+		ReceiptsRoot:    receiptsLower,
+	}
+
+	txA, err := keeper.BuildCanonicalBridgeTransactionForTest(msgA)
+	require.NoError(t, err)
+	txB, err := keeper.BuildCanonicalBridgeTransactionForTest(msgB)
+	require.NoError(t, err)
+
+	require.Equal(t, txA, txB)
+	require.Equal(t, keeper.GenerateSecureBridgeTransactionKeyForTest(txA), keeper.GenerateSecureBridgeTransactionKeyForTest(txB))
+	require.Equal(t, keeper.CanonicalBridgeDepositEventIDForTest(txA), keeper.CanonicalBridgeDepositEventIDForTest(txB))
+}

--- a/inference-chain/x/inference/keeper/bridge_canonical_test.go
+++ b/inference-chain/x/inference/keeper/bridge_canonical_test.go
@@ -45,3 +45,27 @@ func TestBuildCanonicalBridgeTransaction_KeyCollapsesLeadingZerosAndReceiptsRoot
 	require.Equal(t, keeper.GenerateSecureBridgeTransactionKeyForTest(txA), keeper.GenerateSecureBridgeTransactionKeyForTest(txB))
 	require.Equal(t, keeper.CanonicalBridgeDepositEventIDForTest(txA), keeper.CanonicalBridgeDepositEventIDForTest(txB))
 }
+
+func TestCanonicalBridgeDepositEventID_CollapsesLegacyNumericVariants(t *testing.T) {
+	owner := "gonka13779rkgy6ke7cdj8f097pdvx34uvrlcqq8nq2w"
+	base := &types.BridgeTransaction{
+		ChainId:         "ethereum",
+		ContractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		OwnerAddress:    owner,
+		Amount:          "1000",
+		BlockNumber:     "21000000",
+		ReceiptIndex:    "5",
+		ReceiptsRoot:    "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+	}
+	legacyVariant := &types.BridgeTransaction{
+		ChainId:         "Ethereum",
+		ContractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+		OwnerAddress:    owner,
+		Amount:          "01000",
+		BlockNumber:     "021000000",
+		ReceiptIndex:    "05",
+		ReceiptsRoot:    "0xABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890",
+	}
+
+	require.Equal(t, keeper.CanonicalBridgeDepositEventIDForTest(base), keeper.CanonicalBridgeDepositEventIDForTest(legacyVariant))
+}

--- a/inference-chain/x/inference/keeper/bridge_wrapped_token.go
+++ b/inference-chain/x/inference/keeper/bridge_wrapped_token.go
@@ -697,6 +697,23 @@ func (k Keeper) MintTokens(ctx sdk.Context, contractAddr string, recipient strin
 
 // handleCompletedBridgeTransaction handles minting tokens when a bridge transaction is completed
 func (k Keeper) handleCompletedBridgeTransaction(ctx sdk.Context, bridgeTx *types.BridgeTransaction) error {
+	alreadyCompleted, err := k.isBridgeDepositEventCompleted(ctx, bridgeTx)
+	if err != nil {
+		return fmt.Errorf("failed to check bridge deposit completion registry: %w", err)
+	}
+	if alreadyCompleted {
+		k.LogWarn("Bridge exchange: duplicate L1 deposit completion blocked",
+			types.Messages,
+			"chainId", bridgeTx.ChainId,
+			"blockNumber", bridgeTx.BlockNumber,
+			"receiptIndex", bridgeTx.ReceiptIndex,
+			"contractAddress", bridgeTx.ContractAddress,
+			"ownerAddress", bridgeTx.OwnerAddress,
+			"amount", bridgeTx.Amount,
+		)
+		return nil
+	}
+
 	// Check if this is a native token release (WGNK burn on Ethereum)
 	isBridgeContract := k.IsBridgeContractAddress(ctx, bridgeTx.ChainId, bridgeTx.ContractAddress)
 	if isBridgeContract {
@@ -714,7 +731,7 @@ func (k Keeper) handleCompletedBridgeTransaction(ctx sdk.Context, bridgeTx *type
 			"amount", bridgeTx.Amount,
 			"chainId", bridgeTx.ChainId)
 
-		return nil
+		return k.markBridgeDepositEventCompleted(ctx, bridgeTx)
 	}
 
 	// Handle wrapped token minting (existing logic)
@@ -738,7 +755,7 @@ func (k Keeper) handleCompletedBridgeTransaction(ctx sdk.Context, bridgeTx *type
 		"recipient", bridgeTx.OwnerAddress,
 		"amount", bridgeTx.Amount)
 
-	return nil
+	return k.markBridgeDepositEventCompleted(ctx, bridgeTx)
 }
 
 // GetAllBridgeTokenMetadata retrieves all bridge token metadata from chain state

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -81,8 +81,8 @@ type (
 		LastUpgradeHeight              collections.Item[int64]
 		PocV2EnabledEpoch              collections.Item[uint64]
 		// Bridge & Wrapped Token collections
-		BridgeContractAddresses        collections.Map[collections.Pair[string, string], types.BridgeContractAddress]
-		BridgeTransactionsMap          collections.Map[collections.Triple[string, string, string], types.BridgeTransaction]
+		BridgeContractAddresses collections.Map[collections.Pair[string, string], types.BridgeContractAddress]
+		BridgeTransactionsMap   collections.Map[collections.Triple[string, string, string], types.BridgeTransaction]
 		// BridgeTransactionValidators records per-validator confirmations
 		// for a bridge transaction. Key is (chainId, blockNumber, contentHashPart, validator_bech32),
 		// mirroring BridgeTransactionsMap's parent key so conflict txs (same
@@ -95,6 +95,7 @@ type (
 		BridgeMintRefundsMap           collections.Map[string, types.MsgRequestBridgeMint]
 		BridgeWithdrawalRefundsMap     collections.Map[string, types.MsgRequestBridgeWithdrawal]
 		BridgeWithdrawalTokenRefsMap   collections.Map[string, types.BridgeTokenReference]
+		BridgeCompletedDepositEvents   collections.KeySet[string]
 		WrappedTokenCodeIDItem         collections.Item[uint64]
 		WrappedTokenMetadataMap        collections.Map[collections.Pair[string, string], types.BridgeTokenMetadata]
 		WrappedTokenContractsMap       collections.Map[collections.Pair[string, string], types.BridgeWrappedTokenContract]
@@ -102,7 +103,7 @@ type (
 		LiquidityPoolItem              collections.Item[types.LiquidityPool]
 		LiquidityPoolApprovedTokensMap collections.Map[collections.Pair[string, string], types.BridgeTokenReference]
 		// PoC validation sampling snapshots
-		PoCValidationSnapshots collections.Map[int64, types.PoCValidationSnapshot]
+		PoCValidationSnapshots     collections.Map[int64, types.PoCValidationSnapshot]
 		PreservedNodesSnapshotItem collections.Item[types.PreservedNodesSnapshot]
 		// Punishment grace epochs for upgrade protection
 		PunishmentGraceEpochs collections.Map[uint64, types.GraceEpochParams]
@@ -456,6 +457,12 @@ func NewKeeper(
 			"bridge_withdrawal_token_refs",
 			collections.StringKey,
 			codec.CollValue[types.BridgeTokenReference](cdc),
+		),
+		BridgeCompletedDepositEvents: collections.NewKeySet(
+			sb,
+			types.BridgeCompletedDepositEventsPrefix,
+			"bridge_completed_deposit_events",
+			collections.StringKey,
 		),
 		WrappedTokenMetadataMap: collections.NewMap(
 			sb,

--- a/inference-chain/x/inference/keeper/msg_server_bridge_exchange.go
+++ b/inference-chain/x/inference/keeper/msg_server_bridge_exchange.go
@@ -54,18 +54,11 @@ func (k msgServer) BridgeExchange(goCtx context.Context, msg *types.MsgBridgeExc
 		return nil, fmt.Errorf("invalid validator address: %v", err)
 	}
 
-	// Create transaction object with all the content for secure validation
-	// ContractAddress is normalized to lowercase to ensure consistent dedup and comparison
-	// regardless of EIP-55 checksum casing used by individual validator nodes.
-	proposedTx := &types.BridgeTransaction{
-		ChainId:         msg.OriginChain,
-		ContractAddress: strings.ToLower(msg.ContractAddress),
-		OwnerAddress:    msg.OwnerAddress,
-		Amount:          msg.Amount,
-		BlockNumber:     msg.BlockNumber,
-		ReceiptIndex:    msg.ReceiptIndex,
-		ReceiptsRoot:    msg.ReceiptsRoot,
-		// Status and other fields will be set later
+	// Normalize all fields that feed vote-aggregation keys and mint deduplication.
+	proposedTx, err := buildCanonicalBridgeTransaction(msg)
+	if err != nil {
+		k.LogError("Bridge exchange: invalid canonical transaction fields", types.Messages, "error", err)
+		return nil, fmt.Errorf("invalid bridge exchange content: %w", err)
 	}
 
 	// Check if this exact transaction content has already been processed

--- a/inference-chain/x/inference/keeper/msg_server_bridge_exchange_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_bridge_exchange_test.go
@@ -61,14 +61,18 @@ func TestBridgeExchange_DoubleVoteCaseBypass(t *testing.T) {
 		}, nil,
 	).AnyTimes()
 
+	receiptsRoot := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
 	// First Vote (Lowercase)
 	msg1 := &types.MsgBridgeExchange{
 		OriginChain:     "ethereum",
 		ContractAddress: "0x123",
-		OwnerAddress:    "0xabc",
+		OwnerAddress:    validatorLower,
+		OwnerPubKey:     "pk",
 		Amount:          "100",
 		BlockNumber:     "1000",
 		ReceiptIndex:    "1",
+		ReceiptsRoot:    receiptsRoot,
 		Validator:       validatorLower,
 	}
 
@@ -79,10 +83,12 @@ func TestBridgeExchange_DoubleVoteCaseBypass(t *testing.T) {
 	msg2 := &types.MsgBridgeExchange{
 		OriginChain:     "ethereum",
 		ContractAddress: "0x123",
-		OwnerAddress:    "0xabc",
+		OwnerAddress:    validatorLower,
+		OwnerPubKey:     "pk",
 		Amount:          "100",
 		BlockNumber:     "1000",
 		ReceiptIndex:    "1",
+		ReceiptsRoot:    receiptsRoot,
 		Validator:       validatorUpper, // Uppercase
 	}
 

--- a/inference-chain/x/inference/types/bridge_validation.go
+++ b/inference-chain/x/inference/types/bridge_validation.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+var bridgeDigits = regexp.MustCompile(`^[0-9]+$`) //nolint:forbidigo // init code
+
+// decimalStringWithoutLeadingZeros reports whether s is a non-negative base-10
+// integer string without redundant leading zeros (except "0" itself).
+func decimalStringWithoutLeadingZeros(s string) bool {
+	if s == "" || !bridgeDigits.MatchString(s) {
+		return false
+	}
+	return len(s) == 1 || s[0] != '0'
+}
+
+// isValidReceiptsRootHex validates Ethereum block receiptsRoot encoding (0x + 32 bytes).
+func isValidReceiptsRootHex(root string) bool {
+	if len(root) != 66 {
+		return false
+	}
+	if !strings.HasPrefix(strings.ToLower(root), "0x") {
+		return false
+	}
+	_, err := hex.DecodeString(root[2:])
+	return err == nil
+}
+
+// isValidEthereumAddress validates basic Ethereum address format (0x + 40 hex chars).
+func isValidEthereumAddress(address string) bool {
+	if len(address) != 42 {
+		return false
+	}
+	if !strings.HasPrefix(strings.ToLower(address), "0x") {
+		return false
+	}
+
+	hexPart := address[2:]
+	for _, r := range hexPart {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return true
+}

--- a/inference-chain/x/inference/types/bridge_validation_test.go
+++ b/inference-chain/x/inference/types/bridge_validation_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecimalStringWithoutLeadingZeros(t *testing.T) {
+	require.True(t, decimalStringWithoutLeadingZeros("0"))
+	require.True(t, decimalStringWithoutLeadingZeros("1000"))
+	require.False(t, decimalStringWithoutLeadingZeros("01000"))
+	require.False(t, decimalStringWithoutLeadingZeros(""))
+}
+
+func TestIsValidReceiptsRootHex(t *testing.T) {
+	valid := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	require.True(t, isValidReceiptsRootHex(valid))
+	require.True(t, isValidReceiptsRootHex("0xABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890"))
+	require.False(t, isValidReceiptsRootHex("0xabc"))
+	require.False(t, isValidReceiptsRootHex("abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"))
+}

--- a/inference-chain/x/inference/types/keys.go
+++ b/inference-chain/x/inference/types/keys.go
@@ -103,7 +103,10 @@ var (
 	// canonical bech32 address.
 	BridgeTransactionValidatorsPrefix = collections.NewPrefix(64)
 	PreservedNodesSnapshotPrefix      = collections.NewPrefix(65)
-	ParamsKey                         = []byte("p_inference")
+	// BridgeCompletedDepositEventsPrefix records canonical L1 deposit receipts that
+	// have already triggered mint or escrow release.
+	BridgeCompletedDepositEventsPrefix = collections.NewPrefix(66)
+	ParamsKey                          = []byte("p_inference")
 )
 
 func KeyPrefix(p string) []byte {

--- a/inference-chain/x/inference/types/message_bridge_exchange.go
+++ b/inference-chain/x/inference/types/message_bridge_exchange.go
@@ -41,6 +41,9 @@ func (msg *MsgBridgeExchange) ValidateBasic() error {
 	if len(msg.OwnerAddress) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "ownerAddress is required")
 	}
+	if _, err := sdk.AccAddressFromBech32(msg.OwnerAddress); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid ownerAddress (%s)", err)
+	}
 	if len(msg.OwnerPubKey) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "ownerPubKey is required")
 	}
@@ -56,16 +59,18 @@ func (msg *MsgBridgeExchange) ValidateBasic() error {
 	if len(msg.ReceiptsRoot) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "receiptsRoot is required")
 	}
-	// numeric strings: blockNumber and receiptIndex must be unsigned integers
-	if !reDigits.MatchString(msg.BlockNumber) {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "blockNumber must be a base-10 unsigned integer string")
+	// numeric strings: blockNumber and receiptIndex must be unsigned integers without leading zeros
+	if !reDigits.MatchString(msg.BlockNumber) || !decimalStringWithoutLeadingZeros(msg.BlockNumber) {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "blockNumber must be a base-10 unsigned integer string without leading zeros")
 	}
-	if !reDigits.MatchString(msg.ReceiptIndex) {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "receiptIndex must be a base-10 unsigned integer string")
+	if !reDigits.MatchString(msg.ReceiptIndex) || !decimalStringWithoutLeadingZeros(msg.ReceiptIndex) {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "receiptIndex must be a base-10 unsigned integer string without leading zeros")
 	}
-	// amount must be a positive integer (no decimal point) in base-10
-	if !reDigits.MatchString(msg.Amount) {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "amount must be a base-10 unsigned integer string")
+	if !reDigits.MatchString(msg.Amount) || !decimalStringWithoutLeadingZeros(msg.Amount) {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "amount must be a base-10 unsigned integer string without leading zeros")
+	}
+	if !isValidReceiptsRootHex(msg.ReceiptsRoot) {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "receiptsRoot must be 0x-prefixed 32-byte hex")
 	}
 	if bi, ok := new(big.Int).SetString(msg.Amount, 10); !ok || bi.Sign() <= 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "amount must be > 0")

--- a/inference-chain/x/inference/types/message_bridge_exchange_test.go
+++ b/inference-chain/x/inference/types/message_bridge_exchange_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testReceiptsRoot = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
 func TestMsgBridgeExchange_ValidateBasic(t *testing.T) {
+	owner := sample.AccAddress()
 	tests := []struct {
 		name string
 		msg  MsgBridgeExchange
@@ -20,26 +23,42 @@ func TestMsgBridgeExchange_ValidateBasic(t *testing.T) {
 				Validator:       "invalid_address",
 				OriginChain:     "ethereum",
 				ContractAddress: "0xabc",
-				OwnerAddress:    "0xowner",
+				OwnerAddress:    owner,
 				OwnerPubKey:     "pk",
 				Amount:          "100",
 				BlockNumber:     "1",
 				ReceiptIndex:    "0",
-				ReceiptsRoot:    "0xroot",
+				ReceiptsRoot:    testReceiptsRoot,
 			},
 			err: sdkerrors.ErrInvalidAddress,
-		}, {
+		},
+		{
+			name: "rejects leading zeros in block number",
+			msg: MsgBridgeExchange{
+				Validator:       sample.AccAddress(),
+				OriginChain:     "ethereum",
+				ContractAddress: "0xabc",
+				OwnerAddress:    owner,
+				OwnerPubKey:     "pk",
+				Amount:          "100",
+				BlockNumber:     "01",
+				ReceiptIndex:    "0",
+				ReceiptsRoot:    testReceiptsRoot,
+			},
+			err: sdkerrors.ErrInvalidRequest,
+		},
+		{
 			name: "valid minimal",
 			msg: MsgBridgeExchange{
 				Validator:       sample.AccAddress(),
 				OriginChain:     "ethereum",
 				ContractAddress: "0xabc",
-				OwnerAddress:    "0xowner",
+				OwnerAddress:    owner,
 				OwnerPubKey:     "pk",
 				Amount:          "100",
 				BlockNumber:     "1",
 				ReceiptIndex:    "0",
-				ReceiptsRoot:    "0xroot",
+				ReceiptsRoot:    testReceiptsRoot,
 			},
 		},
 	}

--- a/inference-chain/x/inference/types/message_request_bridge_mint.go
+++ b/inference-chain/x/inference/types/message_request_bridge_mint.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"math/big"
-	"strings"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -74,25 +73,6 @@ func (msg *MsgRequestBridgeMint) ValidateBasic() error {
 	}
 
 	return nil
-}
-
-// isValidEthereumAddress validates basic Ethereum address format
-func isValidEthereumAddress(address string) bool {
-	if len(address) != 42 {
-		return false
-	}
-	if !strings.HasPrefix(strings.ToLower(address), "0x") {
-		return false
-	}
-
-	// Check if the rest are valid hex characters
-	hexPart := address[2:]
-	for _, r := range hexPart {
-		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
-			return false
-		}
-	}
-	return true
 }
 
 // isSupportedChainId checks if the chain ID is supported for bridging


### PR DESCRIPTION
## Summary
This fixes a bridge accounting bug where the same Ethereum deposit could produce multiple independent `BridgeTransaction` records, and multiple mints or escrow releases, when validators submitted identical L1 events with different string representations (for example `ReceiptsRoot` hex casing, or leading zeros in `BlockNumber` / `ReceiptIndex` / `Amount`). Vote aggregation keyed off raw strings, while mint/release only guarded completion per record, not per logical deposit.

## Root Cause
`generateSecureBridgeTransactionKey` hashed raw field strings. `ContractAddress` was not normalized on ingress in all paths. `ReceiptsRoot`, numeric fields, and `OwnerAddress` were not canonicalized before hashing or storage. `ValidateBasic` accepted leading-zero decimal strings (`^[0-9]+$`). Separately, `handleCompletedBridgeTransaction` only checked `BRIDGE_PENDING` on the current record; there was no chain-wide registry keyed by L1 receipt identity, so two storage keys for one deposit could each reach quorum and mint independently.

## Fix
- Add `buildCanonicalBridgeTransaction` to normalize all vote-aggregation fields at ingress:
  - `ContractAddress` and `ReceiptsRoot` -> lowercase
  - `BlockNumber`, `ReceiptIndex`, `Amount` -> canonical decimal via `big.Int` (no leading zeros)
  - `OwnerAddress` -> canonical bech32 via `AccAddressFromBech32`
  - `OriginChain` -> lowercase
- Harden `MsgBridgeExchange.ValidateBasic`: require valid bech32 `OwnerAddress`, reject leading zeros on numeric fields, validate `ReceiptsRoot` as `0x` + 32-byte hex.
- Add `BridgeCompletedDepositEvents` KeySet keyed by `canonicalBridgeDepositEventID` (`chainId|blockNumber|receiptIndex|contract|owner|amount`, excluding `ReceiptsRoot` string variants).
- Canonicalize the completed-event ID itself so legacy or split records with leading-zero numeric variants still collapse to the same global completion key.
- In `handleCompletedBridgeTransaction`, skip mint/release if the canonical deposit was already completed; mark completed only after successful mint or escrow release.

## Why This Closes The Vulnerability
The exploit required two conditions: validators could create distinct vote-aggregation keys for the same L1 deposit, and completion/mint was tracked only per key. This PR removes both: equivalent deposit reports collapse to one canonical `BridgeTransaction` identity, and even if a legacy or Byzantine split key reached quorum, the global completion registry ensures at most one mint or escrow release per canonical L1 receipt.

## Test plan
- [ ] `go test ./x/inference/types/... -run 'Bridge|BridgeExchange|Canonical'`
- [ ] `go test ./x/inference/keeper/... -run 'Bridge|Canonical'`
- [ ] Confirm two `MsgBridgeExchange` payloads differing only in `ReceiptsRoot` casing or leading zeros map to the same aggregation key after fix
- [ ] Confirm second completion for the same canonical deposit is blocked at `handleCompletedBridgeTransaction`