### PR TITLE
Handle fatal inference transport status errors

### DIFF
--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -15,6 +16,7 @@ import (
 
 	"devshard/host"
 	"devshard/state"
+	"devshard/transport"
 	"devshard/types"
 	"devshard/user"
 )
@@ -194,6 +196,9 @@ func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w
 func (p *Proxy) sendAndProcess(ctx context.Context, prepared *user.PreparedInference, nonce uint64) (finished bool, confirmedAt int64, err error) {
 	resp, sendErr := p.session.SendOnly(ctx, prepared)
 	if sendErr != nil && resp == nil {
+		if fatalHostSendError(sendErr) {
+			return false, 0, fmt.Errorf("send inference to host %d: %w", prepared.HostIdx(), sendErr)
+		}
 		return false, 0, nil
 	}
 
@@ -206,6 +211,19 @@ func (p *Proxy) sendAndProcess(ctx context.Context, prepared *user.PreparedInfer
 	}
 
 	return false, resp.ConfirmedAt, nil
+}
+
+func fatalHostSendError(err error) bool {
+	var statusErr *transport.HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+
+	switch statusErr.StatusCode {
+	case http.StatusRequestTimeout, http.StatusTooEarly, http.StatusTooManyRequests:
+		return false
+	}
+	return statusErr.StatusCode >= http.StatusBadRequest && statusErr.StatusCode < http.StatusInternalServerError
 }
 
 // sleepUntil blocks until deadline or context cancellation.
@@ -395,13 +413,13 @@ type statusResponse struct {
 // statusSessionConfig is the JSON representation of session config values
 // returned by the devshardctl status endpoint.
 type statusSessionConfig struct {
-	RefusalTimeout   int64  `json:"refusal_timeout"`
-	ExecutionTimeout int64  `json:"execution_timeout"`
-	TokenPrice       uint64 `json:"token_price"`
-	CreateDevshardFee  uint64 `json:"create_devshard_fee"`
-	FeePerNonce      uint64 `json:"fee_per_nonce"`
-	VoteThreshold    uint32 `json:"vote_threshold"`
-	ValidationRate   uint32 `json:"validation_rate"`
+	RefusalTimeout    int64  `json:"refusal_timeout"`
+	ExecutionTimeout  int64  `json:"execution_timeout"`
+	TokenPrice        uint64 `json:"token_price"`
+	CreateDevshardFee uint64 `json:"create_devshard_fee"`
+	FeePerNonce       uint64 `json:"fee_per_nonce"`
+	VoteThreshold     uint32 `json:"vote_threshold"`
+	ValidationRate    uint32 `json:"validation_rate"`
 }
 
 func (p *Proxy) handleDebugPending(w http.ResponseWriter, r *http.Request) {
@@ -498,13 +516,13 @@ func (p *Proxy) handleStatus(w http.ResponseWriter, r *http.Request) {
 		Phase:    phaseStr,
 		Balance:  st.Balance,
 		Config: statusSessionConfig{
-			RefusalTimeout:   cfg.RefusalTimeout,
-			ExecutionTimeout: cfg.ExecutionTimeout,
-			TokenPrice:       cfg.TokenPrice,
-			CreateDevshardFee:  cfg.CreateDevshardFee,
-			FeePerNonce:      cfg.FeePerNonce,
-			VoteThreshold:    cfg.VoteThreshold,
-			ValidationRate:   cfg.ValidationRate,
+			RefusalTimeout:    cfg.RefusalTimeout,
+			ExecutionTimeout:  cfg.ExecutionTimeout,
+			TokenPrice:        cfg.TokenPrice,
+			CreateDevshardFee: cfg.CreateDevshardFee,
+			FeePerNonce:       cfg.FeePerNonce,
+			VoteThreshold:     cfg.VoteThreshold,
+			ValidationRate:    cfg.ValidationRate,
 		},
 	}
 

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"devshard/signing"
 	"devshard/state"
 	"devshard/stub"
+	"devshard/transport"
 	"devshard/types"
 	"devshard/user"
 )
@@ -76,6 +78,61 @@ func TestHasMsgFinish(t *testing.T) {
 	txs = append(txs, &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{InferenceId: 1}}})
 	require.True(t, hasMsgFinish(txs, 1))
 	require.False(t, hasMsgFinish(txs, 2))
+}
+
+func TestFatalHostSendError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "bad request",
+			err:  &transport.HTTPStatusError{StatusCode: http.StatusBadRequest},
+			want: true,
+		},
+		{
+			name: "forbidden wrapped",
+			err:  fmt.Errorf("send failed: %w", &transport.HTTPStatusError{StatusCode: http.StatusForbidden}),
+			want: true,
+		},
+		{
+			name: "not found",
+			err:  &transport.HTTPStatusError{StatusCode: http.StatusNotFound},
+			want: true,
+		},
+		{
+			name: "request timeout is retryable",
+			err:  &transport.HTTPStatusError{StatusCode: http.StatusRequestTimeout},
+			want: false,
+		},
+		{
+			name: "too early is retryable",
+			err:  &transport.HTTPStatusError{StatusCode: http.StatusTooEarly},
+			want: false,
+		},
+		{
+			name: "rate limit is retryable",
+			err:  &transport.HTTPStatusError{StatusCode: http.StatusTooManyRequests},
+			want: false,
+		},
+		{
+			name: "server error uses timeout path",
+			err:  &transport.HTTPStatusError{StatusCode: http.StatusInternalServerError},
+			want: false,
+		},
+		{
+			name: "network error uses timeout path",
+			err:  fmt.Errorf("connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, fatalHostSendError(tt.err))
+		})
+	}
 }
 
 // --- Test infrastructure for proxy-level tests ---

--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -70,6 +70,22 @@ type HTTPClient struct {
 	config      ClientConfig
 }
 
+// HTTPStatusError reports a non-OK response from a devshard host while
+// preserving the status code for proxy retry/fatal classification.
+type HTTPStatusError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("http %s %s: status %d", e.Method, e.Path, e.StatusCode)
+	}
+	return fmt.Sprintf("http %s %s: status %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+}
+
 // NewHTTPClient creates an HTTP client for the devshard transport layer.
 // Uses shared transport for connection pooling, per-call context timeouts.
 func NewHTTPClient(baseURL, escrowID string, signer signing.Signer, cfgs ...ClientConfig) *HTTPClient {
@@ -384,7 +400,12 @@ func (c *HTTPClient) doPostRaw(ctx context.Context, path string, body []byte) (*
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("http %s: status %d: %s", path, resp.StatusCode, string(respBody))
+		return nil, &HTTPStatusError{
+			Method:     http.MethodPost,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Body:       string(respBody),
+		}
 	}
 
 	return resp, nil

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -2,7 +2,9 @@ package transport
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -80,6 +82,25 @@ func TestHTTPClient_Send_RoundTrip(t *testing.T) {
 		}
 	}
 	require.True(t, hasFinish, "mempool should contain MsgFinishInference")
+}
+
+func TestHTTPClient_Send_ReturnsHTTPStatusError(t *testing.T) {
+	userSigner := testutil.MustGenerateKey(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad signature", http.StatusForbidden)
+	}))
+	t.Cleanup(ts.Close)
+
+	client := NewHTTPClient(ts.URL, "escrow-1", userSigner)
+	_, err := client.Send(context.Background(), host.HostRequest{Nonce: 1})
+	require.Error(t, err)
+
+	var statusErr *HTTPStatusError
+	require.True(t, errors.As(err, &statusErr))
+	require.Equal(t, http.StatusForbidden, statusErr.StatusCode)
+	require.Equal(t, http.MethodPost, statusErr.Method)
+	require.Contains(t, statusErr.Path, "/sessions/escrow-1/chat/completions")
+	require.Contains(t, statusErr.Body, "bad signature")
 }
 
 func TestHTTPClient_GetDiffs(t *testing.T) {


### PR DESCRIPTION
## Summary
- add transport.HTTPStatusError so non-OK host responses preserve status code and body details
- classify fatal 4xx inference send failures in devshardctl and return them immediately instead of falling into timeout handling
- keep retryable statuses such as 408, 425, 429, and 5xx on the existing timeout/retry path

## Tests
- GOCACHE=/Users/ramen/Documents/GPT\ PAYING\ METHOD/gonka/.gocache GOMODCACHE=/Users/ramen/Documents/GPT\ PAYING\ METHOD/gonka/.gomodcache go test ./transport
- GOCACHE=/Users/ramen/Documents/GPT\ PAYING\ METHOD/gonka/.gocache GOMODCACHE=/Users/ramen/Documents/GPT\ PAYING\ METHOD/gonka/.gomodcache go test ./cmd/devshardctl

Closes #1019