### PR TITLE
fix(gateway): don't kill redundancy secondaries after normal completion

### DIFF
--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -23,7 +23,15 @@ import (
 
 var sseDoneMarker = []byte("data: [DONE]")
 
-const defaultMetaDrainTimeout = 10 * time.Second
+// defaultMetaDrainTimeout is a last-resort backstop, not an active policy:
+// it must exceed every natural completion window (SecondaryWaitAfterWinner,
+// nonStreamingNoContentTimeout, nonStreamingMaxAttemptWait) so that hosts
+// which are still legitimately generating after a client disconnect get to
+// finish and settle their nonce normally. Cutting a host early records it
+// as a timeout / empty stream through no fault of its own. The only thing
+// this cap should ever terminate is a host that streams forever without
+// tripping any of the normal race timeouts.
+const defaultMetaDrainTimeout = 40 * time.Minute
 
 // metaDrainTimeout applies only after client disconnect (flag.Done() in
 // withMetaDrain), not during normal connected flows. If devshard_meta /
@@ -82,14 +90,36 @@ func (cf *cancelFlag) Done() <-chan struct{} {
 
 // watchClientCancel triggers flag when r's context is canceled (client
 // disconnected). Spawns one short-lived goroutine bounded by request lifetime.
-func watchClientCancel(r *http.Request, flag *cancelFlag) {
+//
+// net/http also cancels the request context when the handler returns after a
+// normal response, which is indistinguishable from a disconnect here. Callers
+// must invoke the returned stop func once RunInference has returned (i.e. the
+// response was fully delivered) so that normal completion does not trip the
+// flag and metaDrain-cancel speculative attempts that are still running under
+// the SecondaryWaitAfterWinner grace window.
+func watchClientCancel(r *http.Request, flag *cancelFlag) (stop func()) {
 	if flag == nil || r == nil {
-		return
+		return func() {}
 	}
+	stopped := make(chan struct{})
 	go func() {
-		<-r.Context().Done()
-		flag.Trigger()
+		select {
+		case <-r.Context().Done():
+			// stop() happens-before the handler returns, which happens-before
+			// net/http cancels the request context, so this non-blocking
+			// re-check deterministically ignores the post-completion cancel
+			// even when the goroutine first wakes up here.
+			select {
+			case <-stopped:
+				return
+			default:
+			}
+			flag.Trigger()
+		case <-stopped:
+		}
 	}()
+	var once sync.Once
+	return func() { once.Do(func() { close(stopped) }) }
 }
 
 // withMetaDrain caps upstream host reads after client disconnect so a
@@ -342,7 +372,7 @@ func (d *deferredWriter) logFlushFailedOnce(err error, where string) {
 func (p *Proxy) handleStreaming(w http.ResponseWriter, r *http.Request, params user.InferenceParams) {
 	started := time.Now()
 	flag := newCancelFlag()
-	watchClientCancel(r, flag)
+	stopClientWatch := watchClientCancel(r, flag)
 	dw := newDeferredWriter(r.Context(), w, p.escrowID, flag)
 
 	// Upstream redundancy is NOT bound to r.Context(): host SSE must be
@@ -351,6 +381,10 @@ func (p *Proxy) handleStreaming(w http.ResponseWriter, r *http.Request, params u
 	// upstream may run after the client is gone.
 	var doneWriteErr error
 	err := p.redundancy.RunInference(context.Background(), params, dw, flag)
+	// The response is fully delivered; detach the disconnect watcher so the
+	// handler returning does not masquerade as a client disconnect and cut
+	// down speculative losers still draining in the background finalizer.
+	stopClientWatch()
 	if flag.Gone() {
 		logRequestStage(r.Context(), "proxy_stream_client_gone",
 			"escrow", p.escrowID,
@@ -508,9 +542,14 @@ func logProxyResponseFinished(ctx context.Context, escrowID, outcome string, dw 
 func (p *Proxy) handleNonStreaming(w http.ResponseWriter, r *http.Request, params user.InferenceParams) {
 	var buf bytes.Buffer
 	flag := newCancelFlag()
-	watchClientCancel(r, flag)
+	stopClientWatch := watchClientCancel(r, flag)
 
 	err := p.redundancy.RunInference(context.Background(), params, &buf, flag)
+	// Winner settled and the response body is buffered; detach the disconnect
+	// watcher so the handler returning does not masquerade as a client
+	// disconnect and cut down speculative losers still draining in the
+	// background finalizer.
+	stopClientWatch()
 	if flag.Gone() {
 		return
 	}

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -128,6 +128,37 @@ func TestCancelFlag_NilSafeAndOneShot(t *testing.T) {
 	}
 }
 
+func TestWatchClientCancel_TriggersOnDisconnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	flag := newCancelFlag()
+	stop := watchClientCancel(r, flag)
+	defer stop()
+
+	cancel()
+
+	select {
+	case <-flag.Done():
+	case <-time.After(time.Second):
+		t.Fatal("flag should trigger when the request context is canceled mid-request")
+	}
+}
+
+func TestWatchClientCancel_StopPreventsTriggerOnNormalCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	flag := newCancelFlag()
+	stop := watchClientCancel(r, flag)
+
+	stop()
+	stop() // must be idempotent
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	require.False(t, flag.Gone(), "normal handler return must not be treated as a client disconnect")
+}
+
 func TestDeferredWriter_SwallowsAfterClientGone(t *testing.T) {
 	rec := httptest.NewRecorder()
 	flag := newCancelFlag()


### PR DESCRIPTION
net/http cancels r.Context() when a handler returns, not only on client disconnect, so every completed request tripped the client-gone flag and withMetaDrain cancelled still-running speculative attempts 10s later — preempting the SecondaryWaitAfterWinner grace. Cancelled losers never reached devshard_meta and were recorded as empty streams / timeouts despite healthy hosts.

- watchClientCancel returns a stop func; handlers call it after RunInference so normal return no longer masquerades as a disconnect.
- defaultMetaDrainTimeout raised 10s -> 40min: a last-resort backstop above all natural completion windows, so hosts can finish and settle even after a real client disconnect.