### PR TITLE
feat(devshard): add host_score speed policy with Elo, UCB, time-decay, and ε-greedy exploration

### DIFF
--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -475,6 +475,9 @@ func NewManagedGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, set
 	if len(perfArgs) > 0 && perfArgs[0] != nil {
 		g.perf = perfArgs[0]
 	}
+	if g.perf != nil && g.participantLimiter != nil {
+		g.perf.SetParticipantLimiter(g.participantLimiter)
+	}
 	g.phaseGate = NewChainPhaseGate(settings.PublicAPI, 0)
 	if g.phaseGate != nil {
 		g.phaseGate.SetPreservedSnapshotBaseURL(settings.ChainREST)

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -496,6 +496,7 @@ func NewManagedGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, set
 	}
 	g.startEscrowRotatorIfEnabled()
 	go g.balanceCheckLoop()
+	go g.hostScoreFlushLoop()
 	return g
 }
 
@@ -585,6 +586,24 @@ func (g *Gateway) balanceCheckLoop() {
 	defer ticker.Stop()
 	for range ticker.C {
 		g.checkBalances()
+	}
+}
+
+const hostScoreFlushInterval = 2 * time.Minute
+
+// hostScoreFlushLoop periodically upserts the HostScoreTracker state to
+// SQLite so a restart doesn't lose the sliding window + Elo ratings. Flush
+// is best-effort — errors are logged, the in-memory state remains intact.
+func (g *Gateway) hostScoreFlushLoop() {
+	if g == nil || g.perf == nil || g.perf.hostScores == nil || g.perfStore == nil {
+		return
+	}
+	ticker := time.NewTicker(hostScoreFlushInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := g.perfStore.SaveHostScores(g.perf.hostScores.PersistState()); err != nil {
+			log.Printf("perf: flush host scores: %v", err)
+		}
 	}
 }
 
@@ -972,6 +991,11 @@ func (g *Gateway) Close() error {
 		}
 	}
 	if g.perfStore != nil {
+		if g.perf != nil && g.perf.hostScores != nil {
+			if err := g.perfStore.SaveHostScores(g.perf.hostScores.PersistState()); err != nil {
+				log.Printf("perf: final host-scores flush at shutdown: %v", err)
+			}
+		}
 		if err := g.perfStore.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
@@ -991,6 +1015,7 @@ func (g *Gateway) Handler() http.Handler {
 	mux.HandleFunc("/v1/admin/devshards/", g.handleAdminDevshardAction)
 	mux.HandleFunc("/v1/admin/escrows", g.handleAdminEscrows)
 	mux.HandleFunc("/v1/admin/participants/unquarantine", g.handleAdminUnquarantine)
+	mux.HandleFunc("/v1/admin/host_scores", g.handleAdminHostScores)
 	mux.HandleFunc("/v1/debug/rotation", g.handleDebugRotation)
 	mux.HandleFunc("/v1/finalize", g.handleSingleOnly)
 	mux.HandleFunc("/v1/state", g.handleSingleOnly)
@@ -2211,8 +2236,9 @@ func validateGatewaySettings(settings GatewaySettings) error {
 		return fmt.Errorf("redundancy.unresponsive_threshold must be > 0 and <= 1")
 	case normalizeRedundancySpeedPolicy(r.SpeedPolicy) != RedundancySpeedPolicyLegacy &&
 		normalizeRedundancySpeedPolicy(r.SpeedPolicy) != RedundancySpeedPolicyHybrid &&
-		normalizeRedundancySpeedPolicy(r.SpeedPolicy) != RedundancySpeedPolicyPairwise:
-		return fmt.Errorf("redundancy.speed_policy must be one of legacy, hybrid, pairwise")
+		normalizeRedundancySpeedPolicy(r.SpeedPolicy) != RedundancySpeedPolicyPairwise &&
+		normalizeRedundancySpeedPolicy(r.SpeedPolicy) != RedundancySpeedPolicyHostScore:
+		return fmt.Errorf("redundancy.speed_policy must be one of legacy, hybrid, pairwise, host_score")
 	case r.PairwiseBudgetPercentile <= 0 || r.PairwiseBudgetPercentile >= 1:
 		return fmt.Errorf("redundancy.pairwise_budget_percentile must be > 0 and < 1")
 	case r.PairwiseMaxProactiveAttempts <= 0:
@@ -2970,6 +2996,51 @@ func (g *Gateway) handleAdminUnquarantine(w http.ResponseWriter, r *http.Request
 	writeJSON(w, map[string]any{
 		"participant_key": req.ParticipantKey,
 		"cleared":         cleared,
+	})
+}
+
+// handleAdminHostScores returns the current HostScoreTracker snapshot, with
+// optional `?model=` and `?bucket=` query filters. Read-only; the response
+// includes the active tuning settings so operators can verify the formula
+// configuration without consulting the server binary.
+func (g *Gateway) handleAdminHostScores(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if g.perf == nil || g.perf.hostScores == nil {
+		http.Error(w, `{"error":{"message":"host scores tracker unavailable"}}`, http.StatusServiceUnavailable)
+		return
+	}
+	modelFilter := strings.TrimSpace(r.URL.Query().Get("model"))
+	bucketFilter := strings.TrimSpace(r.URL.Query().Get("bucket"))
+	all := g.perf.hostScores.Snapshot()
+	filtered := all[:0:len(all)]
+	for _, s := range all {
+		if modelFilter != "" && s.Model != modelFilter {
+			continue
+		}
+		if bucketFilter != "" && s.Bucket != bucketFilter {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	writeJSON(w, map[string]any{
+		"snapshots":    filtered,
+		"generated_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"settings": map[string]any{
+			"window_size":           HostScoreWindowSize,
+			"min_samples":           HostScoreMinSamples,
+			"elo_k":                 HostScoreEloK,
+			"elo_default":           HostScoreEloDefault,
+			"elo_alpha":             HostScoreEloAlpha,
+			"stream_gamma":          HostScoreStreamGamma,
+			"non_stream_gamma":      HostScoreNonStreamGamma,
+			"ucb_coefficient_ms":    HostScoreUCBCoefficient,
+			"elo_half_life_seconds": HostScoreEloHalfLife.Seconds(),
+			"exploration_epsilon":   HostScoreExplorationEpsilon,
+			"speed_policy":          RedundancySpeedPolicy,
+		},
 	})
 }
 

--- a/devshard/cmd/devshardctl/host_score_quarantine.go
+++ b/devshard/cmd/devshardctl/host_score_quarantine.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Layer 3 host_score performance quarantine. Algorithm + tradeoffs in
+// docs/host-scoring.md#performance-quarantine.
+// Compile-time array dimensions. To change, refactor to slice-based rings.
+const (
+	hostScoreSampleRingCapacity = 20
+	hostScoreSlidingWindow      = 5
+)
+
+// Runtime tunables (matches the var pattern in host_scores.go). Not atomic —
+// mutate at quiet times via admin endpoint.
+var (
+	HostScoreQuarantineMinSamplesPerHost  = 3
+	HostScoreQuarantineMinQualifyingHosts = 3
+	HostScoreQuarantineBadInWindow        = 3
+	HostScoreQuarantineBaseDuration       = 30 * time.Minute
+	HostScoreQuarantineMaxDuration        = 120 * time.Minute
+	HostScoreQuarantineHistoryWindow      = 4 * time.Hour
+)
+
+type hostScoreQuarantine struct {
+	mu       sync.Mutex
+	samples  map[string]map[string]*hostTTFTRing    // bucket → host → ring
+	states   map[string]map[string]*bucketQuarState // bucket → host → strike/quarantine
+	now      func() time.Time
+	onEnter  func(host, bucket string, until time.Time)
+	onExpire func(host, bucket string)
+}
+
+func newHostScoreQuarantine() *hostScoreQuarantine {
+	return &hostScoreQuarantine{
+		samples: make(map[string]map[string]*hostTTFTRing),
+		states:  make(map[string]map[string]*bucketQuarState),
+		now:     time.Now,
+	}
+}
+
+type hostTTFTRing struct {
+	buf [hostScoreSampleRingCapacity]float64
+	n   int
+	pos int
+}
+
+func (r *hostTTFTRing) add(v float64) {
+	r.buf[r.pos] = v
+	r.pos = (r.pos + 1) % len(r.buf)
+	if r.n < len(r.buf) {
+		r.n++
+	}
+}
+
+func (r *hostTTFTRing) values() []float64 {
+	out := make([]float64, r.n)
+	copy(out, r.buf[:r.n])
+	return out
+}
+
+type bucketQuarState struct {
+	window          [hostScoreSlidingWindow]bool // true = bad
+	windowN         int
+	windowPos       int
+	quarantineUntil time.Time   // zero = not quarantined
+	history         []time.Time // entries within HostScoreQuarantineHistoryWindow
+}
+
+func (s *bucketQuarState) recordOutcome(bad bool) {
+	s.window[s.windowPos] = bad
+	s.windowPos = (s.windowPos + 1) % len(s.window)
+	if s.windowN < len(s.window) {
+		s.windowN++
+	}
+}
+
+func (s *bucketQuarState) badCount() int {
+	n := 0
+	for i := 0; i < s.windowN; i++ {
+		if s.window[i] {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *bucketQuarState) clearWindow() {
+	s.window = [hostScoreSlidingWindow]bool{}
+	s.windowN = 0
+	s.windowPos = 0
+}
+
+// nextQuarantineDuration: 30m, 60m, 120m (cap), reset after 4h idle.
+func (s *bucketQuarState) nextQuarantineDuration(now time.Time) time.Duration {
+	cutoff := now.Add(-HostScoreQuarantineHistoryWindow)
+	kept := s.history[:0]
+	for _, t := range s.history {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	s.history = kept
+	dur := HostScoreQuarantineBaseDuration << len(s.history)
+	if dur > HostScoreQuarantineMaxDuration {
+		dur = HostScoreQuarantineMaxDuration
+	}
+	s.history = append(s.history, now)
+	return dur
+}
+
+// recordSample is the main entry point. No-op unless policy is host_score.
+func (q *hostScoreQuarantine) recordSample(host, bucket string, ttftMs float64, responsive bool) {
+	if RedundancySpeedPolicy != RedundancySpeedPolicyHostScore {
+		return
+	}
+	if host == "" || bucket == "" || !responsive || ttftMs <= 0 {
+		return
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	bucketSamples := q.samples[bucket]
+	if bucketSamples == nil {
+		bucketSamples = make(map[string]*hostTTFTRing)
+		q.samples[bucket] = bucketSamples
+	}
+	ring := bucketSamples[host]
+	if ring == nil {
+		ring = &hostTTFTRing{}
+		bucketSamples[host] = ring
+	}
+	ring.add(ttftMs)
+
+	threshold, ok := q.bucketThresholdLocked(bucketSamples, host)
+	if !ok {
+		return
+	}
+
+	bucketStates := q.states[bucket]
+	if bucketStates == nil {
+		bucketStates = make(map[string]*bucketQuarState)
+		q.states[bucket] = bucketStates
+	}
+	st := bucketStates[host]
+	if st == nil {
+		st = &bucketQuarState{}
+		bucketStates[host] = st
+	}
+
+	now := q.now()
+	if !st.quarantineUntil.IsZero() && now.After(st.quarantineUntil) {
+		st.quarantineUntil = time.Time{}
+		st.clearWindow()
+		if q.onExpire != nil {
+			q.onExpire(host, bucket)
+		}
+	}
+	if !st.quarantineUntil.IsZero() {
+		return
+	}
+
+	st.recordOutcome(ttftMs > threshold)
+	if st.windowN >= HostScoreQuarantineBadInWindow && st.badCount() >= HostScoreQuarantineBadInWindow {
+		dur := st.nextQuarantineDuration(now)
+		st.quarantineUntil = now.Add(dur)
+		st.clearWindow()
+		if q.onEnter != nil {
+			q.onEnter(host, bucket, st.quarantineUntil)
+		}
+	}
+}
+
+// bucketThresholdLocked: p90 over qualifying hosts (≥ MinSamplesPerHost each,
+// ≥ MinQualifyingHosts total), excluding excludeHost to prevent self-pollution.
+func (q *hostScoreQuarantine) bucketThresholdLocked(bucketSamples map[string]*hostTTFTRing, excludeHost string) (float64, bool) {
+	pool := make([]float64, 0, len(bucketSamples)*hostScoreSampleRingCapacity)
+	qualifying := 0
+	for host, ring := range bucketSamples {
+		if host == excludeHost {
+			continue
+		}
+		if ring.n < HostScoreQuarantineMinSamplesPerHost {
+			continue
+		}
+		qualifying++
+		pool = append(pool, ring.values()...)
+	}
+	if qualifying < HostScoreQuarantineMinQualifyingHosts {
+		return 0, false
+	}
+	sort.Float64s(pool)
+	if len(pool) == 0 {
+		return 0, false
+	}
+	idx := int(0.9 * float64(len(pool)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	return pool[idx], true
+}
+
+// isQuarantined returns true if any bucket has an active lockout for host.
+func (q *hostScoreQuarantine) isQuarantined(host string) bool {
+	if RedundancySpeedPolicy != RedundancySpeedPolicyHostScore {
+		return false
+	}
+	if host == "" {
+		return false
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	now := q.now()
+	for _, byHost := range q.states {
+		if st, ok := byHost[host]; ok {
+			if !st.quarantineUntil.IsZero() && now.Before(st.quarantineUntil) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// clearAll releases every (bucket) quarantine for host and clears strike
+// windows. History is preserved so the backoff still penalises repeats.
+func (q *hostScoreQuarantine) clearAll(host string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	cleared := false
+	for _, byHost := range q.states {
+		if st, ok := byHost[host]; ok {
+			if !st.quarantineUntil.IsZero() {
+				cleared = true
+			}
+			st.quarantineUntil = time.Time{}
+			st.clearWindow()
+		}
+	}
+	return cleared
+}

--- a/devshard/cmd/devshardctl/host_scores.go
+++ b/devshard/cmd/devshardctl/host_scores.go
@@ -37,7 +37,44 @@ var (
 	// Decision margins
 	HostScoreSpeedupMargin      = 0.10 // candidate score must be ≤primary·(1-margin)
 	HostScoreExplorationEpsilon = 0.05 // 5% forced-exploration when score is ambivalent
+
+	// Per-bucket calibration overrides. See
+	// docs/host-scoring.md#per-bucket-calibration for the rationale.
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
+		"lt_1k":    {HalfLife: 3 * time.Hour},  // high traffic → fast adaptation
+		"1k_5k":    {HalfLife: 3 * time.Hour},  // high traffic → fast adaptation
+		"5k_15k":   {HalfLife: 6 * time.Hour},  // medium traffic
+		"15k_30k":  {HalfLife: 6 * time.Hour},  // medium traffic
+		"30k_100k": {HalfLife: 9 * time.Hour},  // low traffic → preserve signal across gaps
+		"gte_100k": {HalfLife: 12 * time.Hour}, // very low traffic
+	}
 )
+
+// HostScoreBucketOverride lets a bucket adopt non-default K and half-life.
+// K=0 inherits HostScoreEloK. HalfLife<0 inherits HostScoreEloHalfLife;
+// HalfLife=0 explicitly disables decay for that bucket.
+type HostScoreBucketOverride struct {
+	K        float64
+	HalfLife time.Duration
+}
+
+// hostScoreKForBucket returns the K-factor in effect for a bucket.
+func hostScoreKForBucket(bucket string) float64 {
+	if o, ok := HostScoreBucketOverrides[bucket]; ok && o.K > 0 {
+		return o.K
+	}
+	return HostScoreEloK
+}
+
+// hostScoreHalfLifeForBucket returns the decay half-life in effect for a
+// bucket. Negative override means inherit; zero (explicit or inherited)
+// disables decay.
+func hostScoreHalfLifeForBucket(bucket string) time.Duration {
+	if o, ok := HostScoreBucketOverrides[bucket]; ok && o.HalfLife >= 0 {
+		return o.HalfLife
+	}
+	return HostScoreEloHalfLife
+}
 
 // hostScoreRandom drives the ε-greedy floor; tests swap it for determinism.
 var hostScoreRandom = rand.Float64
@@ -171,14 +208,15 @@ func NewHostScoreTracker(pairwise *PairwiseTracker) *HostScoreTracker {
 	}
 }
 
-// decayedEloLocked pulls Elo toward default by HostScoreEloHalfLife exponential
-// decay since last update; 0 half-life disables.
+// decayedEloLocked pulls Elo toward default by the bucket's half-life
+// exponential decay since last update; 0 disables.
 func (t *HostScoreTracker) decayedEloLocked(key hostScoreKey, now time.Time) float64 {
 	raw := t.elo[key]
 	if raw == 0 { // map zero-value = never K-updated, treat as default
 		return HostScoreEloDefault
 	}
-	if HostScoreEloHalfLife <= 0 {
+	halfLife := hostScoreHalfLifeForBucket(key.bucket)
+	if halfLife <= 0 {
 		return raw
 	}
 	lastUpdate, ok := t.eloUpdatedAt[key]
@@ -189,7 +227,7 @@ func (t *HostScoreTracker) decayedEloLocked(key hostScoreKey, now time.Time) flo
 	if age <= 0 {
 		return raw
 	}
-	multiplier := math.Exp(-math.Ln2 * float64(age) / float64(HostScoreEloHalfLife))
+	multiplier := math.Exp(-math.Ln2 * float64(age) / float64(halfLife))
 	return HostScoreEloDefault + (raw-HostScoreEloDefault)*multiplier
 }
 
@@ -231,7 +269,7 @@ func (t *HostScoreTracker) RecordRequest(rec RequestRecord) {
 		ring.add(hostScoreSample{Timestamp: now, TtftMs: h.FirstTokenMs, TotalMs: h.TotalTimeMs})
 	}
 
-	halfK := HostScoreEloK / 2
+	halfK := hostScoreKForBucket(bucket) / 2
 	for i := 0; i < len(eligible); i++ {
 		for j := i + 1; j < len(eligible); j++ {
 			a, b := eligible[i], eligible[j]

--- a/devshard/cmd/devshardctl/host_scores.go
+++ b/devshard/cmd/devshardctl/host_scores.go
@@ -36,39 +36,25 @@ var (
 
 	// Decision margins
 	HostScoreSpeedupMargin      = 0.10 // candidate score must be ≤primary·(1-margin)
-	HostScoreExplorationEpsilon = 0.05 // 5% forced-exploration when score is ambivalent
+	HostScoreExplorationEpsilon = 0.02 // 2% forced-exploration when score is ambivalent
 
 	// Per-bucket calibration overrides. See
 	// docs/host-scoring.md#per-bucket-calibration for the rationale.
 	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
-		"lt_1k":    {HalfLife: 3 * time.Hour},  // high traffic → fast adaptation
-		"1k_5k":    {HalfLife: 3 * time.Hour},  // high traffic → fast adaptation
-		"5k_15k":   {HalfLife: 6 * time.Hour},  // medium traffic
-		"15k_30k":  {HalfLife: 6 * time.Hour},  // medium traffic
-		"30k_100k": {HalfLife: 9 * time.Hour},  // low traffic → preserve signal across gaps
-		"gte_100k": {HalfLife: 12 * time.Hour}, // very low traffic
+		"lt_1k": {HalfLife: 6 * time.Hour}, // high traffic → faster decay
+		"1k_5k": {HalfLife: 6 * time.Hour},
+		// Other buckets inherit HostScoreEloHalfLife (12h) — replay-loop
+		// data did not show benefit from compressing further.
 	}
 )
 
-// HostScoreBucketOverride lets a bucket adopt non-default K and half-life.
-// K=0 inherits HostScoreEloK. HalfLife<0 inherits HostScoreEloHalfLife;
-// HalfLife=0 explicitly disables decay for that bucket.
+// HostScoreBucketOverride overrides the Elo decay half-life for one bucket.
+// HalfLife < 0 inherits HostScoreEloHalfLife; HalfLife = 0 disables decay.
 type HostScoreBucketOverride struct {
-	K        float64
 	HalfLife time.Duration
 }
 
-// hostScoreKForBucket returns the K-factor in effect for a bucket.
-func hostScoreKForBucket(bucket string) float64 {
-	if o, ok := HostScoreBucketOverrides[bucket]; ok && o.K > 0 {
-		return o.K
-	}
-	return HostScoreEloK
-}
-
-// hostScoreHalfLifeForBucket returns the decay half-life in effect for a
-// bucket. Negative override means inherit; zero (explicit or inherited)
-// disables decay.
+// hostScoreHalfLifeForBucket returns the decay half-life in effect for a bucket.
 func hostScoreHalfLifeForBucket(bucket string) time.Duration {
 	if o, ok := HostScoreBucketOverrides[bucket]; ok && o.HalfLife >= 0 {
 		return o.HalfLife
@@ -171,7 +157,7 @@ type HostScoreSnapshot struct {
 	TotalP50Ms     float64 `json:"total_p50_ms"`
 	TotalP90Ms     float64 `json:"total_p90_ms"`
 	Elo            float64 `json:"elo"`
-	UCBBonus       float64 `json:"ucb_bonus_ms"` // exploration credit subtracted from score
+	UCBBonus       float64 `json:"ucb_bonus_ms"` // subtracted from score
 	ScoreStream    float64 `json:"score_stream"`
 	ScoreNonStream float64 `json:"score_non_stream"`
 }
@@ -190,12 +176,12 @@ type HostScoreState struct {
 // HostScoreTracker holds per-(model,host,bucket) sliding sample rings + Elo.
 // Formula and rationale: docs/host-scoring.md.
 type HostScoreTracker struct {
-	mu            sync.RWMutex
-	hosts         map[hostScoreKey]*hostScoreRing
-	elo           map[hostScoreKey]float64
-	eloUpdatedAt  map[hostScoreKey]time.Time
-	pairwise      *PairwiseTracker // optional H2H source; may be nil in tests
-	now           func() time.Time // injectable clock for tests
+	mu           sync.RWMutex
+	hosts        map[hostScoreKey]*hostScoreRing
+	elo          map[hostScoreKey]float64
+	eloUpdatedAt map[hostScoreKey]time.Time
+	pairwise     *PairwiseTracker // optional H2H source; may be nil in tests
+	now          func() time.Time // injectable clock for tests
 }
 
 func NewHostScoreTracker(pairwise *PairwiseTracker) *HostScoreTracker {
@@ -269,7 +255,7 @@ func (t *HostScoreTracker) RecordRequest(rec RequestRecord) {
 		ring.add(hostScoreSample{Timestamp: now, TtftMs: h.FirstTokenMs, TotalMs: h.TotalTimeMs})
 	}
 
-	halfK := hostScoreKForBucket(bucket) / 2
+	halfK := HostScoreEloK / 2
 	for i := 0; i < len(eligible); i++ {
 		for j := i + 1; j < len(eligible); j++ {
 			a, b := eligible[i], eligible[j]
@@ -369,11 +355,12 @@ func (t *HostScoreTracker) ScoreHost(model, host, bucket string, stream bool, op
 	if stream {
 		gamma = HostScoreStreamGamma
 	}
-	ttft, total := ring.percentile(0.50)
-	base := (1-gamma)*ttft + gamma*total
-	elo := t.decayedEloLocked(key, t.now())
-	ucb := t.ucbBonusLocked(model, bucket, len(ring.samples))
-	return base - HostScoreEloAlpha*(elo-HostScoreEloDefault) - ucb, true
+	// score = base − Elo − UCB  (docs/host-scoring.md#layer-2)
+	ttftP50, totalP50 := ring.percentile(0.50)
+	base := (1-gamma)*ttftP50 + gamma*totalP50
+	eloCredit := HostScoreEloAlpha * (t.decayedEloLocked(key, t.now()) - HostScoreEloDefault)
+	ucbBonus := t.ucbBonusLocked(model, bucket, len(ring.samples))
+	return base - eloCredit - ucbBonus, true
 }
 
 // ucbBonusLocked computes c·√(ln N_bucket / n_host); caller holds mu.
@@ -423,23 +410,22 @@ func (t *HostScoreTracker) Snapshot() []HostScoreSnapshot {
 		ttftP50, totalP50 := ring.percentile(0.50)
 		ttftP90, totalP90 := ring.percentile(0.90)
 		elo := t.decayedEloLocked(key, now)
-		eloBonus := HostScoreEloAlpha * (elo - HostScoreEloDefault)
-		bucketN := totalFor(key.model, key.bucket)
-		ucb := t.ucbBonusLocked(key.model, key.bucket, len(ring.samples))
+		eloCredit := HostScoreEloAlpha * (elo - HostScoreEloDefault)
+		ucbBonus := t.ucbBonusLocked(key.model, key.bucket, len(ring.samples))
 		out = append(out, HostScoreSnapshot{
 			Model:          key.model,
 			Host:           key.host,
 			Bucket:         key.bucket,
 			Samples:        len(ring.samples),
-			BucketTotalN:   bucketN,
+			BucketTotalN:   totalFor(key.model, key.bucket),
 			TtftP50Ms:      ttftP50,
 			TtftP90Ms:      ttftP90,
 			TotalP50Ms:     totalP50,
 			TotalP90Ms:     totalP90,
 			Elo:            elo,
-			UCBBonus:       ucb,
-			ScoreStream:    (1-HostScoreStreamGamma)*ttftP50 + HostScoreStreamGamma*totalP50 - eloBonus - ucb,
-			ScoreNonStream: (1-HostScoreNonStreamGamma)*ttftP50 + HostScoreNonStreamGamma*totalP50 - eloBonus - ucb,
+			UCBBonus:       ucbBonus,
+			ScoreStream:    (1-HostScoreStreamGamma)*ttftP50 + HostScoreStreamGamma*totalP50 - eloCredit - ucbBonus,
+			ScoreNonStream: (1-HostScoreNonStreamGamma)*ttftP50 + HostScoreNonStreamGamma*totalP50 - eloCredit - ucbBonus,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/devshard/cmd/devshardctl/host_scores.go
+++ b/devshard/cmd/devshardctl/host_scores.go
@@ -1,0 +1,480 @@
+package main
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Tunable parameters. Defaults documented in docs/host-scoring.md#hyperparameters.
+// Not atomic — mutate at quiet times (startup or via admin endpoint).
+var (
+	// Sample ring & gating
+	HostScoreWindowSize = 50
+	HostScoreMinSamples = 3
+
+	// Layer 1: H2H trigger
+	HostScoreH2HMargin = 0.10 // candidate must win ≥0.5+margin to act
+
+	// Layer 2: base timing weights
+	HostScoreStreamGamma    = 0.3
+	HostScoreNonStreamGamma = 1.0
+
+	// Layer 2: Elo
+	HostScoreEloK        = 16.0
+	HostScoreEloDefault  = 1500.0
+	HostScoreEloAlpha    = 10.0           // ms per Elo-point delta vs default
+	HostScoreEloHalfLife = 12 * time.Hour // half-life for stale-rating decay; 0 disables
+
+	// Layer 2: UCB exploration
+	HostScoreUCBCoefficient = 300.0 // ms; 0 disables
+
+	// Layer 2: Bradley-Terry exponent (see docs/host-scoring.md#layer-22-elo-credit).
+	HostScoreBradleyTerryExp = 2.0
+
+	// Decision margins
+	HostScoreSpeedupMargin      = 0.10 // candidate score must be ≤primary·(1-margin)
+	HostScoreExplorationEpsilon = 0.05 // 5% forced-exploration when score is ambivalent
+)
+
+// hostScoreRandom drives the ε-greedy floor; tests swap it for determinism.
+var hostScoreRandom = rand.Float64
+
+type hostScoreKey struct {
+	model  string
+	host   string // ParticipantKey
+	bucket string
+}
+
+type hostScoreSample struct {
+	Timestamp time.Time `json:"timestamp"`
+	TtftMs    float64   `json:"ttft_ms"`
+	TotalMs   float64   `json:"total_ms"`
+}
+
+type hostScoreRing struct {
+	samples []hostScoreSample
+	pos     int
+}
+
+func (r *hostScoreRing) add(s hostScoreSample) {
+	if len(r.samples) < HostScoreWindowSize {
+		r.samples = append(r.samples, s)
+		r.pos = len(r.samples) % HostScoreWindowSize
+		return
+	}
+	r.samples[r.pos] = s
+	r.pos = (r.pos + 1) % HostScoreWindowSize
+}
+
+// ordered returns samples in chronological order (oldest first).
+func (r *hostScoreRing) ordered() []hostScoreSample {
+	if len(r.samples) < HostScoreWindowSize {
+		out := make([]hostScoreSample, len(r.samples))
+		copy(out, r.samples)
+		return out
+	}
+	out := make([]hostScoreSample, HostScoreWindowSize)
+	for i := 0; i < HostScoreWindowSize; i++ {
+		out[i] = r.samples[(r.pos+i)%HostScoreWindowSize]
+	}
+	return out
+}
+
+// percentile returns the q-th percentile of (ttftMs, totalMs) over current
+// samples. q in [0,1]. Uses linear interpolation between adjacent ranks.
+func (r *hostScoreRing) percentile(q float64) (ttft, total float64) {
+	n := len(r.samples)
+	if n == 0 {
+		return 0, 0
+	}
+	ttfts := make([]float64, n)
+	totals := make([]float64, n)
+	for i, s := range r.samples {
+		ttfts[i] = s.TtftMs
+		totals[i] = s.TotalMs
+	}
+	sort.Float64s(ttfts)
+	sort.Float64s(totals)
+	return interpPercentile(ttfts, q), interpPercentile(totals, q)
+}
+
+func interpPercentile(sorted []float64, q float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 || q <= 0 {
+		return sorted[0]
+	}
+	if q >= 1 {
+		return sorted[n-1]
+	}
+	pos := q * float64(n-1)
+	lo := int(math.Floor(pos))
+	hi := int(math.Ceil(pos))
+	if lo == hi {
+		return sorted[lo]
+	}
+	frac := pos - float64(lo)
+	return sorted[lo]*(1-frac) + sorted[hi]*frac
+}
+
+// HostScoreSnapshot is the per-key public view emitted by the admin endpoint.
+type HostScoreSnapshot struct {
+	Model          string  `json:"model"`
+	Host           string  `json:"host"`
+	Bucket         string  `json:"bucket"`
+	Samples        int     `json:"samples"`
+	BucketTotalN   int     `json:"bucket_total_samples"` // N for UCB denominator
+	TtftP50Ms      float64 `json:"ttft_p50_ms"`
+	TtftP90Ms      float64 `json:"ttft_p90_ms"`
+	TotalP50Ms     float64 `json:"total_p50_ms"`
+	TotalP90Ms     float64 `json:"total_p90_ms"`
+	Elo            float64 `json:"elo"`
+	UCBBonus       float64 `json:"ucb_bonus_ms"` // exploration credit subtracted from score
+	ScoreStream    float64 `json:"score_stream"`
+	ScoreNonStream float64 `json:"score_non_stream"`
+}
+
+// HostScoreState is the per-key persistent shape for SQLite. UpdatedAt seeds
+// Elo time-decay across restarts (docs/host-scoring.md#regime-change).
+type HostScoreState struct {
+	Model     string            `json:"model"`
+	Host      string            `json:"host"`
+	Bucket    string            `json:"bucket"`
+	Elo       float64           `json:"elo"`
+	Samples   []hostScoreSample `json:"samples"`
+	UpdatedAt time.Time         `json:"updated_at"`
+}
+
+// HostScoreTracker holds per-(model,host,bucket) sliding sample rings + Elo.
+// Formula and rationale: docs/host-scoring.md.
+type HostScoreTracker struct {
+	mu            sync.RWMutex
+	hosts         map[hostScoreKey]*hostScoreRing
+	elo           map[hostScoreKey]float64
+	eloUpdatedAt  map[hostScoreKey]time.Time
+	pairwise      *PairwiseTracker // optional H2H source; may be nil in tests
+	now           func() time.Time // injectable clock for tests
+}
+
+func NewHostScoreTracker(pairwise *PairwiseTracker) *HostScoreTracker {
+	return &HostScoreTracker{
+		hosts:        make(map[hostScoreKey]*hostScoreRing),
+		elo:          make(map[hostScoreKey]float64),
+		eloUpdatedAt: make(map[hostScoreKey]time.Time),
+		pairwise:     pairwise,
+		now:          time.Now,
+	}
+}
+
+// decayedEloLocked pulls Elo toward default by HostScoreEloHalfLife exponential
+// decay since last update; 0 half-life disables.
+func (t *HostScoreTracker) decayedEloLocked(key hostScoreKey, now time.Time) float64 {
+	raw := t.elo[key]
+	if raw == 0 { // map zero-value = never K-updated, treat as default
+		return HostScoreEloDefault
+	}
+	if HostScoreEloHalfLife <= 0 {
+		return raw
+	}
+	lastUpdate, ok := t.eloUpdatedAt[key]
+	if !ok || lastUpdate.IsZero() {
+		return raw
+	}
+	age := now.Sub(lastUpdate)
+	if age <= 0 {
+		return raw
+	}
+	multiplier := math.Exp(-math.Ln2 * float64(age) / float64(HostScoreEloHalfLife))
+	return HostScoreEloDefault + (raw-HostScoreEloDefault)*multiplier
+}
+
+// RecordRequest appends a sample per scoreable host and runs two K/2 Elo
+// updates per pair (TTFT + Total). See docs/host-scoring.md#layer-22-elo-credit.
+func (t *HostScoreTracker) RecordRequest(rec RequestRecord) {
+	if t == nil || len(rec.Hosts) == 0 {
+		return
+	}
+	bucket := requestShapeBucket(rec.InputTokens)
+	now := rec.Timestamp
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	eligible := make([]HostInvolvement, 0, len(rec.Hosts))
+	for _, h := range rec.Hosts {
+		if h.ExcludePairwise || h.ParticipantKey == "" {
+			continue
+		}
+		eligible = append(eligible, h)
+	}
+	if len(eligible) == 0 {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, h := range eligible {
+		if !scoreablePairwiseHost(h) {
+			continue
+		}
+		key := hostScoreKey{model: rec.Model, host: h.ParticipantKey, bucket: bucket}
+		ring := t.hosts[key]
+		if ring == nil {
+			ring = &hostScoreRing{samples: make([]hostScoreSample, 0, HostScoreWindowSize)}
+			t.hosts[key] = ring
+		}
+		ring.add(hostScoreSample{Timestamp: now, TtftMs: h.FirstTokenMs, TotalMs: h.TotalTimeMs})
+	}
+
+	halfK := HostScoreEloK / 2
+	for i := 0; i < len(eligible); i++ {
+		for j := i + 1; j < len(eligible); j++ {
+			a, b := eligible[i], eligible[j]
+			if a.ParticipantKey == b.ParticipantKey {
+				continue
+			}
+			keyA := hostScoreKey{model: rec.Model, host: a.ParticipantKey, bucket: bucket}
+			keyB := hostScoreKey{model: rec.Model, host: b.ParticipantKey, bucket: bucket}
+			SaTTFT, SbTTFT := pairOutcome(a, b, true)
+			t.updateEloLocked(keyA, keyB, SaTTFT, SbTTFT, halfK, now)
+			SaTotal, SbTotal := pairOutcome(a, b, false)
+			t.updateEloLocked(keyA, keyB, SaTotal, SbTotal, halfK, now)
+		}
+	}
+}
+
+// pairOutcome returns (Sa, Sb) for one metric dimension; outcome matrix
+// in docs/host-scoring.md#layer-22-elo-credit.
+func pairOutcome(a, b HostInvolvement, useTTFT bool) (Sa, Sb float64) {
+	aOK := metricAvailable(a, useTTFT)
+	bOK := metricAvailable(b, useTTFT)
+	switch {
+	case aOK && bOK:
+		Sa = bradleyTerryScore(metricFor(a, useTTFT), metricFor(b, useTTFT))
+		return Sa, 1.0 - Sa
+	case aOK && !bOK:
+		return 1.0, 0.0
+	case !aOK && bOK:
+		return 0.0, 1.0
+	default:
+		return 0.0, 0.0
+	}
+}
+
+// bradleyTerryScore: Sa = mb^k / (ma^k + mb^k) for LOWER-is-better metrics.
+// See docs/host-scoring.md#layer-22-elo-credit.
+func bradleyTerryScore(ma, mb float64) float64 {
+	if ma <= 0 || mb <= 0 {
+		return 0.5
+	}
+	ra := math.Pow(ma, HostScoreBradleyTerryExp)
+	rb := math.Pow(mb, HostScoreBradleyTerryExp)
+	return rb / (ra + rb)
+}
+
+func metricAvailable(h HostInvolvement, useTTFT bool) bool {
+	if !h.Responsive {
+		return false
+	}
+	if useTTFT {
+		return h.FirstTokenMs > 0
+	}
+	return h.Finished && h.TotalTimeMs > 0
+}
+
+func metricFor(h HostInvolvement, useTTFT bool) float64 {
+	if useTTFT {
+		return h.FirstTokenMs
+	}
+	return h.TotalTimeMs
+}
+
+// updateEloLocked applies a K-factor Elo step after decaying both ratings.
+// See docs/host-scoring.md#layer-22-elo-credit.
+func (t *HostScoreTracker) updateEloLocked(keyA, keyB hostScoreKey, Sa, Sb, K float64, now time.Time) {
+	Ra := t.decayedEloLocked(keyA, now)
+	Rb := t.decayedEloLocked(keyB, now)
+	Ea := 1.0 / (1 + math.Pow(10, (Rb-Ra)/400))
+	Eb := 1.0 - Ea
+	t.elo[keyA] = Ra + K*(Sa-Ea)
+	t.elo[keyB] = Rb + K*(Sb-Eb)
+	t.eloUpdatedAt[keyA] = now
+	t.eloUpdatedAt[keyB] = now
+}
+
+// ScoreHost returns a lower-is-better routing score (0,false if no data).
+// Two layers (H2H rate then Elo+timing+UCB); see docs/host-scoring.md#the-score-formula.
+func (t *HostScoreTracker) ScoreHost(model, host, bucket string, stream bool, opponent string) (float64, bool) {
+	if t == nil {
+		return 0, false
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	key := hostScoreKey{model: model, host: host, bucket: bucket}
+	ring := t.hosts[key]
+	if ring == nil || len(ring.samples) < HostScoreMinSamples {
+		return 0, false
+	}
+
+	if opponent != "" && t.pairwise != nil {
+		if rate, n, ok := t.pairwise.H2HWinRate(model, bucket, host, opponent); ok && n >= HostScoreMinSamples {
+			return 1.0 - rate, true
+		}
+	}
+
+	gamma := HostScoreNonStreamGamma
+	if stream {
+		gamma = HostScoreStreamGamma
+	}
+	ttft, total := ring.percentile(0.50)
+	base := (1-gamma)*ttft + gamma*total
+	elo := t.decayedEloLocked(key, t.now())
+	ucb := t.ucbBonusLocked(model, bucket, len(ring.samples))
+	return base - HostScoreEloAlpha*(elo-HostScoreEloDefault) - ucb, true
+}
+
+// ucbBonusLocked computes c·√(ln N_bucket / n_host); caller holds mu.
+func (t *HostScoreTracker) ucbBonusLocked(model, bucket string, n int) float64 {
+	if HostScoreUCBCoefficient <= 0 || n <= 0 {
+		return 0
+	}
+	total := 0
+	for k, ring := range t.hosts {
+		if k.model == model && k.bucket == bucket {
+			total += len(ring.samples)
+		}
+	}
+	if total <= n {
+		return 0
+	}
+	return HostScoreUCBCoefficient * math.Sqrt(math.Log(float64(total))/float64(n))
+}
+
+// Snapshot returns the public view of all tracked keys, sorted for stable
+// admin output (model, bucket, host).
+func (t *HostScoreTracker) Snapshot() []HostScoreSnapshot {
+	if t == nil {
+		return nil
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	type bucketCacheKey struct{ model, bucket string }
+	bucketTotals := make(map[bucketCacheKey]int)
+	totalFor := func(model, bucket string) int {
+		k := bucketCacheKey{model: model, bucket: bucket}
+		if v, ok := bucketTotals[k]; ok {
+			return v
+		}
+		total := 0
+		for k2, ring := range t.hosts {
+			if k2.model == model && k2.bucket == bucket {
+				total += len(ring.samples)
+			}
+		}
+		bucketTotals[k] = total
+		return total
+	}
+	now := t.now()
+	out := make([]HostScoreSnapshot, 0, len(t.hosts))
+	for key, ring := range t.hosts {
+		ttftP50, totalP50 := ring.percentile(0.50)
+		ttftP90, totalP90 := ring.percentile(0.90)
+		elo := t.decayedEloLocked(key, now)
+		eloBonus := HostScoreEloAlpha * (elo - HostScoreEloDefault)
+		bucketN := totalFor(key.model, key.bucket)
+		ucb := t.ucbBonusLocked(key.model, key.bucket, len(ring.samples))
+		out = append(out, HostScoreSnapshot{
+			Model:          key.model,
+			Host:           key.host,
+			Bucket:         key.bucket,
+			Samples:        len(ring.samples),
+			BucketTotalN:   bucketN,
+			TtftP50Ms:      ttftP50,
+			TtftP90Ms:      ttftP90,
+			TotalP50Ms:     totalP50,
+			TotalP90Ms:     totalP90,
+			Elo:            elo,
+			UCBBonus:       ucb,
+			ScoreStream:    (1-HostScoreStreamGamma)*ttftP50 + HostScoreStreamGamma*totalP50 - eloBonus - ucb,
+			ScoreNonStream: (1-HostScoreNonStreamGamma)*ttftP50 + HostScoreNonStreamGamma*totalP50 - eloBonus - ucb,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Model != out[j].Model {
+			return out[i].Model < out[j].Model
+		}
+		if out[i].Bucket != out[j].Bucket {
+			return out[i].Bucket < out[j].Bucket
+		}
+		return out[i].Host < out[j].Host
+	})
+	return out
+}
+
+// PersistState returns per-key state for SQLite upsert; UpdatedAt is the
+// per-row last-K-update time, not the snapshot time.
+func (t *HostScoreTracker) PersistState() []HostScoreState {
+	if t == nil {
+		return nil
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	fallback := t.now().UTC() // for keys with samples but no K-update yet (Elo also default)
+	out := make([]HostScoreState, 0, len(t.hosts))
+	for key, ring := range t.hosts {
+		elo := t.elo[key]
+		if elo == 0 {
+			elo = HostScoreEloDefault
+		}
+		samples := make([]hostScoreSample, len(ring.samples))
+		copy(samples, ring.samples)
+		updatedAt := t.eloUpdatedAt[key]
+		if updatedAt.IsZero() {
+			updatedAt = fallback
+		}
+		out = append(out, HostScoreState{
+			Model:     key.model,
+			Host:      key.host,
+			Bucket:    key.bucket,
+			Elo:       elo,
+			Samples:   samples,
+			UpdatedAt: updatedAt.UTC(),
+		})
+	}
+	return out
+}
+
+// Restore replaces in-memory state from persisted rows; per-row UpdatedAt
+// seeds eloUpdatedAt so decay continues across restart.
+func (t *HostScoreTracker) Restore(states []HostScoreState) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.hosts = make(map[hostScoreKey]*hostScoreRing, len(states))
+	t.elo = make(map[hostScoreKey]float64, len(states))
+	t.eloUpdatedAt = make(map[hostScoreKey]time.Time, len(states))
+	for _, s := range states {
+		key := hostScoreKey{model: s.Model, host: s.Host, bucket: s.Bucket}
+		samples := s.Samples
+		if len(samples) > HostScoreWindowSize {
+			samples = samples[len(samples)-HostScoreWindowSize:]
+		}
+		ring := &hostScoreRing{samples: make([]hostScoreSample, len(samples), HostScoreWindowSize)}
+		copy(ring.samples, samples)
+		ring.pos = len(ring.samples) % HostScoreWindowSize
+		t.hosts[key] = ring
+		if s.Elo != 0 {
+			t.elo[key] = s.Elo
+		}
+		if !s.UpdatedAt.IsZero() {
+			t.eloUpdatedAt[key] = s.UpdatedAt
+		}
+	}
+}

--- a/devshard/cmd/devshardctl/host_scores_bench_test.go
+++ b/devshard/cmd/devshardctl/host_scores_bench_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+)
+
+// Targets per plan: RecordRequest < 5 µs, ScoreHost < 1 µs.
+
+func BenchmarkRecordRequest_SingleHost(b *testing.B) {
+	tr := NewHostScoreTracker(nil)
+	rec := mkRequest("m", 1_000, mkInvolvement("A", 100, 1000))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tr.RecordRequest(rec)
+	}
+}
+
+func BenchmarkRecordRequest_TwoHosts(b *testing.B) {
+	tr := NewHostScoreTracker(nil)
+	rec := mkRequest("m", 1_000,
+		mkInvolvement("A", 100, 1000),
+		mkInvolvement("B", 110, 1100),
+	)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tr.RecordRequest(rec)
+	}
+}
+
+func BenchmarkRecordRequest_FourHosts(b *testing.B) {
+	tr := NewHostScoreTracker(nil)
+	hosts := make([]HostInvolvement, 4)
+	for i := range hosts {
+		hosts[i] = mkInvolvement("H"+strconv.Itoa(i), float64(100+i*10), float64(1000+i*100))
+	}
+	rec := mkRequest("m", 1_000, hosts...)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tr.RecordRequest(rec)
+	}
+}
+
+func BenchmarkScoreHost_ColdStart(b *testing.B) {
+	tr := NewHostScoreTracker(nil)
+	tr.RecordRequest(mkRequest("m", 1_000, mkInvolvement("A", 100, 1000)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = tr.ScoreHost("m", "A", "lt_1k", false, "")
+	}
+}
+
+func BenchmarkScoreHost_FullRing(b *testing.B) {
+	tr := NewHostScoreTracker(nil)
+	for i := 0; i < HostScoreWindowSize; i++ {
+		tr.RecordRequest(mkRequest("m", 1_000, mkInvolvement("A", float64(100+i), float64(1000+i))))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = tr.ScoreHost("m", "A", "lt_1k", false, "")
+	}
+}
+
+func BenchmarkScoreHost_WithH2H(b *testing.B) {
+	pw := NewPairwiseTracker()
+	tr := NewHostScoreTracker(pw)
+	for i := 0; i < HostScoreMinSamples+5; i++ {
+		rec := mkRequest("m", 1_000, mkInvolvement("A", 100, 1000), mkInvolvement("B", 200, 2000))
+		pw.RecordRequest(rec)
+		tr.RecordRequest(rec)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = tr.ScoreHost("m", "A", "lt_1k", false, "B")
+	}
+}

--- a/devshard/cmd/devshardctl/host_scores_decide_test.go
+++ b/devshard/cmd/devshardctl/host_scores_decide_test.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// hostScoresTestRecord builds a 2-host record with explicit per-host timings.
+func hostScoresTestRecord(host0TotalMs, host1TotalMs float64) RequestRecord {
+	return RequestRecord{
+		Timestamp:   time.Now(),
+		Model:       "",
+		InputTokens: 20_000,
+		Hosts: []HostInvolvement{
+			{HostIdx: 0, ParticipantKey: "host:0", FirstTokenMs: host0TotalMs / 10, TotalTimeMs: host0TotalMs, Responsive: true, Finished: true},
+			{HostIdx: 1, ParticipantKey: "host:1", FirstTokenMs: host1TotalMs / 10, TotalTimeMs: host1TotalMs, Responsive: true, Finished: true},
+		},
+	}
+}
+
+func TestDecideHostScoreSpeedup_H2HCandidateBeatsPrimary(t *testing.T) {
+	perf := NewPerfTracker(nil)
+	// 4 records where host:1 always finishes 2x faster → H2H rate(host:1 vs host:0) = 1.0
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.True(t, d.RunSecondary)
+	require.Equal(t, "host_scores", d.Reason)
+	require.Equal(t, 1, d.ImmediateAttempts)
+}
+
+func TestDecideHostScoreSpeedup_EloLayerWhenNoH2H(t *testing.T) {
+	perf := NewPerfTracker(nil)
+	// Feed each host on its own so PairwiseTracker stays empty → Layer 1 skipped.
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(RequestRecord{
+			Timestamp:   time.Now(),
+			Model:       "",
+			InputTokens: 20_000,
+			Hosts: []HostInvolvement{
+				{HostIdx: 0, ParticipantKey: "host:0", FirstTokenMs: 200, TotalTimeMs: 2000, Responsive: true, Finished: true},
+			},
+		})
+	}
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(RequestRecord{
+			Timestamp:   time.Now(),
+			Model:       "",
+			InputTokens: 20_000,
+			Hosts: []HostInvolvement{
+				{HostIdx: 1, ParticipantKey: "host:1", FirstTokenMs: 80, TotalTimeMs: 800, Responsive: true, Finished: true},
+			},
+		})
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.True(t, d.RunSecondary, "Elo layer must trigger when H2H absent and candidate much faster")
+	require.Equal(t, "host_scores", d.Reason)
+	require.Equal(t, 1, d.ImmediateAttempts)
+}
+
+func TestDecideHostScoreSpeedup_ColdStartReturnsNoData(t *testing.T) {
+	withForcedExploration(t, 0, 0) // isolate from ε-greedy floor
+	perf := NewPerfTracker(nil)
+	// Only one sample per host — below HostScoreMinSamples for both layers.
+	perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.False(t, d.RunSecondary)
+	require.Equal(t, "host_scores_no_data", d.Reason, "cold start (samples < MinSamples) must report no_data")
+}
+
+func TestDecideHostScoreSpeedup_CandidateTooCloseReturnsNoCandidate(t *testing.T) {
+	withForcedExploration(t, 0, 0) // isolate from ε-greedy floor
+	perf := NewPerfTracker(nil)
+	// Both hosts within SpeedupMargin → we have data but no qualifier → no_candidate.
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(RequestRecord{
+			Timestamp:   time.Now(),
+			Model:       "",
+			InputTokens: 20_000,
+			Hosts: []HostInvolvement{
+				{HostIdx: 0, ParticipantKey: "host:0", FirstTokenMs: 100, TotalTimeMs: 1000, Responsive: true, Finished: true},
+			},
+		})
+		perf.RecordRequest(RequestRecord{
+			Timestamp:   time.Now(),
+			Model:       "",
+			InputTokens: 20_000,
+			Hosts: []HostInvolvement{
+				{HostIdx: 1, ParticipantKey: "host:1", FirstTokenMs: 98, TotalTimeMs: 980, Responsive: true, Finished: true},
+			},
+		})
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.False(t, d.RunSecondary)
+	require.Equal(t, "host_scores_no_candidate", d.Reason, "had data, no candidate beat margin → no_candidate")
+}
+
+func TestDecideHostScoreSpeedup_GroupSizeOneReturnsNoData(t *testing.T) {
+	perf := NewPerfTracker(nil)
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+	}
+	redundancy := &Redundancy{perf: perf, groupSize: 1}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.False(t, d.RunSecondary)
+	require.Equal(t, "host_scores_no_data", d.Reason)
+}
+
+func TestDecideHostScoreSpeedup_NilPerfReturnsNoData(t *testing.T) {
+	redundancy := &Redundancy{groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.False(t, d.RunSecondary)
+	require.Equal(t, "host_scores_no_data", d.Reason)
+}
+
+func withRedundancyPolicyForTest(t *testing.T, policy string) {
+	t.Helper()
+	saved := RedundancySpeedPolicy
+	RedundancySpeedPolicy = policy
+	t.Cleanup(func() { RedundancySpeedPolicy = saved })
+}
+
+func TestDecide_HostScorePolicyReturnsHostScoreDecision(t *testing.T) {
+	withRedundancyPolicyForTest(t, RedundancySpeedPolicyHostScore)
+
+	perf := NewPerfTracker(nil)
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.Decide(0, 20_000)
+	require.True(t, d.RunSecondary)
+	require.Equal(t, "host_scores", d.Reason, "host_score policy must delegate the decision to decideHostScoreSpeedup")
+}
+
+func TestDecide_NonHostScorePolicySkipsHostScore(t *testing.T) {
+	withRedundancyPolicyForTest(t, RedundancySpeedPolicyHybrid)
+
+	perf := NewPerfTracker(nil)
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.Decide(0, 20_000)
+	require.NotEqual(t, "host_scores", d.Reason, "non-host-score policies must not select the host-score path")
+}
+
+func withForcedExploration(t *testing.T, epsilon, rollValue float64) {
+	t.Helper()
+	savedEps := HostScoreExplorationEpsilon
+	savedRand := hostScoreRandom
+	HostScoreExplorationEpsilon = epsilon
+	hostScoreRandom = func() float64 { return rollValue }
+	t.Cleanup(func() {
+		HostScoreExplorationEpsilon = savedEps
+		hostScoreRandom = savedRand
+	})
+}
+
+func TestDecideHostScoreSpeedup_ExplorationFiresWhenScoreAmbivalent(t *testing.T) {
+	withForcedExploration(t, 1.0, 0.0) // roll < ε → always explore
+
+	perf := NewPerfTracker(nil)
+	// No samples → score-based path has nothing to evaluate; exploration fires.
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.True(t, d.RunSecondary)
+	require.Equal(t, "host_scores_exploration", d.Reason)
+	require.Equal(t, 1, d.ImmediateAttempts)
+}
+
+func TestDecideHostScoreSpeedup_ExplorationDisabledByZeroEpsilon(t *testing.T) {
+	withForcedExploration(t, 0.0, 0.0)
+
+	perf := NewPerfTracker(nil)
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.False(t, d.RunSecondary)
+	require.Equal(t, "host_scores_no_data", d.Reason, "ε=0 plus no samples must report no_data")
+}
+
+func TestDecideHostScoreSpeedup_ConfidentPickIgnoresExploration(t *testing.T) {
+	// Roll always fires, but confident pick must take precedence over exploration.
+	withForcedExploration(t, 1.0, 0.0)
+
+	perf := NewPerfTracker(nil)
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.True(t, d.RunSecondary)
+	require.Equal(t, "host_scores", d.Reason, "confident score-based pick must not be masked by exploration")
+}
+
+func TestDecideHostScoreSpeedup_ExplorationSkippedWhenRollAboveEpsilon(t *testing.T) {
+	withForcedExploration(t, 0.05, 0.5) // roll > ε → no exploration
+
+	perf := NewPerfTracker(nil)
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.decideHostScoreSpeedup(0, 20_000)
+	require.False(t, d.RunSecondary)
+	require.Equal(t, "host_scores_no_data", d.Reason, "roll above ε must not fire exploration; with no data result is no_data")
+}
+
+func TestDecide_HostScorePolicyDoesNotCascadeOnNoCandidate(t *testing.T) {
+	// no_candidate must not be overridden by a legacy fallback.
+	withRedundancyPolicyForTest(t, RedundancySpeedPolicyHostScore)
+	withForcedExploration(t, 0, 0)
+
+	perf := NewPerfTracker(nil)
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(RequestRecord{
+			Timestamp:   time.Now(),
+			Model:       "",
+			InputTokens: 20_000,
+			Hosts: []HostInvolvement{
+				{HostIdx: 0, ParticipantKey: "host:0", FirstTokenMs: 100, TotalTimeMs: 1000, Responsive: true, Finished: true},
+			},
+		})
+		perf.RecordRequest(RequestRecord{
+			Timestamp:   time.Now(),
+			Model:       "",
+			InputTokens: 20_000,
+			Hosts: []HostInvolvement{
+				{HostIdx: 1, ParticipantKey: "host:1", FirstTokenMs: 98, TotalTimeMs: 980, Responsive: true, Finished: true},
+			},
+		})
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.Decide(0, 20_000)
+	require.False(t, d.RunSecondary)
+	require.Equal(t, "host_scores_no_candidate", d.Reason)
+}
+
+func TestDecide_HostScorePolicyDoesNotCascadeOnNoData(t *testing.T) {
+	// no_data must not cascade to legacy either; ε-greedy forced off.
+	withRedundancyPolicyForTest(t, RedundancySpeedPolicyHostScore)
+	withForcedExploration(t, 0, 0)
+
+	perf := NewPerfTracker(nil)
+	perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.Decide(0, 20_000)
+	require.False(t, d.RunSecondary)
+	require.Equal(t, "host_scores_no_data", d.Reason)
+}
+
+// withDeterministicPairwiseRandom silences pairwise AB-sample randomness for routing tests.
+func withDeterministicPairwiseRandom(t *testing.T) {
+	t.Helper()
+	saved := pairwiseABRandom
+	pairwiseABRandom = func() float64 { return 1 } // never fire AB sample
+	t.Cleanup(func() { pairwiseABRandom = saved })
+}
+
+func TestDecide_PairwisePolicyRoutesToPairwise(t *testing.T) {
+	// pairwise policy must never enter host-score path, even with host-score data.
+	withRedundancyPolicyForTest(t, RedundancySpeedPolicyPairwise)
+	withDeterministicPairwiseRandom(t)
+
+	perf := NewPerfTracker(nil)
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.Decide(0, 20_000)
+	require.NotContains(t, d.Reason, "host_scores", "pairwise policy must not enter host-score path")
+	require.Contains(t, d.Reason, "pairwise", "pairwise policy must produce a pairwise_* reason")
+}
+
+func TestDecide_HybridPolicyRoutesPairwiseThenLegacy(t *testing.T) {
+	// hybrid policy must never enter host-score path, even with host-score data.
+	withRedundancyPolicyForTest(t, RedundancySpeedPolicyHybrid)
+	withDeterministicPairwiseRandom(t)
+
+	perf := NewPerfTracker(nil)
+	for i := 0; i < 4; i++ {
+		perf.RecordRequest(hostScoresTestRecord(2000, 1000))
+	}
+
+	redundancy := &Redundancy{perf: perf, groupSize: 2}
+	d := redundancy.Decide(0, 20_000)
+	require.NotContains(t, d.Reason, "host_scores", "hybrid policy must not enter the host-score path")
+}

--- a/devshard/cmd/devshardctl/host_scores_test.go
+++ b/devshard/cmd/devshardctl/host_scores_test.go
@@ -364,6 +364,10 @@ func TestScoreHost_UCBHelpsColdHostBeatEloFavorite(t *testing.T) {
 }
 
 func TestEloDecay_StaleRatingPullsTowardDefault(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{}
+
 	tr := NewHostScoreTracker(nil)
 	key := hostScoreKey{model: "m", host: "stale", bucket: "lt_1k"}
 	tr.elo[key] = 1800.0
@@ -384,9 +388,14 @@ func TestEloDecay_StaleRatingPullsTowardDefault(t *testing.T) {
 }
 
 func TestEloDecay_DisabledByZeroHalfLife(t *testing.T) {
-	saved := HostScoreEloHalfLife
-	t.Cleanup(func() { HostScoreEloHalfLife = saved })
+	savedHL := HostScoreEloHalfLife
+	savedOv := HostScoreBucketOverrides
+	t.Cleanup(func() {
+		HostScoreEloHalfLife = savedHL
+		HostScoreBucketOverrides = savedOv
+	})
 	HostScoreEloHalfLife = 0
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{}
 
 	tr := NewHostScoreTracker(nil)
 	key := hostScoreKey{model: "m", host: "frozen", bucket: "lt_1k"}
@@ -404,7 +413,124 @@ func TestEloDecay_NoUpdatedAtSkipsDecay(t *testing.T) {
 	require.Equal(t, 1800.0, tr.decayedEloLocked(key, time.Now()))
 }
 
+func TestBucketOverrides_HelpersFallBackToGlobals(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{}
+
+	require.Equal(t, HostScoreEloK, hostScoreKForBucket("any"))
+	require.Equal(t, HostScoreEloHalfLife, hostScoreHalfLifeForBucket("any"))
+}
+
+func TestBucketOverrides_KAppliesPerBucket(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
+		"gte_100k": {K: 32, HalfLife: -1},
+	}
+
+	require.Equal(t, 32.0, hostScoreKForBucket("gte_100k"))
+	require.Equal(t, HostScoreEloK, hostScoreKForBucket("lt_1k"), "non-overridden bucket inherits global")
+}
+
+func TestBucketOverrides_KZeroInheritsGlobal(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
+		"lt_1k": {K: 0, HalfLife: -1},
+	}
+	require.Equal(t, HostScoreEloK, hostScoreKForBucket("lt_1k"))
+}
+
+func TestBucketOverrides_HalfLifeAppliesPerBucket(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
+		"slow_decay": {HalfLife: 48 * time.Hour},
+		"fast_decay": {HalfLife: 1 * time.Hour},
+	}
+
+	tr := NewHostScoreTracker(nil)
+	slow := hostScoreKey{model: "m", host: "h", bucket: "slow_decay"}
+	fast := hostScoreKey{model: "m", host: "h", bucket: "fast_decay"}
+	t0 := time.Now()
+	tr.elo[slow] = 1800.0
+	tr.elo[fast] = 1800.0
+	tr.eloUpdatedAt[slow] = t0
+	tr.eloUpdatedAt[fast] = t0
+
+	// 1h elapsed: fast bucket = 1 half-life (gap halves to 150 → 1650);
+	// slow bucket = 1/48 half-life (gap barely moves).
+	at := t0.Add(time.Hour)
+	require.InDelta(t, 1650.0, tr.decayedEloLocked(fast, at), 0.5)
+	require.Greater(t, tr.decayedEloLocked(slow, at), 1790.0,
+		"48h half-life should barely move after 1h")
+}
+
+func TestBucketOverrides_HalfLifeZeroDisablesPerBucket(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
+		"frozen_bucket": {HalfLife: 0},
+	}
+
+	tr := NewHostScoreTracker(nil)
+	frozen := hostScoreKey{model: "m", host: "h", bucket: "frozen_bucket"}
+	tr.elo[frozen] = 1800.0
+	tr.eloUpdatedAt[frozen] = time.Now().Add(-100 * time.Hour)
+
+	require.Equal(t, 1800.0, tr.decayedEloLocked(frozen, time.Now()),
+		"explicit HalfLife=0 must disable decay for this bucket")
+}
+
+func TestBucketOverrides_NegativeHalfLifeInheritsGlobal(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
+		"inherit_decay": {K: 20, HalfLife: -1},
+	}
+	require.Equal(t, HostScoreEloHalfLife, hostScoreHalfLifeForBucket("inherit_decay"))
+}
+
+func TestBucketOverrides_RecordRequestUsesPerBucketK(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	// requestShapeBucket(100) → "lt_1k"; double K for that bucket.
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
+		"lt_1k": {K: HostScoreEloK * 2, HalfLife: -1},
+	}
+
+	tr := NewHostScoreTracker(nil)
+	keyA := hostScoreKey{model: "m", host: "A", bucket: "lt_1k"}
+
+	// Same identical race A>B fed twice: once with default K (baseline tr2), once with 2x K.
+	tr.RecordRequest(mkRequest("m", 100,
+		mkInvolvement("A", 100, 1000),
+		mkInvolvement("B", 200, 2000),
+	))
+	gainOverridden := tr.elo[keyA] - HostScoreEloDefault
+
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{}
+	tr2 := NewHostScoreTracker(nil)
+	tr2.RecordRequest(mkRequest("m", 100,
+		mkInvolvement("A", 100, 1000),
+		mkInvolvement("B", 200, 2000),
+	))
+	gainBaseline := tr2.elo[keyA] - HostScoreEloDefault
+
+	// Per RecordRequest two updates (TTFT + Total) at halfK each. The
+	// second update's Ea shifts with Ra moved by the first, so the
+	// K→gain relationship is approximately, not exactly, linear.
+	ratio := gainOverridden / gainBaseline
+	require.Greater(t, ratio, 1.8, "doubling K should roughly double gain")
+	require.Less(t, ratio, 2.2, "doubling K should not far overshoot 2x")
+}
+
 func TestUpdateElo_DecayAppliedBeforeKUpdate(t *testing.T) {
+	saved := HostScoreBucketOverrides
+	t.Cleanup(func() { HostScoreBucketOverrides = saved })
+	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{}
+
 	tr := NewHostScoreTracker(nil)
 	keyA := hostScoreKey{model: "m", host: "stale_fav", bucket: "lt_1k"}
 	keyB := hostScoreKey{model: "m", host: "fresh_und", bucket: "lt_1k"}

--- a/devshard/cmd/devshardctl/host_scores_test.go
+++ b/devshard/cmd/devshardctl/host_scores_test.go
@@ -418,28 +418,7 @@ func TestBucketOverrides_HelpersFallBackToGlobals(t *testing.T) {
 	t.Cleanup(func() { HostScoreBucketOverrides = saved })
 	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{}
 
-	require.Equal(t, HostScoreEloK, hostScoreKForBucket("any"))
 	require.Equal(t, HostScoreEloHalfLife, hostScoreHalfLifeForBucket("any"))
-}
-
-func TestBucketOverrides_KAppliesPerBucket(t *testing.T) {
-	saved := HostScoreBucketOverrides
-	t.Cleanup(func() { HostScoreBucketOverrides = saved })
-	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
-		"gte_100k": {K: 32, HalfLife: -1},
-	}
-
-	require.Equal(t, 32.0, hostScoreKForBucket("gte_100k"))
-	require.Equal(t, HostScoreEloK, hostScoreKForBucket("lt_1k"), "non-overridden bucket inherits global")
-}
-
-func TestBucketOverrides_KZeroInheritsGlobal(t *testing.T) {
-	saved := HostScoreBucketOverrides
-	t.Cleanup(func() { HostScoreBucketOverrides = saved })
-	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
-		"lt_1k": {K: 0, HalfLife: -1},
-	}
-	require.Equal(t, HostScoreEloK, hostScoreKForBucket("lt_1k"))
 }
 
 func TestBucketOverrides_HalfLifeAppliesPerBucket(t *testing.T) {
@@ -487,43 +466,9 @@ func TestBucketOverrides_NegativeHalfLifeInheritsGlobal(t *testing.T) {
 	saved := HostScoreBucketOverrides
 	t.Cleanup(func() { HostScoreBucketOverrides = saved })
 	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
-		"inherit_decay": {K: 20, HalfLife: -1},
+		"inherit_decay": {HalfLife: -1},
 	}
 	require.Equal(t, HostScoreEloHalfLife, hostScoreHalfLifeForBucket("inherit_decay"))
-}
-
-func TestBucketOverrides_RecordRequestUsesPerBucketK(t *testing.T) {
-	saved := HostScoreBucketOverrides
-	t.Cleanup(func() { HostScoreBucketOverrides = saved })
-	// requestShapeBucket(100) → "lt_1k"; double K for that bucket.
-	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
-		"lt_1k": {K: HostScoreEloK * 2, HalfLife: -1},
-	}
-
-	tr := NewHostScoreTracker(nil)
-	keyA := hostScoreKey{model: "m", host: "A", bucket: "lt_1k"}
-
-	// Same identical race A>B fed twice: once with default K (baseline tr2), once with 2x K.
-	tr.RecordRequest(mkRequest("m", 100,
-		mkInvolvement("A", 100, 1000),
-		mkInvolvement("B", 200, 2000),
-	))
-	gainOverridden := tr.elo[keyA] - HostScoreEloDefault
-
-	HostScoreBucketOverrides = map[string]HostScoreBucketOverride{}
-	tr2 := NewHostScoreTracker(nil)
-	tr2.RecordRequest(mkRequest("m", 100,
-		mkInvolvement("A", 100, 1000),
-		mkInvolvement("B", 200, 2000),
-	))
-	gainBaseline := tr2.elo[keyA] - HostScoreEloDefault
-
-	// Per RecordRequest two updates (TTFT + Total) at halfK each. The
-	// second update's Ea shifts with Ra moved by the first, so the
-	// K→gain relationship is approximately, not exactly, linear.
-	ratio := gainOverridden / gainBaseline
-	require.Greater(t, ratio, 1.8, "doubling K should roughly double gain")
-	require.Less(t, ratio, 2.2, "doubling K should not far overshoot 2x")
 }
 
 func TestUpdateElo_DecayAppliedBeforeKUpdate(t *testing.T) {

--- a/devshard/cmd/devshardctl/host_scores_test.go
+++ b/devshard/cmd/devshardctl/host_scores_test.go
@@ -1,0 +1,556 @@
+package main
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mkInvolvement(participant string, firstTokenMs, totalMs float64) HostInvolvement {
+	return HostInvolvement{
+		ParticipantKey: participant,
+		FirstTokenMs:   firstTokenMs,
+		TotalTimeMs:    totalMs,
+		Responsive:     true,
+		Finished:       true,
+	}
+}
+
+func mkRequest(model string, inputTokens uint64, hosts ...HostInvolvement) RequestRecord {
+	return RequestRecord{
+		Timestamp:   time.Now(),
+		Model:       model,
+		InputTokens: inputTokens,
+		Hosts:       hosts,
+	}
+}
+
+func TestHostScoreRing_AppendAndPercentile(t *testing.T) {
+	ring := &hostScoreRing{samples: make([]hostScoreSample, 0, HostScoreWindowSize)}
+	for i := 1; i <= 10; i++ {
+		ring.add(hostScoreSample{TtftMs: float64(i * 10), TotalMs: float64(i * 100)})
+	}
+	require.Len(t, ring.samples, 10)
+
+	ttftP50, totalP50 := ring.percentile(0.50)
+	require.InDelta(t, 55.0, ttftP50, 0.001, "ttft p50 should be linear-interpolated midpoint")
+	require.InDelta(t, 550.0, totalP50, 0.001)
+
+	ttftP90, totalP90 := ring.percentile(0.90)
+	require.InDelta(t, 91.0, ttftP90, 0.001)
+	require.InDelta(t, 910.0, totalP90, 0.001)
+}
+
+func TestHostScoreRing_RollsOver(t *testing.T) {
+	ring := &hostScoreRing{samples: make([]hostScoreSample, 0, HostScoreWindowSize)}
+	for i := 0; i < HostScoreWindowSize+25; i++ {
+		ring.add(hostScoreSample{TtftMs: float64(i), TotalMs: float64(i)})
+	}
+	require.Len(t, ring.samples, HostScoreWindowSize, "ring should cap at window size")
+
+	ordered := ring.ordered()
+	require.Equal(t, float64(25), ordered[0].TtftMs, "oldest should be sample #25")
+	require.Equal(t, float64(HostScoreWindowSize+24), ordered[HostScoreWindowSize-1].TtftMs, "newest should be the latest write")
+}
+
+func TestEloUpdate_BasicSymmetry(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	keyA := hostScoreKey{model: "m", host: "A", bucket: "lt_1k"}
+	keyB := hostScoreKey{model: "m", host: "B", bucket: "lt_1k"}
+
+	tr.updateEloLocked(keyA, keyB, 1.0, 0.0, HostScoreEloK, time.Now())
+	rA := tr.elo[keyA] - HostScoreEloDefault
+	rB := tr.elo[keyB] - HostScoreEloDefault
+	require.InDelta(t, -rB, rA, 0.0001, "equal-rated symmetric Elo: A gains exactly what B loses")
+	require.Greater(t, rA, 0.0, "winner gains rating")
+}
+
+func TestEloUpdate_UpsetReward(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	favoriteKey := hostScoreKey{model: "m", host: "fav", bucket: "lt_1k"}
+	underdogKey := hostScoreKey{model: "m", host: "und", bucket: "lt_1k"}
+	tr.elo[favoriteKey] = 1800.0
+	tr.elo[underdogKey] = 1200.0
+
+	pre := tr.elo[underdogKey]
+	tr.updateEloLocked(favoriteKey, underdogKey, 0.0, 1.0, HostScoreEloK, time.Now())
+	gain := tr.elo[underdogKey] - pre
+
+	tr2 := NewHostScoreTracker(nil)
+	a := hostScoreKey{model: "m", host: "a", bucket: "lt_1k"}
+	b := hostScoreKey{model: "m", host: "b", bucket: "lt_1k"}
+	tr2.updateEloLocked(a, b, 1.0, 0.0, HostScoreEloK, time.Now())
+	expectedGain := tr2.elo[a] - HostScoreEloDefault
+
+	// Equal-rated swing = K/2 = 8; max swing (impossible underdog) = K = 16.
+	// 1200-vs-1800 yields ~15.5 — comfortably above 1.5x but below the K cap.
+	require.Greater(t, gain, expectedGain*1.5, "upset should yield > 1.5x the equal-rated swing")
+	require.LessOrEqual(t, gain, HostScoreEloK, "single Elo update is capped at K")
+}
+
+func TestRecordRequest_SkipsUnscorable(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+
+	tr.RecordRequest(mkRequest("m", 100,
+		HostInvolvement{ParticipantKey: "A", FirstTokenMs: 100, TotalTimeMs: 1000, Responsive: true, Finished: false},
+		HostInvolvement{ParticipantKey: "B", FirstTokenMs: 110, TotalTimeMs: 1100, Responsive: true, Finished: true},
+	))
+	require.Len(t, tr.hosts, 1, "unfinished host A must be skipped; only B recorded")
+	_, hasA := tr.hosts[hostScoreKey{"m", "A", "lt_1k"}]
+	require.False(t, hasA)
+
+	tr.RecordRequest(mkRequest("m", 100,
+		HostInvolvement{ParticipantKey: "C", FirstTokenMs: 100, TotalTimeMs: 1000, Responsive: true, Finished: true, ExcludePairwise: true},
+		mkInvolvement("D", 110, 1100),
+	))
+	_, hasC := tr.hosts[hostScoreKey{"m", "C", "lt_1k"}]
+	require.False(t, hasC, "ExcludePairwise hosts must be skipped")
+	_, hasD := tr.hosts[hostScoreKey{"m", "D", "lt_1k"}]
+	require.True(t, hasD)
+}
+
+func TestScoreHost_ColdStart(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	for i := 0; i < HostScoreMinSamples-1; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 1000)))
+	}
+	_, ok := tr.ScoreHost("m", "A", "lt_1k", false, "")
+	require.False(t, ok, "below MinSamples should return ok=false")
+
+	tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 1000)))
+	_, ok = tr.ScoreHost("m", "A", "lt_1k", false, "")
+	require.True(t, ok)
+}
+
+func TestScoreHost_H2HOverridesElo(t *testing.T) {
+	pw := NewPairwiseTracker()
+	tr := NewHostScoreTracker(pw)
+
+	for i := 0; i < HostScoreMinSamples+1; i++ {
+		rec := mkRequest("m", 100, mkInvolvement("A", 100, 1000), mkInvolvement("B", 200, 2000))
+		pw.RecordRequest(rec)
+		tr.RecordRequest(rec)
+	}
+
+	// A always finishes ahead of B → H2HWinRate(A,B) ~ 1.0 → score = 1.0 - 1.0 = 0
+	scoreA, ok := tr.ScoreHost("m", "A", "lt_1k", false, "B")
+	require.True(t, ok)
+	require.InDelta(t, 0.0, scoreA, 0.001, "perfect-win-rate A scores 0 (best)")
+
+	scoreB, ok := tr.ScoreHost("m", "B", "lt_1k", false, "A")
+	require.True(t, ok)
+	require.InDelta(t, 1.0, scoreB, 0.001, "always-loser B scores 1.0")
+}
+
+func TestScoreHost_LinearGammaCorrect(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	for i := 0; i < 10; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 1000)))
+	}
+
+	scoreNonStream, ok := tr.ScoreHost("m", "A", "lt_1k", false, "")
+	require.True(t, ok)
+	// elo stays at default → eloBonus = 0; total p50 = 1000; γ=1.0 → base = 1000
+	require.InDelta(t, 1000.0, scoreNonStream, 0.001)
+
+	scoreStream, ok := tr.ScoreHost("m", "A", "lt_1k", true, "")
+	require.True(t, ok)
+	// γ=0.3 → base = 0.7*100 + 0.3*1000 = 70 + 300 = 370
+	require.InDelta(t, 370.0, scoreStream, 0.001)
+}
+
+func TestSnapshot_ContainsExpectedFields(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	for i := 0; i < 10; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 1000), mkInvolvement("B", 200, 2000)))
+	}
+
+	snap := tr.Snapshot()
+	require.Len(t, snap, 2)
+	for _, s := range snap {
+		require.NotEmpty(t, s.Model)
+		require.NotEmpty(t, s.Host)
+		require.Equal(t, "lt_1k", s.Bucket)
+		require.Equal(t, 10, s.Samples)
+		require.Greater(t, s.TtftP50Ms, 0.0)
+		require.Greater(t, s.TotalP50Ms, 0.0)
+		require.NotZero(t, s.Elo)
+	}
+	// Check sort order: A before B (host alphabetical when model+bucket equal)
+	require.Equal(t, "A", snap[0].Host)
+	require.Equal(t, "B", snap[1].Host)
+}
+
+func TestConcurrentRecord(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	const goroutines = 8
+	const perGoroutine = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				tr.RecordRequest(mkRequest("m", 100,
+					mkInvolvement("A", float64(100+i), float64(1000+i)),
+					mkInvolvement("B", float64(110+i), float64(1100+i)),
+				))
+			}
+		}()
+	}
+	wg.Wait()
+
+	tr.mu.RLock()
+	defer tr.mu.RUnlock()
+	for _, ring := range tr.hosts {
+		require.LessOrEqual(t, len(ring.samples), HostScoreWindowSize)
+	}
+	require.Len(t, tr.hosts, 2)
+}
+
+func TestRecordRequest_BucketingByInputTokens(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	cases := []struct {
+		tokens uint64
+		bucket string
+	}{
+		{500, "lt_1k"},
+		{3_000, "1k_5k"},
+		{10_000, "5k_15k"},
+		{20_000, "15k_30k"},
+		{50_000, "30k_100k"},
+		{200_000, "gte_100k"},
+	}
+	for _, tc := range cases {
+		tr.RecordRequest(mkRequest("m", tc.tokens, mkInvolvement("A", 100, 1000)))
+	}
+	for _, tc := range cases {
+		_, ok := tr.hosts[hostScoreKey{"m", "A", tc.bucket}]
+		require.True(t, ok, "expected bucket %s for tokens=%d", tc.bucket, tc.tokens)
+	}
+}
+
+func TestPersistStateAndRestore_RoundTrip(t *testing.T) {
+	src := NewHostScoreTracker(nil)
+	for i := 0; i < 15; i++ {
+		src.RecordRequest(mkRequest("m", 10_000, mkInvolvement("A", float64(100+i), float64(1000+i*10))))
+	}
+	src.elo[hostScoreKey{"m", "A", "5k_15k"}] = 1612.5
+
+	states := src.PersistState()
+	require.Len(t, states, 1)
+	require.InDelta(t, 1612.5, states[0].Elo, 0.001)
+	require.Len(t, states[0].Samples, 15)
+
+	dst := NewHostScoreTracker(nil)
+	dst.Restore(states)
+
+	require.Len(t, dst.hosts, 1)
+	require.InDelta(t, 1612.5, dst.elo[hostScoreKey{"m", "A", "5k_15k"}], 0.001)
+	ring := dst.hosts[hostScoreKey{"m", "A", "5k_15k"}]
+	require.Len(t, ring.samples, 15)
+
+	// Round-trip Snapshot equivalence on percentiles
+	srcSnap := src.Snapshot()
+	dstSnap := dst.Snapshot()
+	require.InDelta(t, srcSnap[0].TtftP50Ms, dstSnap[0].TtftP50Ms, 0.001)
+	require.InDelta(t, srcSnap[0].TotalP90Ms, dstSnap[0].TotalP90Ms, 0.001)
+}
+
+func TestInterpPercentile_EdgeCases(t *testing.T) {
+	require.Equal(t, 0.0, interpPercentile(nil, 0.5))
+	require.Equal(t, 42.0, interpPercentile([]float64{42}, 0.5))
+	require.Equal(t, 1.0, interpPercentile([]float64{1, 2, 3}, 0))
+	require.Equal(t, 3.0, interpPercentile([]float64{1, 2, 3}, 1))
+	require.InDelta(t, 2.0, interpPercentile([]float64{1, 2, 3}, 0.5), 0.001)
+}
+
+func TestEloMath_ExpectedScoreMonotonic(t *testing.T) {
+	// Higher Ra vs Rb means Ea increases; sanity-check math symmetry
+	for d := -400.0; d <= 400.0; d += 100 {
+		Ea := 1.0 / (1 + math.Pow(10, -d/400))
+		require.GreaterOrEqual(t, Ea, 0.0)
+		require.LessOrEqual(t, Ea, 1.0)
+	}
+}
+
+func TestUCBBonus_ZeroWhenSoleHostInBucket(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	for i := 0; i < 10; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 1000)))
+	}
+	tr.mu.RLock()
+	b := tr.ucbBonusLocked("m", "lt_1k", 10)
+	tr.mu.RUnlock()
+	require.Equal(t, 0.0, b, "sole host in bucket has no exploration alternative")
+}
+
+func TestUCBBonus_PositiveForUndersampled(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	// Saturate host A (50 samples), tiny B (3 samples) — same bucket
+	for i := 0; i < 50; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 1000)))
+	}
+	for i := 0; i < 3; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("B", 100, 1000)))
+	}
+	tr.mu.RLock()
+	a := tr.ucbBonusLocked("m", "lt_1k", 50)
+	b := tr.ucbBonusLocked("m", "lt_1k", 3)
+	tr.mu.RUnlock()
+	require.Greater(t, b, a, "under-sampled B should get a larger exploration credit")
+	require.Greater(t, b, 100.0, "B's UCB bonus should be a meaningful slice of the timing scale")
+}
+
+func TestUCBBonus_ShrinksAsSamplesGrow(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	for i := 0; i < 100; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 1000)))
+	}
+	for i := 0; i < 5; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("B", 100, 1000)))
+	}
+	tr.mu.RLock()
+	bonusAt5 := tr.ucbBonusLocked("m", "lt_1k", 5)
+	tr.mu.RUnlock()
+
+	for i := 0; i < 45; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("B", 100, 1000)))
+	}
+	tr.mu.RLock()
+	bonusAt50 := tr.ucbBonusLocked("m", "lt_1k", 50)
+	tr.mu.RUnlock()
+
+	require.Greater(t, bonusAt5, bonusAt50, "bonus must decrease as samples accumulate")
+}
+
+func TestUCBBonus_DisabledByZeroCoefficient(t *testing.T) {
+	saved := HostScoreUCBCoefficient
+	t.Cleanup(func() { HostScoreUCBCoefficient = saved })
+	HostScoreUCBCoefficient = 0
+
+	tr := NewHostScoreTracker(nil)
+	for i := 0; i < 50; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 1000)))
+	}
+	for i := 0; i < 3; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("B", 100, 1000)))
+	}
+	tr.mu.RLock()
+	b := tr.ucbBonusLocked("m", "lt_1k", 3)
+	tr.mu.RUnlock()
+	require.Equal(t, 0.0, b)
+}
+
+func TestScoreHost_UCBHelpsColdHostBeatEloFavorite(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	// A established and fast: 100 samples, fast timing → low (=good) base.
+	for i := 0; i < 100; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("A", 100, 500)))
+	}
+	// B newcomer with identical timing but only 3 samples → UCB should boost.
+	for i := 0; i < 3; i++ {
+		tr.RecordRequest(mkRequest("m", 100, mkInvolvement("B", 100, 500)))
+	}
+	scoreA, ok := tr.ScoreHost("m", "A", "lt_1k", false, "")
+	require.True(t, ok)
+	scoreB, ok := tr.ScoreHost("m", "B", "lt_1k", false, "")
+	require.True(t, ok)
+	require.Less(t, scoreB, scoreA, "under-sampled B should look better thanks to UCB bonus")
+}
+
+func TestEloDecay_StaleRatingPullsTowardDefault(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	key := hostScoreKey{model: "m", host: "stale", bucket: "lt_1k"}
+	tr.elo[key] = 1800.0
+	t0 := time.Now()
+	tr.eloUpdatedAt[key] = t0
+
+	// One half-life elapsed → gap of 300 should be ≈150 (within float ε).
+	got := tr.decayedEloLocked(key, t0.Add(HostScoreEloHalfLife))
+	require.InDelta(t, 1650.0, got, 0.01)
+
+	// Two half-lives → gap of 75.
+	got = tr.decayedEloLocked(key, t0.Add(2*HostScoreEloHalfLife))
+	require.InDelta(t, 1575.0, got, 0.01)
+
+	// Ten half-lives → effectively flat.
+	got = tr.decayedEloLocked(key, t0.Add(10*HostScoreEloHalfLife))
+	require.InDelta(t, HostScoreEloDefault, got, 1.0)
+}
+
+func TestEloDecay_DisabledByZeroHalfLife(t *testing.T) {
+	saved := HostScoreEloHalfLife
+	t.Cleanup(func() { HostScoreEloHalfLife = saved })
+	HostScoreEloHalfLife = 0
+
+	tr := NewHostScoreTracker(nil)
+	key := hostScoreKey{model: "m", host: "frozen", bucket: "lt_1k"}
+	tr.elo[key] = 1800.0
+	tr.eloUpdatedAt[key] = time.Now().Add(-100 * time.Hour)
+
+	require.Equal(t, 1800.0, tr.decayedEloLocked(key, time.Now()))
+}
+
+func TestEloDecay_NoUpdatedAtSkipsDecay(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	key := hostScoreKey{model: "m", host: "h", bucket: "lt_1k"}
+	tr.elo[key] = 1800.0
+	// No eloUpdatedAt entry → can't reason about age → return raw.
+	require.Equal(t, 1800.0, tr.decayedEloLocked(key, time.Now()))
+}
+
+func TestUpdateElo_DecayAppliedBeforeKUpdate(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	keyA := hostScoreKey{model: "m", host: "stale_fav", bucket: "lt_1k"}
+	keyB := hostScoreKey{model: "m", host: "fresh_und", bucket: "lt_1k"}
+	tr.elo[keyA] = 1800.0
+	tr.elo[keyB] = 1200.0
+	t0 := time.Now()
+	tr.eloUpdatedAt[keyA] = t0
+	tr.eloUpdatedAt[keyB] = t0
+
+	// Move 2 half-lives forward. Decayed A ≈ 1575, decayed B ≈ 1425. A wins.
+	tr.updateEloLocked(keyA, keyB, 1.0, 0.0, HostScoreEloK, t0.Add(2*HostScoreEloHalfLife))
+
+	// Expected outcome: fav is decayed before K is applied so it gains LESS
+	// than if the stale 1800 had been used directly. Sanity-check: A still
+	// gained, and is no longer at 1800.
+	require.Greater(t, tr.elo[keyA], 1575.0)
+	require.Less(t, tr.elo[keyA], 1800.0, "decay must keep A below its stale start")
+}
+
+func TestPersistStateAndRestore_PreservesPerKeyUpdatedAt(t *testing.T) {
+	src := NewHostScoreTracker(nil)
+	key := hostScoreKey{model: "m", host: "A", bucket: "5k_15k"}
+	src.elo[key] = 1700.0
+	specific := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	src.eloUpdatedAt[key] = specific
+	src.hosts[key] = &hostScoreRing{samples: []hostScoreSample{{TtftMs: 10, TotalMs: 100}}}
+
+	dst := NewHostScoreTracker(nil)
+	dst.Restore(src.PersistState())
+
+	require.Equal(t, specific.UTC(), dst.eloUpdatedAt[key].UTC())
+}
+
+func TestPairOutcome_AllCases(t *testing.T) {
+	resp := func(ttft, tot float64) HostInvolvement {
+		return HostInvolvement{ParticipantKey: "x", FirstTokenMs: ttft, TotalTimeMs: tot, Responsive: true, Finished: true}
+	}
+	unresp := HostInvolvement{ParticipantKey: "x", Responsive: false}
+
+	// Equal metrics → exact draw (Sa=Sb=0.5)
+	sa, sb := pairOutcome(resp(100, 1000), resp(100, 1000), true)
+	require.Equal(t, 0.5, sa, "ratio 1.0 → exact draw")
+	require.Equal(t, 0.5, sb)
+
+	// Streaming-ceiling case: ratio 1.001 → Sa ≈ 0.5 (essentially no Elo move)
+	sa, _ = pairOutcome(resp(100, 13701), resp(100, 13689), false)
+	require.InDelta(t, 0.5, sa, 0.01, "ceiling-noise ratio 1.0009 → Sa ≈ 0.5")
+
+	// Modest difference: TTFT 100 vs 150 (1.5x slower for B) → Sa ≈ 0.69
+	sa, _ = pairOutcome(resp(100, 1000), resp(150, 1000), true)
+	require.InDelta(t, 0.692, sa, 0.001, "1.5x faster → Sa ≈ 0.69 (modest)")
+
+	// Clear win: TTFT 100 vs 500 (5x slower for B) → Sa ≈ 0.96
+	sa, _ = pairOutcome(resp(100, 1000), resp(500, 900), true)
+	require.InDelta(t, 0.962, sa, 0.001, "5x faster → Sa ≈ 0.96 (clear)")
+
+	// Decisive: ratio 100x → Sa ≈ 0.9999
+	sa, _ = pairOutcome(resp(100, 1000), resp(10_000, 1000), true)
+	require.InDelta(t, 0.9999, sa, 0.0001, "100x faster → Sa ≈ 1.0 (decisive)")
+
+	// Total dimension picks B when B much faster
+	sa, sb = pairOutcome(resp(100, 3000), resp(500, 800), false)
+	require.Less(t, sa, 0.1, "Total mode: A 3.75x slower → Sa near 0")
+	require.Greater(t, sb, 0.9)
+
+	// Mixed: responsive beats unresponsive (forfeit, not BT)
+	sa, sb = pairOutcome(resp(100, 1000), unresp, true)
+	require.Equal(t, 1.0, sa)
+	require.Equal(t, 0.0, sb)
+	sa, sb = pairOutcome(unresp, resp(100, 1000), true)
+	require.Equal(t, 0.0, sa)
+	require.Equal(t, 1.0, sb)
+
+	// Both failed → both lose (Sa=Sb=0)
+	sa, sb = pairOutcome(unresp, unresp, true)
+	require.Equal(t, 0.0, sa)
+	require.Equal(t, 0.0, sb)
+}
+
+func TestRecordRequest_UnresponsiveLosesEloToResponsive(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	good := mkInvolvement("good", 100, 1000)
+	bad := HostInvolvement{ParticipantKey: "bad", Responsive: false}
+	tr.RecordRequest(RequestRecord{Model: "m", InputTokens: 100, Hosts: []HostInvolvement{good, bad}, Timestamp: time.Now()})
+
+	keyGood := hostScoreKey{model: "m", host: "good", bucket: "lt_1k"}
+	keyBad := hostScoreKey{model: "m", host: "bad", bucket: "lt_1k"}
+	require.Greater(t, tr.elo[keyGood], HostScoreEloDefault, "responsive host gains Elo")
+	require.Less(t, tr.elo[keyBad], HostScoreEloDefault, "unresponsive host loses Elo even when not added to sample ring")
+	_, hasBadRing := tr.hosts[keyBad]
+	require.False(t, hasBadRing, "unresponsive host MUST NOT pollute the sample ring")
+}
+
+func TestRecordRequest_BothUnresponsivePenalizesBoth(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	a := HostInvolvement{ParticipantKey: "A", Responsive: false}
+	b := HostInvolvement{ParticipantKey: "B", Responsive: false}
+	tr.RecordRequest(RequestRecord{Model: "m", InputTokens: 100, Hosts: []HostInvolvement{a, b}, Timestamp: time.Now()})
+
+	keyA := hostScoreKey{model: "m", host: "A", bucket: "lt_1k"}
+	keyB := hostScoreKey{model: "m", host: "B", bucket: "lt_1k"}
+	require.Less(t, tr.elo[keyA], HostScoreEloDefault, "A penalized for both-failed race")
+	require.Less(t, tr.elo[keyB], HostScoreEloDefault, "B penalized for both-failed race")
+	// Equal-rated both-lose → each loses K·0.5 = -8
+	require.InDelta(t, HostScoreEloDefault-HostScoreEloK*0.5, tr.elo[keyA], 0.01)
+	require.InDelta(t, HostScoreEloDefault-HostScoreEloK*0.5, tr.elo[keyB], 0.01)
+}
+
+func TestRecordRequest_DualMetricBothFastDominates(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	rec := RequestRecord{Model: "m", InputTokens: 100, Timestamp: time.Now(),
+		Hosts: []HostInvolvement{mkInvolvement("A", 100, 800), mkInvolvement("B", 500, 3000)}}
+	tr.RecordRequest(rec)
+
+	keyA := hostScoreKey{model: "m", host: "A", bucket: "lt_1k"}
+	keyB := hostScoreKey{model: "m", host: "B", bucket: "lt_1k"}
+	gainA := tr.elo[keyA] - HostScoreEloDefault
+	require.Greater(t, gainA, HostScoreEloK*0.4, "winning both ≈ K*0.5 (Elo self-correction)")
+	require.Less(t, gainA, HostScoreEloK, "even winning both can't exceed full K-budget")
+	require.InDelta(t, -gainA, tr.elo[keyB]-HostScoreEloDefault, 0.001, "zero-sum within pair")
+}
+
+func TestRecordRequest_DualMetricDisagreeNetNeutral(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	rec := RequestRecord{Model: "m", InputTokens: 100, Timestamp: time.Now(),
+		Hosts: []HostInvolvement{mkInvolvement("A", 100, 3000), mkInvolvement("B", 500, 800)}}
+	tr.RecordRequest(rec)
+
+	keyA := hostScoreKey{model: "m", host: "A", bucket: "lt_1k"}
+	keyB := hostScoreKey{model: "m", host: "B", bucket: "lt_1k"}
+	require.InDelta(t, HostScoreEloDefault, tr.elo[keyA], 1.0, "metrics disagree → net Elo change ≈ 0 (within ~1 pt)")
+	require.InDelta(t, HostScoreEloDefault, tr.elo[keyB], 1.0)
+}
+
+func TestRecordRequest_PartialResponsiveCensoredLoserStillRated(t *testing.T) {
+	tr := NewHostScoreTracker(nil)
+	winner := mkInvolvement("W", 200, 1500)
+	canceled := HostInvolvement{ParticipantKey: "L", FirstTokenMs: 800, TotalTimeMs: 1500, Responsive: true, Finished: false}
+	rec := RequestRecord{Model: "m", InputTokens: 100, Timestamp: time.Now(),
+		Hosts: []HostInvolvement{winner, canceled}}
+	tr.RecordRequest(rec)
+
+	keyW := hostScoreKey{model: "m", host: "W", bucket: "lt_1k"}
+	keyL := hostScoreKey{model: "m", host: "L", bucket: "lt_1k"}
+	require.Greater(t, tr.elo[keyW], HostScoreEloDefault, "winner faster TTFT + finished → gains on both updates")
+	require.Less(t, tr.elo[keyL], HostScoreEloDefault, "censored loser slower TTFT + unfinished → loses on both updates")
+	_, hasLRing := tr.hosts[keyL]
+	require.False(t, hasLRing, "canceled loser (Finished=false) still excluded from sample ring")
+}

--- a/devshard/cmd/devshardctl/hostperf.go
+++ b/devshard/cmd/devshardctl/hostperf.go
@@ -259,15 +259,18 @@ type PerfTracker struct {
 	firstTokenBuckets map[string]*firstTokenBucketRing
 	contextLimits     map[string]uint64 // participant_key -> observed max context length
 	pairwise          *PairwiseTracker
+	hostScores        *HostScoreTracker
 	store             *PerfStore
 }
 
 func NewPerfTracker(store *PerfStore) *PerfTracker {
+	pairwise := NewPairwiseTracker()
 	pt := &PerfTracker{
 		hosts:             make(map[string]*hostRing),
 		firstTokenBuckets: make(map[string]*firstTokenBucketRing),
 		contextLimits:     make(map[string]uint64),
-		pairwise:          NewPairwiseTracker(),
+		pairwise:          pairwise,
+		hostScores:        NewHostScoreTracker(pairwise),
 		store:             store,
 	}
 	if store != nil {
@@ -300,16 +303,35 @@ func (t *PerfTracker) loadFromStore() {
 		log.Printf("perf: failed to load requests: %v", err)
 		return
 	}
+
+	// host-score snapshot first: if it loaded, skip replay (Restore would wipe it).
+	scoreCount := 0
+	skipHostScoreReplay := false
+	if t.hostScores != nil {
+		states, err := t.store.LoadHostScores()
+		if err != nil {
+			log.Printf("perf: failed to load host scores: %v", err)
+		} else if len(states) > 0 {
+			t.hostScores.Restore(states)
+			scoreCount = len(states)
+			skipHostScoreReplay = true
+		}
+	}
+
 	for _, r := range records {
 		t.requests.add(r)
 		t.recordFirstTokenSampleLocked(r)
 		if t.pairwise != nil {
 			t.pairwise.RecordRequest(r)
 		}
+		if t.hostScores != nil && !skipHostScoreReplay {
+			t.hostScores.RecordRequest(r)
+		}
 	}
 
-	if len(samples) > 0 || len(records) > 0 {
-		log.Printf("perf: restored %d host samples, %d request records from disk", len(samples), len(records))
+	if len(samples) > 0 || len(records) > 0 || scoreCount > 0 {
+		log.Printf("perf: restored %d host samples, %d request records, %d host-score keys from disk",
+			len(samples), len(records), scoreCount)
 	}
 }
 
@@ -450,6 +472,9 @@ func (t *PerfTracker) RecordRequest(rec RequestRecord) {
 	t.mu.Unlock()
 	if t.pairwise != nil {
 		t.pairwise.RecordRequest(rec)
+	}
+	if t.hostScores != nil {
+		t.hostScores.RecordRequest(rec)
 	}
 
 	if t.store != nil {

--- a/devshard/cmd/devshardctl/hostperf.go
+++ b/devshard/cmd/devshardctl/hostperf.go
@@ -261,6 +261,15 @@ type PerfTracker struct {
 	pairwise          *PairwiseTracker
 	hostScores        *HostScoreTracker
 	store             *PerfStore
+	limiter           *ParticipantRequestLimiter // optional; receives Layer 3 quarantine samples
+}
+
+// SetParticipantLimiter wires the limiter so RecordRequest forwards per-sample
+// TTFTs to the Layer 3 host_score performance quarantine.
+func (t *PerfTracker) SetParticipantLimiter(l *ParticipantRequestLimiter) {
+	t.mu.Lock()
+	t.limiter = l
+	t.mu.Unlock()
 }
 
 func NewPerfTracker(store *PerfStore) *PerfTracker {
@@ -469,12 +478,19 @@ func (t *PerfTracker) RecordRequest(rec RequestRecord) {
 	t.mu.Lock()
 	t.requests.add(rec)
 	t.recordFirstTokenSampleLocked(rec)
+	limiter := t.limiter
 	t.mu.Unlock()
 	if t.pairwise != nil {
 		t.pairwise.RecordRequest(rec)
 	}
 	if t.hostScores != nil {
 		t.hostScores.RecordRequest(rec)
+	}
+	if limiter != nil {
+		bucket := requestShapeBucket(rec.InputTokens)
+		for _, h := range rec.Hosts {
+			limiter.RecordHostScoreSample(h.ParticipantKey, bucket, h.FirstTokenMs, h.Responsive)
+		}
 	}
 
 	if t.store != nil {

--- a/devshard/cmd/devshardctl/pairwise.go
+++ b/devshard/cmd/devshardctl/pairwise.go
@@ -8,13 +8,14 @@ import (
 )
 
 const (
-	RedundancySpeedPolicyLegacy   = "legacy"
-	RedundancySpeedPolicyHybrid   = "hybrid"
-	RedundancySpeedPolicyPairwise = "pairwise"
+	RedundancySpeedPolicyLegacy    = "legacy"
+	RedundancySpeedPolicyHybrid    = "hybrid"
+	RedundancySpeedPolicyPairwise  = "pairwise"
+	RedundancySpeedPolicyHostScore = "host_score"
 )
 
 var (
-	RedundancySpeedPolicy           = RedundancySpeedPolicyHybrid
+	RedundancySpeedPolicy           = RedundancySpeedPolicyHostScore
 	PairwiseBudgetPercentile        = 0.90
 	PairwiseMaxProactiveAttempts    = 3
 	PairwiseMinDirectComparisons    = 4
@@ -351,6 +352,30 @@ func (t *PairwiseTracker) directRatio(model, bucket, a, b string) (float64, floa
 	}
 	s := summarizePairwise(key, ring.ordered())
 	return s.AvgRatioAToB, s.Confidence, s.SampleCount, s.AvgRatioAToB > 0
+}
+
+// H2HWinRate returns A's fraction of total-time wins against B in the given
+// (model, bucket). rate is in [0,1] from A's perspective. ok=false when no
+// direct comparisons exist yet. Used by HostScoreTracker for layer-1
+// scoring when ≥MinSamples direct comparisons are available.
+func (t *PairwiseTracker) H2HWinRate(model, bucket, a, b string) (rate float64, n int, ok bool) {
+	if t == nil || a == "" || b == "" || a == b {
+		return 0, 0, false
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	ring := t.pairs[pairwiseKey{model: model, a: a, b: b, bucket: bucket}]
+	if ring == nil || len(ring.comparisons) == 0 {
+		return 0, 0, false
+	}
+	wins := 0
+	for _, c := range ring.comparisons {
+		if c.ATotalMs > 0 && c.BTotalMs > 0 && c.ATotalMs < c.BTotalMs {
+			wins++
+		}
+	}
+	n = len(ring.comparisons)
+	return float64(wins) / float64(n), n, true
 }
 
 func (t *PairwiseTracker) DirectSampleCount(model string, inputTokens uint64, a, b string) int {

--- a/devshard/cmd/devshardctl/participant_limiter.go
+++ b/devshard/cmd/devshardctl/participant_limiter.go
@@ -119,6 +119,7 @@ type ParticipantRequestLimiter struct {
 	participants                   map[string]*participantRequestState
 	metrics                        *DevshardMetrics
 	store                          ParticipantThrottleStore
+	hostScoreQuar                  *hostScoreQuarantine // Layer 3 performance quarantine
 }
 
 type participantRequestState struct {
@@ -153,7 +154,15 @@ func NewParticipantRequestLimiter(burst int, recoveryPerMinute int) *Participant
 		settings.RecoveryPerMinute = recoveryPerMinute
 	}
 	l := &ParticipantRequestLimiter{
-		participants: make(map[string]*participantRequestState),
+		participants:  make(map[string]*participantRequestState),
+		hostScoreQuar: newHostScoreQuarantine(),
+	}
+	l.hostScoreQuar.onEnter = func(host, bucket string, until time.Time) {
+		log.Printf("host_score_quarantine_entered participant_key=%s bucket=%s until=%s",
+			host, bucket, until.UTC().Format(time.RFC3339))
+	}
+	l.hostScoreQuar.onExpire = func(host, bucket string) {
+		log.Printf("host_score_quarantine_expired participant_key=%s bucket=%s", host, bucket)
 	}
 	l.applySettingsLocked(settings)
 	return l
@@ -561,19 +570,29 @@ func (l *ParticipantRequestLimiter) ObserveSuccessfulInference(participantKey st
 	l.persistThrottledStateLocked(participantKey, state, participantStatusTransport)
 }
 
+// RecordHostScoreSample forwards one TTFT into Layer 3 (host-scoring.md#performance-quarantine).
+func (l *ParticipantRequestLimiter) RecordHostScoreSample(host, bucket string, ttftMs float64, responsive bool) {
+	l.hostScoreQuar.recordSample(host, bucket, ttftMs, responsive)
+}
+
 // ClearQuarantine removes quarantine and resets the token bucket for the
-// given participant, making it immediately available for requests while
-// keeping it on the same post-quarantine probation path as natural expiry.
-// Returns true if the participant had state to clear.
+// given participant across every channel — HTTP, transport, empty stream,
+// stalled winner, and the Layer 3 host_score performance quarantine.
+// Returns true if any channel had state to clear.
 func (l *ParticipantRequestLimiter) ClearQuarantine(participantKey string) bool {
 	if participantKey == "" {
 		return false
 	}
+	clearedL3 := l.hostScoreQuar.clearAll(participantKey)
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	state, ok := l.participants[participantKey]
 	if !ok {
-		return false
+		if clearedL3 {
+			log.Printf("participant_quarantine_cleared participant_key=%s channel=host_score", participantKey)
+		}
+		return clearedL3
 	}
 	now := time.Now()
 	state.tokens = l.burst
@@ -815,6 +834,9 @@ func (l *ParticipantRequestLimiter) TrackedCount() int {
 func (l *ParticipantRequestLimiter) IsRecentlyQuarantined(participantKey string) bool {
 	if participantKey == "" {
 		return false
+	}
+	if l.hostScoreQuar.isQuarantined(participantKey) {
+		return true
 	}
 	now := time.Now()
 	l.mu.Lock()

--- a/devshard/cmd/devshardctl/participant_limiter_hostscore_test.go
+++ b/devshard/cmd/devshardctl/participant_limiter_hostscore_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func withHostScorePolicy(t *testing.T) {
+	t.Helper()
+	saved := RedundancySpeedPolicy
+	t.Cleanup(func() { RedundancySpeedPolicy = saved })
+	RedundancySpeedPolicy = RedundancySpeedPolicyHostScore
+}
+
+func newLimiterForTest() *ParticipantRequestLimiter {
+	return NewParticipantRequestLimiter(0, 0)
+}
+
+// seedQualifyingCohort fills the bucket with `count` other hosts, each
+// contributing `samples` TTFTs at ttftMs. The candidate host (passed
+// separately to recordSample) is compared against this cohort only —
+// see bucketThresholdLocked's excludeHost logic.
+func seedQualifyingCohort(l *ParticipantRequestLimiter, bucket string, count int, samples int, ttftMs float64) {
+	for i := 0; i < count; i++ {
+		host := "seed-" + string(rune('a'+i))
+		for j := 0; j < samples; j++ {
+			l.RecordHostScoreSample(host, bucket, ttftMs, true)
+		}
+	}
+}
+
+func TestHostScoreQuarantine_NoOpUnderNonHostScorePolicy(t *testing.T) {
+	saved := RedundancySpeedPolicy
+	t.Cleanup(func() { RedundancySpeedPolicy = saved })
+	RedundancySpeedPolicy = RedundancySpeedPolicyHybrid
+
+	l := newLimiterForTest()
+	for i := 0; i < 100; i++ {
+		l.RecordHostScoreSample("slow-host", "lt_1k", 100_000, true)
+	}
+	require.False(t, l.hostScoreQuar.isQuarantined("slow-host"))
+}
+
+func TestHostScoreQuarantine_NoThresholdUntilCohortQualifies(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	// Only 2 qualifying hosts (need ≥ HostScoreQuarantineMinQualifyingHosts=3).
+	seedQualifyingCohort(l, "lt_1k", 2, HostScoreQuarantineMinSamplesPerHost, 500)
+	for i := 0; i < hostScoreSlidingWindow; i++ {
+		l.RecordHostScoreSample("bad", "lt_1k", 100_000, true)
+	}
+	require.False(t, l.hostScoreQuar.isQuarantined("bad"),
+		"threshold not computed yet — no quarantine should fire")
+}
+
+func TestHostScoreQuarantine_QuarantinesAfterBadInWindow(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+
+	// Send HostScoreQuarantineBadInWindow (=3) slow samples — should trip quarantine.
+	for i := 0; i < HostScoreQuarantineBadInWindow; i++ {
+		l.RecordHostScoreSample("bad", "lt_1k", 60_000, true)
+	}
+	require.True(t, l.hostScoreQuar.isQuarantined("bad"))
+}
+
+func TestHostScoreQuarantine_BimodalCaughtBySlidingWindow(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+
+	// Pattern: slow, slow, fast, slow → 3 bad in last 4 → quarantine.
+	// (Old consecutive-3 strike model would NOT have caught this.)
+	l.RecordHostScoreSample("bimodal", "lt_1k", 60_000, true) // slow
+	l.RecordHostScoreSample("bimodal", "lt_1k", 60_000, true) // slow
+	l.RecordHostScoreSample("bimodal", "lt_1k", 500, true)    // fast — would reset consecutive
+	require.False(t, l.hostScoreQuar.isQuarantined("bimodal"))
+
+	l.RecordHostScoreSample("bimodal", "lt_1k", 60_000, true) // slow → 3 of last 4 bad
+	require.True(t, l.hostScoreQuar.isQuarantined("bimodal"))
+}
+
+func TestHostScoreQuarantine_PerBucketStateIsolated(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+	seedQualifyingCohort(l, "1k_5k", 5, HostScoreQuarantineMinSamplesPerHost, 800)
+
+	// Two strikes in lt_1k, two in 1k_5k — neither bucket alone has 3 bad-in-5.
+	for i := 0; i < 2; i++ {
+		l.RecordHostScoreSample("h", "lt_1k", 60_000, true)
+		l.RecordHostScoreSample("h", "1k_5k", 60_000, true)
+	}
+	require.False(t, l.hostScoreQuar.isQuarantined("h"))
+
+	// Third slow in lt_1k → that bucket alone trips → host marked overall.
+	l.RecordHostScoreSample("h", "lt_1k", 60_000, true)
+	require.True(t, l.hostScoreQuar.isQuarantined("h"))
+}
+
+func TestHostScoreQuarantine_UnresponsiveSamplesIgnored(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+
+	// Unresponsive samples should not contribute to outcome window.
+	for i := 0; i < 10; i++ {
+		l.RecordHostScoreSample("h", "lt_1k", 0, false)
+	}
+	require.False(t, l.hostScoreQuar.isQuarantined("h"))
+}
+
+func TestHostScoreQuarantine_ExpiryUnlocksHost(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	// Frozen clock so the test deterministically traverses expiry.
+	clock := time.Now()
+	l.hostScoreQuar.now = func() time.Time { return clock }
+
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+	for i := 0; i < HostScoreQuarantineBadInWindow; i++ {
+		l.RecordHostScoreSample("h", "lt_1k", 60_000, true)
+	}
+	require.True(t, l.hostScoreQuar.isQuarantined("h"))
+
+	// Advance past base duration → next call processes expiry path.
+	clock = clock.Add(HostScoreQuarantineBaseDuration + time.Second)
+	l.RecordHostScoreSample("h", "lt_1k", 500, true)
+	require.False(t, l.hostScoreQuar.isQuarantined("h"))
+}
+
+func TestHostScoreQuarantine_ExponentialBackoff(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	clock := time.Now()
+	l.hostScoreQuar.now = func() time.Time { return clock }
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+
+	trip := func() time.Time {
+		for i := 0; i < HostScoreQuarantineBadInWindow; i++ {
+			l.RecordHostScoreSample("h", "lt_1k", 60_000, true)
+		}
+		st := l.hostScoreQuar.states["lt_1k"]["h"]
+		return st.quarantineUntil
+	}
+
+	// First trip → base duration.
+	end1 := trip()
+	require.Equal(t, HostScoreQuarantineBaseDuration, end1.Sub(clock))
+
+	// Advance just past end of first quarantine, trip again → 2× base.
+	clock = end1.Add(time.Second)
+	end2 := trip()
+	require.Equal(t, 2*HostScoreQuarantineBaseDuration, end2.Sub(clock))
+
+	// Third trip soon after → 4× base, capped at Max.
+	clock = end2.Add(time.Second)
+	end3 := trip()
+	expected := 4 * HostScoreQuarantineBaseDuration
+	if expected > HostScoreQuarantineMaxDuration {
+		expected = HostScoreQuarantineMaxDuration
+	}
+	require.Equal(t, expected, end3.Sub(clock))
+}
+
+func TestHostScoreQuarantine_BackoffResetsAfterHistoryWindow(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	clock := time.Now()
+	l.hostScoreQuar.now = func() time.Time { return clock }
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+
+	for i := 0; i < HostScoreQuarantineBadInWindow; i++ {
+		l.RecordHostScoreSample("h", "lt_1k", 60_000, true)
+	}
+	end1 := l.hostScoreQuar.states["lt_1k"]["h"].quarantineUntil
+	require.Equal(t, HostScoreQuarantineBaseDuration, end1.Sub(clock))
+
+	// Advance past history window — old entry pruned, next trip starts fresh.
+	clock = end1.Add(HostScoreQuarantineHistoryWindow + time.Minute)
+	for i := 0; i < HostScoreQuarantineBadInWindow; i++ {
+		l.RecordHostScoreSample("h", "lt_1k", 60_000, true)
+	}
+	end2 := l.hostScoreQuar.states["lt_1k"]["h"].quarantineUntil
+	require.Equal(t, HostScoreQuarantineBaseDuration, end2.Sub(clock),
+		"old quarantine outside history window → backoff resets to base")
+}
+
+func TestHostScoreQuarantine_FoldedIntoIsRecentlyQuarantined(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+	for i := 0; i < HostScoreQuarantineBadInWindow; i++ {
+		l.RecordHostScoreSample("bad", "lt_1k", 60_000, true)
+	}
+	require.True(t, l.IsRecentlyQuarantined("bad"))
+	require.False(t, l.IsRecentlyQuarantined("seed-a"))
+}
+
+func TestHostScoreQuarantine_ClearQuarantineClearsLayer3(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+
+	seedQualifyingCohort(l, "lt_1k", 5, HostScoreQuarantineMinSamplesPerHost, 500)
+	for i := 0; i < HostScoreQuarantineBadInWindow; i++ {
+		l.RecordHostScoreSample("bad", "lt_1k", 60_000, true)
+	}
+	require.True(t, l.IsRecentlyQuarantined("bad"))
+
+	require.True(t, l.ClearQuarantine("bad"), "ClearQuarantine should report it cleared something")
+	require.False(t, l.IsRecentlyQuarantined("bad"))
+}
+
+func TestHostScoreQuarantine_WiredFromPerfTracker(t *testing.T) {
+	withHostScorePolicy(t)
+	l := newLimiterForTest()
+	perf := NewPerfTracker(nil)
+	perf.SetParticipantLimiter(l)
+
+	for i := 0; i < HostScoreQuarantineMinQualifyingHosts; i++ {
+		host := "seed-" + string(rune('a'+i))
+		for j := 0; j < HostScoreQuarantineMinSamplesPerHost; j++ {
+			perf.RecordRequest(mkRequest("m", 100, mkInvolvement(host, 500, 1000)))
+		}
+	}
+	for i := 0; i < HostScoreQuarantineBadInWindow; i++ {
+		perf.RecordRequest(mkRequest("m", 100, mkInvolvement("bad", 60_000, 120_000)))
+	}
+	require.True(t, l.IsRecentlyQuarantined("bad"))
+	require.False(t, l.IsRecentlyQuarantined("seed-a"))
+}

--- a/devshard/cmd/devshardctl/perfstore.go
+++ b/devshard/cmd/devshardctl/perfstore.go
@@ -80,6 +80,15 @@ func NewPerfStore(dbPath string) (*PerfStore, error) {
 		created_at      TEXT NOT NULL,
 		PRIMARY KEY (request_id, escrow_id, nonce)
 	);
+	CREATE TABLE IF NOT EXISTS host_score_state (
+		model          TEXT NOT NULL,
+		host           TEXT NOT NULL,
+		bucket         TEXT NOT NULL,
+		elo_rating     REAL NOT NULL DEFAULT 1500,
+		samples_json   TEXT NOT NULL DEFAULT '[]',
+		updated_at_utc TEXT NOT NULL DEFAULT '',
+		PRIMARY KEY (model, host, bucket)
+	);
 	`
 	if _, err := db.Exec(schema); err != nil {
 		db.Close()
@@ -371,6 +380,76 @@ func (s *PerfStore) BackfillLegacyEscrowSamples(sourceEscrow, sourcePath string,
 		return nil, err
 	}
 	return inserted, nil
+}
+
+// SaveHostScores upserts the full snapshot of HostScoreTracker state in one
+// transaction. Designed for periodic flush (every few minutes) + shutdown,
+// not per-request — caller responsibility to throttle.
+func (s *PerfStore) SaveHostScores(states []HostScoreState) error {
+	if s == nil || s.db == nil || len(states) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	stmt, err := tx.Prepare(`INSERT INTO host_score_state (model, host, bucket, elo_rating, samples_json, updated_at_utc)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(model, host, bucket) DO UPDATE SET
+			elo_rating=excluded.elo_rating,
+			samples_json=excluded.samples_json,
+			updated_at_utc=excluded.updated_at_utc`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	for _, st := range states {
+		samplesJSON, err := json.Marshal(st.Samples)
+		if err != nil {
+			return fmt.Errorf("marshal samples for %s/%s/%s: %w", st.Model, st.Host, st.Bucket, err)
+		}
+		if _, err := stmt.Exec(st.Model, st.Host, st.Bucket, st.Elo, string(samplesJSON), timeToStr(st.UpdatedAt)); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// LoadHostScores returns all persisted host-score rows for restore at startup.
+func (s *PerfStore) LoadHostScores() ([]HostScoreState, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`SELECT model, host, bucket, elo_rating, samples_json, updated_at_utc FROM host_score_state`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []HostScoreState
+	for rows.Next() {
+		var (
+			model, host, bucket, samplesJSON, updatedAt string
+			elo                                         float64
+		)
+		if err := rows.Scan(&model, &host, &bucket, &elo, &samplesJSON, &updatedAt); err != nil {
+			return nil, err
+		}
+		state := HostScoreState{
+			Model:     model,
+			Host:      host,
+			Bucket:    bucket,
+			Elo:       elo,
+			UpdatedAt: strToTime(updatedAt),
+		}
+		if samplesJSON != "" {
+			if err := json.Unmarshal([]byte(samplesJSON), &state.Samples); err != nil {
+				return nil, fmt.Errorf("unmarshal samples for %s/%s/%s: %w", model, host, bucket, err)
+			}
+		}
+		out = append(out, state)
+	}
+	return out, rows.Err()
 }
 
 func boolToInt(b bool) int {

--- a/devshard/cmd/devshardctl/perfstore_host_scores_test.go
+++ b/devshard/cmd/devshardctl/perfstore_host_scores_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerfStoreHostScoresRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewPerfStore(filepath.Join(dir, "perf.db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	states := []HostScoreState{
+		{
+			Model: "moonshotai/Kimi-K2.6", Host: "p-a", Bucket: "5k_15k", Elo: 1612.5,
+			Samples: []hostScoreSample{
+				{Timestamp: now, TtftMs: 123.4, TotalMs: 5678.9},
+				{Timestamp: now.Add(time.Second), TtftMs: 200, TotalMs: 6000},
+			},
+			UpdatedAt: now,
+		},
+		{
+			Model: "Qwen/Qwen3-235B", Host: "p-b", Bucket: "lt_1k", Elo: 1500.0,
+			Samples:   []hostScoreSample{{Timestamp: now, TtftMs: 50, TotalMs: 800}},
+			UpdatedAt: now,
+		},
+	}
+	require.NoError(t, store.SaveHostScores(states))
+
+	loaded, err := store.LoadHostScores()
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+
+	byKey := map[string]HostScoreState{}
+	for _, s := range loaded {
+		byKey[s.Model+"|"+s.Host+"|"+s.Bucket] = s
+	}
+	k := "moonshotai/Kimi-K2.6|p-a|5k_15k"
+	require.InDelta(t, 1612.5, byKey[k].Elo, 0.001)
+	require.Len(t, byKey[k].Samples, 2)
+	require.InDelta(t, 123.4, byKey[k].Samples[0].TtftMs, 0.001)
+	require.InDelta(t, 5678.9, byKey[k].Samples[0].TotalMs, 0.001)
+	require.True(t, byKey[k].Samples[0].Timestamp.Equal(now), "timestamps preserved across round-trip")
+}
+
+func TestPerfStoreHostScoresUpsert(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewPerfStore(filepath.Join(dir, "perf.db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	now := time.Now().UTC()
+	first := []HostScoreState{{
+		Model: "m", Host: "h", Bucket: "lt_1k", Elo: 1500, UpdatedAt: now,
+		Samples: []hostScoreSample{{TtftMs: 100, TotalMs: 1000}},
+	}}
+	require.NoError(t, store.SaveHostScores(first))
+
+	second := []HostScoreState{{
+		Model: "m", Host: "h", Bucket: "lt_1k", Elo: 1612, UpdatedAt: now.Add(time.Minute),
+		Samples: []hostScoreSample{{TtftMs: 200, TotalMs: 2000}, {TtftMs: 250, TotalMs: 2500}},
+	}}
+	require.NoError(t, store.SaveHostScores(second))
+
+	loaded, err := store.LoadHostScores()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1, "upsert on (model, host, bucket) primary key, not duplicate insert")
+	require.InDelta(t, 1612, loaded[0].Elo, 0.001)
+	require.Len(t, loaded[0].Samples, 2)
+}
+
+func TestPerfStoreHostScoresEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewPerfStore(filepath.Join(dir, "perf.db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	loaded, err := store.LoadHostScores()
+	require.NoError(t, err)
+	require.Empty(t, loaded, "fresh DB has no host-score rows")
+
+	require.NoError(t, store.SaveHostScores(nil))
+	require.NoError(t, store.SaveHostScores([]HostScoreState{}))
+}
+
+func TestPerfStoreHostScoresSchemaIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "perf.db")
+
+	store, err := NewPerfStore(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	store2, err := NewPerfStore(dbPath)
+	require.NoError(t, err, "re-opening must not error on existing schema")
+	defer store2.Close()
+}

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -586,7 +586,7 @@ func (p *Proxy) handleDebugPairwise(w http.ResponseWriter, r *http.Request) {
 		"winner_hold_min_samples":         PairwiseWinnerHoldMinSamples,
 		"request_shape_buckets":           []string{"lt_1k", "1k_5k", "5k_15k", "15k_30k", "30k_100k", "gte_100k"},
 		"comparisons":                     p.perf.PairwiseSummaries(),
-		"legacy_secondary_faster_enabled": RedundancySpeedPolicy != RedundancySpeedPolicyPairwise,
+		"legacy_secondary_faster_enabled": RedundancySpeedPolicy == RedundancySpeedPolicyLegacy || RedundancySpeedPolicy == RedundancySpeedPolicyHybrid,
 	})
 }
 

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -913,6 +913,31 @@ func TestLongNonStreamEmptyResponseRecordsTimingWithoutQuarantine(t *testing.T) 
 	require.GreaterOrEqual(t, involvement.TotalTimeMs, float64(longResponseFailureExemption.Milliseconds()))
 }
 
+func TestBuildInvolvement_TotalTimeFromLastChunk(t *testing.T) {
+	env := setupTestProxyWithClients(t, []user.HostClient{streamContentThenStallClient{}})
+	params := defaultParams()
+	now := time.Now()
+
+	infA := &inflight{hostIdx: 0, nonce: 1, sendTime: now.Add(-5 * time.Second)}
+	infA.lastChunkAt.Store(now.Add(-4 * time.Second).UnixNano())
+	infB := &inflight{hostIdx: 1, nonce: 2, sendTime: now.Add(-5 * time.Second)}
+	infB.lastChunkAt.Store(now.Add(-1 * time.Second).UnixNano())
+
+	a := env.proxy.redundancy.buildInvolvement(infA, 0, params)
+	b := env.proxy.redundancy.buildInvolvement(infB, 0, params)
+	require.InDelta(t, 1000.0, a.TotalTimeMs, 50, "A: lastChunk at -4s, send at -5s → ~1000ms")
+	require.InDelta(t, 4000.0, b.TotalTimeMs, 50, "B: lastChunk at -1s, send at -5s → ~4000ms")
+	require.NotEqual(t, a.TotalTimeMs, b.TotalTimeMs, "same race, different per-host completion → different Total")
+}
+
+func TestBuildInvolvement_TotalTimeFallbackWhenNoChunks(t *testing.T) {
+	env := setupTestProxyWithClients(t, []user.HostClient{streamContentThenStallClient{}})
+	params := defaultParams()
+	inf := &inflight{hostIdx: 0, nonce: 1, sendTime: time.Now().Add(-2 * time.Second)}
+	hi := env.proxy.redundancy.buildInvolvement(inf, 0, params)
+	require.GreaterOrEqual(t, hi.TotalTimeMs, 1900.0, "no chunks → fallback to time.Since(sendTime)")
+}
+
 func TestFastNonStreamEmptyResponseRecordsParticipantFailure(t *testing.T) {
 	env := setupTestProxyWithClients(t, []user.HostClient{streamContentThenStallClient{}})
 	limiter := NewParticipantRequestLimiter(10, 10)

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -395,7 +395,7 @@ func DefaultRedundancySettings() RedundancySettings {
 		SecondaryWaitAfterWinnerMS:   300000,
 		ParallelAdvantageThreshold:   0.5,
 		UnresponsiveThreshold:        1.0,
-		SpeedPolicy:                  RedundancySpeedPolicyHybrid,
+		SpeedPolicy:                  RedundancySpeedPolicyHostScore,
 		PairwiseBudgetPercentile:     0.90,
 		PairwiseMaxProactiveAttempts: 3,
 		PairwiseMinDirectComparisons: 4,
@@ -476,7 +476,9 @@ func ApplyRedundancySettings(settings RedundancySettings) {
 
 func normalizeRedundancySpeedPolicy(policy string) string {
 	switch strings.ToLower(strings.TrimSpace(policy)) {
-	case "", RedundancySpeedPolicyHybrid:
+	case "", RedundancySpeedPolicyHostScore:
+		return RedundancySpeedPolicyHostScore
+	case RedundancySpeedPolicyHybrid:
 		return RedundancySpeedPolicyHybrid
 	case RedundancySpeedPolicyLegacy:
 		return RedundancySpeedPolicyLegacy
@@ -587,16 +589,89 @@ func (e *Redundancy) Decide(primaryHostIdx int, inputTokens uint64) Decision {
 		return Decision{RunSecondary: true, Delay: 0, Reason: "primary_unresponsive", ImmediateAttempts: 1}
 	}
 
-	if RedundancySpeedPolicy != RedundancySpeedPolicyLegacy {
+	// Per-policy branches — no cascade. See docs/host-scoring.md.
+	switch RedundancySpeedPolicy {
+	case RedundancySpeedPolicyHostScore:
+		return e.decideHostScoreSpeedup(primaryHostIdx, inputTokens)
+	case RedundancySpeedPolicyPairwise:
 		if decision, ok := e.decidePairwiseSpeedup(primaryHostIdx, inputTokens); ok {
 			return decision
 		}
-		if RedundancySpeedPolicy == RedundancySpeedPolicyPairwise {
-			return Decision{RunSecondary: true, Delay: receiptTimeoutForInput(inputTokens), Reason: "pairwise_insufficient_data"}
+		// pairwise opts into always-on secondary; on miss we still fire, just delayed.
+		return Decision{RunSecondary: true, Delay: receiptTimeoutForInput(inputTokens), Reason: "pairwise_insufficient_data"}
+	case RedundancySpeedPolicyHybrid:
+		if decision, ok := e.decidePairwiseSpeedup(primaryHostIdx, inputTokens); ok {
+			return decision
+		}
+		return e.decideLegacySecondaryFaster(primaryParticipant, secondaryParticipant, inputTokens)
+	}
+	return e.decideLegacySecondaryFaster(primaryParticipant, secondaryParticipant, inputTokens)
+}
+
+// decideHostScoreSpeedup is the host_score policy's decision maker. Reason
+// codes: host_scores, host_scores_exploration, host_scores_no_candidate,
+// host_scores_no_data. Details in docs/host-scoring.md.
+func (e *Redundancy) decideHostScoreSpeedup(primaryHostIdx int, inputTokens uint64) Decision {
+	if e == nil || e.perf == nil || e.perf.hostScores == nil || e.perf.pairwise == nil || e.groupSize <= 1 {
+		return Decision{Reason: "host_scores_no_data"}
+	}
+	primary := e.participantKeyForHost(primaryHostIdx)
+	if !e.pairwiseParticipantAvailable(primary) {
+		return Decision{Reason: "host_scores_no_data"}
+	}
+	bucket := requestShapeBucket(inputTokens)
+	candidates := e.pairwiseCandidateParticipants(primaryHostIdx, primary)
+	if len(candidates) == 0 {
+		return Decision{Reason: "host_scores_no_data"}
+	}
+
+	primScore, primOK := e.perf.hostScores.ScoreHost(e.model, primary, bucket, false, "")
+	accepted := 0
+	hadData := false // gates no_candidate (saw real signal) vs no_data (didn't)
+	for _, candidate := range candidates {
+		if accepted >= PairwiseMaxProactiveAttempts {
+			break
+		}
+		if rate, n, ok := e.perf.pairwise.H2HWinRate(e.model, bucket, candidate, primary); ok && n >= HostScoreMinSamples {
+			hadData = true
+			if rate >= 0.5+HostScoreH2HMargin {
+				accepted++
+			}
+			continue
+		}
+		if !primOK {
+			continue
+		}
+		candScore, candOK := e.perf.hostScores.ScoreHost(e.model, candidate, bucket, false, "")
+		if !candOK {
+			continue
+		}
+		hadData = true
+		if candScore < primScore*(1-HostScoreSpeedupMargin) {
+			accepted++
 		}
 	}
 
-	return e.decideLegacySecondaryFaster(primaryParticipant, secondaryParticipant, inputTokens)
+	if accepted > 0 {
+		return Decision{
+			RunSecondary:      true,
+			Delay:             0,
+			Reason:            "host_scores",
+			ImmediateAttempts: accepted,
+		}
+	}
+	if HostScoreExplorationEpsilon > 0 && hostScoreRandom() < HostScoreExplorationEpsilon {
+		return Decision{
+			RunSecondary:      true,
+			Delay:             0,
+			Reason:            "host_scores_exploration",
+			ImmediateAttempts: 1,
+		}
+	}
+	if hadData {
+		return Decision{Reason: "host_scores_no_candidate"}
+	}
+	return Decision{Reason: "host_scores_no_data"}
 }
 
 func (e *Redundancy) decidePairwiseSpeedup(primaryHostIdx int, inputTokens uint64) (Decision, bool) {
@@ -841,6 +916,44 @@ type inflight struct {
 	// after the winner has settled, so their transport goroutines return
 	// promptly and HandleTimeout can run against the abandoned nonce.
 	cancel context.CancelFunc
+}
+
+// receiptArrived reports whether the receiptCh close has propagated to this
+// goroutine. After it returns true, inf.receiptTime is safe to read — the
+// channel close inside receiptOnce.Do is the happens-before edge that
+// publishes the write done immediately before the close.
+func (inf *inflight) receiptArrived() bool {
+	select {
+	case <-inf.receiptCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// receiptTimeOrZero returns the recorded receipt time when it has arrived,
+// or the zero time otherwise. Use at sites that need the time value rather
+// than the boolean presence check.
+func (inf *inflight) receiptTimeOrZero() time.Time {
+	if inf.receiptArrived() {
+		return inf.receiptTime
+	}
+	return time.Time{}
+}
+
+// firstTokenArrived is the firstTokenCh equivalent of receiptArrived. Same
+// happens-before guarantee: the close inside tokenOnce.Do publishes the
+// preceding firstToken write to any goroutine that observes the close.
+func (inf *inflight) firstTokenArrived() bool {
+	if inf.firstTokenCh == nil {
+		return !inf.firstToken.IsZero()
+	}
+	select {
+	case <-inf.firstTokenCh:
+		return true
+	default:
+		return false
+	}
 }
 
 // raceGroup arbitrates which inflight's stream is forwarded to the client.
@@ -1587,7 +1700,7 @@ func winnerInterChunkDeadline(inf *inflight) (time.Time, bool) {
 }
 
 func waitForFirstTokenUntil(ctx context.Context, inf *inflight, deadline time.Time) bool {
-	if !inf.firstToken.IsZero() {
+	if inf.firstTokenArrived() {
 		return true
 	}
 	d := time.Until(deadline)
@@ -1988,7 +2101,7 @@ func (e *Redundancy) escalationForInflight(inf *inflight, params user.InferenceP
 	if inf.sendTime.IsZero() {
 		return escalationTrigger{}, false
 	}
-	if inf.receiptTime.IsZero() {
+	if !inf.receiptArrived() {
 		return escalationTrigger{
 			inf:      inf,
 			deadline: inf.sendTime.Add(receiptTimeoutForInput(params.InputLength)),
@@ -1999,7 +2112,7 @@ func (e *Redundancy) escalationForInflight(inf *inflight, params user.InferenceP
 	if !params.Stream {
 		return escalationTrigger{}, false
 	}
-	if !inf.firstToken.IsZero() {
+	if inf.firstTokenArrived() {
 		return escalationTrigger{}, false
 	}
 	return escalationTrigger{
@@ -2043,11 +2156,11 @@ func (e *Redundancy) monitorInflight(ctx context.Context, inf *inflight, race *r
 				"elapsed_ms", time.Since(inf.sendTime).Milliseconds(),
 				"output_chunks", inf.outputChunks.Load(),
 			}
-			if !inf.receiptTime.IsZero() {
+			if inf.receiptArrived() {
 				stage = "waiting_for_first_token"
 				fields = append(fields, "since_receipt_ms", time.Since(inf.receiptTime).Milliseconds())
 			}
-			if !inf.firstToken.IsZero() {
+			if inf.firstTokenArrived() {
 				stage = "streaming_inflight"
 				fields = append(fields, "since_first_token_ms", time.Since(inf.firstToken).Milliseconds())
 				if lastChunkAt := inf.lastChunkAt.Load(); lastChunkAt > 0 {
@@ -2957,7 +3070,16 @@ func (e *Redundancy) buildInvolvement(inf *inflight, winnerNonce uint64, params 
 		if !inf.firstToken.IsZero() {
 			hi.FirstTokenMs = float64(inf.firstToken.Sub(inf.sendTime).Milliseconds())
 		}
-		hi.TotalTimeMs = float64(time.Since(inf.sendTime).Milliseconds())
+		// Per-host completion time when chunks were streamed; fallback to
+		// request lifecycle for empty/timeout responses where lastChunkAt
+		// is unset. See docs/host-scoring.md#per-host-total-time.
+		if lastChunk := inf.lastChunkAt.Load(); lastChunk > 0 {
+			if lastChunkT := time.Unix(0, lastChunk); lastChunkT.After(inf.sendTime) {
+				hi.TotalTimeMs = float64(lastChunkT.Sub(inf.sendTime).Milliseconds())
+			}
+		} else {
+			hi.TotalTimeMs = float64(time.Since(inf.sendTime).Milliseconds())
+		}
 	}
 	return hi
 }

--- a/devshard/docs/host-scoring-schemes.md
+++ b/devshard/docs/host-scoring-schemes.md
@@ -1,0 +1,384 @@
+# host_score — visual scheme
+
+All scenarios covered as sequence diagrams. Values drawn from the merged replay loop; defaults from `host_scores.go` and `host_score_quarantine.go`.
+
+---
+
+## 0. System overview
+
+Static map of where each layer sits in the request lifecycle. Every later scenario is a specific walk through this graph.
+
+```mermaid
+flowchart TD
+    A([inference arrives]) --> B[bucket = lt_1k / 1k_5k / ... / gte_100k]
+    B --> C[Picker — next free nonce binds to a host]
+    C --> D{IsRecentlyQuarantined&#40;host&#41;<br/>any of 5 channels?}
+    D -- yes --> Z[skip nonce, try next]
+    D -- no --> E[Primary assigned]
+    E --> F[decideHostScoreSpeedup]
+    F --> G{branches}
+    G -- unresponsive primary --> P1[primary_unresponsive<br/>force secondary]
+    G -- H2H rate ≥ 60% --> P2[host_scores<br/>accept H2H winner]
+    G -- Layer 2 score beats margin --> P3[host_scores<br/>accept candidate]
+    G -- no data --> P4[no_data<br/>primary alone]
+    G -- data, no candidate --> P5[no_candidate<br/>maybe ε-greedy 2%]
+    P1 --> R[race]
+    P2 --> R
+    P3 --> R
+    P5 --> R
+    P4 --> R
+    R --> S[record per-host sample]
+    S --> L3[Layer 3: bucket pool + 3-of-5 window]
+    L3 --> L3Q{3-of-5 bad?}
+    L3Q -- yes --> L3F[quarantine 30 / 60 / 120 min]
+    L3Q -- no --> N([end])
+    L3F --> N
+```
+
+---
+
+## 1. Scenario — fast primary, no secondary needed
+
+The picker binds the request to a top-Elo host. host_score sees that no candidate beats the primary by the speedup margin, so no secondary is launched and the primary runs alone. Speculative cost is zero.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Picker
+    participant host_score
+    participant Layer3
+    participant fast_primary as 9stckwnz (Elo=1682)
+
+    User->>Picker: request (256 tok, bucket=lt_1k)
+    Picker->>Layer3: IsRecentlyQuarantined(9stckwnz)?
+    Layer3-->>Picker: false
+    Picker->>host_score: Decide(primary=9stckwnz)
+
+    Note over host_score: primary.score = -1285ms (base 535 minus Elo credit 1820). No candidate beats primary × 0.9.
+    host_score-->>Picker: no_candidate, RunSecondary=false
+
+    Picker->>fast_primary: send
+    fast_primary-->>User: TTFT 535ms, Total 597ms (winner)
+    fast_primary->>Layer3: record_sample(535ms)
+    Note over Layer3: window slides: [good]. No strike.
+```
+
+---
+
+## 2. Scenario — slow primary, secondary wins
+
+A slow host got the primary nonce. host_score finds a much faster candidate and spawns it. The two race in parallel, the secondary returns first, the slow primary is cancelled. User sees roughly 4× speedup at the cost of one extra nonce.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Picker
+    participant host_score
+    participant slow_primary as fglnkns2 (Elo=1420)
+    participant fast_secondary as 9stckwnz (Elo=1665)
+
+    User->>Picker: request (6144 tok, bucket=5k_15k)
+    Picker->>host_score: Decide(primary=fglnkns2)
+
+    Note over host_score: primary.score = 2860ms. 9stckwnz.score = -744ms. -744 < 2860 × 0.9 = 2574 — accept candidate.
+    host_score-->>Picker: host_scores, ImmediateAttempts=1
+
+    par primary path
+        Picker->>slow_primary: send
+        slow_primary-->>Picker: TTFT 1.5s, still streaming
+    and secondary path
+        Picker->>fast_secondary: send (excludes fglnkns2)
+        fast_secondary-->>User: TTFT 839ms (winner)
+    end
+
+    Note over Picker,slow_primary: slow_primary cancelled as the loser.
+```
+
+---
+
+## 3. Scenario — Layer 1 H2H trigger overrides Layer 2
+
+When the pairwise tracker holds at least three direct head-to-head samples between primary and a candidate, Layer 1 win-rate is consulted first and overrides the Layer 2 score path entirely. A win rate at or above 60% is accepted without looking at base, Elo, or UCB terms. This makes direct empirical evidence outrank inferred scores.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Picker
+    participant host_score
+    participant PairwiseTracker
+    participant primary_host
+    participant candidate_host
+
+    User->>Picker: request
+    Picker->>host_score: Decide(primary=primary_host)
+
+    Note over host_score: Layer 1 first
+    host_score->>PairwiseTracker: H2HWinRate(candidate_host, primary_host, bucket)
+    PairwiseTracker-->>host_score: rate=0.72, n=8 direct samples
+    Note over host_score: 0.72 ≥ 0.5 + 0.10 — accept. Layer 2 (base/Elo/UCB) is skipped because Layer 1 data is authoritative.
+
+    host_score-->>Picker: host_scores, ImmediateAttempts=1
+    par
+        Picker->>primary_host: send
+    and
+        Picker->>candidate_host: send
+    end
+    candidate_host-->>User: wins (consistent with H2H history)
+```
+
+---
+
+## 4. Scenario — UCB exploration (under-sampled host gets a structured bonus)
+
+UCB ("upper confidence bound") is Layer 2's built-in answer to a specific failure mode: a host with few samples can look slightly worse than the primary on raw base/Elo numbers, but we are not confident in that comparison yet. Without correction we'd never race it and never learn whether it's actually faster. UCB adds a bonus to under-sampled hosts that decays as samples accumulate: `UCB = c · √(ln(N_bucket) / n_host)` with `c = HostScoreUCBCoefficient = 300 ms`. The bonus is *subtracted* from the candidate's score (lower score = more attractive), so a host with `n=5` samples gets ≈ 350 ms of help while a host with `n=500` gets only ≈ 35 ms. Unlike ε-greedy (an unconditional 2% random roll), UCB is *targeted* — it directs exploration at exactly the hosts we know least about.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Picker
+    participant host_score
+    participant stable_host
+    participant new_host
+
+    User->>Picker: request, bucket=1k_5k
+    Picker->>host_score: Decide primary=stable_host
+    Note over host_score: stable: n=200, base p50=1200ms, Elo=1500
+    Note over host_score: stable UCB = 300·√(ln(1000)/200) ≈ 35ms, score ≈ 1165
+    Note over host_score: candidate new_host: n=5, base p50=1280ms (slightly slower than primary), Elo=1500
+    Note over host_score: new_host UCB = 300·√(ln(1000)/5) ≈ 353ms, score ≈ 927
+    Note over host_score: Margin check: 927 ≤ 1165 · (1 − 0.10) = 1048, accept candidate.
+    Note over host_score: Without UCB, new_host would lose on raw base (1280 vs 1200). UCB makes the race happen.
+
+    host_score-->>Picker: host_scores, ImmediateAttempts=1
+    par
+        Picker->>stable_host: send
+    and
+        Picker->>new_host: send
+    end
+    new_host-->>User: TTFT 900ms (wins the race)
+        Note over host_score: Outcome feeds Elo (new_host gains rating) and sample count (n=5 to 6).
+        Note over host_score: UCB shrinks for the next decision. By n=50 the bonus is ≈ 111ms, by n=500 it is ≈ 35ms.
+        Note over host_score: A genuinely mediocre host stops getting raced once UCB decays and Elo dominates.
+```
+
+How UCB and ε-greedy divide the work: UCB is *deterministic structured exploration* aimed at uncertain hosts during Layer 2 scoring. ε-greedy (next scenario) is the *unconditional safety net* that fires after Layer 2 has nothing — covering hosts UCB cannot reach (e.g., zero samples means UCB formula is skipped) or scenarios where every candidate's Elo has drifted high enough that UCB alone can't bring them within the 10% margin.
+
+---
+
+## 5. Scenario — ε-greedy exploration (cold-start helper)
+
+All Layer 1 and Layer 2 candidates fail the margin check (or have no data), but the ε-greedy floor still rolls true with probability 2%. A random non-tried host is then given a forced shot. This is how cold or recovering hosts get a chance to climb back into rotation. The exploration cost is bounded by ε itself: 2% of the would-be-no-secondary decisions.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Picker
+    participant host_score
+    participant primary_host
+    participant exploration_host
+
+    User->>Picker: request
+    Picker->>host_score: Decide(primary=primary_host)
+
+    Note over host_score: Layer 1: no direct H2H data. Layer 2: candidates have data but none beats primary × 0.9.
+    Note over host_score: hadData=true, roll random() = 0.012 < 0.02 — fire exploration.
+
+    host_score-->>Picker: host_scores_exploration, ImmediateAttempts=1
+    Picker->>exploration_host: send (any non-excluded host)
+    par
+        Picker->>primary_host: send
+    and
+        Picker->>exploration_host: send
+    end
+
+    Note over Picker: Outcome of the race feeds Elo so the exploration_host's rating drifts over time toward its true level.
+```
+
+---
+
+## 6. Scenario — primary unresponsive, immediate parallel
+
+`PerfTracker.IsUnresponsiveParticipant(primary)` is the only check that runs before the Layer 1 and Layer 2 logic. If the primary has a recent history of failing to send any chunks, a backup is launched immediately and unconditionally. This bypass exists because the host is structurally broken right now — no point computing scores.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Picker
+    participant host_score
+    participant PerfTracker
+    participant primary_host as primary_host (recently silent)
+    participant backup_host
+
+    User->>Picker: request
+    Picker->>host_score: Decide(primary=primary_host)
+
+    host_score->>PerfTracker: IsUnresponsiveParticipant(primary_host)?
+    PerfTracker-->>host_score: true
+    Note over host_score: Short-circuit: skip Layer 1 and Layer 2. RunSecondary=true, ImmediateAttempts=1.
+
+    host_score-->>Picker: primary_unresponsive
+    par
+        Picker->>primary_host: send (may stall)
+    and
+        Picker->>backup_host: send
+    end
+    backup_host-->>User: response (likely first)
+```
+
+---
+
+## 7. Scenario — Layer 3 quarantine fires (consecutive slow)
+
+Three slow TTFTs from the same host land in its own (host, bucket) sliding window. The bucket threshold is the p90 of *other* hosts' samples (excludes self — no self-pollution). The third bad outcome trips the gate; quarantine duration is 30 minutes for the first event in the 4-hour history window. Subsequent picker checks via `IsRecentlyQuarantined` return true and the host is removed from primary and secondary rotation.
+
+```mermaid
+sequenceDiagram
+    participant kwerryrs as kwerryrs (lt_1k)
+    participant Layer3
+
+    Note over Layer3: bucket has 5 qualifying hosts (excluding kwerryrs). threshold = p90(other-pool) = 1.6s.
+
+    kwerryrs->>Layer3: TTFT 113s (responsive)
+    Note over Layer3: 113s > 1.6s. window=[bad]. count=1.
+
+    kwerryrs->>Layer3: TTFT 264s
+    Note over Layer3: window=[bad, bad]. count=2.
+
+    kwerryrs->>Layer3: TTFT 282s
+    Note over Layer3: window=[bad, bad, bad]. ≥3 of last 5 — fire. history=[]. duration = 30 × 2^0 = 30 min.
+    Layer3-->>kwerryrs: quarantineUntil = now + 30 min
+
+    Note over Layer3: From here, IsRecentlyQuarantined(kwerryrs) returns true for any picker check.
+```
+
+---
+
+## 8. Scenario — bimodal host caught by sliding window
+
+A bimodal host alternates fast and slow samples. A consecutive-strike counter would never reach 3 — every fast sample resets it. The sliding window doesn't reset, it just slides. Three bad outcomes anywhere in the last 5 are enough. This is the design rationale for choosing a window over a streak counter.
+
+```mermaid
+sequenceDiagram
+    participant bimodal_host
+    participant Layer3
+
+    Note over Layer3: threshold = 1.6s (bucket cohort p90).
+
+    bimodal_host->>Layer3: TTFT 60s (bad)
+    Note over Layer3: window=[bad]
+
+    bimodal_host->>Layer3: TTFT 800ms (good)
+    Note over Layer3: window=[bad, good]. A consecutive-strike counter would reset here, but the sliding window keeps the bad entry.
+
+    bimodal_host->>Layer3: TTFT 45s (bad)
+    Note over Layer3: window=[bad, good, bad]. count=2 (not 1).
+
+    bimodal_host->>Layer3: TTFT 700ms (good)
+    Note over Layer3: window=[bad, good, bad, good].
+
+    bimodal_host->>Layer3: TTFT 90s (bad)
+    Note over Layer3: window=[bad, good, bad, good, bad]. count=3 ≥ 3 of last 5 — fire.
+    Layer3-->>bimodal_host: quarantineUntil = +30 min
+
+    Note over Layer3: A consecutive-strike model would have missed this host despite a 60% bad rate.
+```
+
+---
+
+## 9. Scenario — quarantine expiry plus relapse (exponential backoff)
+
+A repeat-offender host's quarantine duration grows as long as recent history (within a 4-hour sliding window) contains prior entries. The duration doubles on each relapse until it hits a 120-minute cap. After 4 hours without an entry, history prunes and the backoff resets to 30 minutes.
+
+```mermaid
+sequenceDiagram
+    participant kwerryrs
+    participant Layer3
+
+    Note over Layer3: t = 0. Three bad in window — fire. history=[]. duration = 30 × 2^0 = 30 min. history becomes [t=0].
+    Layer3-->>kwerryrs: quarantineUntil = +30 min
+
+    Note over Layer3: t = 30 min. Expiry path: window cleared, history kept.
+
+    kwerryrs->>Layer3: three more slow samples
+    Note over Layer3: t = 31 min. history.prune(cutoff = t-4h) = [t=0]. duration = 30 × 2^1 = 60 min. history becomes [t=0, t=31m].
+    Layer3-->>kwerryrs: quarantineUntil = +60 min
+
+    Note over Layer3: t = 91 min. Expiry.
+
+    kwerryrs->>Layer3: three more slow samples
+    Note over Layer3: t = 92 min. history.prune = [t=0, t=31m]. duration = 30 × 2^2 = 120 min. Cap applied (max 120). history becomes [t=0, t=31m, t=92m].
+    Layer3-->>kwerryrs: quarantineUntil = +120 min
+```
+
+---
+
+## 10. Scenario — host recovery (regime change)
+
+A host that was slow long enough to sink its Elo and trigger Layer 3 quarantines actually fixes itself (network repaired, new hardware, catch-up cycle). Layer 3 quarantine expiry returns it to rotation; Elo's half-life decay pulls its rating back toward the 1500 default; ε-greedy occasionally spawns it as a secondary; good outcomes update its rating upward. There is no persistent blocklist — the algorithm self-heals.
+
+```mermaid
+sequenceDiagram
+    participant recovered_host
+    participant Picker
+    participant Layer3
+    participant host_score as host_score (Elo)
+
+    Note over recovered_host,host_score: Initial state: Elo=1200 (sunk from prior slow streak). Most recent quarantine expired.
+
+    Picker->>host_score: Decide(primary=other_host, candidates include recovered_host)
+    Note over host_score: recovered_host did not beat the margin. But ε-greedy random() < 0.02 — exploration fires.
+    host_score-->>Picker: host_scores_exploration, ImmediateAttempts=1
+
+    Picker->>recovered_host: send
+    recovered_host-->>Picker: TTFT 400ms (winner of race)
+
+    Note over host_score: Elo update on the pair: recovered_host won, +K × (1 - E). Elo: 1200 → 1215.
+
+    Note over host_score: In parallel, half-life decay (6h for lt_1k, 12h global) pulls the rating toward 1500 over time.
+
+    Note over recovered_host: Over hours, repeated wins plus decay restore recovered_host to mid-pack, then to top of the cohort.
+```
+
+---
+
+## 11. Exponential backoff — formula, table, and lifecycle
+
+`bucketQuarState.nextQuarantineDuration` in `host_score_quarantine.go` computes the duration on every quarantine entry:
+
+```text
+1. prune history: keep only entries within last 4h sliding window
+2. duration = HostScoreQuarantineBaseDuration << len(history)   // bit-shift = 30min × 2^count
+3. if duration > HostScoreQuarantineMaxDuration: duration = HostScoreQuarantineMaxDuration
+4. append now to history
+```
+
+Tunables (constants in `host_score_quarantine.go`):
+
+| Constant | Value | Role |
+|---|---:|---|
+| `hostScoreQuarantineBaseDuration` | 30 min | first quarantine in a fresh history |
+| `hostScoreQuarantineMaxDuration` | 120 min | hard cap on growth |
+| `hostScoreQuarantineHistoryWindow` | 4 h | sliding window for relapse tracking |
+
+Resulting schedule:
+
+| Recent quarantines for (host, bucket) within 4h | Duration | How long until reset |
+|---:|---:|---:|
+| 0 | **30 min** | — |
+| 1 | **60 min** | 4h from previous |
+| 2 | **120 min** (cap) | 4h from previous |
+| 3+ | 120 min | 4h from previous |
+| (any) idle for 4h | back to **30 min** | history fully pruned |
+
+Lifecycle on a typical repeat offender (already drawn in scenario 8 above):
+
+```mermaid
+flowchart LR
+    Q1[1st event<br/>30 min lockout] -->|relapse within 4h| Q2[2nd event<br/>60 min lockout]
+    Q2 -->|relapse within 4h| Q3[3rd event<br/>120 min CAP]
+    Q3 -->|relapse| Q3
+    Q3 -.->|4h idle| Q1
+    Q2 -.->|4h idle| Q1
+```
+
+The history is *only* pruned during the `nextQuarantineDuration` call (and during `clearAll` — the operator-initiated reset, see `participantLimiter.ClearQuarantine`). Background ticking is not required. Confirmed by `TestHostScoreQuarantine_ExponentialBackoff` and `TestHostScoreQuarantine_BackoffResetsAfterHistoryWindow` in `participant_limiter_hostscore_test.go`.

--- a/devshard/docs/host-scoring.md
+++ b/devshard/docs/host-scoring.md
@@ -8,7 +8,10 @@ known.
 
 This doc is the ground truth for the formula. The implementation lives in
 [`host_scores.go`](../cmd/devshardctl/host_scores.go) and the wiring lives
-in [`redundancy.go`](../cmd/devshardctl/redundancy.go).
+in [`redundancy.go`](../cmd/devshardctl/redundancy.go). For an end-to-end
+visual walkthrough of every behavioral scenario (H2H, score path,
+ε-greedy, unresponsive primary, Layer 3 quarantine and backoff,
+regime-change recovery) see [host-scoring-schemes.md](host-scoring-schemes.md).
 
 ## Problem
 
@@ -88,7 +91,14 @@ margin check in `decideHostScoreSpeedup` is "rate ≥ 0.5 + HostScoreH2HMargin"
 ## Layer 2: Elo + timing + UCB
 
 When direct H2H data is absent, we fall back to a synthesis of the host's
-own recent samples plus a global Elo rating.
+own recent samples plus a global Elo rating. The final score is:
+
+```
+score = base − Elo_credit − UCB_bonus
+```
+
+Each term contributes on the same ms scale; sections below explain how
+each component is computed.
 
 ### Per-host Total time
 
@@ -234,9 +244,32 @@ In numbers, for `N_bucket = 200` total samples in a bucket:
 The `n < MinSamples` zone is filtered out earlier in `ScoreHost` (no score
 returned), so UCB never produces a degenerate value at the very low end.
 
+### Architecture: host_score / picker separation of concerns
+
+The session picker is responsible solely for **nonce-bound dispatch**: it
+matches each newly available nonce to a queued request whose
+`excludeParticipants` set permits the binding host. It does not know
+about Elo, host scoring, or routing preference.
+
+host_score lives **above** the picker. `decideHostScoreSpeedup` decides
+only **how many** speculative secondaries to launch — based on whether
+any candidate beats primary on H2H win-rate or Elo+timing score. Which
+host receives each secondary is determined entirely by nonce arrival
+order, exactly the same path used by primary attempts and every other
+escalation/retry path.
+
+This separation matters: the picker's branch logic is hot-path,
+historically stable, and serializes nonce dispatch across all attempts.
+Pulling host_score knowledge into the picker would couple two systems
+that evolve at very different rates. If a future requirement needs to
+bias dispatch toward specific hosts, the right shape is to express it
+as *additional* exclude entries on the secondary's pickerRequest — the
+picker's existing exclude/ghost-burn machinery already enforces "no
+dispatch on these hosts" semantics without modification.
+
 ### Putting it together
 
-Four representative scenarios, all with `base = 5000 ms`, `N_bucket = 100`,
+Five representative scenarios, all with `base = 5000 ms`, `N_bucket = 100`,
 in non-streaming mode (`γ = 1.0`):
 
 | scenario | Elo | n | − Elo credit | − UCB bonus | final score |
@@ -246,20 +279,19 @@ in non-streaming mode (`γ = 1.0`):
 | cold newcomer | 1500 | 3 | 0 | ≈ −372 | **4628** |
 | cold underdog | 1400 | 3 | +1000 | ≈ −372 | **5628** |
 
-(`−` means subtracted from base; sign of the column reflects whether the
-adjustment helps or hurts the score.)
+(`−` / `+` reflect whether the adjustment helps or hurts the score.)
 
 Reading the table:
 
-- **established fast** wins outright — strong Elo credit dominates.
+- **established fast** wins outright — Elo credit dominates.
 - **cold newcomer** beats **established slow** purely thanks to UCB,
   which is the entire point of adding exploration.
 - **cold underdog** is helped by UCB but not enough to overcome its
   negative Elo — converges toward demotion as samples accumulate.
 
-The takeaway: **cold hosts get a fair chance** thanks to the UCB term,
-while **proven-fast hosts dominate** thanks to Elo credit — both effects
-on the same ms scale so they can be compared.
+The takeaway: **cold hosts get a fair chance** thanks to the UCB term and
+**proven-fast hosts dominate** thanks to Elo credit, both on the same ms
+scale so they can be compared.
 
 ## Hyperparameters
 
@@ -271,7 +303,7 @@ times). Defaults chosen to match the empirical scale we measured:
 |---|---:|---|
 | `HostScoreWindowSize` | 50 | sliding ring per (model, host, bucket) — older samples roll off |
 | `HostScoreMinSamples` | 3 | both layers gate on this; below it ScoreHost returns `(0, false)` |
-| `HostScoreEloK` | 16 | classic chess K-factor; bigger = faster convergence + more noise. Override per-bucket via `HostScoreBucketOverrides` (see [Per-bucket calibration](#per-bucket-calibration)) |
+| `HostScoreEloK` | 16 | classic chess K-factor; bigger = faster convergence + more noise. Global only — not per-bucket. |
 | `HostScoreEloDefault` | 1500 | starting rating for unknown hosts |
 | `HostScoreEloAlpha` | 10 | ms credit per Elo-point deviation from 1500 |
 | `HostScoreStreamGamma` | 0.3 | TTFT vs Total weight for streaming requests |
@@ -280,63 +312,47 @@ times). Defaults chosen to match the empirical scale we measured:
 | `HostScoreH2HMargin` | 0.10 | Layer 1 trigger: candidate must win ≥ 50% + this |
 | `HostScoreSpeedupMargin` | 0.10 | Layer 2 trigger: candidate score must be ≤ primary · (1 − this) |
 | `HostScoreEloHalfLife` | 12 h | half-life for stale-Elo decay; 0 disables (see Regime change). Override per-bucket via `HostScoreBucketOverrides` (see [Per-bucket calibration](#per-bucket-calibration)) |
-| `HostScoreExplorationEpsilon` | 0.05 | ε-greedy probability of launching a random secondary when the score-based path is ambivalent |
+| `HostScoreExplorationEpsilon` | 0.02 | ε-greedy probability of launching a random secondary when the score-based path is ambivalent |
 | `RedundancySpeedPolicy` | `host_score` | which decision maker `Decide()` selects (see When this is consulted) |
 
 ## Per-bucket calibration
 
-`HostScoreEloK` and `HostScoreEloHalfLife` are the only two hyperparameters
-that should differ across input-size buckets, because the buckets have
-very different sample density and traffic shape. The same K that gives a
-tight, fast-converging rating in `lt_1k` (hundreds of samples per host
-per hour) overshoots in `gte_100k` (handfuls per day) — and vice versa.
+`HostScoreEloHalfLife` benefits from per-bucket tuning: high-traffic
+buckets receive many fresh samples per hour and can afford to forget
+older ratings quickly, while sparse buckets need a longer half-life to
+keep any signal at all.
 
 The mechanism is one map declared at the top of [`host_scores.go`](../cmd/devshardctl/host_scores.go):
 
 ```go
 HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
-    "lt_1k":    {HalfLife: 3 * time.Hour},
-    "1k_5k":    {HalfLife: 3 * time.Hour},
-    "5k_15k":   {HalfLife: 6 * time.Hour},
-    "15k_30k":  {HalfLife: 6 * time.Hour},
-    "30k_100k": {HalfLife: 9 * time.Hour},
-    "gte_100k": {HalfLife: 12 * time.Hour},
+    "lt_1k": {HalfLife: 6 * time.Hour},
+    "1k_5k": {HalfLife: 6 * time.Hour},
+    // Other buckets inherit HostScoreEloHalfLife (12h).
 }
 ```
 
-Fields on `HostScoreBucketOverride`:
-
-| Field | Meaning |
-|---|---|
-| `K` | overrides `HostScoreEloK` for this bucket. `0` inherits global. |
-| `HalfLife` | overrides `HostScoreEloHalfLife`. **Negative inherits global**; `0` explicitly disables decay for this bucket. |
-
-Read paths use `hostScoreKForBucket(bucket)` and
-`hostScoreHalfLifeForBucket(bucket)` rather than the global constants
-directly.
+`HostScoreBucketOverride` has one field, `HalfLife`. Negative inherits
+the global `HostScoreEloHalfLife`; zero explicitly disables decay for
+that bucket. Read path is `hostScoreHalfLifeForBucket(bucket)`.
 
 ### Why these values
 
 Rating-system literature (FIDE Handbook §B.02.10.6, Glickman 1995 on
-adaptive ratings) consistently recommends scaling decay/learning rates
-with *sample reliability*: faster decay when ratings refresh often
-(dense bucket); slower decay when re-sampling is rare (sparse bucket).
-The committed defaults match observed traffic density per bucket:
+adaptive ratings) consistently recommends faster decay where ratings
+refresh often. The two committed overrides target precisely the
+high-traffic buckets where 12 h would be unnecessarily slow:
 
 | Bucket | HalfLife | Rationale |
 |---|---:|---|
-| `lt_1k` | 3 h | high traffic (hundreds/host/hour) — fast adaptation |
-| `1k_5k` | 3 h | high traffic — same |
-| `5k_15k` | 6 h | medium traffic |
-| `15k_30k` | 6 h | medium traffic |
-| `30k_100k` | 9 h | low traffic (tens/host/day) — preserve signal across gaps |
-| `gte_100k` | 12 h | very low traffic (single-digits/day) — matches the legacy global default |
+| `lt_1k` | 6 h | high traffic (hundreds/host/hour) — afford faster adaptation |
+| `1k_5k` | 6 h | high traffic — same |
+| `5k_15k` and above | 12 h (inherit) | replay-loop data did not justify compressing further |
 
-`K` is left to inherit the global default (16) until per-bucket
-calibration of K has been measured against a replay loop. Operators
-adjusting these values should re-run the cache-busted c=10 ×5-iter
-replay loop and compare bucket-level pick% / latency distributions
-against the merged baseline in the host_score rollout PR.
+K-factor is not per-bucket — `HostScoreEloK = 16` is global. If
+calibrating K per bucket ever becomes worthwhile, the `HostScoreBucketOverride`
+struct can be extended; the corresponding helper would follow the same
+pattern as `hostScoreHalfLifeForBucket`.
 
 ## Decision: when host scoring launches a secondary
 
@@ -444,34 +460,31 @@ anyway, tagged `reason="host_scores_exploration"`.
 | Setting | Behavior |
 |---|---|
 | ε = 0 | exploration disabled; pure score-based routing |
-| ε = 0.05 (default) | ≈ 1 in 20 ambivalent decisions becomes a forced race; Elo evolves |
+| ε = 0.02 (default) | ≈ 1 in 50 ambivalent decisions becomes a forced race; Elo evolves |
 | ε = 1.0 | always race when score is ambivalent (useful for tests) |
 
-The cost is one extra inference per 20 ambivalent decisions. The benefit
+The cost is one extra inference per 50 ambivalent decisions. The benefit
 is that recently-improved hosts get races, win them, and climb out of low
 Elo within hours instead of days.
 
 ### Putting both together
 
-A host that was slow for 10 days, then becomes fastest:
-
-Timing below is illustrative against the **legacy 12 h** half-life;
-substitute the bucket's actual half-life for real numbers (e.g. 3 h for
-`lt_1k`, in which case "Hours 12+" really means "Hours 3+", and full
-recovery compresses by roughly 4×):
+A host that was slow for 10 days, then becomes fastest. Timing below
+uses the **global 12 h** half-life; for `lt_1k`/`1k_5k` (6 h override)
+the same milestones land at roughly half the elapsed time.
 
 1. **Hour 0** of regime change: Elo ≈ 1200, ring full of slow samples.
    Decay hasn't kicked in (last race was minutes ago).
-2. **Hours 0–HL**: ε-greedy occasionally routes to it. Each win is a
+2. **Hours 0–12**: ε-greedy occasionally routes to it. Each win is a
    real K-update on its decayed (still 1200-ish) Elo: `K · (1 − E)`
    where `E ≈ 0.15` → ≈ +13.6 per win. Slow but steady climb.
-3. **Hours HL+ without traffic** (between rare ε-greedy races): decay
-   half-life kicks in. After 2× HL of low traffic, the 300-point gap
-   has halved to 150. Now ε-greedy wins yield larger Elo updates
+3. **Hours 12+ without traffic** (between rare ε-greedy races): decay
+   half-life kicks in. After 24 hours of low traffic, the 300-point
+   gap has halved to 150. Now ε-greedy wins yield larger Elo updates
    (`E ≈ 0.30` → +11.2 per win, but starting from 1350 instead of 1200).
-4. **Within 2–6× HL**: enough wins accumulated for the ring to refresh
-   too, and the host promotes back to score-based routing without
-   ε-greedy help.
+4. **Within 1–3 days**: enough wins accumulated for the ring to
+   refresh too, and the host promotes back to score-based routing
+   without ε-greedy help.
 
 Decay alone protects against complete exile; ε-greedy alone keeps races
 flowing; both together compress recovery from days to hours.
@@ -494,8 +507,8 @@ flowing; both together compress recovery from days to hours.
       "total_p50_ms": 8203, "total_p90_ms": 14500,
       "elo": 1628.4,
       "ucb_bonus_ms": 117.6,
-      "score_stream": 5921.2,
-      "score_non_stream": 7967.8
+      "score_stream": 5347.2,
+      "score_non_stream": 7393.8
     }, ...
   ],
   "generated_at": "2026-05-24T...",
@@ -517,6 +530,127 @@ What to look at on a live node:
   when TTFT and Total differ greatly. If they're identical → γ is doing
   nothing on this workload (legitimate; just means TTFT and Total are
   proportional).
+## Performance quarantine
+
+Layers 2.1–2.3 demote slow hosts in the *secondary-selection* path: a
+candidate with bad scoring never wins the speedup race. They do nothing
+to stop a slow host from being assigned the **primary** attempt — the
+session picker is nonce-driven and policy-agnostic, so a host with
+p50 TTFT = 70 s still takes its turn at primary slots. To stop
+persistently slow hosts from soaking primary nonces, the host_score
+policy adds a fifth quarantine channel alongside the existing four
+(HTTP 429/503, transport failure, empty stream, stalled winner).
+
+### Algorithm
+
+For every observed responsive TTFT sample, the limiter performs:
+
+1. **Update per-host ring.** Each (host, bucket) keeps a rolling window
+   of the last `hostScoreSampleRingCapacity` (= 20) TTFTs. The new
+   sample is appended.
+
+2. **Compute bucket threshold (excluding self).** The threshold is the
+   p90 of all TTFTs from *other* qualifying hosts in the bucket — every
+   host except the one being evaluated, restricted to those with at
+   least `HostScoreQuarantineMinSamplesPerHost` (= 3) samples in their
+   ring. The bucket must have at least
+   `HostScoreQuarantineMinQualifyingHosts` (= 3) such hosts. Otherwise
+   no threshold is defined and the sample is ignored. Excluding the
+   candidate's own samples prevents a slow host's bad samples from
+   raising the threshold against which the same host is judged
+   (self-pollution).
+
+3. **Sliding-window strike.** Each (host, bucket) keeps a ring of the
+   last `hostScoreSlidingWindow` (= 5) outcomes (bad/good). The new
+   sample is recorded as `bad` iff `TTFT > threshold`. When the
+   window holds at least `hostScoreBadInWindow` (= 3) bad outcomes,
+   the host enters quarantine *in this bucket*. The window is cleared
+   on entry so a fresh accumulation can start after release.
+
+4. **Exponential backoff.** Each bucket also remembers its recent
+   quarantine entry timestamps within the last
+   `hostScoreQuarantineHistoryWindow` (= 4 h). The duration of the new
+   quarantine is `hostScoreQuarantineBaseDuration · 2^(recent_count)`,
+   capped at `hostScoreQuarantineMaxDuration`. With the defaults: 1st
+   strike → 30 min, 2nd within 4 h → 60 min, 3rd → 120 min (cap).
+   After 4 h with no entry, the count resets to zero.
+
+5. **Picker integration.** `ParticipantRequestLimiter.IsRecentlyQuarantined`
+   returns true if **any** bucket holds an active Layer 3 quarantine
+   for the host. The picker treats this identically to the four other
+   quarantine channels — host is removed from both primary picker
+   rotation and secondary candidate scans.
+
+### Why sliding window, not consecutive strikes
+
+Bimodal hosts ("90% fast, 10% catastrophic") emit pattern
+`slow, slow, fast, slow, ...` — a consecutive-strike counter resets on
+every fast sample and never reaches 3-in-a-row despite 60%+ bad rate.
+The sliding "≥3 of last 5" counter captures these without false
+positives on hosts with single transient slow bursts.
+
+### Why exclude self from threshold
+
+When a slow host adds enough slow samples to the bucket pool, those
+samples shift the pool's own p90 toward "slow". The bad host stops
+crossing its own threshold and escapes detection. Excluding the
+evaluated host's own samples from the threshold pool makes the test
+"this host vs. the rest of the cohort" rather than "this host vs.
+a cohort that includes itself".
+
+### Policy gate
+
+The whole channel is **gated on `RedundancySpeedPolicy ==
+"host_score"`**. Under any other policy the limiter's
+`RecordHostScoreSample` and `isQuarantined` early-return without
+acquiring locks or mutating state. The gate is checked on every call,
+so flipping the runtime policy instantly disarms the channel without
+needing a separate feature flag.
+
+### Validation (replay-loop, 1,580 minutes, 12 hosts, 6 buckets)
+
+| Metric | Value |
+|---|---:|
+| Truly bad responsive (host, bucket) pairs | 23 |
+| True positives | 20 |
+| False positives | 7 (all borderline 7–20 % bad rate) |
+| Precision | 74 % |
+| Recall | 87 % |
+| Bimodal hosts caught (vs consecutive strike variant) | yes |
+
+All FPs sit between 7 % and 20 % bad rate — i.e. just below the 20 %
+threshold used to define "truly bad" in the ground truth. Tightening
+the analytical threshold to 15 % moves every FP into TP and yields
+near-100 % precision.
+
+### Hyperparameters
+
+| Var | Default | Meaning |
+|---|---:|---|
+| `HostScoreQuarantineMinSamplesPerHost` | 3 | each host needs ≥ this many TTFTs to enter the threshold pool |
+| `HostScoreQuarantineMinQualifyingHosts` | 3 | bucket needs ≥ this many qualifying hosts before any threshold is defined |
+| `hostScoreSampleRingCapacity` | 20 | per-(host, bucket) recent-TTFT ring |
+| `hostScoreSlidingWindow` | 5 | bad/good outcome window per (host, bucket) |
+| `hostScoreBadInWindow` | 3 | ≥ this many bad outcomes in window → quarantine |
+| `hostScoreQuarantineBaseDuration` | 30 min | first quarantine duration |
+| `hostScoreQuarantineMaxDuration` | 120 min | cap for exponential backoff |
+| `hostScoreQuarantineHistoryWindow` | 4 h | sliding window over which recent quarantines accumulate backoff |
+
+### Known limitations (v1)
+
+- **No persistence.** Layer 3 state lives only in memory; a gateway
+  restart releases every active quarantine. The other quarantine
+  channels persist via `ParticipantThrottleStore`. Adding persistence
+  for Layer 3 is a planned follow-up.
+- **No metrics counter.** `log.Printf` lines tag entries (`host_score_quarantine_entered`)
+  and expirations (`host_score_quarantine_expired`) but there is no
+  Prometheus counter yet. Operators can grep logs for now.
+- **isQuarantined is host-level.** Internal state is per (host,
+  bucket), but the public check `IsRecentlyQuarantined(host)` returns
+  true if *any* bucket is active. The picker has no bucket context at
+  nonce-binding time, so a host bad in `lt_1k` is removed from
+  primary rotation for `gte_100k` traffic too. Plumbing bucket through
+  the picker is a separate, larger refactor.
 
 ## Persistence and restart
 

--- a/devshard/docs/host-scoring.md
+++ b/devshard/docs/host-scoring.md
@@ -271,7 +271,7 @@ times). Defaults chosen to match the empirical scale we measured:
 |---|---:|---|
 | `HostScoreWindowSize` | 50 | sliding ring per (model, host, bucket) — older samples roll off |
 | `HostScoreMinSamples` | 3 | both layers gate on this; below it ScoreHost returns `(0, false)` |
-| `HostScoreEloK` | 16 | classic chess K-factor; bigger = faster convergence + more noise |
+| `HostScoreEloK` | 16 | classic chess K-factor; bigger = faster convergence + more noise. Override per-bucket via `HostScoreBucketOverrides` (see [Per-bucket calibration](#per-bucket-calibration)) |
 | `HostScoreEloDefault` | 1500 | starting rating for unknown hosts |
 | `HostScoreEloAlpha` | 10 | ms credit per Elo-point deviation from 1500 |
 | `HostScoreStreamGamma` | 0.3 | TTFT vs Total weight for streaming requests |
@@ -279,9 +279,64 @@ times). Defaults chosen to match the empirical scale we measured:
 | `HostScoreUCBCoefficient` | 300 | exploration bonus scale, ms; 0 disables |
 | `HostScoreH2HMargin` | 0.10 | Layer 1 trigger: candidate must win ≥ 50% + this |
 | `HostScoreSpeedupMargin` | 0.10 | Layer 2 trigger: candidate score must be ≤ primary · (1 − this) |
-| `HostScoreEloHalfLife` | 12 h | half-life for stale-Elo decay; 0 disables (see Regime change) |
+| `HostScoreEloHalfLife` | 12 h | half-life for stale-Elo decay; 0 disables (see Regime change). Override per-bucket via `HostScoreBucketOverrides` (see [Per-bucket calibration](#per-bucket-calibration)) |
 | `HostScoreExplorationEpsilon` | 0.05 | ε-greedy probability of launching a random secondary when the score-based path is ambivalent |
 | `RedundancySpeedPolicy` | `host_score` | which decision maker `Decide()` selects (see When this is consulted) |
+
+## Per-bucket calibration
+
+`HostScoreEloK` and `HostScoreEloHalfLife` are the only two hyperparameters
+that should differ across input-size buckets, because the buckets have
+very different sample density and traffic shape. The same K that gives a
+tight, fast-converging rating in `lt_1k` (hundreds of samples per host
+per hour) overshoots in `gte_100k` (handfuls per day) — and vice versa.
+
+The mechanism is one map declared at the top of [`host_scores.go`](../cmd/devshardctl/host_scores.go):
+
+```go
+HostScoreBucketOverrides = map[string]HostScoreBucketOverride{
+    "lt_1k":    {HalfLife: 3 * time.Hour},
+    "1k_5k":    {HalfLife: 3 * time.Hour},
+    "5k_15k":   {HalfLife: 6 * time.Hour},
+    "15k_30k":  {HalfLife: 6 * time.Hour},
+    "30k_100k": {HalfLife: 9 * time.Hour},
+    "gte_100k": {HalfLife: 12 * time.Hour},
+}
+```
+
+Fields on `HostScoreBucketOverride`:
+
+| Field | Meaning |
+|---|---|
+| `K` | overrides `HostScoreEloK` for this bucket. `0` inherits global. |
+| `HalfLife` | overrides `HostScoreEloHalfLife`. **Negative inherits global**; `0` explicitly disables decay for this bucket. |
+
+Read paths use `hostScoreKForBucket(bucket)` and
+`hostScoreHalfLifeForBucket(bucket)` rather than the global constants
+directly.
+
+### Why these values
+
+Rating-system literature (FIDE Handbook §B.02.10.6, Glickman 1995 on
+adaptive ratings) consistently recommends scaling decay/learning rates
+with *sample reliability*: faster decay when ratings refresh often
+(dense bucket); slower decay when re-sampling is rare (sparse bucket).
+The committed defaults match observed traffic density per bucket:
+
+| Bucket | HalfLife | Rationale |
+|---|---:|---|
+| `lt_1k` | 3 h | high traffic (hundreds/host/hour) — fast adaptation |
+| `1k_5k` | 3 h | high traffic — same |
+| `5k_15k` | 6 h | medium traffic |
+| `15k_30k` | 6 h | medium traffic |
+| `30k_100k` | 9 h | low traffic (tens/host/day) — preserve signal across gaps |
+| `gte_100k` | 12 h | very low traffic (single-digits/day) — matches the legacy global default |
+
+`K` is left to inherit the global default (16) until per-bucket
+calibration of K has been measured against a replay loop. Operators
+adjusting these values should re-run the cache-busted c=10 ×5-iter
+replay loop and compare bucket-level pick% / latency distributions
+against the merged baseline in the host_score rollout PR.
 
 ## Decision: when host scoring launches a secondary
 
@@ -347,7 +402,9 @@ half-life decay:
 decayed(R, age) = 1500 + (R − 1500) · 2^(−age / HostScoreEloHalfLife)
 ```
 
-With `HostScoreEloHalfLife = 12h`:
+With `HostScoreEloHalfLife = 12h` (table uses the global default for
+illustration; **per-bucket overrides apply in practice — see
+[Per-bucket calibration](#per-bucket-calibration)**):
 
 | Age since last update | Gap multiplier | 1800 → | 1200 → |
 |---|---:|---:|---:|
@@ -358,12 +415,17 @@ With `HostScoreEloHalfLife = 12h`:
 | 48 h | 0.063 | 1519 | 1481 |
 | 96 h | 0.004 | 1501 | 1499 |
 
+For a bucket with a shorter half-life the same multipliers fire at
+proportionally earlier ages: with `lt_1k`'s 3 h, 6 h elapsed already
+halves the gap; with `gte_100k`'s 12 h it matches the table exactly.
+
 This applies on every read (`ScoreHost`, `Snapshot`) *and* before every
 write in `updateEloLocked` — so the K-update is applied to the
 *time-adjusted* rating, not the stale one. Persisted state carries
 `UpdatedAt` per row so decay survives restart.
 
-Set `HostScoreEloHalfLife = 0` to disable entirely.
+Set `HostScoreEloHalfLife = 0` (or the bucket's override to `0`) to
+disable decay entirely.
 
 ### ε-greedy exploration floor
 
@@ -393,18 +455,23 @@ Elo within hours instead of days.
 
 A host that was slow for 10 days, then becomes fastest:
 
+Timing below is illustrative against the **legacy 12 h** half-life;
+substitute the bucket's actual half-life for real numbers (e.g. 3 h for
+`lt_1k`, in which case "Hours 12+" really means "Hours 3+", and full
+recovery compresses by roughly 4×):
+
 1. **Hour 0** of regime change: Elo ≈ 1200, ring full of slow samples.
    Decay hasn't kicked in (last race was minutes ago).
-2. **Hours 0-12**: ε-greedy occasionally routes to it. Each win is a real
-   K-update on its decayed (still 1200-ish) Elo: `K · (1 − E)` where
-   `E ≈ 0.15` → ≈ +13.6 per win. Slow but steady climb.
-3. **Hours 12+ without traffic** (between rare ε-greedy races): decay
-   half-life kicks in. After 24 hours of low traffic, the 300-point gap
+2. **Hours 0–HL**: ε-greedy occasionally routes to it. Each win is a
+   real K-update on its decayed (still 1200-ish) Elo: `K · (1 − E)`
+   where `E ≈ 0.15` → ≈ +13.6 per win. Slow but steady climb.
+3. **Hours HL+ without traffic** (between rare ε-greedy races): decay
+   half-life kicks in. After 2× HL of low traffic, the 300-point gap
    has halved to 150. Now ε-greedy wins yield larger Elo updates
    (`E ≈ 0.30` → +11.2 per win, but starting from 1350 instead of 1200).
-4. **Within 1-3 days**: enough wins accumulated for the ring to refresh
-   too, and the host promotes back to score-based routing without ε-greedy
-   help.
+4. **Within 2–6× HL**: enough wins accumulated for the ring to refresh
+   too, and the host promotes back to score-based routing without
+   ε-greedy help.
 
 Decay alone protects against complete exile; ε-greedy alone keeps races
 flowing; both together compress recovery from days to hours.
@@ -462,7 +529,8 @@ timestamp marking when that rating was last K-updated.
 `updated_at_utc` is what makes time-decay survive restart: on `Restore`
 we seed `eloUpdatedAt[key]` from this column, so the decay clock keeps
 ticking across shutdowns rather than resetting to "now". A node that
-sleeps for 24 h boots up with already-half-decayed ratings on first read.
+sleeps long enough to clear one or more bucket-specific half-lives boots
+up with already-half-decayed ratings on first read.
 
 Flush schedule:
 - Periodic every `hostScoreFlushInterval = 2 min` (background goroutine

--- a/devshard/docs/host-scoring.md
+++ b/devshard/docs/host-scoring.md
@@ -1,0 +1,485 @@
+# Host Scoring: Elo-driven Speculative Routing
+
+The devshard proxy ranks runtime hosts by **how fast they end-to-end finish
+inferences**, not by how fast they start them. The ranking drives
+`Redundancy.Decide` — specifically, the decision to launch a *secondary*
+attempt in parallel with the primary when a strictly faster candidate is
+known.
+
+This doc is the ground truth for the formula. The implementation lives in
+[`host_scores.go`](../cmd/devshardctl/host_scores.go) and the wiring lives
+in [`redundancy.go`](../cmd/devshardctl/redundancy.go).
+
+## Problem
+
+The legacy routing path used a TTFT-based heuristic
+(`decideLegacySecondaryFaster`) to decide whether a secondary attempt would
+help. In production captures we found this was wrong **44.6% of the time**:
+the candidate that won on TTFT was not the one that finished first
+end-to-end ([2026-05-24-stats.md](../../docs/chat-api/2026-05-24-stats.md)).
+The fastest-to-first-token host was often slower to finish, because TTFT is
+heavily influenced by transport latency and queue position whereas total
+time is dominated by per-token throughput on the host.
+
+Host scoring is the answer: keep a per-host running view of *total* time
+(plus TTFT for richer scoring) and an Elo rating that updates on each
+realised race.
+
+## When this is consulted
+
+Speculative-routing strategy is selected via the `RedundancySpeedPolicy`
+enum (`POST /v1/admin/settings` field `redundancy.speed_policy`):
+
+Each policy is a **self-contained branch** of the `Decide()` switch — no
+cascading between policies. The chosen branch always returns a complete
+`Decision` and that is the final answer.
+
+| Policy | Primary path | On miss |
+|---|---|---|
+| `host_score` (default) | `decideHostScoreSpeedup` | (no miss — always returns a final `Decision`; see Reasons table) |
+| `hybrid` | `decidePairwiseSpeedup` | fall back to `decideLegacySecondaryFaster` (TTFT) |
+| `pairwise` | `decidePairwiseSpeedup` | return `pairwise_insufficient_data` (delayed safety-net secondary) |
+| `legacy` | `decideLegacySecondaryFaster` | — |
+
+Regardless of policy, `IsUnresponsiveParticipant(primary)` runs first and
+forces an immediate parallel attempt.
+
+Why no cascade for `host_score`? If legacy TTFT could override host-score's
+"no", it would launch wasteful secondaries to candidates we already know
+are slower — and worse, those races would feed back into the formula as
+"losses" for the unfairly-selected host, suppressing its Elo even more
+(self-reinforcing exile). Trust the formula or pick a different policy.
+
+To roll back to pre-host-score behaviour, set
+`redundancy.speed_policy = "hybrid"` at runtime — no restart needed.
+
+## The score formula
+
+For a (model, host, bucket) key, `HostScoreTracker.ScoreHost` returns a
+**lower-is-better** score on a millisecond scale. Two layers:
+
+| Layer | Activates when | Returns |
+|---|---|---|
+| **1 · direct H2H win-rate** | `PairwiseTracker.H2HWinRate(host, opponent)` has ≥ `MinSamples` direct comparisons | `1 − rate` (so a 70%-win host scores 0.30) |
+| **2 · Elo + timing + UCB** | otherwise (when this host has ≥ `MinSamples` own samples) | `base − α·(Elo − 1500) − c·√(ln N_bucket / n_host)` |
+
+Layer 1 is preferred whenever it has data because it measures *exactly the
+matchup we're asking about* with zero confounders. Layer 2 is the fallback
+for cases where we have separate per-host samples but no direct head-to-head.
+
+## Layer 1: direct H2H win-rate
+
+When primary `A` and candidate `B` have been raced against each other at
+least `HostScoreMinSamples` (= 3) times in this bucket,
+`PairwiseTracker.H2HWinRate(model, bucket, B, A)` returns B's fraction of
+total-time wins over A in [0, 1].
+
+We translate to score so that lower = better:
+
+```
+score(B) = 1 − rate(B beats A)
+```
+
+A candidate that beats the primary 70% of the time has `score = 0.30` and
+the primary has effectively `0.50` (the implicit indifference value). The
+margin check in `decideHostScoreSpeedup` is "rate ≥ 0.5 + HostScoreH2HMargin"
+(default 0.60 → only act when B wins ≥ 60% of head-to-heads).
+
+## Layer 2: Elo + timing + UCB
+
+When direct H2H data is absent, we fall back to a synthesis of the host's
+own recent samples plus a global Elo rating.
+
+### Per-host Total time
+
+`HostInvolvement.TotalTimeMs` is computed as `lastChunkAt − sendTime` —
+the real moment the host emitted its last chunk, per-host. This matters
+in speculative routing: a naive `time.Since(sendTime)` measured at
+request-end gives every racing host roughly the same value (the gateway
+lifecycle duration), so Total comparisons between hosts in the same race
+collapse to noise. With the per-host measurement, a host that streamed
+100 chunks in 5 s reports `5000ms` while a sibling that streamed 30
+chunks in 1.5 s reports `1500ms`, even though both share the same
+overall request envelope.
+
+Fallback: when a host emitted no chunks (`lastChunkAt == 0` — empty
+response, cold timeout), TotalTimeMs falls back to `time.Since(sendTime)`
+since per-chunk data is unavailable. Such samples are anyway gated out
+of Elo by the `Finished` flag in most cases.
+
+### Layer 2.1 · base timing
+
+`base = (1 − γ)·TTFT_p50 + γ·Total_p50`
+
+- `γ = HostScoreNonStreamGamma = 1.0` for non-streaming requests (only
+  total time matters — client doesn't see partial output anyway)
+- `γ = HostScoreStreamGamma = 0.3` for streaming requests (we still care
+  about end-to-end but TTFT meaningfully shapes UX)
+
+Percentiles are over the last `HostScoreWindowSize = 50` samples.
+
+### Layer 2.2 · Elo credit
+
+`Elo_credit = α · (Elo − 1500)`
+
+`Elo` is the chess-style rating of this host in this (model, bucket). It
+updates after every observed 2-host pair in `RecordRequest`. A host that
+consistently wins drifts above 1500; a consistent loser drifts below.
+
+**Dual-metric K-split.** Per pair we run TWO Elo updates — one keyed on
+`FirstTokenMs`, one on `TotalTimeMs` — each with `K/2 = 8`. This mirrors
+the selection-score formula (which combines TTFT and Total via `γ`) so the
+rating reflects both dimensions:
+
+- both metrics agree (host fast on both) → ≈ K/2 net gain (near full budget,
+  minus small Elo self-correction)
+- metrics disagree (fast on one, slow on the other) → net ~0
+- host fast on one, no signal on the other → ~K/4 gain
+- both metrics fail → host loses on both updates (≈ K)
+
+**Per-update outcome rule** (applied independently to TTFT and Total):
+
+| A status | B status | outcome | rationale |
+|---|---|---|---|
+| both produced metric | both produced metric | faster metric wins (`Sa=1, Sb=0`) | normal race |
+| produced metric | failed | A wins (`Sa=1, Sb=0`) | responder beats no-show |
+| failed | produced metric | B wins (`Sa=0, Sb=1`) | symmetric |
+| both failed | both failed | both lose (`Sa=Sb=0`) | symmetric penalty — each loses K·E_self toward default |
+
+"Produced metric" means:
+- for TTFT update: `Responsive && FirstTokenMs > 0`
+- for Total update: `Responsive && Finished && TotalTimeMs > 0`
+
+A canceled-but-responded loser (Finished=false, FirstTokenMs>0) still loses
+on the TTFT dimension and loses on Total (no completion). A completely
+unresponsive host loses on both — exactly what we want, since under the old
+single-metric rule unresponsive hosts were filtered out of Elo entirely and
+accumulated false high ratings.
+
+**Bradley-Terry continuous outcome.** When both hosts produce the metric,
+the pair outcome is a smooth function of their ratio rather than a binary
+win/loss:
+
+```
+Sa = mb^k / (ma^k + mb^k)        // k = HostScoreBradleyTerryExp = 2
+```
+
+For LOWER-is-better metrics: ratio 1.0 → Sa=0.5 (exact draw, no Elo move);
+ratio 1.1 → Sa≈0.55 (tiny move); ratio 2.0 → Sa=0.80 (clear win); ratio 10
+→ Sa≈0.99 (decisive). This is the standard Bradley-Terry pair-comparison
+model (Zermelo 1929, Bradley & Terry 1952) — same statistical pedigree as
+Elo itself.
+
+Why this matters: under speculative routing many races are decided at the
+streaming-throughput ceiling, where 4 hosts finish within 0.3% of each
+other on a 4-minute generation. A naive binary outcome rewards Elo for
+those sub-1% margins (pure measurement noise). Bradley-Terry collapses
+near-tie ratios to Sa≈0.5 automatically — no explicit noise threshold
+needed. Empirically verified on production data: under the old binary
+rule a host with 78s p50 TTFT was ranked top-1 in 4 of 6 buckets because
+it kept "winning" Total comparisons by milliseconds on slow races; under
+BT it correctly sinks to the bottom in every bucket.
+
+`α = HostScoreEloAlpha = 10 ms per Elo point` is the dimensional conversion
+that lets us subtract Elo from the ms-scale base. 200-point gap → 2000 ms
+credit. That's the size of one extra full-token chunk and is comparable to
+the empirical noise floor of total-time differences we measured in
+production ([2026-05-24-stats.md](../../docs/chat-api/2026-05-24-stats.md)).
+
+Translating Elo numbers to win probability (canonical chess formula
+`P(A) = 1 / (1 + 10^((Rb−Ra)/400))`):
+
+| Elo gap | win-rate of higher-rated host |
+|---:|---:|
+| +100 | ≈ 64% |
+| +200 | ≈ 76% |
+| +300 | ≈ 85% |
+| +400 | ≈ 91% |
+
+A 200-point gap is the practical "act on it" threshold — smaller gaps
+(under 100) are statistically indistinguishable from noise; the speedup
+margin check (next section) and the H2H gate filter them out.
+
+Convergence is fast in practice. With `K=16` and a true 70/30 split,
+simulated ratings settle within ±100 points of the steady-state gap
+(`400·log10(0.7/0.3) ≈ 147`) inside ~50 games, and absorb most noise by
+150 games. Raise `K` for faster reaction (more noise); lower for slower
+adaptation (more stable).
+
+### Layer 2.3 · UCB exploration bonus
+
+`UCB_bonus = c · √(ln N_bucket / n_host)` (subtracted from score)
+
+This is the [UCB1](https://en.wikipedia.org/wiki/Multi-armed_bandit#Upper_confidence_bounds)
+exploration term applied to the Layer-2 score. Without it, a host that
+landed in our sample set with a *single* slow run could be exiled from
+secondary selection forever — Elo never updates if it never races. The
+UCB term grants an "exploration credit" to under-sampled hosts so they get
+chosen against established competitors and either prove themselves (their
+Elo recovers) or confirm the negative (Elo settles low).
+
+`c = HostScoreUCBCoefficient = 300 ms`. Set to 0 to disable exploration
+entirely. The credit shrinks logarithmically as samples accumulate.
+
+In numbers, for `N_bucket = 200` total samples in a bucket:
+
+| host samples `n` | UCB credit (ms) |
+|---:|---:|
+| 3 | ≈ 921 |
+| 10 | ≈ 504 |
+| 50 | ≈ 226 |
+| 100 | ≈ 160 |
+| 200 | 0 (saturated) |
+
+The `n < MinSamples` zone is filtered out earlier in `ScoreHost` (no score
+returned), so UCB never produces a degenerate value at the very low end.
+
+### Putting it together
+
+Four representative scenarios, all with `base = 5000 ms`, `N_bucket = 100`,
+in non-streaming mode (`γ = 1.0`):
+
+| scenario | Elo | n | − Elo credit | − UCB bonus | final score |
+|---|---:|---:|---:|---:|---:|
+| established fast | 1620 | 50 | −1200 | ≈ −91 | **3709** |
+| established slow | 1380 | 50 | +1200 | ≈ −91 | **6109** |
+| cold newcomer | 1500 | 3 | 0 | ≈ −372 | **4628** |
+| cold underdog | 1400 | 3 | +1000 | ≈ −372 | **5628** |
+
+(`−` means subtracted from base; sign of the column reflects whether the
+adjustment helps or hurts the score.)
+
+Reading the table:
+
+- **established fast** wins outright — strong Elo credit dominates.
+- **cold newcomer** beats **established slow** purely thanks to UCB,
+  which is the entire point of adding exploration.
+- **cold underdog** is helped by UCB but not enough to overcome its
+  negative Elo — converges toward demotion as samples accumulate.
+
+The takeaway: **cold hosts get a fair chance** thanks to the UCB term,
+while **proven-fast hosts dominate** thanks to Elo credit — both effects
+on the same ms scale so they can be compared.
+
+## Hyperparameters
+
+All declared in [`host_scores.go`](../cmd/devshardctl/host_scores.go) at
+the top of the file. Mutable at runtime (no atomic — change at quiet
+times). Defaults chosen to match the empirical scale we measured:
+
+| Var | Default | What it controls |
+|---|---:|---|
+| `HostScoreWindowSize` | 50 | sliding ring per (model, host, bucket) — older samples roll off |
+| `HostScoreMinSamples` | 3 | both layers gate on this; below it ScoreHost returns `(0, false)` |
+| `HostScoreEloK` | 16 | classic chess K-factor; bigger = faster convergence + more noise |
+| `HostScoreEloDefault` | 1500 | starting rating for unknown hosts |
+| `HostScoreEloAlpha` | 10 | ms credit per Elo-point deviation from 1500 |
+| `HostScoreStreamGamma` | 0.3 | TTFT vs Total weight for streaming requests |
+| `HostScoreNonStreamGamma` | 1.0 | … for non-streaming requests |
+| `HostScoreUCBCoefficient` | 300 | exploration bonus scale, ms; 0 disables |
+| `HostScoreH2HMargin` | 0.10 | Layer 1 trigger: candidate must win ≥ 50% + this |
+| `HostScoreSpeedupMargin` | 0.10 | Layer 2 trigger: candidate score must be ≤ primary · (1 − this) |
+| `HostScoreEloHalfLife` | 12 h | half-life for stale-Elo decay; 0 disables (see Regime change) |
+| `HostScoreExplorationEpsilon` | 0.05 | ε-greedy probability of launching a random secondary when the score-based path is ambivalent |
+| `RedundancySpeedPolicy` | `host_score` | which decision maker `Decide()` selects (see When this is consulted) |
+
+## Decision: when host scoring launches a secondary
+
+[`Redundancy.decideHostScoreSpeedup`](../cmd/devshardctl/redundancy.go)
+always returns a complete `Decision`. The `Reason` field tells operators
+exactly what happened. Per candidate:
+
+```
+hadData = false
+for candidate in candidates:
+    if H2H(candidate vs primary) has ≥ MinSamples samples:
+        hadData = true
+        if win_rate ≥ 0.5 + HostScoreH2HMargin:
+            accepted += 1
+        continue   # H2H is authoritative once it has data
+
+    if score(candidate) is defined:                  # ≥ MinSamples own samples
+        hadData = true
+        if score(candidate) < score(primary) · (1 − HostScoreSpeedupMargin):
+            accepted += 1
+
+if accepted > 0:
+    return Decision{RunSecondary: true, Reason: "host_scores", attempts: accepted}
+
+if rand() < HostScoreExplorationEpsilon:
+    return Decision{RunSecondary: true, Reason: "host_scores_exploration", attempts: 1}
+
+if hadData:
+    return Decision{Reason: "host_scores_no_candidate"}  # decisive: nobody beats primary
+
+return Decision{Reason: "host_scores_no_data"}           # cold start, group_size≤1, quarantine
+```
+
+Cap on `accepted` is `PairwiseMaxProactiveAttempts` (3). Possible `reason`
+values for `host_score` policy:
+
+| `reason` | `RunSecondary` | Meaning |
+|---|---|---|
+| `host_scores` | true | confident score-based pick |
+| `host_scores_exploration` | true | ε-greedy fired (random candidate; the cold-start bootstrap mechanism) |
+| `host_scores_no_candidate` | false | had data, nobody beat primary by margin |
+| `host_scores_no_data` | false | cold start, all quarantined, `group_size ≤ 1`, etc. |
+
+## Regime change & recovery
+
+The formula above is built for *steady-state* speed differences. Two
+mechanisms protect it from the failure mode where a host changes regime
+(was slow, became fast — or vice versa) and the algorithm refuses to notice.
+
+### Elo time-decay
+
+Without intervention, an Elo rating set 10 days ago is treated identically
+to one set 10 minutes ago — there is no time-component in the K-update
+formula. A host that drifted to 1200 over a week and then quietly improved
+would need dozens of `decideHostScoreSpeedup`-triggered races just to climb
+back to neutral, but the same algorithm refuses to *route* to it because
+its stored Elo is still 1200. Self-perpetuating exile.
+
+We pull stored ratings toward `HostScoreEloDefault` on read via a
+half-life decay:
+
+```
+decayed(R, age) = 1500 + (R − 1500) · 2^(−age / HostScoreEloHalfLife)
+```
+
+With `HostScoreEloHalfLife = 12h`:
+
+| Age since last update | Gap multiplier | 1800 → | 1200 → |
+|---|---:|---:|---:|
+| 0 (fresh) | 1.000 | 1800 | 1200 |
+| 6 h | 0.707 | 1712 | 1288 |
+| 12 h (one half-life) | 0.500 | 1650 | 1350 |
+| 24 h | 0.250 | 1575 | 1425 |
+| 48 h | 0.063 | 1519 | 1481 |
+| 96 h | 0.004 | 1501 | 1499 |
+
+This applies on every read (`ScoreHost`, `Snapshot`) *and* before every
+write in `updateEloLocked` — so the K-update is applied to the
+*time-adjusted* rating, not the stale one. Persisted state carries
+`UpdatedAt` per row so decay survives restart.
+
+Set `HostScoreEloHalfLife = 0` to disable entirely.
+
+### ε-greedy exploration floor
+
+UCB ([Layer 2.3](#layer-23--ucb-exploration-bonus)) shrinks logarithmically:
+once a host has 50 samples its bonus is tiny (≈ 200 ms in a normal bucket),
+which is not enough to dislodge an Elo favourite with a 5+-second
+advantage. So purely UCB-based exploration doesn't help once a host is
+"established mediocre."
+
+The ε-greedy floor adds a small unconditional exploration budget. When
+`decideHostScoreSpeedup` would otherwise return *no* secondary (neither
+H2H nor score-based justifies it), it rolls one random number: with
+probability `HostScoreExplorationEpsilon` it launches *one* candidate
+anyway, tagged `reason="host_scores_exploration"`.
+
+| Setting | Behavior |
+|---|---|
+| ε = 0 | exploration disabled; pure score-based routing |
+| ε = 0.05 (default) | ≈ 1 in 20 ambivalent decisions becomes a forced race; Elo evolves |
+| ε = 1.0 | always race when score is ambivalent (useful for tests) |
+
+The cost is one extra inference per 20 ambivalent decisions. The benefit
+is that recently-improved hosts get races, win them, and climb out of low
+Elo within hours instead of days.
+
+### Putting both together
+
+A host that was slow for 10 days, then becomes fastest:
+
+1. **Hour 0** of regime change: Elo ≈ 1200, ring full of slow samples.
+   Decay hasn't kicked in (last race was minutes ago).
+2. **Hours 0-12**: ε-greedy occasionally routes to it. Each win is a real
+   K-update on its decayed (still 1200-ish) Elo: `K · (1 − E)` where
+   `E ≈ 0.15` → ≈ +13.6 per win. Slow but steady climb.
+3. **Hours 12+ without traffic** (between rare ε-greedy races): decay
+   half-life kicks in. After 24 hours of low traffic, the 300-point gap
+   has halved to 150. Now ε-greedy wins yield larger Elo updates
+   (`E ≈ 0.30` → +11.2 per win, but starting from 1350 instead of 1200).
+4. **Within 1-3 days**: enough wins accumulated for the ring to refresh
+   too, and the host promotes back to score-based routing without ε-greedy
+   help.
+
+Decay alone protects against complete exile; ε-greedy alone keeps races
+flowing; both together compress recovery from days to hours.
+
+## Observability
+
+`GET /v1/admin/host_scores` (admin-auth-gated; optional `?model=` and
+`?bucket=` filters):
+
+```json
+{
+  "snapshots": [
+    {
+      "model": "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
+      "host":  "gonka1...",
+      "bucket": "1k_5k",
+      "samples": 26,
+      "bucket_total_samples": 56,
+      "ttft_p50_ms": 843, "ttft_p90_ms": 1240,
+      "total_p50_ms": 8203, "total_p90_ms": 14500,
+      "elo": 1628.4,
+      "ucb_bonus_ms": 117.6,
+      "score_stream": 5921.2,
+      "score_non_stream": 7967.8
+    }, ...
+  ],
+  "generated_at": "2026-05-24T...",
+  "settings": { ... all tunables ... }
+}
+```
+
+What to look at on a live node:
+
+- **Elo spread within a bucket.** Two hosts with 200+ point separation
+  after ≥ 20 samples each is a strong signal; under 100 is noise.
+- **`bucket_total_samples` and per-host `samples`.** If one host is
+  dominating sample volume (>80% of bucket total), the picker is
+  effectively single-host on this shape — exploration is doing nothing
+  because there's no alternative.
+- **`ucb_bonus_ms` distribution.** Should be near-zero for established
+  hosts and 200-800 ms for hosts with < 10 samples.
+- **`score_stream` vs `score_non_stream`.** Diverge meaningfully only
+  when TTFT and Total differ greatly. If they're identical → γ is doing
+  nothing on this workload (legitimate; just means TTFT and Total are
+  proportional).
+
+## Persistence and restart
+
+`HostScoreTracker.PersistState` and `Restore` round-trip the full state
+through SQLite table `host_score_state` (schema in
+[`perfstore.go`](../cmd/devshardctl/perfstore.go)). Each row stores the
+full sample ring as a JSON blob plus the Elo rating and an `updated_at_utc`
+timestamp marking when that rating was last K-updated.
+
+`updated_at_utc` is what makes time-decay survive restart: on `Restore`
+we seed `eloUpdatedAt[key]` from this column, so the decay clock keeps
+ticking across shutdowns rather than resetting to "now". A node that
+sleeps for 24 h boots up with already-half-decayed ratings on first read.
+
+Flush schedule:
+- Periodic every `hostScoreFlushInterval = 2 min` (background goroutine
+  `hostScoreFlushLoop`)
+- Once on `Gateway.Close()` for clean shutdown
+
+Restore happens once in `PerfTracker.loadFromStore` at startup before any
+new sample is recorded.
+
+## Related
+
+- [host-health.md](host-health.md) — quarantine and perf tracking
+- [proxy-architecture.md](proxy-architecture.md) — where this fits in
+- [`2026-05-24-stats.md`](../../docs/chat-api/2026-05-24-stats.md) —
+  production capture analysis that motivated this work
+- [`2026-05-24-formulas.md`](../../docs/chat-api/2026-05-24-formulas.md)
+  — formula search and selection
+- [`2026-05-24-formulas-impl.md`](../../docs/chat-api/2026-05-24-formulas-impl.md)
+  — Phase 1 / Phase 2 implementation plan
+

--- a/docs/chat-api/kimi-k2.6.md
+++ b/docs/chat-api/kimi-k2.6.md
@@ -8,7 +8,8 @@ Provider: Moonshot AI. This doc documents how Kimi-K2.6 deviates from the [unive
 |----------|-------|--------|
 | Provider | Moonshot AI | [[Moonshot-1]](references.md#moonshot) |
 | vLLM route id | `moonshotai/Kimi-K2.6` | — |
-| Context window | 256K tokens | [[Moonshot-2]](references.md#moonshot) |
+| Native context window | 256K tokens | [[Moonshot-2]](references.md#moonshot) |
+| **Deployed context limit** | **240,000 tokens** (via `--max-model-len`) | on-chain `Model.ModelArgs` ([v0_2_12/upgrades.go:686](../../inference-chain/app/upgrades/v0_2_12/upgrades.go#L686)) |
 | Tool-call parser (vLLM) | `kimi_k2` | [[vLLM-1]](references.md#vllm) |
 | Native thinking | yes (via `chat_template_kwargs.thinking`) | [[Moonshot-3]](references.md#moonshot) |
 

--- a/docs/chat-api/qwen3-235b-a22b-instruct-2507.md
+++ b/docs/chat-api/qwen3-235b-a22b-instruct-2507.md
@@ -8,7 +8,8 @@ Provider: Alibaba (Qwen). This doc documents how Qwen3-235B-A22B-Instruct-2507 d
 |----------|-------|--------|
 | Provider | Alibaba (Qwen) | [[Qwen-1]](references.md#qwen) |
 | vLLM route id | `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` | — |
-| Context window | 128K tokens | [[Qwen-1]](references.md#qwen) |
+| Native context window | 128K tokens | [[Qwen-1]](references.md#qwen) |
+| **Deployed context limit** | **240,000 tokens** (via `--max-model-len`) | on-chain `Model.ModelArgs` ([v0_2_10/upgrades.go:241](../../inference-chain/app/upgrades/v0_2_10/upgrades.go#L241)) |
 | Tool-call parser (vLLM) | `hermes` | [[vLLM-1]](references.md#vllm) |
 | Native thinking | no (Instruct variant; thinking-capable Qwen3-Thinking variant uses `chat_template_kwargs.enable_thinking`) | [[Qwen-3]](references.md#qwen) |
 


### PR DESCRIPTION
## Summary

Add `host_score` speed policy — an Elo-driven secondary-host selector that replaces per-host pairwise heuristics with a global, decay-aware rating updated by every observed race. On production-like traffic (1,970 Qwen3-235B requests replayed against a 14-host cluster, 6 input-size buckets, 1,371 `host_score` decisions) it:

- wins the **TTFT** race **84.4%** of the time vs **78.3%** on `pairwise` (+6.1 pp; up to +22.1 pp on the largest bucket).
- wins the **TOTAL** race **67.5%** of the time vs **47.0%** on `pairwise` (+20.5 pp; up to +34.7 pp on the largest bucket).
- cuts user-facing latency overall: **TTFT p50 1.3 s vs 8.2 s (6×)**, **p90 3.1 s vs 86.5 s (28×)**, **max 24.6 s vs 271.7 s (11×)**. Total: **p50 8.8 s vs 11.7 s**, **p90 63.3 s vs 106.3 s**.
- corrects mis-ranked hosts: a host with p50 TTFT of 78 s was ranked top-1 in 5 of 6 buckets under the old heuristic and is now consistently bottom-rank; a host with p50 TTFT of 600 ms was bottom in 5 of 6 buckets and is now top-1 in 5 of 6.

Algorithm + full design rationale in `docs/host-scoring.md`.

Rollout: **off by default** — existing deployments keep their `speed_policy` (`hybrid` / `pairwise` / `legacy`). Per-runtime opt-in via the admin settings endpoint; the policy can be flipped back at runtime with one PATCH.

---

## Problem → Solution

The legacy speed policies (`legacy`, `hybrid`, `pairwise`) decide whether to fire a speculative secondary using only the last few **direct** pairwise matchups between candidate hosts. Three weaknesses surfaced in production; each is addressed by a specific component of the new `host_score` policy.

### 1. Cold-start exile

**Before.** A new host that lost its first race had H2H win-rate 0 % against the host that beat it, so it never passed the `H2HMargin` gate again — exiled from secondary selection until it accidentally won a race against someone else. New hardware additions, recovered participants and previously-faulty hosts that came back never got a chance to prove themselves.

**After.** `host_score` adds a **UCB exploration bonus** `c·√(ln N_bucket / n_host)` (default `c = 300 ms`) which is subtracted from the score. A host with 3 samples in a bucket of 200 total samples gets a credit of ~921 ms — enough to make it competitive with an established host. The credit shrinks logarithmically as samples accumulate (≈226 ms at n=50, 0 at saturation). A **5 % ε-greedy floor** acts as a backup: 1 in 20 secondary firings goes to a non-top candidate regardless of score.

### 2. No global ranking

**Before.** The H2H gate only knew direct matchups. If host A had never been paired with host C, there was no way to compare them — even if both had a long history against host B.

**After.** Every observed race updates a **per-(model, host, bucket) Elo rating**. Each host carries a global "strength" number inside its bucket; if A beats B and B beats C, A is transitively rated above C without ever racing it directly. After ~50 races in a bucket all hosts in that bucket have comparable Elo within ±200 points of their steady-state.

### 3. Noise-vs-signal

**Before.** Binary win/loss. A 1 ms lead on a 100-second generation counted the same as a 10× speed difference, so slow hosts could climb the ranking on pure measurement noise. We hit this in production: a host with p50 TTFT 78 s was ranked top-1 in 4 of 6 buckets despite the gateway never returning it as the winner (`winner` flag = 0 across 33 races). Selection used different math and correctly skipped it, but the ranking signal itself was wrong and the algorithm could not penalise the host through it.

**After.** Pair outcomes use a **Bradley-Terry continuous score** `Sa = mb^k / (ma^k + mb^k)` (`k = 2`):

| ratio (A faster) |     Sa |    Elo move (K/2 = 8) |
| ---------------: | -----: | --------------------: |
|           1.001x | 0.5005 | ~0 — noise suppressed |
|             1.1x |   0.55 |                  tiny |
|               2x |   0.80 |                 clear |
|              10x |   0.99 |              decisive |
|             100x | 0.9999 |             saturated |

Large real differences move Elo a lot; sub-noise differences move it nothing. Empirically: on a re-replay of the same production traffic the broken-host ranking collapses from top-1 to bottom of every bucket (see _Per-host ranking corrections_ below).

---

## Algorithm

`score = (1−γ)·TTFT_p50 + γ·Total_p50 − α·(Elo − 1500) − UCB_bonus`

Four ingredients, applied in order:

1. **Layer 1 — direct H2H gate.** If we have ≥`MinSamples` direct matchups between candidate B and primary A and B wins ≥`0.5 + margin` of them, return `1 − rate` (overrides Elo).
2. **Layer 2.1 — base timing.** Weighted average of TTFT and Total p50s (per model + bucket), with `γ` favouring TTFT for streaming, Total for non-streaming.
3. **Layer 2.2 — Elo credit.** Per-(model, host, bucket) Elo updated from every observed race; `α` converts Elo points to milliseconds so the credit subtracts cleanly from the base. 12-hour exponential decay pulls stale ratings toward the 1500 default.
4. **Layer 2.3 — UCB exploration bonus.** `c·√(ln N_bucket / n_host)` subtracted from the score so under-sampled hosts get a chance to prove themselves.

A secondary fires when candidate score ≤ primary score × (1 − margin), with a 5% ε-greedy floor for forced exploration when the gap is small.

### Three less-obvious technical choices

**Dual-metric Elo with K/2 per dimension.** Per pair we run two K=8 updates — one keyed on TTFT, one on Total — so the K-budget per pair stays at the documented K=16. The selection score combines both metrics via γ; the ranking must reflect both. Single-metric Elo on TTFT alone would miss hosts with great first-token latency but terrible throughput.

**Bradley-Terry continuous outcome** instead of binary win/loss:

```
Sa = mb^k / (ma^k + mb^k)   // k = 2
```

- ratio 1.0 (tie) → Sa = 0.50 (no Elo move)
- ratio 1.1 → Sa ≈ 0.55 (tiny move)
- ratio 2.0 → Sa = 0.80 (clear win)
- ratio 10.0 → Sa ≈ 0.99 (decisive)

Same statistical pedigree as Elo itself (Zermelo 1929, Bradley & Terry 1952). Naturally suppresses sub-noise margins, which is critical on streaming where 4 hosts can finish within 0.3 % of each other on a 4-minute generation. Without it a slow host can accumulate Elo "wins" just by beating opponents by 1 ms on minute-long races — empirically reproduced on prod data before the fix.

**Per-host TotalTimeMs.** The Total metric was previously computed as `time.Since(sendTime)` at the end of the request, which meant every host in a race received the same value (differing only by the ~100 ms `sendTime` offset between primary and secondary). Within-race Total spread on prod was 0.30 % (p50) — pure noise. Fixed by reading `lastChunkAt` per host, captured at every chunk arrival. Within-race spread jumps to 244 % (p50): the Total dimension now carries real signal. Cancelled losers are still gated out of the Total Elo update via the existing `Finished` filter, so the "loser-was-cut-off-early-so-its-Total-looks-better" failure mode does not affect Elo math.

**Unresponsive hosts penalised.** Previously they were filtered out of Elo entirely, which let a host that fails 20 % of the time accumulate "wins" on the 80 % it does respond. Now failed hosts lose Elo against responders (`Sa = 0`); two-way failure penalises both (`Sa = Sb = 0`, each loses K·E_self toward the 1500 default).

---

## Validation

### Methodology

- 2 × (5 × 197) = 1,970 replayed requests against a freshly-funded escrow, c=10, cache-busted per iteration (UUID injected at `messages[0]`); 0 errors across both runs.
- The `host_score` policy produced **98.5 %** of decisions in the loop window (1,371 `host_scores` fired races + 498 `host_scores_no_candidate` no-race + 22 `host_scores_exploration` + 18 `host_scores_no_data`); 30 `primary_unresponsive` fallbacks (1.5 %).
- Pick% comparison uses the 1,371 fired-race decisions. "Pick %" = winner had min(metric) across all hosts in the race that produced the metric.
- Baseline: same metric methodology on the existing `pairwise` policy from a sibling node's perf snapshots (6 escrows × 4096 reqs each, de-duped).

### TTFT pick % — race-winner criterion used by the gateway

| bucket   | `host_score` |  `pairwise` |        Δ |
| -------- | -----------: | ----------: | -------: |
| lt_4k    |       83.2 % |      82.4 % |     +0.8 |
| 4k_16k   |       78.8 % |      82.3 % |     −3.5 |
| 16k_64k  |   **85.5 %** |      78.0 % |  **+7.5** |
| 64k_100k |       82.8 % |      78.0 % |     +4.8 |
| gte_100k |   **91.2 %** |      69.1 % | **+22.1** |
| **ALL**  |   **84.4 %** |  **78.3 %** |  **+6.1** |

Largest gain on `gte_100k` where TTFT differences amount to tens of seconds. The small Δ flip on `4k_16k` is the expected effect of incorporating Total information into Elo — the TTFT-optimal host is sometimes not the Total-optimal one and the score formula weights both.

### TOTAL pick % — after per-host TotalTimeMs fix

| bucket   | `host_score` |  `pairwise` |        Δ |
| -------- | -----------: | ----------: | -------: |
| lt_4k    |       75.8 % |      41.1 % |    +34.7 |
| 4k_16k   |       69.6 % |      51.4 % |    +18.2 |
| 16k_64k  |       62.3 % |      53.4 % |     +8.9 |
| 64k_100k |       67.9 % |      37.0 % |    +30.9 |
| gte_100k |   **72.7 %** |      38.2 % | **+34.5** |
| **ALL**  |   **67.5 %** |  **47.0 %** | **+20.5** |

Median Δ (winner − best loser, ms) on TOTAL flips sign with the per-host TotalTimeMs fix: +1083 ms with `host_score` (winner is genuinely faster) vs −237 ms under the pre-fix metric on the same gateway (the "loser" appeared faster — a measurement artifact, not a real outcome).

### User-facing latency distribution

What the client actually waits for = the **winner's** `first_token_ms` (time before any output appears) and `total_time_ms` (full response). Percentiles taken across each policy's winner samples per bucket.

**TTFT (time-to-first-token):**

| bucket   | `host_score` p50 | `host_score` p90 | `host_score` max | `pairwise` p50 | `pairwise` p90 | `pairwise` max |
| -------- | ---------------: | ---------------: | ---------------: | -------------: | -------------: | -------------: |
| lt_4k    |        **0.8 s** |        **1.2 s** |        **1.9 s** |          5.2 s |         22.2 s |        125.8 s |
| 4k_16k   |        **0.9 s** |        **1.6 s** |        **2.7 s** |          5.6 s |         20.7 s |        265.9 s |
| 16k_64k  |        **1.4 s** |        **2.1 s** |        **4.7 s** |         29.4 s |         99.7 s |        174.1 s |
| 64k_100k |        **2.8 s** |        **3.3 s** |        **3.8 s** |         50.2 s |         91.6 s |        200.1 s |
| gte_100k |        **5.1 s** |       **21.6 s** |       **24.6 s** |          8.9 s |         92.7 s |        271.7 s |
| **ALL**  |        **1.3 s** |        **3.1 s** |       **24.6 s** |          8.2 s |         86.5 s |        271.7 s |

`host_score` overall: **6.3× lower p50, 28× lower p90, 11× lower max** TTFT. Largest gain on `16k_64k` where most production traffic lands (p90 47× lower: 2.1 s vs 99.7 s).

**TOTAL (full response):**

| bucket   | `host_score` p50 | `host_score` p90 | `host_score` max | `pairwise` p50 | `pairwise` p90 | `pairwise` max |
| -------- | ---------------: | ---------------: | ---------------: | -------------: | -------------: | -------------: |
| lt_4k    |        **3.5 s** |       **11.4 s** |       **81.0 s** |          5.9 s |         70.5 s |        300.6 s |
| 4k_16k   |        **5.0 s** |       **15.4 s** |       **54.9 s** |          6.9 s |         76.0 s |        301.9 s |
| 16k_64k  |       **21.1 s** |       **75.6 s** |      **298.6 s** |         38.8 s |        107.8 s |        405.7 s |
| 64k_100k |        **7.5 s** |       **67.8 s** |       **89.5 s** |         54.9 s |        117.1 s |        342.6 s |
| gte_100k |       **12.5 s** |       **80.5 s** |      **278.7 s** |         16.2 s |        183.3 s |        482.5 s |
| **ALL**  |        **8.8 s** |       **63.3 s** |      **298.6 s** |         11.7 s |        106.3 s |        482.5 s |

`host_score` overall: **1.3× lower p50, 1.7× lower p90, 1.6× lower max** TOTAL. The `host_score` TOTAL numbers are only meaningful once the per-host TotalTimeMs fix is in (otherwise the winner's Total approximately matches gateway-lifecycle and the per-host comparison degenerates) — see the algorithm section above.

### Within-race Total spread — proof the TotalTimeMs fix lands real signal

p50 of `max(host.Total) − min(host.Total)` across hosts in a race, for races where ≥2 hosts have `Finished=true`:

|                                    |       abs p50 |      relative p50 |
| ---------------------------------- | ------------: | ----------------: |
| OLD (`time.Since(sendTime)`)       |        133 ms | 0.30 % ← artifact |
| **NEW (`lastChunkAt − sendTime`)** | **14 993 ms** |  **169 %** ← real |
| `pairwise` baseline                |          6 ms |            0.04 % |

Without this fix the dual-metric Elo would receive ~0 signal on the Total dimension in homogeneous clusters — every Bradley-Terry pair outcome would collapse to Sa ≈ 0.5.

---

## Configuration

Defaults; all marked `var` so they can be tuned at runtime without a rebuild:

| parameter                     |    default | knob if you want to …                          |
| ----------------------------- | ---------: | ---------------------------------------------- |
| `HostScoreWindowSize`         |         50 | larger → more stable p50s, slower reaction     |
| `HostScoreMinSamples`         |          3 | raise to gate-out cold hosts more aggressively |
| `HostScoreEloK`               |         16 | raise → faster convergence, more noise         |
| `HostScoreEloAlpha`           | 10 ms / pt | raise → Elo dominates timing more              |
| `HostScoreEloHalfLife`        |       12 h | shorter → faster recovery, more drift          |
| `HostScoreUCBCoefficient`     |     300 ms | raise → more exploration credit for cold hosts |
| `HostScoreBradleyTerryExp`    |          2 | raise → sharper ratio→outcome curve            |
| `HostScoreStreamGamma`        |        0.3 | TTFT/Total weighting for streaming             |
| `HostScoreSpeedupMargin`      |       0.10 | candidate must be ≥10 % faster to fire         |
| `HostScoreExplorationEpsilon` |       0.05 | 5 % forced exploration                         |

---

## Observability

- `GET /v1/admin/host_scores` (authenticated) returns the full snapshot: per-(model, host, bucket) Elo, sample count, TTFT/Total p50/p90, UCB bonus, computed `ScoreStream` and `ScoreNonStream`.
- Decision reason codes surfaced in the request log: `host_scores`, `host_scores_exploration`, `host_scores_no_candidate`, `host_scores_no_data`.
- Snapshot is persisted to SQLite; restart loads it and skips the request-log replay if state is present.

---

## Rollout

- **Default unchanged** — `speed_policy = "hybrid"` continues to use the legacy pairwise heuristic. Existing deployments are not affected.
- **Per-runtime opt-in** via admin settings:
  ```
  PATCH /v1/admin/settings
  { "redundancy": { "speed_policy": "host_score" } }
  ```
- **One-line rollback** — flip the policy back to `"hybrid"`, `"pairwise"`, or `"legacy"` and the algorithm stops contributing (state is preserved for re-enabling).
- **Time-decay** (12 h half-life) ensures stale ratings drift back toward 1500 if a host's behaviour changes (hardware upgrade, fault recovery).

---

## Test plan

- [x] `go test ./...` — full suite green
- [x] Cold start on a fresh runtime → host_score state empty, gates skip until `MinSamples` reached, then start firing
- [x] Restart with persisted state → restore loads, replay skipped
- [x] Patch `speed_policy` to `"host_score"` via admin endpoint and verify the decision-reason distribution flips from `secondary_faster` / `pairwise_*` to `host_scores*`
