### PR TITLE
Bound gateway runtime-build fan-out to avoid LCD 429 crash-loop

### DIFF
--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -305,8 +305,50 @@ func buildRuntime(cfg RuntimeConfig, chainREST, defaultModel string, perf *PerfT
 	return rt, nil
 }
 
+// defaultMaxConcurrentRuntimeBuilds caps parallel runtime builds at startup: a
+// small keep-alive pool against the shared node LCD, big enough to hide startup
+// latency, small enough to avoid a 429 storm. Overridable per deployment.
+const defaultMaxConcurrentRuntimeBuilds = 16
+
+// resolveMaxConcurrentRuntimeBuilds is the startup build fan-out limit,
+// overridable via DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS (must be >= 1).
+func resolveMaxConcurrentRuntimeBuilds() int {
+	raw := strings.TrimSpace(os.Getenv("DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS"))
+	if raw == "" {
+		return defaultMaxConcurrentRuntimeBuilds
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		log.Printf("invalid DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS=%q (must be >= 1), using default %d", raw, defaultMaxConcurrentRuntimeBuilds)
+		return defaultMaxConcurrentRuntimeBuilds
+	}
+	return n
+}
+
+// buildRuntimeBridgeClient returns the HTTP client for chain-LCD queries, sized
+// so the bounded build fan-out reuses keep-alive connections instead of churning
+// them (the default MaxIdleConnsPerHost is only 2).
+func buildRuntimeBridgeClient(limit int) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = limit
+	transport.MaxIdleConnsPerHost = limit
+	return &http.Client{Timeout: 10 * time.Second, Transport: transport}
+}
+
+var (
+	runtimeBridgeClientOnce sync.Once
+	runtimeBridgeClient     *http.Client
+)
+
+func sharedRuntimeBridgeClient() *http.Client {
+	runtimeBridgeClientOnce.Do(func() {
+		runtimeBridgeClient = buildRuntimeBridgeClient(resolveMaxConcurrentRuntimeBuilds())
+	})
+	return runtimeBridgeClient
+}
+
 func newRESTBridgeForProtocol(chainREST string, pv types.ProtocolVersion) *bridge.RESTBridge {
-	return bridge.NewRESTBridge(chainREST)
+	return bridge.NewRESTBridge(chainREST, bridge.WithHTTPClient(sharedRuntimeBridgeClient()))
 }
 
 func gatewayHostRoutePrefix(override string) string {

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -391,8 +391,13 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 	}
 	t0 := time.Now()
 	ch := make(chan buildResult, len(allCfgs))
+	// Cap concurrent builders (see maxConcurrentRuntimeBuilds); results are still
+	// collected per-index below, so ordering and error handling are unchanged.
+	buildSem := make(chan struct{}, resolveMaxConcurrentRuntimeBuilds())
 	for i, cfg := range allCfgs {
 		go func(idx int, cfg RuntimeConfig) {
+			buildSem <- struct{}{}
+			defer func() { <-buildSem }()
 			rt, err := gatewayRuntimeBuilder(cfg, gatewayState.Settings.ChainREST, gatewayState.Settings.DefaultModel, perf)
 			ch <- buildResult{idx, rt, err}
 		}(i, cfg)

--- a/devshard/cmd/devshardctl/main_test.go
+++ b/devshard/cmd/devshardctl/main_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -166,6 +169,166 @@ func TestBuildGatewayRuntimesPreservesActiveOnOtherErrors(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.True(t, reloaded.Devshards[0].Active)
+}
+
+// measurePeakRuntimeBuildConcurrency runs buildGatewayRuntimes over n active
+// devshards with a fake builder that records the peak number of simultaneous
+// builder invocations.
+func measurePeakRuntimeBuildConcurrency(t *testing.T, n int) int64 {
+	t.Helper()
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, activeDevshardStates(n)))
+
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	var inFlight, peakInFlight atomic.Int64
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, chainREST, defaultModel string, perf *PerfTracker) (*devshardRuntime, error) {
+		running := inFlight.Add(1)
+		for {
+			peak := peakInFlight.Load()
+			if running <= peak || peakInFlight.CompareAndSwap(peak, running) {
+				break
+			}
+		}
+		// Hold the slot briefly so overlapping builders show up in the
+		// high-water mark; this occupies the resource, it does not wait on
+		// async work.
+		time.Sleep(25 * time.Millisecond)
+		inFlight.Add(-1)
+		return &devshardRuntime{id: cfg.ID, model: defaultModel}, nil
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
+
+	runtimes, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+	require.NoError(t, err)
+	require.Len(t, runtimes, n)
+	return peakInFlight.Load()
+}
+
+func TestBuildGatewayRuntimesBoundsBuilderConcurrency(t *testing.T) {
+	// An unbounded fan-out floods the chain LCD (429) and crash-loops startup;
+	// builder concurrency must stay within the resolved bound.
+	const devshardCount = 32
+	limit := int64(resolveMaxConcurrentRuntimeBuilds())
+
+	peak := measurePeakRuntimeBuildConcurrency(t, devshardCount)
+
+	require.Greater(t, int64(devshardCount), limit, "test needs more devshards than the bound to be meaningful")
+	require.LessOrEqual(t, peak, limit, "runtime builder fan-out is unbounded: %d builders ran concurrently", peak)
+}
+
+func TestBuildGatewayRuntimesHonorsConcurrencyEnvOverride(t *testing.T) {
+	t.Setenv("DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS", "4")
+
+	peak := measurePeakRuntimeBuildConcurrency(t, 32)
+
+	require.LessOrEqual(t, peak, int64(4), "DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS=4 must bound builder concurrency")
+}
+
+func activeDevshardStates(n int) []GatewayDevshardState {
+	states := make([]GatewayDevshardState, 0, n)
+	for i := 0; i < n; i++ {
+		states = append(states, GatewayDevshardState{
+			RuntimeConfig: RuntimeConfig{ID: fmt.Sprintf("%d", i+1), PrivateKeyHex: "secret", Model: "Qwen/Test"},
+			Active:        true,
+		})
+	}
+	return states
+}
+
+func TestBuildGatewayRuntimesBoundedFanoutSurvivesRateLimitingLCD(t *testing.T) {
+	// Regression: an unbounded builder fan-out floods the chain LCD, which
+	// answers 429. A 429 is not a soft error (unlike ErrEscrowNotFound /
+	// private-key-missing), so it becomes firstFatal and the gateway fails to
+	// start — restart repeats the same fan-out — crash loop. With the fan-out
+	// bounded, at most the resolved limit of builders hit the LCD at once, so an
+	// LCD that tolerates that many never rate-limits and startup succeeds.
+	const devshardCount = 32
+	limit := int64(resolveMaxConcurrentRuntimeBuilds())
+
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, activeDevshardStates(devshardCount)))
+
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// The fake LCD tolerates up to the resolved limit of concurrent builds and
+	// rejects the one that exceeds it with a 429.
+	var inFlight atomic.Int64
+	var rateLimited atomic.Bool
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, chainREST, defaultModel string, perf *PerfTracker) (*devshardRuntime, error) {
+		defer inFlight.Add(-1)
+		if inFlight.Add(1) > limit {
+			rateLimited.Store(true)
+			return nil, fmt.Errorf("runtime %s: get escrow: chain LCD: 429 Too Many Requests", cfg.ID)
+		}
+		// Hold the slot so genuinely concurrent builders overlap.
+		time.Sleep(25 * time.Millisecond)
+		return &devshardRuntime{id: cfg.ID, model: defaultModel}, nil
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
+
+	runtimes, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+
+	require.False(t, rateLimited.Load(), "fan-out exceeded the LCD's concurrency tolerance and tripped a 429")
+	require.NoError(t, err, "bounded startup must survive a rate-limiting LCD")
+	require.Len(t, runtimes, devshardCount)
+}
+
+func TestResolveMaxConcurrentRuntimeBuildsDefaultsWhenUnset(t *testing.T) {
+	require.NoError(t, os.Unsetenv("DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS"))
+	require.Equal(t, defaultMaxConcurrentRuntimeBuilds, resolveMaxConcurrentRuntimeBuilds())
+}
+
+func TestResolveMaxConcurrentRuntimeBuildsParsesOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{name: "valid positive", env: "4", want: 4},
+		{name: "zero falls back", env: "0", want: defaultMaxConcurrentRuntimeBuilds},
+		{name: "negative falls back", env: "-3", want: defaultMaxConcurrentRuntimeBuilds},
+		{name: "non-numeric falls back", env: "abc", want: defaultMaxConcurrentRuntimeBuilds},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS", tc.env)
+			require.Equal(t, tc.want, resolveMaxConcurrentRuntimeBuilds())
+		})
+	}
+}
+
+func TestBuildRuntimeBridgeClientPinsIdleConnPool(t *testing.T) {
+	client := buildRuntimeBridgeClient(4)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Equal(t, 4, transport.MaxIdleConnsPerHost)
+	require.Equal(t, 4, transport.MaxIdleConns)
+	require.Equal(t, 10*time.Second, client.Timeout)
 }
 
 func TestRepairPersistedGatewayEndpointSettingsBackfillsBlankPublicAPI(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes a startup crash-loop: on a node with many devshards, `buildGatewayRuntimes` built every runtime in parallel with no concurrency limit, so the simultaneous chain LCD/REST queries could trip a `429` — which is not a soft error and fails startup, so the container restarts and repeats the same fan-out.
- Bounds the runtime-build fan-out with a semaphore. The limit is `DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS` (default **16**, must be ≥ 1); an invalid value logs and falls back to the default.
- Sizes the shared bridge HTTP client's `MaxIdleConnsPerHost` to the same limit so the bounded fan-out reuses keep-alive connections instead of churning them (Go's default is only 2).
- Per-index result collection and the existing error handling (soft-skip `ErrEscrowNotFound` / missing private key, `firstFatal` otherwise) are unchanged.

## Why

`buildGatewayRuntimes` launched one goroutine per devshard into a buffered channel with no limiter, so every escrow's builder hit the chain LCD at once. Each build is itself a sequential chain of ~`3 + 2·group_size` LCD calls (`GetEscrow`, `GetSessionBindParams`, `GetValidationThreshold`, and `GetHostInfo` + `VerifyWarmKey` per group slot), so a node with N escrows issues an N-wide burst against the shared `node:1317` LCD. A `429` from that burst is not one of the soft errors the loop tolerates, so it becomes `firstFatal`, startup returns an error, the container exits, restarts, and re-runs the identical fan-out — a crash loop.

The real ceiling is the shared LCD's capacity, which is a deployment property (it also serves validation/PoC and the api container), not a constant derivable in code — the repo pins no rate limit for `node:1317`. So the limit is operator-overridable, with a conservative default of 16: a small keep-alive connection pool to a shared internal service, large enough to hide startup latency (32 escrows → 4 batches → seconds, not minutes) and small enough to stay a minor slice of the LCD. The bridge previously used Go's default transport (`MaxIdleConnsPerHost = 2`), so beyond ~2 concurrent builds each extra request churned a fresh TCP connection; pinning the pool to the limit removes that churn.

## Tests

- `TestBuildGatewayRuntimesBoundsBuilderConcurrency` — peak simultaneous builder invocations ≤ the resolved limit (fails at N with the old unbounded fan-out).
- `TestBuildGatewayRuntimesBoundedFanoutSurvivesRateLimitingLCD` — an LCD that 429s above the limit no longer fails startup; fails if the semaphore is removed.
- `TestBuildGatewayRuntimesHonorsConcurrencyEnvOverride` — `DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS=4` bounds concurrency to 4; fails if the env value is not wired into the semaphore.
- `TestResolveMaxConcurrentRuntimeBuildsDefaultsWhenUnset` / `TestResolveMaxConcurrentRuntimeBuildsParsesOverride` — default when unset; parses a valid override; falls back on `0` / negative / non-numeric.
- `TestBuildRuntimeBridgeClientPinsIdleConnPool` — the bridge client's `MaxIdleConnsPerHost` / `MaxIdleConns` equal the limit and the 10s timeout is preserved.

`go test ./cmd/devshardctl/` is green; the new tests are also green under `-race`. The package's broad `-race` run additionally flags pre-existing `TestRunInference_*` / `TestWaitForFirstToken*` data races that are unrelated to this change.

## Test plan

- [x] `gofmt` / `go vet` clean on the changed files
- [x] `go test ./cmd/devshardctl/ -run 'TestBuildGatewayRuntimes|TestResolveMaxConcurrent|TestBuildRuntimeBridgeClient' -count=1` green
- [x] New tests green under `-race`
- [x] Each new guard verified to fail when its logic is removed (unbounded fan-out; ignored env override)
- [ ] `/run-integration` (Testermint) green
