### PR TITLE
fix: bound finish cost before invalidation refund

### DIFF
--- a/inference-chain/x/inference/calculations/inference_state.go
+++ b/inference-chain/x/inference/calculations/inference_state.go
@@ -69,6 +69,13 @@ func ProcessStartInference(
 			PerTokenPrice: existingPerTokenPrice,
 		}
 	}
+	maxTokens := getMaxTokens(startMessage)
+	if currentInference.FinishedProcessed() {
+		if err := validateFinishedTokenCountsAgainstStart(currentInference, startMessage, maxTokens); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// Works if FinishInference came before
 	currentInference.RequestTimestamp = startMessage.RequestTimestamp
 	currentInference.TransferredBy = startMessage.Creator
@@ -82,7 +89,7 @@ func ProcessStartInference(
 	currentInference.Model = startMessage.Model
 	currentInference.StartBlockHeight = blockContext.BlockHeight
 	currentInference.StartBlockTimestamp = blockContext.BlockTimestamp
-	currentInference.MaxTokens = getMaxTokens(startMessage)
+	currentInference.MaxTokens = maxTokens
 	currentInference.AssignedTo = startMessage.AssignedTo
 	currentInference.NodeVersion = startMessage.NodeVersion
 
@@ -106,6 +113,26 @@ func ProcessStartInference(
 	}
 
 	return currentInference, payments, nil
+}
+
+func validateFinishedTokenCountsAgainstStart(currentInference *types.Inference, startMessage *types.MsgStartInference, maxTokens uint64) error {
+	if currentInference.CompletionTokenCount > maxTokens {
+		return sdkerrors.Wrapf(
+			types.ErrTokenCountOutOfRange,
+			"completion_token_count exceeds start max_tokens (%d > %d)",
+			currentInference.CompletionTokenCount,
+			maxTokens,
+		)
+	}
+	if startMessage.PromptTokenCount != 0 && currentInference.PromptTokenCount != 0 && currentInference.PromptTokenCount != startMessage.PromptTokenCount {
+		return sdkerrors.Wrapf(
+			types.ErrTokenCountOutOfRange,
+			"prompt_token_count mismatch: finish=%d start=%d",
+			currentInference.PromptTokenCount,
+			startMessage.PromptTokenCount,
+		)
+	}
+	return nil
 }
 
 func setEscrowForFinished(currentInference *types.Inference, escrowAmount int64, payments *Payments) error {
@@ -175,6 +202,9 @@ func ProcessFinishInference(
 	actualCost, err := CalculateCost(currentInference)
 	if err != nil {
 		return nil, nil, err
+	}
+	if currentInference.StartProcessed() && actualCost > currentInference.EscrowAmount {
+		actualCost = currentInference.EscrowAmount
 	}
 	currentInference.ActualCost = actualCost
 	if currentInference.StartProcessed() {

--- a/inference-chain/x/inference/calculations/inference_state_test.go
+++ b/inference-chain/x/inference/calculations/inference_state_test.go
@@ -359,6 +359,54 @@ func TestProcessStartInference(t *testing.T) {
 			expectError:    false,
 			expectedStatus: types.InferenceStatus_STARTED,
 		},
+		{
+			name: "Finished inference completion exceeds start max tokens",
+			currentInference: &types.Inference{
+				InferenceId:          "test-id",
+				ExecutedBy:           "executor",
+				PromptTokenCount:     1,
+				CompletionTokenCount: 1_000_000,
+			},
+			startMessage: &types.MsgStartInference{
+				InferenceId:      "test-id",
+				PromptHash:       "hash",
+				PromptTokenCount: 1,
+				RequestedBy:      "requester",
+				Model:            "model",
+				MaxTokens:        1,
+				AssignedTo:       "assignee",
+				NodeVersion:      "1.0",
+			},
+			blockContext: BlockContext{
+				BlockHeight:    100,
+				BlockTimestamp: 1000,
+			},
+			expectError: true,
+		},
+		{
+			name: "Finished inference prompt mismatches nonzero start prompt",
+			currentInference: &types.Inference{
+				InferenceId:          "test-id",
+				ExecutedBy:           "executor",
+				PromptTokenCount:     20,
+				CompletionTokenCount: 1,
+			},
+			startMessage: &types.MsgStartInference{
+				InferenceId:      "test-id",
+				PromptHash:       "hash",
+				PromptTokenCount: 10,
+				RequestedBy:      "requester",
+				Model:            "model",
+				MaxTokens:        10,
+				AssignedTo:       "assignee",
+				NodeVersion:      "1.0",
+			},
+			blockContext: BlockContext{
+				BlockHeight:    100,
+				BlockTimestamp: 1000,
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -392,6 +440,37 @@ func TestProcessStartInference(t *testing.T) {
 			assert.Equal(t, tt.startMessage.NodeVersion, inference.NodeVersion)
 		})
 	}
+}
+
+func TestProcessFinishInference_CapsActualCostToEscrowWhenStarted(t *testing.T) {
+	mockLogger := &MockInferenceLogger{}
+	currentInference := &types.Inference{
+		InferenceId:      "test-id",
+		AssignedTo:       "executor",
+		PromptTokenCount: 1,
+		MaxTokens:        1,
+		EscrowAmount:     2 * PerTokenCost,
+		PerTokenPrice:    PerTokenCost,
+	}
+	finishMessage := &types.MsgFinishInference{
+		InferenceId:          "test-id",
+		ResponseHash:         "hash",
+		PromptTokenCount:     1_000_000,
+		CompletionTokenCount: 1_000_000,
+		ExecutedBy:           "executor",
+	}
+
+	inference, payments, err := ProcessFinishInference(
+		currentInference,
+		finishMessage,
+		BlockContext{BlockHeight: 100, BlockTimestamp: 1000},
+		mockLogger,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2*PerTokenCost), inference.ActualCost)
+	assert.Equal(t, int64(2*PerTokenCost), payments.ExecutorPayment)
+	assert.Zero(t, payments.EscrowAmount)
 }
 
 func TestProcessFinishInference(t *testing.T) {

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference.go
@@ -97,6 +97,10 @@ func (k msgServer) FinishInference(goCtx context.Context, msg *types.MsgFinishIn
 			k.LogError("FinishInference: model field mismatch", types.Inferences, "error", err, "inferenceId", msg.InferenceId)
 			return failedFinish(ctx, err, msg), nil
 		}
+		if err := k.validateFinishTokenCounts(msg, &existingInference); err != nil {
+			k.LogError("FinishInference: token count exceeds start bounds", types.Inferences, "error", err, "inferenceId", msg.InferenceId)
+			return failedFinish(ctx, err, msg), nil
+		}
 		k.LogDebug("FinishInference: cryptographic signature verification skipped; dev and TA components compared for consistency", types.Inferences, "inferenceId", msg.InferenceId)
 	} else {
 		err := k.verifyFinishKeys(ctx, msg, transferAgent.Address, devAddress)
@@ -302,6 +306,30 @@ func (k msgServer) compareFinishModelField(msg *types.MsgFinishInference, infere
 			"model mismatch: finish=%s start=%s",
 			msg.Model,
 			inference.Model,
+		)
+	}
+	return nil
+}
+
+func (k msgServer) validateFinishTokenCounts(msg *types.MsgFinishInference, inference *types.Inference) error {
+	maxTokens := inference.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = calculations.DefaultMaxTokens
+	}
+	if msg.CompletionTokenCount > maxTokens {
+		return sdkerrors.Wrapf(
+			types.ErrTokenCountOutOfRange,
+			"completion_token_count exceeds start max_tokens (%d > %d)",
+			msg.CompletionTokenCount,
+			maxTokens,
+		)
+	}
+	if inference.PromptTokenCount != 0 && msg.PromptTokenCount != 0 && msg.PromptTokenCount != inference.PromptTokenCount {
+		return sdkerrors.Wrapf(
+			types.ErrTokenCountOutOfRange,
+			"prompt_token_count mismatch: finish=%d start=%d",
+			msg.PromptTokenCount,
+			inference.PromptTokenCount,
 		)
 	}
 	return nil

--- a/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_finish_inference_test.go
@@ -171,6 +171,64 @@ func TestMsgServer_FinishInference(t *testing.T) {
 
 }
 
+func TestMsgServer_FinishInference_RejectsCompletionTokenCountAboveStartMax(t *testing.T) {
+	inferenceHelper, k, _ := NewMockInferenceHelper(t)
+	requestTimestamp := inferenceHelper.context.BlockTime().UnixNano()
+
+	modelID := "model1"
+	k.SetModel(inferenceHelper.context, &types.Model{Id: modelID})
+
+	_, err := inferenceHelper.StartInference("promptPayload", modelID, requestTimestamp, 1)
+	require.NoError(t, err)
+
+	inferenceHelper.Mocks.AccountKeeper.EXPECT().HasAccount(gomock.Any(), inferenceHelper.MockRequester.GetBechAddress()).Return(true).AnyTimes()
+	inferenceHelper.Mocks.AccountKeeper.EXPECT().GetAccount(gomock.Any(), inferenceHelper.MockRequester.GetBechAddress()).Return(inferenceHelper.MockRequester).AnyTimes()
+	inferenceHelper.Mocks.AccountKeeper.EXPECT().HasAccount(gomock.Any(), inferenceHelper.MockTransferAgent.GetBechAddress()).Return(true).AnyTimes()
+	inferenceHelper.Mocks.AccountKeeper.EXPECT().GetAccount(gomock.Any(), inferenceHelper.MockTransferAgent.GetBechAddress()).Return(inferenceHelper.MockTransferAgent).AnyTimes()
+	inferenceHelper.Mocks.AccountKeeper.EXPECT().HasAccount(gomock.Any(), inferenceHelper.MockExecutor.GetBechAddress()).Return(true).AnyTimes()
+	inferenceHelper.Mocks.AccountKeeper.EXPECT().GetAccount(gomock.Any(), inferenceHelper.MockExecutor.GetBechAddress()).Return(inferenceHelper.MockExecutor).AnyTimes()
+	inferenceHelper.EnsureActiveParticipants()
+
+	originalPromptHash := sha256Hash(inferenceHelper.promptPayload)
+	promptHash := inferenceHelper.previousInference.PromptHash
+	taComponents := calculations.SignatureComponents{
+		Payload:         promptHash,
+		Timestamp:       inferenceHelper.previousInference.RequestTimestamp,
+		TransferAddress: inferenceHelper.MockTransferAgent.address,
+		ExecutorAddress: inferenceHelper.MockExecutor.address,
+	}
+	taSignature, err := calculations.Sign(inferenceHelper.MockTransferAgent, taComponents, calculations.TransferAgent)
+	require.NoError(t, err)
+	executorSignature, err := calculations.Sign(inferenceHelper.MockExecutor, taComponents, calculations.ExecutorAgent)
+	require.NoError(t, err)
+
+	resp, err := inferenceHelper.MessageServer.FinishInference(inferenceHelper.context, &types.MsgFinishInference{
+		Creator:              inferenceHelper.MockExecutor.address,
+		InferenceId:          inferenceHelper.previousInference.InferenceId,
+		ResponseHash:         "responseHash",
+		ResponsePayload:      "responsePayload",
+		PromptTokenCount:     0,
+		CompletionTokenCount: 2,
+		ExecutedBy:           inferenceHelper.MockExecutor.address,
+		TransferredBy:        inferenceHelper.MockTransferAgent.address,
+		RequestTimestamp:     inferenceHelper.previousInference.RequestTimestamp,
+		TransferSignature:    taSignature,
+		ExecutorSignature:    executorSignature,
+		RequestedBy:          inferenceHelper.MockRequester.address,
+		OriginalPrompt:       inferenceHelper.promptPayload,
+		Model:                inferenceHelper.previousInference.Model,
+		PromptHash:           promptHash,
+		OriginalPromptHash:   originalPromptHash,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.ErrorMessage, types.ErrTokenCountOutOfRange.Error())
+
+	savedInference, found := k.GetInference(inferenceHelper.context, inferenceHelper.previousInference.InferenceId)
+	require.True(t, found)
+	require.Equal(t, types.InferenceStatus_STARTED, savedInference.Status)
+}
+
 func TestMsgServer_FinishInference_UpdatesExecutorOnceOnCompletion(t *testing.T) {
 	inferenceHelper, k, _ := NewMockInferenceHelper(t)
 	requestTimestamp := inferenceHelper.context.BlockTime().UnixNano()

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference.go
@@ -62,20 +62,35 @@ func (k msgServer) InvalidateInference(ctx context.Context, msg *types.MsgInvali
 }
 
 func (k msgServer) refundInvalidatedInference(executor *types.Participant, inference *types.Inference, ctx context.Context) error {
+	refundAmount, err := invalidatedInferenceRefundAmount(inference)
+	if err != nil {
+		return err
+	}
+
 	// Attempt refund BEFORE modifying executor balance.
 	// If refund fails (e.g. underfunded escrow), don't corrupt state.
-	err := k.IssueRefund(ctx, inference.ActualCost, inference.RequestedBy, "invalidated_inference:"+inference.InferenceId)
+	err = k.IssueRefund(ctx, refundAmount, inference.RequestedBy, "invalidated_inference:"+inference.InferenceId)
 	if err != nil {
 		k.LogError("Refund failed", types.Validation, "error", err)
 		return err
 	}
 
 	// Only deduct from executor after successful refund
-	executor.CoinBalance -= inference.ActualCost
-	k.SafeLogSubAccountTransaction(ctx, types.ModuleName, executor.Address, types.OwedSubAccount, inference.ActualCost, "invalidated_inference:"+inference.InferenceId)
-	k.LogInfo("Invalid Inference subtracted from Executor CoinBalance ", types.Balances, "inferenceId", inference.InferenceId, "executor", executor.Address, "actualCost", inference.ActualCost, "coinBalance", executor.CoinBalance)
+	executor.CoinBalance -= refundAmount
+	k.SafeLogSubAccountTransaction(ctx, types.ModuleName, executor.Address, types.OwedSubAccount, refundAmount, "invalidated_inference:"+inference.InferenceId)
+	k.LogInfo("Invalid Inference subtracted from Executor CoinBalance ", types.Balances, "inferenceId", inference.InferenceId, "executor", executor.Address, "actualCost", inference.ActualCost, "refundAmount", refundAmount, "coinBalance", executor.CoinBalance)
 
 	return nil
+}
+
+func invalidatedInferenceRefundAmount(inference *types.Inference) (int64, error) {
+	if inference.ActualCost < 0 {
+		return 0, errorsmod.Wrapf(types.ErrIllegalState, "inference %s has negative actual cost %d", inference.InferenceId, inference.ActualCost)
+	}
+	if inference.EscrowAmount < 0 {
+		return 0, errorsmod.Wrapf(types.ErrInvalidEscrowAmount, "inference %s has negative escrow amount %d", inference.InferenceId, inference.EscrowAmount)
+	}
+	return min(inference.ActualCost, inference.EscrowAmount), nil
 }
 
 type ValidationDecision interface {

--- a/inference-chain/x/inference/keeper/msg_server_invalidate_inference_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_invalidate_inference_test.go
@@ -81,6 +81,7 @@ func TestInvalidateInference_RefundsRequesterAndChargesExecutor_NoSlash(t *testi
 		RequestedBy:     payerAddr,
 		Status:          types.InferenceStatus_FINISHED,
 		ActualCost:      actualCost,
+		EscrowAmount:    actualCost,
 		ProposalDetails: &types.ProposalDetails{PolicyAddress: payerAddr},
 		EpochId:         1,
 	})
@@ -149,6 +150,7 @@ func TestInvalidateInference_RefundsRequesterAndChargesExecutor_WithSlash(t *tes
 		RequestedBy:     payerAddr,
 		Status:          types.InferenceStatus_FINISHED,
 		ActualCost:      actualCost,
+		EscrowAmount:    actualCost,
 		ProposalDetails: &types.ProposalDetails{PolicyAddress: payerAddr},
 		EpochId:         1,
 	})
@@ -178,6 +180,61 @@ func TestInvalidateInference_RefundsRequesterAndChargesExecutor_WithSlash(t *tes
 	updatedInf, found := k.GetInference(ctx, inferenceID)
 	require.True(t, found)
 	require.Equal(t, types.InferenceStatus_INVALIDATED, updatedInf.Status)
+}
+
+func TestInvalidateInference_CapsRefundAndExecutorChargeToEscrow(t *testing.T) {
+	k, ms, ctx, mocks := setupInvalidateHarness(t)
+
+	params := types.DefaultParams()
+	k.SetParams(ctx, params)
+
+	err := setEffectiveEpoch(ctx, k, 1, mocks)
+	require.NoError(t, err)
+
+	executorAddr := sample.AccAddress()
+	payerAddr := sample.AccAddress()
+
+	initialBalance := int64(1_000)
+	executor := types.Participant{
+		Index:                        executorAddr,
+		Address:                      executorAddr,
+		Status:                       types.ParticipantStatus_ACTIVE,
+		ConsecutiveInvalidInferences: 0,
+		CurrentEpochStats:            &types.CurrentEpochStats{},
+		CoinBalance:                  initialBalance,
+	}
+	k.SetParticipant(ctx, executor)
+
+	payer := types.Participant{Index: payerAddr, Address: payerAddr, CurrentEpochStats: &types.CurrentEpochStats{}}
+	k.SetParticipant(ctx, payer)
+	k.SetActiveParticipants(ctx, ParticipantsToActive(1, payer, executor))
+
+	inferenceID := "refund-capped-to-escrow"
+	actualCost := int64(1_000)
+	escrowAmount := int64(10)
+	k.SetInference(ctx, types.Inference{
+		Index:           inferenceID,
+		InferenceId:     inferenceID,
+		ExecutedBy:      executorAddr,
+		RequestedBy:     payerAddr,
+		Status:          types.InferenceStatus_FINISHED,
+		ActualCost:      actualCost,
+		EscrowAmount:    escrowAmount,
+		ProposalDetails: &types.ProposalDetails{PolicyAddress: payerAddr},
+		EpochId:         1,
+	})
+
+	expectedRefund := sdk.NewCoins(sdk.NewCoin(types.BaseCoin, math.NewInt(escrowAmount)))
+	mocks.BankKeeper.EXPECT().LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	mocks.BankKeeper.EXPECT().SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, gomock.Any(), expectedRefund, gomock.Any()).Return(nil).Times(1)
+	mocks.CollateralKeeper.EXPECT().Slash(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	_, err = ms.InvalidateInference(ctx, &types.MsgInvalidateInference{Creator: payerAddr, InferenceId: inferenceID})
+	require.NoError(t, err)
+
+	updatedExecutor, ok := k.GetParticipant(ctx, executorAddr)
+	require.True(t, ok)
+	require.Equal(t, initialBalance-escrowAmount, updatedExecutor.CoinBalance)
 }
 
 func TestInvalidateInference_NextEpoch_NoRefundNoCharge_NoSlash(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes a critical accounting bug where an executor could submit inflated finish-time token counts, persist an `ActualCost` far above the requester escrow, and then trigger `MsgInvalidateInference` to refund that unescrowed amount from the inference module account.

A requester/executor pair could start an inference with a very small escrow, finish it with token counts up to the hardcoded per-field maximum, and later receive an invalidation refund based on the inflated `ActualCost`. Because module-to-account transfers are allowed, the refund could drain materially more coins than were ever escrowed for that inference. Existing inflated inferences also needed protection before their invalidation path executes.

## Root Cause

`MsgFinishInference` only capped token counts against `MaxAllowedTokens`; it did not bind `CompletionTokenCount` to the start-time `MaxTokens`, and prompt token checks did not prevent finish-time values from feeding payment math. `ProcessFinishInference` then stored the raw calculated cost in `inference.ActualCost` even when the start-side escrow was lower. `refundInvalidatedInference` trusted that stored value directly for both the bank refund and executor debt.

## Fix

- Reject finish-after-start completions that exceed the start-time `MaxTokens`, using the default max for legacy zero-valued state.
- Reject prompt-token mismatches when both start and finish supplied nonzero prompt-token counts.
- Validate finish-before-start token counts when the matching start arrives, so out-of-order flows cannot bypass the start bounds.
- Cap persisted `ActualCost` to `EscrowAmount` whenever the start has already been processed.
- Cap invalidation refunds and executor debits to `min(ActualCost, EscrowAmount)` as defense in depth for already-persisted inflated inferences.

## Why This Closes The Vulnerability

The exploit needs an untrusted finish value to become a real module-bank refund. After this change, finish token counts are checked against start-side bounds when that state exists, and the accounting value consumed by validator sharing and invalidation refunds cannot exceed the amount actually escrowed. The invalidation handler also independently caps refunds, so stale inflated state cannot drain the module account.

---

Supersedes #1132 (closed because the head fork was accidentally deleted). 