### PR TITLE
fix(devshard): validate & clamp chat-completion params at the gateway instead of vLLM

### DIFF
--- a/devshard/cmd/devshardctl/paramvalidators/handlers.go
+++ b/devshard/cmd/devshardctl/paramvalidators/handlers.go
@@ -206,6 +206,74 @@ func (h ValidateUintParameter) HandleParameter(ctx ParameterContext) error {
 	return nil
 }
 
+// RejectNumberParameter rejects the request when the parameter is present and parses as a
+// number but Allow returns false for it. Non-numeric or absent values pass through so the
+// dedicated type/shape validators own those cases. Used for range gates whose lower bound is
+// exclusive (e.g. top_p > 0), where clamping to the bound would itself be an illegal value.
+type RejectNumberParameter struct {
+	Allow   func(float64) bool
+	Message string
+}
+
+func (h RejectNumberParameter) HandleParameter(ctx ParameterContext) error {
+	value, exists := ctx.Document[ctx.Parameter]
+	if !exists {
+		return nil
+	}
+	number, ok := devshard.JSONNumericFloat64(value)
+	if !ok {
+		return nil
+	}
+	if h.Allow == nil || h.Allow(number) {
+		return nil
+	}
+	return fmt.Errorf("%s: %s", ctx.Parameter, h.Message)
+}
+
+// ValidateScalarParameter rejects the request when the parameter is present (non-null) but
+// Valid returns false for its raw JSON value. Catches wrong-typed scalars at the boundary
+// instead of forwarding them for an opaque upstream 400.
+type ValidateScalarParameter struct {
+	Valid   func(any) bool
+	Message string
+}
+
+func (h ValidateScalarParameter) HandleParameter(ctx ParameterContext) error {
+	value, exists := ctx.Document[ctx.Parameter]
+	if !exists || value == nil {
+		return nil
+	}
+	if h.Valid == nil || h.Valid(value) {
+		return nil
+	}
+	return fmt.Errorf("%s: %s", ctx.Parameter, h.Message)
+}
+
+// ValidateListElementsParameter rejects the request when any array element fails Valid.
+// Pass-through when the field is absent or not an array.
+type ValidateListElementsParameter struct {
+	Valid   func(any) bool
+	Message string
+}
+
+func (h ValidateListElementsParameter) HandleParameter(ctx ParameterContext) error {
+	raw, ok := ctx.Document[ctx.Parameter].([]any)
+	if !ok {
+		return nil
+	}
+	for index, item := range raw {
+		if h.Valid != nil && !h.Valid(item) {
+			return fmt.Errorf("%s[%d]: %s", ctx.Parameter, index, h.Message)
+		}
+	}
+	return nil
+}
+
+// JSON type predicates for the Validate*Parameter handlers above.
+func IsJSONBool(value any) bool   { _, ok := value.(bool); return ok }
+func IsJSONString(value any) bool { _, ok := value.(string); return ok }
+func IsJSONUint(value any) bool   { _, ok := devshard.JSONNumericUint64(value); return ok }
+
 // LengthCapListParameter bounds the number of entries in an array field, and
 // optionally the byte length of each string entry. MaxEntries=0 disables the
 // array cap; MaxEntryLen=0 disables the per-string cap.

--- a/devshard/cmd/devshardctl/paramvalidators/validate_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/validate_test.go
@@ -1,0 +1,102 @@
+package paramvalidators
+
+import (
+	"strings"
+	"testing"
+)
+
+// ============================================================
+// RejectNumberParameter
+// ============================================================
+
+func TestRejectNumberParameter(t *testing.T) {
+	positive := RejectNumberParameter{Allow: func(v float64) bool { return v > 0 }, Message: "must be greater than 0"}
+
+	// Absent and non-numeric values pass through — dedicated shape validators own those.
+	if err := run(positive, map[string]any{}, "top_p"); err != nil {
+		t.Fatalf("absent field must pass through, got %v", err)
+	}
+	if err := run(positive, map[string]any{"top_p": "not-a-number"}, "top_p"); err != nil {
+		t.Fatalf("non-numeric must pass through, got %v", err)
+	}
+	if err := run(positive, map[string]any{"top_p": 0.5}, "top_p"); err != nil {
+		t.Fatalf("allowed value must pass, got %v", err)
+	}
+
+	err := run(positive, map[string]any{"top_p": 0}, "top_p")
+	if err == nil || !strings.Contains(err.Error(), "top_p") || !strings.Contains(err.Error(), "greater than 0") {
+		t.Fatalf("non-positive must be rejected with a field-named error, got %v", err)
+	}
+}
+
+func TestRejectNumberParameter_TopKPredicate(t *testing.T) {
+	topK := RejectNumberParameter{Allow: func(v float64) bool { return v == -1 || v >= 1 }, Message: "must be -1 or a positive integer"}
+	for _, good := range []any{-1, 1, 50} {
+		if err := run(topK, map[string]any{"top_k": good}, "top_k"); err != nil {
+			t.Fatalf("top_k=%v must pass, got %v", good, err)
+		}
+	}
+	for _, bad := range []any{0, -2} {
+		if err := run(topK, map[string]any{"top_k": bad}, "top_k"); err == nil {
+			t.Fatalf("top_k=%v must be rejected", bad)
+		}
+	}
+}
+
+// ============================================================
+// ValidateScalarParameter
+// ============================================================
+
+func TestValidateScalarParameter(t *testing.T) {
+	mustBeBool := ValidateScalarParameter{Valid: IsJSONBool, Message: "must be a boolean"}
+
+	// Absent or explicit null passes through.
+	if err := run(mustBeBool, map[string]any{}, "stream"); err != nil {
+		t.Fatalf("absent must pass, got %v", err)
+	}
+	if err := run(mustBeBool, map[string]any{"stream": nil}, "stream"); err != nil {
+		t.Fatalf("null must pass, got %v", err)
+	}
+	if err := run(mustBeBool, map[string]any{"stream": true}, "stream"); err != nil {
+		t.Fatalf("bool must pass, got %v", err)
+	}
+	if err := run(mustBeBool, map[string]any{"stream": "yes"}, "stream"); err == nil {
+		t.Fatal("non-bool must be rejected")
+	}
+}
+
+// ============================================================
+// ValidateListElementsParameter
+// ============================================================
+
+func TestValidateListElementsParameter(t *testing.T) {
+	elementsMustBeString := ValidateListElementsParameter{Valid: IsJSONString, Message: "must be a string"}
+
+	// Absent or non-array passes through.
+	if err := run(elementsMustBeString, map[string]any{}, "stop"); err != nil {
+		t.Fatalf("absent must pass, got %v", err)
+	}
+	if err := run(elementsMustBeString, map[string]any{"stop": "single"}, "stop"); err != nil {
+		t.Fatalf("non-array must pass, got %v", err)
+	}
+	if err := run(elementsMustBeString, map[string]any{"stop": []any{"a", "b"}}, "stop"); err != nil {
+		t.Fatalf("all-string array must pass, got %v", err)
+	}
+
+	err := run(elementsMustBeString, map[string]any{"stop": []any{"a", 5, "c"}}, "stop")
+	if err == nil || !strings.Contains(err.Error(), "stop[1]") {
+		t.Fatalf("bad element must be rejected with its index, got %v", err)
+	}
+}
+
+func TestJSONTypePredicates(t *testing.T) {
+	if !IsJSONBool(true) || IsJSONBool("x") {
+		t.Fatal("IsJSONBool")
+	}
+	if !IsJSONString("x") || IsJSONString(1) {
+		t.Fatal("IsJSONString")
+	}
+	if !IsJSONUint(5) || IsJSONUint(-1) || IsJSONUint(3.5) {
+		t.Fatal("IsJSONUint")
+	}
+}

--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -139,6 +139,7 @@ func (p ChatRequestPipeline) applyOutputTokenLimits(ctx *RequestFilterContext) {
 	case hasMaxCompletionTokens:
 		maxCompletionTokens := capOutputTokens(ctx.Request.MaxCompletionTokens, true, ctx.AdminAuthenticated, limits)
 		ctx.Document.Set("max_completion_tokens", maxCompletionTokens)
+		ctx.Document.Set("max_tokens", maxCompletionTokens)
 		ctx.Request.MaxCompletionTokens = maxCompletionTokens
 		ctx.Request.MaxTokens = maxCompletionTokens
 	default:

--- a/devshard/cmd/devshardctl/request_filters_config.go
+++ b/devshard/cmd/devshardctl/request_filters_config.go
@@ -5,7 +5,11 @@ const (
 	MaxChatRequestBodySize       = 10 * 1024 * 1024
 	MaxLoggedResponseFormatBytes = 2048 * 1024
 	MaxChatRequestChoices        = 5
+	MinTemperature               = 0.0
 	MaxTemperature               = 2.0
+	MinPMin                      = 0.0
+	MinPMax                      = 1.0
+	TopPMax                      = 1.0
 	MaxRepetitionPenalty         = 2.0
 )
 

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -342,18 +342,11 @@ func (ctx *RequestFilterContext) DecodeRequest() error {
 	return nil
 }
 
-// SyncRequestView refreshes ctx.Request after PostLimits rules ran. Why we explicitly
-// preserve the token fields instead of re-reading them from the document:
-//
-//   - When the client sends only `max_completion_tokens` (no `max_tokens`),
-//     `applyOutputTokenLimits` sets `ctx.Request.MaxTokens` from the resolved
-//     `max_completion_tokens` (see request_filters.go:139) but does NOT write a
-//     corresponding `max_tokens` key into the document. Re-reading the document would
-//     therefore reset `req.MaxTokens` to 0.
-//   - In the other three branches of `applyOutputTokenLimits`, the document DOES carry
-//     the same value, so preserving from `ctx.Request` is a no-op. Net effect: this
-//     branch only matters for the max-completion-only path, locked in by
-//     TestNormalizeChatRequestDefaultsAndCapsOutputTokens.
+// SyncRequestView refreshes ctx.Request after PostLimits rules ran. The token fields
+// are preserved from ctx.Request rather than re-read because applyOutputTokenLimits is
+// their source of truth; all four of its branches now write the same max_tokens /
+// max_completion_tokens into the document (the max-completion-only branch mirrors into
+// max_tokens too), so this preservation is a harmless no-op safety net.
 //
 // Other fields are re-read so caps applied by PostLimits rules (for example `n` via
 // paramvalidators.CapUintParameter through the adapter) propagate into the projection.

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -110,7 +110,6 @@ func (h MinUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLM
 	return nil
 }
 
-
 // DocumentValidator: validators in paramvalidators expose this contract. May mutate
 // vctx.Document for per-model rewrites alongside shape checks.
 type DocumentValidator interface {
@@ -416,6 +415,26 @@ type VLLMParameterCatalog struct {
 
 var defaultParameterCatalog = defaultVLLMParameterCatalog()
 
+// Shared stateless parameter handlers reused across catalog entries. The rejectNumber gates
+// enforce exclusive-lower-bound ranges (clamping to the bound would itself be an illegal
+// value, so reject instead); the mustBe*/elementsMustBe* validators reject wrong-typed
+// scalars and array elements at the gateway boundary rather than forwarding them for an
+// opaque upstream 400.
+var (
+	rejectNonPositiveNumber = ParameterHandlerAdapter{Handler: paramvalidators.RejectNumberParameter{
+		Allow:   func(value float64) bool { return value > 0 },
+		Message: "must be greater than 0",
+	}}
+	rejectInvalidTopK = ParameterHandlerAdapter{Handler: paramvalidators.RejectNumberParameter{
+		Allow:   func(value float64) bool { return value == -1 || value >= 1 },
+		Message: "must be -1 or a positive integer",
+	}}
+	mustBeBool           = ParameterHandlerAdapter{Handler: paramvalidators.ValidateScalarParameter{Valid: paramvalidators.IsJSONBool, Message: "must be a boolean"}}
+	mustBeUint           = ParameterHandlerAdapter{Handler: paramvalidators.ValidateUintParameter{}}
+	elementsMustBeUint   = ParameterHandlerAdapter{Handler: paramvalidators.ValidateListElementsParameter{Valid: paramvalidators.IsJSONUint, Message: "must be an integer token id"}}
+	elementsMustBeString = ParameterHandlerAdapter{Handler: paramvalidators.ValidateListElementsParameter{Valid: paramvalidators.IsJSONString, Message: "must be a string"}}
+)
+
 // The catalog is the single source of truth for how each supported OpenAI/vLLM field is treated.
 func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 	parameters := slices.Concat(
@@ -423,22 +442,25 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 			newParameter("messages").
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: MessagesMaxEntries}}),
 			newParameter("seed").
-				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.ValidateUintParameter{}}),
+				withRule(RequestFilterStagePreValidation, mustBeUint),
 			newParameter("n").
 				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.CapUintParameter{Max: MaxChatRequestChoices}}).
 				withRule(RequestFilterStagePostLimits, DocumentValidatorHandler{
 					Validator: paramvalidators.GreedySamplingValidator{},
 				}),
 			newParameter("temperature").
-				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(MaxTemperature)}}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Min: floatPointer(MinTemperature), Max: floatPointer(MaxTemperature)}}),
 			newParameter("repetition_penalty").
-				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}}).
+				withRule(RequestFilterStagePostLimits, rejectNonPositiveNumber),
 			newParameter("logit_bias").
 				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatMapParameter{StripNonFinite: true, Min: floatPointer(LogitBiasMinValue), Max: floatPointer(LogitBiasMaxValue), DropFieldIfEmpty: true, MaxEntries: LogitBiasMaxEntries}}),
 			newParameter("stop").
+				withRule(RequestFilterStagePreValidation, elementsMustBeString).
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: StopMaxEntries, MaxEntryLen: StopMaxEntryLen}}),
 			newParameter("stop_token_ids").
-				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: StopTokenIdsMaxEntries}}),
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: StopTokenIdsMaxEntries}}).
+				withRule(RequestFilterStagePreValidation, elementsMustBeUint),
 			newParameter("reasoning").
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.ReasoningValidator{},
@@ -517,6 +539,7 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 					Validator: paramvalidators.ToolChoiceValidator{MaxNameLen: ToolChoiceMaxNameLen},
 				}),
 			newParameter("min_tokens").
+				withRule(RequestFilterStagePreValidation, mustBeUint).
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.ConditionalStripParameter{
 					Predicate: func(ctx paramvalidators.ParameterContext) bool {
 						_, ok := ctx.Document["stop_token_ids"]
@@ -525,6 +548,7 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 				}}).
 				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.ClampUintToFieldParameter{MaxField: "max_tokens"}}),
 			newParameter("bad_words").
+				withRule(RequestFilterStagePreValidation, elementsMustBeString).
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeStringListParameter{
 					Keep: func(value string) bool {
 						return strings.TrimSpace(value) != ""
@@ -581,18 +605,18 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 			newParameter("structured_outputs").
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.StructuredOutputsValidator{
-						RejectedModels:       []string{kimiK26ModelID},
-						MaxDepth:             StructuredOutputsMaxDepth,
-						MaxSize:              StructuredOutputsMaxSize,
-						MaxNodes:             StructuredOutputsMaxNodes,
-						MaxBranch:            StructuredOutputsMaxBranch,
-						MaxEnum:              StructuredOutputsMaxEnum,
-						MaxPatternLen:        StructuredOutputsMaxPatternLen,
-						MaxChoiceEntries:     StructuredOutputsMaxChoiceEntries,
-						MaxChoiceEntryLen:    StructuredOutputsMaxChoiceEntryLen,
-						MaxGrammarLen:        StructuredOutputsMaxGrammarLen,
-						MaxGrammarNesting:    StructuredOutputsMaxGrammarNesting,
-						MaxStructuralTagLen:  StructuredOutputsMaxStructuralTagLen,
+						RejectedModels:      []string{kimiK26ModelID},
+						MaxDepth:            StructuredOutputsMaxDepth,
+						MaxSize:             StructuredOutputsMaxSize,
+						MaxNodes:            StructuredOutputsMaxNodes,
+						MaxBranch:           StructuredOutputsMaxBranch,
+						MaxEnum:             StructuredOutputsMaxEnum,
+						MaxPatternLen:       StructuredOutputsMaxPatternLen,
+						MaxChoiceEntries:    StructuredOutputsMaxChoiceEntries,
+						MaxChoiceEntryLen:   StructuredOutputsMaxChoiceEntryLen,
+						MaxGrammarLen:       StructuredOutputsMaxGrammarLen,
+						MaxGrammarNesting:   StructuredOutputsMaxGrammarNesting,
+						MaxStructuralTagLen: StructuredOutputsMaxStructuralTagLen,
 					},
 				}),
 			newParameter("safety_identifier").
@@ -619,30 +643,46 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 		},
 		[]VLLMParameter{
 			// PreValidation so the floor lands before applyOutputTokenLimits (caps down) and the
-			// thinking_token_budget defaulter (derives ttb from max_tokens).
+			// thinking_token_budget defaulter (derives ttb from max_tokens). Kimi clamps a
+			// too-small budget up to its floor (think-burn mitigation); other models reject a
+			// non-positive budget outright since they have no such floor.
 			newParameter("max_tokens").
 				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
-					Models:  []string{kimiK26ModelID},
-					Handler: MinUintParameterHandler{Min: kimiMaxTokensMin},
+					Models:           []string{kimiK26ModelID},
+					Handler:          MinUintParameterHandler{Min: kimiMaxTokensMin},
+					UnmatchedHandler: rejectNonPositiveNumber,
 				}),
 			newParameter("max_completion_tokens").
 				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
-					Models:  []string{kimiK26ModelID},
-					Handler: MinUintParameterHandler{Min: kimiMaxTokensMin},
+					Models:           []string{kimiK26ModelID},
+					Handler:          MinUintParameterHandler{Min: kimiMaxTokensMin},
+					UnmatchedHandler: rejectNonPositiveNumber,
 				}),
+			// Sampling knobs with per-field ranges: min_p clamps into [0, 1]; top_p clamps
+			// down to 1 but rejects a non-positive value (exclusive lower bound); top_k
+			// accepts -1 (disabled) or any integer >= 1.
+			newParameter("min_p").
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Min: floatPointer(MinPMin), Max: floatPointer(MinPMax)}}),
+			newParameter("top_p").
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(TopPMax)}}).
+				withRule(RequestFilterStagePostLimits, rejectNonPositiveNumber),
+			newParameter("top_k").
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true}}).
+				withRule(RequestFilterStagePostLimits, rejectInvalidTopK),
 		},
+		// model and stream are type-checked during the typed parse (string / bool); register
+		// them as known so the whitelist keeps them.
 		newParameters([]string{
 			"model",
 			"stream",
+		}),
+		// The remaining boolean flags are pass-through fields, so validate their type here.
+		newParameters([]string{
 			"skip_special_tokens",
 			"detokenize",
 			"parallel_tool_calls",
-		}),
-		newParameters([]string{"top_p", "top_k", "min_p"},
-			ParameterRule{
-				Stage:   RequestFilterStagePostLimits,
-				Handler: ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true}},
-			},
+		},
+			ParameterRule{Stage: RequestFilterStagePreValidation, Handler: mustBeBool},
 		),
 		newParameters([]string{"service_tier", "store", "provider", "plugins", "prompt_cache_key", "cache_key", "extra_headers", "thinking_config", "think"},
 			ParameterRule{Stage: RequestFilterStagePreValidation, Handler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}}},

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -275,6 +275,125 @@ func TestNormalizeChatRequestKeepsTemperatureWithinMax(t *testing.T) {
 	require.EqualValues(t, 1.5, raw["temperature"])
 }
 
+func TestNormalizeChatRequestClampsTemperatureBelowMin(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hi"}],
+		"temperature": -1
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 0.0, raw["temperature"])
+}
+
+func TestNormalizeChatRequestClampsMinPIntoRange(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"min_p":-0.5}`))
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 0.0, raw["min_p"])
+
+	body, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"min_p":2}`))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 1.0, raw["min_p"])
+}
+
+func TestNormalizeChatRequestTopPClampsHighRejectsNonPositive(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"top_p":1.5}`))
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 1.0, raw["top_p"])
+
+	for _, bad := range []string{"0", "-0.2"} {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"top_p":` + bad + `}`))
+		require.Error(t, err, "top_p=%s", bad)
+		require.Contains(t, err.Error(), "top_p")
+	}
+}
+
+func TestNormalizeChatRequestRejectsNonPositiveRepetitionPenalty(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"repetition_penalty":0}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "repetition_penalty")
+
+	body, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"repetition_penalty":5}`))
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 2.0, raw["repetition_penalty"])
+}
+
+func TestNormalizeChatRequestRejectsInvalidTopK(t *testing.T) {
+	for _, bad := range []string{"0", "-2"} {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"top_k":` + bad + `}`))
+		require.Error(t, err, "top_k=%s", bad)
+		require.Contains(t, err.Error(), "top_k")
+	}
+	for _, good := range []string{"-1", "1", "50"} {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"top_k":` + good + `}`))
+		require.NoError(t, err, "top_k=%s", good)
+	}
+}
+
+func TestNormalizeChatRequestRejectsZeroMaxTokens(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"max_tokens":0}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max_tokens")
+
+	_, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"max_completion_tokens":0}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max_completion_tokens")
+}
+
+func TestNormalizeChatRequestKimiClampsZeroMaxTokensInsteadOfRejecting(t *testing.T) {
+	body, _, err := normalizeChatRequestForModel([]byte(`{"messages":[{"role":"user","content":"hi"}],"max_tokens":0}`), kimiK26ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, kimiMaxTokensMin, raw["max_tokens"])
+}
+
+func TestNormalizeChatRequestRejectsNonBoolFlags(t *testing.T) {
+	for _, field := range []string{"skip_special_tokens", "detokenize", "parallel_tool_calls"} {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"` + field + `":"yes"}`))
+		require.Error(t, err, field)
+		require.Contains(t, err.Error(), field)
+	}
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"skip_special_tokens":true,"parallel_tool_calls":false}`))
+	require.NoError(t, err)
+}
+
+func TestNormalizeChatRequestRejectsNonIntStopTokenIds(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"stop_token_ids":[1,"two",3]}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stop_token_ids")
+
+	_, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"stop_token_ids":[1,2,3]}`))
+	require.NoError(t, err)
+}
+
+func TestNormalizeChatRequestRejectsNonStringStopAndBadWords(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"stop":["ok",5]}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stop")
+
+	_, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"bad_words":["ok",5]}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad_words")
+}
+
+func TestNormalizeChatRequestRejectsNonIntMinTokens(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"min_tokens":3.5}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "min_tokens")
+
+	_, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"min_tokens":5,"max_tokens":100}`))
+	require.NoError(t, err)
+}
+
 func TestNormalizeChatRequestClampsFrequencyAndPresencePenalty(t *testing.T) {
 	// OpenAI/vLLM accept [-2.0, 2.0] for both. Catalog clamps; out-of-range is rewritten,
 	// not rejected. Per-Kimi force-zero is exercised separately under ApplyKimiRequestOverrides.

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -46,7 +46,7 @@ func TestNormalizeChatRequestDefaultsAndCapsOutputTokens(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 64, req.MaxTokens)
 	require.EqualValues(t, 64, req.MaxCompletionTokens)
-	require.NotContains(t, string(body), `"max_tokens"`)
+	require.Contains(t, string(body), `"max_tokens":64`)
 	require.Contains(t, string(body), `"max_completion_tokens":64`)
 
 	body, req, err = normalizeChatRequest([]byte(`{"max_tokens":10001,"max_completion_tokens":20000,"messages":[{"role":"user","content":"hello"}]}`))
@@ -126,7 +126,7 @@ func TestPrepareChatRequestBodyAdminAuthKeepsMaxCompletionTokensAboveDefault(t *
 	require.NoError(t, err)
 	require.EqualValues(t, 30_000, chatReq.MaxTokens)
 	require.EqualValues(t, 30_000, chatReq.MaxCompletionTokens)
-	require.NotContains(t, string(body), `"max_tokens"`)
+	require.Contains(t, string(body), `"max_tokens":30000`)
 	require.Contains(t, string(body), `"max_completion_tokens":30000`)
 }
 
@@ -354,6 +354,22 @@ func TestNormalizeChatRequestKimiClampsZeroMaxTokensInsteadOfRejecting(t *testin
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(body, &raw))
 	require.EqualValues(t, kimiMaxTokensMin, raw["max_tokens"])
+}
+
+// Regression (found via e2e against the live Kimi route): a Kimi request that
+// sends only max_completion_tokens must floor it AND mirror into max_tokens, so
+// the thinking_token_budget defaulter (which derives from max_tokens) bounds
+// reasoning. Without the mirror the whole budget is spent thinking → empty content.
+func TestNormalizeChatRequestKimiMaxCompletionTokensZeroMirrorsToMaxTokens(t *testing.T) {
+	body, req, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"hi"}],"max_completion_tokens":0}`), kimiK26ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, kimiMaxTokensMin, raw["max_tokens"], "max_tokens mirrored + floored")
+	require.EqualValues(t, kimiMaxTokensMin, raw["max_completion_tokens"], "max_completion_tokens floored")
+	require.EqualValues(t, kimiMaxTokensMin, req.MaxTokens)
+	require.Contains(t, raw, "thinking_token_budget", "thinking budget derives from the mirrored max_tokens")
 }
 
 func TestNormalizeChatRequestRejectsNonBoolFlags(t *testing.T) {

--- a/docs/chat-api/README.md
+++ b/docs/chat-api/README.md
@@ -28,21 +28,21 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M
 |-------|------|---------|----------|--------|
 | `model` | string | — | Required; route key | [[OpenAI-1]](references.md#openai) |
 | `messages` | array | — | Required; OpenAI shape (see [Messages contract](#messages-contract)); ≤2048 entries | [[OpenAI-1]](references.md#openai) |
-| `temperature` | float | 1.0 | cap ≤ 2.0; sanitize (NaN/Inf strip) | [[OpenAI-1]](references.md#openai) |
-| `top_p` | float | 1.0 | sanitize (NaN/Inf strip) | [[OpenAI-1]](references.md#openai) |
-| `top_k` | int | — | sanitize float; vLLM extension | [[vLLM-1]](references.md#vllm) |
-| `min_p` | float | — | sanitize; vLLM extension | [[vLLM-1]](references.md#vllm) |
+| `temperature` | float | 1.0 | clamp to `[0, 2]`; sanitize (NaN/Inf strip) | [[OpenAI-1]](references.md#openai) |
+| `top_p` | float | 1.0 | clamp `>1` → `1`; reject `≤0` (must be in `(0, 1]` — [why](troubleshooting.md#reject-out-of-range-sampling)); sanitize (NaN/Inf strip) | [[OpenAI-1]](references.md#openai) |
+| `top_k` | int | — | must be `-1` (disabled) or `≥1`, else reject ([why](troubleshooting.md#reject-out-of-range-sampling)); sanitize float; vLLM extension | [[vLLM-1]](references.md#vllm) |
+| `min_p` | float | — | clamp to `[0, 1]`; sanitize; vLLM extension | [[vLLM-1]](references.md#vllm) |
 | `frequency_penalty` | float | 0.0 | clamp `[-2, 2]`; see [Kimi override](kimi-k2.6.md#parameter-overrides) for force-rewrite | [[OpenAI-1]](references.md#openai) |
 | `presence_penalty` | float | 0.0 | clamp `[-2, 2]`; see [Kimi override](kimi-k2.6.md#parameter-overrides) for force-rewrite | [[OpenAI-1]](references.md#openai) |
-| `repetition_penalty` | float | 1.0 | cap ≤ 2.0; vLLM extension | [[vLLM-1]](references.md#vllm) |
+| `repetition_penalty` | float | 1.0 | clamp `>2` → `2`; reject `≤0` (must be `>0` — [why](troubleshooting.md#reject-out-of-range-sampling)); vLLM extension | [[vLLM-1]](references.md#vllm) |
 | `logit_bias` | object | — | ≤1024 entries; value range `[-100, 100]` | [[OpenAI-1]](references.md#openai) |
-| `max_tokens` | int | — | clamp | [[OpenAI-1]](references.md#openai) |
-| `max_completion_tokens` | int | — | alias for max_tokens | [[OpenAI-1]](references.md#openai) |
-| `stream` | bool | false | pass-through | [[OpenAI-1]](references.md#openai) |
+| `max_tokens` | int | — | must be `≥1` (reject `0` — [why](troubleshooting.md#reject-nonpositive-max-tokens)); capped to model max; Kimi-K2.6 floors small values to 16 ([why](troubleshooting.md#kimi-empty-content-think-burn)) | [[OpenAI-1]](references.md#openai) |
+| `max_completion_tokens` | int | — | alias for max_tokens (same `≥1` reject / cap / Kimi-floor handling) | [[OpenAI-1]](references.md#openai) |
+| `stream` | bool | false | must be a boolean (else reject — [why](troubleshooting.md#reject-malformed-param-types)); pass-through | [[OpenAI-1]](references.md#openai) |
 | `stream_options` | object | — | strip when stream≠true; whitelist `include_usage`; strip `continuous_usage_stats` | [[OpenAI-1]](references.md#openai) |
-| `stop` | str\|array | — | pass-through; ≤16 entries × 256 B each | [[OpenAI-1]](references.md#openai) |
+| `stop` | str\|array | — | array entries must be strings (else reject — [why](troubleshooting.md#reject-malformed-param-types)); ≤16 entries × 256 B each | [[OpenAI-1]](references.md#openai) |
 | `n` | int | 1 | hard cap ≤5; coerce to 1 when temperature==0 ([why](troubleshooting.md#coerce-n-when-temperature-zero)) | [[OpenAI-1]](references.md#openai), [[CVE-9]](references.md#security-advisories) |
-| `seed` | uint64 | — | pass-through | [[OpenAI-1]](references.md#openai) |
+| `seed` | uint64 | — | must be a non-negative integer (else reject — [why](troubleshooting.md#reject-malformed-param-types)); pass-through | [[OpenAI-1]](references.md#openai) |
 | `logprobs` | bool | — | force `true`; observability pipeline | — |
 | `top_logprobs` | int | — | force `5`; observability pipeline | — |
 | `return_token_ids` | bool | — | force `true`; required for stream-derived `enforced_tokens` reconstruction on Kimi-K2.6 reasoning routes (without it, `<think>`/`</think>` are silently dropped from SSE while still counted in `usage.completion_tokens`). Resulting `prompt_token_ids` / `choices[].token_ids` are stripped from the client-facing response | [[vLLM-19]](references.md#vllm), [[vLLM-20]](references.md#vllm) |
@@ -50,7 +50,7 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M
 | `structured_outputs` | object | — | validated against vLLM envelope (`json`/`regex`/`choice`/`grammar`/`json_object`/`structural_tag`); CVE-driven caps per sub-field — see [Qwen native extensions](qwen3-235b-a22b-instruct-2507.md#native-extensions); **rejected on Kimi-K2.6 route** ([why](troubleshooting.md#reject-structured_outputs-kimi)); **accepted on MiniMax-M2.7 route** — vLLM enforces it ([details](troubleshooting.md#accept-structured_outputs-minimax)); `structural_tag` must be the object form (string form is rejected — crashes the engine); **rejected if combined with `response_format`** ([why](troubleshooting.md#reject-structured_outputs-with-response_format)) | [[vLLM-16]](references.md#vllm), [[vLLM-18]](references.md#vllm), [[CVE-3]](references.md#security-advisories), [[CVE-4]](references.md#security-advisories), [[CVE-8]](references.md#security-advisories) |
 | `tools` | array | — | shape-bounded: function schema depth ≤16, nodes ≤256, branch arms ≤16, enum ≤256, size ≤16 KiB; `$ref`/`$defs`/`definitions` forbidden; `pattern` ≤512 B + regex compile; `function.name` ≤64 B; `tools[].function.strict` silent-stripped (vLLM parsers ignore) | [[OpenAI-1]](references.md#openai), [[CVE-2]](references.md#security-advisories) |
 | `tool_choice` | string\|object | "auto" if tools | shape-strict; `function.name` ≤64 B; `"required"` coerced ([why](troubleshooting.md#coerce-tool-choice-required)) | [[OpenAI-1]](references.md#openai) |
-| `parallel_tool_calls` | bool | — | pass-through | [[OpenAI-1]](references.md#openai) |
+| `parallel_tool_calls` | bool | — | must be a boolean (else reject — [why](troubleshooting.md#reject-malformed-param-types)); pass-through | [[OpenAI-1]](references.md#openai) |
 | `user` | string | — | byte-length ≤512 | [[OpenAI-1]](references.md#openai) |
 | `safety_identifier` | string | — | silent-strip; see [Kimi override](kimi-k2.6.md#parameter-overrides) for pass-through ([why](troubleshooting.md#strip-safety_identifier)) | [[OpenAI-6]](references.md#openai) |
 | `metadata` | object | — | OpenAI bounds: ≤16 keys × 64-char × 512-char vals | [[OpenAI-1]](references.md#openai) |
@@ -67,11 +67,11 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M
 | `enable_thinking` | bool | — | translate to chat_template_kwargs ([why](troubleshooting.md#translate-enable_thinking)) | [[Qwen-3]](references.md#qwen) |
 | `thinking_config` | object | — | silent-strip ([why](troubleshooting.md#strip-thinking_config)) | — |
 | `think` | bool | — | silent-strip ([why](troubleshooting.md#strip-think)) | — |
-| `min_tokens` | int | — | vLLM extension; clamp to ≤max_tokens; conditional strip when stop_token_ids set | [[vLLM-1]](references.md#vllm) |
-| `bad_words` | string array | — | vLLM extension; ≤64 entries × 128 B per entry | [[vLLM-1]](references.md#vllm) |
-| `stop_token_ids` | int array | — | vLLM extension; ≤64 | [[vLLM-1]](references.md#vllm) |
-| `skip_special_tokens` | bool | — | vLLM extension; pass-through | [[vLLM-1]](references.md#vllm) |
-| `detokenize` | bool | — | vLLM extension; pass-through | [[vLLM-1]](references.md#vllm) |
+| `min_tokens` | int | — | vLLM extension; must be a non-negative integer (else reject — [why](troubleshooting.md#reject-malformed-param-types)); clamp to ≤max_tokens; conditional strip when stop_token_ids set | [[vLLM-1]](references.md#vllm) |
+| `bad_words` | string array | — | vLLM extension; entries must be strings (else reject — [why](troubleshooting.md#reject-malformed-param-types)); ≤64 entries × 128 B per entry | [[vLLM-1]](references.md#vllm) |
+| `stop_token_ids` | int array | — | vLLM extension; entries must be non-negative integers (else reject — [why](troubleshooting.md#reject-malformed-param-types)); ≤64 | [[vLLM-1]](references.md#vllm) |
+| `skip_special_tokens` | bool | — | vLLM extension; must be a boolean (else reject — [why](troubleshooting.md#reject-malformed-param-types)) | [[vLLM-1]](references.md#vllm) |
+| `detokenize` | bool | — | vLLM extension; must be a boolean (else reject — [why](troubleshooting.md#reject-malformed-param-types)) | [[vLLM-1]](references.md#vllm) |
 | `chat_template_kwargs` | object | — | depth ≤16, nodes ≤128, size ≤16 KiB; key denylist (`chat_template`, `tokenize`, `tools`, `documents`, `conversation`, `continue_final_message`, `padding`, `truncation`, `max_length`, `return_tensors`, `return_dict`) — CVE-2025-61620 / CVE-2025-62426 mitigation | [[vLLM-1]](references.md#vllm), [[CVE-5]](references.md#security-advisories), [[CVE-6]](references.md#security-advisories) |
 
 *Parameters with truly model-exclusive behavior (`thinking`, `thinking_token_budget`, `messages[].reasoning_content`) are documented in the per-model docs — see [Kimi-K2.6](kimi-k2.6.md) and [Qwen3-235B-A22B-Instruct-2507](qwen3-235b-a22b-instruct-2507.md). For params with universal baseline behavior plus per-model adjustments (`frequency_penalty`, `presence_penalty`, `safety_identifier`), the baseline appears above and the per-model override is linked from the row.*

--- a/docs/chat-api/troubleshooting.md
+++ b/docs/chat-api/troubleshooting.md
@@ -21,6 +21,9 @@ Every parameter that is stripped / rejected / normalized at the gateway is docum
 | `extra_body` keys appear at top level | OpenAI Python SDK passthrough | [#unwrap-extra_body](#unwrap-extra_body) |
 | `enable_thinking` lifts into `chat_template_kwargs` | Qwen3 canonical placement | [#translate-enable_thinking](#translate-enable_thinking) |
 | `reasoning` object decomposed to top-level `reasoning_effort` | OpenRouter unified-reasoning convention | [#translate-reasoning](#translate-reasoning) |
+| 400 on out-of-range `top_p` / `repetition_penalty` / `top_k` | value outside backend-accepted range | [#reject-out-of-range-sampling](#reject-out-of-range-sampling) |
+| 400 on `max_tokens: 0` (non-Kimi route) | zero output budget | [#reject-nonpositive-max-tokens](#reject-nonpositive-max-tokens) |
+| 400 on wrong-typed param (bool / int / array element) | type mismatch caught at the gateway | [#reject-malformed-param-types](#reject-malformed-param-types) |
 
 ## Silent strips
 
@@ -500,6 +503,42 @@ Every parameter that is stripped / rejected / normalized at the gateway is docum
 Multiple parallel tool results in one block: one array entry per call.
 
 **Captured-requests**: n/a — pre-deployment design decision.
+
+---
+
+### #reject-out-of-range-sampling
+
+**What**: HTTP 400 on `top_p ≤ 0`, `repetition_penalty ≤ 0`, or a `top_k` that is neither `-1` nor `≥ 1`.
+
+**Why**: These sampling knobs have ranges the backend enforces: `top_p` must be in `(0, 1]` and `repetition_penalty` must be `> 0` per the OpenAI/vLLM wire schema [[OpenAI-1]](references.md#openai), [[vLLM-1]](references.md#vllm); `top_k` accepts `-1` (disabled) or any integer `≥ 1`. The low end is an *exclusive* bound, so clamping to it would itself be invalid (e.g. `top_p = 0` is not a legal value) — the gateway returns a clear, field-named 400 at the boundary instead of forwarding a value the engine rejects with an opaque error. Values above the *upper* bound are clamped instead (`top_p > 1 → 1`, `repetition_penalty > 2 → 2`), and `temperature` / `min_p` are clamped into `[0, 2]` / `[0, 1]`.
+
+**Fix (client-side)**: send `top_p` in `(0, 1]`, `repetition_penalty > 0`, and `top_k` as `-1` or a positive integer.
+
+**Captured-requests**: n/a — no captures observed.
+
+---
+
+### #reject-nonpositive-max-tokens
+
+**What**: HTTP 400 on `max_tokens: 0` (or `max_completion_tokens: 0`) for non-Kimi routes.
+
+**Why**: A zero output budget is not a meaningful request — vLLM emits no content, and the gateway's redundancy layer then waits for a winner that can never arrive, so the request hangs to the deadline instead of failing fast. The gateway requires `max_tokens ≥ 1` [[OpenAI-1]](references.md#openai). Kimi-K2.6 instead floors small budgets to 16 as part of its think-burn mitigation (see [#kimi-empty-content-think-burn](#kimi-empty-content-think-burn)), so `0` becomes `16` on that route rather than a 400.
+
+**Fix (client-side)**: send `max_tokens ≥ 1`, or omit it to take the route default.
+
+**Captured-requests**: n/a — no captures observed.
+
+---
+
+### #reject-malformed-param-types
+
+**What**: HTTP 400 when a parameter carries the wrong JSON type: non-boolean `stream` / `skip_special_tokens` / `detokenize` / `parallel_tool_calls`; non-integer `seed` / `min_tokens`; non-string elements in `stop` / `bad_words`; non-integer elements in `stop_token_ids`.
+
+**Why**: vLLM rejects these with type errors at the engine boundary, producing opaque upstream 400s. The gateway type-checks them up front against the OpenAI/vLLM wire schema [[OpenAI-1]](references.md#openai), [[vLLM-1]](references.md#vllm) so the client gets an immediate, field-named error instead of a backend round-trip.
+
+**Fix (client-side)**: send each field with its declared type — booleans for the flags, non-negative integers for `seed` / `min_tokens` and `stop_token_ids` elements, strings for `stop` / `bad_words` elements.
+
+**Captured-requests**: n/a — no captures observed.
 
 ## Per-model gotchas
 


### PR DESCRIPTION
## Summary
- The gateway forwarded out-of-range, non-positive, and wrong-typed chat-completion parameters straight to vLLM, which returned opaque upstream 400s — and `max_tokens: 0` (non-Kimi) was worse: vLLM emitted no content, the redundancy layer waited for a winner that can never arrive, and the request returned **0 bytes and timed out**, tying up a request slot/escrow for the full deadline.
- Added gateway-side validation so the backend only ever sees legal values. Out-of-range values with a sane target are clamped; values whose only out-of-bound is an exclusive lower bound or an invalid discrete value are rejected with a clear, field-named 400:

  | Param | Gateway rule |
  |-------|--------------|
  | `temperature` | clamp to `[0, 2]` |
  | `min_p` | clamp to `[0, 1]` |
  | `top_p` | clamp `>1` → `1`; reject `≤0` (must be in `(0, 1]`) |
  | `repetition_penalty` | clamp `>2` → `2`; reject `≤0` (must be `>0`) |
  | `top_k` | reject unless `-1` (disabled) or `≥1` |
  | `max_tokens` / `max_completion_tokens` | reject `0` on non-Kimi routes; Kimi-K2.6 floors small budgets to 16 |
  | `seed`, `min_tokens` | reject non-integer |
  | `stream`, `skip_special_tokens`, `detokenize`, `parallel_tool_calls` | reject non-boolean |
  | `stop`, `bad_words` | reject non-string array elements |
  | `stop_token_ids` | reject non-integer array elements |

- Collapsed the reject/validate logic into three predicate-driven handlers in the `paramvalidators` package — `RejectNumberParameter{Allow, Message}`, `ValidateScalarParameter`, `ValidateListElementsParameter` — driven from the catalog via reusable stateless `ParameterHandlerAdapter` instances (`rejectNonPositiveNumber`, `rejectInvalidTopK`, `mustBeBool`, `mustBeUint`, `elementsMustBeString`, `elementsMustBeUint`). Per-model behavior reuses the existing `ModelScopedParameterHandler` (Kimi clamps `max_tokens`, others reject `0`).

## Why
These parameters are all valid OpenAI/vLLM fields, but the gateway passed any value through and let the engine reject it — producing opaque upstream 400s with no field name, and in the `max_tokens: 0` case a silent hang instead of an error. Catching the bad value at the boundary gives the client an immediate, specific error and keeps invalid requests from consuming a slot.

Reject vs clamp is deliberate: `temperature`/`min_p`/`top_p`/`repetition_penalty` have a sane in-range target so they are clamped silently (in-range client behavior is unchanged), but `top_p`/`repetition_penalty` `≤ 0` have an exclusive lower bound where clamping to `0` would itself be illegal, and `top_k`/`max_tokens: 0` are invalid discrete values — those are rejected. `max_tokens` is per-model: Kimi-K2.6 already floors small budgets to 16 as a think-burn mitigation, so on that route `0` becomes `16` rather than a 400.

The handler unification and file split carry no behavior change — they remove near-duplicate reject/validate types and break up a ~960-line file that mixed handler primitives, the catalog, the JSON document, and parsing.

## Tests
New unit tests, each exercising `normalizeChatRequest` end-to-end (RED → GREEN):

- `TestNormalizeChatRequestClampsTemperatureBelowMin` — `temperature: -1` → `0`
- `TestNormalizeChatRequestClampsMinPIntoRange` — `min_p` clamped into `[0, 1]`
- `TestNormalizeChatRequestTopPClampsHighRejectsNonPositive` — `>1` → `1`; `0` / `-0.2` rejected
- `TestNormalizeChatRequestRejectsNonPositiveRepetitionPenalty` — `0` rejected; `>2` clamped to `2`
- `TestNormalizeChatRequestRejectsInvalidTopK` — `0` / `-2` rejected; `-1` / `1` / `50` accepted
- `TestNormalizeChatRequestRejectsZeroMaxTokens` — `max_tokens` / `max_completion_tokens` = `0` rejected (non-Kimi)
- `TestNormalizeChatRequestKimiClampsZeroMaxTokensInsteadOfRejecting` — Kimi route: `0` → `16`
- `TestNormalizeChatRequestRejectsNonBoolFlags` — non-bool `skip_special_tokens` / `detokenize` / `parallel_tool_calls` rejected
- `TestNormalizeChatRequestRejectsNonIntStopTokenIds` — non-int `stop_token_ids` element rejected
- `TestNormalizeChatRequestRejectsNonStringStopAndBadWords` — non-string `stop` / `bad_words` element rejected
- `TestNormalizeChatRequestRejectsNonIntMinTokens` — non-int `min_tokens` rejected

Existing parameter tests (clamp-above-max, NaN/string sanitize, greedy `n` coercion, Kimi `max_tokens` floor) unchanged. `go build ./...`, `go vet ./cmd/devshardctl/`, and `go test ./cmd/devshardctl/...` all green.

## Test plan
- [x] Out-of-range sampling values clamped or rejected per the table above
- [x] `max_tokens: 0` rejected on non-Kimi routes, floored to 16 on Kimi-K2.6
- [x] Wrong-typed params (bool / int / array element) rejected with a field-named 400
- [x] Handler unification + file split carry no behavior change (full suite green)
- [x] `go test ./...` in `devshard/` green