### PR TITLE
`devshard` Reject underreported inference accounting on host

### DIFF
--- a/common/completionapi/request.go
+++ b/common/completionapi/request.go
@@ -177,6 +177,17 @@ func getMaxTokens(requestMap map[string]interface{}) int {
 	return calculations.DefaultMaxTokens // Default value if not specified
 }
 
+// EffectiveMaxTokens returns the output-token limit the ML execution path will
+// apply for this request body: explicit max_tokens / max_completion_tokens when
+// present, otherwise calculations.DefaultMaxTokens.
+func EffectiveMaxTokens(requestBytes []byte) (uint64, error) {
+	var requestMap map[string]interface{}
+	if err := json.Unmarshal(requestBytes, &requestMap); err != nil {
+		return 0, err
+	}
+	return uint64(getMaxTokens(requestMap)), nil
+}
+
 func getOriginalLogprobs(requestMap map[string]interface{}) *bool {
 	logprobsValue, ok := requestMap["logprobs"]
 	if !ok {

--- a/common/completionapi/request_test.go
+++ b/common/completionapi/request_test.go
@@ -303,6 +303,19 @@ func TestMaxTokens(t *testing.T) {
 	}
 }
 
+func TestEffectiveMaxTokens(t *testing.T) {
+	n, err := EffectiveMaxTokens([]byte(jsonBodyWithMaxTokens))
+	require.NoError(t, err)
+	require.EqualValues(t, 100, n)
+
+	n, err = EffectiveMaxTokens([]byte(jsonBodyNoTokenLimits))
+	require.NoError(t, err)
+	require.EqualValues(t, calculations.DefaultMaxTokens, n)
+
+	_, err = EffectiveMaxTokens([]byte("not-json"))
+	require.Error(t, err)
+}
+
 func TestModifyRequestBody_PreservesMultipartContent(t *testing.T) {
 	r, err := ModifyRequestBody([]byte(jsonBodyMultipartContent), 7)
 	require.NoError(t, err)

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -13,6 +13,8 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"common/completionapi"
+
 	"devshard"
 	"devshard/gossip"
 	"devshard/logging"
@@ -1447,7 +1449,8 @@ func (h *Host) signProposer(msg proto.Message) ([]byte, error) {
 	return h.signer.Sign(data)
 }
 
-// VerifyPayload checks that an InferencePayload matches the expected on-chain fields.
+// VerifyPayload checks that an InferencePayload matches the expected on-chain fields
+// and that those accounting fields cover the actual prompt workload.
 // Used by both executor (signReceipt) and verifier (VerifyRefusedTimeout) paths.
 func VerifyPayload(p *InferencePayload, promptHash []byte, model string, inputLength, maxTokens uint64, startedAt int64) error {
 	hash, err := devshard.CanonicalPromptHash(p.Prompt)
@@ -1468,6 +1471,27 @@ func VerifyPayload(p *InferencePayload, promptHash []byte, model string, inputLe
 	}
 	if p.Model != model {
 		return fmt.Errorf("%w: model %s vs %s", types.ErrPayloadMismatch, p.Model, model)
+	}
+	if err := verifyPayloadWorkload(p); err != nil {
+		return err
+	}
+	return nil
+}
+
+// verifyPayloadWorkload binds signed accounting fields to the prompt body the
+// executor will run: input_length must equal prompt byte length (gateway
+// convention), and declared max_tokens must cover the effective body limit.
+func verifyPayloadWorkload(p *InferencePayload) error {
+	promptLen := uint64(len(p.Prompt))
+	if p.InputLength != promptLen {
+		return fmt.Errorf("%w: input_length %d != prompt bytes %d", types.ErrPayloadMismatch, p.InputLength, promptLen)
+	}
+	bodyMaxTokens, err := completionapi.EffectiveMaxTokens(p.Prompt)
+	if err != nil {
+		return fmt.Errorf("%w: prompt max_tokens: %v", types.ErrPayloadMismatch, err)
+	}
+	if bodyMaxTokens > p.MaxTokens {
+		return fmt.Errorf("%w: prompt max_tokens %d exceeds declared %d", types.ErrPayloadMismatch, bodyMaxTokens, p.MaxTokens)
 	}
 	return nil
 }

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -604,6 +604,76 @@ func TestHost_PayloadMismatch_Params(t *testing.T) {
 	require.ErrorIs(t, err, types.ErrPayloadMismatch)
 }
 
+func TestHost_PayloadMismatch_InputLengthWorkload(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	h := newTestHost(t, 1, hosts, user, 10000, 10)
+
+	// Large prompt signed/reported with underreported input_length.
+	largePrompt := []byte(`{"model":"llama","messages":[{"role":"user","content":"A very large prompt / context goes here..."}],"max_tokens":50}`)
+	promptHash, err := devshard.CanonicalPromptHash(largePrompt)
+	require.NoError(t, err)
+	start := &types.MsgStartInference{
+		InferenceId: 1,
+		PromptHash:  promptHash,
+		Model:       "llama",
+		InputLength: 0,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{
+		{Tx: &types.DevshardTx_StartInference{StartInference: start}},
+	})
+	_, err = h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{diff},
+		Nonce: 1,
+		Payload: &InferencePayload{
+			Prompt:      largePrompt,
+			Model:       "llama",
+			InputLength: 0,
+			MaxTokens:   50,
+			StartedAt:   1000,
+		},
+	})
+	require.ErrorIs(t, err, types.ErrPayloadMismatch)
+	require.Contains(t, err.Error(), "input_length")
+}
+
+func TestHost_PayloadMismatch_MaxTokensWorkload(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	h := newTestHost(t, 1, hosts, user, 10000, 10)
+
+	// Body asks for 1000 tokens while signed reserve only covers 1.
+	prompt := []byte(`{"model":"llama","messages":[{"role":"user","content":"hi"}],"max_tokens":1000}`)
+	promptHash, err := devshard.CanonicalPromptHash(prompt)
+	require.NoError(t, err)
+	start := &types.MsgStartInference{
+		InferenceId: 1,
+		PromptHash:  promptHash,
+		Model:       "llama",
+		InputLength: uint64(len(prompt)),
+		MaxTokens:   1,
+		StartedAt:   1000,
+	}
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{
+		{Tx: &types.DevshardTx_StartInference{StartInference: start}},
+	})
+	_, err = h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{diff},
+		Nonce: 1,
+		Payload: &InferencePayload{
+			Prompt:      prompt,
+			Model:       "llama",
+			InputLength: uint64(len(prompt)),
+			MaxTokens:   1,
+			StartedAt:   1000,
+		},
+	})
+	require.ErrorIs(t, err, types.ErrPayloadMismatch)
+	require.Contains(t, err.Error(), "max_tokens")
+}
+
 func TestHost_StoresOwnSignature(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	user := testutil.MustGenerateKey(t)

--- a/devshard/internal/testutil/testutil.go
+++ b/devshard/internal/testutil/testutil.go
@@ -13,7 +13,10 @@ import (
 
 var deterministicMarshal = proto.MarshalOptions{Deterministic: true}
 
-var TestPrompt = []byte(`{"model":"llama","messages":[{"role":"user","content":"prompt"}]}`)
+// TestPrompt is exactly 100 bytes and includes max_tokens:50 so host workload
+// checks (input_length == len(prompt), body max_tokens <= declared) pass with
+// the StartTx defaults below.
+var TestPrompt = []byte(`{"model":"llama","messages":[{"role":"user","content":"xxxxxxxxxxxxxxxxxxxxxxxxx"}],"max_tokens":50}`)
 var TestPromptHash = mustCanonicalPromptHash(TestPrompt)
 
 func mustCanonicalPromptHash(prompt []byte) [32]byte {

--- a/devshard/protocol/protocol_test.go
+++ b/devshard/protocol/protocol_test.go
@@ -554,14 +554,15 @@ func TestProtocol_VaryingInferenceCosts(t *testing.T) {
 	env := setupEnv(t, 3, 1000000, 100, engines...)
 	ctx := context.Background()
 
-	// Send 6 inferences with different params.
+	// Send 6 inferences. Accounting must cover the shared TestPrompt workload;
+	// MaxTokens may over-reserve, InputLength must equal len(prompt).
 	paramsList := []user.InferenceParams{
 		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: 1000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 200, MaxTokens: 100, StartedAt: 2000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 50, MaxTokens: 25, StartedAt: 3000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 150, MaxTokens: 75, StartedAt: 4000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 80, MaxTokens: 40, StartedAt: 5000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 60, MaxTokens: 30, StartedAt: 6000},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 100, StartedAt: 2000},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: 3000},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 75, StartedAt: 4000},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: 5000},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: 6000},
 	}
 
 	for _, p := range paramsList {


### PR DESCRIPTION
## Summary

- Host `VerifyPayload` now binds signed accounting fields to the actual prompt workload: `input_length` must equal prompt byte length, and declared `max_tokens` must cover the body’s effective limit (`max_tokens` / `max_completion_tokens`, else default).
- Underreported reserves (large prompt / high body `max_tokens` with tiny signed fields) are rejected before execution instead of running underpriced work.
- Adds `completionapi.EffectiveMaxTokens` so host checks use the same effective limit rule as ML request preparation.

## Test plan

- [x] `go test ./host/ ./protocol/ ./transport/ ./user/` in `devshard`
- [x] `go test ./completionapi/ -run 'MaxTokens|Effective'` in `common`
- [x] New host tests for underreported `input_length` and body `max_tokens`