### PR TITLE
`devshard` Finish gossip on missed diff

### DIFF
--- a/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
+++ b/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
@@ -113,6 +113,7 @@ type interruptionTestSuite struct {
 	mockRecorder    *cosmosclient.MockCosmosMessageClient
 	mockQueryClient *mockInterruptionQueryClient
 	mockMLServer    *httptest.Server
+	mockClientFactory *mlnodeclient.MockClientFactory
 	server          *Server
 	configManager   *apiconfig.ConfigManager
 	nodeBroker      *broker.Broker
@@ -148,6 +149,66 @@ func (s *interruptionTestSuite) cleanup() {
 	if s.mockMLServer != nil {
 		s.mockMLServer.Close()
 	}
+}
+
+// waitForInferenceNodeReady blocks until the broker considers the node available
+// for inference (INFERENCE status and no in-flight reconciliation). Without this,
+// ServeHTTP can race reconciliation and return "no nodes available for inference".
+func (s *interruptionTestSuite) waitForInferenceNodeReady(t *testing.T, nodeID string) {
+	t.Helper()
+
+	if !s.pollInferenceNodeReady(nodeID, 2*time.Second) {
+		// Reconciliation may not finish in time on slow CI; force stable INFERENCE status.
+		setStatusCmd := broker.NewSetNodesActualStatusCommand([]broker.StatusUpdate{
+			{
+				NodeId:     nodeID,
+				PrevStatus: types.HardwareNodeStatus_UNKNOWN,
+				NewStatus:  types.HardwareNodeStatus_INFERENCE,
+				Timestamp:  time.Now(),
+			},
+		})
+		err := s.nodeBroker.QueueMessage(setStatusCmd)
+		require.NoError(t, err)
+		require.True(t, <-setStatusCmd.Response)
+	}
+
+	if !s.pollInferenceNodeReady(nodeID, 2*time.Second) {
+		t.Fatalf("node %q did not reach stable INFERENCE status in time", nodeID)
+	}
+}
+
+func (s *interruptionTestSuite) pollInferenceNodeReady(nodeID string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		nodes, err := s.nodeBroker.GetNodes()
+		if err == nil {
+			for _, n := range nodes {
+				if n.Node.Id == nodeID &&
+					n.State.IntendedStatus == types.HardwareNodeStatus_INFERENCE &&
+					n.State.CurrentStatus == types.HardwareNodeStatus_INFERENCE &&
+					n.State.ReconcileInfo == nil {
+					return true
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+func (s *interruptionTestSuite) waitForFinishInferenceCalls(t *testing.T, want int, timeout time.Duration) []*inference.MsgFinishInference {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		calls := s.getFinishInferenceCalls()
+		if len(calls) >= want {
+			return calls
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	calls := s.getFinishInferenceCalls()
+	require.Len(t, calls, want, "timed out waiting for FinishInference calls")
+	return calls
 }
 
 // ============================================================================
@@ -483,9 +544,9 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 	mockParticipant.On("GetPubKey").Return(suite.taKey.GetPubKeyBase64())
 
 	bridge := broker.NewBrokerChainBridgeImpl(suite.mockRecorder, "")
-	mockClientFactory := mlnodeclient.NewMockClientFactory()
+	suite.mockClientFactory = mlnodeclient.NewMockClientFactory()
 
-	suite.nodeBroker = broker.NewBroker(bridge, suite.phaseTracker, mockParticipant, "", mockClientFactory, suite.configManager)
+	suite.nodeBroker = broker.NewBroker(bridge, suite.phaseTracker, mockParticipant, "", suite.mockClientFactory, suite.configManager)
 
 	// 6. Register a node pointing to mock ML server
 	mlServerURL := suite.mockMLServer.URL
@@ -524,7 +585,7 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 	suite.nodeBroker.UpdateNodeEpochData([]*types.MLNodeInfo{&mlNode}, "test-model", model)
 
 	pocURL := fmt.Sprintf("http://%s:%d", host, port+1)
-	mockClient := mockClientFactory.CreateClient(pocURL, fmt.Sprintf("http://%s:%d", host, port)).(*mlnodeclient.MockClient)
+	mockClient := suite.mockClientFactory.CreateClient(pocURL, fmt.Sprintf("http://%s:%d", host, port)).(*mlnodeclient.MockClient)
 	mockClient.Mu.Lock()
 	mockClient.CurrentState = mlnodeclient.MlNodeState_INFERENCE
 	mockClient.InferenceIsHealthy = true
@@ -533,6 +594,8 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 	inferenceUpCmd := broker.NewInferenceUpAllCommand()
 	err = suite.nodeBroker.QueueMessage(inferenceUpCmd)
 	require.NoError(t, err)
+	require.True(t, <-inferenceUpCmd.Response)
+	suite.waitForInferenceNodeReady(t, nodeConfig.Id)
 
 	// 7. Create the public server
 	payloadStorage := newMockPayloadStorage()
@@ -882,10 +945,7 @@ func TestInterruption_ClientDisconnect_StreamingComplete_VerifyFinishInference(t
 
 	suite.server.e.ServeHTTP(disconnectWriter, req)
 
-	// Wait for async processing
-	time.Sleep(500 * time.Millisecond)
-
-	calls := suite.getFinishInferenceCalls()
+	calls := suite.waitForFinishInferenceCalls(t, 1, 2*time.Second)
 	t.Logf("CLIENT_DISCONNECT_STREAM RESULT: FinishInference calls count = %d", len(calls))
 	t.Logf("CLIENT_DISCONNECT_STREAM: Written bytes before disconnect = %d", disconnectWriter.writtenBytes)
 

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -378,7 +378,7 @@ func (h *Host) HandleRequest(ctx context.Context, req HostRequest) (*HostRespons
 	// (d) Collect validation candidates under mutex.
 	validationJobs := h.collectValidationJobs()
 
-	// (f) Collect locally-proposed Finish txs that the user has not yet
+	// (e) Collect locally-proposed Finish txs that the user has not yet
 	// absorbed into a diff. Computed under mutex; broadcast outside it.
 	var staleFinishes []*types.DevshardTx
 	if diffsApplied {
@@ -387,20 +387,20 @@ func (h *Host) HandleRequest(ctx context.Context, req HostRequest) (*HostRespons
 
 	h.mu.Unlock()
 
-	// (g) Execution job for caller to run via RunExecution.
+	// (f) Execution job for caller to run via RunExecution.
 	// Execution is always deferred so the caller can send the receipt
 	// before inference starts (SSE flow).
 
-	// (h) Validate other hosts' inferences outside mutex.
+	// (g) Validate other hosts' inferences outside mutex.
 	for _, vj := range validationJobs {
 		h.enqueueValidation(vj)
 	}
 
-	// (i) Recovery gossip: re-broadcast locally produced Finish that the
+	// (h) Recovery gossip: re-broadcast locally produced Finish that the
 	// user sequencer skipped. gossip.BroadcastTxs dedups by tx hash so
 	// repeated triggers across diffs are harmless.
 	if len(staleFinishes) > 0 && h.gsp != nil {
-		go h.gsp.BroadcastTxs(context.Background(), staleFinishes)
+		go h.broadcastTxsBestEffort(staleFinishes)
 	}
 
 	return &HostResponse{
@@ -693,8 +693,14 @@ func (h *Host) ApplyCatchUpDiffs(diffs []types.Diff) {
 	h.mu.Unlock()
 
 	if len(staleFinishes) > 0 && h.gsp != nil {
-		go h.gsp.BroadcastTxs(context.Background(), staleFinishes)
+		go h.broadcastTxsBestEffort(staleFinishes)
 	}
+}
+
+// broadcastTxsBestEffort keeps gossip asynchronous/non-blocking for the host
+// hot path. BroadcastTxs is intentionally fire-and-forget.
+func (h *Host) broadcastTxsBestEffort(txs []*types.DevshardTx) {
+	h.gsp.BroadcastTxs(context.Background(), txs)
 }
 
 // finishGossipGraceRotations is the number of full slot rotations to wait

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -351,12 +351,14 @@ func (h *Host) HandleRequest(ctx context.Context, req HostRequest) (*HostRespons
 
 	// (a) Apply all new diffs.
 	var lastAppliedTxs []*types.DevshardTx
+	diffsApplied := false
 	for _, diff := range req.Diffs {
 		if err := h.applyAndPersist(diff); err != nil {
 			h.mu.Unlock()
 			return nil, err
 		}
 		lastAppliedTxs = diff.Txs
+		diffsApplied = true
 	}
 
 	// (b) Sign executor receipt (sync, under mutex).
@@ -376,15 +378,29 @@ func (h *Host) HandleRequest(ctx context.Context, req HostRequest) (*HostRespons
 	// (d) Collect validation candidates under mutex.
 	validationJobs := h.collectValidationJobs()
 
+	// (f) Collect locally-proposed Finish txs that the user has not yet
+	// absorbed into a diff. Computed under mutex; broadcast outside it.
+	var staleFinishes []*types.DevshardTx
+	if diffsApplied {
+		staleFinishes = h.collectStaleFinishesLocked()
+	}
+
 	h.mu.Unlock()
 
-	// (e) Execution job for caller to run via RunExecution.
+	// (g) Execution job for caller to run via RunExecution.
 	// Execution is always deferred so the caller can send the receipt
 	// before inference starts (SSE flow).
 
-	// (f) Queue validation work outside mutex.
+	// (h) Validate other hosts' inferences outside mutex.
 	for _, vj := range validationJobs {
 		h.enqueueValidation(vj)
+	}
+
+	// (i) Recovery gossip: re-broadcast locally produced Finish that the
+	// user sequencer skipped. gossip.BroadcastTxs dedups by tx hash so
+	// repeated triggers across diffs are harmless.
+	if len(staleFinishes) > 0 && h.gsp != nil {
+		go h.gsp.BroadcastTxs(context.Background(), staleFinishes)
 	}
 
 	return &HostResponse{
@@ -670,10 +686,38 @@ func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *
 // Already-applied diffs (nonce <= current) are silently skipped.
 func (h *Host) ApplyCatchUpDiffs(diffs []types.Diff) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	for _, diff := range diffs {
 		_ = h.applyAndPersist(diff)
 	}
+	staleFinishes := h.collectStaleFinishesLocked()
+	h.mu.Unlock()
+
+	if len(staleFinishes) > 0 && h.gsp != nil {
+		go h.gsp.BroadcastTxs(context.Background(), staleFinishes)
+	}
+}
+
+// finishGossipGraceRotations is the number of full slot rotations to wait
+// before re-broadcasting a locally-proposed MsgFinishInference that the user
+// sequencer has not yet included in a diff. With round-robin host selection
+// (nonce % len(group)), one rotation = len(group) nonces, so the effective
+// grace is finishGossipGraceRotations * len(group) nonces.
+//
+// Two rotations gives the user two natural chances to pick up the Finish
+// from the executor host's devshard_meta tail (once per rotation) before we
+// fall back to peer-to-peer recovery gossip. Increase if direct-contact
+// recovery should be preferred more strongly; decrease for snappier gossip.
+const finishGossipGraceRotations uint64 = 2
+
+// collectStaleFinishesLocked returns locally proposed MsgFinishInference txs
+// that the user sequencer has not yet included in a diff after the grace
+// period. Caller must hold h.mu. See Mempool.StaleFinishes for the criterion.
+func (h *Host) collectStaleFinishesLocked() []*types.DevshardTx {
+	if h.gsp == nil {
+		return nil
+	}
+	grace := finishGossipGraceRotations * uint64(len(h.group))
+	return h.mempool.StaleFinishes(h.sm.LatestNonce(), grace)
 }
 
 // signIfAccepted computes state root, checks acceptance, signs if allowed,

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -22,6 +22,18 @@ import (
 	"devshard/types"
 )
 
+// finishGossipGraceRotations is the number of full slot rotations to wait
+// before re-broadcasting a locally-proposed MsgFinishInference that the user
+// sequencer has not yet included in a diff. With round-robin host selection
+// (nonce % len(group)), one rotation = len(group) nonces, so the effective
+// grace is finishGossipGraceRotations * len(group) nonces.
+//
+// Two rotations gives the user two natural chances to pick up the Finish
+// from the executor host's devshard_meta tail (once per rotation) before we
+// fall back to peer-to-peer recovery gossip. Increase if direct-contact
+// recovery should be preferred more strongly; decrease for snappier gossip.
+const finishGossipGraceRotations uint64 = 2
+
 // InferencePayload carries the actual request data for the current inference.
 // The host verifies these against the signed MsgStartInference in the diff.
 type InferencePayload struct {
@@ -702,18 +714,6 @@ func (h *Host) ApplyCatchUpDiffs(diffs []types.Diff) {
 func (h *Host) broadcastTxsBestEffort(txs []*types.DevshardTx) {
 	h.gsp.BroadcastTxs(context.Background(), txs)
 }
-
-// finishGossipGraceRotations is the number of full slot rotations to wait
-// before re-broadcasting a locally-proposed MsgFinishInference that the user
-// sequencer has not yet included in a diff. With round-robin host selection
-// (nonce % len(group)), one rotation = len(group) nonces, so the effective
-// grace is finishGossipGraceRotations * len(group) nonces.
-//
-// Two rotations gives the user two natural chances to pick up the Finish
-// from the executor host's devshard_meta tail (once per rotation) before we
-// fall back to peer-to-peer recovery gossip. Increase if direct-contact
-// recovery should be preferred more strongly; decrease for snappier gossip.
-const finishGossipGraceRotations uint64 = 2
 
 // collectStaleFinishesLocked returns locally proposed MsgFinishInference txs
 // that the user sequencer has not yet included in a diff after the grace

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -75,12 +75,19 @@ func awaitTxsCall(t *testing.T, p *recordingPeer, deadline time.Duration) [][]*t
 // one-shot sleep because it continuously checks for asynchronous activity.
 func assertNoTxsCallFor(t *testing.T, p *recordingPeer, quietWindow time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(quietWindow)
-	for time.Now().Before(deadline) {
+	timeout := time.NewTimer(quietWindow)
+	defer timeout.Stop()
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
+	for {
 		if n := p.txsCount.Load(); n > 0 {
 			t.Fatalf("expected no GossipTxs calls for %s, got %d", quietWindow, n)
 		}
-		time.Sleep(5 * time.Millisecond)
+		select {
+		case <-timeout.C:
+			return
+		case <-tick.C:
+		}
 	}
 }
 

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -55,6 +55,8 @@ func awaitTxsCall(t *testing.T, p *recordingPeer, deadline time.Duration) [][]*t
 	t.Helper()
 	timeout := time.NewTimer(deadline)
 	defer timeout.Stop()
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
 	for {
 		if p.txsCount.Load() > 0 {
 			return p.Calls()
@@ -63,8 +65,22 @@ func awaitTxsCall(t *testing.T, p *recordingPeer, deadline time.Duration) [][]*t
 		case <-timeout.C:
 			t.Fatalf("expected at least one GossipTxs call within %s, got 0", deadline)
 			return nil
-		case <-time.After(5 * time.Millisecond):
+		case <-tick.C:
 		}
+	}
+}
+
+// assertNoTxsCallFor polls for the full quietWindow and fails immediately if
+// recordingPeer observes any GossipTxs call. This is more deterministic than a
+// one-shot sleep because it continuously checks for asynchronous activity.
+func assertNoTxsCallFor(t *testing.T, p *recordingPeer, quietWindow time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(quietWindow)
+	for time.Now().Before(deadline) {
+		if n := p.txsCount.Load(); n > 0 {
+			t.Fatalf("expected no GossipTxs calls for %s, got %d", quietWindow, n)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 
@@ -1546,9 +1562,7 @@ func TestHost_FinishGossipRecovery_TriggersOnMissedDiff(t *testing.T) {
 		_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
 		require.NoError(t, err)
 	}
-	time.Sleep(50 * time.Millisecond)
-	require.Equal(t, int32(0), peer.txsCount.Load(),
-		"recovery gossip must not fire until ProposedAt + grace < currentNonce")
+	assertNoTxsCallFor(t, peer, 50*time.Millisecond)
 
 	// One more empty diff crosses the threshold: 1 + grace < currentNonce.
 	crossing := testutil.SignDiff(t, user, "escrow-1", 2+grace, nil)
@@ -1598,10 +1612,8 @@ func TestHost_FinishGossipRecovery_NoTriggerWhenIncluded(t *testing.T) {
 	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff2, diff3}})
 	require.NoError(t, err)
 
-	// Give a goroutine slot for any spurious broadcast to land.
-	time.Sleep(50 * time.Millisecond)
-	require.Equal(t, int32(0), peer.txsCount.Load(),
-		"no recovery gossip should fire when the user includes Finish in time")
+	// Keep a short quiet window and fail immediately if any spurious broadcast lands.
+	assertNoTxsCallFor(t, peer, 50*time.Millisecond)
 }
 
 // TestHost_FinishGossipRecovery_PeerImportedFinishNotAmplified guards the
@@ -1627,7 +1639,5 @@ func TestHost_FinishGossipRecovery_PeerImportedFinishNotAmplified(t *testing.T) 
 		require.NoError(t, err)
 	}
 
-	time.Sleep(50 * time.Millisecond)
-	require.Equal(t, int32(0), peer.txsCount.Load(),
-		"peer-imported Finish (ProposedAt=0) must not be re-broadcast")
+	assertNoTxsCallFor(t, peer, 50*time.Millisecond)
 }

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"devshard"
+	"devshard/gossip"
 	"devshard/internal/testutil"
 	"devshard/signing"
 	"devshard/state"
@@ -20,6 +21,52 @@ import (
 	"devshard/stub"
 	"devshard/types"
 )
+
+// recordingPeer implements gossip.PeerClient and records GossipTxs calls.
+// Used by tests that exercise the host's recovery-gossip trigger.
+type recordingPeer struct {
+	mu       sync.Mutex
+	txsCalls [][]*types.DevshardTx
+	txsCount atomic.Int32
+}
+
+func (p *recordingPeer) GossipNonce(_ context.Context, _ uint64, _, _ []byte, _ uint32) error {
+	return nil
+}
+
+func (p *recordingPeer) GossipTxs(_ context.Context, txs []*types.DevshardTx) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.txsCalls = append(p.txsCalls, txs)
+	p.txsCount.Add(1)
+	return nil
+}
+
+func (p *recordingPeer) Calls() [][]*types.DevshardTx {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([][]*types.DevshardTx, len(p.txsCalls))
+	copy(out, p.txsCalls)
+	return out
+}
+
+// awaitTxsCall polls until the recordingPeer has at least one GossipTxs call.
+func awaitTxsCall(t *testing.T, p *recordingPeer, deadline time.Duration) [][]*types.DevshardTx {
+	t.Helper()
+	timeout := time.NewTimer(deadline)
+	defer timeout.Stop()
+	for {
+		if p.txsCount.Load() > 0 {
+			return p.Calls()
+		}
+		select {
+		case <-timeout.C:
+			t.Fatalf("expected at least one GossipTxs call within %s, got 0", deadline)
+			return nil
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
 
 // --- Package-specific test helpers ---
 
@@ -1431,4 +1478,156 @@ func TestHost_SavesSnapshotOnSettlement(t *testing.T) {
 		state, err := UnmarshalStateSnapshot(data)
 		return err == nil && state.Phase == types.PhaseSettlement && state.LatestNonce == 2
 	}, time.Second, 10*time.Millisecond)
+}
+
+// --- finish-gossip recovery tests ---
+
+// newExecutorHostWithGossip wires host index 1 (executor for inference 1, since
+// 1 % 3 = 1) with a real *gossip.Gossip instance backed by recordingPeer so we
+// can observe the host's recovery-gossip dispatch.
+func newExecutorHostWithGossip(t *testing.T) (*Host, []*signing.Secp256k1Signer, *signing.Secp256k1Signer, *recordingPeer) {
+	t.Helper()
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 100_000, user.Address(), verifier)
+	require.NoError(t, err)
+
+	engine := stub.NewInferenceEngine()
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil,
+		WithGrace(100),
+	)
+	require.NoError(t, err)
+
+	// Build gossip with the host's own mempool as MempoolSink; attach it
+	// to the host afterward to avoid the chicken-and-egg of WithGossip
+	// inside NewHost needing the live mempool.
+	peer := &recordingPeer{}
+	g := gossip.NewGossip("escrow-1", 1 /* slotID */, []gossip.PeerClient{peer}, h.HostMempool())
+	WithGossip(g)(h)
+
+	return h, hosts, user, peer
+}
+
+// TestHost_FinishGossipRecovery_TriggersOnMissedDiff is the core recovery test:
+// after the executor produces a Finish, if the user's subsequent diffs do not
+// include it for more than `finishGossipGraceRotations * len(group)` nonces,
+// the host must broadcast the Finish via tx gossip.
+func TestHost_FinishGossipRecovery_TriggersOnMissedDiff(t *testing.T) {
+	h, _, user, peer := newExecutorHostWithGossip(t)
+	groupSize := uint64(len(h.Group()))
+	grace := finishGossipGraceRotations * groupSize
+
+	// Diff 1: StartTx for inference 1; host 1 executes (1 % 3 = 1).
+	diff1 := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	resp, err := h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{diff1}, Nonce: 1, Payload: defaultPayload(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.ExecutionJob, "host 1 should be the executor")
+
+	// Run execution; this adds MsgFinishInference to mempool with ProposedAt=1.
+	_, err = h.RunExecution(context.Background(), resp.ExecutionJob)
+	require.NoError(t, err)
+	require.NotNil(t, findMempoolFinish(h.MempoolTxs()),
+		"Finish should be in mempool after RunExecution")
+
+	// Apply empty diffs up to (but not past) the grace threshold. The Finish
+	// has ProposedAt=1, so it becomes stale once currentNonce > 1 + grace.
+	// At currentNonce == 1 + grace the trigger must NOT fire yet.
+	for nonce := uint64(2); nonce <= 1+grace; nonce++ {
+		diff := testutil.SignDiff(t, user, "escrow-1", nonce, nil)
+		_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
+		require.NoError(t, err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), peer.txsCount.Load(),
+		"recovery gossip must not fire until ProposedAt + grace < currentNonce")
+
+	// One more empty diff crosses the threshold: 1 + grace < currentNonce.
+	crossing := testutil.SignDiff(t, user, "escrow-1", 2+grace, nil)
+	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{crossing}})
+	require.NoError(t, err)
+
+	// Recovery gossip is dispatched in a goroutine; await the call.
+	calls := awaitTxsCall(t, peer, 2*time.Second)
+	require.GreaterOrEqual(t, len(calls), 1)
+
+	// The broadcasted batch must contain the Finish for inference 1.
+	var found bool
+	for _, batch := range calls {
+		for _, tx := range batch {
+			if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == 1 {
+				found = true
+			}
+		}
+	}
+	require.True(t, found, "broadcast must include MsgFinishInference for inference 1")
+}
+
+// TestHost_FinishGossipRecovery_NoTriggerWhenIncluded verifies that if the
+// next user diff actually includes the Finish, no recovery gossip is sent.
+func TestHost_FinishGossipRecovery_NoTriggerWhenIncluded(t *testing.T) {
+	h, _, user, peer := newExecutorHostWithGossip(t)
+
+	diff1 := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	resp, err := h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{diff1}, Nonce: 1, Payload: defaultPayload(),
+	})
+	require.NoError(t, err)
+
+	_, err = h.RunExecution(context.Background(), resp.ExecutionJob)
+	require.NoError(t, err)
+
+	confirmTx := findMempoolConfirm(h.MempoolTxs())
+	finishTxFromMempool := findMempoolFinish(h.MempoolTxs())
+	require.NotNil(t, confirmTx)
+	require.NotNil(t, finishTxFromMempool)
+
+	// Diff 2 includes confirm, diff 3 includes Finish. The Finish never has
+	// a "missed" applied-diff in this sequence: applyAndPersist removes it
+	// from mempool the moment diff 3 lands.
+	diff2 := testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{confirmTx})
+	diff3 := testutil.SignDiff(t, user, "escrow-1", 3, []*types.DevshardTx{finishTxFromMempool})
+	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff2, diff3}})
+	require.NoError(t, err)
+
+	// Give a goroutine slot for any spurious broadcast to land.
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), peer.txsCount.Load(),
+		"no recovery gossip should fire when the user includes Finish in time")
+}
+
+// TestHost_FinishGossipRecovery_PeerImportedFinishNotAmplified guards the
+// ProposedAt > 0 filter: a Finish that arrived from a peer (added via
+// gossip.OnTxsReceived → mempool.AddTx, ProposedAt=0) must not be re-broadcast
+// even after the staleness threshold would otherwise mark it stale.
+func TestHost_FinishGossipRecovery_PeerImportedFinishNotAmplified(t *testing.T) {
+	h, _, user, peer := newExecutorHostWithGossip(t)
+	groupSize := uint64(len(h.Group()))
+	grace := finishGossipGraceRotations * groupSize
+
+	// Inject a peer-imported Finish for an inference this host did not execute.
+	imported := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{
+		FinishInference: &types.MsgFinishInference{InferenceId: 999},
+	}}
+	h.HostMempool().AddTx(imported) // ProposedAt=0 sentinel.
+
+	// Advance well past 0 + grace so the only thing keeping this tx out of
+	// the broadcast set is the ProposedAt > 0 filter.
+	for nonce := uint64(1); nonce <= grace+2; nonce++ {
+		diff := testutil.SignDiff(t, user, "escrow-1", nonce, nil)
+		_, err := h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
+		require.NoError(t, err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), peer.txsCount.Load(),
+		"peer-imported Finish (ProposedAt=0) must not be re-broadcast")
 }

--- a/devshard/host/mempool.go
+++ b/devshard/host/mempool.go
@@ -51,6 +51,51 @@ func (m *Mempool) HasStaleEntry(currentNonce, grace uint64) bool {
 	return false
 }
 
+// StaleFinishes returns locally-proposed MsgFinishInference txs (ProposedAt > 0)
+// that have been sitting in the mempool for more than `grace` nonces past
+// their proposal point (e.ProposedAt + grace < currentNonce).
+//
+// RemoveIncluded clears any entry whose tx hash is in an applied diff, so an
+// entry still present after applyAndPersist at nonce N was, by definition,
+// not included in any diff up to and including N. The `grace` adds a buffer
+// on top of that: callers typically set it to two full slot rotations
+// (2 * len(group)) so the user has at least two chances to pick up the
+// Finish via natural round-robin contact with the executor host before we
+// resort to peer-to-peer recovery gossip.
+//
+// Used by the host to recover from "user as sole sequencer" stalls: if the
+// user diff failed to absorb our Finish (e.g. because the OpenAI client at
+// devshardctl disconnected before reading devshard_meta, or the proxy
+// crashed mid-drain), we re-broadcast it via tx gossip so peers can learn
+// about it and -- crucially -- include it in their own mempool returns to
+// the user, giving the user another path to sequence it into a signed diff.
+//
+// Peer-imported entries (ProposedAt == 0, set by AddTx via gossip.OnTxsReceived)
+// are intentionally excluded so we don't amplify other hosts' broadcasts.
+//
+// Iteration order is unspecified; consumers (gossip broadcast dedups by tx
+// hash, user re-sorts pending txs) are order-insensitive.
+func (m *Mempool) StaleFinishes(currentNonce, grace uint64) []*types.DevshardTx {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.entries) == 0 {
+		return nil
+	}
+	var out []*types.DevshardTx
+	for _, e := range m.entries {
+		if e.ProposedAt == 0 {
+			continue
+		}
+		if e.Tx.GetFinishInference() == nil {
+			continue
+		}
+		if e.ProposedAt+grace < currentNonce {
+			out = append(out, e.Tx)
+		}
+	}
+	return out
+}
+
 func (m *Mempool) Txs() []*types.DevshardTx {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -74,5 +119,3 @@ func (m *Mempool) Len() int {
 func (m *Mempool) AddTx(tx *types.DevshardTx) {
 	m.Add(MempoolEntry{Tx: tx, ProposedAt: 0})
 }
-
-

--- a/devshard/host/mempool_test.go
+++ b/devshard/host/mempool_test.go
@@ -80,3 +80,42 @@ func TestMempool_DuplicateAdd(t *testing.T) {
 
 	require.Equal(t, 1, m.Len(), "duplicate tx should overwrite, not double-add")
 }
+
+func TestMempool_StaleFinishes(t *testing.T) {
+	m := NewMempool()
+	require.Nil(t, m.StaleFinishes(10, 0), "empty mempool returns nil")
+
+	localFinish := finishTx(1)
+	peerFinish := finishTx(2)
+	val := validationTx(1, 0)
+	m.Add(MempoolEntry{Tx: localFinish, ProposedAt: 5})
+	m.Add(MempoolEntry{Tx: val, ProposedAt: 5})
+	m.AddTx(peerFinish) // ProposedAt: 0 -- gossip-imported sentinel.
+
+	// grace=0, currentNonce == ProposedAt: not yet stale.
+	require.Empty(t, m.StaleFinishes(5, 0))
+
+	// grace=0, currentNonce > ProposedAt: locally-proposed Finish is stale.
+	stale := m.StaleFinishes(6, 0)
+	require.Len(t, stale, 1, "only the local Finish should be returned")
+	require.NotNil(t, stale[0].GetFinishInference())
+	require.Equal(t, uint64(1), stale[0].GetFinishInference().InferenceId)
+
+	// grace > 0 buffers the trigger: at ProposedAt+grace we are still not
+	// stale (5+2 < 7 is false); only past that point.
+	require.Empty(t, m.StaleFinishes(7, 2), "ProposedAt+grace not yet exceeded")
+	require.Len(t, m.StaleFinishes(8, 2), 1, "exceeding ProposedAt+grace marks stale")
+
+	// Peer-imported Finish (ProposedAt=0) must never be reported, regardless
+	// of currentNonce or grace, to avoid amplifying other hosts' broadcasts.
+	for n := uint64(1); n < 100; n++ {
+		for _, tx := range m.StaleFinishes(n, 0) {
+			require.NotEqual(t, uint64(2), tx.GetFinishInference().InferenceId,
+				"peer-imported Finish must be excluded")
+		}
+	}
+
+	// Validations and other non-Finish tx types are never returned, even when
+	// locally proposed and past their proposal nonce.
+	require.Len(t, m.StaleFinishes(99, 0), 1, "only Finish txs are eligible")
+}

--- a/devshard/host/mempool_test.go
+++ b/devshard/host/mempool_test.go
@@ -82,40 +82,96 @@ func TestMempool_DuplicateAdd(t *testing.T) {
 }
 
 func TestMempool_StaleFinishes(t *testing.T) {
-	m := NewMempool()
-	require.Nil(t, m.StaleFinishes(10, 0), "empty mempool returns nil")
-
-	localFinish := finishTx(1)
-	peerFinish := finishTx(2)
-	val := validationTx(1, 0)
-	m.Add(MempoolEntry{Tx: localFinish, ProposedAt: 5})
-	m.Add(MempoolEntry{Tx: val, ProposedAt: 5})
-	m.AddTx(peerFinish) // ProposedAt: 0 -- gossip-imported sentinel.
-
-	// grace=0, currentNonce == ProposedAt: not yet stale.
-	require.Empty(t, m.StaleFinishes(5, 0))
-
-	// grace=0, currentNonce > ProposedAt: locally-proposed Finish is stale.
-	stale := m.StaleFinishes(6, 0)
-	require.Len(t, stale, 1, "only the local Finish should be returned")
-	require.NotNil(t, stale[0].GetFinishInference())
-	require.Equal(t, uint64(1), stale[0].GetFinishInference().InferenceId)
-
-	// grace > 0 buffers the trigger: at ProposedAt+grace we are still not
-	// stale (5+2 < 7 is false); only past that point.
-	require.Empty(t, m.StaleFinishes(7, 2), "ProposedAt+grace not yet exceeded")
-	require.Len(t, m.StaleFinishes(8, 2), 1, "exceeding ProposedAt+grace marks stale")
-
-	// Peer-imported Finish (ProposedAt=0) must never be reported, regardless
-	// of currentNonce or grace, to avoid amplifying other hosts' broadcasts.
-	for n := uint64(1); n < 100; n++ {
-		for _, tx := range m.StaleFinishes(n, 0) {
-			require.NotEqual(t, uint64(2), tx.GetFinishInference().InferenceId,
-				"peer-imported Finish must be excluded")
+	buildMixedMempool := func() *Mempool {
+		m := NewMempool()
+		m.Add(MempoolEntry{Tx: finishTx(1), ProposedAt: 5}) // local finish
+		m.Add(MempoolEntry{Tx: validationTx(1, 0), ProposedAt: 5})
+		m.AddTx(finishTx(2)) // peer-imported finish (ProposedAt=0 sentinel)
+		return m
+	}
+	staleFinishIDs := func(txs []*types.DevshardTx) []uint64 {
+		var ids []uint64
+		for _, tx := range txs {
+			fi := tx.GetFinishInference()
+			if fi != nil {
+				ids = append(ids, fi.InferenceId)
+			}
 		}
+		return ids
 	}
 
-	// Validations and other non-Finish tx types are never returned, even when
-	// locally proposed and past their proposal nonce.
-	require.Len(t, m.StaleFinishes(99, 0), 1, "only Finish txs are eligible")
+	tests := []struct {
+		name         string
+		build        func() *Mempool
+		currentNonce uint64
+		grace        uint64
+		wantNil      bool
+		wantFinishID []uint64
+	}{
+		{
+			name:         "empty mempool returns nil",
+			build:        func() *Mempool { return NewMempool() },
+			currentNonce: 10,
+			grace:        0,
+			wantNil:      true,
+		},
+		{
+			name:         "at proposed nonce not stale",
+			build:        buildMixedMempool,
+			currentNonce: 5,
+			grace:        0,
+			wantFinishID: nil,
+		},
+		{
+			name:         "past proposed nonce stale local finish only",
+			build:        buildMixedMempool,
+			currentNonce: 6,
+			grace:        0,
+			wantFinishID: []uint64{1},
+		},
+		{
+			name:         "grace boundary not exceeded",
+			build:        buildMixedMempool,
+			currentNonce: 7,
+			grace:        2,
+			wantFinishID: nil,
+		},
+		{
+			name:         "grace exceeded marks stale",
+			build:        buildMixedMempool,
+			currentNonce: 8,
+			grace:        2,
+			wantFinishID: []uint64{1},
+		},
+		{
+			name:         "non-finish tx types never returned",
+			build:        buildMixedMempool,
+			currentNonce: 99,
+			grace:        0,
+			wantFinishID: []uint64{1},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.build()
+			got := m.StaleFinishes(tc.currentNonce, tc.grace)
+			if tc.wantNil {
+				require.Nil(t, got)
+				return
+			}
+			require.Equal(t, tc.wantFinishID, staleFinishIDs(got))
+		})
+	}
+
+	t.Run("peer-imported finish is never returned across nonce range", func(t *testing.T) {
+		m := buildMixedMempool()
+		for n := uint64(1); n < 100; n++ {
+			for _, tx := range m.StaleFinishes(n, 0) {
+				require.NotEqual(t, uint64(2), tx.GetFinishInference().InferenceId,
+					"peer-imported Finish must be excluded")
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Summary

When the executor host produces `MsgFinishInference` but the user sequencer does not include it in a signed diff for several nonces (e.g. devshardctl client disconnect before `devshard_meta`, proxy crash, or other stall), other hosts never learn the Finish and the session can wedge.

This change adds **recovery gossip**: after a grace period, the executor re-broadcasts its locally proposed Finish via tx gossip so peers can absorb it and return it to the user through normal mempool paths.

## Behavior

- **Grace:** `finishGossipGraceRotations × len(group)` nonces (default **2 rotations** → `2 × groupSize`). With round-robin executor selection (`nonce % len(group)`), that gives the user two natural passes to pick up the Finish from the executor’s `devshard_meta` tail before P2P recovery.
- **Trigger:** On each `HandleRequest` that applied diffs, and after `ApplyCatchUpDiffs`, the host checks the mempool for stale local Finishes and calls `gossip.BroadcastTxs` (async, hash-deduped).
- **Scope:** Only **locally proposed** `MsgFinishInference` (`ProposedAt > 0`). Peer-imported mempool entries (`ProposedAt == 0`) are not re-broadcast.

## Code touchpoints

| Area | Change |
|------|--------|
| `devshard/host/mempool.go` | `StaleFinishes(currentNonce, grace)` |
| `devshard/host/host.go` | `collectStaleFinishesLocked`, recovery broadcast in `HandleRequest` / `ApplyCatchUpDiffs` |
| `devshard/host/*_test.go` | Unit + integration tests for trigger, no-trigger when included, no amplification of peer imports |

## Test plan

- [ ] `cd devshard/host && go test -run FinishGossip -count=1 .`
- [ ] `cd devshard/host && go test -count=1 .`
- [ ] `cd devshard && go test ./...` (CI **Build and Test Devshard**)