### PR TITLE
early guard smst hardening

### DIFF
--- a/decentralized-api/internal/server/public/poc_handler.go
+++ b/decentralized-api/internal/server/public/poc_handler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -405,11 +406,28 @@ func (s *Server) preparePocProofRequest(
 	}
 
 	reqCount := uint32(req.Count)
+
+	// Quota on distinct snapshot counts per validator (after signature
+	// verification, so only authenticated requests consume quota). Honest
+	// validation touches at most the early and final snapshots; cycling
+	// through more counts is a rebuild-DoS probe, not a legitimate pattern.
+	if s.pocSnapshotLimiter != nil &&
+		!s.pocSnapshotLimiter.Allow(req.ValidatorAddress, int64(req.PocStageStartBlockHeight), req.ModelId, reqCount) {
+		logging.Warn("PoC proofs snapshot-count quota exceeded", types.Validation,
+			"validatorAddress", req.ValidatorAddress,
+			"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
+			"modelId", req.ModelId,
+			"requestedCount", reqCount)
+		return nil, 0, nil, echo.NewHTTPError(http.StatusTooManyRequests, "too many distinct snapshot counts requested")
+	}
 	storeRoot, err := stageStore.GetRootAt(reqCount)
 	if err != nil {
-		logging.Warn("Snapshot count exceeds store", types.Validation,
+		logging.Warn("Snapshot count not servable", types.Validation,
 			"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
 			"requestedCount", reqCount, "error", err)
+		if errors.Is(err, artifacts.ErrUnknownSnapshotCount) {
+			return nil, 0, nil, echo.NewHTTPError(http.StatusBadRequest, "count is not a known snapshot of this store")
+		}
 		return nil, 0, nil, echo.NewHTTPError(http.StatusBadRequest, "count exceeds stored artifacts")
 	}
 	if !bytes.Equal(rootHash, storeRoot) {

--- a/decentralized-api/internal/server/public/poc_handler.go
+++ b/decentralized-api/internal/server/public/poc_handler.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -442,9 +441,6 @@ func (s *Server) preparePocProofRequest(
 			"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
 			"modelId", req.ModelId,
 			"requestedCount", reqCount, "error", err)
-		if errors.Is(err, artifacts.ErrUnknownSnapshotCount) {
-			return nil, 0, nil, echo.NewHTTPError(http.StatusBadRequest, "count is not a known snapshot of this store")
-		}
 		return nil, 0, nil, echo.NewHTTPError(http.StatusBadRequest, "count exceeds stored artifacts")
 	}
 	if !bytes.Equal(rootHash, storeRoot) {

--- a/decentralized-api/internal/server/public/poc_handler.go
+++ b/decentralized-api/internal/server/public/poc_handler.go
@@ -411,19 +411,36 @@ func (s *Server) preparePocProofRequest(
 	// verification, so only authenticated requests consume quota). Honest
 	// validation touches at most the early and final snapshots; cycling
 	// through more counts is a rebuild-DoS probe, not a legitimate pattern.
-	if s.pocSnapshotLimiter != nil &&
-		!s.pocSnapshotLimiter.Allow(req.ValidatorAddress, int64(req.PocStageStartBlockHeight), req.ModelId, reqCount) {
-		logging.Warn("PoC proofs snapshot-count quota exceeded", types.Validation,
-			"validatorAddress", req.ValidatorAddress,
-			"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
-			"modelId", req.ModelId,
-			"requestedCount", reqCount)
-		return nil, 0, nil, echo.NewHTTPError(http.StatusTooManyRequests, "too many distinct snapshot counts requested")
+	if s.pocSnapshotLimiter != nil {
+		allowed, distinct := s.pocSnapshotLimiter.Allow(req.ValidatorAddress, int64(req.PocStageStartBlockHeight), req.ModelId, reqCount)
+		if !allowed {
+			logging.Warn("PoC proofs snapshot-count quota exceeded", types.Validation,
+				"validatorAddress", req.ValidatorAddress,
+				"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
+				"modelId", req.ModelId,
+				"requestedCount", reqCount,
+				"distinctCounts", distinct)
+			return nil, 0, nil, echo.NewHTTPError(http.StatusTooManyRequests, "too many distinct snapshot counts requested")
+		}
+		// Two distinct counts (early + final) is the expected honest ceiling.
+		// A third is tolerated but anomalous: surface it so operators can
+		// spot validators whose early capture diverged (or probing) before
+		// the quota ever trips.
+		if distinct > 2 {
+			logging.Warn("PoC proofs validator exceeded expected two snapshot counts", types.Validation,
+				"validatorAddress", req.ValidatorAddress,
+				"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
+				"modelId", req.ModelId,
+				"requestedCount", reqCount,
+				"distinctCounts", distinct)
+		}
 	}
 	storeRoot, err := stageStore.GetRootAt(reqCount)
 	if err != nil {
 		logging.Warn("Snapshot count not servable", types.Validation,
+			"validatorAddress", req.ValidatorAddress,
 			"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
+			"modelId", req.ModelId,
 			"requestedCount", reqCount, "error", err)
 		if errors.Is(err, artifacts.ErrUnknownSnapshotCount) {
 			return nil, 0, nil, echo.NewHTTPError(http.StatusBadRequest, "count is not a known snapshot of this store")
@@ -432,7 +449,9 @@ func (s *Server) preparePocProofRequest(
 	}
 	if !bytes.Equal(rootHash, storeRoot) {
 		logging.Warn("Root hash mismatch", types.Validation,
+			"validatorAddress", req.ValidatorAddress,
 			"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
+			"modelId", req.ModelId,
 			"requestedCount", reqCount)
 		return nil, 0, nil, echo.NewHTTPError(http.StatusBadRequest, "root_hash does not match store state at count")
 	}

--- a/decentralized-api/internal/server/public/poc_handler_test.go
+++ b/decentralized-api/internal/server/public/poc_handler_test.go
@@ -494,3 +494,87 @@ func TestPostPocProofsByNonce_UsesModelScopedStore(t *testing.T) {
 	assert.Equal(t, uint32(0), resp.Proofs[0].LeafIndex)
 	mockRecorder.AssertExpectations(t)
 }
+
+func TestPostPocProofs_DistinctSnapshotCountQuota(t *testing.T) {
+	store := artifacts.NewManagedArtifactStore(t.TempDir(), 3)
+	defer store.Close()
+
+	// Four flush boundaries: counts 1..4, each a legitimately servable snapshot.
+	modelStore, err := store.GetOrCreateStore(100, "model-a")
+	assert.NoError(t, err)
+	for i := int32(1); i <= 4; i++ {
+		assert.NoError(t, modelStore.AddWithNode(i, []byte{byte(i), 2, 3, 4}, ""))
+		assert.NoError(t, modelStore.Flush())
+	}
+
+	privKey := secp256k1.GenPrivKey()
+	pubKeyB64 := base64.StdEncoding.EncodeToString(privKey.PubKey().Bytes())
+	queryClient, cleanup := newProofQueryClient(t, &proofQueryServer{pubkeyB64: pubKeyB64})
+	defer cleanup()
+
+	mockRecorder := &cosmosclient.MockCosmosMessageClient{}
+	mockRecorder.On("NewInferenceQueryClient").Return(queryClient)
+	mockRecorder.On("GetSignerAddress").Return("participant-signer")
+	mockRecorder.On("SignBytes", mock.Anything).Return([]byte("response-signature"), nil)
+
+	server := &Server{
+		artifactStore:      store,
+		recorder:           mockRecorder,
+		authzCache:         authzcache.NewAuthzCache(mockRecorder),
+		pocSnapshotLimiter: newSnapshotCountLimiter(),
+	}
+	e := echo.New()
+
+	post := func(validator string, count uint32) (int, error) {
+		root, err := modelStore.GetRootAt(count)
+		assert.NoError(t, err)
+		reqBody := &PocProofsRequest{
+			PocStageStartBlockHeight: 100,
+			ModelId:                  "model-a",
+			RootHash:                 base64.StdEncoding.EncodeToString(root),
+			Count:                    StringUint32(count),
+			LeafIndices:              []StringUint32{0},
+			ValidatorAddress:         validator,
+			ValidatorSignerAddress:   validator,
+			Timestamp:                StringInt64(time.Now().UnixNano()),
+		}
+		signature, err := privKey.Sign(buildPocProofsSignPayload(reqBody, root))
+		assert.NoError(t, err)
+		reqBody.Signature = base64.StdEncoding.EncodeToString(signature)
+
+		body, err := json.Marshal(reqBody)
+		assert.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/v1/poc/proofs", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		if err := server.postPocProofs(e.NewContext(req, rec)); err != nil {
+			var httpErr *echo.HTTPError
+			if assert.ErrorAs(t, err, &httpErr) {
+				return httpErr.Code, err
+			}
+			return 0, err
+		}
+		return rec.Code, nil
+	}
+
+	// First three distinct snapshot counts are served.
+	for count := uint32(1); count <= 3; count++ {
+		code, err := post("validator-address", count)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+	}
+
+	// Fourth distinct count trips the quota, even though the snapshot is valid.
+	code, _ := post("validator-address", 4)
+	assert.Equal(t, http.StatusTooManyRequests, code)
+
+	// Repeats of an already-seen count are still served.
+	code, err = post("validator-address", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	// A different validator has an independent quota.
+	code, err = post("other-validator", 4)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code)
+}

--- a/decentralized-api/internal/server/public/poc_snapshot_limiter.go
+++ b/decentralized-api/internal/server/public/poc_snapshot_limiter.go
@@ -1,0 +1,100 @@
+package public
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	// maxDistinctSnapshotCountsPerValidator caps how many distinct snapshot
+	// counts one validator may request proofs for, per (stage, model) store.
+	// Honest validation needs exactly two: the early checkpoint count and the
+	// final commitment count. The third slot absorbs a capture that straddled
+	// a commit boundary. Repeat requests for an already-seen count are always
+	// allowed (they are snapshot-cache hits and cost nothing to serve).
+	maxDistinctSnapshotCountsPerValidator = 3
+
+	// snapshotLimiterIdleTTL evicts idle per-validator entries. It comfortably
+	// covers the validation retry window (~14 minutes).
+	snapshotLimiterIdleTTL = 2 * time.Hour
+
+	// snapshotLimiterMaxEntries bounds limiter memory against many validators
+	// and stages. Oldest entries are evicted first.
+	snapshotLimiterMaxEntries = 8192
+)
+
+type snapshotLimiterEntry struct {
+	counts   map[uint32]struct{}
+	lastSeen time.Time
+}
+
+// snapshotCountLimiter tracks the distinct snapshot counts each validator has
+// requested per (stage, model) store. It exists to stop a registered validator
+// from forcing repeated snapshot-tree rebuilds by cycling through many valid
+// flush-boundary counts. It deliberately does not limit request volume for
+// counts already seen: those are served from the snapshot cache.
+type snapshotCountLimiter struct {
+	mu      sync.Mutex
+	entries map[string]*snapshotLimiterEntry
+	max     int
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+func newSnapshotCountLimiter() *snapshotCountLimiter {
+	return &snapshotCountLimiter{
+		entries: make(map[string]*snapshotLimiterEntry),
+		max:     maxDistinctSnapshotCountsPerValidator,
+		ttl:     snapshotLimiterIdleTTL,
+		now:     time.Now,
+	}
+}
+
+// Allow reports whether the validator may request proofs against the given
+// snapshot count of the (stage, model) store, recording the count if allowed.
+func (l *snapshotCountLimiter) Allow(validatorAddress string, stageHeight int64, modelID string, count uint32) bool {
+	key := fmt.Sprintf("%s|%d|%s", validatorAddress, stageHeight, modelID)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	l.pruneLocked(now)
+
+	entry, ok := l.entries[key]
+	if !ok {
+		entry = &snapshotLimiterEntry{counts: make(map[uint32]struct{}, l.max)}
+		l.entries[key] = entry
+	}
+	entry.lastSeen = now
+
+	if _, seen := entry.counts[count]; seen {
+		return true
+	}
+	if len(entry.counts) >= l.max {
+		return false
+	}
+	entry.counts[count] = struct{}{}
+	return true
+}
+
+func (l *snapshotCountLimiter) pruneLocked(now time.Time) {
+	for key, entry := range l.entries {
+		if now.Sub(entry.lastSeen) > l.ttl {
+			delete(l.entries, key)
+		}
+	}
+	// Hard cap as a memory backstop; evict oldest entries first.
+	for len(l.entries) >= snapshotLimiterMaxEntries {
+		var oldestKey string
+		var oldest time.Time
+		for key, entry := range l.entries {
+			if oldestKey == "" || entry.lastSeen.Before(oldest) {
+				oldestKey = key
+				oldest = entry.lastSeen
+			}
+		}
+		delete(l.entries, oldestKey)
+	}
+}

--- a/decentralized-api/internal/server/public/poc_snapshot_limiter.go
+++ b/decentralized-api/internal/server/public/poc_snapshot_limiter.go
@@ -53,7 +53,10 @@ func newSnapshotCountLimiter() *snapshotCountLimiter {
 
 // Allow reports whether the validator may request proofs against the given
 // snapshot count of the (stage, model) store, recording the count if allowed.
-func (l *snapshotCountLimiter) Allow(validatorAddress string, stageHeight int64, modelID string, count uint32) bool {
+// distinct is the number of distinct counts the validator has used after this
+// request (including the rejected one when allowed is false), so callers can
+// surface validators approaching the quota before it trips.
+func (l *snapshotCountLimiter) Allow(validatorAddress string, stageHeight int64, modelID string, count uint32) (allowed bool, distinct int) {
 	key := fmt.Sprintf("%s|%d|%s", validatorAddress, stageHeight, modelID)
 
 	l.mu.Lock()
@@ -70,13 +73,13 @@ func (l *snapshotCountLimiter) Allow(validatorAddress string, stageHeight int64,
 	entry.lastSeen = now
 
 	if _, seen := entry.counts[count]; seen {
-		return true
+		return true, len(entry.counts)
 	}
 	if len(entry.counts) >= l.max {
-		return false
+		return false, len(entry.counts) + 1
 	}
 	entry.counts[count] = struct{}{}
-	return true
+	return true, len(entry.counts)
 }
 
 func (l *snapshotCountLimiter) pruneLocked(now time.Time) {

--- a/decentralized-api/internal/server/public/poc_snapshot_limiter_test.go
+++ b/decentralized-api/internal/server/public/poc_snapshot_limiter_test.go
@@ -10,21 +10,27 @@ func TestSnapshotCountLimiter(t *testing.T) {
 		l := newSnapshotCountLimiter()
 
 		for i, count := range []uint32{100, 200, 300} {
-			if !l.Allow("val1", 1000, "m1", count) {
+			allowed, distinct := l.Allow("val1", 1000, "m1", count)
+			if !allowed {
 				t.Fatalf("distinct count %d (#%d) should be allowed", count, i+1)
 			}
+			if distinct != i+1 {
+				t.Fatalf("distinct = %d, want %d", distinct, i+1)
+			}
 		}
-		if l.Allow("val1", 1000, "m1", 400) {
+		if allowed, distinct := l.Allow("val1", 1000, "m1", 400); allowed {
 			t.Fatal("4th distinct count should be rejected")
+		} else if distinct != 4 {
+			t.Fatalf("rejected distinct = %d, want 4", distinct)
 		}
 		// Repeats of already-seen counts stay allowed.
 		for _, count := range []uint32{100, 200, 300} {
-			if !l.Allow("val1", 1000, "m1", count) {
+			if allowed, _ := l.Allow("val1", 1000, "m1", count); !allowed {
 				t.Fatalf("repeat of count %d should be allowed", count)
 			}
 		}
 		// Still rejected after repeats.
-		if l.Allow("val1", 1000, "m1", 500) {
+		if allowed, _ := l.Allow("val1", 1000, "m1", 500); allowed {
 			t.Fatal("new distinct count should stay rejected")
 		}
 	})
@@ -34,13 +40,13 @@ func TestSnapshotCountLimiter(t *testing.T) {
 		for _, count := range []uint32{1, 2, 3} {
 			l.Allow("val1", 1000, "m1", count)
 		}
-		if !l.Allow("val2", 1000, "m1", 4) {
+		if allowed, _ := l.Allow("val2", 1000, "m1", 4); !allowed {
 			t.Fatal("other validator must have its own quota")
 		}
-		if !l.Allow("val1", 2000, "m1", 4) {
+		if allowed, _ := l.Allow("val1", 2000, "m1", 4); !allowed {
 			t.Fatal("other stage must have its own quota")
 		}
-		if !l.Allow("val1", 1000, "m2", 4) {
+		if allowed, _ := l.Allow("val1", 1000, "m2", 4); !allowed {
 			t.Fatal("other model must have its own quota")
 		}
 	})
@@ -53,12 +59,12 @@ func TestSnapshotCountLimiter(t *testing.T) {
 		for _, count := range []uint32{1, 2, 3} {
 			l.Allow("val1", 1000, "m1", count)
 		}
-		if l.Allow("val1", 1000, "m1", 4) {
+		if allowed, _ := l.Allow("val1", 1000, "m1", 4); allowed {
 			t.Fatal("quota should be exhausted")
 		}
 
 		current = current.Add(snapshotLimiterIdleTTL + time.Minute)
-		if !l.Allow("val1", 1000, "m1", 4) {
+		if allowed, _ := l.Allow("val1", 1000, "m1", 4); !allowed {
 			t.Fatal("expired entry should reset the quota")
 		}
 	})

--- a/decentralized-api/internal/server/public/poc_snapshot_limiter_test.go
+++ b/decentralized-api/internal/server/public/poc_snapshot_limiter_test.go
@@ -1,0 +1,65 @@
+package public
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSnapshotCountLimiter(t *testing.T) {
+	t.Run("caps distinct counts, allows repeats", func(t *testing.T) {
+		l := newSnapshotCountLimiter()
+
+		for i, count := range []uint32{100, 200, 300} {
+			if !l.Allow("val1", 1000, "m1", count) {
+				t.Fatalf("distinct count %d (#%d) should be allowed", count, i+1)
+			}
+		}
+		if l.Allow("val1", 1000, "m1", 400) {
+			t.Fatal("4th distinct count should be rejected")
+		}
+		// Repeats of already-seen counts stay allowed.
+		for _, count := range []uint32{100, 200, 300} {
+			if !l.Allow("val1", 1000, "m1", count) {
+				t.Fatalf("repeat of count %d should be allowed", count)
+			}
+		}
+		// Still rejected after repeats.
+		if l.Allow("val1", 1000, "m1", 500) {
+			t.Fatal("new distinct count should stay rejected")
+		}
+	})
+
+	t.Run("quota is per validator, stage, and model", func(t *testing.T) {
+		l := newSnapshotCountLimiter()
+		for _, count := range []uint32{1, 2, 3} {
+			l.Allow("val1", 1000, "m1", count)
+		}
+		if !l.Allow("val2", 1000, "m1", 4) {
+			t.Fatal("other validator must have its own quota")
+		}
+		if !l.Allow("val1", 2000, "m1", 4) {
+			t.Fatal("other stage must have its own quota")
+		}
+		if !l.Allow("val1", 1000, "m2", 4) {
+			t.Fatal("other model must have its own quota")
+		}
+	})
+
+	t.Run("idle entries expire", func(t *testing.T) {
+		l := newSnapshotCountLimiter()
+		current := time.Unix(0, 0)
+		l.now = func() time.Time { return current }
+
+		for _, count := range []uint32{1, 2, 3} {
+			l.Allow("val1", 1000, "m1", count)
+		}
+		if l.Allow("val1", 1000, "m1", 4) {
+			t.Fatal("quota should be exhausted")
+		}
+
+		current = current.Add(snapshotLimiterIdleTTL + time.Minute)
+		if !l.Allow("val1", 1000, "m1", 4) {
+			t.Fatal("expired entry should reset the quota")
+		}
+	})
+}

--- a/decentralized-api/internal/server/public/server.go
+++ b/decentralized-api/internal/server/public/server.go
@@ -41,6 +41,7 @@ type Server struct {
 	authzCache          *authzcache.AuthzCache
 	httpClient          *http.Client
 	statsStorage        statsstorage.StatsStorage
+	pocSnapshotLimiter  *snapshotCountLimiter
 }
 
 // ServerOption configures optional Server dependencies.
@@ -86,6 +87,7 @@ func NewServer(
 		epochGroupDataCache: internal.NewEpochGroupDataCache(recorder),
 		authzCache:          authzcache.NewAuthzCache(recorder),
 		httpClient:          NewNoRedirectClient(httpClientTimeout),
+		pocSnapshotLimiter:  newSnapshotCountLimiter(),
 	}
 
 	for _, opt := range opts {

--- a/decentralized-api/poc/artifacts/smst_store.go
+++ b/decentralized-api/poc/artifacts/smst_store.go
@@ -26,12 +26,6 @@ var (
 	ErrNonceNotFound       = errors.New("nonce not found")
 	ErrStoreClosed         = errors.New("store is closed")
 	ErrCapacityExceeded    = errors.New("store capacity exceeded")
-	// ErrUnknownSnapshotCount marks a snapshot count that was never a flush
-	// boundary of this store. Every externally committed (root, count) pair is
-	// produced from flushed state, so an unknown count cannot correspond to any
-	// commitment a validator could have legitimately captured. Rejecting it
-	// outright avoids building a snapshot tree just to discover a mismatch.
-	ErrUnknownSnapshotCount = errors.New("unknown snapshot count")
 )
 
 type bufferedArtifact struct {
@@ -44,14 +38,6 @@ type bufferedArtifact struct {
 type distributionEntry struct {
 	Count uint32            `json:"count"`
 	Dist  map[string]uint32 `json:"dist"`
-}
-
-// rootEntry is a single line in roots.jsonl: the root hash at a flush
-// boundary. Persisting these lets the store recognize every legitimate
-// snapshot count after a restart without rebuilding trees.
-type rootEntry struct {
-	Count uint32 `json:"count"`
-	Root  []byte `json:"root"`
 }
 
 // SMSTArtifactStore provides artifact storage with SMST commitments.
@@ -77,7 +63,6 @@ type SMSTArtifactStore struct {
 
 	distributionHistory map[uint32]map[string]uint32 // count -> distribution snapshot
 	distFile            *os.File                     // distributions.jsonl (append-only)
-	rootsFile           *os.File                     // roots.jsonl (append-only)
 }
 
 var _ ArtifactStore = (*SMSTArtifactStore)(nil)
@@ -90,7 +75,6 @@ func OpenSMST(dir string) (*SMSTArtifactStore, error) {
 
 	dataPath := filepath.Join(dir, "artifacts.data")
 	distPath := filepath.Join(dir, "distributions.jsonl")
-	rootsPath := filepath.Join(dir, "roots.jsonl")
 
 	dataFile, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
@@ -103,18 +87,10 @@ func OpenSMST(dir string) (*SMSTArtifactStore, error) {
 		return nil, fmt.Errorf("open distributions file: %w", err)
 	}
 
-	rootsFile, err := os.OpenFile(rootsPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		dataFile.Close()
-		distFile.Close()
-		return nil, fmt.Errorf("open roots file: %w", err)
-	}
-
 	s := &SMSTArtifactStore{
 		dir:                 dir,
 		dataFile:            dataFile,
 		distFile:            distFile,
-		rootsFile:           rootsFile,
 		buffer:              make([]bufferedArtifact, 0, 1024),
 		offsets:             make([]uint64, 0, 1024),
 		nonceToOffset:       make(map[int32]uint64),
@@ -128,7 +104,6 @@ func OpenSMST(dir string) (*SMSTArtifactStore, error) {
 	if err := s.recover(); err != nil {
 		s.dataFile.Close()
 		s.distFile.Close()
-		s.rootsFile.Close()
 		return nil, fmt.Errorf("recover: %w", err)
 	}
 
@@ -183,72 +158,11 @@ func (s *SMSTArtifactStore) recover() error {
 	rootHash, _ := s.smst.GetRoot()
 	s.flushedRoots[s.flushedLeafCount] = rootHash
 
-	if err := s.recoverFlushedRoots(); err != nil {
-		log.Printf("warning: failed to recover flushed roots: %v", err)
-	}
-
 	if err := s.recoverDistributionHistory(); err != nil {
 		log.Printf("warning: failed to recover distribution history: %v", err)
 	}
 
 	return nil
-}
-
-// recoverFlushedRoots reloads historical flush-boundary roots from roots.jsonl.
-// Entries beyond the recovered leaf count (e.g. after a truncated data file)
-// are dropped. The root recomputed from the data file for the current count
-// takes precedence over any stale persisted entry.
-func (s *SMSTArtifactStore) recoverFlushedRoots() error {
-	if s.rootsFile == nil {
-		return nil
-	}
-	if _, err := s.rootsFile.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("seek roots file: %w", err)
-	}
-
-	reader := bufio.NewReader(s.rootsFile)
-	lineNum := 0
-	for {
-		line, err := reader.ReadBytes('\n')
-		if err != nil && err != io.EOF {
-			return fmt.Errorf("read roots file: %w", err)
-		}
-		line = bytes.TrimRight(line, "\r\n")
-		if len(line) > 0 {
-			lineNum++
-			var entry rootEntry
-			if jsonErr := json.Unmarshal(line, &entry); jsonErr != nil {
-				log.Printf("warning: skipping corrupted root entry at line %d: %v", lineNum, jsonErr)
-			} else if entry.Count > 0 && entry.Count < s.flushedLeafCount && len(entry.Root) == 32 {
-				s.flushedRoots[entry.Count] = entry.Root
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-	}
-	return nil
-}
-
-// appendRootEntry persists the current flush-boundary root. Requires the
-// store write lock to be held.
-func (s *SMSTArtifactStore) appendRootEntry(count uint32, root []byte) {
-	if s.rootsFile == nil {
-		return
-	}
-	data, err := json.Marshal(rootEntry{Count: count, Root: root})
-	if err != nil {
-		log.Printf("warning: marshal root entry: %v", err)
-		return
-	}
-	data = append(data, '\n')
-	if _, err := s.rootsFile.Write(data); err != nil {
-		log.Printf("warning: write root entry: %v", err)
-		return
-	}
-	if err := s.rootsFile.Sync(); err != nil {
-		log.Printf("warning: sync roots file: %v", err)
-	}
 }
 
 func (s *SMSTArtifactStore) recoverDistributionHistory() error {
@@ -376,7 +290,6 @@ func (s *SMSTArtifactStore) flushLocked() error {
 
 	rootHash, _ := s.smst.GetRoot()
 	s.flushedRoots[s.flushedLeafCount] = rootHash
-	s.appendRootEntry(s.flushedLeafCount, rootHash)
 
 	if err := s.appendDistributionSnapshot(); err != nil {
 		log.Printf("warning: distribution snapshot failed (will use simulation): %v", err)
@@ -460,12 +373,13 @@ func (s *SMSTArtifactStore) GetRootAt(snapshotCount uint32) ([]byte, error) {
 	}
 	s.mu.RUnlock()
 
-	// Not the live count and not a recorded flush boundary: no external
-	// commitment can reference this count, so reject instead of building a
-	// snapshot tree just to compare roots (that rebuild was a DoS vector:
-	// a registered validator could force arbitrary snapshot rebuilds by
-	// probing counts).
-	return nil, fmt.Errorf("%w: %d", ErrUnknownSnapshotCount, snapshotCount)
+	tree, unlock, err := s.acquireSnapshotTree(snapshotCount)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	root, _ := tree.GetRoot()
+	return root, nil
 }
 
 func (s *SMSTArtifactStore) GetFlushedRoot() (count uint32, root []byte) {
@@ -881,12 +795,6 @@ func (s *SMSTArtifactStore) Close() error {
 	if s.distFile != nil {
 		if err := s.distFile.Close(); err != nil {
 			return fmt.Errorf("close distributions file: %w", err)
-		}
-	}
-
-	if s.rootsFile != nil {
-		if err := s.rootsFile.Close(); err != nil {
-			return fmt.Errorf("close roots file: %w", err)
 		}
 	}
 

--- a/decentralized-api/poc/artifacts/smst_store.go
+++ b/decentralized-api/poc/artifacts/smst_store.go
@@ -26,6 +26,12 @@ var (
 	ErrNonceNotFound       = errors.New("nonce not found")
 	ErrStoreClosed         = errors.New("store is closed")
 	ErrCapacityExceeded    = errors.New("store capacity exceeded")
+	// ErrUnknownSnapshotCount marks a snapshot count that was never a flush
+	// boundary of this store. Every externally committed (root, count) pair is
+	// produced from flushed state, so an unknown count cannot correspond to any
+	// commitment a validator could have legitimately captured. Rejecting it
+	// outright avoids building a snapshot tree just to discover a mismatch.
+	ErrUnknownSnapshotCount = errors.New("unknown snapshot count")
 )
 
 type bufferedArtifact struct {
@@ -38,6 +44,14 @@ type bufferedArtifact struct {
 type distributionEntry struct {
 	Count uint32            `json:"count"`
 	Dist  map[string]uint32 `json:"dist"`
+}
+
+// rootEntry is a single line in roots.jsonl: the root hash at a flush
+// boundary. Persisting these lets the store recognize every legitimate
+// snapshot count after a restart without rebuilding trees.
+type rootEntry struct {
+	Count uint32 `json:"count"`
+	Root  []byte `json:"root"`
 }
 
 // SMSTArtifactStore provides artifact storage with SMST commitments.
@@ -63,6 +77,7 @@ type SMSTArtifactStore struct {
 
 	distributionHistory map[uint32]map[string]uint32 // count -> distribution snapshot
 	distFile            *os.File                     // distributions.jsonl (append-only)
+	rootsFile           *os.File                     // roots.jsonl (append-only)
 }
 
 var _ ArtifactStore = (*SMSTArtifactStore)(nil)
@@ -75,6 +90,7 @@ func OpenSMST(dir string) (*SMSTArtifactStore, error) {
 
 	dataPath := filepath.Join(dir, "artifacts.data")
 	distPath := filepath.Join(dir, "distributions.jsonl")
+	rootsPath := filepath.Join(dir, "roots.jsonl")
 
 	dataFile, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
@@ -87,10 +103,18 @@ func OpenSMST(dir string) (*SMSTArtifactStore, error) {
 		return nil, fmt.Errorf("open distributions file: %w", err)
 	}
 
+	rootsFile, err := os.OpenFile(rootsPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		dataFile.Close()
+		distFile.Close()
+		return nil, fmt.Errorf("open roots file: %w", err)
+	}
+
 	s := &SMSTArtifactStore{
 		dir:                 dir,
 		dataFile:            dataFile,
 		distFile:            distFile,
+		rootsFile:           rootsFile,
 		buffer:              make([]bufferedArtifact, 0, 1024),
 		offsets:             make([]uint64, 0, 1024),
 		nonceToOffset:       make(map[int32]uint64),
@@ -104,6 +128,7 @@ func OpenSMST(dir string) (*SMSTArtifactStore, error) {
 	if err := s.recover(); err != nil {
 		s.dataFile.Close()
 		s.distFile.Close()
+		s.rootsFile.Close()
 		return nil, fmt.Errorf("recover: %w", err)
 	}
 
@@ -158,11 +183,72 @@ func (s *SMSTArtifactStore) recover() error {
 	rootHash, _ := s.smst.GetRoot()
 	s.flushedRoots[s.flushedLeafCount] = rootHash
 
+	if err := s.recoverFlushedRoots(); err != nil {
+		log.Printf("warning: failed to recover flushed roots: %v", err)
+	}
+
 	if err := s.recoverDistributionHistory(); err != nil {
 		log.Printf("warning: failed to recover distribution history: %v", err)
 	}
 
 	return nil
+}
+
+// recoverFlushedRoots reloads historical flush-boundary roots from roots.jsonl.
+// Entries beyond the recovered leaf count (e.g. after a truncated data file)
+// are dropped. The root recomputed from the data file for the current count
+// takes precedence over any stale persisted entry.
+func (s *SMSTArtifactStore) recoverFlushedRoots() error {
+	if s.rootsFile == nil {
+		return nil
+	}
+	if _, err := s.rootsFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek roots file: %w", err)
+	}
+
+	reader := bufio.NewReader(s.rootsFile)
+	lineNum := 0
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("read roots file: %w", err)
+		}
+		line = bytes.TrimRight(line, "\r\n")
+		if len(line) > 0 {
+			lineNum++
+			var entry rootEntry
+			if jsonErr := json.Unmarshal(line, &entry); jsonErr != nil {
+				log.Printf("warning: skipping corrupted root entry at line %d: %v", lineNum, jsonErr)
+			} else if entry.Count > 0 && entry.Count < s.flushedLeafCount && len(entry.Root) == 32 {
+				s.flushedRoots[entry.Count] = entry.Root
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+	}
+	return nil
+}
+
+// appendRootEntry persists the current flush-boundary root. Requires the
+// store write lock to be held.
+func (s *SMSTArtifactStore) appendRootEntry(count uint32, root []byte) {
+	if s.rootsFile == nil {
+		return
+	}
+	data, err := json.Marshal(rootEntry{Count: count, Root: root})
+	if err != nil {
+		log.Printf("warning: marshal root entry: %v", err)
+		return
+	}
+	data = append(data, '\n')
+	if _, err := s.rootsFile.Write(data); err != nil {
+		log.Printf("warning: write root entry: %v", err)
+		return
+	}
+	if err := s.rootsFile.Sync(); err != nil {
+		log.Printf("warning: sync roots file: %v", err)
+	}
 }
 
 func (s *SMSTArtifactStore) recoverDistributionHistory() error {
@@ -290,6 +376,7 @@ func (s *SMSTArtifactStore) flushLocked() error {
 
 	rootHash, _ := s.smst.GetRoot()
 	s.flushedRoots[s.flushedLeafCount] = rootHash
+	s.appendRootEntry(s.flushedLeafCount, rootHash)
 
 	if err := s.appendDistributionSnapshot(); err != nil {
 		log.Printf("warning: distribution snapshot failed (will use simulation): %v", err)
@@ -373,13 +460,12 @@ func (s *SMSTArtifactStore) GetRootAt(snapshotCount uint32) ([]byte, error) {
 	}
 	s.mu.RUnlock()
 
-	tree, unlock, err := s.acquireSnapshotTree(snapshotCount)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
-	root, _ := tree.GetRoot()
-	return root, nil
+	// Not the live count and not a recorded flush boundary: no external
+	// commitment can reference this count, so reject instead of building a
+	// snapshot tree just to compare roots (that rebuild was a DoS vector:
+	// a registered validator could force arbitrary snapshot rebuilds by
+	// probing counts).
+	return nil, fmt.Errorf("%w: %d", ErrUnknownSnapshotCount, snapshotCount)
 }
 
 func (s *SMSTArtifactStore) GetFlushedRoot() (count uint32, root []byte) {
@@ -795,6 +881,12 @@ func (s *SMSTArtifactStore) Close() error {
 	if s.distFile != nil {
 		if err := s.distFile.Close(); err != nil {
 			return fmt.Errorf("close distributions file: %w", err)
+		}
+	}
+
+	if s.rootsFile != nil {
+		if err := s.rootsFile.Close(); err != nil {
+			return fmt.Errorf("close roots file: %w", err)
 		}
 	}
 

--- a/decentralized-api/poc/artifacts/smst_test.go
+++ b/decentralized-api/poc/artifacts/smst_test.go
@@ -701,6 +701,79 @@ func TestSMSTStoreGetRootAt(t *testing.T) {
 	}
 }
 
+func TestSMSTStoreGetRootAtUnknownCount(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenSMST(dir)
+	if err != nil {
+		t.Fatalf("OpenSMST failed: %v", err)
+	}
+	defer store.Close()
+
+	// Two flush boundaries: 3 and 5.
+	for i := int32(1); i <= 3; i++ {
+		store.Add(i, []byte{byte(i)})
+	}
+	store.Flush()
+	for i := int32(4); i <= 5; i++ {
+		store.Add(i, []byte{byte(i)})
+	}
+	store.Flush()
+
+	for _, count := range []uint32{3, 5} {
+		if _, err := store.GetRootAt(count); err != nil {
+			t.Fatalf("GetRootAt(%d) should serve a flush boundary: %v", count, err)
+		}
+	}
+
+	// Counts between boundaries were never externally committed: reject
+	// without building a snapshot tree.
+	for _, count := range []uint32{1, 2, 4} {
+		if _, err := store.GetRootAt(count); !errors.Is(err, ErrUnknownSnapshotCount) {
+			t.Fatalf("GetRootAt(%d) = %v, want ErrUnknownSnapshotCount", count, err)
+		}
+	}
+}
+
+func TestSMSTStoreRootsSurviveReopen(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenSMST(dir)
+	if err != nil {
+		t.Fatalf("OpenSMST failed: %v", err)
+	}
+
+	boundaryRoots := make(map[uint32][]byte)
+	for i := int32(1); i <= 4; i++ {
+		store.Add(i, []byte{byte(i)})
+		store.Flush()
+		root, err := store.GetRootAt(uint32(i))
+		if err != nil {
+			t.Fatalf("GetRootAt(%d): %v", i, err)
+		}
+		boundaryRoots[uint32(i)] = root
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	store2, err := OpenSMST(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer store2.Close()
+
+	// All historical flush boundaries must still be recognized after a
+	// restart, without rebuilding snapshot trees.
+	for count, want := range boundaryRoots {
+		got, err := store2.GetRootAt(count)
+		if err != nil {
+			t.Fatalf("GetRootAt(%d) after reopen: %v", count, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("GetRootAt(%d) root mismatch after reopen", count)
+		}
+	}
+}
+
 func TestSMSTStoreGetFlushedRoot(t *testing.T) {
 	dir := t.TempDir()
 	store, err := OpenSMST(dir)

--- a/decentralized-api/poc/artifacts/smst_test.go
+++ b/decentralized-api/poc/artifacts/smst_test.go
@@ -701,39 +701,6 @@ func TestSMSTStoreGetRootAt(t *testing.T) {
 	}
 }
 
-func TestSMSTStoreGetRootAtUnknownCount(t *testing.T) {
-	dir := t.TempDir()
-	store, err := OpenSMST(dir)
-	if err != nil {
-		t.Fatalf("OpenSMST failed: %v", err)
-	}
-	defer store.Close()
-
-	// Two flush boundaries: 3 and 5.
-	for i := int32(1); i <= 3; i++ {
-		store.Add(i, []byte{byte(i)})
-	}
-	store.Flush()
-	for i := int32(4); i <= 5; i++ {
-		store.Add(i, []byte{byte(i)})
-	}
-	store.Flush()
-
-	for _, count := range []uint32{3, 5} {
-		if _, err := store.GetRootAt(count); err != nil {
-			t.Fatalf("GetRootAt(%d) should serve a flush boundary: %v", count, err)
-		}
-	}
-
-	// Counts between boundaries were never externally committed: reject
-	// without building a snapshot tree.
-	for _, count := range []uint32{1, 2, 4} {
-		if _, err := store.GetRootAt(count); !errors.Is(err, ErrUnknownSnapshotCount) {
-			t.Fatalf("GetRootAt(%d) = %v, want ErrUnknownSnapshotCount", count, err)
-		}
-	}
-}
-
 func TestSMSTStoreRootsSurviveReopen(t *testing.T) {
 	dir := t.TempDir()
 	store, err := OpenSMST(dir)
@@ -761,8 +728,8 @@ func TestSMSTStoreRootsSurviveReopen(t *testing.T) {
 	}
 	defer store2.Close()
 
-	// All historical flush boundaries must still be recognized after a
-	// restart, without rebuilding snapshot trees.
+	// Historical flush-boundary counts must remain servable after a restart
+	// (rebuilt on demand from the data file).
 	for count, want := range boundaryRoots {
 		got, err := store2.GetRootAt(count)
 		if err != nil {

--- a/decentralized-api/poc/artifacts/snapshot_cache.go
+++ b/decentralized-api/poc/artifacts/snapshot_cache.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
-	snapshotCacheMaxEntries    = 4
+	// snapshotCacheMaxEntries must fit the pinned working set plus rotation
+	// room. With 2 models the worst case pins 4 trees (early + historical
+	// final per model); 6 leaves 2 rotating slots even then. Note that
+	// exceeding the cap with pinned-only entries evicts the LRU pinned tree.
+	snapshotCacheMaxEntries    = 6
 	snapshotCacheIdleTTL       = 20 * time.Minute
 	snapshotCacheMaxConcurrent = 2
 )

--- a/decentralized-api/poc/early_guard.go
+++ b/decentralized-api/poc/early_guard.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"sync"
 
 	"decentralized-api/logging"
 	"decentralized-api/poc/earlyshare"
 
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	"github.com/productscience/inference/x/inference/types"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // earlyShareQueryClient is the subset of the inference query client the guard
@@ -37,6 +41,10 @@ type earlyShareStore interface {
 type EarlyShareGuard struct {
 	cfg   earlyshare.Config
 	store earlyShareStore
+
+	// captureMu collapses concurrent capture attempts for the retry window
+	// (the dispatcher may fire MaybeCapture on every block past the target).
+	captureMu sync.Mutex
 }
 
 // NewEarlyShareGuard builds a guard. Returns nil when the config is disabled or
@@ -76,12 +84,23 @@ func (g *EarlyShareGuard) DeleteStage(ctx context.Context, stageHeight int64) {
 }
 
 // MaybeCapture captures the early checkpoint for a stage if not already done.
-// It is idempotent: the exact-match trigger fires at most once per stage, and a
-// completed capture (e.g. after a restart) is never repeated.
+// It is idempotent: a completed capture (e.g. after a restart) is never
+// repeated, and concurrent attempts collapse to one.
+//
+// The query is pinned to the target block height (x-cosmos-block-height), so
+// the captured snapshot is the consensus state at exactly that height. Every
+// validator capturing the same stage therefore records identical checkpoints,
+// regardless of when in the window its capture actually runs — the capture can
+// be retried on later blocks and still lands on the same snapshot, as long as
+// the queried node retains state for the target height.
 func (g *EarlyShareGuard) MaybeCapture(ctx context.Context, qc earlyShareQueryClient, stageHeight, target, capturedAt int64) {
 	if !g.Enabled() || g.store == nil {
 		return
 	}
+	if !g.captureMu.TryLock() {
+		return // another capture attempt for this process is already running
+	}
+	defer g.captureMu.Unlock()
 
 	done, err := g.store.HasCompletedCapture(ctx, stageHeight)
 	if err != nil {
@@ -92,7 +111,11 @@ func (g *EarlyShareGuard) MaybeCapture(ctx context.Context, qc earlyShareQueryCl
 		return
 	}
 
-	resp, err := qc.AllPoCV2StoreCommitsForStage(ctx, &types.QueryAllPoCV2StoreCommitsForStageRequest{
+	// Pin the query to the target height so all validators see the same state.
+	queryCtx := metadata.AppendToOutgoingContext(ctx,
+		grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(target, 10))
+
+	resp, err := qc.AllPoCV2StoreCommitsForStage(queryCtx, &types.QueryAllPoCV2StoreCommitsForStageRequest{
 		PocStageStartBlockHeight: stageHeight,
 	})
 	if err != nil {

--- a/decentralized-api/poc/early_guard.go
+++ b/decentralized-api/poc/early_guard.go
@@ -117,6 +117,8 @@ func (g *EarlyShareGuard) MaybeCapture(ctx context.Context, qc earlyShareQueryCl
 	// Pin the query to the target height so all validators see the same state.
 	queryCtx := metadata.AppendToOutgoingContext(ctx,
 		grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(target, 10))
+	queryCtx, cancel := context.WithTimeout(queryCtx, 30*1e9) // 30s
+	defer cancel()
 
 	resp, err := qc.AllPoCV2StoreCommitsForStage(queryCtx, &types.QueryAllPoCV2StoreCommitsForStageRequest{
 		PocStageStartBlockHeight: stageHeight,

--- a/decentralized-api/poc/early_guard.go
+++ b/decentralized-api/poc/early_guard.go
@@ -2,8 +2,11 @@ package poc
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -152,8 +155,33 @@ func (g *EarlyShareGuard) MaybeCapture(ctx context.Context, qc earlyShareQueryCl
 		logging.Error("EarlyShareGuard: failed to mark capture run", types.PoC, "stage", stageHeight, "error", err)
 		return
 	}
+	// The digest is a deterministic hash of the whole captured snapshot.
+	// Because the capture query is height-pinned, every validator capturing
+	// this stage must log the same digest; differing digests across
+	// validators indicate capture divergence (version skew, pruned state)
+	// and are the primary observe-mode health signal for the guard.
 	logging.Info("EarlyShareGuard: captured early checkpoints", types.PoC,
-		"stage", stageHeight, "target", target, "capturedAt", capturedAt, "commits", len(checkpoints))
+		"stage", stageHeight, "target", target, "capturedAt", capturedAt,
+		"commits", len(checkpoints), "digest", checkpointsDigest(checkpoints))
+}
+
+// checkpointsDigest computes an order-independent digest of a captured
+// checkpoint set: entries are sorted by (participant, model) and hashed.
+func checkpointsDigest(checkpoints []earlyshare.Checkpoint) string {
+	sorted := make([]earlyshare.Checkpoint, len(checkpoints))
+	copy(sorted, checkpoints)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].ParticipantAddress != sorted[j].ParticipantAddress {
+			return sorted[i].ParticipantAddress < sorted[j].ParticipantAddress
+		}
+		return sorted[i].ModelID < sorted[j].ModelID
+	})
+
+	h := sha256.New()
+	for _, cp := range sorted {
+		fmt.Fprintf(h, "%s|%s|%d|%x\n", cp.ParticipantAddress, cp.ModelID, cp.EarlyCount, cp.EarlyRootHash)
+	}
+	return hex.EncodeToString(h.Sum(nil)[:8])
 }
 
 // earlyDecision is the precomputed guard outcome for one (participant, model).

--- a/decentralized-api/poc/early_guard_test.go
+++ b/decentralized-api/poc/early_guard_test.go
@@ -74,6 +74,34 @@ func TestEarlyShareCaptureTarget(t *testing.T) {
 		}
 	})
 
+	t.Run("fraction arithmetic is integer-deterministic", func(t *testing.T) {
+		// Different float spellings of "one third" (the code default, the
+		// documented config literal, a hand-typed shorter one) must quantize
+		// to the same ppm and produce the identical target height for any
+		// duration. This is what pins all validators to the same capture
+		// block.
+		spellings := []float64{1.0 / 3.0, 0.3333333333, 0.333333}
+		for _, dur := range []int64{30, 100, 720, 7201, 99999} {
+			want := int64(-1)
+			for _, f := range spellings {
+				_, target, ok := EarlyShareCaptureTarget(mkState(types.PoCGeneratePhase, 1000, dur), f)
+				if !ok {
+					t.Fatalf("fraction %v duration %d: expected ok", f, dur)
+				}
+				if want == -1 {
+					want = target
+				} else if target != want {
+					t.Fatalf("fraction %v duration %d: target %d differs from %d", f, dur, target, want)
+				}
+			}
+			// offset = round(dur * 333333 / 1e6), pure integer arithmetic.
+			expected := 1000 + (dur*333333+500000)/1000000
+			if want != expected {
+				t.Fatalf("duration %d: target %d, want %d", dur, want, expected)
+			}
+		}
+	})
+
 	t.Run("confirmation poc generation", func(t *testing.T) {
 		st := mkState(types.InferencePhase, 1000, 30)
 		st.ActiveConfirmationPoCEvent = &types.ConfirmationPoCEvent{

--- a/decentralized-api/poc/early_guard_test.go
+++ b/decentralized-api/poc/early_guard_test.go
@@ -7,8 +7,10 @@ import (
 	"decentralized-api/chainphase"
 	"decentralized-api/poc/earlyshare"
 
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	"github.com/productscience/inference/x/inference/types"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestEarlyShareCaptureTarget(t *testing.T) {
@@ -265,13 +267,15 @@ func TestNewEarlyShareGuardDisabled(t *testing.T) {
 
 // fakeESQueryClient implements earlyShareQueryClient for MaybeCapture tests.
 type fakeESQueryClient struct {
-	resp  *types.QueryAllPoCV2StoreCommitsForStageResponse
-	err   error
-	calls int
+	resp    *types.QueryAllPoCV2StoreCommitsForStageResponse
+	err     error
+	calls   int
+	lastCtx context.Context
 }
 
-func (f *fakeESQueryClient) AllPoCV2StoreCommitsForStage(_ context.Context, _ *types.QueryAllPoCV2StoreCommitsForStageRequest, _ ...grpc.CallOption) (*types.QueryAllPoCV2StoreCommitsForStageResponse, error) {
+func (f *fakeESQueryClient) AllPoCV2StoreCommitsForStage(ctx context.Context, _ *types.QueryAllPoCV2StoreCommitsForStageRequest, _ ...grpc.CallOption) (*types.QueryAllPoCV2StoreCommitsForStageResponse, error) {
 	f.calls++
+	f.lastCtx = ctx
 	return f.resp, f.err
 }
 
@@ -327,6 +331,52 @@ func TestMaybeCapture(t *testing.T) {
 		guard.MaybeCapture(ctx, qc, stage, 1010, 1010)
 		if qc.calls != 0 {
 			t.Fatalf("disabled guard must not query, got %d calls", qc.calls)
+		}
+	})
+
+	t.Run("query is pinned to the target height", func(t *testing.T) {
+		store := newFakeStore()
+		guard := NewEarlyShareGuard(earlyshare.Config{Mode: earlyshare.ModeObserve}, store)
+		qc := &fakeESQueryClient{resp: &types.QueryAllPoCV2StoreCommitsForStageResponse{}}
+
+		guard.MaybeCapture(ctx, qc, stage, 1010, 1042)
+		if qc.calls != 1 {
+			t.Fatalf("expected 1 query call, got %d", qc.calls)
+		}
+		md, ok := metadata.FromOutgoingContext(qc.lastCtx)
+		if !ok {
+			t.Fatal("capture query context missing outgoing metadata")
+		}
+		heights := md.Get(grpctypes.GRPCBlockHeightHeader)
+		if len(heights) != 1 || heights[0] != "1010" {
+			t.Fatalf("expected height header pinned to 1010, got %v", heights)
+		}
+	})
+
+	t.Run("failed capture can be retried on a later block", func(t *testing.T) {
+		store := newFakeStore()
+		guard := NewEarlyShareGuard(earlyshare.Config{Mode: earlyshare.ModeObserve}, store)
+		qc := &fakeESQueryClient{err: context.DeadlineExceeded}
+
+		guard.MaybeCapture(ctx, qc, stage, 1010, 1010)
+		if store.captured[stage] {
+			t.Fatal("stage must not be marked captured on query error")
+		}
+
+		// Retry a few blocks later succeeds and still pins the original target.
+		qc.err = nil
+		qc.resp = &types.QueryAllPoCV2StoreCommitsForStageResponse{
+			Commits: []*types.PoCV2StoreCommitWithAddress{
+				{ParticipantAddress: "a", ModelId: "m1", Count: 10, RootHash: []byte{1}},
+			},
+		}
+		guard.MaybeCapture(ctx, qc, stage, 1010, 1013)
+		if !store.captured[stage] {
+			t.Fatal("stage should be marked captured after retry")
+		}
+		md, _ := metadata.FromOutgoingContext(qc.lastCtx)
+		if got := md.Get(grpctypes.GRPCBlockHeightHeader); len(got) != 1 || got[0] != "1010" {
+			t.Fatalf("retry must pin the original target height, got %v", got)
 		}
 	})
 }

--- a/decentralized-api/poc/phase.go
+++ b/decentralized-api/poc/phase.go
@@ -1,6 +1,8 @@
 package poc
 
 import (
+	"math"
+
 	"decentralized-api/chainphase"
 
 	"github.com/productscience/inference/x/inference/types"
@@ -94,26 +96,39 @@ func ShouldAcceptStoreCommit(epochState *chainphase.EpochState, pocStageStartHei
 	return epochState.LatestEpoch.IsPoCExchangeWindow(currentHeight)
 }
 
+// fractionPPMScale is the denominator for integer fraction arithmetic
+// (parts per million).
+const fractionPPMScale = 1_000_000
+
 // EarlyShareCaptureTarget computes the stage height and the "first fraction"
 // capture target block height for the active PoC or confirmation-PoC generation
 // window. ok is false when no generation window is active or inputs are invalid,
 // in which case the early-share guard must skip (fail open).
 //
-//   - Regular PoC: stage = PocStartBlockHeight, target = stage + fraction*duration.
+// The offset is computed in integer arithmetic: the configured fraction is
+// quantized to parts-per-million once, then offset = round(duration*ppm/1e6).
+// This makes the target height a pure function of (duration, ppm), identical
+// on every validator. Float spellings that agree to six decimal places (e.g.
+// the code default 1.0/3.0 and the documented config literal 0.3333333333)
+// quantize to the same ppm and therefore the same target height, which the
+// previous float multiply did not guarantee.
+//
+//   - Regular PoC: stage = PocStartBlockHeight, target = stage + offset.
 //   - Confirmation PoC: stage = event.TriggerHeight,
-//     target = event.GenerationStartHeight + fraction*duration.
+//     target = event.GenerationStartHeight + offset.
 func EarlyShareCaptureTarget(epochState *chainphase.EpochState, firstFraction float64) (stageHeight int64, targetHeight int64, ok bool) {
 	if epochState.IsNilOrNotSynced() {
 		return 0, 0, false
 	}
-	if firstFraction <= 0 || firstFraction >= 1 {
+	ppm := int64(math.Round(firstFraction * fractionPPMScale))
+	if ppm <= 0 || ppm >= fractionPPMScale {
 		return 0, 0, false
 	}
 	duration := epochState.LatestEpoch.EpochParams.PocStageDuration
 	if duration <= 0 {
 		return 0, 0, false
 	}
-	offset := int64(float64(duration) * firstFraction)
+	offset := (duration*ppm + fractionPPMScale/2) / fractionPPMScale
 
 	// Confirmation PoC generation window during the inference phase.
 	if epochState.CurrentPhase == types.InferencePhase &&

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -185,19 +185,22 @@ func NewOffChainValidator(
 	}
 }
 
-// MaybeCaptureEarlyShare is invoked once per block by the dispatcher. It fires
-// the early-share capture only at the exact first-fraction height of the active
-// PoC/CPoC generation window, mirroring the other exact-match stage transitions
-// in handlePhaseTransitions. If the node is catching up across that height the
-// capture is skipped and the guard simply fails open for that stage.
+// MaybeCaptureEarlyShare is invoked once per block by the dispatcher. From the
+// first-fraction height until the end of the generation window it attempts the
+// early-share capture. The capture query is pinned to the exact first-fraction
+// height (see EarlyShareGuard.MaybeCapture), so a capture that runs a few
+// blocks late — after a restart, a slow query, or a transient chain error —
+// still records the identical consensus snapshot every other validator gets.
+// MaybeCapture is idempotent, so per-block re-invocation acts as a retry loop
+// that stops at the first completed capture.
 func (v *OffChainValidator) MaybeCaptureEarlyShare(epochState chainphase.EpochState) {
 	if v.artifactStore != nil {
 		v.maybeWarmEarlySnapshot(epochState)
 	}
 	if v.guard.Enabled() {
 		stage, target, ok := EarlyShareCaptureTarget(&epochState, v.guard.FirstFraction())
-		if ok && epochState.CurrentBlock.Height == target {
-			go v.guard.MaybeCapture(context.Background(), v.recorder.NewInferenceQueryClient(), stage, target, target)
+		if ok && epochState.CurrentBlock.Height >= target {
+			go v.guard.MaybeCapture(context.Background(), v.recorder.NewInferenceQueryClient(), stage, target, epochState.CurrentBlock.Height)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Hardening follow-up to #1416: deterministic early capture, a per-validator
quota on snapshot rebuilds, and observability to tighten limits later.

## Deterministic capture

- Capture query is pinned to the target height (`x-cosmos-block-height`), so
  every validator records byte-identical checkpoints; capture now retries on
  later blocks in the window (idempotent) instead of firing only at the exact
  height. Late capture requires the node to retain state for that height.
- Target height is computed in integer arithmetic (fraction quantized to ppm,
  `offset = round(duration * ppm / 1e6)`), so it no longer depends on the
  float spelling of the configured fraction.

## Rebuild quota

- Proof endpoints cap each validator at 3 distinct snapshot counts per
  `(stage, model)` (honest need is 2: early + final). Repeats are unlimited
  (cache hits). Excess returns 429 (retryable). Checked after signature
  verification. Can drop to 2 once pinned capture has converged on the
  network.
- Snapshot cache bumped from 4 to 6 entries: with 2 models the worst case
  pins 4 trees (early + historical final per model), which previously left
  zero rotation room.

An earlier revision also persisted flush-boundary roots and rejected unknown
snapshot counts outright; that was dropped after review. A roots-recovery
failure would have silently rejected legitimate historical counts
(fail-closed against honest validators), and the quota already bounds
probing at 3 cached rebuilds per validator per store.

## Observability

- Warning when a validator uses a third distinct count (before anything is
  rejected); quota rejections and root mismatches are tagged with validator
  address and model.
- Capture logs a deterministic digest of the checkpoint set; all validators
  must log the same digest per stage, so divergence is a one-line grep.

Guard stays disabled by default.

## Testing

`go test ./poc/... ./internal/server/public -count=1` passes, incl. `-race`.
New tests: height-pinned capture + retry, historical boundary counts served
after reopen, limiter scoping/TTL, handler 429 on 4th distinct count,
identical targets for three float spellings of 1/3.