### PR TITLE
fix: Bound event-listener tx queue to stop a single zero-fee attacker from OOMing validator nodes

### DIFF
--- a/decentralized-api/internal/event_listener/block_observer.go
+++ b/decentralized-api/internal/event_listener/block_observer.go
@@ -15,6 +15,14 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
+// txEventQueueCapacity bounds the in-memory backlog of synthetic tx events
+// produced by the BlockObserver. When the queue is full, processBlock blocks
+// (applying backpressure to block fetching) instead of letting the backing
+// slice grow without bound and eventually OOM the process. It is sized to
+// comfortably hold several blocks' worth of *relevant* events (irrelevant ones
+// are filtered out before enqueue) while capping worst-case memory.
+const txEventQueueCapacity = 20000
+
 type BlockObserver struct {
 	lastProcessedBlockHeight atomic.Int64
 	lastQueriedBlockHeight   atomic.Int64
@@ -24,6 +32,20 @@ type BlockObserver struct {
 	caughtUp                 atomic.Bool
 	tmClient                 TmHTTPClient
 	notify                   chan struct{}
+	// relevanceFilter, when set, is consulted before enqueuing a synthetic tx
+	// event. Only events for which it returns true are enqueued; this keeps
+	// chain traffic the DAPI has no handler for from consuming queue capacity
+	// and worker time. Barrier events are always enqueued regardless, so block
+	// progress (lastProcessedBlockHeight) still advances for every block.
+	// A nil filter preserves the legacy behavior of enqueuing every event.
+	relevanceFilter func(*chainevents.JSONRPCResponse) bool
+}
+
+// SetRelevanceFilter installs a predicate used to drop irrelevant tx events at
+// the producer before they enter the queue. It must be safe for concurrent use
+// and is expected to be set once during wiring, before Process starts.
+func (bo *BlockObserver) SetRelevanceFilter(filter func(*chainevents.JSONRPCResponse) bool) {
+	bo.relevanceFilter = filter
 }
 
 // TmHTTPClient abstracts the subset of RPC methods we need
@@ -33,7 +55,7 @@ type TmHTTPClient interface {
 }
 
 func NewBlockObserver(manager *apiconfig.ConfigManager) *BlockObserver {
-	queue := NewUnboundedQueue[*chainevents.JSONRPCResponse]()
+	queue := NewBoundedQueue[*chainevents.JSONRPCResponse](txEventQueueCapacity)
 	// Initialize Tendermint RPC client
 	httpClient, err := cosmosclient.NewRpcClient(manager.GetChainNodeConfig().Url)
 	if err != nil {
@@ -64,7 +86,7 @@ func NewBlockObserver(manager *apiconfig.ConfigManager) *BlockObserver {
 
 // NewBlockObserverWithClient allows injecting a custom Tendermint RPC client (used in tests)
 func NewBlockObserverWithClient(manager *apiconfig.ConfigManager, client TmHTTPClient) *BlockObserver {
-	queue := NewUnboundedQueue[*chainevents.JSONRPCResponse]()
+	queue := NewBoundedQueue[*chainevents.JSONRPCResponse](txEventQueueCapacity)
 
 	bo := &BlockObserver{
 		ConfigManager: manager,
@@ -217,10 +239,20 @@ func (bo *BlockObserver) processBlock(ctx context.Context, height int64) bool {
 				Events: events,
 			},
 		}
-		// Enqueue for processing
-		bo.Queue.In <- msg
+		// Drop events the DAPI has no handler for before they consume queue
+		// capacity. The consumer applies the same gate (hasHandler) after
+		// dequeue, so this is behavior-preserving for events that matter.
+		if bo.relevanceFilter != nil && !bo.relevanceFilter(msg) {
+			continue
+		}
+		// Enqueue for processing (blocks under backpressure when the queue is full)
+		if !bo.enqueue(ctx, msg) {
+			return false
+		}
 	}
-	// Enqueue a barrier event to signal block completion when consumed
+	// Always enqueue a barrier event to signal block completion when consumed,
+	// even if every tx event in this block was filtered out. The barrier is how
+	// lastProcessedBlockHeight advances, so it must flow for every observed block.
 	barrier := &chainevents.JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      "block-" + strconv.FormatInt(height, 10) + "-barrier",
@@ -230,8 +262,28 @@ func (bo *BlockObserver) processBlock(ctx context.Context, height int64) bool {
 			Events: map[string][]string{"barrier.height": {strconv.FormatInt(height, 10)}},
 		},
 	}
-	bo.Queue.In <- barrier
+	if !bo.enqueue(ctx, barrier) {
+		return false
+	}
 	return true
+}
+
+// enqueue sends an item to the (possibly bounded) queue while honoring context
+// cancellation. Under backpressure the send blocks until a consumer drains an
+// item; selecting on ctx.Done() ensures a backpressured producer can still shut
+// down cleanly instead of deadlocking on a full queue during teardown.
+//
+// Returning false means the item was not enqueued (context cancelled). Callers
+// (processBlock) treat this like a fetch failure: lastQueriedBlockHeight is not
+// advanced, so the block is retried on the next run and no progress is recorded
+// for a partially-enqueued block.
+func (bo *BlockObserver) enqueue(ctx context.Context, msg *chainevents.JSONRPCResponse) bool {
+	select {
+	case bo.Queue.In <- msg:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // signalAllEventsRead is called once the barrier event for a block

--- a/decentralized-api/internal/event_listener/event_listener.go
+++ b/decentralized-api/internal/event_listener/event_listener.go
@@ -117,6 +117,14 @@ func NewEventListener(
 	for _, opt := range opts {
 		opt(el)
 	}
+
+	// Filter out tx events the DAPI has no handler for at the producer, before
+	// they take a slot in the bounded tx queue. This uses the exact same gate
+	// (hasHandler) the consumer applies after dequeue, so it never drops an
+	// event that would have been handled. Barrier events bypass this filter in
+	// processBlock, so per-block progress still advances.
+	bo.SetRelevanceFilter(el.hasHandler)
+
 	return el
 }
 

--- a/decentralized-api/internal/event_listener/unbounded_queue.go
+++ b/decentralized-api/internal/event_listener/unbounded_queue.go
@@ -4,8 +4,15 @@ import (
 	"sync"
 )
 
-// UnboundedQueue[T] represents an unbounded thread-safe FIFO queue
-// that exposes channels for enqueuing and dequeuing elements of type T
+// UnboundedQueue[T] represents a thread-safe FIFO queue that exposes channels
+// for enqueuing and dequeuing elements of type T.
+//
+// By default the queue is unbounded (see NewUnboundedQueue). When constructed
+// with NewBoundedQueue it instead enforces a maximum number of buffered items
+// and applies backpressure to producers: a send on In blocks once the queue is
+// full, rather than letting the internal backing slice grow without bound. The
+// In/Out channel API, FIFO ordering, and Close semantics are identical in both
+// modes, so callers do not need to change how they use the queue.
 type UnboundedQueue[T any] struct {
 	// Public channels for interacting with the queue
 	In  chan<- T // Send-only channel for producers
@@ -17,20 +24,43 @@ type UnboundedQueue[T any] struct {
 	done      chan struct{}
 	wg        sync.WaitGroup
 	closeOnce sync.Once // Ensures Close is only executed once
+	capacity  int       // 0 = unbounded; >0 = max buffered items before producers block
 }
 
 // NewUnboundedQueue creates a new unbounded queue that exposes channels
 func NewUnboundedQueue[T any]() *UnboundedQueue[T] {
+	return newQueue[T](0)
+}
+
+// NewBoundedQueue creates a FIFO queue that applies backpressure to producers
+// once `capacity` items are buffered. It preserves the same In/Out channel API
+// and ordering guarantees as NewUnboundedQueue; the only behavioral difference
+// is that a send on In blocks while the queue is full instead of the backing
+// store growing without bound. A capacity <= 0 is treated as unbounded.
+//
+// Note: because the internal input channel is buffered for performance, the
+// effective worst-case number of in-flight items is approximately
+// capacity + len(input buffer) + len(output buffer); the bound is intended to
+// cap memory, not to be an exact admission-control limit.
+func NewBoundedQueue[T any](capacity int) *UnboundedQueue[T] {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return newQueue[T](capacity)
+}
+
+func newQueue[T any](capacity int) *UnboundedQueue[T] {
 	input := make(chan T, 100)  // Buffer size is just for performance
 	output := make(chan T, 100) // Buffer size is just for performance
 	done := make(chan struct{})
 
 	q := &UnboundedQueue[T]{
-		In:     input,  // Public producer channel (send-only)
-		Out:    output, // Public consumer channel (receive-only)
-		input:  input,  // Private full access
-		output: output, // Private full access
-		done:   done,
+		In:       input,  // Public producer channel (send-only)
+		Out:      output, // Public consumer channel (receive-only)
+		input:    input,  // Private full access
+		output:   output, // Private full access
+		done:     done,
+		capacity: capacity,
 	}
 
 	q.wg.Add(1)
@@ -58,8 +88,18 @@ func (q *UnboundedQueue[T]) manage() {
 			first = items[0]
 		}
 
+		// Backpressure: when the queue is bounded and full, stop reading from
+		// the input channel. Producers then block on their send to In until a
+		// consumer drains an item. We keep `out` active so consumers can always
+		// make progress and relieve the pressure (so this never deadlocks as
+		// long as some consumer keeps draining).
+		in := q.input
+		if q.capacity > 0 && len(items) >= q.capacity {
+			in = nil
+		}
+
 		select {
-		case item := <-q.input:
+		case item := <-in:
 			// Store new item from producer
 			items = append(items, item)
 

--- a/decentralized-api/internal/event_listener/unbounded_queue_test.go
+++ b/decentralized-api/internal/event_listener/unbounded_queue_test.go
@@ -41,6 +41,49 @@ func TestBasicQueueOperations(t *testing.T) {
 	}
 }
 
+// TestBoundedQueueBackpressureNoDropOrReorder verifies that a bounded queue
+// applies backpressure (a fast producer with a slow consumer never deadlocks
+// and never grows without bound) while still delivering every item exactly
+// once and in FIFO order. This is the core safety property the tx-event queue
+// relies on to avoid the unbounded-memory OOM.
+func TestBoundedQueueBackpressureNoDropOrReorder(t *testing.T) {
+	const capacity = 8
+	q := NewBoundedQueue[int](capacity)
+	defer q.Close()
+
+	const itemCount = 2000
+
+	produceDone := make(chan struct{})
+	go func() {
+		defer close(produceDone)
+		for i := 0; i < itemCount; i++ {
+			q.In <- i // blocks under backpressure once the queue is full
+		}
+	}()
+
+	deadline := time.After(10 * time.Second)
+	for i := 0; i < itemCount; i++ {
+		// Deliberately lag the consumer so the producer must block.
+		if i%100 == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out (possible deadlock) after receiving %d/%d items", i, itemCount)
+		case v := <-q.Out:
+			if v != i {
+				t.Fatalf("FIFO violation: expected %d, got %d", i, v)
+			}
+		}
+	}
+
+	select {
+	case <-produceDone:
+	case <-time.After(time.Second):
+		t.Fatal("producer did not finish after all items were consumed")
+	}
+}
+
 // TestQueueClosing verifies that the queue closes properly
 func TestQueueClosing(t *testing.T) {
 	q := NewUnboundedQueue[int]()


### PR DESCRIPTION
## Summary

This fixes an unbounded-memory bug in the validator API's (`decentralized-api`) chain event-ingestion path, where committed tx events are flattened into an in-memory queue that has **no size limit, no producer backpressure, and no pre-enqueue filtering**. The `BlockObserver` (single producer) walks up to a 500-block catch-up window and synthesizes one queue item for **every tx result in every observed block**, pushing them into a backing slice that grows without bound; only **10 fixed workers** drain it, and relevance filtering happens **after** dequeue. Whenever the consumer is slower than the producer, the backing slice grows until the DAPI process exhausts memory and crashes — and because progress is persisted only when a per-block barrier is consumed, a crash mid-backlog replays the same window on restart, turning a memory spike into a restart loop.

The realistic trigger is not generic traffic (irrelevant events drain in nanoseconds, faster than the RPC-bound producer) but the `MsgRequestThresholdSignature` path: it is open to anyone, has no per-participant rate limit (`ante_fee.go` explicitly documents this), is **free** under the current rollout (`MinGasPriceNgonka = 0`, set by the v0.2.12 upgrade), and faces **no block-gas ceiling** (`max_gas = -1` in genesis, ~21 MB/block). Each such request makes **every** active participant's DAPI do real BLS work (a scalar multiplication per owned slot, up to `i_total_slots = 1000`) plus a **blocking** `BroadcastTxSync`, on only 10 workers — a 1→N amplification with the slow side decoupled from the producer by an unbounded queue. A single funded attacker can therefore drive a target validator's DAPI to OOM while the chain itself stays healthy. This is the same event-ingestion code path validators run in production today.

## Root Cause

`UnboundedQueue.manage()` stores items in a slice with no upper bound and no mechanism to slow producers when consumers fall behind. `BlockObserver.processBlock` enqueues a synthetic event for every tx result before any handler check, and always advances `lastQueriedBlockHeight` the instant a block is enqueued — fully decoupling the producer from the 10-worker consumer. Relevance filtering (`hasHandler`) runs only after dequeue, so irrelevant and malicious-but-relevant traffic alike consume queue memory ahead of any gate. There is no per-process cap on buffered events and no backpressure: the producer never blocks, so the backing slice is bounded only by available RAM. Persistence stores `lastProcessedBlockHeight` (advanced on barrier consumption), not `lastQueriedBlockHeight`, so an OOM crash rebuilds the in-flight backlog from the persisted height on restart.

## Fix

- Add `NewBoundedQueue(capacity)` alongside `NewUnboundedQueue` (same `*UnboundedQueue` type, same `In`/`Out`/`Close` API, same FIFO guarantee). When bounded and full, `manage()` stops reading `input` (so producer sends block) while continuing to serve `output`, giving clean backpressure with no busy-loop and no deadlock as long as any consumer drains. `NewUnboundedQueue` is byte-for-byte unchanged (capacity 0).
- Construct the `BlockObserver` tx queue with `NewBoundedQueue(txEventQueueCapacity)` (`= 20000`). In-memory backlog and worst-case memory are now O(1) in spam volume instead of O(N). The separate NewBlock event queue stays unbounded on purpose, so the height-coordination path `waitForEventHeight` depends on can never backpressure (no deadlock cycle).
- Add a producer-side relevance filter on `BlockObserver`, wired to the exact same predicate the consumer already uses (`el.hasHandler`). Events with no handler are dropped before they take a queue slot — behavior-preserving for every event that matters, since the consumer gates on the identical function. **Barrier events bypass the filter and are always enqueued**, so `lastProcessedBlockHeight` still advances for every observed block.
- Route enqueues through a `ctx`-aware `enqueue()` helper that selects on `ctx.Done()`, so a backpressured producer shuts down cleanly instead of hanging on a full queue; a non-enqueued (cancelled) block leaves `lastQueriedBlockHeight` unadvanced and is simply retried, matching existing fetch-failure semantics.

## Why This Closes The Vulnerability

The failure required three conditions: the queue could grow without bound, the producer ran ahead of the consumer with no backpressure, and a crash mid-backlog replayed the same window. This PR removes all three. Memory is now capped at ~`txEventQueueCapacity` items regardless of how much an attacker spams; when the queue is full the single producer blocks instead of allocating, so the process survives and resumes once load subsides; and because memory is bounded, the persisted-`lastProcessedBlockHeight` replay-on-restart can no longer escalate into an OOM restart loop (and it now replays a tiny set, because irrelevant traffic never enters the queue). Ordering, barrier semantics, and replay/progress guarantees are all preserved by construction. The chain-side validation surface is unchanged; this is a narrowly scoped resource-control fix to the consumer process.

## Test plan

- [ ] `go test ./internal/event_listener/...` in `decentralized-api` (run on Linux/CI — this tree's CGO deps `wasmvm`/`blst` do not build on a Windows host; the edits add no new imports and are type-checked clean by the language server).
- [ ] New `TestBoundedQueueBackpressureNoDropOrReorder`: a fast producer with a slow consumer over a small-capacity bounded queue delivers every item exactly once, in FIFO order, with no deadlock.
- [ ] Existing `TestBlockObserver_StressBackpressure` (200 blocks × 10 txs, slow consumer) still reaches `lastQueriedBlockHeight == 200` and drains all `blocks × (txs+1)` events through the now-bounded queue.
- [ ] Confirm a block with zero handler-matched tx events still emits its barrier and advances `lastProcessedBlockHeight` (relevance filter must not suppress barriers).
- [ ] Soak: synthetic backlog ≫ `txEventQueueCapacity` keeps DAPI RSS flat (bounded) instead of climbing, and the producer goroutine parks on `In` send rather than allocating.
