### PR TITLE
fix(devshard): clamp Chat Completions `n` into [1, 5]

### DIFF
--- a/devshard/cmd/devshardctl/paramvalidators/handlers.go
+++ b/devshard/cmd/devshardctl/paramvalidators/handlers.go
@@ -155,6 +155,7 @@ func (h ForceLiteralParameter) HandleParameter(ctx ParameterContext) error {
 
 // CapUintParameter caps a uint64-shaped field to Max.
 type CapUintParameter struct {
+	Min uint64
 	Max uint64
 }
 
@@ -162,6 +163,9 @@ func (h CapUintParameter) HandleParameter(ctx ParameterContext) error {
 	value, ok := numericJSONValueAsUint64FromMap(ctx.Document, ctx.Parameter)
 	if !ok {
 		return nil
+	}
+	if value < h.Min {
+		ctx.Document[ctx.Parameter] = h.Min
 	}
 	if value > h.Max {
 		ctx.Document[ctx.Parameter] = h.Max

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -425,7 +425,7 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 			newParameter("seed").
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.ValidateUintParameter{}}),
 			newParameter("n").
-				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.CapUintParameter{Max: MaxChatRequestChoices}}).
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.CapUintParameter{Min: 1, Max: MaxChatRequestChoices}}).
 				withRule(RequestFilterStagePostLimits, DocumentValidatorHandler{
 					Validator: paramvalidators.GreedySamplingValidator{},
 				}),

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -203,6 +203,13 @@ func TestNormalizeChatRequestCapsChoices(t *testing.T) {
 	require.NotContains(t, string(body), `"n"`)
 }
 
+func TestNormalizeChatRequestClampsZeroChoicesToOne(t *testing.T) {
+	body, req, err := normalizeChatRequest([]byte(`{"n":0,"messages":[{"role":"user","content":"hi"}]}`))
+	require.NoError(t, err)
+	require.EqualValues(t, 1, req.N)
+	require.Contains(t, string(body), `"n":1`)
+}
+
 func TestNormalizeChatRequestClampsMinTokensAboveEffectiveMax(t *testing.T) {
 	oldDefault := DefaultRequestMaxTokens
 	oldCap := RequestMaxTokensCap


### PR DESCRIPTION
## Summary
The Chat Completions `n` (number of choices) had only an upper cap, no lower bound. A request with **`n: 0`** passed validation, reached vLLM as "zero completions", produced no content chunks, and the redundancy layer waited for a winner that can never arrive — **hanging until the request deadline** instead of returning a clean error. This PR clamps `n` into **`[1, 5]`** in the gateway parameter filter, so `n: 0` is silently corrected to `1`.

## Problem
`n` was wired with `CapUintParameterHandler{Max: 5}` only — the upper bound is enforced, the lower bound is not. The adjacent `GreedySamplingValidator` does **not** help: its `if n <= 1 { return nil }` is an early-exit guard (its only job is coercing `n>1`→`1` under `temperature==0`), so it accepts `n=0` untouched.

Net effect of `n: 0`:
- vLLM is asked for zero completions → never emits a content-bearing chunk.
- Redundancy never crowns a winner → it retries/waits to the overall deadline.
- Client observes **0 bytes received, ~40s, then timeout** — and a request slot / escrow is tied up for the duration. This is strictly worse than a 400.

## Solution
Extend the existing `CapUintParameterHandler` with a `Min` field instead of adding a new handler type. It now clamps a present uint into `[Min, Max]`; `Min` defaults to `0` (no lower bound), so the other `Max`-only usages are unaffected. `n` becomes a single handler: `CapUintParameterHandler{Min: 1, Max: MaxChatRequestChoices}`.

| `n` input | Result |
|-----------|--------|
| `0`       | `1` (clamped up) |
| `1`–`5`   | unchanged |
| `> 5`     | `5` (capped) |
| omitted   | untouched (backend default = 1) |

Silent clamp (not a 400) was chosen so a stray `n: 0` degrades to a normal single-completion response rather than failing the request.

## Config
None. Pure request-filter behavior; no new settings, no schema change.

## Rollout
Standard. No migration, no state change — takes effect on deploy of the gateway.

## Test plan
- New unit test `TestNormalizeChatRequestClampsZeroChoicesToOne` (followed RED → GREEN: code previously let `n=0` through, now clamps to `1`).
- Existing `n` tests unchanged and green: cap-to-5, greedy coercion at `temperature==0`, omit.
- `go build ./...` — clean
- `go vet ./cmd/devshardctl/` — clean
- `go test ./cmd/devshardctl/` — all pass
