### PR TITLE
fix(devshard): make sealing diff-driven to stop state-root divergence

### DIFF
--- a/decentralized-api/internal/devshard/manager.go
+++ b/decentralized-api/internal/devshard/manager.go
@@ -483,7 +483,7 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 
 		for _, rec := range records {
 			sm.InjectWarmKeys(rec.WarmKeyDelta)
-			root, applyErr := sm.ApplyLocal(rec.Nonce, rec.Txs)
+			root, applyErr := sm.ApplyLocalSealed(rec.Nonce, rec.Txs, rec.SealedInferenceIDs)
 			if applyErr != nil {
 				return nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
 			}

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -124,14 +124,12 @@ type Host struct {
 	// Payload prune tracking. All fields below are host-local off-state and
 	// must NOT participate in the state root or snapshot. They drive Tier A
 	// (terminal-status) and Tier C (stale-finished) pruning emission only.
-	pruneSink             PruneEventSink
-	prunedFired           map[uint64]struct{}  // inference IDs we've already emitted a prune for
-	finishedAt            map[uint64]uint64    // inference ID -> nonce of MsgFinishInference
-	finishedAtTime        map[uint64]time.Time // inference ID -> wall clock when this host saw the finish
-	terminalAt            map[uint64]uint64    // inference ID -> nonce when status became terminal (v2)
-	terminalAtTime        map[uint64]time.Time // inference ID -> wall clock at terminal (v2)
-	sealGraceNonces       uint64               // nonce gate from SessionConfig.SealGraceNonces
-	inferenceClearGrace   time.Duration        // wall-clock gate from SessionConfig
+	pruneSink           PruneEventSink
+	prunedFired         map[uint64]struct{}  // inference IDs we've already emitted a prune for
+	finishedAt          map[uint64]uint64    // inference ID -> nonce this host first saw it Finished (seal admission)
+	finishedAtTime      map[uint64]time.Time // inference ID -> wall clock this host first saw it Finished (seal admission)
+	sealGraceNonces     uint64               // nonce gate for seal admission, from SessionConfig.SealGraceNonces
+	inferenceClearGrace time.Duration        // wall-clock gate for seal admission, from SessionConfig
 	maxNonce              devshard.MaxNonceProvider // nil = do not enforce
 }
 
@@ -221,11 +219,9 @@ func NewHost(
 		validating:            make(map[uint64]struct{}),
 		completedResponses:    make(map[uint64][]byte),
 		ownSeed:               ownSeed,
-		prunedFired:           make(map[uint64]struct{}),
+		prunedFired:         make(map[uint64]struct{}),
 		finishedAt:          make(map[uint64]uint64),
 		finishedAtTime:      make(map[uint64]time.Time),
-		terminalAt:          make(map[uint64]uint64),
-		terminalAtTime:      make(map[uint64]time.Time),
 		sealGraceNonces:     sealGraceNonces,
 		inferenceClearGrace: clearGrace,
 	}
@@ -397,7 +393,7 @@ func (h *Host) HandleRequest(ctx context.Context, req HostRequest) (*HostRespons
 			h.mu.Unlock()
 			return nil, err
 		}
-		if err := h.applyAndPersist(diff); err != nil {
+		if err := h.applyAndPersist(diff, true); err != nil {
 			h.mu.Unlock()
 			return nil, observability.Classify(observability.ReasonApplyErr, observability.WhereHostApplyDiff, err)
 		}
@@ -539,8 +535,12 @@ func (h *Host) chainMaxNonce() uint32 {
 
 // applyAndPersist applies a diff, removes included txs from mempool, and persists.
 // Captures WarmKeyDelta (new warm key bindings introduced by this diff) for replay.
+// When admitSeals is true (fresh diffs from the sequencer), the proposed seals
+// are sanity-checked against this host's clock before the diff is applied or
+// signed; replay/recovery/catch-up paths pass false because those diffs are
+// already accepted history and the live clock ledgers are not meaningful.
 // Caller must hold h.mu.
-func (h *Host) applyAndPersist(diff types.Diff) error {
+func (h *Host) applyAndPersist(diff types.Diff, admitSeals bool) error {
 	currentNonce := h.sm.LatestNonce()
 	if diff.Nonce <= currentNonce {
 		return nil
@@ -548,11 +548,20 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 	if err := h.checkDiffNonceLimitLocked(diff); err != nil {
 		return err
 	}
+	if admitSeals {
+		if err := h.admitSealsLocked(diff); err != nil {
+			return err
+		}
+	}
 	phaseBefore := h.sm.Phase()
 	var warmBefore map[uint32]string
 	if h.store != nil {
 		warmBefore = h.sm.WarmKeys()
 	}
+	// Capture each sealed inference's status before the fold removes it from
+	// live state, so the payload-prune event can be labeled terminal vs
+	// stale-finished (a metrics-only distinction).
+	sealReasons := h.sealPruneReasonsLocked(diff)
 	root, err := h.sm.ApplyDiff(diff)
 	if err != nil {
 		return fmt.Errorf("apply diff nonce %d: %w", diff.Nonce, err)
@@ -569,11 +578,12 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 		}
 	}
 
-	// Emit prune events for payloads we no longer need. Tier A fires on
-	// terminal-status flips driven by txs in this diff; Tier C fires when
-	// the local nonce + wall-clock gates have both elapsed for inferences
-	// stuck in Finished. Both run under h.mu so the sink contract holds.
-	h.processPruneEventsLocked(diff)
+	// Maintain the finish-observation ledger (used by the seal admission gate),
+	// then emit payload-prune events for whatever this diff sealed. Pruning is a
+	// host-local side effect fully decoupled from the deterministic state seal:
+	// it carries no clock and never mutates state, so it cannot diverge the root.
+	h.observeFinishLedgerLocked(diff)
+	h.emitSealPrunesLocked(diff, sealReasons)
 
 	if h.store != nil {
 		warmAfter := h.sm.WarmKeys()
@@ -594,153 +604,151 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 	return nil
 }
 
-// processPruneEventsLocked walks the diff's txs to track Finish observations
-// (Tier C ledger) and to fire Tier A prune events for inferences that just
-// terminalized. After the per-tx pass it scans the Tier C ledger for entries
-// whose nonce + wall-clock grace have elapsed and fires those too.
-// Caller must hold h.mu. No-op when no sink is configured.
-func (h *Host) processPruneEventsLocked(diff types.Diff) {
+// admitSealsLocked is a live-only sanity gate over the seal set the sequencer
+// proposes in this diff. It runs before ApplyDiff so this host never signs a
+// state that sealed an inference prematurely (which would prune a payload a
+// validator might still need). It is deliberately NOT part of the state
+// transition: the deterministic fold in ApplyDiff is the source of truth and
+// runs identically everywhere, including replay. This check only decides
+// whether THIS host is willing to apply+sign a fresh diff right now.
+//
+// Rules, per proposed id:
+//   - not live from our view (already sealed/drained, or never seen): lenient,
+//     skip -- the fold is idempotent and there is nothing to gate.
+//   - status not seal-eligible (e.g. Pending/Started/Challenged): reject.
+//   - terminal (Validated/Invalidated/TimedOut): accept immediately, no grace.
+//   - Finished: require the nonce floor and the wall-clock grace (minus a small
+//     clock-skew tolerance) to have elapsed from when THIS host first observed
+//     the finish. If this host never observed the finish (no ledger entry),
+//     be lenient and accept rather than stall.
+//
+// Caller must hold h.mu.
+func (h *Host) admitSealsLocked(diff types.Diff) error {
+	if len(diff.SealedInferenceIDs) == 0 {
+		return nil
+	}
+	now := time.Now()
+	for _, id := range diff.SealedInferenceIDs {
+		rec, ok := h.sm.GetInference(id)
+		if !ok {
+			continue
+		}
+		if isTerminalStatus(rec.Status) {
+			continue
+		}
+		if rec.Status != types.StatusFinished {
+			return fmt.Errorf("%w: inference %d status %v", types.ErrSealNotEligible, id, rec.Status)
+		}
+
+		// Finished: enforce the nonce floor when we know when we saw the finish.
+		finNonce, hasNonce := h.finishedAt[id]
+		if hasNonce && diff.Nonce < finNonce+h.sealGraceNonces {
+			return fmt.Errorf("%w: inference %d sealed at nonce %d, finished at %d + grace %d",
+				types.ErrSealTooEarly, id, diff.Nonce, finNonce, h.sealGraceNonces)
+		}
+		// And the wall-clock grace, with a tolerance for sequencer/host skew.
+		finTime, hasTime := h.finishedAtTime[id]
+		if hasTime && now.Sub(finTime)+sealAdmissionClockTolerance < h.inferenceClearGrace {
+			return fmt.Errorf("%w: inference %d sealed %s after finish, grace %s",
+				types.ErrSealTooEarly, id, now.Sub(finTime), h.inferenceClearGrace)
+		}
+	}
+	return nil
+}
+
+// observeFinishLedgerLocked records when this host first observed each inference
+// reach StatusFinished. The ledger feeds only the seal admission gate
+// (admitSealsLocked), so it runs on every applied diff regardless of pruneSink:
+// admission is a live-only sanity check independent of payload pruning. A tx
+// that moves an inference out of Finished (challenge) or to terminal clears its
+// marker; sealed ids are dropped in emitSealPrunesLocked. Caller holds h.mu.
+func (h *Host) observeFinishLedgerLocked(diff types.Diff) {
+	now := time.Now()
+	for _, tx := range diff.Txs {
+		var id uint64
+		switch {
+		case tx.GetFinishInference() != nil:
+			id = tx.GetFinishInference().InferenceId
+		case tx.GetValidation() != nil:
+			id = tx.GetValidation().InferenceId
+		case tx.GetValidationVote() != nil:
+			id = tx.GetValidationVote().InferenceId
+		case tx.GetTimeoutInference() != nil:
+			id = tx.GetTimeoutInference().InferenceId
+		default:
+			continue
+		}
+		// Only record while the apply left the inference in Finished: a finish
+		// tx can fail (e.g. wrong executor slot) without flipping status, and a
+		// validation/vote/timeout can move it to Challenged or terminal. First
+		// observation wins so the admission grace measures from the earliest
+		// finish this host saw.
+		if rec, ok := h.sm.GetInference(id); ok && rec.Status == types.StatusFinished {
+			if _, tracked := h.finishedAt[id]; !tracked {
+				h.finishedAt[id] = diff.Nonce
+				h.finishedAtTime[id] = now
+			}
+			continue
+		}
+		delete(h.finishedAt, id)
+		delete(h.finishedAtTime, id)
+	}
+}
+
+// sealPruneReasonsLocked captures, before the fold removes them from live state,
+// the prune reason for each inference the diff proposes to seal: terminal vs
+// stale-finished (a metrics-only label). Returns nil when no sink is configured
+// or the diff seals nothing. Caller holds h.mu.
+func (h *Host) sealPruneReasonsLocked(diff types.Diff) map[uint64]PruneReason {
+	if h.pruneSink == nil || len(diff.SealedInferenceIDs) == 0 {
+		return nil
+	}
+	reasons := make(map[uint64]PruneReason, len(diff.SealedInferenceIDs))
+	for _, id := range diff.SealedInferenceIDs {
+		rec, ok := h.sm.GetInference(id)
+		if !ok {
+			continue
+		}
+		if isTerminalStatus(rec.Status) {
+			reasons[id] = PruneReasonTerminal
+		} else {
+			reasons[id] = PruneReasonStaleFinished
+		}
+	}
+	return reasons
+}
+
+// emitSealPrunesLocked dispatches one payload-prune event per inference the diff
+// just sealed. The deterministic fold in ApplyDiff already removed these from
+// live state, so their payloads are no longer needed. This is the sole pruning
+// trigger and is fully decoupled from the state seal: it carries no clock and
+// never mutates state, so it cannot cause root divergence. Dedupe via
+// prunedFired tolerates a diff (or replay) presenting the same id twice. The
+// PayloadEpoch carries h.epochID (the epoch the executor stored under). Caller
+// holds h.mu. No-op when no sink is configured.
+func (h *Host) emitSealPrunesLocked(diff types.Diff, reasons map[uint64]PruneReason) {
 	if h.pruneSink == nil {
 		return
 	}
-	now := time.Now()
-	currentNonce := diff.Nonce
-
-	for _, tx := range diff.Txs {
-		switch {
-		case tx.GetFinishInference() != nil:
-			id := tx.GetFinishInference().InferenceId
-			if _, fired := h.prunedFired[id]; fired {
-				continue
-			}
-			// Only record if the apply actually transitioned to Finished:
-			// applyFinishInference can fail (e.g. wrong executor slot) without
-			// flipping status, in which case applyCore rolls back, so the
-			// status check protects us against that race.
-			rec, ok := h.sm.GetInference(id)
-			if !ok || rec.Status != types.StatusFinished {
-				continue
-			}
-			h.finishedAt[id] = currentNonce
-			h.finishedAtTime[id] = now
-		case tx.GetTimeoutInference() != nil:
-			id := tx.GetTimeoutInference().InferenceId
-			h.maybeEmitTerminalLocked(id, currentNonce, now)
-		case tx.GetValidation() != nil:
-			id := tx.GetValidation().InferenceId
-			h.maybeEmitTerminalLocked(id, currentNonce, now)
-		case tx.GetValidationVote() != nil:
-			id := tx.GetValidationVote().InferenceId
-			h.maybeEmitTerminalLocked(id, currentNonce, now)
-		}
-	}
-
-	h.emitTerminalTierLocked(currentNonce, now)
-	h.emitTierCLocked(currentNonce, now)
-}
-
-// maybeEmitTerminalLocked records or emits a terminal prune for an inference
-// whose post-apply status is terminal. Under v2 composition the event is
-// deferred until sealGraceNonces and inferenceClearGrace have both elapsed.
-// Caller must hold h.mu and must have already verified h.pruneSink is non-nil.
-func (h *Host) maybeEmitTerminalLocked(inferenceID uint64, currentNonce uint64, now time.Time) {
-	if _, fired := h.prunedFired[inferenceID]; fired {
-		return
-	}
-	rec, ok := h.sm.GetInference(inferenceID)
-	if !ok || !isTerminalStatus(rec.Status) {
-		return
-	}
-	if h.sm.EffectiveV2Composition() {
-		if _, tracked := h.terminalAt[inferenceID]; !tracked {
-			h.terminalAt[inferenceID] = currentNonce
-			h.terminalAtTime[inferenceID] = now
-			delete(h.finishedAt, inferenceID)
-			delete(h.finishedAtTime, inferenceID)
-		}
-		return
-	}
-	h.emitPruneLocked(inferenceID, PruneReasonTerminal)
-}
-
-// emitTerminalTierLocked fires deferred terminal prunes under v2 composition
-// once both the nonce and wall-clock gates have cleared.
-func (h *Host) emitTerminalTierLocked(currentNonce uint64, now time.Time) {
-	if !h.sm.EffectiveV2Composition() || len(h.terminalAt) == 0 {
-		return
-	}
-	for id, termNonce := range h.terminalAt {
-		if currentNonce < termNonce+h.sealGraceNonces {
+	for _, id := range diff.SealedInferenceIDs {
+		if _, fired := h.prunedFired[id]; fired {
 			continue
 		}
-		ts, hasTs := h.terminalAtTime[id]
-		if !hasTs || now.Before(ts.Add(h.inferenceClearGrace)) {
-			continue
+		reason := PruneReasonTerminal
+		if r, ok := reasons[id]; ok {
+			reason = r
 		}
-		rec, ok := h.sm.GetInference(id)
-		if !ok || !isTerminalStatus(rec.Status) {
-			delete(h.terminalAt, id)
-			delete(h.terminalAtTime, id)
-			continue
-		}
-		h.emitPruneLocked(id, PruneReasonTerminal)
+		h.prunedFired[id] = struct{}{}
+		delete(h.finishedAt, id)
+		delete(h.finishedAtTime, id)
+		h.pruneSink.OnInferencePrunable(InferencePruneEvent{
+			EscrowID:          h.escrowID,
+			InferenceID:       id,
+			Reason:            reason,
+			PayloadEpoch:      h.epochID,
+			PayloadEpochKnown: h.epochID != 0,
+		})
 	}
-}
-
-// emitTierCLocked walks the Tier C ledger and emits prune events for entries
-// where both gates have cleared. Inferences that are no longer in
-// StatusFinished (e.g. moved to Challenged/Validated/Invalidated under a
-// different path) drop out of the ledger silently. Caller must hold h.mu.
-func (h *Host) emitTierCLocked(currentNonce uint64, now time.Time) {
-	if len(h.finishedAt) == 0 {
-		return
-	}
-	for id, finNonce := range h.finishedAt {
-		if currentNonce < finNonce+h.sealGraceNonces {
-			continue
-		}
-		ts, hasTs := h.finishedAtTime[id]
-		if !hasTs || now.Before(ts.Add(h.inferenceClearGrace)) {
-			continue
-		}
-		rec, ok := h.sm.GetInference(id)
-		if !ok || rec.Status != types.StatusFinished {
-			delete(h.finishedAt, id)
-			delete(h.finishedAtTime, id)
-			continue
-		}
-		h.emitPruneLocked(id, PruneReasonStaleFinished)
-	}
-}
-
-// emitPruneLocked dispatches one InferencePruneEvent and updates the dedupe
-// ledger. The PayloadEpoch carries h.epochID, which is the only epoch the
-// executor stored under for this session (set via WithEpochID); when the
-// host was constructed without an epoch the manager falls back to a global
-// supplier.
-func (h *Host) emitPruneLocked(inferenceID uint64, reason PruneReason) {
-	if err := h.sm.SealInference(inferenceID); err != nil {
-		logging.Warn("failed to seal inference before prune",
-			"subsystem", "host",
-			"escrow_id", h.escrowID,
-			"inference_id", inferenceID,
-			"reason", reason.String(),
-			"error", err,
-		)
-		return
-	}
-	h.prunedFired[inferenceID] = struct{}{}
-	delete(h.finishedAt, inferenceID)
-	delete(h.finishedAtTime, inferenceID)
-	delete(h.terminalAt, inferenceID)
-	delete(h.terminalAtTime, inferenceID)
-	h.pruneSink.OnInferencePrunable(InferencePruneEvent{
-		EscrowID:          h.escrowID,
-		InferenceID:       inferenceID,
-		Reason:            reason,
-		PayloadEpoch:      h.epochID,
-		PayloadEpochKnown: h.epochID != 0,
-	})
 }
 
 // maybeSaveSnapshotLocked copies the current state when shouldSnapshot is true.
@@ -784,7 +792,7 @@ func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *
 func (h *Host) ApplyCatchUpDiffs(diffs []types.Diff) {
 	h.mu.Lock()
 	for _, diff := range diffs {
-		_ = h.applyAndPersist(diff)
+		_ = h.applyAndPersist(diff, false)
 	}
 	staleFinishes := h.collectStaleFinishesLocked()
 	h.mu.Unlock()
@@ -1407,7 +1415,7 @@ func (h *Host) ApplyRecoveredDiffs(ctx context.Context, diffs []types.Diff) ([]g
 	var sigs []gossip.GossipSig
 
 	for _, diff := range diffs {
-		if err := h.applyAndPersist(diff); err != nil {
+		if err := h.applyAndPersist(diff, false); err != nil {
 			return sigs, fmt.Errorf("apply recovered diff nonce %d: %w", diff.Nonce, err)
 		}
 
@@ -1457,7 +1465,7 @@ func (h *Host) challengeReceiptLocked(inferenceID uint64, payload *InferencePayl
 	defer h.mu.Unlock()
 
 	for _, diff := range diffs {
-		if err := h.applyAndPersist(diff); err != nil {
+		if err := h.applyAndPersist(diff, false); err != nil {
 			return nil, 0, nil, fmt.Errorf("apply challenge diff nonce %d: %w", diff.Nonce, err)
 		}
 	}

--- a/devshard/host/prune.go
+++ b/devshard/host/prune.go
@@ -72,6 +72,14 @@ func (f PruneEventSinkFunc) OnInferencePrunable(event InferencePruneEvent) {
 // Normal paths always normalize (production default 3600s); this is a safety net.
 const defaultInferenceClearGrace = 60 * time.Minute
 
+// sealAdmissionClockTolerance is the wall-clock slack the host grants the
+// sequencer when admitting Finished seals. The sequencer freezes its own clock
+// into the signed diff; this host may read a slightly earlier clock, so we
+// treat a Finished inference as past its grace window if it is within this much
+// of the deadline. This only loosens the live-only admission sanity check; it
+// never affects the deterministic fold or the state root.
+const sealAdmissionClockTolerance = 10 * time.Second
+
 // isTerminalStatus returns true for inference statuses that no longer require
 // payload retention (validated, invalidated, or timed out).
 func isTerminalStatus(s types.InferenceStatus) bool {

--- a/devshard/host/prune.go
+++ b/devshard/host/prune.go
@@ -78,7 +78,7 @@ const defaultInferenceClearGrace = 60 * time.Minute
 // treat a Finished inference as past its grace window if it is within this much
 // of the deadline. This only loosens the live-only admission sanity check; it
 // never affects the deterministic fold or the state root.
-const sealAdmissionClockTolerance = 10 * time.Second
+const sealAdmissionClockTolerance = 120 * time.Second // 2 minutes
 
 // isTerminalStatus returns true for inference statuses that no longer require
 // payload retention (validated, invalidated, or timed out).

--- a/devshard/host/prune_test.go
+++ b/devshard/host/prune_test.go
@@ -235,55 +235,75 @@ func (r *pruneTestRig) sealedRow(inferenceID uint64) storage.InferenceRow {
 	return row
 }
 
-// awaitTerminalPrune advances nonces until the v2 terminal grace gates clear
-// and asserts exactly one PruneReasonTerminal event was emitted.
-func (r *pruneTestRig) awaitTerminalPrune(inferenceID uint64, nonce uint64) []InferencePruneEvent {
+// sealDiff signs and applies a seal-bearing diff (no txs) at the given nonce,
+// folding sealedIDs into the accumulator. This is what the user sequencer emits
+// once an inference has cleared its seal gates. Returns the next nonce.
+func (r *pruneTestRig) sealDiff(nonce uint64, sealedIDs ...uint64) uint64 {
 	r.t.Helper()
-	time.Sleep(20 * time.Millisecond)
-	limit := int(r.host.sealGraceNonces) + 3
-	if limit < 3 {
-		limit = 3
-	}
-	for i := 0; i < limit; i++ {
-		if events := r.sink.findFor(inferenceID); len(events) == 1 {
-			require.Equal(r.t, PruneReasonTerminal, events[0].Reason)
-			return events
-		}
-		r.applyDiff(nonce, nil)
-		nonce++
-	}
-	r.t.Fatalf("expected exactly one terminal prune for inference %d, got %d events",
-		inferenceID, len(r.sink.findFor(inferenceID)))
-	return nil
+	d := testutil.SignDiffSealed(r.t, r.user, r.escrowID, nonce, nil, sealedIDs)
+	_, err := r.host.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{d}})
+	require.NoError(r.t, err)
+	return nonce + 1
 }
 
-func TestHost_PruneSink_Terminal_OnValidated(t *testing.T) {
+// trySealDiff is like sealDiff but returns the HandleRequest error instead of
+// asserting success, so admission rejections can be inspected.
+func (r *pruneTestRig) trySealDiff(nonce uint64, sealedIDs ...uint64) error {
+	r.t.Helper()
+	d := testutil.SignDiffSealed(r.t, r.user, r.escrowID, nonce, nil, sealedIDs)
+	_, err := r.host.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{d}})
+	return err
+}
+
+// driveToValidated brings inference 1 (executor slot 1) through to
+// StatusValidated by collecting 3 valid votes (threshold=2). Returns next nonce.
+func (r *pruneTestRig) driveToValidated(startNonce uint64) uint64 {
+	r.t.Helper()
+	nonce := r.driveStartConfirmFinish(1, startNonce)
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidation(1, 2, false)})
+	nonce++
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 0, true)})
+	nonce++
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 3, true)})
+	nonce++
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 4, true)})
+	nonce++
+	require.Equal(r.t, types.StatusValidated, r.inferenceStatus(1))
+	return nonce
+}
+
+// driveToInvalidated brings inference 1 to StatusInvalidated with 3 invalid
+// votes (threshold=2). Returns next nonce.
+func (r *pruneTestRig) driveToInvalidated(startNonce uint64) uint64 {
+	r.t.Helper()
+	nonce := r.driveStartConfirmFinish(1, startNonce)
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidation(1, 2, false)})
+	nonce++
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 0, false)})
+	nonce++
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 3, false)})
+	nonce++
+	require.Equal(r.t, types.StatusInvalidated, r.inferenceStatus(1))
+	return nonce
+}
+
+// Pruning is now driven entirely by the seal set carried in the diff: the host
+// emits a payload-prune event for each id in diff.SealedInferenceIDs after the
+// deterministic fold. It no longer seals state autonomously on a wall clock.
+
+func TestHost_PruneSink_EmitsOnSealedTerminal_Validated(t *testing.T) {
 	rig := newPruneRig(t, 0, 5)
+	nonce := rig.driveToValidated(1)
 
-	// Inference 1: executor=slot 1; validators slot 0,2,3,4. Threshold=2.
-	nonce := rig.driveStartConfirmFinish(1, 1)
+	// No prune until the diff explicitly seals the inference.
+	require.Empty(t, rig.sink.findFor(1), "host must not prune before the diff seals")
 
-	// Validation flips Finished -> Challenged with one invalid vote.
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidation(1, 2, false)})
-	nonce++
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "no Tier A while still Challenged")
+	// Terminal seals are admitted with no grace.
+	rig.sealDiff(nonce, 1)
 
-	// Two valid votes are not enough (threshold=2, need >2).
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, true)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, true)})
-	nonce++
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1))
-
-	// Third valid vote pushes VotesValid=3 > threshold=2 -> StatusValidated.
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 4, true)})
-	nonce++
-	require.Equal(t, types.StatusValidated, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "v2 defers terminal prune until gates clear")
-
-	events := rig.awaitTerminalPrune(1, nonce)
+	events := rig.sink.findFor(1)
+	require.Len(t, events, 1)
+	require.Equal(t, PruneReasonTerminal, events[0].Reason)
 	require.Equal(t, rig.escrowID, events[0].EscrowID)
 	require.Equal(t, rig.epochID, events[0].PayloadEpoch)
 	require.True(t, events[0].PayloadEpochKnown)
@@ -291,201 +311,90 @@ func TestHost_PruneSink_Terminal_OnValidated(t *testing.T) {
 	require.NotZero(t, rig.sealedRow(1).SealedNonce)
 }
 
-func TestHost_PruneSink_Terminal_OnInvalidated(t *testing.T) {
+func TestHost_PruneSink_EmitsOnSealedTerminal_Invalidated(t *testing.T) {
 	rig := newPruneRig(t, 0, 5)
-
-	nonce := rig.driveStartConfirmFinish(1, 1)
-
-	// Validation injects 1 invalid vote -> Challenged.
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidation(1, 2, false)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, false)})
-	nonce++
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
+	nonce := rig.driveToInvalidated(1)
 	require.Empty(t, rig.sink.findFor(1))
 
-	// Third invalid vote: VotesInvalid=3 > threshold=2 -> StatusInvalidated.
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, false)})
-	nonce++
-	require.Equal(t, types.StatusInvalidated, rig.inferenceStatus(1))
-	events := rig.awaitTerminalPrune(1, nonce)
-	require.NotZero(t, rig.sealedRow(1).SealedNonce)
-	_ = events
+	rig.sealDiff(nonce, 1)
+
+	events := rig.sink.findFor(1)
+	require.Len(t, events, 1)
+	require.Equal(t, PruneReasonTerminal, events[0].Reason)
 	rig.inferenceMissing(1)
+	require.NotZero(t, rig.sealedRow(1).SealedNonce)
 }
 
-func TestHost_PruneSink_Terminal_OnTimedOut(t *testing.T) {
+func TestHost_PruneSink_EmitsOnSealedTerminal_TimedOut(t *testing.T) {
 	rig := newPruneRig(t, 0, 5)
 
-	// Start inference 1, then timeout from Pending (no ConfirmStart).
 	rig.applyDiff(1, []*types.DevshardTx{testutil.StartTx(1)})
 	require.Equal(t, types.StatusPending, rig.inferenceStatus(1))
-
-	// Threshold=2 -> need >2 accept votes; collect 3 from non-executor slots.
 	timeoutTx := rig.signTimeoutInference(1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, []uint32{0, 2, 3})
 	rig.applyDiff(2, []*types.DevshardTx{timeoutTx})
 	require.Equal(t, types.StatusTimedOut, rig.inferenceStatus(1))
-	events := rig.awaitTerminalPrune(1, 3)
-	require.NotZero(t, rig.sealedRow(1).SealedNonce)
-	_ = events
+	require.Empty(t, rig.sink.findFor(1))
+
+	rig.sealDiff(3, 1)
+
+	events := rig.sink.findFor(1)
+	require.Len(t, events, 1)
+	require.Equal(t, PruneReasonTerminal, events[0].Reason)
 	rig.inferenceMissing(1)
+	require.NotZero(t, rig.sealedRow(1).SealedNonce)
 }
 
-func TestHost_PruneSink_StaleFinished_TierC(t *testing.T) {
+func TestHost_PruneSink_EmitsOnSealedStaleFinished(t *testing.T) {
+	// Small grace gates so the admission check accepts a Finished seal quickly.
 	rig := newPruneRig(t, 0, 5,
 		WithPruneTuning(2, 10*time.Millisecond),
 	)
-
-	// Finish inference 1 at nonce 3 (Start=1, Confirm=2, Finish=3).
-	nonce := rig.driveStartConfirmFinish(1, 1)
+	nonce := rig.driveStartConfirmFinish(1, 1) // Finish at nonce 3, finishedAt=3.
 	require.Equal(t, types.StatusFinished, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "Finish itself does not emit Tier A")
+	require.Empty(t, rig.sink.findFor(1), "Finish itself does not prune")
 
-	// Wall-clock gate: wait past the configured grace.
+	// Clear the wall-clock grace (10ms, well within the 10s admission tolerance)
+	// and advance to satisfy the nonce floor (finishedAt 3 + grace 2 = 5).
 	time.Sleep(20 * time.Millisecond)
-
-	// Nonce gate not yet met: nonce=4 < finishNonce(3)+grace(2)=5.
-	rig.applyDiff(nonce, nil)
+	rig.applyDiff(nonce, nil) // nonce 4 -> next 5
 	nonce++
-	require.Empty(t, rig.sink.findFor(1), "nonce gate should still hold")
 
-	// Crossing the gate (nonce=5 >= 5) should fire exactly one Tier C.
-	rig.applyDiff(nonce, nil)
-	nonce++
+	// Now a Finished seal is admissible (nonce 5 >= 5).
+	rig.sealDiff(nonce, 1)
+
 	events := rig.sink.findFor(1)
 	require.Len(t, events, 1)
 	require.Equal(t, PruneReasonStaleFinished, events[0].Reason)
 	require.Equal(t, rig.epochID, events[0].PayloadEpoch)
 	rig.inferenceMissing(1)
 	require.NotZero(t, rig.sealedRow(1).SealedNonce)
-
-	// Subsequent diffs must not re-emit for the same inference.
-	rig.applyDiff(nonce, nil)
-	require.Len(t, rig.sink.findFor(1), 1, "Tier C must dedupe across later diffs")
 }
 
-func TestHost_PruneSink_TierC_DoesNotFireWhenNonceGateUnmet(t *testing.T) {
-	rig := newPruneRig(t, 0, 5,
-		WithPruneTuning(50, 1*time.Microsecond),
-	)
-	nonce := rig.driveStartConfirmFinish(1, 1)
-	time.Sleep(2 * time.Millisecond) // wall-clock gate easily satisfied.
-	for i := 0; i < 5; i++ {
-		rig.applyDiff(nonce, nil)
-		nonce++
-	}
-	require.Empty(t, rig.sink.findFor(1), "nonce gate not yet crossed")
-}
-
-func TestHost_PruneSink_TierC_DoesNotFireWhenWallClockGateUnmet(t *testing.T) {
-	rig := newPruneRig(t, 0, 5,
-		WithPruneTuning(2, time.Hour),
-	)
-	nonce := rig.driveStartConfirmFinish(1, 1)
-	for i := 0; i < 4; i++ {
-		rig.applyDiff(nonce, nil)
-		nonce++
-	}
-	require.Empty(t, rig.sink.findFor(1), "wall-clock gate prevents Tier C")
-}
-
-func TestHost_PruneSink_V2_TerminalDelayed(t *testing.T) {
-	hosts := make([]*signing.Secp256k1Signer, 5)
-	for i := range hosts {
-		hosts[i] = testutil.MustGenerateKey(t)
-	}
-	user := testutil.MustGenerateKey(t)
-	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:             60,
-		ExecutionTimeout:           1200,
-		TokenPrice:                 1,
-		VoteThreshold:              2,
-		ValidationRate:             0,
-		InferenceClearGraceSeconds: testutil.TestInferenceClearGraceSeconds,
-	}
-	verifier := signing.NewSecp256k1Verifier()
-	store := storage.NewMemory()
-	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
-		EscrowID: "escrow-1", EpochID: 7, Version: testutil.RuntimeTestVersion,
-		CreatorAddr: user.Address(), Config: config, Group: group, InitialBalance: 1_000_000,
-	}))
-	sm, err := state.NewStateMachine("escrow-1", config, group, 1_000_000, user.Address(), verifier, store,
-	)
-	require.NoError(t, err)
-
-	sink := &recordingPruneSink{}
-	rig := &pruneTestRig{
-		t: t, hosts: hosts, user: user, group: group, config: config,
-		host: nil, sink: sink, stub: stub.NewInferenceEngine(),
-		store: store, escrowID: "escrow-1", epochID: 7,
-	}
-	h, err := NewHost(sm, hosts[0], rig.stub, "escrow-1", group, nil,
-		WithPruneSink(sink), WithEpochID(7), WithGrace(0),
-		WithPruneTuning(2, 10*time.Millisecond),
-	)
-	require.NoError(t, err)
-	rig.host = h
-
-	nonce := rig.driveStartConfirmFinish(1, 1)
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidation(1, 2, false)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, true)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, true)})
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "v2 defers terminal prune until gates clear")
-
-	time.Sleep(20 * time.Millisecond)
-	rig.applyDiff(nonce, nil)
-	nonce++
-	require.Empty(t, rig.sink.findFor(1), "nonce gate should still hold")
-
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 4, true)})
-	nonce++
-	require.Equal(t, types.StatusValidated, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "terminal recorded but gates not yet cleared")
-
-	time.Sleep(20 * time.Millisecond)
-	rig.applyDiff(nonce, nil)
-	nonce++
-	require.Empty(t, rig.sink.findFor(1), "nonce gate should still hold after terminal")
-
-	rig.applyDiff(nonce, nil)
-	events := rig.sink.findFor(1)
-	require.Len(t, events, 1)
-	require.Equal(t, PruneReasonTerminal, events[0].Reason)
-	rig.inferenceMissing(1)
-	require.NotZero(t, rig.sealedRow(1).SealedNonce)
-	sealed, ok := rig.host.sm.ExportSealedNonces()[1]
-	require.True(t, ok, "v2 seal should record sealed nonce")
-	require.NotZero(t, sealed)
-}
-
-func TestHost_PruneSink_TerminalFlipPreemptsTierC(t *testing.T) {
-	// If an inference terminalizes before the Tier C gates expire, only one
-	// terminal prune should fire (after v2 grace) and the Tier C ledger cleared.
-	// Default tuning (1 nonce, 10ms wall) is enough: status leaves Finished before Tier C fires.
+func TestHost_PruneSink_DedupesRepeatedSeal(t *testing.T) {
 	rig := newPruneRig(t, 0, 5)
+	nonce := rig.driveToValidated(1)
+	nonce = rig.sealDiff(nonce, 1)
+	require.Len(t, rig.sink.findFor(1), 1)
+
+	// A later diff that names the same (already sealed) id must not re-emit:
+	// it is no longer live, the fold is a no-op, and prunedFired dedupes.
+	rig.sealDiff(nonce, 1)
+	require.Len(t, rig.sink.findFor(1), 1, "prune must dedupe across diffs")
+}
+
+func TestHost_PruneSink_AdmissionRejectsTooEarlyFinished(t *testing.T) {
+	// Large wall-clock grace so a freshly Finished inference cannot be sealed
+	// yet: the host must reject the diff before applying or pruning it.
+	rig := newPruneRig(t, 0, 5,
+		WithPruneTuning(0, time.Hour),
+	)
 	nonce := rig.driveStartConfirmFinish(1, 1)
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidation(1, 2, false)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, false)})
-	nonce++
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, false)})
-	nonce++
-	require.Equal(t, types.StatusInvalidated, rig.inferenceStatus(1))
+	require.Equal(t, types.StatusFinished, rig.inferenceStatus(1))
 
-	events := rig.awaitTerminalPrune(1, nonce)
-	require.Equal(t, PruneReasonTerminal, events[0].Reason)
-
-	rig.host.mu.Lock()
-	_, stillFinished := rig.host.finishedAt[1]
-	_, stillTerminal := rig.host.terminalAt[1]
-	rig.host.mu.Unlock()
-	require.False(t, stillFinished, "Tier C ledger must drop terminalized inference")
-	require.False(t, stillTerminal, "terminal ledger cleared after prune")
+	err := rig.trySealDiff(nonce, 1)
+	require.ErrorIs(t, err, types.ErrSealTooEarly)
+	require.Empty(t, rig.sink.findFor(1), "rejected seal must not prune")
+	require.Equal(t, types.StatusFinished, rig.inferenceStatus(1), "rejected seal must not mutate state")
 }
 
 func TestHost_PruneSink_NilSafe_NoEmission(t *testing.T) {
@@ -513,14 +422,17 @@ func TestHost_PruneSink_NilSafe_NoEmission(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Drive a full Finish without panicking. Sink is nil so this exercises the
-	// processPruneEventsLocked early-return path.
+	// Drive a full Finish and then seal without panicking. Sink is nil so this
+	// exercises the emitSealPrunesLocked early-return path while the seal still
+	// folds into state.
 	rig := &pruneTestRig{
 		t: t, hosts: hosts, user: user, group: group, config: config,
 		host: h, stub: stub.NewInferenceEngine(), escrowID: "escrow-1", epochID: 7,
 	}
-	_ = rig.driveStartConfirmFinish(1, 1)
-	require.Equal(t, types.StatusFinished, rig.inferenceStatus(1))
+	nonce := rig.driveToValidated(1)
+	require.Equal(t, types.StatusValidated, rig.inferenceStatus(1))
+	rig.sealDiff(nonce, 1)
+	rig.inferenceMissing(1)
 }
 
 func TestHost_ValidateAsync_SkippedDoesNotEnqueueValidation(t *testing.T) {

--- a/devshard/host/validation_obs_test.go
+++ b/devshard/host/validation_obs_test.go
@@ -113,24 +113,17 @@ func (r *obsTestRig) sealedRow(inferenceID uint64) storage.InferenceRow {
 	return row
 }
 
-func (r *obsTestRig) awaitTerminalPrune(inferenceID uint64, nonce uint64, sink *recordingPruneSink) uint64 {
+// sealDiff applies a seal-bearing diff that folds inferenceID and asserts the
+// host emitted exactly one terminal prune for it. Returns the next nonce.
+func (r *obsTestRig) sealDiff(inferenceID uint64, nonce uint64, sink *recordingPruneSink) uint64 {
 	r.t.Helper()
-	time.Sleep(20 * time.Millisecond)
-	limit := int(r.host.sealGraceNonces) + 3
-	if limit < 3 {
-		limit = 3
-	}
-	for i := 0; i < limit; i++ {
-		if events := sink.findFor(inferenceID); len(events) == 1 {
-			require.Equal(r.t, PruneReasonTerminal, events[0].Reason)
-			return nonce
-		}
-		r.applyDiff(nonce, nil)
-		nonce++
-	}
-	r.t.Fatalf("expected exactly one terminal prune for inference %d, got %d events",
-		inferenceID, len(sink.findFor(inferenceID)))
-	return nonce
+	d := testutil.SignDiffSealed(r.t, r.user, r.escrowID, nonce, nil, []uint64{inferenceID})
+	_, err := r.host.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{d}})
+	require.NoError(r.t, err)
+	events := sink.findFor(inferenceID)
+	require.Len(r.t, events, 1)
+	require.Equal(r.t, PruneReasonTerminal, events[0].Reason)
+	return nonce + 1
 }
 
 func (r *obsTestRig) driveStartConfirmFinish(inferenceID, startNonce uint64) uint64 {
@@ -391,7 +384,7 @@ func TestHost_ApplyAndPersist_ValidationObs_NoRecordOnUserLocalCompose(t *testin
 		_, err := userSM.ApplyLocal(rec.Nonce, rec.Txs)
 		require.NoError(t, err)
 	}
-	_, _, err = userSM.ApplyLocalBestEffort(next, []*types.DevshardTx{valTx})
+	_, _, err = userSM.ApplyLocalBestEffort(next, []*types.DevshardTx{valTx}, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), obsCompletedForSlot(t, r.store, r.escrowID, 0))
 
@@ -611,7 +604,7 @@ func TestHost_ApplyAndPersist_NoObsRecordForSealedInference(t *testing.T) {
 	waitObsCompletedForSlot(t, r.store, r.escrowID, 1, 1)
 	waitObsRowCount(t, r.store, r.escrowID, 2)
 
-	next = r.awaitTerminalPrune(inferenceID, next, sink)
+	next = r.sealDiff(inferenceID, next, sink)
 	r.inferenceMissing(inferenceID)
 	require.NotZero(t, r.sealedRow(inferenceID).SealedNonce)
 

--- a/devshard/internal/testutil/testutil.go
+++ b/devshard/internal/testutil/testutil.go
@@ -87,6 +87,29 @@ func SignDiffWithRoot(t *testing.T, signer signing.Signer, escrowID string, nonc
 	return types.Diff{Nonce: nonce, Txs: txs, UserSig: sig, PostStateRoot: postStateRoot}
 }
 
+// SignDiffSealed signs a diff that carries an explicit seal set. The signed
+// DiffContent includes sealed_inference_ids so the host's ApplyDiff signature
+// check and deterministic fold both see them. post_state_root is left empty so
+// the state machine skips root verification (the host recomputes it).
+func SignDiffSealed(t *testing.T, signer signing.Signer, escrowID string, nonce uint64, txs []*types.DevshardTx, sealedIDs []uint64) types.Diff {
+	t.Helper()
+	return SignDiffSealedWithRoot(t, signer, escrowID, nonce, txs, sealedIDs, nil)
+}
+
+// SignDiffSealedWithRoot signs a seal-bearing diff that also commits to an
+// explicit post_state_root, mirroring what the user sequencer produces: the
+// signed content covers txs, sealed_inference_ids, and the root, so the host's
+// ApplyDiff both verifies the signature and asserts its recomputed root matches.
+func SignDiffSealedWithRoot(t *testing.T, signer signing.Signer, escrowID string, nonce uint64, txs []*types.DevshardTx, sealedIDs []uint64, postStateRoot []byte) types.Diff {
+	t.Helper()
+	content := &types.DiffContent{Nonce: nonce, Txs: txs, EscrowId: escrowID, SealedInferenceIds: sealedIDs, PostStateRoot: postStateRoot}
+	data, err := deterministicMarshal.Marshal(content)
+	require.NoError(t, err)
+	sig, err := signer.Sign(data)
+	require.NoError(t, err)
+	return types.Diff{Nonce: nonce, Txs: txs, UserSig: sig, SealedInferenceIDs: sealedIDs, PostStateRoot: postStateRoot}
+}
+
 func SignProposerTx(t *testing.T, signer signing.Signer, msg proto.Message) []byte {
 	t.Helper()
 	data, err := deterministicMarshal.Marshal(msg)

--- a/devshard/proto/devshard/v1/diff.proto
+++ b/devshard/proto/devshard/v1/diff.proto
@@ -10,11 +10,6 @@ message DiffContent {
   repeated DevshardTx txs = 2;
   string escrow_id = 3;
   bytes post_state_root = 4;  // state root AFTER applying this diff's txs
-  // sealed_inference_ids lists the inference ids the sequencer folds into the
-  // sealed accumulator at this nonce. The fold runs (identically on user and
-  // host) after txs are applied and before post_state_root is computed, so the
-  // seal is part of the signed root rather than an off-log, host-local side
-  // effect. Ascending, deduplicated.
   repeated uint64 sealed_inference_ids = 5;
 }
 

--- a/devshard/proto/devshard/v1/diff.proto
+++ b/devshard/proto/devshard/v1/diff.proto
@@ -10,6 +10,12 @@ message DiffContent {
   repeated DevshardTx txs = 2;
   string escrow_id = 3;
   bytes post_state_root = 4;  // state root AFTER applying this diff's txs
+  // sealed_inference_ids lists the inference ids the sequencer folds into the
+  // sealed accumulator at this nonce. The fold runs (identically on user and
+  // host) after txs are applied and before post_state_root is computed, so the
+  // seal is part of the signed root rather than an off-log, host-local side
+  // effect. Ascending, deduplicated.
+  repeated uint64 sealed_inference_ids = 5;
 }
 
 // DevshardTx wraps all 8 tx types in a oneof for deterministic serialization.

--- a/devshard/runtimeconfig/adaptive_provider_test.go
+++ b/devshard/runtimeconfig/adaptive_provider_test.go
@@ -3,6 +3,7 @@ package runtimeconfig
 import (
 	"context"
 	"log/slog"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -154,6 +155,55 @@ func waitActiveSource(t *testing.T, p AdaptiveProvider, want string, max time.Du
 		time.Sleep(2 * time.Millisecond)
 	}
 	t.Fatalf("timeout waiting for active source %q (got %q)", want, p.ActiveSource())
+}
+
+// waitSignal advances the fake clock until ch receives a value or max elapses.
+func waitSignal(t *testing.T, clock *fakeClock, step time.Duration, ch <-chan struct{}, max time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(max)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ch:
+			return
+		default:
+			clock.Advance(step)
+			runtime.Gosched()
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	t.Fatalf("timeout waiting for signal within %v", max)
+}
+
+// driveClockUntil advances the fake clock in steps until cond is true or max
+// wall-clock time elapses. A short sleep between steps lets timer-driven
+// goroutines (gRPC backoff, supervisor stale/reprobe) run reliably.
+func driveClockUntil(t *testing.T, clock *fakeClock, step time.Duration, max time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(max)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		clock.Advance(step)
+		runtime.Gosched()
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v (step=%v)", max, step)
+}
+
+func waitSourceAfterClock(t *testing.T, p AdaptiveProvider, clock *fakeClock, step time.Duration, want string) {
+	t.Helper()
+	for i := 0; i < 5; i++ {
+		if p.ActiveSource() == want {
+			return
+		}
+		clock.Advance(step)
+		runtime.Gosched()
+		time.Sleep(5 * time.Millisecond)
+	}
+	if p.ActiveSource() != want {
+		t.Fatalf("expected active source %q (got %q)", want, p.ActiveSource())
+	}
 }
 
 func TestAdaptive_BootUnimplemented_StartsChain(t *testing.T) {
@@ -327,10 +377,15 @@ func TestAdaptive_OnlyOneRunnerApplies(t *testing.T) {
 
 func TestAdaptive_RoundTrip_GRPCChainGRPC(t *testing.T) {
 	clock := newFakeClock(time.Unix(0, 0))
+	recoverGRPC := atomic.Bool{}
+	pollError := make(chan struct{}, 1)
 	okAt50 := func() (*gen.GetRuntimeConfigResponse, error) {
 		return &gen.GetRuntimeConfigResponse{
 			Config: TestRuntimeConfigProto(50, 3, "raw"),
 		}, nil
+	}
+	down := func() (*gen.GetRuntimeConfigResponse, error) {
+		return nil, status.Error(codes.Unavailable, "down")
 	}
 	client := &scriptNMClient{
 		handlers: []func() (*gen.GetRuntimeConfigResponse, error){
@@ -342,13 +397,17 @@ func TestAdaptive_RoundTrip_GRPCChainGRPC(t *testing.T) {
 					Config: TestRuntimeConfigProto(20, 1, "raw"),
 				}, nil
 			},
+			// Keep failing until chain failover; idx>=2 repeats this handler.
 			func() (*gen.GetRuntimeConfigResponse, error) {
-				return nil, status.Error(codes.Unavailable, "down")
+				if recoverGRPC.Load() {
+					return okAt50()
+				}
+				select {
+				case pollError <- struct{}{}:
+				default:
+				}
+				return down()
 			},
-			func() (*gen.GetRuntimeConfigResponse, error) {
-				return nil, status.Error(codes.Unavailable, "down")
-			},
-			okAt50, okAt50, okAt50,
 		},
 	}
 	fetcher := &fakeFetcher{
@@ -366,15 +425,14 @@ func TestAdaptive_RoundTrip_GRPCChainGRPC(t *testing.T) {
 	waitForHeight(t, p, 20)
 	waitActiveSource(t, p, SourceActiveGRPC, time.Second)
 
+	waitSignal(t, clock, cfg.StaleCheckInterval, pollError, 3*time.Second)
 	clock.Advance(cfg.GRPCStale + cfg.StaleCheckInterval)
-	time.Sleep(30 * time.Millisecond)
-	waitActiveSource(t, p, SourceActiveChain, 3*time.Second)
+	waitSourceAfterClock(t, p, clock, cfg.StaleCheckInterval, SourceActiveChain)
 
-	clock.Advance(cfg.GRPCReprobe)
-	time.Sleep(20 * time.Millisecond)
-	clock.Advance(cfg.GRPCReprobe)
-	time.Sleep(20 * time.Millisecond)
-	waitActiveSource(t, p, SourceActiveGRPC, 3*time.Second)
+	recoverGRPC.Store(true)
+	driveClockUntil(t, clock, cfg.GRPCReprobe, 3*time.Second, func() bool {
+		return p.ActiveSource() == SourceActiveGRPC
+	})
 	waitForHeight(t, p, 50)
 }
 

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -235,8 +235,8 @@ func NewStateMachine(
 // ApplyDiff validates user signature and post_state_root, then applies the diff.
 // Returns the computed state root.
 func (sm *StateMachine) ApplyDiff(diff types.Diff) ([]byte, error) {
-	// 1. Verify user signature (covers nonce, txs, escrow_id, post_state_root).
-	diffContent := BuildDiffContent(sm.state.EscrowID, diff.Nonce, diff.Txs, diff.PostStateRoot)
+	// 1. Verify user signature (covers nonce, txs, escrow_id, sealed ids, post_state_root).
+	diffContent := BuildDiffContent(sm.state.EscrowID, diff.Nonce, diff.Txs, diff.SealedInferenceIDs, diff.PostStateRoot)
 	data, err := deterministicMarshal.Marshal(diffContent)
 	if err != nil {
 		return nil, fmt.Errorf("marshal diff content: %w", err)
@@ -250,24 +250,36 @@ func (sm *StateMachine) ApplyDiff(diff types.Diff) ([]byte, error) {
 		return nil, fmt.Errorf("%w: expected %s, got %s", types.ErrInvalidUserSig, sm.userAddress, recovered)
 	}
 
-	// 2. Apply txs and verify post_state_root atomically.
+	// 2. Apply txs, fold explicit seals, and verify post_state_root atomically.
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	return sm.applyCore(diff.Nonce, diff.Txs, diff.PostStateRoot)
+	return sm.applyCore(diff.Nonce, diff.Txs, diff.SealedInferenceIDs, diff.PostStateRoot)
 }
 
-// ApplyLocal applies txs without signature verification. Used by the user
-// to compute the post_state_root before signing the diff.
+// ApplyLocal applies txs without signature verification (no explicit seals).
+// Used by the user to compute the post_state_root before signing the diff and
+// by tests that do not exercise sealing.
 func (sm *StateMachine) ApplyLocal(nonce uint64, txs []*types.DevshardTx) ([]byte, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	return sm.applyCore(nonce, txs, nil)
+	return sm.applyCore(nonce, txs, nil, nil)
 }
 
-// ApplyLocalBestEffort applies txs one by one, skipping any that fail.
-// Returns the post-state root and the subset of txs that were applied.
-// Used by the user to compose diffs from pending txs that may be stale.
-func (sm *StateMachine) ApplyLocalBestEffort(nonce uint64, txs []*types.DevshardTx) ([]byte, []*types.DevshardTx, error) {
+// ApplyLocalSealed applies txs and folds sealedIDs without signature
+// verification. Used by recovery replay to reconstruct SealedAcc deterministically
+// from persisted diffs (which carry their seal set).
+func (sm *StateMachine) ApplyLocalSealed(nonce uint64, txs []*types.DevshardTx, sealedIDs []uint64) ([]byte, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.applyCore(nonce, txs, sealedIDs, nil)
+}
+
+// ApplyLocalBestEffort applies txs one by one, skipping any that fail, then
+// folds sealedIDs into the accumulator before computing the root. Returns the
+// post-state root and the subset of txs that were applied. Used by the user to
+// compose diffs from pending txs that may be stale; sealedIDs is the seal set
+// the sequencer has decided to commit at this nonce (ascending, deduplicated).
+func (sm *StateMachine) ApplyLocalBestEffort(nonce uint64, txs []*types.DevshardTx, sealedIDs []uint64) ([]byte, []*types.DevshardTx, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -327,6 +339,16 @@ func (sm *StateMachine) ApplyLocalBestEffort(nonce uint64, txs []*types.Devshard
 	if sm.state.Phase == types.PhaseFinalizing && sm.state.FinalizeNonce == 0 {
 		sm.state.FinalizeNonce = nonce
 	}
+
+	// Fold explicitly-sealed inferences into the accumulator before the root is
+	// computed, so the seal is part of the signed post_state_root. Runs before
+	// the settlement drain so any remaining live records drain afterward in a
+	// deterministic, identical order on user and host.
+	if err := sm.foldSealedIDsLocked(sealedIDs, nonce); err != nil {
+		sm.restoreMutable(snap)
+		return nil, nil, fmt.Errorf("fold sealed ids: %w", err)
+	}
+
 	if sm.state.Phase == types.PhaseFinalizing {
 		deadlinePassed := sm.state.LatestNonce >= sm.state.FinalizeNonce+uint64(len(sm.state.Group))
 		if deadlinePassed {
@@ -355,10 +377,13 @@ func (sm *StateMachine) ApplyLocalBestEffort(nonce uint64, txs []*types.Devshard
 	return root, applied, nil
 }
 
-// applyCore validates nonce, applies txs, updates nonce, and returns the state root.
-// If postStateRoot is non-nil, the computed root must match; on mismatch the entire
-// operation is rolled back (including nonce) and an error is returned.
-func (sm *StateMachine) applyCore(nonce uint64, txs []*types.DevshardTx, postStateRoot []byte) ([]byte, error) {
+// applyCore validates nonce, applies txs, folds sealedIDs, updates nonce, and
+// returns the state root. The seal fold runs after txs are applied and before
+// the root is computed, so explicit seals are committed into post_state_root.
+// If postStateRoot is non-nil, the computed root must match; on mismatch the
+// entire operation is rolled back (including nonce and seals) and an error is
+// returned.
+func (sm *StateMachine) applyCore(nonce uint64, txs []*types.DevshardTx, sealedIDs []uint64, postStateRoot []byte) ([]byte, error) {
 	// 1. Validate nonce.
 	expectedNonce := sm.state.LatestNonce + 1
 	if nonce != expectedNonce {
@@ -406,6 +431,15 @@ func (sm *StateMachine) applyCore(nonce uint64, txs []*types.DevshardTx, postSta
 	// Track FinalizeNonce: the nonce at which finalization started.
 	if sm.state.Phase == types.PhaseFinalizing && sm.state.FinalizeNonce == 0 {
 		sm.state.FinalizeNonce = nonce
+	}
+
+	// 6b. Fold explicitly-sealed inferences into the accumulator before the
+	// root is computed, so the seal is part of the signed post_state_root. Runs
+	// before the settlement drain so the fold order is deterministic and
+	// identical on user and host.
+	if err := sm.foldSealedIDsLocked(sealedIDs, nonce); err != nil {
+		sm.restoreMutable(snap)
+		return nil, fmt.Errorf("fold sealed ids: %w", err)
 	}
 
 	if sm.state.Phase == types.PhaseFinalizing {
@@ -1103,13 +1137,16 @@ func (sm *StateMachine) applyFinalizeRound() error {
 	return nil
 }
 
-// BuildDiffContent creates the proto DiffContent from nonce, txs, escrowID, and postStateRoot for signing.
-func BuildDiffContent(escrowID string, nonce uint64, txs []*types.DevshardTx, postStateRoot []byte) *types.DiffContent {
+// BuildDiffContent creates the proto DiffContent from nonce, txs, escrowID,
+// sealedIDs, and postStateRoot for signing. sealedIDs must be ascending and
+// deduplicated so the signed bytes are deterministic across user and host.
+func BuildDiffContent(escrowID string, nonce uint64, txs []*types.DevshardTx, sealedIDs []uint64, postStateRoot []byte) *types.DiffContent {
 	return &types.DiffContent{
-		Nonce:         nonce,
-		Txs:           txs,
-		EscrowId:      escrowID,
-		PostStateRoot: postStateRoot,
+		Nonce:              nonce,
+		Txs:                txs,
+		EscrowId:           escrowID,
+		PostStateRoot:      postStateRoot,
+		SealedInferenceIds: sealedIDs,
 	}
 }
 
@@ -1210,6 +1247,37 @@ func (sm *StateMachine) GetInference(id uint64) (types.InferenceRecord, bool) {
 // VoteThreshold returns the session's vote threshold.
 func (sm *StateMachine) VoteThreshold() uint32 {
 	return sm.state.Config.VoteThreshold
+}
+
+// SealGraceNonces returns the frozen nonce gate before an inference may be
+// sealed. Read by the user sequencer to decide the per-diff seal set.
+func (sm *StateMachine) SealGraceNonces() uint32 {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.state.Config.SealGraceNonces
+}
+
+// InferenceClearGraceSeconds returns the frozen wall-clock grace (seconds)
+// before an inference may be sealed. Read by the user sequencer to decide the
+// per-diff seal set.
+func (sm *StateMachine) InferenceClearGraceSeconds() uint32 {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.state.Config.InferenceClearGraceSeconds
+}
+
+// LiveInferenceStatuses returns a snapshot of id -> status for every inference
+// still live in the state machine. The live set is bounded (in-flight plus
+// in-grace), so this is cheap. Used by the user sequencer to find seal-eligible
+// inferences without deep-copying the full state.
+func (sm *StateMachine) LiveInferenceStatuses() map[uint64]types.InferenceStatus {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	out := make(map[uint64]types.InferenceStatus, len(sm.state.Inferences))
+	for id, rec := range sm.state.Inferences {
+		out[id] = rec.Status
+	}
+	return out
 }
 
 func SortedSlotIDs(group []types.SlotAssignment) []uint32 {

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -1338,7 +1338,7 @@ func TestApplyLocalBestEffort_FeePerNonce_InsufficientBalance_Rollback(t *testin
 		InputLength: 100,
 		MaxTokens:   50,
 		StartedAt:   1000,
-	})})
+	})}, nil)
 	require.ErrorIs(t, err, types.ErrInsufficientBalance)
 	require.Nil(t, applied)
 

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -192,6 +192,58 @@ func (sm *StateMachine) drainLiveIntoSealedAccLocked(sealNonce uint64) error {
 	return nil
 }
 
+// foldSealedIDsLocked folds the given inference ids into SealedAcc at sealNonce,
+// in ascending order, deduplicated, skipping any id that is not currently live
+// (already sealed, drained, or never created). It is the deterministic,
+// diff-driven seal: both the user (when composing a diff) and the host (when
+// applying it) run this before computing post_state_root, so the seal is part
+// of the signed root rather than an off-log, host-local side effect. Because
+// both sides replay the same diffs in the same order, the skip behavior and the
+// accumulator fold order are identical. Caller must hold sm.mu.
+func (sm *StateMachine) foldSealedIDsLocked(ids []uint64, sealNonce uint64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	sorted := make([]uint64, 0, len(ids))
+	seen := make(map[uint64]struct{}, len(ids))
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		sorted = append(sorted, id)
+	}
+	slices.Sort(sorted)
+
+	if sm.sealedNonces == nil {
+		sm.sealedNonces = make(map[uint64]uint64, len(sorted))
+	}
+	cur := sealedAccBytes32(sm.state.SealedAcc)
+
+	for _, id := range sorted {
+		rec, ok := sm.state.Inferences[id]
+		if !ok {
+			// Not live: already sealed/drained or unknown. Skipping keeps the
+			// fold idempotent and identical across user and host.
+			continue
+		}
+		if err := sm.updateCommittedEntryLocked(id, rec); err != nil {
+			return fmt.Errorf("fold sealed inference %d: %w", id, err)
+		}
+		entry := append([]byte(nil), sm.committedEntries[id]...)
+		cur = FoldSealedAccumulator(cur, sealNonce, id, entry)
+		sm.sealedNonces[id] = sealNonce
+		delete(sm.committedEntries, id)
+		if err := sm.upsertInferenceObsLocked(id, sealNonce, rec); err != nil {
+			return fmt.Errorf("persist sealed inference %d during fold: %w", id, err)
+		}
+		delete(sm.state.Inferences, id)
+	}
+	sm.state.SealedAcc = append([]byte(nil), cur[:]...)
+	return nil
+}
+
 func (sm *StateMachine) SealInference(id uint64) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()

--- a/devshard/state/seal_fold_test.go
+++ b/devshard/state/seal_fold_test.go
@@ -1,0 +1,205 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/types"
+)
+
+// newSealFoldSM builds a state machine bound to a caller-supplied user key so
+// several machines (user, host, replay) can share identical inputs and verify
+// the same user-signed diffs.
+func newSealFoldSM(t *testing.T, hosts []*signing.Secp256k1Signer, user *signing.Secp256k1Signer, balance uint64) *StateMachine {
+	t.Helper()
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	store := testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, balance)
+	sm, err := NewStateMachine("escrow-1", config, group, balance, user.Address(), verifier, store)
+	require.NoError(t, err)
+	return sm
+}
+
+// buildStartConfirmFinishDiffs returns the three user-signed diffs that bring
+// inferenceID through Pending -> Started -> Finished, starting at startNonce.
+// The same signed diffs can be applied to multiple machines because they carry
+// no machine-local state.
+func buildStartConfirmFinishDiffs(t *testing.T, user *signing.Secp256k1Signer, hosts []*signing.Secp256k1Signer, inferenceID, startNonce uint64) []types.Diff {
+	t.Helper()
+	executorSlotIdx := inferenceID % uint64(len(hosts))
+
+	start := testutil.SignDiff(t, user, "escrow-1", startNonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
+		InferenceId: inferenceID, PromptHash: []byte("prompt"), Model: "llama",
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	})})
+
+	execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	confirm := testutil.SignDiff(t, user, "escrow-1", startNonce+1, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
+		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: 1000,
+	})})
+
+	finishMsg := &types.MsgFinishInference{
+		InferenceId: inferenceID, ResponseHash: []byte("response"),
+		InputTokens: 80, OutputTokens: 40, ExecutorSlot: uint32(executorSlotIdx),
+		EscrowId: "escrow-1",
+	}
+	finishMsg.ProposerSig = testutil.SignProposerTx(t, hosts[executorSlotIdx], finishMsg)
+	finish := testutil.SignDiff(t, user, "escrow-1", startNonce+2, []*types.DevshardTx{txFinish(finishMsg)})
+
+	return []types.Diff{start, confirm, finish}
+}
+
+// TestV2_DiffSeal_UserHostReplayAgree is the core no-divergence guarantee: once
+// the seal decision is frozen into a signed diff, the user (composing), the host
+// (applying+verifying), and a fresh replay all derive the identical state root
+// and sealed_acc. The fold takes no wall-clock input, so clock skew between the
+// sequencer and any host cannot move the root -- which is exactly the
+// divergence the wall-clock seal gate used to cause.
+func TestV2_DiffSeal_UserHostReplayAgree(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+
+	userSM := newSealFoldSM(t, hosts, user, 1_000_000)
+	hostSM := newSealFoldSM(t, hosts, user, 1_000_000)
+	replaySM := newSealFoldSM(t, hosts, user, 1_000_000)
+
+	var history []types.Diff
+	applyUserHost := func(d types.Diff) {
+		userRoot, err := userSM.ApplyDiff(d)
+		require.NoError(t, err)
+		hostRoot, err := hostSM.ApplyDiff(d)
+		require.NoError(t, err)
+		require.Equal(t, userRoot, hostRoot, "user and host roots must match at nonce %d", d.Nonce)
+		history = append(history, d)
+	}
+
+	for _, d := range buildStartConfirmFinishDiffs(t, user, hosts, 1, 1) {
+		applyUserHost(d)
+	}
+	require.Contains(t, userSM.SnapshotState().Inferences, uint64(1), "inference must be live before seal")
+
+	// The sequencer freezes the seal of inference 1 into the next diff: it
+	// computes the post_state_root locally (best-effort), then signs over the
+	// txs + seal set + root.
+	sealNonce := userSM.LatestNonce() + 1
+	userRoot, applied, err := userSM.ApplyLocalBestEffort(sealNonce, nil, []uint64{1})
+	require.NoError(t, err)
+	require.Empty(t, applied, "seal-only diff applies no txs")
+
+	sealDiff := testutil.SignDiffSealedWithRoot(t, user, "escrow-1", sealNonce, nil, []uint64{1}, userRoot)
+
+	// The host applies the signed diff. ApplyDiff verifies the signature AND
+	// asserts its own recomputed root equals the signed post_state_root, so a
+	// successful apply already proves user==host. We assert the returned root
+	// too for an explicit equality signal.
+	hostRoot, err := hostSM.ApplyDiff(sealDiff)
+	require.NoError(t, err)
+	require.Equal(t, userRoot, hostRoot)
+	history = append(history, sealDiff)
+
+	// Replay reconstructs sealed_acc purely from the persisted seal set.
+	for _, d := range history {
+		_, err := replaySM.ApplyLocalSealed(d.Nonce, d.Txs, d.SealedInferenceIDs)
+		require.NoError(t, err)
+	}
+	replayRoot, err := replaySM.ComputeStateRoot()
+	require.NoError(t, err)
+	require.Equal(t, userRoot, replayRoot, "replay root must match user/host")
+
+	// Inference 1 is sealed everywhere: dropped from live state, folded into a
+	// non-zero, identical sealed_acc.
+	var zero [32]byte
+	userAcc := userSM.SnapshotState().SealedAcc
+	require.Len(t, userAcc, 32)
+	require.NotEqual(t, zero[:], userAcc, "sealed_acc must change after folding the seal")
+	require.Equal(t, userAcc, hostSM.SnapshotState().SealedAcc)
+	require.Equal(t, userAcc, replaySM.SnapshotState().SealedAcc)
+	for name, sm := range map[string]*StateMachine{"user": userSM, "host": hostSM, "replay": replaySM} {
+		require.NotContains(t, sm.SnapshotState().Inferences, uint64(1), "%s must drop sealed inference from live state", name)
+	}
+}
+
+// TestV2_DiffSeal_FoldOrderInvariant verifies the fold is invariant to the
+// order and multiplicity of the proposed seal ids: foldSealedIDsLocked sorts and
+// deduplicates, so a sequencer that lists ids in any order (or repeats one)
+// yields the identical sealed_acc and root. This protects against a subtle
+// divergence where two sequencers emit the same logical seal set in different
+// list orders.
+func TestV2_DiffSeal_FoldOrderInvariant(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+
+	smA := newSealFoldSM(t, hosts, user, 1_000_000)
+	smB := newSealFoldSM(t, hosts, user, 1_000_000)
+
+	driveBoth := func(inferenceID, startNonce uint64) {
+		for _, d := range buildStartConfirmFinishDiffs(t, user, hosts, inferenceID, startNonce) {
+			_, err := smA.ApplyDiff(d)
+			require.NoError(t, err)
+			_, err = smB.ApplyDiff(d)
+			require.NoError(t, err)
+		}
+	}
+	// Inference 1 uses nonces 1..3, inference 4 uses nonces 4..6 (the start tx
+	// requires inference_id == nonce).
+	driveBoth(1, 1)
+	driveBoth(4, 4)
+
+	sealNonce := smA.LatestNonce() + 1
+	rootA, _, err := smA.ApplyLocalBestEffort(sealNonce, nil, []uint64{1, 4})
+	require.NoError(t, err)
+	rootB, _, err := smB.ApplyLocalBestEffort(sealNonce, nil, []uint64{4, 1, 1}) // unsorted + duplicate
+	require.NoError(t, err)
+
+	require.Equal(t, rootA, rootB, "fold must be invariant to seal-id order and duplicates")
+	require.Equal(t, smA.SnapshotState().SealedAcc, smB.SnapshotState().SealedAcc)
+	require.Empty(t, smA.SnapshotState().Inferences)
+	require.Empty(t, smB.SnapshotState().Inferences)
+}
+
+// TestV2_DiffSeal_PostStateRootCommitsToSeal proves the seal is bound into the
+// signed post_state_root: a diff that claims to seal an inference but commits to
+// the root of a state that did NOT seal it is rejected, and the rejection rolls
+// back everything (nonce and seal). This is the mechanism that stops a divergent
+// or dishonest seal decision from being applied+signed.
+func TestV2_DiffSeal_PostStateRootCommitsToSeal(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+
+	hostSM := newSealFoldSM(t, hosts, user, 1_000_000)
+	refSM := newSealFoldSM(t, hosts, user, 1_000_000)
+
+	for _, d := range buildStartConfirmFinishDiffs(t, user, hosts, 1, 1) {
+		_, err := hostSM.ApplyDiff(d)
+		require.NoError(t, err)
+		_, err = refSM.ApplyDiff(d)
+		require.NoError(t, err)
+	}
+
+	sealNonce := hostSM.LatestNonce() + 1
+	// The root of a state that advances the nonce but does NOT seal inference 1.
+	noSealRoot, _, err := refSM.ApplyLocalBestEffort(sealNonce, nil, nil)
+	require.NoError(t, err)
+
+	// A diff that claims to seal [1] but commits to the no-seal root: the host
+	// folds the seal, recomputes a different root, and must reject the diff.
+	badDiff := testutil.SignDiffSealedWithRoot(t, user, "escrow-1", sealNonce, nil, []uint64{1}, noSealRoot)
+	_, err = hostSM.ApplyDiff(badDiff)
+	require.ErrorIs(t, err, types.ErrPostStateRootMismatch)
+
+	// Full rollback: inference still live, nonce not advanced.
+	require.Contains(t, hostSM.SnapshotState().Inferences, uint64(1), "rejected seal must not drop the inference")
+	require.Equal(t, sealNonce-1, hostSM.LatestNonce(), "rejected seal must not advance the nonce")
+}

--- a/devshard/storage/memory_test.go
+++ b/devshard/storage/memory_test.go
@@ -26,6 +26,10 @@ func TestMemory_AppendDiff_GetDiffs(t *testing.T) {
 	runAppendDiff_GetDiffs(t, NewMemory())
 }
 
+func TestMemory_AppendDiff_SealedInferenceIDs(t *testing.T) {
+	runAppendDiff_SealedInferenceIDs(t, NewMemory())
+}
+
 func TestMemory_GetSignatures(t *testing.T) {
 	runGetSignatures(t, NewMemory())
 }

--- a/devshard/storage/migrate.go
+++ b/devshard/storage/migrate.go
@@ -234,6 +234,8 @@ func migrateLegacyDiffs(src *sql.DB, dest Storage, escrowID string, copiedThroug
 	}
 
 	for _, d := range diffs {
+		// Legacy single-file stores predate the new storage layout (and thus the
+		// sealed_inference_ids feature), so these diffs never carry sealed ids.
 		txs, err := unmarshalTxs(d.txsProto)
 		if err != nil {
 			return fmt.Errorf("unmarshal txs nonce %d: %w", d.nonce, err)

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -426,7 +426,7 @@ func (s *Postgres) AppendDiff(escrowID string, rec types.DiffRecord) error {
 		return err
 	}
 
-	txsProto, err := marshalTxs(rec.Txs)
+	txsProto, err := marshalDiffContent(rec.Txs, rec.SealedInferenceIDs)
 	if err != nil {
 		return err
 	}
@@ -615,17 +615,18 @@ func (s *Postgres) GetDiffs(escrowID string, fromNonce, toNonce uint64) ([]types
 				result = append(result, *current)
 			}
 
-			txs, err := unmarshalTxs(txsProto)
+			txs, sealedIDs, err := unmarshalDiffContent(txsProto)
 			if err != nil {
 				return nil, err
 			}
 
 			rec := types.DiffRecord{
 				Diff: types.Diff{
-					Nonce:         nonce,
-					Txs:           txs,
-					UserSig:       userSig,
-					PostStateRoot: postStateRoot,
+					Nonce:              nonce,
+					Txs:                txs,
+					UserSig:            userSig,
+					PostStateRoot:      postStateRoot,
+					SealedInferenceIDs: sealedIDs,
 				},
 				StateHash: stateHash,
 				CreatedAt: createdAt,

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -128,6 +128,9 @@ func TestPostgres_CreateSession_EmptyVersionRejected(t *testing.T) {
 func TestPostgres_AppendDiff_GetDiffs(t *testing.T) {
 	runAppendDiff_GetDiffs(t, newTestPostgres(t))
 }
+func TestPostgres_AppendDiff_SealedInferenceIDs(t *testing.T) {
+	runAppendDiff_SealedInferenceIDs(t, newTestPostgres(t))
+}
 func TestPostgres_GetSignatures(t *testing.T) {
 	runGetSignatures(t, newTestPostgres(t))
 }

--- a/devshard/storage/shared_test.go
+++ b/devshard/storage/shared_test.go
@@ -155,6 +155,36 @@ func runAppendDiff_GetDiffs(t *testing.T, store Storage) {
 	require.Equal(t, uint64(5), meta.LatestNonce)
 }
 
+// runAppendDiff_SealedInferenceIDs verifies a diff's seal set survives the
+// storage round-trip. Sealed ids are part of the signed diff content and must be
+// reconstructed on replay/recovery so sealed_acc is rebuilt deterministically.
+func runAppendDiff_SealedInferenceIDs(t *testing.T, store Storage) {
+	t.Helper()
+
+	require.NoError(t, store.CreateSession(defaultParams()))
+
+	sealed := []uint64{2, 5, 9}
+	require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{
+		Diff: types.Diff{
+			Nonce:              1,
+			UserSig:            []byte("sig"),
+			SealedInferenceIDs: sealed,
+		},
+		StateHash: []byte{0x01},
+	}))
+	// A diff that seals nothing must round-trip without sealed ids.
+	require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{
+		Diff:      types.Diff{Nonce: 2, UserSig: []byte("sig")},
+		StateHash: []byte{0x02},
+	}))
+
+	got, err := store.GetDiffs("escrow-1", 1, 2)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, sealed, got[0].SealedInferenceIDs, "sealed ids must survive the storage round-trip")
+	require.Empty(t, got[1].SealedInferenceIDs, "no-seal diff must round-trip without sealed ids")
+}
+
 func runGetSignatures(t *testing.T, store Storage) {
 	t.Helper()
 

--- a/devshard/storage/sqlite.go
+++ b/devshard/storage/sqlite.go
@@ -574,7 +574,7 @@ func (s *SQLite) AppendDiff(escrowID string, rec types.DiffRecord) error {
 		return err
 	}
 
-	txsProto, err := marshalTxs(rec.Txs)
+	txsProto, err := marshalDiffContent(rec.Txs, rec.SealedInferenceIDs)
 	if err != nil {
 		return err
 	}
@@ -748,17 +748,18 @@ func (s *SQLite) GetDiffs(escrowID string, fromNonce, toNonce uint64) ([]types.D
 				result = append(result, *current)
 			}
 
-			txs, err := unmarshalTxs(txsProto)
+			txs, sealedIDs, err := unmarshalDiffContent(txsProto)
 			if err != nil {
 				return nil, err
 			}
 
 			rec := types.DiffRecord{
 				Diff: types.Diff{
-					Nonce:         nonce,
-					Txs:           txs,
-					UserSig:       userSig,
-					PostStateRoot: postStateRoot,
+					Nonce:              nonce,
+					Txs:                txs,
+					UserSig:            userSig,
+					PostStateRoot:      postStateRoot,
+					SealedInferenceIDs: sealedIDs,
 				},
 				StateHash: stateHash,
 				CreatedAt: createdAt,
@@ -1209,25 +1210,43 @@ func (s *SQLite) pruneBefore(cutoff uint64) error {
 	return nil
 }
 
-// marshalTxs serializes a slice of DevshardTx into a single proto blob
-// by wrapping them in DiffContent (reusing the existing proto message).
-func marshalTxs(txs []*types.DevshardTx) ([]byte, error) {
-	wrapper := &types.DiffContent{Txs: txs}
+// marshalDiffContent serializes a diff's txs and sealed-inference ids into a
+// single proto blob by wrapping them in DiffContent (reusing the existing proto
+// message). Sealed ids are part of the signed diff content, so they must
+// survive storage to reconstruct SealedAcc deterministically on replay.
+func marshalDiffContent(txs []*types.DevshardTx, sealedIDs []uint64) ([]byte, error) {
+	wrapper := &types.DiffContent{Txs: txs, SealedInferenceIds: sealedIDs}
 	data, err := proto.Marshal(wrapper)
 	if err != nil {
-		return nil, fmt.Errorf("marshal txs: %w", err)
+		return nil, fmt.Errorf("marshal diff content: %w", err)
 	}
 	return data, nil
 }
 
-// unmarshalTxs deserializes a proto blob back into DevshardTx slice.
-func unmarshalTxs(data []byte) ([]*types.DevshardTx, error) {
+// unmarshalDiffContent deserializes a proto blob back into the txs slice and
+// sealed-inference ids.
+func unmarshalDiffContent(data []byte) ([]*types.DevshardTx, []uint64, error) {
 	if len(data) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	wrapper := &types.DiffContent{}
 	if err := proto.Unmarshal(data, wrapper); err != nil {
-		return nil, fmt.Errorf("unmarshal txs: %w", err)
+		return nil, nil, fmt.Errorf("unmarshal diff content: %w", err)
 	}
-	return wrapper.Txs, nil
+	return wrapper.Txs, wrapper.SealedInferenceIds, nil
+}
+
+// marshalTxs serializes a slice of DevshardTx into a single proto blob
+// by wrapping them in DiffContent (reusing the existing proto message).
+func marshalTxs(txs []*types.DevshardTx) ([]byte, error) {
+	return marshalDiffContent(txs, nil)
+}
+
+// unmarshalTxs deserializes a proto blob back into DevshardTx slice.
+func unmarshalTxs(data []byte) ([]*types.DevshardTx, error) {
+	txs, _, err := unmarshalDiffContent(data)
+	if err != nil {
+		return nil, err
+	}
+	return txs, nil
 }

--- a/devshard/storage/sqlite_test.go
+++ b/devshard/storage/sqlite_test.go
@@ -112,6 +112,10 @@ func TestSQLite_AppendDiff_GetDiffs(t *testing.T) {
 	runAppendDiff_GetDiffs(t, newTestSQLite(t))
 }
 
+func TestSQLite_AppendDiff_SealedInferenceIDs(t *testing.T) {
+	runAppendDiff_SealedInferenceIDs(t, newTestSQLite(t))
+}
+
 func TestSQLite_GetSignatures(t *testing.T) {
 	runGetSignatures(t, newTestSQLite(t))
 }

--- a/devshard/transport/types.go
+++ b/devshard/transport/types.go
@@ -13,7 +13,7 @@ import (
 // Proto-serialized fields travel as base64 to preserve signature integrity.
 type DiffJSON struct {
 	Nonce         uint64 `json:"nonce"`
-	Txs           []byte `json:"txs"`                        // proto bytes of DiffContent.Txs wrapper
+	Txs           []byte `json:"txs"`                        // proto bytes of DiffContent (txs + sealed_inference_ids)
 	UserSig       []byte `json:"user_sig"`                   // raw sig bytes
 	PostStateRoot []byte `json:"post_state_root,omitempty"`  // state root after applying txs
 }
@@ -92,9 +92,11 @@ type SignaturesResponse struct {
 
 // DiffToJSON converts a domain Diff to its JSON wire format.
 func DiffToJSON(d types.Diff) (DiffJSON, error) {
-	// Serialize the txs as a DiffContent proto (nonce + txs together)
-	// to preserve the exact bytes that were signed.
-	content := &types.DiffContent{Nonce: d.Nonce, Txs: d.Txs}
+	// Serialize the txs and sealed-inference ids as a DiffContent proto to
+	// preserve the exact bytes that were signed. Sealed ids are part of the
+	// signed content, so they must travel inside this proto wrapper (not as a
+	// separate JSON field) to keep signature and state-root verification intact.
+	content := &types.DiffContent{Nonce: d.Nonce, Txs: d.Txs, SealedInferenceIds: d.SealedInferenceIDs}
 	txsBytes, err := proto.Marshal(content)
 	if err != nil {
 		return DiffJSON{}, fmt.Errorf("marshal diff content: %w", err)
@@ -114,10 +116,11 @@ func DiffFromJSON(dj DiffJSON) (types.Diff, error) {
 		return types.Diff{}, fmt.Errorf("unmarshal diff content: %w", err)
 	}
 	return types.Diff{
-		Nonce:         dj.Nonce,
-		Txs:           content.Txs,
-		UserSig:       dj.UserSig,
-		PostStateRoot: dj.PostStateRoot,
+		Nonce:              dj.Nonce,
+		Txs:                content.Txs,
+		UserSig:            dj.UserSig,
+		PostStateRoot:      dj.PostStateRoot,
+		SealedInferenceIDs: content.SealedInferenceIds,
 	}, nil
 }
 

--- a/devshard/types/diff.pb.go
+++ b/devshard/types/diff.pb.go
@@ -28,8 +28,14 @@ type DiffContent struct {
 	Txs           []*DevshardTx          `protobuf:"bytes,2,rep,name=txs,proto3" json:"txs,omitempty"`
 	EscrowId      string                 `protobuf:"bytes,3,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`
 	PostStateRoot []byte                 `protobuf:"bytes,4,opt,name=post_state_root,json=postStateRoot,proto3" json:"post_state_root,omitempty"` // state root AFTER applying this diff's txs
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// sealed_inference_ids lists the inference ids the sequencer folds into the
+	// sealed accumulator at this nonce. The fold runs (identically on user and
+	// host) after txs are applied and before post_state_root is computed, so the
+	// seal is part of the signed root rather than an off-log, host-local side
+	// effect. Ascending, deduplicated.
+	SealedInferenceIds []uint64 `protobuf:"varint,5,rep,packed,name=sealed_inference_ids,json=sealedInferenceIds,proto3" json:"sealed_inference_ids,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *DiffContent) Reset() {
@@ -86,6 +92,13 @@ func (x *DiffContent) GetEscrowId() string {
 func (x *DiffContent) GetPostStateRoot() []byte {
 	if x != nil {
 		return x.PostStateRoot
+	}
+	return nil
+}
+
+func (x *DiffContent) GetSealedInferenceIds() []uint64 {
+	if x != nil {
+		return x.SealedInferenceIds
 	}
 	return nil
 }
@@ -505,12 +518,13 @@ var File_devshard_v1_diff_proto protoreflect.FileDescriptor
 
 const file_devshard_v1_diff_proto_rawDesc = "" +
 	"\n" +
-	"\x16devshard/v1/diff.proto\x12\vdevshard.v1\x1a\x14devshard/v1/tx.proto\"\x93\x01\n" +
+	"\x16devshard/v1/diff.proto\x12\vdevshard.v1\x1a\x14devshard/v1/tx.proto\"\xc5\x01\n" +
 	"\vDiffContent\x12\x14\n" +
 	"\x05nonce\x18\x01 \x01(\x04R\x05nonce\x12)\n" +
 	"\x03txs\x18\x02 \x03(\v2\x17.devshard.v1.DevshardTxR\x03txs\x12\x1b\n" +
 	"\tescrow_id\x18\x03 \x01(\tR\bescrowId\x12&\n" +
-	"\x0fpost_state_root\x18\x04 \x01(\fR\rpostStateRoot\"\xd1\x04\n" +
+	"\x0fpost_state_root\x18\x04 \x01(\fR\rpostStateRoot\x120\n" +
+	"\x14sealed_inference_ids\x18\x05 \x03(\x04R\x12sealedInferenceIds\"\xd1\x04\n" +
 	"\n" +
 	"DevshardTx\x12I\n" +
 	"\x0fstart_inference\x18\x01 \x01(\v2\x1e.devshard.v1.MsgStartInferenceH\x00R\x0estartInference\x12C\n" +

--- a/devshard/types/domain.go
+++ b/devshard/types/domain.go
@@ -102,11 +102,11 @@ func ParseProtocolVersion(s string) (ProtocolVersion, error) {
 
 // SessionConfig holds session-level parameters.
 type SessionConfig struct {
-	RefusalTimeout             int64  // seconds before reason=refused timeout
-	ExecutionTimeout           int64  // seconds before reason=execution timeout
-	TokenPrice                 uint64 // price per input / output token (flat per session)
-	CreateDevshardFee          uint64 // one-time fee charged when creating a devshard session
-	FeePerNonce                uint64 // fee charged per applied nonce (diff)
+	RefusalTimeout    int64  // seconds before reason=refused timeout
+	ExecutionTimeout  int64  // seconds before reason=execution timeout
+	TokenPrice        uint64 // price per input / output token (flat per session)
+	CreateDevshardFee uint64 // one-time fee charged when creating a devshard session
+	FeePerNonce       uint64 // fee charged per applied nonce (diff)
 	// VoteThreshold is frozen at session bind (see ApplyLiveSessionParams).
 	// Consensus logic must read it only via state.StateMachine (applyValidationVote,
 	// applyTimeout); external packages use StateMachine.VoteThreshold() for display.
@@ -125,16 +125,16 @@ type EscrowState struct {
 	// session must use the same tag. Storage CreateSessionParams.Version is the
 	// separate runtime/bind version for versiond routing, not this field.
 	StateRootAndProtocolVersion string
-	Config        SessionConfig
-	Group         []SlotAssignment
-	Balance       uint64
-	Fees          uint64 // total fees collected (devshard create + per-nonce)
-	Phase         SessionPhase
-	FinalizeNonce uint64
-	Inferences    map[uint64]*InferenceRecord
-	HostStats     map[uint32]*HostStats
-	WarmKeys      map[uint32]string // slot ID -> warm key address, lazily populated
-	LatestNonce   uint64
+	Config                      SessionConfig
+	Group                       []SlotAssignment
+	Balance                     uint64
+	Fees                        uint64 // total fees collected (devshard create + per-nonce)
+	Phase                       SessionPhase
+	FinalizeNonce               uint64
+	Inferences                  map[uint64]*InferenceRecord
+	HostStats                   map[uint32]*HostStats
+	WarmKeys                    map[uint32]string // slot ID -> warm key address, lazily populated
+	LatestNonce                 uint64
 	// SealedAcc is the Phase 1 incremental accumulator over sealed inference
 	// commitments (32 bytes). Updated on each SealInference and settlement drain.
 	SealedAcc []byte `json:"sealed_acc,omitempty"`
@@ -145,10 +145,11 @@ type EscrowState struct {
 // Txs uses the proto-generated DevshardTx with its oneof discriminator,
 // which structurally guarantees exactly one tx type per entry.
 type Diff struct {
-	Nonce         uint64
-	Txs           []*DevshardTx
-	UserSig       []byte
-	PostStateRoot []byte
+	Nonce              uint64
+	Txs                []*DevshardTx
+	UserSig            []byte
+	PostStateRoot      []byte
+	SealedInferenceIDs []uint64
 }
 
 // DiffRecord is the storage representation: Diff + computed metadata.

--- a/devshard/types/errors.go
+++ b/devshard/types/errors.go
@@ -42,4 +42,6 @@ var (
 	ErrInvalidGroup          = errors.New("invalid group")
 	ErrEscrowIDMismatch      = errors.New("escrow_id does not match session")
 	ErrNonceLimitExceeded    = errors.New("nonce exceeds chain max_nonce limit")
+	ErrSealNotEligible       = errors.New("sealed inference is not in a seal-eligible status")
+	ErrSealTooEarly          = errors.New("sealed inference has not cleared the seal grace window")
 )

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -220,7 +220,7 @@ func RecoverSession(
 
 	for _, rec := range records {
 		sm.InjectWarmKeys(rec.WarmKeyDelta)
-		root, applyErr := sm.ApplyLocal(rec.Nonce, rec.Txs)
+		root, applyErr := sm.ApplyLocalSealed(rec.Nonce, rec.Txs, rec.SealedInferenceIDs)
 		if applyErr != nil {
 			return nil, nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
 		}

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -26,6 +26,11 @@ import (
 // passed their own deadline before the proxy fires the timeout.
 var TimeoutBuffer = 5 * time.Second
 
+// defaultUserInferenceClearGrace is the wall-clock seal grace the sequencer
+// falls back to when the session config leaves InferenceClearGraceSeconds unset.
+// Mirrors the host fallback; normal sessions always carry a normalized value.
+const defaultUserInferenceClearGrace = 60 * time.Minute
+
 // MaxConcurrentVerifierRPCs caps how many simultaneous VerifyTimeout RPCs the
 // proxy may have open against the same verifier host. When many in-flight
 // nonces time out around the same time (e.g. one executor host stops
@@ -237,6 +242,17 @@ type Session struct {
 	nonceStates     map[uint64]*nonceOutcome     // nonce -> protocol outcome
 	verifierQueue   *verifierHostQueue           // per-verifier RPC limiter for timeout votes
 
+	// Seal ledger: when an inference first becomes seal-eligible (status
+	// Finished or terminal and still live), the sequencer records when it
+	// observed that. The seal set for each new diff is derived from this ledger:
+	// terminal inferences (Validated/Invalidated/TimedOut) are final and seal
+	// immediately (next diff, no grace), while Finished inferences wait the
+	// nonce floor + wall-clock grace so a late challenge can still arrive.
+	// Entries are dropped once the id is sealed. This is the single source of
+	// the nondeterministic wall clock; it is consumed only here, at
+	// composition, and frozen into the signed diff.
+	sealable map[uint64]sealMarker
+
 	// snapshotInFlight is set to true while an async background snapshot
 	// save is running, so concurrent composeDiffLocked invocations do not
 	// pile up duplicate saves. See maybeSaveSnapshotLocked.
@@ -321,6 +337,7 @@ func NewSession(
 		pendingTxKeys:   make(map[string]struct{}),
 		signatures:      make(map[uint64]map[uint32][]byte),
 		nonceStates:     make(map[uint64]*nonceOutcome),
+		sealable:        make(map[uint64]sealMarker),
 		verifierQueue:   SharedVerifierQueue,
 		//TODO: check if we should move it from Session
 		signatureCollectMaxRetries:  3,
@@ -603,11 +620,17 @@ func (s *Session) composeDiffLocked(extraTxs []*types.DevshardTx) (types.Diff, i
 	if s.store != nil {
 		warmBefore = s.sm.WarmKeys()
 	}
-	postStateRoot, applied, err := s.sm.ApplyLocalBestEffort(nonce, candidates)
+
+	// Decide which inferences to seal at this nonce from the seal ledger
+	// (wall-clock grace + nonce floor). The clock is read only here and frozen
+	// into the signed diff, so the host applies the same seal deterministically.
+	sealIDs := s.computeSealIDsLocked(nonce, time.Now())
+
+	postStateRoot, applied, err := s.sm.ApplyLocalBestEffort(nonce, candidates, sealIDs)
 	if err != nil {
 		return types.Diff{}, 0, fmt.Errorf("local apply: %w", err)
 	}
-	diff, err := s.signDiff(nonce, applied, postStateRoot)
+	diff, err := s.signDiff(nonce, applied, sealIDs, postStateRoot)
 	if err != nil {
 		return types.Diff{}, 0, err
 	}
@@ -615,6 +638,12 @@ func (s *Session) composeDiffLocked(extraTxs []*types.DevshardTx) (types.Diff, i
 	s.diffs = append(s.diffs, diff)
 	s.nonce = nonce
 	s.clearPendingTxs()
+
+	// Update the seal ledger from the txs that just applied: drop ids sealed at
+	// this nonce and (un)mark seal-eligibility for the inferences those txs
+	// touched. Event-driven (only the diff's txs), mirroring the host's
+	// finishedAt/terminalAt tracking -- no full live-set scan.
+	s.observeSealEventsLocked(nonce, applied, sealIDs, time.Now())
 
 	if s.store != nil {
 		warmAfter := s.sm.WarmKeys()
@@ -630,6 +659,135 @@ func (s *Session) composeDiffLocked(extraTxs []*types.DevshardTx) (types.Diff, i
 	}
 
 	return diff, hostIdx, nil
+}
+
+// sealMarker records when an inference became seal-eligible. immediate is set
+// for terminal inferences (Validated/Invalidated/TimedOut), which are final and
+// seal without waiting any grace; for Finished inferences it is false and the
+// nonce floor + wall-clock grace gates apply.
+type sealMarker struct {
+	sinceNonce uint64
+	sinceTime  time.Time
+	immediate  bool
+}
+
+// sealEligibleStatus reports whether an inference in this status may be sealed
+// into the accumulator: Finished (stale-finished, Tier C) or terminal (Tier A).
+// Challenged is mid-vote and not yet sealable.
+func sealEligibleStatus(s types.InferenceStatus) bool {
+	switch s {
+	case types.StatusFinished, types.StatusValidated, types.StatusInvalidated, types.StatusTimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+// sealTerminalStatus reports whether an inference status is terminal (final, no
+// further transition possible). Terminal inferences seal immediately, with no
+// grace, since there is nothing left to wait for. Finished is not terminal: it
+// can still be challenged within the grace window.
+func sealTerminalStatus(s types.InferenceStatus) bool {
+	switch s {
+	case types.StatusValidated, types.StatusInvalidated, types.StatusTimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+// userInferenceClearGrace returns the wall-clock grace before an inference may
+// be sealed, from the frozen session config (with a safety fallback).
+func (s *Session) userInferenceClearGrace() time.Duration {
+	secs := s.sm.InferenceClearGraceSeconds()
+	if secs == 0 {
+		return defaultUserInferenceClearGrace
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// computeSealIDsLocked returns the ascending set of ledger inference ids that
+// are due for sealing as of (nonce, now). Terminal inferences (immediate) seal
+// with no grace; Finished inferences must clear both the nonce floor
+// (nonce >= sinceNonce + sealGraceNonces) and the wall-clock grace
+// (now - sinceTime >= inferenceClearGrace). The ledger only ever holds live,
+// seal-eligible ids (maintained by observeSealEventsLocked), so no live state
+// scan is needed here. Only meaningful in the Active phase; during finalization
+// the settlement drain seals the remainder, so we return nil to keep the drain
+// order deterministic. Caller holds s.mu.
+func (s *Session) computeSealIDsLocked(nonce uint64, now time.Time) []uint64 {
+	if s.sm.Phase() != types.PhaseActive {
+		return nil
+	}
+	if len(s.sealable) == 0 {
+		return nil
+	}
+	grace := s.userInferenceClearGrace()
+	sealGraceNonces := uint64(s.sm.SealGraceNonces())
+
+	var ids []uint64
+	for id, m := range s.sealable {
+		if !m.immediate {
+			if nonce < m.sinceNonce+sealGraceNonces {
+				continue
+			}
+			if now.Sub(m.sinceTime) < grace {
+				continue
+			}
+		}
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// observeSealEventsLocked maintains the seal ledger from the txs that just
+// applied. It drops ids sealed at this nonce, then for each inference touched
+// by an applied finish/validation/vote/timeout tx it (re)marks seal-eligibility
+// from that inference's post-apply status: Finished is recorded with grace,
+// terminal is recorded as immediate, and a regression out of a sealable status
+// (e.g. Finished -> Challenged) or a vanished record clears the marker. A
+// Finished marker that later goes terminal is upgraded to immediate. This
+// mirrors the host's event-driven finishedAt/terminalAt tracking and avoids
+// scanning the full live set. Caller holds s.mu.
+func (s *Session) observeSealEventsLocked(nonce uint64, applied []*types.DevshardTx, sealedIDs []uint64, now time.Time) {
+	for _, id := range sealedIDs {
+		delete(s.sealable, id)
+	}
+
+	for _, tx := range applied {
+		var id uint64
+		switch {
+		case tx.GetFinishInference() != nil:
+			id = tx.GetFinishInference().InferenceId
+		case tx.GetValidation() != nil:
+			id = tx.GetValidation().InferenceId
+		case tx.GetValidationVote() != nil:
+			id = tx.GetValidationVote().InferenceId
+		case tx.GetTimeoutInference() != nil:
+			id = tx.GetTimeoutInference().InferenceId
+		default:
+			continue
+		}
+
+		rec, ok := s.sm.GetInference(id)
+		if !ok || !sealEligibleStatus(rec.Status) {
+			// Sealed/drained, or regressed out of a sealable status: ensure no
+			// stale marker lingers.
+			delete(s.sealable, id)
+			continue
+		}
+		terminal := sealTerminalStatus(rec.Status)
+		existing, tracked := s.sealable[id]
+		if !tracked {
+			s.sealable[id] = sealMarker{sinceNonce: nonce, sinceTime: now, immediate: terminal}
+		} else if terminal && !existing.immediate {
+			// Finished -> terminal (validated/invalidated/timed out): upgrade to
+			// immediate sealing; a now-final inference has no reason to wait.
+			existing.immediate = true
+			s.sealable[id] = existing
+		}
+	}
 }
 
 // maybeSaveSnapshotLocked schedules an asynchronous snapshot save when
@@ -1102,9 +1260,11 @@ func (s *Session) Finalize(ctx context.Context) error {
 	return nil
 }
 
-// signDiff builds and signs a diff with the given nonce, txs, and post_state_root.
-func (s *Session) signDiff(nonce uint64, txs []*types.DevshardTx, postStateRoot []byte) (types.Diff, error) {
-	content := state.BuildDiffContent(s.escrowID, nonce, txs, postStateRoot)
+// signDiff builds and signs a diff with the given nonce, txs, sealed ids, and
+// post_state_root. sealedIDs must be ascending and deduplicated so the signed
+// bytes match what the host reconstructs.
+func (s *Session) signDiff(nonce uint64, txs []*types.DevshardTx, sealedIDs []uint64, postStateRoot []byte) (types.Diff, error) {
+	content := state.BuildDiffContent(s.escrowID, nonce, txs, sealedIDs, postStateRoot)
 	data, err := proto.Marshal(content)
 	if err != nil {
 		return types.Diff{}, fmt.Errorf("marshal diff content: %w", err)
@@ -1113,7 +1273,7 @@ func (s *Session) signDiff(nonce uint64, txs []*types.DevshardTx, postStateRoot 
 	if err != nil {
 		return types.Diff{}, fmt.Errorf("sign diff: %w", err)
 	}
-	return types.Diff{Nonce: nonce, Txs: txs, UserSig: sig, PostStateRoot: postStateRoot}, nil
+	return types.Diff{Nonce: nonce, Txs: txs, UserSig: sig, PostStateRoot: postStateRoot, SealedInferenceIDs: sealedIDs}, nil
 }
 
 // devshardTxKey returns a dedup key for host-proposed txs.

--- a/devshard/user/validation_test.go
+++ b/devshard/user/validation_test.go
@@ -14,6 +14,7 @@ import (
 	"devshard/internal/testutil"
 	"devshard/signing"
 	"devshard/state"
+	"devshard/storage"
 	"devshard/stub"
 	"devshard/types"
 )
@@ -54,6 +55,32 @@ func sumHostStatsInvalid(st types.EscrowState) uint32 {
 		n += hs.Invalid
 	}
 	return n
+}
+
+// sealedRecords returns the sealed (SealedNonce>0) inference snapshots from the
+// obs store for ids 1..maxID. Terminal inferences (Validated/Invalidated/
+// TimedOut) seal mid-session under the terminal-immediate rule, so their final
+// status and vote tallies live here rather than in the live Inferences map.
+// Rows with SealedNonce==0 are live snapshots (e.g. Challenged) that still sit
+// in the live map and are skipped here to avoid double counting.
+func sealedRecords(t *testing.T, store *storage.Memory, escrowID string, maxID int) map[uint64]types.InferenceRecord {
+	t.Helper()
+	out := make(map[uint64]types.InferenceRecord)
+	for id := 1; id <= maxID; id++ {
+		row, ok, err := store.GetSealedInference(escrowID, uint64(id))
+		require.NoError(t, err)
+		if !ok || !row.ObsPresent || row.SealedNonce == 0 {
+			continue
+		}
+		out[uint64(id)] = types.InferenceRecord{
+			Status:       types.InferenceStatus(row.SealedStatus),
+			ExecutorSlot: row.SealedExecutorSlot,
+			VotesValid:   row.SealedVotesValid,
+			VotesInvalid: row.SealedVotesInvalid,
+			ValidatedBy:  types.Bitmap128FromBytes(row.SealedValidatedBy),
+		}
+	}
+	return out
 }
 
 func TestSession_Validation_InvalidationConverges(t *testing.T) {
@@ -99,7 +126,8 @@ func TestSession_Validation_InvalidationConverges(t *testing.T) {
 		clients[i] = &InProcessClient{Host: h}
 	}
 
-	userSM, err := state.NewStateMachine("escrow-validation", config, group, balance, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-validation", user.Address(), config, group, balance))
+	userStore := testutil.MustMemoryStore(t, "escrow-validation", user.Address(), config, group, balance)
+	userSM, err := state.NewStateMachine("escrow-validation", config, group, balance, user.Address(), verifier, userStore)
 	require.NoError(t, err)
 	session, err := NewSession(userSM, user, "escrow-validation", group, clients, verifier)
 	require.NoError(t, err)
@@ -139,19 +167,27 @@ func TestSession_Validation_InvalidationConverges(t *testing.T) {
 
 	// Snapshot before finalize: v2 drains state.Inferences into SealedAcc at settlement.
 	preFinalize := session.StateMachine().SnapshotState()
-	var finished, challenged, invalidated, validated, other int
+	var liveFinished, liveChallenged, liveOther int
 	for _, rec := range preFinalize.Inferences {
 		switch rec.Status {
 		case types.StatusFinished:
-			finished++
+			liveFinished++
 		case types.StatusChallenged:
-			challenged++
-		case types.StatusInvalidated:
-			invalidated++
-		case types.StatusValidated:
-			validated++
+			liveChallenged++
 		default:
-			other++
+			liveOther++
+		}
+	}
+	// Terminal inferences seal mid-session under the terminal-immediate rule, so
+	// their final status lives in the sealed obs store, not the live map.
+	sealed := sealedRecords(t, userStore, "escrow-validation", numInferences)
+	var sealedInvalidated, sealedValidated int
+	for _, rec := range sealed {
+		switch rec.Status {
+		case types.StatusInvalidated:
+			sealedInvalidated++
+		case types.StatusValidated:
+			sealedValidated++
 		}
 	}
 	totalHostStatsInvalid := sumHostStatsInvalid(preFinalize)
@@ -160,14 +196,14 @@ func TestSession_Validation_InvalidationConverges(t *testing.T) {
 		totalCalls += v.calls.Load()
 	}
 	hist := fmt.Sprintf(
-		"histogram: live=%d finished=%d challenged=%d invalidated=%d validated=%d other=%d host_stats_invalid=%d validate_calls=%d",
-		len(preFinalize.Inferences), finished, challenged, invalidated, validated, other,
-		totalHostStatsInvalid, totalCalls,
+		"histogram: live=%d live_finished=%d live_challenged=%d live_other=%d sealed_invalidated=%d sealed_validated=%d host_stats_invalid=%d validate_calls=%d",
+		len(preFinalize.Inferences), liveFinished, liveChallenged, liveOther,
+		sealedInvalidated, sealedValidated, totalHostStatsInvalid, totalCalls,
 	)
 	t.Log(hist)
 
-	require.Greater(t, challenged+invalidated, 0, "validators never produced any MsgValidation; %s", hist)
-	require.GreaterOrEqual(t, invalidated, 10, hist)
+	require.Greater(t, sealedInvalidated, 0, "validators never produced any invalidation; %s", hist)
+	require.GreaterOrEqual(t, sealedInvalidated, 10, hist)
 	require.Greater(t, totalHostStatsInvalid, uint32(0), hist)
 
 	require.NoError(t, session.Finalize(ctx))
@@ -236,7 +272,8 @@ func TestSession_Validation_MultiSlotValidatorCountedOnce(t *testing.T) {
 		require.NotNil(t, clients[i], "no client for slot %d", i)
 	}
 
-	userSM, err := state.NewStateMachine("escrow-multi", config, group, balance, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-multi", user.Address(), config, group, balance))
+	userStore := testutil.MustMemoryStore(t, "escrow-multi", user.Address(), config, group, balance)
+	userSM, err := state.NewStateMachine("escrow-multi", config, group, balance, user.Address(), verifier, userStore)
 	require.NoError(t, err)
 	session, err := NewSession(userSM, user, "escrow-multi", group, clients, verifier)
 	require.NoError(t, err)
@@ -274,21 +311,29 @@ func TestSession_Validation_MultiSlotValidatorCountedOnce(t *testing.T) {
 
 	preFinalize := session.StateMachine().SnapshotState()
 	megaSlots := []uint32{1, 2, 3}
+	megaParticipated := func(vb types.Bitmap128) bool {
+		for _, slot := range megaSlots {
+			if vb.IsSet(slot) {
+				return true
+			}
+		}
+		return false
+	}
 
+	// Terminal inferences seal mid-session, so combine the live map with the
+	// sealed obs snapshots to see every inference mega participated in. The two
+	// sets are disjoint: a sealed (SealedNonce>0) inference is no longer live.
 	megaParticipations := 0
 	invalidated := 0
 	for _, rec := range preFinalize.Inferences {
-		participated := false
-		for _, slot := range megaSlots {
-			if rec.ValidatedBy.IsSet(slot) {
-				participated = true
-				break
-			}
-		}
-		if participated {
+		if megaParticipated(rec.ValidatedBy) {
 			megaParticipations++
 		}
-
+	}
+	for _, rec := range sealedRecords(t, userStore, "escrow-multi", numInferences) {
+		if megaParticipated(rec.ValidatedBy) {
+			megaParticipations++
+		}
 		// Invalidation requires VotesInvalid > VoteThreshold(2), i.e. >= 3.
 		// host0 + host2 together have weight 1+1 = 2 (mega excluded as
 		// executor). So every Invalidated inference must include mega's

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -151,7 +151,7 @@ fi
 
 is_placeholder_password() {
     case "$1" in
-        ""|admin1|YourSecretPasswordHere|changeme|<FILLIN>)
+        ""|admin1|YourSecretPasswordHere|changeme|"<FILLIN>")
             return 0
             ;;
         *)


### PR DESCRIPTION
## Problem

We are cleaning inferences from the devshard state, as they are polluting the state. But inference first should be finished/timedouted and after it is finished it could be validated.

The problem is that we don't know will be the inference selected for validation or not, so we need to keep all inferences for some period. We use grace nonces and grace timeout. **The grace timeout for sealing inferences (remove from state to db for stats) is the bad option.**

To be deterministic we should use only grace nonces, but it can introduce another problem for devshards under low-load. Number of inferences forms the number of nonces, it using only grace nonces is very uncertain on how long inference will be in state. So we added grace timeout, that breaks determenism as clock of hosts can diverge and it can lead to diverged state (sealed inferences has accumulator in state, also we are clearing inferences from state).

In target redesign we should know for certain in some N nonces, that inference will be selected for validation or not, so target design will be free of this bad option of using clocks to clear state.

At current intermidiate solution user is sequencing diffs and in diffs there is data to seal inferences. Hosts has gates for it, they check if inference is eligable to be cleaned, and also we have special parameter `sealAdmissionClockTolerance` that is set to `2 minutes` to handle clock divergence between hosts and user (inference grace timeout is `1 hour`). Using 2 minutes as a reliable clock-divergence makes it stable, but end design protocol should be free of grace timeout solution, that brings undeterminism.

## Implementation

Hosts could diverge from the user on `SealedAcc` / `post_state_root` because sealing used a wall-clock grace gate outside the signed diff. Sealing is now an explicit, signed part of each diff (`sealed_inference_ids` in `DiffContent`), folded deterministically in `applyCore` before the state root is computed.

- **User:** event-driven seal ledger; terminal inferences sealed on the next diff, `Finished` after nonce + wall-clock grace.
- **Host:** deterministic fold on apply/replay; live-only admission check (status + 10s clock tolerance) before signing; payload pruning decoupled (prune events emitted from `diff.SealedInferenceIDs` after apply).
- **Wire:** `sealed_inference_ids` carried in the `DiffContent` proto blob on HTTP transport and in SQL `txs_proto` (no schema change).

No protocol-version bump (v2 debugging branch).

## Test plan

- `cd devshard && go test ./...`
- `cd decentralized-api && go test ./...`
- `cd testermint && ./gradlew :test --tests "DevshardStandaloneTests" -DexcludeTags=unstable,exclude`
