### PR TITLE
[P3] Bridge: align ETH README/docs messageHash with BridgeContract.sol (#1285)

### DIFF
--- a/proposals/ethereum-bridge-contact/README.md
+++ b/proposals/ethereum-bridge-contact/README.md
@@ -77,6 +77,7 @@ bytes32 messageHash = keccak256(
         ETHEREUM_CHAIN_ID,
         WITHDRAW_OPERATION,  // keccak256("WITHDRAW_OPERATION")
         recipient,
+        address(this),       // Bridge contract address
         tokenContract,
         amount
     )
@@ -112,6 +113,7 @@ bytes32 messageHash = keccak256(
         ETHEREUM_CHAIN_ID,
         MINT_OPERATION,  // keccak256("MINT_OPERATION")
         recipient,
+        address(this),   // Bridge contract address
         amount
     )
 );
@@ -210,6 +212,7 @@ error MustBeInAdminControl()      // Operation requires ADMIN_CONTROL state
 error InvalidEpochSequence()      // Epoch not sequential
 error NoValidGenesisEpoch()       // Cannot enable operations without epoch 1
 error TimeoutNotReached()         // Timeout check called too early
+error InvalidAmount()             // Zero-amount withdrawal or mint rejected
 ```
 
 ## Gas Costs

--- a/proposals/ethereum-bridge-contact/README.md
+++ b/proposals/ethereum-bridge-contact/README.md
@@ -142,7 +142,7 @@ function submitGroupKey(
     uint64 epochId,
     bytes calldata groupPublicKey,    // 256-byte G2 public key (uncompressed)
     bytes calldata validationSig      // 128-byte signature from previous epoch
-) external
+) public onlyNormalOperation
 ```
 
 Anyone can submit the next sequential epoch with valid signature from previous epoch validators.
@@ -160,19 +160,19 @@ Admin can set group keys without validation signature during ADMIN_CONTROL state
 ### State Management
 
 ```solidity
-function resetToNormalOperation() external onlyOwner
+function resetToNormalOperation() external onlyOwner onlyAdminControl
 function checkAndHandleTimeout() external  // Callable by anyone
 ```
 
 **States:**
-- `ADMIN_CONTROL` - Initial state, conflict resolution, timeout recovery
+- `ADMIN_CONTROL` - Initial state and timeout recovery
 - `NORMAL_OPERATION` - Standard bridge operations
 
 **Timeout:** 30 days without new epochs triggers automatic admin control.
 
 ### Access Control & Multisig Deployment
 
-The `owner` role controls two privileged functions — `setGroupKey()` and `resetToNormalOperation()` — both gated by `onlyAdminControl`, meaning they are only callable in `ADMIN_CONTROL` state (triggered by a 30-day epoch timeout or a BLS key conflict). They are unreachable during normal bridge operation.
+The `owner` role controls two privileged functions — `setGroupKey()` and `resetToNormalOperation()` — both gated by `onlyAdminControl`, meaning they are only callable in `ADMIN_CONTROL` state (initial setup or 30-day epoch timeout recovery). They are unreachable during normal bridge operation.
 
 The contract will be deployed with a **multisig wallet as owner** (no single EOA), eliminating single-key risk for these admin-state scenarios.
 
@@ -186,7 +186,7 @@ function getLatestEpochInfo() external view returns (uint64 epochId, uint64 time
 function isTimeoutReached() external view returns (bool)
 function getContractBalance(address tokenContract) external view returns (uint256)  // address(this) for ETH
 function getWGNKInfo() external view returns (string memory name, string memory symbol, uint8 decimals, uint256 totalSupply)
-function decimals() external view returns (uint8)  // Returns 9
+function decimals() public view virtual override returns (uint8)  // Returns 9
 ```
 
 ## Events

--- a/proposals/ethereum-bridge-contact/SETUP.md
+++ b/proposals/ethereum-bridge-contact/SETUP.md
@@ -36,7 +36,7 @@ SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR-API-KEY
 ETHERSCAN_API_KEY=your_etherscan_api_key
 
 # Bridge configuration
-GENESIS_GROUP_PUBLIC_KEY=0x123456...  # 96-byte hex string
+GENESIS_GROUP_PUBLIC_KEY=0x123456...  # 256-byte uncompressed G2 public key
 ADMIN_ADDRESS=0x742d35Cc6639C0532fBb5Bc...
 ```
 
@@ -125,7 +125,7 @@ const withdrawalCommand = {
     recipient: "0x...",
     tokenContract: "0x...",
     amount: ethers.utils.parseEther("10"),
-    signature: "0x..." // 48-byte BLS signature
+    signature: "0x..." // 128-byte uncompressed G1 BLS signature
 };
 
 await bridge.withdraw(withdrawalCommand);
@@ -187,9 +187,8 @@ bridge.on("AdminControlActivated", (timestamp, reason) => {
 
 **If Contract Stuck in Admin Control:**
 1. Check why: `bridge.getCurrentState()`
-2. Resolve conflicts (if any)
-3. Submit missing epochs
-4. Call `resetToNormalOperation()`
+2. Submit the required epoch group key(s)
+3. Call `resetToNormalOperation()`
 
 **If Funds Stuck:**
 1. Funds can only be withdrawn via valid BLS signatures

--- a/proposals/ethereum-bridge-contact/SETUP.md
+++ b/proposals/ethereum-bridge-contact/SETUP.md
@@ -167,8 +167,10 @@ bridge.on("AdminControlActivated", (timestamp, reason) => {
 - Check latest epoch ID: `bridge.getLatestEpochInfo()`
 
 **"InvalidSignature" Error**
-- Verify BLS signature format (48 bytes, G1 point)
-- Check message encoding: `abi.encodePacked(epochId, requestId, recipient, token, amount)`
+- Verify BLS signature format (128-byte uncompressed G1 point)
+- Check message encoding matches the operation:
+  - Withdrawal: `abi.encodePacked(epochId, GONKA_CHAIN_ID, requestId, ETHEREUM_CHAIN_ID, WITHDRAW_OPERATION, recipient, address(this), tokenContract, amount)`
+  - Mint: `abi.encodePacked(epochId, GONKA_CHAIN_ID, requestId, ETHEREUM_CHAIN_ID, MINT_OPERATION, recipient, address(this), amount)`
 - Ensure group public key is correct for the epoch
 
 **"BridgeNotOperational" Error**

--- a/proposals/ethereum-bridge-contact/ethereum-bridge-contract.md
+++ b/proposals/ethereum-bridge-contact/ethereum-bridge-contract.md
@@ -48,7 +48,7 @@ This document describes the Ethereum smart contract that serves as the bridge en
 
 **Group Key Transitions:**
 
-- Each epoch has an associated BLS group public key (G2 point, 96 bytes)
+- Each epoch has an associated BLS group public key (G2 point, 256 bytes)
 - Group keys represent the consensus validator set for that epoch
 - Transitions must be submitted sequentially by epoch number
 - Each transition includes validation signature from previous epoch (chain of trust)
@@ -56,18 +56,24 @@ This document describes the Ethereum smart contract that serves as the bridge en
 **Optimized Storage:**
 
 ```solidity
-// Optimized group key storage (3 slots instead of 4)
+// Group key storage (8 slots)
 struct GroupKey {
+    // Uncompressed G2 point: X.c0, X.c1, Y.c0, Y.c1 (each 64 bytes → 8 x bytes32)
     bytes32 part0;  // bytes 0-31
-    bytes32 part1;  // bytes 32-63  
+    bytes32 part1;  // bytes 32-63
     bytes32 part2;  // bytes 64-95
+    bytes32 part3;  // bytes 96-127
+    bytes32 part4;  // bytes 128-159
+    bytes32 part5;  // bytes 160-191
+    bytes32 part6;  // bytes 192-223
+    bytes32 part7;  // bytes 224-255
 }
 
-// Simple mapping: epochId => groupPublicKey (96 bytes G2 point, 3 storage slots)
+// Simple mapping: epochId => groupPublicKey (256 bytes G2 point, 8 storage slots)
 mapping(uint64 => GroupKey) public epochGroupKeys;
 
 enum ContractState {
-    ADMIN_CONTROL,      // 0 - Initial state, conflict resolution, and timeout recovery
+    ADMIN_CONTROL,      // 0 - Initial state and timeout recovery
     NORMAL_OPERATION    // 1 - Standard bridge operations
 }
 // Note: Enums compile to uint8 - same efficiency as constants but with type safety
@@ -102,20 +108,23 @@ Since **1 epoch = 1 day**, the timestamp is needed for:
 
 ```solidity
 uint64 public constant MAX_STORED_EPOCHS = 365;  // 365 epochs = 365 days
-uint64 public oldestStoredEpoch = 1;
 
-function submitGroupKey(uint64 epochId, bytes calldata groupPublicKey, bytes calldata validationSig) external {
+function submitGroupKey(uint64 epochId, bytes calldata groupPublicKey, bytes calldata validationSig) public onlyNormalOperation {
+    require(epochId > 1, "Epoch 1 must be set via Admin");
+
     // Verify sequential submission
     require(epochId == epochMeta.latestEpochId + 1, "Must be next epoch");
+    require(groupPublicKey.length == 256, "Invalid group key length");
+
+    GroupKey memory newGroupKeyStruct = _bytesToGroupKey(groupPublicKey);
     
-    // Verify validation signature against previous epoch (if not genesis)
-    if (epochId > 1) {
-        bytes memory prevGroupKey = epochGroupKeys[epochId - 1];
-        require(_verifyTransitionSignature(prevGroupKey, groupPublicKey, validationSig), "Invalid signature");
-    }
+    // Verify validation signature against previous epoch
+    GroupKey memory prevGroupKeyStruct = epochGroupKeys[epochId - 1];
+    require(!_isGroupKeyEmpty(prevGroupKeyStruct), "Previous epoch not found");
+    require(_verifyTransitionSignature(prevGroupKeyStruct, newGroupKeyStruct, validationSig, epochId - 1), "Invalid signature");
     
     // Store only the group public key
-    epochGroupKeys[epochId] = groupPublicKey;
+    epochGroupKeys[epochId] = newGroupKeyStruct;
     
     // Update metadata in packed storage (single SSTORE)
     epochMeta = EpochMetadata({
@@ -125,18 +134,24 @@ function submitGroupKey(uint64 epochId, bytes calldata groupPublicKey, bytes cal
         reserved: 0
     });
     
-    // Clean up old epochs (keep last 365 epochs = 365 days)
-    if (epochId - oldestStoredEpoch >= MAX_STORED_EPOCHS) {
-        delete epochGroupKeys[oldestStoredEpoch];
-        oldestStoredEpoch++;
-    }
+    _cleanupOldEpochs(epochId);
     
-    emit GroupKeySubmitted(epochId, block.timestamp);
+    emit GroupKeySubmitted(epochId, groupPublicKey, block.timestamp);
+}
+
+function _cleanupOldEpochs(uint64 newEpochId) internal {
+    if (newEpochId <= MAX_STORED_EPOCHS) {
+        return;
+    }
+
+    uint64 epochToDelete = newEpochId - MAX_STORED_EPOCHS;
+    delete epochGroupKeys[epochToDelete];
+    emit EpochCleaned(epochToDelete);
 }
 
 // Check for timeout (no new transitions)
-function checkTimeout() external view returns (bool) {
-    return block.timestamp - epochMeta.submissionTimestamp > 30 days;
+function isTimeoutReached() external view returns (bool) {
+    return block.timestamp - epochMeta.submissionTimestamp > TIMEOUT_DURATION;
 }
 ```
 
@@ -149,12 +164,12 @@ function checkTimeout() external view returns (bool) {
 - No validation signature required for genesis epoch (no previous epoch exists)
 - Only after genesis setup can contract transition to `NORMAL_OPERATION`
 
-**Conflict Resolution:**
+**Admin Recovery:**
 
-- If two different group keys submitted for same epoch → contract returns to `ADMIN_CONTROL` state
-- Admin gains temporary control to resolve conflicts
-- Admin can submit correct group key and reset to `NORMAL_OPERATION` state
-- All withdrawal operations suspended during admin control
+- Out-of-sequence group key submissions are rejected
+- Admin can submit the next valid group key while the contract is in `ADMIN_CONTROL`
+- Admin can reset the contract to `NORMAL_OPERATION` once a genesis/latest epoch exists
+- All withdrawal and mint operations are suspended during admin control
 
 **Stuck Epoch Recovery:**
 
@@ -166,16 +181,16 @@ function checkTimeout() external view returns (bool) {
 **Operational Behavior:**
 
 - **ADMIN_CONTROL state automatically suspends all bridge operations** (withdrawals, group key transitions by validators)
-- Only admin functions available: `submitGroupKey()`, `resetToNormalOperation()`
+- Only admin functions available: `setGroupKey()`, `resetToNormalOperation()`
 - **No arbitrary pause power** - admin cannot suspend operations outside of predefined failure scenarios
-- Bridge operations only resume when admin resolves conflicts and transitions to `NORMAL_OPERATION`
+- Bridge operations only resume when admin restores `NORMAL_OPERATION`
 
 **Admin Capabilities in Control State:**
 
 ```solidity
 // Admin functions (only available in ADMIN_CONTROL state):
-function submitGroupKey(uint64 epochId, bytes calldata groupPublicKey) external onlyAdmin;
-function resetToNormalOperation() external onlyAdmin;
+function setGroupKey(uint64 epochId, bytes calldata groupPublicKey) external onlyOwner onlyAdminControl;
+function resetToNormalOperation() external onlyOwner onlyAdminControl;
 // Note: No arbitrary emergency triggers - admin control only activated by predefined conditions
 ```
 
@@ -183,19 +198,21 @@ function resetToNormalOperation() external onlyAdmin;
 
 ```solidity
 // ADMIN_CONTROL → NORMAL_OPERATION (only admin transition)
-function resetToNormalOperation() external onlyAdmin {
-    require(epochMeta.currentState == ContractState.ADMIN_CONTROL, "Must be in admin control");
-    require(hasValidGenesisEpoch(), "Genesis epoch required");
+function resetToNormalOperation() external onlyOwner onlyAdminControl {
+    if (epochMeta.latestEpochId == 0) {
+        revert NoValidGenesisEpoch();
+    }
     
     // Update state in packed storage
     epochMeta.currentState = ContractState.NORMAL_OPERATION;
+
+    emit NormalOperationRestored(epochMeta.latestEpochId, block.timestamp);
 }
 
 // NORMAL_OPERATION → ADMIN_CONTROL (automatic triggers only)
 // Triggered by:
-// 1. Epoch conflict detection (two different keys for same epoch)
-// 2. Timeout (30 days without new group key transition)
-// 3. Initial contract deployment state
+// 1. Timeout (30 days without new group key transition)
+// 2. Initial contract deployment state
 function _triggerAdminControl(string memory reason) internal {
     epochMeta.currentState = ContractState.ADMIN_CONTROL;
     emit AdminControlActivated(block.timestamp, reason);
@@ -203,30 +220,33 @@ function _triggerAdminControl(string memory reason) internal {
 
 // Timeout check function
 function checkAndHandleTimeout() external {
-    require(epochMeta.currentState == ContractState.NORMAL_OPERATION, "Already in admin control");
-    
-    if (block.timestamp - epochMeta.submissionTimestamp > 30 days) {
-        _triggerAdminControl("Timeout: No new epochs for 30 days");
+    if (epochMeta.currentState != ContractState.NORMAL_OPERATION) {
+        return;
     }
+    
+    if (block.timestamp - epochMeta.submissionTimestamp <= TIMEOUT_DURATION) {
+        revert TimeoutNotReached();
+    }
+
+    _triggerAdminControl("Timeout: No new epochs for 30 days");
 }
 ```
 
 **Operations Allowed by State:**
 
-- **ADMIN_CONTROL**: Only admin functions (submitGroupKey, resetToNormalOperation) - **ALL user operations suspended**
-- **NORMAL_OPERATION**: All functions (withdrawals, group key transitions from validators, admin functions)
+- **ADMIN_CONTROL**: Only admin functions (`setGroupKey`, `resetToNormalOperation`) - **ALL user operations suspended**
+- **NORMAL_OPERATION**: Withdrawals, minting, validator `submitGroupKey`, and timeout checks
 
 **State Usage:**
 
 ```solidity
 // Example usage in withdrawal function
-function withdraw(WithdrawalCommand calldata cmd) external {
-    require(epochMeta.currentState == ContractState.NORMAL_OPERATION, "Bridge not operational");
+function withdraw(WithdrawalCommand calldata cmd) external nonReentrant onlyNormalOperation {
     // ... rest of withdrawal logic
 }
 
 // Contract deployment initialization
-constructor() {
+constructor(bytes32 _gonkaChainId, bytes32 _ethereumChainId) {
     epochMeta.currentState = ContractState.ADMIN_CONTROL;  // Start in admin control
 }
 ```
@@ -235,10 +255,9 @@ constructor() {
 
 - **No arbitrary admin pause power** - admin cannot suspend operations at will or trigger emergency stops
 - **Automatic protection only** - system enters admin control only for predefined failure conditions:
-  - Epoch conflicts (two different keys for same epoch)
   - Timeout conditions (30 days without new epochs)
   - Initial deployment state
-- **Limited admin scope** - admin can only resolve conflicts and restore normal operation
+- **Limited admin scope** - admin can only set group keys during admin control and restore normal operation
 - **Transparent triggers** - all transitions to admin control are event-logged with clear reasons
 - **Trustless design** - no manual override mechanisms that could be abused
 
@@ -255,7 +274,7 @@ constructor() {
 
 ```solidity
 // Efficient storage: only what's needed
-mapping(uint64 => bytes) public epochGroupKeys;  // epochId => 96-byte G2 public key
+mapping(uint64 => GroupKey) public epochGroupKeys;  // epochId => 256-byte G2 public key (8 slots)
 mapping(uint64 => mapping(bytes32 => bool)) public processedRequests;  // epochId => requestId => processed
 
 // Packed metadata (single 32-byte storage slot)
@@ -269,26 +288,26 @@ EpochMetadata public epochMeta;
 
 // Constants
 uint64 public constant MAX_STORED_EPOCHS = 365;  // 365 epochs = 365 days
-uint64 public oldestStoredEpoch = 1;
+uint64 public constant TIMEOUT_DURATION = 30 days;
 
-function cleanupOldEpochs(uint64 newEpochId) internal {
-    // Remove old epochs if we exceed the 365 epoch limit
-    while (newEpochId - oldestStoredEpoch >= MAX_STORED_EPOCHS) {
-        // Clean up group key (96 bytes freed)
-        delete epochGroupKeys[oldestStoredEpoch];
-        
-        // Clean up processed requests for this epoch
-        // Note: Individual request deletions would be expensive
-        // Better to use a different storage pattern for large request sets
-        
-        oldestStoredEpoch++;
+function _cleanupOldEpochs(uint64 newEpochId) internal {
+    if (newEpochId <= MAX_STORED_EPOCHS) {
+        return;
     }
+
+    uint64 epochToDelete = newEpochId - MAX_STORED_EPOCHS;
+    delete epochGroupKeys[epochToDelete];
+
+    // Note: Individual request deletions would be expensive
+    // Better to use a different storage pattern for large request sets
+
+    emit EpochCleaned(epochToDelete);
 }
 ```
 
 **Benefits of optimized storage:**
 
-- **Storage efficient**: GroupKey struct uses 3 slots instead of 4 (25% savings per epoch)
+- **Fixed layout**: GroupKey struct uses 8 slots (256-byte uncompressed G2 point)
 - **Gas efficient**: Single SSTORE for metadata update (latestEpochId + timestamp + state)
 - **Contract state included**: Current state stored in same slot for free
 - **Minimal storage**: Only stores essential data (group keys, not validation signatures)

--- a/proposals/ethereum-bridge-contact/ethereum-bridge-contract.md
+++ b/proposals/ethereum-bridge-contact/ethereum-bridge-contract.md
@@ -28,14 +28,14 @@ This document describes the Ethereum smart contract that serves as the bridge en
 
 - Utilizes Ethereum's native BLS12-381 curve support for signature verification
 - Implements threshold signature validation using precompiled contracts
-- Group public keys stored as G2 points (96 bytes compressed format)
-- Signatures verified as G1 points (48 bytes compressed format)
+- Group public keys stored as uncompressed G2 points (256 bytes)
+- Signatures verified as uncompressed G1 points (128 bytes)
 
 **Signature Verification Process:**
 
 ```text
-1. Parse withdrawal command: (epoch_id, request_id, recipient, token, amount)
-2. Encode data using abi.encodePacked for consistent hashing
+1. Parse bridge command and operation context
+2. Encode data using the contract's exact `abi.encodePacked` field order
 3. Compute message hash: keccak256(encoded_data)
 4. Retrieve group public key for specified epoch_id
 5. Verify BLS signature against group public key using precompiled contract (with operation domain separation)
@@ -306,17 +306,20 @@ struct WithdrawalCommand {
     uint64 epochId;           // 8 bytes - epoch for signature validation
     bytes32 requestId;        // 32 bytes - unique request identifier from source chain
     address recipient;        // 20 bytes - Ethereum address to receive tokens
-    address tokenContract;    // 20 bytes - ERC-20 contract address
+    address tokenContract;    // 20 bytes - ERC-20 contract address (or address(this) for ETH)
     uint256 amount;          // 32 bytes - token amount to withdraw
-    bytes signature;         // 48 bytes - BLS threshold signature (G1 point)
+    bytes signature;         // 128 bytes - BLS threshold signature (G1 point, uncompressed)
 }
 ```
 
 **Validation Flow:**
 
-1. **Epoch Validation**: Verify group key exists for specified `epochId` (`epochGroupKeys[epochId].length > 0`)
+1. **Epoch Validation**: Verify a non-empty group key exists for specified `epochId`
 2. **Replay Protection**: Check `requestId` hasn't been processed for this `epochId`
-3. **Signature Verification**: Validate BLS signature against epoch's group public key using message: `abi.encodePacked(epochId, requestId, WITHDRAW_OPERATION, recipient, tokenContract, amount)`
+3. **Signature Verification**: Validate BLS signature against epoch's group public key using message:
+   ```solidity
+   abi.encodePacked(epochId, GONKA_CHAIN_ID, requestId, ETHEREUM_CHAIN_ID, WITHDRAW_OPERATION, recipient, address(this), tokenContract, amount)
+   ```
 4. **Balance Check**: Ensure contract has sufficient token or ETH balance
 5. **Execution**: Transfer tokens or ETH to recipient address
    - **ETH withdrawals**: When `tokenContract == address(this)`, transfer ETH using `call{value:}`
@@ -456,7 +459,7 @@ struct MintCommand {
     bytes32 requestId;        // 32 bytes - unique request identifier from source chain
     address recipient;        // 20 bytes - Ethereum address to receive WGNK
     uint256 amount;          // 32 bytes - WGNK amount to mint
-    bytes signature;         // 48 bytes - BLS threshold signature (G1 point)
+    bytes signature;         // 128 bytes - BLS threshold signature (G1 point, uncompressed)
 }
 
 function mintWithSignature(MintCommand calldata cmd) external;
@@ -467,7 +470,10 @@ function mintWithSignature(MintCommand calldata cmd) external;
 1. **State Check**: Only allowed in `NORMAL_OPERATION` state
 2. **Epoch Validation**: Verify group key exists for specified `epochId`
 3. **Replay Protection**: Check `requestId` hasn't been processed for this `epochId`
-4. **Signature Verification**: Validate BLS signature against epoch's group public key using message: `abi.encodePacked(epochId, requestId, MINT_OPERATION, recipient, amount, )`
+4. **Signature Verification**: Validate BLS signature against epoch's group public key using message:
+   ```solidity
+   abi.encodePacked(epochId, GONKA_CHAIN_ID, requestId, ETHEREUM_CHAIN_ID, MINT_OPERATION, recipient, address(this), amount)
+   ```
 5. **Execution**: Mint WGNK tokens to recipient's balance, increase total supply
 6. **Record Processing**: Mark `requestId` as processed for this `epochId`
 


### PR DESCRIPTION
## Summary

Closes #1285. The Ethereum bridge docs documented the mint/withdraw signed payload **without** the `address(this)` (bridge contract address) field, while the contract source includes it. The chain-side signer already matches the contract, so this is not a production-safety issue — but third-party auditors/integrators following the docs would build an invalid `messageHash` and hit signature-verification failures.

This brings the docs back in line with `BridgeContract.sol`.

- **README quickfix** — cherry-picks the existing upstream fix (`gl/eth-readme-quickfix`, commit `7180faa8`): adds `address(this)` to the mint and withdraw `messageHash` in `proposals/ethereum-bridge-contact/README.md`.
- **Consistency sweep (beyond the quickfix)** — the same inconsistency, plus stale BLS point sizes, existed in two sibling docs. Aligned both with the contract:
  - `SETUP.md` and `ethereum-bridge-contract.md` `messageHash` now include `address(this)` and the full field order for withdraw and mint.
  - BLS sizes corrected to the EIP-2537 precompile encoding — G1 signature **128 bytes**, G2 group key **256 bytes** (uncompressed) — replacing the old 48/96-byte compressed figures.
  - Fixed a trailing-comma typo in the mint encoding example.

Docs-only; no code paths touched.

## Field order (now matches `BridgeContract.sol`)

- withdraw: `epochId, GONKA_CHAIN_ID, requestId, ETHEREUM_CHAIN_ID, WITHDRAW_OPERATION, recipient, address(this), tokenContract, amount`
- mint: `epochId, GONKA_CHAIN_ID, requestId, ETHEREUM_CHAIN_ID, MINT_OPERATION, recipient, address(this), amount`

## Test plan

- [x] Verified mint/withdraw `messageHash` field order against `BridgeContract.sol` (`keccak256(abi.encodePacked(...))`, lines 352/416)
- [x] Verified BLS sizes against the contract's length checks (`signature.length == 128`, `groupPublicKey.length == 256`)
- [x] Docs-only change — no build/test impact
