### PR TITLE
fix(x/inference): exclude self-validation from PoC v2 validation quorum

### DIFF
--- a/inference-chain/x/inference/keeper/msg_server_poc_v2_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_v2_test.go
@@ -131,6 +131,50 @@ func TestSubmitPocValidationsV2_DuplicateSkipped(t *testing.T) {
 	require.True(t, exists)
 }
 
+// Test SubmitPocValidationsV2 rejects self-validation (skip, do not store)
+func TestSubmitPocValidationsV2_SelfValidationSkipped(t *testing.T) {
+	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	// Block height must be in validation exchange window (see DuplicateSkipped).
+	sdkCtx := sdk.UnwrapSDKContext(ctx).WithBlockHeight(160)
+
+	params, err := k.GetParams(sdkCtx)
+	require.NoError(t, err)
+	params.PocParams = &types.PocParams{PocV2Enabled: true}
+	params.EpochParams = &types.EpochParams{
+		PocStageDuration:      50,
+		PocExchangeDuration:   20,
+		PocValidationDelay:    5,
+		PocValidationDuration: 100,
+	}
+	require.NoError(t, k.SetParams(sdkCtx, params))
+
+	k.SetEffectiveEpochIndex(sdkCtx, 0)
+	k.SetEpoch(sdkCtx, &types.Epoch{Index: 1, PocStartBlockHeight: 100})
+
+	msgServer := keeper.NewMsgServerImpl(k)
+
+	// Validator attempts to validate its OWN PoC (ParticipantAddress == Creator).
+	msg := &types.MsgSubmitPocValidationsV2{
+		Creator:                  testutil.Validator,
+		PocStageStartBlockHeight: 100,
+		Validations: []*types.PoCValidationEntryV2{
+			{
+				ParticipantAddress: testutil.Validator,
+				ModelId:            testPoCModelID,
+				ValidatedWeight:    100,
+			},
+		},
+	}
+	// Batch succeeds (self-vote is skipped, not a batch-level error).
+	_, err = msgServer.SubmitPocValidationsV2(sdkCtx, msg)
+	require.NoError(t, err)
+
+	// The self-validation must NOT have been stored.
+	exists, err := k.HasPocValidationV2(sdkCtx, 100, testutil.Validator, testPoCModelID, testutil.Validator)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
 // Test SubmitPocValidationsV2 partial success (valid + invalid in same batch)
 func TestSubmitPocValidationsV2_PartialSuccess(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)

--- a/inference-chain/x/inference/keeper/msg_server_poc_validations_v2.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_validations_v2.go
@@ -119,6 +119,17 @@ func (k msgServer) SubmitPocValidationsV2(goCtx context.Context, msg *types.MsgS
 			continue
 		}
 
+		// Self-validation is not permitted: a participant must never attest to its
+		// own PoC. Skip it (consistent with this handler's skip-don't-fail policy) so
+		// a self-vote can never be stored or counted toward the validation quorum.
+		if validation.ParticipantAddress == msg.Creator {
+			k.LogWarn("[SubmitPocValidationsV2] Self-validation not permitted, skipping", types.PoC,
+				"validator", msg.Creator,
+				"participant", validation.ParticipantAddress,
+				"model_id", modelID)
+			continue
+		}
+
 		// Check for duplicate submission (prevents vote flipping)
 		exists, err := k.HasPocValidationV2(ctx, startBlockHeight, validation.ParticipantAddress, modelID, msg.Creator)
 		if err != nil {

--- a/inference-chain/x/inference/module/chainvalidation.go
+++ b/inference-chain/x/inference/module/chainvalidation.go
@@ -235,6 +235,19 @@ func (wc *PoCWeightCalculator) getParticipantValidations(key types.PoCParticipan
 	wc.Logger.LogInfo("Calculate: Found ALL submitted validations for participant", types.PoC,
 		"participant", key.ParticipantAddress, "modelId", key.ModelID, "len(vals)", len(vals), "validators", validators)
 
+	// Defense in depth: a participant must never count as a validator of its own
+	// PoC. Self-validations are rejected at submission (SubmitPocValidationsV2); drop
+	// any that still reach the tally (e.g. from legacy or migrated data) so self-
+	// attestation can never contribute to the quorum.
+	nonSelf := make([]types.PoCValidationV2, 0, len(vals))
+	for _, v := range vals {
+		if v.ValidatorParticipantAddress == key.ParticipantAddress {
+			continue
+		}
+		nonSelf = append(nonSelf, v)
+	}
+	vals = nonSelf
+
 	// Filter to validations from participants with voting power for this model.
 	// When no voting-power snapshot exists for the model yet, keep the original
 	// validations list for logging and guardian handling. pocValidated() still


### PR DESCRIPTION
## Summary

Prevent a participant from acting as a validator of its **own** Proof-of-Compute (PoC v2) submission. Today a participant's own validation vote is accepted at submission and counted toward the strict `> 2/3` acceptance quorum, because there is no self-exclusion check on either the submission path or the tally. This PR rejects self-validations at ingestion and, as defense in depth, excludes any that reach the tally. A unit test is included.

## Rationale

- **Ingestion** (`SubmitPocValidationsV2`, `x/inference/keeper/msg_server_poc_validations_v2.go`) stores each vote as `{ParticipantAddress, ValidatorParticipantAddress: msg.Creator}` with no guard against `ParticipantAddress == msg.Creator`.
- **Tally** (`getParticipantValidations` -> `pocValidated`, `x/inference/module/chainvalidation.go`) aggregates all stored votes for a participant; a self-vote contributes to `validSlots` / `ValidWeight` against the strict `> 2/3` acceptance threshold.
- The validator set for a target is drawn deterministically and weight-proportionally from the same slot substrate that DevShard settlement uses (`GetSlotsFromSorted`), and that path likewise has no self-exclusion. Allowing self-attestation lets a participant improve its own acceptance odds and lets a coalition more cheaply influence the validation/settlement outcome for a chosen target.

The economic impact is bounded — an attacker still needs a large, real share of validated voting power for this to matter, so under the project's Impact x Likelihood model this is **Low** — but excluding self-validation is a clean correctness improvement with **no effect on honest flows**: honest participants never validate their own PoC.

## Changes

1. **`msg_server_poc_validations_v2.go`** — reject self-validations at submission, using the handler's existing skip-and-continue policy (a bad entry is skipped, the batch is not failed), so a self-vote is never stored.
2. **`chainvalidation.go` (`getParticipantValidations`)** — defense in depth: drop any stored self-vote before tallying. This is the single funnel that all consumers (slot path, non-slot path, guardian handling) read from, so one filter covers every code path and also protects against legacy/migrated data or any other write path.
3. **`msg_server_poc_v2_test.go`** — add `TestSubmitPocValidationsV2_SelfValidationSkipped`, asserting that a self-validation is accepted-but-skipped (the batch succeeds, nothing is stored), mirroring the existing `TestSubmitPocValidationsV2_DuplicateSkipped`.

## Testing

Built and tested under Go 1.24.2 (the version pinned in `go.mod`); `gofmt`-clean.

- `go test ./x/inference/keeper/` — the new `TestSubmitPocValidationsV2_SelfValidationSkipped` passes (the self-vote is accepted-but-skipped and never stored), and the existing handler tests (`DuplicateSkipped`, `PartialSuccess`, `HasPocValidationV2`) still pass — no regression on the ingestion path.
- `go test ./x/inference/module/` — the validation/weight-calculation tests (`TestComputeNewWeights` and its rejection sub-cases, plus the guardian-enhancement suite), which exercise `getParticipantValidations`, all pass — no regression from the tally-side self-exclusion.

The new test reuses the existing validation-handler harness (`keepertest.InferenceKeeperReturningMocks`, `testutil.Validator`, `HasPocValidationV2`) and mirrors `TestSubmitPocValidationsV2_DuplicateSkipped`.

## Notes

- No proto/API changes; no state migration required.
- Behavior for honest participants is unchanged; self-validation is not a legitimate action.
- This is the shared root fix for a validation/settlement hardening class (self-attestation influencing the slot-based quorum). Reported responsibly via the project's vulnerability process; happy to adjust naming/placement to match maintainer preference.