### PR TITLE
devshard: gateway v2 cleanup (escrow rotation review fixes)

### DIFF
--- a/devshard/cmd/devshardctl/chain_tx_rest.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest.go
@@ -369,6 +369,28 @@ func (c *RESTChainTxClient) getJSON(ctx context.Context, path string, out any) e
 	return c.getJSONFromBaseURL(ctx, c.baseURL, path, out)
 }
 
+// chainHTTPError is returned by getJSONFromBaseURL on non-200 responses.
+type chainHTTPError struct {
+	method string
+	path   string
+	status int
+	body   string
+}
+
+func (e *chainHTTPError) Error() string {
+	if e == nil {
+		return "chain HTTP error"
+	}
+	return fmt.Sprintf("%s %s status %d: %s", e.method, e.path, e.status, e.body)
+}
+
+func (e *chainHTTPError) StatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.status
+}
+
 func (c *RESTChainTxClient) getJSONFromBaseURL(ctx context.Context, baseURL, path string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
 	if err != nil {
@@ -381,19 +403,21 @@ func (c *RESTChainTxClient) getJSONFromBaseURL(ctx context.Context, baseURL, pat
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("GET %s status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+		return &chainHTTPError{
+			method: http.MethodGet,
+			path:   path,
+			status: resp.StatusCode,
+			body:   strings.TrimSpace(string(body)),
+		}
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
 }
 
-// isNotFoundError reports whether a chain GET failed with 404 / not-found rather
-// than a transient error.
+// isNotFoundError reports whether a chain GET failed with HTTP 404 rather than
+// a transient error.
 func isNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "status 404") || strings.Contains(s, "not found")
+	var httpErr *chainHTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode() == http.StatusNotFound
 }
 
 func (c *RESTChainTxClient) postJSON(ctx context.Context, path string, in any, out any) error {

--- a/devshard/cmd/devshardctl/chain_tx_rest_test.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -194,6 +195,30 @@ func escrowIDQueryServer(t *testing.T, txHash string, escrowID uint64) *httptest
 			},
 		})
 	}))
+}
+
+func TestIsNotFoundError_Status404(t *testing.T) {
+	err := fmt.Errorf("http://primary: %w", &chainHTTPError{
+		method: http.MethodGet,
+		path:   "/cosmos/tx/v1beta1/txs/ABC",
+		status: http.StatusNotFound,
+		body:   "tx not found",
+	})
+	require.True(t, isNotFoundError(err))
+}
+
+func TestIsNotFoundError_500WithNotFoundBody(t *testing.T) {
+	err := fmt.Errorf("http://fallback: %w", &chainHTTPError{
+		method: http.MethodGet,
+		path:   "/cosmos/tx/v1beta1/txs/ABC",
+		status: http.StatusInternalServerError,
+		body:   `{"message":"tx not found"}`,
+	})
+	require.False(t, isNotFoundError(err))
+
+	var httpErr *chainHTTPError
+	require.True(t, errors.As(err, &httpErr))
+	require.Equal(t, http.StatusInternalServerError, httpErr.StatusCode())
 }
 
 // TestRESTChainTxClient_GetTxEscrowIDTriesFallbackOn404 pins the recovery path:

--- a/devshard/cmd/devshardctl/escrow_recovery_test.go
+++ b/devshard/cmd/devshardctl/escrow_recovery_test.go
@@ -240,12 +240,12 @@ func TestReconcileCommitmentsKeepsFreshTxNotFound(t *testing.T) {
 // never land — only then is it safe to clear.
 func TestReconcileCommitmentsClearsExpiredTxNotFound(t *testing.T) {
 	g, store, settings := newRecoveryGateway(t)
-	old := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
-	_, err := store.db.Exec(`
-		INSERT INTO escrow_rotation_commitments (tx_hash, model, role, epoch, private_key_env, block_height, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		"TXOLD", "Qwen/Test", rotationRoleTemp, 0, "", 0, old)
-	require.NoError(t, err)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{
+		TxHash:    "TXOLD",
+		Model:     "Qwen/Test",
+		Role:      rotationRoleTemp,
+		CreatedAt: time.Now().UTC().Add(-1 * time.Hour),
+	}))
 	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, errTxNotFound })
 
 	g.reconcileCommitments(context.Background(), settings)

--- a/devshard/cmd/devshardctl/escrow_recovery_test.go
+++ b/devshard/cmd/devshardctl/escrow_recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,6 +27,23 @@ func TestGatewayStoreUsesWALAndBusyTimeout(t *testing.T) {
 	var busyTimeout int
 	require.NoError(t, store.db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout))
 	assert.Equal(t, 5000, busyTimeout)
+}
+
+func TestWithDBRetry_RespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var attempts atomic.Int32
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := withDBRetry(ctx, func() error {
+		attempts.Add(1)
+		return errors.New("database is locked")
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, int(attempts.Load()), escrowWriteRetries)
 }
 
 func recoveryTestSettings() GatewaySettings {

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -80,28 +80,32 @@ func (g *Gateway) stopEscrowRotatorLocked() {
 
 func (g *Gateway) runEscrowRotator(stopCh <-chan struct{}, doneCh chan<- struct{}) {
 	defer close(doneCh)
-	g.rotateEscrowsOnce()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g.rotateEscrowsOnce(ctx)
 
 	ticker := time.NewTicker(defaultEscrowRotationInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			g.rotateEscrowsOnce()
+			g.rotateEscrowsOnce(ctx)
 		case <-stopCh:
+			cancel()
 			return
 		}
 	}
 }
 
-func (g *Gateway) rotateEscrowsOnce() {
+func (g *Gateway) rotateEscrowsOnce(ctx context.Context) {
 	if g == nil || g.phaseGate == nil || g.store == nil {
 		return
 	}
 	g.mu.Lock()
 	settings := g.settings
 	g.mu.Unlock()
-	g.reconcileCommitments(context.Background(), settings)
+	g.reconcileCommitments(ctx, settings)
 	rotation := settings.EscrowRotation
 	if !rotation.Enabled {
 		return
@@ -119,18 +123,18 @@ func (g *Gateway) rotateEscrowsOnce() {
 	blocksToEpochSwitch := snapshot.epochSwitchBlockHeight - snapshot.BlockHeight
 
 	if blocksToEpochSwitch >= 0 && blocksToEpochSwitch <= rotation.PrePoCBlocks {
-		g.prepareBridgeEscrows(snapshot, settings)
+		g.prepareBridgeEscrows(ctx, snapshot, settings)
 		return
 	}
 	if !pocActive {
-		g.finishBridgeEscrows(snapshot, settings)
+		g.finishBridgeEscrows(ctx, snapshot, settings)
 	}
 }
 
-func (g *Gateway) prepareBridgeEscrows(snapshot ChainPhaseSnapshot, settings GatewaySettings) {
+func (g *Gateway) prepareBridgeEscrows(ctx context.Context, snapshot ChainPhaseSnapshot, settings GatewaySettings) {
 	epoch := snapshot.EpochIndex
 	for _, model := range normalizedEscrowRotationModels(settings) {
-		ensure, err := g.ensureRotationEscrows(context.Background(), settings, model, rotationRoleTemp, epoch, model.TempCount)
+		ensure, err := g.ensureRotationEscrows(ctx, settings, model, rotationRoleTemp, epoch, model.TempCount)
 		if err != nil {
 			log.Printf("escrow_rotation_temp_create_failed epoch=%d model=%q error=%v", epoch, model.ModelID, err)
 			promoted, promoteErr := g.promoteActiveRegularEscrowsToTemp(model.ModelID, epoch)
@@ -162,7 +166,7 @@ func (g *Gateway) prepareBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gat
 			if devshard.RotationRole == rotationRoleTemp || !devshard.Active || strings.TrimSpace(devshard.Model) != model.ModelID {
 				continue
 			}
-			settledOnChain, err := g.retireRotatedDevshard(context.Background(), devshard.ID, "escrow rotation regular retired", settings)
+			settledOnChain, err := g.retireRotatedDevshard(ctx, devshard.ID, "escrow rotation regular retired", settings)
 			if err != nil {
 				log.Printf("escrow_rotation_regular_retire_failed epoch=%d model=%q escrow=%s error=%v", epoch, model.ModelID, devshard.ID, err)
 				settleFailed++
@@ -185,7 +189,7 @@ func (g *Gateway) prepareBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gat
 	}
 }
 
-func (g *Gateway) finishBridgeEscrows(snapshot ChainPhaseSnapshot, settings GatewaySettings) {
+func (g *Gateway) finishBridgeEscrows(ctx context.Context, snapshot ChainPhaseSnapshot, settings GatewaySettings) {
 	epoch := snapshot.EpochIndex
 	for _, model := range normalizedEscrowRotationModels(settings) {
 		state, ok, err := g.store.LoadState()
@@ -203,7 +207,7 @@ func (g *Gateway) finishBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gate
 		if !hasBridgeEscrows {
 			continue
 		}
-		ensure, err := g.ensureRotationEscrows(context.Background(), settings, model, rotationRoleRegular, epoch, model.TargetCount)
+		ensure, err := g.ensureRotationEscrows(ctx, settings, model, rotationRoleRegular, epoch, model.TargetCount)
 		if err != nil {
 			log.Printf("escrow_rotation_regular_create_failed epoch=%d model=%q error=%v", epoch, model.ModelID, err)
 			g.saveRotationStatus(GatewayRotationStatus{
@@ -230,7 +234,7 @@ func (g *Gateway) finishBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gate
 			if devshard.RotationRole != rotationRoleTemp || devshard.RotationEpoch > epoch || !devshard.Active || strings.TrimSpace(devshard.Model) != model.ModelID {
 				continue
 			}
-			settledOnChain, err := g.retireRotatedDevshard(context.Background(), devshard.ID, "escrow rotation temp retired", settings)
+			settledOnChain, err := g.retireRotatedDevshard(ctx, devshard.ID, "escrow rotation temp retired", settings)
 			if err != nil {
 				log.Printf("escrow_rotation_temp_retire_failed epoch=%d model=%q escrow=%s error=%v", epoch, model.ModelID, devshard.ID, err)
 				settleFailed++
@@ -340,18 +344,18 @@ func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySett
 	onPrepared := func(txHash string) error {
 		c := commitment
 		c.TxHash = txHash
-		return withDBRetry(func() error { return g.store.SaveCommitment(c) })
+		return withDBRetry(ctx, func() error { return g.store.SaveCommitment(c) })
 	}
 	result, err := gatewayCreateEscrowOnChain(g, ctx, settings, model, onPrepared)
 	if err != nil {
 		return nil, err
 	}
-	if err := g.persistRotationEscrow(result.EscrowID, model.ModelID, role, epoch, keyEnv); err != nil {
+	if err := g.persistRotationEscrow(ctx, result.EscrowID, model.ModelID, role, epoch, keyEnv); err != nil {
 		// Escrow is on chain; commitment survives → reconcile recovers it by tx hash.
 		log.Printf("escrow_rotation_persist_failed escrow=%d tx=%s model=%q error=%v recover_via_commitment=true", result.EscrowID, result.TxHash, model.ModelID, err)
 		return nil, err
 	}
-	g.clearCommitment(result.TxHash)
+	g.clearCommitment(ctx, result.TxHash)
 	log.Printf("escrow_rotation_created role=%s epoch=%d model=%q escrow=%d tx_hash=%s", role, epoch, model.ModelID, result.EscrowID, result.TxHash)
 	return result, nil
 }
@@ -458,21 +462,30 @@ func (g *Gateway) currentBlockHeight() uint64 {
 }
 
 // withDBRetry retries a DB write with backoff to ride out a transient lock.
-func withDBRetry(fn func() error) error {
+func withDBRetry(ctx context.Context, fn func() error) error {
 	var err error
 	for attempt := 0; attempt < escrowWriteRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err = fn(); err == nil {
 			return nil
 		}
 		if attempt < escrowWriteRetries-1 {
-			time.Sleep(escrowWriteRetryBackoff)
+			timer := time.NewTimer(escrowWriteRetryBackoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
 		}
 	}
 	return err
 }
 
 // persistRotationEscrow persists + registers a created escrow ("already exists" = ok).
-func (g *Gateway) persistRotationEscrow(escrowID uint64, modelID, role string, epoch uint64, keyEnv string) error {
+func (g *Gateway) persistRotationEscrow(ctx context.Context, escrowID uint64, modelID, role string, epoch uint64, keyEnv string) error {
 	record := GatewayDevshardState{
 		RuntimeConfig: RuntimeConfig{
 			ID:            strconv.FormatUint(escrowID, 10),
@@ -483,7 +496,7 @@ func (g *Gateway) persistRotationEscrow(escrowID uint64, modelID, role string, e
 		RotationRole:  role,
 		RotationEpoch: epoch,
 	}
-	return withDBRetry(func() error {
+	return withDBRetry(ctx, func() error {
 		if _, err := g.addCreatedEscrowRuntime(record); err != nil {
 			if errors.Is(err, errDevshardAlreadyExists) {
 				return nil
@@ -494,11 +507,11 @@ func (g *Gateway) persistRotationEscrow(escrowID uint64, modelID, role string, e
 	})
 }
 
-func (g *Gateway) clearCommitment(txHash string) {
+func (g *Gateway) clearCommitment(ctx context.Context, txHash string) {
 	if g == nil || g.store == nil || strings.TrimSpace(txHash) == "" {
 		return
 	}
-	if err := withDBRetry(func() error { return g.store.DeleteCommitment(txHash) }); err != nil {
+	if err := withDBRetry(ctx, func() error { return g.store.DeleteCommitment(txHash) }); err != nil {
 		log.Printf("escrow_rotation_commitment_clear_failed tx=%s error=%v", txHash, err)
 	}
 }
@@ -530,7 +543,7 @@ func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySett
 				continue
 			}
 			log.Printf("escrow_commitment_no_escrow tx=%s model=%q clearing=true", c.TxHash, c.Model)
-			g.clearCommitment(c.TxHash)
+			g.clearCommitment(ctx, c.TxHash)
 			continue
 		}
 		if err != nil {
@@ -539,14 +552,14 @@ func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySett
 		}
 		if !found {
 			log.Printf("escrow_commitment_tx_failed tx=%s model=%q clearing=true", c.TxHash, c.Model)
-			g.clearCommitment(c.TxHash)
+			g.clearCommitment(ctx, c.TxHash)
 			continue
 		}
-		if err := g.persistRotationEscrow(escrowID, c.Model, c.Role, c.Epoch, c.PrivateKeyEnv); err != nil {
+		if err := g.persistRotationEscrow(ctx, escrowID, c.Model, c.Role, c.Epoch, c.PrivateKeyEnv); err != nil {
 			log.Printf("escrow_commitment_persist_failed tx=%s escrow=%d model=%q error=%v", c.TxHash, escrowID, c.Model, err)
 			continue // keep commitment — retry next pass
 		}
-		g.clearCommitment(c.TxHash)
+		g.clearCommitment(ctx, c.TxHash)
 		g.resetRotationBreaker(c.Model, c.Role)
 		log.Printf("escrow_commitment_recovered tx=%s escrow=%d model=%q role=%s", c.TxHash, escrowID, c.Model, c.Role)
 	}

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -566,14 +566,13 @@ func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySett
 }
 
 // commitmentTxMayStillLand reports whether a not-found tx could yet be committed
-// (within the unordered-tx window) — if so, the commitment must be kept. An
-// unparseable timestamp is treated as still-pending so we never clear too early.
+// (within the unordered-tx window) — if so, the commitment must be kept. A zero
+// timestamp is treated as still-pending so we never clear too early.
 func commitmentTxMayStillLand(c GatewayEscrowCommitment) bool {
-	createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.CreatedAt))
-	if err != nil {
+	if c.CreatedAt.IsZero() {
 		return true
 	}
-	return time.Since(createdAt) <= commitmentReconcileGrace
+	return time.Since(c.CreatedAt) <= commitmentReconcileGrace
 }
 
 func defaultQueryTxEscrowID(ctx context.Context, settings GatewaySettings, txHash string) (uint64, bool, error) {

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -332,12 +332,11 @@ func (g *Gateway) createEscrowOnChain(ctx context.Context, settings GatewaySetti
 }
 
 func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, role string, epoch uint64) (*CreateDevshardEscrowResult, error) {
-	keyEnv := strings.TrimSpace(model.PrivateKeyEnv)
 	commitment := GatewayEscrowCommitment{
 		Model:         model.ModelID,
 		Role:          role,
 		Epoch:         epoch,
-		PrivateKeyEnv: keyEnv,
+		PrivateKeyEnv: model.PrivateKeyEnv,
 		BlockHeight:   g.currentBlockHeight(),
 	}
 	// Intent-first: persist the commitment (with the precomputed tx hash) before broadcast.
@@ -350,7 +349,7 @@ func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySett
 	if err != nil {
 		return nil, err
 	}
-	if err := g.persistRotationEscrow(ctx, result.EscrowID, model.ModelID, role, epoch, keyEnv); err != nil {
+	if err := g.persistRotationEscrow(ctx, result.EscrowID, model.ModelID, role, epoch, model.PrivateKeyEnv); err != nil {
 		// Escrow is on chain; commitment survives → reconcile recovers it by tx hash.
 		log.Printf("escrow_rotation_persist_failed escrow=%d tx=%s model=%q error=%v recover_via_commitment=true", result.EscrowID, result.TxHash, model.ModelID, err)
 		return nil, err
@@ -364,7 +363,6 @@ func normalizedEscrowRotationModels(settings GatewaySettings) []EscrowRotationMo
 	models := make([]EscrowRotationModelSettings, 0, len(settings.EscrowRotation.Models))
 	for _, model := range settings.EscrowRotation.Models {
 		model.ModelID = strings.TrimSpace(model.ModelID)
-		model.PrivateKeyEnv = strings.TrimSpace(model.PrivateKeyEnv)
 		models = append(models, model)
 	}
 	return models
@@ -489,7 +487,7 @@ func (g *Gateway) persistRotationEscrow(ctx context.Context, escrowID uint64, mo
 	record := GatewayDevshardState{
 		RuntimeConfig: RuntimeConfig{
 			ID:            strconv.FormatUint(escrowID, 10),
-			PrivateKeyEnv: strings.TrimSpace(keyEnv),
+			PrivateKeyEnv: keyEnv,
 			Model:         modelID,
 		},
 		Active:        true,

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -1027,7 +1027,7 @@ type GatewayEscrowCommitment struct {
 	Epoch         uint64
 	PrivateKeyEnv string
 	BlockHeight   uint64
-	CreatedAt     string
+	CreatedAt     time.Time
 }
 
 // SaveCommitment records a create intent, keyed by tx hash.
@@ -1035,7 +1035,12 @@ func (s *GatewayStore) SaveCommitment(c GatewayEscrowCommitment) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("gateway store unavailable")
 	}
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	createdAt := c.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	} else {
+		createdAt = createdAt.UTC()
+	}
 	_, err := s.db.Exec(`
 		INSERT OR REPLACE INTO escrow_rotation_commitments (
 			tx_hash, model, role, epoch, private_key_env, block_height, created_at
@@ -1046,12 +1051,26 @@ func (s *GatewayStore) SaveCommitment(c GatewayEscrowCommitment) error {
 		c.Epoch,
 		strings.TrimSpace(c.PrivateKeyEnv),
 		c.BlockHeight,
-		now,
+		createdAt,
 	)
 	if err != nil {
 		return fmt.Errorf("save escrow commitment tx=%s: %w", c.TxHash, err)
 	}
 	return nil
+}
+
+func scanGatewayDBTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return t.UTC()
+	}
+	if t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", raw); err == nil {
+		return t.UTC()
+	}
+	return time.Time{}
 }
 
 // LoadCommitments returns all pending commitments (oldest first).
@@ -1070,9 +1089,11 @@ func (s *GatewayStore) LoadCommitments() ([]GatewayEscrowCommitment, error) {
 	var commitments []GatewayEscrowCommitment
 	for rows.Next() {
 		var c GatewayEscrowCommitment
-		if err := rows.Scan(&c.TxHash, &c.Model, &c.Role, &c.Epoch, &c.PrivateKeyEnv, &c.BlockHeight, &c.CreatedAt); err != nil {
+		var createdAt string
+		if err := rows.Scan(&c.TxHash, &c.Model, &c.Role, &c.Epoch, &c.PrivateKeyEnv, &c.BlockHeight, &createdAt); err != nil {
 			return nil, fmt.Errorf("scan escrow commitment: %w", err)
 		}
+		c.CreatedAt = scanGatewayDBTime(createdAt)
 		commitments = append(commitments, c)
 	}
 	return commitments, rows.Err()

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -95,7 +95,7 @@ type EscrowRotationModelSettings struct {
 	TempCount     int    `json:"temp_count"`
 	TargetCount   int    `json:"target_count"`
 	Amount        uint64 `json:"amount"`
-	PrivateKeyEnv string `json:"private_key_env"`
+	PrivateKeyEnv string `json:"private_key_env"` // trimmed by WithTuningDefaults on settings load
 }
 
 const (
@@ -1049,7 +1049,7 @@ func (s *GatewayStore) SaveCommitment(c GatewayEscrowCommitment) error {
 		strings.TrimSpace(c.Model),
 		strings.TrimSpace(c.Role),
 		c.Epoch,
-		strings.TrimSpace(c.PrivateKeyEnv),
+		c.PrivateKeyEnv,
 		c.BlockHeight,
 		createdAt,
 	)

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -303,6 +303,25 @@ func TestValidateGatewaySettingsRequiresRotationModels(t *testing.T) {
 	require.Contains(t, err.Error(), "duplicate model_id")
 }
 
+func TestGatewaySettingsWithTuningDefaultsTrimsPrivateKeyEnv(t *testing.T) {
+	settings := GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       " Qwen/Test ",
+				PrivateKeyEnv: "  KIMI_KEY  ",
+			}},
+		},
+	}.WithTuningDefaults()
+
+	require.Equal(t, "Qwen/Test", settings.EscrowRotation.Models[0].ModelID)
+	require.Equal(t, "KIMI_KEY", settings.EscrowRotation.Models[0].PrivateKeyEnv)
+}
+
 func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -358,8 +358,8 @@ func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testi
 	})
 
 	g := &Gateway{store: store}
-	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
-	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.prepareBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.prepareBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 0, settleAttempts)
@@ -423,8 +423,8 @@ func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.
 	})
 
 	g := &Gateway{store: store}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 11}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 0, settleAttempts)
@@ -493,7 +493,7 @@ func TestEscrowRotationSkipsCreateWhenModelAbsentFromNetwork(t *testing.T) {
 	)
 
 	g := &Gateway{store: store, capacity: capacity, rotationBreakers: make(map[string]*rotationBreaker)}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 0, createAttempts, "must not create escrow for a model absent from the network")
 	require.Equal(t, []string{"12"}, settled, "stranded temp escrow must still be settled")
@@ -555,7 +555,7 @@ func TestEscrowRotationCreatesWhenModelPresentInNetwork(t *testing.T) {
 	)
 
 	g := &Gateway{store: store, capacity: capacity, rotationBreakers: make(map[string]*rotationBreaker)}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 2, createAttempts, "must create escrows for a model the network serves")
 }
@@ -610,7 +610,7 @@ func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 	})
 
 	g := &Gateway{store: store}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 2, createAttempts)
 	require.Equal(t, []string{"12"}, settled)
@@ -675,7 +675,7 @@ func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenSettlementD
 	rt := &devshardRuntime{id: "12"}
 	rt.active.Store(true)
 	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}}
-	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.prepareBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 0, settleAttempts)
@@ -743,7 +743,7 @@ func TestEscrowRotationFinishDeactivatesTempWithoutSettlementWhenSettlementDisab
 	rt := &devshardRuntime{id: "12"}
 	rt.active.Store(true)
 	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 0, settleAttempts)
@@ -821,7 +821,7 @@ func TestEscrowRotationPrepareRotatesModelsIndependently(t *testing.T) {
 	})
 
 	g := &Gateway{store: store}
-	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.prepareBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, []string{"13"}, settled)
 	state, ok, err := store.LoadState()
@@ -895,7 +895,7 @@ func TestEscrowRotationUsesEpochSwitchHeightDuringPoC(t *testing.T) {
 		epochSwitchBlockHeight: 600,
 	})
 
-	g.rotateEscrowsOnce()
+	g.rotateEscrowsOnce(context.Background())
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 1, settleAttempts)

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -47,8 +47,24 @@ type HostStatsJSON struct {
 	Missed               uint32 `json:"missed"`
 	Invalid              uint32 `json:"invalid"`
 	Cost                 uint64 `json:"cost"`
-	RequiredValidations  uint32 `json:"required_validations"`
-	CompletedValidations uint32 `json:"completed_validations"`
+	RequiredValidations  uint32 `json:"required_validations,omitempty"`
+	CompletedValidations uint32 `json:"completed_validations,omitempty"`
+}
+
+func hostStatsJSONFromDomain(slot uint32, hs *types.HostStats) HostStatsJSON {
+	entry := HostStatsJSON{
+		SlotID:  slot,
+		Missed:  hs.Missed,
+		Invalid: hs.Invalid,
+		Cost:    hs.Cost,
+	}
+	if hs.RequiredValidations != 0 {
+		entry.RequiredValidations = hs.RequiredValidations
+	}
+	if hs.CompletedValidations != 0 {
+		entry.CompletedValidations = hs.CompletedValidations
+	}
+	return entry
 }
 
 type SlotSignatureJSON struct {
@@ -667,11 +683,7 @@ func buildSettlementJSON(p *state.SettlementPayload) (SettlementJSON, error) {
 
 	stats := make([]HostStatsJSON, 0, len(p.HostStats))
 	for slot, hs := range p.HostStats {
-		stats = append(stats, HostStatsJSON{
-			SlotID: slot, Missed: hs.Missed, Invalid: hs.Invalid,
-			Cost: hs.Cost, RequiredValidations: hs.RequiredValidations,
-			CompletedValidations: hs.CompletedValidations,
-		})
+		stats = append(stats, hostStatsJSONFromDomain(slot, hs))
 	}
 
 	sigs := make([]SlotSignatureJSON, 0, len(p.Signatures))

--- a/devshard/cmd/devshardctl/marshal_test.go
+++ b/devshard/cmd/devshardctl/marshal_test.go
@@ -135,3 +135,30 @@ func TestMarshalSettlement_KotlinReserialize(t *testing.T) {
 	require.Equal(t, expectedRoot, stateRoot,
 		"state_root mismatch after Kotlin-style re-serialization")
 }
+
+func TestMarshalSettlement_OmitsZeroValidationFields(t *testing.T) {
+	hostStats := map[uint32]*types.HostStats{
+		0: {Cost: 150},
+		1: {Cost: 100, Missed: 1},
+	}
+	restHash, err := state.ComputeRestHash(9850, map[uint64]*types.InferenceRecord{
+		1: {Status: types.StatusFinished, ExecutorSlot: 0, PromptHash: []byte("abcdefghijklmnopqrstuvwxyz012345")},
+	}, nil)
+	require.NoError(t, err)
+
+	payload := &state.SettlementPayload{
+		EscrowID: "42", Version: "dev", Nonce: 3, Fees: 10,
+		RestHash: restHash, HostStats: hostStats,
+		Signatures: map[uint32][]byte{0: []byte("sig0")},
+	}
+
+	data, err := marshalSettlement(payload)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "required_validations")
+	require.NotContains(t, string(data), "completed_validations")
+
+	var parsed SettlementJSON
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	require.Equal(t, uint32(0), parsed.HostStats[0].RequiredValidations)
+	require.Equal(t, uint32(0), parsed.HostStats[0].CompletedValidations)
+}

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -842,6 +842,21 @@ func (p *Proxy) handleCollectSignatures(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, resp)
 }
 
+func hostStatsDebugEntry(hs *types.HostStats) map[string]any {
+	entry := map[string]any{
+		"missed":  hs.Missed,
+		"invalid": hs.Invalid,
+		"cost":    hs.Cost,
+	}
+	if hs.RequiredValidations != 0 {
+		entry["required_validations"] = hs.RequiredValidations
+	}
+	if hs.CompletedValidations != 0 {
+		entry["completed_validations"] = hs.CompletedValidations
+	}
+	return entry
+}
+
 func (p *Proxy) handleState(w http.ResponseWriter, r *http.Request) {
 	st := p.sm.SnapshotState()
 
@@ -909,13 +924,7 @@ func (p *Proxy) handleState(w http.ResponseWriter, r *http.Request) {
 
 	hostStats := make(map[string]any, len(st.HostStats))
 	for slot, hs := range st.HostStats {
-		hostStats[fmt.Sprintf("%d", slot)] = map[string]any{
-			"missed":                hs.Missed,
-			"invalid":               hs.Invalid,
-			"cost":                  hs.Cost,
-			"required_validations":  hs.RequiredValidations,
-			"completed_validations": hs.CompletedValidations,
-		}
+		hostStats[fmt.Sprintf("%d", slot)] = hostStatsDebugEntry(hs)
 	}
 
 	revealedSeeds := make(map[string]int64, len(st.RevealedSeeds))

--- a/inference-chain/x/inference/module/commands.go
+++ b/inference-chain/x/inference/module/commands.go
@@ -121,8 +121,8 @@ type settlementHostStatsJSON struct {
 	Missed               uint32 `json:"missed"`
 	Invalid              uint32 `json:"invalid"`
 	Cost                 uint64 `json:"cost"`
-	RequiredValidations  uint32 `json:"required_validations"`
-	CompletedValidations uint32 `json:"completed_validations"`
+	RequiredValidations  uint32 `json:"required_validations,omitempty"`
+	CompletedValidations uint32 `json:"completed_validations,omitempty"`
 }
 
 type slotSignatureJSON struct {

--- a/testermint/src/main/kotlin/data/devshard.kt
+++ b/testermint/src/main/kotlin/data/devshard.kt
@@ -73,9 +73,9 @@ data class DevshardHostStatsEntry(
     val invalid: Int,
     val cost: Long,
     @SerializedName("required_validations")
-    val requiredValidations: Int,
+    val requiredValidations: Int? = null,
     @SerializedName("completed_validations")
-    val completedValidations: Int
+    val completedValidations: Int? = null,
 )
 
 data class DevshardSlotSignatureEntry(

--- a/testermint/src/test/kotlin/DevshardStandaloneTests.kt
+++ b/testermint/src/test/kotlin/DevshardStandaloneTests.kt
@@ -363,7 +363,7 @@ class DevshardStandaloneTests : TestermintTest() {
                 assertThat(result.parsed.version).isEqualTo(standaloneTestVersionName)
                 assertThat(result.parsed.hostStats).isNotEmpty()
                 assertThat(result.parsed.signatures).isNotEmpty()
-                assertThat(result.parsed.hostStats.sumOf { it.completedValidations }).isGreaterThan(0)
+                assertThat(result.parsed.hostStats.sumOf { it.completedValidations ?: 0 }).isGreaterThan(0)
 
                 val settleResp = genesis.settleDevshardEscrow(result.rawJson, from = session.keyName)
                 assertThat(settleResp.code)

--- a/testermint/src/test/kotlin/DevshardTestSupport.kt
+++ b/testermint/src/test/kotlin/DevshardTestSupport.kt
@@ -159,7 +159,7 @@ fun LocalInferencePair.assertDevshardSettlement(
     assertThat(result.parsed.nonce).isGreaterThanOrEqualTo(activeNonces)
     assertThat(result.parsed.fees).isEqualTo(expectedFees)
 
-    val totalCompletedValidations = result.parsed.hostStats.sumOf { it.completedValidations }
+    val totalCompletedValidations = result.parsed.hostStats.sumOf { it.completedValidations ?: 0 }
     if (requireCompletedValidations) {
         assertThat(totalCompletedValidations).isGreaterThan(0)
     }

--- a/testermint/src/test/kotlin/DevshardTests.kt
+++ b/testermint/src/test/kotlin/DevshardTests.kt
@@ -198,7 +198,7 @@ class DevshardTests : TestermintTest() {
                     .isEqualTo(session.escrowId.toString())
                 assertThat(result.parsed.hostStats).isNotEmpty()
                 assertThat(result.parsed.signatures).isNotEmpty()
-                assertThat(result.parsed.hostStats.sumOf { it.completedValidations }).isGreaterThan(0)
+                assertThat(result.parsed.hostStats.sumOf { it.completedValidations ?: 0 }).isGreaterThan(0)
 
                 val settleResp = genesis.settleDevshardEscrow(result.rawJson, from = session.keyName)
                 assertThat(settleResp.code)


### PR DESCRIPTION
Small follow-up to escrow-rotation recovery on `dl/gateway-v2`.

## Commits

- **use structured HTTP status for chain tx 404 detection** — replace substring `isNotFoundError` with typed `chainHTTPError` + status code check.
- **make escrow DB retries respect context cancellation** — `withDBRetry` exits promptly on `ctx.Done()` instead of sleeping through shutdown.
- **store escrow commitment CreatedAt as time.Time** — drop string parse/format in the store and rotator.
- **centralize escrow rotation PrivateKeyEnv trimming** — one helper instead of duplicated trim logic.
- **omit zero validation fields from settlement JSON** — `omitempty` for unset validation rate; drop incorrect test expectation that `0` disables validation.

## Test plan

- [ ] `go test ./cmd/devshardctl -run 'TestRESTChainTxClient_GetTxEscrowID|TestReconcileCommitments|TestCreateRotationEscrow'`
- [ ] `DevshardTests.devshard gateway auto-seals inferences after grace timeout`

Made with [Cursor](https://cursor.com)