### PR TITLE
Respect reward recipient for stale devshard escrows

### DIFF
--- a/inference-chain/x/inference/keeper/claim_recipient_schedule.go
+++ b/inference-chain/x/inference/keeper/claim_recipient_schedule.go
@@ -29,6 +29,23 @@ func (k Keeper) GetClaimRecipientForEpoch(ctx context.Context, participant sdk.A
 	return v, true, nil
 }
 
+// ResolveClaimRecipientAddress returns the payout address configured for
+// (participant, epoch), or the participant address when no override exists.
+func (k Keeper) ResolveClaimRecipientAddress(ctx context.Context, participant string, epoch uint64) (sdk.AccAddress, error) {
+	participantAddr, err := sdk.AccAddressFromBech32(participant)
+	if err != nil {
+		return nil, err
+	}
+	recipient, found, err := k.GetClaimRecipientForEpoch(ctx, participantAddr, epoch)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return participantAddr, nil
+	}
+	return sdk.AccAddressFromBech32(recipient)
+}
+
 // SetClaimRecipientForEpoch writes the primary schedule entry and pruning index
 // atomically. All claim-recipient writes must use this helper to keep the two
 // collections in sync.

--- a/inference-chain/x/inference/keeper/devshard_pruning.go
+++ b/inference-chain/x/inference/keeper/devshard_pruning.go
@@ -40,7 +40,7 @@ func (k Keeper) distributeUnsettledEscrow(ctx context.Context, escrow types.Devs
 		recipient, err := k.ResolveClaimRecipientAddress(ctx, addr, escrow.EpochIndex)
 		if err != nil {
 			k.LogError("failed to resolve unsettled escrow recipient", types.Pruning,
-				"escrow_id", escrow.Id, "address", addr)
+				"escrow_id", escrow.Id, "address", addr, "epoch", escrow.EpochIndex, "error", err)
 			continue
 		}
 		coins, err := types.GetCoins(int64(amountByAddr[addr]))

--- a/inference-chain/x/inference/keeper/devshard_pruning.go
+++ b/inference-chain/x/inference/keeper/devshard_pruning.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/productscience/inference/x/inference/types"
 )
 
@@ -38,9 +37,9 @@ func (k Keeper) distributeUnsettledEscrow(ctx context.Context, escrow types.Devs
 	}
 
 	for _, addr := range order {
-		recipient, err := sdk.AccAddressFromBech32(addr)
+		recipient, err := k.ResolveClaimRecipientAddress(ctx, addr, escrow.EpochIndex)
 		if err != nil {
-			k.LogError("invalid address in unsettled escrow", types.Pruning,
+			k.LogError("failed to resolve unsettled escrow recipient", types.Pruning,
 				"escrow_id", escrow.Id, "address", addr)
 			continue
 		}

--- a/inference-chain/x/inference/keeper/devshard_pruning_test.go
+++ b/inference-chain/x/inference/keeper/devshard_pruning_test.go
@@ -220,6 +220,41 @@ func TestPruneDevshardData_UnsettledDistributionAmounts(t *testing.T) {
 	require.NoError(t, pruneDevshard(k, ctx, 5))
 }
 
+func TestPruneDevshardData_UnsettledDistributionUsesClaimRecipient(t *testing.T) {
+	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
+
+	participant := sdk.AccAddress(make([]byte, 20))
+	participant[0] = 0x01
+	recipient := sdk.AccAddress(make([]byte, 20))
+	recipient[0] = 0x09
+
+	slots := make([]string, keeper.DevshardGroupSize)
+	for i := range slots {
+		slots[i] = participant.String()
+	}
+
+	escrow := &types.DevshardEscrow{
+		Creator:    "gonka1creator",
+		Amount:     8_000_000_000,
+		Slots:      slots,
+		EpochIndex: 3,
+		Settled:    false,
+	}
+	_, err := k.StoreDevshardEscrow(ctx, escrow, 1)
+	require.NoError(t, err)
+	require.NoError(t, k.SetClaimRecipientForEpoch(ctx, participant, escrow.EpochIndex, recipient.String()))
+
+	expectedShare, err := types.GetCoins(8_000_000_000)
+	require.NoError(t, err)
+	mock.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, recipient, expectedShare, gomock.Eq("devshard_escrow_unsettled_distribution")).
+		Return(nil)
+
+	require.NoError(t, pruneDevshard(k, ctx, 5))
+}
+
 func TestPruneDevshardData_TracksProgress(t *testing.T) {
 	k, ctx, mock := keepertest.InferenceKeeperReturningMocks(t)
 	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")

--- a/inference-chain/x/inference/keeper/keeper.go
+++ b/inference-chain/x/inference/keeper/keeper.go
@@ -134,8 +134,9 @@ type (
 		DelegationSnapshot          collections.Item[types.DelegationSnapshot]
 		BootstrapDelegationSnapshot collections.Item[types.BootstrapDelegationSnapshot]
 		// Per-participant, per-epoch recipient overrides for MsgClaimRewards.
-		// Set by cold key via MsgSetClaimRecipients; consumed on successful
-		// claim payout (in finishSettle).
+		// Set by cold key via MsgSetClaimRecipients; retained after claim so
+		// late same-epoch payouts can resolve the same recipient, then pruned
+		// once the epoch is safely stale.
 		ClaimRecipients collections.Map[collections.Pair[sdk.AccAddress, uint64], string]
 		// Secondary index for pruning stale recipient overrides by epoch.
 		// Must be updated atomically with ClaimRecipients.

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -134,37 +134,19 @@ func (ms msgServer) payoutClaim(ctx sdk.Context, msg *types.MsgClaimRewards, set
 	}, nil
 }
 
-// resolvePayoutAddress returns the destination address for a claim payout:
-// the on-chain scheduled recipient for (participant, epoch) when one has been
-// set by the cold key, otherwise the participant's own address. participant
-// is assumed to be a valid bech32 string — it has already been verified by
-// validateRequest / validateClaim.
+// resolvePayoutAddress returns the destination address for a claim payout.
 func (ms msgServer) resolvePayoutAddress(ctx context.Context, participant string, epoch uint64) (string, error) {
-	addr, err := sdk.AccAddressFromBech32(participant)
+	addr, err := ms.ResolveClaimRecipientAddress(ctx, participant, epoch)
 	if err != nil {
-		return participant, nil
+		return "", fmt.Errorf("failed to resolve claim recipient for participant %s epoch %d: %w", participant, epoch, err)
 	}
-	recipient, found, err := ms.GetClaimRecipientForEpoch(ctx, addr, epoch)
-	if err != nil {
-		return "", fmt.Errorf("failed to lookup claim recipient for participant %s epoch %d: %w", participant, epoch, err)
+	if addr.String() != participant {
+		ms.LogInfo("Using scheduled claim recipient", types.Claims, "participant", participant, "epoch", epoch, "recipient", addr.String())
 	}
-	if !found {
-		return participant, nil
-	}
-	ms.LogInfo("Using scheduled claim recipient", types.Claims, "participant", participant, "epoch", epoch, "recipient", recipient)
-	return recipient, nil
+	return addr.String(), nil
 }
 
 func (ms msgServer) finishSettle(ctx sdk.Context, settleAmount *types.SettleAmount) {
-	// Consume the schedule entry after payout so per-participant state stays
-	// bounded: without removal, entries would accumulate indefinitely as
-	// epochs advance. Pairs with MaxClaimRecipientLookahead which caps writes;
-	// together they bound how many entries any one participant can hold.
-	if addr, err := sdk.AccAddressFromBech32(settleAmount.Participant); err == nil {
-		if err := ms.RemoveClaimRecipientForEpoch(ctx, addr, settleAmount.EpochIndex); err != nil {
-			ms.LogError("Error removing claim recipient override", types.Claims, "error", err, "participant", settleAmount.Participant, "epoch", settleAmount.EpochIndex)
-		}
-	}
 	ms.RemoveSettleAmount(ctx, settleAmount.Participant)
 	perfSummary, found := ms.GetEpochPerformanceSummary(ctx, settleAmount.EpochIndex, settleAmount.Participant)
 	if found {

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards_test.go
@@ -1233,10 +1233,11 @@ func TestPayoutClaim_WithSchedule(t *testing.T) {
 	require.Equal(t, uint64(1500), resp.Amount)
 	require.Equal(t, "Rewards claimed successfully", resp.Result)
 
-	// Entry must be consumed after successful claim.
+	// Entry is retained after successful claim so late/direct payouts for the
+	// same epoch can still resolve the configured recipient.
 	_, found, err := k.GetClaimRecipientForEpoch(sdkCtx, creatorAddr, epochIndex)
 	require.NoError(t, err)
-	require.False(t, found, "claim recipient entry must be removed after successful claim")
+	require.True(t, found, "claim recipient entry must remain until pruning")
 }
 
 func TestPayoutClaim_WithScheduleAndVesting(t *testing.T) {

--- a/inference-chain/x/inference/keeper/msg_server_set_claim_recipients_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_set_claim_recipients_test.go
@@ -209,23 +209,23 @@ func TestClaimRecipientPruningRemovesPrimaryAndIndex(t *testing.T) {
 	k, _, ctx, creatorAddr := setupSchedule(t, 100)
 	require.NoError(t, k.PruningState.Set(ctx, types.PruningState{}))
 
-	require.NoError(t, k.SetClaimRecipientForEpoch(ctx, creatorAddr, 97, testutil.Executor))
-	require.NoError(t, k.SetClaimRecipientForEpoch(ctx, creatorAddr, 98, testutil.Executor2))
+	require.NoError(t, k.SetClaimRecipientForEpoch(ctx, creatorAddr, 95, testutil.Executor))
+	require.NoError(t, k.SetClaimRecipientForEpoch(ctx, creatorAddr, 96, testutil.Executor2))
 
 	require.NoError(t, k.Prune(ctx, 100))
 
-	_, found, err := k.GetClaimRecipientForEpoch(ctx, creatorAddr, 97)
+	_, found, err := k.GetClaimRecipientForEpoch(ctx, creatorAddr, 95)
 	require.NoError(t, err)
 	require.False(t, found)
-	hasIndex, err := k.ClaimRecipientsByEpoch.Has(ctx, collections.Join(uint64(97), creatorAddr))
+	hasIndex, err := k.ClaimRecipientsByEpoch.Has(ctx, collections.Join(uint64(95), creatorAddr))
 	require.NoError(t, err)
 	require.False(t, hasIndex)
 
-	got, found, err := k.GetClaimRecipientForEpoch(ctx, creatorAddr, 98)
+	got, found, err := k.GetClaimRecipientForEpoch(ctx, creatorAddr, 96)
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, testutil.Executor2, got)
-	hasIndex, err = k.ClaimRecipientsByEpoch.Has(ctx, collections.Join(uint64(98), creatorAddr))
+	hasIndex, err = k.ClaimRecipientsByEpoch.Has(ctx, collections.Join(uint64(96), creatorAddr))
 	require.NoError(t, err)
 	require.True(t, hasIndex)
 }

--- a/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow.go
@@ -152,10 +152,6 @@ func (k msgServer) SettleDevshardEscrow(goCtx context.Context, msg *types.MsgSet
 		}
 		paidValidators[addr] = true
 
-		recipientAddr, err := sdk.AccAddressFromBech32(addr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid validator address %s: %w", addr, err)
-		}
 		inCurrentEpoch := treatAsCurrentEpochSettle[addr]
 		if inCurrentEpoch {
 			participant, found := participantByAddr[addr]
@@ -167,6 +163,10 @@ func (k msgServer) SettleDevshardEscrow(goCtx context.Context, msg *types.MsgSet
 			}
 			touchedParticipants[addr] = true
 		} else {
+			recipientAddr, err := k.ResolveClaimRecipientAddress(goCtx, addr, escrow.EpochIndex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve validator recipient %s for epoch %d: %w", addr, escrow.EpochIndex, err)
+			}
 			if err := k.payCoinsDirectly(goCtx, payout, recipientAddr); err != nil {
 				return nil, err
 			}

--- a/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_settle_devshard_escrow_test.go
@@ -456,6 +456,61 @@ func TestSettleDevshardEscrow_PreviousEpochSettlementAllowedWithoutParticipantSt
 	}
 }
 
+func TestSettleDevshardEscrow_PreviousEpochSettlementUsesClaimRecipient(t *testing.T) {
+	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
+	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")
+
+	key, err := dcrdsecp.GeneratePrivateKey()
+	require.NoError(t, err)
+	participant := cosmosAddressFromDcrdKey(key)
+	recipient := sdk.AccAddress(make([]byte, 20))
+	recipient[0] = 0x44
+
+	keys := make([]*dcrdsecp.PrivateKey, keeper.DevshardGroupSize)
+	slots := make([]string, keeper.DevshardGroupSize)
+	for i := 0; i < keeper.DevshardGroupSize; i++ {
+		keys[i] = key
+		slots[i] = participant.String()
+	}
+	setParticipantForDevshardTest(t, k, ctx, participant.String())
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 6))
+
+	creator := sdk.AccAddress(make([]byte, 20))
+	creator[0] = 0x33
+	escrow := types.DevshardEscrow{
+		Id:         1,
+		Creator:    creator.String(),
+		Amount:     7_000_000_000,
+		Slots:      slots,
+		EpochIndex: 5,
+		Settled:    false,
+	}
+	_, err = k.StoreDevshardEscrow(ctx, &escrow, 1)
+	require.NoError(t, err)
+	require.NoError(t, k.SetClaimRecipientForEpoch(ctx, participant, escrow.EpochIndex, recipient.String()))
+
+	costPerSlot := uint64(100_000_000)
+	msg := buildSettlementTestData(t, escrow, keys, makeHostStats(keeper.DevshardGroupSize, costPerSlot), 0)
+
+	expectedPayout, err := types.GetCoins(int64(uint64(keeper.DevshardGroupSize) * costPerSlot))
+	require.NoError(t, err)
+	mocks.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, recipient, expectedPayout, gomock.Eq("devshard_escrow_payment")).
+		Return(nil)
+	expectedRefund := escrow.Amount - uint64(keeper.DevshardGroupSize)*costPerSlot
+	mocks.BankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(gomock.Any(), types.ModuleName, creator, gomock.Any(), gomock.Eq("devshard_escrow_refund")).
+		DoAndReturn(func(_ context.Context, _ string, _ sdk.AccAddress, coins sdk.Coins, _ string) error {
+			require.Len(t, coins, 1)
+			require.Equal(t, expectedRefund, coins[0].Amount.Uint64())
+			return nil
+		})
+
+	resp, err := ms.SettleDevshardEscrow(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
 func TestSettleDevshardEscrow_PreviousEpochSettlementDoesNotRollIntoCurrentEpochActiveParticipants(t *testing.T) {
 	k, ms, ctx, mocks := setupDevshardEscrowTest(t)
 	sdk.GetConfig().SetBech32PrefixForAccount("gonka", "gonka")

--- a/inference-chain/x/inference/keeper/pruning.go
+++ b/inference-chain/x/inference/keeper/pruning.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	LookbackMultiplier               = int64(5)
-	ClaimRecipientPruningThreshold   = uint64(3)
+	ClaimRecipientPruningThreshold   = uint64(5)
 	ClaimRecipientPruningMaxPerBlock = int64(1000)
 )
 

--- a/inference-chain/x/inference/module/autocli.go
+++ b/inference-chain/x/inference/module/autocli.go
@@ -422,14 +422,6 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "seed"}, {ProtoField: "epoch_index"}},
 				},
 				{
-					RpcMethod: "SetClaimRecipients",
-					Use:       "set-claim-recipients [entries-json]",
-					Short:     "Configure per-epoch claim recipient overrides (cold key only)",
-					Long: "Batch-configures recipient overrides for MsgClaimRewards on future epochs. " +
-						"Pass a JSON array of {epoch, recipient} entries via --entries. " +
-						"An empty recipient clears the override for that epoch.",
-				},
-				{
 					RpcMethod:      "SubmitPocBatch",
 					Use:            "submit-poc-batch [poc-stage-start-block-height] [nonces] [dist]",
 					Short:          "Send a SubmitPocBatch tx",

--- a/testermint/src/test/kotlin/ClaimRecipientTests.kt
+++ b/testermint/src/test/kotlin/ClaimRecipientTests.kt
@@ -60,7 +60,8 @@ class ClaimRecipientTests : TestermintTest() {
             .`as`("configured recipient receives the claim payout")
             .isGreaterThan(recipientBalanceBefore)
         assertThat(genesis.node.listClaimRecipients(participant).entries)
-            .noneMatch { it.epoch == targetEpoch && it.recipient == recipient }
+            .`as`("recipient entry is retained after claim for late same-epoch payouts")
+            .anyMatch { it.epoch == targetEpoch && it.recipient == recipient }
     }
 
     @Test
@@ -104,7 +105,7 @@ class ClaimRecipientTests : TestermintTest() {
             .anyMatch { it.epoch == targetEpoch && it.recipient == recipient }
 
         logSection("Advance until target epoch is past the pruning threshold")
-        while (genesis.getEpochData().latestEpoch.index < targetEpoch + 3) {
+        while (genesis.getEpochData().latestEpoch.index < targetEpoch + 5) {
             genesis.waitForNextEpoch()
         }
         genesis.node.waitForNextBlock(2)


### PR DESCRIPTION
## Summary

This follow-up keeps claim-recipient records after normal reward claims and relies on pruning to remove them later. The goal is to preserve the epoch-level recipient routing long enough for late DevShard payouts, including stale/unsettled escrow pruning, to use the same configured recipient instead of falling back to the participant address.

## Key Decisions

- Claim-recipient entries are no longer consumed by `MsgClaimRewards`.
- Claim-recipient entries are pruned only after they are safely stale.
- Claim-recipient pruning threshold is now `5` epochs.
- DevShard previous/direct settlement resolves recipient using the escrow epoch.
- DevShard stale/unsettled escrow pruning also resolves recipient using the escrow epoch.
- Recipient account existence is still not required; Bech32 validity is enough.

## Safety Note

DevShard escrow pruning threshold is `2` epochs, while claim-recipient pruning threshold is `5` epochs. That gives a 3-epoch buffer where stale DevShard escrows should be pruned before their corresponding claim-recipient records disappear.

This does not protect against arbitrarily delayed manual/direct DevShard settlement beyond the recipient pruning window. If a DevShard payout happens after the recipient record has already been pruned, it will fall back to the participant address.