### PR TITLE
perf: gRPC caching

### DIFF
--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -79,14 +79,15 @@ type ApiConfig struct {
 }
 
 type ChainNodeConfig struct {
-	Url              string `koanf:"url" json:"url"`
-	IsGenesis        bool   `koanf:"is_genesis" json:"is_genesis"`
-	SeedApiUrl       string `koanf:"seed_api_url" json:"seed_api_url"`
-	AccountPublicKey string `koanf:"account_public_key" json:"account_public_key"`
-	SignerKeyName    string `koanf:"signer_key_name" json:"signer_key_name"`
-	KeyringBackend   string `koanf:"keyring_backend" json:"keyring_backend"`
-	KeyringDir       string `koanf:"keyring_dir" json:"keyring_dir"`
-	KeyringPassword  string `json:"-"`
+	Url               string `koanf:"url" json:"url"`
+	IsGenesis         bool   `koanf:"is_genesis" json:"is_genesis"`
+	SeedApiUrl        string `koanf:"seed_api_url" json:"seed_api_url"`
+	AccountPublicKey  string `koanf:"account_public_key" json:"account_public_key"`
+	SignerKeyName     string `koanf:"signer_key_name" json:"signer_key_name"`
+	KeyringBackend    string `koanf:"keyring_backend" json:"keyring_backend"`
+	KeyringDir        string `koanf:"keyring_dir" json:"keyring_dir"`
+	KeyringPassword   string `json:"-"`
+	QueryCacheEnabled bool   `koanf:"query_cache_enabled" json:"query_cache_enabled"`
 	// MinGasPriceNgonka is the gas price in ngonka used for transaction fee calculation.
 	//
 	// When set to a non-zero value, the DAPI uses it as-is (this is an override

--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -79,17 +79,17 @@ type ApiConfig struct {
 }
 
 type ChainNodeConfig struct {
-	Url               string `koanf:"url" json:"url"`
-	IsGenesis         bool   `koanf:"is_genesis" json:"is_genesis"`
-	SeedApiUrl        string `koanf:"seed_api_url" json:"seed_api_url"`
-	AccountPublicKey  string `koanf:"account_public_key" json:"account_public_key"`
-	SignerKeyName     string `koanf:"signer_key_name" json:"signer_key_name"`
-	KeyringBackend    string `koanf:"keyring_backend" json:"keyring_backend"`
-	KeyringDir        string `koanf:"keyring_dir" json:"keyring_dir"`
-	KeyringPassword   string `json:"-"`
-	QueryCacheEnabled bool   `koanf:"query_cache_enabled" json:"query_cache_enabled"`
-	QueryCacheMaxEntries int `koanf:"query_cache_max_entries" json:"query_cache_max_entries"`
-	QueryCacheMaxBytes int64 `koanf:"query_cache_max_bytes" json:"query_cache_max_bytes"`
+	Url                  string `koanf:"url" json:"url"`
+	IsGenesis            bool   `koanf:"is_genesis" json:"is_genesis"`
+	SeedApiUrl           string `koanf:"seed_api_url" json:"seed_api_url"`
+	AccountPublicKey     string `koanf:"account_public_key" json:"account_public_key"`
+	SignerKeyName        string `koanf:"signer_key_name" json:"signer_key_name"`
+	KeyringBackend       string `koanf:"keyring_backend" json:"keyring_backend"`
+	KeyringDir           string `koanf:"keyring_dir" json:"keyring_dir"`
+	KeyringPassword      string `json:"-"`
+	QueryCacheEnabled    bool   `koanf:"query_cache_enabled" json:"query_cache_enabled"`
+	QueryCacheMaxEntries int    `koanf:"query_cache_max_entries" json:"query_cache_max_entries"`
+	QueryCacheMaxBytes   int64  `koanf:"query_cache_max_bytes" json:"query_cache_max_bytes"`
 	// MinGasPriceNgonka is the gas price in ngonka used for transaction fee calculation.
 	//
 	// When set to a non-zero value, the DAPI uses it as-is (this is an override

--- a/decentralized-api/apiconfig/config.go
+++ b/decentralized-api/apiconfig/config.go
@@ -88,6 +88,8 @@ type ChainNodeConfig struct {
 	KeyringDir        string `koanf:"keyring_dir" json:"keyring_dir"`
 	KeyringPassword   string `json:"-"`
 	QueryCacheEnabled bool   `koanf:"query_cache_enabled" json:"query_cache_enabled"`
+	QueryCacheMaxEntries int `koanf:"query_cache_max_entries" json:"query_cache_max_entries"`
+	QueryCacheMaxBytes int64 `koanf:"query_cache_max_bytes" json:"query_cache_max_bytes"`
 	// MinGasPriceNgonka is the gas price in ngonka used for transaction fee calculation.
 	//
 	// When set to a non-zero value, the DAPI uses it as-is (this is an override

--- a/decentralized-api/apiconfig/config_manager.go
+++ b/decentralized-api/apiconfig/config_manager.go
@@ -634,6 +634,11 @@ func readConfig(provider koanf.Provider) (Config, error) {
 	if err != nil {
 		log.Fatalf("error loading env: %v", err)
 	}
+	if !k.Exists("chain_node.query_cache_enabled") {
+		if err := k.Set("chain_node.query_cache_enabled", true); err != nil {
+			log.Fatalf("error setting default chain_node.query_cache_enabled: %v", err)
+		}
+	}
 	// Pre-seed early-share guard defaults so any field absent from yaml/env keeps
 	// its default while explicitly-set values override. koanf unmarshals with
 	// ZeroFields=false, so only keys actually present overwrite these. This is

--- a/decentralized-api/apiconfig/config_manager.go
+++ b/decentralized-api/apiconfig/config_manager.go
@@ -640,12 +640,12 @@ func readConfig(provider koanf.Provider) (Config, error) {
 		}
 	}
 	if !k.Exists("chain_node.query_cache_max_entries") {
-		if err := k.Set("chain_node.query_cache_max_entries", 10000); err != nil {
+		if err := k.Set("chain_node.query_cache_max_entries", 200000); err != nil {
 			log.Fatalf("error setting default chain_node.query_cache_max_entries: %v", err)
 		}
 	}
 	if !k.Exists("chain_node.query_cache_max_bytes") {
-		if err := k.Set("chain_node.query_cache_max_bytes", int64(64<<20)); err != nil {
+		if err := k.Set("chain_node.query_cache_max_bytes", int64(1<<30)); err != nil {
 			log.Fatalf("error setting default chain_node.query_cache_max_bytes: %v", err)
 		}
 	}

--- a/decentralized-api/apiconfig/config_manager.go
+++ b/decentralized-api/apiconfig/config_manager.go
@@ -639,6 +639,16 @@ func readConfig(provider koanf.Provider) (Config, error) {
 			log.Fatalf("error setting default chain_node.query_cache_enabled: %v", err)
 		}
 	}
+	if !k.Exists("chain_node.query_cache_max_entries") {
+		if err := k.Set("chain_node.query_cache_max_entries", 10000); err != nil {
+			log.Fatalf("error setting default chain_node.query_cache_max_entries: %v", err)
+		}
+	}
+	if !k.Exists("chain_node.query_cache_max_bytes") {
+		if err := k.Set("chain_node.query_cache_max_bytes", int64(64<<20)); err != nil {
+			log.Fatalf("error setting default chain_node.query_cache_max_bytes: %v", err)
+		}
+	}
 	// Pre-seed early-share guard defaults so any field absent from yaml/env keeps
 	// its default while explicitly-set values override. koanf unmarshals with
 	// ZeroFields=false, so only keys actually present overwrite these. This is

--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -223,8 +223,8 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 
 	var queryCache *QueryCache
 	if nodeConfig.QueryCacheEnabled {
-		queryCache = NewQueryCache()
-		log.Printf("Query cache enabled")
+		queryCache = NewQueryCacheWithLimits(nodeConfig.QueryCacheMaxEntries, nodeConfig.QueryCacheMaxBytes)
+		log.Printf("Query cache enabled (max_entries=%d, max_bytes=%d)", nodeConfig.QueryCacheMaxEntries, nodeConfig.QueryCacheMaxBytes)
 	}
 
 	client := &InferenceCosmosClient{

--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -35,6 +35,7 @@ import (
 	blstypes "github.com/productscience/inference/x/bls/types"
 	inferencetypes "github.com/productscience/inference/x/inference/types"
 	restrictionstypes "github.com/productscience/inference/x/restrictions/types"
+	"google.golang.org/grpc"
 )
 
 type InferenceCosmosClient struct {
@@ -44,6 +45,7 @@ type InferenceCosmosClient struct {
 	manager         tx_manager.TxManager
 	batchConsumer   *tx_manager.BatchConsumer
 	batchingEnabled bool
+	queryCache      *QueryCache
 }
 
 func NewInferenceCosmosClientWithRetry(
@@ -219,11 +221,18 @@ func NewInferenceCosmosClient(ctx context.Context, addressPrefix string, config 
 		return nil, err
 	}
 
+	var queryCache *QueryCache
+	if nodeConfig.QueryCacheEnabled {
+		queryCache = NewQueryCache()
+		log.Printf("Query cache enabled")
+	}
+
 	client := &InferenceCosmosClient{
 		ctx:        ctx,
 		Address:    accAddress,
 		apiAccount: apiAccount,
 		manager:    mn,
+		queryCache: queryCache,
 	}
 
 	batchingCfg := config.GetTxBatchingConfig()
@@ -289,10 +298,43 @@ type CosmosMessageClient interface {
 	NewRestrictionsQueryClient() restrictionstypes.QueryClient
 	GetAddress() string
 	GetApiAccount() apiconfig.ApiAccount
+	SetQueryCacheHeightHint(height int64)
+	GetQueryCacheStats() *QueryCacheStats
+	ResetQueryCacheStats() bool
 }
 
 func (icc *InferenceCosmosClient) GetApiAccount() apiconfig.ApiAccount {
 	return icc.manager.GetApiAccount()
+}
+
+func (icc *InferenceCosmosClient) SetQueryCacheHeightHint(height int64) {
+	if icc.queryCache != nil {
+		icc.queryCache.SetHeightHint(height)
+	}
+}
+
+func (icc *InferenceCosmosClient) GetQueryCacheStats() *QueryCacheStats {
+	if icc.queryCache == nil {
+		return nil
+	}
+	stats := icc.queryCache.SnapshotStats()
+	return &stats
+}
+
+func (icc *InferenceCosmosClient) ResetQueryCacheStats() bool {
+	if icc.queryCache == nil {
+		return false
+	}
+	icc.queryCache.ResetStats()
+	return true
+}
+
+func (icc *InferenceCosmosClient) cachedConn() grpc.ClientConnInterface {
+	baseConn := grpc.ClientConnInterface(icc.manager.GetClientContext())
+	if icc.queryCache != nil {
+		baseConn = &CachingConn{inner: baseConn, cache: icc.queryCache}
+	}
+	return newObservedQueryClientConn(baseConn)
 }
 
 func (icc *InferenceCosmosClient) GetClientContext() sdkclient.Context {
@@ -508,15 +550,15 @@ func (icc *InferenceCosmosClient) GetPartialUpgrades() (*inferencetypes.QueryAll
 }
 
 func (icc *InferenceCosmosClient) NewUpgradeQueryClient() upgradetypes.QueryClient {
-	return upgradetypes.NewQueryClient(newObservedQueryClientConn(icc.manager.GetClientContext()))
+	return upgradetypes.NewQueryClient(icc.cachedConn())
 }
 
 func (icc *InferenceCosmosClient) NewInferenceQueryClient() inferencetypes.QueryClient {
-	return inferencetypes.NewQueryClient(newObservedQueryClientConn(icc.manager.GetClientContext()))
+	return inferencetypes.NewQueryClient(icc.cachedConn())
 }
 
 func (icc *InferenceCosmosClient) NewCometQueryClient() cmtservice.ServiceClient {
-	return cmtservice.NewServiceClient(newObservedQueryClientConn(icc.manager.GetClientContext()))
+	return cmtservice.NewServiceClient(icc.cachedConn())
 }
 
 func (icc *InferenceCosmosClient) SendTransactionSyncNoRetry(transaction proto.Message, dstMsg proto.Message) error {
@@ -573,9 +615,9 @@ func (icc *InferenceCosmosClient) SubmitPartialSignature(requestId []byte, slotI
 }
 
 func (icc *InferenceCosmosClient) NewBLSQueryClient() blstypes.QueryClient {
-	return blstypes.NewQueryClient(newObservedQueryClientConn(icc.manager.GetClientContext()))
+	return blstypes.NewQueryClient(icc.cachedConn())
 }
 
 func (icc *InferenceCosmosClient) NewRestrictionsQueryClient() restrictionstypes.QueryClient {
-	return restrictionstypes.NewQueryClient(newObservedQueryClientConn(icc.manager.GetClientContext()))
+	return restrictionstypes.NewQueryClient(icc.cachedConn())
 }

--- a/decentralized-api/cosmosclient/mock_cosmos_message_client.go
+++ b/decentralized-api/cosmosclient/mock_cosmos_message_client.go
@@ -226,3 +226,13 @@ func (m *MockCosmosMessageClient) NewRestrictionsQueryClient() restrictionstypes
 	args := m.Called()
 	return args.Get(0).(restrictionstypes.QueryClient)
 }
+
+func (m *MockCosmosMessageClient) SetQueryCacheHeightHint(_ int64) {}
+
+func (m *MockCosmosMessageClient) GetQueryCacheStats() *QueryCacheStats {
+	return nil
+}
+
+func (m *MockCosmosMessageClient) ResetQueryCacheStats() bool {
+	return false
+}

--- a/decentralized-api/cosmosclient/query_cache.go
+++ b/decentralized-api/cosmosclient/query_cache.go
@@ -1,0 +1,452 @@
+package cosmosclient
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	"golang.org/x/sync/singleflight"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	googleproto "google.golang.org/protobuf/proto"
+)
+
+const defaultKeepLastHeights = 3
+
+type queryCacheBypassKey struct{}
+
+var bypassQueryCacheKey queryCacheBypassKey
+
+func WithoutQueryCache(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, bypassQueryCacheKey, true)
+}
+
+func shouldBypassQueryCache(ctx context.Context) bool {
+	v, ok := ctx.Value(bypassQueryCacheKey).(bool)
+	return ok && v
+}
+
+type QueryCacheStats struct {
+	HeightHint                   int64  `json:"height_hint"`
+	Heights                      int    `json:"heights"`
+	Entries                      int    `json:"entries"`
+	RequestsTotal                uint64 `json:"requests_total"`
+	CacheHitTotal                uint64 `json:"cache_hit_total"`
+	CacheCorruptHitTotal         uint64 `json:"cache_corrupt_hit_total"`
+	CacheMissTotal               uint64 `json:"cache_miss_total"`
+	BackendInvokeTotal           uint64 `json:"backend_invoke_total"`
+	CacheWriteTotal              uint64 `json:"cache_write_total"`
+	CacheWriteSkippedHeightTotal uint64 `json:"cache_write_skipped_height_total"`
+	InvokeErrorTotal             uint64 `json:"invoke_error_total"`
+}
+
+type queryCacheCounters struct {
+	requestsTotal                atomic.Uint64
+	cacheHitTotal                atomic.Uint64
+	cacheCorruptHitTotal         atomic.Uint64
+	cacheMissTotal               atomic.Uint64
+	backendInvokeTotal           atomic.Uint64
+	cacheWriteTotal              atomic.Uint64
+	cacheWriteSkippedHeightTotal atomic.Uint64
+	invokeErrorTotal             atomic.Uint64
+}
+
+type QueryCache struct {
+	hint atomic.Int64
+
+	mu       sync.RWMutex
+	byHeight map[int64]map[string][]byte
+	keepLast int
+
+	sfGroup singleflight.Group
+	stats   queryCacheCounters
+}
+
+func NewQueryCache() *QueryCache {
+	return &QueryCache{
+		byHeight: make(map[int64]map[string][]byte),
+		keepLast: defaultKeepLastHeights,
+	}
+}
+
+func (c *QueryCache) SetHeightHint(h int64) {
+	if h <= 0 {
+		return
+	}
+	for {
+		cur := c.hint.Load()
+		if h <= cur {
+			return
+		}
+		if c.hint.CompareAndSwap(cur, h) {
+			return
+		}
+	}
+}
+
+func (c *QueryCache) HeightHint() int64 { return c.hint.Load() }
+
+func (c *QueryCache) SnapshotStats() QueryCacheStats {
+	c.mu.RLock()
+	heights := len(c.byHeight)
+	entries := 0
+	for _, bucket := range c.byHeight {
+		entries += len(bucket)
+	}
+	c.mu.RUnlock()
+
+	return QueryCacheStats{
+		HeightHint:                   c.hint.Load(),
+		Heights:                      heights,
+		Entries:                      entries,
+		RequestsTotal:                c.stats.requestsTotal.Load(),
+		CacheHitTotal:                c.stats.cacheHitTotal.Load(),
+		CacheCorruptHitTotal:         c.stats.cacheCorruptHitTotal.Load(),
+		CacheMissTotal:               c.stats.cacheMissTotal.Load(),
+		BackendInvokeTotal:           c.stats.backendInvokeTotal.Load(),
+		CacheWriteTotal:              c.stats.cacheWriteTotal.Load(),
+		CacheWriteSkippedHeightTotal: c.stats.cacheWriteSkippedHeightTotal.Load(),
+		InvokeErrorTotal:             c.stats.invokeErrorTotal.Load(),
+	}
+}
+
+func (c *QueryCache) ResetStats() {
+	c.stats.requestsTotal.Store(0)
+	c.stats.cacheHitTotal.Store(0)
+	c.stats.cacheCorruptHitTotal.Store(0)
+	c.stats.cacheMissTotal.Store(0)
+	c.stats.backendInvokeTotal.Store(0)
+	c.stats.cacheWriteTotal.Store(0)
+	c.stats.cacheWriteSkippedHeightTotal.Store(0)
+	c.stats.invokeErrorTotal.Store(0)
+}
+
+func (c *QueryCache) lookup(height int64, key string) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if bucket, ok := c.byHeight[height]; ok {
+		v, hit := bucket[key]
+		return v, hit
+	}
+	return nil, false
+}
+
+func (c *QueryCache) store(height int64, key string, data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	bucket, ok := c.byHeight[height]
+	if !ok {
+		bucket = make(map[string][]byte)
+		c.byHeight[height] = bucket
+	}
+	bucket[key] = data
+	c.pruneLocked()
+}
+
+func (c *QueryCache) deleteEntry(height int64, key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if bucket, ok := c.byHeight[height]; ok {
+		delete(bucket, key)
+		if len(bucket) == 0 {
+			delete(c.byHeight, height)
+		}
+	}
+}
+
+func (c *QueryCache) pruneLocked() {
+	if c.keepLast <= 0 {
+		return
+	}
+	for len(c.byHeight) > c.keepLast {
+		var oldest int64
+		first := true
+		for h := range c.byHeight {
+			if first || h < oldest {
+				oldest = h
+				first = false
+			}
+		}
+		delete(c.byHeight, oldest)
+	}
+}
+
+type CachingConn struct {
+	inner grpc.ClientConnInterface
+	cache *QueryCache
+}
+
+func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply interface{}, opts ...grpc.CallOption) error {
+	c.cache.stats.requestsTotal.Add(1)
+
+	if shouldBypassQueryCache(ctx) {
+		return c.invokeBackend(ctx, method, args, reply, opts...)
+	}
+
+	if !isSupportedProtoMessage(args) || !isSupportedProtoMessage(reply) {
+		return c.invokeBackend(ctx, method, args, reply, opts...)
+	}
+
+	explicitHeight := heightFromOutgoingCtx(ctx)
+	height := explicitHeight
+	if height == 0 {
+		height = c.cache.HeightHint()
+	}
+	if height == 0 {
+		return c.invokeBackend(ctx, method, args, reply, opts...)
+	}
+
+	requestHash, hashErr := buildRequestHash(args)
+	if hashErr != nil {
+		return c.invokeBackend(ctx, method, args, reply, opts...)
+	}
+	key := buildCacheKey(method, requestHash)
+
+	if cached, hit := c.cache.lookup(height, key); hit {
+		if err := unmarshalProtoMessage(cached, reply); err == nil {
+			c.cache.stats.cacheHitTotal.Add(1)
+			if header := headerAddrFromCallOptions(opts); header != nil {
+				*header = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
+			}
+			return nil
+		}
+		c.cache.stats.cacheCorruptHitTotal.Add(1)
+		c.cache.deleteEntry(height, key)
+	}
+	c.cache.stats.cacheMissTotal.Add(1)
+
+	pinnedCtx := ctx
+	if explicitHeight == 0 {
+		pinnedCtx = setPinnedHeight(ctx, height)
+	}
+
+	callOpts := make([]grpc.CallOption, len(opts))
+	copy(callOpts, opts)
+	responseHeader := headerAddrFromCallOptions(callOpts)
+	if responseHeader == nil {
+		md := metadata.MD{}
+		responseHeader = &md
+		callOpts = append(callOpts, grpc.Header(responseHeader))
+	}
+
+	sfKey := strconv.FormatInt(height, 10) + "|" + key
+	loadOrFetch := func() (interface{}, error) {
+		if cached, hit := c.cache.lookup(height, key); hit {
+			return cacheInvokeResult{data: cached, height: height, fromCache: true, dataValid: true}, nil
+		}
+
+		if err := c.invokeBackend(pinnedCtx, method, args, reply, callOpts...); err != nil {
+			return nil, err
+		}
+
+		responseHeight := heightFromIncomingMD(*responseHeader)
+		if responseHeight == 0 {
+			c.cache.stats.cacheWriteSkippedHeightTotal.Add(1)
+			data, marshalErr := marshalProtoMessage(reply)
+			if marshalErr != nil {
+				return cacheInvokeResult{height: 0, leaderReply: reply}, nil
+			}
+			return cacheInvokeResult{data: data, height: 0, dataValid: true, leaderReply: reply}, nil
+		}
+
+		data, marshalErr := marshalProtoMessage(reply)
+		if marshalErr != nil {
+			return cacheInvokeResult{height: responseHeight, leaderReply: reply}, nil
+		}
+
+		c.cache.store(responseHeight, key, data)
+		c.cache.stats.cacheWriteTotal.Add(1)
+		c.cache.SetHeightHint(responseHeight)
+
+		return cacheInvokeResult{data: data, height: responseHeight, dataValid: true, leaderReply: reply}, nil
+	}
+
+	resultAny, err, shared := c.cache.sfGroup.Do(sfKey, loadOrFetch)
+	if err != nil {
+		if shared && ctx.Err() == nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+			resultAny, err, shared = c.cache.sfGroup.Do(sfKey, loadOrFetch)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	result, ok := resultAny.(cacheInvokeResult)
+	if !ok {
+		return fmt.Errorf("unexpected cache invoke result type: %T", resultAny)
+	}
+
+	if header := headerAddrFromCallOptions(opts); header != nil && result.height > 0 {
+		*header = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(result.height, 10))
+	}
+
+	if result.leaderReply == reply {
+		return nil
+	}
+
+	if !result.dataValid {
+		if shared {
+			return c.invokeBackend(pinnedCtx, method, args, reply, callOpts...)
+		}
+		return nil
+	}
+
+	if err := unmarshalProtoMessage(result.data, reply); err != nil {
+		if result.fromCache {
+			c.cache.stats.cacheCorruptHitTotal.Add(1)
+		}
+		if result.height > 0 {
+			c.cache.deleteEntry(result.height, key)
+		}
+		return c.invokeBackend(pinnedCtx, method, args, reply, callOpts...)
+	}
+	return nil
+}
+
+func (c *CachingConn) invokeBackend(ctx context.Context, method string, args, reply interface{}, opts ...grpc.CallOption) error {
+	c.cache.stats.backendInvokeTotal.Add(1)
+	if err := c.inner.Invoke(ctx, method, args, reply, opts...); err != nil {
+		c.cache.stats.invokeErrorTotal.Add(1)
+		return err
+	}
+	return nil
+}
+
+func (c *CachingConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return c.inner.NewStream(ctx, desc, method, opts...)
+}
+
+func heightFromOutgoingCtx(ctx context.Context) int64 {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return 0
+	}
+	vals := md.Get(grpctypes.GRPCBlockHeightHeader)
+	if len(vals) == 0 {
+		return 0
+	}
+	h, _ := strconv.ParseInt(vals[len(vals)-1], 10, 64)
+	return h
+}
+
+func setPinnedHeight(ctx context.Context, height int64) context.Context {
+	value := strconv.FormatInt(height, 10)
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return metadata.NewOutgoingContext(ctx, metadata.Pairs(grpctypes.GRPCBlockHeightHeader, value))
+	}
+
+	current := md.Get(grpctypes.GRPCBlockHeightHeader)
+	if len(current) == 1 && current[0] == value {
+		return ctx
+	}
+
+	md = md.Copy()
+	md.Set(grpctypes.GRPCBlockHeightHeader, value)
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func PinHeight(ctx context.Context, height int64) context.Context {
+	if height <= 0 {
+		return ctx
+	}
+	return setPinnedHeight(ctx, height)
+}
+
+func heightFromIncomingMD(md metadata.MD) int64 {
+	vals := md.Get(grpctypes.GRPCBlockHeightHeader)
+	if len(vals) == 0 {
+		return 0
+	}
+	h, err := strconv.ParseInt(vals[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return h
+}
+
+func headerAddrFromCallOptions(opts []grpc.CallOption) *metadata.MD {
+	var headerAddr *metadata.MD
+	for _, opt := range opts {
+		switch h := opt.(type) {
+		case grpc.HeaderCallOption:
+			if h.HeaderAddr != nil {
+				headerAddr = h.HeaderAddr
+			}
+		case *grpc.HeaderCallOption:
+			if h != nil && h.HeaderAddr != nil {
+				headerAddr = h.HeaderAddr
+			}
+		}
+	}
+	return headerAddr
+}
+
+type cacheInvokeResult struct {
+	data        []byte
+	height      int64
+	fromCache   bool
+	dataValid   bool
+	leaderReply interface{}
+}
+
+func buildRequestHash(msg interface{}) (string, error) {
+	data, err := marshalProtoMessage(msg)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+func buildCacheKey(method, requestHash string) string {
+	return method + "|" + requestHash
+}
+
+func isSupportedProtoMessage(msg interface{}) bool {
+	switch msg.(type) {
+	case googleproto.Message, gogoproto.Message:
+		return true
+	default:
+		return false
+	}
+}
+
+func marshalProtoMessage(msg interface{}) ([]byte, error) {
+	switch m := msg.(type) {
+	case googleproto.Message:
+		return googleproto.MarshalOptions{Deterministic: true}.Marshal(m)
+	case gogoproto.Message:
+		// Some gogoproto-generated types don't support deterministic marshal.
+		buf := &gogoproto.Buffer{}
+		buf.SetDeterministic(true)
+		if err := buf.Marshal(m); err == nil {
+			return buf.Bytes(), nil
+		}
+		return gogoproto.Marshal(m)
+	default:
+		return nil, fmt.Errorf("unsupported proto message type: %T", msg)
+	}
+}
+
+func unmarshalProtoMessage(data []byte, msg interface{}) error {
+	switch m := msg.(type) {
+	case googleproto.Message:
+		return googleproto.Unmarshal(data, m)
+	case gogoproto.Message:
+		return gogoproto.Unmarshal(data, m)
+	default:
+		return fmt.Errorf("unsupported proto message type: %T", msg)
+	}
+}

--- a/decentralized-api/cosmosclient/query_cache.go
+++ b/decentralized-api/cosmosclient/query_cache.go
@@ -292,6 +292,11 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 	}
 	c.cache.stats.cacheMissTotal.Add(1)
 
+	backendCtx := ctx
+	if explicitHeight == 0 && hintTrusted {
+		backendCtx = setPinnedHeight(ctx, height)
+	}
+
 	callOpts := make([]grpc.CallOption, len(opts))
 	copy(callOpts, opts)
 	responseHeader := headerAddrFromCallOptions(callOpts)
@@ -309,7 +314,7 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 			}
 		}
 
-		if err := c.invokeBackend(ctx, method, args, reply, callOpts...); err != nil {
+		if err := c.invokeBackend(backendCtx, method, args, reply, callOpts...); err != nil {
 			return nil, err
 		}
 
@@ -358,7 +363,7 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 
 	if !result.dataValid {
 		if shared {
-			return c.invokeBackend(ctx, method, args, reply, callOpts...)
+			return c.invokeBackend(backendCtx, method, args, reply, callOpts...)
 		}
 		return nil
 	}
@@ -370,7 +375,7 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 		if result.height > 0 {
 			c.cache.deleteEntry(result.height, key)
 		}
-		return c.invokeBackend(ctx, method, args, reply, callOpts...)
+		return c.invokeBackend(backendCtx, method, args, reply, callOpts...)
 	}
 	return nil
 }

--- a/decentralized-api/cosmosclient/query_cache.go
+++ b/decentralized-api/cosmosclient/query_cache.go
@@ -1,6 +1,7 @@
 package cosmosclient
 
 import (
+	"container/list"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -18,7 +19,11 @@ import (
 	googleproto "google.golang.org/protobuf/proto"
 )
 
-const defaultKeepLastHeights = 3
+const (
+	defaultKeepLastHeights = 3
+	defaultMaxEntries = 10000
+	defaultMaxBytes   = 64 << 20
+)
 
 type queryCacheBypassKey struct{}
 
@@ -40,6 +45,9 @@ type QueryCacheStats struct {
 	HeightHint                   int64  `json:"height_hint"`
 	Heights                      int    `json:"heights"`
 	Entries                      int    `json:"entries"`
+	TotalBytes                   int64  `json:"total_bytes"`
+	MaxEntries                   int    `json:"max_entries"`
+	MaxBytes                     int64  `json:"max_bytes"`
 	RequestsTotal                uint64 `json:"requests_total"`
 	CacheHitTotal                uint64 `json:"cache_hit_total"`
 	CacheCorruptHitTotal         uint64 `json:"cache_corrupt_hit_total"`
@@ -47,6 +55,7 @@ type QueryCacheStats struct {
 	BackendInvokeTotal           uint64 `json:"backend_invoke_total"`
 	CacheWriteTotal              uint64 `json:"cache_write_total"`
 	CacheWriteSkippedHeightTotal uint64 `json:"cache_write_skipped_height_total"`
+	CacheEvictTotal              uint64 `json:"cache_evict_total"`
 	InvokeErrorTotal             uint64 `json:"invoke_error_total"`
 }
 
@@ -58,24 +67,50 @@ type queryCacheCounters struct {
 	backendInvokeTotal           atomic.Uint64
 	cacheWriteTotal              atomic.Uint64
 	cacheWriteSkippedHeightTotal atomic.Uint64
+	cacheEvictTotal              atomic.Uint64
 	invokeErrorTotal             atomic.Uint64
+}
+
+type lruKey struct {
+	height int64
+	key    string
+}
+
+type lruEntry struct {
+	height int64
+	key    string
+	size   int
 }
 
 type QueryCache struct {
 	hint atomic.Int64
 
-	mu       sync.RWMutex
+	mu       sync.Mutex
 	byHeight map[int64]map[string][]byte
 	keepLast int
+
+	lru        *list.List
+	lruIndex   map[lruKey]*list.Element
+	totalBytes int64
+	maxEntries int
+	maxBytes   int64
 
 	sfGroup singleflight.Group
 	stats   queryCacheCounters
 }
 
 func NewQueryCache() *QueryCache {
+	return NewQueryCacheWithLimits(defaultMaxEntries, defaultMaxBytes)
+}
+
+func NewQueryCacheWithLimits(maxEntries int, maxBytes int64) *QueryCache {
 	return &QueryCache{
-		byHeight: make(map[int64]map[string][]byte),
-		keepLast: defaultKeepLastHeights,
+		byHeight:   make(map[int64]map[string][]byte),
+		keepLast:   defaultKeepLastHeights,
+		lru:        list.New(),
+		lruIndex:   make(map[lruKey]*list.Element),
+		maxEntries: maxEntries,
+		maxBytes:   maxBytes,
 	}
 }
 
@@ -97,18 +132,21 @@ func (c *QueryCache) SetHeightHint(h int64) {
 func (c *QueryCache) HeightHint() int64 { return c.hint.Load() }
 
 func (c *QueryCache) SnapshotStats() QueryCacheStats {
-	c.mu.RLock()
+	c.mu.Lock()
 	heights := len(c.byHeight)
-	entries := 0
-	for _, bucket := range c.byHeight {
-		entries += len(bucket)
-	}
-	c.mu.RUnlock()
+	entries := len(c.lruIndex)
+	totalBytes := c.totalBytes
+	maxEntries := c.maxEntries
+	maxBytes := c.maxBytes
+	c.mu.Unlock()
 
 	return QueryCacheStats{
 		HeightHint:                   c.hint.Load(),
 		Heights:                      heights,
 		Entries:                      entries,
+		TotalBytes:                   totalBytes,
+		MaxEntries:                   maxEntries,
+		MaxBytes:                     maxBytes,
 		RequestsTotal:                c.stats.requestsTotal.Load(),
 		CacheHitTotal:                c.stats.cacheHitTotal.Load(),
 		CacheCorruptHitTotal:         c.stats.cacheCorruptHitTotal.Load(),
@@ -116,6 +154,7 @@ func (c *QueryCache) SnapshotStats() QueryCacheStats {
 		BackendInvokeTotal:           c.stats.backendInvokeTotal.Load(),
 		CacheWriteTotal:              c.stats.cacheWriteTotal.Load(),
 		CacheWriteSkippedHeightTotal: c.stats.cacheWriteSkippedHeightTotal.Load(),
+		CacheEvictTotal:              c.stats.cacheEvictTotal.Load(),
 		InvokeErrorTotal:             c.stats.invokeErrorTotal.Load(),
 	}
 }
@@ -128,34 +167,67 @@ func (c *QueryCache) ResetStats() {
 	c.stats.backendInvokeTotal.Store(0)
 	c.stats.cacheWriteTotal.Store(0)
 	c.stats.cacheWriteSkippedHeightTotal.Store(0)
+	c.stats.cacheEvictTotal.Store(0)
 	c.stats.invokeErrorTotal.Store(0)
 }
 
 func (c *QueryCache) lookup(height int64, key string) ([]byte, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if bucket, ok := c.byHeight[height]; ok {
-		v, hit := bucket[key]
-		return v, hit
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	bucket, ok := c.byHeight[height]
+	if !ok {
+		return nil, false
 	}
-	return nil, false
+	v, hit := bucket[key]
+	if !hit {
+		return nil, false
+	}
+	if el, ok := c.lruIndex[lruKey{height: height, key: key}]; ok {
+		c.lru.MoveToFront(el)
+	}
+	return v, true
 }
 
 func (c *QueryCache) store(height int64, key string, data []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	lk := lruKey{height: height, key: key}
+	if el, ok := c.lruIndex[lk]; ok {
+		ent := el.Value.(*lruEntry)
+		c.totalBytes += int64(len(data)) - int64(ent.size)
+		ent.size = len(data)
+		c.lru.MoveToFront(el)
+	} else {
+		ent := &lruEntry{height: height, key: key, size: len(data)}
+		c.lruIndex[lk] = c.lru.PushFront(ent)
+		c.totalBytes += int64(ent.size)
+	}
+
 	bucket, ok := c.byHeight[height]
 	if !ok {
 		bucket = make(map[string][]byte)
 		c.byHeight[height] = bucket
 	}
 	bucket[key] = data
+
 	c.pruneLocked()
+	c.evictLocked()
 }
 
 func (c *QueryCache) deleteEntry(height int64, key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.removeEntryLocked(height, key)
+}
+
+func (c *QueryCache) removeEntryLocked(height int64, key string) {
+	lk := lruKey{height: height, key: key}
+	if el, ok := c.lruIndex[lk]; ok {
+		c.totalBytes -= int64(el.Value.(*lruEntry).size)
+		c.lru.Remove(el)
+		delete(c.lruIndex, lk)
+	}
 	if bucket, ok := c.byHeight[height]; ok {
 		delete(bucket, key)
 		if len(bucket) == 0 {
@@ -177,8 +249,46 @@ func (c *QueryCache) pruneLocked() {
 				first = false
 			}
 		}
-		delete(c.byHeight, oldest)
+		c.dropHeightLocked(oldest)
 	}
+}
+
+func (c *QueryCache) dropHeightLocked(height int64) {
+	bucket, ok := c.byHeight[height]
+	if !ok {
+		return
+	}
+	for key := range bucket {
+		lk := lruKey{height: height, key: key}
+		if el, ok := c.lruIndex[lk]; ok {
+			c.totalBytes -= int64(el.Value.(*lruEntry).size)
+			c.lru.Remove(el)
+			delete(c.lruIndex, lk)
+		}
+	}
+	delete(c.byHeight, height)
+}
+
+func (c *QueryCache) evictLocked() {
+	for c.overLimitLocked() {
+		el := c.lru.Back()
+		if el == nil {
+			return
+		}
+		ent := el.Value.(*lruEntry)
+		c.removeEntryLocked(ent.height, ent.key)
+		c.stats.cacheEvictTotal.Add(1)
+	}
+}
+
+func (c *QueryCache) overLimitLocked() bool {
+	if c.maxEntries > 0 && len(c.lruIndex) > c.maxEntries {
+		return true
+	}
+	if c.maxBytes > 0 && c.totalBytes > c.maxBytes {
+		return true
+	}
+	return false
 }
 
 type CachingConn struct {

--- a/decentralized-api/cosmosclient/query_cache.go
+++ b/decentralized-api/cosmosclient/query_cache.go
@@ -21,8 +21,8 @@ import (
 
 const (
 	defaultKeepLastHeights = 3
-	defaultMaxEntries = 10000
-	defaultMaxBytes   = 64 << 20
+	defaultMaxEntries = 200000
+	defaultMaxBytes   = 1 << 30 // 1 GiB
 )
 
 type queryCacheBypassKey struct{}

--- a/decentralized-api/cosmosclient/query_cache.go
+++ b/decentralized-api/cosmosclient/query_cache.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	gogoproto "github.com/cosmos/gogoproto/proto"
@@ -21,8 +22,9 @@ import (
 
 const (
 	defaultKeepLastHeights = 3
-	defaultMaxEntries = 200000
-	defaultMaxBytes   = 1 << 30 // 1 GiB
+	defaultMaxEntries      = 200000
+	defaultMaxBytes        = 1 << 30 // 1 GiB
+	defaultMaxHintAge      = 30 * time.Second
 )
 
 type queryCacheBypassKey struct{}
@@ -56,6 +58,8 @@ type QueryCacheStats struct {
 	CacheWriteTotal              uint64 `json:"cache_write_total"`
 	CacheWriteSkippedHeightTotal uint64 `json:"cache_write_skipped_height_total"`
 	CacheEvictTotal              uint64 `json:"cache_evict_total"`
+	CachePruneTotal              uint64 `json:"cache_prune_total"`
+	StaleHintBypassTotal         uint64 `json:"stale_hint_bypass_total"`
 	InvokeErrorTotal             uint64 `json:"invoke_error_total"`
 }
 
@@ -68,6 +72,8 @@ type queryCacheCounters struct {
 	cacheWriteTotal              atomic.Uint64
 	cacheWriteSkippedHeightTotal atomic.Uint64
 	cacheEvictTotal              atomic.Uint64
+	cachePruneTotal              atomic.Uint64
+	staleHintBypassTotal         atomic.Uint64
 	invokeErrorTotal             atomic.Uint64
 }
 
@@ -83,7 +89,10 @@ type lruEntry struct {
 }
 
 type QueryCache struct {
-	hint atomic.Int64
+	hint      atomic.Int64
+	hintSetAt atomic.Int64
+
+	maxHintAge time.Duration
 
 	mu       sync.RWMutex
 	byHeight map[int64]map[string][]byte
@@ -111,6 +120,7 @@ func NewQueryCacheWithLimits(maxEntries int, maxBytes int64) *QueryCache {
 		lruIndex:   make(map[lruKey]*list.Element),
 		maxEntries: maxEntries,
 		maxBytes:   maxBytes,
+		maxHintAge: defaultMaxHintAge,
 	}
 }
 
@@ -120,13 +130,29 @@ func (c *QueryCache) SetHeightHint(h int64) {
 	}
 	for {
 		cur := c.hint.Load()
-		if h <= cur {
+		if h < cur {
+			return
+		}
+		if h == cur {
+			c.hintSetAt.Store(time.Now().UnixNano())
 			return
 		}
 		if c.hint.CompareAndSwap(cur, h) {
+			c.hintSetAt.Store(time.Now().UnixNano())
 			return
 		}
 	}
+}
+
+func (c *QueryCache) hintFresh() bool {
+	if c.maxHintAge <= 0 {
+		return true
+	}
+	setAt := c.hintSetAt.Load()
+	if setAt == 0 {
+		return false
+	}
+	return time.Since(time.Unix(0, setAt)) <= c.maxHintAge
 }
 
 func (c *QueryCache) HeightHint() int64 { return c.hint.Load() }
@@ -155,6 +181,8 @@ func (c *QueryCache) SnapshotStats() QueryCacheStats {
 		CacheWriteTotal:              c.stats.cacheWriteTotal.Load(),
 		CacheWriteSkippedHeightTotal: c.stats.cacheWriteSkippedHeightTotal.Load(),
 		CacheEvictTotal:              c.stats.cacheEvictTotal.Load(),
+		CachePruneTotal:              c.stats.cachePruneTotal.Load(),
+		StaleHintBypassTotal:         c.stats.staleHintBypassTotal.Load(),
 		InvokeErrorTotal:             c.stats.invokeErrorTotal.Load(),
 	}
 }
@@ -168,6 +196,8 @@ func (c *QueryCache) ResetStats() {
 	c.stats.cacheWriteTotal.Store(0)
 	c.stats.cacheWriteSkippedHeightTotal.Store(0)
 	c.stats.cacheEvictTotal.Store(0)
+	c.stats.cachePruneTotal.Store(0)
+	c.stats.staleHintBypassTotal.Store(0)
 	c.stats.invokeErrorTotal.Store(0)
 }
 
@@ -262,6 +292,7 @@ func (c *QueryCache) dropHeightLocked(height int64) {
 			c.lru.Remove(el)
 			delete(c.lruIndex, lk)
 		}
+		c.stats.cachePruneTotal.Add(1)
 	}
 	delete(c.byHeight, height)
 }
@@ -306,7 +337,9 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 
 	explicitHeight := heightFromOutgoingCtx(ctx)
 	height := explicitHeight
+	hintTrusted := true
 	if height == 0 {
+		hintTrusted = c.cache.hintFresh()
 		height = c.cache.HeightHint()
 	}
 	if height == 0 {
@@ -319,23 +352,20 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 	}
 	key := buildCacheKey(method, requestHash)
 
-	if cached, hit := c.cache.lookup(height, key); hit {
-		if err := unmarshalProtoMessage(cached, reply); err == nil {
-			c.cache.stats.cacheHitTotal.Add(1)
-			if header := headerAddrFromCallOptions(opts); header != nil {
-				*header = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
+	if hintTrusted {
+		if cached, hit := c.cache.lookup(height, key); hit {
+			if err := unmarshalProtoMessage(cached, reply); err == nil {
+				c.cache.stats.cacheHitTotal.Add(1)
+				mergeHeightIntoHeader(headerAddrFromCallOptions(opts), height)
+				return nil
 			}
-			return nil
+			c.cache.stats.cacheCorruptHitTotal.Add(1)
+			c.cache.deleteEntry(height, key)
 		}
-		c.cache.stats.cacheCorruptHitTotal.Add(1)
-		c.cache.deleteEntry(height, key)
+	} else {
+		c.cache.stats.staleHintBypassTotal.Add(1)
 	}
 	c.cache.stats.cacheMissTotal.Add(1)
-
-	pinnedCtx := ctx
-	if explicitHeight == 0 {
-		pinnedCtx = setPinnedHeight(ctx, height)
-	}
 
 	callOpts := make([]grpc.CallOption, len(opts))
 	copy(callOpts, opts)
@@ -348,11 +378,13 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 
 	sfKey := strconv.FormatInt(height, 10) + "|" + key
 	loadOrFetch := func() (interface{}, error) {
-		if cached, hit := c.cache.lookup(height, key); hit {
-			return cacheInvokeResult{data: cached, height: height, fromCache: true, dataValid: true}, nil
+		if hintTrusted {
+			if cached, hit := c.cache.lookup(height, key); hit {
+				return cacheInvokeResult{data: cached, height: height, fromCache: true, dataValid: true}, nil
+			}
 		}
 
-		if err := c.invokeBackend(pinnedCtx, method, args, reply, callOpts...); err != nil {
+		if err := c.invokeBackend(ctx, method, args, reply, callOpts...); err != nil {
 			return nil, err
 		}
 
@@ -393,9 +425,7 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 		return fmt.Errorf("unexpected cache invoke result type: %T", resultAny)
 	}
 
-	if header := headerAddrFromCallOptions(opts); header != nil && result.height > 0 {
-		*header = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(result.height, 10))
-	}
+	mergeHeightIntoHeader(headerAddrFromCallOptions(opts), result.height)
 
 	if result.leaderReply == reply {
 		return nil
@@ -403,7 +433,7 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 
 	if !result.dataValid {
 		if shared {
-			return c.invokeBackend(pinnedCtx, method, args, reply, callOpts...)
+			return c.invokeBackend(ctx, method, args, reply, callOpts...)
 		}
 		return nil
 	}
@@ -415,7 +445,7 @@ func (c *CachingConn) Invoke(ctx context.Context, method string, args, reply int
 		if result.height > 0 {
 			c.cache.deleteEntry(result.height, key)
 		}
-		return c.invokeBackend(pinnedCtx, method, args, reply, callOpts...)
+		return c.invokeBackend(ctx, method, args, reply, callOpts...)
 	}
 	return nil
 }
@@ -481,6 +511,20 @@ func heightFromIncomingMD(md metadata.MD) int64 {
 		return 0
 	}
 	return h
+}
+
+func mergeHeightIntoHeader(header *metadata.MD, height int64) {
+	if header == nil || height <= 0 {
+		return
+	}
+	md := *header
+	if md == nil {
+		md = metadata.MD{}
+	} else {
+		md = md.Copy()
+	}
+	md.Set(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
+	*header = md
 }
 
 func headerAddrFromCallOptions(opts []grpc.CallOption) *metadata.MD {

--- a/decentralized-api/cosmosclient/query_cache.go
+++ b/decentralized-api/cosmosclient/query_cache.go
@@ -85,7 +85,7 @@ type lruEntry struct {
 type QueryCache struct {
 	hint atomic.Int64
 
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	byHeight map[int64]map[string][]byte
 	keepLast int
 
@@ -132,13 +132,13 @@ func (c *QueryCache) SetHeightHint(h int64) {
 func (c *QueryCache) HeightHint() int64 { return c.hint.Load() }
 
 func (c *QueryCache) SnapshotStats() QueryCacheStats {
-	c.mu.Lock()
+	c.mu.RLock()
 	heights := len(c.byHeight)
 	entries := len(c.lruIndex)
 	totalBytes := c.totalBytes
 	maxEntries := c.maxEntries
 	maxBytes := c.maxBytes
-	c.mu.Unlock()
+	c.mu.RUnlock()
 
 	return QueryCacheStats{
 		HeightHint:                   c.hint.Load(),
@@ -172,8 +172,8 @@ func (c *QueryCache) ResetStats() {
 }
 
 func (c *QueryCache) lookup(height int64, key string) ([]byte, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	bucket, ok := c.byHeight[height]
 	if !ok {
 		return nil, false
@@ -181,9 +181,6 @@ func (c *QueryCache) lookup(height int64, key string) ([]byte, bool) {
 	v, hit := bucket[key]
 	if !hit {
 		return nil, false
-	}
-	if el, ok := c.lruIndex[lruKey{height: height, key: key}]; ok {
-		c.lru.MoveToFront(el)
 	}
 	return v, true
 }

--- a/decentralized-api/cosmosclient/query_cache.go
+++ b/decentralized-api/cosmosclient/query_cache.go
@@ -1,19 +1,19 @@
 package cosmosclient
 
 import (
-	"container/list"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	gogoproto "github.com/cosmos/gogoproto/proto"
+	"github.com/maypok86/otter/v2"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	defaultKeepLastHeights = 3
-	defaultMaxEntries      = 200000
-	defaultMaxBytes        = 1 << 30 // 1 GiB
-	defaultMaxHintAge      = 30 * time.Second
+	defaultMaxEntries = 200000
+	defaultMaxBytes   = 1 << 30 // 1 GiB
+	defaultMaxHintAge = 30 * time.Second
+	defaultEntryTTL   = 30 * time.Second
+	entryOverhead     = 128
 )
 
 type queryCacheBypassKey struct{}
@@ -45,7 +46,6 @@ func shouldBypassQueryCache(ctx context.Context) bool {
 
 type QueryCacheStats struct {
 	HeightHint                   int64  `json:"height_hint"`
-	Heights                      int    `json:"heights"`
 	Entries                      int    `json:"entries"`
 	TotalBytes                   int64  `json:"total_bytes"`
 	MaxEntries                   int    `json:"max_entries"`
@@ -77,30 +77,13 @@ type queryCacheCounters struct {
 	invokeErrorTotal             atomic.Uint64
 }
 
-type lruKey struct {
-	height int64
-	key    string
-}
-
-type lruEntry struct {
-	height int64
-	key    string
-	size   int
-}
-
 type QueryCache struct {
 	hint      atomic.Int64
 	hintSetAt atomic.Int64
 
 	maxHintAge time.Duration
 
-	mu       sync.RWMutex
-	byHeight map[int64]map[string][]byte
-	keepLast int
-
-	lru        *list.List
-	lruIndex   map[lruKey]*list.Element
-	totalBytes int64
+	entries    *otter.Cache[string, []byte]
 	maxEntries int
 	maxBytes   int64
 
@@ -108,20 +91,77 @@ type QueryCache struct {
 	stats   queryCacheCounters
 }
 
+type queryCacheConfig struct {
+	maxEntries int
+	maxBytes   int64
+	entryTTL   time.Duration
+	clock      otter.Clock
+	executor   func(func())
+}
+
 func NewQueryCache() *QueryCache {
 	return NewQueryCacheWithLimits(defaultMaxEntries, defaultMaxBytes)
 }
 
 func NewQueryCacheWithLimits(maxEntries int, maxBytes int64) *QueryCache {
-	return &QueryCache{
-		byHeight:   make(map[int64]map[string][]byte),
-		keepLast:   defaultKeepLastHeights,
-		lru:        list.New(),
-		lruIndex:   make(map[lruKey]*list.Element),
+	return newQueryCache(queryCacheConfig{
 		maxEntries: maxEntries,
 		maxBytes:   maxBytes,
+		entryTTL:   defaultEntryTTL,
+	})
+}
+
+func newQueryCache(cfg queryCacheConfig) *QueryCache {
+	c := &QueryCache{
 		maxHintAge: defaultMaxHintAge,
+		maxEntries: cfg.maxEntries,
+		maxBytes:   cfg.maxBytes,
 	}
+
+	opts := &otter.Options[string, []byte]{
+		ExpiryCalculator: otter.ExpiryCreating[string, []byte](cfg.entryTTL),
+		OnDeletion: func(e otter.DeletionEvent[string, []byte]) {
+			switch e.Cause {
+			case otter.CauseOverflow:
+				c.stats.cacheEvictTotal.Add(1)
+			case otter.CauseExpiration:
+				c.stats.cachePruneTotal.Add(1)
+			}
+		},
+		Executor: cfg.executor,
+		Clock:    cfg.clock,
+	}
+	switch {
+	case cfg.maxBytes > 0:
+		opts.MaximumWeight = uint64(cfg.maxBytes)
+		opts.Weigher = newEntryWeigher(cfg.maxEntries, cfg.maxBytes)
+	case cfg.maxEntries > 0:
+		opts.MaximumSize = cfg.maxEntries
+	}
+
+	c.entries = otter.Must(opts)
+	return c
+}
+
+func newEntryWeigher(maxEntries int, maxBytes int64) func(key string, value []byte) uint32 {
+	var minWeight uint64
+	if maxEntries > 0 {
+		minWeight = (uint64(maxBytes) + uint64(maxEntries) - 1) / uint64(maxEntries)
+	}
+	return func(key string, value []byte) uint32 {
+		weight := uint64(len(key)+len(value)) + entryOverhead
+		if weight < minWeight {
+			weight = minWeight
+		}
+		if weight > math.MaxUint32 {
+			return math.MaxUint32
+		}
+		return uint32(weight)
+	}
+}
+
+func entryKey(height int64, key string) string {
+	return strconv.FormatInt(height, 10) + "|" + key
 }
 
 func (c *QueryCache) SetHeightHint(h int64) {
@@ -158,21 +198,12 @@ func (c *QueryCache) hintFresh() bool {
 func (c *QueryCache) HeightHint() int64 { return c.hint.Load() }
 
 func (c *QueryCache) SnapshotStats() QueryCacheStats {
-	c.mu.RLock()
-	heights := len(c.byHeight)
-	entries := len(c.lruIndex)
-	totalBytes := c.totalBytes
-	maxEntries := c.maxEntries
-	maxBytes := c.maxBytes
-	c.mu.RUnlock()
-
 	return QueryCacheStats{
 		HeightHint:                   c.hint.Load(),
-		Heights:                      heights,
-		Entries:                      entries,
-		TotalBytes:                   totalBytes,
-		MaxEntries:                   maxEntries,
-		MaxBytes:                     maxBytes,
+		Entries:                      c.entries.EstimatedSize(),
+		TotalBytes:                   int64(c.entries.WeightedSize()),
+		MaxEntries:                   c.maxEntries,
+		MaxBytes:                     c.maxBytes,
 		RequestsTotal:                c.stats.requestsTotal.Load(),
 		CacheHitTotal:                c.stats.cacheHitTotal.Load(),
 		CacheCorruptHitTotal:         c.stats.cacheCorruptHitTotal.Load(),
@@ -202,121 +233,15 @@ func (c *QueryCache) ResetStats() {
 }
 
 func (c *QueryCache) lookup(height int64, key string) ([]byte, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	bucket, ok := c.byHeight[height]
-	if !ok {
-		return nil, false
-	}
-	v, hit := bucket[key]
-	if !hit {
-		return nil, false
-	}
-	return v, true
+	return c.entries.GetIfPresent(entryKey(height, key))
 }
 
 func (c *QueryCache) store(height int64, key string, data []byte) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	lk := lruKey{height: height, key: key}
-	if el, ok := c.lruIndex[lk]; ok {
-		ent := el.Value.(*lruEntry)
-		c.totalBytes += int64(len(data)) - int64(ent.size)
-		ent.size = len(data)
-		c.lru.MoveToFront(el)
-	} else {
-		ent := &lruEntry{height: height, key: key, size: len(data)}
-		c.lruIndex[lk] = c.lru.PushFront(ent)
-		c.totalBytes += int64(ent.size)
-	}
-
-	bucket, ok := c.byHeight[height]
-	if !ok {
-		bucket = make(map[string][]byte)
-		c.byHeight[height] = bucket
-	}
-	bucket[key] = data
-
-	c.pruneLocked()
-	c.evictLocked()
+	c.entries.Set(entryKey(height, key), data)
 }
 
 func (c *QueryCache) deleteEntry(height int64, key string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.removeEntryLocked(height, key)
-}
-
-func (c *QueryCache) removeEntryLocked(height int64, key string) {
-	lk := lruKey{height: height, key: key}
-	if el, ok := c.lruIndex[lk]; ok {
-		c.totalBytes -= int64(el.Value.(*lruEntry).size)
-		c.lru.Remove(el)
-		delete(c.lruIndex, lk)
-	}
-	if bucket, ok := c.byHeight[height]; ok {
-		delete(bucket, key)
-		if len(bucket) == 0 {
-			delete(c.byHeight, height)
-		}
-	}
-}
-
-func (c *QueryCache) pruneLocked() {
-	if c.keepLast <= 0 {
-		return
-	}
-	for len(c.byHeight) > c.keepLast {
-		var oldest int64
-		first := true
-		for h := range c.byHeight {
-			if first || h < oldest {
-				oldest = h
-				first = false
-			}
-		}
-		c.dropHeightLocked(oldest)
-	}
-}
-
-func (c *QueryCache) dropHeightLocked(height int64) {
-	bucket, ok := c.byHeight[height]
-	if !ok {
-		return
-	}
-	for key := range bucket {
-		lk := lruKey{height: height, key: key}
-		if el, ok := c.lruIndex[lk]; ok {
-			c.totalBytes -= int64(el.Value.(*lruEntry).size)
-			c.lru.Remove(el)
-			delete(c.lruIndex, lk)
-		}
-		c.stats.cachePruneTotal.Add(1)
-	}
-	delete(c.byHeight, height)
-}
-
-func (c *QueryCache) evictLocked() {
-	for c.overLimitLocked() {
-		el := c.lru.Back()
-		if el == nil {
-			return
-		}
-		ent := el.Value.(*lruEntry)
-		c.removeEntryLocked(ent.height, ent.key)
-		c.stats.cacheEvictTotal.Add(1)
-	}
-}
-
-func (c *QueryCache) overLimitLocked() bool {
-	if c.maxEntries > 0 && len(c.lruIndex) > c.maxEntries {
-		return true
-	}
-	if c.maxBytes > 0 && c.totalBytes > c.maxBytes {
-		return true
-	}
-	return false
+	c.entries.Invalidate(entryKey(height, key))
 }
 
 type CachingConn struct {

--- a/decentralized-api/cosmosclient/query_cache_safety_test.go
+++ b/decentralized-api/cosmosclient/query_cache_safety_test.go
@@ -1,0 +1,152 @@
+package cosmosclient
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type latestConn struct {
+	mu           sync.Mutex
+	latestHeight int64
+	invokes      int
+	pinnedSeen   []int64
+	extraHeader  bool
+}
+
+func (c *latestConn) Invoke(ctx context.Context, _ string, _ interface{}, _ interface{}, opts ...grpc.CallOption) error {
+	c.mu.Lock()
+	c.invokes++
+	c.pinnedSeen = append(c.pinnedSeen, heightFromOutgoingCtx(ctx))
+	latest := c.latestHeight
+	extra := c.extraHeader
+	c.mu.Unlock()
+
+	height := latest
+	if pinned := heightFromOutgoingCtx(ctx); pinned > 0 {
+		height = pinned
+	}
+
+	if header := headerAddrFromCallOptions(opts); header != nil {
+		md := metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
+		if extra {
+			md.Set("x-extra", "backend-value")
+		}
+		*header = md
+	}
+	return nil
+}
+
+func (c *latestConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, nil
+}
+
+func (c *latestConn) invokeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.invokes
+}
+
+func (c *latestConn) pinned() []int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int64(nil), c.pinnedSeen...)
+}
+
+func TestCachingConn_UnpinnedMissIsNotPinnedAndHealsHint(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &latestConn{latestHeight: 101}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	resp := &emptypb.Empty{}
+	header := metadata.MD{}
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", req, resp, grpc.Header(&header)))
+
+	require.Equal(t, []int64{0}, inner.pinned(), "unpinned caller must not be pinned to the hint")
+	require.Equal(t, []string{"101"}, header.Get(grpctypes.GRPCBlockHeightHeader))
+	require.Equal(t, int64(101), cache.HeightHint(), "response height must advance the hint")
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+}
+
+func TestCachingConn_ExplicitPinIsPreserved(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &latestConn{latestHeight: 105}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	ctx := PinHeight(context.Background(), 99)
+	require.NoError(t, conn.Invoke(ctx, "/inference.Query/Models", &emptypb.Empty{}, &emptypb.Empty{}))
+	require.Equal(t, []int64{99}, inner.pinned())
+}
+
+func TestCachingConn_StaleHintBypassesLookupAndSelfHeals(t *testing.T) {
+	cache := NewQueryCache()
+	cache.maxHintAge = time.Minute
+	cache.SetHeightHint(100)
+
+	req := &emptypb.Empty{}
+	requestHash, err := buildRequestHash(req)
+	require.NoError(t, err)
+	key := buildCacheKey("/inference.Query/Models", requestHash)
+	cache.store(100, key, []byte{})
+
+	cache.hintSetAt.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	inner := &latestConn{latestHeight: 102}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	resp := &emptypb.Empty{}
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", req, resp))
+	require.Equal(t, 1, inner.invokeCount(), "stale hint must skip the cache and hit the backend")
+	require.Equal(t, int64(102), cache.HeightHint())
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(1), stats.StaleHintBypassTotal)
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+}
+
+func TestCachingConn_HeaderKeepsBackendMetadataOnMiss(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &latestConn{latestHeight: 100, extraHeader: true}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	header := metadata.MD{}
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", &emptypb.Empty{}, &emptypb.Empty{}, grpc.Header(&header)))
+	require.Equal(t, []string{"backend-value"}, header.Get("x-extra"))
+	require.Equal(t, []string{"100"}, header.Get(grpctypes.GRPCBlockHeightHeader))
+
+	cachedHeader := metadata.MD{}
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", &emptypb.Empty{}, &emptypb.Empty{}, grpc.Header(&cachedHeader)))
+	require.Equal(t, 1, inner.invokeCount())
+	require.Equal(t, []string{"100"}, cachedHeader.Get(grpctypes.GRPCBlockHeightHeader))
+}
+
+func TestQueryCache_HeightPruneCountsInStats(t *testing.T) {
+	cache := NewQueryCache()
+
+	for h := int64(1); h <= int64(defaultKeepLastHeights+2); h++ {
+		cache.store(h, "k", []byte("v"))
+	}
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, defaultKeepLastHeights, stats.Heights)
+	require.Equal(t, uint64(2), stats.CachePruneTotal)
+}

--- a/decentralized-api/cosmosclient/query_cache_safety_test.go
+++ b/decentralized-api/cosmosclient/query_cache_safety_test.go
@@ -138,15 +138,3 @@ func TestCachingConn_HeaderKeepsBackendMetadataOnMiss(t *testing.T) {
 	require.Equal(t, 1, inner.invokeCount())
 	require.Equal(t, []string{"100"}, cachedHeader.Get(grpctypes.GRPCBlockHeightHeader))
 }
-
-func TestQueryCache_HeightPruneCountsInStats(t *testing.T) {
-	cache := NewQueryCache()
-
-	for h := int64(1); h <= int64(defaultKeepLastHeights+2); h++ {
-		cache.store(h, "k", []byte("v"))
-	}
-
-	stats := cache.SnapshotStats()
-	require.Equal(t, defaultKeepLastHeights, stats.Heights)
-	require.Equal(t, uint64(2), stats.CachePruneTotal)
-}

--- a/decentralized-api/cosmosclient/query_cache_test.go
+++ b/decentralized-api/cosmosclient/query_cache_test.go
@@ -668,7 +668,7 @@ func TestQueryCache_EvictsByByteLimit(t *testing.T) {
 	require.False(t, ok, "least-recently-used entry must be evicted")
 }
 
-func TestQueryCache_LookupBumpsRecency(t *testing.T) {
+func TestQueryCache_LookupDoesNotBumpRecency(t *testing.T) {
 	cache := NewQueryCacheWithLimits(2, 0)
 
 	cache.store(100, "a", []byte("v"))
@@ -679,9 +679,9 @@ func TestQueryCache_LookupBumpsRecency(t *testing.T) {
 	cache.store(100, "c", []byte("v"))
 
 	_, ok = cache.lookup(100, "a")
-	require.True(t, ok, "recently used entry must survive")
+	require.False(t, ok, "lookup must not bump recency on hot read path")
 	_, ok = cache.lookup(100, "b")
-	require.False(t, ok, "least-recently-used entry must be evicted")
+	require.True(t, ok, "entry b remains because reads do not reorder LRU")
 }
 
 func TestQueryCache_HeightPruneReleasesBytes(t *testing.T) {

--- a/decentralized-api/cosmosclient/query_cache_test.go
+++ b/decentralized-api/cosmosclient/query_cache_test.go
@@ -1,0 +1,644 @@
+package cosmosclient
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type testConn struct {
+	mu            sync.Mutex
+	height        int64
+	invokes       int
+	invokeErr     error
+	headerOpts    int
+	blockCh       chan struct{}
+	startedCh     chan struct{}
+	blockOnce     bool
+	heightFromCtx bool
+	omitHeader    bool
+}
+
+func (c *testConn) Invoke(ctx context.Context, _ string, _ interface{}, _ interface{}, opts ...grpc.CallOption) error {
+	c.mu.Lock()
+	c.invokes++
+	currentInvoke := c.invokes
+	invokeErr := c.invokeErr
+	height := c.height
+	blockCh := c.blockCh
+	startedCh := c.startedCh
+	blockOnce := c.blockOnce
+	heightFromCtx := c.heightFromCtx
+	omitHeader := c.omitHeader
+	c.mu.Unlock()
+
+	if heightFromCtx {
+		if pinned := heightFromOutgoingCtx(ctx); pinned > 0 {
+			height = pinned
+		}
+	}
+
+	if startedCh != nil {
+		select {
+		case startedCh <- struct{}{}:
+		default:
+		}
+	}
+	if blockCh != nil && (!blockOnce || currentInvoke == 1) {
+		select {
+		case <-blockCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if invokeErr != nil {
+		return invokeErr
+	}
+
+	var headerAddrs []*metadata.MD
+	for _, opt := range opts {
+		switch headerOpt := opt.(type) {
+		case grpc.HeaderCallOption:
+			if headerOpt.HeaderAddr != nil {
+				headerAddrs = append(headerAddrs, headerOpt.HeaderAddr)
+			}
+		case *grpc.HeaderCallOption:
+			if headerOpt != nil && headerOpt.HeaderAddr != nil {
+				headerAddrs = append(headerAddrs, headerOpt.HeaderAddr)
+			}
+		}
+	}
+	c.mu.Lock()
+	c.headerOpts = len(headerAddrs)
+	c.mu.Unlock()
+	if len(headerAddrs) > 0 && !omitHeader {
+		*headerAddrs[len(headerAddrs)-1] = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
+	}
+	return nil
+}
+
+func (c *testConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, nil
+}
+
+func (c *testConn) invokeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.invokes
+}
+
+func (c *testConn) headerOptCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.headerOpts
+}
+
+func TestCachingConn_CachesByResponseHeight(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{height: 100}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	resp := &emptypb.Empty{}
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+}
+
+func TestCachingConn_CachesAtResponseHeightWhenItDiffers(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{height: 99}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	resp := &emptypb.Empty{}
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+	require.Equal(t, 2, inner.invokeCount())
+}
+
+func TestCachingConn_UsesExistingHeaderCallOption(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{height: 100}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	resp := &emptypb.Empty{}
+	callerHeader := metadata.MD{}
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp, grpc.Header(&callerHeader)))
+	require.Equal(t, 1, inner.headerOptCount())
+	require.Equal(t, []string{"100"}, callerHeader.Get(grpctypes.GRPCBlockHeightHeader))
+
+	cachedHeader := metadata.MD{}
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp, grpc.Header(&cachedHeader)))
+	require.Equal(t, 1, inner.invokeCount())
+	require.Equal(t, []string{"100"}, cachedHeader.Get(grpctypes.GRPCBlockHeightHeader))
+}
+
+func TestCachingConn_SupportsGogoProtoMessages(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{height: 100}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &inferencetypes.QueryParamsRequest{}
+	resp := &inferencetypes.QueryParamsResponse{}
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.inference.Query/Params", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.inference.Query/Params", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+}
+
+func TestCachingConn_DeduplicatesConcurrentMisses(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{
+		height:    100,
+		blockCh:   make(chan struct{}),
+		startedCh: make(chan struct{}, 16),
+	}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp := &emptypb.Empty{}
+			errCh <- conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp)
+		}()
+	}
+
+	<-inner.startedCh
+	close(inner.blockCh)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 1, inner.invokeCount())
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(workers), stats.RequestsTotal)
+	require.GreaterOrEqual(t, stats.CacheMissTotal, uint64(1))
+	require.Equal(t, uint64(workers), stats.CacheHitTotal+stats.CacheMissTotal)
+	require.Equal(t, uint64(1), stats.BackendInvokeTotal)
+	require.Equal(t, uint64(1), stats.CacheWriteTotal)
+}
+
+func TestCachingConn_DeduplicatesConcurrentMisses_WhenResponseHeightMissing(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{
+		height:     100,
+		omitHeader: true,
+		blockCh:    make(chan struct{}),
+		startedCh:  make(chan struct{}, 1),
+	}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	const method = "/inference.Query/EpochInfo"
+
+	leaderErrCh := make(chan error, 1)
+	go func() {
+		resp := &emptypb.Empty{}
+		leaderErrCh <- conn.Invoke(context.Background(), method, req, resp)
+	}()
+
+	<-inner.startedCh
+
+	const workers = 8
+	startFollowers := make(chan struct{})
+	followersReady := make(chan struct{}, workers)
+	followerErrCh := make(chan error, workers)
+	var wg sync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp := &emptypb.Empty{}
+			followersReady <- struct{}{}
+			<-startFollowers
+			followerErrCh <- conn.Invoke(context.Background(), method, req, resp)
+		}()
+	}
+
+	for i := 0; i < workers; i++ {
+		<-followersReady
+	}
+	close(startFollowers)
+
+	require.Eventually(t, func() bool {
+		return cache.SnapshotStats().RequestsTotal == uint64(workers+1)
+	}, time.Second, time.Millisecond)
+
+	close(inner.blockCh)
+
+	require.NoError(t, <-leaderErrCh)
+	wg.Wait()
+	close(followerErrCh)
+
+	for err := range followerErrCh {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 1, inner.invokeCount())
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(workers+1), stats.RequestsTotal)
+	require.Equal(t, uint64(1), stats.BackendInvokeTotal)
+	require.Equal(t, uint64(0), stats.CacheWriteTotal)
+	require.Equal(t, uint64(1), stats.CacheWriteSkippedHeightTotal)
+	require.Equal(t, 0, stats.Heights)
+	require.Equal(t, 0, stats.Entries)
+}
+
+func TestCachingConn_WithoutQueryCache_BypassesHintAndCache(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{height: 100}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	ctx := WithoutQueryCache(context.Background())
+
+	resp := &emptypb.Empty{}
+	require.NoError(t, conn.Invoke(ctx, "/inference.Query/EpochInfo", req, resp))
+	require.NoError(t, conn.Invoke(ctx, "/inference.Query/EpochInfo", req, resp))
+	require.Equal(t, 2, inner.invokeCount())
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(2), stats.RequestsTotal)
+	require.Equal(t, uint64(0), stats.CacheHitTotal)
+	require.Equal(t, uint64(0), stats.CacheMissTotal)
+	require.Equal(t, uint64(2), stats.BackendInvokeTotal)
+	require.Equal(t, uint64(0), stats.CacheWriteTotal)
+}
+
+func TestCachingConn_FallbacksToBackendOnCorruptedCacheEntry(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	req := &emptypb.Empty{}
+	requestHash, err := buildRequestHash(req)
+	require.NoError(t, err)
+	key := buildCacheKey("/inference.Query/EpochInfo", requestHash)
+	cache.store(100, key, []byte("corrupted-payload"))
+
+	inner := &testConn{height: 100}
+	conn := &CachingConn{inner: inner, cache: cache}
+	resp := &emptypb.Empty{}
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(1), stats.CacheHitTotal)
+	require.Equal(t, uint64(1), stats.CacheCorruptHitTotal)
+	require.Equal(t, uint64(1), stats.CacheMissTotal)
+	require.Equal(t, uint64(1), stats.BackendInvokeTotal)
+	require.Equal(t, uint64(1), stats.CacheWriteTotal)
+}
+
+func TestQueryCacheStatsReset(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{height: 100}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	resp := &emptypb.Empty{}
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+
+	beforeReset := cache.SnapshotStats()
+	require.Equal(t, uint64(2), beforeReset.RequestsTotal)
+	require.Equal(t, uint64(1), beforeReset.CacheMissTotal)
+	require.Equal(t, uint64(1), beforeReset.CacheHitTotal)
+	require.Equal(t, uint64(0), beforeReset.CacheCorruptHitTotal)
+	require.Equal(t, uint64(1), beforeReset.BackendInvokeTotal)
+	require.Equal(t, uint64(1), beforeReset.CacheWriteTotal)
+	require.Equal(t, int64(100), beforeReset.HeightHint)
+	require.Equal(t, 1, beforeReset.Heights)
+	require.Equal(t, 1, beforeReset.Entries)
+
+	cache.ResetStats()
+
+	afterReset := cache.SnapshotStats()
+	require.Equal(t, uint64(0), afterReset.RequestsTotal)
+	require.Equal(t, uint64(0), afterReset.CacheMissTotal)
+	require.Equal(t, uint64(0), afterReset.CacheHitTotal)
+	require.Equal(t, uint64(0), afterReset.CacheCorruptHitTotal)
+	require.Equal(t, uint64(0), afterReset.BackendInvokeTotal)
+	require.Equal(t, uint64(0), afterReset.CacheWriteTotal)
+	require.Equal(t, uint64(0), afterReset.InvokeErrorTotal)
+	require.Equal(t, int64(100), afterReset.HeightHint)
+	require.Equal(t, 1, afterReset.Heights)
+	require.Equal(t, 1, afterReset.Entries)
+}
+
+func TestCachingConn_RetriesBackendForSharedContextCancellation(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{
+		height:    100,
+		blockCh:   make(chan struct{}),
+		startedCh: make(chan struct{}, 2),
+		blockOnce: true,
+	}
+	conn := &CachingConn{inner: inner, cache: cache}
+	req := &emptypb.Empty{}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	defer cancelLeader()
+
+	var (
+		leaderErr   error
+		followerErr error
+	)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		resp := &emptypb.Empty{}
+		leaderErr = conn.Invoke(leaderCtx, "/inference.Query/EpochInfo", req, resp)
+	}()
+
+	<-inner.startedCh
+
+	go func() {
+		defer wg.Done()
+		resp := &emptypb.Empty{}
+		followerErr = conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp)
+	}()
+
+	cancelLeader()
+	wg.Wait()
+
+	require.ErrorIs(t, leaderErr, context.Canceled)
+	require.NoError(t, followerErr)
+	require.Equal(t, 2, inner.invokeCount())
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(2), stats.RequestsTotal)
+	require.Equal(t, uint64(2), stats.CacheMissTotal)
+	require.Equal(t, uint64(2), stats.BackendInvokeTotal)
+	require.Equal(t, uint64(1), stats.InvokeErrorTotal)
+	require.Equal(t, uint64(1), stats.CacheWriteTotal)
+}
+
+func TestCachingConn_SharedCancellationRetryDoesNotStampedeBackend(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{
+		height:    100,
+		blockCh:   make(chan struct{}),
+		startedCh: make(chan struct{}, 4),
+		blockOnce: true,
+	}
+	conn := &CachingConn{inner: inner, cache: cache}
+	req := &emptypb.Empty{}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	defer cancelLeader()
+
+	const followers = 8
+	var leaderErr error
+	followerErrCh := make(chan error, followers)
+
+	startFollowers := make(chan struct{})
+	followersReady := make(chan struct{}, followers)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp := &emptypb.Empty{}
+		leaderErr = conn.Invoke(leaderCtx, "/inference.Query/EpochInfo", req, resp)
+	}()
+
+	<-inner.startedCh
+
+	for i := 0; i < followers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp := &emptypb.Empty{}
+			followersReady <- struct{}{}
+			<-startFollowers
+			followerErrCh <- conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp)
+		}()
+	}
+
+	for i := 0; i < followers; i++ {
+		<-followersReady
+	}
+	close(startFollowers)
+
+	cancelLeader()
+	wg.Wait()
+	close(followerErrCh)
+
+	require.ErrorIs(t, leaderErr, context.Canceled)
+	for err := range followerErrCh {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 2, inner.invokeCount())
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(followers+1), stats.RequestsTotal)
+	require.Equal(t, uint64(2), stats.BackendInvokeTotal)
+	require.Equal(t, uint64(1), stats.InvokeErrorTotal)
+	require.Equal(t, uint64(1), stats.CacheWriteTotal)
+}
+
+func TestCachingConn_TwoWorkersDifferentBlockCtx_NoInterference(t *testing.T) {
+	cache := NewQueryCache()
+	inner := &testConn{heightFromCtx: true}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	const method = "/inference.Query/EpochInfo"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		ctx := PinHeight(context.Background(), 100)
+		resp := &emptypb.Empty{}
+		require.NoError(t, conn.Invoke(ctx, method, req, resp))
+		require.NoError(t, conn.Invoke(ctx, method, req, resp)) // hit on 100
+	}()
+	go func() {
+		defer wg.Done()
+		ctx := PinHeight(context.Background(), 101)
+		resp := &emptypb.Empty{}
+		require.NoError(t, conn.Invoke(ctx, method, req, resp))
+		require.NoError(t, conn.Invoke(ctx, method, req, resp)) // hit on 101
+	}()
+	wg.Wait()
+
+	require.Equal(t, 2, inner.invokeCount(), "exactly one backend call per height")
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(4), stats.RequestsTotal)
+	require.Equal(t, uint64(2), stats.CacheHitTotal)
+	require.Equal(t, uint64(2), stats.CacheMissTotal)
+	require.Equal(t, uint64(2), stats.CacheWriteTotal)
+	require.Equal(t, 2, stats.Heights)
+	require.Equal(t, 2, stats.Entries)
+
+	requestHash, err := buildRequestHash(req)
+	require.NoError(t, err)
+	key := buildCacheKey(method, requestHash)
+	_, ok := cache.lookup(100, key)
+	require.True(t, ok, "height 100 entry must exist")
+	_, ok = cache.lookup(101, key)
+	require.True(t, ok, "height 101 entry must exist")
+}
+
+func TestCachingConn_HintFallbackForUnpinnedCallers(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(200)
+
+	inner := &testConn{height: 200}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	resp := &emptypb.Empty{}
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", req, resp))
+	require.Equal(t, 1, inner.invokeCount(), "second unpinned call must hit cache via hint")
+}
+
+func TestCachingConn_HintFlipDuringRequest_NoCorruption(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(100)
+
+	inner := &testConn{
+		heightFromCtx: true,
+		blockCh:       make(chan struct{}),
+		startedCh:     make(chan struct{}, 2),
+		blockOnce:     true,
+	}
+	conn := &CachingConn{inner: inner, cache: cache}
+	req := &emptypb.Empty{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx := PinHeight(context.Background(), 100)
+		resp := &emptypb.Empty{}
+		require.NoError(t, conn.Invoke(ctx, "/inference.Query/EpochInfo", req, resp))
+	}()
+
+	<-inner.startedCh
+	cache.SetHeightHint(101)
+	close(inner.blockCh)
+	wg.Wait()
+
+	require.Equal(t, int64(101), cache.HeightHint(), "hint must not be lowered by completing request")
+
+	requestHash, err := buildRequestHash(req)
+	require.NoError(t, err)
+	key := buildCacheKey("/inference.Query/EpochInfo", requestHash)
+	_, hit100 := cache.lookup(100, key)
+	require.True(t, hit100, "in-flight request must have cached at its actual response height (100)")
+	_, hit101 := cache.lookup(101, key)
+	require.False(t, hit101, "no entry must exist at the bumped hint height")
+
+	resp := &emptypb.Empty{}
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/EpochInfo", req, resp))
+	require.Equal(t, 2, inner.invokeCount(), "post-flip call must reach backend, not reuse 100 entry")
+}
+
+func TestQueryCachePruning_KeepsLastNHeights(t *testing.T) {
+	cache := NewQueryCache()
+	inner := &testConn{heightFromCtx: true}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	const method = "/inference.Query/EpochInfo"
+
+	for h := int64(1); h <= int64(defaultKeepLastHeights+2); h++ {
+		ctx := PinHeight(context.Background(), h)
+		resp := &emptypb.Empty{}
+		require.NoError(t, conn.Invoke(ctx, method, req, resp))
+	}
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, defaultKeepLastHeights, stats.Heights)
+
+	requestHash, err := buildRequestHash(req)
+	require.NoError(t, err)
+	key := buildCacheKey(method, requestHash)
+
+	_, ok := cache.lookup(1, key)
+	require.False(t, ok, "oldest height should have been pruned")
+	_, ok = cache.lookup(2, key)
+	require.False(t, ok, "second oldest height should have been pruned")
+	for h := int64(3); h <= int64(defaultKeepLastHeights+2); h++ {
+		_, ok := cache.lookup(h, key)
+		require.Truef(t, ok, "height %d entry must remain", h)
+	}
+}
+
+func TestPinHeight_DoesNotStackDuplicateValues(t *testing.T) {
+	ctx := PinHeight(context.Background(), 100)
+	ctx = PinHeight(ctx, 100)
+	require.Equal(t, int64(100), heightFromOutgoingCtx(ctx))
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok)
+	vals := md.Get(grpctypes.GRPCBlockHeightHeader)
+	require.Equal(t, []string{"100"}, vals, "no duplicate header values for same height")
+
+	ctx = PinHeight(ctx, 101)
+	require.Equal(t, int64(101), heightFromOutgoingCtx(ctx))
+}

--- a/decentralized-api/cosmosclient/query_cache_test.go
+++ b/decentralized-api/cosmosclient/query_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -266,7 +267,7 @@ func TestCachingConn_DeduplicatesConcurrentMisses_WhenResponseHeightMissing(t *t
 	close(startFollowers)
 
 	require.Eventually(t, func() bool {
-		return cache.SnapshotStats().RequestsTotal == uint64(workers+1)
+		return cache.SnapshotStats().CacheMissTotal == uint64(workers+1)
 	}, time.Second, time.Millisecond)
 
 	close(inner.blockCh)
@@ -279,13 +280,15 @@ func TestCachingConn_DeduplicatesConcurrentMisses_WhenResponseHeightMissing(t *t
 		require.NoError(t, err)
 	}
 
-	require.Equal(t, 1, inner.invokeCount())
+	invokes := inner.invokeCount()
+	require.GreaterOrEqual(t, invokes, 1)
+	require.LessOrEqual(t, invokes, 2, "dedup is best-effort: a follower entering singleflight after the leader completed performs its own call")
+
 	stats := cache.SnapshotStats()
 	require.Equal(t, uint64(workers+1), stats.RequestsTotal)
-	require.Equal(t, uint64(1), stats.BackendInvokeTotal)
+	require.Equal(t, uint64(invokes), stats.BackendInvokeTotal)
 	require.Equal(t, uint64(0), stats.CacheWriteTotal)
-	require.Equal(t, uint64(1), stats.CacheWriteSkippedHeightTotal)
-	require.Equal(t, 0, stats.Heights)
+	require.Equal(t, uint64(invokes), stats.CacheWriteSkippedHeightTotal)
 	require.Equal(t, 0, stats.Entries)
 }
 
@@ -359,7 +362,6 @@ func TestQueryCacheStatsReset(t *testing.T) {
 	require.Equal(t, uint64(1), beforeReset.BackendInvokeTotal)
 	require.Equal(t, uint64(1), beforeReset.CacheWriteTotal)
 	require.Equal(t, int64(100), beforeReset.HeightHint)
-	require.Equal(t, 1, beforeReset.Heights)
 	require.Equal(t, 1, beforeReset.Entries)
 
 	cache.ResetStats()
@@ -373,7 +375,6 @@ func TestQueryCacheStatsReset(t *testing.T) {
 	require.Equal(t, uint64(0), afterReset.CacheWriteTotal)
 	require.Equal(t, uint64(0), afterReset.InvokeErrorTotal)
 	require.Equal(t, int64(100), afterReset.HeightHint)
-	require.Equal(t, 1, afterReset.Heights)
 	require.Equal(t, 1, afterReset.Entries)
 }
 
@@ -527,7 +528,6 @@ func TestCachingConn_TwoWorkersDifferentBlockCtx_NoInterference(t *testing.T) {
 	require.Equal(t, uint64(2), stats.CacheHitTotal)
 	require.Equal(t, uint64(2), stats.CacheMissTotal)
 	require.Equal(t, uint64(2), stats.CacheWriteTotal)
-	require.Equal(t, 2, stats.Heights)
 	require.Equal(t, 2, stats.Entries)
 
 	requestHash, err := buildRequestHash(req)
@@ -598,103 +598,98 @@ func TestCachingConn_HintFlipDuringRequest_NoCorruption(t *testing.T) {
 	require.Equal(t, 2, inner.invokeCount(), "post-flip call must reach backend, not reuse 100 entry")
 }
 
-func TestQueryCachePruning_KeepsLastNHeights(t *testing.T) {
-	cache := NewQueryCache()
-	inner := &testConn{heightFromCtx: true}
-	conn := &CachingConn{inner: inner, cache: cache}
+type fakeClock struct {
+	now atomic.Int64
+}
 
-	req := &emptypb.Empty{}
-	const method = "/inference.Query/EpochInfo"
+func newFakeClock() *fakeClock {
+	c := &fakeClock{}
+	c.now.Store(time.Now().UnixNano())
+	return c
+}
 
-	for h := int64(1); h <= int64(defaultKeepLastHeights+2); h++ {
-		ctx := PinHeight(context.Background(), h)
-		resp := &emptypb.Empty{}
-		require.NoError(t, conn.Invoke(ctx, method, req, resp))
-	}
+func (c *fakeClock) NowNano() int64 { return c.now.Load() }
 
+func (c *fakeClock) Tick(time.Duration) <-chan time.Time { return nil }
+
+func (c *fakeClock) advance(d time.Duration) { c.now.Add(int64(d)) }
+
+func TestQueryCache_EntriesExpireAfterTTL(t *testing.T) {
+	clock := newFakeClock()
+	cache := newQueryCache(queryCacheConfig{
+		maxBytes: defaultMaxBytes,
+		entryTTL: defaultEntryTTL,
+		clock:    clock,
+		executor: func(fn func()) { fn() },
+	})
+
+	cache.store(100, "k", []byte("v"))
+	_, ok := cache.lookup(100, "k")
+	require.True(t, ok)
+
+	clock.advance(defaultEntryTTL + 2*time.Second)
+
+	_, ok = cache.lookup(100, "k")
+	require.False(t, ok, "expired entry must not be visible to reads")
+
+	cache.entries.CleanUp()
 	stats := cache.SnapshotStats()
-	require.Equal(t, defaultKeepLastHeights, stats.Heights)
-
-	requestHash, err := buildRequestHash(req)
-	require.NoError(t, err)
-	key := buildCacheKey(method, requestHash)
-
-	_, ok := cache.lookup(1, key)
-	require.False(t, ok, "oldest height should have been pruned")
-	_, ok = cache.lookup(2, key)
-	require.False(t, ok, "second oldest height should have been pruned")
-	for h := int64(3); h <= int64(defaultKeepLastHeights+2); h++ {
-		_, ok := cache.lookup(h, key)
-		require.Truef(t, ok, "height %d entry must remain", h)
-	}
+	require.Equal(t, uint64(1), stats.CachePruneTotal, "expiration must be counted as prune")
+	require.Equal(t, 0, stats.Entries)
 }
 
 func TestQueryCache_EvictsByEntryLimit(t *testing.T) {
-	cache := NewQueryCacheWithLimits(3, 0)
+	cache := newQueryCache(queryCacheConfig{
+		maxEntries: 3,
+		entryTTL:   defaultEntryTTL,
+		executor:   func(fn func()) { fn() },
+	})
 
 	for i := 0; i < 5; i++ {
 		cache.store(100, "k"+strconv.Itoa(i), []byte("v"))
 	}
+	cache.entries.CleanUp()
 
 	stats := cache.SnapshotStats()
-	require.Equal(t, 3, stats.Entries, "entry count must be bounded by maxEntries")
-	require.Equal(t, uint64(2), stats.CacheEvictTotal)
+	require.LessOrEqual(t, stats.Entries, 3, "entry count must be bounded by maxEntries")
+	require.GreaterOrEqual(t, stats.CacheEvictTotal, uint64(2))
+}
 
-	_, ok := cache.lookup(100, "k0")
-	require.False(t, ok)
-	_, ok = cache.lookup(100, "k1")
-	require.False(t, ok)
-	for i := 2; i < 5; i++ {
-		_, ok := cache.lookup(100, "k"+strconv.Itoa(i))
-		require.Truef(t, ok, "key k%d must remain", i)
+func TestQueryCache_BoundsEntriesUnderByteLimit(t *testing.T) {
+	cache := newQueryCache(queryCacheConfig{
+		maxEntries: 3,
+		maxBytes:   1 << 30,
+		entryTTL:   defaultEntryTTL,
+		executor:   func(fn func()) { fn() },
+	})
+
+	for i := 0; i < 20; i++ {
+		cache.store(100, "k"+strconv.Itoa(i), []byte("v"))
 	}
+	cache.entries.CleanUp()
+
+	stats := cache.SnapshotStats()
+	require.LessOrEqual(t, stats.Entries, 3, "maxEntries must hold even when maxBytes is set")
+	require.GreaterOrEqual(t, stats.CacheEvictTotal, uint64(17))
 }
 
 func TestQueryCache_EvictsByByteLimit(t *testing.T) {
-	cache := NewQueryCacheWithLimits(0, 10)
+	entryWeight := int64(len(entryKey(100, "a")) + len("12345") + entryOverhead)
+	cache := newQueryCache(queryCacheConfig{
+		maxBytes: 2 * entryWeight,
+		entryTTL: defaultEntryTTL,
+		executor: func(fn func()) { fn() },
+	})
 
 	cache.store(100, "a", []byte("12345"))
 	cache.store(100, "b", []byte("12345"))
-	require.Equal(t, int64(10), cache.SnapshotStats().TotalBytes)
-
 	cache.store(100, "c", []byte("12345"))
+	cache.entries.CleanUp()
 
 	stats := cache.SnapshotStats()
-	require.Equal(t, int64(10), stats.TotalBytes)
-	require.Equal(t, 2, stats.Entries)
+	require.LessOrEqual(t, stats.TotalBytes, 2*entryWeight, "total bytes must be bounded by maxBytes")
+	require.LessOrEqual(t, stats.Entries, 2)
 	require.GreaterOrEqual(t, stats.CacheEvictTotal, uint64(1))
-
-	_, ok := cache.lookup(100, "a")
-	require.False(t, ok, "least-recently-used entry must be evicted")
-}
-
-func TestQueryCache_LookupDoesNotBumpRecency(t *testing.T) {
-	cache := NewQueryCacheWithLimits(2, 0)
-
-	cache.store(100, "a", []byte("v"))
-	cache.store(100, "b", []byte("v"))
-	_, ok := cache.lookup(100, "a")
-	require.True(t, ok)
-
-	cache.store(100, "c", []byte("v"))
-
-	_, ok = cache.lookup(100, "a")
-	require.False(t, ok, "lookup must not bump recency on hot read path")
-	_, ok = cache.lookup(100, "b")
-	require.True(t, ok, "entry b remains because reads do not reorder LRU")
-}
-
-func TestQueryCache_HeightPruneReleasesBytes(t *testing.T) {
-	cache := NewQueryCache()
-
-	for h := int64(1); h <= int64(defaultKeepLastHeights+2); h++ {
-		cache.store(h, "k", []byte("payload"))
-	}
-
-	stats := cache.SnapshotStats()
-	require.Equal(t, defaultKeepLastHeights, stats.Heights)
-	require.Equal(t, defaultKeepLastHeights, stats.Entries, "pruned heights must release their entries")
-	require.Equal(t, int64(defaultKeepLastHeights*len("payload")), stats.TotalBytes)
 }
 
 func TestPinHeight_DoesNotStackDuplicateValues(t *testing.T) {

--- a/decentralized-api/cosmosclient/query_cache_test.go
+++ b/decentralized-api/cosmosclient/query_cache_test.go
@@ -556,6 +556,27 @@ func TestCachingConn_HintFallbackForUnpinnedCallers(t *testing.T) {
 	require.Equal(t, 1, inner.invokeCount(), "second unpinned call must hit cache via hint")
 }
 
+func TestCachingConn_HintFallbackPinsTrustedHintForABCIPath(t *testing.T) {
+	cache := NewQueryCache()
+	cache.SetHeightHint(200)
+
+	inner := &testConn{heightFromCtx: true}
+	conn := &CachingConn{inner: inner, cache: cache}
+
+	req := &emptypb.Empty{}
+	resp := &emptypb.Empty{}
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", req, resp))
+	require.Equal(t, 1, inner.invokeCount())
+
+	require.NoError(t, conn.Invoke(context.Background(), "/inference.Query/Models", req, resp))
+	require.Equal(t, 1, inner.invokeCount(), "trusted hint should be pinned so ABCI path can write cache entries")
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, uint64(1), stats.CacheWriteTotal)
+	require.Equal(t, uint64(0), stats.CacheWriteSkippedHeightTotal)
+}
+
 func TestCachingConn_HintFlipDuringRequest_NoCorruption(t *testing.T) {
 	cache := NewQueryCache()
 	cache.SetHeightHint(100)

--- a/decentralized-api/cosmosclient/query_cache_test.go
+++ b/decentralized-api/cosmosclient/query_cache_test.go
@@ -629,6 +629,74 @@ func TestQueryCachePruning_KeepsLastNHeights(t *testing.T) {
 	}
 }
 
+func TestQueryCache_EvictsByEntryLimit(t *testing.T) {
+	cache := NewQueryCacheWithLimits(3, 0)
+
+	for i := 0; i < 5; i++ {
+		cache.store(100, "k"+strconv.Itoa(i), []byte("v"))
+	}
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, 3, stats.Entries, "entry count must be bounded by maxEntries")
+	require.Equal(t, uint64(2), stats.CacheEvictTotal)
+
+	_, ok := cache.lookup(100, "k0")
+	require.False(t, ok)
+	_, ok = cache.lookup(100, "k1")
+	require.False(t, ok)
+	for i := 2; i < 5; i++ {
+		_, ok := cache.lookup(100, "k"+strconv.Itoa(i))
+		require.Truef(t, ok, "key k%d must remain", i)
+	}
+}
+
+func TestQueryCache_EvictsByByteLimit(t *testing.T) {
+	cache := NewQueryCacheWithLimits(0, 10)
+
+	cache.store(100, "a", []byte("12345"))
+	cache.store(100, "b", []byte("12345"))
+	require.Equal(t, int64(10), cache.SnapshotStats().TotalBytes)
+
+	cache.store(100, "c", []byte("12345"))
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, int64(10), stats.TotalBytes)
+	require.Equal(t, 2, stats.Entries)
+	require.GreaterOrEqual(t, stats.CacheEvictTotal, uint64(1))
+
+	_, ok := cache.lookup(100, "a")
+	require.False(t, ok, "least-recently-used entry must be evicted")
+}
+
+func TestQueryCache_LookupBumpsRecency(t *testing.T) {
+	cache := NewQueryCacheWithLimits(2, 0)
+
+	cache.store(100, "a", []byte("v"))
+	cache.store(100, "b", []byte("v"))
+	_, ok := cache.lookup(100, "a")
+	require.True(t, ok)
+
+	cache.store(100, "c", []byte("v"))
+
+	_, ok = cache.lookup(100, "a")
+	require.True(t, ok, "recently used entry must survive")
+	_, ok = cache.lookup(100, "b")
+	require.False(t, ok, "least-recently-used entry must be evicted")
+}
+
+func TestQueryCache_HeightPruneReleasesBytes(t *testing.T) {
+	cache := NewQueryCache()
+
+	for h := int64(1); h <= int64(defaultKeepLastHeights+2); h++ {
+		cache.store(h, "k", []byte("payload"))
+	}
+
+	stats := cache.SnapshotStats()
+	require.Equal(t, defaultKeepLastHeights, stats.Heights)
+	require.Equal(t, defaultKeepLastHeights, stats.Entries, "pruned heights must release their entries")
+	require.Equal(t, int64(defaultKeepLastHeights*len("payload")), stats.TotalBytes)
+}
+
 func TestPinHeight_DoesNotStackDuplicateValues(t *testing.T) {
 	ctx := PinHeight(context.Background(), 100)
 	ctx = PinHeight(ctx, 100)

--- a/decentralized-api/go.mod
+++ b/decentralized-api/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/cometbft/cometbft v0.38.21
 	github.com/consensys/gnark-crypto v0.18.1
 	github.com/cosmos/cosmos-sdk v0.53.3
+	github.com/cosmos/gogoproto v1.7.0
+	github.com/cosmos/ibc-go/v8 v8.7.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
@@ -23,6 +25,7 @@ require (
 	github.com/knadh/koanf/providers/structs v0.1.0
 	github.com/knadh/koanf/v2 v2.1.1
 	github.com/labstack/echo/v4 v4.15.1
+	github.com/maypok86/otter/v2 v2.3.0
 	github.com/nats-io/nats-server/v2 v2.8.4
 	github.com/nats-io/nats.go v1.34.0
 	github.com/pkg/errors v0.9.1
@@ -118,7 +121,6 @@ require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/gogoproto v1.7.0 // indirect
 	github.com/cosmos/iavl v1.2.4 // indirect
 	github.com/cosmos/ibc-go/modules/capability v1.0.1 // indirect
 	github.com/cosmos/ibc-go/v8 v8.7.0 // indirect

--- a/decentralized-api/go.mod
+++ b/decentralized-api/go.mod
@@ -123,7 +123,6 @@ require (
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v1.2.4 // indirect
 	github.com/cosmos/ibc-go/modules/capability v1.0.1 // indirect
-	github.com/cosmos/ibc-go/v8 v8.7.0 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.14.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect

--- a/decentralized-api/go.sum
+++ b/decentralized-api/go.sum
@@ -921,6 +921,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maypok86/otter/v2 v2.3.0 h1:8H8AVVFUSzJwIegKwv1uF5aGitTY+AIrtktg7OcLs8w=
+github.com/maypok86/otter/v2 v2.3.0/go.mod h1:XgIdlpmL6jYz882/CAx1E4C1ukfgDKSaw4mWq59+7l8=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
 github.com/mdelapenya/tlscert v0.2.0/go.mod h1:O4njj3ELLnJjGdkN7M/vIVCpZ+Cf0L6muqOG4tLSl8o=
 github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFet4=

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -88,6 +88,7 @@ type OnNewBlockDispatcher struct {
 	seedAttemptHeight  int64
 	seedConfirmedEpoch uint64
 	seedEnsureInFlight atomic.Bool
+	setQueryCacheHint    func(int64)
 }
 
 const seedRetryCooldownBlocks int64 = 2
@@ -174,6 +175,7 @@ func NewOnNewBlockDispatcherFromCosmosClient(
 		configManager,
 	)
 	dispatcher.epochGroupDataCache = epochGroupDataCache
+	dispatcher.setQueryCacheHint = cosmosClient.SetQueryCacheHeightHint
 	return dispatcher
 }
 
@@ -183,7 +185,7 @@ func (d *OnNewBlockDispatcher) ProcessNewBlock(ctx context.Context, blockInfo ch
 		"height", blockInfo.Height,
 		"hash", blockInfo.Hash)
 
-	// 1. Query network for current state (sync status, epoch params)
+	// 1. Query network for current state (sync status, epoch params).
 	networkInfo, err := d.queryNetworkInfo(ctx)
 	if err != nil {
 		logging.Error("Failed to query network info, skipping block processing", types.Stages,
@@ -191,9 +193,17 @@ func (d *OnNewBlockDispatcher) ProcessNewBlock(ctx context.Context, blockInfo ch
 		return err // Skip processing this block
 	}
 
+	blockCtx := ctx
+	if networkInfo.BlockHeight > 0 {
+		if d.setQueryCacheHint != nil {
+			d.setQueryCacheHint(networkInfo.BlockHeight)
+		}
+		blockCtx = cosmosclient.PinHeight(ctx, networkInfo.BlockHeight)
+	}
+
 	// Fetch validation parameters - skip in tests
 	if d.configManager != nil && !strings.HasPrefix(blockInfo.Hash, "hash-") { // Skip in tests where hash has format "hash-N"
-		params, err := d.queryClient.Params(ctx, &types.QueryParamsRequest{})
+		params, err := d.queryClient.Params(blockCtx, &types.QueryParamsRequest{})
 		if err != nil {
 			logging.Error("Failed to get params", types.Validation, "error", err)
 		} else {
@@ -345,12 +355,22 @@ func (d *OnNewBlockDispatcher) queryNetworkInfo(ctx context.Context) (NetworkInf
 	if err != nil {
 		return NetworkInfo{}, err
 	}
+	if status == nil {
+		return NetworkInfo{}, errors.New("empty status response")
+	}
 	isSynced := !status.SyncInfo.CatchingUp
 
-	epochInfo, err := d.queryClient.EpochInfo(ctx, &types.QueryEpochInfoRequest{})
-	if err != nil || epochInfo == nil {
+	queryCtx := cosmosclient.WithoutQueryCache(ctx)
+	epochInfo, err := d.queryClient.EpochInfo(queryCtx, &types.QueryEpochInfoRequest{})
+	if err != nil {
 		logging.Error("Failed to query epoch info", types.Stages, "error", err)
 		return NetworkInfo{}, err
+	}
+	if epochInfo == nil {
+		return NetworkInfo{}, errors.New("query epoch info returned nil response")
+	}
+	if epochInfo.Params.EpochParams == nil {
+		return NetworkInfo{}, errors.New("query epoch info returned empty epoch params")
 	}
 
 	// Extract confirmation PoC event if active

--- a/decentralized-api/internal/server/admin/cache_stats.go
+++ b/decentralized-api/internal/server/admin/cache_stats.go
@@ -1,0 +1,34 @@
+package admin
+
+import (
+	cosmos_client "decentralized-api/cosmosclient"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type QueryCacheStatsResponse struct {
+	Enabled bool                           `json:"enabled"`
+	Stats   *cosmos_client.QueryCacheStats `json:"stats,omitempty"`
+}
+
+func (s *Server) getQueryCacheStats(c echo.Context) error {
+	stats := s.recorder.GetQueryCacheStats()
+	return c.JSON(http.StatusOK, QueryCacheStatsResponse{
+		Enabled: stats != nil,
+		Stats:   stats,
+	})
+}
+
+func (s *Server) resetQueryCacheStats(c echo.Context) error {
+	enabled := s.recorder.ResetQueryCacheStats()
+	if !enabled {
+		return c.JSON(http.StatusOK, QueryCacheStatsResponse{Enabled: false})
+	}
+
+	stats := s.recorder.GetQueryCacheStats()
+	return c.JSON(http.StatusOK, QueryCacheStatsResponse{
+		Enabled: true,
+		Stats:   stats,
+	})
+}

--- a/decentralized-api/internal/server/admin/server.go
+++ b/decentralized-api/internal/server/admin/server.go
@@ -90,6 +90,8 @@ func NewServer(
 
 	// EXPERIMENTAL: Setup and health report endpoint for participant onboarding
 	g.GET("setup/report", s.getSetupReport)
+	g.GET("cache/stats", s.getQueryCacheStats)
+	g.POST("cache/stats/reset", s.resetQueryCacheStats)
 
 	// Bridge
 	g.POST("bridge/block", s.postBridgeBlock)

--- a/decentralized-api/internal/server/admin/server_test.go
+++ b/decentralized-api/internal/server/admin/server_test.go
@@ -226,3 +226,27 @@ func TestPostVersionStatus(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 }
+
+func TestCacheStatsEndpoints_Disabled(t *testing.T) {
+	s, _, _ := setupTestServer(t)
+
+	t.Run("get cache stats disabled", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/v1/cache/stats", nil)
+		rec := httptest.NewRecorder()
+
+		s.e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.JSONEq(t, `{"enabled":false}`, rec.Body.String())
+	})
+
+	t.Run("reset cache stats disabled", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/admin/v1/cache/stats/reset", nil)
+		rec := httptest.NewRecorder()
+
+		s.e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.JSONEq(t, `{"enabled":false}`, rec.Body.String())
+	})
+}


### PR DESCRIPTION
Supersedes #542

## Summary

Implemented a gRPC query cache in DAPI:
- Cache keying by (block_height, method, request_hash)
- Block-pinned reads via x-cosmos-block-height for consistent per-block queries
- Height hint fallback for unpinned requests
- Explicit cache bypass for EpochInfo to avoid stale network state
- Query cache stats support in the client/admin layer

## Endpoints

- `GET /admin/v1/cache/stats`
- `POST /admin/v1/cache/stats/reset`

## Load test

Tested under load (localtestnet , ~5s blocks). The cache stores results per block, so many identical requests in the same block are served from one backend call (extra ones are deduplicated).

1000 concurrent requests per endpoint (bypassing the proxy, ~5s blocks, cache memory limit = 1 GiB):


| Endpoint | gRPC calls | cache hits | backend calls | cache size | wall (ON) | wall (OFF) |
|---|---|---|---|---|---|---|
| `/v1/governance/models` | 1000 | 999 | 1 | ~3.5 KB | 45 ms | 223 ms |
| `/v1/models` | 1000 | 999 | 1 | ~3.6 KB | 37 ms | 196 ms |
| `/v1/governance/pricing` | 3000 | 2999 | 1 | ~3.6 KB | 37 ms | 536 ms |
| `/v1/pricing` | 1000 | 1000 | 0 | ~3.6 KB | 35 ms | 223 ms |
| `/v1/participants` | 1000 | 999 | 1 | ~3.8 KB | 34 ms | 175 ms |

The latency gain is small on the local testnet (tiny state, backend ~150 ms). On prod (bigger state, real load) it will be more noticeable.

## Out of scope (follow-up PR)

`/v1/status` and ABCI queries are not cached - they use CometBFT RPC, not the gRPC layer. Caching them needs a separate cache, so it's left for a follow-up pr