### PR TITLE
fix(devshard/host): return challenge receipt without blocking on execution

### DIFF
--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -840,8 +840,14 @@ func (h *Host) signReceipt(req HostRequest) ([]byte, int64, *devshard.ExecuteReq
 
 // executeAsync runs inference and adds MsgFinishInference to the mempool.
 // Delegates to RunExecution which also caches the response body for reconnection.
+// The caller must not wait for the inference: it holds a request context whose
+// deadline is far shorter than a long generation, and the executor receipt is
+// already signed. Detaching from cancellation keeps MsgFinishInference on track
+// even after the challenging host hangs up.
 func (h *Host) executeAsync(ctx context.Context, job *devshard.ExecuteRequest) {
-	_, _ = h.RunExecution(ctx, job)
+	go func() {
+		_, _ = h.RunExecution(context.WithoutCancel(ctx), job)
+	}()
 }
 
 func (h *Host) ReleaseExecution(inferenceID uint64) {

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1235,6 +1235,43 @@ func (e *blockingInferenceEngine) Execute(ctx context.Context, req devshard.Exec
 	}
 }
 
+// ctxCapturingInferenceEngine blocks like blockingInferenceEngine, but also
+// records the ctx Execute received, so a test can inspect it (e.g. after the
+// request context is cancelled) instead of inferring detachment indirectly.
+type ctxCapturingInferenceEngine struct {
+	inner   *stub.InferenceEngine
+	started chan struct{}
+	release chan struct{}
+
+	mu  sync.Mutex
+	ctx context.Context
+}
+
+func newCtxCapturingInferenceEngine() *ctxCapturingInferenceEngine {
+	return &ctxCapturingInferenceEngine{
+		inner:   stub.NewInferenceEngine(),
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (e *ctxCapturingInferenceEngine) Execute(ctx context.Context, req devshard.ExecuteRequest) (*devshard.ExecuteResult, error) {
+	// Publish ctx before signaling started, so the test can safely read it
+	// as soon as it observes started.
+	e.mu.Lock()
+	e.ctx = ctx
+	e.mu.Unlock()
+	e.started <- struct{}{}
+	<-e.release
+	return e.inner.Execute(ctx, req)
+}
+
+func (e *ctxCapturingInferenceEngine) executionCtx() context.Context {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.ctx
+}
+
 func TestHost_ChallengeReceipt_DoesNotBlockOnExecution(t *testing.T) {
 	// Regression: ChallengeReceipt used to run the inference synchronously, so a
 	// slow execution held the receipt past the verifier's timeout and a live
@@ -1285,6 +1322,53 @@ func TestHost_ChallengeReceipt_DoesNotBlockOnExecution(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return findMempoolFinish(h.MempoolTxs()) != nil
 	}, 5*time.Second, 10*time.Millisecond, "background execution must queue MsgFinishInference")
+}
+
+func TestHost_ChallengeReceipt_ExecutionSurvivesRequestCancel(t *testing.T) {
+	// Regression: ChallengeReceipt must detach execution from the request context
+	// (context.WithoutCancel), so a challenger that cancels/hangs up after
+	// receiving the receipt cannot abort the executor's in-flight inference.
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	engine := newCtxCapturingInferenceEngine()
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, cErr := h.ChallengeReceipt(ctx, 1, defaultPayload(), []types.Diff{diff})
+		errCh <- cErr
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("execution never started")
+	}
+	// executeAsync returns immediately after spawning execution, so
+	// ChallengeReceipt has already returned by the time Execute is running.
+	require.NoError(t, <-errCh)
+
+	execCtx := engine.executionCtx()
+	cancel() // synchronous: any derived context has Err() set once this returns
+	require.NoError(t, execCtx.Err(), "execution context must not observe the request cancellation")
+	require.Nil(t, execCtx.Done(), "execution context must be uncancellable")
+
+	// Execution is still alive; let it finish and confirm it actually
+	// completes, not just that it avoided the cancellation.
+	close(engine.release)
+	require.Eventually(t, func() bool {
+		return findMempoolFinish(h.MempoolTxs()) != nil
+	}, 5*time.Second, 10*time.Millisecond, "background execution must queue MsgFinishInference despite request cancel")
 }
 
 func TestWarmKey_HostFindsSlotByWarmKey(t *testing.T) {

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1209,6 +1209,84 @@ func TestHost_ChallengeReceipt_AlreadyFinished(t *testing.T) {
 	require.Equal(t, 1, engine.calls, "engine should not be called again")
 }
 
+// blockingInferenceEngine holds Execute open until released, so tests can observe
+// whether the caller waits for the inference to finish.
+type blockingInferenceEngine struct {
+	inner   *stub.InferenceEngine
+	started chan struct{}
+	release chan struct{}
+}
+
+func newBlockingInferenceEngine() *blockingInferenceEngine {
+	return &blockingInferenceEngine{
+		inner:   stub.NewInferenceEngine(),
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (e *blockingInferenceEngine) Execute(ctx context.Context, req devshard.ExecuteRequest) (*devshard.ExecuteResult, error) {
+	e.started <- struct{}{}
+	select {
+	case <-e.release:
+		return e.inner.Execute(ctx, req)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func TestHost_ChallengeReceipt_DoesNotBlockOnExecution(t *testing.T) {
+	// Regression: ChallengeReceipt used to run the inference synchronously, so a
+	// slow execution held the receipt past the verifier's timeout and a live
+	// executor was voted refused-timeout.
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	engine := newBlockingInferenceEngine()
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+
+	type challengeResult struct {
+		receipt     []byte
+		confirmedAt int64
+		err         error
+	}
+	resultCh := make(chan challengeResult, 1)
+	go func() {
+		receipt, confirmedAt, err := h.ChallengeReceipt(context.Background(), 1, defaultPayload(), []types.Diff{diff})
+		resultCh <- challengeResult{receipt: receipt, confirmedAt: confirmedAt, err: err}
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("execution never started")
+	}
+
+	// Execution is still in flight here, so the receipt can only arrive if
+	// ChallengeReceipt does not wait for it.
+	select {
+	case res := <-resultCh:
+		require.NoError(t, res.err)
+		require.NotNil(t, res.receipt, "receipt must return while execution is still running")
+		require.NotZero(t, res.confirmedAt, "receipt must carry confirmed_at")
+	case <-time.After(5 * time.Second):
+		t.Fatal("ChallengeReceipt blocked on execution instead of returning the receipt")
+	}
+
+	// The execution started by the challenge must still complete in the background.
+	close(engine.release)
+	require.Eventually(t, func() bool {
+		return findMempoolFinish(h.MempoolTxs()) != nil
+	}, 5*time.Second, 10*time.Millisecond, "background execution must queue MsgFinishInference")
+}
+
 func TestWarmKey_HostFindsSlotByWarmKey(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	warmSigner := testutil.MustGenerateKey(t)


### PR DESCRIPTION
## What problem does this solve?

`ChallengeReceipt` blocks on the full inference before returning the receipt, despite its contract being fire-and-forget. For any multi-second/minute inference, the verifier's bounded receipt RPC times out first, so a **live executor is wrongly voted as timed out**.

## How do you know this is a real problem?

In `devshard/host/host.go`, `ChallengeReceipt` calls `executeAsync`, which is `_, _ = h.RunExecution(ctx, job)` — synchronous, no `go`. But:

- The doc on `ChallengeReceipt` says it "signs an executor receipt, and **triggers async execution**".
- The `ExecutorClient` contract in `timeout.go` says it "returns a signed receipt … **Also triggers execution** so the inference actually completes" — receipt is the response; execution is a side effect, not a prerequisite.
- The function is literally named `executeAsync`; its sibling `validateAsync` already runs in a background goroutine.

Concrete harm: the verifier wraps the call in `VerifyTimeout` (default 3m). `VerifyRefusedTimeout` treats a client error as "executor unreachable → accept the timeout". A live executor whose long inference blocks the receipt response blows that RPC deadline and is wrongly timed out. The receipt (the liveness proof) never arrives even though the executor is healthy.

## How does this solve the problem?

Launch the execution in the background so the receipt returns immediately:

```go
go h.executeAsync(context.WithoutCancel(ctx), job)
```

`context.WithoutCancel` is required: the caller passes the request context, which echo cancels once the handler returns — a plain `go` with that context would kill the inference the contract requires to complete. WithoutCancel preserves observability values while surviving the RPC return (in-repo precedent: `mlnode/retry.go`).

Safety: the dedup guard `h.executing[inferenceID]` is set under `h.mu` **before** the job is returned, so the goroutine cannot double-execute; `RunExecution` already logs all its failures via `observability.FailReceiptOrphan` (nothing newly swallowed); the goroutine ends when execution returns and the map entry is cleared on defer (no leak).

## What risks does this introduce? How can we mitigate them?

- Execution now completes slightly later relative to the receipt. This is by design and correct: `VerifyRefusedTimeout` rejects on the receipt alone, and `VerifyExecutionTimeout` is a separate, later check anchored at `ConfirmedAt + ExecutionTimeout` — no path requires `MsgFinishInference` present before the receipt returns.
- `context.WithoutCancel` also strips the request **deadline** from `engine.Execute`. This matches the established `validateAsync` / `context.Background()` background-execution norm, and real engines self-bound their runtime — noted here for transparency.

## How do you know this PR fixes the problem?

Added `TestHost_ChallengeReceipt_ReturnsBeforeExecutionCompletes` with a gated (`blockingEngine`) execution seam: asserts `ChallengeReceipt` returns the receipt while the engine is still busy, then that execution still triggers and `MsgFinishInference` reaches the mempool afterward. It **fails on current code** (receipt blocks, 2.03s timeout) and **passes with the fix**.

## Which components are affected?

- `devshard/host/host.go`
- `devshard/host/host_test.go` (new test + seam)

## Testing & evidence

`GOTOOLCHAIN=go1.24.2 go test ./host/ -race`, `go test ./host/ ./transport/ ./user/`, `go vet`, native.

### Before
```
--- FAIL: TestHost_ChallengeReceipt_ReturnsBeforeExecutionCompletes (2.03s)
    ChallengeReceipt blocked on execution: receipt not returned while engine is busy
FAIL	devshard/host
```

### After
```
ok  	devshard/host      # -race
ok  	devshard/transport
ok  	devshard/user
# go vet -> clean on all three
```
