### PR TITLE
perf(devshard): shrink gateway memory footprint and add profiling

### DIFF
--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -409,9 +409,43 @@ func (g *Gateway) settleDevshardOnChain(ctx context.Context, id string, req admi
 		rt.active.Store(false)
 	}
 	g.mu.Unlock()
+	wasResident := ok
 	if !ok {
-		log.Printf("devshard_settle_failed escrow=%s stage=runtime_lookup error=%q", id, "devshard is not active")
-		return nil, fmt.Errorf("devshard %s is not active", id)
+		// Non-resident devshard (inactive/settled): rehydrate a full runtime
+		// (with chain access) solely to build and broadcast this settlement,
+		// then release it. Concurrent settlement of the same id is guarded by
+		// the caller: auto/reconcile paths hold settlementInFlight[id] via
+		// scheduleAutoSettlement, and the chain rejects any duplicate settle
+		// broadcast, so no additional in-flight guard is taken here (taking
+		// one would deadlock the auto path, which already holds it).
+		cfg, known, cfgErr := g.lazyRuntimeConfig(id)
+		if cfgErr != nil {
+			log.Printf("devshard_settle_failed escrow=%s stage=lazy_config error=%q", id, cfgErr.Error())
+			return nil, cfgErr
+		}
+		if !known {
+			log.Printf("devshard_settle_failed escrow=%s stage=runtime_lookup error=%q", id, "devshard is not active")
+			return nil, fmt.Errorf("devshard %s is not active", id)
+		}
+		g.mu.Lock()
+		settings := g.settings
+		g.mu.Unlock()
+		built, buildErr := gatewayRuntimeBuilder(cfg, settings.ChainREST, settings.DefaultModel, g.perf)
+		if buildErr != nil {
+			log.Printf("devshard_settle_failed escrow=%s stage=rehydrate error=%q", id, buildErr.Error())
+			return nil, fmt.Errorf("rehydrate devshard %s for settlement: %w", id, buildErr)
+		}
+		built.active.Store(false)
+		rt = built
+		log.Printf("devshard_settle_rehydrated escrow=%s (transient, non-resident)", id)
+		defer func() {
+			// Flush a final snapshot: Finalize advances the nonce, so a later
+			// read-only rebuild of this settled escrow would otherwise replay
+			// the diff tail. retireClose captures the finalized state once.
+			if closeErr := rt.retireClose("settled-transient"); closeErr != nil {
+				log.Printf("devshard_settle_transient_close_error escrow=%s error=%v", id, closeErr)
+			}
+		}()
 	}
 	if err := g.store.SetDevshardActive(id, false); err != nil {
 		log.Printf("devshard_settle_failed escrow=%s stage=persist_deactivate error=%q", id, err.Error())
@@ -463,5 +497,12 @@ func (g *Gateway) settleDevshardOnChain(ctx context.Context, id string, req admi
 		return nil, err
 	}
 	log.Printf("devshard_settle_submitted escrow=%s tx_hash=%s settler=%s", id, result.TxHash, result.Settler)
+	// A settled escrow is terminal: drop the resident runtime so its memory
+	// (state machine, inference map, SQLite handles) is released now rather
+	// than lingering until the next restart. Transient runtimes are closed by
+	// their own deferred cleanup above.
+	if wasResident {
+		g.retireRuntime(id, "settled")
+	}
 	return result, nil
 }

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -497,6 +497,7 @@ func (g *Gateway) settleDevshardOnChain(ctx context.Context, id string, req admi
 		return nil, err
 	}
 	log.Printf("devshard_settle_submitted escrow=%s tx_hash=%s settler=%s", id, result.TxHash, result.Settler)
+	g.clearSettlementPending(id)
 	// A settled escrow is terminal: drop the resident runtime so its memory
 	// (state machine, inference map, SQLite handles) is released now rather
 	// than lingering until the next restart. Transient runtimes are closed by

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -3983,7 +3983,6 @@ func (g *Gateway) scheduleAutoSettlement(id, reason string) {
 			result, err := gatewaySettleDevshardOnChain(g, ctx, id, adminSettleEscrowRequest{})
 			cancel()
 			if err == nil {
-				g.clearSettlementPending(id)
 				log.Printf("auto_settle_submitted escrow=%s reason=%s tx_hash=%s settler=%s",
 					id, reason, result.TxHash, result.Settler)
 				g.retireRuntime(id, reason)

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -10,9 +10,11 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"net/http/pprof"
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -220,6 +222,7 @@ func newRuntimeMux(proxy *Proxy) http.Handler {
 	mux.HandleFunc("GET /v1/state", proxy.handleState)
 	mux.HandleFunc("GET /v1/debug/pending", proxy.handleDebugPending)
 	mux.HandleFunc("GET /v1/debug/state", proxy.handleDebugState)
+	mux.HandleFunc("GET /v1/debug/inferences", proxy.handleDebugInferences)
 	mux.HandleFunc("GET /v1/debug/perf", proxy.handleDebugPerf)
 	mux.HandleFunc("GET /v1/debug/pairwise", proxy.handleDebugPairwise)
 	mux.HandleFunc("GET /v1/debug/signatures", proxy.handleDebugSignatures)
@@ -314,6 +317,125 @@ func buildRuntime(cfg RuntimeConfig, chainREST, defaultModel string, perf *PerfT
 	return rt, nil
 }
 
+// buildReadOnlyRuntime rehydrates a transient, read-only runtime from local
+// storage without contacting the chain. It is used to serve debug/state
+// endpoints for devshards that are not resident in memory (inactive or
+// settled escrows). The runtime has no host clients and no redundancy: it can
+// answer read queries but must never route inferences. Callers own the
+// returned runtime and must close() it once the response is served.
+func buildReadOnlyRuntime(cfg RuntimeConfig, defaultModel string, perf *PerfTracker) (*devshardRuntime, error) {
+	keyHex := strings.TrimSpace(cfg.PrivateKeyHex)
+	if keyHex == "" && cfg.PrivateKeyEnv != "" {
+		keyHex = strings.TrimSpace(os.Getenv(cfg.PrivateKeyEnv))
+	}
+	if keyHex == "" {
+		return nil, fmt.Errorf("runtime %s: %w", cfg.ID, errRuntimePrivateKeyMissing)
+	}
+	model := cfg.Model
+	if model == "" {
+		model = defaultModel
+	}
+	cfg.StoragePath = normalizeStorageDir(cfg.StoragePath)
+	pv, pvErr := types.ParseProtocolVersion(cfg.ProtocolVersion)
+	if pvErr != nil {
+		return nil, fmt.Errorf("runtime %s: %w", cfg.ID, pvErr)
+	}
+	if perf == nil {
+		perf = NewPerfTracker(nil)
+	}
+	session, sm, err := user.NewLocalSession(user.LocalSessionConfig{
+		PrivateKeyHex:   keyHex,
+		EscrowID:        cfg.ID,
+		StoragePath:     cfg.StoragePath,
+		ProtocolVersion: pv,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("runtime %s: rehydrate local session: %w", cfg.ID, err)
+	}
+	proxy := &Proxy{
+		session:  session,
+		sm:       sm,
+		escrowID: cfg.ID,
+		model:    model,
+		perf:     perf,
+	}
+	rt := &devshardRuntime{
+		id:              cfg.ID,
+		model:           model,
+		handler:         newRuntimeMux(proxy),
+		proxy:           proxy,
+		session:         session,
+		participantKeys: session.ParticipantKeys(),
+	}
+	rt.active.Store(false)
+	rt.activeConfigured = true
+	return rt, nil
+}
+
+// lazyRuntimeConfig resolves a non-resident devshard's runtime config from the
+// registry store, applying the same finalization (storage path, default
+// model) used at boot. It returns false when the devshard is unknown.
+func (g *Gateway) lazyRuntimeConfig(id string) (RuntimeConfig, bool, error) {
+	if g.store == nil {
+		return RuntimeConfig{}, false, fmt.Errorf("gateway state store unavailable")
+	}
+	record, ok, err := g.store.GetDevshard(id)
+	if err != nil {
+		return RuntimeConfig{}, false, err
+	}
+	if !ok {
+		return RuntimeConfig{}, false, nil
+	}
+	g.mu.Lock()
+	defaultModel := g.settings.DefaultModel
+	baseStorageDir := g.baseStorageDir
+	g.mu.Unlock()
+	cfgs, err := finalizeRuntimeConfigs([]RuntimeConfig{record.RuntimeConfig}, defaultModel, baseStorageDir)
+	if err != nil {
+		return RuntimeConfig{}, false, err
+	}
+	return cfgs[0], true, nil
+}
+
+// hydrateReadOnlyRuntime builds a transient read-only runtime for a
+// non-resident devshard, serving from local storage only (no chain). Returns
+// (nil, false, nil) when the devshard is unknown to the registry.
+func (g *Gateway) hydrateReadOnlyRuntime(id string) (*devshardRuntime, bool, error) {
+	cfg, ok, err := g.lazyRuntimeConfig(id)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	rt, err := buildReadOnlyRuntime(cfg, g.settings.DefaultModel, g.perf)
+	if err != nil {
+		return nil, true, err
+	}
+	return rt, true, nil
+}
+
+// isReadOnlyDevshardPath reports whether an inner devshard path may be served
+// by a transient read-only (no-chain, no-clients) runtime. Only idempotent
+// GET reads qualify; anything that dispatches inferences or mutates state is
+// excluded so it never runs against a client-less runtime.
+func isReadOnlyDevshardPath(method, innerPath string) bool {
+	if method != http.MethodGet && method != http.MethodHead {
+		return false
+	}
+	switch innerPath {
+	case "/v1/status",
+		"/v1/state",
+		"/v1/finalize",
+		"/v1/models",
+		"/v1/debug/pending",
+		"/v1/debug/state",
+		"/v1/debug/inferences",
+		"/v1/debug/perf",
+		"/v1/debug/pairwise",
+		"/v1/debug/signatures":
+		return true
+	}
+	return strings.HasPrefix(innerPath, "/v1/requests/")
+}
+
 func newRESTBridgeForProtocol(chainREST string, pv types.ProtocolVersion) *bridge.RESTBridge {
 	return bridge.NewRESTBridge(chainREST)
 }
@@ -337,6 +459,21 @@ func (rt *devshardRuntime) close() error {
 		rt.session.Close()
 	}
 	return nil
+}
+
+// retireClose flushes a final state snapshot at the current (now frozen) nonce
+// so the escrow can later be rebuilt -- read-only for debug/state or fully on
+// reactivation -- without replaying the diff tail accumulated since the last
+// periodic snapshot, then closes the runtime. Use only on retire paths
+// (deactivate, settle, rotation); plain close() is for transient read-only
+// runtimes and build-failure cleanup, where no snapshot flush is wanted.
+func (rt *devshardRuntime) retireClose(reason string) error {
+	if rt.session != nil {
+		if err := rt.session.FlushSnapshot(); err != nil {
+			log.Printf("runtime_retire_snapshot_error escrow=%s reason=%q error=%v", rt.id, reason, err)
+		}
+	}
+	return rt.close()
 }
 
 func (rt *devshardRuntime) acceptsNewInferences() (bool, string) {
@@ -406,9 +543,8 @@ func (rt *devshardRuntime) snapshot() runtimeStatus {
 	if rt.proxy != nil && rt.proxy.sm != nil && rt.proxy.session != nil {
 		phase := rt.proxy.sm.Phase()
 		status.Phase = sessionPhaseLabel(phase)
-		st := rt.proxy.sm.SnapshotState()
 		status.Nonce = rt.proxy.session.Nonce()
-		status.Balance = st.Balance
+		status.Balance = rt.proxy.sm.Balance()
 		status.ProtocolVersion = string(rt.proxy.sm.ProtocolVersion())
 	}
 	if rt.proxy != nil && rt.proxy.phaseGate != nil {
@@ -473,7 +609,7 @@ func NewGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, defaultMod
 		participantLimiter: sharedParticipantRequestLimiter,
 		metrics:            NewDevshardMetrics(),
 		capacity:           NewCapacityState(),
-		chatCache:          newChatResponseCache(chatResponseCacheTTL),
+		chatCache:          newChatResponseCache(chatResponseCacheTTL, readInt64Env("DEVSHARD_CHAT_CACHE_MAX_BYTES", defaultChatCacheMaxBytes)),
 		suspiciousHosts:    make(map[string]struct{}),
 		settings: GatewaySettings{
 			DefaultModel: defaultModel,
@@ -1075,8 +1211,46 @@ func (g *Gateway) Handler() http.Handler {
 	mux.HandleFunc("/v1/debug/pairwise", g.handleSingleOnly)
 	mux.HandleFunc("/v1/debug/signatures", g.handleSingleOnly)
 	mux.HandleFunc("/v1/debug/signatures/collect", g.handleSingleOnly)
+	mux.HandleFunc("/v1/debug/memstats", g.handleDebugMemStats)
+	// Runtime profiling, admin-gated (see isAdminPath). Mounted at the
+	// canonical /debug/pprof/ path so pprof.Index's sub-profile links resolve.
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	mux.HandleFunc("/devshard/", g.handleDevshard)
 	return mux
+}
+
+// handleDebugMemStats reports Go runtime memory statistics so operators can
+// distinguish live heap (HeapInuse) from memory the runtime has reclaimed but
+// not yet returned to the OS (HeapReleased), which explains RSS that stays high
+// after garbage collection. Admin-gated via the /v1/debug/ prefix.
+func (g *Gateway) handleDebugMemStats(w http.ResponseWriter, r *http.Request) {
+	if !allowGetOrHead(w, r) {
+		return
+	}
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	g.mu.Lock()
+	loadedRuntimes := len(g.runtimeOrder)
+	g.mu.Unlock()
+	writeJSON(w, map[string]any{
+		"loaded_runtimes": loadedRuntimes,
+		"num_goroutine":   runtime.NumGoroutine(),
+		"heap_inuse":      m.HeapInuse,
+		"heap_alloc":      m.HeapAlloc,
+		"heap_sys":        m.HeapSys,
+		"heap_idle":       m.HeapIdle,
+		"heap_released":   m.HeapReleased,
+		"heap_objects":    m.HeapObjects,
+		"stack_inuse":     m.StackInuse,
+		"sys":             m.Sys,
+		"next_gc":         m.NextGC,
+		"num_gc":          m.NumGC,
+		"gc_cpu_fraction": m.GCCPUFraction,
+	})
 }
 
 func (g *Gateway) handlePooledModels(w http.ResponseWriter, r *http.Request) {
@@ -1239,6 +1413,28 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 	rt, ok := g.runtimes[devshardID]
 	g.mu.Unlock()
 	if !ok {
+		// Non-resident devshard (inactive/settled). Read-only debug and state
+		// endpoints can be served from a transient runtime rehydrated from
+		// local storage (no chain, no host clients), then released
+		// immediately. Inference and other mutating paths are never
+		// lazy-loaded.
+		//
+		// Rehydration replays diffs and loads a snapshot into a fresh runtime.
+		// That is cheap per call, but an unauthenticated caller could hammer
+		// inactive escrow IDs to inflate gateway memory/CPU. So the hydrating
+		// read paths are admin-only for non-resident devshards; non-admin
+		// callers only get cheap registry metadata (model/active flag) that
+		// needs neither snapshot nor state, and everything else looks unknown.
+		if isReadOnlyDevshardPath(r.Method, innerPath) {
+			if requestHasAdminAuth(r) {
+				g.serveReadOnlyDevshard(w, r, devshardID, innerPath)
+				return
+			}
+			if g.serveInactiveDevshardMetadata(w, r, devshardID, innerPath) {
+				return
+			}
+			logRequestStage(ctx, "gateway_devshard_readonly_requires_admin", "escrow", devshardID, "path", innerPath)
+		}
 		logRequestStage(ctx, "gateway_devshard_not_found", "escrow", devshardID)
 		http.Error(w, fmt.Sprintf(`{"error":{"message":"unknown devshard %s"}}`, devshardID), http.StatusNotFound)
 		return
@@ -1351,6 +1547,91 @@ func (w *gatewayStatusResponseWriter) statusCode() int {
 		return http.StatusOK
 	}
 	return w.status
+}
+
+// serveReadOnlyDevshard rehydrates a transient read-only runtime for a
+// non-resident devshard, serves a single read request against it, then closes
+// it. Each call loads and releases its own runtime (no caching, no
+// refcounting), so concurrent reads simply build independent transient
+// runtimes over the same on-disk storage.
+func (g *Gateway) serveReadOnlyDevshard(w http.ResponseWriter, r *http.Request, devshardID, innerPath string) {
+	ctx := r.Context()
+	rt, known, err := g.hydrateReadOnlyRuntime(devshardID)
+	if err != nil {
+		logRequestStage(ctx, "gateway_devshard_readonly_hydrate_failed", "escrow", devshardID, "error", err)
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s could not be loaded: %s"}}`, devshardID, err.Error()), http.StatusBadGateway)
+		return
+	}
+	if !known {
+		logRequestStage(ctx, "gateway_devshard_not_found", "escrow", devshardID)
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"unknown devshard %s"}}`, devshardID), http.StatusNotFound)
+		return
+	}
+	defer func() {
+		if closeErr := rt.close(); closeErr != nil {
+			log.Printf("gateway_devshard_readonly_close_error escrow=%s error=%v", devshardID, closeErr)
+		}
+	}()
+	logRequestStage(ctx, "gateway_devshard_readonly_served", "escrow", devshardID, "path", innerPath)
+	req := cloneRequestWithBody(r, nil)
+	req.URL.Path = innerPath
+	req.URL.RawPath = innerPath
+	req.RequestURI = innerPath
+	w.Header().Set("X-Devshard-ID", devshardID)
+	w.Header().Set("X-Devshard-Readonly", "1")
+	rt.handler.ServeHTTP(w, req)
+}
+
+// serveInactiveDevshardMetadata answers the read-only devshard endpoints that
+// can be satisfied purely from cheap registry metadata -- no snapshot or state
+// load -- so an unauthenticated caller cannot use them to inflate gateway
+// memory. It returns true when it handled the request; false leaves the caller
+// to refuse (the devshard looks unknown to non-admins).
+//
+// Only /v1/models and a deliberately state-free /v1/status are
+// metadata-serviceable. Every other read-only path (e.g. /v1/requests/*, and
+// the admin-gated /v1/state and /v1/debug/*) needs a hydrated runtime and is
+// therefore admin-only for a non-resident devshard.
+func (g *Gateway) serveInactiveDevshardMetadata(w http.ResponseWriter, r *http.Request, devshardID, innerPath string) bool {
+	switch innerPath {
+	case "/v1/models", "/v1/status":
+	default:
+		return false
+	}
+	if g.store == nil {
+		return false
+	}
+	record, ok, err := g.store.GetDevshard(devshardID)
+	if err != nil || !ok {
+		return false
+	}
+	g.mu.Lock()
+	defaultModel := g.settings.DefaultModel
+	g.mu.Unlock()
+	model := firstNonEmpty(record.Model, defaultModel)
+
+	w.Header().Set("X-Devshard-ID", devshardID)
+	w.Header().Set("X-Devshard-Readonly", "1")
+	w.Header().Set("X-Devshard-Metadata-Only", "1")
+	switch innerPath {
+	case "/v1/models":
+		writeModelList(w, []string{model}, RequestMaxTokensCap)
+	case "/v1/status":
+		// State-free subset only: nonce/balance/phase would require loading
+		// the snapshot + replaying diffs, which is exactly what we are
+		// refusing to do for unauthenticated callers.
+		writeJSON(w, map[string]any{
+			"id":                 devshardID,
+			"model":              model,
+			"active":             record.Active,
+			"resident":           false,
+			"settlement_pending": record.SettlementPending,
+			"rotation_role":      record.RotationRole,
+			"rotation_epoch":     record.RotationEpoch,
+			"metadata_only":      true,
+		})
+	}
+	return true
 }
 
 func (g *Gateway) markDevshardInactiveAfterFinalize(id string, rt *devshardRuntime) {
@@ -2774,6 +3055,10 @@ func (g *Gateway) handleAdminDevshardAction(w http.ResponseWriter, r *http.Reque
 		g.handleAdminDeactivateDevshard(w, r, id)
 		return
 	}
+	if len(parts) == 2 && parts[1] == "activate" && r.Method == http.MethodPost {
+		g.handleAdminActivateDevshard(w, r, id)
+		return
+	}
 	if len(parts) == 2 && parts[1] == "settle" && r.Method == http.MethodPost {
 		g.handleAdminSettleDevshard(w, r, id)
 		return
@@ -3175,21 +3460,87 @@ func (g *Gateway) handleAdminDeactivateDevshard(w http.ResponseWriter, r *http.R
 		return
 	}
 	g.mu.Lock()
-	defer g.mu.Unlock()
-
 	rt, ok := g.runtimes[id]
 	if !ok {
+		g.mu.Unlock()
 		http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s is not active"}}`, id), http.StatusNotFound)
 		return
 	}
 	if err := g.store.SetDevshardActive(id, false); err != nil {
+		g.mu.Unlock()
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusInternalServerError)
 		return
 	}
 	rt.active.Store(false)
+	// Retire from memory so the deactivated runtime stops consuming RAM.
+	// retireRuntimeLocked is drain-safe: if requests are still in flight it
+	// only marks the runtime retire-pending and returns nil, and the drain
+	// hook in releaseRuntime completes the retirement once the last request
+	// finishes. When idle it returns the runtime for us to close outside the
+	// lock. We hold g.mu here, so we must use the *Locked variant (the plain
+	// retireRuntime re-acquires g.mu and would deadlock).
+	retired := g.retireRuntimeLocked(id, "deactivated")
+	g.mu.Unlock()
+	if retired != nil {
+		if err := retired.retireClose("deactivated"); err != nil {
+			log.Printf("deactivate_retire_close_error escrow=%s error=%v", id, err)
+		}
+	}
 	writeJSON(w, map[string]any{
 		"id":     id,
 		"active": false,
+	})
+}
+
+// handleAdminActivateDevshard brings a non-resident (inactive) devshard back
+// into the memory-resident routing pool. It builds a full runtime with chain
+// access and registers it. If the devshard is already resident it simply flips
+// the active flag. This is the reverse of deactivate and the recovery path for
+// devshards demoted at boot or after finalize.
+func (g *Gateway) handleAdminActivateDevshard(w http.ResponseWriter, r *http.Request, id string) {
+	if g.store == nil {
+		http.Error(w, `{"error":{"message":"gateway state store unavailable"}}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	g.mu.Lock()
+	if rt, ok := g.runtimes[id]; ok {
+		if err := g.store.SetDevshardActive(id, true); err != nil {
+			g.mu.Unlock()
+			http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		rt.active.Store(true)
+		g.mu.Unlock()
+		writeJSON(w, map[string]any{
+			"id":               id,
+			"active":           true,
+			"already_resident": true,
+		})
+		return
+	}
+	g.mu.Unlock()
+
+	record, ok, err := g.store.GetDevshard(id)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s not found"}}`, id), http.StatusNotFound)
+		return
+	}
+	record.Active = true
+	record, err = g.addCreatedEscrowRuntime(record)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusBadGateway)
+		return
+	}
+	log.Printf("devshard_activated escrow=%s model=%s storage=%s", record.ID, record.Model, record.StoragePath)
+	writeJSON(w, map[string]any{
+		"id":     record.ID,
+		"model":  record.Model,
+		"active": true,
 	})
 }
 
@@ -3303,8 +3654,9 @@ func (g *Gateway) retireRuntime(id, reason string) bool {
 		return false
 	}
 	// Close the per-runtime SQLite store outside g.mu: it is disk I/O and must
-	// not block other gateway operations that contend for the lock.
-	if err := rt.close(); err != nil {
+	// not block other gateway operations that contend for the lock. retireClose
+	// also flushes a final snapshot so the frozen escrow rebuilds replay-free.
+	if err := rt.retireClose(reason); err != nil {
 		log.Printf("runtime_retire_close_error escrow=%s reason=%q error=%v", id, reason, err)
 	}
 	log.Printf("runtime_retired escrow=%s reason=%q", id, reason)
@@ -3476,16 +3828,14 @@ func (g *Gateway) reconcilePendingSettlements() {
 			continue
 		}
 		g.mu.Lock()
-		rt, exists := g.runtimes[devshard.ID]
-		if exists {
+		if rt, exists := g.runtimes[devshard.ID]; exists {
 			rt.settlementReason = "startup_reconcile"
 			rt.settlementPending.Store(true)
 		}
 		g.mu.Unlock()
-		if !exists {
-			log.Printf("settlement_reconcile_skipped escrow=%s reason=runtime_not_loaded", devshard.ID)
-			continue
-		}
+		// Non-resident pending devshards are still settled: scheduleAutoSettlement
+		// drives settleDevshardOnChain, which rehydrates a transient full runtime
+		// from local storage when the devshard is not resident in memory.
 		log.Printf("settlement_reconcile_queued escrow=%s", devshard.ID)
 		g.scheduleAutoSettlement(devshard.ID, "startup_reconcile")
 	}

--- a/devshard/cmd/devshardctl/gateway_inactive_access_test.go
+++ b/devshard/cmd/devshardctl/gateway_inactive_access_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newInactiveDevshardGateway builds a store-backed gateway that knows about a
+// single non-resident (not in memory), inactive devshard "77". Because no
+// runtime is registered, any /devshard/77/... read takes the non-resident
+// branch of handleDevshard.
+func newInactiveDevshardGateway(t *testing.T) *Gateway {
+	t.Helper()
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	settings := GatewaySettings{DefaultModel: "m"}
+	devshards := []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{
+			ID:            "77",
+			PrivateKeyHex: "secret",
+			Model:         "m",
+			StoragePath:   filepath.Join(t.TempDir(), "escrow-77"),
+		},
+		Active: false,
+	}}
+	require.NoError(t, store.Initialize(settings, devshards))
+
+	return NewManagedGateway(nil, NewGatewayLimiter(0, 0), settings, t.TempDir(), store)
+}
+
+// A non-admin caller may read a non-resident devshard's /v1/status, but only
+// the cheap, state-free metadata subset -- no snapshot/state is loaded.
+func TestInactiveDevshardPublicStatusIsMetadataOnly(t *testing.T) {
+	g := newInactiveDevshardGateway(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/devshard/77/v1/status", nil)
+	rec := httptest.NewRecorder()
+	g.handleDevshard(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("X-Devshard-Metadata-Only"))
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "77", body["id"])
+	require.Equal(t, "m", body["model"])
+	require.Equal(t, false, body["active"])
+	require.Equal(t, false, body["resident"])
+	require.Equal(t, true, body["metadata_only"])
+
+	// Fields that would require replaying diffs / loading a snapshot must be
+	// absent: the whole point is that no state was hydrated.
+	require.NotContains(t, body, "nonce")
+	require.NotContains(t, body, "balance")
+	require.NotContains(t, body, "phase")
+}
+
+// /v1/models is derivable from cheap registry config, so it is public for a
+// non-resident devshard.
+func TestInactiveDevshardPublicModelsIsMetadataOnly(t *testing.T) {
+	g := newInactiveDevshardGateway(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/devshard/77/v1/models", nil)
+	rec := httptest.NewRecorder()
+	g.handleDevshard(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("X-Devshard-Metadata-Only"))
+	require.Contains(t, rec.Body.String(), `"m"`)
+}
+
+// A read that needs hydrated state (here /v1/requests/*) is refused for a
+// non-admin caller on a non-resident devshard: it must look unknown and must
+// not hydrate (no metadata-only response either).
+func TestInactiveDevshardPublicStatefulReadRefused(t *testing.T) {
+	g := newInactiveDevshardGateway(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/devshard/77/v1/requests/abc", nil)
+	rec := httptest.NewRecorder()
+	g.handleDevshard(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Empty(t, rec.Header().Get("X-Devshard-Metadata-Only"))
+	require.Contains(t, rec.Body.String(), "unknown devshard")
+}
+
+// With admin auth present, the non-resident read path hydrates a transient
+// runtime instead of returning the metadata-only response. We only assert it
+// did NOT take the metadata-only branch (hydration may succeed or fail
+// depending on on-disk storage, but either way it is not metadata-only).
+func TestInactiveDevshardAdminReadHydrates(t *testing.T) {
+	g := newInactiveDevshardGateway(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/devshard/77/v1/status", nil)
+	req = req.WithContext(context.WithValue(req.Context(), adminAuthContextKey{}, true))
+	rec := httptest.NewRecorder()
+	g.handleDevshard(rec, req)
+
+	require.Empty(t, rec.Header().Get("X-Devshard-Metadata-Only"),
+		"admin read must hydrate, not serve the metadata-only response")
+}
+
+// An unknown (not-in-store) devshard must not reveal anything to a non-admin,
+// even on the otherwise-public metadata paths.
+func TestUnknownDevshardPublicReadIsNotFound(t *testing.T) {
+	g := newInactiveDevshardGateway(t)
+
+	for _, path := range []string{"/devshard/does-not-exist/v1/status", "/devshard/does-not-exist/v1/models"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		g.handleDevshard(rec, req)
+
+		require.Equal(t, http.StatusNotFound, rec.Code, "path=%s", path)
+		require.Empty(t, rec.Header().Get("X-Devshard-Metadata-Only"), "path=%s", path)
+	}
+}

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -1118,6 +1118,44 @@ func (s *GatewayStore) upsertDevshardTx(tx *sql.Tx, devshard GatewayDevshardStat
 	return nil
 }
 
+// GetDevshard returns the registry record for a single devshard. The second
+// return value is false when no row exists for the id. It is used by lazy
+// hydration to look up the config of a non-resident devshard without loading
+// the entire registry.
+func (s *GatewayStore) GetDevshard(id string) (GatewayDevshardState, bool, error) {
+	id = strings.TrimSpace(id)
+	var devshard GatewayDevshardState
+	var active int
+	var settlementPending int
+	err := s.db.QueryRow(`
+		SELECT id, private_key_hex, private_key_env, model, storage_path, active, created_at, updated_at, protocol_version,
+		       rotation_role, rotation_epoch, settlement_pending
+		FROM gateway_devshards
+		WHERE id = ?`, id).Scan(
+		&devshard.ID,
+		&devshard.PrivateKeyHex,
+		&devshard.PrivateKeyEnv,
+		&devshard.Model,
+		&devshard.StoragePath,
+		&active,
+		&devshard.CreatedAt,
+		&devshard.UpdatedAt,
+		&devshard.ProtocolVersion,
+		&devshard.RotationRole,
+		&devshard.RotationEpoch,
+		&settlementPending,
+	)
+	if err == sql.ErrNoRows {
+		return GatewayDevshardState{}, false, nil
+	}
+	if err != nil {
+		return GatewayDevshardState{}, false, fmt.Errorf("get devshard %s: %w", id, err)
+	}
+	devshard.Active = active != 0
+	devshard.SettlementPending = settlementPending != 0
+	return devshard, true, nil
+}
+
 func (s *GatewayStore) SetDevshardActive(id string, active bool) error {
 	res, err := s.db.Exec(`
 		UPDATE gateway_devshards

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -93,6 +93,21 @@ func seedGatewayTestCapacity(g *Gateway, weights map[string]float64) {
 	g.capacity.SetHostWeightViews(seeded, seeded, nil, nil)
 }
 
+// withSettleDevshardOnChainSideEffects wraps a settlement stub so successful
+// calls apply the same post-broadcast bookkeeping as settleDevshardOnChain.
+func withSettleDevshardOnChainSideEffects(
+	stub func(g *Gateway, ctx context.Context, id string, req adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error),
+) func(*Gateway, context.Context, string, adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+	return func(g *Gateway, ctx context.Context, id string, req adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		result, err := stub(g, ctx, id, req)
+		if err != nil {
+			return nil, err
+		}
+		g.clearSettlementPending(id)
+		return result, nil
+	}
+}
+
 func gatewayTestDepletionGateway(t *testing.T, rt *devshardRuntime, modifySettings ...func(*GatewaySettings)) (*Gateway, *atomic.Int32, *atomic.Int32) {
 	t.Helper()
 
@@ -138,11 +153,11 @@ func gatewayTestDepletionGateway(t *testing.T, rt *devshardRuntime, modifySettin
 		created.Add(1)
 		return &CreateDevshardEscrowResult{EscrowID: 99, TxHash: "OK"}, nil
 	}
-	gatewaySettleDevshardOnChain = func(_ *Gateway, _ context.Context, id string, _ adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+	gatewaySettleDevshardOnChain = withSettleDevshardOnChainSideEffects(func(_ *Gateway, _ context.Context, id string, _ adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
 		require.Equal(t, rt.id, id)
 		settled.Add(1)
 		return &SettleDevshardEscrowResult{EscrowID: mustParseUintForTest(t, id), TxHash: "SETTLED", Settler: "settler"}, nil
-	}
+	})
 	t.Cleanup(func() {
 		gatewayCreateDepletionEscrow = oldCreate
 		gatewaySettleDevshardOnChain = oldSettle

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -362,16 +362,25 @@ func mustBuildGateway(gatewayStore *GatewayStore, gatewayState GatewayState, bas
 }
 
 func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState, baseStorageDir string, perf *PerfTracker) ([]*devshardRuntime, error) {
-	// Load ALL devshards (active and inactive) so that inactive ones
-	// remain accessible for finalization, debug, and settlement retrieval.
-	// Inactive runtimes are loaded with active=false and excluded from
-	// the inference routing pool.
+	// Load only ACTIVE devshards at boot. Inactive devshards (deactivated,
+	// finalized, or settled) stay in the registry but are not built into
+	// memory-resident runtimes: keeping hundreds of dormant escrows resident
+	// wastes RAM, and probing each one against the chain at startup causes a
+	// boot-time request storm. Inactive devshards are rehydrated on demand:
+	// read-only from local storage for debug/state endpoints, or fully (with
+	// chain access) for manual settlement. See hydrateReadOnlyRuntime and the
+	// lazy settle path.
 	type cfgEntry struct {
 		cfg    RuntimeConfig
 		active bool
 	}
 	allEntries := make([]cfgEntry, 0, len(gatewayState.Devshards))
+	skippedInactive := 0
 	for _, devshard := range gatewayState.Devshards {
+		if !devshard.Active {
+			skippedInactive++
+			continue
+		}
 		allEntries = append(allEntries, cfgEntry{cfg: devshard.RuntimeConfig, active: devshard.Active})
 	}
 	allCfgs := make([]RuntimeConfig, len(allEntries))
@@ -469,8 +478,8 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 			out = append(out, rt)
 		}
 	}
-	log.Printf("build_runtimes_parallel count=%d active=%d inactive=%d skipped=%d total_elapsed_ms=%d",
-		len(out), activeCount, inactiveCount, len(skipped), time.Since(t0).Milliseconds())
+	log.Printf("build_runtimes_parallel count=%d active=%d inactive=%d skipped=%d skipped_inactive=%d total_elapsed_ms=%d",
+		len(out), activeCount, inactiveCount, len(skipped), skippedInactive, time.Since(t0).Milliseconds())
 	return out, nil
 }
 
@@ -561,6 +570,7 @@ func isAuthExemptPath(path string) bool {
 func isAdminPath(path string) bool {
 	if strings.HasPrefix(path, "/v1/admin/") ||
 		strings.HasPrefix(path, "/v1/debug/") ||
+		strings.HasPrefix(path, "/debug/pprof/") ||
 		path == "/v1/finalize" ||
 		path == "/v1/state" {
 		return true

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -592,24 +592,22 @@ func (p *Proxy) handleDebugPairwise(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Proxy) handleDebugState(w http.ResponseWriter, r *http.Request) {
-	st := p.sm.SnapshotState()
-
-	counts := make(map[string]int)
-	for _, rec := range st.Inferences {
-		name := inferenceStatusName[rec.Status]
+	total, statusCounts := p.sm.InferenceStatusCounts()
+	counts := make(map[string]int, len(statusCounts))
+	for status, n := range statusCounts {
+		name := inferenceStatusName[status]
 		if name == "" {
-			name = fmt.Sprintf("unknown(%d)", rec.Status)
+			name = fmt.Sprintf("unknown(%d)", status)
 		}
-		counts[name]++
+		counts[name] = n
 	}
 
 	writeJSON(w, map[string]any{
-		"nonce":            st.LatestNonce,
-		"balance":          st.Balance,
-		"total_inferences": len(st.Inferences),
+		"nonce":            p.sm.LatestNonce(),
+		"balance":          p.sm.Balance(),
+		"total_inferences": total,
 		"status_counts":    counts,
 	})
-
 }
 
 func (p *Proxy) handleStatus(w http.ResponseWriter, r *http.Request) {
@@ -631,13 +629,12 @@ func (p *Proxy) handleStatus(w http.ResponseWriter, r *http.Request) {
 		phaseStr = fmt.Sprintf("unknown(%d)", phase)
 	}
 
-	st := p.sm.SnapshotState()
-	cfg := st.Config
+	cfg := p.sm.Config()
 	status := statusResponse{
 		EscrowID: p.escrowID,
 		Nonce:    p.session.Nonce(),
 		Phase:    phaseStr,
-		Balance:  st.Balance,
+		Balance:  p.sm.Balance(),
 		Config: statusSessionConfig{
 			RefusalTimeout:    cfg.RefusalTimeout,
 			ExecutionTimeout:  cfg.ExecutionTimeout,
@@ -842,8 +839,12 @@ func (p *Proxy) handleCollectSignatures(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, resp)
 }
 
+// handleState returns the escrow summary: session scalars, config, group, and
+// the small per-slot maps. It deliberately omits the (potentially large)
+// inference map -- that lives at /v1/debug/inferences -- so this endpoint stays
+// bounded regardless of how many inferences an escrow has accumulated.
 func (p *Proxy) handleState(w http.ResponseWriter, r *http.Request) {
-	st := p.sm.SnapshotState()
+	st := p.sm.SnapshotStateNoInferences()
 
 	var phaseStr string
 	switch st.Phase {
@@ -880,33 +881,6 @@ func (p *Proxy) handleState(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	inferences := make(map[string]any, len(st.Inferences))
-	for id, rec := range st.Inferences {
-		name := inferenceStatusName[rec.Status]
-		if name == "" {
-			name = fmt.Sprintf("unknown(%d)", rec.Status)
-		}
-		inf := map[string]any{
-			"status":        name,
-			"executor_slot": rec.ExecutorSlot,
-			"model":         rec.Model,
-			"prompt_hash":   hex.EncodeToString(rec.PromptHash),
-			"response_hash": hex.EncodeToString(rec.ResponseHash),
-			"input_length":  rec.InputLength,
-			"max_tokens":    rec.MaxTokens,
-			"input_tokens":  rec.InputTokens,
-			"output_tokens": rec.OutputTokens,
-			"reserved_cost": rec.ReservedCost,
-			"actual_cost":   rec.ActualCost,
-			"started_at":    rec.StartedAt,
-			"confirmed_at":  rec.ConfirmedAt,
-			"votes_valid":   rec.VotesValid,
-			"votes_invalid": rec.VotesInvalid,
-			"validated_by":  rec.ValidatedBy.SetBits(),
-		}
-		inferences[fmt.Sprintf("%d", id)] = inf
-	}
-
 	hostStats := make(map[string]any, len(st.HostStats))
 	for slot, hs := range st.HostStats {
 		hostStats[fmt.Sprintf("%d", slot)] = map[string]any{
@@ -931,13 +905,49 @@ func (p *Proxy) handleState(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{
 		"session":        session,
 		"group":          group,
-		"inferences":     inferences,
 		"host_stats":     hostStats,
 		"revealed_seeds": revealedSeeds,
 		"warm_keys":      warmKeys,
 	}
 
 	writeJSON(w, resp)
+}
+
+// handleDebugInferences returns the full inference map for the escrow. It is a
+// debug-only endpoint (potentially large: up to the per-escrow inference cap)
+// split out of /v1/state so that summary reads stay cheap.
+func (p *Proxy) handleDebugInferences(w http.ResponseWriter, r *http.Request) {
+	inferenceMap := p.sm.SnapshotInferences()
+	inferences := make(map[string]any, len(inferenceMap))
+	for id, rec := range inferenceMap {
+		name := inferenceStatusName[rec.Status]
+		if name == "" {
+			name = fmt.Sprintf("unknown(%d)", rec.Status)
+		}
+		inferences[fmt.Sprintf("%d", id)] = map[string]any{
+			"status":        name,
+			"executor_slot": rec.ExecutorSlot,
+			"model":         rec.Model,
+			"prompt_hash":   hex.EncodeToString(rec.PromptHash),
+			"response_hash": hex.EncodeToString(rec.ResponseHash),
+			"input_length":  rec.InputLength,
+			"max_tokens":    rec.MaxTokens,
+			"input_tokens":  rec.InputTokens,
+			"output_tokens": rec.OutputTokens,
+			"reserved_cost": rec.ReservedCost,
+			"actual_cost":   rec.ActualCost,
+			"started_at":    rec.StartedAt,
+			"confirmed_at":  rec.ConfirmedAt,
+			"votes_valid":   rec.VotesValid,
+			"votes_invalid": rec.VotesInvalid,
+			"validated_by":  rec.ValidatedBy.SetBits(),
+		}
+	}
+
+	writeJSON(w, map[string]any{
+		"total_inferences": len(inferences),
+		"inferences":       inferences,
+	})
 }
 
 func (p *Proxy) handleInference(w http.ResponseWriter, r *http.Request) {
@@ -958,8 +968,7 @@ func (p *Proxy) handleInference(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	st := p.sm.SnapshotState()
-	inference, found := st.Inferences[parsedID]
+	inference, found := p.sm.GetInference(parsedID)
 	if !found {
 		http.Error(w, fmt.Sprintf("inference not found for inference ID: %s", inferenceID), http.StatusNotFound)
 		return

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -13,10 +13,29 @@ import (
 
 const chatResponseCacheTTL = time.Hour
 
+// chatCacheSweepInterval bounds how often Set pays for a full expiry sweep.
+// Expiry used to be enforced only lazily inside Get for the exact key being
+// looked up; since keys are hashes of full request bodies, unique requests
+// were never looked up again and their entries lived until process restart.
+const chatCacheSweepInterval = time.Minute
+
+// defaultChatCacheMaxBytes caps the total body bytes held by the cache
+// (overridable via DEVSHARD_CHAT_CACHE_MAX_BYTES). The cap is a safety net
+// against traffic bursts within the TTL window; the sweep handles steady
+// state.
+const defaultChatCacheMaxBytes = int64(256 << 20)
+
+// chatCacheEntryOverhead approximates the per-entry cost beyond the body:
+// map bucket, key string (64-hex sha256), and struct fields.
+const chatCacheEntryOverhead = 256
+
 type chatResponseCache struct {
-	mu      sync.Mutex
-	ttl     time.Duration
-	entries map[string]cachedChatResponse
+	mu         sync.Mutex
+	ttl        time.Duration
+	maxBytes   int64
+	entries    map[string]cachedChatResponse
+	totalBytes int64
+	lastSweep  time.Time
 }
 
 type cachedChatResponse struct {
@@ -29,13 +48,50 @@ type cachedChatResponse struct {
 	ExpiresAt       time.Time
 }
 
-func newChatResponseCache(ttl time.Duration) *chatResponseCache {
+func newChatResponseCache(ttl time.Duration, maxBytes int64) *chatResponseCache {
 	if ttl <= 0 {
 		ttl = chatResponseCacheTTL
 	}
+	if maxBytes <= 0 {
+		maxBytes = defaultChatCacheMaxBytes
+	}
 	return &chatResponseCache{
-		ttl:     ttl,
-		entries: make(map[string]cachedChatResponse),
+		ttl:      ttl,
+		maxBytes: maxBytes,
+		entries:  make(map[string]cachedChatResponse),
+	}
+}
+
+func chatCacheEntrySize(entry cachedChatResponse) int64 {
+	return int64(len(entry.Body)+len(entry.ContentType)+len(entry.EscrowID)+len(entry.SourceRequestID)) + chatCacheEntryOverhead
+}
+
+// deleteLocked removes key from the map and adjusts the byte total.
+// Caller must hold c.mu.
+func (c *chatResponseCache) deleteLocked(key string) {
+	entry, ok := c.entries[key]
+	if !ok {
+		return
+	}
+	delete(c.entries, key)
+	c.totalBytes -= chatCacheEntrySize(entry)
+	if c.totalBytes < 0 {
+		// Entries written directly in tests bypass accounting.
+		c.totalBytes = 0
+	}
+}
+
+// sweepExpiredLocked scans the whole map and drops entries whose TTL has
+// passed, at most once per chatCacheSweepInterval. Caller must hold c.mu.
+func (c *chatResponseCache) sweepExpiredLocked(now time.Time) {
+	if now.Sub(c.lastSweep) < chatCacheSweepInterval {
+		return
+	}
+	c.lastSweep = now
+	for key, entry := range c.entries {
+		if !entry.ExpiresAt.After(now) {
+			c.deleteLocked(key)
+		}
 	}
 }
 
@@ -58,11 +114,11 @@ func (c *chatResponseCache) Get(key string, now time.Time) (cachedChatResponse, 
 		return cachedChatResponse{}, false
 	}
 	if !entry.ExpiresAt.After(now) {
-		delete(c.entries, key)
+		c.deleteLocked(key)
 		return cachedChatResponse{}, false
 	}
 	if responseBodyHasNonCacheableError(entry.Body) {
-		delete(c.entries, key)
+		c.deleteLocked(key)
 		return cachedChatResponse{}, false
 	}
 	entry.Body = append([]byte(nil), entry.Body...)
@@ -83,7 +139,33 @@ func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.T
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.sweepExpiredLocked(now)
+
+	c.deleteLocked(key) // drop any previous version's byte count
 	c.entries[key] = entry
+	c.totalBytes += chatCacheEntrySize(entry)
+
+	// Size cap: evict arbitrary entries (map iteration order) until under
+	// the limit. This is a dedup cache -- evicting a "wrong" entry only
+	// costs one cache miss, so eviction order isn't worth tracking.
+	for other := range c.entries {
+		if c.totalBytes <= c.maxBytes {
+			break
+		}
+		if other != key {
+			c.deleteLocked(other)
+		}
+	}
+}
+
+// Stats reports the current entry count and approximate retained bytes.
+func (c *chatResponseCache) Stats() (entryCount int, totalBytes int64) {
+	if c == nil {
+		return 0, 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries), c.totalBytes
 }
 
 func serveCachedChatResponse(w http.ResponseWriter, r *http.Request, entry cachedChatResponse) {

--- a/devshard/cmd/devshardctl/response_cache_test.go
+++ b/devshard/cmd/devshardctl/response_cache_test.go
@@ -92,8 +92,98 @@ func TestGatewayChatCacheCaptureRejectsRuntimeAndCapabilityErrors(t *testing.T) 
 	}
 }
 
+func okBody(marker byte, size int) []byte {
+	filler := make([]byte, size)
+	for i := range filler {
+		filler[i] = 'a' + (marker+byte(i))%26
+	}
+	return []byte(`{"choices":[{"message":{"content":"` + string(filler) + `"}}]}`)
+}
+
+func cacheEntryForTest(marker byte, bodySize int) cachedChatResponse {
+	return cachedChatResponse{
+		EscrowID:   "escrow-1",
+		StatusCode: http.StatusOK,
+		Body:       okBody(marker, bodySize),
+	}
+}
+
+func TestChatResponseCacheSweepsExpiredEntriesOnSet(t *testing.T) {
+	cache := newChatResponseCache(time.Minute, 0)
+	start := time.Now()
+
+	cache.Set("old-1", cacheEntryForTest(1, 10), start)
+	cache.Set("old-2", cacheEntryForTest(2, 10), start)
+
+	count, _ := cache.Stats()
+	require.Equal(t, 2, count)
+
+	// A Set past both the TTL and the sweep interval must remove the
+	// expired entries even though their keys are never looked up again.
+	cache.Set("new", cacheEntryForTest(3, 10), start.Add(2*time.Minute))
+
+	count, _ = cache.Stats()
+	require.Equal(t, 1, count)
+	_, ok := cache.entries["old-1"]
+	require.False(t, ok)
+	_, ok = cache.entries["old-2"]
+	require.False(t, ok)
+	_, ok = cache.entries["new"]
+	require.True(t, ok)
+}
+
+func TestChatResponseCacheEvictsWhenOverByteCap(t *testing.T) {
+	// Cap fits roughly two 4KB entries plus overhead, not three.
+	cache := newChatResponseCache(time.Minute, 10_000)
+	now := time.Now()
+
+	cache.Set("a", cacheEntryForTest(1, 4096), now)
+	cache.Set("b", cacheEntryForTest(2, 4096), now)
+	cache.Set("c", cacheEntryForTest(3, 4096), now)
+
+	_, totalBytes := cache.Stats()
+	require.LessOrEqual(t, totalBytes, int64(10_000))
+
+	// The just-inserted entry must survive eviction.
+	_, ok := cache.entries["c"]
+	require.True(t, ok)
+}
+
+func TestChatResponseCacheOverwriteDoesNotLeakBytes(t *testing.T) {
+	cache := newChatResponseCache(time.Minute, 1<<20)
+	now := time.Now()
+
+	for i := 0; i < 100; i++ {
+		cache.Set("same-key", cacheEntryForTest(byte(i), 4096), now)
+	}
+
+	count, totalBytes := cache.Stats()
+	require.Equal(t, 1, count)
+	require.Less(t, totalBytes, int64(2*4096+2*chatCacheEntryOverhead))
+
+	entry, ok := cache.Get("same-key", now)
+	require.True(t, ok)
+	require.Equal(t, string(okBody(99, 4096)), string(entry.Body))
+}
+
+func TestChatResponseCacheGetDeletesExpiredAndAdjustsBytes(t *testing.T) {
+	cache := newChatResponseCache(time.Minute, 0)
+	now := time.Now()
+
+	cache.Set("k", cacheEntryForTest(1, 128), now)
+	_, totalBytes := cache.Stats()
+	require.Greater(t, totalBytes, int64(0))
+
+	_, ok := cache.Get("k", now.Add(2*time.Minute))
+	require.False(t, ok)
+
+	count, totalBytes := cache.Stats()
+	require.Equal(t, 0, count)
+	require.Equal(t, int64(0), totalBytes)
+}
+
 func TestChatResponseCacheDropsPreviouslyCachedNonCacheableErrors(t *testing.T) {
-	cache := newChatResponseCache(time.Minute)
+	cache := newChatResponseCache(time.Minute, 0)
 	cache.entries["bad"] = cachedChatResponse{
 		EscrowID:   "escrow-1",
 		StatusCode: http.StatusBadGateway,

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -444,11 +444,70 @@ func (sm *StateMachine) Balance() uint64 {
 	return sm.state.Balance
 }
 
+// Config returns a copy of the session config (a small value type). Use this
+// instead of SnapshotState().Config to avoid deep-copying the inference map.
+func (sm *StateMachine) Config() types.SessionConfig {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.state.Config
+}
+
 // SnapshotState returns a deep copy of the current escrow state.
 func (sm *StateMachine) SnapshotState() types.EscrowState {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	return *cloneEscrowState(sm.state)
+}
+
+// SnapshotStateNoInferences returns a deep copy of the escrow state with the
+// (potentially large) inference map omitted. All other fields, including the
+// small per-slot maps, are copied. Use it for summary/state endpoints that do
+// not render individual inference records, avoiding the cost of copying up to
+// tens of thousands of them.
+func (sm *StateMachine) SnapshotStateNoInferences() types.EscrowState {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	src := sm.state
+	s := *src
+	s.Inferences = nil
+
+	s.Group = make([]types.SlotAssignment, len(src.Group))
+	copy(s.Group, src.Group)
+
+	s.HostStats = make(map[uint32]*types.HostStats, len(src.HostStats))
+	for k, v := range src.HostStats {
+		cp := *v
+		s.HostStats[k] = &cp
+	}
+
+	s.RevealedSeeds = make(map[uint32]int64, len(src.RevealedSeeds))
+	maps.Copy(s.RevealedSeeds, src.RevealedSeeds)
+
+	s.WarmKeys = make(map[uint32]string, len(src.WarmKeys))
+	maps.Copy(s.WarmKeys, src.WarmKeys)
+
+	return s
+}
+
+// SnapshotInferences returns a deep copy of just the inference map. Use it for
+// endpoints that render the full inference list without paying to copy the
+// rest of the escrow state.
+func (sm *StateMachine) SnapshotInferences() map[uint64]*types.InferenceRecord {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return copyInferences(sm.state.Inferences)
+}
+
+// InferenceStatusCounts returns the total number of inferences and a per-status
+// breakdown, computed under the read lock without deep-copying any records.
+func (sm *StateMachine) InferenceStatusCounts() (int, map[types.InferenceStatus]int) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	counts := make(map[types.InferenceStatus]int)
+	for _, rec := range sm.state.Inferences {
+		counts[rec.Status]++
+	}
+	return len(sm.state.Inferences), counts
 }
 
 // ExportState returns a deep-copied pointer form used by recovery snapshots.

--- a/devshard/user/flush_snapshot_test.go
+++ b/devshard/user/flush_snapshot_test.go
@@ -1,0 +1,176 @@
+package user
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/host"
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/state"
+	"devshard/storage"
+	"devshard/stub"
+	"devshard/types"
+)
+
+// replaySpyStore wraps a storage.Storage and records every GetDiffs range so a
+// test can distinguish diff replay from catch-up backfill. During recovery,
+// replayed diffs (fed through ApplyLocal to rebuild SM state) come from a
+// GetDiffs call whose range starts after the snapshot nonce; backfill calls
+// end at the snapshot nonce.
+type replaySpyStore struct {
+	storage.Storage
+	mu    sync.Mutex
+	calls []spyGetDiffs
+}
+
+type spyGetDiffs struct {
+	from, to uint64
+	count    int
+}
+
+func (s *replaySpyStore) GetDiffs(escrowID string, from, to uint64) ([]types.DiffRecord, error) {
+	recs, err := s.Storage.GetDiffs(escrowID, from, to)
+	s.mu.Lock()
+	s.calls = append(s.calls, spyGetDiffs{from: from, to: to, count: len(recs)})
+	s.mu.Unlock()
+	return recs, err
+}
+
+// replayedRecords sums records returned for calls whose range starts strictly
+// after snapNonce -- exactly the post-snapshot diffs RecoverSession replays.
+func (s *replaySpyStore) replayedRecords(snapNonce uint64) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	total := 0
+	for _, c := range s.calls {
+		if c.from > snapNonce {
+			total += c.count
+		}
+	}
+	return total
+}
+
+// buildLiveSession builds a storage-backed session and its state machine,
+// mirroring setupRecoverableSession but returning the live session so a test
+// can drive it and then flush a snapshot.
+func buildLiveSession(
+	t *testing.T, numHosts int, store storage.Storage,
+) (*Session, *state.StateMachine, []types.SlotAssignment, []*signing.Secp256k1Signer, *signing.Secp256k1Signer) {
+	t.Helper()
+	hosts := make([]*signing.Secp256k1Signer, numHosts)
+	for i := range hosts {
+		hosts[i] = testutil.MustGenerateKey(t)
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(numHosts)
+	verifier := signing.NewSecp256k1Verifier()
+
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "escrow-1",
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+
+	clients := make([]HostClient, numHosts)
+	for i := range hosts {
+		sm, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
+		require.NoError(t, err)
+		h, err := host.NewHost(sm, hosts[i], stub.NewInferenceEngine(), "escrow-1", group, nil, host.WithGrace(10))
+		require.NoError(t, err)
+		clients[i] = &InProcessClient{Host: h}
+	}
+
+	userSM, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
+	require.NoError(t, err)
+	session, err := NewSession(userSM, user, "escrow-1", group, clients, verifier, WithStorage(store))
+	require.NoError(t, err)
+
+	return session, userSM, group, hosts, user
+}
+
+// TestFlushSnapshot_RetiredEscrowRebuildsWithoutReplay is the core guarantee of
+// the retire-time snapshot flush: an escrow whose nonce advanced past the last
+// periodic snapshot (here: none, since numInferences < snapshotInterval) must,
+// after FlushSnapshot, rebuild via RecoverSession with zero diff replay.
+func TestFlushSnapshot_RetiredEscrowRebuildsWithoutReplay(t *testing.T) {
+	store := newTestStore(t)
+	numHosts := 3
+	numInferences := 5 // < snapshotInterval, so no periodic snapshot is taken
+
+	session, liveSM, group, hosts, user := buildLiveSession(t, numHosts, store)
+
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	for i := 0; i < numInferences; i++ {
+		_, err := session.SendInference(ctx, params)
+		require.NoError(t, err)
+	}
+	require.Equal(t, uint64(numInferences), session.Nonce())
+
+	// No periodic snapshot exists yet: a plain rebuild here would replay all
+	// numInferences diffs.
+	_, _, err := store.LoadSnapshot("escrow-1")
+	require.ErrorIs(t, err, storage.ErrSnapshotNotFound)
+
+	// Retire: flush a final snapshot at the current (frozen) nonce.
+	require.NoError(t, session.FlushSnapshot())
+
+	snapNonce, _, err := store.LoadSnapshot("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(numInferences), snapNonce, "flush must snapshot at the frozen nonce")
+
+	// Rebuild through a spy to observe replay. With a snapshot at LatestNonce,
+	// RecoverSession must take the early-return path and never fetch (let alone
+	// replay) any post-snapshot diff.
+	verifier := signing.NewSecp256k1Verifier()
+	spy := &replaySpyStore{Storage: store}
+	rec, recSM, err := RecoverSession(spy, user, verifier, "escrow-1", types.LegacySessionVersion, group, buildRecoveryClients(t, hosts, group, user))
+	require.NoError(t, err)
+	require.Equal(t, uint64(numInferences), rec.Nonce())
+	require.Zero(t, spy.replayedRecords(snapNonce), "retired escrow must rebuild with zero diff replay")
+
+	// The rebuilt state must be identical to the live session's state.
+	recRoot, err := recSM.ComputeStateRoot()
+	require.NoError(t, err)
+	liveRoot, err := liveSM.ComputeStateRoot()
+	require.NoError(t, err)
+	require.Equal(t, liveRoot, recRoot, "flushed snapshot must reproduce the live state root")
+}
+
+// TestFlushSnapshot_NoStoreOrEmptyIsNoop verifies FlushSnapshot is safe on
+// sessions with nothing to persist: no store configured, or nonce still 0.
+func TestFlushSnapshot_NoStoreOrEmptyIsNoop(t *testing.T) {
+	// nonce == 0 (no inferences) with a store: must not write a snapshot.
+	store := newTestStore(t)
+	session, _, _, _, _ := buildLiveSession(t, 3, store)
+	require.Equal(t, uint64(0), session.Nonce())
+	require.NoError(t, session.FlushSnapshot())
+	_, _, err := store.LoadSnapshot("escrow-1")
+	require.ErrorIs(t, err, storage.ErrSnapshotNotFound, "flush at nonce 0 must not write a snapshot")
+
+	// No store configured: flush is a no-op that returns nil.
+	verifier := signing.NewSecp256k1Verifier()
+	hostSigner := testutil.MustGenerateKey(t)
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup([]*signing.Secp256k1Signer{hostSigner})
+	config := testutil.DefaultConfig(1)
+	hostSM, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
+	require.NoError(t, err)
+	h, err := host.NewHost(hostSM, hostSigner, stub.NewInferenceEngine(), "escrow-1", group, nil, host.WithGrace(10))
+	require.NoError(t, err)
+	sm, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier)
+	require.NoError(t, err)
+	noStore, err := NewSession(sm, user, "escrow-1", group, []HostClient{&InProcessClient{Host: h}}, verifier)
+	require.NoError(t, err)
+	require.NoError(t, noStore.FlushSnapshot())
+}

--- a/devshard/user/httpsession.go
+++ b/devshard/user/httpsession.go
@@ -3,6 +3,7 @@ package user
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	devshardpkg "devshard"
 	"devshard/bridge"
@@ -23,6 +24,62 @@ type HTTPSessionConfig struct {
 	RoutePrefix      string                          // optional: HTTP path prefix used to reach hosts; default devshard.LegacyRoutePrefix. Versioned binaries use devshard.VersionedRoutePrefix(...).
 	RequestAdmission transport.RequestAdmissionController
 	ProtocolVersion  types.ProtocolVersion // optional: defaults to ProtocolV1
+}
+
+// LocalSessionConfig holds the parameters needed to rehydrate a user Session
+// entirely from local storage, with no chain access and no host clients.
+type LocalSessionConfig struct {
+	PrivateKeyHex   string
+	EscrowID        string
+	StoragePath     string
+	ProtocolVersion types.ProtocolVersion
+}
+
+// NewLocalSession rehydrates a Session from local SQLite storage without
+// contacting the chain and without wiring any host clients. The returned
+// session can answer read-only queries (state, status, debug, settlement
+// build) but cannot dispatch new inferences. Callers own the returned
+// Session and must Close it when done, which also closes the underlying
+// storage handle.
+//
+// Warm-key verification is intentionally omitted (nil resolver): stored
+// diffs carry their warm-key deltas, which RecoverSession injects before
+// replay, so no chain-backed resolver is needed to rebuild state.
+func NewLocalSession(cfg LocalSessionConfig) (*Session, *state.StateMachine, error) {
+	if strings.TrimSpace(cfg.StoragePath) == "" {
+		return nil, nil, fmt.Errorf("local session requires a storage path")
+	}
+	signer, err := signing.SignerFromHex(cfg.PrivateKeyHex)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create signer: %w", err)
+	}
+	pv := cfg.ProtocolVersion
+	if pv == "" {
+		pv = types.ProtocolV1
+	}
+	verifier := signing.NewSecp256k1Verifier()
+	version := devshardpkg.ProtocolSessionVersion(pv)
+
+	store, err := storage.NewSQLite(cfg.StoragePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open storage: %w", err)
+	}
+	meta, err := store.GetSessionMeta(cfg.EscrowID)
+	if err != nil {
+		store.Close()
+		return nil, nil, fmt.Errorf("get session meta: %w", err)
+	}
+	// No host clients: read-only sessions never dispatch inferences. The
+	// slice length must match the group so NewSession's invariant holds.
+	clients := make([]HostClient, len(meta.Group))
+	session, sm, err := RecoverSession(store, signer, verifier, cfg.EscrowID, version, meta.Group, clients,
+		state.WithProtocolVersion(pv),
+	)
+	if err != nil {
+		store.Close()
+		return nil, nil, fmt.Errorf("recover session: %w", err)
+	}
+	return session, sm, nil
 }
 
 // NewHTTPSession creates a user Session wired with HTTP clients to real dapi hosts.

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -284,16 +284,24 @@ func saveSnapshot(store storage.Storage, sm *state.StateMachine, escrowID string
 // or state-machine locks held -- this is what enables async background
 // snapshots from the runtime hot path).
 func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64) {
+	_ = writeSnapshotErr(store, escrowID, nonce, state, cursor)
+}
+
+// writeSnapshotErr is writeSnapshot with an error return, for synchronous
+// callers (e.g. Session.FlushSnapshot on retire) that want to know whether the
+// snapshot landed. It logs on failure exactly like writeSnapshot.
+func writeSnapshotErr(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64) error {
 	blob := sessionSnapshot{State: state, HostSyncNonce: cursor}
 	data, err := json.Marshal(blob)
 	if err != nil {
 		log.Printf("recover_session escrow=%s snapshot_marshal_failed=%v", escrowID, err)
-		return
+		return err
 	}
 	if err := store.SaveSnapshot(escrowID, nonce, data); err != nil {
 		log.Printf("recover_session escrow=%s snapshot_save_failed=%v", escrowID, err)
-		return
+		return err
 	}
 	log.Printf("recover_session escrow=%s snapshot_saved nonce=%d size_bytes=%d host_cursors=%d",
 		escrowID, nonce, len(data), len(cursor))
+	return nil
 }

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -672,6 +672,61 @@ func (s *Session) maybeSaveSnapshotLocked() {
 	}()
 }
 
+// FlushSnapshot synchronously persists a state snapshot at the current nonce.
+// It is called when a runtime is retired from memory (deactivate, settle,
+// rotation) so the now-frozen escrow can later be rebuilt -- for a read-only
+// debug/state request or a reactivation -- without replaying the diff tail
+// accumulated since the last periodic (every snapshotInterval) snapshot.
+//
+// Periodic snapshots are only taken on snapshotInterval boundaries, so a
+// retired escrow otherwise carries up to snapshotInterval-1 un-snapshotted
+// diffs that every rebuild would replay. This flush captures the final nonce
+// once, at the lifecycle transition, making all later rebuilds replay-free.
+//
+// It serializes against the async periodic writer via snapshotInFlight so a
+// slow in-flight periodic save cannot land after (and overwrite) this final
+// snapshot with a staler nonce. Safe to call once, at retire; a no-op when
+// no diffs have been applied (nonce == 0) or no store is configured.
+func (s *Session) FlushSnapshot() error {
+	if s.store == nil {
+		return nil
+	}
+	// Acquire the snapshot slot, waiting briefly for any in-flight async
+	// save to finish. Bounded so retire never blocks indefinitely; if the
+	// async writer is still busy after the wait we proceed anyway (SQLite
+	// serializes the writes, and retire runs after drain so this is rare).
+	acquired := false
+	for i := 0; i < 200; i++ {
+		if s.snapshotInFlight.CompareAndSwap(false, true) {
+			acquired = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if acquired {
+		defer s.snapshotInFlight.Store(false)
+	}
+
+	s.mu.Lock()
+	if s.nonce == 0 {
+		s.mu.Unlock()
+		return nil
+	}
+	// Deep-copy state and cursor under the session lock, mirroring
+	// maybeSaveSnapshotLocked, then release before the disk write.
+	stateCopy := s.sm.ExportState()
+	cursor := make(map[int]uint64, len(s.hostSyncNonce))
+	for k, v := range s.hostSyncNonce {
+		cursor[k] = v
+	}
+	nonce := s.nonce
+	store := s.store
+	escrowID := s.escrowID
+	s.mu.Unlock()
+
+	return writeSnapshotErr(store, escrowID, nonce, stateCopy, cursor)
+}
+
 // PrepareInference composes a diff, applies it locally, advances nonce,
 // and returns everything needed for the HTTP send. Thread-safe.
 //
@@ -1609,7 +1664,7 @@ func (s *Session) IsNonceFinished(nonce uint64) bool {
 // sendTime is when the nonce's network call started.
 func (s *Session) HandleTimeout(ctx context.Context, nonce uint64, sendTime time.Time, payload *host.InferencePayload) (TimeoutResult, error) {
 	s.mu.Lock()
-	cfg := s.sm.SnapshotState().Config
+	cfg := s.sm.Config()
 	confirmedAt := int64(0)
 	if o, ok := s.nonceStates[nonce]; ok {
 		confirmedAt = o.confirmedAt


### PR DESCRIPTION
Reduce devshardctl gateway RSS by not holding inactive escrows in memory, bounding the chat response cache, and avoiding full inference-map deep copies on the common read paths. Adds pprof/memstats for diagnosis. Runtime lifecycle:
- Boot loads only devshards marked active; inactive ones are skipped instead of being hydrated (and re-queried on chain) at startup.
- Non-resident devshards are served on demand: read-only debug/status routes hydrate a transient local-SQLite-only runtime (no chain/host clients), and settlement rehydrates a transient full runtime; both are released right after use.
- All disable paths (admin deactivate, rotation-without-settle, settle) now retire the runtime from memory drain-safely, only after in-flight requests complete. State accessors (avoid copying the full inference map):
- Add StateMachine.Config, SnapshotStateNoInferences, SnapshotInferences, and InferenceStatusCounts; use them at status/config/single-inference call sites instead of SnapshotState. Endpoints:
- /v1/state is now summary-only; the full inference dump moves to a new admin/debug endpoint /v1/debug/inferences (no pagination).
- /v1/debug/state reports inference status counts; single-inference lookup uses GetInference.
- Add /v1/debug/memstats and register net/http/pprof under /debug/pprof/, both gated behind admin auth. Chat response cache:
- Fix unbounded growth: entries keyed by request-body hash were only expired lazily on lookup, so unique requests lived until restart. Add a periodic expiry sweep and a total-bytes cap (DEVSHARD_CHAT_CACHE_MAX_BYTES).