### PR TITLE
Secure observability UI proxying with Jaeger basic auth and opt-in de…

### DIFF
--- a/deploy/join/config.env.template
+++ b/deploy/join/config.env.template
@@ -19,9 +19,15 @@ export PORT=8080
 export INFERENCE_PORT=5050
 export KEYRING_BACKEND=file
 
-# Observability Tools (docs/observability/observability-overview.md)
-export JAEGER_ENABLED=true
-export GRAFANA_ENABLED=true
+# Observability (docs/observability/observability-overview.md)
+# Jaeger and Grafana UIs are disabled by default. Set credentials below first,
+# then set JAEGER_ENABLED=true and/or GRAFANA_ENABLED=true to expose them via proxy.
+export JAEGER_ENABLED=false
+export GRAFANA_ENABLED=false
+export JAEGER_BASIC_AUTH_USER=jaeger
+export JAEGER_BASIC_AUTH_PASSWORD=<FILLIN>
+export GRAFANA_ADMIN_USER=admin
+export GRAFANA_ADMIN_PASSWORD=<FILLIN>
 export DAPI_OTEL_ENABLED=true
 export DEVSHARD_OTEL_ENABLED=true
 export OTEL_ENDPOINT=http://jaeger:4317

--- a/deploy/join/docker-compose.observability.yml
+++ b/deploy/join/docker-compose.observability.yml
@@ -2,14 +2,17 @@ services:
   # Extend the existing services with Jaeger environment variables
   proxy:
     environment:
-      # Optional Jaeger UI proxying
+      # Optional Jaeger UI proxying (requires JAEGER_BASIC_AUTH_* when enabled)
       - JAEGER_ENABLED=${JAEGER_ENABLED:-false}
       - JAEGER_PORT=${JAEGER_PORT:-16686}
       - JAEGER_BASE_PATH=${JAEGER_BASE_PATH:-/jaeger}
-      # Grafana UI proxying
-      - GRAFANA_ENABLED=${GRAFANA_ENABLED:-true}
+      - JAEGER_BASIC_AUTH_USER=${JAEGER_BASIC_AUTH_USER:-}
+      - JAEGER_BASIC_AUTH_PASSWORD=${JAEGER_BASIC_AUTH_PASSWORD:-}
+      # Grafana UI proxying (requires GRAFANA_ADMIN_PASSWORD when enabled)
+      - GRAFANA_ENABLED=${GRAFANA_ENABLED:-false}
       - GRAFANA_PORT=${GRAFANA_PORT:-3000}
       - GRAFANA_BASE_PATH=${GRAFANA_BASE_PATH:-/grafana}
+      - GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-}
 
   jaeger:
     container_name: jaeger

--- a/docs/observability/observability-overview.md
+++ b/docs/observability/observability-overview.md
@@ -19,11 +19,11 @@ The join deployment now has an optional observability overlay in `deploy/join/do
 
 | Component | Purpose | Default internal endpoint | External/local binding |
 | --- | --- | --- | --- |
-| Jaeger | OTLP trace receiver and trace UI | `jaeger:4317`, `jaeger:16686/jaeger` | proxied at `/jaeger/` when enabled |
+| Jaeger | OTLP trace receiver and trace UI | `jaeger:4317`, `jaeger:16686/jaeger` | proxied at `/jaeger/` when enabled (nginx basic auth) |
 | Prometheus | Metrics scraping and storage | `prometheus:9090` | `127.0.0.1:9099` |
 | Loki | Log storage | `loki:3100` | `127.0.0.1:3101` |
 | Promtail | Docker log discovery and shipping to Loki | n/a | n/a |
-| Grafana | Dashboards and data exploration | `grafana:3000` | `127.0.0.1:3000`, proxied at `/grafana/` when enabled |
+| Grafana | Dashboards and data exploration | `grafana:3000` | `127.0.0.1:3000`, proxied at `/grafana/` when enabled (Grafana login) |
 | cAdvisor | Container CPU, memory, network, and filesystem metrics | `cadvisor:8080` | `127.0.0.1:8088` |
 
 Grafana datasources are provisioned automatically:
@@ -36,14 +36,45 @@ Loki has a derived field that extracts `trace_id` from JSON/logfmt log bodies an
 
 ## Enabling The Stack
 
-The template `deploy/join/config.env.template` includes the main switches:
+The template `deploy/join/config.env.template` ships with **Jaeger and Grafana UIs disabled by default** (`JAEGER_ENABLED=false`, `GRAFANA_ENABLED=false`). Metrics, logs, and trace export to Jaeger OTLP still work when the observability overlay is running; only the **public proxy UI routes** stay off until you opt in.
+
+### Security prerequisites (set before enabling UIs)
+
+Jaeger has **no built-in login**. When you expose `/jaeger/` through the nginx proxy, protect it with **nginx HTTP basic auth**:
+
+| Variable | Required when | Purpose |
+| --- | --- | --- |
+| `JAEGER_BASIC_AUTH_USER` | `JAEGER_ENABLED=true` | Basic auth username for `/jaeger/` |
+| `JAEGER_BASIC_AUTH_PASSWORD` | `JAEGER_ENABLED=true` | Basic auth password for `/jaeger/` |
+
+Grafana has its own admin login. Set a **strong admin password before** enabling public UI proxying:
+
+| Variable | Required when | Purpose |
+| --- | --- | --- |
+| `GRAFANA_ADMIN_USER` | recommended | Grafana admin username (default `admin`) |
+| `GRAFANA_ADMIN_PASSWORD` | `GRAFANA_ENABLED=true` | Grafana admin password; must not be left at defaults |
+
+The proxy **refuses to start** if `JAEGER_ENABLED=true` without Jaeger basic auth credentials, or if `GRAFANA_ENABLED=true` with a missing/placeholder password (`admin1`, `<FILLIN>`, etc.).
+
+### Example configuration
+
+Copy `config.env.template` to `config.env`, set secrets, then enable UIs:
 
 ```bash
-export JAEGER_ENABLED=true
-export GRAFANA_ENABLED=true
+# 1. Set credentials first
+export JAEGER_BASIC_AUTH_USER=jaeger
+export JAEGER_BASIC_AUTH_PASSWORD='your-jaeger-basic-auth-secret'
+export GRAFANA_ADMIN_USER=admin
+export GRAFANA_ADMIN_PASSWORD='your-grafana-admin-secret'
+
+# 2. Enable trace/log export (can stay on even when UIs are disabled)
 export DAPI_OTEL_ENABLED=true
 export DEVSHARD_OTEL_ENABLED=true
 export OTEL_ENDPOINT=http://jaeger:4317
+
+# 3. Enable public UI routes only when credentials above are set
+export JAEGER_ENABLED=true
+export GRAFANA_ENABLED=true
 ```
 
 Use the overlay when starting the join stack:
@@ -56,8 +87,10 @@ docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
 
 The proxy exposes UI paths only when the matching flags are enabled:
 
-- `http://<host>:<API_PORT>/grafana/`
-- `http://<host>:<API_PORT>/jaeger/`
+- `http://<host>:<API_PORT>/grafana/` — Grafana login (`GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD`)
+- `http://<host>:<API_PORT>/jaeger/` — nginx basic auth (`JAEGER_BASIC_AUTH_USER` / `JAEGER_BASIC_AUTH_PASSWORD`), then Jaeger UI
+
+OTLP trace ingest (`jaeger:4317`) and Loki log push (`loki:3100`) are **not** proxied on the public API port; they remain on the Docker internal network.
 
 For local-only access, Grafana is also bound on `127.0.0.1:3000`, Prometheus on `127.0.0.1:9099`, Loki on `127.0.0.1:3101`, and cAdvisor on `127.0.0.1:8088`.
 
@@ -427,10 +460,11 @@ If a log line has `trace_id`, Grafana should show a `View trace` derived field l
 
 Check:
 
-1. `GRAFANA_ENABLED=true` is present in `deploy/join/config.env`.
-2. The stack was started with both compose files.
-3. `grafana` is healthy: `docker compose ps grafana`.
-4. `proxy` was recreated after changing the environment.
+1. `GRAFANA_ADMIN_PASSWORD` is set to a strong, non-placeholder value in `deploy/join/config.env`.
+2. `GRAFANA_ENABLED=true` is present in `deploy/join/config.env`.
+3. The stack was started with both compose files.
+4. `grafana` is healthy: `docker compose ps grafana`.
+5. `proxy` was recreated after changing the environment (proxy validates the password at startup).
 
 Common fix:
 
@@ -442,9 +476,11 @@ docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d -
 
 Check:
 
-1. `JAEGER_ENABLED=true` is present.
-2. `jaeger` is running and listening on `16686` internally.
-3. Proxy logs include the Jaeger location block during startup.
+1. `JAEGER_BASIC_AUTH_USER` and `JAEGER_BASIC_AUTH_PASSWORD` are set in `deploy/join/config.env`.
+2. `JAEGER_ENABLED=true` is present.
+3. `jaeger` is running and listening on `16686` internally.
+4. Proxy logs include the Jaeger location block and "basic auth enabled" during startup.
+5. Your browser prompt uses the Jaeger basic auth credentials (Jaeger itself has no login screen).
 
 Common fix:
 
@@ -657,8 +693,8 @@ Useful URLs:
 
 | Tool | URL |
 | --- | --- |
-| Grafana through proxy | `http://<host>:<API_PORT>/grafana/` |
-| Jaeger through proxy | `http://<host>:<API_PORT>/jaeger/` |
+| Grafana through proxy | `http://<host>:<API_PORT>/grafana/` (set `GRAFANA_ADMIN_PASSWORD` before enabling) |
+| Jaeger through proxy | `http://<host>:<API_PORT>/jaeger/` (set `JAEGER_BASIC_AUTH_*` before enabling) |
 | Grafana local bind | `http://127.0.0.1:3000` |
 | Prometheus local bind | `http://127.0.0.1:9099` |
 | Prometheus targets | `http://127.0.0.1:9099/targets` |

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -8,8 +8,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o sidecar main.go
 # Final Stage
 FROM nginx:1.28-alpine
 
-# Install curl, gettext (for envsubst), jq, and bash (for setup-ssl.sh)
-RUN apk add --no-cache curl gettext jq bash
+# Install curl, gettext (for envsubst), jq, bash (for setup-ssl.sh), and
+# apache2-utils (htpasswd for observability UI basic auth).
+RUN apk add --no-cache curl gettext jq bash apache2-utils
 
 # Copy sidecar binary
 COPY --from=builder /app/sidecar /usr/local/bin/sidecar

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -11,8 +11,8 @@ The nginx proxy routes requests to different backend services based on URL paths
 - `/chain-rpc/` → Blockchain RPC endpoint (port 26657)
 - `/chain-api/` → Blockchain REST API (port 1317)
 - `/chain-grpc/` → Blockchain gRPC endpoint (port 9090)
-- `/jaeger/` → Jaeger UI when `JAEGER_ENABLED=true` and the observability overlay is running
-- `/grafana/` → Grafana UI when `GRAFANA_ENABLED=true` and the observability overlay is running
+- `/jaeger/` → Jaeger UI when `JAEGER_ENABLED=true` and the observability overlay is running (nginx basic auth required)
+- `/grafana/` → Grafana UI when `GRAFANA_ENABLED=true` and the observability overlay is running (Grafana login required)
 - `/health` → Nginx health check endpoint
 - `/` → Explorer dashboard when `DASHBOARD_PORT` is set, otherwise a simple "dashboard not configured" page
 
@@ -57,14 +57,17 @@ Key runtime environment variables:
 | `API_SERVICE_NAME` | api | Service name for API upstream |
 | `NODE_SERVICE_NAME` | node | Service name for chain node upstreams |
 | `EXPLORER_SERVICE_NAME` | explorer | Service name for explorer upstream |
-| `JAEGER_ENABLED` | false | Enables proxy routing for the Jaeger UI under `/jaeger/` |
+| `JAEGER_ENABLED` | false | Enables proxy routing for the Jaeger UI under `/jaeger/`. Requires `JAEGER_BASIC_AUTH_USER` and `JAEGER_BASIC_AUTH_PASSWORD`. |
 | `JAEGER_SERVICE_NAME` | jaeger | Service name for Jaeger UI upstream |
 | `JAEGER_PORT` | 16686 | Jaeger UI upstream port |
 | `JAEGER_BASE_PATH` | /jaeger | Base path used by proxied Jaeger UI |
-| `GRAFANA_ENABLED` | false | Enables proxy routing for Grafana under `/grafana/` |
+| `JAEGER_BASIC_AUTH_USER` | - | HTTP basic auth username for `/jaeger/`. Required when `JAEGER_ENABLED=true`. |
+| `JAEGER_BASIC_AUTH_PASSWORD` | - | HTTP basic auth password for `/jaeger/`. Required when `JAEGER_ENABLED=true`. Jaeger has no built-in login; nginx enforces this gate. |
+| `GRAFANA_ENABLED` | false | Enables proxy routing for Grafana under `/grafana/`. Requires a non-default `GRAFANA_ADMIN_PASSWORD`. |
 | `GRAFANA_SERVICE_NAME` | grafana | Service name for Grafana upstream |
 | `GRAFANA_PORT` | 3000 | Grafana upstream port |
 | `GRAFANA_BASE_PATH` | /grafana | Base path used by proxied Grafana UI |
+| `GRAFANA_ADMIN_PASSWORD` | - | Passed to the proxy startup check when `GRAFANA_ENABLED=true`. Must be set to a strong value before enabling public Grafana UI. Also configure on the `grafana` service. |
 | `KEY_NAME` | - | Optional stack key; when set, service names are prefixed as `<KEY_NAME>-*` |
 | `RESOLVER` | 127.0.0.11 | DNS resolver for dynamic upstream resolution (override if needed) |
 | `PROXY_REAL_IP_FROM` | - | Space-separated trusted proxy CIDRs/IPs for nginx `set_real_ip_from` (for example `172.18.0.1/32`). Empty by default (real IP parsing disabled). |
@@ -103,6 +106,28 @@ Key runtime environment variables:
 | `CHAIN_GRPC_RATE_LIMIT_RPS` | 20 | Rate limit for `/chain-grpc/` (default: 20). |
 | `CHAIN_GRPC_RATE_UNIT` | m | Unit for chain gRPC (`s` or `m`). Default `m`. |
 | `CHAIN_GRPC_BURST` | 200 | Burst for chain gRPC. |
+
+### Observability UI security
+
+Jaeger and Grafana UIs are **disabled by default** (`JAEGER_ENABLED=false`, `GRAFANA_ENABLED=false` in `deploy/join/config.env.template`). The observability stack (Prometheus, Loki, trace export) can run without exposing UIs on the public proxy.
+
+When enabling public UI routes, set credentials **before** flipping the enable flags:
+
+1. **Jaeger** — Jaeger has no application login. Set `JAEGER_BASIC_AUTH_USER` and `JAEGER_BASIC_AUTH_PASSWORD`, then set `JAEGER_ENABLED=true`. The proxy refuses to start if Jaeger is enabled without basic auth credentials.
+2. **Grafana** — Set a strong `GRAFANA_ADMIN_PASSWORD` (and optionally `GRAFANA_ADMIN_USER`), then set `GRAFANA_ENABLED=true`. The proxy refuses to start if Grafana is enabled with a missing or placeholder password (`admin1`, `<FILLIN>`, etc.).
+
+Example (`deploy/join/config.env`):
+
+```bash
+export JAEGER_BASIC_AUTH_USER=jaeger
+export JAEGER_BASIC_AUTH_PASSWORD='your-jaeger-basic-auth-secret'
+export GRAFANA_ADMIN_USER=admin
+export GRAFANA_ADMIN_PASSWORD='your-grafana-admin-secret'
+export JAEGER_ENABLED=true
+export GRAFANA_ENABLED=true
+```
+
+See `docs/observability/observability-overview.md` for the full join-stack setup.
 
 > **Note**: `GLOBAL_RATE_LIMIT_RPS` acts as a total ceiling for a single IP. It must be higher than your highest specific limit (e.g. higher than Exempt limit).
 

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -17,7 +17,10 @@ export JAEGER_ENABLED=${JAEGER_ENABLED:-false}
 export JAEGER_SERVICE_NAME=${JAEGER_SERVICE_NAME:-jaeger}
 export JAEGER_PORT=${JAEGER_PORT:-16686}
 export JAEGER_BASE_PATH=${JAEGER_BASE_PATH:-/jaeger}
+export JAEGER_BASIC_AUTH_USER=${JAEGER_BASIC_AUTH_USER:-}
+export JAEGER_BASIC_AUTH_PASSWORD=${JAEGER_BASIC_AUTH_PASSWORD:-}
 export GRAFANA_ENABLED=${GRAFANA_ENABLED:-false}
+export GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-}
 export GRAFANA_SERVICE_NAME=${GRAFANA_SERVICE_NAME:-grafana}
 export GRAFANA_PORT=${GRAFANA_PORT:-3000}
 export GRAFANA_BASE_PATH=${GRAFANA_BASE_PATH:-/grafana}
@@ -146,18 +149,41 @@ else
     export VERSIOND_UPSTREAM="# devshard proxy disabled"
 fi
 
+is_placeholder_password() {
+    case "$1" in
+        ""|admin1|YourSecretPasswordHere|changeme|<FILLIN>)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 if [ "${JAEGER_ENABLED}" = "true" ]; then
-    echo "   Jaeger Service: $FINAL_JAEGER_SERVICE:$JAEGER_PORT (base path: $JAEGER_BASE_PATH)"
+    if [ -z "${JAEGER_BASIC_AUTH_USER}" ] || is_placeholder_password "${JAEGER_BASIC_AUTH_PASSWORD}"; then
+        echo "ERROR: JAEGER_ENABLED=true requires JAEGER_BASIC_AUTH_USER and a non-default JAEGER_BASIC_AUTH_PASSWORD."
+        echo "       Set credentials in config.env before enabling Jaeger UI proxying."
+        exit 1
+    fi
+
+    htpasswd -bc /etc/nginx/jaeger.htpasswd "${JAEGER_BASIC_AUTH_USER}" "${JAEGER_BASIC_AUTH_PASSWORD}"
+
+    echo "   Jaeger Service: $FINAL_JAEGER_SERVICE:$JAEGER_PORT (base path: $JAEGER_BASE_PATH, basic auth enabled)"
     export JAEGER_UPSTREAM="upstream jaeger_backend {
         zone jaeger_backend 64k;
         server ${FINAL_JAEGER_SERVICE}:${JAEGER_PORT} resolve;
     }"
 
     export JAEGER_LOCATION="location = ${JAEGER_BASE_PATH} {
+            auth_basic \"Jaeger\";
+            auth_basic_user_file /etc/nginx/jaeger.htpasswd;
             return 301 ${JAEGER_BASE_PATH}/;
         }
 
         location ${JAEGER_BASE_PATH}/ {
+            auth_basic \"Jaeger\";
+            auth_basic_user_file /etc/nginx/jaeger.htpasswd;
             proxy_pass http://jaeger_backend;
             proxy_set_header Host \$\$host;
             proxy_set_header X-Real-IP \$\$remote_addr;
@@ -170,6 +196,12 @@ else
 fi
 
 if [ "${GRAFANA_ENABLED}" = "true" ]; then
+    if is_placeholder_password "${GRAFANA_ADMIN_PASSWORD}"; then
+        echo "ERROR: GRAFANA_ENABLED=true requires a non-default GRAFANA_ADMIN_PASSWORD."
+        echo "       Set GRAFANA_ADMIN_PASSWORD in config.env before enabling Grafana UI proxying."
+        exit 1
+    fi
+
     echo "   Grafana Service: $FINAL_GRAFANA_SERVICE:$GRAFANA_PORT (base path: $GRAFANA_BASE_PATH)"
     export GRAFANA_UPSTREAM="upstream grafana_backend {
         zone grafana_backend 64k;

--- a/proxy/nginx.unified.conf.template
+++ b/proxy/nginx.unified.conf.template
@@ -92,7 +92,7 @@ http {
     # Dashboard upstream - only included if DASHBOARD_PORT is set
     ${DASHBOARD_UPSTREAM}
 
-    # Jaeger upstream - only included if JAEGER_ENABLED is set
+    # Jaeger upstream - only included if JAEGER_ENABLED is set (nginx basic auth)
     ${JAEGER_UPSTREAM}
 
     # Grafana upstream - only included if GRAFANA_ENABLED is set


### PR DESCRIPTION
Secure observability UI proxying with Jaeger basic auth and opt-in defaults.

Disable Jaeger and Grafana public UI routes by default, require Jaeger
basic auth and a strong Grafana admin password before the proxy will expose
/jaeger/ or /grafana/, and document the setup in join config and observability docs.