### PR TITLE
Move devshard inference sealing into deterministic state-machine

### DIFF
--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -121,18 +121,13 @@ type Host struct {
 	completedResponses map[uint64][]byte // inference ID -> cached ML response body
 	ownSeed            int64             // deterministic seed derived from signer + escrowID
 
-	// Payload prune tracking. All fields below are host-local off-state and
-	// must NOT participate in the state root or snapshot. They drive Tier A
-	// (terminal-status) and Tier C (stale-finished) pruning emission only.
-	pruneSink             PruneEventSink
-	prunedFired           map[uint64]struct{}  // inference IDs we've already emitted a prune for
-	finishedAt            map[uint64]uint64    // inference ID -> nonce of MsgFinishInference
-	finishedAtTime        map[uint64]time.Time // inference ID -> wall clock when this host saw the finish
-	terminalAt            map[uint64]uint64    // inference ID -> nonce when status became terminal (v2)
-	terminalAtTime        map[uint64]time.Time // inference ID -> wall clock at terminal (v2)
-	sealGraceNonces       uint64               // nonce gate from SessionConfig.SealGraceNonces
-	inferenceClearGrace   time.Duration        // wall-clock gate from SessionConfig
-	maxNonce              devshard.MaxNonceProvider // nil = do not enforce
+	// Payload prune tracking. These fields are host-local off-state and must
+	// NOT participate in the state root or snapshot. The deterministic seal now
+	// lives in the state machine (autoSealLocked); the host only emits a
+	// payload-prune event for each inference that the applied diff sealed.
+	pruneSink   PruneEventSink
+	prunedFired map[uint64]struct{}       // inference IDs we've already emitted a prune for
+	maxNonce    devshard.MaxNonceProvider // nil = do not enforce
 }
 
 // SnapshotInterval controls how often hosts persist full state snapshots.
@@ -197,14 +192,6 @@ func NewHost(
 		return nil, fmt.Errorf("derive seed: %w", err)
 	}
 
-	st := sm.SnapshotState()
-	cfg := types.NormalizeSessionConfig(st.Config, len(group))
-	sealGraceNonces := uint64(cfg.SealGraceNonces)
-	clearGrace := time.Duration(cfg.InferenceClearGraceSeconds) * time.Second
-	if clearGrace <= 0 {
-		clearGrace = defaultInferenceClearGrace
-	}
-
 	h := &Host{
 		sm:                    sm,
 		signer:                signer,
@@ -222,12 +209,6 @@ func NewHost(
 		completedResponses:    make(map[uint64][]byte),
 		ownSeed:               ownSeed,
 		prunedFired:           make(map[uint64]struct{}),
-		finishedAt:          make(map[uint64]uint64),
-		finishedAtTime:      make(map[uint64]time.Time),
-		terminalAt:          make(map[uint64]uint64),
-		terminalAtTime:      make(map[uint64]time.Time),
-		sealGraceNonces:     sealGraceNonces,
-		inferenceClearGrace: clearGrace,
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -303,19 +284,6 @@ func WithGrace(grace uint64) HostOption {
 // emits nothing and behaves exactly as before.
 func WithPruneSink(s PruneEventSink) HostOption {
 	return func(h *Host) { h.pruneSink = s }
-}
-
-// WithPruneTuning overrides seal grace gating. Used by tests to drive
-// deterministic stale-payload behavior without waiting on real wall-clock time.
-func WithPruneTuning(graceNonces uint64, graceTime time.Duration) HostOption {
-	return func(h *Host) {
-		if graceNonces > 0 {
-			h.sealGraceNonces = graceNonces
-		}
-		if graceTime > 0 {
-			h.inferenceClearGrace = graceTime
-		}
-	}
 }
 
 func (h *Host) StateRoot() ([]byte, error) {
@@ -553,6 +521,13 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 	if h.store != nil {
 		warmBefore = h.sm.WarmKeys()
 	}
+	// Capture the live inference ids before applying so we can detect which
+	// ones the deterministic seal (state machine autoSeal) folds out of live
+	// state during this diff. Only needed when a prune sink is wired.
+	var liveBefore map[uint64]struct{}
+	if h.pruneSink != nil {
+		liveBefore = h.sm.LiveInferenceIDs()
+	}
 	root, err := h.sm.ApplyDiff(diff)
 	if err != nil {
 		return fmt.Errorf("apply diff nonce %d: %w", diff.Nonce, err)
@@ -569,11 +544,14 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 		}
 	}
 
-	// Emit prune events for payloads we no longer need. Tier A fires on
-	// terminal-status flips driven by txs in this diff; Tier C fires when
-	// the local nonce + wall-clock gates have both elapsed for inferences
-	// stuck in Finished. Both run under h.mu so the sink contract holds.
-	h.processPruneEventsLocked(diff)
+	// Emit one payload-prune event per inference this diff sealed. The seal is
+	// the deterministic state-machine fold; here we only react to it. Pruning
+	// is host-local off-state, carries no clock, and never mutates the root.
+	// Restricted to seals that happened in the Active phase (autoSeal); the
+	// settlement drain tears the whole session down and is handled elsewhere.
+	if h.pruneSink != nil && phaseBefore == types.PhaseActive {
+		h.emitSealPrunesLocked(liveBefore)
+	}
 
 	if h.store != nil {
 		warmAfter := h.sm.WarmKeys()
@@ -594,153 +572,40 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 	return nil
 }
 
-// processPruneEventsLocked walks the diff's txs to track Finish observations
-// (Tier C ledger) and to fire Tier A prune events for inferences that just
-// terminalized. After the per-tx pass it scans the Tier C ledger for entries
-// whose nonce + wall-clock grace have elapsed and fires those too.
-// Caller must hold h.mu. No-op when no sink is configured.
-func (h *Host) processPruneEventsLocked(diff types.Diff) {
-	if h.pruneSink == nil {
+// emitSealPrunesLocked dispatches one payload-prune event per inference that
+// the just-applied diff sealed: an id that was live before the apply and is no
+// longer live afterwards (the state machine's deterministic autoSeal folded it
+// into SealedAcc). Pruning is host-local off-state -- it carries no clock and
+// never mutates the root, so it cannot diverge state. The PayloadEpoch carries
+// h.epochID (the only epoch the executor stored under for this session, set via
+// WithEpochID). Dedupe via prunedFired tolerates the same id appearing twice.
+// Caller must hold h.mu and must have verified h.pruneSink is non-nil.
+func (h *Host) emitSealPrunesLocked(liveBefore map[uint64]struct{}) {
+	if len(liveBefore) == 0 {
 		return
 	}
-	now := time.Now()
-	currentNonce := diff.Nonce
-
-	for _, tx := range diff.Txs {
-		switch {
-		case tx.GetFinishInference() != nil:
-			id := tx.GetFinishInference().InferenceId
-			if _, fired := h.prunedFired[id]; fired {
-				continue
-			}
-			// Only record if the apply actually transitioned to Finished:
-			// applyFinishInference can fail (e.g. wrong executor slot) without
-			// flipping status, in which case applyCore rolls back, so the
-			// status check protects us against that race.
-			rec, ok := h.sm.GetInference(id)
-			if !ok || rec.Status != types.StatusFinished {
-				continue
-			}
-			h.finishedAt[id] = currentNonce
-			h.finishedAtTime[id] = now
-		case tx.GetTimeoutInference() != nil:
-			id := tx.GetTimeoutInference().InferenceId
-			h.maybeEmitTerminalLocked(id, currentNonce, now)
-		case tx.GetValidation() != nil:
-			id := tx.GetValidation().InferenceId
-			h.maybeEmitTerminalLocked(id, currentNonce, now)
-		case tx.GetValidationVote() != nil:
-			id := tx.GetValidationVote().InferenceId
-			h.maybeEmitTerminalLocked(id, currentNonce, now)
-		}
-	}
-
-	h.emitTerminalTierLocked(currentNonce, now)
-	h.emitTierCLocked(currentNonce, now)
-}
-
-// maybeEmitTerminalLocked records or emits a terminal prune for an inference
-// whose post-apply status is terminal. Under v2 composition the event is
-// deferred until sealGraceNonces and inferenceClearGrace have both elapsed.
-// Caller must hold h.mu and must have already verified h.pruneSink is non-nil.
-func (h *Host) maybeEmitTerminalLocked(inferenceID uint64, currentNonce uint64, now time.Time) {
-	if _, fired := h.prunedFired[inferenceID]; fired {
-		return
-	}
-	rec, ok := h.sm.GetInference(inferenceID)
-	if !ok || !isTerminalStatus(rec.Status) {
-		return
-	}
-	if h.sm.EffectiveV2Composition() {
-		if _, tracked := h.terminalAt[inferenceID]; !tracked {
-			h.terminalAt[inferenceID] = currentNonce
-			h.terminalAtTime[inferenceID] = now
-			delete(h.finishedAt, inferenceID)
-			delete(h.finishedAtTime, inferenceID)
-		}
-		return
-	}
-	h.emitPruneLocked(inferenceID, PruneReasonTerminal)
-}
-
-// emitTerminalTierLocked fires deferred terminal prunes under v2 composition
-// once both the nonce and wall-clock gates have cleared.
-func (h *Host) emitTerminalTierLocked(currentNonce uint64, now time.Time) {
-	if !h.sm.EffectiveV2Composition() || len(h.terminalAt) == 0 {
-		return
-	}
-	for id, termNonce := range h.terminalAt {
-		if currentNonce < termNonce+h.sealGraceNonces {
+	for id := range liveBefore {
+		if _, stillLive := h.sm.GetInference(id); stillLive {
 			continue
 		}
-		ts, hasTs := h.terminalAtTime[id]
-		if !hasTs || now.Before(ts.Add(h.inferenceClearGrace)) {
+		if _, fired := h.prunedFired[id]; fired {
 			continue
 		}
-		rec, ok := h.sm.GetInference(id)
-		if !ok || !isTerminalStatus(rec.Status) {
-			delete(h.terminalAt, id)
-			delete(h.terminalAtTime, id)
-			continue
+		// Label terminal vs stale-finished from the sealed snapshot (metrics
+		// only). Fall back to terminal if the obs lookup is unavailable.
+		reason := PruneReasonTerminal
+		if rec, ok := h.sm.LookupSealedInference(id); ok && !isTerminalStatus(rec.Status) {
+			reason = PruneReasonStaleFinished
 		}
-		h.emitPruneLocked(id, PruneReasonTerminal)
+		h.prunedFired[id] = struct{}{}
+		h.pruneSink.OnInferencePrunable(InferencePruneEvent{
+			EscrowID:          h.escrowID,
+			InferenceID:       id,
+			Reason:            reason,
+			PayloadEpoch:      h.epochID,
+			PayloadEpochKnown: h.epochID != 0,
+		})
 	}
-}
-
-// emitTierCLocked walks the Tier C ledger and emits prune events for entries
-// where both gates have cleared. Inferences that are no longer in
-// StatusFinished (e.g. moved to Challenged/Validated/Invalidated under a
-// different path) drop out of the ledger silently. Caller must hold h.mu.
-func (h *Host) emitTierCLocked(currentNonce uint64, now time.Time) {
-	if len(h.finishedAt) == 0 {
-		return
-	}
-	for id, finNonce := range h.finishedAt {
-		if currentNonce < finNonce+h.sealGraceNonces {
-			continue
-		}
-		ts, hasTs := h.finishedAtTime[id]
-		if !hasTs || now.Before(ts.Add(h.inferenceClearGrace)) {
-			continue
-		}
-		rec, ok := h.sm.GetInference(id)
-		if !ok || rec.Status != types.StatusFinished {
-			delete(h.finishedAt, id)
-			delete(h.finishedAtTime, id)
-			continue
-		}
-		h.emitPruneLocked(id, PruneReasonStaleFinished)
-	}
-}
-
-// emitPruneLocked dispatches one InferencePruneEvent and updates the dedupe
-// ledger. The PayloadEpoch carries h.epochID, which is the only epoch the
-// executor stored under for this session (set via WithEpochID); when the
-// host was constructed without an epoch the manager falls back to a global
-// supplier.
-func (h *Host) emitPruneLocked(inferenceID uint64, reason PruneReason) {
-	if err := h.sm.SealInference(inferenceID); err != nil {
-		logging.Warn("failed to seal inference before prune",
-			"subsystem", "host",
-			"escrow_id", h.escrowID,
-			"inference_id", inferenceID,
-			"reason", reason.String(),
-			"error", err,
-		)
-		return
-	}
-	h.prunedFired[inferenceID] = struct{}{}
-	delete(h.finishedAt, inferenceID)
-	delete(h.finishedAtTime, inferenceID)
-	delete(h.terminalAt, inferenceID)
-	delete(h.terminalAtTime, inferenceID)
-	h.pruneSink.OnInferencePrunable(InferencePruneEvent{
-		EscrowID:          h.escrowID,
-		InferenceID:       inferenceID,
-		Reason:            reason,
-		PayloadEpoch:      h.epochID,
-		PayloadEpochKnown: h.epochID != 0,
-	})
 }
 
 // maybeSaveSnapshotLocked copies the current state when shouldSnapshot is true.

--- a/devshard/host/prune.go
+++ b/devshard/host/prune.go
@@ -14,8 +14,8 @@ const (
 	// StatusTimedOut). No further protocol step needs the payload.
 	PruneReasonTerminal PruneReason = iota
 	// PruneReasonStaleFinished is fired for inferences that linger in
-	// StatusFinished after the local validation window expired (nonce gate
-	// plus wall-clock gate). A late validator that arrives after this prune
+	// StatusFinished after both seal gates clear (nonce gate plus state-clock
+	// grace). A late validator that arrives after this prune
 	// will get a 404 and is expected to skip silently via ErrValidationSkipped.
 	PruneReasonStaleFinished
 )

--- a/devshard/host/prune.go
+++ b/devshard/host/prune.go
@@ -1,8 +1,6 @@
 package host
 
 import (
-	"time"
-
 	"devshard/types"
 )
 
@@ -66,11 +64,6 @@ func (f PruneEventSinkFunc) OnInferencePrunable(event InferencePruneEvent) {
 		f(event)
 	}
 }
-
-// defaultInferenceClearGrace is the host fallback when SessionConfig leaves
-// InferenceClearGraceSeconds unset and NormalizeSessionConfig did not run.
-// Normal paths always normalize (production default 3600s); this is a safety net.
-const defaultInferenceClearGrace = 60 * time.Minute
 
 // isTerminalStatus returns true for inference statuses that no longer require
 // payload retention (validated, invalidated, or timed out).

--- a/devshard/host/prune_test.go
+++ b/devshard/host/prune_test.go
@@ -280,8 +280,8 @@ func (r *pruneTestRig) sealedRow(inferenceID uint64) storage.InferenceRow {
 }
 
 // driveToValidated brings inference 1 (executor slot 1) to StatusValidated with
-// 3 valid votes (threshold=2). It does NOT advance the state clock, so the
-// inference stays live until a later confirm bumps the clock. Returns next nonce.
+// 3 valid votes (threshold=2). Terminal statuses seal on the validating diff
+// once the nonce gate clears (no state-clock grace). Returns next nonce.
 func (r *pruneTestRig) driveToValidated(startNonce uint64) uint64 {
 	r.t.Helper()
 	nonce := r.driveStartConfirmFinish(1, startNonce)
@@ -292,27 +292,18 @@ func (r *pruneTestRig) driveToValidated(startNonce uint64) uint64 {
 	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 3, true)})
 	nonce++
 	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 4, true)})
-	nonce++
-	require.Equal(r.t, types.StatusValidated, r.inferenceStatus(1))
-	return nonce
+	return nonce + 1
 }
 
-// The seal is now a deterministic function of state: an inference is folded
-// into SealedAcc (and its payload pruned) once nonce >= id+SealGraceNonces AND
-// the state clock (max ConfirmedAt over recent live inferences) has advanced
-// >= InferenceClearGraceSeconds past the inference's own ConfirmedAt. Tests
-// advance the clock by confirming a newer inference (bumpClock), never by
-// sleeping on the wall clock.
+// The seal is a deterministic function of state. Terminal statuses
+// (Validated/Invalidated/TimedOut) seal once nonce >= id+SealGraceNonces on
+// the diff that made them terminal. Finished (stale-finished) also requires the
+// state clock to advance >= InferenceClearGraceSeconds past ConfirmedAt;
+// those tests use bumpClock to advance the clock without wall-clock sleeps.
 
 func TestHost_PruneSink_SealsTerminal_Validated(t *testing.T) {
 	rig := newPruneRig(t, 0, 5)
-	nonce := rig.driveToValidated(1) // inference 1 Validated, ConfirmedAt=2001.
-
-	// No prune yet: the state clock has not advanced past ConfirmedAt+grace.
-	require.Empty(t, rig.sink.findFor(1), "terminal inference must wait for the clock gate")
-
-	// Confirm a newer inference far enough ahead to clear the clock gate.
-	rig.bumpClock(nonce, pruneTestBaseConfirmedAt+1+pruneTestClearGraceSeconds+5)
+	_ = rig.driveToValidated(1) // inference 1 Validated; seals on last vote diff.
 
 	events := rig.sink.findFor(1)
 	require.Len(t, events, 1)
@@ -332,11 +323,6 @@ func TestHost_PruneSink_SealsTerminal_Invalidated(t *testing.T) {
 	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, false)})
 	nonce++
 	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, false)})
-	nonce++
-	require.Equal(t, types.StatusInvalidated, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1))
-
-	rig.bumpClock(nonce, pruneTestBaseConfirmedAt+1+pruneTestClearGraceSeconds+5)
 
 	events := rig.sink.findFor(1)
 	require.Len(t, events, 1)
@@ -354,11 +340,10 @@ func TestHost_PruneSink_SealsTerminal_TimedOut(t *testing.T) {
 	timeoutTx := rig.signTimeoutInference(1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, []uint32{0, 2, 3})
 	rig.applyDiff(2, []*types.DevshardTx{timeoutTx})
 	require.Equal(t, types.StatusTimedOut, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "no clock yet -> cannot seal")
+	require.Empty(t, rig.sink.findFor(1), "nonce gate not yet cleared at timeout diff")
 
-	// Any confirmed inference makes stateClock >> grace; ConfirmedAt=0 then seals
-	// as soon as the nonce gate (id 1 + 2 = 3) is also cleared.
-	rig.bumpClock(3, pruneTestBaseConfirmedAt)
+	// Terminal short path: no clock grace; advance nonce to clear id+SealGraceNonces.
+	rig.applyDiff(3, nil)
 
 	events := rig.sink.findFor(1)
 	require.Len(t, events, 1)

--- a/devshard/host/prune_test.go
+++ b/devshard/host/prune_test.go
@@ -17,6 +17,17 @@ import (
 	"devshard/types"
 )
 
+const (
+	// pruneTestSealGraceNonces is the nonce gate used by prune tests: an
+	// inference id may be sealed only once nonce >= id + this.
+	pruneTestSealGraceNonces = 2
+	// pruneTestClearGraceSeconds is the clock gate: an inference may be sealed
+	// only once stateClock - ConfirmedAt >= this many "seconds".
+	pruneTestClearGraceSeconds = 5
+	// pruneTestBaseConfirmedAt anchors the ConfirmedAt values the helpers use.
+	pruneTestBaseConfirmedAt = 2000
+)
+
 // recordingPruneSink captures all InferencePruneEvent emissions for assertions.
 type recordingPruneSink struct {
 	mu     sync.Mutex
@@ -65,6 +76,13 @@ type pruneTestRig struct {
 // which group member runs locally; pickng a non-executor avoids interference
 // from the executor receipt path.
 func newPruneRig(t *testing.T, observerIdx, numHosts int, opts ...HostOption) *pruneTestRig {
+	return newPruneRigGrace(t, observerIdx, numHosts, pruneTestSealGraceNonces, pruneTestClearGraceSeconds, opts...)
+}
+
+// newPruneRigGrace is newPruneRig with explicit seal-grace gates, replacing the
+// old host-local WithPruneTuning: the gates now live in SessionConfig and drive
+// the deterministic state-machine seal.
+func newPruneRigGrace(t *testing.T, observerIdx, numHosts int, sealGraceNonces, clearGraceSeconds uint32, opts ...HostOption) *pruneTestRig {
 	t.Helper()
 	hosts := make([]*signing.Secp256k1Signer, numHosts)
 	for i := range hosts {
@@ -72,13 +90,18 @@ func newPruneRig(t *testing.T, observerIdx, numHosts int, opts ...HostOption) *p
 	}
 	user := testutil.MustGenerateKey(t)
 	group := testutil.MakeGroup(hosts)
+	// Small, explicit seal gates so tests can deterministically drive the
+	// state-clock seal: nonce gate = id+2, clock gate = +5 "seconds" of
+	// ConfirmedAt progress. ConfirmedAt values in the helpers below advance in
+	// steps larger than 5 so a single newer confirmed inference clears the gate.
 	config := types.SessionConfig{
 		RefusalTimeout:             60,
 		ExecutionTimeout:           1200,
 		TokenPrice:                 1,
 		VoteThreshold:              uint32(numHosts) / 2,
 		ValidationRate:             0,
-		InferenceClearGraceSeconds: testutil.TestInferenceClearGraceSeconds,
+		SealGraceNonces:            sealGraceNonces,
+		InferenceClearGraceSeconds: clearGraceSeconds,
 		// ValidationRate=0 + no WithValidator means no async validation
 		// will sneak in and emit unrelated mempool entries.
 	}
@@ -104,8 +127,6 @@ func newPruneRig(t *testing.T, observerIdx, numHosts int, opts ...HostOption) *p
 		WithPruneSink(sink),
 		WithEpochID(epochID),
 		WithGrace(0),
-		// v2 defers terminal prune until grace gates clear; tests override as needed.
-		WithPruneTuning(1, 10*time.Millisecond),
 	}
 	allOpts = append(allOpts, opts...)
 	h, err := NewHost(sm, hosts[observerIdx], stubEngine, "escrow-1", group, nil, allOpts...)
@@ -133,24 +154,21 @@ func (r *pruneTestRig) applyDiff(nonce uint64, txs []*types.DevshardTx) {
 	require.NoError(r.t, err)
 }
 
-// driveStartConfirmFinish brings inferenceID through Pending -> Started -> Finished.
-// startNonce is consumed for MsgStartInference; the next two diffs use startNonce+1
-// and startNonce+2.
+// driveStartConfirmFinish brings inferenceID through Pending -> Started ->
+// Finished using a default ConfirmedAt of base+inferenceID. startNonce is
+// consumed for MsgStartInference; the next two diffs use startNonce+1/+2.
 func (r *pruneTestRig) driveStartConfirmFinish(inferenceID, startNonce uint64) uint64 {
+	return r.driveStartConfirmFinishAt(inferenceID, startNonce, pruneTestBaseConfirmedAt+int64(inferenceID))
+}
+
+// driveStartConfirmFinishAt is driveStartConfirmFinish with an explicit
+// executor-signed ConfirmedAt, which is what advances the deterministic state
+// clock for seal gating.
+func (r *pruneTestRig) driveStartConfirmFinishAt(inferenceID, startNonce uint64, confirmedAt int64) uint64 {
 	r.t.Helper()
+	r.startConfirm(inferenceID, startNonce, confirmedAt)
+
 	executorSlot := uint32(inferenceID % uint64(len(r.group)))
-	executorSigner := r.hosts[executorSlot]
-	confirmedAt := int64(2000) + int64(inferenceID)
-
-	r.applyDiff(startNonce, []*types.DevshardTx{testutil.StartTx(inferenceID)})
-
-	execSig := testutil.SignExecutorReceipt(r.t, executorSigner, r.escrowID, inferenceID,
-		testutil.TestPromptHash[:], "llama", 100, 50, 1000, confirmedAt)
-	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: confirmedAt,
-	}}}
-	r.applyDiff(startNonce+1, []*types.DevshardTx{confirmTx})
-
 	finishMsg := &types.MsgFinishInference{
 		InferenceId:  inferenceID,
 		ResponseHash: r.stub.ResponseHash,
@@ -159,11 +177,37 @@ func (r *pruneTestRig) driveStartConfirmFinish(inferenceID, startNonce uint64) u
 		ExecutorSlot: executorSlot,
 		EscrowId:     r.escrowID,
 	}
-	finishMsg.ProposerSig = testutil.SignProposerTx(r.t, executorSigner, finishMsg)
+	finishMsg.ProposerSig = testutil.SignProposerTx(r.t, r.hosts[executorSlot], finishMsg)
 	finishTx := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: finishMsg}}
 	r.applyDiff(startNonce+2, []*types.DevshardTx{finishTx})
 
 	return startNonce + 3
+}
+
+// startConfirm brings inferenceID through Pending -> Started with the given
+// executor-signed ConfirmedAt, leaving it live (Started). Consumes startNonce
+// (start) and startNonce+1 (confirm).
+func (r *pruneTestRig) startConfirm(inferenceID, startNonce uint64, confirmedAt int64) {
+	r.t.Helper()
+	executorSlot := uint32(inferenceID % uint64(len(r.group)))
+	r.applyDiff(startNonce, []*types.DevshardTx{testutil.StartTx(inferenceID)})
+	execSig := testutil.SignExecutorReceipt(r.t, r.hosts[executorSlot], r.escrowID, inferenceID,
+		testutil.TestPromptHash[:], "llama", 100, 50, 1000, confirmedAt)
+	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: confirmedAt,
+	}}}
+	r.applyDiff(startNonce+1, []*types.DevshardTx{confirmTx})
+}
+
+// bumpClock starts and confirms a fresh inference (id == startNonce) with a high
+// ConfirmedAt, advancing the deterministic state clock to confirmedAt. The new
+// inference is left in StatusStarted (not seal-eligible), so it only serves to
+// move the clock forward. The confirm diff (startNonce+1) is the nonce at which
+// any now-eligible older inference will be auto-sealed. Returns the next nonce.
+func (r *pruneTestRig) bumpClock(startNonce uint64, confirmedAt int64) uint64 {
+	r.t.Helper()
+	r.startConfirm(startNonce, startNonce, confirmedAt)
+	return startNonce + 2
 }
 
 // signValidation builds a MsgValidation tx signed by validatorSlot's owner.
@@ -235,55 +279,44 @@ func (r *pruneTestRig) sealedRow(inferenceID uint64) storage.InferenceRow {
 	return row
 }
 
-// awaitTerminalPrune advances nonces until the v2 terminal grace gates clear
-// and asserts exactly one PruneReasonTerminal event was emitted.
-func (r *pruneTestRig) awaitTerminalPrune(inferenceID uint64, nonce uint64) []InferencePruneEvent {
+// driveToValidated brings inference 1 (executor slot 1) to StatusValidated with
+// 3 valid votes (threshold=2). It does NOT advance the state clock, so the
+// inference stays live until a later confirm bumps the clock. Returns next nonce.
+func (r *pruneTestRig) driveToValidated(startNonce uint64) uint64 {
 	r.t.Helper()
-	time.Sleep(20 * time.Millisecond)
-	limit := int(r.host.sealGraceNonces) + 3
-	if limit < 3 {
-		limit = 3
-	}
-	for i := 0; i < limit; i++ {
-		if events := r.sink.findFor(inferenceID); len(events) == 1 {
-			require.Equal(r.t, PruneReasonTerminal, events[0].Reason)
-			return events
-		}
-		r.applyDiff(nonce, nil)
-		nonce++
-	}
-	r.t.Fatalf("expected exactly one terminal prune for inference %d, got %d events",
-		inferenceID, len(r.sink.findFor(inferenceID)))
-	return nil
+	nonce := r.driveStartConfirmFinish(1, startNonce)
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidation(1, 2, false)})
+	nonce++
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 0, true)})
+	nonce++
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 3, true)})
+	nonce++
+	r.applyDiff(nonce, []*types.DevshardTx{r.signValidationVote(1, 4, true)})
+	nonce++
+	require.Equal(r.t, types.StatusValidated, r.inferenceStatus(1))
+	return nonce
 }
 
-func TestHost_PruneSink_Terminal_OnValidated(t *testing.T) {
+// The seal is now a deterministic function of state: an inference is folded
+// into SealedAcc (and its payload pruned) once nonce >= id+SealGraceNonces AND
+// the state clock (max ConfirmedAt over recent live inferences) has advanced
+// >= InferenceClearGraceSeconds past the inference's own ConfirmedAt. Tests
+// advance the clock by confirming a newer inference (bumpClock), never by
+// sleeping on the wall clock.
+
+func TestHost_PruneSink_SealsTerminal_Validated(t *testing.T) {
 	rig := newPruneRig(t, 0, 5)
+	nonce := rig.driveToValidated(1) // inference 1 Validated, ConfirmedAt=2001.
 
-	// Inference 1: executor=slot 1; validators slot 0,2,3,4. Threshold=2.
-	nonce := rig.driveStartConfirmFinish(1, 1)
+	// No prune yet: the state clock has not advanced past ConfirmedAt+grace.
+	require.Empty(t, rig.sink.findFor(1), "terminal inference must wait for the clock gate")
 
-	// Validation flips Finished -> Challenged with one invalid vote.
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidation(1, 2, false)})
-	nonce++
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "no Tier A while still Challenged")
+	// Confirm a newer inference far enough ahead to clear the clock gate.
+	rig.bumpClock(nonce, pruneTestBaseConfirmedAt+1+pruneTestClearGraceSeconds+5)
 
-	// Two valid votes are not enough (threshold=2, need >2).
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, true)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, true)})
-	nonce++
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1))
-
-	// Third valid vote pushes VotesValid=3 > threshold=2 -> StatusValidated.
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 4, true)})
-	nonce++
-	require.Equal(t, types.StatusValidated, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "v2 defers terminal prune until gates clear")
-
-	events := rig.awaitTerminalPrune(1, nonce)
+	events := rig.sink.findFor(1)
+	require.Len(t, events, 1)
+	require.Equal(t, PruneReasonTerminal, events[0].Reason)
 	require.Equal(t, rig.escrowID, events[0].EscrowID)
 	require.Equal(t, rig.epochID, events[0].PayloadEpoch)
 	require.True(t, events[0].PayloadEpochKnown)
@@ -291,67 +324,60 @@ func TestHost_PruneSink_Terminal_OnValidated(t *testing.T) {
 	require.NotZero(t, rig.sealedRow(1).SealedNonce)
 }
 
-func TestHost_PruneSink_Terminal_OnInvalidated(t *testing.T) {
+func TestHost_PruneSink_SealsTerminal_Invalidated(t *testing.T) {
 	rig := newPruneRig(t, 0, 5)
-
 	nonce := rig.driveStartConfirmFinish(1, 1)
-
-	// Validation injects 1 invalid vote -> Challenged.
 	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidation(1, 2, false)})
 	nonce++
 	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, false)})
 	nonce++
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1))
-
-	// Third invalid vote: VotesInvalid=3 > threshold=2 -> StatusInvalidated.
 	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, false)})
 	nonce++
 	require.Equal(t, types.StatusInvalidated, rig.inferenceStatus(1))
-	events := rig.awaitTerminalPrune(1, nonce)
-	require.NotZero(t, rig.sealedRow(1).SealedNonce)
-	_ = events
+	require.Empty(t, rig.sink.findFor(1))
+
+	rig.bumpClock(nonce, pruneTestBaseConfirmedAt+1+pruneTestClearGraceSeconds+5)
+
+	events := rig.sink.findFor(1)
+	require.Len(t, events, 1)
+	require.Equal(t, PruneReasonTerminal, events[0].Reason)
 	rig.inferenceMissing(1)
+	require.NotZero(t, rig.sealedRow(1).SealedNonce)
 }
 
-func TestHost_PruneSink_Terminal_OnTimedOut(t *testing.T) {
+func TestHost_PruneSink_SealsTerminal_TimedOut(t *testing.T) {
 	rig := newPruneRig(t, 0, 5)
 
-	// Start inference 1, then timeout from Pending (no ConfirmStart).
+	// Start inference 1, then timeout from Pending (no ConfirmStart -> ConfirmedAt=0).
 	rig.applyDiff(1, []*types.DevshardTx{testutil.StartTx(1)})
 	require.Equal(t, types.StatusPending, rig.inferenceStatus(1))
-
-	// Threshold=2 -> need >2 accept votes; collect 3 from non-executor slots.
 	timeoutTx := rig.signTimeoutInference(1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, []uint32{0, 2, 3})
 	rig.applyDiff(2, []*types.DevshardTx{timeoutTx})
 	require.Equal(t, types.StatusTimedOut, rig.inferenceStatus(1))
-	events := rig.awaitTerminalPrune(1, 3)
-	require.NotZero(t, rig.sealedRow(1).SealedNonce)
-	_ = events
+	require.Empty(t, rig.sink.findFor(1), "no clock yet -> cannot seal")
+
+	// Any confirmed inference makes stateClock >> grace; ConfirmedAt=0 then seals
+	// as soon as the nonce gate (id 1 + 2 = 3) is also cleared.
+	rig.bumpClock(3, pruneTestBaseConfirmedAt)
+
+	events := rig.sink.findFor(1)
+	require.Len(t, events, 1)
+	require.Equal(t, PruneReasonTerminal, events[0].Reason)
 	rig.inferenceMissing(1)
+	require.NotZero(t, rig.sealedRow(1).SealedNonce)
 }
 
-func TestHost_PruneSink_StaleFinished_TierC(t *testing.T) {
-	rig := newPruneRig(t, 0, 5,
-		WithPruneTuning(2, 10*time.Millisecond),
-	)
+func TestHost_PruneSink_SealsStaleFinished(t *testing.T) {
+	rig := newPruneRig(t, 0, 5)
 
-	// Finish inference 1 at nonce 3 (Start=1, Confirm=2, Finish=3).
+	// Finish inference 1 (ConfirmedAt=2001). Finishing alone never prunes.
 	nonce := rig.driveStartConfirmFinish(1, 1)
 	require.Equal(t, types.StatusFinished, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "Finish itself does not emit Tier A")
+	require.Empty(t, rig.sink.findFor(1), "Finish itself does not prune")
 
-	// Wall-clock gate: wait past the configured grace.
-	time.Sleep(20 * time.Millisecond)
+	// Advance the clock just past ConfirmedAt + grace; nonce gate (1+2=3) is met.
+	nonce = rig.bumpClock(nonce, pruneTestBaseConfirmedAt+1+pruneTestClearGraceSeconds)
 
-	// Nonce gate not yet met: nonce=4 < finishNonce(3)+grace(2)=5.
-	rig.applyDiff(nonce, nil)
-	nonce++
-	require.Empty(t, rig.sink.findFor(1), "nonce gate should still hold")
-
-	// Crossing the gate (nonce=5 >= 5) should fire exactly one Tier C.
-	rig.applyDiff(nonce, nil)
-	nonce++
 	events := rig.sink.findFor(1)
 	require.Len(t, events, 1)
 	require.Equal(t, PruneReasonStaleFinished, events[0].Reason)
@@ -359,133 +385,35 @@ func TestHost_PruneSink_StaleFinished_TierC(t *testing.T) {
 	rig.inferenceMissing(1)
 	require.NotZero(t, rig.sealedRow(1).SealedNonce)
 
-	// Subsequent diffs must not re-emit for the same inference.
+	// Later diffs must not re-emit for the same inference.
 	rig.applyDiff(nonce, nil)
-	require.Len(t, rig.sink.findFor(1), 1, "Tier C must dedupe across later diffs")
+	require.Len(t, rig.sink.findFor(1), 1, "prune must dedupe across later diffs")
 }
 
-func TestHost_PruneSink_TierC_DoesNotFireWhenNonceGateUnmet(t *testing.T) {
-	rig := newPruneRig(t, 0, 5,
-		WithPruneTuning(50, 1*time.Microsecond),
-	)
+func TestHost_PruneSink_DoesNotSealWhenNonceGateUnmet(t *testing.T) {
+	// Large nonce gate, tiny clock gate: the clock advances freely but the nonce
+	// floor (id + 50) is never reached, so the inference must not seal.
+	rig := newPruneRigGrace(t, 0, 5, 50, 1)
 	nonce := rig.driveStartConfirmFinish(1, 1)
-	time.Sleep(2 * time.Millisecond) // wall-clock gate easily satisfied.
+	// Advance the clock well past the grace several times.
 	for i := 0; i < 5; i++ {
-		rig.applyDiff(nonce, nil)
-		nonce++
+		nonce = rig.bumpClock(nonce, pruneTestBaseConfirmedAt+100+int64(i)*10)
 	}
 	require.Empty(t, rig.sink.findFor(1), "nonce gate not yet crossed")
+	require.Equal(t, types.StatusFinished, rig.inferenceStatus(1))
 }
 
-func TestHost_PruneSink_TierC_DoesNotFireWhenWallClockGateUnmet(t *testing.T) {
-	rig := newPruneRig(t, 0, 5,
-		WithPruneTuning(2, time.Hour),
-	)
+func TestHost_PruneSink_DoesNotSealWhenClockGateUnmet(t *testing.T) {
+	// Tiny nonce gate, large clock gate: nonces advance but ConfirmedAt never
+	// moves far enough ahead, so the clock gate keeps the inference live.
+	rig := newPruneRigGrace(t, 0, 5, 2, 100_000)
 	nonce := rig.driveStartConfirmFinish(1, 1)
 	for i := 0; i < 4; i++ {
-		rig.applyDiff(nonce, nil)
-		nonce++
+		// Bump the clock by only +1 each time: well under the 100000 grace.
+		nonce = rig.bumpClock(nonce, pruneTestBaseConfirmedAt+1+int64(i)+1)
 	}
-	require.Empty(t, rig.sink.findFor(1), "wall-clock gate prevents Tier C")
-}
-
-func TestHost_PruneSink_V2_TerminalDelayed(t *testing.T) {
-	hosts := make([]*signing.Secp256k1Signer, 5)
-	for i := range hosts {
-		hosts[i] = testutil.MustGenerateKey(t)
-	}
-	user := testutil.MustGenerateKey(t)
-	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:             60,
-		ExecutionTimeout:           1200,
-		TokenPrice:                 1,
-		VoteThreshold:              2,
-		ValidationRate:             0,
-		InferenceClearGraceSeconds: testutil.TestInferenceClearGraceSeconds,
-	}
-	verifier := signing.NewSecp256k1Verifier()
-	store := storage.NewMemory()
-	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
-		EscrowID: "escrow-1", EpochID: 7, Version: testutil.RuntimeTestVersion,
-		CreatorAddr: user.Address(), Config: config, Group: group, InitialBalance: 1_000_000,
-	}))
-	sm, err := state.NewStateMachine("escrow-1", config, group, 1_000_000, user.Address(), verifier, store,
-	)
-	require.NoError(t, err)
-
-	sink := &recordingPruneSink{}
-	rig := &pruneTestRig{
-		t: t, hosts: hosts, user: user, group: group, config: config,
-		host: nil, sink: sink, stub: stub.NewInferenceEngine(),
-		store: store, escrowID: "escrow-1", epochID: 7,
-	}
-	h, err := NewHost(sm, hosts[0], rig.stub, "escrow-1", group, nil,
-		WithPruneSink(sink), WithEpochID(7), WithGrace(0),
-		WithPruneTuning(2, 10*time.Millisecond),
-	)
-	require.NoError(t, err)
-	rig.host = h
-
-	nonce := rig.driveStartConfirmFinish(1, 1)
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidation(1, 2, false)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, true)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, true)})
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "v2 defers terminal prune until gates clear")
-
-	time.Sleep(20 * time.Millisecond)
-	rig.applyDiff(nonce, nil)
-	nonce++
-	require.Empty(t, rig.sink.findFor(1), "nonce gate should still hold")
-
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 4, true)})
-	nonce++
-	require.Equal(t, types.StatusValidated, rig.inferenceStatus(1))
-	require.Empty(t, rig.sink.findFor(1), "terminal recorded but gates not yet cleared")
-
-	time.Sleep(20 * time.Millisecond)
-	rig.applyDiff(nonce, nil)
-	nonce++
-	require.Empty(t, rig.sink.findFor(1), "nonce gate should still hold after terminal")
-
-	rig.applyDiff(nonce, nil)
-	events := rig.sink.findFor(1)
-	require.Len(t, events, 1)
-	require.Equal(t, PruneReasonTerminal, events[0].Reason)
-	rig.inferenceMissing(1)
-	require.NotZero(t, rig.sealedRow(1).SealedNonce)
-	sealed, ok := rig.host.sm.ExportSealedNonces()[1]
-	require.True(t, ok, "v2 seal should record sealed nonce")
-	require.NotZero(t, sealed)
-}
-
-func TestHost_PruneSink_TerminalFlipPreemptsTierC(t *testing.T) {
-	// If an inference terminalizes before the Tier C gates expire, only one
-	// terminal prune should fire (after v2 grace) and the Tier C ledger cleared.
-	// Default tuning (1 nonce, 10ms wall) is enough: status leaves Finished before Tier C fires.
-	rig := newPruneRig(t, 0, 5)
-	nonce := rig.driveStartConfirmFinish(1, 1)
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidation(1, 2, false)})
-	nonce++
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 0, false)})
-	nonce++
-	require.Equal(t, types.StatusChallenged, rig.inferenceStatus(1))
-	rig.applyDiff(nonce, []*types.DevshardTx{rig.signValidationVote(1, 3, false)})
-	nonce++
-	require.Equal(t, types.StatusInvalidated, rig.inferenceStatus(1))
-
-	events := rig.awaitTerminalPrune(1, nonce)
-	require.Equal(t, PruneReasonTerminal, events[0].Reason)
-
-	rig.host.mu.Lock()
-	_, stillFinished := rig.host.finishedAt[1]
-	_, stillTerminal := rig.host.terminalAt[1]
-	rig.host.mu.Unlock()
-	require.False(t, stillFinished, "Tier C ledger must drop terminalized inference")
-	require.False(t, stillTerminal, "terminal ledger cleared after prune")
+	require.Empty(t, rig.sink.findFor(1), "clock gate prevents seal")
+	require.Equal(t, types.StatusFinished, rig.inferenceStatus(1))
 }
 
 func TestHost_PruneSink_NilSafe_NoEmission(t *testing.T) {
@@ -501,7 +429,8 @@ func TestHost_PruneSink_NilSafe_NoEmission(t *testing.T) {
 		TokenPrice:                 1,
 		VoteThreshold:              2,
 		ValidationRate:             0,
-		InferenceClearGraceSeconds: testutil.TestInferenceClearGraceSeconds,
+		SealGraceNonces:            pruneTestSealGraceNonces,
+		InferenceClearGraceSeconds: pruneTestClearGraceSeconds,
 	}
 	verifier := signing.NewSecp256k1Verifier()
 	store := testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 1_000_000)
@@ -513,14 +442,17 @@ func TestHost_PruneSink_NilSafe_NoEmission(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Drive a full Finish without panicking. Sink is nil so this exercises the
-	// processPruneEventsLocked early-return path.
+	// Drive a full Finish, then seal via the deterministic state clock. The sink
+	// is nil, so this exercises the emitSealPrunes early-return path while the
+	// state machine still folds the inference into SealedAcc.
 	rig := &pruneTestRig{
 		t: t, hosts: hosts, user: user, group: group, config: config,
-		host: h, stub: stub.NewInferenceEngine(), escrowID: "escrow-1", epochID: 7,
+		host: h, stub: stub.NewInferenceEngine(), store: store, escrowID: "escrow-1", epochID: 7,
 	}
-	_ = rig.driveStartConfirmFinish(1, 1)
+	nonce := rig.driveStartConfirmFinish(1, 1)
 	require.Equal(t, types.StatusFinished, rig.inferenceStatus(1))
+	rig.bumpClock(nonce, pruneTestBaseConfirmedAt+1+pruneTestClearGraceSeconds)
+	rig.inferenceMissing(1)
 }
 
 func TestHost_ValidateAsync_SkippedDoesNotEnqueueValidation(t *testing.T) {

--- a/devshard/host/validation_obs_test.go
+++ b/devshard/host/validation_obs_test.go
@@ -43,6 +43,12 @@ func newObsRig(t *testing.T, store storage.Storage, opts ...HostOption) *obsTest
 		TokenPrice:       1,
 		VoteThreshold:    uint32(len(hosts)) / 2,
 		ValidationRate:   0,
+		// Small, explicit seal gates drive the deterministic state-clock seal.
+		// With a single live inference the state clock equals that inference's
+		// own ConfirmedAt (gap 0 < grace), so sealing only fires once a test
+		// advances the clock via bumpClock.
+		SealGraceNonces:            pruneTestSealGraceNonces,
+		InferenceClearGraceSeconds: pruneTestClearGraceSeconds,
 	}
 	verifier := signing.NewSecp256k1Verifier()
 
@@ -113,24 +119,42 @@ func (r *obsTestRig) sealedRow(inferenceID uint64) storage.InferenceRow {
 	return row
 }
 
-func (r *obsTestRig) awaitTerminalPrune(inferenceID uint64, nonce uint64, sink *recordingPruneSink) uint64 {
+// startConfirm brings inferenceID through Pending -> Started with the given
+// executor-signed ConfirmedAt, leaving it live (Started). Consumes startNonce
+// (start) and startNonce+1 (confirm).
+func (r *obsTestRig) startConfirm(inferenceID, startNonce uint64, confirmedAt int64) {
 	r.t.Helper()
-	time.Sleep(20 * time.Millisecond)
-	limit := int(r.host.sealGraceNonces) + 3
-	if limit < 3 {
-		limit = 3
-	}
-	for i := 0; i < limit; i++ {
-		if events := sink.findFor(inferenceID); len(events) == 1 {
-			require.Equal(r.t, PruneReasonTerminal, events[0].Reason)
-			return nonce
-		}
-		r.applyDiff(nonce, nil)
-		nonce++
-	}
-	r.t.Fatalf("expected exactly one terminal prune for inference %d, got %d events",
-		inferenceID, len(sink.findFor(inferenceID)))
-	return nonce
+	executorSlot := uint32(inferenceID % uint64(len(r.group)))
+	executorSigner := r.hosts[executorSlot]
+	r.applyDiff(startNonce, []*types.DevshardTx{testutil.StartTx(inferenceID)})
+	execSig := testutil.SignExecutorReceipt(r.t, executorSigner, r.escrowID, inferenceID,
+		testutil.TestPromptHash[:], "llama", 100, 50, 1000, confirmedAt)
+	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: confirmedAt,
+	}}}
+	r.applyDiff(startNonce+1, []*types.DevshardTx{confirmTx})
+}
+
+// bumpClock confirms a fresh inference (id == startNonce) with a high
+// ConfirmedAt, advancing the deterministic state clock so any older eligible
+// inference is auto-sealed on the confirm diff. The new inference stays in
+// StatusStarted (not seal-eligible). Returns the next free nonce.
+func (r *obsTestRig) bumpClock(startNonce uint64, confirmedAt int64) uint64 {
+	r.t.Helper()
+	r.startConfirm(startNonce, startNonce, confirmedAt)
+	return startNonce + 2
+}
+
+// sealViaClock advances the state clock past inferenceID's ConfirmedAt+grace so
+// the deterministic auto-seal folds it into SealedAcc, then asserts exactly one
+// terminal prune fired. Returns the next free nonce.
+func (r *obsTestRig) sealViaClock(inferenceID uint64, nonce uint64, sink *recordingPruneSink) uint64 {
+	r.t.Helper()
+	next := r.bumpClock(nonce, pruneTestBaseConfirmedAt+int64(inferenceID)+pruneTestClearGraceSeconds+5)
+	events := sink.findFor(inferenceID)
+	require.Len(r.t, events, 1, "expected exactly one terminal prune for inference %d", inferenceID)
+	require.Equal(r.t, PruneReasonTerminal, events[0].Reason)
+	return next
 }
 
 func (r *obsTestRig) driveStartConfirmFinish(inferenceID, startNonce uint64) uint64 {
@@ -594,7 +618,6 @@ func TestHost_ApplyAndPersist_NoObsRecordForSealedInference(t *testing.T) {
 	sink := &recordingPruneSink{}
 	r := newObsRig(t, nil,
 		WithPruneSink(sink),
-		WithPruneTuning(1, 10*time.Millisecond),
 	)
 
 	const inferenceID = uint64(1)
@@ -611,7 +634,7 @@ func TestHost_ApplyAndPersist_NoObsRecordForSealedInference(t *testing.T) {
 	waitObsCompletedForSlot(t, r.store, r.escrowID, 1, 1)
 	waitObsRowCount(t, r.store, r.escrowID, 2)
 
-	next = r.awaitTerminalPrune(inferenceID, next, sink)
+	next = r.sealViaClock(inferenceID, next, sink)
 	r.inferenceMissing(inferenceID)
 	require.NotZero(t, r.sealedRow(inferenceID).SealedNonce)
 

--- a/devshard/host/validation_obs_test.go
+++ b/devshard/host/validation_obs_test.go
@@ -43,10 +43,7 @@ func newObsRig(t *testing.T, store storage.Storage, opts ...HostOption) *obsTest
 		TokenPrice:       1,
 		VoteThreshold:    uint32(len(hosts)) / 2,
 		ValidationRate:   0,
-		// Small, explicit seal gates drive the deterministic state-clock seal.
-		// With a single live inference the state clock equals that inference's
-		// own ConfirmedAt (gap 0 < grace), so sealing only fires once a test
-		// advances the clock via bumpClock.
+		// Small, explicit seal gates for deterministic auto-seal in tests.
 		SealGraceNonces:            pruneTestSealGraceNonces,
 		InferenceClearGraceSeconds: pruneTestClearGraceSeconds,
 	}
@@ -119,42 +116,26 @@ func (r *obsTestRig) sealedRow(inferenceID uint64) storage.InferenceRow {
 	return row
 }
 
-// startConfirm brings inferenceID through Pending -> Started with the given
-// executor-signed ConfirmedAt, leaving it live (Started). Consumes startNonce
-// (start) and startNonce+1 (confirm).
-func (r *obsTestRig) startConfirm(inferenceID, startNonce uint64, confirmedAt int64) {
+// awaitTerminalSeal waits for the terminal short-path seal (nonce gate only).
+// If the terminalizing diff already sealed the inference, this returns
+// immediately; otherwise it advances empty diffs until the nonce gate clears.
+func (r *obsTestRig) awaitTerminalSeal(inferenceID uint64, nonce uint64, sink *recordingPruneSink) uint64 {
 	r.t.Helper()
-	executorSlot := uint32(inferenceID % uint64(len(r.group)))
-	executorSigner := r.hosts[executorSlot]
-	r.applyDiff(startNonce, []*types.DevshardTx{testutil.StartTx(inferenceID)})
-	execSig := testutil.SignExecutorReceipt(r.t, executorSigner, r.escrowID, inferenceID,
-		testutil.TestPromptHash[:], "llama", 100, 50, 1000, confirmedAt)
-	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: confirmedAt,
-	}}}
-	r.applyDiff(startNonce+1, []*types.DevshardTx{confirmTx})
-}
-
-// bumpClock confirms a fresh inference (id == startNonce) with a high
-// ConfirmedAt, advancing the deterministic state clock so any older eligible
-// inference is auto-sealed on the confirm diff. The new inference stays in
-// StatusStarted (not seal-eligible). Returns the next free nonce.
-func (r *obsTestRig) bumpClock(startNonce uint64, confirmedAt int64) uint64 {
-	r.t.Helper()
-	r.startConfirm(startNonce, startNonce, confirmedAt)
-	return startNonce + 2
-}
-
-// sealViaClock advances the state clock past inferenceID's ConfirmedAt+grace so
-// the deterministic auto-seal folds it into SealedAcc, then asserts exactly one
-// terminal prune fired. Returns the next free nonce.
-func (r *obsTestRig) sealViaClock(inferenceID uint64, nonce uint64, sink *recordingPruneSink) uint64 {
-	r.t.Helper()
-	next := r.bumpClock(nonce, pruneTestBaseConfirmedAt+int64(inferenceID)+pruneTestClearGraceSeconds+5)
-	events := sink.findFor(inferenceID)
-	require.Len(r.t, events, 1, "expected exactly one terminal prune for inference %d", inferenceID)
-	require.Equal(r.t, PruneReasonTerminal, events[0].Reason)
-	return next
+	limit := int(pruneTestSealGraceNonces) + 3
+	if limit < 3 {
+		limit = 3
+	}
+	for i := 0; i < limit; i++ {
+		if events := sink.findFor(inferenceID); len(events) == 1 {
+			require.Equal(r.t, PruneReasonTerminal, events[0].Reason)
+			return nonce
+		}
+		r.applyDiff(nonce, nil)
+		nonce++
+	}
+	r.t.Fatalf("expected exactly one terminal prune for inference %d, got %d events",
+		inferenceID, len(sink.findFor(inferenceID)))
+	return nonce
 }
 
 func (r *obsTestRig) driveStartConfirmFinish(inferenceID, startNonce uint64) uint64 {
@@ -630,11 +611,10 @@ func TestHost_ApplyAndPersist_NoObsRecordForSealedInference(t *testing.T) {
 
 	r.applyDiff(next, []*types.DevshardTx{r.signValidationVote(inferenceID, 1, false)})
 	next++
-	require.Equal(t, types.StatusInvalidated, r.host.SnapshotState().Inferences[inferenceID].Status)
 	waitObsCompletedForSlot(t, r.store, r.escrowID, 1, 1)
 	waitObsRowCount(t, r.store, r.escrowID, 2)
 
-	next = r.sealViaClock(inferenceID, next, sink)
+	next = r.awaitTerminalSeal(inferenceID, next, sink)
 	r.inferenceMissing(inferenceID)
 	require.NotZero(t, r.sealedRow(inferenceID).SealedNonce)
 

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -338,6 +338,16 @@ func (sm *StateMachine) ApplyLocalBestEffort(nonce uint64, txs []*types.Devshard
 		}
 	}
 
+	// Deterministically seal inferences whose grace gates have cleared, before
+	// the root is computed, so the user's signed post_state_root commits to the
+	// same seal the host will fold. Reads only state (nonce + ConfirmedAt clock).
+	if sm.state.Phase == types.PhaseActive {
+		if _, err := sm.autoSealLocked(nonce); err != nil {
+			sm.restoreMutable(snap)
+			return nil, nil, fmt.Errorf("auto-seal: %w", err)
+		}
+	}
+
 	root, err := sm.computeStateRootLocked()
 	if err != nil {
 		sm.restoreMutable(snap)
@@ -422,6 +432,17 @@ func (sm *StateMachine) applyCore(nonce uint64, txs []*types.DevshardTx, postSta
 				sm.restoreMutable(snap)
 				return nil, fmt.Errorf("drain live into sealed_acc: %w", err)
 			}
+		}
+	}
+
+	// 6b. Deterministically seal inferences whose grace gates have cleared,
+	// folding them into SealedAcc before the root is computed so the seal is
+	// part of post_state_root. The decision reads only state (nonce + the
+	// ConfirmedAt-derived state clock), so user, host and replay all agree.
+	if sm.state.Phase == types.PhaseActive {
+		if _, err := sm.autoSealLocked(nonce); err != nil {
+			sm.restoreMutable(snap)
+			return nil, fmt.Errorf("auto-seal: %w", err)
 		}
 	}
 
@@ -1194,6 +1215,19 @@ func (sm *StateMachine) SlotAddress(slotID uint32) string {
 
 func (sm *StateMachine) AddressSlotCount(addr string) uint32 {
 	return sm.addressToSlotCount[addr]
+}
+
+// LiveInferenceIDs returns the set of inference ids currently in live state.
+// The live set is bounded (in-flight plus in-grace), so this is cheap. The host
+// uses it to detect which inferences a diff sealed (live before, gone after).
+func (sm *StateMachine) LiveInferenceIDs() map[uint64]struct{} {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	out := make(map[uint64]struct{}, len(sm.state.Inferences))
+	for id := range sm.state.Inferences {
+		out[id] = struct{}{}
+	}
+	return out
 }
 
 // GetInference returns a copy of the inference record for the given ID.

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -9,6 +9,12 @@ import (
 	"devshard/types"
 )
 
+// stateClockWindowFactor sets how many recent live inferences the deterministic
+// state clock scans, as a multiple of the group size N. Concurrency is bounded
+// by the number of slots, so N*factor comfortably covers the in-flight window
+// whose ConfirmedAt timestamps approximate "now".
+const stateClockWindowFactor = 3
+
 func cloneCommittedInferenceEntries(src map[uint64][]byte) map[uint64][]byte {
 	if len(src) == 0 {
 		return make(map[uint64][]byte)
@@ -190,6 +196,124 @@ func (sm *StateMachine) drainLiveIntoSealedAccLocked(sealNonce uint64) error {
 	}
 	sm.state.SealedAcc = append([]byte(nil), cur[:]...)
 	return nil
+}
+
+// sealEligibleStatus reports whether an inference in this status may be folded
+// into the sealed accumulator by the deterministic auto-seal sweep: Finished
+// (stale-finished tier) or terminal (Validated/Invalidated/TimedOut). Pending,
+// Started and Challenged are still in-flight or mid-vote and are not sealable.
+func sealEligibleStatus(s types.InferenceStatus) bool {
+	switch s {
+	case types.StatusFinished, types.StatusValidated, types.StatusInvalidated, types.StatusTimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+// stateClockLocked derives a deterministic "current time" purely from state:
+// the max ConfirmedAt over the latest N*stateClockWindowFactor live inferences
+// (N = group size). ConfirmedAt is executor-signed and committed to the state
+// root, so every node computes the identical clock without reading any wall
+// clock -- which is what lets the auto-seal decision agree across user, host
+// and replay. Returns 0 before any inference has confirmed. Caller holds sm.mu.
+func (sm *StateMachine) stateClockLocked() int64 {
+	if len(sm.state.Inferences) == 0 {
+		return 0
+	}
+	window := len(sm.state.Group) * stateClockWindowFactor
+	if window <= 0 {
+		window = stateClockWindowFactor
+	}
+
+	ids := make([]uint64, 0, len(sm.state.Inferences))
+	for id := range sm.state.Inferences {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	// Inference id == start nonce, so the highest ids are the most recently
+	// started. Scan the tail window and take the max ConfirmedAt.
+	start := 0
+	if len(ids) > window {
+		start = len(ids) - window
+	}
+	var maxConfirmed int64
+	for _, id := range ids[start:] {
+		if c := sm.state.Inferences[id].ConfirmedAt; c > maxConfirmed {
+			maxConfirmed = c
+		}
+	}
+	return maxConfirmed
+}
+
+// autoSealLocked folds every live inference that has cleared both seal gates
+// into SealedAcc, in ascending id order, and returns the ids it sealed. It is
+// the deterministic replacement for the old host-local, wall-clock prune/seal:
+// both gates read only state, so the user (composing a diff), the host
+// (applying it) and replay all seal the identical set at the identical nonce
+// and agree on the post_state_root.
+//
+// Per live, seal-eligible inference, both gates must clear:
+//   - nonce gate:  sealNonce >= id + SealGraceNonces   (id == start nonce)
+//   - clock gate:  stateClock - ConfirmedAt >= InferenceClearGraceSeconds
+//
+// The obs-store write is best-effort (logged, never fatal) so a transient
+// storage error on one node cannot diverge the deterministic seal. Caller must
+// hold sm.mu and should invoke this only in the Active phase (settlement uses
+// drainLiveIntoSealedAccLocked).
+func (sm *StateMachine) autoSealLocked(sealNonce uint64) ([]uint64, error) {
+	if len(sm.state.Inferences) == 0 {
+		return nil, nil
+	}
+	sealGraceNonces := uint64(sm.state.Config.SealGraceNonces)
+	graceSeconds := int64(sm.state.Config.InferenceClearGraceSeconds)
+	stateClock := sm.stateClockLocked()
+
+	var eligible []uint64
+	for id, rec := range sm.state.Inferences {
+		if !sealEligibleStatus(rec.Status) {
+			continue
+		}
+		if sealNonce < id+sealGraceNonces {
+			continue
+		}
+		if stateClock-rec.ConfirmedAt < graceSeconds {
+			continue
+		}
+		eligible = append(eligible, id)
+	}
+	if len(eligible) == 0 {
+		return nil, nil
+	}
+	slices.Sort(eligible)
+
+	if sm.sealedNonces == nil {
+		sm.sealedNonces = make(map[uint64]uint64, len(eligible))
+	}
+	cur := sealedAccBytes32(sm.state.SealedAcc)
+	for _, id := range eligible {
+		rec := sm.state.Inferences[id]
+		if err := sm.updateCommittedEntryLocked(id, rec); err != nil {
+			return nil, fmt.Errorf("auto-seal inference %d: %w", id, err)
+		}
+		entry := append([]byte(nil), sm.committedEntries[id]...)
+		cur = FoldSealedAccumulator(cur, sealNonce, id, entry)
+		sm.sealedNonces[id] = sealNonce
+		delete(sm.committedEntries, id)
+		if err := sm.upsertInferenceObsLocked(id, sealNonce, rec); err != nil {
+			// Observability only; never block or diverge the deterministic seal.
+			logging.Warn("failed to persist sealed inference obs during auto-seal",
+				"subsystem", "state",
+				"escrow_id", sm.state.EscrowID,
+				"inference_id", id,
+				"error", err,
+			)
+		}
+		delete(sm.state.Inferences, id)
+	}
+	sm.state.SealedAcc = append([]byte(nil), cur[:]...)
+	return eligible, nil
 }
 
 func (sm *StateMachine) SealInference(id uint64) error {

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -211,6 +211,18 @@ func sealEligibleStatus(s types.InferenceStatus) bool {
 	}
 }
 
+// terminalAutoSealStatus reports terminal outcomes that may seal as soon as the
+// nonce gate clears, without waiting for the state-clock grace. Finished
+// (stale-finished) still requires both the nonce and clock gates.
+func terminalAutoSealStatus(s types.InferenceStatus) bool {
+	switch s {
+	case types.StatusValidated, types.StatusInvalidated, types.StatusTimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
 // stateClockLocked derives a deterministic "current time" purely from state:
 // the max ConfirmedAt over the latest N*stateClockWindowFactor live inferences
 // (N = group size). ConfirmedAt is executor-signed and committed to the state
@@ -254,9 +266,12 @@ func (sm *StateMachine) stateClockLocked() int64 {
 // (applying it) and replay all seal the identical set at the identical nonce
 // and agree on the post_state_root.
 //
-// Per live, seal-eligible inference, both gates must clear:
-//   - nonce gate:  sealNonce >= id + SealGraceNonces   (id == start nonce)
-//   - clock gate:  stateClock - ConfirmedAt >= InferenceClearGraceSeconds
+// Per live, seal-eligible inference:
+//   - nonce gate (always):  sealNonce >= id + SealGraceNonces   (id == start nonce)
+//   - clock gate (Finished only): stateClock - ConfirmedAt >= InferenceClearGraceSeconds
+//
+// Terminal statuses (Validated/Invalidated/TimedOut) skip the clock gate and
+// seal as soon as the nonce gate clears on the diff that made them terminal.
 //
 // The obs-store write is best-effort (logged, never fatal) so a transient
 // storage error on one node cannot diverge the deterministic seal. Caller must
@@ -278,7 +293,7 @@ func (sm *StateMachine) autoSealLocked(sealNonce uint64) ([]uint64, error) {
 		if sealNonce < id+sealGraceNonces {
 			continue
 		}
-		if stateClock-rec.ConfirmedAt < graceSeconds {
+		if !terminalAutoSealStatus(rec.Status) && stateClock-rec.ConfirmedAt < graceSeconds {
 			continue
 		}
 		eligible = append(eligible, id)

--- a/devshard/user/validation_test.go
+++ b/devshard/user/validation_test.go
@@ -137,10 +137,12 @@ func TestSession_Validation_InvalidationConverges(t *testing.T) {
 		require.NoError(t, session.SendPendingDiff(ctx))
 	}
 
-	// Snapshot before finalize: v2 drains state.Inferences into SealedAcc at settlement.
+	// Snapshot before finalize. Terminal outcomes may already be auto-sealed
+	// out of the live map; ExportAllInferenceRecords includes those snapshots.
 	preFinalize := session.StateMachine().SnapshotState()
+	allRecords := session.StateMachine().ExportAllInferenceRecords()
 	var finished, challenged, invalidated, validated, other int
-	for _, rec := range preFinalize.Inferences {
+	for _, rec := range allRecords {
 		switch rec.Status {
 		case types.StatusFinished:
 			finished++
@@ -160,8 +162,8 @@ func TestSession_Validation_InvalidationConverges(t *testing.T) {
 		totalCalls += v.calls.Load()
 	}
 	hist := fmt.Sprintf(
-		"histogram: live=%d finished=%d challenged=%d invalidated=%d validated=%d other=%d host_stats_invalid=%d validate_calls=%d",
-		len(preFinalize.Inferences), finished, challenged, invalidated, validated, other,
+		"histogram: live=%d records=%d finished=%d challenged=%d invalidated=%d validated=%d other=%d host_stats_invalid=%d validate_calls=%d",
+		len(preFinalize.Inferences), len(allRecords), finished, challenged, invalidated, validated, other,
 		totalHostStatsInvalid, totalCalls,
 	)
 	t.Log(hist)
@@ -272,12 +274,14 @@ func TestSession_Validation_MultiSlotValidatorCountedOnce(t *testing.T) {
 		require.NoError(t, session.SendPendingDiff(ctx))
 	}
 
-	preFinalize := session.StateMachine().SnapshotState()
+	// Terminal invalidations are auto-sealed out of the live map before
+	// finalize; ExportAllInferenceRecords includes sealed snapshots.
+	allRecords := session.StateMachine().ExportAllInferenceRecords()
 	megaSlots := []uint32{1, 2, 3}
 
 	megaParticipations := 0
 	invalidated := 0
-	for _, rec := range preFinalize.Inferences {
+	for _, rec := range allRecords {
 		participated := false
 		for _, slot := range megaSlots {
 			if rec.ValidatedBy.IsSet(slot) {


### PR DESCRIPTION
Host-local wall-clock prune tiers made seal timing node-dependent and risked diverging state roots.

Fold eligible inferences during diff apply using nonce and ConfirmedAt-derived state clock gates, and have the host emit payload-prune events only after the machine seals them.

At this solution we are using last N*3 inferences max(confirmedAt), where N = number of slots

We are sealing inferences with confirmedAt + sealedTimeout < max(confirmedAt_lastN)