### PR TITLE
fix(inference): pay missing-participant slot directly instead of reverting settlement

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow.go
@@ -66,7 +66,16 @@ func (k msgServer) SettleDevshardEscrow(goCtx context.Context, msg *types.MsgSet
 	for _, addr := range uniqueAddrs {
 		participant, found := k.GetParticipant(goCtx, addr)
 		if !found {
-			return nil, fmt.Errorf("participant %s not found", addr)
+			// Participant record does not exist for this slot (e.g. it was
+			// pruned). Fall through to the bank-module payout path that this
+			// same handler already uses for present-but-inactive participants
+			// instead of reverting the whole settlement. treatAsCurrentEpochSettle
+			// is left at its zero value (false), so the payout loop routes the
+			// validator to payCoinsDirectly and the per-participant epoch-stats
+			// aggregation (which requires a non-nil *Participant) is skipped.
+			// Without this fallback a single missing-record slot would strand
+			// every other validator's payout and the creator's refund.
+			continue
 		}
 		participantByAddr[addr] = &participant
 		if escrow.EpochIndex != currentEpochIndex {

--- a/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow_test.go
@@ -642,3 +642,81 @@ func TestSettleDevshardEscrow_AllowlistBlocks(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "address is not allowed to create devshard escrows")
 }
+
+// TestSettleDevshardEscrow_MissingParticipantPaidDirectlyWithoutStranding pins
+// the asymmetry fix: when a slot's Participant record is absent (e.g. pruned),
+// the handler must pay that slot via the bank-module fallback that already
+// exists for present-but-inactive participants, instead of reverting the whole
+// settlement and stranding the escrow.
+func TestSettleDevshardEscrow_MissingParticipantPaidDirectlyWithoutStranding(t *testing.T) {
+	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
+	// Register Participant records for every slot EXCEPT the last one. The
+	// last slot's address has no Participant record in state - the same
+	// condition that arises after participant pruning.
+	for i, addr := range slots {
+		if i == keeper.DevshardGroupSize-1 {
+			continue
+		}
+		setParticipantForDevshardTest(t, k, ctx, addr)
+	}
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 5))
+	setActiveParticipantsForDevshardTest(t, k, ctx, 5, slots[:keeper.DevshardGroupSize-1]...)
+
+	creator := sdk.AccAddress(make([]byte, 20))
+	creator[0] = 0x51
+	escrow := types.DevshardEscrow{
+		Id:         1,
+		Creator:    creator.String(),
+		Amount:     7_000_000_000,
+		Slots:      slots,
+		EpochIndex: 5,
+		Settled:    false,
+	}
+	_, err := k.StoreDevshardEscrow(ctx, &escrow, 1)
+	require.NoError(t, err)
+
+	costPerSlot := uint64(100_000_000)
+	fees := uint64(200_000_000)
+	msg := buildSettlementTestData(t, escrow, keys, makeHostStats(keeper.DevshardGroupSize, costPerSlot), fees)
+
+	// The missing-participant slot must be paid via the bank module fallback
+	// (same path as the present-but-inactive case), not error the tx out.
+	missingAddr, err := sdk.AccAddressFromBech32(slots[keeper.DevshardGroupSize-1])
+	require.NoError(t, err)
+	mocks.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, missingAddr, gomock.Any(), gomock.Eq("devshard_escrow_payment")).
+		Return(nil).
+		Times(1)
+	expectedRefund := escrow.Amount - uint64(keeper.DevshardGroupSize)*costPerSlot - fees
+	mocks.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, creator, gomock.Any(), gomock.Eq("devshard_escrow_refund")).
+		DoAndReturn(func(_ context.Context, _ string, _ sdk.AccAddress, coins sdk.Coins, _ string) error {
+			require.Len(t, coins, 1)
+			require.Equal(t, expectedRefund, coins[0].Amount.Uint64())
+			return nil
+		})
+	mocks.BankKeeper.EXPECT().
+		LogSubAccountTransaction(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes()
+
+	_, err = ms.SettleDevshardEscrow(ctx, msg)
+	require.NoError(t, err)
+
+	// Escrow must be marked settled (i.e. no revert).
+	settled, found := k.GetDevshardEscrow(ctx, 1)
+	require.True(t, found)
+	require.True(t, settled.Settled)
+
+	// Active participants who exist in state are credited in-memory.
+	activeParticipant, found := k.GetParticipant(ctx, slots[0])
+	require.True(t, found)
+	require.Equal(t, int64(costPerSlot)+int64(fees/uint64(keeper.DevshardGroupSize)), activeParticipant.CoinBalance)
+
+	// The handler must NOT silently create a Participant record for the
+	// missing address: the fallback pays via the bank module only.
+	_, found = k.GetParticipant(ctx, slots[keeper.DevshardGroupSize-1])
+	require.False(t, found)
+}


### PR DESCRIPTION
## Summary

`SettleDevshardEscrow` has asymmetric handling for participants who are not available at settle time. Present-but-inactive participants already fall through to the existing `payCoinsDirectly` bank-module fallback (`msg_server_settle_devshard_escrow.go:169-173`), but a slot whose `Participant` record is *absent* (e.g. after participant pruning) hard-errors with `"participant %s not found"` at `:66-70` and reverts the whole `MsgSettleDevshardEscrow`. The result is a stuck escrow: every other validator's payout is blocked, the creator's refund is blocked, and the locked funds cannot be released until the chain is changed. Combined with the unsettled-prune confiscation timer this is a direct fund-lock / griefing path. This PR makes the missing-participant case route through the same fallback the handler already uses for inactive participants, so a single absent record can no longer strand the escrow.

## Root Cause

The settle handler builds `participantByAddr` and `treatAsCurrentEpochSettle` for every unique slot address:

```go
for _, addr := range uniqueAddrs {
    participant, found := k.GetParticipant(goCtx, addr)
    if !found {
        return nil, fmt.Errorf("participant %s not found", addr)
    }
    participantByAddr[addr] = &participant
    ...
}
```

But later in the same function, when a participant *is* present but not in the active set for the current epoch, the payout loop already handles that case by routing through `payCoinsDirectly` (a bank-module `SendCoinsFromModuleToAccount` call):

```go
inCurrentEpoch := treatAsCurrentEpochSettle[addr]
if inCurrentEpoch { ... AddToCoinBalance ... } else { payCoinsDirectly(...) }
```

The asymmetry — fallback for inactive, hard error for missing — is what makes this an oversight rather than a design choice: if stranding the entire tx for unavailability were intended, the inactive case would behave the same way. It does not.

## Fix

In the participant-loading loop, when `GetParticipant` returns `!found`, do not return an error. Instead, skip insertion into `participantByAddr` and `continue`, leaving `treatAsCurrentEpochSettle[addr]` at its zero value (`false`). The rest of the handler then naturally does the right thing:

- The payout loop sees `inCurrentEpoch == false` for the missing addr and routes the payout through `payCoinsDirectly` — the same fallback used for present-but-inactive participants.
- `AggregateDevshardHostStatsIntoCurrentEpochStats`, which is the only call that requires a non-nil `*types.Participant`, sits inside `if treatAsCurrentEpochSettle[addr]` and is skipped.
- `touchedParticipants[addr]` is never set, so `SetParticipant` is not called for an address that has no record.
- `UpdateDevshardHostEpochStats` continues to run because it is keyed by `(epochIndex, addr)` and does not need the participant struct, so per-host epoch accounting is preserved.

## Why This Closes The Vulnerability

Before this change, a single slot whose `Participant` record was absent (e.g. pruned after enough inactive epochs) would cause every call to `SettleDevshardEscrow` for an escrow that touches that slot to revert. Every other validator in the same group was blocked from being paid for the work, the creator's refund was blocked, and the locked escrow funds had no on-chain path out. Whether the missing record happens accidentally (legitimate participant pruning) or is induced as a griefing primitive, the outcome is the same: fund lock + griefing.

After this change, a missing participant record degrades exactly the way an inactive participant already does: the slot is paid via the bank module to its slot address, the rest of the settlement (other validators' payouts, host-epoch stats, creator refund, `Settled = true`) proceeds normally, and the escrow is released. The fix is structurally minimal — it removes one error return and adds one `continue`, relying on logic and fallbacks that already exist in the same function.

## Test plan

- [ ] `go test ./x/inference/keeper/...` in `inference-chain` (Linux + cgo toolchain).
- [ ] `TestSettleDevshardEscrow_MissingParticipantPaidDirectlyWithoutStranding` (new) — 16-slot group, every slot's `Participant` is set except the last; last slot is also absent from the active set. The test asserts the settle succeeds, the missing slot receives a single `devshard_escrow_payment` to its slot address, the creator's `devshard_escrow_refund` fires for the expected remainder, the escrow is marked `Settled`, the active in-state participants receive their `AddToCoinBalance` credit, and the handler does NOT silently create a `Participant` record for the missing address.
- [ ] Existing tests cover the surrounding behavior and must continue to pass: `TestSettleDevshardEscrow_CurrentEpochInactiveParticipantPaidImmediatelyWithoutParticipantStateChange` (present-but-inactive fallback), `TestSettleDevshardEscrow_PreviousEpochSettlementAllowedWithoutParticipantStats` (cross-epoch fallback), `TestSettleDevshardEscrow_HappyPath` (no-fallback baseline).