### PR TITLE
fix(devshard): clamp Kimi-K2.6 max_tokens >= 16 to keep probe content non-empty

### DIFF
--- a/devshard/cmd/devshardctl/request_filters_config.go
+++ b/devshard/cmd/devshardctl/request_filters_config.go
@@ -69,11 +69,7 @@ const (
 	kimiThinkingTokenBudgetDefaultDivisor uint64 = 2
 	kimiThinkingTokenBudgetMax            uint64 = 96_000
 
-	// kimiMaxTokensMin is the lower bound for max_tokens / max_completion_tokens on Kimi-K2.6.
-	// Below this floor, the model emits only the closing </think> special token (which vLLM
-	// drops from message.content), so a probe-style request with max_tokens=1 produces an
-	// empty content field even though completion_tokens=1. Clamping up keeps probes valid
-	// without changing higher-volume client requests.
+	// Below this floor Kimi-K2.6 emits only </think> (special token vLLM drops from content).
 	kimiMaxTokensMin uint64 = 16
 )
 

--- a/devshard/cmd/devshardctl/request_filters_config.go
+++ b/devshard/cmd/devshardctl/request_filters_config.go
@@ -68,6 +68,13 @@ const (
 
 	kimiThinkingTokenBudgetDefaultDivisor uint64 = 2
 	kimiThinkingTokenBudgetMax            uint64 = 96_000
+
+	// kimiMaxTokensMin is the lower bound for max_tokens / max_completion_tokens on Kimi-K2.6.
+	// Below this floor, the model emits only the closing </think> special token (which vLLM
+	// drops from message.content), so a probe-style request with max_tokens=1 produces an
+	// empty content field even though completion_tokens=1. Clamping up keeps probes valid
+	// without changing higher-volume client requests.
+	kimiMaxTokensMin uint64 = 16
 )
 
 // Routed model identifiers. The catalog wires per-model behavior keyed on these strings.

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -232,6 +232,23 @@ func (h ClampUintToFieldParameterHandler) Apply(ctx *RequestFilterContext, param
 	return nil
 }
 
+// MinUintParameterHandler clamps a uint parameter UP to Min when the value is present
+// and below the floor. Pass-through when the field is absent or already >= Min.
+type MinUintParameterHandler struct {
+	Min uint64
+}
+
+func (h MinUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
+	value, ok := numericJSONValueAsUint64FromDocument(&ctx.Document, parameter.Name)
+	if !ok {
+		return nil
+	}
+	if value < h.Min {
+		ctx.Document.Set(parameter.Name, h.Min)
+	}
+	return nil
+}
+
 // ValidateUintParameterHandler rejects the request if the field is present but its value
 // cannot be parsed as a non-negative integer that fits in uint64. Pass-through when the
 // field is absent. Used for fields like `seed` where vLLM expects a uint64 and we want to
@@ -745,11 +762,27 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 					UnmatchedHandler: StripParameterHandler{},
 				}),
 		},
+		[]VLLMParameter{
+			// max_tokens / max_completion_tokens: clamp UP to kimiMaxTokensMin for Kimi-K2.6.
+			// Below the floor the model emits only </think> (a special token vLLM drops from
+			// message.content), so probes with max_tokens=1 produce empty content and get
+			// punished as if the node returned nothing. PreValidation stage so the bump lands
+			// before applyOutputTokenLimits (which only caps down) and before the
+			// thinking_token_budget defaulter (which derives ttb from max_tokens).
+			newParameter("max_tokens").
+				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
+					Models:  []string{kimiK26ModelID},
+					Handler: MinUintParameterHandler{Min: kimiMaxTokensMin},
+				}),
+			newParameter("max_completion_tokens").
+				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
+					Models:  []string{kimiK26ModelID},
+					Handler: MinUintParameterHandler{Min: kimiMaxTokensMin},
+				}),
+		},
 		newParameters([]string{
 			"model",
 			"stream",
-			"max_tokens",
-			"max_completion_tokens",
 			"skip_special_tokens",
 			"detokenize",
 			"parallel_tool_calls",

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -763,12 +763,8 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 				}),
 		},
 		[]VLLMParameter{
-			// max_tokens / max_completion_tokens: clamp UP to kimiMaxTokensMin for Kimi-K2.6.
-			// Below the floor the model emits only </think> (a special token vLLM drops from
-			// message.content), so probes with max_tokens=1 produce empty content and get
-			// punished as if the node returned nothing. PreValidation stage so the bump lands
-			// before applyOutputTokenLimits (which only caps down) and before the
-			// thinking_token_budget defaulter (which derives ttb from max_tokens).
+			// PreValidation so the floor lands before applyOutputTokenLimits (caps down) and the
+			// thinking_token_budget defaulter (derives ttb from max_tokens).
 			newParameter("max_tokens").
 				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
 					Models:  []string{kimiK26ModelID},

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -2101,60 +2102,32 @@ func TestNormalizeChatRequestThinkingTokenBudgetStrippedForOtherModelsEvenIfClie
 	require.NotContains(t, string(body), `thinking_token_budget`)
 }
 
-// max_tokens on Kimi-K2.6: clamped UP to kimiMaxTokensMin (16) so probes with
-// max_tokens=1 do not collapse into a sole </think> token (which vLLM drops from
-// message.content, presenting as empty content to clients).
-
-func TestNormalizeChatRequestKimiMaxTokensClampedFromBelowForProbe(t *testing.T) {
-	body, req, err := normalizeChatRequestForModel(
-		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":1,"thinking_token_budget":0}`),
-		kimiK26ModelID,
-	)
-	require.NoError(t, err)
-	require.Contains(t, string(body), `"max_tokens":16`)
-	require.EqualValues(t, 16, req.MaxTokens)
+func TestNormalizeChatRequestKimiMaxTokensClampedBelow(t *testing.T) {
+	for _, c := range []struct {
+		in, want uint64
+	}{
+		{1, 16}, {8, 16}, {16, 16}, {100, 100},
+	} {
+		body := fmt.Sprintf(`{"messages":[{"role":"user","content":"x"}],"max_tokens":%d,"thinking_token_budget":0}`, c.in)
+		out, req, err := normalizeChatRequestForModel([]byte(body), kimiK26ModelID)
+		require.NoError(t, err)
+		require.Contains(t, string(out), fmt.Sprintf(`"max_tokens":%d`, c.want))
+		require.Contains(t, string(out), `"thinking_token_budget":0`)
+		require.EqualValues(t, c.want, req.MaxTokens)
+	}
 }
 
-func TestNormalizeChatRequestKimiMaxTokensClampedFromBelowMidRange(t *testing.T) {
-	body, _, err := normalizeChatRequestForModel(
-		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":8}`),
-		kimiK26ModelID,
-	)
-	require.NoError(t, err)
-	require.Contains(t, string(body), `"max_tokens":16`)
-}
-
-func TestNormalizeChatRequestKimiMaxTokensAtFloorUnchanged(t *testing.T) {
-	body, _, err := normalizeChatRequestForModel(
-		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":16}`),
-		kimiK26ModelID,
-	)
-	require.NoError(t, err)
-	require.Contains(t, string(body), `"max_tokens":16`)
-}
-
-func TestNormalizeChatRequestKimiMaxTokensAboveFloorUnchanged(t *testing.T) {
-	body, _, err := normalizeChatRequestForModel(
-		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":100}`),
-		kimiK26ModelID,
-	)
-	require.NoError(t, err)
-	require.Contains(t, string(body), `"max_tokens":100`)
-}
-
-func TestNormalizeChatRequestKimiMaxCompletionTokensClampedFromBelow(t *testing.T) {
+func TestNormalizeChatRequestKimiMaxCompletionTokensClampedBelow(t *testing.T) {
 	body, req, err := normalizeChatRequestForModel(
 		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_completion_tokens":1}`),
 		kimiK26ModelID,
 	)
 	require.NoError(t, err)
 	require.Contains(t, string(body), `"max_completion_tokens":16`)
-	// applyOutputTokenLimits mirrors the value into req.MaxTokens (used downstream by the
-	// thinking_token_budget defaulter) even though only max_completion_tokens is on the wire.
 	require.EqualValues(t, 16, req.MaxTokens)
 }
 
-func TestNormalizeChatRequestKimiMaxTokensNotClampedForOtherModels(t *testing.T) {
+func TestNormalizeChatRequestMaxTokensNotClampedForOtherModels(t *testing.T) {
 	body, req, err := normalizeChatRequestForModel(
 		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":1}`),
 		"some/other-model",
@@ -2162,20 +2135,6 @@ func TestNormalizeChatRequestKimiMaxTokensNotClampedForOtherModels(t *testing.T)
 	require.NoError(t, err)
 	require.Contains(t, string(body), `"max_tokens":1`)
 	require.EqualValues(t, 1, req.MaxTokens)
-}
-
-// End-to-end probe scenario: original captured payload (max_tokens=1, thinking_token_budget=0)
-// gets bumped so the downstream defaulter sees max_tokens=16 and the resulting request
-// yields non-empty content from Kimi (verified manually on B300 mlnode-020 / vLLM 0.20.0).
-func TestNormalizeChatRequestKimiProbeRequestSurvivesNormalization(t *testing.T) {
-	body, req, err := normalizeChatRequestForModel(
-		[]byte(`{"messages":[{"role":"user","content":"Who are you?"}],"max_tokens":1,"thinking_token_budget":0}`),
-		kimiK26ModelID,
-	)
-	require.NoError(t, err)
-	require.Contains(t, string(body), `"max_tokens":16`)
-	require.Contains(t, string(body), `"thinking_token_budget":0`)
-	require.EqualValues(t, 16, req.MaxTokens)
 }
 
 // safety_identifier is forwarded to Kimi K2.6 (Moonshot consumes it for abuse tracking)

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -2101,6 +2101,83 @@ func TestNormalizeChatRequestThinkingTokenBudgetStrippedForOtherModelsEvenIfClie
 	require.NotContains(t, string(body), `thinking_token_budget`)
 }
 
+// max_tokens on Kimi-K2.6: clamped UP to kimiMaxTokensMin (16) so probes with
+// max_tokens=1 do not collapse into a sole </think> token (which vLLM drops from
+// message.content, presenting as empty content to clients).
+
+func TestNormalizeChatRequestKimiMaxTokensClampedFromBelowForProbe(t *testing.T) {
+	body, req, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":1,"thinking_token_budget":0}`),
+		kimiK26ModelID,
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"max_tokens":16`)
+	require.EqualValues(t, 16, req.MaxTokens)
+}
+
+func TestNormalizeChatRequestKimiMaxTokensClampedFromBelowMidRange(t *testing.T) {
+	body, _, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":8}`),
+		kimiK26ModelID,
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"max_tokens":16`)
+}
+
+func TestNormalizeChatRequestKimiMaxTokensAtFloorUnchanged(t *testing.T) {
+	body, _, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":16}`),
+		kimiK26ModelID,
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"max_tokens":16`)
+}
+
+func TestNormalizeChatRequestKimiMaxTokensAboveFloorUnchanged(t *testing.T) {
+	body, _, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":100}`),
+		kimiK26ModelID,
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"max_tokens":100`)
+}
+
+func TestNormalizeChatRequestKimiMaxCompletionTokensClampedFromBelow(t *testing.T) {
+	body, req, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_completion_tokens":1}`),
+		kimiK26ModelID,
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"max_completion_tokens":16`)
+	// applyOutputTokenLimits mirrors the value into req.MaxTokens (used downstream by the
+	// thinking_token_budget defaulter) even though only max_completion_tokens is on the wire.
+	require.EqualValues(t, 16, req.MaxTokens)
+}
+
+func TestNormalizeChatRequestKimiMaxTokensNotClampedForOtherModels(t *testing.T) {
+	body, req, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"x"}],"max_tokens":1}`),
+		"some/other-model",
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"max_tokens":1`)
+	require.EqualValues(t, 1, req.MaxTokens)
+}
+
+// End-to-end probe scenario: original captured payload (max_tokens=1, thinking_token_budget=0)
+// gets bumped so the downstream defaulter sees max_tokens=16 and the resulting request
+// yields non-empty content from Kimi (verified manually on B300 mlnode-020 / vLLM 0.20.0).
+func TestNormalizeChatRequestKimiProbeRequestSurvivesNormalization(t *testing.T) {
+	body, req, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"Who are you?"}],"max_tokens":1,"thinking_token_budget":0}`),
+		kimiK26ModelID,
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"max_tokens":16`)
+	require.Contains(t, string(body), `"thinking_token_budget":0`)
+	require.EqualValues(t, 16, req.MaxTokens)
+}
+
 // safety_identifier is forwarded to Kimi K2.6 (Moonshot consumes it for abuse tracking)
 // and silently stripped for every other model (no documented downstream consumer).
 func TestNormalizeChatRequestForwardsSafetyIdentifierForKimi(t *testing.T) {


### PR DESCRIPTION
Probes against Kimi-K2.6 with `max_tokens=1` (or any `max_tokens<16`) produce `content=null`: the model emits only `</think>`, which vLLM drops from `message.content` as a special token. Gateway then punishes the node as if it returned empty.

Fix: PreValidation `MinUintParameterHandler{Min: 16}` on `max_tokens` and `max_completion_tokens` for Kimi-K2.6. PreValidation stage so the bump lands before `applyOutputTokenLimits` (caps down only) and before the `thinking_token_budget` defaulter (which derives ttb from max_tokens).

Verified directly on B300 mlnode-020 (vLLM 0.20.0): original captured payload → `content=null`; same payload after normalization → `'我是</think>我是 Claude，由 Anthropic 开发的人工智能助手。'`.

## Test plan
- [x] Table-driven test on bounds (1→16, 8→16, 16→16, 100→100)
- [x] `max_completion_tokens` clamp
- [x] Non-Kimi passthrough
- [x] Full `devshardctl` suite passes