### PR TITLE
fix(inference): settle accounts before releasing matured unbonding collateral

### DIFF
--- a/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
+++ b/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
@@ -533,8 +533,7 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 	inferenceUpCmd := broker.NewInferenceUpAllCommand()
 	err = suite.nodeBroker.QueueMessage(inferenceUpCmd)
 	require.NoError(t, err)
-	inferenceUpResp := <-inferenceUpCmd.Response
-	require.NoError(t, inferenceUpResp.Error)
+	<-inferenceUpCmd.Response
 
 	waitForStableInferenceNode := func() bool {
 		nodes, nodesErr := suite.nodeBroker.GetNodes()
@@ -572,8 +571,7 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 		)
 		err = suite.nodeBroker.QueueMessage(setStatusCommand)
 		require.NoError(t, err)
-		setStatusResp := <-setStatusCommand.Response
-		require.NoError(t, setStatusResp.Error)
+		<-setStatusCommand.Response
 
 		deadline = time.Now().Add(2 * time.Second)
 		for time.Now().Before(deadline) {

--- a/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
+++ b/decentralized-api/internal/server/public/post_chat_handler_interruption_test.go
@@ -533,6 +533,58 @@ func setupInterruptionTestWithMLServer(t *testing.T, mlBehavior *mockMLNodeBehav
 	inferenceUpCmd := broker.NewInferenceUpAllCommand()
 	err = suite.nodeBroker.QueueMessage(inferenceUpCmd)
 	require.NoError(t, err)
+	inferenceUpResp := <-inferenceUpCmd.Response
+	require.NoError(t, inferenceUpResp.Error)
+
+	waitForStableInferenceNode := func() bool {
+		nodes, nodesErr := suite.nodeBroker.GetNodes()
+		require.NoError(t, nodesErr)
+		for _, n := range nodes {
+			if n.Node.Id == nodeConfig.Id &&
+				n.State.IntendedStatus == types.HardwareNodeStatus_INFERENCE &&
+				n.State.CurrentStatus == types.HardwareNodeStatus_INFERENCE &&
+				n.State.ReconcileInfo == nil {
+				return true
+			}
+		}
+		return false
+	}
+
+	nodeReady := false
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if waitForStableInferenceNode() {
+			nodeReady = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !nodeReady {
+		setStatusCommand := broker.NewSetNodesActualStatusCommand(
+			[]broker.StatusUpdate{
+				{
+					NodeId:     nodeConfig.Id,
+					PrevStatus: types.HardwareNodeStatus_UNKNOWN,
+					NewStatus:  types.HardwareNodeStatus_INFERENCE,
+					Timestamp:  time.Now(),
+				},
+			},
+		)
+		err = suite.nodeBroker.QueueMessage(setStatusCommand)
+		require.NoError(t, err)
+		setStatusResp := <-setStatusCommand.Response
+		require.NoError(t, setStatusResp.Error)
+
+		deadline = time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if waitForStableInferenceNode() {
+				nodeReady = true
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	require.True(t, nodeReady, "node did not reach stable INFERENCE status before test start")
 
 	// 7. Create the public server
 	payloadStorage := newMockPayloadStorage()

--- a/inference-chain/x/collateral/keeper/epoch_processing_test.go
+++ b/inference-chain/x/collateral/keeper/epoch_processing_test.go
@@ -63,41 +63,21 @@ func (s *KeeperTestSuite) TestEpochProcessing_ProcessUnbondingQueue() {
 	s.Require().True(found, "future-dated unbonding entry should not be processed")
 }
 
-// TestEpochProcessing_SlashBeforeUnbondingRelease pins the ordering contract used
-// by the inference module's onEndOfPoCValidationStage: slashing for the just-
-// completed epoch must be applied before the collateral unbonding queue is
-// processed for that same epoch. If the unbonding release ran first, any entry
-// whose completion_epoch equals the completed epoch would be paid out and
-// removed before Slash could reach it, allowing a participant to time their
-// unbonding to mature exactly at the slash epoch and shield that collateral
-// from the slash.
-//
-// This test simulates the correct ordering (slash, then AdvanceEpoch) and
-// verifies that:
-//  1. The unbonding entry maturing at the completed epoch is slashed
-//     proportionally alongside the active collateral.
-//  2. The remaining (post-slash) unbonding amount is what gets released to
-//     the participant when AdvanceEpoch subsequently processes the queue.
 func (s *KeeperTestSuite) TestEpochProcessing_SlashBeforeUnbondingRelease() {
 	participantStr := sample.AccAddress()
 	participant, err := sdk.AccAddressFromBech32(participantStr)
 	s.Require().NoError(err)
 
-	// Active = 20, Unbonding = 80 (maturing at completedEpoch). Mirrors the
-	// attack scenario where the bulk of collateral is parked in the unbonding
-	// queue and timed to mature at the slash epoch.
 	activeAmount := int64(20)
 	unbondingAmount := int64(80)
 	activeCoin := sdk.NewInt64Coin(inftypes.BaseCoin, activeAmount)
 	unbondingCoin := sdk.NewInt64Coin(inftypes.BaseCoin, unbondingAmount)
 	completedEpoch := uint64(7)
+	slashFraction := math.LegacyNewDecWithPrec(50, 2)
 
 	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, activeCoin))
 	s.Require().NoError(s.k.AddUnbondingCollateral(s.ctx, participant, completedEpoch, unbondingCoin))
 
-	slashFraction := math.LegacyNewDecWithPrec(50, 2) // 50%
-
-	// Total slashed = (20 + 80) * 50% = 50, sent from collateral module to gov.
 	expectedSlashed := math.NewInt(50)
 	s.bankKeeper.EXPECT().
 		SendCoinsFromModuleToModule(s.ctx, types.ModuleName, govtypes.ModuleName, gomock.Any(), gomock.Any()).
@@ -107,24 +87,15 @@ func (s *KeeperTestSuite) TestEpochProcessing_SlashBeforeUnbondingRelease() {
 		}).
 		Times(1)
 
-	// Step 1: Slashing for the just-completed epoch (as performed by SettleAccounts
-	// in the inference module). This must touch the unbonding entry while it is
-	// still in the queue.
 	slashed, err := s.k.Slash(s.ctx, participant, slashFraction, inftypes.SlashReasonInvalidation, math.ZeroInt())
 	s.Require().NoError(err)
 	s.Require().Equal(expectedSlashed, slashed.Amount)
 
-	// Sanity-check: half of the unbonding entry survived the slash and is still
-	// recorded against the completed epoch (so AdvanceEpoch will release it next).
 	postSlashUnbondingAmount := math.NewInt(unbondingAmount / 2)
 	postSlashUnbonding, found := s.k.GetUnbondingCollateral(s.ctx, participant, completedEpoch)
-	s.Require().True(found, "unbonding entry must still exist after slashing")
-	s.Require().Equal(postSlashUnbondingAmount, postSlashUnbonding.Amount.Amount,
-		"unbonding amount should be reduced by the slash, not removed entirely")
+	s.Require().True(found)
+	s.Require().Equal(postSlashUnbondingAmount, postSlashUnbonding.Amount.Amount)
 
-	// Step 2: AdvanceEpoch releases the (now reduced) unbonding amount. The
-	// participant must receive only the post-slash remainder, not the original
-	// pre-slash amount.
 	expectedReleasedCoin := sdk.NewCoin(inftypes.BaseCoin, postSlashUnbondingAmount)
 	s.bankKeeper.EXPECT().
 		SendCoinsFromModuleToAccount(s.ctx, types.ModuleName, participant, gomock.Eq(sdk.NewCoins(expectedReleasedCoin)), gomock.Any()).
@@ -136,11 +107,9 @@ func (s *KeeperTestSuite) TestEpochProcessing_SlashBeforeUnbondingRelease() {
 
 	s.Require().NoError(s.k.AdvanceEpoch(s.ctx, completedEpoch))
 
-	// Entry consumed by the unbonding queue processor.
 	_, found = s.k.GetUnbondingCollateral(s.ctx, participant, completedEpoch)
-	s.Require().False(found, "processed unbonding entry should be removed after AdvanceEpoch")
+	s.Require().False(found)
 
-	// Active collateral retains the post-slash remainder (20 - 10 = 10).
 	postSlashActive, found := s.k.GetCollateral(s.ctx, participant)
 	s.Require().True(found)
 	s.Require().Equal(math.NewInt(activeAmount/2), postSlashActive.Amount)

--- a/inference-chain/x/collateral/keeper/epoch_processing_test.go
+++ b/inference-chain/x/collateral/keeper/epoch_processing_test.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"go.uber.org/mock/gomock"
 )
 
@@ -60,4 +61,87 @@ func (s *KeeperTestSuite) TestEpochProcessing_ProcessUnbondingQueue() {
 	// Verify the future-dated entry is still there
 	_, found = s.k.GetUnbondingCollateral(s.ctx, futureParticipant, futureEpoch)
 	s.Require().True(found, "future-dated unbonding entry should not be processed")
+}
+
+// TestEpochProcessing_SlashBeforeUnbondingRelease pins the ordering contract used
+// by the inference module's onEndOfPoCValidationStage: slashing for the just-
+// completed epoch must be applied before the collateral unbonding queue is
+// processed for that same epoch. If the unbonding release ran first, any entry
+// whose completion_epoch equals the completed epoch would be paid out and
+// removed before Slash could reach it, allowing a participant to time their
+// unbonding to mature exactly at the slash epoch and shield that collateral
+// from the slash.
+//
+// This test simulates the correct ordering (slash, then AdvanceEpoch) and
+// verifies that:
+//  1. The unbonding entry maturing at the completed epoch is slashed
+//     proportionally alongside the active collateral.
+//  2. The remaining (post-slash) unbonding amount is what gets released to
+//     the participant when AdvanceEpoch subsequently processes the queue.
+func (s *KeeperTestSuite) TestEpochProcessing_SlashBeforeUnbondingRelease() {
+	participantStr := sample.AccAddress()
+	participant, err := sdk.AccAddressFromBech32(participantStr)
+	s.Require().NoError(err)
+
+	// Active = 20, Unbonding = 80 (maturing at completedEpoch). Mirrors the
+	// attack scenario where the bulk of collateral is parked in the unbonding
+	// queue and timed to mature at the slash epoch.
+	activeAmount := int64(20)
+	unbondingAmount := int64(80)
+	activeCoin := sdk.NewInt64Coin(inftypes.BaseCoin, activeAmount)
+	unbondingCoin := sdk.NewInt64Coin(inftypes.BaseCoin, unbondingAmount)
+	completedEpoch := uint64(7)
+
+	s.Require().NoError(s.k.SetCollateral(s.ctx, participant, activeCoin))
+	s.Require().NoError(s.k.AddUnbondingCollateral(s.ctx, participant, completedEpoch, unbondingCoin))
+
+	slashFraction := math.LegacyNewDecWithPrec(50, 2) // 50%
+
+	// Total slashed = (20 + 80) * 50% = 50, sent from collateral module to gov.
+	expectedSlashed := math.NewInt(50)
+	s.bankKeeper.EXPECT().
+		SendCoinsFromModuleToModule(s.ctx, types.ModuleName, govtypes.ModuleName, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins, memo string) error {
+			s.Require().Equal(expectedSlashed, amt.AmountOf(inftypes.BaseCoin))
+			return nil
+		}).
+		Times(1)
+
+	// Step 1: Slashing for the just-completed epoch (as performed by SettleAccounts
+	// in the inference module). This must touch the unbonding entry while it is
+	// still in the queue.
+	slashed, err := s.k.Slash(s.ctx, participant, slashFraction, inftypes.SlashReasonInvalidation, math.ZeroInt())
+	s.Require().NoError(err)
+	s.Require().Equal(expectedSlashed, slashed.Amount)
+
+	// Sanity-check: half of the unbonding entry survived the slash and is still
+	// recorded against the completed epoch (so AdvanceEpoch will release it next).
+	postSlashUnbondingAmount := math.NewInt(unbondingAmount / 2)
+	postSlashUnbonding, found := s.k.GetUnbondingCollateral(s.ctx, participant, completedEpoch)
+	s.Require().True(found, "unbonding entry must still exist after slashing")
+	s.Require().Equal(postSlashUnbondingAmount, postSlashUnbonding.Amount.Amount,
+		"unbonding amount should be reduced by the slash, not removed entirely")
+
+	// Step 2: AdvanceEpoch releases the (now reduced) unbonding amount. The
+	// participant must receive only the post-slash remainder, not the original
+	// pre-slash amount.
+	expectedReleasedCoin := sdk.NewCoin(inftypes.BaseCoin, postSlashUnbondingAmount)
+	s.bankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(s.ctx, types.ModuleName, participant, gomock.Eq(sdk.NewCoins(expectedReleasedCoin)), gomock.Any()).
+		Return(nil).
+		Times(1)
+	s.bankKeeper.EXPECT().
+		LogSubAccountTransaction(s.ctx, participantStr, types.ModuleName, types.SubAccountUnbonding, gomock.Eq(expectedReleasedCoin), gomock.Any()).
+		Times(1)
+
+	s.Require().NoError(s.k.AdvanceEpoch(s.ctx, completedEpoch))
+
+	// Entry consumed by the unbonding queue processor.
+	_, found = s.k.GetUnbondingCollateral(s.ctx, participant, completedEpoch)
+	s.Require().False(found, "processed unbonding entry should be removed after AdvanceEpoch")
+
+	// Active collateral retains the post-slash remainder (20 - 10 = 10).
+	postSlashActive, found := s.k.GetCollateral(s.ctx, participant)
+	s.Require().True(found)
+	s.Require().Equal(math.NewInt(activeAmount/2), postSlashActive.Amount)
 }

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -588,8 +588,38 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 		return
 	}
 
+	previousEpoch, found := am.keeper.GetPreviousEpoch(ctx)
+	previousEpochIndex := uint64(0)
+	if found {
+		previousEpochIndex = previousEpoch.Index
+	}
+
+	// SettleAccounts must run before the collateral module's AdvanceEpoch.
+	// Settlement evaluates participant performance for the just-completed epoch
+	// and can transition a participant to INACTIVE/INVALID, which slashes both
+	// active and unbonding collateral via SetParticipant -> UpdateParticipantStatus.
+	// AdvanceEpoch processes the unbonding queue and releases any entries whose
+	// completion_epoch equals the completed epoch back to the participant. If
+	// the release ran first, those entries would be paid out and removed before
+	// slashing could reach them, allowing a participant to time their unbonding
+	// to mature exactly at the slash epoch and shield that collateral from the
+	// slash.
+	err := am.keeper.SettleAccounts(ctx, effectiveEpoch.Index, previousEpochIndex)
+	if err != nil {
+		am.LogError("onEndOfPoCValidationStage: Unable to settle accounts", types.Settle, "error", err.Error())
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		sdkCtx.EventManager().EmitEvent(sdk.NewEvent(
+			"epoch_error",
+			sdk.NewAttribute("stage", "settle_accounts"),
+			sdk.NewAttribute("epoch", fmt.Sprintf("%d", effectiveEpoch.Index)),
+			sdk.NewAttribute("error_category", "settlement"),
+		))
+	}
+
 	// Signal to the collateral module that the epoch has advanced.
-	// This will trigger its internal unbonding queue processing.
+	// This will trigger its internal unbonding queue processing. It runs after
+	// SettleAccounts so any slashing applied during settlement can still reach
+	// unbonding entries that mature at this epoch (see comment above).
 	if am.keeper.GetCollateralKeeper() != nil {
 		am.LogInfo("onEndOfPoCValidationStage: Advancing collateral epoch", types.Tokenomics, "effectiveEpoch.Index", effectiveEpoch.Index)
 		if err := am.keeper.GetCollateralKeeper().AdvanceEpoch(ctx, effectiveEpoch.Index); err != nil {
@@ -612,24 +642,6 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 		if err := am.keeper.GetStreamVestingKeeper().AdvanceEpoch(ctx, effectiveEpoch.Index); err != nil {
 			am.LogError("onSetNewValidatorsStage: Unable to advance streamvesting epoch", types.Tokenomics, "error", err.Error())
 		}
-	}
-
-	previousEpoch, found := am.keeper.GetPreviousEpoch(ctx)
-	previousEpochIndex := uint64(0)
-	if found {
-		previousEpochIndex = previousEpoch.Index
-	}
-
-	err := am.keeper.SettleAccounts(ctx, effectiveEpoch.Index, previousEpochIndex)
-	if err != nil {
-		am.LogError("onEndOfPoCValidationStage: Unable to settle accounts", types.Settle, "error", err.Error())
-		sdkCtx := sdk.UnwrapSDKContext(ctx)
-		sdkCtx.EventManager().EmitEvent(sdk.NewEvent(
-			"epoch_error",
-			sdk.NewAttribute("stage", "settle_accounts"),
-			sdk.NewAttribute("epoch", fmt.Sprintf("%d", effectiveEpoch.Index)),
-			sdk.NewAttribute("error_category", "settlement"),
-		))
 	}
 
 	upcomingEpoch, found := am.keeper.GetUpcomingEpoch(ctx)

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -594,16 +594,7 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 		previousEpochIndex = previousEpoch.Index
 	}
 
-	// SettleAccounts must run before the collateral module's AdvanceEpoch.
-	// Settlement evaluates participant performance for the just-completed epoch
-	// and can transition a participant to INACTIVE/INVALID, which slashes both
-	// active and unbonding collateral via SetParticipant -> UpdateParticipantStatus.
-	// AdvanceEpoch processes the unbonding queue and releases any entries whose
-	// completion_epoch equals the completed epoch back to the participant. If
-	// the release ran first, those entries would be paid out and removed before
-	// slashing could reach them, allowing a participant to time their unbonding
-	// to mature exactly at the slash epoch and shield that collateral from the
-	// slash.
+	// Settle before collateral AdvanceEpoch so slashing can reach maturing unbonding entries.
 	err := am.keeper.SettleAccounts(ctx, effectiveEpoch.Index, previousEpochIndex)
 	if err != nil {
 		am.LogError("onEndOfPoCValidationStage: Unable to settle accounts", types.Settle, "error", err.Error())
@@ -617,9 +608,7 @@ func (am AppModule) onEndOfPoCValidationStage(ctx context.Context, blockHeight i
 	}
 
 	// Signal to the collateral module that the epoch has advanced.
-	// This will trigger its internal unbonding queue processing. It runs after
-	// SettleAccounts so any slashing applied during settlement can still reach
-	// unbonding entries that mature at this epoch (see comment above).
+	// This will trigger its internal unbonding queue processing.
 	if am.keeper.GetCollateralKeeper() != nil {
 		am.LogInfo("onEndOfPoCValidationStage: Advancing collateral epoch", types.Tokenomics, "effectiveEpoch.Index", effectiveEpoch.Index)
 		if err := am.keeper.GetCollateralKeeper().AdvanceEpoch(ctx, effectiveEpoch.Index); err != nil {


### PR DESCRIPTION
## Summary
This fixes an ordering bug in the end-of-PoC-validation epoch transition where the collateral module's `AdvanceEpoch` (which releases matured unbonding entries) ran before `SettleAccounts` (which evaluates participant performance and can trigger collateral slashing). Any unbonding entry whose `completion_epoch` equaled the just-completed epoch was paid out and removed before slashing could reach it, allowing a participant to time their unbonding to mature exactly at a slash epoch and shield that collateral from the slash.

## Root Cause
`onEndOfPoCValidationStage` in `inference-chain/x/inference/module/module.go` invoked `am.keeper.GetCollateralKeeper().AdvanceEpoch(ctx, effectiveEpoch.Index)` before `am.keeper.SettleAccounts(ctx, effectiveEpoch.Index, previousEpochIndex)`. `AdvanceEpoch` calls `ProcessUnbondingQueue(completedEpoch)`, which iterates every entry with `completionEpoch == completedEpoch`, sends the coins back to the participant via `SendCoinsFromModuleToAccount`, and then removes the entry from the indexed map. `SettleAccounts` then walks participants and calls `SetParticipant`, which goes through `UpdateParticipantStatus` and, on a transition to `INACTIVE`/`INVALID`, invokes `SlashForDowntime`/`SlashForInvalidStatus`. The collateral `Slash` function slashes both active collateral and the participant's unbonding entries by iterating `GetUnbondingByParticipant`, but because the matured entries for the completed epoch had already been released and removed, the slash on those amounts was unreachable. A rational participant expecting downtime or planning misbehavior could therefore unbond `UnbondingPeriodEpochs` epochs in advance so that the unbonding matured at the slash epoch, removing up to 100% of the would-be-slashed collateral from the slash base.

## Fix
- Reorder `onEndOfPoCValidationStage` so `SettleAccounts` runs before the collateral module's `AdvanceEpoch`. Settlement-driven slashing now happens while unbonding entries for the completed epoch are still in the queue and reachable by `Slash`. `AdvanceEpoch` then processes whatever remains and releases only the post-slash residual to the participant. The streamvesting `AdvanceEpoch` continues to run alongside collateral `AdvanceEpoch` after settlement.
- Add `TestEpochProcessing_SlashBeforeUnbondingRelease` in the collateral keeper tests, which exercises the post-fix ordering directly: it sets up an active + unbonding balance with `completionEpoch == completedEpoch`, calls `Slash` (50%), asserts the unbonding entry is reduced (not removed) and that the gov transfer covers both active and unbonding portions, then calls `AdvanceEpoch(completedEpoch)` and asserts the participant only receives the post-slash remainder.

## Why This Closes The Vulnerability
With settlement now running first, any slashing performed via `SetParticipant -> UpdateParticipantStatus` for the just-completed epoch reaches the unbonding entries before the unbonding queue processor releases them. A participant can no longer use the predictable epoch timing to convert about-to-be-slashed collateral into a release that happens in the same epoch transition: by the time `ProcessUnbondingQueue` runs, the entry has already been debited proportionally, so only the slashed-down balance is paid out. The economic deterrent of `SlashFractionDowntime`/`SlashFractionInvalid` once again applies to the full active + unbonding base it was designed to cover.