### PR TITLE
fix(inference): standardize checked integer handling in settlement and validation paths

### DIFF
--- a/decentralized-api/internal/startup/reward_recovery.go
+++ b/decentralized-api/internal/startup/reward_recovery.go
@@ -8,6 +8,8 @@ import (
 	"decentralized-api/internal/seed"
 	"decentralized-api/internal/validation"
 	"decentralized-api/logging"
+	"math"
+	"math/bits"
 	"sync/atomic"
 	"time"
 
@@ -137,7 +139,10 @@ func (c *RewardRecoveryChecker) AutoRewardRecovery() {
 	}
 
 	settleAmount := settleAmountResp.SettleAmount
-	totalAmount := settleAmount.RewardCoins + settleAmount.WorkCoins
+	totalAmount, carry := bits.Add64(settleAmount.RewardCoins, settleAmount.WorkCoins, 0)
+	if carry != 0 {
+		totalAmount = math.MaxUint64
+	}
 	logging.Info("[AutoRewardRecovery] Found settle amount for participant", types.Claims,
 		"address", address,
 		"rewardCoins", settleAmount.RewardCoins,
@@ -146,7 +151,7 @@ func (c *RewardRecoveryChecker) AutoRewardRecovery() {
 		"epochIndex", settleAmount.EpochIndex)
 
 	// Check if we have unclaimed rewards (totalAmount > 0 indicates pending rewards)
-	if totalAmount <= 0 {
+	if totalAmount == 0 {
 		logging.Info("[AutoRewardRecovery] No unclaimed rewards found", types.Claims, "address", address, "totalAmount", totalAmount)
 		return
 	}

--- a/decentralized-api/internal/validation/inference_validation.go
+++ b/decentralized-api/internal/validation/inference_validation.go
@@ -107,9 +107,9 @@ func (s *InferenceValidator) shouldValidateInference(
 	shouldValidate, message := calculations.ShouldValidate(
 		seed,
 		inferenceDetails,
-		uint32(inferenceDetails.TotalPower),
-		uint32(validatorPower),
-		uint32(inferenceDetails.ExecutorPower),
+		inferenceDetails.TotalPower,
+		validatorPower,
+		inferenceDetails.ExecutorPower,
 		validationParams,
 		false)
 

--- a/inference-chain/x/inference/calculations/should_validate.go
+++ b/inference-chain/x/inference/calculations/should_validate.go
@@ -14,9 +14,9 @@ import (
 func ShouldValidate(
 	seed int64,
 	inferenceDetails *types.InferenceValidationDetails,
-	totalPower uint32,
-	validatorPower uint32,
-	executorPower uint32,
+	totalPower uint64,
+	validatorPower uint64,
+	executorPower uint64,
 	validationParams *types.ValidationParams,
 	debug bool,
 ) (bool, string) {
@@ -31,7 +31,7 @@ func ShouldValidate(
 	// algebraic simplification/removal of temp variables
 	targetValidations := maxValidationAverage.Sub(rangeSize.Mul(executorReputation))
 	// 100% rep will be minValidationAverage, 0% rep will be maxValidationAverage
-	ourProbability := targetValidations.Mul(decimal.NewFromInt(int64(validatorPower))).Div(decimal.NewFromInt(int64(totalPower - executorPower)))
+	ourProbability := targetValidations.Mul(decimal.NewFromUint64(validatorPower)).Div(decimal.NewFromUint64(totalPower - executorPower))
 	if ourProbability.GreaterThan(one) {
 		ourProbability = one
 	}

--- a/inference-chain/x/inference/calculations/should_validate_test.go
+++ b/inference-chain/x/inference/calculations/should_validate_test.go
@@ -18,9 +18,9 @@ func TestShouldValidate(t *testing.T) {
 		name                 string
 		seed                 int64
 		inferenceDetails     *types.InferenceValidationDetails
-		totalPower           uint32
-		validatorPower       uint32
-		executorPower        uint32
+		totalPower           uint64
+		validatorPower       uint64
+		executorPower        uint64
 		expectedResult       bool
 		expectedProbability  float64
 		minValidationAverage float64

--- a/inference-chain/x/inference/keeper/accountsettle.go
+++ b/inference-chain/x/inference/keeper/accountsettle.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"math/bits"
 
 	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -256,8 +257,8 @@ func (k *Keeper) SettleAccounts(ctx context.Context, currentEpochIndex uint64, p
 			k.LogError("Error calculating settle amounts", types.Settle, "error", amount.Error, "participant", amount.Settle.Participant)
 			continue
 		}
-		totalPayment := amount.Settle.WorkCoins + amount.Settle.RewardCoins
-		if totalPayment == 0 {
+		paymentSum, paymentCarry := bits.Add64(amount.Settle.WorkCoins, amount.Settle.RewardCoins, 0)
+		if paymentCarry == 0 && paymentSum == 0 {
 			k.LogDebug("No payment needed for participant", types.Settle, "address", amount.Settle.Participant)
 			continue
 		}

--- a/inference-chain/x/inference/keeper/bitcoin_rewards.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards.go
@@ -739,8 +739,12 @@ func CalculateParticipantBitcoinRewards(
 				if result.IsUint64() {
 					rewardCoins = result.Uint64()
 				} else {
-					// If still too large, participant gets maximum possible uint64
-					rewardCoins = ^uint64(0) // Max uint64
+					logger.Error("bitcoin reward division exceeded uint64; capping to MaxInt64",
+						"participant", participant.Address,
+						"participantWeight", participantWeight,
+						"fixedEpochReward", fixedEpochReward,
+						"totalFullWeight", totalPoCWeightBeforeDowntime)
+					rewardCoins = uint64(math.MaxInt64)
 				}
 				totalDistributed += rewardCoins
 			}

--- a/inference-chain/x/inference/keeper/bitcoin_rewards_test.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards_test.go
@@ -1107,58 +1107,6 @@ func TestGetBitcoinSettleAmounts(t *testing.T) {
 	})
 }
 
-func TestCalculateParticipantBitcoinRewards_ProducerFallbackCapsAtMaxInt64(t *testing.T) {
-	participants := []types.Participant{
-		{
-			Address: "participant1",
-			Status:  types.ParticipantStatus_ACTIVE,
-			CurrentEpochStats: &types.CurrentEpochStats{
-				InferenceCount: 1,
-			},
-		},
-		{
-			Address: "participant2",
-			Status:  types.ParticipantStatus_ACTIVE,
-			CurrentEpochStats: &types.CurrentEpochStats{
-				InferenceCount: 1,
-			},
-		},
-		{
-			Address: "participant3",
-			Status:  types.ParticipantStatus_ACTIVE,
-			CurrentEpochStats: &types.CurrentEpochStats{
-				InferenceCount: 1,
-			},
-		},
-	}
-	epochGroupData := &types.EpochGroupData{
-		EpochIndex: 1,
-		ValidationWeights: []*types.ValidationWeight{
-			createTestValidationWeight("participant1", math.MaxInt64, 100),
-			createTestValidationWeight("participant2", math.MaxInt64, 100),
-			createTestValidationWeight("participant3", math.MaxInt64, 100),
-		},
-	}
-	bitcoinParams := &types.BitcoinRewardParams{
-		InitialEpochReward: math.MaxUint64,
-		DecayRate:          types.DecimalFromFloat(0),
-		GenesisEpoch:       1,
-	}
-
-	results, _, err := CalculateParticipantBitcoinRewards(
-		participants,
-		epochGroupData,
-		bitcoinParams,
-		nil,
-		modelNodesAndScales(epochGroupData),
-		createTestLogger(t),
-	)
-	require.NoError(t, err)
-	require.NotEmpty(t, results)
-	require.Equal(t, uint64(math.MaxInt64), results[0].Settle.RewardCoins)
-	require.NotEqual(t, uint64(math.MaxUint64), results[0].Settle.RewardCoins)
-}
-
 // TestPhase2BonusFunctions tests the Phase 2 enhancement stub functions
 func TestPhase2BonusFunctions(t *testing.T) {
 	// Setup test data

--- a/inference-chain/x/inference/keeper/bitcoin_rewards_test.go
+++ b/inference-chain/x/inference/keeper/bitcoin_rewards_test.go
@@ -1107,6 +1107,58 @@ func TestGetBitcoinSettleAmounts(t *testing.T) {
 	})
 }
 
+func TestCalculateParticipantBitcoinRewards_ProducerFallbackCapsAtMaxInt64(t *testing.T) {
+	participants := []types.Participant{
+		{
+			Address: "participant1",
+			Status:  types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: 1,
+			},
+		},
+		{
+			Address: "participant2",
+			Status:  types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: 1,
+			},
+		},
+		{
+			Address: "participant3",
+			Status:  types.ParticipantStatus_ACTIVE,
+			CurrentEpochStats: &types.CurrentEpochStats{
+				InferenceCount: 1,
+			},
+		},
+	}
+	epochGroupData := &types.EpochGroupData{
+		EpochIndex: 1,
+		ValidationWeights: []*types.ValidationWeight{
+			createTestValidationWeight("participant1", math.MaxInt64, 100),
+			createTestValidationWeight("participant2", math.MaxInt64, 100),
+			createTestValidationWeight("participant3", math.MaxInt64, 100),
+		},
+	}
+	bitcoinParams := &types.BitcoinRewardParams{
+		InitialEpochReward: math.MaxUint64,
+		DecayRate:          types.DecimalFromFloat(0),
+		GenesisEpoch:       1,
+	}
+
+	results, _, err := CalculateParticipantBitcoinRewards(
+		participants,
+		epochGroupData,
+		bitcoinParams,
+		nil,
+		modelNodesAndScales(epochGroupData),
+		createTestLogger(t),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	require.Equal(t, uint64(math.MaxInt64), results[0].Settle.RewardCoins)
+	require.NotEqual(t, uint64(math.MaxUint64), results[0].Settle.RewardCoins)
+}
+
 // TestPhase2BonusFunctions tests the Phase 2 enhancement stub functions
 func TestPhase2BonusFunctions(t *testing.T) {
 	// Setup test data

--- a/inference-chain/x/inference/keeper/claim_rewards_weight_overflow_test.go
+++ b/inference-chain/x/inference/keeper/claim_rewards_weight_overflow_test.go
@@ -1,0 +1,79 @@
+package keeper_test
+
+import (
+	"math"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/testutil"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimRewards_WeightAggregationAboveUint32_StillSamples(t *testing.T) {
+	k, ms, ctx, _ := setupKeeperWithMocks(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	epochIndex := uint64(100)
+	epoch := types.Epoch{Index: epochIndex, PocStartBlockHeight: 1000}
+	k.SetEpoch(sdkCtx, &epoch)
+	require.NoError(t, k.SetParams(sdkCtx, types.DefaultParams()))
+
+	const each = int64(2_200_000_000)
+	require.LessOrEqual(t, each, int64(math.MaxUint32))
+	require.Greater(t, each+each, int64(math.MaxUint32))
+
+	epochData := types.EpochGroupData{
+		EpochIndex:          epochIndex,
+		EpochGroupId:        100,
+		PocStartBlockHeight: epochIndex,
+		ValidationWeights: []*types.ValidationWeight{
+			{MemberAddress: testutil.Creator, Weight: each},
+			{MemberAddress: testutil.Executor, Weight: each},
+		},
+	}
+	k.SetEpochGroupData(sdkCtx, epochData)
+
+	inf := types.InferenceValidationDetails{
+		EpochId:              epochIndex,
+		InferenceId:          "inf-weight-sum-above-uint32",
+		ExecutorId:           testutil.Executor,
+		ExecutorReputation:   50,
+		TrafficBasis:         1000,
+		Model:                "",
+		CreatedAtBlockHeight: 0,
+	}
+	k.SetInferenceValidationDetails(sdkCtx, inf)
+
+	got, err := keeper.GetMustBeValidatedInferencesForTesting(ms, sdkCtx, &types.MsgClaimRewards{
+		Creator:    testutil.Creator,
+		EpochIndex: epochIndex,
+		Seed:       42,
+	})
+	require.NoError(t, err)
+	require.Contains(t, got, "inf-weight-sum-above-uint32")
+}
+
+func TestClaimRewards_TotalWeightOverflow_ReturnsError(t *testing.T) {
+	k, ms, ctx, _ := setupKeeperWithMocks(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	epochIndex := uint64(100)
+	k.SetEpochGroupData(sdkCtx, types.EpochGroupData{
+		EpochIndex:          epochIndex,
+		EpochGroupId:        100,
+		PocStartBlockHeight: epochIndex,
+		ValidationWeights: []*types.ValidationWeight{
+			{MemberAddress: testutil.Creator, Weight: math.MaxInt64},
+			{MemberAddress: testutil.Executor, Weight: 1},
+		},
+	})
+
+	got, err := keeper.GetMustBeValidatedInferencesForTesting(ms, sdkCtx, &types.MsgClaimRewards{
+		Creator:    testutil.Creator,
+		EpochIndex: epochIndex,
+		Seed:       42,
+	})
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Contains(t, err.Error(), "int64 addition overflow")
+}

--- a/inference-chain/x/inference/keeper/claim_rewards_weight_overflow_test.go
+++ b/inference-chain/x/inference/keeper/claim_rewards_weight_overflow_test.go
@@ -11,13 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClaimRewards_WeightAggregationAboveUint32_StillSamples(t *testing.T) {
+func TestClaimRewards_WeightAggregationAboveUint32_UsesUint64Weights(t *testing.T) {
 	k, ms, ctx, _ := setupKeeperWithMocks(t)
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	epochIndex := uint64(100)
 	epoch := types.Epoch{Index: epochIndex, PocStartBlockHeight: 1000}
 	k.SetEpoch(sdkCtx, &epoch)
-	require.NoError(t, k.SetParams(sdkCtx, types.DefaultParams()))
+	params := types.DefaultParams()
+	params.ValidationParams.MinValidationAverage = types.DecimalFromFloat(1.0)
+	params.ValidationParams.MaxValidationAverage = types.DecimalFromFloat(1.0)
+	require.NoError(t, k.SetParams(sdkCtx, params))
 
 	const each = int64(2_200_000_000)
 	require.LessOrEqual(t, each, int64(math.MaxUint32))

--- a/inference-chain/x/inference/keeper/export_test.go
+++ b/inference-chain/x/inference/keeper/export_test.go
@@ -1,0 +1,10 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+func GetMustBeValidatedInferencesForTesting(ms types.MsgServer, ctx sdk.Context, msg *types.MsgClaimRewards) ([]string, error) {
+	return ms.(*msgServer).getMustBeValidatedInferences(ctx, msg)
+}

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -519,19 +519,19 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 		k.LogDebug("Getting validation", types.Claims, "seed", msg.Seed, "totalWeight", totalWeight, "executorPower", executorPower, "validatorPower", validatorPowerForModel)
 		safeTotalWeight, err := safeUint64FromInt64(totalWeight)
 		if err != nil {
-			k.LogError("Weight overflow in validation sampling", types.Claims,
+			k.LogError("Negative weight in validation sampling", types.Claims,
 				"totalWeight", totalWeight, "error", err, "inference", inference.InferenceId)
 			continue // Skip this inference -- can't compute validation probability safely
 		}
 		safeValidatorWeight, err := safeUint64FromInt64(validatorPowerForModel.Weight)
 		if err != nil {
-			k.LogError("Weight overflow in validation sampling", types.Claims,
+			k.LogError("Negative weight in validation sampling", types.Claims,
 				"validatorWeight", validatorPowerForModel.Weight, "error", err, "inference", inference.InferenceId)
 			continue
 		}
 		safeExecutorWeight, err := safeUint64FromInt64(executorPower.Weight)
 		if err != nil {
-			k.LogError("Weight overflow in validation sampling", types.Claims,
+			k.LogError("Negative weight in validation sampling", types.Claims,
 				"executorWeight", executorPower.Weight, "error", err, "inference", inference.InferenceId)
 			continue
 		}

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards.go
@@ -69,14 +69,32 @@ func (ms msgServer) payoutClaim(ctx sdk.Context, msg *types.MsgClaimRewards, set
 	// persists for retry.
 	cacheCtx, writeFn := ctx.CacheContext()
 
-	// Pay for work from escrow
-	escrowPayment := settleAmount.GetWorkCoins()
 	params, err := ms.GetParams(cacheCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get params: %w", err)
 	}
+
+	escrowPayment, err := safeInt64FromUint64(settleAmount.GetWorkCoins())
+	if err != nil {
+		ms.LogError("Work coin amount exceeds int64 payment range", types.Claims, "error", err, "settleAmount", settleAmount)
+		return &types.MsgClaimRewardsResponse{
+			Amount: 0,
+			Result: "Work coin amount exceeds int64 payment range",
+		}, err
+	}
+
+	rewardPayment, err := safeInt64FromUint64(settleAmount.GetRewardCoins())
+	if err != nil {
+		ms.LogError("Reward coin amount exceeds int64 payment range", types.Claims, "error", err, "settleAmount", settleAmount)
+		return &types.MsgClaimRewardsResponse{
+			Amount: 0,
+			Result: "Reward coin amount exceeds int64 payment range",
+		}, err
+	}
+
+	// Pay for work from escrow
 	workVestingPeriod := &params.TokenomicsParams.WorkVestingPeriod
-	if err := ms.PayParticipantFromEscrow(cacheCtx, msg.Creator, int64(escrowPayment), "work_coins:"+settleAmount.Participant, workVestingPeriod); err != nil {
+	if err := ms.PayParticipantFromEscrow(cacheCtx, msg.Creator, escrowPayment, "work_coins:"+settleAmount.Participant, workVestingPeriod); err != nil {
 		if sdkerrors.ErrInsufficientFunds.Is(err) {
 			ms.LogError("Insufficient funds for paying participant for work, claim can be retried", types.Claims, "error", err, "settleAmount", settleAmount)
 			return &types.MsgClaimRewardsResponse{
@@ -96,7 +114,7 @@ func (ms msgServer) payoutClaim(ctx sdk.Context, msg *types.MsgClaimRewards, set
 
 	// Pay rewards from module
 	rewardVestingPeriod := &params.TokenomicsParams.RewardVestingPeriod
-	if err := ms.PayParticipantFromModule(cacheCtx, msg.Creator, int64(settleAmount.GetRewardCoins()), types.ModuleName, "reward_coins:"+settleAmount.Participant, rewardVestingPeriod); err != nil {
+	if err := ms.PayParticipantFromModule(cacheCtx, msg.Creator, rewardPayment, types.ModuleName, "reward_coins:"+settleAmount.Participant, rewardVestingPeriod); err != nil {
 		if sdkerrors.ErrInsufficientFunds.Is(err) {
 			ms.LogError("Insufficient funds for paying rewards, claim can be retried", types.Claims, "error", err, "settleAmount", settleAmount)
 		} else {
@@ -327,7 +345,7 @@ func (k msgServer) getValidatedInferences(ctx sdk.Context, msg *types.MsgClaimRe
 	return wasValidated
 }
 
-func (k msgServer) getEpochGroupWeightData(ctx sdk.Context, pocStartHeight uint64, modelId string) (*types.EpochGroupData, map[string]types.ValidationWeight, int64, bool) {
+func (k msgServer) getEpochGroupWeightData(ctx sdk.Context, pocStartHeight uint64, modelId string) (*types.EpochGroupData, map[string]types.ValidationWeight, int64, bool, error) {
 	epochData, found := k.GetEpochGroupData(ctx, pocStartHeight, modelId)
 	if !found {
 		if modelId == "" {
@@ -335,7 +353,7 @@ func (k msgServer) getEpochGroupWeightData(ctx sdk.Context, pocStartHeight uint6
 		} else {
 			k.LogWarn("Sub epoch data not found", types.Claims, "height", pocStartHeight, "modelId", modelId)
 		}
-		return nil, nil, 0, false
+		return nil, nil, 0, false, nil
 	}
 
 	// Build weight map and total weight for the epoch group
@@ -347,19 +365,33 @@ func (k msgServer) getEpochGroupWeightData(ctx sdk.Context, pocStartHeight uint6
 			continue
 		}
 
-		totalWeight += weight.Weight
+		nextTotalWeight, err := checkedAddInt64(totalWeight, weight.Weight)
+		if err != nil {
+			k.LogError("Validation total weight overflow", types.Claims,
+				"height", pocStartHeight,
+				"modelId", modelId,
+				"totalWeight", totalWeight,
+				"weight", weight.Weight,
+				"error", err,
+			)
+			return nil, nil, 0, false, err
+		}
+		totalWeight = nextTotalWeight
 		weightMap[weight.MemberAddress] = *weight
 	}
 
 	k.LogInfo("Epoch group weight data", types.Claims, "height", pocStartHeight, "modelId", modelId, "totalWeight", totalWeight)
 
-	return &epochData, weightMap, totalWeight, true
+	return &epochData, weightMap, totalWeight, true, nil
 }
 
 //nolint:forbidigo // different use of "Must"
 func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgClaimRewards) ([]string, error) {
 	// Get the main epoch data
-	mainEpochData, mainWeightMap, mainTotalWeight, found := k.getEpochGroupWeightData(ctx, msg.EpochIndex, "")
+	mainEpochData, mainWeightMap, mainTotalWeight, found, err := k.getEpochGroupWeightData(ctx, msg.EpochIndex, "")
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, types.ErrCurrentEpochGroupNotFound
 	}
@@ -401,7 +433,10 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 
 	// Get sub models from the main epoch data
 	for _, subModelId := range mainEpochData.SubGroupModels {
-		_, subWeightMap, subTotalWeight, found := k.getEpochGroupWeightData(ctx, msg.EpochIndex, subModelId)
+		_, subWeightMap, subTotalWeight, found, err := k.getEpochGroupWeightData(ctx, msg.EpochIndex, subModelId)
+		if err != nil {
+			return nil, err
+		}
 		if !found {
 			k.LogWarn("Sub epoch data not found", types.Claims, "epoch", msg.EpochIndex, "modelId", subModelId)
 			continue
@@ -482,19 +517,19 @@ func (k msgServer) getMustBeValidatedInferences(ctx sdk.Context, msg *types.MsgC
 		}
 
 		k.LogDebug("Getting validation", types.Claims, "seed", msg.Seed, "totalWeight", totalWeight, "executorPower", executorPower, "validatorPower", validatorPowerForModel)
-		safeTotalWeight, err := safeUint32FromInt64(totalWeight)
+		safeTotalWeight, err := safeUint64FromInt64(totalWeight)
 		if err != nil {
 			k.LogError("Weight overflow in validation sampling", types.Claims,
 				"totalWeight", totalWeight, "error", err, "inference", inference.InferenceId)
 			continue // Skip this inference -- can't compute validation probability safely
 		}
-		safeValidatorWeight, err := safeUint32FromInt64(validatorPowerForModel.Weight)
+		safeValidatorWeight, err := safeUint64FromInt64(validatorPowerForModel.Weight)
 		if err != nil {
 			k.LogError("Weight overflow in validation sampling", types.Claims,
 				"validatorWeight", validatorPowerForModel.Weight, "error", err, "inference", inference.InferenceId)
 			continue
 		}
-		safeExecutorWeight, err := safeUint32FromInt64(executorPower.Weight)
+		safeExecutorWeight, err := safeUint64FromInt64(executorPower.Weight)
 		if err != nil {
 			k.LogError("Weight overflow in validation sampling", types.Claims,
 				"executorWeight", executorPower.Weight, "error", err, "inference", inference.InferenceId)

--- a/inference-chain/x/inference/keeper/msg_server_claim_rewards_atomicity_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_claim_rewards_atomicity_test.go
@@ -4,12 +4,13 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
-	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/testutil"
+	keepertest "github.com/productscience/inference/testutil/keeper"
 	"github.com/productscience/inference/x/inference/keeper"
 	"github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/require"
@@ -199,6 +200,58 @@ func TestClaimRewards_RewardPaymentFails_SettleRecordPreserved(t *testing.T) {
 	perf, found := k.GetEpochPerformanceSummary(sdkCtx, msg.EpochIndex, testutil.Creator)
 	require.True(t, found)
 	require.False(t, perf.Claimed, "claim must not be marked as completed on payment failure")
+}
+
+func TestClaimRewards_WorkPaymentOverflowsInt64_SettleRecordPreserved(t *testing.T) {
+	k, ms, ctx, _, msg := claimRewardsAtomicitySetup(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	sa, found := k.GetSettleAmount(sdkCtx, testutil.Creator)
+	require.True(t, found)
+	sa.WorkCoins = uint64(math.MaxInt64) + 1
+	require.NoError(t, k.SetSettleAmount(sdkCtx, sa))
+
+	resp, err := ms.ClaimRewards(ctx, msg)
+
+	require.NoError(t, err, "ClaimRewards handler returns nil error by convention")
+	require.NotNil(t, resp)
+	require.Equal(t, uint64(0), resp.Amount)
+	require.Contains(t, resp.Result, "Work coin amount exceeds int64 payment range")
+
+	sa, found = k.GetSettleAmount(sdkCtx, testutil.Creator)
+	require.True(t, found, "settle record must be preserved when work payment cannot fit int64")
+	require.Equal(t, uint64(math.MaxInt64)+1, sa.WorkCoins)
+	require.Equal(t, uint64(500), sa.RewardCoins)
+
+	perf, found := k.GetEpochPerformanceSummary(sdkCtx, msg.EpochIndex, testutil.Creator)
+	require.True(t, found)
+	require.False(t, perf.Claimed, "claim must not be marked as completed on conversion failure")
+}
+
+func TestClaimRewards_RewardPaymentOverflowsInt64_SettleRecordPreserved(t *testing.T) {
+	k, ms, ctx, _, msg := claimRewardsAtomicitySetup(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	sa, found := k.GetSettleAmount(sdkCtx, testutil.Creator)
+	require.True(t, found)
+	sa.RewardCoins = uint64(math.MaxInt64) + 1
+	require.NoError(t, k.SetSettleAmount(sdkCtx, sa))
+
+	resp, err := ms.ClaimRewards(ctx, msg)
+
+	require.NoError(t, err, "ClaimRewards handler returns nil error by convention")
+	require.NotNil(t, resp)
+	require.Equal(t, uint64(0), resp.Amount)
+	require.Contains(t, resp.Result, "Reward coin amount exceeds int64 payment range")
+
+	sa, found = k.GetSettleAmount(sdkCtx, testutil.Creator)
+	require.True(t, found, "settle record must be preserved when reward payment cannot fit int64")
+	require.Equal(t, uint64(1000), sa.WorkCoins)
+	require.Equal(t, uint64(math.MaxInt64)+1, sa.RewardCoins)
+
+	perf, found := k.GetEpochPerformanceSummary(sdkCtx, msg.EpochIndex, testutil.Creator)
+	require.True(t, found)
+	require.False(t, perf.Claimed, "claim must not be marked as completed on conversion failure")
 }
 
 // TestClaimRewards_HappyPath_SettleRecordConsumed proves the normal success

--- a/inference-chain/x/inference/keeper/safecast.go
+++ b/inference-chain/x/inference/keeper/safecast.go
@@ -24,6 +24,31 @@ func safeUint32FromInt64(v int64) (uint32, error) {
 	return uint32(v), nil
 }
 
+// safeUint64FromInt64 converts int64 to uint64, returning error if the value
+// is negative.
+func safeUint64FromInt64(v int64) (uint64, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("int64 value %d cannot be cast to uint64 (negative)", v)
+	}
+	return uint64(v), nil
+}
+
+// safeInt64FromUint64 converts uint64 to int64, returning error if the value
+// exceeds MaxInt64.
+func safeInt64FromUint64(v uint64) (int64, error) {
+	if v > math.MaxInt64 {
+		return 0, fmt.Errorf("uint64 value %d overflows int64 range [0, %d]", v, uint64(math.MaxInt64))
+	}
+	return int64(v), nil
+}
+
+func checkedAddInt64(a, b int64) (int64, error) {
+	if (b > 0 && a > math.MaxInt64-b) || (b < 0 && a < math.MinInt64-b) {
+		return 0, fmt.Errorf("int64 addition overflow: %d + %d", a, b)
+	}
+	return a + b, nil
+}
+
 // safeUint32FromUint64 converts uint64 to uint32, returning error if the value
 // exceeds MaxUint32.
 func safeUint32FromUint64(v uint64) (uint32, error) {

--- a/inference-chain/x/inference/keeper/safecast_test.go
+++ b/inference-chain/x/inference/keeper/safecast_test.go
@@ -67,6 +67,86 @@ func TestSafeUint32FromInt64(t *testing.T) {
 	}
 }
 
+func TestSafeUint64FromInt64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   int64
+		want    uint64
+		wantErr bool
+	}{
+		{"zero", 0, 0, false},
+		{"one", 1, 1, false},
+		{"MaxInt64", math.MaxInt64, math.MaxInt64, false},
+		{"negative one", -1, 0, true},
+		{"MinInt64", math.MinInt64, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeUint64FromInt64(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, uint64(0), got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSafeInt64FromUint64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   uint64
+		want    int64
+		wantErr bool
+	}{
+		{"zero", 0, 0, false},
+		{"MaxInt64", math.MaxInt64, math.MaxInt64, false},
+		{"MaxInt64+1", uint64(math.MaxInt64) + 1, 0, true},
+		{"MaxUint64", math.MaxUint64, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeInt64FromUint64(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, int64(0), got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCheckedAddInt64(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       int64
+		b       int64
+		want    int64
+		wantErr bool
+	}{
+		{"normal sum", 1, 2, 3, false},
+		{"max plus zero", math.MaxInt64, 0, math.MaxInt64, false},
+		{"positive overflow", math.MaxInt64, 1, 0, true},
+		{"negative overflow", math.MinInt64, -1, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := checkedAddInt64(tt.a, tt.b)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, int64(0), got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestSafeUint32FromUint64(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/inference-chain/x/inference/keeper/settle_amount_extreme_test.go
+++ b/inference-chain/x/inference/keeper/settle_amount_extreme_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSettleAccountsZeroPaymentGuard_DistinguishesWrapFromGenuineZero(t *testing.T) {
+func TestZeroPaymentGuardCondition_DistinguishesWrapFromGenuineZero(t *testing.T) {
 	wrapSum, wrapCarry := bits.Add64(math.MaxUint64, 1, 0)
 	require.Equal(t, uint64(0), wrapSum)
 	require.Equal(t, uint64(1), wrapCarry)

--- a/inference-chain/x/inference/keeper/settle_amount_extreme_test.go
+++ b/inference-chain/x/inference/keeper/settle_amount_extreme_test.go
@@ -1,0 +1,21 @@
+package keeper_test
+
+import (
+	"math"
+	"math/bits"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettleAccountsZeroPaymentGuard_DistinguishesWrapFromGenuineZero(t *testing.T) {
+	wrapSum, wrapCarry := bits.Add64(math.MaxUint64, 1, 0)
+	require.Equal(t, uint64(0), wrapSum)
+	require.Equal(t, uint64(1), wrapCarry)
+	require.False(t, wrapCarry == 0 && wrapSum == 0)
+
+	zeroSum, zeroCarry := bits.Add64(0, 0, 0)
+	require.Equal(t, uint64(0), zeroSum)
+	require.Equal(t, uint64(0), zeroCarry)
+	require.True(t, zeroCarry == 0 && zeroSum == 0)
+}

--- a/inference-chain/x/inference/types/settle_amount.go
+++ b/inference-chain/x/inference/types/settle_amount.go
@@ -1,10 +1,13 @@
 package types
 
-import "math"
+import (
+	"math"
+	"math/bits"
+)
 
 func (sa *SettleAmount) GetTotalCoins() int64 {
-	sum := sa.RewardCoins + sa.WorkCoins
-	if sum > math.MaxInt64 {
+	sum, carry := bits.Add64(sa.RewardCoins, sa.WorkCoins, 0)
+	if carry != 0 || sum > math.MaxInt64 {
 		return math.MaxInt64
 	}
 	return int64(sum)

--- a/inference-chain/x/inference/types/settle_amount_test.go
+++ b/inference-chain/x/inference/types/settle_amount_test.go
@@ -1,0 +1,43 @@
+package types
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettleAmountGetTotalCoins(t *testing.T) {
+	tests := []struct {
+		name string
+		sa   SettleAmount
+		want int64
+	}{
+		{
+			name: "normal sum",
+			sa:   SettleAmount{RewardCoins: 1, WorkCoins: 2},
+			want: 3,
+		},
+		{
+			name: "max int64 unchanged",
+			sa:   SettleAmount{RewardCoins: math.MaxInt64, WorkCoins: 0},
+			want: math.MaxInt64,
+		},
+		{
+			name: "above int64 saturates",
+			sa:   SettleAmount{RewardCoins: math.MaxInt64, WorkCoins: 1},
+			want: math.MaxInt64,
+		},
+		{
+			name: "uint64 wrap saturates",
+			sa:   SettleAmount{RewardCoins: math.MaxUint64, WorkCoins: 1},
+			want: math.MaxInt64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.sa.GetTotalCoins())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR keeps the overflow scope intentionally surgical for #1222.

- port the accepted #1100 settlement handling to main:
  - use `bits.Add64` for `RewardCoins + WorkCoins`
  - skip settlement only when the sum is genuinely zero
  - cap the `bitcoin_rewards.go` producer fallback at `MaxInt64`, not `MaxUint64`
- port the accepted #1101 validation widening to main:
  - make `ShouldValidate` use `uint64` powers
  - remove `uint32` narrowing in chain/DAPI callers
  - keep negative-weight rejection via `safeUint64FromInt64`
- add checked payout conversion before payment calls:
  - reject `uint64` amounts that do not fit the `int64` payment API
- add checked `totalWeight` accumulation:
  - return arithmetic overflow as an explicit error, not as “epoch data not found”
- add focused boundary tests for the changed behavior

## Out of scope

- broad repo-wide integer overflow audit
- static analyzer / CI guard
- #1017 supply-cap loop and event semantics
- unrelated casts outside settlement, validation, and payout boundaries

## Tests

cd inference-chain && go test ./x/inference/types ./x/inference/calculations ./x/inference/keeper
cd decentralized-api && go test ./internal/validation ./internal/startup

Notes:
- `GetTotalCoins()` still saturates to `MaxInt64` because it is an aggregate/helper boundary and this matches #1100.
- Payout conversion does not saturate. If a stored `uint64` amount cannot fit the `int64` payment API, the claim returns an error before bank sends and the settle record remains for intervention/retry.
- `getEpochGroupWeightData` keeps `found` separate from `error`: missing sub-epoch data can still be skipped, but arithmetic overflow is propagated.
- Static checks are intentionally left for a follow-up PR so this one stays reviewable.
- If a stored uint64 payout amount does not fit into the int64 bank payment range, ClaimRewards returns before any bank send and the settle record remains for operator intervention; retry only helps after state correction or migration.