### PR TITLE
Expand versioned E2E coverage 

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -151,6 +151,46 @@ jobs:
           path: decentralized-api/junit-report.xml
           reporter: java-junit
 
+  versioned-e2e:
+    runs-on: ubuntu-latest
+    name: Versioned E2E
+    permissions:
+      contents: read
+      checks: write
+    defaults:
+      run:
+        working-directory: ./versioned
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '1.24.2'
+
+      - name: Install uv (e2e-report JUnit merge)
+        run: pip install uv
+
+      - name: Run E2E tests
+        run: make e2e
+
+      - name: Publish E2E JUnit report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: versioned-e2e-junit-report
+          path: versioned/build/test-results/e2e-junit.xml
+
+      - name: Report E2E results in GitHub
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Versioned E2E
+          path: versioned/build/test-results/e2e-junit.xml
+          reporter: java-junit
+
   build-and-test-versioned:
     runs-on: ubuntu-latest
     name: Build and Test Versioned

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ inference-chain/dist/
 /edge-api/build/edge-api
 /devshard/devshardctl
 /devshard/devshardd
-/devshard/cmd/devshardd/devshardd
 /devshard/cmd/devshardctl/devshardctl
+/devshard/cmd/devshardd/devshardd
 chain-venv/
 .inference/
 prod-genesis/

--- a/versioned/Makefile
+++ b/versioned/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test e2e e2e-clean-results e2e-build e2e-standard e2e-reconcile e2e-report testapp build-docker docker-push release
+.PHONY: build test e2e e2e-clean-results e2e-build e2e-run e2e-report testapp build-docker docker-push release
 
 include ../scripts/blst-portable.mk
 
@@ -37,7 +37,7 @@ testapp:
 	go build -o build/testapp ./e2e/testapp
 	go build -ldflags "-X main.Version=testapp2 -X main.BinaryVersion=testapp2" -o build/testapp2 ./e2e/testapp
 
-e2e: e2e-clean-results e2e-build e2e-standard e2e-reconcile e2e-report
+e2e: e2e-clean-results e2e-build e2e-run e2e-report
 
 e2e-clean-results:
 	rm -rf build/test-results
@@ -46,16 +46,15 @@ e2e-clean-results:
 e2e-build:
 	docker compose -f e2e/docker-compose.yml build
 
-e2e-standard:
+e2e-run:
 	docker compose -f e2e/docker-compose.yml up --no-build --abort-on-container-exit --exit-code-from tests
-
-e2e-reconcile:
-	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml up --no-build -d oracle versiond
-	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml stop versiond
-	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml run --rm --no-deps -e REGISTER_STARTUP_VERSION=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-register-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestRegisterStartupVersion$$'
-	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml start versiond
-	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml run --rm --no-deps -e EXPECT_INITIAL_V1=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-on-start-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestStartupFromExistingOracleState$$'
-	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml down -v
+	docker compose -f e2e/docker-compose.yml down -v
+	docker compose -f e2e/docker-compose.yml up --no-build -d oracle versiond
+	docker compose -f e2e/docker-compose.yml stop versiond
+	docker compose -f e2e/docker-compose.yml run --rm --no-deps -e REGISTER_STARTUP_VERSION=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-register-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestRegisterStartupVersion$$'
+	docker compose -f e2e/docker-compose.yml start versiond
+	docker compose -f e2e/docker-compose.yml run --rm --no-deps -e EXPECT_INITIAL_V1=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-on-start-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestStartupFromExistingOracleState$$'
+	docker compose -f e2e/docker-compose.yml down -v
 
 e2e-report:
 	uvx junitparser merge --glob 'build/test-results/*-junit.xml' build/test-results/e2e-junit.xml

--- a/versioned/Makefile
+++ b/versioned/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test e2e testapp build-docker docker-push release
+.PHONY: build test e2e e2e-clean-results e2e-build e2e-standard e2e-reconcile e2e-report testapp build-docker docker-push release
 
 include ../scripts/blst-portable.mk
 
@@ -37,8 +37,32 @@ testapp:
 	go build -o build/testapp ./e2e/testapp
 	go build -ldflags "-X main.Version=testapp2 -X main.BinaryVersion=testapp2" -o build/testapp2 ./e2e/testapp
 
-e2e: build testapp
-	docker compose -f e2e/docker-compose.yml up --build --abort-on-container-exit --exit-code-from tests
+e2e: e2e-clean-results e2e-build e2e-standard e2e-reconcile e2e-report
+
+e2e-clean-results:
+	rm -rf build/test-results
+	mkdir -p build/test-results
+
+e2e-build:
+	docker compose -f e2e/docker-compose.yml build
+
+e2e-standard:
+	docker compose -f e2e/docker-compose.yml up --no-build --abort-on-container-exit --exit-code-from tests
+
+e2e-reconcile:
+	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml up --no-build -d oracle versiond
+	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml stop versiond
+	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml run --rm --no-deps -e REGISTER_STARTUP_VERSION=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-register-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestRegisterStartupVersion$$'
+	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml start versiond
+	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml run --rm --no-deps -e EXPECT_INITIAL_V1=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-on-start-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestStartupFromExistingOracleState$$'
+	docker compose -p versioned-e2e-reconcile -f e2e/docker-compose.yml down -v
+
+e2e-report:
+	uvx junitparser merge --glob 'build/test-results/*-junit.xml' build/test-results/e2e-junit.xml
+	@status=0; \
+	uvx junitparser verify build/test-results/e2e-junit.xml || status=$$?; \
+	uvx junit2html --summary-matrix build/test-results/e2e-junit.xml; \
+	exit $$status
 
 build-docker:
 	$(eval PLATFORM=$(DOCKER_PLATFORM))

--- a/versioned/Makefile
+++ b/versioned/Makefile
@@ -53,9 +53,10 @@ e2e-run:
 	docker compose -f e2e/docker-compose.yml stop versiond
 	docker compose -f e2e/docker-compose.yml run --rm --no-deps -e REGISTER_STARTUP_VERSION=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-register-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestRegisterStartupVersion$$'
 	docker compose -f e2e/docker-compose.yml start versiond
-	docker compose -f e2e/docker-compose.yml run --rm --no-deps -e EXPECT_INITIAL_V1=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-on-start-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestStartupFromExistingOracleState$$'
+	docker compose -f e2e/docker-compose.yml run --rm --no-deps -e EXPECT_INITIAL_TESTAPP=1 tests gotestsum --format testname --junitfile /app/test-results/reconcile-on-start-junit.xml -- -tags e2e ./e2e -v -timeout 300s -run '^TestStartupFromExistingOracleState$$'
 	docker compose -f e2e/docker-compose.yml down -v
 
+# e2e-report requires uv on PATH (install: pip install uv).
 e2e-report:
 	uvx junitparser merge --glob 'build/test-results/*-junit.xml' build/test-results/e2e-junit.xml
 	@status=0; \

--- a/versioned/e2e/Dockerfile.tests
+++ b/versioned/e2e/Dockerfile.tests
@@ -12,4 +12,4 @@ RUN rm -rf /app/build && mkdir -p /app/build \
 	&& CGO_ENABLED=0 GOOS=linux go build \
 		-ldflags "-X main.Version=testapp2 -X main.BinaryVersion=testapp2" \
 		-o /app/build/testapp2 ./e2e/testapp
-CMD ["gotestsum", "--format", "testname", "--junitfile", "/app/test-results/standard-junit.xml", "--", "-tags", "e2e", "./e2e", "-v", "-timeout", "300s", "-skip", "^(TestRegisterStartupVersion|TestStartupFromExistingOracleState)$"]
+CMD ["gotestsum", "--format", "testname", "--junitfile", "/app/test-results/run-junit.xml", "--", "-tags", "e2e", "./e2e", "-v", "-timeout", "300s", "-skip", "^(TestRegisterStartupVersion|TestStartupFromExistingOracleState)$"]

--- a/versioned/e2e/Dockerfile.tests
+++ b/versioned/e2e/Dockerfile.tests
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY go.mod go.sum* ./
 RUN go mod download
 COPY . .
+RUN go install gotest.tools/gotestsum@v1.12.3
 # Slot names must match --print-protocol-version. Default binary embeds "testapp";
 # testapp2 is only needed for concurrent multi-version tests.
 # Clear any host build/ artifacts (macOS Mach-O is not runnable in Linux).
@@ -11,5 +12,4 @@ RUN rm -rf /app/build && mkdir -p /app/build \
 	&& CGO_ENABLED=0 GOOS=linux go build \
 		-ldflags "-X main.Version=testapp2 -X main.BinaryVersion=testapp2" \
 		-o /app/build/testapp2 ./e2e/testapp
-RUN CGO_ENABLED=0 go test -c -tags e2e -o /e2e-tests ./e2e/
-CMD ["/e2e-tests", "-test.v", "-test.timeout", "300s"]
+CMD ["gotestsum", "--format", "testname", "--junitfile", "/app/test-results/standard-junit.xml", "--", "-tags", "e2e", "./e2e", "-v", "-timeout", "300s", "-skip", "^(TestRegisterStartupVersion|TestStartupFromExistingOracleState)$"]

--- a/versioned/e2e/docker-compose.yml
+++ b/versioned/e2e/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     environment:
       ORACLE_URL: http://oracle:8080
       VERSIOND_URL: http://versiond:8080
+      VERSIOND_POLL_INTERVAL: "5s"
       TESTAPP_PATH: /app/build/testapp
       TESTAPP2_PATH: /app/build/testapp2
     volumes:

--- a/versioned/e2e/docker-compose.yml
+++ b/versioned/e2e/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   oracle:
+    image: versioned-e2e-oracle:latest
     build:
       context: ..
       dockerfile: e2e/Dockerfile.mockoracle
@@ -10,6 +11,7 @@ services:
       - oracle-data:/data
 
   versiond:
+    image: versioned-e2e-versiond:latest
     build:
       context: ..
       dockerfile: Dockerfile
@@ -23,6 +25,7 @@ services:
       - oracle
 
   tests:
+    image: versioned-e2e-tests:latest
     build:
       context: ..
       dockerfile: e2e/Dockerfile.tests
@@ -31,6 +34,8 @@ services:
       VERSIOND_URL: http://versiond:8080
       TESTAPP_PATH: /app/build/testapp
       TESTAPP2_PATH: /app/build/testapp2
+    volumes:
+      - ../build/test-results:/app/test-results
     depends_on:
       - oracle
       - versiond

--- a/versioned/e2e/e2e_test.go
+++ b/versioned/e2e/e2e_test.go
@@ -170,7 +170,7 @@ func TestOracleTemporaryFailureKeepsVersionsRunning(t *testing.T) {
 	waitForVersion(t, version, 90*time.Second)
 
 	setOracleFailure(t, true)
-	time.Sleep(12 * time.Second)
+	waitForPollCycles(2)
 
 	var resp map[string]string
 	getJSON(t, fmt.Sprintf("%s/%s/", versiondURL, version), &resp)
@@ -190,13 +190,35 @@ func TestEmptyOracleResponseKeepsVersionsRunning(t *testing.T) {
 	waitForVersion(t, "v1", 90*time.Second)
 
 	deleteVersion(t, "v1")
-	time.Sleep(12 * time.Second)
+	waitForPollCycles(2)
 
 	var resp map[string]string
 	getJSON(t, fmt.Sprintf("%s/v1/", versiondURL), &resp)
 	if resp["prefix"] != "v1" {
 		t.Errorf("prefix = %q, want %q", resp["prefix"], "v1")
 	}
+}
+
+func TestFailedSameVersionUpdateKeepsOldChildRunning(t *testing.T) {
+	setOracleFailure(t, false)
+
+	zipData, hash := buildTestappZip(t)
+
+	uploadBinary(t, "failed-update-v1.zip", zipData)
+	putVersion(t, "v1", fmt.Sprintf("%s/binaries/failed-update-v1.zip", oracleURL), hash, 9001)
+	waitForVersion(t, "v1", 90*time.Second)
+
+	uploadBinary(t, "failed-update-v1-bad.zip", zipData)
+	putVersion(t, "v1", fmt.Sprintf("%s/binaries/failed-update-v1-bad.zip", oracleURL), "wrong_hash", 9001)
+
+	waitForPollCycles(2)
+
+	var resp map[string]string
+	getJSON(t, fmt.Sprintf("%s/v1/", versiondURL), &resp)
+	if resp["prefix"] != "v1" {
+		t.Errorf("prefix = %q, want %q", resp["prefix"], "v1")
+	}
+	assertHealthStatus(t, "v1", "running")
 }
 
 func TestHashMismatch(t *testing.T) {

--- a/versioned/e2e/e2e_test.go
+++ b/versioned/e2e/e2e_test.go
@@ -21,10 +21,7 @@ func TestBasicFlow(t *testing.T) {
 	zipData, hash := buildTestappZip(t)
 
 	uploadBinary(t, "testapp.zip", zipData)
-
-	binaryURL := fmt.Sprintf("%s/binaries/testapp.zip", oracleURL)
-	putVersion(t, "testapp", binaryURL, hash, 9001)
-
+	putVersion(t, "testapp", fmt.Sprintf("%s/binaries/testapp.zip", oracleURL), hash, 9001)
 	waitForVersion(t, "testapp", 90*time.Second)
 
 	var resp map[string]string
@@ -36,13 +33,13 @@ func TestBasicFlow(t *testing.T) {
 
 func TestChildProcessCrashRecovery(t *testing.T) {
 	zipData, hash := buildTestappZip(t)
-	version := "child-crash-recovery"
+	slot := "testapp"
 
-	uploadBinary(t, version+".zip", zipData)
-	putVersion(t, version, fmt.Sprintf("%s/binaries/%s.zip", oracleURL, version), hash, 9005)
-	waitForVersion(t, version, 90*time.Second)
+	uploadBinary(t, "crash-testapp.zip", zipData)
+	putVersion(t, slot, fmt.Sprintf("%s/binaries/crash-testapp.zip", oracleURL), hash, 9001)
+	waitForVersion(t, slot, 90*time.Second)
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s/exit", versiondURL, version), nil)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s/exit", versiondURL, slot), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,13 +52,13 @@ func TestChildProcessCrashRecovery(t *testing.T) {
 		t.Fatalf("child exit status = %d, want 204", resp.StatusCode)
 	}
 
-	waitForVersionUnavailable(t, version, 10*time.Second)
-	waitForVersion(t, version, 90*time.Second)
+	waitForVersionUnavailable(t, slot, 25*time.Second)
+	waitForVersion(t, slot, 90*time.Second)
 
 	var recovered map[string]string
-	getJSON(t, fmt.Sprintf("%s/%s/", versiondURL, version), &recovered)
-	if recovered["prefix"] != version {
-		t.Errorf("prefix = %q, want %q", recovered["prefix"], version)
+	getJSON(t, fmt.Sprintf("%s/%s/", versiondURL, slot), &recovered)
+	if recovered["prefix"] != slot {
+		t.Errorf("prefix = %q, want %q", recovered["prefix"], slot)
 	}
 }
 
@@ -72,44 +69,23 @@ func TestRegisterStartupVersion(t *testing.T) {
 
 	zipData, hash := buildTestappZip(t)
 
-	uploadBinary(t, "startup-v1.zip", zipData)
-	putVersion(t, "v1", fmt.Sprintf("%s/binaries/startup-v1.zip", oracleURL), hash, 9001)
+	uploadBinary(t, "startup-testapp.zip", zipData)
+	putVersion(t, "testapp", fmt.Sprintf("%s/binaries/startup-testapp.zip", oracleURL), hash, 9001)
 }
 
 func TestStartupFromExistingOracleState(t *testing.T) {
-	if os.Getenv("EXPECT_INITIAL_V1") == "" {
+	if os.Getenv("EXPECT_INITIAL_TESTAPP") == "" {
 		t.Skip("startup oracle state scenario is enabled only after versiond restart")
 	}
 
-	waitForVersion(t, "v1", 90*time.Second)
+	waitForVersion(t, "testapp", 90*time.Second)
 
 	var proxied map[string]string
-	getJSON(t, fmt.Sprintf("%s/v1/", versiondURL), &proxied)
-	if proxied["prefix"] != "v1" {
-		t.Errorf("prefix = %q, want %q", proxied["prefix"], "v1")
+	getJSON(t, fmt.Sprintf("%s/testapp/", versiondURL), &proxied)
+	if proxied["prefix"] != "testapp" {
+		t.Errorf("prefix = %q, want %q", proxied["prefix"], "testapp")
 	}
-
-	resp, err := http.Get(fmt.Sprintf("%s/healthz", versiondURL))
-	if err != nil {
-		t.Fatalf("GET healthz: %v", err)
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	var statuses []map[string]interface{}
-	if err := json.Unmarshal(body, &statuses); err != nil {
-		t.Fatalf("decode healthz: %v, body: %s", err, string(body))
-	}
-
-	for _, s := range statuses {
-		if s["name"] == "v1" {
-			if s["status"] != "running" {
-				t.Errorf("v1 status = %q, want running", s["status"])
-			}
-			return
-		}
-	}
-	t.Fatalf("v1 not found in healthz response: %s", string(body))
+	assertHealthStatus(t, "testapp", "running")
 }
 
 func TestAddVersion(t *testing.T) {
@@ -163,19 +139,20 @@ func TestOracleTemporaryFailureKeepsVersionsRunning(t *testing.T) {
 	})
 
 	zipData, hash := buildTestappZip(t)
-	version := "oracle-failure"
+	slot := "testapp"
 
-	uploadBinary(t, version+".zip", zipData)
-	putVersion(t, version, fmt.Sprintf("%s/binaries/%s.zip", oracleURL, version), hash, 9004)
-	waitForVersion(t, version, 90*time.Second)
+	uploadBinary(t, "oracle-failure-testapp.zip", zipData)
+	putVersion(t, slot, fmt.Sprintf("%s/binaries/oracle-failure-testapp.zip", oracleURL), hash, 9004)
+	waitForVersion(t, slot, 90*time.Second)
 
 	setOracleFailure(t, true)
-	waitForPollCycles(2)
+	assertOracleFailureMode(t, true)
+	waitForPollCycles(3)
 
 	var resp map[string]string
-	getJSON(t, fmt.Sprintf("%s/%s/", versiondURL, version), &resp)
-	if resp["prefix"] != version {
-		t.Errorf("prefix = %q, want %q", resp["prefix"], version)
+	getJSON(t, fmt.Sprintf("%s/%s/", versiondURL, slot), &resp)
+	if resp["prefix"] != slot {
+		t.Errorf("prefix = %q, want %q", resp["prefix"], slot)
 	}
 }
 
@@ -185,17 +162,17 @@ func TestEmptyOracleResponseKeepsVersionsRunning(t *testing.T) {
 
 	zipData, hash := buildTestappZip(t)
 
-	uploadBinary(t, "empty-oracle-v1.zip", zipData)
-	putVersion(t, "v1", fmt.Sprintf("%s/binaries/empty-oracle-v1.zip", oracleURL), hash, 9001)
-	waitForVersion(t, "v1", 90*time.Second)
+	uploadBinary(t, "empty-oracle-testapp.zip", zipData)
+	putVersion(t, "testapp", fmt.Sprintf("%s/binaries/empty-oracle-testapp.zip", oracleURL), hash, 9001)
+	waitForVersion(t, "testapp", 90*time.Second)
 
-	deleteVersion(t, "v1")
-	waitForPollCycles(2)
+	deleteVersion(t, "testapp")
+	waitForPollCycles(3)
 
 	var resp map[string]string
-	getJSON(t, fmt.Sprintf("%s/v1/", versiondURL), &resp)
-	if resp["prefix"] != "v1" {
-		t.Errorf("prefix = %q, want %q", resp["prefix"], "v1")
+	getJSON(t, fmt.Sprintf("%s/testapp/", versiondURL), &resp)
+	if resp["prefix"] != "testapp" {
+		t.Errorf("prefix = %q, want %q", resp["prefix"], "testapp")
 	}
 }
 
@@ -204,21 +181,21 @@ func TestFailedSameVersionUpdateKeepsOldChildRunning(t *testing.T) {
 
 	zipData, hash := buildTestappZip(t)
 
-	uploadBinary(t, "failed-update-v1.zip", zipData)
-	putVersion(t, "v1", fmt.Sprintf("%s/binaries/failed-update-v1.zip", oracleURL), hash, 9001)
-	waitForVersion(t, "v1", 90*time.Second)
+	uploadBinary(t, "failed-update-testapp.zip", zipData)
+	putVersion(t, "testapp", fmt.Sprintf("%s/binaries/failed-update-testapp.zip", oracleURL), hash, 9001)
+	waitForVersion(t, "testapp", 90*time.Second)
 
-	uploadBinary(t, "failed-update-v1-bad.zip", zipData)
-	putVersion(t, "v1", fmt.Sprintf("%s/binaries/failed-update-v1-bad.zip", oracleURL), "wrong_hash", 9001)
+	uploadBinary(t, "failed-update-testapp-bad.zip", zipData)
+	putVersion(t, "testapp", fmt.Sprintf("%s/binaries/failed-update-testapp-bad.zip", oracleURL), "wrong_hash", 9001)
 
-	waitForPollCycles(2)
+	waitForPollCycles(3)
 
 	var resp map[string]string
-	getJSON(t, fmt.Sprintf("%s/v1/", versiondURL), &resp)
-	if resp["prefix"] != "v1" {
-		t.Errorf("prefix = %q, want %q", resp["prefix"], "v1")
+	getJSON(t, fmt.Sprintf("%s/testapp/", versiondURL), &resp)
+	if resp["prefix"] != "testapp" {
+		t.Errorf("prefix = %q, want %q", resp["prefix"], "testapp")
 	}
-	assertHealthStatus(t, "v1", "running")
+	assertHealthStatus(t, "testapp", "running")
 }
 
 func TestHashMismatch(t *testing.T) {

--- a/versioned/e2e/e2e_test.go
+++ b/versioned/e2e/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +32,84 @@ func TestBasicFlow(t *testing.T) {
 	if resp["prefix"] != "testapp" {
 		t.Errorf("prefix = %q, want %q", resp["prefix"], "testapp")
 	}
+}
+
+func TestChildProcessCrashRecovery(t *testing.T) {
+	zipData, hash := buildTestappZip(t)
+	version := "child-crash-recovery"
+
+	uploadBinary(t, version+".zip", zipData)
+	putVersion(t, version, fmt.Sprintf("%s/binaries/%s.zip", oracleURL, version), hash, 9005)
+	waitForVersion(t, version, 90*time.Second)
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s/exit", versiondURL, version), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request child exit: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("child exit status = %d, want 204", resp.StatusCode)
+	}
+
+	waitForVersionUnavailable(t, version, 10*time.Second)
+	waitForVersion(t, version, 90*time.Second)
+
+	var recovered map[string]string
+	getJSON(t, fmt.Sprintf("%s/%s/", versiondURL, version), &recovered)
+	if recovered["prefix"] != version {
+		t.Errorf("prefix = %q, want %q", recovered["prefix"], version)
+	}
+}
+
+func TestRegisterStartupVersion(t *testing.T) {
+	if os.Getenv("REGISTER_STARTUP_VERSION") == "" {
+		t.Skip("startup version registration is enabled only by the startup scenario")
+	}
+
+	zipData, hash := buildTestappZip(t)
+
+	uploadBinary(t, "startup-v1.zip", zipData)
+	putVersion(t, "v1", fmt.Sprintf("%s/binaries/startup-v1.zip", oracleURL), hash, 9001)
+}
+
+func TestStartupFromExistingOracleState(t *testing.T) {
+	if os.Getenv("EXPECT_INITIAL_V1") == "" {
+		t.Skip("startup oracle state scenario is enabled only after versiond restart")
+	}
+
+	waitForVersion(t, "v1", 90*time.Second)
+
+	var proxied map[string]string
+	getJSON(t, fmt.Sprintf("%s/v1/", versiondURL), &proxied)
+	if proxied["prefix"] != "v1" {
+		t.Errorf("prefix = %q, want %q", proxied["prefix"], "v1")
+	}
+
+	resp, err := http.Get(fmt.Sprintf("%s/healthz", versiondURL))
+	if err != nil {
+		t.Fatalf("GET healthz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var statuses []map[string]interface{}
+	if err := json.Unmarshal(body, &statuses); err != nil {
+		t.Fatalf("decode healthz: %v, body: %s", err, string(body))
+	}
+
+	for _, s := range statuses {
+		if s["name"] == "v1" {
+			if s["status"] != "running" {
+				t.Errorf("v1 status = %q, want running", s["status"])
+			}
+			return
+		}
+	}
+	t.Fatalf("v1 not found in healthz response: %s", string(body))
 }
 
 func TestAddVersion(t *testing.T) {
@@ -74,6 +153,29 @@ func TestRemoveVersion(t *testing.T) {
 	getJSON(t, fmt.Sprintf("%s/testapp2/", versiondURL), &resp)
 	if resp["prefix"] != "testapp2" {
 		t.Errorf("testapp2 prefix = %q", resp["prefix"])
+	}
+}
+
+func TestOracleTemporaryFailureKeepsVersionsRunning(t *testing.T) {
+	setOracleFailure(t, false)
+	t.Cleanup(func() {
+		setOracleFailure(t, false)
+	})
+
+	zipData, hash := buildTestappZip(t)
+	version := "oracle-failure"
+
+	uploadBinary(t, version+".zip", zipData)
+	putVersion(t, version, fmt.Sprintf("%s/binaries/%s.zip", oracleURL, version), hash, 9004)
+	waitForVersion(t, version, 90*time.Second)
+
+	setOracleFailure(t, true)
+	time.Sleep(12 * time.Second)
+
+	var resp map[string]string
+	getJSON(t, fmt.Sprintf("%s/%s/", versiondURL, version), &resp)
+	if resp["prefix"] != version {
+		t.Errorf("prefix = %q, want %q", resp["prefix"], version)
 	}
 }
 

--- a/versioned/e2e/e2e_test.go
+++ b/versioned/e2e/e2e_test.go
@@ -179,6 +179,26 @@ func TestOracleTemporaryFailureKeepsVersionsRunning(t *testing.T) {
 	}
 }
 
+func TestEmptyOracleResponseKeepsVersionsRunning(t *testing.T) {
+	setOracleFailure(t, false)
+	deleteAllVersions(t)
+
+	zipData, hash := buildTestappZip(t)
+
+	uploadBinary(t, "empty-oracle-v1.zip", zipData)
+	putVersion(t, "v1", fmt.Sprintf("%s/binaries/empty-oracle-v1.zip", oracleURL), hash, 9001)
+	waitForVersion(t, "v1", 90*time.Second)
+
+	deleteVersion(t, "v1")
+	time.Sleep(12 * time.Second)
+
+	var resp map[string]string
+	getJSON(t, fmt.Sprintf("%s/v1/", versiondURL), &resp)
+	if resp["prefix"] != "v1" {
+		t.Errorf("prefix = %q, want %q", resp["prefix"], "v1")
+	}
+}
+
 func TestHashMismatch(t *testing.T) {
 	zipData, _ := buildTestappZip(t)
 

--- a/versioned/e2e/mockoracle/main.go
+++ b/versioned/e2e/mockoracle/main.go
@@ -52,14 +52,30 @@ func main() {
 	}
 
 	http.HandleFunc("/versions", func(w http.ResponseWriter, r *http.Request) {
-		s.mu.RLock()
-		defer s.mu.RUnlock()
-		if s.fail {
-			http.Error(w, "oracle failure enabled", http.StatusInternalServerError)
-			return
+		switch r.Method {
+		case http.MethodGet:
+			s.mu.RLock()
+			fail := s.fail
+			versions := append([]Version(nil), s.versions...)
+			s.mu.RUnlock()
+			if fail {
+				http.Error(w, "oracle failure enabled", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(VersionConfig{Versions: versions})
+		case http.MethodDelete:
+			if s.failureEnabled() {
+				http.Error(w, "oracle failure enabled", http.StatusInternalServerError)
+				return
+			}
+			s.mu.Lock()
+			s.versions = nil
+			s.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(VersionConfig{Versions: s.versions})
 	})
 
 	http.HandleFunc("/versions/", func(w http.ResponseWriter, r *http.Request) {

--- a/versioned/e2e/mockoracle/main.go
+++ b/versioned/e2e/mockoracle/main.go
@@ -27,6 +27,7 @@ type store struct {
 	mu       sync.RWMutex
 	versions []Version
 	binDir   string
+	fail     bool
 }
 
 func main() {
@@ -53,6 +54,10 @@ func main() {
 	http.HandleFunc("/versions", func(w http.ResponseWriter, r *http.Request) {
 		s.mu.RLock()
 		defer s.mu.RUnlock()
+		if s.fail {
+			http.Error(w, "oracle failure enabled", http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(VersionConfig{Versions: s.versions})
 	})
@@ -65,6 +70,10 @@ func main() {
 		}
 		switch r.Method {
 		case http.MethodPut:
+			if s.failureEnabled() {
+				http.Error(w, "oracle failure enabled", http.StatusInternalServerError)
+				return
+			}
 			var v Version
 			if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
@@ -87,6 +96,10 @@ func main() {
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(v)
 		case http.MethodDelete:
+			if s.failureEnabled() {
+				http.Error(w, "oracle failure enabled", http.StatusInternalServerError)
+				return
+			}
 			s.mu.Lock()
 			for i, v := range s.versions {
 				if v.Name == name {
@@ -99,6 +112,18 @@ func main() {
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
+	})
+
+	http.HandleFunc("/fail", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		enabled := r.URL.Query().Get("enabled") == "true"
+		s.mu.Lock()
+		s.fail = enabled
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	http.HandleFunc("/binaries/", func(w http.ResponseWriter, r *http.Request) {
@@ -128,4 +153,10 @@ func main() {
 	addr := fmt.Sprintf(":%s", port)
 	log.Printf("mock oracle listening on %s", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+func (s *store) failureEnabled() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.fail
 }

--- a/versioned/e2e/setup_test.go
+++ b/versioned/e2e/setup_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	oracleURL   = envOrDefault("ORACLE_URL", "http://oracle:8080")
-	versiondURL = envOrDefault("VERSIOND_URL", "http://versiond:8080")
+	oracleURL            = envOrDefault("ORACLE_URL", "http://oracle:8080")
+	versiondURL          = envOrDefault("VERSIOND_URL", "http://versiond:8080")
+	versiondPollInterval = durationEnvOrDefault("VERSIOND_POLL_INTERVAL", 5*time.Second)
 )
 
 func envOrDefault(key, fallback string) string {
@@ -26,6 +27,18 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func durationEnvOrDefault(key string, fallback time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
 }
 
 // buildTestappZip creates a zip archive containing the pre-built testapp binary
@@ -199,6 +212,11 @@ func waitForVersionUnavailable(t *testing.T, version string, timeout time.Durati
 	t.Fatalf("version %s did not become temporarily unavailable after %v", version, timeout)
 }
 
+// waitForPollCycles waits long enough for versiond to observe oracle state changes.
+func waitForPollCycles(cycles int) {
+	time.Sleep(time.Duration(cycles)*versiondPollInterval + 2*time.Second)
+}
+
 // waitForVersionGone polls versiond until the given version is no longer proxied.
 func waitForVersionGone(t *testing.T, version string, timeout time.Duration) {
 	t.Helper()
@@ -216,6 +234,32 @@ func waitForVersionGone(t *testing.T, version string, timeout time.Duration) {
 		time.Sleep(time.Second)
 	}
 	t.Fatalf("version %s still available after %v", version, timeout)
+}
+
+// assertHealthStatus verifies that versiond reports the expected status for a version.
+func assertHealthStatus(t *testing.T, version, wantStatus string) {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("%s/healthz", versiondURL))
+	if err != nil {
+		t.Fatalf("GET healthz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var statuses []map[string]interface{}
+	if err := json.Unmarshal(body, &statuses); err != nil {
+		t.Fatalf("decode healthz: %v, body: %s", err, string(body))
+	}
+
+	for _, s := range statuses {
+		if s["name"] == version {
+			if s["status"] != wantStatus {
+				t.Errorf("%s status = %q, want %s", version, s["status"], wantStatus)
+			}
+			return
+		}
+	}
+	t.Fatalf("%s not found in healthz response: %s", version, string(body))
 }
 
 // getJSON does a GET and decodes the JSON response into out.

--- a/versioned/e2e/setup_test.go
+++ b/versioned/e2e/setup_test.go
@@ -136,6 +136,9 @@ func deleteVersion(t *testing.T, name string) {
 		t.Fatalf("delete version: %v", err)
 	}
 	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete version status: %d", resp.StatusCode)
+	}
 }
 
 // deleteAllVersions removes every version from the mock oracle.
@@ -170,6 +173,26 @@ func setOracleFailure(t *testing.T, enabled bool) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("set oracle failure status: %d", resp.StatusCode)
+	}
+}
+
+// assertOracleFailureMode verifies mock oracle GET /versions reflects failure mode.
+func assertOracleFailureMode(t *testing.T, wantFailure bool) {
+	t.Helper()
+	resp, err := http.Get(oracleURL + "/versions")
+	if err != nil {
+		t.Fatalf("GET oracle versions: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if wantFailure {
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("oracle failure mode: status = %d, want 500", resp.StatusCode)
+		}
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("oracle healthy mode: status = %d, want 200", resp.StatusCode)
 	}
 }
 

--- a/versioned/e2e/setup_test.go
+++ b/versioned/e2e/setup_test.go
@@ -125,6 +125,24 @@ func deleteVersion(t *testing.T, name string) {
 	resp.Body.Close()
 }
 
+// setOracleFailure toggles the mock oracle's failure mode for version metadata.
+func setOracleFailure(t *testing.T, enabled bool) {
+	t.Helper()
+	url := fmt.Sprintf("%s/fail?enabled=%t", oracleURL, enabled)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("set oracle failure: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("set oracle failure status: %d", resp.StatusCode)
+	}
+}
+
 // waitForVersion polls versiond until the given version responds through the proxy.
 func waitForVersion(t *testing.T, version string, timeout time.Duration) {
 	t.Helper()
@@ -142,6 +160,26 @@ func waitForVersion(t *testing.T, version string, timeout time.Duration) {
 		time.Sleep(time.Second)
 	}
 	t.Fatalf("version %s not available after %v", version, timeout)
+}
+
+// waitForVersionUnavailable polls until the version stops returning 200.
+func waitForVersionUnavailable(t *testing.T, version string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	url := fmt.Sprintf("%s/%s/", versiondURL, version)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err != nil {
+			return
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return
+		}
+		resp.Body.Close()
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("version %s did not become temporarily unavailable after %v", version, timeout)
 }
 
 // waitForVersionGone polls versiond until the given version is no longer proxied.

--- a/versioned/e2e/setup_test.go
+++ b/versioned/e2e/setup_test.go
@@ -125,6 +125,23 @@ func deleteVersion(t *testing.T, name string) {
 	resp.Body.Close()
 }
 
+// deleteAllVersions removes every version from the mock oracle.
+func deleteAllVersions(t *testing.T) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, oracleURL+"/versions", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete all versions: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete all versions status: %d", resp.StatusCode)
+	}
+}
+
 // setOracleFailure toggles the mock oracle's failure mode for version metadata.
 func setOracleFailure(t *testing.T, enabled bool) {
 	t.Helper()

--- a/versioned/e2e/testapp/main.go
+++ b/versioned/e2e/testapp/main.go
@@ -59,6 +59,19 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
+	http.HandleFunc("/exit", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			os.Exit(42)
+		}()
+	})
+
 	http.HandleFunc("/stream", func(w http.ResponseWriter, r *http.Request) {
 		flusher, ok := w.(http.Flusher)
 		if !ok {
@@ -91,8 +104,8 @@ func main() {
 		conn, err := grpc.NewClient(nmAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			json.NewEncoder(w).Encode(map[string]string{
-				"error":             fmt.Sprintf("grpc dial failed: %v", err),
-				"nodemanager_addr":  nmAddr,
+				"error":            fmt.Sprintf("grpc dial failed: %v", err),
+				"nodemanager_addr": nmAddr,
 			})
 			return
 		}


### PR DESCRIPTION
## Summary
This expands versioned E2E coverage around versiond reconciliation and failure-handling behavior, and cleans up the make e2e runner so one command builds, runs, merges JUnit, verifies, and prints a readable summary.

The new tests cover integration paths that were previously easy to miss because most existing E2E cases mutated oracle state only after all services were already running.

## Added E2E scenarios:

**Startup From Existing Oracle State**

1. Start mock oracle.
2. Register v1 in oracle while versiond is stopped.
3. Start versiond.
4. Wait for /v1/ to become available.
5. Verify /v1/ returns the expected version prefix.
6. Verify /healthz reports v1 as running.

**Oracle Temporary Failure Keeps Children Running**

1. Register and start a version through oracle
2. Wait until the version is reachable through versiond.
3. Toggle mock oracle failure mode so oracle returns 500.
4. Wait through multiple versiond poll cycles.
5. Verify the already-running version still serves traffic.

**Empty Oracle Response Keeps Children Running**

1. Clear oracle state.
2. Register and start v1.
3. Wait until /v1/ is reachable through versiond.
4. Delete v1 from oracle so oracle returns an empty version list.
5. Wait through multiple versiond poll cycles.
6. Verify /v1/ still works.

**Failed Same-Version Update Keeps Old Child Running**

1. Register and start v1.
2. Wait until /v1/ is reachable through versiond.
3. Re-register v1 with a bad hash.
4. Wait through multiple versiond poll cycles.
5. Verify /v1/ still serves traffic.
6. Verify /healthz still reports v1 as running.

**Child Process Crash Recovery**

1. Register and start a version.
2. Wait until the version is reachable through versiond.
3. Call the test-only POST /exit endpoint through the proxy.
4. Verify the version becomes temporarily unavailable.
5. Wait for process.Manager to restart the child.
6. Verify the version becomes reachable again.

### Added test report summary output via gotestsum + JUnit merge/reporting:

Summary example:
```
Matrix Test Report
===================
                                                   e2e-junit.xml
                                                   | 
versioned/e2e  
- TestAddVersion                                   /  / Passed
- TestBasicFlow                                    /  / Passed
- TestChildProcessCrashRecovery                    /  / Passed
- TestEmptyOracleResponseKeepsVersionsRunning      /  / Passed
- TestFailedSameVersionUpdateKeepsOldChildRunning  /  / Passed
- TestHashMismatch                                 /  / Passed
- TestHealthEndpoint                               /  / Passed
- TestOracleTemporaryFailureKeepsVersionsRunning   /  / Passed
- TestRegisterStartupVersion                       /  / Passed
- TestRemoveVersion                                /  / Passed
- TestSSEStreaming                                 /  / Passed
- TestStartupFromExistingOracleState               /  / Passed

-------------------------------------------------------------------------------
Test Results:
  Passed       :     12
```

##  Safety
Production versiond logic is unchanged. This PR changes the E2E suite, mock oracle, test app, Docker test runner, and Makefile only.