### PR TITLE
docs: fix Duing typo in dev_notes build notes

### DIFF
--- a/dev_notes/build.md
+++ b/dev_notes/build.md
@@ -1,7 +1,7 @@
 # Notes on build issues/fixes
 **Issue**
 
-Duing build, something like
+During build, something like
 ```aiignore
 17.20 google.golang.org/protobuf/internal/filedesc: /usr/local/go/pkg/tool/linux_amd64/compile: signal: illegal instruction
 ```


### PR DESCRIPTION
## What problem does this solve?

A typo in `dev_notes/build.md` — "Duing" should be "During" — in the build-issues note.

## How do you know this is a real problem?

Line 4 reads `Duing build, something like`. "Duing" is a misspelling of "During"
(`git grep Duing` returns only this single occurrence).

## How does this solve the problem?

Corrects the spelling `Duing` → `During`.

## What risks does this introduce? How can we mitigate them?

None. Documentation-only change with no runtime behavior impact; single-word correction in one file.

## How do you know this PR fixes the problem?

The word now reads "During". See the before/after diff below.

## Which components are affected?

`dev_notes/build.md` only.

## Testing & evidence

No code paths changed; automated tests are not applicable to this documentation-only change.

```diff
@@ Notes on build issues/fixes (line 4)
-Duing build, something like
+During build, something like
```
