### PR TITLE
Add Testermint upgrade rehearsal workflow

### DIFF
--- a/.github/workflows/testermint-upgrade-rehearsal.yml
+++ b/.github/workflows/testermint-upgrade-rehearsal.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   upgrade-rehearsal:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 240
 
     env:

--- a/.github/workflows/testermint-upgrade-rehearsal.yml
+++ b/.github/workflows/testermint-upgrade-rehearsal.yml
@@ -19,6 +19,10 @@ on:
         type: string
         default: ''
 
+  push:
+    branches:
+      - upgrade-v*
+
 concurrency:
   group: testermint-upgrade-rehearsal-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/testermint-upgrade-rehearsal.yml
+++ b/.github/workflows/testermint-upgrade-rehearsal.yml
@@ -1,0 +1,275 @@
+name: Testermint Upgrade Rehearsal
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_ref:
+        description: 'Candidate ref to test. Defaults to the dispatch ref.'
+        required: false
+        type: string
+        default: ''
+      target_upgrade:
+        description: 'Target upgrade name, e.g. v0.2.14. Defaults to newest semantic UpgradeName.'
+        required: false
+        type: string
+        default: ''
+      previous_release:
+        description: 'Previous canonical release, e.g. release/v0.2.13. Defaults to highest release below target.'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: testermint-upgrade-rehearsal-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+  checks: write
+  actions: read
+
+jobs:
+  upgrade-rehearsal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+
+    env:
+      NEW_DIR: ${{ github.workspace }}/new
+      OLD_DIR: ${{ github.workspace }}/old
+      PREP_MANIFEST: ${{ github.workspace }}/upgrade-rehearsal-manifest.json
+      COMPLETE_MANIFEST: ${{ github.workspace }}/upgrade-rehearsal-completion-manifest.json
+
+    steps:
+      - name: Check initial disk space
+        run: df -h
+
+      - name: Free up runner disk space
+        timeout-minutes: 8
+        run: |
+          set -euo pipefail
+          for path in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL; do
+            if [[ -e "$path" ]]; then
+              echo "Removing $path"
+              timeout 150s sudo rm -rf "$path" || echo "Timed out removing $path; continuing"
+              df -h
+            fi
+          done
+          timeout 120s sudo docker system prune -af --volumes || echo "Docker prune timed out; continuing"
+          sudo apt-get clean
+          df -h
+
+      - name: Checkout candidate
+        uses: actions/checkout@v4
+        with:
+          path: new
+          fetch-depth: 0
+          ref: ${{ inputs.candidate_ref || github.ref }}
+
+      - name: Fetch candidate tags
+        working-directory: new
+        run: git fetch --tags --force
+
+      - name: Resolve rehearsal versions
+        id: versions
+        working-directory: new
+        run: |
+          python3 scripts/upgrade-rehearsal/resolve_versions.py \
+            --repo . \
+            --target-upgrade '${{ inputs.target_upgrade }}' \
+            --previous-release '${{ inputs.previous_release }}'
+
+      - name: Checkout previous release
+        uses: actions/checkout@v4
+        with:
+          path: old
+          fetch-depth: 0
+          ref: ${{ steps.versions.outputs.previous_release }}
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          version: '28.5.2'
+
+      - name: Verify Docker
+        run: |
+          docker --version
+          docker compose version
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make zip unzip jq
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
+
+      - name: Resolve previous production images
+        id: images
+        working-directory: old
+        run: python3 ../new/scripts/upgrade-rehearsal/resolve_previous_images.py --compose deploy/join/docker-compose.yml
+
+      - name: Pull and retag previous images for local Testermint
+        working-directory: ${{ github.workspace }}
+        env:
+          PREVIOUS_NODE_IMAGE: ${{ steps.images.outputs.node_image }}
+          PREVIOUS_API_IMAGE: ${{ steps.images.outputs.api_image }}
+          PREVIOUS_PROXY_IMAGE: ${{ steps.images.outputs.proxy_image }}
+          PREVIOUS_VERSIOND_IMAGE: ${{ steps.images.outputs.versiond_image }}
+          TARGET_NODE_IMAGE: ${{ steps.images.outputs.node_target_image }}
+          TARGET_API_IMAGE: ${{ steps.images.outputs.api_target_image }}
+          TARGET_PROXY_IMAGE: ${{ steps.images.outputs.proxy_target_image }}
+          TARGET_VERSIOND_IMAGE: ${{ steps.images.outputs.versiond_target_image }}
+        run: ./new/scripts/upgrade-rehearsal/prepare_previous_images.sh
+
+      - name: Build previous mock-server image
+        working-directory: old
+        run: make mock-server-build-docker
+
+      - name: Apply old-checkout prep test patch
+        working-directory: old
+        run: git apply ../new/testermint/upgrade-rehearsal/previous-release-prep.patch
+
+      - name: Run old-checkout prep test
+        timeout-minutes: 75
+        working-directory: old/testermint
+        env:
+          GONKA_REPO_ROOT: ${{ env.OLD_DIR }}
+          PREVIOUS_RELEASE: ${{ steps.versions.outputs.previous_release }}
+          UPGRADE_REHEARSAL_MANIFEST: ${{ env.PREP_MANIFEST }}
+        run: |
+          sudo -E ./gradlew test \
+            --tests "UpgradeRehearsalPrepTests.prepare upgrade rehearsal state" \
+            -x mock_server:test \
+            --stacktrace
+
+      - name: Build candidate upgrade archives
+        timeout-minutes: 90
+        working-directory: new
+        env:
+          # The default GitHub runner Docker driver cannot export registry
+          # caches. Keep this deterministic over fast; the rehearsal is already
+          # expensive and cache writes are not part of what it proves.
+          USE_REGISTRY_CACHE: '0'
+          VERSION: ${{ steps.versions.outputs.target_upgrade }}
+        run: |
+          make build-for-upgrade
+          sudo chown -R "$USER:$USER" public-html || true
+          find public-html -maxdepth 4 -type f -print
+
+      - name: Serve candidate upgrade archives on chain-public
+        working-directory: ${{ github.workspace }}
+        run: |
+          docker rm -f upgrade-binary-server || true
+          docker run -d \
+            --name upgrade-binary-server \
+            --network chain-public \
+            -v "${NEW_DIR}/public-html:/usr/local/apache2/htdocs:ro" \
+            httpd:2.4
+          docker run --rm --network chain-public curlimages/curl:8.11.1 \
+            -fsS http://upgrade-binary-server/v2/inferenced/inferenced-amd64.zip >/dev/null
+          docker run --rm --network chain-public curlimages/curl:8.11.1 \
+            -fsS http://upgrade-binary-server/v2/dapi/decentralized-api-amd64.zip >/dev/null
+
+      - name: Run current-checkout upgrade completion test
+        working-directory: new/testermint
+        env:
+          GONKA_REPO_ROOT: ${{ env.NEW_DIR }}
+          UPGRADE_REHEARSAL_TARGET: ${{ steps.versions.outputs.target_upgrade }}
+          UPGRADE_REHEARSAL_MANIFEST: ${{ env.PREP_MANIFEST }}
+          UPGRADE_REHEARSAL_COMPLETE_MANIFEST: ${{ env.COMPLETE_MANIFEST }}
+          UPGRADE_BINARY_BASE_URL: http://upgrade-binary-server
+        run: |
+          sudo -E ./gradlew test \
+            --tests "UpgradeRehearsalTests.complete upgrade rehearsal" \
+            -x mock_server:test \
+            --stacktrace
+
+      - name: Capture Docker state
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir -p upgrade-rehearsal-diagnostics
+          docker ps -a > upgrade-rehearsal-diagnostics/docker-ps.txt
+          docker images > upgrade-rehearsal-diagnostics/docker-images.txt
+          for container in genesis-node genesis-api join1-node join1-api join2-node join2-api upgrade-binary-server; do
+            docker logs "$container" --tail 300 > "upgrade-rehearsal-diagnostics/${container}.log" 2>&1 || true
+          done
+
+      - name: Upload rehearsal artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: testermint-upgrade-rehearsal-artifacts
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            upgrade-rehearsal-manifest.json
+            upgrade-rehearsal-completion-manifest.json
+            upgrade-rehearsal-diagnostics/
+            old/testermint/logs/
+            old/testermint/build/test-results/**/*.xml
+            new/testermint/logs/
+            new/testermint/build/test-results/**/*.xml
+
+      - name: Publish old prep test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        continue-on-error: true
+        with:
+          name: Upgrade Rehearsal Prep
+          path: old/testermint/build/test-results/**/*.xml
+          reporter: java-junit
+          fail-on-error: false
+
+      - name: Publish completion test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        continue-on-error: true
+        with:
+          name: Upgrade Rehearsal Completion
+          path: new/testermint/build/test-results/**/*.xml
+          reporter: java-junit
+          fail-on-error: false
+
+      - name: Write workflow summary
+        if: always()
+        run: |
+          {
+            echo "# Testermint Upgrade Rehearsal"
+            echo
+            echo "- Target upgrade: ${{ steps.versions.outputs.target_upgrade }}"
+            echo "- Previous release: ${{ steps.versions.outputs.previous_release }}"
+            echo "- Previous node image: ${{ steps.images.outputs.node_image }}"
+            echo "- Previous API image: ${{ steps.images.outputs.api_image }}"
+            echo
+            if [[ -f "${PREP_MANIFEST}" ]]; then
+              echo "## Prep Manifest"
+              echo '```json'
+              cat "${PREP_MANIFEST}"
+              echo
+              echo '```'
+            fi
+            if [[ -f "${COMPLETE_MANIFEST}" ]]; then
+              echo "## Completion Manifest"
+              echo '```json'
+              cat "${COMPLETE_MANIFEST}"
+              echo
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/testermint-upgrade-rehearsal.md
+++ b/docs/testermint-upgrade-rehearsal.md
@@ -45,6 +45,20 @@ The workflow applies that patch to the old checkout before running the prep test
 
 The workflow must not tear the cluster down after this phase. The live Docker containers and volumes are the upgrade subject.
 
+### Maintaining The Prep Patch
+
+`previous-release-prep.patch` is intentionally version-coupled to the previous release's Testermint harness. When the previous canonical release changes, refresh the patch against that release instead of assuming the old patch still applies.
+
+Recommended refresh loop:
+
+1. Check out the new previous release tag in a scratch worktree, for example `git worktree add /tmp/gonka-prev release/v0.2.14`.
+2. Add or update `testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt` in that scratch checkout.
+3. Run the prep test locally or in a temporary workflow run until it creates the expected manifest and leaves the cluster running.
+4. From the scratch checkout, regenerate the patch with `git diff -- testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt > /path/to/current/testermint/upgrade-rehearsal/previous-release-prep.patch`.
+5. Re-run `testermint-upgrade-rehearsal.yml` with explicit `target_upgrade` and `previous_release` overrides before relying on the default discovery path.
+
+Keep the patch narrow. It should add only the old-checkout prep test and should not alter cluster teardown, Docker image naming, or production chain code in the old release.
+
 ## Phase 2: Build Candidate Upgrade Archives
 
 The candidate checkout builds the upgrade archives with:

--- a/docs/testermint-upgrade-rehearsal.md
+++ b/docs/testermint-upgrade-rehearsal.md
@@ -42,7 +42,7 @@ The workflow applies that patch to the old checkout before running the prep test
 - runs a normal inference;
 - creates and settles a devshard escrow;
 - waits into another epoch;
-- writes an upgrade rehearsal manifest with heights, epoch indexes, participant ids, inference id, and devshard escrow id.
+- writes an upgrade rehearsal manifest with heights, epoch indexes, participant ids, baseline participant weights, inference id, and devshard escrow id.
 
 The workflow must not tear the cluster down after this phase. The live Docker containers and volumes are the upgrade subject.
 
@@ -96,7 +96,7 @@ The attach test:
 
 By default, the power-stability check allows at most a 50% per-miner and total-power change across that post-upgrade PoC cycle. Use `UPGRADE_REHEARSAL_MAX_POWER_CHANGE_PERCENT` only for debugging a known intentional power-model change; do not loosen it to hide unexpected miner removal or cPoC fallout.
 
-The completion manifest records the post-upgrade PoC start block, `SET_NEW_VALIDATORS` block, before/after epoch ids, and miner weights so a failed or suspicious run can be compared without replaying the full logs first.
+The completion manifest records the post-upgrade PoC start block, `SET_NEW_VALIDATORS` block, pre-upgrade baseline epoch/weights, and post-upgrade epoch/weights so a failed or suspicious run can be compared without replaying the full logs first.
 
 ## Running In GitHub Actions
 

--- a/docs/testermint-upgrade-rehearsal.md
+++ b/docs/testermint-upgrade-rehearsal.md
@@ -1,0 +1,128 @@
+# Testermint Upgrade Rehearsal
+
+This workflow tests an actual local software upgrade before we spend Testnet time on it. It starts a Testermint cluster from the previous production release, creates meaningful pre-upgrade state, then upgrades the still-running cluster with binaries built from the candidate branch.
+
+The rehearsal is intentionally separate from the normal integration matrix. It needs two repository checkouts, two versions of the Testermint harness, and live Docker state that must survive between phases.
+
+## What It Proves
+
+- The previous release can still boot in the current CI environment using the production images declared by that release.
+- The previous release's own Testermint harness can create realistic pre-upgrade state.
+- The candidate branch can submit a real Cosmos SDK software-upgrade proposal against that existing cluster.
+- Cosmovisor downloads and installs the candidate `inferenced` and `decentralized-api` upgrade archives.
+- The chain resumes block production after the upgrade and records the expected `last-upgrade-height`.
+- Normal inference and devshard settlement still work after the upgrade.
+
+## Version And Image Discovery
+
+The workflow treats deploy scripts as the canonical source for production image references.
+
+1. The target upgrade defaults to the newest semantic `UpgradeName` found under `inference-chain/app/upgrades/*/constants.go` in the candidate checkout.
+2. The previous release defaults to the highest canonical release tag below that target, where canonical means `release/vX.Y.Z`.
+3. Suffix tags such as `release/v0.2.13-testnet-3`, `release/v0.2.13-testnet-rehearsal-1`, or ad hoc tags are ignored.
+4. The old checkout is made at that previous release tag.
+5. Previous production image refs are read from the old checkout's `deploy/join/docker-compose.yml`.
+6. Those production images are pulled and retagged to the local Testermint image names, such as `ghcr.io/product-science/inferenced`, `ghcr.io/product-science/api`, and `ghcr.io/product-science/proxy:latest`.
+
+Manual workflow inputs can override the target upgrade or previous release when debugging a non-standard branch.
+
+## Phase 1: Prepare Old State
+
+The old release checkout runs the old release's Testermint harness against the previous production images.
+
+Because old release tags are immutable, the candidate branch stores a small patch at:
+
+`testermint/upgrade-rehearsal/previous-release-prep.patch`
+
+The workflow applies that patch to the old checkout before running the prep test. The patched test:
+
+- boots the old cluster from scratch;
+- waits through an epoch;
+- runs a normal inference;
+- creates and settles a devshard escrow;
+- waits into another epoch;
+- writes an upgrade rehearsal manifest with heights, epoch indexes, participant ids, inference id, and devshard escrow id.
+
+The workflow must not tear the cluster down after this phase. The live Docker containers and volumes are the upgrade subject.
+
+## Phase 2: Build Candidate Upgrade Archives
+
+The candidate checkout builds the upgrade archives with:
+
+`make build-for-upgrade`
+
+The generated archives live under:
+
+- `public-html/v2/inferenced/inferenced-amd64.zip`
+- `public-html/v2/dapi/decentralized-api-amd64.zip`
+
+The workflow starts a small HTTP container on the `chain-public` Docker network and serves `public-html` to the old cluster. The current Testermint attach test computes SHA-256 checksums locally and includes them in the upgrade URLs.
+
+Do not use `make build-for-upgrade-tests` for this rehearsal. That target builds `inferenced` with the `upgraded` build tag, which swaps in the synthetic `v0.0.1test` handler and omits release handlers such as `v0.2.14`. This workflow is meant to exercise production-style release archives.
+
+## Phase 3: Complete The Upgrade
+
+The current checkout runs an attach-only Testermint test. This is the most important safety rule: phase 2 must discover the existing cluster and must not call the normal cluster setup path that can rebuild Docker state.
+
+The attach test:
+
+- reads the phase 1 manifest and asserts that meaningful old state exists;
+- attaches to `genesis`, `join1`, and `join2` containers by local Testermint image/name conventions;
+- submits a software-upgrade proposal whose title matches the target `UpgradeName`;
+- deposits and votes;
+- waits for the upgrade height and cosmovisor restart;
+- verifies `last-upgrade-height` on every node after the candidate binary is running;
+- verifies basic API/node health;
+- runs a post-upgrade normal inference;
+- enables devshard request handling with a governance params proposal if the upgraded chain reports it disabled;
+- creates and settles a post-upgrade devshard escrow.
+
+## Running In GitHub Actions
+
+Use the dedicated workflow:
+
+`testermint-upgrade-rehearsal.yml`
+
+Typical manual run:
+
+```bash
+gh workflow run testermint-upgrade-rehearsal.yml --ref <candidate-ref>
+```
+
+Useful debug overrides:
+
+```bash
+gh workflow run testermint-upgrade-rehearsal.yml \
+  --ref <candidate-ref> \
+  -f target_upgrade=v0.2.14 \
+  -f previous_release=release/v0.2.13
+```
+
+The workflow uploads:
+
+- old and new Testermint logs;
+- old and new JUnit XML;
+- the prep and completion manifests;
+- a Docker state snapshot from the runner.
+
+The first live `v0.2.13` to `v0.2.14` rehearsal prep run completed in about 19 minutes and produced old-chain state across heights 76 to 198 and epochs 2 to 5. Treat a quiet prep step as normal while it is still within its workflow timeout.
+
+## Common Failures
+
+If previous image resolution fails, inspect the old tag's `deploy/join/docker-compose.yml`. The parser expects a service-level `image:` entry for at least `node` and `api`.
+
+If phase 1 fails before booting, confirm the old production images are still pullable from GHCR and that the retagged image names match local Testermint compose files.
+
+If the candidate archive build fails with `Cache export is not supported for the docker driver`, keep `USE_REGISTRY_CACHE=0` for this workflow or add an explicit Docker Buildx container-driver setup plus package write permissions. The rehearsal does not need to publish registry build caches.
+
+If the completion test fails on `last-upgrade-height` before submitting the proposal, make sure it is not querying candidate-only CLI commands against the previous release binary. Pre-upgrade assertions should rely on the prep manifest and old-chain health; `last-upgrade-height` is only meaningful after the candidate upgrade has applied.
+
+If phase 2 rebuilds the cluster, that is a bug. The current rehearsal test should only call attach/discovery helpers and should never call `initCluster`, `setupLocalCluster`, `launch.sh`, or `stop-rebuild.sh`.
+
+If the proposal passes but the chain never resumes, inspect node logs around the upgrade height. The most useful signals are cosmovisor download errors, checksum mismatches, missing upgrade handler names, or archive layout issues.
+
+If the node downloads the candidate binary and restarts, but the new binary still halts with `UPGRADE "<target>" NEEDED`, first confirm the candidate archive was built with `make build-for-upgrade` and not the test-only target. A test-tagged binary will not register normal release upgrade handlers.
+
+If post-upgrade inference fails with versioned endpoint routing, check that the test stubs mock-server responses for the target upgrade segment as well as the default segment.
+
+If post-upgrade devshard settlement fails with `devshard completion and timeout requests are disabled`, query inference params and confirm `devshard_escrow_params.devshard_requests_enabled` is true. The rehearsal completion test enables this through a normal governance params proposal because older state or operational settings can carry a disabled value across the upgrade. When building that params proposal, preserve the existing `devshard_escrow_params.max_nonce` value, or repair a missing/zero value to the chain default, because a full `MsgUpdateParams` proposal with `max_nonce: 0` is rejected during proposal validation.

--- a/docs/testermint-upgrade-rehearsal.md
+++ b/docs/testermint-upgrade-rehearsal.md
@@ -11,6 +11,7 @@ The rehearsal is intentionally separate from the normal integration matrix. It n
 - The candidate branch can submit a real Cosmos SDK software-upgrade proposal against that existing cluster.
 - Cosmovisor downloads and installs the candidate `inferenced` and `decentralized-api` upgrade archives.
 - The chain resumes block production after the upgrade and records the expected `last-upgrade-height`.
+- The upgraded chain completes a new epoch/PoC cycle with the prepared miners still active and with no dramatic miner-power shift.
 - Normal inference and devshard settlement still work after the upgrade.
 
 ## Version And Image Discovery
@@ -87,9 +88,15 @@ The attach test:
 - waits for the upgrade height and cosmovisor restart;
 - verifies `last-upgrade-height` on every node after the candidate binary is running;
 - verifies basic API/node health;
+- waits for a post-upgrade `START_OF_POC` and then the matching `SET_NEW_VALIDATORS` stage so a full candidate-binary PoC cycle has completed;
+- verifies every prepared miner is still active, not excluded, has non-zero PoC power, and has no dramatic power change compared with the pre-PoC post-upgrade snapshot;
 - runs a post-upgrade normal inference;
 - enables devshard request handling with a governance params proposal if the upgraded chain reports it disabled;
 - creates and settles a post-upgrade devshard escrow.
+
+By default, the power-stability check allows at most a 50% per-miner and total-power change across that post-upgrade PoC cycle. Use `UPGRADE_REHEARSAL_MAX_POWER_CHANGE_PERCENT` only for debugging a known intentional power-model change; do not loosen it to hide unexpected miner removal or cPoC fallout.
+
+The completion manifest records the post-upgrade PoC start block, `SET_NEW_VALIDATORS` block, before/after epoch ids, and miner weights so a failed or suspicious run can be compared without replaying the full logs first.
 
 ## Running In GitHub Actions
 
@@ -138,5 +145,7 @@ If the proposal passes but the chain never resumes, inspect node logs around the
 If the node downloads the candidate binary and restarts, but the new binary still halts with `UPGRADE "<target>" NEEDED`, first confirm the candidate archive was built with `make build-for-upgrade` and not the test-only target. A test-tagged binary will not register normal release upgrade handlers.
 
 If post-upgrade inference fails with versioned endpoint routing, check that the test stubs mock-server responses for the target upgrade segment as well as the default segment.
+
+If the post-upgrade PoC/power check fails, inspect whether the prepared miners disappeared from active participants, appeared in `excluded_participants`, reported zero PoC weight, or crossed the configured power-change threshold. This check is meant to catch upgrades that technically resume blocks but break the next epoch's miner set or cPoC/PoC accounting.
 
 If post-upgrade devshard settlement fails with `devshard completion and timeout requests are disabled`, query inference params and confirm `devshard_escrow_params.devshard_requests_enabled` is true. The rehearsal completion test enables this through a normal governance params proposal because older state or operational settings can carry a disabled value across the upgrade. When building that params proposal, preserve the existing `devshard_escrow_params.max_nonce` value, or repair a missing/zero value to the chain default, because a full `MsgUpdateParams` proposal with `max_nonce: 0` is rejected during proposal validation.

--- a/docs/testermint-upgrade-rehearsal.md
+++ b/docs/testermint-upgrade-rehearsal.md
@@ -88,15 +88,15 @@ The attach test:
 - waits for the upgrade height and cosmovisor restart;
 - verifies `last-upgrade-height` on every node after the candidate binary is running;
 - verifies basic API/node health;
-- waits for a post-upgrade `START_OF_POC` and then the matching `SET_NEW_VALIDATORS` stage so a full candidate-binary PoC cycle has completed;
-- verifies every prepared miner is still active, not excluded, has non-zero PoC power, and has no dramatic power change compared with the pre-PoC post-upgrade snapshot;
+- waits for a post-upgrade `START_OF_POC`, the matching `SET_NEW_VALIDATORS` stage, and then `CLAIM_REWARDS` so the candidate binary has completed PoC and crossed into the new epoch flow;
+- verifies every prepared miner is still active, not excluded, has non-zero PoC power, and has no dramatic power change after both `SET_NEW_VALIDATORS` and `CLAIM_REWARDS`;
 - runs a post-upgrade normal inference;
 - enables devshard request handling with a governance params proposal if the upgraded chain reports it disabled;
 - creates and settles a post-upgrade devshard escrow.
 
 By default, the power-stability check allows at most a 50% per-miner and total-power change across that post-upgrade PoC cycle. Use `UPGRADE_REHEARSAL_MAX_POWER_CHANGE_PERCENT` only for debugging a known intentional power-model change; do not loosen it to hide unexpected miner removal or cPoC fallout.
 
-The completion manifest records the post-upgrade PoC start block, `SET_NEW_VALIDATORS` block, pre-upgrade baseline epoch/weights, and post-upgrade epoch/weights so a failed or suspicious run can be compared without replaying the full logs first.
+The completion manifest records the post-upgrade PoC start block, `SET_NEW_VALIDATORS` block, `CLAIM_REWARDS` block, pre-upgrade baseline epoch/weights, post-PoC epoch/weights, and new-epoch weights so a failed or suspicious run can be compared without replaying the full logs first.
 
 ## Running In GitHub Actions
 
@@ -146,6 +146,6 @@ If the node downloads the candidate binary and restarts, but the new binary stil
 
 If post-upgrade inference fails with versioned endpoint routing, check that the test stubs mock-server responses for the target upgrade segment as well as the default segment.
 
-If the post-upgrade PoC/power check fails, inspect whether the prepared miners disappeared from active participants, appeared in `excluded_participants`, reported zero PoC weight, or crossed the configured power-change threshold. This check is meant to catch upgrades that technically resume blocks but break the next epoch's miner set or cPoC/PoC accounting.
+If the post-upgrade PoC/power check fails, inspect whether the prepared miners disappeared from active participants, appeared in `excluded_participants`, reported zero PoC weight, failed to remain available after `CLAIM_REWARDS`, or crossed the configured power-change threshold. This check is meant to catch upgrades that technically resume blocks but break the next epoch's miner set or cPoC/PoC accounting.
 
 If post-upgrade devshard settlement fails with `devshard completion and timeout requests are disabled`, query inference params and confirm `devshard_escrow_params.devshard_requests_enabled` is true. The rehearsal completion test enables this through a normal governance params proposal because older state or operational settings can carry a disabled value across the upgrade. When building that params proposal, preserve the existing `devshard_escrow_params.max_nonce` value, or repair a missing/zero value to the chain default, because a full `MsgUpdateParams` proposal with `max_nonce: 0` is rejected during proposal validation.

--- a/scripts/upgrade-rehearsal/prepare_previous_images.sh
+++ b/scripts/upgrade-rehearsal/prepare_previous_images.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pull_and_tag() {
+  local source_image="$1"
+  local target_image="$2"
+
+  if [[ -z "${source_image}" || -z "${target_image}" ]]; then
+    return 0
+  fi
+
+  echo "Pulling ${source_image}"
+  docker pull "${source_image}"
+  echo "Tagging ${source_image} as ${target_image}"
+  docker tag "${source_image}" "${target_image}"
+}
+
+pull_and_tag "${PREVIOUS_NODE_IMAGE:-}" "${TARGET_NODE_IMAGE:-ghcr.io/product-science/inferenced}"
+pull_and_tag "${PREVIOUS_API_IMAGE:-}" "${TARGET_API_IMAGE:-ghcr.io/product-science/api}"
+pull_and_tag "${PREVIOUS_PROXY_IMAGE:-}" "${TARGET_PROXY_IMAGE:-ghcr.io/product-science/proxy:latest}"
+pull_and_tag "${PREVIOUS_VERSIOND_IMAGE:-}" "${TARGET_VERSIOND_IMAGE:-versiond:latest}"
+
+echo "Prepared previous release images:"
+docker images | grep -E 'product-science/(inferenced|api|proxy)|versiond' || true

--- a/scripts/upgrade-rehearsal/resolve_previous_images.py
+++ b/scripts/upgrade-rehearsal/resolve_previous_images.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Read production image references from a previous release deploy compose file."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from pathlib import Path
+
+
+SERVICE_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$")
+IMAGE_RE = re.compile(r"^\s+image:\s*([^#\s]+)")
+
+LOCAL_TARGETS = {
+    "node": "ghcr.io/product-science/inferenced",
+    "api": "ghcr.io/product-science/api",
+    "proxy": "ghcr.io/product-science/proxy:latest",
+    "versiond": "versiond:latest",
+}
+
+
+def parse_service_images(compose_file: Path) -> dict[str, str]:
+    images: dict[str, str] = {}
+    current_service: str | None = None
+    for raw_line in compose_file.read_text().splitlines():
+        service_match = SERVICE_RE.match(raw_line)
+        if service_match:
+            current_service = service_match.group(1)
+            continue
+
+        image_match = IMAGE_RE.match(raw_line)
+        if image_match and current_service:
+            images[current_service] = image_match.group(1).strip()
+
+    return images
+
+
+def write_outputs(values: dict[str, str]) -> None:
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a", encoding="utf-8") as handle:
+            for key, value in values.items():
+                handle.write(f"{key}={value}\n")
+
+    for key, value in values.items():
+        print(f"{key}={value}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compose", required=True, help="path to previous release deploy/join/docker-compose.yml")
+    args = parser.parse_args()
+
+    compose_file = Path(args.compose).resolve()
+    images = parse_service_images(compose_file)
+
+    missing = [service for service in ("node", "api") if service not in images]
+    if missing:
+        raise RuntimeError(f"missing required service image(s) in {compose_file}: {', '.join(missing)}")
+
+    outputs: dict[str, str] = {}
+    for service, target in LOCAL_TARGETS.items():
+        image = images.get(service, "")
+        outputs[f"{service}_image"] = image
+        outputs[f"{service}_target_image"] = target
+
+    write_outputs(outputs)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upgrade-rehearsal/resolve_versions.py
+++ b/scripts/upgrade-rehearsal/resolve_versions.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Resolve the target upgrade and previous canonical release tag."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+CANONICAL_RELEASE_RE = re.compile(r"^release/v(\d+)\.(\d+)\.(\d+)$")
+UPGRADE_NAME_RE = re.compile(r'UpgradeName\s*=\s*"([^"]+)"')
+
+
+@dataclass(frozen=True, order=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, value: str) -> "SemVer":
+        match = SEMVER_RE.match(value)
+        if not match:
+            raise ValueError(f"not a semantic version: {value}")
+        return cls(*(int(part) for part in match.groups()))
+
+    def with_v(self) -> str:
+        return f"v{self.major}.{self.minor}.{self.patch}"
+
+    def without_v(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+def run_git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def normalize_upgrade(value: str) -> tuple[str, SemVer]:
+    cleaned = value.strip()
+    if cleaned.startswith("release/"):
+        cleaned = cleaned[len("release/") :]
+    version = SemVer.parse(cleaned)
+    return version.with_v(), version
+
+
+def normalize_release(value: str) -> tuple[str, SemVer]:
+    cleaned = value.strip()
+    if cleaned.startswith("release/"):
+        cleaned = cleaned[len("release/") :]
+    upgrade, version = normalize_upgrade(cleaned)
+    return f"release/{upgrade}", version
+
+
+def discover_target_upgrade(repo: Path) -> tuple[str, SemVer]:
+    candidates: list[tuple[SemVer, str, Path]] = []
+    upgrades_dir = repo / "inference-chain" / "app" / "upgrades"
+    for constants_file in upgrades_dir.glob("*/constants.go"):
+        text = constants_file.read_text()
+        match = UPGRADE_NAME_RE.search(text)
+        if not match:
+            continue
+        name = match.group(1)
+        try:
+            upgrade, version = normalize_upgrade(name)
+        except ValueError:
+            continue
+        candidates.append((version, upgrade, constants_file))
+
+    if not candidates:
+        raise RuntimeError(f"no semantic UpgradeName constants found under {upgrades_dir}")
+
+    _, upgrade, source = max(candidates, key=lambda item: item[0])
+    print(f"Discovered target upgrade {upgrade} from {source}", file=sys.stderr)
+    return normalize_upgrade(upgrade)
+
+
+def canonical_release_tags(repo: Path) -> list[tuple[SemVer, str]]:
+    tags = run_git(repo, "tag", "--list", "release/v*").splitlines()
+    releases: list[tuple[SemVer, str]] = []
+    for tag in tags:
+        match = CANONICAL_RELEASE_RE.match(tag)
+        if not match:
+            continue
+        version = SemVer(*(int(part) for part in match.groups()))
+        releases.append((version, tag))
+    return sorted(releases)
+
+
+def write_outputs(values: dict[str, str]) -> None:
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a", encoding="utf-8") as handle:
+            for key, value in values.items():
+                handle.write(f"{key}={value}\n")
+
+    for key, value in values.items():
+        print(f"{key}={value}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=".", help="candidate repository checkout")
+    parser.add_argument("--target-upgrade", default="", help="override target upgrade, e.g. v0.2.14")
+    parser.add_argument("--previous-release", default="", help="override previous release, e.g. release/v0.2.13")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    if args.target_upgrade.strip():
+        target_upgrade, target_version = normalize_upgrade(args.target_upgrade)
+    else:
+        target_upgrade, target_version = discover_target_upgrade(repo)
+
+    if args.previous_release.strip():
+        previous_release, previous_version = normalize_release(args.previous_release)
+    else:
+        candidates = [
+            (version, tag)
+            for version, tag in canonical_release_tags(repo)
+            if version < target_version
+        ]
+        if not candidates:
+            raise RuntimeError(f"no canonical release tag found before {target_upgrade}")
+        previous_version, previous_release = candidates[-1]
+
+    if previous_version >= target_version:
+        raise RuntimeError(
+            f"previous release {previous_release} must be lower than target upgrade {target_upgrade}"
+        )
+
+    write_outputs(
+        {
+            "target_upgrade": target_upgrade,
+            "target_version": target_version.without_v(),
+            "target_release": f"release/{target_upgrade}",
+            "previous_upgrade": previous_version.with_v(),
+            "previous_version": previous_version.without_v(),
+            "previous_release": previous_release,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/testermint/src/main/kotlin/data/AppExport.kt
+++ b/testermint/src/main/kotlin/data/AppExport.kt
@@ -302,6 +302,8 @@ data class DevshardEscrowParams(
     val approvedVersions: List<DevshardApprovedVersion>? = emptyList(),
     @SerializedName("max_nonce")
     val maxNonce: Long = 0,
+    @SerializedName("devshard_requests_enabled")
+    val devshardRequestsEnabled: Boolean? = null,
 )
 
 data class PocParams(

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -143,11 +143,11 @@ class UpgradeRehearsalTests : TestermintTest() {
         val participantIds = manifest.getAsJsonArray("participantIds").map { it.asString }
         assertThat(participantIds).describedAs("prepared participant ids").isNotEmpty()
 
-        val before = capturePocPowerSnapshot(genesis, participantIds, "before post-upgrade PoC")
+        val before = prepPocPowerSnapshot(manifest, participantIds)
         val pocStart = genesis.waitForStage(EpochStage.START_OF_POC, offset = 1)
         val setNewValidators = genesis.waitForStage(EpochStage.SET_NEW_VALIDATORS, offset = 2)
         waitForClusterOperational(cluster, genesis)
-        val after = capturePocPowerSnapshot(genesis, participantIds, "after post-upgrade PoC")
+        val after = captureActivePocPowerSnapshot(genesis, participantIds, "after post-upgrade PoC")
 
         assertThat(after.epochId)
             .describedAs("post-upgrade PoC should advance the active participant epoch")
@@ -164,7 +164,33 @@ class UpgradeRehearsalTests : TestermintTest() {
         )
     }
 
-    private fun capturePocPowerSnapshot(
+    private fun prepPocPowerSnapshot(manifest: JsonObject, participantIds: List<String>): PocPowerSnapshot {
+        val weightsObject = manifest.getAsJsonObject("participantWeights")
+        val weights = participantIds.associateWith { participantId ->
+            require(weightsObject.has(participantId)) {
+                "Prepared manifest is missing PoC weight for participant $participantId"
+            }
+            weightsObject.get(participantId).asLong
+        }
+        weights.forEach { (participantId, weight) ->
+            assertThat(weight)
+                .describedAs("prepared participant $participantId PoC power")
+                .isPositive()
+        }
+
+        Logger.info(
+            "prepared pre-upgrade PoC power snapshot: epoch={}, weights={}",
+            manifest.get("finalEpoch").asLong,
+            weights,
+        )
+
+        return PocPowerSnapshot(
+            epochId = manifest.get("finalEpoch").asLong,
+            weights = weights,
+        )
+    }
+
+    private fun captureActivePocPowerSnapshot(
         genesis: LocalInferencePair,
         participantIds: List<String>,
         label: String,
@@ -290,6 +316,7 @@ class UpgradeRehearsalTests : TestermintTest() {
         assertThat(manifest.get("devshardEscrowId").asLong).isGreaterThan(0)
         assertThat(manifest.get("devshardRequests").asInt).isGreaterThan(0)
         assertThat(manifest.getAsJsonArray("participantIds")).isNotEmpty()
+        assertThat(manifest.getAsJsonObject("participantWeights").entrySet()).isNotEmpty()
         assertThat(manifest.get("finalHeight").asLong).isGreaterThan(manifest.get("startingHeight").asLong)
     }
 

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -16,6 +16,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertNotNull
 
+@Tag("exclude")
 class UpgradeRehearsalTests : TestermintTest() {
     private val defaultDevshardMaxNonce = 20_000L
 

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -184,19 +184,16 @@ class UpgradeRehearsalTests : TestermintTest() {
             ?.let(::File)
             ?: File(manifestFile().parentFile, "completion-manifest.json")
         output.parentFile.mkdirs()
-        output.writeText(
-            """
-                {
-                  "schema": 1,
-                  "phase": "completed",
-                  "completedAt": "${escapeJson(Instant.now().toString())}",
-                  "targetUpgrade": "${escapeJson(targetUpgrade)}",
-                  "upgradeHeight": $upgradeHeight,
-                  "postUpgradeInferenceId": "${escapeJson(postInferenceId)}",
-                  "postUpgradeDevshardEscrowId": $postDevshardEscrowId
-                }
-            """.trimIndent()
+        val manifest = mapOf(
+            "schema" to 1,
+            "phase" to "completed",
+            "completedAt" to Instant.now().toString(),
+            "targetUpgrade" to targetUpgrade,
+            "upgradeHeight" to upgradeHeight,
+            "postUpgradeInferenceId" to postInferenceId,
+            "postUpgradeDevshardEscrowId" to postDevshardEscrowId,
         )
+        output.writeText(cosmosJson.toJson(manifest))
         Logger.info("Wrote upgrade rehearsal completion manifest to {}", output.absolutePath)
     }
 
@@ -356,11 +353,4 @@ class UpgradeRehearsalTests : TestermintTest() {
     private fun requiredEnv(name: String): String =
         System.getenv(name)?.takeIf { it.isNotBlank() }
             ?: error("Required environment variable $name is not set")
-
-    private fun escapeJson(value: String): String =
-        value
-            .replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
 }

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -129,10 +129,13 @@ class UpgradeRehearsalTests : TestermintTest() {
     private data class PostUpgradePocResult(
         val beforeEpochId: Long,
         val afterEpochId: Long,
+        val newEpochId: Long,
         val pocStartBlock: Long,
         val setNewValidatorsBlock: Long,
+        val claimRewardsBlock: Long,
         val beforeWeights: Map<String, Long>,
         val afterWeights: Map<String, Long>,
+        val newEpochWeights: Map<String, Long>,
     )
 
     private fun assertPostUpgradePocSucceeded(
@@ -154,13 +157,24 @@ class UpgradeRehearsalTests : TestermintTest() {
             .isGreaterThan(before.epochId)
         assertMinerPowerStable(before, after)
 
+        val claimRewards = genesis.waitForStage(EpochStage.CLAIM_REWARDS, offset = 2)
+        waitForClusterOperational(cluster, genesis)
+        val newEpoch = captureActivePocPowerSnapshot(genesis, participantIds, "after post-upgrade new epoch")
+        assertThat(newEpoch.epochId)
+            .describedAs("post-upgrade active participant epoch should remain advanced after CLAIM_REWARDS")
+            .isGreaterThanOrEqualTo(after.epochId)
+        assertMinerPowerStable(before, newEpoch)
+
         return PostUpgradePocResult(
             beforeEpochId = before.epochId,
             afterEpochId = after.epochId,
+            newEpochId = newEpoch.epochId,
             pocStartBlock = pocStart.stageBlock,
             setNewValidatorsBlock = setNewValidators.stageBlock,
+            claimRewardsBlock = claimRewards.stageBlock,
             beforeWeights = before.weights,
             afterWeights = after.weights,
+            newEpochWeights = newEpoch.weights,
         )
     }
 
@@ -354,10 +368,13 @@ class UpgradeRehearsalTests : TestermintTest() {
             "postUpgradeDevshardEscrowId" to postDevshardEscrowId,
             "postUpgradePocBeforeEpoch" to postUpgradePocResult.beforeEpochId,
             "postUpgradePocAfterEpoch" to postUpgradePocResult.afterEpochId,
+            "postUpgradeNewEpoch" to postUpgradePocResult.newEpochId,
             "postUpgradePocStartBlock" to postUpgradePocResult.pocStartBlock,
             "postUpgradeSetNewValidatorsBlock" to postUpgradePocResult.setNewValidatorsBlock,
+            "postUpgradeClaimRewardsBlock" to postUpgradePocResult.claimRewardsBlock,
             "postUpgradePocBeforeWeights" to postUpgradePocResult.beforeWeights,
             "postUpgradePocAfterWeights" to postUpgradePocResult.afterWeights,
+            "postUpgradeNewEpochWeights" to postUpgradePocResult.newEpochWeights,
         )
         output.writeText(cosmosJson.toJson(manifest))
         Logger.info("Wrote upgrade rehearsal completion manifest to {}", output.absolutePath)

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -1,0 +1,366 @@
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.productscience.*
+import com.productscience.data.UpdateParams
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.tinylog.Logger
+import java.io.File
+import java.security.MessageDigest
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertNotNull
+
+class UpgradeRehearsalTests : TestermintTest() {
+    private val defaultDevshardMaxNonce = 20_000L
+
+    @Test
+    @Tag("upgrade-rehearsal")
+    @Timeout(value = 90, unit = TimeUnit.MINUTES)
+    fun `complete upgrade rehearsal`() {
+        val targetUpgrade = requiredEnv("UPGRADE_REHEARSAL_TARGET")
+        val manifest = loadPrepManifest()
+        assertPreparedManifest(manifest)
+
+        val cluster = attachPreparedCluster()
+        val genesis = cluster.genesis
+        configureInferenceMocks(cluster, targetUpgrade, "upgrade rehearsal post-upgrade")
+
+        waitForClusterOperational(cluster, genesis)
+
+        val upgradeLeadBlocks = System.getenv("UPGRADE_REHEARSAL_LEAD_BLOCKS")?.toLongOrNull() ?: 80L
+        val upgradeHeight = genesis.getCurrentBlockHeight() + upgradeLeadBlocks
+        val binaryPath = rehearsalBinaryPath("v2/inferenced/inferenced-amd64.zip")
+        val apiBinaryPath = rehearsalBinaryPath("v2/dapi/decentralized-api-amd64.zip")
+
+        logSection("Submitting upgrade rehearsal proposal for $targetUpgrade at block $upgradeHeight")
+        val response = genesis.submitUpgradeProposal(
+            title = targetUpgrade,
+            description = "Testermint upgrade rehearsal to $targetUpgrade",
+            binaryPath = binaryPath,
+            apiBinaryPath = apiBinaryPath,
+            height = upgradeHeight,
+            nodeVersion = targetUpgrade,
+        )
+        require(response.code == 0) { "Upgrade proposal failed: ${response.rawLog}" }
+        val proposalId = assertNotNull(response.getProposalId(), "could not find upgrade proposal id")
+
+        val govParams = genesis.node.getGovParams().params
+        val deposit = genesis.makeGovernanceDeposit(proposalId, govParams.minDeposit.first().amount)
+        require(deposit.code == 0) { "Upgrade proposal deposit failed: ${deposit.rawLog}" }
+
+        logSection("Voting on upgrade rehearsal proposal")
+        cluster.allPairs.forEach { pair ->
+            val vote = pair.voteOnProposal(proposalId, "yes")
+            require(vote.code == 0) { "Vote failed for ${pair.name}: ${vote.rawLog}" }
+        }
+
+        logSection("Waiting for governance voting period")
+        Thread.sleep(govParams.votingPeriod.plus(Duration.ofSeconds(5)).toMillis())
+
+        logSection("Waiting for upgrade height $upgradeHeight")
+        genesis.node.waitForMinimumBlock(upgradeHeight - 2, "upgrade rehearsal height")
+
+        logSection("Waiting for cosmovisor to apply upgrade")
+        Thread.sleep(Duration.ofMinutes(5).toMillis())
+        genesis.node.waitForNextBlock(1)
+
+        logSection("Verifying upgrade marker and cluster health")
+        verifyUpgradeWithLocalApiRecovery(cluster, genesis)
+        waitForLastUpgradeHeight(cluster, genesis, upgradeHeight, maxBlocks = 60)
+        assertLastUpgradeHeight(cluster, upgradeHeight)
+        waitForClusterOperational(cluster, genesis)
+
+        logSection("Running post-upgrade normal inference")
+        configureInferenceMocks(cluster, targetUpgrade, "upgrade rehearsal post-upgrade normal inference")
+        genesis.waitForStage(EpochStage.SET_NEW_VALIDATORS)
+        waitForClusterOperational(cluster, genesis)
+        genesis.waitForNextInferenceWindow()
+        val postInference = genesis.makeInferenceRequest(inferenceRequest)
+        assertThat(postInference.choices.first().message.content).isNotEmpty()
+
+        logSection("Running post-upgrade devshard settlement")
+        ensureDevshardRequestsEnabled(cluster, genesis)
+        configureDevshardMocks(cluster, targetUpgrade, "upgrade rehearsal post-upgrade devshard")
+        val user = genesis.createFundedDevshardUser("upgrade-rehearsal-post-devshard-user")
+        genesis.waitForNextInferenceWindow()
+        val escrowAmount = 7_000_000_000L
+        val escrowId = genesis.createDevshardEscrowForUser(escrowAmount, user.keyName, modelId = defaultModel)
+        val handle = genesis.startDevshardProxy(escrowId = escrowId, keyName = user.keyName)
+        try {
+            genesis.waitForDevshardProxyWarmup()
+            repeat(5) { index ->
+                val responseText = genesis.sendChatCompletion(
+                    handle.proxyUrl,
+                    defaultModel,
+                    "upgrade rehearsal post-upgrade prompt $index",
+                )
+                assertThat(responseText).isNotEmpty()
+            }
+            genesis.assertDevshardSettlement(
+                handle,
+                escrowId,
+                user,
+                escrowAmount,
+                requireCompletedValidations = false,
+            )
+        } finally {
+            genesis.stopDevshardProxy(escrowId)
+        }
+
+        writeCompletionManifest(targetUpgrade, upgradeHeight, postInference.id, escrowId)
+    }
+
+    private fun ensureDevshardRequestsEnabled(cluster: LocalCluster, genesis: LocalInferencePair) {
+        val params = genesis.getParams()
+        val current = params.devshardEscrowParams?.devshardRequestsEnabled
+        if (current == true) {
+            logSection("Devshard request handling is already enabled")
+            return
+        }
+
+        logSection("Enabling devshard request handling after upgrade through governance params")
+        val devshardParams = requireNotNull(params.devshardEscrowParams) {
+            "Cannot enable devshard request handling because devshard escrow params are missing"
+        }
+        genesis.runProposal(
+            cluster,
+            UpdateParams(
+                params = params.copy(
+                    devshardEscrowParams = devshardParams.copy(
+                        devshardRequestsEnabled = true,
+                        maxNonce = devshardParams.maxNonce.takeIf { it > 0 } ?: defaultDevshardMaxNonce,
+                    ),
+                ),
+            ),
+        )
+
+        val updated = genesis.getParams().devshardEscrowParams?.devshardRequestsEnabled
+        assertThat(updated).isEqualTo(true)
+        waitForClusterOperational(cluster, genesis)
+    }
+
+    private fun attachPreparedCluster(): LocalCluster {
+        val cluster = getLocalCluster(inferenceConfig)
+            ?: error("No prepared Testermint cluster found. The rehearsal completion phase must not rebuild the cluster.")
+        require(cluster.joinPairs.size >= 2) {
+            "Expected at least two join pairs in prepared cluster, found ${cluster.joinPairs.size}"
+        }
+        return cluster
+    }
+
+    private fun assertPreparedManifest(manifest: JsonObject) {
+        assertThat(manifest.get("phase").asString).isEqualTo("prepared")
+        assertThat(manifest.get("normalInferenceId").asString).isNotBlank()
+        assertThat(manifest.get("devshardEscrowId").asLong).isGreaterThan(0)
+        assertThat(manifest.get("devshardRequests").asInt).isGreaterThan(0)
+        assertThat(manifest.getAsJsonArray("participantIds")).isNotEmpty()
+        assertThat(manifest.get("finalHeight").asLong).isGreaterThan(manifest.get("startingHeight").asLong)
+    }
+
+    private fun loadPrepManifest(): JsonObject {
+        val file = manifestFile()
+        require(file.exists()) { "Upgrade rehearsal prep manifest not found: ${file.absolutePath}" }
+        return JsonParser.parseString(file.readText()).asJsonObject
+    }
+
+    private fun manifestFile(): File =
+        System.getenv("UPGRADE_REHEARSAL_MANIFEST")
+            ?.takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?: File("../prod-local/upgrade-rehearsal/manifest.json")
+
+    private fun writeCompletionManifest(
+        targetUpgrade: String,
+        upgradeHeight: Long,
+        postInferenceId: String,
+        postDevshardEscrowId: Long,
+    ) {
+        val output = System.getenv("UPGRADE_REHEARSAL_COMPLETE_MANIFEST")
+            ?.takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?: File(manifestFile().parentFile, "completion-manifest.json")
+        output.parentFile.mkdirs()
+        output.writeText(
+            """
+                {
+                  "schema": 1,
+                  "phase": "completed",
+                  "completedAt": "${escapeJson(Instant.now().toString())}",
+                  "targetUpgrade": "${escapeJson(targetUpgrade)}",
+                  "upgradeHeight": $upgradeHeight,
+                  "postUpgradeInferenceId": "${escapeJson(postInferenceId)}",
+                  "postUpgradeDevshardEscrowId": $postDevshardEscrowId
+                }
+            """.trimIndent()
+        )
+        Logger.info("Wrote upgrade rehearsal completion manifest to {}", output.absolutePath)
+    }
+
+    private fun configureInferenceMocks(cluster: LocalCluster, targetUpgrade: String, content: String) {
+        val response = defaultInferenceResponseObject.withResponse(content)
+        cluster.allPairs.forEach { pair ->
+            listOf("", "v3.0.8", targetUpgrade).distinct().forEach { segment ->
+                pair.mock?.setInferenceResponse(response, segment = segment)
+            }
+        }
+    }
+
+    private fun configureDevshardMocks(cluster: LocalCluster, targetUpgrade: String, content: String) {
+        val response = devshardChatResponse(content)
+        cluster.allPairs.forEach { pair ->
+            listOf("", "v3.0.8", targetUpgrade).distinct().forEach { segment ->
+                pair.mock?.setInferenceResponse(response = response, segment = segment)
+            }
+        }
+    }
+
+    private fun devshardChatResponse(content: String): String =
+        """{"id":"test","object":"chat.completion","created":0,"model":"$defaultModel","choices":[{"index":0,"message":{"role":"assistant","content":"$content"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}"""
+
+    private fun assertLastUpgradeHeight(pair: LocalInferencePair, expectedHeight: Long, expectedFound: Boolean = true) {
+        val response = pair.node.getLastUpgradeHeight()
+        assertThat(response.found).isEqualTo(expectedFound)
+        assertThat(response.lastUpgradeHeight).isEqualTo(expectedHeight)
+    }
+
+    private fun assertLastUpgradeHeight(cluster: LocalCluster, expectedHeight: Long, expectedFound: Boolean = true) {
+        cluster.allPairs.forEach { pair ->
+            assertLastUpgradeHeight(pair, expectedHeight, expectedFound)
+        }
+    }
+
+    private fun assertLastUpgradeHeightUnset(cluster: LocalCluster) {
+        assertLastUpgradeHeight(cluster, 0, expectedFound = false)
+    }
+
+    private fun verifyPairHealthy(pair: LocalInferencePair) {
+        pair.api.getParticipants()
+        pair.api.getNodes()
+        pair.node.getColdAddress()
+    }
+
+    private fun pairIsOperational(pair: LocalInferencePair): Boolean =
+        runCatching {
+            verifyPairHealthy(pair)
+            pair.api.getNodes().isNotEmpty() &&
+                pair.api.getNodes().all { node ->
+                    node.state.currentStatus != "UNKNOWN" && node.state.intendedStatus != "UNKNOWN"
+                }
+        }.getOrDefault(false)
+
+    private fun waitForClusterOperational(cluster: LocalCluster, genesis: LocalInferencePair, maxBlocks: Int = 30) {
+        val startBlock = genesis.getCurrentBlockHeight()
+        val targetBlock = startBlock + maxBlocks
+
+        while (genesis.getCurrentBlockHeight() < targetBlock) {
+            if (cluster.allPairs.all(::pairIsOperational)) {
+                return
+            }
+            genesis.node.waitForNextBlock(1)
+        }
+
+        error("Cluster did not become operational by block $targetBlock")
+    }
+
+    private fun waitForLastUpgradeHeight(
+        cluster: LocalCluster,
+        genesis: LocalInferencePair,
+        expectedHeight: Long,
+        maxBlocks: Int,
+    ) {
+        val startBlock = genesis.getCurrentBlockHeight()
+        val targetBlock = startBlock + maxBlocks
+
+        while (genesis.getCurrentBlockHeight() < targetBlock) {
+            val allUpdated = cluster.allPairs.all { pair ->
+                runCatching {
+                    val response = pair.node.getLastUpgradeHeight()
+                    response.found && response.lastUpgradeHeight == expectedHeight
+                }.getOrDefault(false)
+            }
+            if (allUpdated) {
+                return
+            }
+            genesis.node.waitForNextBlock(1)
+        }
+
+        error("LastUpgradeHeight did not become $expectedHeight by block $targetBlock")
+    }
+
+    private fun isBadGatewayFailure(t: Throwable): Boolean =
+        generateSequence(t) { it.cause }.any { cause ->
+            cause.message?.contains("502") == true || cause.message?.contains("Bad Gateway") == true
+        }
+
+    private fun verifyUpgradeWithLocalApiRecovery(cluster: LocalCluster, genesis: LocalInferencePair) {
+        fun failedPairs(): List<LocalInferencePair> =
+            cluster.allPairs.filter { pair -> runCatching { verifyPairHealthy(pair) }.isFailure }
+
+        val initialFailures = failedPairs()
+        if (initialFailures.isEmpty()) {
+            return
+        }
+
+        val firstFailure = runCatching { verifyPairHealthy(initialFailures.first()) }.exceptionOrNull()
+        if (firstFailure == null || !isBadGatewayFailure(firstFailure)) {
+            throw firstFailure ?: IllegalStateException("Upgrade verification failed for unknown reason")
+        }
+
+        Logger.warn(
+            "Post-upgrade API verification failed with 502; restarting local API containers for {}",
+            initialFailures.joinToString(", ") { it.name },
+        )
+        initialFailures.forEach { it.restartApiContainer() }
+
+        genesis.waitForBlock(20) {
+            cluster.allPairs.all { pair ->
+                runCatching {
+                    verifyPairHealthy(pair)
+                    true
+                }.getOrDefault(false)
+            }
+        }
+
+        cluster.allPairs.forEach(::verifyPairHealthy)
+    }
+
+    private fun rehearsalBinaryPath(path: String): String {
+        val localPath = File("../public-html/$path")
+        val sha = sha256(localPath)
+        val baseUrl = System.getenv("UPGRADE_BINARY_BASE_URL")
+            ?.takeIf { it.isNotBlank() }
+            ?: "http://genesis-mock-server:8080/files"
+        return "${baseUrl.trimEnd('/')}/$path?checksum=sha256:$sha"
+    }
+
+    private fun sha256(file: File): String {
+        require(file.exists()) { "Upgrade binary file does not exist: ${file.absolutePath}" }
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(8192)
+            while (true) {
+                val bytesRead = input.read(buffer)
+                if (bytesRead == -1) {
+                    break
+                }
+                digest.update(buffer, 0, bytesRead)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun requiredEnv(name: String): String =
+        System.getenv(name)?.takeIf { it.isNotBlank() }
+            ?: error("Required environment variable $name is not set")
+
+    private fun escapeJson(value: String): String =
+        value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+}

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -294,15 +294,18 @@ class UpgradeRehearsalTests : TestermintTest() {
         }
 
     private fun verifyUpgradeWithLocalApiRecovery(cluster: LocalCluster, genesis: LocalInferencePair) {
+        fun pairHealthFailure(pair: LocalInferencePair): Throwable? =
+            runCatching { verifyPairHealthy(pair) }.exceptionOrNull()
+
         fun failedPairs(): List<LocalInferencePair> =
-            cluster.allPairs.filter { pair -> runCatching { verifyPairHealthy(pair) }.isFailure }
+            cluster.allPairs.filter { pair -> pairHealthFailure(pair) != null }
 
         val initialFailures = failedPairs()
         if (initialFailures.isEmpty()) {
             return
         }
 
-        val firstFailure = runCatching { verifyPairHealthy(initialFailures.first()) }.exceptionOrNull()
+        val firstFailure = pairHealthFailure(initialFailures.first())
         if (firstFailure == null || !isBadGatewayFailure(firstFailure)) {
             throw firstFailure ?: IllegalStateException("Upgrade verification failed for unknown reason")
         }
@@ -313,16 +316,21 @@ class UpgradeRehearsalTests : TestermintTest() {
         )
         initialFailures.forEach { it.restartApiContainer() }
 
-        genesis.waitForBlock(20) {
-            cluster.allPairs.all { pair ->
-                runCatching {
-                    verifyPairHealthy(pair)
-                    true
-                }.getOrDefault(false)
+        val startBlock = genesis.getCurrentBlockHeight()
+        val targetBlock = startBlock + 40
+        while (genesis.getCurrentBlockHeight() < targetBlock) {
+            val remainingFailures = failedPairs()
+            if (remainingFailures.isEmpty()) {
+                return
             }
+            Logger.info(
+                "Waiting for restarted API containers to recover: {}",
+                remainingFailures.joinToString(", ") { it.name },
+            )
+            genesis.node.waitForNextBlock(2)
         }
 
-        cluster.allPairs.forEach(::verifyPairHealthy)
+        error("API containers did not recover from post-upgrade 502 by block $targetBlock")
     }
 
     private fun rehearsalBinaryPath(path: String): String {

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -1,6 +1,8 @@
+import com.github.kittinunf.fuel.core.FuelError
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.productscience.*
+import com.productscience.data.OpenAIResponse
 import com.productscience.data.UpdateParams
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
@@ -79,7 +81,7 @@ class UpgradeRehearsalTests : TestermintTest() {
         genesis.waitForStage(EpochStage.SET_NEW_VALIDATORS)
         waitForClusterOperational(cluster, genesis)
         genesis.waitForNextInferenceWindow()
-        val postInference = genesis.makeInferenceRequest(inferenceRequest)
+        val postInference = makeInferenceRequestWhenRoutable(genesis, inferenceRequest)
         assertThat(postInference.choices.first().message.content).isNotEmpty()
 
         logSection("Running post-upgrade devshard settlement")
@@ -92,6 +94,7 @@ class UpgradeRehearsalTests : TestermintTest() {
         val handle = genesis.startDevshardProxy(escrowId = escrowId, keyName = user.keyName)
         try {
             genesis.waitForDevshardProxyWarmup()
+            makeInferenceRequestWhenRoutable(genesis, inferenceRequest)
             repeat(5) { index ->
                 val responseText = genesis.sendChatCompletion(
                     handle.proxyUrl,
@@ -238,6 +241,54 @@ class UpgradeRehearsalTests : TestermintTest() {
         pair.api.getParticipants()
         pair.api.getNodes()
         pair.node.getColdAddress()
+    }
+
+    private fun makeInferenceRequestWhenRoutable(
+        pair: LocalInferencePair,
+        request: String,
+        maxBlocks: Int = 25,
+    ): OpenAIResponse {
+        val startBlock = pair.getCurrentBlockHeight()
+        val deadlineBlock = startBlock + maxBlocks
+        var lastFailure: Throwable? = null
+
+        while (pair.getCurrentBlockHeight() <= deadlineBlock) {
+            try {
+                return pair.makeInferenceRequest(request)
+            } catch (e: Exception) {
+                if (!isTransientInferenceRoutingFailure(e)) {
+                    throw e
+                }
+                lastFailure = e
+                Logger.warn(e) {
+                    "Inference routing is not ready at block ${pair.getCurrentBlockHeight()}; waiting for next block"
+                }
+                pair.node.waitForNextBlock(1)
+            }
+        }
+
+        throw IllegalStateException("Inference routing did not become ready by block $deadlineBlock", lastFailure)
+    }
+
+    private fun isTransientInferenceRoutingFailure(t: Throwable): Boolean {
+        val transientMessages = listOf(
+            "503",
+            "Service Unavailable",
+            "Active participants found, but length is 0",
+            "After filtering participants the length is 0",
+            "epoch group data not found",
+        )
+        val causeMatches = generateSequence(t) { it.cause }.any { cause ->
+            transientMessages.any { message -> cause.message?.contains(message) == true }
+        }
+        val fuelMatches = generateSequence(t) { it.cause }.filterIsInstance<FuelError>().any { fuel ->
+            fuel.response.statusCode == 503 ||
+                transientMessages.any { message ->
+                    fuel.response.data.toString(Charsets.UTF_8).contains(message)
+                }
+        }
+
+        return causeMatches || fuelMatches
     }
 
     private fun pairIsOperational(pair: LocalInferencePair): Boolean =

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -2,6 +2,7 @@ import com.github.kittinunf.fuel.core.FuelError
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.productscience.*
+import com.productscience.data.ActiveParticipant
 import com.productscience.data.OpenAIResponse
 import com.productscience.data.UpdateParams
 import org.assertj.core.api.Assertions.assertThat
@@ -77,9 +78,11 @@ class UpgradeRehearsalTests : TestermintTest() {
         assertLastUpgradeHeight(cluster, upgradeHeight)
         waitForClusterOperational(cluster, genesis)
 
+        logSection("Verifying post-upgrade epoch transition and PoC miner power")
+        val postUpgradePocResult = assertPostUpgradePocSucceeded(cluster, genesis, manifest)
+
         logSection("Running post-upgrade normal inference")
         configureInferenceMocks(cluster, targetUpgrade, "upgrade rehearsal post-upgrade normal inference")
-        genesis.waitForStage(EpochStage.SET_NEW_VALIDATORS)
         waitForClusterOperational(cluster, genesis)
         genesis.waitForNextInferenceWindow()
         val postInference = makeInferenceRequestWhenRoutable(genesis, inferenceRequest)
@@ -115,7 +118,132 @@ class UpgradeRehearsalTests : TestermintTest() {
             genesis.stopDevshardProxy(escrowId)
         }
 
-        writeCompletionManifest(targetUpgrade, upgradeHeight, postInference.id, escrowId)
+        writeCompletionManifest(targetUpgrade, upgradeHeight, postInference.id, escrowId, postUpgradePocResult)
+    }
+
+    private data class PocPowerSnapshot(
+        val epochId: Long,
+        val weights: Map<String, Long>,
+    )
+
+    private data class PostUpgradePocResult(
+        val beforeEpochId: Long,
+        val afterEpochId: Long,
+        val pocStartBlock: Long,
+        val setNewValidatorsBlock: Long,
+        val beforeWeights: Map<String, Long>,
+        val afterWeights: Map<String, Long>,
+    )
+
+    private fun assertPostUpgradePocSucceeded(
+        cluster: LocalCluster,
+        genesis: LocalInferencePair,
+        manifest: JsonObject,
+    ): PostUpgradePocResult {
+        val participantIds = manifest.getAsJsonArray("participantIds").map { it.asString }
+        assertThat(participantIds).describedAs("prepared participant ids").isNotEmpty()
+
+        val before = capturePocPowerSnapshot(genesis, participantIds, "before post-upgrade PoC")
+        val pocStart = genesis.waitForStage(EpochStage.START_OF_POC, offset = 1)
+        val setNewValidators = genesis.waitForStage(EpochStage.SET_NEW_VALIDATORS, offset = 2)
+        waitForClusterOperational(cluster, genesis)
+        val after = capturePocPowerSnapshot(genesis, participantIds, "after post-upgrade PoC")
+
+        assertThat(after.epochId)
+            .describedAs("post-upgrade PoC should advance the active participant epoch")
+            .isGreaterThan(before.epochId)
+        assertMinerPowerStable(before, after)
+
+        return PostUpgradePocResult(
+            beforeEpochId = before.epochId,
+            afterEpochId = after.epochId,
+            pocStartBlock = pocStart.stageBlock,
+            setNewValidatorsBlock = setNewValidators.stageBlock,
+            beforeWeights = before.weights,
+            afterWeights = after.weights,
+        )
+    }
+
+    private fun capturePocPowerSnapshot(
+        genesis: LocalInferencePair,
+        participantIds: List<String>,
+        label: String,
+    ): PocPowerSnapshot {
+        val activeResponse = genesis.api.getActiveParticipants()
+        val activeById = activeResponse.activeParticipants.participants.associateBy { it.index }
+        val missingParticipants = participantIds.filterNot(activeById::containsKey)
+        assertThat(missingParticipants)
+            .describedAs("$label missing prepared miners from active participants")
+            .isEmpty()
+
+        val excludedIds = activeResponse.excludedParticipants.map { it.address }.toSet()
+        val excludedPreparedParticipants = participantIds.filter { it in excludedIds }
+        assertThat(excludedPreparedParticipants)
+            .describedAs("$label excluded prepared miners")
+            .isEmpty()
+
+        val weights = participantIds.associateWith { participantId ->
+            val participant = activeById.getValue(participantId)
+            assertParticipantHasPocPower(participant, label)
+            participant.weight
+        }
+
+        Logger.info(
+            "{} PoC power snapshot: epoch={}, weights={}",
+            label,
+            activeResponse.activeParticipants.epochId,
+            weights,
+        )
+
+        return PocPowerSnapshot(
+            epochId = activeResponse.activeParticipants.epochId,
+            weights = weights,
+        )
+    }
+
+    private fun assertParticipantHasPocPower(participant: ActiveParticipant, label: String) {
+        assertThat(participant.weight)
+            .describedAs("$label participant ${participant.index} aggregate PoC power")
+            .isPositive()
+
+        val nodeWeights = participant.mlNodes.flatMap { group -> group.mlNodes }.map { node -> node.pocWeight }
+        assertThat(nodeWeights)
+            .describedAs("$label participant ${participant.index} ML node PoC weights")
+            .isNotEmpty()
+        assertThat(nodeWeights.any { it > 0L })
+            .describedAs("$label participant ${participant.index} should have at least one positive ML node PoC weight")
+            .isTrue()
+    }
+
+    private fun assertMinerPowerStable(before: PocPowerSnapshot, after: PocPowerSnapshot) {
+        val maxChangePercent = System.getenv("UPGRADE_REHEARSAL_MAX_POWER_CHANGE_PERCENT")
+            ?.toLongOrNull()
+            ?: 50L
+        require(maxChangePercent >= 0) {
+            "UPGRADE_REHEARSAL_MAX_POWER_CHANGE_PERCENT must be non-negative, got $maxChangePercent"
+        }
+
+        before.weights.forEach { (participantId, beforeWeight) ->
+            val afterWeight = after.weights[participantId]
+                ?: error("Missing post-upgrade PoC weight for prepared miner $participantId")
+            val delta = if (afterWeight >= beforeWeight) afterWeight - beforeWeight else beforeWeight - afterWeight
+            assertThat(delta * 100)
+                .describedAs(
+                    "post-upgrade PoC power change for $participantId " +
+                        "(before=$beforeWeight, after=$afterWeight, maxChangePercent=$maxChangePercent)",
+                )
+                .isLessThanOrEqualTo(beforeWeight * maxChangePercent)
+        }
+
+        val beforeTotal = before.weights.values.sum()
+        val afterTotal = after.weights.values.sum()
+        val totalDelta = if (afterTotal >= beforeTotal) afterTotal - beforeTotal else beforeTotal - afterTotal
+        assertThat(totalDelta * 100)
+            .describedAs(
+                "post-upgrade total miner power change " +
+                    "(before=$beforeTotal, after=$afterTotal, maxChangePercent=$maxChangePercent)",
+            )
+            .isLessThanOrEqualTo(beforeTotal * maxChangePercent)
     }
 
     private fun ensureDevshardRequestsEnabled(cluster: LocalCluster, genesis: LocalInferencePair) {
@@ -182,6 +310,7 @@ class UpgradeRehearsalTests : TestermintTest() {
         upgradeHeight: Long,
         postInferenceId: String,
         postDevshardEscrowId: Long,
+        postUpgradePocResult: PostUpgradePocResult,
     ) {
         val output = System.getenv("UPGRADE_REHEARSAL_COMPLETE_MANIFEST")
             ?.takeIf { it.isNotBlank() }
@@ -196,6 +325,12 @@ class UpgradeRehearsalTests : TestermintTest() {
             "upgradeHeight" to upgradeHeight,
             "postUpgradeInferenceId" to postInferenceId,
             "postUpgradeDevshardEscrowId" to postDevshardEscrowId,
+            "postUpgradePocBeforeEpoch" to postUpgradePocResult.beforeEpochId,
+            "postUpgradePocAfterEpoch" to postUpgradePocResult.afterEpochId,
+            "postUpgradePocStartBlock" to postUpgradePocResult.pocStartBlock,
+            "postUpgradeSetNewValidatorsBlock" to postUpgradePocResult.setNewValidatorsBlock,
+            "postUpgradePocBeforeWeights" to postUpgradePocResult.beforeWeights,
+            "postUpgradePocAfterWeights" to postUpgradePocResult.afterWeights,
         )
         output.writeText(cosmosJson.toJson(manifest))
         Logger.info("Wrote upgrade rehearsal completion manifest to {}", output.absolutePath)

--- a/testermint/upgrade-rehearsal/previous-release-prep.patch
+++ b/testermint/upgrade-rehearsal/previous-release-prep.patch
@@ -1,9 +1,9 @@
 diff --git a/testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt b/testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt
 new file mode 100644
-index 000000000..7e7a0d7b3
+index 000000000..5a2d131fe
 --- /dev/null
 +++ b/testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt
-@@ -0,0 +1,114 @@
+@@ -0,0 +1,121 @@
 +import com.productscience.*
 +import org.assertj.core.api.Assertions.assertThat
 +import org.junit.jupiter.api.Tag
@@ -81,6 +81,12 @@ index 000000000..7e7a0d7b3
 +        val finalEpoch = genesis.getEpochData().latestEpoch.index
 +        val finalHeight = genesis.getCurrentBlockHeight()
 +        val participantIds = genesis.api.getParticipants().map { it.id }
++        val participantWeights = genesis.node.getParticipantCurrentStats()
++            .participantCurrentStats
++            ?.associate { it.participantId to it.weight }
++            ?: emptyMap()
++        assertThat(participantWeights.keys).containsAll(participantIds)
++        participantWeights.values.forEach { weight -> assertThat(weight).isPositive() }
 +        val manifest = """
 +            {
 +              "schema": 1,
@@ -95,7 +101,8 @@ index 000000000..7e7a0d7b3
 +              "devshardEscrowId": $escrowId,
 +              "devshardRequests": $devshardRequests,
 +              "devshardSettlementVersion": "${escapeJson(settlementVersion)}",
-+              "participantIds": ${cosmosJson.toJson(participantIds)}
++              "participantIds": ${cosmosJson.toJson(participantIds)},
++              "participantWeights": ${cosmosJson.toJson(participantWeights)}
 +            }
 +        """.trimIndent()
 +

--- a/testermint/upgrade-rehearsal/previous-release-prep.patch
+++ b/testermint/upgrade-rehearsal/previous-release-prep.patch
@@ -1,0 +1,120 @@
+diff --git a/testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt b/testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt
+new file mode 100644
+index 000000000..7e7a0d7b3
+--- /dev/null
++++ b/testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt
+@@ -0,0 +1,114 @@
++import com.productscience.*
++import org.assertj.core.api.Assertions.assertThat
++import org.junit.jupiter.api.Tag
++import org.junit.jupiter.api.Test
++import org.junit.jupiter.api.Timeout
++import org.tinylog.Logger
++import java.io.File
++import java.time.Instant
++import java.util.concurrent.TimeUnit
++
++class UpgradeRehearsalPrepTests : TestermintTest() {
++    private val rehearsalConfig = inferenceConfig.copy(
++        genesisSpec = createSpec(epochLength = 40, epochShift = 10).merge(devshardNoRestrictionsSpec)
++    )
++
++    @Test
++    @Tag("upgrade-rehearsal")
++    @Timeout(value = 60, unit = TimeUnit.MINUTES)
++    fun `prepare upgrade rehearsal state`() {
++        val (cluster, genesis) = initCluster(config = rehearsalConfig, reboot = true)
++        val startingHeight = genesis.getCurrentBlockHeight()
++        val startingEpoch = genesis.getEpochData().latestEpoch.index
++        val previousRelease = System.getenv("PREVIOUS_RELEASE") ?: "unknown"
++
++        cluster.stubDevshardChatResponse(content = "upgrade rehearsal pre-upgrade")
++
++        logSection("Waiting through an old-version epoch")
++        genesis.waitForNextEpoch()
++
++        logSection("Running pre-upgrade normal inference")
++        genesis.waitForNextInferenceWindow()
++        val normalInference = genesis.makeInferenceRequest(inferenceRequest)
++        assertThat(normalInference.choices.first().message.content).isNotEmpty()
++        genesis.waitForStage(EpochStage.CLAIM_REWARDS, offset = 2)
++
++        logSection("Running pre-upgrade devshard settlement")
++        val user = genesis.createFundedDevshardUser("upgrade-rehearsal-pre-devshard-user")
++        genesis.waitForNextInferenceWindow()
++        val escrowAmount = 7_000_000_000L
++        val escrowId = genesis.createDevshardEscrowForUser(
++            escrowAmount,
++            user.keyName,
++            modelId = defaultModel,
++        )
++
++        val handle = genesis.startDevshardProxy(escrowId = escrowId, keyName = user.keyName)
++        var devshardRequests = 0
++        var settlementVersion = ""
++        try {
++            genesis.waitForDevshardProxyWarmup()
++            repeat(5) { index ->
++                val response = genesis.sendChatCompletion(
++                    handle.proxyUrl,
++                    defaultModel,
++                    "upgrade rehearsal pre-upgrade prompt $index",
++                )
++                assertThat(response).isNotEmpty()
++                devshardRequests += 1
++            }
++            val settlement = genesis.assertDevshardSettlement(
++                handle,
++                escrowId,
++                user,
++                escrowAmount,
++                requireCompletedValidations = false,
++            )
++            settlementVersion = settlement.parsed.version
++        } finally {
++            genesis.stopDevshardProxy(escrowId)
++        }
++
++        logSection("Waiting into another old-version epoch")
++        genesis.waitForNextEpoch()
++
++        val finalEpoch = genesis.getEpochData().latestEpoch.index
++        val finalHeight = genesis.getCurrentBlockHeight()
++        val participantIds = genesis.api.getParticipants().map { it.id }
++        val manifest = """
++            {
++              "schema": 1,
++              "phase": "prepared",
++              "preparedAt": "${escapeJson(Instant.now().toString())}",
++              "previousRelease": "${escapeJson(previousRelease)}",
++              "startingHeight": $startingHeight,
++              "finalHeight": $finalHeight,
++              "startingEpoch": "$startingEpoch",
++              "finalEpoch": "$finalEpoch",
++              "normalInferenceId": "${escapeJson(normalInference.id)}",
++              "devshardEscrowId": $escrowId,
++              "devshardRequests": $devshardRequests,
++              "devshardSettlementVersion": "${escapeJson(settlementVersion)}",
++              "participantIds": ${cosmosJson.toJson(participantIds)}
++            }
++        """.trimIndent()
++
++        val output = manifestFile()
++        output.parentFile.mkdirs()
++        output.writeText(manifest)
++        Logger.info("Wrote upgrade rehearsal prep manifest to {}", output.absolutePath)
++    }
++
++    private fun manifestFile(): File =
++        System.getenv("UPGRADE_REHEARSAL_MANIFEST")
++            ?.takeIf { it.isNotBlank() }
++            ?.let(::File)
++            ?: File("../prod-local/upgrade-rehearsal/manifest.json")
++
++    private fun escapeJson(value: String): String =
++        value
++            .replace("\\", "\\\\")
++            .replace("\"", "\\\"")
++            .replace("\n", "\\n")
++            .replace("\r", "\\r")
++}


### PR DESCRIPTION
## Summary

Adds a dedicated Testermint upgrade rehearsal workflow that runs an actual local software upgrade before spending Testnet time on it.

The workflow:
- discovers the target upgrade and previous canonical release dynamically;
- checks out the previous release and pulls the production images declared by that release;
- applies a small prep-test patch to the old checkout so the old Testermint harness creates meaningful state;
- keeps the old Docker cluster alive;
- builds candidate production-style upgrade archives from the PR branch;
- serves those archives on the Testermint Docker network;
- attaches the current Testermint harness to the existing old cluster, submits the upgrade proposal, waits for cosmovisor, and verifies post-upgrade inference plus devshard settlement.

## Why

Testing upgrades only in Testnet is too risky and expensive. This gives us a repeatable CI rehearsal that catches version-discovery, archive-layout, cosmovisor, migration, and post-upgrade behavior issues before Testnet.

## Validation

Local checks:
- `git diff --check`
- `zsh -lc 'cd inference-chain && GOTOOLCHAIN=go1.24.2 go test ./app/upgrades/v0_2_14 ./x/inference/module -run TestDoesNotExist'`
- `python3 scripts/upgrade-rehearsal/resolve_versions.py --repo . --target-upgrade v0.2.14 --previous-release release/v0.2.13`
- `python3 scripts/upgrade-rehearsal/resolve_previous_images.py --compose deploy/join/docker-compose.yml`

Workflow validation before squashing history:
- Intentional crash proof failed correctly: https://github.com/gonka-ai/gonka/actions/runs/26902286237
- Clean full rehearsal succeeded: https://github.com/gonka-ai/gonka/actions/runs/26905450054
- Clean full rehearsal succeeded again: https://github.com/gonka-ai/gonka/actions/runs/26908298954

The squashed PR commit has the same tree as the twice-green validated commit. I am also dispatching the new upgrade rehearsal workflow against this PR head so the PR shows fresh evidence on the final commit.

## Notes

The workflow is currently `workflow_dispatch` only. We can decide in review whether to keep it manual for release branches or wire it into a release gate later.
