### PR TITLE
fix: validate Ethereum destination on bridge withdrawal

### DIFF
--- a/inference-chain/x/inference/types/message_request_bridge_withdrawal.go
+++ b/inference-chain/x/inference/types/message_request_bridge_withdrawal.go
@@ -41,9 +41,12 @@ func (msg *MsgRequestBridgeWithdrawal) ValidateBasic() error {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "amount must be positive")
 	}
 
-	// Validate destination address is not empty (Ethereum address format not validated here)
+	// Validate destination address is not empty
 	if len(msg.DestinationAddress) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "destination address cannot be empty")
+	}
+	if !isValidEthereumAddress(msg.DestinationAddress) {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "destination address must be a valid Ethereum address")
 	}
 
 	// Validate destination bridge address is not empty

--- a/inference-chain/x/inference/types/message_request_bridge_withdrawal_test.go
+++ b/inference-chain/x/inference/types/message_request_bridge_withdrawal_test.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/productscience/inference/testutil/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgRequestBridgeWithdrawal_ValidateBasic_DestinationAddress(t *testing.T) {
+	base := MsgRequestBridgeWithdrawal{
+		Creator:                  sample.AccAddress(),
+		UserAddress:              sample.AccAddress(),
+		Amount:                   "100",
+		DestinationBridgeAddress: "0x1234567890123456789012345678901234567890",
+	}
+
+	tests := []struct {
+		name               string
+		destinationAddress string
+		wantErr            bool
+	}{
+		{
+			name:               "rejects short destination",
+			destinationAddress: "0x12345",
+			wantErr:            true,
+		},
+		{
+			name:               "rejects invalid hex destination",
+			destinationAddress: "0xGGGG567890123456789012345678901234567890",
+			wantErr:            true,
+		},
+		{
+			name:               "rejects destination without prefix",
+			destinationAddress: "1234567890123456789012345678901234567890",
+			wantErr:            true,
+		},
+		{
+			name:               "accepts valid destination",
+			destinationAddress: "0x3333333333333333333333333333333333333333",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := base
+			msg.DestinationAddress = tt.destinationAddress
+
+			err := msg.ValidateBasic()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This fixes a validation gap where `MsgRequestBridgeWithdrawal` accepted malformed `DestinationAddress` values at `ValidateBasic` and only failed later during BLS signature preparation. Users paid gas for transactions that could never succeed, while `MsgRequestBridgeMint` already rejected the same malformed addresses up front.

Related deposit-side fixes: #1196.

## Root Cause
`MsgRequestBridgeWithdrawal.ValidateBasic` checked `DestinationAddress` for non-empty length only. `DestinationBridgeAddress` was validated with `isValidEthereumAddress`, but the user's ultimate Ethereum recipient was not. The handler called `ethereumAddressToBytes(recipient)` in `prepareBridgeWithdrawalSignatureData`, which failed after the message was already included in a block.

## Fix
- Apply `isValidEthereumAddress` to `DestinationAddress` in `MsgRequestBridgeWithdrawal.ValidateBasic`, matching `MsgRequestBridgeMint`.
- Add unit tests rejecting short/invalid destination addresses.

## Why This Closes The Vulnerability
Malformed withdrawal destinations are rejected before broadcast, eliminating wasted gas and inconsistent UX between symmetric bridge mint and withdrawal flows. Execution-time failures from invalid recipient encoding on the withdrawal path are no longer reachable through `ValidateBasic`-accepted messages.

## Test plan
- [ ] `go test ./x/inference/types/... -run 'Withdrawal|BridgeWithdrawal'`
- [ ] Submit `MsgRequestBridgeWithdrawal` with `DestinationAddress = "0x12345"` and confirm `ValidateBasic` error before execution