### PR TITLE
Recover orphaned rotation escrows on DB persist failure instead of re-minting on chain

### DIFF
--- a/devshard/cmd/devshardctl/chain_tx_rest.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest.go
@@ -122,6 +122,10 @@ func txHashFromBytes(txBytes []byte) string {
 	return strings.ToUpper(hex.EncodeToString(sum[:]))
 }
 
+// errTxNotFound marks a tx that is not on chain (404) — distinct from one that
+// committed but failed. The tx may still land until its unordered TTL elapses.
+var errTxNotFound = errors.New("tx not found on chain")
+
 // GetTxEscrowID resolves a create tx hash to its escrow_id in one lookup;
 // found=false when the tx is absent or failed (no escrow), error when unreachable.
 func (c *RESTChainTxClient) GetTxEscrowID(ctx context.Context, txHash string) (uint64, bool, error) {
@@ -131,7 +135,7 @@ func (c *RESTChainTxClient) GetTxEscrowID(ctx context.Context, txHash string) (u
 		err := c.getJSONFromBaseURL(ctx, baseURL, "/cosmos/tx/v1beta1/txs/"+url.PathEscape(txHash), &payload)
 		if err != nil {
 			if isNotFoundError(err) {
-				return 0, false, nil // tx never landed → no escrow created
+				return 0, false, errTxNotFound // not on chain (yet) — caller decides by age
 			}
 			lastErr = fmt.Errorf("%s: %w", baseURL, err)
 			continue

--- a/devshard/cmd/devshardctl/chain_tx_rest.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest.go
@@ -130,12 +130,14 @@ var errTxNotFound = errors.New("tx not found on chain")
 // found=false when the tx is absent or failed (no escrow), error when unreachable.
 func (c *RESTChainTxClient) GetTxEscrowID(ctx context.Context, txHash string) (uint64, bool, error) {
 	var lastErr error
+	hasNotFoundError := false
 	for _, baseURL := range c.txQueryBaseURLs() {
 		var payload txResponseEnvelope
 		err := c.getJSONFromBaseURL(ctx, baseURL, "/cosmos/tx/v1beta1/txs/"+url.PathEscape(txHash), &payload)
 		if err != nil {
 			if isNotFoundError(err) {
-				return 0, false, errTxNotFound // not on chain (yet) — caller decides by age
+				hasNotFoundError = true // this endpoint lacks it; try the fallback before deciding
+				continue
 			}
 			lastErr = fmt.Errorf("%s: %w", baseURL, err)
 			continue
@@ -147,6 +149,10 @@ func (c *RESTChainTxClient) GetTxEscrowID(ctx context.Context, txHash string) (u
 			return escrowID, true, nil
 		}
 		lastErr = fmt.Errorf("tx %s committed via %s but escrow_id event was not found", txHash, baseURL)
+	}
+	// Only conclude "not on chain" when every reachable endpoint agreed on 404.
+	if lastErr == nil && hasNotFoundError {
+		return 0, false, errTxNotFound
 	}
 	return 0, false, lastErr
 }

--- a/devshard/cmd/devshardctl/chain_tx_rest.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -113,7 +115,39 @@ func NewRESTChainTxClient(cfg RESTChainTxConfig) (*RESTChainTxClient, error) {
 	}, nil
 }
 
-func (c *RESTChainTxClient) CreateDevshardEscrow(ctx context.Context, signer *signing.Secp256k1Signer, amount uint64, modelID string) (*CreateDevshardEscrowResult, error) {
+// txHashFromBytes returns the cosmos tx hash (uppercase-hex SHA-256 of the tx
+// bytes), computable before broadcast and equal to the hash the node returns.
+func txHashFromBytes(txBytes []byte) string {
+	sum := sha256.Sum256(txBytes)
+	return strings.ToUpper(hex.EncodeToString(sum[:]))
+}
+
+// GetTxEscrowID resolves a create tx hash to its escrow_id in one lookup;
+// found=false when the tx is absent or failed (no escrow), error when unreachable.
+func (c *RESTChainTxClient) GetTxEscrowID(ctx context.Context, txHash string) (uint64, bool, error) {
+	var lastErr error
+	for _, baseURL := range c.txQueryBaseURLs() {
+		var payload txResponseEnvelope
+		err := c.getJSONFromBaseURL(ctx, baseURL, "/cosmos/tx/v1beta1/txs/"+url.PathEscape(txHash), &payload)
+		if err != nil {
+			if isNotFoundError(err) {
+				return 0, false, nil // tx never landed → no escrow created
+			}
+			lastErr = fmt.Errorf("%s: %w", baseURL, err)
+			continue
+		}
+		if payload.TxResponse.Code != 0 {
+			return 0, false, nil // tx committed but failed → no escrow created
+		}
+		if escrowID, ok := payload.TxResponse.createdEscrowID(); ok {
+			return escrowID, true, nil
+		}
+		lastErr = fmt.Errorf("tx %s committed via %s but escrow_id event was not found", txHash, baseURL)
+	}
+	return 0, false, lastErr
+}
+
+func (c *RESTChainTxClient) CreateDevshardEscrow(ctx context.Context, signer *signing.Secp256k1Signer, amount uint64, modelID string, onPrepared func(txHash string) error) (*CreateDevshardEscrowResult, error) {
 	if c == nil {
 		return nil, fmt.Errorf("chain tx client is nil")
 	}
@@ -145,9 +179,19 @@ func (c *RESTChainTxClient) CreateDevshardEscrow(ctx context.Context, signer *si
 	if err != nil {
 		return nil, err
 	}
-	txHash, err := c.broadcastTx(ctx, txBytes)
+	// Record the intent (precomputed hash) before the irreversible broadcast; abort if it fails.
+	txHash := txHashFromBytes(txBytes)
+	if onPrepared != nil {
+		if err := onPrepared(txHash); err != nil {
+			return nil, fmt.Errorf("record escrow create intent before broadcast: %w", err)
+		}
+	}
+	broadcastHash, err := c.broadcastTx(ctx, txBytes)
 	if err != nil {
 		return nil, err
+	}
+	if !strings.EqualFold(broadcastHash, txHash) {
+		return nil, fmt.Errorf("tx hash mismatch: precomputed %s, node returned %s", txHash, broadcastHash)
 	}
 	escrowID, err := c.waitForCreatedEscrowID(ctx, txHash)
 	if err != nil {
@@ -330,6 +374,16 @@ func (c *RESTChainTxClient) getJSONFromBaseURL(ctx context.Context, baseURL, pat
 		return fmt.Errorf("GET %s status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// isNotFoundError reports whether a chain GET failed with 404 / not-found rather
+// than a transient error.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "status 404") || strings.Contains(s, "not found")
 }
 
 func (c *RESTChainTxClient) postJSON(ctx context.Context, path string, in any, out any) error {

--- a/devshard/cmd/devshardctl/chain_tx_rest_test.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest_test.go
@@ -20,6 +20,7 @@ func TestRESTChainTxClient_CreateDevshardEscrow(t *testing.T) {
 	require.NoError(t, err)
 
 	var broadcastSeen bool
+	var expectedHash string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/cosmos/auth/v1beta1/accounts/" + signer.Address():
@@ -44,18 +45,20 @@ func TestRESTChainTxClient_CreateDevshardEscrow(t *testing.T) {
 			require.NotEmpty(t, txBytes)
 			assertUnorderedTx(t, txBytes)
 			broadcastSeen = true
+			// A real node returns SHA-256(txBytes); the client precomputes the same.
+			expectedHash = txHashFromBytes(txBytes)
 			writeTestJSON(t, w, map[string]any{
 				"tx_response": map[string]any{
 					"code":   0,
-					"txhash": "ABC123",
+					"txhash": expectedHash,
 				},
 			})
-		case "/cosmos/tx/v1beta1/txs/ABC123":
+		case "/cosmos/tx/v1beta1/txs/" + expectedHash:
 			require.True(t, broadcastSeen)
 			writeTestJSON(t, w, map[string]any{
 				"tx_response": map[string]any{
 					"code":   0,
-					"txhash": "ABC123",
+					"txhash": expectedHash,
 					"events": []map[string]any{{
 						"type": "devshard_escrow_created",
 						"attributes": []map[string]string{{
@@ -81,10 +84,11 @@ func TestRESTChainTxClient_CreateDevshardEscrow(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	result, err := client.CreateDevshardEscrow(t.Context(), signer, 1_000_000, "Qwen/Test")
+	result, err := client.CreateDevshardEscrow(t.Context(), signer, 1_000_000, "Qwen/Test", nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(42), result.EscrowID)
-	require.Equal(t, "ABC123", result.TxHash)
+	require.NotEmpty(t, expectedHash)
+	require.Equal(t, expectedHash, result.TxHash)
 	require.Equal(t, signer.Address(), result.Creator)
 }
 
@@ -93,6 +97,7 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 	require.NoError(t, err)
 
 	var broadcastSeen bool
+	var expectedHash string
 	broadcastServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/cosmos/auth/v1beta1/accounts/" + signer.Address():
@@ -116,13 +121,14 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 			require.NoError(t, err)
 			assertUnorderedTx(t, txBytes)
 			broadcastSeen = true
+			expectedHash = txHashFromBytes(txBytes)
 			writeTestJSON(t, w, map[string]any{
 				"tx_response": map[string]any{
 					"code":   0,
-					"txhash": "FALLBACK123",
+					"txhash": expectedHash,
 				},
 			})
-		case "/cosmos/tx/v1beta1/txs/FALLBACK123":
+		case "/cosmos/tx/v1beta1/txs/" + expectedHash:
 			http.Error(w, `{"code":2,"message":"transaction indexing is disabled"}`, http.StatusInternalServerError)
 		default:
 			http.NotFound(w, r)
@@ -131,12 +137,12 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 	defer broadcastServer.Close()
 
 	queryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/cosmos/tx/v1beta1/txs/FALLBACK123", r.URL.Path)
+		require.Equal(t, "/cosmos/tx/v1beta1/txs/"+expectedHash, r.URL.Path)
 		require.True(t, broadcastSeen)
 		writeTestJSON(t, w, map[string]any{
 			"tx_response": map[string]any{
 				"code":   0,
-				"txhash": "FALLBACK123",
+				"txhash": expectedHash,
 				"events": []map[string]any{{
 					"type": "devshard_escrow_created",
 					"attributes": []map[string]string{{
@@ -160,10 +166,11 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	result, err := client.CreateDevshardEscrow(t.Context(), signer, 1_000_000, "Qwen/Test")
+	result, err := client.CreateDevshardEscrow(t.Context(), signer, 1_000_000, "Qwen/Test", nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(43), result.EscrowID)
-	require.Equal(t, "FALLBACK123", result.TxHash)
+	require.NotEmpty(t, expectedHash)
+	require.Equal(t, expectedHash, result.TxHash)
 	require.Equal(t, signer.Address(), result.Creator)
 }
 

--- a/devshard/cmd/devshardctl/chain_tx_rest_test.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest_test.go
@@ -174,6 +174,92 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 	require.Equal(t, signer.Address(), result.Creator)
 }
 
+// escrowIDQueryServer returns a query endpoint that replies with a committed
+// create tx carrying an escrow_id event for txHash, and 404 for anything else.
+func escrowIDQueryServer(t *testing.T, txHash string, escrowID uint64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cosmos/tx/v1beta1/txs/"+txHash {
+			http.NotFound(w, r)
+			return
+		}
+		writeTestJSON(t, w, map[string]any{
+			"tx_response": map[string]any{
+				"code":   0,
+				"txhash": txHash,
+				"events": []map[string]any{{
+					"type":       "devshard_escrow_created",
+					"attributes": []map[string]string{{"key": "escrow_id", "value": fmt.Sprintf("%d", escrowID)}},
+				}},
+			},
+		})
+	}))
+}
+
+// TestRESTChainTxClient_GetTxEscrowIDTriesFallbackOn404 pins the recovery path:
+// when the primary node has not indexed the create tx (404), the escrow_id must
+// still be resolved from the fallback query URL rather than reported missing.
+func TestRESTChainTxClient_GetTxEscrowIDTriesFallbackOn404(t *testing.T) {
+	const txHash = "ABC123"
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r) // primary hasn't indexed the tx yet
+	}))
+	defer primary.Close()
+	fallback := escrowIDQueryServer(t, txHash, 77)
+	defer fallback.Close()
+
+	client, err := NewRESTChainTxClient(RESTChainTxConfig{BaseURL: primary.URL, TxQueryURL: fallback.URL, ChainID: "gonka-test"})
+	require.NoError(t, err)
+
+	escrowID, found, err := client.GetTxEscrowID(t.Context(), txHash)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint64(77), escrowID)
+}
+
+// TestRESTChainTxClient_GetTxEscrowIDNotFoundWhenAllEndpoints404 confirms the
+// only-after-all-endpoints semantics: errTxNotFound is returned solely when
+// every reachable endpoint agrees the tx is absent.
+func TestRESTChainTxClient_GetTxEscrowIDNotFoundWhenAllEndpoints404(t *testing.T) {
+	notFound := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { http.NotFound(w, r) }))
+	}
+	primary := notFound()
+	defer primary.Close()
+	fallback := notFound()
+	defer fallback.Close()
+
+	client, err := NewRESTChainTxClient(RESTChainTxConfig{BaseURL: primary.URL, TxQueryURL: fallback.URL, ChainID: "gonka-test"})
+	require.NoError(t, err)
+
+	_, found, err := client.GetTxEscrowID(t.Context(), "ABC123")
+	require.False(t, found)
+	require.ErrorIs(t, err, errTxNotFound)
+}
+
+// TestRESTChainTxClient_GetTxEscrowIDInconclusiveOnFallbackError guards against
+// orphaning: a 404 on the primary plus a real error on the fallback is
+// inconclusive, so a non-errTxNotFound error is returned and the caller keeps
+// the commitment for a later retry instead of clearing it.
+func TestRESTChainTxClient_GetTxEscrowIDInconclusiveOnFallbackError(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer primary.Close()
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"transaction indexing is disabled"}`, http.StatusInternalServerError)
+	}))
+	defer fallback.Close()
+
+	client, err := NewRESTChainTxClient(RESTChainTxConfig{BaseURL: primary.URL, TxQueryURL: fallback.URL, ChainID: "gonka-test"})
+	require.NoError(t, err)
+
+	_, found, err := client.GetTxEscrowID(t.Context(), "ABC123")
+	require.False(t, found)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errTxNotFound)
+}
+
 func TestRESTChainTxClient_SettleDevshardEscrow(t *testing.T) {
 	signer, err := signing.GenerateKey()
 	require.NoError(t, err)

--- a/devshard/cmd/devshardctl/escrow_recovery_test.go
+++ b/devshard/cmd/devshardctl/escrow_recovery_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The root-cause layer: the gateway store must open in WAL with a busy timeout
+// so concurrent writes wait instead of failing with "database is locked".
+func TestGatewayStoreUsesWALAndBusyTimeout(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	var journalMode string
+	require.NoError(t, store.db.QueryRow("PRAGMA journal_mode").Scan(&journalMode))
+	assert.Equal(t, "wal", strings.ToLower(journalMode))
+
+	var busyTimeout int
+	require.NoError(t, store.db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout))
+	assert.Equal(t, 5000, busyTimeout)
+}
+
+func recoveryTestSettings() GatewaySettings {
+	return GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Enabled:           true,
+			SettlementEnabled: true,
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       "Qwen/Test",
+				TempCount:     1,
+				TargetCount:   1,
+				Amount:        1000,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+			}},
+		},
+	}.WithTuningDefaults()
+}
+
+func stubRuntimeBuilder(t *testing.T) {
+	t.Helper()
+	saved := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, _, _ string, _ *PerfTracker) (*devshardRuntime, error) {
+		return &devshardRuntime{id: cfg.ID, model: cfg.Model}, nil
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = saved })
+}
+
+// stubCreateOnChain replaces the on-chain create with a fake that mimics the real
+// flow: it invokes onPrepared(txHash) (so the commitment is written) and aborts
+// without a result if that fails — exactly as CreateDevshardEscrow does.
+func stubCreateOnChain(t *testing.T, txHash string, escrowID uint64) {
+	t.Helper()
+	saved := gatewayCreateEscrowOnChain
+	gatewayCreateEscrowOnChain = func(_ *Gateway, _ context.Context, _ GatewaySettings, _ EscrowRotationModelSettings, onPrepared func(string) error) (*CreateDevshardEscrowResult, error) {
+		if onPrepared != nil {
+			if err := onPrepared(txHash); err != nil {
+				return nil, err
+			}
+		}
+		return &CreateDevshardEscrowResult{EscrowID: escrowID, TxHash: txHash}, nil
+	}
+	t.Cleanup(func() { gatewayCreateEscrowOnChain = saved })
+}
+
+func stubQueryTxEscrowID(t *testing.T, fn func(string) (uint64, bool, error)) {
+	t.Helper()
+	saved := gatewayQueryTxEscrowID
+	gatewayQueryTxEscrowID = func(_ context.Context, _ GatewaySettings, txHash string) (uint64, bool, error) {
+		return fn(txHash)
+	}
+	t.Cleanup(func() { gatewayQueryTxEscrowID = saved })
+}
+
+func newRecoveryGateway(t *testing.T) (*Gateway, *GatewayStore, GatewaySettings) {
+	t.Helper()
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	settings := recoveryTestSettings()
+	require.NoError(t, store.Initialize(settings, nil))
+	stubRuntimeBuilder(t)
+	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{}}
+	return g, store, settings
+}
+
+func devshardIDs(t *testing.T, store *GatewayStore) map[string]GatewayDevshardState {
+	t.Helper()
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	return gatewayDevshardsByID(state.Devshards)
+}
+
+// Happy path: intent commitment is written before the chain tx, the escrow is
+// persisted, and the commitment is cleared.
+func TestCreateRotationEscrowIntentFirstThenPersistAndClear(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	stubCreateOnChain(t, "TXAAA", 777)
+	model := normalizedEscrowRotationModels(settings)[0]
+
+	_, err := g.createRotationEscrow(context.Background(), settings, model, rotationRoleTemp, 10)
+	require.NoError(t, err)
+
+	require.Contains(t, devshardIDs(t, store), "777", "escrow persisted")
+	commitments, err := store.LoadCommitments()
+	require.NoError(t, err)
+	assert.Empty(t, commitments, "commitment cleared after persist")
+}
+
+// If the intent commitment cannot be written, no chain tx is broadcast and no
+// escrow is created — the safe failure.
+func TestCreateRotationEscrowAbortsWhenCommitmentWriteFails(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	stubCreateOnChain(t, "TXBBB", 778)
+	model := normalizedEscrowRotationModels(settings)[0]
+
+	// Make every write fail, as a locked/read-only DB would.
+	_, err := store.db.Exec("PRAGMA query_only=ON")
+	require.NoError(t, err)
+
+	_, err = g.createRotationEscrow(context.Background(), settings, model, rotationRoleTemp, 10)
+	require.Error(t, err)
+
+	_, _ = store.db.Exec("PRAGMA query_only=OFF")
+	assert.NotContains(t, devshardIDs(t, store), "778", "no escrow created when intent write fails")
+	commitments, _ := store.LoadCommitments()
+	assert.Empty(t, commitments)
+}
+
+// If the post-create persist fails, the commitment survives and reconcile later
+// recovers the escrow from chain by its tx hash — escrow_id is never lost.
+func TestCreateRotationEscrowPersistFailureRecoversViaCommitment(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	stubCreateOnChain(t, "TXCCC", 888)
+	model := normalizedEscrowRotationModels(settings)[0]
+
+	// Force the persist to fail (runtime build error) on the create path.
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(RuntimeConfig, string, string, *PerfTracker) (*devshardRuntime, error) {
+		return nil, errors.New("persist boom")
+	}
+	_, err := g.createRotationEscrow(context.Background(), settings, model, rotationRoleTemp, 10)
+	require.Error(t, err)
+	gatewayRuntimeBuilder = savedBuilder // restore (stubRuntimeBuilder's success)
+
+	require.NotContains(t, devshardIDs(t, store), "888", "not persisted yet")
+	commitments, err := store.LoadCommitments()
+	require.NoError(t, err)
+	require.Len(t, commitments, 1, "commitment kept for recovery")
+	assert.Equal(t, "TXCCC", commitments[0].TxHash)
+
+	// Reconcile: chain resolves the tx hash to the escrow_id.
+	stubQueryTxEscrowID(t, func(txHash string) (uint64, bool, error) {
+		assert.Equal(t, "TXCCC", txHash)
+		return 888, true, nil
+	})
+	g.reconcileCommitments(context.Background(), settings)
+
+	assert.Contains(t, devshardIDs(t, store), "888", "recovered via commitment")
+	commitments, _ = store.LoadCommitments()
+	assert.Empty(t, commitments, "commitment cleared after recovery")
+}
+
+// Reconcile persists an escrow for a pending commitment and clears it.
+func TestReconcileCommitmentsRecoversFromChain(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{
+		TxHash: "TXDDD", Model: "Qwen/Test", Role: rotationRoleTemp, Epoch: 11, PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+	}))
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 999, true, nil })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	assert.Contains(t, devshardIDs(t, store), "999")
+	commitments, _ := store.LoadCommitments()
+	assert.Empty(t, commitments)
+}
+
+// A commitment whose tx never landed (no escrow on chain) is cleared.
+func TestReconcileCommitmentsClearsWhenTxAbsent(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{TxHash: "TXEEE", Model: "Qwen/Test", Role: rotationRoleTemp}))
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, nil })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	commitments, _ := store.LoadCommitments()
+	assert.Empty(t, commitments, "commitment cleared when no escrow exists on chain")
+}
+
+// A transient chain error leaves the commitment for the next pass.
+func TestReconcileCommitmentsKeepsCommitmentOnChainError(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{TxHash: "TXFFF", Model: "Qwen/Test", Role: rotationRoleTemp}))
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, errors.New("chain unreachable") })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	commitments, err := store.LoadCommitments()
+	require.NoError(t, err)
+	require.Len(t, commitments, 1, "commitment retained when chain cannot be queried")
+	assert.Equal(t, "TXFFF", commitments[0].TxHash)
+}

--- a/devshard/cmd/devshardctl/escrow_recovery_test.go
+++ b/devshard/cmd/devshardctl/escrow_recovery_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -188,8 +189,9 @@ func TestReconcileCommitmentsRecoversFromChain(t *testing.T) {
 	assert.Empty(t, commitments)
 }
 
-// A commitment whose tx never landed (no escrow on chain) is cleared.
-func TestReconcileCommitmentsClearsWhenTxAbsent(t *testing.T) {
+// A commitment whose tx committed but failed (no escrow created) is cleared
+// immediately — the failure is final, the tx can never produce an escrow.
+func TestReconcileCommitmentsClearsWhenTxCommittedFailed(t *testing.T) {
 	g, store, settings := newRecoveryGateway(t)
 	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{TxHash: "TXEEE", Model: "Qwen/Test", Role: rotationRoleTemp}))
 	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, nil })
@@ -197,7 +199,41 @@ func TestReconcileCommitmentsClearsWhenTxAbsent(t *testing.T) {
 	g.reconcileCommitments(context.Background(), settings)
 
 	commitments, _ := store.LoadCommitments()
-	assert.Empty(t, commitments, "commitment cleared when no escrow exists on chain")
+	assert.Empty(t, commitments, "commitment cleared when tx committed but created no escrow")
+}
+
+// A fresh commitment whose tx is not (yet) on chain must be KEPT: an unordered
+// tx can still land until its TTL elapses, and a fresh 404 is usually mempool /
+// index lag, not a failed broadcast. Clearing now would orphan a real escrow.
+func TestReconcileCommitmentsKeepsFreshTxNotFound(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{TxHash: "TXFRESH", Model: "Qwen/Test", Role: rotationRoleTemp}))
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, errTxNotFound })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	commitments, err := store.LoadCommitments()
+	require.NoError(t, err)
+	require.Len(t, commitments, 1, "fresh not-found commitment retained until its tx can no longer land")
+	assert.Equal(t, "TXFRESH", commitments[0].TxHash)
+}
+
+// Once the commitment is older than the unordered-tx window, a not-found tx can
+// never land — only then is it safe to clear.
+func TestReconcileCommitmentsClearsExpiredTxNotFound(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	old := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
+	_, err := store.db.Exec(`
+		INSERT INTO escrow_rotation_commitments (tx_hash, model, role, epoch, private_key_env, block_height, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"TXOLD", "Qwen/Test", rotationRoleTemp, 0, "", 0, old)
+	require.NoError(t, err)
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, errTxNotFound })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	commitments, _ := store.LoadCommitments()
+	assert.Empty(t, commitments, "commitment cleared once the unordered tx can no longer land")
 }
 
 // A transient chain error leaves the commitment for the next pass.

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -18,15 +18,28 @@ const (
 	rotationRoleTemp    = "temp"
 
 	defaultEscrowRotationInterval = 15 * time.Second
+
+	rotationBreakerMaxCooldownTicks = 4
+
+	escrowWriteRetries      = 10
+	escrowWriteRetryBackoff = 200 * time.Millisecond
 )
 
 var (
 	errDevshardBusy                   = errors.New("devshard has active requests")
-	errEscrowRotationCreateSuppressed = errors.New("escrow rotation create already failed for this epoch")
+	errDevshardAlreadyExists          = errors.New("devshard already exists")
+	errEscrowRotationCreateSuppressed = errors.New("escrow rotation create suppressed (backoff)")
 	gatewayCreateRotationEscrow       = (*Gateway).createRotationEscrow
+	gatewayCreateEscrowOnChain        = (*Gateway).createEscrowOnChain
 	gatewayCreateDepletionEscrow      func(*Gateway, context.Context, GatewaySettings, EscrowRotationModelSettings, string, uint64) (*CreateDevshardEscrowResult, error)
 	gatewaySettleDevshardOnChain      = (*Gateway).settleDevshardOnChain
+	gatewayQueryTxEscrowID            = defaultQueryTxEscrowID
 )
+
+type rotationBreaker struct {
+	consecutiveFailures int
+	cooldownTicks       int
+}
 
 func (g *Gateway) startEscrowRotatorIfEnabled() {
 	g.mu.Lock()
@@ -88,6 +101,7 @@ func (g *Gateway) rotateEscrowsOnce() {
 	g.mu.Lock()
 	settings := g.settings
 	g.mu.Unlock()
+	g.reconcileCommitments(context.Background(), settings)
 	rotation := settings.EscrowRotation
 	if !rotation.Enabled {
 		return
@@ -270,17 +284,18 @@ func (g *Gateway) ensureRotationEscrows(ctx context.Context, settings GatewaySet
 			return result, nil
 		}
 	}
-	if count < target && g.rotationCreateFailed(model.ModelID, role, epoch) {
+	if count < target && g.rotationCreateGated(model.ModelID, role) {
 		return result, errEscrowRotationCreateSuppressed
 	}
 	for count < target {
 		if _, err := gatewayCreateRotationEscrow(g, ctx, settings, model, role, epoch); err != nil {
-			g.recordRotationCreateFailure(model.ModelID, role, epoch)
+			g.recordRotationCreateFailure(model.ModelID, role)
 			return result, err
 		}
 		count++
 		result.CreatedCount++
 	}
+	g.resetRotationBreaker(model.ModelID, role)
 	return result, nil
 }
 
@@ -300,7 +315,7 @@ func (g *Gateway) rotationModelServedByNetwork(modelID string) (served bool, kno
 	return false, true
 }
 
-func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, role string, epoch uint64) (*CreateDevshardEscrowResult, error) {
+func (g *Gateway) createEscrowOnChain(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, onPrepared func(txHash string) error) (*CreateDevshardEscrowResult, error) {
 	signer, _, err := signerFromRequestKey("", model.PrivateKeyEnv)
 	if err != nil {
 		return nil, err
@@ -309,23 +324,34 @@ func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySett
 	if err != nil {
 		return nil, err
 	}
-	result, err := txClient.CreateDevshardEscrow(ctx, signer, model.Amount, model.ModelID)
+	return txClient.CreateDevshardEscrow(ctx, signer, model.Amount, model.ModelID, onPrepared)
+}
+
+func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, role string, epoch uint64) (*CreateDevshardEscrowResult, error) {
+	keyEnv := strings.TrimSpace(model.PrivateKeyEnv)
+	commitment := GatewayEscrowCommitment{
+		Model:         model.ModelID,
+		Role:          role,
+		Epoch:         epoch,
+		PrivateKeyEnv: keyEnv,
+		BlockHeight:   g.currentBlockHeight(),
+	}
+	// Intent-first: persist the commitment (with the precomputed tx hash) before broadcast.
+	onPrepared := func(txHash string) error {
+		c := commitment
+		c.TxHash = txHash
+		return withDBRetry(func() error { return g.store.SaveCommitment(c) })
+	}
+	result, err := gatewayCreateEscrowOnChain(g, ctx, settings, model, onPrepared)
 	if err != nil {
 		return nil, err
 	}
-	record := GatewayDevshardState{
-		RuntimeConfig: RuntimeConfig{
-			ID:            strconv.FormatUint(result.EscrowID, 10),
-			PrivateKeyEnv: strings.TrimSpace(model.PrivateKeyEnv),
-			Model:         model.ModelID,
-		},
-		Active:        true,
-		RotationRole:  role,
-		RotationEpoch: epoch,
-	}
-	if _, err := g.addCreatedEscrowRuntime(record); err != nil {
+	if err := g.persistRotationEscrow(result.EscrowID, model.ModelID, role, epoch, keyEnv); err != nil {
+		// Escrow is on chain; commitment survives → reconcile recovers it by tx hash.
+		log.Printf("escrow_rotation_persist_failed escrow=%d tx=%s model=%q error=%v recover_via_commitment=true", result.EscrowID, result.TxHash, model.ModelID, err)
 		return nil, err
 	}
+	g.clearCommitment(result.TxHash)
 	log.Printf("escrow_rotation_created role=%s epoch=%d model=%q escrow=%d tx_hash=%s", role, epoch, model.ModelID, result.EscrowID, result.TxHash)
 	return result, nil
 }
@@ -376,24 +402,145 @@ func (g *Gateway) saveRotationStatus(status GatewayRotationStatus) {
 	}
 }
 
-func (g *Gateway) rotationFailureKey(modelID, role string, epoch uint64) string {
-	return fmt.Sprintf("%s|%s|%d", strings.TrimSpace(modelID), role, epoch)
+func rotationBreakerKey(modelID, role string) string {
+	return strings.TrimSpace(modelID) + "|" + role
 }
 
-func (g *Gateway) recordRotationCreateFailure(modelID, role string, epoch uint64) {
+// rotationCreateGated reports whether create is in backoff; decrements one tick.
+func (g *Gateway) rotationCreateGated(modelID, role string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if g.rotationFailures == nil {
-		g.rotationFailures = make(map[string]struct{})
+	breaker := g.rotationBreakers[rotationBreakerKey(modelID, role)]
+	if breaker == nil || breaker.cooldownTicks <= 0 {
+		return false
 	}
-	g.rotationFailures[g.rotationFailureKey(modelID, role, epoch)] = struct{}{}
+	breaker.cooldownTicks--
+	return true
 }
 
-func (g *Gateway) rotationCreateFailed(modelID, role string, epoch uint64) bool {
+// recordRotationCreateFailure grows the per-(model,role) backoff after a failure.
+func (g *Gateway) recordRotationCreateFailure(modelID, role string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	_, ok := g.rotationFailures[g.rotationFailureKey(modelID, role, epoch)]
-	return ok
+	if g.rotationBreakers == nil {
+		g.rotationBreakers = make(map[string]*rotationBreaker)
+	}
+	key := rotationBreakerKey(modelID, role)
+	breaker := g.rotationBreakers[key]
+	if breaker == nil {
+		breaker = &rotationBreaker{}
+		g.rotationBreakers[key] = breaker
+	}
+	breaker.consecutiveFailures++
+	cooldown := 1 << (breaker.consecutiveFailures - 1)
+	if cooldown > rotationBreakerMaxCooldownTicks {
+		cooldown = rotationBreakerMaxCooldownTicks
+	}
+	breaker.cooldownTicks = cooldown
+}
+
+// resetRotationBreaker clears the backoff for a (model, role) after success.
+func (g *Gateway) resetRotationBreaker(modelID, role string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.rotationBreakers, rotationBreakerKey(modelID, role))
+}
+
+func (g *Gateway) currentBlockHeight() uint64 {
+	if g == nil || g.phaseGate == nil {
+		return 0
+	}
+	height := g.phaseGate.Snapshot().BlockHeight
+	if height < 0 {
+		return 0
+	}
+	return uint64(height)
+}
+
+// withDBRetry retries a DB write with backoff to ride out a transient lock.
+func withDBRetry(fn func() error) error {
+	var err error
+	for attempt := 0; attempt < escrowWriteRetries; attempt++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		if attempt < escrowWriteRetries-1 {
+			time.Sleep(escrowWriteRetryBackoff)
+		}
+	}
+	return err
+}
+
+// persistRotationEscrow persists + registers a created escrow ("already exists" = ok).
+func (g *Gateway) persistRotationEscrow(escrowID uint64, modelID, role string, epoch uint64, keyEnv string) error {
+	record := GatewayDevshardState{
+		RuntimeConfig: RuntimeConfig{
+			ID:            strconv.FormatUint(escrowID, 10),
+			PrivateKeyEnv: strings.TrimSpace(keyEnv),
+			Model:         modelID,
+		},
+		Active:        true,
+		RotationRole:  role,
+		RotationEpoch: epoch,
+	}
+	return withDBRetry(func() error {
+		if _, err := g.addCreatedEscrowRuntime(record); err != nil {
+			if errors.Is(err, errDevshardAlreadyExists) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	})
+}
+
+func (g *Gateway) clearCommitment(txHash string) {
+	if g == nil || g.store == nil || strings.TrimSpace(txHash) == "" {
+		return
+	}
+	if err := withDBRetry(func() error { return g.store.DeleteCommitment(txHash) }); err != nil {
+		log.Printf("escrow_rotation_commitment_clear_failed tx=%s error=%v", txHash, err)
+	}
+}
+
+// reconcileCommitments recovers escrows from pending commitments via tx hash:
+// found → persist + clear; tx absent → clear; chain error → keep for next pass.
+func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySettings) {
+	if g == nil || g.store == nil {
+		return
+	}
+	commitments, err := g.store.LoadCommitments()
+	if err != nil {
+		log.Printf("escrow_commitments_load_failed error=%v", err)
+		return
+	}
+	for _, c := range commitments {
+		escrowID, found, err := gatewayQueryTxEscrowID(ctx, settings, c.TxHash)
+		if err != nil {
+			log.Printf("escrow_commitment_tx_query_failed tx=%s model=%q error=%v", c.TxHash, c.Model, err)
+			continue // chain unreachable — retry next pass
+		}
+		if !found {
+			log.Printf("escrow_commitment_no_escrow tx=%s model=%q clearing=true", c.TxHash, c.Model)
+			g.clearCommitment(c.TxHash)
+			continue
+		}
+		if err := g.persistRotationEscrow(escrowID, c.Model, c.Role, c.Epoch, c.PrivateKeyEnv); err != nil {
+			log.Printf("escrow_commitment_persist_failed tx=%s escrow=%d model=%q error=%v", c.TxHash, escrowID, c.Model, err)
+			continue // keep commitment — retry next pass
+		}
+		g.clearCommitment(c.TxHash)
+		g.resetRotationBreaker(c.Model, c.Role)
+		log.Printf("escrow_commitment_recovered tx=%s escrow=%d model=%q role=%s", c.TxHash, escrowID, c.Model, c.Role)
+	}
+}
+
+func defaultQueryTxEscrowID(ctx context.Context, settings GatewaySettings, txHash string) (uint64, bool, error) {
+	txClient, err := newGatewayRESTChainTxClient(settings, "", "", 0, 0)
+	if err != nil {
+		return 0, false, err
+	}
+	return txClient.GetTxEscrowID(ctx, txHash)
 }
 
 func (g *Gateway) settleDevshardOnChain(ctx context.Context, id string, req adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -503,8 +503,14 @@ func (g *Gateway) clearCommitment(txHash string) {
 	}
 }
 
+// commitmentReconcileGrace is how long a not-found tx is given before the
+// commitment is cleared: the unordered-tx TTL plus margin for index lag. Until
+// it elapses, a 404 may be a pending/unindexed tx that still creates an escrow.
+const commitmentReconcileGrace = defaultUnorderedTxTTL + 2*time.Minute
+
 // reconcileCommitments recovers escrows from pending commitments via tx hash:
-// found → persist + clear; tx absent → clear; chain error → keep for next pass.
+// found → persist + clear; committed-failed → clear; not-found → clear only once
+// the tx can no longer land; chain error → keep for next pass.
 func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySettings) {
 	if g == nil || g.store == nil {
 		return
@@ -516,12 +522,23 @@ func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySett
 	}
 	for _, c := range commitments {
 		escrowID, found, err := gatewayQueryTxEscrowID(ctx, settings, c.TxHash)
+		if errors.Is(err, errTxNotFound) {
+			// Tx not on chain. An unordered tx can still land until its TTL
+			// elapses, so a fresh 404 is likely mempool/index lag — keep it.
+			if commitmentTxMayStillLand(c) {
+				log.Printf("escrow_commitment_tx_pending tx=%s model=%q", c.TxHash, c.Model)
+				continue
+			}
+			log.Printf("escrow_commitment_no_escrow tx=%s model=%q clearing=true", c.TxHash, c.Model)
+			g.clearCommitment(c.TxHash)
+			continue
+		}
 		if err != nil {
 			log.Printf("escrow_commitment_tx_query_failed tx=%s model=%q error=%v", c.TxHash, c.Model, err)
 			continue // chain unreachable — retry next pass
 		}
 		if !found {
-			log.Printf("escrow_commitment_no_escrow tx=%s model=%q clearing=true", c.TxHash, c.Model)
+			log.Printf("escrow_commitment_tx_failed tx=%s model=%q clearing=true", c.TxHash, c.Model)
 			g.clearCommitment(c.TxHash)
 			continue
 		}
@@ -533,6 +550,17 @@ func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySett
 		g.resetRotationBreaker(c.Model, c.Role)
 		log.Printf("escrow_commitment_recovered tx=%s escrow=%d model=%q role=%s", c.TxHash, escrowID, c.Model, c.Role)
 	}
+}
+
+// commitmentTxMayStillLand reports whether a not-found tx could yet be committed
+// (within the unordered-tx window) — if so, the commitment must be kept. An
+// unparseable timestamp is treated as still-pending so we never clear too early.
+func commitmentTxMayStillLand(c GatewayEscrowCommitment) bool {
+	createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.CreatedAt))
+	if err != nil {
+		return true
+	}
+	return time.Since(createdAt) <= commitmentReconcileGrace
 }
 
 func defaultQueryTxEscrowID(ctx context.Context, settings GatewaySettings, txHash string) (uint64, bool, error) {

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -56,7 +56,7 @@ type Gateway struct {
 	baseStorageDir        string
 	rotatorStop           chan struct{}
 	rotatorDone           chan struct{}
-	rotationFailures      map[string]struct{}
+	rotationBreakers      map[string]*rotationBreaker
 	finalizeMu            sync.Mutex
 	settlementMu          sync.Mutex
 	settlementInFlight    map[string]struct{}
@@ -478,7 +478,7 @@ func NewGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, defaultMod
 		settings: GatewaySettings{
 			DefaultModel: defaultModel,
 		},
-		rotationFailures:   make(map[string]struct{}),
+		rotationBreakers:   make(map[string]*rotationBreaker),
 		settlementInFlight: make(map[string]struct{}),
 	}
 	g.participantLimiter.SetMetrics(g.metrics)
@@ -526,6 +526,7 @@ func NewManagedGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, set
 	for _, rt := range g.runtimeOrder {
 		g.attachEscrowChecker(rt)
 	}
+	go g.reconcileCommitments(context.Background(), settings)
 	g.startEscrowRotatorIfEnabled()
 	// Settle escrows left pending by a pre-restart drain. Runs synchronously
 	// so the store read completes before the gateway serves traffic; the
@@ -2649,7 +2650,7 @@ func (g *Gateway) handleAdminEscrows(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusBadRequest)
 		return
 	}
-	result, err := txClient.CreateDevshardEscrow(r.Context(), signer, req.Amount, modelID)
+	result, err := txClient.CreateDevshardEscrow(r.Context(), signer, req.Amount, modelID, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusBadGateway)
 		return
@@ -2729,7 +2730,7 @@ func (g *Gateway) addCreatedEscrowRuntime(record GatewayDevshardState) (GatewayD
 		return record, fmt.Errorf("gateway state is not initialized")
 	}
 	if _, exists := g.runtimes[record.ID]; exists {
-		return record, fmt.Errorf("devshard %s already exists", record.ID)
+		return record, fmt.Errorf("devshard %s: %w", record.ID, errDevshardAlreadyExists)
 	}
 	if record.Model == "" {
 		record.Model = state.Settings.DefaultModel

--- a/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
+++ b/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
@@ -17,7 +17,7 @@ func newRetireTestGateway(id string) (*Gateway, *devshardRuntime) {
 	g := &Gateway{
 		runtimes:         map[string]*devshardRuntime{id: rt},
 		runtimeOrder:     []*devshardRuntime{rt},
-		rotationFailures: make(map[string]struct{}),
+		rotationBreakers: make(map[string]*rotationBreaker),
 	}
 	return g, rt
 }

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -314,6 +314,19 @@ func NewGatewayStore(path string) (*GatewayStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open gateway store: %w", err)
 	}
+	// Serialize access and wait on contention instead of failing with "database is
+	// locked". Mirrors storage/sqlite.go.
+	db.SetMaxOpenConns(1)
+	for _, pragma := range []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA synchronous=NORMAL",
+		"PRAGMA busy_timeout=5000",
+	} {
+		if _, err := db.Exec(pragma); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("apply gateway store pragma %q: %w", pragma, err)
+		}
+	}
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS gateway_settings (
 			id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -479,6 +492,19 @@ func NewGatewayStore(path string) (*GatewayStore, error) {
 	)`); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("init gateway suspicious hosts table: %w", err)
+	}
+	// Write-ahead intent for an escrow create (written before the on-chain tx).
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS escrow_rotation_commitments (
+		tx_hash TEXT PRIMARY KEY,
+		model TEXT NOT NULL,
+		role TEXT NOT NULL DEFAULT '',
+		epoch INTEGER NOT NULL DEFAULT 0,
+		private_key_env TEXT NOT NULL DEFAULT '',
+		block_height INTEGER NOT NULL DEFAULT 0,
+		created_at TEXT NOT NULL
+	)`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("init escrow rotation commitments table: %w", err)
 	}
 	if err := ensureColumn(db, "participant_throttle_state", "quarantine_until_utc", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		db.Close()
@@ -991,6 +1017,76 @@ func (s *GatewayStore) LoadRotationStatuses(limit int) ([]GatewayRotationStatus,
 		return nil, err
 	}
 	return statuses, nil
+}
+
+// GatewayEscrowCommitment is the write-ahead intent for one escrow create, keyed by tx hash.
+type GatewayEscrowCommitment struct {
+	TxHash        string
+	Model         string
+	Role          string
+	Epoch         uint64
+	PrivateKeyEnv string
+	BlockHeight   uint64
+	CreatedAt     string
+}
+
+// SaveCommitment records a create intent, keyed by tx hash.
+func (s *GatewayStore) SaveCommitment(c GatewayEscrowCommitment) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("gateway store unavailable")
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.db.Exec(`
+		INSERT OR REPLACE INTO escrow_rotation_commitments (
+			tx_hash, model, role, epoch, private_key_env, block_height, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		strings.TrimSpace(c.TxHash),
+		strings.TrimSpace(c.Model),
+		strings.TrimSpace(c.Role),
+		c.Epoch,
+		strings.TrimSpace(c.PrivateKeyEnv),
+		c.BlockHeight,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("save escrow commitment tx=%s: %w", c.TxHash, err)
+	}
+	return nil
+}
+
+// LoadCommitments returns all pending commitments (oldest first).
+func (s *GatewayStore) LoadCommitments() ([]GatewayEscrowCommitment, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT tx_hash, model, role, epoch, private_key_env, block_height, created_at
+		FROM escrow_rotation_commitments
+		ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("load escrow commitments: %w", err)
+	}
+	defer rows.Close()
+	var commitments []GatewayEscrowCommitment
+	for rows.Next() {
+		var c GatewayEscrowCommitment
+		if err := rows.Scan(&c.TxHash, &c.Model, &c.Role, &c.Epoch, &c.PrivateKeyEnv, &c.BlockHeight, &c.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan escrow commitment: %w", err)
+		}
+		commitments = append(commitments, c)
+	}
+	return commitments, rows.Err()
+}
+
+// DeleteCommitment clears a commitment once its escrow is persisted (or proven absent).
+func (s *GatewayStore) DeleteCommitment(txHash string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("gateway store unavailable")
+	}
+	if _, err := s.db.Exec(`DELETE FROM escrow_rotation_commitments WHERE tx_hash = ?`, strings.TrimSpace(txHash)); err != nil {
+		return fmt.Errorf("delete escrow commitment tx=%s: %w", txHash, err)
+	}
+	return nil
 }
 
 func (s *GatewayStore) LoadSuspiciousHosts() ([]GatewaySuspiciousHost, error) {

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -357,7 +357,7 @@ func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testi
 		gatewaySettleDevshardOnChain = oldSettle
 	})
 
-	g := &Gateway{store: store, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store}
 	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
@@ -422,7 +422,7 @@ func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.
 		gatewaySettleDevshardOnChain = oldSettle
 	})
 
-	g := &Gateway{store: store, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
@@ -492,7 +492,7 @@ func TestEscrowRotationSkipsCreateWhenModelAbsentFromNetwork(t *testing.T) {
 		map[string]map[string]float64{"Qwen/Present": {"host": 1}},
 	)
 
-	g := &Gateway{store: store, capacity: capacity, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store, capacity: capacity, rotationBreakers: make(map[string]*rotationBreaker)}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 0, createAttempts, "must not create escrow for a model absent from the network")
@@ -554,7 +554,7 @@ func TestEscrowRotationCreatesWhenModelPresentInNetwork(t *testing.T) {
 		map[string]map[string]float64{"Qwen/Test": {"host": 1}},
 	)
 
-	g := &Gateway{store: store, capacity: capacity, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store, capacity: capacity, rotationBreakers: make(map[string]*rotationBreaker)}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 2, createAttempts, "must create escrows for a model the network serves")
@@ -609,7 +609,7 @@ func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 		gatewaySettleDevshardOnChain = oldSettle
 	})
 
-	g := &Gateway{store: store, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 2, createAttempts)
@@ -674,7 +674,7 @@ func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenSettlementD
 
 	rt := &devshardRuntime{id: "12"}
 	rt.active.Store(true)
-	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}}
 	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
@@ -742,7 +742,7 @@ func TestEscrowRotationFinishDeactivatesTempWithoutSettlementWhenSettlementDisab
 
 	rt := &devshardRuntime{id: "12"}
 	rt.active.Store(true)
-	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
@@ -820,7 +820,7 @@ func TestEscrowRotationPrepareRotatesModelsIndependently(t *testing.T) {
 		gatewaySettleDevshardOnChain = oldSettle
 	})
 
-	g := &Gateway{store: store, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store}
 	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, []string{"13"}, settled)
@@ -883,10 +883,9 @@ func TestEscrowRotationUsesEpochSwitchHeightDuringPoC(t *testing.T) {
 	})
 
 	g := &Gateway{
-		store:            store,
-		settings:         settings,
-		phaseGate:        &ChainPhaseGate{},
-		rotationFailures: make(map[string]struct{}),
+		store:     store,
+		settings:  settings,
+		phaseGate: &ChainPhaseGate{},
 	}
 	g.phaseGate.storeSnapshot(ChainPhaseSnapshot{
 		BlockHeight:            350,


### PR DESCRIPTION
## Summary

- Auto escrow rotation created the on-chain escrow and only then persisted it; when the gateway DB write failed (e.g. `database is locked`), the escrow ID was lost, the rotator re-derived the needed count from the DB (which never saw it), and minted another escrow on chain every tick — an unbounded, fund-burning loop.
- Intent-first: before the chain tx, the gateway writes a durable commitment row to the DB — `model, role, epoch, block_height`, and the `tx_hash` precomputed from the signed bytes. If that write fails (after retries), no tx is broadcast: nothing is created, so nothing can be lost.
- Recovery via chain: after the escrow is created the result is persisted and the commitment cleared, in the same flow. If the persist fails (crash/lock after broadcast), the surviving commitment lets `reconcileCommitments` resolve the `tx_hash` to its on-chain `escrow_id` and persist it — run at startup and at the start of every rotation tick. The chain is the source of truth, queried by the precomputed hash, so losing an `escrow_id` is impossible.
- Root cause of the lock fixed: `NewGatewayStore` now opens SQLite with `journal_mode=WAL`, `synchronous=NORMAL`, `busy_timeout=5000`, and `SetMaxOpenConns(1)`, matching `perfstore.go` and `storage/sqlite.go` — the gateway store was the only one opened with defaults.
- All state lives in the DB (no sidecar file). DB writes retry with backoff; a per-`(model, role)` in-memory backoff avoids hammering a down DB/chain. No hard pause is needed — every failure is now either safe (no escrow created) or recoverable (commitment + reconcile).

| Failure point | Outcome |
| --- | --- |
| commitment write (before tx) | abort, no broadcast, no escrow — safe |
| chain broadcast | no escrow created — safe |
| persist (after tx) | commitment survives → reconcile recovers from chain |
| crash / restart anytime | startup reconcile recovers from chain |

## Why

The chain assigns the `escrow_id`, so the durable record cannot carry it before the tx. Recording the *intent* (with the precomputed `tx_hash`) before the irreversible broadcast is what makes a storage failure abort *before* any escrow is created, and a post-broadcast failure recoverable by querying the tx — the transactional-outbox pattern, reconciled against the chain rather than a local file. The cosmos tx hash equals `SHA-256` of the broadcast bytes and is computable before broadcast; a defensive check fails loudly if a node's returned hash ever differs.

State is kept in the DB rather than a sidecar journal because the gateway already cannot function without its DB, and a second store shares the same failure modes (disk full, fs errors) without adding reliability. One source of truth plus chain reconciliation also closes the broader untracked-orphan case and removes the only loss window a write-after-broadcast journal has.

`SetMaxOpenConns(1)` is safe for throughput: the hot request path never touches `gateway.db` — proxying, redundancy, and session picking use in-memory state, and perf/A-B data lives in a separate `perf.db` — so it serializes only low-frequency rotation/admin writes. Both rotation paths are covered: depletion-triggered replacement (`replaceDepletedEscrow`) calls the same `createRotationEscrow`.

Note: recovery is keyed by `tx_hash` in each gateway's own DB, so it is correct under independent gateways. A single chain key shared across gateways that create concurrently is a separate concern — cosmos account-sequence contention — and should use one key per gateway.

## Tests

- `TestCreateRotationEscrowIntentFirstThenPersistAndClear` — happy path: commitment written before the chain tx, escrow persisted, commitment cleared.
- `TestCreateRotationEscrowAbortsWhenCommitmentWriteFails` — a read-only/locked DB makes the intent write fail → no broadcast, no escrow.
- `TestCreateRotationEscrowPersistFailureRecoversViaCommitment` — persist fails after create → commitment kept → reconcile resolves the tx hash to the escrow and persists it.
- `TestReconcileCommitmentsRecoversFromChain` / `...ClearsWhenTxAbsent` / `...KeepsCommitmentOnChainError` — reconcile persists+clears when the tx is found, clears when the tx never landed, and retains the commitment on a transient chain error.
- `TestRESTChainTxClient_CreateDevshardEscrow*` — the precomputed `tx_hash` matches the node's, and `onPrepared` runs before broadcast; the mock node echoes `SHA-256(txBytes)` like a real node.
- `TestGatewayStoreUsesWALAndBusyTimeout` — the store opens in WAL with `busy_timeout=5000`.
- `go test ./cmd/devshardctl/...` green; `-race` clean on the commitment/chain suite.

## Test plan

- [x] `go test ./cmd/devshardctl/...` green; `-race` clean on the commitment/chain tests
- [x] Intent-first + chain-reconciliation proven by integration tests (real SQLite for the intent/persist paths; chain resolution stubbed at the `tx_hash → escrow_id` seam)
