### PR TITLE
[P2] Onboarding Clarity: handler-layer UX + selfcheck, Dima's approach (supersedes #1261, #866)

### DIFF
--- a/decentralized-api/apiconfig/constants.go
+++ b/decentralized-api/apiconfig/constants.go
@@ -1,0 +1,22 @@
+package apiconfig
+
+// Timing constants used by onboarding UX helpers in the admin layer.
+// Kept in apiconfig (not admin) so other components — including the
+// selfcheck mode — can reference the same defaults without importing
+// the admin package.
+const (
+	// DefaultBlockTimeSeconds is the assumed average chain block time
+	// used to translate block-distance to seconds for human-facing timing.
+	DefaultBlockTimeSeconds = 6.0
+
+	// AutoTestMinSecondsBeforePoC is the minimum slack required before
+	// the next PoC to trigger a pre-PoC self-test on an MLnode. Below
+	// this slack we avoid disrupting an MLnode that may need to load
+	// models for the upcoming PoC.
+	AutoTestMinSecondsBeforePoC int64 = 3600
+
+	// OnlineAlertLeadSeconds is the lead time before the next PoC at
+	// which we switch UX guidance from "safe to be offline" to
+	// "must be online now".
+	OnlineAlertLeadSeconds int64 = 600
+)

--- a/decentralized-api/broker/broker.go
+++ b/decentralized-api/broker/broker.go
@@ -1619,12 +1619,16 @@ func (b *Broker) EnsurePreservedMembershipCached(epochState *chainphase.EpochSta
 // if that model exists in the current epoch subgroup set.
 func (b *Broker) PopulateSingleNodeEpochData(nodeId string) error {
 	if b.phaseTracker == nil {
-		logging.Warn("Cannot populate node epoch data: phase tracker not initialized", types.Nodes, "node_id", nodeId)
+		// Info, not Warn: only happens during early startup before the
+		// phase tracker is wired — expected, not an error.
+		logging.Info("Cannot populate node epoch data yet: phase tracker not initialized (normal during startup)", types.Nodes, "node_id", nodeId)
 		return fmt.Errorf("phase tracker not initialized")
 	}
 	epochState := b.phaseTracker.GetCurrentEpochState()
 	if epochState == nil || epochState.IsNilOrNotSynced() {
-		logging.Warn("Cannot populate node epoch data: epoch state not synced", types.Nodes, "node_id", nodeId)
+		// Info, not Warn: normal while the node is still syncing the chain
+		// during onboarding — epoch data is populated once it is synced.
+		logging.Info("Cannot populate node epoch data yet: epoch state not synced (normal until the chain syncs)", types.Nodes, "node_id", nodeId)
 		return fmt.Errorf("epoch state not synced")
 	}
 

--- a/decentralized-api/broker/node_admin_commands.go
+++ b/decentralized-api/broker/node_admin_commands.go
@@ -161,10 +161,18 @@ func (c RegisterNode) Execute(b *Broker) {
 		b.nodeWorkGroup.AddWorker(c.Node.Id, worker)
 	}()
 
-	// Populate epoch data for the newly registered node
+	// Populate epoch data for the newly registered node. While the chain
+	// has not synced yet (normal during onboarding) this is expected, so
+	// log it at Info; once the chain is synced, a failure here is a
+	// genuine problem and stays at Warn.
 	if err := b.PopulateSingleNodeEpochData(c.Node.Id); err != nil {
-		logging.Warn("RegisterNode. Failed to populate epoch data", types.Nodes, "node_id", c.Node.Id, "error", err)
+		if b.phaseTracker == nil || b.phaseTracker.GetCurrentEpochState().IsNilOrNotSynced() {
+			logging.Info("RegisterNode. Epoch data not available yet; will populate after the chain syncs", types.Nodes, "node_id", c.Node.Id)
+		} else {
+			logging.Warn("RegisterNode. Failed to populate epoch data", types.Nodes, "node_id", c.Node.Id, "error", err)
+		}
 	}
+
 
 	// Trigger a status check for the newly added node.
 	b.TriggerStatusQuery(true)

--- a/decentralized-api/broker/node_worker_commands.go
+++ b/decentralized-api/broker/node_worker_commands.go
@@ -135,12 +135,13 @@ func (c InferenceUpNodeCommand) Execute(ctx context.Context, worker *NodeWorker)
 			result.Succeeded = false
 			result.Error = "No epoch models available for this node"
 			result.FinalStatus = types.HardwareNodeStatus_FAILED
-			// Info, not Error: this state is normal when the participant
-			// has not yet joined the active set for the current epoch.
-			// A genuine misconfiguration shows up downstream as a
-			// FAILED node status; logging at Error here only spams
-			// healthy onboarding flows.
-			logging.Info(result.Error+" (participant may not be active in current epoch)", types.Nodes, "node_id", worker.nodeId)
+			// Warn, not Error: this state is normal when the participant
+			// has not yet joined the active set for the current epoch, so
+			// Error would spam healthy onboarding flows. We keep it at
+			// Warn (not Info) so a genuine misconfiguration — which also
+			// lands here and sets FinalStatus=FAILED — stays visible to
+			// operators and alerting.
+			logging.Warn(result.Error+" (participant may not be active in current epoch)", types.Nodes, "node_id", worker.nodeId)
 			return result
 		}
 

--- a/decentralized-api/broker/node_worker_commands.go
+++ b/decentralized-api/broker/node_worker_commands.go
@@ -135,7 +135,12 @@ func (c InferenceUpNodeCommand) Execute(ctx context.Context, worker *NodeWorker)
 			result.Succeeded = false
 			result.Error = "No epoch models available for this node"
 			result.FinalStatus = types.HardwareNodeStatus_FAILED
-			logging.Error(result.Error, types.Nodes, "node_id", worker.nodeId)
+			// Info, not Error: this state is normal when the participant
+			// has not yet joined the active set for the current epoch.
+			// A genuine misconfiguration shows up downstream as a
+			// FAILED node status; logging at Error here only spams
+			// healthy onboarding flows.
+			logging.Info(result.Error+" (participant may not be active in current epoch)", types.Nodes, "node_id", worker.nodeId)
 			return result
 		}
 

--- a/decentralized-api/broker/node_worker_commands.go
+++ b/decentralized-api/broker/node_worker_commands.go
@@ -135,13 +135,12 @@ func (c InferenceUpNodeCommand) Execute(ctx context.Context, worker *NodeWorker)
 			result.Succeeded = false
 			result.Error = "No epoch models available for this node"
 			result.FinalStatus = types.HardwareNodeStatus_FAILED
-			// Warn, not Error: this state is normal when the participant
-			// has not yet joined the active set for the current epoch, so
-			// Error would spam healthy onboarding flows. We keep it at
-			// Warn (not Info) so a genuine misconfiguration — which also
-			// lands here and sets FinalStatus=FAILED — stays visible to
-			// operators and alerting.
-			logging.Warn(result.Error+" (participant may not be active in current epoch)", types.Nodes, "node_id", worker.nodeId)
+			// Info, not Error (per proposal): this state is normal when the
+			// participant has not yet joined the active set for the current
+			// epoch — not a misconfiguration the operator needs to act on.
+			// A genuine problem still surfaces downstream via the node's
+			// FAILED status, so visibility is not lost.
+			logging.Info("Participant not yet active - model assignment pending (normal for new participants)", types.Nodes, "node_id", worker.nodeId)
 			return result
 		}
 

--- a/decentralized-api/internal/server/admin/mlnode_tester.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester.go
@@ -6,6 +6,7 @@ import (
 	"decentralized-api/mlnodeclient"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
@@ -148,7 +149,17 @@ func (t *MLNodeTester) runOnce(ctx context.Context, cfg apiconfig.InferenceNodeC
 		_ = client.Stop(stopCtx)
 	}()
 
-	for modelId, modelCfg := range cfg.Models {
+	// Iterate models in a stable (sorted) order so FailingModel and the
+	// per-model load sequence are deterministic across runs — Go map
+	// iteration order is randomized.
+	modelIds := make([]string, 0, len(cfg.Models))
+	for modelId := range cfg.Models {
+		modelIds = append(modelIds, modelId)
+	}
+	sort.Strings(modelIds)
+
+	for _, modelId := range modelIds {
+		modelCfg := cfg.Models[modelId]
 		modelStart := time.Now()
 		if err := client.InferenceUp(ctx, modelId, modelCfg.Args); err != nil {
 			result.Status = TestFailed

--- a/decentralized-api/internal/server/admin/mlnode_tester.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester.go
@@ -77,6 +77,15 @@ func (t *MLNodeTester) LastResult(nodeId string) *TestResult {
 	return nil
 }
 
+// Invalidate drops any recorded result for nodeId, so a stale pass from a
+// previous configuration is not reported as validated after the node is
+// changed.
+func (t *MLNodeTester) Invalidate(nodeId string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.lastTests, nodeId)
+}
+
 // IsRunning reports whether a test is currently in flight for nodeId.
 func (t *MLNodeTester) IsRunning(nodeId string) bool {
 	t.mu.Lock()

--- a/decentralized-api/internal/server/admin/mlnode_tester.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester.go
@@ -117,6 +117,17 @@ func (t *MLNodeTester) Run(ctx context.Context, nodeId string) (*TestResult, err
 	return result, nil
 }
 
+// versionedURL builds an MLnode URL, inserting the node version into the
+// path when non-empty — matching broker.Node.PoCUrlWithVersion /
+// InferenceUrlWithVersion so the tester reaches the same routes the broker
+// uses in versioned (rolling-upgrade) deployments.
+func versionedURL(host string, port int, segment, version string) string {
+	if version == "" {
+		return fmt.Sprintf("http://%s:%d%s", host, port, segment)
+	}
+	return fmt.Sprintf("http://%s:%d/%s%s", host, port, version, segment)
+}
+
 func (t *MLNodeTester) findNode(nodeId string) (apiconfig.InferenceNodeConfig, bool) {
 	for _, n := range t.configManager.GetNodes() {
 		if n.Id == nodeId {
@@ -138,8 +149,13 @@ func (t *MLNodeTester) runOnce(ctx context.Context, cfg apiconfig.InferenceNodeC
 		result.DurationMs = time.Since(started).Milliseconds()
 	}()
 
-	pocUrl := fmt.Sprintf("http://%s:%d%s", cfg.Host, cfg.PoCPort, cfg.PoCSegment)
-	inferenceUrl := fmt.Sprintf("http://%s:%d%s", cfg.Host, cfg.InferencePort, cfg.InferenceSegment)
+	// Build URLs the same way the broker does for versioned (rolling-
+	// upgrade) deployments: insert the current node version into the path
+	// when set, so the test hits the same MLnode routes the broker uses
+	// (an unversioned URL would hit the wrong endpoint and falsely fail).
+	version := t.configManager.GetCurrentNodeVersion()
+	pocUrl := versionedURL(cfg.Host, cfg.PoCPort, cfg.PoCSegment, version)
+	inferenceUrl := versionedURL(cfg.Host, cfg.InferencePort, cfg.InferenceSegment, version)
 	client := t.factory.CreateClient(pocUrl, inferenceUrl)
 
 	// Best-effort cleanup at the end so a successful test leaves the

--- a/decentralized-api/internal/server/admin/mlnode_tester.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester.go
@@ -30,6 +30,7 @@ type TestResult struct {
 	Error        string           `json:"error,omitempty"`
 	LoadMs       map[string]int64 `json:"load_ms,omitempty"`
 	HealthMs     int64            `json:"health_ms,omitempty"`
+	RespMs       int64            `json:"resp_ms,omitempty"`
 	StartedAt    time.Time        `json:"started_at"`
 	DurationMs   int64            `json:"duration_ms"`
 }
@@ -158,6 +159,7 @@ func (t *MLNodeTester) runOnce(ctx context.Context, cfg apiconfig.InferenceNodeC
 	}
 	sort.Strings(modelIds)
 
+	lastModel := ""
 	for _, modelId := range modelIds {
 		modelCfg := cfg.Models[modelId]
 		modelStart := time.Now()
@@ -169,6 +171,7 @@ func (t *MLNodeTester) runOnce(ctx context.Context, cfg apiconfig.InferenceNodeC
 			return result
 		}
 		result.LoadMs[modelId] = time.Since(modelStart).Milliseconds()
+		lastModel = modelId
 	}
 
 	healthStart := time.Now()
@@ -183,6 +186,22 @@ func (t *MLNodeTester) runOnce(ctx context.Context, cfg apiconfig.InferenceNodeC
 		result.Status = TestFailed
 		result.Error = "health check returned not ok"
 		return result
+	}
+
+	// Response validation: send one real inference request against the
+	// loaded model and validate the response, recording response time.
+	// (Uses the existing host:port URL construction; see #717 follow-up
+	// in proposals/onboarding-clarity-v1/README.md.)
+	if lastModel != "" {
+		respStart := time.Now()
+		if err := client.Inference(ctx, lastModel); err != nil {
+			result.Status = TestFailed
+			result.FailingModel = lastModel
+			result.Error = "inference request error: " + err.Error()
+			result.RespMs = time.Since(respStart).Milliseconds()
+			return result
+		}
+		result.RespMs = time.Since(respStart).Milliseconds()
 	}
 
 	return result

--- a/decentralized-api/internal/server/admin/mlnode_tester.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester.go
@@ -1,0 +1,178 @@
+package admin
+
+import (
+	"context"
+	"decentralized-api/apiconfig"
+	"decentralized-api/mlnodeclient"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// TestResultStatus is the outcome of a one-shot MLnode validation.
+type TestResultStatus string
+
+const (
+	TestSuccess TestResultStatus = "SUCCESS"
+	TestFailed  TestResultStatus = "FAILED"
+)
+
+// TestResult is the report returned by MLNodeTester.Run for one node.
+// Reported back to the HTTP caller verbatim; not stored on broker
+// state. Each per-model load time is recorded in LoadMs to help
+// operators spot slow model loads.
+type TestResult struct {
+	NodeId       string           `json:"node_id"`
+	Status       TestResultStatus `json:"status"`
+	FailingModel string           `json:"failing_model,omitempty"`
+	Error        string           `json:"error,omitempty"`
+	LoadMs       map[string]int64 `json:"load_ms,omitempty"`
+	HealthMs     int64            `json:"health_ms,omitempty"`
+	StartedAt    time.Time        `json:"started_at"`
+	DurationMs   int64            `json:"duration_ms"`
+}
+
+// ErrTestInProgress is returned by MLNodeTester.Run when a test is
+// already running for the same node id. Callers should translate this
+// to HTTP 409 Conflict.
+var ErrTestInProgress = errors.New("mlnode test already in progress for this node")
+
+// ErrNodeNotFound is returned by MLNodeTester.Run when the requested
+// node id is not present in the configured node list. Callers should
+// translate this to HTTP 404 Not Found.
+var ErrNodeNotFound = errors.New("node not configured")
+
+// MLNodeTester runs one-shot validation against a configured MLnode
+// without involving the broker. It is safe for concurrent use; a
+// per-node mutex prevents two tests running against the same node.
+type MLNodeTester struct {
+	configManager *apiconfig.ConfigManager
+	factory       mlnodeclient.ClientFactory
+
+	mu        sync.Mutex
+	inFlight  map[string]bool
+	lastTests map[string]*TestResult
+}
+
+func NewMLNodeTester(cm *apiconfig.ConfigManager, factory mlnodeclient.ClientFactory) *MLNodeTester {
+	return &MLNodeTester{
+		configManager: cm,
+		factory:       factory,
+		inFlight:      map[string]bool{},
+		lastTests:     map[string]*TestResult{},
+	}
+}
+
+// LastResult returns the most recent TestResult for nodeId, or nil
+// if no test has been recorded for that node yet.
+func (t *MLNodeTester) LastResult(nodeId string) *TestResult {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if r, ok := t.lastTests[nodeId]; ok {
+		return r
+	}
+	return nil
+}
+
+// IsRunning reports whether a test is currently in flight for nodeId.
+func (t *MLNodeTester) IsRunning(nodeId string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.inFlight[nodeId]
+}
+
+// Run validates the MLnode behind nodeId: for each configured model,
+// it loads the model and measures load time; then it runs a single
+// inference-health check. Models that load successfully are torn down
+// via Stop on completion. Returns ErrNodeNotFound or ErrTestInProgress
+// before launching the test.
+func (t *MLNodeTester) Run(ctx context.Context, nodeId string) (*TestResult, error) {
+	cfg, ok := t.findNode(nodeId)
+	if !ok {
+		return nil, ErrNodeNotFound
+	}
+
+	t.mu.Lock()
+	if t.inFlight[nodeId] {
+		t.mu.Unlock()
+		return nil, ErrTestInProgress
+	}
+	t.inFlight[nodeId] = true
+	t.mu.Unlock()
+
+	defer func() {
+		t.mu.Lock()
+		delete(t.inFlight, nodeId)
+		t.mu.Unlock()
+	}()
+
+	result := t.runOnce(ctx, cfg)
+
+	t.mu.Lock()
+	t.lastTests[nodeId] = result
+	t.mu.Unlock()
+	return result, nil
+}
+
+func (t *MLNodeTester) findNode(nodeId string) (apiconfig.InferenceNodeConfig, bool) {
+	for _, n := range t.configManager.GetNodes() {
+		if n.Id == nodeId {
+			return n, true
+		}
+	}
+	return apiconfig.InferenceNodeConfig{}, false
+}
+
+func (t *MLNodeTester) runOnce(ctx context.Context, cfg apiconfig.InferenceNodeConfig) *TestResult {
+	started := time.Now()
+	result := &TestResult{
+		NodeId:    cfg.Id,
+		Status:    TestSuccess,
+		LoadMs:    map[string]int64{},
+		StartedAt: started,
+	}
+	defer func() {
+		result.DurationMs = time.Since(started).Milliseconds()
+	}()
+
+	pocUrl := fmt.Sprintf("http://%s:%d%s", cfg.Host, cfg.PoCPort, cfg.PoCSegment)
+	inferenceUrl := fmt.Sprintf("http://%s:%d%s", cfg.Host, cfg.InferencePort, cfg.InferenceSegment)
+	client := t.factory.CreateClient(pocUrl, inferenceUrl)
+
+	// Best-effort cleanup at the end so a successful test leaves the
+	// MLnode idle, not stuck in inference mode.
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = client.Stop(stopCtx)
+	}()
+
+	for modelId, modelCfg := range cfg.Models {
+		modelStart := time.Now()
+		if err := client.InferenceUp(ctx, modelId, modelCfg.Args); err != nil {
+			result.Status = TestFailed
+			result.FailingModel = modelId
+			result.Error = err.Error()
+			result.LoadMs[modelId] = time.Since(modelStart).Milliseconds()
+			return result
+		}
+		result.LoadMs[modelId] = time.Since(modelStart).Milliseconds()
+	}
+
+	healthStart := time.Now()
+	ok, err := client.InferenceHealth(ctx)
+	result.HealthMs = time.Since(healthStart).Milliseconds()
+	if err != nil {
+		result.Status = TestFailed
+		result.Error = "health check error: " + err.Error()
+		return result
+	}
+	if !ok {
+		result.Status = TestFailed
+		result.Error = "health check returned not ok"
+		return result
+	}
+
+	return result
+}

--- a/decentralized-api/internal/server/admin/mlnode_tester.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester.go
@@ -166,20 +166,28 @@ func (t *MLNodeTester) runOnce(ctx context.Context, cfg apiconfig.InferenceNodeC
 		_ = client.Stop(stopCtx)
 	}()
 
-	// Iterate models in a stable (sorted) order so FailingModel and the
-	// per-model load sequence are deterministic across runs — Go map
-	// iteration order is randomized.
+	// Iterate models in a stable (sorted) order so FailingModel is
+	// deterministic. Each configured model is fully validated
+	// (load -> health -> inference) and the node is stopped before the next
+	// model, because the MLnode rejects a second /inference/up while one is
+	// already running with HTTP 409 ("VLLM is already running").
 	modelIds := make([]string, 0, len(cfg.Models))
 	for modelId := range cfg.Models {
 		modelIds = append(modelIds, modelId)
 	}
 	sort.Strings(modelIds)
 
-	lastModel := ""
-	for _, modelId := range modelIds {
-		modelCfg := cfg.Models[modelId]
+	for i, modelId := range modelIds {
+		// Stop the previously-loaded model so the next InferenceUp is not
+		// rejected with 409.
+		if i > 0 {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_ = client.Stop(stopCtx)
+			cancel()
+		}
+
 		modelStart := time.Now()
-		if err := client.InferenceUp(ctx, modelId, modelCfg.Args); err != nil {
+		if err := client.InferenceUp(ctx, modelId, cfg.Models[modelId].Args); err != nil {
 			result.Status = TestFailed
 			result.FailingModel = modelId
 			result.Error = err.Error()
@@ -187,32 +195,29 @@ func (t *MLNodeTester) runOnce(ctx context.Context, cfg apiconfig.InferenceNodeC
 			return result
 		}
 		result.LoadMs[modelId] = time.Since(modelStart).Milliseconds()
-		lastModel = modelId
-	}
 
-	healthStart := time.Now()
-	ok, err := client.InferenceHealth(ctx)
-	result.HealthMs = time.Since(healthStart).Milliseconds()
-	if err != nil {
-		result.Status = TestFailed
-		result.Error = "health check error: " + err.Error()
-		return result
-	}
-	if !ok {
-		result.Status = TestFailed
-		result.Error = "health check returned not ok"
-		return result
-	}
-
-	// Response validation: send one real inference request against the
-	// loaded model and validate the response, recording response time.
-	// (Uses the existing host:port URL construction; see #717 follow-up
-	// in proposals/onboarding-clarity-v1/README.md.)
-	if lastModel != "" {
-		respStart := time.Now()
-		if err := client.Inference(ctx, lastModel); err != nil {
+		healthStart := time.Now()
+		ok, err := client.InferenceHealth(ctx)
+		result.HealthMs = time.Since(healthStart).Milliseconds()
+		if err != nil {
 			result.Status = TestFailed
-			result.FailingModel = lastModel
+			result.FailingModel = modelId
+			result.Error = "health check error: " + err.Error()
+			return result
+		}
+		if !ok {
+			result.Status = TestFailed
+			result.FailingModel = modelId
+			result.Error = "health check returned not ok"
+			return result
+		}
+
+		// Response validation: send a real inference request for THIS model
+		// and validate the response, recording response time.
+		respStart := time.Now()
+		if err := client.Inference(ctx, modelId); err != nil {
+			result.Status = TestFailed
+			result.FailingModel = modelId
 			result.Error = "inference request error: " + err.Error()
 			result.RespMs = time.Since(respStart).Milliseconds()
 			return result

--- a/decentralized-api/internal/server/admin/mlnode_tester_test.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester_test.go
@@ -112,6 +112,39 @@ func TestMLNodeTester_ModelLoadFailure(t *testing.T) {
 	}
 }
 
+func TestMLNodeTester_InferenceRequestFailure(t *testing.T) {
+	cm := newTesterConfig(t, []apiconfig.InferenceNodeConfig{{
+		Id:            "node1",
+		Host:          "test-host",
+		PoCPort:       8080,
+		InferencePort: 5000,
+		Models: map[string]apiconfig.ModelConfig{
+			"model-a": {},
+		},
+	}})
+	factory := mlnodeclient.NewMockClientFactory()
+	mockClient := factory.CreateClient("http://test-host:8080", "http://test-host:5000").(*mlnodeclient.MockClient)
+	// Model loads fine and is healthy, but the inference request fails —
+	// the response-validation step must catch it.
+	mockClient.InferenceIsHealthy = true
+	mockClient.InferenceError = errors.New("bad gateway")
+
+	tester := NewMLNodeTester(cm, factory)
+	result, err := tester.Run(context.Background(), "node1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TestFailed {
+		t.Fatalf("got %q, want %q", result.Status, TestFailed)
+	}
+	if result.FailingModel != "model-a" {
+		t.Errorf("FailingModel=%q, want model-a", result.FailingModel)
+	}
+	if mockClient.InferenceCalled == 0 {
+		t.Errorf("expected the response-validation step to call Inference")
+	}
+}
+
 func TestMLNodeTester_RejectsConcurrent(t *testing.T) {
 	cm := newTesterConfig(t, []apiconfig.InferenceNodeConfig{{
 		Id:            "node1",

--- a/decentralized-api/internal/server/admin/mlnode_tester_test.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester_test.go
@@ -112,6 +112,18 @@ func TestMLNodeTester_ModelLoadFailure(t *testing.T) {
 	}
 }
 
+func TestVersionedURL(t *testing.T) {
+	if got := versionedURL("h", 8080, "/seg", ""); got != "http://h:8080/seg" {
+		t.Errorf("unversioned = %q", got)
+	}
+	if got := versionedURL("h", 8080, "/seg", "v1.2.3"); got != "http://h:8080/v1.2.3/seg" {
+		t.Errorf("versioned = %q", got)
+	}
+	if got := versionedURL("h", 5000, "", "v1"); got != "http://h:5000/v1" {
+		t.Errorf("versioned no-segment = %q", got)
+	}
+}
+
 func TestMLNodeTester_InferenceRequestFailure(t *testing.T) {
 	cm := newTesterConfig(t, []apiconfig.InferenceNodeConfig{{
 		Id:            "node1",

--- a/decentralized-api/internal/server/admin/mlnode_tester_test.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester_test.go
@@ -112,6 +112,45 @@ func TestMLNodeTester_ModelLoadFailure(t *testing.T) {
 	}
 }
 
+func TestMLNodeTester_MultipleModels(t *testing.T) {
+	cm := newTesterConfig(t, []apiconfig.InferenceNodeConfig{{
+		Id:            "node1",
+		Host:          "test-host",
+		PoCPort:       8080,
+		InferencePort: 5000,
+		Models: map[string]apiconfig.ModelConfig{
+			"model-a": {},
+			"model-b": {},
+		},
+	}})
+	factory := mlnodeclient.NewMockClientFactory()
+	mockClient := factory.CreateClient("http://test-host:8080", "http://test-host:5000").(*mlnodeclient.MockClient)
+	mockClient.InferenceIsHealthy = true
+
+	tester := NewMLNodeTester(cm, factory)
+	result, err := tester.Run(context.Background(), "node1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TestSuccess {
+		t.Fatalf("status=%q error=%q", result.Status, result.Error)
+	}
+	// Each configured model must be loaded AND inference-probed, with a
+	// Stop between them (the MLnode 409s a second /inference/up otherwise).
+	if len(result.LoadMs) != 2 {
+		t.Errorf("LoadMs=%v, want both models loaded", result.LoadMs)
+	}
+	if mockClient.InferenceUpCalled != 2 {
+		t.Errorf("InferenceUp called %d times, want 2", mockClient.InferenceUpCalled)
+	}
+	if mockClient.InferenceCalled != 2 {
+		t.Errorf("inference probed %d times, want 2 (one per model)", mockClient.InferenceCalled)
+	}
+	if mockClient.StopCalled < 1 {
+		t.Errorf("Stop called %d times, want >=1 (between models)", mockClient.StopCalled)
+	}
+}
+
 func TestVersionedURL(t *testing.T) {
 	if got := versionedURL("h", 8080, "/seg", ""); got != "http://h:8080/seg" {
 		t.Errorf("unversioned = %q", got)

--- a/decentralized-api/internal/server/admin/mlnode_tester_test.go
+++ b/decentralized-api/internal/server/admin/mlnode_tester_test.go
@@ -1,0 +1,135 @@
+package admin
+
+import (
+	"context"
+	"decentralized-api/apiconfig"
+	"decentralized-api/mlnodeclient"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/knadh/koanf/providers/file"
+)
+
+func newTesterConfig(t *testing.T, nodes []apiconfig.InferenceNodeConfig) *apiconfig.ConfigManager {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "tester-config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+	if _, err := tmpFile.Write([]byte("nodes: []")); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	cm := &apiconfig.ConfigManager{
+		KoanProvider:   file.Provider(tmpFile.Name()),
+		WriterProvider: apiconfig.NewFileWriteCloserProvider(tmpFile.Name()),
+	}
+	if err := cm.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(nodes) > 0 {
+		if err := cm.SetNodes(nodes); err != nil {
+			t.Fatalf("SetNodes: %v", err)
+		}
+	}
+	return cm
+}
+
+func TestMLNodeTester_NodeNotFound(t *testing.T) {
+	cm := newTesterConfig(t, nil)
+	factory := mlnodeclient.NewMockClientFactory()
+	tester := NewMLNodeTester(cm, factory)
+
+	_, err := tester.Run(context.Background(), "missing")
+	if !errors.Is(err, ErrNodeNotFound) {
+		t.Fatalf("got %v, want ErrNodeNotFound", err)
+	}
+}
+
+func TestMLNodeTester_SuccessRecordsResult(t *testing.T) {
+	cm := newTesterConfig(t, []apiconfig.InferenceNodeConfig{{
+		Id:            "node1",
+		Host:          "test-host",
+		PoCPort:       8080,
+		InferencePort: 5000,
+		Models: map[string]apiconfig.ModelConfig{
+			"Qwen2.5-7B-Instruct": {Args: []string{"--quantization", "fp8"}},
+		},
+	}})
+	factory := mlnodeclient.NewMockClientFactory()
+
+	// Pre-create the mock client at the same pocUrl the tester will
+	// use, and configure it to report healthy.
+	mockClient := factory.CreateClient("http://test-host:8080", "http://test-host:5000").(*mlnodeclient.MockClient)
+	mockClient.InferenceIsHealthy = true
+
+	tester := NewMLNodeTester(cm, factory)
+	result, err := tester.Run(context.Background(), "node1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TestSuccess {
+		t.Fatalf("got %q, want %q (error=%q)", result.Status, TestSuccess, result.Error)
+	}
+	if _, ok := result.LoadMs["Qwen2.5-7B-Instruct"]; !ok {
+		t.Fatalf("LoadMs missing for model: %+v", result.LoadMs)
+	}
+	if got := tester.LastResult("node1"); got == nil || got.Status != TestSuccess {
+		t.Fatalf("LastResult not recorded: %+v", got)
+	}
+}
+
+func TestMLNodeTester_ModelLoadFailure(t *testing.T) {
+	cm := newTesterConfig(t, []apiconfig.InferenceNodeConfig{{
+		Id:            "node1",
+		Host:          "test-host",
+		PoCPort:       8080,
+		InferencePort: 5000,
+		Models: map[string]apiconfig.ModelConfig{
+			"broken-model": {},
+		},
+	}})
+	factory := mlnodeclient.NewMockClientFactory()
+	mockClient := factory.CreateClient("http://test-host:8080", "http://test-host:5000").(*mlnodeclient.MockClient)
+	mockClient.InferenceUpError = errors.New("OOM")
+
+	tester := NewMLNodeTester(cm, factory)
+	result, err := tester.Run(context.Background(), "node1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != TestFailed {
+		t.Fatalf("got %q, want %q", result.Status, TestFailed)
+	}
+	if result.FailingModel != "broken-model" {
+		t.Errorf("FailingModel=%q, want broken-model", result.FailingModel)
+	}
+	if result.Error == "" {
+		t.Errorf("Error empty, expected OOM message")
+	}
+}
+
+func TestMLNodeTester_RejectsConcurrent(t *testing.T) {
+	cm := newTesterConfig(t, []apiconfig.InferenceNodeConfig{{
+		Id:            "node1",
+		Host:          "test-host",
+		PoCPort:       8080,
+		InferencePort: 5000,
+		Models:        map[string]apiconfig.ModelConfig{"m": {}},
+	}})
+	factory := mlnodeclient.NewMockClientFactory()
+	tester := NewMLNodeTester(cm, factory)
+
+	// Simulate an ongoing test, then verify a concurrent Run rejects.
+	tester.mu.Lock()
+	tester.inFlight["node1"] = true
+	tester.mu.Unlock()
+
+	_, err := tester.Run(context.Background(), "node1")
+	if !errors.Is(err, ErrTestInProgress) {
+		t.Fatalf("got %v, want ErrTestInProgress", err)
+	}
+}

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -132,9 +132,10 @@ func (s *Server) computeOnboarding(n broker.NodeResponse) *OnboardingStatus {
 	// OR when there is a test signal to report — a test in progress or a
 	// failed test matters even before the participant joins the active
 	// set. Otherwise lead with participant-level onboarding guidance.
+	shouldBeOnline := timing != nil && timing.ShouldBeOnline
 	var userMsg, guidance string
 	if active || mlState == MLNodeState_TESTING || mlState == MLNodeState_TEST_FAILED {
-		userMsg = BuildMLNodeMessage(mlState, seconds, failingModel, validated)
+		userMsg = BuildMLNodeMessage(mlState, seconds, failingModel, validated, shouldBeOnline)
 		guidance = BuildParticipantMessage(participantState)
 	} else {
 		userMsg = BuildParticipantMessage(participantState)
@@ -358,7 +359,14 @@ func (s *Server) nodeIsServing(nodeId string) bool {
 }
 
 func (s *Server) maybeAutoTest(nodeId string) {
-	if s.tester == nil || s.phaseTracker == nil {
+	if s.tester == nil {
+		return
+	}
+	// The config may have just changed: drop any prior test result so a
+	// stale pass from the old configuration can't keep showing the node as
+	// validated (a retest is scheduled below when conditions allow).
+	s.tester.Invalidate(nodeId)
+	if s.phaseTracker == nil {
 		return
 	}
 	// Never auto-test a node that is already assigned/serving in the

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -93,12 +93,20 @@ func (s *Server) computeOnboarding(n broker.NodeResponse) *OnboardingStatus {
 	testFailed := n.State.FailureReason != "" &&
 		n.State.CurrentStatus == types.HardwareNodeStatus_FAILED
 	failingModel := ""
+	// validated == the node's most recent test passed. Gates the
+	// reassuring "waiting for PoC" wording per the proposal.
+	validated := false
 	if s.tester != nil {
 		nodeId := n.Node.Id
 		isTesting = s.tester.IsRunning(nodeId)
-		if last := s.tester.LastResult(nodeId); last != nil && last.Status == TestFailed {
-			testFailed = true
-			failingModel = last.FailingModel
+		if last := s.tester.LastResult(nodeId); last != nil {
+			switch last.Status {
+			case TestFailed:
+				testFailed = true
+				failingModel = last.FailingModel
+			case TestSuccess:
+				validated = true
+			}
 		}
 	}
 
@@ -115,7 +123,7 @@ func (s *Server) computeOnboarding(n broker.NodeResponse) *OnboardingStatus {
 	// set. Otherwise lead with participant-level onboarding guidance.
 	var userMsg, guidance string
 	if active || mlState == MLNodeState_TESTING || mlState == MLNodeState_TEST_FAILED {
-		userMsg = BuildMLNodeMessage(mlState, seconds, failingModel)
+		userMsg = BuildMLNodeMessage(mlState, seconds, failingModel, validated)
 		guidance = BuildParticipantMessage(participantState)
 	} else {
 		userMsg = BuildParticipantMessage(participantState)

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -77,23 +77,45 @@ func (s *Server) computeOnboarding(n broker.NodeResponse) *OnboardingStatus {
 
 	participantState := DeriveParticipantState(active)
 
-	var seconds int64
+	// Use a sentinel (not 0) when the schedule is unknown so downstream
+	// helpers never render a bogus "PoC starting soon (in 0s)".
+	seconds := SecondsUntilPoCUnknown
 	if timing != nil {
 		seconds = timing.SecondsUntilNextPoC
 	}
 
+	// Onboarding test signal is owned by the MLNodeTester, not the
+	// broker: IsTesting while a one-shot test is in flight, TEST_FAILED
+	// (with the offending model) from the most recent failed result. A
+	// broker-side FAILED status is kept as a secondary signal so genuine
+	// operational failures still surface even without a recent test.
+	isTesting := false
 	testFailed := n.State.FailureReason != "" &&
 		n.State.CurrentStatus == types.HardwareNodeStatus_FAILED
+	failingModel := ""
+	if s.tester != nil {
+		nodeId := n.Node.Id
+		isTesting = s.tester.IsRunning(nodeId)
+		if last := s.tester.LastResult(nodeId); last != nil && last.Status == TestFailed {
+			testFailed = true
+			failingModel = last.FailingModel
+		}
+	}
+
 	mlState, _ := DeriveMLNodeState(OnboardingStateInputs{
 		ParticipantActive:   active,
-		IsTesting:           false,
+		IsTesting:           isTesting,
 		TestFailed:          testFailed,
 		SecondsUntilNextPoC: seconds,
 	})
 
+	// Lead with the MLnode-level message when the participant is active
+	// OR when there is a test signal to report — a test in progress or a
+	// failed test matters even before the participant joins the active
+	// set. Otherwise lead with participant-level onboarding guidance.
 	var userMsg, guidance string
-	if active {
-		userMsg = BuildMLNodeMessage(mlState, seconds, "")
+	if active || mlState == MLNodeState_TESTING || mlState == MLNodeState_TEST_FAILED {
+		userMsg = BuildMLNodeMessage(mlState, seconds, failingModel)
 		guidance = BuildParticipantMessage(participantState)
 	} else {
 		userMsg = BuildParticipantMessage(participantState)
@@ -235,6 +257,8 @@ func (s *Server) createNewNode(ctx echo.Context) error {
 		}
 		// sync config file with updated node list
 		syncNodesWithConfig(s.nodeBroker, s.configManager)
+		// Config changed — re-test if PoC is far enough away.
+		s.maybeAutoTest(node.Id)
 		return ctx.JSON(http.StatusOK, node)
 	} else {
 		node, err := s.addNode(newNode)
@@ -273,7 +297,43 @@ func (s *Server) addNode(newNode apiconfig.InferenceNodeConfig) (apiconfig.Infer
 		return apiconfig.InferenceNodeConfig{}, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to save node configuration: %v", err))
 	}
 
+	// Auto-test the freshly registered node if PoC is far enough away.
+	s.maybeAutoTest(node.Id)
+
 	return *node, nil
+}
+
+// shouldAutoTest reports whether a node should be auto-tested right now.
+// We only auto-test when the next PoC is more than
+// AutoTestMinSecondsBeforePoC away, so loading models for a validation
+// run never disturbs an imminent PoC. An unknown schedule
+// (SecondsUntilPoCUnknown / negative) returns false.
+func shouldAutoTest(secondsUntilNextPoC int64) bool {
+	return secondsUntilNextPoC > apiconfig.AutoTestMinSecondsBeforePoC
+}
+
+// maybeAutoTest fires a one-shot MLnode validation in the background
+// after a node is registered or its config changes, implementing the
+// proposal's "auto-test a new MLnode when there's >1h until PoC". It is
+// fire-and-forget: the result is recorded on the MLNodeTester and
+// surfaces through GET /nodes via computeOnboarding — nothing is written
+// back to the broker. No-op when the schedule is unknown, PoC is near,
+// or a test for this node is already running.
+func (s *Server) maybeAutoTest(nodeId string) {
+	if s.tester == nil || s.phaseTracker == nil {
+		return
+	}
+	timing := ComputeTiming(s.phaseTracker.GetCurrentEpochState())
+	if timing == nil || !shouldAutoTest(timing.SecondsUntilNextPoC) {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		if _, err := s.tester.Run(ctx, nodeId); err != nil && !errors.Is(err, ErrTestInProgress) {
+			logging.Debug("auto-test not run", types.Nodes, "node_id", nodeId, "error", err)
+		}
+	}()
 }
 
 // postNodeTest handles POST /admin/v1/nodes/:id/test by running a

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -113,10 +113,11 @@ func (s *Server) computeOnboarding(n broker.NodeResponse) *OnboardingStatus {
 			}
 		}
 	}
-	// An active participant's node is already proven (selected and serving
-	// in the current epoch), so treat it as validated for the user-facing
-	// wording rather than showing "not yet validated".
-	if active {
+	// A node that is itself assigned/serving in the current epoch is already
+	// proven, so treat it as validated. Use node-specific evidence only —
+	// participant-wide activity must NOT validate a spare/untested node, or
+	// a broken node could show "validated, safe to be offline".
+	if len(n.State.EpochMLNodes) > 0 {
 		validated = true
 	}
 

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -299,6 +299,8 @@ func (s *Server) addNode(newNode apiconfig.InferenceNodeConfig) (apiconfig.Infer
 
 	// Auto-test the freshly registered node if PoC is far enough away.
 	s.maybeAutoTest(node.Id)
+	// Make "waiting for PoC" the visible log right after registration.
+	s.logOnboardingStatus(false)
 
 	return *node, nil
 }

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -89,9 +89,13 @@ func (s *Server) computeOnboarding(n broker.NodeResponse) *OnboardingStatus {
 	// (with the offending model) from the most recent failed result. A
 	// broker-side FAILED status is kept as a secondary signal so genuine
 	// operational failures still surface even without a recent test.
+	// TEST_FAILED is derived ONLY from the MLnode validation test, never
+	// from the broker's operational FAILED status. An inactive
+	// participant's node is driven to INFERENCE and "fails" with
+	// no-epoch-models — that is normal onboarding, not a test failure, so
+	// surfacing it as TEST_FAILED would contradict the proposal.
 	isTesting := false
-	testFailed := n.State.FailureReason != "" &&
-		n.State.CurrentStatus == types.HardwareNodeStatus_FAILED
+	testFailed := false
 	failingModel := ""
 	// validated == the node's most recent test passed. Gates the
 	// reassuring "waiting for PoC" wording per the proposal.

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -340,8 +340,21 @@ func (s *Server) maybeAutoTest(nodeId string) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
-		if _, err := s.tester.Run(ctx, nodeId); err != nil && !errors.Is(err, ErrTestInProgress) {
-			logging.Debug("auto-test not run", types.Nodes, "node_id", nodeId, "error", err)
+		result, err := s.tester.Run(ctx, nodeId)
+		switch {
+		case errors.Is(err, ErrTestInProgress):
+			// A test is already running for this node; nothing to do.
+		case err != nil:
+			logging.Debug("Auto-test could not run", types.Nodes, "node_id", nodeId, "error", err)
+		case result != nil && result.Status == TestFailed:
+			// Report the failure prominently in the API node logs so the
+			// operator can fix it before PoC (proposal: detailed error
+			// reporting on TEST_FAILED).
+			logging.Error("Auto-test failed for MLnode before PoC", types.Nodes,
+				"node_id", nodeId, "failing_model", result.FailingModel, "error", result.Error)
+		case result != nil:
+			logging.Info("Auto-test passed for MLnode", types.Nodes,
+				"node_id", nodeId, "duration_ms", result.DurationMs)
 		}
 	}()
 }

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -339,15 +339,33 @@ func shouldAutoTest(secondsUntilNextPoC int64) bool {
 // surfaces through GET /nodes via computeOnboarding — nothing is written
 // back to the broker. No-op when the schedule is unknown, PoC is near,
 // or a test for this node is already running.
+// nodeIsServing reports whether the given node is currently assigned to
+// serve in the active epoch (it has epoch MLnode assignments). Such a node
+// must not be disrupted by a validation test. Per-node, not participant-
+// wide, so idle/spare nodes remain testable.
+func (s *Server) nodeIsServing(nodeId string) bool {
+	nodes, err := s.nodeBroker.GetNodes()
+	if err != nil {
+		return false
+	}
+	for _, n := range nodes {
+		if n.Node.Id == nodeId {
+			return len(n.State.EpochMLNodes) > 0
+		}
+	}
+	return false
+}
+
 func (s *Server) maybeAutoTest(nodeId string) {
 	if s.tester == nil || s.phaseTracker == nil {
 		return
 	}
-	// Never auto-test while the participant is active: such a node is
-	// serving inference, and the test would reload + Stop it outside the
-	// broker's knowledge, briefly taking it out of service. Pre-PoC
-	// validation is for onboarding (inactive) nodes only.
-	if s.activityTracker != nil && s.activityTracker.IsActive() {
+	// Never auto-test a node that is already assigned/serving in the
+	// current epoch: the test would reload + Stop it outside the broker's
+	// knowledge, briefly taking it out of service. This is per-node, so an
+	// idle/spare node still gets tested even when the participant has other
+	// active nodes.
+	if s.nodeIsServing(nodeId) {
 		return
 	}
 	timing := ComputeTiming(s.phaseTracker.GetCurrentEpochState())
@@ -384,7 +402,7 @@ func (s *Server) maybeAutoTest(nodeId string) {
 // Status codes:
 //   200 — test completed (body contains TestResult, possibly with status=FAILED)
 //   404 — node id not in configManager
-//   409 — a test is already running for this node
+//   409 — a test is already running, or the node is serving in the epoch
 func (s *Server) postNodeTest(c echo.Context) error {
 	nodeId := c.Param("id")
 	if nodeId == "" {
@@ -392,6 +410,16 @@ func (s *Server) postNodeTest(c echo.Context) error {
 	}
 	if s.tester == nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "tester not initialized"})
+	}
+
+	// Refuse to test a node that is assigned/serving in the current epoch:
+	// the test reloads models and then stops the node outside the broker's
+	// state machine, taking it out of service. Operators must drain it first.
+	if s.nodeIsServing(nodeId) {
+		return c.JSON(http.StatusConflict, map[string]string{
+			"error":   "node is assigned and serving in the current epoch; testing would take it out of service",
+			"node_id": nodeId,
+		})
 	}
 
 	// Per-call timeout: model load + health probe is expected to

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -113,6 +113,12 @@ func (s *Server) computeOnboarding(n broker.NodeResponse) *OnboardingStatus {
 			}
 		}
 	}
+	// An active participant's node is already proven (selected and serving
+	// in the current epoch), so treat it as validated for the user-facing
+	// wording rather than showing "not yet validated".
+	if active {
+		validated = true
+	}
 
 	mlState, _ := DeriveMLNodeState(OnboardingStateInputs{
 		ParticipantActive:   active,
@@ -335,6 +341,13 @@ func shouldAutoTest(secondsUntilNextPoC int64) bool {
 // or a test for this node is already running.
 func (s *Server) maybeAutoTest(nodeId string) {
 	if s.tester == nil || s.phaseTracker == nil {
+		return
+	}
+	// Never auto-test while the participant is active: such a node is
+	// serving inference, and the test would reload + Stop it outside the
+	// broker's knowledge, briefly taking it out of service. Pre-PoC
+	// validation is for onboarding (inactive) nodes only.
+	if s.activityTracker != nil && s.activityTracker.IsActive() {
 		return
 	}
 	timing := ComputeTiming(s.phaseTracker.GetCurrentEpochState())

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -1,12 +1,15 @@
 package admin
 
 import (
+	"context"
 	"decentralized-api/apiconfig"
 	"decentralized-api/broker"
 	"decentralized-api/chainphase"
 	"decentralized-api/logging"
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/productscience/inference/x/inference/types"
@@ -271,6 +274,41 @@ func (s *Server) addNode(newNode apiconfig.InferenceNodeConfig) (apiconfig.Infer
 	}
 
 	return *node, nil
+}
+
+// postNodeTest handles POST /admin/v1/nodes/:id/test by running a
+// synchronous one-shot validation against the configured MLnode.
+// Does not mutate broker state — the response carries the result
+// for the caller to display.
+//
+// Status codes:
+//   200 — test completed (body contains TestResult, possibly with status=FAILED)
+//   404 — node id not in configManager
+//   409 — a test is already running for this node
+func (s *Server) postNodeTest(c echo.Context) error {
+	nodeId := c.Param("id")
+	if nodeId == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "node id is required"})
+	}
+	if s.tester == nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "tester not initialized"})
+	}
+
+	// Per-call timeout: model load + health probe is expected to
+	// complete well under this. Clients can retry on timeout.
+	ctx, cancel := context.WithTimeout(c.Request().Context(), 5*time.Minute)
+	defer cancel()
+
+	result, err := s.tester.Run(ctx, nodeId)
+	switch {
+	case errors.Is(err, ErrNodeNotFound):
+		return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error(), "node_id": nodeId})
+	case errors.Is(err, ErrTestInProgress):
+		return c.JSON(http.StatusConflict, map[string]string{"error": err.Error(), "node_id": nodeId})
+	case err != nil:
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, result)
 }
 
 // enableNode handles POST /admin/v1/nodes/:id/enable

--- a/decentralized-api/internal/server/admin/node_handlers.go
+++ b/decentralized-api/internal/server/admin/node_handlers.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"decentralized-api/apiconfig"
 	"decentralized-api/broker"
+	"decentralized-api/chainphase"
 	"decentralized-api/logging"
 	"fmt"
 	"net/http"
@@ -11,13 +12,98 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
+// NodeWithOnboarding is the admin GET /nodes response item. It wraps
+// the broker's view of a node with onboarding UX fields that are
+// derived at the handler layer (not stored on broker state).
+type NodeWithOnboarding struct {
+	broker.NodeResponse
+	Onboarding *OnboardingStatus `json:"onboarding,omitempty"`
+}
+
+// OnboardingStatus aggregates everything the admin UI needs to show
+// human-friendly setup state without inspecting raw broker internals.
+type OnboardingStatus struct {
+	ParticipantState string                `json:"participant_state"`
+	MLNodeState      MLNodeOnboardingState `json:"mlnode_state"`
+	Timing           *TimingInfo           `json:"timing,omitempty"`
+	UserMessage      string                `json:"user_message,omitempty"`
+	Guidance         string                `json:"guidance,omitempty"`
+}
+
 func (s *Server) getNodes(ctx echo.Context) error {
 	nodes, err := s.nodeBroker.GetNodes()
 	if err != nil {
 		logging.Error("Error getting nodes", types.Nodes, "error", err)
 		return err
 	}
-	return ctx.JSON(http.StatusOK, nodes)
+
+	enriched := make([]NodeWithOnboarding, len(nodes))
+	for i, n := range nodes {
+		enriched[i] = NodeWithOnboarding{
+			NodeResponse: n,
+			Onboarding:   s.computeOnboarding(n),
+		}
+	}
+	return ctx.JSON(http.StatusOK, enriched)
+}
+
+// computeOnboarding derives onboarding UX fields for one node from
+// the broker's NodeResponse + cached participant activity + the
+// chain phase tracker. It performs no chain RPC calls and does not
+// mutate broker state. Returns nil if neither timing nor activity
+// is known yet (e.g. chain not yet synced and tracker not started).
+func (s *Server) computeOnboarding(n broker.NodeResponse) *OnboardingStatus {
+	var epochState *chainphase.EpochState
+	if s.phaseTracker != nil {
+		epochState = s.phaseTracker.GetCurrentEpochState()
+	}
+	timing := ComputeTiming(epochState)
+	if timing == nil && s.activityTracker == nil {
+		return nil
+	}
+
+	active := false
+	if s.activityTracker != nil {
+		active = s.activityTracker.IsActive()
+	}
+	// EpochMLNodes already-populated also implies activity for this
+	// participant in the current epoch; treat as a secondary signal.
+	if !active && len(n.State.EpochMLNodes) > 0 {
+		active = true
+	}
+
+	participantState := DeriveParticipantState(active)
+
+	var seconds int64
+	if timing != nil {
+		seconds = timing.SecondsUntilNextPoC
+	}
+
+	testFailed := n.State.FailureReason != "" &&
+		n.State.CurrentStatus == types.HardwareNodeStatus_FAILED
+	mlState, _ := DeriveMLNodeState(OnboardingStateInputs{
+		ParticipantActive:   active,
+		IsTesting:           false,
+		TestFailed:          testFailed,
+		SecondsUntilNextPoC: seconds,
+	})
+
+	var userMsg, guidance string
+	if active {
+		userMsg = BuildMLNodeMessage(mlState, seconds, "")
+		guidance = BuildParticipantMessage(participantState)
+	} else {
+		userMsg = BuildParticipantMessage(participantState)
+		guidance = BuildInactiveGuidance(seconds)
+	}
+
+	return &OnboardingStatus{
+		ParticipantState: string(participantState),
+		MLNodeState:      mlState,
+		Timing:           timing,
+		UserMessage:      userMsg,
+		Guidance:         guidance,
+	}
 }
 
 func (s *Server) deleteNode(ctx echo.Context) error {

--- a/decentralized-api/internal/server/admin/node_handlers_test.go
+++ b/decentralized-api/internal/server/admin/node_handlers_test.go
@@ -176,6 +176,23 @@ func TestMaybeAutoTest(t *testing.T) {
 	})
 }
 
+// TestLogOnboardingStatus covers the onboarding status logger's branching:
+// no-op (returns prevActive) when no node is configured, and reports
+// inactive (false) while a configured node's participant isn't active.
+func TestLogOnboardingStatus(t *testing.T) {
+	s, cm, _ := setupTestServer(t)
+
+	// No nodes configured yet -> no-op, prevActive passes through.
+	assert.True(t, s.logOnboardingStatus(true))
+	assert.False(t, s.logOnboardingStatus(false))
+
+	// With a configured node and an inactive participant (activityTracker
+	// nil in the test server), it reports inactive and logs "waiting".
+	registerTestNode(t, s, cm, "node-1")
+	assert.False(t, s.logOnboardingStatus(false))
+	assert.False(t, s.logOnboardingStatus(true))
+}
+
 // TestGetNodesOnboarding verifies the GET /nodes response shape (the
 // existing node fields plus the new optional onboarding envelope) and
 // that a failed manual test surfaces as TEST_FAILED — the gap #1 wiring

--- a/decentralized-api/internal/server/admin/node_handlers_test.go
+++ b/decentralized-api/internal/server/admin/node_handlers_test.go
@@ -1,0 +1,210 @@
+package admin
+
+import (
+	"context"
+	"decentralized-api/apiconfig"
+	"decentralized-api/chainphase"
+	"decentralized-api/mlnodeclient"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// registerTestNode adds a node to the config manager and registers it
+// with the broker so the admin handlers can see it. Mirrors the
+// known-good node shape used by TestPostVersionStatus.
+func registerTestNode(t *testing.T, s *Server, cm *apiconfig.ConfigManager, id string) apiconfig.InferenceNodeConfig {
+	t.Helper()
+	nodeConfig := apiconfig.InferenceNodeConfig{
+		Id:               id,
+		Host:             "localhost",
+		InferencePort:    8080,
+		InferenceSegment: "/api/v1",
+		PoCPort:          8081,
+		PoCSegment:       "/api/v1",
+		MaxConcurrent:    3,
+		Models: map[string]apiconfig.ModelConfig{
+			"test-model": {Args: []string{}},
+		},
+	}
+	nodes := append(cm.GetNodes(), nodeConfig)
+	assert.NoError(t, cm.SetNodes(nodes))
+
+	respChan := s.nodeBroker.LoadNodeToBroker(&nodeConfig)
+	select {
+	case response := <-respChan:
+		if response.Error != nil || response.Node == nil {
+			t.Fatalf("failed to register node %s", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out registering node %s", id)
+	}
+	return nodeConfig
+}
+
+// pocURL the MLNodeTester will compute for registerTestNode's node.
+const testNodePoCURL = "http://localhost:8081/api/v1"
+
+// TestPostNodeTest exercises the manual MLnode test trigger end-to-end
+// through the HTTP layer (the automated stand-in for "hit POST
+// /admin/v1/nodes/:id/test on a live node"), using a mocked MLnode.
+func TestPostNodeTest(t *testing.T) {
+	s, cm, factory := setupTestServer(t)
+	registerTestNode(t, s, cm, "node-1")
+
+	t.Run("success returns 200 with SUCCESS", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/admin/v1/nodes/node-1/test", nil)
+		rec := httptest.NewRecorder()
+		s.e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var result TestResult
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+		assert.Equal(t, TestSuccess, result.Status)
+		assert.Equal(t, "node-1", result.NodeId)
+	})
+
+	t.Run("model load failure returns 200 with FAILED + failing model", func(t *testing.T) {
+		// Stub the same mock client the tester will use (factory keys by
+		// pocURL) so InferenceUp fails like a misconfigured MLnode.
+		mc := factory.CreateClient(testNodePoCURL, "").(*mlnodeclient.MockClient)
+		mc.InferenceUpError = errors.New("CUDA out of memory")
+		defer func() { mc.InferenceUpError = nil }()
+
+		req := httptest.NewRequest(http.MethodPost, "/admin/v1/nodes/node-1/test", nil)
+		rec := httptest.NewRecorder()
+		s.e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var result TestResult
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+		assert.Equal(t, TestFailed, result.Status)
+		assert.Equal(t, "test-model", result.FailingModel)
+	})
+
+	t.Run("unknown node returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/admin/v1/nodes/does-not-exist/test", nil)
+		rec := httptest.NewRecorder()
+		s.e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}
+
+// nodeView is a lightweight projection of the GET /nodes response used
+// to assert the JSON shape the way an external consumer (the admin UI)
+// reads it — by field name, not by binding to the strongly-typed
+// broker structs (whose proto enums don't round-trip through
+// encoding/json).
+type nodeView struct {
+	Node struct {
+		Id string `json:"id"`
+	} `json:"node"`
+	State      json.RawMessage `json:"state"`
+	Onboarding *struct {
+		ParticipantState string `json:"participant_state"`
+		MLNodeState      string `json:"mlnode_state"`
+		UserMessage      string `json:"user_message"`
+	} `json:"onboarding"`
+}
+
+func getNodeViews(t *testing.T, s *Server) []nodeView {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/admin/v1/nodes", nil)
+	rec := httptest.NewRecorder()
+	s.e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var nodes []nodeView
+	if err := json.Unmarshal(rec.Body.Bytes(), &nodes); err != nil {
+		t.Fatalf("unmarshal err: %v\nbody: %s", err, rec.Body.String())
+	}
+	return nodes
+}
+
+// TestShouldAutoTest covers the auto-test gate: only fire when the next
+// PoC is strictly more than the configured lead time away.
+func TestShouldAutoTest(t *testing.T) {
+	assert.False(t, shouldAutoTest(apiconfig.AutoTestMinSecondsBeforePoC), "exactly the threshold is not > threshold")
+	assert.True(t, shouldAutoTest(apiconfig.AutoTestMinSecondsBeforePoC+1))
+	assert.False(t, shouldAutoTest(0))
+	assert.False(t, shouldAutoTest(SecondsUntilPoCUnknown), "unknown schedule must not auto-test")
+}
+
+// TestMaybeAutoTest verifies the auto-trigger fires a background test
+// only when PoC is far away, recording the result on the tester (which
+// then surfaces via GET /nodes) without any broker write.
+func TestMaybeAutoTest(t *testing.T) {
+	s, cm, _ := setupTestServer(t)
+	registerTestNode(t, s, cm, "node-1")
+
+	t.Run("does not fire when PoC is near", func(t *testing.T) {
+		// setupTestServer's phase tracker puts PoC ~594s away (< 1h).
+		s.maybeAutoTest("node-1")
+		time.Sleep(100 * time.Millisecond)
+		assert.Nil(t, s.tester.LastResult("node-1"))
+	})
+
+	t.Run("fires when PoC is far away", func(t *testing.T) {
+		// Push the next PoC far out so the gate opens.
+		s.phaseTracker.Update(
+			chainphase.BlockInfo{Height: 1, Hash: "h"},
+			&types.Epoch{Index: 100, PocStartBlockHeight: 10000},
+			&types.EpochParams{},
+			true,
+			nil,
+		)
+		s.maybeAutoTest("node-1")
+
+		var got *TestResult
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			if got = s.tester.LastResult("node-1"); got != nil {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		if assert.NotNil(t, got, "auto-test should have recorded a result") {
+			assert.Equal(t, TestSuccess, got.Status)
+		}
+	})
+}
+
+// TestGetNodesOnboarding verifies the GET /nodes response shape (the
+// existing node fields plus the new optional onboarding envelope) and
+// that a failed manual test surfaces as TEST_FAILED — the gap #1 wiring
+// from the tester back into the onboarding status.
+func TestGetNodesOnboarding(t *testing.T) {
+	s, cm, factory := setupTestServer(t)
+	registerTestNode(t, s, cm, "node-1")
+
+	t.Run("response preserves node shape and adds onboarding", func(t *testing.T) {
+		nodes := getNodeViews(t, s)
+		assert.Len(t, nodes, 1)
+		assert.Equal(t, "node-1", nodes[0].Node.Id) // existing field still there
+		assert.NotEmpty(t, nodes[0].State)          // existing state block still there
+		assert.NotNil(t, nodes[0].Onboarding)       // new optional envelope present
+	})
+
+	t.Run("failed manual test surfaces as TEST_FAILED", func(t *testing.T) {
+		// Make the MLnode fail, then run a manual test so the tester
+		// records a failed result for node-1.
+		mc := factory.CreateClient(testNodePoCURL, "").(*mlnodeclient.MockClient)
+		mc.InferenceUpError = errors.New("model not found")
+		_, err := s.tester.Run(context.Background(), "node-1")
+		assert.NoError(t, err)
+
+		nodes := getNodeViews(t, s)
+		assert.Len(t, nodes, 1)
+		if assert.NotNil(t, nodes[0].Onboarding) {
+			assert.Equal(t, string(MLNodeState_TEST_FAILED), nodes[0].Onboarding.MLNodeState)
+			assert.Contains(t, nodes[0].Onboarding.UserMessage, "test-model")
+		}
+	})
+}

--- a/decentralized-api/internal/server/admin/node_handlers_test.go
+++ b/decentralized-api/internal/server/admin/node_handlers_test.go
@@ -215,6 +215,25 @@ func TestComputeOnboarding_BrokerFailedIsNotTestFailed(t *testing.T) {
 	}
 }
 
+// TestComputeOnboarding_ActiveIsValidated checks that an active
+// participant's node is treated as validated — it must not be shown as
+// "not yet validated", since it is already serving in the epoch.
+func TestComputeOnboarding_ActiveIsValidated(t *testing.T) {
+	s, _, _ := setupTestServer(t)
+	n := broker.NodeResponse{
+		Node: broker.Node{Id: "active-node"},
+		State: broker.NodeState{
+			// A populated epoch-MLnodes map marks the participant active.
+			EpochMLNodes: map[string]types.MLNodeInfo{"m": {}},
+		},
+	}
+	ob := s.computeOnboarding(n)
+	if assert.NotNil(t, ob) {
+		assert.Equal(t, string(ParticipantState_ACTIVE_PARTICIPATING), ob.ParticipantState)
+		assert.NotContains(t, ob.UserMessage, "not yet validated")
+	}
+}
+
 // TestGetNodesOnboarding verifies the GET /nodes response shape (the
 // existing node fields plus the new optional onboarding envelope) and
 // that a failed manual test surfaces as TEST_FAILED — the gap #1 wiring

--- a/decentralized-api/internal/server/admin/node_handlers_test.go
+++ b/decentralized-api/internal/server/admin/node_handlers_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"decentralized-api/apiconfig"
+	"decentralized-api/broker"
 	"decentralized-api/chainphase"
 	"decentralized-api/mlnodeclient"
 	"encoding/json"
@@ -191,6 +192,27 @@ func TestLogOnboardingStatus(t *testing.T) {
 	registerTestNode(t, s, cm, "node-1")
 	assert.False(t, s.logOnboardingStatus(false))
 	assert.False(t, s.logOnboardingStatus(true))
+}
+
+// TestComputeOnboarding_BrokerFailedIsNotTestFailed guards the fix that
+// TEST_FAILED comes only from the MLnode test, not the broker's
+// operational FAILED status. An inactive node the broker marked FAILED
+// ("no epoch models") with no recorded test result must NOT be shown as
+// TEST_FAILED — that is normal onboarding.
+func TestComputeOnboarding_BrokerFailedIsNotTestFailed(t *testing.T) {
+	s, _, _ := setupTestServer(t)
+	n := broker.NodeResponse{
+		Node: broker.Node{Id: "inactive-node"},
+		State: broker.NodeState{
+			FailureReason: "No epoch models available for this node",
+			CurrentStatus: types.HardwareNodeStatus_FAILED,
+		},
+	}
+	ob := s.computeOnboarding(n)
+	if assert.NotNil(t, ob) {
+		assert.NotEqual(t, MLNodeState_TEST_FAILED, ob.MLNodeState,
+			"inactive node with broker FAILED must not surface as TEST_FAILED")
+	}
 }
 
 // TestGetNodesOnboarding verifies the GET /nodes response shape (the

--- a/decentralized-api/internal/server/admin/onboarding_logger.go
+++ b/decentralized-api/internal/server/admin/onboarding_logger.go
@@ -59,6 +59,26 @@ func (s *Server) logOnboardingStatus(prevActive bool) bool {
 	if timing := ComputeTiming(s.phaseTracker.GetCurrentEpochState()); timing != nil {
 		seconds = timing.SecondsUntilNextPoC
 	}
-	logging.Info(BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, seconds, ""), types.Nodes)
+	logging.Info(BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, seconds, "", s.allNodesValidated()), types.Nodes)
 	return false
+}
+
+// allNodesValidated reports whether every configured MLnode has a passing
+// most-recent test. Used to gate the reassuring "waiting for PoC" wording:
+// the calm "validated, safe to be offline" line is only logged once all
+// nodes have been verified.
+func (s *Server) allNodesValidated() bool {
+	if s.tester == nil {
+		return false
+	}
+	nodes := s.configManager.GetNodes()
+	if len(nodes) == 0 {
+		return false
+	}
+	for _, n := range nodes {
+		if r := s.tester.LastResult(n.Id); r == nil || r.Status != TestSuccess {
+			return false
+		}
+	}
+	return true
 }

--- a/decentralized-api/internal/server/admin/onboarding_logger.go
+++ b/decentralized-api/internal/server/admin/onboarding_logger.go
@@ -56,10 +56,12 @@ func (s *Server) logOnboardingStatus(prevActive bool) bool {
 		return true
 	}
 	seconds := SecondsUntilPoCUnknown
+	shouldBeOnline := false
 	if timing := ComputeTiming(s.phaseTracker.GetCurrentEpochState()); timing != nil {
 		seconds = timing.SecondsUntilNextPoC
+		shouldBeOnline = timing.ShouldBeOnline
 	}
-	logging.Info(BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, seconds, "", s.allNodesValidated()), types.Nodes)
+	logging.Info(BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, seconds, "", s.allNodesValidated(), shouldBeOnline), types.Nodes)
 	return false
 }
 

--- a/decentralized-api/internal/server/admin/onboarding_logger.go
+++ b/decentralized-api/internal/server/admin/onboarding_logger.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"context"
+	"decentralized-api/logging"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// StartOnboardingStatusLogger periodically emits a clear, operator-facing
+// "waiting for PoC" status line while the participant is onboarding
+// (configured but not yet in the active set). This makes the most
+// visible log during the wait the onboarding status — addressing the
+// "clearer logging when a node is launched and waiting for PoC" goal —
+// instead of leaving operators to guess. It logs once immediately, then
+// on each tick, and goes quiet once the participant is active (logging
+// the inactive->active transition exactly once). Reads cached state
+// only; performs no chain RPCs and does not touch the broker.
+func (s *Server) StartOnboardingStatusLogger(ctx context.Context, interval time.Duration) {
+	if s.phaseTracker == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		active := s.logOnboardingStatus(false)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				active = s.logOnboardingStatus(active)
+			}
+		}
+	}()
+}
+
+// logOnboardingStatus logs the current onboarding/waiting status once and
+// returns whether the participant is currently active. prevActive lets it
+// announce the inactive->active transition exactly once and then stay
+// quiet while active. No-op (returns prevActive) when no MLnode is
+// configured, since there is nothing to wait for.
+func (s *Server) logOnboardingStatus(prevActive bool) bool {
+	if len(s.configManager.GetNodes()) == 0 {
+		return prevActive
+	}
+	active := s.activityTracker != nil && s.activityTracker.IsActive()
+	if active {
+		if !prevActive {
+			logging.Info("Participant is now in the active set and participating", types.Participants)
+		}
+		return true
+	}
+	seconds := SecondsUntilPoCUnknown
+	if timing := ComputeTiming(s.phaseTracker.GetCurrentEpochState()); timing != nil {
+		seconds = timing.SecondsUntilNextPoC
+	}
+	logging.Info(BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, seconds, ""), types.Nodes)
+	return false
+}

--- a/decentralized-api/internal/server/admin/onboarding_state_manager.go
+++ b/decentralized-api/internal/server/admin/onboarding_state_manager.go
@@ -25,6 +25,12 @@ const (
 	ParticipantState_ACTIVE_PARTICIPATING ParticipantState = "ACTIVE_PARTICIPATING"
 )
 
+// SecondsUntilPoCUnknown is the sentinel SecondsUntilNextPoC value used
+// when the chain phase tracker has not synced yet. It suppresses
+// timing-based alerting so onboarding never renders a bogus
+// "PoC starting soon (in 0s)" derived from an unknown schedule.
+const SecondsUntilPoCUnknown int64 = -1
+
 // OnboardingStateInputs aggregates everything required to derive
 // onboarding state for one MLnode. All fields are inputs computed
 // elsewhere — none of these are mutated by the helpers in this file.
@@ -54,6 +60,10 @@ func DeriveMLNodeState(in OnboardingStateInputs) (state MLNodeOnboardingState, a
 		return MLNodeState_TEST_FAILED, true
 	case in.IsTesting:
 		return MLNodeState_TESTING, true
+	case in.SecondsUntilNextPoC < 0:
+		// Timing unknown (tracker not synced yet): waiting, but we have
+		// no basis to alert the operator to come online.
+		return MLNodeState_WAITING_FOR_POC, false
 	case in.SecondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds:
 		return MLNodeState_WAITING_FOR_POC, true
 	default:

--- a/decentralized-api/internal/server/admin/onboarding_state_manager.go
+++ b/decentralized-api/internal/server/admin/onboarding_state_manager.go
@@ -1,0 +1,62 @@
+package admin
+
+import (
+	"decentralized-api/apiconfig"
+)
+
+// MLNodeOnboardingState describes the user-visible onboarding state of
+// an individual MLnode as derived at the API layer. The broker does
+// not track or mutate this state — it is computed on each admin read
+// from broker outputs and chain state.
+type MLNodeOnboardingState string
+
+const (
+	MLNodeState_WAITING_FOR_POC MLNodeOnboardingState = "WAITING_FOR_POC"
+	MLNodeState_TESTING         MLNodeOnboardingState = "TESTING"
+	MLNodeState_TEST_FAILED     MLNodeOnboardingState = "TEST_FAILED"
+)
+
+// ParticipantState describes whether the participant the API is
+// running on behalf of has joined the active set in the current epoch.
+type ParticipantState string
+
+const (
+	ParticipantState_INACTIVE_WAITING     ParticipantState = "INACTIVE_WAITING"
+	ParticipantState_ACTIVE_PARTICIPATING ParticipantState = "ACTIVE_PARTICIPATING"
+)
+
+// OnboardingStateInputs aggregates everything required to derive
+// onboarding state for one MLnode. All fields are inputs computed
+// elsewhere — none of these are mutated by the helpers in this file.
+type OnboardingStateInputs struct {
+	ParticipantActive   bool
+	IsTesting           bool
+	TestFailed          bool
+	SecondsUntilNextPoC int64
+}
+
+// DeriveParticipantState reports whether the participant is in the
+// active set right now.
+func DeriveParticipantState(active bool) ParticipantState {
+	if active {
+		return ParticipantState_ACTIVE_PARTICIPATING
+	}
+	return ParticipantState_INACTIVE_WAITING
+}
+
+// DeriveMLNodeState computes the MLnode onboarding state for a node
+// given the inputs. Returns the state and whether the user should be
+// alerted to bring the MLnode online ("alert" implies the PoC window
+// is approaching or active).
+func DeriveMLNodeState(in OnboardingStateInputs) (state MLNodeOnboardingState, alert bool) {
+	switch {
+	case in.TestFailed:
+		return MLNodeState_TEST_FAILED, true
+	case in.IsTesting:
+		return MLNodeState_TESTING, true
+	case in.SecondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds:
+		return MLNodeState_WAITING_FOR_POC, true
+	default:
+		return MLNodeState_WAITING_FOR_POC, false
+	}
+}

--- a/decentralized-api/internal/server/admin/onboarding_state_manager_test.go
+++ b/decentralized-api/internal/server/admin/onboarding_state_manager_test.go
@@ -46,6 +46,12 @@ func TestDeriveMLNodeState(t *testing.T) {
 			wantState: MLNodeState_WAITING_FOR_POC,
 			wantAlert: true,
 		},
+		{
+			name:      "timing unknown -> waiting, no alert",
+			in:        OnboardingStateInputs{SecondsUntilNextPoC: SecondsUntilPoCUnknown},
+			wantState: MLNodeState_WAITING_FOR_POC,
+			wantAlert: false,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -69,6 +75,10 @@ func TestBuildMLNodeMessage(t *testing.T) {
 	far := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "")
 	if !strings.Contains(far, "safe to be offline") {
 		t.Errorf("non-alert message missing offline guidance: %q", far)
+	}
+	unknown := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, SecondsUntilPoCUnknown, "")
+	if !strings.Contains(unknown, "syncing") || strings.Contains(unknown, "0s") {
+		t.Errorf("unknown-timing message should not invent a countdown: %q", unknown)
 	}
 }
 

--- a/decentralized-api/internal/server/admin/onboarding_state_manager_test.go
+++ b/decentralized-api/internal/server/admin/onboarding_state_manager_test.go
@@ -1,0 +1,93 @@
+package admin
+
+import (
+	"decentralized-api/apiconfig"
+	"strings"
+	"testing"
+)
+
+func TestDeriveParticipantState(t *testing.T) {
+	if got := DeriveParticipantState(true); got != ParticipantState_ACTIVE_PARTICIPATING {
+		t.Errorf("active=true: got %q want %q", got, ParticipantState_ACTIVE_PARTICIPATING)
+	}
+	if got := DeriveParticipantState(false); got != ParticipantState_INACTIVE_WAITING {
+		t.Errorf("active=false: got %q want %q", got, ParticipantState_INACTIVE_WAITING)
+	}
+}
+
+func TestDeriveMLNodeState(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        OnboardingStateInputs
+		wantState MLNodeOnboardingState
+		wantAlert bool
+	}{
+		{
+			name:      "test failed takes precedence",
+			in:        OnboardingStateInputs{TestFailed: true, IsTesting: true, SecondsUntilNextPoC: 99999},
+			wantState: MLNodeState_TEST_FAILED,
+			wantAlert: true,
+		},
+		{
+			name:      "testing in progress",
+			in:        OnboardingStateInputs{IsTesting: true, SecondsUntilNextPoC: 99999},
+			wantState: MLNodeState_TESTING,
+			wantAlert: true,
+		},
+		{
+			name:      "waiting, plenty of time -> no alert",
+			in:        OnboardingStateInputs{SecondsUntilNextPoC: apiconfig.OnlineAlertLeadSeconds + 1},
+			wantState: MLNodeState_WAITING_FOR_POC,
+			wantAlert: false,
+		},
+		{
+			name:      "waiting, within alert lead -> alert",
+			in:        OnboardingStateInputs{SecondsUntilNextPoC: apiconfig.OnlineAlertLeadSeconds},
+			wantState: MLNodeState_WAITING_FOR_POC,
+			wantAlert: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotState, gotAlert := DeriveMLNodeState(tc.in)
+			if gotState != tc.wantState || gotAlert != tc.wantAlert {
+				t.Errorf("got (%q, %v) want (%q, %v)", gotState, gotAlert, tc.wantState, tc.wantAlert)
+			}
+		})
+	}
+}
+
+func TestBuildMLNodeMessage(t *testing.T) {
+	got := BuildMLNodeMessage(MLNodeState_TEST_FAILED, 0, "Qwen2.5-7B")
+	if !strings.Contains(got, "Qwen2.5-7B") {
+		t.Errorf("failing model not surfaced: %q", got)
+	}
+	near := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds-1, "")
+	if !strings.Contains(near, "must be online") {
+		t.Errorf("alert message missing online directive: %q", near)
+	}
+	far := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "")
+	if !strings.Contains(far, "safe to be offline") {
+		t.Errorf("non-alert message missing offline guidance: %q", far)
+	}
+}
+
+func TestFormatShortDuration(t *testing.T) {
+	tests := []struct {
+		seconds int64
+		want    string
+	}{
+		{0, "0s"},
+		{-1, "0s"},
+		{45, "45s"},
+		{120, "2m"},
+		{125, "2m 5s"},
+		{3600, "1h"},
+		{3660, "1h 1m"},
+	}
+	for _, tc := range tests {
+		if got := formatShortDuration(tc.seconds); got != tc.want {
+			t.Errorf("formatShortDuration(%d) = %q, want %q", tc.seconds, got, tc.want)
+		}
+	}
+}

--- a/decentralized-api/internal/server/admin/onboarding_state_manager_test.go
+++ b/decentralized-api/internal/server/admin/onboarding_state_manager_test.go
@@ -64,21 +64,35 @@ func TestDeriveMLNodeState(t *testing.T) {
 }
 
 func TestBuildMLNodeMessage(t *testing.T) {
-	got := BuildMLNodeMessage(MLNodeState_TEST_FAILED, 0, "Qwen2.5-7B")
+	got := BuildMLNodeMessage(MLNodeState_TEST_FAILED, 0, "Qwen2.5-7B", false)
 	if !strings.Contains(got, "Qwen2.5-7B") {
 		t.Errorf("failing model not surfaced: %q", got)
 	}
-	near := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds-1, "")
+	// Validated node within the alert window: be online now.
+	near := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds-1, "", true)
 	if !strings.Contains(near, "must be online") {
 		t.Errorf("alert message missing online directive: %q", near)
 	}
-	far := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "")
+	// Validated node, far out: reassuring "safe to be offline".
+	far := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "", true)
 	if !strings.Contains(far, "safe to be offline") {
-		t.Errorf("non-alert message missing offline guidance: %q", far)
+		t.Errorf("non-alert validated message missing offline guidance: %q", far)
 	}
-	unknown := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, SecondsUntilPoCUnknown, "")
+	// Unknown schedule (validated): no invented countdown.
+	unknown := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, SecondsUntilPoCUnknown, "", true)
 	if !strings.Contains(unknown, "syncing") || strings.Contains(unknown, "0s") {
 		t.Errorf("unknown-timing message should not invent a countdown: %q", unknown)
+	}
+	// Not validated, far out: must NOT show the reassuring "safe to be
+	// offline" — should flag it isn't validated yet.
+	unval := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "", false)
+	if strings.Contains(unval, "safe to be offline") || !strings.Contains(unval, "not yet validated") {
+		t.Errorf("unvalidated waiting message should withhold the ready reassurance: %q", unval)
+	}
+	// Not validated, near PoC: still tells operator to come online.
+	unvalNear := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds-1, "", false)
+	if !strings.Contains(unvalNear, "online") || !strings.Contains(unvalNear, "not yet validated") {
+		t.Errorf("unvalidated near-PoC message should flag unvalidated + online: %q", unvalNear)
 	}
 }
 

--- a/decentralized-api/internal/server/admin/onboarding_state_manager_test.go
+++ b/decentralized-api/internal/server/admin/onboarding_state_manager_test.go
@@ -64,33 +64,39 @@ func TestDeriveMLNodeState(t *testing.T) {
 }
 
 func TestBuildMLNodeMessage(t *testing.T) {
-	got := BuildMLNodeMessage(MLNodeState_TEST_FAILED, 0, "Qwen2.5-7B", false)
+	got := BuildMLNodeMessage(MLNodeState_TEST_FAILED, 0, "Qwen2.5-7B", false, false)
 	if !strings.Contains(got, "Qwen2.5-7B") {
 		t.Errorf("failing model not surfaced: %q", got)
 	}
-	// Validated node within the alert window: be online now.
-	near := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds-1, "", true)
+	// Validated node within the alert window (shouldBeOnline): be online now.
+	near := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds-1, "", true, true)
 	if !strings.Contains(near, "must be online") {
 		t.Errorf("alert message missing online directive: %q", near)
 	}
-	// Validated node, far out: reassuring "safe to be offline".
-	far := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "", true)
+	// Validated node, far out, not in the online window: safe to be offline.
+	far := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "", true, false)
 	if !strings.Contains(far, "safe to be offline") {
 		t.Errorf("non-alert validated message missing offline guidance: %q", far)
 	}
-	// Unknown schedule (validated): no invented countdown.
-	unknown := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, SecondsUntilPoCUnknown, "", true)
+	// Active PoC: shouldBeOnline true even though the countdown is large —
+	// must NOT advertise offline safety.
+	activePoC := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "", true, true)
+	if strings.Contains(activePoC, "safe to be offline") || !strings.Contains(activePoC, "must be online") {
+		t.Errorf("active-PoC message must tell operator to be online: %q", activePoC)
+	}
+	// Unknown schedule (validated, not online): no invented countdown.
+	unknown := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, SecondsUntilPoCUnknown, "", true, false)
 	if !strings.Contains(unknown, "syncing") || strings.Contains(unknown, "0s") {
 		t.Errorf("unknown-timing message should not invent a countdown: %q", unknown)
 	}
 	// Not validated, far out: must NOT show the reassuring "safe to be
 	// offline" — should flag it isn't validated yet.
-	unval := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "", false)
+	unval := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds+3600, "", false, false)
 	if strings.Contains(unval, "safe to be offline") || !strings.Contains(unval, "not yet validated") {
 		t.Errorf("unvalidated waiting message should withhold the ready reassurance: %q", unval)
 	}
 	// Not validated, near PoC: still tells operator to come online.
-	unvalNear := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds-1, "", false)
+	unvalNear := BuildMLNodeMessage(MLNodeState_WAITING_FOR_POC, apiconfig.OnlineAlertLeadSeconds-1, "", false, true)
 	if !strings.Contains(unvalNear, "online") || !strings.Contains(unvalNear, "not yet validated") {
 		t.Errorf("unvalidated near-PoC message should flag unvalidated + online: %q", unvalNear)
 	}

--- a/decentralized-api/internal/server/admin/server.go
+++ b/decentralized-api/internal/server/admin/server.go
@@ -3,10 +3,12 @@ package admin
 import (
 	"decentralized-api/apiconfig"
 	"decentralized-api/broker"
+	"decentralized-api/chainphase"
 	cosmos_client "decentralized-api/cosmosclient"
 	"decentralized-api/internal/server/middleware"
 	pserver "decentralized-api/internal/server/public"
 	"decentralized-api/internal/validation"
+	"decentralized-api/participant"
 	"decentralized-api/payloadstorage"
 
 	"cosmossdk.io/x/feegrant"
@@ -26,14 +28,16 @@ import (
 )
 
 type Server struct {
-	e              *echo.Echo
-	nodeBroker     *broker.Broker
-	configManager  *apiconfig.ConfigManager
-	recorder       cosmos_client.CosmosMessageClient
-	validator      *validation.InferenceValidator
-	cdc            *codec.ProtoCodec
-	blockQueue     *pserver.BridgeQueue
-	payloadStorage payloadstorage.PayloadStorage
+	e               *echo.Echo
+	nodeBroker      *broker.Broker
+	configManager   *apiconfig.ConfigManager
+	recorder        cosmos_client.CosmosMessageClient
+	validator       *validation.InferenceValidator
+	cdc             *codec.ProtoCodec
+	blockQueue      *pserver.BridgeQueue
+	payloadStorage  payloadstorage.PayloadStorage
+	phaseTracker    *chainphase.ChainPhaseTracker
+	activityTracker *participant.ActivityTracker
 }
 
 func NewServer(
@@ -42,20 +46,24 @@ func NewServer(
 	configManager *apiconfig.ConfigManager,
 	validator *validation.InferenceValidator,
 	blockQueue *pserver.BridgeQueue,
-	payloadStorage payloadstorage.PayloadStorage) *Server {
+	payloadStorage payloadstorage.PayloadStorage,
+	phaseTracker *chainphase.ChainPhaseTracker,
+	activityTracker *participant.ActivityTracker) *Server {
 	cdc := getCodec()
 
 	e := echo.New()
 	e.HTTPErrorHandler = middleware.TransparentErrorHandler
 	s := &Server{
-		e:              e,
-		nodeBroker:     nodeBroker,
-		configManager:  configManager,
-		recorder:       recorder,
-		validator:      validator,
-		cdc:            cdc,
-		blockQueue:     blockQueue,
-		payloadStorage: payloadStorage,
+		e:               e,
+		nodeBroker:      nodeBroker,
+		configManager:   configManager,
+		recorder:        recorder,
+		validator:       validator,
+		cdc:             cdc,
+		blockQueue:      blockQueue,
+		payloadStorage:  payloadStorage,
+		phaseTracker:    phaseTracker,
+		activityTracker: activityTracker,
 	}
 
 	e.Use(middleware.LoggingMiddleware)

--- a/decentralized-api/internal/server/admin/server.go
+++ b/decentralized-api/internal/server/admin/server.go
@@ -8,6 +8,7 @@ import (
 	"decentralized-api/internal/server/middleware"
 	pserver "decentralized-api/internal/server/public"
 	"decentralized-api/internal/validation"
+	"decentralized-api/mlnodeclient"
 	"decentralized-api/participant"
 	"decentralized-api/payloadstorage"
 
@@ -38,6 +39,7 @@ type Server struct {
 	payloadStorage  payloadstorage.PayloadStorage
 	phaseTracker    *chainphase.ChainPhaseTracker
 	activityTracker *participant.ActivityTracker
+	tester          *MLNodeTester
 }
 
 func NewServer(
@@ -48,7 +50,8 @@ func NewServer(
 	blockQueue *pserver.BridgeQueue,
 	payloadStorage payloadstorage.PayloadStorage,
 	phaseTracker *chainphase.ChainPhaseTracker,
-	activityTracker *participant.ActivityTracker) *Server {
+	activityTracker *participant.ActivityTracker,
+	mlnodeFactory mlnodeclient.ClientFactory) *Server {
 	cdc := getCodec()
 
 	e := echo.New()
@@ -64,6 +67,7 @@ func NewServer(
 		payloadStorage:  payloadStorage,
 		phaseTracker:    phaseTracker,
 		activityTracker: activityTracker,
+		tester:          NewMLNodeTester(configManager, mlnodeFactory),
 	}
 
 	e.Use(middleware.LoggingMiddleware)
@@ -75,6 +79,7 @@ func NewServer(
 	g.PUT("nodes/:id", s.createNewNode)
 	g.GET("nodes/upgrade-status", s.getUpgradeStatus)
 	g.POST("nodes/version-status", s.postVersionStatus)
+	g.POST("nodes/:id/test", s.postNodeTest)
 	g.GET("nodes", s.getNodes)
 	g.DELETE("nodes/:id", s.deleteNode)
 	g.POST("nodes/:id/enable", s.enableNode)

--- a/decentralized-api/internal/server/admin/server_test.go
+++ b/decentralized-api/internal/server/admin/server_test.go
@@ -135,8 +135,9 @@ func setupTestServer(t *testing.T) (*Server, *apiconfig.ConfigManager, *mlnodecl
 	// 4. Broker
 	nodeBroker := broker.NewBroker(bridge, phaseTracker, mockParticipant, "", mockClientFactory, configManager)
 
-	// 5. Server
-	s := NewServer(mockCosmos, nodeBroker, configManager, nil, nil, nil)
+	// 5. Server — phaseTracker is the real instance the broker uses;
+	// activityTracker left nil so tests don't depend on chain queries.
+	s := NewServer(mockCosmos, nodeBroker, configManager, nil, nil, nil, phaseTracker, nil)
 
 	return s, configManager, mockClientFactory
 }

--- a/decentralized-api/internal/server/admin/server_test.go
+++ b/decentralized-api/internal/server/admin/server_test.go
@@ -137,7 +137,8 @@ func setupTestServer(t *testing.T) (*Server, *apiconfig.ConfigManager, *mlnodecl
 
 	// 5. Server — phaseTracker is the real instance the broker uses;
 	// activityTracker left nil so tests don't depend on chain queries.
-	s := NewServer(mockCosmos, nodeBroker, configManager, nil, nil, nil, phaseTracker, nil)
+	// Reuse the broker's mock factory so tester tests can stub clients.
+	s := NewServer(mockCosmos, nodeBroker, configManager, nil, nil, nil, phaseTracker, nil, mockClientFactory)
 
 	return s, configManager, mockClientFactory
 }

--- a/decentralized-api/internal/server/admin/status_reporter.go
+++ b/decentralized-api/internal/server/admin/status_reporter.go
@@ -20,6 +20,11 @@ func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, 
 		}
 		return "MLnode test failed: model '" + failingModel + "' could not be loaded"
 	case MLNodeState_WAITING_FOR_POC:
+		if secondsUntilNextPoC < 0 {
+			// Schedule not yet known (chain phase tracker not synced):
+			// avoid an invented countdown like "in 0s".
+			return "Waiting for next PoC cycle (schedule syncing)"
+		}
 		if secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds {
 			return "PoC starting soon (in " + formatShortDuration(secondsUntilNextPoC) +
 				") - MLnode must be online now"
@@ -46,7 +51,8 @@ func BuildParticipantMessage(state ParticipantState) string {
 // do automatically.
 func BuildInactiveGuidance(secondsUntilNextPoC int64) string {
 	if secondsUntilNextPoC > apiconfig.AutoTestMinSecondsBeforePoC {
-		return "MLnode will be tested automatically when there is more than 1 hour until next PoC"
+		return "MLnode will be tested automatically when there is more than " +
+			formatShortDuration(apiconfig.AutoTestMinSecondsBeforePoC) + " until next PoC"
 	}
 	return ""
 }

--- a/decentralized-api/internal/server/admin/status_reporter.go
+++ b/decentralized-api/internal/server/admin/status_reporter.go
@@ -1,0 +1,52 @@
+package admin
+
+import (
+	"decentralized-api/apiconfig"
+)
+
+// BuildMLNodeMessage produces the human-facing one-liner shown to the
+// operator for the MLnode's current onboarding state.
+//
+// failingModel is included in the TEST_FAILED message when non-empty;
+// the WAITING_FOR_POC message branches on whether the next PoC is
+// inside the online-alert window.
+func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, failingModel string) string {
+	switch state {
+	case MLNodeState_TESTING:
+		return "Testing MLnode configuration - model loading in progress"
+	case MLNodeState_TEST_FAILED:
+		if failingModel == "" {
+			return "MLnode test failed"
+		}
+		return "MLnode test failed: model '" + failingModel + "' could not be loaded"
+	case MLNodeState_WAITING_FOR_POC:
+		if secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds {
+			return "PoC starting soon (in " + formatShortDuration(secondsUntilNextPoC) +
+				") - MLnode must be online now"
+		}
+		return "Waiting for next PoC cycle (starts in " + formatShortDuration(secondsUntilNextPoC) +
+			") - safe to be offline until " + formatShortDuration(apiconfig.OnlineAlertLeadSeconds) + " before PoC"
+	}
+	return ""
+}
+
+// BuildParticipantMessage produces the participant-level guidance line.
+func BuildParticipantMessage(state ParticipantState) string {
+	switch state {
+	case ParticipantState_ACTIVE_PARTICIPATING:
+		return "Participant is in active set and participating"
+	case ParticipantState_INACTIVE_WAITING:
+		return "Participant not yet active - model assignment will occur after joining active set"
+	}
+	return ""
+}
+
+// BuildInactiveGuidance is shown alongside BuildParticipantMessage when
+// the participant is not yet active, explaining what the system will
+// do automatically.
+func BuildInactiveGuidance(secondsUntilNextPoC int64) string {
+	if secondsUntilNextPoC > apiconfig.AutoTestMinSecondsBeforePoC {
+		return "MLnode will be tested automatically when there is more than 1 hour until next PoC"
+	}
+	return ""
+}

--- a/decentralized-api/internal/server/admin/status_reporter.go
+++ b/decentralized-api/internal/server/admin/status_reporter.go
@@ -7,10 +7,12 @@ import (
 // BuildMLNodeMessage produces the human-facing one-liner shown to the
 // operator for the MLnode's current onboarding state.
 //
-// failingModel is included in the TEST_FAILED message when non-empty;
-// the WAITING_FOR_POC message branches on whether the next PoC is
-// inside the online-alert window.
-func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, failingModel string) string {
+// failingModel is included in the TEST_FAILED message when non-empty.
+// validated gates the reassuring "waiting for PoC" wording: per the
+// proposal, the calm "validated, safe to be offline" message is only
+// shown once a test has passed; until then we say the MLnode is not yet
+// validated (it still tells the operator to be online when PoC is near).
+func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, failingModel string, validated bool) string {
 	switch state {
 	case MLNodeState_TESTING:
 		return "Testing MLnode configuration - model loading in progress"
@@ -20,17 +22,26 @@ func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, 
 		}
 		return "MLnode test failed: model '" + failingModel + "' could not be loaded"
 	case MLNodeState_WAITING_FOR_POC:
-		if secondsUntilNextPoC < 0 {
+		switch {
+		case secondsUntilNextPoC < 0 && validated:
 			// Schedule not yet known (chain phase tracker not synced):
 			// avoid an invented countdown like "in 0s".
 			return "Waiting for next PoC cycle (schedule syncing)"
-		}
-		if secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds {
+		case secondsUntilNextPoC < 0:
+			return "MLnode not yet validated - it will be tested before the next PoC"
+		case secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds && validated:
 			return "PoC starting soon (in " + formatShortDuration(secondsUntilNextPoC) +
 				") - MLnode must be online now"
+		case secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds:
+			return "PoC starting soon (in " + formatShortDuration(secondsUntilNextPoC) +
+				") - MLnode not yet validated, bring it online now"
+		case validated:
+			return "Waiting for next PoC cycle (starts in " + formatShortDuration(secondsUntilNextPoC) +
+				") - validated, safe to be offline until " + formatShortDuration(apiconfig.OnlineAlertLeadSeconds) + " before PoC"
+		default:
+			return "Waiting for next PoC cycle (starts in " + formatShortDuration(secondsUntilNextPoC) +
+				") - MLnode not yet validated; it will be auto-tested, or run a manual test"
 		}
-		return "Waiting for next PoC cycle (starts in " + formatShortDuration(secondsUntilNextPoC) +
-			") - safe to be offline until " + formatShortDuration(apiconfig.OnlineAlertLeadSeconds) + " before PoC"
 	}
 	return ""
 }

--- a/decentralized-api/internal/server/admin/status_reporter.go
+++ b/decentralized-api/internal/server/admin/status_reporter.go
@@ -8,11 +8,12 @@ import (
 // operator for the MLnode's current onboarding state.
 //
 // failingModel is included in the TEST_FAILED message when non-empty.
-// validated gates the reassuring "waiting for PoC" wording: per the
-// proposal, the calm "validated, safe to be offline" message is only
-// shown once a test has passed; until then we say the MLnode is not yet
-// validated (it still tells the operator to be online when PoC is near).
-func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, failingModel string, validated bool) string {
+// validated gates the reassuring "safe to be offline" wording (only shown
+// once a test has passed). shouldBeOnline reflects the current PoC window
+// (it honors the phase, so during an active PoC it is true even though the
+// countdown points to the next epoch) — when true we never tell the
+// operator it is safe to be offline.
+func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, failingModel string, validated, shouldBeOnline bool) string {
 	switch state {
 	case MLNodeState_TESTING:
 		return "Testing MLnode configuration - model loading in progress"
@@ -22,6 +23,19 @@ func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, 
 		}
 		return "MLnode test failed: model '" + failingModel + "' could not be loaded"
 	case MLNodeState_WAITING_FOR_POC:
+		if shouldBeOnline {
+			// In or approaching the PoC window — must be online now,
+			// regardless of the countdown (which points to the next epoch's
+			// PoC once the current one has started).
+			when := "PoC window active"
+			if secondsUntilNextPoC >= 0 && secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds {
+				when = "PoC starting soon (in " + formatShortDuration(secondsUntilNextPoC) + ")"
+			}
+			if validated {
+				return when + " - MLnode must be online now"
+			}
+			return when + " - MLnode not yet validated, bring it online now"
+		}
 		switch {
 		case secondsUntilNextPoC < 0 && validated:
 			// Schedule not yet known (chain phase tracker not synced):
@@ -29,12 +43,6 @@ func BuildMLNodeMessage(state MLNodeOnboardingState, secondsUntilNextPoC int64, 
 			return "Waiting for next PoC cycle (schedule syncing)"
 		case secondsUntilNextPoC < 0:
 			return "MLnode not yet validated - it will be tested before the next PoC"
-		case secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds && validated:
-			return "PoC starting soon (in " + formatShortDuration(secondsUntilNextPoC) +
-				") - MLnode must be online now"
-		case secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds:
-			return "PoC starting soon (in " + formatShortDuration(secondsUntilNextPoC) +
-				") - MLnode not yet validated, bring it online now"
 		case validated:
 			return "Waiting for next PoC cycle (starts in " + formatShortDuration(secondsUntilNextPoC) +
 				") - validated, safe to be offline until " + formatShortDuration(apiconfig.OnlineAlertLeadSeconds) + " before PoC"

--- a/decentralized-api/internal/server/admin/timing_calculator.go
+++ b/decentralized-api/internal/server/admin/timing_calculator.go
@@ -1,0 +1,74 @@
+package admin
+
+import (
+	"decentralized-api/apiconfig"
+	"decentralized-api/chainphase"
+	"strconv"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// TimingInfo is the JSON shape returned to admins for one node,
+// describing where the chain sits in the PoC cycle.
+type TimingInfo struct {
+	CurrentPhase        string `json:"current_phase"`
+	BlocksUntilNextPoC  int64  `json:"blocks_until_next_poc"`
+	SecondsUntilNextPoC int64  `json:"seconds_until_next_poc"`
+	ShouldBeOnline      bool   `json:"should_be_online"`
+}
+
+// ComputeTiming derives TimingInfo from the current epoch state.
+// Returns nil when the chain phase tracker has not yet synced (the
+// admin handler then omits the timing block entirely rather than
+// reporting zeros).
+func ComputeTiming(es *chainphase.EpochState) *TimingInfo {
+	if es.IsNilOrNotSynced() {
+		return nil
+	}
+	currentHeight := es.CurrentBlock.Height
+	nextPoC := es.LatestEpoch.NextPoCStart()
+	blocks := nextPoC - currentHeight
+	if blocks < 0 {
+		blocks = 0
+	}
+	seconds := int64(float64(blocks) * apiconfig.DefaultBlockTimeSeconds)
+	return &TimingInfo{
+		CurrentPhase:        string(es.CurrentPhase),
+		BlocksUntilNextPoC:  blocks,
+		SecondsUntilNextPoC: seconds,
+		ShouldBeOnline:      shouldBeOnline(es.CurrentPhase, seconds),
+	}
+}
+
+func shouldBeOnline(phase types.EpochPhase, secondsUntilNextPoC int64) bool {
+	switch phase {
+	case types.PoCGeneratePhase, types.PoCGenerateWindDownPhase,
+		types.PoCValidatePhase, types.PoCValidateWindDownPhase:
+		return true
+	}
+	return secondsUntilNextPoC <= apiconfig.OnlineAlertLeadSeconds
+}
+
+// formatShortDuration renders a non-negative seconds count as a compact
+// human string such as "2h 15m", "8m", or "45s". Zero or negative
+// values render as "0s".
+func formatShortDuration(seconds int64) string {
+	if seconds <= 0 {
+		return "0s"
+	}
+	h := seconds / 3600
+	m := (seconds % 3600) / 60
+	s := seconds % 60
+	switch {
+	case h > 0 && m > 0:
+		return strconv.FormatInt(h, 10) + "h " + strconv.FormatInt(m, 10) + "m"
+	case h > 0:
+		return strconv.FormatInt(h, 10) + "h"
+	case m > 0 && s > 0:
+		return strconv.FormatInt(m, 10) + "m " + strconv.FormatInt(s, 10) + "s"
+	case m > 0:
+		return strconv.FormatInt(m, 10) + "m"
+	default:
+		return strconv.FormatInt(s, 10) + "s"
+	}
+}

--- a/decentralized-api/internal/server/admin/timing_calculator.go
+++ b/decentralized-api/internal/server/admin/timing_calculator.go
@@ -26,7 +26,14 @@ func ComputeTiming(es *chainphase.EpochState) *TimingInfo {
 		return nil
 	}
 	currentHeight := es.CurrentBlock.Height
-	nextPoC := es.LatestEpoch.NextPoCStart()
+	// The imminent PoC is this epoch's PoC start while we are still before
+	// it (pre-PoC inference phase); only once we're past it does the next
+	// PoC become the following epoch's. Using NextPoCStart() unconditionally
+	// would overcount by an epoch and miss the real online-alert window.
+	nextPoC := es.LatestEpoch.StartOfPoC()
+	if currentHeight >= nextPoC {
+		nextPoC = es.LatestEpoch.NextPoCStart()
+	}
 	blocks := nextPoC - currentHeight
 	if blocks < 0 {
 		blocks = 0

--- a/decentralized-api/internal/server/admin/timing_calculator_test.go
+++ b/decentralized-api/internal/server/admin/timing_calculator_test.go
@@ -1,0 +1,34 @@
+package admin
+
+import (
+	"decentralized-api/chainphase"
+	"testing"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// TestComputeTiming_UsesImminentPoCStart guards the fix that the countdown
+// targets this epoch's PoC while we are still before it (pre-PoC inference
+// phase), and only the following epoch's PoC once we are past it.
+func TestComputeTiming_UsesImminentPoCStart(t *testing.T) {
+	mk := func(height int64) *chainphase.EpochState {
+		ec := types.NewEpochContext(
+			types.Epoch{Index: 1, PocStartBlockHeight: 1000},
+			types.EpochParams{EpochLength: 100},
+		)
+		return &chainphase.EpochState{
+			LatestEpoch:  ec,
+			CurrentBlock: chainphase.BlockInfo{Height: height},
+			CurrentPhase: types.InferencePhase,
+			IsSynced:     true,
+		}
+	}
+	// Before this epoch's PoC (1000): count to 1000, not the next epoch.
+	if got := ComputeTiming(mk(900)); got == nil || got.BlocksUntilNextPoC != 100 {
+		t.Fatalf("pre-PoC: BlocksUntilNextPoC = %v, want 100", got)
+	}
+	// Past this epoch's PoC: count to the next epoch's PoC (1100).
+	if got := ComputeTiming(mk(1050)); got == nil || got.BlocksUntilNextPoC != 50 {
+		t.Fatalf("post-PoC: BlocksUntilNextPoC = %v, want 50", got)
+	}
+}

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -317,6 +317,9 @@ func main() {
 	logging.Info("start admin server on addr", types.Server, "addr", addr)
 	adminServer := adminserver.NewServer(recorder, nodeBroker, configManager, validator, blockQueue, payloadStore, chainPhaseTracker, activityTracker, &mlnodeclient.HttpClientFactory{})
 	adminServer.Start(addr)
+	// Surface a periodic "waiting for PoC" status while onboarding so the
+	// most visible log during the wait is the onboarding state.
+	adminServer.StartOnboardingStatusLogger(ctx, 5*time.Minute)
 
 	nmGrpcPort := configManager.GetApiConfig().NodeManagerGrpcPort
 	if nmGrpcPort == 0 {

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -17,6 +17,7 @@ import (
 	"decentralized-api/payloadstorage"
 	"decentralized-api/poc"
 	"decentralized-api/poc/artifacts"
+	"decentralized-api/selfcheck"
 	"decentralized-api/statsstorage"
 	"net"
 
@@ -63,6 +64,10 @@ func main() {
 	}
 	if len(os.Args) >= 2 && os.Args[1] == "pre-upgrade" {
 		os.Exit(1)
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "selfcheck" {
+		runSelfcheck()
+		return
 	}
 
 	configManager, err := apiconfig.LoadDefaultConfigManager()
@@ -310,7 +315,7 @@ func main() {
 
 	addr = fmt.Sprintf(":%v", configManager.GetApiConfig().AdminServerPort)
 	logging.Info("start admin server on addr", types.Server, "addr", addr)
-	adminServer := adminserver.NewServer(recorder, nodeBroker, configManager, validator, blockQueue, payloadStore, chainPhaseTracker, activityTracker)
+	adminServer := adminserver.NewServer(recorder, nodeBroker, configManager, validator, blockQueue, payloadStore, chainPhaseTracker, activityTracker, &mlnodeclient.HttpClientFactory{})
 	adminServer.Start(addr)
 
 	nmGrpcPort := configManager.GetApiConfig().NodeManagerGrpcPort
@@ -350,6 +355,26 @@ func main() {
 	}
 
 	os.Exit(1) // Exit with an error for cosmovisor to restart the process
+}
+
+// runSelfcheck drives a one-shot PoC-wiring assertion suite against a
+// fresh broker backed by a mocked chain. Prints the report to stderr
+// and exits 0 on PASS, 1 on FAIL. Intended for operator confidence
+// before joining the network: "does my participant binary react to
+// epoch events as expected?"
+func runSelfcheck() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	report, err := selfcheck.Run(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "selfcheck: setup error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprint(os.Stderr, report.String())
+	if !report.Pass {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }
 
 func returnStatus(configManager *apiconfig.ConfigManager) {

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -111,6 +111,11 @@ func main() {
 		logging.Error("Failed to get participant info", types.Participants, "error", err)
 		return
 	}
+	// Background tracker for "is this participant in the current
+	// active set?" — admin handlers read its cached answer so they
+	// don't trigger N+1 chain RPCs per request. Started below once
+	// the cancellable context is available.
+	activityTracker := participant.NewActivityTracker(recorder, participantInfo.GetAddress(), 30*time.Second)
 	chainBridge := broker.NewBrokerChainBridgeImpl(recorder, configManager.GetChainNodeConfig().Url)
 	nodeBroker := broker.NewBroker(chainBridge, chainPhaseTracker, participantInfo, configManager.GetApiConfig().PoCCallbackUrl, &mlnodeclient.HttpClientFactory{}, configManager)
 
@@ -157,6 +162,10 @@ func main() {
 
 	// Start periodic config auto-flush of dynamic data to DB
 	configManager.StartAutoFlush(ctx, 60*time.Second)
+
+	// Start the participant activity tracker so admin handlers can
+	// answer "is this participant active?" without a per-request RPC.
+	activityTracker.Start(ctx)
 
 	// Optional off-chain inference stats storage (PostgreSQL-backed when PGHOST is configured).
 	statsStore, err := statsstorage.NewStatsStorage(ctx)
@@ -301,7 +310,7 @@ func main() {
 
 	addr = fmt.Sprintf(":%v", configManager.GetApiConfig().AdminServerPort)
 	logging.Info("start admin server on addr", types.Server, "addr", addr)
-	adminServer := adminserver.NewServer(recorder, nodeBroker, configManager, validator, blockQueue, payloadStore)
+	adminServer := adminserver.NewServer(recorder, nodeBroker, configManager, validator, blockQueue, payloadStore, chainPhaseTracker, activityTracker)
 	adminServer.Start(addr)
 
 	nmGrpcPort := configManager.GetApiConfig().NodeManagerGrpcPort

--- a/decentralized-api/mlnodeclient/client.go
+++ b/decentralized-api/mlnodeclient/client.go
@@ -6,6 +6,7 @@ import (
 	"decentralized-api/utils"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -14,10 +15,11 @@ import (
 )
 
 const (
-	stopPath        = "/api/v1/stop"
-	nodeStatePath   = "/api/v1/state"
-	powStatusPath   = "/api/v1/pow/status"
-	inferenceUpPath = "/api/v1/inference/up"
+	stopPath            = "/api/v1/stop"
+	nodeStatePath       = "/api/v1/state"
+	powStatusPath       = "/api/v1/pow/status"
+	inferenceUpPath     = "/api/v1/inference/up"
+	chatCompletionsPath = "/v1/chat/completions"
 )
 
 type Client struct {
@@ -147,6 +149,65 @@ func (api *Client) InferenceHealth(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatCompletionRequest struct {
+	Model     string        `json:"model"`
+	Messages  []chatMessage `json:"messages"`
+	MaxTokens int           `json:"max_tokens"`
+}
+
+type chatCompletionResponse struct {
+	Choices []struct {
+		Message chatMessage `json:"message"`
+	} `json:"choices"`
+}
+
+// Inference sends a minimal OpenAI-compatible chat-completion request to
+// the MLnode's inference endpoint (the same /v1/chat/completions path the
+// public handler proxies to) and validates that a usable response comes
+// back. Returns an error if the request fails or the response carries no
+// choices. Used by the pre-PoC validation test as the "send a test
+// inference request and validate the response" step.
+func (api *Client) Inference(ctx context.Context, model string) error {
+	requestURL, err := url.JoinPath(api.inferenceUrl, chatCompletionsPath)
+	if err != nil {
+		return err
+	}
+
+	req := chatCompletionRequest{
+		Model:     model,
+		Messages:  []chatMessage{{Role: "user", Content: "ping"}},
+		MaxTokens: 1,
+	}
+
+	resp, err := utils.SendPostJsonRequest(ctx, &api.client, requestURL, req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("inference request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed chatCompletionResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("invalid inference response: %w", err)
+	}
+	if len(parsed.Choices) == 0 {
+		return fmt.Errorf("inference response contained no choices")
+	}
+	return nil
 }
 
 type inferenceUpDto struct {

--- a/decentralized-api/mlnodeclient/interface.go
+++ b/decentralized-api/mlnodeclient/interface.go
@@ -17,6 +17,7 @@ type MLNodeClient interface {
 	// Inference operations
 	InferenceHealth(ctx context.Context) (bool, error)
 	InferenceUp(ctx context.Context, model string, args []string) error
+	Inference(ctx context.Context, model string) error
 	GetLoadedModels(ctx context.Context) ([]string, error)
 
 	// GPU operations

--- a/decentralized-api/mlnodeclient/mock.go
+++ b/decentralized-api/mlnodeclient/mock.go
@@ -31,6 +31,7 @@ type MockClient struct {
 	NodeStateError        error
 	InferenceHealthError  error
 	InferenceUpError      error
+	InferenceError        error
 	GetGPUDevicesError    error
 	GetGPUDriverError     error
 	CheckModelStatusError error
@@ -44,6 +45,7 @@ type MockClient struct {
 	NodeStateCalled        int
 	InferenceHealthCalled  int
 	InferenceUpCalled      int
+	InferenceCalled        int
 	GetGPUDevicesCalled    int
 	GetGPUDriverCalled     int
 	CheckModelStatusCalled int
@@ -141,6 +143,7 @@ func (m *MockClient) Reset() {
 	m.NodeStateError = nil
 	m.InferenceHealthError = nil
 	m.InferenceUpError = nil
+	m.InferenceError = nil
 	m.GetGPUDevicesError = nil
 	m.GetGPUDriverError = nil
 	m.CheckModelStatusError = nil
@@ -153,6 +156,7 @@ func (m *MockClient) Reset() {
 	m.NodeStateCalled = 0
 	m.InferenceHealthCalled = 0
 	m.InferenceUpCalled = 0
+	m.InferenceCalled = 0
 	m.GetGPUDevicesCalled = 0
 	m.GetGPUDriverCalled = 0
 	m.CheckModelStatusCalled = 0
@@ -220,6 +224,17 @@ func (m *MockClient) InferenceUp(ctx context.Context, model string, args []strin
 	}
 	m.CurrentState = MlNodeState_INFERENCE
 	m.InferenceIsHealthy = true
+	return nil
+}
+
+func (m *MockClient) Inference(ctx context.Context, model string) error {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	m.InferenceCalled++
+	m.LastInferenceModel = model
+	if m.InferenceError != nil {
+		return m.InferenceError
+	}
 	return nil
 }
 

--- a/decentralized-api/participant/activity_tracker.go
+++ b/decentralized-api/participant/activity_tracker.go
@@ -100,7 +100,13 @@ func (t *ActivityTracker) query(ctx context.Context) (bool, error) {
 			EpochIndex: epochIndex,
 			ModelId:    modelId,
 		})
-		if err != nil || subResp == nil {
+		if err != nil {
+			// Transient RPC failure: surface the error so refresh keeps the
+			// previous value instead of flipping an active participant to
+			// inactive on a missing subgroup.
+			return false, err
+		}
+		if subResp == nil {
 			continue
 		}
 		for _, w := range subResp.EpochGroupData.ValidationWeights {

--- a/decentralized-api/participant/activity_tracker.go
+++ b/decentralized-api/participant/activity_tracker.go
@@ -1,0 +1,111 @@
+package participant
+
+import (
+	"context"
+	"decentralized-api/cosmosclient"
+	"decentralized-api/logging"
+	"sync/atomic"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// ActivityTracker caches whether the current participant is part of
+// the active epoch group. The result is refreshed periodically by a
+// background goroutine so that admin HTTP handlers can call
+// IsActive() without making any chain RPC calls per request.
+//
+// "Active" means the participant has at least one MLnode assigned to
+// some model subgroup in the current epoch group data.
+type ActivityTracker struct {
+	queryClient queryClient
+	address     string
+	interval    time.Duration
+
+	active atomic.Bool
+}
+
+// queryClient is a narrow interface over cosmosclient.CosmosMessageClient
+// covering only what the tracker needs. Defined to make unit testing
+// straightforward.
+type queryClient interface {
+	NewInferenceQueryClient() types.QueryClient
+}
+
+// NewActivityTracker constructs a tracker but does not start it. Call
+// Start to launch the background refresher.
+func NewActivityTracker(client cosmosclient.CosmosMessageClient, address string, interval time.Duration) *ActivityTracker {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	return &ActivityTracker{
+		queryClient: client,
+		address:     address,
+		interval:    interval,
+	}
+}
+
+// IsActive returns the most recently observed activity status. False
+// until the first successful refresh completes.
+func (t *ActivityTracker) IsActive() bool {
+	return t.active.Load()
+}
+
+// Start launches a goroutine that refreshes IsActive() every interval
+// until ctx is cancelled. Performs one immediate refresh before
+// returning so IsActive() is meaningful for the first admin request.
+func (t *ActivityTracker) Start(ctx context.Context) {
+	t.refresh(ctx)
+	go func() {
+		ticker := time.NewTicker(t.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				t.refresh(ctx)
+			}
+		}
+	}()
+}
+
+func (t *ActivityTracker) refresh(ctx context.Context) {
+	active, err := t.query(ctx)
+	if err != nil {
+		// Chain may not be ready at startup; keep the previous value
+		// rather than flipping to false on transient errors.
+		logging.Debug("ActivityTracker refresh failed", types.Participants, "error", err)
+		return
+	}
+	if t.active.Swap(active) != active {
+		logging.Info("Participant active status changed", types.Participants, "active", active)
+	}
+}
+
+func (t *ActivityTracker) query(ctx context.Context) (bool, error) {
+	q := t.queryClient.NewInferenceQueryClient()
+	parentResp, err := q.CurrentEpochGroupData(ctx, &types.QueryCurrentEpochGroupDataRequest{})
+	if err != nil {
+		return false, err
+	}
+	if parentResp == nil {
+		return false, nil
+	}
+	epochIndex := parentResp.EpochGroupData.EpochIndex
+	for _, modelId := range parentResp.EpochGroupData.SubGroupModels {
+		subResp, err := q.EpochGroupData(ctx, &types.QueryGetEpochGroupDataRequest{
+			EpochIndex: epochIndex,
+			ModelId:    modelId,
+		})
+		if err != nil || subResp == nil {
+			continue
+		}
+		for _, w := range subResp.EpochGroupData.ValidationWeights {
+			if w.MemberAddress == t.address && len(w.MlNodes) > 0 {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/decentralized-api/participant/activity_tracker.go
+++ b/decentralized-api/participant/activity_tracker.go
@@ -51,12 +51,14 @@ func (t *ActivityTracker) IsActive() bool {
 	return t.active.Load()
 }
 
-// Start launches a goroutine that refreshes IsActive() every interval
-// until ctx is cancelled. Performs one immediate refresh before
-// returning so IsActive() is meaningful for the first admin request.
+// Start launches a goroutine that refreshes IsActive() immediately and
+// then every interval until ctx is cancelled. Start returns without
+// blocking: the initial refresh runs inside the goroutine so a slow or
+// unresponsive chain RPC can't hold up API startup (IsActive() stays
+// false until the first successful refresh).
 func (t *ActivityTracker) Start(ctx context.Context) {
-	t.refresh(ctx)
 	go func() {
+		t.refresh(ctx)
 		ticker := time.NewTicker(t.interval)
 		defer ticker.Stop()
 		for {

--- a/decentralized-api/selfcheck/config.go
+++ b/decentralized-api/selfcheck/config.go
@@ -1,0 +1,35 @@
+package selfcheck
+
+import (
+	"decentralized-api/apiconfig"
+	"os"
+
+	"github.com/knadh/koanf/providers/file"
+)
+
+// newInMemoryConfig builds a ConfigManager backed by a tmpfile, used
+// only during selfcheck. Returns the manager plus a cleanup func that
+// removes the tmpfile.
+func newInMemoryConfig() (*apiconfig.ConfigManager, func(), error) {
+	tmp, err := os.CreateTemp("", "selfcheck-config-*.yaml")
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := tmp.Write([]byte("nodes: []")); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return nil, nil, err
+	}
+	tmp.Close()
+
+	cm := &apiconfig.ConfigManager{
+		KoanProvider:   file.Provider(tmp.Name()),
+		WriterProvider: apiconfig.NewFileWriteCloserProvider(tmp.Name()),
+	}
+	if err := cm.Load(); err != nil {
+		os.Remove(tmp.Name())
+		return nil, nil, err
+	}
+	cleanup := func() { os.Remove(tmp.Name()) }
+	return cm, cleanup, nil
+}

--- a/decentralized-api/selfcheck/evaluator.go
+++ b/decentralized-api/selfcheck/evaluator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/productscience/inference/x/inference/types"
 )
 
 // CheckResult is the outcome of one assertion stage.
@@ -122,6 +124,40 @@ func (e *Evaluator) AssertHardwareDiffSubmitted() CheckResult {
 	return CheckResult{
 		Name: "hardware-diff-submitted", Pass: false,
 		Details: "broker did not submit hardware diff within timeout",
+	}
+}
+
+// AssertNodeIntendedStatus waits until the broker has driven the
+// synthetic node to the expected intended status. This is the core
+// PoC-lifecycle check: it proves the broker reacted to a phase
+// transition by setting the node's target state, without needing a
+// real MLnode. wantPoC is only checked when non-empty (it distinguishes
+// the GENERATING vs VALIDATING sub-states, both of which map to the
+// POC hardware status).
+func (e *Evaluator) AssertNodeIntendedStatus(name string, wantHW types.HardwareNodeStatus, wantPoC broker.PocStatus) CheckResult {
+	deadline := time.Now().Add(e.Timeout)
+	var lastHW types.HardwareNodeStatus
+	var lastPoC broker.PocStatus
+	for time.Now().Before(deadline) {
+		nodes, err := e.Broker.GetNodes()
+		if err != nil {
+			return CheckResult{Name: name, Pass: false, Details: err.Error()}
+		}
+		for _, n := range nodes {
+			if n.Node.Id != e.NodeId {
+				continue
+			}
+			lastHW, lastPoC = n.State.IntendedStatus, n.State.PocIntendedStatus
+			if lastHW == wantHW && (wantPoC == "" || lastPoC == wantPoC) {
+				return CheckResult{Name: name, Pass: true}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return CheckResult{
+		Name: name, Pass: false,
+		Details: fmt.Sprintf("intended status never reached %v/%v within timeout (last seen %v/%v)",
+			wantHW, wantPoC, lastHW, lastPoC),
 	}
 }
 

--- a/decentralized-api/selfcheck/evaluator.go
+++ b/decentralized-api/selfcheck/evaluator.go
@@ -1,0 +1,137 @@
+package selfcheck
+
+import (
+	"decentralized-api/broker"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CheckResult is the outcome of one assertion stage.
+type CheckResult struct {
+	Name    string `json:"name"`
+	Pass    bool   `json:"pass"`
+	Details string `json:"details,omitempty"`
+}
+
+// Report is the aggregate outcome of a selfcheck run. Pass is true iff
+// every stage's Pass is true.
+type Report struct {
+	Pass   bool          `json:"pass"`
+	Stages []CheckResult `json:"stages"`
+}
+
+// String renders the report as a human-readable summary suitable for
+// printing to stderr at the end of a CLI selfcheck invocation.
+func (r Report) String() string {
+	var b strings.Builder
+	if r.Pass {
+		b.WriteString("selfcheck: PASS\n")
+	} else {
+		b.WriteString("selfcheck: FAIL\n")
+	}
+	for _, s := range r.Stages {
+		mark := "PASS"
+		if !s.Pass {
+			mark = "FAIL"
+		}
+		fmt.Fprintf(&b, "  [%s] %s", mark, s.Name)
+		if s.Details != "" {
+			fmt.Fprintf(&b, " — %s", s.Details)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// Evaluator runs assertions against a broker driven through a
+// synthetic PoC cycle by EventDriver. It is intentionally minimal:
+// each stage queries broker state via the public GetNodes API and
+// reports pass/fail. A full PoC artifact simulation is out of scope.
+type Evaluator struct {
+	Broker  *broker.Broker
+	Bridge  *MockChainBridge
+	NodeId  string
+	Timeout time.Duration
+}
+
+// NewEvaluator constructs an Evaluator with a sensible default
+// per-stage poll timeout.
+func NewEvaluator(b *broker.Broker, bridge *MockChainBridge, nodeId string) *Evaluator {
+	return &Evaluator{
+		Broker:  b,
+		Bridge:  bridge,
+		NodeId:  nodeId,
+		Timeout: 5 * time.Second,
+	}
+}
+
+// AssertNodeRegistered waits until the broker reports the synthetic
+// node as registered. Pass iff GetNodes returns an entry for NodeId
+// within Timeout.
+func (e *Evaluator) AssertNodeRegistered() CheckResult {
+	deadline := time.Now().Add(e.Timeout)
+	for time.Now().Before(deadline) {
+		nodes, err := e.Broker.GetNodes()
+		if err != nil {
+			return CheckResult{Name: "node-registered", Pass: false, Details: err.Error()}
+		}
+		for _, n := range nodes {
+			if n.Node.Id == e.NodeId {
+				return CheckResult{Name: "node-registered", Pass: true}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return CheckResult{Name: "node-registered", Pass: false, Details: "timeout waiting for node"}
+}
+
+// AssertEpochModelsPopulated checks that after a chain refresh, the
+// broker has populated EpochMLNodes for the synthetic node — i.e. the
+// chain-bridge wiring is working end-to-end through the broker.
+func (e *Evaluator) AssertEpochModelsPopulated() CheckResult {
+	deadline := time.Now().Add(e.Timeout)
+	for time.Now().Before(deadline) {
+		nodes, err := e.Broker.GetNodes()
+		if err != nil {
+			return CheckResult{Name: "epoch-models-populated", Pass: false, Details: err.Error()}
+		}
+		for _, n := range nodes {
+			if n.Node.Id != e.NodeId {
+				continue
+			}
+			if len(n.State.EpochMLNodes) > 0 {
+				return CheckResult{Name: "epoch-models-populated", Pass: true}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return CheckResult{Name: "epoch-models-populated", Pass: false, Details: "EpochMLNodes empty"}
+}
+
+// AssertHardwareDiffSubmitted checks that the broker reported its
+// node hardware up to the (mocked) chain via SubmitHardwareDiff.
+func (e *Evaluator) AssertHardwareDiffSubmitted() CheckResult {
+	deadline := time.Now().Add(e.Timeout)
+	for time.Now().Before(deadline) {
+		if len(e.Bridge.SubmittedDiffsSnapshot()) > 0 {
+			return CheckResult{Name: "hardware-diff-submitted", Pass: true}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return CheckResult{
+		Name: "hardware-diff-submitted", Pass: false,
+		Details: "broker did not submit hardware diff within timeout",
+	}
+}
+
+// Combine aggregates stage results into a final Report.
+func (e *Evaluator) Combine(stages ...CheckResult) Report {
+	r := Report{Pass: true, Stages: stages}
+	for _, s := range stages {
+		if !s.Pass {
+			r.Pass = false
+		}
+	}
+	return r
+}

--- a/decentralized-api/selfcheck/event_driver.go
+++ b/decentralized-api/selfcheck/event_driver.go
@@ -1,0 +1,70 @@
+package selfcheck
+
+import (
+	"decentralized-api/broker"
+	"decentralized-api/chainphase"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// EventDriver advances a ChainPhaseTracker through a synthetic PoC
+// cycle and triggers the broker commands that would normally be
+// queued by the production OnNewBlockDispatcher.
+//
+// It does NOT simulate the full PoC artifact protocol — only the
+// chain-side events the broker reacts to:
+//   - epoch group data refresh (Inference phase boundary)
+//   - PoC start trigger        (StartPocCommand)
+//   - validation start         (InitValidateCommand)
+//   - inference-up resume      (InferenceUpAllCommand)
+//
+// The Evaluator inspects broker state between transitions to judge
+// whether the broker is behaving correctly. This is enough to catch
+// onboarding regressions where the broker fails to react to common
+// epoch events.
+type EventDriver struct {
+	Bridge       *MockChainBridge
+	PhaseTracker *chainphase.ChainPhaseTracker
+	Broker       *broker.Broker
+	Epoch        *types.Epoch
+	EpochParams  *types.EpochParams
+}
+
+// PushBlock updates the phase tracker to the given block height and
+// returns the resulting EpochState. The hash is synthetic.
+func (d *EventDriver) PushBlock(height int64) *chainphase.EpochState {
+	d.PhaseTracker.Update(
+		chainphase.BlockInfo{Height: height, Hash: "selfcheck-blk"},
+		d.Epoch,
+		d.EpochParams,
+		true,
+		nil,
+	)
+	return d.PhaseTracker.GetCurrentEpochState()
+}
+
+// RefreshEpochData updates the broker's per-node epoch view from the
+// (mocked) chain. This mirrors what OnNewBlockDispatcher does at the
+// start of every phase transition.
+func (d *EventDriver) RefreshEpochData() error {
+	es := d.PhaseTracker.GetCurrentEpochState()
+	return d.Broker.UpdateNodeWithEpochData(es)
+}
+
+// TriggerStartPoC queues the StartPocCommand the broker would normally
+// receive from OnNewBlockDispatcher when the chain crosses into the
+// PoC generate phase.
+func (d *EventDriver) TriggerStartPoC() error {
+	return d.Broker.QueueMessage(broker.NewStartPocCommand())
+}
+
+// TriggerInitValidate queues the InitValidateCommand for the validation
+// phase transition.
+func (d *EventDriver) TriggerInitValidate() error {
+	return d.Broker.QueueMessage(broker.NewInitValidateCommand())
+}
+
+// TriggerInferenceUpAll resumes inference at end of validation.
+func (d *EventDriver) TriggerInferenceUpAll() error {
+	return d.Broker.QueueMessage(broker.NewInferenceUpAllCommand())
+}

--- a/decentralized-api/selfcheck/mock_chain_bridge.go
+++ b/decentralized-api/selfcheck/mock_chain_bridge.go
@@ -1,0 +1,146 @@
+package selfcheck
+
+import (
+	"decentralized-api/broker"
+	"sync"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// MockChainBridge implements broker.BrokerChainBridge with hardcoded
+// responses that describe a single-participant, single-node, single-model
+// network. It is the foundation for running the real broker in
+// isolation during selfcheck — no chain RPC calls leave the process.
+//
+// All methods are safe for concurrent use.
+type MockChainBridge struct {
+	// ParticipantAddress is "self" — the participant address treated
+	// as active in epoch group data. Must match what NewBroker is
+	// constructed with via participant.CurrenParticipantInfo.
+	ParticipantAddress string
+
+	// ModelId is the single governance model used in the synthetic
+	// epoch group data and reported by GetGovernanceModels.
+	ModelId string
+
+	// NodeId is the MLnode id assigned to ParticipantAddress in the
+	// epoch group data. The selfcheck registers this id into the
+	// broker so EpochMLNodes lookups succeed.
+	NodeId string
+
+	// EpochIndex is the epoch index reported by epoch group responses.
+	EpochIndex uint64
+
+	// SubmittedDiffs records every SubmitHardwareDiff call so the
+	// Evaluator can assert the broker reported its hardware on startup.
+	mu             sync.Mutex
+	SubmittedDiffs []*types.MsgSubmitHardwareDiff
+}
+
+var _ broker.BrokerChainBridge = (*MockChainBridge)(nil)
+
+func (m *MockChainBridge) GetHardwareNodes() (*types.QueryHardwareNodesResponse, error) {
+	return &types.QueryHardwareNodesResponse{
+		Nodes: &types.HardwareNodes{HardwareNodes: nil},
+	}, nil
+}
+
+func (m *MockChainBridge) SubmitHardwareDiff(diff *types.MsgSubmitHardwareDiff) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SubmittedDiffs = append(m.SubmittedDiffs, diff)
+	return nil
+}
+
+func (m *MockChainBridge) GetBlockHash(height int64) (string, error) {
+	return "selfcheck-fake-hash", nil
+}
+
+func (m *MockChainBridge) GetGovernanceModels() (*types.QueryModelsAllResponse, error) {
+	return &types.QueryModelsAllResponse{
+		Model: []types.Model{{Id: m.ModelId}},
+	}, nil
+}
+
+// GetCurrentEpochGroupData returns a parent epoch group that points at
+// the single model subgroup. TotalWeight is non-zero so the v0.2.13
+// broker considers the epoch populated.
+func (m *MockChainBridge) GetCurrentEpochGroupData() (*types.QueryCurrentEpochGroupDataResponse, error) {
+	return &types.QueryCurrentEpochGroupDataResponse{
+		EpochGroupData: types.EpochGroupData{
+			EpochIndex:     m.EpochIndex,
+			SubGroupModels: []string{m.ModelId},
+			TotalWeight:    1,
+		},
+	}, nil
+}
+
+// GetEpochGroupDataByModelId returns:
+//   - The parent group (modelId="") with the subgroup pointer.
+//   - The model-specific subgroup with one ValidationWeights entry
+//     assigning ParticipantAddress's NodeId to the model.
+func (m *MockChainBridge) GetEpochGroupDataByModelId(epochIndex uint64, modelId string) (*types.QueryGetEpochGroupDataResponse, error) {
+	if modelId == "" {
+		return &types.QueryGetEpochGroupDataResponse{
+			EpochGroupData: types.EpochGroupData{
+				EpochIndex:     epochIndex,
+				SubGroupModels: []string{m.ModelId},
+				TotalWeight:    1,
+			},
+		}, nil
+	}
+	return &types.QueryGetEpochGroupDataResponse{
+		EpochGroupData: types.EpochGroupData{
+			EpochIndex:    epochIndex,
+			ModelSnapshot: &types.Model{Id: modelId},
+			ValidationWeights: []*types.ValidationWeight{
+				{
+					MemberAddress: m.ParticipantAddress,
+					Weight:        1,
+					MlNodes: []*types.MLNodeInfo{
+						{NodeId: m.NodeId},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// GetPreservedNodesSnapshot returns an empty snapshot — selfcheck does
+// not exercise preserved-node restoration. Added for v0.2.13 broker
+// interface compatibility.
+func (m *MockChainBridge) GetPreservedNodesSnapshot() (*types.QueryPreservedNodesSnapshotResponse, error) {
+	return &types.QueryPreservedNodesSnapshotResponse{}, nil
+}
+
+func (m *MockChainBridge) GetParams() (*types.QueryParamsResponse, error) {
+	return &types.QueryParamsResponse{
+		Params: types.Params{
+			EpochParams: m.epochParams(),
+		},
+	}, nil
+}
+
+// epochParams produces a deliberately short PoC cycle (a handful of
+// blocks per phase) so the EventDriver can step through a full epoch
+// in under a second of simulated time.
+func (m *MockChainBridge) epochParams() *types.EpochParams {
+	return &types.EpochParams{
+		EpochLength:           100,
+		PocStageDuration:      10,
+		PocExchangeDuration:   5,
+		PocValidationDelay:    1,
+		PocValidationDuration: 10,
+		SetNewValidatorsDelay: 1,
+	}
+}
+
+// SubmittedDiffsSnapshot returns a snapshot of recorded diffs so the
+// Evaluator can inspect them without racing the broker.
+func (m *MockChainBridge) SubmittedDiffsSnapshot() []*types.MsgSubmitHardwareDiff {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*types.MsgSubmitHardwareDiff, len(m.SubmittedDiffs))
+	copy(out, m.SubmittedDiffs)
+	return out
+}

--- a/decentralized-api/selfcheck/run.go
+++ b/decentralized-api/selfcheck/run.go
@@ -1,0 +1,146 @@
+// Package selfcheck provides a standalone mode for the api binary
+// that exercises the broker against a mocked chain to verify the
+// PoC lifecycle wiring is intact, without touching production code
+// paths. It is the implementation of the approach suggested by
+// reviewers on PR #866: keep the broker untouched, drive it with
+// synthetic events, and observe outcomes from a separate evaluator.
+//
+// See proposals/onboarding-clarity-v1/README.md for product context.
+package selfcheck
+
+import (
+	"context"
+	"decentralized-api/apiconfig"
+	"decentralized-api/broker"
+	"decentralized-api/chainphase"
+	"decentralized-api/mlnodeclient"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+const (
+	selfParticipantAddress = "selfcheck-participant"
+	selfNodeId             = "selfcheck-node-1"
+	selfModelId            = "selfcheck-model"
+)
+
+// Run executes the selfcheck and returns a Report. The Report's Pass
+// field is the overall outcome. An error is only returned if setup
+// itself failed (e.g. broker could not be constructed); per-stage
+// assertion failures are surfaced via Report.Pass=false.
+//
+// Run blocks until completion (a few seconds at most) or until ctx is
+// cancelled.
+func Run(ctx context.Context) (Report, error) {
+	// Disable the production "enforced model id" gate — selfcheck uses
+	// a synthetic model id and otherwise registration would be
+	// rejected. Tests in broker_test.go set this same env var.
+	if os.Getenv("ENFORCED_MODEL_ID") == "" {
+		os.Setenv("ENFORCED_MODEL_ID", "disabled")
+	}
+
+	bridge := &MockChainBridge{
+		ParticipantAddress: selfParticipantAddress,
+		ModelId:            selfModelId,
+		NodeId:             selfNodeId,
+		EpochIndex:         1,
+	}
+
+	phaseParams, err := bridge.GetParams()
+	if err != nil {
+		return Report{}, fmt.Errorf("mock GetParams: %w", err)
+	}
+
+	// Anchor the synthetic epoch so phase math is consistent.
+	const pocStart int64 = 1000
+	epoch := &types.Epoch{Index: 1, PocStartBlockHeight: pocStart}
+	phaseTracker := &chainphase.ChainPhaseTracker{}
+	phaseTracker.UpdateEpochParams(*phaseParams.Params.EpochParams)
+
+	// Configure a single fake node in the in-memory config manager so
+	// the broker reads it as a known node. We use a real
+	// ConfigManager wired to a tmpfile so SetNodes round-trips cleanly.
+	cm, cleanup, err := newInMemoryConfig()
+	if err != nil {
+		return Report{}, fmt.Errorf("newInMemoryConfig: %w", err)
+	}
+	defer cleanup()
+	if err := cm.SetNodes([]apiconfig.InferenceNodeConfig{{
+		Id:            selfNodeId,
+		Host:          "127.0.0.1",
+		InferencePort: 18080,
+		PoCPort:       18080,
+		MaxConcurrent: 1,
+		Models:        map[string]apiconfig.ModelConfig{selfModelId: {}},
+	}}); err != nil {
+		return Report{}, fmt.Errorf("SetNodes: %w", err)
+	}
+
+	mockFactory := mlnodeclient.NewMockClientFactory()
+	participantInfo := &staticParticipant{addr: selfParticipantAddress}
+	nodeBroker := broker.NewBroker(
+		bridge,
+		phaseTracker,
+		participantInfo,
+		"http://selfcheck-callback",
+		mockFactory,
+		cm,
+	)
+
+	// Load the configured node into the broker.
+	for _, n := range cm.GetNodes() {
+		ch := nodeBroker.LoadNodeToBroker(&n)
+		if ch != nil {
+			<-ch
+		}
+	}
+
+	driver := &EventDriver{
+		Bridge:       bridge,
+		PhaseTracker: phaseTracker,
+		Broker:       nodeBroker,
+		Epoch:        epoch,
+		EpochParams:  phaseParams.Params.EpochParams,
+	}
+	driver.PushBlock(pocStart - 50) // Inference phase, well before PoC
+
+	if err := driver.RefreshEpochData(); err != nil {
+		return Report{}, fmt.Errorf("RefreshEpochData: %w", err)
+	}
+
+	// Give the broker's goroutines a beat to process queued commands.
+	if err := waitOrCtx(ctx, 200*time.Millisecond); err != nil {
+		return Report{}, err
+	}
+
+	// nodeSyncWorker runs on a 60s ticker; trigger immediately so
+	// AssertHardwareDiffSubmitted has something to observe within
+	// selfcheck's short window.
+	_ = nodeBroker.QueueMessage(broker.NewSyncNodesCommand())
+
+	ev := NewEvaluator(nodeBroker, bridge, selfNodeId)
+	registered := ev.AssertNodeRegistered()
+	epochPopulated := ev.AssertEpochModelsPopulated()
+	hwSubmitted := ev.AssertHardwareDiffSubmitted()
+
+	return ev.Combine(registered, epochPopulated, hwSubmitted), nil
+}
+
+func waitOrCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// staticParticipant is a CurrenParticipantInfo whose values never
+// change — enough for selfcheck where the participant is hardcoded.
+type staticParticipant struct{ addr string }
+
+func (p *staticParticipant) GetAddress() string { return p.addr }
+func (p *staticParticipant) GetPubKey() string  { return "selfcheck-pubkey" }

--- a/decentralized-api/selfcheck/run.go
+++ b/decentralized-api/selfcheck/run.go
@@ -35,12 +35,20 @@ const (
 // Run blocks until completion (a few seconds at most) or until ctx is
 // cancelled.
 func Run(ctx context.Context) (Report, error) {
-	// Disable the production "enforced model id" gate — selfcheck uses
-	// a synthetic model id and otherwise registration would be
-	// rejected. Tests in broker_test.go set this same env var.
-	if os.Getenv("ENFORCED_MODEL_ID") == "" {
-		os.Setenv("ENFORCED_MODEL_ID", "disabled")
-	}
+	// Disable the production "enforced model id" gate for the duration
+	// of this run — selfcheck uses a synthetic model id that the gate
+	// would otherwise reject. Restore the caller's prior value on return
+	// so we don't leak process-wide state into tests or programmatic
+	// callers in the same process.
+	prevEnforced, hadEnforced := os.LookupEnv("ENFORCED_MODEL_ID")
+	os.Setenv("ENFORCED_MODEL_ID", "disabled")
+	defer func() {
+		if hadEnforced {
+			os.Setenv("ENFORCED_MODEL_ID", prevEnforced)
+		} else {
+			os.Unsetenv("ENFORCED_MODEL_ID")
+		}
+	}()
 
 	bridge := &MockChainBridge{
 		ParticipantAddress: selfParticipantAddress,
@@ -126,7 +134,41 @@ func Run(ctx context.Context) (Report, error) {
 	epochPopulated := ev.AssertEpochModelsPopulated()
 	hwSubmitted := ev.AssertHardwareDiffSubmitted()
 
-	return ev.Combine(registered, epochPopulated, hwSubmitted), nil
+	// Drive a full PoC lifecycle and assert the broker reacts to each
+	// phase the way the production OnNewBlockDispatcher would. We step
+	// the synthetic chain through PoCGenerate -> PoCValidate -> back to
+	// Inference, queueing the same broker commands a real block would,
+	// and observe the broker's intended-state decisions (no real MLnode
+	// needed). This is what "PoC lifecycle working" means at the broker
+	// layer — the part reviewers asked us to verify in isolation.
+	ec := types.NewEpochContext(*epoch, *phaseParams.Params.EpochParams)
+
+	// PoC generation phase.
+	driver.PushBlock(ec.StartOfPoC())
+	if err := driver.TriggerStartPoC(); err != nil {
+		return Report{}, fmt.Errorf("TriggerStartPoC: %w", err)
+	}
+	pocGenerate := ev.AssertNodeIntendedStatus("poc-generate",
+		types.HardwareNodeStatus_POC, broker.PocStatusGenerating)
+
+	// PoC validation phase.
+	driver.PushBlock(ec.StartOfPoCValidation())
+	if err := driver.TriggerInitValidate(); err != nil {
+		return Report{}, fmt.Errorf("TriggerInitValidate: %w", err)
+	}
+	pocValidate := ev.AssertNodeIntendedStatus("poc-validate",
+		types.HardwareNodeStatus_POC, broker.PocStatusValidating)
+
+	// Back to inference once validation is over.
+	driver.PushBlock(ec.EndOfPoCValidation())
+	if err := driver.TriggerInferenceUpAll(); err != nil {
+		return Report{}, fmt.Errorf("TriggerInferenceUpAll: %w", err)
+	}
+	inferenceResume := ev.AssertNodeIntendedStatus("inference-resumed",
+		types.HardwareNodeStatus_INFERENCE, "")
+
+	return ev.Combine(registered, epochPopulated, hwSubmitted,
+		pocGenerate, pocValidate, inferenceResume), nil
 }
 
 func waitOrCtx(ctx context.Context, d time.Duration) error {

--- a/decentralized-api/selfcheck/run_test.go
+++ b/decentralized-api/selfcheck/run_test.go
@@ -1,0 +1,32 @@
+package selfcheck
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestRunPasses asserts that the selfcheck reports PASS on a healthy
+// broker driven by the synthetic chain. Doubles as a regression guard
+// against changes to broker construction that would break the public
+// API the selfcheck depends on.
+func TestRunPasses(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	report, err := Run(ctx)
+	if err != nil {
+		t.Fatalf("Run setup error: %v", err)
+	}
+	if !report.Pass {
+		t.Fatalf("selfcheck did not pass:\n%s", report.String())
+	}
+	if len(report.Stages) == 0 {
+		t.Fatal("expected at least one stage in report")
+	}
+	for _, s := range report.Stages {
+		if !s.Pass {
+			t.Errorf("stage %q failed: %s", s.Name, s.Details)
+		}
+	}
+}

--- a/dev_notes/onboarding_observability.md
+++ b/dev_notes/onboarding_observability.md
@@ -1,0 +1,156 @@
+# Onboarding Observability — Logs & API by Stage
+
+What this branch adds so an operator can see what a node is doing during
+onboarding. Onboarding state is **derived at the admin handler layer**
+(read-only; nothing is written back to the broker / `NodeState`). This
+document maps each onboarding stage to (a) the log lines the API node
+emits and (b) what the admin API returns.
+
+Log subsystems used: `types.Nodes`, `types.Participants`.
+
+## Surfaces
+
+| Surface | Purpose |
+|---|---|
+| `GET /admin/v1/nodes` | Each node carries an `onboarding` block (states, timing, messages). |
+| `POST /admin/v1/nodes/:id/test` | One-shot MLnode validation (load → health → inference). |
+| `api selfcheck` (CLI subcommand) | Offline PoC-lifecycle self-test against a mocked chain. |
+| Process logs | Emitted by the API node; the status logger keeps "waiting for PoC" visible. |
+
+## The `onboarding` block
+
+```json
+{
+  "participant_state": "INACTIVE_WAITING | ACTIVE_PARTICIPATING",
+  "mlnode_state":      "WAITING_FOR_POC | TESTING | TEST_FAILED",
+  "timing": {
+    "current_phase":          "Inference | PoCGenerate | PoCValidate | ...",
+    "blocks_until_next_poc":   1988,
+    "seconds_until_next_poc":  11928,
+    "should_be_online":        false
+  },
+  "user_message": "…",
+  "guidance":     "…"
+}
+```
+
+`mlnode_state` is `TEST_FAILED` **only** when the MLnode validation test
+failed — never from the broker's operational `FAILED` status (an inactive
+node failing with "no epoch models" is normal onboarding, not a test
+failure). `timing` is omitted until the chain phase tracker has synced.
+
+## Lifecycle stages
+
+### A. Process start — chain not yet synced
+
+Logs (demoted to Info; they are normal startup states, not errors):
+```
+INFO Cannot populate node epoch data yet: phase tracker not initialized (normal during startup)   [Nodes]
+INFO Cannot populate node epoch data yet: epoch state not synced (normal until the chain syncs)    [Nodes]
+INFO RegisterNode. Epoch data not available yet; will populate after the chain syncs               [Nodes]
+```
+API: `onboarding` present, `timing` omitted; `mlnode_state=WAITING_FOR_POC`;
+`user_message="MLnode not yet validated - it will be tested before the next PoC"`
+(or `"Waiting for next PoC cycle (schedule syncing)"` once a test has passed).
+
+### B. Registered, chain synced, participant inactive (the long wait)
+
+Logs (status heartbeat at startup and every 5 minutes while inactive):
+```
+INFO MLnode not yet validated - it will be tested before the next PoC   [Nodes]
+```
+Once at least one node has passed a test, the heartbeat becomes:
+```
+INFO Waiting for next PoC cycle (starts in 2h 15m) - validated, safe to be offline until 10m before PoC   [Nodes]
+```
+If the participant is inactive and the node's model isn't in the active
+epoch, this is logged at Info (not Error):
+```
+INFO Participant not yet active - model assignment pending (normal for new participants)   [Nodes]
+```
+API:
+```json
+{
+  "participant_state": "INACTIVE_WAITING",
+  "mlnode_state": "WAITING_FOR_POC",
+  "timing": { "current_phase": "Inference", "seconds_until_next_poc": 11928, "should_be_online": false },
+  "user_message": "Participant not yet active - model assignment will occur after joining active set",
+  "guidance": "MLnode will be tested automatically when there is more than 1h until next PoC"
+}
+```
+
+### C. Pre-PoC auto-test running
+
+A test is auto-triggered on register / config-change when there is more
+than 1h until PoC (or run manually via `POST /test`).
+
+API: `mlnode_state=TESTING`,
+`user_message="Testing MLnode configuration - model loading in progress"`.
+
+### D. Test passed
+
+Logs (auto-test):
+```
+INFO Auto-test passed for MLnode   node_id=… duration_ms=…   [Nodes]
+```
+API: `mlnode_state=WAITING_FOR_POC`; the reassuring wording is now shown:
+`user_message="Waiting for next PoC cycle (starts in 2h 15m) - validated, safe to be offline until 10m before PoC"`.
+
+### E. Test failed
+
+Logs (auto-test failure is reported at the API node):
+```
+ERROR Auto-test failed for MLnode before PoC   node_id=… failing_model=… error=…   [Nodes]
+```
+API: `mlnode_state=TEST_FAILED`,
+`user_message="MLnode test failed: model 'Qwen/Qwen2.5-7B-Instruct' could not be loaded"`.
+
+### F. PoC approaching (within the online-alert lead, 10 min)
+
+API: `timing.should_be_online=true`; the message switches to:
+`user_message="PoC starting soon (in 8m) - MLnode must be online now"`
+(or, if not yet validated, `"… - MLnode not yet validated, bring it online now"`).
+
+### G. Participant joins the active set
+
+Logs (logged once on the inactive → active transition, then the heartbeat
+goes quiet):
+```
+INFO Participant is now in the active set and participating   [Participants]
+```
+API: `participant_state=ACTIVE_PARTICIPATING`,
+`user_message="Participant is in active set and participating"`.
+
+## `POST /admin/v1/nodes/:id/test`
+
+Runs load → health → inference against the MLnode and returns the result
+(no broker mutation). `200` with the result body (status may be `FAILED`),
+`404` if the node id is unknown, `409` if a test is already running.
+
+```json
+{
+  "node_id": "wiremock",
+  "status": "SUCCESS",                         // or "FAILED"
+  "failing_model": "…",                        // present on failure
+  "error": "…",                                // present on failure
+  "load_ms":  { "Qwen/Qwen2.5-7B-Instruct": 4 }, // per-model load time
+  "health_ms": 7,                              // health-check time
+  "resp_ms":   31,                             // inference-request time
+  "duration_ms": 44
+}
+```
+
+## `api selfcheck`
+
+Runs the real broker against a mocked chain through a full synthetic PoC
+lifecycle and prints a per-stage report; exit 0 on PASS, 1 on FAIL.
+
+```
+selfcheck: PASS
+  [PASS] node-registered
+  [PASS] epoch-models-populated
+  [PASS] hardware-diff-submitted
+  [PASS] poc-generate
+  [PASS] poc-validate
+  [PASS] inference-resumed
+```

--- a/proposals/onboarding-clarity-v1/README.md
+++ b/proposals/onboarding-clarity-v1/README.md
@@ -1,0 +1,154 @@
+# Onboarding Clarity Enhancement
+
+## Overview
+
+This proposal addresses critical user experience issues during node onboarding by implementing clear state reporting, proactive testing, and intelligent waiting period management. The current onboarding process leaves users confused about system status, with unclear error messages and no guidance on expected waiting periods or next steps.
+
+## Problem Statement
+
+### Current Onboarding Issues
+
+**Unclear Waiting States**: When users install and start nodes, there is no clear indication that nothing will happen until the next Proof-of-Compute (PoC) cycle begins. Users see their nodes running but receive no feedback about the expected waiting period or what will happen next.
+
+**Confusing Error Messages**: The API node shows "there is no model for ml node" messages even when the participant is not yet active, creating confusion about whether the setup is correct.
+
+**Lack of Proactive Testing**: New MLnodes are not tested before participating in PoC, leading to failures during critical consensus periods that could have been detected earlier.
+
+**Poor Restart Handling**: When API nodes restart, they don't properly check if participants are part of the active participant set, leading to inconsistent behavior.
+
+**Insufficient Status Information**: Users cannot determine:
+- How long until the next PoC cycle
+- Whether their MLnode is properly configured
+- If they can safely turn off servers during waiting periods
+- When they should be online for participation
+
+## Proposed Solution
+
+**Better Status Messages:**
+- When MLnode registered, the latest and most visible log should be "waiting for PoC"
+- Tell users exactly when next PoC starts
+- Tell users when they should bring the server online, and when they can safely turn off servers temporarily
+- Show: Info message "Waiting for next PoC cycle (starts in 2h 15m) - you can safely turn off the server and restart it 10 minutes before PoC"
+
+**Proactive Testing:**
+- When a new MLnode is registered (and there's >1 hour until PoC), automatically test it
+- Test: model loading, health check, inference request
+- Only show "waiting for PoC" if the test passes
+- If test fails, show clear error with specific problem
+
+**Better Restart Handling:**
+- When API node restarts, check if participant is actually in active set
+- Don't show confusing error messages if participant isn't active yet
+- Instead of: Error "there is no model for ml node" 
+- Show: Info message "Participant not yet active - model assignment pending (normal for new participants)"
+
+### Enhanced State Management System
+
+The proposal introduces a comprehensive state management system that provides clear feedback at every stage of the onboarding and participation lifecycle.
+
+#### New MLnode States
+
+**Enhanced State Enumeration**:
+- `WAITING_FOR_POC` - MLnode is configured and waiting for next PoC cycle
+- `TESTING` - MLnode is undergoing pre-PoC validation testing
+- `TEST_FAILED` - MLnode failed validation testing
+
+**Timing Guidance Through Messages**:
+The same `WAITING_FOR_POC` state provides different user messages based on timing:
+- "Waiting for next PoC cycle (starts in 2h 15m) - you can safely turn off the server and restart it 10 minutes before PoC"
+- "PoC starting soon (in 8 minutes) - MLnode must be online now"
+
+#### New API Node Participant States
+
+**Participant Status Tracking**:
+- `INACTIVE_WAITING` - Participant registered but not yet in active set
+- `ACTIVE_PARTICIPATING` - Participant is in active set and participating in current epoch
+
+### Proactive MLnode Testing System
+
+#### Pre-PoC Validation Flow
+
+**Testing Trigger Conditions**:
+- New MLnode registered OR configuration changes detected, when more than 1 hour until next PoC
+- Manual testing request through admin interface
+
+**Testing Process**:
+1. **Model Loading Test**: MLnode switches to "testing" state and performs similar operations as in "inference" state - load configured models and verify successful loading
+2. **Health Check**: Perform inference health check to ensure model is functional
+3. **Response Validation**: Send test inference request and validate response
+4. **Performance Baseline**: Record loading time and response time metrics
+
+**Test Result Actions**:
+- **Success**: Switch MLnode to `WAITING_FOR_POC` state
+- **Failure**: Switch to `TEST_FAILED` state with detailed error reporting in both MLnode and API node logs
+
+### Intelligent Timing System
+
+#### PoC Schedule Awareness
+
+**Timing Calculations**:
+- Calculate time until next PoC cycle using epoch parameters
+- Determine safe offline windows (more than 10 minutes until PoC)
+- Provide countdown timers for user interfaces
+- Alert users when they should be online
+
+**Existing Epoch Structure Integration**:
+- Use existing `Epoch` structure with PoC start block height and upcoming epoch information
+- Leverage existing `EpochParams` with `PocStageDuration`, `PocValidationDuration`, and other timing parameters
+- Utilize current `chainphase.EpochState` and block height tracking for accurate PoC timing calculations
+
+### Enhanced Logging and Status Reporting
+
+#### User-Friendly Status Messages
+
+**Clear State Communications**:
+- "Waiting for next PoC cycle (starts in 2h 15m) - you can safely turn off the server and restart it 10 minutes before PoC"
+- "Testing MLnode configuration - model loading in progress"
+- "MLnode test failed: model 'Qwen/Qwen2.5-7B-Instruct' could not be loaded"
+- "PoC starting soon (in 8 minutes) - MLnode must be online now"
+
+**Contextual Error Messages**:
+- Suppress "no model for ml node" messages when participant is inactive
+- Show clear explanations: "Participant not yet active - model assignment will occur after joining active set"
+- Provide actionable guidance: "MLnode will be tested automatically when there is more than 1 hour until next PoC"
+
+#### Enhanced Logging Categories
+
+**Extend Existing Logging System**:
+- Enhance existing `types.Nodes` logging with onboarding state transitions
+- Add testing-specific logs within existing `types.Nodes` category
+- Use existing `types.Participants` for participant status changes
+- Integrate timing guidance into existing log categories rather than creating new ones
+
+### Implementation Architecture
+
+#### API Node Enhancements
+
+**New Components for Admin Server** (`decentralized-api/internal/server/admin/`):
+- `OnboardingStateManager` - Centralized state tracking for onboarding process
+- `MLnodeTestingOrchestrator` - Manages pre-PoC testing workflows  
+- `TimingCalculator` - Computes PoC schedules and safe offline windows
+- `StatusReporter` - Generates user-friendly status messages
+
+**MLnode Server** (`decentralized-api/internal/server/mlnode/server.go`):
+- No changes needed - existing PoC batch endpoints remain the same
+
+#### Integration Points
+
+**Broker Integration**:
+- Enhance `NodeState` structure with new onboarding-specific fields
+- Modify `RegisterNode` command to trigger testing when appropriate
+- Update status query results to include timing information
+
+**Chain Integration**:
+- Query active participant status during startup
+- Monitor epoch transitions for timing calculations
+- Track participant weight changes for status updates
+
+### Conclusion
+
+This proposal addresses critical gaps in the Gonka network's onboarding experience by providing clear state communication, proactive testing, and intelligent timing guidance. The implementation focuses on user experience improvements while maintaining system reliability and security.
+
+The modular architecture allows for incremental deployment and easy maintenance, while the comprehensive testing approach ensures that configuration issues are caught early rather than during critical consensus periods. This results in a more reliable network and significantly improved user experience for node operators.
+
+The enhanced status reporting and timing guidance eliminate confusion about waiting periods and provide clear actionable information, transforming the onboarding process from a frustrating guessing game into a transparent, guided experience.


### PR DESCRIPTION
## Summary

Supersedes #866, completes #1261. Implements issue #326 (clearer onboarding logs, no false "errors", pre-PoC readiness testing) **without touching the broker** — onboarding UX is derived at the admin handler layer, and PoC wiring is verified in a separate `api selfcheck` mode against a mocked chain.

- **Onboarding status** — `GET /admin/v1/nodes` returns an optional `onboarding` block: MLnode state `WAITING_FOR_POC`/`TESTING`/`TEST_FAILED`, participant `INACTIVE_WAITING`/`ACTIVE_PARTICIPATING`, timing, and human messages. Derived read-only (`TimingCalculator`/`StatusReporter`/`OnboardingStateManager` + a 30s-cached `ActivityTracker`, no per-request chain RPCs). `broker.NodeState` unchanged.
- **Pre-PoC testing** — `POST /admin/v1/nodes/:id/test` (manual) + auto-test on register/config-change when >1h to PoC. Runs model load → health → inference request and records timings. Pass → `WAITING_FOR_POC` (the "safe to be offline" wording only after a pass); fail → `TEST_FAILED`, logged at the API node. `TEST_FAILED` comes only from the test, never from the broker's operational FAILED.
- **`api selfcheck`** — drives a full synthetic PoC lifecycle (`PoCGenerate → PoCValidate → Inference`) and reports per-stage PASS/FAIL (exit 0/1).
- **Log cleanup** — a "waiting for PoC (starts in 2h 15m)…" line at startup and every 5 min while onboarding; benign startup/inactive logs demoted to Info; genuine failures stay visible.

### Why not #866

#866 added UX state to `broker.NodeState` + new broker commands; reviewers (@patimen, @DimaOrekhovPS) flagged this as complexity on a critical path. Same features, broker untouched:

| | #866 | This PR |
|---|---|---|
| `broker.NodeState` new fields | 6 | 0 |
| broker new commands | 2 | 0 |
| per-request chain RPCs in `GET /nodes` | N+1 | 0 (30s cache) |
| UX state computation | broker writes back | handler derives |

Product context in `proposals/onboarding-clarity-v1/README.md`.

## Test plan

- [x] `go build` / `go vet` / `go test` (broker, admin, selfcheck, participant, mlnodeclient) — green
- [x] `api selfcheck` — 6 stages PASS, exit 0
- [x] End-to-end on a local network (real API node + chain, WireMock as the MLnode): `GET /nodes` onboarding (additive shape), `POST /test` SUCCESS (load/health/resp) and the `TEST_FAILED` path, onboarding logs
- [ ] Against a **real MLnode (vLLM)** / the **public testnet** — not yet run