### PR TITLE
fix(inference): refund creator when unsettled devshard escrow is pruned

### DIFF
--- a/inference-chain/x/inference/keeper/devshard_pruning.go
+++ b/inference-chain/x/inference/keeper/devshard_pruning.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	"context"
+	"fmt"
+	"math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
@@ -10,52 +12,27 @@ import (
 const DevshardPruningThreshold = uint64(2)
 const DevshardPruningMax = int64(100)
 
-// distributeUnsettledEscrow splits the escrowed funds equally among unique validators in the group.
-// Integer division remainder stays in the module account.
-func (k Keeper) distributeUnsettledEscrow(ctx context.Context, escrow types.DevshardEscrow) error {
-	// Count unique addresses (first pass)
-	seen := make(map[string]bool)
-	var uniqueCount uint64
-	for _, addr := range escrow.Slots {
-		if !seen[addr] {
-			seen[addr] = true
-			uniqueCount++
-		}
-	}
-
-	if uniqueCount == 0 {
+// refundUnsettledEscrow returns the full locked amount to the creator when an
+// escrow ages out unsettled. Settlement is the only proof of validator work, so
+// an unsettled escrow pays no validators; the full amount is still held by the
+// module account (the unsettled path never disbursed it) and is refunded intact.
+func (k Keeper) refundUnsettledEscrow(ctx context.Context, escrow types.DevshardEscrow) error {
+	if escrow.Amount == 0 {
 		return nil
 	}
-
-	share := escrow.Amount / uniqueCount
-	if share == 0 {
-		return nil
+	if escrow.Amount > math.MaxInt64 {
+		return fmt.Errorf("unsettled escrow %d refund amount %d exceeds max int64", escrow.Id, escrow.Amount)
 	}
-
-	// Pay in slot order (deterministic iteration over escrow.Slots)
-	paid := make(map[string]bool)
-	for _, addr := range escrow.Slots {
-		if paid[addr] {
-			continue
-		}
-		paid[addr] = true
-
-		recipient, err := sdk.AccAddressFromBech32(addr)
-		if err != nil {
-			k.LogError("invalid address in unsettled escrow", types.Pruning,
-				"escrow_id", escrow.Id, "address", addr)
-			continue
-		}
-		coins, err := types.GetCoins(int64(share))
-		if err != nil {
-			continue
-		}
-		err = k.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, recipient, coins, "devshard_escrow_unsettled_distribution")
-		if err != nil {
-			k.LogError("failed to distribute unsettled escrow funds", types.Pruning,
-				"escrow_id", escrow.Id, "address", addr, "error", err)
-		}
+	creatorAddr, err := sdk.AccAddressFromBech32(escrow.Creator)
+	if err != nil {
+		return fmt.Errorf("invalid creator address %q for unsettled escrow %d: %w", escrow.Creator, escrow.Id, err)
 	}
-
+	coins, err := types.GetCoins(int64(escrow.Amount))
+	if err != nil {
+		return fmt.Errorf("invalid refund amount for unsettled escrow %d: %w", escrow.Id, err)
+	}
+	if err := k.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, creatorAddr, coins, "devshard_escrow_unsettled_refund"); err != nil {
+		return fmt.Errorf("failed to refund unsettled escrow %d to creator %s: %w", escrow.Id, escrow.Creator, err)
+	}
 	return nil
 }

--- a/inference-chain/x/inference/keeper/devshard_pruning_test.go
+++ b/inference-chain/x/inference/keeper/devshard_pruning_test.go
@@ -119,37 +119,24 @@ func TestPruneDevshardData_HostStatsDeleted(t *testing.T) {
 	require.Equal(t, uint64(0), count)
 }
 
-func TestPruneDevshardData_UnsettledEscrowDistributesFunds(t *testing.T) {
+func TestPruneDevshardData_UnsettledEscrowRefundsCreator(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
 	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
-	// Create 4 unique validators in 16 slots
-	addr1 := sdk.AccAddress(make([]byte, 20))
-	addr1[0] = 0x01
-	addr2 := sdk.AccAddress(make([]byte, 20))
-	addr2[0] = 0x02
-	addr3 := sdk.AccAddress(make([]byte, 20))
-	addr3[0] = 0x03
-	addr4 := sdk.AccAddress(make([]byte, 20))
-	addr4[0] = 0x04
+	creator := sdk.AccAddress(make([]byte, 20))
+	creator[0] = 0xCC
 
+	// Slot ownership is irrelevant: the full amount is refunded to the creator.
 	slots := make([]string, keeper.DevshardGroupSize)
-	for i := 0; i < 4; i++ {
-		slots[i] = addr1.String()
-	}
-	for i := 4; i < 8; i++ {
-		slots[i] = addr2.String()
-	}
-	for i := 8; i < 12; i++ {
-		slots[i] = addr3.String()
-	}
-	for i := 12; i < 16; i++ {
-		slots[i] = addr4.String()
+	for i := range slots {
+		v := sdk.AccAddress(make([]byte, 20))
+		v[0] = byte(i + 1)
+		slots[i] = v.String()
 	}
 
 	escrow := &types.DevshardEscrow{
-		Creator:    "gonka1creator",
+		Creator:    creator.String(),
 		Amount:     8_000_000_000, // 8 GNK
 		Slots:      slots,
 		EpochIndex: 3,
@@ -158,11 +145,14 @@ func TestPruneDevshardData_UnsettledEscrowDistributesFunds(t *testing.T) {
 	_, err := k.StoreDevshardEscrow(ctx, escrow, 1)
 	require.NoError(t, err)
 
-	// Expect 4 payments of 2 GNK each (8 GNK / 4 unique validators)
+	// Expect a single refund of the FULL amount to the creator -- no validator
+	// distribution.
+	refund, err := types.GetCoins(8_000_000_000)
+	require.NoError(t, err)
 	mock.BankKeeper.EXPECT().
-		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, gomock.Any(), gomock.Any(), gomock.Eq("devshard_escrow_unsettled_distribution")).
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, creator, refund, gomock.Eq("devshard_escrow_unsettled_refund")).
 		Return(nil).
-		Times(4)
+		Times(1)
 
 	require.NoError(t, pruneDevshard(k, ctx, 5))
 
@@ -171,35 +161,27 @@ func TestPruneDevshardData_UnsettledEscrowDistributesFunds(t *testing.T) {
 	require.False(t, found)
 }
 
-func TestPruneDevshardData_UnsettledDistributionAmounts(t *testing.T) {
+func TestPruneDevshardData_UnsettledRefundFullAmountNoStrandedRemainder(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
 	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
-	// Create 4 unique validators in 16 slots (4 slots each)
-	addrs := make([]sdk.AccAddress, 4)
-	for i := range addrs {
-		addrs[i] = sdk.AccAddress(make([]byte, 20))
-		addrs[i][0] = byte(i + 1)
-	}
+	creator := sdk.AccAddress(make([]byte, 20))
+	creator[0] = 0xCC
 
+	// Amount is intentionally NOT divisible by the validator count, so the old
+	// equal-split would have stranded a remainder; the refund returns it all.
 	slots := make([]string, keeper.DevshardGroupSize)
-	for i := 0; i < 4; i++ {
-		slots[i] = addrs[0].String()
-	}
-	for i := 4; i < 8; i++ {
-		slots[i] = addrs[1].String()
-	}
-	for i := 8; i < 12; i++ {
-		slots[i] = addrs[2].String()
-	}
-	for i := 12; i < 16; i++ {
-		slots[i] = addrs[3].String()
+	for i := range slots {
+		v := sdk.AccAddress(make([]byte, 20))
+		v[0] = byte((i % 4) + 1)
+		slots[i] = v.String()
 	}
 
+	const amount = uint64(8_000_000_003) // not divisible by 4
 	escrow := &types.DevshardEscrow{
-		Creator:    "gonka1creator",
-		Amount:     8_000_000_000, // 8 GNK
+		Creator:    creator.String(),
+		Amount:     amount,
 		Slots:      slots,
 		EpochIndex: 3,
 		Settled:    false,
@@ -207,15 +189,13 @@ func TestPruneDevshardData_UnsettledDistributionAmounts(t *testing.T) {
 	_, err := k.StoreDevshardEscrow(ctx, escrow, 1)
 	require.NoError(t, err)
 
-	// Each of 4 validators should receive exactly 2 GNK (8 GNK / 4)
-	expectedShare, err := types.GetCoins(2_000_000_000)
+	// The entire locked amount is refunded to the creator -- nothing stranded.
+	expectedRefund, err := types.GetCoins(int64(amount))
 	require.NoError(t, err)
-
-	for _, addr := range addrs {
-		mock.BankKeeper.EXPECT().
-			SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, addr, expectedShare, gomock.Eq("devshard_escrow_unsettled_distribution")).
-			Return(nil)
-	}
+	mock.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, creator, expectedRefund, gomock.Eq("devshard_escrow_unsettled_refund")).
+		Return(nil).
+		Times(1)
 
 	require.NoError(t, pruneDevshard(k, ctx, 5))
 }

--- a/inference-chain/x/inference/keeper/pruning.go
+++ b/inference-chain/x/inference/keeper/pruning.go
@@ -253,8 +253,8 @@ func (k Keeper) GetDevshardPruner(params types.Params) Pruner[collections.Pair[u
 
 			escrow, found := k.GetDevshardEscrow(ctx, escrowID)
 			if found && !escrow.Settled {
-				if err := k.distributeUnsettledEscrow(ctx, escrow); err != nil {
-					k.LogError("failed to distribute unsettled escrow", types.Pruning,
+				if err := k.refundUnsettledEscrow(ctx, escrow); err != nil {
+					k.LogError("failed to refund unsettled escrow", types.Pruning,
 						"escrow_id", escrowID, "error", err)
 				}
 			}


### PR DESCRIPTION
## Summary
If a devshard escrow is never settled, the pruner (at `epoch + 2`) split the **entire** locked amount equally among the unique slot validators — the creator received **no refund**, and the integer-division remainder was **permanently stranded** in the module account. With no cancel/refund message, any failure to settle (lost quorum, validator withholding, client crash, or a hash-drift settlement rejection) became a total creator loss and a value-transfer to the validator group. This PR refunds the full locked amount to the creator on prune.

## Problem
- `distributeUnsettledEscrow` computed `share = escrow.Amount / uniqueValidators` and paid each unique slot validator; **no branch** sent anything to `escrow.Creator`, and `escrow.Amount % uniqueValidators` was never swept (and if `amount < uniqueValidators`, `share == 0` stranded the whole amount).
- The only devshard escrow txs are create and settle — there is **no** `CancelDevshardEscrow` / `RefundDevshardEscrow`, so "settle (needs quorum) or forfeit via prune" was the entire option set.
- Settlement is the only on-chain proof that validators performed (and were credited for) work; an unsettled escrow has no such proof, so distributing the balance to validators paid for unproven work.

## Solution
Replace the distribution with `refundUnsettledEscrow`: return the **full** `escrow.Amount` to `escrow.Creator` (bank memo `devshard_escrow_unsettled_refund`). The unsettled path never disbursed any funds — settlement, which pays validators and refunds the remainder, sets `escrow.Settled` and is therefore skipped by the pruner — so the full amount is still held by the module account and is returned to the payer intact, with nothing stranded.