### PR TITLE
docs: fix two markdown formatting errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We introduce a novel consensus mechanism, **Proof of Work 2.0**, that ensures ne
 
 ![The Task flow](https://github.com/user-attachments/assets/1ba81a47-f4ef-4eb1-9fcd-b6d371a20f5f)
 
-*[Work in progress] Diagram 1. The Task flow [Source](docs/papers/InferenceFlow.png)**
+*[Work in progress] Diagram 1. The Task flow [Source](docs/papers/InferenceFlow.png)*
 
 For a deeper technical and conceptual explanation, check out [the White Paper](https://gonka.ai/whitepaper.pdf).
 ## Getting started
@@ -49,7 +49,7 @@ Make sure you have the following installed:
 Clone the repository:
 ```
 git clone https://github.com/gonka-ai/gonka.git
-cd gonka (or repo name)**
+cd gonka
 ```
 
 Build chain and API nodes, and run unit tests:


### PR DESCRIPTION
## What problem does this solve?

Two small Markdown errors in the top-level `README.md` render incorrectly. One breaks an
italic caption; the other puts invalid text into a copy-paste shell command in the
"Build the project" section.

## How do you know this is a real problem?

- **Line 24** — the Diagram 1 caption opens emphasis with a single `*` but closes with `**`:
  `*[Work in progress] Diagram 1. The Task flow [Source](docs/papers/InferenceFlow.png)**`.
  The unbalanced markers mean the line does not render as intended italic.
- **Line 52** — inside the fenced code block under "2. Build the project", the clone
  instructions read `cd gonka (or repo name)**`. The trailing `**` and the parenthetical
  are stray editing leftovers; a reader copying the block runs an invalid command.

## How does this solve the problem?

- Line 24: close the caption with a single `*`.
- Line 52: reduce the command to `cd gonka`.

## What risks does this introduce? How can we mitigate them?

None. This is a documentation-only change with no runtime behavior impact. The change is
confined to README prose/formatting, so blast radius is a single file.

## How do you know this PR fixes the problem?

Verified the rendered Markdown: the caption now renders as a single italic line, and the
code block now shows a clean, copy-pasteable `cd gonka`. See the before/after diff below.

## Which components are affected?

`README.md` only.

## Testing & evidence

No code paths changed; automated tests are not applicable to this documentation-only change.

```diff
@@ The Task flow caption (line 24)
-*[Work in progress] Diagram 1. The Task flow [Source](docs/papers/InferenceFlow.png)**
+*[Work in progress] Diagram 1. The Task flow [Source](docs/papers/InferenceFlow.png)*

@@ Build the project / clone block (line 52)
 git clone https://github.com/gonka-ai/gonka.git
-cd gonka (or repo name)**
+cd gonka
```
