### PR TITLE
docs: fix srcipts typo in inference-chain readme

### DIFF
--- a/inference-chain/readme.md
+++ b/inference-chain/readme.md
@@ -16,7 +16,7 @@ make build
 
 set up envs and basic config:
 ```shell
-./srcipts/init-local.sh
+./scripts/init-local.sh
 ```
 
 TODO: run at least genesis node


### PR DESCRIPTION
## What problem does this solve?

A typo in `inference-chain/readme.md` points to a non-existent path `./srcipts/init-local.sh`
in the local setup instructions, so following the doc as written fails.

## How do you know this is a real problem?

Line 19 reads `./srcipts/init-local.sh` ("srcipts" is misspelled). The real script is at
`inference-chain/scripts/init-local.sh` — the directory `inference-chain/scripts/` exists and
contains `init-local.sh`, while no `srcipts/` directory exists. Running the command as written
yields "no such file or directory".

## How does this solve the problem?

Corrects the spelling `srcipts` → `scripts` so the path resolves.

## What risks does this introduce? How can we mitigate them?

None. Documentation-only change with no runtime behavior impact; single-character correction in
one file.

## How do you know this PR fixes the problem?

Verified the corrected path exists in the repo: `inference-chain/scripts/init-local.sh` is
present. See the before/after diff below.

## Which components are affected?

`inference-chain/readme.md` only.

## Testing & evidence

No code paths changed; automated tests are not applicable to this documentation-only change.

```diff
@@ set up envs and basic config (line 19)
-./srcipts/init-local.sh
+./scripts/init-local.sh
```
