### PR TITLE
fix(gateway): propagate proxy request ID to runner for FinalCost accounting

### DIFF
--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"devshard/logging"
 	"devshard/state"
 	"devshard/types"
 	"devshard/user"
@@ -349,8 +350,10 @@ func (p *Proxy) handleStreaming(w http.ResponseWriter, r *http.Request, params u
 	// drained through devshard_meta even if the client disconnects.
 	// metaDrainTimeout (via withMetaDrain in redundancy) bounds how long
 	// upstream may run after the client is gone.
+	// Propagate the proxy's request ID so the runner shares the same ID —
+	// this ensures /v1/requests/{id} accounting is findable by proxy ID.
 	var doneWriteErr error
-	err := p.redundancy.RunInference(context.Background(), params, dw, flag)
+	err := p.redundancy.RunInference(logging.PropagateRequestID(context.Background(), r.Context()), params, dw, flag)
 	if flag.Gone() {
 		logRequestStage(r.Context(), "proxy_stream_client_gone",
 			"escrow", p.escrowID,
@@ -510,7 +513,9 @@ func (p *Proxy) handleNonStreaming(w http.ResponseWriter, r *http.Request, param
 	flag := newCancelFlag()
 	watchClientCancel(r, flag)
 
-	err := p.redundancy.RunInference(context.Background(), params, &buf, flag)
+	// Propagate the proxy's request ID so the runner shares the same ID —
+	// this ensures /v1/requests/{id} accounting is findable by proxy ID.
+	err := p.redundancy.RunInference(logging.PropagateRequestID(context.Background(), r.Context()), params, &buf, flag)
 	if flag.Gone() {
 		return
 	}


### PR DESCRIPTION
## Problem

`GET /devshard/{escrow}/v1/requests/{id}` (the FinalCost / request accounting endpoint) always returns `404 not found` for v2 gateway requests. This breaks request detail expansion in the OpenBroker dashboard — `final_cost_json` is never populated for any v2 request.

**Root cause:** `handleStreaming` and `handleNonStreaming` both call:
```go
p.redundancy.RunInference(context.Background(), ...)
```
A fresh `context.Background()` carries no request ID, so `RunInference` mints a **new** ID for the runner that differs from the proxy's ID placed in the `X-Request-Id` response header. Since `request_accounting` is indexed by the **runner's** ID, every FinalCost lookup using the proxy's ID returns 404 — permanently, regardless of how long you wait.

## Fix

Propagate **only the request ID** (not cancellation) from the proxy context into the detached background context:

```go
logging.PropagateRequestID(context.Background(), r.Context())
```

`logging.PropagateRequestID` copies just the request ID value. `WithRequestID` is already a no-op when an ID is present, so `RunInference` reuses the proxy's ID instead of creating a new one. The runner still executes on a detached context — client disconnect does not cancel it — preserving the existing behaviour.

## Changes

`devshard/cmd/devshardctl/proxy.go` — 2 call sites (`handleStreaming` + `handleNonStreaming`) + `devshard/logging` import.

## Verification

`go build ./cmd/devshardctl/...` passes. After deploying, `GET /v1/requests/{proxy_request_id}` returns the accounting record immediately for all fresh requests.