### PR TITLE
Auto-finish live inferences at settlement drain

### DIFF
--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -300,6 +300,12 @@ func WithMaxNonceProvider(p devshard.MaxNonceProvider) HostOption {
 // WithGrace adds a StalenessChecker to the host's acceptance chain.
 // If a checker was already set via the constructor, both are composed
 // via CompositeChecker.
+//
+// Production HostManager intentionally does not use this option: settlement
+// protection comes from deterministic drain accounting (settleLiveRecordLocked),
+// not signature withholding. WithGrace must not be paired with finish-gossip
+// recovery — gossip is a best-effort convenience for the user to sequence a
+// real Finish at actual cost; withholding would freeze settlement instead.
 func WithGrace(grace uint64) HostOption {
 	return func(h *Host) {
 		sc := NewStalenessChecker(h.mempool, grace)
@@ -646,6 +652,10 @@ func (h *Host) broadcastTxsBestEffort(txs []*types.DevshardTx) {
 // collectStaleFinishesLocked returns locally proposed MsgFinishInference txs
 // that the user sequencer has not yet included in a diff after the grace
 // period. Caller must hold h.mu. See Mempool.StaleFinishes for the criterion.
+//
+// Recovery gossip (broadcastTxsBestEffort) is independent of WithGrace: it
+// gives the payer another path to pick up a Finish before settlement drain
+// auto-credits at reserved cost. It does not gate signing.
 func (h *Host) collectStaleFinishesLocked() []*types.DevshardTx {
 	if h.gsp == nil {
 		return nil

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1570,7 +1570,8 @@ func TestHost_SavesSnapshotOnSettlement(t *testing.T) {
 
 // newExecutorHostWithGossip wires host index 1 (executor for inference 1, since
 // 1 % 3 = 1) with a real *gossip.Gossip instance backed by recordingPeer so we
-// can observe the host's recovery-gossip dispatch.
+// can observe the host's recovery-gossip dispatch. Matches production HostManager:
+// no WithGrace (gossip recovery is not paired with signature withholding).
 func newExecutorHostWithGossip(t *testing.T) (*Host, []*signing.Secp256k1Signer, *signing.Secp256k1Signer, *recordingPeer) {
 	t.Helper()
 	hosts := []*signing.Secp256k1Signer{
@@ -1586,9 +1587,7 @@ func newExecutorHostWithGossip(t *testing.T) (*Host, []*signing.Secp256k1Signer,
 	require.NoError(t, err)
 
 	engine := stub.NewInferenceEngine()
-	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil,
-		WithGrace(100),
-	)
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil)
 	require.NoError(t, err)
 
 	// Build gossip with the host's own mempool as MempoolSink; attach it
@@ -1710,4 +1709,58 @@ func TestHost_FinishGossipRecovery_PeerImportedFinishNotAmplified(t *testing.T) 
 	}
 
 	assertNoTxsCallFor(t, peer, 50*time.Millisecond)
+}
+
+// TestHost_FinishGossipRecovery_StillSignsWithoutWithGrace guards Step 4 of the
+// settlement auto-finish plan: stale-finish recovery gossip must not be paired
+// with WithGrace. The host still signs state even when its own Finish sits
+// stale in the mempool past the gossip grace window.
+func TestHost_FinishGossipRecovery_StillSignsWithoutWithGrace(t *testing.T) {
+	h, _, user, peer := newExecutorHostWithGossip(t)
+	require.Nil(t, h.checker, "production-like host must not install StalenessChecker")
+
+	groupSize := uint64(len(h.Group()))
+	grace := finishGossipGraceRotations * groupSize
+
+	diff1 := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	resp, err := h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{diff1}, Nonce: 1, Payload: defaultPayload(),
+	})
+	require.NoError(t, err)
+	_, err = h.RunExecution(context.Background(), resp.ExecutionJob)
+	require.NoError(t, err)
+
+	for nonce := uint64(2); nonce <= 2+grace; nonce++ {
+		diff := testutil.SignDiff(t, user, "escrow-1", nonce, nil)
+		resp, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
+		require.NoError(t, err)
+		require.NotNil(t, resp.StateSig, "nonce %d: host must sign without WithGrace", nonce)
+	}
+
+	calls := awaitTxsCall(t, peer, 2*time.Second)
+	require.NotEmpty(t, calls, "recovery gossip should still fire without WithGrace")
+}
+
+// TestHost_ProductionConfig_OmitsWithGrace mirrors HostManager.hostOpts: production
+// hosts omit WithGrace; settlement protection is in the state-machine drain.
+func TestHost_ProductionConfig_OmitsWithGrace(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	store := testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 100_000)
+	sm, err := state.NewStateMachine("escrow-1", config, group, 100_000, user.Address(), verifier, store)
+	require.NoError(t, err)
+
+	h, err := NewHost(sm, hosts[0], stub.NewInferenceEngine(), "escrow-1", group, nil,
+		WithStorage(store),
+		WithEpochID(7),
+	)
+	require.NoError(t, err)
+	require.Nil(t, h.checker)
 }

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -87,8 +87,8 @@ type StateMachine struct {
 	// sealed. It is the only piece of per-id seal metadata that survives in
 	// the durable sealed-inference index; everything else needed for cold-path
 	// validation lives in committedEntries (and on disk in the snapshot).
-	sealedNonces map[uint64]uint64
-	inferenceStore    storage.Storage
+	sealedNonces   map[uint64]uint64
+	inferenceStore storage.Storage
 
 	// Lookup maps derived from group at construction time.
 	slotToAddress      map[uint32]string
@@ -172,15 +172,15 @@ func NewStateMachine(
 
 	sm := &StateMachine{
 		state: &types.EscrowState{
-			EscrowID:   escrowID,
+			EscrowID:                    escrowID,
 			StateRootAndProtocolVersion: types.EffectiveStateRootAndProtocolVersion,
-			Config:     config,
-			Group:      groupCopy,
-			Balance:    initialBalance,
-			Fees:       config.CreateDevshardFee,
-			Inferences: make(map[uint64]*types.InferenceRecord),
-			HostStats:  hostStats,
-			WarmKeys:   make(map[uint32]string),
+			Config:                      config,
+			Group:                       groupCopy,
+			Balance:                     initialBalance,
+			Fees:                        config.CreateDevshardFee,
+			Inferences:                  make(map[uint64]*types.InferenceRecord),
+			HostStats:                   hostStats,
+			WarmKeys:                    make(map[uint32]string),
 		},
 		verifier:           verifier,
 		userAddress:        userAddress,
@@ -1117,6 +1117,28 @@ func (sm *StateMachine) applyFinalizeRound() error {
 	}
 	sm.state.Phase = types.PhaseFinalizing
 	return nil
+}
+
+// settleLiveRecordLocked applies the deterministic settlement default to a
+// still-live inference at the Finalizing->Settlement drain.
+func (sm *StateMachine) settleLiveRecordLocked(rec *types.InferenceRecord) {
+	switch rec.Status {
+	case types.StatusStarted:
+		// Host committed via signed receipt: pay reserved (surplus == 0).
+		rec.ActualCost = rec.ReservedCost
+		rec.Status = types.StatusFinished
+		sm.state.HostStats[rec.ExecutorSlot].Cost += rec.ReservedCost
+	case types.StatusPending:
+		// No commitment: refund the reservation to the creator.
+		sm.state.Balance += rec.ReservedCost
+		rec.ActualCost = 0
+		rec.Status = types.StatusTimedOut
+		// Do not Missed++: state cannot distinguish user censorship from host absence.
+	case types.StatusChallenged:
+		// Mid-dispute: keep current tally-driven status; seal as-is.
+	default:
+		// Terminal already; seal unchanged.
+	}
 }
 
 // BuildDiffContent creates the proto DiffContent from nonce, txs, escrowID, and postStateRoot for signing.

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -2294,6 +2294,218 @@ func TestV2_FinalizeDrainDeterministicOrder(t *testing.T) {
 	require.Equal(t, rootA, rootB)
 }
 
+func advanceToSettlement(t *testing.T, sm *StateMachine, user *signing.Secp256k1Signer, groupSize int) {
+	t.Helper()
+	nonce := sm.LatestNonce() + 1
+	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txFinalize()})
+	_, err := sm.ApplyDiff(diff)
+	require.NoError(t, err)
+	require.Equal(t, types.PhaseFinalizing, sm.Phase())
+
+	st := sm.SnapshotState()
+	for n := st.LatestNonce + 1; n <= st.FinalizeNonce+uint64(groupSize); n++ {
+		diff = testutil.SignDiff(t, user, "escrow-1", n, nil)
+		_, err = sm.ApplyDiff(diff)
+		require.NoError(t, err)
+	}
+	require.Equal(t, types.PhaseSettlement, sm.Phase())
+}
+
+func TestDrainSettle_StartedAutoFinishes(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	sm, user := newTestSM(t, hosts, 10000)
+	applyStartConfirmFinish_Setup(t, sm, user, hosts, 1)
+
+	before := sm.SnapshotState()
+	require.Equal(t, uint64(0), before.HostStats[1].Cost)
+
+	advanceToSettlement(t, sm, user, len(hosts))
+
+	after := sm.SnapshotState()
+	require.Equal(t, uint64(150), after.HostStats[1].Cost)
+	require.Equal(t, before.Balance, after.Balance)
+
+	sealed, ok := sm.LookupSealedInference(1)
+	require.True(t, ok)
+	require.Equal(t, types.StatusFinished, sealed.Status)
+	require.Equal(t, uint64(150), sealed.ActualCost)
+}
+
+func TestDrainSettle_PendingRefunds(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	sm, user := newTestSM(t, hosts, 10000)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
+		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	})})
+	_, err := sm.ApplyDiff(diff)
+	require.NoError(t, err)
+
+	before := sm.SnapshotState()
+	require.Equal(t, types.StatusPending, before.Inferences[1].Status)
+
+	advanceToSettlement(t, sm, user, len(hosts))
+
+	after := sm.SnapshotState()
+	require.Equal(t, before.Balance+150, after.Balance)
+	require.Equal(t, uint64(0), after.HostStats[1].Cost)
+	require.Equal(t, uint32(0), after.HostStats[1].Missed)
+
+	sealed, ok := sm.LookupSealedInference(1)
+	require.True(t, ok)
+	require.Equal(t, types.StatusTimedOut, sealed.Status)
+	require.Equal(t, uint64(0), sealed.ActualCost)
+}
+
+func TestDrainSettle_ChallengedUnchanged(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	sm, user := newTestSM(t, hosts, 10000)
+	applyStartConfirmFinish(t, sm, user, hosts, 1)
+
+	valMsg := &types.MsgValidation{InferenceId: 1, ValidatorSlot: 0, Valid: false, EscrowId: "escrow-1"}
+	valMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], valMsg)
+	nonce := sm.SnapshotState().LatestNonce + 1
+	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txValidation(valMsg)})
+	_, err := sm.ApplyDiff(diff)
+	require.NoError(t, err)
+
+	before := sm.SnapshotState()
+	require.Equal(t, types.StatusChallenged, before.Inferences[1].Status)
+	require.Equal(t, uint64(120), before.HostStats[1].Cost)
+
+	advanceToSettlement(t, sm, user, len(hosts))
+
+	after := sm.SnapshotState()
+	require.Equal(t, before.Balance, after.Balance)
+	require.Equal(t, uint64(120), after.HostStats[1].Cost)
+
+	sealed, ok := sm.LookupSealedInference(1)
+	require.True(t, ok)
+	require.Equal(t, types.StatusChallenged, sealed.Status)
+	require.Equal(t, uint32(1), sealed.VotesInvalid)
+}
+
+// TestDrainSettle_CensoredFinishCreditsHost is the settlement-drain regression
+// for the "free compute" exploit: user sequences start+confirm, censors finish,
+// and finalizes — the host must be credited ReservedCost without WithGrace.
+func TestDrainSettle_CensoredFinishCreditsHost(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	sm, user := newTestSM(t, hosts, 10000)
+	applyStartConfirmFinish_Setup(t, sm, user, hosts, 1)
+
+	before := sm.SnapshotState()
+	require.Equal(t, types.StatusStarted, before.Inferences[1].Status)
+	require.Equal(t, uint64(0), before.HostStats[1].Cost)
+
+	advanceToSettlement(t, sm, user, len(hosts))
+
+	after := sm.SnapshotState()
+	require.Equal(t, uint64(150), after.HostStats[1].Cost)
+	require.Equal(t, before.Balance, after.Balance)
+}
+
+func TestDrainSettle_MixedDeterministic(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+
+	driveMixed := func(t *testing.T) *StateMachine {
+		t.Helper()
+		sm, user := newTestSM(t, hosts, 20000)
+
+		// inf 1: pending (executor slot 1).
+		diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
+			InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
+			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		})})
+		_, err := sm.ApplyDiff(diff)
+		require.NoError(t, err)
+
+		for nonce := uint64(2); nonce <= 3; nonce++ {
+			diff = testutil.SignDiff(t, user, "escrow-1", nonce, nil)
+			_, err = sm.ApplyDiff(diff)
+			require.NoError(t, err)
+		}
+
+		// inf 4: started (executor slot 4).
+		diff = testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{txStart(&types.MsgStartInference{
+			InferenceId: 4, PromptHash: []byte("prompt"), Model: "llama",
+			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		})})
+		_, err = sm.ApplyDiff(diff)
+		require.NoError(t, err)
+
+		execSig := testutil.SignExecutorReceipt(t, hosts[4], "escrow-1", 4, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+		diff = testutil.SignDiff(t, user, "escrow-1", 5, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
+			InferenceId: 4, ExecutorSig: execSig, ConfirmedAt: 1000,
+		})})
+		_, err = sm.ApplyDiff(diff)
+		require.NoError(t, err)
+
+		diff = testutil.SignDiff(t, user, "escrow-1", 6, nil)
+		_, err = sm.ApplyDiff(diff)
+		require.NoError(t, err)
+
+		// inf 7: finished (executor slot 2).
+		diff = testutil.SignDiff(t, user, "escrow-1", 7, []*types.DevshardTx{txStart(&types.MsgStartInference{
+			InferenceId: 7, PromptHash: []byte("prompt"), Model: "llama",
+			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		})})
+		_, err = sm.ApplyDiff(diff)
+		require.NoError(t, err)
+
+		execSig = testutil.SignExecutorReceipt(t, hosts[2], "escrow-1", 7, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+		diff = testutil.SignDiff(t, user, "escrow-1", 8, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
+			InferenceId: 7, ExecutorSig: execSig, ConfirmedAt: 1000,
+		})})
+		_, err = sm.ApplyDiff(diff)
+		require.NoError(t, err)
+
+		finishMsg := &types.MsgFinishInference{
+			InferenceId: 7, ResponseHash: []byte("response"),
+			InputTokens: 80, OutputTokens: 40, ExecutorSlot: 2,
+			EscrowId: "escrow-1",
+		}
+		finishMsg.ProposerSig = testutil.SignProposerTx(t, hosts[2], finishMsg)
+		diff = testutil.SignDiff(t, user, "escrow-1", 9, []*types.DevshardTx{txFinish(finishMsg)})
+		_, err = sm.ApplyDiff(diff)
+		require.NoError(t, err)
+
+		advanceToSettlement(t, sm, user, len(hosts))
+		return sm
+	}
+
+	a := driveMixed(t)
+	b := driveMixed(t)
+
+	stA := a.SnapshotState()
+	stB := b.SnapshotState()
+	require.Equal(t, stA.SealedAcc, stB.SealedAcc)
+	require.Equal(t, stA.HostStats, stB.HostStats)
+	require.Equal(t, stA.Balance, stB.Balance)
+
+	require.Equal(t, uint64(0), stA.HostStats[1].Cost)
+	require.Equal(t, uint64(150), stA.HostStats[4].Cost)
+	require.Equal(t, uint64(120), stA.HostStats[2].Cost)
+
+	var totalCost uint64
+	for _, hs := range stA.HostStats {
+		totalCost += hs.Cost
+	}
+	require.LessOrEqual(t, totalCost+stA.Fees, uint64(20000))
+}
+
 // --- Warm Key Tests ---
 
 func newTestSMWithWarmKey(t *testing.T, hosts []*signing.Secp256k1Signer, balance uint64, resolver WarmKeyResolver) (*StateMachine, *signing.Secp256k1Signer) {
@@ -2923,4 +3135,104 @@ func TestApplyLocalBestEffort_ChallengeObsInsertFailure_StillApplied(t *testing.
 	require.NoError(t, err)
 	require.Equal(t, root, hostRoot)
 	require.Equal(t, types.StatusChallenged, hostSM.SnapshotState().Inferences[1].Status)
+}
+
+func callSettleLiveRecordLocked(t *testing.T, sm *StateMachine, rec *types.InferenceRecord) {
+	t.Helper()
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.settleLiveRecordLocked(rec)
+}
+
+func TestSettleLiveRecordLocked_Started(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	sm, user := newTestSM(t, hosts, 10000)
+	applyStartConfirmFinish_Setup(t, sm, user, hosts, 1)
+
+	before := sm.SnapshotState()
+	rec := before.Inferences[1]
+	require.Equal(t, types.StatusStarted, rec.Status)
+	require.Equal(t, uint64(150), rec.ReservedCost)
+	require.Equal(t, uint64(0), before.HostStats[1].Cost)
+
+	callSettleLiveRecordLocked(t, sm, sm.state.Inferences[1])
+
+	after := sm.SnapshotState()
+	require.Equal(t, types.StatusFinished, after.Inferences[1].Status)
+	require.Equal(t, uint64(150), after.Inferences[1].ActualCost)
+	require.Equal(t, uint64(150), after.HostStats[1].Cost)
+	require.Equal(t, before.Balance, after.Balance)
+}
+
+func TestSettleLiveRecordLocked_Pending(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	sm, user := newTestSM(t, hosts, 10000)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
+		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	})})
+	_, err := sm.ApplyDiff(diff)
+	require.NoError(t, err)
+
+	before := sm.SnapshotState()
+	rec := before.Inferences[1]
+	require.Equal(t, types.StatusPending, rec.Status)
+	require.Equal(t, uint64(150), rec.ReservedCost)
+	require.Equal(t, uint32(0), before.HostStats[1].Missed)
+
+	callSettleLiveRecordLocked(t, sm, sm.state.Inferences[1])
+
+	after := sm.SnapshotState()
+	require.Equal(t, types.StatusTimedOut, after.Inferences[1].Status)
+	require.Equal(t, uint64(0), after.Inferences[1].ActualCost)
+	require.Equal(t, before.Balance+rec.ReservedCost, after.Balance)
+	require.Equal(t, uint64(0), after.HostStats[1].Cost)
+	require.Equal(t, uint32(0), after.HostStats[1].Missed)
+}
+
+func TestSettleLiveRecordLocked_ChallengedUnchanged(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	sm, user := newTestSM(t, hosts, 10000)
+	applyStartConfirmFinish(t, sm, user, hosts, 1)
+
+	valMsg := &types.MsgValidation{InferenceId: 1, ValidatorSlot: 0, Valid: false, EscrowId: "escrow-1"}
+	valMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], valMsg)
+	nonce := sm.SnapshotState().LatestNonce + 1
+	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txValidation(valMsg)})
+	_, err := sm.ApplyDiff(diff)
+	require.NoError(t, err)
+
+	before := sm.SnapshotState()
+	require.Equal(t, types.StatusChallenged, before.Inferences[1].Status)
+
+	callSettleLiveRecordLocked(t, sm, sm.state.Inferences[1])
+
+	after := sm.SnapshotState()
+	require.Equal(t, types.StatusChallenged, after.Inferences[1].Status)
+	require.Equal(t, before.Balance, after.Balance)
+	require.Equal(t, before.HostStats[1].Cost, after.HostStats[1].Cost)
+	require.Equal(t, before.Inferences[1].VotesInvalid, after.Inferences[1].VotesInvalid)
+}
+
+func TestSettleLiveRecordLocked_TerminalUnchanged(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	sm, user := newTestSM(t, hosts, 10000)
+	applyStartConfirmFinish(t, sm, user, hosts, 1)
+
+	before := sm.SnapshotState()
+	require.Equal(t, types.StatusFinished, before.Inferences[1].Status)
+	require.Equal(t, uint64(120), before.Inferences[1].ActualCost)
+	require.Equal(t, uint64(120), before.HostStats[1].Cost)
+
+	callSettleLiveRecordLocked(t, sm, sm.state.Inferences[1])
+
+	after := sm.SnapshotState()
+	require.Equal(t, types.StatusFinished, after.Inferences[1].Status)
+	require.Equal(t, uint64(120), after.Inferences[1].ActualCost)
+	require.Equal(t, uint64(120), after.HostStats[1].Cost)
+	require.Equal(t, before.Balance, after.Balance)
 }

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -230,6 +230,7 @@ func (sm *StateMachine) drainLiveIntoSealedAccLocked(sealNonce uint64) error {
 
 	for _, id := range ids {
 		rec := sm.state.Inferences[id]
+		sm.settleLiveRecordLocked(rec)
 		if err := sm.updateCommittedEntryLocked(id, rec); err != nil {
 			return fmt.Errorf("drain live inference %d: %w", id, err)
 		}

--- a/inference-chain/x/inference/keeper/devshard_settlement_test.go
+++ b/inference-chain/x/inference/keeper/devshard_settlement_test.go
@@ -605,6 +605,27 @@ func TestVerifyDevshardSettlement_UnsortedHostStats(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestVerifyDevshardSettlement_AutoFinishedHostCosts exercises chain verification
+// with host_stats shaped like settlement-drain auto-finish (reserved-cost credit
+// on a censored Started inference, zero on refunded Pending slots).
+func TestVerifyDevshardSettlement_AutoFinishedHostCosts(t *testing.T) {
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	keys, slots := generateDevshardKeys(t, keeper.DevshardGroupSize)
+	const escrowAmount = uint64(10_000)
+	escrow := types.DevshardEscrow{
+		Id: 1, Creator: "gonka1creator", Amount: escrowAmount, Slots: slots,
+	}
+
+	hostStats := makeHostStats(keeper.DevshardGroupSize, 0)
+	hostStats[1].Cost = 150 // auto-finished Started inference at reserved cost
+	hostStats[2].Cost = 120 // normally finished inference
+
+	msg := buildSettlementTestData(t, escrow, keys, hostStats, 0)
+	err := keeper.VerifyDevshardSettlement(escrow, msg, testDevshardEscrowParams(), nil)
+	require.NoError(t, err)
+}
+
 func TestVerifyDevshardSettlement_ZeroCost(t *testing.T) {
 	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
 


### PR DESCRIPTION
## Motivation

The user (creator) is the payer, the sole sequencer, **and** the caller of finalize. Settlement should therefore be a deterministic close-out that always resolves — never a state that can be frozen by a participant refusing to sign. Withholding via `WithGrace` is the wrong tool for that: it trades liveness for a veto, does not reliably protect a minority victim under quorum, and can spread freezes through unvalidated gossip with no dispute path to un-brick the session. The fair answer belongs in settlement accounting, not in who signs last.

Today, when the `Finalizing → Settlement` transition drains live inferences into the sealed accumulator, it folds each record **as-is**: a `Started` inference (one the executor cryptographically committed to via a signed receipt) seals with `HostStats[slot].Cost == 0`, because cost is only ever credited by `applyFinishInference`. A malicious sole-sequencer can stream the output, never sequence the `MsgFinishInference`, and settle with the host paid nothing.

This makes the settlement drain apply a **deterministic default outcome** to every still-live inference, by status:

## Summary

Closes a settlement exploit where a user-sequencer could stream inference output, censor `MsgFinishInference`, and settle with `HostStats.Cost == 0` for work the host had already committed to via a signed receipt.

At the `Finalizing → Settlement` drain, live inferences now get a deterministic default outcome instead of sealing as-is:

| Status at drain | Outcome |
| --- | --- |
| `Started` | Credit `ReservedCost` to executor, seal as `Finished` |
| `Pending` | Refund reservation to creator, seal as `TimedOut` |
| `Challenged` | Unchanged (existing tally semantics) |
| Terminal | Unchanged |

Settlement is the terminal step in the devshard lifecycle — no post-settlement challenge window and no distinct auto-finished status.

## Approach

- **State machine:** `settleLiveRecordLocked` in `machine.go`, invoked from `drainLiveIntoSealedAccLocked` in `seal.go`.
- **Host:** Stale-finish gossip recovery stays as a best-effort convenience for the payer to sequence a real `Finish` at actual cost. Production `HostManager` does **not** use `WithGrace` / signature withholding; accounting at drain is the protection.
- **Chain:** No production changes. Existing `VerifyDevshardSettlement` bounds still hold because auto-finish only raises credited cost within reserved debits.

## Tests

- `devshard/state/machine_test.go` — unit and drain integration tests (Started, Pending, Challenged, mixed, censored-finish regression)
- `devshard/state/settlement_chain_test.go` — end-to-end `BuildSettlement` → quorum → `VerifyDevshardSettlement`
- `inference-chain/.../devshard_settlement_test.go` — `TestVerifyDevshardSettlement_AutoFinishedHostCosts`
- `devshard/host/host_test.go` — gossip recovery without `WithGrace`, production config omits `WithGrace`

## Test plan

```bash
cd devshard && go test ./state/ -run 'SettleLive|DrainSettle' -v
cd devshard && go test ./state/ -run 'AutoFinished' -v
cd devshard && go test ./host/ -run 'FinishGossip|ProductionConfig' -v
cd inference-chain && go test ./x/inference/keeper/ -run 'TestVerifyDevshardSettlement_AutoFinishedHostCosts' -v
```

## Rollout note

Consensus-affecting change at the settlement drain. Must be gated behind `StateRootAndProtocolVersion` / `approved_versions` like other root-format changes. See `devshard/docs/settlement-auto-finish-plan.md` for full design rationale.