### PR TITLE
fix(mlnode): scheduler-heartbeat liveness for vLLM runner + damped proxy health probe

### DIFF
--- a/mlnode/packages/api/src/api/inference/vllm/runner.py
+++ b/mlnode/packages/api/src/api/inference/vllm/runner.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import time
 import requests
@@ -22,6 +23,87 @@ WAIT_FOR_SERVER_TIMEOUT = 1200
 WAIT_FOR_SERVER_CHECK_INTERVAL = 3
 
 logger = create_logger(__name__)
+
+HANG_CONSECUTIVE = 3
+
+# (metric suffix, cross-series reduce). Sum/max across ALL series: /metrics
+# can briefly expose several registries mid-restart.
+_HEARTBEAT_SERIES = (
+    ("iteration_tokens_total_count", sum),
+    ("num_requests_running", max),
+    ("num_requests_waiting", max),
+)
+
+
+def _int_env(name: str, default: int) -> int:
+    """os.environ[name] as int; unset/empty -> default, garbage -> default + warning."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer -- using %d", name, raw, default)
+        return default
+
+
+def _scrape_heartbeat(host: str, port: int):
+    """(iters, running, waiting) floats from /metrics; None per unreadable value.
+    Raises requests.ConnectionError when the instance is unreachable (dead)."""
+    try:
+        txt = requests.get(f"http://{host}:{port}/metrics", timeout=3).text
+    except requests.exceptions.ConnectTimeout:
+        # Saturation, not death: the caller's grace window decides.
+        return None, None, None
+    except requests.ConnectionError:
+        raise
+    except Exception:
+        return None, None, None
+    values = []
+    for name, reduce_fn in _HEARTBEAT_SERIES:
+        try:
+            series = re.findall(rf"(?m)^vllm:{name}\S*\s+([0-9eE.+-]+)", txt)
+            values.append(reduce_fn(float(x) for x in series) if series else None)
+        except Exception:
+            values.append(None)
+    return tuple(values)
+
+
+def _heartbeat_verdict(port: int, st: dict, iters, running, waiting, now: float, grace: int) -> bool:
+    """Advance one port's heartbeat state (mutates st); True = instance alive.
+    Branch order is semantic -- reorder only with the unit tests in hand."""
+    read_ok = iters is not None or running is not None or waiting is not None
+    has_work = (running is not None and running > 0) or (waiting is not None and waiting > 0)
+    # Fresh baseline on either: legitimate idle (readable scrape, no work) or a
+    # stepping engine -- ANY counter change counts, including the reset after an
+    # engine restart (a ">" test would false-HUNG on the stale high baseline).
+    # A blind scrape (all None) is neither: refreshing on it would silently
+    # disable hang detection.
+    if (read_ok and not has_work) or (
+        iters is not None and (st["iter"] is None or iters != st["iter"])
+    ):
+        st["ts"] = now
+        st["iter"] = iters
+        st["hung"] = 0
+        return True
+    if iters is None:
+        # Counter unreadable: alive only within grace.
+        return now - st["ts"] <= grace
+    if now - st["ts"] > grace:
+        # Frozen with work past grace: require consecutive verdicts so one
+        # confused scrape cannot start the restart escalation.
+        st["hung"] += 1
+        if st["hung"] >= HANG_CONSECUTIVE:
+            logger.error(
+                "vLLM instance on port %s: scheduler heartbeat frozen >%ss "
+                "over %d consecutive checks with running=%s waiting=%s -- "
+                "reporting unhealthy for restart",
+                port, grace, st["hung"], running, waiting,
+            )
+            return False
+        return True
+    st["hung"] = 0
+    return True
 
 
 class IVLLMRunner(ITrackableTask):
@@ -63,6 +145,7 @@ class VLLMRunner(IVLLMRunner):
         self.dtype = dtype
         self.additional_args = additional_args or []
         self.processes: List[subprocess.Popen] = []
+        self._hb = {}  # per-port heartbeat state; outlives engine restarts
 
     def _get_arg_value(self, name: str, default: int = 1) -> int:
         if name in self.additional_args:
@@ -224,15 +307,28 @@ class VLLMRunner(IVLLMRunner):
     def is_available(self) -> bool:
         if not self.is_running():
             return False
-        try:
-            # Check if any backend is available
-            for port in range(self.VLLM_PORT + 1, self.VLLM_PORT + len(self.processes) + 1):
-                resp = requests.get(f"http://{self.VLLM_HOST}:{port}/health", timeout=2)
-                if resp.status_code == 200:
-                    return True
-            return False
-        except (requests.ConnectionError, requests.Timeout):
-            return False
+        # Scheduler-heartbeat liveness. vLLM /health returns 200 even when the
+        # scheduler is deadlocked (check_health only reads the `errored` flag)
+        # and misses its deadline while merely busy. The iteration counter
+        # advances on every engine step and freezes only on a real stall; the
+        # grace window also absorbs the counter's observed pre-stall flatline.
+        grace = _int_env("MLNODE_HANG_GRACE_SEC", 120)
+        now = time.time()
+        healthy = True
+        # Check every instance: a hang must not hide behind a healthy sibling.
+        for port in range(self.VLLM_PORT + 1, self.VLLM_PORT + len(self.processes) + 1):
+            try:
+                iters, running, waiting = _scrape_heartbeat(self.VLLM_HOST, port)
+            except requests.ConnectionError:
+                # Refused/unreachable -> this instance is dead.
+                return False
+            st = self._hb.setdefault(port, {"ts": now, "iter": iters, "hung": 0})
+            if grace <= 0:
+                # Detection disabled: only process death / refusal mark unhealthy.
+                continue
+            ok = _heartbeat_verdict(port, st, iters, running, waiting, now, grace)
+            healthy = healthy and ok
+        return healthy
 
     def get_error_if_exist(self) -> Optional[str]:
         for p in self.processes:

--- a/mlnode/packages/api/src/api/proxy.py
+++ b/mlnode/packages/api/src/api/proxy.py
@@ -22,6 +22,9 @@ LIMITS = httpx.Limits(
 
 vllm_backend_ports: List[int] = []
 vllm_healthy: Dict[int, bool] = {}
+# /health prober damping -- contract in _apply_health_damping.
+HEALTH_FAIL_STREAK: int = 3
+vllm_health_fail_streak: Dict[int, int] = {}
 vllm_counts: Dict[int, int] = {}
 poc_status_by_port: Dict[int, str] = {}  # PoC status: "IDLE", "GENERATING", "STOPPED", or ""
 pow_generate_rr_index: int = 0
@@ -189,6 +192,19 @@ async def call_backend(port: int, method: str, path: str, json_body: dict = None
         raise ValueError(f"Unsupported method: {method}")
 
 
+def _apply_health_damping(port: int, probe_ok: bool) -> bool:
+    """Damped health verdict: unhealthy only after HEALTH_FAIL_STREAK
+    consecutive probe failures, instant recovery on success; a backend that
+    has never succeeded (startup) stays down regardless of streak."""
+    if probe_ok:
+        vllm_health_fail_streak[port] = 0
+        return True
+    vllm_health_fail_streak[port] = vllm_health_fail_streak.get(port, 0) + 1
+    if vllm_healthy.get(port) and vllm_health_fail_streak[port] < HEALTH_FAIL_STREAK:
+        return True
+    return False
+
+
 async def _health_check_vllm(interval: float = 2.0):
     """Health check for vLLM backends and manage compatibility server."""
     logger.info("Health check loop started, checking every %s seconds", interval)
@@ -205,11 +221,13 @@ async def _health_check_vllm(interval: float = 2.0):
                 if vllm_client is None:
                     logger.warning(f"Health check skipped for port {p}: vllm_client is None")
                     continue
-                r = await vllm_client.get(f"http://{VLLM_HOST}:{p}/health", timeout=2)
+                r = await vllm_client.get(f"http://{VLLM_HOST}:{p}/health", timeout=10)
                 ok = r.status_code == 200
                 logger.debug("Health check for port %d: status=%d, ok=%s", p, r.status_code, ok)
             except Exception as e:
                 logger.debug("Health check for port %d failed: %s", p, e)
+
+            ok = _apply_health_damping(p, ok)
 
             prev = vllm_healthy.get(p)
             if prev != ok:

--- a/mlnode/packages/api/tests/unit/test_proxy.py
+++ b/mlnode/packages/api/tests/unit/test_proxy.py
@@ -443,3 +443,60 @@ async def test_resource_cleanup_verification():
     # Verify backend counts reset
     for port in [5001, 5002]:
         assert proxy_module.vllm_counts[port] == 0 
+
+# ---------------------------------------------------------------------------
+# Health-probe damping (_apply_health_damping)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def clean_health_state():
+    """Reset the module-level health dicts around each damping test."""
+    saved_healthy = dict(proxy_module.vllm_healthy)
+    saved_streak = dict(proxy_module.vllm_health_fail_streak)
+    proxy_module.vllm_healthy.clear()
+    proxy_module.vllm_health_fail_streak.clear()
+    yield
+    proxy_module.vllm_healthy.clear()
+    proxy_module.vllm_healthy.update(saved_healthy)
+    proxy_module.vllm_health_fail_streak.clear()
+    proxy_module.vllm_health_fail_streak.update(saved_streak)
+
+
+def _drive(port, probes, start_healthy):
+    """Feed a probe sequence through the damping and record verdicts, updating
+    vllm_healthy the same way _health_check_vllm does."""
+    proxy_module.vllm_healthy[port] = start_healthy
+    out = []
+    for probe in probes:
+        ok = proxy_module._apply_health_damping(port, probe)
+        proxy_module.vllm_healthy[port] = ok
+        out.append(ok)
+    return out
+
+
+def test_damping_startup_stays_down_until_first_success(clean_health_state):
+    assert _drive(5001, [False, False, True], start_healthy=False) == [False, False, True]
+
+
+def test_damping_two_blips_still_healthy(clean_health_state):
+    """Missed /health deadlines on a busy-but-alive engine (up to
+    HEALTH_FAIL_STREAK-1 in a row) must not stop the compatibility server."""
+    assert _drive(5001, [True, False, False, True], start_healthy=True) == [True, True, True, True]
+
+
+def test_damping_three_consecutive_failures_is_down(clean_health_state):
+    assert _drive(5001, [True, False, False, False], start_healthy=True) == [True, True, True, False]
+
+
+def test_damping_recovers_instantly_on_success(clean_health_state):
+    assert _drive(5001, [False, False, False, True], start_healthy=True) == [True, True, False, True]
+
+
+def test_damping_ports_are_independent(clean_health_state):
+    proxy_module.vllm_healthy.update({5001: True, 5002: True})
+    # 5001 fails 3x -> down; 5002 keeps succeeding -> up
+    for _ in range(3):
+        proxy_module.vllm_healthy[5001] = proxy_module._apply_health_damping(5001, False)
+        proxy_module.vllm_healthy[5002] = proxy_module._apply_health_damping(5002, True)
+    assert proxy_module.vllm_healthy[5001] is False
+    assert proxy_module.vllm_healthy[5002] is True

--- a/mlnode/packages/api/tests/unit/test_runner_heartbeat.py
+++ b/mlnode/packages/api/tests/unit/test_runner_heartbeat.py
@@ -1,0 +1,275 @@
+"""Unit tests for VLLMRunner.is_available() scheduler-heartbeat liveness.
+
+The check replaces vLLM's /health probe (wrong in both directions: false-positive
+under load, false-negative on a silent deadlock) with a read of the Prometheus
+counter vllm:iteration_tokens_total_count, which advances on every engine step
+and freezes only when the engine loop stalls.
+
+These tests drive is_available() over a controlled clock and mocked /metrics
+responses, covering the steady state, the hardened race conditions
+(counter-reset on engine restart, multi-process /metrics, blind scrapes,
+ConnectTimeout-vs-refused classification), multi-instance aggregation, and the
+config edge cases (grace disabled, malformed env).
+"""
+import re
+
+import pytest
+import requests as real_requests
+
+from api.inference.vllm import runner as runner_mod
+from api.inference.vllm.runner import VLLMRunner
+
+
+class _FakeResp:
+    def __init__(self, text):
+        self.text = text
+
+
+class _Clock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+def _metrics(iters=None, running=None, waiting=None, series=1):
+    """Render a minimal /metrics body. `series` repeats the counter/gauge lines
+    to emulate more than one engine registry exposed on the same port."""
+    lines = []
+    for k in range(series):
+        if iters is not None:
+            lines.append(f'vllm:iteration_tokens_total_count{{engine="{k}"}} {iters}')
+        if running is not None:
+            lines.append(f'vllm:num_requests_running{{engine="{k}"}} {running}')
+        if waiting is not None:
+            lines.append(f'vllm:num_requests_waiting{{engine="{k}"}} {waiting}')
+    return "\n".join(lines) + "\n"
+
+
+def _make_runner(monkeypatch, n_instances=1):
+    """A VLLMRunner with __init__ bypassed, `n_instances` live processes, a
+    controllable clock, and a per-port mockable /metrics endpoint."""
+    r = object.__new__(VLLMRunner)
+    r.VLLM_HOST = "127.0.0.1"
+    r.VLLM_PORT = 5000
+    r._hb = {}  # __init__ is bypassed; mirror its heartbeat-state init
+    proc = type("P", (), {"poll": staticmethod(lambda: None)})()
+    r.processes = [proc] * n_instances
+
+    clock = _Clock()
+    monkeypatch.setattr(runner_mod.time, "time", clock)
+
+    # per-port response/exception; "*" is the default for unlisted ports
+    state = {"*": {"resp": _metrics(iters=100, running=40, waiting=0), "exc": None}}
+
+    def fake_get(url, timeout=None):
+        port = int(url.split(":")[-1].split("/")[0])
+        s = state.get(port, state["*"])
+        if s["exc"] is not None:
+            raise s["exc"]
+        return _FakeResp(s["resp"])
+
+    monkeypatch.setattr(runner_mod.requests, "get", fake_get)
+
+    r._clock = clock
+    r._state = state
+    return r
+
+
+@pytest.fixture
+def runner(monkeypatch):
+    return _make_runner(monkeypatch, n_instances=1)
+
+
+def _serve(runner, port="*", **kw):
+    runner._state[port] = {"resp": _metrics(**kw), "exc": None}
+
+
+def _fail(runner, exc, port="*"):
+    runner._state[port] = {"resp": "", "exc": exc}
+
+
+def test_process_dead_is_unavailable(runner):
+    runner.processes = []  # is_running() -> False
+    assert runner.is_available() is False
+
+
+def test_advancing_counter_is_alive(runner):
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True  # baseline
+    runner._clock.advance(2)
+    _serve(runner, iters=185, running=40, waiting=0)
+    assert runner.is_available() is True
+
+
+def test_counter_regression_rebaselines(runner):
+    """Engine subprocess restarts and its counter resets to ~0 while work is
+    present. A '>' test would false-HUNG; '!=' must re-baseline and stay alive."""
+    _serve(runner, iters=90000, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(2)
+    _serve(runner, iters=5, running=40, waiting=0)  # fresh engine, counter reset
+    assert runner.is_available() is True
+    assert runner._hb[5001]["iter"] == 5  # re-baselined to the new low value
+
+
+def test_multiprocess_metrics_sum_advances(runner):
+    """Two registries on one port: the summed counter advances while either
+    engine steps, so the node is not read as frozen."""
+    _serve(runner, iters=100, running=40, waiting=0, series=2)  # sum=200
+    assert runner.is_available() is True
+    assert runner._hb[5001]["iter"] == 200
+    runner._clock.advance(2)
+    _serve(runner, iters=150, running=40, waiting=0, series=2)  # sum=300
+    assert runner.is_available() is True
+
+
+def test_idle_engine_is_alive(runner):
+    """No work (running==0 and waiting==0) with a frozen counter is a legitimate
+    idle-wait, not a hang."""
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(500)  # way past grace
+    _serve(runner, iters=100, running=0, waiting=0)  # counter frozen but no work
+    assert runner.is_available() is True
+
+
+def test_real_hang_reports_unhealthy_after_consecutive(runner, monkeypatch):
+    """Work present, counter frozen past grace: unhealthy only after
+    HANG_CONSECUTIVE (3) verdicts, so a single confused scrape cannot escalate."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True  # baseline @ t=1000
+    runner._clock.advance(200)  # past 120s grace, counter still 100, work present
+    assert runner.is_available() is True   # hung count 1/3
+    runner._clock.advance(2)
+    assert runner.is_available() is True   # hung count 2/3
+    runner._clock.advance(2)
+    assert runner.is_available() is False  # hung count 3/3 -> unhealthy
+
+
+def test_grace_recovers_before_escalation(runner, monkeypatch):
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(200)
+    assert runner.is_available() is True   # 1/3
+    runner._clock.advance(2)
+    _serve(runner, iters=300, running=40, waiting=0)  # engine steps again
+    assert runner.is_available() is True   # re-baselined, hung count reset
+    assert runner._hb[5001]["hung"] == 0
+
+
+def test_partial_scrape_missing_counter_uses_grace(runner, monkeypatch):
+    """Counter series absent but gauges present (work ongoing): alive within
+    grace, dead once grace is exceeded with no counter to prove liveness."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(60)
+    _serve(runner, iters=None, running=40, waiting=0)  # counter gone
+    assert runner.is_available() is True   # within grace (60s <= 120s)
+    runner._clock.advance(100)             # now 160s since baseline
+    _serve(runner, iters=None, running=40, waiting=0)
+    assert runner.is_available() is False
+
+
+def test_full_scrape_failure_is_not_masked_as_idle(runner, monkeypatch):
+    """Regression guard for the idle-shortcut hole: a total /metrics failure
+    (every value None) must NOT refresh the baseline and report healthy, which
+    would silently disable hang detection. It must fall through to grace."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True   # baseline @ t=1000
+    base_ts = runner._hb[5001]["ts"]
+    runner._clock.advance(30)
+    _serve(runner, iters=None, running=None, waiting=None)  # blind scrape
+    assert runner.is_available() is True   # within grace
+    assert runner._hb[5001]["ts"] == base_ts  # baseline NOT refreshed blindly
+    runner._clock.advance(200)             # 230s since baseline, still blind
+    _serve(runner, iters=None, running=None, waiting=None)
+    assert runner.is_available() is False  # grace exceeded -> unhealthy
+
+
+def test_connection_refused_is_dead(runner):
+    _fail(runner, real_requests.ConnectionError())
+    assert runner.is_available() is False
+
+
+def test_connect_timeout_uses_grace_not_dead(runner, monkeypatch):
+    """ConnectTimeout subclasses ConnectionError in requests, but a full SYN
+    backlog on a saturated server is not death: it must take the grace path,
+    not the immediate-dead path."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True   # baseline
+    runner._clock.advance(2)
+    _fail(runner, real_requests.exceptions.ConnectTimeout())
+    assert runner.is_available() is True   # within grace -> alive
+    runner._clock.advance(200)             # past grace, still timing out
+    assert runner.is_available() is False  # grace exceeded -> unhealthy
+
+
+def test_hang_detection_disabled_when_grace_zero(runner, monkeypatch):
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "0")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(100000)  # arbitrarily long freeze with work present
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True  # detection off
+
+
+def test_grace_zero_tolerates_blind_scrapes(runner, monkeypatch):
+    """grace=0 must disable ALL hang escalation, including the blind-scrape
+    path: a slow /metrics must not mark the node dead when detection is off."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "0")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(500)
+    _fail(runner, TimeoutError())  # scrape fails entirely
+    assert runner.is_available() is True   # still alive: detection disabled
+    # but a refused connection still means dead even with detection off
+    _fail(runner, real_requests.ConnectionError())
+    assert runner.is_available() is False
+
+
+def test_malformed_grace_env_does_not_raise(runner, monkeypatch):
+    """An empty or garbage MLNODE_HANG_GRACE_SEC must not raise out of
+    is_available (a fleet-wide env templating mistake would otherwise turn
+    every health poll into an exception -> watcher kill-loop)."""
+    for bad in ("", "  ", "abc", "12.5"):
+        monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", bad)
+        _serve(runner, iters=100, running=40, waiting=0)
+        assert runner.is_available() is True  # falls back to default 120
+
+
+def test_multi_instance_hang_in_one_instance_reported(monkeypatch):
+    """Instance 3 freezes with work while instances 1/2/4 keep stepping: the
+    node must go unhealthy after grace + consecutive verdicts."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    r = _make_runner(monkeypatch, n_instances=4)
+    _serve(r, iters=100, running=40, waiting=0)          # default: advancing...
+    _serve(r, port=5003, iters=777, running=20, waiting=0)  # ...incl. 5003
+    assert r.is_available() is True  # baseline for all ports
+
+    step = 100
+    for tick in range(1, 4):
+        r._clock.advance(200 if tick == 1 else 2)
+        step += 85
+        _serve(r, iters=step, running=40, waiting=0)     # others advance
+        _serve(r, port=5003, iters=777, running=20, waiting=0)  # 5003 frozen
+        expected = tick < 3  # unhealthy on the 3rd consecutive frozen verdict
+        assert r.is_available() is expected, f"tick {tick}"
+
+
+def test_multi_instance_refused_port_is_dead(monkeypatch):
+    """A refused connection on ANY instance means that engine's API server is
+    gone: the node reports dead even if other instances are healthy."""
+    r = _make_runner(monkeypatch, n_instances=4)
+    _serve(r, iters=100, running=40, waiting=0)
+    _fail(r, real_requests.ConnectionError(), port=5002)
+    assert r.is_available() is False


### PR DESCRIPTION
## Problem
vLLM `/health` is the wrong liveness signal in both directions, and mlnode relies on it twice:

1. **Real hang, `/health` 200.** A TP worker deadlocks on the shm collective: scheduler frozen, zero throughput — but `AsyncLLM.check_health` only reads the `errored` flag. The node silently serves nothing until someone notices (5–22 min in production).
2. **Busy engine, `/health` timeout.** A saturated engine misses the 2 s deadline: `runner.is_available()` reports dead → a healthy node gets restarted (observed 8+/day); the proxy prober flips on a single miss → the compatibility server stops, dropping in-flight relays (23 flaps/2.3 h).

## Fix
- **`runner.py`**: liveness = `vllm:iteration_tokens_total_count` heartbeat — advances on every engine step, freezes only on a stall. Per-instance; re-baselines after engine restarts; aggregates multi-registry scrapes; a failed scrape can't pass for idle; `ConnectTimeout` = saturation (grace path), refused = dead. `MLNODE_HANG_GRACE_SEC` (default 120, `0` disables).
- **`proxy.py`**: prober timeout 2 → 10 s; unhealthy only after 3 consecutive failures, instant recovery.

## Validation
21 unit tests. 4×B300 Kimi-K2.6 fleet, several days: false restarts → **0** (incl. a full hour at max_num_seqs saturation), real stalls detected in ~2 min and self-healed via the existing restart path, proxy flaps → 0. Detection layer only — the underlying vLLM stall is addressed in gonka-ai/vllm#58.
