### PR TITLE
feat(devshard): expose gateway chat cache size metric

### DIFF
--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -2696,6 +2696,21 @@ func TestGatewayMetricsCollectorIncludesHostConnectionSnapshots(t *testing.T) {
 	requireMetricGaugeValue(t, families, "devshard_host_transport_connections", map[string]string{"address": "10.1.2.3", "state": "hold_after_close"}, 4)
 }
 
+func TestGatewayMetricsCollectorReportsChatCacheEntries(t *testing.T) {
+	g := NewGateway(nil, NewGatewayLimiter(0, 0), "Qwen/Test")
+	now := time.Now()
+	g.chatCache.Set(chatCacheKey("Qwen/Test", []byte("body-1")), cachedChatResponse{EscrowID: "12", Body: []byte("resp-1")}, now)
+	g.chatCache.Set(chatCacheKey("Qwen/Test", []byte("body-2")), cachedChatResponse{EscrowID: "12", Body: []byte("resp-2")}, now)
+
+	collector := newGatewayMetricsCollectorWithHostConnections(g, fakeHostConnectionSnapshotter(nil))
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	requireMetricGaugeValue(t, families, "devshard_gateway_chat_cache_entries", nil, 2)
+}
+
 type fakeHostConnectionSnapshotter []transport.HostConnectionSnapshot
 
 func (f fakeHostConnectionSnapshotter) Snapshots() []transport.HostConnectionSnapshot {

--- a/devshard/cmd/devshardctl/metrics.go
+++ b/devshard/cmd/devshardctl/metrics.go
@@ -285,6 +285,7 @@ type gatewayMetricsCollector struct {
 	escrowBlockedParticipantsDesc *prometheus.Desc
 	hostOpenDesc                  *prometheus.Desc
 	hostStateDesc                 *prometheus.Desc
+	chatCacheEntriesDesc          *prometheus.Desc
 }
 
 func newGatewayMetricsCollector(gateway *Gateway) *gatewayMetricsCollector {
@@ -401,6 +402,12 @@ func newGatewayMetricsCollectorWithHostConnections(gateway *Gateway, hostConnect
 			[]string{"address", "state"},
 			nil,
 		),
+		chatCacheEntriesDesc: prometheus.NewDesc(
+			"devshard_gateway_chat_cache_entries",
+			"Current number of cached chat responses held in the gateway dedup cache.",
+			nil,
+			nil,
+		),
 	}
 }
 
@@ -422,6 +429,7 @@ func (c *gatewayMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.escrowBlockedParticipantsDesc
 	ch <- c.hostOpenDesc
 	ch <- c.hostStateDesc
+	ch <- c.chatCacheEntriesDesc
 }
 
 func (c *gatewayMetricsCollector) Collect(ch chan<- prometheus.Metric) {
@@ -455,6 +463,13 @@ func (c *gatewayMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			c.participantTrackedDesc,
 			prometheus.GaugeValue,
 			float64(c.gateway.participantLimiter.TrackedCount()),
+		)
+	}
+	if c.gateway.chatCache != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.chatCacheEntriesDesc,
+			prometheus.GaugeValue,
+			float64(c.gateway.chatCache.Len()),
 		)
 	}
 

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -69,6 +69,16 @@ func (c *chatResponseCache) Get(key string, now time.Time) (cachedChatResponse, 
 	return entry, true
 }
 
+// Len returns the number of cached entries. Intended for tests and metrics.
+func (c *chatResponseCache) Len() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
 func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.Time) {
 	if c == nil || key == "" || len(entry.Body) == 0 || strings.TrimSpace(entry.EscrowID) == "" {
 		return


### PR DESCRIPTION
### Problem

The gateway chat cache exports no metrics, so operators can't see how many responses are cached or how occupancy tracks traffic. Every other gateway subsystem (limiter, capacity, participant limiter, host connections) already exposes gauges via `gatewayMetricsCollector`; the cache was the only unobservable one.

### Fix

Add a `chatResponseCache.Len()` accessor and a new gauge `devshard_gateway_chat_cache_entries` to `gatewayMetricsCollector` — declared in `Describe`, emitted in `Collect` when `gateway.chatCache != nil`. No labels
(single process-wide cache). Purely additive, read-only, reuses the existing collector wiring.

### Tests

`TestGatewayMetricsCollectorReportsChatCacheEntries` seeds two entries and asserts the gauge reads 2 via the registry, following the existing `requireMetricGaugeValue` pattern. 

### Note

Companion to #1409 (which bounds the same cache). Independent of it: this PR only adds the accessor + gauge, so it applies cleanly on its own, and #1409 keeps the reported count bounded.