### PR TITLE
fix(devshard/user): guard lazy finalizeClients init against data race

### DIFF
--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -1234,8 +1234,11 @@ func (s *Session) hasQuorum(nonce uint64, threshold uint32) bool {
 // getFinalizeClients returns a client list with admission control stripped.
 // Built lazily and cached on s.finalizeClients. Each client that implements
 // a ClearAdmission method gets a shallow copy with admission disabled;
-// others are used as-is.
+// others are used as-is. Safe for concurrent use: CollectSignatures can run
+// simultaneously from Finalize and the debug collect-signatures endpoint.
 func (s *Session) getFinalizeClients() []HostClient {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.finalizeClients != nil {
 		return s.finalizeClients
 	}

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -1157,3 +1157,35 @@ func TestFinalize_SignatureStatus_InsufficientQuorum(t *testing.T) {
 		require.Less(t, finalEntry.SigWeight, uint32(4))
 	}
 }
+
+// TestUser_GetFinalizeClientsConcurrent verifies the lazy finalizeClients
+// init is safe under concurrent access. CollectSignatures (which triggers
+// the init) is reachable simultaneously from Finalize and from the public
+// debug endpoint POST /v1/debug/signatures/collect, so two goroutines can
+// hit the check-then-write at the same time. Run with -race.
+func TestUser_GetFinalizeClientsConcurrent(t *testing.T) {
+	const numHosts = 3
+	session, _, _ := setupSession(t, numHosts, 100000, 10)
+
+	const goroutines = 16
+	results := make([][]HostClient, goroutines)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			<-start
+			results[g] = session.getFinalizeClients()
+		}(g)
+	}
+	close(start)
+	wg.Wait()
+
+	for g, res := range results {
+		require.Len(t, res, numHosts, "goroutine %d got wrong client count", g)
+		for i, c := range res {
+			require.NotNil(t, c, "goroutine %d saw nil client at slot %d", g, i)
+		}
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

`Session.getFinalizeClients` performs an unsynchronized lazy initialization of the shared `s.finalizeClients` field, racing when the same session is hit concurrently. This produces a data race (flagged by `-race`) and can yield a torn/partial client list.

## How do you know this is a real problem?

In `devshard/user/session.go`, `getFinalizeClients` does a check-then-write outside any lock — `if s.finalizeClients != nil { return ... }` … else `s.finalizeClients = make(...)` — while every other `Session` field is guarded by `s.mu` (a `sync.Mutex`). It is reached from `CollectSignatures`, which is invoked both from `Finalize` **and directly from the public HTTP endpoint** `handleCollectSignatures` (`POST /v1/debug/signatures/collect`, `cmd/devshardctl/proxy.go`). Two concurrent requests against one session race on the field. `go test -race` reproduces it deterministically (trace below).

## How does this solve the problem?

Guard the lazy init with the session's existing mutex:

```go
s.mu.Lock()
defer s.mu.Unlock()
```

Verified this is deadlock-free: the sole caller (`CollectSignatures`) does not hold `s.mu` at the call site (it acquires the lock only later), and the returned slice is assigned once and never mutated, so it is safely published under the lock.

## What risks does this introduce? How can we mitigate them?

Low. Adds one mutex acquisition on a path that already synchronizes elsewhere; matches the struct's uniform locking discipline (same pattern as neighboring methods). No new field, no lock-ordering change. Deadlock ruled out by confirming no caller holds `s.mu` when reaching this method.

## How do you know this PR fixes the problem?

Added `TestUser_GetFinalizeClientsConcurrent`: 16 goroutines released simultaneously, each calling `getFinalizeClients`, asserting a consistent result. It reports a **DATA RACE** on the current code under `-race` and **passes cleanly with the fix**.

## Which components are affected?

- `devshard/user/session.go`
- `devshard/user/session_test.go` (new test)

## Testing & evidence

`GOTOOLCHAIN=go1.24.2 go test ./user/... -race` and `go vet ./user/...`, native.

### Before
```
WARNING: DATA RACE
Write at 0x00c0001478e0 by goroutine 16:
  devshard/user.(*Session).getFinalizeClients()
      devshard/user/session.go:1245 +0x96
Previous read at 0x00c0001478e0 by goroutine 25:
  devshard/user.(*Session).getFinalizeClients()
      devshard/user/session.go:1253 +0x224
...
--- FAIL: TestUser_GetFinalizeClientsConcurrent (0.03s)
    testing.go:1490: race detected during execution of test
FAIL	devshard/user	0.084s
```

### After
```
ok  	devshard/user	5.412s   # full package under -race
# go vet ./user/...  -> clean
```
