### PR TITLE
Add standalone devshard gateway update harness.

### DIFF
--- a/deploy/join/devshard-update-harness/README.md
+++ b/deploy/join/devshard-update-harness/README.md
@@ -1,0 +1,135 @@
+# Devshard gateway update harness
+
+Minimal production-shaped stack for testing a blue/green devshard gateway
+update on a host that does **not** run the full join node stack.
+
+## What this provides
+
+```text
+clients / load test
+   |
+   v
+proxy                         container name: proxy
+   |                           config: /etc/nginx/nginx.conf
+   |                           public path: /devshard-gateway/v1/...
+   v
+devshard-gateway              from ../docker-compose.devshard-gateway.yml
+   |
+   +-- temp gateway later      alias: devshard-gateway-temp (created by update flow)
+```
+
+This harness matches the container names and nginx switch points expected by
+the production update workflow (`devshard-gateway` <-> `devshard-gateway-temp`
+inside `proxy`).
+
+It does **not** start node, api, versiond, explorer, miners, or any other join
+services. Point the gateway at remote chain/API endpoints in your local
+`config.devshard.env`.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `docker-compose.yml` | Umbrella: gateway + proxy |
+| `docker-compose.proxy.yml` | Lightweight `proxy` only |
+| `nginx/nginx.conf` | Switchable upstream to `devshard-gateway:8080` |
+
+Gateway service definition is reused from
+`../docker-compose.devshard-gateway.yml`.
+
+Gateway env is **not** committed here. Use the existing join template:
+
+- `../config.devshard.env.template` -> copy to `../config.devshard.env`
+- fill in chain/API URLs, keys, model, and `DEVSHARD_ROUTE_PREFIX` locally
+
+The automated update script and its JSON config live under
+`devshard/docs/devshard-update/` (merge that docs/PR branch separately).
+
+## Prerequisites
+
+From `deploy/join`:
+
+1. Create the shared Docker network (once per host):
+
+```bash
+docker network create join_default
+```
+
+2. Prepare gateway env (local only, not committed):
+
+```bash
+cp config.devshard.env.template config.devshard.env
+chmod 600 config.devshard.env
+# edit: DEVSHARD_CHAIN_REST, DEVSHARD_PUBLIC_API, DEVSHARD_PRIVATE_KEY, etc.
+```
+
+3. Set the gateway image tag in `docker-compose.devshard-gateway.yml` to the
+   image you built or pulled on that host.
+
+4. Export compose-level vars if needed:
+
+```bash
+export DEVSHARD_ENV_FILE=./config.devshard.env
+export DEVSHARD_INSTANCE_NAME=devshard-gateway
+export DEVSHARD_STORAGE_HOST_DIR=.devshardctl
+```
+
+## Start
+
+```bash
+cd deploy/join
+docker compose -f devshard-update-harness/docker-compose.yml up -d
+```
+
+Or start pieces separately:
+
+```bash
+docker compose -f docker-compose.devshard-gateway.yml up -d
+docker compose -f devshard-update-harness/docker-compose.proxy.yml up -d
+```
+
+Default localhost bindings (override in compose if your host needs different ports):
+
+- gateway admin/direct: `127.0.0.1:18080`
+- proxy public path: `127.0.0.1:18090`
+
+## Smoke checks
+
+Direct gateway:
+
+```bash
+curl -fsS http://127.0.0.1:18080/v1/status
+```
+
+Through proxy (production-shaped path):
+
+```bash
+curl -fsS http://127.0.0.1:18090/devshard-gateway/v1/status
+```
+
+Confirm nginx upstream:
+
+```bash
+docker exec proxy sh -lc "grep -nE 'devshard-gateway|devshard-gateway-temp' /etc/nginx/nginx.conf"
+```
+
+## Blue/green update test
+
+After merging the update docs/script branch:
+
+1. Run the update workflow from `deploy/join` using
+   `devshard/docs/devshard-update/scripts/update.sh` and a local
+   `update.config.json` (not committed).
+2. Point continuous inference at the proxy URL, not the gateway port directly.
+3. When changing protocol version (e.g. v2 -> v3), update both:
+   - image build arg `DEVSHARD_PROTOCOL_VERSION`
+   - runtime `DEVSHARD_ROUTE_PREFIX` in your local `config.devshard.env`
+   - escrow `protocol_version` in your local update config
+
+## Stop
+
+```bash
+cd deploy/join
+docker compose -f devshard-update-harness/docker-compose.yml down
+docker rm -f devshard-gateway-temp 2>/dev/null || true
+```

--- a/deploy/join/devshard-update-harness/docker-compose.proxy.yml
+++ b/deploy/join/devshard-update-harness/docker-compose.proxy.yml
@@ -1,0 +1,32 @@
+# Lightweight proxy front for testing the production-shaped blue/green update.
+# Intentionally NOT the full join-stack proxy (no node/api/versiond/explorer).
+#
+# Required names for the update script:
+#   container: proxy
+#   network:   join_default (external)
+#   upstream:  devshard-gateway:8080  (rewritten to devshard-gateway-temp:8080)
+#
+# Bind localhost-only so the harness does not claim public host ports.
+services:
+  proxy:
+    container_name: proxy
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:18090:80"
+    volumes:
+      # Read-write on purpose: the update script rewrites upstream hostnames
+      # inside /etc/nginx/nginx.conf, then runs nginx -t && nginx -s reload.
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+    networks:
+      - join_default
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
+
+networks:
+  join_default:
+    external: true

--- a/deploy/join/devshard-update-harness/docker-compose.yml
+++ b/deploy/join/devshard-update-harness/docker-compose.yml
@@ -1,0 +1,16 @@
+# Standalone production-shaped gateway stack for blue/green update testing.
+#
+# Starts:
+#   - devshard-gateway (from ../docker-compose.devshard-gateway.yml)
+#   - proxy            (lightweight nginx front)
+#
+# Run from deploy/join:
+#   source config.devshard.env   # or export vars from your local env file
+#   docker compose -f devshard-update-harness/docker-compose.yml up -d
+#
+# Prerequisite: external network `join_default` must exist:
+#   docker network create join_default
+
+include:
+  - path: ../docker-compose.devshard-gateway.yml
+  - path: docker-compose.proxy.yml

--- a/deploy/join/devshard-update-harness/nginx/nginx.conf
+++ b/deploy/join/devshard-update-harness/nginx/nginx.conf
@@ -1,0 +1,91 @@
+# Lightweight production-shaped front for blue/green gateway update tests.
+# Container name must be `proxy`. Config path must be `/etc/nginx/nginx.conf`.
+# Upstream host names must match the update script:
+#   old: devshard-gateway:8080
+#   new: devshard-gateway-temp:8080
+#
+# Public routes mimic production:
+#   /devshard-gateway/v1/...  -> rewrite to /v1/... then proxy
+#   /v1/chat/completions      -> short OpenAI-compatible alias
+
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+    keepalive_timeout 65;
+    client_max_body_size 10M;
+
+    # Named upstream so the update script can rewrite either:
+    #   proxy_pass http://devshard-gateway:8080;
+    # or
+    #   server devshard-gateway:8080;
+    upstream gateway_upstream {
+        server devshard-gateway:8080;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        location = /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        # Explicit gateway prefix used by production and by the update script
+        # public_prefix=/devshard-gateway checks.
+        location ^~ /devshard-gateway/ {
+            rewrite ^/devshard-gateway(/.*)$ $1 break;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
+            proxy_buffering off;
+            proxy_request_buffering off;
+            proxy_connect_timeout 75s;
+            proxy_send_timeout 1200s;
+            proxy_read_timeout 1200s;
+            proxy_pass http://gateway_upstream;
+        }
+
+        # Short OpenAI-compatible alias used in production smoke paths.
+        location = /v1/chat/completions {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
+            proxy_buffering off;
+            proxy_request_buffering off;
+            proxy_connect_timeout 75s;
+            proxy_send_timeout 1200s;
+            proxy_read_timeout 1200s;
+            proxy_pass http://gateway_upstream;
+        }
+
+        # Direct admin/status convenience through the same front.
+        location ^~ /v1/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
+            proxy_buffering off;
+            proxy_request_buffering off;
+            proxy_connect_timeout 75s;
+            proxy_send_timeout 1200s;
+            proxy_read_timeout 1200s;
+            proxy_pass http://gateway_upstream;
+        }
+    }
+}

--- a/devshard/docs/devshard-update/.gitignore
+++ b/devshard/docs/devshard-update/.gitignore
@@ -1,0 +1,1 @@
+sandbox/

--- a/devshard/docs/devshard-update/README.md
+++ b/devshard/docs/devshard-update/README.md
@@ -1,6 +1,6 @@
 # Devshard Gateway Update
 
-Update a devshard gateway to a new image version behind nginx without dropping in-flight requests. Assumes multi-devshard **gateway-proxy** mode (routing prefix `/devshard-gateway/`) behind the nginx `proxy` container. Single-instance host, two ways — **Manual** (steps by hand) and **Automated** (one script). For a 2+ instance pool, see the Pool section below.
+Update a devshard gateway to a new image version without dropping in-flight requests. Full blue/green updates support nginx or Caddy routing; weighted canary updates are nginx-only. Single-instance host, two ways — **Manual** (nginx steps by hand) and **Automated** (one script). For a 2+ instance pool, see the Pool section below.
 
 An **escrow** and a **devshard** are the same object. The examples assume:
 
@@ -11,6 +11,23 @@ TEMP="http://127.0.0.1:18081"
 REPO="ghcr.io/gonka-ai/devshard-gateway"
 # <OLD> / <NEW> = current / target image tag; <MODEL> = a model id you serve
 ```
+
+## Current mainnet v3 target
+
+Use `ghcr.io/gonka-ai/devshard-gateway:mainnet-v0.2.13-v3-post1`.
+Verify registry access before starting:
+
+```bash
+docker pull ghcr.io/gonka-ai/devshard-gateway:mainnet-v0.2.13-v3-post1
+```
+
+For the v1/v2 → v3 migration, prefer the automated workflow below. Configure
+the exact image currently present in compose as `image.from_tag`, the image
+above as `image.to_tag`, the running protocol as
+`escrow.source_protocol_version`, and target protocol / route as `"3"` /
+`/devshard/v3`. Keep `models[].main_seed_count >= 1`. Older gateways may omit
+`protocol_version`; the script treats missing values as source-protocol state
+and deactivates them locally without settlement before starting v3.
 
 ## Manual update (single instance)
 
@@ -45,7 +62,7 @@ curl -fsS "$MAIN/v1/admin/settings" -H "Authorization: Bearer $KEY" \
 ```bash
 curl -fsS -X POST "$TEMP/v1/admin/escrows" -H "Authorization: Bearer $KEY" \
   -H 'Content-Type: application/json' \
-  -d '{"amount":5000000000,"model_id":"<MODEL>","private_key_env":"DEVSHARD_PRIVATE_KEY","protocol_version":"1"}'
+  -d '{"amount":5000000000,"model_id":"<MODEL>","private_key_env":"DEVSHARD_PRIVATE_KEY","protocol_version":"<TARGET_PROTOCOL>"}'
 # repeat per escrow and per model; then record the created ids:
 curl -fsS "$TEMP/v1/admin/devshards" -H "Authorization: Bearer $KEY" | jq '.devshards[].id'
 ```
@@ -107,7 +124,7 @@ docker stop devshard-gateway-temp && docker rm devshard-gateway-temp
 **12. Import + activate the temp escrows into main** (so their funds aren't stranded) — for each temp escrow `<ID>`:
 
 ```bash
-BODY='{"id":"<ID>","model":"<MODEL>","storage_path":"/root/.devshardctl/temp/escrow-<ID>/state.db","protocol_version":"1","private_key_env":"DEVSHARD_PRIVATE_KEY"}'
+BODY='{"id":"<ID>","model":"<MODEL>","storage_path":"/root/.devshardctl/temp/escrow-<ID>/state.db","protocol_version":"<TARGET_PROTOCOL>","private_key_env":"DEVSHARD_PRIVATE_KEY"}'
 curl -fsS -X POST "$MAIN/v1/admin/devshards/import" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "$(jq '.active=false' <<<"$BODY")"
 curl -fsS -X POST "$MAIN/v1/admin/devshards"        -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "$BODY"
 ```
@@ -118,20 +135,28 @@ curl -fsS -X POST "$MAIN/v1/admin/devshards"        -H "Authorization: Bearer $K
 
 The script runs steps 1–12 from a JSON config (models and everything else are config-driven — nothing hardcoded).
 
+Set `routing.type` to `nginx` (the backward-compatible default) or `caddy`.
+Backend-specific switch functions stay independent; the update workflow only
+selects whether traffic moves to temp or main. `update-canary.sh` supports nginx
+only.
+
+Gateway-2 requires an additional external gate: remove `10.0.1.5:18080` from
+node4's active split and fallback path before the update. Node4 connects to the
+host port directly and bypasses gateway-2's Caddy configuration.
+
 ### Before a protocol-changing update
 
-`update.config.json` sets the protocol of newly created escrows, but it does not
-edit the gateway env file. Before starting a protocol change:
+The script stages the target route in the gateway env file (after making a
+backup) before it creates temp. Before starting a protocol change:
 
-1. Back up `config.devshard.env`.
-2. Change `DEVSHARD_ROUTE_PREFIX` to the target route, for example
-   `/devshard/v2` to `/devshard/v3`.
-3. Verify the running main container still has the source route. Docker reads
+1. Set `escrow.route_prefix` to the target route, for example
+   `/devshard/v3`.
+2. Verify the running main container still has the source route. Docker reads
    its env only when the container is created, so the existing main remains on
    v2 while temp and the later recreated main read v3.
-4. Set `escrow.source_protocol_version` to the running protocol and
+3. Set `escrow.source_protocol_version` to the running protocol and
    `escrow.protocol_version` to the target (`"2"` and `"3"` for v2 to v3).
-5. Set `models[].main_seed_count` to at least `1` for every served model.
+4. Set `models[].main_seed_count` to at least `1` for every served model.
 
 The public client path remains `/devshard-gateway/v1/...`.
 
@@ -146,10 +171,24 @@ source-protocol escrows on main. Deactivation is local only: it does **not**
 settle, delete, or transfer funds. This prevents the target binary from trying
 to open incompatible source-protocol session state.
 
+The default `deactivation.mode=api` calls the drained source gateway's admin
+endpoint. Some legacy images do not provide that route. For those images only,
+set `deactivation.mode=sqlite` and `deactivation.gateway_db`: the script stops
+MAIN after the drain gate, backs up `gateway.db*`, marks only active
+source-protocol records inactive, and requires `PRAGMA integrity_check` to
+return `ok` before continuing.
+
 After main restarts on the target image, the script creates the configured
-target-protocol seed escrows and proves direct inference before switching nginx
-back. Temp is then drained and stopped before its escrows are imported and
-activated on main, preserving one writer per escrow.
+target-protocol seed escrows and proves direct inference before switching the
+selected router back. Temp is then drained and stopped before its escrows are
+imported and activated on main, preserving one writer per escrow.
+
+Temp escrow rotation is deliberately disabled throughout this handoff. Draining
+means `active_requests == 0`; it does not exhaust escrows. If
+`rotation.restore_after_update` is true, the script snapshots MAIN's complete
+settings before disabling rotation and restores the exact original
+`escrow_rotation` object afterward. This preserves enabled state, settlement
+state, and per-model rotation targets.
 
 ```bash
 cp scripts/update.config.sample.json update.config.json     # edit: image tags, models[], nginx, compose
@@ -161,7 +200,7 @@ cp scripts/update.config.sample.json update.config.json     # edit: image tags, 
 - Run a single step: `./scripts/update.sh --config update.config.json <step>`.
 - Recover stranded temp escrows after an aborted run: `./scripts/update.sh --config update.config.json recover` (or `recover --settle`).
 
-The config (see [scripts/update.config.sample.json](scripts/update.config.sample.json)) holds the image (`repository`, `from_tag`, `to_tag`, `skip_pull`), the `models[]` array (`model`, temp `escrow_count`, `main_seed_count`, `escrow_amount`), source/target escrow protocol versions, `allow_unavailable_models`, and the nginx / compose / timeout blocks. Set `image.skip_pull=true` only when the exact target image is already loaded locally; the script verifies it with `docker image inspect` and skips both registry pulls. For same-protocol image updates, source and target protocol are equal and `main_seed_count` may remain `0`. Env vars override individual fields.
+The config (see [scripts/update.config.sample.json](scripts/update.config.sample.json)) holds the image (`repository`, `from_tag`, `to_tag`, `skip_pull`), the `models[]` array (`model`, temp `escrow_count`, `main_seed_count`, `escrow_amount`), source/target escrow protocol versions, explicit deactivation mode, `allow_unavailable_models`, generic `routing`, the selected `nginx` or `caddy` block, and compose / timeout settings. A gateway-2 starting point is provided at [update.config.gateway2.json](update.config.gateway2.json). Set `image.skip_pull=true` only when the exact target image is already loaded locally; the script verifies it with `docker image inspect` and skips both registry pulls. For same-protocol image updates, source and target protocol are equal and `main_seed_count` may remain `0`. Env vars override individual fields.
 
 ## Restore the nginx backup
 

--- a/devshard/docs/devshard-update/README.md
+++ b/devshard/docs/devshard-update/README.md
@@ -1,0 +1,161 @@
+# Devshard Gateway Update
+
+Update a devshard gateway to a new image version behind nginx without dropping in-flight requests. Assumes multi-devshard **gateway-proxy** mode (routing prefix `/devshard-gateway/`) behind the nginx `proxy` container. Single-instance host, two ways — **Manual** (steps by hand) and **Automated** (one script). For a 2+ instance pool, see the Pool section below.
+
+An **escrow** and a **devshard** are the same object. The examples assume:
+
+```bash
+KEY="$DEVSHARD_ADMIN_API_KEY"
+MAIN="http://127.0.0.1:18080"
+TEMP="http://127.0.0.1:18081"
+REPO="ghcr.io/gonka-ai/devshard-gateway"
+# <OLD> / <NEW> = current / target image tag; <MODEL> = a model id you serve
+```
+
+## Manual update (single instance)
+
+Run from the gateway host's deploy dir (e.g. `deploy/join`). A temp gateway holds traffic while main updates.
+
+**1. Disable escrow rotation on main** (so nothing settles on-chain mid-update):
+
+```bash
+curl -fsS "$MAIN/v1/admin/settings" -H "Authorization: Bearer $KEY" \
+  | jq '.escrow_rotation.enabled = false' \
+  | curl -fsS -X POST "$MAIN/v1/admin/settings" -H "Authorization: Bearer $KEY" \
+      -H 'Content-Type: application/json' -d @-
+```
+
+**2. Start a temp gateway** on the new image, with its own storage and no escrows; reuse main's env file (keeps secrets out of `/tmp`):
+
+```bash
+docker run -d --name devshard-gateway-temp --restart unless-stopped \
+  --network join_default --network-alias devshard-gateway-temp \
+  --env-file ./config.devshard.env \
+  -e DEVSHARDS_JSON='[]' -e DEVSHARD_STORAGE_DIR=/root/.devshardctl/temp -e DEVSHARD_PORT=8080 \
+  -p 127.0.0.1:18081:8080 -v "$PWD/.devshardctl:/root/.devshardctl" \
+  "$REPO:<NEW>"
+curl -fsS "$MAIN/v1/admin/settings" -H "Authorization: Bearer $KEY" \
+  | jq '.escrow_rotation.enabled = false | .escrow_rotation.models = []' \
+  | curl -fsS -X POST "$TEMP/v1/admin/settings" -H "Authorization: Bearer $KEY" \
+      -H 'Content-Type: application/json' -d @-
+```
+
+**3. Mint temp escrows — for every model main serves** (a model with no temp escrows is unavailable during the update; each mint spends on-chain funds):
+
+```bash
+curl -fsS -X POST "$TEMP/v1/admin/escrows" -H "Authorization: Bearer $KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"amount":5000000000,"model_id":"<MODEL>","private_key_env":"DEVSHARD_PRIVATE_KEY","protocol_version":"1"}'
+# repeat per escrow and per model; then record the created ids:
+curl -fsS "$TEMP/v1/admin/devshards" -H "Authorization: Bearer $KEY" | jq '.devshards[].id'
+```
+
+**4. Verify temp** — status responds and a chat smoke test passes (test each model):
+
+```bash
+curl -fsS "$TEMP/v1/status" -H "Authorization: Bearer $KEY" | jq '[.devshards[].active_requests]|length'
+curl -fsS -X POST "$TEMP/v1/chat/completions" -H 'Content-Type: application/json' \
+  -d '{"model":"<MODEL>","max_tokens":1,"messages":[{"role":"user","content":"ok"}]}' >/dev/null && echo ok
+```
+
+**5. Switch nginx to temp** (graceful reload; in-flight streams finish). This matches both a direct `proxy_pass http://host:8080` and a named-upstream `server host:8080;`:
+
+```bash
+docker exec proxy sh -lc "cp /etc/nginx/nginx.conf /tmp/nginx.conf.bak && \
+  sed -E -i 's#http://devshard-gateway:8080#http://devshard-gateway-temp:8080#g; \
+             s#(server[[:space:]]+)devshard-gateway:8080#\1devshard-gateway-temp:8080#g' /etc/nginx/nginx.conf && \
+  nginx -t && nginx -s reload"
+```
+
+**6. Drain main** — repeat until this prints `0`:
+
+```bash
+curl -fsS "$MAIN/v1/status" -H "Authorization: Bearer $KEY" | jq '[.devshards[].active_requests]|max'
+```
+
+**7. Bump the image tag in compose:**
+
+```bash
+sed -i "s#$REPO:<OLD>#$REPO:<NEW>#g" docker-compose.devshard-gateway.yml
+```
+
+**8. Recreate main on the new image** (compose is the image source — not an env var):
+
+```bash
+docker compose -f docker-compose.devshard-gateway.yml up -d --no-deps --force-recreate devshard-gateway
+```
+
+**9. Verify main** — status responds and a chat smoke test passes (same as step 4, against `$MAIN`).
+
+**10. Switch nginx back to main** — same as step 5 with `devshard-gateway-temp` → `devshard-gateway`.
+
+**11. Drain temp, then stop AND remove it** (`--restart unless-stopped` means a leftover container would resurrect and corrupt state):
+
+```bash
+curl -fsS "$TEMP/v1/status" -H "Authorization: Bearer $KEY" | jq '[.devshards[].active_requests]|max'   # until 0
+docker stop devshard-gateway-temp && docker rm devshard-gateway-temp
+```
+
+**12. Import + activate the temp escrows into main** (so their funds aren't stranded) — for each temp escrow `<ID>`:
+
+```bash
+BODY='{"id":"<ID>","model":"<MODEL>","storage_path":"/root/.devshardctl/temp/escrow-<ID>/state.db","protocol_version":"1","private_key_env":"DEVSHARD_PRIVATE_KEY"}'
+curl -fsS -X POST "$MAIN/v1/admin/devshards/import" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "$(jq '.active=false' <<<"$BODY")"
+curl -fsS -X POST "$MAIN/v1/admin/devshards"        -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "$BODY"
+```
+
+**Rollback:** if a step fails, do not switch back to a bad main — keep the alias on temp, restore `/tmp/nginx.conf.bak` and reload, and re-pull the old image tag. If you stopped after minting temp escrows, finish steps 11–12 (or settle each via `POST /v1/admin/devshards/{id}/settle`) so their funds are recovered.
+
+## Automated update (single instance)
+
+The script runs steps 1–12 from a JSON config (models and everything else are config-driven — nothing hardcoded).
+
+```bash
+cp scripts/update.config.sample.json update.config.json     # edit: image tags, models[], nginx, compose
+./scripts/update.sh --config update.config.json run          # dry run — prints the full plan
+./scripts/update.sh --config update.config.json run --run    # execute
+```
+
+- `--run` executes (default is dry-run); `--yes` skips confirmations (unattended).
+- Run a single step: `./scripts/update.sh --config update.config.json <step>`.
+- Recover stranded temp escrows after an aborted run: `./scripts/update.sh --config update.config.json recover` (or `recover --settle`).
+
+The config (see [scripts/update.config.sample.json](scripts/update.config.sample.json)) holds the image (`repository`, `from_tag`, `to_tag`), the `models[]` array (`model`, `escrow_count`, `escrow_amount`), `allow_unavailable_models`, and the nginx / compose / timeout blocks. Env vars override individual fields.
+
+## Restore the nginx backup
+
+The switch backs up the nginx config **before every change**, inside the `proxy` container next to the config: `<config_path>.blue-green-backup` (e.g. `/etc/nginx/nginx.conf.blue-green-backup`). The manual step 5 above instead writes `/tmp/nginx.conf.bak`. To revert routing, restore whichever you used and reload:
+
+```bash
+docker exec proxy sh -lc "cp /etc/nginx/nginx.conf.blue-green-backup /etc/nginx/nginx.conf && nginx -t && nginx -s reload"
+# manual path: cp /tmp/nginx.conf.bak /etc/nginx/nginx.conf && nginx -t && nginx -s reload
+```
+
+Confirm the upstream it now points at:
+
+```bash
+docker exec proxy sh -lc "grep -nE 'devshard.*:8080' /etc/nginx/nginx.conf"
+```
+
+**Caveat — the backup is overwritten on each switch.** It holds the routing as of just *before the most recent switch*: after `switch-to-main` it points back at **temp**, not the pristine original. For a guaranteed clean revert, copy the original aside before you start:
+
+```bash
+docker exec proxy sh -lc "cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.orig"
+```
+
+## Pool (multi-instance)
+
+If 2+ gateway instances sit behind nginx, update one at a time — no temp gateway:
+
+1. Remove one instance from the nginx `upstream` (comment its `server` line or mark it `down`); `nginx -t && nginx -s reload`.
+2. Drain it: `GET /v1/status` until `max(.devshards[].active_requests) == 0`.
+3. Bump its image tag in compose; `docker compose -f <file> up -d --no-deps --force-recreate <service>`.
+4. Verify: `/v1/status` responds and a `POST /v1/chat/completions` returns.
+5. Return it to the pool; reload. Repeat for the next instance.
+
+## References
+
+- [references/admin-api.md](references/admin-api.md) — gateway admin endpoints used here.
+- [references/nginx-alias-switching.md](references/nginx-alias-switching.md) — how the upstream switch keeps in-flight streams alive.
+- [references/troubleshooting.md](references/troubleshooting.md) — drain stalls, unroutable escrows, rollback.
+- [SKILL.md](SKILL.md) — operator/agent skill wrapping this process.

--- a/devshard/docs/devshard-update/README.md
+++ b/devshard/docs/devshard-update/README.md
@@ -73,6 +73,10 @@ docker exec proxy sh -lc "cp /etc/nginx/nginx.conf /tmp/nginx.conf.bak && \
 curl -fsS "$MAIN/v1/status" -H "Authorization: Bearer $KEY" | jq '[.devshards[].active_requests]|max'
 ```
 
+**Protocol change only:** deactivate each active source-protocol escrow after
+main drains and before recreating it. Use
+`POST /v1/admin/devshards/<ID>/deactivate`. Do not settle or delete it.
+
 **7. Bump the image tag in compose:**
 
 ```bash
@@ -85,7 +89,11 @@ sed -i "s#$REPO:<OLD>#$REPO:<NEW>#g" docker-compose.devshard-gateway.yml
 docker compose -f docker-compose.devshard-gateway.yml up -d --no-deps --force-recreate devshard-gateway
 ```
 
-**9. Verify main** — status responds and a chat smoke test passes (same as step 4, against `$MAIN`).
+**Protocol change only:** create at least one target-protocol seed escrow per
+served model on main before returning traffic.
+
+**9. Verify main** — status responds, target-protocol seed escrows are active,
+and a chat smoke test passes (same as step 4, against `$MAIN`).
 
 **10. Switch nginx back to main** — same as step 5 with `devshard-gateway-temp` → `devshard-gateway`.
 
@@ -110,6 +118,39 @@ curl -fsS -X POST "$MAIN/v1/admin/devshards"        -H "Authorization: Bearer $K
 
 The script runs steps 1–12 from a JSON config (models and everything else are config-driven — nothing hardcoded).
 
+### Before a protocol-changing update
+
+`update.config.json` sets the protocol of newly created escrows, but it does not
+edit the gateway env file. Before starting a protocol change:
+
+1. Back up `config.devshard.env`.
+2. Change `DEVSHARD_ROUTE_PREFIX` to the target route, for example
+   `/devshard/v2` to `/devshard/v3`.
+3. Verify the running main container still has the source route. Docker reads
+   its env only when the container is created, so the existing main remains on
+   v2 while temp and the later recreated main read v3.
+4. Set `escrow.source_protocol_version` to the running protocol and
+   `escrow.protocol_version` to the target (`"2"` and `"3"` for v2 to v3).
+5. Set `models[].main_seed_count` to at least `1` for every served model.
+
+The public client path remains `/devshard-gateway/v1/...`.
+
+Schedule a protocol-changing run shortly after `set_new_validators`, once the
+chain is back in `Inference`. Ensure enough blocks remain before the next PoC
+for escrow creation, smoke checks, both nginx switches, and draining. On chains
+with a two-epoch pruning threshold, use fresh source and temp escrows; do not
+resume an interrupted run after its escrows cross that threshold.
+
+After nginx moves traffic to temp and main drains, the script deactivates the
+source-protocol escrows on main. Deactivation is local only: it does **not**
+settle, delete, or transfer funds. This prevents the target binary from trying
+to open incompatible source-protocol session state.
+
+After main restarts on the target image, the script creates the configured
+target-protocol seed escrows and proves direct inference before switching nginx
+back. Temp is then drained and stopped before its escrows are imported and
+activated on main, preserving one writer per escrow.
+
 ```bash
 cp scripts/update.config.sample.json update.config.json     # edit: image tags, models[], nginx, compose
 ./scripts/update.sh --config update.config.json run          # dry run — prints the full plan
@@ -120,7 +161,7 @@ cp scripts/update.config.sample.json update.config.json     # edit: image tags, 
 - Run a single step: `./scripts/update.sh --config update.config.json <step>`.
 - Recover stranded temp escrows after an aborted run: `./scripts/update.sh --config update.config.json recover` (or `recover --settle`).
 
-The config (see [scripts/update.config.sample.json](scripts/update.config.sample.json)) holds the image (`repository`, `from_tag`, `to_tag`), the `models[]` array (`model`, `escrow_count`, `escrow_amount`), `allow_unavailable_models`, and the nginx / compose / timeout blocks. Env vars override individual fields.
+The config (see [scripts/update.config.sample.json](scripts/update.config.sample.json)) holds the image (`repository`, `from_tag`, `to_tag`, `skip_pull`), the `models[]` array (`model`, temp `escrow_count`, `main_seed_count`, `escrow_amount`), source/target escrow protocol versions, `allow_unavailable_models`, and the nginx / compose / timeout blocks. Set `image.skip_pull=true` only when the exact target image is already loaded locally; the script verifies it with `docker image inspect` and skips both registry pulls. For same-protocol image updates, source and target protocol are equal and `main_seed_count` may remain `0`. Env vars override individual fields.
 
 ## Restore the nginx backup
 

--- a/devshard/docs/devshard-update/SKILL.md
+++ b/devshard/docs/devshard-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devshard-update
-description: Update a Gonka devshard gateway to a new image version without dropping in-flight /v1/chat/completions requests, driven by a JSON config. Single-instance blue/green (temp gateway + nginx switch + drain + config-driven temp escrows + import); a recover command reclaims stranded temp escrows; multi-instance pools use a rolling update.
+description: Update a Gonka devshard gateway to a new image version without dropping in-flight /v1/chat/completions requests, driven by a JSON config. Single-instance blue/green (temp gateway + nginx or Caddy switch + drain + config-driven temp escrows + import); a recover command reclaims stranded temp escrows; multi-instance pools use a rolling update.
 ---
 
 # Devshard Gateway Update
@@ -16,6 +16,18 @@ cp scripts/update.config.sample.json update.config.json     # edit: image tags, 
 ```
 
 Add `--yes` for unattended. Everything is config-driven (models included) — nothing is hardcoded.
+
+## Routing backends
+
+`update.sh` supports full blue/green updates with `routing.type=nginx` (default)
+or `routing.type=caddy`. The workflow chooses the switch direction; independent
+`nginx_switch` and `caddy_switch` implementations own their config syntax.
+`update-canary.sh` remains nginx-only because weighted canary routing is an
+nginx feature in this deployment.
+
+For gateway-2, start with `update.config.gateway2.json`. First remove gateway-2
+from node4's split **and** fallback path: node4 reaches `10.0.1.5:18080`
+directly and therefore bypasses gateway-2's Caddy switch.
 
 ## Canary (operator-paced, no built-in wait)
 
@@ -39,14 +51,17 @@ Modes: `prepare` | `set <0..100>` | `check` | `finish` | `recover`. Mid-canary u
 - MAIN's image comes from the compose file; the `bump-main-image` step rewrites the full compose image ref from `image.from_tag` to `image.to_tag` (same-repo tag bump via `image.repository`, or full `repo:tag` strings in both fields for cross-repo moves).
 - For a protocol change, the script stages `DEVSHARD_ROUTE_PREFIX` in the gateway env file during `create-temp-gateway` / canary `prepare` (backup first; default `/devshard/v<protocol>` or set `escrow.route_prefix`). Running MAIN keeps its old env until recreate; temp and the recreated MAIN read the target route.
 - For a protocol change, configure `escrow.source_protocol_version`, target `escrow.protocol_version`, and `models[].main_seed_count >= 1`. The script deactivates source escrows without settlement before recreating main, then creates target seed escrows before switching traffic back.
+- `deactivation.mode=api` uses the normal admin endpoint. For legacy source images that do not expose `/deactivate`, explicitly use `deactivation.mode=sqlite` plus `deactivation.gateway_db`; after the drain gate the script stops MAIN, backs up `gateway.db*`, updates only active source-protocol records, and requires SQLite integrity `ok`.
+- Temp rotation is intentionally disabled and its model list cleared to freeze escrow ownership during the handoff. Draining only waits for active requests; it does not exhaust escrows.
+- With `rotation.restore_after_update=true`, the script snapshots MAIN's complete original settings before disabling rotation and restores the exact original `escrow_rotation` object afterward, including enabled, settlement, and model targets.
 - Schedule protocol changes shortly after `set_new_validators` in `Inference`, with fresh escrows and enough blocks before the next PoC. Do not resume after the chain's escrow-pruning threshold.
 - Temp escrows must cover every model MAIN serves — `preflight` fails closed if a served model has no temp coverage and isn't in `allow_unavailable_models`.
-- Public verification runs only if `nginx.public_base_url` is set — never trust loopback.
+- Public verification runs only if `routing.public_base_url` (or the legacy backend-specific field) is set — never trust loopback.
 - Do not assume the nginx config path — inspect with `docker exec <proxy> sh -lc 'nginx -T'`.
 
 ## Config
 
-`scripts/update.config.sample.json` — blocks: `image {repository?, from_tag, to_tag, skip_pull}` (`from_tag`/`to_tag` may be bare tags joined with `repository`, or full `repo:tag` refs for cross-registry upgrades), `models[] {model, escrow_count, main_seed_count, escrow_amount}`, `allow_unavailable_models[]`, `escrow {source_protocol_version, protocol_version, private_key_env}`, `main`, `temp`, `nginx`, `compose`, `timeouts`, `rotation`. Use `image.skip_pull=true` only when the exact target image is already loaded locally; both registry pulls are then skipped. Any field is overridable by the matching env var.
+`scripts/update.config.sample.json` — blocks: `image {repository?, from_tag, to_tag, skip_pull}` (`from_tag`/`to_tag` may be bare tags joined with `repository`, or full `repo:tag` refs for cross-registry upgrades), `models[] {model, escrow_count, main_seed_count, escrow_amount}`, `allow_unavailable_models[]`, `escrow {source_protocol_version, protocol_version, private_key_env}`, `deactivation {mode, gateway_db?}`, `main`, `temp`, `routing {type, public_base_url, public_prefix}`, the selected `nginx` or `caddy` block, `compose`, `timeouts`, `rotation`. Use `image.skip_pull=true` only when the exact target image is already loaded locally; both registry pulls are then skipped. Any field is overridable by the matching env var.
 
 ## Steps & actions
 

--- a/devshard/docs/devshard-update/SKILL.md
+++ b/devshard/docs/devshard-update/SKILL.md
@@ -17,12 +17,27 @@ cp scripts/update.config.sample.json update.config.json     # edit: image tags, 
 
 Add `--yes` for unattended. Everything is config-driven (models included) — nothing is hardcoded.
 
+## Canary (operator-paced, no built-in wait)
+
+Same config; temp = target image, MAIN stays on source until `finish`. You wait between steps:
+
+```bash
+./scripts/update-canary.sh --config update.config.json prepare --run
+./scripts/update-canary.sh --config update.config.json set 10 --run
+./scripts/update-canary.sh --config update.config.json check --run   # wait yourself, re-check
+./scripts/update-canary.sh --config update.config.json set 50 --run
+./scripts/update-canary.sh --config update.config.json check --run
+./scripts/update-canary.sh --config update.config.json finish --run  # 100% temp → recreate MAIN → fold
+```
+
+Modes: `prepare` | `set <0..100>` | `check` | `finish` | `recover`. Mid-canary uses nginx upstream **weights**; `0`/`100` pin a single host. Hard-coded `proxy_pass http://host:port` paths do not follow weights — `check` warns.
+
 ## Safety rules
 
 - Treat any live gateway host as production. Show the exact command and get approval before running it.
 - Dry-run first (`run` without `--run`) and read the plan.
-- MAIN's image comes from the compose file; the `bump-main-image` step rewrites the tag from `image.from_tag` to `image.to_tag`.
-- For a protocol change, back up and manually stage `DEVSHARD_ROUTE_PREFIX` in the gateway env before running the script. Verify the running main still has the source route; temp and the recreated main must read the target route.
+- MAIN's image comes from the compose file; the `bump-main-image` step rewrites the full compose image ref from `image.from_tag` to `image.to_tag` (same-repo tag bump via `image.repository`, or full `repo:tag` strings in both fields for cross-repo moves).
+- For a protocol change, the script stages `DEVSHARD_ROUTE_PREFIX` in the gateway env file during `create-temp-gateway` / canary `prepare` (backup first; default `/devshard/v<protocol>` or set `escrow.route_prefix`). Running MAIN keeps its old env until recreate; temp and the recreated MAIN read the target route.
 - For a protocol change, configure `escrow.source_protocol_version`, target `escrow.protocol_version`, and `models[].main_seed_count >= 1`. The script deactivates source escrows without settlement before recreating main, then creates target seed escrows before switching traffic back.
 - Schedule protocol changes shortly after `set_new_validators` in `Inference`, with fresh escrows and enough blocks before the next PoC. Do not resume after the chain's escrow-pruning threshold.
 - Temp escrows must cover every model MAIN serves — `preflight` fails closed if a served model has no temp coverage and isn't in `allow_unavailable_models`.
@@ -31,7 +46,7 @@ Add `--yes` for unattended. Everything is config-driven (models included) — no
 
 ## Config
 
-`scripts/update.config.sample.json` — blocks: `image {repository, from_tag, to_tag, skip_pull}`, `models[] {model, escrow_count, main_seed_count, escrow_amount}`, `allow_unavailable_models[]`, `escrow {source_protocol_version, protocol_version, private_key_env}`, `main`, `temp`, `nginx`, `compose`, `timeouts`, `rotation`. Use `image.skip_pull=true` only when the exact target image is already loaded locally; both registry pulls are then skipped. Any field is overridable by the matching env var.
+`scripts/update.config.sample.json` — blocks: `image {repository?, from_tag, to_tag, skip_pull}` (`from_tag`/`to_tag` may be bare tags joined with `repository`, or full `repo:tag` refs for cross-registry upgrades), `models[] {model, escrow_count, main_seed_count, escrow_amount}`, `allow_unavailable_models[]`, `escrow {source_protocol_version, protocol_version, private_key_env}`, `main`, `temp`, `nginx`, `compose`, `timeouts`, `rotation`. Use `image.skip_pull=true` only when the exact target image is already loaded locally; both registry pulls are then skipped. Any field is overridable by the matching env var.
 
 ## Steps & actions
 

--- a/devshard/docs/devshard-update/SKILL.md
+++ b/devshard/docs/devshard-update/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: devshard-update
+description: Update a Gonka devshard gateway to a new image version without dropping in-flight /v1/chat/completions requests, driven by a JSON config. Single-instance blue/green (temp gateway + nginx switch + drain + config-driven temp escrows + import); a recover command reclaims stranded temp escrows; multi-instance pools use a rolling update.
+---
+
+# Devshard Gateway Update
+
+Companion to [README.md](README.md) (manual steps + the command) and [scripts/update.sh](scripts/update.sh).
+
+## One command (single instance)
+
+```bash
+cp scripts/update.config.sample.json update.config.json     # edit: image tags, models[], nginx, compose
+./scripts/update.sh --config update.config.json run          # dry run — prints the plan
+./scripts/update.sh --config update.config.json run --run    # execute
+```
+
+Add `--yes` for unattended. Everything is config-driven (models included) — nothing is hardcoded.
+
+## Safety rules
+
+- Treat any live gateway host as production. Show the exact command and get approval before running it.
+- Dry-run first (`run` without `--run`) and read the plan.
+- MAIN's image comes from the compose file; the `bump-main-image` step rewrites the tag from `image.from_tag` to `image.to_tag`.
+- Temp escrows must cover every model MAIN serves — `preflight` fails closed if a served model has no temp coverage and isn't in `allow_unavailable_models`.
+- Public verification runs only if `nginx.public_base_url` is set — never trust loopback.
+- Do not assume the nginx config path — inspect with `docker exec <proxy> sh -lc 'nginx -T'`.
+
+## Config
+
+`scripts/update.config.sample.json` — blocks: `image {repository, from_tag, to_tag}`, `models[] {model, escrow_count, escrow_amount}`, `allow_unavailable_models[]`, `escrow`, `main`, `temp`, `nginx`, `compose`, `timeouts`, `rotation`. Any field is overridable by the matching env var.
+
+## Steps & actions
+
+Full-flow order (aborts on the first failed gate and names the step):
+`init` → `preflight` → `disable-main-rotation` → `create-temp-gateway` → `create-temp-escrows` → `check-temp` → `switch-to-temp` → `check-alias-temp` → `drain-main` → `bump-main-image` → `update-main` → `check-main-direct` → `switch-to-main` → `check-alias-main` → `drain-temp` → `stop-temp` → `import-temp` → `activate-temp` → `restore-main-rotation` → `status`.
+
+- Single step: `./scripts/update.sh --config <file> <step> --run`.
+- Resume: `... run --run --from-step drain-main`.
+- Recover stranded temp escrows after an aborted run: `./scripts/update.sh --config <file> recover --run` (add `--settle` to settle them instead of folding into main).
+- `plan` / `validate` / `list-steps` for inspection (no side effects).
+
+## Remote execution
+
+```bash
+ssh -p <port> <user>@<host> "$(cat <<'REMOTE'
+set -euo pipefail
+cd <deploy-dir>
+./scripts/update.sh --config update.config.json run --run --yes
+REMOTE
+)"
+```

--- a/devshard/docs/devshard-update/SKILL.md
+++ b/devshard/docs/devshard-update/SKILL.md
@@ -22,18 +22,21 @@ Add `--yes` for unattended. Everything is config-driven (models included) — no
 - Treat any live gateway host as production. Show the exact command and get approval before running it.
 - Dry-run first (`run` without `--run`) and read the plan.
 - MAIN's image comes from the compose file; the `bump-main-image` step rewrites the tag from `image.from_tag` to `image.to_tag`.
+- For a protocol change, back up and manually stage `DEVSHARD_ROUTE_PREFIX` in the gateway env before running the script. Verify the running main still has the source route; temp and the recreated main must read the target route.
+- For a protocol change, configure `escrow.source_protocol_version`, target `escrow.protocol_version`, and `models[].main_seed_count >= 1`. The script deactivates source escrows without settlement before recreating main, then creates target seed escrows before switching traffic back.
+- Schedule protocol changes shortly after `set_new_validators` in `Inference`, with fresh escrows and enough blocks before the next PoC. Do not resume after the chain's escrow-pruning threshold.
 - Temp escrows must cover every model MAIN serves — `preflight` fails closed if a served model has no temp coverage and isn't in `allow_unavailable_models`.
 - Public verification runs only if `nginx.public_base_url` is set — never trust loopback.
 - Do not assume the nginx config path — inspect with `docker exec <proxy> sh -lc 'nginx -T'`.
 
 ## Config
 
-`scripts/update.config.sample.json` — blocks: `image {repository, from_tag, to_tag}`, `models[] {model, escrow_count, escrow_amount}`, `allow_unavailable_models[]`, `escrow`, `main`, `temp`, `nginx`, `compose`, `timeouts`, `rotation`. Any field is overridable by the matching env var.
+`scripts/update.config.sample.json` — blocks: `image {repository, from_tag, to_tag, skip_pull}`, `models[] {model, escrow_count, main_seed_count, escrow_amount}`, `allow_unavailable_models[]`, `escrow {source_protocol_version, protocol_version, private_key_env}`, `main`, `temp`, `nginx`, `compose`, `timeouts`, `rotation`. Use `image.skip_pull=true` only when the exact target image is already loaded locally; both registry pulls are then skipped. Any field is overridable by the matching env var.
 
 ## Steps & actions
 
 Full-flow order (aborts on the first failed gate and names the step):
-`init` → `preflight` → `disable-main-rotation` → `create-temp-gateway` → `create-temp-escrows` → `check-temp` → `switch-to-temp` → `check-alias-temp` → `drain-main` → `bump-main-image` → `update-main` → `check-main-direct` → `switch-to-main` → `check-alias-main` → `drain-temp` → `stop-temp` → `import-temp` → `activate-temp` → `restore-main-rotation` → `status`.
+`init` → `preflight` → `disable-main-rotation` → `create-temp-gateway` → `create-temp-escrows` → `check-temp` → `switch-to-temp` → `check-alias-temp` → `drain-main` → `deactivate-main-source` → `bump-main-image` → `update-main` → `create-main-seed-escrows` → `check-main-direct` → `switch-to-main` → `check-alias-main` → `drain-temp` → `stop-temp` → `import-temp` → `activate-temp` → `restore-main-rotation` → `status`.
 
 - Single step: `./scripts/update.sh --config <file> <step> --run`.
 - Resume: `... run --run --from-step drain-main`.

--- a/devshard/docs/devshard-update/references/admin-api.md
+++ b/devshard/docs/devshard-update/references/admin-api.md
@@ -51,7 +51,14 @@ curl -fsS http://127.0.0.1:18080/v1/admin/settings -H "Authorization: Bearer $KE
 
 ## protocol_version
 
-Only `"1"` (aka `""` / `"v1"`) parses; anything else is rejected. It is a stored field but effectively pinned to v1 — a gateway image "vX → vY" update is **not** a protocol change. Pass `"1"` (or leave default) when creating/importing/activating.
+The gateway accepts `"1"` / `"v1"`, `"2"` / `"v2"`, and `"3"` / `"v3"`;
+stored values are normalized to `"1"`, `"2"`, and `"3"`.
+
+This per-escrow value is separate from the gateway image's build-time protocol
+and `DEVSHARD_ROUTE_PREFIX`. During a protocol change, deactivate source
+escrows before recreating main on the target image. Otherwise the target binary
+can fail startup while recovering incompatible source session state (for
+example, `stored v2, requested v3`).
 
 ## Notes for migration
 

--- a/devshard/docs/devshard-update/references/admin-api.md
+++ b/devshard/docs/devshard-update/references/admin-api.md
@@ -1,0 +1,62 @@
+# Reference — Gateway Admin API (migration subset)
+
+The endpoints a broker touches during a zero-downtime update. All admin routes require `Authorization: Bearer $DEVSHARD_ADMIN_API_KEY`; `/v1/status` is public. Handlers live in `devshard/cmd/devshardctl/gateway.go`.
+
+## Status & draining
+
+| Method / path | Purpose |
+|---|---|
+| `GET /v1/status` | Public health + per-devshard runtime snapshot. **The drain gate.** Each devshard reports `active_requests`. |
+| `GET /v1/admin/devshards` | Full admin list of persisted devshards (active + inactive) with model, protocol_version, storage, balance. |
+| `GET /v1/admin/state` | Broader admin snapshot (devshards + effective settings). |
+
+**Drain check** — poll until zero:
+
+```bash
+curl -fsS http://127.0.0.1:18080/v1/status \
+  -H "Authorization: Bearer $DEVSHARD_ADMIN_API_KEY" \
+  | jq '[.devshards[]?.active_requests // 0] | max // 0'
+```
+
+`active_requests` is an atomic counter per runtime, incremented on request reserve and decremented on release, then serialized under `devshards[].active_requests`. It is also exported as the Prometheus gauge `devshard_runtime_active_requests`.
+
+## Settings
+
+| Method / path | Purpose |
+|---|---|
+| `GET /v1/admin/settings` | Effective persisted gateway settings. |
+| `POST /v1/admin/settings` | Update settings live (e.g. `escrow_rotation`, `max_concurrent_requests`). |
+
+During a migration, copy main's settings to the temp gateway but force rotation off so temp never auto-settles:
+
+```bash
+curl -fsS http://127.0.0.1:18080/v1/admin/settings -H "Authorization: Bearer $KEY" \
+  | jq '.escrow_rotation.enabled = false | .escrow_rotation.models = []' \
+  | curl -fsS -X POST http://127.0.0.1:18081/v1/admin/settings -H "Authorization: Bearer $KEY" \
+      -H 'Content-Type: application/json' -d @-
+```
+
+`escrow_rotation.enabled = false` is the master off switch — it stops the rotator and thus all auto-settlement. Disable it on **MAIN** directly (a running gateway keeps whatever is in `gateway.db`, not the first-boot default); `settlement_enabled` and `models` are finer controls you don't need to touch for a swap.
+
+## Escrow lifecycle
+
+| Method / path | Purpose |
+|---|---|
+| `POST /v1/admin/escrows` | Create a **new** escrow on-chain (`amount`, `model_id`, `private_key_env`, `protocol_version`) and optionally register it. Used to seed **temp** escrows. |
+| `POST /v1/admin/devshards/import` | Import an **existing** escrow into this gateway by `id` + `storage_path` + `private_key_env` (+ optional `perf_path`), with `active:false`. Carries an escrow's sqlite state into a fresh gateway process — the storage-portability tool. |
+| `POST /v1/admin/devshards` | Register / **activate** a devshard (`id`, `model`, `storage_path`, `protocol_version`, `private_key_env`). Adds it to the routing pool. |
+| `POST /v1/admin/devshards/{id}/deactivate` | Set `active=false` — removes from the routing pool, keeps the runtime loaded, **does not settle**. In-flight requests finish. |
+| `POST /v1/admin/devshards/{id}/settle` | Deliberately settle an escrow on-chain (drain-aware). |
+| `DELETE /v1/admin/devshards/{id}` | Remove a devshard cleanly. |
+
+## protocol_version
+
+Only `"1"` (aka `""` / `"v1"`) parses; anything else is rejected. It is a stored field but effectively pinned to v1 — a gateway image "vX → vY" update is **not** a protocol change. Pass `"1"` (or leave default) when creating/importing/activating.
+
+## Notes for migration
+
+- **Import needs `storage_path`.** It is how an existing escrow's `state.db` is reattached to a new process. Point it at the temp escrow's container path (e.g. `/root/.devshardctl/temp-<run-id>/escrow-<id>/state.db`).
+- **Create vs import:** `create` mints a *new* on-chain escrow; `import` re-attaches an *existing* one. Temp escrows are `create`d, then later `import`ed into main.
+- **Deactivate ≠ settle.** Deactivating during a swap is safe and reversible; settlement is a separate, config-gated, drain-aware action.
+- **`escrow` and `devshard` are the same object.** `create` mints it (`/v1/admin/escrows`); everything else lists/imports/activates/deactivates it (`/v1/admin/devshards`, and it appears under `/v1/status .devshards[]`).
+- **Field name differs by call:** `create` takes `model_id`; `import` and `activate` take `model`.

--- a/devshard/docs/devshard-update/references/nginx-alias-switching.md
+++ b/devshard/docs/devshard-update/references/nginx-alias-switching.md
@@ -1,0 +1,54 @@
+# Reference — nginx upstream switch
+
+The `proxy` container forwards `/v1/chat/completions` to the gateway. The zero-downtime switch repoints that target from the old gateway to the new one and reloads, without cutting in-flight streams.
+
+## Why in-flight streams survive
+
+`nginx -s reload` is graceful:
+
+1. `nginx -t` validates the new config.
+2. `nginx -s reload` starts **new** workers with the new config and tells the **old** workers to stop accepting connections.
+3. Old workers keep running until their in-flight requests finish (including long SSE streams), then exit.
+
+New requests go to the new target; existing requests drain on the old workers. Nothing is cut mid-stream — which is why the switch uses reload, never a proxy-container restart.
+
+## What the switch changes
+
+Both the manual `sed` (README step 5) and the script replace the upstream host `<old>:PORT` → `<new>:PORT` in the nginx config (inside the `proxy` container), then run `nginx -t && nginx -s reload`. One `sed` handles **both** config styles:
+
+```nginx
+location /devshard-gateway/ { proxy_pass http://devshard-gateway:8080/; }   # direct pass — host swapped
+upstream pool { server devshard-gateway:8080; }                              # named upstream — host swapped
+# proxy_pass http://pool;  — references the block by name, left untouched (correct)
+```
+
+In the config these are `nginx.old_upstream`, `nginx.new_upstream`, `nginx.upstream_port`, `nginx.config_path`, `nginx.proxy_container`.
+
+## Pool (2+ gateways)
+
+A named upstream with multiple `server` lines. Rolling update: mark one `down` (or comment it), reload, drain+update that instance, restore it, reload; repeat. nginx load-balances across whoever is up, so capacity never drops to zero.
+
+```nginx
+upstream devshard_gateway {
+    server gw-a:8080;
+    server gw-b:8080;   # comment out (or `down`) while updating gw-b, then restore
+}
+```
+
+## Finding the live config
+
+Do not assume the path. The effective config may be `/etc/nginx/nginx.conf`, a file under `conf.d/`, or an included fragment:
+
+```bash
+docker exec proxy sh -lc 'nginx -T 2>&1 | grep -n "devshard\|v1/chat\|proxy_pass\|upstream"'
+```
+
+Set `nginx.config_path`, `nginx.proxy_container`, `nginx.old_upstream`, `nginx.new_upstream`, and `nginx.upstream_port` in the config to match what you find.
+
+The gateway's compose (`deploy/join/docker-compose.devshard-gateway.yml`) registers it under two network aliases — `${DEVSHARD_INSTANCE_NAME:-devshard-gateway}` and `devshard-pool` — so the proxy could reach it by either. The proxy's own config is not in this repo, so `nginx.old_upstream` (default `devshard-gateway`) is a guess: confirm the real upstream host with `nginx -T` before you switch.
+
+## Gotchas
+
+- **Verify through the public URL, not `127.0.0.1`.** Public verification runs only if `nginx.public_base_url` is set; a loopback check can pass while the public route is broken.
+- **Host+port replacement.** The switch rewrites `http://<host>:PORT` and `server <host>:PORT;`. A `proxy_pass` that points at an upstream *name*, a variable, a map, or a non-configured port won't match — set `nginx.old_upstream` / `nginx.new_upstream` / `nginx.upstream_port`, or switch by hand.
+- **Always `nginx -t` before reload.** A reload with a broken config keeps the old workers serving but blocks the switch. The switch gates the reload on `nginx -t` and backs up the config first — restore the backup to revert routing instantly.

--- a/devshard/docs/devshard-update/references/troubleshooting.md
+++ b/devshard/docs/devshard-update/references/troubleshooting.md
@@ -1,0 +1,51 @@
+# Reference — Troubleshooting & rollback
+
+Symptoms, causes, and fixes during a zero-downtime gateway update. Endpoints in [admin-api.md](admin-api.md); nginx behavior in [nginx-alias-switching.md](nginx-alias-switching.md).
+
+## Drain never reaches zero
+
+`active_requests` stays above 0 past the poll window.
+
+- **A long stream is genuinely running.** Large `max_tokens` / slow model can hold a request for minutes. Raise `timeouts.drain_timeout_seconds` in the config (default `7200`) rather than force-killing.
+- **A hung/abandoned stream.** A client that vanished mid-SSE can leave a request parked. Confirm via `GET /v1/status` per devshard; if one runtime is stuck with a client that's gone, decide whether to wait out the server-side timeout or accept dropping that single request before recreate.
+- **New requests still arriving.** The nginx switch didn't take. Re-check routing through the **public** URL — you may have verified loopback only.
+
+## Escrows missing / not routable after update
+
+`GET /v1/admin/devshards` returns empty or fewer than expected.
+
+- **Volume not mounted.** The new container didn't get `/root/.devshardctl`. The gateway then ran the first-boot env path instead of loading `gateway.db`. Stop it, fix the `-v .../.devshardctl:/root/.devshardctl` mount, restart — nothing is lost, sqlite is still on disk.
+- **Imported escrow inactive.** After `import-temp` the escrow is `active:false` by design. Run `activate-temp` (`POST /v1/admin/devshards`) to add it to the routing pool.
+- **Wrong `storage_path` on import.** Import re-attaches an escrow's `state.db` by path. If the path is wrong the escrow imports but can't serve. Point it at the temp escrow's real container path (e.g. `/root/.devshardctl/temp-<run-id>/escrow-<id>/state.db`).
+
+## nginx reload fails
+
+- **`nginx -t` errors.** The switch is blocked (old workers keep serving — no outage). Fix the config or restore the backup `<backup-dir>/nginx.conf.blue-green-backup`, then reload.
+- **`sed` matched nothing.** The upstream pattern didn't match (a `proxy_pass` via upstream *name*, a variable, a different port, or already switched). Inspect with `nginx -T`; set `nginx.old_upstream` / `nginx.new_upstream` / `nginx.upstream_port` in the config.
+
+## Temp gateway won't start
+
+- **Admin port clash.** `TEMP_ADMIN_PORT` (default `18081`) is already bound. Pick a free port.
+- **Same escrow as main.** Never let temp bootstrap the main escrows — it starts with `DEVSHARDS_JSON=[]` for a reason (one writer per escrow). If you see nonce/state errors, temp is fighting main over an escrow; give temp its own fresh escrows only.
+
+## MAIN came back on the old version
+
+`update-main` recreates MAIN from the compose file using the image tag pinned there. The `bump-main-image` step rewrites that tag from `image.from_tag` to `image.to_tag` before `update-main` runs. If MAIN came back on the old version, the tag wasn't bumped — confirm `bump-main-image` ran (running steps by hand, edit the compose image tag before `update-main`).
+
+## New image is bad
+
+- Do **not** `switch-to-main` (Path B) or return the instance to the pool (Path A).
+- Re-pull the previous image tag and `--force-recreate` back to it; verify `check-main-direct`; then retry.
+- Routing rollback is instant: restore the nginx backup and reload, or keep the alias pointed at the still-good temp/other instance.
+
+## Settlement fired unexpectedly
+
+- `escrow_rotation.enabled = false` is the master switch — it stops the rotator and all auto-settlement. The `disable-main-rotation` step sets it on MAIN; if a settle fired mid-migration, rotation was still on there (a running gateway keeps whatever is in `gateway.db`, not the first-boot default). Settle deliberately afterward via `POST /v1/admin/devshards/{id}/settle`.
+- A settle that was *queued* (`settlement_queued_waiting_for_drain`) is normal and harmless — it waits for `active_requests == 0` and does not drop requests.
+
+## Rollback checklist
+
+1. Stop routing new traffic to the bad target (restore nginx backup + reload, or keep alias on the good side).
+2. Confirm the good side is serving via the **public** URL smoke test.
+3. Recreate the bad container on the last-known-good image; verify direct.
+4. Only then resume the normal step order.

--- a/devshard/docs/devshard-update/references/troubleshooting.md
+++ b/devshard/docs/devshard-update/references/troubleshooting.md
@@ -32,6 +32,14 @@ Symptoms, causes, and fixes during a zero-downtime gateway update. Endpoints in 
 
 `update-main` recreates MAIN from the compose file using the image tag pinned there. The `bump-main-image` step rewrites that tag from `image.from_tag` to `image.to_tag` before `update-main` runs. If MAIN came back on the old version, the tag wasn't bumped — confirm `bump-main-image` ran (running steps by hand, edit the compose image tag before `update-main`).
 
+## MAIN restart loops with `session version mismatch`
+
+The target binary is trying to recover active source-protocol session state
+from the persistent gateway database. Keep traffic on temp, recreate main on
+the source image/route, deactivate its active source escrows without settling,
+then recreate main on the target image/route. Create target-protocol seed
+escrows and pass the direct smoke test before switching traffic back.
+
 ## New image is bad
 
 - Do **not** `switch-to-main` (Path B) or return the instance to the pool (Path A).

--- a/devshard/docs/devshard-update/references/troubleshooting.md
+++ b/devshard/docs/devshard-update/references/troubleshooting.md
@@ -40,6 +40,11 @@ the source image/route, deactivate its active source escrows without settling,
 then recreate main on the target image/route. Create target-protocol seed
 escrows and pass the direct smoke test before switching traffic back.
 
+Older gateways may omit `protocol_version` on `GET /v1/admin/devshards` (null /
+missing). For a protocol change, `deactivate-main-source` treats missing protocol
+as the configured `escrow.source_protocol_version` so active pre-protocol escrows
+are still deactivated (never settled).
+
 ## New image is bad
 
 - Do **not** `switch-to-main` (Path B) or return the instance to the pool (Path A).

--- a/devshard/docs/devshard-update/scripts/update-canary.sh
+++ b/devshard/docs/devshard-update/scripts/update-canary.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+# -E: inherit ERR trap into functions (bash >= 4).
+
+# Operator-driven canary cutover for a single-instance Gonka gateway.
+# Temp runs the target image; MAIN stays on the source image until finish.
+# No sleeps — you wait, then re-run check / set yourself.
+#
+# Modes:
+#   prepare          stand up temp + mint escrows + smoke (nginx still 100% MAIN)
+#   set <percent>    send <percent>% of nginx traffic to TEMP (0..100)
+#   check            verify MAIN/TEMP/public health + show current canary weights
+#   finish           require/force 100% TEMP, then drain/recreate MAIN and fold temp
+#   plan|validate    inspection (no side effects beyond validate)
+#   recover          delegate to update.sh recover
+#
+# Usage:
+#   ./update-canary.sh --config update.config.json prepare
+#   ./update-canary.sh --config update.config.json set 10 --run
+#   ./update-canary.sh --config update.config.json check --run
+#   ./update-canary.sh --config update.config.json set 50 --run
+#   ./update-canary.sh --config update.config.json finish --run
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPDATE_SH="${SCRIPT_DIR}/update.sh"
+
+usage() {
+  cat <<'EOF'
+Canary update for a single-instance devshard gateway (temp=v3, MAIN=source).
+
+  ./update-canary.sh --config <file> <mode> [percent] [flags]
+
+Modes:
+  prepare           create temp gateway + escrows; leave nginx on MAIN
+  set <percent>     weighted traffic to TEMP (0=MAIN only, 100=TEMP only)
+  check             health gates + print current upstream weight lines
+  finish            100% TEMP (if needed) then recreate MAIN and fold temp
+  plan|validate     show plan / validate shared update.config.json
+  recover           stranded temp escrow recover (delegates to update.sh)
+
+Flags: same as update.sh (--run, --dry-run, --yes, --deploy-dir, --settle).
+There is no built-in wait — observe yourself between set/check calls.
+EOF
+}
+
+CONFIG_ARG="${DEVSHARD_UPDATE_CONFIG:-./update.config.json}"
+MODE=""; SET_PERCENT=""; DEPLOY_DIR="$(pwd)"
+DRY_RUN=1; [[ "${RUN:-0}" == "1" ]] && DRY_RUN=0
+ASSUME_YES=0; RECOVER_SETTLE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)       CONFIG_ARG="${2:?--config needs a value}"; shift 2 ;;
+    --config=*)     CONFIG_ARG="${1#*=}"; shift ;;
+    --deploy-dir)   DEPLOY_DIR="${2:?--deploy-dir needs a value}"; shift 2 ;;
+    --deploy-dir=*) DEPLOY_DIR="${1#*=}"; shift ;;
+    --settle)       RECOVER_SETTLE=1; shift ;;
+    --run)          DRY_RUN=0; shift ;;
+    --dry-run)      DRY_RUN=1; shift ;;
+    --yes|-y)       ASSUME_YES=1; shift ;;
+    --help|-h)      usage; exit 0 ;;
+    --*)            echo "unknown flag: $1" >&2; usage >&2; exit 2 ;;
+    prepare|check|finish|plan|validate|recover)
+      MODE="$1"; shift ;;
+    set)
+      MODE="set"; shift
+      SET_PERCENT="${1:?set needs a percent 0..100}"; shift ;;
+    *)
+      # allow: set 10 as two tokens already handled; bare number after set only
+      echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+[[ -n "${MODE}" ]] || MODE="plan"
+
+gate_ok()   { printf '    GATE-OK %s\n' "$1"; }
+gate_fail() { printf '    GATE-FAIL %s\n' "$1"; }
+note()      { printf '      - %s\n' "$1"; }
+
+abspath() { case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s/%s\n' "$(pwd)" "$1" ;; esac; }
+
+update_flags() {
+  local -a flags=(--config "${CONFIG_ARG}" --deploy-dir "${DEPLOY_DIR}")
+  [[ "${DRY_RUN}" == "0" ]] && flags+=(--run)
+  [[ "${ASSUME_YES}" == "1" ]] && flags+=(--yes)
+  [[ "${RECOVER_SETTLE}" == "1" ]] && flags+=(--settle)
+  printf '%s\n' "${flags[@]}"
+}
+
+run_update() {
+  local -a flags=()
+  local line
+  while IFS= read -r line; do flags+=("${line}"); done < <(update_flags)
+  note "update.sh $* ${flags[*]}"
+  bash "${UPDATE_SH}" "${flags[@]}" "$@"
+}
+
+# Load the same JSON fields update.sh uses for nginx / admin URLs (lightweight).
+load_canary_config() {
+  local path; path="$(abspath "${CONFIG_ARG}")"
+  [[ -f "${path}" ]] || { echo "config file not found: ${path}" >&2; exit 2; }
+  CONFIG_JSON="$(cat "${path}")"
+  MAIN_ADMIN_URL="$(jq -r '.main.admin_url // empty' <<<"${CONFIG_JSON}")"
+  TEMP_ADMIN_PORT="$(jq -r '.temp.admin_port // empty' <<<"${CONFIG_JSON}")"
+  TEMP_ADMIN_URL="http://127.0.0.1:${TEMP_ADMIN_PORT}"
+  TEMP_UPSTREAM_ALIAS="$(jq -r '.temp.upstream_alias // empty' <<<"${CONFIG_JSON}")"
+  NGINX_PROXY_CONTAINER="$(jq -r '.nginx.proxy_container // empty' <<<"${CONFIG_JSON}")"
+  NGINX_CONFIG_PATH="$(jq -r '.nginx.config_path // empty' <<<"${CONFIG_JSON}")"
+  NGINX_OLD_UPSTREAM="$(jq -r '.nginx.old_upstream // empty' <<<"${CONFIG_JSON}")"
+  NGINX_NEW_UPSTREAM="$(jq -r '.nginx.new_upstream // empty' <<<"${CONFIG_JSON}")"
+  [[ -n "${NGINX_NEW_UPSTREAM}" ]] || NGINX_NEW_UPSTREAM="${TEMP_UPSTREAM_ALIAS}"
+  NGINX_UPSTREAM_PORT="$(jq -r '.nginx.upstream_port // empty' <<<"${CONFIG_JSON}")"
+  NGINX_PUBLIC_BASE_URL="$(jq -r '.nginx.public_base_url // empty' <<<"${CONFIG_JSON}")"
+  NGINX_PUBLIC_PREFIX="$(jq -r '.nginx.public_prefix // "/devshard-gateway"' <<<"${CONFIG_JSON}")"
+  SMOKE_MODEL="$(jq -r '.smoke_test.model // empty' <<<"${CONFIG_JSON}")"
+  [[ -n "${SMOKE_MODEL}" ]] || SMOKE_MODEL="$(jq -r '.models[0].model // empty' <<<"${CONFIG_JSON}")"
+  MAIN_STORAGE_HOST_DIR="$(jq -r '.main.storage_host_dir // ".devshardctl"' <<<"${CONFIG_JSON}")"
+  # Prefer deploy-dir state (writable); .devshardctl is often root-owned on prod hosts.
+  CANARY_STATE_FILE="$(abspath "${DEPLOY_DIR}")/canary-run-state.env"
+}
+
+save_canary_percent() {
+  [[ -n "${CANARY_STATE_FILE:-}" ]] || load_canary_config
+  mkdir -p "$(dirname "${CANARY_STATE_FILE}")"
+  printf 'CANARY_TEMP_PERCENT=%s\n' "$1" > "${CANARY_STATE_FILE}"
+}
+
+read_canary_percent() {
+  # shellcheck disable=SC1090
+  [[ -f "${CANARY_STATE_FILE}" ]] && source "${CANARY_STATE_FILE}" || true
+  echo "${CANARY_TEMP_PERCENT:-0}"
+}
+
+need_key() {
+  [[ -n "${DEVSHARD_ADMIN_API_KEY:-}" ]] || {
+    echo "DEVSHARD_ADMIN_API_KEY is not set in this shell (source config.devshard.env first)" >&2
+    exit 2
+  }
+}
+
+admin_get() {
+  curl -fsS "$1$2" -H "Authorization: Bearer ${DEVSHARD_ADMIN_API_KEY}"
+}
+
+smoke_chat() {
+  local auth_hdr=()
+  if [[ -n "${DEVSHARD_ADMIN_API_KEY:-}" ]]; then
+    auth_hdr=(-H "Authorization: Bearer ${DEVSHARD_ADMIN_API_KEY}")
+  elif [[ -n "${DEVSHARD_API_KEYS:-}" ]]; then
+    auth_hdr=(-H "Authorization: Bearer ${DEVSHARD_API_KEYS%%,*}")
+  fi
+  curl -fsS -X POST "$1/v1/chat/completions" "${auth_hdr[@]}" -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg m "$2" '{model:$m, stream:false, max_tokens:1, messages:[{role:"user", content:"Reply with ok"}]}')" >/dev/null
+}
+
+# Rewrite nginx so TEMP gets $1% of traffic (MAIN gets the rest) via upstream
+# `server` weights. percent=0 → MAIN only; percent=100 → TEMP only (full switch).
+# Direct proxy_pass http://host:port paths cannot weight; those stay as-is and
+# check warns if they still pin only MAIN while percent>0.
+nginx_set_percent() {
+  local percent="$1"
+  local main="${NGINX_OLD_UPSTREAM}" temp="${NGINX_NEW_UPSTREAM}" port="${NGINX_UPSTREAM_PORT}"
+  local cfg="${NGINX_CONFIG_PATH}" proxy="${NGINX_PROXY_CONTAINER}"
+  local backup="${cfg}.canary-backup" tmp="${cfg}.canary-tmp"
+  local w_temp="${percent}" w_main=$((100 - percent))
+
+  if ! [[ "${percent}" =~ ^[0-9]+$ ]] || (( percent < 0 || percent > 100 )); then
+    echo "percent must be an integer 0..100, got: ${percent}" >&2
+    return 2
+  fi
+
+  note "nginx canary TEMP=${percent}% MAIN=$((100 - percent))% (${temp}:${port} / ${main}:${port})"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    note "would rewrite ${cfg} server weights and nginx -t && reload"
+    return 0
+  fi
+
+  local inner
+  # percent 0 → MAIN only; 100 → TEMP only; else both with relative weights.
+  # Also rewrites direct proxy_pass http://host:port → the active sole host when
+  # percent is 0 or 100; mid-canary direct proxy_pass cannot weight (check warns).
+  inner="$(cat <<INNER
+set -eu
+test -f '${cfg}'
+cp '${cfg}' '${backup}'
+
+awk -v main='${main}' -v temp='${temp}' -v port='${port}' -v wm='${w_main}' -v wt='${w_temp}' '
+  BEGIN {
+    re_main = "^[[:space:]]*server[[:space:]]+" main ":" port "([^0-9]|\$)"
+    re_temp = "^[[:space:]]*server[[:space:]]+" temp ":" port "([^0-9]|\$)"
+    touched_any = 0
+  }
+  function emit_servers() {
+    if (wm > 0) printf "        server %s:%s weight=%d max_fails=2 fail_timeout=30s;\\n", main, port, wm
+    if (wt > 0) printf "        server %s:%s weight=%d max_fails=2 fail_timeout=30s;\\n", temp, port, wt
+    emitted = 1
+  }
+  /^[[:space:]]*upstream[[:space:]]/ {
+    in_up = 1; removed = 0; emitted = 0
+    print; next
+  }
+  in_up && (\$0 ~ re_main || \$0 ~ re_temp) {
+    removed = 1; touched_any = 1; next
+  }
+  in_up && /^[[:space:]]*}/ {
+    if (removed && !emitted) emit_servers()
+    in_up = 0; print; next
+  }
+  in_up && /^[[:space:]]*server[[:space:]]/ && removed && !emitted {
+    emit_servers()
+    print; next
+  }
+  wm == 100 && wt == 0 {
+    gsub("http://" temp ":" port, "http://" main ":" port)
+  }
+  wm == 0 && wt == 100 {
+    gsub("http://" main ":" port, "http://" temp ":" port)
+  }
+  { print }
+  END {
+    if (!touched_any) {
+      print "ERROR: no upstream server lines matched MAIN/TEMP hosts — check nginx.old_upstream/new_upstream" > "/dev/stderr"
+      exit 3
+    }
+  }
+' '${cfg}' > '${tmp}'
+
+if mv '${tmp}' '${cfg}' 2>/dev/null; then
+  :
+else
+  cat '${tmp}' > '${cfg}'
+  rm -f '${tmp}'
+fi
+
+if [ '${w_main}' -gt 0 ]; then
+  grep -Eq "server[[:space:]]+${main}:${port}" '${cfg}'
+fi
+if [ '${w_temp}' -gt 0 ]; then
+  grep -Eq "server[[:space:]]+${temp}:${port}" '${cfg}'
+fi
+nginx -t
+nginx -s reload
+echo "canary weights applied TEMP=${w_temp} MAIN=${w_main}"
+INNER
+)"
+  if docker exec "${proxy}" sh -lc "${inner}"; then
+    save_canary_percent "${percent}"
+    gate_ok "canary TEMP=${percent}% applied and reloaded"
+    return 0
+  fi
+  gate_fail "canary weight set to ${percent}% failed (restore ${backup} if needed)"
+  return 1
+}
+
+show_canary_nginx() {
+  note "nginx server lines for MAIN/TEMP (from nginx -T)"
+  docker exec "${NGINX_PROXY_CONTAINER}" sh -lc \
+    "nginx -T 2>/dev/null | grep -nE 'server[[:space:]]+(${NGINX_OLD_UPSTREAM}|${NGINX_NEW_UPSTREAM}):${NGINX_UPSTREAM_PORT}|proxy_pass http://(${NGINX_OLD_UPSTREAM}|${NGINX_NEW_UPSTREAM}):${NGINX_UPSTREAM_PORT}' | head -40" \
+    || true
+}
+
+cmd_prepare() {
+  load_canary_config
+  echo "==> canary prepare (temp up; nginx stays on MAIN)"
+  run_update init
+  run_update preflight
+  run_update disable-main-rotation
+  run_update create-temp-gateway
+  run_update create-temp-escrows
+  run_update check-temp
+  save_canary_percent 0
+  gate_ok "prepare complete — next: set 10 --run, then check --run (you wait between)"
+}
+
+cmd_set() {
+  load_canary_config
+  echo "==> canary set TEMP=${SET_PERCENT}%"
+  nginx_set_percent "${SET_PERCENT}"
+  show_canary_nginx
+}
+
+cmd_check() {
+  load_canary_config
+  need_key
+  echo "==> canary check (recorded TEMP percent=$(read_canary_percent))"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    note "would check MAIN/TEMP status, smoke, public smoke, nginx weight lines"
+    return 0
+  fi
+
+  local main_max temp_max
+  main_max="$(admin_get "${MAIN_ADMIN_URL}" "/v1/status" | jq '[.devshards[]?.active_requests // 0] | max // 0')"
+  temp_max="$(admin_get "${TEMP_ADMIN_URL}" "/v1/status" | jq '[.devshards[]?.active_requests // 0] | max // 0')"
+  note "MAIN max active_requests=${main_max}"
+  note "TEMP max active_requests=${temp_max}"
+  gate_ok "MAIN and TEMP status reachable"
+
+  local pct; pct="$(read_canary_percent)"
+  if (( pct > 0 && temp_max == 0 )); then
+    note "WARNING: canary percent=${pct} but TEMP shows 0 active_requests (may be idle, or weights not hitting TEMP)"
+  fi
+  if (( pct > 0 && pct < 100 && temp_max > 0 )); then
+    gate_ok "TEMP is receiving traffic (active_requests=${temp_max})"
+  fi
+
+  smoke_chat "${MAIN_ADMIN_URL}" "${SMOKE_MODEL}"
+  gate_ok "MAIN direct smoke (${SMOKE_MODEL})"
+  smoke_chat "${TEMP_ADMIN_URL}" "${SMOKE_MODEL}"
+  gate_ok "TEMP direct smoke (${SMOKE_MODEL})"
+
+  if [[ -n "${NGINX_PUBLIC_BASE_URL}" ]]; then
+    smoke_chat "${NGINX_PUBLIC_BASE_URL}${NGINX_PUBLIC_PREFIX}" "${SMOKE_MODEL}"
+    gate_ok "public smoke (${NGINX_PUBLIC_BASE_URL}${NGINX_PUBLIC_PREFIX})"
+  else
+    note "public_base_url unset — skipping public smoke"
+  fi
+
+  show_canary_nginx
+  # Warn about hard-coded single-host proxy_pass (cannot canary).
+  if docker exec "${NGINX_PROXY_CONTAINER}" sh -lc \
+      "nginx -T 2>/dev/null | grep -E 'proxy_pass http://${NGINX_OLD_UPSTREAM}:${NGINX_UPSTREAM_PORT}'" >/dev/null 2>&1; then
+    note "WARNING: some proxy_pass lines still hard-code MAIN (${NGINX_OLD_UPSTREAM}:${NGINX_UPSTREAM_PORT}); those paths do not follow canary weights"
+  fi
+}
+
+cmd_finish() {
+  load_canary_config
+  echo "==> canary finish (cut over MAIN to target image, fold temp)"
+  local pct; pct="$(read_canary_percent)"
+  if (( pct != 100 )); then
+    note "recorded canary percent=${pct}; forcing 100% TEMP before finish"
+    SET_PERCENT=100
+    nginx_set_percent 100
+  fi
+  run_update check-alias-temp
+  run_update drain-main
+  run_update deactivate-main-source
+  run_update bump-main-image
+  run_update update-main
+  run_update create-main-seed-escrows
+  run_update check-main-direct
+  run_update switch-to-main
+  run_update check-alias-main
+  run_update drain-temp
+  run_update stop-temp
+  run_update import-temp
+  run_update activate-temp
+  run_update restore-main-rotation
+  run_update status
+  save_canary_percent 0
+  gate_ok "canary finish complete"
+}
+
+print_plan() {
+  load_canary_config
+  cat <<EOF
+Devshard gateway CANARY update (operator-paced)
+Config: $(abspath "${CONFIG_ARG}")
+Mode:   $([[ "${DRY_RUN}" == "1" ]] && echo "dry-run (use --run to execute)" || echo LIVE)
+MAIN:   ${NGINX_OLD_UPSTREAM} @ ${MAIN_ADMIN_URL}
+TEMP:   ${NGINX_NEW_UPSTREAM} @ ${TEMP_ADMIN_URL}
+Nginx:  ${NGINX_PROXY_CONTAINER}:${NGINX_CONFIG_PATH}
+Public: ${NGINX_PUBLIC_BASE_URL:-<unset>}
+Smoke:  ${SMOKE_MODEL}
+State:  ${CANARY_STATE_FILE} (TEMP percent=$(read_canary_percent))
+
+Operator flow (no built-in wait):
+  1) prepare --run
+  2) set 10 --run
+  3) check --run          # you wait ~30m yourself, re-check as needed
+  4) set 50 --run
+  5) check --run
+  6) finish --run         # forces 100% TEMP, recreates MAIN, folds escrows
+
+Recover stranded temp escrows: recover --run   (add --settle only if you want settle)
+EOF
+}
+
+main() {
+  DEPLOY_DIR="$(abspath "${DEPLOY_DIR}")"
+  cd "${DEPLOY_DIR}"
+  [[ -f "${UPDATE_SH}" ]] || { echo "update.sh not found next to this script: ${UPDATE_SH}" >&2; exit 2; }
+
+  case "${MODE}" in
+    plan)     print_plan ;;
+    validate) run_update validate ;;
+    prepare)  cmd_prepare ;;
+    set)      cmd_set ;;
+    check)    cmd_check ;;
+    finish)   cmd_finish ;;
+    recover)  run_update recover ;;
+    *)        echo "unknown mode: ${MODE}" >&2; usage >&2; exit 2 ;;
+  esac
+}
+
+main

--- a/devshard/docs/devshard-update/scripts/update-canary.sh
+++ b/devshard/docs/devshard-update/scripts/update-canary.sh
@@ -99,6 +99,11 @@ load_canary_config() {
   local path; path="$(abspath "${CONFIG_ARG}")"
   [[ -f "${path}" ]] || { echo "config file not found: ${path}" >&2; exit 2; }
   CONFIG_JSON="$(cat "${path}")"
+  ROUTING_TYPE="$(jq -r '.routing.type // "nginx"' <<<"${CONFIG_JSON}")"
+  [[ "${ROUTING_TYPE}" == "nginx" ]] || {
+    echo "update-canary.sh supports routing.type=nginx only (got ${ROUTING_TYPE}); use update.sh for a full ${ROUTING_TYPE} blue/green update" >&2
+    exit 2
+  }
   MAIN_ADMIN_URL="$(jq -r '.main.admin_url // empty' <<<"${CONFIG_JSON}")"
   TEMP_ADMIN_PORT="$(jq -r '.temp.admin_port // empty' <<<"${CONFIG_JSON}")"
   TEMP_ADMIN_URL="http://127.0.0.1:${TEMP_ADMIN_PORT}"

--- a/devshard/docs/devshard-update/scripts/update.config.sample.json
+++ b/devshard/docs/devshard-update/scripts/update.config.sample.json
@@ -2,14 +2,16 @@
   "image": {
     "repository": "ghcr.io/gonka-ai/devshard-gateway",
     "from_tag": "mainnet-v0.2.13-latest",
-    "to_tag": "mainnet-v0.2.14-latest"
+    "to_tag": "mainnet-v0.2.14-latest",
+    "skip_pull": false
   },
   "models": [
-    { "model": "moonshotai/Kimi-K2.6", "escrow_count": 4, "escrow_amount": 5000000000 },
-    { "model": "MiniMaxAI/MiniMax-M2.7", "escrow_count": 2, "escrow_amount": 5000000000 }
+    { "model": "moonshotai/Kimi-K2.6", "escrow_count": 4, "main_seed_count": 0, "escrow_amount": 5000000000 },
+    { "model": "MiniMaxAI/MiniMax-M2.7", "escrow_count": 2, "main_seed_count": 0, "escrow_amount": 5000000000 }
   ],
   "allow_unavailable_models": [],
   "escrow": {
+    "source_protocol_version": "1",
     "protocol_version": "1",
     "private_key_env": "DEVSHARD_PRIVATE_KEY"
   },

--- a/devshard/docs/devshard-update/scripts/update.config.sample.json
+++ b/devshard/docs/devshard-update/scripts/update.config.sample.json
@@ -1,0 +1,52 @@
+{
+  "image": {
+    "repository": "ghcr.io/gonka-ai/devshard-gateway",
+    "from_tag": "mainnet-v0.2.13-latest",
+    "to_tag": "mainnet-v0.2.14-latest"
+  },
+  "models": [
+    { "model": "moonshotai/Kimi-K2.6", "escrow_count": 4, "escrow_amount": 5000000000 },
+    { "model": "MiniMaxAI/MiniMax-M2.7", "escrow_count": 2, "escrow_amount": 5000000000 }
+  ],
+  "allow_unavailable_models": [],
+  "escrow": {
+    "protocol_version": "1",
+    "private_key_env": "DEVSHARD_PRIVATE_KEY"
+  },
+  "main": {
+    "admin_url": "http://127.0.0.1:18080",
+    "container": "devshard-gateway",
+    "storage_host_dir": ".devshardctl",
+    "env_file": "./config.devshard.env"
+  },
+  "temp": {
+    "admin_port": 18081,
+    "upstream_alias": "devshard-gateway-temp",
+    "network": "join_default"
+  },
+  "nginx": {
+    "proxy_container": "proxy",
+    "config_path": "/etc/nginx/nginx.conf",
+    "old_upstream": "devshard-gateway",
+    "new_upstream": "devshard-gateway-temp",
+    "upstream_port": 8080,
+    "public_base_url": "",
+    "public_prefix": "/devshard-gateway"
+  },
+  "compose": {
+    "file": "docker-compose.devshard-gateway.yml",
+    "service": "devshard-gateway"
+  },
+  "timeouts": {
+    "ready_timeout_seconds": 180,
+    "ready_poll_seconds": 3,
+    "drain_timeout_seconds": 7200,
+    "drain_poll_seconds": 10
+  },
+  "smoke_test": {
+    "model": ""
+  },
+  "rotation": {
+    "restore_after_update": false
+  }
+}

--- a/devshard/docs/devshard-update/scripts/update.sh
+++ b/devshard/docs/devshard-update/scripts/update.sh
@@ -1,0 +1,622 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+# -E (errtrace): the ERR trap must be inherited by shell functions so a failed
+# gate deep in a step still reports where it stopped. Requires bash >= 4.
+
+# Zero-downtime update for a Gonka devshard gateway (single instance, blue/green).
+# One self-contained file, driven by a JSON config (models config-driven).
+#
+# Flow: stand up a temp gateway on its OWN fresh escrows, switch nginx to temp,
+# drain main, bump the compose image tag + recreate main, switch back, drain +
+# remove temp, then fold the temp escrows into main. Dry-run unless --run.
+#
+# Sections below: CLI -> config load/validate/resolve -> helpers (progress,
+# admin API, docker/nginx) -> steps -> orchestration -> recover -> entrypoint.
+#
+# Usage:
+#   ./update.sh --config update.config.json                     # dry-run plan
+#   ./update.sh --config update.config.json run --run --yes     # full flow, unattended
+#   ./update.sh --config update.config.json <step> --run        # one step
+#   ./update.sh --config update.config.json run --run --from-step drain-main
+#   ./update.sh --config update.config.json recover --run [--settle]
+#   ./update.sh --config update.config.json plan|validate|list-steps
+
+ORDERED_STEPS=(
+  init preflight disable-main-rotation create-temp-gateway create-temp-escrows
+  check-temp switch-to-temp check-alias-temp drain-main bump-main-image
+  update-main check-main-direct switch-to-main check-alias-main drain-temp
+  stop-temp import-temp activate-temp restore-main-rotation status
+)
+
+# --- CLI ---------------------------------------------------------------------
+
+usage() {
+  cat <<'EOF'
+Zero-downtime devshard gateway update (v2, single-file, config-driven).
+
+  ./update.sh --config <file> [action] [flags]
+
+Actions:  run | plan | validate | list-steps | recover | <step>
+Flags:
+  --config <file>     JSON config (default $DEVSHARD_UPDATE_CONFIG or ./update.config.json)
+  --run               execute for real (default dry-run; also RUN=1)
+  --dry-run           force dry-run even if RUN=1
+  --yes, -y           auto-confirm destructive steps (unattended)
+  --from-step <name>  with 'run': start at this step, skip earlier ones
+  --settle            with 'recover': settle stranded escrows instead of activating
+  --deploy-dir <dir>  directory to operate from (default: cwd)
+EOF
+}
+
+CONFIG_ARG="${DEVSHARD_UPDATE_CONFIG:-./update.config.json}"
+ACTION=""; FROM_STEP=""; DEPLOY_DIR="$(pwd)"
+DRY_RUN=1; [[ "${RUN:-0}" == "1" ]] && DRY_RUN=0
+ASSUME_YES=0; RECOVER_SETTLE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)      CONFIG_ARG="${2:?--config needs a value}"; shift 2 ;;
+    --config=*)    CONFIG_ARG="${1#*=}"; shift ;;
+    --from-step)   FROM_STEP="${2:?--from-step needs a value}"; shift 2 ;;
+    --from-step=*) FROM_STEP="${1#*=}"; shift ;;
+    --deploy-dir)  DEPLOY_DIR="${2:?--deploy-dir needs a value}"; shift 2 ;;
+    --deploy-dir=*) DEPLOY_DIR="${1#*=}"; shift ;;
+    --settle)      RECOVER_SETTLE=1; shift ;;
+    --run)         DRY_RUN=0; shift ;;
+    --dry-run)     DRY_RUN=1; shift ;;
+    --yes|-y)      ASSUME_YES=1; shift ;;
+    --help|-h)     usage; exit 0 ;;
+    --*)           echo "unknown flag: $1" >&2; usage >&2; exit 2 ;;
+    *)             ACTION="$1"; shift ;;
+  esac
+done
+[[ -z "${ACTION}" ]] && ACTION="plan"
+
+# --- progress (linear; markers are grepped by the sandbox test) --------------
+
+STEP_INDEX=0; STEP_TOTAL=0; CURRENT_STEP=""
+step_begin() { CURRENT_STEP="$1"; STEP_INDEX=$(( STEP_INDEX + 1 )); printf '==> [%2d/%2d] %s\n' "${STEP_INDEX}" "${STEP_TOTAL}" "$1"; }
+gate_ok()    { printf '    GATE-OK %s\n' "$1"; }
+gate_fail()  { printf '    GATE-FAIL %s\n' "$1"; }
+note()       { printf '      - %s\n' "$1"; }
+
+# --- config: load, validate (fail fast), resolve (env overrides JSON) --------
+
+cfg()  { jq -r "$1 // \"\"" <<<"${CONFIG_JSON}"; }
+cfgn() { jq -r "$1 // empty" <<<"${CONFIG_JSON}"; }
+
+config_validate() {
+  local errors
+  errors="$(jq -r '
+    def req(v; name): if (v == null or v == "") then "missing/empty: \(name)" else empty end;
+    def num(v; name): if (v|type) != "number" then "not a number: \(name)" else empty end;
+    [ req(.image.repository; "image.repository"),
+      req(.image.from_tag; "image.from_tag"),
+      req(.image.to_tag; "image.to_tag"),
+      (if ((.models // []) | length) < 1 then "models must be a non-empty array of {model, escrow_count, escrow_amount}" else empty end),
+      (.models // [] | to_entries[] |
+        ( req(.value.model; "models[\(.key)].model"),
+          num(.value.escrow_count; "models[\(.key)].escrow_count"),
+          num(.value.escrow_amount; "models[\(.key)].escrow_amount") )),
+      req(.escrow.protocol_version; "escrow.protocol_version"),
+      req(.escrow.private_key_env; "escrow.private_key_env"),
+      req(.main.admin_url; "main.admin_url"),
+      req(.main.container; "main.container"),
+      req(.main.storage_host_dir; "main.storage_host_dir"),
+      num(.temp.admin_port; "temp.admin_port"),
+      req(.temp.upstream_alias; "temp.upstream_alias"),
+      req(.temp.network; "temp.network"),
+      req(.nginx.proxy_container; "nginx.proxy_container"),
+      req(.nginx.config_path; "nginx.config_path"),
+      req(.nginx.old_upstream; "nginx.old_upstream"),
+      req(.nginx.new_upstream; "nginx.new_upstream"),
+      num(.nginx.upstream_port; "nginx.upstream_port"),
+      req(.compose.file; "compose.file"),
+      req(.compose.service; "compose.service"),
+      num(.timeouts.ready_timeout_seconds; "timeouts.ready_timeout_seconds"),
+      num(.timeouts.ready_poll_seconds; "timeouts.ready_poll_seconds"),
+      num(.timeouts.drain_timeout_seconds; "timeouts.drain_timeout_seconds"),
+      num(.timeouts.drain_poll_seconds; "timeouts.drain_poll_seconds")
+    ] | .[]' <<<"${CONFIG_JSON}")"
+  if [[ -n "${errors}" ]]; then
+    echo "Config validation failed for ${CONFIG_PATH}:" >&2
+    sed 's/^/  - /' <<<"${errors}" >&2
+    return 1
+  fi
+}
+
+resolve_config() {
+  IMAGE_REPO="${IMAGE_REPO:-$(cfg .image.repository)}"
+  IMAGE_FROM_TAG="${IMAGE_FROM_TAG:-$(cfg .image.from_tag)}"
+  IMAGE_TO_TAG="${IMAGE_TO_TAG:-$(cfg .image.to_tag)}"
+  IMAGE_FROM_REF="${IMAGE_REPO}:${IMAGE_FROM_TAG}"
+  IMAGE_TO_REF="${IMAGE_REPO}:${IMAGE_TO_TAG}"
+  ESCROW_PROTOCOL_VERSION="${ESCROW_PROTOCOL_VERSION:-$(cfg .escrow.protocol_version)}"
+  ESCROW_PRIVATE_KEY_ENV="${ESCROW_PRIVATE_KEY_ENV:-$(cfg .escrow.private_key_env)}"
+  MAIN_ADMIN_URL="${MAIN_ADMIN_URL:-$(cfg .main.admin_url)}"
+  MAIN_CONTAINER="${MAIN_CONTAINER:-$(cfg .main.container)}"
+  MAIN_STORAGE_HOST_DIR="${MAIN_STORAGE_HOST_DIR:-$(cfg .main.storage_host_dir)}"
+  MAIN_ENV_FILE="${MAIN_ENV_FILE:-$(cfg .main.env_file)}"
+  TEMP_ADMIN_PORT="${TEMP_ADMIN_PORT:-$(cfgn .temp.admin_port)}"
+  TEMP_ADMIN_URL="${TEMP_ADMIN_URL:-http://127.0.0.1:${TEMP_ADMIN_PORT}}"
+  TEMP_UPSTREAM_ALIAS="${TEMP_UPSTREAM_ALIAS:-$(cfg .temp.upstream_alias)}"
+  TEMP_NETWORK="${TEMP_NETWORK:-$(cfg .temp.network)}"
+  NGINX_PROXY_CONTAINER="${NGINX_PROXY_CONTAINER:-$(cfg .nginx.proxy_container)}"
+  NGINX_CONFIG_PATH="${NGINX_CONFIG_PATH:-$(cfg .nginx.config_path)}"
+  NGINX_OLD_UPSTREAM="${NGINX_OLD_UPSTREAM:-$(cfg .nginx.old_upstream)}"
+  NGINX_NEW_UPSTREAM="${NGINX_NEW_UPSTREAM:-$(cfg .nginx.new_upstream)}"
+  [[ -n "${NGINX_NEW_UPSTREAM}" ]] || NGINX_NEW_UPSTREAM="${TEMP_UPSTREAM_ALIAS}"
+  NGINX_UPSTREAM_PORT="${NGINX_UPSTREAM_PORT:-$(cfgn .nginx.upstream_port)}"
+  NGINX_PUBLIC_BASE_URL="${NGINX_PUBLIC_BASE_URL:-$(cfg .nginx.public_base_url)}"
+  NGINX_PUBLIC_PREFIX="${NGINX_PUBLIC_PREFIX:-$(cfg .nginx.public_prefix)}"
+  COMPOSE_FILE="${COMPOSE_FILE:-$(cfg .compose.file)}"
+  COMPOSE_SERVICE="${COMPOSE_SERVICE:-$(cfg .compose.service)}"
+  READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-$(cfgn .timeouts.ready_timeout_seconds)}"
+  READY_POLL_SECONDS="${READY_POLL_SECONDS:-$(cfgn .timeouts.ready_poll_seconds)}"
+  DRAIN_TIMEOUT_SECONDS="${DRAIN_TIMEOUT_SECONDS:-$(cfgn .timeouts.drain_timeout_seconds)}"
+  DRAIN_POLL_SECONDS="${DRAIN_POLL_SECONDS:-$(cfgn .timeouts.drain_poll_seconds)}"
+  SMOKE_MODEL="${SMOKE_MODEL:-$(cfg .smoke_test.model)}"
+  [[ -n "${SMOKE_MODEL}" ]] || SMOKE_MODEL="$(jq -r '.models[0].model' <<<"${CONFIG_JSON}")"
+  ROTATION_RESTORE="${ROTATION_RESTORE:-$(jq -r '.rotation.restore_after_update // false' <<<"${CONFIG_JSON}")}"
+}
+
+load_config() {
+  local path="$1"
+  [[ -f "${path}" ]] || { echo "config file not found: ${path}" >&2; exit 2; }
+  CONFIG_PATH="${path}"
+  CONFIG_JSON="$(jq -c . "${path}" 2>&1)" || { echo "config is not valid JSON: ${path}"$'\n'"  ${CONFIG_JSON}" >&2; exit 2; }
+  config_validate || exit 2
+  resolve_config
+}
+
+models_tsv()    { jq -r '.models[] | [.model, (.escrow_count|tostring), (.escrow_amount|tostring)] | @tsv' <<<"${CONFIG_JSON}"; }
+covered_models() { jq -r '.models[].model, ((.allow_unavailable_models // [])[])' <<<"${CONFIG_JSON}"; }
+
+# --- helpers: admin API, command runner, gateway ops -------------------------
+
+need_key() { [[ -n "${DEVSHARD_ADMIN_API_KEY:-}" ]] || { echo "DEVSHARD_ADMIN_API_KEY is required" >&2; return 1; }; }
+
+admin_get()  { curl -fsS "$1$2" -H "Authorization: Bearer ${DEVSHARD_ADMIN_API_KEY}"; }
+admin_post() { curl -fsS -X POST "$1$2" -H "Authorization: Bearer ${DEVSHARD_ADMIN_API_KEY}" -H 'Content-Type: application/json' -d "$3"; }
+
+# Print a command, run it only in live mode.
+run()       { note "exec: $*"; [[ "${DRY_RUN}" == "1" ]] || "$@"; }
+run_shell() { note "exec: $(sed -E 's/Bearer [^ ]+/Bearer <redacted>/g' <<<"$1")"; [[ "${DRY_RUN}" == "1" ]] || bash -euo pipefail -c "$1"; }
+
+confirm() {
+  [[ "${DRY_RUN}" == "1" ]] && return 0
+  [[ "${ASSUME_YES}" == "1" ]] && { note "auto-confirm (--yes): $1"; return 0; }
+  [[ -t 0 ]] || { gate_fail "confirmation required but no TTY: $1 (rerun with --yes)"; return 1; }
+  local reply; printf '\n?? %s [y/N] ' "$1"; read -r reply
+  case "${reply}" in y|Y|yes|YES) return 0 ;; *) gate_fail "declined: $1"; return 1 ;; esac
+}
+
+wait_ready() {
+  local name="$1" url="$2" deadline=$(( SECONDS + READY_TIMEOUT_SECONDS ))
+  while :; do
+    admin_get "${url}" "/v1/status" >/dev/null 2>&1 && { gate_ok "${name} ready"; return 0; }
+    (( SECONDS >= deadline )) && { gate_fail "${name} not ready within ${READY_TIMEOUT_SECONDS}s"; return 1; }
+    sleep "${READY_POLL_SECONDS}"
+  done
+}
+
+# The drain gate: block until max active_requests == 0 or timeout.
+wait_drain() {
+  local name="$1" url="$2" deadline=$(( SECONDS + DRAIN_TIMEOUT_SECONDS )) active
+  while :; do
+    active="$(admin_get "${url}" "/v1/status" | jq '[.devshards[]?.active_requests // 0] | max // 0')"
+    note "${name} active_requests=${active}"
+    [[ "${active}" == "0" ]] && { gate_ok "${name} drained (active_requests=0)"; return 0; }
+    (( SECONDS >= deadline )) && { gate_fail "${name} did not drain within ${DRAIN_TIMEOUT_SECONDS}s (active_requests=${active})"; return 1; }
+    sleep "${DRAIN_POLL_SECONDS}"
+  done
+}
+
+smoke_chat() {
+  curl -fsS -X POST "$1/v1/chat/completions" -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg m "$2" '{model:$m, stream:false, max_tokens:1, messages:[{role:"user", content:"Reply with ok"}]}')" >/dev/null
+}
+
+settings_sync_to_temp() {
+  local settings
+  settings="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" | jq '.escrow_rotation.enabled=false | .escrow_rotation.models=[]')"
+  admin_post "${TEMP_ADMIN_URL}" "/v1/admin/settings" "${settings}" >/dev/null
+}
+
+assert_settings_aligned() {
+  local main_settings temp_settings
+  main_settings="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" | jq -S '.escrow_rotation.enabled=false | .escrow_rotation.models=[]')"
+  temp_settings="$(admin_get "${TEMP_ADMIN_URL}" "/v1/admin/settings" | jq -S '.escrow_rotation.enabled=false | .escrow_rotation.models=[]')"
+  [[ "${main_settings}" == "${temp_settings}" ]] || { gate_fail "temp settings do not match main"; return 1; }
+  gate_ok "temp settings match main (rotation disabled on temp)"
+}
+
+# Start the temp gateway on its OWN empty escrow set. Reuses MAIN's --env-file
+# so no secret material is written to a new path. --restart unless-stopped, so
+# it MUST later be stopped AND removed to avoid a two-writer resurrection.
+temp_start() {
+  run_shell "docker rm -f '${TEMP_CONTAINER}' >/dev/null 2>&1 || true"
+  local -a args=(docker run -d --name "${TEMP_CONTAINER}" --restart unless-stopped
+                 --network "${TEMP_NETWORK}" --network-alias "${TEMP_UPSTREAM_ALIAS}")
+  [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]] && args+=(--env-file "${MAIN_ENV_FILE_ABS}")
+  args+=(-e DEVSHARDS_JSON='[]' -e DEVSHARD_STORAGE_DIR="${TEMP_STORAGE_CONTAINER_DIR}" -e DEVSHARD_PORT=8080
+         -p "127.0.0.1:${TEMP_ADMIN_PORT}:8080" -v "${STORAGE_HOST_DIR_ABS}:/root/.devshardctl" "${IMAGE_TO_REF}")
+  run "${args[@]}"
+}
+
+# Rewrite the compose image tag from_ref -> to_ref. Portable (sed to a temp file
+# then mv; no GNU-only -i). Idempotent; backs up first; fails loudly if absent.
+compose_bump() {
+  local file="${COMPOSE_FILE}" from="${IMAGE_FROM_REF}" to="${IMAGE_TO_REF}"
+  [[ -f "${file}" ]] || { gate_fail "compose file not found: ${file}"; return 1; }
+  if grep -q "${to}" "${file}" && ! grep -q "${from}" "${file}"; then gate_ok "compose already pins ${to}"; return 0; fi
+  grep -q "${from}" "${file}" || { gate_fail "neither '${from}' nor '${to}' found in ${file}"; return 1; }
+  [[ "${DRY_RUN}" == "1" ]] && { note "would bump ${file}: ${from} -> ${to}"; return 0; }
+  cp "${file}" "${file}.blue-green-backup"
+  sed "s#${from}#${to}#g" "${file}" > "${file}.blue-green-tmp"
+  mv "${file}.blue-green-tmp" "${file}"
+  grep -q "${to}" "${file}" || { gate_fail "bump did not apply; restore ${file}.blue-green-backup"; return 1; }
+  gate_ok "compose image bumped ${from} -> ${to} (backup: ${file}.blue-green-backup)"
+}
+
+# Switch the nginx upstream host inside the proxy container, then validate and
+# gracefully reload (never restart). Handles both a direct proxy_pass
+# http://host:PORT and a named-upstream `server host:PORT;`. Portable sed;
+# backs up first; idempotent if already switched.
+nginx_switch() {
+  local from="$1" to="$2" port="${NGINX_UPSTREAM_PORT}"
+  local cfg_path="${NGINX_CONFIG_PATH}" backup="${NGINX_CONFIG_PATH}.blue-green-backup" tmp="${NGINX_CONFIG_PATH}.blue-green-tmp"
+  local old_pat="(http://${from}:${port}|server[[:space:]]+${from}:${port})"
+  local new_pat="(http://${to}:${port}|server[[:space:]]+${to}:${port})"
+  note "nginx upstream switch ${from} -> ${to} in ${cfg_path}"
+  if [[ "${DRY_RUN}" == "1" ]]; then note "would docker exec ${NGINX_PROXY_CONTAINER} sh -lc '<switch ${from}->${to} + nginx -t + reload>'"; return 0; fi
+  local inner
+  inner="$(cat <<INNER
+set -eu
+test -f '${cfg_path}'
+if ! grep -Eq '${old_pat}' '${cfg_path}'; then
+  if grep -Eq '${new_pat}' '${cfg_path}'; then echo 'nginx already on ${to}:${port}'; exit 0; fi
+  echo 'ERROR: upstream ${from}:${port} not found in ${cfg_path} (check nginx -T)' >&2; exit 3
+fi
+cp '${cfg_path}' '${backup}'
+sed -E 's#http://${from}:${port}#http://${to}:${port}#g; s#(server[[:space:]]+)${from}:${port}#\1${to}:${port}#g' '${cfg_path}' > '${tmp}'
+mv '${tmp}' '${cfg_path}'
+grep -Eq '${new_pat}' '${cfg_path}' || { echo 'ERROR: switch did not apply; restore ${backup}' >&2; exit 4; }
+nginx -t
+nginx -s reload
+echo 'nginx upstream switched ${from} -> ${to} and reloaded'
+INNER
+)"
+  if docker exec "${NGINX_PROXY_CONTAINER}" sh -lc "${inner}"; then gate_ok "nginx switched ${from} -> ${to} (graceful reload)"; return 0; fi
+  gate_fail "nginx switch ${from} -> ${to} failed"; return 1
+}
+
+# Fold one temp escrow into main: import inactive (carries its state.db), then
+# either activate (route it) or settle (drain-aware on-chain). Shared by the
+# activate-temp step and the recover command.
+import_escrow_into_main() {
+  local id="$1" model="$2" proto="$3"
+  local storage="${TEMP_STORAGE_CONTAINER_DIR}/escrow-${id}/state.db" perf="${TEMP_STORAGE_CONTAINER_DIR}/perf.db"
+  admin_post "${MAIN_ADMIN_URL}" "/v1/admin/devshards/import" \
+    "$(jq -nc --arg id "${id}" --arg m "${model}" --arg s "${storage}" --arg p "${proto}" \
+       --arg pk "${ESCROW_PRIVATE_KEY_ENV}" --arg perf "${perf}" \
+       '{id:$id, model:$m, storage_path:$s, protocol_version:$p, private_key_env:$pk, perf_path:$perf, active:false}')" >/dev/null
+}
+activate_escrow_on_main() {
+  local id="$1" model="$2" proto="$3"
+  local storage="${TEMP_STORAGE_CONTAINER_DIR}/escrow-${id}/state.db"
+  admin_post "${MAIN_ADMIN_URL}" "/v1/admin/devshards" \
+    "$(jq -nc --arg id "${id}" --arg m "${model}" --arg s "${storage}" --arg p "${proto}" \
+       --arg pk "${ESCROW_PRIVATE_KEY_ENV}" \
+       '{id:$id, model:$m, storage_path:$s, protocol_version:$p, private_key_env:$pk}')" >/dev/null
+}
+
+# --- run state (survives single-step / resume / recover invocations) ---------
+
+runstate_init() {
+  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+  TEMP_CONTAINER="${TEMP_UPSTREAM_ALIAS}-${RUN_ID}"
+  TEMP_STORAGE_HOST_DIR="${STORAGE_HOST_DIR_ABS}/temp-${RUN_ID}"
+  TEMP_STORAGE_CONTAINER_DIR="/root/.devshardctl/temp-${RUN_ID}"
+  TEMP_DEVSHARDS_FILE="${TEMP_STORAGE_HOST_DIR}/temp-devshards.json"
+}
+runstate_write() {
+  cat > "${RUN_STATE_FILE}" <<EOF
+RUN_ID='${RUN_ID}'
+TEMP_CONTAINER='${TEMP_CONTAINER}'
+TEMP_STORAGE_HOST_DIR='${TEMP_STORAGE_HOST_DIR}'
+TEMP_STORAGE_CONTAINER_DIR='${TEMP_STORAGE_CONTAINER_DIR}'
+TEMP_DEVSHARDS_FILE='${TEMP_DEVSHARDS_FILE}'
+EOF
+}
+
+# --- steps -------------------------------------------------------------------
+
+step_init() {
+  run mkdir -p "${STORAGE_HOST_DIR_ABS}"
+  runstate_init
+  if [[ "${DRY_RUN}" == "1" ]]; then note "would write run state (run id ${RUN_ID}) to ${RUN_STATE_FILE}"; return 0; fi
+  mkdir -p "${STORAGE_HOST_DIR_ABS}"; runstate_write
+  note "run id ${RUN_ID}; state ${RUN_STATE_FILE}"
+}
+
+step_preflight() {
+  need_key
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    admin_get "${MAIN_ADMIN_URL}" "/v1/status" >/dev/null 2>&1 || { gate_ok "dry-run: main not reachable now; coverage check runs live"; return 0; }
+  else
+    wait_ready "main gateway" "${MAIN_ADMIN_URL}"
+  fi
+  local uncovered="" served
+  while IFS= read -r served; do
+    [[ -z "${served}" ]] && continue
+    covered_models | grep -Fxq "${served}" || uncovered="${uncovered} ${served}"
+  done < <(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/devshards" | jq -r '[.devshards[]? | select(.active==true) | .model] | unique | .[]')
+  [[ -n "${uncovered}" ]] && { gate_fail "main serves uncovered models:${uncovered} (add to models[] or allow_unavailable_models)"; return 1; }
+  gate_ok "every model main serves is covered by temp escrows or allow-listed"
+}
+
+step_disable_main_rotation() {
+  need_key
+  [[ "${DRY_RUN}" == "1" ]] && { note "would disable escrow_rotation on MAIN so nothing settles on-chain mid-update"; return 0; }
+  local settings; settings="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" | jq '.escrow_rotation.enabled=false')"
+  admin_post "${MAIN_ADMIN_URL}" "/v1/admin/settings" "${settings}" >/dev/null
+  gate_ok "MAIN escrow_rotation disabled"
+}
+
+step_create_temp_gateway() {
+  need_key
+  run mkdir -p "${TEMP_STORAGE_HOST_DIR}"
+  run docker pull "${IMAGE_TO_REF}"
+  temp_start
+  [[ "${DRY_RUN}" == "1" ]] && { note "would wait for temp readiness and sync main settings (rotation off) to temp"; return 0; }
+  wait_ready "temp gateway" "${TEMP_ADMIN_URL}"
+  settings_sync_to_temp
+  gate_ok "temp gateway up on ${TEMP_ADMIN_URL}; settings synced (rotation off)"
+}
+
+step_create_temp_escrows() {
+  need_key
+  local model count amount i body
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    while IFS=$'\t' read -r model count amount; do note "would mint ${count} x ${model} @ ${amount}"; done < <(models_tsv)
+    return 0
+  fi
+  confirm "mint fresh temp escrows on-chain (spends real funds; irreversible)"
+  mkdir -p "${TEMP_STORAGE_HOST_DIR}"
+  ESCROWS_MINTED=1
+  while IFS=$'\t' read -r model count amount; do
+    for (( i=1; i<=count; i++ )); do
+      note "mint ${i}/${count} ${model} @ ${amount}"
+      body="$(jq -nc --argjson amount "${amount}" --arg model "${model}" --arg pk "${ESCROW_PRIVATE_KEY_ENV}" --arg pv "${ESCROW_PROTOCOL_VERSION}" \
+        '{amount:$amount, model_id:$model, private_key_env:$pk, protocol_version:$pv}')"
+      admin_post "${TEMP_ADMIN_URL}" "/v1/admin/escrows" "${body}" >/dev/null
+    done
+  done < <(models_tsv)
+  admin_get "${TEMP_ADMIN_URL}" "/v1/admin/devshards" > "${TEMP_DEVSHARDS_FILE}"
+  gate_ok "temp escrows minted; recorded to ${TEMP_DEVSHARDS_FILE}"
+}
+
+step_check_temp() {
+  need_key
+  [[ "${DRY_RUN}" == "1" ]] && { note "would verify temp readiness, settings alignment, per-model routable escrows, and a chat smoke test"; return 0; }
+  wait_ready "temp gateway" "${TEMP_ADMIN_URL}"
+  assert_settings_aligned
+  local model count amount active
+  while IFS=$'\t' read -r model count amount; do
+    active="$(admin_get "${TEMP_ADMIN_URL}" "/v1/admin/devshards" | jq --arg m "${model}" '[.devshards[]? | select(.model==$m and .active==true)] | length')"
+    (( active < count )) && { gate_fail "temp has ${active} active escrows for ${model}, need ${count} (model would be unavailable during update)"; return 1; }
+    gate_ok "temp: ${active}/${count} active escrows for ${model}"
+  done < <(models_tsv)
+  smoke_chat "${TEMP_ADMIN_URL}" "${SMOKE_MODEL}"
+  gate_ok "temp chat smoke test passed (${SMOKE_MODEL})"
+  admin_get "${TEMP_ADMIN_URL}" "/v1/admin/devshards" > "${TEMP_DEVSHARDS_FILE}"
+}
+
+step_switch_to_temp() { confirm "switch nginx upstream to TEMP (${NGINX_NEW_UPSTREAM})"; nginx_switch "${NGINX_OLD_UPSTREAM}" "${NGINX_NEW_UPSTREAM}"; }
+step_check_alias_temp() { check_alias temp; }
+
+step_drain_main() {
+  need_key
+  [[ "${DRY_RUN}" == "1" ]] && { note "would wait for main active_requests to reach 0 (the drain gate)"; return 0; }
+  wait_drain "main gateway" "${MAIN_ADMIN_URL}"
+}
+
+step_bump_main_image() { compose_bump; }
+
+step_update_main() {
+  confirm "recreate MAIN from ${COMPOSE_FILE} on the bumped image"
+  note "MAIN image comes from ${COMPOSE_FILE} (service ${COMPOSE_SERVICE}), not an env ref"
+  local src=""; [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]] && src="source '${MAIN_ENV_FILE_ABS}' && "
+  run_shell "cd '${DEPLOY_DIR}' && ${src}docker compose -f '${COMPOSE_FILE}' pull ${COMPOSE_SERVICE} && docker compose -f '${COMPOSE_FILE}' up -d --no-deps --force-recreate ${COMPOSE_SERVICE} && docker compose -f '${COMPOSE_FILE}' ps ${COMPOSE_SERVICE}"
+  gate_ok "MAIN recreated on new image"
+}
+
+step_check_main_direct() {
+  need_key
+  [[ "${DRY_RUN}" == "1" ]] && { note "would verify main readiness and a direct chat smoke test before switching back"; return 0; }
+  wait_ready "main gateway" "${MAIN_ADMIN_URL}"
+  smoke_chat "${MAIN_ADMIN_URL}" "${SMOKE_MODEL}"
+  gate_ok "main direct chat smoke test passed (${SMOKE_MODEL})"
+}
+
+step_switch_to_main() { confirm "switch nginx upstream back to MAIN (${NGINX_OLD_UPSTREAM})"; nginx_switch "${NGINX_NEW_UPSTREAM}" "${NGINX_OLD_UPSTREAM}"; }
+step_check_alias_main() { check_alias main; }
+
+step_drain_temp() {
+  need_key
+  [[ "${DRY_RUN}" == "1" ]] && { note "would wait for temp active_requests to reach 0 before removing it"; return 0; }
+  wait_drain "temp gateway" "${TEMP_ADMIN_URL}"
+}
+
+step_stop_temp() {
+  confirm "stop AND remove the temp container ${TEMP_CONTAINER}"
+  run docker stop "${TEMP_CONTAINER}"
+  run docker rm "${TEMP_CONTAINER}"
+  gate_ok "temp container stopped and removed"
+}
+
+step_import_temp() {
+  need_key
+  [[ "${DRY_RUN}" == "1" ]] && { note "would import temp escrows from ${TEMP_DEVSHARDS_FILE} into main (inactive)"; return 0; }
+  confirm "import temp escrows into MAIN (inactive)"
+  local row id model proto
+  while IFS= read -r row; do
+    id="$(jq -r '.id' <<<"${row}")"; model="$(jq -r '.model // ""' <<<"${row}")"; proto="$(jq -r '.protocol_version // ""' <<<"${row}")"
+    note "import ${id} (${model}) inactive"; import_escrow_into_main "${id}" "${model}" "${proto}"
+  done < <(jq -c '.devshards[]' "${TEMP_DEVSHARDS_FILE}")
+  gate_ok "temp escrows imported into main (inactive)"
+}
+
+step_activate_temp() {
+  need_key
+  [[ "${DRY_RUN}" == "1" ]] && { note "would activate imported temp escrows on main"; return 0; }
+  confirm "activate imported temp escrows on MAIN"
+  local row id model proto
+  while IFS= read -r row; do
+    id="$(jq -r '.id' <<<"${row}")"; model="$(jq -r '.model // ""' <<<"${row}")"; proto="$(jq -r '.protocol_version // ""' <<<"${row}")"
+    note "activate ${id} (${model})"; activate_escrow_on_main "${id}" "${model}" "${proto}"
+  done < <(jq -c '.devshards[]' "${TEMP_DEVSHARDS_FILE}")
+  ESCROWS_MINTED=0
+  gate_ok "temp escrows activated on main"
+}
+
+step_restore_main_rotation() {
+  need_key
+  [[ "${ROTATION_RESTORE}" != "true" ]] && { note "leaving MAIN escrow_rotation disabled (set rotation.restore_after_update=true to re-enable)"; return 0; }
+  [[ "${DRY_RUN}" == "1" ]] && { note "would re-enable escrow_rotation on MAIN"; return 0; }
+  local settings; settings="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" | jq '.escrow_rotation.enabled=true')"
+  admin_post "${MAIN_ADMIN_URL}" "/v1/admin/settings" "${settings}" >/dev/null
+  gate_ok "MAIN escrow_rotation re-enabled"
+}
+
+step_status() {
+  need_key
+  [[ "${DRY_RUN}" == "1" ]] && { note "would show main/temp status"; return 0; }
+  note "main status: $(admin_get "${MAIN_ADMIN_URL}" "/v1/status" | jq -c '{active:([.devshards[]?|select(.active==true)]|length), max_active_requests:([.devshards[]?.active_requests//0]|max//0)}')"
+  note "temp status: $(admin_get "${TEMP_ADMIN_URL}" "/v1/status" 2>/dev/null | jq -c '{active:([.devshards[]?|select(.active==true)]|length)}' 2>/dev/null || echo gone)"
+}
+
+# check-alias-temp / check-alias-main: verify the public route (skipped if unset).
+check_alias() {
+  local side="$1"; need_key
+  [[ -z "${NGINX_PUBLIC_BASE_URL}" ]] && { note "no nginx.public_base_url set; skipping public ${side} verification"; return 0; }
+  [[ "${DRY_RUN}" == "1" ]] && { note "would verify public ${side} route via ${NGINX_PUBLIC_BASE_URL}"; return 0; }
+  case "${NGINX_PUBLIC_BASE_URL}" in *127.0.0.1*|*localhost*) note "WARNING: public_base_url is loopback; can pass while the real route is broken" ;; esac
+  curl -fsS "${NGINX_PUBLIC_BASE_URL}${NGINX_PUBLIC_PREFIX}/v1/status" -H "Authorization: Bearer ${DEVSHARD_ADMIN_API_KEY}" >/dev/null
+  smoke_chat "${NGINX_PUBLIC_BASE_URL}${NGINX_PUBLIC_PREFIX}" "${SMOKE_MODEL}"
+  gate_ok "public ${side} route verified"
+}
+
+# --- recover: fold stranded temp escrows into main, or settle them -----------
+
+cmd_recover() {
+  need_key
+  [[ -f "${TEMP_DEVSHARDS_FILE:-}" ]] || { echo "recover: no temp-escrows state at ${TEMP_DEVSHARDS_FILE:-<none>} (run init/create-temp-escrows first, or set --deploy-dir)" >&2; exit 1; }
+  local mode; mode="$([[ "${RECOVER_SETTLE}" == "1" ]] && echo settle || echo activate)"
+  echo "==> recover from ${TEMP_DEVSHARDS_FILE} (mode: import+${mode}; dry-run=${DRY_RUN})"
+  [[ "${DRY_RUN}" == "1" ]] || confirm "recover temp escrows into MAIN (import+${mode})"
+  local row id model proto count=0
+  while IFS= read -r row; do
+    id="$(jq -r '.id' <<<"${row}")"; model="$(jq -r '.model // ""' <<<"${row}")"; proto="$(jq -r '.protocol_version // ""' <<<"${row}")"
+    count=$(( count + 1 ))
+    if [[ "${DRY_RUN}" == "1" ]]; then note "would import+${mode} ${id} (${model})"; continue; fi
+    import_escrow_into_main "${id}" "${model}" "${proto}"
+    if [[ "${RECOVER_SETTLE}" == "1" ]]; then
+      note "settle ${id} (${model})"; admin_post "${MAIN_ADMIN_URL}" "/v1/admin/devshards/${id}/settle" '{}' >/dev/null
+    else
+      note "activate ${id} (${model})"; activate_escrow_on_main "${id}" "${model}" "${proto}"
+    fi
+  done < <(jq -c '.devshards[]' "${TEMP_DEVSHARDS_FILE}")
+  ESCROWS_MINTED=0
+  gate_ok "recovered ${count} temp escrow(s) into main (import+${mode})"
+}
+
+# --- orchestration + error handling ------------------------------------------
+
+run_flow() {
+  local -a steps=("$@"); STEP_TOTAL="${#steps[@]}"; STEP_INDEX=0
+  local step
+  for step in "${steps[@]}"; do
+    step_begin "${step}"
+    "step_${step//-/_}"
+  done
+}
+
+print_plan() {
+  cat <<EOF
+Devshard gateway update (v2, single-file)
+Config: ${CONFIG_PATH}
+Mode:   $([[ "${DRY_RUN}" == "1" ]] && echo "dry-run (use --run to execute)" || echo LIVE)
+Image:  ${IMAGE_FROM_REF} -> ${IMAGE_TO_REF}
+Main:   ${MAIN_CONTAINER} @ ${MAIN_ADMIN_URL}
+Temp:   ${TEMP_UPSTREAM_ALIAS} @ ${TEMP_ADMIN_URL} (network ${TEMP_NETWORK})
+Nginx:  ${NGINX_PROXY_CONTAINER}:${NGINX_CONFIG_PATH}  ${NGINX_OLD_UPSTREAM} <-> ${NGINX_NEW_UPSTREAM}:${NGINX_UPSTREAM_PORT}
+Public: ${NGINX_PUBLIC_BASE_URL:-<unset; public checks skipped>}
+Smoke:  ${SMOKE_MODEL}
+Models (fresh temp escrows minted per model):
+$(models_tsv | while IFS=$'\t' read -r m c a; do printf '  %s x %s @ %s\n' "${c}" "${m}" "${a}"; done)
+Steps:
+$(printf '  %s\n' "${ORDERED_STEPS[@]}")
+EOF
+}
+
+ESCROWS_MINTED=0; ON_ERR=0
+on_error() {
+  local code=$?
+  [[ "${ON_ERR}" == "1" ]] && return; ON_ERR=1
+  {
+    echo ""
+    echo "FAILED at step: ${CURRENT_STEP:-setup} (exit ${code})"
+    echo "Inspect: ${0##*/} --config '${CONFIG_ARG}' status --run ; restore nginx backup (${NGINX_CONFIG_PATH:-<config>}.blue-green-backup) to revert routing."
+    if [[ "${ESCROWS_MINTED}" == "1" ]]; then
+      echo ""
+      echo "WARNING: temp escrows were minted on-chain but not yet folded into main."
+      echo "  Recorded at: ${TEMP_DEVSHARDS_FILE:-<run state>}"
+      echo "  Recover: ${0##*/} --config '${CONFIG_ARG}' --deploy-dir '${DEPLOY_DIR}' recover --run   (add --settle to settle instead of activate)"
+    fi
+  } >&2
+}
+trap on_error ERR
+
+# --- entrypoint --------------------------------------------------------------
+
+abspath() { case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s/%s\n' "$(pwd)" "$1" ;; esac; }
+
+main() {
+  DEPLOY_DIR="$(abspath "${DEPLOY_DIR}")"
+  local config_abs; config_abs="$(abspath "${CONFIG_ARG}")"
+  cd "${DEPLOY_DIR}"
+  load_config "${config_abs}"
+
+  STORAGE_HOST_DIR_ABS="$(abspath "${MAIN_STORAGE_HOST_DIR}")"
+  MAIN_ENV_FILE_ABS=""; [[ -n "${MAIN_ENV_FILE}" ]] && MAIN_ENV_FILE_ABS="$(abspath "${MAIN_ENV_FILE}")"
+  RUN_STATE_FILE="${STORAGE_HOST_DIR_ABS}/blue-green-run-state.env"
+  # shellcheck disable=SC1090
+  [[ -f "${RUN_STATE_FILE}" ]] && source "${RUN_STATE_FILE}"
+
+  case "${ACTION}" in
+    validate)   echo "config OK: ${CONFIG_PATH}" ;;
+    list-steps) printf '%s\n' "${ORDERED_STEPS[@]}" ;;
+    plan)       print_plan ;;
+    recover)    cmd_recover ;;
+    run)
+      local -a steps=("${ORDERED_STEPS[@]}")
+      if [[ -n "${FROM_STEP}" ]]; then
+        steps=(); local seen=0 s
+        for s in "${ORDERED_STEPS[@]}"; do [[ "${s}" == "${FROM_STEP}" ]] && seen=1; [[ "${seen}" == "1" ]] && steps+=("${s}"); done
+        [[ "${#steps[@]}" -gt 0 ]] || { echo "unknown --from-step: ${FROM_STEP}" >&2; exit 2; }
+      fi
+      run_flow "${steps[@]}"
+      echo "update complete: ${IMAGE_FROM_TAG} -> ${IMAGE_TO_TAG}"
+      ;;
+    *)
+      local ok=0 s
+      for s in "${ORDERED_STEPS[@]}"; do [[ "${s}" == "${ACTION}" ]] && ok=1; done
+      (( ok )) || { echo "unknown action/step: ${ACTION}" >&2; usage >&2; exit 2; }
+      run_flow "${ACTION}"
+      ;;
+  esac
+}
+
+main

--- a/devshard/docs/devshard-update/scripts/update.sh
+++ b/devshard/docs/devshard-update/scripts/update.sh
@@ -287,7 +287,14 @@ if ! grep -Eq '${old_pat}' '${cfg_path}'; then
 fi
 cp '${cfg_path}' '${backup}'
 sed -E 's#http://${from}:${port}#http://${to}:${port}#g; s#(server[[:space:]]+)${from}:${port}#\1${to}:${port}#g' '${cfg_path}' > '${tmp}'
-mv '${tmp}' '${cfg_path}'
+# Prefer mv (atomic replace). Bind-mounted nginx.conf rejects inode replacement
+# ("Resource busy" / "File exists") — fall back to in-place content overwrite.
+if mv '${tmp}' '${cfg_path}' 2>/dev/null; then
+  :
+else
+  cat '${tmp}' > '${cfg_path}'
+  rm -f '${tmp}'
+fi
 grep -Eq '${new_pat}' '${cfg_path}' || { echo 'ERROR: switch did not apply; restore ${backup}' >&2; exit 4; }
 nginx -t
 nginx -s reload

--- a/devshard/docs/devshard-update/scripts/update.sh
+++ b/devshard/docs/devshard-update/scripts/update.sh
@@ -91,7 +91,11 @@ config_validate() {
   errors="$(jq -r '
     def req(v; name): if (v == null or v == "") then "missing/empty: \(name)" else empty end;
     def num(v; name): if (v|type) != "number" then "not a number: \(name)" else empty end;
-    [ req(.image.repository; "image.repository"),
+    [ # from_tag/to_tag may be full image refs (contain '/'), e.g. repo:tag across registries.
+      # Otherwise repository is required and joined as repository:tag.
+      (if ((.image.from_tag|tostring|contains("/")) and (.image.to_tag|tostring|contains("/")))
+       then empty
+       else req(.image.repository; "image.repository") end),
       req(.image.from_tag; "image.from_tag"),
       req(.image.to_tag; "image.to_tag"),
       (if ((.models // []) | length) < 1 then "models must be a non-empty array of {model, escrow_count, escrow_amount}" else empty end),
@@ -132,16 +136,33 @@ config_validate() {
   fi
 }
 
+# Compose stores a full image ref. from_tag/to_tag may be that full ref (contain '/'),
+# or a bare tag joined with image.repository (same-repo bumps).
+image_ref() {
+  local repo="$1" tag_or_ref="$2"
+  if [[ "${tag_or_ref}" == */* ]]; then
+    printf '%s\n' "${tag_or_ref}"
+  else
+    printf '%s:%s\n' "${repo}" "${tag_or_ref}"
+  fi
+}
+
 resolve_config() {
   IMAGE_REPO="${IMAGE_REPO:-$(cfg .image.repository)}"
   IMAGE_FROM_TAG="${IMAGE_FROM_TAG:-$(cfg .image.from_tag)}"
   IMAGE_TO_TAG="${IMAGE_TO_TAG:-$(cfg .image.to_tag)}"
-  IMAGE_FROM_REF="${IMAGE_REPO}:${IMAGE_FROM_TAG}"
-  IMAGE_TO_REF="${IMAGE_REPO}:${IMAGE_TO_TAG}"
+  IMAGE_FROM_REF="${IMAGE_FROM_REF:-$(image_ref "${IMAGE_REPO}" "${IMAGE_FROM_TAG}")}"
+  IMAGE_TO_REF="${IMAGE_TO_REF:-$(image_ref "${IMAGE_REPO}" "${IMAGE_TO_TAG}")}"
   IMAGE_SKIP_PULL="${IMAGE_SKIP_PULL:-$(jq -r '.image.skip_pull // false' <<<"${CONFIG_JSON}")}"
   ESCROW_PROTOCOL_VERSION="${ESCROW_PROTOCOL_VERSION:-$(cfg .escrow.protocol_version)}"
   SOURCE_PROTOCOL_VERSION="${SOURCE_PROTOCOL_VERSION:-$(jq -r '.escrow.source_protocol_version // .escrow.protocol_version' <<<"${CONFIG_JSON}")}"
   ESCROW_PRIVATE_KEY_ENV="${ESCROW_PRIVATE_KEY_ENV:-$(cfg .escrow.private_key_env)}"
+  # Target HTTP route for temp + recreated MAIN. Defaults to /devshard/v<protocol>
+  # on a protocol change; empty for same-protocol image bumps (env file untouched).
+  TARGET_ROUTE_PREFIX="${TARGET_ROUTE_PREFIX:-$(cfg .escrow.route_prefix)}"
+  if [[ -z "${TARGET_ROUTE_PREFIX}" && "${SOURCE_PROTOCOL_VERSION#v}" != "${ESCROW_PROTOCOL_VERSION#v}" ]]; then
+    TARGET_ROUTE_PREFIX="/devshard/v${ESCROW_PROTOCOL_VERSION#v}"
+  fi
   MAIN_ADMIN_URL="${MAIN_ADMIN_URL:-$(cfg .main.admin_url)}"
   MAIN_CONTAINER="${MAIN_CONTAINER:-$(cfg .main.container)}"
   MAIN_STORAGE_HOST_DIR="${MAIN_STORAGE_HOST_DIR:-$(cfg .main.storage_host_dir)}"
@@ -247,21 +268,43 @@ assert_settings_aligned() {
   gate_ok "temp settings match main (rotation disabled on temp)"
 }
 
-# Start the temp gateway on its OWN empty escrow set. Reuses MAIN's --env-file
-# so no secret material is written to a new path. --restart unless-stopped, so
-# it MUST later be stopped AND removed to avoid a two-writer resurrection.
+# Docker --env-file rejects shell-style "export KEY=value" lines (common in
+# config.devshard.env). Build a sanitized sibling for docker run only.
+docker_env_file_from() {
+  local src="$1" dst="$2"
+  # Keep KEY=VALUE; strip leading export; drop blank/comment lines docker ignores anyway.
+  sed -E \
+    -e '/^[[:space:]]*#/d' \
+    -e '/^[[:space:]]*$/d' \
+    -e 's/^[[:space:]]*export[[:space:]]+//' \
+    "${src}" > "${dst}"
+}
+
+# Start the temp gateway on its OWN empty escrow set. Reuses MAIN's env file
+# (sanitized for docker). --restart unless-stopped, so it MUST later be stopped
+# AND removed to avoid a two-writer resurrection.
 temp_start() {
   run_shell "docker rm -f '${TEMP_CONTAINER}' >/dev/null 2>&1 || true"
   local -a args=(docker run -d --name "${TEMP_CONTAINER}" --restart unless-stopped
                  --network "${TEMP_NETWORK}" --network-alias "${TEMP_UPSTREAM_ALIAS}")
-  [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]] && args+=(--env-file "${MAIN_ENV_FILE_ABS}")
+  local docker_env=""
+  if [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]]; then
+    docker_env="${MAIN_ENV_FILE_ABS}.docker"
+    if [[ "${DRY_RUN}" == "1" ]]; then
+      note "would sanitize ${MAIN_ENV_FILE_ABS} -> ${docker_env} for docker --env-file"
+    else
+      docker_env_file_from "${MAIN_ENV_FILE_ABS}" "${docker_env}"
+    fi
+    args+=(--env-file "${docker_env}")
+  fi
   args+=(-e DEVSHARDS_JSON='[]' -e DEVSHARD_STORAGE_DIR="${TEMP_STORAGE_CONTAINER_DIR}" -e DEVSHARD_PORT=8080
          -p "127.0.0.1:${TEMP_ADMIN_PORT}:8080" -v "${STORAGE_HOST_DIR_ABS}:/root/.devshardctl" "${IMAGE_TO_REF}")
   run "${args[@]}"
 }
 
-# Rewrite the compose image tag from_ref -> to_ref. Portable (sed to a temp file
-# then mv; no GNU-only -i). Idempotent; backs up first; fails loudly if absent.
+# Rewrite the compose image ref from_ref -> to_ref (full repo:tag strings).
+# Portable (sed to a temp file then mv; no GNU-only -i). Idempotent; backs up
+# first; fails loudly if absent. Supports cross-repository upgrades.
 compose_bump() {
   local file="${COMPOSE_FILE}" from="${IMAGE_FROM_REF}" to="${IMAGE_TO_REF}"
   [[ -f "${file}" ]] || { gate_fail "compose file not found: ${file}"; return 1; }
@@ -352,13 +395,37 @@ TEMP_STORAGE_CONTAINER_DIR='${TEMP_STORAGE_CONTAINER_DIR}'
 TEMP_DEVSHARDS_FILE='${TEMP_DEVSHARDS_FILE}'
 EOF
 }
+# Canary/single-step invokes update.sh per step (new process). Load prior init
+# state, or create it if missing (e.g. dry-run prepare after init skipped write).
+ensure_runstate() {
+  if [[ -n "${TEMP_STORAGE_HOST_DIR:-}" && -n "${TEMP_CONTAINER:-}" ]]; then
+    return 0
+  fi
+  if [[ -f "${RUN_STATE_FILE}" ]]; then
+    # shellcheck disable=SC1090
+    source "${RUN_STATE_FILE}"
+  fi
+  if [[ -z "${TEMP_STORAGE_HOST_DIR:-}" || -z "${TEMP_CONTAINER:-}" ]]; then
+    runstate_init
+    mkdir -p "${STORAGE_HOST_DIR_ABS}"
+    runstate_write
+    note "run state initialized (${RUN_ID}) at ${RUN_STATE_FILE}"
+  fi
+}
 
 # --- steps -------------------------------------------------------------------
 
 step_init() {
   run mkdir -p "${STORAGE_HOST_DIR_ABS}"
   runstate_init
-  if [[ "${DRY_RUN}" == "1" ]]; then note "would write run state (run id ${RUN_ID}) to ${RUN_STATE_FILE}"; return 0; fi
+  # Always persist so later single-step / canary invocations can source it
+  # (including dry-run prepare, which runs each step in a new process).
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    mkdir -p "${STORAGE_HOST_DIR_ABS}"
+    runstate_write
+    note "would continue with run id ${RUN_ID}; wrote dry-run state ${RUN_STATE_FILE}"
+    return 0
+  fi
   mkdir -p "${STORAGE_HOST_DIR_ABS}"; runstate_write
   note "run id ${RUN_ID}; state ${RUN_STATE_FILE}"
 }
@@ -393,7 +460,58 @@ step_disable_main_rotation() {
   gate_ok "MAIN escrow_rotation disabled"
 }
 
+# On a protocol change, stage DEVSHARD_ROUTE_PREFIX in MAIN's env file so temp
+# (and later recreated MAIN) read the target route. Running MAIN keeps its old
+# env until recreate — Docker only applies --env-file at container create.
+stage_target_route_prefix() {
+  if [[ "${SOURCE_PROTOCOL_VERSION#v}" == "${ESCROW_PROTOCOL_VERSION#v}" ]]; then
+    note "same protocol; leaving DEVSHARD_ROUTE_PREFIX in env file unchanged"
+    return 0
+  fi
+  [[ -n "${TARGET_ROUTE_PREFIX}" ]] ||
+    { gate_fail "protocol change needs escrow.route_prefix or derivable /devshard/v<protocol>"; return 1; }
+  [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]] ||
+    { gate_fail "main.env_file missing; cannot stage DEVSHARD_ROUTE_PREFIX=${TARGET_ROUTE_PREFIX}"; return 1; }
+
+  note "stage DEVSHARD_ROUTE_PREFIX=${TARGET_ROUTE_PREFIX} in ${MAIN_ENV_FILE_ABS}"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    note "would backup env file and set DEVSHARD_ROUTE_PREFIX=${TARGET_ROUTE_PREFIX}"
+    return 0
+  fi
+
+  local backup="${MAIN_ENV_FILE_ABS}.bak-route-$(date -u +%Y%m%dT%H%M%SZ)"
+  cp "${MAIN_ENV_FILE_ABS}" "${backup}"
+  note "env backup: ${backup}"
+
+  if grep -qE '^(export[[:space:]]+)?DEVSHARD_ROUTE_PREFIX=' "${MAIN_ENV_FILE_ABS}"; then
+    # Portable in-place replace (no GNU sed -i).
+    local tmp="${MAIN_ENV_FILE_ABS}.route-tmp"
+    sed -E "s|^(export[[:space:]]+)?DEVSHARD_ROUTE_PREFIX=.*|\\1DEVSHARD_ROUTE_PREFIX=${TARGET_ROUTE_PREFIX}|" \
+      "${MAIN_ENV_FILE_ABS}" > "${tmp}"
+    mv "${tmp}" "${MAIN_ENV_FILE_ABS}"
+  else
+    printf '\n# staged by update.sh for protocol %s -> %s\nDEVSHARD_ROUTE_PREFIX=%s\n' \
+      "${SOURCE_PROTOCOL_VERSION}" "${ESCROW_PROTOCOL_VERSION}" "${TARGET_ROUTE_PREFIX}" \
+      >> "${MAIN_ENV_FILE_ABS}"
+  fi
+
+  grep -qE "^(export[[:space:]]+)?DEVSHARD_ROUTE_PREFIX=${TARGET_ROUTE_PREFIX}$" "${MAIN_ENV_FILE_ABS}" ||
+    { gate_fail "failed to stage DEVSHARD_ROUTE_PREFIX=${TARGET_ROUTE_PREFIX}"; return 1; }
+
+  # Running MAIN must still be on the old env (not recreated yet).
+  local live
+  live="$(docker exec "${MAIN_CONTAINER}" printenv DEVSHARD_ROUTE_PREFIX 2>/dev/null || true)"
+  if [[ "${live}" == "${TARGET_ROUTE_PREFIX}" ]]; then
+    gate_fail "running ${MAIN_CONTAINER} already has DEVSHARD_ROUTE_PREFIX=${live}; expected it to still be on the source route until recreate"
+    return 1
+  fi
+  note "running MAIN DEVSHARD_ROUTE_PREFIX='${live:-<unset>}' (unchanged until recreate); file staged for temp/new MAIN"
+  gate_ok "staged DEVSHARD_ROUTE_PREFIX=${TARGET_ROUTE_PREFIX} in env file"
+}
+
 step_create_temp_gateway() {
+  stage_target_route_prefix
+  ensure_runstate
   need_key
   run mkdir -p "${TEMP_STORAGE_HOST_DIR}"
   if [[ "${IMAGE_SKIP_PULL}" == "true" ]]; then
@@ -409,6 +527,7 @@ step_create_temp_gateway() {
 }
 
 step_create_temp_escrows() {
+  ensure_runstate
   need_key
   local model count amount i body
   if [[ "${DRY_RUN}" == "1" ]]; then
@@ -431,6 +550,7 @@ step_create_temp_escrows() {
 }
 
 step_check_temp() {
+  ensure_runstate
   need_key
   [[ "${DRY_RUN}" == "1" ]] && { note "would verify temp readiness, settings alignment, per-model routable escrows, and a chat smoke test"; return 0; }
   wait_ready "temp gateway" "${TEMP_ADMIN_URL}"
@@ -455,6 +575,21 @@ step_drain_main() {
   wait_drain "main gateway" "${MAIN_ADMIN_URL}"
 }
 
+# Active MAIN escrows whose protocol_version matches $1 (strip leading v), or
+# is missing/null/empty. Older gateways omit the field; treat that as source
+# during a protocol change so deactivate cannot no-op while traffic still has
+# active pre-protocol escrows.
+jq_active_source_escrows() {
+  local source="$1"
+  jq -r --arg p "${source}" '
+    def proto:
+      if (.protocol_version == null) then ""
+      else (.protocol_version | tostring | sub("^v"; ""))
+      end;
+    [.devshards[]? | select(.active == true and (proto == $p or proto == ""))]
+  '
+}
+
 step_deactivate_main_source() {
   need_key
   if [[ "${SOURCE_PROTOCOL_VERSION#v}" == "${ESCROW_PROTOCOL_VERSION#v}" ]]; then
@@ -462,7 +597,7 @@ step_deactivate_main_source() {
     return 0
   fi
   [[ "${DRY_RUN}" == "1" ]] && {
-    note "would deactivate active protocol-${SOURCE_PROTOCOL_VERSION#v} escrows on drained MAIN (no settlement)"
+    note "would deactivate active protocol-${SOURCE_PROTOCOL_VERSION#v} (or missing protocol_version) escrows on drained MAIN (no settlement)"
     return 0
   }
   confirm "deactivate source-protocol escrows on drained MAIN (local only; no settlement)"
@@ -473,10 +608,10 @@ step_deactivate_main_source() {
     admin_post "${MAIN_ADMIN_URL}" "/v1/admin/devshards/${id}/deactivate" '{}' >/dev/null
     count=$(( count + 1 ))
   done < <(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/devshards" |
-    jq -r --arg p "${source}" '.devshards[]? | select(.active==true and (.protocol_version|tostring)==$p) | .id')
+    jq_active_source_escrows "${source}" | jq -r '.[].id')
   local remaining
   remaining="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/devshards" |
-    jq --arg p "${source}" '[.devshards[]? | select(.active==true and (.protocol_version|tostring)==$p)] | length')"
+    jq_active_source_escrows "${source}" | jq 'length')"
   (( remaining == 0 )) ||
     { gate_fail "${remaining} source-protocol escrow(s) remain active on main"; return 1; }
   gate_ok "deactivated ${count} source-protocol escrow(s) on main without settlement"
@@ -690,7 +825,8 @@ main() {
 
   STORAGE_HOST_DIR_ABS="$(abspath "${MAIN_STORAGE_HOST_DIR}")"
   MAIN_ENV_FILE_ABS=""; [[ -n "${MAIN_ENV_FILE}" ]] && MAIN_ENV_FILE_ABS="$(abspath "${MAIN_ENV_FILE}")"
-  RUN_STATE_FILE="${STORAGE_HOST_DIR_ABS}/blue-green-run-state.env"
+  # Keep operator-writable next to the deploy dir (.devshardctl is often root-owned).
+  RUN_STATE_FILE="${DEPLOY_DIR}/blue-green-run-state.env"
   # shellcheck disable=SC1090
   [[ -f "${RUN_STATE_FILE}" ]] && source "${RUN_STATE_FILE}"
 
@@ -707,7 +843,7 @@ main() {
         [[ "${#steps[@]}" -gt 0 ]] || { echo "unknown --from-step: ${FROM_STEP}" >&2; exit 2; }
       fi
       run_flow "${steps[@]}"
-      echo "update complete: ${IMAGE_FROM_TAG} -> ${IMAGE_TO_TAG}"
+      echo "update complete: ${IMAGE_FROM_REF} -> ${IMAGE_TO_REF}"
       ;;
     *)
       local ok=0 s

--- a/devshard/docs/devshard-update/scripts/update.sh
+++ b/devshard/docs/devshard-update/scripts/update.sh
@@ -213,7 +213,14 @@ wait_drain() {
 }
 
 smoke_chat() {
-  curl -fsS -X POST "$1/v1/chat/completions" -H 'Content-Type: application/json' \
+  # Prefer admin key when models are admin-only; fall back to first API key; else unauthenticated.
+  local auth_hdr=()
+  if [[ -n "${DEVSHARD_ADMIN_API_KEY:-}" ]]; then
+    auth_hdr=(-H "Authorization: Bearer ${DEVSHARD_ADMIN_API_KEY}")
+  elif [[ -n "${DEVSHARD_API_KEYS:-}" ]]; then
+    auth_hdr=(-H "Authorization: Bearer ${DEVSHARD_API_KEYS%%,*}")
+  fi
+  curl -fsS -X POST "$1/v1/chat/completions" "${auth_hdr[@]}" -H 'Content-Type: application/json' \
     -d "$(jq -nc --arg m "$2" '{model:$m, stream:false, max_tokens:1, messages:[{role:"user", content:"Reply with ok"}]}')" >/dev/null
 }
 

--- a/devshard/docs/devshard-update/scripts/update.sh
+++ b/devshard/docs/devshard-update/scripts/update.sh
@@ -23,8 +23,9 @@ set -Eeuo pipefail
 
 ORDERED_STEPS=(
   init preflight disable-main-rotation create-temp-gateway create-temp-escrows
-  check-temp switch-to-temp check-alias-temp drain-main bump-main-image
-  update-main check-main-direct switch-to-main check-alias-main drain-temp
+  check-temp switch-to-temp check-alias-temp drain-main deactivate-main-source
+  bump-main-image update-main create-main-seed-escrows check-main-direct
+  switch-to-main check-alias-main drain-temp
   stop-temp import-temp activate-temp restore-main-rotation status
 )
 
@@ -97,9 +98,15 @@ config_validate() {
       (.models // [] | to_entries[] |
         ( req(.value.model; "models[\(.key)].model"),
           num(.value.escrow_count; "models[\(.key)].escrow_count"),
+          num((.value.main_seed_count // 0); "models[\(.key)].main_seed_count"),
           num(.value.escrow_amount; "models[\(.key)].escrow_amount") )),
       req(.escrow.protocol_version; "escrow.protocol_version"),
       req(.escrow.private_key_env; "escrow.private_key_env"),
+      (if (((.escrow.source_protocol_version // .escrow.protocol_version) | tostring | sub("^v"; "")) !=
+           ((.escrow.protocol_version | tostring | sub("^v"; ""))) and
+           any(.models[]; (.main_seed_count // 0) < 1))
+       then "protocol change requires models[].main_seed_count >= 1 for every model"
+       else empty end),
       req(.main.admin_url; "main.admin_url"),
       req(.main.container; "main.container"),
       req(.main.storage_host_dir; "main.storage_host_dir"),
@@ -131,7 +138,9 @@ resolve_config() {
   IMAGE_TO_TAG="${IMAGE_TO_TAG:-$(cfg .image.to_tag)}"
   IMAGE_FROM_REF="${IMAGE_REPO}:${IMAGE_FROM_TAG}"
   IMAGE_TO_REF="${IMAGE_REPO}:${IMAGE_TO_TAG}"
+  IMAGE_SKIP_PULL="${IMAGE_SKIP_PULL:-$(jq -r '.image.skip_pull // false' <<<"${CONFIG_JSON}")}"
   ESCROW_PROTOCOL_VERSION="${ESCROW_PROTOCOL_VERSION:-$(cfg .escrow.protocol_version)}"
+  SOURCE_PROTOCOL_VERSION="${SOURCE_PROTOCOL_VERSION:-$(jq -r '.escrow.source_protocol_version // .escrow.protocol_version' <<<"${CONFIG_JSON}")}"
   ESCROW_PRIVATE_KEY_ENV="${ESCROW_PRIVATE_KEY_ENV:-$(cfg .escrow.private_key_env)}"
   MAIN_ADMIN_URL="${MAIN_ADMIN_URL:-$(cfg .main.admin_url)}"
   MAIN_CONTAINER="${MAIN_CONTAINER:-$(cfg .main.container)}"
@@ -169,7 +178,7 @@ load_config() {
   resolve_config
 }
 
-models_tsv()    { jq -r '.models[] | [.model, (.escrow_count|tostring), (.escrow_amount|tostring)] | @tsv' <<<"${CONFIG_JSON}"; }
+models_tsv()    { jq -r '.models[] | [.model, (.escrow_count|tostring), (.escrow_amount|tostring), ((.main_seed_count // 0)|tostring)] | @tsv' <<<"${CONFIG_JSON}"; }
 covered_models() { jq -r '.models[].model, ((.allow_unavailable_models // [])[])' <<<"${CONFIG_JSON}"; }
 
 # --- helpers: admin API, command runner, gateway ops -------------------------
@@ -367,6 +376,12 @@ step_preflight() {
     covered_models | grep -Fxq "${served}" || uncovered="${uncovered} ${served}"
   done < <(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/devshards" | jq -r '[.devshards[]? | select(.active==true) | .model] | unique | .[]')
   [[ -n "${uncovered}" ]] && { gate_fail "main serves uncovered models:${uncovered} (add to models[] or allow_unavailable_models)"; return 1; }
+  if [[ "${SOURCE_PROTOCOL_VERSION#v}" != "${ESCROW_PROTOCOL_VERSION#v}" ]]; then
+    local missing_seeds
+    missing_seeds="$(jq -r '[.models[] | select((.main_seed_count // 0) < 1) | .model] | join(" ")' <<<"${CONFIG_JSON}")"
+    [[ -z "${missing_seeds}" ]] ||
+      { gate_fail "protocol change requires models[].main_seed_count >= 1 for:${missing_seeds}"; return 1; }
+  fi
   gate_ok "every model main serves is covered by temp escrows or allow-listed"
 }
 
@@ -381,7 +396,11 @@ step_disable_main_rotation() {
 step_create_temp_gateway() {
   need_key
   run mkdir -p "${TEMP_STORAGE_HOST_DIR}"
-  run docker pull "${IMAGE_TO_REF}"
+  if [[ "${IMAGE_SKIP_PULL}" == "true" ]]; then
+    run docker image inspect "${IMAGE_TO_REF}"
+  else
+    run docker pull "${IMAGE_TO_REF}"
+  fi
   temp_start
   [[ "${DRY_RUN}" == "1" ]] && { note "would wait for temp readiness and sync main settings (rotation off) to temp"; return 0; }
   wait_ready "temp gateway" "${TEMP_ADMIN_URL}"
@@ -393,13 +412,13 @@ step_create_temp_escrows() {
   need_key
   local model count amount i body
   if [[ "${DRY_RUN}" == "1" ]]; then
-    while IFS=$'\t' read -r model count amount; do note "would mint ${count} x ${model} @ ${amount}"; done < <(models_tsv)
+    while IFS=$'\t' read -r model count amount seed_count; do note "would mint ${count} x ${model} @ ${amount}"; done < <(models_tsv)
     return 0
   fi
   confirm "mint fresh temp escrows on-chain (spends real funds; irreversible)"
   mkdir -p "${TEMP_STORAGE_HOST_DIR}"
   ESCROWS_MINTED=1
-  while IFS=$'\t' read -r model count amount; do
+  while IFS=$'\t' read -r model count amount seed_count; do
     for (( i=1; i<=count; i++ )); do
       note "mint ${i}/${count} ${model} @ ${amount}"
       body="$(jq -nc --argjson amount "${amount}" --arg model "${model}" --arg pk "${ESCROW_PRIVATE_KEY_ENV}" --arg pv "${ESCROW_PROTOCOL_VERSION}" \
@@ -417,7 +436,7 @@ step_check_temp() {
   wait_ready "temp gateway" "${TEMP_ADMIN_URL}"
   assert_settings_aligned
   local model count amount active
-  while IFS=$'\t' read -r model count amount; do
+  while IFS=$'\t' read -r model count amount seed_count; do
     active="$(admin_get "${TEMP_ADMIN_URL}" "/v1/admin/devshards" | jq --arg m "${model}" '[.devshards[]? | select(.model==$m and .active==true)] | length')"
     (( active < count )) && { gate_fail "temp has ${active} active escrows for ${model}, need ${count} (model would be unavailable during update)"; return 1; }
     gate_ok "temp: ${active}/${count} active escrows for ${model}"
@@ -436,20 +455,84 @@ step_drain_main() {
   wait_drain "main gateway" "${MAIN_ADMIN_URL}"
 }
 
+step_deactivate_main_source() {
+  need_key
+  if [[ "${SOURCE_PROTOCOL_VERSION#v}" == "${ESCROW_PROTOCOL_VERSION#v}" ]]; then
+    note "source and target protocol are the same; leaving main escrows active"
+    return 0
+  fi
+  [[ "${DRY_RUN}" == "1" ]] && {
+    note "would deactivate active protocol-${SOURCE_PROTOCOL_VERSION#v} escrows on drained MAIN (no settlement)"
+    return 0
+  }
+  confirm "deactivate source-protocol escrows on drained MAIN (local only; no settlement)"
+  local id count=0 source="${SOURCE_PROTOCOL_VERSION#v}"
+  while IFS= read -r id; do
+    [[ -n "${id}" ]] || continue
+    note "deactivate source escrow ${id}"
+    admin_post "${MAIN_ADMIN_URL}" "/v1/admin/devshards/${id}/deactivate" '{}' >/dev/null
+    count=$(( count + 1 ))
+  done < <(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/devshards" |
+    jq -r --arg p "${source}" '.devshards[]? | select(.active==true and (.protocol_version|tostring)==$p) | .id')
+  local remaining
+  remaining="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/devshards" |
+    jq --arg p "${source}" '[.devshards[]? | select(.active==true and (.protocol_version|tostring)==$p)] | length')"
+  (( remaining == 0 )) ||
+    { gate_fail "${remaining} source-protocol escrow(s) remain active on main"; return 1; }
+  gate_ok "deactivated ${count} source-protocol escrow(s) on main without settlement"
+}
+
 step_bump_main_image() { compose_bump; }
 
 step_update_main() {
   confirm "recreate MAIN from ${COMPOSE_FILE} on the bumped image"
   note "MAIN image comes from ${COMPOSE_FILE} (service ${COMPOSE_SERVICE}), not an env ref"
-  local src=""; [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]] && src="source '${MAIN_ENV_FILE_ABS}' && "
-  run_shell "cd '${DEPLOY_DIR}' && ${src}docker compose -f '${COMPOSE_FILE}' pull ${COMPOSE_SERVICE} && docker compose -f '${COMPOSE_FILE}' up -d --no-deps --force-recreate ${COMPOSE_SERVICE} && docker compose -f '${COMPOSE_FILE}' ps ${COMPOSE_SERVICE}"
+  local src="" pull=""
+  [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]] && src="source '${MAIN_ENV_FILE_ABS}' && "
+  [[ "${IMAGE_SKIP_PULL}" != "true" ]] && pull="docker compose -f '${COMPOSE_FILE}' pull ${COMPOSE_SERVICE} && "
+  run_shell "cd '${DEPLOY_DIR}' && ${src}${pull}docker compose -f '${COMPOSE_FILE}' up -d --no-deps --force-recreate ${COMPOSE_SERVICE} && docker compose -f '${COMPOSE_FILE}' ps ${COMPOSE_SERVICE}"
   gate_ok "MAIN recreated on new image"
+}
+
+step_create_main_seed_escrows() {
+  need_key
+  local model temp_count amount seed_count i body total=0
+  while IFS=$'\t' read -r model temp_count amount seed_count; do
+    total=$(( total + seed_count ))
+  done < <(models_tsv)
+  (( total > 0 )) || { note "no main seed escrows configured"; return 0; }
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    while IFS=$'\t' read -r model temp_count amount seed_count; do
+      note "would mint ${seed_count} main seed x ${model} @ ${amount}"
+    done < <(models_tsv)
+    return 0
+  fi
+  confirm "mint target-protocol seed escrows on updated MAIN (spends real funds; irreversible)"
+  while IFS=$'\t' read -r model temp_count amount seed_count; do
+    for (( i=1; i<=seed_count; i++ )); do
+      note "mint main seed ${i}/${seed_count} ${model} @ ${amount}"
+      body="$(jq -nc --argjson amount "${amount}" --arg model "${model}" --arg pk "${ESCROW_PRIVATE_KEY_ENV}" --arg pv "${ESCROW_PROTOCOL_VERSION}" \
+        '{amount:$amount, model_id:$model, private_key_env:$pk, protocol_version:$pv}')"
+      admin_post "${MAIN_ADMIN_URL}" "/v1/admin/escrows" "${body}" >/dev/null
+    done
+  done < <(models_tsv)
+  gate_ok "main seed escrows minted"
 }
 
 step_check_main_direct() {
   need_key
-  [[ "${DRY_RUN}" == "1" ]] && { note "would verify main readiness and a direct chat smoke test before switching back"; return 0; }
+  [[ "${DRY_RUN}" == "1" ]] && { note "would verify main readiness, target-protocol seed coverage, and a direct chat smoke before switching back"; return 0; }
   wait_ready "main gateway" "${MAIN_ADMIN_URL}"
+  local model temp_count amount seed_count active
+  while IFS=$'\t' read -r model temp_count amount seed_count; do
+    (( seed_count > 0 )) || continue
+    active="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/devshards" |
+      jq --arg m "${model}" --arg p "${ESCROW_PROTOCOL_VERSION#v}" \
+        '[.devshards[]? | select(.active==true and .model==$m and (.protocol_version|tostring)==$p)] | length')"
+    (( active >= seed_count )) ||
+      { gate_fail "main has ${active}/${seed_count} active target-protocol seed escrows for ${model}"; return 1; }
+    gate_ok "main: ${active}/${seed_count} target-protocol seed escrows active for ${model}"
+  done < <(models_tsv)
   smoke_chat "${MAIN_ADMIN_URL}" "${SMOKE_MODEL}"
   gate_ok "main direct chat smoke test passed (${SMOKE_MODEL})"
 }
@@ -563,13 +646,15 @@ Devshard gateway update (v2, single-file)
 Config: ${CONFIG_PATH}
 Mode:   $([[ "${DRY_RUN}" == "1" ]] && echo "dry-run (use --run to execute)" || echo LIVE)
 Image:  ${IMAGE_FROM_REF} -> ${IMAGE_TO_REF}
+Pull:   $([[ "${IMAGE_SKIP_PULL}" == "true" ]] && echo "skip (require exact local target image)" || echo "registry")
+Protocol: ${SOURCE_PROTOCOL_VERSION} -> ${ESCROW_PROTOCOL_VERSION}
 Main:   ${MAIN_CONTAINER} @ ${MAIN_ADMIN_URL}
 Temp:   ${TEMP_UPSTREAM_ALIAS} @ ${TEMP_ADMIN_URL} (network ${TEMP_NETWORK})
 Nginx:  ${NGINX_PROXY_CONTAINER}:${NGINX_CONFIG_PATH}  ${NGINX_OLD_UPSTREAM} <-> ${NGINX_NEW_UPSTREAM}:${NGINX_UPSTREAM_PORT}
 Public: ${NGINX_PUBLIC_BASE_URL:-<unset; public checks skipped>}
 Smoke:  ${SMOKE_MODEL}
 Models (fresh temp escrows minted per model):
-$(models_tsv | while IFS=$'\t' read -r m c a; do printf '  %s x %s @ %s\n' "${c}" "${m}" "${a}"; done)
+$(models_tsv | while IFS=$'\t' read -r m c a s; do printf '  %s: temp=%s, main-seed=%s, amount=%s each\n' "${m}" "${c}" "${s}" "${a}"; done)
 Steps:
 $(printf '  %s\n' "${ORDERED_STEPS[@]}")
 EOF

--- a/devshard/docs/devshard-update/scripts/update.sh
+++ b/devshard/docs/devshard-update/scripts/update.sh
@@ -6,12 +6,12 @@ set -Eeuo pipefail
 # Zero-downtime update for a Gonka devshard gateway (single instance, blue/green).
 # One self-contained file, driven by a JSON config (models config-driven).
 #
-# Flow: stand up a temp gateway on its OWN fresh escrows, switch nginx to temp,
+# Flow: stand up a temp gateway on its OWN fresh escrows, switch routing to temp,
 # drain main, bump the compose image tag + recreate main, switch back, drain +
 # remove temp, then fold the temp escrows into main. Dry-run unless --run.
 #
 # Sections below: CLI -> config load/validate/resolve -> helpers (progress,
-# admin API, docker/nginx) -> steps -> orchestration -> recover -> entrypoint.
+# admin API, Docker/router) -> steps -> orchestration -> recover -> entrypoint.
 #
 # Usage:
 #   ./update.sh --config update.config.json                     # dry-run plan
@@ -106,6 +106,11 @@ config_validate() {
           num(.value.escrow_amount; "models[\(.key)].escrow_amount") )),
       req(.escrow.protocol_version; "escrow.protocol_version"),
       req(.escrow.private_key_env; "escrow.private_key_env"),
+      ((.deactivation.mode // "api") as $mode |
+        if ($mode == "api") then empty
+        elif ($mode == "sqlite") then req(.deactivation.gateway_db; "deactivation.gateway_db")
+        else "deactivation.mode must be api or sqlite"
+        end),
       (if (((.escrow.source_protocol_version // .escrow.protocol_version) | tostring | sub("^v"; "")) !=
            ((.escrow.protocol_version | tostring | sub("^v"; ""))) and
            any(.models[]; (.main_seed_count // 0) < 1))
@@ -117,11 +122,22 @@ config_validate() {
       num(.temp.admin_port; "temp.admin_port"),
       req(.temp.upstream_alias; "temp.upstream_alias"),
       req(.temp.network; "temp.network"),
-      req(.nginx.proxy_container; "nginx.proxy_container"),
-      req(.nginx.config_path; "nginx.config_path"),
-      req(.nginx.old_upstream; "nginx.old_upstream"),
-      req(.nginx.new_upstream; "nginx.new_upstream"),
-      num(.nginx.upstream_port; "nginx.upstream_port"),
+      ((.routing.type // "nginx") as $routing |
+        if $routing == "nginx" then
+          ( req(.nginx.proxy_container; "nginx.proxy_container"),
+            req(.nginx.config_path; "nginx.config_path"),
+            req(.nginx.old_upstream; "nginx.old_upstream"),
+            req(.nginx.new_upstream; "nginx.new_upstream"),
+            num(.nginx.upstream_port; "nginx.upstream_port") )
+        elif $routing == "caddy" then
+          ( req(.caddy.proxy_container; "caddy.proxy_container"),
+            req(.caddy.config_path; "caddy.config_path"),
+            req(.caddy.old_upstream; "caddy.old_upstream"),
+            req(.caddy.new_upstream; "caddy.new_upstream"),
+            num(.caddy.upstream_port; "caddy.upstream_port") )
+        else
+          "routing.type must be nginx or caddy"
+        end),
       req(.compose.file; "compose.file"),
       req(.compose.service; "compose.service"),
       num(.timeouts.ready_timeout_seconds; "timeouts.ready_timeout_seconds"),
@@ -157,6 +173,8 @@ resolve_config() {
   ESCROW_PROTOCOL_VERSION="${ESCROW_PROTOCOL_VERSION:-$(cfg .escrow.protocol_version)}"
   SOURCE_PROTOCOL_VERSION="${SOURCE_PROTOCOL_VERSION:-$(jq -r '.escrow.source_protocol_version // .escrow.protocol_version' <<<"${CONFIG_JSON}")}"
   ESCROW_PRIVATE_KEY_ENV="${ESCROW_PRIVATE_KEY_ENV:-$(cfg .escrow.private_key_env)}"
+  DEACTIVATION_MODE="${DEACTIVATION_MODE:-$(jq -r '.deactivation.mode // "api"' <<<"${CONFIG_JSON}")}"
+  GATEWAY_DB_PATH="${GATEWAY_DB_PATH:-$(cfg .deactivation.gateway_db)}"
   # Target HTTP route for temp + recreated MAIN. Defaults to /devshard/v<protocol>
   # on a protocol change; empty for same-protocol image bumps (env file untouched).
   TARGET_ROUTE_PREFIX="${TARGET_ROUTE_PREFIX:-$(cfg .escrow.route_prefix)}"
@@ -171,6 +189,7 @@ resolve_config() {
   TEMP_ADMIN_URL="${TEMP_ADMIN_URL:-http://127.0.0.1:${TEMP_ADMIN_PORT}}"
   TEMP_UPSTREAM_ALIAS="${TEMP_UPSTREAM_ALIAS:-$(cfg .temp.upstream_alias)}"
   TEMP_NETWORK="${TEMP_NETWORK:-$(cfg .temp.network)}"
+  ROUTING_TYPE="${ROUTING_TYPE:-$(jq -r '.routing.type // "nginx"' <<<"${CONFIG_JSON}")}"
   NGINX_PROXY_CONTAINER="${NGINX_PROXY_CONTAINER:-$(cfg .nginx.proxy_container)}"
   NGINX_CONFIG_PATH="${NGINX_CONFIG_PATH:-$(cfg .nginx.config_path)}"
   NGINX_OLD_UPSTREAM="${NGINX_OLD_UPSTREAM:-$(cfg .nginx.old_upstream)}"
@@ -179,6 +198,14 @@ resolve_config() {
   NGINX_UPSTREAM_PORT="${NGINX_UPSTREAM_PORT:-$(cfgn .nginx.upstream_port)}"
   NGINX_PUBLIC_BASE_URL="${NGINX_PUBLIC_BASE_URL:-$(cfg .nginx.public_base_url)}"
   NGINX_PUBLIC_PREFIX="${NGINX_PUBLIC_PREFIX:-$(cfg .nginx.public_prefix)}"
+  CADDY_PROXY_CONTAINER="${CADDY_PROXY_CONTAINER:-$(cfg .caddy.proxy_container)}"
+  CADDY_CONFIG_PATH="${CADDY_CONFIG_PATH:-$(cfg .caddy.config_path)}"
+  CADDY_OLD_UPSTREAM="${CADDY_OLD_UPSTREAM:-$(cfg .caddy.old_upstream)}"
+  CADDY_NEW_UPSTREAM="${CADDY_NEW_UPSTREAM:-$(cfg .caddy.new_upstream)}"
+  [[ -n "${CADDY_NEW_UPSTREAM}" ]] || CADDY_NEW_UPSTREAM="${TEMP_UPSTREAM_ALIAS}"
+  CADDY_UPSTREAM_PORT="${CADDY_UPSTREAM_PORT:-$(cfgn .caddy.upstream_port)}"
+  PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-${NGINX_PUBLIC_BASE_URL:-$(jq -r '.routing.public_base_url // .nginx.public_base_url // .caddy.public_base_url // ""' <<<"${CONFIG_JSON}")}}"
+  PUBLIC_PREFIX="${PUBLIC_PREFIX:-${NGINX_PUBLIC_PREFIX:-$(jq -r '.routing.public_prefix // .nginx.public_prefix // .caddy.public_prefix // ""' <<<"${CONFIG_JSON}")}}"
   COMPOSE_FILE="${COMPOSE_FILE:-$(cfg .compose.file)}"
   COMPOSE_SERVICE="${COMPOSE_SERVICE:-$(cfg .compose.service)}"
   READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-$(cfgn .timeouts.ready_timeout_seconds)}"
@@ -187,7 +214,7 @@ resolve_config() {
   DRAIN_POLL_SECONDS="${DRAIN_POLL_SECONDS:-$(cfgn .timeouts.drain_poll_seconds)}"
   SMOKE_MODEL="${SMOKE_MODEL:-$(cfg .smoke_test.model)}"
   [[ -n "${SMOKE_MODEL}" ]] || SMOKE_MODEL="$(jq -r '.models[0].model' <<<"${CONFIG_JSON}")"
-  ROTATION_RESTORE="${ROTATION_RESTORE:-$(jq -r '.rotation.restore_after_update // false' <<<"${CONFIG_JSON}")}"
+  ROTATION_RESTORE="${ROTATION_RESTORE:-$(jq -r '.rotation.restore_after_update // true' <<<"${CONFIG_JSON}")}"
 }
 
 load_config() {
@@ -252,6 +279,14 @@ smoke_chat() {
   fi
   curl -fsS -X POST "$1/v1/chat/completions" "${auth_hdr[@]}" -H 'Content-Type: application/json' \
     -d "$(jq -nc --arg m "$2" '{model:$m, stream:false, max_tokens:1, messages:[{role:"user", content:"Reply with ok"}]}')" >/dev/null
+}
+
+smoke_configured_models() {
+  local url="$1" label="$2" model
+  while IFS= read -r model; do
+    smoke_chat "${url}" "${model}"
+    gate_ok "${label} chat smoke passed (${model})"
+  done < <(jq -r '.models[].model' <<<"${CONFIG_JSON}")
 }
 
 settings_sync_to_temp() {
@@ -357,6 +392,61 @@ INNER
   gate_fail "nginx switch ${from} -> ${to} failed"; return 1
 }
 
+# Switch a Caddy reverse_proxy host, validate, and gracefully reload. Kept
+# separate from nginx_switch so each routing backend owns its config syntax.
+caddy_switch() {
+  local from="$1" to="$2" port="${CADDY_UPSTREAM_PORT}"
+  local cfg_path="${CADDY_CONFIG_PATH}" backup="${CADDY_CONFIG_PATH}.blue-green-backup" tmp="${CADDY_CONFIG_PATH}.blue-green-tmp"
+  local old_pat="reverse_proxy[[:space:]]+${from}:${port}"
+  local new_pat="reverse_proxy[[:space:]]+${to}:${port}"
+  note "Caddy upstream switch ${from} -> ${to} in ${cfg_path}"
+  if [[ "${DRY_RUN}" == "1" ]]; then note "would docker exec ${CADDY_PROXY_CONTAINER} sh -lc '<switch ${from}->${to} + caddy validate + reload>'"; return 0; fi
+  local inner
+  inner="$(cat <<INNER
+set -eu
+test -f '${cfg_path}'
+if ! grep -Eq '${old_pat}' '${cfg_path}'; then
+  if grep -Eq '${new_pat}' '${cfg_path}'; then echo 'Caddy already on ${to}:${port}'; exit 0; fi
+  echo 'ERROR: reverse_proxy ${from}:${port} not found in ${cfg_path}' >&2; exit 3
+fi
+cp '${cfg_path}' '${backup}'
+sed -E 's#(reverse_proxy[[:space:]]+)${from}:${port}#\1${to}:${port}#g' '${cfg_path}' > '${tmp}'
+if mv '${tmp}' '${cfg_path}' 2>/dev/null; then
+  :
+else
+  cat '${tmp}' > '${cfg_path}'
+  rm -f '${tmp}'
+fi
+grep -Eq '${new_pat}' '${cfg_path}' || { echo 'ERROR: Caddy switch did not apply; restore ${backup}' >&2; exit 4; }
+caddy validate --config '${cfg_path}' --adapter caddyfile
+caddy reload --config '${cfg_path}' --adapter caddyfile
+echo 'Caddy upstream switched ${from} -> ${to} and reloaded'
+INNER
+)"
+  if docker exec "${CADDY_PROXY_CONTAINER}" sh -lc "${inner}"; then gate_ok "Caddy switched ${from} -> ${to} (graceful reload)"; return 0; fi
+  gate_fail "Caddy switch ${from} -> ${to} failed"; return 1
+}
+
+# The workflow selects direction; backend-specific functions implement syntax.
+routing_switch() {
+  local side="$1"
+  case "${ROUTING_TYPE}" in
+    nginx)
+      case "${side}" in
+        temp) nginx_switch "${NGINX_OLD_UPSTREAM}" "${NGINX_NEW_UPSTREAM}" ;;
+        main) nginx_switch "${NGINX_NEW_UPSTREAM}" "${NGINX_OLD_UPSTREAM}" ;;
+      esac
+      ;;
+    caddy)
+      case "${side}" in
+        temp) caddy_switch "${CADDY_OLD_UPSTREAM}" "${CADDY_NEW_UPSTREAM}" ;;
+        main) caddy_switch "${CADDY_NEW_UPSTREAM}" "${CADDY_OLD_UPSTREAM}" ;;
+      esac
+      ;;
+    *) gate_fail "unsupported routing.type: ${ROUTING_TYPE}"; return 1 ;;
+  esac
+}
+
 # Fold one temp escrow into main: import inactive (carries its state.db), then
 # either activate (route it) or settle (drain-aware on-chain). Shared by the
 # activate-temp step and the recover command.
@@ -385,6 +475,8 @@ runstate_init() {
   TEMP_STORAGE_HOST_DIR="${STORAGE_HOST_DIR_ABS}/temp-${RUN_ID}"
   TEMP_STORAGE_CONTAINER_DIR="/root/.devshardctl/temp-${RUN_ID}"
   TEMP_DEVSHARDS_FILE="${TEMP_STORAGE_HOST_DIR}/temp-devshards.json"
+  MAIN_SETTINGS_SNAPSHOT_FILE="${DEPLOY_DIR}/blue-green-main-settings-${RUN_ID}.json"
+  MAIN_DB_BACKUP_DIR="${DEPLOY_DIR}/gateway-db-pre-${RUN_ID}"
 }
 runstate_write() {
   cat > "${RUN_STATE_FILE}" <<EOF
@@ -393,12 +485,14 @@ TEMP_CONTAINER='${TEMP_CONTAINER}'
 TEMP_STORAGE_HOST_DIR='${TEMP_STORAGE_HOST_DIR}'
 TEMP_STORAGE_CONTAINER_DIR='${TEMP_STORAGE_CONTAINER_DIR}'
 TEMP_DEVSHARDS_FILE='${TEMP_DEVSHARDS_FILE}'
+MAIN_SETTINGS_SNAPSHOT_FILE='${MAIN_SETTINGS_SNAPSHOT_FILE}'
+MAIN_DB_BACKUP_DIR='${MAIN_DB_BACKUP_DIR}'
 EOF
 }
 # Canary/single-step invokes update.sh per step (new process). Load prior init
 # state, or create it if missing (e.g. dry-run prepare after init skipped write).
 ensure_runstate() {
-  if [[ -n "${TEMP_STORAGE_HOST_DIR:-}" && -n "${TEMP_CONTAINER:-}" ]]; then
+  if [[ -n "${TEMP_STORAGE_HOST_DIR:-}" && -n "${TEMP_CONTAINER:-}" && -n "${MAIN_SETTINGS_SNAPSHOT_FILE:-}" && -n "${MAIN_DB_BACKUP_DIR:-}" ]]; then
     return 0
   fi
   if [[ -f "${RUN_STATE_FILE}" ]]; then
@@ -410,6 +504,15 @@ ensure_runstate() {
     mkdir -p "${STORAGE_HOST_DIR_ABS}"
     runstate_write
     note "run state initialized (${RUN_ID}) at ${RUN_STATE_FILE}"
+  elif [[ -z "${MAIN_SETTINGS_SNAPSHOT_FILE:-}" ]]; then
+    MAIN_SETTINGS_SNAPSHOT_FILE="${DEPLOY_DIR}/blue-green-main-settings-${RUN_ID}.json"
+    MAIN_DB_BACKUP_DIR="${DEPLOY_DIR}/gateway-db-pre-${RUN_ID}"
+    runstate_write
+    note "upgraded run state with MAIN settings snapshot path: ${MAIN_SETTINGS_SNAPSHOT_FILE}"
+  elif [[ -z "${MAIN_DB_BACKUP_DIR:-}" ]]; then
+    MAIN_DB_BACKUP_DIR="${DEPLOY_DIR}/gateway-db-pre-${RUN_ID}"
+    runstate_write
+    note "upgraded run state with gateway DB backup path: ${MAIN_DB_BACKUP_DIR}"
   fi
 }
 
@@ -449,13 +552,34 @@ step_preflight() {
     [[ -z "${missing_seeds}" ]] ||
       { gate_fail "protocol change requires models[].main_seed_count >= 1 for:${missing_seeds}"; return 1; }
   fi
+  if [[ "${DEACTIVATION_MODE}" == "sqlite" ]]; then
+    command -v python3 >/dev/null ||
+      { gate_fail "deactivation.mode=sqlite requires python3"; return 1; }
+    [[ -n "${GATEWAY_DB_ABS:-}" && -f "${GATEWAY_DB_ABS}" ]] ||
+      { gate_fail "gateway database not found: ${GATEWAY_DB_ABS:-<unset>}"; return 1; }
+    gate_ok "offline SQLite deactivation prerequisites available"
+  fi
   gate_ok "every model main serves is covered by temp escrows or allow-listed"
 }
 
 step_disable_main_rotation() {
+  ensure_runstate
   need_key
-  [[ "${DRY_RUN}" == "1" ]] && { note "would disable escrow_rotation on MAIN so nothing settles on-chain mid-update"; return 0; }
-  local settings; settings="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" | jq '.escrow_rotation.enabled=false')"
+  [[ "${DRY_RUN}" == "1" ]] && {
+    note "would snapshot MAIN settings to ${MAIN_SETTINGS_SNAPSHOT_FILE} and disable escrow_rotation"
+    return 0
+  }
+  local settings
+  if [[ ! -f "${MAIN_SETTINGS_SNAPSHOT_FILE}" ]]; then
+    admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" |
+      jq -e 'select(.escrow_rotation != null)' > "${MAIN_SETTINGS_SNAPSHOT_FILE}"
+    chmod 600 "${MAIN_SETTINGS_SNAPSHOT_FILE}"
+    note "saved original MAIN settings: ${MAIN_SETTINGS_SNAPSHOT_FILE}"
+  else
+    jq -e '.escrow_rotation != null' "${MAIN_SETTINGS_SNAPSHOT_FILE}" >/dev/null
+    note "using existing original MAIN settings snapshot: ${MAIN_SETTINGS_SNAPSHOT_FILE}"
+  fi
+  settings="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" | jq '.escrow_rotation.enabled=false')"
   admin_post "${MAIN_ADMIN_URL}" "/v1/admin/settings" "${settings}" >/dev/null
   gate_ok "MAIN escrow_rotation disabled"
 }
@@ -561,12 +685,11 @@ step_check_temp() {
     (( active < count )) && { gate_fail "temp has ${active} active escrows for ${model}, need ${count} (model would be unavailable during update)"; return 1; }
     gate_ok "temp: ${active}/${count} active escrows for ${model}"
   done < <(models_tsv)
-  smoke_chat "${TEMP_ADMIN_URL}" "${SMOKE_MODEL}"
-  gate_ok "temp chat smoke test passed (${SMOKE_MODEL})"
+  smoke_configured_models "${TEMP_ADMIN_URL}" "temp"
   admin_get "${TEMP_ADMIN_URL}" "/v1/admin/devshards" > "${TEMP_DEVSHARDS_FILE}"
 }
 
-step_switch_to_temp() { confirm "switch nginx upstream to TEMP (${NGINX_NEW_UPSTREAM})"; nginx_switch "${NGINX_OLD_UPSTREAM}" "${NGINX_NEW_UPSTREAM}"; }
+step_switch_to_temp() { confirm "switch ${ROUTING_TYPE} upstream to TEMP (${TEMP_UPSTREAM_ALIAS})"; routing_switch temp; }
 step_check_alias_temp() { check_alias temp; }
 
 step_drain_main() {
@@ -590,6 +713,70 @@ jq_active_source_escrows() {
   '
 }
 
+deactivate_main_source_sqlite() {
+  local source="$1" expected
+  expected="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/devshards" |
+    jq_active_source_escrows "${source}" | jq 'length')"
+  if (( expected == 0 )); then
+    gate_ok "no active source-protocol escrow records require offline deactivation"
+    return 0
+  fi
+
+  confirm "stop drained MAIN, back up gateway DB, and deactivate ${expected} source-protocol record(s) offline (no settlement)"
+  run docker stop "${MAIN_CONTAINER}"
+  run mkdir -p -m 700 "${MAIN_DB_BACKUP_DIR}"
+  run_shell "cp -a '${GATEWAY_DB_ABS}'* '${MAIN_DB_BACKUP_DIR}/'"
+
+  python3 - "${GATEWAY_DB_ABS}" "${source}" "${expected}" <<'PY'
+import datetime
+import sqlite3
+import sys
+
+path, source, expected_raw = sys.argv[1:]
+expected = int(expected_raw)
+db = sqlite3.connect(path)
+try:
+    db.execute("BEGIN IMMEDIATE")
+    where = """
+        active = 1 AND (
+            REPLACE(COALESCE(protocol_version, ''), 'v', '') = ?
+            OR TRIM(COALESCE(protocol_version, '')) = ''
+        )
+    """
+    before = db.execute(
+        f"SELECT COUNT(*) FROM gateway_devshards WHERE {where}", (source,)
+    ).fetchone()[0]
+    if before != expected:
+        raise RuntimeError(
+            f"source record count changed before offline update: expected {expected}, found {before}"
+        )
+    updated = db.execute(
+        f"""UPDATE gateway_devshards
+            SET active = 0, updated_at = ?
+            WHERE {where}""",
+        (datetime.datetime.now(datetime.timezone.utc).isoformat(), source),
+    ).rowcount
+    if updated != expected:
+        raise RuntimeError(f"updated {updated} records, expected {expected}")
+    remaining = db.execute(
+        f"SELECT COUNT(*) FROM gateway_devshards WHERE {where}", (source,)
+    ).fetchone()[0]
+    if remaining:
+        raise RuntimeError(f"{remaining} source records remain active")
+    db.commit()
+    integrity = db.execute("PRAGMA integrity_check").fetchone()[0]
+    if integrity != "ok":
+        raise RuntimeError(f"SQLite integrity check failed: {integrity}")
+finally:
+    db.close()
+
+print(f"offline_deactivated={expected}")
+print("remaining_active_source=0")
+print("integrity=ok")
+PY
+  gate_ok "offline-deactivated ${expected} source-protocol record(s); backup: ${MAIN_DB_BACKUP_DIR}"
+}
+
 step_deactivate_main_source() {
   need_key
   if [[ "${SOURCE_PROTOCOL_VERSION#v}" == "${ESCROW_PROTOCOL_VERSION#v}" ]]; then
@@ -597,9 +784,13 @@ step_deactivate_main_source() {
     return 0
   fi
   [[ "${DRY_RUN}" == "1" ]] && {
-    note "would deactivate active protocol-${SOURCE_PROTOCOL_VERSION#v} (or missing protocol_version) escrows on drained MAIN (no settlement)"
+    note "would deactivate active protocol-${SOURCE_PROTOCOL_VERSION#v} (or missing protocol_version) escrows on drained MAIN via ${DEACTIVATION_MODE} (no settlement)"
     return 0
   }
+  if [[ "${DEACTIVATION_MODE}" == "sqlite" ]]; then
+    deactivate_main_source_sqlite "${SOURCE_PROTOCOL_VERSION#v}"
+    return
+  fi
   confirm "deactivate source-protocol escrows on drained MAIN (local only; no settlement)"
   local id count=0 source="${SOURCE_PROTOCOL_VERSION#v}"
   while IFS= read -r id; do
@@ -623,9 +814,11 @@ step_update_main() {
   confirm "recreate MAIN from ${COMPOSE_FILE} on the bumped image"
   note "MAIN image comes from ${COMPOSE_FILE} (service ${COMPOSE_SERVICE}), not an env ref"
   local src="" pull=""
-  [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]] && src="source '${MAIN_ENV_FILE_ABS}' && "
+  [[ -n "${MAIN_ENV_FILE_ABS}" && -f "${MAIN_ENV_FILE_ABS}" ]] &&
+    src="set -a && source '${MAIN_ENV_FILE_ABS}' && set +a && "
   [[ "${IMAGE_SKIP_PULL}" != "true" ]] && pull="docker compose -f '${COMPOSE_FILE}' pull ${COMPOSE_SERVICE} && "
   run_shell "cd '${DEPLOY_DIR}' && ${src}${pull}docker compose -f '${COMPOSE_FILE}' up -d --no-deps --force-recreate ${COMPOSE_SERVICE} && docker compose -f '${COMPOSE_FILE}' ps ${COMPOSE_SERVICE}"
+  [[ "${DRY_RUN}" == "1" ]] || wait_ready "main gateway" "${MAIN_ADMIN_URL}"
   gate_ok "MAIN recreated on new image"
 }
 
@@ -668,11 +861,10 @@ step_check_main_direct() {
       { gate_fail "main has ${active}/${seed_count} active target-protocol seed escrows for ${model}"; return 1; }
     gate_ok "main: ${active}/${seed_count} target-protocol seed escrows active for ${model}"
   done < <(models_tsv)
-  smoke_chat "${MAIN_ADMIN_URL}" "${SMOKE_MODEL}"
-  gate_ok "main direct chat smoke test passed (${SMOKE_MODEL})"
+  smoke_configured_models "${MAIN_ADMIN_URL}" "main direct"
 }
 
-step_switch_to_main() { confirm "switch nginx upstream back to MAIN (${NGINX_OLD_UPSTREAM})"; nginx_switch "${NGINX_NEW_UPSTREAM}" "${NGINX_OLD_UPSTREAM}"; }
+step_switch_to_main() { confirm "switch ${ROUTING_TYPE} upstream back to MAIN"; routing_switch main; }
 step_check_alias_main() { check_alias main; }
 
 step_drain_temp() {
@@ -715,11 +907,19 @@ step_activate_temp() {
 
 step_restore_main_rotation() {
   need_key
-  [[ "${ROTATION_RESTORE}" != "true" ]] && { note "leaving MAIN escrow_rotation disabled (set rotation.restore_after_update=true to re-enable)"; return 0; }
-  [[ "${DRY_RUN}" == "1" ]] && { note "would re-enable escrow_rotation on MAIN"; return 0; }
-  local settings; settings="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" | jq '.escrow_rotation.enabled=true')"
+  [[ "${ROTATION_RESTORE}" != "true" ]] && { note "leaving MAIN escrow_rotation disabled (set rotation.restore_after_update=true to restore its original settings)"; return 0; }
+  [[ "${DRY_RUN}" == "1" ]] && { note "would restore MAIN's exact original escrow_rotation settings"; return 0; }
+  [[ -n "${MAIN_SETTINGS_SNAPSHOT_FILE:-}" && -f "${MAIN_SETTINGS_SNAPSHOT_FILE}" ]] ||
+    { gate_fail "original MAIN settings snapshot is missing: ${MAIN_SETTINGS_SNAPSHOT_FILE:-<unset>}"; return 1; }
+  local original_rotation settings restored_rotation
+  original_rotation="$(jq -ce '.escrow_rotation' "${MAIN_SETTINGS_SNAPSHOT_FILE}")"
+  settings="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" |
+    jq -c --argjson original "${original_rotation}" '.escrow_rotation=$original')"
   admin_post "${MAIN_ADMIN_URL}" "/v1/admin/settings" "${settings}" >/dev/null
-  gate_ok "MAIN escrow_rotation re-enabled"
+  restored_rotation="$(admin_get "${MAIN_ADMIN_URL}" "/v1/admin/settings" | jq -cS '.escrow_rotation')"
+  [[ "${restored_rotation}" == "$(jq -cS . <<<"${original_rotation}")" ]] ||
+    { gate_fail "MAIN escrow_rotation does not match original snapshot after restore"; return 1; }
+  gate_ok "MAIN escrow_rotation restored exactly (enabled, settlement, models)"
 }
 
 step_status() {
@@ -732,11 +932,11 @@ step_status() {
 # check-alias-temp / check-alias-main: verify the public route (skipped if unset).
 check_alias() {
   local side="$1"; need_key
-  [[ -z "${NGINX_PUBLIC_BASE_URL}" ]] && { note "no nginx.public_base_url set; skipping public ${side} verification"; return 0; }
-  [[ "${DRY_RUN}" == "1" ]] && { note "would verify public ${side} route via ${NGINX_PUBLIC_BASE_URL}"; return 0; }
-  case "${NGINX_PUBLIC_BASE_URL}" in *127.0.0.1*|*localhost*) note "WARNING: public_base_url is loopback; can pass while the real route is broken" ;; esac
-  curl -fsS "${NGINX_PUBLIC_BASE_URL}${NGINX_PUBLIC_PREFIX}/v1/status" -H "Authorization: Bearer ${DEVSHARD_ADMIN_API_KEY}" >/dev/null
-  smoke_chat "${NGINX_PUBLIC_BASE_URL}${NGINX_PUBLIC_PREFIX}" "${SMOKE_MODEL}"
+  [[ -z "${PUBLIC_BASE_URL}" ]] && { note "no routing.public_base_url set; skipping public ${side} verification"; return 0; }
+  [[ "${DRY_RUN}" == "1" ]] && { note "would verify public ${side} route via ${PUBLIC_BASE_URL}"; return 0; }
+  case "${PUBLIC_BASE_URL}" in *127.0.0.1*|*localhost*) note "WARNING: public_base_url is loopback; can pass while the real route is broken" ;; esac
+  curl -fsS "${PUBLIC_BASE_URL}${PUBLIC_PREFIX}/v1/status" -H "Authorization: Bearer ${DEVSHARD_ADMIN_API_KEY}" >/dev/null
+  smoke_configured_models "${PUBLIC_BASE_URL}${PUBLIC_PREFIX}" "public ${side}"
   gate_ok "public ${side} route verified"
 }
 
@@ -785,8 +985,10 @@ Pull:   $([[ "${IMAGE_SKIP_PULL}" == "true" ]] && echo "skip (require exact loca
 Protocol: ${SOURCE_PROTOCOL_VERSION} -> ${ESCROW_PROTOCOL_VERSION}
 Main:   ${MAIN_CONTAINER} @ ${MAIN_ADMIN_URL}
 Temp:   ${TEMP_UPSTREAM_ALIAS} @ ${TEMP_ADMIN_URL} (network ${TEMP_NETWORK})
-Nginx:  ${NGINX_PROXY_CONTAINER}:${NGINX_CONFIG_PATH}  ${NGINX_OLD_UPSTREAM} <-> ${NGINX_NEW_UPSTREAM}:${NGINX_UPSTREAM_PORT}
-Public: ${NGINX_PUBLIC_BASE_URL:-<unset; public checks skipped>}
+Routing: ${ROUTING_TYPE}
+$([[ "${ROUTING_TYPE}" == "nginx" ]] && printf 'Nginx:  %s:%s  %s <-> %s:%s\n' "${NGINX_PROXY_CONTAINER}" "${NGINX_CONFIG_PATH}" "${NGINX_OLD_UPSTREAM}" "${NGINX_NEW_UPSTREAM}" "${NGINX_UPSTREAM_PORT}" || printf 'Caddy:  %s:%s  %s <-> %s:%s\n' "${CADDY_PROXY_CONTAINER}" "${CADDY_CONFIG_PATH}" "${CADDY_OLD_UPSTREAM}" "${CADDY_NEW_UPSTREAM}" "${CADDY_UPSTREAM_PORT}")
+Public: ${PUBLIC_BASE_URL:-<unset; public checks skipped>}${PUBLIC_PREFIX}
+Rotation: $([[ "${ROTATION_RESTORE}" == "true" ]] && echo "restore exact original MAIN settings" || echo "leave disabled")
 Smoke:  ${SMOKE_MODEL}
 Models (fresh temp escrows minted per model):
 $(models_tsv | while IFS=$'\t' read -r m c a s; do printf '  %s: temp=%s, main-seed=%s, amount=%s each\n' "${m}" "${c}" "${s}" "${a}"; done)
@@ -802,7 +1004,7 @@ on_error() {
   {
     echo ""
     echo "FAILED at step: ${CURRENT_STEP:-setup} (exit ${code})"
-    echo "Inspect: ${0##*/} --config '${CONFIG_ARG}' status --run ; restore nginx backup (${NGINX_CONFIG_PATH:-<config>}.blue-green-backup) to revert routing."
+    echo "Inspect: ${0##*/} --config '${CONFIG_ARG}' status --run ; restore the ${ROUTING_TYPE:-routing} .blue-green-backup to revert routing."
     if [[ "${ESCROWS_MINTED}" == "1" ]]; then
       echo ""
       echo "WARNING: temp escrows were minted on-chain but not yet folded into main."
@@ -825,6 +1027,7 @@ main() {
 
   STORAGE_HOST_DIR_ABS="$(abspath "${MAIN_STORAGE_HOST_DIR}")"
   MAIN_ENV_FILE_ABS=""; [[ -n "${MAIN_ENV_FILE}" ]] && MAIN_ENV_FILE_ABS="$(abspath "${MAIN_ENV_FILE}")"
+  GATEWAY_DB_ABS=""; [[ -n "${GATEWAY_DB_PATH}" ]] && GATEWAY_DB_ABS="$(abspath "${GATEWAY_DB_PATH}")"
   # Keep operator-writable next to the deploy dir (.devshardctl is often root-owned).
   RUN_STATE_FILE="${DEPLOY_DIR}/blue-green-run-state.env"
   # shellcheck disable=SC1090

--- a/devshard/docs/devshard-update/update.config.gateway2.json
+++ b/devshard/docs/devshard-update/update.config.gateway2.json
@@ -1,27 +1,27 @@
 {
   "image": {
-    "repository": "ghcr.io/gonka-ai/devshard-gateway",
-    "from_tag": "mainnet-v0.2.13-latest",
-    "to_tag": "mainnet-v0.2.14-latest",
+    "from_tag": "ghcr.io/gonka-ai/devshard-gateway:mainnet-v0.2.13-v2-obs-mem",
+    "to_tag": "ghcr.io/gonka-ai/devshard-gateway:mainnet-v0.2.13-v3-post1",
     "skip_pull": false
   },
   "models": [
-    { "model": "moonshotai/Kimi-K2.6", "escrow_count": 4, "main_seed_count": 0, "escrow_amount": 5000000000 },
-    { "model": "MiniMaxAI/MiniMax-M2.7", "escrow_count": 2, "main_seed_count": 0, "escrow_amount": 5000000000 }
+    { "model": "MiniMaxAI/MiniMax-M2.7", "escrow_count": 4, "main_seed_count": 1, "escrow_amount": 500000000 },
+    { "model": "moonshotai/Kimi-K2.6", "escrow_count": 4, "main_seed_count": 1, "escrow_amount": 500000000 }
   ],
   "allow_unavailable_models": [],
   "escrow": {
-    "source_protocol_version": "1",
-    "protocol_version": "1",
-    "route_prefix": "",
+    "source_protocol_version": "2",
+    "protocol_version": "3",
+    "route_prefix": "/devshard/v3",
     "private_key_env": "DEVSHARD_PRIVATE_KEY"
   },
   "deactivation": {
-    "mode": "api"
+    "mode": "sqlite",
+    "gateway_db": ".devshardctl/gateway.db"
   },
   "main": {
     "admin_url": "http://127.0.0.1:18080",
-    "container": "devshard-gateway",
+    "container": "gateway-v1",
     "storage_host_dir": ".devshardctl",
     "env_file": "./config.devshard.env"
   },
@@ -31,13 +31,13 @@
     "network": "join_default"
   },
   "routing": {
-    "type": "nginx",
-    "public_base_url": "",
-    "public_prefix": "/devshard-gateway"
+    "type": "caddy",
+    "public_base_url": "https://gateway-2.gonka.ai",
+    "public_prefix": ""
   },
-  "nginx": {
-    "proxy_container": "proxy",
-    "config_path": "/etc/nginx/nginx.conf",
+  "caddy": {
+    "proxy_container": "devshard-gateway-caddy",
+    "config_path": "/tmp/Caddyfile",
     "old_upstream": "devshard-gateway",
     "new_upstream": "devshard-gateway-temp",
     "upstream_port": 8080
@@ -53,7 +53,7 @@
     "drain_poll_seconds": 10
   },
   "smoke_test": {
-    "model": ""
+    "model": "MiniMaxAI/MiniMax-M2.7"
   },
   "rotation": {
     "restore_after_update": true

--- a/devshard/docs/devshard-update/update.config.node4.json
+++ b/devshard/docs/devshard-update/update.config.node4.json
@@ -1,44 +1,43 @@
 {
   "image": {
-    "repository": "ghcr.io/gonka-ai/devshard-gateway",
-    "from_tag": "mainnet-v0.2.13-latest",
-    "to_tag": "mainnet-v0.2.14-latest",
+    "from_tag": "libermans/gonka-devshard-proxy:latest",
+    "to_tag": "ghcr.io/gonka-ai/devshard-gateway:mainnet-v0.2.13-v3",
     "skip_pull": false
   },
   "models": [
-    { "model": "moonshotai/Kimi-K2.6", "escrow_count": 4, "main_seed_count": 0, "escrow_amount": 5000000000 },
-    { "model": "MiniMaxAI/MiniMax-M2.7", "escrow_count": 2, "main_seed_count": 0, "escrow_amount": 5000000000 }
+    { "model": "MiniMaxAI/MiniMax-M2.7", "escrow_count": 4, "main_seed_count": 1, "escrow_amount": 1000000000 },
+    { "model": "moonshotai/Kimi-K2.6", "escrow_count": 4, "main_seed_count": 1, "escrow_amount": 1000000000 }
   ],
   "allow_unavailable_models": [],
   "escrow": {
     "source_protocol_version": "1",
-    "protocol_version": "1",
-    "route_prefix": "",
+    "protocol_version": "3",
+    "route_prefix": "/devshard/v3",
     "private_key_env": "DEVSHARD_PRIVATE_KEY"
   },
   "main": {
     "admin_url": "http://127.0.0.1:18080",
-    "container": "devshard-gateway",
+    "container": "devshardctl-multi",
     "storage_host_dir": ".devshardctl",
     "env_file": "./config.devshard.env"
   },
   "temp": {
     "admin_port": 18081,
-    "upstream_alias": "devshard-gateway-temp",
+    "upstream_alias": "devshardctl-multi-temp",
     "network": "join_default"
   },
   "nginx": {
     "proxy_container": "proxy",
     "config_path": "/etc/nginx/nginx.conf",
-    "old_upstream": "devshard-gateway",
-    "new_upstream": "devshard-gateway-temp",
+    "old_upstream": "devshardctl-multi",
+    "new_upstream": "devshardctl-multi-temp",
     "upstream_port": 8080,
-    "public_base_url": "",
+    "public_base_url": "https://node4.gonka.ai",
     "public_prefix": "/devshard-gateway"
   },
   "compose": {
-    "file": "docker-compose.devshard-gateway.yml",
-    "service": "devshard-gateway"
+    "file": "docker-compose.devshardctl.yml",
+    "service": "devshardctl"
   },
   "timeouts": {
     "ready_timeout_seconds": 180,
@@ -47,7 +46,7 @@
     "drain_poll_seconds": 10
   },
   "smoke_test": {
-    "model": ""
+    "model": "MiniMaxAI/MiniMax-M2.7"
   },
   "rotation": {
     "restore_after_update": false

--- a/devshard/docs/devshard-update/update.config.node4.json
+++ b/devshard/docs/devshard-update/update.config.node4.json
@@ -1,7 +1,7 @@
 {
   "image": {
     "from_tag": "libermans/gonka-devshard-proxy:latest",
-    "to_tag": "ghcr.io/gonka-ai/devshard-gateway:mainnet-v0.2.13-v3",
+    "to_tag": "ghcr.io/gonka-ai/devshard-gateway:mainnet-v0.2.13-v3-post1",
     "skip_pull": false
   },
   "models": [
@@ -14,6 +14,10 @@
     "protocol_version": "3",
     "route_prefix": "/devshard/v3",
     "private_key_env": "DEVSHARD_PRIVATE_KEY"
+  },
+  "deactivation": {
+    "mode": "sqlite",
+    "gateway_db": ".devshardctl/gateway.db"
   },
   "main": {
     "admin_url": "http://127.0.0.1:18080",
@@ -49,6 +53,6 @@
     "model": "MiniMaxAI/MiniMax-M2.7"
   },
   "rotation": {
-    "restore_after_update": false
+    "restore_after_update": true
   }
 }


### PR DESCRIPTION
Provide a lightweight production-shaped proxy + gateway compose stack for blue/green update testing without the full join node deployment.