### PR TITLE
`devshard` fix(devshardctl): drain upstream SSE for devshard_meta after client cancel

### DIFF
--- a/decentralized-api/internal/devshard/bridge_test.go
+++ b/decentralized-api/internal/devshard/bridge_test.go
@@ -72,7 +72,8 @@ func TestChainBridge_GetEscrow_SealGraceFromParams(t *testing.T) {
 	qc.On("Params", mock.Anything, mock.Anything).Return(&inferenceTypes.QueryParamsResponse{
 		Params: inferenceTypes.Params{
 			DevshardEscrowParams: &inferenceTypes.DevshardEscrowParams{
-				DefaultSealGraceNonces: 88,
+				DefaultSealGraceNonces:            88,
+				DefaultInferenceClearGraceSeconds: 99,
 			},
 		},
 	}, nil)
@@ -81,6 +82,7 @@ func TestChainBridge_GetEscrow_SealGraceFromParams(t *testing.T) {
 	info, err := cb.GetEscrow("42")
 	require.NoError(t, err)
 	assert.Equal(t, uint32(88), info.SealGraceNonces)
+	assert.Equal(t, uint32(99), info.InferenceClearGraceSeconds)
 }
 
 func TestChainBridge_GetEscrow_ParamsError_LeavesSealGraceZero(t *testing.T) {
@@ -103,6 +105,7 @@ func TestChainBridge_GetEscrow_ParamsError_LeavesSealGraceZero(t *testing.T) {
 	info, err := cb.GetEscrow("1")
 	require.NoError(t, err)
 	assert.Equal(t, uint32(0), info.SealGraceNonces)
+	assert.Equal(t, uint32(0), info.InferenceClearGraceSeconds)
 }
 
 func TestChainBridge_GetEscrow_DefaultSealGraceZero_UsesGroupFallback(t *testing.T) {
@@ -131,4 +134,5 @@ func TestChainBridge_GetEscrow_DefaultSealGraceZero_UsesGroupFallback(t *testing
 	info, err := cb.GetEscrow("1")
 	require.NoError(t, err)
 	assert.Equal(t, uint32(30), info.SealGraceNonces)
+	assert.Equal(t, inferenceTypes.DefaultDevshardInferenceClearGraceSeconds, info.InferenceClearGraceSeconds)
 }

--- a/decentralized-api/internal/devshard/manager_test.go
+++ b/decentralized-api/internal/devshard/manager_test.go
@@ -756,12 +756,13 @@ func TestCreateSession_FreezesSealGraceFromBridge(t *testing.T) {
 
 	br := &mockBridge{
 		escrow: &bridge.EscrowInfo{
-			EscrowID:        "escrow-1",
-			Amount:          100000,
-			CreatorAddress:  user.Address(),
-			Slots:           addresses,
-			SealGraceNonces: 123,
-			TokenPrice:      1,
+			EscrowID:                   "escrow-1",
+			Amount:                     100000,
+			CreatorAddress:             user.Address(),
+			Slots:                      addresses,
+			SealGraceNonces:            123,
+			InferenceClearGraceSeconds: 456,
+			TokenPrice:                 1,
 		},
 	}
 
@@ -772,6 +773,7 @@ func TestCreateSession_FreezesSealGraceFromBridge(t *testing.T) {
 	meta, err := store.GetSessionMeta("escrow-1")
 	require.NoError(t, err)
 	require.Equal(t, uint32(123), meta.Config.SealGraceNonces)
+	require.Equal(t, uint32(456), meta.Config.InferenceClearGraceSeconds)
 }
 
 func TestCreateSession_RejectsExistingDifferentVersion(t *testing.T) {

--- a/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
+++ b/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
@@ -113,6 +113,7 @@ type interruptionTestSuite struct {
 	mockRecorder    *cosmosclient.MockCosmosMessageClient
 	mockQueryClient *mockInterruptionQueryClient
 	mockMLServer    *httptest.Server
+	mockClientFactory *mlnodeclient.MockClientFactory
 	server          *Server
 	configManager   *apiconfig.ConfigManager
 	nodeBroker      *broker.Broker
@@ -148,6 +149,66 @@ func (s *interruptionTestSuite) cleanup() {
 	if s.mockMLServer != nil {
 		s.mockMLServer.Close()
 	}
+}
+
+// waitForInferenceNodeReady blocks until the broker considers the node available
+// for inference (INFERENCE status and no in-flight reconciliation). Without this,
+// ServeHTTP can race reconciliation and return "no nodes available for inference".
+func (s *interruptionTestSuite) waitForInferenceNodeReady(t *testing.T, nodeID string) {
+	t.Helper()
+
+	if !s.pollInferenceNodeReady(nodeID, 2*time.Second) {
+		// Reconciliation may not finish in time on slow CI; force stable INFERENCE status.
+		setStatusCmd := broker.NewSetNodesActualStatusCommand([]broker.StatusUpdate{
+			{
+				NodeId:     nodeID,
+				PrevStatus: types.HardwareNodeStatus_UNKNOWN,
+				NewStatus:  types.HardwareNodeStatus_INFERENCE,
+				Timestamp:  time.Now(),
+			},
+		})
+		err := s.nodeBroker.QueueMessage(setStatusCmd)
+		require.NoError(t, err)
+		require.True(t, <-setStatusCmd.Response)
+	}
+
+	if !s.pollInferenceNodeReady(nodeID, 2*time.Second) {
+		t.Fatalf("node %q did not reach stable INFERENCE status in time", nodeID)
+	}
+}
+
+func (s *interruptionTestSuite) pollInferenceNodeReady(nodeID string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		nodes, err := s.nodeBroker.GetNodes()
+		if err == nil {
+			for _, n := range nodes {
+				if n.Node.Id == nodeID &&
+					n.State.IntendedStatus == types.HardwareNodeStatus_INFERENCE &&
+					n.State.CurrentStatus == types.HardwareNodeStatus_INFERENCE &&
+					n.State.ReconcileInfo == nil {
+					return true
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+func (s *interruptionTestSuite) waitForFinishInferenceCalls(t *testing.T, want int, timeout time.Duration) []*inference.MsgFinishInference {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		calls := s.getFinishInferenceCalls()
+		if len(calls) >= want {
+			return calls
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	calls := s.getFinishInferenceCalls()
+	require.Len(t, calls, want, "timed out waiting for FinishInference calls")
+	return calls
 }
 
 // ============================================================================
@@ -483,9 +544,9 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 	mockParticipant.On("GetPubKey").Return(suite.taKey.GetPubKeyBase64())
 
 	bridge := broker.NewBrokerChainBridgeImpl(suite.mockRecorder, "")
-	mockClientFactory := mlnodeclient.NewMockClientFactory()
+	suite.mockClientFactory = mlnodeclient.NewMockClientFactory()
 
-	suite.nodeBroker = broker.NewBroker(bridge, suite.phaseTracker, mockParticipant, "", mockClientFactory, suite.configManager)
+	suite.nodeBroker = broker.NewBroker(bridge, suite.phaseTracker, mockParticipant, "", suite.mockClientFactory, suite.configManager)
 
 	// 6. Register a node pointing to mock ML server
 	mlServerURL := suite.mockMLServer.URL
@@ -524,7 +585,7 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 	suite.nodeBroker.UpdateNodeEpochData([]*types.MLNodeInfo{&mlNode}, "test-model", model)
 
 	pocURL := fmt.Sprintf("http://%s:%d", host, port+1)
-	mockClient := mockClientFactory.CreateClient(pocURL, fmt.Sprintf("http://%s:%d", host, port)).(*mlnodeclient.MockClient)
+	mockClient := suite.mockClientFactory.CreateClient(pocURL, fmt.Sprintf("http://%s:%d", host, port)).(*mlnodeclient.MockClient)
 	mockClient.Mu.Lock()
 	mockClient.CurrentState = mlnodeclient.MlNodeState_INFERENCE
 	mockClient.InferenceIsHealthy = true
@@ -533,6 +594,8 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 	inferenceUpCmd := broker.NewInferenceUpAllCommand()
 	err = suite.nodeBroker.QueueMessage(inferenceUpCmd)
 	require.NoError(t, err)
+	require.True(t, <-inferenceUpCmd.Response)
+	suite.waitForInferenceNodeReady(t, nodeConfig.Id)
 
 	// 7. Create the public server
 	payloadStorage := newMockPayloadStorage()
@@ -882,10 +945,7 @@ func TestInterruption_ClientDisconnect_StreamingComplete_VerifyFinishInference(t
 
 	suite.server.e.ServeHTTP(disconnectWriter, req)
 
-	// Wait for async processing
-	time.Sleep(500 * time.Millisecond)
-
-	calls := suite.getFinishInferenceCalls()
+	calls := suite.waitForFinishInferenceCalls(t, 1, 2*time.Second)
 	t.Logf("CLIENT_DISCONNECT_STREAM RESULT: FinishInference calls count = %d", len(calls))
 	t.Logf("CLIENT_DISCONNECT_STREAM: Written bytes before disconnect = %d", disconnectWriter.writtenBytes)
 

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -527,8 +527,9 @@ type statusSessionConfig struct {
 	CreateDevshardFee uint64 `json:"create_devshard_fee"`
 	FeePerNonce       uint64 `json:"fee_per_nonce"`
 	VoteThreshold     uint32 `json:"vote_threshold"`
-	ValidationRate    uint32 `json:"validation_rate"`
-	SealGraceNonces   uint32 `json:"seal_grace_nonces"`
+	ValidationRate             uint32 `json:"validation_rate"`
+	SealGraceNonces            uint32 `json:"seal_grace_nonces"`
+	InferenceClearGraceSeconds uint32 `json:"inference_clear_grace_seconds"`
 }
 
 func (p *Proxy) handleDebugPending(w http.ResponseWriter, r *http.Request) {
@@ -645,8 +646,9 @@ func (p *Proxy) handleStatus(w http.ResponseWriter, r *http.Request) {
 			CreateDevshardFee: cfg.CreateDevshardFee,
 			FeePerNonce:       cfg.FeePerNonce,
 			VoteThreshold:     cfg.VoteThreshold,
-			ValidationRate:    cfg.ValidationRate,
-			SealGraceNonces:   cfg.SealGraceNonces,
+			ValidationRate:             cfg.ValidationRate,
+			SealGraceNonces:            cfg.SealGraceNonces,
+			InferenceClearGraceSeconds: cfg.InferenceClearGraceSeconds,
 		},
 	}
 

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,13 +20,25 @@ import (
 	"devshard/user"
 )
 
-// metaDrainTimeout caps how long the upstream SSE drain may continue after
-// the OpenAI client has disconnected. The drain must run long enough to
-// observe devshard_meta (which the host emits after [DONE]) so that the
-// session can merge mempool txs (e.g. MsgFinishInference) into pending,
-// but a malicious upstream host must not be able to pin the proxy
-// indefinitely once the client is gone.
-const metaDrainTimeout = 5 * time.Second
+const defaultMetaDrainTimeout = 10 * time.Second
+
+// metaDrainTimeout applies only after client disconnect (flag.Done() in
+// sendAndProcess), not during normal connected flows. If devshard_meta /
+// MsgFinishInference is missed due to this cap, proxy continues via
+// handleTimeout (progresses, but may classify as timeout).
+var metaDrainTimeout = metaDrainTimeoutFromEnv()
+
+func metaDrainTimeoutFromEnv() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("DEVSHARD_META_DRAIN_TIMEOUT_SECONDS"))
+	if raw == "" {
+		return defaultMetaDrainTimeout
+	}
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds <= 0 {
+		return defaultMetaDrainTimeout
+	}
+	return time.Duration(seconds) * time.Second
+}
 
 // cancelFlag is a one-shot signal used to communicate "client disconnected"
 // from the request handler down into runInference / sendAndProcess. The

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -242,7 +242,7 @@ func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w
 		reason = types.TimeoutReason_TIMEOUT_REASON_REFUSED
 	}
 
-	// Attempt 2 (final). Skipped when the client is gone -- mitigation 2.
+	// Attempt 2 (final). Skipped when the client is gone.
 	if !flag.Gone() {
 		if w != nil {
 			writeStreamReset(w)

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -19,6 +19,64 @@ import (
 	"devshard/user"
 )
 
+// metaDrainTimeout caps how long the upstream SSE drain may continue after
+// the OpenAI client has disconnected. The drain must run long enough to
+// observe devshard_meta (which the host emits after [DONE]) so that the
+// session can merge mempool txs (e.g. MsgFinishInference) into pending,
+// but a malicious upstream host must not be able to pin the proxy
+// indefinitely once the client is gone.
+const metaDrainTimeout = 5 * time.Second
+
+// cancelFlag is a one-shot signal used to communicate "client disconnected"
+// from the request handler down into runInference / sendAndProcess. The
+// upstream HTTP context is intentionally NOT canceled when the client goes
+// away -- protocol completion (devshard_meta + ProcessResponse) must run to
+// preserve session sequencing of MsgFinishInference into the next user diff.
+type cancelFlag struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+func newCancelFlag() *cancelFlag { return &cancelFlag{ch: make(chan struct{})} }
+
+func (cf *cancelFlag) Trigger() {
+	if cf == nil {
+		return
+	}
+	cf.once.Do(func() { close(cf.ch) })
+}
+
+func (cf *cancelFlag) Gone() bool {
+	if cf == nil {
+		return false
+	}
+	select {
+	case <-cf.ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func (cf *cancelFlag) Done() <-chan struct{} {
+	if cf == nil {
+		return nil
+	}
+	return cf.ch
+}
+
+// watchClientCancel triggers flag when r's context is canceled (client
+// disconnected). Spawns one short-lived goroutine bounded by request lifetime.
+func watchClientCancel(r *http.Request, flag *cancelFlag) {
+	if flag == nil || r == nil {
+		return
+	}
+	go func() {
+		<-r.Context().Done()
+		flag.Trigger()
+	}()
+}
+
 // streamRegistry routes SSE lines to per-request writers by nonce.
 type streamRegistry struct {
 	mu      sync.RWMutex
@@ -138,7 +196,12 @@ var timeoutBuffer = 5 * time.Second
 // runInference sends the inference to the host with at most two attempts.
 // On first failure, waits for the appropriate deadline then retries once.
 // If both attempts fail, collects timeout votes and submits MsgTimeoutInference.
-func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w io.Writer) error {
+//
+// flag may be nil. When non-nil and triggered (client disconnected), the
+// second attempt is skipped (mitigation 2): no point streaming a reset to
+// nobody, but the timeout flow still runs because the network needs
+// MsgTimeoutInference recorded if the executor truly didn't finish.
+func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w io.Writer, flag *cancelFlag) error {
 	prepared, err := p.session.PrepareInference(params)
 	if err != nil {
 		return fmt.Errorf("prepare: %w", err)
@@ -154,7 +217,7 @@ func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w
 	now := time.Now()
 
 	// Attempt 1.
-	finished, confirmedAt, err := p.sendAndProcess(ctx, prepared, nonce)
+	finished, confirmedAt, err := p.sendAndProcess(ctx, prepared, nonce, flag)
 	if err != nil {
 		return err
 	}
@@ -162,7 +225,7 @@ func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w
 		return nil
 	}
 
-	// Wait for the appropriate deadline.
+	// Wait for the appropriate deadline before retrying or collecting timeout votes.
 	var reason types.TimeoutReason
 	if confirmedAt > 0 {
 		deadline := time.Unix(confirmedAt, 0).Add(
@@ -179,21 +242,21 @@ func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w
 		reason = types.TimeoutReason_TIMEOUT_REASON_REFUSED
 	}
 
-	// Attempt 2 (final).
-	if w != nil {
-		writeStreamReset(w)
-	}
-	finished, confirmedAt, err = p.sendAndProcess(ctx, prepared, nonce)
-	if err != nil {
-		return err
-	}
-	if finished {
-		return nil
-	}
-
-	// Update reason if attempt 2 revealed a receipt.
-	if confirmedAt > 0 {
-		reason = types.TimeoutReason_TIMEOUT_REASON_EXECUTION
+	// Attempt 2 (final). Skipped when the client is gone -- mitigation 2.
+	if !flag.Gone() {
+		if w != nil {
+			writeStreamReset(w)
+		}
+		finished, confirmedAt, err = p.sendAndProcess(ctx, prepared, nonce, flag)
+		if err != nil {
+			return err
+		}
+		if finished {
+			return nil
+		}
+		if confirmedAt > 0 {
+			reason = types.TimeoutReason_TIMEOUT_REASON_EXECUTION
+		}
 	}
 
 	return p.handleTimeout(ctx, prepared, nonce, reason, params)
@@ -202,12 +265,38 @@ func (p *Proxy) runInference(ctx context.Context, params user.InferenceParams, w
 // sendAndProcess sends the prepared inference and processes the response.
 // Returns finished=true when MsgFinishInference is in the host's mempool.
 // confirmedAt is the executor's receipt timestamp (0 if no receipt received).
-func (p *Proxy) sendAndProcess(ctx context.Context, prepared *user.PreparedInference, nonce uint64) (finished bool, confirmedAt int64, err error) {
-	resp, sendErr := p.session.SendOnly(ctx, prepared)
+//
+// When flag is non-nil and triggered, the underlying upstream context is
+// capped by metaDrainTimeout so a malicious upstream host cannot pin the
+// proxy indefinitely after the client has disconnected.
+func (p *Proxy) sendAndProcess(ctx context.Context, prepared *user.PreparedInference, nonce uint64, flag *cancelFlag) (finished bool, confirmedAt int64, err error) {
+	sendCtx := ctx
+	if flag != nil {
+		var cancel context.CancelFunc
+		sendCtx, cancel = context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			select {
+			case <-flag.Done():
+				select {
+				case <-time.After(metaDrainTimeout):
+					cancel()
+				case <-sendCtx.Done():
+				}
+			case <-sendCtx.Done():
+			}
+		}()
+	}
+
+	resp, sendErr := p.session.SendOnly(sendCtx, prepared)
 	if sendErr != nil && resp == nil {
 		return false, 0, nil
 	}
 
+	// Always process whatever response we got -- even partial. The host
+	// emits devshard_meta after [DONE]; if the client disconnected and
+	// metaDrainTimeout fired mid-parse, the partial result still carries
+	// receipt/state and any mempool txs that were read before the cap.
 	if err := p.session.ProcessResponse(prepared.HostIdx(), resp, nonce); err != nil {
 		return false, 0, fmt.Errorf("process response: %w", err)
 	}
@@ -283,58 +372,84 @@ func (p *Proxy) handleTimeout(ctx context.Context, prepared *user.PreparedInfere
 	return fmt.Errorf("inference %d timed out but insufficient votes to prove it", nonce)
 }
 
-// deferredWriter delays WriteHeader(200) until the first Write call.
-// If runInference errors before any streaming data arrives, the proxy
-// can still return a proper HTTP error status.
-type deferredWriter struct {
+// proxyWriter delays WriteHeader(200) until the first Write call and
+// swallows all output once the client has disconnected. This is the
+// downstream side of the "decouple upstream from r.Context()" design:
+// upstream work (host SSE drain, ProcessResponse, timeout flow) keeps
+// running while the client-facing writer becomes a no-op.
+type proxyWriter struct {
 	w       http.ResponseWriter
 	started bool
+	flag    *cancelFlag
 }
 
-func (d *deferredWriter) Write(p []byte) (int, error) {
-	if !d.started {
-		d.w.Header().Set("Content-Type", "text/event-stream")
-		d.w.Header().Set("Cache-Control", "no-cache")
-		d.w.Header().Set("Connection", "keep-alive")
-		d.w.WriteHeader(http.StatusOK)
-		d.started = true
+func (pw *proxyWriter) Write(p []byte) (int, error) {
+	if pw.flag.Gone() {
+		// Client is gone; pretend success so callers don't error mid-protocol.
+		return len(p), nil
 	}
-	return d.w.Write(p)
+	if !pw.started {
+		pw.w.Header().Set("Content-Type", "text/event-stream")
+		pw.w.Header().Set("Cache-Control", "no-cache")
+		pw.w.Header().Set("Connection", "keep-alive")
+		pw.w.WriteHeader(http.StatusOK)
+		pw.started = true
+	}
+	return pw.w.Write(p)
 }
 
-func (d *deferredWriter) Flush() {
-	if f, ok := d.w.(http.Flusher); ok {
+func (pw *proxyWriter) Flush() {
+	if pw.flag.Gone() {
+		return
+	}
+	if f, ok := pw.w.(http.Flusher); ok {
 		f.Flush()
 	}
 }
 
 func (p *Proxy) handleStreaming(w http.ResponseWriter, r *http.Request, params user.InferenceParams) {
-	dw := &deferredWriter{w: w}
+	flag := newCancelFlag()
+	pw := &proxyWriter{w: w, flag: flag}
+	watchClientCancel(r, flag)
 
-	err := p.runInference(r.Context(), params, dw)
+	// Upstream work is intentionally NOT bound to r.Context(): the host
+	// SSE body must be drained through devshard_meta even if the client
+	// disconnects, so the session can merge MsgFinishInference into pending.
+	// metaDrainTimeout (applied inside sendAndProcess) bounds how long the
+	// upstream may run after the client is gone.
+	err := p.runInference(context.Background(), params, pw, flag)
+	if flag.Gone() {
+		// Client already gone. Protocol work has been completed (or
+		// capped by metaDrainTimeout). Nothing more to send back.
+		return
+	}
 	if err != nil {
-		if !dw.started {
-			// No streaming data sent yet -- return proper HTTP error.
+		if !pw.started {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadGateway)
 			fmt.Fprintf(w, `{"error":{"message":%q}}`, err.Error())
 			return
 		}
-		// Already streaming -- send error as SSE data.
 		log.Printf("inference error (mid-stream): %v", err)
-		fmt.Fprintf(dw, "data: {\"error\":{\"message\":%q}}\n\n", err.Error())
-		dw.Flush()
+		fmt.Fprintf(pw, "data: {\"error\":{\"message\":%q}}\n\n", err.Error())
+		pw.Flush()
 		return
 	}
 
-	fmt.Fprint(dw, "data: [DONE]\n\n")
-	dw.Flush()
+	fmt.Fprint(pw, "data: [DONE]\n\n")
+	pw.Flush()
 }
 
 func (p *Proxy) handleNonStreaming(w http.ResponseWriter, r *http.Request, params user.InferenceParams) {
 	var buf bytes.Buffer
+	flag := newCancelFlag()
+	watchClientCancel(r, flag)
 
-	err := p.runInference(r.Context(), params, &buf)
+	err := p.runInference(context.Background(), params, &buf, flag)
+	if flag.Gone() {
+		// Client gone; skip the response write but protocol work has run.
+		return
+	}
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusBadGateway)
 		return

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -92,6 +92,24 @@ func TestHasMsgFinish(t *testing.T) {
 	require.False(t, hasMsgFinish(txs, 2))
 }
 
+func TestMetaDrainTimeoutFromEnv_Default(t *testing.T) {
+	t.Setenv("DEVSHARD_META_DRAIN_TIMEOUT_SECONDS", "")
+	require.Equal(t, defaultMetaDrainTimeout, metaDrainTimeoutFromEnv())
+}
+
+func TestMetaDrainTimeoutFromEnv_Override(t *testing.T) {
+	t.Setenv("DEVSHARD_META_DRAIN_TIMEOUT_SECONDS", "17")
+	require.Equal(t, 17*time.Second, metaDrainTimeoutFromEnv())
+}
+
+func TestMetaDrainTimeoutFromEnv_InvalidFallsBack(t *testing.T) {
+	t.Setenv("DEVSHARD_META_DRAIN_TIMEOUT_SECONDS", "nope")
+	require.Equal(t, defaultMetaDrainTimeout, metaDrainTimeoutFromEnv())
+
+	t.Setenv("DEVSHARD_META_DRAIN_TIMEOUT_SECONDS", "0")
+	require.Equal(t, defaultMetaDrainTimeout, metaDrainTimeoutFromEnv())
+}
+
 // --- Test infrastructure for proxy-level tests ---
 
 // killableClient wraps a HostClient. Kill/Revive toggle availability.

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -223,7 +223,7 @@ func TestRunInference_HappyPath(t *testing.T) {
 	ctx := context.Background()
 
 	var buf bytes.Buffer
-	err := env.proxy.runInference(ctx, defaultParams(), &buf)
+	err := env.proxy.runInference(ctx, defaultParams(), &buf, nil)
 	require.NoError(t, err)
 
 	// Inference 1 exists in state (applied locally by PrepareInference).
@@ -251,7 +251,7 @@ func TestRunInference_RefusalTimeout(t *testing.T) {
 	env.killables[1].Kill()
 
 	var buf bytes.Buffer
-	err := env.proxy.runInference(ctx, defaultParams(), &buf)
+	err := env.proxy.runInference(ctx, defaultParams(), &buf, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "timed out")
 	require.Contains(t, err.Error(), "REFUSED")
@@ -279,7 +279,7 @@ func TestRunInference_ExecutionTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	var buf bytes.Buffer
-	err := env.proxy.runInference(ctx, defaultParams(), &buf)
+	err := env.proxy.runInference(ctx, defaultParams(), &buf, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "timed out")
 	require.Contains(t, err.Error(), "EXECUTION")
@@ -305,7 +305,7 @@ func TestRunInference_RecoveryOnRetry(t *testing.T) {
 	}()
 
 	var buf bytes.Buffer
-	err := env.proxy.runInference(ctx, defaultParams(), &buf)
+	err := env.proxy.runInference(ctx, defaultParams(), &buf, nil)
 	require.NoError(t, err, "second attempt should succeed after host is revived")
 
 	// MsgFinishInference should be in pending txs (not yet applied to state).
@@ -329,7 +329,7 @@ func TestHandleTimeout_InsufficientVotes(t *testing.T) {
 	env.killables[1].Kill()
 
 	var buf bytes.Buffer
-	err := env.proxy.runInference(ctx, defaultParams(), &buf)
+	err := env.proxy.runInference(ctx, defaultParams(), &buf, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "insufficient votes")
 
@@ -338,4 +338,106 @@ func TestHandleTimeout_InsufficientVotes(t *testing.T) {
 	rec, ok := st.Inferences[1]
 	require.True(t, ok)
 	require.Equal(t, types.StatusPending, rec.Status)
+}
+
+// --- Cancel-flag / client-disconnect tests ---
+
+func TestCancelFlag_NilSafeAndOneShot(t *testing.T) {
+	var nilFlag *cancelFlag
+	require.False(t, nilFlag.Gone(), "nil flag must be safe to query")
+	require.Nil(t, nilFlag.Done(), "nil flag must return a nil channel")
+	nilFlag.Trigger() // must not panic.
+
+	flag := newCancelFlag()
+	require.False(t, flag.Gone())
+	flag.Trigger()
+	require.True(t, flag.Gone())
+	flag.Trigger() // idempotent.
+	require.True(t, flag.Gone())
+
+	select {
+	case <-flag.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done channel should fire after Trigger")
+	}
+}
+
+func TestProxyWriter_SwallowsAfterClientGone(t *testing.T) {
+	rec := httptest.NewRecorder()
+	flag := newCancelFlag()
+	pw := &proxyWriter{w: rec, flag: flag}
+
+	n, err := pw.Write([]byte("data: first\n\n"))
+	require.NoError(t, err)
+	require.Equal(t, 13, n)
+	require.True(t, pw.started)
+	require.Contains(t, rec.Body.String(), "data: first")
+
+	flag.Trigger()
+	before := rec.Body.Len()
+
+	n, err = pw.Write([]byte("data: dropped\n\n"))
+	require.NoError(t, err, "writes after client cancel must succeed for callers")
+	require.Equal(t, 15, n, "Write must report full byte count to keep callers happy")
+	require.Equal(t, before, rec.Body.Len(), "no bytes should reach the recorder after cancel")
+
+	pw.Flush() // must be a no-op once client is gone -- exercises the early return.
+}
+
+// TestRunInference_ClientGoneSkipsRetry verifies mitigation 2: when the
+// cancel flag fires while attempt 1 is in flight (executor down), the proxy
+// must skip the second send attempt and go directly to the timeout flow.
+func TestRunInference_ClientGoneSkipsRetry(t *testing.T) {
+	zeroTimeoutBuffer(t)
+	env := setupTestProxy(t, 3, nil, true)
+	ctx := context.Background()
+
+	env.killables[1].Kill()
+
+	flag := newCancelFlag()
+	flag.Trigger()
+
+	var buf bytes.Buffer
+	err := env.proxy.runInference(ctx, defaultParams(), &buf, flag)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+	require.Contains(t, err.Error(), "REFUSED")
+
+	// Attempt 2 must have been skipped: the executor was never revived,
+	// yet the timeout flow still committed because verifiers accept.
+	st := env.sm.SnapshotState()
+	rec, ok := st.Inferences[1]
+	require.True(t, ok)
+	require.Equal(t, types.StatusTimedOut, rec.Status)
+
+	// No stream_reset SSE event must have been written -- attempt 2 was
+	// the only writer of stream_reset, and it was skipped under cancel.
+	require.NotContains(t, buf.String(), "devshard_stream_reset",
+		"writeStreamReset must not run when client is gone")
+}
+
+// TestRunInference_ClientGoneDuringHappyPath exercises the inverse: when the
+// first attempt succeeds, the cancel flag should not change behavior. The
+// session must still merge MsgFinishInference into pendingTxs.
+func TestRunInference_ClientGoneDuringHappyPath(t *testing.T) {
+	zeroTimeoutBuffer(t)
+	env := setupTestProxy(t, 3, nil, true)
+	ctx := context.Background()
+
+	flag := newCancelFlag()
+	flag.Trigger() // client already gone before attempt 1.
+
+	var buf bytes.Buffer
+	err := env.proxy.runInference(ctx, defaultParams(), &buf, flag)
+	require.NoError(t, err)
+
+	pending := env.session.PendingTxs()
+	hasFinish := false
+	for _, tx := range pending {
+		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == 1 {
+			hasFinish = true
+		}
+	}
+	require.True(t, hasFinish,
+		"MsgFinishInference must reach pendingTxs even when client disconnected -- this is the whole point of the fix")
 }

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
@@ -63,6 +65,18 @@ func TestStreamRegistry_ForwardAndReset(t *testing.T) {
 	before := buf.String()
 	reg.callback(nonce, "data: ignored")
 	require.Equal(t, before, buf.String())
+}
+
+func TestHandleStatus_ExposesSealGraceConfig(t *testing.T) {
+	env := setupTestProxy(t, 3, nil, true)
+	rec := httptest.NewRecorder()
+	env.proxy.handleStatus(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp statusResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, uint32(types.DefaultSealGraceNonces(3)), resp.Config.SealGraceNonces)
+	require.Equal(t, uint32(types.DefaultInferenceClearGraceSeconds), resp.Config.InferenceClearGraceSeconds)
 }
 
 func TestHasMsgFinish(t *testing.T) {

--- a/devshard/docs/proxy.md
+++ b/devshard/docs/proxy.md
@@ -64,10 +64,28 @@ No request body needed. Response is the settlement payload ready for `inferenced
 Returns current session state.
 
 ```json
-{"escrow_id":"42","nonce":15,"phase":"active","balance":5000000000}
+{
+  "escrow_id": "42",
+  "nonce": 15,
+  "phase": "active",
+  "balance": 5000000000,
+  "config": {
+    "refusal_timeout": 60,
+    "execution_timeout": 1200,
+    "token_price": 1,
+    "create_devshard_fee": 10000,
+    "fee_per_nonce": 1000,
+    "vote_threshold": 8,
+    "validation_rate": 5000,
+    "seal_grace_nonces": 160,
+    "inference_clear_grace_seconds": 120
+  }
+}
 ```
 
 Phase values: `active`, `finalizing`, `settlement`.
+
+`config` mirrors the session's frozen `SessionConfig`, including the paired seal-grace gates (`seal_grace_nonces`, `inference_clear_grace_seconds`).
 
 ## OpenAI Python SDK
 

--- a/devshard/storage/shared_test.go
+++ b/devshard/storage/shared_test.go
@@ -69,7 +69,7 @@ func runCreateSession_GetSessionMeta(t *testing.T, store Storage) {
 	require.Equal(t, uint64(7), meta.EpochID)
 	require.Equal(t, types.DefaultStateRootVersion, meta.Version)
 	require.Equal(t, types.DefaultSealGraceNonces(len(meta.Group)), meta.Config.SealGraceNonces)
-	require.Equal(t, types.DefaultInferenceClearGraceSeconds, meta.Config.InferenceClearGraceSeconds)
+	require.Equal(t, uint32(types.DefaultInferenceClearGraceSeconds), meta.Config.InferenceClearGraceSeconds)
 	require.Equal(t, "creator", meta.CreatorAddr)
 	require.Equal(t, uint64(1000), meta.InitialBalance)
 	require.Len(t, meta.Group, 2)

--- a/devshard/storage/shared_test.go
+++ b/devshard/storage/shared_test.go
@@ -69,6 +69,7 @@ func runCreateSession_GetSessionMeta(t *testing.T, store Storage) {
 	require.Equal(t, uint64(7), meta.EpochID)
 	require.Equal(t, types.DefaultStateRootVersion, meta.Version)
 	require.Equal(t, types.DefaultSealGraceNonces(len(meta.Group)), meta.Config.SealGraceNonces)
+	require.Equal(t, types.DefaultInferenceClearGraceSeconds, meta.Config.InferenceClearGraceSeconds)
 	require.Equal(t, "creator", meta.CreatorAddr)
 	require.Equal(t, uint64(1000), meta.InitialBalance)
 	require.Len(t, meta.Group, 2)


### PR DESCRIPTION
When a user aborts a streaming chat (Ctrl+C / client disconnect), **devshardctl** must still read the host’s SSE stream until **`devshard_meta`** arrives. That event carries mempool updates (e.g. `MsgFinishInference`) needed for correct session sequencing. Previously, canceling the client could stop the upstream read too early and drop protocol completion.

**Behavior:** On client disconnect, the proxy stops writing to the client but keeps the **upstream** request alive (bounded drain, default **5s**). It continues parsing SSE until `devshard_meta` or timeout. The OpenAI-facing request context is not canceled solely because the client went away.

## Commits

| Commit | Summary |
|--------|---------|
| `85f2cb79d` | devshardctl: upstream SSE drain through `devshard_meta` on client cancel |
| `651bfab53` | Follow-up cleanup in `proxy.go` |
|`6fe5e29c2`|Added inference_clear_grace_seconds missed|

Other commits are for aligning with 0.2.13

## Files

- `devshard/cmd/devshardctl/proxy.go` — cancel flag, bounded meta drain, streaming/non-streaming paths
- `devshard/cmd/devshardctl/proxy_test.go` — client-cancel + meta drain coverage