### PR TITLE
fix(inference): skip revalidation votes when voter is not an epoch-group member

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_validation.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation.go
@@ -236,6 +236,37 @@ func (k msgServer) revalidateInferenceVote(
 		revalidationOption = group.VOTE_OPTION_YES
 	}
 
+	// Structural membership precheck: the voter may be absent from the epoch
+	// sub-group either at handler entry, or after the first vote triggers a
+	// self-invalidation cascade that removes the voter mid-transaction. Voting
+	// as a non-member makes x/group return an error (voteValidationProposal only
+	// tolerates the "proposal already decided" case), which would fail the whole
+	// MsgValidation. Skip each vote as a no-op unless membership is confirmed at
+	// that point.
+	isMember := func() bool {
+		sg, err := k.GetEpochGroup(ctx, inference.EpochId, inference.Model)
+		if err != nil || sg == nil || sg.GroupData == nil || sg.GroupData.EpochGroupId == 0 {
+			return false
+		}
+		members, mErr := sg.GetGroupMembers(ctx)
+		if mErr != nil {
+			return false
+		}
+		for _, m := range members {
+			if m.Member != nil && m.Member.Address == voter {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !isMember() {
+		k.LogError("Voter not in epoch sub-group at handler entry; skipping both votes",
+			types.Validation, "voter", voter, "inferenceId", inference.InferenceId,
+			"epochId", inference.EpochId, "model", inference.Model)
+		return &types.MsgValidationResponse{}, nil
+	}
+
 	voteMsg := &group.MsgVote{
 		ProposalId: inference.ProposalDetails.InvalidatePolicyId,
 		Voter:      voter,
@@ -245,6 +276,15 @@ func (k msgServer) revalidateInferenceVote(
 	}
 	if err := k.voteValidationProposal(ctx, voteMsg); err != nil {
 		return nil, err
+	}
+
+	// Re-check: the Invalidate vote may have statistically invalidated the
+	// voter themselves, removing them from the group; the Revalidate vote would
+	// then hard-error.
+	if !isMember() {
+		k.LogError("Voter removed from epoch sub-group after Invalidate vote; skipping Revalidate vote",
+			types.Validation, "voter", voter, "inferenceId", inference.InferenceId)
+		return &types.MsgValidationResponse{}, nil
 	}
 
 	voteMsg.ProposalId = inference.ProposalDetails.ReValidatePolicyId

--- a/inference-chain/x/inference/keeper/msg_server_validation_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_validation_test.go
@@ -78,6 +78,22 @@ func TestMsgServer_Validation_Invalidate(t *testing.T) {
 	mocks.GroupKeeper.EXPECT().SubmitProposal(gomock.Any(), gomock.Any()).Return(&group.MsgSubmitProposalResponse{
 		ProposalId: 2,
 	}, nil)
+
+	// The membership precheck in revalidateInferenceVote performs a real x/group
+	// membership query. Give the sub-group a non-zero EpochGroupId and stub the
+	// membership query so the revalidation voter is recognized as a member;
+	// otherwise both votes are correctly skipped as no-ops.
+	groupData, _ := k.GetEpochGroupData(ctx, 0, MODEL_ID)
+	groupData.EpochGroupId = 1
+	k.SetEpochGroupData(ctx, groupData)
+	mocks.GroupKeeper.EXPECT().GroupMembers(gomock.Any(), gomock.Any()).Return(
+		&group.QueryGroupMembersResponse{
+			Members: []*group.GroupMember{
+				{GroupId: 1, Member: &group.Member{Address: testutil.Requester, Weight: "100"}},
+			},
+		}, nil,
+	).AnyTimes()
+
 	ms := inferenceHelper.MessageServer
 	_, err = ms.Validation(ctx, &types.MsgValidation{
 		InferenceId:  expected.InferenceId,
@@ -118,6 +134,60 @@ func TestMsgServer_Validation_Invalidate(t *testing.T) {
 	has, err := k.ActiveInvalidations.Has(ctx, collections.Join(sdk.MustAccAddressFromBech32(testutil.Validator), expected.InferenceId))
 	require.NoError(t, err)
 	require.True(t, has)
+}
+
+// TestMsgServer_Validation_Revalidation_SkipsVoteWhenVoterNotInGroup is the
+// regression reproducer for the membership precheck. When the revalidation
+// voter is absent from the inference's epoch sub-group, the handler must NOT
+// attempt an x/group vote — the real x/group keeper rejects a non-member vote
+// with an error that would fail the whole MsgValidation. Pre-fix the handler
+// voted unconditionally; this test FAILS pre-fix (the stubbed-out Vote is
+// called, violating Times(0)) and passes with the membership precheck.
+func TestMsgServer_Validation_Revalidation_SkipsVoteWhenVoterNotInGroup(t *testing.T) {
+	inferenceHelper, k, ctx := NewMockInferenceHelper(t)
+	createParticipants(t, inferenceHelper.MessageServer, ctx)
+	model := &types.Model{Id: MODEL_ID, ValidationThreshold: &types.Decimal{Value: 85, Exponent: -2}}
+	k.SetModel(ctx, model)
+	StubModelSubgroup(t, ctx, k, inferenceHelper.Mocks, model)
+	addMembersToGroupData(k, ctx)
+
+	expected, err := inferenceHelper.StartInference("promptPayload", model.Id, time.Now().UnixNano(), calculations.DefaultMaxTokens)
+	require.NoError(t, err)
+	_, err = inferenceHelper.FinishInference()
+	require.NoError(t, err)
+	buildValidationCacheForTest(t, k, ctx)
+
+	mocks := inferenceHelper.Mocks
+	mocks.GroupKeeper.EXPECT().SubmitProposal(gomock.Any(), gomock.Any()).Return(&group.MsgSubmitProposalResponse{ProposalId: 1}, nil)
+	mocks.GroupKeeper.EXPECT().SubmitProposal(gomock.Any(), gomock.Any()).Return(&group.MsgSubmitProposalResponse{ProposalId: 2}, nil)
+
+	ms := inferenceHelper.MessageServer
+	_, err = ms.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Validator,
+		ValueDecimal: types.DecimalFromFloat(0.80),
+	})
+	require.NoError(t, err)
+	inference, found := k.GetInference(ctx, expected.InferenceId)
+	require.True(t, found)
+	require.Equal(t, types.InferenceStatus_VOTING, inference.Status)
+
+	// The sub-group's EpochGroupId is left 0 (addMembersToGroupData writes only
+	// ValidationWeights, no real x/group), so the revalidation voter is not a
+	// confirmed member and the handler must skip both votes.
+	mocks.GroupKeeper.EXPECT().Vote(gomock.Any(), gomock.Any()).Times(0)
+
+	_, err = ms.Validation(ctx, &types.MsgValidation{
+		InferenceId:  expected.InferenceId,
+		Creator:      testutil.Requester,
+		ValueDecimal: types.DecimalFromFloat(0.80),
+		Revalidation: true,
+	})
+	require.NoError(t, err, "revalidation by a non-member must be a no-op, not an error")
+
+	inference, found = k.GetInference(ctx, expected.InferenceId)
+	require.True(t, found)
+	require.Equal(t, types.InferenceStatus_VOTING, inference.Status)
 }
 
 func addMembersToGroupData(k keeper.Keeper, ctx sdk.Context) {


### PR DESCRIPTION
## Problem

`revalidateInferenceVote` cast the Invalidate/Revalidate x/group votes unconditionally. The voter can be absent from the inference's epoch sub-group — either at handler entry (group membership is permissive), or after the Invalidate vote statistically invalidates the voter themselves and removes them from the group mid-transaction. The real x/group keeper rejects a non-member vote with an error (`voteValidationProposal` only tolerates the "proposal already decided" case), which fails the whole `MsgValidation`.

## Fix

Add a membership precheck before voting: confirm the voter is in the epoch sub-group, otherwise skip the vote as a no-op. Checked both at handler entry and again after the Invalidate vote (the self-invalidation cascade).

## Tests

- `TestMsgServer_Validation_Revalidation_SkipsVoteWhenVoterNotInGroup` — new reproducer; fails pre-fix (the unconditional vote is attempted on a non-member), passes with the precheck.
- `TestMsgServer_Validation_Invalidate` — updated to establish real x/group membership (non-zero `EpochGroupId` + stubbed `GroupMembers`) so its votes still fire under the precheck.

## Context

Surfaced by simulation/fuzz testing for inference-chain (#982), where the revalidation-vote factory hit a non-member vote that hard-errored mid-run.

Closes #1269.

cc @patimen (#982 author)
