### PR TITLE
`devshard` log vLLM validation replay rejections (400/422) before auto-pass

### DIFF
--- a/decentralized-api/internal/devshard/shared_runtime.go
+++ b/decentralized-api/internal/devshard/shared_runtime.go
@@ -250,6 +250,31 @@ func EvaluateValidationResponse(
 	thresholds *ValidationThresholdResolver,
 ) (*devshardpkg.ValidateResult, error) {
 	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity {
+		respBytes, readErr := ReadHTTPBody(resp)
+		if readErr != nil {
+			logging.Warn(logPrefix+" validation replay rejected by ML node; treating as passed (body unreadable)",
+				chaintypes.Validation,
+				"inferenceId", inferenceID,
+				"escrowId", req.EscrowID,
+				"model", req.Model,
+				"status", resp.StatusCode,
+				"claimedInputTokens", req.InputTokens,
+				"claimedOutputTokens", req.OutputTokens,
+				"readError", readErr,
+			)
+		} else {
+			logging.Warn(logPrefix+" validation replay rejected by ML node; treating as passed (logits not checked)",
+				chaintypes.Validation,
+				"inferenceId", inferenceID,
+				"escrowId", req.EscrowID,
+				"model", req.Model,
+				"status", resp.StatusCode,
+				"claimedInputTokens", req.InputTokens,
+				"claimedOutputTokens", req.OutputTokens,
+				"rejectHint", validationReplayRejectHint(respBytes),
+				"body", truncateForLog(respBytes, 2048),
+			)
+		}
 		return &devshardpkg.ValidateResult{Valid: true}, nil
 	}
 
@@ -299,6 +324,35 @@ func tokenCountInflated(claimed, validation uint64) bool {
 	// TODO: figure out tokens
 	const tokenCountTolerance uint64 = 3
 	return claimed > validation && claimed-validation > tokenCountTolerance
+}
+
+// validationReplayRejectHint classifies ML-node error bodies for warn logs only.
+// It does not affect pass/fail; operators use it to spot context-limit vs other rejects.
+func validationReplayRejectHint(body []byte) string {
+	s := strings.ToLower(string(body))
+	switch {
+	case strings.Contains(s, "context_length_exceeded"),
+		strings.Contains(s, "max_model_len"),
+		strings.Contains(s, "maximum context length"),
+		strings.Contains(s, "context length"):
+		return "likely_context_limit"
+	case strings.Contains(s, "enforced_tokens"), strings.Contains(s, "enforced tokens"):
+		return "likely_enforced_tokens"
+	case strings.Contains(s, "logprobs"):
+		return "likely_logprobs"
+	default:
+		return "unspecified"
+	}
+}
+
+func truncateForLog(body []byte, maxLen int) string {
+	if maxLen <= 0 || len(body) == 0 {
+		return ""
+	}
+	if len(body) <= maxLen {
+		return string(body)
+	}
+	return string(body[:maxLen]) + "...(truncated)"
 }
 
 func EvaluateValidationResult(


### PR DESCRIPTION
## Summary

When devshard validation replay gets **HTTP 400 or 422** from vLLM, we still return **`Valid: true`** without comparing logits (same policy as mainnet `inference_validation.go`). That means **no cryptographic check** ran for that inference.

This PR adds **warn-level logging** on that path so we can see **why** vLLM rejected the replay and investigate whether we are **marking invalid or suspicious inferences as valid**.

Changes:
- Read the ML node response body on 400/422 before returning pass.
- Log structured fields: `inferenceId`, `escrowId`, `model`, `status`, claimed input/output tokens, truncated `body`, and `rejectHint` (heuristic: `likely_context_limit`, `likely_enforced_tokens`, `likely_logprobs`, `unspecified`).
- Add design note `devshard/docs/validation-context-window.md` describing the near–context-window problem, execute-time cap (Layer 1), and follow-ups for 400 handling.

**Behavior is unchanged:** 400/422 still → `Valid: true`. This is observability only.

## Why this matters

Validation replay can fail for several reasons:

| Cause | Security concern |
|-------|------------------|
| Context window / `max_model_len` exceeded | Honest near-limit inference **or** oversized replay — **pass with zero logit check** |
| Payload/schema rejected on validator node | May be version skew (legacy compat) or bad request |
| `enforced_tokens` / logprobs issues | Possible replay bug vs executor fraud |

Today we **cannot distinguish** these in production logs because devshard returned pass **without logging the rejection**. We need that signal to answer:

> Are we auto-passing inferences that should have been **invalid** or at least **not validated**?

Watch for warns like:

```text
validation replay rejected by ML node; treating as passed (logits not checked)
  rejectHint=likely_context_limit