### PR TITLE
fix(poc): retry early-proof once, then fail closed on unavailability

### DIFF
--- a/decentralized-api/poc/early_guard.go
+++ b/decentralized-api/poc/early_guard.go
@@ -375,22 +375,23 @@ func (g *EarlyShareGuard) checkPrefix(ctx context.Context, pf proofFetcher, stag
 		return true, ""
 	}
 
-	earlyProofs, err := pf.FetchAndVerifyProofs(ctx, work.url, ProofRequest{
+	// One retry on transient failures so a genuine hiccup doesn't fail the participant.
+	earlyReq := ProofRequest{
 		PocStageStartBlockHeight: stage,
 		ModelId:                  work.modelId,
 		RootHash:                 dec.earlyRoot,
 		Count:                    dec.earlyCount,
 		LeafIndices:              []uint32{sharedLeaf},
 		ParticipantAddress:       work.address,
-	})
-	if err != nil {
-		if isPermanentProofError(err) {
-			// Early root cannot prove the shared leaf -> hard failure.
-			return false, fmt.Sprintf("early_proof_invalid leaf=%d: %v", sharedLeaf, err)
-		}
-		logging.Debug("EarlyShareGuard: early shared-leaf proof unavailable (transient)", types.PoC,
+	}
+	earlyProofs, err := pf.FetchAndVerifyProofs(ctx, work.url, earlyReq)
+	if err != nil && !isPermanentProofError(err) {
+		logging.Debug("EarlyShareGuard: early shared-leaf proof transient failure, retrying", types.PoC,
 			"participant", work.address, "leaf", sharedLeaf, "error", err)
-		return true, ""
+		earlyProofs, err = pf.FetchAndVerifyProofs(ctx, work.url, earlyReq)
+	}
+	if err != nil {
+		return false, fmt.Sprintf("early_proof_unavailable leaf=%d: %v", sharedLeaf, err)
 	}
 	if len(earlyProofs) != 1 {
 		return false, fmt.Sprintf("early_proof_missing leaf=%d", sharedLeaf)

--- a/decentralized-api/poc/early_guard_test.go
+++ b/decentralized-api/poc/early_guard_test.go
@@ -444,14 +444,70 @@ func TestDecide(t *testing.T) {
 		}
 	})
 
-	t.Run("transient early-proof error does not fail participant", func(t *testing.T) {
+	t.Run("transient early-proof error persists after retry -> vote no", func(t *testing.T) {
 		art := VerifiedArtifact{LeafIndex: 3, Nonce: 7, VectorB64: "vec"}
 		f := mkFetcher(art, art, context.DeadlineExceeded)
 		dec := prefixDec
 		dec.shareVoteNo = false
 		voteNo, reason := guard.decide(ctx, f, stage, work, dec)
-		if voteNo {
-			t.Fatalf("transient early-proof error must not vote no, got: %s", reason)
+		if !voteNo {
+			t.Fatalf("persistent transient early-proof error must vote no, got no vote: %s", reason)
+		}
+		// 1 call for final root + 2 calls for early root (initial + 1 retry) = 3.
+		if f.calls != 3 {
+			t.Fatalf("expected 3 fetcher calls (final + early + 1 retry), got %d", f.calls)
 		}
 	})
+
+	t.Run("transient early-proof error succeeds on retry -> no vote", func(t *testing.T) {
+		art := VerifiedArtifact{LeafIndex: 3, Nonce: 7, VectorB64: "vec"}
+		f := mkFlakyEarlyFetcher(finalRoot, earlyRoot, art, art, context.DeadlineExceeded)
+		dec := prefixDec
+		dec.shareVoteNo = false
+		voteNo, reason := guard.decide(ctx, f, stage, work, dec)
+		if voteNo {
+			t.Fatalf("retry-succeeded early proof must not vote no, got: %s", reason)
+		}
+		if f.calls != 3 {
+			t.Fatalf("expected 3 fetcher calls (final + early_fail + early_retry_ok), got %d", f.calls)
+		}
+	})
+}
+
+// mkFlakyEarlyFetcher returns a fetcher whose early-root call fails once with the
+// given transient error, then succeeds on the second call. Final-root calls
+// always succeed.
+func mkFlakyEarlyFetcher(finalRoot, earlyRoot []byte, finalArt, earlyArt VerifiedArtifact, transientErr error) *flakyProofFetcher {
+	return &flakyProofFetcher{
+		finalRoot:      finalRoot,
+		earlyRoot:      earlyRoot,
+		finalArt:       finalArt,
+		earlyArt:       earlyArt,
+		transientErr:   transientErr,
+	}
+}
+
+type flakyProofFetcher struct {
+	finalRoot      []byte
+	earlyRoot      []byte
+	finalArt       VerifiedArtifact
+	earlyArt       VerifiedArtifact
+	transientErr   error
+	calls          int
+	earlyCallCount int
+}
+
+func (f *flakyProofFetcher) FetchAndVerifyProofs(_ context.Context, _ string, req ProofRequest) ([]VerifiedArtifact, error) {
+	f.calls++
+	if string(req.RootHash) == string(f.finalRoot) {
+		return []VerifiedArtifact{f.finalArt}, nil
+	}
+	if string(req.RootHash) == string(f.earlyRoot) {
+		f.earlyCallCount++
+		if f.earlyCallCount == 1 {
+			return nil, f.transientErr
+		}
+		return []VerifiedArtifact{f.earlyArt}, nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION
The early-share guard's prefix-proof check silently passed a participant whenever their own published early rootHash could not be proven, because any non-typed error was treated as a transient network hiccup and the guard failed open. This is exploitable: an attacker who publishes a random rootHash for their early commit (with no backing MMR data) will always return HTTP 400 "snapshot not found" for the shared-leaf query. That response is not one of the three typed proof errors, so isPermanentProofError returns false and checkPrefix returns (true, "") — the participant clears the prefix check without ever proving they held the data they committed to. A participant cannot reasonably have a persistent transient failure against their own published commitment: they either kept the data (and can prove it) or they did not (and cannot). The one legitimate case for a single-shot failure is a genuine network flake, which a retry covers.

Changes:
- checkPrefix now retries the early-proof fetch once on non-permanent errors, then treats any remaining error as a hard failure and votes no with reason "early_proof_unavailable".
- Permanent proof errors continue to fail immediately without retry.
- Final-proof handling is unchanged: transient failures there still fail open, since the main validation path already vets the final commitment.

Tests:
- Replaced the "transient error does not fail participant" case with two new cases: persistent transient error across both attempts -> vote no, asserting exactly 3 fetcher calls (final + early + 1 retry); transient error on first attempt, success on retry -> no vote, also asserting 3 fetcher calls.
- Added flakyProofFetcher, a per-root call-counted fake that fails the first early-root call with a configured transient error and succeeds afterwards.
- Existing permanent-error, matching-prefix, vector-mismatch, and low-share cases are unchanged and still pass.