### PR TITLE
fix(gateway): control automatic escrow rotation due to low balance/high none count

### DIFF
--- a/deploy/join/config.devshard.env.template
+++ b/deploy/join/config.devshard.env.template
@@ -59,9 +59,12 @@ export DEVSHARD_CAPACITY_AWARE_LIMITS=on
 #
 # At pre_poc_blocks before the next epoch switch at set_new_validators, the
 # gateway creates temp bridge escrows, then locally deactivates/finalizes/settles
-# regular escrows. After the next epoch leaves PoC, it creates target_count
-# regular escrows and settles the temp ones.
+# regular escrows. It also replaces low-balance/high-nonce escrows. After the
+# next epoch leaves PoC, it creates target_count regular escrows and settles the
+# temp ones. Set settlement disabled to keep automatic creation/deactivation but
+# skip automatic finalization and on-chain settlement.
 # export DEVSHARD_ESCROW_ROTATION_ENABLED=true
+# export DEVSHARD_ESCROW_ROTATION_SETTLEMENT_DISABLED=false
 # export DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS=300
 # export DEVSHARD_ESCROW_ROTATION_MODELS_JSON='[
 #   {"model_id":"Qwen/Qwen3-235B-A22B-Instruct-2507-FP8","temp_count":8,"target_count":16,"amount":5000000000,"private_key_env":"DEVSHARD_PRIVATE_KEY"}

--- a/deploy/join/config.devshard.env.template
+++ b/deploy/join/config.devshard.env.template
@@ -61,10 +61,10 @@ export DEVSHARD_CAPACITY_AWARE_LIMITS=on
 # gateway creates temp bridge escrows, then locally deactivates/finalizes/settles
 # regular escrows. It also replaces low-balance/high-nonce escrows. After the
 # next epoch leaves PoC, it creates target_count regular escrows and settles the
-# temp ones. Set settlement disabled to keep automatic creation/deactivation but
+# temp ones. Keep settlement disabled to create/deactivate automatically but
 # skip automatic finalization and on-chain settlement.
 # export DEVSHARD_ESCROW_ROTATION_ENABLED=true
-# export DEVSHARD_ESCROW_ROTATION_SETTLEMENT_DISABLED=false
+# export DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED=false
 # export DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS=300
 # export DEVSHARD_ESCROW_ROTATION_MODELS_JSON='[
 #   {"model_id":"Qwen/Qwen3-235B-A22B-Instruct-2507-FP8","temp_count":8,"target_count":16,"amount":5000000000,"private_key_env":"DEVSHARD_PRIVATE_KEY"}

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -147,11 +147,11 @@ func (g *Gateway) prepareBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gat
 			if devshard.RotationRole == rotationRoleTemp || !devshard.Active || strings.TrimSpace(devshard.Model) != model.ModelID {
 				continue
 			}
-			log.Printf("escrow_rotation_settling_regular epoch=%d model=%q escrow=%s", epoch, model.ModelID, devshard.ID)
-			if _, err := gatewaySettleDevshardOnChain(g, context.Background(), devshard.ID, adminSettleEscrowRequest{}); err != nil {
-				log.Printf("escrow_rotation_regular_settle_failed epoch=%d model=%q escrow=%s error=%v", epoch, model.ModelID, devshard.ID, err)
+			settledOnChain, err := g.retireRotatedDevshard(context.Background(), devshard.ID, "escrow rotation regular retired", settings)
+			if err != nil {
+				log.Printf("escrow_rotation_regular_retire_failed epoch=%d model=%q escrow=%s error=%v", epoch, model.ModelID, devshard.ID, err)
 				settleFailed++
-			} else {
+			} else if settledOnChain {
 				settled++
 			}
 		}
@@ -215,11 +215,11 @@ func (g *Gateway) finishBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gate
 			if devshard.RotationRole != rotationRoleTemp || devshard.RotationEpoch > epoch || !devshard.Active || strings.TrimSpace(devshard.Model) != model.ModelID {
 				continue
 			}
-			log.Printf("escrow_rotation_settling_temp epoch=%d model=%q temp_epoch=%d escrow=%s", epoch, model.ModelID, devshard.RotationEpoch, devshard.ID)
-			if _, err := gatewaySettleDevshardOnChain(g, context.Background(), devshard.ID, adminSettleEscrowRequest{}); err != nil {
-				log.Printf("escrow_rotation_temp_settle_failed epoch=%d model=%q escrow=%s error=%v", epoch, model.ModelID, devshard.ID, err)
+			settledOnChain, err := g.retireRotatedDevshard(context.Background(), devshard.ID, "escrow rotation temp retired", settings)
+			if err != nil {
+				log.Printf("escrow_rotation_temp_retire_failed epoch=%d model=%q escrow=%s error=%v", epoch, model.ModelID, devshard.ID, err)
 				settleFailed++
-			} else {
+			} else if settledOnChain {
 				settled++
 			}
 		}

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -3191,7 +3191,6 @@ func (g *Gateway) retireRotatedDevshard(ctx context.Context, id, reason string, 
 	if _, err := gatewaySettleDevshardOnChain(g, ctx, id, adminSettleEscrowRequest{}); err != nil {
 		return false, err
 	}
-	}
 	return true, nil
 }
 

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -3113,13 +3113,14 @@ func (g *Gateway) deactivateAndSettleDevshardByID(id, reason string) {
 func (g *Gateway) retireRotatedDevshard(ctx context.Context, id, reason string, settings GatewaySettings) (bool, error) {
 	if !settings.EscrowRotation.SettlementEnabled {
 		if g.deactivateDevshardByIDWithReason(id, reason) {
-			log.Printf("escrow_rotation_deactivated_without_settlement escrow=%s reason=%s", id, reason)
+			log.Printf("escrow_rotation_deactivated_without_settlement escrow=%s reason=%q", id, reason)
 		}
 		return false, nil
 	}
-	log.Printf("escrow_rotation_settling escrow=%s reason=%s", id, reason)
+	log.Printf("escrow_rotation_settling escrow=%s reason=%q", id, reason)
 	if _, err := gatewaySettleDevshardOnChain(g, ctx, id, adminSettleEscrowRequest{}); err != nil {
 		return false, err
+	}
 	}
 	return true, nil
 }

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -3063,6 +3063,7 @@ func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
 	}
 	rt.proxy.redundancy.onBalanceExhausted = func() {
 		if !g.escrowRotationEnabled() {
+			g.deactivateDevshardByIDWithReason(escrowID, "escrow balance exhausted")
 			return
 		}
 		log.Printf("gateway_replacing_exhausted_escrow escrow=%s", escrowID)
@@ -3153,7 +3154,7 @@ func (g *Gateway) scheduleDepletedEscrowReplacement(id, modelID, reason string) 
 		ctx, cancel := context.WithTimeout(context.Background(), autoSettlementAttemptTimeout)
 		defer cancel()
 		if err := g.replaceDepletedEscrow(ctx, id, modelID, reason); err != nil {
-			log.Printf("escrow_depletion_replacement_failed escrow=%s model=%q reason=%s error=%v", id, modelID, reason, err)
+			log.Printf("escrow_depletion_replacement_failed escrow=%s model=%q reason=%q error=%v", id, modelID, reason, err)
 		}
 	}()
 }
@@ -3182,7 +3183,7 @@ func (g *Gateway) replaceDepletedEscrow(ctx context.Context, id, modelID, reason
 	if err != nil {
 		return fmt.Errorf("create replacement escrow: %w", err)
 	}
-	log.Printf("escrow_depletion_replacement_created old_escrow=%s new_escrow=%d model=%q reason=%s tx_hash=%s",
+	log.Printf("escrow_depletion_replacement_created old_escrow=%s new_escrow=%d model=%q reason=%q tx_hash=%s",
 		id, result.EscrowID, model.ModelID, reason, result.TxHash)
 	if !settings.EscrowRotation.SettlementEnabled {
 		g.deactivateDevshardByIDWithReason(id, reason)

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -1853,10 +1853,10 @@ type adminPerfRequest struct {
 }
 
 type adminEscrowRotationRequest struct {
-	Enabled            *bool                          `json:"enabled,omitempty"`
-	SettlementDisabled *bool                          `json:"settlement_disabled,omitempty"`
-	PrePoCBlocks       *int64                         `json:"pre_poc_blocks,omitempty"`
-	Models             *[]EscrowRotationModelSettings `json:"models,omitempty"`
+	Enabled           *bool                          `json:"enabled,omitempty"`
+	SettlementEnabled *bool                          `json:"settlement_enabled,omitempty"`
+	PrePoCBlocks      *int64                         `json:"pre_poc_blocks,omitempty"`
+	Models            *[]EscrowRotationModelSettings `json:"models,omitempty"`
 }
 
 func (g *Gateway) handleAdminState(w http.ResponseWriter, r *http.Request) {
@@ -2062,10 +2062,10 @@ func (g *Gateway) handleDebugRotation(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, map[string]any{
 		"settings": map[string]any{
-			"enabled":             settings.EscrowRotation.Enabled,
-			"settlement_disabled": settings.EscrowRotation.SettlementDisabled,
-			"pre_poc_blocks":      settings.EscrowRotation.PrePoCBlocks,
-			"models":              settings.EscrowRotation.Models,
+			"enabled":            settings.EscrowRotation.Enabled,
+			"settlement_enabled": settings.EscrowRotation.SettlementEnabled,
+			"pre_poc_blocks":     settings.EscrowRotation.PrePoCBlocks,
+			"models":             settings.EscrowRotation.Models,
 		},
 		"chain": map[string]any{
 			"block_height":               snapshot.BlockHeight,
@@ -2181,8 +2181,8 @@ func applyEscrowRotationRequest(settings *EscrowRotationSettings, req *adminEscr
 	if req.Enabled != nil {
 		settings.Enabled = *req.Enabled
 	}
-	if req.SettlementDisabled != nil {
-		settings.SettlementDisabled = *req.SettlementDisabled
+	if req.SettlementEnabled != nil {
+		settings.SettlementEnabled = *req.SettlementEnabled
 	}
 	if req.PrePoCBlocks != nil {
 		settings.PrePoCBlocks = *req.PrePoCBlocks
@@ -3111,7 +3111,7 @@ func (g *Gateway) deactivateAndSettleDevshardByID(id, reason string) {
 }
 
 func (g *Gateway) retireRotatedDevshard(ctx context.Context, id, reason string, settings GatewaySettings) (bool, error) {
-	if settings.EscrowRotation.SettlementDisabled {
+	if !settings.EscrowRotation.SettlementEnabled {
 		if g.deactivateDevshardByIDWithReason(id, reason) {
 			log.Printf("escrow_rotation_deactivated_without_settlement escrow=%s reason=%s", id, reason)
 		}
@@ -3183,7 +3183,7 @@ func (g *Gateway) replaceDepletedEscrow(ctx context.Context, id, modelID, reason
 	}
 	log.Printf("escrow_depletion_replacement_created old_escrow=%s new_escrow=%d model=%q reason=%s tx_hash=%s",
 		id, result.EscrowID, model.ModelID, reason, result.TxHash)
-	if settings.EscrowRotation.SettlementDisabled {
+	if !settings.EscrowRotation.SettlementEnabled {
 		g.deactivateDevshardByIDWithReason(id, reason)
 	} else {
 		g.deactivateAndSettleDevshardByID(id, reason)

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -556,6 +556,10 @@ const (
 // escrow is close to exhausting its usable balance or nonce budget.
 func (g *Gateway) checkBalances() {
 	g.mu.Lock()
+	if !g.settings.EscrowRotation.Enabled {
+		g.mu.Unlock()
+		return
+	}
 	runtimes := make([]*devshardRuntime, len(g.runtimeOrder))
 	copy(runtimes, g.runtimeOrder)
 	g.mu.Unlock()
@@ -1292,11 +1296,13 @@ func (g *Gateway) reserveRuntimeForModel(requestModel string, inputTokens int64)
 	skipReasonCounts := make(map[string]int)
 	for _, rt := range g.runtimeOrder {
 		if g.runtimeAtNonceLimit(rt) {
-			depletedEscrows = append(depletedEscrows, struct {
-				id     string
-				model  string
-				reason string
-			}{id: rt.id, model: rt.model, reason: "high_nonce"})
+			if g.settings.EscrowRotation.Enabled {
+				depletedEscrows = append(depletedEscrows, struct {
+					id     string
+					model  string
+					reason string
+				}{id: rt.id, model: rt.model, reason: "high_nonce"})
+			}
 			skipReasonCounts["high_nonce"]++
 			continue
 		}
@@ -1847,9 +1853,10 @@ type adminPerfRequest struct {
 }
 
 type adminEscrowRotationRequest struct {
-	Enabled      *bool                          `json:"enabled,omitempty"`
-	PrePoCBlocks *int64                         `json:"pre_poc_blocks,omitempty"`
-	Models       *[]EscrowRotationModelSettings `json:"models,omitempty"`
+	Enabled            *bool                          `json:"enabled,omitempty"`
+	SettlementDisabled *bool                          `json:"settlement_disabled,omitempty"`
+	PrePoCBlocks       *int64                         `json:"pre_poc_blocks,omitempty"`
+	Models             *[]EscrowRotationModelSettings `json:"models,omitempty"`
 }
 
 func (g *Gateway) handleAdminState(w http.ResponseWriter, r *http.Request) {
@@ -2055,9 +2062,10 @@ func (g *Gateway) handleDebugRotation(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, map[string]any{
 		"settings": map[string]any{
-			"enabled":        settings.EscrowRotation.Enabled,
-			"pre_poc_blocks": settings.EscrowRotation.PrePoCBlocks,
-			"models":         settings.EscrowRotation.Models,
+			"enabled":             settings.EscrowRotation.Enabled,
+			"settlement_disabled": settings.EscrowRotation.SettlementDisabled,
+			"pre_poc_blocks":      settings.EscrowRotation.PrePoCBlocks,
+			"models":              settings.EscrowRotation.Models,
 		},
 		"chain": map[string]any{
 			"block_height":               snapshot.BlockHeight,
@@ -2172,6 +2180,9 @@ func applyPerfRequest(settings *PerfSettings, req *adminPerfRequest) {
 func applyEscrowRotationRequest(settings *EscrowRotationSettings, req *adminEscrowRotationRequest) {
 	if req.Enabled != nil {
 		settings.Enabled = *req.Enabled
+	}
+	if req.SettlementDisabled != nil {
+		settings.SettlementDisabled = *req.SettlementDisabled
 	}
 	if req.PrePoCBlocks != nil {
 		settings.PrePoCBlocks = *req.PrePoCBlocks
@@ -3051,9 +3062,21 @@ func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
 		}
 	}
 	rt.proxy.redundancy.onBalanceExhausted = func() {
+		if !g.escrowRotationEnabled() {
+			return
+		}
 		log.Printf("gateway_replacing_exhausted_escrow escrow=%s", escrowID)
 		g.scheduleDepletedEscrowReplacement(escrowID, modelID, "balance_exhausted")
 	}
+}
+
+func (g *Gateway) escrowRotationEnabled() bool {
+	if g == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.settings.EscrowRotation.Enabled
 }
 
 // deactivateDevshardByID marks a devshard inactive in memory and persists the change.
@@ -3087,8 +3110,25 @@ func (g *Gateway) deactivateAndSettleDevshardByID(id, reason string) {
 	g.scheduleAutoSettlement(id, reason)
 }
 
+func (g *Gateway) retireRotatedDevshard(ctx context.Context, id, reason string, settings GatewaySettings) (bool, error) {
+	if settings.EscrowRotation.SettlementDisabled {
+		if g.deactivateDevshardByIDWithReason(id, reason) {
+			log.Printf("escrow_rotation_deactivated_without_settlement escrow=%s reason=%s", id, reason)
+		}
+		return false, nil
+	}
+	log.Printf("escrow_rotation_settling escrow=%s reason=%s", id, reason)
+	if _, err := gatewaySettleDevshardOnChain(g, ctx, id, adminSettleEscrowRequest{}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (g *Gateway) scheduleDepletedEscrowReplacement(id, modelID, reason string) {
 	if g == nil {
+		return
+	}
+	if !g.escrowRotationEnabled() {
 		return
 	}
 	g.replenishmentMu.Lock()
@@ -3118,7 +3158,12 @@ func (g *Gateway) scheduleDepletedEscrowReplacement(id, modelID, reason string) 
 }
 
 func (g *Gateway) replaceDepletedEscrow(ctx context.Context, id, modelID, reason string) error {
+	g.mu.Lock()
 	settings := g.settings
+	g.mu.Unlock()
+	if !settings.EscrowRotation.Enabled {
+		return nil
+	}
 	model, ok := replacementModelForDepletedEscrow(settings, modelID)
 	if !ok {
 		return fmt.Errorf("no escrow rotation model configured for %q", modelID)
@@ -3138,7 +3183,11 @@ func (g *Gateway) replaceDepletedEscrow(ctx context.Context, id, modelID, reason
 	}
 	log.Printf("escrow_depletion_replacement_created old_escrow=%s new_escrow=%d model=%q reason=%s tx_hash=%s",
 		id, result.EscrowID, model.ModelID, reason, result.TxHash)
-	g.deactivateAndSettleDevshardByID(id, reason)
+	if settings.EscrowRotation.SettlementDisabled {
+		g.deactivateDevshardByIDWithReason(id, reason)
+	} else {
+		g.deactivateAndSettleDevshardByID(id, reason)
+	}
 	return nil
 }
 

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -81,9 +81,10 @@ type PerfSettings struct {
 }
 
 type EscrowRotationSettings struct {
-	Enabled      bool                          `json:"enabled"`
-	PrePoCBlocks int64                         `json:"pre_poc_blocks"`
-	Models       []EscrowRotationModelSettings `json:"models,omitempty"`
+	Enabled            bool                          `json:"enabled"`
+	SettlementDisabled bool                          `json:"settlement_disabled"`
+	PrePoCBlocks       int64                         `json:"pre_poc_blocks"`
+	Models             []EscrowRotationModelSettings `json:"models,omitempty"`
 }
 
 type EscrowRotationModelSettings struct {
@@ -485,11 +486,13 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 		       redundancy_pairwise_winner_hold_ms, redundancy_pairwise_winner_hold_min_speedup,
 		       redundancy_pairwise_winner_hold_min_samples,
 		       perf_sample_size, perf_window_ms,
-		       escrow_rotation_enabled, escrow_rotation_pre_poc_blocks, escrow_rotation_models_json,
+		       escrow_rotation_enabled, escrow_rotation_settlement_disabled,
+		       escrow_rotation_pre_poc_blocks, escrow_rotation_models_json,
 	       gateway_disabled_enabled, gateway_disabled_message, gateway_disabled_new_url
 		FROM gateway_settings
 		WHERE id = 1`)
 	var rotationEnabled int
+	var rotationSettlementDisabled int
 	var disabledEnabled int
 	var rotationModelsJSON string
 	var modelLimitsJSON string
@@ -534,6 +537,7 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 		&state.Settings.Perf.SampleSize,
 		&state.Settings.Perf.WindowMS,
 		&rotationEnabled,
+		&rotationSettlementDisabled,
 		&state.Settings.EscrowRotation.PrePoCBlocks,
 		&rotationModelsJSON,
 		&disabledEnabled,
@@ -547,6 +551,7 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 		return GatewayState{}, false, fmt.Errorf("load gateway settings: %w", err)
 	}
 	state.Settings.EscrowRotation.Enabled = rotationEnabled != 0
+	state.Settings.EscrowRotation.SettlementDisabled = rotationSettlementDisabled != 0
 	if strings.TrimSpace(rotationModelsJSON) != "" {
 		if err := json.Unmarshal([]byte(rotationModelsJSON), &state.Settings.EscrowRotation.Models); err != nil {
 			return GatewayState{}, false, fmt.Errorf("load gateway rotation models: %w", err)
@@ -639,10 +644,11 @@ func (s *GatewayStore) Initialize(settings GatewaySettings, devshards []GatewayD
 			redundancy_pairwise_winner_hold_ms, redundancy_pairwise_winner_hold_min_speedup,
 			redundancy_pairwise_winner_hold_min_samples,
 			perf_sample_size, perf_window_ms,
-			escrow_rotation_enabled, escrow_rotation_pre_poc_blocks, escrow_rotation_models_json,
+			escrow_rotation_enabled, escrow_rotation_settlement_disabled,
+			escrow_rotation_pre_poc_blocks, escrow_rotation_models_json,
 			gateway_disabled_enabled, gateway_disabled_message, gateway_disabled_new_url,
 			updated_at
-		) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strings.TrimSpace(settings.ChainREST),
 		strings.TrimSpace(settings.PublicAPI),
 		strings.TrimSpace(settings.DefaultModel),
@@ -682,6 +688,7 @@ func (s *GatewayStore) Initialize(settings GatewaySettings, devshards []GatewayD
 		settings.Perf.SampleSize,
 		settings.Perf.WindowMS,
 		gatewayBoolToInt(settings.EscrowRotation.Enabled),
+		gatewayBoolToInt(settings.EscrowRotation.SettlementDisabled),
 		settings.EscrowRotation.PrePoCBlocks,
 		mustMarshalEscrowRotationModels(settings.EscrowRotation.Models),
 		gatewayBoolToInt(settings.Disabled.Enabled),
@@ -743,6 +750,7 @@ func (s *GatewayStore) UpdateSettings(settings GatewaySettings) error {
 		    perf_sample_size = ?,
 		    perf_window_ms = ?,
 		    escrow_rotation_enabled = ?,
+		    escrow_rotation_settlement_disabled = ?,
 		    escrow_rotation_pre_poc_blocks = ?,
 		    escrow_rotation_models_json = ?,
 		    gateway_disabled_enabled = ?,
@@ -789,6 +797,7 @@ func (s *GatewayStore) UpdateSettings(settings GatewaySettings) error {
 		settings.Perf.SampleSize,
 		settings.Perf.WindowMS,
 		gatewayBoolToInt(settings.EscrowRotation.Enabled),
+		gatewayBoolToInt(settings.EscrowRotation.SettlementDisabled),
 		settings.EscrowRotation.PrePoCBlocks,
 		mustMarshalEscrowRotationModels(settings.EscrowRotation.Models),
 		gatewayBoolToInt(settings.Disabled.Enabled),
@@ -1143,6 +1152,7 @@ func ensureGatewaySettingsRotationColumns(db *sql.DB) error {
 		ddl  string
 	}{
 		{"escrow_rotation_enabled", "INTEGER NOT NULL DEFAULT 0"},
+		{"escrow_rotation_settlement_disabled", "INTEGER NOT NULL DEFAULT 0"},
 		{"escrow_rotation_pre_poc_blocks", "INTEGER NOT NULL DEFAULT 300"},
 		{"escrow_rotation_models_json", "TEXT NOT NULL DEFAULT ''"},
 	}

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -81,10 +81,10 @@ type PerfSettings struct {
 }
 
 type EscrowRotationSettings struct {
-	Enabled            bool                          `json:"enabled"`
-	SettlementDisabled bool                          `json:"settlement_disabled"`
-	PrePoCBlocks       int64                         `json:"pre_poc_blocks"`
-	Models             []EscrowRotationModelSettings `json:"models,omitempty"`
+	Enabled           bool                          `json:"enabled"`
+	SettlementEnabled bool                          `json:"settlement_enabled"`
+	PrePoCBlocks      int64                         `json:"pre_poc_blocks"`
+	Models            []EscrowRotationModelSettings `json:"models,omitempty"`
 }
 
 type EscrowRotationModelSettings struct {
@@ -552,7 +552,7 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 		return GatewayState{}, false, fmt.Errorf("load gateway settings: %w", err)
 	}
 	state.Settings.EscrowRotation.Enabled = rotationEnabled != 0
-	state.Settings.EscrowRotation.SettlementDisabled = rotationSettlementEnabled == 0
+	state.Settings.EscrowRotation.SettlementEnabled = rotationSettlementEnabled != 0
 	if strings.TrimSpace(rotationModelsJSON) != "" {
 		if err := json.Unmarshal([]byte(rotationModelsJSON), &state.Settings.EscrowRotation.Models); err != nil {
 			return GatewayState{}, false, fmt.Errorf("load gateway rotation models: %w", err)
@@ -689,7 +689,7 @@ func (s *GatewayStore) Initialize(settings GatewaySettings, devshards []GatewayD
 		settings.Perf.SampleSize,
 		settings.Perf.WindowMS,
 		gatewayBoolToInt(settings.EscrowRotation.Enabled),
-		gatewayBoolToInt(!settings.EscrowRotation.SettlementDisabled),
+		gatewayBoolToInt(settings.EscrowRotation.SettlementEnabled),
 		settings.EscrowRotation.PrePoCBlocks,
 		mustMarshalEscrowRotationModels(settings.EscrowRotation.Models),
 		gatewayBoolToInt(settings.Disabled.Enabled),
@@ -798,7 +798,7 @@ func (s *GatewayStore) UpdateSettings(settings GatewaySettings) error {
 		settings.Perf.SampleSize,
 		settings.Perf.WindowMS,
 		gatewayBoolToInt(settings.EscrowRotation.Enabled),
-		gatewayBoolToInt(!settings.EscrowRotation.SettlementDisabled),
+		gatewayBoolToInt(settings.EscrowRotation.SettlementEnabled),
 		settings.EscrowRotation.PrePoCBlocks,
 		mustMarshalEscrowRotationModels(settings.EscrowRotation.Models),
 		gatewayBoolToInt(settings.Disabled.Enabled),

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -336,6 +336,7 @@ func NewGatewayStore(path string) (*GatewayStore, error) {
 			perf_sample_size INTEGER NOT NULL DEFAULT 256,
 			perf_window_ms INTEGER NOT NULL DEFAULT 3600000,
 			escrow_rotation_enabled INTEGER NOT NULL DEFAULT 0,
+			escrow_rotation_settlement_enabled INTEGER NOT NULL DEFAULT 0,
 			escrow_rotation_pre_poc_blocks INTEGER NOT NULL DEFAULT 300,
 			escrow_rotation_models_json TEXT NOT NULL DEFAULT '',
 			gateway_disabled_enabled INTEGER NOT NULL DEFAULT 0,
@@ -486,13 +487,13 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 		       redundancy_pairwise_winner_hold_ms, redundancy_pairwise_winner_hold_min_speedup,
 		       redundancy_pairwise_winner_hold_min_samples,
 		       perf_sample_size, perf_window_ms,
-		       escrow_rotation_enabled, escrow_rotation_settlement_disabled,
+		       escrow_rotation_enabled, escrow_rotation_settlement_enabled,
 		       escrow_rotation_pre_poc_blocks, escrow_rotation_models_json,
 	       gateway_disabled_enabled, gateway_disabled_message, gateway_disabled_new_url
 		FROM gateway_settings
 		WHERE id = 1`)
 	var rotationEnabled int
-	var rotationSettlementDisabled int
+	var rotationSettlementEnabled int
 	var disabledEnabled int
 	var rotationModelsJSON string
 	var modelLimitsJSON string
@@ -537,7 +538,7 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 		&state.Settings.Perf.SampleSize,
 		&state.Settings.Perf.WindowMS,
 		&rotationEnabled,
-		&rotationSettlementDisabled,
+		&rotationSettlementEnabled,
 		&state.Settings.EscrowRotation.PrePoCBlocks,
 		&rotationModelsJSON,
 		&disabledEnabled,
@@ -551,7 +552,7 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 		return GatewayState{}, false, fmt.Errorf("load gateway settings: %w", err)
 	}
 	state.Settings.EscrowRotation.Enabled = rotationEnabled != 0
-	state.Settings.EscrowRotation.SettlementDisabled = rotationSettlementDisabled != 0
+	state.Settings.EscrowRotation.SettlementDisabled = rotationSettlementEnabled == 0
 	if strings.TrimSpace(rotationModelsJSON) != "" {
 		if err := json.Unmarshal([]byte(rotationModelsJSON), &state.Settings.EscrowRotation.Models); err != nil {
 			return GatewayState{}, false, fmt.Errorf("load gateway rotation models: %w", err)
@@ -644,7 +645,7 @@ func (s *GatewayStore) Initialize(settings GatewaySettings, devshards []GatewayD
 			redundancy_pairwise_winner_hold_ms, redundancy_pairwise_winner_hold_min_speedup,
 			redundancy_pairwise_winner_hold_min_samples,
 			perf_sample_size, perf_window_ms,
-			escrow_rotation_enabled, escrow_rotation_settlement_disabled,
+			escrow_rotation_enabled, escrow_rotation_settlement_enabled,
 			escrow_rotation_pre_poc_blocks, escrow_rotation_models_json,
 			gateway_disabled_enabled, gateway_disabled_message, gateway_disabled_new_url,
 			updated_at
@@ -688,7 +689,7 @@ func (s *GatewayStore) Initialize(settings GatewaySettings, devshards []GatewayD
 		settings.Perf.SampleSize,
 		settings.Perf.WindowMS,
 		gatewayBoolToInt(settings.EscrowRotation.Enabled),
-		gatewayBoolToInt(settings.EscrowRotation.SettlementDisabled),
+		gatewayBoolToInt(!settings.EscrowRotation.SettlementDisabled),
 		settings.EscrowRotation.PrePoCBlocks,
 		mustMarshalEscrowRotationModels(settings.EscrowRotation.Models),
 		gatewayBoolToInt(settings.Disabled.Enabled),
@@ -750,7 +751,7 @@ func (s *GatewayStore) UpdateSettings(settings GatewaySettings) error {
 		    perf_sample_size = ?,
 		    perf_window_ms = ?,
 		    escrow_rotation_enabled = ?,
-		    escrow_rotation_settlement_disabled = ?,
+		    escrow_rotation_settlement_enabled = ?,
 		    escrow_rotation_pre_poc_blocks = ?,
 		    escrow_rotation_models_json = ?,
 		    gateway_disabled_enabled = ?,
@@ -797,7 +798,7 @@ func (s *GatewayStore) UpdateSettings(settings GatewaySettings) error {
 		settings.Perf.SampleSize,
 		settings.Perf.WindowMS,
 		gatewayBoolToInt(settings.EscrowRotation.Enabled),
-		gatewayBoolToInt(settings.EscrowRotation.SettlementDisabled),
+		gatewayBoolToInt(!settings.EscrowRotation.SettlementDisabled),
 		settings.EscrowRotation.PrePoCBlocks,
 		mustMarshalEscrowRotationModels(settings.EscrowRotation.Models),
 		gatewayBoolToInt(settings.Disabled.Enabled),
@@ -1152,7 +1153,7 @@ func ensureGatewaySettingsRotationColumns(db *sql.DB) error {
 		ddl  string
 	}{
 		{"escrow_rotation_enabled", "INTEGER NOT NULL DEFAULT 0"},
-		{"escrow_rotation_settlement_disabled", "INTEGER NOT NULL DEFAULT 0"},
+		{"escrow_rotation_settlement_enabled", "INTEGER NOT NULL DEFAULT 0"},
 		{"escrow_rotation_pre_poc_blocks", "INTEGER NOT NULL DEFAULT 300"},
 		{"escrow_rotation_models_json", "TEXT NOT NULL DEFAULT ''"},
 	}

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -454,7 +454,7 @@ func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 	require.True(t, statuses[0].Completed)
 }
 
-func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenDisabled(t *testing.T) {
+func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenSettlementDisabled(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -136,8 +136,9 @@ func TestGatewayStoreUpdateSettings(t *testing.T) {
 			UnresponsiveThreshold:        0.8,
 		},
 		EscrowRotation: EscrowRotationSettings{
-			Enabled:      true,
-			PrePoCBlocks: 123,
+			Enabled:            true,
+			SettlementDisabled: true,
+			PrePoCBlocks:       123,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Kimi/Rotate",
 				TempCount:     2,
@@ -168,6 +169,7 @@ func TestGatewayStoreUpdateSettings(t *testing.T) {
 	require.EqualValues(t, 17, state.Settings.Redundancy.PerInputTokenFirstTokenLagMS)
 	require.Equal(t, 0.4, state.Settings.Redundancy.ParallelAdvantageThreshold)
 	require.True(t, state.Settings.EscrowRotation.Enabled)
+	require.True(t, state.Settings.EscrowRotation.SettlementDisabled)
 	require.EqualValues(t, 123, state.Settings.EscrowRotation.PrePoCBlocks)
 	require.Equal(t, []EscrowRotationModelSettings{{
 		ModelID:       "Kimi/Rotate",
@@ -446,6 +448,142 @@ func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 	require.Equal(t, "finish_regular", statuses[0].Stage)
 	require.EqualValues(t, 2, statuses[0].CreatedCount)
 	require.EqualValues(t, 1, statuses[0].SettledCount)
+	require.True(t, statuses[0].Completed)
+}
+
+func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenDisabled(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	settings := GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Enabled:            true,
+			SettlementDisabled: true,
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       "Qwen/Test",
+				TempCount:     1,
+				TargetCount:   2,
+				Amount:        1000,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+			}},
+		},
+	}.WithTuningDefaults()
+	require.NoError(t, store.Initialize(settings, []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Test"},
+		Active:        true,
+		RotationRole:  rotationRoleRegular,
+		RotationEpoch: 9,
+	}}))
+
+	oldCreate := gatewayCreateRotationEscrow
+	oldSettle := gatewaySettleDevshardOnChain
+	createAttempts := 0
+	settleAttempts := 0
+	gatewayCreateRotationEscrow = func(*Gateway, context.Context, GatewaySettings, EscrowRotationModelSettings, string, uint64) (*CreateDevshardEscrowResult, error) {
+		createAttempts++
+		return &CreateDevshardEscrowResult{EscrowID: 99, TxHash: "OK"}, nil
+	}
+	gatewaySettleDevshardOnChain = func(*Gateway, context.Context, string, adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		settleAttempts++
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		gatewayCreateRotationEscrow = oldCreate
+		gatewaySettleDevshardOnChain = oldSettle
+	})
+
+	rt := &devshardRuntime{id: "12"}
+	rt.active.Store(true)
+	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}, rotationFailures: make(map[string]struct{})}
+	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+
+	require.Equal(t, 1, createAttempts)
+	require.Equal(t, 0, settleAttempts)
+	require.False(t, rt.active.Load())
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, gatewayDevshardsByID(state.Devshards)["12"].Active)
+	statuses, err := store.LoadRotationStatuses(1)
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+	require.EqualValues(t, 0, statuses[0].SettledCount)
+	require.True(t, statuses[0].Completed)
+}
+
+func TestEscrowRotationFinishDeactivatesTempWithoutSettlementWhenDisabled(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	settings := GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Enabled:            true,
+			SettlementDisabled: true,
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       "Qwen/Test",
+				TempCount:     1,
+				TargetCount:   1,
+				Amount:        1000,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+			}},
+		},
+	}.WithTuningDefaults()
+	require.NoError(t, store.Initialize(settings, []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Test"},
+		Active:        true,
+		RotationRole:  rotationRoleTemp,
+		RotationEpoch: 10,
+	}}))
+
+	oldCreate := gatewayCreateRotationEscrow
+	oldSettle := gatewaySettleDevshardOnChain
+	createAttempts := 0
+	settleAttempts := 0
+	gatewayCreateRotationEscrow = func(*Gateway, context.Context, GatewaySettings, EscrowRotationModelSettings, string, uint64) (*CreateDevshardEscrowResult, error) {
+		createAttempts++
+		return &CreateDevshardEscrowResult{EscrowID: 99, TxHash: "OK"}, nil
+	}
+	gatewaySettleDevshardOnChain = func(*Gateway, context.Context, string, adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		settleAttempts++
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		gatewayCreateRotationEscrow = oldCreate
+		gatewaySettleDevshardOnChain = oldSettle
+	})
+
+	rt := &devshardRuntime{id: "12"}
+	rt.active.Store(true)
+	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}, rotationFailures: make(map[string]struct{})}
+	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+
+	require.Equal(t, 1, createAttempts)
+	require.Equal(t, 0, settleAttempts)
+	require.False(t, rt.active.Load())
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, gatewayDevshardsByID(state.Devshards)["12"].Active)
+	statuses, err := store.LoadRotationStatuses(1)
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+	require.EqualValues(t, 0, statuses[0].SettledCount)
 	require.True(t, statuses[0].Completed)
 }
 

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -136,9 +136,9 @@ func TestGatewayStoreUpdateSettings(t *testing.T) {
 			UnresponsiveThreshold:        0.8,
 		},
 		EscrowRotation: EscrowRotationSettings{
-			Enabled:            true,
-			SettlementDisabled: true,
-			PrePoCBlocks:       123,
+			Enabled:           true,
+			SettlementEnabled: true,
+			PrePoCBlocks:      123,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Kimi/Rotate",
 				TempCount:     2,
@@ -169,7 +169,7 @@ func TestGatewayStoreUpdateSettings(t *testing.T) {
 	require.EqualValues(t, 17, state.Settings.Redundancy.PerInputTokenFirstTokenLagMS)
 	require.Equal(t, 0.4, state.Settings.Redundancy.ParallelAdvantageThreshold)
 	require.True(t, state.Settings.EscrowRotation.Enabled)
-	require.True(t, state.Settings.EscrowRotation.SettlementDisabled)
+	require.True(t, state.Settings.EscrowRotation.SettlementEnabled)
 	require.EqualValues(t, 123, state.Settings.EscrowRotation.PrePoCBlocks)
 	require.Equal(t, []EscrowRotationModelSettings{{
 		ModelID:       "Kimi/Rotate",
@@ -278,7 +278,8 @@ func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testi
 		DefaultRequestMaxTokens: 1000,
 		MaxConcurrentRequests:   2,
 		EscrowRotation: EscrowRotationSettings{
-			Enabled: true,
+			Enabled:           true,
+			SettlementEnabled: true,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Qwen/Test",
 				TempCount:     8,
@@ -347,7 +348,8 @@ func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.
 		DefaultRequestMaxTokens: 1000,
 		MaxConcurrentRequests:   2,
 		EscrowRotation: EscrowRotationSettings{
-			Enabled: true,
+			Enabled:           true,
+			SettlementEnabled: true,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Qwen/Test",
 				TempCount:     1,
@@ -403,7 +405,8 @@ func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 		DefaultRequestMaxTokens: 1000,
 		MaxConcurrentRequests:   2,
 		EscrowRotation: EscrowRotationSettings{
-			Enabled: true,
+			Enabled:           true,
+			SettlementEnabled: true,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Qwen/Test",
 				TempCount:     1,
@@ -465,8 +468,8 @@ func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenDisabled(t 
 		DefaultRequestMaxTokens: 1000,
 		MaxConcurrentRequests:   2,
 		EscrowRotation: EscrowRotationSettings{
-			Enabled:            true,
-			SettlementDisabled: true,
+			Enabled:           true,
+			SettlementEnabled: false,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Qwen/Test",
 				TempCount:     1,
@@ -533,8 +536,8 @@ func TestEscrowRotationFinishDeactivatesTempWithoutSettlementWhenDisabled(t *tes
 		DefaultRequestMaxTokens: 1000,
 		MaxConcurrentRequests:   2,
 		EscrowRotation: EscrowRotationSettings{
-			Enabled:            true,
-			SettlementDisabled: true,
+			Enabled:           true,
+			SettlementEnabled: false,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Qwen/Test",
 				TempCount:     1,
@@ -601,7 +604,8 @@ func TestEscrowRotationPrepareRotatesModelsIndependently(t *testing.T) {
 		DefaultRequestMaxTokens: 1000,
 		MaxConcurrentRequests:   2,
 		EscrowRotation: EscrowRotationSettings{
-			Enabled: true,
+			Enabled:           true,
+			SettlementEnabled: true,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Qwen/Test",
 				TempCount:     1,
@@ -673,8 +677,9 @@ func TestEscrowRotationUsesEpochSwitchHeightDuringPoC(t *testing.T) {
 		DefaultRequestMaxTokens: 1000,
 		MaxConcurrentRequests:   2,
 		EscrowRotation: EscrowRotationSettings{
-			Enabled:      true,
-			PrePoCBlocks: 300,
+			Enabled:           true,
+			SettlementEnabled: true,
+			PrePoCBlocks:      300,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "Qwen/Test",
 				TempCount:     1,

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -522,7 +522,7 @@ func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenSettlementD
 	require.True(t, statuses[0].Completed)
 }
 
-func TestEscrowRotationFinishDeactivatesTempWithoutSettlementWhenDisabled(t *testing.T) {
+func TestEscrowRotationFinishDeactivatesTempWithoutSettlementWhenSettlementDisabled(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -76,7 +76,7 @@ func gatewayTestRuntimeForLimits(t *testing.T, id string, balance, nonce uint64)
 	}
 }
 
-func gatewayTestDepletionGateway(t *testing.T, rt *devshardRuntime) (*Gateway, *atomic.Int32, *atomic.Int32) {
+func gatewayTestDepletionGateway(t *testing.T, rt *devshardRuntime, modifySettings ...func(*GatewaySettings)) (*Gateway, *atomic.Int32, *atomic.Int32) {
 	t.Helper()
 
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
@@ -100,6 +100,9 @@ func gatewayTestDepletionGateway(t *testing.T, rt *devshardRuntime) (*Gateway, *
 			}},
 		},
 	}.WithTuningDefaults()
+	for _, modify := range modifySettings {
+		modify(&settings)
+	}
 	require.NoError(t, store.Initialize(settings, []GatewayDevshardState{{
 		RuntimeConfig: RuntimeConfig{ID: rt.id, PrivateKeyHex: "secret", Model: rt.model},
 		Active:        true,
@@ -160,6 +163,33 @@ func TestGatewayCheckBalancesReplacesAndDeactivatesHighNonce(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return created.Load() == 1 && settled.Load() == 1 && !rt.active.Load()
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestGatewayCheckBalancesNoOpWhenRotationDisabled(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit)
+	g, created, settled := gatewayTestDepletionGateway(t, rt, func(settings *GatewaySettings) {
+		settings.EscrowRotation.Enabled = false
+	})
+
+	g.checkBalances()
+
+	require.EqualValues(t, 0, created.Load())
+	require.EqualValues(t, 0, settled.Load())
+	require.True(t, rt.active.Load())
+}
+
+func TestGatewayCheckBalancesReplacesAndDeactivatesWithoutSettlement(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit-1)
+	g, created, settled := gatewayTestDepletionGateway(t, rt, func(settings *GatewaySettings) {
+		settings.EscrowRotation.SettlementDisabled = true
+	})
+
+	g.checkBalances()
+
+	require.Eventually(t, func() bool {
+		return created.Load() == 1 && !rt.active.Load()
+	}, time.Second, 10*time.Millisecond)
+	require.EqualValues(t, 0, settled.Load())
 }
 
 func TestGatewayCheckBalancesKeepsRuntimeBelowLimits(t *testing.T) {
@@ -2232,6 +2262,42 @@ func TestAdminSettingsRejectsInvalidTuning(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "empty_stream_threshold")
 }
 
+func TestAdminSettingsUpdatesEscrowRotationSettlementDisabled(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, nil))
+
+	g := NewManagedGateway(nil, NewGatewayLimiter(2, 200), GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, t.TempDir(), store)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/settings",
+		strings.NewReader(`{"escrow_rotation":{"settlement_disabled":true}}`))
+	rec := httptest.NewRecorder()
+	g.handleAdminSettings(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, state.Settings.EscrowRotation.SettlementDisabled)
+}
+
 func TestDebugRotationReportsCountdownAndLatestStatus(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)
@@ -2289,6 +2355,9 @@ func TestDebugRotationReportsCountdownAndLatestStatus(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var body struct {
+		Settings struct {
+			SettlementDisabled bool `json:"settlement_disabled"`
+		} `json:"settings"`
 		Chain struct {
 			BlocksToEpochSwitch     int64 `json:"blocks_to_epoch_switch"`
 			BlocksUntilNextRotation int64 `json:"blocks_until_next_rotation"`
@@ -2296,6 +2365,7 @@ func TestDebugRotationReportsCountdownAndLatestStatus(t *testing.T) {
 		Latest []GatewayRotationStatus `json:"latest"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.False(t, body.Settings.SettlementDisabled)
 	require.EqualValues(t, 400, body.Chain.BlocksToEpochSwitch)
 	require.EqualValues(t, 100, body.Chain.BlocksUntilNextRotation)
 	require.Len(t, body.Latest, 1)

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -193,6 +193,25 @@ func TestGatewayCheckBalancesReplacesAndDeactivatesWithoutSettlement(t *testing.
 	require.EqualValues(t, 0, settled.Load())
 }
 
+func TestGatewayBalanceExhaustedDeactivatesWhenRotationDisabled(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold, nonceDeactivationLimit-1)
+	rt.proxy.redundancy = &Redundancy{}
+	g, created, settled := gatewayTestDepletionGateway(t, rt, func(settings *GatewaySettings) {
+		settings.EscrowRotation.Enabled = false
+	})
+	g.attachEscrowChecker(rt)
+
+	rt.proxy.redundancy.onBalanceExhausted()
+
+	require.EqualValues(t, 0, created.Load())
+	require.EqualValues(t, 0, settled.Load())
+	require.False(t, rt.active.Load())
+	state, ok, err := g.store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, gatewayDevshardsByID(state.Devshards)["12"].Active)
+}
+
 func TestGatewayCheckBalancesKeepsRuntimeBelowLimits(t *testing.T) {
 	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold, nonceDeactivationLimit-1)
 	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "m")

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -90,7 +90,8 @@ func gatewayTestDepletionGateway(t *testing.T, rt *devshardRuntime, modifySettin
 		DefaultRequestMaxTokens: 1000,
 		MaxConcurrentRequests:   2,
 		EscrowRotation: EscrowRotationSettings{
-			Enabled: true,
+			Enabled:           true,
+			SettlementEnabled: true,
 			Models: []EscrowRotationModelSettings{{
 				ModelID:       "m",
 				TempCount:     1,
@@ -181,7 +182,7 @@ func TestGatewayCheckBalancesNoOpWhenRotationDisabled(t *testing.T) {
 func TestGatewayCheckBalancesReplacesAndDeactivatesWithoutSettlement(t *testing.T) {
 	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit-1)
 	g, created, settled := gatewayTestDepletionGateway(t, rt, func(settings *GatewaySettings) {
-		settings.EscrowRotation.SettlementDisabled = true
+		settings.EscrowRotation.SettlementEnabled = false
 	})
 
 	g.checkBalances()
@@ -2262,7 +2263,7 @@ func TestAdminSettingsRejectsInvalidTuning(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "empty_stream_threshold")
 }
 
-func TestAdminSettingsUpdatesEscrowRotationSettlementDisabled(t *testing.T) {
+func TestAdminSettingsUpdatesEscrowRotationSettlementEnabled(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -2287,7 +2288,7 @@ func TestAdminSettingsUpdatesEscrowRotationSettlementDisabled(t *testing.T) {
 	}, t.TempDir(), store)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/admin/settings",
-		strings.NewReader(`{"escrow_rotation":{"settlement_disabled":true}}`))
+		strings.NewReader(`{"escrow_rotation":{"settlement_enabled":true}}`))
 	rec := httptest.NewRecorder()
 	g.handleAdminSettings(rec, req)
 
@@ -2295,7 +2296,7 @@ func TestAdminSettingsUpdatesEscrowRotationSettlementDisabled(t *testing.T) {
 	state, ok, err := store.LoadState()
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.True(t, state.Settings.EscrowRotation.SettlementDisabled)
+	require.True(t, state.Settings.EscrowRotation.SettlementEnabled)
 }
 
 func TestDebugRotationReportsCountdownAndLatestStatus(t *testing.T) {
@@ -2356,7 +2357,7 @@ func TestDebugRotationReportsCountdownAndLatestStatus(t *testing.T) {
 
 	var body struct {
 		Settings struct {
-			SettlementDisabled bool `json:"settlement_disabled"`
+			SettlementEnabled bool `json:"settlement_enabled"`
 		} `json:"settings"`
 		Chain struct {
 			BlocksToEpochSwitch     int64 `json:"blocks_to_epoch_switch"`
@@ -2365,7 +2366,7 @@ func TestDebugRotationReportsCountdownAndLatestStatus(t *testing.T) {
 		Latest []GatewayRotationStatus `json:"latest"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	require.False(t, body.Settings.SettlementDisabled)
+	require.False(t, body.Settings.SettlementEnabled)
 	require.EqualValues(t, 400, body.Chain.BlocksToEpochSwitch)
 	require.EqualValues(t, 100, body.Chain.BlocksUntilNextRotation)
 	require.Len(t, body.Latest, 1)

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -181,9 +181,10 @@ func mustLoadBootstrapOptions(flags cliFlags, baseStorageDir string) bootstrapOp
 			NewURL:  os.Getenv("DEVSHARD_GATEWAY_DISABLED_NEW_URL"),
 		},
 		EscrowRotation: EscrowRotationSettings{
-			Enabled:      readBoolEnv("DEVSHARD_ESCROW_ROTATION_ENABLED", false),
-			PrePoCBlocks: readInt64Env("DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS", 300),
-			Models:       mustReadEscrowRotationModelsEnv(),
+			Enabled:            readBoolEnv("DEVSHARD_ESCROW_ROTATION_ENABLED", false),
+			SettlementDisabled: readBoolEnv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_DISABLED", false),
+			PrePoCBlocks:       readInt64Env("DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS", 300),
+			Models:             mustReadEscrowRotationModelsEnv(),
 		},
 	}.WithTuningDefaults()
 	return opts

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -181,10 +181,10 @@ func mustLoadBootstrapOptions(flags cliFlags, baseStorageDir string) bootstrapOp
 			NewURL:  os.Getenv("DEVSHARD_GATEWAY_DISABLED_NEW_URL"),
 		},
 		EscrowRotation: EscrowRotationSettings{
-			Enabled:            readBoolEnv("DEVSHARD_ESCROW_ROTATION_ENABLED", false),
-			SettlementDisabled: !readBoolEnv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED", false),
-			PrePoCBlocks:       readInt64Env("DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS", 300),
-			Models:             mustReadEscrowRotationModelsEnv(),
+			Enabled:           readBoolEnv("DEVSHARD_ESCROW_ROTATION_ENABLED", false),
+			SettlementEnabled: readBoolEnv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED", false),
+			PrePoCBlocks:      readInt64Env("DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS", 300),
+			Models:            mustReadEscrowRotationModelsEnv(),
 		},
 	}.WithTuningDefaults()
 	return opts

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -182,7 +182,7 @@ func mustLoadBootstrapOptions(flags cliFlags, baseStorageDir string) bootstrapOp
 		},
 		EscrowRotation: EscrowRotationSettings{
 			Enabled:            readBoolEnv("DEVSHARD_ESCROW_ROTATION_ENABLED", false),
-			SettlementDisabled: readBoolEnv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_DISABLED", false),
+			SettlementDisabled: !readBoolEnv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED", false),
 			PrePoCBlocks:       readInt64Env("DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS", 300),
 			Models:             mustReadEscrowRotationModelsEnv(),
 		},

--- a/devshard/cmd/devshardctl/main_test.go
+++ b/devshard/cmd/devshardctl/main_test.go
@@ -15,14 +15,14 @@ func TestBootstrapEscrowRotationSettlementEnabledEnv(t *testing.T) {
 	t.Setenv("DEVSHARDS_JSON", "[]")
 	t.Setenv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED", "true")
 	opts := mustLoadBootstrapOptions(cliFlags{}, t.TempDir())
-	require.False(t, opts.bootstrapSettings.EscrowRotation.SettlementDisabled)
+	require.True(t, opts.bootstrapSettings.EscrowRotation.SettlementEnabled)
 }
 
 func TestBootstrapEscrowRotationSettlementDefaultsDisabled(t *testing.T) {
 	t.Setenv("DEVSHARDS_JSON", "[]")
 	require.NoError(t, os.Unsetenv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED"))
 	opts := mustLoadBootstrapOptions(cliFlags{}, t.TempDir())
-	require.True(t, opts.bootstrapSettings.EscrowRotation.SettlementDisabled)
+	require.False(t, opts.bootstrapSettings.EscrowRotation.SettlementEnabled)
 }
 
 func TestBuildGatewayRuntimesDeactivatesMissingEscrow(t *testing.T) {

--- a/devshard/cmd/devshardctl/main_test.go
+++ b/devshard/cmd/devshardctl/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -9,6 +10,20 @@ import (
 
 	"devshard/bridge"
 )
+
+func TestBootstrapEscrowRotationSettlementEnabledEnv(t *testing.T) {
+	t.Setenv("DEVSHARDS_JSON", "[]")
+	t.Setenv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED", "true")
+	opts := mustLoadBootstrapOptions(cliFlags{}, t.TempDir())
+	require.False(t, opts.bootstrapSettings.EscrowRotation.SettlementDisabled)
+}
+
+func TestBootstrapEscrowRotationSettlementDefaultsDisabled(t *testing.T) {
+	t.Setenv("DEVSHARDS_JSON", "[]")
+	require.NoError(t, os.Unsetenv("DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED"))
+	opts := mustLoadBootstrapOptions(cliFlags{}, t.TempDir())
+	require.True(t, opts.bootstrapSettings.EscrowRotation.SettlementDisabled)
+}
 
 func TestBuildGatewayRuntimesDeactivatesMissingEscrow(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))

--- a/devshard/docs/gateway-rotation-controls-pr.md
+++ b/devshard/docs/gateway-rotation-controls-pr.md
@@ -23,4 +23,4 @@ For first-boot env config, `DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED=false` i
 
 ## Test Plan
 
-- `GOMODCACHE="/Users/dima/go/pkg/mod" go test ./cmd/devshardctl`
+- `(cd devshard && go test ./cmd/devshardctl)`

--- a/devshard/docs/gateway-rotation-controls-pr.md
+++ b/devshard/docs/gateway-rotation-controls-pr.md
@@ -1,0 +1,24 @@
+# Devshard Gateway Rotation Controls
+
+## Summary
+
+The devshard gateway has two automatic escrow rotation paths:
+
+- Epoch/PoC rotation creates temporary bridge escrows before PoC, then returns to regular escrows after PoC.
+- Depletion rotation creates a replacement escrow when an active escrow is low on balance or close to the nonce limit.
+
+This change makes `escrow_rotation.enabled` the master switch for both paths. When it is `false`, the gateway no longer performs automatic PoC rotation or low-balance/high-nonce replacement.
+
+It also adds `escrow_rotation.settlement_disabled`. When rotation is enabled but settlement is disabled, the gateway still creates replacement escrows and locally deactivates old escrows, but it skips automatic finalization and on-chain settlement. Manual settlement through the admin API remains available.
+
+## Behavior
+
+- `escrow_rotation.enabled=false`: no automatic escrow rotation.
+- `escrow_rotation.enabled=true` and `settlement_disabled=false`: create replacements, deactivate old escrows, and settle them on-chain.
+- `escrow_rotation.enabled=true` and `settlement_disabled=true`: create replacements and deactivate old escrows locally, but do not auto-settle.
+
+`GET /v1/admin/settings` shows the persisted gateway settings from `gateway.db`, which are the effective settings after first boot.
+
+## Test Plan
+
+- `GOMODCACHE="/Users/dima/go/pkg/mod" go test ./cmd/devshardctl`

--- a/devshard/docs/gateway-rotation-controls-pr.md
+++ b/devshard/docs/gateway-rotation-controls-pr.md
@@ -9,15 +9,15 @@ The devshard gateway has two automatic escrow rotation paths:
 
 This change makes `escrow_rotation.enabled` the master switch for both paths. When it is `false`, the gateway no longer performs automatic PoC rotation or low-balance/high-nonce replacement.
 
-It also adds `escrow_rotation.settlement_disabled`. When rotation is enabled but settlement is disabled, the gateway still creates replacement escrows and locally deactivates old escrows, but it skips automatic finalization and on-chain settlement. Manual settlement through the admin API remains available.
+It also adds `escrow_rotation.settlement_enabled`. When rotation is enabled but settlement is not enabled, the gateway still creates replacement escrows and locally deactivates old escrows, but it skips automatic finalization and on-chain settlement. Manual settlement through the admin API remains available.
 
-For first-boot env config, `DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED=false` is the default and maps to `escrow_rotation.settlement_disabled=true`.
+For first-boot env config, `DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED=false` is the default and maps to `escrow_rotation.settlement_enabled=false`.
 
 ## Behavior
 
 - `escrow_rotation.enabled=false`: no automatic escrow rotation.
-- `escrow_rotation.enabled=true` and `settlement_disabled=false`: create replacements, deactivate old escrows, and settle them on-chain.
-- `escrow_rotation.enabled=true` and `settlement_disabled=true`: create replacements and deactivate old escrows locally, but do not auto-settle.
+- `escrow_rotation.enabled=true` and `settlement_enabled=true`: create replacements, deactivate old escrows, and settle them on-chain.
+- `escrow_rotation.enabled=true` and `settlement_enabled=false`: create replacements and deactivate old escrows locally, but do not auto-settle.
 
 `GET /v1/admin/settings` shows the persisted gateway settings from `gateway.db`, which are the effective settings after first boot.
 

--- a/devshard/docs/gateway-rotation-controls-pr.md
+++ b/devshard/docs/gateway-rotation-controls-pr.md
@@ -11,6 +11,8 @@ This change makes `escrow_rotation.enabled` the master switch for both paths. Wh
 
 It also adds `escrow_rotation.settlement_disabled`. When rotation is enabled but settlement is disabled, the gateway still creates replacement escrows and locally deactivates old escrows, but it skips automatic finalization and on-chain settlement. Manual settlement through the admin API remains available.
 
+For first-boot env config, `DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED=false` is the default and maps to `escrow_rotation.settlement_disabled=true`.
+
 ## Behavior
 
 - `escrow_rotation.enabled=false`: no automatic escrow rotation.

--- a/devshard/docs/proxy.md
+++ b/devshard/docs/proxy.md
@@ -32,7 +32,7 @@ All settings can be passed as flags or environment variables. Flags take precede
 | - | `DEVSHARD_GATEWAY_DISABLED_MESSAGE` | no | `please use ... base url` | Message shown while the gateway is disabled |
 | - | `DEVSHARD_GATEWAY_DISABLED_NEW_URL` | no | - | Replacement chat completions URL returned while the gateway is disabled |
 | - | `DEVSHARD_ESCROW_ROTATION_ENABLED` | no | `false` | Enable automatic epoch and depletion escrow rotation |
-| - | `DEVSHARD_ESCROW_ROTATION_SETTLEMENT_DISABLED` | no | `false` | Keep automatic escrow creation/deactivation, but skip automatic finalization and on-chain settlement |
+| - | `DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED` | no | `false` | Enable automatic finalization and on-chain settlement for rotated escrows |
 | - | `DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS` | no | `300` | Blocks before the next epoch switch at `set_new_validators` to create temp bridge escrows |
 | - | `DEVSHARD_ESCROW_ROTATION_MODELS_JSON` | when rotation enabled | - | JSON array of per-model rotation configs: `model_id`, `temp_count`, `target_count`, `amount`, `private_key_env` |
 

--- a/devshard/docs/proxy.md
+++ b/devshard/docs/proxy.md
@@ -269,7 +269,7 @@ depletion replacement are disabled.
 4. It then deactivates, finalizes, and settles the previous epoch's temp
    escrows.
 
-Set `escrow_rotation.settlement_disabled` to `true` to keep automatic creation
+Set `escrow_rotation.settlement_enabled` to `false` to keep automatic creation
 and local deactivation while skipping automatic finalization and on-chain
 settlement. Manual settlement through `POST /v1/admin/devshards/{id}/settle`
 remains available.
@@ -284,7 +284,7 @@ curl -X POST http://localhost:8080/v1/admin/settings \
   -d '{
     "escrow_rotation": {
       "enabled": true,
-      "settlement_disabled": false,
+      "settlement_enabled": false,
       "pre_poc_blocks": 300,
       "models": [{
         "model_id": "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",

--- a/devshard/docs/proxy.md
+++ b/devshard/docs/proxy.md
@@ -31,7 +31,8 @@ All settings can be passed as flags or environment variables. Flags take precede
 | - | `DEVSHARD_GATEWAY_DISABLED` | no | `false` | Return a 308 redirect-shaped JSON response for all non-admin requests |
 | - | `DEVSHARD_GATEWAY_DISABLED_MESSAGE` | no | `please use ... base url` | Message shown while the gateway is disabled |
 | - | `DEVSHARD_GATEWAY_DISABLED_NEW_URL` | no | - | Replacement chat completions URL returned while the gateway is disabled |
-| - | `DEVSHARD_ESCROW_ROTATION_ENABLED` | no | `false` | Enable automatic epoch escrow rotation |
+| - | `DEVSHARD_ESCROW_ROTATION_ENABLED` | no | `false` | Enable automatic epoch and depletion escrow rotation |
+| - | `DEVSHARD_ESCROW_ROTATION_SETTLEMENT_DISABLED` | no | `false` | Keep automatic escrow creation/deactivation, but skip automatic finalization and on-chain settlement |
 | - | `DEVSHARD_ESCROW_ROTATION_PRE_POC_BLOCKS` | no | `300` | Blocks before the next epoch switch at `set_new_validators` to create temp bridge escrows |
 | - | `DEVSHARD_ESCROW_ROTATION_MODELS_JSON` | when rotation enabled | - | JSON array of per-model rotation configs: `model_id`, `temp_count`, `target_count`, `amount`, `private_key_env` |
 
@@ -255,7 +256,9 @@ Automatic rotation uses two roles:
   PoC/epoch transition.
 
 When `escrow_rotation.enabled` is true, the gateway watches the chain phase
-snapshot from `DEVSHARD_PUBLIC_API`:
+snapshot from `DEVSHARD_PUBLIC_API` and also replaces escrows that approach the
+low-balance or high-nonce limits. When it is false, both epoch rotation and
+depletion replacement are disabled.
 
 1. During inference phase, when the chain is within `pre_poc_blocks` of PoC,
    the gateway ensures `temp_count` temp escrows exist for the current epoch.
@@ -265,6 +268,11 @@ snapshot from `DEVSHARD_PUBLIC_API`:
    exist for the new epoch.
 4. It then deactivates, finalizes, and settles the previous epoch's temp
    escrows.
+
+Set `escrow_rotation.settlement_disabled` to `true` to keep automatic creation
+and local deactivation while skipping automatic finalization and on-chain
+settlement. Manual settlement through `POST /v1/admin/devshards/{id}/settle`
+remains available.
 
 Rotation settings are persisted in `gateway.db`. After first boot, update them
 through `POST /v1/admin/settings`:
@@ -276,12 +284,15 @@ curl -X POST http://localhost:8080/v1/admin/settings \
   -d '{
     "escrow_rotation": {
       "enabled": true,
-      "private_key_env": "DEVSHARD_PRIVATE_KEY",
-      "amount": 5000000000,
-      "model_id": "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
+      "settlement_disabled": false,
       "pre_poc_blocks": 300,
-      "temp_count": 8,
-      "target_count": 16
+      "models": [{
+        "model_id": "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
+        "temp_count": 8,
+        "target_count": 16,
+        "amount": 5000000000,
+        "private_key_env": "DEVSHARD_PRIVATE_KEY"
+      }]
     },
     "tx_gas_limit": 700000
   }'


### PR DESCRIPTION
# Devshard Gateway Rotation Controls

## Summary

The devshard gateway has two automatic escrow rotation paths:

- Epoch/PoC rotation creates temporary bridge escrows before PoC, then returns to regular escrows after PoC.
- Depletion rotation creates a replacement escrow when an active escrow is low on balance or close to the nonce limit.

This change makes `escrow_rotation.enabled` the master switch for both paths. When it is `false`, the gateway no longer performs automatic PoC rotation or low-balance/high-nonce replacement.

It also adds `escrow_rotation.settlement_enabled`. When rotation is enabled but settlement is not enabled, the gateway still creates replacement escrows and locally deactivates old escrows, but it skips automatic finalization and on-chain settlement. Manual settlement through the admin API remains available.

For first-boot env config, `DEVSHARD_ESCROW_ROTATION_SETTLEMENT_ENABLED=false` is the default and maps to `escrow_rotation.settlement_enabled=false`.

## Behavior

- `escrow_rotation.enabled=false`: no automatic escrow rotation.
- `escrow_rotation.enabled=true` and `settlement_enabled=true`: create replacements, deactivate old escrows, and settle them on-chain.
- `escrow_rotation.enabled=true` and `settlement_enabled=false`: create replacements and deactivate old escrows locally, but do not auto-settle.

`GET /v1/admin/settings` shows the persisted gateway settings from `gateway.db`, which are the effective settings after first boot.

## Test Plan

- `(cd devshard && go test ./cmd/devshardctl)`
