### PR TITLE
fix(testermint): schedule upgrade rehearsal in inference safely

### DIFF
--- a/testermint/src/main/kotlin/Epochs.kt
+++ b/testermint/src/main/kotlin/Epochs.kt
@@ -48,24 +48,28 @@ fun EpochResponse.findStageSafeInferenceBlock(
 ): StageSafeInferenceBlock? {
     require(minimumSlackBeforeNextPoc >= 0) { "minimumSlackBeforeNextPoc must be non-negative" }
 
-    val inferenceWindows = listOf(
-        epochStages.claimMoney + 1 to epochStages.nextPocStart,
-        nextEpochStages.claimMoney + 1 to nextEpochStages.nextPocStart,
-    )
+    val epochLength = nextEpochStages.pocStart - epochStages.pocStart
+    require(epochLength > 0) { "epoch stages must advance across epochs" }
 
-    return inferenceWindows.firstNotNullOfOrNull { (windowStart, nextPocStart) ->
+    val firstInferenceWindowStart = epochStages.claimMoney + 1
+    val firstInferenceWindowNextPoc = epochStages.nextPocStart
+    val firstCandidateWindowIndex = maxOf(0L, (earliestBlock - firstInferenceWindowStart) / epochLength)
+
+    for (windowIndex in firstCandidateWindowIndex..firstCandidateWindowIndex + 1) {
+        val windowStart = firstInferenceWindowStart + windowIndex * epochLength
+        val nextPocStart = firstInferenceWindowNextPoc + windowIndex * epochLength
         val candidateBlock = maxOf(blockHeight + 1, earliestBlock, windowStart)
         val latestSafeBlock = nextPocStart - minimumSlackBeforeNextPoc - 1
         if (candidateBlock <= latestSafeBlock) {
-            StageSafeInferenceBlock(
+            return StageSafeInferenceBlock(
                 block = candidateBlock,
                 inferenceWindowStart = windowStart,
                 nextPocStart = nextPocStart,
             )
-        } else {
-            null
         }
     }
+
+    return null
 }
 
 @Deprecated("Use EpochResponse.getNextStage instead. We keep it only to get the block when the very 1st validators are active.")

--- a/testermint/src/main/kotlin/Epochs.kt
+++ b/testermint/src/main/kotlin/Epochs.kt
@@ -13,6 +13,14 @@ enum class EpochStage {
     CLAIM_REWARDS
 }
 
+private const val DEFAULT_INFERENCE_STAGE_SLACK_BLOCKS = 3L
+
+data class StageSafeInferenceBlock(
+    val block: Long,
+    val inferenceWindowStart: Long,
+    val nextPocStart: Long,
+)
+
 fun EpochResponse.getNextStage(stage: EpochStage): Long {
     return when (stage) {
         EpochStage.START_OF_POC -> resolveUpcomingStage(epochStages.pocStart, nextEpochStages.pocStart)
@@ -31,6 +39,32 @@ fun EpochResponse.resolveUpcomingStage(latestEpochStage: Long, nextEpochStage: L
         latestEpochStage
     } else {
         nextEpochStage
+    }
+}
+
+fun EpochResponse.findStageSafeInferenceBlock(
+    earliestBlock: Long,
+    minimumSlackBeforeNextPoc: Long = DEFAULT_INFERENCE_STAGE_SLACK_BLOCKS,
+): StageSafeInferenceBlock? {
+    require(minimumSlackBeforeNextPoc >= 0) { "minimumSlackBeforeNextPoc must be non-negative" }
+
+    val inferenceWindows = listOf(
+        epochStages.claimMoney + 1 to epochStages.nextPocStart,
+        nextEpochStages.claimMoney + 1 to nextEpochStages.nextPocStart,
+    )
+
+    return inferenceWindows.firstNotNullOfOrNull { (windowStart, nextPocStart) ->
+        val candidateBlock = maxOf(blockHeight + 1, earliestBlock, windowStart)
+        val latestSafeBlock = nextPocStart - minimumSlackBeforeNextPoc - 1
+        if (candidateBlock <= latestSafeBlock) {
+            StageSafeInferenceBlock(
+                block = candidateBlock,
+                inferenceWindowStart = windowStart,
+                nextPocStart = nextPocStart,
+            )
+        } else {
+            null
+        }
     }
 }
 

--- a/testermint/src/main/kotlin/Epochs.kt
+++ b/testermint/src/main/kotlin/Epochs.kt
@@ -13,7 +13,7 @@ enum class EpochStage {
     CLAIM_REWARDS
 }
 
-private const val DEFAULT_INFERENCE_STAGE_SLACK_BLOCKS = 3L
+const val INFERENCE_STAGE_SLACK_BLOCKS = 3L
 
 data class StageSafeInferenceBlock(
     val block: Long,
@@ -44,7 +44,7 @@ fun EpochResponse.resolveUpcomingStage(latestEpochStage: Long, nextEpochStage: L
 
 fun EpochResponse.findStageSafeInferenceBlock(
     earliestBlock: Long,
-    minimumSlackBeforeNextPoc: Long = DEFAULT_INFERENCE_STAGE_SLACK_BLOCKS,
+    minimumSlackBeforeNextPoc: Long = INFERENCE_STAGE_SLACK_BLOCKS,
 ): StageSafeInferenceBlock? {
     require(minimumSlackBeforeNextPoc >= 0) { "minimumSlackBeforeNextPoc must be non-negative" }
 

--- a/testermint/src/main/kotlin/data/epoch.kt
+++ b/testermint/src/main/kotlin/data/epoch.kt
@@ -1,6 +1,7 @@
 package com.productscience.data
 
 import com.google.gson.annotations.SerializedName
+import com.productscience.INFERENCE_STAGE_SLACK_BLOCKS
 
 data class EpochResponse(
     @SerializedName("block_height")
@@ -22,7 +23,7 @@ data class EpochResponse(
     val safeForInference: Boolean =
         if (phase == EpochPhase.Inference) {
             val blocksUntilEnd = nextEpochStages.pocStart - blockHeight
-            blocksUntilEnd > 3
+            blocksUntilEnd > INFERENCE_STAGE_SLACK_BLOCKS
         } else {
             false
         }

--- a/testermint/src/test/kotlin/EpochSchedulingHelpersTest.kt
+++ b/testermint/src/test/kotlin/EpochSchedulingHelpersTest.kt
@@ -1,0 +1,137 @@
+import com.productscience.findStageSafeInferenceBlock
+import com.productscience.data.Decimal
+import com.productscience.data.EpochExchangeWindow
+import com.productscience.data.EpochParams
+import com.productscience.data.EpochPhase
+import com.productscience.data.EpochResponse
+import com.productscience.data.EpochStages
+import com.productscience.data.LatestEpochDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EpochSchedulingHelpersTest {
+    @Test
+    fun `findStageSafeInferenceBlock uses current inference window when lead fits`() {
+        val epochData = epochResponse(
+            blockHeight = 420,
+            phase = EpochPhase.Inference,
+            epochClaimMoney = 416,
+            epochNextPocStart = 450,
+            nextClaimMoney = 466,
+            nextNextPocStart = 500,
+        )
+
+        val selected = requireNotNull(epochData.findStageSafeInferenceBlock(earliestBlock = 428))
+
+        assertThat(selected.block).isEqualTo(428)
+        assertThat(selected.inferenceWindowStart).isEqualTo(417)
+        assertThat(selected.nextPocStart).isEqualTo(450)
+    }
+
+    @Test
+    fun `findStageSafeInferenceBlock skips unsafe tail of current inference window`() {
+        val epochData = epochResponse(
+            blockHeight = 420,
+            phase = EpochPhase.Inference,
+            epochClaimMoney = 416,
+            epochNextPocStart = 450,
+            nextClaimMoney = 466,
+            nextNextPocStart = 500,
+        )
+
+        val selected = requireNotNull(epochData.findStageSafeInferenceBlock(earliestBlock = 447))
+
+        assertThat(selected.block).isEqualTo(467)
+        assertThat(selected.inferenceWindowStart).isEqualTo(467)
+        assertThat(selected.nextPocStart).isEqualTo(500)
+    }
+
+    @Test
+    fun `findStageSafeInferenceBlock anchors on upcoming inference window when currently in validation`() {
+        val epochData = epochResponse(
+            blockHeight = 433,
+            phase = EpochPhase.PoCValidate,
+            epochClaimMoney = 440,
+            epochNextPocStart = 460,
+            nextClaimMoney = 476,
+            nextNextPocStart = 510,
+        )
+
+        val selected = requireNotNull(epochData.findStageSafeInferenceBlock(earliestBlock = 445))
+
+        assertThat(selected.block).isEqualTo(445)
+        assertThat(selected.inferenceWindowStart).isEqualTo(441)
+        assertThat(selected.nextPocStart).isEqualTo(460)
+    }
+
+    private fun epochResponse(
+        blockHeight: Long,
+        phase: EpochPhase,
+        epochClaimMoney: Long,
+        epochNextPocStart: Long,
+        nextClaimMoney: Long,
+        nextNextPocStart: Long,
+    ): EpochResponse {
+        return EpochResponse(
+            blockHeight = blockHeight,
+            latestEpoch = LatestEpochDto(index = 11, pocStartBlockHeight = 400),
+            phase = phase,
+            epochStages = epochStages(
+                epochIndex = 11,
+                claimMoney = epochClaimMoney,
+                nextPocStart = epochNextPocStart,
+            ),
+            nextEpochStages = epochStages(
+                epochIndex = 12,
+                claimMoney = nextClaimMoney,
+                nextPocStart = nextNextPocStart,
+            ),
+            epochParams = EpochParams(
+                epochLength = 60,
+                epochMultiplier = 1,
+                epochShift = 0,
+                defaultUnitOfComputePrice = 100,
+                pocStageDuration = 10,
+                pocExchangeDuration = 1,
+                pocValidationDelay = 2,
+                pocValidationDuration = 4,
+                setNewValidatorsDelay = 1,
+                inferenceValidationCutoff = 1,
+                inferencePruningEpochThreshold = 10,
+                inferencePruningMax = 100,
+                pocPruningMax = 100,
+                pocSlotAllocation = Decimal.fromDouble(0.5),
+                confirmationPocSafetyWindow = 0,
+            ),
+            isConfirmationPocActive = false,
+            activeConfirmationPocEvent = null,
+        )
+    }
+
+    private fun epochStages(
+        epochIndex: Long,
+        claimMoney: Long,
+        nextPocStart: Long,
+    ): EpochStages {
+        return EpochStages(
+            epochIndex = epochIndex,
+            pocStart = claimMoney - 20,
+            pocGenerationWindDown = claimMoney - 16,
+            pocGenerationEnd = claimMoney - 15,
+            pocValidationStart = claimMoney - 10,
+            pocValidationWindDown = claimMoney - 6,
+            pocValidationEnd = claimMoney - 5,
+            setNewValidators = claimMoney - 1,
+            claimMoney = claimMoney,
+            nextPocStart = nextPocStart,
+            pocExchangeWindow = EpochExchangeWindow(
+                start = claimMoney - 14,
+                end = claimMoney - 11,
+            ),
+            pocValExchangeWindow = EpochExchangeWindow(
+                start = claimMoney - 9,
+                end = claimMoney - 7,
+            ),
+        )
+    }
+}

--- a/testermint/src/test/kotlin/EpochSchedulingHelpersTest.kt
+++ b/testermint/src/test/kotlin/EpochSchedulingHelpersTest.kt
@@ -64,6 +64,24 @@ class EpochSchedulingHelpersTest {
         assertThat(selected.nextPocStart).isEqualTo(460)
     }
 
+    @Test
+    fun `findStageSafeInferenceBlock projects forward beyond the next epoch when lead is long`() {
+        val epochData = epochResponse(
+            blockHeight = 363,
+            phase = EpochPhase.Inference,
+            epochClaimMoney = 358,
+            epochNextPocStart = 390,
+            nextClaimMoney = 398,
+            nextNextPocStart = 430,
+        )
+
+        val selected = requireNotNull(epochData.findStageSafeInferenceBlock(earliestBlock = 443))
+
+        assertThat(selected.block).isEqualTo(443)
+        assertThat(selected.inferenceWindowStart).isEqualTo(439)
+        assertThat(selected.nextPocStart).isEqualTo(470)
+    }
+
     private fun epochResponse(
         blockHeight: Long,
         phase: EpochPhase,

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -128,34 +128,29 @@ class UpgradeRehearsalTests : TestermintTest() {
     ): Long {
         require(minimumLeadBlocks >= 0) { "UPGRADE_REHEARSAL_LEAD_BLOCKS must be non-negative" }
 
-        while (true) {
-            val epochData = genesis.getEpochData()
-            val earliestUpgradeBlock = epochData.blockHeight + minimumLeadBlocks
-            val scheduledUpgrade = epochData.findStageSafeInferenceBlock(
+        val epochData = genesis.getEpochData()
+        val earliestUpgradeBlock = epochData.blockHeight + minimumLeadBlocks
+        val scheduledUpgrade = requireNotNull(
+            epochData.findStageSafeInferenceBlock(
                 earliestBlock = earliestUpgradeBlock,
                 minimumSlackBeforeNextPoc = upgradeSchedulingSlackBlocks,
             )
-
-            if (scheduledUpgrade != null) {
-                Logger.info(
-                    "Selected stage-safe upgrade height {} from block {} during phase {} " +
-                        "(inference window {}..{}, earliest acceptable block {})",
-                    scheduledUpgrade.block,
-                    epochData.blockHeight,
-                    epochData.phase,
-                    scheduledUpgrade.inferenceWindowStart,
-                    scheduledUpgrade.nextPocStart - 1,
-                    earliestUpgradeBlock,
-                )
-                return scheduledUpgrade.block
-            }
-
-            logSection(
-                "Waiting for next inference window to schedule upgrade safely " +
-                    "(current block ${epochData.blockHeight}, phase ${epochData.phase}, lead $minimumLeadBlocks)"
-            )
-            genesis.waitForStage(EpochStage.CLAIM_REWARDS)
+        ) {
+            "Failed to find a stage-safe upgrade block for height $earliestUpgradeBlock " +
+                "with slack $upgradeSchedulingSlackBlocks from phase ${epochData.phase}"
         }
+
+        Logger.info(
+            "Selected stage-safe upgrade height {} from block {} during phase {} " +
+                "(inference window {}..{}, earliest acceptable block {})",
+            scheduledUpgrade.block,
+            epochData.blockHeight,
+            epochData.phase,
+            scheduledUpgrade.inferenceWindowStart,
+            scheduledUpgrade.nextPocStart - 1,
+            earliestUpgradeBlock,
+        )
+        return scheduledUpgrade.block
     }
 
     private data class PocPowerSnapshot(

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -20,6 +20,7 @@ import kotlin.test.assertNotNull
 @Tag("exclude")
 class UpgradeRehearsalTests : TestermintTest() {
     private val defaultDevshardMaxNonce = 20_000L
+    private val upgradeSchedulingSlackBlocks = 3L
 
     @Test
     @Tag("upgrade-rehearsal")
@@ -36,7 +37,7 @@ class UpgradeRehearsalTests : TestermintTest() {
         waitForClusterOperational(cluster, genesis)
 
         val upgradeLeadBlocks = System.getenv("UPGRADE_REHEARSAL_LEAD_BLOCKS")?.toLongOrNull() ?: 80L
-        val upgradeHeight = genesis.getCurrentBlockHeight() + upgradeLeadBlocks
+        val upgradeHeight = scheduleStageSafeUpgradeHeight(genesis, upgradeLeadBlocks)
         val binaryPath = rehearsalBinaryPath("v2/inferenced/inferenced-amd64.zip")
         val apiBinaryPath = rehearsalBinaryPath("v2/dapi/decentralized-api-amd64.zip")
 
@@ -119,6 +120,42 @@ class UpgradeRehearsalTests : TestermintTest() {
         }
 
         writeCompletionManifest(targetUpgrade, upgradeHeight, postInference.id, escrowId, postUpgradePocResult)
+    }
+
+    private fun scheduleStageSafeUpgradeHeight(
+        genesis: LocalInferencePair,
+        minimumLeadBlocks: Long,
+    ): Long {
+        require(minimumLeadBlocks >= 0) { "UPGRADE_REHEARSAL_LEAD_BLOCKS must be non-negative" }
+
+        while (true) {
+            val epochData = genesis.getEpochData()
+            val earliestUpgradeBlock = epochData.blockHeight + minimumLeadBlocks
+            val scheduledUpgrade = epochData.findStageSafeInferenceBlock(
+                earliestBlock = earliestUpgradeBlock,
+                minimumSlackBeforeNextPoc = upgradeSchedulingSlackBlocks,
+            )
+
+            if (scheduledUpgrade != null) {
+                Logger.info(
+                    "Selected stage-safe upgrade height {} from block {} during phase {} " +
+                        "(inference window {}..{}, earliest acceptable block {})",
+                    scheduledUpgrade.block,
+                    epochData.blockHeight,
+                    epochData.phase,
+                    scheduledUpgrade.inferenceWindowStart,
+                    scheduledUpgrade.nextPocStart - 1,
+                    earliestUpgradeBlock,
+                )
+                return scheduledUpgrade.block
+            }
+
+            logSection(
+                "Waiting for next inference window to schedule upgrade safely " +
+                    "(current block ${epochData.blockHeight}, phase ${epochData.phase}, lead $minimumLeadBlocks)"
+            )
+            genesis.waitForStage(EpochStage.CLAIM_REWARDS)
+        }
     }
 
     private data class PocPowerSnapshot(

--- a/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
+++ b/testermint/src/test/kotlin/UpgradeRehearsalTests.kt
@@ -20,7 +20,6 @@ import kotlin.test.assertNotNull
 @Tag("exclude")
 class UpgradeRehearsalTests : TestermintTest() {
     private val defaultDevshardMaxNonce = 20_000L
-    private val upgradeSchedulingSlackBlocks = 3L
 
     @Test
     @Tag("upgrade-rehearsal")
@@ -133,11 +132,11 @@ class UpgradeRehearsalTests : TestermintTest() {
         val scheduledUpgrade = requireNotNull(
             epochData.findStageSafeInferenceBlock(
                 earliestBlock = earliestUpgradeBlock,
-                minimumSlackBeforeNextPoc = upgradeSchedulingSlackBlocks,
+                minimumSlackBeforeNextPoc = INFERENCE_STAGE_SLACK_BLOCKS,
             )
         ) {
             "Failed to find a stage-safe upgrade block for height $earliestUpgradeBlock " +
-                "with slack $upgradeSchedulingSlackBlocks from phase ${epochData.phase}"
+                "with slack $INFERENCE_STAGE_SLACK_BLOCKS from phase ${epochData.phase}"
         }
 
         Logger.info(


### PR DESCRIPTION
## Summary
- replace the raw `current + leadBlocks` rehearsal upgrade height with stage-aware inference-window scheduling
- handle longer lead times by projecting forward to a future safe inference window
- add focused regression coverage for the scheduler helper

This should be an easy merge into `upgrade-v0.2.14`; the upgrade rehearsal workflow is green on this branch.