### PR TITLE
test(devshard): fix thinking_token_budget validator test (compile error + assertion)

### DIFF
--- a/devshard/cmd/devshardctl/paramvalidators/thinking_token_budget_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/thinking_token_budget_test.go
@@ -1,6 +1,7 @@
 package paramvalidators
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ func TestThinkingTokenBudgetDefaultsValidator(t *testing.T) {
 	t.Run("preserves client value when present", func(t *testing.T) {
 		doc := parseDocument(t, `{"max_tokens":4096,"thinking_token_budget":500}`)
 		require.NoError(t, v.Validate(ValidatorContext{Document: doc, RoutedModel: "kimi-model"}))
-		require.EqualValues(t, float64(500), doc["thinking_token_budget"])
+		require.Equal(t, json.Number("500"), doc["thinking_token_budget"])
 	})
 
 	t.Run("splits in half regardless of size", func(t *testing.T) {
@@ -54,8 +55,8 @@ func TestThinkingTokenBudgetDefaultsValidator(t *testing.T) {
 		require.False(t, exists)
 	})
 
-	t.Run("zero divisor saturates at max_tokens", func(t *testing.T) {
-		vZero := ThinkingTokenBudgetDefaultsValidator{DefaultDivisor: 0, MinValue: 256, Models: []string{"kimi-model"}}
+	t.Run("zero divisor uses max_tokens", func(t *testing.T) {
+		vZero := ThinkingTokenBudgetDefaultsValidator{DefaultDivisor: 0, Models: []string{"kimi-model"}}
 		doc := parseDocument(t, `{"max_tokens":4096}`)
 		require.NoError(t, vZero.Validate(ValidatorContext{Document: doc, RoutedModel: "kimi-model"}))
 		require.EqualValues(t, 4096, doc["thinking_token_budget"])


### PR DESCRIPTION
## Summary

Follow-up to #1202. Two problems in the `thinking_token_budget` validator unit test, both of which slipped through because **CI never ran on #1202** — the workflow was gated on first-time-contributor approval (`no checks reported` the whole time), so the `paramvalidators` test package was never compiled or executed before merge.

### 1. Compile error (takes down the whole package)

The `zero divisor` subtest constructed the validator with `MinValue: 256`, but the `MinValue` field was removed when the floor was dropped (last commit of #1202). The stale field reference fails to compile:

```
unknown field MinValue in struct literal of type ThinkingTokenBudgetDefaultsValidator
```

A compile error in the test fails the **entire** `paramvalidators` test package, not just one case.

### 2. Wrong assertion type

`preserves client value when present` compared against `float64(500)`:

```go
require.EqualValues(t, float64(500), doc["thinking_token_budget"])
```

`parseDocument` decodes with `dec.UseNumber()`, so an untouched client value stays `json.Number("500")` (a `string` underlying type). `EqualValues` coerces int/uint/float to each other but **not** `json.Number` ↔ `float64`, so it returns false.

## Fix

```diff
-vZero := ThinkingTokenBudgetDefaultsValidator{DefaultDivisor: 0, MinValue: 256, Models: ...}
+vZero := ThinkingTokenBudgetDefaultsValidator{DefaultDivisor: 0, Models: ...}

-require.EqualValues(t, float64(500), doc["thinking_token_budget"])
+require.Equal(t, json.Number("500"), doc["thinking_token_budget"])
```

Plus the `encoding/json` import. **Validator logic is unchanged** — it correctly leaves a client value untouched and self-balances the default split; only the test was wrong.

## Verification (traced, no Go toolchain locally)

- All 8 validator sub-tests: injected defaults set `uint64` → `EqualValues` numeric-coerces ✓; the preserved client value is `json.Number` → `Equal` matches ✓.
- All 9 pipeline tests in `request_filters_test.go` use `require.Contains(string(body), ...)` (string match on marshaled JSON) — unaffected, and the clamp paths verified via `numericJSONValueAsUint64` which handles `json.Number`.
- `TestDefaultCatalogSchemaDepthLimits` looks up validators by name (`response_format`/`tools`/`chat_template_kwargs`) — `thinking_token_budget` is skipped, no conflict.
- Exhaustive grep: no remaining references to `MinValue` / removed symbols anywhere under `devshard/cmd/devshardctl/`.

## Test plan

- [ ] `go test ./devshard/cmd/devshardctl/paramvalidators/` — package compiles + green.
- [ ] `go test ./devshard/cmd/devshardctl/...` — full suite green.

## Stacking

Based on `dl/devshards-gateway-to-main` HEAD `dd2f3fe31` (the #1202 merge). One test file: 1 import + 2 line changes.
