### PR TITLE
`devshard` H1 report. Stale diff must not authorize execution

### DIFF
--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -699,6 +699,10 @@ func (h *Host) findDiff(diffs []types.Diff, nonce uint64) *types.Diff {
 // signReceipt verifies the payload and signs the executor receipt (sync, under mutex).
 // Returns the receipt sig, confirmed_at timestamp, an ExecuteRequest if this host is the executor,
 // and cached response body if the inference already completed (reconnect case).
+//
+// Authorization comes from applied escrow state for req.Nonce, not from MsgStartInference
+// bytes in the request. applyAndPersist may skip stale diffs without verifying them; those
+// skipped bytes must never authorize execution.
 // Caller must hold h.mu.
 func (h *Host) signReceipt(req HostRequest) ([]byte, int64, *devshard.ExecuteRequest, []byte, receiptOutcome, error) {
 	outcome := receiptOutcome{reason: observability.ReasonNotExecutor}
@@ -706,90 +710,101 @@ func (h *Host) signReceipt(req HostRequest) ([]byte, int64, *devshard.ExecuteReq
 		outcome.reason = observability.ReasonPayloadAbsent
 		return nil, 0, nil, nil, outcome, nil
 	}
-	targetDiff := h.findDiff(req.Diffs, req.Nonce)
-	if targetDiff == nil {
+	if h.findDiff(req.Diffs, req.Nonce) == nil {
 		outcome.reason = observability.ReasonTargetDiffAbsent
 		return nil, 0, nil, nil, outcome, nil
 	}
 
-	for _, tx := range targetDiff.Txs {
-		start := tx.GetStartInference()
-		if start == nil {
-			continue
-		}
-		outcome.inferenceID = start.InferenceId
-		executorSlot := h.group[start.InferenceId%uint64(len(h.group))].SlotID
-		if !h.slotIDs[executorSlot] {
-			continue
-		}
-		outcome.receiptExpected = true
-
-		// Verify payload matches signed diff.
-		if err := VerifyPayload(req.Payload, start.PromptHash, start.Model, start.InputLength, start.MaxTokens, start.StartedAt); err != nil {
-			return nil, 0, nil, nil, outcome, observability.Classify(observability.ReasonPayloadVerifyErr, observability.WhereHostSignReceipt, err)
-		}
-
-		// Sign executor receipt with wall-clock confirmed_at.
-		confirmedAt := time.Now().Unix()
-		receiptContent := &types.ExecutorReceiptContent{
-			InferenceId: start.InferenceId,
-			PromptHash:  start.PromptHash,
-			Model:       start.Model,
-			InputLength: start.InputLength,
-			MaxTokens:   start.MaxTokens,
-			StartedAt:   start.StartedAt,
-			EscrowId:    h.escrowID,
-			ConfirmedAt: confirmedAt,
-		}
-		receiptData, err := proto.Marshal(receiptContent)
-		if err != nil {
-			return nil, 0, nil, nil, outcome, observability.Classify(observability.ReasonReceiptMarshalErr, observability.WhereHostSignReceipt, fmt.Errorf("marshal executor receipt: %w", err))
-		}
-		sig, err := h.signer.Sign(receiptData)
-		if err != nil {
-			return nil, 0, nil, nil, outcome, observability.Classify(observability.ReasonReceiptSignErr, observability.WhereHostSignReceipt, fmt.Errorf("sign executor receipt: %w", err))
-		}
-
-		// Add MsgConfirmStart to mempool so it survives HTTP failures.
-		// If the response is lost (e.g. 503), the next request delivers it via mempool.
-		h.mempool.Add(MempoolEntry{
-			Tx: &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-				InferenceId: start.InferenceId,
-				ExecutorSig: sig,
-				ConfirmedAt: confirmedAt,
-			}}},
-			ProposedAt: h.sm.LatestNonce(),
-		})
-
-		// Dedup: return receipt (proves executor alive) but skip execution.
-		if _, dup := h.executing[start.InferenceId]; dup {
-			outcome.reason = observability.ReasonAlreadyExecuting
-			return sig, confirmedAt, nil, nil, outcome, nil
-		}
-
-		// Already completed: execution finished, response cached.
-		if cached, ok := h.completedResponses[start.InferenceId]; ok {
-			outcome.reason = observability.ReasonCachedResponse
-			return sig, confirmedAt, nil, cached, outcome, nil
-		}
-
-		h.executing[start.InferenceId] = struct{}{}
-		outcome.executionExpected = true
-		outcome.reason = observability.ReasonOK
-
-		job := &devshard.ExecuteRequest{
-			InferenceID: start.InferenceId,
-			Model:       start.Model,
-			Prompt:      req.Payload.Prompt,
-			PromptHash:  start.PromptHash,
-			InputLength: start.InputLength,
-			MaxTokens:   start.MaxTokens,
-			EscrowID:    h.escrowID,
-			EpochID:     h.epochID,
-		}
-		return sig, confirmedAt, job, nil, outcome, nil
+	// Protocol: inference_id == nonce. Authorize only from applied state.
+	inferenceID := req.Nonce
+	outcome.inferenceID = inferenceID
+	executorSlot := h.group[inferenceID%uint64(len(h.group))].SlotID
+	if !h.slotIDs[executorSlot] {
+		// Here reason is default observability.ReasonNotExecutor
+		return nil, 0, nil, nil, outcome, nil
 	}
-	return nil, 0, nil, nil, outcome, nil
+	outcome.receiptExpected = true
+
+	// HandleRequest applies diffs before signReceipt. A newly applied
+	// MsgStartInference creates Inferences[id] in memory (and reserves cost).
+	// If the target diff was stale/skipped, ApplyDiff never ran and ok is false.
+	rec, ok := h.sm.GetInference(inferenceID)
+	if !ok {
+		outcome.reason = observability.ReasonInferenceDisappeared
+		return nil, 0, nil, nil, outcome, nil
+	}
+
+	// Verify payload against the applied record (not unverified request-diff fields).
+	if err := VerifyPayload(req.Payload, rec.PromptHash, rec.Model, rec.InputLength, rec.MaxTokens, rec.StartedAt); err != nil {
+		return nil, 0, nil, nil, outcome, observability.Classify(observability.ReasonPayloadVerifyErr, observability.WhereHostSignReceipt, err)
+	}
+
+	_, alreadyExecuting := h.executing[inferenceID]
+	cached, hasCached := h.completedResponses[inferenceID]
+	if rec.Status != types.StatusPending && !alreadyExecuting && !hasCached {
+		outcome.reason = observability.ReasonInferenceDisappeared
+		return nil, 0, nil, nil, outcome, nil
+	}
+
+	// Sign executor receipt with wall-clock confirmed_at.
+	confirmedAt := time.Now().Unix()
+	receiptContent := &types.ExecutorReceiptContent{
+		InferenceId: inferenceID,
+		PromptHash:  rec.PromptHash,
+		Model:       rec.Model,
+		InputLength: rec.InputLength,
+		MaxTokens:   rec.MaxTokens,
+		StartedAt:   rec.StartedAt,
+		EscrowId:    h.escrowID,
+		ConfirmedAt: confirmedAt,
+	}
+	receiptData, err := proto.Marshal(receiptContent)
+	if err != nil {
+		return nil, 0, nil, nil, outcome, observability.Classify(observability.ReasonReceiptMarshalErr, observability.WhereHostSignReceipt, fmt.Errorf("marshal executor receipt: %w", err))
+	}
+	sig, err := h.signer.Sign(receiptData)
+	if err != nil {
+		return nil, 0, nil, nil, outcome, observability.Classify(observability.ReasonReceiptSignErr, observability.WhereHostSignReceipt, fmt.Errorf("sign executor receipt: %w", err))
+	}
+
+	// Add MsgConfirmStart to mempool so it survives HTTP failures.
+	// If the response is lost (e.g. 503), the next request delivers it via mempool.
+	h.mempool.Add(MempoolEntry{
+		Tx: &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+			InferenceId: inferenceID,
+			ExecutorSig: sig,
+			ConfirmedAt: confirmedAt,
+		}}},
+		ProposedAt: h.sm.LatestNonce(),
+	})
+
+	// Dedup: return receipt (proves executor alive) but skip execution.
+	if alreadyExecuting {
+		outcome.reason = observability.ReasonAlreadyExecuting
+		return sig, confirmedAt, nil, nil, outcome, nil
+	}
+
+	// Already completed: execution finished, response cached.
+	if hasCached {
+		outcome.reason = observability.ReasonCachedResponse
+		return sig, confirmedAt, nil, cached, outcome, nil
+	}
+
+	h.executing[inferenceID] = struct{}{}
+	outcome.executionExpected = true
+	outcome.reason = observability.ReasonOK
+
+	job := &devshard.ExecuteRequest{
+		InferenceID: inferenceID,
+		Model:       rec.Model,
+		Prompt:      req.Payload.Prompt,
+		PromptHash:  rec.PromptHash,
+		InputLength: rec.InputLength,
+		MaxTokens:   rec.MaxTokens,
+		EscrowID:    h.escrowID,
+		EpochID:     h.epochID,
+	}
+	return sig, confirmedAt, job, nil, outcome, nil
 }
 
 // executeAsync runs inference and adds MsgFinishInference to the mempool.

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -241,6 +241,49 @@ func TestHost_ExecutorReceipt(t *testing.T) {
 	require.Equal(t, hosts[1].Address(), addr)
 }
 
+func TestHost_StaleDiffDoesNotAuthorizeExecution(t *testing.T) {
+	// A skipped/stale diff must not authorize receipt or ML execution.
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	h := newTestHost(t, 1, hosts, user, 1_000_000, 10)
+	ctx := context.Background()
+
+	balanceBefore := h.SnapshotState().Balance
+
+	// Advance to nonce 1 without creating inference 1.
+	advance := testutil.SignDiff(t, user, "escrow-1", 1, nil)
+	_, err := h.HandleRequest(ctx, HostRequest{Diffs: []types.Diff{advance}})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), h.SnapshotState().LatestNonce)
+	_, exists := h.SnapshotState().Inferences[1]
+	require.False(t, exists)
+
+	// Resend nonce 1 with an unapplied Start and nil UserSig.
+	stale := types.Diff{
+		Nonce: 1,
+		Txs: []*types.DevshardTx{
+			testutil.StartTx(1),
+		},
+		UserSig: nil,
+	}
+	resp, err := handleAndExecute(t, h, ctx, HostRequest{
+		Diffs:   []types.Diff{stale},
+		Nonce:   1,
+		Payload: defaultPayload(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Receipt, "stale unapplied start must not produce a receipt")
+	require.Nil(t, resp.ExecutionJob)
+	require.Nil(t, findMempoolFinish(resp.Mempool))
+	require.Nil(t, findMempoolConfirm(resp.Mempool))
+
+	after := h.SnapshotState()
+	require.Equal(t, uint64(1), after.LatestNonce)
+	_, exists = after.Inferences[1]
+	require.False(t, exists)
+	require.Equal(t, balanceBefore, after.Balance)
+}
+
 func TestHost_DisabledAvailabilityRejectsCompletionButAllowsFinalize(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	user := testutil.MustGenerateKey(t)


### PR DESCRIPTION
# [HackerOne #3867318](https://hackerone.com/reports/3867318) — stale diff must not authorize execution

## Summary

`signReceipt` authorized inference from raw request-diff `MsgStartInference` bytes even when `applyAndPersist` skipped that diff as already applied. An escrow owner could therefore trigger real ML work without applying Start or reserving escrow.

## Fix

Authorize receipts/execution from applied escrow state for `req.Nonce` (`GetInference` + payload match against the state record). Skipped/stale/unapplied Starts no longer produce a receipt or `ExecutionJob`.

## Severity note

Medium: authenticated escrow-owner resource abuse only; no third-party fund theft or settleable unpaid payout.
