### PR TITLE
feat(api): optional signed agent request envelope

### DIFF
--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -48,6 +48,11 @@ const (
 	DefaultAgentEnvelopeMaxTTLSeconds       int64 = 3600
 	DefaultAgentEnvelopeMaxBodySize         int64 = 10 * 1024 * 1024
 	DefaultAgentEnvelopeAttributionQueueCap       = 1024
+	// MaxAgentEnvelopeBodySize is the hard upper bound for max_body_size. A
+	// configured value outside (0, MaxAgentEnvelopeBodySize] falls back to the
+	// default. The bound keeps the signed-payload length prefixes well within
+	// uint32 range.
+	MaxAgentEnvelopeBodySize int64 = 1 << 30
 )
 
 type NatsServerConfig struct {

--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -53,6 +53,14 @@ const (
 	// default. The bound keeps the signed-payload length prefixes well within
 	// uint32 range.
 	MaxAgentEnvelopeBodySize int64 = 1 << 30
+	// MaxAgentEnvelopeTTLSeconds is the hard upper bound for max_ttl_seconds.
+	// A value outside (0, MaxAgentEnvelopeTTLSeconds] falls back to the
+	// default. The bound prevents a negative or overflowing time.Duration.
+	MaxAgentEnvelopeTTLSeconds int64 = 7 * 24 * 3600
+	// MaxAgentEnvelopeQueueCap is the hard upper bound for
+	// attribution_queue_cap. A value outside (0, MaxAgentEnvelopeQueueCap]
+	// falls back to the default, bounding the buffered-channel allocation.
+	MaxAgentEnvelopeQueueCap = 1 << 20
 )
 
 type NatsServerConfig struct {

--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -27,8 +27,28 @@ type Config struct {
 	BandwidthParams          BandwidthParamsCache     `koanf:"bandwidth_params" json:"bandwidth_params"`
 	PoCParams                PoCParamsCache           `koanf:"poc_params" json:"poc_params"`
 	TransferAgentAccessCache TransferAgentAccessCache `koanf:"-" json:"-"` // not persisted, synced from chain
-	DevshardVersionsCache      DevshardVersionsCache      `koanf:"-" json:"-"` // not persisted, synced from chain
+	DevshardVersionsCache    DevshardVersionsCache    `koanf:"-" json:"-"` // not persisted, synced from chain
+	AgentEnvelope            AgentEnvelopeConfig      `koanf:"agent_envelope" json:"agent_envelope"`
 }
+
+// AgentEnvelopeConfig configures the optional signed agent request envelope
+// verifier. The envelope layer is off unless Enabled is set. ChainID must be
+// set to this network's chain ID when the layer is enabled.
+type AgentEnvelopeConfig struct {
+	Enabled             bool   `koanf:"enabled" json:"enabled"`
+	ChainID             string `koanf:"chain_id" json:"chain_id"`
+	MaxTTLSeconds       int64  `koanf:"max_ttl_seconds" json:"max_ttl_seconds"`
+	MaxBodySize         int64  `koanf:"max_body_size" json:"max_body_size"`
+	AttributionQueueCap int    `koanf:"attribution_queue_cap" json:"attribution_queue_cap"`
+}
+
+// Default agent-envelope settings, applied by GetAgentEnvelopeConfig when a
+// field is left at its zero value.
+const (
+	DefaultAgentEnvelopeMaxTTLSeconds       int64 = 3600
+	DefaultAgentEnvelopeMaxBodySize         int64 = 10 * 1024 * 1024
+	DefaultAgentEnvelopeAttributionQueueCap       = 1024
+)
 
 type NatsServerConfig struct {
 	Host                  string `koanf:"host" json:"host"`

--- a/decentralized-api/apiconfig/config_manager.go
+++ b/decentralized-api/apiconfig/config_manager.go
@@ -151,7 +151,7 @@ func (cm *ConfigManager) GetAgentEnvelopeConfig() AgentEnvelopeConfig {
 	if cfg.MaxTTLSeconds == 0 {
 		cfg.MaxTTLSeconds = DefaultAgentEnvelopeMaxTTLSeconds
 	}
-	if cfg.MaxBodySize == 0 {
+	if cfg.MaxBodySize <= 0 || cfg.MaxBodySize > MaxAgentEnvelopeBodySize {
 		cfg.MaxBodySize = DefaultAgentEnvelopeMaxBodySize
 	}
 	if cfg.AttributionQueueCap == 0 {

--- a/decentralized-api/apiconfig/config_manager.go
+++ b/decentralized-api/apiconfig/config_manager.go
@@ -148,13 +148,13 @@ func (cm *ConfigManager) GetAgentEnvelopeConfig() AgentEnvelopeConfig {
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()
 	cfg := cm.currentConfig.AgentEnvelope
-	if cfg.MaxTTLSeconds == 0 {
+	if cfg.MaxTTLSeconds <= 0 || cfg.MaxTTLSeconds > MaxAgentEnvelopeTTLSeconds {
 		cfg.MaxTTLSeconds = DefaultAgentEnvelopeMaxTTLSeconds
 	}
 	if cfg.MaxBodySize <= 0 || cfg.MaxBodySize > MaxAgentEnvelopeBodySize {
 		cfg.MaxBodySize = DefaultAgentEnvelopeMaxBodySize
 	}
-	if cfg.AttributionQueueCap == 0 {
+	if cfg.AttributionQueueCap <= 0 || cfg.AttributionQueueCap > MaxAgentEnvelopeQueueCap {
 		cfg.AttributionQueueCap = DefaultAgentEnvelopeAttributionQueueCap
 	}
 	return cfg

--- a/decentralized-api/apiconfig/config_manager.go
+++ b/decentralized-api/apiconfig/config_manager.go
@@ -142,6 +142,24 @@ func (cm *ConfigManager) GetApiConfig() ApiConfig {
 	return cm.currentConfig.Api
 }
 
+// GetAgentEnvelopeConfig returns the agent-envelope settings with defaults
+// applied for any field left at its zero value.
+func (cm *ConfigManager) GetAgentEnvelopeConfig() AgentEnvelopeConfig {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+	cfg := cm.currentConfig.AgentEnvelope
+	if cfg.MaxTTLSeconds == 0 {
+		cfg.MaxTTLSeconds = DefaultAgentEnvelopeMaxTTLSeconds
+	}
+	if cfg.MaxBodySize == 0 {
+		cfg.MaxBodySize = DefaultAgentEnvelopeMaxBodySize
+	}
+	if cfg.AttributionQueueCap == 0 {
+		cfg.AttributionQueueCap = DefaultAgentEnvelopeAttributionQueueCap
+	}
+	return cfg
+}
+
 func (cm *ConfigManager) GetNatsConfig() NatsServerConfig {
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()

--- a/decentralized-api/examples/aps-client/README.md
+++ b/decentralized-api/examples/aps-client/README.md
@@ -1,0 +1,34 @@
+# aps-client
+
+A reference client for the optional signed agent request envelope.
+
+It generates a principal key and an agent key, builds an envelope, signs it,
+and prints the `X-Agent-Passport` and `X-Agent-Sig` headers along with a curl
+command that attaches them.
+
+## Run
+
+```
+go run ./examples/aps-client
+```
+
+## What it shows
+
+1. A principal key (a Gonka account key) and an agent key (a portable Ed25519
+   key) are generated.
+2. The principal signs an envelope that binds the agent key to the principal
+   address with a model allowlist, an expiry, and a beneficiary. The signature
+   uses ADR-036, the Cosmos arbitrary-data signing format that Keplr and the
+   chain CLI also produce.
+3. The agent signs the specific request with its Ed25519 key.
+4. The two headers are printed.
+
+## Notes
+
+The envelope is additive metadata. A real inference request still carries
+Gonka's existing developer signature and requester headers. The envelope adds
+agent identity, request-layer scope, and beneficiary attribution on top.
+
+In production the principal signature is produced by the developer's real key,
+for example through Keplr `signArbitrary`. This demo generates a throwaway
+principal key so it runs without a wallet.

--- a/decentralized-api/examples/aps-client/main.go
+++ b/decentralized-api/examples/aps-client/main.go
@@ -1,0 +1,126 @@
+// Command aps-client is a reference client for the optional signed agent
+// request envelope. It generates a principal key and an agent key, builds and
+// signs an envelope, and prints the X-Agent-Passport and X-Agent-Sig headers
+// plus a ready-to-run curl command.
+//
+// In production the principal signature is produced by the developer's real
+// Gonka account key, for example through Keplr or the chain CLI. This demo
+// generates a throwaway principal key so the example is self-contained. The
+// envelope is additive metadata: a real request still carries Gonka's existing
+// developer signature and requester headers.
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"decentralized-api/internal/agentenvelope"
+	"decentralized-api/internal/agentenvelope/jcs"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	chainID = "gonka-mainnet"
+	model   = "Qwen/QwQ-32B"
+	path    = "/v1/chat/completions"
+	apiURL  = "http://localhost:9000"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// Step 1: keys. The principal key anchors to a Gonka account. The agent
+	// key is the portable per-request signing key.
+	principalPriv := secp256k1.GenPrivKey()
+	principalPub := principalPriv.PubKey().(*secp256k1.PubKey)
+	principalAddr := sdk.AccAddress(principalPub.Address()).String()
+
+	agentPub, agentPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	// Step 2: the envelope. The principal delegates a scoped capability to
+	// the agent: one model, a 30 minute lifetime, one beneficiary.
+	now := time.Now().UTC()
+	models := []string{model}
+	env := agentenvelope.EnvelopeV1{
+		Version:          agentenvelope.SchemaVersion,
+		Audience:         agentenvelope.Audience,
+		ChainID:          chainID,
+		AgentID:          "urn:aps:agent:demo",
+		AgentPubkey:      agentenvelope.TypedKey{Type: agentenvelope.KeyTypeEd25519, PublicKey: base64.StdEncoding.EncodeToString(agentPub)},
+		PrincipalAddress: principalAddr,
+		PrincipalPubkey:  agentenvelope.TypedKey{Type: agentenvelope.KeyTypeSecp256k1, PublicKey: base64.StdEncoding.EncodeToString(principalPub.Key)},
+		Scope: agentenvelope.Scope{
+			AllowedModels: &models,
+			ExpiresAt:     now.Add(30 * time.Minute),
+		},
+		Beneficiary: "urn:customer:demo-corp",
+		IssuedAt:    now,
+	}
+
+	// Step 3: the principal signature (ADR-036). In production this is done
+	// by the developer's real key, for example via Keplr signArbitrary.
+	env.PrincipalSig = ""
+	unsigned, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+	signBytes, err := agentenvelope.PrincipalSignBytes(principalAddr, unsigned)
+	if err != nil {
+		return err
+	}
+	psig, err := principalPriv.Sign(signBytes)
+	if err != nil {
+		return err
+	}
+	env.PrincipalSig = base64.StdEncoding.EncodeToString(psig)
+
+	rawEnvelope, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+
+	// Step 4: the per-request body and the agent signature over it.
+	body := []byte(`{"model":"` + model + `","messages":[{"role":"user","content":"Hello"}]}`)
+	envJCS, err := jcs.Canonicalize(rawEnvelope)
+	if err != nil {
+		return err
+	}
+	payload := agentenvelope.AgentSigPayload(chainID, http.MethodPost, path, envJCS, body)
+	agentSig := ed25519.Sign(agentPriv, payload)
+
+	passportHeader := base64.StdEncoding.EncodeToString(rawEnvelope)
+	agentSigHeader := base64.StdEncoding.EncodeToString(agentSig)
+
+	fmt.Println("Signed agent request envelope")
+	fmt.Println("  principal:", principalAddr)
+	fmt.Println("  agent_id: ", env.AgentID)
+	fmt.Println("  model:    ", model)
+	fmt.Println()
+	fmt.Println("X-Agent-Passport:", passportHeader)
+	fmt.Println()
+	fmt.Println("X-Agent-Sig:", agentSigHeader)
+	fmt.Println()
+	fmt.Println("Example request (the envelope headers are additive to Gonka's existing request auth):")
+	fmt.Printf("curl -sS %s%s \\\n", apiURL, path)
+	fmt.Printf("  -H 'Content-Type: application/json' \\\n")
+	fmt.Printf("  -H 'X-Agent-Passport: %s' \\\n", passportHeader)
+	fmt.Printf("  -H 'X-Agent-Sig: %s' \\\n", agentSigHeader)
+	fmt.Printf("  --data '%s'\n", string(body))
+	return nil
+}

--- a/decentralized-api/internal/agentenvelope/attribution.go
+++ b/decentralized-api/internal/agentenvelope/attribution.go
@@ -1,0 +1,94 @@
+package agentenvelope
+
+import "sync"
+
+// AttributionSink receives verified attribution events for emission. The
+// production wiring adapts Gonka's logging package to this interface; tests
+// inject a recording implementation. Keeping the sink behind an interface
+// keeps this package free of a logging dependency and keeps it unit testable.
+type AttributionSink interface {
+	Emit(event AttributionEvent)
+}
+
+// AttributionEmitter buffers attribution events on a bounded channel and
+// drains them on a single background goroutine, so emission never gates the
+// inference request path.
+//
+// If the queue is full, Enqueue drops the event and increments a counter.
+// Drop-on-full is the correct backpressure response for observability data: a
+// slow log sink must not stall inference responses. v1 attribution is an
+// observability layer, not consensus, so a drop is acceptable and is recorded.
+// There is no ordering guarantee, and events can be lost under sink
+// backpressure.
+type AttributionEmitter struct {
+	ch     chan AttributionEvent
+	sink   AttributionSink
+	wg     sync.WaitGroup
+	mu     sync.Mutex
+	closed bool
+	// dropped is guarded by mu, as is the closed flag and the channel send.
+	dropped uint64
+}
+
+// NewAttributionEmitter starts an emitter with the given bounded-queue
+// capacity and starts its drain goroutine. The caller owns the returned
+// emitter and must call Close during shutdown. A capacity below 1 is raised
+// to 1.
+func NewAttributionEmitter(capacity int, sink AttributionSink) *AttributionEmitter {
+	if capacity < 1 {
+		capacity = 1
+	}
+	e := &AttributionEmitter{
+		ch:   make(chan AttributionEvent, capacity),
+		sink: sink,
+	}
+	e.wg.Add(1)
+	go e.drain()
+	return e
+}
+
+func (e *AttributionEmitter) drain() {
+	defer e.wg.Done()
+	for ev := range e.ch {
+		e.sink.Emit(ev)
+	}
+}
+
+// Enqueue submits an event for asynchronous emission. It never blocks. If the
+// queue is full, or the emitter is closed, the event is dropped and the drop
+// counter is incremented.
+func (e *AttributionEmitter) Enqueue(ev AttributionEvent) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		e.dropped++
+		return
+	}
+	select {
+	case e.ch <- ev:
+	default:
+		e.dropped++
+	}
+}
+
+// Dropped returns the number of events dropped because the queue was full or
+// the emitter was closed.
+func (e *AttributionEmitter) Dropped() uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.dropped
+}
+
+// Close stops accepting events, drains the buffered events to the sink, and
+// waits for the background goroutine to finish. Close is idempotent.
+func (e *AttributionEmitter) Close() {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return
+	}
+	e.closed = true
+	close(e.ch)
+	e.mu.Unlock()
+	e.wg.Wait()
+}

--- a/decentralized-api/internal/agentenvelope/attribution.go
+++ b/decentralized-api/internal/agentenvelope/attribution.go
@@ -50,8 +50,16 @@ func NewAttributionEmitter(capacity int, sink AttributionSink) *AttributionEmitt
 func (e *AttributionEmitter) drain() {
 	defer e.wg.Done()
 	for ev := range e.ch {
-		e.sink.Emit(ev)
+		e.emitOne(ev)
 	}
+}
+
+// emitOne forwards one event to the sink. The call is recovered so a panicking
+// sink drops a single event rather than crashing the drain goroutine, which in
+// Go would terminate the whole process.
+func (e *AttributionEmitter) emitOne(ev AttributionEvent) {
+	defer func() { _ = recover() }()
+	e.sink.Emit(ev)
 }
 
 // Enqueue submits an event for asynchronous emission. It never blocks. If the

--- a/decentralized-api/internal/agentenvelope/attribution_test.go
+++ b/decentralized-api/internal/agentenvelope/attribution_test.go
@@ -118,3 +118,26 @@ func TestAttributionEmitter_CloseIdempotent(t *testing.T) {
 	e.Close()
 	e.Close()
 }
+
+// panicSink panics on its first Emit. An unrecovered panic in the drain
+// goroutine would terminate the process, so the emitter must isolate it.
+type panicSink struct{ calls int }
+
+func (s *panicSink) Emit(ev AttributionEvent) {
+	s.calls++
+	if s.calls == 1 {
+		panic("sink failure")
+	}
+}
+
+func TestAttributionEmitter_SinkPanicDoesNotKillDrain(t *testing.T) {
+	sink := &panicSink{}
+	e := NewAttributionEmitter(8, sink)
+	for i := 0; i < 3; i++ {
+		e.Enqueue(AttributionEvent{InferenceID: "x"})
+	}
+	e.Close()
+	if sink.calls != 3 {
+		t.Errorf("sink Emit called %d times, want 3 (drain survived the panic)", sink.calls)
+	}
+}

--- a/decentralized-api/internal/agentenvelope/attribution_test.go
+++ b/decentralized-api/internal/agentenvelope/attribution_test.go
@@ -1,0 +1,120 @@
+package agentenvelope
+
+import (
+	"sync"
+	"testing"
+)
+
+// recordingSink keeps every emitted event. Only the single drain goroutine
+// writes to it; tests read it after Close, which waits for that goroutine.
+type recordingSink struct {
+	events []AttributionEvent
+}
+
+func (s *recordingSink) Emit(ev AttributionEvent) { s.events = append(s.events, ev) }
+
+func TestAttributionEmitter_HappyPath(t *testing.T) {
+	sink := &recordingSink{}
+	e := NewAttributionEmitter(8, sink)
+	for i := 0; i < 3; i++ {
+		e.Enqueue(AttributionEvent{InferenceID: "inf"})
+	}
+	e.Close()
+	if len(sink.events) != 3 {
+		t.Errorf("emitted %d events, want 3", len(sink.events))
+	}
+	if e.Dropped() != 0 {
+		t.Errorf("dropped %d, want 0", e.Dropped())
+	}
+}
+
+// blockingSink blocks inside the first Emit until released, so a test can hold
+// the drain goroutine still and fill the bounded channel deterministically.
+type blockingSink struct {
+	started chan struct{}
+	release chan struct{}
+	count   int
+}
+
+func (s *blockingSink) Emit(ev AttributionEvent) {
+	if s.count == 0 {
+		close(s.started)
+		<-s.release
+	}
+	s.count++
+}
+
+func TestAttributionEmitter_DropsWhenFull(t *testing.T) {
+	sink := &blockingSink{started: make(chan struct{}), release: make(chan struct{})}
+	e := NewAttributionEmitter(4, sink)
+
+	// The first event is taken by the drain goroutine, which then blocks
+	// inside Emit. The channel buffer is now empty.
+	e.Enqueue(AttributionEvent{InferenceID: "blocking"})
+	<-sink.started
+
+	// Fill the bounded channel (capacity 4).
+	for i := 0; i < 4; i++ {
+		e.Enqueue(AttributionEvent{InferenceID: "buffered"})
+	}
+	// Two more events must be dropped.
+	e.Enqueue(AttributionEvent{InferenceID: "dropped"})
+	e.Enqueue(AttributionEvent{InferenceID: "dropped"})
+	if got := e.Dropped(); got != 2 {
+		t.Errorf("dropped %d, want 2", got)
+	}
+
+	close(sink.release)
+	e.Close()
+	if sink.count != 5 {
+		t.Errorf("emitted %d events, want 5 (1 blocking + 4 buffered)", sink.count)
+	}
+}
+
+type countingSink struct{ count int }
+
+func (s *countingSink) Emit(ev AttributionEvent) { s.count++ }
+
+func TestAttributionEmitter_ConcurrentProducers(t *testing.T) {
+	sink := &countingSink{}
+	e := NewAttributionEmitter(1024, sink)
+
+	const producers, perProducer = 8, 2000
+	var wg sync.WaitGroup
+	for p := 0; p < producers; p++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perProducer; i++ {
+				e.Enqueue(AttributionEvent{InferenceID: "concurrent"})
+			}
+		}()
+	}
+	wg.Wait()
+	e.Close()
+
+	total := producers * perProducer
+	if sink.count+int(e.Dropped()) != total {
+		t.Errorf("emitted %d + dropped %d = %d, want %d",
+			sink.count, e.Dropped(), sink.count+int(e.Dropped()), total)
+	}
+}
+
+func TestAttributionEmitter_EnqueueAfterCloseDrops(t *testing.T) {
+	sink := &recordingSink{}
+	e := NewAttributionEmitter(8, sink)
+	e.Close()
+	e.Enqueue(AttributionEvent{InferenceID: "after-close"})
+	if e.Dropped() != 1 {
+		t.Errorf("dropped %d, want 1", e.Dropped())
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("emitted %d events after close, want 0", len(sink.events))
+	}
+}
+
+func TestAttributionEmitter_CloseIdempotent(t *testing.T) {
+	e := NewAttributionEmitter(8, &recordingSink{})
+	e.Close()
+	e.Close()
+}

--- a/decentralized-api/internal/agentenvelope/beneficiary.go
+++ b/decentralized-api/internal/agentenvelope/beneficiary.go
@@ -1,0 +1,35 @@
+package agentenvelope
+
+import "unicode/utf8"
+
+// validateBeneficiary checks the optional principal-attested beneficiary
+// string.
+//
+// Per architectural principle P10 it rejects, it never transforms. The
+// beneficiary is part of the principal-signed envelope. Silently stripping or
+// normalizing it before logging would break the equivalence between what the
+// principal signed and what the network records, so a beneficiary that cannot
+// be logged verbatim and safely is treated as a malformed envelope.
+//
+// An empty beneficiary is allowed: the field is optional. A non-empty
+// beneficiary is rejected if it exceeds the byte limit, is not valid UTF-8, or
+// contains any Unicode Cc control character (the C0 range U+0000-U+001F and
+// the C1 range U+007F-U+009F). The control-character rule closes the log
+// injection vector.
+func validateBeneficiary(b string) error {
+	if b == "" {
+		return nil
+	}
+	if len(b) > MaxBeneficiaryBytes {
+		return ErrBeneficiaryInvalid
+	}
+	if !utf8.ValidString(b) {
+		return ErrBeneficiaryInvalid
+	}
+	for _, r := range b {
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
+			return ErrBeneficiaryInvalid
+		}
+	}
+	return nil
+}

--- a/decentralized-api/internal/agentenvelope/beneficiary_test.go
+++ b/decentralized-api/internal/agentenvelope/beneficiary_test.go
@@ -1,0 +1,39 @@
+package agentenvelope
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateBeneficiary_Valid(t *testing.T) {
+	cases := []string{
+		"",
+		"urn:customer:acme-corp",
+		"a beneficiary with spaces",
+		"unicode-é-is-fine",
+		strings.Repeat("a", MaxBeneficiaryBytes),
+	}
+	for _, b := range cases {
+		if err := validateBeneficiary(b); err != nil {
+			t.Errorf("validateBeneficiary(%q) = %v, want nil", b, err)
+		}
+	}
+}
+
+func TestValidateBeneficiary_Rejected(t *testing.T) {
+	// Control characters are built with string(rune(...)) so the test source
+	// stays printable ASCII.
+	cases := map[string]string{
+		"newline":      "customer" + string(rune(0x0a)) + "injected-log-line",
+		"escape":       "customer" + string(rune(0x1b)) + "attack",
+		"del":          "customer" + string(rune(0x7f)) + "del",
+		"c1 control":   "customer" + string(rune(0x85)) + "nel",
+		"too long":     strings.Repeat("a", MaxBeneficiaryBytes+1),
+		"invalid utf8": string([]byte{0x66, 0x6f, 0xff}),
+	}
+	for name, b := range cases {
+		if err := validateBeneficiary(b); err != ErrBeneficiaryInvalid {
+			t.Errorf("%s: validateBeneficiary = %v, want ErrBeneficiaryInvalid", name, err)
+		}
+	}
+}

--- a/decentralized-api/internal/agentenvelope/context.go
+++ b/decentralized-api/internal/agentenvelope/context.go
@@ -1,0 +1,46 @@
+package agentenvelope
+
+import (
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// echoContextKey is the Echo context key under which a verified Context is
+// stored by the middleware and read by the handler.
+const echoContextKey = "aps_agent_envelope_context"
+
+// Context is the verified result the middleware attaches to the request.
+//
+// RequestBound is the forward-compatibility guard from architectural principle
+// P15. The middleware verifies the envelope crypto and scope and sets
+// RequestBound to false. The handler sets it to true only after it confirms
+// the envelope principal matches the parsed requester address, or resolves
+// that link through an authz grant. Attribution is emitted only when
+// RequestBound is true.
+type Context struct {
+	Envelope          *EnvelopeV1
+	EnvelopeSHA256    string
+	RequestBodySHA256 string
+	VerifiedAt        time.Time
+	RequestBound      bool
+}
+
+// SetEchoContext stores a verified Context on the Echo request context.
+func SetEchoContext(c echo.Context, apsCtx *Context) {
+	c.Set(echoContextKey, apsCtx)
+}
+
+// FromEchoContext returns the verified Context attached to the Echo request
+// context, or nil if the request carried no agent envelope.
+func FromEchoContext(c echo.Context) *Context {
+	v := c.Get(echoContextKey)
+	if v == nil {
+		return nil
+	}
+	apsCtx, ok := v.(*Context)
+	if !ok {
+		return nil
+	}
+	return apsCtx
+}

--- a/decentralized-api/internal/agentenvelope/errors.go
+++ b/decentralized-api/internal/agentenvelope/errors.go
@@ -1,0 +1,99 @@
+package agentenvelope
+
+import "net/http"
+
+// EnvelopeError is a verification failure with a stable machine-readable code
+// and the HTTP status the middleware should return.
+//
+// Status mapping follows architectural principle P14:
+//   - 400: the request is structurally malformed (bad base64, bad JSON, a
+//     header pair where one of the two headers is missing).
+//   - 401: a credential is wrong. The client must rebuild the envelope. This
+//     covers bad signatures, wrong chain_id, wrong audience, an unknown
+//     version, an address that does not derive from the embedded pubkey, a
+//     wrong pubkey type, and an invalid beneficiary.
+//   - 403: the credential is valid but the request is not permitted. This
+//     covers expiry, not-yet-valid, an over-long TTL, a model outside scope,
+//     an explicit deny-all model list, and a principal that does not match
+//     the requester.
+//   - 413: the request body exceeds the configured maximum.
+//   - 500: an internal error, including a chain query failure during authz
+//     grantee resolution.
+type EnvelopeError struct {
+	code   string
+	status int
+	msg    string
+}
+
+// Error implements the error interface.
+func (e *EnvelopeError) Error() string { return e.msg }
+
+// Code returns the stable machine-readable error code.
+func (e *EnvelopeError) Code() string { return e.code }
+
+// HTTPStatus returns the HTTP status code the middleware should return.
+func (e *EnvelopeError) HTTPStatus() int { return e.status }
+
+func newErr(code string, status int, msg string) *EnvelopeError {
+	return &EnvelopeError{code: code, status: status, msg: msg}
+}
+
+// Named verification errors. The verifier returns these so the middleware can
+// map a single failure to a stable code and the correct HTTP status.
+var (
+	// 400 structural.
+	ErrSigHeaderMismatch = newErr("sig_header_mismatch", http.StatusBadRequest,
+		"agentenvelope: one of X-Agent-Passport or X-Agent-Sig is present without the other")
+	ErrHeaderMalformed = newErr("header_malformed", http.StatusBadRequest,
+		"agentenvelope: a passport header is not valid base64")
+	ErrEnvelopeMalformed = newErr("envelope_malformed", http.StatusBadRequest,
+		"agentenvelope: the envelope is not valid JSON or is missing a required field")
+
+	// 401 credential wrong.
+	ErrVersionUnknown = newErr("version_unknown", http.StatusUnauthorized,
+		"agentenvelope: unknown envelope schema version")
+	ErrAudienceMismatch = newErr("audience_mismatch", http.StatusUnauthorized,
+		"agentenvelope: envelope audience does not match this verifier")
+	ErrChainIDMismatch = newErr("chain_id_mismatch", http.StatusUnauthorized,
+		"agentenvelope: envelope chain_id does not match this verifier")
+	ErrPrincipalPubkeyTypeInvalid = newErr("principal_pubkey_type_invalid", http.StatusUnauthorized,
+		"agentenvelope: principal pubkey type is not secp256k1")
+	ErrPrincipalPubkeyMalformed = newErr("principal_pubkey_malformed", http.StatusUnauthorized,
+		"agentenvelope: principal pubkey is not a valid compressed secp256k1 key")
+	ErrPrincipalMultisigUnsupported = newErr("principal_multisig_unsupported", http.StatusUnauthorized,
+		"agentenvelope: multi-signature principal keys are not supported in v1")
+	ErrPrincipalAddressMismatch = newErr("principal_address_mismatch", http.StatusUnauthorized,
+		"agentenvelope: principal address does not derive from the embedded pubkey")
+	ErrAgentPubkeyTypeInvalid = newErr("agent_pubkey_type_invalid", http.StatusUnauthorized,
+		"agentenvelope: agent pubkey type is not ed25519")
+	ErrAgentPubkeyMalformed = newErr("agent_pubkey_malformed", http.StatusUnauthorized,
+		"agentenvelope: agent pubkey is not a valid 32-byte ed25519 key")
+	ErrBeneficiaryInvalid = newErr("beneficiary_invalid", http.StatusUnauthorized,
+		"agentenvelope: beneficiary contains control characters, invalid UTF-8, or exceeds the byte limit")
+	ErrPrincipalSigInvalid = newErr("principal_sig_invalid", http.StatusUnauthorized,
+		"agentenvelope: principal signature verification failed")
+	ErrAgentSigInvalid = newErr("agent_sig_invalid", http.StatusUnauthorized,
+		"agentenvelope: agent signature verification failed")
+
+	// 403 not permitted.
+	ErrTTLTooLong = newErr("ttl_too_long", http.StatusForbidden,
+		"agentenvelope: envelope lifetime exceeds the configured maximum TTL")
+	ErrEnvelopeNotYetValid = newErr("envelope_not_yet_valid", http.StatusForbidden,
+		"agentenvelope: envelope not_before is in the future")
+	ErrEnvelopeExpired = newErr("envelope_expired", http.StatusForbidden,
+		"agentenvelope: envelope has expired")
+	ErrAllowedModelsEmpty = newErr("allowed_models_empty", http.StatusForbidden,
+		"agentenvelope: envelope scope allows zero models")
+	ErrModelNotAllowed = newErr("model_not_allowed", http.StatusForbidden,
+		"agentenvelope: requested model is not in the envelope scope")
+	ErrPrincipalMismatch = newErr("principal_mismatch", http.StatusForbidden,
+		"agentenvelope: envelope principal does not match the requester and no authz grant resolves it")
+
+	// 413 body bound.
+	ErrBodyTooLarge = newErr("body_too_large", http.StatusRequestEntityTooLarge,
+		"agentenvelope: request body exceeds the configured maximum size")
+
+	// 500 internal.
+	ErrChainQueryFailed = newErr("chain_query_failed", http.StatusInternalServerError,
+		"agentenvelope: authz grantee resolution chain query failed")
+)

--- a/decentralized-api/internal/agentenvelope/jcs/jcs.go
+++ b/decentralized-api/internal/agentenvelope/jcs/jcs.go
@@ -1,0 +1,183 @@
+// Package jcs implements the RFC 8785 JSON Canonicalization Scheme.
+//
+// JCS produces a deterministic, byte-stable serialization of a JSON value so
+// that a signature produced over one serialization verifies against an
+// independently produced serialization of the same logical value. The agent
+// envelope relies on this for cross-implementation signature verification: a
+// passport canonicalized by an APS client SDK must produce the same bytes
+// when re-canonicalized here in Go before the principal signature is checked.
+//
+// Gonka's existing utils.CanonicalizeJSON is not RFC 8785 strict. It re-encodes
+// through encoding/json, which appends a trailing newline, re-formats numbers
+// through float64, and escapes U+2028 and U+2029. This package vendors a
+// strict implementation rather than depending on it.
+//
+// Number handling: the agent envelope schema contains no JSON numbers (every
+// field is a string, an object, or an array of strings). Numbers are still
+// canonicalized for completeness. Integer values within the IEEE-754 double
+// safe-integer range are emitted as plain decimals. Non-integer values are
+// emitted with Go shortest round-trip formatting, which matches the ECMAScript
+// algorithm for common cases. Callers that canonicalize arbitrary non-integer
+// numbers should verify the result against RFC 8785 Appendix B.
+package jcs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strconv"
+	"unicode/utf16"
+)
+
+// Canonicalize parses input as a single JSON value and returns its RFC 8785
+// canonical serialization. It returns an error if input is not valid JSON or
+// contains trailing content after the first value.
+func Canonicalize(input []byte) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(input))
+	dec.UseNumber()
+
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		return nil, fmt.Errorf("jcs: parse input: %w", err)
+	}
+
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); err != io.EOF {
+		return nil, fmt.Errorf("jcs: unexpected trailing content after JSON value")
+	}
+
+	var buf bytes.Buffer
+	if err := write(&buf, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func write(buf *bytes.Buffer, v interface{}) error {
+	switch t := v.(type) {
+	case nil:
+		buf.WriteString("null")
+	case bool:
+		if t {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case string:
+		writeString(buf, t)
+	case json.Number:
+		s, err := canonicalNumber(string(t))
+		if err != nil {
+			return err
+		}
+		buf.WriteString(s)
+	case []interface{}:
+		buf.WriteByte('[')
+		for i, e := range t {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := write(buf, e); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case map[string]interface{}:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sortKeys(keys)
+		buf.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			writeString(buf, k)
+			buf.WriteByte(':')
+			if err := write(buf, t[k]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	default:
+		return fmt.Errorf("jcs: unsupported JSON type %T", v)
+	}
+	return nil
+}
+
+// sortKeys orders object member names by their UTF-16 code units, per
+// RFC 8785 section 3.2.3.
+func sortKeys(keys []string) {
+	sort.Slice(keys, func(i, j int) bool {
+		return lessUTF16(keys[i], keys[j])
+	})
+}
+
+func lessUTF16(a, b string) bool {
+	ua := utf16.Encode([]rune(a))
+	ub := utf16.Encode([]rune(b))
+	for i := 0; i < len(ua) && i < len(ub); i++ {
+		if ua[i] != ub[i] {
+			return ua[i] < ub[i]
+		}
+	}
+	return len(ua) < len(ub)
+}
+
+const hexDigits = "0123456789abcdef"
+
+// writeString emits s as a JSON string using RFC 8785 escaping: the seven
+// short escapes, \u00XX with lowercase hex for the remaining C0 control
+// characters, and literal UTF-8 for everything else. U+2028 and U+2029 are
+// emitted literally, matching ECMAScript JSON.stringify.
+func writeString(buf *bytes.Buffer, s string) {
+	buf.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		case '\b':
+			buf.WriteString(`\b`)
+		case '\f':
+			buf.WriteString(`\f`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '\t':
+			buf.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				buf.WriteString(`\u00`)
+				buf.WriteByte(hexDigits[(r>>4)&0xf])
+				buf.WriteByte(hexDigits[r&0xf])
+			} else {
+				buf.WriteRune(r)
+			}
+		}
+	}
+	buf.WriteByte('"')
+}
+
+// canonicalNumber returns the RFC 8785 canonical serialization of a JSON
+// number given in its original textual form.
+func canonicalNumber(raw string) (string, error) {
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return "", fmt.Errorf("jcs: invalid number %q: %w", raw, err)
+	}
+	if math.IsInf(f, 0) || math.IsNaN(f) {
+		return "", fmt.Errorf("jcs: non-finite number %q", raw)
+	}
+	if f == math.Trunc(f) && math.Abs(f) < (1<<53) {
+		// Integer in the safe-integer range. Normalizes -0 to 0.
+		return strconv.FormatInt(int64(f), 10), nil
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64), nil
+}

--- a/decentralized-api/internal/agentenvelope/jcs/jcs.go
+++ b/decentralized-api/internal/agentenvelope/jcs/jcs.go
@@ -1,4 +1,7 @@
-// Package jcs implements the RFC 8785 JSON Canonicalization Scheme.
+// Package jcs implements RFC 8785 JSON Canonicalization (JCS) as used by the
+// agent envelope: object key ordering, minimal string escaping, and UTF-8
+// output. It is scoped to the envelope schema rather than offered as a
+// general-purpose RFC 8785 library; see the number and Unicode notes below.
 //
 // JCS produces a deterministic, byte-stable serialization of a JSON value so
 // that a signature produced over one serialization verifies against an
@@ -19,6 +22,11 @@
 // emitted with Go shortest round-trip formatting, which matches the ECMAScript
 // algorithm for common cases. Callers that canonicalize arbitrary non-integer
 // numbers should verify the result against RFC 8785 Appendix B.
+//
+// Unicode handling: input is expected to be valid UTF-8. The envelope's only
+// free-text field, beneficiary, is UTF-8 validated and control-character
+// rejected before canonicalization, so lone surrogates do not reach this path
+// from a valid envelope. This package does not separately reject them.
 package jcs
 
 import (

--- a/decentralized-api/internal/agentenvelope/jcs/jcs_test.go
+++ b/decentralized-api/internal/agentenvelope/jcs/jcs_test.go
@@ -1,0 +1,98 @@
+package jcs
+
+import "testing"
+
+func canon(t *testing.T, in string) string {
+	t.Helper()
+	out, err := Canonicalize([]byte(in))
+	if err != nil {
+		t.Fatalf("Canonicalize(%q) error: %v", in, err)
+	}
+	return string(out)
+}
+
+func TestCanonicalize_KeySortingUTF16(t *testing.T) {
+	// Keys sort by UTF-16 code unit: 'Z'(0x5A) < 'a'(0x61) < 'b'(0x62) < U+00E9.
+	got := canon(t, "{\"b\":\"1\",\"é\":\"4\",\"a\":\"2\",\"Z\":\"3\"}")
+	want := "{\"Z\":\"3\",\"a\":\"2\",\"b\":\"1\",\"é\":\"4\"}"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalize_StringEscapes(t *testing.T) {
+	// The seven short escapes, plus \u00XX lowercase hex for other C0 controls.
+	got := canon(t, `{"k":"a\nb\tcd\"e\\f"}`)
+	want := `{"k":"a\nb\tcd\"e\\f"}`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalize_LineSeparatorNotEscaped(t *testing.T) {
+	// RFC 8785 emits U+2028 literally, unlike Go encoding/json.
+	got := canon(t, "{\"k\":\" \"}")
+	want := "{\"k\":\" \"}"
+	if got != want {
+		t.Errorf("U+2028 should be literal: got %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalize_Nested(t *testing.T) {
+	got := canon(t, `{"outer":{"y":"2","x":"1"},"arr":["c","a","b"]}`)
+	want := `{"arr":["c","a","b"],"outer":{"x":"1","y":"2"}}`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalize_Numbers(t *testing.T) {
+	cases := map[string]string{
+		`{"n":1e2}`:  `{"n":100}`,
+		`{"n":1.0}`:  `{"n":1}`,
+		`{"n":-0}`:   `{"n":0}`,
+		`{"n":0}`:    `{"n":0}`,
+		`{"n":-123}`: `{"n":-123}`,
+	}
+	for in, want := range cases {
+		if got := canon(t, in); got != want {
+			t.Errorf("Canonicalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCanonicalize_LiteralsAndArrays(t *testing.T) {
+	got := canon(t, `{"a":true,"b":false,"c":null,"d":[]}`)
+	want := `{"a":true,"b":false,"c":null,"d":[]}`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalize_Idempotent(t *testing.T) {
+	in := `{"b":"1","a":{"z":"9","y":"8"},"c":["x","w"]}`
+	once := canon(t, in)
+	twice := canon(t, once)
+	if once != twice {
+		t.Errorf("not idempotent: once=%q twice=%q", once, twice)
+	}
+}
+
+func TestCanonicalize_RejectsTrailingContent(t *testing.T) {
+	if _, err := Canonicalize([]byte(`{"a":"1"} {"b":"2"}`)); err == nil {
+		t.Error("expected error for trailing content, got nil")
+	}
+}
+
+func TestCanonicalize_RejectsInvalidJSON(t *testing.T) {
+	if _, err := Canonicalize([]byte(`{"a":}`)); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestCanonicalize_RejectsRawControlChar(t *testing.T) {
+	// A literal unescaped control byte inside a string is invalid JSON.
+	if _, err := Canonicalize([]byte("{\"k\":\"a\x01b\"}")); err == nil {
+		t.Error("expected error for raw control char in string, got nil")
+	}
+}

--- a/decentralized-api/internal/agentenvelope/pubkey.go
+++ b/decentralized-api/internal/agentenvelope/pubkey.go
@@ -1,0 +1,62 @@
+package agentenvelope
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// secp256k1CompressedLen is the byte length of a compressed secp256k1 public key.
+const secp256k1CompressedLen = 33
+
+// decodeAgentPubkey validates an agent TypedKey and returns the ed25519 key.
+// The agent key is always ed25519: it is the portable, network-agnostic
+// per-request signing key.
+func decodeAgentPubkey(tk TypedKey) (ed25519.PublicKey, error) {
+	if tk.Type != KeyTypeEd25519 {
+		return nil, ErrAgentPubkeyTypeInvalid
+	}
+	raw, err := base64.StdEncoding.DecodeString(tk.PublicKey)
+	if err != nil || len(raw) != ed25519.PublicKeySize {
+		return nil, ErrAgentPubkeyMalformed
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+// decodePrincipalPubkey validates a principal TypedKey and returns the
+// secp256k1 key. The principal key is always secp256k1: it anchors to a
+// Gonka account, whose identity model is secp256k1.
+//
+// The type is asserted strictly. Multi-signature principal keys are a real
+// Cosmos primitive but break the single-key signing assumption, so v1 rejects
+// them with a distinct error rather than failing later in an opaque way. This
+// is the algorithm-confusion defense from architectural principle P13.
+func decodePrincipalPubkey(tk TypedKey) (*secp256k1.PubKey, error) {
+	if strings.Contains(strings.ToLower(tk.Type), "multisig") {
+		return nil, ErrPrincipalMultisigUnsupported
+	}
+	if tk.Type != KeyTypeSecp256k1 {
+		return nil, ErrPrincipalPubkeyTypeInvalid
+	}
+	raw, err := base64.StdEncoding.DecodeString(tk.PublicKey)
+	if err != nil || len(raw) != secp256k1CompressedLen {
+		return nil, ErrPrincipalPubkeyMalformed
+	}
+	return &secp256k1.PubKey{Key: raw}, nil
+}
+
+// deriveAddress returns the bech32 account address for a secp256k1 public key,
+// using the SDK's configured account prefix.
+//
+// Derivation is bech32(ripemd160(sha256(compressed_pubkey))). It is one-way
+// verifiable: the verifier requires the derived address to equal the
+// envelope's principal_address. A signature verified by a pubkey that derives
+// to the stated address is equivalent to looking up the same pubkey on chain,
+// so embedding the pubkey in the envelope adds no trust assumption while
+// removing the chain query entirely (architectural principle P3).
+func deriveAddress(pk *secp256k1.PubKey) string {
+	return sdk.AccAddress(pk.Address()).String()
+}

--- a/decentralized-api/internal/agentenvelope/pubkey_test.go
+++ b/decentralized-api/internal/agentenvelope/pubkey_test.go
@@ -1,0 +1,95 @@
+package agentenvelope
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+)
+
+func TestDecodeAgentPubkey_Valid(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk := TypedKey{Type: KeyTypeEd25519, PublicKey: base64.StdEncoding.EncodeToString(pub)}
+	got, err := decodeAgentPubkey(tk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ed25519.PublicKey(got).Equal(pub) {
+		t.Error("decoded key does not match input")
+	}
+}
+
+func TestDecodeAgentPubkey_WrongType(t *testing.T) {
+	tk := TypedKey{Type: KeyTypeSecp256k1, PublicKey: base64.StdEncoding.EncodeToString(make([]byte, 32))}
+	if _, err := decodeAgentPubkey(tk); err != ErrAgentPubkeyTypeInvalid {
+		t.Errorf("got %v, want ErrAgentPubkeyTypeInvalid", err)
+	}
+}
+
+func TestDecodeAgentPubkey_Malformed(t *testing.T) {
+	cases := map[string]TypedKey{
+		"bad base64": {Type: KeyTypeEd25519, PublicKey: "not!base64!"},
+		"wrong len":  {Type: KeyTypeEd25519, PublicKey: base64.StdEncoding.EncodeToString(make([]byte, 31))},
+	}
+	for name, tk := range cases {
+		if _, err := decodeAgentPubkey(tk); err != ErrAgentPubkeyMalformed {
+			t.Errorf("%s: got %v, want ErrAgentPubkeyMalformed", name, err)
+		}
+	}
+}
+
+func TestDecodePrincipalPubkey_Valid(t *testing.T) {
+	pk := secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+	tk := TypedKey{Type: KeyTypeSecp256k1, PublicKey: base64.StdEncoding.EncodeToString(pk.Key)}
+	got, err := decodePrincipalPubkey(tk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equals(pk) {
+		t.Error("decoded key does not match input")
+	}
+}
+
+func TestDecodePrincipalPubkey_WrongType(t *testing.T) {
+	tk := TypedKey{Type: KeyTypeEd25519, PublicKey: base64.StdEncoding.EncodeToString(make([]byte, 33))}
+	if _, err := decodePrincipalPubkey(tk); err != ErrPrincipalPubkeyTypeInvalid {
+		t.Errorf("got %v, want ErrPrincipalPubkeyTypeInvalid", err)
+	}
+}
+
+func TestDecodePrincipalPubkey_Multisig(t *testing.T) {
+	tk := TypedKey{Type: "tendermint/PubKeyMultisigThreshold", PublicKey: base64.StdEncoding.EncodeToString(make([]byte, 33))}
+	if _, err := decodePrincipalPubkey(tk); err != ErrPrincipalMultisigUnsupported {
+		t.Errorf("got %v, want ErrPrincipalMultisigUnsupported", err)
+	}
+}
+
+func TestDecodePrincipalPubkey_Malformed(t *testing.T) {
+	cases := map[string]TypedKey{
+		"bad base64": {Type: KeyTypeSecp256k1, PublicKey: "not!base64!"},
+		"wrong len":  {Type: KeyTypeSecp256k1, PublicKey: base64.StdEncoding.EncodeToString(make([]byte, 32))},
+	}
+	for name, tk := range cases {
+		if _, err := decodePrincipalPubkey(tk); err != ErrPrincipalPubkeyMalformed {
+			t.Errorf("%s: got %v, want ErrPrincipalPubkeyMalformed", name, err)
+		}
+	}
+}
+
+func TestDeriveAddress_Deterministic(t *testing.T) {
+	pk := secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+	a := deriveAddress(pk)
+	b := deriveAddress(pk)
+	if a == "" || a != b {
+		t.Errorf("address derivation not deterministic: %q vs %q", a, b)
+	}
+	other := secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+	if deriveAddress(other) == a {
+		t.Error("distinct keys derived the same address")
+	}
+}

--- a/decentralized-api/internal/agentenvelope/signing.go
+++ b/decentralized-api/internal/agentenvelope/signing.go
@@ -116,21 +116,23 @@ func VerifyPrincipalSig(pk *secp256k1.PubKey, principalAddress string, rawEnvelo
 //	"APS-AGENT-SIG-V1\n" ||
 //	u32_be(len(chain_id))     || chain_id ||
 //	u32_be(len(method))       || method   ||
-//	u32_be(len(path))         || path     ||
+//	u32_be(len(request_uri))  || request_uri ||
 //	u32_be(len(envelope_jcs)) || envelope_jcs ||
 //	u32_be(len(body))         || body
 //
+// request_uri is the full request target, the path together with any query
+// string, so the signature binds the exact endpoint a request was made to.
 // Length prefixes make field boundaries unambiguous: no two distinct field
 // tuples can serialize to the same byte string, which a plain separator could
 // allow. This is the TLS 1.3 transcript and Noise protocol pattern. The body
 // is bounded well below 4 GiB by the body-size limit, so the uint32 length is
 // always exact.
-func AgentSigPayload(chainID, method, path string, envelopeJCS, body []byte) []byte {
+func AgentSigPayload(chainID, method, requestURI string, envelopeJCS, body []byte) []byte {
 	var buf bytes.Buffer
 	buf.WriteString(agentSigDomain)
 	writeLengthPrefixed(&buf, []byte(chainID))
 	writeLengthPrefixed(&buf, []byte(method))
-	writeLengthPrefixed(&buf, []byte(path))
+	writeLengthPrefixed(&buf, []byte(requestURI))
 	writeLengthPrefixed(&buf, envelopeJCS)
 	writeLengthPrefixed(&buf, body)
 	return buf.Bytes()
@@ -147,7 +149,7 @@ func writeLengthPrefixed(buf *bytes.Buffer, b []byte) {
 // length-prefixed payload. The agent key signs the payload directly with pure
 // Ed25519 (RFC 8032), with no SHA-256 prehash: a prehash would be a
 // non-standard construction.
-func VerifyAgentSig(pub ed25519.PublicKey, chainID, method, path string, rawEnvelope, body []byte, sigB64 string) error {
+func VerifyAgentSig(pub ed25519.PublicKey, chainID, method, requestURI string, rawEnvelope, body []byte, sigB64 string) error {
 	sig, err := base64.StdEncoding.DecodeString(sigB64)
 	if err != nil || len(sig) != ed25519.SignatureSize {
 		return ErrAgentSigInvalid
@@ -156,7 +158,7 @@ func VerifyAgentSig(pub ed25519.PublicKey, chainID, method, path string, rawEnve
 	if err != nil {
 		return ErrEnvelopeMalformed
 	}
-	payload := AgentSigPayload(chainID, method, path, envelopeJCS, body)
+	payload := AgentSigPayload(chainID, method, requestURI, envelopeJCS, body)
 	if !ed25519.Verify(pub, payload, sig) {
 		return ErrAgentSigInvalid
 	}

--- a/decentralized-api/internal/agentenvelope/signing.go
+++ b/decentralized-api/internal/agentenvelope/signing.go
@@ -1,0 +1,154 @@
+package agentenvelope
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+
+	"decentralized-api/internal/agentenvelope/jcs"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+)
+
+// agentSigDomain is the domain-separation tag prefixed to every agent signing
+// payload. A fixed protocol tag means an APS agent signature cannot be
+// mistaken for a signature in any other protocol, and the reverse.
+const agentSigDomain = "APS-AGENT-SIG-V1\n"
+
+// principalCanonicalJSON returns the JCS-canonical form of the envelope used
+// for the ADR-036 principal signature: the received envelope with the
+// principal_sig field set to the empty string. The field is present and
+// empty, never absent, so the signer and verifier canonicalize the same shape.
+func principalCanonicalJSON(rawEnvelope []byte) ([]byte, error) {
+	var m map[string]interface{}
+	if err := json.Unmarshal(rawEnvelope, &m); err != nil {
+		return nil, ErrEnvelopeMalformed
+	}
+	m["principal_sig"] = ""
+	re, err := json.Marshal(m)
+	if err != nil {
+		return nil, ErrEnvelopeMalformed
+	}
+	return jcs.Canonicalize(re)
+}
+
+// adr036SignBytes builds the ADR-036 arbitrary-data sign bytes for a signer
+// over data.
+//
+// The structure is the legacy-amino StdSignDoc that Keplr signArbitrary and
+// the cosmos-sdk CLI tx sign-data both produce for off-chain signing: an empty
+// chain_id, account_number and sequence of 0, an empty fee, no memo, and a
+// single sign/MsgSignData message carrying the signer address and the
+// base64-encoded data. account_number, sequence and gas are JSON strings, and
+// fee.amount is an empty array, matching amino JSON.
+//
+// The cosmos-sdk fork in use does not ship a turnkey MsgSignData type, so the
+// document is constructed directly and canonicalized with the same RFC 8785
+// JCS used elsewhere. Amino JSON sorts object keys, which JCS also does, so
+// the output matches the bytes a Keplr or CLI signer hashes and signs.
+func adr036SignBytes(signer string, data []byte) ([]byte, error) {
+	doc := map[string]interface{}{
+		"account_number": "0",
+		"chain_id":       "",
+		"fee":            map[string]interface{}{"amount": []interface{}{}, "gas": "0"},
+		"memo":           "",
+		"msgs": []interface{}{
+			map[string]interface{}{
+				"type": "sign/MsgSignData",
+				"value": map[string]interface{}{
+					"data":   base64.StdEncoding.EncodeToString(data),
+					"signer": signer,
+				},
+			},
+		},
+		"sequence": "0",
+	}
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	return jcs.Canonicalize(raw)
+}
+
+// VerifyPrincipalSig verifies the ADR-036 principal signature over the
+// envelope. pk is the secp256k1 key embedded in the envelope. principalAddress
+// is bound into the ADR-036 message, so a signature is valid only for the
+// address it was produced for.
+//
+// Verification goes through secp256k1.PubKey.VerifySignature, which expects
+// the 64-byte R||S low-S Cosmos signature form and applies the SHA-256 prehash
+// internally. The Go ecdsa package is never used directly: it would produce
+// DER-encoded signatures that do not verify here.
+func VerifyPrincipalSig(pk *secp256k1.PubKey, principalAddress string, rawEnvelope []byte, sigB64 string) error {
+	sig, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil {
+		return ErrPrincipalSigInvalid
+	}
+	canon, err := principalCanonicalJSON(rawEnvelope)
+	if err != nil {
+		return err
+	}
+	signBytes, err := adr036SignBytes(principalAddress, canon)
+	if err != nil {
+		return ErrPrincipalSigInvalid
+	}
+	if !pk.VerifySignature(signBytes, sig) {
+		return ErrPrincipalSigInvalid
+	}
+	return nil
+}
+
+// AgentSigPayload builds the length-prefixed, domain-separated payload an agent
+// signs for one request:
+//
+//	"APS-AGENT-SIG-V1\n" ||
+//	u32_be(len(chain_id))     || chain_id ||
+//	u32_be(len(method))       || method   ||
+//	u32_be(len(path))         || path     ||
+//	u32_be(len(envelope_jcs)) || envelope_jcs ||
+//	u32_be(len(body))         || body
+//
+// Length prefixes make field boundaries unambiguous: no two distinct field
+// tuples can serialize to the same byte string, which a plain separator could
+// allow. This is the TLS 1.3 transcript and Noise protocol pattern. The body
+// is bounded well below 4 GiB by the body-size limit, so the uint32 length is
+// always exact.
+func AgentSigPayload(chainID, method, path string, envelopeJCS, body []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(agentSigDomain)
+	writeLengthPrefixed(&buf, []byte(chainID))
+	writeLengthPrefixed(&buf, []byte(method))
+	writeLengthPrefixed(&buf, []byte(path))
+	writeLengthPrefixed(&buf, envelopeJCS)
+	writeLengthPrefixed(&buf, body)
+	return buf.Bytes()
+}
+
+func writeLengthPrefixed(buf *bytes.Buffer, b []byte) {
+	var lp [4]byte
+	binary.BigEndian.PutUint32(lp[:], uint32(len(b)))
+	buf.Write(lp[:])
+	buf.Write(b)
+}
+
+// VerifyAgentSig verifies the per-request Ed25519 agent signature over the
+// length-prefixed payload. The agent key signs the payload directly with pure
+// Ed25519 (RFC 8032), with no SHA-256 prehash: a prehash would be a
+// non-standard construction.
+func VerifyAgentSig(pub ed25519.PublicKey, chainID, method, path string, rawEnvelope, body []byte, sigB64 string) error {
+	sig, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return ErrAgentSigInvalid
+	}
+	envelopeJCS, err := jcs.Canonicalize(rawEnvelope)
+	if err != nil {
+		return ErrEnvelopeMalformed
+	}
+	payload := AgentSigPayload(chainID, method, path, envelopeJCS, body)
+	if !ed25519.Verify(pub, payload, sig) {
+		return ErrAgentSigInvalid
+	}
+	return nil
+}

--- a/decentralized-api/internal/agentenvelope/signing.go
+++ b/decentralized-api/internal/agentenvelope/signing.go
@@ -72,6 +72,20 @@ func adr036SignBytes(signer string, data []byte) ([]byte, error) {
 	return jcs.Canonicalize(raw)
 }
 
+// PrincipalSignBytes returns the ADR-036 bytes the principal signs to
+// authorize an envelope. A client computes these bytes, signs them with the
+// principal's secp256k1 key, and places the standard-base64 signature in the
+// envelope's principal_sig field. The principal_sig field is emptied before
+// canonicalization, so the caller may pass the envelope JSON with that field
+// absent, empty, or already populated.
+func PrincipalSignBytes(principalAddress string, rawEnvelope []byte) ([]byte, error) {
+	canon, err := principalCanonicalJSON(rawEnvelope)
+	if err != nil {
+		return nil, err
+	}
+	return adr036SignBytes(principalAddress, canon)
+}
+
 // VerifyPrincipalSig verifies the ADR-036 principal signature over the
 // envelope. pk is the secp256k1 key embedded in the envelope. principalAddress
 // is bound into the ADR-036 message, so a signature is valid only for the
@@ -86,13 +100,9 @@ func VerifyPrincipalSig(pk *secp256k1.PubKey, principalAddress string, rawEnvelo
 	if err != nil {
 		return ErrPrincipalSigInvalid
 	}
-	canon, err := principalCanonicalJSON(rawEnvelope)
+	signBytes, err := PrincipalSignBytes(principalAddress, rawEnvelope)
 	if err != nil {
 		return err
-	}
-	signBytes, err := adr036SignBytes(principalAddress, canon)
-	if err != nil {
-		return ErrPrincipalSigInvalid
 	}
 	if !pk.VerifySignature(signBytes, sig) {
 		return ErrPrincipalSigInvalid

--- a/decentralized-api/internal/agentenvelope/signing_cosmjs_test.go
+++ b/decentralized-api/internal/agentenvelope/signing_cosmjs_test.go
@@ -1,0 +1,63 @@
+package agentenvelope
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+)
+
+// The constants below are an ADR-036 signature fixture produced by an
+// independent implementation: the Node script in
+// testdata/adr036_cosmjs_fixture.mjs, which uses @cosmjs/amino and
+// @cosmjs/crypto. That amino signing path is the one Keplr signArbitrary also
+// uses, so a signature accepted here is accepted for a Keplr-signed envelope.
+//
+// The script signs with the fixed private key 0x11 repeated 32 times over the
+// UTF-8 data "aps-cosmjs-cross-check". See the script header to regenerate.
+const (
+	cosmjsPubkeyB64    = "A081W9y3zAr3KO88zrlhXZBoS7Wyyl+FmrDwtwQHWHGq"
+	cosmjsSigner       = "gonka1l3e9pgs3mmwuwrh95fecme0s0qtn2880el49wm"
+	cosmjsDataB64      = "YXBzLWNvc21qcy1jcm9zcy1jaGVjaw=="
+	cosmjsSignDocB64   = "eyJhY2NvdW50X251bWJlciI6IjAiLCJjaGFpbl9pZCI6IiIsImZlZSI6eyJhbW91bnQiOltdLCJnYXMiOiIwIn0sIm1lbW8iOiIiLCJtc2dzIjpbeyJ0eXBlIjoic2lnbi9Nc2dTaWduRGF0YSIsInZhbHVlIjp7ImRhdGEiOiJZWEJ6TFdOdmMyMXFjeTFqY205emN5MWphR1ZqYXc9PSIsInNpZ25lciI6ImdvbmthMWwzZTlwZ3MzbW13dXdyaDk1ZmVjbWUwczBxdG4yODgwZWw0OXdtIn19XSwic2VxdWVuY2UiOiIwIn0="
+	cosmjsSignatureB64 = "Q616U7VuZ48FGTyu+GUMsZ87yR1MQTUW2GeTQTJzq0caZlFO+0iGdLZ7KnxkYpLorBmRsrj8WLnte6ENi2juPw=="
+)
+
+// TestADR036_CosmjsCrossCheck verifies that this package's ADR-036
+// construction matches an independent implementation and accepts a signature
+// it produced.
+func TestADR036_CosmjsCrossCheck(t *testing.T) {
+	data, err := base64.StdEncoding.DecodeString(cosmjsDataB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Our ADR-036 sign-doc bytes must be byte-identical to the bytes the
+	// independent amino serializer produced.
+	got, err := adr036SignBytes(cosmjsSigner, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDoc, err := base64.StdEncoding.DecodeString(cosmjsSignDocB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(wantDoc) {
+		t.Fatalf("ADR-036 sign bytes diverge from cosmjs:\n got:  %s\n want: %s", got, wantDoc)
+	}
+
+	// A signature produced by the independent signer must verify through our
+	// verification path.
+	pkBytes, err := base64.StdEncoding.DecodeString(cosmjsPubkeyB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(cosmjsSignatureB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk := &secp256k1.PubKey{Key: pkBytes}
+	if !pk.VerifySignature(got, sig) {
+		t.Error("cosmjs-produced ADR-036 signature did not verify through VerifySignature")
+	}
+}

--- a/decentralized-api/internal/agentenvelope/signing_test.go
+++ b/decentralized-api/internal/agentenvelope/signing_test.go
@@ -1,0 +1,191 @@
+package agentenvelope
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+
+	"decentralized-api/internal/agentenvelope/jcs"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+)
+
+// sampleEnvelopeJSON returns minimal envelope-shaped JSON for signing tests.
+// Full schema validation is exercised in the verifier tests.
+func sampleEnvelopeJSON(principalSig string) []byte {
+	return []byte(`{"v":"aps-agent-envelope-v1","audience":"gonka",` +
+		`"chain_id":"gonka-test","agent_id":"urn:aps:agent:t",` +
+		`"principal_sig":"` + principalSig + `"}`)
+}
+
+// signPrincipal produces an ADR-036 signature over an envelope, the way a
+// principal SDK would. It returns the standard-base64 signature.
+func signPrincipal(t *testing.T, priv *secp256k1.PrivKey, signer string, rawEnvelope []byte) string {
+	t.Helper()
+	canon, err := principalCanonicalJSON(rawEnvelope)
+	if err != nil {
+		t.Fatalf("principalCanonicalJSON: %v", err)
+	}
+	signBytes, err := adr036SignBytes(signer, canon)
+	if err != nil {
+		t.Fatalf("adr036SignBytes: %v", err)
+	}
+	sig, err := priv.Sign(signBytes)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(sig)
+}
+
+func TestVerifyPrincipalSig_RoundTrip(t *testing.T) {
+	priv := secp256k1.GenPrivKey()
+	pub := priv.PubKey().(*secp256k1.PubKey)
+	addr := deriveAddress(pub)
+
+	env := sampleEnvelopeJSON("")
+	sigB64 := signPrincipal(t, priv, addr, env)
+
+	if err := VerifyPrincipalSig(pub, addr, env, sigB64); err != nil {
+		t.Fatalf("round-trip verify failed: %v", err)
+	}
+	// The same signature verifies when principal_sig is already populated,
+	// since canonicalization empties it.
+	filled := sampleEnvelopeJSON(sigB64)
+	if err := VerifyPrincipalSig(pub, addr, filled, sigB64); err != nil {
+		t.Errorf("verify against populated principal_sig failed: %v", err)
+	}
+}
+
+func TestVerifyPrincipalSig_WrongKeyFails(t *testing.T) {
+	priv := secp256k1.GenPrivKey()
+	pub := priv.PubKey().(*secp256k1.PubKey)
+	addr := deriveAddress(pub)
+	env := sampleEnvelopeJSON("")
+	sigB64 := signPrincipal(t, priv, addr, env)
+
+	other := secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+	if err := VerifyPrincipalSig(other, addr, env, sigB64); err != ErrPrincipalSigInvalid {
+		t.Errorf("got %v, want ErrPrincipalSigInvalid", err)
+	}
+}
+
+func TestVerifyPrincipalSig_WrongSignerAddressFails(t *testing.T) {
+	priv := secp256k1.GenPrivKey()
+	pub := priv.PubKey().(*secp256k1.PubKey)
+	addr := deriveAddress(pub)
+	env := sampleEnvelopeJSON("")
+	sigB64 := signPrincipal(t, priv, addr, env)
+
+	// The ADR-036 message binds the signer address. Verifying with a
+	// different address changes the sign bytes and must fail.
+	otherAddr := deriveAddress(secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey))
+	if err := VerifyPrincipalSig(pub, otherAddr, env, sigB64); err != ErrPrincipalSigInvalid {
+		t.Errorf("got %v, want ErrPrincipalSigInvalid", err)
+	}
+}
+
+func TestVerifyPrincipalSig_TamperedEnvelopeFails(t *testing.T) {
+	priv := secp256k1.GenPrivKey()
+	pub := priv.PubKey().(*secp256k1.PubKey)
+	addr := deriveAddress(pub)
+	env := sampleEnvelopeJSON("")
+	sigB64 := signPrincipal(t, priv, addr, env)
+
+	tampered := []byte(`{"v":"aps-agent-envelope-v1","audience":"gonka",` +
+		`"chain_id":"gonka-OTHER","agent_id":"urn:aps:agent:t","principal_sig":""}`)
+	if err := VerifyPrincipalSig(pub, addr, tampered, sigB64); err != ErrPrincipalSigInvalid {
+		t.Errorf("got %v, want ErrPrincipalSigInvalid", err)
+	}
+}
+
+func TestVerifyPrincipalSig_BadBase64Fails(t *testing.T) {
+	pub := secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+	if err := VerifyPrincipalSig(pub, "addr", sampleEnvelopeJSON(""), "not!base64!"); err != ErrPrincipalSigInvalid {
+		t.Errorf("got %v, want ErrPrincipalSigInvalid", err)
+	}
+}
+
+func TestADR036SignBytes_ReferenceVector(t *testing.T) {
+	// Pins the ADR-036 sign-doc to the documented amino-JSON form. Confirmed
+	// against cosmos-sdk legacytx.StdSignDoc: account_number and sequence are
+	// amino-marshaled as the string "0", timeout_height is the only omitempty
+	// field (so it is absent), and chain_id, memo, and fee are always present.
+	got, err := adr036SignBytes("gonka1test", []byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"account_number":"0","chain_id":"","fee":{"amount":[],"gas":"0"},` +
+		`"memo":"","msgs":[{"type":"sign/MsgSignData","value":` +
+		`{"data":"aGVsbG8=","signer":"gonka1test"}}],"sequence":"0"}`
+	if string(got) != want {
+		t.Errorf("ADR-036 sign bytes diverged from amino-JSON form:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestAgentSigPayload_LengthPrefixUnambiguous(t *testing.T) {
+	// Two field tuples whose naive concatenation would collide must produce
+	// distinct payloads under length prefixing.
+	a := AgentSigPayload("ab", "", "/p", nil, nil)
+	b := AgentSigPayload("a", "b", "/p", nil, nil)
+	if string(a) == string(b) {
+		t.Error("length prefixing failed to disambiguate field boundaries")
+	}
+}
+
+func TestVerifyAgentSig_RoundTrip(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := sampleEnvelopeJSON("sig")
+	body := []byte(`{"model":"Qwen/QwQ-32B"}`)
+
+	canon, err := jcs.Canonicalize(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := AgentSigPayload("gonka-test", "POST", "/v1/chat/completions", canon, body)
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, payload))
+
+	if err := VerifyAgentSig(pub, "gonka-test", "POST", "/v1/chat/completions", env, body, sig); err != nil {
+		t.Fatalf("round-trip verify failed: %v", err)
+	}
+}
+
+func TestVerifyAgentSig_TamperedBodyFails(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := sampleEnvelopeJSON("sig")
+	canon, err := jcs.Canonicalize(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := AgentSigPayload("gonka-test", "POST", "/v1/chat/completions", canon, []byte("original"))
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, payload))
+
+	if err := VerifyAgentSig(pub, "gonka-test", "POST", "/v1/chat/completions", env, []byte("tampered"), sig); err != ErrAgentSigInvalid {
+		t.Errorf("got %v, want ErrAgentSigInvalid", err)
+	}
+}
+
+func TestVerifyAgentSig_TamperedPathFails(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := sampleEnvelopeJSON("sig")
+	canon, err := jcs.Canonicalize(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("b")
+	payload := AgentSigPayload("gonka-test", "POST", "/v1/chat/completions", canon, body)
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, payload))
+
+	if err := VerifyAgentSig(pub, "gonka-test", "POST", "/v1/completions", env, body, sig); err != ErrAgentSigInvalid {
+		t.Errorf("got %v, want ErrAgentSigInvalid", err)
+	}
+}

--- a/decentralized-api/internal/agentenvelope/testdata/adr036_cosmjs_fixture.mjs
+++ b/decentralized-api/internal/agentenvelope/testdata/adr036_cosmjs_fixture.mjs
@@ -1,0 +1,47 @@
+// Regenerates the ADR-036 cross-check fixture used by signing_cosmjs_test.go.
+//
+// Setup and run:
+//   npm install @cosmjs/amino@0.32.4 @cosmjs/crypto@0.32.4 @cosmjs/encoding@0.32.4
+//   node adr036_cosmjs_fixture.mjs
+//
+// Copy the printed JSON fields into the const block in signing_cosmjs_test.go.
+//
+// @cosmjs/amino is the amino signing path that Keplr signArbitrary also uses,
+// so a signature accepted by the Go verifier here is accepted for a
+// Keplr-signed envelope.
+import { Secp256k1, sha256 } from "@cosmjs/crypto";
+import { toBase64, fromHex, toBech32, toUtf8 } from "@cosmjs/encoding";
+import { serializeSignDoc, rawSecp256k1PubkeyToRawAddress } from "@cosmjs/amino";
+
+// Fixed private key so the fixture is reproducible.
+const privkey = fromHex("11".repeat(32));
+const keypair = await Secp256k1.makeKeypair(privkey);
+const compressed = Secp256k1.compressPubkey(keypair.pubkey);
+const signer = toBech32("gonka", rawSecp256k1PubkeyToRawAddress(compressed));
+
+const dataBytes = toUtf8("aps-cosmjs-cross-check");
+const dataB64 = toBase64(dataBytes);
+
+// ADR-036 sign doc: empty chain_id, account_number and sequence "0", empty
+// fee, no memo, a single sign/MsgSignData message.
+const signDoc = {
+  chain_id: "",
+  account_number: "0",
+  sequence: "0",
+  fee: { gas: "0", amount: [] },
+  msgs: [{ type: "sign/MsgSignData", value: { signer, data: dataB64 } }],
+  memo: "",
+};
+const signBytes = serializeSignDoc(signDoc);
+
+const sig = await Secp256k1.createSignature(sha256(signBytes), privkey);
+const sig64 = new Uint8Array([...sig.r(32), ...sig.s(32)]);
+
+console.log(JSON.stringify({
+  pubkey_b64: toBase64(compressed),
+  signer,
+  data_b64: dataB64,
+  signdoc_b64: toBase64(signBytes),
+  signdoc_text: new TextDecoder().decode(signBytes),
+  signature_b64: toBase64(sig64),
+}, null, 2));

--- a/decentralized-api/internal/agentenvelope/types.go
+++ b/decentralized-api/internal/agentenvelope/types.go
@@ -1,0 +1,89 @@
+// Package agentenvelope verifies an optional signed agent request envelope on
+// Gonka inference requests.
+//
+// The envelope is opt-in metadata. When present it carries a cryptographic
+// agent identity, a request-layer delegation scope, and a principal-attested
+// beneficiary reference. It composes with Gonka's existing Developer, Transfer
+// Agent, and Executor signature chain without replacing any part of it. When
+// the envelope headers are absent, request behavior is unchanged.
+//
+// The wire format is APS-compatible (Agent Passport System). Nothing in this
+// package requires Gonka to adopt APS as a network-wide standard; the verifier
+// is self-contained and the schema is versioned.
+package agentenvelope
+
+import "time"
+
+// SchemaVersion is the only envelope schema version this verifier accepts.
+const SchemaVersion = "aps-agent-envelope-v1"
+
+// Audience is the required protocol-surface binding value. It scopes a
+// passport to the Gonka inference surface so a passport signed for this
+// surface cannot be replayed against a different protocol on the same chain.
+const Audience = "gonka"
+
+// Key type tags.
+const (
+	KeyTypeEd25519   = "ed25519"
+	KeyTypeSecp256k1 = "secp256k1"
+)
+
+// MaxBeneficiaryBytes bounds the principal-attested beneficiary string.
+const MaxBeneficiaryBytes = 255
+
+// TypedKey is a curve-tagged public key. PublicKey is the standard-base64
+// encoding of the raw key bytes (32 bytes for ed25519, 33 bytes compressed
+// for secp256k1).
+type TypedKey struct {
+	Type      string `json:"type"`
+	PublicKey string `json:"public_key"`
+}
+
+// Scope carries the request-layer delegation limits the principal attests.
+//
+// AllowedModels uses field-presence semantics, per architectural principle P8:
+//   - nil pointer (field omitted): all models allowed
+//   - non-nil pointer to an empty slice (field present as []): deny all
+//   - non-nil pointer to a non-empty slice: only the listed models allowed
+type Scope struct {
+	AllowedModels *[]string  `json:"allowed_models,omitempty"`
+	ExpiresAt     time.Time  `json:"expires_at"`
+	NotBefore     *time.Time `json:"not_before,omitempty"`
+}
+
+// EnvelopeV1 is the aps-agent-envelope-v1 schema.
+//
+// PrincipalSig is the standard-base64 ADR-036 signature produced by the
+// principal's secp256k1 key over the JCS-canonical envelope with the
+// principal_sig field set to the empty string. The field carries no omitempty
+// tag: it is always present on the wire, and empty during canonicalization.
+type EnvelopeV1 struct {
+	Version          string    `json:"v"`
+	Audience         string    `json:"audience"`
+	ChainID          string    `json:"chain_id"`
+	AgentID          string    `json:"agent_id"`
+	AgentPubkey      TypedKey  `json:"agent_pubkey"`
+	PrincipalAddress string    `json:"principal_address"`
+	PrincipalPubkey  TypedKey  `json:"principal_pubkey"`
+	Scope            Scope     `json:"scope"`
+	Beneficiary      string    `json:"beneficiary,omitempty"`
+	IssuedAt         time.Time `json:"issued_at"`
+	PrincipalSig     string    `json:"principal_sig"`
+}
+
+// AttributionEvent is the structured record emitted after a verified,
+// request-bound inference is submitted to chain. It is observability data in
+// v1, not an on-chain record.
+type AttributionEvent struct {
+	Version           string    `json:"v"`
+	InferenceID       string    `json:"inference_id"`
+	ChainID           string    `json:"chain_id"`
+	Model             string    `json:"model"`
+	AgentID           string    `json:"agent_id"`
+	PrincipalAddress  string    `json:"principal_address"`
+	Beneficiary       string    `json:"beneficiary,omitempty"`
+	RequestBodySHA256 string    `json:"request_body_sha256"`
+	EnvelopeSHA256    string    `json:"envelope_sha256"`
+	PassportExpiresAt time.Time `json:"passport_expires_at"`
+	VerifiedAt        time.Time `json:"verified_at"`
+}

--- a/decentralized-api/internal/agentenvelope/verifier.go
+++ b/decentralized-api/internal/agentenvelope/verifier.go
@@ -1,0 +1,132 @@
+package agentenvelope
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+)
+
+// Config holds the verifier settings a node operator controls.
+type Config struct {
+	// ChainID is the Gonka chain ID this verifier accepts envelopes for.
+	ChainID string
+	// MaxTTL caps the lifetime (expires_at minus issued_at) of any envelope.
+	MaxTTL time.Duration
+}
+
+// Verify runs the envelope verification flow over already-extracted request
+// inputs and returns a verified Context on success.
+//
+// It covers steps 3 through 21 of the documented verification sequence:
+// envelope parse, version, audience, chain_id, TTL, time window, principal and
+// agent key decoding, address derivation, beneficiary validation, the ADR-036
+// principal signature, the per-request agent signature, and the model scope
+// check. Any failure stops the flow and returns the mapped EnvelopeError.
+//
+// Header presence and base64 decoding (steps 1 and 2), the bounded body read
+// (steps 16 and 17), and model extraction are the middleware's responsibility.
+// Verify is transport-agnostic so it can be unit tested without an HTTP stack.
+//
+// rawEnvelope is the base64-decoded X-Agent-Passport JSON. agentSigB64 is the
+// X-Agent-Sig header value. body is the bounded request body. requestedModel
+// is the model named in that body. now is the verification time.
+//
+// On success the returned Context has RequestBound set to false. The handler
+// sets it to true only after it confirms the envelope principal matches the
+// request's requester address, directly or through an authz grant.
+func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, path string, body []byte, requestedModel string, now time.Time) (*Context, error) {
+	// Step 3: envelope parse.
+	var env EnvelopeV1
+	if err := json.Unmarshal(rawEnvelope, &env); err != nil {
+		return nil, ErrEnvelopeMalformed
+	}
+
+	// Step 4: schema version.
+	if env.Version != SchemaVersion {
+		return nil, ErrVersionUnknown
+	}
+	// Step 5: audience binding.
+	if env.Audience != Audience {
+		return nil, ErrAudienceMismatch
+	}
+	// Step 6: chain binding.
+	if env.ChainID != cfg.ChainID {
+		return nil, ErrChainIDMismatch
+	}
+	// Step 7: TTL bound. issued_at is the lifetime anchor.
+	if env.Scope.ExpiresAt.Sub(env.IssuedAt) > cfg.MaxTTL {
+		return nil, ErrTTLTooLong
+	}
+	// Step 8: time window.
+	if env.Scope.NotBefore != nil && now.Before(*env.Scope.NotBefore) {
+		return nil, ErrEnvelopeNotYetValid
+	}
+	if now.After(env.Scope.ExpiresAt) {
+		return nil, ErrEnvelopeExpired
+	}
+
+	// Steps 9 and 10: principal pubkey type assertion and decode.
+	principalPub, err := decodePrincipalPubkey(env.PrincipalPubkey)
+	if err != nil {
+		return nil, err
+	}
+	// Step 11: the embedded pubkey must derive to the stated address.
+	if deriveAddress(principalPub) != env.PrincipalAddress {
+		return nil, ErrPrincipalAddressMismatch
+	}
+	// Steps 12 and 13: agent pubkey type assertion and decode.
+	agentPub, err := decodeAgentPubkey(env.AgentPubkey)
+	if err != nil {
+		return nil, err
+	}
+	// Step 14: beneficiary validation (reject on invalid, never transform).
+	if err := validateBeneficiary(env.Beneficiary); err != nil {
+		return nil, err
+	}
+	// Step 15: ADR-036 principal signature.
+	if err := VerifyPrincipalSig(principalPub, env.PrincipalAddress, rawEnvelope, env.PrincipalSig); err != nil {
+		return nil, err
+	}
+	// Steps 18 and 19: per-request agent signature.
+	if err := VerifyAgentSig(agentPub, cfg.ChainID, method, path, rawEnvelope, body, agentSigB64); err != nil {
+		return nil, err
+	}
+	// Step 20: model scope.
+	if err := checkModelScope(env.Scope, requestedModel); err != nil {
+		return nil, err
+	}
+
+	// Step 21: build the verified context. RequestBound stays false until the
+	// handler confirms the principal/requester link.
+	envHash := sha256.Sum256(rawEnvelope)
+	bodyHash := sha256.Sum256(body)
+	return &Context{
+		Envelope:          &env,
+		EnvelopeSHA256:    hex.EncodeToString(envHash[:]),
+		RequestBodySHA256: hex.EncodeToString(bodyHash[:]),
+		VerifiedAt:        now,
+		RequestBound:      false,
+	}, nil
+}
+
+// checkModelScope enforces the field-presence semantics of allowed_models from
+// architectural principle P8:
+//   - field omitted (nil): all models allowed
+//   - field present and empty: deny all
+//   - field present and non-empty: only the listed models allowed
+func checkModelScope(scope Scope, requestedModel string) error {
+	if scope.AllowedModels == nil {
+		return nil
+	}
+	models := *scope.AllowedModels
+	if len(models) == 0 {
+		return ErrAllowedModelsEmpty
+	}
+	for _, m := range models {
+		if m == requestedModel {
+			return nil
+		}
+	}
+	return ErrModelNotAllowed
+}

--- a/decentralized-api/internal/agentenvelope/verifier.go
+++ b/decentralized-api/internal/agentenvelope/verifier.go
@@ -16,26 +16,6 @@ type Config struct {
 	MaxTTL time.Duration
 }
 
-// Verify runs the envelope verification flow over already-extracted request
-// inputs and returns a verified Context on success.
-//
-// It covers steps 3 through 21 of the documented verification sequence:
-// envelope parse, version, audience, chain_id, TTL, time window, principal and
-// agent key decoding, address derivation, beneficiary validation, the ADR-036
-// principal signature, the per-request agent signature, and the model scope
-// check. Any failure stops the flow and returns the mapped EnvelopeError.
-//
-// Header presence and base64 decoding (steps 1 and 2), the bounded body read
-// (steps 16 and 17), and model extraction are the middleware's responsibility.
-// Verify is transport-agnostic so it can be unit tested without an HTTP stack.
-//
-// rawEnvelope is the base64-decoded X-Agent-Passport JSON. agentSigB64 is the
-// X-Agent-Sig header value. body is the bounded request body. requestedModel
-// is the model named in that body. now is the verification time.
-//
-// On success the returned Context has RequestBound set to false. The handler
-// sets it to true only after it confirms the envelope principal matches the
-// request's requester address, directly or through an authz grant.
 // clockSkewTolerance bounds how far an envelope's issued_at may sit in the
 // future relative to verification time. It absorbs benign client clock skew
 // while rejecting a future-dated issued_at that would otherwise let the TTL
@@ -112,6 +92,26 @@ func hasDuplicateKeys(raw []byte) bool {
 	}
 }
 
+// Verify runs the envelope verification flow over already-extracted request
+// inputs and returns a verified Context on success.
+//
+// It covers steps 3 through 21 of the documented verification sequence:
+// envelope parse, version, audience, chain_id, TTL, time window, principal and
+// agent key decoding, address derivation, beneficiary validation, the ADR-036
+// principal signature, the per-request agent signature, and the model scope
+// check. Any failure stops the flow and returns the mapped EnvelopeError.
+//
+// Header presence and base64 decoding (steps 1 and 2), the bounded body read
+// (steps 16 and 17), and model extraction are the middleware's responsibility.
+// Verify is transport-agnostic so it can be unit tested without an HTTP stack.
+//
+// rawEnvelope is the base64-decoded X-Agent-Passport JSON. agentSigB64 is the
+// X-Agent-Sig header value. body is the bounded request body. requestedModel
+// is the model named in that body. now is the verification time.
+//
+// On success the returned Context has RequestBound set to false. The handler
+// sets it to true only after it confirms the envelope principal matches the
+// request's requester address, directly or through an authz grant.
 func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, path string, body []byte, requestedModel string, now time.Time) (*Context, error) {
 	// Step 3: envelope parse. Duplicate JSON member names are rejected: they
 	// are an I-JSON and RFC 8785 violation and are ambiguous at a signature

--- a/decentralized-api/internal/agentenvelope/verifier.go
+++ b/decentralized-api/internal/agentenvelope/verifier.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"time"
 )
 
@@ -112,12 +113,20 @@ func hasDuplicateKeys(raw []byte) bool {
 // On success the returned Context has RequestBound set to false. The handler
 // sets it to true only after it confirms the envelope principal matches the
 // request's requester address, directly or through an authz grant.
-func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, path string, body []byte, requestedModel string, now time.Time) (*Context, error) {
-	// Step 3: envelope parse. Duplicate JSON member names are rejected: they
-	// are an I-JSON and RFC 8785 violation and are ambiguous at a signature
-	// boundary.
+func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, requestURI string, body []byte, requestedModel string, now time.Time) (*Context, error) {
+	// Step 3: strict envelope parse. A v1 envelope carries only the v1 schema,
+	// so unknown fields are rejected: nothing outside the schema can enter the
+	// signed canonical form. Trailing content after the envelope object and
+	// duplicate member names are rejected too. A duplicate name is an I-JSON
+	// and RFC 8785 violation and is ambiguous at a signature boundary.
+	dec := json.NewDecoder(bytes.NewReader(rawEnvelope))
+	dec.DisallowUnknownFields()
 	var env EnvelopeV1
-	if err := json.Unmarshal(rawEnvelope, &env); err != nil {
+	if err := dec.Decode(&env); err != nil {
+		return nil, ErrEnvelopeMalformed
+	}
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); err != io.EOF {
 		return nil, ErrEnvelopeMalformed
 	}
 	if hasDuplicateKeys(rawEnvelope) {
@@ -139,7 +148,11 @@ func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, path string, b
 	if env.ChainID != cfg.ChainID {
 		return nil, ErrChainIDMismatch
 	}
-	// Step 7: TTL bound. issued_at is the lifetime anchor.
+	// Step 7: TTL bound. issued_at is the lifetime anchor; expires_at must be
+	// strictly after it, and the lifetime must not exceed the configured cap.
+	if !env.Scope.ExpiresAt.After(env.IssuedAt) {
+		return nil, ErrEnvelopeMalformed
+	}
 	if env.Scope.ExpiresAt.Sub(env.IssuedAt) > cfg.MaxTTL {
 		return nil, ErrTTLTooLong
 	}
@@ -179,7 +192,7 @@ func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, path string, b
 		return nil, err
 	}
 	// Steps 18 and 19: per-request agent signature.
-	if err := VerifyAgentSig(agentPub, cfg.ChainID, method, path, rawEnvelope, body, agentSigB64); err != nil {
+	if err := VerifyAgentSig(agentPub, cfg.ChainID, method, requestURI, rawEnvelope, body, agentSigB64); err != nil {
 		return nil, err
 	}
 	// Step 20: model scope.

--- a/decentralized-api/internal/agentenvelope/verifier.go
+++ b/decentralized-api/internal/agentenvelope/verifier.go
@@ -1,6 +1,7 @@
 package agentenvelope
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -60,10 +61,66 @@ func validateEnvelopeRequired(env *EnvelopeV1) error {
 	return nil
 }
 
+// hasDuplicateKeys reports whether any JSON object in raw has a repeated member
+// name. encoding/json silently keeps the last value for a duplicate name; a
+// different implementation may keep the first or reject the input. At a
+// signature boundary that ambiguity is unacceptable, so the verifier rejects
+// an envelope that has it.
+func hasDuplicateKeys(raw []byte) bool {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	type frame struct {
+		object    bool
+		expectKey bool
+		keys      map[string]struct{}
+	}
+	var stack []*frame
+	afterValue := func() {
+		if n := len(stack); n > 0 && stack[n-1].object {
+			stack[n-1].expectKey = true
+		}
+	}
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return false // EOF or malformed: the struct parse reports malformed
+		}
+		if d, ok := tok.(json.Delim); ok {
+			switch d {
+			case '{':
+				stack = append(stack, &frame{object: true, expectKey: true, keys: map[string]struct{}{}})
+			case '[':
+				stack = append(stack, &frame{})
+			case '}', ']':
+				stack = stack[:len(stack)-1]
+				afterValue()
+			}
+			continue
+		}
+		if n := len(stack); n > 0 && stack[n-1].object && stack[n-1].expectKey {
+			key, ok := tok.(string)
+			if !ok {
+				return false // a non-string key is malformed
+			}
+			if _, dup := stack[n-1].keys[key]; dup {
+				return true
+			}
+			stack[n-1].keys[key] = struct{}{}
+			stack[n-1].expectKey = false
+			continue
+		}
+		afterValue()
+	}
+}
+
 func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, path string, body []byte, requestedModel string, now time.Time) (*Context, error) {
-	// Step 3: envelope parse.
+	// Step 3: envelope parse. Duplicate JSON member names are rejected: they
+	// are an I-JSON and RFC 8785 violation and are ambiguous at a signature
+	// boundary.
 	var env EnvelopeV1
 	if err := json.Unmarshal(rawEnvelope, &env); err != nil {
+		return nil, ErrEnvelopeMalformed
+	}
+	if hasDuplicateKeys(rawEnvelope) {
 		return nil, ErrEnvelopeMalformed
 	}
 	if err := validateEnvelopeRequired(&env); err != nil {

--- a/decentralized-api/internal/agentenvelope/verifier.go
+++ b/decentralized-api/internal/agentenvelope/verifier.go
@@ -35,11 +35,39 @@ type Config struct {
 // On success the returned Context has RequestBound set to false. The handler
 // sets it to true only after it confirms the envelope principal matches the
 // request's requester address, directly or through an authz grant.
+// clockSkewTolerance bounds how far an envelope's issued_at may sit in the
+// future relative to verification time. It absorbs benign client clock skew
+// while rejecting a future-dated issued_at that would otherwise let the TTL
+// bound stay small while the real validity window is arbitrarily long.
+const clockSkewTolerance = 30 * time.Second
+
+// validateEnvelopeRequired rejects an envelope missing a field the later
+// verification steps assume is present. Without it a missing field surfaces
+// as an unrelated downstream error: a missing principal_sig as an invalid
+// signature, a missing scope as a TTL violation. A missing field is a
+// malformed envelope.
+func validateEnvelopeRequired(env *EnvelopeV1) error {
+	switch {
+	case env.AgentID == "",
+		env.PrincipalAddress == "",
+		env.PrincipalSig == "",
+		env.AgentPubkey.PublicKey == "",
+		env.PrincipalPubkey.PublicKey == "",
+		env.IssuedAt.IsZero(),
+		env.Scope.ExpiresAt.IsZero():
+		return ErrEnvelopeMalformed
+	}
+	return nil
+}
+
 func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, path string, body []byte, requestedModel string, now time.Time) (*Context, error) {
 	// Step 3: envelope parse.
 	var env EnvelopeV1
 	if err := json.Unmarshal(rawEnvelope, &env); err != nil {
 		return nil, ErrEnvelopeMalformed
+	}
+	if err := validateEnvelopeRequired(&env); err != nil {
+		return nil, err
 	}
 
 	// Step 4: schema version.
@@ -58,7 +86,12 @@ func (cfg Config) Verify(rawEnvelope []byte, agentSigB64, method, path string, b
 	if env.Scope.ExpiresAt.Sub(env.IssuedAt) > cfg.MaxTTL {
 		return nil, ErrTTLTooLong
 	}
-	// Step 8: time window.
+	// Step 8: time window. issued_at must not be meaningfully in the future:
+	// a future-dated issued_at keeps the TTL bound small while the real
+	// wall-clock validity window is arbitrarily long.
+	if env.IssuedAt.After(now.Add(clockSkewTolerance)) {
+		return nil, ErrEnvelopeNotYetValid
+	}
 	if env.Scope.NotBefore != nil && now.Before(*env.Scope.NotBefore) {
 		return nil, ErrEnvelopeNotYetValid
 	}

--- a/decentralized-api/internal/agentenvelope/verifier_test.go
+++ b/decentralized-api/internal/agentenvelope/verifier_test.go
@@ -166,6 +166,9 @@ func TestVerify_FieldErrors(t *testing.T) {
 			e.IssuedAt = h.now.Add(-10 * time.Minute)
 			e.Scope.ExpiresAt = h.now.Add(-time.Minute)
 		}, ErrEnvelopeExpired},
+		{"expires before issued", func(e *EnvelopeV1, h *harness) {
+			e.Scope.ExpiresAt = h.now.Add(-time.Minute)
+		}, ErrEnvelopeMalformed},
 		{"principal pubkey type", func(e *EnvelopeV1, h *harness) { e.PrincipalPubkey.Type = KeyTypeEd25519 }, ErrPrincipalPubkeyTypeInvalid},
 		{"principal pubkey multisig", func(e *EnvelopeV1, h *harness) {
 			e.PrincipalPubkey.Type = "tendermint/PubKeyMultisigThreshold"
@@ -225,6 +228,25 @@ func TestVerify_DuplicateKeyRejected(t *testing.T) {
 	raw, sig := h.sign(h.validEnvelope())
 	// Inject a duplicate "audience" member into the signed envelope JSON.
 	tampered := append([]byte(`{"audience":"injected",`), raw[1:]...)
+	if _, err := h.verify(tampered, sig); err != ErrEnvelopeMalformed {
+		t.Errorf("got %v, want ErrEnvelopeMalformed", err)
+	}
+}
+
+func TestVerify_UnknownFieldRejected(t *testing.T) {
+	h := newHarness(t)
+	raw, sig := h.sign(h.validEnvelope())
+	// Inject an unknown field into the signed envelope JSON.
+	tampered := append([]byte(`{"unknown_field":1,`), raw[1:]...)
+	if _, err := h.verify(tampered, sig); err != ErrEnvelopeMalformed {
+		t.Errorf("got %v, want ErrEnvelopeMalformed", err)
+	}
+}
+
+func TestVerify_TrailingContentRejected(t *testing.T) {
+	h := newHarness(t)
+	raw, sig := h.sign(h.validEnvelope())
+	tampered := []byte(string(raw) + " {}")
 	if _, err := h.verify(tampered, sig); err != ErrEnvelopeMalformed {
 		t.Errorf("got %v, want ErrEnvelopeMalformed", err)
 	}

--- a/decentralized-api/internal/agentenvelope/verifier_test.go
+++ b/decentralized-api/internal/agentenvelope/verifier_test.go
@@ -149,6 +149,12 @@ func TestVerify_FieldErrors(t *testing.T) {
 		want   *EnvelopeError
 	}{
 		{"version", func(e *EnvelopeV1, h *harness) { e.Version = "aps-agent-envelope-v2" }, ErrVersionUnknown},
+		{"missing agent_id", func(e *EnvelopeV1, h *harness) { e.AgentID = "" }, ErrEnvelopeMalformed},
+		{"zero issued_at", func(e *EnvelopeV1, h *harness) { e.IssuedAt = time.Time{} }, ErrEnvelopeMalformed},
+		{"future issued_at", func(e *EnvelopeV1, h *harness) {
+			e.IssuedAt = h.now.Add(time.Hour)
+			e.Scope.ExpiresAt = h.now.Add(90 * time.Minute)
+		}, ErrEnvelopeNotYetValid},
 		{"audience", func(e *EnvelopeV1, h *harness) { e.Audience = "not-gonka" }, ErrAudienceMismatch},
 		{"chain id", func(e *EnvelopeV1, h *harness) { e.ChainID = "other-chain" }, ErrChainIDMismatch},
 		{"ttl too long", func(e *EnvelopeV1, h *harness) { e.Scope.ExpiresAt = h.now.Add(2 * time.Hour) }, ErrTTLTooLong},

--- a/decentralized-api/internal/agentenvelope/verifier_test.go
+++ b/decentralized-api/internal/agentenvelope/verifier_test.go
@@ -201,6 +201,35 @@ func TestVerify_FieldErrors(t *testing.T) {
 	}
 }
 
+func TestHasDuplicateKeys(t *testing.T) {
+	cases := map[string]struct {
+		json string
+		want bool
+	}{
+		"clean object":          {`{"a":1,"b":2}`, false},
+		"nested clean":          {`{"a":{"x":1},"b":{"x":2}}`, false},
+		"array of objects":      {`[{"a":1},{"a":2}]`, false},
+		"top-level duplicate":   {`{"a":1,"a":2}`, true},
+		"nested duplicate":      {`{"x":{"y":1,"y":2}}`, true},
+		"duplicate after value": {`{"x":{"y":1},"x":2}`, true},
+	}
+	for name, tc := range cases {
+		if got := hasDuplicateKeys([]byte(tc.json)); got != tc.want {
+			t.Errorf("%s: hasDuplicateKeys(%s) = %v, want %v", name, tc.json, got, tc.want)
+		}
+	}
+}
+
+func TestVerify_DuplicateKeyRejected(t *testing.T) {
+	h := newHarness(t)
+	raw, sig := h.sign(h.validEnvelope())
+	// Inject a duplicate "audience" member into the signed envelope JSON.
+	tampered := append([]byte(`{"audience":"injected",`), raw[1:]...)
+	if _, err := h.verify(tampered, sig); err != ErrEnvelopeMalformed {
+		t.Errorf("got %v, want ErrEnvelopeMalformed", err)
+	}
+}
+
 func TestVerify_EnvelopeMalformed(t *testing.T) {
 	h := newHarness(t)
 	if _, err := h.verify([]byte("{not valid json"), ""); err != ErrEnvelopeMalformed {

--- a/decentralized-api/internal/agentenvelope/verifier_test.go
+++ b/decentralized-api/internal/agentenvelope/verifier_test.go
@@ -1,0 +1,241 @@
+package agentenvelope
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"decentralized-api/internal/agentenvelope/jcs"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+)
+
+const (
+	testChainID = "gonka-test"
+	testMethod  = "POST"
+	testPath    = "/v1/chat/completions"
+	testModel   = "Qwen/QwQ-32B"
+)
+
+// harness holds fresh keys and request material for one verifier test.
+type harness struct {
+	t             *testing.T
+	cfg           Config
+	principalPriv *secp256k1.PrivKey
+	principalPub  *secp256k1.PubKey
+	agentPriv     ed25519.PrivateKey
+	agentPub      ed25519.PublicKey
+	now           time.Time
+	body          []byte
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	pp := secp256k1.GenPrivKey()
+	apub, apriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &harness{
+		t:             t,
+		cfg:           Config{ChainID: testChainID, MaxTTL: time.Hour},
+		principalPriv: pp,
+		principalPub:  pp.PubKey().(*secp256k1.PubKey),
+		agentPriv:     apriv,
+		agentPub:      apub,
+		now:           time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC),
+		body:          []byte(`{"model":"` + testModel + `","messages":[]}`),
+	}
+}
+
+// validEnvelope returns a default well-formed envelope for the harness keys.
+func (h *harness) validEnvelope() *EnvelopeV1 {
+	models := []string{testModel}
+	return &EnvelopeV1{
+		Version:          SchemaVersion,
+		Audience:         Audience,
+		ChainID:          testChainID,
+		AgentID:          "urn:aps:agent:test",
+		AgentPubkey:      TypedKey{Type: KeyTypeEd25519, PublicKey: base64.StdEncoding.EncodeToString(h.agentPub)},
+		PrincipalAddress: deriveAddress(h.principalPub),
+		PrincipalPubkey:  TypedKey{Type: KeyTypeSecp256k1, PublicKey: base64.StdEncoding.EncodeToString(h.principalPub.Key)},
+		Scope: Scope{
+			AllowedModels: &models,
+			ExpiresAt:     h.now.Add(30 * time.Minute),
+		},
+		Beneficiary: "urn:customer:acme-corp",
+		IssuedAt:    h.now,
+	}
+}
+
+// sign serializes env, produces the ADR-036 principal signature with the
+// harness principal key and the per-request agent signature with the harness
+// agent key, and returns the wire envelope and the agent signature header.
+func (h *harness) sign(env *EnvelopeV1) (rawEnvelope []byte, agentSigB64 string) {
+	h.t.Helper()
+	env.PrincipalSig = ""
+	unsigned, err := json.Marshal(env)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	canon, err := principalCanonicalJSON(unsigned)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	signBytes, err := adr036SignBytes(env.PrincipalAddress, canon)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	psig, err := h.principalPriv.Sign(signBytes)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	env.PrincipalSig = base64.StdEncoding.EncodeToString(psig)
+	rawEnvelope, err = json.Marshal(env)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	envJCS, err := jcs.Canonicalize(rawEnvelope)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	payload := AgentSigPayload(testChainID, testMethod, testPath, envJCS, h.body)
+	return rawEnvelope, base64.StdEncoding.EncodeToString(ed25519.Sign(h.agentPriv, payload))
+}
+
+// verify runs the harness default request against the verifier.
+func (h *harness) verify(raw []byte, agentSig string) (*Context, error) {
+	return h.cfg.Verify(raw, agentSig, testMethod, testPath, h.body, testModel, h.now)
+}
+
+func TestVerify_HappyPath(t *testing.T) {
+	h := newHarness(t)
+	raw, sig := h.sign(h.validEnvelope())
+	ctx, err := h.verify(raw, sig)
+	if err != nil {
+		t.Fatalf("happy path failed: %v", err)
+	}
+	if ctx == nil || ctx.Envelope == nil {
+		t.Fatal("verified context or envelope is nil")
+	}
+	if ctx.RequestBound {
+		t.Error("RequestBound must be false after the middleware-stage verify")
+	}
+	if ctx.EnvelopeSHA256 == "" || ctx.RequestBodySHA256 == "" {
+		t.Error("verified context is missing content hashes")
+	}
+}
+
+func TestVerify_AllowedModelsOmittedAllowsAll(t *testing.T) {
+	h := newHarness(t)
+	env := h.validEnvelope()
+	env.Scope.AllowedModels = nil
+	raw, sig := h.sign(env)
+	if _, err := h.verify(raw, sig); err != nil {
+		t.Errorf("omitted allowed_models should allow all models, got %v", err)
+	}
+}
+
+// TestVerify_FieldErrors mutates one envelope field before signing and asserts
+// the verifier rejects it with the expected error. Each mutated field is
+// caught by its own step, ahead of the signature checks.
+func TestVerify_FieldErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(e *EnvelopeV1, h *harness)
+		want   *EnvelopeError
+	}{
+		{"version", func(e *EnvelopeV1, h *harness) { e.Version = "aps-agent-envelope-v2" }, ErrVersionUnknown},
+		{"audience", func(e *EnvelopeV1, h *harness) { e.Audience = "not-gonka" }, ErrAudienceMismatch},
+		{"chain id", func(e *EnvelopeV1, h *harness) { e.ChainID = "other-chain" }, ErrChainIDMismatch},
+		{"ttl too long", func(e *EnvelopeV1, h *harness) { e.Scope.ExpiresAt = h.now.Add(2 * time.Hour) }, ErrTTLTooLong},
+		{"not yet valid", func(e *EnvelopeV1, h *harness) {
+			nb := h.now.Add(time.Hour)
+			e.Scope.NotBefore = &nb
+		}, ErrEnvelopeNotYetValid},
+		{"expired", func(e *EnvelopeV1, h *harness) {
+			e.IssuedAt = h.now.Add(-10 * time.Minute)
+			e.Scope.ExpiresAt = h.now.Add(-time.Minute)
+		}, ErrEnvelopeExpired},
+		{"principal pubkey type", func(e *EnvelopeV1, h *harness) { e.PrincipalPubkey.Type = KeyTypeEd25519 }, ErrPrincipalPubkeyTypeInvalid},
+		{"principal pubkey multisig", func(e *EnvelopeV1, h *harness) {
+			e.PrincipalPubkey.Type = "tendermint/PubKeyMultisigThreshold"
+		}, ErrPrincipalMultisigUnsupported},
+		{"principal pubkey malformed", func(e *EnvelopeV1, h *harness) { e.PrincipalPubkey.PublicKey = "not!base64" }, ErrPrincipalPubkeyMalformed},
+		{"principal address mismatch", func(e *EnvelopeV1, h *harness) {
+			e.PrincipalAddress = deriveAddress(secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey))
+		}, ErrPrincipalAddressMismatch},
+		{"agent pubkey type", func(e *EnvelopeV1, h *harness) { e.AgentPubkey.Type = KeyTypeSecp256k1 }, ErrAgentPubkeyTypeInvalid},
+		{"agent pubkey malformed", func(e *EnvelopeV1, h *harness) { e.AgentPubkey.PublicKey = "not!base64" }, ErrAgentPubkeyMalformed},
+		{"beneficiary invalid", func(e *EnvelopeV1, h *harness) {
+			e.Beneficiary = "bad" + string(rune(0x01)) + "control"
+		}, ErrBeneficiaryInvalid},
+		{"allowed models empty", func(e *EnvelopeV1, h *harness) {
+			empty := []string{}
+			e.Scope.AllowedModels = &empty
+		}, ErrAllowedModelsEmpty},
+		{"model not allowed", func(e *EnvelopeV1, h *harness) {
+			m := []string{"some-other-model"}
+			e.Scope.AllowedModels = &m
+		}, ErrModelNotAllowed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			env := h.validEnvelope()
+			tc.mutate(env, h)
+			raw, sig := h.sign(env)
+			if _, err := h.verify(raw, sig); err != tc.want {
+				t.Errorf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerify_EnvelopeMalformed(t *testing.T) {
+	h := newHarness(t)
+	if _, err := h.verify([]byte("{not valid json"), ""); err != ErrEnvelopeMalformed {
+		t.Errorf("got %v, want ErrEnvelopeMalformed", err)
+	}
+}
+
+func TestVerify_PrincipalSigInvalid(t *testing.T) {
+	h := newHarness(t)
+	raw, sig := h.sign(h.validEnvelope())
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	// Replace principal_sig with a well-formed but wrong signature.
+	m["principal_sig"] = base64.StdEncoding.EncodeToString(make([]byte, 64))
+	tampered, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.verify(tampered, sig); err != ErrPrincipalSigInvalid {
+		t.Errorf("got %v, want ErrPrincipalSigInvalid", err)
+	}
+}
+
+func TestVerify_AgentSigInvalid(t *testing.T) {
+	h := newHarness(t)
+	raw, _ := h.sign(h.validEnvelope())
+	wrongSig := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	if _, err := h.verify(raw, wrongSig); err != ErrAgentSigInvalid {
+		t.Errorf("got %v, want ErrAgentSigInvalid", err)
+	}
+}
+
+func TestVerify_TamperedBodyFailsAgentSig(t *testing.T) {
+	h := newHarness(t)
+	raw, sig := h.sign(h.validEnvelope())
+	// A body different from the one the agent signed must fail step 19.
+	_, err := h.cfg.Verify(raw, sig, testMethod, testPath, []byte(`{"model":"`+testModel+`","messages":[{"role":"user"}]}`), testModel, h.now)
+	if err != ErrAgentSigInvalid {
+		t.Errorf("got %v, want ErrAgentSigInvalid", err)
+	}
+}

--- a/decentralized-api/internal/server/middleware/agent_envelope.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope.go
@@ -75,7 +75,7 @@ func AgentEnvelopeMiddleware(enabled bool, cfg agentenvelope.Config, maxBodyByte
 			if merr != nil {
 				return mapEnvelopeError(merr)
 			}
-			apsCtx, verr := cfg.Verify(envelopeJSON, sigHdr, req.Method, req.URL.Path, body, model, time.Now().UTC())
+			apsCtx, verr := cfg.Verify(envelopeJSON, sigHdr, req.Method, req.URL.RequestURI(), body, model, time.Now().UTC())
 			if verr != nil {
 				return mapEnvelopeError(verr)
 			}

--- a/decentralized-api/internal/server/middleware/agent_envelope.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope.go
@@ -1,0 +1,127 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"decentralized-api/internal/agentenvelope"
+
+	"github.com/labstack/echo/v4"
+)
+
+const (
+	headerPassport = "X-Agent-Passport"
+	headerAgentSig = "X-Agent-Sig"
+)
+
+// AgentEnvelopeMiddleware returns Echo middleware that verifies an optional
+// signed agent request envelope on inference completion endpoints.
+//
+// When the X-Agent-Passport header is absent, the request passes through with
+// behavior identical to a node that does not run this middleware. When the
+// header is present, the middleware decodes and verifies the envelope and the
+// per-request agent signature, then attaches a verified agentenvelope.Context
+// to the Echo context for the handler. A verification failure ends the request
+// with the mapped HTTP status.
+//
+// The verified context carries RequestBound false. The handler sets it true
+// only after it confirms the envelope principal matches the request's
+// requester address, directly or through an authz grant.
+//
+// enabled gates the whole middleware: when false it is a pure passthrough, so
+// the middleware can be mounted unconditionally and toggled by config.
+func AgentEnvelopeMiddleware(enabled bool, cfg agentenvelope.Config, maxBodyBytes int64) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if !enabled {
+				return next(c)
+			}
+			req := c.Request()
+			passportHdr := req.Header.Get(headerPassport)
+			sigHdr := req.Header.Get(headerAgentSig)
+
+			// Step 1: header presence. An absent passport is a passthrough.
+			// One header without the other is a malformed request.
+			if passportHdr == "" && sigHdr == "" {
+				return next(c)
+			}
+			if passportHdr == "" || sigHdr == "" {
+				return envelopeHTTPError(agentenvelope.ErrSigHeaderMismatch)
+			}
+
+			// Step 2: decode the passport header to envelope JSON. The
+			// signature header is decoded only to reject a malformed header as
+			// 400; the verifier re-decodes it from the original string.
+			envelopeJSON, err := base64.StdEncoding.DecodeString(passportHdr)
+			if err != nil {
+				return envelopeHTTPError(agentenvelope.ErrHeaderMalformed)
+			}
+			if _, err := base64.StdEncoding.DecodeString(sigHdr); err != nil {
+				return envelopeHTTPError(agentenvelope.ErrHeaderMalformed)
+			}
+
+			// Steps 16 and 17: bounded body read, then restore for the handler.
+			body, err := readBoundedBody(c, maxBodyBytes)
+			if err != nil {
+				return err
+			}
+
+			apsCtx, verr := cfg.Verify(envelopeJSON, sigHdr, req.Method, req.URL.Path, body, extractModel(body), time.Now().UTC())
+			if verr != nil {
+				return mapEnvelopeError(verr)
+			}
+
+			// Step 21: attach the verified context for the handler.
+			agentenvelope.SetEchoContext(c, apsCtx)
+			return next(c)
+		}
+	}
+}
+
+// readBoundedBody reads at most maxBytes from the request body, then restores
+// the body so the downstream handler can read it again. A body over the limit
+// returns 413; any other read error is treated as a malformed request.
+func readBoundedBody(c echo.Context, maxBytes int64) ([]byte, error) {
+	limited := http.MaxBytesReader(c.Response().Writer, c.Request().Body, maxBytes)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return nil, envelopeHTTPError(agentenvelope.ErrBodyTooLarge)
+		}
+		return nil, envelopeHTTPError(agentenvelope.ErrEnvelopeMalformed)
+	}
+	c.Request().Body = io.NopCloser(bytes.NewReader(body))
+	return body, nil
+}
+
+// extractModel pulls the model field from an OpenAI-style request body. A body
+// that does not parse yields an empty model, which the scope check treats as
+// a model outside any non-empty allowlist.
+func extractModel(body []byte) string {
+	var parsed struct {
+		Model string `json:"model"`
+	}
+	_ = json.Unmarshal(body, &parsed)
+	return parsed.Model
+}
+
+// mapEnvelopeError converts a verifier error into an Echo HTTP error. Verify
+// only ever returns *agentenvelope.EnvelopeError; anything else is treated as
+// an internal error.
+func mapEnvelopeError(err error) error {
+	var ee *agentenvelope.EnvelopeError
+	if errors.As(err, &ee) {
+		return envelopeHTTPError(ee)
+	}
+	return echo.NewHTTPError(http.StatusInternalServerError, "agentenvelope: internal verification error")
+}
+
+func envelopeHTTPError(ee *agentenvelope.EnvelopeError) error {
+	return echo.NewHTTPError(ee.HTTPStatus(), ee.Code())
+}

--- a/decentralized-api/internal/server/middleware/agent_envelope.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope.go
@@ -105,14 +105,18 @@ func readBoundedBody(c echo.Context, maxBytes int64) ([]byte, error) {
 }
 
 // extractModel pulls the model field from an OpenAI-style request body. The
-// body is part of the signed request, so a body that does not parse is a
-// malformed request, not a scope failure: it returns ErrEnvelopeMalformed
-// rather than an empty model that the scope check would later read as a 403.
+// body is part of the signed request, so a body that does not parse, or that
+// carries no model, is a malformed request rather than a scope failure: it
+// returns ErrEnvelopeMalformed (400) instead of an empty model that the scope
+// check would later read as a 403.
 func extractModel(body []byte) (string, error) {
 	var parsed struct {
 		Model string `json:"model"`
 	}
 	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", agentenvelope.ErrEnvelopeMalformed
+	}
+	if parsed.Model == "" {
 		return "", agentenvelope.ErrEnvelopeMalformed
 	}
 	return parsed.Model, nil

--- a/decentralized-api/internal/server/middleware/agent_envelope.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope.go
@@ -71,7 +71,11 @@ func AgentEnvelopeMiddleware(enabled bool, cfg agentenvelope.Config, maxBodyByte
 				return err
 			}
 
-			apsCtx, verr := cfg.Verify(envelopeJSON, sigHdr, req.Method, req.URL.Path, body, extractModel(body), time.Now().UTC())
+			model, merr := extractModel(body)
+			if merr != nil {
+				return mapEnvelopeError(merr)
+			}
+			apsCtx, verr := cfg.Verify(envelopeJSON, sigHdr, req.Method, req.URL.Path, body, model, time.Now().UTC())
 			if verr != nil {
 				return mapEnvelopeError(verr)
 			}
@@ -100,15 +104,18 @@ func readBoundedBody(c echo.Context, maxBytes int64) ([]byte, error) {
 	return body, nil
 }
 
-// extractModel pulls the model field from an OpenAI-style request body. A body
-// that does not parse yields an empty model, which the scope check treats as
-// a model outside any non-empty allowlist.
-func extractModel(body []byte) string {
+// extractModel pulls the model field from an OpenAI-style request body. The
+// body is part of the signed request, so a body that does not parse is a
+// malformed request, not a scope failure: it returns ErrEnvelopeMalformed
+// rather than an empty model that the scope check would later read as a 403.
+func extractModel(body []byte) (string, error) {
 	var parsed struct {
 		Model string `json:"model"`
 	}
-	_ = json.Unmarshal(body, &parsed)
-	return parsed.Model
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", agentenvelope.ErrEnvelopeMalformed
+	}
+	return parsed.Model, nil
 }
 
 // mapEnvelopeError converts a verifier error into an Echo HTTP error. Verify

--- a/decentralized-api/internal/server/middleware/agent_envelope_integration_test.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope_integration_test.go
@@ -231,6 +231,15 @@ func TestIntegration_MalformedBody(t *testing.T) {
 	}
 }
 
+func TestIntegration_BodyMissingModel(t *testing.T) {
+	e, _ := itServer(t, 10<<20)
+	sr := buildSignedRequest(t, nil)
+	// Valid JSON, but no model field: malformed request, not a scope failure.
+	if rec := sendIT(e, sr, []byte(`{"messages":[]}`)); rec.Code != http.StatusBadRequest {
+		t.Errorf("body with no model: code %d, want 400", rec.Code)
+	}
+}
+
 func BenchmarkMiddleware_AbsentHeader(b *testing.B) {
 	e, _ := itServer(b, 10<<20)
 	b.ResetTimer()

--- a/decentralized-api/internal/server/middleware/agent_envelope_integration_test.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope_integration_test.go
@@ -223,6 +223,14 @@ func TestIntegration_BodyTooLarge(t *testing.T) {
 	}
 }
 
+func TestIntegration_MalformedBody(t *testing.T) {
+	e, _ := itServer(t, 10<<20)
+	sr := buildSignedRequest(t, nil)
+	if rec := sendIT(e, sr, []byte("{not valid json")); rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed body with an envelope present: code %d, want 400", rec.Code)
+	}
+}
+
 func BenchmarkMiddleware_AbsentHeader(b *testing.B) {
 	e, _ := itServer(b, 10<<20)
 	b.ResetTimer()

--- a/decentralized-api/internal/server/middleware/agent_envelope_integration_test.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope_integration_test.go
@@ -1,0 +1,242 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"decentralized-api/internal/agentenvelope"
+	"decentralized-api/internal/agentenvelope/jcs"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/labstack/echo/v4"
+)
+
+const (
+	itChainID = "gonka-integration"
+	itModel   = "Qwen/QwQ-32B"
+	itPath    = "/v1/chat/completions"
+)
+
+// signedRequest is a fully signed agent request: the two header values and
+// the request body the agent signature was produced over.
+type signedRequest struct {
+	passportHeader string
+	agentSigHeader string
+	body           []byte
+}
+
+// buildSignedRequest produces a real, fully signed agent request using only
+// the exported agentenvelope API, the way a client SDK would. The optional
+// mutate hook adjusts the envelope before it is signed.
+func buildSignedRequest(t testing.TB, mutate func(*agentenvelope.EnvelopeV1)) signedRequest {
+	t.Helper()
+	principalPriv := secp256k1.GenPrivKey()
+	principalPub := principalPriv.PubKey().(*secp256k1.PubKey)
+	agentPub, agentPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	models := []string{itModel}
+	env := &agentenvelope.EnvelopeV1{
+		Version:          agentenvelope.SchemaVersion,
+		Audience:         agentenvelope.Audience,
+		ChainID:          itChainID,
+		AgentID:          "urn:aps:agent:integration",
+		AgentPubkey:      agentenvelope.TypedKey{Type: agentenvelope.KeyTypeEd25519, PublicKey: base64.StdEncoding.EncodeToString(agentPub)},
+		PrincipalAddress: sdk.AccAddress(principalPub.Address()).String(),
+		PrincipalPubkey:  agentenvelope.TypedKey{Type: agentenvelope.KeyTypeSecp256k1, PublicKey: base64.StdEncoding.EncodeToString(principalPub.Key)},
+		Scope: agentenvelope.Scope{
+			AllowedModels: &models,
+			ExpiresAt:     now.Add(30 * time.Minute),
+		},
+		Beneficiary: "urn:customer:integration",
+		IssuedAt:    now,
+	}
+	if mutate != nil {
+		mutate(env)
+	}
+	body := []byte(`{"model":"` + itModel + `","messages":[]}`)
+
+	// Principal signature: ADR-036 over the envelope with principal_sig empty.
+	env.PrincipalSig = ""
+	unsigned, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signBytes, err := agentenvelope.PrincipalSignBytes(env.PrincipalAddress, unsigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	psig, err := principalPriv.Sign(signBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env.PrincipalSig = base64.StdEncoding.EncodeToString(psig)
+
+	rawEnvelope, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Agent signature: Ed25519 over the length-prefixed payload binding the
+	// chain, method, path, full canonical envelope, and body.
+	envJCS, err := jcs.Canonicalize(rawEnvelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := agentenvelope.AgentSigPayload(env.ChainID, http.MethodPost, itPath, envJCS, body)
+	agentSig := ed25519.Sign(agentPriv, payload)
+
+	return signedRequest{
+		passportHeader: base64.StdEncoding.EncodeToString(rawEnvelope),
+		agentSigHeader: base64.StdEncoding.EncodeToString(agentSig),
+		body:           body,
+	}
+}
+
+// itServer builds an Echo instance with the agent-envelope middleware mounted
+// on a recording handler. The returned function reports the verified context
+// the handler observed, or nil.
+func itServer(t testing.TB, maxBody int64) (*echo.Echo, func() *agentenvelope.Context) {
+	t.Helper()
+	e := echo.New()
+	var captured *agentenvelope.Context
+	cfg := agentenvelope.Config{ChainID: itChainID, MaxTTL: time.Hour}
+	mw := AgentEnvelopeMiddleware(true, cfg, maxBody)
+	e.POST(itPath, func(c echo.Context) error {
+		captured = agentenvelope.FromEchoContext(c)
+		if _, err := io.ReadAll(c.Request().Body); err != nil {
+			return err
+		}
+		return c.NoContent(http.StatusOK)
+	}, mw)
+	return e, func() *agentenvelope.Context { return captured }
+}
+
+func sendIT(e *echo.Echo, sr signedRequest, overrideBody []byte) *httptest.ResponseRecorder {
+	body := sr.body
+	if overrideBody != nil {
+		body = overrideBody
+	}
+	req := httptest.NewRequest(http.MethodPost, itPath, bytes.NewReader(body))
+	if sr.passportHeader != "" {
+		req.Header.Set(headerPassport, sr.passportHeader)
+	}
+	if sr.agentSigHeader != "" {
+		req.Header.Set(headerAgentSig, sr.agentSigHeader)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestIntegration_HappyPath(t *testing.T) {
+	e, captured := itServer(t, 10<<20)
+	rec := sendIT(e, buildSignedRequest(t, nil), nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("happy path: code %d, body %s", rec.Code, rec.Body.String())
+	}
+	apsCtx := captured()
+	if apsCtx == nil || apsCtx.Envelope == nil {
+		t.Fatal("verified context not attached for the handler")
+	}
+	if apsCtx.RequestBound {
+		t.Error("RequestBound must be false after the middleware stage")
+	}
+	if apsCtx.Envelope.AgentID != "urn:aps:agent:integration" {
+		t.Errorf("unexpected agent id %q", apsCtx.Envelope.AgentID)
+	}
+}
+
+func TestIntegration_EnvelopeTamperFails(t *testing.T) {
+	e, _ := itServer(t, 10<<20)
+	sr := buildSignedRequest(t, nil)
+
+	// Tamper a principal-signed field after signing.
+	raw, err := base64.StdEncoding.DecodeString(sr.passportHeader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["agent_id"] = "urn:aps:agent:attacker"
+	tampered, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sr.passportHeader = base64.StdEncoding.EncodeToString(tampered)
+
+	if rec := sendIT(e, sr, nil); rec.Code != http.StatusUnauthorized {
+		t.Errorf("tampered envelope: code %d, want 401", rec.Code)
+	}
+}
+
+func TestIntegration_BodyTamperFails(t *testing.T) {
+	e, _ := itServer(t, 10<<20)
+	sr := buildSignedRequest(t, nil)
+	other := []byte(`{"model":"` + itModel + `","messages":[{"role":"user","content":"x"}]}`)
+	if rec := sendIT(e, sr, other); rec.Code != http.StatusUnauthorized {
+		t.Errorf("tampered body: code %d, want 401", rec.Code)
+	}
+}
+
+func TestIntegration_WrongChainFails(t *testing.T) {
+	e, _ := itServer(t, 10<<20)
+	sr := buildSignedRequest(t, func(env *agentenvelope.EnvelopeV1) {
+		env.ChainID = "some-other-chain"
+	})
+	if rec := sendIT(e, sr, nil); rec.Code != http.StatusUnauthorized {
+		t.Errorf("wrong chain id: code %d, want 401", rec.Code)
+	}
+}
+
+func TestIntegration_ModelNotAllowedFails(t *testing.T) {
+	e, _ := itServer(t, 10<<20)
+	sr := buildSignedRequest(t, func(env *agentenvelope.EnvelopeV1) {
+		models := []string{"some-other-model"}
+		env.Scope.AllowedModels = &models
+	})
+	if rec := sendIT(e, sr, nil); rec.Code != http.StatusForbidden {
+		t.Errorf("model not allowed: code %d, want 403", rec.Code)
+	}
+}
+
+func TestIntegration_BodyTooLarge(t *testing.T) {
+	e, _ := itServer(t, 1<<20) // 1 MiB cap
+	sr := buildSignedRequest(t, nil)
+	oversized := bytes.Repeat([]byte("a"), 2<<20)
+	if rec := sendIT(e, sr, oversized); rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("oversized body: code %d, want 413", rec.Code)
+	}
+}
+
+func BenchmarkMiddleware_AbsentHeader(b *testing.B) {
+	e, _ := itServer(b, 10<<20)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, itPath, strings.NewReader("{}"))
+		e.ServeHTTP(httptest.NewRecorder(), req)
+	}
+}
+
+func BenchmarkMiddleware_ValidEnvelope(b *testing.B) {
+	e, _ := itServer(b, 10<<20)
+	sr := buildSignedRequest(b, nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sendIT(e, sr, nil)
+	}
+}

--- a/decentralized-api/internal/server/middleware/agent_envelope_integration_test.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope_integration_test.go
@@ -240,6 +240,21 @@ func TestIntegration_BodyMissingModel(t *testing.T) {
 	}
 }
 
+func TestIntegration_QueryStringIsBound(t *testing.T) {
+	e, _ := itServer(t, 10<<20)
+	sr := buildSignedRequest(t, nil) // signs the request URI with no query string
+	// Send the same request to a URL with an extra query string. The agent
+	// signature binds the full request URI, so it must no longer verify.
+	req := httptest.NewRequest(http.MethodPost, itPath+"?injected=1", bytes.NewReader(sr.body))
+	req.Header.Set(headerPassport, sr.passportHeader)
+	req.Header.Set(headerAgentSig, sr.agentSigHeader)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("an unsigned query string should fail verification: code %d, want 401", rec.Code)
+	}
+}
+
 func BenchmarkMiddleware_AbsentHeader(b *testing.B) {
 	e, _ := itServer(b, 10<<20)
 	b.ResetTimer()

--- a/decentralized-api/internal/server/middleware/agent_envelope_test.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope_test.go
@@ -93,9 +93,15 @@ func TestMiddleware_MalformedEnvelope(t *testing.T) {
 
 func TestMiddleware_VerificationFailureMapsStatus(t *testing.T) {
 	e, ran := testServer(t, true)
-	// A well-formed envelope with an unknown version maps to 401.
+	// A complete envelope (all required fields present) with an unknown
+	// schema version reaches the version check and maps to 401.
+	envelope := `{"v":"aps-agent-envelope-v999","audience":"gonka","chain_id":"gonka-test",` +
+		`"agent_id":"urn:aps:agent:t","agent_pubkey":{"type":"ed25519","public_key":"AA=="},` +
+		`"principal_address":"gonka1test","principal_pubkey":{"type":"secp256k1","public_key":"AA=="},` +
+		`"scope":{"allowed_models":["m"],"expires_at":"2099-01-01T00:00:00Z"},` +
+		`"beneficiary":"urn:c","issued_at":"2026-01-01T00:00:00Z","principal_sig":"AA=="}`
 	rec := do(e, map[string]string{
-		headerPassport: base64.StdEncoding.EncodeToString([]byte(`{"v":"wrong-version"}`)),
+		headerPassport: base64.StdEncoding.EncodeToString([]byte(envelope)),
 		headerAgentSig: base64.StdEncoding.EncodeToString(make([]byte, 64)),
 	})
 	if rec.Code != http.StatusUnauthorized {

--- a/decentralized-api/internal/server/middleware/agent_envelope_test.go
+++ b/decentralized-api/internal/server/middleware/agent_envelope_test.go
@@ -1,0 +1,107 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"decentralized-api/internal/agentenvelope"
+
+	"github.com/labstack/echo/v4"
+)
+
+// testServer builds an Echo instance with the agent-envelope middleware
+// mounted on a recording handler. The returned function reports whether the
+// downstream handler ran.
+func testServer(t *testing.T, enabled bool) (*echo.Echo, func() bool) {
+	t.Helper()
+	e := echo.New()
+	ran := false
+	cfg := agentenvelope.Config{ChainID: "gonka-test", MaxTTL: time.Hour}
+	mw := AgentEnvelopeMiddleware(enabled, cfg, 1<<20)
+	e.POST("/v1/chat/completions", func(c echo.Context) error {
+		// Confirm the handler can still read the body after the middleware.
+		if _, err := io.ReadAll(c.Request().Body); err != nil {
+			return err
+		}
+		ran = true
+		return c.NoContent(http.StatusOK)
+	}, mw)
+	return e, func() bool { return ran }
+}
+
+func do(e *echo.Echo, headers map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"Qwen/QwQ-32B","messages":[]}`))
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestMiddleware_DisabledPassesThrough(t *testing.T) {
+	e, ran := testServer(t, false)
+	rec := do(e, map[string]string{headerPassport: "anything", headerAgentSig: "anything"})
+	if rec.Code != http.StatusOK || !ran() {
+		t.Errorf("disabled middleware should pass through: code=%d ran=%v", rec.Code, ran())
+	}
+}
+
+func TestMiddleware_NoHeadersPassesThrough(t *testing.T) {
+	e, ran := testServer(t, true)
+	rec := do(e, nil)
+	if rec.Code != http.StatusOK || !ran() {
+		t.Errorf("absent headers should pass through: code=%d ran=%v", rec.Code, ran())
+	}
+}
+
+func TestMiddleware_PassportWithoutSig(t *testing.T) {
+	e, ran := testServer(t, true)
+	rec := do(e, map[string]string{headerPassport: base64.StdEncoding.EncodeToString([]byte("{}"))})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("passport without signature should be 400, got %d", rec.Code)
+	}
+	if ran() {
+		t.Error("handler must not run on a header-pair mismatch")
+	}
+}
+
+func TestMiddleware_BadBase64Passport(t *testing.T) {
+	e, _ := testServer(t, true)
+	rec := do(e, map[string]string{headerPassport: "not!base64!", headerAgentSig: "also!bad"})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed base64 header should be 400, got %d", rec.Code)
+	}
+}
+
+func TestMiddleware_MalformedEnvelope(t *testing.T) {
+	e, _ := testServer(t, true)
+	rec := do(e, map[string]string{
+		headerPassport: base64.StdEncoding.EncodeToString([]byte("not json")),
+		headerAgentSig: base64.StdEncoding.EncodeToString(make([]byte, 64)),
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed envelope should be 400, got %d", rec.Code)
+	}
+}
+
+func TestMiddleware_VerificationFailureMapsStatus(t *testing.T) {
+	e, ran := testServer(t, true)
+	// A well-formed envelope with an unknown version maps to 401.
+	rec := do(e, map[string]string{
+		headerPassport: base64.StdEncoding.EncodeToString([]byte(`{"v":"wrong-version"}`)),
+		headerAgentSig: base64.StdEncoding.EncodeToString(make([]byte, 64)),
+	})
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("unknown version should be 401, got %d", rec.Code)
+	}
+	if ran() {
+		t.Error("handler must not run when verification fails")
+	}
+}

--- a/decentralized-api/internal/server/public/aps_attribution.go
+++ b/decentralized-api/internal/server/public/aps_attribution.go
@@ -15,15 +15,16 @@ import (
 // warm-key grantee to act for a developer principal.
 const apsMsgTypeStartInference = "/inference.inference.MsgStartInference"
 
-// validateAgentEnvelopeConfig guards against a misconfigured envelope layer. A
-// verifier enabled with an empty chain_id would reject every envelope with a
-// chain mismatch, so the layer is logged and disabled rather than started in
-// that state. This surfaces the most common operator error at startup instead
-// of at request time.
+// validateAgentEnvelopeConfig enforces that an enabled envelope layer is
+// configured. A verifier enabled with an empty chain_id would reject every
+// envelope, so an empty chain_id with the layer enabled is a startup
+// misconfiguration: the node refuses to start rather than running with a
+// security and attribution feature that the operator believes is on while it
+// is silently degraded.
 func validateAgentEnvelopeConfig(cfg apiconfig.AgentEnvelopeConfig) apiconfig.AgentEnvelopeConfig {
 	if cfg.Enabled && cfg.ChainID == "" {
-		logging.Error("agent_envelope is enabled but chain_id is empty; disabling the envelope layer until it is configured", types.Config)
-		cfg.Enabled = false
+		logging.Error("agent_envelope.enabled is set but agent_envelope.chain_id is empty", types.Config)
+		panic("agent_envelope: enabled requires a non-empty chain_id (set agent_envelope.chain_id)")
 	}
 	return cfg
 }

--- a/decentralized-api/internal/server/public/aps_attribution.go
+++ b/decentralized-api/internal/server/public/aps_attribution.go
@@ -3,6 +3,7 @@ package public
 import (
 	"context"
 
+	"decentralized-api/apiconfig"
 	"decentralized-api/internal/agentenvelope"
 	"decentralized-api/logging"
 
@@ -13,6 +14,19 @@ import (
 // apsMsgTypeStartInference is the message type an authz grant must cover for a
 // warm-key grantee to act for a developer principal.
 const apsMsgTypeStartInference = "/inference.inference.MsgStartInference"
+
+// validateAgentEnvelopeConfig guards against a misconfigured envelope layer. A
+// verifier enabled with an empty chain_id would reject every envelope with a
+// chain mismatch, so the layer is logged and disabled rather than started in
+// that state. This surfaces the most common operator error at startup instead
+// of at request time.
+func validateAgentEnvelopeConfig(cfg apiconfig.AgentEnvelopeConfig) apiconfig.AgentEnvelopeConfig {
+	if cfg.Enabled && cfg.ChainID == "" {
+		logging.Error("agent_envelope is enabled but chain_id is empty; disabling the envelope layer until it is configured", types.Config)
+		cfg.Enabled = false
+	}
+	return cfg
+}
 
 // apsAttributionSink adapts the agent-envelope attribution emitter to Gonka's
 // structured logging. It is the one place that knows the log field layout.

--- a/decentralized-api/internal/server/public/aps_attribution.go
+++ b/decentralized-api/internal/server/public/aps_attribution.go
@@ -33,7 +33,7 @@ func validateAgentEnvelopeConfig(cfg apiconfig.AgentEnvelopeConfig) apiconfig.Ag
 type apsAttributionSink struct{}
 
 func (apsAttributionSink) Emit(ev agentenvelope.AttributionEvent) {
-	logging.Info("APS attribution", types.Inferences,
+	logging.Info("APS inference-start attribution", types.Inferences,
 		"v", ev.Version,
 		"inference_id", ev.InferenceID,
 		"chain_id", ev.ChainID,
@@ -59,15 +59,19 @@ func (apsAttributionSink) Emit(ev agentenvelope.AttributionEvent) {
 func (s *Server) bindAgentEnvelope(reqCtx context.Context, apsCtx *agentenvelope.Context, requesterAddress string) error {
 	principal := apsCtx.Envelope.PrincipalAddress
 	if principal != requesterAddress {
-		// The requester is not the principal. Accept the request only if the
-		// principal granted the requester authz authority on MsgStartInference.
-		pubkey, err := s.authzCache.GetPubKeyForSigner(reqCtx, principal, requesterAddress, apsMsgTypeStartInference)
+		// The requester is not the principal. Accept only if the principal
+		// granted the requester authz authority on MsgStartInference.
+		// GetPubKeyForSigner returns the grantee key when an active grant
+		// exists and an empty string otherwise; only grant existence is used
+		// here. The requester's own signature on the request is validated by
+		// Gonka's existing request-auth path, not by APS.
+		granteePubkey, err := s.authzCache.GetPubKeyForSigner(reqCtx, principal, requesterAddress, apsMsgTypeStartInference)
 		if err != nil {
 			logging.Error("APS authz grantee resolution failed", types.Inferences,
 				"principal", principal, "requester", requesterAddress, "error", err)
 			return echo.NewHTTPError(agentenvelope.ErrChainQueryFailed.HTTPStatus(), agentenvelope.ErrChainQueryFailed.Code())
 		}
-		if pubkey == "" {
+		if granteePubkey == "" {
 			return echo.NewHTTPError(agentenvelope.ErrPrincipalMismatch.HTTPStatus(), agentenvelope.ErrPrincipalMismatch.Code())
 		}
 	}
@@ -79,6 +83,9 @@ func (s *Server) bindAgentEnvelope(reqCtx context.Context, apsCtx *agentenvelope
 // request-bound inference. The emitter is asynchronous and drops on
 // backpressure, so this never blocks the request path.
 func (s *Server) emitAgentAttribution(apsCtx *agentenvelope.Context, inferenceID, model string) {
+	if s.apsEmitter == nil {
+		return
+	}
 	env := apsCtx.Envelope
 	s.apsEmitter.Enqueue(agentenvelope.AttributionEvent{
 		Version:           "aps-attribution-v1",

--- a/decentralized-api/internal/server/public/aps_attribution.go
+++ b/decentralized-api/internal/server/public/aps_attribution.go
@@ -1,0 +1,82 @@
+package public
+
+import (
+	"context"
+
+	"decentralized-api/internal/agentenvelope"
+	"decentralized-api/logging"
+
+	"github.com/labstack/echo/v4"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// apsMsgTypeStartInference is the message type an authz grant must cover for a
+// warm-key grantee to act for a developer principal.
+const apsMsgTypeStartInference = "/inference.inference.MsgStartInference"
+
+// apsAttributionSink adapts the agent-envelope attribution emitter to Gonka's
+// structured logging. It is the one place that knows the log field layout.
+type apsAttributionSink struct{}
+
+func (apsAttributionSink) Emit(ev agentenvelope.AttributionEvent) {
+	logging.Info("APS attribution", types.Inferences,
+		"v", ev.Version,
+		"inference_id", ev.InferenceID,
+		"chain_id", ev.ChainID,
+		"model", ev.Model,
+		"agent_id", ev.AgentID,
+		"principal_address", ev.PrincipalAddress,
+		"beneficiary", ev.Beneficiary,
+		"request_body_sha256", ev.RequestBodySHA256,
+		"envelope_sha256", ev.EnvelopeSHA256,
+		"passport_expires_at", ev.PassportExpiresAt,
+		"verified_at", ev.VerifiedAt,
+	)
+}
+
+// bindAgentEnvelope completes agent-envelope verification for a request that
+// carried a verified envelope. It confirms the envelope principal matches the
+// request requester, directly or through an authz grant on MsgStartInference,
+// then marks the verified context request-bound. This is the handler-side
+// half of the layering split: the middleware verified the crypto and scope,
+// and only here, after the requester address has been parsed, can the
+// principal be bound to the request. Attribution is emitted only for
+// request-bound contexts.
+func (s *Server) bindAgentEnvelope(reqCtx context.Context, apsCtx *agentenvelope.Context, requesterAddress string) error {
+	principal := apsCtx.Envelope.PrincipalAddress
+	if principal != requesterAddress {
+		// The requester is not the principal. Accept the request only if the
+		// principal granted the requester authz authority on MsgStartInference.
+		pubkey, err := s.authzCache.GetPubKeyForSigner(reqCtx, principal, requesterAddress, apsMsgTypeStartInference)
+		if err != nil {
+			logging.Error("APS authz grantee resolution failed", types.Inferences,
+				"principal", principal, "requester", requesterAddress, "error", err)
+			return echo.NewHTTPError(agentenvelope.ErrChainQueryFailed.HTTPStatus(), agentenvelope.ErrChainQueryFailed.Code())
+		}
+		if pubkey == "" {
+			return echo.NewHTTPError(agentenvelope.ErrPrincipalMismatch.HTTPStatus(), agentenvelope.ErrPrincipalMismatch.Code())
+		}
+	}
+	apsCtx.RequestBound = true
+	return nil
+}
+
+// emitAgentAttribution enqueues a structured attribution event for a verified,
+// request-bound inference. The emitter is asynchronous and drops on
+// backpressure, so this never blocks the request path.
+func (s *Server) emitAgentAttribution(apsCtx *agentenvelope.Context, inferenceID, model string) {
+	env := apsCtx.Envelope
+	s.apsEmitter.Enqueue(agentenvelope.AttributionEvent{
+		Version:           "aps-attribution-v1",
+		InferenceID:       inferenceID,
+		ChainID:           env.ChainID,
+		Model:             model,
+		AgentID:           env.AgentID,
+		PrincipalAddress:  env.PrincipalAddress,
+		Beneficiary:       env.Beneficiary,
+		RequestBodySHA256: apsCtx.RequestBodySHA256,
+		EnvelopeSHA256:    apsCtx.EnvelopeSHA256,
+		PassportExpiresAt: env.Scope.ExpiresAt,
+		VerifiedAt:        apsCtx.VerifiedAt,
+	})
+}

--- a/decentralized-api/internal/server/public/aps_attribution_test.go
+++ b/decentralized-api/internal/server/public/aps_attribution_test.go
@@ -1,0 +1,28 @@
+package public
+
+import (
+	"testing"
+
+	"decentralized-api/apiconfig"
+)
+
+func TestValidateAgentEnvelopeConfig(t *testing.T) {
+	// Disabled: returned unchanged regardless of chain_id.
+	if got := validateAgentEnvelopeConfig(apiconfig.AgentEnvelopeConfig{Enabled: false}); got.Enabled {
+		t.Error("disabled config should stay disabled")
+	}
+
+	// Enabled with a chain_id: returned unchanged.
+	got := validateAgentEnvelopeConfig(apiconfig.AgentEnvelopeConfig{Enabled: true, ChainID: "gonka-mainnet"})
+	if !got.Enabled || got.ChainID != "gonka-mainnet" {
+		t.Error("enabled config with a chain_id should be returned unchanged")
+	}
+
+	// Enabled with an empty chain_id: must panic so the node refuses to start.
+	defer func() {
+		if recover() == nil {
+			t.Error("enabled config with empty chain_id should panic")
+		}
+	}()
+	validateAgentEnvelopeConfig(apiconfig.AgentEnvelopeConfig{Enabled: true, ChainID: ""})
+}

--- a/decentralized-api/internal/server/public/post_chat_handler.go
+++ b/decentralized-api/internal/server/public/post_chat_handler.go
@@ -6,6 +6,7 @@ import (
 	"decentralized-api/apiconfig"
 	"decentralized-api/broker"
 	"decentralized-api/completionapi"
+	"decentralized-api/internal/agentenvelope"
 	"decentralized-api/logging"
 	"decentralized-api/utils"
 	"encoding/json"
@@ -307,6 +308,17 @@ func (s *Server) enforceTransferAgentAccess(taAddress string) error {
 func (s *Server) handleTransferRequest(ctx echo.Context, request *ChatRequest) error {
 	logging.Debug("GET inference requester for transfer", types.Inferences, "address", request.RequesterAddress)
 
+	// Agent-envelope step 22: bind the verified envelope to this request by
+	// confirming the envelope principal matches the requester, or resolves to
+	// it through an authz grant. apsCtx is nil when the request carried no
+	// envelope, in which case the existing flow runs unchanged.
+	apsCtx := agentenvelope.FromEchoContext(ctx)
+	if apsCtx != nil {
+		if err := s.bindAgentEnvelope(ctx.Request().Context(), apsCtx, request.RequesterAddress); err != nil {
+			return err
+		}
+	}
+
 	queryClient := s.recorder.NewInferenceQueryClient()
 	requester, err := queryClient.AccountByAddress(ctx.Request().Context(), &types.QueryAccountByAddressRequest{Address: request.RequesterAddress})
 	if err != nil {
@@ -389,6 +401,11 @@ func (s *Server) handleTransferRequest(ctx echo.Context, request *ChatRequest) e
 			logging.Error("Failed to submit MsgStartInference", types.Inferences, "id", inferenceRequest.InferenceId, "error", err)
 		} else {
 			logging.Debug("Submitted MsgStartInference", types.Inferences, "id", inferenceRequest.InferenceId)
+			// Agent-envelope step 23: emit attribution for a request-bound
+			// envelope after the inference is submitted to chain.
+			if apsCtx != nil && apsCtx.RequestBound {
+				s.emitAgentAttribution(apsCtx, inferenceRequest.InferenceId, request.OpenAiRequest.Model)
+			}
 		}
 	}()
 

--- a/decentralized-api/internal/server/public/server.go
+++ b/decentralized-api/internal/server/public/server.go
@@ -6,6 +6,7 @@ import (
 	"decentralized-api/chainphase"
 	"decentralized-api/cosmosclient"
 	"decentralized-api/internal"
+	"decentralized-api/internal/agentenvelope"
 	"decentralized-api/internal/authzcache"
 	"decentralized-api/internal/server/middleware"
 	"decentralized-api/payloadstorage"
@@ -38,6 +39,7 @@ type Server struct {
 	authzCache          *authzcache.AuthzCache
 	httpClient          *http.Client
 	statsStorage        statsstorage.StatsStorage
+	apsEmitter          *agentenvelope.AttributionEmitter
 }
 
 // ServerOption configures optional Server dependencies.
@@ -90,6 +92,20 @@ func NewServer(
 
 	s.bandwidthLimiter = internal.NewBandwidthLimiterFromConfig(configManager, recorder, phaseTracker)
 
+	// Optional signed agent request envelope. Disabled by config default; when
+	// enabled, the middleware verifies the envelope on the completion
+	// endpoints and the handler emits attribution through this emitter.
+	aeConfig := configManager.GetAgentEnvelopeConfig()
+	s.apsEmitter = agentenvelope.NewAttributionEmitter(aeConfig.AttributionQueueCap, apsAttributionSink{})
+	apsMiddleware := middleware.AgentEnvelopeMiddleware(
+		aeConfig.Enabled,
+		agentenvelope.Config{
+			ChainID: aeConfig.ChainID,
+			MaxTTL:  time.Duration(aeConfig.MaxTTLSeconds) * time.Second,
+		},
+		aeConfig.MaxBodySize,
+	)
+
 	e.Use(middleware.LoggingMiddleware)
 	e.Use(echoMiddleware.BodyLimit(MaxRequestBodyLimit))
 	g := e.Group("/v1/")
@@ -97,8 +113,8 @@ func NewServer(
 	g.GET("status", s.getStatus)
 	g.GET("identity", s.getIdentity)
 
-	g.POST("chat/completions", s.postChat)
-	g.POST("completions", s.postCompletions)
+	g.POST("chat/completions", s.postChat, apsMiddleware)
+	g.POST("completions", s.postCompletions, apsMiddleware)
 	g.GET("chat/completions", s.getChatById)
 	g.GET("inference/payloads", s.getInferencePayloads)
 

--- a/decentralized-api/internal/server/public/server.go
+++ b/decentralized-api/internal/server/public/server.go
@@ -95,7 +95,11 @@ func NewServer(
 	// Optional signed agent request envelope. Disabled by config default; when
 	// enabled, the middleware verifies the envelope on the completion
 	// endpoints and the handler emits attribution through this emitter.
-	aeConfig := configManager.GetAgentEnvelopeConfig()
+	aeConfig := validateAgentEnvelopeConfig(configManager.GetAgentEnvelopeConfig())
+	// The attribution emitter runs for the lifetime of the process. The
+	// decentralized-api Server has no graceful-shutdown path, so there is no
+	// Close call site, matching the other long-lived goroutines the server
+	// starts.
 	s.apsEmitter = agentenvelope.NewAttributionEmitter(aeConfig.AttributionQueueCap, apsAttributionSink{})
 	apsMiddleware := middleware.AgentEnvelopeMiddleware(
 		aeConfig.Enabled,

--- a/decentralized-api/internal/server/public/server.go
+++ b/decentralized-api/internal/server/public/server.go
@@ -96,11 +96,13 @@ func NewServer(
 	// enabled, the middleware verifies the envelope on the completion
 	// endpoints and the handler emits attribution through this emitter.
 	aeConfig := validateAgentEnvelopeConfig(configManager.GetAgentEnvelopeConfig())
-	// The attribution emitter runs for the lifetime of the process. The
-	// decentralized-api Server has no graceful-shutdown path, so there is no
-	// Close call site, matching the other long-lived goroutines the server
-	// starts.
-	s.apsEmitter = agentenvelope.NewAttributionEmitter(aeConfig.AttributionQueueCap, apsAttributionSink{})
+	// The attribution emitter is created only when the layer is enabled, so a
+	// node with the feature off (the default) starts no extra goroutine. When
+	// created it runs for the process lifetime: decentralized-api's Server has
+	// no graceful-shutdown path, matching its other long-lived goroutines.
+	if aeConfig.Enabled {
+		s.apsEmitter = agentenvelope.NewAttributionEmitter(aeConfig.AttributionQueueCap, apsAttributionSink{})
+	}
 	apsMiddleware := middleware.AgentEnvelopeMiddleware(
 		aeConfig.Enabled,
 		agentenvelope.Config{

--- a/docs/specs/aps-agent-envelope.md
+++ b/docs/specs/aps-agent-envelope.md
@@ -61,6 +61,12 @@ that does not run the middleware.
 allowed, present and empty means no model is allowed, present and non-empty
 restricts to the listed models.
 
+A v1 envelope carries only the fields above. Any additional field is still
+covered by the principal signature and the canonical form, so clients must not
+add extension fields in v1: the JCS canonicalizer is scoped to the string,
+object, and array shapes this schema uses and does not implement full RFC 8785
+number canonicalization. Extension fields are a v2 concern.
+
 ## Signing model
 
 The principal signature covers the envelope with `principal_sig` set to the
@@ -105,11 +111,13 @@ HTTP status mapping:
 
 ## Attribution event
 
-After a verified, request-bound inference is submitted to chain, a structured
-event is emitted through an asynchronous bounded-queue emitter. The event
-carries the agent id, principal address, beneficiary, model, inference id, and
-content hashes. The emitter drops on a full queue and counts the drops, so
-logging backpressure never stalls a response. v1 attribution is observability
+After a verified, request-bound inference request is submitted to chain
+(MsgStartInference), a structured inference-start attribution event is emitted
+through an asynchronous bounded-queue emitter. This is start-of-request
+attribution, not execution or settlement attribution. The event carries the
+agent id, principal address, beneficiary, model, inference id, and content
+hashes. The emitter drops on a full queue and counts the drops, so logging
+backpressure never stalls a response. v1 attribution is observability
 data, not an on-chain record.
 
 ## Configuration
@@ -118,6 +126,15 @@ The `agent_envelope` config block: `enabled` (default false), `chain_id`,
 `max_ttl_seconds` (default 3600), `max_body_size` (default 10 MiB), and
 `attribution_queue_cap` (default 1024). The layer is off unless `enabled` is
 set.
+
+`chain_id` must match this network's chain id; an envelope carrying a
+different chain id is rejected. If the layer is enabled with an empty
+`chain_id`, the node logs an error at startup and the layer stays off, rather
+than rejecting every request or refusing to start: the envelope is opt-in
+metadata and a misconfiguration of it should not take a host down.
+`max_ttl_seconds`, `max_body_size`, and `attribution_queue_cap` are each
+bounded to a sane range; a value outside its range falls back to the default.
+Deriving `chain_id` from the chain node automatically is deferred future work.
 
 ## Backward compatibility
 

--- a/docs/specs/aps-agent-envelope.md
+++ b/docs/specs/aps-agent-envelope.md
@@ -70,7 +70,8 @@ number canonicalization. Extension fields are a v2 concern.
 ## Signing model
 
 The principal signature covers the envelope with `principal_sig` set to the
-empty string, canonicalized with RFC 8785 JCS, wrapped in an ADR-036
+empty string, canonicalized with a JCS canonicalizer (RFC 8785, scoped to the
+string, object, and array shapes this schema uses), wrapped in an ADR-036
 `MsgSignData` document, and signed with the principal's secp256k1 key.
 
 The agent signature is `Ed25519.Sign` over a domain-separated, length-prefixed
@@ -97,6 +98,13 @@ type and decode, address derivation check, agent pubkey type and decode,
 beneficiary validation, ADR-036 principal signature, bounded body read, agent
 signature, model scope. Any failure stops the flow and returns the mapped HTTP
 status. The handler then performs the principal-to-requester binding.
+
+This binding, and the attribution that follows it, happen on the client-facing
+transfer-request path only. A Transfer Agent forwards work to an executor with
+a fixed header set that does not include the APS headers, so executor-hop
+requests carry no envelope and do not participate in APS v1. The verifier also
+rejects an envelope whose JSON contains duplicate member names, since a
+duplicate name is ambiguous at a signature boundary.
 
 HTTP status mapping:
 
@@ -129,12 +137,13 @@ set.
 
 `chain_id` must match this network's chain id; an envelope carrying a
 different chain id is rejected. If the layer is enabled with an empty
-`chain_id`, the node logs an error at startup and the layer stays off, rather
-than rejecting every request or refusing to start: the envelope is opt-in
-metadata and a misconfiguration of it should not take a host down.
-`max_ttl_seconds`, `max_body_size`, and `attribution_queue_cap` are each
-bounded to a sane range; a value outside its range falls back to the default.
-Deriving `chain_id` from the chain node automatically is deferred future work.
+`chain_id` the node refuses to start: a verifier with no chain id would reject
+every envelope, and a misconfigured security and attribution feature should
+fail loudly at startup rather than run silently degraded. `max_ttl_seconds`,
+`max_body_size`, and `attribution_queue_cap` are each bounded to a sane range;
+a value outside its range falls back to the default, since each has a safe
+default whereas `chain_id` has none. Deriving `chain_id` from the chain node
+automatically is deferred future work.
 
 ## Backward compatibility
 

--- a/docs/specs/aps-agent-envelope.md
+++ b/docs/specs/aps-agent-envelope.md
@@ -1,0 +1,145 @@
+# Agent Request Envelope
+
+Status: proposal, reference implementation in `decentralized-api/internal/agentenvelope`.
+
+## Overview
+
+The agent request envelope is an optional, signed metadata layer on inference
+completion requests. When a request carries the `X-Agent-Passport` and
+`X-Agent-Sig` headers, a middleware on `/v1/chat/completions` and
+`/v1/completions` verifies that:
+
+- the envelope was signed by a Gonka principal (the developer key), via ADR-036
+- the principal public key embedded in the envelope derives to the stated
+  principal address, so no chain query is needed for signature verification
+- the agent signed this specific request, binding the chain id, method, path,
+  envelope, and body
+- the envelope is within its validity window and its configured maximum TTL
+- the requested model is within the delegated scope
+
+On success the verified context is attached for the handler, which confirms
+the envelope principal matches the request requester (directly or through an
+`x/authz` grant) and emits a structured attribution event after the inference
+is submitted to chain.
+
+The envelope answers three questions the existing identity model cannot:
+which agent key made the request, what request-layer scope it was authorized
+for, and which beneficiary the work was attributed to.
+
+## What this does not change
+
+The envelope is additive. It does not replace or modify the developer
+signature on the AuthKey, the Transfer Agent signature, the Executor
+signature, AuthKey replay protection, timestamp validation, `x/authz`
+semantics, escrow, settlement, or `MsgFinishInference`. When the
+`X-Agent-Passport` header is absent, request behavior is identical to a node
+that does not run the middleware.
+
+## Envelope schema
+
+```json
+{
+  "v": "aps-agent-envelope-v1",
+  "audience": "gonka",
+  "chain_id": "<gonka chain id>",
+  "agent_id": "urn:aps:agent:<id>",
+  "agent_pubkey": { "type": "ed25519", "public_key": "<base64, 32 bytes>" },
+  "principal_address": "<gonka bech32 address>",
+  "principal_pubkey": { "type": "secp256k1", "public_key": "<base64, 33 bytes>" },
+  "scope": {
+    "allowed_models": ["Qwen/QwQ-32B"],
+    "expires_at": "<RFC3339>",
+    "not_before": "<RFC3339, optional>"
+  },
+  "beneficiary": "urn:customer:<id>",
+  "issued_at": "<RFC3339>",
+  "principal_sig": "<base64 ADR-036 signature>"
+}
+```
+
+`allowed_models` uses field-presence semantics: omitted means all models are
+allowed, present and empty means no model is allowed, present and non-empty
+restricts to the listed models.
+
+## Signing model
+
+The principal signature covers the envelope with `principal_sig` set to the
+empty string, canonicalized with RFC 8785 JCS, wrapped in an ADR-036
+`MsgSignData` document, and signed with the principal's secp256k1 key.
+
+The agent signature is `Ed25519.Sign` over a domain-separated, length-prefixed
+payload:
+
+```
+"APS-AGENT-SIG-V1\n" ||
+u32_be(len(chain_id))     || chain_id ||
+u32_be(len(method))       || method   ||
+u32_be(len(path))         || path     ||
+u32_be(len(envelope_jcs)) || envelope_jcs ||
+u32_be(len(body))         || body
+```
+
+The length prefixes make field boundaries unambiguous. The construction
+follows the TLS 1.3 transcript pattern (RFC 8446 section 4.4.1). The agent key
+signs the payload directly with no SHA-256 prehash.
+
+## Verification flow
+
+The middleware runs, in order: header presence and base64 decode, envelope
+parse, version, audience, chain id, TTL bound, time window, principal pubkey
+type and decode, address derivation check, agent pubkey type and decode,
+beneficiary validation, ADR-036 principal signature, bounded body read, agent
+signature, model scope. Any failure stops the flow and returns the mapped HTTP
+status. The handler then performs the principal-to-requester binding.
+
+HTTP status mapping:
+
+- 400: malformed structure (bad base64, bad JSON, a header pair with one
+  header missing)
+- 401: a wrong credential (bad signature, wrong chain id or audience, unknown
+  version, address mismatch, wrong pubkey type, invalid beneficiary)
+- 403: a valid credential that is not permitted (expired, not yet valid, TTL
+  too long, model out of scope, principal mismatch)
+- 413: request body over the configured maximum
+- 500: a chain query failure during authz grantee resolution
+
+## Attribution event
+
+After a verified, request-bound inference is submitted to chain, a structured
+event is emitted through an asynchronous bounded-queue emitter. The event
+carries the agent id, principal address, beneficiary, model, inference id, and
+content hashes. The emitter drops on a full queue and counts the drops, so
+logging backpressure never stalls a response. v1 attribution is observability
+data, not an on-chain record.
+
+## Configuration
+
+The `agent_envelope` config block: `enabled` (default false), `chain_id`,
+`max_ttl_seconds` (default 3600), `max_body_size` (default 10 MiB), and
+`attribution_queue_cap` (default 1024). The layer is off unless `enabled` is
+set.
+
+## Backward compatibility
+
+With the layer disabled, or with no `X-Agent-Passport` header, request
+behavior is byte-identical to baseline. The middleware is a passthrough.
+
+## Security limitations in v1
+
+- No revocation. A bounded maximum TTL limits the lifetime of a stolen
+  envelope; there is no revocation list.
+- The envelope is not bound to a specific host. A passport plus signature pair
+  is an agent capability, not a single-host token. The agent signature is per
+  request, so a captured request cannot be replayed against a different body,
+  and Gonka's existing AuthKey replay protection still applies.
+- Multi-signature principal keys are rejected. v1 supports single-key
+  secp256k1 principals only.
+- The beneficiary is a principal-attested opaque string. The network does not
+  verify it as a real-world identity.
+
+## Future work
+
+These are out of scope for this proposal and would be discussed separately:
+on-chain attribution by extending `MsgFinishInference` with optional agent and
+beneficiary fields, scoped delegation chains, devshard integration, and a
+revocation mechanism.

--- a/docs/specs/aps-agent-envelope.md
+++ b/docs/specs/aps-agent-envelope.md
@@ -130,6 +130,13 @@ hashes. The emitter drops on a full queue and counts the drops, so logging
 backpressure never stalls a response. v1 attribution is observability
 data, not an on-chain record.
 
+The two content hashes, `request_body_sha256` and `envelope_sha256`, are taken
+over the request as it was received at this node. The inbound body is not the
+body Gonka submits on chain: the inference path rewrites it before computing
+the `MsgStartInference` prompt hash. `request_body_sha256` is therefore an
+ingress integrity reference, not the on-chain prompt hash, and the two are not
+expected to be equal.
+
 ## Configuration
 
 The `agent_envelope` config block: `enabled` (default false), `chain_id`,
@@ -156,6 +163,9 @@ behavior is byte-identical to baseline. The middleware is a passthrough.
 
 - No revocation. A bounded maximum TTL limits the lifetime of a stolen
   envelope; there is no revocation list.
+- Warm-key authz resolution reuses Gonka's existing authz cache. A revoked
+  `x/authz` grant can still resolve for that cache's TTL window. APS inherits
+  this staleness from the shared cache and adds none of its own.
 - The envelope is not bound to a specific host. A passport plus signature pair
   is an agent capability, not a single-host token. The agent signature is per
   request, so a captured request cannot be replayed against a different body,

--- a/docs/specs/aps-agent-envelope.md
+++ b/docs/specs/aps-agent-envelope.md
@@ -61,11 +61,10 @@ that does not run the middleware.
 allowed, present and empty means no model is allowed, present and non-empty
 restricts to the listed models.
 
-A v1 envelope carries only the fields above. Any additional field is still
-covered by the principal signature and the canonical form, so clients must not
-add extension fields in v1: the JCS canonicalizer is scoped to the string,
-object, and array shapes this schema uses and does not implement full RFC 8785
-number canonicalization. Extension fields are a v2 concern.
+A v1 envelope carries only the fields above. The verifier parses it strictly:
+an envelope with an unknown field, a duplicate member name, or trailing
+content after the envelope object is rejected as malformed. Extension fields
+are a v2 concern.
 
 ## Signing model
 
@@ -81,22 +80,25 @@ payload:
 "APS-AGENT-SIG-V1\n" ||
 u32_be(len(chain_id))     || chain_id ||
 u32_be(len(method))       || method   ||
-u32_be(len(path))         || path     ||
+u32_be(len(request_uri)) || request_uri ||
 u32_be(len(envelope_jcs)) || envelope_jcs ||
 u32_be(len(body))         || body
 ```
 
-The length prefixes make field boundaries unambiguous. The construction
-follows the TLS 1.3 transcript pattern (RFC 8446 section 4.4.1). The agent key
-signs the payload directly with no SHA-256 prehash.
+request_uri is the full request target, the path with any query string, so
+the signature binds the exact endpoint. The length prefixes make field
+boundaries unambiguous. The construction follows the TLS 1.3 transcript
+pattern (RFC 8446 section 4.4.1). The agent key signs the payload directly
+with no SHA-256 prehash.
 
 ## Verification flow
 
-The middleware runs, in order: header presence and base64 decode, envelope
-parse, version, audience, chain id, TTL bound, time window, principal pubkey
-type and decode, address derivation check, agent pubkey type and decode,
-beneficiary validation, ADR-036 principal signature, bounded body read, agent
-signature, model scope. Any failure stops the flow and returns the mapped HTTP
+The middleware runs, in order: header presence and base64 decode, strict
+envelope parse (unknown fields, duplicate member names, and trailing content
+rejected), version, audience, chain id, TTL bound, time window, principal
+pubkey type and decode, address derivation check, agent pubkey type and
+decode, beneficiary validation, ADR-036 principal signature, bounded body
+read, agent signature, model scope. Any failure stops the flow and returns the mapped HTTP
 status. The handler then performs the principal-to-requester binding.
 
 This binding, and the attribution that follows it, happen on the client-facing


### PR DESCRIPTION
## Summary

Reference implementation for the envelope schema discussed in [#1230](https://github.com/gonka-ai/gonka/discussions/1230). Follows up on @gmorgachev's broker-side, request-layer placement suggestion in [#1185](https://github.com/gonka-ai/gonka/discussions/1185).

The middleware sits on `/v1/chat/completions` and `/v1/completions`, verifies a signed agent request envelope when the headers are present, and preserves today's behavior when they are absent.

The envelope cryptographically binds an Ed25519 agent identity to an existing Gonka Developer's Cosmos secp256k1 key via ADR-036, enforces request-layer scope (model allowlist, expiry, audience, chain_id), and emits a structured attribution event after inference submission. The existing Developer/TA/Executor signing chain, AuthKey replay protection, `x/authz` delegation, escrow logic, and `MsgFinishInference` are untouched.

## Problem

Gonka's existing identity model treats a Developer as a single Cosmos secp256k1 key. When an automated agent calls inference under a Developer today, the three available paths each have a real cost:

1. Use the Developer's cold key directly. Security risk.
2. Use a Cosmos `x/authz` warm key. Works for signing, but `RequestedBy` resolves to the grantee address; the specific agent identity is invisible on chain.
3. Wrap the inference API with a custom service that holds the warm key. Most common today; the wrapping service carries trust, and the agent identity is still invisible.

`x/authz` is also message-type scoped, not attribute scoped. A Developer cannot grant a warm key the right to run inference only for model X, only for purpose Y, only until Tuesday. A custom `InferenceAuthorization` type in `x/authz` would address that, but it's a chain change requiring governance.

A third gap, unrelated to the above: there is no on-chain field for the beneficiary when the payer (Developer) and the entity the work is done for differ. Existing on-chain attribution maps to payer only.

## Solution

A new middleware reads an optional `X-Agent-Passport` header. When present, it:

1. Verifies the envelope's `principal_sig` against the Developer's Cosmos secp256k1 key via **ADR-036**, the same arbitrary-data path Keplr `signArbitrary` uses. Cross-validated by an independent `@cosmjs/amino` reference vector in tests.
2. Confirms the embedded `principal_pubkey` derives to the stated `principal_address`. No chain query needed, which eliminates first-tx-pubkey and DoS surfaces.
3. Verifies a per-request `X-Agent-Sig` over a domain-separated, length-prefixed payload, binding `chain_id`, HTTP method, full request URI (path + query string), the JCS-canonicalized envelope, and the request body.
4. Checks scope: `audience` equals `"gonka"`, `chain_id` matches, `not_before` and `expires_at` bound the window, `expires_at - issued_at` is within `MaxEnvelopeTTL`, `issued_at` is not more than 30s in the future (clock-skew bound), and the request's model is in `allowed_models` if the field is present.
5. Validates `beneficiary` is well-formed: rejects control chars, bad UTF-8, and length over 255 bytes; no silent transformation.
6. Attaches a verified `Context` to the Echo request with `RequestBound = false`.

After the existing `readRequest` parses `RequesterAddress`, the handler confirms `principal_address == RequesterAddress`, or resolves via `x/authz` (Grantee to Granter) using Gonka's existing `AuthzCache.GetPubKeyForSigner` directly. On success, it sets `RequestBound = true`. After `s.recorder.StartInference` succeeds, the attribution event is enqueued through a bounded async emitter.

## Composition with existing Cosmos patterns

This adds no new root of trust. It composes on top of primitives Gonka already uses:

- **ADR-036** (Arbitrary Message Signature Specification) for the Developer's signature on the passport.
- **`x/authz`** for warm-key resolution. Reuses `AuthzCache.GetPubKeyForSigner(granter, signer, msgType)` directly; no new resolver layer.
- **Ed25519** from the Go standard library for the agent's per-request signature.
- **RFC 8785 JCS** for canonicalization. Vendored, scoped honestly to the envelope schema: no JSON numbers, no full Unicode surrogate handling, and unknown fields are rejected.

## Hardening invariants

All non-optional. Each has a corresponding test.

| Concern | Mitigation |
|---|---|
| Body OOM | `http.MaxBytesReader` at `MaxBodySize` (default 10 MiB, capped at 1 GiB) |
| Cross-chain replay | `chain_id` in envelope + `chain_id` in agent-sig payload (defense in depth) |
| Cross-endpoint replay | Method + full request URI (path + query) in agent-sig payload |
| Body substitution | Body bytes in agent-sig payload |
| Field-boundary substitution | Length-prefix domain separation, TLS 1.3 transcript pattern |
| Envelope tampering | Strict decode (`DisallowUnknownFields`, no trailing content), duplicate-key rejection, principal_sig over full JCS envelope |
| Algorithm confusion | Strict `*secp256k1.PubKey` type assertion; multi-sig rejected explicitly |
| Stolen passport blast radius | Bounded `MaxEnvelopeTTL` (default 1h, configurable) |
| Future-dated `issued_at` | 30s clock-skew tolerance; envelopes further in the future rejected |
| Log injection (beneficiary) | Reject on control chars, bad UTF-8, length over 255 bytes; no transformation |
| Logger backpressure | Bounded channel + background drain + drop-on-full + counter |
| Logger panic | Drain goroutine recovers; sink panic cannot crash the node |
| Misconfiguration | Layer enabled with empty `chain_id` panics at startup, not at first request |
| Required fields | `validateEnvelopeRequired` rejects missing fields as 400, not as downstream errors |
| Body parse failure | 400 when an envelope is present and the body is malformed |

## Tests

`go test -race ./internal/agentenvelope/... ./internal/server/middleware/...` clean under `GOTOOLCHAIN=go1.24.2`.

- ~80 unit tests in `internal/agentenvelope/` (one per named error class, plus happy paths, JCS Appendix B vectors, cosmjs cross-check).
- 13 HTTP integration tests in `internal/server/middleware/` covering passthrough (no headers), disabled-by-config, full happy path, every named-error rejection, and the request-URI-with-query-string binding.
- Independent ADR-036 cross-check via `@cosmjs/amino` in `signing_cosmjs_test.go`, using the amino path Keplr `signArbitrary` uses. This cross-check gives confidence that the sign bytes match the Keplr path.
- Two benchmarks: absent-header overhead, full-verify warm-authz overhead.

## Components affected

Only `decentralized-api/`. No changes to `inference-chain/`, broker, devshard, event listener, validation, cosmosclient, ML node, consensus, ante handlers, escrow, settlement, tokenomics, or `MsgFinishInference`.

New code lives in `decentralized-api/internal/agentenvelope/`. The middleware is mounted in `server.go` (~20 lines). Handler changes in `post_chat_handler.go` total ~17 lines: principal-match or `x/authz` Grantee resolution, then `RequestBound = true`, then attribution enqueue after `StartInference`. New config struct in `apiconfig/` with bounded defaults.

A `examples/aps-client/` reference client and a `docs/specs/aps-agent-envelope.md` spec doc ship with the change.

## What this PR explicitly does NOT do

Listing exhaustively because reviewers historically check each surface; flagging them upfront so review can focus where it matters.

1. Replace any existing signing layer (Developer, TA, Executor)
2. Modify Cosmos `x/authz` semantics, `authzcache`, AuthKey replay protection, or `ValidateTimestamp`
3. Modify escrow, settlement, pricing, tokenomics, consensus, ante handlers, ML node, PoC, or validation
4. Modify `MsgStartInference` or `MsgFinishInference`
5. Implement scoped delegation chains (Phase 2)
6. Implement passport revocation beyond short TTL (Phase 2)
7. Implement multi-sig principal support (Phase 2)
8. Implement devshard daemon integration (Phase 2)
9. Verify beneficiary identity (it's a signed claim, not a verified identity)
10. Require any inference request to identify an agent (header is optional)
11. Change request body size limits or any other operational constraint
12. Add new external dependencies (Ed25519 is Go standard library; cosmos-sdk and Echo are already in the dep tree)
13. Add chain query latency when `principal_address == RequesterAddress`
14. Claim adoption of APS as a Gonka-wide standard

## Future work explicitly out of scope

Each of these gets a separate Discussion if interest exists:

- Extending `MsgFinishInference` with optional `AgentId` and `Beneficiary` fields (chain change, governance)
- Scoped delegation chains (parent agent narrows scope, hands to sub-agent)
- Multi-hop attribution receipts
- Devshard daemon integration (different code path, different signing semantics)
- CosmWasm helper contracts for on-chain enforcement
- Multi-sig principal support
- Revocation mechanism beyond short TTL

## Disclosure

I maintain APS (Agent Passport System, [agent-passport.org](https://agent-passport.org)), an Apache 2.0 open protocol for AI agent identity and scoped delegation. The envelope format in this PR is APS-compatible. The verifier is fully isolated in `internal/agentenvelope/`, so the wire format can be swapped without re-architecting anything else. Adopting it Gonka-side does not require Gonka to adopt APS network-wide.

The Future work items above would all get separate Discussions if Gonka maintainers wanted to pursue them; none are assumed by this PR.

## Reviewer notes

@gmorgachev, this follows up on the broker-side, request-layer placement direction from your reply in [#1185](https://github.com/gonka-ai/gonka/discussions/1185). The middleware sits in front of `/v1/chat/completions` and `/v1/completions`; no changes anywhere else in the request path.

Happy to split the PR into stacked commits if a smaller review shape would be easier. As-is, the diff is ~2,700 new lines, mostly in one new package, and ~25 modified lines across two existing files; the commits are already logically separated by layer: foundation, verifier, middleware, tests, docs, and review-pass refinements.

Ready for review when you are.
