### PR TITLE
Keep upgrade archives AMD64-only

### DIFF
--- a/.github/workflows/build-upgrades.yml
+++ b/.github/workflows/build-upgrades.yml
@@ -40,4 +40,4 @@ jobs:
           df -h
 
       - name: Run Makefile build
-        run: make build-for-upgrade UPGRADE_ARCHES=amd64
+        run: make build-for-upgrade

--- a/.github/workflows/publish_upgrade_binaries.yml
+++ b/.github/workflows/publish_upgrade_binaries.yml
@@ -18,11 +18,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up QEMU for arm64 upgrade packaging
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Run Makefile build
         run: VERSION="${GITHUB_REF_NAME#release/}" make build-for-upgrade
         # This should produce files in:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Make Upgrade Build
         if: ${{ inputs.enable_upgrades }}
         run: |
-          make build-for-upgrade-tests UPGRADE_ARCHES=amd64
+          make build-for-upgrade-tests
           # Fix ownership of upgrade build files
           sudo chown -R $USER:$USER public-html/ || true
 

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,6 @@ USE_REGISTRY_CACHE ?= 0
 PLATFORM ?= linux/amd64
 GOOS ?= linux
 GOARCH ?= amd64
-UPGRADE_ARCHES ?= amd64 arm64
-ifdef GITHUB_ACTIONS
-# PR-comment integration runs load the reusable workflow from main, so keep
-# upgrade test artifacts on amd64 unless a workflow explicitly overrides this.
-UPGRADE_TEST_ARCHES ?= amd64
-else
-UPGRADE_TEST_ARCHES ?= $(UPGRADE_ARCHES)
-endif
 ifeq ($(USE_REGISTRY_CACHE),1)
 _MOCK_CACHE_ARGS := --cache-from type=registry,ref=ghcr.io/gonka-ai/mock-server:buildcache --cache-to type=registry,ref=ghcr.io/gonka-ai/mock-server:buildcache,mode=min
 _MOCK_BUILD_CMD := docker buildx build --load $(_MOCK_CACHE_ARGS)
@@ -229,16 +221,12 @@ build-for-upgrade:
 	@rm -f public-html/v2/checksums.txt public-html/v2/urls.txt
 	@mkdir -p public-html/v2/inferenced public-html/v2/dapi
 	@rm -f public-html/v2/inferenced/inferenced-*.zip public-html/v2/dapi/decentralized-api-*.zip
-	@for arch in $(UPGRADE_ARCHES); do \
-		make -C inference-chain build-for-upgrade PLATFORM=linux/$$arch GOOS=linux GOARCH=$$arch; \
-		make -C decentralized-api build-for-upgrade PLATFORM=linux/$$arch GOOS=linux GOARCH=$$arch; \
-	done
+	@make -C inference-chain build-for-upgrade
+	@make -C decentralized-api build-for-upgrade
 
 build-for-upgrade-tests:
 	@rm -f public-html/v2/checksums.txt public-html/v2/urls.txt
 	@mkdir -p public-html/v2/inferenced public-html/v2/dapi
 	@rm -f public-html/v2/inferenced/inferenced-*.zip public-html/v2/dapi/decentralized-api-*.zip
-	@for arch in $(UPGRADE_TEST_ARCHES); do \
-		make -C inference-chain build-for-upgrade TESTS=1 PLATFORM=linux/$$arch GOOS=linux GOARCH=$$arch; \
-		make -C decentralized-api build-for-upgrade TESTS=1 PLATFORM=linux/$$arch GOOS=linux GOARCH=$$arch; \
-	done
+	@make -C inference-chain build-for-upgrade TESTS=1
+	@make -C decentralized-api build-for-upgrade TESTS=1

--- a/Makefile
+++ b/Makefile
@@ -221,12 +221,12 @@ build-for-upgrade:
 	@rm -f public-html/v2/checksums.txt public-html/v2/urls.txt
 	@mkdir -p public-html/v2/inferenced public-html/v2/dapi
 	@rm -f public-html/v2/inferenced/inferenced-*.zip public-html/v2/dapi/decentralized-api-*.zip
-	@make -C inference-chain build-for-upgrade
-	@make -C decentralized-api build-for-upgrade
+	@make -C inference-chain build-for-upgrade PLATFORM=linux/amd64 GOOS=linux GOARCH=amd64
+	@make -C decentralized-api build-for-upgrade PLATFORM=linux/amd64 GOOS=linux GOARCH=amd64
 
 build-for-upgrade-tests:
 	@rm -f public-html/v2/checksums.txt public-html/v2/urls.txt
 	@mkdir -p public-html/v2/inferenced public-html/v2/dapi
 	@rm -f public-html/v2/inferenced/inferenced-*.zip public-html/v2/dapi/decentralized-api-*.zip
-	@make -C inference-chain build-for-upgrade TESTS=1
-	@make -C decentralized-api build-for-upgrade TESTS=1
+	@make -C inference-chain build-for-upgrade TESTS=1 PLATFORM=linux/amd64 GOOS=linux GOARCH=amd64
+	@make -C decentralized-api build-for-upgrade TESTS=1 PLATFORM=linux/amd64 GOOS=linux GOARCH=amd64

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -139,9 +139,6 @@ build-for-upgrade:
 	@echo "--> cleaning up intermediate build output"
 	@rm -rf ./output
 
-build-for-upgrade-arm:
-	@$(MAKE) build-for-upgrade PLATFORM=linux/arm64 GOOS=linux GOARCH=arm64
-
 download-linux-deps:
 	@echo "--> Downloading static wasmvm library for Linux (x86_64)..."
 	@mkdir -p build/deps

--- a/inference-chain/Makefile
+++ b/inference-chain/Makefile
@@ -192,9 +192,6 @@ build-for-upgrade:
 	@echo "--> cleaning up intermediate build output"
 	@rm -rf ./output
 
-build-for-upgrade-arm:
-	@$(MAKE) build-for-upgrade PLATFORM=linux/arm64 GOOS=linux GOARCH=arm64
-
 #################################################
 # CROSS-COMPILATION SECTION
 #################################################


### PR DESCRIPTION
Remove the multi-arch upgrade archive loop and ARM-only workflow setup so release upgrade binaries stay on the supported AMD64 platform while preserving the separate Docker platform plumbing used by local builds.