### PR TITLE
Bridge block sync

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,5 +1,5 @@
 # Extract Geth binary from prebuilt container
-FROM ghcr.io/product-science/bridge-geth:0.2.12@sha256:57f8e07499b4798337e1a224741657aa7b06dd2669e5411854731139bb2a072c AS geth-source
+FROM ghcr.io/product-science/bridge-geth:0.2.14@sha256:1f17da5ce8ace7055c6c6b50eb88bdcaacf67893b05eee14d8fa2ab04719a1b6 AS geth-source
 
 # Extract Prysm binaries from prebuilt container  
 FROM ghcr.io/product-science/bridge-prysm:0.2.12@sha256:bdace2b516a5c502aa2e5575433f3c35986002ea3bc18e5cb54a307bf4aafa7a AS prysm-source

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,5 +1,5 @@
 # Extract Geth binary from prebuilt container
-FROM ghcr.io/product-science/bridge-geth:0.2.14@sha256:1f17da5ce8ace7055c6c6b50eb88bdcaacf67893b05eee14d8fa2ab04719a1b6 AS geth-source
+FROM ghcr.io/product-science/bridge-geth:0.2.14@sha256:34ba99ad83f1e64a550b60a4db495de649c4bc3a486db06703b98a40a1227034 AS geth-source
 
 # Extract Prysm binaries from prebuilt container  
 FROM ghcr.io/product-science/bridge-prysm:0.2.12@sha256:bdace2b516a5c502aa2e5575433f3c35986002ea3bc18e5cb54a307bf4aafa7a AS prysm-source

--- a/bridge/script.sh
+++ b/bridge/script.sh
@@ -12,6 +12,20 @@ GETH_DISCOVERY_PORT=${GETH_DISCOVERY_PORT:-$GETH_P2P_PORT}
 PRYSM_P2P_TCP_PORT=${PRYSM_P2P_TCP_PORT:-13000}
 PRYSM_P2P_UDP_PORT=${PRYSM_P2P_UDP_PORT:-12000}
 
+# Bridge continuity settings.
+# BRIDGE_GETLASTBLOCK is OPTIONAL: when unset, continuity is disabled and geth
+# behaves exactly as before (direct posting, no restarts). BRIDGE_CACHE_RANGES is
+# the in-RAM recovery window (default 4) and only matters when continuity is on.
+BRIDGE_CACHE_RANGES=${BRIDGE_CACHE_RANGES:-4}
+
+# Build the optional --bridge.getlastblock flag only when the URL is set, so an empty
+# value is never passed as a bare flag. URLs contain no spaces, so word-splitting the
+# unquoted variable into the geth invocation is safe.
+BRIDGE_GETLASTBLOCK_FLAG=""
+if [ -n "$BRIDGE_GETLASTBLOCK" ]; then
+    BRIDGE_GETLASTBLOCK_FLAG="--bridge.getlastblock $BRIDGE_GETLASTBLOCK"
+fi
+
 require_env_vars() {
     missing=false
     for var_name in "$@"; do
@@ -43,13 +57,18 @@ PRYSM_FORMATTED_LOG=/var/log/prysm/beacon.log
 
 # Determine network flags
 NETWORK_FLAGS=""
+CHAIN_ID="ethereum"
 if [ "$ETHEREUM_NETWORK" = "sepolia" ] || [ "$ETHEREUM_NETWORK" = "testnet" ]; then
     echo "Running on Sepolia testnet"
     NETWORK_FLAGS="--sepolia"
+    CHAIN_ID="sepolia"
 else
     echo "Running on Mainnet (default)"
     # Geth defaults to mainnet, no flag needed
 fi
+
+# Watchdog timer variables
+ZERO_PEERS_START_TIME=0
 
 echo "Initializing Ethereum Bridge Service Version 0.1.0"
 
@@ -188,6 +207,9 @@ start_geth() {
           --ipcdisable \
          --bridge.postblock $BRIDGE_POSTBLOCK \
          --bridge.getaddresses $BRIDGE_GETADDRESSES \
+         --bridge.chain "$CHAIN_ID" \
+         $BRIDGE_GETLASTBLOCK_FLAG \
+         --bridge.cacheranges "$BRIDGE_CACHE_RANGES" \
          --authrpc.addr 127.0.0.1 \
          --authrpc.port $GETH_AUTHRPC_PORT \
          --authrpc.jwtsecret $JWT_SECRET_PATH \
@@ -215,6 +237,9 @@ start_geth() {
                  --ipcdisable \
                  --bridge.postblock $BRIDGE_POSTBLOCK \
                  --bridge.getaddresses $BRIDGE_GETADDRESSES \
+                 --bridge.chain "$CHAIN_ID" \
+                 $BRIDGE_GETLASTBLOCK_FLAG \
+                 --bridge.cacheranges "$BRIDGE_CACHE_RANGES" \
                  --authrpc.addr 127.0.0.1 \
                  --authrpc.port $GETH_AUTHRPC_PORT \
                  --authrpc.jwtsecret $JWT_SECRET_PATH \
@@ -312,6 +337,25 @@ restart_processes() {
     fi
 }
 
+# Function to query geth peer count via JSON-RPC
+get_geth_peer_count() {
+    local resp
+    resp=$(curl -s -m 5 -X POST -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' \
+        "http://127.0.0.1:$GETH_HTTP_PORT" 2>/dev/null)
+    if [ $? -ne 0 ] || [ -z "$resp" ]; then
+        echo "-1"
+        return
+    fi
+    local hex_val
+    hex_val=$(echo "$resp" | grep -o '"result":"[^"]*"' | cut -d'"' -f4)
+    if [ -z "$hex_val" ]; then
+        echo "-1"
+        return
+    fi
+    printf "%d" "$hex_val" 2>/dev/null || echo "-1"
+}
+
 # Function to check if processes are still running and restart if needed
 check_and_restart_processes() {
     local restart_needed=false
@@ -352,6 +396,39 @@ check_and_restart_processes() {
     if [ "$restart_needed" = "true" ]; then
         echo "Restarting processes due to crash..."
         restart_processes
+        return
+    fi
+
+    # Peer count watchdog check (Mainnet only)
+    if [ "$ETHEREUM_NETWORK" != "sepolia" ] && [ "$ETHEREUM_NETWORK" != "testnet" ]; then
+        if [ -n "$GETH_PID" ] && kill -0 "$GETH_PID" 2>/dev/null; then
+            local peers
+            peers=$(get_geth_peer_count)
+            if [ "$peers" = "0" ]; then
+                if [ "$ZERO_PEERS_START_TIME" -eq 0 ]; then
+                    ZERO_PEERS_START_TIME=$(date +%s)
+                    echo "Geth peer count is zero. Starting watchdog timer..."
+                else
+                    local now
+                    now=$(date +%s)
+                    local elapsed=$((now - ZERO_PEERS_START_TIME))
+                    if [ $elapsed -ge 3600 ]; then
+                        echo "Geth has had zero peers for $elapsed seconds (>= 1 hour). Triggering watchdog restart..."
+                        ZERO_PEERS_START_TIME=0
+                        restart_processes
+                    fi
+                fi
+            else
+                if [ "$ZERO_PEERS_START_TIME" -ne 0 ]; then
+                    echo "Geth peer count recovered to $peers. Resetting watchdog timer."
+                    ZERO_PEERS_START_TIME=0
+                fi
+            fi
+        else
+            ZERO_PEERS_START_TIME=0
+        fi
+    else
+        ZERO_PEERS_START_TIME=0
     fi
 }
 

--- a/bridge/script.sh
+++ b/bridge/script.sh
@@ -13,9 +13,12 @@ PRYSM_P2P_TCP_PORT=${PRYSM_P2P_TCP_PORT:-13000}
 PRYSM_P2P_UDP_PORT=${PRYSM_P2P_UDP_PORT:-12000}
 
 # Bridge continuity settings.
-# BRIDGE_GETLASTBLOCK is OPTIONAL: when unset, continuity is disabled and geth
-# behaves exactly as before (direct posting, no restarts). BRIDGE_CACHE_RANGES is
-# the in-RAM recovery window (default 4) and only matters when continuity is on.
+# Default endpoints and beacon URL to local production API service if unset.
+BRIDGE_POSTBLOCK=${BRIDGE_POSTBLOCK:-http://api:9200/admin/v1/bridge/block}
+BRIDGE_GETADDRESSES=${BRIDGE_GETADDRESSES:-http://api:9000/v1/bridge/addresses}
+BRIDGE_GETLASTBLOCK=${BRIDGE_GETLASTBLOCK:-http://api:9000/v1/bridge/block/latest}
+BEACON_STATE_URL=${BEACON_STATE_URL:-https://beaconstate.info/}
+
 BRIDGE_CACHE_RANGES=${BRIDGE_CACHE_RANGES:-4}
 
 # Build the optional --bridge.getlastblock flag only when the URL is set, so an empty

--- a/decentralized-api/apiconfig/sqlite_store.go
+++ b/decentralized-api/apiconfig/sqlite_store.go
@@ -116,9 +116,73 @@ CREATE TABLE IF NOT EXISTS bls_dealer_openings (
   created_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f','now')),
   PRIMARY KEY(epoch_id, recipient_index, ciphertext_index)
 );
-CREATE INDEX IF NOT EXISTS idx_bls_dealer_openings_epoch_id ON bls_dealer_openings(epoch_id);`
+CREATE INDEX IF NOT EXISTS idx_bls_dealer_openings_epoch_id ON bls_dealer_openings(epoch_id);
+
+CREATE TABLE IF NOT EXISTS bridge_state (
+  chain_id TEXT PRIMARY KEY,
+  latest_block INTEGER NOT NULL,
+  updated_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f','now'))
+);`
 	_, err := db.ExecContext(ctx, stmt)
 	return err
+}
+
+// GetBridgeLatestBlock retrieves the latest successfully processed block number for a chain.
+// If the chain has no row yet, it returns (0, false, nil) to indicate an uninitialized chain.
+func GetBridgeLatestBlock(ctx context.Context, db *sql.DB, chain string) (uint64, bool, error) {
+	if db == nil {
+		return 0, false, errors.New("db is nil")
+	}
+	var latest uint64
+	err := db.QueryRowContext(ctx, "SELECT latest_block FROM bridge_state WHERE chain_id = ?", chain).Scan(&latest)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return latest, true, nil
+}
+
+// SetBridgeLatestBlock upserts the latest processed block number for a chain.
+func SetBridgeLatestBlock(ctx context.Context, db *sql.DB, chain string, blockNum uint64) error {
+	if db == nil {
+		return errors.New("db is nil")
+	}
+	_, err := db.ExecContext(ctx, `
+INSERT INTO bridge_state (chain_id, latest_block, updated_at)
+VALUES (?, ?, STRFTIME('%Y-%m-%d %H:%M:%f','now'))
+ON CONFLICT(chain_id) DO UPDATE SET
+  latest_block = excluded.latest_block,
+  updated_at = STRFTIME('%Y-%m-%d %H:%M:%f','now')
+`, chain, blockNum)
+	return err
+}
+
+// LoadAllBridgeLatestBlocks retrieves the latest block numbers for all chains as a map.
+func LoadAllBridgeLatestBlocks(ctx context.Context, db *sql.DB) (map[string]uint64, error) {
+	if db == nil {
+		return nil, errors.New("db is nil")
+	}
+	rows, err := db.QueryContext(ctx, "SELECT chain_id, latest_block FROM bridge_state")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	res := make(map[string]uint64)
+	for rows.Next() {
+		var chain string
+		var latest uint64
+		if err := rows.Scan(&chain, &latest); err != nil {
+			return nil, err
+		}
+		res[chain] = latest
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // UpsertInferenceNodes replaces or inserts the given nodes by id.

--- a/decentralized-api/cosmosclient/cosmosclient.go
+++ b/decentralized-api/cosmosclient/cosmosclient.go
@@ -271,6 +271,7 @@ type CosmosMessageClient interface {
 	SubmitUnitOfComputePriceProposal(transaction *inferenceapi.MsgSubmitUnitOfComputePriceProposal) error
 	BridgeExchange(transaction *inferencetypes.MsgBridgeExchange) error
 	GetBridgeAddresses(ctx context.Context, chainId string) ([]inferencetypes.BridgeContractAddress, error)
+	BridgeTransactionsByReceipt(ctx context.Context, originChain, blockNumber, receiptIndex string) ([]inferencetypes.BridgeTransaction, error)
 	NewInferenceQueryClient() inferencetypes.QueryClient
 	NewCometQueryClient() cmtservice.ServiceClient
 	BankBalances(ctx context.Context, address string) ([]sdk.Coin, error)
@@ -482,6 +483,18 @@ func (icc *InferenceCosmosClient) GetBridgeAddresses(ctx context.Context, chainI
 	}
 
 	return resp.Addresses, nil
+}
+
+func (icc *InferenceCosmosClient) BridgeTransactionsByReceipt(ctx context.Context, originChain, blockNumber, receiptIndex string) ([]inferencetypes.BridgeTransaction, error) {
+	resp, err := icc.NewInferenceQueryClient().BridgeTransaction(ctx, &inferencetypes.QueryGetBridgeTransactionRequest{
+		OriginChain:  originChain,
+		BlockNumber:  blockNumber,
+		ReceiptIndex: receiptIndex,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.BridgeTransactions, nil
 }
 
 func (icc *InferenceCosmosClient) SendTransactionAsyncWithRetry(msg sdk.Msg, deadlineBlock ...int64) (*sdk.TxResponse, error) {

--- a/decentralized-api/cosmosclient/mock_cosmos_message_client.go
+++ b/decentralized-api/cosmosclient/mock_cosmos_message_client.go
@@ -158,6 +158,15 @@ func (m *MockCosmosMessageClient) GetBridgeAddresses(ctx context.Context, chainI
 	return args.Get(0).([]inferencetypes.BridgeContractAddress), args.Error(1)
 }
 
+func (m *MockCosmosMessageClient) BridgeTransactionsByReceipt(ctx context.Context, originChain, blockNumber, receiptIndex string) ([]inferencetypes.BridgeTransaction, error) {
+	args := m.Called(ctx, originChain, blockNumber, receiptIndex)
+	var txs []inferencetypes.BridgeTransaction
+	if r := args.Get(0); r != nil {
+		txs = r.([]inferencetypes.BridgeTransaction)
+	}
+	return txs, args.Error(1)
+}
+
 func (m *MockCosmosMessageClient) SendTransactionAsyncWithRetry(msg sdk.Msg, deadlineBlock ...int64) (*sdk.TxResponse, error) {
 	args := m.Called(msg)
 	return args.Get(0).(*sdk.TxResponse), args.Error(1)

--- a/decentralized-api/internal/server/admin/bridge_handlers.go
+++ b/decentralized-api/internal/server/admin/bridge_handlers.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -44,22 +45,28 @@ func (s *Server) postBridgeBlock(c echo.Context) error {
 		"receiptsRoot", blockData.ReceiptsRoot,
 		"receiptsCount", len(blockData.Receipts))
 
-	// Add the block to the shared queue. AddBlock processes the block synchronously
-	// (and any contiguous successors), so an error here means a Cosmos submission
-	// failed. Return HTTP 500 so Geth halts its downloader loop and retries the
-	// failed block range (fail-closed).
+	// The POST is a receipt-ACK, not a commit report. AddBlock returns an error
+	// ONLY when the block could not be accepted into the queue:
+	//   - ErrBridgeQueueFull -> 503 back-pressure (Geth's sendRangeDirectly stops
+	//     and resends later; nothing is dropped),
+	//   - any other error -> 400 (malformed / unexpected input).
+	// Otherwise the block is received (buffered/duplicate/bootstrapping) -> 200.
+	// Commit success/failure is owned by the drain and never reported here.
 	blockNumber, err := s.blockQueue.AddBlock(blockData)
-	if err != nil {
-		slog.Error("Failed to process bridge block", "blockNumber", blockData.BlockNumber, "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	switch {
+	case err == nil:
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"status":        "received",
+			"message":       "Block received",
+			"blockNumber":   blockNumber,
+			"receiptsCount": len(blockData.Receipts),
+			"queueSize":     len(s.blockQueue.GetPendingBlocks()),
+		})
+	case errors.Is(err, pserver.ErrBridgeQueueFull):
+		slog.Warn("Bridge: back-pressure, rejecting block", "blockNumber", blockData.BlockNumber, "error", err)
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+	default:
+		slog.Error("Bridge: malformed/unexpected block", "blockNumber", blockData.BlockNumber, "error", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
-
-	// Return success response
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"status":        "success",
-		"message":       "Block processed",
-		"blockNumber":   blockNumber,
-		"receiptsCount": len(blockData.Receipts),
-		"queueSize":     len(s.blockQueue.GetPendingBlocks()),
-	})
 }

--- a/decentralized-api/internal/server/admin/bridge_handlers.go
+++ b/decentralized-api/internal/server/admin/bridge_handlers.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"io"
 	"log/slog"
+	"net/http"
 	"strings"
 
 	pserver "decentralized-api/internal/server/public"
@@ -43,13 +44,20 @@ func (s *Server) postBridgeBlock(c echo.Context) error {
 		"receiptsRoot", blockData.ReceiptsRoot,
 		"receiptsCount", len(blockData.Receipts))
 
-	// Add the block to the shared queue
-	blockNumber := s.blockQueue.AddBlock(blockData)
+	// Add the block to the shared queue. AddBlock processes the block synchronously
+	// (and any contiguous successors), so an error here means a Cosmos submission
+	// failed. Return HTTP 500 so Geth halts its downloader loop and retries the
+	// failed block range (fail-closed).
+	blockNumber, err := s.blockQueue.AddBlock(blockData)
+	if err != nil {
+		slog.Error("Failed to process bridge block", "blockNumber", blockData.BlockNumber, "error", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
 
 	// Return success response
-	return c.JSON(200, map[string]interface{}{
+	return c.JSON(http.StatusOK, map[string]interface{}{
 		"status":        "success",
-		"message":       "Block queued for processing",
+		"message":       "Block processed",
 		"blockNumber":   blockNumber,
 		"receiptsCount": len(blockData.Receipts),
 		"queueSize":     len(s.blockQueue.GetPendingBlocks()),

--- a/decentralized-api/internal/server/public/bridge_handlers.go
+++ b/decentralized-api/internal/server/public/bridge_handlers.go
@@ -1,11 +1,13 @@
 package public
 
 import (
+	"context"
+	"database/sql"
+	"decentralized-api/apiconfig"
 	"decentralized-api/cosmosclient"
 	cosmos_client "decentralized-api/cosmosclient"
 
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"sort"
@@ -18,16 +20,31 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
-// BlockQueue manages a queue of blocks to be processed
+// minBlocksToBootstrap is the number of blocks we buffer on a fresh (uninitialized)
+// chain before sorting and choosing the minimum block number as the bootstrap origin.
+// Buffering protects against network latency delivering a higher block before the
+// lowest one (which would otherwise be permanently discarded as a duplicate).
+const minBlocksToBootstrap = 6
+
+// maxBufferedBlocksPerChain bounds the number of out-of-order blocks buffered per
+// chain (M3). It prevents unbounded memory growth if latest+1 never arrives (deep
+// gap or a withheld block). Sized well above the bootstrap threshold and the
+// realistic in-flight segment depth.
+const maxBufferedBlocksPerChain = 10000
+
+// BridgeQueue manages an in-memory queue of blocks processed synchronously and in
+// strict sequential order per chain. Blocks are committed to the Cosmos chain inside
+// the HTTP request thread (no background workers); progress is mirrored to SQLite so
+// the node bootstraps cleanly after restarts.
 type BridgeQueue struct {
-	pendingBlocks             map[string]*BridgeBlock // Key is blockNumber
-	lock                      sync.RWMutex
-	minBlocksBeforeProcessing int // Minimum number of blocks needed before starting processing
-	recorder                  cosmosclient.CosmosMessageClient
-	processCh                 chan struct{} // Channel to signal processing is needed
+	pendingBlocks map[string]*BridgeBlock // Key: "chain:blockNumber"
+	latestBlocks  map[string]uint64       // Key: "chain" -> latest processed block number (in memory)
+	lock          sync.RWMutex            // Protects both maps (RWMutex: handshake GET reads under RLock)
+	recorder      cosmosclient.CosmosMessageClient
+	db            *sql.DB
 }
 
-// PostBlockResponse is returned by postBlock on success
+// PostBlockResponse is returned by the admin POST handler on success.
 type PostBlockResponse struct {
 	Status        string `json:"status"`
 	Message       string `json:"message"`
@@ -36,72 +53,194 @@ type PostBlockResponse struct {
 	QueueSize     int    `json:"queueSize"`
 }
 
-// BridgeStatusResponse represents the current status of the bridge queue
+// BridgeStatusResponse represents the current status of the bridge queue.
 type BridgeStatusResponse struct {
-	PendingBlocksCount        int            `json:"pendingBlocksCount"`
-	PendingReceiptsCount      int            `json:"pendingReceiptsCount"`
-	BlockCountByNumber        map[string]int `json:"blockCountByNumber"`
-	EarliestBlockNumber       uint64         `json:"earliestBlockNumber"`
-	LatestBlockNumber         uint64         `json:"latestBlockNumber"`
-	ReadyToProcess            bool           `json:"readyToProcess"`
-	MinBlocksBeforeProcessing int            `json:"minBlocksBeforeProcessing"`
+	PendingBlocksCount   int            `json:"pendingBlocksCount"`
+	PendingReceiptsCount int            `json:"pendingReceiptsCount"`
+	BlockCountByNumber   map[string]int `json:"blockCountByNumber"`
+	EarliestBlockNumber  uint64         `json:"earliestBlockNumber"`
+	LatestBlockNumber    uint64         `json:"latestBlockNumber"`
 }
 
-// BridgeAddressesResponse returns bridge contract addresses for a chain
+// BridgeAddressesResponse returns bridge contract addresses for a chain.
 type BridgeAddressesResponse struct {
 	ChainName string   `json:"chain_name"`
 	ChainID   string   `json:"chain_id"`
 	Addresses []string `json:"addresses"`
 }
 
-// NewBlockQueue creates a new queue for blocks with receipts
-func NewBlockQueue(recorder cosmosclient.CosmosMessageClient) *BridgeQueue {
-	queue := &BridgeQueue{
-		pendingBlocks:             make(map[string]*BridgeBlock),
-		minBlocksBeforeProcessing: 6,
-		recorder:                  recorder,
-		processCh:                 make(chan struct{}, 1), // Buffered channel to prevent blocking
-	}
-
-	// Start the queue processor
-	go queue.init()
-
-	return queue
+// LatestBridgeBlockResponse is the handshake payload served by GET /v1/bridge/block/latest.
+type LatestBridgeBlockResponse struct {
+	ChainId     string `json:"chainId"`
+	BlockNumber uint64 `json:"blockNumber"`
 }
 
-// AddBlock adds a block to the queue
-func (q *BridgeQueue) AddBlock(block BridgeBlock) string {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
-	// Check if block already exists
-	if _, exists := q.pendingBlocks[block.BlockNumber]; exists {
-		slog.Info("Block already in queue", "blockNumber", block.BlockNumber)
-		return block.BlockNumber
+// NewBlockQueue creates a new queue for blocks with receipts. The latest processed
+// block numbers per chain are loaded once from SQLite at startup into the in-memory
+// latestBlocks map, so subsequent duplicate/out-of-order checks never touch disk.
+func NewBlockQueue(recorder cosmosclient.CosmosMessageClient, db *sql.DB) *BridgeQueue {
+	q := &BridgeQueue{
+		pendingBlocks: make(map[string]*BridgeBlock),
+		latestBlocks:  make(map[string]uint64),
+		recorder:      recorder,
+		db:            db,
 	}
 
-	q.pendingBlocks[block.BlockNumber] = &block
-
-	slog.Info("Bridge queue: Added block as pending",
-		"blockNumber", block.BlockNumber,
-		"originChain", block.OriginChain,
-		"receiptsCount", len(block.Receipts),
-		"queueLength", len(q.pendingBlocks))
-
-	// Signal processing if we have enough blocks
-	if len(q.pendingBlocks) >= q.minBlocksBeforeProcessing {
-		select {
-		case q.processCh <- struct{}{}:
-			// Signal sent successfully
-		default:
-			// Channel is full, processing is already queued
+	// Load persisted bridge states from SQLite once on startup.
+	if db != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		states, err := apiconfig.LoadAllBridgeLatestBlocks(ctx, db)
+		if err != nil {
+			slog.Error("Failed to load bridge states at startup", "err", err)
+		} else {
+			q.latestBlocks = states
+			slog.Info("Loaded bridge states at startup", "states", states)
 		}
 	}
 
-	return block.BlockNumber
+	return q
 }
 
-// GetPendingBlocks returns all pending blocks
+// GetLatestBlock returns the latest processed block for a chain (handshake read
+// path). It is the only safe way for the public GET handler to read latestBlocks,
+// which the admin POST handler writes concurrently.
+func (q *BridgeQueue) GetLatestBlock(chain string) (uint64, bool) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	v, ok := q.latestBlocks[chain]
+	return v, ok
+}
+
+// AddBlock adds a block and processes it synchronously if it is the next in
+// sequence. It enforces a strict sequential invariant (latest+1) per chain.
+// Returns the block number echoed back, or an error to signal a fail-closed state
+// (the caller must surface this as HTTP 500 so Geth halts and retries).
+func (q *BridgeQueue) AddBlock(block BridgeBlock) (string, error) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	blockNum, err := strconv.ParseUint(block.BlockNumber, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid block number %q: %w", block.BlockNumber, err)
+	}
+
+	latest, exists := q.latestBlocks[block.OriginChain]
+	justBootstrapped := false
+
+	// Case A: Uninitialized chain (bootstrapping / first run).
+	if !exists {
+		key := fmt.Sprintf("%s:%d", block.OriginChain, blockNum)
+		q.pendingBlocks[key] = &block
+		slog.Info("Buffered block during bootstrapping", "chain", block.OriginChain, "block", blockNum)
+
+		// Count buffered blocks for this chain.
+		var chainBlocks []uint64
+		for _, pBlock := range q.pendingBlocks {
+			if pBlock.OriginChain == block.OriginChain {
+				if val, err := strconv.ParseUint(pBlock.BlockNumber, 10, 64); err == nil {
+					chainBlocks = append(chainBlocks, val)
+				}
+			}
+		}
+
+		// Wait until we have enough blocks to establish correct ordering.
+		if len(chainBlocks) < minBlocksToBootstrap {
+			slog.Info("Awaiting more blocks to bootstrap bridge state",
+				"chain", block.OriginChain, "count", len(chainBlocks), "target", minBlocksToBootstrap)
+			return block.BlockNumber, nil
+		}
+
+		// Sort to find the minimum block number.
+		sort.Slice(chainBlocks, func(i, j int) bool { return chainBlocks[i] < chainBlocks[j] })
+		minBlock := chainBlocks[0]
+
+		// Bootstrap latest to minBlock - 1 (or 0 if minBlock == 0).
+		bootstrapVal := uint64(0)
+		if minBlock > 0 {
+			bootstrapVal = minBlock - 1
+		}
+		slog.Info("Bootstrapping bridge state from buffered blocks", "chain", block.OriginChain, "val", bootstrapVal)
+
+		// Commit the bootstrapped origin immediately, BEFORE processing any block.
+		// If the first block (latest+1) later fails on Cosmos, the chain is already
+		// marked initialized at `latest`, so Geth's retry is recognized as latest+1
+		// rather than re-entering the bootstrapping buffer loop.
+		if err := apiconfig.SetBridgeLatestBlock(context.Background(), q.db, block.OriginChain, bootstrapVal); err != nil {
+			return "", fmt.Errorf("failed to bootstrap SQLite state: %w", err)
+		}
+		q.latestBlocks[block.OriginChain] = bootstrapVal
+		latest = bootstrapVal
+		justBootstrapped = true
+	}
+
+	// Case B: Initialized-chain guards.
+	// NOTE (C3): skip these when we just bootstrapped. minBlock = latest+1 is already
+	// buffered, so we go straight to the drain loop below. Re-applying the out-of-order
+	// guard to the (arbitrary) triggering block would stall the queue at `latest`.
+	if !justBootstrapped {
+		if blockNum <= latest {
+			slog.Info("Discarding duplicate block", "block", blockNum, "latest", latest)
+			return block.BlockNumber, nil
+		}
+		if blockNum > latest+1 {
+			// Out-of-order: buffer (enforce per-chain cap, M3) and wait.
+			if q.countPendingForChain(block.OriginChain) >= maxBufferedBlocksPerChain {
+				slog.Warn("Dropping out-of-order block: per-chain buffer cap reached",
+					"chain", block.OriginChain, "block", blockNum, "cap", maxBufferedBlocksPerChain)
+				return block.BlockNumber, nil
+			}
+			key := fmt.Sprintf("%s:%d", block.OriginChain, blockNum)
+			q.pendingBlocks[key] = &block
+			slog.Info("Buffered out-of-order block", "block", blockNum, "expected", latest+1)
+			return block.BlockNumber, nil
+		}
+		// Sequential: ensure the incoming block is buffered for the unified drain.
+		q.pendingBlocks[fmt.Sprintf("%s:%d", block.OriginChain, blockNum)] = &block
+	}
+
+	// Drain consecutive blocks starting at latest+1 (NOT at the incoming blockNum).
+	currBlockNum := latest + 1
+	for {
+		key := fmt.Sprintf("%s:%d", block.OriginChain, currBlockNum)
+		nextBlock, ok := q.pendingBlocks[key]
+		if !ok {
+			break
+		}
+
+		slog.Info("Processing sequential block", "chain", nextBlock.OriginChain, "block", nextBlock.BlockNumber)
+		if err := q.processBlockReceipts(nextBlock); err != nil {
+			// Fail-closed: halt pipeline and propagate error, leaving the queue
+			// unmodified and uncommitted so the block is retried in the same state.
+			return "", err
+		}
+
+		// Commit progress to SQLite and update in-memory state.
+		if err := apiconfig.SetBridgeLatestBlock(context.Background(), q.db, block.OriginChain, currBlockNum); err != nil {
+			return "", fmt.Errorf("failed to save latest block: %w", err)
+		}
+		q.latestBlocks[block.OriginChain] = currBlockNum
+
+		delete(q.pendingBlocks, key)
+		currBlockNum++
+	}
+
+	return block.BlockNumber, nil
+}
+
+// countPendingForChain returns the number of buffered blocks for a chain.
+// Caller must hold q.lock.
+func (q *BridgeQueue) countPendingForChain(chain string) int {
+	count := 0
+	for _, pBlock := range q.pendingBlocks {
+		if pBlock.OriginChain == chain {
+			count++
+		}
+	}
+	return count
+}
+
+// GetPendingBlocks returns all pending blocks.
 func (q *BridgeQueue) GetPendingBlocks() []BridgeBlock {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
@@ -120,101 +259,19 @@ func (q *BridgeQueue) GetQueueSize() int {
 	return len(q.pendingBlocks)
 }
 
-// Init sets up the queue processing
-func (q *BridgeQueue) init() {
-	ticker := time.NewTicker(5 * time.Minute) // Process every 5 minutes regardless
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			slog.Info("Bridge queue: Processing blocks due to timeout")
-			q.processBlocks()
-		case <-q.processCh:
-			// Process blocks when minimum threshold is reached
-			slog.Info("Bridge queue: Processing blocks due to minimum threshold reached")
-			q.processBlocks()
+// processBlockReceipts processes every receipt in a block, returning the first error.
+func (q *BridgeQueue) processBlockReceipts(block *BridgeBlock) error {
+	for _, receipt := range block.Receipts {
+		if err := q.processReceipt(receipt, *block); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
-// processBlocks processes queued blocks in order starting from the earliest
-func (q *BridgeQueue) processBlocks() {
-	for {
-		block, exists := q.getNextBlock()
-		if !exists {
-			break
-		}
-
-		// Process the block and its receipts
-		slog.Info("Processing block",
-			"blockNumber", block.BlockNumber,
-			"originChain", block.OriginChain,
-			"receiptsRoot", block.ReceiptsRoot,
-			"receiptsCount", len(block.Receipts))
-
-		// Process each receipt in the block
-		for _, receipt := range block.Receipts {
-			// Process the receipt with block information
-			q.processReceipt(receipt, block)
-		}
-	}
-}
-
-// getNextBlock retrieves and removes the earliest block from the queue
-func (q *BridgeQueue) getNextBlock() (BridgeBlock, bool) {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
-	if len(q.pendingBlocks) == 0 {
-		return BridgeBlock{}, false
-	}
-
-	// Create a slice of all blocks
-	var blocks []struct {
-		blockNumber string
-		block       BridgeBlock
-	}
-
-	for blockNum, pendingBlock := range q.pendingBlocks {
-		blocks = append(blocks, struct {
-			blockNumber string
-			block       BridgeBlock
-		}{
-			blockNumber: blockNum,
-			block:       *pendingBlock,
-		})
-	}
-
-	// Sort blocks by block number (ascending)
-	sort.Slice(blocks, func(i, j int) bool {
-		blockNumI, errI := strconv.ParseUint(blocks[i].blockNumber, 10, 64)
-		blockNumJ, errJ := strconv.ParseUint(blocks[j].blockNumber, 10, 64)
-
-		// If parsing fails, fall back to string comparison
-		if errI != nil || errJ != nil {
-			return blocks[i].blockNumber < blocks[j].blockNumber
-		}
-
-		return blockNumI < blockNumJ
-	})
-
-	// Get the earliest block
-	earliestBlock := blocks[0]
-
-	// Remove it from the queue
-	delete(q.pendingBlocks, earliestBlock.blockNumber)
-
-	slog.Info("Retrieved next block for processing",
-		"blockNumber", earliestBlock.blockNumber,
-		"remainingBlocks", len(q.pendingBlocks))
-
-	return earliestBlock.block, true
-}
-
-// processReceipt handles an individual receipt (similar to previous cosmos processing)
-func (q *BridgeQueue) processReceipt(receipt BridgeReceipt, block BridgeBlock) {
-	// Process the transaction (e.g., create Cosmos transaction)
+// processReceipt handles an individual receipt by submitting a MsgBridgeExchange to
+// Cosmos. It returns any error so the synchronous pipeline can fail closed.
+func (q *BridgeQueue) processReceipt(receipt BridgeReceipt, block BridgeBlock) error {
 	slog.Info("Processing receipt",
 		"chain", block.OriginChain,
 		"contract", receipt.ContractAddress,
@@ -224,16 +281,11 @@ func (q *BridgeQueue) processReceipt(receipt BridgeReceipt, block BridgeBlock) {
 		"blockNumber", block.BlockNumber,
 		"receiptIndex", receipt.ReceiptIndex)
 
-	// Derive Cosmos address from public key
 	cosmosAddress, err := cosmos_client.PubKeyToAddress(receipt.OwnerPubKey)
 	if err != nil {
-		slog.Error("Failed to derive Cosmos address from public key",
-			"error", err,
-			"publicKey", receipt.OwnerPubKey)
-		return
+		return fmt.Errorf("failed to derive Cosmos address from public key %q: %w", receipt.OwnerPubKey, err)
 	}
 
-	// Format the public key with 0x prefix if it doesn't already have it
 	ownerPubKey := receipt.OwnerPubKey
 	if !strings.HasPrefix(ownerPubKey, "0x") {
 		ownerPubKey = "0x" + ownerPubKey
@@ -251,127 +303,72 @@ func (q *BridgeQueue) processReceipt(receipt BridgeReceipt, block BridgeBlock) {
 		ReceiptsRoot:    block.ReceiptsRoot,
 	}
 
-	err = q.recorder.BridgeExchange(msg)
-	if err != nil {
-		slog.Error("Error processing bridge exchange",
-			"error", err,
-			"blockNumber", block.BlockNumber,
-			"receiptIndex", receipt.ReceiptIndex)
+	if err := q.recorder.BridgeExchange(msg); err != nil {
+		return fmt.Errorf("cosmos transaction failed: %w", err)
 	}
+	return nil
 }
 
-// postBlock handles POST requests to submit finalized blocks with optional receipts
-func (s *Server) postBlock(c echo.Context) error {
-	// Debug: Log raw request body
-	rawBody := c.Request().Body
-	bodyBytes, err := io.ReadAll(rawBody)
-	if err != nil {
-		slog.Error("Failed to read request body", "error", err)
-		return echo.NewHTTPError(http.StatusBadRequest, "Failed to read request body")
+// getLatestBridgeBlock serves the Geth startup/continuity handshake. It returns ONLY
+// the unified `blockNumber` key (plus `chainId`). When a chain is uninitialized the
+// blockNumber is omitted so Geth's tri-state parser treats it as "uninitialized" and
+// falls back to legacy behavior.
+func (s *Server) getLatestBridgeBlock(c echo.Context) error {
+	chain := c.QueryParam("chain")
+	if chain == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Chain parameter is required (e.g., 'ethereum')")
 	}
-
-	// Log the raw JSON for debugging
-	slog.Info("Received raw request body", "body", string(bodyBytes))
-
-	// Reset the body for binding
-	c.Request().Body = io.NopCloser(strings.NewReader(string(bodyBytes)))
-
-	var blockData BridgeBlock
-	if err := c.Bind(&blockData); err != nil {
-		slog.Error("Failed to decode block data", "error", err)
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body: "+err.Error())
+	latest, ok := s.blockQueue.GetLatestBlock(chain)
+	if !ok {
+		// Uninitialized: omit blockNumber so Geth falls back to legacy.
+		return c.JSON(http.StatusOK, map[string]string{"chainId": chain})
 	}
-
-	// Validate required fields
-	if blockData.BlockNumber == "" || blockData.ReceiptsRoot == "" || blockData.OriginChain == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "Required fields missing: blockNumber, receiptsRoot, originChain")
-	}
-
-	slog.Info("Received finalized block",
-		"blockNumber", blockData.BlockNumber,
-		"originChain", blockData.OriginChain,
-		"receiptsRoot", blockData.ReceiptsRoot,
-		"receiptsCount", len(blockData.Receipts))
-
-	// Debug: Log each receipt to see what we're actually receiving
-	for i, receipt := range blockData.Receipts {
-		slog.Info("Received receipt details",
-			"receiptIndex", i,
-			"contract", receipt.ContractAddress,
-			"owner", receipt.OwnerAddress,
-			"publicKey", receipt.OwnerPubKey,
-			"publicKeyLength", len(receipt.OwnerPubKey),
-			"amount", receipt.Amount,
-			"receiptIndex", receipt.ReceiptIndex)
-	}
-
-	// Add the block to the queue
-	blockNumber := s.blockQueue.AddBlock(blockData)
-
-	// Return success response
-	return c.JSON(http.StatusOK, &PostBlockResponse{
-		Status:        "success",
-		Message:       "Block queued for processing",
-		BlockNumber:   blockNumber,
-		ReceiptsCount: len(blockData.Receipts),
-		QueueSize:     s.blockQueue.GetQueueSize(),
-	})
+	return c.JSON(http.StatusOK, &LatestBridgeBlockResponse{ChainId: chain, BlockNumber: latest})
 }
 
-// getBridgeStatus returns information about the queue status
+// getBridgeStatus returns information about the queue status.
 func (s *Server) getBridgeStatus(c echo.Context) error {
 	pendingBlocks := s.blockQueue.GetPendingBlocks()
 
-	// Group blocks by number
+	// Group blocks by number.
 	blockCountByNumber := make(map[string]int)
 
-	// Track earliest and latest block numbers
+	// Track earliest and latest block numbers.
 	var blockNumbers []uint64
 
 	for _, block := range pendingBlocks {
 		blockNum := block.BlockNumber
 		blockCountByNumber[blockNum]++
 
-		// Parse block number for sorting
-		if blockNum, err := strconv.ParseUint(block.BlockNumber, 10, 64); err == nil {
-			blockNumbers = append(blockNumbers, blockNum)
+		if parsed, err := strconv.ParseUint(block.BlockNumber, 10, 64); err == nil {
+			blockNumbers = append(blockNumbers, parsed)
 		}
 	}
 
 	var earliestBlock, latestBlock uint64
-	var readyToProcess bool
-
 	if len(blockNumbers) > 0 {
-		// Sort the block numbers
-		sort.Slice(blockNumbers, func(i, j int) bool {
-			return blockNumbers[i] < blockNumbers[j]
-		})
-
+		sort.Slice(blockNumbers, func(i, j int) bool { return blockNumbers[i] < blockNumbers[j] })
 		earliestBlock = blockNumbers[0]
 		latestBlock = blockNumbers[len(blockNumbers)-1]
-		readyToProcess = len(blockNumbers) >= s.blockQueue.minBlocksBeforeProcessing
 	}
 
-	// Count total receipts in all blocks
 	totalReceipts := 0
 	for _, block := range pendingBlocks {
 		totalReceipts += len(block.Receipts)
 	}
 
 	response := &BridgeStatusResponse{
-		PendingBlocksCount:        len(pendingBlocks),
-		PendingReceiptsCount:      totalReceipts,
-		BlockCountByNumber:        blockCountByNumber,
-		EarliestBlockNumber:       earliestBlock,
-		LatestBlockNumber:         latestBlock,
-		ReadyToProcess:            readyToProcess,
-		MinBlocksBeforeProcessing: s.blockQueue.minBlocksBeforeProcessing,
+		PendingBlocksCount:   len(pendingBlocks),
+		PendingReceiptsCount: totalReceipts,
+		BlockCountByNumber:   blockCountByNumber,
+		EarliestBlockNumber:  earliestBlock,
+		LatestBlockNumber:    latestBlock,
 	}
 
 	return c.JSON(http.StatusOK, response)
 }
 
-// getBridgeAddresses returns bridge addresses for a specific chain by name
+// getBridgeAddresses returns bridge addresses for a specific chain by name.
 func (s *Server) getBridgeAddresses(c echo.Context) error {
 	chainName := c.QueryParam("chain")
 
@@ -379,16 +376,14 @@ func (s *Server) getBridgeAddresses(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Chain parameter is required (e.g., 'ethereum', 'polygon')")
 	}
 
-	// Use chainName directly as chainId
+	// Use chainName directly as chainId.
 	chainId := chainName
 
-	// Get addresses for this chain
 	addresses, err := s.recorder.GetBridgeAddresses(c.Request().Context(), chainId)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to get addresses for chain '%s': %v", chainName, err))
 	}
 
-	// Convert to simple address list for API response
 	var addressList []string
 	for _, item := range addresses {
 		addressList = append(addressList, item.Address)

--- a/decentralized-api/internal/server/public/bridge_handlers.go
+++ b/decentralized-api/internal/server/public/bridge_handlers.go
@@ -6,6 +6,7 @@ import (
 	"decentralized-api/apiconfig"
 	"decentralized-api/cosmosclient"
 	cosmos_client "decentralized-api/cosmosclient"
+	"errors"
 
 	"fmt"
 	"log/slog"
@@ -18,6 +19,23 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/productscience/inference/x/inference/types"
+)
+
+// ErrBridgeQueueFull is the single sentinel that signals back-pressure: the
+// per-chain out-of-order buffer is full, so the block cannot be accepted right
+// now. The admin POST handler maps ONLY this error to HTTP 503 so Geth's
+// sendRangeDirectly stops and resends later; no block is ever dropped while
+// reporting success.
+var ErrBridgeQueueFull = errors.New("Bridge: Queue is full")
+
+// Bridge commit-confirmation tuning. Confirmation is an index-independent
+// module-state poll via the already-deployed BridgeTransaction query (no chain
+// upgrade required), bounded so the drain never blocks forever on a receipt that
+// is not (yet) recorded; on deadline the block is left in the queue and retried
+// on the next POST.
+const (
+	bridgeConfirmTimeout      = 60 * time.Second
+	bridgeConfirmPollInterval = 2 * time.Second
 )
 
 // minBlocksToBootstrap is the number of blocks we buffer on a fresh (uninitialized)
@@ -40,6 +58,7 @@ type BridgeQueue struct {
 	pendingBlocks map[string]*BridgeBlock // Key: "chain:blockNumber"
 	latestBlocks  map[string]uint64       // Key: "chain" -> latest processed block number (in memory)
 	lock          sync.RWMutex            // Protects both maps (RWMutex: handshake GET reads under RLock)
+	drainMu       sync.Mutex              // Serializes drains; held WITHOUT the data lock during network I/O
 	recorder      cosmosclient.CosmosMessageClient
 	db            *sql.DB
 }
@@ -92,10 +111,10 @@ func NewBlockQueue(recorder cosmosclient.CosmosMessageClient, db *sql.DB) *Bridg
 		defer cancel()
 		states, err := apiconfig.LoadAllBridgeLatestBlocks(ctx, db)
 		if err != nil {
-			slog.Error("Failed to load bridge states at startup", "err", err)
+			slog.Error("Bridge: Failed to load bridge states at startup", "err", err)
 		} else {
 			q.latestBlocks = states
-			slog.Info("Loaded bridge states at startup", "states", states)
+			slog.Info("Bridge: Loaded bridge states at startup", "states", states)
 		}
 	}
 
@@ -112,27 +131,45 @@ func (q *BridgeQueue) GetLatestBlock(chain string) (uint64, bool) {
 	return v, ok
 }
 
-// AddBlock adds a block and processes it synchronously if it is the next in
-// sequence. It enforces a strict sequential invariant (latest+1) per chain.
-// Returns the block number echoed back, or an error to signal a fail-closed state
-// (the caller must surface this as HTTP 500 so Geth halts and retries).
+// AddBlock is a receipt-ACK: it accepts a block into the queue (ACCEPT phase,
+// under the data lock) and then triggers the drain (DRAIN phase, under drainMu
+// with NO data lock held during network I/O). The returned error means ONLY that
+// the block could not be accepted:
+//   - malformed input (block-number parse / bootstrap persistence failure), or
+//   - back-pressure (ErrBridgeQueueFull, buffer full).
+//
+// Every received outcome (buffered, duplicate, bootstrapping) returns
+// (blockNumber, nil). Commit success/failure is NOT reported through this call;
+// it is owned by the drain, which advances `latest` only after every receipt of a
+// block is confirmed recorded on-chain.
 func (q *BridgeQueue) AddBlock(block BridgeBlock) (string, error) {
+	if err := q.accept(block); err != nil {
+		return "", err
+	}
+	q.drain(block.OriginChain)
+	return block.BlockNumber, nil
+}
+
+// accept performs the ACCEPT phase under the data lock only: parse/validate,
+// bootstrap, dedup, buffer, and back-pressure. It performs NO network I/O. The
+// only quick disk write here is the bootstrap origin commit (SQLite), which is
+// not network I/O and must be consistent with the in-memory bootstrap value.
+func (q *BridgeQueue) accept(block BridgeBlock) error {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
 	blockNum, err := strconv.ParseUint(block.BlockNumber, 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("invalid block number %q: %w", block.BlockNumber, err)
+		return fmt.Errorf("Bridge: Invalid block number %q: %w", block.BlockNumber, err)
 	}
 
 	latest, exists := q.latestBlocks[block.OriginChain]
-	justBootstrapped := false
 
 	// Case A: Uninitialized chain (bootstrapping / first run).
 	if !exists {
 		key := fmt.Sprintf("%s:%d", block.OriginChain, blockNum)
 		q.pendingBlocks[key] = &block
-		slog.Info("Buffered block during bootstrapping", "chain", block.OriginChain, "block", blockNum)
+		slog.Info("Bridge: Buffered block during bootstrapping", "chain", block.OriginChain, "block", blockNum)
 
 		// Count buffered blocks for this chain.
 		var chainBlocks []uint64
@@ -146,9 +183,9 @@ func (q *BridgeQueue) AddBlock(block BridgeBlock) (string, error) {
 
 		// Wait until we have enough blocks to establish correct ordering.
 		if len(chainBlocks) < minBlocksToBootstrap {
-			slog.Info("Awaiting more blocks to bootstrap bridge state",
+			slog.Info("Bridge: Awaiting more blocks to bootstrap bridge state",
 				"chain", block.OriginChain, "count", len(chainBlocks), "target", minBlocksToBootstrap)
-			return block.BlockNumber, nil
+			return nil
 		}
 
 		// Sort to find the minimum block number.
@@ -160,72 +197,91 @@ func (q *BridgeQueue) AddBlock(block BridgeBlock) (string, error) {
 		if minBlock > 0 {
 			bootstrapVal = minBlock - 1
 		}
-		slog.Info("Bootstrapping bridge state from buffered blocks", "chain", block.OriginChain, "val", bootstrapVal)
+		slog.Info("Bridge: Bootstrapping bridge state from buffered blocks", "chain", block.OriginChain, "val", bootstrapVal)
 
-		// Commit the bootstrapped origin immediately, BEFORE processing any block.
-		// If the first block (latest+1) later fails on Cosmos, the chain is already
+		// Commit the bootstrapped origin immediately, BEFORE draining any block.
+		// If the first block (latest+1) later fails to commit, the chain is already
 		// marked initialized at `latest`, so Geth's retry is recognized as latest+1
 		// rather than re-entering the bootstrapping buffer loop.
 		if err := apiconfig.SetBridgeLatestBlock(context.Background(), q.db, block.OriginChain, bootstrapVal); err != nil {
-			return "", fmt.Errorf("failed to bootstrap SQLite state: %w", err)
+			return fmt.Errorf("Bridge: failed to bootstrap SQLite state: %w", err)
 		}
 		q.latestBlocks[block.OriginChain] = bootstrapVal
-		latest = bootstrapVal
-		justBootstrapped = true
+		// minBlock = latest+1 is already buffered; the drain (started by AddBlock)
+		// will pick it up at latest+1.
+		return nil
 	}
 
 	// Case B: Initialized-chain guards.
-	// NOTE (C3): skip these when we just bootstrapped. minBlock = latest+1 is already
-	// buffered, so we go straight to the drain loop below. Re-applying the out-of-order
-	// guard to the (arbitrary) triggering block would stall the queue at `latest`.
-	if !justBootstrapped {
-		if blockNum <= latest {
-			slog.Info("Discarding duplicate block", "block", blockNum, "latest", latest)
-			return block.BlockNumber, nil
-		}
-		if blockNum > latest+1 {
-			// Out-of-order: buffer (enforce per-chain cap, M3) and wait.
-			if q.countPendingForChain(block.OriginChain) >= maxBufferedBlocksPerChain {
-				slog.Warn("Dropping out-of-order block: per-chain buffer cap reached",
-					"chain", block.OriginChain, "block", blockNum, "cap", maxBufferedBlocksPerChain)
-				return block.BlockNumber, nil
-			}
-			key := fmt.Sprintf("%s:%d", block.OriginChain, blockNum)
-			q.pendingBlocks[key] = &block
-			slog.Info("Buffered out-of-order block", "block", blockNum, "expected", latest+1)
-			return block.BlockNumber, nil
-		}
-		// Sequential: ensure the incoming block is buffered for the unified drain.
-		q.pendingBlocks[fmt.Sprintf("%s:%d", block.OriginChain, blockNum)] = &block
+	if blockNum <= latest {
+		slog.Info("Bridge: Discarding duplicate block", "block", blockNum, "latest", latest)
+		return nil
 	}
+	if blockNum > latest+1 {
+		// Out-of-order: enforce the per-chain cap as BACK-PRESSURE (never drop).
+		// A full buffer returns ErrBridgeQueueFull -> 503, so Geth stops and resends
+		// later; back-pressure self-clears as the drain confirms blocks and frees
+		// space. This is the ONLY place this sentinel is returned.
+		if q.countPendingForChain(block.OriginChain) >= maxBufferedBlocksPerChain {
+			return fmt.Errorf("%w: chain=%s pending=%d cap=%d",
+				ErrBridgeQueueFull, block.OriginChain,
+				q.countPendingForChain(block.OriginChain), maxBufferedBlocksPerChain)
+		}
+		key := fmt.Sprintf("%s:%d", block.OriginChain, blockNum)
+		q.pendingBlocks[key] = &block
+		slog.Info("Bridge: Buffered out-of-order block", "block", blockNum, "expected", latest+1)
+		return nil
+	}
+	// Sequential: buffer the incoming block for the unified drain.
+	q.pendingBlocks[fmt.Sprintf("%s:%d", block.OriginChain, blockNum)] = &block
+	return nil
+}
 
-	// Drain consecutive blocks starting at latest+1 (NOT at the incoming blockNum).
-	currBlockNum := latest + 1
+// drain commits buffered blocks from latest+1 in strict sequential order. It is
+// serialized by drainMu (one drain at a time) and never holds the data lock
+// across network I/O: the data lock is taken only for quick in-memory reads
+// (peek latest+1) and the advance/delete write. A block whose receipts are not
+// all confirmed is left in the queue and retried on the next POST's drain.
+func (q *BridgeQueue) drain(chain string) {
+	q.drainMu.Lock()
+	defer q.drainMu.Unlock()
+
+	ctx := context.Background()
 	for {
-		key := fmt.Sprintf("%s:%d", block.OriginChain, currBlockNum)
+		// Quick read under the data lock: copy the next block pointer out.
+		q.lock.RLock()
+		latest := q.latestBlocks[chain]
+		key := fmt.Sprintf("%s:%d", chain, latest+1)
 		nextBlock, ok := q.pendingBlocks[key]
+		q.lock.RUnlock()
 		if !ok {
-			break
+			return
 		}
 
-		slog.Info("Processing sequential block", "chain", nextBlock.OriginChain, "block", nextBlock.BlockNumber)
-		if err := q.processBlockReceipts(nextBlock); err != nil {
-			// Fail-closed: halt pipeline and propagate error, leaving the queue
-			// unmodified and uncommitted so the block is retried in the same state.
-			return "", err
+		slog.Info("Bridge: Processing sequential block", "chain", chain, "block", nextBlock.BlockNumber)
+
+		// Network I/O with NO lock held: broadcast + confirm each receipt.
+		if err := q.processBlockReceipts(ctx, nextBlock); err != nil {
+			// Not (yet) confirmed on-chain: leave the block buffered, do NOT advance
+			// latest, do NOT surface to the POST. Retried on the next POST's drain.
+			slog.Warn("Bridge: Block not yet committed; leaving in queue",
+				"chain", chain, "block", latest+1, "err", err)
+			return
 		}
 
-		// Commit progress to SQLite and update in-memory state.
-		if err := apiconfig.SetBridgeLatestBlock(context.Background(), q.db, block.OriginChain, currBlockNum); err != nil {
-			return "", fmt.Errorf("failed to save latest block: %w", err)
+		// Quick write under the data lock: advance latest (SQLite + memory) and
+		// delete the committed block.
+		q.lock.Lock()
+		if err := apiconfig.SetBridgeLatestBlock(ctx, q.db, chain, latest+1); err != nil {
+			q.lock.Unlock()
+			slog.Error("Bridge: Failed to persist latest block; not advancing latest pointer",
+				"chain", chain, "block", latest+1, "err", err)
+			return
 		}
-		q.latestBlocks[block.OriginChain] = currBlockNum
-
+		q.latestBlocks[chain] = latest + 1
 		delete(q.pendingBlocks, key)
-		currBlockNum++
+		q.lock.Unlock()
 	}
-
-	return block.BlockNumber, nil
 }
 
 // countPendingForChain returns the number of buffered blocks for a chain.
@@ -259,31 +315,55 @@ func (q *BridgeQueue) GetQueueSize() int {
 	return len(q.pendingBlocks)
 }
 
-// processBlockReceipts processes every receipt in a block, returning the first error.
-func (q *BridgeQueue) processBlockReceipts(block *BridgeBlock) error {
+// processBlockReceipts commits every receipt in a block. It returns success only
+// when ALL receipts are confirmed recorded on-chain; any unconfirmed receipt
+// returns an error, which the drain turns into log-and-leave-in-queue.
+func (q *BridgeQueue) processBlockReceipts(ctx context.Context, block *BridgeBlock) error {
 	for _, receipt := range block.Receipts {
-		if err := q.processReceipt(receipt, *block); err != nil {
+		if err := q.commitReceipt(ctx, receipt, *block); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// processReceipt handles an individual receipt by submitting a MsgBridgeExchange to
-// Cosmos. It returns any error so the synchronous pipeline can fail closed.
-func (q *BridgeQueue) processReceipt(receipt BridgeReceipt, block BridgeBlock) error {
-	slog.Info("Processing receipt",
+// commitReceipt sends a receipt optimistically (no pre-check) and then treats an
+// index-independent module-state read as the AUTHORITY for whether it is
+// committed. The chain's "already validated" dedup response is treated as success
+// (so re-sent blocks make forward progress instead of stalling on dedup errors).
+func (q *BridgeQueue) commitReceipt(ctx context.Context, receipt BridgeReceipt, block BridgeBlock) error {
+	msg, err := q.buildBridgeExchangeMsg(receipt, block)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("Bridge: Committing receipt",
 		"chain", block.OriginChain,
 		"contract", receipt.ContractAddress,
-		"owner", receipt.OwnerAddress,
-		"publicKey", receipt.OwnerPubKey,
+		"owner", msg.OwnerAddress,
 		"amount", receipt.Amount,
 		"blockNumber", block.BlockNumber,
 		"receiptIndex", receipt.ReceiptIndex)
 
+	// 1. Send optimistically. "already recorded by us" is success, not failure;
+	// any other error is uncertain -> stop and retry on the next POST. We do NOT
+	// rely on the broadcast's own nil (broadcastMessage can swallow Code != 0);
+	// the confirmation read below is the authority.
+	if err := q.recorder.BridgeExchange(msg); err != nil && !isAlreadyRecorded(err) {
+		return fmt.Errorf("Bridge: Exchange submit not confirmable: %w", err)
+	}
+
+	// 2. Confirm via index-independent state read (bounded poll).
+	return q.confirmReceiptRecorded(ctx, msg)
+}
+
+// buildBridgeExchangeMsg builds the MsgBridgeExchange for a receipt, deriving the
+// owner's Cosmos address from its public key. The same content fields feed the
+// confirmation query, so the on-chain content hash matches exactly.
+func (q *BridgeQueue) buildBridgeExchangeMsg(receipt BridgeReceipt, block BridgeBlock) (*types.MsgBridgeExchange, error) {
 	cosmosAddress, err := cosmos_client.PubKeyToAddress(receipt.OwnerPubKey)
 	if err != nil {
-		return fmt.Errorf("failed to derive Cosmos address from public key %q: %w", receipt.OwnerPubKey, err)
+		return nil, fmt.Errorf("Bridge: Failed to derive Cosmos address from public key %q: %w", receipt.OwnerPubKey, err)
 	}
 
 	ownerPubKey := receipt.OwnerPubKey
@@ -291,7 +371,7 @@ func (q *BridgeQueue) processReceipt(receipt BridgeReceipt, block BridgeBlock) e
 		ownerPubKey = "0x" + ownerPubKey
 	}
 
-	msg := &types.MsgBridgeExchange{
+	return &types.MsgBridgeExchange{
 		Validator:       q.recorder.GetAccountAddress(),
 		OriginChain:     block.OriginChain,
 		ContractAddress: receipt.ContractAddress,
@@ -301,12 +381,86 @@ func (q *BridgeQueue) processReceipt(receipt BridgeReceipt, block BridgeBlock) e
 		BlockNumber:     block.BlockNumber,
 		ReceiptIndex:    receipt.ReceiptIndex,
 		ReceiptsRoot:    block.ReceiptsRoot,
-	}
+	}, nil
+}
 
-	if err := q.recorder.BridgeExchange(msg); err != nil {
-		return fmt.Errorf("cosmos transaction failed: %w", err)
+// confirmReceiptRecorded polls the chain (via the already-deployed, index-
+// independent BridgeTransaction query) until our validator's confirmation for
+// this exact receipt content is present, or a bounded deadline elapses. A
+// deadline is "uncertain" -> the receipt is left uncommitted and retried on the
+// next POST's drain.
+func (q *BridgeQueue) confirmReceiptRecorded(ctx context.Context, msg *types.MsgBridgeExchange) error {
+	deadline := time.Now().Add(bridgeConfirmTimeout)
+	for {
+		recorded, err := q.receiptRecorded(ctx, msg)
+		if err == nil && recorded {
+			return nil
+		}
+		if err != nil {
+			slog.Warn("Bridge: Confirmation query failed; will retry",
+				"blockNumber", msg.BlockNumber, "receiptIndex", msg.ReceiptIndex, "err", err)
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("Bridge: Receipt not confirmed within %s: chain=%s block=%s receiptIndex=%s",
+				bridgeConfirmTimeout, msg.OriginChain, msg.BlockNumber, msg.ReceiptIndex)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(bridgeConfirmPollInterval):
+		}
 	}
-	return nil
+}
+
+// receiptRecorded reports whether our validator's confirmation for this exact
+// receipt content is present in chain state. It uses the existing
+// BridgeTransaction query (filtered by chain/block/receiptIndex) and then matches
+// the remaining content fields, so a conflicting transaction (same receipt
+// location, different content) cannot be mistaken for ours.
+func (q *BridgeQueue) receiptRecorded(ctx context.Context, msg *types.MsgBridgeExchange) (bool, error) {
+	txs, err := q.recorder.BridgeTransactionsByReceipt(ctx, msg.OriginChain, msg.BlockNumber, msg.ReceiptIndex)
+	if err != nil {
+		return false, err
+	}
+	for _, tx := range txs {
+		if !bridgeTxMatchesMsg(tx, msg) {
+			continue
+		}
+		for _, v := range tx.Validators {
+			if v == msg.Validator {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// bridgeTxMatchesMsg reports whether an on-chain bridge transaction has the same
+// content as our message. The query already filters by chain/block/receiptIndex;
+// matching the remaining content fields guards against confirming on a conflicting
+// entry. ContractAddress is compared case-insensitively because the chain
+// normalizes it to lowercase (see msg_server_bridge_exchange.go).
+func bridgeTxMatchesMsg(tx types.BridgeTransaction, msg *types.MsgBridgeExchange) bool {
+	return tx.ChainId == msg.OriginChain &&
+		strings.EqualFold(tx.ContractAddress, msg.ContractAddress) &&
+		tx.OwnerAddress == msg.OwnerAddress &&
+		tx.Amount == msg.Amount &&
+		tx.BlockNumber == msg.BlockNumber &&
+		tx.ReceiptIndex == msg.ReceiptIndex &&
+		tx.ReceiptsRoot == msg.ReceiptsRoot
+}
+
+// isAlreadyRecorded reports whether the broadcast error is the chain's dedup
+// signal that our validator already recorded this exact receipt. This is treated
+// as success (§1.3). The string match is fragile and only an optimization to skip
+// a redundant poll; the confirmation read remains the authority.
+func isAlreadyRecorded(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "Bridge: Validator has already validated this transaction")
 }
 
 // getLatestBridgeBlock serves the Geth startup/continuity handshake. It returns ONLY

--- a/decentralized-api/internal/server/public/server.go
+++ b/decentralized-api/internal/server/public/server.go
@@ -130,6 +130,7 @@ func NewServer(
 
 	g.GET("bridge/status", s.getBridgeStatus)
 	g.GET("bridge/addresses", s.getBridgeAddresses)
+	g.GET("bridge/block/latest", s.getLatestBridgeBlock)
 
 	g.GET("epochs/:epoch", s.getEpochById)
 	g.GET("epochs/:epoch/participants", s.getParticipantsByEpoch)

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -202,7 +202,7 @@ func main() {
 	logging.Info("start public server on addr", types.Server, "addr", addr)
 
 	// Bridge external block queue
-	blockQueue := pserver.NewBlockQueue(recorder)
+	blockQueue := pserver.NewBlockQueue(recorder, configManager.SqlDb().GetDb())
 
 	// Shared payload storage for both public and admin servers
 	// Uses PostgreSQL if PGHOST is set and accessible, otherwise file-based

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -110,6 +110,8 @@ services:
       - JWT_SECRET_PATH=/data/jwt/jwt.hex
       - BRIDGE_POSTBLOCK=http://api:9200/admin/v1/bridge/block
       - BRIDGE_GETADDRESSES=http://api:9000/v1/bridge/addresses
+      - BRIDGE_GETLASTBLOCK=${BRIDGE_GETLASTBLOCK:-http://api:9000/v1/bridge/block/latest}
+      - BRIDGE_CACHE_RANGES=${BRIDGE_CACHE_RANGES:-4}
       - BEACON_STATE_URL=https://beaconstate.info/
       - PERSISTENT_DB_DIR=/persistent-db
     volumes:


### PR DESCRIPTION
### Endpoint Topology (production)

Geth talks to **two different servers** (confirmed by `local-test-net/docker-compose.bridge.yml` and `deploy/join/docker-compose.yml`):

| Operation | Server | URL | Geth flag |
| --- | --- | --- | --- |
| Post block | **admin** (`:9200`) | `POST /admin/v1/bridge/block` | `--bridge.postblock` |
| Get bridge addresses | **public** (`:9000`) | `GET /v1/bridge/addresses` | `--bridge.getaddresses` |
| Handshake (last block) | **public** (`:9000`) | `GET /v1/bridge/block/latest` | `--bridge.getlastblock` |

Both servers share the same `*BridgeQueue` instance (injected in `main.go`), so the admin POST handler writes `latestBlocks`/SQLite while the public GET handler reads it. Because they share state, the GET handler **must** read `latestBlocks` through a lock-guarded accessor.

---

## Part I — Geth-side architecture (commit 1)

### 1.1 The Receipt-Only Finality Pipeline

- **Decoupled Sync**: `bridge-geth` runs in a custom `ReceiptSync` mode where blocks are not executed and the traditional `blockchain.CurrentHeader()` stays near genesis. The node tracks chain progress entirely through the consensus-layer Engine API, feeding headers into the `Skeleton` syncer.
- **Finality-Aware Posting**: The downloader retrieves block bodies and receipts but does **not** forward them to the API immediately. It asserts that blocks are at or below the finalized skeleton head (`progress.Finalized`), matching the canonical chain path.
- **Handshake Alignment**: When Geth starts, it queries the API's `/v1/bridge/block/latest` endpoint to retrieve the last block the Cosmos ledger has processed, using this value to calculate and set its downloading start cursor (`origin = clamp(C, tail-1, latest-1)`).

### 1.2 Strict Sequential Processing Invariant

- **The Chain-Phase Rule**: The decentralized API is a gateway to a Cosmos ledger that enforces block receipt order. Releasing transactions out-of-order or skipping blocks is fatal.
- **Queue-As-Buffer**: If a block is skipped due to network latency, the API queues subsequent blocks but **blocks execution** until `latest+1` arrives, then drains in perfect order.
- **Confirm-Before-Advance (commit 2)**: `latest` advances **only after every receipt of a block is confirmed recorded on-chain** (module-state read). A drain failure leaves the block buffered, `latest` unchanged, and the POST still returns `200` — retried on the next POST. This replaces the old "broadcast = committed" / `500`-on-failure model.

### 1.3 Recovery vs. Self-Healing Restart

- **In-Memory Range History**: Geth groups block payloads into batches/ranges as they are downloaded. It stores the last *N* finalized ranges of these payloads in memory (default 4).
- **Geth-Side Self-Healing**: Geth queries the API's latest block before sending a range starting at `blockX`.
  - **If API is slightly behind** (within Geth's *N*-range memory): Geth re-transmits the missing range(s) from memory block-by-block, restoring API state.
  - **If API is deeply behind** (beyond Geth's memory capacity): Geth logs a critical error (`log.Crit`) and exits. The system supervisor (e.g., Docker, Cosmovisor) restarts Geth. On restart, Geth's startup handshake queries the API's actual progress and seamlessly re-seeds its sync origin to resume downloading from the correct block height.

### 1.4 Schema Unification

- **Legacy Cleanup**: Historically, the API status endpoint returned a bloat of redundant keys (`latestProcessedBlock`, `lastBlock`, `blockNumber`, `block`) to support older Geth versions.
- **Standardization**: We unify both Geth and the API to use **only** the `blockNumber` key (plus `chainId` for context) across all endpoints. Geth's `GetLastConfirmedBlock` is refactored to parse only `blockNumber`.

### 1.5 Initial State & Handshake Error Fallback

- **Fail-Safe Architecture**: The synchronization loop must be resilient against API-side downtime or uninitialized states. Geth must **never** block or freeze its downloader because of failures in the continuity check.
- **Graceful Fallback**: If the API is in its initial state (returning no block number, `ok == false`) OR if Geth fails to reach the API (transport error, connection timeout, 5xx server error, `err != nil`), Geth must **gracefully fall back to its previous legacy behavior**:
  - **At Startup**: Geth calculates its sync origin as `latest - 1` (normal previous behavior) instead of blocking or erroring.
  - **During Sync Loop**: Geth logs a warning and posts block ranges directly to the API (`sendRangeDirectly`) without enforcing continuity checks, managing range memory, or triggering restarts.
- **Automatic Bootstrapping Handoff**: Once Geth successfully posts its first block range through the fallback path, the API automatically bootstraps its database state. For all subsequent queries, the handshake will return `ok == true` and Geth will seamlessly transition to enforcing full continuity.

### 1.6 Two-Layer Recovery Model (Geth side)

Geth recovers from API/cosmos lag through **two complementary layers**. They are not redundant — each covers a different failure mode and time scale:

- **Layer 1 — Origin re-seed (`receiptSyncOrigin`, cycle start)**: At the start of every ReceiptSync cycle, Geth queries the API's last confirmed block `C` and sets `origin = clamp(C, skeletonTail-1, latest-1)`, so it re-downloads from `C+1`. This is the §1.1 handshake alignment and is the **only** mechanism that recovers a gap **across a restart** (a fresh process re-derives `origin` from `C`). It also re-fetches the missing bodies/receipts from devp2p execution peers.
  - **`latest` is the beacon/skeleton head** (from `d.skeleton.Bounds()`), **not** the API's `block/latest` (`C`). They move independently, which is exactly why we keep the explicit `C` query for re-seeding.
  - **Cosmos-down behavior is FALLBACK, not pause** (Option B): if the API is unreachable at cycle start, `receiptSyncOrigin` returns `latest-1` (proceed as before) instead of erroring. This keeps the downloader from freezing and lets Layer 2 own in-process recovery.
- **Layer 2 — In-RAM range cache (`CheckContinuityAndSend`, send time)**: After a segment is downloaded, Geth resends shallow gaps directly from a rolling cache of the last *N* finalized ranges (default 4), without waiting for a devp2p re-download. This is a **fast path / optimization** over Layer 1 for the common case where the API lost its volatile `pendingBlocks` buffer on restart (so `C` regressed by ≤ *N* ranges).

### 1.7 Configurable In-RAM Cache Window

The number of finalized ranges Geth keeps in memory is operator-configurable via `--bridge.cacheranges` (Geth) / `BRIDGE_CACHE_RANGES` (wrapper), **default 4**.

- **Sizing rationale**: at ~12–20 min of synchronous processing per segment, 4 ranges ≈ 48–80 min of in-RAM recovery window, which exceeds the realistic API/cosmos lag. A gap wider than the window is treated as an emergency: deliberate `log.Crit` → supervisor restart → Layer 1 re-seed.
- **Off switch**: continuity is disabled by leaving `--bridge.getlastblock` **unset** (existing `IsContinuityConfigured() == false` fallback → legacy direct posting, no restart).
- **Minimum window**: when continuity *is* configured, `--bridge.cacheranges` must be `>= 1`. If a value `< 1` is supplied, clamp to `1` and `log.Warn`.

---

## Part II — API commit pipeline (commit 2)

### 2.1 The POST Contract: Receipt-ACK, not Commit

- **Geth ignores the POST result for flow control.** `importBlockReceiptResults` logs a warning and **continues** on a failed `CheckContinuityAndSend`; it never retries the same segment synchronously. Gating the POST on a synchronous Cosmos commit buys nothing on Geth's side.
- **`sendRangeDirectly` stops at the first non-200.** A `500` on a block that was actually *received fine* leaves the **rest of that segment unsent**, manufacturing gaps in what the API ever sees.
- **Contract:** the POST response means **"block received into the queue"** (`200`), **"malformed input"** (`400`), or **"I cannot accept this block right now — back off"** (`503`, queue full). It **never** reports Cosmos commit status.

### 2.2 Confirm-Before-Advance (never skip; resend is safe)

- **`BridgeExchange` is fire-and-forget today.** It uses `BroadcastTxSync` (CheckTx only, not inclusion) and `broadcastMessage` **swallows `resp.Code != 0`**. A CheckTx rejection — or an accepted-but-never-included tx — can report **success**, letting the API advance `latest` over a receipt that never landed: a **silent skip**.
- **Protection is against *skipping*, not *resending*.** Re-sending an already-applied receipt is harmless (§2.3). The API advances `latest` **only after the receipt is confirmed recorded on-chain**, and may freely re-send on any uncertainty.
- **No pre-check.** Send optimistically, then **read the outcome**.

### 2.3 On-Chain Idempotency & Dedup-as-Success

- The chain enforces exactly-once *effect* (dedup by content; mint once per `BRIDGE_PENDING`).
- A re-submission by the same validator returns `"validator has already validated this transaction"`. The API treats **"our validator already recorded this receipt"** as **success**, not an error.

### 2.4 Index-Independent Confirmation (validators may run `tx_index = "null"`)

- Validators may run `tx_index = "null"`. `WaitForTx` / `SyncNoRetry` fail-fast under `null` and cannot distinguish on-chain success from failure — **rejected** as the confirmation authority.
- **Rule:** confirmation uses a **module-state read** via the **already-deployed** `BridgeTransaction` query (`GetBridgeTransactionsByReceipt`): match full receipt content, check **our validator** is in `Validators`. No chain upgrade required. An `O(1)` dedicated query is a future optimization gated on a chain upgrade.

### 2.5 Back-Pressure instead of Silent Drop

- A full per-chain buffer returns **`503`** so Geth's `sendRangeDirectly` stops and resends later. We never drop a block while reporting it received (`200`).

### 2.6 Retry Model (drain on next POST; no background worker)

- The drain runs **inside `AddBlock`** and always restarts at `latest+1`. There is **no** background ticker/worker.
- A block that fails to commit stays in the queue; retried on the **next POST**. With an L1 that keeps producing blocks, Geth keeps POSTing, so retries keep flowing.

### 2.7 Concurrency: No Network I/O Under the Data Lock

- The drain performs broadcast + confirmation I/O per receipt. The data lock (`sync.RWMutex`) is taken only for quick in-memory reads/writes; all network I/O happens with the lock released. Draining is serialized by a **separate** `drainMu` so `GET /v1/bridge/block/latest` stays responsive.

---

## Part III — System architecture flowcharts

### 3.1 Geth-Side Downloader, Continuity & Cache Lifecycle

Zoom: **`CheckContinuityAndSend`** — handshake, gap math, in-RAM resend vs `log.Crit`, and *which* blocks to send. The `SendRange` / `SendFilter` / `SendDirect` / `ResendMemory` nodes all end in "POST block-by-block"; per-POST `200`/`503` behavior is expanded in §3.4.

```mermaid
flowchart TD
    %% Define Nodes
    Start([Segment of results downloaded]) --> FetchAddrs[Fetch bridge contract addresses once]
    FetchAddrs --> PreparePayloads[Prepare BlockRequest payloads for all blocks in segment]
    PreparePayloads --> QueryAPI[Query GET /v1/bridge/block/latest]

    %% Far Right Branch: Handshake/Transport Failure (Graceful Fallback)
    QueryAPI -- "Transient Transport Error OR Handshake Failure\n(Graceful Fallback)" --> SendDirect[Send segment block-by-block directly]
    SendDirect --> Done([Segment Sync Complete])

    %% Success Branch
    QueryAPI -- "Success: Got apiLatest" --> Compare{Compare apiLatest with expected blockX - 1}

    %% Left Branch: API is behind (Check memory or abort for restart)
    Compare -- "apiLatest < expected\n(API is behind)" --> CheckMemory{Is apiLatest + 1\nin memory?}

    CheckMemory -- "No: Deep Gap\n(Unrecoverable)" --> LogCrit[log.Crit: Gap exceeds Geth memory]
    LogCrit --> Exit([os.Exit 1: Abort & Restart Node])

    CheckMemory -- "Yes: Recoverable" --> ResendMemory[Resend missing blocks from memory]
    ResendMemory --> SendRange[Send segment block-by-block via POST]

    %% Middle Branch: Sequential / Normal Path
    Compare -- "apiLatest == expected\n(Sequential)" --> SendRange

    %% Right Branch: API is ahead (Filter & Send only if needed)
    Compare -- "apiLatest >= blockX\n(API is ahead)" --> FilterRange{Are there blocks > apiLatest?}
    FilterRange -- "No: API fully ahead" --> Done
    FilterRange -- "Yes: Partial overlap" --> SendFilter[Send remaining blocks > apiLatest]

    %% Memory Caching (Only for successful handshake paths that actually sent blocks)
    SendRange --> CacheRange[Save segment to recentRanges memory]
    SendFilter --> CacheFilter[Save sent blocks to recentRanges memory]
    CacheRange --> Done
    CacheFilter --> Done
```

### 3.2 Memory Caching vs. Node Restart

| Path / Outcome | Trigger Condition | Actions Taken | Purpose |
| --- | --- | --- | --- |
| **Save Segment to Memory** (`CacheRange` / `CacheFilter`) | A block range (or filtered partial range) is successfully sent to the API, and the API handshake was successful (sequential, recovered from memory, or partially ahead). | 1. Post the newly sent blocks to the API.<br>2. Append the sent blocks as a range to Geth's in-memory `recentRanges` slice.<br>3. Evict the oldest range if `len(recentRanges) > BridgeMaxCachedRanges` (default 4). | Rolling window of the last *N* finalized ranges so Geth can self-heal and resend blocks if the API briefly drops or lags. |
| **Supervisor Restart** (`log.Crit`) | The API is healthy and online, but its progress (`apiLatest`) lags behind Geth's expected block height by more than the *N* ranges stored in Geth's memory (or the cache does not contiguously cover the gap). | 1. Log a critical error (`log.Crit`) specifying the gap size (go-ethereum's `log.Crit` terminates the process). | Triggers the node supervisor to restart Geth. On startup, Geth queries the API's actual progress to re-bootstrap its skeleton downloader origin (Layer 1), correcting the gap. |

> [!IMPORTANT]
> **No Caching on Legacy Fallback or Full Skip**
> * **Graceful Fallback**: If the API is offline or returns a transport error, Geth posts the range directly using `SendDirect` and **bypasses** all memory caching.
> * **API Fully Ahead**: If the API is fully ahead of the current segment (`apiLatest >= endBlock`), Geth skips sending entirely and **bypasses** memory caching.

### 3.3 API-Side Commit Pipeline (accept + drain)

The POST does the **accept** phase and returns; the **drain** phase commits from `latest+1`, advancing `latest` only when every receipt of a block is confirmed.

```mermaid
flowchart TD
    POST([POST /admin/v1/bridge/block]) --> Accept[ACCEPT phase: acquire data lock]
    Accept --> Valid{Valid blockNumber & fields?}
    Valid -- No --> R400([Return 400: malformed])
    Valid -- Yes --> Dup{blockNumber <= latest?}
    Dup -- "Yes: duplicate" --> Ret200d([Return 200: received])
    Dup -- "No" --> Gap{blockNumber > latest + 1?}
    Gap -- "Yes: out of order" --> Cap{Buffer full for chain?}
    Cap -- "Yes" --> R503([Return 503: BACK-PRESSURE, never drop])
    Cap -- "No" --> Buf[Buffer block] --> Ret200([Return 200: received])
    Gap -- "No: == latest + 1" --> Buf2[Buffer block] --> Ret200

    Ret200 -. triggers .-> Drain
    Ret200d -. triggers .-> Drain

    subgraph Drain[DRAIN phase: drainMu held, data lock NOT held during I/O]
        D1{block latest+1 buffered?}
        D1 -- No --> Stop([Stop draining])
        D1 -- "Yes" --> Send[Broadcast each receipt: no pre-check]
        Send --> Conf[Confirm via existing BridgeTransaction query: our validator recorded? NOT WaitForTx]
        Conf -- "recorded / already-validated = success" --> AllR{All receipts confirmed?}
        Conf -- "not yet / real error" --> LogStop[Log only; leave block; latest unchanged; stop]
        AllR -- No --> Send
        AllR -- "Yes" --> Adv[Advance latest+1: SQLite + memory; delete block]
        Adv --> D1
    end
```

**Startup (Phase 1, unchanged from commit 1):** on API boot, `NewBlockQueue` loads `latestBlocks` from SQLite once (`LoadAllBridgeLatestBlocks`). Fresh chains buffer ≥ 6 blocks before bootstrapping `latest = minBlock - 1`. All subsequent duplicate/out-of-order checks use the in-memory map — no SQLite reads on the POST hot path.

### 3.4 Geth POST loop — detail inside §3.1's send nodes (`200` / `503`)

Not a second top-level Geth chart — a **zoom into `sendRangeDirectly`**, i.e. what happens inside every "Send segment block-by-block via POST" box in §3.1 (`SendRange`, `SendFilter`, `SendDirect`, `ResendMemory`). §3.1 answers *what* to send; this answers *how each POST is interpreted*.

Also adds cycle context §3.1 omits: Layer 1 re-seed, segment download, Layer 2 cache write, and `importBlockReceiptResults` swallow-on-continue.

Commit 2 change here only: POST means `200` = received into queue (keep sending the segment); stop the segment on `503` / other non-`200` during accept — not on Cosmos commit failure.

```mermaid
flowchart TD
    Cyc([ReceiptSync cycle start]) --> Seed[receiptSyncOrigin: re-seed origin from API C — Layer 1]
    Seed --> DL[Download bodies + receipts for segment]
    DL --> Chk[CheckContinuityAndSend]
    Chk --> Sendr[sendRangeDirectly: POST each block in order]
    Sendr --> Resp{POST status?}
    Resp -- "200: received" --> Nextb[Next block in segment]
    Resp -- "503 / non-200" --> StopSeg[Stop sending this segment]
    Nextb --> Sendr
    Nextb --> Cache[SaveRangeToMemory — Layer 2]
    StopSeg --> Swallow[importBlockReceiptResults: log warn, CONTINUE]
    Cache --> NextCyc([Next cycle])
    Swallow --> NextCyc
    NextCyc --> Cyc
```

### 3.5 Why decoupled POST + confirmed commit

1. **Receipt-ACK POST**: Geth swallows the response and `sendRangeDirectly` stops at the first non-200. Returning `200` on receipt lets Geth POST the **entire** segment. The queue holds the full run and the drain cascades once `latest+1` clears — eliminating the "missing middle blocks" gap a mid-segment `500` would create.
2. **Confirmed commit**: `latest` is the contract with Geth's handshake. Advancing it only after on-chain confirmation guarantees resuming from `latest+1` is always correct, with **no skipped receipt**. Combined with on-chain dedup, re-sends are safe and idempotent.
3. **Back-pressure, not drop**: the single place we say "no" to Geth (`503`) is when the buffer is full — exactly when we want Geth to pause and resend later, never losing a block.

