### PR TITLE
Aggregated gateway fixes

### DIFF
--- a/deploy/join/docker-compose.devshard-gateway.yml
+++ b/deploy/join/docker-compose.devshard-gateway.yml
@@ -1,4 +1,67 @@
 services:
+  # Optional HTTPS frontend for standalone devshard-gateway.
+  #
+  # HTTP-01 certificate:
+  #   export DEVSHARD_GATEWAY_DOMAIN=your.domain.com
+  #
+  # Cloudflare DNS-01 certificate:
+  #   export DEVSHARD_GATEWAY_DOMAIN=your.domain.com
+  #   export CLOUDFLARE_API_TOKEN=<cloudflare token with DNS edit access>
+  #
+  # Start:
+  #   docker compose --profile ssl -f docker-compose.devshard-gateway.yml up -d
+  devshard-gateway-caddy:
+    profiles:
+      - ssl
+    container_name: ${DEVSHARD_CADDY_INSTANCE_NAME:-devshard-gateway-caddy}
+    image: gonka-devshard-gateway-caddy:local
+    build:
+      dockerfile_inline: |
+        FROM caddy:2-builder AS builder
+        RUN xcaddy build --with github.com/caddy-dns/cloudflare
+
+        FROM caddy:2
+        COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+    command:
+      - sh
+      - -ec
+      - |
+        if [ -z "$${DEVSHARD_GATEWAY_DOMAIN:-}" ]; then
+          echo "DEVSHARD_GATEWAY_DOMAIN is required"
+          exit 1
+        fi
+
+        {
+          if [ -n "$${CLOUDFLARE_API_TOKEN:-}" ]; then
+            printf '{\n  acme_dns cloudflare {env.CLOUDFLARE_API_TOKEN}\n}\n\n'
+          fi
+          printf '%s {\n' "$${DEVSHARD_GATEWAY_DOMAIN}"
+          printf '  @metrics path /metrics*\n'
+          printf '  respond @metrics 404\n\n'
+          printf '  handle /grafana* {\n'
+          printf '    reverse_proxy grafana:3000\n'
+          printf '  }\n\n'
+          printf '  reverse_proxy devshard-gateway:8080\n'
+          printf '}\n'
+        } > /tmp/Caddyfile
+
+        exec caddy run --config /tmp/Caddyfile --adapter caddyfile
+    environment:
+      - DEVSHARD_GATEWAY_DOMAIN=${DEVSHARD_GATEWAY_DOMAIN:-}
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:-}
+    volumes:
+      - caddy_devshard_data:/data
+      - caddy_devshard_config:/config
+    ports:
+      - "${DEVSHARD_HTTPS_HTTP_PORT:-80}:80"
+      - "${DEVSHARD_HTTPS_PORT:-443}:443"
+    networks:
+      - join_default
+    depends_on:
+      devshard-gateway:
+        condition: service_started
+    restart: unless-stopped
+
   devshard-gateway:
     container_name: ${DEVSHARD_INSTANCE_NAME:-devshard-gateway}
     image: ghcr.io/gonka-ai/devshard-gateway:mainnet-v0.2.13-latest
@@ -26,3 +89,7 @@ services:
 networks:
   join_default:
     external: true
+
+volumes:
+  caddy_devshard_data:
+  caddy_devshard_config:

--- a/deploy/join/observability/grafana/dashboards/gonka-gateway-observability.json
+++ b/deploy/join/observability/grafana/dashboards/gonka-gateway-observability.json
@@ -1,0 +1,1699 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 104,
+      "panels": [],
+      "title": "Overall Gateway Health",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 110,
+      "panels": [],
+      "title": "Nonce Consumption",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Gateway-observed nonce-consuming actions per accepted non-cache request. This is not voting amount.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 22
+      },
+      "id": 111,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(devshard_gateway_slot_decisions_total{model=~\"$model\"}[$__range])) / clamp_min(sum(increase(devshard_gateway_requests_total{model=~\"$model\",outcome!~\"cached|invalid_request|model_rejected|gateway_limited\"}[$__range])), 1)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total nonces / accepted request",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Real participant sends per accepted non-cache request.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 5,
+        "y": 22
+      },
+      "id": 112,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(devshard_gateway_slot_decisions_total{model=~\"$model\",decision=\"real_send\"}[$__range])) / clamp_min(sum(increase(devshard_gateway_requests_total{model=~\"$model\",outcome!~\"cached|invalid_request|model_rejected|gateway_limited\"}[$__range])), 1)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Real sends / accepted request",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Prepared nonces where the gateway intentionally did not contact a participant.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 10,
+        "y": 22
+      },
+      "id": 113,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(devshard_gateway_slot_decisions_total{model=~\"$model\",decision=\"ghost_no_send\"}[$__range])) / clamp_min(sum(increase(devshard_gateway_requests_total{model=~\"$model\",outcome!~\"cached|invalid_request|model_rejected|gateway_limited\"}[$__range])), 1)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "No-send burns / accepted request",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Top nonce-consuming gateway actions by kind and reason. This uses the existing slot decision metric but labels it by nonce semantics.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 22
+      },
+      "id": 114,
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(devshard_gateway_slot_decisions_total{model=~\"$model\"}[$__rate_interval])) by (decision, reason))",
+          "legendFormat": "{{decision}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Nonce consumption by reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Gateway-observed nonce-consuming actions per accepted non-cache request over time. Spikes indicate PoC/cPoC, quarantine, throttling, capability skips, or redundancy pressure. This is not voting amount.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 115,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_slot_decisions_total{model=~\"$model\"}[5m])) / clamp_min(sum(rate(devshard_gateway_requests_total{model=~\"$model\",outcome!~\"cached|invalid_request|model_rejected|gateway_limited\"}[5m])), 0.001)",
+          "legendFormat": "total nonces / accepted request",
+          "refId": "A"
+        }
+      ],
+      "title": "Total nonces / accepted request over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Prometheus scrape state for the gateway.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "down"
+                },
+                "1": {
+                  "text": "up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "up{job=\"devshard-gateway\"}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Scrape",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Selected-window gateway request rate.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 3,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(devshard_gateway_requests_total{model=~\"$model\"}[$__range])) / $__range_s",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Request Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Successful or cached user requests divided by all requests.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 7,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(devshard_gateway_requests_total{model=~\"$model\",outcome=~\"success|cached\"}[$__range])) / clamp_min(sum(increase(devshard_gateway_requests_total{model=~\"$model\"}[$__range])), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Range User Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "User-visible failures in the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 11,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(devshard_gateway_critical_user_failures_total{model=~\"$model\"}[$__range]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Range Critical User Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Cached requests divided by all requests.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 15,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(devshard_gateway_requests_total{model=~\"$model\",outcome=\"cached\"}[$__range])) / clamp_min(sum(increase(devshard_gateway_requests_total{model=~\"$model\"}[$__range])), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Range Cache Hit Share",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Gateway-wide capacity scale applied to limiter caps.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 19,
+        "y": 1
+      },
+      "id": 73,
+      "options": {
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "devshard_gateway_capacity_scale",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Capacity Scale",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Lowest capacity scale among selected models.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 74,
+      "options": {
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "min(devshard_gateway_capacity_scale_by_model{model=~\"$model\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Worst Model Capacity Scale",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Final user outcomes by bounded reason.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 5
+      },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_requests_total{model=~\"$model\"}[$__rate_interval])) by (outcome, reason)",
+          "legendFormat": "{{outcome}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "What Users Saw by Outcome and Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Top critical user-visible failure reasons.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 5
+      },
+      "id": 9,
+      "targets": [
+        {
+          "expr": "topk(15, sum(increase(devshard_gateway_critical_user_failures_total{model=~\"$model\",reason=~\"$reason\"}[$__range])) by (reason))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top User-Visible Failure Reasons",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Gateway-wide chat route p95. Not participant latency.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 5
+      },
+      "id": 10,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_http_request_duration_seconds_bucket{path=~\"/v1/.+chat.+\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p95 route latency",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Chat Route p95 (gateway-wide)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Gateway limiter rejections by reason.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
+      "id": 11,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_limit_rejections_total[$__rate_interval])) by (reason)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Admission Rejections by Reason (gateway-wide)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current limiter load and effective caps.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
+      "id": 12,
+      "targets": [
+        {
+          "expr": "devshard_gateway_inflight_requests",
+          "legendFormat": "inflight requests",
+          "refId": "A"
+        },
+        {
+          "expr": "devshard_gateway_effective_max_concurrent_requests",
+          "legendFormat": "request cap",
+          "refId": "B"
+        },
+        {
+          "expr": "devshard_gateway_inflight_input_tokens",
+          "legendFormat": "inflight input tokens",
+          "refId": "C"
+        },
+        {
+          "expr": "devshard_gateway_effective_max_input_tokens_in_flight",
+          "legendFormat": "input token cap",
+          "refId": "D"
+        }
+      ],
+      "title": "Active Requests and Input Tokens",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Capacity scale over time by model.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "id": 98,
+      "targets": [
+        {
+          "expr": "devshard_gateway_capacity_scale_by_model{model=~\"$model\"}",
+          "refId": "A",
+          "legendFormat": "{{model}}"
+        }
+      ],
+      "title": "Model Capacity Scale by Model",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Successful user requests that hid participant or policy failures.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "id": 99,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_user_requests_with_hidden_failure_total{model=~\"$model\",reason=~\"$reason\"}[$__rate_interval])) by (reason)",
+          "refId": "A",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "title": "Successful Requests with Hidden Participant Failures by Reason",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 105,
+      "panels": [],
+      "title": "Suspect Addresses (start here)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Address-level suspect queue. Counts are selected-window increases; rates use finished or started attempts as stated in the column header.",
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 103,
+      "targets": [
+        {
+          "expr": "round(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "round(sum by (participant_key, model) (increase(devshard_gateway_attempts_terminal_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "B",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_terminal_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_terminal_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts))",
+          "refId": "C",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts))",
+          "refId": "D",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "round((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "E",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "round(((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "F",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "round(((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "G",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "round(((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "H",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "round(((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "I",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "round(((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "J",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "round(((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts)))",
+          "refId": "K",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_gateway_participant_first_content_seconds_bucket{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (participant_key, model, le)) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts))",
+          "refId": "L",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_gateway_participant_receipt_seconds_bucket{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (participant_key, model, le)) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts))",
+          "refId": "M",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_gateway_participant_prefill_seconds_per_input_token_bucket{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (participant_key, model, le)) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts))",
+          "refId": "N",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_gateway_participant_total_attempt_seconds_bucket{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (participant_key, model, le)) and on (participant_key, model) topk(30, ((((sum by (participant_key, model) (increase(devshard_gateway_attempt_failures_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_slot_decisions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",decision!=\"real_send\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_no_winner_attempts_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_timeout_actions_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_transport_errors_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\",path_kind=\"inference\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])))) + ((sum by (participant_key, model) (increase(devshard_gateway_participant_limit_rejections_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))) or on (participant_key, model) (0 * sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range]))))) / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)) and on (participant_key, model) (sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total{participant_key!=\"unknown\",participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) >= $min_attempts))",
+          "refId": "O",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "title": "Suspect Address Scorecard",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "links": [
+            {
+              "title": "Drill into this address",
+              "url": "/d/gonka-gateway-observability/gonka-gateway-observability?var-model=${__data.fields.model}&var-participant_key=${__data.fields.participant_key}"
+            }
+          ]
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "participant_key"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 360
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "model"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 220
+              }
+            ]
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "participant_key": 0,
+              "model": 1,
+              "Value #A": 2,
+              "Value #B": 3,
+              "Value #C": 4,
+              "Value #D": 5,
+              "Value #E": 6,
+              "Value #F": 7,
+              "Value #G": 8,
+              "Value #H": 9,
+              "Value #I": 10,
+              "Value #J": 11,
+              "Value #K": 12,
+              "Value #L": 13,
+              "Value #M": 14,
+              "Value #N": 15,
+              "Value #O": 16
+            },
+            "renameByName": {
+              "participant_key": "participant_key",
+              "model": "model",
+              "Value #A": "started_attempts\ncount",
+              "Value #B": "finished_attempts\ncount",
+              "Value #C": "failure_rate\nfailed/finished",
+              "Value #D": "issues_per_started\ncount/start",
+              "Value #E": "issue_count\ncount",
+              "Value #F": "failed_attempts\ncount",
+              "Value #G": "no_send_slots\ncount",
+              "Value #H": "no_winner_attempts\ncount",
+              "Value #I": "timeout_skipped_failed\ncount",
+              "Value #J": "inference_transport_errors\ncount",
+              "Value #K": "limit_rejections\ncount",
+              "Value #L": "p95_ttft_first_content\nseconds",
+              "Value #M": "p95_receipt\nseconds",
+              "Value #N": "p95_prefill_per_input_token\nseconds",
+              "Value #O": "p95_total_attempt\nseconds",
+              "Value": "started_attempts\ncount"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 106,
+      "panels": [],
+      "title": "Explain Selected Participant",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Sent attempts by role and start reason.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 58
+      },
+      "id": 14,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_attempts_started_total{participant_key=~\"$participant_key\",model=~\"$model\",reason=~\"$reason\"}[$__rate_interval])) by (role, reason)",
+          "legendFormat": "{{role}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Real Attempts Started by Role and Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Terminal attempt outcomes by visibility.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 58
+      },
+      "id": 15,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_attempts_terminal_total{participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (outcome, visibility)",
+          "legendFormat": "{{outcome}} / {{visibility}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Terminal Attempts by Outcome and Visibility",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Failed attempts with reason preserved.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 58
+      },
+      "id": 16,
+      "targets": [
+        {
+          "expr": "topk(12, sum(rate(devshard_gateway_attempt_failures_total{participant_key=~\"$participant_key\",model=~\"$model\",reason=~\"$reason\"}[$__rate_interval])) by (reason, visibility))",
+          "legendFormat": "{{reason}} / {{visibility}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Attempts by Reason and Visibility",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Share of attributed user-visible wins by address.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 66
+      },
+      "id": 17,
+      "targets": [
+        {
+          "expr": "topk(20, (sum by (participant_key, model) (increase(devshard_gateway_user_visible_wins_total{participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) / clamp_min(sum by (model) (increase(devshard_gateway_user_visible_wins_total{model=~\"$model\"}[$__range])), 1)))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "User-Visible Winner Share by Participant",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Count of attributed user-visible wins by address.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 66
+      },
+      "id": 76,
+      "targets": [
+        {
+          "expr": "topk(20, sum(increase(devshard_gateway_user_visible_wins_total{participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])) by (participant_key, model))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "User-Visible Winner Count by Participant",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Receipt p95 by address and model.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 66
+      },
+      "id": 101,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_gateway_participant_receipt_seconds_bucket{participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (participant_key, model, le))",
+          "refId": "A",
+          "legendFormat": "{{participant_key}} / {{model}}"
+        }
+      ],
+      "title": "Participant Receipt p95 by Address",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "TTFT-equivalent first-content p95 by address and model.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 74
+      },
+      "id": 22,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_gateway_participant_first_content_seconds_bucket{participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (participant_key, model, le))",
+          "legendFormat": "{{participant_key}} / {{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Participant TTFT / First Content p95 by Address",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Prefill-after-receipt p95 per input token by address and model.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 74
+      },
+      "id": 102,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_gateway_participant_prefill_seconds_per_input_token_bucket{participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (participant_key, model, le))",
+          "refId": "A",
+          "legendFormat": "{{participant_key}} / {{model}}"
+        }
+      ],
+      "title": "Participant Prefill per Input Token p95 by Address",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Address-level total attempt p95.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 74
+      },
+      "id": 24,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(devshard_gateway_participant_total_attempt_seconds_bucket{participant_key=~\"$participant_key\",model=~\"$model\"}[$__rate_interval])) by (participant_key, model, le))",
+          "legendFormat": "{{participant_key}} / {{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Participant Total Attempt Time p95 by Address",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "No-receipt and empty-stream failures divided by finished attempts.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 82
+      },
+      "id": 47,
+      "targets": [
+        {
+          "expr": "topk(20, (sum by (participant_key, model, reason) (increase(devshard_gateway_attempt_failures_total{participant_key=~\"$participant_key\",model=~\"$model\",reason=~\"no_receipt|empty_stream\"}[$__range])) / ignoring(reason) group_left clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_terminal_total{participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "No-Receipt and Empty-Stream Rates",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Transport and EOF failures divided by finished attempts.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 82
+      },
+      "id": 48,
+      "targets": [
+        {
+          "expr": "topk(20, (sum by (participant_key, model, reason) (increase(devshard_gateway_attempt_failures_total{participant_key=~\"$participant_key\",model=~\"$model\",reason=~\"eof_transport|error_stream|transport_error\"}[$__range])) / ignoring(reason) group_left clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_terminal_total{participant_key=~\"$participant_key\",model=~\"$model\"}[$__range])), 1)))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transport and EOF Failure Rates",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current quarantine or no-winner mode by address.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 82
+      },
+      "id": 49,
+      "targets": [
+        {
+          "expr": "sum(devshard_gateway_participant_quarantine_state{participant_key=~\"$participant_key\",model=~\"$model\"}) by (participant_key, model, mode)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current Participant Quarantine Mode",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "User-visible winners that later recorded failures.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 90
+      },
+      "id": 28,
+      "targets": [
+        {
+          "expr": "topk(15, sum(increase(devshard_gateway_attempt_failures_total{participant_key=~\"$participant_key\",model=~\"$model\",reason=~\"$reason\",visibility=\"user_visible_winner\"}[$__range])) by (participant_key, model, reason))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Winner Failures After User-Visible Content",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 98
+      },
+      "id": 107,
+      "panels": [],
+      "title": "Global Cost and Policy Pressure",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "All real sends divided by user requests.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 99
+      },
+      "id": 18,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_attempts_started_total{model=~\"$model\"}[$__rate_interval])) / clamp_min(sum(rate(devshard_gateway_requests_total{model=~\"$model\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "sent attempts / request",
+          "refId": "A"
+        }
+      ],
+      "title": "Global Sent Attempts per User Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Failed sends divided by successful user requests.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 99
+      },
+      "id": 19,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_attempts_terminal_total{model=~\"$model\",outcome=~\"failed|not_finished\"}[$__rate_interval])) / clamp_min(sum(rate(devshard_gateway_requests_total{model=~\"$model\",outcome=\"success\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "failed sent attempts / successful request",
+          "refId": "A"
+        }
+      ],
+      "title": "Global Failed Sends per Successful User Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Extra-role sends divided by user requests.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 99
+      },
+      "id": 31,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_attempts_started_total{model=~\"$model\",role=\"extra\"}[$__rate_interval])) / clamp_min(sum(rate(devshard_gateway_requests_total{model=~\"$model\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "extra sends / request",
+          "refId": "A"
+        }
+      ],
+      "title": "Extra Real Sends per User Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "No-send slot decisions divided by user requests.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 107
+      },
+      "id": 32,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_slot_decisions_total{model=~\"$model\",escrow_id=~\"$escrow_id\",decision!=\"real_send\"}[$__rate_interval])) / clamp_min(sum(rate(devshard_gateway_requests_total{model=~\"$model\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "no-send slots / request",
+          "refId": "A"
+        }
+      ],
+      "title": "Ghost or No-Send Slots per User Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Top no-send slot reasons.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 107
+      },
+      "id": 38,
+      "targets": [
+        {
+          "expr": "topk(20, sum(increase(devshard_gateway_slot_decisions_total{model=~\"$model\",escrow_id=~\"$escrow_id\",reason=~\"$reason\",decision!=\"real_send\"}[$__range])) by (reason, quarantine_mode))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Skipped-Slot Reasons",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Expected, started, completed, skipped, and failed timeout work.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 107
+      },
+      "id": 100,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_timeout_actions_total{participant_key=~\"$participant_key\",model=~\"$model\",reason=~\"$reason\"}[$__rate_interval])) by (kind, action)",
+          "refId": "A",
+          "legendFormat": "{{kind}} / {{action}}"
+        }
+      ],
+      "title": "Timeout Actions by Kind and Action",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Skipped and failed timeout work by reason.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 115
+      },
+      "id": 58,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_timeout_actions_total{participant_key=~\"$participant_key\",model=~\"$model\",action=~\"skipped|failed\",reason=~\"$reason\"}[$__rate_interval])) by (action, reason)",
+          "legendFormat": "{{action}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Timeout Skip and Failure Reasons Over Time",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 123
+      },
+      "id": 108,
+      "panels": [],
+      "title": "Escrow and Runtime Diagnostics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "No-send pressure by model and escrow.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 124
+      },
+      "id": 53,
+      "targets": [
+        {
+          "expr": "topk(40, sum(increase(devshard_gateway_slot_decisions_total{model=~\"$model\",escrow_id=~\"$escrow_id\",decision!=\"real_send\"}[$__range])) by (model, escrow_id, reason))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Model x Escrow No-Send Pressure",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Runtime picker choices by selected escrow and model.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 124
+      },
+      "id": 54,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_picker_choice_total{model=~\"$model\",devshard_id=~\"$escrow_id\"}[$__rate_interval])) by (devshard_id, model)",
+          "legendFormat": "{{devshard_id}} / {{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Picker Choices by Model and Escrow",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Blocked participant count by selected escrow and model.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 124
+      },
+      "id": 42,
+      "targets": [
+        {
+          "expr": "devshard_gateway_escrow_blocked_participants{model=~\"$model\",devshard_id=~\"$escrow_id\"}",
+          "legendFormat": "{{devshard_id}} / {{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Escrow Blocked Participant Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Transport errors outside inference path, such as timeout verification, challenge receipt, gossip, or query paths.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 132
+      },
+      "id": 109,
+      "targets": [
+        {
+          "expr": "sum(rate(devshard_gateway_participant_transport_errors_total{path_kind!=\"inference\"}[$__rate_interval])) by (path_kind, status)",
+          "legendFormat": "{{path_kind}} / {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Non-Inference Transport Errors by Path",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "gateway",
+    "devshard",
+    "observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values({__name__=~\"devshard_gateway_capacity_scale_by_model|devshard_gateway_requests_total|devshard_gateway_attempts_started_total|devshard_gateway_attempt_failures_total|devshard_gateway_slot_decisions_total|devshard_gateway_timeout_actions_total\"}, model)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "model",
+        "name": "model",
+        "query": {
+          "query": "label_values({__name__=~\"devshard_gateway_capacity_scale_by_model|devshard_gateway_requests_total|devshard_gateway_attempts_started_total|devshard_gateway_attempt_failures_total|devshard_gateway_slot_decisions_total|devshard_gateway_timeout_actions_total\"}, model)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values({__name__=~\"devshard_gateway_attempts_started_total|devshard_gateway_attempts_terminal_total|devshard_gateway_attempt_failures_total|devshard_gateway_user_visible_wins_total|devshard_gateway_slot_decisions_total|devshard_gateway_no_winner_attempts_total|devshard_gateway_participant_quarantine_state|devshard_gateway_timeout_actions_total\",model=~\"$model\"}, participant_key)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "participant_key (optional drilldown)",
+        "name": "participant_key",
+        "query": {
+          "query": "label_values({__name__=~\"devshard_gateway_attempts_started_total|devshard_gateway_attempts_terminal_total|devshard_gateway_attempt_failures_total|devshard_gateway_user_visible_wins_total|devshard_gateway_slot_decisions_total|devshard_gateway_no_winner_attempts_total|devshard_gateway_participant_quarantine_state|devshard_gateway_timeout_actions_total\",model=~\"$model\"}, participant_key)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values({__name__=~\"devshard_gateway_attempt_failures_total|devshard_gateway_user_requests_with_hidden_failure_total|devshard_gateway_slot_decisions_total|devshard_gateway_timeout_actions_total|devshard_gateway_critical_user_failures_total|devshard_gateway_no_winner_attempts_total\",model=~\"$model\"}, reason)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "reason (optional detail filter)",
+        "name": "reason",
+        "query": {
+          "query": "label_values({__name__=~\"devshard_gateway_attempt_failures_total|devshard_gateway_user_requests_with_hidden_failure_total|devshard_gateway_slot_decisions_total|devshard_gateway_timeout_actions_total|devshard_gateway_critical_user_failures_total|devshard_gateway_no_winner_attempts_total\",model=~\"$model\"}, reason)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(devshard_gateway_slot_decisions_total{model=~\"$model\"}, escrow_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "escrow_id",
+        "name": "escrow_id",
+        "query": {
+          "query": "label_values(devshard_gateway_slot_decisions_total{model=~\"$model\"}, escrow_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "20",
+          "value": "20"
+        },
+        "hide": 0,
+        "label": "min_attempts",
+        "name": "min_attempts",
+        "query": "5,10,20,50,100",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "",
+  "title": "Gonka Gateway Observability",
+  "uid": "gonka-gateway-observability",
+  "version": 17,
+  "weekStart": ""
+}

--- a/deploy/join/observability/prometheus.yml
+++ b/deploy/join/observability/prometheus.yml
@@ -19,6 +19,12 @@ scrape_configs:
       - url: http://api:9100/sd/devshardd
         refresh_interval: 15s
 
+  - job_name: devshard-gateway
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - devshard-gateway:8080
+
   - job_name: gonka-node
     static_configs:
       - targets:

--- a/devshard/Dockerfile
+++ b/devshard/Dockerfile
@@ -7,6 +7,8 @@ FROM --platform=$BUILDPLATFORM golang:1.24.2-alpine3.21 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG DEVSHARD_VERSION=dev
+ARG DEVSHARD_PROTOCOL_VERSION=v2
 
 WORKDIR /app
 
@@ -20,7 +22,8 @@ COPY . .
 RUN --mount=type=cache,id=go-build-cache-devshard,target=/root/.cache/go-build \
     --mount=type=cache,id=go-mod-cache-devshard,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -o /devshardctl ./cmd/devshardctl/
+    go build -ldflags "-X main.Version=${DEVSHARD_VERSION} -X devshard/types.buildStateRootProtocolVersion=${DEVSHARD_PROTOCOL_VERSION}" \
+    -o /devshardctl ./cmd/devshardctl/
 
 ################################################################################
 # Final image

--- a/devshard/cmd/devshardctl/capacity_state_test.go
+++ b/devshard/cmd/devshardctl/capacity_state_test.go
@@ -372,7 +372,7 @@ func TestGatewayLimiterUnlimitedBaselinePreservedUnderScale(t *testing.T) {
 
 func TestDevshardRuntimeLoadIsActivePerWeight(t *testing.T) {
 	rt := &devshardRuntime{}
-	rt.activeRequests.Store(2)
+	rt.activeUserRequests.Store(2)
 	rt.reservedTokens.Store(3) // reserved tokens no longer factor in.
 
 	require.InDelta(t, 0.5, rt.load(4.0), 1e-9)

--- a/devshard/cmd/devshardctl/capacity_state_test.go
+++ b/devshard/cmd/devshardctl/capacity_state_test.go
@@ -334,6 +334,10 @@ func TestGatewaySelectsPoCWeightConcurrencyRate(t *testing.T) {
 	t.Cleanup(func() { setPoCPhaseState(false, "") })
 	poc := g.limiterCapacityForModel("Model/A")
 	require.InDelta(t, 10.0, poc.MaxConcurrentPer10000Weight, 1e-9)
+
+	g.phaseGate.storeSnapshot(ChainPhaseSnapshot{ConfirmationPoCPhase: confirmationPoCGeneration, BlockReason: "confirmation_poc"})
+	confirmationPoc := g.limiterCapacityForModel("Model/A")
+	require.InDelta(t, 10.0, confirmationPoc.MaxConcurrentPer10000Weight, 1e-9)
 }
 
 func TestGatewayLimiterAcquireBlocksWhenScaledToZero(t *testing.T) {

--- a/devshard/cmd/devshardctl/capacity_state_test.go
+++ b/devshard/cmd/devshardctl/capacity_state_test.go
@@ -334,10 +334,6 @@ func TestGatewaySelectsPoCWeightConcurrencyRate(t *testing.T) {
 	t.Cleanup(func() { setPoCPhaseState(false, "") })
 	poc := g.limiterCapacityForModel("Model/A")
 	require.InDelta(t, 10.0, poc.MaxConcurrentPer10000Weight, 1e-9)
-
-	g.phaseGate.storeSnapshot(ChainPhaseSnapshot{ConfirmationPoCPhase: confirmationPoCGeneration, BlockReason: "confirmation_poc"})
-	confirmationPoc := g.limiterCapacityForModel("Model/A")
-	require.InDelta(t, 10.0, confirmationPoc.MaxConcurrentPer10000Weight, 1e-9)
 }
 
 func TestGatewayLimiterAcquireBlocksWhenScaledToZero(t *testing.T) {

--- a/devshard/cmd/devshardctl/chain_tx_rest.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -113,7 +115,49 @@ func NewRESTChainTxClient(cfg RESTChainTxConfig) (*RESTChainTxClient, error) {
 	}, nil
 }
 
-func (c *RESTChainTxClient) CreateDevshardEscrow(ctx context.Context, signer *signing.Secp256k1Signer, amount uint64, modelID string) (*CreateDevshardEscrowResult, error) {
+// txHashFromBytes returns the cosmos tx hash (uppercase-hex SHA-256 of the tx
+// bytes), computable before broadcast and equal to the hash the node returns.
+func txHashFromBytes(txBytes []byte) string {
+	sum := sha256.Sum256(txBytes)
+	return strings.ToUpper(hex.EncodeToString(sum[:]))
+}
+
+// errTxNotFound marks a tx that is not on chain (404) — distinct from one that
+// committed but failed. The tx may still land until its unordered TTL elapses.
+var errTxNotFound = errors.New("tx not found on chain")
+
+// GetTxEscrowID resolves a create tx hash to its escrow_id in one lookup;
+// found=false when the tx is absent or failed (no escrow), error when unreachable.
+func (c *RESTChainTxClient) GetTxEscrowID(ctx context.Context, txHash string) (uint64, bool, error) {
+	var lastErr error
+	hasNotFoundError := false
+	for _, baseURL := range c.txQueryBaseURLs() {
+		var payload txResponseEnvelope
+		err := c.getJSONFromBaseURL(ctx, baseURL, "/cosmos/tx/v1beta1/txs/"+url.PathEscape(txHash), &payload)
+		if err != nil {
+			if isNotFoundError(err) {
+				hasNotFoundError = true // this endpoint lacks it; try the fallback before deciding
+				continue
+			}
+			lastErr = fmt.Errorf("%s: %w", baseURL, err)
+			continue
+		}
+		if payload.TxResponse.Code != 0 {
+			return 0, false, nil // tx committed but failed → no escrow created
+		}
+		if escrowID, ok := payload.TxResponse.createdEscrowID(); ok {
+			return escrowID, true, nil
+		}
+		lastErr = fmt.Errorf("tx %s committed via %s but escrow_id event was not found", txHash, baseURL)
+	}
+	// Only conclude "not on chain" when every reachable endpoint agreed on 404.
+	if lastErr == nil && hasNotFoundError {
+		return 0, false, errTxNotFound
+	}
+	return 0, false, lastErr
+}
+
+func (c *RESTChainTxClient) CreateDevshardEscrow(ctx context.Context, signer *signing.Secp256k1Signer, amount uint64, modelID string, onPrepared func(txHash string) error) (*CreateDevshardEscrowResult, error) {
 	if c == nil {
 		return nil, fmt.Errorf("chain tx client is nil")
 	}
@@ -145,9 +189,19 @@ func (c *RESTChainTxClient) CreateDevshardEscrow(ctx context.Context, signer *si
 	if err != nil {
 		return nil, err
 	}
-	txHash, err := c.broadcastTx(ctx, txBytes)
+	// Record the intent (precomputed hash) before the irreversible broadcast; abort if it fails.
+	txHash := txHashFromBytes(txBytes)
+	if onPrepared != nil {
+		if err := onPrepared(txHash); err != nil {
+			return nil, fmt.Errorf("record escrow create intent before broadcast: %w", err)
+		}
+	}
+	broadcastHash, err := c.broadcastTx(ctx, txBytes)
 	if err != nil {
 		return nil, err
+	}
+	if !strings.EqualFold(broadcastHash, txHash) {
+		return nil, fmt.Errorf("tx hash mismatch: precomputed %s, node returned %s", txHash, broadcastHash)
 	}
 	escrowID, err := c.waitForCreatedEscrowID(ctx, txHash)
 	if err != nil {
@@ -330,6 +384,16 @@ func (c *RESTChainTxClient) getJSONFromBaseURL(ctx context.Context, baseURL, pat
 		return fmt.Errorf("GET %s status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// isNotFoundError reports whether a chain GET failed with 404 / not-found rather
+// than a transient error.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "status 404") || strings.Contains(s, "not found")
 }
 
 func (c *RESTChainTxClient) postJSON(ctx context.Context, path string, in any, out any) error {

--- a/devshard/cmd/devshardctl/chain_tx_rest.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest.go
@@ -369,6 +369,28 @@ func (c *RESTChainTxClient) getJSON(ctx context.Context, path string, out any) e
 	return c.getJSONFromBaseURL(ctx, c.baseURL, path, out)
 }
 
+// chainHTTPError is returned by getJSONFromBaseURL on non-200 responses.
+type chainHTTPError struct {
+	method string
+	path   string
+	status int
+	body   string
+}
+
+func (e *chainHTTPError) Error() string {
+	if e == nil {
+		return "chain HTTP error"
+	}
+	return fmt.Sprintf("%s %s status %d: %s", e.method, e.path, e.status, e.body)
+}
+
+func (e *chainHTTPError) StatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.status
+}
+
 func (c *RESTChainTxClient) getJSONFromBaseURL(ctx context.Context, baseURL, path string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
 	if err != nil {
@@ -381,19 +403,21 @@ func (c *RESTChainTxClient) getJSONFromBaseURL(ctx context.Context, baseURL, pat
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("GET %s status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+		return &chainHTTPError{
+			method: http.MethodGet,
+			path:   path,
+			status: resp.StatusCode,
+			body:   strings.TrimSpace(string(body)),
+		}
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
 }
 
-// isNotFoundError reports whether a chain GET failed with 404 / not-found rather
-// than a transient error.
+// isNotFoundError reports whether a chain GET failed with HTTP 404 rather than
+// a transient error.
 func isNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "status 404") || strings.Contains(s, "not found")
+	var httpErr *chainHTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode() == http.StatusNotFound
 }
 
 func (c *RESTChainTxClient) postJSON(ctx context.Context, path string, in any, out any) error {

--- a/devshard/cmd/devshardctl/chain_tx_rest_test.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -194,6 +195,30 @@ func escrowIDQueryServer(t *testing.T, txHash string, escrowID uint64) *httptest
 			},
 		})
 	}))
+}
+
+func TestIsNotFoundError_Status404(t *testing.T) {
+	err := fmt.Errorf("http://primary: %w", &chainHTTPError{
+		method: http.MethodGet,
+		path:   "/cosmos/tx/v1beta1/txs/ABC",
+		status: http.StatusNotFound,
+		body:   "tx not found",
+	})
+	require.True(t, isNotFoundError(err))
+}
+
+func TestIsNotFoundError_500WithNotFoundBody(t *testing.T) {
+	err := fmt.Errorf("http://fallback: %w", &chainHTTPError{
+		method: http.MethodGet,
+		path:   "/cosmos/tx/v1beta1/txs/ABC",
+		status: http.StatusInternalServerError,
+		body:   `{"message":"tx not found"}`,
+	})
+	require.False(t, isNotFoundError(err))
+
+	var httpErr *chainHTTPError
+	require.True(t, errors.As(err, &httpErr))
+	require.Equal(t, http.StatusInternalServerError, httpErr.StatusCode())
 }
 
 // TestRESTChainTxClient_GetTxEscrowIDTriesFallbackOn404 pins the recovery path:

--- a/devshard/cmd/devshardctl/chain_tx_rest_test.go
+++ b/devshard/cmd/devshardctl/chain_tx_rest_test.go
@@ -20,6 +20,7 @@ func TestRESTChainTxClient_CreateDevshardEscrow(t *testing.T) {
 	require.NoError(t, err)
 
 	var broadcastSeen bool
+	var expectedHash string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/cosmos/auth/v1beta1/accounts/" + signer.Address():
@@ -44,18 +45,20 @@ func TestRESTChainTxClient_CreateDevshardEscrow(t *testing.T) {
 			require.NotEmpty(t, txBytes)
 			assertUnorderedTx(t, txBytes)
 			broadcastSeen = true
+			// A real node returns SHA-256(txBytes); the client precomputes the same.
+			expectedHash = txHashFromBytes(txBytes)
 			writeTestJSON(t, w, map[string]any{
 				"tx_response": map[string]any{
 					"code":   0,
-					"txhash": "ABC123",
+					"txhash": expectedHash,
 				},
 			})
-		case "/cosmos/tx/v1beta1/txs/ABC123":
+		case "/cosmos/tx/v1beta1/txs/" + expectedHash:
 			require.True(t, broadcastSeen)
 			writeTestJSON(t, w, map[string]any{
 				"tx_response": map[string]any{
 					"code":   0,
-					"txhash": "ABC123",
+					"txhash": expectedHash,
 					"events": []map[string]any{{
 						"type": "devshard_escrow_created",
 						"attributes": []map[string]string{{
@@ -81,10 +84,11 @@ func TestRESTChainTxClient_CreateDevshardEscrow(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	result, err := client.CreateDevshardEscrow(t.Context(), signer, 1_000_000, "Qwen/Test")
+	result, err := client.CreateDevshardEscrow(t.Context(), signer, 1_000_000, "Qwen/Test", nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(42), result.EscrowID)
-	require.Equal(t, "ABC123", result.TxHash)
+	require.NotEmpty(t, expectedHash)
+	require.Equal(t, expectedHash, result.TxHash)
 	require.Equal(t, signer.Address(), result.Creator)
 }
 
@@ -93,6 +97,7 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 	require.NoError(t, err)
 
 	var broadcastSeen bool
+	var expectedHash string
 	broadcastServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/cosmos/auth/v1beta1/accounts/" + signer.Address():
@@ -116,13 +121,14 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 			require.NoError(t, err)
 			assertUnorderedTx(t, txBytes)
 			broadcastSeen = true
+			expectedHash = txHashFromBytes(txBytes)
 			writeTestJSON(t, w, map[string]any{
 				"tx_response": map[string]any{
 					"code":   0,
-					"txhash": "FALLBACK123",
+					"txhash": expectedHash,
 				},
 			})
-		case "/cosmos/tx/v1beta1/txs/FALLBACK123":
+		case "/cosmos/tx/v1beta1/txs/" + expectedHash:
 			http.Error(w, `{"code":2,"message":"transaction indexing is disabled"}`, http.StatusInternalServerError)
 		default:
 			http.NotFound(w, r)
@@ -131,12 +137,12 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 	defer broadcastServer.Close()
 
 	queryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/cosmos/tx/v1beta1/txs/FALLBACK123", r.URL.Path)
+		require.Equal(t, "/cosmos/tx/v1beta1/txs/"+expectedHash, r.URL.Path)
 		require.True(t, broadcastSeen)
 		writeTestJSON(t, w, map[string]any{
 			"tx_response": map[string]any{
 				"code":   0,
-				"txhash": "FALLBACK123",
+				"txhash": expectedHash,
 				"events": []map[string]any{{
 					"type": "devshard_escrow_created",
 					"attributes": []map[string]string{{
@@ -160,11 +166,98 @@ func TestRESTChainTxClient_CreateDevshardEscrowUsesTxQueryFallback(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	result, err := client.CreateDevshardEscrow(t.Context(), signer, 1_000_000, "Qwen/Test")
+	result, err := client.CreateDevshardEscrow(t.Context(), signer, 1_000_000, "Qwen/Test", nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(43), result.EscrowID)
-	require.Equal(t, "FALLBACK123", result.TxHash)
+	require.NotEmpty(t, expectedHash)
+	require.Equal(t, expectedHash, result.TxHash)
 	require.Equal(t, signer.Address(), result.Creator)
+}
+
+// escrowIDQueryServer returns a query endpoint that replies with a committed
+// create tx carrying an escrow_id event for txHash, and 404 for anything else.
+func escrowIDQueryServer(t *testing.T, txHash string, escrowID uint64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cosmos/tx/v1beta1/txs/"+txHash {
+			http.NotFound(w, r)
+			return
+		}
+		writeTestJSON(t, w, map[string]any{
+			"tx_response": map[string]any{
+				"code":   0,
+				"txhash": txHash,
+				"events": []map[string]any{{
+					"type":       "devshard_escrow_created",
+					"attributes": []map[string]string{{"key": "escrow_id", "value": fmt.Sprintf("%d", escrowID)}},
+				}},
+			},
+		})
+	}))
+}
+
+// TestRESTChainTxClient_GetTxEscrowIDTriesFallbackOn404 pins the recovery path:
+// when the primary node has not indexed the create tx (404), the escrow_id must
+// still be resolved from the fallback query URL rather than reported missing.
+func TestRESTChainTxClient_GetTxEscrowIDTriesFallbackOn404(t *testing.T) {
+	const txHash = "ABC123"
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r) // primary hasn't indexed the tx yet
+	}))
+	defer primary.Close()
+	fallback := escrowIDQueryServer(t, txHash, 77)
+	defer fallback.Close()
+
+	client, err := NewRESTChainTxClient(RESTChainTxConfig{BaseURL: primary.URL, TxQueryURL: fallback.URL, ChainID: "gonka-test"})
+	require.NoError(t, err)
+
+	escrowID, found, err := client.GetTxEscrowID(t.Context(), txHash)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint64(77), escrowID)
+}
+
+// TestRESTChainTxClient_GetTxEscrowIDNotFoundWhenAllEndpoints404 confirms the
+// only-after-all-endpoints semantics: errTxNotFound is returned solely when
+// every reachable endpoint agrees the tx is absent.
+func TestRESTChainTxClient_GetTxEscrowIDNotFoundWhenAllEndpoints404(t *testing.T) {
+	notFound := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { http.NotFound(w, r) }))
+	}
+	primary := notFound()
+	defer primary.Close()
+	fallback := notFound()
+	defer fallback.Close()
+
+	client, err := NewRESTChainTxClient(RESTChainTxConfig{BaseURL: primary.URL, TxQueryURL: fallback.URL, ChainID: "gonka-test"})
+	require.NoError(t, err)
+
+	_, found, err := client.GetTxEscrowID(t.Context(), "ABC123")
+	require.False(t, found)
+	require.ErrorIs(t, err, errTxNotFound)
+}
+
+// TestRESTChainTxClient_GetTxEscrowIDInconclusiveOnFallbackError guards against
+// orphaning: a 404 on the primary plus a real error on the fallback is
+// inconclusive, so a non-errTxNotFound error is returned and the caller keeps
+// the commitment for a later retry instead of clearing it.
+func TestRESTChainTxClient_GetTxEscrowIDInconclusiveOnFallbackError(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer primary.Close()
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"transaction indexing is disabled"}`, http.StatusInternalServerError)
+	}))
+	defer fallback.Close()
+
+	client, err := NewRESTChainTxClient(RESTChainTxConfig{BaseURL: primary.URL, TxQueryURL: fallback.URL, ChainID: "gonka-test"})
+	require.NoError(t, err)
+
+	_, found, err := client.GetTxEscrowID(t.Context(), "ABC123")
+	require.False(t, found)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errTxNotFound)
 }
 
 func TestRESTChainTxClient_SettleDevshardEscrow(t *testing.T) {

--- a/devshard/cmd/devshardctl/escrow_recovery_test.go
+++ b/devshard/cmd/devshardctl/escrow_recovery_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The root-cause layer: the gateway store must open in WAL with a busy timeout
+// so concurrent writes wait instead of failing with "database is locked".
+func TestGatewayStoreUsesWALAndBusyTimeout(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	var journalMode string
+	require.NoError(t, store.db.QueryRow("PRAGMA journal_mode").Scan(&journalMode))
+	assert.Equal(t, "wal", strings.ToLower(journalMode))
+
+	var busyTimeout int
+	require.NoError(t, store.db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout))
+	assert.Equal(t, 5000, busyTimeout)
+}
+
+func recoveryTestSettings() GatewaySettings {
+	return GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Enabled:           true,
+			SettlementEnabled: true,
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       "Qwen/Test",
+				TempCount:     1,
+				TargetCount:   1,
+				Amount:        1000,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+			}},
+		},
+	}.WithTuningDefaults()
+}
+
+func stubRuntimeBuilder(t *testing.T) {
+	t.Helper()
+	saved := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, _, _ string, _ *PerfTracker) (*devshardRuntime, error) {
+		return &devshardRuntime{id: cfg.ID, model: cfg.Model}, nil
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = saved })
+}
+
+// stubCreateOnChain replaces the on-chain create with a fake that mimics the real
+// flow: it invokes onPrepared(txHash) (so the commitment is written) and aborts
+// without a result if that fails — exactly as CreateDevshardEscrow does.
+func stubCreateOnChain(t *testing.T, txHash string, escrowID uint64) {
+	t.Helper()
+	saved := gatewayCreateEscrowOnChain
+	gatewayCreateEscrowOnChain = func(_ *Gateway, _ context.Context, _ GatewaySettings, _ EscrowRotationModelSettings, onPrepared func(string) error) (*CreateDevshardEscrowResult, error) {
+		if onPrepared != nil {
+			if err := onPrepared(txHash); err != nil {
+				return nil, err
+			}
+		}
+		return &CreateDevshardEscrowResult{EscrowID: escrowID, TxHash: txHash}, nil
+	}
+	t.Cleanup(func() { gatewayCreateEscrowOnChain = saved })
+}
+
+func stubQueryTxEscrowID(t *testing.T, fn func(string) (uint64, bool, error)) {
+	t.Helper()
+	saved := gatewayQueryTxEscrowID
+	gatewayQueryTxEscrowID = func(_ context.Context, _ GatewaySettings, txHash string) (uint64, bool, error) {
+		return fn(txHash)
+	}
+	t.Cleanup(func() { gatewayQueryTxEscrowID = saved })
+}
+
+func newRecoveryGateway(t *testing.T) (*Gateway, *GatewayStore, GatewaySettings) {
+	t.Helper()
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	settings := recoveryTestSettings()
+	require.NoError(t, store.Initialize(settings, nil))
+	stubRuntimeBuilder(t)
+	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{}}
+	return g, store, settings
+}
+
+func devshardIDs(t *testing.T, store *GatewayStore) map[string]GatewayDevshardState {
+	t.Helper()
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	return gatewayDevshardsByID(state.Devshards)
+}
+
+// Happy path: intent commitment is written before the chain tx, the escrow is
+// persisted, and the commitment is cleared.
+func TestCreateRotationEscrowIntentFirstThenPersistAndClear(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	stubCreateOnChain(t, "TXAAA", 777)
+	model := normalizedEscrowRotationModels(settings)[0]
+
+	_, err := g.createRotationEscrow(context.Background(), settings, model, rotationRoleTemp, 10)
+	require.NoError(t, err)
+
+	require.Contains(t, devshardIDs(t, store), "777", "escrow persisted")
+	commitments, err := store.LoadCommitments()
+	require.NoError(t, err)
+	assert.Empty(t, commitments, "commitment cleared after persist")
+}
+
+// If the intent commitment cannot be written, no chain tx is broadcast and no
+// escrow is created — the safe failure.
+func TestCreateRotationEscrowAbortsWhenCommitmentWriteFails(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	stubCreateOnChain(t, "TXBBB", 778)
+	model := normalizedEscrowRotationModels(settings)[0]
+
+	// Make every write fail, as a locked/read-only DB would.
+	_, err := store.db.Exec("PRAGMA query_only=ON")
+	require.NoError(t, err)
+
+	_, err = g.createRotationEscrow(context.Background(), settings, model, rotationRoleTemp, 10)
+	require.Error(t, err)
+
+	_, _ = store.db.Exec("PRAGMA query_only=OFF")
+	assert.NotContains(t, devshardIDs(t, store), "778", "no escrow created when intent write fails")
+	commitments, _ := store.LoadCommitments()
+	assert.Empty(t, commitments)
+}
+
+// If the post-create persist fails, the commitment survives and reconcile later
+// recovers the escrow from chain by its tx hash — escrow_id is never lost.
+func TestCreateRotationEscrowPersistFailureRecoversViaCommitment(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	stubCreateOnChain(t, "TXCCC", 888)
+	model := normalizedEscrowRotationModels(settings)[0]
+
+	// Force the persist to fail (runtime build error) on the create path.
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(RuntimeConfig, string, string, *PerfTracker) (*devshardRuntime, error) {
+		return nil, errors.New("persist boom")
+	}
+	_, err := g.createRotationEscrow(context.Background(), settings, model, rotationRoleTemp, 10)
+	require.Error(t, err)
+	gatewayRuntimeBuilder = savedBuilder // restore (stubRuntimeBuilder's success)
+
+	require.NotContains(t, devshardIDs(t, store), "888", "not persisted yet")
+	commitments, err := store.LoadCommitments()
+	require.NoError(t, err)
+	require.Len(t, commitments, 1, "commitment kept for recovery")
+	assert.Equal(t, "TXCCC", commitments[0].TxHash)
+
+	// Reconcile: chain resolves the tx hash to the escrow_id.
+	stubQueryTxEscrowID(t, func(txHash string) (uint64, bool, error) {
+		assert.Equal(t, "TXCCC", txHash)
+		return 888, true, nil
+	})
+	g.reconcileCommitments(context.Background(), settings)
+
+	assert.Contains(t, devshardIDs(t, store), "888", "recovered via commitment")
+	commitments, _ = store.LoadCommitments()
+	assert.Empty(t, commitments, "commitment cleared after recovery")
+}
+
+// Reconcile persists an escrow for a pending commitment and clears it.
+func TestReconcileCommitmentsRecoversFromChain(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{
+		TxHash: "TXDDD", Model: "Qwen/Test", Role: rotationRoleTemp, Epoch: 11, PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+	}))
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 999, true, nil })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	assert.Contains(t, devshardIDs(t, store), "999")
+	commitments, _ := store.LoadCommitments()
+	assert.Empty(t, commitments)
+}
+
+// A commitment whose tx committed but failed (no escrow created) is cleared
+// immediately — the failure is final, the tx can never produce an escrow.
+func TestReconcileCommitmentsClearsWhenTxCommittedFailed(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{TxHash: "TXEEE", Model: "Qwen/Test", Role: rotationRoleTemp}))
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, nil })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	commitments, _ := store.LoadCommitments()
+	assert.Empty(t, commitments, "commitment cleared when tx committed but created no escrow")
+}
+
+// A fresh commitment whose tx is not (yet) on chain must be KEPT: an unordered
+// tx can still land until its TTL elapses, and a fresh 404 is usually mempool /
+// index lag, not a failed broadcast. Clearing now would orphan a real escrow.
+func TestReconcileCommitmentsKeepsFreshTxNotFound(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{TxHash: "TXFRESH", Model: "Qwen/Test", Role: rotationRoleTemp}))
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, errTxNotFound })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	commitments, err := store.LoadCommitments()
+	require.NoError(t, err)
+	require.Len(t, commitments, 1, "fresh not-found commitment retained until its tx can no longer land")
+	assert.Equal(t, "TXFRESH", commitments[0].TxHash)
+}
+
+// Once the commitment is older than the unordered-tx window, a not-found tx can
+// never land — only then is it safe to clear.
+func TestReconcileCommitmentsClearsExpiredTxNotFound(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	old := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
+	_, err := store.db.Exec(`
+		INSERT INTO escrow_rotation_commitments (tx_hash, model, role, epoch, private_key_env, block_height, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"TXOLD", "Qwen/Test", rotationRoleTemp, 0, "", 0, old)
+	require.NoError(t, err)
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, errTxNotFound })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	commitments, _ := store.LoadCommitments()
+	assert.Empty(t, commitments, "commitment cleared once the unordered tx can no longer land")
+}
+
+// A transient chain error leaves the commitment for the next pass.
+func TestReconcileCommitmentsKeepsCommitmentOnChainError(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{TxHash: "TXFFF", Model: "Qwen/Test", Role: rotationRoleTemp}))
+	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, errors.New("chain unreachable") })
+
+	g.reconcileCommitments(context.Background(), settings)
+
+	commitments, err := store.LoadCommitments()
+	require.NoError(t, err)
+	require.Len(t, commitments, 1, "commitment retained when chain cannot be queried")
+	assert.Equal(t, "TXFFF", commitments[0].TxHash)
+}

--- a/devshard/cmd/devshardctl/escrow_recovery_test.go
+++ b/devshard/cmd/devshardctl/escrow_recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,6 +27,23 @@ func TestGatewayStoreUsesWALAndBusyTimeout(t *testing.T) {
 	var busyTimeout int
 	require.NoError(t, store.db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout))
 	assert.Equal(t, 5000, busyTimeout)
+}
+
+func TestWithDBRetry_RespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var attempts atomic.Int32
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := withDBRetry(ctx, func() error {
+		attempts.Add(1)
+		return errors.New("database is locked")
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, int(attempts.Load()), escrowWriteRetries)
 }
 
 func recoveryTestSettings() GatewaySettings {
@@ -222,12 +240,12 @@ func TestReconcileCommitmentsKeepsFreshTxNotFound(t *testing.T) {
 // never land — only then is it safe to clear.
 func TestReconcileCommitmentsClearsExpiredTxNotFound(t *testing.T) {
 	g, store, settings := newRecoveryGateway(t)
-	old := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
-	_, err := store.db.Exec(`
-		INSERT INTO escrow_rotation_commitments (tx_hash, model, role, epoch, private_key_env, block_height, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		"TXOLD", "Qwen/Test", rotationRoleTemp, 0, "", 0, old)
-	require.NoError(t, err)
+	require.NoError(t, store.SaveCommitment(GatewayEscrowCommitment{
+		TxHash:    "TXOLD",
+		Model:     "Qwen/Test",
+		Role:      rotationRoleTemp,
+		CreatedAt: time.Now().UTC().Add(-1 * time.Hour),
+	}))
 	stubQueryTxEscrowID(t, func(string) (uint64, bool, error) { return 0, false, errTxNotFound })
 
 	g.reconcileCommitments(context.Background(), settings)

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -404,9 +404,9 @@ func (g *Gateway) settleDevshardOnChain(ctx context.Context, id string, req admi
 	log.Printf("devshard_settle_start escrow=%s", id)
 	g.mu.Lock()
 	rt, ok := g.runtimes[id]
-	if ok && rt.activeRequests.Load() > 0 {
+	if ok && rt.escrowHasBackgroundWork() {
 		g.mu.Unlock()
-		log.Printf("devshard_settle_blocked escrow=%s reason=active_requests count=%d", id, rt.activeRequests.Load())
+		log.Printf("devshard_settle_blocked escrow=%s reason=background_work active_requests=%d pending_race_cleanup=%d", id, rt.activeUserRequests.Load(), rt.pendingRaceCleanup.Load())
 		return nil, errDevshardBusy
 	}
 	if ok {

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -80,28 +80,32 @@ func (g *Gateway) stopEscrowRotatorLocked() {
 
 func (g *Gateway) runEscrowRotator(stopCh <-chan struct{}, doneCh chan<- struct{}) {
 	defer close(doneCh)
-	g.rotateEscrowsOnce()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g.rotateEscrowsOnce(ctx)
 
 	ticker := time.NewTicker(defaultEscrowRotationInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			g.rotateEscrowsOnce()
+			g.rotateEscrowsOnce(ctx)
 		case <-stopCh:
+			cancel()
 			return
 		}
 	}
 }
 
-func (g *Gateway) rotateEscrowsOnce() {
+func (g *Gateway) rotateEscrowsOnce(ctx context.Context) {
 	if g == nil || g.phaseGate == nil || g.store == nil {
 		return
 	}
 	g.mu.Lock()
 	settings := g.settings
 	g.mu.Unlock()
-	g.reconcileCommitments(context.Background(), settings)
+	g.reconcileCommitments(ctx, settings)
 	rotation := settings.EscrowRotation
 	if !rotation.Enabled {
 		return
@@ -119,18 +123,18 @@ func (g *Gateway) rotateEscrowsOnce() {
 	blocksToEpochSwitch := snapshot.epochSwitchBlockHeight - snapshot.BlockHeight
 
 	if blocksToEpochSwitch >= 0 && blocksToEpochSwitch <= rotation.PrePoCBlocks {
-		g.prepareBridgeEscrows(snapshot, settings)
+		g.prepareBridgeEscrows(ctx, snapshot, settings)
 		return
 	}
 	if !pocActive {
-		g.finishBridgeEscrows(snapshot, settings)
+		g.finishBridgeEscrows(ctx, snapshot, settings)
 	}
 }
 
-func (g *Gateway) prepareBridgeEscrows(snapshot ChainPhaseSnapshot, settings GatewaySettings) {
+func (g *Gateway) prepareBridgeEscrows(ctx context.Context, snapshot ChainPhaseSnapshot, settings GatewaySettings) {
 	epoch := snapshot.EpochIndex
 	for _, model := range normalizedEscrowRotationModels(settings) {
-		ensure, err := g.ensureRotationEscrows(context.Background(), settings, model, rotationRoleTemp, epoch, model.TempCount)
+		ensure, err := g.ensureRotationEscrows(ctx, settings, model, rotationRoleTemp, epoch, model.TempCount)
 		if err != nil {
 			log.Printf("escrow_rotation_temp_create_failed epoch=%d model=%q error=%v", epoch, model.ModelID, err)
 			promoted, promoteErr := g.promoteActiveRegularEscrowsToTemp(model.ModelID, epoch)
@@ -162,7 +166,7 @@ func (g *Gateway) prepareBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gat
 			if devshard.RotationRole == rotationRoleTemp || !devshard.Active || strings.TrimSpace(devshard.Model) != model.ModelID {
 				continue
 			}
-			settledOnChain, err := g.retireRotatedDevshard(context.Background(), devshard.ID, "escrow rotation regular retired", settings)
+			settledOnChain, err := g.retireRotatedDevshard(ctx, devshard.ID, "escrow rotation regular retired", settings)
 			if err != nil {
 				log.Printf("escrow_rotation_regular_retire_failed epoch=%d model=%q escrow=%s error=%v", epoch, model.ModelID, devshard.ID, err)
 				settleFailed++
@@ -185,7 +189,7 @@ func (g *Gateway) prepareBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gat
 	}
 }
 
-func (g *Gateway) finishBridgeEscrows(snapshot ChainPhaseSnapshot, settings GatewaySettings) {
+func (g *Gateway) finishBridgeEscrows(ctx context.Context, snapshot ChainPhaseSnapshot, settings GatewaySettings) {
 	epoch := snapshot.EpochIndex
 	for _, model := range normalizedEscrowRotationModels(settings) {
 		state, ok, err := g.store.LoadState()
@@ -203,7 +207,7 @@ func (g *Gateway) finishBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gate
 		if !hasBridgeEscrows {
 			continue
 		}
-		ensure, err := g.ensureRotationEscrows(context.Background(), settings, model, rotationRoleRegular, epoch, model.TargetCount)
+		ensure, err := g.ensureRotationEscrows(ctx, settings, model, rotationRoleRegular, epoch, model.TargetCount)
 		if err != nil {
 			log.Printf("escrow_rotation_regular_create_failed epoch=%d model=%q error=%v", epoch, model.ModelID, err)
 			g.saveRotationStatus(GatewayRotationStatus{
@@ -230,7 +234,7 @@ func (g *Gateway) finishBridgeEscrows(snapshot ChainPhaseSnapshot, settings Gate
 			if devshard.RotationRole != rotationRoleTemp || devshard.RotationEpoch > epoch || !devshard.Active || strings.TrimSpace(devshard.Model) != model.ModelID {
 				continue
 			}
-			settledOnChain, err := g.retireRotatedDevshard(context.Background(), devshard.ID, "escrow rotation temp retired", settings)
+			settledOnChain, err := g.retireRotatedDevshard(ctx, devshard.ID, "escrow rotation temp retired", settings)
 			if err != nil {
 				log.Printf("escrow_rotation_temp_retire_failed epoch=%d model=%q escrow=%s error=%v", epoch, model.ModelID, devshard.ID, err)
 				settleFailed++
@@ -328,30 +332,29 @@ func (g *Gateway) createEscrowOnChain(ctx context.Context, settings GatewaySetti
 }
 
 func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, role string, epoch uint64) (*CreateDevshardEscrowResult, error) {
-	keyEnv := strings.TrimSpace(model.PrivateKeyEnv)
 	commitment := GatewayEscrowCommitment{
 		Model:         model.ModelID,
 		Role:          role,
 		Epoch:         epoch,
-		PrivateKeyEnv: keyEnv,
+		PrivateKeyEnv: model.PrivateKeyEnv,
 		BlockHeight:   g.currentBlockHeight(),
 	}
 	// Intent-first: persist the commitment (with the precomputed tx hash) before broadcast.
 	onPrepared := func(txHash string) error {
 		c := commitment
 		c.TxHash = txHash
-		return withDBRetry(func() error { return g.store.SaveCommitment(c) })
+		return withDBRetry(ctx, func() error { return g.store.SaveCommitment(c) })
 	}
 	result, err := gatewayCreateEscrowOnChain(g, ctx, settings, model, onPrepared)
 	if err != nil {
 		return nil, err
 	}
-	if err := g.persistRotationEscrow(result.EscrowID, model.ModelID, role, epoch, keyEnv); err != nil {
+	if err := g.persistRotationEscrow(ctx, result.EscrowID, model.ModelID, role, epoch, model.PrivateKeyEnv); err != nil {
 		// Escrow is on chain; commitment survives -> reconcile recovers it by tx hash.
 		log.Printf("escrow_rotation_persist_failed escrow=%d tx=%s model=%q error=%v recover_via_commitment=true", result.EscrowID, result.TxHash, model.ModelID, err)
 		return nil, err
 	}
-	g.clearCommitment(result.TxHash)
+	g.clearCommitment(ctx, result.TxHash)
 	log.Printf("escrow_rotation_created role=%s epoch=%d model=%q escrow=%d tx_hash=%s", role, epoch, model.ModelID, result.EscrowID, result.TxHash)
 	return result, nil
 }
@@ -373,7 +376,6 @@ func normalizedEscrowRotationModels(settings GatewaySettings) []EscrowRotationMo
 	models := make([]EscrowRotationModelSettings, 0, len(settings.EscrowRotation.Models))
 	for _, model := range settings.EscrowRotation.Models {
 		model.ModelID = strings.TrimSpace(model.ModelID)
-		model.PrivateKeyEnv = strings.TrimSpace(model.PrivateKeyEnv)
 		models = append(models, model)
 	}
 	return models
@@ -471,32 +473,41 @@ func (g *Gateway) currentBlockHeight() uint64 {
 }
 
 // withDBRetry retries a DB write with backoff to ride out a transient lock.
-func withDBRetry(fn func() error) error {
+func withDBRetry(ctx context.Context, fn func() error) error {
 	var err error
 	for attempt := 0; attempt < escrowWriteRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err = fn(); err == nil {
 			return nil
 		}
 		if attempt < escrowWriteRetries-1 {
-			time.Sleep(escrowWriteRetryBackoff)
+			timer := time.NewTimer(escrowWriteRetryBackoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
 		}
 	}
 	return err
 }
 
 // persistRotationEscrow persists + registers a created escrow ("already exists" = ok).
-func (g *Gateway) persistRotationEscrow(escrowID uint64, modelID, role string, epoch uint64, keyEnv string) error {
+func (g *Gateway) persistRotationEscrow(ctx context.Context, escrowID uint64, modelID, role string, epoch uint64, keyEnv string) error {
 	record := GatewayDevshardState{
 		RuntimeConfig: RuntimeConfig{
 			ID:            strconv.FormatUint(escrowID, 10),
-			PrivateKeyEnv: strings.TrimSpace(keyEnv),
+			PrivateKeyEnv: keyEnv,
 			Model:         modelID,
 		},
 		Active:        true,
 		RotationRole:  role,
 		RotationEpoch: epoch,
 	}
-	return withDBRetry(func() error {
+	return withDBRetry(ctx, func() error {
 		if _, err := g.addCreatedEscrowRuntime(record); err != nil {
 			if errors.Is(err, errDevshardAlreadyExists) {
 				return nil
@@ -507,11 +518,11 @@ func (g *Gateway) persistRotationEscrow(escrowID uint64, modelID, role string, e
 	})
 }
 
-func (g *Gateway) clearCommitment(txHash string) {
+func (g *Gateway) clearCommitment(ctx context.Context, txHash string) {
 	if g == nil || g.store == nil || strings.TrimSpace(txHash) == "" {
 		return
 	}
-	if err := withDBRetry(func() error { return g.store.DeleteCommitment(txHash) }); err != nil {
+	if err := withDBRetry(ctx, func() error { return g.store.DeleteCommitment(txHash) }); err != nil {
 		log.Printf("escrow_rotation_commitment_clear_failed tx=%s error=%v", txHash, err)
 	}
 }
@@ -543,7 +554,7 @@ func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySett
 				continue
 			}
 			log.Printf("escrow_commitment_no_escrow tx=%s model=%q clearing=true", c.TxHash, c.Model)
-			g.clearCommitment(c.TxHash)
+			g.clearCommitment(ctx, c.TxHash)
 			continue
 		}
 		if err != nil {
@@ -552,28 +563,27 @@ func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySett
 		}
 		if !found {
 			log.Printf("escrow_commitment_tx_failed tx=%s model=%q clearing=true", c.TxHash, c.Model)
-			g.clearCommitment(c.TxHash)
+			g.clearCommitment(ctx, c.TxHash)
 			continue
 		}
-		if err := g.persistRotationEscrow(escrowID, c.Model, c.Role, c.Epoch, c.PrivateKeyEnv); err != nil {
+		if err := g.persistRotationEscrow(ctx, escrowID, c.Model, c.Role, c.Epoch, c.PrivateKeyEnv); err != nil {
 			log.Printf("escrow_commitment_persist_failed tx=%s escrow=%d model=%q error=%v", c.TxHash, escrowID, c.Model, err)
 			continue // keep commitment — retry next pass
 		}
-		g.clearCommitment(c.TxHash)
+		g.clearCommitment(ctx, c.TxHash)
 		g.resetRotationBreaker(c.Model, c.Role)
 		log.Printf("escrow_commitment_recovered tx=%s escrow=%d model=%q role=%s", c.TxHash, escrowID, c.Model, c.Role)
 	}
 }
 
 // commitmentTxMayStillLand reports whether a not-found tx could yet be committed
-// (within the unordered-tx window) — if so, the commitment must be kept. An
-// unparseable timestamp is treated as still-pending so we never clear too early.
+// (within the unordered-tx window) — if so, the commitment must be kept. A zero
+// timestamp is treated as still-pending so we never clear too early.
 func commitmentTxMayStillLand(c GatewayEscrowCommitment) bool {
-	createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.CreatedAt))
-	if err != nil {
+	if c.CreatedAt.IsZero() {
 		return true
 	}
-	return time.Since(createdAt) <= commitmentReconcileGrace
+	return time.Since(c.CreatedAt) <= commitmentReconcileGrace
 }
 
 func defaultQueryTxEscrowID(ctx context.Context, settings GatewaySettings, txHash string) (uint64, bool, error) {

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -263,6 +264,12 @@ func (g *Gateway) ensureRotationEscrows(ctx context.Context, settings GatewaySet
 		}
 	}
 	result.ExistingCount = count
+	if count < target {
+		if served, known := g.rotationModelServedByNetwork(model.ModelID); known && !served {
+			log.Printf("escrow_rotation_skip_model_absent role=%s epoch=%d model=%q reason=model_not_in_network", role, epoch, model.ModelID)
+			return result, nil
+		}
+	}
 	if count < target && g.rotationCreateFailed(model.ModelID, role, epoch) {
 		return result, errEscrowRotationCreateSuppressed
 	}
@@ -275,6 +282,22 @@ func (g *Gateway) ensureRotationEscrows(ctx context.Context, settings GatewaySet
 		result.CreatedCount++
 	}
 	return result, nil
+}
+
+// rotationModelServedByNetwork reports whether the model is served; known is false on cold start (empty model set) so callers don't skip a genuinely-served model.
+func (g *Gateway) rotationModelServedByNetwork(modelID string) (served bool, known bool) {
+	if g == nil || g.capacity == nil {
+		return false, false
+	}
+	networkModels := g.capacity.Models()
+	if len(networkModels) == 0 {
+		return false, false
+	}
+	modelID = strings.TrimSpace(modelID)
+	if slices.Contains(networkModels, modelID) {
+		return true, true
+	}
+	return false, true
 }
 
 func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, role string, epoch uint64) (*CreateDevshardEscrowResult, error) {

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -290,21 +290,25 @@ func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySett
 	if err != nil {
 		return nil, err
 	}
-	record := GatewayDevshardState{
-		RuntimeConfig: RuntimeConfig{
-			ID:            strconv.FormatUint(result.EscrowID, 10),
-			PrivateKeyEnv: strings.TrimSpace(model.PrivateKeyEnv),
-			Model:         model.ModelID,
-		},
-		Active:        true,
-		RotationRole:  role,
-		RotationEpoch: epoch,
-	}
+	record := newRotationDevshardState(result, model, role, epoch)
 	if _, err := g.addCreatedEscrowRuntime(record); err != nil {
 		return nil, err
 	}
 	log.Printf("escrow_rotation_created role=%s epoch=%d model=%q escrow=%d tx_hash=%s", role, epoch, model.ModelID, result.EscrowID, result.TxHash)
 	return result, nil
+}
+
+func newRotationDevshardState(result *CreateDevshardEscrowResult, model EscrowRotationModelSettings, role string, epoch uint64) GatewayDevshardState {
+	return GatewayDevshardState{
+		RuntimeConfig: RuntimeConfig{
+			ID:            strconv.FormatUint(result.EscrowID, 10),
+			PrivateKeyEnv: strings.TrimSpace(model.PrivateKeyEnv),
+			Model:         strings.TrimSpace(model.ModelID),
+		},
+		Active:        true,
+		RotationRole:  role,
+		RotationEpoch: epoch,
+	}
 }
 
 func normalizedEscrowRotationModels(settings GatewaySettings) []EscrowRotationModelSettings {

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -18,15 +18,28 @@ const (
 	rotationRoleTemp    = "temp"
 
 	defaultEscrowRotationInterval = 15 * time.Second
+
+	rotationBreakerMaxCooldownTicks = 4
+
+	escrowWriteRetries      = 10
+	escrowWriteRetryBackoff = 200 * time.Millisecond
 )
 
 var (
 	errDevshardBusy                   = errors.New("devshard has active requests")
-	errEscrowRotationCreateSuppressed = errors.New("escrow rotation create already failed for this epoch")
+	errDevshardAlreadyExists          = errors.New("devshard already exists")
+	errEscrowRotationCreateSuppressed = errors.New("escrow rotation create suppressed (backoff)")
 	gatewayCreateRotationEscrow       = (*Gateway).createRotationEscrow
+	gatewayCreateEscrowOnChain        = (*Gateway).createEscrowOnChain
 	gatewayCreateDepletionEscrow      func(*Gateway, context.Context, GatewaySettings, EscrowRotationModelSettings, string, uint64) (*CreateDevshardEscrowResult, error)
 	gatewaySettleDevshardOnChain      = (*Gateway).settleDevshardOnChain
+	gatewayQueryTxEscrowID            = defaultQueryTxEscrowID
 )
+
+type rotationBreaker struct {
+	consecutiveFailures int
+	cooldownTicks       int
+}
 
 func (g *Gateway) startEscrowRotatorIfEnabled() {
 	g.mu.Lock()
@@ -88,6 +101,7 @@ func (g *Gateway) rotateEscrowsOnce() {
 	g.mu.Lock()
 	settings := g.settings
 	g.mu.Unlock()
+	g.reconcileCommitments(context.Background(), settings)
 	rotation := settings.EscrowRotation
 	if !rotation.Enabled {
 		return
@@ -270,17 +284,18 @@ func (g *Gateway) ensureRotationEscrows(ctx context.Context, settings GatewaySet
 			return result, nil
 		}
 	}
-	if count < target && g.rotationCreateFailed(model.ModelID, role, epoch) {
+	if count < target && g.rotationCreateGated(model.ModelID, role) {
 		return result, errEscrowRotationCreateSuppressed
 	}
 	for count < target {
 		if _, err := gatewayCreateRotationEscrow(g, ctx, settings, model, role, epoch); err != nil {
-			g.recordRotationCreateFailure(model.ModelID, role, epoch)
+			g.recordRotationCreateFailure(model.ModelID, role)
 			return result, err
 		}
 		count++
 		result.CreatedCount++
 	}
+	g.resetRotationBreaker(model.ModelID, role)
 	return result, nil
 }
 
@@ -300,7 +315,7 @@ func (g *Gateway) rotationModelServedByNetwork(modelID string) (served bool, kno
 	return false, true
 }
 
-func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, role string, epoch uint64) (*CreateDevshardEscrowResult, error) {
+func (g *Gateway) createEscrowOnChain(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, onPrepared func(txHash string) error) (*CreateDevshardEscrowResult, error) {
 	signer, _, err := signerFromRequestKey("", model.PrivateKeyEnv)
 	if err != nil {
 		return nil, err
@@ -309,14 +324,34 @@ func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySett
 	if err != nil {
 		return nil, err
 	}
-	result, err := txClient.CreateDevshardEscrow(ctx, signer, model.Amount, model.ModelID)
+	return txClient.CreateDevshardEscrow(ctx, signer, model.Amount, model.ModelID, onPrepared)
+}
+
+func (g *Gateway) createRotationEscrow(ctx context.Context, settings GatewaySettings, model EscrowRotationModelSettings, role string, epoch uint64) (*CreateDevshardEscrowResult, error) {
+	keyEnv := strings.TrimSpace(model.PrivateKeyEnv)
+	commitment := GatewayEscrowCommitment{
+		Model:         model.ModelID,
+		Role:          role,
+		Epoch:         epoch,
+		PrivateKeyEnv: keyEnv,
+		BlockHeight:   g.currentBlockHeight(),
+	}
+	// Intent-first: persist the commitment (with the precomputed tx hash) before broadcast.
+	onPrepared := func(txHash string) error {
+		c := commitment
+		c.TxHash = txHash
+		return withDBRetry(func() error { return g.store.SaveCommitment(c) })
+	}
+	result, err := gatewayCreateEscrowOnChain(g, ctx, settings, model, onPrepared)
 	if err != nil {
 		return nil, err
 	}
-	record := newRotationDevshardState(result, model, role, epoch)
-	if _, err := g.addCreatedEscrowRuntime(record); err != nil {
+	if err := g.persistRotationEscrow(result.EscrowID, model.ModelID, role, epoch, keyEnv); err != nil {
+		// Escrow is on chain; commitment survives -> reconcile recovers it by tx hash.
+		log.Printf("escrow_rotation_persist_failed escrow=%d tx=%s model=%q error=%v recover_via_commitment=true", result.EscrowID, result.TxHash, model.ModelID, err)
 		return nil, err
 	}
+	g.clearCommitment(result.TxHash)
 	log.Printf("escrow_rotation_created role=%s epoch=%d model=%q escrow=%d tx_hash=%s", role, epoch, model.ModelID, result.EscrowID, result.TxHash)
 	return result, nil
 }
@@ -380,24 +415,173 @@ func (g *Gateway) saveRotationStatus(status GatewayRotationStatus) {
 	}
 }
 
-func (g *Gateway) rotationFailureKey(modelID, role string, epoch uint64) string {
-	return fmt.Sprintf("%s|%s|%d", strings.TrimSpace(modelID), role, epoch)
+func rotationBreakerKey(modelID, role string) string {
+	return strings.TrimSpace(modelID) + "|" + role
 }
 
-func (g *Gateway) recordRotationCreateFailure(modelID, role string, epoch uint64) {
+// rotationCreateGated reports whether create is in backoff; decrements one tick.
+func (g *Gateway) rotationCreateGated(modelID, role string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if g.rotationFailures == nil {
-		g.rotationFailures = make(map[string]struct{})
+	breaker := g.rotationBreakers[rotationBreakerKey(modelID, role)]
+	if breaker == nil || breaker.cooldownTicks <= 0 {
+		return false
 	}
-	g.rotationFailures[g.rotationFailureKey(modelID, role, epoch)] = struct{}{}
+	breaker.cooldownTicks--
+	return true
 }
 
-func (g *Gateway) rotationCreateFailed(modelID, role string, epoch uint64) bool {
+// recordRotationCreateFailure grows the per-(model,role) backoff after a failure.
+func (g *Gateway) recordRotationCreateFailure(modelID, role string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	_, ok := g.rotationFailures[g.rotationFailureKey(modelID, role, epoch)]
-	return ok
+	if g.rotationBreakers == nil {
+		g.rotationBreakers = make(map[string]*rotationBreaker)
+	}
+	key := rotationBreakerKey(modelID, role)
+	breaker := g.rotationBreakers[key]
+	if breaker == nil {
+		breaker = &rotationBreaker{}
+		g.rotationBreakers[key] = breaker
+	}
+	breaker.consecutiveFailures++
+	cooldown := 1 << (breaker.consecutiveFailures - 1)
+	if cooldown > rotationBreakerMaxCooldownTicks {
+		cooldown = rotationBreakerMaxCooldownTicks
+	}
+	breaker.cooldownTicks = cooldown
+}
+
+// resetRotationBreaker clears the backoff for a (model, role) after success.
+func (g *Gateway) resetRotationBreaker(modelID, role string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.rotationBreakers, rotationBreakerKey(modelID, role))
+}
+
+func (g *Gateway) currentBlockHeight() uint64 {
+	if g == nil || g.phaseGate == nil {
+		return 0
+	}
+	height := g.phaseGate.Snapshot().BlockHeight
+	if height < 0 {
+		return 0
+	}
+	return uint64(height)
+}
+
+// withDBRetry retries a DB write with backoff to ride out a transient lock.
+func withDBRetry(fn func() error) error {
+	var err error
+	for attempt := 0; attempt < escrowWriteRetries; attempt++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		if attempt < escrowWriteRetries-1 {
+			time.Sleep(escrowWriteRetryBackoff)
+		}
+	}
+	return err
+}
+
+// persistRotationEscrow persists + registers a created escrow ("already exists" = ok).
+func (g *Gateway) persistRotationEscrow(escrowID uint64, modelID, role string, epoch uint64, keyEnv string) error {
+	record := GatewayDevshardState{
+		RuntimeConfig: RuntimeConfig{
+			ID:            strconv.FormatUint(escrowID, 10),
+			PrivateKeyEnv: strings.TrimSpace(keyEnv),
+			Model:         modelID,
+		},
+		Active:        true,
+		RotationRole:  role,
+		RotationEpoch: epoch,
+	}
+	return withDBRetry(func() error {
+		if _, err := g.addCreatedEscrowRuntime(record); err != nil {
+			if errors.Is(err, errDevshardAlreadyExists) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	})
+}
+
+func (g *Gateway) clearCommitment(txHash string) {
+	if g == nil || g.store == nil || strings.TrimSpace(txHash) == "" {
+		return
+	}
+	if err := withDBRetry(func() error { return g.store.DeleteCommitment(txHash) }); err != nil {
+		log.Printf("escrow_rotation_commitment_clear_failed tx=%s error=%v", txHash, err)
+	}
+}
+
+// commitmentReconcileGrace is how long a not-found tx is given before the
+// commitment is cleared: the unordered-tx TTL plus margin for index lag. Until
+// it elapses, a 404 may be a pending/unindexed tx that still creates an escrow.
+const commitmentReconcileGrace = defaultUnorderedTxTTL + 2*time.Minute
+
+// reconcileCommitments recovers escrows from pending commitments via tx hash:
+// found → persist + clear; committed-failed → clear; not-found → clear only once
+// the tx can no longer land; chain error → keep for next pass.
+func (g *Gateway) reconcileCommitments(ctx context.Context, settings GatewaySettings) {
+	if g == nil || g.store == nil {
+		return
+	}
+	commitments, err := g.store.LoadCommitments()
+	if err != nil {
+		log.Printf("escrow_commitments_load_failed error=%v", err)
+		return
+	}
+	for _, c := range commitments {
+		escrowID, found, err := gatewayQueryTxEscrowID(ctx, settings, c.TxHash)
+		if errors.Is(err, errTxNotFound) {
+			// Tx not on chain. An unordered tx can still land until its TTL
+			// elapses, so a fresh 404 is likely mempool/index lag — keep it.
+			if commitmentTxMayStillLand(c) {
+				log.Printf("escrow_commitment_tx_pending tx=%s model=%q", c.TxHash, c.Model)
+				continue
+			}
+			log.Printf("escrow_commitment_no_escrow tx=%s model=%q clearing=true", c.TxHash, c.Model)
+			g.clearCommitment(c.TxHash)
+			continue
+		}
+		if err != nil {
+			log.Printf("escrow_commitment_tx_query_failed tx=%s model=%q error=%v", c.TxHash, c.Model, err)
+			continue // chain unreachable — retry next pass
+		}
+		if !found {
+			log.Printf("escrow_commitment_tx_failed tx=%s model=%q clearing=true", c.TxHash, c.Model)
+			g.clearCommitment(c.TxHash)
+			continue
+		}
+		if err := g.persistRotationEscrow(escrowID, c.Model, c.Role, c.Epoch, c.PrivateKeyEnv); err != nil {
+			log.Printf("escrow_commitment_persist_failed tx=%s escrow=%d model=%q error=%v", c.TxHash, escrowID, c.Model, err)
+			continue // keep commitment — retry next pass
+		}
+		g.clearCommitment(c.TxHash)
+		g.resetRotationBreaker(c.Model, c.Role)
+		log.Printf("escrow_commitment_recovered tx=%s escrow=%d model=%q role=%s", c.TxHash, escrowID, c.Model, c.Role)
+	}
+}
+
+// commitmentTxMayStillLand reports whether a not-found tx could yet be committed
+// (within the unordered-tx window) — if so, the commitment must be kept. An
+// unparseable timestamp is treated as still-pending so we never clear too early.
+func commitmentTxMayStillLand(c GatewayEscrowCommitment) bool {
+	createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.CreatedAt))
+	if err != nil {
+		return true
+	}
+	return time.Since(createdAt) <= commitmentReconcileGrace
+}
+
+func defaultQueryTxEscrowID(ctx context.Context, settings GatewaySettings, txHash string) (uint64, bool, error) {
+	txClient, err := newGatewayRESTChainTxClient(settings, "", "", 0, 0)
+	if err != nil {
+		return 0, false, err
+	}
+	return txClient.GetTxEscrowID(ctx, txHash)
 }
 
 func (g *Gateway) settleDevshardOnChain(ctx context.Context, id string, req adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {

--- a/devshard/cmd/devshardctl/filtercore/scoping.go
+++ b/devshard/cmd/devshardctl/filtercore/scoping.go
@@ -1,0 +1,13 @@
+// Package filtercore holds primitives shared between paramvalidators (top-level
+// request fields) and messagevalidators (per-message shape rules). Both layers
+// dispatch behavior on the routed model id; the dispatch primitive lives here
+// so the two packages do not reimplement it.
+package filtercore
+
+import "slices"
+
+// MatchesModel reports whether routedModel equals any entry in models. Empty
+// models slice always returns false.
+func MatchesModel(routedModel string, models []string) bool {
+	return slices.Contains(models, routedModel)
+}

--- a/devshard/cmd/devshardctl/filtercore/scoping_test.go
+++ b/devshard/cmd/devshardctl/filtercore/scoping_test.go
@@ -1,0 +1,25 @@
+package filtercore
+
+import "testing"
+
+func TestMatchesModel(t *testing.T) {
+	cases := []struct {
+		name        string
+		routed      string
+		models      []string
+		want        bool
+	}{
+		{name: "empty list", routed: "model-a", models: nil, want: false},
+		{name: "single match", routed: "model-a", models: []string{"model-a"}, want: true},
+		{name: "no match", routed: "model-a", models: []string{"model-b"}, want: false},
+		{name: "match in multi", routed: "model-b", models: []string{"model-a", "model-b", "model-c"}, want: true},
+		{name: "case sensitive", routed: "Model-A", models: []string{"model-a"}, want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := MatchesModel(c.routed, c.models); got != c.want {
+				t.Fatalf("MatchesModel(%q, %v) = %v, want %v", c.routed, c.models, got, c.want)
+			}
+		})
+	}
+}

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -305,8 +305,50 @@ func buildRuntime(cfg RuntimeConfig, chainREST, defaultModel string, perf *PerfT
 	return rt, nil
 }
 
+// defaultMaxConcurrentRuntimeBuilds caps parallel runtime builds at startup: a
+// small keep-alive pool against the shared node LCD, big enough to hide startup
+// latency, small enough to avoid a 429 storm. Overridable per deployment.
+const defaultMaxConcurrentRuntimeBuilds = 16
+
+// resolveMaxConcurrentRuntimeBuilds is the startup build fan-out limit,
+// overridable via DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS (must be >= 1).
+func resolveMaxConcurrentRuntimeBuilds() int {
+	raw := strings.TrimSpace(os.Getenv("DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS"))
+	if raw == "" {
+		return defaultMaxConcurrentRuntimeBuilds
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		log.Printf("invalid DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS=%q (must be >= 1), using default %d", raw, defaultMaxConcurrentRuntimeBuilds)
+		return defaultMaxConcurrentRuntimeBuilds
+	}
+	return n
+}
+
+// buildRuntimeBridgeClient returns the HTTP client for chain-LCD queries, sized
+// so the bounded build fan-out reuses keep-alive connections instead of churning
+// them (the default MaxIdleConnsPerHost is only 2).
+func buildRuntimeBridgeClient(limit int) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = limit
+	transport.MaxIdleConnsPerHost = limit
+	return &http.Client{Timeout: 10 * time.Second, Transport: transport}
+}
+
+var (
+	runtimeBridgeClientOnce sync.Once
+	runtimeBridgeClient     *http.Client
+)
+
+func sharedRuntimeBridgeClient() *http.Client {
+	runtimeBridgeClientOnce.Do(func() {
+		runtimeBridgeClient = buildRuntimeBridgeClient(resolveMaxConcurrentRuntimeBuilds())
+	})
+	return runtimeBridgeClient
+}
+
 func newRESTBridgeForProtocol(chainREST string, pv types.ProtocolVersion) *bridge.RESTBridge {
-	return bridge.NewRESTBridge(chainREST)
+	return bridge.NewRESTBridge(chainREST, bridge.WithHTTPClient(sharedRuntimeBridgeClient()))
 }
 
 func resolveGatewayRoutePrefix() (string, error) {

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -80,9 +80,12 @@ type devshardRuntime struct {
 	// same escrow.
 	participantSlotCounts map[string]int
 
-	active         atomic.Bool
-	activeRequests atomic.Int64
-	reservedTokens atomic.Int64
+	active             atomic.Bool
+	activeUserRequests atomic.Int64
+	reservedTokens     atomic.Int64
+
+	// pendingRaceCleanup counts background race cleanups (refund + loser-signature persistence) still in flight
+	pendingRaceCleanup atomic.Int64
 
 	// settlementPending marks an escrow that has been deactivated and must
 	// be settled once its in-flight requests drain. settlementReason is
@@ -97,6 +100,11 @@ type devshardRuntime struct {
 	retireReason  string
 
 	activeConfigured bool
+}
+
+// escrowHasBackgroundWork reports whether foreground requests or background race cleanups are in flight; settle and store-close must wait until it is false.
+func (rt *devshardRuntime) escrowHasBackgroundWork() bool {
+	return rt.activeUserRequests.Load() > 0 || rt.pendingRaceCleanup.Load() > 0
 }
 
 type runtimeStatus struct {
@@ -478,7 +486,7 @@ func (rt *devshardRuntime) snapshot() runtimeStatus {
 		ID:                rt.id,
 		Model:             rt.model,
 		Active:            rt.active.Load(),
-		ActiveRequests:    rt.activeRequests.Load(),
+		ActiveRequests:    rt.activeUserRequests.Load(),
 		ReservedTokens:    rt.reservedTokens.Load(),
 		SettlementPending: rt.settlementPending.Load(),
 	}
@@ -500,8 +508,8 @@ func (rt *devshardRuntime) snapshot() runtimeStatus {
 	return status
 }
 
-// TODO: the (reservedTokens*1000 + activeRequests) formula is missleading,
-// let's just leave activeRequests here, and leave a todo comment, that
+// TODO: the (reservedTokens*1000 + activeUserRequests) formula is missleading,
+// let's just leave activeUserRequests here, and leave a todo comment, that
 // we might need to change it, so that if limits for tokens or cuncurrent
 // requests are set, we need to measure if the escrow is further from
 // the limists
@@ -509,8 +517,8 @@ func (rt *devshardRuntime) snapshot() runtimeStatus {
 // load returns the capacity-aware load score for this runtime. Lower
 // is better; the picker selects the runtime with the smallest load.
 //
-// Score is simply activeRequests / W(e):
-//   - activeRequests is the live count of in-flight inferences this
+// Score is simply activeUserRequests / W(e):
+//   - activeUserRequests is the live count of in-flight inferences this
 //     runtime owns (incremented on dispatch, decremented on
 //     completion). It's the most direct, low-latency signal of "is
 //     this runtime busy right now".
@@ -533,7 +541,7 @@ func (rt *devshardRuntime) load(weight float64) float64 {
 	if weight <= 0 {
 		return math.Inf(+1)
 	}
-	return float64(rt.activeRequests.Load()) / weight
+	return float64(rt.activeUserRequests.Load()) / weight
 }
 
 func NewGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, defaultModel string) *Gateway {
@@ -629,6 +637,7 @@ func (g *Gateway) attachRuntimeSharedState(rt *devshardRuntime) {
 	}
 	g.attachMetrics(rt)
 	g.attachEscrowChecker(rt)
+	g.attachRaceCleanupBarrier(rt)
 	if g.capacity != nil {
 		g.capacity.SetEscrowMembership(rt.id, rt.participantSlotCounts)
 	}
@@ -1408,7 +1417,7 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if innerPath == "/v1/finalize" && r.Method == http.MethodPost {
-		if rt.activeRequests.Load() > 0 {
+		if rt.escrowHasBackgroundWork() {
 			http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s has active requests"}}`, devshardID), http.StatusConflict)
 			return
 		}
@@ -1652,7 +1661,7 @@ func (g *Gateway) formatCandidateWeightsLocked(candidates []*devshardRuntime, re
 // Fallback rules:
 //   - No capacity state attached, or escrow not registered with the
 //     state (no slot/membership info): use neutral weight 1.0 so the
-//     picker degrades to a pure activeRequests comparison.
+//     picker degrades to a pure activeUserRequests comparison.
 //   - Escrow registered but W(e) == 0 (every host is PoC-excluded or
 //     fully throttled): honor the 0 so the runtime drops to +Inf load
 //     and stops receiving traffic until at least one host recovers.
@@ -1670,30 +1679,45 @@ func (g *Gateway) reserveRuntime(rt *devshardRuntime, inputTokens int64) {
 }
 
 func (g *Gateway) reserveRuntimeLocked(rt *devshardRuntime, inputTokens int64) {
-	rt.activeRequests.Add(1)
+	rt.activeUserRequests.Add(1)
 	rt.reservedTokens.Add(inputTokens)
 }
 
 func (g *Gateway) releaseRuntime(rt *devshardRuntime, inputTokens int64) {
-	remaining := rt.activeRequests.Add(-1)
+	remaining := rt.activeUserRequests.Add(-1)
 	rt.reservedTokens.Add(-inputTokens)
-	// active=false (set during enqueue) blocks new reservations, so the count
-	// only drains downward — remaining==0 is the exact "last request finished"
-	// edge. scheduleAutoSettlement dedups, so a double-fire is harmless.
-	if remaining != 0 {
+	// Stay non-quiet while a background race cleanup is still refunding/persisting; its own releaseRaceCleanup re-checks the drain (whichever hits zero last fires; dedup makes a double-fire harmless).
+	if remaining != 0 || rt.pendingRaceCleanup.Load() != 0 {
 		return
 	}
+	g.runtimeDrained(rt)
+}
 
+// runtimeDrained fires the deferred settle/retire once a runtime is quiet; scheduleAutoSettlement/retireRuntime dedup, so a double-fire from the two drain paths is harmless.
+func (g *Gateway) runtimeDrained(rt *devshardRuntime) {
 	if rt.settlementPending.Load() {
 		log.Printf("settlement_drain_complete escrow=%s reason=%s", rt.id, rt.settlementReason)
 		g.scheduleAutoSettlement(rt.id, rt.settlementReason)
 		return
 	}
-
 	if rt.retirePending.Load() {
 		log.Printf("runtime_retire_drain_complete escrow=%s reason=%s", rt.id, rt.retireReason)
 		g.retireRuntime(rt.id, rt.retireReason)
 	}
+}
+
+// startRaceCleanup registers a background race cleanup against the drain barrier; it must run synchronously before the cleanup goroutine spawns (and before the winning handler returns).
+func (g *Gateway) startRaceCleanup(rt *devshardRuntime) {
+	rt.pendingRaceCleanup.Add(1)
+}
+
+// releaseRaceCleanup clears a race cleanup from the barrier and fires the deferred settle/retire if the runtime is now quiet.
+func (g *Gateway) releaseRaceCleanup(rt *devshardRuntime) {
+	remaining := rt.pendingRaceCleanup.Add(-1)
+	if remaining != 0 || rt.activeUserRequests.Load() != 0 {
+		return
+	}
+	g.runtimeDrained(rt)
 }
 
 func (rt *devshardRuntime) validateRequestedModel(requestModel string) error {
@@ -2931,7 +2955,7 @@ func (g *Gateway) handleAdminDevshardParticipants(w http.ResponseWriter, r *http
 	}
 	model := rt.model
 	active := rt.active.Load()
-	activeRequests := rt.activeRequests.Load()
+	activeUserRequests := rt.activeUserRequests.Load()
 	participantKeys := runtimeParticipantKeys(rt)
 	slotCounts := make(map[string]int, len(rt.participantSlotCounts))
 	for key, count := range rt.participantSlotCounts {
@@ -2976,7 +3000,7 @@ func (g *Gateway) handleAdminDevshardParticipants(w http.ResponseWriter, r *http
 		"id":                id,
 		"model":             model,
 		"active":            active,
-		"active_requests":   activeRequests,
+		"active_requests":   activeUserRequests,
 		"participant_count": len(participants),
 		"available_count":   availableCount,
 		"blocked_count":     blockedCount,
@@ -3346,7 +3370,7 @@ func (g *Gateway) handleAdminCleanDevshard(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if rt, ok := g.runtimes[id]; ok {
-		if rt.activeRequests.Load() > 0 {
+		if rt.escrowHasBackgroundWork() {
 			http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s has active requests"}}`, id), http.StatusConflict)
 			return
 		}
@@ -3447,10 +3471,10 @@ func (g *Gateway) retireRuntimeLocked(id, reason string) *devshardRuntime {
 		log.Printf("runtime_retire_skipped escrow=%s reason=%q cause=not_registered", id, reason)
 		return nil
 	}
-	if inFlight := rt.activeRequests.Load(); inFlight > 0 {
+	if rt.escrowHasBackgroundWork() {
 		rt.retireReason = reason
 		rt.retirePending.Store(true)
-		log.Printf("runtime_retire_deferred escrow=%s reason=%q active_requests=%d", id, reason, inFlight)
+		log.Printf("runtime_retire_deferred escrow=%s reason=%q active_requests=%d pending_race_cleanup=%d", id, reason, rt.activeUserRequests.Load(), rt.pendingRaceCleanup.Load())
 		return nil
 	}
 	delete(g.runtimes, id)
@@ -3473,6 +3497,15 @@ func (g *Gateway) attachMetrics(rt *devshardRuntime) {
 	}
 	rt.proxy.redundancy.metrics = g.metrics
 	rt.proxy.redundancy.devshardID = rt.id
+}
+
+// attachRaceCleanupBarrier wires the runtime's background race cleanups into the drain barrier so settle/store-close wait for them, not just for foreground requests.
+func (g *Gateway) attachRaceCleanupBarrier(rt *devshardRuntime) {
+	if g == nil || rt == nil || rt.proxy == nil || rt.proxy.redundancy == nil {
+		return
+	}
+	rt.proxy.redundancy.onRaceCleanupStart = func() { g.startRaceCleanup(rt) }
+	rt.proxy.redundancy.onRaceCleanupDone = func() { g.releaseRaceCleanup(rt) }
 }
 
 func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
@@ -3547,9 +3580,9 @@ func (g *Gateway) deactivateAndSettleDevshardByID(id, reason string) {
 	g.mu.Lock()
 	rt, ok := g.runtimes[id]
 	g.mu.Unlock()
-	if ok && rt.activeRequests.Load() > 0 {
-		log.Printf("settlement_queued_waiting_for_drain escrow=%s reason=%s active_requests=%d",
-			id, reason, rt.activeRequests.Load())
+	if ok && rt.escrowHasBackgroundWork() {
+		log.Printf("settlement_queued_waiting_for_drain escrow=%s reason=%s active_requests=%d pending_race_cleanup=%d",
+			id, reason, rt.activeUserRequests.Load(), rt.pendingRaceCleanup.Load())
 		return
 	}
 	g.scheduleAutoSettlement(id, reason)

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -84,6 +84,13 @@ type devshardRuntime struct {
 	activeRequests atomic.Int64
 	reservedTokens atomic.Int64
 
+	// settlementPending marks an escrow that has been deactivated and must
+	// be settled once its in-flight requests drain. settlementReason is
+	// written before the flag and read after it in the lock-free drain hook;
+	// the atomic Store→Load pair supplies the happens-before.
+	settlementPending atomic.Bool
+	settlementReason  string
+
 	activeConfigured bool
 }
 
@@ -97,6 +104,7 @@ type runtimeStatus struct {
 	ProtocolVersion      string `json:"protocol_version,omitempty"`
 	ActiveRequests       int64  `json:"active_requests"`
 	ReservedTokens       int64  `json:"reserved_tokens"`
+	SettlementPending    bool   `json:"settlement_pending,omitempty"`
 	ChainPhase           string `json:"chain_phase,omitempty"`
 	ConfirmationPoCPhase string `json:"confirmation_poc_phase,omitempty"`
 	RequestsBlocked      bool   `json:"requests_blocked"`
@@ -462,11 +470,12 @@ func sessionPhaseLabel(phase types.SessionPhase) string {
 
 func (rt *devshardRuntime) snapshot() runtimeStatus {
 	status := runtimeStatus{
-		ID:             rt.id,
-		Model:          rt.model,
-		Active:         rt.active.Load(),
-		ActiveRequests: rt.activeRequests.Load(),
-		ReservedTokens: rt.reservedTokens.Load(),
+		ID:                rt.id,
+		Model:             rt.model,
+		Active:            rt.active.Load(),
+		ActiveRequests:    rt.activeRequests.Load(),
+		ReservedTokens:    rt.reservedTokens.Load(),
+		SettlementPending: rt.settlementPending.Load(),
 	}
 	if rt.proxy != nil && rt.proxy.sm != nil && rt.proxy.session != nil {
 		phase := rt.proxy.sm.Phase()
@@ -592,6 +601,10 @@ func NewManagedGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, set
 		g.attachEscrowChecker(rt)
 	}
 	g.startEscrowRotatorIfEnabled()
+	// Settle escrows left pending by a pre-restart drain. Runs synchronously
+	// so the store read completes before the gateway serves traffic; the
+	// settlements it schedules run in their own goroutines.
+	g.reconcilePendingSettlements()
 	go g.balanceCheckLoop()
 	return g
 }
@@ -1657,8 +1670,15 @@ func (g *Gateway) reserveRuntimeLocked(rt *devshardRuntime, inputTokens int64) {
 }
 
 func (g *Gateway) releaseRuntime(rt *devshardRuntime, inputTokens int64) {
-	rt.activeRequests.Add(-1)
+	remaining := rt.activeRequests.Add(-1)
 	rt.reservedTokens.Add(-inputTokens)
+	// active=false (set during enqueue) blocks new reservations, so the count
+	// only drains downward — remaining==0 is the exact "last request finished"
+	// edge. scheduleAutoSettlement dedups, so a double-fire is harmless.
+	if remaining == 0 && rt.settlementPending.Load() {
+		log.Printf("settlement_drain_complete escrow=%s reason=%s", rt.id, rt.settlementReason)
+		g.scheduleAutoSettlement(rt.id, rt.settlementReason)
+	}
 }
 
 func (rt *devshardRuntime) validateRequestedModel(requestModel string) error {
@@ -3454,11 +3474,103 @@ func (g *Gateway) deactivateDevshardByIDWithReason(id, reason string) bool {
 	return true
 }
 
+// deactivateAndSettleDevshardByID stops new traffic to an escrow and settles
+// it. If requests are still in flight it marks the escrow settlement-pending
+// and returns; the drain hook in releaseRuntime settles once the last request
+// finishes. Otherwise it settles immediately.
 func (g *Gateway) deactivateAndSettleDevshardByID(id, reason string) {
 	if !g.deactivateDevshardByIDWithReason(id, reason) {
 		return
 	}
+	g.markSettlementPending(id, reason)
+
+	g.mu.Lock()
+	rt, ok := g.runtimes[id]
+	g.mu.Unlock()
+	if ok && rt.activeRequests.Load() > 0 {
+		log.Printf("settlement_queued_waiting_for_drain escrow=%s reason=%s active_requests=%d",
+			id, reason, rt.activeRequests.Load())
+		return
+	}
 	g.scheduleAutoSettlement(id, reason)
+}
+
+// markSettlementPending records that an escrow must be settled once its
+// in-flight requests drain. The reason is stored before the flag so the
+// lock-free drain hook in releaseRuntime reads a consistent value.
+func (g *Gateway) markSettlementPending(id, reason string) {
+	g.mu.Lock()
+	rt, ok := g.runtimes[id]
+	if ok {
+		rt.settlementReason = reason
+		rt.settlementPending.Store(true)
+	}
+	g.mu.Unlock()
+	if g.store != nil {
+		if err := g.store.SetDevshardSettlementPending(id, true); err != nil {
+			log.Printf("settlement_pending_persist_failed escrow=%s error=%v", id, err)
+		}
+	}
+}
+
+// reconcilePendingSettlements settles escrows that were marked pending before
+// a restart. After a restart no requests are in flight, so each such escrow
+// can settle immediately. Hydrates the in-memory marker too.
+func (g *Gateway) reconcilePendingSettlements() {
+	if g.store == nil {
+		return
+	}
+	state, ok, err := g.store.LoadState()
+	if err != nil || !ok {
+		if err != nil {
+			log.Printf("settlement_reconcile_load_failed error=%v", err)
+		}
+		return
+	}
+	// Honor the operator's config: when settlement is disabled, never settle on
+	// startup. Leave the marker intact so a later re-enable still settles it.
+	if !state.Settings.EscrowRotation.SettlementEnabled {
+		for _, devshard := range state.Devshards {
+			if !devshard.Active && devshard.SettlementPending {
+				log.Printf("settlement_reconcile_skipped escrow=%s reason=settlement_disabled", devshard.ID)
+			}
+		}
+		return
+	}
+	for _, devshard := range state.Devshards {
+		if devshard.Active || !devshard.SettlementPending {
+			continue
+		}
+		g.mu.Lock()
+		rt, exists := g.runtimes[devshard.ID]
+		if exists {
+			rt.settlementReason = "startup_reconcile"
+			rt.settlementPending.Store(true)
+		}
+		g.mu.Unlock()
+		if !exists {
+			log.Printf("settlement_reconcile_skipped escrow=%s reason=runtime_not_loaded", devshard.ID)
+			continue
+		}
+		log.Printf("settlement_reconcile_queued escrow=%s", devshard.ID)
+		g.scheduleAutoSettlement(devshard.ID, "startup_reconcile")
+	}
+}
+
+// clearSettlementPending is called after a successful settlement so a
+// restart-time reconcile does not re-settle the escrow.
+func (g *Gateway) clearSettlementPending(id string) {
+	g.mu.Lock()
+	rt, ok := g.runtimes[id]
+	if ok {
+		rt.settlementPending.Store(false)
+	}
+	g.mu.Unlock()
+	if g.store != nil {
+		if err := g.store.SetDevshardSettlementPending(id, false); err != nil {
+			log.Printf("settlement_pending_clear_failed escrow=%s error=%v", id, err)
+		}
+	}
 }
 
 func (g *Gateway) retireRotatedDevshard(ctx context.Context, id, reason string, settings GatewaySettings) (bool, error) {
@@ -3584,6 +3696,7 @@ func (g *Gateway) scheduleAutoSettlement(id, reason string) {
 			result, err := gatewaySettleDevshardOnChain(g, ctx, id, adminSettleEscrowRequest{})
 			cancel()
 			if err == nil {
+				g.clearSettlementPending(id)
 				log.Printf("auto_settle_submitted escrow=%s reason=%s tx_hash=%s settler=%s",
 					id, reason, result.TxHash, result.Settler)
 				return

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -91,6 +91,11 @@ type devshardRuntime struct {
 	settlementPending atomic.Bool
 	settlementReason  string
 
+	// retirePending marks a runtime whose retirement was deferred because a
+	// request was still in flight;
+	retirePending atomic.Bool
+	retireReason  string
+
 	activeConfigured bool
 }
 
@@ -1675,9 +1680,19 @@ func (g *Gateway) releaseRuntime(rt *devshardRuntime, inputTokens int64) {
 	// active=false (set during enqueue) blocks new reservations, so the count
 	// only drains downward — remaining==0 is the exact "last request finished"
 	// edge. scheduleAutoSettlement dedups, so a double-fire is harmless.
-	if remaining == 0 && rt.settlementPending.Load() {
+	if remaining != 0 {
+		return
+	}
+
+	if rt.settlementPending.Load() {
 		log.Printf("settlement_drain_complete escrow=%s reason=%s", rt.id, rt.settlementReason)
 		g.scheduleAutoSettlement(rt.id, rt.settlementReason)
+		return
+	}
+
+	if rt.retirePending.Load() {
+		log.Printf("runtime_retire_drain_complete escrow=%s reason=%s", rt.id, rt.retireReason)
+		g.retireRuntime(rt.id, rt.retireReason)
 	}
 }
 
@@ -3404,6 +3419,48 @@ func removeRuntime(runtimes []*devshardRuntime, id string) []*devshardRuntime {
 	return out
 }
 
+// retireRuntime drops a runtime from the in-memory registry and closes it,
+// releasing its user session and the per-runtime SQLite handles that session owns.
+func (g *Gateway) retireRuntime(id, reason string) bool {
+	g.mu.Lock()
+	rt := g.retireRuntimeLocked(id, reason)
+	g.mu.Unlock()
+	if rt == nil {
+		return false
+	}
+	// Close the per-runtime SQLite store outside g.mu: it is disk I/O and must
+	// not block other gateway operations that contend for the lock.
+	if err := rt.close(); err != nil {
+		log.Printf("runtime_retire_close_error escrow=%s reason=%q error=%v", id, reason, err)
+	}
+	log.Printf("runtime_retired escrow=%s reason=%q", id, reason)
+	return true
+}
+
+// retireRuntimeLocked removes the runtime from the registry and returns it so
+// the caller can close it outside the lock. It returns nil when nothing was
+// retired: the runtime is unknown, or its retirement was deferred because
+// requests are still in flight. Callers must hold g.mu.
+func (g *Gateway) retireRuntimeLocked(id, reason string) *devshardRuntime {
+	rt, ok := g.runtimes[id]
+	if !ok {
+		log.Printf("runtime_retire_skipped escrow=%s reason=%q cause=not_registered", id, reason)
+		return nil
+	}
+	if inFlight := rt.activeRequests.Load(); inFlight > 0 {
+		rt.retireReason = reason
+		rt.retirePending.Store(true)
+		log.Printf("runtime_retire_deferred escrow=%s reason=%q active_requests=%d", id, reason, inFlight)
+		return nil
+	}
+	delete(g.runtimes, id)
+	g.runtimeOrder = removeRuntime(g.runtimeOrder, id)
+	if g.capacity != nil {
+		g.capacity.RemoveEscrow(id)
+	}
+	return rt
+}
+
 func (g *Gateway) sortRuntimeOrderLocked() {
 	slices.SortFunc(g.runtimeOrder, func(a, b *devshardRuntime) int {
 		return strings.Compare(a.id, b.id)
@@ -3428,12 +3485,15 @@ func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
 		rt.proxy.redundancy.onEscrowMissing = func() {
 			go g.escrowChecker.TriggerCheck(escrowID, func() {
 				g.deactivateDevshardByID(escrowID)
+				// Escrow no longer exists on chain -- nothing to settle.
+				g.retireRuntime(escrowID, "escrow confirmed missing on chain")
 			})
 		}
 	}
 	rt.proxy.redundancy.onBalanceExhausted = func() {
 		if !g.escrowRotationEnabled() {
 			g.deactivateDevshardByIDWithReason(escrowID, "escrow balance exhausted")
+			g.retireRuntime(escrowID, "escrow balance exhausted")
 			return
 		}
 		log.Printf("gateway_replacing_exhausted_escrow escrow=%s", escrowID)
@@ -3578,12 +3638,14 @@ func (g *Gateway) retireRotatedDevshard(ctx context.Context, id, reason string, 
 		if g.deactivateDevshardByIDWithReason(id, reason) {
 			log.Printf("escrow_rotation_deactivated_without_settlement escrow=%s reason=%q", id, reason)
 		}
+		g.retireRuntime(id, reason)
 		return false, nil
 	}
 	log.Printf("escrow_rotation_settling escrow=%s reason=%q", id, reason)
 	if _, err := gatewaySettleDevshardOnChain(g, ctx, id, adminSettleEscrowRequest{}); err != nil {
 		return false, err
 	}
+	g.retireRuntime(id, reason)
 	return true, nil
 }
 
@@ -3648,6 +3710,7 @@ func (g *Gateway) replaceDepletedEscrow(ctx context.Context, id, modelID, reason
 		id, result.EscrowID, model.ModelID, reason, result.TxHash)
 	if !settings.EscrowRotation.SettlementEnabled {
 		g.deactivateDevshardByIDWithReason(id, reason)
+		g.retireRuntime(id, reason)
 	} else {
 		g.deactivateAndSettleDevshardByID(id, reason)
 	}
@@ -3699,11 +3762,16 @@ func (g *Gateway) scheduleAutoSettlement(id, reason string) {
 				g.clearSettlementPending(id)
 				log.Printf("auto_settle_submitted escrow=%s reason=%s tx_hash=%s settler=%s",
 					id, reason, result.TxHash, result.Settler)
+				g.retireRuntime(id, reason)
 				return
 			}
 			log.Printf("auto_settle_failed escrow=%s reason=%s attempt=%d/%d error=%v",
 				id, reason, attempt, autoSettlementMaxAttempts, err)
 			if attempt == autoSettlementMaxAttempts {
+				// Settlement exhausted its retries; free the in-memory runtime
+				// anyway so a permanently-unsettleable escrow cannot leak its
+				// SQLite store. On-disk state is preserved for manual recovery.
+				g.retireRuntime(id, reason)
 				return
 			}
 			time.Sleep(autoSettlementRetryInterval)

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -305,6 +305,10 @@ func buildRuntime(cfg RuntimeConfig, chainREST, defaultModel string, perf *PerfT
 	return rt, nil
 }
 
+func newRESTBridgeForProtocol(chainREST string, pv types.ProtocolVersion) *bridge.RESTBridge {
+	return bridge.NewRESTBridge(chainREST)
+}
+
 func resolveGatewayRoutePrefix() (string, error) {
 	routePrefix := strings.TrimSpace(os.Getenv("DEVSHARD_ROUTE_PREFIX"))
 	if routePrefix == "" {
@@ -321,8 +325,21 @@ func resolveGatewayRoutePrefix() (string, error) {
 	return normalized, nil
 }
 
-func newRESTBridgeForProtocol(chainREST string, pv types.ProtocolVersion) *bridge.RESTBridge {
-	return bridge.NewRESTBridge(chainREST)
+func gatewayHostRoutePrefix(override string) string {
+	override = strings.TrimSpace(override)
+	if override != "" {
+		return override
+	}
+	version := strings.TrimSpace(Version)
+	if version == "" {
+		version = "dev"
+	}
+	return devshardpkg.VersionedRoutePrefix(version)
+}
+
+func validateGatewayHostRoutePrefix(routePrefix string) error {
+	_, _, err := devshardpkg.ResolveRoutePrefix(routePrefix)
+	return err
 }
 
 // hostSlotCounts builds a slot-count map from a per-slot participant
@@ -1152,6 +1169,7 @@ func (g *Gateway) handlePooledChat(w http.ResponseWriter, r *http.Request) {
 	body, model, inputTokens, err := g.parseChatReservation(r, g.settings.DefaultModel)
 	if err != nil {
 		logRequestStage(ctx, "gateway_parse_failed", "error", err)
+		g.recordGatewayRequestOutcome(firstNonEmpty(model, g.settings.DefaultModel), "invalid_request", "invalid_request")
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), chatRequestErrorStatus(err, http.StatusBadRequest))
 		return
 	}
@@ -1161,11 +1179,13 @@ func (g *Gateway) handlePooledChat(w http.ResponseWriter, r *http.Request) {
 	requestModel := firstNonEmpty(model, g.settings.DefaultModel)
 	if err := g.validatePooledRequestedModel(requestModel); err != nil {
 		logRequestStage(ctx, "gateway_model_rejected", "model", requestModel, "error", err)
+		g.recordGatewayRequestOutcome(requestModel, "model_rejected", "model_rejected")
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), gatewayStatusCodeForError(err))
 		return
 	}
 	if err := g.modelAccessError(r, requestModel); err != nil {
 		logRequestStage(ctx, "gateway_model_temporarily_unavailable", "model", requestModel, "error", err)
+		g.recordGatewayRequestOutcome(requestModel, "model_rejected", "model_access_rejected")
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), gatewayStatusCodeForError(err))
 		return
 	}
@@ -1175,6 +1195,7 @@ func (g *Gateway) handlePooledChat(w http.ResponseWriter, r *http.Request) {
 	if entry, ok := g.chatCache.Get(cacheKey, time.Now()); ok {
 		logRequestStage(ctx, "gateway_cache_hit", "escrow", entry.EscrowID, "model", requestModel, "stream", stream)
 		g.recordCachedAccountingAlias(ctx, entry)
+		g.recordGatewayRequestOutcome(requestModel, "cached", "cache_hit")
 		serveCachedChatResponse(w, r, entry)
 		return
 	}
@@ -1184,8 +1205,10 @@ func (g *Gateway) handlePooledChat(w http.ResponseWriter, r *http.Request) {
 		g.refreshCapacityScale()
 		limitModel := requestModel
 		if err := g.limiter.AcquireForModelWithCapacity(limitModel, inputTokens, g.limiterCapacityForModel(limitModel)); err != nil {
-			g.metrics.RecordLimitRejection(limiterReasonLabel(err))
-			logRequestStage(ctx, "gateway_limiter_rejected", "reason", limiterReasonLabel(err), "input_tokens", inputTokens)
+			reason := limiterReasonLabel(err)
+			g.metrics.RecordLimitRejection(reason)
+			g.recordGatewayRequestOutcome(limitModel, "gateway_limited", reason)
+			logRequestStage(ctx, "gateway_limiter_rejected", "reason", reason, "input_tokens", inputTokens)
 			http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusTooManyRequests)
 			return
 		}
@@ -1199,8 +1222,9 @@ func (g *Gateway) handlePooledChat(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logRequestStage(ctx, "gateway_runtime_select_failed", "error", err)
 		if isParticipantRateLimitError(err) {
-			g.metrics.RecordParticipantLimitRejection("pooled_route")
+			g.metrics.RecordParticipantLimitRejection("", requestModel, "pooled_route")
 		}
+		g.recordGatewayRequestOutcome(requestModel, "runtime_unavailable", gatewayRuntimeUnavailableReason(err))
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), gatewayStatusCodeForError(err))
 		return
 	}
@@ -1260,23 +1284,27 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 	if innerPath == "/v1/chat/completions" {
 		if ok, reason := rt.acceptsNewInferences(); !ok {
 			logRequestStage(ctx, "gateway_devshard_unavailable", "escrow", devshardID, "reason", reason)
+			g.recordGatewayRequestOutcome(firstNonEmpty(rt.model, g.settings.DefaultModel), "runtime_unavailable", runtimeSkipReasonKey(reason))
 			http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s is unavailable for new inferences: %s"}}`, devshardID, reason), http.StatusConflict)
 			return
 		}
 		body, model, inputTokens, err := g.parseChatReservation(r, firstNonEmpty(rt.model, g.settings.DefaultModel))
 		if err != nil {
 			logRequestStage(ctx, "gateway_devshard_parse_failed", "escrow", devshardID, "error", err)
+			g.recordGatewayRequestOutcome(firstNonEmpty(model, rt.model, g.settings.DefaultModel), "invalid_request", "invalid_request")
 			http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), chatRequestErrorStatus(err, http.StatusBadRequest))
 			return
 		}
 		if err := rt.validateRequestedModel(model); err != nil {
 			logRequestStage(ctx, "gateway_devshard_model_rejected", "escrow", devshardID, "model", model, "error", err)
+			g.recordGatewayRequestOutcome(firstNonEmpty(model, rt.model, g.settings.DefaultModel), "model_rejected", "model_rejected")
 			http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), gatewayStatusCodeForError(err))
 			return
 		}
 		limitModel := firstNonEmpty(model, rt.model, g.settings.DefaultModel)
 		if err := g.modelAccessError(r, limitModel); err != nil {
 			logRequestStage(ctx, "gateway_devshard_model_temporarily_unavailable", "escrow", devshardID, "model", limitModel, "error", err)
+			g.recordGatewayRequestOutcome(limitModel, "model_rejected", "model_access_rejected")
 			http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), gatewayStatusCodeForError(err))
 			return
 		}
@@ -1285,6 +1313,7 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := g.chatCache.Get(cacheKey, time.Now()); ok {
 			logRequestStage(ctx, "gateway_devshard_cache_hit", "escrow", entry.EscrowID, "model", limitModel, "stream", stream)
 			g.recordCachedAccountingAlias(ctx, entry)
+			g.recordGatewayRequestOutcome(limitModel, "cached", "cache_hit")
 			serveCachedChatResponse(w, r, entry)
 			return
 		}
@@ -1292,8 +1321,10 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 		if capacityAwareLimitsEnabled() || !relaxedPoCBypassActive() {
 			g.refreshCapacityScale()
 			if err := g.limiter.AcquireForModelWithCapacity(limitModel, inputTokens, g.limiterCapacityForModel(limitModel)); err != nil {
-				g.metrics.RecordLimitRejection(limiterReasonLabel(err))
-				logRequestStage(ctx, "gateway_devshard_limiter_rejected", "escrow", devshardID, "reason", limiterReasonLabel(err), "input_tokens", inputTokens)
+				reason := limiterReasonLabel(err)
+				g.metrics.RecordLimitRejection(reason)
+				g.recordGatewayRequestOutcome(limitModel, "gateway_limited", reason)
+				logRequestStage(ctx, "gateway_devshard_limiter_rejected", "escrow", devshardID, "reason", reason, "input_tokens", inputTokens)
 				http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusTooManyRequests)
 				return
 			}
@@ -1386,6 +1417,28 @@ func (g *Gateway) serveChatToRuntime(rt *devshardRuntime, path string, body []by
 	capture := &gatewayChatCacheCapture{ResponseWriter: w}
 	rt.handler.ServeHTTP(capture, req)
 	return capture
+}
+
+func (g *Gateway) recordGatewayRequestOutcome(model, outcome, reason string) {
+	if g == nil || g.metrics == nil {
+		return
+	}
+	g.metrics.RecordGatewayRequest(model, outcome, reason)
+	switch outcome {
+	case "failed", "runtime_unavailable", "gateway_limited", "invalid_request", "model_rejected", "gateway_disabled":
+		g.metrics.RecordCriticalUserFailure(model, reason)
+	}
+}
+
+func gatewayRuntimeUnavailableReason(err error) string {
+	switch {
+	case err == nil:
+		return "runtime_unavailable"
+	case isParticipantRateLimitError(err):
+		return "participant_limited"
+	default:
+		return "runtime_unavailable"
+	}
 }
 
 func (g *Gateway) recordCachedAccountingAlias(ctx context.Context, entry cachedChatResponse) {

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -56,7 +56,7 @@ type Gateway struct {
 	baseStorageDir        string
 	rotatorStop           chan struct{}
 	rotatorDone           chan struct{}
-	rotationFailures      map[string]struct{}
+	rotationBreakers      map[string]*rotationBreaker
 	finalizeMu            sync.Mutex
 	settlementMu          sync.Mutex
 	settlementInFlight    map[string]struct{}
@@ -565,7 +565,7 @@ func NewGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, defaultMod
 		settings: GatewaySettings{
 			DefaultModel: defaultModel,
 		},
-		rotationFailures:   make(map[string]struct{}),
+		rotationBreakers:   make(map[string]*rotationBreaker),
 		settlementInFlight: make(map[string]struct{}),
 	}
 	g.participantLimiter.SetMetrics(g.metrics)
@@ -613,6 +613,7 @@ func NewManagedGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, set
 	for _, rt := range g.runtimeOrder {
 		g.attachEscrowChecker(rt)
 	}
+	go g.reconcileCommitments(context.Background(), settings)
 	g.startEscrowRotatorIfEnabled()
 	// Settle escrows left pending by a pre-restart drain. Runs synchronously
 	// so the store read completes before the gateway serves traffic; the
@@ -2799,7 +2800,7 @@ func (g *Gateway) handleAdminEscrows(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusBadRequest)
 		return
 	}
-	result, err := txClient.CreateDevshardEscrow(r.Context(), signer, req.Amount, modelID)
+	result, err := txClient.CreateDevshardEscrow(r.Context(), signer, req.Amount, modelID, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusBadGateway)
 		return
@@ -2879,7 +2880,7 @@ func (g *Gateway) addCreatedEscrowRuntime(record GatewayDevshardState) (GatewayD
 		return record, fmt.Errorf("gateway state is not initialized")
 	}
 	if _, exists := g.runtimes[record.ID]; exists {
-		return record, fmt.Errorf("devshard %s already exists", record.ID)
+		return record, fmt.Errorf("devshard %s: %w", record.ID, errDevshardAlreadyExists)
 	}
 	if record.Model == "" {
 		record.Model = state.Settings.DefaultModel

--- a/devshard/cmd/devshardctl/gateway_race_cleanup_barrier_test.go
+++ b/devshard/cmd/devshardctl/gateway_race_cleanup_barrier_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A speculative race returns to the client on the winner and hands its still
+// pending losers to a background race cleanup (finishRaceWhenPendingDone) that
+// keeps refunding reserved cost and persisting loser signatures on
+// context.Background() for up to SecondaryWaitAfterWinner. That cleanup holds no
+// activeUserRequests slot, so the drain barrier must track it separately:
+// settling (which reads the balance the cleanup is still mutating) and retiring
+// (which closes the SQLite store the cleanup is still writing to) must both wait
+// until the cleanup drains too.
+
+// TestReleaseRuntimeDefersSettleWhilePendingRaceCleanup pins the money branch: a
+// runtime with a pending race cleanup must NOT settle when its last foreground
+// request drains — only once the cleanup completes as well.
+func TestReleaseRuntimeDefersSettleWhilePendingRaceCleanup(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt)
+
+	g.reserveRuntime(rt, 1) // the one in-flight foreground request
+	g.startRaceCleanup(rt)  // its background race cleanup, spawned before it returns
+	rt.settlementReason = "low_balance"
+	rt.settlementPending.Store(true)
+
+	g.releaseRuntime(rt, 1) // foreground request returns; cleanup still in flight
+	require.Never(t, func() bool { return settled.Load() > 0 }, 200*time.Millisecond, 20*time.Millisecond,
+		"settlement must not fire while a background race cleanup is still refunding/persisting")
+
+	g.releaseRaceCleanup(rt) // cleanup drains
+	require.Eventually(t, func() bool { return settled.Load() == 1 }, time.Second, 10*time.Millisecond,
+		"settlement must fire exactly once, after the cleanup drains")
+}
+
+// TestReleaseRuntimeDefersRetireWhilePendingRaceCleanup pins the durability
+// branch: retirement (which closes the per-runtime SQLite store) must defer
+// while a race cleanup is still writing loser signatures, and fire once it drains.
+func TestReleaseRuntimeDefersRetireWhilePendingRaceCleanup(t *testing.T) {
+	g, rt := newRetireTestGateway("12")
+	g.reserveRuntime(rt, 0) // the one in-flight foreground request
+	g.startRaceCleanup(rt)  // its background race cleanup
+	rt.retireReason = "balance exhausted"
+	rt.retirePending.Store(true)
+
+	g.releaseRuntime(rt, 0) // foreground request returns; cleanup still in flight
+	_, stillRegistered := g.runtimes["12"]
+	require.True(t, stillRegistered, "retire must defer while a race cleanup is in flight")
+
+	g.releaseRaceCleanup(rt) // cleanup drains
+	_, stillRegistered = g.runtimes["12"]
+	require.False(t, stillRegistered, "retire fires once the cleanup drains")
+	require.Empty(t, g.runtimeOrder)
+}
+
+// TestGoTrackedRaceCleanupStartsBarrierSynchronously pins the ordering contract
+// the fix depends on: the start hook must fire synchronously, before the cleanup
+// goroutine is spawned, so a winning foreground handler that returns and drops
+// activeUserRequests immediately afterwards can never observe the runtime as
+// quiet while this cleanup is still in flight.
+func TestGoTrackedRaceCleanupStartsBarrierSynchronously(t *testing.T) {
+	var started, done atomic.Int64
+	release := make(chan struct{})
+	redundancy := &Redundancy{
+		onRaceCleanupStart: func() { started.Add(1) },
+		onRaceCleanupDone:  func() { done.Add(1) },
+	}
+
+	redundancy.goTrackedRaceCleanup(func() { <-release })
+
+	require.Equal(t, int64(1), started.Load(), "start hook must fire before goTrackedRaceCleanup returns")
+	require.Equal(t, int64(0), done.Load(), "done hook must not fire while the cleanup runs")
+
+	close(release)
+	require.Eventually(t, func() bool { return done.Load() == 1 }, time.Second, 10*time.Millisecond,
+		"done hook must fire once the cleanup completes")
+}
+
+// TestConcurrentDrainSettlesExactlyOnce guards the two-counter drain: when the
+// last foreground request and the last race cleanup reach zero concurrently,
+// exactly one of the racing drain paths must settle — never zero (a lost
+// wakeup) and, thanks to dedup, never twice.
+func TestConcurrentDrainSettlesExactlyOnce(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt)
+
+	g.reserveRuntime(rt, 1)
+	g.startRaceCleanup(rt)
+	rt.settlementReason = "low_balance"
+	rt.settlementPending.Store(true)
+
+	var ready sync.WaitGroup
+	ready.Add(2)
+	start := make(chan struct{})
+	go func() { ready.Done(); <-start; g.releaseRuntime(rt, 1) }()
+	go func() { ready.Done(); <-start; g.releaseRaceCleanup(rt) }()
+	ready.Wait()
+	close(start) // release both drains as simultaneously as the scheduler allows
+
+	require.Eventually(t, func() bool { return settled.Load() == 1 }, time.Second, 10*time.Millisecond,
+		"a concurrent drain must settle exactly once")
+	require.Never(t, func() bool { return settled.Load() > 1 }, 200*time.Millisecond, 20*time.Millisecond,
+		"dedup must keep a double drain from settling twice")
+}

--- a/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
+++ b/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
@@ -17,7 +17,7 @@ func newRetireTestGateway(id string) (*Gateway, *devshardRuntime) {
 	g := &Gateway{
 		runtimes:         map[string]*devshardRuntime{id: rt},
 		runtimeOrder:     []*devshardRuntime{rt},
-		rotationFailures: make(map[string]struct{}),
+		rotationBreakers: make(map[string]*rotationBreaker),
 	}
 	return g, rt
 }

--- a/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
+++ b/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newRetireTestGateway builds a minimal Gateway holding a single active runtime
+// registered in both the lookup map and the ordered slice, mirroring how the
+// real registry is populated.
+func newRetireTestGateway(id string) (*Gateway, *devshardRuntime) {
+	rt := &devshardRuntime{id: id}
+	rt.active.Store(true)
+	g := &Gateway{
+		runtimes:         map[string]*devshardRuntime{id: rt},
+		runtimeOrder:     []*devshardRuntime{rt},
+		rotationFailures: make(map[string]struct{}),
+	}
+	return g, rt
+}
+
+// TestRetireRuntimeRemovesRuntimeFromRegistry pins the core leak fix: retiring a
+// runtime must drop it from both g.runtimes and g.runtimeOrder so its
+// user.Session (and the per-runtime SQLite handles it owns) can be released.
+func TestRetireRuntimeRemovesRuntimeFromRegistry(t *testing.T) {
+	g, _ := newRetireTestGateway("12")
+
+	require.True(t, g.retireRuntime("12", "test"))
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "runtime must be removed from g.runtimes")
+	require.Empty(t, g.runtimeOrder, "runtime must be removed from g.runtimeOrder")
+
+	// Idempotent: retiring an already-gone runtime is a no-op, not a panic.
+	require.False(t, g.retireRuntime("12", "test"))
+}
+
+// TestRetireRuntimeDefersWhileRequestsInFlight guards against closing a SQLite
+// store out from under an in-flight request: retirement must defer (and leave
+// the runtime registered) until the request count drains to zero.
+func TestRetireRuntimeDefersWhileRequestsInFlight(t *testing.T) {
+	g, rt := newRetireTestGateway("12")
+	rt.activeRequests.Store(1)
+
+	require.False(t, g.retireRuntime("12", "busy"))
+	_, stillRegistered := g.runtimes["12"]
+	require.True(t, stillRegistered, "busy runtime must stay registered")
+	require.True(t, rt.retirePending.Load(), "deferred retire must record its intent")
+	require.Equal(t, "busy", rt.retireReason)
+
+	rt.activeRequests.Store(0)
+	require.True(t, g.retireRuntime("12", "drained"))
+	_, stillRegistered = g.runtimes["12"]
+	require.False(t, stillRegistered)
+}
+
+// TestReleaseRuntimeRetiresAfterDrain: a retire deferred while busy fires once
+// the last request drains through releaseRuntime.
+func TestReleaseRuntimeRetiresAfterDrain(t *testing.T) {
+	g, rt := newRetireTestGateway("12")
+	rt.activeRequests.Store(1)
+
+	require.False(t, g.retireRuntime("12", "balance exhausted"))
+	_, stillRegistered := g.runtimes["12"]
+	require.True(t, stillRegistered, "busy runtime must stay registered")
+
+	g.releaseRuntime(rt, 0)
+
+	_, stillRegistered = g.runtimes["12"]
+	require.False(t, stillRegistered, "drained runtime must be retired by releaseRuntime")
+	require.Empty(t, g.runtimeOrder)
+}
+
+// TestReleaseRuntimeRetiresWithOnlyRetirePending exercises the retire branch in
+// isolation: only retirePending set (no settlement), drain → retire.
+func TestReleaseRuntimeRetiresWithOnlyRetirePending(t *testing.T) {
+	g, rt := newRetireTestGateway("12")
+	rt.activeRequests.Store(1)
+	rt.retireReason = "balance exhausted"
+	rt.retirePending.Store(true)
+
+	g.releaseRuntime(rt, 0)
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "retire branch must fire on drain")
+	require.Empty(t, g.runtimeOrder)
+}
+
+// TestReleaseRuntimeDefersWhileRequestsRemain: while remaining != 0 nothing
+// fires; settled stays 0 until the last request drains. Uses settlementPending
+// because scheduleAutoSettlement fires regardless of the live count, so a
+// broken guard leaks as settled>0 (retire would self-defer and hide it).
+func TestReleaseRuntimeDefersWhileRequestsRemain(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt)
+
+	g.reserveRuntime(rt, 1)
+	g.reserveRuntime(rt, 1)
+	rt.settlementReason = "low_balance"
+	rt.settlementPending.Store(true)
+
+	g.releaseRuntime(rt, 1) // remaining == 1 → quiet
+	require.Never(t, func() bool { return settled.Load() > 0 }, 200*time.Millisecond, 20*time.Millisecond)
+
+	g.releaseRuntime(rt, 1) // remaining == 0 → settles once
+	require.Eventually(t, func() bool { return settled.Load() == 1 }, time.Second, 10*time.Millisecond)
+}
+
+// TestRetireRotatedDevshardRetiresWithoutSettlement covers the no-settle
+// terminal path: when settlement is disabled, the rotated-out runtime is
+// deactivated AND retired in the same step.
+func TestRetireRotatedDevshardRetiresWithoutSettlement(t *testing.T) {
+	g, _ := newRetireTestGateway("12")
+	settings := GatewaySettings{EscrowRotation: EscrowRotationSettings{SettlementEnabled: false}}
+
+	settled, err := g.retireRotatedDevshard(context.Background(), "12", "rotated", settings)
+	require.NoError(t, err)
+	require.False(t, settled)
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "no-settle rotation must retire the runtime")
+}
+
+// TestRetireRotatedDevshardRetiresAfterSettlement covers the settle terminal
+// path: the runtime stays alive through settlement (which reads its session)
+// and is retired only once settlement succeeds.
+func TestRetireRotatedDevshardRetiresAfterSettlement(t *testing.T) {
+	g, _ := newRetireTestGateway("12")
+	settings := GatewaySettings{EscrowRotation: EscrowRotationSettings{SettlementEnabled: true}}
+
+	oldSettle := gatewaySettleDevshardOnChain
+	gatewaySettleDevshardOnChain = func(g *Gateway, _ context.Context, id string, _ adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		// The session must still be reachable at settlement time.
+		_, ok := g.runtimes[id]
+		require.True(t, ok, "runtime must still be registered during settlement")
+		return &SettleDevshardEscrowResult{TxHash: "OK"}, nil
+	}
+	t.Cleanup(func() { gatewaySettleDevshardOnChain = oldSettle })
+
+	settled, err := g.retireRotatedDevshard(context.Background(), "12", "rotated", settings)
+	require.NoError(t, err)
+	require.True(t, settled)
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "settled rotation must retire the runtime")
+}

--- a/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
+++ b/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
@@ -43,7 +43,7 @@ func TestRetireRuntimeRemovesRuntimeFromRegistry(t *testing.T) {
 // the runtime registered) until the request count drains to zero.
 func TestRetireRuntimeDefersWhileRequestsInFlight(t *testing.T) {
 	g, rt := newRetireTestGateway("12")
-	rt.activeRequests.Store(1)
+	rt.activeUserRequests.Store(1)
 
 	require.False(t, g.retireRuntime("12", "busy"))
 	_, stillRegistered := g.runtimes["12"]
@@ -51,7 +51,7 @@ func TestRetireRuntimeDefersWhileRequestsInFlight(t *testing.T) {
 	require.True(t, rt.retirePending.Load(), "deferred retire must record its intent")
 	require.Equal(t, "busy", rt.retireReason)
 
-	rt.activeRequests.Store(0)
+	rt.activeUserRequests.Store(0)
 	require.True(t, g.retireRuntime("12", "drained"))
 	_, stillRegistered = g.runtimes["12"]
 	require.False(t, stillRegistered)
@@ -61,7 +61,7 @@ func TestRetireRuntimeDefersWhileRequestsInFlight(t *testing.T) {
 // the last request drains through releaseRuntime.
 func TestReleaseRuntimeRetiresAfterDrain(t *testing.T) {
 	g, rt := newRetireTestGateway("12")
-	rt.activeRequests.Store(1)
+	rt.activeUserRequests.Store(1)
 
 	require.False(t, g.retireRuntime("12", "balance exhausted"))
 	_, stillRegistered := g.runtimes["12"]
@@ -78,7 +78,7 @@ func TestReleaseRuntimeRetiresAfterDrain(t *testing.T) {
 // isolation: only retirePending set (no settlement), drain → retire.
 func TestReleaseRuntimeRetiresWithOnlyRetirePending(t *testing.T) {
 	g, rt := newRetireTestGateway("12")
-	rt.activeRequests.Store(1)
+	rt.activeUserRequests.Store(1)
 	rt.retireReason = "balance exhausted"
 	rt.retirePending.Store(true)
 

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -95,7 +95,7 @@ type EscrowRotationModelSettings struct {
 	TempCount     int    `json:"temp_count"`
 	TargetCount   int    `json:"target_count"`
 	Amount        uint64 `json:"amount"`
-	PrivateKeyEnv string `json:"private_key_env"`
+	PrivateKeyEnv string `json:"private_key_env"` // trimmed by WithTuningDefaults on settings load
 }
 
 const (
@@ -1027,7 +1027,7 @@ type GatewayEscrowCommitment struct {
 	Epoch         uint64
 	PrivateKeyEnv string
 	BlockHeight   uint64
-	CreatedAt     string
+	CreatedAt     time.Time
 }
 
 // SaveCommitment records a create intent, keyed by tx hash.
@@ -1035,7 +1035,12 @@ func (s *GatewayStore) SaveCommitment(c GatewayEscrowCommitment) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("gateway store unavailable")
 	}
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	createdAt := c.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	} else {
+		createdAt = createdAt.UTC()
+	}
 	_, err := s.db.Exec(`
 		INSERT OR REPLACE INTO escrow_rotation_commitments (
 			tx_hash, model, role, epoch, private_key_env, block_height, created_at
@@ -1044,14 +1049,28 @@ func (s *GatewayStore) SaveCommitment(c GatewayEscrowCommitment) error {
 		strings.TrimSpace(c.Model),
 		strings.TrimSpace(c.Role),
 		c.Epoch,
-		strings.TrimSpace(c.PrivateKeyEnv),
+		c.PrivateKeyEnv,
 		c.BlockHeight,
-		now,
+		createdAt,
 	)
 	if err != nil {
 		return fmt.Errorf("save escrow commitment tx=%s: %w", c.TxHash, err)
 	}
 	return nil
+}
+
+func scanGatewayDBTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return t.UTC()
+	}
+	if t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", raw); err == nil {
+		return t.UTC()
+	}
+	return time.Time{}
 }
 
 // LoadCommitments returns all pending commitments (oldest first).
@@ -1070,9 +1089,11 @@ func (s *GatewayStore) LoadCommitments() ([]GatewayEscrowCommitment, error) {
 	var commitments []GatewayEscrowCommitment
 	for rows.Next() {
 		var c GatewayEscrowCommitment
-		if err := rows.Scan(&c.TxHash, &c.Model, &c.Role, &c.Epoch, &c.PrivateKeyEnv, &c.BlockHeight, &c.CreatedAt); err != nil {
+		var createdAt string
+		if err := rows.Scan(&c.TxHash, &c.Model, &c.Role, &c.Epoch, &c.PrivateKeyEnv, &c.BlockHeight, &createdAt); err != nil {
 			return nil, fmt.Errorf("scan escrow commitment: %w", err)
 		}
+		c.CreatedAt = scanGatewayDBTime(createdAt)
 		commitments = append(commitments, c)
 	}
 	return commitments, rows.Err()

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -314,6 +314,19 @@ func NewGatewayStore(path string) (*GatewayStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open gateway store: %w", err)
 	}
+	// Serialize access and wait on contention instead of failing with "database is
+	// locked". Mirrors storage/sqlite.go.
+	db.SetMaxOpenConns(1)
+	for _, pragma := range []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA synchronous=NORMAL",
+		"PRAGMA busy_timeout=5000",
+	} {
+		if _, err := db.Exec(pragma); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("apply gateway store pragma %q: %w", pragma, err)
+		}
+	}
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS gateway_settings (
 			id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -479,6 +492,19 @@ func NewGatewayStore(path string) (*GatewayStore, error) {
 	)`); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("init gateway suspicious hosts table: %w", err)
+	}
+	// Write-ahead intent for an escrow create (written before the on-chain tx).
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS escrow_rotation_commitments (
+		tx_hash TEXT PRIMARY KEY,
+		model TEXT NOT NULL,
+		role TEXT NOT NULL DEFAULT '',
+		epoch INTEGER NOT NULL DEFAULT 0,
+		private_key_env TEXT NOT NULL DEFAULT '',
+		block_height INTEGER NOT NULL DEFAULT 0,
+		created_at TEXT NOT NULL
+	)`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("init escrow rotation commitments table: %w", err)
 	}
 	if err := ensureColumn(db, "participant_throttle_state", "quarantine_until_utc", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		db.Close()
@@ -991,6 +1017,76 @@ func (s *GatewayStore) LoadRotationStatuses(limit int) ([]GatewayRotationStatus,
 		return nil, err
 	}
 	return statuses, nil
+}
+
+// GatewayEscrowCommitment is the write-ahead intent for one escrow create, keyed by tx hash.
+type GatewayEscrowCommitment struct {
+	TxHash        string
+	Model         string
+	Role          string
+	Epoch         uint64
+	PrivateKeyEnv string
+	BlockHeight   uint64
+	CreatedAt     string
+}
+
+// SaveCommitment records a create intent, keyed by tx hash.
+func (s *GatewayStore) SaveCommitment(c GatewayEscrowCommitment) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("gateway store unavailable")
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.db.Exec(`
+		INSERT OR REPLACE INTO escrow_rotation_commitments (
+			tx_hash, model, role, epoch, private_key_env, block_height, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		strings.TrimSpace(c.TxHash),
+		strings.TrimSpace(c.Model),
+		strings.TrimSpace(c.Role),
+		c.Epoch,
+		strings.TrimSpace(c.PrivateKeyEnv),
+		c.BlockHeight,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("save escrow commitment tx=%s: %w", c.TxHash, err)
+	}
+	return nil
+}
+
+// LoadCommitments returns all pending commitments (oldest first).
+func (s *GatewayStore) LoadCommitments() ([]GatewayEscrowCommitment, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT tx_hash, model, role, epoch, private_key_env, block_height, created_at
+		FROM escrow_rotation_commitments
+		ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("load escrow commitments: %w", err)
+	}
+	defer rows.Close()
+	var commitments []GatewayEscrowCommitment
+	for rows.Next() {
+		var c GatewayEscrowCommitment
+		if err := rows.Scan(&c.TxHash, &c.Model, &c.Role, &c.Epoch, &c.PrivateKeyEnv, &c.BlockHeight, &c.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan escrow commitment: %w", err)
+		}
+		commitments = append(commitments, c)
+	}
+	return commitments, rows.Err()
+}
+
+// DeleteCommitment clears a commitment once its escrow is persisted (or proven absent).
+func (s *GatewayStore) DeleteCommitment(txHash string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("gateway store unavailable")
+	}
+	if _, err := s.db.Exec(`DELETE FROM escrow_rotation_commitments WHERE tx_hash = ?`, strings.TrimSpace(txHash)); err != nil {
+		return fmt.Errorf("delete escrow commitment tx=%s: %w", txHash, err)
+	}
+	return nil
 }
 
 func (s *GatewayStore) LoadSuspiciousHosts() ([]GatewaySuspiciousHost, error) {

--- a/devshard/cmd/devshardctl/gateway_store.go
+++ b/devshard/cmd/devshardctl/gateway_store.go
@@ -285,11 +285,12 @@ func normalizeGatewayModelAccess(access []GatewayModelAccessSettings) []GatewayM
 
 type GatewayDevshardState struct {
 	RuntimeConfig
-	Active        bool   `json:"active"`
-	RotationRole  string `json:"rotation_role,omitempty"`
-	RotationEpoch uint64 `json:"rotation_epoch,omitempty"`
-	CreatedAt     string `json:"created_at,omitempty"`
-	UpdatedAt     string `json:"updated_at,omitempty"`
+	Active            bool   `json:"active"`
+	SettlementPending bool   `json:"settlement_pending,omitempty"`
+	RotationRole      string `json:"rotation_role,omitempty"`
+	RotationEpoch     uint64 `json:"rotation_epoch,omitempty"`
+	CreatedAt         string `json:"created_at,omitempty"`
+	UpdatedAt         string `json:"updated_at,omitempty"`
 }
 
 type GatewaySuspiciousHost struct {
@@ -375,6 +376,7 @@ func NewGatewayStore(path string) (*GatewayStore, error) {
 			active INTEGER NOT NULL DEFAULT 1,
 			rotation_role TEXT NOT NULL DEFAULT '',
 			rotation_epoch INTEGER NOT NULL DEFAULT 0,
+			settlement_pending INTEGER NOT NULL DEFAULT 0,
 			created_at TEXT NOT NULL,
 			updated_at TEXT NOT NULL
 		)`,
@@ -436,6 +438,10 @@ func NewGatewayStore(path string) (*GatewayStore, error) {
 	if err := ensureGatewayDevshardsColumn(db, "rotation_epoch", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("migrate gateway devshard epoch: %w", err)
+	}
+	if err := ensureGatewayDevshardsColumn(db, "settlement_pending", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate gateway devshard settlement_pending: %w", err)
 	}
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS participant_throttle_state (
 		participant_key TEXT PRIMARY KEY,
@@ -626,7 +632,7 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 
 	rows, err := s.db.Query(`
 		SELECT id, private_key_hex, private_key_env, model, storage_path, active, created_at, updated_at, protocol_version,
-		       rotation_role, rotation_epoch
+		       rotation_role, rotation_epoch, settlement_pending
 		FROM gateway_devshards
 		ORDER BY id`)
 	if err != nil {
@@ -636,6 +642,7 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 	for rows.Next() {
 		var devshard GatewayDevshardState
 		var active int
+		var settlementPending int
 		if err := rows.Scan(
 			&devshard.ID,
 			&devshard.PrivateKeyHex,
@@ -648,10 +655,12 @@ func (s *GatewayStore) LoadState() (GatewayState, bool, error) {
 			&devshard.ProtocolVersion,
 			&devshard.RotationRole,
 			&devshard.RotationEpoch,
+			&settlementPending,
 		); err != nil {
 			return GatewayState{}, false, fmt.Errorf("scan gateway devshard: %w", err)
 		}
 		devshard.Active = active != 0
+		devshard.SettlementPending = settlementPending != 0
 		state.Devshards = append(state.Devshards, devshard)
 	}
 	if err := rows.Err(); err != nil {
@@ -1081,11 +1090,16 @@ func (s *GatewayStore) UpsertDevshard(devshard GatewayDevshardState) error {
 func (s *GatewayStore) upsertDevshardTx(tx *sql.Tx, devshard GatewayDevshardState, now string) error {
 	createdAt := now
 	_ = tx.QueryRow(`SELECT created_at FROM gateway_devshards WHERE id = ?`, devshard.ID).Scan(&createdAt)
+	// Preserve the existing settlement_pending marker so an unrelated upsert
+	// never silently clears a queued settlement; a brand-new row falls back
+	// to the value carried on devshard.
+	settlementPending := gatewayBoolToInt(devshard.SettlementPending)
+	_ = tx.QueryRow(`SELECT settlement_pending FROM gateway_devshards WHERE id = ?`, devshard.ID).Scan(&settlementPending)
 	if _, err := tx.Exec(`
 		INSERT OR REPLACE INTO gateway_devshards (
 			id, private_key_hex, private_key_env, model, storage_path, active, created_at, updated_at, protocol_version,
-			rotation_role, rotation_epoch
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			rotation_role, rotation_epoch, settlement_pending
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strings.TrimSpace(devshard.ID),
 		strings.TrimSpace(devshard.PrivateKeyHex),
 		strings.TrimSpace(devshard.PrivateKeyEnv),
@@ -1097,6 +1111,7 @@ func (s *GatewayStore) upsertDevshardTx(tx *sql.Tx, devshard GatewayDevshardStat
 		strings.TrimSpace(devshard.ProtocolVersion),
 		strings.TrimSpace(devshard.RotationRole),
 		devshard.RotationEpoch,
+		settlementPending,
 	); err != nil {
 		return fmt.Errorf("upsert gateway devshard %s: %w", devshard.ID, err)
 	}
@@ -1114,6 +1129,28 @@ func (s *GatewayStore) SetDevshardActive(id string, active bool) error {
 	)
 	if err != nil {
 		return fmt.Errorf("update devshard %s active=%t: %w", id, active, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected for devshard %s: %w", id, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("devshard %s not found", id)
+	}
+	return nil
+}
+
+func (s *GatewayStore) SetDevshardSettlementPending(id string, pending bool) error {
+	res, err := s.db.Exec(`
+		UPDATE gateway_devshards
+		SET settlement_pending = ?, updated_at = ?
+		WHERE id = ?`,
+		gatewayBoolToInt(pending),
+		time.Now().UTC().Format(time.RFC3339Nano),
+		strings.TrimSpace(id),
+	)
+	if err != nil {
+		return fmt.Errorf("update devshard %s settlement_pending=%t: %w", id, pending, err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -787,6 +787,49 @@ func TestEscrowRotationUsesEpochSwitchHeightDuringPoC(t *testing.T) {
 	require.Equal(t, 1, settleAttempts)
 }
 
+func TestGatewayStoreSetDevshardSettlementPending(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST: "http://node:1317", DefaultModel: "m", DefaultRequestMaxTokens: 1000,
+	}.WithTuningDefaults(), []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "m"},
+		Active:        true,
+	}}))
+
+	// Default is not pending.
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, gatewayDevshardsByID(state.Devshards)["12"].SettlementPending)
+
+	// Set pending → persisted and survives reload.
+	require.NoError(t, store.SetDevshardSettlementPending("12", true))
+	state, _, err = store.LoadState()
+	require.NoError(t, err)
+	require.True(t, gatewayDevshardsByID(state.Devshards)["12"].SettlementPending)
+
+	// An unrelated upsert must NOT wipe the pending marker.
+	require.NoError(t, store.UpsertDevshard(GatewayDevshardState{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "m"},
+		Active:        false,
+	}))
+	state, _, err = store.LoadState()
+	require.NoError(t, err)
+	require.True(t, gatewayDevshardsByID(state.Devshards)["12"].SettlementPending)
+
+	// Clear pending.
+	require.NoError(t, store.SetDevshardSettlementPending("12", false))
+	state, _, err = store.LoadState()
+	require.NoError(t, err)
+	require.False(t, gatewayDevshardsByID(state.Devshards)["12"].SettlementPending)
+
+	// Unknown id errors.
+	require.Error(t, store.SetDevshardSettlementPending("nope", true))
+}
+
 func gatewayDevshardsByID(devshards []GatewayDevshardState) map[string]GatewayDevshardState {
 	byID := make(map[string]GatewayDevshardState, len(devshards))
 	for _, devshard := range devshards {

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -303,6 +303,25 @@ func TestValidateGatewaySettingsRequiresRotationModels(t *testing.T) {
 	require.Contains(t, err.Error(), "duplicate model_id")
 }
 
+func TestGatewaySettingsWithTuningDefaultsTrimsPrivateKeyEnv(t *testing.T) {
+	settings := GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       " Qwen/Test ",
+				PrivateKeyEnv: "  KIMI_KEY  ",
+			}},
+		},
+	}.WithTuningDefaults()
+
+	require.Equal(t, "Qwen/Test", settings.EscrowRotation.Models[0].ModelID)
+	require.Equal(t, "KIMI_KEY", settings.EscrowRotation.Models[0].PrivateKeyEnv)
+}
+
 func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)
@@ -358,8 +377,8 @@ func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testi
 	})
 
 	g := &Gateway{store: store}
-	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
-	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.prepareBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.prepareBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 0, settleAttempts)
@@ -438,8 +457,8 @@ func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.
 	})
 
 	g := &Gateway{store: store}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 11}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 0, settleAttempts)
@@ -508,7 +527,7 @@ func TestEscrowRotationSkipsCreateWhenModelAbsentFromNetwork(t *testing.T) {
 	)
 
 	g := &Gateway{store: store, capacity: capacity, rotationBreakers: make(map[string]*rotationBreaker)}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 0, createAttempts, "must not create escrow for a model absent from the network")
 	require.Equal(t, []string{"12"}, settled, "stranded temp escrow must still be settled")
@@ -570,7 +589,7 @@ func TestEscrowRotationCreatesWhenModelPresentInNetwork(t *testing.T) {
 	)
 
 	g := &Gateway{store: store, capacity: capacity, rotationBreakers: make(map[string]*rotationBreaker)}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 2, createAttempts, "must create escrows for a model the network serves")
 }
@@ -625,7 +644,7 @@ func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 	})
 
 	g := &Gateway{store: store}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 2, createAttempts)
 	require.Equal(t, []string{"12"}, settled)
@@ -690,7 +709,7 @@ func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenSettlementD
 	rt := &devshardRuntime{id: "12"}
 	rt.active.Store(true)
 	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}}
-	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.prepareBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 0, settleAttempts)
@@ -758,7 +777,7 @@ func TestEscrowRotationFinishDeactivatesTempWithoutSettlementWhenSettlementDisab
 	rt := &devshardRuntime{id: "12"}
 	rt.active.Store(true)
 	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}}
-	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.finishBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 0, settleAttempts)
@@ -836,7 +855,7 @@ func TestEscrowRotationPrepareRotatesModelsIndependently(t *testing.T) {
 	})
 
 	g := &Gateway{store: store}
-	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
+	g.prepareBridgeEscrows(context.Background(),ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, []string{"13"}, settled)
 	state, ok, err := store.LoadState()
@@ -910,7 +929,7 @@ func TestEscrowRotationUsesEpochSwitchHeightDuringPoC(t *testing.T) {
 		epochSwitchBlockHeight: 600,
 	})
 
-	g.rotateEscrowsOnce()
+	g.rotateEscrowsOnce(context.Background())
 
 	require.Equal(t, 1, createAttempts)
 	require.Equal(t, 1, settleAttempts)

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -373,6 +373,21 @@ func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testi
 	require.Equal(t, rotationRoleRegular, byID["13"].RotationRole)
 }
 
+func TestNewRotationDevshardStateDoesNotForceProtocolVersion(t *testing.T) {
+	record := newRotationDevshardState(&CreateDevshardEscrowResult{EscrowID: 99}, EscrowRotationModelSettings{
+		ModelID:       "Qwen/Test",
+		PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+	}, rotationRoleTemp, 10)
+
+	require.Equal(t, "99", record.ID)
+	require.Equal(t, "Qwen/Test", record.Model)
+	require.Equal(t, "DEVSHARD_PRIVATE_KEY", record.PrivateKeyEnv)
+	require.Empty(t, record.ProtocolVersion)
+	require.True(t, record.Active)
+	require.Equal(t, rotationRoleTemp, record.RotationRole)
+	require.EqualValues(t, 10, record.RotationEpoch)
+}
+
 func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -357,7 +357,7 @@ func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testi
 		gatewaySettleDevshardOnChain = oldSettle
 	})
 
-	g := &Gateway{store: store, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store}
 	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
@@ -437,7 +437,7 @@ func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.
 		gatewaySettleDevshardOnChain = oldSettle
 	})
 
-	g := &Gateway{store: store, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
@@ -507,7 +507,7 @@ func TestEscrowRotationSkipsCreateWhenModelAbsentFromNetwork(t *testing.T) {
 		map[string]map[string]float64{"Qwen/Present": {"host": 1}},
 	)
 
-	g := &Gateway{store: store, capacity: capacity, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store, capacity: capacity, rotationBreakers: make(map[string]*rotationBreaker)}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 0, createAttempts, "must not create escrow for a model absent from the network")
@@ -569,7 +569,7 @@ func TestEscrowRotationCreatesWhenModelPresentInNetwork(t *testing.T) {
 		map[string]map[string]float64{"Qwen/Test": {"host": 1}},
 	)
 
-	g := &Gateway{store: store, capacity: capacity, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store, capacity: capacity, rotationBreakers: make(map[string]*rotationBreaker)}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
 
 	require.Equal(t, 2, createAttempts, "must create escrows for a model the network serves")
@@ -624,7 +624,7 @@ func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 		gatewaySettleDevshardOnChain = oldSettle
 	})
 
-	g := &Gateway{store: store, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 2, createAttempts)
@@ -689,7 +689,7 @@ func TestEscrowRotationPrepareDeactivatesRegularWithoutSettlementWhenSettlementD
 
 	rt := &devshardRuntime{id: "12"}
 	rt.active.Store(true)
-	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}}
 	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
@@ -757,7 +757,7 @@ func TestEscrowRotationFinishDeactivatesTempWithoutSettlementWhenSettlementDisab
 
 	rt := &devshardRuntime{id: "12"}
 	rt.active.Store(true)
-	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store, runtimes: map[string]*devshardRuntime{"12": rt}}
 	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, 1, createAttempts)
@@ -835,7 +835,7 @@ func TestEscrowRotationPrepareRotatesModelsIndependently(t *testing.T) {
 		gatewaySettleDevshardOnChain = oldSettle
 	})
 
-	g := &Gateway{store: store, rotationFailures: make(map[string]struct{})}
+	g := &Gateway{store: store}
 	g.prepareBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 10}, settings)
 
 	require.Equal(t, []string{"13"}, settled)
@@ -898,10 +898,9 @@ func TestEscrowRotationUsesEpochSwitchHeightDuringPoC(t *testing.T) {
 	})
 
 	g := &Gateway{
-		store:            store,
-		settings:         settings,
-		phaseGate:        &ChainPhaseGate{},
-		rotationFailures: make(map[string]struct{}),
+		store:     store,
+		settings:  settings,
+		phaseGate: &ChainPhaseGate{},
 	}
 	g.phaseGate.storeSnapshot(ChainPhaseSnapshot{
 		BlockHeight:            350,

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -445,6 +445,136 @@ func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.
 	require.Equal(t, 0, settleAttempts)
 }
 
+func TestEscrowRotationSkipsCreateWhenModelAbsentFromNetwork(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	settings := GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Enabled:           true,
+			SettlementEnabled: true,
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       "Qwen/Removed",
+				TempCount:     1,
+				TargetCount:   16,
+				Amount:        1000,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+			}},
+		},
+	}.WithTuningDefaults()
+	// A stale temp bridge escrow remains for a model the network no longer
+	// serves; finishing rotation must NOT broadcast a regular create (which
+	// the chain rejects with ErrEpochGroupDataNotFound and still burns the
+	// gas fee) but MUST still settle the stranded temp escrow to recover funds.
+	require.NoError(t, store.Initialize(settings, []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Removed"},
+		Active:        true,
+		RotationRole:  rotationRoleTemp,
+		RotationEpoch: 10,
+	}}))
+
+	oldCreate := gatewayCreateRotationEscrow
+	oldSettle := gatewaySettleDevshardOnChain
+	createAttempts := 0
+	var settled []string
+	gatewayCreateRotationEscrow = func(*Gateway, context.Context, GatewaySettings, EscrowRotationModelSettings, string, uint64) (*CreateDevshardEscrowResult, error) {
+		createAttempts++
+		return &CreateDevshardEscrowResult{EscrowID: uint64(90 + createAttempts), TxHash: "OK"}, nil
+	}
+	gatewaySettleDevshardOnChain = func(_ *Gateway, _ context.Context, id string, _ adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		settled = append(settled, id)
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		gatewayCreateRotationEscrow = oldCreate
+		gatewaySettleDevshardOnChain = oldSettle
+	})
+
+	// The network serves a different model; "Qwen/Removed" is positively absent.
+	capacity := NewCapacityState()
+	capacity.SetHostWeightViews(
+		map[string]float64{"host": 1},
+		map[string]float64{"host": 1},
+		map[string]map[string]float64{"Qwen/Present": {"host": 1}},
+		map[string]map[string]float64{"Qwen/Present": {"host": 1}},
+	)
+
+	g := &Gateway{store: store, capacity: capacity, rotationFailures: make(map[string]struct{})}
+	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+
+	require.Equal(t, 0, createAttempts, "must not create escrow for a model absent from the network")
+	require.Equal(t, []string{"12"}, settled, "stranded temp escrow must still be settled")
+}
+
+func TestEscrowRotationCreatesWhenModelPresentInNetwork(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	settings := GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		EscrowRotation: EscrowRotationSettings{
+			Enabled:           true,
+			SettlementEnabled: true,
+			Models: []EscrowRotationModelSettings{{
+				ModelID:       "Qwen/Test",
+				TempCount:     1,
+				TargetCount:   2,
+				Amount:        1000,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+			}},
+		},
+	}.WithTuningDefaults()
+	require.NoError(t, store.Initialize(settings, []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Test"},
+		Active:        true,
+		RotationRole:  rotationRoleTemp,
+		RotationEpoch: 10,
+	}}))
+
+	oldCreate := gatewayCreateRotationEscrow
+	oldSettle := gatewaySettleDevshardOnChain
+	createAttempts := 0
+	gatewayCreateRotationEscrow = func(*Gateway, context.Context, GatewaySettings, EscrowRotationModelSettings, string, uint64) (*CreateDevshardEscrowResult, error) {
+		createAttempts++
+		return &CreateDevshardEscrowResult{EscrowID: uint64(90 + createAttempts), TxHash: "OK"}, nil
+	}
+	gatewaySettleDevshardOnChain = func(*Gateway, context.Context, string, adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		gatewayCreateRotationEscrow = oldCreate
+		gatewaySettleDevshardOnChain = oldSettle
+	})
+
+	capacity := NewCapacityState()
+	capacity.SetHostWeightViews(
+		map[string]float64{"host": 1},
+		map[string]float64{"host": 1},
+		map[string]map[string]float64{"Qwen/Test": {"host": 1}},
+		map[string]map[string]float64{"Qwen/Test": {"host": 1}},
+	)
+
+	g := &Gateway{store: store, capacity: capacity, rotationFailures: make(map[string]struct{})}
+	g.finishBridgeEscrows(ChainPhaseSnapshot{EpochIndex: 11}, settings)
+
+	require.Equal(t, 2, createAttempts, "must create escrows for a model the network serves")
+}
+
 func TestEscrowRotationFinishSettlesTempFromCurrentLatestEpoch(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -906,6 +906,26 @@ func TestGatewayHostRoutePrefixDefaultsToBuildVersion(t *testing.T) {
 	require.Error(t, validateGatewayHostRoutePrefix("/v1/devshard"))
 }
 
+func TestResolveGatewayRoutePrefixDefaultsToBuildVersion(t *testing.T) {
+	oldVersion := Version
+	t.Cleanup(func() { Version = oldVersion })
+	Version = "v2"
+
+	t.Setenv("DEVSHARD_ROUTE_PREFIX", "")
+	got, err := resolveGatewayRoutePrefix()
+	require.NoError(t, err)
+	require.Equal(t, "/devshard/v2", got)
+
+	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/v1/devshard")
+	_, err = resolveGatewayRoutePrefix()
+	require.ErrorContains(t, err, "unsupported devshard route prefix")
+
+	t.Setenv("DEVSHARD_ROUTE_PREFIX", " /devshard/test ")
+	got, err = resolveGatewayRoutePrefix()
+	require.NoError(t, err)
+	require.Equal(t, "/devshard/test", got)
+}
+
 func TestAdminImportDevshardLoadsInactiveRuntimeAndAccounting(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -66,26 +66,6 @@ func gatewayTestStateMachineInPhase(t *testing.T, phase types.SessionPhase) *sta
 	return sm
 }
 
-func TestResolveGatewayRoutePrefixDefaultsToBuildVersion(t *testing.T) {
-	oldVersion := Version
-	t.Cleanup(func() { Version = oldVersion })
-	Version = "v2"
-
-	t.Setenv("DEVSHARD_ROUTE_PREFIX", "")
-	got, err := resolveGatewayRoutePrefix()
-	require.NoError(t, err)
-	require.Equal(t, "/devshard/v2", got)
-
-	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/v1/devshard")
-	_, err = resolveGatewayRoutePrefix()
-	require.ErrorContains(t, err, "unsupported devshard route prefix")
-
-	t.Setenv("DEVSHARD_ROUTE_PREFIX", " /devshard/test ")
-	got, err = resolveGatewayRoutePrefix()
-	require.NoError(t, err)
-	require.Equal(t, "/devshard/test", got)
-}
-
 func gatewayTestRuntimeForLimits(t *testing.T, id string, balance, nonce uint64) *devshardRuntime {
 	t.Helper()
 
@@ -911,6 +891,19 @@ func TestAdminAddDevshardWiresSharedPhaseGate(t *testing.T) {
 	require.Equal(t, confirmationPoCValidation, addedStatus.ConfirmationPoCPhase)
 	require.True(t, addedStatus.RequestsBlocked)
 	require.Equal(t, "confirmation_poc", addedStatus.BlockReason)
+}
+
+func TestGatewayHostRoutePrefixDefaultsToBuildVersion(t *testing.T) {
+	previousVersion := Version
+	Version = "dev"
+	t.Cleanup(func() { Version = previousVersion })
+
+	require.Equal(t, "/devshard/dev", gatewayHostRoutePrefix(""))
+	require.Equal(t, "/devshard/v2", gatewayHostRoutePrefix("/devshard/v2"))
+	require.Equal(t, "/v1/devshard", gatewayHostRoutePrefix("/v1/devshard"))
+	require.NoError(t, validateGatewayHostRoutePrefix("/devshard/dev"))
+	require.NoError(t, validateGatewayHostRoutePrefix("/devshard/v2"))
+	require.Error(t, validateGatewayHostRoutePrefix("/v1/devshard"))
 }
 
 func TestAdminImportDevshardLoadsInactiveRuntimeAndAccounting(t *testing.T) {
@@ -2769,6 +2762,8 @@ func TestGatewayMetricsEndpointExposedAndUpdated(t *testing.T) {
 	require.Contains(t, body, `status="429"`)
 	require.Contains(t, body, `devshard_gateway_limit_rejections_total`)
 	require.Contains(t, body, `reason="max_input_tokens_in_flight"`)
+	require.Contains(t, body, `devshard_gateway_requests_total{model="Qwen/Test",outcome="gateway_limited",reason="max_input_tokens_in_flight"} 1`)
+	require.Contains(t, body, `devshard_gateway_critical_user_failures_total{model="Qwen/Test",reason="max_input_tokens_in_flight"} 1`)
 	require.Contains(t, body, `devshard_gateway_inflight_requests`)
 	require.Contains(t, body, `devshard_runtime_active`)
 	require.Contains(t, body, `devshard_id="12"`)

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -336,19 +336,19 @@ func TestParseDevshardPath(t *testing.T) {
 }
 
 func TestGatewayChooseRuntimeUsesLowestLoad(t *testing.T) {
-	// Load score is activeRequests / W(e). Both runtimes share W(e)=1
+	// Load score is activeUserRequests / W(e). Both runtimes share W(e)=1
 	// (no capacity model wired). The picker should prefer the runtime
 	// with fewer in-flight requests.
 	a := &devshardRuntime{id: "6", model: "m"}
 	b := &devshardRuntime{id: "12", model: "m"}
-	a.activeRequests.Store(5)
-	b.activeRequests.Store(1)
+	a.activeUserRequests.Store(5)
+	b.activeUserRequests.Store(1)
 
 	g := NewGateway([]*devshardRuntime{a, b}, NewGatewayLimiter(0, 0), "m")
 	chosen, err := g.reserveRuntimeForModel("m", 5)
 	require.NoError(t, err)
 	require.Equal(t, "12", chosen.id)
-	require.EqualValues(t, 2, chosen.activeRequests.Load())
+	require.EqualValues(t, 2, chosen.activeUserRequests.Load())
 	require.EqualValues(t, 5, chosen.reservedTokens.Load())
 }
 
@@ -807,7 +807,7 @@ func TestAdminDeactivateDevshardAllowsActiveRequestsAndStopsNewChat(t *testing.T
 			w.WriteHeader(http.StatusNoContent)
 		}),
 	}
-	rt.activeRequests.Store(1)
+	rt.activeUserRequests.Store(1)
 	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
 	g.store = store
 
@@ -817,7 +817,7 @@ func TestAdminDeactivateDevshardAllowsActiveRequestsAndStopsNewChat(t *testing.T
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.False(t, rt.active.Load())
-	require.EqualValues(t, 1, rt.activeRequests.Load())
+	require.EqualValues(t, 1, rt.activeUserRequests.Load())
 
 	state, ok, err := store.LoadState()
 	require.NoError(t, err)
@@ -1151,7 +1151,7 @@ func TestGatewayHandleDevshardFinalizeRequiresNoActiveRequests(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 		}),
 	}
-	rt.activeRequests.Store(1)
+	rt.activeUserRequests.Store(1)
 	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
 	g.store = store
 
@@ -1163,7 +1163,7 @@ func TestGatewayHandleDevshardFinalizeRequiresNoActiveRequests(t *testing.T) {
 	require.False(t, forwarded)
 	require.True(t, rt.active.Load())
 
-	rt.activeRequests.Store(0)
+	rt.activeUserRequests.Store(0)
 	rec = httptest.NewRecorder()
 	g.handleDevshard(rec, req)
 
@@ -1235,8 +1235,8 @@ func TestGatewayHandlePooledChatSetsChosenDevshardHeader(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 		}),
 	}
-	slow.activeRequests.Store(10)
-	fast.activeRequests.Store(0)
+	slow.activeUserRequests.Store(10)
+	fast.activeUserRequests.Store(0)
 
 	g := NewGateway([]*devshardRuntime{slow, fast}, NewGatewayLimiter(0, 0), "Qwen/Test")
 	g.settings.ModelLimits = []GatewayModelLimitSettings{{ModelID: "Qwen/Test", AccessMode: string(gatewayAccessModeOpen)}}
@@ -1485,7 +1485,7 @@ func TestGatewayHandlePooledChatRejectsUnsupportedModel(t *testing.T) {
 	require.Contains(t, rec.Body.String(), `unsupported model \"Nope/Unsupported\"`)
 	require.Contains(t, rec.Body.String(), "Qwen/Test")
 	require.False(t, forwarded)
-	require.EqualValues(t, 0, rt.activeRequests.Load())
+	require.EqualValues(t, 0, rt.activeUserRequests.Load())
 }
 
 func TestGatewayHandlePooledChatRejectsUnsupportedModelBeforeDefaultAdminOnly(t *testing.T) {
@@ -1510,7 +1510,7 @@ func TestGatewayHandlePooledChatRejectsUnsupportedModelBeforeDefaultAdminOnly(t 
 	require.Contains(t, rec.Body.String(), `unsupported model \"Nope/Unsupported\"`)
 	require.NotContains(t, rec.Body.String(), "admin API key")
 	require.False(t, forwarded)
-	require.EqualValues(t, 0, rt.activeRequests.Load())
+	require.EqualValues(t, 0, rt.activeUserRequests.Load())
 }
 
 func TestGatewayHandleDevshardChatRejectsUnsupportedModel(t *testing.T) {
@@ -1535,7 +1535,7 @@ func TestGatewayHandleDevshardChatRejectsUnsupportedModel(t *testing.T) {
 	require.Contains(t, rec.Body.String(), `unsupported model \"Nope/Unsupported\"`)
 	require.Contains(t, rec.Body.String(), "Qwen/Test")
 	require.False(t, forwarded)
-	require.EqualValues(t, 0, rt.activeRequests.Load())
+	require.EqualValues(t, 0, rt.activeUserRequests.Load())
 }
 
 func TestGatewayPooledChatRefreshesCapacityScaleBeforeAcquire(t *testing.T) {

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -238,6 +238,93 @@ func TestGatewayCheckBalancesKeepsRuntimeBelowLimits(t *testing.T) {
 	require.True(t, rt.active.Load())
 }
 
+func TestEnqueueSettlementWaitsForActiveRequests(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt)
+
+	// One request in flight → settlement must NOT fire yet, but escrow is
+	// deactivated and marked pending (in-memory + persisted).
+	g.reserveRuntime(rt, 1)
+	g.deactivateAndSettleDevshardByID("12", "low_balance")
+
+	require.False(t, rt.active.Load())
+	require.True(t, rt.settlementPending.Load())
+	state, ok, err := g.store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, gatewayDevshardsByID(state.Devshards)["12"].SettlementPending)
+	require.EqualValues(t, 0, settled.Load())
+
+	// Draining the last request triggers exactly one settlement, which
+	// clears the marker.
+	g.releaseRuntime(rt, 1)
+	require.Eventually(t, func() bool {
+		return settled.Load() == 1 && !rt.settlementPending.Load()
+	}, time.Second, 10*time.Millisecond)
+
+	state, _, err = g.store.LoadState()
+	require.NoError(t, err)
+	require.False(t, gatewayDevshardsByID(state.Devshards)["12"].SettlementPending)
+}
+
+func TestEnqueueSettlementSettlesImmediatelyWhenDrained(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold-1, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt)
+
+	// No active requests → settle right away.
+	g.deactivateAndSettleDevshardByID("12", "low_balance")
+
+	require.Eventually(t, func() bool {
+		return settled.Load() == 1 && !rt.active.Load()
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestReconcilePendingSettlementsSettlesDrainedEscrow(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt)
+
+	// Simulate a marker left behind by a pre-restart drain.
+	rt.active.Store(false)
+	require.NoError(t, g.store.SetDevshardActive("12", false))
+	require.NoError(t, g.store.SetDevshardSettlementPending("12", true))
+
+	g.reconcilePendingSettlements()
+
+	require.Eventually(t, func() bool {
+		return settled.Load() == 1 && !rt.settlementPending.Load()
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestReconcilePendingSettlementsSkipsActiveOrUnflagged(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt)
+
+	// Active escrow, no pending marker → nothing to do.
+	g.reconcilePendingSettlements()
+	require.Never(t, func() bool { return settled.Load() > 0 }, 200*time.Millisecond, 20*time.Millisecond)
+}
+
+func TestReconcilePendingSettlementsSkipsWhenSettlementDisabled(t *testing.T) {
+	rt := gatewayTestRuntimeForLimits(t, "12", balanceMinimumThreshold, nonceDeactivationLimit-1)
+	g, _, settled := gatewayTestDepletionGateway(t, rt, func(settings *GatewaySettings) {
+		settings.EscrowRotation.SettlementEnabled = false
+	})
+
+	// Inactive escrow flagged pending, but settlement is disabled → reconcile
+	// must not settle, and the marker is preserved for a later re-enable.
+	rt.active.Store(false)
+	require.NoError(t, g.store.SetDevshardActive("12", false))
+	require.NoError(t, g.store.SetDevshardSettlementPending("12", true))
+
+	g.reconcilePendingSettlements()
+
+	require.Never(t, func() bool { return settled.Load() > 0 }, 200*time.Millisecond, 20*time.Millisecond)
+	state, ok, err := g.store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, gatewayDevshardsByID(state.Devshards)["12"].SettlementPending)
+}
+
 func TestParseDevshardPath(t *testing.T) {
 	id, inner, ok := parseDevshardPath("/devshard/12/v1/debug/perf")
 	require.True(t, ok)

--- a/devshard/cmd/devshardctl/hostperf.go
+++ b/devshard/cmd/devshardctl/hostperf.go
@@ -39,6 +39,7 @@ func ApplyPerfSettings(settings PerfSettings) {
 type RequestSample struct {
 	HostIdx        int
 	ParticipantKey string
+	Model          string
 	Responsive     bool
 	SendTime       time.Time
 	ReceiptTime    time.Time // zero if no receipt

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -391,8 +391,13 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 	}
 	t0 := time.Now()
 	ch := make(chan buildResult, len(allCfgs))
+	// Cap concurrent builders (see maxConcurrentRuntimeBuilds); results are still
+	// collected per-index below, so ordering and error handling are unchanged.
+	buildSem := make(chan struct{}, resolveMaxConcurrentRuntimeBuilds())
 	for i, cfg := range allCfgs {
 		go func(idx int, cfg RuntimeConfig) {
+			buildSem <- struct{}{}
+			defer func() { <-buildSem }()
 			rt, err := gatewayRuntimeBuilder(cfg, gatewayState.Settings.ChainREST, gatewayState.Settings.DefaultModel, perf)
 			ch <- buildResult{idx, rt, err}
 		}(i, cfg)

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -48,8 +48,24 @@ type HostStatsJSON struct {
 	Missed               uint32 `json:"missed"`
 	Invalid              uint32 `json:"invalid"`
 	Cost                 uint64 `json:"cost"`
-	RequiredValidations  uint32 `json:"required_validations"`
-	CompletedValidations uint32 `json:"completed_validations"`
+	RequiredValidations  uint32 `json:"required_validations,omitempty"`
+	CompletedValidations uint32 `json:"completed_validations,omitempty"`
+}
+
+func hostStatsJSONFromDomain(slot uint32, hs *types.HostStats) HostStatsJSON {
+	entry := HostStatsJSON{
+		SlotID:  slot,
+		Missed:  hs.Missed,
+		Invalid: hs.Invalid,
+		Cost:    hs.Cost,
+	}
+	if hs.RequiredValidations != 0 {
+		entry.RequiredValidations = hs.RequiredValidations
+	}
+	if hs.CompletedValidations != 0 {
+		entry.CompletedValidations = hs.CompletedValidations
+	}
+	return entry
 }
 
 type SlotSignatureJSON struct {
@@ -673,11 +689,7 @@ func buildSettlementJSON(p *state.SettlementPayload) (SettlementJSON, error) {
 
 	stats := make([]HostStatsJSON, 0, len(p.HostStats))
 	for slot, hs := range p.HostStats {
-		stats = append(stats, HostStatsJSON{
-			SlotID: slot, Missed: hs.Missed, Invalid: hs.Invalid,
-			Cost: hs.Cost, RequiredValidations: hs.RequiredValidations,
-			CompletedValidations: hs.CompletedValidations,
-		})
+		stats = append(stats, hostStatsJSONFromDomain(slot, hs))
 	}
 
 	sigs := make([]SlotSignatureJSON, 0, len(p.Signatures))

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -104,6 +104,7 @@ var gatewayRuntimeBuilder = buildRuntime
 func main() {
 	ConfigurePoCRequestMode(os.Getenv("DEVSHARD_POC_REQUEST_MODE"))
 	ConfigureCapacityAwareLimits(os.Getenv("DEVSHARD_CAPACITY_AWARE_LIMITS"))
+	configureClassifyCapsFromEnv()
 	flags := parseCLIFlags()
 	runtimeOpts := mustLoadRuntimeOptions(flags)
 	gatewayStore := mustOpenGatewayStore(runtimeOpts.baseStorageDir)

--- a/devshard/cmd/devshardctl/main_test.go
+++ b/devshard/cmd/devshardctl/main_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -166,6 +169,166 @@ func TestBuildGatewayRuntimesPreservesActiveOnOtherErrors(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.True(t, reloaded.Devshards[0].Active)
+}
+
+// measurePeakRuntimeBuildConcurrency runs buildGatewayRuntimes over n active
+// devshards with a fake builder that records the peak number of simultaneous
+// builder invocations.
+func measurePeakRuntimeBuildConcurrency(t *testing.T, n int) int64 {
+	t.Helper()
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, activeDevshardStates(n)))
+
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	var inFlight, peakInFlight atomic.Int64
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, chainREST, defaultModel string, perf *PerfTracker) (*devshardRuntime, error) {
+		running := inFlight.Add(1)
+		for {
+			peak := peakInFlight.Load()
+			if running <= peak || peakInFlight.CompareAndSwap(peak, running) {
+				break
+			}
+		}
+		// Hold the slot briefly so overlapping builders show up in the
+		// high-water mark; this occupies the resource, it does not wait on
+		// async work.
+		time.Sleep(25 * time.Millisecond)
+		inFlight.Add(-1)
+		return &devshardRuntime{id: cfg.ID, model: defaultModel}, nil
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
+
+	runtimes, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+	require.NoError(t, err)
+	require.Len(t, runtimes, n)
+	return peakInFlight.Load()
+}
+
+func TestBuildGatewayRuntimesBoundsBuilderConcurrency(t *testing.T) {
+	// An unbounded fan-out floods the chain LCD (429) and crash-loops startup;
+	// builder concurrency must stay within the resolved bound.
+	const devshardCount = 32
+	limit := int64(resolveMaxConcurrentRuntimeBuilds())
+
+	peak := measurePeakRuntimeBuildConcurrency(t, devshardCount)
+
+	require.Greater(t, int64(devshardCount), limit, "test needs more devshards than the bound to be meaningful")
+	require.LessOrEqual(t, peak, limit, "runtime builder fan-out is unbounded: %d builders ran concurrently", peak)
+}
+
+func TestBuildGatewayRuntimesHonorsConcurrencyEnvOverride(t *testing.T) {
+	t.Setenv("DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS", "4")
+
+	peak := measurePeakRuntimeBuildConcurrency(t, 32)
+
+	require.LessOrEqual(t, peak, int64(4), "DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS=4 must bound builder concurrency")
+}
+
+func activeDevshardStates(n int) []GatewayDevshardState {
+	states := make([]GatewayDevshardState, 0, n)
+	for i := 0; i < n; i++ {
+		states = append(states, GatewayDevshardState{
+			RuntimeConfig: RuntimeConfig{ID: fmt.Sprintf("%d", i+1), PrivateKeyHex: "secret", Model: "Qwen/Test"},
+			Active:        true,
+		})
+	}
+	return states
+}
+
+func TestBuildGatewayRuntimesBoundedFanoutSurvivesRateLimitingLCD(t *testing.T) {
+	// Regression: an unbounded builder fan-out floods the chain LCD, which
+	// answers 429. A 429 is not a soft error (unlike ErrEscrowNotFound /
+	// private-key-missing), so it becomes firstFatal and the gateway fails to
+	// start — restart repeats the same fan-out — crash loop. With the fan-out
+	// bounded, at most the resolved limit of builders hit the LCD at once, so an
+	// LCD that tolerates that many never rate-limits and startup succeeds.
+	const devshardCount = 32
+	limit := int64(resolveMaxConcurrentRuntimeBuilds())
+
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, activeDevshardStates(devshardCount)))
+
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// The fake LCD tolerates up to the resolved limit of concurrent builds and
+	// rejects the one that exceeds it with a 429.
+	var inFlight atomic.Int64
+	var rateLimited atomic.Bool
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, chainREST, defaultModel string, perf *PerfTracker) (*devshardRuntime, error) {
+		defer inFlight.Add(-1)
+		if inFlight.Add(1) > limit {
+			rateLimited.Store(true)
+			return nil, fmt.Errorf("runtime %s: get escrow: chain LCD: 429 Too Many Requests", cfg.ID)
+		}
+		// Hold the slot so genuinely concurrent builders overlap.
+		time.Sleep(25 * time.Millisecond)
+		return &devshardRuntime{id: cfg.ID, model: defaultModel}, nil
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
+
+	runtimes, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+
+	require.False(t, rateLimited.Load(), "fan-out exceeded the LCD's concurrency tolerance and tripped a 429")
+	require.NoError(t, err, "bounded startup must survive a rate-limiting LCD")
+	require.Len(t, runtimes, devshardCount)
+}
+
+func TestResolveMaxConcurrentRuntimeBuildsDefaultsWhenUnset(t *testing.T) {
+	require.NoError(t, os.Unsetenv("DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS"))
+	require.Equal(t, defaultMaxConcurrentRuntimeBuilds, resolveMaxConcurrentRuntimeBuilds())
+}
+
+func TestResolveMaxConcurrentRuntimeBuildsParsesOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{name: "valid positive", env: "4", want: 4},
+		{name: "zero falls back", env: "0", want: defaultMaxConcurrentRuntimeBuilds},
+		{name: "negative falls back", env: "-3", want: defaultMaxConcurrentRuntimeBuilds},
+		{name: "non-numeric falls back", env: "abc", want: defaultMaxConcurrentRuntimeBuilds},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DEVSHARD_MAX_CONCURRENT_RUNTIME_BUILDS", tc.env)
+			require.Equal(t, tc.want, resolveMaxConcurrentRuntimeBuilds())
+		})
+	}
+}
+
+func TestBuildRuntimeBridgeClientPinsIdleConnPool(t *testing.T) {
+	client := buildRuntimeBridgeClient(4)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Equal(t, 4, transport.MaxIdleConnsPerHost)
+	require.Equal(t, 4, transport.MaxIdleConns)
+	require.Equal(t, 10*time.Second, client.Timeout)
 }
 
 func TestRepairPersistedGatewayEndpointSettingsBackfillsBlankPublicAPI(t *testing.T) {

--- a/devshard/cmd/devshardctl/marshal_test.go
+++ b/devshard/cmd/devshardctl/marshal_test.go
@@ -37,11 +37,11 @@ func TestMarshalSettlement_RoundTrip(t *testing.T) {
 	payload := &state.SettlementPayload{
 		EscrowID:                    "42",
 		StateRootAndProtocolVersion: "dev",
-		Nonce:      5,
-		Fees:       321,
-		RestHash:   restHash,
-		HostStats:  hostStats,
-		Signatures: map[uint32][]byte{0: []byte("sig0"), 1: []byte("sig1")},
+		Nonce:                       5,
+		Fees:                        321,
+		RestHash:                    restHash,
+		HostStats:                   hostStats,
+		Signatures:                  map[uint32][]byte{0: []byte("sig0"), 1: []byte("sig1")},
 	}
 
 	// Step 1: marshal (devshardctl side)
@@ -147,9 +147,13 @@ func TestMarshalSettlement_OmitsZeroValidationFields(t *testing.T) {
 	require.NoError(t, err)
 
 	payload := &state.SettlementPayload{
-		EscrowID: "42", Version: "dev", Nonce: 3, Fees: 10,
-		RestHash: restHash, HostStats: hostStats,
-		Signatures: map[uint32][]byte{0: []byte("sig0")},
+		EscrowID:                    "42",
+		StateRootAndProtocolVersion: "dev",
+		Nonce:                       3,
+		Fees:                        10,
+		RestHash:                    restHash,
+		HostStats:                   hostStats,
+		Signatures:                  map[uint32][]byte{0: []byte("sig0")},
 	}
 
 	data, err := marshalSettlement(payload)

--- a/devshard/cmd/devshardctl/marshal_test.go
+++ b/devshard/cmd/devshardctl/marshal_test.go
@@ -135,3 +135,30 @@ func TestMarshalSettlement_KotlinReserialize(t *testing.T) {
 	require.Equal(t, expectedRoot, stateRoot,
 		"state_root mismatch after Kotlin-style re-serialization")
 }
+
+func TestMarshalSettlement_OmitsZeroValidationFields(t *testing.T) {
+	hostStats := map[uint32]*types.HostStats{
+		0: {Cost: 150},
+		1: {Cost: 100, Missed: 1},
+	}
+	restHash, err := state.ComputeRestHash(9850, map[uint64]*types.InferenceRecord{
+		1: {Status: types.StatusFinished, ExecutorSlot: 0, PromptHash: []byte("abcdefghijklmnopqrstuvwxyz012345")},
+	}, nil)
+	require.NoError(t, err)
+
+	payload := &state.SettlementPayload{
+		EscrowID: "42", Version: "dev", Nonce: 3, Fees: 10,
+		RestHash: restHash, HostStats: hostStats,
+		Signatures: map[uint32][]byte{0: []byte("sig0")},
+	}
+
+	data, err := marshalSettlement(payload)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "required_validations")
+	require.NotContains(t, string(data), "completed_validations")
+
+	var parsed SettlementJSON
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	require.Equal(t, uint32(0), parsed.HostStats[0].RequiredValidations)
+	require.Equal(t, uint32(0), parsed.HostStats[0].CompletedValidations)
+}

--- a/devshard/cmd/devshardctl/messagevalidators/content.go
+++ b/devshard/cmd/devshardctl/messagevalidators/content.go
@@ -1,0 +1,124 @@
+package messagevalidators
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateNonEmptyContent rejects empty strings and empty/malformed content-part
+// arrays. Each non-string content must be a []any of typed text parts.
+func ValidateNonEmptyContent(content any) error {
+	switch value := content.(type) {
+	case string:
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("must not be empty")
+		}
+		return nil
+	case []any:
+		if len(value) == 0 {
+			return fmt.Errorf("must not be empty")
+		}
+		for i, rawPart := range value {
+			part, ok := rawPart.(map[string]any)
+			if !ok {
+				return fmt.Errorf("[%d] must be an object", i)
+			}
+			text, err := RequiredTextContentPart(part, i)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(text) == "" {
+				return fmt.Errorf("[%d].text must not be empty", i)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("must be a string or an array of typed content parts")
+	}
+}
+
+func ValidateRequiredContentField(message map[string]any) error {
+	content, exists := message["content"]
+	if !exists || content == nil {
+		return fmt.Errorf("is required")
+	}
+	return ValidateNonEmptyContent(content)
+}
+
+func ValidateAssistantContentField(message map[string]any, canBeEmpty bool) error {
+	content, exists := message["content"]
+	if !exists || content == nil {
+		if canBeEmpty {
+			return nil
+		}
+		return fmt.Errorf("is required unless tool_calls or function_call is provided")
+	}
+	return ValidateNonEmptyContent(content)
+}
+
+// RequiredTextContentPart validates that part has type:"text" and a non-empty text field.
+// Returned errors carry no `messages[%d].content` prefix — the caller adds it.
+func RequiredTextContentPart(part map[string]any, partIndex int) (string, error) {
+	partType, err := RequiredNonEmptyString(part, "type")
+	if err != nil {
+		return "", fmt.Errorf("[%d].type: %w", partIndex, err)
+	}
+	if partType != "text" {
+		return "", fmt.Errorf("[%d].type has unsupported value %q", partIndex, partType)
+	}
+	text, err := RequiredNonEmptyString(part, "text")
+	if err != nil {
+		return "", fmt.Errorf("[%d].text: %w", partIndex, err)
+	}
+	return text, nil
+}
+
+// CombineTextContentParts joins typed text parts into a single newline-separated string.
+// Returned errors carry no `messages[%d].content` prefix — the caller adds it.
+func CombineTextContentParts(parts []any) (string, error) {
+	texts := make([]string, 0, len(parts))
+	for partIndex, rawPart := range parts {
+		part, ok := rawPart.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("[%d] must be an object", partIndex)
+		}
+		text, err := RequiredTextContentPart(part, partIndex)
+		if err != nil {
+			return "", err
+		}
+		texts = append(texts, text)
+	}
+	if len(texts) == 0 {
+		return "", nil
+	}
+	return strings.Join(texts, "\n"), nil
+}
+
+func IsEmptyContent(content any) bool {
+	switch v := content.(type) {
+	case string:
+		return strings.TrimSpace(v) == ""
+	case []any:
+		return len(v) == 0
+	default:
+		return false
+	}
+}
+
+func IsAssistantTurnEmpty(msg map[string]any) bool {
+	if raw, exists := msg["tool_calls"]; exists && raw != nil {
+		if calls, ok := raw.([]any); ok && len(calls) > 0 {
+			return false
+		}
+	}
+	if raw, exists := msg["function_call"]; exists && raw != nil {
+		if fc, ok := raw.(map[string]any); ok && len(fc) > 0 {
+			return false
+		}
+	}
+	content, exists := msg["content"]
+	if !exists || content == nil {
+		return true
+	}
+	return IsEmptyContent(content)
+}

--- a/devshard/cmd/devshardctl/messagevalidators/content_test.go
+++ b/devshard/cmd/devshardctl/messagevalidators/content_test.go
@@ -1,0 +1,261 @@
+package messagevalidators
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateNonEmptyContent(t *testing.T) {
+	cases := []struct {
+		name      string
+		content   any
+		errSubstr string
+	}{
+		{"string-ok", "hello", ""},
+		{"string-with-think-block", "<think>step</think> answer", ""},
+		{"string-empty", "", "must not be empty"},
+		{"string-whitespace", "  \t\n  ", "must not be empty"},
+		{"array-of-text-parts-ok", []any{map[string]any{"type": "text", "text": "hello"}}, ""},
+		{"array-empty", []any{}, "must not be empty"},
+		{"array-element-not-object", []any{"not-an-object"}, "[0] must be an object"},
+		{"array-part-missing-type", []any{map[string]any{"text": "no type"}}, "[0].type"},
+		{"array-part-wrong-type", []any{map[string]any{"type": "image_url", "text": "x"}}, "unsupported value"},
+		{"array-part-empty-text", []any{map[string]any{"type": "text", "text": " "}}, "[0].text"},
+		{"number-not-supported", 42, "must be a string or an array"},
+		{"object-not-supported", map[string]any{}, "must be a string or an array"},
+		{"nil-not-supported", nil, "must be a string or an array"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateNonEmptyContent(tc.content)
+			if tc.errSubstr == "" {
+				if err != nil {
+					t.Fatalf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Fatalf("want error containing %q, got %q", tc.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateRequiredContentField(t *testing.T) {
+	t.Run("missing-rejected", func(t *testing.T) {
+		err := ValidateRequiredContentField(map[string]any{})
+		if err == nil || !strings.Contains(err.Error(), "is required") {
+			t.Fatalf("want 'is required', got %v", err)
+		}
+	})
+	t.Run("nil-rejected", func(t *testing.T) {
+		err := ValidateRequiredContentField(map[string]any{"content": nil})
+		if err == nil || !strings.Contains(err.Error(), "is required") {
+			t.Fatalf("want 'is required', got %v", err)
+		}
+	})
+	t.Run("string-ok", func(t *testing.T) {
+		err := ValidateRequiredContentField(map[string]any{"content": "hi"})
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+	})
+}
+
+func TestValidateAssistantContentField(t *testing.T) {
+	t.Run("missing-with-canBeEmpty-ok", func(t *testing.T) {
+		// Assistant turn with tool_calls/function_call can omit content.
+		err := ValidateAssistantContentField(map[string]any{}, true)
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+	})
+	t.Run("missing-without-canBeEmpty-rejected", func(t *testing.T) {
+		err := ValidateAssistantContentField(map[string]any{}, false)
+		if err == nil || !strings.Contains(err.Error(), "tool_calls or function_call") {
+			t.Fatalf("want hint about tool_calls/function_call, got %v", err)
+		}
+	})
+	t.Run("nil-with-canBeEmpty-ok", func(t *testing.T) {
+		err := ValidateAssistantContentField(map[string]any{"content": nil}, true)
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+	})
+	t.Run("non-empty-content-still-validated", func(t *testing.T) {
+		// Even when canBeEmpty=true, present content must not be empty/wrong shape.
+		err := ValidateAssistantContentField(map[string]any{"content": ""}, true)
+		if err == nil {
+			t.Fatal("empty string content must still be rejected")
+		}
+	})
+}
+
+func TestRequiredTextContentPart(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		text, err := RequiredTextContentPart(map[string]any{"type": "text", "text": "hello"}, 0)
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+		if text != "hello" {
+			t.Fatalf("want 'hello', got %q", text)
+		}
+	})
+	t.Run("missing-type", func(t *testing.T) {
+		_, err := RequiredTextContentPart(map[string]any{"text": "hi"}, 2)
+		if err == nil || !strings.Contains(err.Error(), "[2].type") {
+			t.Fatalf("want '[2].type', got %v", err)
+		}
+	})
+	t.Run("wrong-type", func(t *testing.T) {
+		_, err := RequiredTextContentPart(map[string]any{"type": "image_url", "text": "x"}, 3)
+		if err == nil || !strings.Contains(err.Error(), "unsupported value") {
+			t.Fatalf("want 'unsupported value', got %v", err)
+		}
+	})
+	t.Run("missing-text", func(t *testing.T) {
+		_, err := RequiredTextContentPart(map[string]any{"type": "text"}, 0)
+		if err == nil || !strings.Contains(err.Error(), "[0].text") {
+			t.Fatalf("want '[0].text', got %v", err)
+		}
+	})
+}
+
+func TestCombineTextContentParts(t *testing.T) {
+	t.Run("single-part", func(t *testing.T) {
+		got, err := CombineTextContentParts([]any{map[string]any{"type": "text", "text": "hello"}})
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+		if got != "hello" {
+			t.Fatalf("want 'hello', got %q", got)
+		}
+	})
+	t.Run("multiple-parts-newline-join", func(t *testing.T) {
+		got, err := CombineTextContentParts([]any{
+			map[string]any{"type": "text", "text": "first"},
+			map[string]any{"type": "text", "text": "second"},
+		})
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+		if got != "first\nsecond" {
+			t.Fatalf("want 'first\\nsecond', got %q", got)
+		}
+	})
+	t.Run("empty-array-returns-empty-string", func(t *testing.T) {
+		got, err := CombineTextContentParts([]any{})
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+		if got != "" {
+			t.Fatalf("want empty, got %q", got)
+		}
+	})
+	t.Run("non-object-element", func(t *testing.T) {
+		_, err := CombineTextContentParts([]any{"plain-string"})
+		if err == nil || !strings.Contains(err.Error(), "[0] must be an object") {
+			t.Fatalf("want '[0] must be an object', got %v", err)
+		}
+	})
+	t.Run("propagates-part-error", func(t *testing.T) {
+		_, err := CombineTextContentParts([]any{map[string]any{"type": "image_url", "text": "x"}})
+		if err == nil || !strings.Contains(err.Error(), "unsupported value") {
+			t.Fatalf("want 'unsupported value', got %v", err)
+		}
+	})
+	t.Run("preserves-think-block-in-text", func(t *testing.T) {
+		// MiniMax-M2.7 round-trips <think>...</think> verbatim in content.
+		got, err := CombineTextContentParts([]any{
+			map[string]any{"type": "text", "text": "<think>reasoning</think>"},
+			map[string]any{"type": "text", "text": "answer"},
+		})
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+		if got != "<think>reasoning</think>\nanswer" {
+			t.Fatalf("think block must round-trip, got %q", got)
+		}
+	})
+}
+
+func TestIsEmptyContent(t *testing.T) {
+	cases := []struct {
+		name    string
+		content any
+		want    bool
+	}{
+		{"empty-string", "", true},
+		{"whitespace-string", "   ", true},
+		{"non-empty-string", "x", false},
+		{"empty-array", []any{}, true},
+		{"non-empty-array", []any{1}, false},
+		{"nil-not-empty", nil, false}, // nil is "missing", not "empty"
+		{"int-not-empty", 42, false},
+		{"object-not-empty", map[string]any{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsEmptyContent(tc.content); got != tc.want {
+				t.Fatalf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestIsAssistantTurnEmpty(t *testing.T) {
+	t.Run("no-fields-empty", func(t *testing.T) {
+		if !IsAssistantTurnEmpty(map[string]any{}) {
+			t.Fatal("empty turn must be empty")
+		}
+	})
+	t.Run("content-only-non-empty", func(t *testing.T) {
+		if IsAssistantTurnEmpty(map[string]any{"content": "hi"}) {
+			t.Fatal("turn with content must not be empty")
+		}
+	})
+	t.Run("tool-calls-non-empty", func(t *testing.T) {
+		msg := map[string]any{"tool_calls": []any{map[string]any{"id": "x"}}}
+		if IsAssistantTurnEmpty(msg) {
+			t.Fatal("turn with tool_calls must not be empty")
+		}
+	})
+	t.Run("empty-tool-calls-array-still-empty", func(t *testing.T) {
+		// Empty tool_calls = informationless placeholder.
+		msg := map[string]any{"tool_calls": []any{}}
+		if !IsAssistantTurnEmpty(msg) {
+			t.Fatal("empty tool_calls slot is informationless")
+		}
+	})
+	t.Run("nil-tool-calls-treated-as-absent", func(t *testing.T) {
+		msg := map[string]any{"tool_calls": nil}
+		if !IsAssistantTurnEmpty(msg) {
+			t.Fatal("nil tool_calls is absent")
+		}
+	})
+	t.Run("function-call-non-empty", func(t *testing.T) {
+		msg := map[string]any{"function_call": map[string]any{"name": "fn"}}
+		if IsAssistantTurnEmpty(msg) {
+			t.Fatal("turn with function_call must not be empty")
+		}
+	})
+	t.Run("empty-function-call-object-empty", func(t *testing.T) {
+		msg := map[string]any{"function_call": map[string]any{}}
+		if !IsAssistantTurnEmpty(msg) {
+			t.Fatal("empty function_call object is informationless")
+		}
+	})
+	t.Run("nil-content-empty", func(t *testing.T) {
+		if !IsAssistantTurnEmpty(map[string]any{"content": nil}) {
+			t.Fatal("nil content is empty")
+		}
+	})
+	t.Run("empty-content-array-empty", func(t *testing.T) {
+		if !IsAssistantTurnEmpty(map[string]any{"content": []any{}}) {
+			t.Fatal("empty content array is empty")
+		}
+	})
+}

--- a/devshard/cmd/devshardctl/messagevalidators/fields.go
+++ b/devshard/cmd/devshardctl/messagevalidators/fields.go
@@ -1,0 +1,44 @@
+package messagevalidators
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RequiredNonEmptyString returns the trimmed string value at values[field]
+// or describes why it's missing/wrong. Returned errors carry no positional
+// prefix — the caller (which knows the message/part index) wraps them.
+func RequiredNonEmptyString(values map[string]any, field string) (string, error) {
+	rawValue, exists := values[field]
+	if !exists || rawValue == nil {
+		return "", fmt.Errorf("is required")
+	}
+	value, ok := rawValue.(string)
+	if !ok {
+		return "", fmt.Errorf("must be a string")
+	}
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("must not be empty")
+	}
+	return value, nil
+}
+
+func OptionalStringField(values map[string]any, field string) error {
+	rawValue, exists := values[field]
+	if !exists || rawValue == nil {
+		return nil
+	}
+	if _, ok := rawValue.(string); !ok {
+		return fmt.Errorf("must be a string")
+	}
+	return nil
+}
+
+func EnsureFieldsAbsent(values map[string]any, fields ...string) error {
+	for _, field := range fields {
+		if _, exists := values[field]; exists {
+			return fmt.Errorf("%s is not allowed for this role", field)
+		}
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/messagevalidators/fields_test.go
+++ b/devshard/cmd/devshardctl/messagevalidators/fields_test.go
@@ -1,0 +1,120 @@
+package messagevalidators
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRequiredNonEmptyString(t *testing.T) {
+	cases := []struct {
+		name      string
+		values    map[string]any
+		field     string
+		want      string
+		errSubstr string
+	}{
+		{"happy", map[string]any{"x": "hello"}, "x", "hello", ""},
+		{"trimmed-keeps-original", map[string]any{"x": "  hello  "}, "x", "  hello  ", ""},
+		{"missing", map[string]any{}, "x", "", "is required"},
+		{"explicit-nil", map[string]any{"x": nil}, "x", "", "is required"},
+		{"non-string", map[string]any{"x": 42}, "x", "", "must be a string"},
+		{"bool-not-string", map[string]any{"x": true}, "x", "", "must be a string"},
+		{"empty-string", map[string]any{"x": ""}, "x", "", "must not be empty"},
+		{"whitespace-only", map[string]any{"x": "   \t\n"}, "x", "", "must not be empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RequiredNonEmptyString(tc.values, tc.field)
+			if tc.errSubstr == "" {
+				if err != nil {
+					t.Fatalf("want no error, got %v", err)
+				}
+				if got != tc.want {
+					t.Fatalf("want %q, got %q", tc.want, got)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Fatalf("want error containing %q, got %q", tc.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestOptionalStringField(t *testing.T) {
+	cases := []struct {
+		name      string
+		values    map[string]any
+		field     string
+		errSubstr string
+	}{
+		{"missing-ok", map[string]any{}, "x", ""},
+		{"explicit-nil-ok", map[string]any{"x": nil}, "x", ""},
+		{"empty-string-ok", map[string]any{"x": ""}, "x", ""},
+		{"valid-string-ok", map[string]any{"x": "hello"}, "x", ""},
+		{"non-string-rejected", map[string]any{"x": 42}, "x", "must be a string"},
+		{"object-rejected", map[string]any{"x": map[string]any{}}, "x", "must be a string"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := OptionalStringField(tc.values, tc.field)
+			if tc.errSubstr == "" {
+				if err != nil {
+					t.Fatalf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Fatalf("want error containing %q, got %q", tc.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestEnsureFieldsAbsent(t *testing.T) {
+	t.Run("all-absent-ok", func(t *testing.T) {
+		err := EnsureFieldsAbsent(map[string]any{"role": "user"}, "tool_calls", "tool_call_id")
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+	})
+	t.Run("present-rejected", func(t *testing.T) {
+		err := EnsureFieldsAbsent(map[string]any{"role": "user", "tool_calls": []any{}}, "tool_calls")
+		if err == nil {
+			t.Fatal("want error, got nil")
+		}
+		if !strings.Contains(err.Error(), "tool_calls is not allowed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("first-violation-wins", func(t *testing.T) {
+		// Multiple violations: caller sees the first listed disallowed field.
+		err := EnsureFieldsAbsent(map[string]any{"a": 1, "b": 2}, "a", "b")
+		if err == nil {
+			t.Fatal("want error, got nil")
+		}
+		if !strings.Contains(err.Error(), "a is not allowed") {
+			t.Fatalf("want first-violation 'a', got %v", err)
+		}
+	})
+	t.Run("nil-value-still-present", func(t *testing.T) {
+		// An explicit null in the request still counts as "present" — clients that
+		// emit nil placeholders must not bypass the role policy.
+		err := EnsureFieldsAbsent(map[string]any{"tool_calls": nil}, "tool_calls")
+		if err == nil {
+			t.Fatal("want error, got nil")
+		}
+	})
+	t.Run("variadic-empty-ok", func(t *testing.T) {
+		err := EnsureFieldsAbsent(map[string]any{"a": 1}, []string{}...)
+		if err != nil {
+			t.Fatalf("want no error, got %v", err)
+		}
+	})
+}

--- a/devshard/cmd/devshardctl/messagevalidators/minimax_tool_message.go
+++ b/devshard/cmd/devshardctl/messagevalidators/minimax_tool_message.go
@@ -1,0 +1,76 @@
+package messagevalidators
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// MiniMax-M2.7 tool result messages carry per-call results as an array of
+// {name, type:"text", text} objects instead of OpenAI's single content string
+// keyed by tool_call_id.
+var (
+	ErrMinimaxToolContentShape = errors.New("content: must be a non-empty array of {name,type,text} objects")
+	ErrMinimaxToolEntryShape   = errors.New("content entry: invalid shape")
+)
+
+type MinimaxToolMessage struct {
+	MaxEntries  int
+	NameMaxLen  int
+	TextMaxSize int
+}
+
+// Validate enforces the MiniMax tool message content shape and per-entry caps.
+func (v MinimaxToolMessage) Validate(content any) error {
+	entries, ok := content.([]any)
+	if !ok {
+		return fmt.Errorf("%w: not an array", ErrMinimaxToolContentShape)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("%w: array is empty", ErrMinimaxToolContentShape)
+	}
+	if v.MaxEntries > 0 && len(entries) > v.MaxEntries {
+		return fmt.Errorf("%w: %d entries exceeds limit %d", ErrMinimaxToolContentShape, len(entries), v.MaxEntries)
+	}
+	for i, rawEntry := range entries {
+		if err := v.validateEntry(i, rawEntry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v MinimaxToolMessage) validateEntry(index int, raw any) error {
+	entry, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: [%d] must be an object", ErrMinimaxToolEntryShape, index)
+	}
+	// Closed allow-list. Stray keys would otherwise reach the upstream parser
+	// whose union-with-null typing has been a crash vector (SGLang #16057).
+	for key := range entry {
+		switch key {
+		case "name", "type", "text":
+		default:
+			return fmt.Errorf("%w: [%d] has unsupported key %q", ErrMinimaxToolEntryShape, index, key)
+		}
+	}
+	name, ok := entry["name"].(string)
+	if !ok || strings.TrimSpace(name) == "" {
+		return fmt.Errorf("%w: [%d].name must be a non-empty string", ErrMinimaxToolEntryShape, index)
+	}
+	if v.NameMaxLen > 0 && len(name) > v.NameMaxLen {
+		return fmt.Errorf("%w: [%d].name length %d exceeds limit %d", ErrMinimaxToolEntryShape, index, len(name), v.NameMaxLen)
+	}
+	partType, ok := entry["type"].(string)
+	if !ok || partType != "text" {
+		return fmt.Errorf("%w: [%d].type must be \"text\"", ErrMinimaxToolEntryShape, index)
+	}
+	text, ok := entry["text"].(string)
+	if !ok {
+		return fmt.Errorf("%w: [%d].text must be a string", ErrMinimaxToolEntryShape, index)
+	}
+	if v.TextMaxSize > 0 && len(text) > v.TextMaxSize {
+		return fmt.Errorf("%w: [%d].text size %d exceeds limit %d", ErrMinimaxToolEntryShape, index, len(text), v.TextMaxSize)
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/messagevalidators/minimax_tool_message_test.go
+++ b/devshard/cmd/devshardctl/messagevalidators/minimax_tool_message_test.go
@@ -1,0 +1,112 @@
+package messagevalidators
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func validatorForTest() MinimaxToolMessage {
+	return MinimaxToolMessage{MaxEntries: 16, NameMaxLen: 64, TextMaxSize: 1024}
+}
+
+func TestMinimaxToolMessage_AcceptsCanonicalShape(t *testing.T) {
+	v := validatorForTest()
+	content := []any{
+		map[string]any{"name": "get_weather", "type": "text", "text": `{"temperature":"25"}`},
+		map[string]any{"name": "search_web", "type": "text", "text": "results"},
+	}
+	if err := v.Validate(content); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsNonArray(t *testing.T) {
+	if err := validatorForTest().Validate("plain string"); !errors.Is(err, ErrMinimaxToolContentShape) {
+		t.Fatalf("expected ErrMinimaxToolContentShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsEmptyArray(t *testing.T) {
+	if err := validatorForTest().Validate([]any{}); !errors.Is(err, ErrMinimaxToolContentShape) {
+		t.Fatalf("expected ErrMinimaxToolContentShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsTooManyEntries(t *testing.T) {
+	v := MinimaxToolMessage{MaxEntries: 2, NameMaxLen: 64, TextMaxSize: 1024}
+	content := []any{
+		map[string]any{"name": "a", "type": "text", "text": "1"},
+		map[string]any{"name": "b", "type": "text", "text": "2"},
+		map[string]any{"name": "c", "type": "text", "text": "3"},
+	}
+	if err := v.Validate(content); !errors.Is(err, ErrMinimaxToolContentShape) {
+		t.Fatalf("expected ErrMinimaxToolContentShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsNonObjectEntry(t *testing.T) {
+	if err := validatorForTest().Validate([]any{"not an object"}); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsMissingName(t *testing.T) {
+	content := []any{map[string]any{"type": "text", "text": "result"}}
+	if err := validatorForTest().Validate(content); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsBlankName(t *testing.T) {
+	content := []any{map[string]any{"name": "", "type": "text", "text": "result"}}
+	if err := validatorForTest().Validate(content); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}
+
+// A whitespace-only name must be rejected too: it otherwise passes the gateway,
+// reaches the MiniMax tool parser, and hangs the request until the deadline.
+func TestMinimaxToolMessage_RejectsWhitespaceName(t *testing.T) {
+	content := []any{map[string]any{"name": "   ", "type": "text", "text": "result"}}
+	if err := validatorForTest().Validate(content); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsOverlongName(t *testing.T) {
+	v := MinimaxToolMessage{MaxEntries: 16, NameMaxLen: 8, TextMaxSize: 1024}
+	content := []any{map[string]any{"name": "way_too_long_function_name", "type": "text", "text": "ok"}}
+	if err := v.Validate(content); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsWrongType(t *testing.T) {
+	content := []any{map[string]any{"name": "fn", "type": "image_url", "text": "x"}}
+	if err := validatorForTest().Validate(content); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsNonStringText(t *testing.T) {
+	content := []any{map[string]any{"name": "fn", "type": "text", "text": 42}}
+	if err := validatorForTest().Validate(content); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsOverlongText(t *testing.T) {
+	v := MinimaxToolMessage{MaxEntries: 16, NameMaxLen: 64, TextMaxSize: 4}
+	content := []any{map[string]any{"name": "fn", "type": "text", "text": strings.Repeat("a", 5)}}
+	if err := v.Validate(content); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}
+
+func TestMinimaxToolMessage_RejectsExtraKeys(t *testing.T) {
+	content := []any{map[string]any{"name": "fn", "type": "text", "text": "ok", "extra": true}}
+	if err := validatorForTest().Validate(content); !errors.Is(err, ErrMinimaxToolEntryShape) {
+		t.Fatalf("expected ErrMinimaxToolEntryShape, got %v", err)
+	}
+}

--- a/devshard/cmd/devshardctl/messagevalidators/normalizers.go
+++ b/devshard/cmd/devshardctl/messagevalidators/normalizers.go
@@ -1,0 +1,249 @@
+package messagevalidators
+
+import (
+	"fmt"
+	"slices"
+)
+
+// Wire-format role values; kept as local literals so the package stays free of
+// main-package imports. These match what is on the JSON wire and never change.
+const (
+	roleAssistant = "assistant"
+	roleTool      = "tool"
+)
+
+// OrphanToolMessageDropper drops role:"tool" entries whose tool_call_id has no
+// matching prior assistant.tool_call. Mirrors ValidateDocument's pending-set
+// accounting so survivors pass the strict check downstream.
+type OrphanToolMessageDropper struct{}
+
+func (OrphanToolMessageDropper) Apply(messages []any) ([]any, bool, error) {
+	pending := map[string]struct{}{}
+	filtered := make([]any, 0, len(messages))
+	dropped := false
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			filtered = append(filtered, raw)
+			continue
+		}
+		role, _ := msg["role"].(string)
+		switch role {
+		case roleAssistant:
+			if calls, ok := msg["tool_calls"].([]any); ok {
+				for _, rawCall := range calls {
+					call, ok := rawCall.(map[string]any)
+					if !ok {
+						continue
+					}
+					if id, ok := call["id"].(string); ok && id != "" {
+						pending[id] = struct{}{}
+					}
+				}
+			}
+		case roleTool:
+			if id, ok := msg["tool_call_id"].(string); ok && id != "" {
+				if _, matched := pending[id]; !matched {
+					dropped = true
+					continue
+				}
+				delete(pending, id)
+			}
+		}
+		filtered = append(filtered, raw)
+	}
+	return filtered, dropped, nil
+}
+
+// MinimaxOrphanToolMessageDropper drops role:"tool" messages on routes whose
+// tool messages carry no tool_call_id (e.g. MiniMax-M2.7). Orphan = tool
+// message appearing before any assistant.tool_calls[] block. The block stays
+// open across consecutive tool turns and resets on the next non-tool message.
+type MinimaxOrphanToolMessageDropper struct{}
+
+func (MinimaxOrphanToolMessageDropper) Apply(messages []any) ([]any, bool, error) {
+	inToolBlock := false
+	filtered := make([]any, 0, len(messages))
+	dropped := false
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			filtered = append(filtered, raw)
+			inToolBlock = false
+			continue
+		}
+		role, _ := msg["role"].(string)
+		switch role {
+		case roleAssistant:
+			inToolBlock = false
+			if calls, ok := msg["tool_calls"].([]any); ok && len(calls) > 0 {
+				inToolBlock = true
+			}
+		case roleTool:
+			if !inToolBlock {
+				dropped = true
+				continue
+			}
+		default:
+			inToolBlock = false
+		}
+		filtered = append(filtered, raw)
+	}
+	return filtered, dropped, nil
+}
+
+// EmptyAssistantTurnDropper drops role:"assistant" messages with no content
+// and no tool_calls / function_call — informationless placeholders left by
+// session-resume serializers.
+type EmptyAssistantTurnDropper struct{}
+
+func (EmptyAssistantTurnDropper) Apply(messages []any) ([]any, bool, error) {
+	filtered := make([]any, 0, len(messages))
+	dropped := false
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			filtered = append(filtered, raw)
+			continue
+		}
+		if role, _ := msg["role"].(string); role == roleAssistant && IsAssistantTurnEmpty(msg) {
+			dropped = true
+			continue
+		}
+		filtered = append(filtered, raw)
+	}
+	return filtered, dropped, nil
+}
+
+// EmptyContentNormalizer fills/normalizes content for special-case roles:
+//   - role:"tool" with missing, null, or empty content → ToolSentinel
+//   - role:"assistant" with empty content AND a tool_calls/function_call payload → null
+//
+// SkipRoles bypasses messages whose role is listed (e.g. MiniMax tool messages
+// carry array content with a non-OpenAI shape and must not be touched here).
+type EmptyContentNormalizer struct {
+	ToolSentinel string
+	SkipRoles    []string
+}
+
+func (n EmptyContentNormalizer) Apply(messages []any) ([]any, bool, error) {
+	changed := false
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if slices.Contains(n.SkipRoles, role) {
+			continue
+		}
+		content, exists := msg["content"]
+		switch {
+		case !exists, content == nil:
+			if role == roleTool {
+				msg["content"] = n.ToolSentinel
+				changed = true
+			}
+		case IsEmptyContent(content):
+			switch role {
+			case roleAssistant:
+				_, hasToolCalls := msg["tool_calls"]
+				_, hasFunctionCall := msg["function_call"]
+				if hasToolCalls || hasFunctionCall {
+					msg["content"] = nil
+					changed = true
+				}
+			case roleTool:
+				msg["content"] = n.ToolSentinel
+				changed = true
+			}
+		}
+	}
+	return messages, changed, nil
+}
+
+// LegacyToolNameStripper strips the legacy `name` field from role:"tool"
+// messages — an artifact of the old role:"function" API. Universal.
+type LegacyToolNameStripper struct{}
+
+func (LegacyToolNameStripper) Apply(messages []any) ([]any, bool, error) {
+	changed := false
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role != roleTool {
+			continue
+		}
+		if _, exists := msg["name"]; !exists {
+			continue
+		}
+		delete(msg, "name")
+		changed = true
+	}
+	return messages, changed, nil
+}
+
+// MinimaxToolCallIDStripper silently strips tool_call_id from role:"tool"
+// messages. Clients dual-emitting tool_call_id for cross-route portability
+// keep working — MiniMax itself correlates tool results positionally.
+type MinimaxToolCallIDStripper struct{}
+
+func (MinimaxToolCallIDStripper) Apply(messages []any) ([]any, bool, error) {
+	changed := false
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role != roleTool {
+			continue
+		}
+		if _, exists := msg["tool_call_id"]; exists {
+			delete(msg, "tool_call_id")
+			changed = true
+		}
+	}
+	return messages, changed, nil
+}
+
+// TextPartsFlattener combines a content array of {type:"text",text} parts into
+// a single newline-joined string. SkipRoles bypasses messages whose role is
+// listed (e.g. MiniMax tool messages keep their {name,type,text}[] shape).
+type TextPartsFlattener struct {
+	SkipRoles []string
+}
+
+func (n TextPartsFlattener) Apply(messages []any) ([]any, bool, error) {
+	changed := false
+	for index, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if slices.Contains(n.SkipRoles, role) {
+			continue
+		}
+		content, exists := msg["content"]
+		if !exists || content == nil {
+			continue
+		}
+		parts, ok := content.([]any)
+		if !ok {
+			continue
+		}
+		combined, err := CombineTextContentParts(parts)
+		if err != nil {
+			return nil, false, fmt.Errorf("messages[%d].content%w", index, err)
+		}
+		if combined != "" {
+			msg["content"] = combined
+			changed = true
+		}
+	}
+	return messages, changed, nil
+}

--- a/devshard/cmd/devshardctl/messagevalidators/normalizers_test.go
+++ b/devshard/cmd/devshardctl/messagevalidators/normalizers_test.go
@@ -1,0 +1,379 @@
+package messagevalidators
+
+import (
+	"strings"
+	"testing"
+
+	"devshard/cmd/devshardctl/testutil"
+)
+
+// ============================================================
+// OrphanToolMessageDropper
+// ============================================================
+
+func TestOrphanToolMessageDropper_DropsToolWithUnmatchedID(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "user", "content": "hi"},
+		map[string]any{"role": "tool", "tool_call_id": "nobody", "content": "stray"},
+		map[string]any{"role": "assistant", "content": "hello"},
+	}
+	out, changed, err := OrphanToolMessageDropper{}.Apply(msgs)
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if !changed {
+		t.Fatal("changed must be true when something is dropped")
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 surviving messages, got %d", len(out))
+	}
+	if testutil.MapAt(t, out, 1)["role"] != "assistant" {
+		t.Fatal("orphan tool message must be dropped, assistant survives")
+	}
+}
+
+func TestOrphanToolMessageDropper_KeepsMatchedToolMessage(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "user", "content": "q"},
+		map[string]any{"role": "assistant", "content": "", "tool_calls": []any{
+			map[string]any{"id": "c1", "type": "function", "function": map[string]any{"name": "fn"}},
+		}},
+		map[string]any{"role": "tool", "tool_call_id": "c1", "content": "result"},
+	}
+	out, changed, err := OrphanToolMessageDropper{}.Apply(msgs)
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if changed {
+		t.Fatal("nothing should change for a well-formed sequence")
+	}
+	if len(out) != 3 {
+		t.Fatalf("want 3 messages, got %d", len(out))
+	}
+}
+
+func TestOrphanToolMessageDropper_ConsumesPendingOnMatch(t *testing.T) {
+	// Same id appearing twice — second tool message is orphan because
+	// the first consumed the pending entry.
+	msgs := []any{
+		map[string]any{"role": "assistant", "content": "", "tool_calls": []any{
+			map[string]any{"id": "c1", "type": "function", "function": map[string]any{"name": "fn"}},
+		}},
+		map[string]any{"role": "tool", "tool_call_id": "c1", "content": "first"},
+		map[string]any{"role": "tool", "tool_call_id": "c1", "content": "second"},
+	}
+	out, changed, _ := OrphanToolMessageDropper{}.Apply(msgs)
+	if !changed {
+		t.Fatal("must drop the second tool message")
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 survivors, got %d", len(out))
+	}
+}
+
+// ============================================================
+// MinimaxOrphanToolMessageDropper
+// ============================================================
+
+func TestMinimaxOrphanToolMessageDropper_DropsToolBeforeAnyAssistant(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "user", "content": "hi"},
+		map[string]any{"role": "tool", "content": []any{map[string]any{"name": "fn", "type": "text", "text": "x"}}},
+		map[string]any{"role": "assistant", "content": "hello"},
+	}
+	out, changed, _ := MinimaxOrphanToolMessageDropper{}.Apply(msgs)
+	if !changed {
+		t.Fatal("orphan tool before assistant must be dropped")
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 survivors, got %d", len(out))
+	}
+}
+
+func TestMinimaxOrphanToolMessageDropper_KeepsConsecutiveToolsInBlock(t *testing.T) {
+	// After assistant.tool_calls=[...], tool block stays open across all
+	// consecutive tool messages (parallel results).
+	msgs := []any{
+		map[string]any{"role": "user", "content": "q"},
+		map[string]any{"role": "assistant", "tool_calls": []any{
+			map[string]any{"id": "c1"}, map[string]any{"id": "c2"},
+		}},
+		map[string]any{"role": "tool", "content": []any{map[string]any{"name": "fn", "type": "text", "text": "r1"}}},
+		map[string]any{"role": "tool", "content": []any{map[string]any{"name": "fn", "type": "text", "text": "r2"}}},
+	}
+	out, changed, _ := MinimaxOrphanToolMessageDropper{}.Apply(msgs)
+	if changed {
+		t.Fatal("both tool messages are part of the block, no drops")
+	}
+	if len(out) != 4 {
+		t.Fatalf("want 4 messages preserved, got %d", len(out))
+	}
+}
+
+func TestMinimaxOrphanToolMessageDropper_NonToolMessageClosesBlock(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{"id": "c1"}}},
+		map[string]any{"role": "tool", "content": []any{map[string]any{"name": "fn", "type": "text", "text": "r"}}},
+		map[string]any{"role": "user", "content": "follow up"},
+		map[string]any{"role": "tool", "content": []any{map[string]any{"name": "fn", "type": "text", "text": "stray"}}},
+	}
+	out, changed, _ := MinimaxOrphanToolMessageDropper{}.Apply(msgs)
+	if !changed {
+		t.Fatal("tool after user must be dropped")
+	}
+	if len(out) != 3 {
+		t.Fatalf("want 3 survivors (drop final orphan), got %d", len(out))
+	}
+}
+
+func TestMinimaxOrphanToolMessageDropper_EmptyToolCallsDoesNotOpenBlock(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "assistant", "content": "no tools", "tool_calls": []any{}},
+		map[string]any{"role": "tool", "content": []any{map[string]any{"name": "fn", "type": "text", "text": "x"}}},
+	}
+	out, changed, _ := MinimaxOrphanToolMessageDropper{}.Apply(msgs)
+	if !changed {
+		t.Fatal("empty tool_calls does not open a block; tool is orphan")
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 survivor, got %d", len(out))
+	}
+}
+
+// ============================================================
+// EmptyAssistantTurnDropper
+// ============================================================
+
+func TestEmptyAssistantTurnDropper(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "user", "content": "hi"},
+		map[string]any{"role": "assistant"},                      // truly empty
+		map[string]any{"role": "assistant", "content": ""},       // empty string content
+		map[string]any{"role": "assistant", "content": "answer"}, // keep
+		map[string]any{"role": "user", "content": ""},            // user role NOT dropped here (validator job)
+		map[string]any{"role": "assistant", "tool_calls": []any{ // tool_calls makes it non-empty
+			map[string]any{"id": "c1"},
+		}},
+	}
+	out, changed, _ := EmptyAssistantTurnDropper{}.Apply(msgs)
+	if !changed {
+		t.Fatal("must drop 2 empty assistant turns")
+	}
+	if len(out) != 4 {
+		t.Fatalf("want 4 survivors, got %d", len(out))
+	}
+	// Survivors: user[0], assistant[answer], user[empty], assistant[tool_calls]
+	roles := []string{}
+	for _, m := range out {
+		roles = append(roles, m.(map[string]any)["role"].(string))
+	}
+	got := strings.Join(roles, ",")
+	if got != "user,assistant,user,assistant" {
+		t.Fatalf("survivor roles: %q", got)
+	}
+}
+
+// ============================================================
+// EmptyContentNormalizer
+// ============================================================
+
+func TestEmptyContentNormalizer_FillsToolWithSentinel(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "tool", "tool_call_id": "c1"}, // missing content
+		map[string]any{"role": "tool", "tool_call_id": "c2", "content": nil},
+		map[string]any{"role": "tool", "tool_call_id": "c3", "content": ""},
+	}
+	_, changed, _ := EmptyContentNormalizer{ToolSentinel: "(no result)"}.Apply(msgs)
+	if !changed {
+		t.Fatal("must have rewritten all three tool messages")
+	}
+	for i, raw := range msgs {
+		m := raw.(map[string]any)
+		if m["content"] != "(no result)" {
+			t.Fatalf("[%d] want sentinel, got %v", i, m["content"])
+		}
+	}
+}
+
+func TestEmptyContentNormalizer_NullifiesAssistantWithCalls(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "assistant", "content": "", "tool_calls": []any{map[string]any{"id": "c1"}}},
+		map[string]any{"role": "assistant", "content": "", "function_call": map[string]any{"name": "fn"}},
+	}
+	_, changed, _ := EmptyContentNormalizer{ToolSentinel: "x"}.Apply(msgs)
+	if !changed {
+		t.Fatal("must nullify content on assistant turns with call payload")
+	}
+	for i, raw := range msgs {
+		m := raw.(map[string]any)
+		if m["content"] != nil {
+			t.Fatalf("[%d] want nil content, got %v", i, m["content"])
+		}
+	}
+}
+
+func TestEmptyContentNormalizer_LeavesAssistantWithoutCalls(t *testing.T) {
+	// Empty content on assistant turn WITHOUT call payload is left untouched —
+	// the validator will reject it as malformed. The normalizer must not paper
+	// over the bug by inventing content.
+	msg := map[string]any{"role": "assistant", "content": ""}
+	msgs := []any{msg}
+	_, changed, _ := EmptyContentNormalizer{ToolSentinel: "x"}.Apply(msgs)
+	if changed {
+		t.Fatal("must not touch assistant turn without call payload")
+	}
+	if msg["content"] != "" {
+		t.Fatalf("content must remain empty string, got %v", msg["content"])
+	}
+}
+
+func TestEmptyContentNormalizer_SkipRolesBypassesTool(t *testing.T) {
+	// MiniMax chain: tool messages carry array content with non-OpenAI shape.
+	// The normalizer must NOT replace it with the sentinel.
+	msg := map[string]any{"role": "tool", "content": []any{}}
+	msgs := []any{msg}
+	_, changed, _ := EmptyContentNormalizer{
+		ToolSentinel: "(no result)",
+		SkipRoles:    []string{"tool"},
+	}.Apply(msgs)
+	if changed {
+		t.Fatal("SkipRoles must bypass tool messages")
+	}
+	if _, ok := msg["content"].([]any); !ok {
+		t.Fatalf("tool content must remain array, got %T", msg["content"])
+	}
+}
+
+func TestEmptyContentNormalizer_LeavesUserRoleAlone(t *testing.T) {
+	// User role isn't a special case: empty content is the validator's
+	// concern, not the normalizer's.
+	msg := map[string]any{"role": "user", "content": ""}
+	msgs := []any{msg}
+	_, changed, _ := EmptyContentNormalizer{ToolSentinel: "x"}.Apply(msgs)
+	if changed {
+		t.Fatal("user role is not normalized")
+	}
+}
+
+// ============================================================
+// LegacyToolNameStripper
+// ============================================================
+
+func TestLegacyToolNameStripper(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "user", "content": "hi", "name": "kept"},                          // not tool — name kept
+		map[string]any{"role": "tool", "tool_call_id": "c1", "content": "r", "name": "stripped"}, // tool — name stripped
+		map[string]any{"role": "tool", "tool_call_id": "c2", "content": "r"},                     // no name — no-op
+		map[string]any{"role": "assistant", "content": "x", "name": "assistant-name"},            // not tool — kept
+	}
+	_, changed, _ := LegacyToolNameStripper{}.Apply(msgs)
+	if !changed {
+		t.Fatal("must strip name from one tool message")
+	}
+	if _, has := testutil.MapAt(t, msgs, 0)["name"]; !has {
+		t.Fatal("user.name must be preserved")
+	}
+	if _, has := testutil.MapAt(t, msgs, 1)["name"]; has {
+		t.Fatal("tool.name must be stripped")
+	}
+	if _, has := testutil.MapAt(t, msgs, 3)["name"]; !has {
+		t.Fatal("assistant.name must be preserved")
+	}
+}
+
+// ============================================================
+// MinimaxToolCallIDStripper
+// ============================================================
+
+func TestMinimaxToolCallIDStripper(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "user", "tool_call_id": "weird-but-kept", "content": "hi"}, // not tool
+		map[string]any{"role": "tool", "tool_call_id": "c1", "content": []any{}},          // tool — stripped
+		map[string]any{"role": "tool", "content": []any{}},                                // tool no id — no-op
+	}
+	_, changed, _ := MinimaxToolCallIDStripper{}.Apply(msgs)
+	if !changed {
+		t.Fatal("must strip from one tool message")
+	}
+	if _, has := testutil.MapAt(t, msgs, 0)["tool_call_id"]; !has {
+		t.Fatal("non-tool role: tool_call_id preserved (validator's problem)")
+	}
+	if _, has := testutil.MapAt(t, msgs, 1)["tool_call_id"]; has {
+		t.Fatal("tool message: tool_call_id must be stripped")
+	}
+}
+
+// ============================================================
+// TextPartsFlattener
+// ============================================================
+
+func TestTextPartsFlattener_JoinsTextParts(t *testing.T) {
+	msg := map[string]any{
+		"role": "user",
+		"content": []any{
+			map[string]any{"type": "text", "text": "first"},
+			map[string]any{"type": "text", "text": "second"},
+		},
+	}
+	_, changed, err := TextPartsFlattener{}.Apply([]any{msg})
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if !changed {
+		t.Fatal("must have flattened content")
+	}
+	if msg["content"] != "first\nsecond" {
+		t.Fatalf("want 'first\\nsecond', got %v", msg["content"])
+	}
+}
+
+func TestTextPartsFlattener_LeavesStringAlone(t *testing.T) {
+	msg := map[string]any{"role": "user", "content": "already string"}
+	_, changed, _ := TextPartsFlattener{}.Apply([]any{msg})
+	if changed {
+		t.Fatal("string content must not trigger change")
+	}
+}
+
+func TestTextPartsFlattener_SkipRolesBypassesTool(t *testing.T) {
+	// MiniMax tool messages carry {name,type,text}[] arrays — must NOT be flattened.
+	msg := map[string]any{
+		"role": "tool",
+		"content": []any{
+			map[string]any{"name": "fn", "type": "text", "text": "result"},
+		},
+	}
+	_, changed, _ := TextPartsFlattener{SkipRoles: []string{"tool"}}.Apply([]any{msg})
+	if changed {
+		t.Fatal("SkipRoles must skip tool")
+	}
+	if _, ok := msg["content"].([]any); !ok {
+		t.Fatalf("tool content must remain array, got %T", msg["content"])
+	}
+}
+
+func TestTextPartsFlattener_ErrorIncludesMessageIndex(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "user", "content": "ok"},
+		map[string]any{"role": "user", "content": []any{
+			map[string]any{"type": "image_url", "text": "x"},
+		}},
+	}
+	_, _, err := TextPartsFlattener{}.Apply(msgs)
+	if err == nil {
+		t.Fatal("want error from bad part")
+	}
+	if !strings.Contains(err.Error(), "messages[1].content") {
+		t.Fatalf("error must include messages[1].content, got %v", err)
+	}
+}
+
+func TestTextPartsFlattener_EmptyContentArrayLeftAlone(t *testing.T) {
+	// CombineTextContentParts returns "" for empty arrays; flattener treats
+	// "" as "no change" so the empty array is preserved (validator's call).
+	msg := map[string]any{"role": "user", "content": []any{}}
+	_, changed, _ := TextPartsFlattener{}.Apply([]any{msg})
+	if changed {
+		t.Fatal("empty content array must not be flattened to empty string")
+	}
+}

--- a/devshard/cmd/devshardctl/messagevalidators/toolcalls.go
+++ b/devshard/cmd/devshardctl/messagevalidators/toolcalls.go
@@ -1,0 +1,82 @@
+package messagevalidators
+
+import "fmt"
+
+// ValidateToolCallsField validates the message.tool_calls field and returns
+// (collected ids, hasField, error). A null tool_calls is treated as absent
+// and silently removed (some SDKs serialize empty slots that way). Errors
+// carry no `messages[%d]` prefix — the caller wraps them.
+func ValidateToolCallsField(message map[string]any) ([]string, bool, error) {
+	rawToolCalls, exists := message["tool_calls"]
+	if !exists {
+		return nil, false, nil
+	}
+	if rawToolCalls == nil {
+		delete(message, "tool_calls")
+		return nil, false, nil
+	}
+	toolCalls, ok := rawToolCalls.([]any)
+	if !ok {
+		return nil, true, fmt.Errorf("tool_calls must be an array")
+	}
+	if len(toolCalls) == 0 {
+		return nil, true, fmt.Errorf("tool_calls must not be empty")
+	}
+	seen := map[string]struct{}{}
+	ids := make([]string, 0, len(toolCalls))
+	for callIndex, rawCall := range toolCalls {
+		call, ok := rawCall.(map[string]any)
+		if !ok {
+			return nil, true, fmt.Errorf("tool_calls[%d] must be an object", callIndex)
+		}
+		id, err := RequiredNonEmptyString(call, "id")
+		if err != nil {
+			return nil, true, fmt.Errorf("tool_calls[%d].id: %w", callIndex, err)
+		}
+		if _, exists := seen[id]; exists {
+			return nil, true, fmt.Errorf("tool_calls[%d].id is duplicated", callIndex)
+		}
+		seen[id] = struct{}{}
+		callType, err := RequiredNonEmptyString(call, "type")
+		if err != nil {
+			return nil, true, fmt.Errorf("tool_calls[%d].type: %w", callIndex, err)
+		}
+		if callType != "function" {
+			return nil, true, fmt.Errorf("tool_calls[%d].type must be \"function\"", callIndex)
+		}
+		function, ok := call["function"].(map[string]any)
+		if !ok {
+			return nil, true, fmt.Errorf("tool_calls[%d].function must be an object", callIndex)
+		}
+		if _, err := RequiredNonEmptyString(function, "name"); err != nil {
+			return nil, true, fmt.Errorf("tool_calls[%d].function.name: %w", callIndex, err)
+		}
+		if err := OptionalStringField(function, "arguments"); err != nil {
+			return nil, true, fmt.Errorf("tool_calls[%d].function.arguments: %w", callIndex, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, true, nil
+}
+
+func ValidateFunctionCallField(message map[string]any) (bool, error) {
+	rawFunctionCall, exists := message["function_call"]
+	if !exists {
+		return false, nil
+	}
+	if rawFunctionCall == nil {
+		delete(message, "function_call")
+		return false, nil
+	}
+	functionCall, ok := rawFunctionCall.(map[string]any)
+	if !ok {
+		return true, fmt.Errorf("function_call must be an object")
+	}
+	if _, err := RequiredNonEmptyString(functionCall, "name"); err != nil {
+		return true, fmt.Errorf("function_call.name: %w", err)
+	}
+	if err := OptionalStringField(functionCall, "arguments"); err != nil {
+		return true, fmt.Errorf("function_call.arguments: %w", err)
+	}
+	return true, nil
+}

--- a/devshard/cmd/devshardctl/messagevalidators/toolcalls_test.go
+++ b/devshard/cmd/devshardctl/messagevalidators/toolcalls_test.go
@@ -1,0 +1,202 @@
+package messagevalidators
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateToolCallsField_Absent(t *testing.T) {
+	msg := map[string]any{}
+	ids, has, err := ValidateToolCallsField(msg)
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if has {
+		t.Fatal("hasField must be false when field absent")
+	}
+	if ids != nil {
+		t.Fatalf("want nil ids, got %v", ids)
+	}
+}
+
+func TestValidateToolCallsField_NullTreatedAsAbsent(t *testing.T) {
+	// LangChain serializes empty slots as `null`; gateway silently drops it.
+	msg := map[string]any{"tool_calls": nil}
+	ids, has, err := ValidateToolCallsField(msg)
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if has {
+		t.Fatal("hasField must be false when value is null")
+	}
+	if _, stillThere := msg["tool_calls"]; stillThere {
+		t.Fatal("null tool_calls must be deleted from message")
+	}
+	if ids != nil {
+		t.Fatalf("want nil ids, got %v", ids)
+	}
+}
+
+func TestValidateToolCallsField_Happy(t *testing.T) {
+	msg := map[string]any{
+		"tool_calls": []any{
+			map[string]any{
+				"id":       "call_1",
+				"type":     "function",
+				"function": map[string]any{"name": "fn", "arguments": "{}"},
+			},
+			map[string]any{
+				"id":       "call_2",
+				"type":     "function",
+				"function": map[string]any{"name": "fn", "arguments": ""},
+			},
+		},
+	}
+	ids, has, err := ValidateToolCallsField(msg)
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if !has {
+		t.Fatal("hasField must be true")
+	}
+	if len(ids) != 2 || ids[0] != "call_1" || ids[1] != "call_2" {
+		t.Fatalf("want [call_1, call_2], got %v", ids)
+	}
+}
+
+func TestValidateToolCallsField_Errors(t *testing.T) {
+	cases := []struct {
+		name      string
+		msg       map[string]any
+		errSubstr string
+	}{
+		{
+			"not-array",
+			map[string]any{"tool_calls": "not-array"},
+			"tool_calls must be an array",
+		},
+		{
+			"empty-array",
+			map[string]any{"tool_calls": []any{}},
+			"tool_calls must not be empty",
+		},
+		{
+			"element-not-object",
+			map[string]any{"tool_calls": []any{"x"}},
+			"tool_calls[0] must be an object",
+		},
+		{
+			"missing-id",
+			map[string]any{"tool_calls": []any{
+				map[string]any{"type": "function", "function": map[string]any{"name": "fn"}},
+			}},
+			"tool_calls[0].id",
+		},
+		{
+			"duplicate-id",
+			map[string]any{"tool_calls": []any{
+				map[string]any{"id": "x", "type": "function", "function": map[string]any{"name": "fn"}},
+				map[string]any{"id": "x", "type": "function", "function": map[string]any{"name": "fn"}},
+			}},
+			"tool_calls[1].id is duplicated",
+		},
+		{
+			"wrong-type",
+			map[string]any{"tool_calls": []any{
+				map[string]any{"id": "x", "type": "code_interpreter", "function": map[string]any{"name": "fn"}},
+			}},
+			"tool_calls[0].type",
+		},
+		{
+			"function-not-object",
+			map[string]any{"tool_calls": []any{
+				map[string]any{"id": "x", "type": "function", "function": "not-object"},
+			}},
+			"tool_calls[0].function must be an object",
+		},
+		{
+			"function-missing-name",
+			map[string]any{"tool_calls": []any{
+				map[string]any{"id": "x", "type": "function", "function": map[string]any{}},
+			}},
+			"tool_calls[0].function.name",
+		},
+		{
+			"function-arguments-not-string",
+			map[string]any{"tool_calls": []any{
+				map[string]any{"id": "x", "type": "function", "function": map[string]any{"name": "fn", "arguments": 42}},
+			}},
+			"tool_calls[0].function.arguments",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := ValidateToolCallsField(tc.msg)
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Fatalf("want error containing %q, got %q", tc.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateFunctionCallField_Absent(t *testing.T) {
+	has, err := ValidateFunctionCallField(map[string]any{})
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if has {
+		t.Fatal("hasField must be false")
+	}
+}
+
+func TestValidateFunctionCallField_NullTreatedAsAbsent(t *testing.T) {
+	msg := map[string]any{"function_call": nil}
+	has, err := ValidateFunctionCallField(msg)
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if has {
+		t.Fatal("hasField must be false")
+	}
+	if _, stillThere := msg["function_call"]; stillThere {
+		t.Fatal("null function_call must be deleted")
+	}
+}
+
+func TestValidateFunctionCallField_Happy(t *testing.T) {
+	has, err := ValidateFunctionCallField(map[string]any{
+		"function_call": map[string]any{"name": "fn", "arguments": "{}"},
+	})
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if !has {
+		t.Fatal("hasField must be true")
+	}
+}
+
+func TestValidateFunctionCallField_Errors(t *testing.T) {
+	cases := []struct {
+		name      string
+		msg       map[string]any
+		errSubstr string
+	}{
+		{"not-object", map[string]any{"function_call": "x"}, "function_call must be an object"},
+		{"missing-name", map[string]any{"function_call": map[string]any{}}, "function_call.name"},
+		{"args-not-string", map[string]any{"function_call": map[string]any{"name": "fn", "arguments": 42}}, "function_call.arguments"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ValidateFunctionCallField(tc.msg)
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Fatalf("want error containing %q, got %q", tc.errSubstr, err.Error())
+			}
+		})
+	}
+}

--- a/devshard/cmd/devshardctl/messagevalidators/types.go
+++ b/devshard/cmd/devshardctl/messagevalidators/types.go
@@ -1,0 +1,14 @@
+// Package messagevalidators holds leaf-level shape/bounds validators for
+// per-message content. It mirrors paramvalidators (which validates top-level
+// request fields). Validators are model-agnostic — per-model dispatch happens
+// upstream in ChatMessageProcessor's role-policy catalog, which picks which
+// validator (if any) to call for a given (route, role) pair.
+package messagevalidators
+
+// ContentValidator validates the value of a single message's `content` field.
+// Implementations are pure: they do not mutate the message and do not have
+// access to cross-message state. Cross-message correlation (e.g. tool_call_id
+// matching) is handled by ChatMessageProcessor's per-role policy, not here.
+type ContentValidator interface {
+	Validate(content any) error
+}

--- a/devshard/cmd/devshardctl/metrics.go
+++ b/devshard/cmd/devshardctl/metrics.go
@@ -840,7 +840,7 @@ func (c *gatewayMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		labels := []string{rt.id, rt.model}
 		ch <- prometheus.MustNewConstMetric(c.runtimeActiveDesc, prometheus.GaugeValue, active, labels...)
-		ch <- prometheus.MustNewConstMetric(c.runtimeRequestsDesc, prometheus.GaugeValue, float64(rt.activeRequests.Load()), labels...)
+		ch <- prometheus.MustNewConstMetric(c.runtimeRequestsDesc, prometheus.GaugeValue, float64(rt.activeUserRequests.Load()), labels...)
 		ch <- prometheus.MustNewConstMetric(c.runtimeReservedDesc, prometheus.GaugeValue, float64(rt.reservedTokens.Load()), labels...)
 		blocked := 0
 		if c.gateway.participantLimiter != nil {

--- a/devshard/cmd/devshardctl/metrics.go
+++ b/devshard/cmd/devshardctl/metrics.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +34,63 @@ type DevshardMetrics struct {
 	hostFirstTokenSeconds      *prometheus.HistogramVec
 	hostCTTFLSecondsPerToken   *prometheus.HistogramVec
 	hostTotalSeconds           *prometheus.HistogramVec
+	participantReceiptSeconds  *prometheus.HistogramVec
+	participantFirstContent    *prometheus.HistogramVec
+	participantPrefillPerToken *prometheus.HistogramVec
+	participantTotalSeconds    *prometheus.HistogramVec
+
+	gatewayRequests       *prometheus.CounterVec
+	criticalUserFailures  *prometheus.CounterVec
+	hiddenFailures        *prometheus.CounterVec
+	userVisibleWins       *prometheus.CounterVec
+	slotDecisions         *prometheus.CounterVec
+	attemptsStarted       *prometheus.CounterVec
+	attemptsTerminal      *prometheus.CounterVec
+	attemptFailures       *prometheus.CounterVec
+	quarantineTransitions *prometheus.CounterVec
+	noWinnerAttempts      *prometheus.CounterVec
+	timeoutActions        *prometheus.CounterVec
+}
+
+type GatewaySlotDecisionMetric struct {
+	ParticipantKey string
+	Model          string
+	EscrowID       string
+	Decision       string
+	Reason         string
+	QuarantineMode string
+}
+
+type GatewayAttemptStartMetric struct {
+	ParticipantKey string
+	Model          string
+	Role           string
+	Reason         string
+	QuarantineMode string
+}
+
+type GatewayAttemptTerminalMetric struct {
+	ParticipantKey string
+	Model          string
+	Role           string
+	Outcome        string
+	Visibility     string
+}
+
+type GatewayAttemptFailureMetric struct {
+	ParticipantKey string
+	Model          string
+	Role           string
+	Reason         string
+	Visibility     string
+}
+
+type GatewayTimeoutActionMetric struct {
+	ParticipantKey string
+	Model          string
+	Kind           string
+	Action         string
+	Reason         string
 }
 
 func NewDevshardMetrics() *DevshardMetrics {
@@ -66,16 +127,16 @@ func NewDevshardMetrics() *DevshardMetrics {
 		participantLimitRejections: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "devshard_gateway_participant_limit_rejections_total",
-				Help: "Total participant-budget rejections by routing scope.",
+				Help: "Total participant-budget rejections by participant, model, and routing scope.",
 			},
-			[]string{"scope"},
+			[]string{"participant_key", "model", "scope"},
 		),
 		participantTransportErrors: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "devshard_gateway_participant_transport_errors_total",
-				Help: "Total participant-bound transport request errors by request kind and upstream status.",
+				Help: "Total participant-bound transport request errors by participant, model, request kind, and upstream status.",
 			},
-			[]string{"path_kind", "status"},
+			[]string{"participant_key", "model", "path_kind", "status"},
 		),
 		speculativeDecisions: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -137,6 +198,115 @@ func NewDevshardMetrics() *DevshardMetrics {
 			},
 			[]string{"devshard_id", "host_idx"},
 		),
+		participantReceiptSeconds: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "devshard_gateway_participant_receipt_seconds",
+				Help:    "Time from gateway inference send until receipt confirmation by participant and model.",
+				Buckets: prometheus.ExponentialBuckets(0.01, 2, 12),
+			},
+			[]string{"participant_key", "model"},
+		),
+		participantFirstContent: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "devshard_gateway_participant_first_content_seconds",
+				Help:    "Time from gateway inference send until first content by participant and model.",
+				Buckets: prometheus.ExponentialBuckets(0.01, 2, 12),
+			},
+			[]string{"participant_key", "model"},
+		),
+		participantPrefillPerToken: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "devshard_gateway_participant_prefill_seconds_per_input_token",
+				Help:    "Time from receipt until first content divided by input tokens, by participant and model.",
+				Buckets: prometheus.ExponentialBuckets(0.0001, 2, 12),
+			},
+			[]string{"participant_key", "model"},
+		),
+		participantTotalSeconds: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "devshard_gateway_participant_total_attempt_seconds",
+				Help:    "Total inference attempt time observed by the gateway, by participant and model.",
+				Buckets: prometheus.ExponentialBuckets(0.01, 2, 12),
+			},
+			[]string{"participant_key", "model"},
+		),
+		gatewayRequests: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_requests_total",
+				Help: "Total gateway chat requests by model, user-visible outcome, and bounded reason.",
+			},
+			[]string{"model", "outcome", "reason"},
+		),
+		criticalUserFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_critical_user_failures_total",
+				Help: "Total critical user-visible gateway failures by model and bounded reason.",
+			},
+			[]string{"model", "reason"},
+		),
+		hiddenFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_user_requests_with_hidden_failure_total",
+				Help: "Total successful user requests that hid gateway-visible participant or policy failures.",
+			},
+			[]string{"model", "severity", "reason"},
+		),
+		userVisibleWins: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_user_visible_wins_total",
+				Help: "Total user-visible winning responses by participant and model.",
+			},
+			[]string{"participant_key", "model"},
+		),
+		slotDecisions: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_slot_decisions_total",
+				Help: "Total gateway slot decisions by participant, model, escrow, decision, reason, and quarantine mode.",
+			},
+			[]string{"participant_key", "model", "escrow_id", "decision", "reason", "quarantine_mode"},
+		),
+		attemptsStarted: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_attempts_started_total",
+				Help: "Total real gateway attempts started by participant, model, role, reason, and quarantine mode.",
+			},
+			[]string{"participant_key", "model", "role", "reason", "quarantine_mode"},
+		),
+		attemptsTerminal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_attempts_terminal_total",
+				Help: "Total real gateway attempts by terminal outcome and visibility.",
+			},
+			[]string{"participant_key", "model", "role", "outcome", "visibility"},
+		),
+		attemptFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_attempt_failures_total",
+				Help: "Total failed real gateway attempts by bounded failure reason and visibility.",
+			},
+			[]string{"participant_key", "model", "role", "reason", "visibility"},
+		),
+		quarantineTransitions: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_participant_quarantine_transitions_total",
+				Help: "Total participant quarantine and no-winner state transitions by participant, model, mode, and reason.",
+			},
+			[]string{"participant_key", "model", "mode", "reason"},
+		),
+		noWinnerAttempts: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_no_winner_attempts_total",
+				Help: "Total real no-winner attempts by participant, model, reason, and quarantine mode.",
+			},
+			[]string{"participant_key", "model", "reason", "quarantine_mode"},
+		),
+		timeoutActions: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_timeout_actions_total",
+				Help: "Total gateway timeout actions by participant, model, timeout kind, action, and reason.",
+			},
+			[]string{"participant_key", "model", "kind", "action", "reason"},
+		),
 	}
 
 	registry.MustRegister(
@@ -153,6 +323,21 @@ func NewDevshardMetrics() *DevshardMetrics {
 		m.hostFirstTokenSeconds,
 		m.hostCTTFLSecondsPerToken,
 		m.hostTotalSeconds,
+		m.participantReceiptSeconds,
+		m.participantFirstContent,
+		m.participantPrefillPerToken,
+		m.participantTotalSeconds,
+		m.gatewayRequests,
+		m.criticalUserFailures,
+		m.hiddenFailures,
+		m.userVisibleWins,
+		m.slotDecisions,
+		m.attemptsStarted,
+		m.attemptsTerminal,
+		m.attemptFailures,
+		m.quarantineTransitions,
+		m.noWinnerAttempts,
+		m.timeoutActions,
 	)
 
 	m.handler = promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
@@ -202,18 +387,27 @@ func (m *DevshardMetrics) RecordLimitRejection(reason string) {
 	m.gatewayLimitRejections.WithLabelValues(reason).Inc()
 }
 
-func (m *DevshardMetrics) RecordParticipantLimitRejection(scope string) {
+func (m *DevshardMetrics) RecordParticipantLimitRejection(participantKey, model, scope string) {
 	if m == nil {
 		return
 	}
-	m.participantLimitRejections.WithLabelValues(scope).Inc()
+	m.participantLimitRejections.WithLabelValues(
+		metricLabel(participantKey, "unknown"),
+		metricLabel(model, "unknown"),
+		metricLabel(scope, "unknown"),
+	).Inc()
 }
 
-func (m *DevshardMetrics) RecordParticipantTransportError(pathKind string, statusCode int) {
+func (m *DevshardMetrics) RecordParticipantTransportError(participantKey, model, pathKind string, statusCode int) {
 	if m == nil {
 		return
 	}
-	m.participantTransportErrors.WithLabelValues(pathKind, strconv.Itoa(statusCode)).Inc()
+	m.participantTransportErrors.WithLabelValues(
+		metricLabel(participantKey, "unknown"),
+		metricLabel(model, "unknown"),
+		metricLabel(pathKind, "unknown"),
+		strconv.Itoa(statusCode),
+	).Inc()
 }
 
 func (m *DevshardMetrics) RecordSpeculativeDecision(reason string) {
@@ -244,47 +438,190 @@ func (m *DevshardMetrics) RecordPickerChoice(devshardID, model string) {
 	m.pickerChoices.WithLabelValues(devshardID, model).Inc()
 }
 
+func (m *DevshardMetrics) RecordGatewayRequest(model, outcome, reason string) {
+	if m == nil {
+		return
+	}
+	m.gatewayRequests.WithLabelValues(metricLabel(model, "unknown"), metricLabel(outcome, "unknown"), metricLabel(reason, "none")).Inc()
+}
+
+func (m *DevshardMetrics) RecordCriticalUserFailure(model, reason string) {
+	if m == nil {
+		return
+	}
+	m.criticalUserFailures.WithLabelValues(metricLabel(model, "unknown"), metricLabel(reason, "unknown")).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewayHiddenFailure(model, severity, reason string) {
+	if m == nil {
+		return
+	}
+	m.hiddenFailures.WithLabelValues(metricLabel(model, "unknown"), metricLabel(severity, "unknown"), metricLabel(reason, "unknown")).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewayUserVisibleWin(participantKey, model string) {
+	if m == nil {
+		return
+	}
+	m.userVisibleWins.WithLabelValues(metricLabel(participantKey, "unknown"), metricLabel(model, "unknown")).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewaySlotDecision(decision GatewaySlotDecisionMetric) {
+	if m == nil {
+		return
+	}
+	m.slotDecisions.WithLabelValues(
+		metricLabel(decision.ParticipantKey, "unknown"),
+		metricLabel(decision.Model, "unknown"),
+		metricLabel(decision.EscrowID, "unknown"),
+		metricLabel(decision.Decision, "unknown"),
+		metricLabel(decision.Reason, "unknown"),
+		metricLabel(decision.QuarantineMode, "none"),
+	).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewayAttemptStarted(start GatewayAttemptStartMetric) {
+	if m == nil {
+		return
+	}
+	m.attemptsStarted.WithLabelValues(
+		metricLabel(start.ParticipantKey, "unknown"),
+		metricLabel(start.Model, "unknown"),
+		metricLabel(start.Role, "unknown"),
+		metricLabel(start.Reason, "none"),
+		metricLabel(start.QuarantineMode, "none"),
+	).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewayAttemptTerminal(terminal GatewayAttemptTerminalMetric) {
+	if m == nil {
+		return
+	}
+	m.attemptsTerminal.WithLabelValues(
+		metricLabel(terminal.ParticipantKey, "unknown"),
+		metricLabel(terminal.Model, "unknown"),
+		metricLabel(terminal.Role, "unknown"),
+		metricLabel(terminal.Outcome, "unknown"),
+		metricLabel(terminal.Visibility, "unknown"),
+	).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewayAttemptFailure(failure GatewayAttemptFailureMetric) {
+	if m == nil {
+		return
+	}
+	m.attemptFailures.WithLabelValues(
+		metricLabel(failure.ParticipantKey, "unknown"),
+		metricLabel(failure.Model, "unknown"),
+		metricLabel(failure.Role, "unknown"),
+		metricLabel(failure.Reason, "unknown"),
+		metricLabel(failure.Visibility, "unknown"),
+	).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewayQuarantineTransition(participantKey, model, mode, reason string) {
+	if m == nil {
+		return
+	}
+	m.quarantineTransitions.WithLabelValues(
+		metricLabel(participantKey, "unknown"),
+		metricLabel(model, "all"),
+		metricLabel(mode, "none"),
+		metricLabel(reason, "unknown"),
+	).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewayNoWinnerAttempt(participantKey, model, reason, quarantineMode string) {
+	if m == nil {
+		return
+	}
+	m.noWinnerAttempts.WithLabelValues(
+		metricLabel(participantKey, "unknown"),
+		metricLabel(model, "unknown"),
+		metricLabel(reason, "unknown"),
+		metricLabel(quarantineMode, "none"),
+	).Inc()
+}
+
+func (m *DevshardMetrics) RecordGatewayTimeoutAction(action GatewayTimeoutActionMetric) {
+	if m == nil {
+		return
+	}
+	m.timeoutActions.WithLabelValues(
+		metricLabel(action.ParticipantKey, "unknown"),
+		metricLabel(action.Model, "unknown"),
+		metricLabel(action.Kind, "unknown"),
+		metricLabel(action.Action, "unknown"),
+		metricLabel(action.Reason, "none"),
+	).Inc()
+}
+
 func (m *DevshardMetrics) ObserveRequestSample(devshardID string, sample RequestSample) {
 	if m == nil {
 		return
 	}
 
 	labels := []string{devshardID, strconv.Itoa(sample.HostIdx)}
+	participantLabels := []string{
+		metricLabel(sample.ParticipantKey, "unknown"),
+		metricLabel(sample.Model, "unknown"),
+	}
 	if receiptSeconds := sample.ReceiptMs() / 1000; receiptSeconds > 0 {
 		m.hostReceiptSeconds.WithLabelValues(labels...).Observe(receiptSeconds)
+		m.participantReceiptSeconds.WithLabelValues(participantLabels...).Observe(receiptSeconds)
 	}
 	if !sample.SendTime.IsZero() && !sample.FirstToken.IsZero() {
-		m.hostFirstTokenSeconds.WithLabelValues(labels...).Observe(sample.FirstToken.Sub(sample.SendTime).Seconds())
+		firstContentSeconds := sample.FirstToken.Sub(sample.SendTime).Seconds()
+		m.hostFirstTokenSeconds.WithLabelValues(labels...).Observe(firstContentSeconds)
+		m.participantFirstContent.WithLabelValues(participantLabels...).Observe(firstContentSeconds)
 	}
 	if cttfl := sample.CTTFL() / 1000; cttfl > 0 {
 		m.hostCTTFLSecondsPerToken.WithLabelValues(labels...).Observe(cttfl)
+		m.participantPrefillPerToken.WithLabelValues(participantLabels...).Observe(cttfl)
 	}
 	if sample.TotalTime > 0 {
 		m.hostTotalSeconds.WithLabelValues(labels...).Observe(sample.TotalTime.Seconds())
+		m.participantTotalSeconds.WithLabelValues(participantLabels...).Observe(sample.TotalTime.Seconds())
 	}
+}
+
+func metricLabel(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value != "" {
+		return value
+	}
+	fallback = strings.TrimSpace(fallback)
+	if fallback != "" {
+		return fallback
+	}
+	return "unknown"
 }
 
 type gatewayMetricsCollector struct {
 	gateway         *Gateway
 	hostConnections hostConnectionSnapshotter
 
-	inflightRequestsDesc          *prometheus.Desc
-	inflightTokensDesc            *prometheus.Desc
-	effectiveMaxConcurrentDesc    *prometheus.Desc
-	effectiveMaxInputTokensDesc   *prometheus.Desc
-	capacityScaleDesc             *prometheus.Desc
-	capacityTotalDesc             *prometheus.Desc
-	capacityBaselineDesc          *prometheus.Desc
-	escrowWeightDesc              *prometheus.Desc
-	runtimeActiveDesc             *prometheus.Desc
-	runtimeRequestsDesc           *prometheus.Desc
-	runtimeReservedDesc           *prometheus.Desc
-	participantExhaustedDesc      *prometheus.Desc
-	participantTrackedDesc        *prometheus.Desc
-	escrowParticipantLimitedDesc  *prometheus.Desc
-	escrowBlockedParticipantsDesc *prometheus.Desc
-	hostOpenDesc                  *prometheus.Desc
-	hostStateDesc                 *prometheus.Desc
+	inflightRequestsDesc           *prometheus.Desc
+	inflightTokensDesc             *prometheus.Desc
+	effectiveMaxConcurrentDesc     *prometheus.Desc
+	effectiveMaxInputTokensDesc    *prometheus.Desc
+	capacityScaleDesc              *prometheus.Desc
+	capacityTotalDesc              *prometheus.Desc
+	capacityBaselineDesc           *prometheus.Desc
+	capacityScaleByModelDesc       *prometheus.Desc
+	capacityTotalByModelDesc       *prometheus.Desc
+	capacityBaselineByModelDesc    *prometheus.Desc
+	escrowWeightDesc               *prometheus.Desc
+	runtimeActiveDesc              *prometheus.Desc
+	runtimeRequestsDesc            *prometheus.Desc
+	runtimeReservedDesc            *prometheus.Desc
+	participantExhaustedDesc       *prometheus.Desc
+	participantTrackedDesc         *prometheus.Desc
+	participantQuarantineStateDesc *prometheus.Desc
+	escrowParticipantLimitedDesc   *prometheus.Desc
+	escrowBlockedParticipantsDesc  *prometheus.Desc
+	hostOpenDesc                   *prometheus.Desc
+	hostStateDesc                  *prometheus.Desc
 }
 
 func newGatewayMetricsCollector(gateway *Gateway) *gatewayMetricsCollector {
@@ -341,6 +678,24 @@ func newGatewayMetricsCollectorWithHostConnections(gateway *Gateway, hostConnect
 			nil,
 			nil,
 		),
+		capacityScaleByModelDesc: prometheus.NewDesc(
+			"devshard_gateway_capacity_scale_by_model",
+			"Ratio W_tot(model) / W_ref(model) for each model (1.0 = full model capacity).",
+			[]string{"model"},
+			nil,
+		),
+		capacityTotalByModelDesc: prometheus.NewDesc(
+			"devshard_gateway_capacity_total_weight_by_model",
+			"Current gateway-wide effective host weight (W_tot) for each model.",
+			[]string{"model"},
+			nil,
+		),
+		capacityBaselineByModelDesc: prometheus.NewDesc(
+			"devshard_gateway_capacity_baseline_weight_by_model",
+			"Baseline gateway-wide host weight (W_ref) for each model.",
+			[]string{"model"},
+			nil,
+		),
 		escrowWeightDesc: prometheus.NewDesc(
 			"devshard_gateway_escrow_weight",
 			"Per-escrow effective weight W(e) used by the capacity-aware picker.",
@@ -375,6 +730,12 @@ func newGatewayMetricsCollectorWithHostConnections(gateway *Gateway, hostConnect
 			"devshard_gateway_participants_tracked",
 			"Current number of participants in reactive throttle tracking (entered after first 429/503).",
 			nil,
+			nil,
+		),
+		participantQuarantineStateDesc: prometheus.NewDesc(
+			"devshard_gateway_participant_quarantine_state",
+			"Current participant quarantine or no-winner state by participant and model.",
+			[]string{"participant_key", "model", "mode"},
 			nil,
 		),
 		escrowParticipantLimitedDesc: prometheus.NewDesc(
@@ -412,12 +773,16 @@ func (c *gatewayMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.capacityScaleDesc
 	ch <- c.capacityTotalDesc
 	ch <- c.capacityBaselineDesc
+	ch <- c.capacityScaleByModelDesc
+	ch <- c.capacityTotalByModelDesc
+	ch <- c.capacityBaselineByModelDesc
 	ch <- c.escrowWeightDesc
 	ch <- c.runtimeActiveDesc
 	ch <- c.runtimeRequestsDesc
 	ch <- c.runtimeReservedDesc
 	ch <- c.participantExhaustedDesc
 	ch <- c.participantTrackedDesc
+	ch <- c.participantQuarantineStateDesc
 	ch <- c.escrowParticipantLimitedDesc
 	ch <- c.escrowBlockedParticipantsDesc
 	ch <- c.hostOpenDesc
@@ -428,6 +793,10 @@ func (c *gatewayMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	if c.gateway == nil {
 		return
 	}
+
+	c.gateway.mu.Lock()
+	runtimes := append([]*devshardRuntime(nil), c.gateway.runtimeOrder...)
+	c.gateway.mu.Unlock()
 
 	if c.gateway.limiter != nil {
 		snapshot := c.gateway.limiter.Snapshot()
@@ -444,6 +813,11 @@ func (c *gatewayMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		for id, w := range capSnap.EscrowWeights {
 			ch <- prometheus.MustNewConstMetric(c.escrowWeightDesc, prometheus.GaugeValue, w, id)
 		}
+		for _, model := range capacityMetricModels(c.gateway.capacity, runtimes) {
+			ch <- prometheus.MustNewConstMetric(c.capacityScaleByModelDesc, prometheus.GaugeValue, c.gateway.capacity.ScaleFactorForModel(model), model)
+			ch <- prometheus.MustNewConstMetric(c.capacityTotalByModelDesc, prometheus.GaugeValue, c.gateway.capacity.TotalWeightForModel(model), model)
+			ch <- prometheus.MustNewConstMetric(c.capacityBaselineByModelDesc, prometheus.GaugeValue, c.gateway.capacity.BaselineWeightForModel(model), model)
+		}
 	}
 	if c.gateway.participantLimiter != nil {
 		ch <- prometheus.MustNewConstMetric(
@@ -458,9 +832,7 @@ func (c *gatewayMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		)
 	}
 
-	c.gateway.mu.Lock()
-	runtimes := append([]*devshardRuntime(nil), c.gateway.runtimeOrder...)
-	c.gateway.mu.Unlock()
+	emittedParticipantStates := make(map[string]struct{})
 	for _, rt := range runtimes {
 		active := 0.0
 		if rt.active.Load() {
@@ -473,6 +845,26 @@ func (c *gatewayMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		blocked := 0
 		if c.gateway.participantLimiter != nil {
 			blocked = len(c.gateway.participantLimiter.BlockedParticipants(rt.participantKeys))
+			for participantKey, snapshot := range c.gateway.participantLimiter.Snapshot(rt.participantKeys) {
+				if !participantSnapshotAppliesToModel(snapshot, rt.model) {
+					continue
+				}
+				model := metricLabel(rt.model, "unknown")
+				mode := participantSnapshotMode(snapshot)
+				stateKey := participantKey + "\x00" + model + "\x00" + mode
+				if _, ok := emittedParticipantStates[stateKey]; ok {
+					continue
+				}
+				emittedParticipantStates[stateKey] = struct{}{}
+				ch <- prometheus.MustNewConstMetric(
+					c.participantQuarantineStateDesc,
+					prometheus.GaugeValue,
+					1,
+					participantKey,
+					model,
+					mode,
+				)
+			}
 		}
 		limited := 0.0
 		if blocked > 0 {
@@ -491,6 +883,138 @@ func (c *gatewayMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.hostStateDesc, prometheus.GaugeValue, float64(snapshot.Idle), snapshot.Address, "idle")
 		ch <- prometheus.MustNewConstMetric(c.hostStateDesc, prometheus.GaugeValue, float64(snapshot.HoldAfterClose), snapshot.Address, "hold_after_close")
 	}
+}
+
+func participantSnapshotAppliesToModel(snapshot ParticipantThrottleSnapshot, model string) bool {
+	if len(snapshot.ModelIDs) == 0 {
+		return true
+	}
+	model = normalizeModelID(model)
+	if model == "" {
+		return true
+	}
+	for _, modelID := range snapshot.ModelIDs {
+		if normalizeModelID(modelID) == model {
+			return true
+		}
+	}
+	return false
+}
+
+func capacityMetricModels(capacity *CapacityState, runtimes []*devshardRuntime) []string {
+	seen := make(map[string]struct{})
+	if capacity != nil {
+		for _, model := range capacity.Models() {
+			model = strings.TrimSpace(model)
+			if model != "" {
+				seen[model] = struct{}{}
+			}
+		}
+	}
+	for _, rt := range runtimes {
+		if rt == nil {
+			continue
+		}
+		model := strings.TrimSpace(rt.model)
+		if model != "" {
+			seen[model] = struct{}{}
+		}
+	}
+	models := make([]string, 0, len(seen))
+	for model := range seen {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+	return models
+}
+
+func participantSnapshotMode(snapshot ParticipantThrottleSnapshot) string {
+	switch {
+	case snapshot.ProbeQuarantined:
+		return "probe"
+	case snapshot.ShadowQuarantined:
+		return "shadow"
+	case snapshot.Probationary:
+		return "probation"
+	default:
+		return "none"
+	}
+}
+
+type nonceFinishedChecker interface {
+	IsNonceFinished(uint64) bool
+}
+
+func gatewayAttemptFailureReason(inf *inflight, session nonceFinishedChecker) string {
+	if inf == nil {
+		return "unknown"
+	}
+	switch {
+	case inf.phaseTransitionAborted:
+		return "phase_transition_aborted"
+	case isErrorStreamAttempt(inf):
+		return "error_stream"
+	case isEmptyStreamAttempt(inf):
+		return "empty_stream"
+	}
+	if inf.err != nil {
+		var upstreamErr *transport.UpstreamStatusError
+		switch {
+		case errors.As(inf.err, &upstreamErr):
+			return gatewayHTTPFailureReason(upstreamErr.StatusCode)
+		case errors.Is(inf.err, transport.ErrSSEStreamTruncated):
+			return "sse_truncated"
+		case errors.Is(inf.err, io.EOF), errors.Is(inf.err, io.ErrUnexpectedEOF), strings.Contains(strings.ToLower(inf.err.Error()), "eof"):
+			return "eof_transport"
+		case errors.Is(inf.err, context.Canceled), errors.Is(inf.err, context.DeadlineExceeded):
+			return "client_cancelled"
+		default:
+			return "transport_error"
+		}
+	}
+	if inf.receiptTime.IsZero() {
+		return "no_receipt"
+	}
+	if session != nil && !session.IsNonceFinished(inf.nonce) {
+		return "not_finished"
+	}
+	return "unknown"
+}
+
+func gatewayHTTPFailureReason(statusCode int) string {
+	switch statusCode {
+	case http.StatusTooManyRequests:
+		return "http_429"
+	case http.StatusServiceUnavailable:
+		return "http_503"
+	case http.StatusForbidden:
+		return "http_forbidden"
+	case http.StatusNotFound:
+		return "http_not_found"
+	case http.StatusUnauthorized:
+		return "http_timestamp_drift"
+	default:
+		if statusCode >= 400 {
+			return "http_error"
+		}
+		return "transport_error"
+	}
+}
+
+func gatewayAttemptVisibility(inf *inflight, winnerNonce uint64, successful bool) string {
+	if inf == nil {
+		return "unknown"
+	}
+	if inf.suspicious {
+		return "no_winner"
+	}
+	if successful && winnerNonce != 0 && inf.nonce == winnerNonce {
+		return "user_visible_winner"
+	}
+	if successful {
+		return "suppressed_loser"
+	}
+	return "failed_not_finished"
 }
 
 type metricsResponseWriter struct {

--- a/devshard/cmd/devshardctl/metrics_test.go
+++ b/devshard/cmd/devshardctl/metrics_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewayCoreV1MetricsRecordBoundedLabels(t *testing.T) {
+	m := NewDevshardMetrics()
+
+	m.RecordParticipantLimitRejection("participant-1", "Qwen/Test", "transport_request")
+	m.RecordParticipantTransportError("participant-1", "Qwen/Test", "inference", http.StatusServiceUnavailable)
+	m.RecordGatewayRequest("Qwen/Test", "success", "none")
+	m.RecordCriticalUserFailure("Qwen/Test", "runtime_unavailable")
+	m.RecordGatewayHiddenFailure("Qwen/Test", "protected", "empty_stream")
+	m.RecordGatewayUserVisibleWin("participant-1", "Qwen/Test")
+	m.RecordGatewaySlotDecision(GatewaySlotDecisionMetric{
+		ParticipantKey: "participant-1",
+		Model:          "Qwen/Test",
+		EscrowID:       "12",
+		Decision:       "ghost_no_send",
+		Reason:         "participant_throttled_no_send",
+		QuarantineMode: "probe",
+	})
+	m.RecordGatewayAttemptStarted(GatewayAttemptStartMetric{
+		ParticipantKey: "participant-1",
+		Model:          "Qwen/Test",
+		Role:           "extra",
+		Reason:         "receipt_timeout",
+		QuarantineMode: "none",
+	})
+	m.RecordGatewayAttemptTerminal(GatewayAttemptTerminalMetric{
+		ParticipantKey: "participant-1",
+		Model:          "Qwen/Test",
+		Role:           "extra",
+		Outcome:        "failed",
+		Visibility:     "failed_not_finished",
+	})
+	m.RecordGatewayAttemptFailure(GatewayAttemptFailureMetric{
+		ParticipantKey: "participant-1",
+		Model:          "Qwen/Test",
+		Role:           "extra",
+		Reason:         "empty_stream",
+		Visibility:     "failed_not_finished",
+	})
+	m.RecordGatewayNoWinnerAttempt("participant-1", "Qwen/Test", "shadow_quarantine", "shadow")
+	m.RecordGatewayTimeoutAction(GatewayTimeoutActionMetric{
+		ParticipantKey: "participant-1",
+		Model:          "Qwen/Test",
+		Kind:           "execution",
+		Action:         "completed",
+		Reason:         "none",
+	})
+
+	families, err := m.registry.Gather()
+	require.NoError(t, err)
+	requireMetricCounterValue(t, families, "devshard_gateway_participant_limit_rejections_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "scope": "transport_request"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_participant_transport_errors_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "path_kind": "inference", "status": "503"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_requests_total", map[string]string{"model": "Qwen/Test", "outcome": "success", "reason": "none"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_critical_user_failures_total", map[string]string{"model": "Qwen/Test", "reason": "runtime_unavailable"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_user_requests_with_hidden_failure_total", map[string]string{"model": "Qwen/Test", "severity": "protected", "reason": "empty_stream"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_user_visible_wins_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_slot_decisions_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "escrow_id": "12", "decision": "ghost_no_send", "reason": "participant_throttled_no_send", "quarantine_mode": "probe"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_attempts_started_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "role": "extra", "reason": "receipt_timeout", "quarantine_mode": "none"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_attempts_terminal_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "role": "extra", "outcome": "failed", "visibility": "failed_not_finished"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_attempt_failures_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "role": "extra", "reason": "empty_stream", "visibility": "failed_not_finished"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_no_winner_attempts_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "reason": "shadow_quarantine", "quarantine_mode": "shadow"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_timeout_actions_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "kind": "execution", "action": "completed", "reason": "none"}, 1)
+}
+
+func TestGatewayMetricsCollectorIncludesParticipantQuarantineState(t *testing.T) {
+	limiter := NewParticipantRequestLimiter(10, 10)
+	for i := 0; i < emptyStreamQuarantineThreshold; i++ {
+		limiter.ObserveEmptyStreamForModel("participant-1", "Qwen/Test")
+	}
+
+	g := &Gateway{
+		participantLimiter: limiter,
+		runtimeOrder: []*devshardRuntime{{
+			id:              "12",
+			model:           "Qwen/Test",
+			participantKeys: []string{"participant-1"},
+		}},
+	}
+	collector := newGatewayMetricsCollectorWithHostConnections(g, fakeHostConnectionSnapshotter(nil))
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	requireMetricGaugeValue(t, families, "devshard_gateway_participant_quarantine_state", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "mode": "shadow"}, 1)
+}
+
+func TestGatewayMetricsCollectorDedupesParticipantQuarantineState(t *testing.T) {
+	limiter := NewParticipantRequestLimiter(10, 10)
+	for i := 0; i < emptyStreamQuarantineThreshold; i++ {
+		limiter.ObserveEmptyStreamForModel("participant-1", "Qwen/Test")
+	}
+
+	g := &Gateway{
+		participantLimiter: limiter,
+		runtimeOrder: []*devshardRuntime{
+			{
+				id:              "12",
+				model:           "Qwen/Test",
+				participantKeys: []string{"participant-1"},
+			},
+			{
+				id:              "44",
+				model:           "Qwen/Test",
+				participantKeys: []string{"participant-1"},
+			},
+		},
+	}
+	collector := newGatewayMetricsCollectorWithHostConnections(g, fakeHostConnectionSnapshotter(nil))
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	requireMetricGaugeValue(t, families, "devshard_gateway_participant_quarantine_state", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "mode": "shadow"}, 1)
+}
+
+func TestGatewayMetricsCollectorIncludesModelCapacityScales(t *testing.T) {
+	capacity := NewCapacityState()
+	capacity.SetEscrowMembership("qwen", map[string]int{"host-q": 1})
+	capacity.SetEscrowMembership("kimi", map[string]int{"host-k": 1})
+	capacity.SetHostWeightViews(
+		map[string]float64{"host-q": 40, "host-k": 50},
+		map[string]float64{"host-q": 150, "host-k": 50},
+		map[string]map[string]float64{
+			"Qwen/Test": {"host-q": 40},
+			"Kimi/Test": {"host-k": 50},
+		},
+		map[string]map[string]float64{
+			"Qwen/Test": {"host-q": 150},
+			"Kimi/Test": {"host-k": 50},
+		},
+	)
+	g := &Gateway{
+		capacity: capacity,
+		runtimeOrder: []*devshardRuntime{
+			{id: "qwen", model: "Qwen/Test"},
+			{id: "kimi", model: "Kimi/Test"},
+			{id: "runtime-only", model: "Runtime/Only"},
+		},
+	}
+	collector := newGatewayMetricsCollectorWithHostConnections(g, fakeHostConnectionSnapshotter(nil))
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_scale_by_model", map[string]string{"model": "Qwen/Test"}, 40.0/150.0)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_total_weight_by_model", map[string]string{"model": "Qwen/Test"}, 40)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_baseline_weight_by_model", map[string]string{"model": "Qwen/Test"}, 150)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_scale_by_model", map[string]string{"model": "Kimi/Test"}, 1)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_total_weight_by_model", map[string]string{"model": "Kimi/Test"}, 50)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_baseline_weight_by_model", map[string]string{"model": "Kimi/Test"}, 50)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_scale_by_model", map[string]string{"model": "Runtime/Only"}, 90.0/200.0)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_total_weight_by_model", map[string]string{"model": "Runtime/Only"}, 90)
+	requireMetricGaugeValue(t, families, "devshard_gateway_capacity_baseline_weight_by_model", map[string]string{"model": "Runtime/Only"}, 200)
+}
+
+func TestParticipantLimiterRecordsQuarantineTransitions(t *testing.T) {
+	m := NewDevshardMetrics()
+	limiter := NewParticipantRequestLimiter(10, 10)
+	limiter.SetMetrics(m)
+
+	limiter.ObserveResultWithBodyForModel("participant-1", "Qwen/Test", "/sessions/12/chat/completions", http.StatusServiceUnavailable, "")
+	for i := 0; i < emptyStreamQuarantineThreshold; i++ {
+		limiter.ObserveEmptyStreamForModel("participant-2", "Qwen/Test")
+	}
+
+	families, err := m.registry.Gather()
+	require.NoError(t, err)
+	requireMetricCounterValue(t, families, "devshard_gateway_participant_quarantine_transitions_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "mode": "probe", "reason": "http_throttle_quarantine"}, 1)
+	requireMetricCounterValue(t, families, "devshard_gateway_participant_quarantine_transitions_total", map[string]string{"participant_key": "participant-2", "model": "Qwen/Test", "mode": "shadow", "reason": "empty_stream_quarantine"}, 1)
+}
+
+func TestGatewayParticipantTimingMetricsRecordAddressAndModel(t *testing.T) {
+	m := NewDevshardMetrics()
+	now := time.Now()
+
+	m.ObserveRequestSample("12", RequestSample{
+		HostIdx:        1,
+		ParticipantKey: "participant-1",
+		Model:          "Qwen/Test",
+		SendTime:       now,
+		ReceiptTime:    now.Add(100 * time.Millisecond),
+		FirstToken:     now.Add(300 * time.Millisecond),
+		TotalTime:      900 * time.Millisecond,
+		InputTokens:    10,
+	})
+
+	families, err := m.registry.Gather()
+	require.NoError(t, err)
+	labels := map[string]string{"participant_key": "participant-1", "model": "Qwen/Test"}
+	requireMetricHistogramCount(t, families, "devshard_gateway_participant_receipt_seconds", labels, 1)
+	requireMetricHistogramCount(t, families, "devshard_gateway_participant_first_content_seconds", labels, 1)
+	requireMetricHistogramCount(t, families, "devshard_gateway_participant_prefill_seconds_per_input_token", labels, 1)
+	requireMetricHistogramCount(t, families, "devshard_gateway_participant_total_attempt_seconds", labels, 1)
+}
+
+func TestGatewayAttemptMetricClassifiers(t *testing.T) {
+	now := time.Now()
+
+	require.Equal(t, "empty_stream", gatewayAttemptFailureReason(&inflight{receiptTime: now}, nil))
+	require.Equal(t, "error_stream", gatewayAttemptFailureReason(&inflight{receiptTime: now, errorSource: "error.BadRequestError"}, nil))
+	require.Equal(t, "eof_transport", gatewayAttemptFailureReason(&inflight{err: io.EOF}, nil))
+	require.Equal(t, "phase_transition_aborted", gatewayAttemptFailureReason(&inflight{phaseTransitionAborted: true}, nil))
+
+	require.Equal(t, "user_visible_winner", gatewayAttemptVisibility(&inflight{nonce: 7}, 7, true))
+	require.Equal(t, "no_winner", gatewayAttemptVisibility(&inflight{nonce: 7, suspicious: true}, 7, true))
+	require.Equal(t, "suppressed_loser", gatewayAttemptVisibility(&inflight{nonce: 8}, 7, true))
+	require.Equal(t, "failed_not_finished", gatewayAttemptVisibility(&inflight{nonce: 8}, 0, false))
+}
+
+func requireMetricCounterValue(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string, want float64) {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metricLabelsMatch(metric, labels) {
+				require.NotNil(t, metric.Counter)
+				require.Equal(t, want, metric.Counter.GetValue())
+				return
+			}
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+}
+
+func requireMetricHistogramCount(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string, want uint64) {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metricLabelsMatch(metric, labels) {
+				require.NotNil(t, metric.Histogram)
+				require.Equal(t, want, metric.Histogram.GetSampleCount())
+				return
+			}
+		}
+	}
+	t.Fatalf("histogram %s with labels %v not found", name, labels)
+}

--- a/devshard/cmd/devshardctl/paramvalidators/context.go
+++ b/devshard/cmd/devshardctl/paramvalidators/context.go
@@ -6,3 +6,18 @@ type ValidatorContext struct {
 	Document    map[string]any
 	RoutedModel string
 }
+
+// ParameterContext is the input bundle passed to ParameterHandler.HandleParameter.
+// Document is shared with the pipeline; handlers may mutate it (delete the field,
+// rewrite its value, etc.). Parameter is the field name the handler is wired against.
+type ParameterContext struct {
+	Document    map[string]any
+	Parameter   string
+	RoutedModel string
+}
+
+// ParameterHandler is the leaf type for stage-driven rewrites of a single field.
+// The caller wraps the returned error as HTTP 400.
+type ParameterHandler interface {
+	HandleParameter(ParameterContext) error
+}

--- a/devshard/cmd/devshardctl/paramvalidators/handlers.go
+++ b/devshard/cmd/devshardctl/paramvalidators/handlers.go
@@ -210,6 +210,74 @@ func (h ValidateUintParameter) HandleParameter(ctx ParameterContext) error {
 	return nil
 }
 
+// RejectNumberParameter rejects the request when the parameter is present and parses as a
+// number but Allow returns false for it. Non-numeric or absent values pass through so the
+// dedicated type/shape validators own those cases. Used for range gates whose lower bound is
+// exclusive (e.g. top_p > 0), where clamping to the bound would itself be an illegal value.
+type RejectNumberParameter struct {
+	Allow   func(float64) bool
+	Message string
+}
+
+func (h RejectNumberParameter) HandleParameter(ctx ParameterContext) error {
+	value, exists := ctx.Document[ctx.Parameter]
+	if !exists {
+		return nil
+	}
+	number, ok := devshard.JSONNumericFloat64(value)
+	if !ok {
+		return nil
+	}
+	if h.Allow == nil || h.Allow(number) {
+		return nil
+	}
+	return fmt.Errorf("%s: %s", ctx.Parameter, h.Message)
+}
+
+// ValidateScalarParameter rejects the request when the parameter is present (non-null) but
+// Valid returns false for its raw JSON value. Catches wrong-typed scalars at the boundary
+// instead of forwarding them for an opaque upstream 400.
+type ValidateScalarParameter struct {
+	Valid   func(any) bool
+	Message string
+}
+
+func (h ValidateScalarParameter) HandleParameter(ctx ParameterContext) error {
+	value, exists := ctx.Document[ctx.Parameter]
+	if !exists || value == nil {
+		return nil
+	}
+	if h.Valid == nil || h.Valid(value) {
+		return nil
+	}
+	return fmt.Errorf("%s: %s", ctx.Parameter, h.Message)
+}
+
+// ValidateListElementsParameter rejects the request when any array element fails Valid.
+// Pass-through when the field is absent or not an array.
+type ValidateListElementsParameter struct {
+	Valid   func(any) bool
+	Message string
+}
+
+func (h ValidateListElementsParameter) HandleParameter(ctx ParameterContext) error {
+	raw, ok := ctx.Document[ctx.Parameter].([]any)
+	if !ok {
+		return nil
+	}
+	for index, item := range raw {
+		if h.Valid != nil && !h.Valid(item) {
+			return fmt.Errorf("%s[%d]: %s", ctx.Parameter, index, h.Message)
+		}
+	}
+	return nil
+}
+
+// JSON type predicates for the Validate*Parameter handlers above.
+func IsJSONBool(value any) bool   { _, ok := value.(bool); return ok }
+func IsJSONString(value any) bool { _, ok := value.(string); return ok }
+func IsJSONUint(value any) bool   { _, ok := devshard.JSONNumericUint64(value); return ok }
+
 // LengthCapListParameter bounds the number of entries in an array field, and
 // optionally the byte length of each string entry. MaxEntries=0 disables the
 // array cap; MaxEntryLen=0 disables the per-string cap.

--- a/devshard/cmd/devshardctl/paramvalidators/handlers.go
+++ b/devshard/cmd/devshardctl/paramvalidators/handlers.go
@@ -1,0 +1,237 @@
+package paramvalidators
+
+import (
+	"fmt"
+	"math"
+
+	"devshard"
+)
+
+// StripParameter deletes the parameter field from the document unconditionally.
+type StripParameter struct{}
+
+func (StripParameter) HandleParameter(ctx ParameterContext) error {
+	delete(ctx.Document, ctx.Parameter)
+	return nil
+}
+
+// ConditionalStripParameter deletes the parameter field when Predicate returns true.
+// Predicate is called only when the rule fires; nil predicate is a no-op.
+type ConditionalStripParameter struct {
+	Predicate func(ParameterContext) bool
+}
+
+func (h ConditionalStripParameter) HandleParameter(ctx ParameterContext) error {
+	if h.Predicate != nil && h.Predicate(ctx) {
+		delete(ctx.Document, ctx.Parameter)
+	}
+	return nil
+}
+
+// SanitizeStringListParameter filters a []string-shaped field. Non-string entries pass
+// through unchanged so other validators can flag them. DropFieldIfEmpty removes the
+// field entirely when the filter leaves it empty.
+type SanitizeStringListParameter struct {
+	Keep             func(string) bool
+	DropFieldIfEmpty bool
+}
+
+func (h SanitizeStringListParameter) HandleParameter(ctx ParameterContext) error {
+	raw, ok := ctx.Document[ctx.Parameter].([]any)
+	if !ok {
+		return nil
+	}
+	cleaned := raw[:0]
+	for _, item := range raw {
+		value, ok := item.(string)
+		if !ok {
+			cleaned = append(cleaned, item)
+			continue
+		}
+		if h.Keep == nil || h.Keep(value) {
+			cleaned = append(cleaned, value)
+		}
+	}
+	if len(cleaned) == 0 && h.DropFieldIfEmpty {
+		delete(ctx.Document, ctx.Parameter)
+		return nil
+	}
+	ctx.Document[ctx.Parameter] = cleaned
+	return nil
+}
+
+// SanitizeFloatParameter normalizes a numeric knob: parses string/json.Number inputs,
+// drops non-finite values when StripNonFinite is set, clamps to [Min, Max].
+type SanitizeFloatParameter struct {
+	StripNonFinite bool
+	Min            *float64
+	Max            *float64
+}
+
+func (h SanitizeFloatParameter) HandleParameter(ctx ParameterContext) error {
+	value, exists := ctx.Document[ctx.Parameter]
+	if !exists {
+		return nil
+	}
+	number, ok := devshard.JSONNumericFloat64(value)
+	if !ok {
+		delete(ctx.Document, ctx.Parameter)
+		return nil
+	}
+	if h.StripNonFinite && (math.IsNaN(number) || math.IsInf(number, 0)) {
+		delete(ctx.Document, ctx.Parameter)
+		return nil
+	}
+	if h.Min != nil && number < *h.Min {
+		number = *h.Min
+	}
+	if h.Max != nil && number > *h.Max {
+		number = *h.Max
+	}
+	ctx.Document[ctx.Parameter] = number
+	return nil
+}
+
+// SanitizeFloatMapParameter applies SanitizeFloatParameter semantics to every value in
+// a map-shaped field. Entries that fail clamping are dropped (not clamped) — vLLM
+// rejects out-of-range logit_bias entries.
+type SanitizeFloatMapParameter struct {
+	StripNonFinite   bool
+	Min              *float64
+	Max              *float64
+	DropFieldIfEmpty bool
+	MaxEntries       int
+}
+
+func (h SanitizeFloatMapParameter) HandleParameter(ctx ParameterContext) error {
+	raw, ok := ctx.Document[ctx.Parameter].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if h.MaxEntries > 0 && len(raw) > h.MaxEntries {
+		return fmt.Errorf("%s: map size %d exceeds limit %d", ctx.Parameter, len(raw), h.MaxEntries)
+	}
+	for key, value := range raw {
+		number, ok := devshard.JSONNumericFloat64(value)
+		if !ok {
+			continue
+		}
+		if h.StripNonFinite && (math.IsNaN(number) || math.IsInf(number, 0)) {
+			delete(raw, key)
+			continue
+		}
+		if h.Min != nil && number < *h.Min {
+			delete(raw, key)
+			continue
+		}
+		if h.Max != nil && number > *h.Max {
+			delete(raw, key)
+		}
+	}
+	if len(raw) == 0 && h.DropFieldIfEmpty {
+		delete(ctx.Document, ctx.Parameter)
+		return nil
+	}
+	ctx.Document[ctx.Parameter] = raw
+	return nil
+}
+
+// ForceLiteralParameter writes Value into the document. OverwriteOnly leaves the
+// field untouched when it isn't already present.
+type ForceLiteralParameter struct {
+	Value         any
+	OverwriteOnly bool
+}
+
+func (h ForceLiteralParameter) HandleParameter(ctx ParameterContext) error {
+	if h.OverwriteOnly {
+		if _, exists := ctx.Document[ctx.Parameter]; !exists {
+			return nil
+		}
+	}
+	ctx.Document[ctx.Parameter] = h.Value
+	return nil
+}
+
+// CapUintParameter caps a uint64-shaped field to Max.
+type CapUintParameter struct {
+	Max uint64
+}
+
+func (h CapUintParameter) HandleParameter(ctx ParameterContext) error {
+	value, ok := numericJSONValueAsUint64FromMap(ctx.Document, ctx.Parameter)
+	if !ok {
+		return nil
+	}
+	if value > h.Max {
+		ctx.Document[ctx.Parameter] = h.Max
+	}
+	return nil
+}
+
+// ClampUintToFieldParameter clamps the parameter to the value of another field
+// in the same document (e.g. thinking_token_budget ≤ max_tokens). A zero MaxField
+// value or missing MaxField is treated as "no clamp".
+type ClampUintToFieldParameter struct {
+	MaxField string
+}
+
+func (h ClampUintToFieldParameter) HandleParameter(ctx ParameterContext) error {
+	value, ok := numericJSONValueAsUint64FromMap(ctx.Document, ctx.Parameter)
+	if !ok {
+		return nil
+	}
+	maxValue, ok := numericJSONValueAsUint64FromMap(ctx.Document, h.MaxField)
+	if !ok || maxValue == 0 {
+		return nil
+	}
+	if value > maxValue {
+		ctx.Document[ctx.Parameter] = maxValue
+	}
+	return nil
+}
+
+// ValidateUintParameter rejects requests whose field is present but cannot be parsed
+// as a non-negative integer that fits in uint64. Pass-through when the field is absent.
+type ValidateUintParameter struct{}
+
+func (h ValidateUintParameter) HandleParameter(ctx ParameterContext) error {
+	raw, exists := ctx.Document[ctx.Parameter]
+	if !exists || raw == nil {
+		return nil
+	}
+	if _, ok := devshard.JSONNumericUint64(raw); !ok {
+		return fmt.Errorf("%s: must be a non-negative integer", ctx.Parameter)
+	}
+	return nil
+}
+
+// LengthCapListParameter bounds the number of entries in an array field, and
+// optionally the byte length of each string entry. MaxEntries=0 disables the
+// array cap; MaxEntryLen=0 disables the per-string cap.
+type LengthCapListParameter struct {
+	MaxEntries  int
+	MaxEntryLen int
+}
+
+func (h LengthCapListParameter) HandleParameter(ctx ParameterContext) error {
+	raw, ok := ctx.Document[ctx.Parameter].([]any)
+	if !ok {
+		return nil
+	}
+	if h.MaxEntries > 0 && len(raw) > h.MaxEntries {
+		return fmt.Errorf("%s: array length %d exceeds limit %d", ctx.Parameter, len(raw), h.MaxEntries)
+	}
+	if h.MaxEntryLen > 0 {
+		for i, item := range raw {
+			s, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if len(s) > h.MaxEntryLen {
+				return fmt.Errorf("%s[%d]: string length %d exceeds limit %d", ctx.Parameter, i, len(s), h.MaxEntryLen)
+			}
+		}
+	}
+	return nil
+}

--- a/devshard/cmd/devshardctl/paramvalidators/handlers.go
+++ b/devshard/cmd/devshardctl/paramvalidators/handlers.go
@@ -155,6 +155,7 @@ func (h ForceLiteralParameter) HandleParameter(ctx ParameterContext) error {
 
 // CapUintParameter caps a uint64-shaped field to Max.
 type CapUintParameter struct {
+	Min uint64
 	Max uint64
 }
 
@@ -162,6 +163,9 @@ func (h CapUintParameter) HandleParameter(ctx ParameterContext) error {
 	value, ok := numericJSONValueAsUint64FromMap(ctx.Document, ctx.Parameter)
 	if !ok {
 		return nil
+	}
+	if value < h.Min {
+		ctx.Document[ctx.Parameter] = h.Min
 	}
 	if value > h.Max {
 		ctx.Document[ctx.Parameter] = h.Max

--- a/devshard/cmd/devshardctl/paramvalidators/handlers_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/handlers_test.go
@@ -1,0 +1,450 @@
+package paramvalidators
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"devshard/cmd/devshardctl/testutil"
+)
+
+// run is a tiny wrapper that builds a ParameterContext and dispatches the handler.
+func run(h ParameterHandler, doc map[string]any, param string) error {
+	return h.HandleParameter(ParameterContext{
+		Document:    doc,
+		Parameter:   param,
+		RoutedModel: "",
+	})
+}
+
+// ============================================================
+// StripParameter
+// ============================================================
+
+func TestStripParameter(t *testing.T) {
+	doc := map[string]any{"x": "y", "keep": 1}
+	if err := run(StripParameter{}, doc, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := doc["x"]; has {
+		t.Fatal("x must be stripped")
+	}
+	if _, has := doc["keep"]; !has {
+		t.Fatal("other fields must remain")
+	}
+}
+
+func TestStripParameter_NoopWhenAbsent(t *testing.T) {
+	doc := map[string]any{"keep": 1}
+	if err := run(StripParameter{}, doc, "x"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ============================================================
+// ConditionalStripParameter
+// ============================================================
+
+func TestConditionalStripParameter_PredicateTrue(t *testing.T) {
+	doc := map[string]any{"min_tokens": 10, "stop_token_ids": []any{42}}
+	h := ConditionalStripParameter{
+		Predicate: func(ctx ParameterContext) bool {
+			_, ok := ctx.Document["stop_token_ids"]
+			return ok
+		},
+	}
+	if err := run(h, doc, "min_tokens"); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := doc["min_tokens"]; has {
+		t.Fatal("min_tokens must be stripped when stop_token_ids present")
+	}
+}
+
+func TestConditionalStripParameter_PredicateFalse(t *testing.T) {
+	doc := map[string]any{"min_tokens": 10}
+	h := ConditionalStripParameter{
+		Predicate: func(ctx ParameterContext) bool {
+			_, ok := ctx.Document["stop_token_ids"]
+			return ok
+		},
+	}
+	if err := run(h, doc, "min_tokens"); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := doc["min_tokens"]; !has {
+		t.Fatal("min_tokens must remain when predicate is false")
+	}
+}
+
+func TestConditionalStripParameter_NilPredicateNoop(t *testing.T) {
+	doc := map[string]any{"x": 1}
+	if err := run(ConditionalStripParameter{}, doc, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := doc["x"]; !has {
+		t.Fatal("nil predicate is a no-op")
+	}
+}
+
+// ============================================================
+// SanitizeStringListParameter
+// ============================================================
+
+func TestSanitizeStringListParameter_Filters(t *testing.T) {
+	doc := map[string]any{"bad_words": []any{"keep", "", "  ", "also-keep"}}
+	h := SanitizeStringListParameter{
+		Keep:             func(s string) bool { return strings.TrimSpace(s) != "" },
+		DropFieldIfEmpty: true,
+	}
+	if err := run(h, doc, "bad_words"); err != nil {
+		t.Fatal(err)
+	}
+	out := doc["bad_words"].([]any)
+	if len(out) != 2 || out[0] != "keep" || out[1] != "also-keep" {
+		t.Fatalf("want [keep, also-keep], got %v", out)
+	}
+}
+
+func TestSanitizeStringListParameter_DropsFieldWhenEmpty(t *testing.T) {
+	doc := map[string]any{"bad_words": []any{"", "  "}}
+	h := SanitizeStringListParameter{
+		Keep:             func(s string) bool { return strings.TrimSpace(s) != "" },
+		DropFieldIfEmpty: true,
+	}
+	if err := run(h, doc, "bad_words"); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := doc["bad_words"]; has {
+		t.Fatal("empty post-filter array must be removed when DropFieldIfEmpty=true")
+	}
+}
+
+func TestSanitizeStringListParameter_NonStringElementsPreserved(t *testing.T) {
+	// Non-strings pass through so later validators can flag them; the filter
+	// only acts on strings.
+	doc := map[string]any{"x": []any{"a", 42, true, "b"}}
+	h := SanitizeStringListParameter{Keep: func(s string) bool { return true }}
+	if err := run(h, doc, "x"); err != nil {
+		t.Fatal(err)
+	}
+	out := doc["x"].([]any)
+	if len(out) != 4 {
+		t.Fatalf("want 4 elements, got %d", len(out))
+	}
+}
+
+func TestSanitizeStringListParameter_AbsentFieldNoop(t *testing.T) {
+	doc := map[string]any{}
+	if err := run(SanitizeStringListParameter{}, doc, "x"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ============================================================
+// SanitizeFloatParameter
+// ============================================================
+
+func TestSanitizeFloatParameter_Clamps(t *testing.T) {
+	doc := map[string]any{"t": 5.0}
+	h := SanitizeFloatParameter{Min: testutil.FloatPtr(0), Max: testutil.FloatPtr(2.0)}
+	if err := run(h, doc, "t"); err != nil {
+		t.Fatal(err)
+	}
+	if doc["t"].(float64) != 2.0 {
+		t.Fatalf("want clamped to 2.0, got %v", doc["t"])
+	}
+}
+
+func TestSanitizeFloatParameter_StripsNonFinite(t *testing.T) {
+	for _, v := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		doc := map[string]any{"t": v}
+		h := SanitizeFloatParameter{StripNonFinite: true}
+		if err := run(h, doc, "t"); err != nil {
+			t.Fatal(err)
+		}
+		if _, has := doc["t"]; has {
+			t.Fatalf("non-finite %v must be stripped", v)
+		}
+	}
+}
+
+func TestSanitizeFloatParameter_NonNumericStripped(t *testing.T) {
+	doc := map[string]any{"t": "not-a-number"}
+	if err := run(SanitizeFloatParameter{}, doc, "t"); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := doc["t"]; has {
+		t.Fatal("non-numeric must be stripped")
+	}
+}
+
+func TestSanitizeFloatParameter_StringNumericCoerced(t *testing.T) {
+	// Some SDKs serialize numbers as strings for high-precision fields.
+	doc := map[string]any{"t": "1.5"}
+	if err := run(SanitizeFloatParameter{}, doc, "t"); err != nil {
+		t.Fatal(err)
+	}
+	if doc["t"].(float64) != 1.5 {
+		t.Fatalf("want 1.5, got %v", doc["t"])
+	}
+}
+
+// ============================================================
+// SanitizeFloatMapParameter
+// ============================================================
+
+func TestSanitizeFloatMapParameter_DropsOutOfRange(t *testing.T) {
+	doc := map[string]any{"logit_bias": map[string]any{
+		"a": 50.0,   // out of [-100, 100]? No, in range
+		"b": 150.0,  // > 100 → drop
+		"c": -200.0, // < -100 → drop
+		"d": 0.0,
+	}}
+	h := SanitizeFloatMapParameter{Min: testutil.FloatPtr(-100), Max: testutil.FloatPtr(100)}
+	if err := run(h, doc, "logit_bias"); err != nil {
+		t.Fatal(err)
+	}
+	out := doc["logit_bias"].(map[string]any)
+	if _, has := out["b"]; has {
+		t.Fatal("b must be dropped")
+	}
+	if _, has := out["c"]; has {
+		t.Fatal("c must be dropped")
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 surviving entries, got %d", len(out))
+	}
+}
+
+func TestSanitizeFloatMapParameter_DropsNonFinite(t *testing.T) {
+	doc := map[string]any{"m": map[string]any{
+		"a": 1.0,
+		"b": math.NaN(),
+		"c": math.Inf(1),
+	}}
+	h := SanitizeFloatMapParameter{StripNonFinite: true}
+	if err := run(h, doc, "m"); err != nil {
+		t.Fatal(err)
+	}
+	out := doc["m"].(map[string]any)
+	if len(out) != 1 {
+		t.Fatalf("want 1 surviving, got %d", len(out))
+	}
+}
+
+func TestSanitizeFloatMapParameter_RejectsOversizeMap(t *testing.T) {
+	doc := map[string]any{"m": map[string]any{}}
+	for i := 0; i < 5; i++ {
+		doc["m"].(map[string]any)[string(rune('a'+i))] = 1.0
+	}
+	h := SanitizeFloatMapParameter{MaxEntries: 3}
+	err := run(h, doc, "m")
+	if err == nil || !strings.Contains(err.Error(), "exceeds limit") {
+		t.Fatalf("want 'exceeds limit', got %v", err)
+	}
+}
+
+func TestSanitizeFloatMapParameter_DropFieldIfEmpty(t *testing.T) {
+	doc := map[string]any{"m": map[string]any{"a": math.NaN(), "b": math.Inf(1)}}
+	h := SanitizeFloatMapParameter{StripNonFinite: true, DropFieldIfEmpty: true}
+	if err := run(h, doc, "m"); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := doc["m"]; has {
+		t.Fatal("post-filter empty map must be removed")
+	}
+}
+
+// ============================================================
+// ForceLiteralParameter
+// ============================================================
+
+func TestForceLiteralParameter_Overwrites(t *testing.T) {
+	doc := map[string]any{"logprobs": false}
+	if err := run(ForceLiteralParameter{Value: true}, doc, "logprobs"); err != nil {
+		t.Fatal(err)
+	}
+	if doc["logprobs"] != true {
+		t.Fatalf("want true, got %v", doc["logprobs"])
+	}
+}
+
+func TestForceLiteralParameter_CreatesWhenAbsent(t *testing.T) {
+	doc := map[string]any{}
+	if err := run(ForceLiteralParameter{Value: 5}, doc, "n"); err != nil {
+		t.Fatal(err)
+	}
+	if doc["n"] != 5 {
+		t.Fatalf("want 5, got %v", doc["n"])
+	}
+}
+
+func TestForceLiteralParameter_OverwriteOnlySkipsAbsent(t *testing.T) {
+	doc := map[string]any{}
+	h := ForceLiteralParameter{Value: 0.0, OverwriteOnly: true}
+	if err := run(h, doc, "frequency_penalty"); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := doc["frequency_penalty"]; has {
+		t.Fatal("OverwriteOnly must not create absent field")
+	}
+}
+
+func TestForceLiteralParameter_OverwriteOnlyTouchesPresent(t *testing.T) {
+	doc := map[string]any{"frequency_penalty": 0.5}
+	h := ForceLiteralParameter{Value: 0.0, OverwriteOnly: true}
+	if err := run(h, doc, "frequency_penalty"); err != nil {
+		t.Fatal(err)
+	}
+	if doc["frequency_penalty"] != 0.0 {
+		t.Fatalf("want 0.0, got %v", doc["frequency_penalty"])
+	}
+}
+
+// ============================================================
+// CapUintParameter
+// ============================================================
+
+func TestCapUintParameter(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		max  uint64
+		want any
+	}{
+		{"caps-when-over", float64(100), 10, uint64(10)},
+		{"leaves-when-under", float64(5), 10, float64(5)},
+		{"leaves-when-equal", float64(10), 10, float64(10)},
+		{"non-numeric-noop", "x", 10, "x"},
+		{"negative-noop", float64(-1), 10, float64(-1)}, // not coerced → not capped
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := map[string]any{"n": tc.in}
+			if err := run(CapUintParameter{Max: tc.max}, doc, "n"); err != nil {
+				t.Fatal(err)
+			}
+			if doc["n"] != tc.want {
+				t.Fatalf("want %v, got %v", tc.want, doc["n"])
+			}
+		})
+	}
+}
+
+// ============================================================
+// ClampUintToFieldParameter
+// ============================================================
+
+func TestClampUintToFieldParameter(t *testing.T) {
+	t.Run("clamps-to-other-field", func(t *testing.T) {
+		doc := map[string]any{"min_tokens": float64(1000), "max_tokens": float64(100)}
+		if err := run(ClampUintToFieldParameter{MaxField: "max_tokens"}, doc, "min_tokens"); err != nil {
+			t.Fatal(err)
+		}
+		if doc["min_tokens"] != uint64(100) {
+			t.Fatalf("want clamped to 100, got %v", doc["min_tokens"])
+		}
+	})
+	t.Run("max-field-absent-noop", func(t *testing.T) {
+		doc := map[string]any{"min_tokens": float64(1000)}
+		if err := run(ClampUintToFieldParameter{MaxField: "max_tokens"}, doc, "min_tokens"); err != nil {
+			t.Fatal(err)
+		}
+		if doc["min_tokens"] != float64(1000) {
+			t.Fatal("must not clamp when max field is absent")
+		}
+	})
+	t.Run("max-field-zero-noop", func(t *testing.T) {
+		// max_tokens=0 means "no max set" — don't clamp to 0.
+		doc := map[string]any{"min_tokens": float64(1000), "max_tokens": float64(0)}
+		if err := run(ClampUintToFieldParameter{MaxField: "max_tokens"}, doc, "min_tokens"); err != nil {
+			t.Fatal(err)
+		}
+		if doc["min_tokens"] != float64(1000) {
+			t.Fatal("max=0 must not clamp")
+		}
+	})
+}
+
+// ============================================================
+// ValidateUintParameter
+// ============================================================
+
+func TestValidateUintParameter(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        any
+		errSubstr string
+	}{
+		{"valid-int", float64(42), ""},
+		{"absent", nil, ""},
+		{"negative-rejected", float64(-1), "must be a non-negative integer"},
+		{"float-rejected", float64(1.5), "must be a non-negative integer"},
+		{"string-rejected", "42", "must be a non-negative integer"},
+		{"bool-rejected", true, "must be a non-negative integer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := map[string]any{}
+			if tc.name != "absent" {
+				doc["seed"] = tc.in
+			}
+			err := run(ValidateUintParameter{}, doc, "seed")
+			if tc.errSubstr == "" {
+				if err != nil {
+					t.Fatalf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Fatalf("want %q, got %q", tc.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+// ============================================================
+// LengthCapListParameter
+// ============================================================
+
+func TestLengthCapListParameter_CapsArray(t *testing.T) {
+	doc := map[string]any{"stop": []any{"a", "b", "c"}}
+	err := run(LengthCapListParameter{MaxEntries: 2}, doc, "stop")
+	if err == nil || !strings.Contains(err.Error(), "array length") {
+		t.Fatalf("want 'array length' error, got %v", err)
+	}
+}
+
+func TestLengthCapListParameter_CapsEntryLen(t *testing.T) {
+	doc := map[string]any{"stop": []any{"short", strings.Repeat("x", 100)}}
+	err := run(LengthCapListParameter{MaxEntryLen: 10}, doc, "stop")
+	if err == nil || !strings.Contains(err.Error(), "string length") {
+		t.Fatalf("want 'string length' error, got %v", err)
+	}
+}
+
+func TestLengthCapListParameter_NonStringEntriesSkipped(t *testing.T) {
+	// stop_token_ids is an int array — string cap doesn't apply.
+	doc := map[string]any{"stop_token_ids": []any{1, 2, 3, 4}}
+	if err := run(LengthCapListParameter{MaxEntries: 0, MaxEntryLen: 5}, doc, "stop_token_ids"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLengthCapListParameter_WithinCapOK(t *testing.T) {
+	doc := map[string]any{"stop": []any{"a", "b"}}
+	if err := run(LengthCapListParameter{MaxEntries: 5, MaxEntryLen: 10}, doc, "stop"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLengthCapListParameter_AbsentFieldNoop(t *testing.T) {
+	doc := map[string]any{}
+	if err := run(LengthCapListParameter{MaxEntries: 1}, doc, "stop"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/devshard/cmd/devshardctl/paramvalidators/numeric.go
+++ b/devshard/cmd/devshardctl/paramvalidators/numeric.go
@@ -1,0 +1,14 @@
+package paramvalidators
+
+import "devshard"
+
+// numericJSONValueAsUint64FromMap reads document[field] and coerces it to a uint64
+// using the shared devshard primitive. Convenience helper for handlers that read
+// integer fields out of the raw document by name.
+func numericJSONValueAsUint64FromMap(document map[string]any, field string) (uint64, bool) {
+	value, ok := document[field]
+	if !ok {
+		return 0, false
+	}
+	return devshard.JSONNumericUint64(value)
+}

--- a/devshard/cmd/devshardctl/paramvalidators/response_format.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format.go
@@ -98,7 +98,7 @@ func (v ResponseFormatValidator) validateJSONSchemaWrapper(rf map[string]any) er
 		return fmt.Errorf("%w: must be an object", ErrResponseFormatJSONSchema)
 	}
 	name, ok := wrapper["name"].(string)
-	if !ok || name == "" {
+	if !ok || strings.TrimSpace(name) == "" {
 		return fmt.Errorf("%w: must be a non-empty string", ErrResponseFormatName)
 	}
 	if len(name) > v.MaxNameLen {

--- a/devshard/cmd/devshardctl/paramvalidators/response_format_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/response_format_test.go
@@ -77,6 +77,7 @@ func TestResponseFormatValidatorRejects(t *testing.T) {
 		{name: "unknown type", body: `{"response_format":{"type":"banana"}}`, wantErr: ErrResponseFormatType},
 		{name: "json_schema wrapper missing", body: `{"response_format":{"type":"json_schema"}}`, wantErr: ErrResponseFormatJSONSchema},
 		{name: "json_schema missing name", body: `{"response_format":{"type":"json_schema","json_schema":{"schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatName},
+		{name: "json_schema whitespace name", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"   ","schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatName},
 		{name: "json_schema name has bad chars", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"bad name","schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatName},
 		{name: "json_schema name too long", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"` + strings.Repeat("a", 65) + `","schema":{"type":"object"}}}}`, wantErr: ErrResponseFormatName},
 		{name: "json_schema missing schema", body: `{"response_format":{"type":"json_schema","json_schema":{"name":"r"}}}`, wantErr: ErrResponseFormatSchemaShape},

--- a/devshard/cmd/devshardctl/paramvalidators/structured_outputs.go
+++ b/devshard/cmd/devshardctl/paramvalidators/structured_outputs.go
@@ -1,10 +1,13 @@
 package paramvalidators
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"devshard/cmd/devshardctl/filtercore"
 )
 
 var (
@@ -86,10 +89,8 @@ func (v StructuredOutputsValidator) Validate(vctx ValidatorContext) error {
 	if !exists {
 		return nil
 	}
-	for _, m := range v.RejectedModels {
-		if m == vctx.RoutedModel {
-			return fmt.Errorf("%w", ErrStructuredOutputsNotSupportedOnRoute)
-		}
+	if filtercore.MatchesModel(vctx.RoutedModel, v.RejectedModels) {
+		return fmt.Errorf("%w", ErrStructuredOutputsNotSupportedOnRoute)
 	}
 	obj, ok := raw.(map[string]any)
 	if !ok {
@@ -279,13 +280,21 @@ func (v StructuredOutputsValidator) validateGrammar(value any) error {
 	return nil
 }
 
+// validateStructuralTag accepts only the OBJECT form (vLLM's
+// StructuralTagResponseFormat: {type, structures[], triggers[]}). A JSON-encoded
+// STRING form crashes the engine with an HTTP 500 on the request handler, so it
+// is rejected here regardless of route. Size is bounded on the serialized object.
 func (v StructuredOutputsValidator) validateStructuralTag(value any) error {
-	s, ok := value.(string)
+	obj, ok := value.(map[string]any)
 	if !ok {
-		return fmt.Errorf("%w: must be a string", ErrStructuredOutputsStructuralTagShape)
+		return fmt.Errorf("%w: must be an object (a JSON-encoded string crashes the engine)", ErrStructuredOutputsStructuralTagShape)
 	}
-	if len(s) > v.MaxStructuralTagLen {
-		return fmt.Errorf("%w: %d > %d", ErrStructuredOutputsStructuralTagLength, len(s), v.MaxStructuralTagLen)
+	encoded, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrStructuredOutputsStructuralTagShape, err)
+	}
+	if len(encoded) > v.MaxStructuralTagLen {
+		return fmt.Errorf("%w: %d > %d", ErrStructuredOutputsStructuralTagLength, len(encoded), v.MaxStructuralTagLen)
 	}
 	return nil
 }

--- a/devshard/cmd/devshardctl/paramvalidators/structured_outputs_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/structured_outputs_test.go
@@ -268,20 +268,27 @@ func TestStructuredOutputsValidatorJSONObject(t *testing.T) {
 func TestStructuredOutputsValidatorStructuralTag(t *testing.T) {
 	v := defaultStructuredOutputsValidator()
 
-	t.Run("accepts a normal tag", func(t *testing.T) {
-		body := `{"structured_outputs":{"structural_tag":"<tool>...</tool>"}}`
+	t.Run("accepts the object form", func(t *testing.T) {
+		body := `{"structured_outputs":{"structural_tag":{"type":"structural_tag","structures":[],"triggers":[]}}}`
 		require.NoError(t, v.Validate(ValidatorContext{Document: parseDocument(t, body)}))
 	})
 
-	t.Run("rejects non-string", func(t *testing.T) {
+	t.Run("rejects the engine-crashing string form", func(t *testing.T) {
+		// A JSON-encoded string structural_tag returns HTTP 500 from vLLM; reject it here.
+		body := `{"structured_outputs":{"structural_tag":"<tool>...</tool>"}}`
+		err := v.Validate(ValidatorContext{Document: parseDocument(t, body)})
+		require.ErrorIs(t, err, ErrStructuredOutputsStructuralTagShape)
+	})
+
+	t.Run("rejects a non-object scalar", func(t *testing.T) {
 		body := `{"structured_outputs":{"structural_tag":42}}`
 		err := v.Validate(ValidatorContext{Document: parseDocument(t, body)})
 		require.ErrorIs(t, err, ErrStructuredOutputsStructuralTagShape)
 	})
 
-	t.Run("rejects oversize", func(t *testing.T) {
+	t.Run("rejects oversize object", func(t *testing.T) {
 		long := strings.Repeat("a", 4*1024+1)
-		body := `{"structured_outputs":{"structural_tag":"` + long + `"}}`
+		body := `{"structured_outputs":{"structural_tag":{"type":"structural_tag","blob":"` + long + `"}}}`
 		err := v.Validate(ValidatorContext{Document: parseDocument(t, body)})
 		require.ErrorIs(t, err, ErrStructuredOutputsStructuralTagLength)
 	})

--- a/devshard/cmd/devshardctl/paramvalidators/thinking.go
+++ b/devshard/cmd/devshardctl/paramvalidators/thinking.go
@@ -3,6 +3,8 @@ package paramvalidators
 import (
 	"errors"
 	"fmt"
+
+	"devshard/cmd/devshardctl/filtercore"
 )
 
 // ErrThinkingShape covers the wrapper-level rejection. ErrThinkingType covers the inner
@@ -70,12 +72,7 @@ func resolveThinkingType(typeStr string) (bool, bool) {
 }
 
 func (v ThinkingValidator) shouldMirror(routedModel string) bool {
-	for _, m := range v.MirrorToTemplateKwargsForModels {
-		if m == routedModel {
-			return true
-		}
-	}
-	return false
+	return filtercore.MatchesModel(routedModel, v.MirrorToTemplateKwargsForModels)
 }
 
 func mirrorThinkingToTemplateKwargs(document map[string]any, enabled bool) error {

--- a/devshard/cmd/devshardctl/paramvalidators/tool_choice.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tool_choice.go
@@ -3,6 +3,7 @@ package paramvalidators
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var (
@@ -37,7 +38,7 @@ func (v ToolChoiceValidator) Validate(vctx ValidatorContext) error {
 			return fmt.Errorf("%w: function must be an object", ErrToolChoiceFunctionShape)
 		}
 		name, ok := fn["name"].(string)
-		if !ok || name == "" {
+		if !ok || strings.TrimSpace(name) == "" {
 			return fmt.Errorf("%w: function.name must be a non-empty string", ErrToolChoiceFunctionShape)
 		}
 		if v.MaxNameLen > 0 && len(name) > v.MaxNameLen {

--- a/devshard/cmd/devshardctl/paramvalidators/tool_choice_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tool_choice_test.go
@@ -46,6 +46,7 @@ func TestToolChoiceValidatorRejects(t *testing.T) {
 		{name: "object function not object", body: `{"tool_choice":{"type":"function","function":"x"}}`, wantErr: ErrToolChoiceFunctionShape},
 		{name: "object missing name", body: `{"tool_choice":{"type":"function","function":{}}}`, wantErr: ErrToolChoiceFunctionShape},
 		{name: "object empty name", body: `{"tool_choice":{"type":"function","function":{"name":""}}}`, wantErr: ErrToolChoiceFunctionShape},
+		{name: "object whitespace name", body: `{"tool_choice":{"type":"function","function":{"name":"   "}}}`, wantErr: ErrToolChoiceFunctionShape},
 		{name: "object non-string name", body: `{"tool_choice":{"type":"function","function":{"name":42}}}`, wantErr: ErrToolChoiceFunctionShape},
 		{name: "name exceeds length cap", body: `{"tool_choice":{"type":"function","function":{"name":"` + longString(65) + `"}}}`, wantErr: ErrToolChoiceFunctionShape},
 	}

--- a/devshard/cmd/devshardctl/paramvalidators/tools.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tools.go
@@ -3,6 +3,7 @@ package paramvalidators
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // Tool-specific sentinels. Schema-walk rejections (depth/nodes/ref/enum/branch/size) flow
@@ -80,7 +81,7 @@ func (v ToolsValidator) Validate(vctx ValidatorContext) error {
 			return fmt.Errorf("%w: tools[%d].function must be an object", ErrToolFunctionShape, i)
 		}
 		name, ok := fn["name"].(string)
-		if !ok || name == "" {
+		if !ok || strings.TrimSpace(name) == "" {
 			return fmt.Errorf("%w (tools[%d])", ErrToolFunctionName, i)
 		}
 		// OpenAI Structured Outputs flag. vLLM accepts but does not honor it

--- a/devshard/cmd/devshardctl/paramvalidators/tools_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/tools_test.go
@@ -65,6 +65,7 @@ func TestToolsValidatorRejects(t *testing.T) {
 		// function.name required.
 		{name: "function name missing", body: `{"tools":[{"type":"function","function":{}}]}`, wantErr: ErrToolFunctionName},
 		{name: "function name empty", body: `{"tools":[{"type":"function","function":{"name":""}}]}`, wantErr: ErrToolFunctionName},
+		{name: "function name whitespace", body: `{"tools":[{"type":"function","function":{"name":"   "}}]}`, wantErr: ErrToolFunctionName},
 		{name: "function name not a string", body: `{"tools":[{"type":"function","function":{"name":42}}]}`, wantErr: ErrToolFunctionName},
 		{name: "depth exceeds limit", body: `{"tools":[` + toolWithParams(nestedPropertiesSchema(17)) + `]}`, wantErr: ErrSchemaDepth},
 		{name: "deep recursion attack hidden in tool", body: `{"tools":[` + toolWithParams(nestedPropertiesSchema(200)) + `]}`, wantErr: ErrSchemaDepth},

--- a/devshard/cmd/devshardctl/paramvalidators/validate_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/validate_test.go
@@ -1,0 +1,102 @@
+package paramvalidators
+
+import (
+	"strings"
+	"testing"
+)
+
+// ============================================================
+// RejectNumberParameter
+// ============================================================
+
+func TestRejectNumberParameter(t *testing.T) {
+	positive := RejectNumberParameter{Allow: func(v float64) bool { return v > 0 }, Message: "must be greater than 0"}
+
+	// Absent and non-numeric values pass through — dedicated shape validators own those.
+	if err := run(positive, map[string]any{}, "top_p"); err != nil {
+		t.Fatalf("absent field must pass through, got %v", err)
+	}
+	if err := run(positive, map[string]any{"top_p": "not-a-number"}, "top_p"); err != nil {
+		t.Fatalf("non-numeric must pass through, got %v", err)
+	}
+	if err := run(positive, map[string]any{"top_p": 0.5}, "top_p"); err != nil {
+		t.Fatalf("allowed value must pass, got %v", err)
+	}
+
+	err := run(positive, map[string]any{"top_p": 0}, "top_p")
+	if err == nil || !strings.Contains(err.Error(), "top_p") || !strings.Contains(err.Error(), "greater than 0") {
+		t.Fatalf("non-positive must be rejected with a field-named error, got %v", err)
+	}
+}
+
+func TestRejectNumberParameter_TopKPredicate(t *testing.T) {
+	topK := RejectNumberParameter{Allow: func(v float64) bool { return v == -1 || v >= 1 }, Message: "must be -1 or a positive integer"}
+	for _, good := range []any{-1, 1, 50} {
+		if err := run(topK, map[string]any{"top_k": good}, "top_k"); err != nil {
+			t.Fatalf("top_k=%v must pass, got %v", good, err)
+		}
+	}
+	for _, bad := range []any{0, -2} {
+		if err := run(topK, map[string]any{"top_k": bad}, "top_k"); err == nil {
+			t.Fatalf("top_k=%v must be rejected", bad)
+		}
+	}
+}
+
+// ============================================================
+// ValidateScalarParameter
+// ============================================================
+
+func TestValidateScalarParameter(t *testing.T) {
+	mustBeBool := ValidateScalarParameter{Valid: IsJSONBool, Message: "must be a boolean"}
+
+	// Absent or explicit null passes through.
+	if err := run(mustBeBool, map[string]any{}, "stream"); err != nil {
+		t.Fatalf("absent must pass, got %v", err)
+	}
+	if err := run(mustBeBool, map[string]any{"stream": nil}, "stream"); err != nil {
+		t.Fatalf("null must pass, got %v", err)
+	}
+	if err := run(mustBeBool, map[string]any{"stream": true}, "stream"); err != nil {
+		t.Fatalf("bool must pass, got %v", err)
+	}
+	if err := run(mustBeBool, map[string]any{"stream": "yes"}, "stream"); err == nil {
+		t.Fatal("non-bool must be rejected")
+	}
+}
+
+// ============================================================
+// ValidateListElementsParameter
+// ============================================================
+
+func TestValidateListElementsParameter(t *testing.T) {
+	elementsMustBeString := ValidateListElementsParameter{Valid: IsJSONString, Message: "must be a string"}
+
+	// Absent or non-array passes through.
+	if err := run(elementsMustBeString, map[string]any{}, "stop"); err != nil {
+		t.Fatalf("absent must pass, got %v", err)
+	}
+	if err := run(elementsMustBeString, map[string]any{"stop": "single"}, "stop"); err != nil {
+		t.Fatalf("non-array must pass, got %v", err)
+	}
+	if err := run(elementsMustBeString, map[string]any{"stop": []any{"a", "b"}}, "stop"); err != nil {
+		t.Fatalf("all-string array must pass, got %v", err)
+	}
+
+	err := run(elementsMustBeString, map[string]any{"stop": []any{"a", 5, "c"}}, "stop")
+	if err == nil || !strings.Contains(err.Error(), "stop[1]") {
+		t.Fatalf("bad element must be rejected with its index, got %v", err)
+	}
+}
+
+func TestJSONTypePredicates(t *testing.T) {
+	if !IsJSONBool(true) || IsJSONBool("x") {
+		t.Fatal("IsJSONBool")
+	}
+	if !IsJSONString("x") || IsJSONString(1) {
+		t.Fatal("IsJSONString")
+	}
+	if !IsJSONUint(5) || IsJSONUint(-1) || IsJSONUint(3.5) {
+		t.Fatal("IsJSONUint")
+	}
+}

--- a/devshard/cmd/devshardctl/participant_limiter.go
+++ b/devshard/cmd/devshardctl/participant_limiter.go
@@ -451,7 +451,7 @@ func (l *ParticipantRequestLimiter) AllowRequestForModel(participantKey, modelID
 		return nil
 	}
 	if l.metrics != nil {
-		l.metrics.RecordParticipantLimitRejection("transport_request")
+		l.metrics.RecordParticipantLimitRejection(participantKey, normalizeModelID(modelID), "transport_request")
 	}
 	log.Printf("participant_limit_rejected participant_key=%s", participantKey)
 	return &ParticipantRateLimitError{ParticipantKey: participantKey}
@@ -533,7 +533,7 @@ func (l *ParticipantRequestLimiter) ObserveResultWithBodyForModel(participantKey
 		return
 	}
 	if l.metrics != nil && statusCode >= http.StatusBadRequest {
-		l.metrics.RecordParticipantTransportError(participantPathKind(path), statusCode)
+		l.metrics.RecordParticipantTransportError(participantKey, normalizeModelID(modelID), participantPathKind(path), statusCode)
 	}
 	quarantineFor := l.participantHTTPQuarantine(path, statusCode, body)
 	if quarantineFor == 0 {
@@ -544,6 +544,7 @@ func (l *ParticipantRequestLimiter) ObserveResultWithBodyForModel(participantKey
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.applyQuarantineLocked(participantKey, modelID, now.Add(quarantineFor), now, participantQuarantineProbe)
+	l.recordQuarantineTransition(participantKey, modelID, participantQuarantineProbe.String(), participantHTTPQuarantineReason(path, statusCode, body))
 
 	log.Printf("participant_limit_activated participant_key=%s status=%d path_kind=%s",
 		participantKey, statusCode, participantPathKind(path))
@@ -565,7 +566,7 @@ func (l *ParticipantRequestLimiter) ObserveTransportFailureForModel(participantK
 	}
 	kind := participantPathKind(path)
 	if l.metrics != nil {
-		l.metrics.RecordParticipantTransportError(kind, 0)
+		l.metrics.RecordParticipantTransportError(participantKey, normalizeModelID(modelID), kind, 0)
 	}
 	if kind != "inference" {
 		log.Printf("participant_transport_failure_ignored participant_key=%s path_kind=%s error=%q",
@@ -590,6 +591,7 @@ func (l *ParticipantRequestLimiter) ObserveTransportFailureForModel(participantK
 		state.failureStrikes++
 		if state.failureStrikes >= l.failureStrikeThreshold {
 			l.applyQuarantineLocked(participantKey, modelID, now.Add(l.transportFailureQuarantine), now, participantQuarantineProbe)
+			l.recordQuarantineTransition(participantKey, modelID, participantQuarantineProbe.String(), "eof_transport_quarantine")
 			log.Printf("participant_limit_eof_transport_quarantine participant_key=%s model_id=%q reason=eof_transport strikes=%d threshold=%d quarantine_mode=%s error=%q",
 				participantKey, normalizeModelID(modelID), state.failureStrikes, l.failureStrikeThreshold, participantQuarantineProbe.String(), truncateError(err))
 			l.persistThrottledStateLocked(participantKey, state, participantStatusEOFTransport)
@@ -602,6 +604,7 @@ func (l *ParticipantRequestLimiter) ObserveTransportFailureForModel(participantK
 	}
 
 	l.applyQuarantineLocked(participantKey, modelID, now.Add(l.transportFailureQuarantine), now, participantQuarantineProbe)
+	l.recordQuarantineTransition(participantKey, modelID, participantQuarantineProbe.String(), "transport_failure_quarantine")
 	log.Printf("participant_limit_transport_failure participant_key=%s path_kind=%s error=%q",
 		participantKey, kind, truncateError(err))
 	l.persistThrottledStateLocked(participantKey, l.participants[participantKey], participantStatusTransport)
@@ -656,6 +659,7 @@ func (l *ParticipantRequestLimiter) ObserveEmptyStreamForModel(participantKey, m
 	state.failureStrikes++
 	if state.failureStrikes >= l.failureStrikeThreshold {
 		l.applyQuarantineLocked(participantKey, modelID, now.Add(l.emptyStreamQuarantine), now, participantQuarantineShadow)
+		l.recordQuarantineTransition(participantKey, modelID, participantQuarantineShadow.String(), "empty_stream_quarantine")
 		log.Printf("participant_limit_empty_stream_quarantine participant_key=%s model_id=%q reason=empty_stream strikes=%d threshold=%d quarantine_mode=%s",
 			participantKey, normalizeModelID(modelID), state.failureStrikes, l.failureStrikeThreshold, participantQuarantineShadow.String())
 		l.persistThrottledStateLocked(participantKey, state, participantStatusEmptyStream)
@@ -684,6 +688,7 @@ func (l *ParticipantRequestLimiter) ObserveStalledWinnerForModel(participantKey,
 
 	state := l.ensureStateLocked(participantKey, now)
 	l.applyQuarantineLocked(participantKey, modelID, now.Add(l.stalledWinnerQuarantine), now, participantQuarantineShadow)
+	l.recordQuarantineTransition(participantKey, modelID, participantQuarantineShadow.String(), "stalled_winner_quarantine")
 	log.Printf("participant_limit_stalled_winner_quarantine participant_key=%s", participantKey)
 	l.persistThrottledStateLocked(participantKey, state, participantStatusStalledWinner)
 }
@@ -1222,8 +1227,31 @@ func (l *ParticipantRequestLimiter) clearExpiredQuarantineIfAnyLocked(key string
 		state.tokens = l.burst
 		state.lastRefill = now
 		state.failureStrikes = participantStrikesAfterQuarantine
+		l.recordQuarantineTransition(key, "", "probation", "quarantine_expired")
 		l.persistThrottledStateLocked(key, state, participantStatusTransport)
 		log.Printf("participant_quarantine_ended participant_key=%s", key)
+	}
+}
+
+func (l *ParticipantRequestLimiter) recordQuarantineTransition(participantKey, modelID, mode, reason string) {
+	if l == nil || l.metrics == nil {
+		return
+	}
+	l.metrics.RecordGatewayQuarantineTransition(participantKey, normalizeModelID(modelID), mode, reason)
+}
+
+func participantHTTPQuarantineReason(path string, statusCode int, body string) string {
+	switch {
+	case isParticipantThrottleStatus(statusCode):
+		return "http_throttle_quarantine"
+	case statusCode == http.StatusUnauthorized && participantPathKind(path) == "inference" && strings.Contains(strings.ToLower(body), "timestamp drift"):
+		return "http_timestamp_drift"
+	case statusCode == http.StatusNotFound && participantPathKind(path) == "inference":
+		return "http_not_found"
+	case statusCode == http.StatusForbidden && participantPathKind(path) == "inference":
+		return "http_forbidden"
+	default:
+		return "transport_failure_quarantine"
 	}
 }
 

--- a/devshard/cmd/devshardctl/phase_gate.go
+++ b/devshard/cmd/devshardctl/phase_gate.go
@@ -17,10 +17,8 @@ import (
 
 const (
 	defaultChainPhasePollInterval = 5 * time.Second
-	// versionsTTLPollMultiplier scales the poll interval into how long a
-	// /v1/versions fetch stays fresh, so entries survive a couple of missed polls
-	// but never outlive the poller's cadence.
-	versionsTTLPollMultiplier = 3
+	// versionsTTL is how long a /v1/versions fetch stays fresh.
+	versionsTTL = 3 * defaultChainPhasePollInterval
 
 	epochPhaseInference           = "Inference"
 	epochPhasePoCGenerate         = "PoCGenerate"
@@ -257,7 +255,7 @@ func NewChainPhaseGate(baseURL string, pollInterval time.Duration) *ChainPhaseGa
 		client:                        client,
 		pollInterval:                  pollInterval,
 		defaultMaxSpeculativeAttempts: CurrentMaxSpeculativeAttempts(),
-		versions:                      NewVersionsCache(client, versionsTTLPollMultiplier*pollInterval),
+		versions:                      NewVersionsCache(client, versionsTTL),
 		stopCh:                        make(chan struct{}),
 		doneCh:                        make(chan struct{}),
 	}

--- a/devshard/cmd/devshardctl/phase_gate.go
+++ b/devshard/cmd/devshardctl/phase_gate.go
@@ -17,8 +17,10 @@ import (
 
 const (
 	defaultChainPhasePollInterval = 5 * time.Second
-	// versionsTTL is how long a /v1/versions fetch stays fresh.
-	versionsTTL = 3 * defaultChainPhasePollInterval
+	// versionsTTLPollMultiplier scales the poll interval into how long a
+	// /v1/versions fetch stays fresh, so entries survive a couple of missed polls
+	// but never outlive the poller's cadence.
+	versionsTTLPollMultiplier = 3
 
 	epochPhaseInference           = "Inference"
 	epochPhasePoCGenerate         = "PoCGenerate"
@@ -255,7 +257,7 @@ func NewChainPhaseGate(baseURL string, pollInterval time.Duration) *ChainPhaseGa
 		client:                        client,
 		pollInterval:                  pollInterval,
 		defaultMaxSpeculativeAttempts: CurrentMaxSpeculativeAttempts(),
-		versions:                      NewVersionsCache(client, versionsTTL),
+		versions:                      NewVersionsCache(client, versionsTTLPollMultiplier*pollInterval),
 		stopCh:                        make(chan struct{}),
 		doneCh:                        make(chan struct{}),
 	}

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -1054,6 +1054,21 @@ func (p *Proxy) handleSyncHosts(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func hostStatsDebugEntry(hs *types.HostStats) map[string]any {
+	entry := map[string]any{
+		"missed":  hs.Missed,
+		"invalid": hs.Invalid,
+		"cost":    hs.Cost,
+	}
+	if hs.RequiredValidations != 0 {
+		entry["required_validations"] = hs.RequiredValidations
+	}
+	if hs.CompletedValidations != 0 {
+		entry["completed_validations"] = hs.CompletedValidations
+	}
+	return entry
+}
+
 func (p *Proxy) handleState(w http.ResponseWriter, r *http.Request) {
 	st := p.sm.SnapshotState()
 
@@ -1121,13 +1136,7 @@ func (p *Proxy) handleState(w http.ResponseWriter, r *http.Request) {
 
 	hostStats := make(map[string]any, len(st.HostStats))
 	for slot, hs := range st.HostStats {
-		hostStats[fmt.Sprintf("%d", slot)] = map[string]any{
-			"missed":                hs.Missed,
-			"invalid":               hs.Invalid,
-			"cost":                  hs.Cost,
-			"required_validations":  hs.RequiredValidations,
-			"completed_validations": hs.CompletedValidations,
-		}
+		hostStats[fmt.Sprintf("%d", slot)] = hostStatsDebugEntry(hs)
 	}
 
 	revealedSeeds := map[string]int64{}

--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -23,7 +23,15 @@ import (
 
 var sseDoneMarker = []byte("data: [DONE]")
 
-const defaultMetaDrainTimeout = 10 * time.Second
+// defaultMetaDrainTimeout is a last-resort backstop, not an active policy:
+// it must exceed every natural completion window (SecondaryWaitAfterWinner,
+// nonStreamingNoContentTimeout, nonStreamingMaxAttemptWait) so that hosts
+// which are still legitimately generating after a client disconnect get to
+// finish and settle their nonce normally. Cutting a host early records it
+// as a timeout / empty stream through no fault of its own. The only thing
+// this cap should ever terminate is a host that streams forever without
+// tripping any of the normal race timeouts.
+const defaultMetaDrainTimeout = 40 * time.Minute
 
 // metaDrainTimeout applies only after client disconnect (flag.Done() in
 // withMetaDrain), not during normal connected flows. If devshard_meta /
@@ -82,14 +90,36 @@ func (cf *cancelFlag) Done() <-chan struct{} {
 
 // watchClientCancel triggers flag when r's context is canceled (client
 // disconnected). Spawns one short-lived goroutine bounded by request lifetime.
-func watchClientCancel(r *http.Request, flag *cancelFlag) {
+//
+// net/http also cancels the request context when the handler returns after a
+// normal response, which is indistinguishable from a disconnect here. Callers
+// must invoke the returned stop func once RunInference has returned (i.e. the
+// response was fully delivered) so that normal completion does not trip the
+// flag and metaDrain-cancel speculative attempts that are still running under
+// the SecondaryWaitAfterWinner grace window.
+func watchClientCancel(r *http.Request, flag *cancelFlag) (stop func()) {
 	if flag == nil || r == nil {
-		return
+		return func() {}
 	}
+	stopped := make(chan struct{})
 	go func() {
-		<-r.Context().Done()
-		flag.Trigger()
+		select {
+		case <-r.Context().Done():
+			// stop() happens-before the handler returns, which happens-before
+			// net/http cancels the request context, so this non-blocking
+			// re-check deterministically ignores the post-completion cancel
+			// even when the goroutine first wakes up here.
+			select {
+			case <-stopped:
+				return
+			default:
+			}
+			flag.Trigger()
+		case <-stopped:
+		}
 	}()
+	var once sync.Once
+	return func() { once.Do(func() { close(stopped) }) }
 }
 
 // withMetaDrain caps upstream host reads after client disconnect so a
@@ -342,7 +372,7 @@ func (d *deferredWriter) logFlushFailedOnce(err error, where string) {
 func (p *Proxy) handleStreaming(w http.ResponseWriter, r *http.Request, params user.InferenceParams) {
 	started := time.Now()
 	flag := newCancelFlag()
-	watchClientCancel(r, flag)
+	stopClientWatch := watchClientCancel(r, flag)
 	dw := newDeferredWriter(r.Context(), w, p.escrowID, flag)
 
 	// Upstream redundancy is NOT bound to r.Context(): host SSE must be
@@ -351,6 +381,10 @@ func (p *Proxy) handleStreaming(w http.ResponseWriter, r *http.Request, params u
 	// upstream may run after the client is gone.
 	var doneWriteErr error
 	err := p.redundancy.RunInference(context.Background(), params, dw, flag)
+	// The response is fully delivered; detach the disconnect watcher so the
+	// handler returning does not masquerade as a client disconnect and cut
+	// down speculative losers still draining in the background finalizer.
+	stopClientWatch()
 	if flag.Gone() {
 		logRequestStage(r.Context(), "proxy_stream_client_gone",
 			"escrow", p.escrowID,
@@ -508,9 +542,14 @@ func logProxyResponseFinished(ctx context.Context, escrowID, outcome string, dw 
 func (p *Proxy) handleNonStreaming(w http.ResponseWriter, r *http.Request, params user.InferenceParams) {
 	var buf bytes.Buffer
 	flag := newCancelFlag()
-	watchClientCancel(r, flag)
+	stopClientWatch := watchClientCancel(r, flag)
 
 	err := p.redundancy.RunInference(context.Background(), params, &buf, flag)
+	// Winner settled and the response body is buffered; detach the disconnect
+	// watcher so the handler returning does not masquerade as a client
+	// disconnect and cut down speculative losers still draining in the
+	// background finalizer.
+	stopClientWatch()
 	if flag.Gone() {
 		return
 	}

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -128,6 +128,37 @@ func TestCancelFlag_NilSafeAndOneShot(t *testing.T) {
 	}
 }
 
+func TestWatchClientCancel_TriggersOnDisconnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	flag := newCancelFlag()
+	stop := watchClientCancel(r, flag)
+	defer stop()
+
+	cancel()
+
+	select {
+	case <-flag.Done():
+	case <-time.After(time.Second):
+		t.Fatal("flag should trigger when the request context is canceled mid-request")
+	}
+}
+
+func TestWatchClientCancel_StopPreventsTriggerOnNormalCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	flag := newCancelFlag()
+	stop := watchClientCancel(r, flag)
+
+	stop()
+	stop() // must be idempotent
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	require.False(t, flag.Gone(), "normal handler return must not be treated as a client disconnect")
+}
+
 func TestDeferredWriter_SwallowsAfterClientGone(t *testing.T) {
 	rec := httptest.NewRecorder()
 	flag := newCancelFlag()
@@ -1914,6 +1945,15 @@ func TestRunInference_ExportsPrometheusMetrics(t *testing.T) {
 	require.Contains(t, body, `reason="attempt_failed"`)
 	require.Contains(t, body, `devshard_id="escrow-proxy"`)
 	require.Contains(t, body, "devshard_host_total_time_seconds")
+	require.Contains(t, body, `devshard_gateway_requests_total{model="llama",outcome="success",reason="none"} 1`)
+	require.Contains(t, body, "devshard_gateway_slot_decisions_total")
+	require.Contains(t, body, `decision="real_send"`)
+	require.Contains(t, body, "devshard_gateway_attempts_started_total")
+	require.Contains(t, body, `role="primary"`)
+	require.Contains(t, body, `role="extra"`)
+	require.Contains(t, body, "devshard_gateway_attempts_terminal_total")
+	require.Contains(t, body, "devshard_gateway_attempt_failures_total")
+	require.Contains(t, body, "devshard_gateway_user_requests_with_hidden_failure_total")
 }
 
 func TestPerfTrackerIsUnresponsiveUsesThreshold(t *testing.T) {

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -827,6 +827,8 @@ type inflight struct {
 	prepared                   *user.PreparedInference
 	hostIdx                    int
 	hostID                     string
+	role                       string
+	startReason                string
 	nonce                      uint64
 	escrowID                   string
 	sendTime                   time.Time
@@ -1448,6 +1450,8 @@ func (e *Redundancy) RunInference(ctx context.Context, params user.InferencePara
 		}
 		return err
 	}
+	primary.role = "primary"
+	primary.startReason = "primary"
 	triedParticipants[e.session.HostParticipantKey(primary.hostIdx)] = true
 
 	decision := e.Decide(primary.hostIdx, params.InputLength)
@@ -1637,6 +1641,7 @@ func (e *Redundancy) startInflight(ctx context.Context, inf *inflight, race *rac
 	// before awaitRace can observe the attempt.
 	inf.sendTime = time.Now()
 	inf.startedBeforePoCGeneration = !currentPoCGenerationActive()
+	e.recordGatewayAttemptStarted(inf, params)
 	go e.monitorInflight(ctx, inf, race)
 
 	go func() {
@@ -1753,6 +1758,8 @@ func (e *Redundancy) startAdditionalInflight(streamCtx, settleCtx context.Contex
 		return nil
 	}
 	triedParticipants[e.session.HostParticipantKey(next.hostIdx)] = true
+	next.role = "extra"
+	next.startReason = reason
 	if e.metrics != nil {
 		e.metrics.RecordSpeculativeAttemptStart(reason)
 	}
@@ -3109,6 +3116,7 @@ func (e *Redundancy) recordPostContentWinnerFailureOnce(inf *inflight, params us
 		sample := RequestSample{
 			HostIdx:        inf.hostIdx,
 			ParticipantKey: participantKey,
+			Model:          gatewayMetricModel(params, e.model),
 			Responsive:     false,
 			SendTime:       inf.sendTime,
 			ReceiptTime:    inf.receiptTime,
@@ -3230,6 +3238,7 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 		}
 		fields = append(fields, inf.stallLogFields(finishedAt)...)
 		logInferenceStage(ctx, inf.escrowID, inf.nonce, "race_completed", fields...)
+		e.recordGatewayAttemptTerminal(inf, params, winnerNonce, ok)
 		if !ok {
 			e.recordWinnerTerminalFailureOnce(inf, params, winnerNonce)
 			failed = append(failed, inf)
@@ -3250,16 +3259,19 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 			if inf.phaseTransitionAborted {
 				logInferenceStage(ctx, inf.escrowID, inf.nonce, "timeout_skipped",
 					"host", inf.hostID, "reason", "phase_transition_aborted")
+				e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "skipped", "phase_transition_aborted")
 				continue
 			}
 			if reason, skip := emptyStreamWithoutWinnerTimeoutSkipReason(inf, e.session); skip {
 				logInferenceStage(ctx, inf.escrowID, inf.nonce, "timeout_skipped",
 					"host", inf.hostID, "reason", reason)
+				e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "skipped", reason)
 				continue
 			}
 			if !shouldRunHandleTimeout(inf, e.session) {
 				logInferenceStage(ctx, inf.escrowID, inf.nonce, "timeout_skipped",
 					"host", inf.hostID, "reason", "nonce_already_finished")
+				e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "skipped", "nonce_already_finished")
 				continue
 			}
 			if e.longResponseFailureExempt(inf) {
@@ -3270,6 +3282,7 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 					"content_chunks", inf.contentChunks.Load(),
 					"output_bytes", inf.outputBytes.Load(),
 				)
+				e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "skipped", "long_response_after_content")
 				continue
 			}
 			payload := &host.InferencePayload{
@@ -3279,17 +3292,22 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 				MaxTokens:   params.MaxTokens,
 				StartedAt:   params.StartedAt,
 			}
+			e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "started", "none")
 			result, err := e.session.HandleTimeout(ctx, inf.nonce, inf.sendTime, payload)
 			if result.Reason != "" && e.metrics != nil {
 				e.metrics.RecordInferenceTimeout(result.Reason)
 			}
 			if err != nil {
+				e.recordGatewayTimeoutAction(inf, params, timeoutResultKind(result, inf), "failed", "timeout_collection_error")
 				logInferenceStage(ctx, inf.escrowID, inf.nonce, "timeout_failed", "host", inf.hostID, "error", err)
+			} else {
+				e.recordGatewayTimeoutAction(inf, params, timeoutResultKind(result, inf), "completed", "none")
 			}
 		}
 		if hostErr := hostApplicationErrorFromAttempts(attempts, winnerNonce); hostErr != nil {
 			captureAllAttemptsFailedRequest(ctx, e.devshardID, params, hostErr)
 			logRequestStage(ctx, "request_failed", "escrow", e.devshardID, "error", hostErr)
+			e.recordGatewayRequestOutcome(params.Model, "failed", gatewayRequestFailureReason(failed))
 			e.completeAccountingRequest(ctx, 0, decision, "failed")
 			e.logRequestSettled(ctx, 0, decision, "failed")
 			e.checkEscrowMissing(ctx, attempts)
@@ -3304,6 +3322,7 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 		}
 		captureAllAttemptsFailedRequest(ctx, e.devshardID, params, fmt.Errorf("%s", errMsg))
 		logRequestStage(ctx, "request_failed", "escrow", e.devshardID, "error", errMsg)
+		e.recordGatewayRequestOutcome(params.Model, "failed", gatewayRequestFailureReason(failed))
 		e.completeAccountingRequest(ctx, 0, decision, "failed")
 		e.logRequestSettled(ctx, 0, decision, "failed")
 		e.checkEscrowMissing(ctx, attempts)
@@ -3353,16 +3372,19 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 					if inf.phaseTransitionAborted {
 						logInferenceStage(bgCtx, inf.escrowID, inf.nonce, "timeout_skipped",
 							"host", inf.hostID, "reason", "phase_transition_aborted")
+						e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "skipped", "phase_transition_aborted")
 						continue
 					}
 					if reason, blocked := e.escrowStateBlockReason(e.participantKeyForHost(inf.hostIdx)); blocked {
 						logInferenceStage(bgCtx, inf.escrowID, inf.nonce, "timeout_skipped",
 							"host", inf.hostID, "reason", reason)
+						e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "skipped", reason)
 						continue
 					}
 					if !shouldRunHandleTimeout(inf, e.session) {
 						logInferenceStage(bgCtx, inf.escrowID, inf.nonce, "timeout_skipped",
 							"host", inf.hostID, "reason", "nonce_already_finished")
+						e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "skipped", "nonce_already_finished")
 						continue
 					}
 					if e.longResponseFailureExempt(inf) {
@@ -3373,14 +3395,19 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 							"content_chunks", inf.contentChunks.Load(),
 							"output_bytes", inf.outputBytes.Load(),
 						)
+						e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "skipped", "long_response_after_content")
 						continue
 					}
+					e.recordGatewayTimeoutAction(inf, params, timeoutKindForInflight(inf), "started", "none")
 					result, err := e.session.HandleTimeout(bgCtx, inf.nonce, inf.sendTime, payload)
 					if result.Reason != "" && e.metrics != nil {
 						e.metrics.RecordInferenceTimeout(result.Reason)
 					}
 					if err != nil {
+						e.recordGatewayTimeoutAction(inf, params, timeoutResultKind(result, inf), "failed", "timeout_collection_error")
 						logInferenceStage(bgCtx, inf.escrowID, inf.nonce, "background_timeout_failed", "host", inf.hostID, "error", err)
+					} else {
+						e.recordGatewayTimeoutAction(inf, params, timeoutResultKind(result, inf), "completed", "none")
 					}
 				}
 				e.logRequestSettled(bgCtx, winnerNonce, decision, "success")
@@ -3389,6 +3416,9 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 	}
 
 	e.completeAccountingRequest(ctx, winnerNonce, decision, "success")
+	e.recordGatewayRequestOutcome(params.Model, "success", "none")
+	e.recordGatewayUserVisibleWin(attempts, params, winnerNonce)
+	e.recordGatewayHiddenFailure(params.Model, failed)
 	logRequestStage(ctx, "request_succeeded", "escrow", e.devshardID, "winner_nonce", winnerNonce, "decision", decision.Reason)
 	if len(failed) == 0 {
 		e.logRequestSettled(ctx, winnerNonce, decision, "success")
@@ -3498,6 +3528,175 @@ func (e *Redundancy) completeAccountingRequest(ctx context.Context, winnerNonce 
 	e.perf.CompleteAccountingRequest(requestID, e.devshardID, winnerNonce, decision.Reason, outcome, time.Now())
 }
 
+func (e *Redundancy) recordGatewayRequestOutcome(model, outcome, reason string) {
+	if e == nil || e.metrics == nil {
+		return
+	}
+	e.metrics.RecordGatewayRequest(model, outcome, reason)
+	if outcome == "failed" {
+		e.metrics.RecordCriticalUserFailure(model, reason)
+	}
+}
+
+func (e *Redundancy) recordGatewayAttemptStarted(inf *inflight, params user.InferenceParams) {
+	if e == nil || e.metrics == nil || inf == nil || inf.probe {
+		return
+	}
+	participantKey := e.participantKeyForHost(inf.hostIdx)
+	model := gatewayMetricModel(params, e.model)
+	role := gatewayAttemptRole(inf)
+	reason := gatewayAttemptStartReason(inf)
+	quarantineMode := e.quarantineModeForParticipant(participantKey)
+	e.metrics.RecordGatewaySlotDecision(GatewaySlotDecisionMetric{
+		ParticipantKey: participantKey,
+		Model:          model,
+		EscrowID:       inf.escrowID,
+		Decision:       "real_send",
+		Reason:         reason,
+		QuarantineMode: quarantineMode,
+	})
+	e.metrics.RecordGatewayAttemptStarted(GatewayAttemptStartMetric{
+		ParticipantKey: participantKey,
+		Model:          model,
+		Role:           role,
+		Reason:         reason,
+		QuarantineMode: quarantineMode,
+	})
+	if inf.suspicious {
+		e.metrics.RecordGatewayNoWinnerAttempt(participantKey, model, inf.noWinnerReason, inf.noWinnerQuarantineMode)
+	}
+}
+
+func (e *Redundancy) recordGatewayAttemptTerminal(inf *inflight, params user.InferenceParams, winnerNonce uint64, ok bool) {
+	if e == nil || e.metrics == nil || inf == nil || inf.probe {
+		return
+	}
+	outcome := "success"
+	if !ok {
+		outcome = "failed"
+	}
+	participantKey := e.participantKeyForHost(inf.hostIdx)
+	model := gatewayMetricModel(params, e.model)
+	visibility := gatewayAttemptVisibility(inf, winnerNonce, ok)
+	role := gatewayAttemptRole(inf)
+	e.metrics.RecordGatewayAttemptTerminal(GatewayAttemptTerminalMetric{
+		ParticipantKey: participantKey,
+		Model:          model,
+		Role:           role,
+		Outcome:        outcome,
+		Visibility:     visibility,
+	})
+	if !ok {
+		e.metrics.RecordGatewayAttemptFailure(GatewayAttemptFailureMetric{
+			ParticipantKey: participantKey,
+			Model:          model,
+			Role:           role,
+			Reason:         gatewayAttemptFailureReason(inf, e.session),
+			Visibility:     visibility,
+		})
+	}
+}
+
+func (e *Redundancy) recordGatewayUserVisibleWin(attempts []*inflight, params user.InferenceParams, winnerNonce uint64) {
+	if e == nil || e.metrics == nil || winnerNonce == 0 {
+		return
+	}
+	if winner := inflightByNonce(attempts, winnerNonce); winner != nil && !winner.probe {
+		e.metrics.RecordGatewayUserVisibleWin(e.participantKeyForHost(winner.hostIdx), gatewayMetricModel(params, e.model))
+	}
+}
+
+func (e *Redundancy) recordGatewayHiddenFailure(model string, failed []*inflight) {
+	if e == nil || e.metrics == nil || len(failed) == 0 {
+		return
+	}
+	for _, inf := range failed {
+		if inf == nil || inf.probe {
+			continue
+		}
+		e.metrics.RecordGatewayHiddenFailure(model, "protected", gatewayAttemptFailureReason(inf, e.session))
+		return
+	}
+}
+
+func (e *Redundancy) recordGatewayTimeoutAction(inf *inflight, params user.InferenceParams, kind, action, reason string) {
+	if e == nil || e.metrics == nil || inf == nil || inf.probe {
+		return
+	}
+	e.metrics.RecordGatewayTimeoutAction(GatewayTimeoutActionMetric{
+		ParticipantKey: e.participantKeyForHost(inf.hostIdx),
+		Model:          gatewayMetricModel(params, e.model),
+		Kind:           kind,
+		Action:         action,
+		Reason:         reason,
+	})
+}
+
+func (e *Redundancy) quarantineModeForParticipant(participantKey string) string {
+	if e == nil || participantKey == "" {
+		return "none"
+	}
+	if status, ok := e.noWinnerStatusForParticipant(participantKey); ok {
+		if status.quarantineMode != "" {
+			return status.quarantineMode
+		}
+		return "probation"
+	}
+	if e.participantLimiter != nil && e.participantLimiter.IsBlockedForModel(participantKey, e.model) {
+		return participantQuarantineProbe.String()
+	}
+	return "none"
+}
+
+func gatewayMetricModel(params user.InferenceParams, fallback string) string {
+	if params.Model != "" {
+		return params.Model
+	}
+	return fallback
+}
+
+func gatewayAttemptRole(inf *inflight) string {
+	if inf == nil || strings.TrimSpace(inf.role) == "" {
+		return "primary"
+	}
+	return inf.role
+}
+
+func gatewayAttemptStartReason(inf *inflight) string {
+	if inf == nil || strings.TrimSpace(inf.startReason) == "" {
+		return "primary"
+	}
+	return inf.startReason
+}
+
+func gatewayRequestFailureReason(failed []*inflight) string {
+	for _, inf := range failed {
+		if inf != nil && !inf.probe {
+			return gatewayAttemptFailureReason(inf, nil)
+		}
+	}
+	return "unknown"
+}
+
+func timeoutKindForInflight(inf *inflight) string {
+	if inf == nil {
+		return "unknown"
+	}
+	if inf.receiptTime.IsZero() {
+		return "refused"
+	}
+	return "execution"
+}
+
+func timeoutResultKind(result user.TimeoutResult, inf *inflight) string {
+	switch result.Reason {
+	case "refused", "execution":
+		return result.Reason
+	default:
+		return timeoutKindForInflight(inf)
+	}
+}
+
 func (e *Redundancy) buildInvolvement(inf *inflight, winnerNonce uint64, params user.InferenceParams) HostInvolvement {
 	successfulForPerf := attemptCountsAsSuccessfulForPerf(inf, params, e.session)
 	hi := HostInvolvement{
@@ -3548,6 +3747,7 @@ func (e *Redundancy) recordSample(inf *inflight, params user.InferenceParams, re
 	sample := RequestSample{
 		HostIdx:        inf.hostIdx,
 		ParticipantKey: participantKey,
+		Model:          gatewayMetricModel(params, e.model),
 		Responsive:     responsive,
 		SendTime:       inf.sendTime,
 		ReceiptTime:    inf.receiptTime,
@@ -3639,6 +3839,17 @@ func ghostProbeParams(model string) user.InferenceParams {
 func (e *Redundancy) runGhostProbe(prepared *user.PreparedInference, kind ghostKind, reason string) {
 	if prepared == nil || e.session == nil {
 		return
+	}
+	participantKey := e.participantKeyForHost(prepared.HostIdx())
+	if e.metrics != nil {
+		e.metrics.RecordGatewaySlotDecision(GatewaySlotDecisionMetric{
+			ParticipantKey: participantKey,
+			Model:          e.model,
+			EscrowID:       e.devshardID,
+			Decision:       "ghost_no_send",
+			Reason:         reason,
+			QuarantineMode: e.quarantineModeForParticipant(participantKey),
+		})
 	}
 	ctx, _ := ensureRequestLogContext(context.Background())
 	logInferenceStage(ctx, e.devshardID, prepared.Nonce(), "ghost_probe_skipped",

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -537,6 +537,8 @@ type Redundancy struct {
 	metrics               *DevshardMetrics
 	onEscrowMissing       func() // called (at most once per request) when a host reports escrow not found
 	onBalanceExhausted    func() // called (once) when local state hits insufficient balance
+	onRaceCleanupStart    func() // fires synchronously before a race cleanup goroutine spawns
+	onRaceCleanupDone     func() // fires when a race cleanup goroutine finishes
 	balanceExhaustedOnce  sync.Once
 	picker                *sessionPicker
 	participantLimiter    *ParticipantRequestLimiter
@@ -2251,7 +2253,9 @@ func (e *Redundancy) awaitRace(streamCtx, settleCtx context.Context, attempts []
 						"max_wait_ms", SecondaryWaitAfterWinner.Milliseconds(),
 						"decision", decision.Reason,
 					)
-					go e.finishRaceWhenPendingDone(settleCtx, attempts, params, decision, winner, raceFinishOptions{recordFailureSamples: true})
+					e.goTrackedRaceCleanup(func() {
+						e.finishRaceWhenPendingDone(settleCtx, attempts, params, decision, winner, raceFinishOptions{recordFailureSamples: true})
+					})
 					return nil
 				}
 			}
@@ -2376,9 +2380,11 @@ func (e *Redundancy) awaitRace(streamCtx, settleCtx context.Context, attempts []
 					}
 					e.markPhaseTransitionAbort(inf)
 					e.recordWinnerTerminalFailureOnce(inf, params, w)
-					go e.finishRaceWhenPendingDone(settleCtx, attempts, params, decision, w, raceFinishOptions{
-						forceTreatAsFailure:  true,
-						recordFailureSamples: true,
+					e.goTrackedRaceCleanup(func() {
+						e.finishRaceWhenPendingDone(settleCtx, attempts, params, decision, w, raceFinishOptions{
+							forceTreatAsFailure:  true,
+							recordFailureSamples: true,
+						})
 					})
 					logRequestStage(settleCtx, "winner_failed_after_content", "escrow", e.devshardID, "winner_nonce", w, "error", err)
 					return err
@@ -2442,7 +2448,7 @@ func (e *Redundancy) awaitRace(streamCtx, settleCtx context.Context, attempts []
 				recordFailureSamples:            true,
 				nonStreamingReducedTokenTimeout: true,
 			}
-			go func() {
+			e.goTrackedRaceCleanup(func() {
 				if err := e.finishRaceOutcome(settleCtx, attempts, params, decision, 0, opts); err != nil {
 					var timeoutErr *nonStreamingReducedMaxTokensTimeoutError
 					if errors.As(err, &timeoutErr) {
@@ -2450,7 +2456,7 @@ func (e *Redundancy) awaitRace(streamCtx, settleCtx context.Context, attempts []
 					}
 					logRequestStage(settleCtx, "background_finish_failed", "escrow", e.devshardID, "error", err)
 				}
-			}()
+			})
 			return &nonStreamingReducedMaxTokensTimeoutError{}
 		case <-stallC:
 			now := time.Now()
@@ -2519,7 +2525,9 @@ func (e *Redundancy) awaitRace(streamCtx, settleCtx context.Context, attempts []
 			}
 			pending := pendingInflights(attempts)
 			logRequestStage(settleCtx, "request_stream_canceled", "escrow", e.devshardID, "winner_nonce", winner, "pending", len(pending), "decision", decision.Reason, "error", streamCtx.Err())
-			go e.finishRaceWhenPendingDone(settleCtx, attempts, params, decision, winner, raceFinishOptions{})
+			e.goTrackedRaceCleanup(func() {
+				e.finishRaceWhenPendingDone(settleCtx, attempts, params, decision, winner, raceFinishOptions{})
+			})
 			return streamCtx.Err()
 		}
 
@@ -2688,6 +2696,19 @@ type raceFinishOptions struct {
 	forceTreatAsFailure             bool
 	recordFailureSamples            bool
 	nonStreamingReducedTokenTimeout bool
+}
+
+// goTrackedRaceCleanup runs a background race cleanup detached while keeping the drain barrier aware of it; onRaceCleanupStart fires synchronously so the winning handler can never see the runtime as quiet mid-cleanup.
+func (e *Redundancy) goTrackedRaceCleanup(fn func()) {
+	if e.onRaceCleanupStart != nil {
+		e.onRaceCleanupStart()
+	}
+	go func() {
+		if e.onRaceCleanupDone != nil {
+			defer e.onRaceCleanupDone()
+		}
+		fn()
+	}()
 }
 
 func (e *Redundancy) finishRaceWhenPendingDone(ctx context.Context, attempts []*inflight, params user.InferenceParams, decision Decision, winnerNonce uint64, opts raceFinishOptions) {
@@ -3567,7 +3588,7 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 			StartedAt:   params.StartedAt,
 		}
 		if anySucceeded {
-			go func() {
+			e.goTrackedRaceCleanup(func() {
 				bgCtx, _ := ensureRequestLogContext(context.Background())
 				bgCtx = logging.PropagateRequestID(bgCtx, ctx)
 				for _, inf := range failed {
@@ -3617,7 +3638,7 @@ func (e *Redundancy) finishRaceOutcome(ctx context.Context, attempts []*inflight
 					}
 				}
 				e.logRequestSettled(bgCtx, winnerNonce, decision, "success")
-			}()
+			})
 		}
 	}
 

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -872,6 +872,14 @@ type inflight struct {
 	// different attempt wins or the attempt ends with no content.
 	pendingBuf []byte
 
+	// classifyPartial keeps the tail after the last '\n' from prior Writes;
+	// used to reassemble fragmented SSE events for the classifier.
+	classifyPartial []byte
+	classifyCapLog  sync.Once
+	// participantClassifyBytes is the shared per-participant byte counter this
+	// attempt contributes to; resolved at creation. Nil disables the cap.
+	participantClassifyBytes *atomic.Int64
+
 	// contentSource labels the field that produced the first content event
 	// ("delta.content", "delta.reasoning_content", "delta.tool_calls", or the
 	// streaming-only convertible shape "message.content"). Set exactly once
@@ -1241,6 +1249,219 @@ type raceWriter struct {
 	inf   *inflight
 }
 
+const (
+	defaultMaxClassifyPartial            = 1 << 20   // 1 MiB per attempt
+	defaultMaxClassifyPartialParticipant = 10 << 20  // 10 MiB per participant
+	defaultMaxClassifyPartialGlobal      = 100 << 20 // 100 MiB process-wide
+)
+
+// Reassembly-buffer caps, tunable at startup via configureClassifyCapsFromEnv.
+// These are machine-scale memory knobs, not governance policy.
+var (
+	maxClassifyPartial                  = defaultMaxClassifyPartial
+	maxClassifyPartialParticipant int64 = defaultMaxClassifyPartialParticipant
+	maxClassifyPartialGlobal      int64 = defaultMaxClassifyPartialGlobal
+)
+
+// configureClassifyCapsFromEnv overrides the reassembly caps from the
+// environment; unset variables keep the conservative defaults.
+func configureClassifyCapsFromEnv() {
+	maxClassifyPartial = int(readInt64Env("GATEWAY_CLASSIFY_MAX_ATTEMPT_BYTES", int64(defaultMaxClassifyPartial)))
+	maxClassifyPartialParticipant = readInt64Env("GATEWAY_CLASSIFY_MAX_PARTICIPANT_BYTES", defaultMaxClassifyPartialParticipant)
+	maxClassifyPartialGlobal = readInt64Env("GATEWAY_CLASSIFY_MAX_GLOBAL_BYTES", defaultMaxClassifyPartialGlobal)
+}
+
+// classifyPartialBytes is the live total of every inflight's classifyPartial.
+var classifyPartialBytes atomic.Int64
+
+// participantClassify bounds live reassembly bytes per participant so one
+// hostile participant can't exhaust the shared global pool and starve others.
+var participantClassify = &participantClassifyTracker{counters: map[string]*atomic.Int64{}}
+
+type participantClassifyTracker struct {
+	mu       sync.Mutex
+	counters map[string]*atomic.Int64
+}
+
+// counterFor returns the participant's byte counter, creating it on first use.
+// Entries are never removed; the participant set is the bounded validator set.
+func (t *participantClassifyTracker) counterFor(participantKey string) *atomic.Int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	counter := t.counters[participantKey]
+	if counter == nil {
+		counter = &atomic.Int64{}
+		t.counters[participantKey] = counter
+	}
+	return counter
+}
+
+// takeParseable returns the prefix of (classifyPartial + p) ending at the last
+// '\n'; the trailing fragment is stashed for the next call.
+func (rw *raceWriter) takeParseable(p []byte) []byte {
+	lastNL := bytes.LastIndexByte(p, '\n')
+	if lastNL == -1 {
+		if rw.growClassify(p) {
+			return nil
+		}
+		// Cap hit: classify the raw chunk best-effort (incomplete fragments won't parse).
+		rw.dropClassify()
+		return p
+	}
+
+	var parseable []byte
+	if len(rw.inf.classifyPartial) == 0 {
+		parseable = p[:lastNL+1]
+	} else {
+		buf := make([]byte, 0, len(rw.inf.classifyPartial)+lastNL+1)
+		buf = append(buf, rw.inf.classifyPartial...)
+		buf = append(buf, p[:lastNL+1]...)
+		parseable = buf
+	}
+	if !rw.replaceClassify(p[lastNL+1:]) {
+		rw.dropClassify()
+	}
+	return parseable
+}
+
+// classifyParseable records the first content/non-retriable-error signal for
+// this attempt, returning whether the buffer carried either.
+func (rw *raceWriter) classifyParseable(parseable []byte) (hasContent, hasError bool) {
+	if len(parseable) == 0 {
+		return false, false
+	}
+	if src, ok := sseChunkContentSource(parseable); ok {
+		hasContent = true
+		if rw.inf.contentSource == "" {
+			rw.inf.contentSource = src
+		}
+	} else if details, ok := sseChunkErrorDetails(parseable); ok {
+		src := "error"
+		if details.Type != "" {
+			src = "error." + details.Type
+		}
+		hasError = !isRetriableCapabilityErrorMessage(details.Message)
+		if rw.inf.errorSource == "" {
+			rw.inf.errorSource = src
+			rw.inf.errorCode = details.Code
+			rw.inf.errorType = details.Type
+			rw.inf.errorMessage = details.Message
+			rw.inf.errorBodySample = append(rw.inf.errorBodySample, parseable...)
+		}
+	}
+	return hasContent, hasError
+}
+
+// flushClassify classifies a newline-less final SSE event left in classifyPartial
+// once the stream ends, so a truncated tail isn't misread as empty_stream.
+func (rw *raceWriter) flushClassify() {
+	if rw.inf.probe || len(rw.inf.classifyPartial) == 0 {
+		return
+	}
+	hasContent, hasError := rw.classifyParseable(rw.inf.classifyPartial)
+	rw.dropClassify()
+	if hasContent || hasError {
+		rw.inf.contentChunks.Add(1)
+	}
+}
+
+// flushClassifyAndCheckEmpty flushes a buffered newline-less final event before deciding empty, so a truncated final content/error event isn't misread as empty_stream. Call on the send goroutine after SendOnly returns.
+func (rw *raceWriter) flushClassifyAndCheckEmpty() bool {
+	rw.flushClassify()
+	return isEmptyStreamAttempt(rw.inf)
+}
+
+// logClassifyDrop reports the first reassembly-buffer drop for this attempt.
+// Capped at once per attempt so a persistently newline-less or oversized
+// transport can't spam the log.
+func (rw *raceWriter) logClassifyDrop(reason string) {
+	rw.inf.classifyCapLog.Do(func() {
+		ctx := context.Background()
+		if rw.group != nil {
+			ctx = rw.group.logCtx
+		}
+		logInferenceStage(ctx, rw.inf.escrowID, rw.nonce, "classify_buffer_dropped",
+			"host", rw.inf.hostID,
+			"reason", reason,
+			"buffered", len(rw.inf.classifyPartial),
+			"global_bytes", classifyPartialBytes.Load(),
+		)
+	})
+}
+
+// growClassify appends tail to classifyPartial if all caps still fit.
+func (rw *raceWriter) growClassify(tail []byte) bool {
+	if len(rw.inf.classifyPartial)+len(tail) > maxClassifyPartial {
+		rw.logClassifyDrop("per_attempt_cap")
+		return false
+	}
+	if reason := rw.inf.reserveClassifyBytes(int64(len(tail))); reason != "" {
+		rw.logClassifyDrop(reason)
+		return false
+	}
+	rw.inf.classifyPartial = append(rw.inf.classifyPartial, tail...)
+	return true
+}
+
+// replaceClassify swaps classifyPartial for buf, adjusting byte accounting.
+func (rw *raceWriter) replaceClassify(buf []byte) bool {
+	if len(buf) > maxClassifyPartial {
+		rw.logClassifyDrop("per_attempt_cap")
+		return false
+	}
+	delta := int64(len(buf) - len(rw.inf.classifyPartial))
+	if delta > 0 {
+		if reason := rw.inf.reserveClassifyBytes(delta); reason != "" {
+			rw.logClassifyDrop(reason)
+			return false
+		}
+	} else if delta < 0 {
+		rw.inf.adjustClassifyBytes(delta)
+	}
+	rw.inf.classifyPartial = append(rw.inf.classifyPartial[:0], buf...)
+	return true
+}
+
+// dropClassify releases the per-attempt buffer and its accounted bytes.
+func (rw *raceWriter) dropClassify() {
+	rw.inf.releaseClassifyPartial()
+}
+
+// reserveClassifyBytes charges n bytes against the participant then global cap,
+// rolling back on the first cap hit. Returns the drop reason, "" on success.
+func (inf *inflight) reserveClassifyBytes(n int64) string {
+	participant := inf.participantClassifyBytes
+	if participant != nil && participant.Add(n) > maxClassifyPartialParticipant {
+		participant.Add(-n)
+		return "participant_cap"
+	}
+	if classifyPartialBytes.Add(n) > maxClassifyPartialGlobal {
+		classifyPartialBytes.Add(-n)
+		if participant != nil {
+			participant.Add(-n)
+		}
+		return "global_cap"
+	}
+	return ""
+}
+
+// adjustClassifyBytes adds delta to the global and per-participant counters.
+func (inf *inflight) adjustClassifyBytes(delta int64) {
+	classifyPartialBytes.Add(delta)
+	if inf.participantClassifyBytes != nil {
+		inf.participantClassifyBytes.Add(delta)
+	}
+}
+
+// releaseClassifyPartial frees the reassembly buffer's backing array and
+// decrements the counters. Nils the slice so cap doesn't outlive the gauge.
+func (inf *inflight) releaseClassifyPartial() {
+	if n := len(inf.classifyPartial); n > 0 {
+		inf.adjustClassifyBytes(-int64(n))
+	}
+	inf.classifyPartial = nil
+}
+
 func (rw *raceWriter) ctxErr() error {
 	if rw.group == nil || rw.group.writeCtx == nil {
 		return nil
@@ -1269,25 +1490,7 @@ func (rw *raceWriter) Write(p []byte) (int, error) {
 	var chunkHasContent bool
 	var chunkHasError bool
 	if !rw.inf.probe {
-		if src, ok := sseChunkContentSource(p); ok {
-			chunkHasContent = true
-			if rw.inf.contentSource == "" {
-				rw.inf.contentSource = src
-			}
-		} else if details, ok := sseChunkErrorDetails(p); ok {
-			src := "error"
-			if details.Type != "" {
-				src = "error." + details.Type
-			}
-			chunkHasError = !isRetriableCapabilityErrorMessage(details.Message)
-			if rw.inf.errorSource == "" {
-				rw.inf.errorSource = src
-				rw.inf.errorCode = details.Code
-				rw.inf.errorType = details.Type
-				rw.inf.errorMessage = details.Message
-				rw.inf.errorBodySample = append(rw.inf.errorBodySample, p...)
-			}
-		}
+		chunkHasContent, chunkHasError = rw.classifyParseable(rw.takeParseable(p))
 	}
 	if chunkHasContent || chunkHasError {
 		rw.inf.contentChunks.Add(1)
@@ -1572,19 +1775,20 @@ func (e *Redundancy) prepareInflight(ctx context.Context, params user.InferenceP
 		participantKey := e.session.HostParticipantKey(res.prepared.HostIdx())
 		noWinner, noWinnerOK := e.noWinnerStatusForParticipant(participantKey)
 		inf := &inflight{
-			prepared:               res.prepared,
-			hostIdx:                res.prepared.HostIdx(),
-			hostID:                 e.session.HostLabel(res.prepared.HostIdx()),
-			nonce:                  res.prepared.Nonce(),
-			escrowID:               e.devshardID,
-			probe:                  res.isProbe,
-			suspicious:             noWinnerOK,
-			noWinnerReason:         noWinner.reason,
-			noWinnerQuarantineMode: noWinner.quarantineMode,
-			noWinnerFailureStrikes: noWinner.failureStrikes,
-			done:                   make(chan struct{}),
-			receiptCh:              make(chan struct{}),
-			firstTokenCh:           make(chan struct{}),
+			prepared:                 res.prepared,
+			hostIdx:                  res.prepared.HostIdx(),
+			hostID:                   e.session.HostLabel(res.prepared.HostIdx()),
+			nonce:                    res.prepared.Nonce(),
+			escrowID:                 e.devshardID,
+			probe:                    res.isProbe,
+			suspicious:               noWinnerOK,
+			noWinnerReason:           noWinner.reason,
+			noWinnerQuarantineMode:   noWinner.quarantineMode,
+			noWinnerFailureStrikes:   noWinner.failureStrikes,
+			done:                     make(chan struct{}),
+			receiptCh:                make(chan struct{}),
+			firstTokenCh:             make(chan struct{}),
+			participantClassifyBytes: participantClassify.counterFor(participantKey),
 		}
 		e.recordAccountingAttempt(ctx, inf)
 		return inf, nil
@@ -1647,6 +1851,8 @@ func (e *Redundancy) startInflight(ctx context.Context, inf *inflight, race *rac
 	go func() {
 		defer close(inf.done)
 		defer cancel()
+		// Sole owner of classifyPartial: release on every exit path (incl. the early error return); content is classified synchronously via flushClassifyAndCheckEmpty below.
+		defer inf.releaseClassifyPartial()
 		logInferenceStage(ctx, inf.escrowID, inf.nonce, "started", "host", inf.hostID)
 		inf.resp, inf.err = e.session.SendOnly(attemptCtx, inf.prepared, rw, receiptHandler)
 		streamBytes := int64(0)
@@ -1678,7 +1884,7 @@ func (e *Redundancy) startInflight(ctx context.Context, inf *inflight, race *rac
 		// stream_bytes_read > 0 but output_chunks == 0 because only devshard
 		// receipt/meta events were parsed and no inference data was forwarded to
 		// the race writer.
-		if isEmptyStreamAttempt(inf) {
+		if rw.flushClassifyAndCheckEmpty() {
 			responseBodySample, responseSampleTruncated := bodySampleForLog(inf.pendingBuf, emptyStreamBodySampleLimit)
 			inf.emptyResponseBodySample = responseBodySample
 			inf.emptyResponseBodySampleTruncated = responseSampleTruncated

--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -90,10 +90,10 @@ func (p ChatRequestPipeline) Normalize(body []byte, adminAuthenticated bool, lim
 	if err := p.parameters.Apply(RequestFilterStagePreValidation, ctx); err != nil {
 		return nil, chatRequest{}, err
 	}
-	if err := p.messages.NormalizeDocument(&ctx.Document); err != nil {
+	if err := p.messages.NormalizeDocument(&ctx.Document, ctx.RoutedModel); err != nil {
 		return nil, chatRequest{}, err
 	}
-	if err := p.messages.ValidateDocument(&ctx.Document); err != nil {
+	if err := p.messages.ValidateDocument(&ctx.Document, ctx.RoutedModel); err != nil {
 		return nil, chatRequest{}, err
 	}
 	if err := ctx.DecodeRequest(); err != nil {

--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -139,6 +139,7 @@ func (p ChatRequestPipeline) applyOutputTokenLimits(ctx *RequestFilterContext) {
 	case hasMaxCompletionTokens:
 		maxCompletionTokens := capOutputTokens(ctx.Request.MaxCompletionTokens, true, ctx.AdminAuthenticated, limits)
 		ctx.Document.Set("max_completion_tokens", maxCompletionTokens)
+		ctx.Document.Set("max_tokens", maxCompletionTokens)
 		ctx.Request.MaxCompletionTokens = maxCompletionTokens
 		ctx.Request.MaxTokens = maxCompletionTokens
 	default:

--- a/devshard/cmd/devshardctl/request_filters_config.go
+++ b/devshard/cmd/devshardctl/request_filters_config.go
@@ -20,7 +20,7 @@ const (
 // wrappers (~9-10 levels) plus a small allowance for client-side structuring.
 const MaxRequestNestingDepth = 32
 
-// Per-parameter bounds wired into the catalog. Values match supported-params.md.
+// Per-parameter bounds wired into the catalog. Values match docs/chat-api/README.md.
 const (
 	MessagesMaxEntries = 2048
 
@@ -83,10 +83,20 @@ const (
 
 	// Below this floor Kimi-K2.6 emits only </think> (special token vLLM drops from content).
 	kimiMaxTokensMin uint64 = 16
+
+	MinimaxToolMessageMaxEntries = 16
+	MinimaxToolMessageNameMaxLen = 64
+	// 64 KiB per-entry defensive cap; no vendor recommendation (MiniMax-4 fixes shape,
+	// not size). Sized to fit common agent tool-results (file reads, build logs).
+	MinimaxToolMessageTextMaxSize = 64 * 1024
 )
 
-// Routed model identifiers. The catalog wires per-model behavior keyed on these strings.
-const kimiK26ModelID = "moonshotai/Kimi-K2.6"
+// Routed model identifiers. The parameter catalog and the message processor
+// both dispatch on these strings.
+const (
+	kimiK26ModelID    = "moonshotai/Kimi-K2.6"
+	miniMaxM27ModelID = "MiniMaxAI/MiniMax-M2.7"
+)
 
 // Sentinel content used by message normalization when an upstream tool result is empty.
 const emptyToolResultContent = "<empty tool result>"

--- a/devshard/cmd/devshardctl/request_filters_config.go
+++ b/devshard/cmd/devshardctl/request_filters_config.go
@@ -5,7 +5,11 @@ const (
 	MaxChatRequestBodySize       = 10 * 1024 * 1024
 	MaxLoggedResponseFormatBytes = 2048 * 1024
 	MaxChatRequestChoices        = 5
+	MinTemperature               = 0.0
 	MaxTemperature               = 2.0
+	MinPMin                      = 0.0
+	MinPMax                      = 1.0
+	TopPMax                      = 1.0
 	MaxRepetitionPenalty         = 2.0
 )
 

--- a/devshard/cmd/devshardctl/request_filters_messages.go
+++ b/devshard/cmd/devshardctl/request_filters_messages.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"fmt"
-	"strings"
+	"devshard/cmd/devshardctl/messagevalidators"
 )
 
 type MessageRole string
@@ -23,21 +22,88 @@ const (
 	MessageContentOptionalWithCalls
 )
 
+// MessageRolePolicy bundles validate-side rules for a (route, role) pair.
+// Per-model overrides plug into ChatMessageProcessor.modelRoles and replace
+// the default entry verbatim for that role on that route.
 type MessageRolePolicy struct {
 	Role              MessageRole
 	DisallowedFields  []string
 	RequireName       bool
 	RequireToolCallID bool
 	ContentRule       MessageContentRule
+	// ContentValidator, when non-nil, replaces the default role-specific
+	// content shape check. Used by MiniMax-M2.7 tool messages whose content
+	// is a {name,type,text}[] array instead of a string.
+	ContentValidator messagevalidators.ContentValidator
 }
 
+// MessageNormalizer rewrites the messages array before ValidateDocument runs.
+// Returns the (possibly filtered/rewritten) messages, whether anything
+// changed, and an unrecoverable error (which the caller wraps as HTTP 400).
+type MessageNormalizer interface {
+	Apply(messages []any) ([]any, bool, error)
+}
+
+// ChatMessageProcessor coordinates per-model normalization and validation.
+// Mirrors defaultVLLMParameterCatalog's per-model dispatch pattern for the
+// message side of the pipeline.
 type ChatMessageProcessor struct {
-	roles map[string]MessageRolePolicy
+	defaultRoles       map[string]MessageRolePolicy
+	modelRoles         map[string]map[string]MessageRolePolicy
+	defaultNormalizers []MessageNormalizer
+	modelNormalizers   map[string][]MessageNormalizer
 }
 
 var defaultMessageProcessor = defaultChatMessageProcessor()
 
 func defaultChatMessageProcessor() ChatMessageProcessor {
+	return ChatMessageProcessor{
+		defaultRoles: openAIRolePolicies(),
+		// Per-model role-policy overrides. Adding a model = add one row.
+		modelRoles: map[string]map[string]MessageRolePolicy{
+			// MiniMax-M2.7 tool messages omit tool_call_id and carry results as a
+			// {name,type,text}[] array — see docs/chat-api/minimax-m2.7.md.
+			miniMaxM27ModelID: {
+				string(MessageRoleTool): {
+					Role:              MessageRoleTool,
+					DisallowedFields:  []string{"tool_calls", "function_call"},
+					RequireToolCallID: false,
+					ContentRule:       MessageContentRequired,
+					ContentValidator: messagevalidators.MinimaxToolMessage{
+						MaxEntries:  MinimaxToolMessageMaxEntries,
+						NameMaxLen:  MinimaxToolMessageNameMaxLen,
+						TextMaxSize: MinimaxToolMessageTextMaxSize,
+					},
+				},
+			},
+		},
+		defaultNormalizers: []MessageNormalizer{
+			messagevalidators.OrphanToolMessageDropper{},
+			messagevalidators.EmptyAssistantTurnDropper{},
+			messagevalidators.EmptyContentNormalizer{ToolSentinel: emptyToolResultContent},
+			messagevalidators.LegacyToolNameStripper{},
+			messagevalidators.TextPartsFlattener{},
+		},
+		// Per-model normalizer chain overrides. Adding a model = add one row.
+		modelNormalizers: map[string][]MessageNormalizer{
+			miniMaxM27ModelID: {
+				messagevalidators.MinimaxOrphanToolMessageDropper{},
+				messagevalidators.EmptyAssistantTurnDropper{},
+				messagevalidators.EmptyContentNormalizer{
+					ToolSentinel: emptyToolResultContent,
+					SkipRoles:    []string{string(MessageRoleTool)},
+				},
+				messagevalidators.LegacyToolNameStripper{},
+				messagevalidators.MinimaxToolCallIDStripper{},
+				messagevalidators.TextPartsFlattener{
+					SkipRoles: []string{string(MessageRoleTool)},
+				},
+			},
+		},
+	}
+}
+
+func openAIRolePolicies() map[string]MessageRolePolicy {
 	policies := []MessageRolePolicy{
 		{Role: MessageRoleDeveloper, DisallowedFields: []string{"tool_calls", "tool_call_id", "function_call"}, ContentRule: MessageContentRequired},
 		{Role: MessageRoleSystem, DisallowedFields: []string{"tool_calls", "tool_call_id", "function_call"}, ContentRule: MessageContentRequired},
@@ -50,53 +116,47 @@ func defaultChatMessageProcessor() ChatMessageProcessor {
 	for _, policy := range policies {
 		byRole[string(policy.Role)] = policy
 	}
-	return ChatMessageProcessor{roles: byRole}
+	return byRole
 }
 
-// NormalizeDocument only fixes shapes we intentionally accept, for example empty tool content or text-part arrays.
-func (p ChatMessageProcessor) NormalizeDocument(document *ChatRequestDocument) error {
+func (p ChatMessageProcessor) resolveRoles(routedModel string) map[string]MessageRolePolicy {
+	overrides := p.modelRoles[routedModel]
+	if len(overrides) == 0 {
+		return p.defaultRoles
+	}
+	merged := make(map[string]MessageRolePolicy, len(p.defaultRoles))
+	for k, v := range p.defaultRoles {
+		merged[k] = v
+	}
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	return merged
+}
+
+func (p ChatMessageProcessor) resolveNormalizers(routedModel string) []MessageNormalizer {
+	if list, ok := p.modelNormalizers[routedModel]; ok {
+		return list
+	}
+	return p.defaultNormalizers
+}
+
+// NormalizeDocument fixes message shapes the gateway intentionally accepts
+// (orphan tool drops, empty tool content sentinels, content-array flattening).
+// The per-route normalizer chain decides what runs.
+func (p ChatMessageProcessor) NormalizeDocument(document *ChatRequestDocument, routedModel string) error {
 	messages, ok := document.Array("messages")
 	if !ok {
 		return nil
 	}
 	changed := false
-	if filtered, dropped := p.dropOrphanToolMessages(messages); dropped {
-		messages = filtered
-		changed = true
-	}
-	if filtered, dropped := p.dropEmptyAssistantTurns(messages); dropped {
-		messages = filtered
-		changed = true
-	}
-	for index, rawMessage := range messages {
-		message, ok := rawMessage.(map[string]any)
-		if !ok {
-			continue
-		}
-		role, _ := message["role"].(string)
-		if p.normalizeMissingContent(message, role) {
-			changed = true
-		}
-		if p.normalizeEmptyContent(message, role) {
-			changed = true
-		}
-		if p.normalizeStripLegacyToolName(message, role) {
-			changed = true
-		}
-		content, exists := message["content"]
-		if !exists || content == nil {
-			continue
-		}
-		parts, ok := content.([]any)
-		if !ok {
-			continue
-		}
-		combined, err := combineTextContentParts(parts, index)
+	for _, n := range p.resolveNormalizers(routedModel) {
+		rewritten, ch, err := n.Apply(messages)
 		if err != nil {
-			return err
+			return wrapBadChatRequest(err)
 		}
-		if combined != "" {
-			message["content"] = combined
+		if ch {
+			messages = rewritten
 			changed = true
 		}
 	}
@@ -106,154 +166,10 @@ func (p ChatMessageProcessor) NormalizeDocument(document *ChatRequestDocument) e
 	return nil
 }
 
-// Drops role:"tool" entries whose tool_call_id has no matching prior assistant.tool_call.
-// Mirrors ValidateDocument's pending-set accounting so survivors pass the strict check.
-func (p ChatMessageProcessor) dropOrphanToolMessages(messages []any) ([]any, bool) {
-	pending := map[string]struct{}{}
-	filtered := make([]any, 0, len(messages))
-	dropped := false
-	for _, raw := range messages {
-		msg, ok := raw.(map[string]any)
-		if !ok {
-			filtered = append(filtered, raw)
-			continue
-		}
-		role, _ := msg["role"].(string)
-		switch role {
-		case string(MessageRoleAssistant):
-			if calls, ok := msg["tool_calls"].([]any); ok {
-				for _, rawCall := range calls {
-					call, ok := rawCall.(map[string]any)
-					if !ok {
-						continue
-					}
-					if id, ok := call["id"].(string); ok && id != "" {
-						pending[id] = struct{}{}
-					}
-				}
-			}
-		case string(MessageRoleTool):
-			if id, ok := msg["tool_call_id"].(string); ok && id != "" {
-				if _, matched := pending[id]; !matched {
-					dropped = true
-					continue
-				}
-				delete(pending, id)
-			}
-		}
-		filtered = append(filtered, raw)
-	}
-	return filtered, dropped
-}
-
-// Drops role:"assistant" messages with no content and no tool_calls/function_call —
-// informationless placeholders left by session-resume serializers.
-func (p ChatMessageProcessor) dropEmptyAssistantTurns(messages []any) ([]any, bool) {
-	filtered := make([]any, 0, len(messages))
-	dropped := false
-	for _, raw := range messages {
-		msg, ok := raw.(map[string]any)
-		if !ok {
-			filtered = append(filtered, raw)
-			continue
-		}
-		if role, _ := msg["role"].(string); role == string(MessageRoleAssistant) && isAssistantTurnEmpty(msg) {
-			dropped = true
-			continue
-		}
-		filtered = append(filtered, raw)
-	}
-	return filtered, dropped
-}
-
-func isAssistantTurnEmpty(msg map[string]any) bool {
-	if raw, exists := msg["tool_calls"]; exists && raw != nil {
-		if calls, ok := raw.([]any); ok && len(calls) > 0 {
-			return false
-		}
-	}
-	if raw, exists := msg["function_call"]; exists && raw != nil {
-		if fc, ok := raw.(map[string]any); ok && len(fc) > 0 {
-			return false
-		}
-	}
-	content, exists := msg["content"]
-	if !exists || content == nil {
-		return true
-	}
-	return isEmptyContent(content)
-}
-
-// Strips legacy `name` from role:"tool" messages (artifact of the old role:"function" API).
-func (p ChatMessageProcessor) normalizeStripLegacyToolName(message map[string]any, role string) bool {
-	if role != string(MessageRoleTool) {
-		return false
-	}
-	if _, exists := message["name"]; !exists {
-		return false
-	}
-	delete(message, "name")
-	return true
-}
-
-func (p ChatMessageProcessor) normalizeMissingContent(message map[string]any, role string) bool {
-	if _, exists := message["content"]; exists {
-		return false
-	}
-	if role == string(MessageRoleTool) {
-		message["content"] = emptyToolResultContent
-		return true
-	}
-	return false
-}
-
-// Empty assistant content (string/array/null) is allowed only when a call payload is present;
-// empty tool content is normalized to a sentinel string.
-func (p ChatMessageProcessor) normalizeEmptyContent(message map[string]any, role string) bool {
-	content, exists := message["content"]
-	if !exists {
-		return false
-	}
-	if content == nil {
-		if role == string(MessageRoleTool) {
-			message["content"] = emptyToolResultContent
-			return true
-		}
-		return false
-	}
-	if !isEmptyContent(content) {
-		return false
-	}
-	switch role {
-	case string(MessageRoleAssistant):
-		if _, hasToolCalls := message["tool_calls"]; hasToolCalls {
-			message["content"] = nil
-			return true
-		}
-		if _, hasFunctionCall := message["function_call"]; hasFunctionCall {
-			message["content"] = nil
-			return true
-		}
-	case string(MessageRoleTool):
-		message["content"] = emptyToolResultContent
-		return true
-	}
-	return false
-}
-
-func isEmptyContent(content any) bool {
-	switch v := content.(type) {
-	case string:
-		return strings.TrimSpace(v) == ""
-	case []any:
-		return len(v) == 0
-	default:
-		return false
-	}
-}
-
-// ValidateDocument enforces the OpenAI-compatible message contract and makes sure tool responses match earlier assistant tool_calls.
-func (p ChatMessageProcessor) ValidateDocument(document *ChatRequestDocument) error {
+// ValidateDocument enforces the per-role policies resolved against the routed
+// model. RequireToolCallID and ContentValidator are honored as policy fields
+// so per-model overrides reuse the same validation skeleton.
+func (p ChatMessageProcessor) ValidateDocument(document *ChatRequestDocument, routedModel string) error {
 	rawMessages, exists := document.Array("messages")
 	if !exists {
 		return badChatRequest("messages is required")
@@ -261,6 +177,7 @@ func (p ChatMessageProcessor) ValidateDocument(document *ChatRequestDocument) er
 	if len(rawMessages) == 0 {
 		return badChatRequest("messages must not be empty")
 	}
+	roles := p.resolveRoles(routedModel)
 
 	pendingToolCalls := map[string]struct{}{}
 	for i, rawMessage := range rawMessages {
@@ -268,40 +185,50 @@ func (p ChatMessageProcessor) ValidateDocument(document *ChatRequestDocument) er
 		if !ok {
 			return badChatRequest("messages[%d] must be an object", i)
 		}
-		role, err := requiredNonEmptyString(message, "role")
+		role, err := messagevalidators.RequiredNonEmptyString(message, "role")
 		if err != nil {
 			return badChatRequest("messages[%d].role: %v", i, err)
 		}
-		policy, ok := p.roles[role]
+		policy, ok := roles[role]
 		if !ok {
 			return badChatRequest("messages[%d].role has unsupported value %q", i, role)
 		}
-		if err := ensureFieldsAbsent(message, policy.DisallowedFields...); err != nil {
+		if err := messagevalidators.EnsureFieldsAbsent(message, policy.DisallowedFields...); err != nil {
 			return badChatRequest("messages[%d]: %v", i, err)
 		}
+		if err := p.validateRoleSpecific(message, i, policy, pendingToolCalls); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-		switch policy.Role {
-		case MessageRoleDeveloper, MessageRoleSystem, MessageRoleUser:
-			if err := validateRequiredContent(message); err != nil {
-				return badChatRequest("messages[%d].content: %v", i, err)
-			}
-		case MessageRoleAssistant:
-			toolCallIDs, hasToolCalls, err := validateToolCallsField(message, i)
-			if err != nil {
-				return err
-			}
-			hasFunctionCall, err := validateFunctionCallField(message, i)
-			if err != nil {
-				return err
-			}
-			if err := validateAssistantContent(message, hasToolCalls || hasFunctionCall); err != nil {
-				return badChatRequest("messages[%d].content: %v", i, err)
-			}
-			for _, id := range toolCallIDs {
-				pendingToolCalls[id] = struct{}{}
-			}
-		case MessageRoleTool:
-			toolCallID, err := requiredNonEmptyString(message, "tool_call_id")
+// validateRoleSpecific keeps ValidateDocument's iteration loop legible: each
+// case reads as a single responsibility.
+func (p ChatMessageProcessor) validateRoleSpecific(message map[string]any, i int, policy MessageRolePolicy, pendingToolCalls map[string]struct{}) error {
+	switch policy.Role {
+	case MessageRoleDeveloper, MessageRoleSystem, MessageRoleUser:
+		if err := messagevalidators.ValidateRequiredContentField(message); err != nil {
+			return badChatRequest("messages[%d].content: %v", i, err)
+		}
+	case MessageRoleAssistant:
+		toolCallIDs, hasToolCalls, err := messagevalidators.ValidateToolCallsField(message)
+		if err != nil {
+			return badChatRequest("messages[%d].%v", i, err)
+		}
+		hasFunctionCall, err := messagevalidators.ValidateFunctionCallField(message)
+		if err != nil {
+			return badChatRequest("messages[%d].%v", i, err)
+		}
+		if err := messagevalidators.ValidateAssistantContentField(message, hasToolCalls || hasFunctionCall); err != nil {
+			return badChatRequest("messages[%d].content: %v", i, err)
+		}
+		for _, id := range toolCallIDs {
+			pendingToolCalls[id] = struct{}{}
+		}
+	case MessageRoleTool:
+		if policy.RequireToolCallID {
+			toolCallID, err := messagevalidators.RequiredNonEmptyString(message, "tool_call_id")
 			if err != nil {
 				return badChatRequest("messages[%d].tool_call_id: %v", i, err)
 			}
@@ -309,216 +236,31 @@ func (p ChatMessageProcessor) ValidateDocument(document *ChatRequestDocument) er
 				return badChatRequest("messages[%d].tool_call_id does not match any previous assistant tool_calls", i)
 			}
 			delete(pendingToolCalls, toolCallID)
-			if err := validateRequiredContent(message); err != nil {
-				return badChatRequest("messages[%d].content: %v", i, err)
+		}
+		if policy.ContentValidator != nil {
+			content, exists := message["content"]
+			if !exists {
+				return badChatRequest("messages[%d].content: is required", i)
 			}
-		case MessageRoleFunction:
-			if _, err := requiredNonEmptyString(message, "name"); err != nil {
+			if err := policy.ContentValidator.Validate(content); err != nil {
+				return badChatRequest("messages[%d].%v", i, err)
+			}
+		} else if err := messagevalidators.ValidateRequiredContentField(message); err != nil {
+			return badChatRequest("messages[%d].content: %v", i, err)
+		}
+	case MessageRoleFunction:
+		if policy.RequireName {
+			if _, err := messagevalidators.RequiredNonEmptyString(message, "name"); err != nil {
 				return badChatRequest("messages[%d].name: %v", i, err)
 			}
-			if err := validateRequiredContent(message); err != nil {
-				return badChatRequest("messages[%d].content: %v", i, err)
-			}
+		}
+		if err := messagevalidators.ValidateRequiredContentField(message); err != nil {
+			return badChatRequest("messages[%d].content: %v", i, err)
 		}
 	}
 	return nil
 }
 
 func validateOpenAICompatChatMessages(request map[string]any) error {
-	return defaultMessageProcessor.ValidateDocument(&ChatRequestDocument{raw: request})
-}
-
-func validateToolCallsField(message map[string]any, messageIndex int) ([]string, bool, error) {
-	rawToolCalls, exists := message["tool_calls"]
-	if !exists {
-		return nil, false, nil
-	}
-	// Treat explicit null as absent (some SDKs serialize empty slots that way).
-	if rawToolCalls == nil {
-		delete(message, "tool_calls")
-		return nil, false, nil
-	}
-	toolCalls, ok := rawToolCalls.([]any)
-	if !ok {
-		return nil, true, badChatRequest("messages[%d].tool_calls must be an array", messageIndex)
-	}
-	if len(toolCalls) == 0 {
-		return nil, true, badChatRequest("messages[%d].tool_calls must not be empty", messageIndex)
-	}
-	seen := map[string]struct{}{}
-	ids := make([]string, 0, len(toolCalls))
-	for callIndex, rawCall := range toolCalls {
-		call, ok := rawCall.(map[string]any)
-		if !ok {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d] must be an object", messageIndex, callIndex)
-		}
-		id, err := requiredNonEmptyString(call, "id")
-		if err != nil {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].id: %v", messageIndex, callIndex, err)
-		}
-		if _, exists := seen[id]; exists {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].id is duplicated", messageIndex, callIndex)
-		}
-		seen[id] = struct{}{}
-		callType, err := requiredNonEmptyString(call, "type")
-		if err != nil {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].type: %v", messageIndex, callIndex, err)
-		}
-		if callType != "function" {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].type must be \"function\"", messageIndex, callIndex)
-		}
-		function, ok := call["function"].(map[string]any)
-		if !ok {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].function must be an object", messageIndex, callIndex)
-		}
-		if _, err := requiredNonEmptyString(function, "name"); err != nil {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].function.name: %v", messageIndex, callIndex, err)
-		}
-		if err := optionalStringField(function, "arguments"); err != nil {
-			return nil, true, badChatRequest("messages[%d].tool_calls[%d].function.arguments: %v", messageIndex, callIndex, err)
-		}
-		ids = append(ids, id)
-	}
-	return ids, true, nil
-}
-
-func validateFunctionCallField(message map[string]any, messageIndex int) (bool, error) {
-	rawFunctionCall, exists := message["function_call"]
-	if !exists {
-		return false, nil
-	}
-	if rawFunctionCall == nil {
-		delete(message, "function_call")
-		return false, nil
-	}
-	functionCall, ok := rawFunctionCall.(map[string]any)
-	if !ok {
-		return true, badChatRequest("messages[%d].function_call must be an object", messageIndex)
-	}
-	if _, err := requiredNonEmptyString(functionCall, "name"); err != nil {
-		return true, badChatRequest("messages[%d].function_call.name: %v", messageIndex, err)
-	}
-	if err := optionalStringField(functionCall, "arguments"); err != nil {
-		return true, badChatRequest("messages[%d].function_call.arguments: %v", messageIndex, err)
-	}
-	return true, nil
-}
-
-func validateAssistantContent(message map[string]any, canBeEmpty bool) error {
-	content, exists := message["content"]
-	if !exists || content == nil {
-		if canBeEmpty {
-			return nil
-		}
-		return fmt.Errorf("is required unless tool_calls or function_call is provided")
-	}
-	return validateNonEmptyContent(content)
-}
-
-func validateRequiredContent(message map[string]any) error {
-	content, exists := message["content"]
-	if !exists || content == nil {
-		return fmt.Errorf("is required")
-	}
-	return validateNonEmptyContent(content)
-}
-
-func validateNonEmptyContent(content any) error {
-	switch value := content.(type) {
-	case string:
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("must not be empty")
-		}
-		return nil
-	case []any:
-		if len(value) == 0 {
-			return fmt.Errorf("must not be empty")
-		}
-		for i, rawPart := range value {
-			part, ok := rawPart.(map[string]any)
-			if !ok {
-				return fmt.Errorf("[%d] must be an object", i)
-			}
-			text, err := requiredTextContentPart(part, i)
-			if err != nil {
-				return err
-			}
-			if strings.TrimSpace(text) == "" {
-				return fmt.Errorf("[%d].text must not be empty", i)
-			}
-		}
-		return nil
-	default:
-		return fmt.Errorf("must be a string or an array of typed content parts")
-	}
-}
-
-// We only accept text parts here because the gateway normalizes typed text content into a plain string before forwarding.
-func requiredTextContentPart(part map[string]any, partIndex int) (string, error) {
-	partType, err := requiredNonEmptyString(part, "type")
-	if err != nil {
-		return "", fmt.Errorf("[%d].type: %w", partIndex, err)
-	}
-	if partType != "text" {
-		return "", fmt.Errorf("[%d].type has unsupported value %q", partIndex, partType)
-	}
-	text, err := requiredNonEmptyString(part, "text")
-	if err != nil {
-		return "", fmt.Errorf("[%d].text: %w", partIndex, err)
-	}
-	return text, nil
-}
-
-func combineTextContentParts(parts []any, messageIndex int) (string, error) {
-	texts := make([]string, 0, len(parts))
-	for partIndex, rawPart := range parts {
-		part, ok := rawPart.(map[string]any)
-		if !ok {
-			return "", badChatRequest("messages[%d].content[%d] must be an object", messageIndex, partIndex)
-		}
-		text, err := requiredTextContentPart(part, partIndex)
-		if err != nil {
-			return "", badChatRequest("messages[%d].content%v", messageIndex, err)
-		}
-		texts = append(texts, text)
-	}
-	if len(texts) == 0 {
-		return "", nil
-	}
-	return strings.Join(texts, "\n"), nil
-}
-
-func ensureFieldsAbsent(values map[string]any, fields ...string) error {
-	for _, field := range fields {
-		if _, exists := values[field]; exists {
-			return fmt.Errorf("%s is not allowed for this role", field)
-		}
-	}
-	return nil
-}
-
-func requiredNonEmptyString(values map[string]any, field string) (string, error) {
-	rawValue, exists := values[field]
-	if !exists || rawValue == nil {
-		return "", fmt.Errorf("is required")
-	}
-	value, ok := rawValue.(string)
-	if !ok {
-		return "", fmt.Errorf("must be a string")
-	}
-	if strings.TrimSpace(value) == "" {
-		return "", fmt.Errorf("must not be empty")
-	}
-	return value, nil
-}
-
-func optionalStringField(values map[string]any, field string) error {
-	rawValue, exists := values[field]
-	if !exists || rawValue == nil {
-		return nil
-	}
-	if _, ok := rawValue.(string); !ok {
-		return fmt.Errorf("must be a string")
-	}
-	return nil
+	return defaultMessageProcessor.ValidateDocument(&ChatRequestDocument{raw: request}, "")
 }

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -110,7 +110,6 @@ func (h MinUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLM
 	return nil
 }
 
-
 // DocumentValidator: validators in paramvalidators expose this contract. May mutate
 // vctx.Document for per-model rewrites alongside shape checks.
 type DocumentValidator interface {
@@ -343,18 +342,11 @@ func (ctx *RequestFilterContext) DecodeRequest() error {
 	return nil
 }
 
-// SyncRequestView refreshes ctx.Request after PostLimits rules ran. Why we explicitly
-// preserve the token fields instead of re-reading them from the document:
-//
-//   - When the client sends only `max_completion_tokens` (no `max_tokens`),
-//     `applyOutputTokenLimits` sets `ctx.Request.MaxTokens` from the resolved
-//     `max_completion_tokens` (see request_filters.go:139) but does NOT write a
-//     corresponding `max_tokens` key into the document. Re-reading the document would
-//     therefore reset `req.MaxTokens` to 0.
-//   - In the other three branches of `applyOutputTokenLimits`, the document DOES carry
-//     the same value, so preserving from `ctx.Request` is a no-op. Net effect: this
-//     branch only matters for the max-completion-only path, locked in by
-//     TestNormalizeChatRequestDefaultsAndCapsOutputTokens.
+// SyncRequestView refreshes ctx.Request after PostLimits rules ran. The token fields
+// are preserved from ctx.Request rather than re-read because applyOutputTokenLimits is
+// their source of truth; all four of its branches now write the same max_tokens /
+// max_completion_tokens into the document (the max-completion-only branch mirrors into
+// max_tokens too), so this preservation is a harmless no-op safety net.
 //
 // Other fields are re-read so caps applied by PostLimits rules (for example `n` via
 // paramvalidators.CapUintParameter through the adapter) propagate into the projection.
@@ -416,6 +408,26 @@ type VLLMParameterCatalog struct {
 
 var defaultParameterCatalog = defaultVLLMParameterCatalog()
 
+// Shared stateless parameter handlers reused across catalog entries. The rejectNumber gates
+// enforce exclusive-lower-bound ranges (clamping to the bound would itself be an illegal
+// value, so reject instead); the mustBe*/elementsMustBe* validators reject wrong-typed
+// scalars and array elements at the gateway boundary rather than forwarding them for an
+// opaque upstream 400.
+var (
+	rejectNonPositiveNumber = ParameterHandlerAdapter{Handler: paramvalidators.RejectNumberParameter{
+		Allow:   func(value float64) bool { return value > 0 },
+		Message: "must be greater than 0",
+	}}
+	rejectInvalidTopK = ParameterHandlerAdapter{Handler: paramvalidators.RejectNumberParameter{
+		Allow:   func(value float64) bool { return value == -1 || value >= 1 },
+		Message: "must be -1 or a positive integer",
+	}}
+	mustBeBool           = ParameterHandlerAdapter{Handler: paramvalidators.ValidateScalarParameter{Valid: paramvalidators.IsJSONBool, Message: "must be a boolean"}}
+	mustBeUint           = ParameterHandlerAdapter{Handler: paramvalidators.ValidateUintParameter{}}
+	elementsMustBeUint   = ParameterHandlerAdapter{Handler: paramvalidators.ValidateListElementsParameter{Valid: paramvalidators.IsJSONUint, Message: "must be an integer token id"}}
+	elementsMustBeString = ParameterHandlerAdapter{Handler: paramvalidators.ValidateListElementsParameter{Valid: paramvalidators.IsJSONString, Message: "must be a string"}}
+)
+
 // The catalog is the single source of truth for how each supported OpenAI/vLLM field is treated.
 func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 	parameters := slices.Concat(
@@ -423,22 +435,25 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 			newParameter("messages").
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: MessagesMaxEntries}}),
 			newParameter("seed").
-				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.ValidateUintParameter{}}),
+				withRule(RequestFilterStagePreValidation, mustBeUint),
 			newParameter("n").
 				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.CapUintParameter{Min: 1, Max: MaxChatRequestChoices}}).
 				withRule(RequestFilterStagePostLimits, DocumentValidatorHandler{
 					Validator: paramvalidators.GreedySamplingValidator{},
 				}),
 			newParameter("temperature").
-				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(MaxTemperature)}}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Min: floatPointer(MinTemperature), Max: floatPointer(MaxTemperature)}}),
 			newParameter("repetition_penalty").
-				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}}).
+				withRule(RequestFilterStagePostLimits, rejectNonPositiveNumber),
 			newParameter("logit_bias").
 				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatMapParameter{StripNonFinite: true, Min: floatPointer(LogitBiasMinValue), Max: floatPointer(LogitBiasMaxValue), DropFieldIfEmpty: true, MaxEntries: LogitBiasMaxEntries}}),
 			newParameter("stop").
+				withRule(RequestFilterStagePreValidation, elementsMustBeString).
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: StopMaxEntries, MaxEntryLen: StopMaxEntryLen}}),
 			newParameter("stop_token_ids").
-				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: StopTokenIdsMaxEntries}}),
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: StopTokenIdsMaxEntries}}).
+				withRule(RequestFilterStagePreValidation, elementsMustBeUint),
 			newParameter("reasoning").
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.ReasoningValidator{},
@@ -517,6 +532,7 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 					Validator: paramvalidators.ToolChoiceValidator{MaxNameLen: ToolChoiceMaxNameLen},
 				}),
 			newParameter("min_tokens").
+				withRule(RequestFilterStagePreValidation, mustBeUint).
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.ConditionalStripParameter{
 					Predicate: func(ctx paramvalidators.ParameterContext) bool {
 						_, ok := ctx.Document["stop_token_ids"]
@@ -525,6 +541,7 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 				}}).
 				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.ClampUintToFieldParameter{MaxField: "max_tokens"}}),
 			newParameter("bad_words").
+				withRule(RequestFilterStagePreValidation, elementsMustBeString).
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeStringListParameter{
 					Keep: func(value string) bool {
 						return strings.TrimSpace(value) != ""
@@ -581,18 +598,18 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 			newParameter("structured_outputs").
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.StructuredOutputsValidator{
-						RejectedModels:       []string{kimiK26ModelID},
-						MaxDepth:             StructuredOutputsMaxDepth,
-						MaxSize:              StructuredOutputsMaxSize,
-						MaxNodes:             StructuredOutputsMaxNodes,
-						MaxBranch:            StructuredOutputsMaxBranch,
-						MaxEnum:              StructuredOutputsMaxEnum,
-						MaxPatternLen:        StructuredOutputsMaxPatternLen,
-						MaxChoiceEntries:     StructuredOutputsMaxChoiceEntries,
-						MaxChoiceEntryLen:    StructuredOutputsMaxChoiceEntryLen,
-						MaxGrammarLen:        StructuredOutputsMaxGrammarLen,
-						MaxGrammarNesting:    StructuredOutputsMaxGrammarNesting,
-						MaxStructuralTagLen:  StructuredOutputsMaxStructuralTagLen,
+						RejectedModels:      []string{kimiK26ModelID},
+						MaxDepth:            StructuredOutputsMaxDepth,
+						MaxSize:             StructuredOutputsMaxSize,
+						MaxNodes:            StructuredOutputsMaxNodes,
+						MaxBranch:           StructuredOutputsMaxBranch,
+						MaxEnum:             StructuredOutputsMaxEnum,
+						MaxPatternLen:       StructuredOutputsMaxPatternLen,
+						MaxChoiceEntries:    StructuredOutputsMaxChoiceEntries,
+						MaxChoiceEntryLen:   StructuredOutputsMaxChoiceEntryLen,
+						MaxGrammarLen:       StructuredOutputsMaxGrammarLen,
+						MaxGrammarNesting:   StructuredOutputsMaxGrammarNesting,
+						MaxStructuralTagLen: StructuredOutputsMaxStructuralTagLen,
 					},
 				}),
 			newParameter("safety_identifier").
@@ -619,30 +636,46 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 		},
 		[]VLLMParameter{
 			// PreValidation so the floor lands before applyOutputTokenLimits (caps down) and the
-			// thinking_token_budget defaulter (derives ttb from max_tokens).
+			// thinking_token_budget defaulter (derives ttb from max_tokens). Kimi clamps a
+			// too-small budget up to its floor (think-burn mitigation); other models reject a
+			// non-positive budget outright since they have no such floor.
 			newParameter("max_tokens").
 				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
-					Models:  []string{kimiK26ModelID},
-					Handler: MinUintParameterHandler{Min: kimiMaxTokensMin},
+					Models:           []string{kimiK26ModelID},
+					Handler:          MinUintParameterHandler{Min: kimiMaxTokensMin},
+					UnmatchedHandler: rejectNonPositiveNumber,
 				}),
 			newParameter("max_completion_tokens").
 				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
-					Models:  []string{kimiK26ModelID},
-					Handler: MinUintParameterHandler{Min: kimiMaxTokensMin},
+					Models:           []string{kimiK26ModelID},
+					Handler:          MinUintParameterHandler{Min: kimiMaxTokensMin},
+					UnmatchedHandler: rejectNonPositiveNumber,
 				}),
+			// Sampling knobs with per-field ranges: min_p clamps into [0, 1]; top_p clamps
+			// down to 1 but rejects a non-positive value (exclusive lower bound); top_k
+			// accepts -1 (disabled) or any integer >= 1.
+			newParameter("min_p").
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Min: floatPointer(MinPMin), Max: floatPointer(MinPMax)}}),
+			newParameter("top_p").
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(TopPMax)}}).
+				withRule(RequestFilterStagePostLimits, rejectNonPositiveNumber),
+			newParameter("top_k").
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true}}).
+				withRule(RequestFilterStagePostLimits, rejectInvalidTopK),
 		},
+		// model and stream are type-checked during the typed parse (string / bool); register
+		// them as known so the whitelist keeps them.
 		newParameters([]string{
 			"model",
 			"stream",
+		}),
+		// The remaining boolean flags are pass-through fields, so validate their type here.
+		newParameters([]string{
 			"skip_special_tokens",
 			"detokenize",
 			"parallel_tool_calls",
-		}),
-		newParameters([]string{"top_p", "top_k", "min_p"},
-			ParameterRule{
-				Stage:   RequestFilterStagePostLimits,
-				Handler: ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true}},
-			},
+		},
+			ParameterRule{Stage: RequestFilterStagePreValidation, Handler: mustBeBool},
 		),
 		newParameters([]string{"service_tier", "store", "provider", "plugins", "prompt_cache_key", "cache_key", "extra_headers", "thinking_config", "think"},
 			ParameterRule{Stage: RequestFilterStagePreValidation, Handler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}}},

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -425,7 +425,7 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 			newParameter("seed").
 				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.ValidateUintParameter{}}),
 			newParameter("n").
-				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.CapUintParameter{Max: MaxChatRequestChoices}}).
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.CapUintParameter{Min: 1, Max: MaxChatRequestChoices}}).
 				withRule(RequestFilterStagePostLimits, DocumentValidatorHandler{
 					Validator: paramvalidators.GreedySamplingValidator{},
 				}),

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -3,13 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"math"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 
 	"devshard"
+	"devshard/cmd/devshardctl/filtercore"
 	"devshard/cmd/devshardctl/paramvalidators"
 )
 
@@ -41,137 +40,28 @@ type ParameterHandler interface {
 	Apply(*RequestFilterContext, VLLMParameter) error
 }
 
-type StripParameterHandler struct{}
-
-func (StripParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	ctx.Document.Delete(parameter.Name)
-	return nil
+// ParameterHandlerAdapter wraps a paramvalidators.ParameterHandler (which operates on a
+// raw map[string]any) so the catalog can drive it through the standard ParameterHandler
+// contract. Mirrors DocumentValidatorHandler's role for DocumentValidator.
+type ParameterHandlerAdapter struct {
+	Handler paramvalidators.ParameterHandler
 }
 
-type ConditionalStripParameterHandler struct {
-	Predicate func(*RequestFilterContext) bool
-}
-
-func (h ConditionalStripParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	if h.Predicate != nil && h.Predicate(ctx) {
-		ctx.Document.Delete(parameter.Name)
-	}
-	return nil
-}
-
-type SanitizeStringListParameterHandler struct {
-	Keep             func(string) bool
-	DropFieldIfEmpty bool
-}
-
-func (h SanitizeStringListParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	raw, ok := ctx.Document.Array(parameter.Name)
-	if !ok {
+func (h ParameterHandlerAdapter) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
+	if h.Handler == nil {
 		return nil
 	}
-	cleaned := raw[:0]
-	for _, item := range raw {
-		value, ok := item.(string)
-		if !ok {
-			cleaned = append(cleaned, item)
-			continue
-		}
-		if h.Keep == nil || h.Keep(value) {
-			cleaned = append(cleaned, value)
-		}
+	var handlerErr error
+	ctx.Document.LockedScope(func(raw map[string]any) {
+		handlerErr = h.Handler.HandleParameter(paramvalidators.ParameterContext{
+			Document:    raw,
+			Parameter:   parameter.Name,
+			RoutedModel: ctx.RoutedModel,
+		})
+	})
+	if handlerErr != nil {
+		return wrapBadChatRequest(handlerErr)
 	}
-	if len(cleaned) == 0 && h.DropFieldIfEmpty {
-		ctx.Document.Delete(parameter.Name)
-		return nil
-	}
-	ctx.Document.Set(parameter.Name, cleaned)
-	return nil
-}
-
-// SanitizeFloatParameterHandler normalizes numeric knobs from either JSON numbers or string-encoded numbers.
-type SanitizeFloatParameterHandler struct {
-	StripNonFinite bool
-	Min            *float64
-	Max            *float64
-}
-
-func (h SanitizeFloatParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	value, ok := ctx.Document.Get(parameter.Name)
-	if !ok {
-		return nil
-	}
-	number, ok := numericJSONValueAsFloat64(value)
-	if !ok {
-		ctx.Document.Delete(parameter.Name)
-		return nil
-	}
-	if h.StripNonFinite && (math.IsNaN(number) || math.IsInf(number, 0)) {
-		ctx.Document.Delete(parameter.Name)
-		return nil
-	}
-	if h.Min != nil && number < *h.Min {
-		number = *h.Min
-	}
-	if h.Max != nil && number > *h.Max {
-		number = *h.Max
-	}
-	ctx.Document.Set(parameter.Name, number)
-	return nil
-}
-
-type SanitizeFloatMapParameterHandler struct {
-	StripNonFinite   bool
-	Min              *float64
-	Max              *float64
-	DropFieldIfEmpty bool
-	MaxEntries       int
-}
-
-func (h SanitizeFloatMapParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	raw, ok := ctx.Document.Object(parameter.Name)
-	if !ok {
-		return nil
-	}
-	if h.MaxEntries > 0 && len(raw) > h.MaxEntries {
-		return badChatRequest("%s: map size %d exceeds limit %d", parameter.Name, len(raw), h.MaxEntries)
-	}
-	for key, value := range raw {
-		number, ok := numericJSONValueAsFloat64(value)
-		if !ok {
-			continue
-		}
-		if h.StripNonFinite && (math.IsNaN(number) || math.IsInf(number, 0)) {
-			delete(raw, key)
-			continue
-		}
-		if h.Min != nil && number < *h.Min {
-			delete(raw, key)
-			continue
-		}
-		if h.Max != nil && number > *h.Max {
-			delete(raw, key)
-		}
-	}
-	if len(raw) == 0 && h.DropFieldIfEmpty {
-		ctx.Document.Delete(parameter.Name)
-		return nil
-	}
-	ctx.Document.Set(parameter.Name, raw)
-	return nil
-}
-
-type ForceLiteralParameterHandler struct {
-	Value any
-	OverwriteOnly bool
-}
-
-func (h ForceLiteralParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	if h.OverwriteOnly {
-		if _, exists := ctx.Document.Get(parameter.Name); !exists {
-			return nil
-		}
-	}
-	ctx.Document.Set(parameter.Name, h.Value)
 	return nil
 }
 
@@ -185,13 +75,11 @@ type ModelScopedParameterHandler struct {
 }
 
 func (h ModelScopedParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	for _, m := range h.Models {
-		if m == ctx.RoutedModel {
-			if h.Handler == nil {
-				return nil
-			}
-			return h.Handler.Apply(ctx, parameter)
+	if filtercore.MatchesModel(ctx.RoutedModel, h.Models) {
+		if h.Handler == nil {
+			return nil
 		}
+		return h.Handler.Apply(ctx, parameter)
 	}
 	if h.UnmatchedHandler == nil {
 		return nil
@@ -199,48 +87,20 @@ func (h ModelScopedParameterHandler) Apply(ctx *RequestFilterContext, parameter 
 	return h.UnmatchedHandler.Apply(ctx, parameter)
 }
 
-type CapUintParameterHandler struct {
-	Max uint64
-}
-
-func (h CapUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	value, ok := numericJSONValueAsUint64FromDocument(&ctx.Document, parameter.Name)
-	if !ok {
-		return nil
-	}
-	if value > h.Max {
-		ctx.Document.Set(parameter.Name, h.Max)
-	}
-	return nil
-}
-
-type ClampUintToFieldParameterHandler struct {
-	MaxField string
-}
-
-func (h ClampUintToFieldParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	value, ok := numericJSONValueAsUint64FromDocument(&ctx.Document, parameter.Name)
-	if !ok {
-		return nil
-	}
-	maxValue, ok := numericJSONValueAsUint64FromDocument(&ctx.Document, h.MaxField)
-	if !ok || maxValue == 0 {
-		return nil
-	}
-	if value > maxValue {
-		ctx.Document.Set(parameter.Name, maxValue)
-	}
-	return nil
-}
-
 // MinUintParameterHandler clamps a uint parameter UP to Min when the value is present
 // and below the floor. Pass-through when the field is absent or already >= Min.
+// Used by the Kimi-K2.6 max_tokens floor; lives here (rather than in paramvalidators)
+// because it has only one call-site and was added after the bulk-handler migration.
 type MinUintParameterHandler struct {
 	Min uint64
 }
 
 func (h MinUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	value, ok := numericJSONValueAsUint64FromDocument(&ctx.Document, parameter.Name)
+	raw, ok := ctx.Document.Get(parameter.Name)
+	if !ok {
+		return nil
+	}
+	value, ok := devshard.JSONNumericUint64(raw)
 	if !ok {
 		return nil
 	}
@@ -250,55 +110,6 @@ func (h MinUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLM
 	return nil
 }
 
-// ValidateUintParameterHandler rejects the request if the field is present but its value
-// cannot be parsed as a non-negative integer that fits in uint64. Pass-through when the
-// field is absent. Used for fields like `seed` where vLLM expects a uint64 and we want to
-// catch garbage types at the gateway boundary rather than relying on the upstream's error
-// path.
-type ValidateUintParameterHandler struct{}
-
-func (h ValidateUintParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	raw, exists := ctx.Document.Get(parameter.Name)
-	if !exists || raw == nil {
-		return nil
-	}
-	if _, ok := devshard.JSONNumericUint64(raw); !ok {
-		return badChatRequest("%s: must be a non-negative integer", parameter.Name)
-	}
-	return nil
-}
-
-// LengthCapListParameterHandler bounds the number of entries in a JSON array, and
-// optionally the byte length of each string entry. Used for fields like `stop`,
-// `stop_token_ids`, and `bad_words` -- vLLM scans every entry against every generated
-// token, so unbounded arrays linearly slow inference. MaxEntries=0 disables the array cap,
-// MaxEntryLen=0 disables the per-string cap (use 0 for int-only arrays).
-type LengthCapListParameterHandler struct {
-	MaxEntries  int
-	MaxEntryLen int
-}
-
-func (h LengthCapListParameterHandler) Apply(ctx *RequestFilterContext, parameter VLLMParameter) error {
-	raw, ok := ctx.Document.Array(parameter.Name)
-	if !ok {
-		return nil
-	}
-	if h.MaxEntries > 0 && len(raw) > h.MaxEntries {
-		return badChatRequest("%s: array length %d exceeds limit %d", parameter.Name, len(raw), h.MaxEntries)
-	}
-	if h.MaxEntryLen > 0 {
-		for i, item := range raw {
-			s, ok := item.(string)
-			if !ok {
-				continue
-			}
-			if len(s) > h.MaxEntryLen {
-				return badChatRequest("%s[%d]: string length %d exceeds limit %d", parameter.Name, i, len(s), h.MaxEntryLen)
-			}
-		}
-	}
-	return nil
-}
 
 // DocumentValidator: validators in paramvalidators expose this contract. May mutate
 // vctx.Document for per-model rewrites alongside shape checks.
@@ -546,7 +357,7 @@ func (ctx *RequestFilterContext) DecodeRequest() error {
 //     TestNormalizeChatRequestDefaultsAndCapsOutputTokens.
 //
 // Other fields are re-read so caps applied by PostLimits rules (for example `n` via
-// CapUintParameterHandler) propagate into the projection.
+// paramvalidators.CapUintParameter through the adapter) propagate into the projection.
 func (ctx *RequestFilterContext) SyncRequestView() error {
 	var req chatRequest
 	if err := readChatRequestFields(&ctx.Document, &req); err != nil {
@@ -610,24 +421,24 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 	parameters := slices.Concat(
 		[]VLLMParameter{
 			newParameter("messages").
-				withRule(RequestFilterStagePreValidation, LengthCapListParameterHandler{MaxEntries: MessagesMaxEntries}),
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: MessagesMaxEntries}}),
 			newParameter("seed").
-				withRule(RequestFilterStagePreValidation, ValidateUintParameterHandler{}),
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.ValidateUintParameter{}}),
 			newParameter("n").
-				withRule(RequestFilterStagePostLimits, CapUintParameterHandler{Max: MaxChatRequestChoices}).
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.CapUintParameter{Max: MaxChatRequestChoices}}).
 				withRule(RequestFilterStagePostLimits, DocumentValidatorHandler{
 					Validator: paramvalidators.GreedySamplingValidator{},
 				}),
 			newParameter("temperature").
-				withRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true, Max: floatPointer(MaxTemperature)}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(MaxTemperature)}}),
 			newParameter("repetition_penalty").
-				withRule(RequestFilterStagePostLimits, SanitizeFloatParameterHandler{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Max: floatPointer(MaxRepetitionPenalty)}}),
 			newParameter("logit_bias").
-				withRule(RequestFilterStagePostLimits, SanitizeFloatMapParameterHandler{StripNonFinite: true, Min: floatPointer(LogitBiasMinValue), Max: floatPointer(LogitBiasMaxValue), DropFieldIfEmpty: true, MaxEntries: LogitBiasMaxEntries}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatMapParameter{StripNonFinite: true, Min: floatPointer(LogitBiasMinValue), Max: floatPointer(LogitBiasMaxValue), DropFieldIfEmpty: true, MaxEntries: LogitBiasMaxEntries}}),
 			newParameter("stop").
-				withRule(RequestFilterStagePreValidation, LengthCapListParameterHandler{MaxEntries: StopMaxEntries, MaxEntryLen: StopMaxEntryLen}),
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: StopMaxEntries, MaxEntryLen: StopMaxEntryLen}}),
 			newParameter("stop_token_ids").
-				withRule(RequestFilterStagePreValidation, LengthCapListParameterHandler{MaxEntries: StopTokenIdsMaxEntries}),
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: StopTokenIdsMaxEntries}}),
 			newParameter("reasoning").
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.ReasoningValidator{},
@@ -641,13 +452,26 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 				}).
 				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
 					Models:           nil,
-					UnmatchedHandler: StripParameterHandler{},
+					UnmatchedHandler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}},
 				}),
+			// MiniMax-M2.7 has no chat_template knob for enable_thinking (vLLM #36778);
+			// strip on this route before EnableThinkingValidator runs.
 			newParameter("enable_thinking").
+				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
+					Models:  []string{miniMaxM27ModelID},
+					Handler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}},
+				}).
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.EnableThinkingValidator{},
 				}),
+			// thinking: Kimi mirrors to chat_template_kwargs.thinking; MiniMax-M2.7 has no
+			// equivalent knob (interleaved thinking is structural to the chat template) so
+			// strip the field before ThinkingValidator runs. Other routes normalize+keep.
 			newParameter("thinking").
+				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
+					Models:  []string{miniMaxM27ModelID},
+					Handler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}},
+				}).
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.ThinkingValidator{
 						MirrorToTemplateKwargsForModels: []string{kimiK26ModelID},
@@ -664,7 +488,7 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 			newParameter("thinking_token_budget").
 				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
 					Models:           []string{kimiK26ModelID},
-					UnmatchedHandler: StripParameterHandler{},
+					UnmatchedHandler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}},
 				}).
 				withRule(RequestFilterStagePostLimits, ModelScopedParameterHandler{
 					Models: []string{kimiK26ModelID},
@@ -674,8 +498,8 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 						},
 					},
 				}).
-				withRule(RequestFilterStagePostLimits, CapUintParameterHandler{Max: kimiThinkingTokenBudgetMax}).
-				withRule(RequestFilterStagePostLimits, ClampUintToFieldParameterHandler{MaxField: "max_tokens"}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.CapUintParameter{Max: kimiThinkingTokenBudgetMax}}).
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.ClampUintToFieldParameter{MaxField: "max_tokens"}}),
 			newParameter("tools").
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.ToolsValidator{
@@ -693,20 +517,21 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 					Validator: paramvalidators.ToolChoiceValidator{MaxNameLen: ToolChoiceMaxNameLen},
 				}),
 			newParameter("min_tokens").
-				withRule(RequestFilterStagePreValidation, ConditionalStripParameterHandler{
-					Predicate: func(ctx *RequestFilterContext) bool {
-						return ctx.Document.Has("stop_token_ids")
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.ConditionalStripParameter{
+					Predicate: func(ctx paramvalidators.ParameterContext) bool {
+						_, ok := ctx.Document["stop_token_ids"]
+						return ok
 					},
-				}).
-				withRule(RequestFilterStagePostLimits, ClampUintToFieldParameterHandler{MaxField: "max_tokens"}),
+				}}).
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.ClampUintToFieldParameter{MaxField: "max_tokens"}}),
 			newParameter("bad_words").
-				withRule(RequestFilterStagePreValidation, SanitizeStringListParameterHandler{
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.SanitizeStringListParameter{
 					Keep: func(value string) bool {
 						return strings.TrimSpace(value) != ""
 					},
 					DropFieldIfEmpty: true,
-				}).
-				withRule(RequestFilterStagePreValidation, LengthCapListParameterHandler{MaxEntries: BadWordsMaxEntries, MaxEntryLen: BadWordsMaxEntryLen}),
+				}}).
+				withRule(RequestFilterStagePreValidation, ParameterHandlerAdapter{Handler: paramvalidators.LengthCapListParameter{MaxEntries: BadWordsMaxEntries, MaxEntryLen: BadWordsMaxEntryLen}}),
 			// OpenAI Chat Completions standard observability fields. No inference-side
 			// semantics on the vLLM upstream; clients send them for end-user tracking,
 			// distributed tracing, agent control, and streaming token accounting.
@@ -736,11 +561,11 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 					Validator: paramvalidators.StreamOptionsValidator{},
 				}),
 			newParameter("return_token_ids").
-				withRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: true}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.ForceLiteralParameter{Value: true}}),
 			newParameter("logprobs").
-				withRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: true}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.ForceLiteralParameter{Value: true}}),
 			newParameter("top_logprobs").
-				withRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: TopLogprobsForcedValue}),
+				withRule(RequestFilterStagePostLimits, ParameterHandlerAdapter{Handler: paramvalidators.ForceLiteralParameter{Value: TopLogprobsForcedValue}}),
 			newParameter("response_format").
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.ResponseFormatValidator{
@@ -779,7 +604,17 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 							DefaultMaxLen: SafetyIdentifierMaxLen,
 						},
 					},
-					UnmatchedHandler: StripParameterHandler{},
+					UnmatchedHandler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}},
+				}),
+			// MiniMax-M2.7 native extension lifted from extra_body. On the MiniMax
+			// route the field passes through to vLLM verbatim (controls whether
+			// reasoning is emitted as inline <think>...</think> in content or as a
+			// separate reasoning_details[] array). Stripped on other routes since
+			// Kimi/Qwen vLLM serves don't know the field. See docs/chat-api/minimax-m2.7.md.
+			newParameter("reasoning_split").
+				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
+					Models:           []string{miniMaxM27ModelID},
+					UnmatchedHandler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}},
 				}),
 		},
 		[]VLLMParameter{
@@ -806,11 +641,11 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 		newParameters([]string{"top_p", "top_k", "min_p"},
 			ParameterRule{
 				Stage:   RequestFilterStagePostLimits,
-				Handler: SanitizeFloatParameterHandler{StripNonFinite: true},
+				Handler: ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true}},
 			},
 		),
 		newParameters([]string{"service_tier", "store", "provider", "plugins", "prompt_cache_key", "cache_key", "extra_headers", "thinking_config", "think"},
-			ParameterRule{Stage: RequestFilterStagePreValidation, Handler: StripParameterHandler{}},
+			ParameterRule{Stage: RequestFilterStagePreValidation, Handler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}}},
 		),
 		// frequency_penalty / presence_penalty share identical rules: catalog clamp
 		// [-2, 2] for all models + per-Kimi force-rewrite to 0.0 (Moonshot's K2.6 wire
@@ -818,13 +653,13 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 		newParameters([]string{"frequency_penalty", "presence_penalty"},
 			ParameterRule{
 				Stage:   RequestFilterStagePostLimits,
-				Handler: SanitizeFloatParameterHandler{StripNonFinite: true, Min: floatPointer(PenaltyMin), Max: floatPointer(PenaltyMax)},
+				Handler: ParameterHandlerAdapter{Handler: paramvalidators.SanitizeFloatParameter{StripNonFinite: true, Min: floatPointer(PenaltyMin), Max: floatPointer(PenaltyMax)}},
 			},
 			ParameterRule{
 				Stage: RequestFilterStagePostLimits,
 				Handler: ModelScopedParameterHandler{
 					Models:  []string{kimiK26ModelID},
-					Handler: ForceLiteralParameterHandler{Value: KimiK2PenaltyForcedValue, OverwriteOnly: true},
+					Handler: ParameterHandlerAdapter{Handler: paramvalidators.ForceLiteralParameter{Value: KimiK2PenaltyForcedValue, OverwriteOnly: true}},
 				},
 			},
 		),
@@ -929,33 +764,4 @@ func newParameters(names []string, rules ...ParameterRule) []VLLMParameter {
 
 func floatPointer(value float64) *float64 {
 	return &value
-}
-
-func numericJSONValueAsFloat64(value any) (float64, bool) {
-	switch v := value.(type) {
-	case float64:
-		return v, true
-	case int:
-		return float64(v), true
-	case int64:
-		return float64(v), true
-	case uint64:
-		return float64(v), true
-	case json.Number:
-		number, err := v.Float64()
-		return number, err == nil
-	case string:
-		number, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
-		return number, err == nil
-	default:
-		return 0, false
-	}
-}
-
-func numericJSONValueAsUint64FromDocument(document *ChatRequestDocument, field string) (uint64, bool) {
-	value, ok := document.Get(field)
-	if !ok {
-		return 0, false
-	}
-	return devshard.JSONNumericUint64(value)
 }

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -46,7 +46,7 @@ func TestNormalizeChatRequestDefaultsAndCapsOutputTokens(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 64, req.MaxTokens)
 	require.EqualValues(t, 64, req.MaxCompletionTokens)
-	require.NotContains(t, string(body), `"max_tokens"`)
+	require.Contains(t, string(body), `"max_tokens":64`)
 	require.Contains(t, string(body), `"max_completion_tokens":64`)
 
 	body, req, err = normalizeChatRequest([]byte(`{"max_tokens":10001,"max_completion_tokens":20000,"messages":[{"role":"user","content":"hello"}]}`))
@@ -126,7 +126,7 @@ func TestPrepareChatRequestBodyAdminAuthKeepsMaxCompletionTokensAboveDefault(t *
 	require.NoError(t, err)
 	require.EqualValues(t, 30_000, chatReq.MaxTokens)
 	require.EqualValues(t, 30_000, chatReq.MaxCompletionTokens)
-	require.NotContains(t, string(body), `"max_tokens"`)
+	require.Contains(t, string(body), `"max_tokens":30000`)
 	require.Contains(t, string(body), `"max_completion_tokens":30000`)
 }
 
@@ -280,6 +280,141 @@ func TestNormalizeChatRequestKeepsTemperatureWithinMax(t *testing.T) {
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(body, &raw))
 	require.EqualValues(t, 1.5, raw["temperature"])
+}
+
+func TestNormalizeChatRequestClampsTemperatureBelowMin(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{
+		"messages": [{"role": "user", "content": "hi"}],
+		"temperature": -1
+	}`))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 0.0, raw["temperature"])
+}
+
+func TestNormalizeChatRequestClampsMinPIntoRange(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"min_p":-0.5}`))
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 0.0, raw["min_p"])
+
+	body, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"min_p":2}`))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 1.0, raw["min_p"])
+}
+
+func TestNormalizeChatRequestTopPClampsHighRejectsNonPositive(t *testing.T) {
+	body, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"top_p":1.5}`))
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 1.0, raw["top_p"])
+
+	for _, bad := range []string{"0", "-0.2"} {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"top_p":` + bad + `}`))
+		require.Error(t, err, "top_p=%s", bad)
+		require.Contains(t, err.Error(), "top_p")
+	}
+}
+
+func TestNormalizeChatRequestRejectsNonPositiveRepetitionPenalty(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"repetition_penalty":0}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "repetition_penalty")
+
+	body, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"repetition_penalty":5}`))
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, 2.0, raw["repetition_penalty"])
+}
+
+func TestNormalizeChatRequestRejectsInvalidTopK(t *testing.T) {
+	for _, bad := range []string{"0", "-2"} {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"top_k":` + bad + `}`))
+		require.Error(t, err, "top_k=%s", bad)
+		require.Contains(t, err.Error(), "top_k")
+	}
+	for _, good := range []string{"-1", "1", "50"} {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"top_k":` + good + `}`))
+		require.NoError(t, err, "top_k=%s", good)
+	}
+}
+
+func TestNormalizeChatRequestRejectsZeroMaxTokens(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"max_tokens":0}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max_tokens")
+
+	_, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"max_completion_tokens":0}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max_completion_tokens")
+}
+
+func TestNormalizeChatRequestKimiClampsZeroMaxTokensInsteadOfRejecting(t *testing.T) {
+	body, _, err := normalizeChatRequestForModel([]byte(`{"messages":[{"role":"user","content":"hi"}],"max_tokens":0}`), kimiK26ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, kimiMaxTokensMin, raw["max_tokens"])
+}
+
+// Regression (found via e2e against the live Kimi route): a Kimi request that
+// sends only max_completion_tokens must floor it AND mirror into max_tokens, so
+// the thinking_token_budget defaulter (which derives from max_tokens) bounds
+// reasoning. Without the mirror the whole budget is spent thinking → empty content.
+func TestNormalizeChatRequestKimiMaxCompletionTokensZeroMirrorsToMaxTokens(t *testing.T) {
+	body, req, err := normalizeChatRequestForModel(
+		[]byte(`{"messages":[{"role":"user","content":"hi"}],"max_completion_tokens":0}`), kimiK26ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.EqualValues(t, kimiMaxTokensMin, raw["max_tokens"], "max_tokens mirrored + floored")
+	require.EqualValues(t, kimiMaxTokensMin, raw["max_completion_tokens"], "max_completion_tokens floored")
+	require.EqualValues(t, kimiMaxTokensMin, req.MaxTokens)
+	require.Contains(t, raw, "thinking_token_budget", "thinking budget derives from the mirrored max_tokens")
+}
+
+func TestNormalizeChatRequestRejectsNonBoolFlags(t *testing.T) {
+	for _, field := range []string{"skip_special_tokens", "detokenize", "parallel_tool_calls"} {
+		_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"` + field + `":"yes"}`))
+		require.Error(t, err, field)
+		require.Contains(t, err.Error(), field)
+	}
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"skip_special_tokens":true,"parallel_tool_calls":false}`))
+	require.NoError(t, err)
+}
+
+func TestNormalizeChatRequestRejectsNonIntStopTokenIds(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"stop_token_ids":[1,"two",3]}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stop_token_ids")
+
+	_, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"stop_token_ids":[1,2,3]}`))
+	require.NoError(t, err)
+}
+
+func TestNormalizeChatRequestRejectsNonStringStopAndBadWords(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"stop":["ok",5]}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stop")
+
+	_, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"bad_words":["ok",5]}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad_words")
+}
+
+func TestNormalizeChatRequestRejectsNonIntMinTokens(t *testing.T) {
+	_, _, err := normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"min_tokens":3.5}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "min_tokens")
+
+	_, _, err = normalizeChatRequest([]byte(`{"messages":[{"role":"user","content":"hi"}],"min_tokens":5,"max_tokens":100}`))
+	require.NoError(t, err)
 }
 
 func TestNormalizeChatRequestClampsFrequencyAndPresencePenalty(t *testing.T) {

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -2583,3 +2583,332 @@ func TestStructuredOutputsCatalogEntryRunsInPreValidationStage(t *testing.T) {
 	}
 	require.True(t, found, "structured_outputs catalog entry missing")
 }
+
+// ====================================================================
+// MiniMax-M2.7 route — see docs/chat-api/minimax-m2.7.md
+// ====================================================================
+
+func TestNormalizeForMinimaxStripsThinking(t *testing.T) {
+	body := `{"model":"MiniMaxAI/MiniMax-M2.7","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled"}}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.NotContains(t, raw, "thinking")
+	require.NotContains(t, raw, "chat_template_kwargs")
+}
+
+func TestNormalizeForMinimaxStripsEnableThinking(t *testing.T) {
+	body := `{"model":"MiniMaxAI/MiniMax-M2.7","messages":[{"role":"user","content":"hi"}],"enable_thinking":true}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.NotContains(t, raw, "enable_thinking")
+	require.NotContains(t, raw, "chat_template_kwargs")
+}
+
+func TestNormalizeForMinimaxStripsThinkingTokenBudget(t *testing.T) {
+	body := `{"model":"MiniMaxAI/MiniMax-M2.7","messages":[{"role":"user","content":"hi"}],"max_tokens":4096,"thinking_token_budget":1024}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.NotContains(t, raw, "thinking_token_budget")
+}
+
+func TestNormalizeForMinimaxDoesNotForceZeroPenalties(t *testing.T) {
+	body := `{"model":"MiniMaxAI/MiniMax-M2.7","messages":[{"role":"user","content":"hi"}],"frequency_penalty":0.5,"presence_penalty":-0.5}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.EqualValues(t, 0.5, raw["frequency_penalty"])
+	require.EqualValues(t, -0.5, raw["presence_penalty"])
+}
+
+func TestNormalizeForMinimaxStripsSafetyIdentifier(t *testing.T) {
+	body := `{"model":"MiniMaxAI/MiniMax-M2.7","messages":[{"role":"user","content":"hi"}],"safety_identifier":"abuse-track-hash"}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.NotContains(t, raw, "safety_identifier")
+}
+
+func TestNormalizeForMinimaxAcceptsToolMessageArrayShape(t *testing.T) {
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"weather in Paris?"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{}"}}]},
+			{"role":"tool","content":[{"name":"get_weather","type":"text","text":"{\"temp\":\"18\"}"}]}
+		]
+	}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	msgs, ok := raw["messages"].([]any)
+	require.True(t, ok)
+	require.Len(t, msgs, 3)
+	toolMsg := msgs[2].(map[string]any)
+	content, ok := toolMsg["content"].([]any)
+	require.True(t, ok, "M2.7 tool content must remain an array (no flatten)")
+	require.Len(t, content, 1)
+	entry := content[0].(map[string]any)
+	require.Equal(t, "get_weather", entry["name"])
+	require.Equal(t, "text", entry["type"])
+}
+
+func TestNormalizeForMinimaxStripsToolCallIDFromToolMessage(t *testing.T) {
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"call_1","content":[{"name":"fn","type":"text","text":"ok"}]}
+		]
+	}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	msgs := raw["messages"].([]any)
+	toolMsg := msgs[2].(map[string]any)
+	require.NotContains(t, toolMsg, "tool_call_id", "M2.7 strips tool_call_id silently for dual-emit compat")
+}
+
+func TestNormalizeForMinimaxDropsOrphanToolMessage(t *testing.T) {
+	// Orphan = no preceding assistant.tool_calls[] block.
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"tool","content":[{"name":"fn","type":"text","text":"strayed"}]},
+			{"role":"assistant","content":"hello"}
+		]
+	}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	msgs := raw["messages"].([]any)
+	require.Len(t, msgs, 2, "orphan tool message must be dropped")
+	require.Equal(t, "user", msgs[0].(map[string]any)["role"])
+	require.Equal(t, "assistant", msgs[1].(map[string]any)["role"])
+}
+
+func TestNormalizeForMinimaxPreservesThinkBlocksInAssistantContent(t *testing.T) {
+	// MiniMax-M2.7 interleaved-thinking constraint: <think>...</think> in
+	// assistant content history must round-trip byte-identical.
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"first question"},
+			{"role":"assistant","content":"<think>let me reason about this</think> here is the answer"},
+			{"role":"user","content":"follow up"}
+		]
+	}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	msgs := raw["messages"].([]any)
+	asst := msgs[1].(map[string]any)
+	require.Equal(t, "<think>let me reason about this</think> here is the answer", asst["content"])
+}
+
+func TestValidateForMinimaxRejectsBareStringToolContent(t *testing.T) {
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","content":"bare string instead of array"}
+		]
+	}`
+	_, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "content")
+	require.Equal(t, http.StatusBadRequest, chatRequestErrorStatus(err, http.StatusInternalServerError))
+}
+
+func TestValidateForMinimaxRejectsToolEntryMissingName(t *testing.T) {
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","content":[{"type":"text","text":"missing name"}]}
+		]
+	}`
+	_, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name")
+}
+
+func TestValidateForMinimaxRejectsToolEntryWrongType(t *testing.T) {
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","content":[{"name":"fn","type":"image_url","text":"x"}]}
+		]
+	}`
+	_, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "type")
+}
+
+func TestValidateForMinimaxRejectsExtraKeysInToolEntry(t *testing.T) {
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","content":[{"name":"fn","type":"text","text":"ok","unexpected":true}]}
+		]
+	}`
+	_, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported key")
+}
+
+func TestNormalizeForOpenAIRouteStillRequiresToolCallID(t *testing.T) {
+	// Sanity: the catalog default policy keeps OpenAI-compat behavior on non-M2.7 routes.
+	body := `{
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","content":[{"name":"fn","type":"text","text":"ok"}]}
+		]
+	}`
+	_, _, err := normalizeChatRequest([]byte(body))
+	require.Error(t, err, "OpenAI route requires tool_call_id; array-content tool message should fail validation")
+}
+
+func TestNormalizeForMinimaxPassesReasoningSplitFromExtraBody(t *testing.T) {
+	// extra_body.reasoning_split is a MiniMax native extension; gateway lifts it
+	// to top-level (universal extra_body unwrap) and forwards to vLLM verbatim.
+	body := `{"model":"MiniMaxAI/MiniMax-M2.7","messages":[{"role":"user","content":"hi"}],"extra_body":{"reasoning_split":true}}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.NotContains(t, raw, "extra_body")
+	require.Equal(t, true, raw["reasoning_split"], "reasoning_split must survive the closed-allowlist check on MiniMax")
+}
+
+func TestNormalizeForMinimaxPassesReasoningSplitTopLevel(t *testing.T) {
+	body := `{"model":"MiniMaxAI/MiniMax-M2.7","messages":[{"role":"user","content":"hi"}],"reasoning_split":false}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.Equal(t, false, raw["reasoning_split"])
+}
+
+func TestNormalizeStripsReasoningSplitOnDefaultRoute(t *testing.T) {
+	// Kimi/Qwen vLLM servers do not know reasoning_split; the gateway strips it so
+	// stray clients don't trip an upstream parser error. Assert it is actually gone
+	// on both the empty default route and an explicit non-MiniMax (Kimi) route.
+	for _, routedModel := range []string{"", kimiK26ModelID} {
+		body := `{"messages":[{"role":"user","content":"hi"}],"reasoning_split":true}`
+		out, _, err := normalizeChatRequestForModel([]byte(body), routedModel)
+		require.NoError(t, err)
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(out, &raw))
+		require.NotContains(t, raw, "reasoning_split", "route=%q", routedModel)
+	}
+}
+
+func TestNormalizeForMinimaxPreservesReasoningDetailsOnAssistantTurn(t *testing.T) {
+	// MiniMax-M2.7 emits reasoning_details[] on the response when reasoning_split=true;
+	// clients round-trip it back into history. Gateway MUST NOT strip — stripping
+	// breaks interleaved-thinking continuity.
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"final answer","reasoning_details":[{"type":"text","text":"step 1"},{"type":"text","text":"step 2"}]}
+		]
+	}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	msgs := raw["messages"].([]any)
+	asst := msgs[1].(map[string]any)
+	details, ok := asst["reasoning_details"].([]any)
+	require.True(t, ok, "reasoning_details must round-trip on assistant turn")
+	require.Len(t, details, 2)
+}
+
+func TestValidateForMinimaxRejectsToolMessageExceedingMaxEntries(t *testing.T) {
+	entries := make([]string, 0, MinimaxToolMessageMaxEntries+1)
+	for i := 0; i < MinimaxToolMessageMaxEntries+1; i++ {
+		entries = append(entries, `{"name":"fn","type":"text","text":"r"}`)
+	}
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","content":[` + strings.Join(entries, ",") + `]}
+		]
+	}`
+	_, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds limit")
+}
+
+func TestValidateForMinimaxRejectsToolMessageNameTooLong(t *testing.T) {
+	tooLongName := strings.Repeat("x", MinimaxToolMessageNameMaxLen+1)
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","content":[{"name":"` + tooLongName + `","type":"text","text":"ok"}]}
+		]
+	}`
+	_, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name length")
+}
+
+func TestValidateForMinimaxRejectsToolMessageTextTooLarge(t *testing.T) {
+	tooLongText := strings.Repeat("a", MinimaxToolMessageTextMaxSize+1)
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","content":[{"name":"fn","type":"text","text":"` + tooLongText + `"}]}
+		]
+	}`
+	_, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "text size")
+}
+
+func TestNormalizeForMinimaxStripsToolsFunctionStrict(t *testing.T) {
+	// ToolsValidator silently strips function.strict on every route; confirm it
+	// holds on the MiniMax route (vLLM minimax_m2 parser ignores the field).
+	body := `{
+		"model":"MiniMaxAI/MiniMax-M2.7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"type":"function","function":{"name":"fn","strict":true,"parameters":{"type":"object","properties":{}}}}]
+	}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), miniMaxM27ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	tools, ok := raw["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	fn := tools[0].(map[string]any)["function"].(map[string]any)
+	require.NotContains(t, fn, "strict")
+}

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -203,6 +203,13 @@ func TestNormalizeChatRequestCapsChoices(t *testing.T) {
 	require.NotContains(t, string(body), `"n"`)
 }
 
+func TestNormalizeChatRequestClampsZeroChoicesToOne(t *testing.T) {
+	body, req, err := normalizeChatRequest([]byte(`{"n":0,"messages":[{"role":"user","content":"hi"}]}`))
+	require.NoError(t, err)
+	require.EqualValues(t, 1, req.N)
+	require.Contains(t, string(body), `"n":1`)
+}
+
 func TestNormalizeChatRequestClampsMinTokensAboveEffectiveMax(t *testing.T) {
 	oldDefault := DefaultRequestMaxTokens
 	oldCap := RequestMaxTokensCap

--- a/devshard/cmd/devshardctl/sse_fixtures_test.go
+++ b/devshard/cmd/devshardctl/sse_fixtures_test.go
@@ -1,0 +1,439 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"math/rand/v2"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Minimal vLLM-shaped SSE fixtures for raceWriter classification tests.
+const sseContentStream = "" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"Qwen/Qwen3","choices":[],"usage":{"prompt_tokens":3,"total_tokens":5,"completion_tokens":2}}` + "\n\n" +
+	`data: [DONE]` + "\n\n"
+
+const sseToolCallsStream = "" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call-1","type":"function","index":0,"function":{"name":"get_weather"}}]},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":\"sf\"}"}}]},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":""},"finish_reason":"tool_calls"}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":2,"model":"Qwen/Qwen3","choices":[],"usage":{"prompt_tokens":20,"total_tokens":40,"completion_tokens":20}}` + "\n\n" +
+	`data: [DONE]` + "\n\n"
+
+var sseEmbeddedFixtures = []struct {
+	name       string
+	body       string
+	wantSource string
+}{
+	{"delta.content", sseContentStream, "delta.content"},
+	{"delta.tool_calls", sseToolCallsStream, "delta.tool_calls"},
+}
+
+// Stream whose final content event carries no trailing newline (truncated
+// upstream, mid-event proxy close). Write only classifies up to the last '\n',
+// so the "ok" event lands in classifyPartial and is recovered by flushClassify.
+const sseNewlineLessFinalContent = "" +
+	`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","created":3,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-3","object":"chat.completion.chunk","created":3,"model":"Qwen/Qwen3","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`
+
+// Same shape, but the newline-less final event is a non-retriable error.
+const sseNewlineLessFinalError = "" +
+	`data: {"error":{"message":"boom","type":"server_error","code":"internal"}}`
+
+func TestSseBlobClassifierNotEmpty(t *testing.T) {
+	for _, fx := range sseEmbeddedFixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			src, ok := sseChunkContentSource([]byte(fx.body))
+			require.True(t, ok, "blob classifier returned EMPTY")
+			require.Equal(t, fx.wantSource, src)
+		})
+	}
+}
+
+// Regression: classifier must work for any chunk size, including sub-event.
+func TestSseRaceWriterAllChunkSizes(t *testing.T) {
+	chunkSizes := []int{1, 64, 256, 1024, 4096, 8192}
+	for _, fx := range sseEmbeddedFixtures {
+		for _, sz := range chunkSizes {
+			t.Run(fx.name+"/chunk="+strconv.Itoa(sz), func(t *testing.T) {
+				t.Parallel()
+				inf := mkRaceWriterInflight(t)
+				rw := mkRaceWriter(t, inf)
+				body := []byte(fx.body)
+				for i := 0; i < len(body); i += sz {
+					end := i + sz
+					if end > len(body) {
+						end = len(body)
+					}
+					_, err := rw.Write(body[i:end])
+					require.NoError(t, err)
+				}
+				require.False(t, isEmptyStreamAttempt(inf),
+					"classified empty (cc=%d oc=%d)",
+					inf.contentChunks.Load(), inf.outputChunks.Load())
+				require.Equal(t, fx.wantSource, inf.contentSource)
+			})
+		}
+	}
+}
+
+// Per-attempt cap: oversized newline-less stream is dropped, global counter balanced.
+func TestSseRaceWriterClassifyCapDrops(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write(bytes.Repeat([]byte("x"), maxClassifyPartial+1))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(inf.classifyPartial))
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// replaceClassify drops the trailing fragment when it exceeds the per-attempt cap.
+func TestSseRaceWriterReplaceClassifyPerAttemptCapDrops(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	chunk := append([]byte("\n"), bytes.Repeat([]byte("x"), maxClassifyPartial+1)...)
+	_, err := rw.Write(chunk)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(inf.classifyPartial))
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// growClassify drops a newline-less chunk when the global cap is already reached.
+func TestSseRaceWriterGrowClassifyGlobalCapDrops(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	defer classifyPartialBytes.Store(before)
+	classifyPartialBytes.Store(maxClassifyPartialGlobal)
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write([]byte("data: partial-no-newline"))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(inf.classifyPartial))
+	require.Equal(t, maxClassifyPartialGlobal, classifyPartialBytes.Load())
+}
+
+// replaceClassify drops the trailing fragment when the global cap is reached.
+func TestSseRaceWriterReplaceClassifyGlobalCapDrops(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	defer classifyPartialBytes.Store(before)
+	classifyPartialBytes.Store(maxClassifyPartialGlobal)
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write([]byte("\ntail"))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(inf.classifyPartial))
+	require.Equal(t, maxClassifyPartialGlobal, classifyPartialBytes.Load())
+}
+
+// Dropping the buffer must free its backing array, not just shrink len — else
+// real memory outlives the gauge and can exceed the global cap.
+func TestSseRaceWriterDropReleasesBackingArray(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write(bytes.Repeat([]byte("x"), maxClassifyPartial-10))
+	require.NoError(t, err)
+	require.Greater(t, cap(inf.classifyPartial), 0)
+	_, err = rw.Write(bytes.Repeat([]byte("x"), 20))
+	require.NoError(t, err)
+	require.Equal(t, 0, cap(inf.classifyPartial), "drop must release the backing array")
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// releaseClassifyPartial frees a len-0-but-large-cap buffer (the send-goroutine defer after a drop) and leaves the gauge unchanged when len is already 0.
+func TestReleaseClassifyPartialFreesLenZeroBuffer(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	inf.classifyPartial = make([]byte, 0, maxClassifyPartial)
+	inf.releaseClassifyPartial()
+	require.Nil(t, inf.classifyPartial)
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// Realistic transport shape: arbitrary chunk boundaries from TLS/proxy flushes.
+func TestSseRaceWriterRandomChunking(t *testing.T) {
+	for fxIndex, fx := range sseEmbeddedFixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			t.Parallel()
+			// Own rng per subtest: *rand.Rand is not safe for concurrent use.
+			rng := rand.New(rand.NewPCG(42, uint64(fxIndex)))
+			inf := mkRaceWriterInflight(t)
+			rw := mkRaceWriter(t, inf)
+			body := []byte(fx.body)
+			for i := 0; i < len(body); {
+				sz := 1 + rng.IntN(64)
+				end := i + sz
+				if end > len(body) {
+					end = len(body)
+				}
+				_, err := rw.Write(body[i:end])
+				require.NoError(t, err)
+				i = end
+			}
+			require.False(t, isEmptyStreamAttempt(inf),
+				"classified empty (cc=%d oc=%d)",
+				inf.contentChunks.Load(), inf.outputChunks.Load())
+			require.Equal(t, fx.wantSource, inf.contentSource)
+		})
+	}
+}
+
+// Regression: a content event delivered as the final, newline-less write is
+// stashed in classifyPartial during Write and would leave the attempt looking
+// empty. flushClassify (run once the upstream stream ends) must recover it.
+func TestSseRaceWriterFlushRecoversNewlineLessContent(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalContent))
+	require.NoError(t, err)
+	// Before the flush the trailing content event is unclassified.
+	require.True(t, isEmptyStreamAttempt(inf),
+		"precondition: newline-less final event should be unclassified until flush")
+
+	rw.flushClassify()
+
+	require.False(t, isEmptyStreamAttempt(inf),
+		"flush must classify the newline-less final content event")
+	require.Equal(t, "delta.content", inf.contentSource)
+	require.Equal(t, 0, len(inf.classifyPartial), "flush must release the buffer")
+}
+
+// Regression: flushClassifyAndCheckEmpty must flush the buffered final event before reading contentChunks (a prior deferred flush ran after the decision, misclassifying content as empty).
+func TestFlushClassifyAndCheckEmptyFlushesBeforeDeciding(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalContent))
+	require.NoError(t, err)
+	require.True(t, isEmptyStreamAttempt(inf),
+		"precondition: unflushed newline-less final event looks empty")
+
+	require.False(t, rw.flushClassifyAndCheckEmpty(),
+		"must flush the buffered final content before the empty-stream decision")
+	require.Equal(t, "delta.content", inf.contentSource)
+}
+
+// Regression: a newline-less final error event must resolve to an error stream, not empty, through the same flush-before-decide path.
+func TestFlushClassifyAndCheckEmptyFinalErrorIsNotEmpty(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalError))
+	require.NoError(t, err)
+
+	require.False(t, rw.flushClassifyAndCheckEmpty(),
+		"final error event must not be classified as empty_stream")
+	require.True(t, isErrorStreamAttempt(inf))
+}
+
+// Regression: the same recovery must apply to a newline-less final error event
+// so the attempt is classified as an error stream, not an empty one.
+func TestSseRaceWriterFlushRecoversNewlineLessError(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalError))
+	require.NoError(t, err)
+
+	rw.flushClassify()
+
+	require.True(t, isErrorStreamAttempt(inf), "flush must classify the final error event")
+	require.False(t, isEmptyStreamAttempt(inf))
+	require.Equal(t, "error.server_error", inf.errorSource)
+}
+
+// flushClassify is a no-op when nothing was buffered (normal newline-terminated
+// stream) and stays balanced against the global counter.
+func TestSseRaceWriterFlushNoBufferedTail(t *testing.T) {
+	before := classifyPartialBytes.Load()
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseContentStream))
+	require.NoError(t, err)
+	require.False(t, isEmptyStreamAttempt(inf))
+	source := inf.contentSource
+	contentChunks := inf.contentChunks.Load()
+
+	rw.flushClassify()
+
+	require.Equal(t, source, inf.contentSource, "flush must not change an already-classified attempt")
+	require.Equal(t, contentChunks, inf.contentChunks.Load(), "flush must not double-count content")
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// A probe attempt never classifies content, so flushClassify must leave it untouched.
+func TestSseRaceWriterFlushProbeNoop(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	inf.probe = true
+	rw := mkRaceWriter(t, inf)
+
+	_, err := rw.Write([]byte(sseNewlineLessFinalContent))
+	require.NoError(t, err)
+
+	rw.flushClassify()
+
+	require.Equal(t, int64(0), inf.contentChunks.Load(), "probe flush must not count content")
+	require.Equal(t, "", inf.contentSource)
+}
+
+// On a cap drop, the raw write chunk is still classified best-effort rather than
+// silently skipped — a complete content line survives even when it can't buffer.
+func TestSseRaceWriterGracefulDegradationOnCapDrop(t *testing.T) {
+	inf := mkRaceWriterInflight(t)
+	rw := mkRaceWriter(t, inf)
+	_, err := rw.Write(bytes.Repeat([]byte("x"), maxClassifyPartial-10))
+	require.NoError(t, err)
+	_, err = rw.Write([]byte(`data: {"choices":[{"delta":{"content":"ok"}}]}`))
+	require.NoError(t, err)
+	require.False(t, isEmptyStreamAttempt(inf), "capped content chunk must still classify")
+	require.Equal(t, "delta.content", inf.contentSource)
+}
+
+// A hostile participant that fills its own budget must not starve another
+// attempt from a different participant sharing the global pool.
+func TestSseRaceWriterParticipantCapIsolatesParticipants(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	maxClassifyPartial = 100
+	maxClassifyPartialParticipant = 150
+	maxClassifyPartialGlobal = 1 << 30
+
+	hostile := &atomic.Int64{}
+	honest := &atomic.Int64{}
+	infHostile := mkRaceWriterInflight(t)
+	infHostile.participantClassifyBytes = hostile
+	infHonest := mkRaceWriterInflight(t)
+	infHonest.participantClassifyBytes = honest
+
+	_, err := mkRaceWriter(t, infHostile).Write(bytes.Repeat([]byte("x"), 100))
+	require.NoError(t, err)
+	require.Equal(t, int64(100), hostile.Load())
+
+	// The honest participant still has its full budget available.
+	_, err = mkRaceWriter(t, infHonest).Write(bytes.Repeat([]byte("y"), 100))
+	require.NoError(t, err)
+	require.Equal(t, 100, len(infHonest.classifyPartial), "honest attempt must not be starved")
+	require.Equal(t, int64(100), honest.Load())
+}
+
+// The same participant is capped across concurrent attempts sharing its counter.
+func TestSseRaceWriterParticipantCapDropsOverBudget(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	maxClassifyPartial = 100
+	maxClassifyPartialParticipant = 150
+	maxClassifyPartialGlobal = 1 << 30
+
+	shared := &atomic.Int64{}
+	first := mkRaceWriterInflight(t)
+	first.participantClassifyBytes = shared
+	second := mkRaceWriterInflight(t)
+	second.participantClassifyBytes = shared
+
+	_, err := mkRaceWriter(t, first).Write(bytes.Repeat([]byte("x"), 100))
+	require.NoError(t, err)
+	_, err = mkRaceWriter(t, second).Write(bytes.Repeat([]byte("y"), 100))
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(second.classifyPartial), "participant cap must drop the over-budget attempt")
+	require.Equal(t, int64(100), shared.Load(), "over-budget bytes rolled back")
+}
+
+// A global-cap drop must roll back the participant counter it already charged.
+func TestSseRaceWriterGlobalCapRollsBackParticipant(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	maxClassifyPartial = 1000
+	maxClassifyPartialParticipant = 1000
+	maxClassifyPartialGlobal = 50
+
+	participant := &atomic.Int64{}
+	inf := mkRaceWriterInflight(t)
+	inf.participantClassifyBytes = participant
+	before := classifyPartialBytes.Load()
+
+	_, err := mkRaceWriter(t, inf).Write(bytes.Repeat([]byte("x"), 100))
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(inf.classifyPartial), "global cap drops the attempt")
+	require.Equal(t, int64(0), participant.Load(), "participant counter rolled back")
+	require.Equal(t, before, classifyPartialBytes.Load())
+}
+
+// Releasing the buffer decrements both the global and participant counters.
+func TestReleaseClassifyPartialDecrementsParticipant(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	maxClassifyPartial = 1000
+	maxClassifyPartialParticipant = 1000
+	maxClassifyPartialGlobal = 1 << 30
+
+	participant := &atomic.Int64{}
+	inf := mkRaceWriterInflight(t)
+	inf.participantClassifyBytes = participant
+
+	_, err := mkRaceWriter(t, inf).Write(bytes.Repeat([]byte("x"), 100))
+	require.NoError(t, err)
+	require.Equal(t, int64(100), participant.Load())
+
+	inf.releaseClassifyPartial()
+
+	require.Equal(t, int64(0), participant.Load(), "release decrements participant counter")
+	require.Nil(t, inf.classifyPartial)
+}
+
+func TestConfigureClassifyCapsFromEnv(t *testing.T) {
+	restore := saveClassifyCaps()
+	defer restore()
+	t.Setenv("GATEWAY_CLASSIFY_MAX_ATTEMPT_BYTES", "2048")
+	t.Setenv("GATEWAY_CLASSIFY_MAX_PARTICIPANT_BYTES", "4096")
+	t.Setenv("GATEWAY_CLASSIFY_MAX_GLOBAL_BYTES", "8192")
+
+	configureClassifyCapsFromEnv()
+
+	require.Equal(t, 2048, maxClassifyPartial)
+	require.Equal(t, int64(4096), maxClassifyPartialParticipant)
+	require.Equal(t, int64(8192), maxClassifyPartialGlobal)
+}
+
+// saveClassifyCaps snapshots the tunable caps and returns a restore func.
+func saveClassifyCaps() func() {
+	attempt, participant, global := maxClassifyPartial, maxClassifyPartialParticipant, maxClassifyPartialGlobal
+	return func() {
+		maxClassifyPartial = attempt
+		maxClassifyPartialParticipant = participant
+		maxClassifyPartialGlobal = global
+	}
+}
+
+func mkRaceWriterInflight(t testing.TB) *inflight {
+	t.Helper()
+	return &inflight{
+		hostID:       "fixture-host",
+		escrowID:     "fixture-escrow",
+		nonce:        1,
+		done:         make(chan struct{}),
+		receiptCh:    make(chan struct{}),
+		firstTokenCh: make(chan struct{}),
+		receiptTime:  time.Now(),
+	}
+}
+
+func mkRaceWriter(t testing.TB, inf *inflight) *raceWriter {
+	t.Helper()
+	ctx := context.Background()
+	var sink bytes.Buffer
+	rg := newRaceGroup(ctx, ctx, inf.escrowID, &sink)
+	return &raceWriter{group: rg, nonce: inf.nonce, inf: inf}
+}

--- a/devshard/cmd/devshardctl/testutil/testutil.go
+++ b/devshard/cmd/devshardctl/testutil/testutil.go
@@ -1,0 +1,20 @@
+// Package testutil holds small assertion helpers shared across devshardctl test
+// packages. It imports "testing" on purpose: it is test-support code (like
+// net/http/httptest) and is only ever linked into _test binaries that import it.
+package testutil
+
+import "testing"
+
+// FloatPtr returns a pointer to v, for building optional float parameters in tests.
+func FloatPtr(v float64) *float64 { return &v }
+
+// MapAt returns items[index] as a map[string]any, failing the test if the element
+// is missing or not a map.
+func MapAt(t *testing.T, items []any, index int) map[string]any {
+	t.Helper()
+	value, ok := items[index].(map[string]any)
+	if !ok {
+		t.Fatalf("items[%d] is not a map: %T", index, items[index])
+	}
+	return value
+}

--- a/devshard/json.go
+++ b/devshard/json.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 )
 
 // CanonicalizeJSON returns a deterministic JSON encoding with sorted keys and
@@ -39,6 +41,31 @@ func CanonicalPromptHash(prompt []byte) ([]byte, error) {
 	}
 	h := sha256.Sum256(canonical)
 	return h[:], nil
+}
+
+// JSONNumericFloat64 converts a JSON-decoded numeric value to float64. Accepts
+// float64, int / int64 / uint64, json.Number, and string (trimmed and parsed)
+// because some clients serialize numerics as strings for fields like
+// temperature / top_p.
+func JSONNumericFloat64(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case json.Number:
+		number, err := v.Float64()
+		return number, err == nil
+	case string:
+		number, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		return number, err == nil
+	default:
+		return 0, false
+	}
 }
 
 // JSONNumericUint64 converts a JSON-decoded numeric value to uint64. Accepts

--- a/devshard/json_test.go
+++ b/devshard/json_test.go
@@ -135,6 +135,44 @@ func TestCanonicalPromptHash_StoredPayloadMatchesDirectHash(t *testing.T) {
 		"validator sha256(stored_canonical) must equal user CanonicalPromptHash(original)")
 }
 
+func TestJSONNumericFloat64(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want float64
+		ok   bool
+	}{
+		{"float64_positive", 1.5, 1.5, true},
+		{"float64_zero", float64(0), 0, true},
+		{"float64_negative", -2.5, -2.5, true},
+		{"int_positive", 7, 7, true},
+		{"int_negative", -3, -3, true},
+		{"int64_positive", int64(42), 42, true},
+		{"uint64", uint64(99), 99, true},
+		{"json_Number_float", json.Number("3.14"), 3.14, true},
+		{"json_Number_integer", json.Number("42"), 42, true},
+		{"json_Number_negative", json.Number("-1.5"), -1.5, true},
+		{"json_Number_garbage", json.Number("abc"), 0, false},
+		{"string_float", "1.5", 1.5, true},
+		{"string_integer", "100", 100, true},
+		{"string_trimmed", "  2.5  ", 2.5, true},
+		{"string_negative", "-0.25", -0.25, true},
+		{"string_invalid", "abc", 0, false},
+		{"string_empty", "", 0, false},
+		{"bool", true, 0, false},
+		{"nil", nil, 0, false},
+		{"slice", []int{1, 2}, 0, false},
+		{"map", map[string]int{"x": 1}, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := JSONNumericFloat64(c.in)
+			require.Equal(t, c.ok, ok, "ok mismatch")
+			require.Equal(t, c.want, got, "value mismatch")
+		})
+	}
+}
+
 func TestJSONNumericUint64(t *testing.T) {
 	cases := []struct {
 		name string

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -374,10 +373,6 @@ func (sm *StateMachine) logAutoSealDiagnosticLocked(
 	if len(candidates) == 0 && len(sealed) == 0 {
 		return
 	}
-	candidatesJSON, err := json.Marshal(candidates)
-	if err != nil {
-		candidatesJSON = []byte(fmt.Sprintf("marshal error: %v", err))
-	}
 	args := []any{
 		"subsystem", side,
 		"diagnostic", "auto_seal",
@@ -387,9 +382,9 @@ func (sm *StateMachine) logAutoSealDiagnosticLocked(
 		"inference_seal_grace_nonces", sealGraceNonces,
 		"inference_seal_grace_seconds", graceSeconds,
 		"state_clock_confirmed_at", stateClock,
-		"candidates", string(candidatesJSON),
 		"sealed_ids", sealed,
 		"sealed_count", len(sealed),
+		"candidates_count", len(candidates),
 		"live_inferences_count", len(sm.state.Inferences),
 	}
 	if clockWin.Known {

--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -251,7 +251,7 @@ func (c *HTTPClient) Send(ctx context.Context, req host.HostRequest, stream io.W
 	contentType := resp.Header.Get("Content-Type")
 	if strings.HasPrefix(contentType, "text/event-stream") {
 		cr := &countingReader{r: resp.Body}
-		result, err := c.parseSSEResponse(cr, stream, receiptHandler)
+		result, err := c.parseSSEResponse(ctx, cr, stream, receiptHandler)
 		if result != nil {
 			result.StreamBytesRead = cr.n
 		}
@@ -285,7 +285,7 @@ func (c *HTTPClient) Send(ctx context.Context, req host.HostRequest, stream io.W
 //     ([DONE] or devshard_receipt) from a clean EOF that arrives *before* one.
 //     bufio.Scanner squashes io.EOF into a nil error, so the caller cannot tell
 //     a successful completion from a peer / middlebox closing the body early.
-func (c *HTTPClient) parseSSEResponse(r io.Reader, stream io.Writer, receiptHandler func()) (*host.HostResponse, error) {
+func (c *HTTPClient) parseSSEResponse(ctx context.Context, r io.Reader, stream io.Writer, receiptHandler func()) (*host.HostResponse, error) {
 	br := bufio.NewReaderSize(r, 64<<10)
 	var result host.HostResponse
 	var writeErrLogged bool
@@ -300,6 +300,16 @@ func (c *HTTPClient) parseSSEResponse(r io.Reader, stream io.Writer, receiptHand
 		}
 		if readErr != nil {
 			if readErr == io.EOF {
+				// A cancelled context (client disconnect, race resolved, drain)
+				// can surface as a clean EOF once the peer closes the body after
+				// we abort the request. The receipt event sets sawTerminator
+				// early, so without this check a cancelled stream that never
+				// carried content would be reported as a successful empty
+				// response and wrongly scored against the host. Report the
+				// cancellation as the error it is.
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return &result, fmt.Errorf("read SSE stream: %w", ctxErr)
+				}
 				if !sawTerminator {
 					return &result, ErrSSEStreamTruncated
 				}
@@ -700,6 +710,12 @@ func (c *HTTPClient) observeResultWithBody(path string, statusCode int, body str
 
 func (c *HTTPClient) observeTransportFailure(path string, err error) {
 	if c == nil || c.config.Admission == nil || strings.TrimSpace(c.config.ParticipantKey) == "" {
+		return
+	}
+	// A cancelled request context is our own signal (client disconnect, race
+	// resolved, drain), not a fault of the host. Attributing it as a transport
+	// failure would quarantine a healthy host, so skip it.
+	if errors.Is(err, context.Canceled) {
 		return
 	}
 	c.config.Admission.ObserveTransportFailure(c.config.ParticipantKey, path, err)

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,7 +195,7 @@ func TestParseSSE_PartialResult(t *testing.T) {
 	// Use a reader that returns the data then an error (simulating connection drop).
 	r := &truncatedReader{data: []byte(sseData)}
 
-	result, err := client.parseSSEResponse(r, nil, nil)
+	result, err := client.parseSSEResponse(context.Background(), r, nil, nil)
 	require.Error(t, err, "should return error from broken stream")
 	require.NotNil(t, result, "should return partial result")
 	require.Equal(t, uint64(1), result.Nonce)
@@ -349,4 +350,58 @@ type lineCollector func(line string)
 func (c lineCollector) Write(p []byte) (int, error) {
 	c(string(p))
 	return len(p), nil
+}
+
+const receiptOnlySSE = "data: {\"devshard_receipt\":{\"state_sig\":\"c2ln\",\"state_hash\":\"aGFzaA==\",\"nonce\":1,\"receipt\":\"cmVjZWlwdA==\",\"confirmed_at\":1000}}\n\n"
+
+func TestParseSSE_CancelledContextReportsCancellation(t *testing.T) {
+	// A cancelled attempt (client disconnect, race resolved, drain) can see the
+	// peer close with a clean EOF after the receipt already arrived. The receipt
+	// sets the terminator, so without a context check this would read as a
+	// successful empty response and be scored against the host. It must instead
+	// surface as the cancellation it is.
+	client := &HTTPClient{config: DefaultClientConfig()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := client.parseSSEResponse(ctx, strings.NewReader(receiptOnlySSE), nil, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Receipt, "receipt should still be extracted from the partial stream")
+}
+
+func TestParseSSE_ReceiptThenCleanEOFSucceeds(t *testing.T) {
+	// Without cancellation, a receipt-terminated stream that closes cleanly is a
+	// successful completion, even when it carried no content. This guards against
+	// the context check regressing the normal empty-but-complete path.
+	client := &HTTPClient{config: DefaultClientConfig()}
+
+	result, err := client.parseSSEResponse(context.Background(), strings.NewReader(receiptOnlySSE), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, uint64(1), result.Nonce)
+	require.NotNil(t, result.Receipt)
+}
+
+func TestObserveTransportFailure_IgnoresContextCancellation(t *testing.T) {
+	admission := &stubAdmissionController{}
+	client := &HTTPClient{config: DefaultClientConfig()}
+	client.config.ParticipantKey = "shared-host"
+	client.config.Admission = admission
+
+	const path = "/sessions/escrow-1/chat/completions"
+
+	// Our own cancellation must never quarantine the host, whether it arrives
+	// bare or wrapped.
+	client.observeTransportFailure(path, context.Canceled)
+	client.observeTransportFailure(path, fmt.Errorf("POST %s: %w", path, context.Canceled))
+	require.Empty(t, admission.observed, "cancellation must not be reported as a transport failure")
+
+	// A genuine transport error is still reported.
+	client.observeTransportFailure(path, errors.New("connection refused"))
+	require.Len(t, admission.observed, 1)
+	require.Contains(t, admission.observed[0], "shared-host")
+	require.Contains(t, admission.observed[0], "transport")
 }

--- a/devshard/types/domain.go
+++ b/devshard/types/domain.go
@@ -84,6 +84,8 @@ type ProtocolVersion string
 
 const (
 	ProtocolV1 ProtocolVersion = "1"
+	ProtocolV2 ProtocolVersion = "2"
+	ProtocolV3 ProtocolVersion = "3"
 )
 
 // ParseProtocolVersion parses a string into a ProtocolVersion.
@@ -92,6 +94,10 @@ func ParseProtocolVersion(s string) (ProtocolVersion, error) {
 	switch strings.TrimSpace(s) {
 	case "", string(ProtocolV1), "v1":
 		return ProtocolV1, nil
+	case string(ProtocolV2), "v2":
+		return ProtocolV2, nil
+	case string(ProtocolV3), "v3":
+		return ProtocolV3, nil
 	default:
 		return "", fmt.Errorf("unknown protocol version %q", s)
 	}

--- a/devshard/types/domain_test.go
+++ b/devshard/types/domain_test.go
@@ -25,6 +25,26 @@ func TestParseProtocolVersion_AcceptsRouteStyleV1(t *testing.T) {
 	}
 }
 
+func TestParseProtocolVersion_AcceptsRouteStyleV2(t *testing.T) {
+	got, err := ParseProtocolVersion("v2")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != ProtocolV2 {
+		t.Fatalf("expected v2 to normalize to %s, got %s", ProtocolV2, got)
+	}
+}
+
+func TestParseProtocolVersion_AcceptsRouteStyleV3(t *testing.T) {
+	got, err := ParseProtocolVersion("v3")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != ProtocolV3 {
+		t.Fatalf("expected v3 to normalize to %s, got %s", ProtocolV3, got)
+	}
+}
+
 func TestParseProtocolVersion_RejectsOldProtocol(t *testing.T) {
 	if _, err := ParseProtocolVersion("0.2.11"); err == nil {
 		t.Fatal("expected old protocol to be rejected")

--- a/devshard/user/session_close_test.go
+++ b/devshard/user/session_close_test.go
@@ -33,11 +33,23 @@ func (s *closeCountingStore) GetSignatures(string, uint64) (map[uint32][]byte, e
 func (s *closeCountingStore) GetSessionMeta(string) (*storage.SessionMeta, error) {
 	return nil, storage.ErrSessionNotFound
 }
-func (s *closeCountingStore) MarkFinalized(string, uint64) error { return nil }
-func (s *closeCountingStore) LastFinalized(string) (uint64, error) { return 0, nil }
+func (s *closeCountingStore) MarkFinalized(string, uint64) error        { return nil }
+func (s *closeCountingStore) LastFinalized(string) (uint64, error)      { return 0, nil }
 func (s *closeCountingStore) SaveSnapshot(string, uint64, []byte) error { return nil }
 func (s *closeCountingStore) LoadSnapshot(string) (uint64, []byte, error) {
 	return 0, nil, storage.ErrSnapshotNotFound
+}
+func (s *closeCountingStore) InsertSealedInference(string, storage.InferenceRow) error { return nil }
+func (s *closeCountingStore) GetSealedInference(string, uint64) (storage.InferenceRow, bool, error) {
+	return storage.InferenceRow{}, false, nil
+}
+func (s *closeCountingStore) DeleteSealedInferences(string) error { return nil }
+func (s *closeCountingStore) RecordValidationsAppliedOnce(string, []storage.ValidationObsEntry) error {
+	return nil
+}
+func (s *closeCountingStore) DrainInferenceValidationObs(string, uint64) error { return nil }
+func (s *closeCountingStore) GetValidationObservability(string) ([]storage.SlotValidationObs, error) {
+	return nil, nil
 }
 func (s *closeCountingStore) PruneEpoch(uint64) error { return nil }
 func (s *closeCountingStore) Close() error {

--- a/devshard/user/session_close_test.go
+++ b/devshard/user/session_close_test.go
@@ -1,0 +1,58 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/storage"
+	"devshard/types"
+)
+
+// closeCountingStore is a storage.Storage that records how many times Close is
+// called. Every other method is an inert stub: this fake exists only to prove
+// that Session.Close releases the underlying store, which is the resource the
+// per-runtime memory leak was failing to free.
+type closeCountingStore struct {
+	closeCalls int
+}
+
+func (s *closeCountingStore) CreateSession(storage.CreateSessionParams) error { return nil }
+func (s *closeCountingStore) MarkSettled(string) error                        { return nil }
+func (s *closeCountingStore) ListActiveSessions() ([]storage.ActiveSession, error) {
+	return nil, nil
+}
+func (s *closeCountingStore) AppendDiff(string, types.DiffRecord) error { return nil }
+func (s *closeCountingStore) GetDiffs(string, uint64, uint64) ([]types.DiffRecord, error) {
+	return nil, nil
+}
+func (s *closeCountingStore) AddSignature(string, uint64, uint32, []byte) error { return nil }
+func (s *closeCountingStore) GetSignatures(string, uint64) (map[uint32][]byte, error) {
+	return nil, nil
+}
+func (s *closeCountingStore) GetSessionMeta(string) (*storage.SessionMeta, error) {
+	return nil, storage.ErrSessionNotFound
+}
+func (s *closeCountingStore) MarkFinalized(string, uint64) error { return nil }
+func (s *closeCountingStore) LastFinalized(string) (uint64, error) { return 0, nil }
+func (s *closeCountingStore) SaveSnapshot(string, uint64, []byte) error { return nil }
+func (s *closeCountingStore) LoadSnapshot(string) (uint64, []byte, error) {
+	return 0, nil, storage.ErrSnapshotNotFound
+}
+func (s *closeCountingStore) PruneEpoch(uint64) error { return nil }
+func (s *closeCountingStore) Close() error {
+	s.closeCalls++
+	return nil
+}
+
+// TestSession_Close_ClosesUnderlyingStore proves the resource-release leg of the
+// leak fix: closing a Session must close the storage it owns. The gateway-side
+// tests prove rt.close() is now invoked on every automatic deactivation path;
+// this proves that invocation actually frees the SQLite store the session holds.
+func TestSession_Close_ClosesUnderlyingStore(t *testing.T) {
+	store := &closeCountingStore{}
+	session, _, _ := setupSessionWithOptions(t, 1, 1_000_000, 0, WithStorage(store))
+
+	require.NoError(t, session.Close())
+	require.Equal(t, 1, store.closeCalls, "Session.Close must close the injected storage exactly once")
+}

--- a/docs/chat-api/README.md
+++ b/docs/chat-api/README.md
@@ -1,10 +1,11 @@
 # Gonka Chat Completions API
 
-OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B via vLLM. This doc covers universal parameter behavior. For per-model overrides see [Kimi-K2.6](kimi-k2.6.md) / [Qwen3-235B](qwen3-235b-a22b-instruct-2507.md).
+OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M2.7 via vLLM. This doc covers universal parameter behavior. For per-model overrides see [Kimi-K2.6](kimi-k2.6.md) / [Qwen3-235B](qwen3-235b-a22b-instruct-2507.md) / [MiniMax-M2.7](minimax-m2.7.md).
 
 ## Quick navigation
 - [Per-model overrides: Kimi-K2.6](kimi-k2.6.md)
 - [Per-model overrides: Qwen3-235B-A22B-Instruct-2507](qwen3-235b-a22b-instruct-2507.md)
+- [Per-model overrides: MiniMax-M2.7](minimax-m2.7.md)
 - [Why was my param stripped/rejected?](troubleshooting.md)
 - [Client agents compatibility](agents.md)
 - [Source citations](references.md)
@@ -46,7 +47,7 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B via vLLM. T
 | `top_logprobs` | int | — | force `5`; observability pipeline | — |
 | `return_token_ids` | bool | — | force `true`; required for stream-derived `enforced_tokens` reconstruction on Kimi-K2.6 reasoning routes (without it, `<think>`/`</think>` are silently dropped from SSE while still counted in `usage.completion_tokens`). Resulting `prompt_token_ids` / `choices[].token_ids` are stripped from the client-facing response | [[vLLM-19]](references.md#vllm), [[vLLM-20]](references.md#vllm) |
 | `response_format` | object | — | shape-bounded (depth ≤16, nodes ≤128, branch arms ≤16, enum ≤256, size ≤16 KiB); `$ref`/`$defs`/`definitions` forbidden; `pattern` ≤512 B + must compile as regex; `json_schema.name` non-empty ≤64 chars matching `^[A-Za-z0-9_.-]+$`; schema must be an object | [[OpenAI-1]](references.md#openai), [[CVE-2]](references.md#security-advisories) |
-| `structured_outputs` | object | — | validated against vLLM envelope (`json`/`regex`/`choice`/`grammar`/`json_object`/`structural_tag`); CVE-driven caps per sub-field — see [Qwen native extensions](qwen3-235b-a22b-instruct-2507.md#native-extensions); **rejected on Kimi-K2.6 route** ([why](troubleshooting.md#reject-structured_outputs-kimi)); **rejected if combined with `response_format`** ([why](troubleshooting.md#reject-structured_outputs-with-response_format)) | [[vLLM-16]](references.md#vllm), [[vLLM-18]](references.md#vllm), [[CVE-3]](references.md#security-advisories), [[CVE-4]](references.md#security-advisories), [[CVE-8]](references.md#security-advisories) |
+| `structured_outputs` | object | — | validated against vLLM envelope (`json`/`regex`/`choice`/`grammar`/`json_object`/`structural_tag`); CVE-driven caps per sub-field — see [Qwen native extensions](qwen3-235b-a22b-instruct-2507.md#native-extensions); **rejected on Kimi-K2.6 route** ([why](troubleshooting.md#reject-structured_outputs-kimi)); **accepted on MiniMax-M2.7 route** — vLLM enforces it ([details](troubleshooting.md#accept-structured_outputs-minimax)); `structural_tag` must be the object form (string form is rejected — crashes the engine); **rejected if combined with `response_format`** ([why](troubleshooting.md#reject-structured_outputs-with-response_format)) | [[vLLM-16]](references.md#vllm), [[vLLM-18]](references.md#vllm), [[CVE-3]](references.md#security-advisories), [[CVE-4]](references.md#security-advisories), [[CVE-8]](references.md#security-advisories) |
 | `tools` | array | — | shape-bounded: function schema depth ≤16, nodes ≤256, branch arms ≤16, enum ≤256, size ≤16 KiB; `$ref`/`$defs`/`definitions` forbidden; `pattern` ≤512 B + regex compile; `function.name` ≤64 B; `tools[].function.strict` silent-stripped (vLLM parsers ignore) | [[OpenAI-1]](references.md#openai), [[CVE-2]](references.md#security-advisories) |
 | `tool_choice` | string\|object | "auto" if tools | shape-strict; `function.name` ≤64 B; `"required"` coerced ([why](troubleshooting.md#coerce-tool-choice-required)) | [[OpenAI-1]](references.md#openai) |
 | `parallel_tool_calls` | bool | — | pass-through | [[OpenAI-1]](references.md#openai) |
@@ -103,6 +104,7 @@ Enforced by the gateway's message validator:
 - **Lenient SDK compat:** orphan `role: "tool"` messages — those whose `tool_call_id` was never emitted by a prior `assistant.tool_calls[].id` — are silently dropped before validation. Long agent conversations sometimes lose part of a multi-tool fan-out during client-side history compaction.
 - **Lenient SDK compat:** empty `role: "assistant"` turns — no `content` AND no `tool_calls` AND no `function_call` — are silently dropped. The model can't observe an informationless turn; the drop is a semantic no-op.
 - **Strict (no lenient compat):** duplicate `tool_calls[].id` within a single assistant message is rejected per OpenAI spec — see [troubleshooting](troubleshooting.md#reject-duplicate-tool-call-id).
+- **Route-specific shape:** the `MiniMaxAI/MiniMax-M2.7` route uses a different `role:"tool"` contract — `content` is a `{name,type,text}[]` array, `tool_call_id` is absent (silently stripped if present), and the orphan-drop policy is "no preceding assistant.tool_calls[] block" rather than "no matching tool_call_id". See [accept-tool-message-minimax-shape](troubleshooting.md#accept-tool-message-minimax-shape) and the [MiniMax-M2.7 per-model doc](minimax-m2.7.md).
 
 ## Errors
 

--- a/docs/chat-api/README.md
+++ b/docs/chat-api/README.md
@@ -28,21 +28,21 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M
 |-------|------|---------|----------|--------|
 | `model` | string | — | Required; route key | [[OpenAI-1]](references.md#openai) |
 | `messages` | array | — | Required; OpenAI shape (see [Messages contract](#messages-contract)); ≤2048 entries | [[OpenAI-1]](references.md#openai) |
-| `temperature` | float | 1.0 | cap ≤ 2.0; sanitize (NaN/Inf strip) | [[OpenAI-1]](references.md#openai) |
-| `top_p` | float | 1.0 | sanitize (NaN/Inf strip) | [[OpenAI-1]](references.md#openai) |
-| `top_k` | int | — | sanitize float; vLLM extension | [[vLLM-1]](references.md#vllm) |
-| `min_p` | float | — | sanitize; vLLM extension | [[vLLM-1]](references.md#vllm) |
+| `temperature` | float | 1.0 | clamp to `[0, 2]`; sanitize (NaN/Inf strip) | [[OpenAI-1]](references.md#openai) |
+| `top_p` | float | 1.0 | clamp `>1` → `1`; reject `≤0` (must be in `(0, 1]` — [why](troubleshooting.md#reject-out-of-range-sampling)); sanitize (NaN/Inf strip) | [[OpenAI-1]](references.md#openai) |
+| `top_k` | int | — | must be `-1` (disabled) or `≥1`, else reject ([why](troubleshooting.md#reject-out-of-range-sampling)); sanitize float; vLLM extension | [[vLLM-1]](references.md#vllm) |
+| `min_p` | float | — | clamp to `[0, 1]`; sanitize; vLLM extension | [[vLLM-1]](references.md#vllm) |
 | `frequency_penalty` | float | 0.0 | clamp `[-2, 2]`; see [Kimi override](kimi-k2.6.md#parameter-overrides) for force-rewrite | [[OpenAI-1]](references.md#openai) |
 | `presence_penalty` | float | 0.0 | clamp `[-2, 2]`; see [Kimi override](kimi-k2.6.md#parameter-overrides) for force-rewrite | [[OpenAI-1]](references.md#openai) |
-| `repetition_penalty` | float | 1.0 | cap ≤ 2.0; vLLM extension | [[vLLM-1]](references.md#vllm) |
+| `repetition_penalty` | float | 1.0 | clamp `>2` → `2`; reject `≤0` (must be `>0` — [why](troubleshooting.md#reject-out-of-range-sampling)); vLLM extension | [[vLLM-1]](references.md#vllm) |
 | `logit_bias` | object | — | ≤1024 entries; value range `[-100, 100]` | [[OpenAI-1]](references.md#openai) |
-| `max_tokens` | int | — | clamp | [[OpenAI-1]](references.md#openai) |
-| `max_completion_tokens` | int | — | alias for max_tokens | [[OpenAI-1]](references.md#openai) |
-| `stream` | bool | false | pass-through | [[OpenAI-1]](references.md#openai) |
+| `max_tokens` | int | — | must be `≥1` (reject `0` — [why](troubleshooting.md#reject-nonpositive-max-tokens)); capped to model max; Kimi-K2.6 floors small values to 16 ([why](troubleshooting.md#kimi-empty-content-think-burn)) | [[OpenAI-1]](references.md#openai) |
+| `max_completion_tokens` | int | — | alias for max_tokens (same `≥1` reject / cap / Kimi-floor handling) | [[OpenAI-1]](references.md#openai) |
+| `stream` | bool | false | must be a boolean (else reject — [why](troubleshooting.md#reject-malformed-param-types)); pass-through | [[OpenAI-1]](references.md#openai) |
 | `stream_options` | object | — | strip when stream≠true; whitelist `include_usage`; strip `continuous_usage_stats` | [[OpenAI-1]](references.md#openai) |
-| `stop` | str\|array | — | pass-through; ≤16 entries × 256 B each | [[OpenAI-1]](references.md#openai) |
+| `stop` | str\|array | — | array entries must be strings (else reject — [why](troubleshooting.md#reject-malformed-param-types)); ≤16 entries × 256 B each | [[OpenAI-1]](references.md#openai) |
 | `n` | int | 1 | hard cap ≤5; coerce to 1 when temperature==0 ([why](troubleshooting.md#coerce-n-when-temperature-zero)) | [[OpenAI-1]](references.md#openai), [[CVE-9]](references.md#security-advisories) |
-| `seed` | uint64 | — | pass-through | [[OpenAI-1]](references.md#openai) |
+| `seed` | uint64 | — | must be a non-negative integer (else reject — [why](troubleshooting.md#reject-malformed-param-types)); pass-through | [[OpenAI-1]](references.md#openai) |
 | `logprobs` | bool | — | force `true`; observability pipeline | — |
 | `top_logprobs` | int | — | force `5`; observability pipeline | — |
 | `return_token_ids` | bool | — | force `true`; required for stream-derived `enforced_tokens` reconstruction on Kimi-K2.6 reasoning routes (without it, `<think>`/`</think>` are silently dropped from SSE while still counted in `usage.completion_tokens`). Resulting `prompt_token_ids` / `choices[].token_ids` are stripped from the client-facing response | [[vLLM-19]](references.md#vllm), [[vLLM-20]](references.md#vllm) |
@@ -50,7 +50,7 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M
 | `structured_outputs` | object | — | validated against vLLM envelope (`json`/`regex`/`choice`/`grammar`/`json_object`/`structural_tag`); CVE-driven caps per sub-field — see [Qwen native extensions](qwen3-235b-a22b-instruct-2507.md#native-extensions); **rejected on Kimi-K2.6 route** ([why](troubleshooting.md#reject-structured_outputs-kimi)); **accepted on MiniMax-M2.7 route** — vLLM enforces it ([details](troubleshooting.md#accept-structured_outputs-minimax)); `structural_tag` must be the object form (string form is rejected — crashes the engine); **rejected if combined with `response_format`** ([why](troubleshooting.md#reject-structured_outputs-with-response_format)) | [[vLLM-16]](references.md#vllm), [[vLLM-18]](references.md#vllm), [[CVE-3]](references.md#security-advisories), [[CVE-4]](references.md#security-advisories), [[CVE-8]](references.md#security-advisories) |
 | `tools` | array | — | shape-bounded: function schema depth ≤16, nodes ≤256, branch arms ≤16, enum ≤256, size ≤16 KiB; `$ref`/`$defs`/`definitions` forbidden; `pattern` ≤512 B + regex compile; `function.name` ≤64 B; `tools[].function.strict` silent-stripped (vLLM parsers ignore) | [[OpenAI-1]](references.md#openai), [[CVE-2]](references.md#security-advisories) |
 | `tool_choice` | string\|object | "auto" if tools | shape-strict; `function.name` ≤64 B; `"required"` coerced ([why](troubleshooting.md#coerce-tool-choice-required)) | [[OpenAI-1]](references.md#openai) |
-| `parallel_tool_calls` | bool | — | pass-through | [[OpenAI-1]](references.md#openai) |
+| `parallel_tool_calls` | bool | — | must be a boolean (else reject — [why](troubleshooting.md#reject-malformed-param-types)); pass-through | [[OpenAI-1]](references.md#openai) |
 | `user` | string | — | byte-length ≤512 | [[OpenAI-1]](references.md#openai) |
 | `safety_identifier` | string | — | silent-strip; see [Kimi override](kimi-k2.6.md#parameter-overrides) for pass-through ([why](troubleshooting.md#strip-safety_identifier)) | [[OpenAI-6]](references.md#openai) |
 | `metadata` | object | — | OpenAI bounds: ≤16 keys × 64-char × 512-char vals | [[OpenAI-1]](references.md#openai) |
@@ -67,11 +67,11 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M
 | `enable_thinking` | bool | — | translate to chat_template_kwargs ([why](troubleshooting.md#translate-enable_thinking)) | [[Qwen-3]](references.md#qwen) |
 | `thinking_config` | object | — | silent-strip ([why](troubleshooting.md#strip-thinking_config)) | — |
 | `think` | bool | — | silent-strip ([why](troubleshooting.md#strip-think)) | — |
-| `min_tokens` | int | — | vLLM extension; clamp to ≤max_tokens; conditional strip when stop_token_ids set | [[vLLM-1]](references.md#vllm) |
-| `bad_words` | string array | — | vLLM extension; ≤64 entries × 128 B per entry | [[vLLM-1]](references.md#vllm) |
-| `stop_token_ids` | int array | — | vLLM extension; ≤64 | [[vLLM-1]](references.md#vllm) |
-| `skip_special_tokens` | bool | — | vLLM extension; pass-through | [[vLLM-1]](references.md#vllm) |
-| `detokenize` | bool | — | vLLM extension; pass-through | [[vLLM-1]](references.md#vllm) |
+| `min_tokens` | int | — | vLLM extension; must be a non-negative integer (else reject — [why](troubleshooting.md#reject-malformed-param-types)); clamp to ≤max_tokens; conditional strip when stop_token_ids set | [[vLLM-1]](references.md#vllm) |
+| `bad_words` | string array | — | vLLM extension; entries must be strings (else reject — [why](troubleshooting.md#reject-malformed-param-types)); ≤64 entries × 128 B per entry | [[vLLM-1]](references.md#vllm) |
+| `stop_token_ids` | int array | — | vLLM extension; entries must be non-negative integers (else reject — [why](troubleshooting.md#reject-malformed-param-types)); ≤64 | [[vLLM-1]](references.md#vllm) |
+| `skip_special_tokens` | bool | — | vLLM extension; must be a boolean (else reject — [why](troubleshooting.md#reject-malformed-param-types)) | [[vLLM-1]](references.md#vllm) |
+| `detokenize` | bool | — | vLLM extension; must be a boolean (else reject — [why](troubleshooting.md#reject-malformed-param-types)) | [[vLLM-1]](references.md#vllm) |
 | `chat_template_kwargs` | object | — | depth ≤16, nodes ≤128, size ≤16 KiB; key denylist (`chat_template`, `tokenize`, `tools`, `documents`, `conversation`, `continue_final_message`, `padding`, `truncation`, `max_length`, `return_tensors`, `return_dict`) — CVE-2025-61620 / CVE-2025-62426 mitigation | [[vLLM-1]](references.md#vllm), [[CVE-5]](references.md#security-advisories), [[CVE-6]](references.md#security-advisories) |
 
 *Parameters with truly model-exclusive behavior (`thinking`, `thinking_token_budget`, `messages[].reasoning_content`) are documented in the per-model docs — see [Kimi-K2.6](kimi-k2.6.md) and [Qwen3-235B-A22B-Instruct-2507](qwen3-235b-a22b-instruct-2507.md). For params with universal baseline behavior plus per-model adjustments (`frequency_penalty`, `presence_penalty`, `safety_identifier`), the baseline appears above and the per-model override is linked from the row.*

--- a/docs/chat-api/agents.md
+++ b/docs/chat-api/agents.md
@@ -28,6 +28,14 @@ Cause: model (typically Kimi-K2.6) emitted duplicate symbolic ids in one assista
 
 Cause: Kimi-K2.6 reads from `chat_template_kwargs.thinking` only — the gateway mirrors automatically from top-level `thinking.type`. The top-level field is dropped after mirroring. To override the mirrored value, pre-set `chat_template_kwargs.thinking` directly in your request body.
 
+### "My tool message is rejected on MiniMax-M2.7"
+
+Cause: MiniMax-M2.7 uses a different `role:"tool"` contract from OpenAI — `content` must be an array of `{name, type:"text", text}` entries, with no `tool_call_id`. Bare-string `content` or OpenAI-style `tool_call_id`-correlated messages are rejected with HTTP 400. See [accept-tool-message-minimax-shape](troubleshooting.md#accept-tool-message-minimax-shape) and the [MiniMax-M2.7 per-model doc](minimax-m2.7.md). Clients dual-emitting `tool_call_id` for portability across routes are fine — the gateway silently strips it.
+
+### "My `<think>` blocks disappeared on MiniMax-M2.7"
+
+They shouldn't. MiniMax-M2.7 emits reasoning inline as `<think>...</think>` in `content`, and the gateway preserves these byte-identical across multi-turn history. If you're seeing them stripped, you're probably running them through a client-side reasoning filter — keep them in conversation history for chain-of-thought continuity ([[MiniMax-5]](references.md#minimax)).
+
 ### "My cache key disappeared"
 
 Cause: `cache_key` / `prompt_cache_key` silently stripped. vLLM uses a different field (`cache_salt`) for cache isolation, and the aliasing PR is unmerged — see [troubleshooting](troubleshooting.md#strip-cache_key) for the full chain of upstream gaps.

--- a/docs/chat-api/minimax-m2.7.md
+++ b/docs/chat-api/minimax-m2.7.md
@@ -1,0 +1,88 @@
+# MiniMax-M2.7 (`MiniMaxAI/MiniMax-M2.7`) — overrides & extensions
+
+Provider: MiniMax AI. This doc documents how MiniMax-M2.7 deviates from the [universal contract](README.md). For params that behave the same as universal, see the universal contract directly.
+
+Mirrors the structure of [Kimi-K2.6](kimi-k2.6.md) and [Qwen3-235B](qwen3-235b-a22b-instruct-2507.md). Chain-side wiring (HfCommit pin, ModelArgs, PoC params) lives in `inference-chain/app/upgrades/v0_2_13/upgrades.go`.
+
+## Model facts
+
+| Property | Value | Source |
+|----------|-------|--------|
+| Provider | MiniMax AI | [[MiniMax-1]](references.md#minimax) |
+| vLLM route id | `MiniMaxAI/MiniMax-M2.7` | — |
+| Total params | 229 B (sparse MoE; ~10 B activated, inherited from M2 base) | [[MiniMax-2]](references.md#minimax) |
+| Tensor types | F32 / BF16 / F8_E4M3 (FP8) | [[MiniMax-2]](references.md#minimax) |
+| Max context per sequence | 196 K tokens (180 K served) | [[MiniMax-3]](references.md#minimax) |
+| Tool-call parser (vLLM) | `minimax_m2` | [[MiniMax-3]](references.md#minimax), [[vLLM-21]](references.md#vllm) |
+| Reasoning parser (vLLM) | `minimax_m2_append_think` (per MiniMax guide); see [parser caveat](#deployment-requirements) | [[MiniMax-3]](references.md#minimax) |
+| Native thinking | yes — **interleaved** `<think>...</think>` tags embedded in `content` | [[MiniMax-2]](references.md#minimax), [[MiniMax-4]](references.md#minimax) |
+| Recommended sampling | `temperature=1.0, top_p=0.95, top_k=40` | [[MiniMax-2]](references.md#minimax) |
+
+## Deployment requirements
+
+Infrastructure-level constraints that must hold BEFORE this route is served — these are enforced by vLLM engine configuration / flags, NOT by the gateway:
+
+- **HfCommit pinned** — `--trust-remote-code` is required by the model card ([[MiniMax-3]](references.md#minimax)), which puts the deployment inside the blast radius of [[CVE-12]](references.md#security-advisories) (vLLM hardcoded trust_remote_code bypass via malicious model repositories). Mitigation: pin the HuggingFace `revision=<commit-sha>` to a verified weights checkpoint. Never serve `revision=main`.
+- **Tool-call parser MUST be `minimax_m2`** ([[vLLM-21]](references.md#vllm)). Drives the wire-format the model emits (`<minimax:tool_call>` XML, converted to OpenAI `tool_calls[]` on the response by vLLM).
+- **Reasoning parser caveat** — official MiniMax recommendation is `--reasoning-parser minimax_m2_append_think` ([[MiniMax-3]](references.md#minimax)). vLLM upstream has known bugs on M2.5+ with this parser ([[vLLM-23]](references.md#vllm), [[vLLM-24]](references.md#vllm), [[vLLM-27]](references.md#vllm)): `extract_reasoning_streaming` assumes no opening `<think>` tag (M2.5+ emits one), and reasoning can be missing from SSE deltas. The visible-content stream still includes the reasoning, just not separated into `reasoning_content`. For the gateway this means `<think>...</think>` blocks land **inline in `content`** on responses — the pass-through design already handles this.
+- **Pure TP8 is NOT supported** — vLLM recipe forbids it; H100 TP4+EP4 is the supported topology ([[vLLM-21]](references.md#vllm)).
+- **AMD path (MI300X/MI325X/MI350X/MI355X)** requires `VLLM_ROCM_USE_AITER=1 VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1`; first AITER launch JITs for several minutes ([[vLLM-21]](references.md#vllm)).
+- **Avoid Ampere (A100) FP8** — M2.7 FP8 loads on vLLM v0.19.0 but crashes on nightly ([[vLLM-22]](references.md#vllm)). Either stay on a pinned tagged release or use BF16 on Ampere.
+- **Disable `pythonic` and `qwen3_coder` tool-call parsers** — same vendor-agnostic CVE history that applies to Kimi/Qwen routes ([[CVE-1]](references.md#security-advisories), [[CVE-7]](references.md#security-advisories)).
+
+## Parameter overrides
+
+*Delta from [universal contract](README.md#supported-parameters-universal-behavior). Listed params behave differently on this route; everything else matches universal.*
+
+| Param | Universal | On MiniMax-M2.7 | Why |
+|-------|-----------|-----------------|-----|
+| `tools[].function.strict` | (silent-strip in universal via `ToolsValidator`) | silent-strip — vLLM `minimax_m2` parser ignores | [[vLLM-21]](references.md#vllm) |
+| `thinking` (top-level Anthropic-style object) | mirrored to `chat_template_kwargs.thinking` on Kimi route | **silent-strip on this route** — MiniMax has no `chat_template_kwargs` toggle for thinking; thinking is always on and emitted inline as `<think>...</think>` in `content`. Clients wanting to suppress thinking display must parse + filter client-side. | [[MiniMax-2]](references.md#minimax), [why](troubleshooting.md#strip-thinking-minimax) |
+| `thinking_token_budget` | injected/clamped on Kimi; silent-strip on Qwen | **silent-strip** — no equivalent knob in MiniMax chat template | [[MiniMax-2]](references.md#minimax) |
+| `enable_thinking` (top-level) | translated to `chat_template_kwargs.enable_thinking` on Qwen | **silent-strip on this route** — MiniMax does not honor; thinking is structural to the chat template, not configurable per request ([[vLLM-25]](references.md#vllm)). | [why](troubleshooting.md#strip-enable_thinking-minimax) |
+| `safety_identifier` | strip (universal); pass-through on Kimi | strip (no MiniMax abuse-tracking API contract) | [[MiniMax-1]](references.md#minimax) |
+| Content of `role:"tool"` messages | universal: string or text-part array, flattened to string; `tool_call_id` required | **MiniMax shape**: `content: [{name, type:"text", text}]` array; no `tool_call_id` (silently stripped if dual-emitted). Per-entry caps: ≤16 entries × `name` ≤64 B × `text` ≤64 KiB; closed allow-list of keys. | [[MiniMax-4]](references.md#minimax), [why](troubleshooting.md#accept-tool-message-minimax-shape) |
+
+## Native extensions
+
+*Params unique to this route — no equivalent in the universal contract.*
+
+| Param | Type | Behavior | Source |
+|-------|------|----------|--------|
+| `extra_body.reasoning_split` | bool | If `true`, vLLM/MiniMax emit reasoning as a separate `reasoning_details[]` array on the response instead of inline `<think>...</think>` blocks in `content`. Gateway unwraps `extra_body` per universal contract; the lifted key passes through to vLLM. Document client responsibility: round-trip `reasoning_details` (or `<think>` blocks) verbatim into history. | [[MiniMax-5]](references.md#minimax) |
+| `messages[].reasoning_details` | array | Assistant-turn reasoning history when client uses `reasoning_split=true`. **Pass-through** — assistant-side validator does not strip. **Critical:** stripping these breaks M2.7 interleaved-thinking continuity. | [[MiniMax-5]](references.md#minimax) |
+| `<think>...</think>` blocks in assistant `content` | inline tags | **Pass-through verbatim** when round-tripped in history. The gateway message validator MUST NOT strip these from prior assistant turns or rewrite their internals. | [[MiniMax-2]](references.md#minimax), [[MiniMax-5]](references.md#minimax) |
+| Tool-call output XML (`<minimax:tool_call><invoke name=…><parameter name=…>`) | tag stream | Emitted by the model verbatim; the vLLM `minimax_m2` tool-call parser converts to OpenAI `tool_calls[]` format on the response. Gateway pass-through — no special handling required on the response path. | [[MiniMax-4]](references.md#minimax), [[vLLM-21]](references.md#vllm) |
+| MiniMax-only response fields (`base_resp`, `output_sensitive`, `input_sensitive`) | object / bool | **Pass-through** on the response. Document existence; clients may ignore. | [[MiniMax-5]](references.md#minimax) |
+
+## Rejected MiniMax-platform-only keys
+
+*Fields the MiniMax direct API (platform.minimax.io) accepts that the gateway rejects with HTTP 400 via the closed top-level allowlist. Listed so clients porting from the MiniMax platform see why their request fails.*
+
+| Param | Why rejected |
+|-------|--------------|
+| `partial` | Assistant-prefill / continuation flag on the MiniMax platform. Rejected because it bypasses the gateway's per-role message validation (which treats the trailing turn as a new prompt, not a forced model continuation) and would expose vLLM to a chat-template integrity hazard that the OpenAI Chat Completions contract does not anticipate. Clients wanting equivalent behavior must shape the request through the normal `messages[]` array. [[MiniMax-5]](references.md#minimax) |
+| `web_search` / `enable_search` / `search_kwargs` | MiniMax platform-side network-search features; vLLM does not implement them. Silent-stripping would mislead clients into thinking search ran. Fail-loud is the safer default. [[MiniMax-1]](references.md#minimax) |
+| `mask_sensitive_info` | MiniMax platform-side content masking; not implemented in vLLM. Same fail-loud rationale. [[MiniMax-1]](references.md#minimax) |
+
+## Structured outputs
+
+| Field | Status | Note |
+|-------|--------|------|
+| `response_format` | ✅ supported (see universal) | xgrammar via vLLM; full schema bounds enforced. Compatible with thinking models since xgrammar runs on the `content`-emission phase, after thinking. |
+| `structured_outputs` | ✅ **accepted on this route** | vLLM enforces the constraint on M2.7 (verified with discriminating/control requests across `json`/`regex`/`choice`/`grammar`/`json_object`). `structural_tag` must be the object form — the JSON-encoded string form is rejected (crashes the engine). See [accept-structured_outputs-minimax](troubleshooting.md#accept-structured_outputs-minimax). |
+
+## Known model-side bugs we work around
+
+- **Streaming tool_calls malformation** ([[vLLM-26]](references.md#vllm), [[SGLang-1]](references.md#sglang)): under SSE streaming a single tool call is sometimes emitted as two `tool_calls[]` entries — one with `name=null` and duplicated `arguments`. PR #35895 fixed the `stream_interval > 1` case; the `name=null` malformation may still occur with concurrent calls. Documented as a known client-responsibility issue.
+- **Tool-call parser fails on `str | null` param types** ([[SGLang-2]](references.md#sglang)): `minimax_m2_tool_parser._convert_param_value` errors on union-with-null param values; clients should avoid `["string","null"]` in tool parameter schemas.
+- **Reasoning missing in stream mode** ([[vLLM-27]](references.md#vllm)): when serving with `--reasoning-parser minimax_m2_append_think` and `stream=true`, reasoning_content is sometimes absent from delta chunks. Upstream bug; no gateway mitigation.
+- **`thinking` cannot be disabled** ([[vLLM-25]](references.md#vllm)): even with `chat_template_kwargs.enable_thinking=false`, M2.5+ still emits `<think>` blocks. Confirms the strip-`enable_thinking` policy.
+- **A100 / Ampere FP8 regression** ([[vLLM-22]](references.md#vllm)): M2.7 FP8 fails on Ampere with vLLM nightly. Mitigated by deployment-side version pin; no gateway responsibility.
+
+## See also
+- [Troubleshooting](troubleshooting.md)
+- [References](references.md)
+- [Universal contract](README.md)
+- [Kimi-K2.6 overrides](kimi-k2.6.md)
+- [Qwen3-235B overrides](qwen3-235b-a22b-instruct-2507.md)

--- a/docs/chat-api/references.md
+++ b/docs/chat-api/references.md
@@ -8,10 +8,12 @@ Namespaces:
 - `[vLLM-N]` vLLM
 - `[Moonshot-N]` Moonshot (includes Kimi model line)
 - `[Qwen-N]` Qwen
+- `[MiniMax-N]` MiniMax AI (MiniMax-M2 line)
+- `[SGLang-N]` SGLang (cross-engine parser bug references)
 - `[OpenRouter-N]` OpenRouter
 - `[CVE-N]` security advisories
 
-Industry/community sources (Ollama blog, OpenAI community thread, arxiv papers) are inline links in `troubleshooting.md` and `agents.md`, not here. Captured-requests evidence is referenced inline by request-id.
+Industry/community sources (Ollama blog, OpenAI community thread, arxiv papers) are inline links in `troubleshooting.md` and `agents.md`, not here. Captured-requests evidence is referenced inline by request-id. Chain governance changes (model registration, ModelArgs pins) are cited inline by PR number under the appropriate per-model doc, not in this file.
 
 ## OpenAI
 
@@ -48,6 +50,14 @@ Industry/community sources (Ollama blog, OpenAI community thread, arxiv papers) 
 - **[vLLM-18]** [Structured outputs feature docs](https://docs.vllm.ai/en/latest/features/structured_outputs.html) — `structured_outputs` supersedes `guided_json`/`guided_regex`/`guided_grammar`/`guided_choice`.
 - **[vLLM-19]** [PR #29074 — kimi_k2 reasoning parser: emit DeltaMessage when return_token_ids=true](https://github.com/vllm-project/vllm/pull/29074) — changes `extract_reasoning_streaming` to emit an empty `DeltaMessage()` (with the token id attached) instead of `None` for single-token deltas carrying `<think>`/`</think>`. Without `return_token_ids=true`, those tokens are silently dropped from the SSE stream while still counted in `usage.completion_tokens`, producing a hidden-token gap that breaks stream-derived `enforced_tokens` reconstruction.
 - **[vLLM-20]** [kimi_k2_reasoning_parser.py source](https://github.com/vllm-project/vllm/blob/main/vllm/reasoning/kimi_k2_reasoning_parser.py) — the parser whose `extract_reasoning_streaming` returns `None` (= suppresses event) when a delta is exactly `<think>` or `</think>`. Tokens still counted in usage; vLLM-19 added the `return_token_ids` escape valve.
+- **[vLLM-21]** [vLLM Recipes — MiniMax-M2 Series Usage Guide](https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html) — official vLLM recipe covering M2/M2.1/M2.5/M2.7 deployment (parsers, topology, compilation-config, AMD AITER env vars).
+- **[vLLM-22]** [Issue #39610 — MiniMax-M2.7/Qwen3.5 FP8 fail on A100/Ampere with nightly](https://github.com/vllm-project/vllm/issues/39610) — regression confirmed vs v0.19.0.
+- **[vLLM-23]** [Issue #38212 — MiniMaxM2ReasoningParser broken for M2.5](https://github.com/vllm-project/vllm/issues/38212) — `extract_reasoning_streaming` assumes no opening `<think>` tag; M2.5/.7 do emit it.
+- **[vLLM-24]** [Issue #34625 — Reasoning Parser not working with MiniMax M2.5](https://github.com/vllm-project/vllm/issues/34625) — same parser class affects M2.5+ reasoning extraction.
+- **[vLLM-25]** [Issue #36778 — Thinking cannot be disabled on M2.5 via chat_template_kwargs](https://github.com/vllm-project/vllm/issues/36778) — drives strip-`enable_thinking` policy on the M2.7 route.
+- **[vLLM-26]** [PR #35895 — minimax_m2 tool parser fix for stream_interval > 1](https://github.com/vllm-project/vllm/pull/35895) — covers one streaming malformation class.
+- **[vLLM-27]** [Issue #36632 — MiniMax-M2.5 reasoning missing in chat completions stream](https://github.com/vllm-project/vllm/issues/36632) — `--reasoning-parser minimax_m2_append_think` skips reasoning content in SSE deltas.
+- **[vLLM-28]** [Issue #28963 — MiniMax tool parsing errors](https://github.com/vllm-project/vllm/issues/28963) — error in `_convert_param_value`.
 
 ## Moonshot
 
@@ -61,6 +71,19 @@ Industry/community sources (Ollama blog, OpenAI community thread, arxiv papers) 
 - **[Qwen-1]** [Qwen3-235B-A22B-Instruct-2507 model card](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507) — confirms model is non-thinking-only; basis for stripping `reasoning_effort`.
 - **[Qwen-2]** [Qwen3-235B-A22B-Instruct-2507-FP8 model card](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507-FP8) — FP8 quantised variant model card; same non-thinking confirmation.
 - **[Qwen-3]** [Qwen vLLM deployment docs](https://qwen.readthedocs.io/en/latest/deployment/vllm.html) — canonical placement for `enable_thinking` inside `chat_template_kwargs`; notes it is not OpenAI API compatible at the top level.
+
+## MiniMax
+
+- **[MiniMax-1]** [MiniMax platform docs index](https://platform.minimax.io/docs) — overview of MiniMax-hosted API surface.
+- **[MiniMax-2]** [MiniMax-M2.7 model card](https://huggingface.co/MiniMaxAI/MiniMax-M2.7) — architecture (229B params, F32/BF16/F8_E4M3 tensor types), sampling recommendations, interleaved `<think>...</think>` constraint.
+- **[MiniMax-3]** [MiniMax-M2.7 vLLM deployment guide](https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/vllm_deploy_guide.md) — exact CLI invocations, GPU sizing (220 GB weights + 240 GB/1M tokens), 196K max context per sequence, parser flags.
+- **[MiniMax-4]** [MiniMax-M2.7 tool calling guide](https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/tool_calling_guide.md) — `<minimax:tool_call><invoke><parameter>` output format; `role:"tool"` with `content:[{name,type,text}]` array (no `tool_call_id`).
+- **[MiniMax-5]** [MiniMax M2 Tool Use & Interleaved Thinking docs](https://platform.minimax.io/docs/guides/text-m2-function-call) — `extra_body.reasoning_split`, `reasoning_details[]` response field, multi-turn history rules.
+
+## SGLang
+
+- **[SGLang-1]** [Issue #23071 — MiniMax-M2 streaming tool_calls malformed](https://github.com/sgl-project/sglang/issues/23071) — under SSE streaming a single tool call sometimes splits into two entries (`name=null` + duplicated arguments).
+- **[SGLang-2]** [Issue #16057 — MiniMax M2 tool parser failure on `str | null` union param types](https://github.com/sgl-project/sglang/issues/16057) — parser crashes on union-with-null in tool parameter schema; potential DoS vector via crafted tool schema.
 
 ## OpenRouter
 
@@ -84,4 +107,7 @@ Industry/community sources (Ollama blog, OpenAI community thread, arxiv papers) 
 - **[CVE-9]** [CVE-2026-34756 / GHSA-3mwp-wvh9-7528 (vLLM)](https://github.com/vllm-project/vllm/security/advisories/GHSA-3mwp-wvh9-7528) — unbounded `n` causes OOM; `CapUintParameterHandler` clamps `n ≤ 5`.
 - **[CVE-10]** [CVE-2026-44222 / GHSA-hpv8-x276-m59f (vLLM)](https://github.com/vllm-project/vllm/security/advisories/GHSA-hpv8-x276-m59f) — special-token literals crash VL models; requires content sanitizer for Kimi-K2.6 multimodal path.
 - **[CVE-11]** [CVE-2026-44223 / GHSA-83vm-p52w-f9pw (vLLM)](https://github.com/vllm-project/vllm/security/advisories/GHSA-83vm-p52w-f9pw) — penalty fields crash EngineCore with `extract_hidden_states` spec decode; pin vLLM ≥ 0.20.0.
+- **[CVE-12]** [CVE-2026-27893 / RAXE-2026-044 (vLLM)](https://raxe.ai/labs/advisories/RAXE-2026-044) — vLLM hardcoded trust_remote_code bypass enables RCE via malicious model repositories; direct mitigation for the MiniMax-M2.7 route is the chain-pinned `HfCommit` SHA in the governance model config.
+- **[CVE-13]** [CVE-2026-22778 (vLLM)](https://www.ox.security/blog/cve-2026-22778-vllm-rce-vulnerability/) — RCE via crafted video link in multimodal content; gateway mitigates by rejecting non-text content parts on all text-only routes (M2.7 included).
+- **[CVE-14]** [CVE-2025-62164 / GHSA-mrw7-hf4f-83pf (vLLM)](https://github.com/advisories/GHSA-mrw7-hf4f-83pf) — tensor deserialization → DoS / potential RCE; pin vLLM ≥ patched release.
 

--- a/docs/chat-api/troubleshooting.md
+++ b/docs/chat-api/troubleshooting.md
@@ -7,6 +7,7 @@ Every parameter that is stripped / rejected / normalized at the gateway is docum
 | HTTP / behavior | Common cause | Anchor |
 |-----------------|--------------|--------|
 | 400 `"<param>" is currently rejected by the Gonka network` | non-allowlist parameter | [#reject-unknown-param](#reject-unknown-param) |
+| 400 `...name must be a non-empty string` on a whitespace-only name | names are trimmed before the non-empty check | [#reject-whitespace-names](#reject-whitespace-names) |
 | 400 `messages[N].tool_calls[M].id is duplicated` | Kimi-K2.6 model-side bug | [#reject-duplicate-tool-call-id](#reject-duplicate-tool-call-id) |
 | 400 on `tags` | undocumented field | [#reject-tags](#reject-tags) |
 | 400 on `guided_json` / `guided_regex` / etc. | vLLM-native structured decoding | [#reject-guided-decoding](#reject-guided-decoding) |
@@ -197,6 +198,48 @@ Every parameter that is stripped / rejected / normalized at the gateway is docum
 **Fix (client-side)**: send `user` instead if you need OpenAI-compatible attribution; the gateway uniformly validates that field with a 512 B cap.
 
 **Captured-requests**: n/a — no captures observed.
+
+---
+
+### #strip-thinking-minimax
+
+**What**: top-level `thinking: {...}` (Anthropic-style wrapper) silent-stripped on the MiniMax-M2.7 route before `ThinkingValidator` runs.
+
+**Why**: MiniMax-M2.7 has no `chat_template_kwargs` switch for thinking — interleaved reasoning is structural to the chat template and always-on. The model emits `<think>...</think>` blocks inline in `content` by design ([[MiniMax-2]](references.md#minimax)). Mirroring `thinking` into template kwargs (as on Kimi-K2.6) or normalizing it (as on Qwen-style routes) is a no-op on this route. Silent-strip is the closest behavior to the model's actual contract.
+
+**When to restore**: when MiniMax adds a documented per-request thinking toggle.
+
+**Fix (client-side)**: stop sending `thinking`; for clients that need to suppress the visible thinking display, parse + filter `<think>...</think>` blocks client-side from the response content.
+
+**Captured-requests**: n/a — pre-deployment design decision.
+
+---
+
+### #strip-enable_thinking-minimax
+
+**What**: top-level `enable_thinking: bool` silent-stripped on the MiniMax-M2.7 route before `EnableThinkingValidator` runs (which would otherwise translate it into `chat_template_kwargs.enable_thinking`).
+
+**Why**: vLLM Issue [vLLM-25](references.md#vllm) ([#36778](https://github.com/vllm-project/vllm/issues/36778)) confirms `chat_template_kwargs.enable_thinking=false` does NOT disable thinking on M2.5+. Forwarding the translated kwarg would silently mislead clients into believing they'd disabled reasoning when in fact the model still emits `<think>` blocks. Strip avoids the misleading appearance of effect.
+
+**When to restore**: when the upstream Issue is fixed and the kwarg is honored on the M2 line.
+
+**Fix (client-side)**: stop sending `enable_thinking` on this route — see [strip-thinking-minimax](#strip-thinking-minimax) for the broader story.
+
+**Captured-requests**: n/a — pre-deployment design decision.
+
+---
+
+### #strip-tool_call_id-minimax
+
+**What**: `tool_call_id` on `role:"tool"` messages silent-stripped on the MiniMax-M2.7 route during message normalization.
+
+**Why**: MiniMax-M2.7 tool messages correlate by `name` + positional order within a tool-result block, not by `tool_call_id` ([[MiniMax-4]](references.md#minimax)). Clients porting OpenAI code may dual-emit the field. Forwarding it is harmless (vLLM ignores) but rejecting it would force every OpenAI-compat client to fork their tool-message serializer per route. Silent-strip preserves compat without implying semantics we don't honor.
+
+**When to restore**: never — the field has no consumer on this route.
+
+**Fix (client-side)**: omit `tool_call_id` for cleanest payloads. If you must dual-emit (e.g. shared serializer across routes), it's a free pass-through to silent-strip.
+
+**Captured-requests**: n/a — anticipated dual-emission from porting clients.
 
 ---
 
@@ -411,9 +454,57 @@ Every parameter that is stripped / rejected / normalized at the gateway is docum
 
 **Captured-requests**: n/a — no captures observed.
 
+---
+
+### #accept-structured_outputs-minimax
+
+**What**: `structured_outputs` is accepted on the `MiniMaxAI/MiniMax-M2.7` route (not rejected). Only Kimi-K2.6 rejects the field.
+
+**Why**: The vLLM structured-output manager actively enforces the constraint on this route — verified end-to-end with paired discriminating/control requests: the `json`, `regex`, `choice`, `grammar`, and `json_object` kinds each steered output away from the natural answer the control produced. The engine holds the constraint, so there is no need to gate the field at the gateway.
+
+**Caveat — `structural_tag` must be the OBJECT form**: a JSON-encoded *string* `structural_tag` crashes vLLM with an HTTP 500 on the request handler, so the gateway rejects the string form with a 400 on every route. Send the object shape (`{"type":"structural_tag","structures":[...],"triggers":[...]}`).
+
+**Caveat — `response_format` conflict**: `structured_outputs` still cannot be combined with `response_format` (see [#reject-structured_outputs-with-response_format](#reject-structured_outputs-with-response_format)).
+
+**Captured-requests**: n/a — pre-deployment design decision.
+
+---
+
+### #reject-whitespace-names
+
+**What**: HTTP 400 on a name field that is present but contains only whitespace — e.g. `tools[].function.name`, `tool_choice.function.name`, `response_format.json_schema.name`, or a MiniMax tool-result entry `name`. The error reads `...name must be a non-empty string`.
+
+**Why**: Every name validator trims with `strings.TrimSpace` *before* its non-empty check. Without the trim a whitespace-only name passes the gateway, reaches the engine as an effectively empty / nonexistent tool or schema name, and the request produces no usable output — it hangs until the deadline (0 bytes) and ties up a request slot/escrow. This is the same hang class as `max_tokens: 0` and `n: 0`. The engine is not crashed; the request just never completes.
+
+**Maintainer note**: when adding any new name/identifier field to a validator, check it with `strings.TrimSpace(value) == ""` (or `messagevalidators.RequiredNonEmptyString`), never a bare `== ""` — a bare empty-string check is a whitespace-bypass that re-opens this hang.
+
+**Fix (client-side)**: send a real (non-blank) name.
+
+---
+
+### #accept-tool-message-minimax-shape
+
+**What**: On the MiniMaxAI/MiniMax-M2.7 route, `role:"tool"` messages MUST carry `content` as an array of `{name, type:"text", text}` objects (the MiniMax-native shape per [[MiniMax-4]](references.md#minimax)) — not the OpenAI string + `tool_call_id` shape. Bare-string content is rejected with HTTP 400.
+
+**Why**: MiniMax's tool-calling contract correlates tool results by per-entry `name` + positional order inside a tool-result block; there is no `tool_call_id`. The MinimaxToolMessage content validator (registered in the per-model role policy override) enforces the entry shape and caps (≤16 entries, name ≤64 B, text ≤64 KiB, closed allow-list of keys to defend against [[SGLang-2]](references.md#sglang) union-with-null crash class). `tool_call_id`, if dual-emitted by a client porting from OpenAI, is silently stripped — see [strip-tool_call_id-minimax](#strip-tool_call_id-minimax).
+
+**When to restore**: when MiniMax adds OpenAI-compat tool-message handling to their parser.
+
+**Fix (client-side)**: emit the M2.7 shape:
+```json
+{"role": "tool",
+ "content": [
+    {"name": "<function_name>", "type": "text", "text": "<json-stringified result>"}
+ ]}
+```
+Multiple parallel tool results in one block: one array entry per call.
+
+**Captured-requests**: n/a — pre-deployment design decision.
+
 ## Per-model gotchas
 
 Brief pointers to deeper notes in per-model docs:
 
 - **Kimi-K2.6**: [Known model-side bugs we work around](kimi-k2.6.md#known-model-side-bugs-we-work-around)
 - **Qwen3-235B-A22B-Instruct-2507**: [Known model-side bugs we work around](qwen3-235b-a22b-instruct-2507.md#known-model-side-bugs-we-work-around)
+- **MiniMaxAI/MiniMax-M2.7**: [Known model-side bugs we work around](minimax-m2.7.md#known-model-side-bugs-we-work-around)

--- a/docs/chat-api/troubleshooting.md
+++ b/docs/chat-api/troubleshooting.md
@@ -21,6 +21,9 @@ Every parameter that is stripped / rejected / normalized at the gateway is docum
 | `extra_body` keys appear at top level | OpenAI Python SDK passthrough | [#unwrap-extra_body](#unwrap-extra_body) |
 | `enable_thinking` lifts into `chat_template_kwargs` | Qwen3 canonical placement | [#translate-enable_thinking](#translate-enable_thinking) |
 | `reasoning` object decomposed to top-level `reasoning_effort` | OpenRouter unified-reasoning convention | [#translate-reasoning](#translate-reasoning) |
+| 400 on out-of-range `top_p` / `repetition_penalty` / `top_k` | value outside backend-accepted range | [#reject-out-of-range-sampling](#reject-out-of-range-sampling) |
+| 400 on `max_tokens: 0` (non-Kimi route) | zero output budget | [#reject-nonpositive-max-tokens](#reject-nonpositive-max-tokens) |
+| 400 on wrong-typed param (bool / int / array element) | type mismatch caught at the gateway | [#reject-malformed-param-types](#reject-malformed-param-types) |
 
 ## Silent strips
 
@@ -500,6 +503,42 @@ Every parameter that is stripped / rejected / normalized at the gateway is docum
 Multiple parallel tool results in one block: one array entry per call.
 
 **Captured-requests**: n/a — pre-deployment design decision.
+
+---
+
+### #reject-out-of-range-sampling
+
+**What**: HTTP 400 on `top_p ≤ 0`, `repetition_penalty ≤ 0`, or a `top_k` that is neither `-1` nor `≥ 1`.
+
+**Why**: These sampling knobs have ranges the backend enforces: `top_p` must be in `(0, 1]` and `repetition_penalty` must be `> 0` per the OpenAI/vLLM wire schema [[OpenAI-1]](references.md#openai), [[vLLM-1]](references.md#vllm); `top_k` accepts `-1` (disabled) or any integer `≥ 1`. The low end is an *exclusive* bound, so clamping to it would itself be invalid (e.g. `top_p = 0` is not a legal value) — the gateway returns a clear, field-named 400 at the boundary instead of forwarding a value the engine rejects with an opaque error. Values above the *upper* bound are clamped instead (`top_p > 1 → 1`, `repetition_penalty > 2 → 2`), and `temperature` / `min_p` are clamped into `[0, 2]` / `[0, 1]`.
+
+**Fix (client-side)**: send `top_p` in `(0, 1]`, `repetition_penalty > 0`, and `top_k` as `-1` or a positive integer.
+
+**Captured-requests**: n/a — no captures observed.
+
+---
+
+### #reject-nonpositive-max-tokens
+
+**What**: HTTP 400 on `max_tokens: 0` (or `max_completion_tokens: 0`) for non-Kimi routes.
+
+**Why**: A zero output budget is not a meaningful request — vLLM emits no content, and the gateway's redundancy layer then waits for a winner that can never arrive, so the request hangs to the deadline instead of failing fast. The gateway requires `max_tokens ≥ 1` [[OpenAI-1]](references.md#openai). Kimi-K2.6 instead floors small budgets to 16 as part of its think-burn mitigation (see [#kimi-empty-content-think-burn](#kimi-empty-content-think-burn)), so `0` becomes `16` on that route rather than a 400.
+
+**Fix (client-side)**: send `max_tokens ≥ 1`, or omit it to take the route default.
+
+**Captured-requests**: n/a — no captures observed.
+
+---
+
+### #reject-malformed-param-types
+
+**What**: HTTP 400 when a parameter carries the wrong JSON type: non-boolean `stream` / `skip_special_tokens` / `detokenize` / `parallel_tool_calls`; non-integer `seed` / `min_tokens`; non-string elements in `stop` / `bad_words`; non-integer elements in `stop_token_ids`.
+
+**Why**: vLLM rejects these with type errors at the engine boundary, producing opaque upstream 400s. The gateway type-checks them up front against the OpenAI/vLLM wire schema [[OpenAI-1]](references.md#openai), [[vLLM-1]](references.md#vllm) so the client gets an immediate, field-named error instead of a backend round-trip.
+
+**Fix (client-side)**: send each field with its declared type — booleans for the flags, non-negative integers for `seed` / `min_tokens` and `stop_token_ids` elements, strings for `stop` / `bad_words` elements.
+
+**Captured-requests**: n/a — no captures observed.
 
 ## Per-model gotchas
 

--- a/inference-chain/x/inference/module/commands.go
+++ b/inference-chain/x/inference/module/commands.go
@@ -122,8 +122,8 @@ type settlementHostStatsJSON struct {
 	Missed               uint32 `json:"missed"`
 	Invalid              uint32 `json:"invalid"`
 	Cost                 uint64 `json:"cost"`
-	RequiredValidations  uint32 `json:"required_validations"`
-	CompletedValidations uint32 `json:"completed_validations"`
+	RequiredValidations  uint32 `json:"required_validations,omitempty"`
+	CompletedValidations uint32 `json:"completed_validations,omitempty"`
 }
 
 type slotSignatureJSON struct {

--- a/proposals/ethereum-bridge-contact/transfer-ownership.js
+++ b/proposals/ethereum-bridge-contact/transfer-ownership.js
@@ -29,6 +29,16 @@ async function getProviderAndSigner() {
     return { provider, signer, ethers };
 }
 
+async function buildTransferOwnershipOverrides(bridge, newOwnerAddress, feeData) {
+    const gasLimit = await bridge.transferOwnership.estimateGas(newOwnerAddress);
+
+    return {
+        gasLimit,
+        maxFeePerGas: feeData.maxFeePerGas,
+        maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+    };
+}
+
 async function transferOwnership(contractAddress, newOwnerAddress) {
     console.log("=== Transfer Ownership of Bridge Contract ===\n");
     
@@ -93,15 +103,14 @@ async function transferOwnership(contractAddress, newOwnerAddress) {
     console.log("Gas fees:");
     console.log("- Max Fee:", ethers.formatUnits(feeData.maxFeePerGas, "gwei"), "gwei");
     console.log("- Priority Fee:", ethers.formatUnits(feeData.maxPriorityFeePerGas, "gwei"), "gwei");
+    const overrides = await buildTransferOwnershipOverrides(bridge, newOwnerAddress, feeData);
+    console.log("- Gas Limit:", overrides.gasLimit.toString());
     console.log();
     
     // Transfer ownership
     console.log(`Transferring ownership to ${newOwnerAddress}...`);
     console.log("(Confirm the transaction on your Ledger if using hardware wallet)");
-    const tx = await bridge.transferOwnership(newOwnerAddress, {
-        maxFeePerGas: feeData.maxFeePerGas,
-        maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
-    });
+    const tx = await bridge.transferOwnership(newOwnerAddress, overrides);
     
     console.log("✓ Transaction sent:", tx.hash);
     console.log("Waiting for confirmation...");
@@ -169,6 +178,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 }
 
 export {
+    buildTransferOwnershipOverrides,
     transferOwnership
 };
 

--- a/proposals/gateway-observability/observability.md
+++ b/proposals/gateway-observability/observability.md
@@ -1,0 +1,1094 @@
+# Proposal: Devshard Gateway Observability
+
+## Summary
+
+`devshardctl` gateway mode is the reliability layer in front of devshards. It
+selects escrows, routes user requests, starts extra participant attempts, hides
+loser failures, quarantines bad participants, burns ghost/probe slots, serves
+cache hits, and triggers timeout handling.
+
+That makes the final user experience better, but it also hides the evidence that
+devshard protocol developers need. A user request can succeed while several
+participant attempts failed, stalled, were skipped, were shadowed as no-winner,
+or forced extra timeout work. Host-side `devshardd` observability is useful, but
+it is not a trusted global source in a decentralized network. Hosts may be
+dishonest, offline, misconfigured, or unwilling to expose data. Gateway
+observability must therefore provide the gateway-owned outside view of what
+happened.
+
+The goal of this proposal is a metrics-first Grafana dashboard for protocol
+developers. It should show, per participant address, model, and sometimes
+escrow:
+
+- what the user saw,
+- what the gateway sent, skipped, or ghosted,
+- why each gateway-visible failure or policy decision happened,
+- how much overscheduling was needed to protect users,
+- which participants look unreliable, suspicious, slow, or costly,
+- which patterns should inform future protocol changes.
+
+This proposal does not add a lifecycle database, new request drilldown APIs, or
+long-term per-request storage. Each user request and gateway/devshard attempt is
+a lifecycle concept used to increment precise Prometheus metrics, then the raw
+event can disappear.
+
+## Implementation Status
+
+Core V1 is implemented as the first pass:
+
+- Gateway request outcome counters, critical user failure counters, hidden
+  failure counters, user-visible winner counters, slot decision counters,
+  attempt start/terminal/failure counters, no-winner attempt counters,
+  timeout action counters, and participant quarantine state/transition metrics
+  are emitted from the gateway's in-memory Prometheus registry.
+- Per-model capacity gauges expose current scale, current weight, and baseline
+  weight so the dashboard can show reduced capacity by model instead of only an
+  aggregate gateway scale.
+- The focused dashboard is
+  `deploy/join/observability/grafana/dashboards/gonka-gateway-observability.json`.
+  It is organized summary-first with top-N tables, minimum-volume filters, and
+  lower-level drilldown rows so high-cardinality participant and reason data
+  remains readable. The interaction flow is model-first: select a model, inspect
+  top reasons, then drill into participants for the selected reason.
+- Metrics are recorded at existing lifecycle boundaries in `gateway.go`,
+  `redundancy.go`, `session_picker.go` via `runGhostProbe`, and
+  `participant_limiter.go`.
+- The implementation does not add request persistence, new APIs, database
+  writes, or Grafana queries against functional stores.
+
+Deferred from Core V1:
+
+- Diagnostic V1 metric families not needed for the first dashboard.
+- Core inference performance metric families listed below. They are design
+  targets, not emitted metrics in the current implementation.
+- Decode-token histograms and token/s calculations that require actual output
+  token plumbing.
+- Lifecycle database, request drilldown APIs, OTEL/Jaeger traces,
+  Loki-derived panels, and offline protocol-analysis exports.
+
+TODO: review naming across gateway metrics, dashboard labels, and docs for
+`slot`, `nonce`, `diff`, `decision`, `attempt`, and `vote`. In particular,
+`devshard_gateway_slot_decisions_total` is currently displayed as gateway nonce
+consumption in the dashboard because it counts real sends and ghost/no-send
+nonce burns, not voting amount. A later cleanup should decide whether to rename
+the emitted metric or keep it as a compatibility name with clearer dashboard
+labels.
+
+## Goal
+
+Gateway observability must answer protocol-development questions without trusting
+host-owned metrics:
+
+1. Which participant addresses perform worse for each model?
+2. Why did each participant fail or get skipped: no receipt, empty stream,
+   transport error, timeout, quarantine, capability miss, state divergence, or
+   another bounded reason?
+3. Which user-visible successes hid participant failures?
+4. How often does the gateway need extra real sends, ghost burns, probes, or
+   skipped slots to keep user failures near zero?
+5. How many slots are skipped because of quarantine, and which quarantine mode
+   caused the skip?
+6. Which participants are no-winner because of shadow quarantine, probation, or
+   manual suspicion?
+7. Which timeout actions are expected, started, completed, skipped, or failed?
+8. Which metrics should protocol developers use to tune participant selection,
+   redundancy, timeout windows, quarantine thresholds, validation, and
+   incentives?
+
+The first result should be one clear gateway dashboard backed by bounded
+Prometheus counters, gauges, and histograms. The dashboard must preserve failure
+reasons everywhere it shows failures. A panel that says only "failed" is not
+enough.
+
+## Non-Goals
+
+- Do not add a lifecycle DB or any new request/attempt persistence.
+- Do not add new admin APIs or drilldown endpoints.
+- Do not write new observability data to `gateway.db`, `perf.db`, or devshard
+  session storage.
+- Do not make dashboards query hot functional stores.
+- Do not add OTEL, Jaeger, or tracing requirements in the first pass.
+- Do not expose request bodies, prompt hashes, response bodies, private key
+  material, raw errors, `request_id`, or `nonce` in Prometheus labels.
+- Do not use host-side `devshardd` metrics as the source of truth for gateway
+  accountability.
+- Do not try to prove semantic truthfulness of model output. The gateway can
+  observe transport, timing, stream, protocol, and policy behavior; it cannot
+  prove the answer content is honest.
+
+## Current Gateway Role
+
+The important gateway code paths are:
+
+| Area | Files | Current responsibility |
+| --- | --- | --- |
+| Gateway routing | `devshard/cmd/devshardctl/gateway.go` | Request admission, model access, capacity-aware runtime selection, cache hits, runtime skip reasons. |
+| Per-escrow HTTP | `devshard/cmd/devshardctl/proxy.go` | OpenAI-compatible request handling, request accounting/debug surfaces, response mapping. |
+| Redundancy | `devshard/cmd/devshardctl/redundancy.go` | Primary and extra attempts, winner selection, loser suppression, empty stream/stall detection, timeout actions. |
+| Slot selection | `devshard/cmd/devshardctl/session_picker.go` | Nonce/host selection, ghost/probe/no-send reasons, capability and quarantine skips. |
+| Participant health | `devshard/cmd/devshardctl/participant_limiter.go` | Probe quarantine, shadow quarantine, probation, manual no-winner, failure strikes. |
+| Performance scoring | `devshard/cmd/devshardctl/hostperf.go`, `devshard/cmd/devshardctl/pairwise.go` | Rolling responsiveness and pairwise latency signals used for speculative routing. |
+| Metrics | `devshard/cmd/devshardctl/metrics.go` | Existing Prometheus gateway metrics and the right extension point. |
+| Transport | `devshard/transport/client.go` | Upstream HTTP status, transport failures, SSE/receipt path, host connection tracking. |
+
+Existing gateway metrics already cover HTTP route health, limiter rejection,
+speculative decision counts, timeout summary counts, picker choices, host timing
+by `host_idx`, runtime capacity, and transport connection state. The current gap
+is participant-accountable, reason-complete gateway behavior.
+
+The existing devshardd dashboards cover host/protocol internals such as terminal
+outcomes, interruptions, ML-node execute/validate attempts, validation
+lifecycle, payload serving, mempool/queue depth, traces, and logs. Gateway
+observability is the complementary outside view. It must remain useful even when
+host-side devshardd data is absent or untrusted.
+
+## Terminology Alignment
+
+Metric names, labels, reasons, and lifecycle terms must align with existing
+devshard terminology wherever possible.
+
+Primary sources:
+
+- `devshard/` code, especially `devshard/cmd/devshardctl/`
+- `devshard/docs/`
+- `devshard/observability/` naming patterns
+- `proposals/inference/` as earlier design context, with caution because it is
+  partly outdated
+
+Do not invent parallel names when an existing devshard term exists. If gateway
+observability needs a new term, the proposal must explain why the existing term
+does not fit and how the new term maps back to devshard protocol concepts.
+
+## Request Hierarchy
+
+One user request can produce zero, one, or many gateway/devshard attempts or
+scheduling decisions.
+
+```mermaid
+flowchart TD
+    UserRequest["User request"] --> Gateway["Gateway admission, routing, cache"]
+    Gateway --> UserStatus["User request status"]
+    Gateway --> AttemptA["Gateway/devshard attempt: primary"]
+    Gateway --> AttemptB["Gateway/devshard attempt: extra"]
+    Gateway --> AttemptC["Gateway/devshard decision: probe, ghost, or skipped"]
+    AttemptA --> AttemptStatusA["Attempt status + reason"]
+    AttemptB --> AttemptStatusB["Attempt status + reason"]
+    AttemptC --> DecisionStatus["Decision status + reason"]
+    AttemptStatusA --> Aggregate["Aggregate by user request"]
+    AttemptStatusB --> Aggregate
+    DecisionStatus --> Aggregate
+    Aggregate --> Metrics["Metrics and dashboard"]
+```
+
+User request outcome answers whether the final user was served. Critical user
+failures should be close to zero.
+
+Gateway/devshard attempt status answers what happened to each participant
+communication or scheduling decision. Attempt failures may be non-zero even when
+the user request succeeded.
+
+Overscheduling is the ratio between user requests and gateway/devshard attempts
+or decisions. Hidden failure rate is the rate of successful user requests where
+one or more gateway/devshard attempts failed, stalled, timed out, were no-winner,
+or were skipped for policy/health reasons.
+
+Skipped-slot pressure is tracked separately because it changes protocol behavior
+even when no HTTP request is sent.
+
+## Dimensions And Labels
+
+Use these dimensions consistently:
+
+| Dimension | Meaning | Prometheus label? |
+| --- | --- | --- |
+| `participant_key` | Gonka validator address / participant identity. Primary accountability key. | Yes, bounded by fewer than 100 participant keys in the target deployment. |
+| `model` | Requested model id. Required for capability and performance comparison. | Yes. |
+| `escrow_id` / `devshard_id` | On-chain devshard escrow/session. Existing gateway metrics usually call this `devshard_id`; this proposal uses `escrow_id` for the same logical id unless referencing existing metrics. Required for localized routing, skipped-slot, and timeout diagnosis. Not part of the default participant-quality view. | Sometimes. Use on counters where per-escrow attribution matters. Avoid it on default performance histograms. |
+| `host_idx` | Escrow-local slot index. Useful only with escrow membership mapping. | Existing host-index metrics may keep it; new accountability metrics should prefer `participant_key`. |
+| `role` | Why this attempt exists: primary, extra, ghost, skipped, cache alias. | Yes. |
+| `visibility` | Whether an attempt was user-visible, suppressed, no-winner, or failed before usable output. | Yes. |
+| `outcome` | Terminal result for a specific metric family. Each metric must define its own legal outcome enum. | Yes. |
+| `reason` | Bounded explanation from code path/log stage. | Yes. Required on failure and policy counters. |
+| `input_token_bucket` | Coarse gateway-side request input estimate. It is not guaranteed to be exact model-tokenizer output. | Yes for performance metrics. |
+| `output_token_bucket` | Coarse output-token bucket. Only valid when actual output token count is known. | Yes for decode metrics. |
+| `stream` | Whether the request used streaming. | Only where streaming and non-streaming share a metric. |
+| `capability_reason` | Bounded subreason for capability no-send. | Only on capability-specific counters. |
+| `request_id` | Gateway request id for logs/debug lookup. | No. |
+| `nonce` | Devshard inference nonce. | No. |
+
+Forbidden labels: raw error text, request body data, prompt hash, response hash,
+private key material, URLs with unbounded ids, `request_id`, `nonce`, trace id.
+
+Reason values must be bounded. If a reason cannot be classified, emit
+`reason="unknown"` and make that rare enough to alert on.
+
+### Token Buckets, Visibility, And Hidden Failure Severity
+
+Use coarse token buckets in dashboards. Do not expose exact input tokens, output
+tokens, `max_tokens`, or `max_completion_tokens` as labels.
+
+`input_token_bucket` uses the best gateway-side estimate available at the metric
+emission point. It must not be treated as canonical model tokenization unless the
+implementation has actual tokenizer-backed input tokens.
+
+Input token buckets:
+
+| Bucket | Meaning |
+| --- | --- |
+| `lt_10k` | Fewer than 10,000 input tokens. |
+| `10k_50k` | At least 10,000 and fewer than 50,000 input tokens. |
+| `50k_100k` | At least 50,000 and fewer than 100,000 input tokens. |
+| `100k_256k` | At least 100,000 and fewer than 256,000 input tokens. |
+| `gte_256k` | At least 256,000 input tokens. |
+
+Output token buckets:
+
+| Bucket | Meaning |
+| --- | --- |
+| `lt_128` | Fewer than 128 output tokens. |
+| `128_512` | At least 128 and fewer than 512 output tokens. |
+| `512_2k` | At least 512 and fewer than 2,000 output tokens. |
+| `2k_8k` | At least 2,000 and fewer than 8,000 output tokens. |
+| `gte_8k` | At least 8,000 output tokens. |
+
+Attempt visibility values:
+
+| Visibility | Meaning |
+| --- | --- |
+| `user_visible_winner` | This attempt produced the content shown to the user. Use for SLO and final-user performance panels. |
+| `suppressed_loser` | The attempt produced or could have produced data, but another attempt won. Use for hidden cost and participant-quality analysis. |
+| `no_winner_candidate` | The participant was shadow-quarantined, probationary, or manually suspicious and could not win normally. |
+| `failed_not_finished` | The attempt failed or did not reach usable output. |
+
+Hidden failure severity values:
+
+| Severity | Meaning |
+| --- | --- |
+| `loser_pre_winner` | A non-winning attempt failed before the user-visible winner was selected. |
+| `loser_after_winner` | A non-winning attempt failed after another attempt already protected the user. |
+| `winner_post_content` | The user-visible winner produced content, then stalled or failed. |
+| `scheduling_only` | A ghost/no-send, queue, cache, or policy decision created overhead without an upstream participant failure. |
+
+## Reason Taxonomy
+
+The dashboard must show why failures happened. Reason values should map to
+existing code paths or log stages, not invented analytical guesses.
+
+### Admission And Routing Reasons
+
+| Reason | Meaning |
+| --- | --- |
+| `max_concurrent_requests` | Gateway concurrency cap rejected the user request. |
+| `max_input_tokens_in_flight` | Gateway input-token cap rejected the user request. |
+| `model_access_denied` | Model access mode rejected the caller. |
+| `unsupported_model` | No configured runtime supports the requested model. |
+| `model_temporarily_unavailable` | Model exists but policy temporarily blocks it. |
+| `no_runtime_for_model` | No active compatible runtime exists. |
+| `all_escrows_zero_capacity` | Candidate escrows exist but all have zero effective capacity. |
+| `high_nonce` | Candidate escrow is near or over its nonce limit. |
+| `inactive` | Candidate escrow is inactive. |
+| `finalizing` | Candidate escrow is finalizing. |
+| `settlement` | Candidate escrow is in settlement. |
+| `low_balance` | Escrow balance is low enough to affect routing or replacement. |
+| `balance_exhausted` | Escrow balance was exhausted. |
+| `escrow_missing` | Escrow lookup or upstream escrow state was missing. |
+| `insufficient_balance` | Escrow cannot pay for more work. |
+| `invalid_request` | Request parsing, normalization, or parameter validation failed. |
+| `body_required` | Request body was missing. |
+| `body_too_large` | Request body exceeded the gateway limit. |
+| `malformed_json` | Request body was not valid JSON. |
+| `unknown_parameter` | Request contained a rejected parameter. |
+| `messages_invalid` | Request messages were malformed or unsupported. |
+| `parameter_invalid` | Request parameter failed validation. |
+| `schema_invalid` | Structured schema validation failed. |
+| `structured_outputs_invalid` | Structured output settings were invalid. |
+| `operator_disabled` | Gateway disabled mode returned a configured response. |
+| `cache_hit` | User request was served from cache. |
+
+### Scheduling And Slot Reasons
+
+Use existing picker and redundancy strings where possible.
+
+| Reason | Meaning |
+| --- | --- |
+| `normal` | Primary path. |
+| `primary_unresponsive` | PerfTracker expects primary to be slow or failed. |
+| `receipt_timeout` | No receipt arrived in the expected window. |
+| `first_token_timeout` | Receipt arrived but first token lagged. |
+| `attempt_failed` | Prior attempt failed before winner selection. |
+| `primary_suspicious` | Primary is suspicious or shadow/no-winner. |
+| `suspicious_host` | Escalation caused by suspicious/no-winner host. |
+| `pairwise_budgeted_speedup` | Pairwise tracker expects another participant to be faster. |
+| `pairwise_ab_sample` | Intentional pairwise exploration sample. |
+| `pairwise_insufficient_data` | Pairwise mode lacks enough data and falls back. |
+| `secondary_faster` | Legacy/simple speed policy expects secondary advantage. |
+| `poc_probe` | PoC/probe path caused extra scheduling. |
+| `poc_unavailable_host` | Picker burned a ghost because PoC made the host unavailable. |
+| `participant_throttled_no_send` | Picker burned a ghost because the participant is probe-quarantined/throttled. |
+| `participant_capability_no_send` | Participant cannot serve the request shape/model. |
+| `no_compatible_request_after_stale` | Queued requests excluded this participant past the stale threshold. |
+| `all_hosts_excluded` | Request already tried every distinct participant in the escrow. |
+| `no_available_host` | Untried participants exist but none are currently usable. |
+| `stale_wait` | Picker held a queued request while waiting for a compatible slot. |
+| `context_cancelled` | Picker or request context was cancelled before dispatch. |
+| `picker_stopped` | Picker stopped before it could dispatch. |
+
+### Attempt Failure Reasons
+
+| Reason | Meaning |
+| --- | --- |
+| `no_receipt` | No receipt was observed. |
+| `receipt_but_no_content` | Receipt arrived but no content appeared. |
+| `empty_stream` | Stream produced no usable content chunks. |
+| `error_stream` | Host returned an OpenAI-style streamed error. |
+| `content_but_not_finished` | Content appeared but finish was missing. |
+| `winner_stalled_after_content` | Winner emitted content then stalled. |
+| `inter_chunk_stall` | Stream stalled between chunks. |
+| `hard_timeout` | Attempt exceeded the hard timeout. |
+| `transport_error` | Connection, DNS, TLS, timeout, or non-HTTP transport failure. |
+| `eof_transport` | EOF-style stream/read failure. |
+| `sse_truncated` | SSE stream ended unexpectedly. |
+| `http_429` | Host returned HTTP 429. |
+| `http_503` | Host returned HTTP 503. |
+| `http_forbidden` | Host returned HTTP 403. |
+| `http_not_found` | Host returned HTTP 404. |
+| `http_timestamp_drift` | Host returned timestamp-related HTTP 401. |
+| `http_error` | Other non-success HTTP status. |
+| `phase_transition_aborted` | Phase changed and attempt was intentionally aborted. |
+| `state_divergence` | Local/session state diverged from expected state. |
+| `client_cancelled` | Client disconnected or cancelled. |
+
+### Policy And Participant-Health Reasons
+
+| Reason | Meaning |
+| --- | --- |
+| `probe_quarantine` | Participant is blocked from real traffic for the model. |
+| `shadow_quarantine` | Participant receives traffic but cannot win. |
+| `probation` | Participant is recovering but remains no-winner. |
+| `manual_suspicious` | Participant is on the manual suspicious list. |
+| `empty_stream_quarantine` | Empty-stream strike threshold caused shadow quarantine. |
+| `eof_transport_quarantine` | EOF strike threshold caused probe quarantine. |
+| `transport_failure_quarantine` | Non-EOF transport failure caused probe quarantine. |
+| `http_throttle_quarantine` | HTTP 429/503 caused probe quarantine. |
+| `stalled_winner_quarantine` | Stalled winner caused shadow quarantine. |
+
+### Timeout Taxonomy
+
+Timeout metrics use three separate label dimensions: `kind`, `action`, and
+`reason`. Do not duplicate `kind` or `action` values inside `reason`.
+
+Timeout kind values:
+
+| Kind | Meaning |
+| --- | --- |
+| `refused` | No receipt before refusal timeout. |
+| `execution` | Receipt exists but execution did not finish before execution timeout. |
+| `unknown` | Classified fallback. |
+
+Timeout action values:
+
+| Action | Meaning |
+| --- | --- |
+| `expected` | Attempt should need timeout handling. |
+| `started` | Timeout handling began. |
+| `completed` | Timeout handling completed. |
+| `skipped` | Timeout handling was intentionally skipped. |
+| `failed` | Timeout handling failed. |
+
+Timeout reason values:
+
+| Reason | Meaning |
+| --- | --- |
+| `none` | No additional reason applies. |
+| `nonce_already_finished` | Timeout skipped because nonce was already finished. |
+| `empty_stream_without_non_empty_winner` | Timeout skipped for empty stream without a non-empty winner. |
+| `long_response_after_content` | Timeout skipped/deferred because long content had already appeared. |
+| `timeout_insufficient_votes` | Timeout vote collection lacked enough accepted weight. |
+| `timeout_collection_error` | Timeout vote collection failed. |
+| `timeout_diff_send_failed` | Timeout diff could not be sent. |
+| `timeout_vote_rejected` | A contacted verifier rejected the timeout. |
+| `timeout_vote_error` | A contacted verifier errored while verifying timeout. |
+| `timeout_vote_queue_expired` | Verifier queue wait expired before the vote RPC. |
+
+Per-verifier timeout vote metrics are future work unless `user.Session` exposes
+structured verifier outcomes. Executor-level timeout actions are in scope.
+
+## Metric Taxonomy
+
+Metrics should be incremented at existing gateway lifecycle boundaries. Do not
+add a request ledger to derive them later.
+
+### Authoritative Metrics
+
+Use one authoritative metric for each dashboard question. Other metrics may add
+diagnostic detail, but they should not be mixed into the same ratio without an
+explicit reason.
+
+| Question | Authoritative metric |
+| --- | --- |
+| What happened to the user request? | `devshard_gateway_requests_total` |
+| Whose output did users see? | `devshard_gateway_user_visible_wins_total` |
+| Which user successes hid gateway-visible problems? | `devshard_gateway_user_requests_with_hidden_failure_total` |
+| Which slots were real sends, ghost/no-send burns, or exhausted? | `devshard_gateway_slot_decisions_total` |
+| Which real attempts started? | `devshard_gateway_attempts_started_total` |
+| How did real attempts terminate? | `devshard_gateway_attempts_terminal_total` and `devshard_gateway_attempt_failures_total` |
+| What is the current participant quarantine/no-winner state? | `devshard_gateway_participant_quarantine_state` |
+| What timeout work happened for a participant? | `devshard_gateway_timeout_actions_total` |
+| How fast was user-visible and attempt-level inference? | `devshard_gateway_user_visible_ttft_seconds`, `devshard_gateway_attempt_first_content_seconds`, and decode token/duration metrics |
+
+### Core V1 Metrics
+
+Core metrics drive the first dashboard and default participant-quality table.
+They avoid `escrow_id` unless the metric is specifically about slots.
+
+```text
+devshard_gateway_requests_total{model,outcome,reason}
+devshard_gateway_critical_user_failures_total{model,reason}
+devshard_gateway_user_requests_with_hidden_failure_total{model,severity,reason}
+devshard_gateway_user_visible_wins_total{participant_key,model}
+
+devshard_gateway_slot_decisions_total{
+  participant_key,
+  model,
+  escrow_id,
+  decision,
+  reason,
+  quarantine_mode
+}
+
+devshard_gateway_attempts_started_total{
+  participant_key,
+  model,
+  role,
+  reason,
+  quarantine_mode
+}
+
+devshard_gateway_attempts_terminal_total{
+  participant_key,
+  model,
+  role,
+  outcome,
+  visibility
+}
+
+devshard_gateway_attempt_failures_total{
+  participant_key,
+  model,
+  role,
+  reason,
+  visibility
+}
+
+devshard_gateway_participant_quarantine_state{participant_key,model,mode}
+devshard_gateway_participant_quarantine_transitions_total{participant_key,model,mode,reason}
+devshard_gateway_no_winner_attempts_total{participant_key,model,reason,quarantine_mode}
+
+devshard_gateway_timeout_actions_total{
+  participant_key,
+  model,
+  kind,
+  action,
+  reason
+}
+```
+
+User request `outcome` values:
+
+| Outcome | Meaning |
+| --- | --- |
+| `success` | User received a successful response or stream. |
+| `failed` | Gateway returned an error after trying or deciding no usable path exists. |
+| `cached` | Gateway served cached output without new participant traffic. |
+| `client_cancelled` | Client disconnected or cancelled. |
+| `model_rejected` | Model policy/access rejected the request. |
+| `gateway_limited` | Gateway-wide limit rejected the request. |
+| `runtime_unavailable` | No compatible runtime/escrow was available. |
+| `invalid_request` | Request failed parsing or validation. |
+| `gateway_disabled` | Gateway disabled mode returned a configured response. |
+| `unknown` | Classified fallback; should be rare. |
+
+Real attempt `role` values:
+
+| Role | Meaning |
+| --- | --- |
+| `primary` | First real attempt intended to serve the user request. |
+| `extra` | Additional real attempt caused by redundancy/fallback. |
+
+Ghost/no-send, skipped, and cache-alias decisions are counted by
+`slot_decisions_total`, `picker_queue_events_total`, or request/cache metrics,
+not by real attempt metrics. Do not use `role="probe"` for current gateway
+behavior; current probe-like paths are ghost/no-send burns unless a future
+implementation introduces a real HTTP probe.
+
+Real attempt `outcome` values:
+
+| Outcome | Meaning |
+| --- | --- |
+| `success` | Attempt completed and is usable. |
+| `failed` | Attempt ended with a communication, stream, protocol, or application failure. |
+| `not_finished` | Attempt started but did not reach expected finish state. |
+| `client_cancelled` | Client cancellation affected the attempt. |
+| `timeout_skipped` | Timeout was expected but intentionally skipped. |
+| `unknown` | Classified fallback; should be rare. |
+
+`attempt_failures_total` carries `reason`; `attempts_terminal_total` does not.
+This keeps high-cardinality failure reasons out of the main terminal counter.
+
+`visibility` is the single winner/loser/no-winner encoding for attempt metrics.
+Do not add parallel `winner`, `hidden_from_user`, or `no_winner` boolean labels.
+`attempts_started_total` does not include `visibility` because winner/loser state
+is only known later, after race settlement.
+
+`user_requests_with_hidden_failure_total` is emitted at user-request settlement,
+after the gateway knows the final user request outcome and whether another
+attempt protected the client.
+
+`critical_user_failures_total` is the small user-visible failure set that should
+stay near zero. It should include failed, runtime unavailable, gateway limited,
+invalid request, and model rejected when those are not intentional maintenance.
+
+`user_visible_wins_total` counts the participant whose output was actually shown
+to the user. It has no `escrow_id` label by default because the main question is
+which address users really see for each model. Cached requests should not
+increment this metric unless the gateway can safely attribute the cache source to
+the original winner.
+
+Route latency should use the existing gateway HTTP duration metric unless a
+model-aware duration is added later.
+
+### Core Inference Performance Metrics
+
+Status: not implemented in Core V1. These metric names are future
+instrumentation targets and should not be referenced by the current dashboard
+until `devshardctl` emits them.
+
+```text
+devshard_gateway_attempt_receipt_seconds{participant_key,model,outcome}
+devshard_gateway_attempt_total_seconds{participant_key,model,outcome}
+
+devshard_gateway_user_visible_ttft_seconds{
+  participant_key,
+  model,
+  input_token_bucket,
+  outcome
+}
+
+devshard_gateway_attempt_first_content_seconds{
+  participant_key,
+  model,
+  input_token_bucket,
+  visibility,
+  outcome
+}
+
+devshard_gateway_attempt_prefill_after_receipt_seconds{
+  participant_key,
+  model,
+  input_token_bucket,
+  visibility,
+  outcome
+}
+
+devshard_gateway_attempt_decode_duration_seconds{
+  participant_key,
+  model,
+  input_token_bucket,
+  output_token_bucket,
+  visibility,
+  outcome
+}
+
+devshard_gateway_attempt_decode_tokens_total{
+  participant_key,
+  model,
+  input_token_bucket,
+  output_token_bucket,
+  visibility,
+  outcome
+}
+```
+
+These metrics attribute inference performance to participant identity, not only
+escrow-local `host_idx`. Keep the default participant-quality performance view
+aggregated by `participant_key` and `model`. Escrow-specific performance belongs
+in diagnostics only.
+
+Definitions:
+
+| Metric | Meaning |
+| --- | --- |
+| `attempt_receipt_seconds` | Time from upstream send to devshard receipt. |
+| `attempt_total_seconds` | Time from upstream send to attempt completion. Do not include loser settlement after the attempt is done. |
+| `user_visible_ttft_seconds` | Time from gateway request acceptance to the first content-bearing chunk successfully written to the client for the user-visible winner. Cache hits and non-streaming requests do not increment it. |
+| `attempt_first_content_seconds` | Time from upstream attempt send to the first content-bearing chunk for that attempt. |
+| `attempt_prefill_after_receipt_seconds` | Time from receipt observed by the gateway to the first content-bearing chunk. |
+| `attempt_decode_duration_seconds` | Time from first content-bearing chunk to generation end for that attempt. Do not include timeout handling, loser settlement, or background drain. |
+| `attempt_decode_tokens_total` | Actual output tokens for the attempt, from `MsgFinishInference.OutputTokens` or final OpenAI usage when available. |
+
+Decode tokens/s is derived from `attempt_decode_tokens_total` and
+`attempt_decode_duration_seconds`. Do not add a separate
+`attempt_decode_tokens_per_second` metric in the first pass. Do not derive decode
+tokens/s from SSE chunk count. Chunks and bytes can be useful future diagnostics,
+but they are not tokens. If actual output tokens are unavailable, do not
+increment decode token metrics.
+
+For thinking/reasoning models, content-bearing chunks include visible assistant
+content, reasoning content, and tool-call content if those chunks are forwarded
+to the user. If a future dashboard needs "first visible answer token" separate
+from "first reasoning/tool token", add a new bounded `content_source` label or a
+separate metric.
+
+### Derived Ratios
+
+Do not add a separate required `devshard_gateway_overscheduled_attempts_total`
+counter. Overscheduling overlaps with request, slot, and attempt metrics and
+should be derived from authoritative counters.
+
+```text
+extra_real_sends_per_user_request =
+  rate(devshard_gateway_attempts_started_total{role="extra"}[$window])
+  / rate(devshard_gateway_requests_total[$window])
+
+ghost_no_send_per_user_request =
+  rate(devshard_gateway_slot_decisions_total{decision="ghost_no_send"}[$window])
+  / rate(devshard_gateway_requests_total[$window])
+
+suppressed_losers_per_user_request =
+  rate(devshard_gateway_attempts_terminal_total{visibility="suppressed_loser"}[$window])
+  / rate(devshard_gateway_requests_total[$window])
+
+failed_sent_attempts_per_successful_user_request =
+  rate(devshard_gateway_attempts_terminal_total{
+    outcome=~"failed|not_finished",
+    visibility="failed_not_finished"
+  }[$window])
+  / rate(devshard_gateway_requests_total{outcome="success"}[$window])
+```
+
+### Diagnostic V1 Metrics
+
+Diagnostic metrics explain localized or lower-level gateway behavior. They can
+appear in gateway mechanics, heatmaps, or drilldown panels, but should not drive
+the default participant-quality score unless explicitly stated.
+
+Status: not implemented in Core V1. Treat metric names in this section as future
+metric contracts. Dashboards should not reference them until implementation and
+dashboard lint confirm they are emitted.
+
+#### Runtime Selection
+
+```text
+devshard_gateway_runtime_selection_total{model,escrow_id,outcome,reason}
+```
+
+Runtime selection `outcome` values: `selected`, `skipped`, `unavailable`.
+
+#### Cache Lifecycle
+
+```text
+devshard_gateway_cache_events_total{model,stream,event,reason}
+```
+
+`event` values: `hit`, `miss`, `stored`, `store_skipped`, `expired`.
+
+`reason` should stay bounded: `cache_hit`, `cache_miss`,
+`noncacheable_status`, `noncacheable_error`, `write_error`, `request_error`,
+`expired`, `unknown`.
+
+#### Limiter And PoC Bypass
+
+```text
+devshard_gateway_limiter_bypass_total{model,reason}
+```
+
+`reason` values: `poc`, `confirmation_poc`, `unknown`.
+
+#### Picker Queue Events
+
+```text
+devshard_gateway_picker_queue_events_total{model,escrow_id,event,reason}
+```
+
+`event` values: `hold`, `drop`, `chooser_error`, `stopped`.
+
+`held` is not a slot decision because it does not consume a nonce. Use this
+metric for queue holds and drops, and `slot_decisions_total` for real sends or
+ghost/no-send nonce burns.
+
+#### Capability Subreasons
+
+```text
+devshard_gateway_capability_no_send_total{
+  participant_key,
+  model,
+  escrow_id,
+  capability_reason
+}
+```
+
+`capability_reason` values: `tool_choice_unsupported`,
+`context_limit_exceeded`, `escrow_state_root_diverged`, `unknown`.
+
+#### Escalation Starts And Skips
+
+```text
+devshard_gateway_escalations_total{
+  participant_key,
+  model,
+  stage,
+  action,
+  trigger_reason,
+  skip_reason
+}
+```
+
+`action` values: `started`, `skipped`.
+
+`skip_reason` values: `attempt_limit`, `race_decided`, `exhausted`,
+`client_cancelled`, `unknown`. Use `skip_reason="none"` when action is
+`started`.
+
+#### No-Winner Fallback Wins
+
+```text
+devshard_gateway_no_winner_fallback_wins_total{
+  participant_key,
+  model,
+  reason,
+  quarantine_mode
+}
+```
+
+This counts cases where a suspicious, shadow-quarantined, or probationary
+participant eventually becomes the fallback winner because no clean winner is
+available.
+
+#### Participant Strike And Manual Suspicion State
+
+```text
+devshard_gateway_participant_failure_strikes{participant_key,model,mode}
+devshard_gateway_manual_suspicion_state{participant_key}
+devshard_gateway_manual_suspicion_transitions_total{participant_key,action}
+```
+
+`action` values for manual suspicion: `added`, `removed`.
+
+#### Upstream Transport Attribution
+
+```text
+devshard_gateway_upstream_requests_total{
+  participant_key,
+  model,
+  path_kind,
+  outcome,
+  status_code,
+  error_class,
+  quarantine_action
+}
+```
+
+`path_kind` should reuse existing transport path kinds: `inference`,
+`verify_timeout`, `challenge_receipt`, `gossip`, `query`, `other`.
+
+`outcome` values: `success`, `http_error`, `transport_error`,
+`admission_rejected`, `cancelled`, `unknown`.
+
+`error_class` values should be bounded: `none`, `eof`, `sse_truncated`,
+`dial_timeout`, `connection_refused`, `connection_reset`, `dns`, `tls`,
+`context_cancelled`, `other`.
+
+`quarantine_action` values: `none`, `probe_quarantine`, `shadow_quarantine`,
+`strike_incremented`, `ignored_non_inference`.
+
+#### Stream Delivery Outcomes
+
+```text
+devshard_gateway_stream_delivery_total{model,outcome,reason}
+```
+
+`outcome` values: `ok`, `client_cancelled`, `write_failed`, `flush_failed`,
+`done_write_failed`, `host_error`, `error_after_done`, `unknown`.
+
+This tracks gateway-to-client delivery, not host execution. Client delivery
+failures matter because the gateway can continue background drain or protocol
+settlement after the user is gone. They should not be confused with participant
+execution quality.
+
+## Dashboard
+
+Add a gateway dashboard focused on protocol developers. The dashboard should have
+filters for `model`, `participant_key`, `escrow_id`, `reason`, and time window.
+
+Core rows should use the authoritative metrics listed above. Diagnostic rows can
+use more specialized metrics, but they should not change the default
+participant-quality score without an explicit dashboard note.
+
+### Row 1: User Health
+
+Purpose: show whether users are protected.
+
+Panels:
+
+- User requests by `outcome` and `reason`.
+- Critical user failures by `reason`.
+- User success rate.
+- Gateway p95 route latency.
+- Active requests and input tokens in flight from existing gateway metrics.
+- Limiter rejects by reason.
+- Runtime unavailable / model rejected / invalid request rates.
+- Cache hit rate.
+
+### Row 2: Devshard Attempt Health
+
+Purpose: show what happened behind each user request.
+
+Panels:
+
+- Attempts started by `role`.
+- Attempts terminal by `outcome`.
+- Attempt failures by `reason`.
+- Winner vs loser outcomes.
+- User-visible wins by participant and model.
+- Sent attempts per user request.
+- Failed sent attempts per successful user request.
+
+### Row 3: Inference Performance
+
+Purpose: compare user-visible latency and participant execution quality.
+
+Panels:
+
+- User-visible TTFT p50/p95/p99 by model and input token bucket.
+- User-visible TTFT p95 by participant and model.
+- Attempt first-content p95 by `visibility`, model, and input token bucket.
+- Prefill-after-receipt p95 by participant and input token bucket.
+- Decode tokens/s p50/p95 by participant, model, and input token bucket.
+- Decode tokens/s comparison for `user_visible_winner` vs `suppressed_loser`.
+- Slow-but-successful participants: high TTFT or decode latency with low failure
+  rate.
+- Fast-but-unreliable participants: low TTFT but high hidden failure, no-winner,
+  or timeout rate.
+
+### Row 4: Hidden Failures
+
+Purpose: show failures hidden by redundancy.
+
+Panels:
+
+- User requests with hidden failures by severity and reason.
+- Hidden loser failures before winner selection.
+- Hidden loser failures after winner selection.
+- Winner failures after content.
+- Top hidden failure participants by model.
+- Top hidden failure reasons by model.
+
+### Row 5: Overscheduling
+
+Purpose: show cost of protecting the user.
+
+Panels:
+
+- Extra real sends per user request.
+- Ghost/no-send slots per user request.
+- Suppressed losers per user request.
+- Overscheduling derived from authoritative request, slot, and attempt metrics.
+- Useful redundancy vs waste:
+  - useful: `receipt_timeout`, `first_token_timeout`,
+    `primary_unresponsive`, `attempt_failed`, `pairwise_budgeted_speedup`;
+  - exploration: `pairwise_ab_sample`, `poc_probe`;
+  - waste/policy pressure: `participant_throttled_no_send`,
+    `participant_capability_no_send`, `no_compatible_request_after_stale`,
+    `all_hosts_excluded`, `no_available_host`, `manual_suspicious`,
+    `shadow_quarantine`, `probation`.
+
+### Row 6: Skipped Slots And Quarantine Pressure
+
+Purpose: show how much protocol scheduling is changed before any HTTP send.
+
+Panels:
+
+- Slots skipped because of quarantine by participant, model, and escrow.
+- Ghost burns by reason.
+- Capability no-send by model and participant.
+- PoC unavailable host ghost burns.
+- No available host / all hosts excluded rates.
+- Current quarantine state by participant and model.
+- Quarantine transitions by reason.
+
+### Row 7: Participant Quality
+
+Purpose: make bad or suspicious addresses obvious.
+
+Default table dimensions: `participant_key`, `model`.
+
+Do not include `escrow_id` in the default participant quality table. Escrow views
+belong in the heatmaps and localized diagnostics, where the question is whether a
+specific escrow has routing, slot, or timeout problems.
+
+Columns:
+
+| Column | Meaning |
+| --- | --- |
+| sent attempts | Real communications sent upstream. |
+| success rate | `success / sent attempts`. |
+| hidden failure rate | Hidden failures on successful user requests. |
+| no receipt rate | `reason=no_receipt`. |
+| empty stream rate | `reason=empty_stream`. |
+| transport error rate | Transport and EOF reasons. |
+| timeout action rate | Timeout expected/started/completed/skipped/failed. |
+| p95 receipt | Receipt latency. |
+| p95 user-visible TTFT | Time until users see first content from this participant. |
+| p95 first content | Attempt first-content latency. |
+| p95 prefill after receipt | Time from receipt to first content. |
+| p95 total | Total attempt latency. |
+| decode tokens/s | Actual output tokens divided by decode duration, only when output tokens are known. |
+| user-visible wins | Participant outputs shown to final users. |
+| attempt wins | Winner attempts before cache/user-visible aggregation. |
+| no-winner attempts | Shadow/probation/manual suspicious sends that could not win. |
+| skipped quarantine slots | No-send slots caused by quarantine. |
+| quarantine mode | Current probe/shadow/probation/none state. |
+
+Tables should apply a minimum volume threshold, for example at least 20 sent
+attempts in the selected window, so low-sample noise does not dominate.
+
+### Row 8: Model And Escrow Heatmaps
+
+Purpose: find localized failures.
+
+Panels:
+
+- Participant x model failure heatmap by reason.
+- Participant x escrow failure heatmap by reason.
+- Model x escrow overscheduling heatmap.
+- Runtime selection skips by model and escrow.
+- Capability skips by model and participant.
+
+All escrow-specific heatmaps are diagnostic. They should explain localized
+routing, slot, or timeout problems, not replace the default participant+model
+quality view.
+
+### Row 9: Timeout Actions
+
+Purpose: understand timeout pressure and skipped/failed timeout handling.
+
+Panels:
+
+- Timeout expected vs started vs completed vs skipped vs failed.
+- Timeout kind breakdown: `refused`, `execution`, `unknown`.
+- Timeout skip reasons.
+- Timeout failures by participant and model.
+- Attempts with `not_finished` but no timeout action.
+- Executor-level insufficient vote or collection error rates, only if those
+  outcomes are structurally available.
+
+### Row 10: Diagnostic Gateway Mechanics
+
+Purpose: expose gateway behavior that changes request flow before or after
+participant execution.
+
+Panels:
+
+- Cache lifecycle events: hit, miss, stored, skipped, expired.
+- Picker queue holds, drops, chooser errors, and stopped events.
+- Stream delivery failures to the client by reason.
+- Participant strike distribution by model and mode.
+- Manual suspicion state and transitions.
+- Escalation started vs skipped by trigger and skip reason.
+- No-winner fallback wins by participant and model.
+- Upstream transport outcomes by path kind, status code, error class, and
+  quarantine action.
+
+### Row 11: Protocol Feedback
+
+Purpose: turn gateway data into protocol changes.
+
+Panels or saved queries:
+
+- Redundancy pressure by reason and model.
+- Participants that repeatedly require extra sends but avoid quarantine.
+- Quarantine threshold candidates: participants with 1, 2, and 3 strikes.
+- Timeout window candidates from receipt, first-content, and TTFT distributions.
+- Decode throughput candidates by model and input token bucket.
+- Capability gap by model.
+- Cache effectiveness and cache-induced winner attribution gaps.
+- Escrow sizing pressure from runtime skips, blocked participants, and
+  overscheduling.
+- Incentive inputs: hidden failures, no-winner sends, skipped quarantine slots,
+  timeout actions, and successful-but-protected user requests.
+
+## Performance And Data Isolation
+
+Gateway observability must never make the gateway slower or less reliable.
+
+Requirements:
+
+- Metrics are in-memory Prometheus counter/gauge/histogram updates only.
+- Do not perform synchronous disk writes for this proposal.
+- Do not add new writes to `gateway.db`, `perf.db`, or devshard session DBs.
+- Do not query functional DBs from Grafana panels.
+- Do not add locks around streaming or request forwarding for metrics.
+- Metrics must fail open. If metric recording panics or errors, the gateway path
+  must continue.
+- If a metric would create too many active series, remove labels in this order:
+  `escrow_id` from diagnostic metrics, `output_token_bucket` from decode
+  histograms, `visibility` from performance histograms, then rare reason detail
+  from histograms. Preserve `participant_key`, `model`, and `reason` on counters
+  where accountability depends on them.
+
+High-load observability data is not critical path state. Prometheus retention is
+the retention mechanism for first-pass metrics. Request capture remains a
+separate, optional forensic feature and must not feed dashboards.
+
+## Privacy And Safety
+
+- Do not expose prompts, response bodies, request captures, base64 payloads, raw
+  captured samples, private keys, or private-key environment variable names.
+- Do not use raw error text as a label. Log raw errors only for manual drilldown.
+- Do not add participant labels to public scrape targets. These metrics are for
+  trusted deployment observability.
+- Treat `participant_key` as accountability data. It is intentional in these
+  metrics, but it should stay inside authenticated observability surfaces.
+
+## Future Work
+
+The following are useful but out of scope for the first pass:
+
+- A durable lifecycle ledger for exact per-request forensic replay.
+- New admin APIs for request or participant drilldown.
+- Per-verifier timeout vote metrics after timeout code exposes structured
+  verifier outcomes.
+- Escrow rotation events, for example
+  `devshard_gateway_escrow_rotation_events_total{model,role,stage,outcome,reason}`.
+- Chain transaction metrics, for example
+  `devshard_gateway_chain_tx_total{operation,stage,outcome,code,codespace}`.
+- `X-Devshard-Error` code metrics after transport plumbing exposes response
+  headers to gateway metrics. Candidate values include `requests_disabled`,
+  `initializing`, and `not_implemented`.
+- Chain reconciliation dashboards that compare gateway-observed outcomes with
+  finalized chain state.
+- Offline protocol-analysis exports.
+- OTEL/Jaeger spans for gateway internals.
+- Loki-derived panels. Logs should remain drilldown evidence, not the primary
+  metric source.
+
+## References
+
+- Gateway routing: `devshard/cmd/devshardctl/gateway.go`
+- User request handling: `devshard/cmd/devshardctl/proxy.go`
+- Redundancy and hidden failures: `devshard/cmd/devshardctl/redundancy.go`
+- Session picker and ghost/probe behavior:
+  `devshard/cmd/devshardctl/session_picker.go`
+- Participant limiter and quarantine:
+  `devshard/cmd/devshardctl/participant_limiter.go`
+- Gateway metrics: `devshard/cmd/devshardctl/metrics.go`
+- Request accounting: `devshard/cmd/devshardctl/request_accounting.go`
+- Host performance and pairwise data:
+  `devshard/cmd/devshardctl/hostperf.go`,
+  `devshard/cmd/devshardctl/pairwise.go`
+- Transport observations: `devshard/transport/client.go`
+- Request capture: `devshard/cmd/devshardctl/request_capture.go`
+- Gateway architecture docs: `devshard/docs/proxy-architecture.md`
+- Host health docs: `devshard/docs/host-health.md`
+- Devshard observability overview: `docs/observability/observability-overview.md`
+- Existing dashboards: `deploy/join/observability/grafana/dashboards/`

--- a/testermint/src/main/kotlin/data/devshard.kt
+++ b/testermint/src/main/kotlin/data/devshard.kt
@@ -93,9 +93,9 @@ data class DevshardHostStatsEntry(
     val invalid: Int,
     val cost: Long,
     @SerializedName("required_validations")
-    val requiredValidations: Int,
+    val requiredValidations: Int? = null,
     @SerializedName("completed_validations")
-    val completedValidations: Int
+    val completedValidations: Int? = null,
 )
 
 data class DevshardSlotSignatureEntry(

--- a/testermint/src/test/kotlin/DevshardStandaloneTests.kt
+++ b/testermint/src/test/kotlin/DevshardStandaloneTests.kt
@@ -378,6 +378,7 @@ class DevshardStandaloneTests : TestermintTest() {
                     .isEqualTo(session.escrowId.toString())
                 assertThat(result.parsed.stateRootAndProtocolVersion).isEqualTo(devshardStateRootProtocolVersion())
                 assertThat(result.parsed.hostStats).isNotEmpty()
+                assertThat(result.parsed.hostStats.sumOf { it.completedValidations ?: 0 }).isGreaterThan(0)
                 assertThat(result.parsed.signatures).isNotEmpty()
                 val obs = genesis.getDevshardShardStatsDetail(session.escrowId, routePrefix = overrideRoutePrefix)
                 assertThat(obs.validationObservability.totals.completedValidations)

--- a/testermint/src/test/kotlin/DevshardTestSupport.kt
+++ b/testermint/src/test/kotlin/DevshardTestSupport.kt
@@ -378,7 +378,7 @@ fun LocalInferencePair.assertDevshardSettlement(
     assertThat(result.parsed.nonce).isGreaterThanOrEqualTo(activeNonces)
     assertThat(result.parsed.fees).isEqualTo(expectedFees)
 
-    val totalCompletedValidations = result.parsed.hostStats.sumOf { it.completedValidations }
+    val totalCompletedValidations = result.parsed.hostStats.sumOf { it.completedValidations ?: 0 }
     if (requireCompletedValidations) {
         assertThat(totalCompletedValidations).isGreaterThan(0)
     }


### PR DESCRIPTION
Collecting gateway fixes from different branches and prepare for v3 version

Cherry-picked / forward-ported commits:
- fix(devshard): avoid penalizing cancelled gateway hosts
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/d0331b9da
- feat(devshard): add gateway observability bundle
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/3749b47a
- fix(devshard): restore mlnode-side changes lost in gateway port
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/50715a69
- feat(devshard): add gateway prometheus scrape job and design doc
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/9f96801d
- fix(devshard): stamp gateway version in devshardctl docker build
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/e851028f
- chore(bridge): estimate gas limit in transfer-ownership script
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/9d8d73a5
- protocol versions
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/ebe5fce0
- fix(devshard): bound gateway runtime-build fan-out to avoid LCD 429 crash-loop (#1423)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/2b18c681
- feat(devshard): settle depleted escrow after in-flight requests drain (#1314)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/398f1b62
- fix(devshard): retire runtime escrow (#1349)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/4c145fc1
- MiniMax-M2.7 route - per-model dispatch + tool-message shape + reasoning_split (#1226)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/2764c78f
- fix(devshard): skip escrow rotation for models absent from the network (#1375)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/cee57530
- fix(devshard): clamp chat n into [1,5] so n=0 no longer hangs the request (#1316)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/d94bfd44
- fix(devshard): validate & clamp chat-completion params at the gateway instead of vLLM (#1318)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/927148d7
- fix(devshard): reassemble fragmented SSE events for raceWriter content classification (#1240)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/acb6f869
- count background race finalizers in the drain barrier (#1403)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/4255f831
- Recover orphaned rotation escrows on DB persist failure instead of re-minting on chain (#1343)
  by Daniil Yankouski
  https://github.com/gonka-ai/gonka/commit/6b819d72
- Gateway v2 cleanup (#1420)
  by a-kuprin
  https://github.com/gonka-ai/gonka/commit/3d3c5e0f
- test(devshard): preserve host stats validation assertion
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/40d0c9ac
- fix(devshard): adapt gateway-v2 tests to mlnode interfaces
  by Gleb Morgachev
  https://github.com/gonka-ai/gonka/commit/9c286540