### PR TITLE
fix(devshard): reassemble fragmented SSE events for raceWriter content classification

### DIFF
--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -103,6 +103,7 @@ var gatewayRuntimeBuilder = buildRuntime
 func main() {
 	ConfigurePoCRequestMode(os.Getenv("DEVSHARD_POC_REQUEST_MODE"))
 	ConfigureCapacityAwareLimits(os.Getenv("DEVSHARD_CAPACITY_AWARE_LIMITS"))
+	configureClassifyCapsFromEnv()
 	flags := parseCLIFlags()
 	runtimeOpts := mustLoadRuntimeOptions(flags)
 	gatewayStore := mustOpenGatewayStore(runtimeOpts.baseStorageDir)

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -873,6 +873,7 @@ type inflight struct {
 	// classifyPartial keeps the tail after the last '\n' from prior Writes;
 	// used to reassemble fragmented SSE events for the classifier.
 	classifyPartial []byte
+	classifyCapLog  sync.Once
 
 	// contentSource labels the field that produced the first content event
 	// ("delta.content", "delta.reasoning_content", "delta.tool_calls", or the
@@ -1280,13 +1281,33 @@ func (rw *raceWriter) takeParseable(p []byte) []byte {
 	return parseable
 }
 
+// logClassifyDrop reports the first reassembly-buffer drop for this attempt.
+// Capped at once per attempt so a persistently newline-less or oversized
+// transport can't spam the log.
+func (rw *raceWriter) logClassifyDrop(reason string) {
+	rw.inf.classifyCapLog.Do(func() {
+		ctx := context.Background()
+		if rw.group != nil {
+			ctx = rw.group.logCtx
+		}
+		logInferenceStage(ctx, rw.inf.escrowID, rw.nonce, "classify_buffer_dropped",
+			"host", rw.inf.hostID,
+			"reason", reason,
+			"buffered", len(rw.inf.classifyPartial),
+			"global_bytes", classifyPartialBytes.Load(),
+		)
+	})
+}
+
 // growClassify appends tail to classifyPartial if both caps still fit.
 func (rw *raceWriter) growClassify(tail []byte) bool {
 	if len(rw.inf.classifyPartial)+len(tail) > maxClassifyPartial {
+		rw.logClassifyDrop("per_attempt_cap")
 		return false
 	}
 	if classifyPartialBytes.Add(int64(len(tail))) > maxClassifyPartialGlobal {
 		classifyPartialBytes.Add(-int64(len(tail)))
+		rw.logClassifyDrop("global_cap")
 		return false
 	}
 	rw.inf.classifyPartial = append(rw.inf.classifyPartial, tail...)
@@ -1296,11 +1317,13 @@ func (rw *raceWriter) growClassify(tail []byte) bool {
 // replaceClassify swaps classifyPartial for buf, adjusting global accounting.
 func (rw *raceWriter) replaceClassify(buf []byte) bool {
 	if len(buf) > maxClassifyPartial {
+		rw.logClassifyDrop("per_attempt_cap")
 		return false
 	}
 	delta := int64(len(buf) - len(rw.inf.classifyPartial))
 	if delta > 0 && classifyPartialBytes.Add(delta) > maxClassifyPartialGlobal {
 		classifyPartialBytes.Add(-delta)
+		rw.logClassifyDrop("global_cap")
 		return false
 	}
 	if delta < 0 {

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -1387,7 +1387,7 @@ func (rw *raceWriter) Write(p []byte) (int, error) {
 					rw.inf.errorCode = details.Code
 					rw.inf.errorType = details.Type
 					rw.inf.errorMessage = details.Message
-					rw.inf.errorBodySample = append(rw.inf.errorBodySample, p...)
+					rw.inf.errorBodySample = append(rw.inf.errorBodySample, parseable...)
 				}
 			}
 		}

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -1281,6 +1281,47 @@ func (rw *raceWriter) takeParseable(p []byte) []byte {
 	return parseable
 }
 
+// classifyParseable records the first content/non-retriable-error signal for
+// this attempt, returning whether the buffer carried either.
+func (rw *raceWriter) classifyParseable(parseable []byte) (hasContent, hasError bool) {
+	if len(parseable) == 0 {
+		return false, false
+	}
+	if src, ok := sseChunkContentSource(parseable); ok {
+		hasContent = true
+		if rw.inf.contentSource == "" {
+			rw.inf.contentSource = src
+		}
+	} else if details, ok := sseChunkErrorDetails(parseable); ok {
+		src := "error"
+		if details.Type != "" {
+			src = "error." + details.Type
+		}
+		hasError = !isRetriableCapabilityErrorMessage(details.Message)
+		if rw.inf.errorSource == "" {
+			rw.inf.errorSource = src
+			rw.inf.errorCode = details.Code
+			rw.inf.errorType = details.Type
+			rw.inf.errorMessage = details.Message
+			rw.inf.errorBodySample = append(rw.inf.errorBodySample, parseable...)
+		}
+	}
+	return hasContent, hasError
+}
+
+// flushClassify classifies a newline-less final SSE event left in classifyPartial
+// once the stream ends, so a truncated tail isn't misread as empty_stream.
+func (rw *raceWriter) flushClassify() {
+	if rw.inf.probe || len(rw.inf.classifyPartial) == 0 {
+		return
+	}
+	hasContent, hasError := rw.classifyParseable(rw.inf.classifyPartial)
+	rw.dropClassify()
+	if hasContent || hasError {
+		rw.inf.contentChunks.Add(1)
+	}
+}
+
 // logClassifyDrop reports the first reassembly-buffer drop for this attempt.
 // Capped at once per attempt so a persistently newline-less or oversized
 // transport can't spam the log.
@@ -1369,28 +1410,7 @@ func (rw *raceWriter) Write(p []byte) (int, error) {
 	var chunkHasContent bool
 	var chunkHasError bool
 	if !rw.inf.probe {
-		parseable := rw.takeParseable(p)
-		if len(parseable) > 0 {
-			if src, ok := sseChunkContentSource(parseable); ok {
-				chunkHasContent = true
-				if rw.inf.contentSource == "" {
-					rw.inf.contentSource = src
-				}
-			} else if details, ok := sseChunkErrorDetails(parseable); ok {
-				src := "error"
-				if details.Type != "" {
-					src = "error." + details.Type
-				}
-				chunkHasError = !isRetriableCapabilityErrorMessage(details.Message)
-				if rw.inf.errorSource == "" {
-					rw.inf.errorSource = src
-					rw.inf.errorCode = details.Code
-					rw.inf.errorType = details.Type
-					rw.inf.errorMessage = details.Message
-					rw.inf.errorBodySample = append(rw.inf.errorBodySample, parseable...)
-				}
-			}
-		}
+		chunkHasContent, chunkHasError = rw.classifyParseable(rw.takeParseable(p))
 	}
 	if chunkHasContent || chunkHasError {
 		rw.inf.contentChunks.Add(1)
@@ -1747,6 +1767,7 @@ func (e *Redundancy) startInflight(ctx context.Context, inf *inflight, race *rac
 	go func() {
 		defer close(inf.done)
 		defer cancel()
+		defer rw.flushClassify()
 		logInferenceStage(ctx, inf.escrowID, inf.nonce, "started", "host", inf.hostID)
 		inf.resp, inf.err = e.session.SendOnly(attemptCtx, inf.prepared, rw, receiptHandler)
 		streamBytes := int64(0)

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -1254,62 +1254,41 @@ type raceWriter struct {
 // back to processing only the current Write.
 const maxClassifyPartial = 256 * 1024
 
-// takeParseable returns bytes safe for SSE classification — the prefix of
-// (prior partial + p) up to and including the final '\n'. Trailing bytes
-// after the last newline are stashed in inf.classifyPartial for the next
-// Write. When no newline is present yet, returns nil and stashes everything.
-// Required because sseChunkContentSource etc. only parse complete data:-
-// prefixed lines; without reassembly a small-chunked transport (TLS
-// fragmentation, slow connections) silently strips classification of any
-// event split across Writes.
+// takeParseable returns the prefix of (buffered partial + p) ending on '\n',
+// safe to feed to the SSE classifier. Trailing bytes after the last '\n'
+// are stashed in inf.classifyPartial for the next Write. Returns nil when
+// no '\n' has been seen yet.
+//
+// Invariant: classifyPartial never contains '\n' — by construction it is
+// the tail kept after the last '\n' on a prior call. So new '\n's can only
+// appear inside p, and we only need to scan p (not the combined buffer).
 func (rw *raceWriter) takeParseable(p []byte) []byte {
-	if len(rw.inf.classifyPartial) == 0 {
-		// Fast path: no prior partial, only inspect p itself.
-		lastNL := bytes.LastIndexByte(p, '\n')
-		if lastNL == -1 {
-			if len(p) > 0 {
-				rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], p...)
-			}
-			return nil
-		}
-		if lastNL+1 < len(p) {
-			rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], p[lastNL+1:]...)
-		} else {
+	lastNLinP := bytes.LastIndexByte(p, '\n')
+
+	if lastNLinP == -1 {
+		// No newline in p — buffer it, unless adding p would exceed the cap.
+		if len(rw.inf.classifyPartial)+len(p) > maxClassifyPartial {
 			rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
-		}
-		return p[: lastNL+1]
-	}
-
-	// Defensive: malformed stream growing without newlines — drop partial.
-	if len(rw.inf.classifyPartial)+len(p) > maxClassifyPartial {
-		rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
-		lastNL := bytes.LastIndexByte(p, '\n')
-		if lastNL == -1 {
 			return nil
 		}
-		if lastNL+1 < len(p) {
-			rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], p[lastNL+1:]...)
-		}
-		return p[: lastNL+1]
-	}
-
-	// Combine prior partial with new bytes; classify whole view.
-	combined := append(rw.inf.classifyPartial, p...)
-	lastNL := bytes.LastIndexByte(combined, '\n')
-	if lastNL == -1 {
-		rw.inf.classifyPartial = combined
+		rw.inf.classifyPartial = append(rw.inf.classifyPartial, p...)
 		return nil
 	}
-	// Copy out the trailing partial — combined shares backing with the prior
-	// classifyPartial, which we're about to replace.
-	if lastNL+1 < len(combined) {
-		tail := make([]byte, len(combined)-lastNL-1)
-		copy(tail, combined[lastNL+1:])
-		rw.inf.classifyPartial = tail
+
+	// p has '\n'. Build parseable = classifyPartial + p[:lastNLinP+1].
+	var parseable []byte
+	if len(rw.inf.classifyPartial) == 0 {
+		parseable = p[:lastNLinP+1]
 	} else {
-		rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
+		buf := make([]byte, 0, len(rw.inf.classifyPartial)+lastNLinP+1)
+		buf = append(buf, rw.inf.classifyPartial...)
+		buf = append(buf, p[:lastNLinP+1]...)
+		parseable = buf
 	}
-	return combined[: lastNL+1]
+
+	// Stash the trailing fragment. Empty trailing → append is a no-op.
+	rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], p[lastNLinP+1:]...)
+	return parseable
 }
 
 func (rw *raceWriter) ctxErr() error {

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -870,6 +870,15 @@ type inflight struct {
 	// different attempt wins or the attempt ends with no content.
 	pendingBuf []byte
 
+	// classifyPartial holds bytes after the last '\n' from prior Write calls.
+	// SSE classifiers (sseChunkContentSource/ErrorDetails/UsageCompletionTokens)
+	// require complete data:-prefixed lines in a single call to parse; when
+	// transport delivers SSE events fragmented across Writes (TLS small frames,
+	// proxy flush mid-event, slow connections), naive per-Write classification
+	// silently misses content. This buffer reassembles events for classification
+	// only — forwarding to the client still uses raw Write bytes unchanged.
+	classifyPartial []byte
+
 	// contentSource labels the field that produced the first content event
 	// ("delta.content", "delta.reasoning_content", "delta.tool_calls", or the
 	// streaming-only convertible shape "message.content"). Set exactly once
@@ -1239,6 +1248,70 @@ type raceWriter struct {
 	inf   *inflight
 }
 
+// maxClassifyPartial caps the SSE-reassembly buffer to defend against
+// malformed transports that stream indefinitely without newlines. If we
+// hit this cap the accumulated partial is dropped and classification falls
+// back to processing only the current Write.
+const maxClassifyPartial = 256 * 1024
+
+// takeParseable returns bytes safe for SSE classification — the prefix of
+// (prior partial + p) up to and including the final '\n'. Trailing bytes
+// after the last newline are stashed in inf.classifyPartial for the next
+// Write. When no newline is present yet, returns nil and stashes everything.
+// Required because sseChunkContentSource etc. only parse complete data:-
+// prefixed lines; without reassembly a small-chunked transport (TLS
+// fragmentation, slow connections) silently strips classification of any
+// event split across Writes.
+func (rw *raceWriter) takeParseable(p []byte) []byte {
+	if len(rw.inf.classifyPartial) == 0 {
+		// Fast path: no prior partial, only inspect p itself.
+		lastNL := bytes.LastIndexByte(p, '\n')
+		if lastNL == -1 {
+			if len(p) > 0 {
+				rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], p...)
+			}
+			return nil
+		}
+		if lastNL+1 < len(p) {
+			rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], p[lastNL+1:]...)
+		} else {
+			rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
+		}
+		return p[: lastNL+1]
+	}
+
+	// Defensive: malformed stream growing without newlines — drop partial.
+	if len(rw.inf.classifyPartial)+len(p) > maxClassifyPartial {
+		rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
+		lastNL := bytes.LastIndexByte(p, '\n')
+		if lastNL == -1 {
+			return nil
+		}
+		if lastNL+1 < len(p) {
+			rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], p[lastNL+1:]...)
+		}
+		return p[: lastNL+1]
+	}
+
+	// Combine prior partial with new bytes; classify whole view.
+	combined := append(rw.inf.classifyPartial, p...)
+	lastNL := bytes.LastIndexByte(combined, '\n')
+	if lastNL == -1 {
+		rw.inf.classifyPartial = combined
+		return nil
+	}
+	// Copy out the trailing partial — combined shares backing with the prior
+	// classifyPartial, which we're about to replace.
+	if lastNL+1 < len(combined) {
+		tail := make([]byte, len(combined)-lastNL-1)
+		copy(tail, combined[lastNL+1:])
+		rw.inf.classifyPartial = tail
+	} else {
+		rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
+	}
+	return combined[: lastNL+1]
+}
+
 func (rw *raceWriter) ctxErr() error {
 	if rw.group == nil || rw.group.writeCtx == nil {
 		return nil
@@ -1267,23 +1340,27 @@ func (rw *raceWriter) Write(p []byte) (int, error) {
 	var chunkHasContent bool
 	var chunkHasError bool
 	if !rw.inf.probe {
-		if src, ok := sseChunkContentSource(p); ok {
-			chunkHasContent = true
-			if rw.inf.contentSource == "" {
-				rw.inf.contentSource = src
-			}
-		} else if details, ok := sseChunkErrorDetails(p); ok {
-			src := "error"
-			if details.Type != "" {
-				src = "error." + details.Type
-			}
-			chunkHasError = !isRetriableCapabilityErrorMessage(details.Message)
-			if rw.inf.errorSource == "" {
-				rw.inf.errorSource = src
-				rw.inf.errorCode = details.Code
-				rw.inf.errorType = details.Type
-				rw.inf.errorMessage = details.Message
-				rw.inf.errorBodySample = append(rw.inf.errorBodySample, p...)
+		// Reassemble across Writes: SSE events are only parseable when whole.
+		parseable := rw.takeParseable(p)
+		if len(parseable) > 0 {
+			if src, ok := sseChunkContentSource(parseable); ok {
+				chunkHasContent = true
+				if rw.inf.contentSource == "" {
+					rw.inf.contentSource = src
+				}
+			} else if details, ok := sseChunkErrorDetails(parseable); ok {
+				src := "error"
+				if details.Type != "" {
+					src = "error." + details.Type
+				}
+				chunkHasError = !isRetriableCapabilityErrorMessage(details.Message)
+				if rw.inf.errorSource == "" {
+					rw.inf.errorSource = src
+					rw.inf.errorCode = details.Code
+					rw.inf.errorType = details.Type
+					rw.inf.errorMessage = details.Message
+					rw.inf.errorBodySample = append(rw.inf.errorBodySample, p...)
+				}
 			}
 		}
 	}

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -1374,12 +1374,18 @@ func (rw *raceWriter) replaceClassify(buf []byte) bool {
 	return true
 }
 
-// dropClassify zeroes the per-attempt buffer and releases its bytes globally.
+// dropClassify releases the per-attempt buffer and its global bytes.
 func (rw *raceWriter) dropClassify() {
-	if n := len(rw.inf.classifyPartial); n > 0 {
+	rw.inf.releaseClassifyPartial()
+}
+
+// releaseClassifyPartial frees the reassembly buffer's backing array and
+// decrements the global gauge. Nils the slice so cap doesn't outlive the gauge.
+func (inf *inflight) releaseClassifyPartial() {
+	if n := len(inf.classifyPartial); n > 0 {
 		classifyPartialBytes.Add(-int64(n))
 	}
-	rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
+	inf.classifyPartial = nil
 }
 
 func (rw *raceWriter) ctxErr() error {
@@ -2554,12 +2560,7 @@ func (e *Redundancy) escalationDelay(stage string, params user.InferenceParams) 
 }
 
 func (e *Redundancy) monitorInflight(ctx context.Context, inf *inflight, race *raceGroup) {
-	defer func() {
-		if n := len(inf.classifyPartial); n > 0 {
-			classifyPartialBytes.Add(-int64(n))
-			inf.classifyPartial = nil
-		}
-	}()
+	defer inf.releaseClassifyPartial()
 	ticker := time.NewTicker(LogHeartbeatInterval)
 	defer ticker.Stop()
 

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -870,13 +870,8 @@ type inflight struct {
 	// different attempt wins or the attempt ends with no content.
 	pendingBuf []byte
 
-	// classifyPartial holds bytes after the last '\n' from prior Write calls.
-	// SSE classifiers (sseChunkContentSource/ErrorDetails/UsageCompletionTokens)
-	// require complete data:-prefixed lines in a single call to parse; when
-	// transport delivers SSE events fragmented across Writes (TLS small frames,
-	// proxy flush mid-event, slow connections), naive per-Write classification
-	// silently misses content. This buffer reassembles events for classification
-	// only — forwarding to the client still uses raw Write bytes unchanged.
+	// classifyPartial keeps the tail after the last '\n' from prior Writes;
+	// used to reassemble fragmented SSE events for the classifier.
 	classifyPartial []byte
 
 	// contentSource labels the field that produced the first content event
@@ -1248,47 +1243,79 @@ type raceWriter struct {
 	inf   *inflight
 }
 
-// maxClassifyPartial caps the SSE-reassembly buffer to defend against
-// malformed transports that stream indefinitely without newlines. If we
-// hit this cap the accumulated partial is dropped and classification falls
-// back to processing only the current Write.
-const maxClassifyPartial = 256 * 1024
+const (
+	// maxClassifyPartial is the per-attempt soft cap; any plausible single SSE
+	// event is orders of magnitude smaller.
+	maxClassifyPartial = 1 << 20 // 1 MiB
+	// maxClassifyPartialGlobal is the hard cap across all live attempts.
+	maxClassifyPartialGlobal int64 = 100 << 20 // 100 MiB
+)
 
-// takeParseable returns the prefix of (buffered partial + p) ending on '\n',
-// safe to feed to the SSE classifier. Trailing bytes after the last '\n'
-// are stashed in inf.classifyPartial for the next Write. Returns nil when
-// no '\n' has been seen yet.
-//
-// Invariant: classifyPartial never contains '\n' — by construction it is
-// the tail kept after the last '\n' on a prior call. So new '\n's can only
-// appear inside p, and we only need to scan p (not the combined buffer).
+// classifyPartialBytes is the live total of every inflight's classifyPartial.
+var classifyPartialBytes atomic.Int64
+
+// takeParseable returns the prefix of (classifyPartial + p) ending at the last
+// '\n'; the trailing fragment is stashed for the next call.
 func (rw *raceWriter) takeParseable(p []byte) []byte {
-	lastNLinP := bytes.LastIndexByte(p, '\n')
-
-	if lastNLinP == -1 {
-		// No newline in p — buffer it, unless adding p would exceed the cap.
-		if len(rw.inf.classifyPartial)+len(p) > maxClassifyPartial {
-			rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
-			return nil
+	lastNL := bytes.LastIndexByte(p, '\n')
+	if lastNL == -1 {
+		if !rw.growClassify(p) {
+			rw.dropClassify()
 		}
-		rw.inf.classifyPartial = append(rw.inf.classifyPartial, p...)
 		return nil
 	}
 
-	// p has '\n'. Build parseable = classifyPartial + p[:lastNLinP+1].
 	var parseable []byte
 	if len(rw.inf.classifyPartial) == 0 {
-		parseable = p[:lastNLinP+1]
+		parseable = p[:lastNL+1]
 	} else {
-		buf := make([]byte, 0, len(rw.inf.classifyPartial)+lastNLinP+1)
+		buf := make([]byte, 0, len(rw.inf.classifyPartial)+lastNL+1)
 		buf = append(buf, rw.inf.classifyPartial...)
-		buf = append(buf, p[:lastNLinP+1]...)
+		buf = append(buf, p[:lastNL+1]...)
 		parseable = buf
 	}
-
-	// Stash the trailing fragment. Empty trailing → append is a no-op.
-	rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], p[lastNLinP+1:]...)
+	if !rw.replaceClassify(p[lastNL+1:]) {
+		rw.dropClassify()
+	}
 	return parseable
+}
+
+// growClassify appends tail to classifyPartial if both caps still fit.
+func (rw *raceWriter) growClassify(tail []byte) bool {
+	if len(rw.inf.classifyPartial)+len(tail) > maxClassifyPartial {
+		return false
+	}
+	if classifyPartialBytes.Add(int64(len(tail))) > maxClassifyPartialGlobal {
+		classifyPartialBytes.Add(-int64(len(tail)))
+		return false
+	}
+	rw.inf.classifyPartial = append(rw.inf.classifyPartial, tail...)
+	return true
+}
+
+// replaceClassify swaps classifyPartial for buf, adjusting global accounting.
+func (rw *raceWriter) replaceClassify(buf []byte) bool {
+	if len(buf) > maxClassifyPartial {
+		return false
+	}
+	delta := int64(len(buf) - len(rw.inf.classifyPartial))
+	if delta > 0 && classifyPartialBytes.Add(delta) > maxClassifyPartialGlobal {
+		classifyPartialBytes.Add(-delta)
+		return false
+	}
+	if delta < 0 {
+		classifyPartialBytes.Add(delta)
+	}
+	rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], buf...)
+	return true
+}
+
+// dropClassify zeroes the per-attempt buffer and releases its bytes globally.
+func (rw *raceWriter) dropClassify() {
+	if n := len(rw.inf.classifyPartial); n > 0 {
+		classifyPartialBytes.Add(-int64(n))
+	}
+	rw.inf.classifyPartial = rw.inf.classifyPartial[:0]
 }
 
 func (rw *raceWriter) ctxErr() error {
@@ -1319,7 +1346,6 @@ func (rw *raceWriter) Write(p []byte) (int, error) {
 	var chunkHasContent bool
 	var chunkHasError bool
 	if !rw.inf.probe {
-		// Reassemble across Writes: SSE events are only parseable when whole.
 		parseable := rw.takeParseable(p)
 		if len(parseable) > 0 {
 			if src, ok := sseChunkContentSource(parseable); ok {
@@ -2484,6 +2510,12 @@ func (e *Redundancy) escalationDelay(stage string, params user.InferenceParams) 
 }
 
 func (e *Redundancy) monitorInflight(ctx context.Context, inf *inflight, race *raceGroup) {
+	defer func() {
+		if n := len(inf.classifyPartial); n > 0 {
+			classifyPartialBytes.Add(-int64(n))
+			inf.classifyPartial = nil
+		}
+	}()
 	ticker := time.NewTicker(LogHeartbeatInterval)
 	defer ticker.Stop()
 

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -874,6 +874,9 @@ type inflight struct {
 	// used to reassemble fragmented SSE events for the classifier.
 	classifyPartial []byte
 	classifyCapLog  sync.Once
+	// participantClassifyBytes is the shared per-participant byte counter this
+	// attempt contributes to; resolved at creation. Nil disables the cap.
+	participantClassifyBytes *atomic.Int64
 
 	// contentSource labels the field that produced the first content event
 	// ("delta.content", "delta.reasoning_content", "delta.tool_calls", or the
@@ -1245,25 +1248,63 @@ type raceWriter struct {
 }
 
 const (
-	// maxClassifyPartial is the per-attempt soft cap; any plausible single SSE
-	// event is orders of magnitude smaller.
-	maxClassifyPartial = 1 << 20 // 1 MiB
-	// maxClassifyPartialGlobal is the hard cap across all live attempts.
-	maxClassifyPartialGlobal int64 = 100 << 20 // 100 MiB
+	defaultMaxClassifyPartial            = 1 << 20   // 1 MiB per attempt
+	defaultMaxClassifyPartialParticipant = 10 << 20  // 10 MiB per participant
+	defaultMaxClassifyPartialGlobal      = 100 << 20 // 100 MiB process-wide
 )
+
+// Reassembly-buffer caps, tunable at startup via configureClassifyCapsFromEnv.
+// These are machine-scale memory knobs, not governance policy.
+var (
+	maxClassifyPartial                  = defaultMaxClassifyPartial
+	maxClassifyPartialParticipant int64 = defaultMaxClassifyPartialParticipant
+	maxClassifyPartialGlobal      int64 = defaultMaxClassifyPartialGlobal
+)
+
+// configureClassifyCapsFromEnv overrides the reassembly caps from the
+// environment; unset variables keep the conservative defaults.
+func configureClassifyCapsFromEnv() {
+	maxClassifyPartial = int(readInt64Env("GATEWAY_CLASSIFY_MAX_ATTEMPT_BYTES", int64(defaultMaxClassifyPartial)))
+	maxClassifyPartialParticipant = readInt64Env("GATEWAY_CLASSIFY_MAX_PARTICIPANT_BYTES", defaultMaxClassifyPartialParticipant)
+	maxClassifyPartialGlobal = readInt64Env("GATEWAY_CLASSIFY_MAX_GLOBAL_BYTES", defaultMaxClassifyPartialGlobal)
+}
 
 // classifyPartialBytes is the live total of every inflight's classifyPartial.
 var classifyPartialBytes atomic.Int64
+
+// participantClassify bounds live reassembly bytes per participant so one
+// hostile participant can't exhaust the shared global pool and starve others.
+var participantClassify = &participantClassifyTracker{counters: map[string]*atomic.Int64{}}
+
+type participantClassifyTracker struct {
+	mu       sync.Mutex
+	counters map[string]*atomic.Int64
+}
+
+// counterFor returns the participant's byte counter, creating it on first use.
+// Entries are never removed; the participant set is the bounded validator set.
+func (t *participantClassifyTracker) counterFor(participantKey string) *atomic.Int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	counter := t.counters[participantKey]
+	if counter == nil {
+		counter = &atomic.Int64{}
+		t.counters[participantKey] = counter
+	}
+	return counter
+}
 
 // takeParseable returns the prefix of (classifyPartial + p) ending at the last
 // '\n'; the trailing fragment is stashed for the next call.
 func (rw *raceWriter) takeParseable(p []byte) []byte {
 	lastNL := bytes.LastIndexByte(p, '\n')
 	if lastNL == -1 {
-		if !rw.growClassify(p) {
-			rw.dropClassify()
+		if rw.growClassify(p) {
+			return nil
 		}
-		return nil
+		// Cap hit: classify the raw chunk best-effort (incomplete fragments won't parse).
+		rw.dropClassify()
+		return p
 	}
 
 	var parseable []byte
@@ -1322,6 +1363,12 @@ func (rw *raceWriter) flushClassify() {
 	}
 }
 
+// flushClassifyAndCheckEmpty flushes a buffered newline-less final event before deciding empty, so a truncated final content/error event isn't misread as empty_stream. Call on the send goroutine after SendOnly returns.
+func (rw *raceWriter) flushClassifyAndCheckEmpty() bool {
+	rw.flushClassify()
+	return isEmptyStreamAttempt(rw.inf)
+}
+
 // logClassifyDrop reports the first reassembly-buffer drop for this attempt.
 // Capped at once per attempt so a persistently newline-less or oversized
 // transport can't spam the log.
@@ -1340,50 +1387,75 @@ func (rw *raceWriter) logClassifyDrop(reason string) {
 	})
 }
 
-// growClassify appends tail to classifyPartial if both caps still fit.
+// growClassify appends tail to classifyPartial if all caps still fit.
 func (rw *raceWriter) growClassify(tail []byte) bool {
 	if len(rw.inf.classifyPartial)+len(tail) > maxClassifyPartial {
 		rw.logClassifyDrop("per_attempt_cap")
 		return false
 	}
-	if classifyPartialBytes.Add(int64(len(tail))) > maxClassifyPartialGlobal {
-		classifyPartialBytes.Add(-int64(len(tail)))
-		rw.logClassifyDrop("global_cap")
+	if reason := rw.inf.reserveClassifyBytes(int64(len(tail))); reason != "" {
+		rw.logClassifyDrop(reason)
 		return false
 	}
 	rw.inf.classifyPartial = append(rw.inf.classifyPartial, tail...)
 	return true
 }
 
-// replaceClassify swaps classifyPartial for buf, adjusting global accounting.
+// replaceClassify swaps classifyPartial for buf, adjusting byte accounting.
 func (rw *raceWriter) replaceClassify(buf []byte) bool {
 	if len(buf) > maxClassifyPartial {
 		rw.logClassifyDrop("per_attempt_cap")
 		return false
 	}
 	delta := int64(len(buf) - len(rw.inf.classifyPartial))
-	if delta > 0 && classifyPartialBytes.Add(delta) > maxClassifyPartialGlobal {
-		classifyPartialBytes.Add(-delta)
-		rw.logClassifyDrop("global_cap")
-		return false
-	}
-	if delta < 0 {
-		classifyPartialBytes.Add(delta)
+	if delta > 0 {
+		if reason := rw.inf.reserveClassifyBytes(delta); reason != "" {
+			rw.logClassifyDrop(reason)
+			return false
+		}
+	} else if delta < 0 {
+		rw.inf.adjustClassifyBytes(delta)
 	}
 	rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], buf...)
 	return true
 }
 
-// dropClassify releases the per-attempt buffer and its global bytes.
+// dropClassify releases the per-attempt buffer and its accounted bytes.
 func (rw *raceWriter) dropClassify() {
 	rw.inf.releaseClassifyPartial()
 }
 
+// reserveClassifyBytes charges n bytes against the participant then global cap,
+// rolling back on the first cap hit. Returns the drop reason, "" on success.
+func (inf *inflight) reserveClassifyBytes(n int64) string {
+	participant := inf.participantClassifyBytes
+	if participant != nil && participant.Add(n) > maxClassifyPartialParticipant {
+		participant.Add(-n)
+		return "participant_cap"
+	}
+	if classifyPartialBytes.Add(n) > maxClassifyPartialGlobal {
+		classifyPartialBytes.Add(-n)
+		if participant != nil {
+			participant.Add(-n)
+		}
+		return "global_cap"
+	}
+	return ""
+}
+
+// adjustClassifyBytes adds delta to the global and per-participant counters.
+func (inf *inflight) adjustClassifyBytes(delta int64) {
+	classifyPartialBytes.Add(delta)
+	if inf.participantClassifyBytes != nil {
+		inf.participantClassifyBytes.Add(delta)
+	}
+}
+
 // releaseClassifyPartial frees the reassembly buffer's backing array and
-// decrements the global gauge. Nils the slice so cap doesn't outlive the gauge.
+// decrements the counters. Nils the slice so cap doesn't outlive the gauge.
 func (inf *inflight) releaseClassifyPartial() {
 	if n := len(inf.classifyPartial); n > 0 {
-		classifyPartialBytes.Add(-int64(n))
+		inf.adjustClassifyBytes(-int64(n))
 	}
 	inf.classifyPartial = nil
 }
@@ -1699,19 +1771,20 @@ func (e *Redundancy) prepareInflight(ctx context.Context, params user.InferenceP
 		participantKey := e.session.HostParticipantKey(res.prepared.HostIdx())
 		noWinner, noWinnerOK := e.noWinnerStatusForParticipant(participantKey)
 		inf := &inflight{
-			prepared:               res.prepared,
-			hostIdx:                res.prepared.HostIdx(),
-			hostID:                 e.session.HostLabel(res.prepared.HostIdx()),
-			nonce:                  res.prepared.Nonce(),
-			escrowID:               e.devshardID,
-			probe:                  res.isProbe,
-			suspicious:             noWinnerOK,
-			noWinnerReason:         noWinner.reason,
-			noWinnerQuarantineMode: noWinner.quarantineMode,
-			noWinnerFailureStrikes: noWinner.failureStrikes,
-			done:                   make(chan struct{}),
-			receiptCh:              make(chan struct{}),
-			firstTokenCh:           make(chan struct{}),
+			prepared:                 res.prepared,
+			hostIdx:                  res.prepared.HostIdx(),
+			hostID:                   e.session.HostLabel(res.prepared.HostIdx()),
+			nonce:                    res.prepared.Nonce(),
+			escrowID:                 e.devshardID,
+			probe:                    res.isProbe,
+			suspicious:               noWinnerOK,
+			noWinnerReason:           noWinner.reason,
+			noWinnerQuarantineMode:   noWinner.quarantineMode,
+			noWinnerFailureStrikes:   noWinner.failureStrikes,
+			done:                     make(chan struct{}),
+			receiptCh:                make(chan struct{}),
+			firstTokenCh:             make(chan struct{}),
+			participantClassifyBytes: participantClassify.counterFor(participantKey),
 		}
 		e.recordAccountingAttempt(ctx, inf)
 		return inf, nil
@@ -1773,7 +1846,8 @@ func (e *Redundancy) startInflight(ctx context.Context, inf *inflight, race *rac
 	go func() {
 		defer close(inf.done)
 		defer cancel()
-		defer rw.flushClassify()
+		// Sole owner of classifyPartial: release on every exit path (incl. the early error return); content is classified synchronously via flushClassifyAndCheckEmpty below.
+		defer inf.releaseClassifyPartial()
 		logInferenceStage(ctx, inf.escrowID, inf.nonce, "started", "host", inf.hostID)
 		inf.resp, inf.err = e.session.SendOnly(attemptCtx, inf.prepared, rw, receiptHandler)
 		streamBytes := int64(0)
@@ -1805,7 +1879,7 @@ func (e *Redundancy) startInflight(ctx context.Context, inf *inflight, race *rac
 		// stream_bytes_read > 0 but output_chunks == 0 because only devshard
 		// receipt/meta events were parsed and no inference data was forwarded to
 		// the race writer.
-		if isEmptyStreamAttempt(inf) {
+		if rw.flushClassifyAndCheckEmpty() {
 			responseBodySample, responseSampleTruncated := bodySampleForLog(inf.pendingBuf, emptyStreamBodySampleLimit)
 			inf.emptyResponseBodySample = responseBodySample
 			inf.emptyResponseBodySampleTruncated = responseSampleTruncated
@@ -2560,7 +2634,6 @@ func (e *Redundancy) escalationDelay(stage string, params user.InferenceParams) 
 }
 
 func (e *Redundancy) monitorInflight(ctx context.Context, inf *inflight, race *raceGroup) {
-	defer inf.releaseClassifyPartial()
 	ticker := time.NewTicker(LogHeartbeatInterval)
 	defer ticker.Stop()
 

--- a/devshard/cmd/devshardctl/sse_fixtures_test.go
+++ b/devshard/cmd/devshardctl/sse_fixtures_test.go
@@ -133,6 +133,32 @@ func TestSseRaceWriterReplaceClassifyGlobalCapDrops(t *testing.T) {
 	require.Equal(t, maxClassifyPartialGlobal, classifyPartialBytes.Load())
 }
 
+// Dropping the buffer must free its backing array, not just shrink len — else
+// real memory outlives the gauge and can exceed the global cap.
+func TestSseRaceWriterDropReleasesBackingArray(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write(bytes.Repeat([]byte("x"), maxClassifyPartial-10))
+	require.NoError(t, err)
+	require.Greater(t, cap(inf.classifyPartial), 0)
+	_, err = rw.Write(bytes.Repeat([]byte("x"), 20))
+	require.NoError(t, err)
+	require.Equal(t, 0, cap(inf.classifyPartial), "drop must release the backing array")
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// releaseClassifyPartial frees a len-0-but-large-cap buffer (the monitorInflight
+// cleanup case) and leaves the gauge unchanged when len is already 0.
+func TestReleaseClassifyPartialFreesLenZeroBuffer(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	inf.classifyPartial = make([]byte, 0, maxClassifyPartial)
+	inf.releaseClassifyPartial()
+	require.Nil(t, inf.classifyPartial)
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
 // Realistic transport shape: arbitrary chunk boundaries from TLS/proxy flushes.
 func TestSseRaceWriterRandomChunking(t *testing.T) {
 	for fxIndex, fx := range sseEmbeddedFixtures {

--- a/devshard/cmd/devshardctl/sse_fixtures_test.go
+++ b/devshard/cmd/devshardctl/sse_fixtures_test.go
@@ -36,6 +36,17 @@ var sseEmbeddedFixtures = []struct {
 	{"delta.tool_calls", sseToolCallsStream, "delta.tool_calls"},
 }
 
+// Stream whose final content event carries no trailing newline (truncated
+// upstream, mid-event proxy close). Write only classifies up to the last '\n',
+// so the "ok" event lands in classifyPartial and is recovered by flushClassify.
+const sseNewlineLessFinalContent = "" +
+	`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","created":3,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","created":3,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`
+
+// Same shape, but the newline-less final event is a non-retriable error.
+const sseNewlineLessFinalError = "" +
+	`data: {"error":{"message":"boom","type":"server_error","code":"internal"}}`
+
 func TestSseBlobClassifierNotEmpty(t *testing.T) {
 	for _, fx := range sseEmbeddedFixtures {
 		t.Run(fx.name, func(t *testing.T) {
@@ -84,6 +95,44 @@ func TestSseRaceWriterClassifyCapDrops(t *testing.T) {
 	require.Equal(t, before, classifyPartialBytes.Load())
 }
 
+// replaceClassify drops the trailing fragment when it exceeds the per-attempt cap.
+func TestSseRaceWriterReplaceClassifyPerAttemptCapDrops(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	chunk := append([]byte("\n"), bytes.Repeat([]byte("x"), maxClassifyPartial+1)...)
+	_, err := rw.Write(chunk)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(inf.classifyPartial))
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// growClassify drops a newline-less chunk when the global cap is already reached.
+func TestSseRaceWriterGrowClassifyGlobalCapDrops(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	defer classifyPartialBytes.Store(before)
+	classifyPartialBytes.Store(maxClassifyPartialGlobal)
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write([]byte("data: partial-no-newline"))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(inf.classifyPartial))
+	require.Equal(t, maxClassifyPartialGlobal, classifyPartialBytes.Load())
+}
+
+// replaceClassify drops the trailing fragment when the global cap is reached.
+func TestSseRaceWriterReplaceClassifyGlobalCapDrops(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	defer classifyPartialBytes.Store(before)
+	classifyPartialBytes.Store(maxClassifyPartialGlobal)
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write([]byte("\ntail"))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(inf.classifyPartial))
+	require.Equal(t, maxClassifyPartialGlobal, classifyPartialBytes.Load())
+}
+
 // Realistic transport shape: arbitrary chunk boundaries from TLS/proxy flushes.
 func TestSseRaceWriterRandomChunking(t *testing.T) {
 	for fxIndex, fx := range sseEmbeddedFixtures {
@@ -110,6 +159,78 @@ func TestSseRaceWriterRandomChunking(t *testing.T) {
 			require.Equal(t, fx.wantSource, inf.contentSource)
 		})
 	}
+}
+
+// Regression: a content event delivered as the final, newline-less write is
+// stashed in classifyPartial during Write and would leave the attempt looking
+// empty. flushClassify (run once the upstream stream ends) must recover it.
+func TestSseRaceWriterFlushRecoversNewlineLessContent(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalContent))
+	require.NoError(t, err)
+	// Before the flush the trailing content event is unclassified.
+	require.True(t, isEmptyStreamAttempt(inf),
+		"precondition: newline-less final event should be unclassified until flush")
+
+	rw.flushClassify()
+
+	require.False(t, isEmptyStreamAttempt(inf),
+		"flush must classify the newline-less final content event")
+	require.Equal(t, "delta.content", inf.contentSource)
+	require.Equal(t, 0, len(inf.classifyPartial), "flush must release the buffer")
+}
+
+// Regression: the same recovery must apply to a newline-less final error event
+// so the attempt is classified as an error stream, not an empty one.
+func TestSseRaceWriterFlushRecoversNewlineLessError(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalError))
+	require.NoError(t, err)
+
+	rw.flushClassify()
+
+	require.True(t, isErrorStreamAttempt(inf), "flush must classify the final error event")
+	require.False(t, isEmptyStreamAttempt(inf))
+	require.Equal(t, "error.server_error", inf.errorSource)
+}
+
+// flushClassify is a no-op when nothing was buffered (normal newline-terminated
+// stream) and stays balanced against the global counter.
+func TestSseRaceWriterFlushNoBufferedTail(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseContentStream))
+	require.NoError(t, err)
+	require.False(t, isEmptyStreamAttempt(inf))
+	source := inf.contentSource
+	contentChunks := inf.contentChunks.Load()
+
+	rw.flushClassify()
+
+	require.Equal(t, source, inf.contentSource, "flush must not change an already-classified attempt")
+	require.Equal(t, contentChunks, inf.contentChunks.Load(), "flush must not double-count content")
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// A probe attempt never classifies content, so flushClassify must leave it untouched.
+func TestSseRaceWriterFlushProbeNoop(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	inf.probe = true
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalContent))
+	require.NoError(t, err)
+
+	rw.flushClassify()
+
+	require.Equal(t, int64(0), inf.contentChunks.Load(), "probe flush must not count content")
+	require.Equal(t, "", inf.contentSource)
 }
 
 func mkRaceWriterInflight(t testing.TB) *inflight {

--- a/devshard/cmd/devshardctl/sse_fixtures_test.go
+++ b/devshard/cmd/devshardctl/sse_fixtures_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"math/rand/v2"
+	"strconv"
 	"testing"
 	"time"
 
@@ -49,7 +51,8 @@ func TestSseRaceWriterAllChunkSizes(t *testing.T) {
 	chunkSizes := []int{1, 64, 256, 1024, 4096, 8192}
 	for _, fx := range sseEmbeddedFixtures {
 		for _, sz := range chunkSizes {
-			t.Run(fx.name+"/chunk="+itoa(sz), func(t *testing.T) {
+			t.Run(fx.name+"/chunk="+strconv.Itoa(sz), func(t *testing.T) {
+				t.Parallel()
 				inf := mkRaceWriterInflight(t)
 				rw := mkRaceWriter(t, inf)
 				body := []byte(fx.body)
@@ -83,14 +86,16 @@ func TestSseRaceWriterClassifyCapDrops(t *testing.T) {
 
 // Realistic transport shape: arbitrary chunk boundaries from TLS/proxy flushes.
 func TestSseRaceWriterRandomChunking(t *testing.T) {
-	rng := pseudoRandSeed(42)
-	for _, fx := range sseEmbeddedFixtures {
+	for fxIndex, fx := range sseEmbeddedFixtures {
 		t.Run(fx.name, func(t *testing.T) {
+			t.Parallel()
+			// Own rng per subtest: *rand.Rand is not safe for concurrent use.
+			rng := rand.New(rand.NewPCG(42, uint64(fxIndex)))
 			inf := mkRaceWriterInflight(t)
 			rw := mkRaceWriter(t, inf)
 			body := []byte(fx.body)
 			for i := 0; i < len(body); {
-				sz := 1 + rng()%64
+				sz := 1 + rng.IntN(64)
 				end := i + sz
 				if end > len(body) {
 					end = len(body)
@@ -105,42 +110,6 @@ func TestSseRaceWriterRandomChunking(t *testing.T) {
 			require.Equal(t, fx.wantSource, inf.contentSource)
 		})
 	}
-}
-
-// pseudoRandSeed is a deterministic xorshift32.
-func pseudoRandSeed(seed int64) func() int {
-	state := uint32(seed)
-	if state == 0 {
-		state = 1
-	}
-	return func() int {
-		state ^= state << 13
-		state ^= state >> 17
-		state ^= state << 5
-		return int(state)
-	}
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var buf [20]byte
-	i := len(buf)
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
 }
 
 func mkRaceWriterInflight(t testing.TB) *inflight {

--- a/devshard/cmd/devshardctl/sse_fixtures_test.go
+++ b/devshard/cmd/devshardctl/sse_fixtures_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Embedded SSE responses that mirror vLLM's chat.completion.chunk shape.
+// Trimmed of logprobs/token-id noise — the classifier only inspects
+// choices[].delta.{content,reasoning,reasoning_content,tool_calls} and
+// the message.* variants, so we keep just those fields.
+
+const sseContentStream = "" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[],"usage":{"prompt_tokens":3,"total_tokens":5,"completion_tokens":2}}` + "\n\n" +
+	`data: [DONE]` + "\n\n"
+
+const sseToolCallsStream = "" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call-1","type":"function","index":0,"function":{"name":"get_weather"}}]},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":\"sf\"}"}}]},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":""},"finish_reason":"tool_calls"}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[],"usage":{"prompt_tokens":20,"total_tokens":40,"completion_tokens":20}}` + "\n\n" +
+	`data: [DONE]` + "\n\n"
+
+var sseEmbeddedFixtures = []struct {
+	name       string
+	body       string
+	wantSource string
+}{
+	{"delta.content", sseContentStream, "delta.content"},
+	{"delta.tool_calls", sseToolCallsStream, "delta.tool_calls"},
+}
+
+// TestSseBlobClassifierNotEmpty feeds the whole body to sseChunkContentSource
+// as a single blob — the simplest sanity check that fixtures match real
+// vLLM shape and that the classifier labels the expected source.
+func TestSseBlobClassifierNotEmpty(t *testing.T) {
+	for _, fx := range sseEmbeddedFixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			src, ok := sseChunkContentSource([]byte(fx.body))
+			require.True(t, ok, "blob classifier returned EMPTY")
+			require.Equal(t, fx.wantSource, src)
+		})
+	}
+}
+
+// TestSseRaceWriterAllChunkSizes is the regression test for the
+// SSE-reassembly fix. Without buffering across Writes, small chunk sizes
+// (sub-event) cause the classifier to miss content entirely. With the
+// takeParseable buffering in raceWriter, every chunk size from 1 byte
+// upward must classify correctly.
+func TestSseRaceWriterAllChunkSizes(t *testing.T) {
+	chunkSizes := []int{1, 64, 256, 1024, 4096, 8192}
+	for _, fx := range sseEmbeddedFixtures {
+		for _, sz := range chunkSizes {
+			t.Run(fx.name+"/chunk="+itoa(sz), func(t *testing.T) {
+				inf := mkRaceWriterInflight(t)
+				rw := mkRaceWriter(t, inf)
+				body := []byte(fx.body)
+				for i := 0; i < len(body); i += sz {
+					end := i + sz
+					if end > len(body) {
+						end = len(body)
+					}
+					_, err := rw.Write(body[i:end])
+					require.NoError(t, err)
+				}
+				require.False(t, isEmptyStreamAttempt(inf),
+					"classified empty (cc=%d oc=%d)",
+					inf.contentChunks.Load(), inf.outputChunks.Load())
+				require.Equal(t, fx.wantSource, inf.contentSource)
+			})
+		}
+	}
+}
+
+// TestSseRaceWriterRandomChunking covers the realistic transport shape
+// where chunk boundaries are arbitrary (TLS frames, proxy flushes).
+func TestSseRaceWriterRandomChunking(t *testing.T) {
+	rng := pseudoRandSeed(42)
+	for _, fx := range sseEmbeddedFixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			inf := mkRaceWriterInflight(t)
+			rw := mkRaceWriter(t, inf)
+			body := []byte(fx.body)
+			for i := 0; i < len(body); {
+				sz := 1 + rng()%64
+				end := i + sz
+				if end > len(body) {
+					end = len(body)
+				}
+				_, err := rw.Write(body[i:end])
+				require.NoError(t, err)
+				i = end
+			}
+			require.False(t, isEmptyStreamAttempt(inf),
+				"classified empty (cc=%d oc=%d)",
+				inf.contentChunks.Load(), inf.outputChunks.Load())
+			require.Equal(t, fx.wantSource, inf.contentSource)
+		})
+	}
+}
+
+// pseudoRandSeed is a deterministic xorshift32 — keeps fuzz coverage
+// reproducible across runs without seed-state coupling.
+func pseudoRandSeed(seed int64) func() int {
+	state := uint32(seed)
+	if state == 0 {
+		state = 1
+	}
+	return func() int {
+		state ^= state << 13
+		state ^= state >> 17
+		state ^= state << 5
+		return int(state)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+func mkRaceWriterInflight(t testing.TB) *inflight {
+	t.Helper()
+	return &inflight{
+		hostID:       "fixture-host",
+		escrowID:     "fixture-escrow",
+		nonce:        1,
+		done:         make(chan struct{}),
+		receiptCh:    make(chan struct{}),
+		firstTokenCh: make(chan struct{}),
+		receiptTime:  time.Now(),
+	}
+}
+
+func mkRaceWriter(t testing.TB, inf *inflight) *raceWriter {
+	t.Helper()
+	ctx := context.Background()
+	var sink bytes.Buffer
+	rg := newRaceGroup(ctx, ctx, inf.escrowID, &sink)
+	return &raceWriter{group: rg, nonce: inf.nonce, inf: inf}
+}

--- a/devshard/cmd/devshardctl/sse_fixtures_test.go
+++ b/devshard/cmd/devshardctl/sse_fixtures_test.go
@@ -9,11 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Embedded SSE responses that mirror vLLM's chat.completion.chunk shape.
-// Trimmed of logprobs/token-id noise — the classifier only inspects
-// choices[].delta.{content,reasoning,reasoning_content,tool_calls} and
-// the message.* variants, so we keep just those fields.
-
+// Minimal vLLM-shaped SSE fixtures for raceWriter classification tests.
 const sseContentStream = "" +
 	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n" +
 	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}` + "\n\n" +
@@ -38,9 +34,6 @@ var sseEmbeddedFixtures = []struct {
 	{"delta.tool_calls", sseToolCallsStream, "delta.tool_calls"},
 }
 
-// TestSseBlobClassifierNotEmpty feeds the whole body to sseChunkContentSource
-// as a single blob — the simplest sanity check that fixtures match real
-// vLLM shape and that the classifier labels the expected source.
 func TestSseBlobClassifierNotEmpty(t *testing.T) {
 	for _, fx := range sseEmbeddedFixtures {
 		t.Run(fx.name, func(t *testing.T) {
@@ -51,11 +44,7 @@ func TestSseBlobClassifierNotEmpty(t *testing.T) {
 	}
 }
 
-// TestSseRaceWriterAllChunkSizes is the regression test for the
-// SSE-reassembly fix. Without buffering across Writes, small chunk sizes
-// (sub-event) cause the classifier to miss content entirely. With the
-// takeParseable buffering in raceWriter, every chunk size from 1 byte
-// upward must classify correctly.
+// Regression: classifier must work for any chunk size, including sub-event.
 func TestSseRaceWriterAllChunkSizes(t *testing.T) {
 	chunkSizes := []int{1, 64, 256, 1024, 4096, 8192}
 	for _, fx := range sseEmbeddedFixtures {
@@ -81,8 +70,18 @@ func TestSseRaceWriterAllChunkSizes(t *testing.T) {
 	}
 }
 
-// TestSseRaceWriterRandomChunking covers the realistic transport shape
-// where chunk boundaries are arbitrary (TLS frames, proxy flushes).
+// Per-attempt cap: oversized newline-less stream is dropped, global counter balanced.
+func TestSseRaceWriterClassifyCapDrops(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write(bytes.Repeat([]byte("x"), maxClassifyPartial+1))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(inf.classifyPartial))
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// Realistic transport shape: arbitrary chunk boundaries from TLS/proxy flushes.
 func TestSseRaceWriterRandomChunking(t *testing.T) {
 	rng := pseudoRandSeed(42)
 	for _, fx := range sseEmbeddedFixtures {
@@ -108,8 +107,7 @@ func TestSseRaceWriterRandomChunking(t *testing.T) {
 	}
 }
 
-// pseudoRandSeed is a deterministic xorshift32 — keeps fuzz coverage
-// reproducible across runs without seed-state coupling.
+// pseudoRandSeed is a deterministic xorshift32.
 func pseudoRandSeed(seed int64) func() int {
 	state := uint32(seed)
 	if state == 0 {

--- a/devshard/cmd/devshardctl/sse_fixtures_test.go
+++ b/devshard/cmd/devshardctl/sse_fixtures_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"math/rand/v2"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -148,8 +149,7 @@ func TestSseRaceWriterDropReleasesBackingArray(t *testing.T) {
 	require.Equal(t, before, classifyPartialBytes.Load())
 }
 
-// releaseClassifyPartial frees a len-0-but-large-cap buffer (the monitorInflight
-// cleanup case) and leaves the gauge unchanged when len is already 0.
+// releaseClassifyPartial frees a len-0-but-large-cap buffer (the send-goroutine defer after a drop) and leaves the gauge unchanged when len is already 0.
 func TestReleaseClassifyPartialFreesLenZeroBuffer(t *testing.T) {
 	before := classifyPartialBytes.Load()
 	inf := mkRaceWriterInflight(t)
@@ -208,6 +208,34 @@ func TestSseRaceWriterFlushRecoversNewlineLessContent(t *testing.T) {
 	require.Equal(t, 0, len(inf.classifyPartial), "flush must release the buffer")
 }
 
+// Regression: flushClassifyAndCheckEmpty must flush the buffered final event before reading contentChunks (a prior deferred flush ran after the decision, misclassifying content as empty).
+func TestFlushClassifyAndCheckEmptyFlushesBeforeDeciding(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalContent))
+	require.NoError(t, err)
+	require.True(t, isEmptyStreamAttempt(inf),
+		"precondition: unflushed newline-less final event looks empty")
+
+	require.False(t, rw.flushClassifyAndCheckEmpty(),
+		"must flush the buffered final content before the empty-stream decision")
+	require.Equal(t, "delta.content", inf.contentSource)
+}
+
+// Regression: a newline-less final error event must resolve to an error stream, not empty, through the same flush-before-decide path.
+func TestFlushClassifyAndCheckEmptyFinalErrorIsNotEmpty(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalError))
+	require.NoError(t, err)
+
+	require.False(t, rw.flushClassifyAndCheckEmpty(),
+		"final error event must not be classified as empty_stream")
+	require.True(t, isErrorStreamAttempt(inf))
+}
+
 // Regression: the same recovery must apply to a newline-less final error event
 // so the attempt is classified as an error stream, not an empty one.
 func TestSseRaceWriterFlushRecoversNewlineLessError(t *testing.T) {
@@ -257,6 +285,136 @@ func TestSseRaceWriterFlushProbeNoop(t *testing.T) {
 
 	require.Equal(t, int64(0), inf.contentChunks.Load(), "probe flush must not count content")
 	require.Equal(t, "", inf.contentSource)
+}
+
+// On a cap drop, the raw write chunk is still classified best-effort rather than
+// silently skipped — a complete content line survives even when it can't buffer.
+func TestSseRaceWriterGracefulDegradationOnCapDrop(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write(bytes.Repeat([]byte("x"), maxClassifyPartial-10))
+	require.NoError(t, err)
+	_, err = rw.Write([]byte(`data: {"choices":[{"delta":{"content":"ok"}}]}`))
+	require.NoError(t, err)
+	require.False(t, isEmptyStreamAttempt(inf), "capped content chunk must still classify")
+	require.Equal(t, "delta.content", inf.contentSource)
+}
+
+// A hostile participant that fills its own budget must not starve another
+// attempt from a different participant sharing the global pool.
+func TestSseRaceWriterParticipantCapIsolatesParticipants(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	maxClassifyPartial = 100
+	maxClassifyPartialParticipant = 150
+	maxClassifyPartialGlobal = 1 << 30
+
+	hostile := &atomic.Int64{}
+	honest := &atomic.Int64{}
+	infHostile := mkRaceWriterInflight(t)
+	infHostile.participantClassifyBytes = hostile
+	infHonest := mkRaceWriterInflight(t)
+	infHonest.participantClassifyBytes = honest
+
+	_, err := mkRaceWriter(t, infHostile).Write(bytes.Repeat([]byte("x"), 100))
+	require.NoError(t, err)
+	require.Equal(t, int64(100), hostile.Load())
+
+	// The honest participant still has its full budget available.
+	_, err = mkRaceWriter(t, infHonest).Write(bytes.Repeat([]byte("y"), 100))
+	require.NoError(t, err)
+	require.Equal(t, 100, len(infHonest.classifyPartial), "honest attempt must not be starved")
+	require.Equal(t, int64(100), honest.Load())
+}
+
+// The same participant is capped across concurrent attempts sharing its counter.
+func TestSseRaceWriterParticipantCapDropsOverBudget(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	maxClassifyPartial = 100
+	maxClassifyPartialParticipant = 150
+	maxClassifyPartialGlobal = 1 << 30
+
+	shared := &atomic.Int64{}
+	first := mkRaceWriterInflight(t)
+	first.participantClassifyBytes = shared
+	second := mkRaceWriterInflight(t)
+	second.participantClassifyBytes = shared
+
+	_, err := mkRaceWriter(t, first).Write(bytes.Repeat([]byte("x"), 100))
+	require.NoError(t, err)
+	_, err = mkRaceWriter(t, second).Write(bytes.Repeat([]byte("y"), 100))
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(second.classifyPartial), "participant cap must drop the over-budget attempt")
+	require.Equal(t, int64(100), shared.Load(), "over-budget bytes rolled back")
+}
+
+// A global-cap drop must roll back the participant counter it already charged.
+func TestSseRaceWriterGlobalCapRollsBackParticipant(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	maxClassifyPartial = 1000
+	maxClassifyPartialParticipant = 1000
+	maxClassifyPartialGlobal = 50
+
+	participant := &atomic.Int64{}
+	inf := mkRaceWriterInflight(t)
+	inf.participantClassifyBytes = participant
+	before := classifyPartialBytes.Load()
+
+	_, err := mkRaceWriter(t, inf).Write(bytes.Repeat([]byte("x"), 100))
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(inf.classifyPartial), "global cap drops the attempt")
+	require.Equal(t, int64(0), participant.Load(), "participant counter rolled back")
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// Releasing the buffer decrements both the global and participant counters.
+func TestReleaseClassifyPartialDecrementsParticipant(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	maxClassifyPartial = 1000
+	maxClassifyPartialParticipant = 1000
+	maxClassifyPartialGlobal = 1 << 30
+
+	participant := &atomic.Int64{}
+	inf := mkRaceWriterInflight(t)
+	inf.participantClassifyBytes = participant
+
+	_, err := mkRaceWriter(t, inf).Write(bytes.Repeat([]byte("x"), 100))
+	require.NoError(t, err)
+	require.Equal(t, int64(100), participant.Load())
+
+	inf.releaseClassifyPartial()
+
+	require.Equal(t, int64(0), participant.Load(), "release decrements participant counter")
+	require.Nil(t, inf.classifyPartial)
+}
+
+func TestConfigureClassifyCapsFromEnv(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	t.Setenv("GATEWAY_CLASSIFY_MAX_ATTEMPT_BYTES", "2048")
+	t.Setenv("GATEWAY_CLASSIFY_MAX_PARTICIPANT_BYTES", "4096")
+	t.Setenv("GATEWAY_CLASSIFY_MAX_GLOBAL_BYTES", "8192")
+
+	configureClassifyCapsFromEnv()
+
+	require.Equal(t, 2048, maxClassifyPartial)
+	require.Equal(t, int64(4096), maxClassifyPartialParticipant)
+	require.Equal(t, int64(8192), maxClassifyPartialGlobal)
+}
+
+// saveClassifyCaps snapshots the tunable caps and returns a restore func.
+func saveClassifyCaps() func() {
+	attempt, participant, global := maxClassifyPartial, maxClassifyPartialParticipant, maxClassifyPartialGlobal
+	return func() {
+		maxClassifyPartial = attempt
+		maxClassifyPartialParticipant = participant
+		maxClassifyPartialGlobal = global
+	}
 }
 
 func mkRaceWriterInflight(t testing.TB) *inflight {


### PR DESCRIPTION
## Summary
- `raceWriter.Write` classified each call in isolation, so when transport delivered an SSE event split across `Write` calls (TLS fragmentation, proxy flush mid-event, slow connections), `sseChunkContentSource` / `sseChunkErrorDetails` saw only a fragment and the response was misclassified as empty — triggering false `empty_stream` quarantine.
- Added `inflight.classifyPartial` + `raceWriter.takeParseable(p)` so classification always parses a buffer ending on `\n` and stashes the trailing partial for the next `Write`. Forwarding to the client is unchanged — only the bytes fed to the classifier are reassembled.
- Memory is bounded by two caps: a generous **per-attempt soft cap of 1 MiB** (orders of magnitude above any plausible single SSE event) and a **global hard cap of 100 MiB** across all in-flight attempts, tracked via `atomic.Int64`. When either cap would be exceeded, the per-attempt buffer is dropped and classification falls back to the current `Write`. Buffer memory is released via `defer` in `monitorInflight` — the single per-attempt cleanup point — so the global gauge stays balanced.
- Added embedded SSE fixtures + a regression suite that exercises the full `raceWriter` pipeline across a wide chunk-size range, plus a cap-drop test that verifies the global counter returns to baseline.

## Why
On the route we kept seeing `empty_stream` events for responses that actually carried full content. Root cause: classifier ran per `Write`, but SSE event boundaries don't align with `Write` boundaries. Validated against real captured vLLM responses (not checked in — too noisy for the diff): before the fix 100% misclassified empty at sub-KiB chunks; after the fix 0% empty at every chunk size from 1 byte through 8 KiB.

The two-tier cap design replaces an earlier single per-attempt cap of 256 KiB. The new shape addresses two opposite concerns raised in review: per-attempt 1 MiB is generous enough that no legitimate SSE event from vLLM-class servers will hit it (real events are sub-KiB to single-digit KiB), while the global 100 MiB ceiling is the hard guarantee that no number of misbehaving upstreams can exhaust process memory.

## Tests
Embedded fixtures in [sse_fixtures_test.go](devshard/cmd/devshardctl/sse_fixtures_test.go) mirror the vLLM `chat.completion.chunk` shape for both `delta.content` and `delta.tool_calls` paths:

- `TestSseBlobClassifierNotEmpty` — sanity-checks each fixture as a single blob (2/2 PASS)
- `TestSseRaceWriterAllChunkSizes` — feeds each fixture through the writer at chunk sizes `{1, 64, 256, 1024, 4096, 8192}`, asserts `isEmptyStreamAttempt == false` and `contentSource` matches expected (12/12 PASS)
- `TestSseRaceWriterRandomChunking` — deterministic xorshift random chunk sizes 1–64 bytes (2/2 PASS)
- `TestSseRaceWriterClassifyCapDrops` — writes `maxClassifyPartial + 1` newline-less bytes, asserts buffer is dropped and global counter returns to baseline (1/1 PASS)

`go test ./...` under `devshard/` — all packages green.

## Test plan
- [x] All embedded-fixture tests pass at every chunk size 1 B → 8 KiB
- [x] Per-attempt cap drops the buffer; global gauge stays balanced
- [x] `go test ./...` in `devshard/` green
