### PR TITLE
docs: add Chinese (zh) translations for key documentation

### DIFF
--- a/docs/zh/consumer_setup.md
+++ b/docs/zh/consumer_setup.md
@@ -1,0 +1,125 @@
+# 消费者设置指南
+创建开发者账户并向 Gonka 网络发送推理请求的分步指南。
+---
+## 1. 定义变量
+在开始之前，设置所需的环境变量：
+```bash
+export ACCOUNT_NAME="myaccount"
+export NODE_URL="http://node2.gonka.ai:8000"
+```
+| 变量 | 描述 |
+|---|---|
+| `ACCOUNT_NAME` | 您账户的本地密钥环名称。仅存在于您的机器上，不会记录在链上。 |
+| `NODE_URL` | 任意 Gonka 节点的 URL。用于账户查询、推理请求和链上操作。 |
+将 `myaccount` 替换为您喜欢的任何名称，并从下面的列表中选择一个节点 URL。
+<details>
+<summary><b>创世节点</b></summary>
+```
+http://node1.gonka.ai:8000
+http://node2.gonka.ai:8000
+http://node3.gonka.ai:8000
+http://185.216.21.98:8000
+http://36.189.234.197:18026
+http://36.189.234.237:17241
+http://47.236.26.199:8000
+http://47.236.19.22:18000
+http://gonka.spv.re:8000
+```
+</details>
+<details>
+<summary><b>如何选择一个随机活跃节点</b></summary>
+获取当前活跃参与者列表，并选择任意一个 `inference_url`：
+```bash
+curl "$NODE_URL/v1/epochs/current/participants"
+```
+使用随机节点可以改善网络去中心化和负载分配。
+</details>
+---
+## 2. 安装 `inferenced` CLI
+从[官方仓库](https://github.com/gonka-ai/gonka)下载适用于您系统的最新 `inferenced` 二进制文件。
+```bash
+chmod +x inferenced
+sudo mv inferenced /usr/local/bin/
+inferenced version
+```
+**macOS 用户：** 如果看到安全警告，请前往 **系统设置 → 隐私与安全性**，然后点击"仍要允许"。
+---
+## 3. 创建账户
+创建一个将用于签名推理请求的本地密钥对。
+```bash
+inferenced keys add "$ACCOUNT_NAME"
+```
+输出包含您的**地址**、**公钥**和**助记词短语**。
+> **重要提示：** 请安全备份助记词短语和私钥——它们是恢复账户和签名请求的唯一方式。
+保存地址以备后续步骤使用：
+```bash
+export GONKA_ADDRESS="<输出中的地址>"
+```
+在步骤 5 中，您还需要私钥来配置客户端连接器。如何存储和提供私钥（环境变量、密钥管理器、`.env` 文件等）由您决定。
+---
+## 4. 为账户充值并发布公钥
+要发送推理请求，您的账户必须有正余额，并且其公钥必须发布在链上。
+您**不需要**注册为参与者——这仅是推理托管所需要的。
+### 4.1 为账户充值
+您的账户需要正余额来支付推理费用。有关钱包、余额和转账的完整指南，请参阅[钱包与转账指南](https://gonka.ai/wallet/wallet-and-transfer-guide/)。
+您可以随时查看当前余额：
+```bash
+inferenced query bank balances "$GONKA_ADDRESS" --node "$NODE_URL/chain-rpc"
+```
+要从另一个钱包为账户充值，发送任意数量的 `ngonka`：
+```bash
+inferenced tx bank send <发送者密钥名称> "$GONKA_ADDRESS" 1000000ngonka \
+  --chain-id gonka-mainnet \
+  --node "$NODE_URL/chain-rpc"
+```
+您也可以使用 [Keplr](https://gonka.ai/wallet/wallet-and-transfer-guide/#send-coins) 或 [Leap](https://gonka.ai/wallet/wallet-and-transfer-guide/#send-coins) 钱包进行转账。
+### 4.2 在链上发布公钥
+账户充值后，发布您的公钥：
+```bash
+inferenced publish-pubkey \
+  --from "$ACCOUNT_NAME" \
+  --node "$NODE_URL/chain-rpc" \
+  --yes
+```
+这会执行一次最小化的自我转账（`1ngonka`），将您的公钥注册到区块链上。
+> 如果出现 `rpc error: code = NotFound ... account ... not found` 错误，说明您的账户尚未收到代币——请先完成步骤 4.1。
+### 4.3 验证账户
+```bash
+curl -s "$NODE_URL/v2/accounts/$GONKA_ADDRESS" | jq .
+```
+响应应包含 `pubkey`、`balance` 和 `denom`。
+---
+## 5. 发送推理请求
+Gonka 使用修改版的 OpenAI SDK，自动使用您的私钥签名每个请求。所有支持语言的完整文档和示例请参见 [gonka-openai 仓库](https://github.com/gonka-ai/gonka-openai/)。
+### 最小 Python 示例
+```bash
+pip install gonka-openai
+```
+```python
+from gonka_openai import GonkaOpenAI
+client = GonkaOpenAI(
+    gonka_private_key="<您的私钥>",  # 步骤 3 中的十六进制编码私钥
+    source_url="<NODE_URL>",          # 步骤 1 中的同一节点 URL
+)
+response = client.chat.completions.create(
+    model="Qwen/Qwen2.5-7B-Instruct",
+    messages=[{"role": "user", "content": "你好！"}],
+    max_tokens=128,
+)
+print(response.choices[0].message.content)
+```
+> 如果出现 `Insufficient balance` 错误，请为账户充值更多代币或降低 `max_tokens`。
+---
+## 密钥管理参考
+```bash
+# 列出所有账户
+inferenced keys list
+# 显示公钥
+inferenced keys show "$ACCOUNT_NAME" --pubkey
+# 从助记词恢复账户
+inferenced keys add "$ACCOUNT_NAME" --recover
+# 删除账户（谨慎使用）
+inferenced keys delete "$ACCOUNT_NAME"
+# 导出私钥（谨慎使用）
+inferenced keys export "$ACCOUNT_NAME" --unarmored-hex --unsafe
+```

--- a/docs/zh/gonka_poc.md
+++ b/docs/zh/gonka_poc.md
@@ -1,0 +1,164 @@
+# Gonka 计算证明（PoC）设计
+本文档描述了 Gonka 网络中完整的计算证明设计和工作流程。PoC 系统基于计算性能而非代币质押来确定验证者共识权重，利用了 [cosmos_changes.md](cosmos_changes.md) 中描述的 Cosmos SDK 修改。
+## 系统架构
+Gonka 网络由三种主要节点类型组成，它们协同工作以实现 PoC 共识机制：
+### 1. ML 节点
+- **用途**：执行机器学习计算，用于 PoC 生成和验证
+- **位置**：`mlnode/` 包
+- **关键组件**：
+  - 使用 transformer 模型的证明生成工作器
+  - 批量验证能力
+  - 用于外部通信的 REST API
+### 2. 去中心化 API 节点
+- **用途**：编排 PoC 操作并管理 ML 节点协调
+- **位置**：`decentralized-api/` 包
+- **关键组件**：
+  - 用于 ML 节点管理的节点代理
+  - 用于工作流协调的 PoC 编排器
+  - 用于 epoch 管理的链阶段追踪器
+### 3. 推理链节点
+- **用途**：运行修改版 Cosmos SDK 的区块链验证者
+- **位置**：`inference-chain/` 包
+- **关键组件**：
+  - PoC 批量和验证消息处理器
+  - Epoch 管理和验证者集更新
+  - 与 SetComputeValidators 函数的集成
+## PoC 工作流程概述
+PoC 系统在 epoch 内的不同阶段运行。每个 epoch 代表验证者执行计算工作以确定下一个验证周期的投票权重的时期。
+### Epoch 结构
+每个 epoch 包含由 `inference-chain/x/inference/types/epoch_context.go` 中的 EpochContext 管理的几个不同阶段：
+1. **PoC 生成阶段**：ML 节点生成计算证明批次
+2. **PoC 验证阶段**：验证者交叉验证提交的批次
+3. **PoC 验证结束阶段**：计算结果并确定新权重
+4. **验证者集更新阶段**：具有更新投票权重的新验证者被激活
+## 详细 PoC 流程
+### 阶段 1：PoC 生成启动
+当链到达 PoC 起始区块高度时（由 EpochContext 中的 `IsStartOfPocStage` 确定），发生以下情况：
+**链侧（inference-chain/x/inference/module/module.go）**：
+- `onStartOfPocStage` 在 EndBlock 处理器中被触发
+- 通过 `CreateEpochGroup` 创建新的 epoch
+- 基于配置的阈值清理旧的推理和 PoC 数据
+**API 节点侧（decentralized-api/internal/event_listener/new_block_dispatcher.go）**：
+- OnNewBlockDispatcher 检测 PoC 起始转换
+- NodePoCOrchestrator 接收 StartPoCEvent
+- 使用区块高度生成随机种子
+### 阶段 2：ML 节点 PoC 生成
+**API 节点编排（decentralized-api/broker/node_worker_commands.go）**：
+- API 节点为每个管理的 ML 节点执行 StartPoCNodeCommand
+- 命令通过代理的节点工作器系统分发
+- 每个 ML 节点接收初始化参数，包括区块哈希、公钥和回调 URL
+**ML 节点计算（mlnode/packages/pow/src/pow/compute/）**：
+- ML 节点使用分发的区块哈希作为种子初始化 transformer 模型
+- 工作器开始使用 Compute 类生成证明批次
+- 每个批次包含从模型输出计算的非ces和距离值
+- 生成的批次通过回调机制发送回 API 节点
+**批次提交（decentralized-api/internal/server/mlnode/post_generated_batches_handler.go）**：
+- API 节点从 ML 节点接收生成的批次
+- 批次被转换为 MsgSubmitPocBatch 消息
+- 消息通过 cosmos 客户端提交到区块链
+### 阶段 3：PoC 验证阶段
+当验证阶段开始时（由 `IsStartOfPoCValidationStage` 确定）：
+**验证启动（decentralized-api/internal/poc/node_orchestrator.go）**：
+- ValidateReceivedBatches 函数被触发
+- API 节点从链上查询所有提交的 PoC 批次
+- 使用确定性 nonce 选择应用验证采样
+- ML 节点通过 InitValidateNodeCommand 切换到验证模式
+**ML 节点验证（mlnode/packages/pow/src/pow/compute/compute.py）**：
+- ML 节点通过 ValidateBatch API 接收要验证的批次
+- validate 方法为给定的 nonces 重新生成证明
+- 验证结果包括欺诈检测和统计分析
+- 结果作为 MsgSubmitPocValidation 消息发送回去
+### 阶段 4：PoC 结果计算
+在验证阶段结束时（`IsEndOfPoCValidationStage`）：
+**权重计算（inference-chain/x/inference/module/chainvalidation.go）**：
+- `ComputeNewWeights` 函数处理所有提交的批次和验证结果
+- 从活跃参与者中获取当前验证者权重
+- 使用基于多数的逻辑做出 PoC 验证决策
+- 根据其他验证者的验证结果接受或拒绝参与者
+**验证决策逻辑**：
+- 每个参与者的提交由其他网络参与者验证
+- 接受需要超过一半按权重计算的参与者的有效验证
+- 如果无效验证超过一半按权重计算的参与者，则发生拒绝
+- 决策包含欺诈检测阈值和统计分析
+### 阶段 5：验证者集更新
+在 `IsSetNewValidatorsStage` 期间：
+**验证者权重更新（inference-chain/x/inference/module/module.go）**：
+- 系统使用计算结果调用 `SetComputeValidators`
+- 该函数在修改的 Cosmos SDK 质押模块中实现
+- 基于 PoC 结果激活具有投票权重的新验证者集
+**Epoch 过渡**：
+- 有效 epoch 索引更新为即将到来的 epoch
+- 对前一个 epoch 执行账户结算
+- 为新 epoch 的参与者进行模型分配
+- 为下一个验证期注册活跃参与者
+## 权重系统和使用场景
+Gonka 网络运行两种不同的权重系统，服务于不同的目的：
+### 质押模块权重（共识权重）
+此权重通过 `SetComputeValidators` 设置，用于所有 Cosmos SDK 原生共识和治理操作：
+**使用场景**：
+- **区块共识**：确定 CometBFT 中区块生产的验证者选择概率
+- **治理投票**：链上治理提案的投票权重
+- **惩罚**：影响验证者不当行为的惩罚幅度
+- **验证者集**：控制哪些验证者在共识集中处于活跃状态
+- **奖励分配**：影响区块奖励和佣金分配
+**权重来源**：从 PoC 计算结果派生，在每个 epoch 验证周期结束时更新。
+### EpochGroup 权重（内部网络权重）
+此权重记录在 EpochGroups 及其子组中，用于 epoch 期间的内部网络操作：
+**使用场景**：
+- **PoC 验证决策**：确定对其他参与者 PoC 提交的基于多数的验证中的权重
+- **推理工作分配**：控制每个参与者接收多少推理工作
+- **模型分配**：影响参与者被分配服务哪些模型
+- **网络资源分配**：影响 epoch 内计算资源的分配
+- **参与者选择**：用于确定哪些参与者进入下一个 epoch
+**权重来源**：基于历史 PoC 性能、从前一个 epoch 保留的权重以及 MLNode 计算能力。
+### 权重流动和同步
+两种权重系统在 epoch 生命周期的特定点同步：
+1. **Epoch 期间**：EpochGroup 权重管理内部操作和 PoC 验证
+2. **Epoch 结束时**：使用 EpochGroup 权重进行验证决策来计算 PoC 结果
+3. **验证者更新**：成功参与者的权重通过 `SetComputeValidators` 转移到质押模块
+4. **新 Epoch**：更新的共识权重变为活跃状态，同时建立新的 EpochGroup 权重
+这种双权重架构确保区块链共识保持稳定和安全，同时允许在计算 epoch 期间灵活的资源分配和验证。
+## 与修改版 Cosmos SDK 的集成
+### SetComputeValidators 函数
+PoC 结果和共识之间的核心集成点是修改的质押模块中的 `SetComputeValidators` 函数：
+**函数位置**：在 `inference-chain/x/inference/types/expected_keepers.go` 中引用
+**用途**：基于 PoC 计算结果而非质押代币更新验证者投票权重
+**过程**：
+1. 接收包含公钥和计算权重的 ComputeResult 对象
+2. 将新结果与现有验证者集进行协调
+3. 更新验证者权重索引以集成 CometBFT
+4. 在不进行代币移动的情况下管理验证者过渡
+### 权重计算覆盖
+**传统质押**：投票权重 = 质押代币 / PowerReduction
+**PoC 系统**：投票权重 = 计算的 PoC 分数（PowerReduction = 1）
+`cosmos_changes.md` 中的修改系统确保：
+- 基于 PoC 的验证者不进行实际的代币质押
+- `TotalBondedTokens` 通过汇总验证者权重分数来计算
+- 惩罚影响 PoC 分数而非销毁代币
+- Hook 机制安全地触发抵押模块惩罚
+## 关键实现文件
+### 链侧 PoC 管理
+- `inference-chain/x/inference/module/module.go` - 主要 epoch 和阶段管理
+- `inference-chain/x/inference/module/chainvalidation.go` - PoC 验证逻辑
+- `inference-chain/x/inference/keeper/msg_server_submit_poc_batch.go` - 批次提交处理器
+- `inference-chain/x/inference/keeper/msg_server_submit_poc_validation.go` - 验证提交处理器
+### API 节点编排
+- `decentralized-api/internal/poc/node_orchestrator.go` - PoC 工作流协调
+- `decentralized-api/broker/node_worker_commands.go` - ML 节点命令执行
+- `decentralized-api/internal/event_listener/new_block_dispatcher.go` - 链事件处理
+### ML 节点计算
+- `mlnode/packages/pow/src/pow/compute/compute.py` - 核心 PoC 计算引擎
+- `mlnode/packages/pow/src/pow/compute/worker.py` - 工作器进程管理
+- `mlnode/packages/pow/src/pow/service/manager.py` - PoC 服务管理
+## Epoch 和参与者管理
+### Epoch 生命周期
+- **创建**：在 PoC 开始时通过 `CreateEpochGroup` 创建新 epoch
+- **追踪**：分别维护当前、即将到来和之前的 epoch
+- **过渡**：epoch 准备和验证者切换之间有清晰的边界
+- **存储**：Epoch 数据使用顺序索引和 PoC 起始区块高度存储
+### 参与者选择
+- **保留**：具有推理分配的前一个 epoch 参与者被保留
+- **权重计算**：从 MLNode PoC 权重计算总权重
+- **模型分配**：参与者接收推理工作的模型分配
+- **注册**：基于 PoC 性能注册顶级矿工
+这种设计创建了一个强大的计算共识机制，其中验证者投票权重直接反映已证明的计算能力而非经济质押，同时保持底层 Cosmos SDK 共识引擎的安全性和功能性。

--- a/docs/zh/join_chain.md
+++ b/docs/zh/join_chain.md
@@ -1,0 +1,41 @@
+# 设置您的链节点
+## 前提条件
+### 依赖项
+您需要安装 Docker 来处理容器的启动。
+### 文件
+您需要两个文件来开始：
+1. launch_chain.sh - 这是将使用参数启动您的链的脚本
+2. docker-compose-local.yml - 这是一个用于在本地启动链的 docker-compose 文件，由 launch_chain.sh 调用
+### config.env
+首先，您需要创建一个包含以下环境变量的文件：
+* KEY_NAME - 密钥的名称，以及将要创建的两个节点（API 和节点）的名称。
+* NODE_CONFIG - 这是一个包含推理节点信息的文件路径（见下文）
+* ADD_ENDPOINT - 这是链中已存在端点的公共 URL，将用于将您的账户添加到链中。
+* PORT - 这是将为您的 API 端点暴露的本地端口
+* PUBLIC_IP - 这是您将用于暴露自己端点的主机地址。它最终需要映射到在此过程中创建的 API 容器。
+## NODE_CONFIG
+这是一个 JSON 文件，定义了实际为您的节点提供推理请求的推理服务器端点。格式如下：
+```
+[
+    {
+        "id": "uniqueNodeName",
+        "url": "http://35.76.234.56:8080/",
+        "max_concurrent": 10,
+        "models": [
+            "Qwen/Qwen2.5-7B-Instruct"
+        ]
+    }
+]
+```
+`max_concurrent` 指定给定端点一次可以处理多少个请求。API 将在您指定的所有端点之间平衡所有请求。
+## 启动
+创建好包含正确设置的 config.env 文件后，只需运行 `./launch_chain.sh` —— 这将：
+1. 启动您的节点，该节点将使用 Docker 镜像中指定的种子节点连接到链，然后将您添加为网络的参与者。赶上当前链高度需要一些时间。
+2. 启动您的 API，它将连接到您的节点，并成为您的主要入口点，提供推理请求并允许您管理节点。
+## 自定义部署
+您的环境可能有所不同，取决于您想在哪里部署以及如何部署。但您可以使用 `launch_chain.sh` 和 `docker-compose-local.yml` 作为自己部署的起点。
+重要要点：
+1. 使用 `docker-compose-local.yml` 中包含的 Docker 镜像——这些是将用于加入链的镜像。它们包含所有必要的创世状态和种子节点。
+2. 每个 Docker 容器都需要设置一个 "KEY_NODE" 作为密钥和 API 的主 URL。
+3. 添加推理节点通过 /v1/nodes/batch 端点完成。您可以在 `launch_chain.sh` 中看到调用。
+4. 要将您的节点添加到网络中，您仍然需要一个已加入节点的 URL。`launch_chain.sh` 展示了如何获取负载数据（通过在节点上执行命令）以及如何构建它。


### PR DESCRIPTION
## Summary

Add Chinese translations for three core documentation files to lower the barrier for Chinese-speaking developers and node operators to participate in the Gonka network.

## Changes

### New files in `docs/zh/`:

| File | Source | Description |
|---|---|---|
| `docs/zh/consumer_setup.md` | `docs/consumer_setup.md` | Consumer setup guide — account creation, funding, public key publishing, and sending inference requests |
| `docs/zh/join_chain.md` | `docs/join_chain.md` | Chain node setup guide — prerequisites, config.env, NODE_CONFIG, launching and customizing deployment |
| `docs/zh/gonka_poc.md` | `docs/gonka_poc.md` | Proof of Compute design — system architecture, 5-stage PoC workflow, dual power systems, Cosmos SDK integration |

## Translation approach

- All technical terms (PoC, epoch, MLNode, Cosmos SDK, CometBFT, etc.) are preserved in their original English form for clarity
- Code blocks, commands, and file paths are kept identical to the originals
- Table formatting and document structure mirror the English versions
- Links to external resources are preserved

## Motivation

Chinese is one of the largest developer communities globally. Providing documentation in Chinese aligns with the Gonka bounty program goal of expanding network accessibility through translations.

---

**Bounty reference:** Documentation/Translation (20–200 GNK) — https://joingonka.ai/en/knowledge/bounty/