### PR TITLE
fix(devshard): do not penalize hosts for our own request cancellation

### DIFF
--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -258,7 +258,7 @@ func (c *HTTPClient) Send(ctx context.Context, req host.HostRequest, stream io.W
 	contentType := resp.Header.Get("Content-Type")
 	if strings.HasPrefix(contentType, "text/event-stream") {
 		cr := &countingReader{r: resp.Body}
-		result, err := c.parseSSEResponse(cr, stream, receiptHandler)
+		result, err := c.parseSSEResponse(ctx, cr, stream, receiptHandler)
 		if result != nil {
 			result.StreamBytesRead = cr.n
 		}
@@ -292,7 +292,7 @@ func (c *HTTPClient) Send(ctx context.Context, req host.HostRequest, stream io.W
 //     ([DONE] or devshard_receipt) from a clean EOF that arrives *before* one.
 //     bufio.Scanner squashes io.EOF into a nil error, so the caller cannot tell
 //     a successful completion from a peer / middlebox closing the body early.
-func (c *HTTPClient) parseSSEResponse(r io.Reader, stream io.Writer, receiptHandler func()) (*host.HostResponse, error) {
+func (c *HTTPClient) parseSSEResponse(ctx context.Context, r io.Reader, stream io.Writer, receiptHandler func()) (*host.HostResponse, error) {
 	br := bufio.NewReaderSize(r, 64<<10)
 	var result host.HostResponse
 	var writeErrLogged bool
@@ -307,6 +307,16 @@ func (c *HTTPClient) parseSSEResponse(r io.Reader, stream io.Writer, receiptHand
 		}
 		if readErr != nil {
 			if readErr == io.EOF {
+				// A cancelled context (client disconnect, race resolved, drain)
+				// can surface as a clean EOF once the peer closes the body after
+				// we abort the request. The receipt event sets sawTerminator
+				// early, so without this check a cancelled stream that never
+				// carried content would be reported as a successful empty
+				// response and wrongly scored against the host. Report the
+				// cancellation as the error it is.
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return &result, fmt.Errorf("read SSE stream: %w", ctxErr)
+				}
 				if !sawTerminator {
 					return &result, ErrSSEStreamTruncated
 				}
@@ -707,6 +717,12 @@ func (c *HTTPClient) observeResultWithBody(path string, statusCode int, body str
 
 func (c *HTTPClient) observeTransportFailure(path string, err error) {
 	if c == nil || c.config.Admission == nil || strings.TrimSpace(c.config.ParticipantKey) == "" {
+		return
+	}
+	// A cancelled request context is our own signal (client disconnect, race
+	// resolved, drain), not a fault of the host. Attributing it as a transport
+	// failure would quarantine a healthy host, so skip it.
+	if errors.Is(err, context.Canceled) {
 		return
 	}
 	c.config.Admission.ObserveTransportFailure(c.config.ParticipantKey, path, err)

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -189,7 +190,7 @@ func TestParseSSE_PartialResult(t *testing.T) {
 	// Use a reader that returns the data then an error (simulating connection drop).
 	r := &truncatedReader{data: []byte(sseData)}
 
-	result, err := client.parseSSEResponse(r, nil, nil)
+	result, err := client.parseSSEResponse(context.Background(), r, nil, nil)
 	require.Error(t, err, "should return error from broken stream")
 	require.NotNil(t, result, "should return partial result")
 	require.Equal(t, uint64(1), result.Nonce)
@@ -343,4 +344,58 @@ type lineCollector func(line string)
 func (c lineCollector) Write(p []byte) (int, error) {
 	c(string(p))
 	return len(p), nil
+}
+
+const receiptOnlySSE = "data: {\"devshard_receipt\":{\"state_sig\":\"c2ln\",\"state_hash\":\"aGFzaA==\",\"nonce\":1,\"receipt\":\"cmVjZWlwdA==\",\"confirmed_at\":1000}}\n\n"
+
+func TestParseSSE_CancelledContextReportsCancellation(t *testing.T) {
+	// A cancelled attempt (client disconnect, race resolved, drain) can see the
+	// peer close with a clean EOF after the receipt already arrived. The receipt
+	// sets the terminator, so without a context check this would read as a
+	// successful empty response and be scored against the host. It must instead
+	// surface as the cancellation it is.
+	client := &HTTPClient{config: DefaultClientConfig()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := client.parseSSEResponse(ctx, strings.NewReader(receiptOnlySSE), nil, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Receipt, "receipt should still be extracted from the partial stream")
+}
+
+func TestParseSSE_ReceiptThenCleanEOFSucceeds(t *testing.T) {
+	// Without cancellation, a receipt-terminated stream that closes cleanly is a
+	// successful completion, even when it carried no content. This guards against
+	// the context check regressing the normal empty-but-complete path.
+	client := &HTTPClient{config: DefaultClientConfig()}
+
+	result, err := client.parseSSEResponse(context.Background(), strings.NewReader(receiptOnlySSE), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, uint64(1), result.Nonce)
+	require.NotNil(t, result.Receipt)
+}
+
+func TestObserveTransportFailure_IgnoresContextCancellation(t *testing.T) {
+	admission := &stubAdmissionController{}
+	client := &HTTPClient{config: DefaultClientConfig()}
+	client.config.ParticipantKey = "shared-host"
+	client.config.Admission = admission
+
+	const path = "/sessions/escrow-1/chat/completions"
+
+	// Our own cancellation must never quarantine the host, whether it arrives
+	// bare or wrapped.
+	client.observeTransportFailure(path, context.Canceled)
+	client.observeTransportFailure(path, fmt.Errorf("POST %s: %w", path, context.Canceled))
+	require.Empty(t, admission.observed, "cancellation must not be reported as a transport failure")
+
+	// A genuine transport error is still reported.
+	client.observeTransportFailure(path, errors.New("connection refused"))
+	require.Len(t, admission.observed, 1)
+	require.Contains(t, admission.observed[0], "shared-host")
+	require.Contains(t, admission.observed[0], "transport")
 }


### PR DESCRIPTION
## Summary
Two paths attributed a cancellation initiated on our side (client disconnect, race resolved, drain) to the host, penalizing a healthy host for our own action.

## Changes
- `parseSSEResponse` now takes the request context. A cancellation can surface as a clean `io.EOF` once the peer closes the body after we abort the request. The devshard receipt sets the stream terminator early, so such a stream — even with no content — was returned with a nil error and scored as an `empty_stream` against the host. When the context is cancelled it now returns the context error instead.
- `observeTransportFailure` now skips `context.Canceled`. Previously a cancelled request context was reported as a transport failure, which immediately quarantines the host for 30 minutes across all escrows on the shared limiter.

## Tests
- `TestParseSSE_CancelledContextReportsCancellation` — receipt then clean EOF under a cancelled context returns the context error, with the receipt still extracted.
- `TestParseSSE_ReceiptThenCleanEOFSucceeds` — the same stream without cancellation still succeeds, guarding the empty-but-complete path.
- `TestObserveTransportFailure_IgnoresContextCancellation` — bare and wrapped `context.Canceled` are not reported; a genuine transport error still is.
