### PR TITLE
fix(devshard/mlnode): close response body on non-retryable status

### DIFF
--- a/devshard/mlnode/retry.go
+++ b/devshard/mlnode/retry.go
@@ -68,6 +68,10 @@ func DoWithNode(
 
 		// retry only on transport error
 		if outcome != gen.ReleaseOutcome_TRANSPORT_ERROR {
+			// Close body before returning: the response is not handed to the caller.
+			if resp != nil && resp.Body != nil {
+				_ = resp.Body.Close()
+			}
 			return nil, err
 		}
 

--- a/devshard/mlnode/retry_test.go
+++ b/devshard/mlnode/retry_test.go
@@ -180,6 +180,23 @@ func TestDoWithNode_4xx_NoRetry(t *testing.T) {
 	assert.Equal(t, gen.ReleaseOutcome_APPLICATION_ERROR, lock.releases[0].outcome)
 }
 
+func TestDoWithNode_4xx_ClosesBody(t *testing.T) {
+	lock := &stubLock{
+		acquires: []acquireResult{{nodeID: "node-1", endpoint: "http://node1", lockID: "lock-1"}},
+	}
+
+	body := &trackingBody{Reader: strings.NewReader("error body")}
+
+	_, err := mlnode.DoWithNode(context.Background(), lock, "model-a", 3,
+		func(_ context.Context, _ string) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusBadRequest, Body: body}, nil
+		},
+	)
+
+	require.Error(t, err)
+	assert.True(t, body.isClosed(), "4xx response body must be closed before returning to avoid connection leak")
+}
+
 func TestDoWithNode_Timeout_StopsRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	lock := &stubLock{


### PR DESCRIPTION
## What problem does this solve?

`DoWithNode` leaks HTTP response bodies (and therefore connections/file descriptors) when a node returns a non-retryable status (4xx/3xx/1xx). Under repeated client-error responses from a node, connections are never returned to the transport pool.

## How do you know this is a real problem?

In `devshard/mlnode/retry.go`, on a non-retryable outcome `runAttempt` returns a **non-nil** `*http.Response` (with `APPLICATION_ERROR`), and `DoWithNode` then hits `if outcome != gen.ReleaseOutcome_TRANSPORT_ERROR { return nil, err }` and returns `nil` to the caller **without closing `resp.Body`**. The response is orphaned — the caller receives `nil` and can never close it. The 5xx retry path already closes the body before retrying (and is covered by `TestDoWithNode_5xx_ClosesBodyBeforeRetry`); the non-retryable path was simply missed. The existing `TestDoWithNode_4xx_NoRetry` uses a no-op body, so it never caught the leak.

## How does this solve the problem?

Close the response body on the non-retryable branch before returning, using the same guarded idiom as the existing 5xx path:

```go
// Close body before returning: the response is not handed to the caller.
if resp != nil && resp.Body != nil {
    _ = resp.Body.Close()
}
```

The `nil` guard also covers the timeout/transport path where `runAttempt` returns a nil response. The success path returns earlier (`if err == nil`) and hands the body to the caller unclosed, so there is no double-close and no risk of closing a body the caller still owns.

## What risks does this introduce? How can we mitigate them?

Minimal. The two close sites (5xx retry, non-retryable return) are mutually exclusive by `outcome`; the success path is untouched. No behavior change for callers beyond the connection now being released as intended. Guarded against nil resp/body.

## How do you know this PR fixes the problem?

Added a fail-first regression test `TestDoWithNode_4xx_ClosesBody` mirroring the 5xx test: a 400 response with a tracking body, asserting `isClosed()` after `DoWithNode` returns. It **fails on the current code** (body not closed) and **passes with the fix**.

## Which components are affected?

- `devshard/mlnode/retry.go`
- `devshard/mlnode/retry_test.go` (new test)

## Testing & evidence

`GOTOOLCHAIN=go1.24.2 go test ./mlnode/...` and `go vet ./mlnode/...`, run natively (devshard is its own module, no cgo).

### Before
```
=== RUN   TestDoWithNode_4xx_ClosesBody
    retry_test.go:197:
        	Error:      	Should be true
        	Messages:   	4xx response body must be closed before returning to avoid connection leak
--- FAIL: TestDoWithNode_4xx_ClosesBody (0.00s)
FAIL	devshard/mlnode	0.018s
```

### After
```
--- PASS: TestDoWithNode_4xx_ClosesBody (0.00s)
ok  	devshard/mlnode	0.055s   # full package suite, all pre-existing tests pass
# go vet ./mlnode/...  -> clean
```
