### PR TITLE
fix(devshard): retire runtime escrow

### DIFF
--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -3278,6 +3278,36 @@ func removeRuntime(runtimes []*devshardRuntime, id string) []*devshardRuntime {
 	return out
 }
 
+// retireRuntime drops a runtime from the in-memory registry and closes it,
+// releasing its user. Session and the per-runtime SQLite handles that session owns.
+func (g *Gateway) retireRuntime(id, reason string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.retireRuntimeLocked(id, reason)
+}
+
+// retireRuntimeLocked is retireRuntime's body; callers must already hold g.mu.
+func (g *Gateway) retireRuntimeLocked(id, reason string) bool {
+	rt, ok := g.runtimes[id]
+	if !ok {
+		return false
+	}
+	if inFlight := rt.activeRequests.Load(); inFlight > 0 {
+		log.Printf("runtime_retire_deferred escrow=%s reason=%q active_requests=%d", id, reason, inFlight)
+		return false
+	}
+	delete(g.runtimes, id)
+	g.runtimeOrder = removeRuntime(g.runtimeOrder, id)
+	if g.capacity != nil {
+		g.capacity.RemoveEscrow(id)
+	}
+	if err := rt.close(); err != nil {
+		log.Printf("runtime_retire_close_error escrow=%s reason=%q error=%v", id, reason, err)
+	}
+	log.Printf("runtime_retired escrow=%s reason=%q", id, reason)
+	return true
+}
+
 func (g *Gateway) sortRuntimeOrderLocked() {
 	slices.SortFunc(g.runtimeOrder, func(a, b *devshardRuntime) int {
 		return strings.Compare(a.id, b.id)
@@ -3301,13 +3331,17 @@ func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
 	if g.escrowChecker != nil {
 		rt.proxy.redundancy.onEscrowMissing = func() {
 			go g.escrowChecker.TriggerCheck(escrowID, func() {
-				g.deactivateDevshardByID(escrowID)
+				if g.deactivateDevshardByID(escrowID) {
+					// Escrow no longer exists on chain -- nothing to settle.
+					g.retireRuntime(escrowID, "escrow confirmed missing on chain")
+				}
 			})
 		}
 	}
 	rt.proxy.redundancy.onBalanceExhausted = func() {
 		if !g.escrowRotationEnabled() {
 			g.deactivateDevshardByIDWithReason(escrowID, "escrow balance exhausted")
+			g.retireRuntime(escrowID, "escrow balance exhausted")
 			return
 		}
 		log.Printf("gateway_replacing_exhausted_escrow escrow=%s", escrowID)
@@ -3452,12 +3486,14 @@ func (g *Gateway) retireRotatedDevshard(ctx context.Context, id, reason string, 
 		if g.deactivateDevshardByIDWithReason(id, reason) {
 			log.Printf("escrow_rotation_deactivated_without_settlement escrow=%s reason=%q", id, reason)
 		}
+		g.retireRuntime(id, reason)
 		return false, nil
 	}
 	log.Printf("escrow_rotation_settling escrow=%s reason=%q", id, reason)
 	if _, err := gatewaySettleDevshardOnChain(g, ctx, id, adminSettleEscrowRequest{}); err != nil {
 		return false, err
 	}
+	g.retireRuntime(id, reason)
 	return true, nil
 }
 
@@ -3522,6 +3558,7 @@ func (g *Gateway) replaceDepletedEscrow(ctx context.Context, id, modelID, reason
 		id, result.EscrowID, model.ModelID, reason, result.TxHash)
 	if !settings.EscrowRotation.SettlementEnabled {
 		g.deactivateDevshardByIDWithReason(id, reason)
+		g.retireRuntime(id, reason)
 	} else {
 		g.deactivateAndSettleDevshardByID(id, reason)
 	}
@@ -3573,11 +3610,16 @@ func (g *Gateway) scheduleAutoSettlement(id, reason string) {
 				g.clearSettlementPending(id)
 				log.Printf("auto_settle_submitted escrow=%s reason=%s tx_hash=%s settler=%s",
 					id, reason, result.TxHash, result.Settler)
+				g.retireRuntime(id, reason)
 				return
 			}
 			log.Printf("auto_settle_failed escrow=%s reason=%s attempt=%d/%d error=%v",
 				id, reason, attempt, autoSettlementMaxAttempts, err)
 			if attempt == autoSettlementMaxAttempts {
+				// Settlement exhausted its retries; free the in-memory runtime
+				// anyway so a permanently-unsettleable escrow cannot leak its
+				// SQLite store. On-disk state is preserved for manual recovery.
+				g.retireRuntime(id, reason)
 				return
 			}
 			time.Sleep(autoSettlementRetryInterval)

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -91,6 +91,11 @@ type devshardRuntime struct {
 	settlementPending atomic.Bool
 	settlementReason  string
 
+	// retirePending marks a runtime whose retirement was deferred because a
+	// request was still in flight;
+	retirePending atomic.Bool
+	retireReason  string
+
 	activeConfigured bool
 }
 
@@ -1549,9 +1554,19 @@ func (g *Gateway) releaseRuntime(rt *devshardRuntime, inputTokens int64) {
 	// active=false (set during enqueue) blocks new reservations, so the count
 	// only drains downward — remaining==0 is the exact "last request finished"
 	// edge. scheduleAutoSettlement dedups, so a double-fire is harmless.
-	if remaining == 0 && rt.settlementPending.Load() {
+	if remaining != 0 {
+		return
+	}
+
+	if rt.settlementPending.Load() {
 		log.Printf("settlement_drain_complete escrow=%s reason=%s", rt.id, rt.settlementReason)
 		g.scheduleAutoSettlement(rt.id, rt.settlementReason)
+		return
+	}
+
+	if rt.retirePending.Load() {
+		log.Printf("runtime_retire_drain_complete escrow=%s reason=%s", rt.id, rt.retireReason)
+		g.retireRuntime(rt.id, rt.retireReason)
 	}
 }
 
@@ -3282,30 +3297,42 @@ func removeRuntime(runtimes []*devshardRuntime, id string) []*devshardRuntime {
 // releasing its user session and the per-runtime SQLite handles that session owns.
 func (g *Gateway) retireRuntime(id, reason string) bool {
 	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.retireRuntimeLocked(id, reason)
-}
-
-// retireRuntimeLocked is retireRuntime's body; callers must already hold g.mu.
-func (g *Gateway) retireRuntimeLocked(id, reason string) bool {
-	rt, ok := g.runtimes[id]
-	if !ok {
+	rt := g.retireRuntimeLocked(id, reason)
+	g.mu.Unlock()
+	if rt == nil {
 		return false
 	}
+	// Close the per-runtime SQLite store outside g.mu: it is disk I/O and must
+	// not block other gateway operations that contend for the lock.
+	if err := rt.close(); err != nil {
+		log.Printf("runtime_retire_close_error escrow=%s reason=%q error=%v", id, reason, err)
+	}
+	log.Printf("runtime_retired escrow=%s reason=%q", id, reason)
+	return true
+}
+
+// retireRuntimeLocked removes the runtime from the registry and returns it so
+// the caller can close it outside the lock. It returns nil when nothing was
+// retired: the runtime is unknown, or its retirement was deferred because
+// requests are still in flight. Callers must hold g.mu.
+func (g *Gateway) retireRuntimeLocked(id, reason string) *devshardRuntime {
+	rt, ok := g.runtimes[id]
+	if !ok {
+		log.Printf("runtime_retire_skipped escrow=%s reason=%q cause=not_registered", id, reason)
+		return nil
+	}
 	if inFlight := rt.activeRequests.Load(); inFlight > 0 {
+		rt.retireReason = reason
+		rt.retirePending.Store(true)
 		log.Printf("runtime_retire_deferred escrow=%s reason=%q active_requests=%d", id, reason, inFlight)
-		return false
+		return nil
 	}
 	delete(g.runtimes, id)
 	g.runtimeOrder = removeRuntime(g.runtimeOrder, id)
 	if g.capacity != nil {
 		g.capacity.RemoveEscrow(id)
 	}
-	if err := rt.close(); err != nil {
-		log.Printf("runtime_retire_close_error escrow=%s reason=%q error=%v", id, reason, err)
-	}
-	log.Printf("runtime_retired escrow=%s reason=%q", id, reason)
-	return true
+	return rt
 }
 
 func (g *Gateway) sortRuntimeOrderLocked() {
@@ -3332,8 +3359,8 @@ func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
 		rt.proxy.redundancy.onEscrowMissing = func() {
 			go g.escrowChecker.TriggerCheck(escrowID, func() {
 				g.deactivateDevshardByID(escrowID)
- 				// Escrow no longer exists on chain -- nothing to settle.
- 				g.retireRuntime(escrowID, "escrow confirmed missing on chain")
+				// Escrow no longer exists on chain -- nothing to settle.
+				g.retireRuntime(escrowID, "escrow confirmed missing on chain")
 			})
 		}
 	}

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -3279,7 +3279,7 @@ func removeRuntime(runtimes []*devshardRuntime, id string) []*devshardRuntime {
 }
 
 // retireRuntime drops a runtime from the in-memory registry and closes it,
-// releasing its user. Session and the per-runtime SQLite handles that session owns.
+// releasing its user session and the per-runtime SQLite handles that session owns.
 func (g *Gateway) retireRuntime(id, reason string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -3331,10 +3331,9 @@ func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
 	if g.escrowChecker != nil {
 		rt.proxy.redundancy.onEscrowMissing = func() {
 			go g.escrowChecker.TriggerCheck(escrowID, func() {
-				if g.deactivateDevshardByID(escrowID) {
-					// Escrow no longer exists on chain -- nothing to settle.
-					g.retireRuntime(escrowID, "escrow confirmed missing on chain")
-				}
+				g.deactivateDevshardByID(escrowID)
+ 				// Escrow no longer exists on chain -- nothing to settle.
+ 				g.retireRuntime(escrowID, "escrow confirmed missing on chain")
 			})
 		}
 	}

--- a/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
+++ b/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newRetireTestGateway builds a minimal Gateway holding a single active runtime
+// registered in both the lookup map and the ordered slice, mirroring how the
+// real registry is populated.
+func newRetireTestGateway(id string) (*Gateway, *devshardRuntime) {
+	rt := &devshardRuntime{id: id}
+	rt.active.Store(true)
+	g := &Gateway{
+		runtimes:         map[string]*devshardRuntime{id: rt},
+		runtimeOrder:     []*devshardRuntime{rt},
+		rotationFailures: make(map[string]struct{}),
+	}
+	return g, rt
+}
+
+// TestRetireRuntimeRemovesRuntimeFromRegistry pins the core leak fix: retiring a
+// runtime must drop it from both g.runtimes and g.runtimeOrder so its
+// user.Session (and the per-runtime SQLite handles it owns) can be released.
+func TestRetireRuntimeRemovesRuntimeFromRegistry(t *testing.T) {
+	g, _ := newRetireTestGateway("12")
+
+	require.True(t, g.retireRuntime("12", "test"))
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "runtime must be removed from g.runtimes")
+	require.Empty(t, g.runtimeOrder, "runtime must be removed from g.runtimeOrder")
+
+	// Idempotent: retiring an already-gone runtime is a no-op, not a panic.
+	require.False(t, g.retireRuntime("12", "test"))
+}
+
+// TestRetireRuntimeDefersWhileRequestsInFlight guards against closing a SQLite
+// store out from under an in-flight request: retirement must defer (and leave
+// the runtime registered) until the request count drains to zero.
+func TestRetireRuntimeDefersWhileRequestsInFlight(t *testing.T) {
+	g, rt := newRetireTestGateway("12")
+	rt.activeRequests.Store(1)
+
+	require.False(t, g.retireRuntime("12", "busy"))
+	_, stillRegistered := g.runtimes["12"]
+	require.True(t, stillRegistered, "busy runtime must stay registered")
+
+	rt.activeRequests.Store(0)
+	require.True(t, g.retireRuntime("12", "drained"))
+	_, stillRegistered = g.runtimes["12"]
+	require.False(t, stillRegistered)
+}
+
+// TestRetireRotatedDevshardRetiresWithoutSettlement covers the no-settle
+// terminal path: when settlement is disabled, the rotated-out runtime is
+// deactivated AND retired in the same step.
+func TestRetireRotatedDevshardRetiresWithoutSettlement(t *testing.T) {
+	g, _ := newRetireTestGateway("12")
+	settings := GatewaySettings{EscrowRotation: EscrowRotationSettings{SettlementEnabled: false}}
+
+	settled, err := g.retireRotatedDevshard(context.Background(), "12", "rotated", settings)
+	require.NoError(t, err)
+	require.False(t, settled)
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "no-settle rotation must retire the runtime")
+}
+
+// TestRetireRotatedDevshardRetiresAfterSettlement covers the settle terminal
+// path: the runtime stays alive through settlement (which reads its session)
+// and is retired only once settlement succeeds.
+func TestRetireRotatedDevshardRetiresAfterSettlement(t *testing.T) {
+	g, _ := newRetireTestGateway("12")
+	settings := GatewaySettings{EscrowRotation: EscrowRotationSettings{SettlementEnabled: true}}
+
+	oldSettle := gatewaySettleDevshardOnChain
+	gatewaySettleDevshardOnChain = func(g *Gateway, _ context.Context, id string, _ adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		// The session must still be reachable at settlement time.
+		_, ok := g.runtimes[id]
+		require.True(t, ok, "runtime must still be registered during settlement")
+		return &SettleDevshardEscrowResult{TxHash: "OK"}, nil
+	}
+	t.Cleanup(func() { gatewaySettleDevshardOnChain = oldSettle })
+
+	settled, err := g.retireRotatedDevshard(context.Background(), "12", "rotated", settings)
+	require.NoError(t, err)
+	require.True(t, settled)
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "settled rotation must retire the runtime")
+}

--- a/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
+++ b/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -47,11 +48,65 @@ func TestRetireRuntimeDefersWhileRequestsInFlight(t *testing.T) {
 	require.False(t, g.retireRuntime("12", "busy"))
 	_, stillRegistered := g.runtimes["12"]
 	require.True(t, stillRegistered, "busy runtime must stay registered")
+	require.True(t, rt.retirePending.Load(), "deferred retire must record its intent")
+	require.Equal(t, "busy", rt.retireReason)
 
 	rt.activeRequests.Store(0)
 	require.True(t, g.retireRuntime("12", "drained"))
 	_, stillRegistered = g.runtimes["12"]
 	require.False(t, stillRegistered)
+}
+
+// TestReleaseRuntimeRetiresAfterDrain: a retire deferred while busy fires once
+// the last request drains through releaseRuntime.
+func TestReleaseRuntimeRetiresAfterDrain(t *testing.T) {
+	g, rt := newRetireTestGateway("12")
+	rt.activeRequests.Store(1)
+
+	require.False(t, g.retireRuntime("12", "balance exhausted"))
+	_, stillRegistered := g.runtimes["12"]
+	require.True(t, stillRegistered, "busy runtime must stay registered")
+
+	g.releaseRuntime(rt, 0)
+
+	_, stillRegistered = g.runtimes["12"]
+	require.False(t, stillRegistered, "drained runtime must be retired by releaseRuntime")
+	require.Empty(t, g.runtimeOrder)
+}
+
+// TestReleaseRuntimeRetiresWithOnlyRetirePending exercises the retire branch in
+// isolation: only retirePending set (no settlement), drain → retire.
+func TestReleaseRuntimeRetiresWithOnlyRetirePending(t *testing.T) {
+	g, rt := newRetireTestGateway("12")
+	rt.activeRequests.Store(1)
+	rt.retireReason = "balance exhausted"
+	rt.retirePending.Store(true)
+
+	g.releaseRuntime(rt, 0)
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "retire branch must fire on drain")
+	require.Empty(t, g.runtimeOrder)
+}
+
+// TestReleaseRuntimeDefersWhileRequestsRemain: while remaining != 0 nothing
+// fires; settled stays 0 until the last request drains. Uses settlementPending
+// because scheduleAutoSettlement fires regardless of the live count, so a
+// broken guard leaks as settled>0 (retire would self-defer and hide it).
+func TestReleaseRuntimeDefersWhileRequestsRemain(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt)
+
+	g.reserveRuntime(rt, 1)
+	g.reserveRuntime(rt, 1)
+	rt.settlementReason = "low_balance"
+	rt.settlementPending.Store(true)
+
+	g.releaseRuntime(rt, 1) // remaining == 1 → quiet
+	require.Never(t, func() bool { return settled.Load() > 0 }, 200*time.Millisecond, 20*time.Millisecond)
+
+	g.releaseRuntime(rt, 1) // remaining == 0 → settles once
+	require.Eventually(t, func() bool { return settled.Load() == 1 }, time.Second, 10*time.Millisecond)
 }
 
 // TestRetireRotatedDevshardRetiresWithoutSettlement covers the no-settle

--- a/devshard/user/session_close_test.go
+++ b/devshard/user/session_close_test.go
@@ -1,0 +1,58 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/storage"
+	"devshard/types"
+)
+
+// closeCountingStore is a storage.Storage that records how many times Close is
+// called. Every other method is an inert stub: this fake exists only to prove
+// that Session.Close releases the underlying store, which is the resource the
+// per-runtime memory leak was failing to free.
+type closeCountingStore struct {
+	closeCalls int
+}
+
+func (s *closeCountingStore) CreateSession(storage.CreateSessionParams) error { return nil }
+func (s *closeCountingStore) MarkSettled(string) error                        { return nil }
+func (s *closeCountingStore) ListActiveSessions() ([]storage.ActiveSession, error) {
+	return nil, nil
+}
+func (s *closeCountingStore) AppendDiff(string, types.DiffRecord) error { return nil }
+func (s *closeCountingStore) GetDiffs(string, uint64, uint64) ([]types.DiffRecord, error) {
+	return nil, nil
+}
+func (s *closeCountingStore) AddSignature(string, uint64, uint32, []byte) error { return nil }
+func (s *closeCountingStore) GetSignatures(string, uint64) (map[uint32][]byte, error) {
+	return nil, nil
+}
+func (s *closeCountingStore) GetSessionMeta(string) (*storage.SessionMeta, error) {
+	return nil, storage.ErrSessionNotFound
+}
+func (s *closeCountingStore) MarkFinalized(string, uint64) error { return nil }
+func (s *closeCountingStore) LastFinalized(string) (uint64, error) { return 0, nil }
+func (s *closeCountingStore) SaveSnapshot(string, uint64, []byte) error { return nil }
+func (s *closeCountingStore) LoadSnapshot(string) (uint64, []byte, error) {
+	return 0, nil, storage.ErrSnapshotNotFound
+}
+func (s *closeCountingStore) PruneEpoch(uint64) error { return nil }
+func (s *closeCountingStore) Close() error {
+	s.closeCalls++
+	return nil
+}
+
+// TestSession_Close_ClosesUnderlyingStore proves the resource-release leg of the
+// leak fix: closing a Session must close the storage it owns. The gateway-side
+// tests prove rt.close() is now invoked on every automatic deactivation path;
+// this proves that invocation actually frees the SQLite store the session holds.
+func TestSession_Close_ClosesUnderlyingStore(t *testing.T) {
+	store := &closeCountingStore{}
+	session, _, _ := setupSessionWithOptions(t, 1, 1_000_000, 0, WithStorage(store))
+
+	require.NoError(t, session.Close())
+	require.Equal(t, 1, store.closeCalls, "Session.Close must close the injected storage exactly once")
+}


### PR DESCRIPTION
## Summary

Free a deactivated escrow's in-memory runtime once its in-flight requests drain. When a devshard escrow was deactivated (escrow missing on chain, balance exhausted, nonce depletion, or rotation), its `devshardRuntime` was left in the gateway registry **forever** — holding the `user.Session` and the per-runtime SQLite handle open. Over many rotations this leaks memory and file descriptors. This PR retires the runtime on every automatic deactivation path, and gates that retirement on the escrow draining to **zero** active requests, so it never closes a store out from under a live request.

- **Retire on deactivation** — `retireRuntime` drops the runtime from `g.runtimes` / `g.runtimeOrder`, removes it from capacity, and closes its session/SQLite store. Wired into every automatic deactivation path.
- **Drain-gated** — if requests are still in flight, retirement is marked `retirePending`; the last request to finish fires it from the `releaseRuntime` drain hook. Mirrors the settlement drain mechanism from #1314.
- **Settlement takes priority** — when an escrow is both settlement-pending and retire-pending, the drain edge routes to settlement (which retires the runtime itself), never a bare retire that would close the store mid-settle.
- **I/O off the lock** — the SQLite `close()` runs outside `g.mu`.

Scope: `devshard/cmd/devshardctl` (+ one `devshard/user` test). No chain, api, or ml-node changes.

---

## Problem → Solution

### 1. Deactivated escrows leaked their runtime

**Before.** Deactivation flipped `active=false` and stopped traffic, but the `devshardRuntime` stayed in the registry, keeping its `user.Session` and per-runtime SQLite handle open indefinitely. Rotation churns escrows, so handles and memory accumulated.

**After.** `retireRuntime` removes the runtime from the registry and capacity and closes its session, and is called on every automatic deactivation path: escrow-missing-on-chain, balance-exhausted (rotation disabled), rotated-out (settle and no-settle), depleted-escrow replacement (no-settle), and auto-settlement (both on success and after retries are exhausted, so a permanently-unsettleable escrow still can't leak its store — on-disk state is preserved for manual recovery).

### 2. Retiring could close a store out from under a live request

**Before.** A naive retire would `close()` the SQLite store even while requests were still reading/writing it.

**After.** `retireRuntimeLocked` returns early and records `retirePending` when `activeRequests > 0`. The drain hook in `releaseRuntime` fires the deferred retire at exactly `remaining == 0`. Because `active=false` blocks new reservations, the count only drains downward, so that is the precise "last request finished" edge. The hook is mutually exclusive with settlement: a settlement-pending escrow routes to `scheduleAutoSettlement` (which retires the runtime itself once settled), so retirement never preempts an in-flight settlement.

### 3. The close held the gateway lock

**Before.** `rt.close()` ran inside `g.mu`, so disk I/O blocked every other gateway operation contending for the lock.

**After.** `retireRuntimeLocked` performs the registry mutations under `g.mu` and returns the runtime; `retireRuntime` releases the lock and only then calls `rt.close()`.

---

## Concurrency

The drain hook in `releaseRuntime` is lock-free. `retireReason` is written before `retirePending` (under `g.mu`) and read after the atomic `retirePending.Load()` in the hook — the atomic Store→Load pair supplies the happens-before, identical to the `settlementReason`/`settlementPending` pair. `retirePending` is **not** persisted (unlike `settlementPending`): retirement only frees a live in-memory handle, and a restart reopens handles fresh, so there is nothing to reconcile. Verified clean under `go test -race`.

---

## Test plan

`go test ./cmd/devshardctl/... ./user/...` (and `-race`) — all green:

- [x] `TestRetireRuntimeRemovesRuntimeFromRegistry` — retire drops the runtime from `g.runtimes` and `g.runtimeOrder`; idempotent on a missing id.
- [x] `TestRetireRuntimeDefersWhileRequestsInFlight` — retire defers (and records intent) while busy, succeeds once the count is zero.
- [x] `TestReleaseRuntimeRetiresAfterDrain` — a deferred retire fires once the last request drains through `releaseRuntime`.
- [x] `TestReleaseRuntimeRetiresWithOnlyRetirePending` — retire branch in isolation: only `retirePending` set, drain → retire.
- [x] `TestReleaseRuntimeDefersWhileRequestsRemain` — `remaining != 0` fires nothing; the drain edge only acts at zero.
- [x] `TestRetireRotatedDevshardRetiresWithoutSettlement` / `...RetiresAfterSettlement` — rotation retires in both the no-settle and settle terminal paths.
- [x] `TestSession_Close_ClosesUnderlyingStore` — proves `Session.Close` releases the SQLite store the leak was failing to free.
- [x] `go test -race` clean — confirms the lock-free drain hook's happens-before.
