### PR TITLE
fix(x/inference): derive pricing capacity from per-model throughput per tokenomics-v2 spec

### DIFF
--- a/inference-chain/x/inference/epochgroup/epoch_group.go
+++ b/inference-chain/x/inference/epochgroup/epoch_group.go
@@ -177,6 +177,7 @@ func (eg *EpochGroup) updateEpochGroupWithNewMember(ctx context.Context, member 
 	})
 
 	mlNodes := eg.getMLNodeInfo(member, eg.GroupData.ModelId)
+	eg.populateNodeThroughputs(ctx, mlNodes, eg.GroupData.ModelId)
 	votingPower := eg.getVotingPowerForModel(member, eg.GroupData.ModelId)
 
 	eg.GroupData.ValidationWeights = append(eg.GroupData.ValidationWeights, &types.ValidationWeight{

--- a/inference-chain/x/inference/epochgroup/throughput.go
+++ b/inference-chain/x/inference/epochgroup/throughput.go
@@ -1,0 +1,63 @@
+package epochgroup
+
+import (
+	"context"
+	"math"
+	"math/big"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// computeMLNodeThroughput returns tokens/second for a node given its PoC weight and
+// the governance model's throughput parameters.
+//
+// UNITS ASSUMPTION: throughput_per_nonce is compute-units/second per nonce of PoC
+// weight; units_of_compute_per_token converts that to tokens/second:
+//
+//	Throughput = PocWeight * ThroughputPerNonce / UnitsOfComputePerToken
+//
+// Pure integer arithmetic (consensus-critical). Zero inputs yield 0. Products that
+// overflow int64 are truncated to math.MaxInt64.
+func computeMLNodeThroughput(pocWeight int64, throughputPerNonce, unitsOfComputePerToken uint64) int64 {
+	if pocWeight <= 0 || throughputPerNonce == 0 || unitsOfComputePerToken == 0 {
+		return 0
+	}
+
+	num := new(big.Int).Mul(big.NewInt(pocWeight), new(big.Int).SetUint64(throughputPerNonce))
+	den := new(big.Int).SetUint64(unitsOfComputePerToken)
+	result := new(big.Int).Quo(num, den)
+	if !result.IsInt64() {
+		if result.Sign() < 0 {
+			return 0
+		}
+		return math.MaxInt64
+	}
+	return result.Int64()
+}
+
+// populateNodeThroughputs sets MLNodeInfo.Throughput from the governance model
+// for this subgroup. Called immediately before TotalThroughput is summed so the
+// capacity path can prefer real tokens/s over the TotalWeight proxy.
+func (eg *EpochGroup) populateNodeThroughputs(ctx context.Context, mlNodes []*types.MLNodeInfo, modelId string) {
+	// Resolve model params up front; leave them at zero when the model is
+	// missing / has no keeper / has zero params. computeMLNodeThroughput then
+	// yields 0 for every node in those cases.
+	var throughputPerNonce, unitsOfComputePerToken uint64
+	if modelId != "" && eg.ModelKeeper != nil {
+		if model, found := eg.ModelKeeper.GetGovernanceModel(ctx, modelId); found && model != nil {
+			throughputPerNonce = model.ThroughputPerNonce
+			unitsOfComputePerToken = model.UnitsOfComputePerToken
+		}
+	}
+
+	// Always overwrite Throughput so a node preserved from a prior epoch (whose
+	// pointer/value carried last epoch's computed throughput) never leaks a stale
+	// nonzero value into TotalThroughput — that would defeat the TotalWeight
+	// fallback for zero-param / legacy models.
+	for _, node := range mlNodes {
+		if node == nil {
+			continue
+		}
+		node.Throughput = computeMLNodeThroughput(node.PocWeight, throughputPerNonce, unitsOfComputePerToken)
+	}
+}

--- a/inference-chain/x/inference/epochgroup/throughput_test.go
+++ b/inference-chain/x/inference/epochgroup/throughput_test.go
@@ -1,0 +1,180 @@
+package epochgroup
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeMLNodeThroughput(t *testing.T) {
+	t.Run("normal case", func(t *testing.T) {
+		// Kimi-scale example from spec: 95298 * 1500 / 10000 = 14294
+		got := computeMLNodeThroughput(95298, 1500, 10000)
+		require.Equal(t, int64(14294), got)
+	})
+
+	t.Run("zero ThroughputPerNonce", func(t *testing.T) {
+		require.Equal(t, int64(0), computeMLNodeThroughput(100, 0, 1000))
+	})
+
+	t.Run("zero UnitsOfComputePerToken", func(t *testing.T) {
+		require.Equal(t, int64(0), computeMLNodeThroughput(100, 1000, 0))
+	})
+
+	t.Run("zero PocWeight", func(t *testing.T) {
+		require.Equal(t, int64(0), computeMLNodeThroughput(0, 1000, 1000))
+	})
+
+	t.Run("negative PocWeight", func(t *testing.T) {
+		require.Equal(t, int64(0), computeMLNodeThroughput(-1, 1000, 1000))
+	})
+
+	t.Run("large product near int64 bounds truncates to MaxInt64", func(t *testing.T) {
+		// math.MaxInt64 * 2 / 1 overflows int64; must not wrap, clamp to MaxInt64
+		got := computeMLNodeThroughput(math.MaxInt64, 2, 1)
+		require.Equal(t, int64(math.MaxInt64), got)
+	})
+
+	t.Run("large values that still fit", func(t *testing.T) {
+		// 1e15 * 1000 / 1000 = 1e15, well within int64
+		got := computeMLNodeThroughput(1_000_000_000_000_000, 1000, 1000)
+		require.Equal(t, int64(1_000_000_000_000_000), got)
+	})
+}
+
+type mockModelKeeper struct {
+	models map[string]*types.Model
+}
+
+func (m *mockModelKeeper) GetGovernanceModel(ctx context.Context, id string) (*types.Model, bool) {
+	model, found := m.models[id]
+	return model, found
+}
+
+func (m *mockModelKeeper) GetGovernanceModels(ctx context.Context) ([]*types.Model, error) {
+	list := make([]*types.Model, 0, len(m.models))
+	for _, model := range m.models {
+		list = append(list, model)
+	}
+	return list, nil
+}
+
+type mockEpochGroupDataKeeper struct {
+	data map[string]types.EpochGroupData
+}
+
+func epochGroupKey(epochIndex uint64, modelId string) string {
+	return fmt.Sprintf("%d|%s", epochIndex, modelId)
+}
+
+func (m *mockEpochGroupDataKeeper) SetEpochGroupData(ctx context.Context, epochGroupData types.EpochGroupData) {
+	if m.data == nil {
+		m.data = make(map[string]types.EpochGroupData)
+	}
+	m.data[epochGroupKey(epochGroupData.EpochIndex, epochGroupData.ModelId)] = epochGroupData
+}
+
+func (m *mockEpochGroupDataKeeper) GetEpochGroupData(ctx context.Context, epochIndex uint64, modelId string) (types.EpochGroupData, bool) {
+	val, found := m.data[epochGroupKey(epochIndex, modelId)]
+	return val, found
+}
+
+func (m *mockEpochGroupDataKeeper) RemoveEpochGroupData(ctx context.Context, epochIndex uint64, modelId string) {
+	delete(m.data, epochGroupKey(epochIndex, modelId))
+}
+
+func (m *mockEpochGroupDataKeeper) GetAllEpochGroupData(ctx context.Context) []types.EpochGroupData {
+	out := make([]types.EpochGroupData, 0, len(m.data))
+	for _, v := range m.data {
+		out = append(out, v)
+	}
+	return out
+}
+
+func TestUpdateEpochGroupWithNewMember_PopulatesTotalThroughput(t *testing.T) {
+	modelId := "kimi-k2"
+	groupDataKeeper := &mockEpochGroupDataKeeper{data: map[string]types.EpochGroupData{}}
+	modelKeeper := &mockModelKeeper{
+		models: map[string]*types.Model{
+			modelId: {
+				Id:                     modelId,
+				ThroughputPerNonce:     1500,
+				UnitsOfComputePerToken: 10000,
+			},
+		},
+	}
+
+	initial := types.EpochGroupData{
+		EpochIndex: 1,
+		ModelId:    modelId,
+	}
+	groupDataKeeper.SetEpochGroupData(context.Background(), initial)
+
+	eg := &EpochGroup{
+		Logger:          &mockLogger{},
+		ModelKeeper:     modelKeeper,
+		GroupDataKeeper: groupDataKeeper,
+		GroupData:       &initial,
+	}
+
+	node1 := &types.MLNodeInfo{NodeId: "n1", PocWeight: 10000}
+	node2 := &types.MLNodeInfo{NodeId: "n2", PocWeight: 20000}
+	member := EpochMember{
+		Address: "participant-1",
+		Weight:  30000,
+		Models:  []string{modelId},
+		MlNodes: []*types.ModelMLNodes{{MlNodes: []*types.MLNodeInfo{node1, node2}}},
+	}
+
+	eg.updateEpochGroupWithNewMember(context.Background(), member, initial)
+
+	// 10000*1500/10000 + 20000*1500/10000 = 1500 + 3000 = 4500
+	require.Equal(t, int64(4500), eg.GroupData.TotalThroughput)
+	require.Equal(t, int64(1500), node1.Throughput)
+	require.Equal(t, int64(3000), node2.Throughput)
+
+	stored, found := groupDataKeeper.GetEpochGroupData(context.Background(), 1, modelId)
+	require.True(t, found)
+	require.Equal(t, int64(4500), stored.TotalThroughput)
+}
+
+func TestUpdateEpochGroupWithNewMember_ZeroModelParamsLeavesThroughputZero(t *testing.T) {
+	modelId := "legacy-model"
+	groupDataKeeper := &mockEpochGroupDataKeeper{data: map[string]types.EpochGroupData{}}
+	modelKeeper := &mockModelKeeper{
+		models: map[string]*types.Model{
+			modelId: {
+				Id:                     modelId,
+				ThroughputPerNonce:     0,
+				UnitsOfComputePerToken: 10000,
+			},
+		},
+	}
+
+	initial := types.EpochGroupData{EpochIndex: 1, ModelId: modelId}
+	eg := &EpochGroup{
+		Logger:          &mockLogger{},
+		ModelKeeper:     modelKeeper,
+		GroupDataKeeper: groupDataKeeper,
+		GroupData:       &initial,
+	}
+
+	// Pre-set a stale nonzero Throughput as a preserved node from a prior epoch
+	// would carry. The zero-param path must overwrite it back to 0 so it does not
+	// leak into TotalThroughput and defeat the TotalWeight fallback.
+	node := &types.MLNodeInfo{NodeId: "n1", PocWeight: 100, Throughput: 999}
+	member := EpochMember{
+		Address: "p1",
+		Weight:  100,
+		Models:  []string{modelId},
+		MlNodes: []*types.ModelMLNodes{{MlNodes: []*types.MLNodeInfo{node}}},
+	}
+
+	eg.updateEpochGroupWithNewMember(context.Background(), member, initial)
+	require.Equal(t, int64(0), eg.GroupData.TotalThroughput)
+	require.Equal(t, int64(0), node.Throughput)
+}

--- a/inference-chain/x/inference/keeper/dynamic_pricing.go
+++ b/inference-chain/x/inference/keeper/dynamic_pricing.go
@@ -349,16 +349,16 @@ func (k *Keeper) CacheAllModelCapacities(ctx context.Context) error {
 			continue
 		}
 
-		// TODO: The proposal mentions copying from a `total_throughput` field, but this field
-		// doesn't exist in the current EpochGroupData structure. For now, we use TotalWeight
-		// as a proxy for capacity (tokens per second), as 1000 nonce of PoC produce aproximetely
-		// 1000 tokens for of QwQ-32B model. In a future task, we need to:
-		// 1. Add `total_throughput` field to EpochGroupData proto
-		// 2. Update this function to use the actual throughput data (tokens/second)
-		// 3. Implement logic to calculate/set throughput during epoch formation
-		capacity := modelEpochData.TotalWeight
+		// Prefer TotalThroughput (tokens/s summed from per-node Throughput at epoch
+		// formation). Fall back to TotalWeight as a QwQ-calibrated proxy (≈1000 nonce
+		// ≈ 1000 tokens/s for QwQ-32B) when throughput is unset — e.g. the epoch before
+		// a coordinated upgrade, or models with zero ThroughputPerNonce /
+		// UnitsOfComputePerToken. Default 1000 when both are zero.
+		capacity := modelEpochData.TotalThroughput
 		if capacity <= 0 {
-			// Set a reasonable default capacity for models with no weight
+			capacity = modelEpochData.TotalWeight
+		}
+		if capacity <= 0 {
 			capacity = 1000 // 1K tokens per second as default
 			k.LogWarn("Using default capacity for model with zero total weight", types.Pricing,
 				"modelId", modelId, "defaultCapacityPerSec", capacity)

--- a/inference-chain/x/inference/keeper/dynamic_pricing_test.go
+++ b/inference-chain/x/inference/keeper/dynamic_pricing_test.go
@@ -244,6 +244,61 @@ func TestModelCapacityCaching(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestCacheAllModelCapacities_PrefersTotalThroughput verifies capacity selection:
+// TotalThroughput when > 0, else TotalWeight proxy, else default 1000.
+func TestCacheAllModelCapacities_PrefersTotalThroughput(t *testing.T) {
+	k, ctx := setupTestKeeperWithDynamicPricing(t)
+	goCtx := sdk.UnwrapSDKContext(ctx)
+
+	const epochIndex uint64 = 1
+	require.NoError(t, k.SetEffectiveEpochIndex(goCtx, epochIndex))
+
+	k.SetEpochGroupData(goCtx, types.EpochGroupData{
+		EpochIndex:     epochIndex,
+		ModelId:        "",
+		SubGroupModels: []string{"model-throughput", "model-weight", "model-default"},
+	})
+
+	// Prefer TotalThroughput over TotalWeight when both are set.
+	k.SetEpochGroupData(goCtx, types.EpochGroupData{
+		EpochIndex:      epochIndex,
+		ModelId:         "model-throughput",
+		TotalThroughput: 5000,
+		TotalWeight:     9999, // must be ignored when TotalThroughput > 0
+	})
+
+	// Fall back to TotalWeight when TotalThroughput is 0.
+	k.SetEpochGroupData(goCtx, types.EpochGroupData{
+		EpochIndex:      epochIndex,
+		ModelId:         "model-weight",
+		TotalThroughput: 0,
+		TotalWeight:     2500,
+	})
+
+	// Default 1000 when both TotalThroughput and TotalWeight are 0.
+	k.SetEpochGroupData(goCtx, types.EpochGroupData{
+		EpochIndex:      epochIndex,
+		ModelId:         "model-default",
+		TotalThroughput: 0,
+		TotalWeight:     0,
+	})
+
+	err := k.CacheAllModelCapacities(goCtx)
+	require.NoError(t, err)
+
+	capacity, err := k.GetCachedModelCapacity(goCtx, "model-throughput")
+	require.NoError(t, err)
+	require.Equal(t, int64(5000), capacity)
+
+	capacity, err = k.GetCachedModelCapacity(goCtx, "model-weight")
+	require.NoError(t, err)
+	require.Equal(t, int64(2500), capacity)
+
+	capacity, err = k.GetCachedModelCapacity(goCtx, "model-default")
+	require.NoError(t, err)
+	require.Equal(t, int64(1000), capacity)
+}
+
 // TestModelCurrentPriceStorage tests KV storage for current prices
 func TestModelCurrentPriceStorage(t *testing.T) {
 	k, ctx := setupTestKeeperWithDynamicPricing(t)

--- a/inference-chain/x/inference/module/model_assignment.go
+++ b/inference-chain/x/inference/module/model_assignment.go
@@ -357,9 +357,10 @@ func sumLiveRootTotalWeight(rootData types.EpochGroupData, liveRootSet map[strin
 }
 
 func (ma *ModelAssigner) setModelsForParticipants(ctx context.Context, participants []*types.ActiveParticipant, upcomingEpoch types.Epoch) {
-	// TODO: We may need to populate throughput in MLNodeInfo using the model's ThroughputPerNonce
-	// This would ensure consistent throughput calculations based on governance model parameters
-	// rather than relying on hardware node declarations alone.
+	// MLNodeInfo.Throughput is populated later at epoch-group formation
+	// (epochgroup.updateEpochGroupWithNewMember) from the governance model's
+	// ThroughputPerNonce / UnitsOfComputePerToken, once the final model assignment
+	// is known. See proposals/tokenomics-v2/dynamic-pricing.md.
 	ma.LogInfo("Starting model and slot assignment for participants", types.Allocation, "flow_context", FlowContext, "step", "start", "num_participants", len(participants), "epoch_index", upcomingEpoch.Index)
 
 	governanceModels, err := ma.keeper.GetGovernanceModelsSorted(ctx)


### PR DESCRIPTION
# fix(x/inference): derive pricing capacity from per-model throughput per tokenomics-v2 spec

Part 2 of 2 for #1450 — replace the raw `TotalWeight` pricing-capacity proxy
with per-model throughput derived from the model registry.

Dynamic pricing utilization = `load / (capacity × 5s)`. `CacheAllModelCapacities`
(`inference-chain/x/inference/keeper/dynamic_pricing.go`) sets
`capacity := modelEpochData.TotalWeight` — raw PoC nonce weight treated as
tokens/second, calibrated once against QwQ-32B. Per-nonce throughput varies
strongly by model (~7× across the three currently served), so a single
`weight × 1` constant puts the 0.40–0.60 stability band at a different (and
unknown) *true* utilization for every model. This PR derives capacity from the
registry's per-model throughput instead, per `tokenomics-v2/dynamic-pricing.md`
§2.2.3.

<details><summary>Why this is needed — analysis excerpt</summary>

**The formula.** Per model, per block:

```
utilization = averageLoadPerBlock / (capacity × 5s)
0.40 ≤ u ≤ 0.60 → no change; below → down (≤2%/block); above → up (≤2%/block)
```

The numerator is a rolling ~60s average of real `prompt + completion` tokens of
completed inferences of that model — fine. The denominator is a proxy the code
itself flags as temporary:

```go
// TODO: The proposal mentions copying from a `total_throughput` field, but this field
// doesn't exist in the current EpochGroupData structure. For now, we use TotalWeight
// as a proxy for capacity (tokens per second), as 1000 nonce of PoC produce aproximetely
// 1000 tokens for of QwQ-32B model. ...
capacity := modelEpochData.TotalWeight
```

So the ratio assumes **1 PoC nonce ≈ 1 token/s, calibrated on QwQ-32B**, applied
uniformly to every model. No per-model normalization enters this weight upstream:
a sub-group's member weight is the sum of raw `PocWeight` (the code comment says
"no coefficient"), and the per-model `weight_scale_factor` applies only to rewards
and consensus voting weight, never to the pricing denominator.

**The on-chain registry says the constant can't be right.** Each model carries a
per-model `throughput_per_nonce` (mainnet values via `.../inference/models_all`):

| model | `throughput_per_nonce` |
|---|---|
| `MiniMaxAI/MiniMax-M2.7` | 5000 |
| `moonshotai/Kimi-K2.6` | 1500 |
| `zai-org/GLM-5.2-FP8` | 700 |

A 7× spread across the three served models. The same nonce buys very different
token throughput per model, so the `weight × 1` constant makes the stability band
sit at a different true hardware utilization for each.

**A second on-chain conversion disagrees by ~12–16×.** The devshard gateway's
admission control converts the *same* raw weight into serving capacity at 5
concurrent requests per 10,000 weight per devshard instance
(`devshard/cmd/devshardctl/gateway_limiter.go`); across uncoordinated shards the
workable network total is roughly 32 concurrent per 10,000 weight (a rough Gonka-
team figure, not on-chain). At ~20–26 tok/s decode per Kimi stream that is
~640–830 tok/s per 10,000 weight, while the pricing keeper assumes 10,000 tok/s
for the same weight — a ~12–16× disagreement, both conversions model-uniform.

**Kimi K2.6 concretely** (live, epoch 326, 2026-07-14): sub-group `TotalWeight` is
**95,298**, so the keeper assumes ~95k tok/s. The price stops falling only above
~38k tok/s (U = 0.4) and rises only above ~57k tok/s (U = 0.6). Two independent
estimates of the fleet's real sustainable throughput land far below: a hardware
estimate (~65 B200-class GPUs, ~12–36k tok/s decode, overstatement ~3–8×) and a
concurrency estimate (~300 admittable streams × ~20–26 tok/s ≈ 6–8k tok/s,
overstatement ~12–16×). Either way the decode ceiling sits below the 0.40 lower
bound, so under organic decode-bound demand Kimi's utilization can never reach the
stability zone — the mechanism can only lower its price. (Sub-group weight is also
volatile, 38k–95k across recent epochs, so the thresholds swing ~2.5× per epoch.)

**Caveat (both directions).** Load counts `prompt + completion` equally and prefill
is far cheaper than decode, so a prompt-heavy workload can post completed-token
rates above decode throughput — the thresholds are unreachable for real demand yet
reachable by deliberate prompt-stuffing, making the signal manipulable upward.
Separately, rejected demand (429s under load) never becomes a completed inference,
so genuine congestion is invisible to this utilization signal.

**Units are unpinned.** The spec does not pin the units of `throughput_per_nonce`
(tokens/s per nonce? per 1000 nonces?). Whatever they are, the same nonce clearly
buys different throughput per model, so the fix must carry the per-model factor
through; this PR's specific unit reading is flagged for confirmation below.

</details>

## Spec alignment

`proposals/tokenomics-v2/dynamic-pricing.md` §2.2.3: at epoch activation the
system copies each model subgroup's `total_throughput` field into the
`capacity/{model_id}` KV store. This PR implements exactly that (and the two
in-tree TODOs at `model_assignment.go` and `dynamic_pricing.go`), nothing more.
The fix is half-built already: `EpochGroupData.TotalThroughput` exists and
`epoch_group.go` already sums `TotalThroughput += node.Throughput` — but
`MLNodeInfo.Throughput` is never assigned, so the sum is always 0 and the
capacity path falls back to `TotalWeight`.

## Implementation

- **Populate per-node throughput** (`epochgroup/throughput.go`, new):
  `populateNodeThroughputs` is called in
  `epochgroup.updateEpochGroupWithNewMember`, right after node selection and
  before the existing per-model `TotalThroughput` accumulation. This site has
  `ModelKeeper.GetGovernanceModel` access, runs after final model assignment,
  and needs no new keeper plumbing (chainvalidation lacks Model access;
  model_assignment's TODO is earlier and would bake the wrong model on
  reassignment).
- **Formula** (`computeMLNodeThroughput`, pure integer, `math/big`):
  `Throughput = PocWeight × ThroughputPerNonce / UnitsOfComputePerToken`.
  Zero/missing params → 0; products over int64 saturate to `math.MaxInt64`
  instead of wrapping.
- **Assignment is unconditional.** Every node's `Throughput` is overwritten each
  formation, including back to 0 for zero-param models. A node preserved from a
  prior epoch carries last epoch's computed value on its pointer; without an
  unconditional overwrite that stale nonzero would leak into `TotalThroughput`
  and silently defeat the `TotalWeight` fallback for legacy/zero-param models.
  (This is guarded by a dedicated test.)
- **Capacity fallback chain** (`CacheAllModelCapacities`):
  `TotalThroughput > 0` → else `TotalWeight` proxy → else default `1000`. The
  QwQ context in the comment is compressed, not deleted.

## Units assumption — please confirm

The spec does not pin the units of `throughput_per_nonce`. This PR reads it as
**compute-units/second per nonce of PoC weight**, with
`units_of_compute_per_token` converting to tokens/second. This uses only
existing fields, is dimensionally consistent, and yields sane magnitudes:
Kimi K2.6 at 95,298 subgroup weight → **14,294 tokens/s** (vs 95,298 under the
weight proxy). If the intended units differ, this is a **one-line change** in
`computeMLNodeThroughput`; the rest of the wiring is unaffected. Flagging
prominently because the whole calibration depends on this reading.

## Reader impact

Non-pricing readers of `MLNodeInfo.Throughput` are only the dedup tiebreaker
`compareMLNodePreference` (`module/model_assignment.go`) and log-only helpers.
The tiebreaker breaks ties on `Throughput` only *after* `PocWeight` is equal;
its `dedupMLNodesById` call operates on per-participant duplicates that differ
only in `Throughput` (overwritten at formation) and `TimeslotAllocation` (reset
downstream), so whichever copy it keeps is functionally identical — selection
and ordering are unchanged. `EpochGroupData.TotalThroughput` has no consumer
besides the epoch_group writer and the new capacity read. Populated Throughput
also persists in `ValidationWeights` and is copied into next-epoch rebuilds; the
same reasoning holds there.

## Rollout safety

Capacities re-cache each epoch; node throughput populates at the next formation.
The fix self-activates **one epoch after** a coordinated upgrade. Until then,
and for any model without registry data, the `TotalWeight` fallback preserves
current behavior exactly.

## Tests

`throughput_test.go` (normal case 95298×1500/10000=14294, each zero-param path,
negative weight, int64-bound saturation, large-in-range), the single-member
subgroup sum (`TotalThroughput` now nonzero after formation), the stale-value
overwrite guard, and `dynamic_pricing_test.go` capacity-selection
(TotalThroughput > TotalWeight > default 1000).

## Consensus impact

`TotalThroughput` and `MLNodeInfo.Throughput` become non-zero for models with
registry params, changing cached capacity and thus utilization/price
trajectories. **Consensus-breaking**; requires a coordinated upgrade.

## Out of scope (disclosed)

- Multi-member `TotalThroughput` accumulation across successive
  `updateEpochGroupWithNewMember` calls is not directly unit-tested (a
  single-member, two-node sum plus capacity selection are tested separately).
- The aggregate `int64` `TotalThroughput +=` sum is not overflow-saturated
  (only the per-node compute is); bounded far below int64 in practice.
- The fallback chain intentionally mixes units (tokens/s vs raw weight) when
  throughput data is absent — inherent to the spec's fallback design.
- Capacity is cached from the effective epoch group after
  `moveUpcomingToEffectiveGroup` — pre-existing timing semantics, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
