### PR TITLE
Bump gonka-ai/cosmos-sdk to v0.53.3-ps19-observability

### DIFF
--- a/decentralized-api/go.mod
+++ b/decentralized-api/go.mod
@@ -313,7 +313,7 @@ require (
 
 replace (
 	devshard => ../devshard
-	github.com/cosmos/cosmos-sdk => github.com/gonka-ai/cosmos-sdk v0.53.3-ps19
+	github.com/cosmos/cosmos-sdk => github.com/gonka-ai/cosmos-sdk v0.53.3-ps19-observability
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/productscience/inference => ../inference-chain
 )

--- a/decentralized-api/go.sum
+++ b/decentralized-api/go.sum
@@ -625,8 +625,8 @@ github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gonka-ai/cosmos-sdk v0.53.3-ps19 h1:2EB13gzwvQLWW5s3CfFQ5PjF0pzPc7l8CG/CZi+7i/Y=
-github.com/gonka-ai/cosmos-sdk v0.53.3-ps19/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
+github.com/gonka-ai/cosmos-sdk v0.53.3-ps19-observability h1:jzgFsresYGzIbtF/Ov69GxFQ7NHG42R0bP6nMNdzoQU=
+github.com/gonka-ai/cosmos-sdk v0.53.3-ps19-observability/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=

--- a/inference-chain/go.mod
+++ b/inference-chain/go.mod
@@ -4,7 +4,7 @@ go 1.24.2
 
 replace (
 	cosmossdk.io/store => github.com/gonka-ai/cosmos-sdk/store v1.1.2-ps1
-	github.com/cosmos/cosmos-sdk => github.com/gonka-ai/cosmos-sdk v0.53.3-ps19
+	github.com/cosmos/cosmos-sdk => github.com/gonka-ai/cosmos-sdk v0.53.3-ps19-observability
 	// fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	// replace broken goleveldb

--- a/inference-chain/go.sum
+++ b/inference-chain/go.sum
@@ -790,8 +790,8 @@ github.com/golangci/revgrep v0.5.3 h1:3tL7c1XBMtWHHqVpS5ChmiAAoe4PF/d5+ULzV9sLAz
 github.com/golangci/revgrep v0.5.3/go.mod h1:U4R/s9dlXZsg8uJmaR1GrloUr14D7qDl8gi2iPXJH8k=
 github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed h1:IURFTjxeTfNFP0hTEi1YKjB/ub8zkpaOqFFMApi2EAs=
 github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed/go.mod h1:XLXN8bNw4CGRPaqgl3bv/lhz7bsGPh4/xSaMTbo2vkQ=
-github.com/gonka-ai/cosmos-sdk v0.53.3-ps19 h1:2EB13gzwvQLWW5s3CfFQ5PjF0pzPc7l8CG/CZi+7i/Y=
-github.com/gonka-ai/cosmos-sdk v0.53.3-ps19/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
+github.com/gonka-ai/cosmos-sdk v0.53.3-ps19-observability h1:jzgFsresYGzIbtF/Ov69GxFQ7NHG42R0bP6nMNdzoQU=
+github.com/gonka-ai/cosmos-sdk v0.53.3-ps19-observability/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
 github.com/gonka-ai/cosmos-sdk/store v1.1.2-ps1 h1:8kmYjdJ9ht+o+0GnJywdf2JounFAWOZZ5xZSrJ6ntFk=
 github.com/gonka-ai/cosmos-sdk/store v1.1.2-ps1/go.mod h1:7a15p+QsM5UXf7VMhO3ylmqj85k9UBN/h1kwMcLiffA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=


### PR DESCRIPTION
Picks up gonka_query_* Prometheus metrics, slow-query logging with app.toml/env controls, and ABCI query path label sanitization (gonka-ai/cosmos-sdk#18).