### PR TITLE
fix(inference): derive devshard settlement quorum from distinct validators

### DIFF
--- a/inference-chain/x/inference/keeper/devshard_settlement.go
+++ b/inference-chain/x/inference/keeper/devshard_settlement.go
@@ -20,6 +20,10 @@ import (
 const (
 	DevshardGroupSize   = 16
 	DevshardQuorumSlots = 2*DevshardGroupSize/3 + 1
+	// DevshardMinDistinctSlotValidators is the minimum number of distinct
+	// validators an escrow's slots must resolve to at creation, so no single
+	// validator can reach settlement quorum alone.
+	DevshardMinDistinctSlotValidators = 2
 	// DevshardSettlementPhase is the phase byte appended to the state root preimage.
 	// The chain hardcodes 0x02 (Settlement) so only fully-finalized devshard states
 	// can pass verification. States at phase Active (0x00) or Finalizing (0x01)
@@ -140,9 +144,18 @@ func VerifyDevshardSettlement(escrow types.DevshardEscrow, msg *types.MsgSettleD
 	}
 	sigHash := sha256.Sum256(sigData)
 
-	// Verify signatures and count slot votes
+	// Quorum is over distinct validators, not slots: one validator can own many
+	// slots (weighted sampling with replacement) and the signed payload omits
+	// slot_id, so per-slot counting would let it meet quorum by replaying one sig.
+	distinctValidators := make(map[string]bool, len(escrow.Slots))
+	for _, addr := range escrow.Slots {
+		distinctValidators[addr] = true
+	}
+	requiredQuorum := DevshardQuorumFor(len(distinctValidators))
+
+	// Verify signatures and count distinct validator votes.
 	seenSlots := make(map[uint32]bool, len(msg.Signatures))
-	slotVotes := 0
+	votedValidators := make(map[string]bool, len(distinctValidators))
 	for _, sig := range msg.Signatures {
 		if seenSlots[sig.SlotId] {
 			return fmt.Errorf("duplicate signature for slot %d", sig.SlotId)
@@ -163,13 +176,13 @@ func VerifyDevshardSettlement(escrow types.DevshardEscrow, msg *types.MsgSettleD
 			}
 		}
 
-		slotVotes++
+		// One vote per distinct validator (keyed by cold address; warm keys fold in).
+		votedValidators[expectedAddr] = true
 	}
 
-	// Check quorum: derived from actual slot count in escrow.
-	requiredQuorum := DevshardQuorumFor(len(escrow.Slots))
-	if slotVotes < requiredQuorum {
-		return fmt.Errorf("insufficient quorum: %d slot votes, need %d", slotVotes, requiredQuorum)
+	// Check quorum: a supermajority of DISTINCT slot-validators must sign.
+	if len(votedValidators) < requiredQuorum {
+		return fmt.Errorf("insufficient quorum: %d distinct validator votes, need %d", len(votedValidators), requiredQuorum)
 	}
 
 	// Verify total cost + fees does not exceed escrow amount

--- a/inference-chain/x/inference/keeper/finding_slot_quorum_test.go
+++ b/inference-chain/x/inference/keeper/finding_slot_quorum_test.go
@@ -1,0 +1,101 @@
+package keeper_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	dcrdsecp "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// TestFinding2_DistinctValidatorQuorum is the regression guard for the
+// distinct-validator quorum fix. One validator can own most slots (weighted
+// sampling with replacement) and the signed payload omits slot_id, so before
+// the fix it could meet quorum by replaying one signature. Here 16 slots map to
+// 6 distinct validators (quorum 5): the attacker's 11 slots count as ONE vote
+// (rejected), while attacker + 4 honest = 5 distinct votes settles.
+func TestFinding2_DistinctValidatorQuorum(t *testing.T) {
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	const attackerSlots = 11 // slots 0..10
+	const honestCount = 5    // slots 11..15
+
+	attacker, err := dcrdsecp.GeneratePrivateKey()
+	require.NoError(t, err)
+	attackerAddr := cosmosAddressFromDcrdKey(attacker).String()
+
+	honestKeys := make([]*dcrdsecp.PrivateKey, honestCount)
+	slots := make([]string, keeper.DevshardGroupSize) // 16
+	for i := 0; i < attackerSlots; i++ {
+		slots[i] = attackerAddr // one validator owns a majority of slots
+	}
+	for i := 0; i < honestCount; i++ {
+		k, err := dcrdsecp.GeneratePrivateKey()
+		require.NoError(t, err)
+		honestKeys[i] = k
+		slots[attackerSlots+i] = cosmosAddressFromDcrdKey(k).String()
+	}
+
+	escrow := types.DevshardEscrow{
+		Id:      1,
+		Creator: "gonka1creator",
+		Amount:  7_000_000_000,
+		Slots:   slots,
+	}
+	hostStats := makeHostStats(keeper.DevshardGroupSize, 1_000_000)
+
+	distinct := map[string]bool{}
+	for _, a := range slots {
+		distinct[a] = true
+	}
+	require.Equal(t, 6, len(distinct), "escrow resolves to 6 distinct validators")
+	require.Equal(t, 5, keeper.DevshardQuorumFor(len(distinct)), "distinct-validator quorum is 5")
+
+	// Baseline message yields the correct state_root and the slot-independent
+	// sigHash; the attacker signs it once (SlotId 0).
+	base := buildSettlementTestData(t, escrow, []*dcrdsecp.PrivateKey{attacker}, hostStats, 0)
+	attackerSig := base.Signatures[0].Signature
+	require.Len(t, attackerSig, 65)
+
+	// Recompute the exact sigHash the chain verifies against so we can co-sign
+	// with the honest validators.
+	sigContent := &types.DevshardStateSignatureContent{
+		StateRoot: base.StateRoot,
+		EscrowId:  fmt.Sprint(escrow.Id),
+		Nonce:     base.Nonce,
+	}
+	sigData, err := sigContent.XXX_Marshal(nil, true)
+	require.NoError(t, err)
+	sigHash := sha256.Sum256(sigData)
+
+	// --- Attack: attacker reuses its single signature across all 11 owned slots.
+	forged := make([]*types.DevshardSlotSignature, 0, attackerSlots)
+	for i := 0; i < attackerSlots; i++ {
+		forged = append(forged, &types.DevshardSlotSignature{SlotId: uint32(i), Signature: attackerSig})
+	}
+	base.Signatures = forged
+	err = keeper.VerifyDevshardSettlement(escrow, base, testDevshardEscrowParams(), nil)
+	require.Error(t, err,
+		"REGRESSION: a single validator owning 11 slots must NOT meet quorum by replaying one signature")
+	require.Contains(t, err.Error(), "insufficient quorum",
+		"single validator is one distinct vote, below the 5 distinct-validator quorum")
+
+	// --- Liveness: attacker (11 slots) + 4 honest distinct validators = 5 votes -> accepted.
+	live := make([]*types.DevshardSlotSignature, 0, attackerSlots+4)
+	for i := 0; i < attackerSlots; i++ {
+		live = append(live, &types.DevshardSlotSignature{SlotId: uint32(i), Signature: attackerSig})
+	}
+	for i := 0; i < 4; i++ { // honest validators own slots 11..14
+		hs, err := signGoEthFormat(honestKeys[i], sigHash[:])
+		require.NoError(t, err)
+		live = append(live, &types.DevshardSlotSignature{SlotId: uint32(attackerSlots + i), Signature: hs})
+	}
+	base.Signatures = live
+	err = keeper.VerifyDevshardSettlement(escrow, base, testDevshardEscrowParams(), nil)
+	require.NoError(t, err, "a genuine 5-distinct-validator quorum must still settle")
+}

--- a/inference-chain/x/inference/keeper/msg_server_create_devshard_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_create_devshard_escrow.go
@@ -77,6 +77,18 @@ func (k msgServer) CreateDevshardEscrow(goCtx context.Context, msg *types.MsgCre
 		int(ep.GroupSize),
 	)
 
+	// Reject escrows whose slots resolve to too few distinct validators: slots
+	// are sampled with replacement, so a sole/dominant validator could settle
+	// alone. Reject up front rather than lock funds in an unsettleable escrow.
+	distinctValidators := make(map[string]bool, len(slots))
+	for _, addr := range slots {
+		distinctValidators[addr] = true
+	}
+	if len(distinctValidators) < DevshardMinDistinctSlotValidators {
+		return nil, fmt.Errorf("model %q epoch group too concentrated for devshard: %d distinct slot validators, need >= %d",
+			msg.ModelId, len(distinctValidators), DevshardMinDistinctSlotValidators)
+	}
+
 	creatorAddr, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		return nil, fmt.Errorf("invalid creator address: %w", err)


### PR DESCRIPTION
## Summary
A devshard escrow's settlement quorum was derived from the number of signed **slots**, not the number of distinct **validators**. Slots are assigned by weighted sampling **with replacement**, so one validator can legitimately occupy many — or all — of an escrow's 16 slots, and the per-slot signature payload commits only to `StateRoot + EscrowId + Nonce` (not the slot id). A single validator that owned `>= 11` slots could therefore reuse **one** signature across 11 slot ids and single-handedly satisfy the `11-of-16` quorum, forging settlement with no genuine multi-party agreement. This PR makes quorum count **distinct validators** and rejects escrow creation when the sampled slots resolve to too few distinct validators.

## Problem
- Quorum was `DevshardQuorumFor(len(escrow.Slots))` and the verification loop counted one vote per **slot** (`slotVotes++`), deduping only on `sig.SlotId`.
- The signed payload (`DevshardStateSignatureContent`) omits `slot_id`, so one 65-byte signature recovers to the same address for every slot that validator owns and matches `escrow.Slots[sig.SlotId]` each time.
- Escrow creation applied **no** distinct-validator floor and **no** per-validator slot cap, and sampled from model-local weights only (no abstention scaling), so a single-validator or dominant-validator model group could be fully owned by one party.

A single dominant/sole validator could thus settle an arbitrary final state, deny honest-minority slots any payout, and write per-validator epoch work-stat counters (`InferenceCount` / `MissedRequests` / `ValidatedInferences`) that feed the downtime reward gate. Confirmed by an empirical test in which one key met the `11-of-16` quorum with a single reused signature.

## Solution
Two changes:

- **`VerifyDevshardSettlement`** now derives the required quorum from the number of **distinct validators** that own slots (`DevshardQuorumFor(len(distinctValidators))`) and tallies **one vote per distinct slot-validator** (keyed by the slot's expected cold address, so a warm-key signature folds into that validator's single vote). A validator can never contribute more than one vote regardless of how many slots it owns.
- **`CreateDevshardEscrow`** rejects escrows whose sampled slots resolve to fewer than `DevshardMinDistinctSlotValidators` (2) distinct validators, so an escrow can never be created that a single party could settle alone.