### PR TITLE
test: centralize bech32 test config to prevent sdk config races

### DIFF
--- a/inference-chain/app/tally_integration_test.go
+++ b/inference-chain/app/tally_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/productscience/inference/app"
+	"github.com/productscience/inference/testutil"
 	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
 
@@ -192,11 +193,7 @@ func TestTallyBugReproduction(t *testing.T) {
 func createTestApp(t *testing.T) *app.App {
 	t.Helper()
 
-	// Configure SDK for gonka addresses
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount("gonka", "gonkapub")
-	config.SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
-	config.SetBech32PrefixForConsensusNode("gonkavalcons", "gonkavalconspub")
+	testutil.EnsureBech32Config()
 
 	db := dbm.NewMemDB()
 	logger := log.NewNopLogger()

--- a/inference-chain/app/upgrades/v0_2_8/upgrades_test.go
+++ b/inference-chain/app/upgrades/v0_2_8/upgrades_test.go
@@ -152,7 +152,7 @@ type testMocks struct {
 }
 
 func setupTestKeeper(t *testing.T, ctrl *gomock.Controller) (keeper.Keeper, sdk.Context, testMocks) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	bankKeeper := keepertest.NewMockBookkeepingBankKeeper(ctrl)
 	bankViewKeeper := keepertest.NewMockBankKeeper(ctrl)

--- a/inference-chain/testutil/bech32.go
+++ b/inference-chain/testutil/bech32.go
@@ -1,0 +1,18 @@
+package testutil
+
+import (
+	"sync"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var bech32ConfigOnce sync.Once
+
+func EnsureBech32Config() {
+	bech32ConfigOnce.Do(func() {
+		cfg := sdk.GetConfig()
+		cfg.SetBech32PrefixForAccount("gonka", "gonkapub")
+		cfg.SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
+		cfg.SetBech32PrefixForConsensusNode("gonkavalcons", "gonkavalconspub")
+	})
+}

--- a/inference-chain/testutil/keeper/genesistransfer.go
+++ b/inference-chain/testutil/keeper/genesistransfer.go
@@ -81,8 +81,7 @@ func (m mockBookkeepingBankKeeper) SendCoinsFromModuleToAccount(ctx context.Cont
 }
 
 func GenesistransferKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
-	// Configure SDK with proper Bech32 prefix for gonka
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonkapub")
+	EnsureBech32Config()
 
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
 

--- a/inference-chain/testutil/keeper/inference.go
+++ b/inference-chain/testutil/keeper/inference.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/productscience/inference/testutil"
 	blskeeper "github.com/productscience/inference/x/bls/keeper"
 	blstypes "github.com/productscience/inference/x/bls/types"
 	"github.com/productscience/inference/x/inference/keeper"
@@ -36,15 +36,8 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-var bech32ConfigOnce sync.Once
-
-func ensureBech32Config() {
-	bech32ConfigOnce.Do(func() {
-		cfg := sdk.GetConfig()
-		cfg.SetBech32PrefixForAccount("gonka", "gonkapub")
-		cfg.SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
-		cfg.SetBech32PrefixForConsensusNode("gonkavalcons", "gonkavalconspub")
-	})
+func EnsureBech32Config() {
+	testutil.EnsureBech32Config()
 }
 
 func InferenceKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
@@ -198,7 +191,7 @@ func InferenceKeeperWithMock(
 	authzKeeper types.AuthzKeeper,
 	upgradeKeeper types.UpgradeKeeper,
 ) (keeper.Keeper, sdk.Context) {
-	ensureBech32Config()
+	EnsureBech32Config()
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
 	transientStoreKey := storetypes.NewTransientStoreKey(types.TransientStoreKey)
 	blsStoreKey := storetypes.NewKVStoreKey(blstypes.StoreKey)

--- a/inference-chain/testutil/keeper/restrictions.go
+++ b/inference-chain/testutil/keeper/restrictions.go
@@ -64,8 +64,7 @@ func (m *SimpleBankKeeper) SendCoins(ctx context.Context, fromAddr, toAddr sdk.A
 }
 
 func RestrictionsKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
-	// Configure SDK with proper Bech32 prefix for gonka
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonkapub")
+	EnsureBech32Config()
 
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
 

--- a/inference-chain/x/bls/types/validate_basic_test.go
+++ b/inference-chain/x/bls/types/validate_basic_test.go
@@ -4,16 +4,15 @@ import (
 	"testing"
 
 	errorsmod "cosmossdk.io/errors"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkbech32 "github.com/cosmos/cosmos-sdk/types/bech32"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/productscience/inference/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 // setupBech32 configures the bech32 HRP used by sdk.AccAddressFromBech32
 func setupBech32() {
-	// Use the same prefix seen in other tests in this repo
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonkapub")
+	testutil.EnsureBech32Config()
 }
 
 func mkAddr(t *testing.T) string {

--- a/inference-chain/x/inference/keeper/devshard_pruning_test.go
+++ b/inference-chain/x/inference/keeper/devshard_pruning_test.go
@@ -24,7 +24,7 @@ func pruneDevshard(k keeper.Keeper, ctx sdk.Context, currentEpoch int64) error {
 
 func TestPruneDevshardData_DeletesOldEscrows(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	mock.BankKeeper.ExpectAny(ctx)
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
@@ -56,7 +56,7 @@ func TestPruneDevshardData_DeletesOldEscrows(t *testing.T) {
 
 func TestPruneDevshardData_PreservesRecentEscrows(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	mock.BankKeeper.ExpectAny(ctx)
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
@@ -81,7 +81,7 @@ func TestPruneDevshardData_PreservesRecentEscrows(t *testing.T) {
 
 func TestPruneDevshardData_HostStatsDeleted(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	mock.BankKeeper.ExpectAny(ctx)
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
@@ -121,7 +121,7 @@ func TestPruneDevshardData_HostStatsDeleted(t *testing.T) {
 
 func TestPruneDevshardData_UnsettledEscrowDistributesFunds(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
 	// Create 4 unique validators in 16 slots
@@ -173,7 +173,7 @@ func TestPruneDevshardData_UnsettledEscrowDistributesFunds(t *testing.T) {
 
 func TestPruneDevshardData_UnsettledDistributionAmounts(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
 	// Create 4 unique validators in 16 slots (4 slots each)
@@ -222,7 +222,7 @@ func TestPruneDevshardData_UnsettledDistributionAmounts(t *testing.T) {
 
 func TestPruneDevshardData_UnsettledDistributionUsesClaimRecipient(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
 	participant := sdk.AccAddress(make([]byte, 20))
@@ -257,7 +257,7 @@ func TestPruneDevshardData_UnsettledDistributionUsesClaimRecipient(t *testing.T)
 
 func TestPruneDevshardData_TracksProgress(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	mock.BankKeeper.ExpectAny(ctx)
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
@@ -304,7 +304,7 @@ func TestPruneDevshardData_TracksProgress(t *testing.T) {
 // receives 4/16, rather than an equal split across the two unique addresses.
 func TestPruneDevshardData_UnequalSlotsPaidPerSlot(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
 	addrA := sdk.AccAddress(make([]byte, 20))

--- a/inference-chain/x/inference/keeper/devshard_settlement_test.go
+++ b/inference-chain/x/inference/keeper/devshard_settlement_test.go
@@ -16,6 +16,7 @@ import (
 	dcrdecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 	"github.com/stretchr/testify/require"
 
+	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/types"
 )
@@ -122,15 +123,15 @@ func buildSettlementTestDataWithNonce(
 	}
 
 	return &types.MsgSettleDevshardEscrow{
-		Settler:    escrow.Creator,
-		EscrowId:   escrow.Id,
+		Settler:                     escrow.Creator,
+		EscrowId:                    escrow.Id,
 		StateRootAndProtocolVersion: settlementVersion,
-		StateRoot:  stateRoot[:],
-		Nonce:      nonce,
-		Fees:       fees,
-		RestHash:   restHash[:],
-		HostStats:  hostStats,
-		Signatures: sigs,
+		StateRoot:                   stateRoot[:],
+		Nonce:                       nonce,
+		Fees:                        fees,
+		RestHash:                    restHash[:],
+		HostStats:                   hostStats,
+		Signatures:                  sigs,
 	}
 }
 
@@ -199,15 +200,15 @@ func buildSettlementTestDataWithVersion(
 	}
 
 	return &types.MsgSettleDevshardEscrow{
-		Settler:    escrow.Creator,
-		EscrowId:   escrow.Id,
+		Settler:                     escrow.Creator,
+		EscrowId:                    escrow.Id,
 		StateRootAndProtocolVersion: version,
-		StateRoot:  stateRoot[:],
-		Nonce:      nonce,
-		Fees:       fees,
-		RestHash:   restHash[:],
-		HostStats:  hostStats,
-		Signatures: sigs,
+		StateRoot:                   stateRoot[:],
+		Nonce:                       nonce,
+		Fees:                        fees,
+		RestHash:                    restHash[:],
+		HostStats:                   hostStats,
+		Signatures:                  sigs,
 	}
 }
 
@@ -238,7 +239,7 @@ func makeHostStats(n int, costPerSlot uint64) []*types.DevshardSettlementHostSta
 }
 
 func TestVerifyDevshardSettlement_HappyPath(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -276,7 +277,7 @@ func TestVerifyDevshardSettlement_VersionTooLong(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_InsufficientQuorum(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -292,7 +293,7 @@ func TestVerifyDevshardSettlement_InsufficientQuorum(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_CostExceedsAmount(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -307,7 +308,7 @@ func TestVerifyDevshardSettlement_CostExceedsAmount(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_FeesExceedAmount(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -323,7 +324,7 @@ func TestVerifyDevshardSettlement_FeesExceedAmount(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_NonceExceedsLimit(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -338,7 +339,7 @@ func TestVerifyDevshardSettlement_NonceExceedsLimit(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_MissedExceedsAssignedPerSlot(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -354,7 +355,7 @@ func TestVerifyDevshardSettlement_MissedExceedsAssignedPerSlot(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_InvalidExceedsCompletedPerSlot(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -371,7 +372,7 @@ func TestVerifyDevshardSettlement_InvalidExceedsCompletedPerSlot(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_RemainderSlotMissedAllowed(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -386,7 +387,7 @@ func TestVerifyDevshardSettlement_RemainderSlotMissedAllowed(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_NonRemainderSlotMissedRejected(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -402,7 +403,7 @@ func TestVerifyDevshardSettlement_NonRemainderSlotMissedRejected(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_InvalidSignature(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 
@@ -423,7 +424,7 @@ func TestVerifyDevshardSettlement_InvalidSignature(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_WarmKeyAccepted(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	// Generate keys for signing (these are the "warm keys")
 	warmKeys, _ := generateDevshardKeys(t, keeper.DevshardGroupSize)
@@ -460,7 +461,7 @@ func TestVerifyDevshardSettlement_WarmKeyAccepted(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_WarmKeyRejected(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	warmKeys, _ := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	_, coldSlots := generateDevshardKeys(t, keeper.DevshardGroupSize)
@@ -481,7 +482,7 @@ func TestVerifyDevshardSettlement_WarmKeyRejected(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_DuplicateSignerMultiSlot(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	// One validator owns all 16 slots
 	key, err := dcrdsecp.GeneratePrivateKey()
@@ -536,7 +537,7 @@ func TestComputeDevshardHostStatsHash_Deterministic(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_DuplicateHostStatsSlotId(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -555,7 +556,7 @@ func TestVerifyDevshardSettlement_DuplicateHostStatsSlotId(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_DuplicateSlotId(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -581,7 +582,7 @@ func TestVerifyDevshardSettlement_DuplicateSlotId(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_UnsortedHostStats(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -606,7 +607,7 @@ func TestVerifyDevshardSettlement_UnsortedHostStats(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_ZeroCost(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -636,7 +637,7 @@ func TestComputeDevshardHostStatsHash_GoldenValue(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_WrongPhaseRejected(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -699,7 +700,7 @@ func TestVerifyDevshardSettlement_NilParams(t *testing.T) {
 }
 
 func TestVerifyDevshardSettlement_ApprovedVersionsRejectUnknown(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -727,7 +728,7 @@ func TestVerifyDevshardSettlement_ApprovedVersionsRejectUnknown(t *testing.T) {
 // rest_hash from any v2-specific inputs (those fields are reserved on the
 // wire; see tx.proto's MsgSettleDevshardEscrow `reserved 10, 11, 12, 13`).
 func TestVerifyDevshardSettlement_V2_HappyPath(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{
@@ -753,7 +754,7 @@ func TestVerifyDevshardSettlement_V2_HappyPath(t *testing.T) {
 // v1 message as "v2" (without re-signing) must fail the state_root check,
 // because the version_hash byte block participates in the preimage.
 func TestVerifyDevshardSettlement_VersionTagBoundByStateRoot(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	escrow := types.DevshardEscrow{

--- a/inference-chain/x/inference/keeper/ibc_wrapped_token_test.go
+++ b/inference-chain/x/inference/keeper/ibc_wrapped_token_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/x/inference/types"
@@ -101,7 +100,7 @@ func TestValidateIbcTokenForTrade(t *testing.T) {
 	// We need to use the QueryServer interface, but Keeper implements it.
 	// We can call ValidateIbcTokenForTrade directly on k.
 
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	denom := "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
 	chainId := "cosmoshub-4"

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards_atomicity_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards_atomicity_test.go
@@ -8,8 +8,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
-	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/testutil"
+	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/require"
@@ -22,7 +22,7 @@ func claimRewardsAtomicitySetup(t *testing.T) (keeper.Keeper, types.MsgServer, s
 	t.Helper()
 	k, ctx, mocks := keepertest.InferenceKeeperReturningMocks(t)
 	ms := keeper.NewMsgServerImpl(k)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	// Create mock account and use its key for signing
 	mockAccount := NewMockAccount(testutil.Creator)

--- a/inference-chain/x/inference/keeper/msg_server_create_devshard_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_create_devshard_escrow_test.go
@@ -16,7 +16,7 @@ import (
 
 func setupDevshardEscrowTest(t testing.TB) (keeper.Keeper, types.MsgServer, sdk.Context, *keepertest.InferenceMocks) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	return k, keeper.NewMsgServerImpl(k), ctx, &mock
 }
 

--- a/inference-chain/x/inference/keeper/msg_server_poc_delegation_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_delegation_test.go
@@ -3,14 +3,14 @@ package keeper_test
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/testutil"
+	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMsgSetPoCDelegation_ValidateBasic_RejectsSelfDelegation(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	msg := &types.MsgSetPoCDelegation{
 		Sender:     testutil.Creator,

--- a/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/types"
 )
@@ -38,7 +39,7 @@ func setActiveParticipantsForDevshardTest(t *testing.T, k keeper.Keeper, ctx sdk
 
 func TestSettleDevshardEscrow_FeesSplitBySlotCount(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keyH1, err := dcrdsecp.GeneratePrivateKey()
 	require.NoError(t, err)
@@ -116,7 +117,7 @@ func TestSettleDevshardEscrow_FeesSplitBySlotCount(t *testing.T) {
 
 func TestSettleDevshardEscrow_HappyPath(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys := make([]*dcrdsecp.PrivateKey, keeper.DevshardGroupSize)
 	slots := make([]string, keeper.DevshardGroupSize)
@@ -180,7 +181,7 @@ func TestSettleDevshardEscrow_HappyPath(t *testing.T) {
 
 func TestSettleDevshardEscrow_AlreadySettled(t *testing.T) {
 	k, ms, ctx, _ := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	creator := sdk.AccAddress(make([]byte, 20))
 	creator[0] = 0xBB
@@ -203,7 +204,7 @@ func TestSettleDevshardEscrow_AlreadySettled(t *testing.T) {
 
 func TestSettleDevshardEscrow_WrongSettler(t *testing.T) {
 	k, ms, ctx, _ := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	creator := sdk.AccAddress(make([]byte, 20))
 	creator[0] = 0xCC
@@ -227,7 +228,7 @@ func TestSettleDevshardEscrow_WrongSettler(t *testing.T) {
 
 func TestSettleDevshardEscrow_ZeroCostSettlement(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys := make([]*dcrdsecp.PrivateKey, keeper.DevshardGroupSize)
 	slots := make([]string, keeper.DevshardGroupSize)
@@ -274,7 +275,7 @@ func TestSettleDevshardEscrow_ZeroCostSettlement(t *testing.T) {
 
 func TestSettleDevshardEscrow_AggregatesParticipantStats(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keyH1, err := dcrdsecp.GeneratePrivateKey()
 	require.NoError(t, err)
@@ -339,7 +340,7 @@ func TestSettleDevshardEscrow_AggregatesParticipantStats(t *testing.T) {
 
 func TestSettleDevshardEscrow_AggregatesParticipantStatsWithRemainderSlots(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keyH1, err := dcrdsecp.GeneratePrivateKey()
 	require.NoError(t, err)
@@ -402,7 +403,7 @@ func TestSettleDevshardEscrow_AggregatesParticipantStatsWithRemainderSlots(t *te
 
 func TestSettleDevshardEscrow_PreviousEpochSettlementAllowedWithoutParticipantStats(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	for _, addr := range slots {
@@ -458,7 +459,7 @@ func TestSettleDevshardEscrow_PreviousEpochSettlementAllowedWithoutParticipantSt
 
 func TestSettleDevshardEscrow_PreviousEpochSettlementUsesClaimRecipient(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	key, err := dcrdsecp.GeneratePrivateKey()
 	require.NoError(t, err)
@@ -513,7 +514,7 @@ func TestSettleDevshardEscrow_PreviousEpochSettlementUsesClaimRecipient(t *testi
 
 func TestSettleDevshardEscrow_PreviousEpochSettlementDoesNotRollIntoCurrentEpochActiveParticipants(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	for _, addr := range slots {
@@ -570,7 +571,7 @@ func TestSettleDevshardEscrow_PreviousEpochSettlementDoesNotRollIntoCurrentEpoch
 
 func TestSettleDevshardEscrow_CurrentEpochInactiveParticipantPaidImmediatelyWithoutParticipantStateChange(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	for _, addr := range slots {
@@ -632,7 +633,7 @@ func TestSettleDevshardEscrow_CurrentEpochInactiveParticipantPaidImmediatelyWith
 
 func TestSettleDevshardEscrow_OlderThanPreviousEpochRejected(t *testing.T) {
 	k, ms, ctx, _ := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
 	for _, addr := range slots {
@@ -662,7 +663,7 @@ func TestSettleDevshardEscrow_OlderThanPreviousEpochRejected(t *testing.T) {
 
 func TestSettleDevshardEscrow_AllowlistBlocks(t *testing.T) {
 	k, ms, ctx, _ := setupDevshardEscrowTest(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 
 	creator := sdk.AccAddress(make([]byte, 20))
 	creator[0] = 0xCC

--- a/inference-chain/x/inference/keeper/msg_server_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_test.go
@@ -23,7 +23,7 @@ func setupMsgServerWithKeeper(k keeper.Keeper) types.MsgServer {
 
 func setupKeeperWithMocks(t testing.TB) (keeper.Keeper, types.MsgServer, sdk.Context, *keepertest.InferenceMocks) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	return k, keeper.NewMsgServerImpl(k), ctx, &mock
 }
 

--- a/inference-chain/x/inference/keeper/payment_handler_atomicity_test.go
+++ b/inference-chain/x/inference/keeper/payment_handler_atomicity_test.go
@@ -14,7 +14,7 @@ import (
 
 func vestedPaymentSetup(t *testing.T) (keeper.Keeper, sdk.Context, *keepertest.InferenceMocks) {
 	t.Helper()
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	k, ctx, mocks := keepertest.InferenceKeeperReturningMocks(t)
 	return k, ctx, &mocks
 }

--- a/inference-chain/x/inference/keeper/permissions_test.go
+++ b/inference-chain/x/inference/keeper/permissions_test.go
@@ -39,8 +39,7 @@ func (w testWasmKeeper) GetContractInfo(_ context.Context, _ sdk.AccAddress) *wa
 func setupPermissionsHarness(t *testing.T) (keeper.Keeper, types.MsgServer, sdk.Context, *keepertest.InferenceMocks) {
 	t.Helper()
 	k, ctx, mocks := keepertest.InferenceKeeperReturningMocks(t)
-	// bech32 config for tests
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	keepertest.EnsureBech32Config()
 	ms := keeper.NewMsgServerImpl(k)
 	return k, ms, ctx, &mocks
 }
@@ -216,7 +215,6 @@ func TestPermission_InvalidSignerAddress(t *testing.T) {
 
 func TestPermission_GuardianSkipsMalformedConfiguredAddress(t *testing.T) {
 	k, ms, ctx, _ := setupPermissionsHarness(t)
-	sdk.GetConfig().SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
 
 	signer := sdk.MustAccAddressFromBech32(testutil.Validator)
 	guardianOperator := sdk.ValAddress(signer).String()

--- a/inference-chain/x/inference/module/bls_integration_test.go
+++ b/inference-chain/x/inference/module/bls_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/productscience/inference/testutil"
 	keepertest "github.com/productscience/inference/testutil/keeper"
 	blskeeper "github.com/productscience/inference/x/bls/keeper"
 	blstypes "github.com/productscience/inference/x/bls/types"
@@ -72,12 +73,7 @@ var (
 
 // setupSDKConfig configures the SDK for testing if not already configured
 func setupSDKConfig() {
-	config := sdk.GetConfig()
-	// Only configure if not already configured with gonka prefix
-	if config.GetBech32AccountAddrPrefix() != "gonka" {
-		config.SetBech32PrefixForAccount("gonka", "gonkapub")
-		config.SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
-	}
+	testutil.EnsureBech32Config()
 }
 
 // setupTestAddresses generates valid bech32 addresses for testing
@@ -476,8 +472,8 @@ func TestBLSKeyGenerationPrunesExcessWarmKeys(t *testing.T) {
 		authAny, err := codectypes.NewAnyWithValue(authztypes.NewGenericAuthorization("/inference.bls.MsgSubmitDealerPart"))
 		require.NoError(t, err)
 		grants[i] = &authztypes.GrantAuthorization{
-			Granter: aliceAccAddrStr,
-			Grantee: granteeAddr.String(),
+			Granter:       aliceAccAddrStr,
+			Grantee:       granteeAddr.String(),
 			Authorization: authAny,
 		}
 		baseAcc := authtypes.NewBaseAccount(granteeAddr, warmKey.PubKey(), 0, 0)
@@ -496,10 +492,10 @@ func TestBLSKeyGenerationPrunesExcessWarmKeys(t *testing.T) {
 
 	// Setup participant
 	storedParticipant := types.Participant{
-		Index:           aliceAccAddrStr,
-		Address:         aliceAccAddrStr,
-		Weight:          100,
-		Status:          types.ParticipantStatus_ACTIVE,
+		Index:   aliceAccAddrStr,
+		Address: aliceAccAddrStr,
+		Weight:  100,
+		Status:  types.ParticipantStatus_ACTIVE,
 	}
 	k.SetParticipant(ctx, storedParticipant)
 

--- a/inference-chain/x/inference/module/chainvalidation_test.go
+++ b/inference-chain/x/inference/module/chainvalidation_test.go
@@ -26,8 +26,7 @@ var validatorOperatorAddress1 = "gonkavaloper1gcrlrhvw8kd7zr6pl92rxnc6j20chatkcx
 var validatorOperatorAddress2 = "gonkavaloper1xk89s4ymj9y20aym3xa0mz4jhdx40hewckhw0u"
 
 func TestComputeNewWeightsWithStakingValidators(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonkapub")
-	sdk.GetConfig().SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
+	testutil.EnsureBech32Config()
 
 	validatorAccAddress1, err := utils.OperatorAddressToAccAddress(validatorOperatorAddress1)
 	require.NoError(t, err, "Failed to convert operator address to account address")
@@ -318,8 +317,7 @@ func TestPostGracePeriod_PartialCollateral(t *testing.T) {
 }
 
 func TestComputeNewWeights(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonkapub")
-	sdk.GetConfig().SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
+	testutil.EnsureBech32Config()
 
 	validatorOperatorAddress := validatorOperatorAddress1
 	validatorAccAddress, err := utils.OperatorAddressToAccAddress(validatorOperatorAddress)
@@ -650,8 +648,7 @@ func setWeightDistribution(ctx sdk.Context, k keeper.Keeper, participant string,
 }
 
 func TestComputeNewWeights_AllowlistExcludesParticipant(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonkapub")
-	sdk.GetConfig().SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
+	testutil.EnsureBech32Config()
 
 	validatorAccAddress2, err := utils.OperatorAddressToAccAddress(validatorOperatorAddress2)
 	require.NoError(t, err)

--- a/inference-chain/x/inference/module/genesis_guardian_slot_reservation_precision_test.go
+++ b/inference-chain/x/inference/module/genesis_guardian_slot_reservation_precision_test.go
@@ -5,6 +5,7 @@ import (
 
 	mathsdk "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/testutil"
 	keepertest "github.com/productscience/inference/testutil/keeper"
 	inference "github.com/productscience/inference/x/inference/module"
 	"github.com/productscience/inference/x/inference/types"
@@ -68,12 +69,7 @@ func TestDecimalPrecisionPanic_Isolated(t *testing.T) {
 func TestApplyBLSGuardianSlotReservation_RepeatingDecimalPrecision(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
-	// Setup SDK config for bech32
-	config := sdk.GetConfig()
-	if config.GetBech32AccountAddrPrefix() != "gonka" {
-		config.SetBech32PrefixForAccount("gonka", "gonkapub")
-		config.SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
-	}
+	testutil.EnsureBech32Config()
 
 	// Generate valid addresses
 	guardian1AccAddr := sdk.AccAddress([]byte("guardian1___________"))
@@ -134,11 +130,7 @@ func TestApplyBLSGuardianSlotReservation_RepeatingDecimalPrecision(t *testing.T)
 func TestApplyBLSGuardianSlotReservation_PrimeWeights(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
 
-	config := sdk.GetConfig()
-	if config.GetBech32AccountAddrPrefix() != "gonka" {
-		config.SetBech32PrefixForAccount("gonka", "gonkapub")
-		config.SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
-	}
+	testutil.EnsureBech32Config()
 
 	guardian1AccAddr := sdk.AccAddress([]byte("guardian1___________"))
 	guardian1OpAddr := sdk.ValAddress(guardian1AccAddr).String()

--- a/inference-chain/x/inference/module/model_assignment_test.go
+++ b/inference-chain/x/inference/module/model_assignment_test.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/testutil"
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/utils"
 
@@ -527,12 +527,7 @@ func TestSamplePreservedForEpisode_ExcludesGuardians(t *testing.T) {
 	ctx := context.Background()
 	modelID := "model-guardian-test"
 
-	// Set bech32 prefixes so utils.OperatorAddressToAccAddress can decode the
-	// gonkavaloper... fixture below. Safe to call repeatedly across tests in
-	// this package (no Seal()).
-	cfg := sdk.GetConfig()
-	cfg.SetBech32PrefixForAccount("gonka", "gonkapub")
-	cfg.SetBech32PrefixForValidator("gonkavaloper", "gonkavaloperpub")
+	testutil.EnsureBech32Config()
 
 	// A pre-known valid gonkavaloper bech32 used in other tests in this package.
 	guardianOperator := "gonkavaloper1gcrlrhvw8kd7zr6pl92rxnc6j20chatkcx6w4t"

--- a/inference-chain/x/inference/module/weight_calculator_test.go
+++ b/inference-chain/x/inference/module/weight_calculator_test.go
@@ -404,7 +404,7 @@ func TestPoCWeightCalculator_Calculate_RejectsWhenVotingPowerIsInsufficient(t *t
 }
 
 func TestUpdateConfirmationWeightsV2_UsesPerModelWeightScaleFactor(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonkapub")
+	testutil.EnsureBech32Config()
 
 	k, ctx := newMinimalInferenceKeeper(t)
 
@@ -1004,7 +1004,7 @@ func newMinimalInferenceKeeper(t *testing.T) (keeper.Keeper, sdk.Context) {
 func newMinimalInferenceKeeperWithStub(t *testing.T) (keeper.Keeper, sdk.Context, *stubGroupKeeper) {
 	t.Helper()
 
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	testutil.EnsureBech32Config()
 
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
 	transientStoreKey := storetypes.NewTransientStoreKey(types.TransientStoreKey)

--- a/inference-chain/x/streamvesting/keeper/keeper_test.go
+++ b/inference-chain/x/streamvesting/keeper/keeper_test.go
@@ -22,7 +22,7 @@ type KeeperTestSuite struct {
 }
 
 func (suite *KeeperTestSuite) SetupTest() {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	testutil.EnsureBech32Config()
 	k, ctx, mocks := keepertest.StreamVestingKeeperWithMocks(suite.T())
 	suite.ctx = ctx
 	suite.keeper = k

--- a/inference-chain/x/streamvesting/types/msg_transfer_with_vesting_test.go
+++ b/inference-chain/x/streamvesting/types/msg_transfer_with_vesting_test.go
@@ -7,11 +7,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/productscience/inference/testutil"
 	"github.com/productscience/inference/x/streamvesting/types"
 )
 
 func init() {
-	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	testutil.EnsureBech32Config()
 }
 
 func validAddr(seed byte) string {


### PR DESCRIPTION
## Problem
Keeper tests were flaky with fatal error: concurrent map read and map write, failing CI intermittently (~1 in 3-5 runs).

## Why
Parallel tests (t.Parallel()) were creating keepers while repeatedly mutating global sdk.Config bech32 prefixes.
One test could write the config map while another was reading it during address decoding, which caused a Go runtime crash.

## Fix
Use a shared testutil.EnsureBech32Config() helper guarded by sync.Once, and route test setup through this helper instead of direct sdk.GetConfig().SetBech32Prefix* writes.
This change is test-only (production config is still initialized once at startup).

## Stack trace

```bash
fatal error: concurrent map read and map write

goroutine 2226 [running]:
internal/runtime/maps.fatal(...)
	runtime/panic.go:1046 +0x20
github.com/cosmos/cosmos-sdk/types.(*Config).GetBech32AccountAddrPrefix(...)
	gonka-ai/cosmos-sdk@v0.53.3-ps19/types/config.go:162
github.com/cosmos/cosmos-sdk/types.AccAddressFromBech32(...)
	gonka-ai/cosmos-sdk@v0.53.3-ps19/types/address.go:199 +0x48
github.com/productscience/inference/x/inference/keeper.Keeper.SetMaintenanceState(...)
	inference-chain/x/inference/keeper/maintenance.go:54 +0x5c
github.com/productscience/inference/x/inference/keeper.msgServer.ScheduleMaintenance(...)
	inference-chain/x/inference/keeper/msg_server_schedule_maintenance.go:116 +0x89c
github.com/productscience/inference/x/inference/keeper_test.TestLifecycle_NoTransitionsAtWrongHeight(...)
	inference-chain/x/inference/keeper/maintenance_test.go:503 +0x2c8
testing.tRunner(...)
	testing/testing.go:1934 +0xc8
created by testing.(*T).Run in goroutine 1
	testing/testing.go:1997 +0x364
```