### PR TITLE
feat(sim): Cosmos SDK simulation + first-wave + V2 PoC chain (Phase 1+2+3 of #982)

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -1,0 +1,48 @@
+name: Simulation Smoke (manual)
+
+# Manual trigger only; simulation runs add ~5-15 min to CI cost.
+# Maintainers may add `pull_request` / `push` triggers when sim coverage is
+# considered worth gating on. See docs/simulation.md for context.
+#
+# To activate auto-triggers, replace the `workflow_dispatch:` block below with:
+#
+#   pull_request:
+#     branches:
+#       - '**'
+#   push:
+#     branches:
+#       - main
+#
+# Or keep manual-only and trigger via the Actions tab / `gh workflow run`.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sim-smoke:
+    runs-on: ubuntu-24.04
+    name: Run sim-smoke-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.2'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('inference-chain/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run sim-smoke-test
+        working-directory: inference-chain
+        run: make sim-smoke-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build versiond-build-docker testapp-server-build-docker
+.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build versiond-build-docker testapp-server-build-docker node-sim-smoke-test node-sim-full-test
 
 VERSION ?= $(shell git describe --always)
 DEVSHARD_VERSION ?= dev
@@ -21,6 +21,13 @@ api-build-docker:
 
 node-build-docker:
 	@make -C inference-chain build-docker SET_LATEST=1 $(if $(GENESIS_OVERRIDES_FILE),GENESIS_OVERRIDES_FILE=$(GENESIS_OVERRIDES_FILE),)
+
+# Simulation dispatchers (issue #982 Phase 1)
+node-sim-smoke-test:
+	@make -C inference-chain sim-smoke-test
+
+node-sim-full-test:
+	@make -C inference-chain sim-full-test
 
 mock-server-build-docker:
 	@echo "Building mock-server JAR file..."

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -10,22 +10,23 @@ its phased implementation.
 From repo root:
 
 ```bash
-make sim-smoke-test   # 50 blocks × 20 ops, ~15 min
-make sim-full-test    # 500 blocks × 200 ops, ~120 min (Phase 2+ recommended)
+make sim-smoke-test   # 50 blocks × 20 ops, ~10 s
+make sim-full-test    # 500 blocks × 200 ops, ~35 s (Phase 2+ recommended)
 ```
 
-Both targets enter the `inference-chain` module and run `go test -run
-TestFullAppSimulation` with the `sims` build tag. The `*_Postrun` tests
-(see Test inventory) are not invoked by these targets; they call `t.Skip`
-with the reason and only run when invoked directly via
-`go test -tags sims ./app/...` without a `-run` filter.
+Both targets enter the `inference-chain` module and run
+`TestFullAppSimulation` with the `sims` build tag; `sim-smoke-test` also
+runs `TestFullSimulation_x_Inference_Integrated` (per-op state assertions).
+The `*_Postrun` tests (see Test inventory) are not invoked by these
+targets; they call `t.Skip` with the reason and only run when invoked
+directly via `go test -tags sims ./app/...` without a `-run` filter.
 
 ## Run modes
 
 | Target | Blocks × Ops | Seeds | Wall-clock | When to use |
 |---|---|---|---|---|
-| `sim-smoke-test` | 50 × 20 | 1 (`-Seed=99`) | ~15 min | Pre-PR sanity check; CI via [`.github/workflows/simulation.yml`](../.github/workflows/simulation.yml) (`workflow_dispatch` only, not a required PR check) |
-| `sim-full-test` | 500 × 200 | 1 (`-Seed=99`) | ~120 min | After Phase 2 real ops land. Informative only when ops are not NoOpMsg stubs |
+| `sim-smoke-test` | 50 × 20 | 1 (`-Seed=99`) | ~10 s | Pre-PR sanity check; CI via [`.github/workflows/simulation.yml`](../.github/workflows/simulation.yml) (`workflow_dispatch` only, not a required PR check) |
+| `sim-full-test` | 500 × 200 | 1 (`-Seed=99`) | ~35 s | After Phase 2 real ops land. Informative only when ops are not NoOpMsg stubs |
 | direct `go test` (with `-Seed=N`) | per `-NumBlocks` / `-BlockSize` flags | 1 (the supplied `-Seed`) | depends | Reproducing a specific seed, debugging |
 | direct `go test` (no `-Seed`) | per flags | simsx `defaultSeeds` (37 seeds, parallel subtests) | depends | Broad coverage sweep |
 
@@ -57,7 +58,50 @@ Read by `simcli.GetSimulatorFlags()` in `app/sim_test.go:init`:
 | `-NumBlocks` | (unset) | Number of blocks per simulation. |
 | `-BlockSize` | (unset) | Number of ops attempted per block. |
 | `-Seed` | (unset; falls back to simsx defaultSeeds list) | Specific seed to use. Override for reproducing failures. |
+| `-GenesisTime` | `time.Now().Unix()` at process start | UNIX timestamp of the simulated genesis. The default is the **wall clock**, so it differs every process; pin it for cross-process reproducibility (see [Reproducibility](#reproducibility)). |
 | `-Verbose` | `false` | Verbose logging. |
+
+## Reproducibility
+
+A simulation run is a pure function of **two** inputs, not one: the RNG
+`-Seed` *and* `-GenesisTime`. Pinning `-Seed` alone is not enough.
+
+`gonka-ai/cosmos-sdk@v0.53.3-ps17` registers `-GenesisTime` with a default
+of `time.Now().Unix()` (`x/simulation/client/cli/flags.go:62`), evaluated
+once per process. The genesis timestamp flows through `AppStateRandomizedFn`
+into time-gated chain logic (gov/group voting windows, access cutoffs), so
+two runs of the same `-Seed` minutes apart produce a different `opsCount`
+and a different AppHash.
+
+`TestAppStateDeterminism` does not catch this — it runs the same seed
+several times *inside one process*, where `-GenesisTime` is already fixed.
+
+`make sim-smoke-test` / `make sim-full-test` pin `-GenesisTime` (see
+`inference-chain/Makefile`, `SIM_GENESIS_TIME`) so their AppHash is
+reproducible across machines and CI. When reproducing a run with a direct
+`go test`, pass the **same** `-GenesisTime` as the original, not just
+`-Seed`.
+
+## Validator set in long runs
+
+A Cosmos simulation needs a non-empty validator set every block, or simsx
+aborts the run (`x/simulation/simulate.go:266` — `t.Skip("empty validator
+set")`).
+
+`inference-chain`'s validator set is managed by the PoC flow:
+`SetComputeValidators` (`cosmos-sdk/x/staking/keeper/compute.go`) rebuilds it
+every epoch from compute results. The simulation does not run PoC, so it never
+refreshes the set — while cosmos `x/slashing` keeps downtime-jailing validators
+on the random vote-info simsx feeds each block. Left alone the bonded set
+drains linearly to zero (observed ~block 135 of a seed-99 run) and the run
+skips.
+
+`EnsureComputeValidators` (`x/inference/simulation/bootstrap.go`) bridges the
+gap: when the bonded validator count falls below a floor it feeds every
+validator back through `SetComputeValidators`, which un-jails and re-bonds them
+— mimicking production's per-epoch refresh. The x/inference op factories call
+it, so `sim-full-test` completes a real 500-block run. Faithfully simulating
+the full PoC validator rotation is separate, larger work.
 
 ## Expected output
 
@@ -174,6 +218,7 @@ docker run --rm --network host \
 | Test | What it checks | Status |
 |---|---|---|
 | `TestFullAppSimulation` | Top-level simsx run: random genesis → simulate → CheckExportSimulation | Green |
+| `TestFullSimulation_x_Inference_Integrated` | Smoke simsx run + post-run keeper-state assertions: StartInference/FinishInference/MsgValidation each reached state mutation | Green |
 | `TestAppImportExport_Postrun` | Export → fresh app InitGenesis → KV-store diff | **Skipped** (tracks fork bonded-pool issue, see TODO and gonka-ai/gonka#1153) |
 | `TestAppSimulationAfterImport_Postrun` | Export → fresh app InitChain → second simulation | **Skipped** (same fork issue + post-import simulation step not yet wired) |
 | `TestAppStateDeterminism` | 3 seeds × 3 attempts: identical AppHash | Green |
@@ -181,13 +226,16 @@ docker run --rm --network host \
 | `TestDisabledOpsSimModule_*` | Wrapper produces empty WeightedOperations for staking/distribution/wasm | Green |
 | `TestBankGenesisFix_SupplyRecomputed` | `fixBankGenesisState` makes Supply match Balances | Green |
 
-## Phase status (as of 2026-05-08)
+## Phase status
 
-- **Phase 1** (this issue): simsx migration, smoke/full Make targets, disabled
-  upstream ops, restored test semantics, fixBankGenesisState. **In progress.**
-- **Phase 2**: first-wave x/inference real ops (SubmitNewParticipant,
+`#982` defines a four-phase roadmap. Phases 1 and 2 are implemented; both
+`sim-smoke-test` and `sim-full-test` exercise real `x/inference` operations.
+
+- **Phase 1** — simsx migration, smoke/full Make targets, disabled upstream
+  ops, restored test semantics, `fixBankGenesisState`. **Done.**
+- **Phase 2** — first-wave `x/inference` real ops (SubmitNewParticipant,
   StartInference, FinishInference, Validation, ClaimRewards) replacing
-  NoOpMsg stubs. After this phase, `sim-full-test` produces meaningful signal.
+  NoOpMsg stubs. **Done.**
 - **Phase 3**: weight tuning, store decoders, custom invariants,
   parameter-edge fuzzing. PoC-state determinism beyond AppHash.
 - **Phase 4**: simulation operations for other custom modules (bls,

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -236,7 +236,181 @@ docker run --rm --network host \
 - **Phase 2** — first-wave `x/inference` real ops (SubmitNewParticipant,
   StartInference, FinishInference, Validation, ClaimRewards) replacing
   NoOpMsg stubs. **Done.**
-- **Phase 3**: weight tuning, store decoders, custom invariants,
-  parameter-edge fuzzing. PoC-state determinism beyond AppHash.
+- **Phase 3** — second-wave ops (Invalidate/Revalidate via failing
+  `MsgValidation` + revalidation votes; participant-self ops:
+  SubmitUnitOfComputePriceProposal, SubmitHardwareDiff,
+  SubmitNewUnfundedParticipant), store decoders, custom invariants,
+  realistic-frequency weight tuning, aggressive parameter-boundary
+  fuzzing, multi-seed triage. **Done.**
 - **Phase 4**: simulation operations for other custom modules (bls,
   bookkeeper, collateral, genesistransfer, restrictions, streamvesting).
+  Not yet implemented.
+
+## Parameter fuzzing (#982 Phase 3 bullet 5)
+
+Each sim run derives a deterministic seeded `*rand.Rand` from
+`simState.Seed` and applies it via
+`x/inference/simulation/MutateSimParams` to randomize the
+governance-mutable `Params` fields, pushing values to their
+`Params.Validate()` **boundaries** (not safe mid-ranges).
+`GenesisOnlyParams` (collateral_amount, model_init_params, ...) are NOT
+touched — issue wording specifies "mutable runtime params, not genesis".
+
+Three design rules (derived from the code, not from caution):
+
+1. **Economic params** (prices, vesting, fees, weight ratios) are pushed
+   to their `Validate()` boundaries — they are liveness-safe (an extreme
+   price just makes a tx fail gracefully) and stress the
+   accounting/invariant paths where findings #1265/#1269/#1273 live.
+2. **Timing params** (`EpochParams`) are widened but kept internally
+   consistent: `Validate()` does not enforce that PoC + validation stages
+   fit inside `EpochLength`, but the simulation requires it, so the floor
+   is held at the proven baseline (30) and stage durations are derived as
+   fractions of `EpochLength`.
+3. **Collateral slashing-activation levers** (`SlashFractionInvalid`,
+   `SlashFractionDowntime`, `DowntimeMissedPercentageThreshold`,
+   `GracePeriodEndEpoch`) are **NOT** fuzzed. The sim's upstream-validator
+   substrate runs at `Tokens=1` (an InitChain shrink hack, see
+   `app/sim_test.go::shrinkUpstreamStakingValidators`); ANY active slashing
+   zeroes `Tokens`+`DelegatorShares` → `x/slashing` `Unjail` divides 0/0 →
+   validators jail and never recover → the cometbft set drains and the run
+   SKIPs on "empty validator set". This is a sim-substrate limitation, not
+   a production constraint; those params are exercised by unit tests.
+
+Parameter **combinations** are exercised via corner profiles: ~1/4 of
+seeds drive every knob to its low boundary, ~1/4 to its high boundary,
+the rest spread independently — so corner-combination effects surface
+instead of averaging out. Same `-Seed=N` → same mutated params.
+
+### Fields fuzzed
+
+| Sub-struct | Field | Fuzz range | Note |
+|---|---|---|---|
+| EpochParams | `EpochLength` | [30, 120] | floor = proven baseline |
+| EpochParams | `PocStageDuration` | `EpochLength/5` (≥2) | derived, stays viable |
+| EpochParams | `PocValidationDuration` | `EpochLength/8` (≥1) | derived |
+| EpochParams | `InferencePruningEpochThreshold` | [1, 10] | |
+| ValidationParams | `MinRampUpMeasurements` | [1, 50] | |
+| ValidationParams | `ExpirationBlocks` | [5, 80] | |
+| ValidationParams | `MinValidationTrafficCutoff` | [0, 1000] | |
+| PocParams | `DefaultDifficulty` | [1, 20] | |
+| PocParams | `PocDataPruningEpochThreshold` | [1, 10] | |
+| FeeParams | `MinGasPriceNgonka` | [0, 5000] | |
+| FeeParams | `BaseValidationGas` | [500, 50000] | |
+| CollateralParams | `BaseWeightRatio` | [0, 1] | non-slashing |
+| CollateralParams | `CollateralPerWeightUnit` | [0, 100] | non-slashing |
+| TokenomicsParams | `WorkVestingPeriod` | [0, 360] | |
+| TokenomicsParams | `RewardVestingPeriod` | [0, 360] | |
+| DynamicPricingParams | `StabilityZoneLowerBound` | [0, 0.49] | `< upper` by construction |
+| DynamicPricingParams | `StabilityZoneUpperBound` | [0.51, 1.0] | |
+| DynamicPricingParams | `PriceElasticity` | [0.01, 1.0] | |
+| DynamicPricingParams | `UtilizationWindowDuration` | [1, 600] | |
+| DynamicPricingParams | `MinPerTokenPrice` | [1, 1000] | |
+| DynamicPricingParams | `BasePerTokenPrice` | [1, 2000] | |
+| DynamicPricingParams | `GracePeriodPerTokenPrice` | [0, 1000] | |
+| DynamicPricingParams | `GracePeriodEndEpoch` (pricing) | [0, 50] | pricing grace, not slashing |
+
+**Held at defaults (slashing-activation levers, see design rule 3):**
+`CollateralParams.{SlashFractionInvalid, SlashFractionDowntime,
+DowntimeMissedPercentageThreshold, GracePeriodEndEpoch}`.
+
+### Alternate initial values vs in-simulation governance flows
+
+#982 Phase 3 asks to decide *which* mutable params are varied by
+alternate initial values versus by in-simulation governance flows. The
+decision here: **all** mutable params are varied via alternate initial
+values (genesis fuzzing above). In-simulation governance-flow variation
+(submitting `MsgUpdateParams` mid-run) is **not** used, because
+`MsgUpdateParams` — like the participant allow-list messages
+(`AddParticipantsToAllowList` / `RemoveParticipantsFromAllowList`) — is
+authority-gated: its signer must be the gov module account, which has no
+private key, so a simsx factory cannot sign for it. Driving it would
+require the full x/gov proposal flow, and gonka does not register typed
+proposal-msg sim handlers for `x/inference`. Genesis fuzzing covers the
+same parameter space deterministically without that machinery.
+
+Consequently, **authority-gated ops are intentionally not factory-driven**
+(allow-list add/remove, `UpdateParams`). This is a coverage boundary, not
+an oversight — the same simsx signing constraint that blocks them is
+documented at the factory registration site (`module/simulation.go`).
+
+### Multi-seed triage protocol
+
+1. Run sim-full across at least 5 seeds. The Makefile pins `-Seed=99`,
+   so call `go test` directly:
+
+   ```bash
+   for seed in 1 7 32 99 123 256 1024; do
+     CGO_ENABLED=1 CGO_LDFLAGS="-L/lib/wasmvm-static" \
+       go test -mod=readonly -tags "sims muslc" -timeout 600s \
+       ./app/ -run "TestFullAppSimulation" \
+       -Enabled=true -NumBlocks=500 -BlockSize=200 \
+       -Seed=$seed -GenesisTime=1700000000 -Verbose=true \
+       2>&1 | tee /tmp/sim-full-seed-$seed.log
+   done
+   ```
+
+2. For each seed, record:
+   - Outcome: PASS / SKIP `<reason>` / FAIL `<block, op, msg>`
+   - Final height + opsCount (if PASS)
+   - Invariant fires (if any) — from `subsystem=Crisis` log entries or
+     post-run callback in `app/sim_test.go::checkInferenceInvariants`
+
+3. Triage recurring failures by pattern:
+   - **Same block × same op × same msg type** across seeds → real bug
+     (file Finding issue à la #1205)
+   - **Different block + SKIP `empty validator set`** across seeds →
+     sim-fragility (substrate / validator-drain — out of P3-B scope)
+   - **PASS on most, FAIL on outliers** → parameter edge case worth
+     investigating; document in P3-8 weight-tuning rationale
+
+### Custom invariants
+
+Registered via `x/inference/keeper/invariants.go::RegisterInvariants` and
+checked post-run in the sim harness:
+
+| Invariant | Checks |
+|---|---|
+| `bank-backs-positive-balance` | module account balance ≥ Σ positive participant CoinBalances (solvency) |
+| `no-stuck-voting` | no inference stuck in VOTING > 2 epochs past its own EpochId |
+| `effective-epoch-fresh` | effective epoch index is current |
+| `active-invalidations-ref-live` | every `ActiveInvalidations` entry references a live inference |
+
+Two invariants from an earlier iteration were **removed** after the
+multi-seed sweep proved them ill-specified (the fuzz caught our own bad
+invariants before they shipped):
+
+- `no-orphan-balance` (CoinBalance>0 ⟹ CurrentEpochStats activity>0) —
+  false premise: `shareWorkWithValidators` legitimately credits a
+  validator's CoinBalance without touching `CurrentEpochStats` (the
+  validation count increments the *executor*, not the validating
+  msg.Creator; the credit bypasses `AddToCoinBalance` so `EarnedCoins`
+  stays 0). The money is tracked by the bookkeeper and backed per
+  `bank-backs`.
+- `net-balance-bounded-by-work` (|Σ CoinBalance| ≤ Σ EarnedCoins this
+  epoch) — compares a cross-settle cumulative balance against a
+  per-epoch counter; `shareWork` redistribution + per-participant settle
+  resets break the equality legitimately. `bank-backs` is the sound
+  solvency check.
+
+### Multi-seed sweep
+
+37-seed default-seed-list sweep (no `-Seed`, `-NumBlocks=100
+-BlockSize=100`, `-GenesisTime` pinned). Of 33 seeds that complete (5
+SKIP early on the `empty validator set` substrate limit), **30 break
+`bank-backs-positive-balance`** — the module account ends under-funded
+relative to participant CoinBalances.
+
+**Root cause (seed=99, verbose trace):** the #1273 asymmetric invalidation
+refund. 16 invalidations each emit `Invalid Inference subtracted from
+Executor CoinBalance actualCost=N coinBalance=-N` — the executor is
+debited the full `ActualCost` (into debt) while the validators' work-shares
+are not reversed; the module, having refunded the client, is left short by
+~Σ validator-shares (~1.12M ngonka gap on seed=99). `spendable == total`
+on the module rules out a vesting artifact — genuine under-backing.
+
+This is the **strongest demonstration of #1273**: not a grace-period edge
+case but a solvency break on ~91% of completing seeds whenever
+invalidations occur. The harness will turn green here once #1273 is fixed
+upstream; until then the sweep is the regression signal for that fix.
+Posted to gonka-ai/gonka#1273.

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -1,0 +1,194 @@
+# Simulation and Fuzz Testing
+
+This document covers how to run, interpret, and extend Cosmos SDK simulation
+tests for `inference-chain`. It is the operator/developer reference for
+[issue gonka-ai/gonka#982](https://github.com/gonka-ai/gonka/issues/982) and
+its phased implementation.
+
+## Quick start
+
+From repo root:
+
+```bash
+make sim-smoke-test   # 50 blocks × 20 ops, ~15 min
+make sim-full-test    # 500 blocks × 200 ops, ~120 min (Phase 2+ recommended)
+```
+
+Both targets enter the `inference-chain` module and run `go test -run
+TestFullAppSimulation` with the `sims` build tag. The `*_Postrun` tests
+(see Test inventory) are not invoked by these targets; they call `t.Skip`
+with the reason and only run when invoked directly via
+`go test -tags sims ./app/...` without a `-run` filter.
+
+## Run modes
+
+| Target | Blocks × Ops | Seeds | Wall-clock | When to use |
+|---|---|---|---|---|
+| `sim-smoke-test` | 50 × 20 | 1 (`-Seed=99`) | ~15 min | Pre-PR sanity check; CI via [`.github/workflows/simulation.yml`](../.github/workflows/simulation.yml) (`workflow_dispatch` only, not a required PR check) |
+| `sim-full-test` | 500 × 200 | 1 (`-Seed=99`) | ~120 min | After Phase 2 real ops land. Informative only when ops are not NoOpMsg stubs |
+| direct `go test` (with `-Seed=N`) | per `-NumBlocks` / `-BlockSize` flags | 1 (the supplied `-Seed`) | depends | Reproducing a specific seed, debugging |
+| direct `go test` (no `-Seed`) | per flags | simsx `defaultSeeds` (37 seeds, parallel subtests) | depends | Broad coverage sweep |
+
+**Seed dispatch:** `TestFullAppSimulation` reads `-Seed` via `simcli.NewConfigFromFlags()`. When set, it calls `simsx.RunWithSeed` for a single-seed run (matches Make targets). When unset (CLI default sentinel), it falls through to `simsx.Run` which fans out the framework's default 37-seed list as parallel `t.Run("seed: N", ...)` subtests.
+
+## Build tags
+
+| Tag | Purpose |
+|---|---|
+| `sims` | Includes simulation test files (`sim_test.go`, `sim_bench_test.go`). Required for all simulation runs. |
+| `simsbench` | Includes benchmark variant (`BenchmarkFullAppSimulation`). Used for performance profiling, not correctness. |
+| `muslc` | Required when building under Alpine/musl (CI, canonical Docker). Links static `libwasmvm_muslc.x86_64.a`. |
+
+Combine with `,` or space:
+
+```bash
+go test -tags 'sims muslc' ./app/...                  # production-tag combo
+go test -tags 'sims simsbench muslc' ./app/...        # also picks up benchmark
+```
+
+## CLI flags
+
+Read by `simcli.GetSimulatorFlags()` in `app/sim_test.go:init`:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `-Enabled` | `false` | Master switch. Set to `true` to actually run simulation; without it the tests skip. |
+| `-Commit` | `false` | Commit blocks during simulation. Required for any meaningful run. |
+| `-NumBlocks` | (unset) | Number of blocks per simulation. |
+| `-BlockSize` | (unset) | Number of ops attempted per block. |
+| `-Seed` | (unset; falls back to simsx defaultSeeds list) | Specific seed to use. Override for reproducing failures. |
+| `-Verbose` | `false` | Verbose logging. |
+
+## Expected output
+
+Successful smoke run prints per-seed summaries:
+
+```
++++ DONE (seed: 99):
+... (operation stats per module)
+```
+
+A successful determinism run (`TestAppStateDeterminism`) is silent in
+non-verbose mode and exits 0. The test runs 3 seeds × 3 attempts each (9
+runs internally).
+
+A successful full run prints the same per-seed summary plus
+`PrintStats(testInstance.DB)` output (db-level statistics) when `-Commit=true`.
+
+## Failure interpretation
+
+### Determinism failure
+
+```
+non-determinism in seed N: attempt 0 vs M
+```
+
+Different AppHash across attempts of the same seed. Common causes:
+
+- Go map iteration in keeper code (use `Iterate` with `PrefixedPairRange`).
+- `time.Now()` or other system-clock reads in state code.
+- RNG used outside the `r *rand.Rand` provided by simulation.
+- Floating-point arithmetic in state code (use `shopspring/decimal`).
+
+Capture the failing seed and re-run `TestAppStateDeterminism` with `-Seed=N`
+to isolate it. The test honors `-Seed` and overrides its internal triplet
+(`defaultSimSeeds`) when a non-default seed is passed:
+
+```bash
+cd inference-chain
+go test -mod=readonly -tags 'sims muslc' \
+    -run TestAppStateDeterminism ./app/... \
+    -Enabled=true -Commit=true -Seed=42 -v
+```
+
+### Bonded-pool panic on import
+
+```
+panic: bonded pool balance is different from bonded coins:  <-> NNNNstake
+  at gonka-ai/cosmos-sdk@v0.53.3-ps17/x/staking/keeper/genesis.go:158
+```
+
+This is a **known fork-level inconsistency**, not a bug in the simulation.
+`TestAppImportExport_Postrun` and `TestAppSimulationAfterImport_Postrun`
+hit this panic by design; see the TODO blocks above each test in
+`app/sim_test.go`.
+
+Production avoids this path by using `x/upgrade` in-place handlers
+(`app/upgrades/v0_2_*`) rather than vanilla `inferenced export → init`.
+
+### Linker error: cannot find -lwasmvm_muslc.x86_64
+
+When running outside the canonical Docker:
+
+```
+ld: cannot find -lwasmvm_muslc.x86_64: No such file or directory
+```
+
+The static lib name MUST include the architecture suffix exactly:
+`libwasmvm_muslc.x86_64.a` (not `libwasmvm_muslc.a`). Download from
+[CosmWasm/wasmvm releases](https://github.com/CosmWasm/wasmvm/releases),
+match version with `inference-chain/go.mod`.
+
+## Reproducing failing seeds
+
+Smoke run prints `seed: N` for each parallelised sub-test. Re-run a single
+seed:
+
+```bash
+cd inference-chain
+go test -mod=readonly -tags 'sims muslc' \
+    -run 'TestFullAppSimulation/seed:_<N>' ./app/ \
+    -Enabled=true -Commit=true -NumBlocks=50 -BlockSize=20 -v
+```
+
+For `TestAppStateDeterminism`, the seed appears in the failure message
+directly.
+
+## Canonical Docker run
+
+Local environments often have ABI mismatches with `bytedance/sonic` or
+missing wasmvm libs. Canonical run uses Alpine + musl + static wasmvm. The
+`WASMVM_VERSION` is derived inside the container from `inference-chain/go.mod`
+so it stays in sync with the dependency:
+
+```bash
+docker run --rm --network host \
+  -v "$PWD":/src -w /src/inference-chain \
+  -v "$HOME/go/pkg/mod":/go/pkg/mod \
+  golang:1.24.2-alpine3.20 sh -c '
+    apk add --no-cache gcc musl-dev curl &&
+    WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v2 | awk "{print \$2}") &&
+    mkdir -p /lib/wasmvm-static &&
+    curl -sL -o /lib/wasmvm-static/libwasmvm_muslc.x86_64.a \
+      "https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.x86_64.a" &&
+    CGO_ENABLED=1 CGO_LDFLAGS="-L/lib/wasmvm-static" \
+      go test -mod=readonly -tags "sims muslc" ./app/...
+  '
+```
+
+`--network host` is required because Docker bridge often timeouts to
+`github.com` when downloading wasmvm.
+
+## Test inventory
+
+| Test | What it checks | Status |
+|---|---|---|
+| `TestFullAppSimulation` | Top-level simsx run: random genesis → simulate → CheckExportSimulation | Green |
+| `TestAppImportExport_Postrun` | Export → fresh app InitGenesis → KV-store diff | **Skipped** (tracks fork bonded-pool issue, see TODO and gonka-ai/gonka#1153) |
+| `TestAppSimulationAfterImport_Postrun` | Export → fresh app InitChain → second simulation | **Skipped** (same fork issue + post-import simulation step not yet wired) |
+| `TestAppStateDeterminism` | 3 seeds × 3 attempts: identical AppHash | Green |
+| `TestApp_GenesisInit_*` | Genesis init produces blocked module accounts + PoC validators | Green |
+| `TestDisabledOpsSimModule_*` | Wrapper produces empty WeightedOperations for staking/distribution/wasm | Green |
+| `TestBankGenesisFix_SupplyRecomputed` | `fixBankGenesisState` makes Supply match Balances | Green |
+
+## Phase status (as of 2026-05-08)
+
+- **Phase 1** (this issue): simsx migration, smoke/full Make targets, disabled
+  upstream ops, restored test semantics, fixBankGenesisState. **In progress.**
+- **Phase 2**: first-wave x/inference real ops (SubmitNewParticipant,
+  StartInference, FinishInference, Validation, ClaimRewards) replacing
+  NoOpMsg stubs. After this phase, `sim-full-test` produces meaningful signal.
+- **Phase 3**: weight tuning, store decoders, custom invariants,
+  parameter-edge fuzzing. PoC-state determinism beyond AppHash.
+- **Phase 4**: simulation operations for other custom modules (bls,
+  bookkeeper, collateral, genesistransfer, restrictions, streamvesting).

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -318,18 +318,24 @@ proto:
 
 SIM_PKG := ./app/
 
+# -GenesisTime is pinned: gonka-ai/cosmos-sdk registers it with a
+# time.Now() default (x/simulation/client/cli/flags.go:62), so an unpinned
+# run is reproducible only within a single process. Pinning it alongside
+# -Seed makes the AppHash reproducible across machines and CI runs.
+SIM_GENESIS_TIME := 1700000000
+
 sim-smoke-test:
-	@echo "--> Running smoke simulation: 50 blocks x 20 ops/block (~15 min)"
-	@go test -mod=readonly -tags sims $(SIM_PKG) \
-		-run TestFullAppSimulation \
+	@echo "--> Running smoke simulation: 50 blocks x 20 ops/block (~10 s)"
+	@go test -mod=readonly -tags "sims muslc" $(SIM_PKG) \
+		-run 'TestFullAppSimulation|TestFullSimulation_x_Inference_Integrated' \
 		-Enabled=true -Commit=true \
-		-NumBlocks=50 -BlockSize=20 -Seed=99 \
+		-NumBlocks=50 -BlockSize=20 -Seed=99 -GenesisTime=$(SIM_GENESIS_TIME) \
 		-v -timeout 30m
 
 sim-full-test:
-	@echo "--> Running full simulation: 500 blocks x 200 ops/block (~120 min)"
-	@go test -mod=readonly -tags sims $(SIM_PKG) \
+	@echo "--> Running full simulation: 500 blocks x 200 ops/block (~35 s)"
+	@go test -mod=readonly -tags "sims muslc" $(SIM_PKG) \
 		-run TestFullAppSimulation \
 		-Enabled=true -Commit=true \
-		-NumBlocks=500 -BlockSize=200 -Seed=99 \
+		-NumBlocks=500 -BlockSize=200 -Seed=99 -GenesisTime=$(SIM_GENESIS_TIME) \
 		-v -timeout 180m

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install build build-docker init clean-state mock-expected-keepers docker-push release build-all package deploy proto
+.PHONY: all install build build-docker init clean-state mock-expected-keepers docker-push release build-all package deploy proto sim-smoke-test sim-full-test
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
@@ -310,3 +310,26 @@ mock-expected-keepers:
 
 proto:
 	ignite generate proto-go
+
+#################################################
+# SIMULATION SECTION (issue #982 Phase 1)
+#################################################
+# Targets are no-ops until TestFullAppSimulation lands in Phase 1 item 1.A (sim_test.go migration).
+
+SIM_PKG := ./app/
+
+sim-smoke-test:
+	@echo "--> Running smoke simulation: 50 blocks x 20 ops/block (~15 min)"
+	@go test -mod=readonly -tags sims $(SIM_PKG) \
+		-run TestFullAppSimulation \
+		-Enabled=true -Commit=true \
+		-NumBlocks=50 -BlockSize=20 -Seed=99 \
+		-v -timeout 30m
+
+sim-full-test:
+	@echo "--> Running full simulation: 500 blocks x 200 ops/block (~120 min)"
+	@go test -mod=readonly -tags sims $(SIM_PKG) \
+		-run TestFullAppSimulation \
+		-Enabled=true -Commit=true \
+		-NumBlocks=500 -BlockSize=200 -Seed=99 \
+		-v -timeout 180m

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -333,9 +333,9 @@ sim-smoke-test:
 		-v -timeout 30m
 
 sim-full-test:
-	@echo "--> Running full simulation: 500 blocks x 200 ops/block (~35 s)"
+	@echo "--> Running full simulation: 500 blocks x 200 ops/block"
 	@go test -mod=readonly -tags "sims muslc" $(SIM_PKG) \
-		-run TestFullAppSimulation \
+		-run 'TestFullAppSimulation|TestFullSimulation_x_Inference_Integrated' \
 		-Enabled=true -Commit=true \
 		-NumBlocks=500 -BlockSize=200 -Seed=99 -GenesisTime=$(SIM_GENESIS_TIME) \
 		-v -timeout 180m

--- a/inference-chain/app/app.go
+++ b/inference-chain/app/app.go
@@ -58,6 +58,7 @@ import (
 	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	group "github.com/cosmos/cosmos-sdk/x/group"
 	groupkeeper "github.com/cosmos/cosmos-sdk/x/group/keeper"
 	_ "github.com/cosmos/cosmos-sdk/x/group/module" // import for side-effects
 	_ "github.com/cosmos/cosmos-sdk/x/mint"         // import for side-effects
@@ -324,8 +325,9 @@ func New(
 	//
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing transactions
 	//
-	// staking/distribution/wasmd weighted ops are disabled - see app/simulation.go
-	// for rationale. Genesis state generation is preserved via Go embedding.
+	// staking/distribution/wasmd/group weighted ops are disabled - see
+	// app/simulation.go for rationale. Genesis state generation is preserved
+	// via Go embedding.
 	mustSimMod := func(name string) module.AppModuleSimulation {
 		sm, ok := app.ModuleManager.Modules[name].(module.AppModuleSimulation)
 		if !ok {
@@ -336,11 +338,13 @@ func New(
 	stakingSimMod := mustSimMod(stakingtypes.ModuleName)
 	distrSimMod := mustSimMod(distrtypes.ModuleName)
 	wasmSimMod := mustSimMod(wasmtypes.ModuleName)
+	groupSimMod := mustSimMod(group.ModuleName)
 	overrideModules := map[string]module.AppModuleSimulation{
 		authtypes.ModuleName:    auth.NewAppModule(app.appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
 		stakingtypes.ModuleName: disabledOpsSimModule{stakingSimMod},
 		distrtypes.ModuleName:   disabledOpsSimModule{distrSimMod},
 		wasmtypes.ModuleName:    disabledOpsSimModule{wasmSimMod},
+		group.ModuleName:        disabledOpsSimModule{groupSimMod},
 	}
 	app.sm = module.NewSimulationManagerFromAppModules(app.ModuleManager.Modules, overrideModules)
 	app.sm.RegisterStoreDecoders()

--- a/inference-chain/app/app.go
+++ b/inference-chain/app/app.go
@@ -51,6 +51,7 @@ import (
 	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	_ "github.com/cosmos/cosmos-sdk/x/distribution" // import for side-effects
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
@@ -69,6 +70,7 @@ import (
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	_ "github.com/cosmos/cosmos-sdk/x/staking" // import for side-effects
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	_ "github.com/cosmos/ibc-go/modules/capability" // import for side-effects
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
@@ -321,8 +323,24 @@ func New(
 	// create the simulation manager and define the order of the modules for deterministic simulations
 	//
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing transactions
+	//
+	// staking/distribution/wasmd weighted ops are disabled - see app/simulation.go
+	// for rationale. Genesis state generation is preserved via Go embedding.
+	mustSimMod := func(name string) module.AppModuleSimulation {
+		sm, ok := app.ModuleManager.Modules[name].(module.AppModuleSimulation)
+		if !ok {
+			panic(fmt.Sprintf("module %q is missing or does not implement module.AppModuleSimulation: cannot wrap with disabledOpsSimModule", name))
+		}
+		return sm
+	}
+	stakingSimMod := mustSimMod(stakingtypes.ModuleName)
+	distrSimMod := mustSimMod(distrtypes.ModuleName)
+	wasmSimMod := mustSimMod(wasmtypes.ModuleName)
 	overrideModules := map[string]module.AppModuleSimulation{
-		authtypes.ModuleName: auth.NewAppModule(app.appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
+		authtypes.ModuleName:    auth.NewAppModule(app.appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
+		stakingtypes.ModuleName: disabledOpsSimModule{stakingSimMod},
+		distrtypes.ModuleName:   disabledOpsSimModule{distrSimMod},
+		wasmtypes.ModuleName:    disabledOpsSimModule{wasmSimMod},
 	}
 	app.sm = module.NewSimulationManagerFromAppModules(app.ModuleManager.Modules, overrideModules)
 	app.sm.RegisterStoreDecoders()
@@ -433,6 +451,18 @@ func (app *App) GetCapabilityScopedKeeper(moduleName string) capabilitykeeper.Sc
 // SimulationManager implements the SimulationApp interface.
 func (app *App) SimulationManager() *module.SimulationManager {
 	return app.sm
+}
+
+// TxConfig returns the App's TxConfig.
+// Implements simsx.SimulationApp interface required by simsx.Run.
+func (app *App) TxConfig() client.TxConfig {
+	return app.txConfig
+}
+
+// GetBaseApp returns the underlying *baseapp.BaseApp.
+// Implements simsx.SimulationApp interface required by simsx.Run.
+func (app *App) GetBaseApp() *baseapp.BaseApp {
+	return app.BaseApp
 }
 
 // RegisterAPIRoutes registers all application module routes with the provided

--- a/inference-chain/app/genesis_test.go
+++ b/inference-chain/app/genesis_test.go
@@ -1,0 +1,81 @@
+package app_test
+
+import (
+	"slices"
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApp_GenesisInit_ModuleAccountsAndPoCValidators verifies four
+// properties after a fresh InitGenesis on an app where staking,
+// distribution, and wasmd are wrapped in disabledOpsSimModule:
+//
+//	(a) InitGenesis runs without panic. Implicit: if it panicked,
+//	    createTestApp would not return.
+//	(b) The five blocked module accounts are populated (app_config.go
+//	    blockedModuleAccountAddrs).
+//	(c) New validators can be added via the gonka PoC compute path
+//	    (StakingKeeper.SetComputeValidators), since vanilla Cosmos token
+//	    delegation is disabled in this fork (docs/cosmos_changes.md).
+//	(d) The fee collector is a usable ModuleAccount, not a bare
+//	    BaseAccount.
+//
+// Reuses createTestApp from tally_integration_test.go (PR #496).
+// Subtests share testApp and ctx from the outer scope; one of them
+// mutates state via SetComputeValidators, so failures are isolated per
+// subtest but state is not.
+func TestApp_GenesisInit_ModuleAccountsAndPoCValidators(t *testing.T) {
+	testApp := createTestApp(t)
+	ctx := testApp.BaseApp.NewUncachedContext(false, cmtproto.Header{ChainID: TallyTestChainID, Height: 1})
+
+	t.Run("blocked module accounts populated", func(t *testing.T) {
+		blocked := []string{
+			authtypes.FeeCollectorName,
+			distrtypes.ModuleName,
+			minttypes.ModuleName,
+			stakingtypes.BondedPoolName,
+			stakingtypes.NotBondedPoolName,
+		}
+		for _, name := range blocked {
+			t.Run(name, func(t *testing.T) {
+				addr := testApp.AccountKeeper.GetModuleAddress(name)
+				require.NotNil(t, addr, "GetModuleAddress(%s) should not be nil", name)
+				acct := testApp.AccountKeeper.GetAccount(ctx, addr)
+				require.NotNil(t, acct, "module account %s should exist after InitGenesis", name)
+			})
+		}
+	})
+
+	t.Run("PoC compute validator can be added", func(t *testing.T) {
+		pocPub := ed25519.GenPrivKey().PubKey()
+		pocOpAddr := sdk.ValAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+		pocResults := []stakingkeeper.ComputeResult{{
+			Power:           100,
+			ValidatorPubKey: pocPub,
+			OperatorAddress: pocOpAddr,
+		}}
+
+		postPoC, err := testApp.StakingKeeper.SetComputeValidators(ctx, pocResults, true /* isTestnet */)
+		require.NoError(t, err)
+		require.True(t, slices.ContainsFunc(postPoC, func(v stakingtypes.Validator) bool {
+			return v.OperatorAddress == pocOpAddr && v.IsBonded()
+		}), "PoC compute validator must be present and bonded after SetComputeValidators")
+	})
+
+	t.Run("fee collector is ModuleAccount", func(t *testing.T) {
+		feeAddr := testApp.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+		feeAcct := testApp.AccountKeeper.GetAccount(ctx, feeAddr)
+		_, isModAcct := feeAcct.(sdk.ModuleAccountI)
+		require.True(t, isModAcct, "fee collector should implement ModuleAccountI")
+	})
+}

--- a/inference-chain/app/sdk_config.go
+++ b/inference-chain/app/sdk_config.go
@@ -1,0 +1,36 @@
+package app
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// CoinType is the SLIP-44 coin type used for HD key derivation on the Gonka chain.
+const CoinType = 1200
+
+// InitSDKConfig sets the chain's bech32 prefixes and coin type on the
+// global sdk.Config. Idempotent. Does not seal; production callers must
+// call SealSDKConfig after this.
+//
+// Tests call this without sealing so per-test helpers like createTestApp
+// can re-set the same prefixes from package init scope under the sims
+// build tag without hitting the sealed-config panic.
+func InitSDKConfig() {
+	accountPubKeyPrefix := AccountAddressPrefix + "pub"
+	validatorAddressPrefix := AccountAddressPrefix + "valoper"
+	validatorPubKeyPrefix := AccountAddressPrefix + "valoperpub"
+	consNodeAddressPrefix := AccountAddressPrefix + "valcons"
+	consNodePubKeyPrefix := AccountAddressPrefix + "valconspub"
+
+	config := sdk.GetConfig()
+	config.SetCoinType(CoinType) // TODO: change to custom coin type
+	config.SetBech32PrefixForAccount(AccountAddressPrefix, accountPubKeyPrefix)
+	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
+	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)
+}
+
+// SealSDKConfig seals the global sdk.Config so subsequent SetBech32 or
+// SetCoinType calls panic. Production callers (cmd/inferenced) call this
+// after InitSDKConfig at startup so address parsing stays strict for
+// the lifetime of the process. Tests do not call it; sealing breaks
+// createTestApp and other helpers that re-set prefixes per test.
+func SealSDKConfig() {
+	sdk.GetConfig().Seal()
+}

--- a/inference-chain/app/setup_test.go
+++ b/inference-chain/app/setup_test.go
@@ -1,0 +1,20 @@
+package app_test
+
+import (
+	"os"
+	"testing"
+
+	inferencemodule "github.com/productscience/inference/x/inference/module"
+)
+
+// TestMain enables a test-only escape hatch in x/inference/module that
+// suppresses the "denom <X> already registered" panic from
+// sdk.RegisterDenom when multiple tests in this package each spin up a
+// fresh *app.App via createTestApp, NewSimApp, or
+// NewSimulationAppInstance. `go test` compiles each package to its own
+// binary so the flag dies with the process; production semantics (flag
+// default=false) are unaffected. See x/inference/module/genesis.go:16-22.
+func TestMain(m *testing.M) {
+	inferencemodule.IgnoreDuplicateDenomRegistration = true
+	os.Exit(m.Run())
+}

--- a/inference-chain/app/setup_test.go
+++ b/inference-chain/app/setup_test.go
@@ -13,7 +13,7 @@ import (
 // fresh *app.App via createTestApp, NewSimApp, or
 // NewSimulationAppInstance. `go test` compiles each package to its own
 // binary so the flag dies with the process; production semantics (flag
-// default=false) are unaffected. See x/inference/module/genesis.go:16-22.
+// default=false) are unaffected. See x/inference/module/genesis.go.
 func TestMain(m *testing.M) {
 	inferencemodule.IgnoreDuplicateDenomRegistration = true
 	os.Exit(m.Run())

--- a/inference-chain/app/sim_bench_test.go
+++ b/inference-chain/app/sim_bench_test.go
@@ -1,155 +1,33 @@
+//go:build simsbench
+
 package app_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/server"
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
-	"github.com/stretchr/testify/require"
-
-	"github.com/productscience/inference/app"
 )
 
+// BenchmarkFullAppSimulation profiles a single full-simulation run.
+//
+// A full simulation takes minutes, so b.N looping is not meaningful and
+// the benchmark is single-iteration. Pass `-benchtime=1x`. Per-iteration
+// metrics (ns/op, allocs/op) are not useful; this benchmark exists for
+// `-cpuprofile`, `-memprofile`, and `-trace`.
+//
 // Profile with:
-// `go test -benchmem -run=^$ -bench ^BenchmarkFullAppSimulation ./app -Commit=true -cpuprofile cpu.out`
+//
+//	go test -tags 'sims simsbench' -run=^$ \
+//	    github.com/productscience/inference/app \
+//	    -bench ^BenchmarkFullAppSimulation$ -benchtime=1x -cpuprofile cpu.out
 func BenchmarkFullAppSimulation(b *testing.B) {
-	b.ReportAllocs()
-
 	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
+	config.ChainID = simsx.SimAppChainID
 
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "goleveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if err != nil {
-		b.Fatalf("simulation setup failed: %s", err.Error())
+	seed := config.Seed
+	if seed == simcli.DefaultSeedValue {
+		seed = defaultSimSeeds[0]
 	}
-
-	if skip {
-		b.Skip("skipping benchmark application simulation")
-	}
-
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, interBlockCacheOpt())
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	if err = simtestutil.CheckExportSimulation(bApp, config, simParams); err != nil {
-		b.Fatal(err)
-	}
-
-	if simErr != nil {
-		b.Fatal(simErr)
-	}
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-}
-
-func BenchmarkInvariants(b *testing.B) {
-	b.ReportAllocs()
-
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-invariant-bench", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if err != nil {
-		b.Fatalf("simulation setup failed: %s", err.Error())
-	}
-
-	if skip {
-		b.Skip("skipping benchmark application simulation")
-	}
-
-	config.AllInvariants = false
-
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, interBlockCacheOpt())
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	if err = simtestutil.CheckExportSimulation(bApp, config, simParams); err != nil {
-		b.Fatal(err)
-	}
-
-	if simErr != nil {
-		b.Fatal(simErr)
-	}
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-
-	ctx := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight() + 1})
-
-	// 3. Benchmark each invariant separately
-	//
-	// NOTE: We use the crisis keeper as it has all the invariants registered with
-	// their respective metadata which makes it useful for testing/benchmarking.
-	for _, cr := range bApp.CrisisKeeper.Routes() {
-		cr := cr
-		b.Run(fmt.Sprintf("%s/%s", cr.ModuleName, cr.Route), func(b *testing.B) {
-			if res, stop := cr.Invar(ctx); stop {
-				b.Fatalf(
-					"broken invariant at block %d of %d\n%s",
-					ctx.BlockHeight()-1, config.NumBlocks, res,
-				)
-			}
-		})
-	}
+	simsx.RunWithSeed(b, config, NewSimApp, setupStateFactory, seed, nil)
 }

--- a/inference-chain/app/sim_inference_test.go
+++ b/inference-chain/app/sim_inference_test.go
@@ -1,0 +1,92 @@
+//go:build sims
+
+package app_test
+
+import (
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/app"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
+)
+
+// TestFullSimulation_x_Inference_Integrated runs the smoke simulation and
+// asserts — by inspecting keeper state after the run — that the Phase 2
+// first-wave x/inference operations actually mutate chain state, not just
+// get delivered as txs.
+//
+// Why state inspection rather than the simsx report: the `+++ DONE` report
+// exposes a single combined `inference_completed` counter for all five
+// inference ops and itemises only *skips*, so it cannot show per-op success.
+// The keeper's Inferences collection is the ground truth.
+//
+// Asserted (one signal per op, each reachable only through that op's
+// state-mutating path):
+//   - StartInference  -> inferences with AssignedTo set (StartProcessed).
+//   - FinishInference -> inferences with ExecutedBy set (FinishedProcessed,
+//     types/inference.go).
+//   - MsgValidation   -> inferences in VALIDATED status, set only by the
+//     passing branch at msg_server_validation.go.
+//
+// Not asserted, by design:
+//   - MsgSubmitNewParticipant is idempotent; sim accounts are already
+//     genesis participants (BuildSimGenesisParticipants), so it takes the
+//     no-op update path and leaves no distinguishing state.
+//   - MsgClaimRewards runs against EffectiveEpochIndex=0, where the handler
+//     returns a graceful response without mutating state
+//     (msg_server_claim_rewards.go).
+//
+// Both ops are still exercised by the run — they have no state
+// fingerprint to assert on.
+//
+// Seed dispatch mirrors TestFullAppSimulation. Run via `make sim-smoke-test`,
+// which pins -Seed and -GenesisTime (see docs/simulation.md §Reproducibility).
+func TestFullSimulation_x_Inference_Integrated(t *testing.T) {
+	if !simcli.FlagEnabledValue {
+		t.Skip("pass -Enabled=true to run this; e.g. via make sim-smoke-test")
+	}
+	cfg := simcli.NewConfigFromFlags()
+	cfg.ChainID = simsx.SimAppChainID
+
+	assertInferenceLifecycle := func(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+		tb.Helper()
+		bApp := ti.App
+		ctx := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
+
+		infs, err := bApp.InferenceKeeper.GetAllInference(ctx)
+		require.NoError(tb, err)
+
+		var startProcessed, finishProcessed, validated int
+		for _, inf := range infs {
+			if inf.AssignedTo != "" {
+				startProcessed++
+			}
+			if inf.ExecutedBy != "" {
+				finishProcessed++
+			}
+			if inf.Status == inferencetypes.InferenceStatus_VALIDATED {
+				validated++
+			}
+		}
+		tb.Logf("x/inference lifecycle: total=%d startProcessed=%d finishProcessed=%d validated=%d",
+			len(infs), startProcessed, finishProcessed, validated)
+
+		require.Positivef(tb, startProcessed,
+			"MsgStartInference never reached SetInference (no inference has AssignedTo set)")
+		require.Positivef(tb, finishProcessed,
+			"MsgFinishInference never reached state mutation (no inference has ExecutedBy set)")
+		require.Positivef(tb, validated,
+			"MsgValidation never reached its passing-branch state mutation (no VALIDATED inference)")
+	}
+
+	if cfg.Seed != simcli.DefaultSeedValue {
+		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil, assertInferenceLifecycle)
+		return
+	}
+	simsx.Run(t, NewSimApp, setupStateFactory, assertInferenceLifecycle)
+}

--- a/inference-chain/app/sim_inference_test.go
+++ b/inference-chain/app/sim_inference_test.go
@@ -127,8 +127,8 @@ func TestFullSimulation_x_Inference_Integrated(t *testing.T) {
 	}
 
 	if cfg.Seed != simcli.DefaultSeedValue {
-		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil, assertInferenceLifecycle)
+		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil, assertInferenceLifecycle, checkInferenceInvariants)
 		return
 	}
-	simsx.Run(t, NewSimApp, setupStateFactory, assertInferenceLifecycle)
+	simsx.Run(t, NewSimApp, setupStateFactory, assertInferenceLifecycle, checkInferenceInvariants)
 }

--- a/inference-chain/app/sim_inference_test.go
+++ b/inference-chain/app/sim_inference_test.go
@@ -32,6 +32,15 @@ import (
 //     types/inference.go).
 //   - MsgValidation   -> inferences in VALIDATED status, set only by the
 //     passing branch at msg_server_validation.go.
+//   - MsgValidation (failing branch) -> inferences with ProposalDetails
+//     set, populated only by startValidationVoteWithPolicy after a
+//     sub-threshold value drives the inference to VOTING and the two
+//     x/group proposals are submitted (proves the F-1 group-membership
+//     fix in bootstrap.go).
+//   - MsgValidation (revalidation vote) -> inferences in INVALIDATED status,
+//     reachable only when MsgRevalidationVoteFactory drives an x/group
+//     invalidate proposal to quorum and the group module executes the inner
+//     MsgInvalidateInference (msg_server_invalidate_inference.go).
 //
 // Not asserted, by design:
 //   - MsgSubmitNewParticipant is idempotent; sim accounts are already
@@ -44,8 +53,9 @@ import (
 // Both ops are still exercised by the run — they have no state
 // fingerprint to assert on.
 //
-// Seed dispatch mirrors TestFullAppSimulation. Run via `make sim-smoke-test`,
-// which pins -Seed and -GenesisTime (see docs/simulation.md §Reproducibility).
+// Seed dispatch mirrors TestFullAppSimulation. Run via `make sim-smoke-test`
+// or `make sim-full-test`, which pin -Seed and -GenesisTime (see
+// docs/simulation.md §Reproducibility).
 func TestFullSimulation_x_Inference_Integrated(t *testing.T) {
 	if !simcli.FlagEnabledValue {
 		t.Skip("pass -Enabled=true to run this; e.g. via make sim-smoke-test")
@@ -61,7 +71,7 @@ func TestFullSimulation_x_Inference_Integrated(t *testing.T) {
 		infs, err := bApp.InferenceKeeper.GetAllInference(ctx)
 		require.NoError(tb, err)
 
-		var startProcessed, finishProcessed, validated int
+		var startProcessed, finishProcessed, validated, proposed, invalidated int
 		for _, inf := range infs {
 			if inf.AssignedTo != "" {
 				startProcessed++
@@ -72,9 +82,15 @@ func TestFullSimulation_x_Inference_Integrated(t *testing.T) {
 			if inf.Status == inferencetypes.InferenceStatus_VALIDATED {
 				validated++
 			}
+			if inf.ProposalDetails != nil {
+				proposed++
+			}
+			if inf.Status == inferencetypes.InferenceStatus_INVALIDATED {
+				invalidated++
+			}
 		}
-		tb.Logf("x/inference lifecycle: total=%d startProcessed=%d finishProcessed=%d validated=%d",
-			len(infs), startProcessed, finishProcessed, validated)
+		tb.Logf("x/inference lifecycle: total=%d startProcessed=%d finishProcessed=%d validated=%d proposed=%d invalidated=%d",
+			len(infs), startProcessed, finishProcessed, validated, proposed, invalidated)
 
 		require.Positivef(tb, startProcessed,
 			"MsgStartInference never reached SetInference (no inference has AssignedTo set)")
@@ -82,6 +98,32 @@ func TestFullSimulation_x_Inference_Integrated(t *testing.T) {
 			"MsgFinishInference never reached state mutation (no inference has ExecutedBy set)")
 		require.Positivef(tb, validated,
 			"MsgValidation never reached its passing-branch state mutation (no VALIDATED inference)")
+		// proposed > 0 is the real-x/group verification of the failing
+		// MsgValidation path: ProposalDetails is set only after both
+		// group.SubmitProposal calls succeed. It holds for both the smoke
+		// (50x20) and full (500x200) seed-99 configs this test runs under.
+		// testkeeper cannot substitute: its x/group keeper is a gomock mock,
+		// so the real SubmitProposal only runs under the full sim app.
+		require.Positivef(tb, proposed,
+			"failing MsgValidation never created x/group proposals (no inference has ProposalDetails) — "+
+				"the failing-validation factory split or the F-1 group-membership fix is not working")
+		// invalidated > 0 is the x/group *execution* check for the
+		// revalidation path: INVALIDATED is reachable only by the inner
+		// MsgInvalidateInference the group module dispatches once a
+		// revalidation vote drives an invalidate proposal past the 50%
+		// PercentageDecisionPolicy. That quorum must be reached within the
+		// proposal's creation block — the sim's 5000-10000 s/block time step
+		// closes the 4-minute group voting window before the next block. The
+		// smoke config (50x20) delivers too few revalidation votes per block
+		// to reach a 3-of-5 same-block quorum; only the full config
+		// (500x200, make sim-full-test) does. So the assertion is gated on
+		// the full config; the smoke run logs `invalidated` for visibility
+		// but does not require it.
+		if cfg.NumBlocks >= 500 && cfg.BlockSize >= 200 {
+			require.Positivef(tb, invalidated,
+				"no inference reached INVALIDATED — the revalidation-vote factory never drove an "+
+					"x/group invalidate proposal to quorum/execution")
+		}
 	}
 
 	if cfg.Seed != simcli.DefaultSeedValue {

--- a/inference-chain/app/sim_test.go
+++ b/inference-chain/app/sim_test.go
@@ -17,6 +17,8 @@ import (
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	"github.com/cosmos/cosmos-sdk/testutil/simsx"
@@ -78,6 +80,7 @@ func setupStateFactory(bApp *app.App) simsx.SimStateFactory {
 			bApp.SimulationManager(),
 			bApp.DefaultGenesis(),
 			func(rawState map[string]json.RawMessage) {
+				shrinkUpstreamStakingValidators(bApp, rawState)
 				fixBankGenesisState(bApp, rawState)
 			},
 		),
@@ -164,6 +167,112 @@ func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
 // above the per-inference escrow (~6.3 × 10^5 ngonka in current sim) even
 // at the make sim-full-test scale of 500 blocks × 200 ops/block.
 var simAccountNgonka = sdkmath.NewInt(1_000_000_000_000_000)
+
+// shrinkUpstreamStakingValidators reduces every upstream-generated staking
+// validator's Tokens and matching DelegatorShares/Delegation.Shares to 1
+// (in BondDenom), so that EpochGroup.ValidationWeights[].Weight (sourced
+// from Tokens via epochgroup.NewEpochMemberFromStakingValidator,
+// epoch_group.go:103) does not dominate over sim genesis participants
+// (each at simValidatorPower=1_000_000 from x/inference/simulation/
+// bootstrap.go).
+//
+// Background: cosmos-sdk's RandomizedGenState (x/staking/simulation/
+// genesis.go) generates 1-299 random Unbonded validators with Tokens=
+// InitialStake ≈ 10^12 each. x/inference's InitGenesisEpoch
+// (module/genesis.go:186) iterates ALL staking validators via
+// GetAllValidators and adds them to EpochGroup.ValidationWeights with
+// Weight=Tokens. Without this shrink:
+//   - totalNetworkWeight ≈ N × 10^12 (often ~10^13–10^14)
+//   - validWeight max = NumSimGenesisParticipants × simValidatorPower
+//     = 5 × 10^6
+//   - Calculate's 2/3-of-total threshold (chainvalidation.go:327) is
+//     unreachable → ComputeNewWeights yields nil active set → no
+//     SetComputeValidators → cometbft set drains → SKIP "empty
+//     validator set" (cosmos-sdk x/simulation/simulate.go:266).
+//
+// All validators are retained (so staking.InitGenesis still bonds ≥1 and
+// InitChain doesn't panic on empty validator set per
+// cosmos-sdk types/module/module.go:524) but their Tokens shrink to 1.
+// NotBondedPool balance is adjusted to mirror the new sum, preserving
+// the upstream invariant (state_helpers.go:132-139) that
+// NotBondedPool == sum(Status==Unbonded).Tokens.
+func shrinkUpstreamStakingValidators(bApp *app.App, rawState map[string]json.RawMessage) {
+	stakingBz, ok := rawState[stakingtypes.ModuleName]
+	if !ok {
+		panic("staking genesis state missing from randomized state")
+	}
+	var stakingState stakingtypes.GenesisState
+	bApp.AppCodec().MustUnmarshalJSON(stakingBz, &stakingState)
+
+	originalNotBonded := sdkmath.ZeroInt()
+	for _, v := range stakingState.Validators {
+		if v.Status == stakingtypes.Unbonded {
+			originalNotBonded = originalNotBonded.Add(v.Tokens)
+		}
+	}
+
+	oneToken := sdkmath.OneInt()
+	oneShares := sdkmath.LegacyOneDec()
+	for i := range stakingState.Validators {
+		operAddr := stakingState.Validators[i].OperatorAddress
+		valAddr, err := sdk.ValAddressFromBech32(operAddr)
+		if err != nil {
+			panic(err)
+		}
+		accAddr := sdk.AccAddress(valAddr).String()
+		// Derivation mirrors x/inference/simulation.SimValidatorKey
+		// (genesis.go:17) so sim genesis EpochMember.Pubkey ==
+		// staking.Validator.ConsensusPubkey for the same account. Without
+		// this alignment, the GON-191 stale-consensus-key filter in our
+		// cosmos-sdk fork (x/staking/keeper/compute.go:358) removes sim
+		// genesis validators from the bonded set on the first
+		// SetComputeValidators call from EnsureSimActiveParticipantsSeeded.
+		pubKey := ed25519.GenPrivKeyFromSecret([]byte("gonka-sim-validator:" + accAddr)).PubKey()
+		pkAny, err := codectypes.NewAnyWithValue(pubKey)
+		if err != nil {
+			panic(err)
+		}
+		stakingState.Validators[i].ConsensusPubkey = pkAny
+		stakingState.Validators[i].Tokens = oneToken
+		stakingState.Validators[i].DelegatorShares = oneShares
+	}
+	for i := range stakingState.Delegations {
+		stakingState.Delegations[i].Shares = oneShares
+	}
+	for i := range stakingState.LastValidatorPowers {
+		stakingState.LastValidatorPowers[i].Power = 1
+	}
+	rawState[stakingtypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&stakingState)
+
+	numUnbonded := sdkmath.ZeroInt()
+	for _, v := range stakingState.Validators {
+		if v.Status == stakingtypes.Unbonded {
+			numUnbonded = numUnbonded.AddRaw(1)
+		}
+	}
+	delta := originalNotBonded.Sub(numUnbonded)
+	if delta.IsZero() || delta.IsNegative() {
+		return
+	}
+
+	bankBz, ok := rawState[banktypes.ModuleName]
+	if !ok {
+		panic("bank genesis state missing from randomized state")
+	}
+	var bankState banktypes.GenesisState
+	bApp.AppCodec().MustUnmarshalJSON(bankBz, &bankState)
+
+	notBondedAddr := authtypes.NewModuleAddress(stakingtypes.NotBondedPoolName).String()
+	bondDenom := stakingState.Params.BondDenom
+	for i := range bankState.Balances {
+		if bankState.Balances[i].Address == notBondedAddr {
+			bankState.Balances[i].Coins = bankState.Balances[i].Coins.Sub(
+				sdk.NewCoin(bondDenom, delta))
+			break
+		}
+	}
+	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
+}
 
 // TestFullAppSimulation is the simsx entry point for `make sim-smoke-test`
 // and `make sim-full-test`. CLI flags (-NumBlocks, -BlockSize, -Seed,

--- a/inference-chain/app/sim_test.go
+++ b/inference-chain/app/sim_test.go
@@ -3,6 +3,7 @@
 package app_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"strings"
@@ -19,10 +20,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/kv"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
@@ -33,6 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/productscience/inference/app"
+	inferencekeeper "github.com/productscience/inference/x/inference/keeper"
 	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
 
@@ -59,6 +63,13 @@ func NewSimApp(
 	appOpts servertypes.AppOptions,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *app.App {
+	// Force per-block crisis-module invariant checks for sim runs so a
+	// broken invariant halts the sim at the offending block instead of
+	// only surfacing post-run. The simsx runner passes an AppOptionsMap;
+	// inject InvCheckPeriod=1 before app.New consumes it.
+	if m, ok := appOpts.(simtestutil.AppOptionsMap); ok {
+		m[server.FlagInvCheckPeriod] = uint(1)
+	}
 	bApp, err := app.New(logger, db, traceStore, loadLatest, appOpts, []wasmkeeper.Option{}, baseAppOptions...)
 	if err != nil {
 		panic(err)
@@ -90,84 +101,6 @@ func setupStateFactory(bApp *app.App) simsx.SimStateFactory {
 	}
 }
 
-// fixBankGenesisState patches the randomized sim genesis so InitGenesis succeeds:
-//
-//  1. Add Gonka denom metadata, required by inference module init
-//     (app.initializeDenomMetadata reads BankKeeper.GetDenomMetaData(BaseCoin)).
-//  2. Fund every sim account with ngonka: upstream
-//     simsx hardwires simState.BondDenom = sdk.DefaultBondDenom = "stake"
-//     (testutil/simsx/runner.go:286), so the randomized bank GenesisState
-//     funds accounts with `stake` but not the `ngonka` BaseCoin that
-//     StartInference's escrow flow requires (payment_handler.go).
-//     Without this, every StartInference fails at PutPaymentInEscrow with
-//     "insufficient spendable funds" and routes through failedStart — so
-//     no Inferences ever land in keeper and the rest of the first-wave
-//     ops never see paired state. We give each account simAccountNgonka
-//     coins of ngonka (~10^15 ≈ 10^6 GNK), well above the per-inference
-//     escrow even for the full-test 100K-op run.
-//  3. Recompute bank Supply from Balances. The randomized genesis sets
-//     Supply based on NumBonded staking validators, but with staking ops
-//     disabled the bonded pool is never funded, so the default Supply
-//     would fail the supply-vs-balance invariant at InitGenesis. Same
-//     recompute keeps Supply in sync after the ngonka top-up.
-//
-// The denom-metadata + Supply-recompute steps are ported from hleb-albau
-// PR gonka-ai/gonka#995; the ngonka top-up is added on top.
-func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
-	bankStateBz, ok := rawState[banktypes.ModuleName]
-	if !ok {
-		panic("bank genesis state missing from randomized state")
-	}
-	var bankState banktypes.GenesisState
-	bApp.AppCodec().MustUnmarshalJSON(bankStateBz, &bankState)
-
-	bankState.DenomMetadata = append(bankState.DenomMetadata, banktypes.Metadata{
-		Description: "Coins for the Gonka network.",
-		Base:        inferencetypes.BaseCoin,
-		Display:     inferencetypes.NativeCoin,
-		Name:        "Gonka",
-		Symbol:      "GNK",
-		DenomUnits: []*banktypes.DenomUnit{
-			{Denom: inferencetypes.BaseCoin, Exponent: 0, Aliases: []string{"nanogonka"}},
-			{Denom: "ugonka", Exponent: 3, Aliases: []string{"microgonka"}},
-			{Denom: "mgonka", Exponent: 6, Aliases: []string{"milligonka"}},
-			{Denom: inferencetypes.NativeCoin, Exponent: 9},
-		},
-	})
-
-	// Build the set of module-account addresses so we DON'T top them up
-	// with ngonka — staking InitGenesis verifies notBondedPool balance ==
-	// declared NotBondedCoins (stake only); adding ngonka there panics
-	// «not bonded pool balance is different from not bonded coins»
-	// (cosmos-sdk x/staking/keeper/genesis.go:174).
-	moduleAddrs := make(map[string]bool, 16)
-	for name := range app.GetMaccPerms() {
-		moduleAddrs[authtypes.NewModuleAddress(name).String()] = true
-	}
-
-	ngonkaTopUp := sdk.NewCoin(inferencetypes.BaseCoin, simAccountNgonka)
-	for i := range bankState.Balances {
-		if moduleAddrs[bankState.Balances[i].Address] {
-			continue
-		}
-		bankState.Balances[i].Coins = bankState.Balances[i].Coins.Add(ngonkaTopUp)
-	}
-
-	var actualSupply sdk.Coins
-	for _, balance := range bankState.Balances {
-		actualSupply = actualSupply.Add(balance.Coins...)
-	}
-	bankState.Supply = actualSupply
-
-	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
-}
-
-// simAccountNgonka is the per-sim-account ngonka top-up amount applied by
-// fixBankGenesisState. 10^15 ngonka = 10^6 GNK — comfortable buffer
-// above the per-inference escrow (~6.3 × 10^5 ngonka in current sim) even
-// at the make sim-full-test scale of 500 blocks × 200 ops/block.
-var simAccountNgonka = sdkmath.NewInt(1_000_000_000_000_000)
-
 // shrinkUpstreamStakingValidators reduces every upstream-generated staking
 // validator's Tokens and matching DelegatorShares/Delegation.Shares to 1
 // (in BondDenom), so that EpochGroup.ValidationWeights[].Weight (sourced
@@ -190,9 +123,9 @@ var simAccountNgonka = sdkmath.NewInt(1_000_000_000_000_000)
 //     SetComputeValidators → cometbft set drains → SKIP "empty
 //     validator set" (cosmos-sdk x/simulation/simulate.go:266).
 //
-// All validators are retained (so staking.InitGenesis still bonds ≥1 and
+// We keep all validators (so staking.InitGenesis still bonds ≥1 and
 // InitChain doesn't panic on empty validator set per
-// cosmos-sdk types/module/module.go:524) but their Tokens shrink to 1.
+// cosmos-sdk types/module/module.go:524) but shrink their Tokens.
 // NotBondedPool balance is adjusted to mirror the new sum, preserving
 // the upstream invariant (state_helpers.go:132-139) that
 // NotBondedPool == sum(Status==Unbonded).Tokens.
@@ -274,6 +207,84 @@ func shrinkUpstreamStakingValidators(bApp *app.App, rawState map[string]json.Raw
 	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
 }
 
+// fixBankGenesisState patches the randomized sim genesis so InitGenesis succeeds:
+//
+//  1. Add Gonka denom metadata, required by inference module init
+//     (app.initializeDenomMetadata reads BankKeeper.GetDenomMetaData(BaseCoin)).
+//  2. Fund every sim account with ngonka: upstream
+//     simsx hardwires simState.BondDenom = sdk.DefaultBondDenom = "stake"
+//     (testutil/simsx/runner.go:286), so the randomized bank GenesisState
+//     funds accounts with `stake` but not the `ngonka` BaseCoin that
+//     StartInference's escrow flow requires (payment_handler.go).
+//     Without this, every StartInference fails at PutPaymentInEscrow with
+//     "insufficient spendable funds" and routes through failedStart — so
+//     no Inferences ever land in keeper and the rest of the first-wave
+//     ops never see paired state. We give each account simAccountNgonka
+//     coins of ngonka (~10^15 ≈ 10^6 GNK), well above the per-inference
+//     escrow even for the full-test 100K-op run.
+//  3. Recompute bank Supply from Balances. The randomized genesis sets
+//     Supply based on NumBonded staking validators, but with staking ops
+//     disabled the bonded pool is never funded, so the default Supply
+//     would fail the supply-vs-balance invariant at InitGenesis. Same
+//     recompute keeps Supply in sync after the ngonka top-up.
+//
+// The denom-metadata + Supply-recompute steps are ported from hleb-albau
+// PR gonka-ai/gonka#995; the ngonka top-up is added on top.
+func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
+	bankStateBz, ok := rawState[banktypes.ModuleName]
+	if !ok {
+		panic("bank genesis state missing from randomized state")
+	}
+	var bankState banktypes.GenesisState
+	bApp.AppCodec().MustUnmarshalJSON(bankStateBz, &bankState)
+
+	bankState.DenomMetadata = append(bankState.DenomMetadata, banktypes.Metadata{
+		Description: "Coins for the Gonka network.",
+		Base:        inferencetypes.BaseCoin,
+		Display:     inferencetypes.NativeCoin,
+		Name:        "Gonka",
+		Symbol:      "GNK",
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: inferencetypes.BaseCoin, Exponent: 0, Aliases: []string{"nanogonka"}},
+			{Denom: "ugonka", Exponent: 3, Aliases: []string{"microgonka"}},
+			{Denom: "mgonka", Exponent: 6, Aliases: []string{"milligonka"}},
+			{Denom: inferencetypes.NativeCoin, Exponent: 9},
+		},
+	})
+
+	// Build the set of module-account addresses so we DON'T top them up
+	// with ngonka — staking InitGenesis verifies notBondedPool balance ==
+	// declared NotBondedCoins (stake only); adding ngonka there panics
+	// «not bonded pool balance is different from not bonded coins»
+	// (cosmos-sdk x/staking/keeper/genesis.go:174).
+	moduleAddrs := make(map[string]bool, 16)
+	for name := range app.GetMaccPerms() {
+		moduleAddrs[authtypes.NewModuleAddress(name).String()] = true
+	}
+
+	ngonkaTopUp := sdk.NewCoin(inferencetypes.BaseCoin, simAccountNgonka)
+	for i := range bankState.Balances {
+		if moduleAddrs[bankState.Balances[i].Address] {
+			continue
+		}
+		bankState.Balances[i].Coins = bankState.Balances[i].Coins.Add(ngonkaTopUp)
+	}
+
+	var actualSupply sdk.Coins
+	for _, balance := range bankState.Balances {
+		actualSupply = actualSupply.Add(balance.Coins...)
+	}
+	bankState.Supply = actualSupply
+
+	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
+}
+
+// simAccountNgonka is the per-sim-account ngonka top-up amount applied by
+// fixBankGenesisState. 10^15 ngonka = 10^6 GNK — comfortable buffer
+// above the per-inference escrow (~6.3 × 10^5 ngonka in current sim) even
+// at the make sim-full-test scale of 500 blocks × 200 ops/block.
+var simAccountNgonka = sdkmath.NewInt(1_000_000_000_000_000)
+
 // TestFullAppSimulation is the simsx entry point for `make sim-smoke-test`
 // and `make sim-full-test`. CLI flags (-NumBlocks, -BlockSize, -Seed,
 // -Enabled) come from simcli.GetSimulatorFlags() in init().
@@ -294,10 +305,25 @@ func TestFullAppSimulation(t *testing.T) {
 	cfg.ChainID = simsx.SimAppChainID
 
 	if cfg.Seed != simcli.DefaultSeedValue {
-		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil)
+		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil, checkInferenceInvariants)
 		return
 	}
-	simsx.Run(t, NewSimApp, setupStateFactory)
+	simsx.Run(t, NewSimApp, setupStateFactory, checkInferenceInvariants)
+}
+
+// checkInferenceInvariants runs every x/inference invariant against the
+// final sim state and fails the test on any breakage. Used as a post-run
+// callback so a violation prints the specific invariant name +
+// descriptive message even when per-block crisis checks miss the final
+// EndBlocker (e.g. when sim halts mid-tx on an unrelated failure).
+func checkInferenceInvariants(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+	tb.Helper()
+	bApp := ti.App
+	ctx := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
+	msg, broken := inferencekeeper.AllInvariants(bApp.InferenceKeeper)(ctx)
+	if broken {
+		tb.Fatalf("x/inference invariant broken on post-run check: %s", msg)
+	}
 }
 
 // TestAppImportExport_Postrun is t.Skip'd because InitGenesis on the
@@ -463,17 +489,106 @@ func TestAppStateDeterminism(t *testing.T) {
 		// capture synchronously, so hashes[attempt] is populated before the
 		// next iteration.
 		hashes := make([][]byte, attempts)
+		// Snapshot KV state per attempt so a divergence prints decoded
+		// proto state via the modules' RegisterStoreDecoder registry,
+		// instead of an opaque AppHash mismatch.
+		snapshots := make([]storeSnapshot, attempts)
+		var decoders simtypes.StoreDecoderRegistry
 		for attempt := range attempts {
 			capture := func(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
 				hashes[attempt] = ti.App.LastCommitID().Hash
+				snapshots[attempt] = snapshotStores(ti.App)
+				decoders = ti.App.SimulationManager().StoreDecoders
 			}
 			simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, seed, nil, capture)
 			require.NotEmptyf(t, hashes[attempt],
 				"capture callback was not invoked for seed %d attempt %d", seed, attempt)
 		}
 		for i := 1; i < attempts; i++ {
+			if !bytes.Equal(hashes[0], hashes[i]) {
+				dumpKVDivergence(t, seed, i, snapshots[0], snapshots[i], decoders)
+			}
 			require.Equalf(t, hashes[0], hashes[i],
 				"non-determinism in seed %d: attempt 0 vs %d", seed, i)
 		}
 	}
+}
+
+// storeSnapshot is the captured KV state of every IAVL store at the end
+// of one simulation attempt. Used by TestAppStateDeterminism's divergence
+// dump so a regression prints decoded proto state instead of raw hash.
+type storeSnapshot map[string][]kv.Pair
+
+// snapshotStores iterates every IAVL store on the app and returns a deep
+// copy of every (key, value) pair. Run only after a sim completes — uses
+// a legacy context against the last block height.
+func snapshotStores(bApp *app.App) storeSnapshot {
+	snap := make(storeSnapshot)
+	ctx := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
+	for _, storeKey := range bApp.GetStoreKeys() {
+		kvKey, ok := storeKey.(*storetypes.KVStoreKey)
+		if !ok {
+			continue
+		}
+		name := kvKey.Name()
+		kvStore := ctx.KVStore(kvKey)
+		iter := kvStore.Iterator(nil, nil)
+		var pairs []kv.Pair
+		for ; iter.Valid(); iter.Next() {
+			pairs = append(pairs, kv.Pair{
+				Key:   append([]byte{}, iter.Key()...),
+				Value: append([]byte{}, iter.Value()...),
+			})
+		}
+		iter.Close()
+		snap[name] = pairs
+	}
+	return snap
+}
+
+// dumpKVDivergence diffs two captured snapshots store-by-store and emits
+// a readable diff via the per-module store decoders. The diff is only
+// emitted for stores whose KV pairs disagree.
+func dumpKVDivergence(t *testing.T, seed int64, attempt int, a, b storeSnapshot, decoders simtypes.StoreDecoderRegistry) {
+	t.Helper()
+	for name, pairsA := range a {
+		pairsB := b[name]
+		failedA, failedB := diffCapturedPairs(pairsA, pairsB)
+		if len(failedA) == 0 {
+			continue
+		}
+		t.Logf("KV divergence in store %q (seed %d, attempt 0 vs %d):\n%s",
+			name, seed, attempt,
+			simtestutil.GetSimulationLog(name, decoders, failedA, failedB))
+	}
+}
+
+// diffCapturedPairs returns aligned slices of pairs that differ between
+// the two captures. Missing keys on one side become nil-value placeholders.
+func diffCapturedPairs(a, b []kv.Pair) (failedA, failedB []kv.Pair) {
+	indexB := make(map[string]int, len(b))
+	for i, p := range b {
+		indexB[string(p.Key)] = i
+	}
+	seenA := make(map[string]struct{}, len(a))
+	for _, pa := range a {
+		seenA[string(pa.Key)] = struct{}{}
+		j, ok := indexB[string(pa.Key)]
+		if !ok {
+			failedA = append(failedA, pa)
+			failedB = append(failedB, kv.Pair{Key: pa.Key, Value: nil})
+			continue
+		}
+		if !bytes.Equal(pa.Value, b[j].Value) {
+			failedA = append(failedA, pa)
+			failedB = append(failedB, b[j])
+		}
+	}
+	for _, pb := range b {
+		if _, ok := seenA[string(pb.Key)]; !ok {
+			failedA = append(failedA, kv.Pair{Key: pb.Key, Value: nil})
+			failedB = append(failedB, pb)
+		}
+	}
+	return
 }

--- a/inference-chain/app/sim_test.go
+++ b/inference-chain/app/sim_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"cosmossdk.io/log"
+	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/feegrant"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -21,6 +22,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
@@ -89,12 +91,25 @@ func setupStateFactory(bApp *app.App) simsx.SimStateFactory {
 //
 //  1. Add Gonka denom metadata, required by inference module init
 //     (app.initializeDenomMetadata reads BankKeeper.GetDenomMetaData(BaseCoin)).
-//  2. Recompute bank Supply from Balances. The randomized genesis sets
+//  2. Fund every sim account with ngonka: upstream
+//     simsx hardwires simState.BondDenom = sdk.DefaultBondDenom = "stake"
+//     (testutil/simsx/runner.go:286), so the randomized bank GenesisState
+//     funds accounts with `stake` but not the `ngonka` BaseCoin that
+//     StartInference's escrow flow requires (payment_handler.go).
+//     Without this, every StartInference fails at PutPaymentInEscrow with
+//     "insufficient spendable funds" and routes through failedStart — so
+//     no Inferences ever land in keeper and the rest of the first-wave
+//     ops never see paired state. We give each account simAccountNgonka
+//     coins of ngonka (~10^15 ≈ 10^6 GNK), well above the per-inference
+//     escrow even for the full-test 100K-op run.
+//  3. Recompute bank Supply from Balances. The randomized genesis sets
 //     Supply based on NumBonded staking validators, but with staking ops
 //     disabled the bonded pool is never funded, so the default Supply
-//     would fail the supply-vs-balance invariant at InitGenesis.
+//     would fail the supply-vs-balance invariant at InitGenesis. Same
+//     recompute keeps Supply in sync after the ngonka top-up.
 //
-// Ported from hleb-albau PR gonka-ai/gonka#995.
+// The denom-metadata + Supply-recompute steps are ported from hleb-albau
+// PR gonka-ai/gonka#995; the ngonka top-up is added on top.
 func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
 	bankStateBz, ok := rawState[banktypes.ModuleName]
 	if !ok {
@@ -117,6 +132,24 @@ func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
 		},
 	})
 
+	// Build the set of module-account addresses so we DON'T top them up
+	// with ngonka — staking InitGenesis verifies notBondedPool balance ==
+	// declared NotBondedCoins (stake only); adding ngonka there panics
+	// «not bonded pool balance is different from not bonded coins»
+	// (cosmos-sdk x/staking/keeper/genesis.go:174).
+	moduleAddrs := make(map[string]bool, 16)
+	for name := range app.GetMaccPerms() {
+		moduleAddrs[authtypes.NewModuleAddress(name).String()] = true
+	}
+
+	ngonkaTopUp := sdk.NewCoin(inferencetypes.BaseCoin, simAccountNgonka)
+	for i := range bankState.Balances {
+		if moduleAddrs[bankState.Balances[i].Address] {
+			continue
+		}
+		bankState.Balances[i].Coins = bankState.Balances[i].Coins.Add(ngonkaTopUp)
+	}
+
 	var actualSupply sdk.Coins
 	for _, balance := range bankState.Balances {
 		actualSupply = actualSupply.Add(balance.Coins...)
@@ -125,6 +158,12 @@ func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
 
 	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
 }
+
+// simAccountNgonka is the per-sim-account ngonka top-up amount applied by
+// fixBankGenesisState. 10^15 ngonka = 10^6 GNK — comfortable buffer
+// above the per-inference escrow (~6.3 × 10^5 ngonka in current sim) even
+// at the make sim-full-test scale of 500 blocks × 200 ops/block.
+var simAccountNgonka = sdkmath.NewInt(1_000_000_000_000_000)
 
 // TestFullAppSimulation is the simsx entry point for `make sim-smoke-test`
 // and `make sim-full-test`. CLI flags (-NumBlocks, -BlockSize, -Seed,
@@ -200,8 +239,7 @@ func checkImportExport(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simty
 		// Defensive: even with disabledOpsSimModule on staking we keep the
 		// upstream-known skip path for the rare case of an empty validator set.
 		if strings.Contains(err.Error(), "validator set is empty after InitGenesis") {
-			tb.Log("skipping import-export comparison: validator set empty")
-			return
+			tb.Skip("import-export comparison skipped: validator set empty")
 		}
 		tb.Fatalf("InitGenesis on newApp: %v", err)
 	}

--- a/inference-chain/app/sim_test.go
+++ b/inference-chain/app/sim_test.go
@@ -1,18 +1,14 @@
+//go:build sims || simsbench
+
 package app_test
 
 import (
 	"encoding/json"
-	"flag"
-	"fmt"
-	"math/rand"
-	"os"
-	"runtime/debug"
+	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"cosmossdk.io/log"
-	"cosmossdk.io/store"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/feegrant"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -20,191 +16,222 @@ import (
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/server"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	simulationtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	"github.com/productscience/inference/app"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
 
-const (
-	SimAppChainID = "inference-simapp"
-)
+// Compile-time check that *app.App satisfies simsx.SimulationApp.
+var _ simsx.SimulationApp = (*app.App)(nil)
 
-var FlagEnableStreamingValue bool
+// defaultSimSeeds is the canonical seed triplet shared by
+// TestAppStateDeterminism (full sweep) and BenchmarkFullAppSimulation
+// (uses [0] as the single-seed default).
+var defaultSimSeeds = []int64{1, 32, 123}
 
-// Get flags every time the simulator is run
 func init() {
 	simcli.GetSimulatorFlags()
-	flag.BoolVar(&FlagEnableStreamingValue, "EnableStreaming", false, "Enable streaming service")
+	app.InitSDKConfig()
 }
 
-// fauxMerkleModeOpt returns a BaseApp option to use a dbStoreAdapter instead of
-// an IAVLStore for faster simulation speed.
-func fauxMerkleModeOpt(bapp *baseapp.BaseApp) {
-	bapp.SetFauxMerkleMode()
-}
-
-// interBlockCacheOpt returns a BaseApp option function that sets the persistent
-// inter-block write-through cache.
-func interBlockCacheOpt() func(*baseapp.BaseApp) {
-	return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager())
-}
-
-// BenchmarkSimulation run the chain simulation
-// Running using starport command:
-// `ignite chain simulate -v --numBlocks 200 --blockSize 50`
-// Running as go benchmark test:
-// `go test -benchmem -run=^$ -bench ^BenchmarkSimulation ./app -NumBlocks=200 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true`
-func BenchmarkSimulation(b *testing.B) {
-	simcli.FlagSeedValue = time.Now().Unix()
-	simcli.FlagVerboseValue = true
-	simcli.FlagCommitValue = true
-	simcli.FlagEnabledValue = true
-
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		b.Skip("skipping application simulation")
+// NewSimApp adapts app.New to the simsx.Run appFactory signature by hiding the
+// wasmd opts argument required by gonka's constructor.
+func NewSimApp(
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	loadLatest bool,
+	appOpts servertypes.AppOptions,
+	baseAppOptions ...func(*baseapp.BaseApp),
+) *app.App {
+	bApp, err := app.New(logger, db, traceStore, loadLatest, appOpts, []wasmkeeper.Option{}, baseAppOptions...)
+	if err != nil {
+		panic(err)
 	}
-	require.NoError(b, err, "simulation setup failed")
+	return bApp
+}
 
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(b, err)
-	require.NoError(b, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
+// setupStateFactory builds the SimStateFactory consumed by simsx.Run for each
+// seed. AccountKeeper satisfies simsx.AccountSourceX (AccountSource +
+// ModuleAccountSource); BankKeeper satisfies simsx.BalanceSource.
+//
+// AppStateFnWithExtendedCb (rather than plain AppStateFn) lets fixBankGenesisState
+// patch the randomized rawState before InitGenesis runs.
+func setupStateFactory(bApp *app.App) simsx.SimStateFactory {
+	return simsx.SimStateFactory{
+		Codec: bApp.AppCodec(),
+		AppStateFn: simtestutil.AppStateFnWithExtendedCb(
+			bApp.AppCodec(),
+			bApp.SimulationManager(),
+			bApp.DefaultGenesis(),
+			func(rawState map[string]json.RawMessage) {
+				fixBankGenesisState(bApp, rawState)
+			},
+		),
+		BlockedAddr:   app.BlockedAddresses(),
+		AccountSource: bApp.AccountKeeper,
+		BalanceSource: bApp.BankKeeper,
 	}
 }
 
-func TestAppImportExport(t *testing.T) {
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		t.Skip("skipping application import/export simulation")
+// fixBankGenesisState patches the randomized sim genesis so InitGenesis succeeds:
+//
+//  1. Add Gonka denom metadata, required by inference module init
+//     (app.initializeDenomMetadata reads BankKeeper.GetDenomMetaData(BaseCoin)).
+//  2. Recompute bank Supply from Balances. The randomized genesis sets
+//     Supply based on NumBonded staking validators, but with staking ops
+//     disabled the bonded pool is never funded, so the default Supply
+//     would fail the supply-vs-balance invariant at InitGenesis.
+//
+// Ported from hleb-albau PR gonka-ai/gonka#995.
+func fixBankGenesisState(bApp *app.App, rawState map[string]json.RawMessage) {
+	bankStateBz, ok := rawState[banktypes.ModuleName]
+	if !ok {
+		panic("bank genesis state missing from randomized state")
 	}
-	require.NoError(t, err, "simulation setup failed")
+	var bankState banktypes.GenesisState
+	bApp.AppCodec().MustUnmarshalJSON(bankStateBz, &bankState)
 
-	defer func() {
-		require.NoError(t, db.Close())
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	bankState.DenomMetadata = append(bankState.DenomMetadata, banktypes.Metadata{
+		Description: "Coins for the Gonka network.",
+		Base:        inferencetypes.BaseCoin,
+		Display:     inferencetypes.NativeCoin,
+		Name:        "Gonka",
+		Symbol:      "GNK",
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: inferencetypes.BaseCoin, Exponent: 0, Aliases: []string{"nanogonka"}},
+			{Denom: "ugonka", Exponent: 3, Aliases: []string{"microgonka"}},
+			{Denom: "mgonka", Exponent: 6, Aliases: []string{"milligonka"}},
+			{Denom: inferencetypes.NativeCoin, Exponent: 9},
+		},
+	})
 
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, bApp.Name())
-
-	// Run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
+	var actualSupply sdk.Coins
+	for _, balance := range bankState.Balances {
+		actualSupply = actualSupply.Add(balance.Coins...)
 	}
+	bankState.Supply = actualSupply
 
-	fmt.Printf("exporting genesis...\n")
+	rawState[banktypes.ModuleName] = bApp.AppCodec().MustMarshalJSON(&bankState)
+}
 
+// TestFullAppSimulation is the simsx entry point for `make sim-smoke-test`
+// and `make sim-full-test`. CLI flags (-NumBlocks, -BlockSize, -Seed,
+// -Enabled) come from simcli.GetSimulatorFlags() in init().
+//
+// Requires -Enabled=true. simsx does not gate on it the way legacy
+// simulation.SimulateFromSeed did; this test restores that gate so a
+// raw `go test -tags sims ./app/...` skips fast.
+//
+// With user-supplied -Seed=N (Make targets), dispatches to
+// simsx.RunWithSeed for a single-seed run. Without it, falls through to
+// simsx.Run which fans out the framework's defaultSeeds list (37 seeds
+// in this fork) as parallel subtests.
+func TestFullAppSimulation(t *testing.T) {
+	if !simcli.FlagEnabledValue {
+		t.Skip("pass -Enabled=true to run this; e.g. via make sim-smoke-test")
+	}
+	cfg := simcli.NewConfigFromFlags()
+	cfg.ChainID = simsx.SimAppChainID
+
+	if cfg.Seed != simcli.DefaultSeedValue {
+		simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, cfg.Seed, nil)
+		return
+	}
+	simsx.Run(t, NewSimApp, setupStateFactory)
+}
+
+// TestAppImportExport_Postrun is t.Skip'd because InitGenesis on the
+// re-imported state panics at gonka-ai/cosmos-sdk@v0.53.3-ps17
+// x/staking/keeper/genesis.go:157-158 ("bonded pool balance is different
+// from bonded coins").
+//
+// The fork's PoC architecture (gonka/docs/cosmos_changes.md) disables
+// token bonding: SetComputeValidators creates bonded validators without
+// bank transfers, pool.go iterates manually, and delegation.go +
+// val_state_change.go skip the transfers. genesis.go:157 was not updated
+// to mirror that skip, so its upstream invariant bondedBalance.Equal(
+// bondedCoins) no longer holds against live state.
+//
+// Production sidesteps this by using x/upgrade in-place handlers (see
+// app/upgrades/v0_2_12) instead of `inferenced export -> init`. Funding
+// the bonded pool here to make the test green would mask the
+// inconsistency, so it stays skipped.
+//
+// Re-enable once gonka-ai/cosmos-sdk genesis.go applies the same
+// PoC-validator skip already in delegation.go. Fork fix proposal:
+// gonka-ai/gonka#1153. Broader Phase 1 work: gonka-ai/gonka#982.
+func TestAppImportExport_Postrun(t *testing.T) {
+	t.Skip("blocked on gonka-ai/cosmos-sdk genesis.go:157; see gonka-ai/gonka#1153 for the fork fix proposal")
+	simsx.Run(t, NewSimApp, setupStateFactory, checkImportExport)
+}
+
+func checkImportExport(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+	tb.Helper()
+	bApp := ti.App
+
+	tb.Logf("exporting genesis...")
 	exported, err := bApp.ExportAppStateAndValidators(false, []string{}, []string{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	fmt.Printf("importing genesis...\n")
-
-	newDB, newDir, _, _, err := simtestutil.SetupSimulation(config, "leveldb-app-sim-2", "Simulation-2", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	require.NoError(t, err, "simulation setup failed")
-
-	defer func() {
-		require.NoError(t, newDB.Close())
-		require.NoError(t, os.RemoveAll(newDir))
-	}()
-
-	newApp, err := app.New(logger, newDB, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, newApp.Name())
+	tb.Logf("importing genesis into fresh app...")
+	newTI := simsx.NewSimulationAppInstance(tb, ti.Cfg, NewSimApp)
+	newApp := newTI.App
+	defer func() { _ = newApp.Close() }()
 
 	var genesisState app.GenesisState
-	err = json.Unmarshal(exported.AppState, &genesisState)
-	require.NoError(t, err)
+	require.NoError(tb, json.Unmarshal(exported.AppState, &genesisState))
 
-	ctxA := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
-	ctxB := newApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight()})
-	_, err = newApp.ModuleManager.InitGenesis(ctxB, bApp.AppCodec(), genesisState)
-
-	if err != nil {
+	header := cmtproto.Header{Height: bApp.LastBlockHeight()}
+	ctxA := bApp.NewContextLegacy(true, header)
+	ctxB := newApp.NewContextLegacy(true, header)
+	if _, err := newApp.ModuleManager.InitGenesis(ctxB, newApp.AppCodec(), genesisState); err != nil {
+		// Defensive: even with disabledOpsSimModule on staking we keep the
+		// upstream-known skip path for the rare case of an empty validator set.
 		if strings.Contains(err.Error(), "validator set is empty after InitGenesis") {
-			logger.Info("Skipping simulation as all validators have been unbonded")
-			logger.Info("err", err, "stacktrace", string(debug.Stack()))
+			tb.Log("skipping import-export comparison: validator set empty")
 			return
 		}
+		tb.Fatalf("InitGenesis on newApp: %v", err)
 	}
-	require.NoError(t, err)
-	err = newApp.StoreConsensusParams(ctxB, exported.ConsensusParams)
-	require.NoError(t, err)
-	fmt.Printf("comparing stores...\n")
+	require.NoError(tb, newApp.StoreConsensusParams(ctxB, exported.ConsensusParams))
 
-	// skip certain prefixes
-	skipPrefixes := map[string][][]byte{
+	tb.Logf("comparing stores...")
+	skipPrefixes := importExportSkipPrefixes()
+	storeKeys := bApp.GetStoreKeys()
+	require.NotEmpty(tb, storeKeys)
+	for _, appKeyA := range storeKeys {
+		if _, ok := appKeyA.(*storetypes.KVStoreKey); !ok {
+			continue
+		}
+		keyName := appKeyA.Name()
+		appKeyB := newApp.GetKey(keyName)
+		storeA := ctxA.KVStore(appKeyA)
+		storeB := ctxB.KVStore(appKeyB)
+		failedKVAs, failedKVBs := simtestutil.DiffKVStores(storeA, storeB, skipPrefixes[keyName])
+		require.Equalf(tb, len(failedKVAs), len(failedKVBs), "unequal failure sets for %s", keyName)
+		if len(failedKVAs) != 0 {
+			tb.Fatalf("KV diff for %s:\n%s", keyName,
+				simtestutil.GetSimulationLog(keyName, bApp.SimulationManager().StoreDecoders, failedKVAs, failedKVBs))
+		}
+	}
+}
+
+// importExportSkipPrefixes mirrors upstream cosmos-sdk simapp's skip set:
+// transient queues populated by runtime hooks, not by InitGenesis.
+func importExportSkipPrefixes() map[string][][]byte {
+	return map[string][][]byte{
 		stakingtypes.StoreKey: {
 			stakingtypes.UnbondingQueueKey, stakingtypes.RedelegationQueueKey, stakingtypes.ValidatorQueueKey,
 			stakingtypes.HistoricalInfoKey, stakingtypes.UnbondingIDKey, stakingtypes.UnbondingIndexKey,
@@ -214,224 +241,92 @@ func TestAppImportExport(t *testing.T) {
 		feegrant.StoreKey:      {feegrant.FeeAllowanceQueueKeyPrefix},
 		slashingtypes.StoreKey: {slashingtypes.ValidatorMissedBlockBitmapKeyPrefix},
 	}
-
-	storeKeys := bApp.GetStoreKeys()
-	require.NotEmpty(t, storeKeys)
-
-	for _, appKeyA := range storeKeys {
-		// only compare kvstores
-		if _, ok := appKeyA.(*storetypes.KVStoreKey); !ok {
-			continue
-		}
-
-		keyName := appKeyA.Name()
-		appKeyB := newApp.GetKey(keyName)
-
-		storeA := ctxA.KVStore(appKeyA)
-		storeB := ctxB.KVStore(appKeyB)
-
-		failedKVAs, failedKVBs := simtestutil.DiffKVStores(storeA, storeB, skipPrefixes[keyName])
-		require.Equal(t, len(failedKVAs), len(failedKVBs), "unequal sets of key-values to compare %s", keyName)
-
-		fmt.Printf("compared %d different key/value pairs between %s and %s\n", len(failedKVAs), appKeyA, appKeyB)
-
-		require.Equal(t, 0, len(failedKVAs), simtestutil.GetSimulationLog(keyName, bApp.SimulationManager().StoreDecoders, failedKVAs, failedKVBs))
-	}
 }
 
-func TestAppSimulationAfterImport(t *testing.T) {
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
+// TestAppSimulationAfterImport_Postrun is t.Skip'd. Two things must be
+// done before re-enabling, in order:
+//
+//  1. gonka-ai/cosmos-sdk genesis.go:157 bonded-pool fix per
+//     gonka-ai/gonka#1153 (InitChain on the imported state currently
+//     panics on the same fork asymmetry as TestAppImportExport_Postrun).
+//  2. Wire SimulateFromSeedX into checkSimulationAfterImport. The current
+//     body only verifies InitChain succeeds; the test name promises a
+//     second simulation step that is not yet implemented (TODO in the
+//     body).
+//
+// Removing t.Skip with only (1) cleared would make the test pass while
+// never exercising the second simulation step. Both must land first.
+func TestAppSimulationAfterImport_Postrun(t *testing.T) {
+	t.Skip("blocked on (1) gonka-ai/cosmos-sdk genesis.go:157 fix per gonka-ai/gonka#1153, and (2) wiring SimulateFromSeedX for the after-import simulation step")
+	simsx.Run(t, NewSimApp, setupStateFactory, checkSimulationAfterImport)
+}
 
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-sim", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if skip {
-		t.Skip("skipping application simulation after import")
-	}
-	require.NoError(t, err, "simulation setup failed")
+func checkSimulationAfterImport(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+	tb.Helper()
+	bApp := ti.App
 
-	defer func() {
-		require.NoError(t, db.Close())
-		require.NoError(t, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	var emptyWasmOpts []wasmkeeper.Option
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, bApp.Name())
-
-	// Run randomized simulation
-	stopEarly, simParams, simErr := simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	err = simtestutil.CheckExportSimulation(bApp, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-
-	if stopEarly {
-		fmt.Println("can't export or import a zero-validator genesis, exiting test...")
-		return
-	}
-
-	fmt.Printf("exporting genesis...\n")
-
+	tb.Logf("exporting genesis (forZeroHeight=true)...")
 	exported, err := bApp.ExportAppStateAndValidators(true, []string{}, []string{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	fmt.Printf("importing genesis...\n")
-
-	newDB, newDir, _, _, err := simtestutil.SetupSimulation(config, "leveldb-app-sim-2", "Simulation-2", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	require.NoError(t, err, "simulation setup failed")
-
-	defer func() {
-		require.NoError(t, newDB.Close())
-		require.NoError(t, os.RemoveAll(newDir))
-	}()
-
-	newApp, err := app.New(logger, newDB, nil, true, appOptions, emptyWasmOpts, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
-	require.NoError(t, err)
-	require.Equal(t, app.Name, newApp.Name())
+	tb.Logf("importing genesis into fresh app via InitChain...")
+	newTI := simsx.NewSimulationAppInstance(tb, ti.Cfg, NewSimApp)
+	newApp := newTI.App
+	defer func() { _ = newApp.Close() }()
 
 	_, err = newApp.InitChain(&abci.RequestInitChain{
 		AppStateBytes: exported.AppState,
-		ChainId:       SimAppChainID,
+		ChainId:       ti.Cfg.ChainID,
 	})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	_, _, err = simulation.SimulateFromSeed(
-		t,
-		os.Stdout,
-		newApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(newApp, newApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-	require.NoError(t, err)
+	// TODO: once import unblocks, run SimulateFromSeedX on newApp. Needs
+	// either a copy of simsx's unexported prepareWeightedOps or a minimal
+	// ops registry.
+	tb.Log("import succeeded; second-simulation step deferred (see TODO)")
 }
 
+// TestAppStateDeterminism asserts that running the same seed N times
+// produces an identical AppHash. Uses simsx.RunWithSeed directly because
+// simsx.Run fans out distinct seeds in parallel; determinism wants the
+// same seed sequentially. PoC-state determinism beyond AppHash
+// (EffectiveIndex, epoch-state collections) is Phase 3 territory per the
+// issue body.
 func TestAppStateDeterminism(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in -short mode")
+	}
 	if !simcli.FlagEnabledValue {
-		t.Skip("skipping application simulation")
+		t.Skip("pass -Enabled=true to run this; simsx does not gate on it")
 	}
+	cfg := simcli.NewConfigFromFlags()
+	cfg.ChainID = simsx.SimAppChainID
 
-	config := simcli.NewConfigFromFlags()
-	config.InitialBlockHeight = 1
-	config.ExportParamsPath = ""
-	config.OnOperation = true
-	config.AllInvariants = true
-
-	numSeeds := 3
-	numTimesToRunPerSeed := 3 // This used to be set to 5, but we've temporarily reduced it to 3 for the sake of faster CI.
-	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
-
-	// We will be overriding the random seed and just run a single simulation on the provided seed value
-	if config.Seed != simcli.DefaultSeedValue {
-		numSeeds = 1
+	// Block counts inherit from simcli flags.
+	// Honor user-supplied -Seed=N for single-seed reproduction of a failure.
+	seeds := defaultSimSeeds
+	if cfg.Seed != simcli.DefaultSeedValue {
+		seeds = []int64{cfg.Seed}
 	}
+	const attempts = 3
 
-	appOptions := viper.New()
-	if FlagEnableStreamingValue {
-		m := make(map[string]interface{})
-		m["streaming.abci.keys"] = []string{"*"}
-		m["streaming.abci.plugin"] = "abci_v1"
-		m["streaming.abci.stop-node-on-err"] = true
-		for key, value := range m {
-			appOptions.SetDefault(key, value)
+	for _, seed := range seeds {
+		// Pre-allocated indexed slots so a failure points at the specific
+		// attempt rather than a generic count mismatch. RunWithSeed invokes
+		// capture synchronously, so hashes[attempt] is populated before the
+		// next iteration.
+		hashes := make([][]byte, attempts)
+		for attempt := range attempts {
+			capture := func(tb testing.TB, ti simsx.TestInstance[*app.App], _ []simtypes.Account) {
+				hashes[attempt] = ti.App.LastCommitID().Hash
+			}
+			simsx.RunWithSeed(t, cfg, NewSimApp, setupStateFactory, seed, nil, capture)
+			require.NotEmptyf(t, hashes[attempt],
+				"capture callback was not invoked for seed %d attempt %d", seed, attempt)
 		}
-	}
-	appOptions.SetDefault(flags.FlagHome, app.DefaultNodeHome)
-	appOptions.SetDefault(server.FlagInvCheckPeriod, simcli.FlagPeriodValue)
-	if simcli.FlagVerboseValue {
-		appOptions.SetDefault(flags.FlagLogLevel, "debug")
-	}
-
-	for i := 0; i < numSeeds; i++ {
-		if config.Seed == simcli.DefaultSeedValue {
-			config.Seed = rand.Int63()
-		}
-		fmt.Println("config.Seed: ", config.Seed)
-
-		for j := 0; j < numTimesToRunPerSeed; j++ {
-			var logger log.Logger
-			if simcli.FlagVerboseValue {
-				logger = log.NewTestLogger(t)
-			} else {
-				logger = log.NewNopLogger()
-			}
-			chainID := fmt.Sprintf("chain-id-%d-%d", i, j)
-			config.ChainID = chainID
-
-			db := dbm.NewMemDB()
-			var emptyWasmOpts []wasmkeeper.Option
-
-			bApp, err := app.New(
-				logger,
-				db,
-				nil,
-				true,
-				appOptions,
-				emptyWasmOpts,
-				interBlockCacheOpt(),
-				baseapp.SetChainID(chainID),
-			)
-			require.NoError(t, err)
-
-			fmt.Printf(
-				"running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",
-				config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
-			)
-
-			_, _, err = simulation.SimulateFromSeed(
-				t,
-				os.Stdout,
-				bApp.BaseApp,
-				simtestutil.AppStateFn(
-					bApp.AppCodec(),
-					bApp.SimulationManager(),
-					bApp.DefaultGenesis(),
-				),
-				simulationtypes.RandomAccounts,
-				simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-				app.BlockedAddresses(),
-				config,
-				bApp.AppCodec(),
-			)
-			require.NoError(t, err)
-
-			if config.Commit {
-				simtestutil.PrintStats(db)
-			}
-
-			appHash := bApp.LastCommitID().Hash
-			appHashList[j] = appHash
-
-			if j != 0 {
-				require.Equal(
-					t, string(appHashList[0]), string(appHashList[j]),
-					"non-determinism in seed %d: %d/%d, attempt: %d/%d\n", config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
-				)
-			}
+		for i := 1; i < attempts; i++ {
+			require.Equalf(t, hashes[0], hashes[i],
+				"non-determinism in seed %d: attempt 0 vs %d", seed, i)
 		}
 	}
 }

--- a/inference-chain/app/simulation.go
+++ b/inference-chain/app/simulation.go
@@ -19,6 +19,12 @@ import (
 //   - wasmd v0.54.2: BuildOperationInput uses a failingAddressCodec
 //     rather than the app codec, so all wasm sim ops fail. Fixed in
 //     v0.60.0+ (CosmWasm/wasmd#2250).
+//   - group: x/group's sim ops (SimulateMsgUpdateGroupMembers etc.) pick a
+//     random group and remove/replace members. They cannot tell gonka's
+//     epoch-group x/group groups apart from their own, so they corrupt the
+//     validation groups gonka's epoch flow owns — desyncing them from
+//     EpochGroupData.ValidationWeights. gonka exercises x/group through its
+//     own ops (MsgValidation / revalidation votes), not x/group's stock ops.
 //
 // Originally proposed by hleb-albau in gonka-ai/gonka#995.
 type disabledOpsSimModule struct {

--- a/inference-chain/app/simulation.go
+++ b/inference-chain/app/simulation.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+)
+
+// disabledOpsSimModule wraps an AppModuleSimulation and returns nil from
+// WeightedOperations, so the wrapped module's sim ops are excluded from
+// the simulator while GenerateGenesisState and store decoders continue
+// to work through embedding. HasProposalMsgs and HasProposalContents are
+// not on AppModuleSimulation, so they are never promoted regardless of
+// the wrapped module.
+//
+// Used for:
+//   - staking/distribution: the PoC chain has no token bonding or
+//     traditional rewards (docs/cosmos_changes.md); the stock sim msgs
+//     target state machinery this fork has neutralised.
+//   - wasmd v0.54.2: BuildOperationInput uses a failingAddressCodec
+//     rather than the app codec, so all wasm sim ops fail. Fixed in
+//     v0.60.0+ (CosmWasm/wasmd#2250).
+//
+// Originally proposed by hleb-albau in gonka-ai/gonka#995.
+type disabledOpsSimModule struct {
+	module.AppModuleSimulation
+}
+
+// WeightedOperations always returns nil. See type doc.
+func (disabledOpsSimModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return nil
+}

--- a/inference-chain/app/simulation_test.go
+++ b/inference-chain/app/simulation_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSimModule is a non-nil AppModuleSimulation stub that returns a
+// non-empty WeightedOperations slice. Lets the test below show that
+// disabledOpsSimModule's override actually fires, instead of trivially
+// passing because of a nil embed.
+type stubSimModule struct {
+	module.AppModuleSimulation
+}
+
+func (stubSimModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return make([]simtypes.WeightedOperation, 1)
+}
+
+// TestDisabledOpsSimModule_SuppressesEmbeddedOps confirms the wrapper's
+// override takes precedence over the embedded module's
+// WeightedOperations.
+func TestDisabledOpsSimModule_SuppressesEmbeddedOps(t *testing.T) {
+	require.NotEmpty(t, stubSimModule{}.WeightedOperations(module.SimulationState{}))
+	wrapped := disabledOpsSimModule{stubSimModule{}}
+	require.Empty(t, wrapped.WeightedOperations(module.SimulationState{}))
+}

--- a/inference-chain/cmd/inferenced/cmd/config.go
+++ b/inference-chain/cmd/inferenced/cmd/config.go
@@ -3,31 +3,7 @@ package cmd
 import (
 	cmtcfg "github.com/cometbft/cometbft/config"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/productscience/inference/app"
 )
-
-const (
-	CoinType = 1200
-)
-
-func initSDKConfig() {
-	// Set prefixes
-	accountPubKeyPrefix := app.AccountAddressPrefix + "pub"
-	validatorAddressPrefix := app.AccountAddressPrefix + "valoper"
-	validatorPubKeyPrefix := app.AccountAddressPrefix + "valoperpub"
-	consNodeAddressPrefix := app.AccountAddressPrefix + "valcons"
-	consNodePubKeyPrefix := app.AccountAddressPrefix + "valconspub"
-
-	// Set and seal config
-	config := sdk.GetConfig()
-	config.SetCoinType(CoinType) // TODO: change to custom coin type
-	config.SetBech32PrefixForAccount(app.AccountAddressPrefix, accountPubKeyPrefix)
-	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
-	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)
-	config.Seal()
-}
 
 // initCometBFTConfig helps to override default CometBFT Config values.
 // return cmtcfg.DefaultConfig if no custom configuration is required for the application.

--- a/inference-chain/cmd/inferenced/cmd/root.go
+++ b/inference-chain/cmd/inferenced/cmd/root.go
@@ -29,7 +29,8 @@ import (
 
 // NewRootCmd creates a new root command for inferenced. It is called once in the main function.
 func NewRootCmd() *cobra.Command {
-	initSDKConfig()
+	app.InitSDKConfig()
+	app.SealSDKConfig()
 
 	var (
 		txConfigOpts       tx.ConfigOptions

--- a/inference-chain/testutil/keeper/inference.go
+++ b/inference-chain/testutil/keeper/inference.go
@@ -43,9 +43,10 @@ func InferenceKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	validatorSetMock := NewMockValidatorSet(ctrl)
 	groupMock := NewMockGroupMessageKeeper(ctrl)
 	stakingMock := NewMockStakingKeeper(ctrl)
-	// EnsureComputeValidators (x/inference/simulation, called by the op
-	// factories) invokes GetAllValidators; tolerate it with an empty set so
-	// it short-circuits before any SetComputeValidators round-trip.
+	// BuildEpochSubstrate (x/inference/simulation/substrate.go, called by
+	// the op factories) invokes GetAllValidators; tolerate it with an
+	// empty set so substrate short-circuits before any SetComputeValidators
+	// round-trip in unit tests that don't wire a real x/staking keeper.
 	stakingMock.EXPECT().GetAllValidators(gomock.Any()).
 		Return([]stakingtypes.Validator{}, nil).AnyTimes()
 	collateralMock := NewMockCollateralKeeper(ctrl)

--- a/inference-chain/testutil/keeper/inference.go
+++ b/inference-chain/testutil/keeper/inference.go
@@ -43,6 +43,11 @@ func InferenceKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	validatorSetMock := NewMockValidatorSet(ctrl)
 	groupMock := NewMockGroupMessageKeeper(ctrl)
 	stakingMock := NewMockStakingKeeper(ctrl)
+	// EnsureComputeValidators (x/inference/simulation, called by the op
+	// factories) invokes GetAllValidators; tolerate it with an empty set so
+	// it short-circuits before any SetComputeValidators round-trip.
+	stakingMock.EXPECT().GetAllValidators(gomock.Any()).
+		Return([]stakingtypes.Validator{}, nil).AnyTimes()
 	collateralMock := NewMockCollateralKeeper(ctrl)
 	streamvestingMock := NewMockStreamVestingKeeper(ctrl)
 	authzKeeper := NewMockAuthzKeeper(ctrl)

--- a/inference-chain/x/inference/epochgroup/epoch_group.go
+++ b/inference-chain/x/inference/epochgroup/epoch_group.go
@@ -87,7 +87,16 @@ func NewEpochMemberFromStakingValidator(
 		return nil, err
 	}
 
-	pubKey := validator.ConsensusPubkey.String()
+	// EpochMember.Pubkey is stored as the x/group member Metadata and read back
+	// by GetComputeResults via base64.StdEncoding.DecodeString to reconstruct the
+	// ed25519 validator key. Any.String() yields a "&Any{TypeUrl:...}" debug
+	// string that is not valid base64; encode the raw consensus key bytes the
+	// same way NewEpochMemberFromActiveParticipant does (ActiveParticipant.ValidatorKey).
+	consPubKey, err := validator.ConsPubKey()
+	if err != nil {
+		return nil, err
+	}
+	pubKey := base64.StdEncoding.EncodeToString(consPubKey.Bytes())
 
 	return &EpochMember{
 		Address:       accAddr,

--- a/inference-chain/x/inference/keeper/invariants.go
+++ b/inference-chain/x/inference/keeper/invariants.go
@@ -1,0 +1,217 @@
+package keeper
+
+import (
+	"context"
+	"fmt"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// RegisterInvariants wires this module's invariants into the crisis
+// module's registry. The simulation framework can also run them via a
+// post-run callback; see app/sim_test.go.
+//
+// Each invariant returns (description, broken). When broken == true, the
+// crisis module logs the description and (depending on config) halts the
+// chain. In sim, broken == true causes the test to fail with the message.
+func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
+	ir.RegisterRoute(types.ModuleName, "bank-backs-positive-balance", BankBacksPositiveBalanceInvariant(k))
+	ir.RegisterRoute(types.ModuleName, "no-stuck-voting", NoStuckVotingInvariant(k))
+	ir.RegisterRoute(types.ModuleName, "effective-epoch-fresh", EffectiveEpochFreshInvariant(k))
+	ir.RegisterRoute(types.ModuleName, "active-invalidations-ref-live", ActiveInvalidationsRefLiveInvariant(k))
+}
+
+// AllInvariants returns every invariant as a single function. Used by
+// the sim post-run callback so a violation logs which invariant fired.
+func AllInvariants(k Keeper) sdk.Invariant {
+	invs := []struct {
+		name string
+		fn   sdk.Invariant
+	}{
+		{"bank-backs-positive-balance", BankBacksPositiveBalanceInvariant(k)},
+		{"no-stuck-voting", NoStuckVotingInvariant(k)},
+		{"effective-epoch-fresh", EffectiveEpochFreshInvariant(k)},
+		{"active-invalidations-ref-live", ActiveInvalidationsRefLiveInvariant(k)},
+	}
+	return func(ctx sdk.Context) (string, bool) {
+		for _, inv := range invs {
+			if msg, broken := inv.fn(ctx); broken {
+				return sdk.FormatInvariant(types.ModuleName, inv.name, msg), true
+			}
+		}
+		return "", false
+	}
+}
+
+// --- A1 ----------------------------------------------------------------
+
+// BankBacksPositiveBalanceInvariant verifies that the inference module
+// account holds at least as many ngonka coins as the sum of all positive
+// participant CoinBalances. Catches: settle/payout flow paying out more
+// than the module can back, double-credit in validation share, drain via
+// underflow in invalidation refund.
+func BankBacksPositiveBalanceInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var positiveSum int64
+		err := iteratePositiveBalances(ctx, k, func(_ string, balance int64) {
+			positiveSum += balance
+		})
+		if err != nil {
+			return fmt.Sprintf("iterate participants: %v", err), true
+		}
+		moduleAddr := authtypes.NewModuleAddress(types.ModuleName)
+		moduleBalance := k.BankView.SpendableCoin(ctx, moduleAddr, types.BaseCoin).Amount.Int64()
+		if moduleBalance < positiveSum {
+			return fmt.Sprintf("module account %s has %d %s but participants are owed %d",
+				moduleAddr, moduleBalance, types.BaseCoin, positiveSum), true
+		}
+		return "", false
+	}
+}
+
+// --- B -----------------------------------------------------------------
+
+// NoStuckVotingInvariant verifies that no Inference is stuck in VOTING
+// more than 2 epochs past its own EpochId. Catches: x/group proposal
+// failed to execute (quorum miss); inference status transition lost;
+// `Revalidation:true` vote never reached.
+func NoStuckVotingInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		currentEpoch, found := k.GetEffectiveEpochIndex(ctx)
+		if !found {
+			return "", false
+		}
+		var stuck string
+		iter, err := k.Inferences.Iterate(ctx, nil)
+		if err != nil {
+			return fmt.Sprintf("iterate inferences: %v", err), true
+		}
+		defer iter.Close()
+		for ; iter.Valid(); iter.Next() {
+			inf, err := iter.Value()
+			if err != nil {
+				return fmt.Sprintf("decode inference: %v", err), true
+			}
+			if inf.Status != types.InferenceStatus_VOTING {
+				continue
+			}
+			if inf.EpochId+2 < currentEpoch {
+				stuck = fmt.Sprintf("inference %s stuck in VOTING since epoch %d (current epoch %d)",
+					inf.InferenceId, inf.EpochId, currentEpoch)
+				break
+			}
+		}
+		if stuck != "" {
+			return stuck, true
+		}
+		return "", false
+	}
+}
+
+// --- C -----------------------------------------------------------------
+
+// EffectiveEpochFreshInvariant verifies that EffectiveEpochIndex tracks
+// the highest Epoch.Index recorded in the Epochs map within +1 (the
+// upcoming-epoch window). Production lifecycle (epoch.go:73, GetUpcomingEpoch):
+// the next-to-become-effective epoch is written to Epochs[N+1] during
+// the PoC validation stage, BEFORE EffectiveEpochIndex flips on
+// onSetNewValidatorsStage. So a single Epoch.Index = EffectiveEpochIndex+1
+// is expected and not broken. Two or more pending upcoming epochs are.
+//
+// Catches: EffectiveEpochIndex stuck while multiple upcoming Epoch rows
+// pile up (epoch transition stalled); rollback bug.
+func EffectiveEpochFreshInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		current, found := k.GetEffectiveEpochIndex(ctx)
+		if !found {
+			// Pre-genesis state: no current index set yet. Treat as not broken.
+			return "", false
+		}
+		var maxStored uint64
+		iter, err := k.Epochs.Iterate(ctx, nil)
+		if err != nil {
+			return fmt.Sprintf("iterate epochs: %v", err), true
+		}
+		defer iter.Close()
+		for ; iter.Valid(); iter.Next() {
+			e, err := iter.Value()
+			if err != nil {
+				return fmt.Sprintf("decode epoch: %v", err), true
+			}
+			if e.Index > maxStored {
+				maxStored = e.Index
+			}
+		}
+		if current+1 < maxStored {
+			return fmt.Sprintf("EffectiveEpochIndex=%d trails max Epoch.Index=%d by more than the one-upcoming-epoch window",
+				current, maxStored), true
+		}
+		return "", false
+	}
+}
+
+// --- D -----------------------------------------------------------------
+
+// ActiveInvalidationsRefLiveInvariant verifies that every entry in the
+// ActiveInvalidations keyset references an existing Inference. Catches:
+// inference deleted while still in active-invalidations lifecycle;
+// dangling keyset entry from incomplete invalidation cleanup.
+//
+// ActiveInvalidations is keyed by (validator AccAddress, inferenceId
+// string); we check the second element for an existing Inferences entry.
+func ActiveInvalidationsRefLiveInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var dangling string
+		err := k.ActiveInvalidations.Walk(ctx, nil,
+			func(key collections.Pair[sdk.AccAddress, string]) (stop bool, err error) {
+				inferenceId := key.K2()
+				has, err := k.Inferences.Has(ctx, inferenceId)
+				if err != nil {
+					return true, err
+				}
+				if !has {
+					dangling = fmt.Sprintf("ActiveInvalidations references missing inference %q",
+						inferenceId)
+					return true, nil
+				}
+				return false, nil
+			})
+		if err != nil {
+			return fmt.Sprintf("walk ActiveInvalidations: %v", err), true
+		}
+		if dangling != "" {
+			return dangling, true
+		}
+		return "", false
+	}
+}
+
+// --- helpers -----------------------------------------------------------
+
+func iterateParticipants(ctx context.Context, k Keeper, cb func(types.Participant)) error {
+	iter, err := k.Participants.Iterate(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		p, err := iter.Value()
+		if err != nil {
+			return err
+		}
+		cb(p)
+	}
+	return nil
+}
+
+func iteratePositiveBalances(ctx context.Context, k Keeper, cb func(addr string, balance int64)) error {
+	return iterateParticipants(ctx, k, func(p types.Participant) {
+		if p.CoinBalance > 0 {
+			cb(p.Address, p.CoinBalance)
+		}
+	})
+}

--- a/inference-chain/x/inference/keeper/invariants_test.go
+++ b/inference-chain/x/inference/keeper/invariants_test.go
@@ -1,0 +1,163 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/collections"
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// --- A1: BankBacksPositiveBalance ----------------------------------------
+
+func TestInvariant_BankBacksPositiveBalance_Holds(t *testing.T) {
+	k, ctx, mocks := keepertest.InferenceKeeperReturningMocks(t)
+	// Two participants, total positive CoinBalance = 300.
+	setParticipant(t, k, ctx, "gonka1aaa", 100)
+	setParticipant(t, k, ctx, "gonka1bbb", 200)
+	// Module account has enough to back.
+	expectModuleBalance(mocks, 500)
+
+	msg, broken := keeper.BankBacksPositiveBalanceInvariant(k)(ctx)
+	require.False(t, broken, "should hold; msg=%q", msg)
+}
+
+func TestInvariant_BankBacksPositiveBalance_Broken(t *testing.T) {
+	k, ctx, mocks := keepertest.InferenceKeeperReturningMocks(t)
+	setParticipant(t, k, ctx, "gonka1aaa", 1000)
+	// Module account has only 100 — owed 1000.
+	expectModuleBalance(mocks, 100)
+
+	msg, broken := keeper.BankBacksPositiveBalanceInvariant(k)(ctx)
+	require.True(t, broken, "should be broken")
+	require.Contains(t, msg, "owed 1000")
+}
+
+// --- B: NoStuckVoting ----------------------------------------------------
+
+func TestInvariant_NoStuckVoting_Holds(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 5))
+	// VOTING inference from epoch 4: 4 + 2 = 6 >= 5 → holds.
+	setInference(t, k, ctx, "id-fresh", types.InferenceStatus_VOTING, 4)
+
+	msg, broken := keeper.NoStuckVotingInvariant(k)(ctx)
+	require.False(t, broken, "should hold; msg=%q", msg)
+}
+
+func TestInvariant_NoStuckVoting_Broken(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 5))
+	// VOTING from epoch 2: 2 + 2 = 4 < 5 → stuck.
+	setInference(t, k, ctx, "id-stuck", types.InferenceStatus_VOTING, 2)
+
+	msg, broken := keeper.NoStuckVotingInvariant(k)(ctx)
+	require.True(t, broken)
+	require.Contains(t, msg, "id-stuck")
+	require.Contains(t, msg, "epoch 2")
+}
+
+// --- C: EffectiveEpochFresh ----------------------------------------------
+
+func TestInvariant_EffectiveEpochFresh_Holds(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 5))
+	require.NoError(t, k.Epochs.Set(ctx, 3, types.Epoch{Index: 3}))
+	require.NoError(t, k.Epochs.Set(ctx, 5, types.Epoch{Index: 5}))
+
+	msg, broken := keeper.EffectiveEpochFreshInvariant(k)(ctx)
+	require.False(t, broken, "should hold; msg=%q", msg)
+}
+
+func TestInvariant_EffectiveEpochFresh_Broken(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 3))
+	// Stored epoch 7 > current 3 → broken.
+	require.NoError(t, k.Epochs.Set(ctx, 7, types.Epoch{Index: 7}))
+
+	msg, broken := keeper.EffectiveEpochFreshInvariant(k)(ctx)
+	require.True(t, broken)
+	require.Contains(t, msg, "EffectiveEpochIndex=3")
+	require.Contains(t, msg, "max Epoch.Index=7")
+}
+
+// --- D: ActiveInvalidationsRefLive ---------------------------------------
+
+func TestInvariant_ActiveInvalidationsRefLive_Holds(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	setInference(t, k, ctx, "live-inf", types.InferenceStatus_VOTING, 1)
+	validator := sdk.AccAddress("validator-aaaa")
+	require.NoError(t, k.ActiveInvalidations.Set(ctx, collections.Join(validator, "live-inf")))
+
+	msg, broken := keeper.ActiveInvalidationsRefLiveInvariant(k)(ctx)
+	require.False(t, broken, "should hold; msg=%q", msg)
+}
+
+func TestInvariant_ActiveInvalidationsRefLive_Broken(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	validator := sdk.AccAddress("validator-bbbb")
+	// No Inferences entry for this id → dangling reference.
+	require.NoError(t, k.ActiveInvalidations.Set(ctx, collections.Join(validator, "ghost-inf")))
+
+	msg, broken := keeper.ActiveInvalidationsRefLiveInvariant(k)(ctx)
+	require.True(t, broken)
+	require.Contains(t, msg, "ghost-inf")
+}
+
+// --- AllInvariants composite ---------------------------------------------
+
+func TestAllInvariants_StopsOnFirstBroken(t *testing.T) {
+	k, ctx, mocks := keepertest.InferenceKeeperReturningMocks(t)
+	// A1 always reaches SpendableCoin regardless of whether it trips;
+	// mock it generously so we can isolate the C violation we want to fire.
+	expectModuleBalance(mocks, 1_000_000)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 3))
+	// Trigger C: stored epoch ahead of current.
+	require.NoError(t, k.Epochs.Set(ctx, 9, types.Epoch{Index: 9}))
+
+	msg, broken := keeper.AllInvariants(k)(ctx)
+	require.True(t, broken)
+	require.Contains(t, msg, "effective-epoch-fresh")
+	require.Contains(t, msg, "invariant")
+}
+
+// --- helpers -------------------------------------------------------------
+
+func setParticipant(t *testing.T, k keeper.Keeper, ctx sdk.Context, addr string, balance int64) {
+	t.Helper()
+	accAddr, err := sdk.AccAddressFromBech32(addr)
+	if err != nil {
+		// Allow non-bech32 test strings; use raw bytes.
+		accAddr = sdk.AccAddress(addr)
+	}
+	require.NoError(t, k.Participants.Set(ctx, accAddr, types.Participant{
+		Address:           accAddr.String(),
+		CoinBalance:       balance,
+		CurrentEpochStats: &types.CurrentEpochStats{},
+	}))
+}
+
+func setInference(t *testing.T, k keeper.Keeper, ctx sdk.Context, id string, status types.InferenceStatus, epoch uint64) {
+	t.Helper()
+	require.NoError(t, k.Inferences.Set(ctx, id, types.Inference{
+		InferenceId: id,
+		Status:      status,
+		EpochId:     epoch,
+	}))
+}
+
+func expectModuleBalance(mocks keepertest.InferenceMocks, amount int64) {
+	mocks.BankViewKeeper.EXPECT().
+		SpendableCoin(gomock.Any(),
+			authtypes.NewModuleAddress(types.ModuleName),
+			types.BaseCoin).
+		Return(sdk.NewCoin(types.BaseCoin, sdkmath.NewInt(amount))).
+		AnyTimes()
+}

--- a/inference-chain/x/inference/keeper/refund_invalidation_bug_test.go
+++ b/inference-chain/x/inference/keeper/refund_invalidation_bug_test.go
@@ -1,0 +1,88 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/testutil/sample"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// TestRefundInvalidation_LeavesAccountingDrift constructively reproduces
+// the inference module's accounting drift triggered by
+// refundInvalidatedInference (`msg_server_invalidate_inference.go:64-79`).
+//
+// Scenario:
+//
+//  1. Client escrows ActualCost=500 ngonka via MsgStartInference; module
+//     account ends up holding the 500.
+//  2. Inference completes; executor's CoinBalance is credited the full
+//     500. A validator's vote then redistributes 100 of the 500 to the
+//     validator via shareWorkWithValidators
+//     (`msg_server_validation.go:483, :495`). Post-completion state:
+//     executor.CoinBalance=+400, validator.CoinBalance=+100,
+//     positiveSum=500, moduleBalance=500 — BankBacksPositiveBalance
+//     invariant holds.
+//  3. Inference is later invalidated. `refundInvalidatedInference` does:
+//        k.IssueRefund(ctx, ActualCost, RequestedBy, ...)   // bank: -500
+//        executor.CoinBalance -= ActualCost                  // ledger: -500 from executor only
+//     Validator's +100 claim is NOT touched.
+//
+// Post-invalidation state: executor.CoinBalance=-100, validator=+100,
+// positiveSum=100, moduleBalance=0. moduleBalance < positiveSum →
+// invariant fires by exactly the validator's share (100 ngonka), which
+// is the gap between the symmetric credit path (split among multiple
+// parties) and the asymmetric debit path (charged to executor only).
+//
+// This test demonstrates a single legitimate handler call breaking the
+// BankBacksPositiveBalanceInvariant. The drift is not a sim artefact —
+// it is deterministic from the handler's existing logic.
+func TestRefundInvalidation_LeavesAccountingDrift(t *testing.T) {
+	k, ctx, mocks := keepertest.InferenceKeeperReturningMocks(t)
+
+	// Bank mocks for the refund path:
+	// IssueRefund → PayParticipantFromEscrow → SendCoinsFromModuleToAccount
+	// + best-effort LogSubAccountTransaction.
+	mocks.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(
+			gomock.Any(), types.ModuleName, gomock.Any(), gomock.Any(), gomock.Any(),
+		).Return(nil).Times(1)
+	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).AnyTimes()
+
+	// Pre-state: executor +400, validator +100 (post-completion +
+	// post-validation-share). positiveSum = 500.
+	executorAddr := sample.AccAddress()
+	validatorAddr := sample.AccAddress()
+	requesterAddr := sample.AccAddress()
+	setParticipant(t, k, ctx, executorAddr, 400)
+	setParticipant(t, k, ctx, validatorAddr, 100)
+
+	const actualCost = int64(500)
+
+	// Mirror the two state mutations from refundInvalidatedInference at
+	// `msg_server_invalidate_inference.go:67` (bank refund) and `:74`
+	// (executor ledger debit). The handler is package-private; we call
+	// the same exported primitives in the same order.
+	require.NoError(t,
+		k.IssueRefund(ctx, actualCost, requesterAddr, "invalidated_inference:test-id"),
+	)
+	setParticipant(t, k, ctx, executorAddr, 400-actualCost)
+
+	// Module account: started at 500, paid out 500 in refund, now holds 0.
+	expectModuleBalance(mocks, 0)
+
+	msg, broken := keeper.BankBacksPositiveBalanceInvariant(k)(ctx)
+	require.Truef(t, broken,
+		"BUG REPRODUCED: refundInvalidatedInference debits full ActualCost from "+
+			"executor only — the validator's +100 claim from shareWorkWithValidators "+
+			"remains as positive CoinBalance, but the backing coins have already left "+
+			"the module account as refund. Invariant must fire. msg=%q", msg)
+	require.Contains(t, msg, "owed 100",
+		"module account expected to be unable to cover the validator's +100 claim")
+}

--- a/inference-chain/x/inference/module/chainvalidation_test.go
+++ b/inference-chain/x/inference/module/chainvalidation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/productscience/inference/x/inference/utils"
 
 	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/x/group"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,17 @@ import (
 
 var validatorOperatorAddress1 = "gonkavaloper1gcrlrhvw8kd7zr6pl92rxnc6j20chatkcx6w4t"
 var validatorOperatorAddress2 = "gonkavaloper1xk89s4ymj9y20aym3xa0mz4jhdx40hewckhw0u"
+
+// validatorConsPubAny returns an Any-wrapped ed25519 pubkey derived from
+// operatorAddr. Empty &codectypes.Any{} fails Validator.ConsPubKey() — the
+// path InitGenesis takes for staking validators.
+func validatorConsPubAny(t *testing.T, operatorAddr string) *codectypes.Any {
+	t.Helper()
+	pk := ed25519.GenPrivKeyFromSecret([]byte("test:" + operatorAddr)).PubKey()
+	a, err := codectypes.NewAnyWithValue(pk)
+	require.NoError(t, err)
+	return a
+}
 
 func TestComputeNewWeightsWithStakingValidators(t *testing.T) {
 	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonkapub")
@@ -42,12 +54,12 @@ func TestComputeNewWeightsWithStakingValidators(t *testing.T) {
 	validators := []stakingtypes.Validator{
 		{
 			OperatorAddress: validatorOperatorAddress1,
-			ConsensusPubkey: &codectypes.Any{},
+			ConsensusPubkey: validatorConsPubAny(t, validatorOperatorAddress1),
 			Tokens:          math.NewInt(100),
 		},
 		{
 			OperatorAddress: validatorOperatorAddress2,
-			ConsensusPubkey: &codectypes.Any{},
+			ConsensusPubkey: validatorConsPubAny(t, validatorOperatorAddress2),
 			Tokens:          math.NewInt(201),
 		},
 	}
@@ -340,7 +352,7 @@ func TestComputeNewWeights(t *testing.T) {
 				validators := []stakingtypes.Validator{
 					{
 						OperatorAddress: validatorOperatorAddress,
-						ConsensusPubkey: &codectypes.Any{},
+						ConsensusPubkey: validatorConsPubAny(t, validatorOperatorAddress),
 						Tokens:          math.NewInt(100),
 					},
 				}
@@ -659,7 +671,7 @@ func TestComputeNewWeights_AllowlistExcludesParticipant(t *testing.T) {
 	validators := []stakingtypes.Validator{
 		{
 			OperatorAddress: validatorOperatorAddress2,
-			ConsensusPubkey: &codectypes.Any{},
+			ConsensusPubkey: validatorConsPubAny(t, validatorOperatorAddress2),
 			Tokens:          math.NewInt(200),
 		},
 	}

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -152,7 +152,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 }
 
 // RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted)
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+	keeper.RegisterInvariants(ir, am.keeper)
+}
 
 // InitGenesis performs the module's genesis initialization. It returns no validator updates.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {

--- a/inference-chain/x/inference/module/simulation.go
+++ b/inference-chain/x/inference/module/simulation.go
@@ -56,6 +56,14 @@ const (
 	// TODO: Determine the simulation weight value
 	defaultWeightMsgRevalidateInference int = 100
 
+	opWeightMsgRevalidationVote = "op_weight_msg_revalidation_vote"
+	// Skewed above the uniform Phase 2 default of 100 so revalidation votes
+	// reliably coincide, within a block, with the failing MsgValidation that
+	// opened the proposals — the 4-minute group voting window closes before the
+	// next block. Provisional; this plan's Phase 3 weight-tuning chunk
+	// recalibrates from observed hit ratios.
+	defaultWeightMsgRevalidationVote int = 200
+
 	opWeightMsgClaimRewards = "op_weight_msg_claim_rewards"
 	// TODO: Determine the simulation weight value
 	defaultWeightMsgClaimRewards int = 100
@@ -63,6 +71,18 @@ const (
 	opWeightMsgSubmitPocBatch = "op_weight_msg_submit_poc_batch"
 	// TODO: Determine the simulation weight value
 	defaultWeightMsgSubmitPocBatch int = 100
+
+	opWeightMsgPoCV2StoreCommit = "op_weight_msg_poc_v2_store_commit"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgPoCV2StoreCommit int = 100
+
+	opWeightMsgMLNodeWeightDistribution = "op_weight_msg_ml_node_weight_distribution"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgMLNodeWeightDistribution int = 100
+
+	opWeightMsgSubmitPocValidationsV2 = "op_weight_msg_submit_poc_validations_v2"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgSubmitPocValidationsV2 int = 100
 
 	opWeightMsgSubmitSeed = "op_weight_msg_submit_seed"
 	// TODO: Determine the simulation weight value
@@ -91,7 +111,7 @@ const (
 //
 //   - ParticipantList is pre-seeded so the four ActiveParticipant-gated ops
 //     (Start/Finish/Validation/ClaimRewards) have someone to promote via
-//     EnsureActiveParticipantsSeeded (x/inference/simulation/bootstrap.go).
+//     BuildEpochSubstrate (x/inference/simulation/substrate.go).
 //   - ModelList is pre-seeded with Qwen + Kimi (mainnet-realistic values)
 //     so MsgStartInference's RecordInferencePrice has a
 //     governance-registered model to look up. EnsureModelsInEpochGroup
@@ -100,7 +120,7 @@ const (
 //     state BeginBlocker / UpdateDynamicPricing iterate.
 func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	inferenceGenesis := types.GenesisState{
-		Params:            types.DefaultParams(),
+		Params:            inferencesimulation.BuildSimGenesisParams(),
 		GenesisOnlyParams: types.DefaultGenesisOnlyParams(),
 		ParticipantList:   inferencesimulation.BuildSimGenesisParticipants(simState),
 		ModelList:         inferencesimulation.BuildSimGenesisModels(),
@@ -432,6 +452,16 @@ func (am AppModule) WeightedOperationsX(weights simsx.WeightSource, reg simsx.Re
 		inferencesimulation.MsgFinishInferenceFactory(am.keeper))
 	reg.Add(weights.Get(opWeightMsgValidation, uint32(defaultWeightMsgValidation)),
 		inferencesimulation.MsgValidationFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgRevalidationVote, uint32(defaultWeightMsgRevalidationVote)),
+		inferencesimulation.MsgRevalidationVoteFactory(am.keeper, am.groupMsgServer))
 	reg.Add(weights.Get(opWeightMsgClaimRewards, uint32(defaultWeightMsgClaimRewards)),
 		inferencesimulation.MsgClaimRewardsFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgPoCV2StoreCommit, uint32(defaultWeightMsgPoCV2StoreCommit)),
+		inferencesimulation.MsgPoCV2StoreCommitFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgMLNodeWeightDistribution, uint32(defaultWeightMsgMLNodeWeightDistribution)),
+		inferencesimulation.MsgMLNodeWeightDistributionFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgSubmitPocValidationsV2, uint32(defaultWeightMsgSubmitPocValidationsV2)),
+		inferencesimulation.MsgSubmitPocValidationsV2Factory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgSubmitSeed, uint32(defaultWeightMsgSubmitSeed)),
+		inferencesimulation.MsgSubmitSeedFactory(am.keeper))
 }

--- a/inference-chain/x/inference/module/simulation.go
+++ b/inference-chain/x/inference/module/simulation.go
@@ -3,6 +3,7 @@ package inference
 import (
 	"math/rand"
 
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -87,14 +88,22 @@ const (
 )
 
 // GenerateGenesisState creates a randomized GenState of the module.
+//
+//   - ParticipantList is pre-seeded so the four ActiveParticipant-gated ops
+//     (Start/Finish/Validation/ClaimRewards) have someone to promote via
+//     EnsureActiveParticipantsSeeded (x/inference/simulation/bootstrap.go).
+//   - ModelList is pre-seeded with Qwen + Kimi (mainnet-realistic values)
+//     so MsgStartInference's RecordInferencePrice has a
+//     governance-registered model to look up. EnsureModelsInEpochGroup
+//     (x/inference/simulation/bootstrap.go) promotes them into the genesis
+//     EpochGroup's SubGroupModels on first op invocation, which is the
+//     state BeginBlocker / UpdateDynamicPricing iterate.
 func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
-	accs := make([]string, len(simState.Accounts))
-	for i, acc := range simState.Accounts {
-		accs[i] = acc.Address.String()
-	}
 	inferenceGenesis := types.GenesisState{
 		Params:            types.DefaultParams(),
 		GenesisOnlyParams: types.DefaultGenesisOnlyParams(),
+		ParticipantList:   inferencesimulation.BuildSimGenesisParticipants(simState),
+		ModelList:         inferencesimulation.BuildSimGenesisModels(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&inferenceGenesis) //nolint:forbidigo // Simulation code
@@ -406,4 +415,23 @@ func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.Wei
 		),
 		// this line is used by starport scaffolding # simapp/module/OpMsg
 	}
+}
+
+// WeightedOperationsX registers the Phase 2 first-wave x/inference message
+// factories with the simsx runner. simsx.Run prefers this method over the
+// legacy WeightedOperations() when an AppModule implements HasWeightedOperationsX
+// (see fork testutil/simsx/runner.go:333). Phase 2 first-wave covers:
+// SubmitNewParticipant, StartInference, FinishInference, Validation, ClaimRewards.
+// Remaining ops stay on the legacy WeightedOperations() path until Phase 3.
+func (am AppModule) WeightedOperationsX(weights simsx.WeightSource, reg simsx.Registry) {
+	reg.Add(weights.Get(opWeightMsgSubmitNewParticipant, uint32(defaultWeightMsgSubmitNewParticipant)),
+		inferencesimulation.MsgSubmitNewParticipantFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgStartInference, uint32(defaultWeightMsgStartInference)),
+		inferencesimulation.MsgStartInferenceFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgFinishInference, uint32(defaultWeightMsgFinishInference)),
+		inferencesimulation.MsgFinishInferenceFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgValidation, uint32(defaultWeightMsgValidation)),
+		inferencesimulation.MsgValidationFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgClaimRewards, uint32(defaultWeightMsgClaimRewards)),
+		inferencesimulation.MsgClaimRewardsFactory(am.keeper))
 }

--- a/inference-chain/x/inference/module/simulation.go
+++ b/inference-chain/x/inference/module/simulation.go
@@ -25,28 +25,32 @@ var (
 
 const (
 	opWeightMsgStartInference = "op_weight_msg_start_inference"
-	// TODO: Determine the simulation weight value
+	// Inference-lifecycle baseline (highest-frequency op); other weights are
+	// tuned relative to this 100.
 	defaultWeightMsgStartInference int = 100
 
 	opWeightMsgFinishInference = "op_weight_msg_finish_inference"
-	// TODO: Determine the simulation weight value
+	// Pairs 1:1 with StartInference, so same baseline weight.
 	defaultWeightMsgFinishInference int = 100
 
 	opWeightMsgSubmitNewParticipant = "op_weight_msg_submit_new_participant"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgSubmitNewParticipant int = 100
+	// Registration is infrequent relative to inference traffic; the genesis
+	// sim participants already populate the active set, so new joins are rare.
+	defaultWeightMsgSubmitNewParticipant int = 20
 
 	opWeightMsgValidation = "op_weight_msg_validation"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgValidation int = 100
+	// Highest-frequency post-inference op and the highest bug-finding value
+	// path (validation/invalidation/refund accounting), so skewed above the
+	// inference-lifecycle baseline.
+	defaultWeightMsgValidation int = 130
 
 	opWeightMsgSubmitPoC = "op_weight_msg_submit_po_c"
 	// TODO: Determine the simulation weight value
 	defaultWeightMsgSubmitPoC int = 100
 
 	opWeightMsgSubmitNewUnfundedParticipant = "op_weight_msg_submit_new_unfunded_participant"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgSubmitNewUnfundedParticipant int = 100
+	// Direct (unfunded) registration is rare relative to inference traffic.
+	defaultWeightMsgSubmitNewUnfundedParticipant int = 15
 
 	opWeightMsgInvalidateInference = "op_weight_msg_invalidate_inference"
 	// TODO: Determine the simulation weight value
@@ -65,40 +69,43 @@ const (
 	defaultWeightMsgRevalidationVote int = 200
 
 	opWeightMsgClaimRewards = "op_weight_msg_claim_rewards"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgClaimRewards int = 100
+	// Periodic (per settlement cycle), not per-block, so below the
+	// inference-lifecycle baseline.
+	defaultWeightMsgClaimRewards int = 40
 
 	opWeightMsgSubmitPocBatch = "op_weight_msg_submit_poc_batch"
 	// TODO: Determine the simulation weight value
 	defaultWeightMsgSubmitPocBatch int = 100
 
 	opWeightMsgPoCV2StoreCommit = "op_weight_msg_poc_v2_store_commit"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgPoCV2StoreCommit int = 100
+	// Per-PoC-window op (self-reschedules via future-ops); fires only inside
+	// its exchange window, so a moderate weight suffices.
+	defaultWeightMsgPoCV2StoreCommit int = 80
 
 	opWeightMsgMLNodeWeightDistribution = "op_weight_msg_ml_node_weight_distribution"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgMLNodeWeightDistribution int = 100
+	// Per-PoC-window op (paired with the commit above).
+	defaultWeightMsgMLNodeWeightDistribution int = 80
 
 	opWeightMsgSubmitPocValidationsV2 = "op_weight_msg_submit_poc_validations_v2"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgSubmitPocValidationsV2 int = 100
+	// Per-PoC-validation-window op.
+	defaultWeightMsgSubmitPocValidationsV2 int = 80
 
 	opWeightMsgSubmitSeed = "op_weight_msg_submit_seed"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgSubmitSeed int = 100
+	// Once per epoch per participant; low weight (extra attempts just skip on
+	// "seed already submitted").
+	defaultWeightMsgSubmitSeed int = 30
 
 	opWeightMsgSubmitUnitOfComputePriceProposal = "op_weight_msg_submit_unit_of_compute_price_proposal"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgSubmitUnitOfComputePriceProposal int = 100
+	// Pricing proposals are occasional (per-participant governance input).
+	defaultWeightMsgSubmitUnitOfComputePriceProposal int = 30
 
 	opWeightMsgRegisterModel = "op_weight_msg_register_model"
 	// TODO: Determine the simulation weight value
 	defaultWeightMsgRegisterModel int = 100
 
 	opWeightMsgSubmitHardwareDiff = "op_weight_msg_submit_hardware_diff"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgSubmitHardwareDiff int = 100
+	// Hardware topology changes are occasional, not per-block.
+	defaultWeightMsgSubmitHardwareDiff int = 25
 
 	opWeightMsgCreatePartialUpgrade = "op_weight_msg_create_partial_upgrade"
 	// TODO: Determine the simulation weight value
@@ -120,7 +127,7 @@ const (
 //     state BeginBlocker / UpdateDynamicPricing iterate.
 func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	inferenceGenesis := types.GenesisState{
-		Params:            inferencesimulation.BuildSimGenesisParams(),
+		Params:            inferencesimulation.BuildSimGenesisParams(simState),
 		GenesisOnlyParams: types.DefaultGenesisOnlyParams(),
 		ParticipantList:   inferencesimulation.BuildSimGenesisParticipants(simState),
 		ModelList:         inferencesimulation.BuildSimGenesisModels(),
@@ -129,8 +136,13 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&inferenceGenesis) //nolint:forbidigo // Simulation code
 }
 
-// RegisterStoreDecoder registers a decoder.
-func (am AppModule) RegisterStoreDecoder(_ simtypes.StoreDecoderRegistry) {}
+// RegisterStoreDecoder wires the x/inference store decoder so that
+// AppHash-divergence dumps (TestAppImportExport_Postrun and the
+// TestAppStateDeterminism divergence dump added in this chunk) print
+// readable proto state instead of raw hex.
+func (am AppModule) RegisterStoreDecoder(sdr simtypes.StoreDecoderRegistry) {
+	sdr[types.StoreKey] = inferencesimulation.NewDecodeStore(am.cdc)
+}
 
 // WeightedOperations returns the all the gov module operations with their respective weights.
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
@@ -437,12 +449,18 @@ func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.Wei
 	}
 }
 
-// WeightedOperationsX registers the Phase 2 first-wave x/inference message
-// factories with the simsx runner. simsx.Run prefers this method over the
-// legacy WeightedOperations() when an AppModule implements HasWeightedOperationsX
-// (see fork testutil/simsx/runner.go:333). Phase 2 first-wave covers:
-// SubmitNewParticipant, StartInference, FinishInference, Validation, ClaimRewards.
-// Remaining ops stay on the legacy WeightedOperations() path until Phase 3.
+// WeightedOperationsX registers the real x/inference message factories with
+// the simsx runner. simsx.Run prefers this method over the legacy
+// WeightedOperations() when an AppModule implements HasWeightedOperationsX
+// (see fork testutil/simsx/runner.go:333). Covered messages: the inference
+// lifecycle (SubmitNewParticipant, Start/Finish, Validation, RevalidationVote,
+// ClaimRewards), the PoC-v2 chain (PoCV2StoreCommit, MLNodeWeightDistribution,
+// SubmitPocValidationsV2, SubmitSeed), and the participant-self ops
+// (SubmitUnitOfComputePriceProposal, SubmitHardwareDiff,
+// SubmitNewUnfundedParticipant). Authority-gated ops (allow-list, UpdateParams)
+// are not factory-driven — their signer is the gov module account, which a
+// simsx factory cannot sign for; mutable params are instead varied via genesis
+// fuzzing (see x/inference/simulation/genesis_fuzz.go).
 func (am AppModule) WeightedOperationsX(weights simsx.WeightSource, reg simsx.Registry) {
 	reg.Add(weights.Get(opWeightMsgSubmitNewParticipant, uint32(defaultWeightMsgSubmitNewParticipant)),
 		inferencesimulation.MsgSubmitNewParticipantFactory(am.keeper))
@@ -464,4 +482,10 @@ func (am AppModule) WeightedOperationsX(weights simsx.WeightSource, reg simsx.Re
 		inferencesimulation.MsgSubmitPocValidationsV2Factory(am.keeper))
 	reg.Add(weights.Get(opWeightMsgSubmitSeed, uint32(defaultWeightMsgSubmitSeed)),
 		inferencesimulation.MsgSubmitSeedFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgSubmitUnitOfComputePriceProposal, uint32(defaultWeightMsgSubmitUnitOfComputePriceProposal)),
+		inferencesimulation.MsgSubmitUnitOfComputePriceProposalFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgSubmitHardwareDiff, uint32(defaultWeightMsgSubmitHardwareDiff)),
+		inferencesimulation.MsgSubmitHardwareDiffFactory(am.keeper))
+	reg.Add(weights.Get(opWeightMsgSubmitNewUnfundedParticipant, uint32(defaultWeightMsgSubmitNewUnfundedParticipant)),
+		inferencesimulation.MsgSubmitNewUnfundedParticipantFactory(am.keeper))
 }

--- a/inference-chain/x/inference/module/simulation.go
+++ b/inference-chain/x/inference/module/simulation.go
@@ -93,7 +93,8 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 		accs[i] = acc.Address.String()
 	}
 	inferenceGenesis := types.GenesisState{
-		Params: types.DefaultParams(),
+		Params:            types.DefaultParams(),
+		GenesisOnlyParams: types.DefaultGenesisOnlyParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState
 	}
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&inferenceGenesis) //nolint:forbidigo // Simulation code

--- a/inference-chain/x/inference/simulation/active_participants_pick.go
+++ b/inference-chain/x/inference/simulation/active_participants_pick.go
@@ -6,6 +6,8 @@ import (
 	"cosmossdk.io/collections"
 	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/cosmos/cosmos-sdk/x/group"
 
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/types"
@@ -37,9 +39,15 @@ func collectInferencesByStatus(
 	return out, nil
 }
 
-// PickRandomFinishedInference returns a FINISHED-status Inference from the
-// on-chain Inferences collection. If none exists yet (no Start+Finish pair
-// has completed) the reporter is Skipped and (zero, false) is returned.
+// PickRandomFinishedInference returns a FINISHED-status Inference whose
+// EpochId is within the last two epochs (inference.EpochId >=
+// currentEpoch-1). Older inferences are filtered out because the
+// MsgValidation handler keys its transient validation cache by EpochId;
+// stale epochs no longer have a live ActiveParticipantsSet entry, so
+// PickRandomActiveSimAccountExcluding would return a validator whose
+// permission check fails the handler with «participant is not active»
+// and aborts the simsx run. If none qualifies the reporter is Skipped
+// and (zero, false) is returned.
 //
 // Used by MsgValidationFactory: passing a STARTED-status inference to
 // MsgValidation triggers the hard ErrInferenceNotFinished path
@@ -55,6 +63,11 @@ func PickRandomFinishedInference(
 	testData *simsx.ChainDataSource,
 	reporter simsx.SimulationReporter,
 ) (types.Inference, bool) {
+	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+	if err != nil {
+		reporter.Skipf("EffectiveEpochIndex get failed: %v", err)
+		return types.Inference{}, false
+	}
 	finished, err := collectInferencesByStatus(ctx, k, types.InferenceStatus_FINISHED)
 	if err != nil {
 		reporter.Skipf("Inferences scan failed: %v", err)
@@ -64,7 +77,20 @@ func PickRandomFinishedInference(
 		reporter.Skip("no FINISHED inferences in keeper yet")
 		return types.Inference{}, false
 	}
-	return finished[testData.Rand().Intn(len(finished))], true
+	// inf.EpochId+1 >= currentEpoch guards against uint64 underflow at
+	// currentEpoch == 0; at currentEpoch == N the test admits EpochIds
+	// {N-1, N, N+1, ...}, i.e. anything not strictly older than N-1.
+	fresh := finished[:0]
+	for _, inf := range finished {
+		if currentEpoch == 0 || inf.EpochId+1 >= currentEpoch {
+			fresh = append(fresh, inf)
+		}
+	}
+	if len(fresh) == 0 {
+		reporter.Skipf("no FINISHED inferences in last two epochs (current=%d)", currentEpoch)
+		return types.Inference{}, false
+	}
+	return fresh[testData.Rand().Intn(len(fresh))], true
 }
 
 // FindRandomStartedInference returns a random STARTED-status inference
@@ -116,6 +142,43 @@ func PickRandomGovernanceModelID(
 	return models[testData.Rand().Intn(len(models))].Id, true
 }
 
+// PickRandomSupportedGovernanceModelID returns a random governance model that
+// the given active participant supports in the specified epoch. Start/finish
+// factories use this after choosing an executor so generated inferences do not
+// assign that executor to a model sub-group it does not belong to.
+func PickRandomSupportedGovernanceModelID(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+	epoch uint64,
+	participantAddr string,
+) (string, bool) {
+	active, found := k.GetActiveParticipants(ctx, epoch)
+	if !found {
+		reporter.Skipf("ActiveParticipants for epoch %d not found", epoch)
+		return "", false
+	}
+
+	var supported []string
+	for _, participant := range active.Participants {
+		if participant == nil || participant.Index != participantAddr {
+			continue
+		}
+		for _, modelID := range participant.Models {
+			if _, found := k.GetGovernanceModel(ctx, modelID); found {
+				supported = append(supported, modelID)
+			}
+		}
+		break
+	}
+	if len(supported) == 0 {
+		reporter.Skipf("active participant %s has no supported governance models in epoch %d", participantAddr, epoch)
+		return "", false
+	}
+	return supported[testData.Rand().Intn(len(supported))], true
+}
+
 // PickRandomActiveSimAccountExcluding behaves like PickRandomActiveSimAccount
 // but draws from a CALLER-SPECIFIED epoch's ActiveParticipantsSet and filters
 // out the given address. MsgValidationFactory must pick a validator from the
@@ -133,6 +196,11 @@ func PickRandomActiveSimAccountExcluding(
 	epoch uint64,
 	excludeAddr string,
 ) (simsx.SimAccount, bool) {
+	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+	if err != nil {
+		reporter.Skipf("EffectiveEpochIndex get failed: %v", err)
+		return simsx.SimAccount{}, false
+	}
 	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
 		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](epoch))
 	if err != nil {
@@ -150,6 +218,14 @@ func PickRandomActiveSimAccountExcluding(
 		}
 		bech := key.K2().String()
 		if bech == excludeAddr {
+			continue
+		}
+		excluded, err := k.ExcludedParticipantsMap.Has(ctx, collections.Join(currentEpoch, key.K2()))
+		if err != nil {
+			reporter.Skipf("ExcludedParticipantsMap lookup failed: %v", err)
+			return simsx.SimAccount{}, false
+		}
+		if excluded {
 			continue
 		}
 		addrs = append(addrs, key.K2())
@@ -175,9 +251,9 @@ func PickRandomActiveSimAccountExcluding(
 // pick index is drawn from testData.Rand() so the same seed reproduces the
 // same choice.
 //
-// Pairs with EnsureActiveParticipantsSeeded (bootstrap.go): factories
-// should call EnsureActiveParticipantsSeeded first so this picker has a
-// non-empty set to draw from.
+// Pairs with BuildEpochSubstrate (substrate.go): factories should call
+// BuildEpochSubstrate first so ActiveParticipants[currentEpoch] is
+// populated and this picker has a non-empty set to draw from.
 func PickRandomActiveSimAccount(
 	ctx context.Context,
 	k keeper.Keeper,
@@ -204,6 +280,14 @@ func PickRandomActiveSimAccount(
 			reporter.Skipf("ActiveParticipantsSet key decode failed: %v", err)
 			return simsx.SimAccount{}, false
 		}
+		excluded, err := k.ExcludedParticipantsMap.Has(ctx, collections.Join(currentEpoch, key.K2()))
+		if err != nil {
+			reporter.Skipf("ExcludedParticipantsMap lookup failed: %v", err)
+			return simsx.SimAccount{}, false
+		}
+		if excluded {
+			continue
+		}
 		addrs = append(addrs, key.K2())
 	}
 	if len(addrs) == 0 {
@@ -217,4 +301,63 @@ func PickRandomActiveSimAccount(
 		return simsx.SimAccount{}, false
 	}
 	return testData.GetAccount(reporter, pick.String()), true
+}
+
+// PickRandomVotingInferenceWithOpenProposal returns a VOTING-status inference
+// whose x/group invalidation proposals are still inside their voting window
+// (created in the current block).
+//
+// The validation group's voting period is 4 minutes (epochgroup/epoch_group.go
+// CreateGroup), while the cosmos simulation advances block time by 5000-10000 s
+// per block (x/simulation/simulate.go) — so a proposal is votable only in the
+// very block it was submitted. Among the live inferences the one with the
+// highest ReValidatePolicyId is returned: every revalidation op in a block then
+// converges on the same freshest proposal pair, the only way to concentrate
+// enough YES weight to cross the 50% PercentageDecisionPolicy quorum before the
+// block ends. Deterministic (no rng) so same-seed runs reproduce.
+//
+// Returns (zero, false) when no VOTING inference has an open proposal.
+func PickRandomVotingInferenceWithOpenProposal(
+	ctx context.Context,
+	k keeper.Keeper,
+	groupKeeper types.GroupMessageKeeper,
+) (types.Inference, bool) {
+	voting, err := collectInferencesByStatus(ctx, k, types.InferenceStatus_VOTING)
+	if err != nil || len(voting) == 0 {
+		return types.Inference{}, false
+	}
+	var best types.Inference
+	found := false
+	for _, inf := range voting {
+		if inf.ProposalDetails == nil || !proposalWindowOpen(ctx, groupKeeper, inf.ProposalDetails) {
+			continue
+		}
+		if !found || inf.ProposalDetails.ReValidatePolicyId > best.ProposalDetails.ReValidatePolicyId {
+			best, found = inf, true
+		}
+	}
+	return best, found
+}
+
+// proposalWindowOpen reports whether the ReValidate proposal behind a VOTING
+// inference is still SUBMITTED and before its VotingPeriodEnd. Both proposals
+// from submitValidationProposalsWithPolicy (msg_server_validation.go) share one
+// VotingPeriodEnd, so the ReValidate one stands in for the pair. The query is
+// reverse-paginated: only the most recent proposals — those created this
+// block — can still be open.
+func proposalWindowOpen(ctx context.Context, groupKeeper types.GroupMessageKeeper, pd *types.ProposalDetails) bool {
+	resp, err := groupKeeper.ProposalsByGroupPolicy(ctx, &group.QueryProposalsByGroupPolicyRequest{
+		Address:    pd.PolicyAddress,
+		Pagination: &query.PageRequest{Reverse: true, Limit: 128},
+	})
+	if err != nil || resp == nil {
+		return false
+	}
+	blockTime := sdk.UnwrapSDKContext(ctx).BlockTime()
+	for _, p := range resp.Proposals {
+		if p.Id == pd.ReValidatePolicyId {
+			return p.Status == group.PROPOSAL_STATUS_SUBMITTED && p.VotingPeriodEnd.After(blockTime)
+		}
+	}
+	return false
 }

--- a/inference-chain/x/inference/simulation/active_participants_pick.go
+++ b/inference-chain/x/inference/simulation/active_participants_pick.go
@@ -1,0 +1,220 @@
+package simulation
+
+import (
+	"context"
+
+	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// collectInferencesByStatus returns every Inference in the keeper whose
+// Status matches. Iteration order is collections-sorted by InferenceId,
+// so a same-seed pick over the result is deterministic.
+func collectInferencesByStatus(
+	ctx context.Context,
+	k keeper.Keeper,
+	status types.InferenceStatus,
+) ([]types.Inference, error) {
+	iter, err := k.Inferences.Iterate(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+	out := make([]types.Inference, 0, 16)
+	for ; iter.Valid(); iter.Next() {
+		val, err := iter.Value()
+		if err != nil {
+			return nil, err
+		}
+		if val.Status == status {
+			out = append(out, val)
+		}
+	}
+	return out, nil
+}
+
+// PickRandomFinishedInference returns a FINISHED-status Inference from the
+// on-chain Inferences collection. If none exists yet (no Start+Finish pair
+// has completed) the reporter is Skipped and (zero, false) is returned.
+//
+// Used by MsgValidationFactory: passing a STARTED-status inference to
+// MsgValidation triggers the hard ErrInferenceNotFinished path
+// (msg_server_validation.go) which would abort the simsx run.
+// Skip-on-empty keeps the simulation progressing until at least one
+// Start→Finish pair lands.
+//
+// Returns the full Inference, not just its ID — collectInferencesByStatus
+// already deserialized it, so the caller needs no second keeper read.
+func PickRandomFinishedInference(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+) (types.Inference, bool) {
+	finished, err := collectInferencesByStatus(ctx, k, types.InferenceStatus_FINISHED)
+	if err != nil {
+		reporter.Skipf("Inferences scan failed: %v", err)
+		return types.Inference{}, false
+	}
+	if len(finished) == 0 {
+		reporter.Skip("no FINISHED inferences in keeper yet")
+		return types.Inference{}, false
+	}
+	return finished[testData.Rand().Intn(len(finished))], true
+}
+
+// FindRandomStartedInference returns a random STARTED-status inference
+// whose AssignedTo address is a known sim account (so the Finish factory
+// can sign as it). Returns (zero, false) when none qualifies — the
+// caller then falls back to a fresh finish-first message rather than
+// Skipping. Does NOT touch the reporter.
+func FindRandomStartedInference(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+) (types.Inference, bool) {
+	started, err := collectInferencesByStatus(ctx, k, types.InferenceStatus_STARTED)
+	if err != nil || len(started) == 0 {
+		return types.Inference{}, false
+	}
+	eligible := started[:0]
+	for _, inf := range started {
+		if inf.AssignedTo != "" && testData.HasAccount(inf.AssignedTo) {
+			eligible = append(eligible, inf)
+		}
+	}
+	if len(eligible) == 0 {
+		return types.Inference{}, false
+	}
+	return eligible[testData.Rand().Intn(len(eligible))], true
+}
+
+// PickRandomGovernanceModelID returns a model Id from the on-chain
+// Models collection at random. If empty (no models registered) the
+// reporter is Skipped and ("", false) is returned. Deterministic across
+// same-seed runs because GetGovernanceModels returns the
+// collections-sorted (bech32-key string) view.
+func PickRandomGovernanceModelID(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+) (string, bool) {
+	models, err := k.GetGovernanceModels(ctx)
+	if err != nil {
+		reporter.Skipf("GetGovernanceModels failed: %v", err)
+		return "", false
+	}
+	if len(models) == 0 {
+		reporter.Skip("no governance models registered")
+		return "", false
+	}
+	return models[testData.Rand().Intn(len(models))].Id, true
+}
+
+// PickRandomActiveSimAccountExcluding behaves like PickRandomActiveSimAccount
+// but draws from a CALLER-SPECIFIED epoch's ActiveParticipantsSet and filters
+// out the given address. MsgValidationFactory must pick a validator from the
+// *inference's* epoch — not the current epoch — because the handler keys the
+// transient validation cache by inference.EpochId (GetCachedEpochDataModelWeight,
+// msg_server_validation.go). Drawing from the current epoch breaks after an
+// epoch transition: a current-epoch validator is absent from a previous-epoch
+// inference's cache and the handler hard-fails with ErrParticipantNotFound.
+// Also satisfies validator!=executor (msg_server_validation.go).
+func PickRandomActiveSimAccountExcluding(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+	epoch uint64,
+	excludeAddr string,
+) (simsx.SimAccount, bool) {
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](epoch))
+	if err != nil {
+		reporter.Skipf("ActiveParticipantsSet iterate failed: %v", err)
+		return simsx.SimAccount{}, false
+	}
+	defer iter.Close()
+
+	addrs := make([]sdk.AccAddress, 0, 8)
+	for ; iter.Valid(); iter.Next() {
+		key, err := iter.Key()
+		if err != nil {
+			reporter.Skipf("ActiveParticipantsSet key decode failed: %v", err)
+			return simsx.SimAccount{}, false
+		}
+		bech := key.K2().String()
+		if bech == excludeAddr {
+			continue
+		}
+		addrs = append(addrs, key.K2())
+	}
+	if len(addrs) == 0 {
+		reporter.Skipf("no active participants in epoch %d other than %s", epoch, excludeAddr)
+		return simsx.SimAccount{}, false
+	}
+	pick := addrs[testData.Rand().Intn(len(addrs))]
+	if !testData.HasAccount(pick.String()) {
+		reporter.Skipf("active participant %s not in sim accounts", pick.String())
+		return simsx.SimAccount{}, false
+	}
+	return testData.GetAccount(reporter, pick.String()), true
+}
+
+// PickRandomActiveSimAccount returns a sim account whose address is in
+// ActiveParticipantsSet[currentEpoch]. On any miss (empty set, address not
+// in sim accounts, keeper error) the reporter is Skipped with an
+// informative message and (zero, false) is returned.
+//
+// Determinism: ActiveParticipantsSet iteration is collections-sorted; the
+// pick index is drawn from testData.Rand() so the same seed reproduces the
+// same choice.
+//
+// Pairs with EnsureActiveParticipantsSeeded (bootstrap.go): factories
+// should call EnsureActiveParticipantsSeeded first so this picker has a
+// non-empty set to draw from.
+func PickRandomActiveSimAccount(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	reporter simsx.SimulationReporter,
+) (simsx.SimAccount, bool) {
+	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+	if err != nil {
+		reporter.Skipf("EffectiveEpochIndex get failed: %v", err)
+		return simsx.SimAccount{}, false
+	}
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](currentEpoch))
+	if err != nil {
+		reporter.Skipf("ActiveParticipantsSet iterate failed: %v", err)
+		return simsx.SimAccount{}, false
+	}
+	defer iter.Close()
+
+	addrs := make([]sdk.AccAddress, 0, 8)
+	for ; iter.Valid(); iter.Next() {
+		key, err := iter.Key()
+		if err != nil {
+			reporter.Skipf("ActiveParticipantsSet key decode failed: %v", err)
+			return simsx.SimAccount{}, false
+		}
+		addrs = append(addrs, key.K2())
+	}
+	if len(addrs) == 0 {
+		reporter.Skip("no active participants in current epoch")
+		return simsx.SimAccount{}, false
+	}
+
+	pick := addrs[testData.Rand().Intn(len(addrs))]
+	if !testData.HasAccount(pick.String()) {
+		reporter.Skipf("active participant %s not in sim accounts", pick.String())
+		return simsx.SimAccount{}, false
+	}
+	return testData.GetAccount(reporter, pick.String()), true
+}

--- a/inference-chain/x/inference/simulation/active_participants_pick_test.go
+++ b/inference-chain/x/inference/simulation/active_participants_pick_test.go
@@ -1,0 +1,84 @@
+package simulation_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/simulation"
+)
+
+// TestPickRandomActiveSimAccount_PicksFromCurrentEpoch — with a non-empty
+// ActiveParticipantsSet for currentEpoch, the picker returns one of the
+// registered sim accounts and does not Skip the reporter.
+func TestPickRandomActiveSimAccount_PicksFromCurrentEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 4, 5)
+	registerAsParticipants(t, k, ctx, accs)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+
+	cds := simsx.NewChainDataSource(ctx, rand.New(rand.NewSource(99)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	got, ok := simulation.PickRandomActiveSimAccount(ctx, k, cds, reporter)
+	require.True(t, ok)
+	require.False(t, reporter.IsSkipped(), "reporter unexpectedly skipped")
+
+	addrs := map[string]bool{}
+	for _, a := range accs {
+		addrs[a.Address.String()] = true
+	}
+	require.True(t, addrs[got.AddressBech32],
+		"picked address %s not in seeded set", got.AddressBech32)
+}
+
+// TestPickRandomActiveSimAccount_EmptySet_Skips — without seeding, the
+// picker sets reporter.Skip and returns false.
+func TestPickRandomActiveSimAccount_EmptySet_Skips(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 5, 3)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+
+	cds := simsx.NewChainDataSource(ctx, rand.New(rand.NewSource(1)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	_, ok := simulation.PickRandomActiveSimAccount(ctx, k, cds, reporter)
+	require.False(t, ok)
+	require.True(t, reporter.IsSkipped(),
+		"empty ActiveParticipantsSet should cause Skip")
+}
+
+// TestPickRandomActiveSimAccount_DeterministicWithSeed — same seed in the
+// data-source's *rand.Rand must yield identical picks across calls. The
+// helper is sim-only and must be deterministic for replayable simulation.
+func TestPickRandomActiveSimAccount_DeterministicWithSeed(t *testing.T) {
+	k1, ctx1 := keepertest.InferenceKeeper(t)
+	k2, ctx2 := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 6, 5)
+	registerAsParticipants(t, k1, ctx1, accs)
+	registerAsParticipants(t, k2, ctx2, accs)
+	require.NoError(t, k1.SetEffectiveEpochIndex(ctx1, 0))
+	require.NoError(t, k2.SetEffectiveEpochIndex(ctx2, 0))
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx1, k1))
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx2, k2))
+
+	const seed = int64(123)
+	cds1 := simsx.NewChainDataSource(ctx1, rand.New(rand.NewSource(seed)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	cds2 := simsx.NewChainDataSource(ctx2, rand.New(rand.NewSource(seed)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	r1 := simsx.NewBasicSimulationReporter()
+	r2 := simsx.NewBasicSimulationReporter()
+
+	got1, ok1 := simulation.PickRandomActiveSimAccount(ctx1, k1, cds1, r1)
+	got2, ok2 := simulation.PickRandomActiveSimAccount(ctx2, k2, cds2, r2)
+	require.True(t, ok1)
+	require.True(t, ok2)
+	require.Equal(t, got1.AddressBech32, got2.AddressBech32)
+}

--- a/inference-chain/x/inference/simulation/active_participants_pick_test.go
+++ b/inference-chain/x/inference/simulation/active_participants_pick_test.go
@@ -19,7 +19,7 @@ func TestPickRandomActiveSimAccount_PicksFromCurrentEpoch(t *testing.T) {
 	accs := newSimAccounts(t, 4, 5)
 	registerAsParticipants(t, k, ctx, accs)
 	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+	seedActiveParticipantsForTest(t, ctx, k, accs, 0)
 
 	cds := simsx.NewChainDataSource(ctx, rand.New(rand.NewSource(99)),
 		nil, nil, gonkaBech32Codec(), accs...)
@@ -65,8 +65,8 @@ func TestPickRandomActiveSimAccount_DeterministicWithSeed(t *testing.T) {
 	registerAsParticipants(t, k2, ctx2, accs)
 	require.NoError(t, k1.SetEffectiveEpochIndex(ctx1, 0))
 	require.NoError(t, k2.SetEffectiveEpochIndex(ctx2, 0))
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx1, k1))
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx2, k2))
+	seedActiveParticipantsForTest(t, ctx1, k1, accs, 0)
+	seedActiveParticipantsForTest(t, ctx2, k2, accs, 0)
 
 	const seed = int64(123)
 	cds1 := simsx.NewChainDataSource(ctx1, rand.New(rand.NewSource(seed)),

--- a/inference-chain/x/inference/simulation/bootstrap.go
+++ b/inference-chain/x/inference/simulation/bootstrap.go
@@ -4,141 +4,17 @@ import (
 	"context"
 	"errors"
 
-	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 
+	"github.com/productscience/inference/x/inference/epochgroup"
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/types"
 )
 
-// simValidatorPower is the uniform consensus power EnsureComputeValidators
-// assigns to every validator on a refresh. gonka sets DefaultPowerReduction to
-// 1, so this is consensus power directly. The exact value is irrelevant — only
-// that it is positive and uniform (keeps the refresh deterministic).
+// simValidatorPower is the uniform consensus power assigned to every
+// sim validator. gonka sets DefaultPowerReduction to 1, so this is
+// consensus power directly.
 const simValidatorPower = 1_000_000
-
-// simBondedValidatorFloor is the bonded-validator count below which
-// EnsureComputeValidators refreshes the set. Kept well above zero so the
-// cometbft validator set cannot empty between two factory invocations even
-// across a stretch of non-x/inference blocks (downtime jailing was observed at
-// ~1.7 validators/block; this floor gives >25 blocks of grace).
-const simBondedValidatorFloor = 50
-
-// EnsureMembersInEpochGroup writes a sim-only ValidationWeights entry
-// for each ActiveParticipant into every sub-group's EpochGroupData. Used
-// by MsgValidationFactory so the handler's transient-cache lookup at
-// GetCachedEpochDataModelWeight (msg_server_validation.go) finds
-// the validator and routes through the normal validation logic instead
-// of returning ErrParticipantNotFound and aborting simsx.
-//
-// Approach: instead of calling EpochGroup.AddMember — which
-// dispatches through the cosmos `group` module via UpdateGroupMembers
-// and swallows sub-group AddMember errors at addToModelGroups:309-312 —
-// we mutate `EpochGroupData.ValidationWeights` directly via
-// SetEpochGroupData. The on-chain MsgValidation handler reads from the
-// transient cache, which BuildEpochDataTransientCache populates from
-// `EpochGroupData.ValidationWeights` (epoch_data_transient_cache.go).
-// Skipping the group-module roundtrip removes both an
-// unobservable failure path and the unnecessary write to GroupKeeper
-// state.
-//
-// Sim-only bridge over production's PoC validator-rotation flow
-// (activeparticipants.go addNewActiveParticipantsAsValidators) — no
-// production code change.
-//
-// Idempotent per sub-group: appends only addresses not already in
-// ValidationWeights.
-//
-// Weight=1, Reputation=0, VotingPower=1 chosen as the minimal non-zero
-// values required by the validation arithmetic (zero weight would
-// confuse vote-tallying division).
-//
-// After all sub-groups are updated, BuildEpochDataTransientCache is
-// invoked so MsgValidation in the SAME block sees the freshly-populated
-// cache (BeginBlocker rebuilds at block start; this mid-block rebuild
-// avoids the one-block latency window).
-//
-// Tolerance: no current epoch group ⇒ nil (unit-test path).
-func EnsureMembersInEpochGroup(ctx context.Context, k keeper.Keeper) error {
-	eg, err := k.GetCurrentEpochGroup(ctx)
-	if err != nil {
-		if errors.Is(err, types.ErrEffectiveEpochNotFound) || errors.Is(err, types.ErrEpochGroupDataNotFound) {
-			return nil
-		}
-		return err
-	}
-
-	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
-	if err != nil {
-		return err
-	}
-
-	addrs := make([]string, 0, 8)
-	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
-		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](currentEpoch))
-	if err != nil {
-		return err
-	}
-	for ; iter.Valid(); iter.Next() {
-		key, err := iter.Key()
-		if err != nil {
-			iter.Close()
-			return err
-		}
-		addrs = append(addrs, key.K2().String())
-	}
-	if closeErr := iter.Close(); closeErr != nil {
-		return closeErr
-	}
-	if len(addrs) == 0 {
-		return nil
-	}
-
-	// Update each sub-group's EpochGroupData ValidationWeights
-	// (the actual source the transient cache builds from). Plus
-	// the root group, so root-level meta lookups also work.
-	groupKeys := append([]string{""}, eg.GroupData.SubGroupModels...)
-	anyAdded := false
-	for _, modelID := range groupKeys {
-		data, found := k.GetEpochGroupData(ctx, currentEpoch, modelID)
-		if !found {
-			continue
-		}
-		have := make(map[string]bool, len(data.ValidationWeights))
-		for _, vw := range data.ValidationWeights {
-			if vw != nil {
-				have[vw.MemberAddress] = true
-			}
-		}
-		added := false
-		for _, addr := range addrs {
-			if have[addr] {
-				continue
-			}
-			data.ValidationWeights = append(data.ValidationWeights, &types.ValidationWeight{
-				MemberAddress: addr,
-				Weight:        1,
-				Reputation:    0,
-				VotingPower:   1,
-			})
-			data.TotalWeight += 1
-			added = true
-		}
-		if added {
-			k.SetEpochGroupData(ctx, data)
-			anyAdded = true
-		}
-	}
-
-	// Rebuild the transient cache only when ValidationWeights actually
-	// changed — MsgValidationFactory calls this per-op, and once the epoch's
-	// members are seeded every later call would otherwise rebuild for nothing.
-	if !anyAdded {
-		return nil
-	}
-	return k.BuildEpochDataTransientCache(ctx)
-}
 
 // EnsureModelsInEpochGroup promotes every model in the Models collection
 // into the current epoch group's SubGroupModels. Sim-only bridge over
@@ -153,9 +29,6 @@ func EnsureMembersInEpochGroup(ctx context.Context, k keeper.Keeper) error {
 //
 // Idempotent: CreateSubGroup checks in-memory cache and on-chain state
 // before creating a new sub-group, so repeated calls are no-ops.
-//
-// Determinism: GetGovernanceModels returns models in collections-sorted
-// order (Models is a collections.Map keyed by string Id).
 //
 // Tolerance: if no current epoch group exists (unit-test contexts that
 // don't run the full InitGenesisEpochGroup wiring), returns nil without
@@ -184,117 +57,141 @@ func EnsureModelsInEpochGroup(ctx context.Context, k keeper.Keeper) error {
 	return nil
 }
 
-// EnsureActiveParticipantsSeeded promotes all registered Participants into
-// ActiveParticipantsSet[currentEpoch] if it is currently empty. Sim-only
-// bridge from the Participants seeded at genesis over the gap that the
-// production PoC-epoch flow (activeparticipants.go) would normally
-// close — issue #982 demands operations «honor message preconditions»,
-// while faithfully simulating the full PoC epoch flow is a separate effort.
+// activeParticipantFromSimParticipant materializes an ActiveParticipant
+// from a registered Participant + the simulation's fixed model list.
+func activeParticipantFromSimParticipant(epoch uint64, participant types.Participant) *types.ActiveParticipant {
+	models := append([]string(nil), SimModelIDs...)
+	mlNodes := make([]*types.ModelMLNodes, 0, len(models))
+	votingPowers := make([]*types.ModelVotingPower, 0, len(models))
+	for _, modelID := range models {
+		mlNodes = append(mlNodes, &types.ModelMLNodes{MlNodes: []*types.MLNodeInfo{{
+			NodeId:     participant.Index + "/" + modelID,
+			Throughput: simValidatorPower,
+			PocWeight:  simValidatorPower,
+		}}})
+		votingPowers = append(votingPowers, &types.ModelVotingPower{
+			ModelId:     modelID,
+			VotingPower: simValidatorPower,
+		})
+	}
+	return &types.ActiveParticipant{
+		Index:        participant.Index,
+		ValidatorKey: participant.ValidatorKey,
+		Weight:       simValidatorPower,
+		InferenceUrl: participant.InferenceUrl,
+		Models:       models,
+		Seed: &types.RandomSeed{
+			Participant: participant.Index,
+			EpochIndex:  epoch,
+			Signature:   "sim-seed-" + participant.Index,
+		},
+		MlNodes:      mlNodes,
+		VotingPowers: votingPowers,
+	}
+}
+
+// EnsureSimActiveParticipantsSeeded promotes sim genesis participants
+// into the current epoch group + writes ActiveParticipants + refreshes
+// the transient validation cache and compute-validator set. Idempotent.
 //
-// Idempotent: any (currentEpoch, *) entry already present ⇒ no-op.
+// Production code does this work at end of each PoC validation stage
+// (module.go onEndOfPoCValidationStage → addEpochMembers + SetComputeValidators).
+// At sim genesis the chain runs ~58 blocks before the first PoC stage
+// completes; without this seeder those blocks have:
+//   - no ActiveParticipants → participant-gated factories skip
+//   - empty ValidationWeights → MsgValidation can't resolve sub-groups
+//   - empty transient validation cache → pricing/validation BeginBlocker fails
+//   - no compute validators → cometbft validator drain
 //
-// Determinism: GetAllParticipant returns participants in bech32-sorted
-// order (collections.Map invariant), so the ActiveParticipants slice is
-// identical across same-seed runs.
-//
-// No msg-server flow, no production semantics change.
-func EnsureActiveParticipantsSeeded(ctx context.Context, k keeper.Keeper) error {
+// After the first real rotation populates ActiveParticipants[epoch+1] via
+// the production pipeline, this helper is a no-op.
+func EnsureSimActiveParticipantsSeeded(ctx context.Context, k keeper.Keeper) error {
 	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
 	if err != nil {
 		return err
 	}
 
-	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
-		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](currentEpoch))
+	simParticipants := make([]types.Participant, 0, NumSimGenesisParticipants)
+	iter, err := k.Participants.Iterate(ctx, nil)
 	if err != nil {
 		return err
 	}
-	seeded := iter.Valid()
-	if closeErr := iter.Close(); closeErr != nil {
-		return closeErr
-	}
-	if seeded {
-		return nil
-	}
-
-	participants := k.GetAllParticipant(ctx)
-	if len(participants) == 0 {
-		return nil
-	}
-
-	active := make([]*types.ActiveParticipant, 0, len(participants))
-	for _, p := range participants {
-		active = append(active, &types.ActiveParticipant{
-			Index: p.Index,
-		})
-	}
-	return k.SetActiveParticipantsCache(ctx, types.ActiveParticipants{
-		EpochId:      currentEpoch,
-		Participants: active,
-	})
-}
-
-// EnsureComputeValidators keeps the cometbft validator set alive across long
-// simulation runs.
-//
-// Sim-only bridge over production's PoC validator-rotation flow. In production,
-// cosmos x/slashing downtime-jails offline validators, but every epoch
-// onSetNewValidatorsStage (module.go) calls SetComputeValidators, whose
-// updateValidator (cosmos-sdk x/staking/keeper/compute.go:492) sets
-// Jailed=false / Status=Bonded for every validator still doing PoC work — so the
-// validator set is continuously refreshed and never drains.
-//
-// The simulation does not run PoC, so SetComputeValidators is never invoked and
-// downtime-jailed validators are never un-jailed. Over a long run every
-// validator jails out, the set empties, and simsx aborts with "empty validator
-// set" (cosmos-sdk x/simulation/simulate.go:266) — observed draining bonded
-// validators 131->83->35->0 over blocks 56->110->~135.
-//
-// This helper mimics the production refresh: when the bonded validator count
-// falls below simBondedValidatorFloor it feeds every current validator back
-// through SetComputeValidators, which un-jails and re-bonds them. Idempotent —
-// above the floor it is a cheap no-op, and SetComputeValidators itself skips
-// validators already bonded at the target power (compute.go:176).
-//
-// Determinism: GetAllValidators returns collections-sorted output and
-// SetComputeValidators sorts its inputs internally (compute.go:140-163), so the
-// refresh reproduces across same-seed runs. No production code change.
-func EnsureComputeValidators(ctx context.Context, k keeper.Keeper) error {
-	validators, err := k.Staking.GetAllValidators(ctx)
-	if err != nil {
-		return err
-	}
-	if len(validators) == 0 {
-		return nil
-	}
-
-	bonded := 0
-	for i := range validators {
-		if validators[i].IsBonded() && !validators[i].IsJailed() {
-			bonded++
+	for ; iter.Valid(); iter.Next() {
+		if len(simParticipants) >= NumSimGenesisParticipants {
+			break
 		}
-	}
-	if bonded >= simBondedValidatorFloor {
-		return nil
-	}
-
-	results := make([]stakingkeeper.ComputeResult, 0, len(validators))
-	for i := range validators {
-		pubKey, err := validators[i].ConsPubKey()
+		p, err := iter.Value()
 		if err != nil {
-			// A validator with an undecodable consensus key cannot be fed back;
-			// skip it rather than aborting the whole refresh.
-			continue
+			iter.Close()
+			return err
 		}
-		results = append(results, stakingkeeper.ComputeResult{
-			Power:           simValidatorPower,
-			ValidatorPubKey: pubKey,
-			OperatorAddress: validators[i].OperatorAddress,
-		})
+		simParticipants = append(simParticipants, p)
 	}
-	// isTestnet=true selects the current SetComputeValidators path (the legacy
-	// pre-ValidatorIndexFixHeight branch only matters for mainnet's early
-	// history); matches what mainnet runs today.
-	_, err = k.Staking.SetComputeValidators(ctx, results, true)
-	return err
+	iter.Close()
+
+	// Set RandomSeeds for upcoming epoch on every call. Production validators
+	// submit MsgSubmitSeed; ComputeNewWeights reads RandomSeeds keyed by
+	// (upcomingEpoch.Index, participantAddress) at end of PoC validation
+	// — if missing, the commit is skipped. SetRandomSeed overwrites, so
+	// per-call invocation is idempotent in effect.
+	upcoming := currentEpoch + 1
+	for _, p := range simParticipants {
+		seed := types.RandomSeed{
+			Participant: p.Index,
+			EpochIndex:  upcoming,
+			Signature:   "sim-seed-" + p.Index,
+		}
+		if err := k.SetRandomSeed(ctx, seed); err != nil {
+			return err
+		}
+	}
+
+	if _, found := k.GetActiveParticipants(ctx, currentEpoch); found {
+		return nil
+	}
+
+	activeParticipants := make([]*types.ActiveParticipant, 0, len(simParticipants))
+	for _, p := range simParticipants {
+		activeParticipants = append(activeParticipants, activeParticipantFromSimParticipant(currentEpoch, p))
+	}
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	blockHeight := sdkCtx.BlockHeight()
+	if err := k.SetActiveParticipants(ctx, types.ActiveParticipants{
+		Participants:         activeParticipants,
+		EpochGroupId:         currentEpoch,
+		EpochId:              currentEpoch,
+		PocStartBlockHeight:  blockHeight,
+		EffectiveBlockHeight: blockHeight,
+		CreatedAtBlockHeight: blockHeight,
+	}); err != nil {
+		return err
+	}
+
+	eg, err := k.GetCurrentEpochGroup(ctx)
+	if err != nil {
+		if errors.Is(err, types.ErrEffectiveEpochNotFound) || errors.Is(err, types.ErrEpochGroupDataNotFound) {
+			return nil
+		}
+		return err
+	}
+	for _, ap := range activeParticipants {
+		member := epochgroup.NewEpochMemberFromActiveParticipant(ap, 0, 0, nil)
+		if err := eg.AddMember(ctx, member); err != nil {
+			return err
+		}
+	}
+
+	if err := k.BuildEpochDataTransientCache(ctx); err != nil {
+		return err
+	}
+
+	computeResult, err := eg.GetComputeResults(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err := k.Staking.SetComputeValidators(ctx, computeResult, true); err != nil {
+		return err
+	}
+	return nil
 }

--- a/inference-chain/x/inference/simulation/bootstrap.go
+++ b/inference-chain/x/inference/simulation/bootstrap.go
@@ -1,0 +1,300 @@
+package simulation
+
+import (
+	"context"
+	"errors"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// simValidatorPower is the uniform consensus power EnsureComputeValidators
+// assigns to every validator on a refresh. gonka sets DefaultPowerReduction to
+// 1, so this is consensus power directly. The exact value is irrelevant — only
+// that it is positive and uniform (keeps the refresh deterministic).
+const simValidatorPower = 1_000_000
+
+// simBondedValidatorFloor is the bonded-validator count below which
+// EnsureComputeValidators refreshes the set. Kept well above zero so the
+// cometbft validator set cannot empty between two factory invocations even
+// across a stretch of non-x/inference blocks (downtime jailing was observed at
+// ~1.7 validators/block; this floor gives >25 blocks of grace).
+const simBondedValidatorFloor = 50
+
+// EnsureMembersInEpochGroup writes a sim-only ValidationWeights entry
+// for each ActiveParticipant into every sub-group's EpochGroupData. Used
+// by MsgValidationFactory so the handler's transient-cache lookup at
+// GetCachedEpochDataModelWeight (msg_server_validation.go) finds
+// the validator and routes through the normal validation logic instead
+// of returning ErrParticipantNotFound and aborting simsx.
+//
+// Approach: instead of calling EpochGroup.AddMember — which
+// dispatches through the cosmos `group` module via UpdateGroupMembers
+// and swallows sub-group AddMember errors at addToModelGroups:309-312 —
+// we mutate `EpochGroupData.ValidationWeights` directly via
+// SetEpochGroupData. The on-chain MsgValidation handler reads from the
+// transient cache, which BuildEpochDataTransientCache populates from
+// `EpochGroupData.ValidationWeights` (epoch_data_transient_cache.go).
+// Skipping the group-module roundtrip removes both an
+// unobservable failure path and the unnecessary write to GroupKeeper
+// state.
+//
+// Sim-only bridge over production's PoC validator-rotation flow
+// (activeparticipants.go addNewActiveParticipantsAsValidators) — no
+// production code change.
+//
+// Idempotent per sub-group: appends only addresses not already in
+// ValidationWeights.
+//
+// Weight=1, Reputation=0, VotingPower=1 chosen as the minimal non-zero
+// values required by the validation arithmetic (zero weight would
+// confuse vote-tallying division).
+//
+// After all sub-groups are updated, BuildEpochDataTransientCache is
+// invoked so MsgValidation in the SAME block sees the freshly-populated
+// cache (BeginBlocker rebuilds at block start; this mid-block rebuild
+// avoids the one-block latency window).
+//
+// Tolerance: no current epoch group ⇒ nil (unit-test path).
+func EnsureMembersInEpochGroup(ctx context.Context, k keeper.Keeper) error {
+	eg, err := k.GetCurrentEpochGroup(ctx)
+	if err != nil {
+		if errors.Is(err, types.ErrEffectiveEpochNotFound) || errors.Is(err, types.ErrEpochGroupDataNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	addrs := make([]string, 0, 8)
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](currentEpoch))
+	if err != nil {
+		return err
+	}
+	for ; iter.Valid(); iter.Next() {
+		key, err := iter.Key()
+		if err != nil {
+			iter.Close()
+			return err
+		}
+		addrs = append(addrs, key.K2().String())
+	}
+	if closeErr := iter.Close(); closeErr != nil {
+		return closeErr
+	}
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	// Update each sub-group's EpochGroupData ValidationWeights
+	// (the actual source the transient cache builds from). Plus
+	// the root group, so root-level meta lookups also work.
+	groupKeys := append([]string{""}, eg.GroupData.SubGroupModels...)
+	anyAdded := false
+	for _, modelID := range groupKeys {
+		data, found := k.GetEpochGroupData(ctx, currentEpoch, modelID)
+		if !found {
+			continue
+		}
+		have := make(map[string]bool, len(data.ValidationWeights))
+		for _, vw := range data.ValidationWeights {
+			if vw != nil {
+				have[vw.MemberAddress] = true
+			}
+		}
+		added := false
+		for _, addr := range addrs {
+			if have[addr] {
+				continue
+			}
+			data.ValidationWeights = append(data.ValidationWeights, &types.ValidationWeight{
+				MemberAddress: addr,
+				Weight:        1,
+				Reputation:    0,
+				VotingPower:   1,
+			})
+			data.TotalWeight += 1
+			added = true
+		}
+		if added {
+			k.SetEpochGroupData(ctx, data)
+			anyAdded = true
+		}
+	}
+
+	// Rebuild the transient cache only when ValidationWeights actually
+	// changed — MsgValidationFactory calls this per-op, and once the epoch's
+	// members are seeded every later call would otherwise rebuild for nothing.
+	if !anyAdded {
+		return nil
+	}
+	return k.BuildEpochDataTransientCache(ctx)
+}
+
+// EnsureModelsInEpochGroup promotes every model in the Models collection
+// into the current epoch group's SubGroupModels. Sim-only bridge over
+// the production gap that the PoC epoch flow normally closes: at sim
+// InitGenesis the inference module writes models to k.Models but the
+// genesis EpochGroup created by InitGenesisEpoch (module/genesis.go)
+// has an empty SubGroupModels list. UpdateDynamicPricing
+// (dynamic_pricing.go) iterates EpochGroup.SubGroupModels rather than
+// Models, so without this seeding BeginBlocker never computes a price
+// for the sim models and every StartInference fails with
+// «current price not found for model» at RecordInferencePrice.
+//
+// Idempotent: CreateSubGroup checks in-memory cache and on-chain state
+// before creating a new sub-group, so repeated calls are no-ops.
+//
+// Determinism: GetGovernanceModels returns models in collections-sorted
+// order (Models is a collections.Map keyed by string Id).
+//
+// Tolerance: if no current epoch group exists (unit-test contexts that
+// don't run the full InitGenesisEpochGroup wiring), returns nil without
+// touching state. Production sim app always has the genesis epoch group
+// via InitGenesisEpoch, so this branch only fires in the keeper-mock
+// tests in this package.
+//
+// No msg-server flow, no production semantics change.
+func EnsureModelsInEpochGroup(ctx context.Context, k keeper.Keeper) error {
+	eg, err := k.GetCurrentEpochGroup(ctx)
+	if err != nil {
+		if errors.Is(err, types.ErrEffectiveEpochNotFound) || errors.Is(err, types.ErrEpochGroupDataNotFound) {
+			return nil
+		}
+		return err
+	}
+	models, err := k.GetGovernanceModels(ctx)
+	if err != nil {
+		return err
+	}
+	for _, m := range models {
+		if _, err := eg.CreateSubGroup(ctx, m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnsureActiveParticipantsSeeded promotes all registered Participants into
+// ActiveParticipantsSet[currentEpoch] if it is currently empty. Sim-only
+// bridge from the Participants seeded at genesis over the gap that the
+// production PoC-epoch flow (activeparticipants.go) would normally
+// close — issue #982 demands operations «honor message preconditions»,
+// while faithfully simulating the full PoC epoch flow is a separate effort.
+//
+// Idempotent: any (currentEpoch, *) entry already present ⇒ no-op.
+//
+// Determinism: GetAllParticipant returns participants in bech32-sorted
+// order (collections.Map invariant), so the ActiveParticipants slice is
+// identical across same-seed runs.
+//
+// No msg-server flow, no production semantics change.
+func EnsureActiveParticipantsSeeded(ctx context.Context, k keeper.Keeper) error {
+	currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](currentEpoch))
+	if err != nil {
+		return err
+	}
+	seeded := iter.Valid()
+	if closeErr := iter.Close(); closeErr != nil {
+		return closeErr
+	}
+	if seeded {
+		return nil
+	}
+
+	participants := k.GetAllParticipant(ctx)
+	if len(participants) == 0 {
+		return nil
+	}
+
+	active := make([]*types.ActiveParticipant, 0, len(participants))
+	for _, p := range participants {
+		active = append(active, &types.ActiveParticipant{
+			Index: p.Index,
+		})
+	}
+	return k.SetActiveParticipantsCache(ctx, types.ActiveParticipants{
+		EpochId:      currentEpoch,
+		Participants: active,
+	})
+}
+
+// EnsureComputeValidators keeps the cometbft validator set alive across long
+// simulation runs.
+//
+// Sim-only bridge over production's PoC validator-rotation flow. In production,
+// cosmos x/slashing downtime-jails offline validators, but every epoch
+// onSetNewValidatorsStage (module.go) calls SetComputeValidators, whose
+// updateValidator (cosmos-sdk x/staking/keeper/compute.go:492) sets
+// Jailed=false / Status=Bonded for every validator still doing PoC work — so the
+// validator set is continuously refreshed and never drains.
+//
+// The simulation does not run PoC, so SetComputeValidators is never invoked and
+// downtime-jailed validators are never un-jailed. Over a long run every
+// validator jails out, the set empties, and simsx aborts with "empty validator
+// set" (cosmos-sdk x/simulation/simulate.go:266) — observed draining bonded
+// validators 131->83->35->0 over blocks 56->110->~135.
+//
+// This helper mimics the production refresh: when the bonded validator count
+// falls below simBondedValidatorFloor it feeds every current validator back
+// through SetComputeValidators, which un-jails and re-bonds them. Idempotent —
+// above the floor it is a cheap no-op, and SetComputeValidators itself skips
+// validators already bonded at the target power (compute.go:176).
+//
+// Determinism: GetAllValidators returns collections-sorted output and
+// SetComputeValidators sorts its inputs internally (compute.go:140-163), so the
+// refresh reproduces across same-seed runs. No production code change.
+func EnsureComputeValidators(ctx context.Context, k keeper.Keeper) error {
+	validators, err := k.Staking.GetAllValidators(ctx)
+	if err != nil {
+		return err
+	}
+	if len(validators) == 0 {
+		return nil
+	}
+
+	bonded := 0
+	for i := range validators {
+		if validators[i].IsBonded() && !validators[i].IsJailed() {
+			bonded++
+		}
+	}
+	if bonded >= simBondedValidatorFloor {
+		return nil
+	}
+
+	results := make([]stakingkeeper.ComputeResult, 0, len(validators))
+	for i := range validators {
+		pubKey, err := validators[i].ConsPubKey()
+		if err != nil {
+			// A validator with an undecodable consensus key cannot be fed back;
+			// skip it rather than aborting the whole refresh.
+			continue
+		}
+		results = append(results, stakingkeeper.ComputeResult{
+			Power:           simValidatorPower,
+			ValidatorPubKey: pubKey,
+			OperatorAddress: validators[i].OperatorAddress,
+		})
+	}
+	// isTestnet=true selects the current SetComputeValidators path (the legacy
+	// pre-ValidatorIndexFixHeight branch only matters for mainnet's early
+	// history); matches what mainnet runs today.
+	_, err = k.Staking.SetComputeValidators(ctx, results, true)
+	return err
+}

--- a/inference-chain/x/inference/simulation/bootstrap_test.go
+++ b/inference-chain/x/inference/simulation/bootstrap_test.go
@@ -1,7 +1,6 @@
 package simulation_test
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,56 +8,6 @@ import (
 	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/x/inference/simulation"
 )
-
-// TestEnsureActiveParticipantsSeeded_SeedsCurrentEpoch — with N Participants
-// registered and ActiveParticipantsSet empty for currentEpoch, the helper
-// promotes all of them.
-func TestEnsureActiveParticipantsSeeded_SeedsCurrentEpoch(t *testing.T) {
-	k, ctx := keepertest.InferenceKeeper(t)
-	accs := newSimAccounts(t, 1, 5)
-	regs := registerAsParticipants(t, k, ctx, accs)
-	const epoch = uint64(7)
-	require.NoError(t, k.SetEffectiveEpochIndex(ctx, epoch))
-
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
-
-	got := collectActiveAddrs(t, ctx, k, epoch)
-	sort.Strings(got)
-	want := append([]string{}, regs...)
-	sort.Strings(want)
-	require.Equal(t, want, got)
-}
-
-// TestEnsureActiveParticipantsSeeded_Idempotent — a second call with
-// ActiveParticipantsSet non-empty for currentEpoch returns nil and does
-// not change the set.
-func TestEnsureActiveParticipantsSeeded_Idempotent(t *testing.T) {
-	k, ctx := keepertest.InferenceKeeper(t)
-	accs := newSimAccounts(t, 2, 3)
-	registerAsParticipants(t, k, ctx, accs)
-	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
-
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
-	first := collectActiveAddrs(t, ctx, k, 0)
-
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
-	second := collectActiveAddrs(t, ctx, k, 0)
-
-	// collectActiveAddrs returns store-ordered (deterministic) addresses;
-	// first and second use the same helper, so a direct Equal is valid.
-	require.Equal(t, first, second)
-}
-
-// TestEnsureActiveParticipantsSeeded_NoParticipants_NoOp — empty Participants
-// collection ⇒ helper returns nil without populating ActiveParticipantsSet.
-func TestEnsureActiveParticipantsSeeded_NoParticipants_NoOp(t *testing.T) {
-	k, ctx := keepertest.InferenceKeeper(t)
-	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
-
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
-
-	require.Empty(t, collectActiveAddrs(t, ctx, k, 0))
-}
 
 // TestEnsureModelsInEpochGroup_TolerantOnMissingEpoch — without an
 // EffectiveEpochIndex set, GetCurrentEpochGroup returns
@@ -78,38 +27,4 @@ func TestEnsureModelsInEpochGroup_TolerantOnMissingEpochGroupData(t *testing.T) 
 	k, ctx := keepertest.InferenceKeeper(t)
 	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
 	require.NoError(t, simulation.EnsureModelsInEpochGroup(ctx, k))
-}
-
-// TestEnsureMembersInEpochGroup_TolerantOnMissingEpoch — no
-// EffectiveEpochIndex set ⇒ GetCurrentEpochGroup fails with
-// ErrEffectiveEpochNotFound; helper no-ops. Same tolerance contract as
-// EnsureModelsInEpochGroup.
-func TestEnsureMembersInEpochGroup_TolerantOnMissingEpoch(t *testing.T) {
-	k, ctx := keepertest.InferenceKeeper(t)
-	require.NoError(t, simulation.EnsureMembersInEpochGroup(ctx, k))
-}
-
-// TestEnsureMembersInEpochGroup_TolerantOnMissingEpochGroupData — index
-// is set but no EpochGroupData exists yet; helper no-ops.
-func TestEnsureMembersInEpochGroup_TolerantOnMissingEpochGroupData(t *testing.T) {
-	k, ctx := keepertest.InferenceKeeper(t)
-	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
-	require.NoError(t, simulation.EnsureMembersInEpochGroup(ctx, k))
-}
-
-// TestEnsureActiveParticipantsSeeded_RespectsEffectiveEpoch — the helper
-// writes to currentEpoch (= EffectiveEpochIndex) and leaves other epoch
-// slots untouched.
-func TestEnsureActiveParticipantsSeeded_RespectsEffectiveEpoch(t *testing.T) {
-	k, ctx := keepertest.InferenceKeeper(t)
-	accs := newSimAccounts(t, 3, 4)
-	registerAsParticipants(t, k, ctx, accs)
-	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 42))
-
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
-
-	require.Len(t, collectActiveAddrs(t, ctx, k, 42), len(accs))
-	require.Empty(t, collectActiveAddrs(t, ctx, k, 0))
-	require.Empty(t, collectActiveAddrs(t, ctx, k, 41))
-	require.Empty(t, collectActiveAddrs(t, ctx, k, 43))
 }

--- a/inference-chain/x/inference/simulation/bootstrap_test.go
+++ b/inference-chain/x/inference/simulation/bootstrap_test.go
@@ -1,0 +1,115 @@
+package simulation_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/simulation"
+)
+
+// TestEnsureActiveParticipantsSeeded_SeedsCurrentEpoch — with N Participants
+// registered and ActiveParticipantsSet empty for currentEpoch, the helper
+// promotes all of them.
+func TestEnsureActiveParticipantsSeeded_SeedsCurrentEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 1, 5)
+	regs := registerAsParticipants(t, k, ctx, accs)
+	const epoch = uint64(7)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, epoch))
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+
+	got := collectActiveAddrs(t, ctx, k, epoch)
+	sort.Strings(got)
+	want := append([]string{}, regs...)
+	sort.Strings(want)
+	require.Equal(t, want, got)
+}
+
+// TestEnsureActiveParticipantsSeeded_Idempotent — a second call with
+// ActiveParticipantsSet non-empty for currentEpoch returns nil and does
+// not change the set.
+func TestEnsureActiveParticipantsSeeded_Idempotent(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 2, 3)
+	registerAsParticipants(t, k, ctx, accs)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+	first := collectActiveAddrs(t, ctx, k, 0)
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+	second := collectActiveAddrs(t, ctx, k, 0)
+
+	// collectActiveAddrs returns store-ordered (deterministic) addresses;
+	// first and second use the same helper, so a direct Equal is valid.
+	require.Equal(t, first, second)
+}
+
+// TestEnsureActiveParticipantsSeeded_NoParticipants_NoOp — empty Participants
+// collection ⇒ helper returns nil without populating ActiveParticipantsSet.
+func TestEnsureActiveParticipantsSeeded_NoParticipants_NoOp(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+
+	require.Empty(t, collectActiveAddrs(t, ctx, k, 0))
+}
+
+// TestEnsureModelsInEpochGroup_TolerantOnMissingEpoch — without an
+// EffectiveEpochIndex set, GetCurrentEpochGroup returns
+// ErrEffectiveEpochNotFound; the helper must treat that as a no-op
+// (returns nil) so unit-test keepers without full InitGenesisEpochGroup
+// wiring still let the factories run.
+func TestEnsureModelsInEpochGroup_TolerantOnMissingEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	// No SetEffectiveEpochIndex call — GetCurrentEpochGroup will fail.
+	require.NoError(t, simulation.EnsureModelsInEpochGroup(ctx, k))
+}
+
+// TestEnsureModelsInEpochGroup_TolerantOnMissingEpochGroupData — index
+// is set but no EpochGroupData exists yet; helper must also no-op for
+// this branch (ErrEpochGroupDataNotFound).
+func TestEnsureModelsInEpochGroup_TolerantOnMissingEpochGroupData(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+	require.NoError(t, simulation.EnsureModelsInEpochGroup(ctx, k))
+}
+
+// TestEnsureMembersInEpochGroup_TolerantOnMissingEpoch — no
+// EffectiveEpochIndex set ⇒ GetCurrentEpochGroup fails with
+// ErrEffectiveEpochNotFound; helper no-ops. Same tolerance contract as
+// EnsureModelsInEpochGroup.
+func TestEnsureMembersInEpochGroup_TolerantOnMissingEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	require.NoError(t, simulation.EnsureMembersInEpochGroup(ctx, k))
+}
+
+// TestEnsureMembersInEpochGroup_TolerantOnMissingEpochGroupData — index
+// is set but no EpochGroupData exists yet; helper no-ops.
+func TestEnsureMembersInEpochGroup_TolerantOnMissingEpochGroupData(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 0))
+	require.NoError(t, simulation.EnsureMembersInEpochGroup(ctx, k))
+}
+
+// TestEnsureActiveParticipantsSeeded_RespectsEffectiveEpoch — the helper
+// writes to currentEpoch (= EffectiveEpochIndex) and leaves other epoch
+// slots untouched.
+func TestEnsureActiveParticipantsSeeded_RespectsEffectiveEpoch(t *testing.T) {
+	k, ctx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 3, 4)
+	registerAsParticipants(t, k, ctx, accs)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 42))
+
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(ctx, k))
+
+	require.Len(t, collectActiveAddrs(t, ctx, k, 42), len(accs))
+	require.Empty(t, collectActiveAddrs(t, ctx, k, 0))
+	require.Empty(t, collectActiveAddrs(t, ctx, k, 41))
+	require.Empty(t, collectActiveAddrs(t, ctx, k, 43))
+}

--- a/inference-chain/x/inference/simulation/decoder.go
+++ b/inference-chain/x/inference/simulation/decoder.go
@@ -1,0 +1,138 @@
+package simulation
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/types/kv"
+	"github.com/cosmos/gogoproto/proto"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// NewDecodeStore returns the x/inference store decoder used by
+// simtestutil.GetSimulationLog on AppHash divergence. The simsx happy-path
+// never invokes it; the decoder feeds (a) TestAppImportExport_Postrun's
+// existing diff path and (b) the TestAppStateDeterminism divergence dump
+// added alongside this decoder.
+//
+// Coverage scope is the ~39 collections actively written by the current
+// simsx factories and EndBlocker paths. Bridge / devshard / liquidity /
+// legacy training / cleared-by-upgrade prefixes are excluded — those
+// collections are never produced by the sim and decoding them would be
+// dead code. Unknown prefixes fall through to a labelled hex dump so a
+// future Phase 4 collection does not silently break divergence dumps.
+func NewDecodeStore(cdc codec.BinaryCodec) func(kvA, kvB kv.Pair) string {
+	return func(kvA, kvB kv.Pair) string {
+		switch {
+
+		// === Core inference state ===
+		case bytes.HasPrefix(kvA.Key, types.ParticipantsPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.Participant{}, &types.Participant{}, "Participant")
+		case bytes.HasPrefix(kvA.Key, types.InferencesPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.Inference{}, &types.Inference{}, "Inference")
+		case bytes.HasPrefix(kvA.Key, types.InferenceTimeoutPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.InferenceTimeout{}, &types.InferenceTimeout{}, "InferenceTimeout")
+		case bytes.HasPrefix(kvA.Key, types.InferenceValidationDetailsPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.InferenceValidationDetails{}, &types.InferenceValidationDetails{}, "InferenceValidationDetails")
+		case bytes.HasPrefix(kvA.Key, types.ModelsPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.Model{}, &types.Model{}, "Model")
+
+		// === Epoch state ===
+		case bytes.HasPrefix(kvA.Key, types.EpochsPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.Epoch{}, &types.Epoch{}, "Epoch")
+		case bytes.HasPrefix(kvA.Key, types.EpochGroupDataPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.EpochGroupData{}, &types.EpochGroupData{}, "EpochGroupData")
+		case bytes.HasPrefix(kvA.Key, types.EpochGroupValidationsPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.EpochGroupValidations{}, &types.EpochGroupValidations{}, "EpochGroupValidations")
+		case bytes.HasPrefix(kvA.Key, types.EpochPerformanceSummaryPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.EpochPerformanceSummary{}, &types.EpochPerformanceSummary{}, "EpochPerformanceSummary")
+
+		// === PoC v1 (still active via PoCBatch factory) ===
+		case bytes.HasPrefix(kvA.Key, types.RandomSeedPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.RandomSeed{}, &types.RandomSeed{}, "RandomSeed")
+		case bytes.HasPrefix(kvA.Key, types.PoCBatchPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.PoCBatch{}, &types.PoCBatch{}, "PoCBatch")
+		case bytes.HasPrefix(kvA.Key, types.PoCValidationPref):
+			return decodeProto(cdc, kvA, kvB, &types.PoCValidation{}, &types.PoCValidation{}, "PoCValidation")
+		case bytes.HasPrefix(kvA.Key, types.PoCValidationSnapshotPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.PoCValidationSnapshot{}, &types.PoCValidationSnapshot{}, "PoCValidationSnapshot")
+
+		// === PoC v2 (exercised by 3 V2 factories) ===
+		case bytes.HasPrefix(kvA.Key, types.PoCV2StoreCommitPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.PoCV2StoreCommit{}, &types.PoCV2StoreCommit{}, "PoCV2StoreCommit")
+		case bytes.HasPrefix(kvA.Key, types.PoCValidationV2Prefix):
+			return decodeProto(cdc, kvA, kvB, &types.PoCValidationV2{}, &types.PoCValidationV2{}, "PoCValidationV2")
+		case bytes.HasPrefix(kvA.Key, types.MLNodeWeightDistributionPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.MLNodeWeightDistribution{}, &types.MLNodeWeightDistribution{}, "MLNodeWeightDistribution")
+
+		// === Pricing ===
+		case bytes.HasPrefix(kvA.Key, types.ModelLoadRollingWindowPrefix),
+			bytes.HasPrefix(kvA.Key, types.ModelInferenceCountRollingWindowPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.RollingWindowState{}, &types.RollingWindowState{}, "RollingWindowState")
+		case bytes.HasPrefix(kvA.Key, types.UnitOfComputePriceProposalPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.UnitOfComputePriceProposal{}, &types.UnitOfComputePriceProposal{}, "UnitOfComputePriceProposal")
+
+		// === Invalidation lifecycle ===
+		case bytes.HasPrefix(kvA.Key, types.ExcludedParticipantsPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.ExcludedParticipant{}, &types.ExcludedParticipant{}, "ExcludedParticipant")
+		case bytes.HasPrefix(kvA.Key, types.ConfirmationPoCEventsPrefix),
+			bytes.HasPrefix(kvA.Key, types.ActiveConfirmationPoCEventPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.ConfirmationPoCEvent{}, &types.ConfirmationPoCEvent{}, "ConfirmationPoCEvent")
+
+		// === Settlement & rewards ===
+		case bytes.HasPrefix(kvA.Key, types.SettleAmountPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.SettleAmount{}, &types.SettleAmount{}, "SettleAmount")
+		case bytes.HasPrefix(kvA.Key, types.TopMinerPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.TopMiner{}, &types.TopMiner{}, "TopMiner")
+
+		// === Upgrade & pruning ===
+		case bytes.HasPrefix(kvA.Key, types.PartialUpgradePrefix):
+			return decodeProto(cdc, kvA, kvB, &types.PartialUpgrade{}, &types.PartialUpgrade{}, "PartialUpgrade")
+		case bytes.HasPrefix(kvA.Key, types.PruningStatePrefix):
+			return decodeProto(cdc, kvA, kvB, &types.PruningState{}, &types.PruningState{}, "PruningState")
+		case bytes.HasPrefix(kvA.Key, types.PunishmentGraceEpochsPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.GraceEpochParams{}, &types.GraceEpochParams{}, "GraceEpochParams")
+		case bytes.HasPrefix(kvA.Key, types.PreservedNodesSnapshotPrefix):
+			return decodeProto(cdc, kvA, kvB, &types.PreservedNodesSnapshot{}, &types.PreservedNodesSnapshot{}, "PreservedNodesSnapshot")
+
+		// === KeySets (no value bytes) ===
+		case bytes.HasPrefix(kvA.Key, types.ActiveInvalidationsPrefix),
+			bytes.HasPrefix(kvA.Key, types.ParticipantAllowListPrefix),
+			bytes.HasPrefix(kvA.Key, types.EpochGroupValidationEntryPrefix),
+			bytes.HasPrefix(kvA.Key, types.ActiveParticipantsCachePrefix),
+			bytes.HasPrefix(kvA.Key, types.InferencesToPrunePrefix):
+			return fmt.Sprintf("KeySet entry\nA key: %X\nB key: %X\n", kvA.Key, kvB.Key)
+
+		// === Raw uint64 Items / Maps ===
+		case bytes.HasPrefix(kvA.Key, types.EffectiveEpochIndexPrefix),
+			bytes.HasPrefix(kvA.Key, types.PocV2EnabledEpochPrefix),
+			bytes.HasPrefix(kvA.Key, types.DynamicPricingCurrentPrefix),
+			bytes.HasPrefix(kvA.Key, types.DynamicPricingCapacityPrefix):
+			return fmt.Sprintf("uint64\nA: %d\nB: %d\n",
+				binary.BigEndian.Uint64(kvA.Value), binary.BigEndian.Uint64(kvB.Value))
+		case bytes.HasPrefix(kvA.Key, types.LastUpgradeHeightPrefix):
+			return fmt.Sprintf("int64\nA: %d\nB: %d\n",
+				int64(binary.BigEndian.Uint64(kvA.Value)), int64(binary.BigEndian.Uint64(kvB.Value)))
+
+		// === Legacy params (raw store.Set with string key, not collections) ===
+		case bytes.Equal(kvA.Key, types.ParamsKey):
+			return decodeProto(cdc, kvA, kvB, &types.Params{}, &types.Params{}, "Params")
+
+		default:
+			return fmt.Sprintf("unhandled inference prefix\nA key: %X => %X\nB key: %X => %X\n",
+				kvA.Key, kvA.Value, kvB.Key, kvB.Value)
+		}
+	}
+}
+
+// decodeProto unmarshals both halves of the kv pair into the supplied proto
+// targets and returns a side-by-side dump. The two distinct pointer args
+// avoid aliasing across kvA and kvB.
+func decodeProto(cdc codec.BinaryCodec, kvA, kvB kv.Pair, a, b proto.Message, label string) string {
+	cdc.MustUnmarshal(kvA.Value, a)
+	cdc.MustUnmarshal(kvB.Value, b)
+	return fmt.Sprintf("%s\nA: %v\nB: %v\n", label, a, b)
+}

--- a/inference-chain/x/inference/simulation/decoder_test.go
+++ b/inference-chain/x/inference/simulation/decoder_test.go
@@ -1,0 +1,143 @@
+package simulation_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/types/kv"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/simulation"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// keyWithPrefix builds a sample KV key by appending an arbitrary suffix
+// after the collection prefix. The decoder switch only inspects the
+// prefix, so the suffix bytes are not interpreted.
+func keyWithPrefix(prefix []byte, suffix string) []byte {
+	out := make([]byte, 0, len(prefix)+len(suffix))
+	out = append(out, prefix...)
+	out = append(out, suffix...)
+	return out
+}
+
+func newTestCodec() codec.BinaryCodec {
+	return codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+}
+
+func TestNewDecodeStore_Participant_DecodesProto(t *testing.T) {
+	cdc := newTestCodec()
+	dec := simulation.NewDecodeStore(cdc)
+
+	a := &types.Participant{Address: "gonka1aaaa", CoinBalance: 100}
+	b := &types.Participant{Address: "gonka1aaaa", CoinBalance: 200}
+
+	out := dec(
+		kv.Pair{Key: keyWithPrefix(types.ParticipantsPrefix, "k"), Value: cdc.MustMarshal(a)},
+		kv.Pair{Key: keyWithPrefix(types.ParticipantsPrefix, "k"), Value: cdc.MustMarshal(b)},
+	)
+	require.True(t, strings.HasPrefix(out, "Participant\n"), "label missing: %q", out)
+	require.Contains(t, out, "100")
+	require.Contains(t, out, "200")
+}
+
+func TestNewDecodeStore_Inference_DecodesProto(t *testing.T) {
+	cdc := newTestCodec()
+	dec := simulation.NewDecodeStore(cdc)
+
+	a := &types.Inference{InferenceId: "id-A", Status: types.InferenceStatus_STARTED}
+	b := &types.Inference{InferenceId: "id-B", Status: types.InferenceStatus_FINISHED}
+
+	out := dec(
+		kv.Pair{Key: keyWithPrefix(types.InferencesPrefix, "id-A"), Value: cdc.MustMarshal(a)},
+		kv.Pair{Key: keyWithPrefix(types.InferencesPrefix, "id-A"), Value: cdc.MustMarshal(b)},
+	)
+	require.True(t, strings.HasPrefix(out, "Inference\n"))
+	require.Contains(t, out, "id-A")
+	require.Contains(t, out, "id-B")
+}
+
+func TestNewDecodeStore_KeySet_PrintsKeyHex(t *testing.T) {
+	cdc := newTestCodec()
+	dec := simulation.NewDecodeStore(cdc)
+
+	keyA := keyWithPrefix(types.ActiveInvalidationsPrefix, "a-entry")
+	keyB := keyWithPrefix(types.ActiveInvalidationsPrefix, "b-entry")
+
+	out := dec(
+		kv.Pair{Key: keyA, Value: nil},
+		kv.Pair{Key: keyB, Value: nil},
+	)
+	require.True(t, strings.HasPrefix(out, "KeySet entry\n"))
+	require.Contains(t, out, fmt.Sprintf("%X", keyA))
+	require.Contains(t, out, fmt.Sprintf("%X", keyB))
+}
+
+func TestNewDecodeStore_Uint64_EffectiveEpochIndex(t *testing.T) {
+	cdc := newTestCodec()
+	dec := simulation.NewDecodeStore(cdc)
+
+	bufA := make([]byte, 8)
+	bufB := make([]byte, 8)
+	binary.BigEndian.PutUint64(bufA, 42)
+	binary.BigEndian.PutUint64(bufB, 43)
+
+	out := dec(
+		kv.Pair{Key: types.EffectiveEpochIndexPrefix, Value: bufA},
+		kv.Pair{Key: types.EffectiveEpochIndexPrefix, Value: bufB},
+	)
+	require.True(t, strings.HasPrefix(out, "uint64\n"))
+	require.Contains(t, out, "42")
+	require.Contains(t, out, "43")
+}
+
+func TestNewDecodeStore_Int64_LastUpgradeHeight(t *testing.T) {
+	cdc := newTestCodec()
+	dec := simulation.NewDecodeStore(cdc)
+
+	bufA := make([]byte, 8)
+	bufB := make([]byte, 8)
+	binary.BigEndian.PutUint64(bufA, uint64(int64(100)))
+	binary.BigEndian.PutUint64(bufB, uint64(int64(200)))
+
+	out := dec(
+		kv.Pair{Key: types.LastUpgradeHeightPrefix, Value: bufA},
+		kv.Pair{Key: types.LastUpgradeHeightPrefix, Value: bufB},
+	)
+	require.True(t, strings.HasPrefix(out, "int64\n"))
+	require.Contains(t, out, "100")
+	require.Contains(t, out, "200")
+}
+
+func TestNewDecodeStore_LegacyParamsKey(t *testing.T) {
+	cdc := newTestCodec()
+	dec := simulation.NewDecodeStore(cdc)
+
+	defaultParams := types.DefaultParams()
+	out := dec(
+		kv.Pair{Key: types.ParamsKey, Value: cdc.MustMarshal(&defaultParams)},
+		kv.Pair{Key: types.ParamsKey, Value: cdc.MustMarshal(&defaultParams)},
+	)
+	require.True(t, strings.HasPrefix(out, "Params\n"), "label missing: %q", out)
+}
+
+func TestNewDecodeStore_UnknownPrefix_FallsBackToHex(t *testing.T) {
+	cdc := newTestCodec()
+	dec := simulation.NewDecodeStore(cdc)
+
+	// 0xFE is intentionally outside any used prefix range — would conflict
+	// with no current collection.
+	keyA := []byte{0xFE, 'a'}
+	keyB := []byte{0xFE, 'b'}
+	out := dec(
+		kv.Pair{Key: keyA, Value: []byte{1, 2}},
+		kv.Pair{Key: keyB, Value: []byte{3, 4}},
+	)
+	require.True(t, strings.HasPrefix(out, "unhandled inference prefix\n"))
+	require.Contains(t, out, fmt.Sprintf("%X", keyA))
+	require.Contains(t, out, fmt.Sprintf("%X", keyB))
+}

--- a/inference-chain/x/inference/simulation/future_ops.go
+++ b/inference-chain/x/inference/simulation/future_ops.go
@@ -1,0 +1,69 @@
+package simulation
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// simBlockTimeFloor matches cosmos-sdk x/simulation/params.go
+// minTimePerBlock. The runner advances block time uniformly in
+// [5000s, 10000s]. Future ops fire when header time strictly exceeds
+// the scheduled BlockTime, so scheduling at the floor guarantees
+// arrival at or before the target sim block — a late estimate would
+// miss a PoC window and cost a whole sim epoch.
+const simBlockTimeFloor = 5000 * time.Second
+
+// pocFactoryState dedups self-reschedule by sim-epoch index across the
+// lifetime of one factory instance. simsx fires queued ops on a single
+// goroutine today; the atomic guard pins the contract so a concurrent
+// runner upgrade does not silently double-book.
+//
+// Concurrency assumption: cosmos-sdk simsx fires queued ops serially
+// today (x/simulation/simulate.go runQueuedTimeOperations is a single
+// goroutine). A single *LazyStateSimMsgFactory instance is reused
+// across multiple queued fires, and SetFutureOpsRegistry mutates its
+// fsOpsReg field on each fire (testutil/simsx/registry.go); if a
+// future runner upgrade dispatches factories concurrently, the
+// closure's read of r.fsOpsReg would race that write. The atomic
+// guard here is forward-compatible; the closure-side assumption
+// upstream is not — re-audit if upstream introduces parallel sim ops.
+type pocFactoryState struct {
+	lastScheduledEpoch atomic.Uint64
+}
+
+// newPocFactoryState returns an initialised factory-state guard.
+func newPocFactoryState() *pocFactoryState {
+	return &pocFactoryState{}
+}
+
+// scheduleForEpoch enqueues factory at the estimated arrival time of
+// targetHeight, but only when epochIndex strictly exceeds every prior
+// schedule for this state. Returns true when a schedule was added.
+func (s *pocFactoryState) scheduleForEpoch(
+	ctx context.Context,
+	fOpsReg simsx.FutureOpsRegistry,
+	epochIndex uint64,
+	currentHeight, targetHeight int64,
+	factory simsx.SimMsgFactoryX,
+) bool {
+	for {
+		prev := s.lastScheduledEpoch.Load()
+		if epochIndex <= prev {
+			return false
+		}
+		if s.lastScheduledEpoch.CompareAndSwap(prev, epochIndex) {
+			break
+		}
+	}
+	delta := targetHeight - currentHeight
+	if delta < 1 {
+		delta = 1
+	}
+	now := sdk.UnwrapSDKContext(ctx).BlockTime()
+	fOpsReg.Add(now.Add(time.Duration(delta)*simBlockTimeFloor), factory)
+	return true
+}

--- a/inference-chain/x/inference/simulation/genesis.go
+++ b/inference-chain/x/inference/simulation/genesis.go
@@ -1,0 +1,94 @@
+package simulation
+
+import (
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// SimModelIDs is the canonical ordered list of model IDs registered at
+// sim genesis. Tests assert exact membership; factories pick from it.
+var SimModelIDs = []string{
+	"Qwen/Qwen2.5-7B-Instruct",
+	"moonshotai/Kimi-K2.6",
+}
+
+// BuildSimGenesisModels returns the Phase-2 sim model registry. Values
+// mirror real mainnet governance entries:
+//
+//   - Qwen/Qwen2.5-7B-Instruct: from x/inference/keeper/model_test.go
+//     (the canonical genesis-style example in the keeper's own tests).
+//   - moonshotai/Kimi-K2.6: from app/upgrades/v0_2_12/upgrades.go
+//     (kimiGovernanceModel) — installed on mainnet via the v0.2.12 upgrade
+//     handler.
+//
+// ProposedBy="genesis" is required by the production InitGenesis check at
+// module/genesis.go; InitGenesis then rewrites it to k.GetAuthority().
+// Using realistic mainnet parameters (Phase-2 issue text §«helper logic
+// for selecting valid accounts and valid preconditions … realistic
+// messages rather than mostly generating invalid transactions»).
+//
+// Sim-only — does not run on production chain init.
+func BuildSimGenesisModels() []types.Model {
+	return []types.Model{
+		{
+			ProposedBy:             "genesis",
+			Id:                     "Qwen/Qwen2.5-7B-Instruct",
+			UnitsOfComputePerToken: 100,
+			HfRepo:                 "Qwen/Qwen2.5-7B-Instruct",
+			HfCommit:               "a09a35458c702b33eeacc393d103063234e8bc28",
+			ModelArgs:              []string{"--quantization", "fp8"},
+			VRam:                   24,
+			ThroughputPerNonce:     10000,
+			ValidationThreshold:    &types.Decimal{Value: 85, Exponent: -2},
+		},
+		{
+			ProposedBy:             "genesis",
+			Id:                     "moonshotai/Kimi-K2.6",
+			UnitsOfComputePerToken: 10000,
+			HfRepo:                 "moonshotai/Kimi-K2.6",
+			HfCommit:               "5a49d036ab7472b7d5912ded487150ec1358c11d",
+			ModelArgs: []string{
+				"--max-model-len", "240000",
+				"--tool-call-parser", "kimi_k2",
+				"--reasoning-parser", "kimi_k2",
+			},
+			VRam:                720,
+			ThroughputPerNonce:  1500,
+			ValidationThreshold: &types.Decimal{Value: 920, Exponent: -3},
+		},
+	}
+}
+
+// NumSimGenesisParticipants is the count of sim accounts pre-registered as
+// Participants at sim genesis. The bootstrap helper (bootstrap.go) promotes
+// them into ActiveParticipantsSet[currentEpoch] on first call from any
+// active-participant-gated factory.
+const NumSimGenesisParticipants = 5
+
+// BuildSimGenesisParticipants picks N sim accounts and returns them as
+// Participant entries for GenesisState.ParticipantList. Status is left
+// zero — production InitGenesis runs the participant loop BEFORE SetParams,
+// so UpdateParticipantStatus → ComputeStatus hits its genesis fast path
+// (calculations/status.go) and assigns ACTIVE.
+//
+// Sim-only — no production code change. ActiveParticipantsSet promotion is
+// done lazily by EnsureActiveParticipantsSeeded (bootstrap.go).
+//
+// Determinism: simState.Accounts is generated from r *rand.Rand by simsx,
+// so the same seed yields the same prefix selection.
+func BuildSimGenesisParticipants(simState *module.SimulationState) []types.Participant {
+	n := NumSimGenesisParticipants
+	if len(simState.Accounts) < n {
+		n = len(simState.Accounts)
+	}
+	out := make([]types.Participant, 0, n)
+	for i := 0; i < n; i++ {
+		addr := simState.Accounts[i].Address.String()
+		out = append(out, types.Participant{
+			Index:   addr,
+			Address: addr,
+		})
+	}
+	return out
+}

--- a/inference-chain/x/inference/simulation/genesis.go
+++ b/inference-chain/x/inference/simulation/genesis.go
@@ -83,8 +83,15 @@ func BuildSimGenesisModels() []types.Model {
 // DefaultParams() leaves it at the Go zero value (false) which is the
 // pre-upgrade legacy. Sim is meant to mirror current mainnet behaviour,
 // so we flip it here.
-func BuildSimGenesisParams() types.Params {
+func BuildSimGenesisParams(simState *module.SimulationState) types.Params {
 	params := types.DefaultParams()
+	// Apply parameter fuzzing for multi-seed exploration (#982 Phase 3
+	// bullet 5). simState.Rand is seeded deterministically from
+	// simState.Seed; runs with the same -Seed flag produce the same
+	// mutated params.
+	if simState != nil && simState.Rand != nil {
+		MutateSimParams(simState.Rand, &params)
+	}
 	if params.PocParams != nil {
 		params.PocParams.PocV2Enabled = true
 	}

--- a/inference-chain/x/inference/simulation/genesis.go
+++ b/inference-chain/x/inference/simulation/genesis.go
@@ -1,10 +1,23 @@
 package simulation
 
 import (
+	"encoding/base64"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	"github.com/productscience/inference/x/inference/types"
 )
+
+// SimValidatorKey derives a deterministic base64-encoded ed25519 validator
+// public key for a sim participant from its account address. Shared by
+// BuildSimGenesisParticipants and MsgSubmitNewParticipantFactory so the same
+// address always maps to the same key — keeping the epoch-group x/group member
+// Metadata consistent and MsgSubmitNewParticipant re-submission idempotent.
+func SimValidatorKey(addr string) string {
+	pubKey := ed25519.GenPrivKeyFromSecret([]byte("gonka-sim-validator:" + addr)).PubKey()
+	return base64.StdEncoding.EncodeToString(pubKey.Bytes())
+}
 
 // SimModelIDs is the canonical ordered list of model IDs registered at
 // sim genesis. Tests assert exact membership; factories pick from it.
@@ -60,6 +73,24 @@ func BuildSimGenesisModels() []types.Model {
 	}
 }
 
+// BuildSimGenesisParams returns DefaultParams with sim-only overrides
+// applied: PocV2Enabled=true so the V2 PoC msg handlers
+// (PoCV2StoreCommit, MLNodeWeightDistribution, SubmitPocValidationsV2)
+// accept submissions. Without this the handlers reject with
+// ErrNotSupported (msg_server_poc_v2_commit.go:43).
+//
+// Mainnet uses PocV2Enabled=true via the v0.2.x upgrade chain;
+// DefaultParams() leaves it at the Go zero value (false) which is the
+// pre-upgrade legacy. Sim is meant to mirror current mainnet behaviour,
+// so we flip it here.
+func BuildSimGenesisParams() types.Params {
+	params := types.DefaultParams()
+	if params.PocParams != nil {
+		params.PocParams.PocV2Enabled = true
+	}
+	return params
+}
+
 // NumSimGenesisParticipants is the count of sim accounts pre-registered as
 // Participants at sim genesis. The bootstrap helper (bootstrap.go) promotes
 // them into ActiveParticipantsSet[currentEpoch] on first call from any
@@ -73,7 +104,8 @@ const NumSimGenesisParticipants = 5
 // (calculations/status.go) and assigns ACTIVE.
 //
 // Sim-only — no production code change. ActiveParticipantsSet promotion is
-// done lazily by EnsureActiveParticipantsSeeded (bootstrap.go).
+// done lazily by BuildEpochSubstrate (substrate.go) on the first factory
+// call per epoch.
 //
 // Determinism: simState.Accounts is generated from r *rand.Rand by simsx,
 // so the same seed yields the same prefix selection.
@@ -86,8 +118,9 @@ func BuildSimGenesisParticipants(simState *module.SimulationState) []types.Parti
 	for i := 0; i < n; i++ {
 		addr := simState.Accounts[i].Address.String()
 		out = append(out, types.Participant{
-			Index:   addr,
-			Address: addr,
+			Index:        addr,
+			Address:      addr,
+			ValidatorKey: SimValidatorKey(addr),
 		})
 	}
 	return out

--- a/inference-chain/x/inference/simulation/genesis_fuzz.go
+++ b/inference-chain/x/inference/simulation/genesis_fuzz.go
@@ -1,0 +1,189 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// MutateSimParams randomizes the governance-mutable Params for each sim seed,
+// pushing values to the real Params.Validate() boundaries and across all seven
+// in-scope sub-structs. Per issue #982 Phase 3: "explore parameter boundaries
+// and parameter combinations more aggressively."
+//
+// Three design rules, derived from the code (not from caution):
+//
+//  1. Most economic params (prices, vesting, fees, weight ratios) are pushed to
+//     their Validate() boundaries. They are liveness-safe — an extreme price or
+//     vesting period just makes a tx fail gracefully (escrow > balance, etc.),
+//     it does not halt the chain — and they stress the accounting/invariant
+//     paths where findings #1265/#1269/#1273 live.
+//  2. Timing params (EpochParams) are widened but kept internally consistent:
+//     Validate() does NOT enforce that the PoC + validation stages fit inside
+//     EpochLength, but the simulation requires it. So EpochLength is fuzzed
+//     within a survivable band (floor 30, matching the proven baseline) and the
+//     stage durations are derived as fractions of it.
+//  3. Collateral SLASHING-activation levers (SlashFractionInvalid/Downtime,
+//     DowntimeMissedPercentageThreshold, GracePeriodEndEpoch) are NOT fuzzed.
+//     The sim's upstream-validator substrate runs at Tokens=1 (an InitChain
+//     shrink hack, see app/sim_test.go shrinkUpstreamStakingValidators), and
+//     ANY active slashing zeroes Tokens+DelegatorShares → x/slashing Unjail
+//     divides 0/0 → validators jail and never recover → the cometbft set
+//     drains and the run SKIPs on "empty validator set". This is a sim-substrate
+//     limitation, NOT a production constraint; those params are covered by unit
+//     tests, not by genesis fuzzing.
+//
+// GenesisOnlyParams (collateral_amount, model_init_params, ...) are NOT touched
+// — only runtime-mutable Params. See docs/simulation.md §Parameter fuzzing.
+//
+// Parameter COMBINATIONS are exercised via corner profiles: ~1/4 of seeds drive
+// every knob to its low boundary, ~1/4 to its high boundary, the rest spread
+// independently — so corner-combination bugs surface instead of averaging out.
+func MutateSimParams(rng *rand.Rand, params *types.Params) {
+	if params == nil {
+		return
+	}
+	p := pickProfile(rng)
+
+	if params.EpochParams != nil {
+		epochLen := fuzzInt64(rng, p, 30, 120)
+		params.EpochParams.EpochLength = epochLen
+		params.EpochParams.PocStageDuration = clampMinI64(epochLen/5, 2)      // ~20%, >=2
+		params.EpochParams.PocValidationDuration = clampMinI64(epochLen/8, 1) // ~12%, >=1
+		params.EpochParams.InferencePruningEpochThreshold = fuzzUint64(rng, p, 1, 10)
+	}
+	if params.ValidationParams != nil {
+		params.ValidationParams.MinRampUpMeasurements = fuzzInt32(rng, p, 1, 50)
+		params.ValidationParams.ExpirationBlocks = fuzzInt64(rng, p, 5, 80)
+		params.ValidationParams.MinValidationTrafficCutoff = fuzzInt64(rng, p, 0, 1000)
+	}
+	if params.PocParams != nil {
+		params.PocParams.DefaultDifficulty = fuzzInt32(rng, p, 1, 20)
+		params.PocParams.PocDataPruningEpochThreshold = fuzzUint64(rng, p, 1, 10)
+	}
+	if params.FeeParams != nil {
+		params.FeeParams.MinGasPriceNgonka = fuzzUint64(rng, p, 0, 5000)
+		params.FeeParams.BaseValidationGas = fuzzUint64(rng, p, 500, 50000)
+	}
+	// CollateralParams — only the non-slashing economic levers. The slashing
+	// levers (SlashFraction*, DowntimeMissedPercentageThreshold,
+	// GracePeriodEndEpoch) are deliberately left at defaults: active slashing
+	// drains the Tokens=1 sim validator substrate (see rule 3 above).
+	if params.CollateralParams != nil {
+		params.CollateralParams.BaseWeightRatio = fuzzDecimal(rng, p, 0, 1)          // [0,1]
+		params.CollateralParams.CollateralPerWeightUnit = fuzzDecimal(rng, p, 0, 100) // >=0
+	}
+	if params.TokenomicsParams != nil {
+		params.TokenomicsParams.WorkVestingPeriod = fuzzUint64(rng, p, 0, 360)
+		params.TokenomicsParams.RewardVestingPeriod = fuzzUint64(rng, p, 0, 360)
+	}
+	// DynamicPricingParams — lower<upper enforced by construction; prices >0.
+	if params.DynamicPricingParams != nil {
+		params.DynamicPricingParams.StabilityZoneLowerBound = fuzzDecimal(rng, p, 0, 0.49)
+		params.DynamicPricingParams.StabilityZoneUpperBound = fuzzDecimal(rng, p, 0.51, 1.0)
+		params.DynamicPricingParams.PriceElasticity = fuzzDecimal(rng, p, 0.01, 1.0) // (0,1]
+		params.DynamicPricingParams.UtilizationWindowDuration = fuzzUint64(rng, p, 1, 600)
+		params.DynamicPricingParams.MinPerTokenPrice = fuzzUint64(rng, p, 1, 1000)
+		params.DynamicPricingParams.BasePerTokenPrice = fuzzUint64(rng, p, 1, 2000)
+		params.DynamicPricingParams.GracePeriodPerTokenPrice = fuzzUint64(rng, p, 0, 1000)
+		params.DynamicPricingParams.GracePeriodEndEpoch = fuzzUint64(rng, p, 0, 50)
+	}
+}
+
+// fuzzProfile biases a whole seed toward a corner of the parameter space.
+type fuzzProfile int
+
+const (
+	profileSpread fuzzProfile = iota // independent uniform draws
+	profileLow                       // every field at its low boundary
+	profileHigh                      // every field at its high boundary
+)
+
+func pickProfile(rng *rand.Rand) fuzzProfile {
+	switch rng.Intn(4) {
+	case 0:
+		return profileLow
+	case 1:
+		return profileHigh
+	default:
+		return profileSpread
+	}
+}
+
+func fuzzInt64(rng *rand.Rand, p fuzzProfile, min, max int64) int64 {
+	switch p {
+	case profileLow:
+		return min
+	case profileHigh:
+		return max
+	default:
+		return randInt64(rng, min, max)
+	}
+}
+
+func fuzzUint64(rng *rand.Rand, p fuzzProfile, min, max uint64) uint64 {
+	switch p {
+	case profileLow:
+		return min
+	case profileHigh:
+		return max
+	default:
+		return randUint64(rng, min, max)
+	}
+}
+
+func fuzzInt32(rng *rand.Rand, p fuzzProfile, min, max int32) int32 {
+	switch p {
+	case profileLow:
+		return min
+	case profileHigh:
+		return max
+	default:
+		return randInt32(rng, min, max)
+	}
+}
+
+// fuzzDecimal returns a *types.Decimal in [lo,hi], boundary-pulled per profile.
+func fuzzDecimal(rng *rand.Rand, p fuzzProfile, lo, hi float64) *types.Decimal {
+	var f float64
+	switch p {
+	case profileLow:
+		f = lo
+	case profileHigh:
+		f = hi
+	default:
+		f = lo + rng.Float64()*(hi-lo)
+	}
+	return types.DecimalFromFloat(f)
+}
+
+func clampMinI64(v, min int64) int64 {
+	if v < min {
+		return min
+	}
+	return v
+}
+
+// randInt64 returns a random int64 in [min, max] inclusive.
+func randInt64(rng *rand.Rand, min, max int64) int64 {
+	if max <= min {
+		return min
+	}
+	return min + rng.Int63n(max-min+1)
+}
+
+// randUint64 returns a random uint64 in [min, max] inclusive.
+func randUint64(rng *rand.Rand, min, max uint64) uint64 {
+	if max <= min {
+		return min
+	}
+	return min + uint64(rng.Int63n(int64(max-min+1)))
+}
+
+// randInt32 returns a random int32 in [min, max] inclusive.
+func randInt32(rng *rand.Rand, min, max int32) int32 {
+	if max <= min {
+		return min
+	}
+	return min + rng.Int31n(max-min+1)
+}

--- a/inference-chain/x/inference/simulation/genesis_test.go
+++ b/inference-chain/x/inference/simulation/genesis_test.go
@@ -1,0 +1,72 @@
+package simulation_test
+
+import (
+	"encoding/json"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/simulation"
+)
+
+// TestBuildSimGenesisParticipants_PicksN verifies the helper extracts
+// exactly NumSimGenesisParticipants entries from a longer Accounts slice,
+// preserving the prefix order (deterministic given simState.Rand seed).
+func TestBuildSimGenesisParticipants_PicksN(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	accs := simtypes.RandomAccounts(r, simulation.NumSimGenesisParticipants+3)
+	simState := &module.SimulationState{
+		Accounts:     accs,
+		Rand:         r,
+		GenState:     map[string]json.RawMessage{},
+		GenTimestamp: time.Unix(0, 0),
+	}
+
+	got := simulation.BuildSimGenesisParticipants(simState)
+	require.Len(t, got, simulation.NumSimGenesisParticipants)
+	for i, p := range got {
+		require.Equal(t, accs[i].Address.String(), p.Index)
+		require.Equal(t, accs[i].Address.String(), p.Address)
+	}
+}
+
+// TestBuildSimGenesisParticipants_FewerAccountsAvailable caps the output
+// length at len(simState.Accounts) when that is below
+// NumSimGenesisParticipants — the helper must not panic or pad.
+func TestBuildSimGenesisParticipants_FewerAccountsAvailable(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	want := simulation.NumSimGenesisParticipants - 2
+	require.Greater(t, want, 0)
+	accs := simtypes.RandomAccounts(r, want)
+	simState := &module.SimulationState{
+		Accounts:     accs,
+		Rand:         r,
+		GenState:     map[string]json.RawMessage{},
+		GenTimestamp: time.Unix(0, 0),
+	}
+
+	got := simulation.BuildSimGenesisParticipants(simState)
+	require.Len(t, got, want)
+}
+
+// TestBuildSimGenesisModels_KimiAndQwen — sim genesis registers Qwen +
+// Kimi with ProposedBy="genesis" (required by production InitGenesis at
+// module/genesis.go). Values must match the canonical mainnet
+// entries so the simulation pressure-tests realistic chain config.
+func TestBuildSimGenesisModels_KimiAndQwen(t *testing.T) {
+	got := simulation.BuildSimGenesisModels()
+	require.Len(t, got, 2)
+	ids := []string{got[0].Id, got[1].Id}
+	require.ElementsMatch(t, simulation.SimModelIDs, ids)
+	for _, m := range got {
+		require.Equal(t, "genesis", m.ProposedBy,
+			"sim genesis model must set ProposedBy=genesis")
+		require.NotEmpty(t, m.HfRepo)
+		require.NotZero(t, m.UnitsOfComputePerToken)
+		require.NotNil(t, m.ValidationThreshold)
+	}
+}

--- a/inference-chain/x/inference/simulation/genesis_test.go
+++ b/inference-chain/x/inference/simulation/genesis_test.go
@@ -31,6 +31,7 @@ func TestBuildSimGenesisParticipants_PicksN(t *testing.T) {
 	for i, p := range got {
 		require.Equal(t, accs[i].Address.String(), p.Index)
 		require.Equal(t, accs[i].Address.String(), p.Address)
+		require.NotEmpty(t, p.ValidatorKey)
 	}
 }
 

--- a/inference-chain/x/inference/simulation/helpers_test.go
+++ b/inference-chain/x/inference/simulation/helpers_test.go
@@ -72,7 +72,12 @@ func putFinishedInference(t *testing.T, k keeper.Keeper, ctx context.Context, id
 		Index:       id,
 		InferenceId: id,
 		ExecutedBy:  executedBy,
-		Status:      types.InferenceStatus_FINISHED,
+		// A real finished inference always carries a model; MsgValidationFactory
+		// resolves the validator's transient weight by (EpochId, Model), so an
+		// empty model would make every validator miss the cache and the factory
+		// skip. Use a genesis-registered sim model.
+		Model:  simulation.SimModelIDs[0],
+		Status: types.InferenceStatus_FINISHED,
 	}))
 }
 
@@ -112,6 +117,41 @@ func seedActiveParticipantsForTest(t *testing.T, ctx context.Context, k keeper.K
 		EpochId:      epoch,
 		Participants: aps,
 	}))
+}
+
+// seedModelWeightCacheForTest populates the transient model-weight cache
+// that MsgValidationFactory consults via GetCachedEpochDataModelWeight
+// before drawing a validator. It writes a root epoch group exposing the
+// first sim model as a sub-group, a model sub-group carrying a
+// ValidationWeight for every given member, then builds the transient cache
+// — the validator-side machinery that seedActiveParticipantsForTest
+// deliberately skips and that EnsureSimActiveParticipantsSeeded performs
+// during a real sim run.
+func seedModelWeightCacheForTest(t *testing.T, ctx context.Context, k keeper.Keeper, members []string, epoch uint64) {
+	t.Helper()
+	model := simulation.SimModelIDs[0]
+	k.SetEpochGroupData(ctx, types.EpochGroupData{
+		EpochIndex:     epoch,
+		ModelId:        "",
+		SubGroupModels: []string{model},
+	})
+	weights := make([]*types.ValidationWeight, 0, len(members))
+	var total int64
+	for _, addr := range members {
+		weights = append(weights, &types.ValidationWeight{
+			MemberAddress: addr,
+			Weight:        100,
+			Reputation:    50,
+		})
+		total += 100
+	}
+	k.SetEpochGroupData(ctx, types.EpochGroupData{
+		EpochIndex:        epoch,
+		ModelId:           model,
+		ValidationWeights: weights,
+		TotalWeight:       total,
+	})
+	require.NoError(t, k.BuildEpochDataTransientCache(ctx))
 }
 
 // collectActiveAddrs returns the bech32 addresses in ActiveParticipantsSet

--- a/inference-chain/x/inference/simulation/helpers_test.go
+++ b/inference-chain/x/inference/simulation/helpers_test.go
@@ -97,6 +97,23 @@ func putStartedInference(t *testing.T, k keeper.Keeper, ctx context.Context, id,
 	}))
 }
 
+// seedActiveParticipantsForTest directly writes ActiveParticipants[epoch]
+// from the given sim accounts, bypassing BuildEpochSubstrate. Used by
+// picker tests that exercise pure read-side picker logic and do not need
+// the substrate's validator-side machinery (real x/staking validators,
+// SetComputeValidators call, etc. — these need a full app sim setup).
+func seedActiveParticipantsForTest(t *testing.T, ctx context.Context, k keeper.Keeper, accs []simtypes.Account, epoch uint64) {
+	t.Helper()
+	aps := make([]*types.ActiveParticipant, 0, len(accs))
+	for _, a := range accs {
+		aps = append(aps, &types.ActiveParticipant{Index: a.Address.String()})
+	}
+	require.NoError(t, k.SetActiveParticipants(ctx, types.ActiveParticipants{
+		EpochId:      epoch,
+		Participants: aps,
+	}))
+}
+
 // collectActiveAddrs returns the bech32 addresses in ActiveParticipantsSet
 // for the given epoch, in iteration (collections-sorted) order.
 func collectActiveAddrs(t *testing.T, ctx context.Context, k keeper.Keeper, epoch uint64) []string {

--- a/inference-chain/x/inference/simulation/helpers_test.go
+++ b/inference-chain/x/inference/simulation/helpers_test.go
@@ -1,0 +1,122 @@
+package simulation_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/core/address"
+	sdkaddress "github.com/cosmos/cosmos-sdk/codec/address"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/simulation"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// newSimAccounts returns n deterministic sim accounts using seed.
+// Equivalent to simtypes.RandomAccounts with an explicit math/rand source.
+func newSimAccounts(t *testing.T, seed int64, n int) []simtypes.Account {
+	t.Helper()
+	return simtypes.RandomAccounts(rand.New(rand.NewSource(seed)), n)
+}
+
+// registerAsParticipants registers each sim account as a Participant in the
+// keeper. Status pre-set to ACTIVE and CurrentEpochStats initialized so
+// UpdateParticipantStatus → ComputeStatus does not flip status under
+// DefaultParams (matches the keeper_test.createNParticipant pattern at
+// inference-chain/x/inference/keeper/participant_test.go).
+func registerAsParticipants(t *testing.T, k keeper.Keeper, ctx context.Context, accs []simtypes.Account) []string {
+	t.Helper()
+	out := make([]string, 0, len(accs))
+	for _, a := range accs {
+		addr := a.Address.String()
+		require.NoError(t, k.SetParticipant(ctx, types.Participant{
+			Index:             addr,
+			Address:           addr,
+			Status:            types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: types.NewCurrentEpochStats(),
+		}))
+		out = append(out, addr)
+	}
+	return out
+}
+
+// registerSimGenesisModels writes the Phase-2 sim models into the keeper.
+// Unit-test analogue of what InitGenesis does (module/genesis.go)
+// when it consumes GenesisState.ModelList. Needed so factory tests can
+// successfully invoke PickRandomGovernanceModelID without running a full
+// app-level sim genesis.
+func registerSimGenesisModels(t *testing.T, k keeper.Keeper, ctx context.Context) {
+	t.Helper()
+	for _, m := range simulation.BuildSimGenesisModels() {
+		mm := m
+		mm.ProposedBy = k.GetAuthority()
+		k.SetModel(ctx, &mm)
+	}
+}
+
+// putFinishedInference writes a FINISHED-status Inference into the
+// keeper. Used by MsgValidation factory tests: PickRandomFinishedInference
+// filters by Status==FINISHED to avoid the hard ErrInferenceNotFinished
+// path at msg_server_validation.go.
+// ExecutedBy is required to satisfy validator!=executor at
+// msg_server_validation.go — pass any registered participant
+// address whose role you do NOT want drawn as the validator.
+func putFinishedInference(t *testing.T, k keeper.Keeper, ctx context.Context, id, executedBy string) {
+	t.Helper()
+	require.NoError(t, k.SetInference(ctx, types.Inference{
+		Index:       id,
+		InferenceId: id,
+		ExecutedBy:  executedBy,
+		Status:      types.InferenceStatus_FINISHED,
+	}))
+}
+
+// putStartedInference writes a STARTED-status Inference with the dev/TA
+// components the MsgFinishInference start-first pairing path compares
+// against (compareDevComponents / compareFinishTAComponents). assignedTo
+// is both the executor and the account the Finish factory signs as.
+func putStartedInference(t *testing.T, k keeper.Keeper, ctx context.Context, id, assignedTo, model string) {
+	t.Helper()
+	require.NoError(t, k.SetInference(ctx, types.Inference{
+		Index:              id,
+		InferenceId:        id,
+		AssignedTo:         assignedTo,
+		ExecutedBy:         assignedTo,
+		TransferredBy:      assignedTo,
+		RequestedBy:        assignedTo,
+		PromptHash:         "sim-prompt-hash",
+		OriginalPromptHash: "sim-original-prompt-hash",
+		Model:              model,
+		RequestTimestamp:   1_000_000,
+		Status:             types.InferenceStatus_STARTED,
+	}))
+}
+
+// collectActiveAddrs returns the bech32 addresses in ActiveParticipantsSet
+// for the given epoch, in iteration (collections-sorted) order.
+func collectActiveAddrs(t *testing.T, ctx context.Context, k keeper.Keeper, epoch uint64) []string {
+	t.Helper()
+	iter, err := k.ActiveParticipantsSet.Iterate(ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](epoch))
+	require.NoError(t, err)
+	defer iter.Close()
+	out := make([]string, 0, 8)
+	for ; iter.Valid(); iter.Next() {
+		key, err := iter.Key()
+		require.NoError(t, err)
+		out = append(out, key.K2().String())
+	}
+	return out
+}
+
+// gonkaBech32Codec returns the address codec wired to the gonka account
+// prefix that keepertest.InferenceKeeper installs via
+// sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka").
+func gonkaBech32Codec() address.Codec {
+	return sdkaddress.NewBech32Codec("gonka")
+}

--- a/inference-chain/x/inference/simulation/ml_node_weight_distribution.go
+++ b/inference-chain/x/inference/simulation/ml_node_weight_distribution.go
@@ -1,0 +1,127 @@
+package simulation
+
+import (
+	"context"
+
+	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// MsgMLNodeWeightDistributionFactory creates a factory for MsgMLNodeWeightDistribution.
+//
+// Handler invariants the factory satisfies:
+//   - window: PoC start through EndOfPoCValidation
+//     (msg_server_poc_v2_commit.go)
+//   - existing PoCV2StoreCommit required for (participant, model, stage):
+//     factory pre-checks PoCV2StoreCommits.Has, skips if absent
+//   - sum(Entry.Weights[*].Weight) == commit.Count: factory reads the
+//     commit and emits a single MLNodeWeight at full weight
+//   - idempotency: MLNodeWeightDistributions.Has pre-check
+//
+// Implements HasFutureOpsRegistry: every skip and every success books
+// the next target window. Target height is StartOfPoC+2, two blocks
+// after MsgPoCV2StoreCommitFactory's StartOfPoC+1 target, so the
+// store commit is durable in KV before this factory's idempotency
+// check reads it.
+//
+// Requires Params.PocParams.PocV2Enabled=true.
+func MsgMLNodeWeightDistributionFactory(k keeper.Keeper) simsx.SimMsgFactoryX {
+	st := newPocFactoryState()
+	var self simsx.SimMsgFactoryX
+	self = simsx.NewSimMsgFactoryWithFutureOps[*types.MsgMLNodeWeightDistribution](
+		func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter, fOpsReg simsx.FutureOpsRegistry) ([]simsx.SimAccount, *types.MsgMLNodeWeightDistribution) {
+			sdkCtx := sdk.UnwrapSDKContext(ctx)
+			currentBlockHeight := sdkCtx.BlockHeight()
+
+			upcomingEpoch, found := k.GetUpcomingEpoch(ctx)
+			if !found || upcomingEpoch == nil {
+				reporter.Skipf("no upcoming epoch (pre-PoC genesis or post-rotation gap)")
+				return nil, nil
+			}
+			params, err := k.GetParams(ctx)
+			if err != nil {
+				reporter.Skipf("GetParams failed: %v", err)
+				return nil, nil
+			}
+			epochContext := types.NewEpochContext(*upcomingEpoch, *params.EpochParams)
+			stage := epochContext.StartOfPoC()
+			windowStart := stage + 2
+			if currentBlockHeight < stage || currentBlockHeight > epochContext.EndOfPoCValidation() {
+				if currentBlockHeight < stage {
+					st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index, currentBlockHeight, windowStart, self)
+				} else {
+					st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index+1, currentBlockHeight, epochContext.NextPoCStart()+2, self)
+				}
+				reporter.Skipf("outside PoC+validation window (h=%d, [%d, %d])",
+					currentBlockHeight, stage, epochContext.EndOfPoCValidation())
+				return nil, nil
+			}
+
+			ta, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+			if !ok {
+				return nil, nil
+			}
+
+			// Read PoCV2StoreCommits to find a (model) slot for this
+			// participant that has a commit but no distribution yet. Random
+			// model selection over the SimModelIDs × N-participants matrix
+			// would almost always miss the sparse subset of slots that have
+			// landed commits.
+			var modelID string
+			var key collections.Triple[int64, sdk.AccAddress, string]
+			picked := false
+			order := testData.Rand().Rand.Perm(len(SimModelIDs))
+			for _, idx := range order {
+				candidate := SimModelIDs[idx]
+				k3 := collections.Join3(stage, ta.Address, candidate)
+				hasCommit, _ := k.PoCV2StoreCommits.Has(ctx, k3)
+				if !hasCommit {
+					continue
+				}
+				if hasDist, _ := k.MLNodeWeightDistributions.Has(ctx, k3); hasDist {
+					continue
+				}
+				modelID, key, picked = candidate, k3, true
+				break
+			}
+			if !picked {
+				reporter.Skipf("no pending (commit AND not-yet-distributed) slot for participant %s at stage=%d",
+					ta.AddressBech32, stage)
+				return nil, nil
+			}
+
+			// Read commit to learn Count (handler validates sum(weights)==commit.Count).
+			commit, err := k.PoCV2StoreCommits.Get(ctx, key)
+			if err != nil {
+				reporter.Skipf("PoCV2StoreCommits.Get failed: %v", err)
+				return nil, nil
+			}
+
+			// Build single-node distribution with full weight == commit.Count.
+			// NodeId pattern matches activeParticipantFromSimParticipant
+			// (bootstrap.go:79) so downstream lookups by NodeId align.
+			msg := &types.MsgMLNodeWeightDistribution{
+				Creator:                  ta.AddressBech32,
+				PocStageStartBlockHeight: stage,
+				Entries: []*types.MLNodeDistributionEntry{
+					{
+						ModelId: modelID,
+						Weights: []*types.MLNodeWeight{
+							{
+								NodeId: ta.AddressBech32 + "/" + modelID,
+								Weight: commit.Count,
+							},
+						},
+					},
+				},
+			}
+			st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index+1, currentBlockHeight, epochContext.NextPoCStart()+2, self)
+			return []simsx.SimAccount{ta}, msg
+		},
+	)
+	return self
+}

--- a/inference-chain/x/inference/simulation/msg_factory.go
+++ b/inference-chain/x/inference/simulation/msg_factory.go
@@ -3,6 +3,8 @@ package simulation
 import (
 	"context"
 	"encoding/base64"
+	"errors"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +14,7 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-// Phase 2 first-wave message factories for x/inference.
+// Message factories for x/inference.
 //
 // Each factory returns a simsx.SimMsgFactoryFn[*types.MsgX] that, when
 // invoked, builds a single randomized but valid message instance plus the
@@ -43,7 +45,8 @@ func MsgSubmitNewParticipantFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*type
 			return nil, nil
 		}
 		msg := &types.MsgSubmitNewParticipant{
-			Creator: from.Address.String(),
+			Creator:      from.Address.String(),
+			ValidatorKey: SimValidatorKey(from.Address.String()),
 		}
 		return []simsx.SimAccount{from}, msg
 	}
@@ -72,23 +75,26 @@ func MsgSubmitNewParticipantFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*type
 // addTimeout. Result: inference lands in keeper.
 func MsgStartInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgStartInference] {
 	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgStartInference) {
-		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
-			reporter.Skipf("active-participants bootstrap failed: %v", err)
-			return nil, nil
-		}
-		if err := EnsureComputeValidators(ctx, k); err != nil {
-			reporter.Skipf("compute-validators refresh failed: %v", err)
-			return nil, nil
-		}
+		// EnsureModelsInEpochGroup runs FIRST so the model sub-groups
+		// exist before any participant-gated factory body touches them.
 		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
 			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureSimActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("sim active-participants seeding failed: %v", err)
 			return nil, nil
 		}
 		ta, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
 		if !ok {
 			return nil, nil
 		}
-		modelID, ok := PickRandomGovernanceModelID(ctx, k, testData, reporter)
+		currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+		if err != nil {
+			reporter.Skipf("EffectiveEpochIndex get failed: %v", err)
+			return nil, nil
+		}
+		modelID, ok := PickRandomSupportedGovernanceModelID(ctx, k, testData, reporter, currentEpoch, ta.AddressBech32)
 		if !ok {
 			return nil, nil
 		}
@@ -156,16 +162,13 @@ func MsgStartInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgS
 // account occupies all four address roles.
 func MsgFinishInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgFinishInference] {
 	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgFinishInference) {
-		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
-			reporter.Skipf("active-participants bootstrap failed: %v", err)
-			return nil, nil
-		}
-		if err := EnsureComputeValidators(ctx, k); err != nil {
-			reporter.Skipf("compute-validators refresh failed: %v", err)
-			return nil, nil
-		}
+		// Order — see MsgStartInferenceFactory comment.
 		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
 			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureSimActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("sim active-participants seeding failed: %v", err)
 			return nil, nil
 		}
 
@@ -205,7 +208,12 @@ func MsgFinishInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.Msg
 		if !ok {
 			return nil, nil
 		}
-		modelID, ok := PickRandomGovernanceModelID(ctx, k, testData, reporter)
+		currentEpoch, err := k.EffectiveEpochIndex.Get(ctx)
+		if err != nil {
+			reporter.Skipf("EffectiveEpochIndex get failed: %v", err)
+			return nil, nil
+		}
+		modelID, ok := PickRandomSupportedGovernanceModelID(ctx, k, testData, reporter, currentEpoch, ta.AddressBech32)
 		if !ok {
 			return nil, nil
 		}
@@ -264,60 +272,122 @@ func MsgFinishInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.Msg
 // «no eligible candidate» rather than failed.
 //
 // ValueDecimal is generated via shopspring/decimal (no float in op gen
-// per plan §145 determinism guards) and is always ABOVE the picked
-// model's ValidationThreshold so the handler takes the «passed» branch
-// (msg_server_validation.go): inference → VALIDATED, no group
-// proposal. The invalidation-voting branch (value ≤ threshold) submits
-// a cosmos `group` proposal requiring the validator to be a registered
-// group member — that membership path is deferred to Phase 3 (it needs
-// the full PoC validator-rotation flow, not a sim-only shortcut).
+// per the determinism guards). Most validations submit a value ABOVE
+// the picked model's ValidationThreshold so the handler takes the
+// «passed» branch (msg_server_validation.go): inference → VALIDATED.
+// A configurable minority (failingValidationOneInN) submit a value
+// ≤ threshold, taking the invalidation-voting branch: inference →
+// VOTING plus two cosmos `group` proposals. SubmitProposal requires the
+// proposer to be a registered group member; BuildEpochSubstrate
+// (substrate.go) seeds that membership via real EpochGroup.AddMember.
+//
+// Delivery is wrapped with the tolerateDuplicateValidation result handler:
+// the random (validator, inference) pick can re-draw a pair that already
+// validated this inference, which the handler rejects with
+// ErrDuplicateValidation. That is a legitimate negative outcome — a
+// participant cannot validate the same inference twice — so it is reported
+// as a successful op instead of aborting the run.
 //
 // Exercises: ValidateBasic; CheckPermission (Active ∨ PreviousActive,
 // permissions.go); GetParticipant lookup; GetInference (found
-// branch); transient validation cache lookup; the passing-validation
-// state transition.
-func MsgValidationFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgValidation] {
-	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgValidation) {
-		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
-			reporter.Skipf("active-participants bootstrap failed: %v", err)
-			return nil, nil
-		}
-		if err := EnsureComputeValidators(ctx, k); err != nil {
-			reporter.Skipf("compute-validators refresh failed: %v", err)
-			return nil, nil
-		}
-		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
-			reporter.Skipf("models epoch-group seeding failed: %v", err)
-			return nil, nil
-		}
-		if err := EnsureMembersInEpochGroup(ctx, k); err != nil {
-			reporter.Skipf("members epoch-group seeding failed: %v", err)
-			return nil, nil
-		}
-		inference, ok := PickRandomFinishedInference(ctx, k, testData, reporter)
-		if !ok {
-			return nil, nil
-		}
-		// Validator is drawn from the inference's OWN epoch (not the current
-		// epoch): the handler keys the transient validation cache by
-		// inference.EpochId, so a current-epoch validator would miss the cache
-		// after an epoch transition and the handler would hard-fail with
-		// ErrParticipantNotFound. Excludes the executor —
-		// msg_server_validation.go hard-rejects self-validation.
-		validator, ok := PickRandomActiveSimAccountExcluding(ctx, k, testData, reporter, inference.EpochId, inference.ExecutedBy)
-		if !ok {
-			return nil, nil
-		}
+// branch); transient validation cache lookup; both the passing- and
+// failing-validation state transitions; the duplicate-validation
+// rejection (ErrDuplicateValidation) as a negative path.
+func MsgValidationFactory(k keeper.Keeper) *simsx.ResultHandlingSimMsgFactory[*types.MsgValidation] {
+	return simsx.NewSimMsgFactoryWithDeliveryResultHandler(
+		func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgValidation, simsx.SimDeliveryResultHandler) {
+			// Order — see MsgStartInferenceFactory comment.
+			if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+				reporter.Skipf("models epoch-group seeding failed: %v", err)
+				return nil, nil, nil
+			}
+			if err := EnsureSimActiveParticipantsSeeded(ctx, k); err != nil {
+				reporter.Skipf("sim active-participants seeding failed: %v", err)
+				return nil, nil, nil
+			}
+			inference, ok := PickRandomFinishedInference(ctx, k, testData, reporter)
+			if !ok {
+				return nil, nil, nil
+			}
+			// Validator is drawn from the inference's OWN epoch (not the current
+			// epoch): the handler keys the transient validation cache by
+			// inference.EpochId, so a current-epoch validator would miss the cache
+			// after an epoch transition and the handler would hard-fail with
+			// ErrParticipantNotFound. Excludes the executor —
+			// msg_server_validation.go hard-rejects self-validation.
+			validator, ok := PickRandomActiveSimAccountExcluding(ctx, k, testData, reporter, inference.EpochId, inference.ExecutedBy)
+			if !ok {
+				return nil, nil, nil
+			}
+			// The handler reads the per-model transient cache by
+			// (inference.EpochId, inference.Model, msg.Creator). A participant
+			// may be in ActiveParticipantsSet but absent from a specific
+			// model's sub-group if they did not commit for that model in the
+			// preceding PoC window — skip rather than triggering the handler's
+			// ErrParticipantNotFound hard-fail (which aborts the sim).
+			if _, hasWeight, _ := k.GetCachedEpochDataModelWeight(ctx, inference.EpochId, inference.Model, validator.AddressBech32); !hasWeight {
+				reporter.Skipf("validator %s lacks model-weight cache entry for (epoch=%d, model=%s)",
+					validator.AddressBech32, inference.EpochId, inference.Model)
+				return nil, nil, nil
+			}
 
-		valueDec := passingValidationValue(ctx, k, testData, inference.Model)
+			// A configurable minority of validations submit a failing value
+			// (≤ threshold), driving the handler's invalidation-voting branch:
+			// inference → VOTING + two x/group proposals. The rest pass.
+			var valueDec decimal.Decimal
+			if testData.Rand().IntInRange(0, failingValidationOneInN) == 0 {
+				valueDec = failingValidationValue(ctx, k, testData, inference.Model)
+			} else {
+				valueDec = passingValidationValue(ctx, k, testData, inference.Model)
+			}
 
-		msg := &types.MsgValidation{
-			Creator:      validator.AddressBech32,
-			InferenceId:  inference.InferenceId,
-			ValueDecimal: types.DecimalFromDecimal(valueDec),
-		}
-		return []simsx.SimAccount{validator}, msg
+			msg := &types.MsgValidation{
+				Creator:      validator.AddressBech32,
+				InferenceId:  inference.InferenceId,
+				ValueDecimal: types.DecimalFromDecimal(valueDec),
+			}
+			return []simsx.SimAccount{validator}, msg, tolerateDuplicateOrDroppedProposer
+		},
+	)
+}
+
+// tolerateDuplicateOrDroppedProposer is the delivery result handler for
+// MsgValidationFactory. It tolerates two known-benign delivery failures:
+//
+//  1. ErrDuplicateValidation — the factory draws a random
+//     (validator, inference) pair each invocation; over a long run it
+//     eventually re-draws a pair that already validated that inference,
+//     which the handler rejects (addInferenceToEpochGroupValidations,
+//     msg_server_validation.go). A participant validating the same
+//     inference twice is a legitimate negative outcome the chain is meant
+//     to reject.
+//
+//  2. x/group "not in group: %s: unauthorized" — the failing-validation
+//     path calls submitValidationProposalsWithPolicy
+//     (msg_server_validation.go:280), which sets the revalidation
+//     proposal's proposer to inference.ExecutedBy. If the executor was
+//     dropped from the active set at the preceding epoch transition
+//     (PoC re-election or slashing), x/group.SubmitProposal
+//     (cosmos-sdk x/group/keeper/msg_server.go:581) rejects with
+//     ErrUnauthorized. In production this is harmless: the tx is rejected,
+//     other validators may still try, and module.go:240
+//     expireInferenceAndIssueRefund eventually times the inference out and
+//     refunds the client. simsx treats any DeliverTx failure as a hard
+//     halt; we tolerate this specific case to mirror production liveness.
+//
+// Any other delivery error is a real failure and is propagated to abort
+// the run.
+func tolerateDuplicateOrDroppedProposer(err error) error {
+	if err == nil {
+		return nil
 	}
+	if errors.Is(err, types.ErrDuplicateValidation) {
+		return nil
+	}
+	if strings.Contains(err.Error(), "not in group:") {
+		return nil
+	}
+	return err
 }
 
 // MsgClaimRewardsFactory creates a factory for MsgClaimRewards.
@@ -338,12 +408,8 @@ func MsgValidationFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgValid
 // path.
 func MsgClaimRewardsFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgClaimRewards] {
 	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgClaimRewards) {
-		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
-			reporter.Skipf("bootstrap failed: %v", err)
-			return nil, nil
-		}
-		if err := EnsureComputeValidators(ctx, k); err != nil {
-			reporter.Skipf("compute-validators refresh failed: %v", err)
+		if err := EnsureSimActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("sim active-participants seeding failed: %v", err)
 			return nil, nil
 		}
 		claimant, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
@@ -393,4 +459,169 @@ func passingValidationValue(
 	}
 	numerator := testData.Rand().IntInRange(minPct, maxPct+1)
 	return decimal.NewFromInt(int64(numerator)).Div(decimal.NewFromInt(100))
+}
+
+// failingValidationOneInN is the reciprocal of the fraction of MsgValidation
+// ops that submit a failing value. 4 ⇒ ~25% fail (a minority), enough to
+// exercise the invalidation-voting branch + revalidation flow without
+// starving the passing path.
+const failingValidationOneInN = 4
+
+// failingValidationValue returns a ValueDecimal at or below the given
+// model's ValidationThreshold, so MsgValidation routes through the
+// invalidation-voting branch (msg_server_validation.go): the handler sets
+// the inference to VOTING and submits the two cosmos `group` proposals.
+// Integer-percent arithmetic over shopspring/decimal — no float,
+// deterministic. The handler compares with GreaterThan, so a value equal
+// to the threshold still fails.
+//
+// Falls back to 0 when the model or its threshold can't be resolved
+// (0 is at or below every realistic threshold).
+func failingValidationValue(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	modelID string,
+) decimal.Decimal {
+	maxPct := 0
+	if model, found := k.GetGovernanceModel(ctx, modelID); found && model.ValidationThreshold != nil {
+		// largest integer percent still ≤ the threshold
+		maxPct = int(model.ValidationThreshold.ToDecimal().
+			Mul(decimal.NewFromInt(100)).Floor().IntPart())
+	}
+	if maxPct < 0 {
+		maxPct = 0
+	}
+	numerator := testData.Rand().IntInRange(0, maxPct+1)
+	return decimal.NewFromInt(int64(numerator)).Div(decimal.NewFromInt(100))
+}
+
+// MsgRevalidationVoteFactory creates a factory for revalidation-vote
+// MsgValidation messages (Revalidation:true) — the x/group vote path that
+// drives second-wave invalidation/revalidation.
+//
+// A failing MsgValidation (failingValidationValue) sends an inference to VOTING
+// and submits two x/group proposals — Invalidate and ReValidate — behind the
+// model's epoch group policy. This factory casts validator votes on them:
+// MsgValidation{Revalidation:true} routes to revalidateInferenceVote
+// (msg_server_validation.go), which calls group.Vote with Exec_EXEC_TRY on
+// both. Once YES weight crosses the group's 50% PercentageDecisionPolicy the
+// group module executes the winning proposal internally, dispatching
+// MsgInvalidateInference or MsgRevalidateInference with Creator = policy
+// address.
+//
+// There is no standalone MsgInvalidateInference factory: that message's
+// Creator must be the group policy address, but DeliverSimsMsg stamps the
+// sender's account sequence and the ante SigVerificationDecorator checks it
+// against the policy address's sequence -> ErrWrongSequence (chunk P3-1).
+// Every tx this factory delivers is a plain MsgValidation (sender == Creator
+// == validator); the inner decision messages are dispatched by the group
+// module and never reach the ante handler.
+//
+// Block-time constraint: the sim advances 5000-10000 s per block while the
+// validation group's voting window is 4 minutes, so a proposal is votable
+// only in the block it was created. The factory votes only on inferences with
+// a live proposal window (PickRandomVotingInferenceWithOpenProposal) and fixes
+// the vote direction per inference (revalidationVoteIsPass) so every validator
+// that votes on a given inference agrees and the YES weight concentrates on
+// one proposal. A vote that still lands on a non-votable proposal — the window
+// closed, a same-block vote already executed it, or this validator already
+// voted — returns a benign x/group error that tolerateGroupVoteOutcome
+// classifies as an expected negative outcome rather than a sim failure.
+func MsgRevalidationVoteFactory(
+	k keeper.Keeper,
+	groupKeeper types.GroupMessageKeeper,
+) *simsx.ResultHandlingSimMsgFactory[*types.MsgValidation] {
+	return simsx.NewSimMsgFactoryWithDeliveryResultHandler(
+		func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgValidation, simsx.SimDeliveryResultHandler) {
+			// Order — see MsgStartInferenceFactory comment.
+			if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+				reporter.Skipf("models epoch-group seeding failed: %v", err)
+				return nil, nil, nil
+			}
+			if err := EnsureSimActiveParticipantsSeeded(ctx, k); err != nil {
+				reporter.Skipf("sim active-participants seeding failed: %v", err)
+				return nil, nil, nil
+			}
+
+			inference, ok := PickRandomVotingInferenceWithOpenProposal(ctx, k, groupKeeper)
+			if !ok {
+				reporter.Skip("no VOTING inference with an open proposal window")
+				return nil, nil, nil
+			}
+			// Any active participant in the inference's epoch is an x/group
+			// member (seeded by BuildEpochSubstrate) and is present in the
+			// transient validation cache the handler reads. Revalidation is
+			// exempt from the self-validation check (msg_server_validation.go),
+			// so the executor may vote too — nothing is excluded.
+			voter, ok := PickRandomActiveSimAccountExcluding(ctx, k, testData, reporter, inference.EpochId, "")
+			if !ok {
+				return nil, nil, nil
+			}
+			// Same model-weight cache requirement as the primary
+			// MsgValidationFactory — see comment there.
+			if _, hasWeight, _ := k.GetCachedEpochDataModelWeight(ctx, inference.EpochId, inference.Model, voter.AddressBech32); !hasWeight {
+				reporter.Skipf("voter %s lacks model-weight cache entry for (epoch=%d, model=%s)",
+					voter.AddressBech32, inference.EpochId, inference.Model)
+				return nil, nil, nil
+			}
+
+			// Fixed per-inference direction: revalidateInferenceVote derives
+			// YES-on-Invalidate vs YES-on-ReValidate from `passed` (value >
+			// model threshold), and ValueDecimal selects it.
+			var valueDec decimal.Decimal
+			if revalidationVoteIsPass(inference.InferenceId) {
+				valueDec = passingValidationValue(ctx, k, testData, inference.Model)
+			} else {
+				valueDec = failingValidationValue(ctx, k, testData, inference.Model)
+			}
+
+			msg := &types.MsgValidation{
+				Creator:      voter.AddressBech32,
+				InferenceId:  inference.InferenceId,
+				Revalidation: true,
+				ValueDecimal: types.DecimalFromDecimal(valueDec),
+			}
+			return []simsx.SimAccount{voter}, msg, tolerateGroupVoteOutcome
+		},
+	)
+}
+
+// revalidationVoteIsPass fixes the vote direction for an inference: true =>
+// vote to revalidate (the inference stays valid), false => vote to invalidate.
+// Derived purely from the inference id so every validator voting on the same
+// inference agrees without any shared state; ~1 in 3 pass, the rest
+// invalidate — the skew keeps MsgInvalidateInference the reliably-exercised
+// path for the smoke assertion.
+func revalidationVoteIsPass(inferenceID string) bool {
+	var sum uint32
+	for i := 0; i < len(inferenceID); i++ {
+		sum += uint32(inferenceID[i])
+	}
+	return sum%3 == 0
+}
+
+// tolerateGroupVoteOutcome is the delivery result handler for revalidation
+// votes. Concurrent revalidation in a chain whose sim block time outpaces the
+// 4-minute voting window legitimately produces non-fatal x/group errors: the
+// window closed (ErrExpired "voting period has ended already"), a same-block
+// vote already decided or executed the proposal ("proposal not open for
+// voting"), or this validator already voted ("store vote"). Those are expected
+// negative-path outcomes, reported as a successful op. Any other delivery
+// error is a real failure and is propagated to abort the run.
+func tolerateGroupVoteOutcome(err error) error {
+	if err == nil {
+		return nil
+	}
+	errMsg := err.Error()
+	for _, benign := range []string{
+		"voting period has ended already",
+		"proposal not open for voting",
+		"store vote",
+	} {
+		if strings.Contains(errMsg, benign) {
+			return nil
+		}
+	}
+	return err
 }

--- a/inference-chain/x/inference/simulation/msg_factory.go
+++ b/inference-chain/x/inference/simulation/msg_factory.go
@@ -1,0 +1,396 @@
+package simulation
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/shopspring/decimal"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// Phase 2 first-wave message factories for x/inference.
+//
+// Each factory returns a simsx.SimMsgFactoryFn[*types.MsgX] that, when
+// invoked, builds a single randomized but valid message instance plus the
+// signing accounts. The simsx runner handles tx assembly, signing, and
+// delivery — factories only produce the message.
+//
+// Each factory first runs the sim-only Ensure* bootstrap helpers
+// (bootstrap.go) so the message's on-chain preconditions hold, then
+// generates a message that clears ValidateBasic, the permission gate and
+// signature verification — so the tx reaches real keeper state mutation
+// instead of being rejected.
+
+// MsgSubmitNewParticipantFactory creates a factory for MsgSubmitNewParticipant.
+//
+// MsgSubmitNewParticipant has all-optional fields except Creator
+// (ValidateBasic: types/message_submit_new_participant.go). Minimal valid
+// msg = Creator only. Handler (keeper/msg_server_submit_new_participant.go)
+// is idempotent: if a participant with this address already exists, the msg
+// becomes a no-op update (all optional fields empty). On a fresh address a
+// new participant is created. Either path exercises the registration
+// permission check (OpenRegistrationPermission); if registration is closed
+// at this block height the tx will fail with ErrNewParticipantRegistrationClosed
+// — that is a legitimate simulation outcome, not a factory bug.
+func MsgSubmitNewParticipantFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgSubmitNewParticipant] {
+	return func(_ context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgSubmitNewParticipant) {
+		from := testData.AnyAccount(reporter)
+		if reporter.IsSkipped() {
+			return nil, nil
+		}
+		msg := &types.MsgSubmitNewParticipant{
+			Creator: from.Address.String(),
+		}
+		return []simsx.SimAccount{from}, msg
+	}
+}
+
+// MsgStartInferenceFactory creates a factory for MsgStartInference.
+//
+// Real-ECDSA path. Produces a ValidateBasic-passing msg with a
+// real ActiveParticipant as Creator (= RequestedBy = AssignedTo — same
+// sim account occupies all three roles, so the dev pubkey lookup matches
+// the TA). msg.InferenceId is a real secp256k1 dev signature of
+// (OriginalPromptHash || RequestTimestamp || Creator) produced by
+// SignDevStart, so the handler's verifyStartFirstMessageKeys
+// (msg_server_start_inference.go) passes its dev-signature check and
+// the inference is actually persisted via SetInference (line 133),
+// unblocking paired Finish/Validation state flow.
+//
+// TransferSignature is still a random 64-byte base64 payload — it is
+// not verified on the start-first path (deferred to FinishInference,
+// see msg_server_start_inference.go policy comment).
+//
+// Exercises: ValidateBasic, CheckPermission(ActiveParticipantPermission),
+// developer/transfer-agent access gating, GetParticipant lookup,
+// timestamp window, dev signature verification (PASS), participant
+// access gating, ProcessStartInference, RecordInferencePrice, SetInference,
+// addTimeout. Result: inference lands in keeper.
+func MsgStartInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgStartInference] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgStartInference) {
+		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("active-participants bootstrap failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureComputeValidators(ctx, k); err != nil {
+			reporter.Skipf("compute-validators refresh failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		ta, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		modelID, ok := PickRandomGovernanceModelID(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		timestamp := sdkCtx.BlockTime().UnixNano()
+
+		transferSigBytes := make([]byte, 64)
+		testData.Rand().Read(transferSigBytes)
+		promptHashBytes := make([]byte, 32)
+		testData.Rand().Read(promptHashBytes)
+		originalPromptHashBytes := make([]byte, 32)
+		testData.Rand().Read(originalPromptHashBytes)
+
+		msg := &types.MsgStartInference{
+			Creator:            ta.AddressBech32,
+			RequestedBy:        ta.AddressBech32,
+			AssignedTo:         ta.AddressBech32,
+			TransferSignature:  base64.StdEncoding.EncodeToString(transferSigBytes),
+			PromptHash:         base64.StdEncoding.EncodeToString(promptHashBytes),
+			OriginalPromptHash: base64.StdEncoding.EncodeToString(originalPromptHashBytes),
+			Model:              modelID,
+			PromptPayload:      "sim-prompt-payload",
+			RequestTimestamp:   timestamp,
+			MaxTokens:          uint64(testData.Rand().IntInRange(1, 1024)),
+			PromptTokenCount:   uint64(testData.Rand().IntInRange(1, 512)),
+		}
+		devSig, err := SignDevStart(ta, msg)
+		if err != nil {
+			reporter.Skipf("SignDevStart failed: %v", err)
+			return nil, nil
+		}
+		msg.InferenceId = devSig
+		return []simsx.SimAccount{ta}, msg
+	}
+}
+
+// MsgFinishInferenceFactory creates a factory for MsgFinishInference.
+//
+// Two paths, chosen by keeper state:
+//
+//  1. start-first pairing: when a STARTED-status inference
+//     exists whose AssignedTo is a known sim account, the factory
+//     finishes THAT inference — copying its InferenceId and dev/TA
+//     components so the handler's StartProcessed() branch
+//     (msg_server_finish_inference.go) takes the compare-only path
+//     (compareDevComponents / compareFinishTAComponents /
+//     compareFinishModelField) and transitions the inference
+//     STARTED → FINISHED. This is what produces FINISHED inferences
+//     for MsgValidation to act on. Signatures are NOT re-verified on
+//     this path, so InferenceId is reused verbatim and Transfer/Executor
+//     signatures are random-but-shape-valid.
+//
+//  2. fresh finish-first: when no STARTED inference qualifies,
+//     the factory builds a brand-new finish-first message with real
+//     secp256k1 dev (SignDevFinish) + TA (SignTAFinish) signatures so
+//     the handler's verifyFinishKeys path (line 102) passes its
+//     cryptographic check.
+//
+// ExecutorSignature is always random 64-byte base64 — executor signature
+// verification is disabled by policy on both paths
+// (msg_server_finish_inference.go).
+//
+// Creator == ExecutedBy is a hard invariant (line 28-32); the same sim
+// account occupies all four address roles.
+func MsgFinishInferenceFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgFinishInference] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgFinishInference) {
+		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("active-participants bootstrap failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureComputeValidators(ctx, k); err != nil {
+			reporter.Skipf("compute-validators refresh failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+
+		// Path 1: pair with an existing STARTED inference.
+		if started, ok := FindRandomStartedInference(ctx, k, testData); ok {
+			executor := testData.GetAccount(reporter, started.AssignedTo)
+			if reporter.IsSkipped() {
+				return nil, nil
+			}
+			executorSigBytes := make([]byte, 64)
+			testData.Rand().Read(executorSigBytes)
+			transferSigBytes := make([]byte, 64)
+			testData.Rand().Read(transferSigBytes)
+			responseHashBytes := make([]byte, 32)
+			testData.Rand().Read(responseHashBytes)
+			msg := &types.MsgFinishInference{
+				Creator:              started.AssignedTo,
+				ExecutedBy:           started.AssignedTo,
+				TransferredBy:        started.TransferredBy,
+				RequestedBy:          started.RequestedBy,
+				InferenceId:          started.InferenceId,
+				TransferSignature:    base64.StdEncoding.EncodeToString(transferSigBytes),
+				ExecutorSignature:    base64.StdEncoding.EncodeToString(executorSigBytes),
+				ResponseHash:         base64.StdEncoding.EncodeToString(responseHashBytes),
+				PromptHash:           started.PromptHash,
+				OriginalPromptHash:   started.OriginalPromptHash,
+				Model:                started.Model,
+				RequestTimestamp:     started.RequestTimestamp,
+				PromptTokenCount:     uint64(testData.Rand().IntInRange(1, 512)),
+				CompletionTokenCount: uint64(testData.Rand().IntInRange(1, 512)),
+			}
+			return []simsx.SimAccount{executor}, msg
+		}
+
+		// Path 2: fresh finish-first.
+		ta, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		modelID, ok := PickRandomGovernanceModelID(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		timestamp := sdkCtx.BlockTime().UnixNano()
+
+		executorSigBytes := make([]byte, 64)
+		testData.Rand().Read(executorSigBytes)
+		responseHashBytes := make([]byte, 32)
+		testData.Rand().Read(responseHashBytes)
+		promptHashBytes := make([]byte, 32)
+		testData.Rand().Read(promptHashBytes)
+		originalPromptHashBytes := make([]byte, 32)
+		testData.Rand().Read(originalPromptHashBytes)
+
+		msg := &types.MsgFinishInference{
+			Creator:              ta.AddressBech32,
+			ExecutedBy:           ta.AddressBech32,
+			TransferredBy:        ta.AddressBech32,
+			RequestedBy:          ta.AddressBech32,
+			ExecutorSignature:    base64.StdEncoding.EncodeToString(executorSigBytes),
+			ResponseHash:         base64.StdEncoding.EncodeToString(responseHashBytes),
+			PromptHash:           base64.StdEncoding.EncodeToString(promptHashBytes),
+			OriginalPromptHash:   base64.StdEncoding.EncodeToString(originalPromptHashBytes),
+			Model:                modelID,
+			RequestTimestamp:     timestamp,
+			PromptTokenCount:     uint64(testData.Rand().IntInRange(1, 512)),
+			CompletionTokenCount: uint64(testData.Rand().IntInRange(1, 512)),
+		}
+		devSig, err := SignDevFinish(ta, msg)
+		if err != nil {
+			reporter.Skipf("SignDevFinish failed: %v", err)
+			return nil, nil
+		}
+		msg.InferenceId = devSig
+		taSig, err := SignTAFinish(ta, msg)
+		if err != nil {
+			reporter.Skipf("SignTAFinish failed: %v", err)
+			return nil, nil
+		}
+		msg.TransferSignature = taSig
+		return []simsx.SimAccount{ta}, msg
+	}
+}
+
+// MsgValidationFactory creates a factory for MsgValidation.
+//
+// Paired-state rebind. The handler's GetInference branch
+// (msg_server_validation.go) returns ErrInferenceNotFound as a
+// HARD error; simsx treats hard-error tx as a fatal simulation failure
+// and aborts the run. To stay clear of that
+// path, this factory picks a random InferenceId from the Inferences
+// collection if any exist; if empty (early sim blocks, before Start has
+// landed any inference) it Skips the reporter so simsx counts the op as
+// «no eligible candidate» rather than failed.
+//
+// ValueDecimal is generated via shopspring/decimal (no float in op gen
+// per plan §145 determinism guards) and is always ABOVE the picked
+// model's ValidationThreshold so the handler takes the «passed» branch
+// (msg_server_validation.go): inference → VALIDATED, no group
+// proposal. The invalidation-voting branch (value ≤ threshold) submits
+// a cosmos `group` proposal requiring the validator to be a registered
+// group member — that membership path is deferred to Phase 3 (it needs
+// the full PoC validator-rotation flow, not a sim-only shortcut).
+//
+// Exercises: ValidateBasic; CheckPermission (Active ∨ PreviousActive,
+// permissions.go); GetParticipant lookup; GetInference (found
+// branch); transient validation cache lookup; the passing-validation
+// state transition.
+func MsgValidationFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgValidation] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgValidation) {
+		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("active-participants bootstrap failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureComputeValidators(ctx, k); err != nil {
+			reporter.Skipf("compute-validators refresh failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureMembersInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("members epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		inference, ok := PickRandomFinishedInference(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		// Validator is drawn from the inference's OWN epoch (not the current
+		// epoch): the handler keys the transient validation cache by
+		// inference.EpochId, so a current-epoch validator would miss the cache
+		// after an epoch transition and the handler would hard-fail with
+		// ErrParticipantNotFound. Excludes the executor —
+		// msg_server_validation.go hard-rejects self-validation.
+		validator, ok := PickRandomActiveSimAccountExcluding(ctx, k, testData, reporter, inference.EpochId, inference.ExecutedBy)
+		if !ok {
+			return nil, nil
+		}
+
+		valueDec := passingValidationValue(ctx, k, testData, inference.Model)
+
+		msg := &types.MsgValidation{
+			Creator:      validator.AddressBech32,
+			InferenceId:  inference.InferenceId,
+			ValueDecimal: types.DecimalFromDecimal(valueDec),
+		}
+		return []simsx.SimAccount{validator}, msg
+	}
+}
+
+// MsgClaimRewardsFactory creates a factory for MsgClaimRewards.
+//
+// Produces a ValidateBasic-passing msg with EpochIndex=1 (must be > 0
+// per message_claim_rewards.go) and a random Seed. At sim genesis
+// EffectiveEpochIndex=0, so handler's validateRequest hits the
+// currentEpoch==0 branch (msg_server_claim_rewards.go) and
+// returns a graceful response{Result: "..."} with nil error. Op
+// delivered, gas consumed, no state mutation.
+//
+// Real reward claiming requires SettleAmount records, which are
+// produced by upstream PoC/epoch flows or by completed inference
+// settlement — both outside this first-wave scope.
+//
+// Exercises: ValidateBasic; CheckPermission (Active ∨ PreviousActive,
+// permissions.go); validateRequest's currentEpoch==0 early-return
+// path.
+func MsgClaimRewardsFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgClaimRewards] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgClaimRewards) {
+		if err := EnsureActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("bootstrap failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureComputeValidators(ctx, k); err != nil {
+			reporter.Skipf("compute-validators refresh failed: %v", err)
+			return nil, nil
+		}
+		claimant, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+
+		msg := &types.MsgClaimRewards{
+			Creator:    claimant.AddressBech32,
+			Seed:       testData.Rand().Int63(),
+			EpochIndex: 1,
+		}
+		return []simsx.SimAccount{claimant}, msg
+	}
+}
+
+// passingValidationValue returns a ValueDecimal strictly above the given
+// model's ValidationThreshold, so MsgValidation routes through the
+// «passed» branch (msg_server_validation.go). Uses integer-percent
+// arithmetic over shopspring/decimal — no float, deterministic.
+//
+// Falls back to a fixed 0.99 when the model or its threshold can't be
+// resolved (the handler would then evaluate against whatever threshold
+// it loads; 0.99 clears every realistic mainnet threshold ≤ 0.98).
+func passingValidationValue(
+	ctx context.Context,
+	k keeper.Keeper,
+	testData *simsx.ChainDataSource,
+	modelID string,
+) decimal.Decimal {
+	const maxPct = 100
+	minPct := 99
+	if model, found := k.GetGovernanceModel(ctx, modelID); found && model.ValidationThreshold != nil {
+		// threshold is in [0,1]; smallest integer percentage strictly
+		// above it = floor(threshold*100) + 1.
+		thresholdPct := model.ValidationThreshold.ToDecimal().
+			Mul(decimal.NewFromInt(100)).Floor().IntPart()
+		// Assigned unconditionally — int(thresholdPct)+1 IS the smallest
+		// integer percent strictly above the threshold. The old «p < minPct»
+		// guard left minPct at the 99 default for thresholds ≥ 0.99, letting
+		// IntInRange emit a value EQUAL to (not above) the threshold. The
+		// minPct>maxPct clamp below covers the degenerate threshold = 1.0 case.
+		minPct = int(thresholdPct) + 1
+	}
+	if minPct > maxPct {
+		minPct = maxPct
+	}
+	numerator := testData.Rand().IntInRange(minPct, maxPct+1)
+	return decimal.NewFromInt(int64(numerator)).Div(decimal.NewFromInt(100))
+}

--- a/inference-chain/x/inference/simulation/msg_factory_test.go
+++ b/inference-chain/x/inference/simulation/msg_factory_test.go
@@ -178,12 +178,16 @@ func TestMsgValidationFactory_PicksExistingInference(t *testing.T) {
 	const seededID = "sim-inference-001"
 	executor := regAddrs[0]
 	putFinishedInference(t, kk, sdkCtx, seededID, executor)
+	// MsgValidationFactory consults the per-model transient weight cache
+	// (GetCachedEpochDataModelWeight) before drawing a validator; seed it
+	// for the active participants so a real validator is eligible.
+	seedModelWeightCacheForTest(t, sdkCtx, kk, regAddrs, 0)
 	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(42)),
 		nil, nil, gonkaBech32Codec(), accs...)
 	reporter := simsx.NewBasicSimulationReporter()
 
 	signers, msg := simulation.MsgValidationFactory(kk).SimMsgFactoryFn(sdkCtx, cds, reporter)
-	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly: %s", reporter.Comment())
 	require.NotNil(t, msg)
 	require.Len(t, signers, 1)
 	require.NoError(t, msg.ValidateBasic())

--- a/inference-chain/x/inference/simulation/msg_factory_test.go
+++ b/inference-chain/x/inference/simulation/msg_factory_test.go
@@ -1,0 +1,235 @@
+package simulation_test
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	"github.com/productscience/inference/x/inference/calculations"
+	"github.com/productscience/inference/x/inference/simulation"
+)
+
+func decimalOne() decimal.Decimal { return decimal.NewFromInt(1) }
+
+// Each factory test exercises the message-building closure end-to-end:
+// keeper seeded with N Participants → bootstrap + pick run inside the
+// factory → ValidateBasic must pass on the produced msg → signer in
+// returned []SimAccount must match msg.Creator. This is the unit-level
+// contract for these factories. Full simsx hit-rate behavior is covered
+// separately by the verification-gate smoke test.
+
+const factoryAccountCount = 5
+
+func TestMsgSubmitNewParticipantFactory_BuildsValidMsg(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 11, factoryAccountCount)
+	// SubmitNewParticipant does not require ActiveParticipantsSet — minimal
+	// setup. We still register accounts so they exist as sim accounts.
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(12)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgSubmitNewParticipantFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+}
+
+func TestMsgStartInferenceFactory_BuildsValidMsg(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 21, factoryAccountCount)
+	registerAsParticipants(t, kk, sdkCtx, accs)
+	registerSimGenesisModels(t, kk, sdkCtx)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(22)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgStartInferenceFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	// Same account in all three roles.
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+	require.Equal(t, msg.Creator, msg.RequestedBy)
+	require.Equal(t, msg.Creator, msg.AssignedTo)
+	// Bootstrap side effect — ActiveParticipantsSet[0] is now non-empty.
+	require.NotEmpty(t, collectActiveAddrs(t, sdkCtx, kk, 0))
+	// Picked Model is one of the genesis-registered sim models.
+	require.Contains(t, simulation.SimModelIDs, msg.Model)
+	// Real dev signature in msg.InferenceId. Verify against
+	// signer pubkey so the handler's verifyStartFirstMessageKeys would
+	// pass.
+	devComponents := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.Creator,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(devComponents, calculations.Developer,
+			pubKeyB64(t, signers[0].Account), msg.InferenceId))
+}
+
+// TestMsgFinishInferenceFactory_FinishFirst_BuildsValidMsg — with no
+// STARTED inference in keeper, the factory takes path 2 (fresh
+// finish-first) and produces a msg with real dev + TA signatures.
+func TestMsgFinishInferenceFactory_FinishFirst_BuildsValidMsg(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 31, factoryAccountCount)
+	registerAsParticipants(t, kk, sdkCtx, accs)
+	registerSimGenesisModels(t, kk, sdkCtx)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(32)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgFinishInferenceFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	// Creator == ExecutedBy (hard at msg_server_finish_inference.go)
+	// and same account occupies all four roles.
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+	require.Equal(t, msg.Creator, msg.ExecutedBy)
+	require.Equal(t, msg.Creator, msg.TransferredBy)
+	require.Equal(t, msg.Creator, msg.RequestedBy)
+	// Picked Model is one of the genesis-registered sim models.
+	require.Contains(t, simulation.SimModelIDs, msg.Model)
+	// Real dev signature in msg.InferenceId.
+	devComponents := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(devComponents, calculations.Developer,
+			pubKeyB64(t, signers[0].Account), msg.InferenceId))
+	// Real TA signature in msg.TransferSignature.
+	taComponents := calculations.SignatureComponents{
+		Payload:         msg.PromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+		ExecutorAddress: msg.ExecutedBy,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(taComponents, calculations.TransferAgent,
+			pubKeyB64(t, signers[0].Account), msg.TransferSignature))
+}
+
+// TestMsgFinishInferenceFactory_PairsStartedInference — with a
+// STARTED inference present whose AssignedTo is a sim account, the
+// factory takes path 1 and finishes THAT inference, copying its
+// InferenceId and the dev/TA components the start-first compare path
+// checks (compareDevComponents / compareFinishTAComponents).
+func TestMsgFinishInferenceFactory_PairsStartedInference(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 33, factoryAccountCount)
+	regAddrs := registerAsParticipants(t, kk, sdkCtx, accs)
+	registerSimGenesisModels(t, kk, sdkCtx)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	// InferenceId must be base64 of 64 bytes (utils.ValidateBase64RSig64,
+	// enforced by MsgFinishInference.ValidateBasic). Real Start inferences
+	// carry a 64-byte dev signature here; the test uses a fixed-byte
+	// stand-in.
+	startedID := base64.StdEncoding.EncodeToString(make([]byte, 64))
+	assignedTo := regAddrs[2]
+	putStartedInference(t, kk, sdkCtx, startedID, assignedTo, simulation.SimModelIDs[0])
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(34)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgFinishInferenceFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	// Finishes the seeded STARTED inference verbatim.
+	require.Equal(t, startedID, msg.InferenceId)
+	require.Equal(t, assignedTo, msg.Creator)
+	require.Equal(t, assignedTo, msg.ExecutedBy)
+	require.Equal(t, assignedTo, signers[0].AddressBech32)
+	// dev/TA components copied from the inference (compare-path inputs).
+	require.Equal(t, "sim-prompt-hash", msg.PromptHash)
+	require.Equal(t, "sim-original-prompt-hash", msg.OriginalPromptHash)
+	require.Equal(t, simulation.SimModelIDs[0], msg.Model)
+	require.Equal(t, int64(1_000_000), msg.RequestTimestamp)
+}
+
+// TestMsgValidationFactory_PicksExistingInference — with a pre-seeded
+// Inference in keeper whose ExecutedBy is one of the active sim
+// participants, the factory picks a DIFFERENT active sim participant as
+// validator (validator!=executor constraint) and produces a
+// ValidateBasic-passing msg referencing the seeded InferenceId.
+func TestMsgValidationFactory_PicksExistingInference(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 41, factoryAccountCount)
+	regAddrs := registerAsParticipants(t, kk, sdkCtx, accs)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(sdkCtx, kk))
+	const seededID = "sim-inference-001"
+	executor := regAddrs[0]
+	putFinishedInference(t, kk, sdkCtx, seededID, executor)
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(42)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgValidationFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+	require.Equal(t, seededID, msg.InferenceId)
+	require.NotEqual(t, executor, msg.Creator,
+		"validator must not equal executor (msg_server_validation.go)")
+	require.NotNil(t, msg.ValueDecimal)
+	v := msg.ValueDecimal.ToDecimal()
+	require.False(t, v.IsNegative())
+	require.True(t, v.LessThanOrEqual(decimalOne()))
+}
+
+// TestMsgValidationFactory_EmptyFinishedInferences_Skips — no FINISHED
+// inferences in keeper ⇒ reporter Skipped, no msg produced. Even if
+// STARTED inferences exist they're filtered out (factory uses
+// PickRandomFinishedInference so MsgValidation handler's
+// ErrInferenceNotFinished path at line 77-79 is never reached).
+func TestMsgValidationFactory_EmptyFinishedInferences_Skips(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 43, factoryAccountCount)
+	registerAsParticipants(t, kk, sdkCtx, accs)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(44)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	_, msg := simulation.MsgValidationFactory(kk)(sdkCtx, cds, reporter)
+	require.Nil(t, msg)
+	require.True(t, reporter.IsSkipped(), "expected Skip on empty Inferences")
+}
+
+func TestMsgClaimRewardsFactory_BuildsValidMsg(t *testing.T) {
+	kk, sdkCtx := keepertest.InferenceKeeper(t)
+	accs := newSimAccounts(t, 51, factoryAccountCount)
+	registerAsParticipants(t, kk, sdkCtx, accs)
+	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
+	cds := simsx.NewChainDataSource(sdkCtx, rand.New(rand.NewSource(52)),
+		nil, nil, gonkaBech32Codec(), accs...)
+	reporter := simsx.NewBasicSimulationReporter()
+
+	signers, msg := simulation.MsgClaimRewardsFactory(kk)(sdkCtx, cds, reporter)
+	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
+	require.NotNil(t, msg)
+	require.Len(t, signers, 1)
+	require.NoError(t, msg.ValidateBasic())
+	require.Equal(t, signers[0].AddressBech32, msg.Creator)
+	require.Greater(t, msg.EpochIndex, uint64(0)) // ValidateBasic requirement
+}

--- a/inference-chain/x/inference/simulation/msg_factory_test.go
+++ b/inference-chain/x/inference/simulation/msg_factory_test.go
@@ -174,7 +174,7 @@ func TestMsgValidationFactory_PicksExistingInference(t *testing.T) {
 	accs := newSimAccounts(t, 41, factoryAccountCount)
 	regAddrs := registerAsParticipants(t, kk, sdkCtx, accs)
 	require.NoError(t, kk.SetEffectiveEpochIndex(sdkCtx, 0))
-	require.NoError(t, simulation.EnsureActiveParticipantsSeeded(sdkCtx, kk))
+	seedActiveParticipantsForTest(t, sdkCtx, kk, accs, 0)
 	const seededID = "sim-inference-001"
 	executor := regAddrs[0]
 	putFinishedInference(t, kk, sdkCtx, seededID, executor)
@@ -182,7 +182,7 @@ func TestMsgValidationFactory_PicksExistingInference(t *testing.T) {
 		nil, nil, gonkaBech32Codec(), accs...)
 	reporter := simsx.NewBasicSimulationReporter()
 
-	signers, msg := simulation.MsgValidationFactory(kk)(sdkCtx, cds, reporter)
+	signers, msg := simulation.MsgValidationFactory(kk).SimMsgFactoryFn(sdkCtx, cds, reporter)
 	require.False(t, reporter.IsSkipped(), "factory skipped unexpectedly")
 	require.NotNil(t, msg)
 	require.Len(t, signers, 1)
@@ -211,7 +211,7 @@ func TestMsgValidationFactory_EmptyFinishedInferences_Skips(t *testing.T) {
 		nil, nil, gonkaBech32Codec(), accs...)
 	reporter := simsx.NewBasicSimulationReporter()
 
-	_, msg := simulation.MsgValidationFactory(kk)(sdkCtx, cds, reporter)
+	_, msg := simulation.MsgValidationFactory(kk).SimMsgFactoryFn(sdkCtx, cds, reporter)
 	require.Nil(t, msg)
 	require.True(t, reporter.IsSkipped(), "expected Skip on empty Inferences")
 }

--- a/inference-chain/x/inference/simulation/signing.go
+++ b/inference-chain/x/inference/simulation/signing.go
@@ -1,0 +1,77 @@
+package simulation
+
+import (
+	"encoding/base64"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+
+	"github.com/productscience/inference/x/inference/calculations"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// Sim-only signing helpers for Phase 2 first-wave factories.
+//
+// The on-chain signature scheme used by `verifyStartFirstMessageKeys`
+// (msg_server_start_inference.go) and `verifyFinishKeys`
+// (msg_server_finish_inference.go) is:
+//
+//   bytes = Payload || strconv(EpochId if>0) || strconv(Timestamp) ||
+//           TransferAddress (|| ExecutorAddress for TA/Executor)
+//   sig   = base64( secp256k1_sign(privKey, bytes) )  // r||s, 64 bytes
+//
+// Encoding lives in calculations/signature_validate.go. Factories
+// in this package generate the components from msg fields and sign with
+// the picked SimAccount's PrivKey so the produced tx clears the cryptographic
+// verify path and the inference actually lands in the keeper.
+
+// simAccountSigner adapts a simtypes.Account PrivKey to the
+// calculations.Signer interface (SignBytes returns base64-encoded sig).
+type simAccountSigner struct{ priv cryptotypes.PrivKey }
+
+func (s simAccountSigner) SignBytes(data []byte) (string, error) {
+	sig, err := s.priv.Sign(data)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// SignDevStart signs MsgStartInference dev components. Result goes in
+// msg.InferenceId (the field is named after the inference but is treated
+// by the handler as the dev signature — see
+// msg_server_start_inference.go calculations.SignatureData
+// `DevSignature: msg.InferenceId`).
+func SignDevStart(sa simsx.SimAccount, msg *types.MsgStartInference) (string, error) {
+	components := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.Creator,
+	}
+	return calculations.Sign(simAccountSigner{priv: sa.PrivKey}, components, calculations.Developer)
+}
+
+// SignDevFinish signs MsgFinishInference dev components. Result goes in
+// msg.InferenceId. Mirrors getFinishDevSignatureComponents at
+// msg_server_finish_inference.go.
+func SignDevFinish(sa simsx.SimAccount, msg *types.MsgFinishInference) (string, error) {
+	components := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+	}
+	return calculations.Sign(simAccountSigner{priv: sa.PrivKey}, components, calculations.Developer)
+}
+
+// SignTAFinish signs MsgFinishInference TA components. Result goes in
+// msg.TransferSignature. Mirrors getFinishTASignatureComponents at
+// msg_server_finish_inference.go (TA/Executor share bytes layout).
+func SignTAFinish(sa simsx.SimAccount, msg *types.MsgFinishInference) (string, error) {
+	components := calculations.SignatureComponents{
+		Payload:         msg.PromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+		ExecutorAddress: msg.ExecutedBy,
+	}
+	return calculations.Sign(simAccountSigner{priv: sa.PrivKey}, components, calculations.TransferAgent)
+}

--- a/inference-chain/x/inference/simulation/signing.go
+++ b/inference-chain/x/inference/simulation/signing.go
@@ -10,7 +10,7 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-// Sim-only signing helpers for Phase 2 first-wave factories.
+// Sim-only signing helpers for the x/inference message factories.
 //
 // The on-chain signature scheme used by `verifyStartFirstMessageKeys`
 // (msg_server_start_inference.go) and `verifyFinishKeys`

--- a/inference-chain/x/inference/simulation/signing_test.go
+++ b/inference-chain/x/inference/simulation/signing_test.go
@@ -1,0 +1,138 @@
+package simulation_test
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/calculations"
+	"github.com/productscience/inference/x/inference/simulation"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// pubKeyB64 returns the standard-base64 encoding of the secp256k1 pubkey
+// bytes — the same format the on-chain GetAccountPubKey returns
+// (msg_server_start_inference.go).
+func pubKeyB64(t *testing.T, a simtypes.Account) string {
+	t.Helper()
+	return base64.StdEncoding.EncodeToString(a.PubKey.Bytes())
+}
+
+// TestSignDevStart_RoundTrip — SignDevStart's output decodes and
+// ValidateSignature(Developer) accepts it against the signing account's
+// pubkey. This verifies the helper plugs cleanly into the on-chain
+// VerifyKeys path used by verifyStartFirstMessageKeys.
+func TestSignDevStart_RoundTrip(t *testing.T) {
+	accs := simtypes.RandomAccounts(rand.New(rand.NewSource(1)), 1)
+	sa := simsx.SimAccount{Account: accs[0]}
+
+	msg := &types.MsgStartInference{
+		Creator:            accs[0].Address.String(),
+		RequestedBy:        accs[0].Address.String(),
+		AssignedTo:         accs[0].Address.String(),
+		OriginalPromptHash: "orig-hash",
+		PromptHash:         "prompt-hash",
+		Model:              "sim-model",
+		RequestTimestamp:   1234567890,
+	}
+
+	sig, err := simulation.SignDevStart(sa, msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, sig)
+
+	components := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.Creator,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(components, calculations.Developer,
+			pubKeyB64(t, accs[0]), sig))
+}
+
+// TestSignDevFinish_RoundTrip — same for Finish dev signature, using
+// MsgFinishInference's TransferredBy as TransferAddress.
+func TestSignDevFinish_RoundTrip(t *testing.T) {
+	accs := simtypes.RandomAccounts(rand.New(rand.NewSource(2)), 1)
+	sa := simsx.SimAccount{Account: accs[0]}
+
+	msg := &types.MsgFinishInference{
+		Creator:            accs[0].Address.String(),
+		ExecutedBy:         accs[0].Address.String(),
+		TransferredBy:      accs[0].Address.String(),
+		RequestedBy:        accs[0].Address.String(),
+		OriginalPromptHash: "orig-hash-finish",
+		PromptHash:         "prompt-hash-finish",
+		Model:              "sim-model",
+		RequestTimestamp:   2222222222,
+	}
+
+	sig, err := simulation.SignDevFinish(sa, msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, sig)
+
+	components := calculations.SignatureComponents{
+		Payload:         msg.OriginalPromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(components, calculations.Developer,
+			pubKeyB64(t, accs[0]), sig))
+}
+
+// TestSignTAFinish_RoundTrip — TA signature includes ExecutorAddress in
+// the byte payload (getTransferBytes appends ExecutorAddress on top of
+// getDevBytes). Verified via ValidateSignature(TransferAgent).
+func TestSignTAFinish_RoundTrip(t *testing.T) {
+	accs := simtypes.RandomAccounts(rand.New(rand.NewSource(3)), 1)
+	sa := simsx.SimAccount{Account: accs[0]}
+
+	msg := &types.MsgFinishInference{
+		Creator:          accs[0].Address.String(),
+		ExecutedBy:       accs[0].Address.String(),
+		TransferredBy:    accs[0].Address.String(),
+		PromptHash:       "ta-prompt-hash",
+		RequestTimestamp: 3333333333,
+	}
+
+	sig, err := simulation.SignTAFinish(sa, msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, sig)
+
+	components := calculations.SignatureComponents{
+		Payload:         msg.PromptHash,
+		Timestamp:       msg.RequestTimestamp,
+		TransferAddress: msg.TransferredBy,
+		ExecutorAddress: msg.ExecutedBy,
+	}
+	require.NoError(t,
+		calculations.ValidateSignature(components, calculations.TransferAgent,
+			pubKeyB64(t, accs[0]), sig))
+}
+
+// TestSignDevStart_Deterministic — same key + same components → same
+// signature. cosmos-sdk secp256k1 uses deterministic ECDSA per RFC 6979,
+// so the helper must reproduce bit-identically. This guarantees
+// replay-determinism across simulator seeds.
+func TestSignDevStart_Deterministic(t *testing.T) {
+	accs := simtypes.RandomAccounts(rand.New(rand.NewSource(4)), 1)
+	sa := simsx.SimAccount{Account: accs[0]}
+
+	msg := &types.MsgStartInference{
+		Creator:            accs[0].Address.String(),
+		RequestedBy:        accs[0].Address.String(),
+		OriginalPromptHash: "det-hash",
+		RequestTimestamp:   9999999999,
+	}
+
+	sig1, err := simulation.SignDevStart(sa, msg)
+	require.NoError(t, err)
+	sig2, err := simulation.SignDevStart(sa, msg)
+	require.NoError(t, err)
+	require.Equal(t, sig1, sig2)
+}

--- a/inference-chain/x/inference/simulation/submit_poc_v2_commit.go
+++ b/inference-chain/x/inference/simulation/submit_poc_v2_commit.go
@@ -1,0 +1,104 @@
+package simulation
+
+import (
+	"context"
+
+	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// MsgPoCV2StoreCommitFactory creates a factory for MsgPoCV2StoreCommit.
+//
+// Handler invariants the factory satisfies:
+//   - window: IsPoCExchangeWindow (msg_server_poc_v2_commit.go)
+//   - monotonic Count per (participant, model, stage): factory submits at
+//     most one commit per triple via PoCV2StoreCommits.Has pre-check
+//   - entry shape: ModelId must be governance-registered, Count > 0,
+//     RootHash exactly 32 bytes
+//
+// Implements HasFutureOpsRegistry: every skip and every success books
+// the next target PoC window onto the future-op queue, so the factory
+// keeps firing in its target window independently of how the random
+// operation pump schedules it.
+//
+// Requires Params.PocParams.PocV2Enabled=true.
+func MsgPoCV2StoreCommitFactory(k keeper.Keeper) simsx.SimMsgFactoryX {
+	st := newPocFactoryState()
+	var self simsx.SimMsgFactoryX
+	self = simsx.NewSimMsgFactoryWithFutureOps[*types.MsgPoCV2StoreCommit](
+		func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter, fOpsReg simsx.FutureOpsRegistry) ([]simsx.SimAccount, *types.MsgPoCV2StoreCommit) {
+			sdkCtx := sdk.UnwrapSDKContext(ctx)
+			currentBlockHeight := sdkCtx.BlockHeight()
+
+			// Read upcoming epoch + epoch params to compute the PoC window.
+			upcomingEpoch, found := k.GetUpcomingEpoch(ctx)
+			if !found || upcomingEpoch == nil {
+				reporter.Skipf("no upcoming epoch (pre-PoC genesis or post-rotation gap)")
+				return nil, nil
+			}
+			params, err := k.GetParams(ctx)
+			if err != nil {
+				reporter.Skipf("GetParams failed: %v", err)
+				return nil, nil
+			}
+			epochContext := types.NewEpochContext(*upcomingEpoch, *params.EpochParams)
+			windowStart := epochContext.StartOfPoC() + 1
+			if !epochContext.IsPoCExchangeWindow(currentBlockHeight) {
+				if currentBlockHeight < windowStart {
+					st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index, currentBlockHeight, windowStart, self)
+				} else {
+					st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index+1, currentBlockHeight, epochContext.NextPoCStart()+1, self)
+				}
+				reporter.Skipf("outside PoC exchange window (h=%d)", currentBlockHeight)
+				return nil, nil
+			}
+
+			// Pick a sim genesis participant. Limits commits to the 5 sim genesis
+			// accounts so ComputeNewWeights' inferred ActiveParticipant set
+			// aligns with our intended validator set rather than throwaway
+			// random simState.Accounts.
+			ta, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+			if !ok {
+				return nil, nil
+			}
+
+			// Pick a model (Kimi or Qwen — both in SimModelIDs / sim genesis).
+			modelID := SimModelIDs[testData.Rand().Rand.Intn(len(SimModelIDs))]
+
+			// Idempotency check: skip if commit already exists for this
+			// (participant, model, stage). Avoids the monotonic-Count constraint.
+			stage := epochContext.StartOfPoC()
+			commitKey := collections.Join3(stage, ta.Address, modelID)
+			has, _ := k.PoCV2StoreCommits.Has(ctx, commitKey)
+			if has {
+				reporter.Skipf("commit already exists for (%s, %s, stage=%d)",
+					ta.AddressBech32, modelID, stage)
+				return nil, nil
+			}
+
+			// Build the entry: random 32-byte RootHash + Count in [100, 999].
+			rootHash := make([]byte, 32)
+			testData.Rand().Read(rootHash)
+			count := uint32(100 + testData.Rand().Rand.Intn(900))
+
+			msg := &types.MsgPoCV2StoreCommit{
+				Creator:                  ta.AddressBech32,
+				PocStageStartBlockHeight: stage,
+				Entries: []*types.PoCV2CommitEntry{
+					{
+						ModelId:  modelID,
+						Count:    count,
+						RootHash: rootHash,
+					},
+				},
+			}
+			st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index+1, currentBlockHeight, epochContext.NextPoCStart()+1, self)
+			return []simsx.SimAccount{ta}, msg
+		},
+	)
+	return self
+}

--- a/inference-chain/x/inference/simulation/submit_poc_validations_v2.go
+++ b/inference-chain/x/inference/simulation/submit_poc_validations_v2.go
@@ -1,0 +1,144 @@
+package simulation
+
+import (
+	"context"
+
+	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// MsgSubmitPocValidationsV2Factory creates a factory for MsgSubmitPocValidationsV2.
+//
+// Handler invariants the factory satisfies:
+//   - window: IsValidationExchangeWindow (msg_server_poc_validations_v2.go)
+//   - idempotency per (validator, participant, model, stage): factory
+//     pre-checks HasPocValidationV2 so the skip reason surfaces in the
+//     sim report rather than as an in-handler skip count
+//
+// Validation references a (participant, model) pair from earlier
+// commits; factory skips if no commit exists for the chosen target so
+// the validation surface stays consistent with what production
+// validators would observe.
+//
+// Self-validation is not forbidden by the handler, so the factory does
+// not exclude validator == target.
+//
+// Implements HasFutureOpsRegistry: every skip and every success books
+// the next epoch's validation window onto the future-op queue.
+//
+// Requires Params.PocParams.PocV2Enabled=true.
+func MsgSubmitPocValidationsV2Factory(k keeper.Keeper) simsx.SimMsgFactoryX {
+	st := newPocFactoryState()
+	var self simsx.SimMsgFactoryX
+	self = simsx.NewSimMsgFactoryWithFutureOps[*types.MsgSubmitPocValidationsV2](
+		func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter, fOpsReg simsx.FutureOpsRegistry) ([]simsx.SimAccount, *types.MsgSubmitPocValidationsV2) {
+			sdkCtx := sdk.UnwrapSDKContext(ctx)
+			currentBlockHeight := sdkCtx.BlockHeight()
+
+			upcomingEpoch, found := k.GetUpcomingEpoch(ctx)
+			if !found || upcomingEpoch == nil {
+				reporter.Skipf("no upcoming epoch")
+				return nil, nil
+			}
+			params, err := k.GetParams(ctx)
+			if err != nil {
+				reporter.Skipf("GetParams failed: %v", err)
+				return nil, nil
+			}
+			epochContext := types.NewEpochContext(*upcomingEpoch, *params.EpochParams)
+			windowStart := epochContext.StartOfPoCValidation() + 1
+			if !epochContext.IsValidationExchangeWindow(currentBlockHeight) {
+				w := epochContext.ValidationExchangeWindow()
+				if currentBlockHeight < windowStart {
+					st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index, currentBlockHeight, windowStart, self)
+				} else {
+					nextWindowStart := epochContext.NextPoCStart() + params.EpochParams.GetStartOfPoCValidationStage() + 1
+					st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index+1, currentBlockHeight, nextWindowStart, self)
+				}
+				reporter.Skipf("outside validation exchange window (h=%d, [%d, %d])",
+					currentBlockHeight, w.Start, w.End)
+				return nil, nil
+			}
+
+			validator, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+			if !ok {
+				return nil, nil
+			}
+			stage := epochContext.StartOfPoC()
+
+			// Iterate PoCV2StoreCommits at this stage to find a (target,
+			// modelID) the validator hasn't validated yet. Random target
+			// selection over the N-participants × len(SimModelIDs) matrix
+			// would almost always miss the sparse subset of slots that
+			// have landed commits.
+			type validationCandidate struct {
+				target  sdk.AccAddress
+				modelID string
+				count   uint32
+			}
+			iter, err := k.PoCV2StoreCommits.Iterate(ctx,
+				collections.NewPrefixedTripleRange[int64, sdk.AccAddress, string](stage))
+			if err != nil {
+				reporter.Skipf("PoCV2StoreCommits iterate failed: %v", err)
+				return nil, nil
+			}
+			defer iter.Close()
+			var pick validationCandidate
+			candidateCount := 0
+			for ; iter.Valid(); iter.Next() {
+				key, kerr := iter.Key()
+				if kerr != nil {
+					reporter.Skipf("PoCV2StoreCommits key decode failed: %v", kerr)
+					return nil, nil
+				}
+				targetAddr := key.K2()
+				modelCandidate := key.K3()
+				dup, _ := k.HasPocValidationV2(ctx, stage, targetAddr.String(), modelCandidate, validator.AddressBech32)
+				if dup {
+					continue
+				}
+				val, verr := iter.Value()
+				if verr != nil {
+					reporter.Skipf("PoCV2StoreCommits value decode failed: %v", verr)
+					return nil, nil
+				}
+				candidate := validationCandidate{target: targetAddr, modelID: modelCandidate, count: val.Count}
+				// Reservoir sampling: each candidate replaces the current
+				// pick with probability 1/(candidateCount+1), yielding a
+				// uniform pick across all encountered candidates without
+				// materializing the full slice.
+				if candidateCount == 0 || testData.Rand().Rand.Intn(candidateCount+1) == 0 {
+					pick = candidate
+				}
+				candidateCount++
+			}
+			if candidateCount == 0 {
+				reporter.Skipf("validator %s has nothing left to validate at stage=%d",
+					validator.AddressBech32, stage)
+				return nil, nil
+			}
+			targetBech32 := pick.target.String()
+			modelID := pick.modelID
+
+			msg := &types.MsgSubmitPocValidationsV2{
+				Creator:                  validator.AddressBech32,
+				PocStageStartBlockHeight: stage,
+				Validations: []*types.PoCValidationEntryV2{
+					{
+						ParticipantAddress: targetBech32,
+						ModelId:            modelID,
+						ValidatedWeight:    int64(pick.count),
+					},
+				},
+			}
+			nextWindowStart := epochContext.NextPoCStart() + params.EpochParams.GetStartOfPoCValidationStage() + 1
+			st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index+1, currentBlockHeight, nextWindowStart, self)
+			return []simsx.SimAccount{validator}, msg
+		},
+	)
+	return self
+}

--- a/inference-chain/x/inference/simulation/submit_secondary_op_factories.go
+++ b/inference-chain/x/inference/simulation/submit_secondary_op_factories.go
@@ -1,0 +1,105 @@
+package simulation
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// Second-wave self-signed participant ops. Each is signed by an active sim
+// participant (the Creator), so it clears ValidateBasic + the permission gate
+// + signature verification and reaches real keeper state mutation. These are
+// the real factories for three messages that previously had only NoOpMsg
+// legacy stubs (unreachable under the simsx HasWeightedOperationsX path).
+
+// MsgSubmitUnitOfComputePriceProposalFactory exercises the unit-of-compute
+// price proposal path: CheckPermission(ActiveParticipantPermission) +
+// GetEffectiveEpoch, then SetUnitOfComputePriceProposal.
+func MsgSubmitUnitOfComputePriceProposalFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgSubmitUnitOfComputePriceProposal] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgSubmitUnitOfComputePriceProposal) {
+		if err := EnsureSimActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("sim active-participants seeding failed: %v", err)
+			return nil, nil
+		}
+		from, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		msg := &types.MsgSubmitUnitOfComputePriceProposal{
+			Creator: from.AddressBech32,
+			Price:   uint64(1 + testData.Rand().Intn(10000)),
+		}
+		return []simsx.SimAccount{from}, msg
+	}
+}
+
+// MsgSubmitHardwareDiffFactory exercises the hardware-node diff path:
+// CheckPermission(ParticipantPermission) + governance-model validation, then
+// SetHardwareNodes. The node advertises a genesis-registered governance model
+// (SimModelIDs) so IsValidGovernanceModel passes; the RNG-varied LocalId makes
+// repeated calls produce add/modify diffs against the participant's node set.
+func MsgSubmitHardwareDiffFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgSubmitHardwareDiff] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgSubmitHardwareDiff) {
+		if err := EnsureModelsInEpochGroup(ctx, k); err != nil {
+			reporter.Skipf("models epoch-group seeding failed: %v", err)
+			return nil, nil
+		}
+		if err := EnsureSimActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("sim active-participants seeding failed: %v", err)
+			return nil, nil
+		}
+		from, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		node := &types.HardwareNode{
+			LocalId: fmt.Sprintf("sim-node-%d", testData.Rand().Intn(1<<20)),
+			Models:  []string{SimModelIDs[testData.Rand().Intn(len(SimModelIDs))]},
+			Host:    "sim-host",
+			Port:    "5000",
+		}
+		msg := &types.MsgSubmitHardwareDiff{
+			Creator:       from.AddressBech32,
+			NewOrModified: []*types.HardwareNode{node},
+		}
+		return []simsx.SimAccount{from}, msg
+	}
+}
+
+// MsgSubmitNewUnfundedParticipantFactory exercises the direct (unfunded)
+// participant-registration path: CheckPermission(OpenRegistrationPermission),
+// then account creation with a pubkey that must match the supplied address.
+// The signer is an existing active participant (Creator); the new participant
+// (Address) is a fresh secp256k1 identity derived deterministically from the
+// sim RNG so the address matches the handler-rederived pubkey and the run
+// stays reproducible.
+func MsgSubmitNewUnfundedParticipantFactory(k keeper.Keeper) simsx.SimMsgFactoryFn[*types.MsgSubmitNewUnfundedParticipant] {
+	return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgSubmitNewUnfundedParticipant) {
+		if err := EnsureSimActiveParticipantsSeeded(ctx, k); err != nil {
+			reporter.Skipf("sim active-participants seeding failed: %v", err)
+			return nil, nil
+		}
+		creator, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+		if !ok {
+			return nil, nil
+		}
+		secret := make([]byte, 32)
+		testData.Rand().Read(secret)
+		pub := secp256k1.GenPrivKeyFromSecret(secret).PubKey()
+		newAddr := sdk.AccAddress(pub.Address()).String()
+		msg := &types.MsgSubmitNewUnfundedParticipant{
+			Creator:      creator.AddressBech32,
+			Address:      newAddr,
+			PubKey:       base64.StdEncoding.EncodeToString(pub.Bytes()),
+			ValidatorKey: SimValidatorKey(newAddr),
+		}
+		return []simsx.SimAccount{creator}, msg
+	}
+}

--- a/inference-chain/x/inference/simulation/submit_seed.go
+++ b/inference-chain/x/inference/simulation/submit_seed.go
@@ -1,15 +1,24 @@
 package simulation
 
 import (
+	"context"
+	"encoding/hex"
 	"math/rand"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/testutil/simsx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/types"
 )
 
+// SimulateMsgSubmitSeed is a legacy simtypes.Operation stub kept for the
+// non-simsx WeightedOperations() / ProposalMsgs() hooks. simsx prefers
+// WeightedOperationsX (module/simulation.go), which routes to
+// MsgSubmitSeedFactory below. This stub is reachable only by the legacy
+// runner.
 func SimulateMsgSubmitSeed(
 	ak types.AccountKeeper,
 	bk types.BankKeeper,
@@ -21,9 +30,85 @@ func SimulateMsgSubmitSeed(
 		msg := &types.MsgSubmitSeed{
 			Creator: simAccount.Address.String(),
 		}
-
-		// TODO: Handling the SubmitSeed simulation
-
-		return simtypes.NoOpMsg(types.ModuleName, sdk.MsgTypeURL(msg), "SubmitSeed simulation not implemented"), nil, nil
+		return simtypes.NoOpMsg(types.ModuleName, sdk.MsgTypeURL(msg), "SubmitSeed legacy stub — simsx uses MsgSubmitSeedFactory"), nil, nil
 	}
+}
+
+// MsgSubmitSeedFactory creates a factory for MsgSubmitSeed.
+//
+// Handler invariants the factory satisfies:
+//   - permission: ParticipantPermission (msg_server_submit_seed.go)
+//   - msg.EpochIndex in [currentEpoch, currentEpoch+1]
+//   - ValidateBasic: Creator bech32, EpochIndex > 0, Signature is hex-128
+//     (utils.ValidateHexRSig64) — shape only, no crypto verification
+//   - idempotency: RandomSeeds.Set is unconditional, so the factory
+//     pre-checks GetRandomSeed to surface the duplicate as a sim skip
+//     rather than a redundant state write
+//
+// Targets upcomingEpoch.Index so ComputeNewWeights' seed lookup
+// (chainvalidation.go:949 — `GetRandomSeed(ctx, upcomingEpoch.Index, ...)`)
+// finds a seed for every committing participant. Without seeds, every
+// PoCV2StoreCommit is filtered out, `pocMiningParticipants` stays empty
+// and `onEndOfPoCValidationStage` returns `computeResult == nil` —
+// halting the chain at the next epoch transition.
+//
+// Implements HasFutureOpsRegistry: every skip and every success books
+// the next PoC exchange window onto the future-op queue.
+func MsgSubmitSeedFactory(k keeper.Keeper) simsx.SimMsgFactoryX {
+	st := newPocFactoryState()
+	var self simsx.SimMsgFactoryX
+	self = simsx.NewSimMsgFactoryWithFutureOps[*types.MsgSubmitSeed](
+		func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter, fOpsReg simsx.FutureOpsRegistry) ([]simsx.SimAccount, *types.MsgSubmitSeed) {
+			sdkCtx := sdk.UnwrapSDKContext(ctx)
+			currentBlockHeight := sdkCtx.BlockHeight()
+
+			upcomingEpoch, found := k.GetUpcomingEpoch(ctx)
+			if !found || upcomingEpoch == nil {
+				reporter.Skipf("no upcoming epoch")
+				return nil, nil
+			}
+			params, err := k.GetParams(ctx)
+			if err != nil {
+				reporter.Skipf("GetParams failed: %v", err)
+				return nil, nil
+			}
+			epochContext := types.NewEpochContext(*upcomingEpoch, *params.EpochParams)
+			windowStart := epochContext.StartOfPoC() + 1
+			if !epochContext.IsPoCExchangeWindow(currentBlockHeight) {
+				if currentBlockHeight < windowStart {
+					st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index, currentBlockHeight, windowStart, self)
+				} else {
+					st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index+1, currentBlockHeight, epochContext.NextPoCStart()+1, self)
+				}
+				reporter.Skipf("outside PoC exchange window (h=%d)", currentBlockHeight)
+				return nil, nil
+			}
+
+			ta, ok := PickRandomActiveSimAccount(ctx, k, testData, reporter)
+			if !ok {
+				return nil, nil
+			}
+
+			if _, exists := k.GetRandomSeed(ctx, upcomingEpoch.Index, ta.AddressBech32); exists {
+				reporter.Skipf("seed already submitted for (%s, epoch=%d)", ta.AddressBech32, upcomingEpoch.Index)
+				return nil, nil
+			}
+
+			// Handler does not verify the signature cryptographically — only
+			// shape (utils.ValidateHexRSig64: hex-128 = 64 bytes). Random
+			// payload is sufficient and keeps the sim deterministic via
+			// testData.Rand().
+			sigBytes := make([]byte, 64)
+			testData.Rand().Read(sigBytes)
+
+			msg := &types.MsgSubmitSeed{
+				Creator:    ta.AddressBech32,
+				EpochIndex: upcomingEpoch.Index,
+				Signature:  hex.EncodeToString(sigBytes),
+			}
+			st.scheduleForEpoch(ctx, fOpsReg, upcomingEpoch.Index+1, currentBlockHeight, epochContext.NextPoCStart()+1, self)
+			return []simsx.SimAccount{ta}, msg
+		},
+	)
+	return self
 }


### PR DESCRIPTION
Closes #982

## Summary

Combined Phase 1 + Phase 2 + Phase 3 of #982 — full local-verification milestone.

- **Phase 1**: simsx migration of `inference-chain` simulation app. `HasWeightedOperationsX` registry, disabled-incompatible upstream sim ops (staking/distribution/wasm), `make sim-smoke-test`/`sim-full-test`, postRunActions for ImportExport / SimulationAfterImport, `fixBankGenesisState`. Pinned `-GenesisTime` for reproducibility.
- **Phase 2**: First-wave x/inference real ops via simsx — `SubmitNewParticipant`, `StartInference`, `FinishInference`, `Validation`, `ClaimRewards`. Real secp256k1 dev/TA signatures (`signing.go`), real model registration (`SimModelIDs`), `EnsureModelsInEpochGroup`. Failing-validation branch through real `x/group.SubmitProposal` + revalidation votes (`MsgRevalidationVoteFactory`).
- **Phase 3**: V2 PoC chain factory family — `MsgPoCV2StoreCommit`, `MsgMLNodeWeightDistribution`, `MsgSubmitPocValidationsV2`, `MsgSubmitSeedFactory` — implementing cosmos-sdk simsx `HasFutureOpsRegistry`. State-driven (target, model) selection in F2/F3 with reservoir sampling. Picker age-filter + model-weight cache filter in `MsgValidation`/`MsgRevalidationVote`. Bootstrap goes through real production paths (`EpochGroup.AddMember` + `BuildEpochDataTransientCache` + `Staking.SetComputeValidators`).

## Verification (canonical Docker, seed=99, GenesisTime=1700000000)

- `make sim-smoke-test` (50×20): PASS, lifecycle `total=75 startProcessed=72 finishProcessed=62 validated=50 proposed=4`.
- `make sim-full-test` (500×200) against `gonka-ai/cosmos-sdk` carrying the fixes from #1205 and #14: PASS, height=501, opsCount=60763, app-hash `d7a20cf044230b56189194968872515be0d059d0a0401203f67995e87870b9d8`.
- Cherry-picked onto `gm/microrelease` (v0.2.13 staging) + same patched cosmos: PASS, height=501, opsCount=53892, app-hash `8108a42faf20e550bec3ec748330c0453e58d238d156afb199a3db87a1baccf6`. One adapter line: `NewEpochMemberFromActiveParticipant` 3-arg signature change.

## Surfaced fork-side findings (already filed, NOT in this PR)

This simulation surfaced two distinct `gonka-ai/cosmos-sdk` bugs end-to-end. Both filed separately:

1. **`markValidatorForDeletion` jailed-branch race** vs CometBFT validator-update lag — issue gonka-ai/gonka#1205. Reproduces as sim-full halt around block ~140-147 depending on RNG path.
2. **GON-191 stale consensus-key reassignment** — gonka-ai/cosmos-sdk PR #14 by `@0xgonka`. Independently needed for validator re-registration with reused cons-keys.

Isolated test with only PR #14 applied (no #1205 patch) reproduces the same b147 halt — confirming the two fixes are orthogonal and both required for clean sim-full liveness. With both applied, sim-full completes 500 blocks deterministically.

## Closes / Supersedes

- Supersedes #1182 (closed with forward-pointer to this PR).

## Test plan

- [ ] `make sim-smoke-test` PASS in canonical Docker
- [ ] `make sim-full-test` PASS in canonical Docker (against patched cosmos-sdk per above)
- [ ] Adversarial review via codex:rescue — APPROVE (1 FIX folded, 1 COURSE-CORRECT folded)
- [ ] `gonka-ai/ai-reviewer` (claude_max_proxy) — 0 must-fix, 1 major (folded), 3 nits (folded)
- [ ] V2 PoC chain advances ≥12 epoch rotations (`currentEpoch=12` observed at end-of-run)

cc @patimen

---

## Update — Phase 3 quality added (commit `983fcaac4`)

This PR now also carries the Phase 3 hardening/quality work (4th commit):
custom invariants via `RegisterInvariants` (bank-backs-positive-balance
solvency, no-stuck-voting, effective-epoch-fresh, active-invalidations-ref-live),
store decoders, aggressive parameter-boundary fuzzing, and three real
secondary-op factories (`SubmitUnitOfComputePriceProposal`, `SubmitHardwareDiff`,
`SubmitNewUnfundedParticipant`) replacing NoOp stubs.

### Prerequisites — sim-full is green only with all of these applied

The full 500×200 run surfaced, and depends on, these production fixes — each
filed as its own focused PR (kept out of this PR to preserve scope):

- **gonka-ai/gonka#1275** — `expireInferences` refunds the client escrow for
  `VOTING` inferences stranded on an x/group quorum miss (reported in #1265, fixed by #1275).
- **gonka-ai/gonka#1276** — `revalidateInferenceVote` membership precheck: skip
  the x/group votes when the voter is not an epoch-group member (reported in #1269, fixed by #1276).
- **gonka-ai/cosmos-sdk#16** — `markValidatorForDeletion` hardening (jailed-delete
  race vs CometBFT lag + non-jailed `DelegatorShares` divide-by-zero); this is the
  PR for the #1205 issue noted above, and is complementary to GON-191
  (gonka-ai/cosmos-sdk#14).

Verified combined (canonical Docker, seed=99, `GenesisTime=1700000000`, against
cosmos-sdk#16): **`sim-full` 500×200 PASS, height=501, opsCount=38727, app-hash
`f76df5cdfe03161ff114e8c926c719bed0e27d60e5548a883b79ef9826372b82`** — this
supersedes the earlier app-hash above (that run predates the quality work and the
fixes). Unit tests (`keeper` / `simulation` / `module`) pass standalone on stock
`v0.53.3-ps17`.

### Open design question (not a blocker)

The post-run `bank-backs` solvency invariant holds in the canonical 500×200 run
(transient intra-epoch under-backing heals via debt-recovery by settlement). The
asymmetric refund-debit drift it surfaces under shorter / aggressive runs is a
design question, filed as **gonka-ai/gonka#1273** with reproducer
`TestRefundInvalidation_LeavesAccountingDrift` — deliberately not fixed here,
pending maintainer guidance on intended semantics.


