### PR TITLE
fix(devshard): wire StalenessChecker into production hosts to stop non-payment

### DIFF
--- a/decentralized-api/internal/devshard/manager.go
+++ b/decentralized-api/internal/devshard/manager.go
@@ -323,7 +323,7 @@ func (m *HostManager) create(escrowID string) (*transport.Server, error) {
 	}
 
 	h, err := host.NewHost(sm, m.signer, m.engine, escrowID, group, nil,
-		m.hostOptions(escrow.EpochID)...,
+		m.hostOptions(escrow.EpochID, config.InferenceSealGraceNonces)...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create host: %w", err)
@@ -507,7 +507,7 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 	}
 
 	h, err := host.NewHost(sm, m.signer, m.engine, escrowID, meta.Group, nil,
-		m.hostOptions(meta.EpochID)...,
+		m.hostOptions(meta.EpochID, meta.Config.InferenceSealGraceNonces)...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create host: %w", err)
@@ -523,15 +523,19 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 	return srv, nil
 }
 
-// hostOptions returns the common HostOption set used when constructing a
-// host either for a fresh session or a recovered one. Keeps the option list
-// in one place so future additions (prune sink, gossip, etc.) stay symmetric.
-func (m *HostManager) hostOptions(epochID uint64) []host.HostOption {
+// hostOptions returns the common HostOption set for a fresh or recovered host.
+// graceNonces installs the StalenessChecker (host.WithGrace): the host withholds
+// its state-root signature once a host-proposed tx has gone un-sequenced past
+// the grace window, the documented "User ignores MsgFinishInference" defense.
+func (m *HostManager) hostOptions(epochID uint64, graceNonces uint32) []host.HostOption {
 	opts := []host.HostOption{
 		host.WithValidator(m.validator),
 		host.WithStorage(m.store),
 		host.WithEpochID(epochID),
 		host.WithAvailabilityProvider(m.availability),
+	}
+	if graceNonces > 0 {
+		opts = append(opts, host.WithGrace(uint64(graceNonces)))
 	}
 	if m.pruneSink != nil {
 		opts = append(opts, host.WithPruneSink(m.pruneSink))

--- a/devshard/host/finding_nonpayment_test.go
+++ b/devshard/host/finding_nonpayment_test.go
@@ -1,0 +1,95 @@
+package host
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/state"
+	"devshard/stub"
+	"devshard/types"
+)
+
+// newHostProdWiring builds a Host the way production (manager.hostOptions) does
+// after the fix: checker == nil plus host.WithGrace from the escrow-frozen
+// InferenceSealGraceNonces, so the executor withholds on a censored finish.
+func newHostProdWiring(t *testing.T, hostIdx int, hosts []*signing.Secp256k1Signer, user *signing.Secp256k1Signer, balance uint64) *Host {
+	t.Helper()
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine(
+		"escrow-1", config, group, balance, user.Address(), verifier,
+		testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, balance),
+	)
+	require.NoError(t, err)
+	engine := stub.NewInferenceEngine()
+	// Mirror fixed production wiring: checker == nil, WithGrace installed.
+	h, err := NewHost(sm, hosts[hostIdx], engine, "escrow-1", group, nil,
+		WithGrace(uint64(config.InferenceSealGraceNonces)),
+	)
+	require.NoError(t, err)
+	return h
+}
+
+// TestHost_Finding1_NonPayment_NoWithholdOnCensoredFinish is the regression
+// guard for the host non-payment fix. The user (sequencer) censors the
+// executor's MsgFinishInference -- the only tx that credits HostStats.Cost --
+// leaving the host uncredited for a delivered response. With host.WithGrace
+// wired in, the host MUST withhold its state signature once the finish goes
+// stale, denying the user the settlement quorum. This failed before the fix.
+func TestHost_Finding1_NonPayment_NoWithholdOnCensoredFinish(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+
+	// Host index 1 is the executor for inference 1 (1 % len(group) == 1).
+	const execHostIdx = 1
+	h := newHostProdWiring(t, execHostIdx, hosts, user, 100000)
+
+	// Nonce 1: user starts inference 1; executor runs it and produces a finish.
+	diff1 := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	resp, err := handleAndExecute(t, h, context.Background(), HostRequest{
+		Diffs: []types.Diff{diff1}, Nonce: 1, Payload: defaultPayload(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, findMempoolFinish(resp.Mempool),
+		"executor must produce MsgFinishInference for the work it just performed")
+
+	// Nonces 2..50: user censors the finish and advances with empty diffs,
+	// well past the grace window (floor 20).
+	var lastResp *HostResponse
+	const lastNonce = uint64(50)
+	for nonce := uint64(2); nonce <= lastNonce; nonce++ {
+		diff := testutil.SignDiff(t, user, "escrow-1", nonce, nil)
+		lastResp, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
+		require.NoError(t, err)
+	}
+
+	// The finish is still stuck in the executor's mempool, never applied.
+	require.NotNil(t, findMempoolFinish(h.MempoolTxs()),
+		"finish remains un-included after 49 nonces of censorship")
+
+	// The inference never reached Finished and the executor slot is uncredited.
+	st := h.sm.SnapshotState()
+	rec := st.Inferences[1]
+	require.NotNil(t, rec, "inference 1 must exist in state")
+	require.NotEqual(t, types.StatusFinished, rec.Status,
+		"inference never reached Finished because confirm/finish were censored")
+
+	execSlot := h.group[1%uint64(len(h.group))].SlotID
+	if hs := st.HostStats[execSlot]; hs != nil {
+		require.Equal(t, uint64(0), hs.Cost,
+			"executor uncredited (HostStats.Cost == 0) despite delivering the response")
+	}
+
+	// Regression guard: after the censored finish goes stale, the host MUST
+	// withhold its state signature. False before the fix, true after.
+	require.Nil(t, lastResp.StateSig,
+		"REGRESSION: host signed nonce %d despite its MsgFinishInference being "+
+			"censored; host.WithGrace must stay wired in manager.hostOptions.", lastNonce)
+}


### PR DESCRIPTION
## Summary
A devshard session makes the user the sole sequencer, so the executor host's only economic leverage is **withholding its state-root signature** when the user censors the executor's `MsgFinishInference` (the tx that credits the host for delivered work). That defense — the `StalenessChecker`, reachable only via `host.WithGrace` — was never wired into the production host. `HostManager` built every host with `checker == nil` and `hostOptions` omitted `WithGrace`, so the host signed **every** state root, including the final settlement root, even when its delivered-work finish was censored. This PR wires `host.WithGrace` into `hostOptions`, sourced from the escrow-frozen `InferenceSealGraceNonces`, so the executor withholds once a censored finish goes stale.

## Problem
Both production constructors passed `nil` for the checker and `hostOptions` never added `WithGrace`:

- `host.NewHost(sm, m.signer, m.engine, escrowID, group, nil, m.hostOptions(...)...)` in both `create` and `recoverStoredSession` ⇒ `h.checker == nil`.
- `signIfAccepted` only withholds when `h.checker != nil`, so the host signed unconditionally.
- `Cost` is credited **only** by `MsgFinishInference` (`applyFinishInference`, which requires status `Started`). Censoring it leaves `HostStats[slot].Cost == 0`, and `Missed` is never incremented (only an explicit timeout does that), so the victim isn't even flagged.
- At settlement, the Finalizing→Settlement drain folds non-terminal inferences with no status check, on-chain payout derives from `HostStats.Cost`, the remainder (`escrow.Amount − totalPayout`) refunds to the creator, and `VerifyDevshardSettlement` has no `Cost > 0` lower bound.

Net effect: a malicious allowlisted user takes the streamed inference output, never sequences the finish, and settles with `Cost == 0` — the host computes for free and the user is refunded the reserved compute cost (paying only per-nonce fees). Confirmed by an empirically failing host test before this change.

## Solution
`hostOptions` now takes the escrow-frozen grace and installs `host.WithGrace(InferenceSealGraceNonces)`. The grace is the governance-controlled, escrow-frozen seal grace (normalized to a floor of 20), which sits well above the honest sequencer's one-nonce inclusion latency, so honest-but-slow users do not trigger spurious withholding while a censored finish denies the user the 2/3+ settlement quorum.