### PR TITLE
docs: fix stale references in README quickstart and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This section walks you through setting up a local development environment to bui
 #### 1. Environment setup
 Make sure you have the following installed:
 1. Git CLI
-2. Go 1.22.8
+2. Go 1.24.2
 3. Docker Desktop (4.37+)
 4. Make
 5. Java 19+
@@ -63,7 +63,7 @@ This command will build locally, deploy a small network of Docker containers, an
 ```
 make run-tests
 ```
-There’s also an option to just run a Docker local chain, without running the tests, use `launch-local-test-chain-w-reset.sh` script for that. The script will spin up a miniature local chain consisting of 3 participants.
+There’s also an option to just run a Docker local chain, without running the tests, use the `local-test-net/launch.sh` script for that. The script will spin up a miniature local chain consisting of 3 participants.
 
 To run Go unit tests for `chain` node (`inference-chain`)  and `api` node (`decentralized-api`) use `node-test` and `api-test` make targets.
 ## Architectural overview
@@ -97,7 +97,7 @@ The repository is organized as follows:
 /dev_notes          # Chain developer knowledge base
 /docs               # Documentation on specific aspects of the chain
 /inference-chain    # Chain node
-/prepare-local      # Scripts and configs for running local chain
+/local-test-net     # Scripts and configs for running local chain
 /testermint         # Integration tests suite
 ```
 ## Testing


### PR DESCRIPTION
## What problem does this solve?

Three references in the top-level `README.md` "Local Quickstart" and "Repository Layout"
sections point at things that no longer exist or are outdated, which trips up newcomers
following the setup steps.

## How do you know this is a real problem?

- **Line 42** — Environment setup lists `Go 1.22.8`, but both Go modules declare a newer
  minimum: `inference-chain/go.mod` and `decentralized-api/go.mod` both specify `go 1.24.2`.
  Installing 1.22.8 cannot build the modules.
- **Line 66** — instructs running `launch-local-test-chain-w-reset.sh`, but no such file
  exists in the repository (`git grep launch-local-test-chain-w-reset` returns nothing).
  The actual script is `local-test-net/launch.sh`, whose header reads *"runs 1 genesis node,
  which is used as seed node also, and 2 full nodes"* — exactly the "miniature local chain
  consisting of 3 participants" the README describes — and it resets state (`rm -rf prod-local`).
- **Line 100** — the Repository Layout lists `/prepare-local`, which does not exist. The
  directory holding the local-chain scripts and configs is `/local-test-net`.

## How does this solve the problem?

- Line 42: bump the documented Go version to `1.24.2` to match `go.mod`.
- Line 66: point to the real script `local-test-net/launch.sh`.
- Line 100: rename the layout entry `/prepare-local` → `/local-test-net`.

## What risks does this introduce? How can we mitigate them?

None. Documentation-only change with no runtime behavior impact. Blast radius is a single
file (`README.md`); each new reference was verified to exist in the repository.

## How do you know this PR fixes the problem?

Verified each target against the repo: `go.mod` files show `go 1.24.2`; `local-test-net/launch.sh`
exists and matches the "3 participants" description; `/local-test-net` is the real directory while
`/prepare-local` is absent. Rendered Markdown is unchanged in structure (code spans and the layout
block's alignment preserved). See the before/after diff below.

## Which components are affected?

`README.md` only.

## Testing & evidence

No code paths changed; automated tests are not applicable to this documentation-only change.

```diff
@@ Local Quickstart / Environment setup (line 42)
-2. Go 1.22.8
+2. Go 1.24.2

@@ Run local tests (line 66)
-...without running the tests, use `launch-local-test-chain-w-reset.sh` script for that.
+...without running the tests, use the `local-test-net/launch.sh` script for that.

@@ Repository Layout (line 100)
-/prepare-local      # Scripts and configs for running local chain
+/local-test-net     # Scripts and configs for running local chain
```
