### PR TITLE
fix(devshard): skip escrow rotation for models absent from the network

### DIFF
--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -263,6 +264,12 @@ func (g *Gateway) ensureRotationEscrows(ctx context.Context, settings GatewaySet
 		}
 	}
 	result.ExistingCount = count
+	if count < target {
+		if served, known := g.rotationModelServedByNetwork(model.ModelID); known && !served {
+			log.Printf("escrow_rotation_skip_model_absent role=%s epoch=%d model=%q reason=model_not_in_network", role, epoch, model.ModelID)
+			return result, nil
+		}
+	}
 	if count < target && g.rotationCreateFailed(model.ModelID, role, epoch) {
 		return result, errEscrowRotationCreateSuppressed
 	}
@@ -275,6 +282,22 @@ func (g *Gateway) ensureRotationEscrows(ctx context.Context, settings GatewaySet
 		result.CreatedCount++
 	}
 	return result, nil
+}
+
+// rotationModelServedByNetwork reports whether the model is served; known is false on cold start (empty model set) so callers don't skip a genuinely-served model.
+func (g *Gateway) rotationModelServedByNetwork(modelID string) (served bool, known bool) {
+	if g == nil || g.capacity == nil {
+		return false, false
+	}
+	networkModels := g.capacity.Models()
+	if len(networkModels) == 0 {
+		return false, false
+	}
+	modelID = strings.TrimSpace(modelID)
+	if slices.Contains(networkModels, modelID) {
+		return true, true
+	}
+	return false, true
 }
 
 func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, role string, epoch uint64) (*CreateDevshardEscrowResult, error) {

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -430,6 +430,136 @@ func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.
 	require.Equal(t, 0, settleAttempts)
 }
 
+func TestEscrowRotationSkipsCreateWhenModelAbsentFromNetwork(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	settings := GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Enabled:           true,
+			SettlementEnabled: true,
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       "Qwen/Removed",
+				TempCount:     1,
+				TargetCount:   16,
+				Amount:        1000,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+			}},
+		},
+	}.WithTuningDefaults()
+	// A stale temp bridge escrow remains for a model the network no longer
+	// serves; finishing rotation must NOT broadcast a regular create (which
+	// the chain rejects with ErrEpochGroupDataNotFound and still burns the
+	// gas fee) but MUST still settle the stranded temp escrow to recover funds.
+	require.NoError(t, store.Initialize(settings, []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Removed"},
+		Active:        true,
+		RotationRole:  rotationRoleTemp,
+		RotationEpoch: 10,
+	}}))
+
+	oldCreate := gatewayCreateRotationEscrow
+	oldSettle := gatewaySettleDevshardOnChain
+	createAttempts := 0
+	var settled []string
+	gatewayCreateRotationEscrow = func(*Gateway, context.Context, GatewaySettings, EscrowRotationModelSettings, string, uint64) (*CreateDevshardEscrowResult, error) {
+		createAttempts++
+		return &CreateDevshardEscrowResult{EscrowID: uint64(90 + createAttempts), TxHash: "OK"}, nil
+	}
+	gatewaySettleDevshardOnChain = func(_ *Gateway, _ context.Context, id string, _ adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		settled = append(settled, id)
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		gatewayCreateRotationEscrow = oldCreate
+		gatewaySettleDevshardOnChain = oldSettle
+	})
+
+	// The network serves a different model; "Qwen/Removed" is positively absent.
+	capacity := NewCapacityState()
+	capacity.SetHostWeightViews(
+		map[string]float64{"host": 1},
+		map[string]float64{"host": 1},
+		map[string]map[string]float64{"Qwen/Present": {"host": 1}},
+		map[string]map[string]float64{"Qwen/Present": {"host": 1}},
+	)
+
+	g := &Gateway{store: store, capacity: capacity, rotationFailures: make(map[string]struct{})}
+	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+
+	require.Equal(t, 0, createAttempts, "must not create escrow for a model absent from the network")
+	require.Equal(t, []string{"12"}, settled, "stranded temp escrow must still be settled")
+}
+
+func TestEscrowRotationCreatesWhenModelPresentInNetwork(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	settings := GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Enabled:           true,
+			SettlementEnabled: true,
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       "Qwen/Test",
+				TempCount:     1,
+				TargetCount:   2,
+				Amount:        1000,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+			}},
+		},
+	}.WithTuningDefaults()
+	require.NoError(t, store.Initialize(settings, []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Test"},
+		Active:        true,
+		RotationRole:  rotationRoleTemp,
+		RotationEpoch: 10,
+	}}))
+
+	oldCreate := gatewayCreateRotationEscrow
+	oldSettle := gatewaySettleDevshardOnChain
+	createAttempts := 0
+	gatewayCreateRotationEscrow = func(*Gateway, context.Context, GatewaySettings, EscrowRotationModelSettings, string, uint64) (*CreateDevshardEscrowResult, error) {
+		createAttempts++
+		return &CreateDevshardEscrowResult{EscrowID: uint64(90 + createAttempts), TxHash: "OK"}, nil
+	}
+	gatewaySettleDevshardOnChain = func(*Gateway, context.Context, string, adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		gatewayCreateRotationEscrow = oldCreate
+		gatewaySettleDevshardOnChain = oldSettle
+	})
+
+	capacity := NewCapacityState()
+	capacity.SetHostWeightViews(
+		map[string]float64{"host": 1},
+		map[string]float64{"host": 1},
+		map[string]map[string]float64{"Qwen/Test": {"host": 1}},
+		map[string]map[string]float64{"Qwen/Test": {"host": 1}},
+	)
+
+	g := &Gateway{store: store, capacity: capacity, rotationFailures: make(map[string]struct{})}
+	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+
+	require.Equal(t, 2, createAttempts, "must create escrows for a model the network serves")
+}
+
 func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Stop the escrow rotator from creating escrows for a model the network no longer serves. With `rotation.enabled=true`, the rotator broadcast `MsgCreateDevshardEscrow` for **every** configured model with no check that the model still exists on chain. For an absent model the chain rejects the tx with `ErrEpochGroupDataNotFound` (code 1126) — but the rejected tx still **consumes the gas fee**, so balance burned once per epoch, indefinitely. This PR gates creation on the model being present in the network's live model set, and only suppresses when we positively know it's absent so legitimate rotation never stalls.

---

## What is the problem

### Creating an escrow for an absent model burns the fee every epoch

**Before** 
`prepareBridgeEscrows` / `finishBridgeEscrows` → `ensureRotationEscrows` → `createRotationEscrow` broadcast a create for each configured rotation model unconditionally. If the model had no epoch group on chain, the tx failed (`code=1`, `ErrEpochGroupDataNotFound`) yet still paid gas. The per-epoch `rotationFailures` suppression only deduped *within* one epoch and reset each epoch, so the burn recurred forever:

```
escrow_rotation_regular_create_failed epoch=311 model="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8" error=... raw_log=failed to get epoch group for model ...: epoch group data not found 
```

**After** 
`rotationModelServedByNetwork(modelID)` checks the model against `CapacityState.Models()` — populated every ~5s by the phase gate from the chain's `/v1/epochs/current/participants` endpoint (each participant advertises its `Models`). When we positively know the model is absent, `ensureRotationEscrows` returns before broadcasting. When the set isn't known yet (empty), it falls through to existing behavior so a real model is never skipped.

---

## Test plan

`go test ./cmd/devshardctl/...` (and `go vet`, `gofmt`) — all green:

- [x] `TestEscrowRotationSkipsCreateWhenModelAbsentFromNetwork` — absent model ⇒ 0 create attempts, stranded temp escrow still settled (recovers funds). Fails RED (16 creates) without the guard.
- [x] `TestEscrowRotationCreatesWhenModelPresentInNetwork` — model present in the network ⇒ creates proceed normally.
- [x] Existing rotation suite (`TestEscrowRotation*`) unchanged and green — `capacity==nil` ⇒ `known=false` ⇒ no behavior change on the existing paths.
