### PR TITLE
Make gateway phase gate independent of decentralized-api

### DIFF
--- a/deploy/join/config.devshard.env.template
+++ b/deploy/join/config.devshard.env.template
@@ -12,7 +12,8 @@
 # Once /root/.devshardctl/gateway.db exists, devshard membership and gateway settings
 # are loaded from that state DB instead of these env values.
 export DEVSHARD_CHAIN_REST=http://node:1317
-export DEVSHARD_PUBLIC_API=http://api:9000
+# DEVSHARD_PUBLIC_API is deprecated; phase gate uses DEVSHARD_CHAIN_REST only.
+# export DEVSHARD_PUBLIC_API=http://api:9000
 export DEVSHARD_PORT=8080
 export DEVSHARD_STORAGE_DIR=/root/.devshardctl
 export DEVSHARD_STORAGE_HOST_DIR=.devshardctl

--- a/devshard/cmd/devshardctl/active_participants_abci.go
+++ b/devshard/cmd/devshardctl/active_participants_abci.go
@@ -1,0 +1,412 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+const (
+	activeParticipantsKeyPrefix = "ActiveParticipants/value/"
+	abciStoreInferenceKeyPath   = "store/inference/key"
+)
+
+// activeParticipantsStoreKey matches inference-chain
+// types.ActiveParticipantsFullKey: "ActiveParticipants/value/" + big-endian
+// epoch + "/". No cosmos-sdk dependency required.
+func activeParticipantsStoreKey(epoch uint64) []byte {
+	key := make([]byte, 0, len(activeParticipantsKeyPrefix)+8+1)
+	key = append(key, activeParticipantsKeyPrefix...)
+	var epochBytes [8]byte
+	binary.BigEndian.PutUint64(epochBytes[:], epoch)
+	key = append(key, epochBytes[:]...)
+	key = append(key, '/')
+	return key
+}
+
+type chainCurrentEpochResponse struct {
+	Epoch jsonUint64 `json:"epoch"`
+}
+
+type abciQueryRESTResponse struct {
+	Code  uint32 `json:"code"`
+	Log   string `json:"log"`
+	Value string `json:"value"`
+}
+
+func (g *ChainPhaseGate) fetchEffectiveEpochIndex() (uint64, error) {
+	if g == nil || g.currentEpochEndpoint == "" {
+		return 0, fmt.Errorf("current epoch endpoint not configured")
+	}
+	resp, err := g.client.Get(g.currentEpochEndpoint)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		return 0, fmt.Errorf("get_current_epoch status %d", resp.StatusCode)
+	}
+	var payload chainCurrentEpochResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return 0, err
+	}
+	return uint64(payload.Epoch), nil
+}
+
+func (g *ChainPhaseGate) fetchActiveParticipantsGroup(epoch uint64) (chainActiveParticipantsGroup, error) {
+	var empty chainActiveParticipantsGroup
+	if g == nil || g.chainRESTBase == "" {
+		return empty, fmt.Errorf("chain REST base not configured")
+	}
+
+	dataHex := hex.EncodeToString(activeParticipantsStoreKey(epoch))
+	q := url.Values{}
+	q.Set("path", abciStoreInferenceKeyPath)
+	q.Set("data", dataHex)
+	q.Set("prove", "false")
+	endpoint := g.chainRESTBase + "/cosmos/base/tendermint/v1beta1/abci_query?" + q.Encode()
+
+	resp, err := g.client.Get(endpoint)
+	if err != nil {
+		return empty, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		return empty, fmt.Errorf("abci_query active participants status %d", resp.StatusCode)
+	}
+
+	var payload abciQueryRESTResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return empty, err
+	}
+	if payload.Code != 0 {
+		return empty, fmt.Errorf("abci_query active participants code=%d log=%s", payload.Code, payload.Log)
+	}
+	if strings.TrimSpace(payload.Value) == "" {
+		return empty, fmt.Errorf("active participants not found for epoch %d", epoch)
+	}
+
+	raw, err := decodeABCIBytes(payload.Value)
+	if err != nil {
+		return empty, fmt.Errorf("decode abci value: %w", err)
+	}
+	participants, err := unmarshalActiveParticipants(raw)
+	if err != nil {
+		return empty, fmt.Errorf("unmarshal active participants: %w", err)
+	}
+	return chainActiveParticipantsGroup{Participants: participants}, nil
+}
+
+func decodeABCIBytes(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, fmt.Errorf("empty value")
+	}
+	// Prefer standard base64 (protobuf JSON bytes), then URL-safe, then hex.
+	if raw, err := base64.StdEncoding.DecodeString(value); err == nil {
+		return raw, nil
+	}
+	if raw, err := base64.RawStdEncoding.DecodeString(value); err == nil {
+		return raw, nil
+	}
+	if raw, err := base64.URLEncoding.DecodeString(value); err == nil {
+		return raw, nil
+	}
+	if raw, err := hex.DecodeString(value); err == nil {
+		return raw, nil
+	}
+	return nil, fmt.Errorf("unsupported abci value encoding")
+}
+
+// unmarshalActiveParticipants decodes the gogo-protobuf ActiveParticipants
+// bytes stored on-chain. Wire format is standard protobuf; we only keep the
+// fields the gateway phase gate needs and skip the rest (seed, voting_powers).
+func unmarshalActiveParticipants(data []byte) ([]chainActiveParticipant, error) {
+	var out []chainActiveParticipant
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return nil, fmt.Errorf("bad tag: %w", protowire.ParseError(n))
+		}
+		data = data[n:]
+		switch {
+		case num == 1 && typ == protowire.BytesType:
+			msg, n := protowire.ConsumeBytes(data)
+			if n < 0 {
+				return nil, fmt.Errorf("bad participant bytes: %w", protowire.ParseError(n))
+			}
+			data = data[n:]
+			p, err := unmarshalActiveParticipant(msg)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, p)
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, data)
+			if n < 0 {
+				return nil, fmt.Errorf("skip field %d: %w", num, protowire.ParseError(n))
+			}
+			data = data[n:]
+		}
+	}
+	return out, nil
+}
+
+func unmarshalActiveParticipant(data []byte) (chainActiveParticipant, error) {
+	var p chainActiveParticipant
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return p, fmt.Errorf("bad participant tag: %w", protowire.ParseError(n))
+		}
+		data = data[n:]
+		switch {
+		case num == 1 && typ == protowire.BytesType:
+			s, n := protowire.ConsumeString(data)
+			if n < 0 {
+				return p, protowire.ParseError(n)
+			}
+			p.Index = s
+			data = data[n:]
+		case num == 3 && typ == protowire.VarintType:
+			v, n := protowire.ConsumeVarint(data)
+			if n < 0 {
+				return p, protowire.ParseError(n)
+			}
+			p.Weight = jsonUint64(v)
+			data = data[n:]
+		case num == 4 && typ == protowire.BytesType:
+			s, n := protowire.ConsumeString(data)
+			if n < 0 {
+				return p, protowire.ParseError(n)
+			}
+			p.InferenceURL = s
+			data = data[n:]
+		case num == 5 && typ == protowire.BytesType:
+			s, n := protowire.ConsumeString(data)
+			if n < 0 {
+				return p, protowire.ParseError(n)
+			}
+			p.Models = append(p.Models, s)
+			data = data[n:]
+		case num == 7 && typ == protowire.BytesType:
+			msg, n := protowire.ConsumeBytes(data)
+			if n < 0 {
+				return p, protowire.ParseError(n)
+			}
+			data = data[n:]
+			group, err := unmarshalModelMLNodes(msg)
+			if err != nil {
+				return p, err
+			}
+			p.MLNodes = append(p.MLNodes, group)
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, data)
+			if n < 0 {
+				return p, protowire.ParseError(n)
+			}
+			data = data[n:]
+		}
+	}
+	return p, nil
+}
+
+func unmarshalModelMLNodes(data []byte) (chainModelMLNodes, error) {
+	var group chainModelMLNodes
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return group, protowire.ParseError(n)
+		}
+		data = data[n:]
+		switch {
+		case num == 1 && typ == protowire.BytesType:
+			msg, n := protowire.ConsumeBytes(data)
+			if n < 0 {
+				return group, protowire.ParseError(n)
+			}
+			data = data[n:]
+			node, err := unmarshalMLNodeInfo(msg)
+			if err != nil {
+				return group, err
+			}
+			group.MLNodes = append(group.MLNodes, node)
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, data)
+			if n < 0 {
+				return group, protowire.ParseError(n)
+			}
+			data = data[n:]
+		}
+	}
+	return group, nil
+}
+
+func unmarshalMLNodeInfo(data []byte) (chainMLNodeInfo, error) {
+	var node chainMLNodeInfo
+	for len(data) > 0 {
+		num, typ, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return node, protowire.ParseError(n)
+		}
+		data = data[n:]
+		switch {
+		case num == 1 && typ == protowire.BytesType:
+			s, n := protowire.ConsumeString(data)
+			if n < 0 {
+				return node, protowire.ParseError(n)
+			}
+			node.NodeID = s
+			data = data[n:]
+		case num == 3 && typ == protowire.VarintType:
+			v, n := protowire.ConsumeVarint(data)
+			if n < 0 {
+				return node, protowire.ParseError(n)
+			}
+			node.PoCWeight = jsonUint64(v)
+			data = data[n:]
+		case num == 4 && typ == protowire.BytesType:
+			// packed repeated bool
+			packed, n := protowire.ConsumeBytes(data)
+			if n < 0 {
+				return node, protowire.ParseError(n)
+			}
+			data = data[n:]
+			for len(packed) > 0 {
+				v, vn := protowire.ConsumeVarint(packed)
+				if vn < 0 {
+					return node, protowire.ParseError(vn)
+				}
+				node.TimeslotAllocation = append(node.TimeslotAllocation, v != 0)
+				packed = packed[vn:]
+			}
+		case num == 4 && typ == protowire.VarintType:
+			v, n := protowire.ConsumeVarint(data)
+			if n < 0 {
+				return node, protowire.ParseError(n)
+			}
+			node.TimeslotAllocation = append(node.TimeslotAllocation, v != 0)
+			data = data[n:]
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, data)
+			if n < 0 {
+				return node, protowire.ParseError(n)
+			}
+			data = data[n:]
+		}
+	}
+	return node, nil
+}
+
+// marshalActiveParticipants encodes gateway participant structs into the same
+// wire shape the chain stores. Used by tests to mock abci_query values.
+func marshalActiveParticipants(participants []chainActiveParticipant) ([]byte, error) {
+	var out []byte
+	for _, p := range participants {
+		msg, err := marshalActiveParticipant(p)
+		if err != nil {
+			return nil, err
+		}
+		out = protowire.AppendTag(out, 1, protowire.BytesType)
+		out = protowire.AppendBytes(out, msg)
+	}
+	return out, nil
+}
+
+func marshalActiveParticipant(p chainActiveParticipant) ([]byte, error) {
+	var out []byte
+	if p.Index != "" {
+		out = protowire.AppendTag(out, 1, protowire.BytesType)
+		out = protowire.AppendString(out, p.Index)
+	}
+	if p.Weight != 0 {
+		out = protowire.AppendTag(out, 3, protowire.VarintType)
+		out = protowire.AppendVarint(out, uint64(p.Weight))
+	}
+	if p.InferenceURL != "" {
+		out = protowire.AppendTag(out, 4, protowire.BytesType)
+		out = protowire.AppendString(out, p.InferenceURL)
+	}
+	for _, model := range p.Models {
+		out = protowire.AppendTag(out, 5, protowire.BytesType)
+		out = protowire.AppendString(out, model)
+	}
+	for _, group := range p.MLNodes {
+		msg, err := marshalModelMLNodes(group)
+		if err != nil {
+			return nil, err
+		}
+		out = protowire.AppendTag(out, 7, protowire.BytesType)
+		out = protowire.AppendBytes(out, msg)
+	}
+	return out, nil
+}
+
+func marshalModelMLNodes(group chainModelMLNodes) ([]byte, error) {
+	var out []byte
+	for _, node := range group.MLNodes {
+		msg, err := marshalMLNodeInfo(node)
+		if err != nil {
+			return nil, err
+		}
+		out = protowire.AppendTag(out, 1, protowire.BytesType)
+		out = protowire.AppendBytes(out, msg)
+	}
+	return out, nil
+}
+
+func marshalMLNodeInfo(node chainMLNodeInfo) ([]byte, error) {
+	var out []byte
+	if node.NodeID != "" {
+		out = protowire.AppendTag(out, 1, protowire.BytesType)
+		out = protowire.AppendString(out, node.NodeID)
+	}
+	if node.PoCWeight != 0 {
+		out = protowire.AppendTag(out, 3, protowire.VarintType)
+		out = protowire.AppendVarint(out, uint64(node.PoCWeight))
+	}
+	if len(node.TimeslotAllocation) > 0 {
+		var packed []byte
+		for _, b := range node.TimeslotAllocation {
+			var v uint64
+			if b {
+				v = 1
+			}
+			packed = protowire.AppendVarint(packed, v)
+		}
+		out = protowire.AppendTag(out, 4, protowire.BytesType)
+		out = protowire.AppendBytes(out, packed)
+	}
+	return out, nil
+}
+
+func writeABCIQueryActiveParticipants(w http.ResponseWriter, participants []chainActiveParticipant) error {
+	raw, err := marshalActiveParticipants(participants)
+	if err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	payload := abciQueryRESTResponse{
+		Code:  0,
+		Value: base64.StdEncoding.EncodeToString(raw),
+	}
+	return json.NewEncoder(w).Encode(payload)
+}
+
+func writeCurrentEpoch(w http.ResponseWriter, epoch uint64) error {
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(map[string]string{
+		"epoch": strconv.FormatUint(epoch, 10),
+	})
+}

--- a/devshard/cmd/devshardctl/epoch_stages.go
+++ b/devshard/cmd/devshardctl/epoch_stages.go
@@ -1,0 +1,118 @@
+package main
+
+import "strings"
+
+// Epoch stage offsets mirror inference-chain/x/inference/types/epoch_params.go
+// so the gateway can derive set_new_validators / next_poc_start / phase from
+// existing chain EpochInfo (params + latest_epoch) without new chain queries
+// and without depending on decentralized-api.
+const (
+	pocGenerateWindDownFactor = 0.8
+	pocValidateWindDownFactor = 0.8
+)
+
+type chainEpochParams struct {
+	EpochLength            jsonInt64 `json:"epoch_length"`
+	EpochShift             jsonInt64 `json:"epoch_shift"`
+	PocStageDuration       jsonInt64 `json:"poc_stage_duration"`
+	PocExchangeDuration    jsonInt64 `json:"poc_exchange_duration"`
+	PocValidationDelay     jsonInt64 `json:"poc_validation_delay"`
+	PocValidationDuration  jsonInt64 `json:"poc_validation_duration"`
+	SetNewValidatorsDelay  jsonInt64 `json:"set_new_validators_delay"`
+	InferenceValidationCut jsonInt64 `json:"inference_validation_cutoff"`
+}
+
+func (p chainEpochParams) endOfPoCStage() int64 {
+	return int64(p.PocStageDuration)
+}
+
+func (p chainEpochParams) startOfPoCValidationStage() int64 {
+	return p.endOfPoCStage() + int64(p.PocValidationDelay)
+}
+
+func (p chainEpochParams) endOfPoCValidationStage() int64 {
+	return p.startOfPoCValidationStage() + int64(p.PocValidationDuration)
+}
+
+func (p chainEpochParams) setNewValidatorsStage() int64 {
+	return p.endOfPoCValidationStage() + int64(p.SetNewValidatorsDelay)
+}
+
+func (p chainEpochParams) setNewValidatorsHeight(pocStart int64, epochIndex uint64) int64 {
+	if epochIndex == 0 {
+		return 0
+	}
+	return pocStart + p.setNewValidatorsStage()
+}
+
+func (p chainEpochParams) nextPoCStart(pocStart int64, epochIndex uint64) int64 {
+	if epochIndex == 0 {
+		return -int64(p.EpochShift) + int64(p.EpochLength)
+	}
+	return pocStart + int64(p.EpochLength)
+}
+
+func deriveEpochStages(epoch chainLatestEpoch, params chainEpochParams) (current, next chainEpochStages) {
+	index := uint64(epoch.Index)
+	pocStart := int64(epoch.PocStartBlockHeight)
+	current = chainEpochStages{
+		EpochIndex:       jsonUint64(index),
+		SetNewValidators: jsonInt64(params.setNewValidatorsHeight(pocStart, index)),
+		NextPoCStart:     jsonInt64(params.nextPoCStart(pocStart, index)),
+	}
+	nextPocStart := int64(current.NextPoCStart)
+	next = chainEpochStages{
+		EpochIndex:       jsonUint64(index + 1),
+		SetNewValidators: jsonInt64(params.setNewValidatorsHeight(nextPocStart, index+1)),
+		NextPoCStart:     jsonInt64(params.nextPoCStart(nextPocStart, index+1)),
+	}
+	return current, next
+}
+
+// deriveEpochPhaseFromParams mirrors EpochContext.GetCurrentPhase.
+func deriveEpochPhaseFromParams(blockHeight int64, epoch chainLatestEpoch, params chainEpochParams) string {
+	index := uint64(epoch.Index)
+	if index == 0 {
+		return epochPhaseInference
+	}
+	pocStart := int64(epoch.PocStartBlockHeight)
+	if blockHeight < pocStart {
+		return epochPhaseInference
+	}
+	windDown := pocStart + int64(float64(params.PocStageDuration)*pocGenerateWindDownFactor)
+	validationStart := pocStart + params.startOfPoCValidationStage()
+	validationWindDown := pocStart + params.startOfPoCValidationStage() + int64(float64(params.PocValidationDuration)*pocValidateWindDownFactor)
+	validationEnd := pocStart + params.endOfPoCValidationStage()
+
+	switch {
+	case blockHeight >= pocStart && blockHeight < windDown:
+		return epochPhasePoCGenerate
+	case blockHeight >= windDown && blockHeight < validationStart:
+		return epochPhasePoCGenerateWindDown
+	case blockHeight >= validationStart && blockHeight < validationWindDown:
+		return epochPhasePoCValidate
+	case blockHeight >= validationWindDown && blockHeight < validationEnd:
+		return epochPhasePoCValidateWindDown
+	default:
+		return epochPhaseInference
+	}
+}
+
+// enrichEpochInfoStages fills phase/stages from EpochInfo params when the LCD
+// response does not include precomputed fields (current mainnet EpochInfo).
+func enrichEpochInfoStages(payload *chainEpochInfoResponse) {
+	if payload == nil {
+		return
+	}
+	params := payload.Params.EpochParams
+	current, next := deriveEpochStages(payload.LatestEpoch, params)
+	if payload.EpochStages.SetNewValidators == 0 && payload.EpochStages.NextPoCStart == 0 {
+		payload.EpochStages = current
+	}
+	if payload.NextEpochStages.SetNewValidators == 0 {
+		payload.NextEpochStages = next
+	}
+	if strings.TrimSpace(payload.Phase) == "" {
+		payload.Phase = deriveEpochPhaseFromParams(int64(payload.BlockHeight), payload.LatestEpoch, params)
+	}
+}

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -730,7 +730,7 @@ func NewManagedGateway(runtimes []*devshardRuntime, limiter *GatewayLimiter, set
 	if len(perfArgs) > 0 && perfArgs[0] != nil {
 		g.perf = perfArgs[0]
 	}
-	g.phaseGate = NewChainPhaseGate(settings.PublicAPI, 0)
+	g.phaseGate = NewChainPhaseGate(settings.ChainREST, 0)
 	if g.phaseGate != nil {
 		g.phaseGate.SetPreservedSnapshotBaseURL(settings.ChainREST)
 	}
@@ -2620,7 +2620,7 @@ func (g *Gateway) handleAdminSettings(w http.ResponseWriter, r *http.Request) {
 		if g.phaseGate != nil {
 			g.phaseGate.Stop()
 		}
-		g.phaseGate = NewChainPhaseGate(settings.PublicAPI, 0)
+		g.phaseGate = NewChainPhaseGate(settings.ChainREST, 0)
 		if g.phaseGate != nil {
 			g.phaseGate.SetPreservedSnapshotBaseURL(settings.ChainREST)
 		}

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -224,7 +224,7 @@ func parseCLIFlags() cliFlags {
 	fs := flag.NewFlagSet("devshardctl", flag.ExitOnError)
 	escrowID := fs.String("escrow-id", "", "escrow ID (required, or DEVSHARD_ESCROW_ID env)")
 	chainREST := fs.String("chain-rest", defaultChainRESTURL, "chain REST API URL")
-	publicAPI := fs.String("public-api", defaultPublicAPIURL, "public API URL used for epoch/PoC phase checks")
+	publicAPI := fs.String("public-api", defaultPublicAPIURL, "deprecated: unused by phase gate (kept for settings compatibility)")
 	model := fs.String("model", defaultModelName, "default model name")
 	port := fs.String("port", defaultListenPort, "listen port")
 	privateKey := fs.String("private-key", "", "private key hex (alternative to DEVSHARD_PRIVATE_KEY env)")

--- a/devshard/cmd/devshardctl/phase_gate.go
+++ b/devshard/cmd/devshardctl/phase_gate.go
@@ -51,8 +51,9 @@ type ChainPhaseSnapshot struct {
 }
 
 type ChainPhaseGate struct {
+	chainRESTBase                 string
 	endpoint                      string
-	participantsEndpoint          string
+	currentEpochEndpoint          string
 	preservedSnapshotEndpoint     string
 	client                        *http.Client
 	pollInterval                  time.Duration
@@ -83,10 +84,15 @@ type chainEpochInfoResponse struct {
 	BlockHeight             jsonInt64                         `json:"block_height"`
 	Phase                   string                            `json:"phase"`
 	LatestEpoch             chainLatestEpoch                  `json:"latest_epoch"`
+	Params                  chainEpochInfoParams              `json:"params"`
 	EpochStages             chainEpochStages                  `json:"epoch_stages"`
 	NextEpochStages         chainEpochStages                  `json:"next_epoch_stages"`
 	IsConfirmationPoCActive bool                              `json:"is_confirmation_poc_active"`
 	ActiveConfirmationPoC   *chainConfirmationPoCEventPayload `json:"active_confirmation_poc_event,omitempty"`
+}
+
+type chainEpochInfoParams struct {
+	EpochParams chainEpochParams `json:"epoch_params"`
 }
 
 type chainLatestEpoch struct {
@@ -103,10 +109,6 @@ type chainEpochStages struct {
 type chainConfirmationPoCEventPayload struct {
 	Phase         confirmationPoCPhaseValue `json:"phase"`
 	TriggerHeight jsonInt64                 `json:"trigger_height"`
-}
-
-type chainCurrentParticipantsResponse struct {
-	ActiveParticipants chainActiveParticipantsGroup `json:"active_participants"`
 }
 
 type chainActiveParticipantsGroup struct {
@@ -242,18 +244,23 @@ func (e *RequestAdmissionError) Error() string {
 	return "request admission blocked"
 }
 
-func NewChainPhaseGate(baseURL string, pollInterval time.Duration) *ChainPhaseGate {
-	baseURL = strings.TrimSpace(baseURL)
-	if baseURL == "" {
+func NewChainPhaseGate(chainREST string, pollInterval time.Duration) *ChainPhaseGate {
+	chainREST = strings.TrimSpace(chainREST)
+	if chainREST == "" {
 		return nil
 	}
 	if pollInterval <= 0 {
 		pollInterval = defaultChainPhasePollInterval
 	}
+	base := strings.TrimRight(chainREST, "/")
 	client := &http.Client{Timeout: 5 * time.Second}
 	return &ChainPhaseGate{
-		endpoint:                      strings.TrimRight(baseURL, "/") + "/v1/epochs/latest",
-		participantsEndpoint:          strings.TrimRight(baseURL, "/") + "/v1/epochs/current/participants",
+		// Phase gate talks only to chain LCD: EpochInfo + GetCurrentEpoch +
+		// ABCI store query for ActiveParticipants. No decentralized-api, and
+		// no new Inference Chain query endpoints required.
+		chainRESTBase:                 base,
+		endpoint:                      base + "/productscience/inference/inference/epoch_info",
+		currentEpochEndpoint:          base + "/productscience/inference/inference/get_current_epoch",
 		client:                        client,
 		pollInterval:                  pollInterval,
 		defaultMaxSpeculativeAttempts: CurrentMaxSpeculativeAttempts(),
@@ -273,6 +280,8 @@ func (g *ChainPhaseGate) SetPreservedSnapshotBaseURL(baseURL string) {
 	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	// Prefer the constructor's chain-REST snapshot URL; only override when the
+	// caller points at a different chain REST base (admin settings update).
 	g.preservedSnapshotEndpoint = strings.TrimRight(baseURL, "/") + "/productscience/inference/inference/preserved_nodes_snapshot"
 }
 
@@ -480,6 +489,7 @@ func (g *ChainPhaseGate) fetchEpochInfo() (*chainEpochInfoResponse, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return nil, err
 	}
+	enrichEpochInfoStages(&payload)
 	return &payload, nil
 }
 
@@ -523,19 +533,14 @@ func (g *ChainPhaseGate) fetchPreservedParticipantKeys() ([]string, []string, er
 }
 
 func (g *ChainPhaseGate) fetchParticipantsState(pocActive bool, expectedSnapshotAnchor int64, allowAllWhenSnapshotMissing bool) (*participantsState, error) {
-	resp, err := g.client.Get(g.participantsEndpoint)
+	// Effective/current epoch (not latest): during main PoC latest advances
+	// while inference still routes against the still-serving cohort.
+	epochIndex, err := g.fetchEffectiveEpochIndex()
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		io.Copy(io.Discard, resp.Body)
-		return nil, fmt.Errorf("current participants status %d", resp.StatusCode)
-	}
-
-	var payload chainCurrentParticipantsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	group, err := g.fetchActiveParticipantsGroup(epochIndex)
+	if err != nil {
 		return nil, err
 	}
 
@@ -555,17 +560,17 @@ func (g *ChainPhaseGate) fetchParticipantsState(pocActive bool, expectedSnapshot
 
 	state := &participantsState{
 		preservedByModel:   make(map[string][]string),
-		weights:            make(map[string]float64, len(payload.ActiveParticipants.Participants)),
+		weights:            make(map[string]float64, len(group.Participants)),
 		weightsByModel:     make(map[string]map[string]float64),
-		fullWeights:        make(map[string]float64, len(payload.ActiveParticipants.Participants)),
+		fullWeights:        make(map[string]float64, len(group.Participants)),
 		fullWeightsByModel: make(map[string]map[string]float64),
-		inferenceURLs:      make(map[string]string, len(payload.ActiveParticipants.Participants)),
-		nodesByParticipant: make(map[string][]participantNode, len(payload.ActiveParticipants.Participants)),
+		inferenceURLs:      make(map[string]string, len(group.Participants)),
+		nodesByParticipant: make(map[string][]participantNode, len(group.Participants)),
 	}
-	seenPreserved := make(map[string]struct{}, len(payload.ActiveParticipants.Participants))
+	seenPreserved := make(map[string]struct{}, len(group.Participants))
 	seenPreservedByModel := make(map[string]map[string]struct{})
-	seenExcluded := make(map[string]struct{}, len(payload.ActiveParticipants.Participants))
-	for _, participant := range payload.ActiveParticipants.Participants {
+	seenExcluded := make(map[string]struct{}, len(group.Participants))
+	for _, participant := range group.Participants {
 		key := strings.TrimSpace(participant.Index)
 		if key == "" {
 			// A participant with no chain Index is not addressable

--- a/devshard/cmd/devshardctl/phase_gate_test.go
+++ b/devshard/cmd/devshardctl/phase_gate_test.go
@@ -11,9 +11,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// participantsTestServer mocks get_current_epoch + ABCI ActiveParticipants
+// (and optional extra LCD paths such as preserved_nodes_snapshot).
+func participantsTestServer(t *testing.T, participants []chainActiveParticipant, extras map[string]http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/productscience/inference/inference/get_current_epoch":
+			require.NoError(t, writeCurrentEpoch(w, 11))
+		case r.URL.Path == "/cosmos/base/tendermint/v1beta1/abci_query":
+			require.Contains(t, r.URL.RawQuery, "path=store%2Finference%2Fkey")
+			require.NoError(t, writeABCIQueryActiveParticipants(w, participants))
+		default:
+			if extras != nil {
+				if h, ok := extras[r.URL.Path]; ok {
+					h(w, r)
+					return
+				}
+			}
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+
 func TestChainPhaseGateFetchEpochInfoParsesConfirmationPoC(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/latest", r.URL.Path)
+		require.Equal(t, "/productscience/inference/inference/epoch_info", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"block_height":"150",
@@ -91,7 +115,7 @@ func TestChainPhaseGateDerivesEpochSwitchFromNextSetNewValidatorsAfterCurrentSwi
 
 func TestChainPhaseGateFetchEpochInfoParsesNumericConfirmationPoCGracePeriod(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/latest", r.URL.Path)
+		require.Equal(t, "/productscience/inference/inference/epoch_info", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"block_height":"151",
@@ -123,7 +147,7 @@ func TestChainPhaseGateFetchEpochInfoParsesNumericConfirmationPoCGracePeriod(t *
 
 func TestChainPhaseGateFetchEpochInfoParsesNumericConfirmationPoCCompleted(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/latest", r.URL.Path)
+		require.Equal(t, "/productscience/inference/inference/epoch_info", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"block_height":"152",
@@ -154,7 +178,7 @@ func TestChainPhaseGateFetchEpochInfoParsesNumericConfirmationPoCCompleted(t *te
 
 func TestChainPhaseGateBlocksDuringRegularPoC(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/latest", r.URL.Path)
+		require.Equal(t, "/productscience/inference/inference/epoch_info", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"block_height":"105",
@@ -209,7 +233,7 @@ func TestChainPhaseGateRelaxedModeAllowsRequestsDuringPoC(t *testing.T) {
 	setPoCModeForTest(t, pocRequestModeRelaxed)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/latest", r.URL.Path)
+		require.Equal(t, "/productscience/inference/inference/epoch_info", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"block_height":"105",
@@ -257,41 +281,23 @@ func TestChainPhaseGateRelaxedModeKeepsSpeculativeAttemptsUnclamped(t *testing.T
 }
 
 func TestChainPhaseGateFetchPreservedParticipantKeys(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/current/participants", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		// Two preserved entries for the same gonka address dedupe to
-		// one in the response, mirroring how multi-slot validators
-		// appear on chain. The participant with no preserved MLNode
-		// times slots flows to the excluded list.
-		_, _ = w.Write([]byte(`{
-			"active_participants": {
-				"participants": [
-					{
-						"index": "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-						"inference_url": "http://preserved.example:8080",
-						"ml_nodes": [
-							{"ml_nodes": [{"timeslot_allocation": [true, true]}]}
-						]
-					},
-					{
-						"index": "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-						"inference_url": "http://preserved.example:8081",
-						"ml_nodes": [
-							{"ml_nodes": [{"timeslot_allocation": [true, true]}]}
-						]
-					},
-					{
-						"index": "gonka1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2",
-						"inference_url": "http://regular.example:8080",
-						"ml_nodes": [
-							{"ml_nodes": [{"timeslot_allocation": [true, false]}]}
-						]
-					}
-				]
-			}
-		}`))
-	}))
+	server := participantsTestServer(t, []chainActiveParticipant{
+		{
+			Index:        "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+			InferenceURL: "http://preserved.example:8080",
+			MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{{TimeslotAllocation: []bool{true, true}}}}},
+		},
+		{
+			Index:        "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+			InferenceURL: "http://preserved.example:8081",
+			MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{{TimeslotAllocation: []bool{true, true}}}}},
+		},
+		{
+			Index:        "gonka1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2",
+			InferenceURL: "http://regular.example:8080",
+			MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{{TimeslotAllocation: []bool{true, false}}}}},
+		},
+	}, nil)
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -307,28 +313,17 @@ func TestChainPhaseGateFetchPreservedParticipantKeys(t *testing.T) {
 	}, excluded)
 }
 
+
 func TestChainPhaseGateUsesPreservedNodePoCWeightDuringPoC(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/current/participants", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"active_participants": {
-				"participants": [
-					{
-						"index": "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-						"weight": 100,
-						"models": ["Model/A"],
-						"ml_nodes": [
-							{"ml_nodes": [
-								{"poc_weight": 40, "timeslot_allocation": [true, true]},
-								{"poc_weight": 60, "timeslot_allocation": [true, false]}
-							]}
-						]
-					}
-				]
-			}
-		}`))
-	}))
+	server := participantsTestServer(t, []chainActiveParticipant{{
+		Index:  "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+		Weight: 100,
+		Models: []string{"Model/A"},
+		MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{
+			{PoCWeight: 40, TimeslotAllocation: []bool{true, true}},
+			{PoCWeight: 60, TimeslotAllocation: []bool{true, false}},
+		}}},
+	}}, nil)
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -356,31 +351,22 @@ func TestChainPhaseGateUsesPreservedNodePoCWeightDuringPoC(t *testing.T) {
 	}, state.fullWeightsByModel)
 }
 
+
 func TestChainPhaseGateUsesRawPoCWeightOutsidePoC(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/current/participants", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"active_participants": {
-				"participants": [
-					{
-						"index": "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-						"weight": 999,
-						"models": ["Model/A", "Model/B"],
-						"ml_nodes": [
-							{"ml_nodes": [
-								{"node_id": "a1", "poc_weight": 40, "timeslot_allocation": [true, false]},
-								{"node_id": "a2", "poc_weight": 10, "timeslot_allocation": [true, false]}
-							]},
-							{"ml_nodes": [
-								{"node_id": "b1", "poc_weight": 60, "timeslot_allocation": [true, false]}
-							]}
-						]
-					}
-				]
-			}
-		}`))
-	}))
+	server := participantsTestServer(t, []chainActiveParticipant{{
+		Index:  "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+		Weight: 999,
+		Models: []string{"Model/A", "Model/B"},
+		MLNodes: []chainModelMLNodes{
+			{MLNodes: []chainMLNodeInfo{
+				{NodeID: "a1", PoCWeight: 40, TimeslotAllocation: []bool{true, false}},
+				{NodeID: "a2", PoCWeight: 10, TimeslotAllocation: []bool{true, false}},
+			}},
+			{MLNodes: []chainMLNodeInfo{
+				{NodeID: "b1", PoCWeight: 60, TimeslotAllocation: []bool{true, false}},
+			}},
+		},
+	}}, nil)
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -412,39 +398,29 @@ func TestChainPhaseGateUsesRawPoCWeightOutsidePoC(t *testing.T) {
 	}, state.fullWeightsByModel)
 }
 
+
 func TestChainPhaseGateUsesPreservedSnapshotDuringPoC(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/v1/epochs/current/participants":
-			_, _ = w.Write([]byte(`{
-				"active_participants": {
-					"participants": [
-						{
-							"index": "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-							"weight": 100,
-							"models": ["Model/A"],
-							"ml_nodes": [
-								{"ml_nodes": [
-									{"node_id": "node-a", "poc_weight": 40, "timeslot_allocation": [true, false]},
-									{"node_id": "node-b", "poc_weight": 60, "timeslot_allocation": [true, false]}
-								]}
-							]
-						},
-						{
-							"index": "gonka1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2",
-							"weight": 100,
-							"models": ["Model/A"],
-							"ml_nodes": [
-								{"ml_nodes": [
-									{"node_id": "node-c", "poc_weight": 70, "timeslot_allocation": [true, false]}
-								]}
-							]
-						}
-					]
-				}
-			}`))
-		case "/productscience/inference/inference/preserved_nodes_snapshot":
+	server := participantsTestServer(t, []chainActiveParticipant{
+		{
+			Index:  "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+			Weight: 100,
+			Models: []string{"Model/A"},
+			MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{
+				{NodeID: "node-a", PoCWeight: 40, TimeslotAllocation: []bool{true, false}},
+				{NodeID: "node-b", PoCWeight: 60, TimeslotAllocation: []bool{true, false}},
+			}}},
+		},
+		{
+			Index:  "gonka1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2",
+			Weight: 100,
+			Models: []string{"Model/A"},
+			MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{
+				{NodeID: "node-c", PoCWeight: 70, TimeslotAllocation: []bool{true, false}},
+			}}},
+		},
+	}, map[string]http.HandlerFunc{
+		"/productscience/inference/inference/preserved_nodes_snapshot": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{
 				"found": true,
 				"snapshot": {
@@ -462,10 +438,8 @@ func TestChainPhaseGateUsesPreservedSnapshotDuringPoC(t *testing.T) {
 					]
 				}
 			}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
+		},
+	})
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -501,6 +475,7 @@ func TestChainPhaseGateUsesPreservedSnapshotDuringPoC(t *testing.T) {
 	}, state.fullWeightsByModel)
 }
 
+
 func TestShouldRefreshPoCPreservedParticipantsOnConfirmationGenerationTransition(t *testing.T) {
 	previous := ChainPhaseSnapshot{
 		EpochPhase:           epochPhaseInference,
@@ -523,33 +498,20 @@ func TestShouldRefreshPoCPreservedParticipantsOnConfirmationGenerationTransition
 }
 
 func TestChainPhaseGateFallsBackToTimeslotAllocationWhenPreservedSnapshotMissing(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/v1/epochs/current/participants":
-			_, _ = w.Write([]byte(`{
-				"active_participants": {
-					"participants": [
-						{
-							"index": "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-							"weight": 100,
-							"models": ["Model/A"],
-							"ml_nodes": [
-								{"ml_nodes": [
-									{"node_id": "node-a", "poc_weight": 40, "timeslot_allocation": [true, true]},
-									{"node_id": "node-b", "poc_weight": 60, "timeslot_allocation": [true, false]}
-								]}
-							]
-						}
-					]
-				}
-			}`))
-		case "/productscience/inference/inference/preserved_nodes_snapshot":
+	server := participantsTestServer(t, []chainActiveParticipant{{
+		Index:  "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+		Weight: 100,
+		Models: []string{"Model/A"},
+		MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{
+			{NodeID: "node-a", PoCWeight: 40, TimeslotAllocation: []bool{true, true}},
+			{NodeID: "node-b", PoCWeight: 60, TimeslotAllocation: []bool{true, false}},
+		}}},
+	}}, map[string]http.HandlerFunc{
+		"/productscience/inference/inference/preserved_nodes_snapshot": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"found": false}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
+		},
+	})
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -565,28 +527,18 @@ func TestChainPhaseGateFallsBackToTimeslotAllocationWhenPreservedSnapshotMissing
 	}, state.weights)
 }
 
+
 func TestChainPhaseGateIgnoresStalePreservedSnapshot(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/v1/epochs/current/participants":
-			_, _ = w.Write([]byte(`{
-				"active_participants": {
-					"participants": [
-						{
-							"index": "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-							"weight": 100,
-							"models": ["Model/A"],
-							"ml_nodes": [
-								{"ml_nodes": [
-									{"node_id": "node-a", "poc_weight": 40, "timeslot_allocation": [true, false]}
-								]}
-							]
-						}
-					]
-				}
-			}`))
-		case "/productscience/inference/inference/preserved_nodes_snapshot":
+	server := participantsTestServer(t, []chainActiveParticipant{{
+		Index:  "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+		Weight: 100,
+		Models: []string{"Model/A"},
+		MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{
+			{NodeID: "node-a", PoCWeight: 40, TimeslotAllocation: []bool{true, false}},
+		}}},
+	}}, map[string]http.HandlerFunc{
+		"/productscience/inference/inference/preserved_nodes_snapshot": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{
 				"found": true,
 				"snapshot": {
@@ -604,10 +556,8 @@ func TestChainPhaseGateIgnoresStalePreservedSnapshot(t *testing.T) {
 					]
 				}
 			}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
+		},
+	})
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -623,33 +573,21 @@ func TestChainPhaseGateIgnoresStalePreservedSnapshot(t *testing.T) {
 	}, state.weights)
 }
 
+
 func TestChainPhaseGateKeepsAllParticipantsAvailableDuringConfirmationGraceBeforeSnapshot(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/v1/epochs/current/participants":
-			_, _ = w.Write([]byte(`{
-				"active_participants": {
-					"participants": [
-						{
-							"index": "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-							"weight": 100,
-							"models": ["Model/A"],
-							"ml_nodes": [
-								{"ml_nodes": [
-									{"node_id": "node-a", "poc_weight": 40, "timeslot_allocation": [true, false]}
-								]}
-							]
-						}
-					]
-				}
-			}`))
-		case "/productscience/inference/inference/preserved_nodes_snapshot":
+	server := participantsTestServer(t, []chainActiveParticipant{{
+		Index:  "gonka1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+		Weight: 100,
+		Models: []string{"Model/A"},
+		MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{
+			{NodeID: "node-a", PoCWeight: 40, TimeslotAllocation: []bool{true, false}},
+		}}},
+	}}, map[string]http.HandlerFunc{
+		"/productscience/inference/inference/preserved_nodes_snapshot": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"found": false}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
+		},
+	})
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -670,28 +608,17 @@ func TestChainPhaseGateKeepsAllParticipantsAvailableDuringConfirmationGraceBefor
 	}, state.weightsByModel)
 }
 
+
 func TestChainPhaseGateExcludedParticipantContributesZeroDuringPoC(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/current/participants", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"active_participants": {
-				"participants": [
-					{
-						"index": "gonka1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2",
-						"weight": 100,
-						"models": ["Model/A"],
-						"ml_nodes": [
-							{"ml_nodes": [
-								{"poc_weight": 40, "timeslot_allocation": [true, false]},
-								{"poc_weight": 60, "timeslot_allocation": [true, false]}
-							]}
-						]
-					}
-				]
-			}
-		}`))
-	}))
+	server := participantsTestServer(t, []chainActiveParticipant{{
+		Index:  "gonka1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2",
+		Weight: 100,
+		Models: []string{"Model/A"},
+		MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{
+			{PoCWeight: 40, TimeslotAllocation: []bool{true, false}},
+			{PoCWeight: 60, TimeslotAllocation: []bool{true, false}},
+		}}},
+	}}, nil)
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -711,30 +638,21 @@ func TestChainPhaseGateExcludedParticipantContributesZeroDuringPoC(t *testing.T)
 	}, state.weightsByModel)
 }
 
+
 func TestChainPhaseGateMapsOuterMLNodesToModels(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/epochs/current/participants", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"active_participants": {
-				"participants": [
-					{
-						"index": "gonka1cccccccccccccccccccccccccccccccccccc3",
-						"weight": 100,
-						"models": ["Model/A", "Model/B"],
-						"ml_nodes": [
-							{"ml_nodes": [
-								{"node_id": "a1", "poc_weight": 40, "timeslot_allocation": [true, true]}
-							]},
-							{"ml_nodes": [
-								{"node_id": "b1", "poc_weight": 60, "timeslot_allocation": [true, false]}
-							]}
-						]
-					}
-				]
-			}
-		}`))
-	}))
+	server := participantsTestServer(t, []chainActiveParticipant{{
+		Index:  "gonka1cccccccccccccccccccccccccccccccccccc3",
+		Weight: 100,
+		Models: []string{"Model/A", "Model/B"},
+		MLNodes: []chainModelMLNodes{
+			{MLNodes: []chainMLNodeInfo{
+				{NodeID: "a1", PoCWeight: 40, TimeslotAllocation: []bool{true, true}},
+			}},
+			{MLNodes: []chainMLNodeInfo{
+				{NodeID: "b1", PoCWeight: 60, TimeslotAllocation: []bool{true, false}},
+			}},
+		},
+	}}, nil)
 	defer server.Close()
 
 	gate := NewChainPhaseGate(server.URL, 0)
@@ -751,6 +669,7 @@ func TestChainPhaseGateMapsOuterMLNodesToModels(t *testing.T) {
 		},
 	}, state.weightsByModel)
 }
+
 
 func TestChainPhaseGateLogsConfirmationPoCTransitionInRelaxedMode(t *testing.T) {
 	setPoCModeForTest(t, pocRequestModeRelaxed)
@@ -996,4 +915,71 @@ func contains(ss []string, s string) bool {
 		}
 	}
 	return false
+}
+
+
+func TestDeriveEpochStagesMatchesSetNewValidatorsMath(t *testing.T) {
+	params := chainEpochParams{
+		EpochLength:           500,
+		PocStageDuration:      50,
+		PocValidationDelay:    5,
+		PocValidationDuration: 40,
+		SetNewValidatorsDelay: 2,
+	}
+	epoch := chainLatestEpoch{Index: 12, PocStartBlockHeight: 1000}
+
+	current, next := deriveEpochStages(epoch, params)
+	require.Equal(t, int64(1097), int64(current.SetNewValidators))
+	require.Equal(t, int64(1500), int64(current.NextPoCStart))
+	require.Equal(t, uint64(13), uint64(next.EpochIndex))
+	require.Equal(t, int64(1597), int64(next.SetNewValidators))
+}
+
+func TestEnrichEpochInfoStagesDerivesPhaseWhenMissing(t *testing.T) {
+	payload := &chainEpochInfoResponse{
+		BlockHeight: 1010,
+		LatestEpoch: chainLatestEpoch{Index: 12, PocStartBlockHeight: 1000},
+		Params: chainEpochInfoParams{EpochParams: chainEpochParams{
+			EpochLength:           500,
+			PocStageDuration:      50,
+			PocValidationDelay:    5,
+			PocValidationDuration: 40,
+			SetNewValidatorsDelay: 2,
+		}},
+	}
+	enrichEpochInfoStages(payload)
+	require.Equal(t, epochPhasePoCGenerate, payload.Phase)
+	require.Equal(t, int64(1097), int64(payload.EpochStages.SetNewValidators))
+	require.Equal(t, int64(1500), int64(payload.EpochStages.NextPoCStart))
+}
+
+func TestNewChainPhaseGateUsesChainRESTPaths(t *testing.T) {
+	gate := NewChainPhaseGate("http://node:1317/", 0)
+	require.NotNil(t, gate)
+	require.Equal(t, "http://node:1317/productscience/inference/inference/epoch_info", gate.endpoint)
+	require.Equal(t, "http://node:1317/productscience/inference/inference/get_current_epoch", gate.currentEpochEndpoint)
+	require.Equal(t, "http://node:1317", gate.chainRESTBase)
+	gate.SetPreservedSnapshotBaseURL("http://node:1317/")
+	require.Equal(t, "http://node:1317/productscience/inference/inference/preserved_nodes_snapshot", gate.preservedSnapshotURL())
+}
+
+func TestActiveParticipantsStoreKeyAndRoundTrip(t *testing.T) {
+	key := activeParticipantsStoreKey(11)
+	require.Equal(t, "ActiveParticipants/value/", string(key[:len("ActiveParticipants/value/")]))
+	require.Equal(t, byte('/'), key[len(key)-1])
+
+	in := []chainActiveParticipant{{
+		Index:        "gonka1abc",
+		Weight:       42,
+		InferenceURL: "http://x",
+		Models:       []string{"M1", "M2"},
+		MLNodes: []chainModelMLNodes{{MLNodes: []chainMLNodeInfo{
+			{NodeID: "n1", PoCWeight: 7, TimeslotAllocation: []bool{true, false}},
+		}}},
+	}}
+	raw, err := marshalActiveParticipants(in)
+	require.NoError(t, err)
+	out, err := unmarshalActiveParticipants(raw)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
 }

--- a/devshard/docs/proxy.md
+++ b/devshard/docs/proxy.md
@@ -17,12 +17,13 @@ All settings can be passed as flags or environment variables. Flags take precede
 | ------ | ------ | ------ | ------ | ------ |
 | `--private-key` | `DEVSHARD_PRIVATE_KEY` | yes | - | Hex-encoded secp256k1 private key |
 | `--escrow-id` | `DEVSHARD_ESCROW_ID` | yes | - | On-chain escrow ID |
-| `--chain-rest` | `DEVSHARD_CHAIN_REST` | no | `http://localhost:1317` | Chain REST API URL |
+| `--chain-rest` | `DEVSHARD_CHAIN_REST` | no | `http://localhost:1317` | Chain REST API URL (epoch/PoC phase, active participants via ABCI, txs) |
 | `--model` | `DEVSHARD_MODEL` | no | `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` | Default model (used when request omits `model`) |
 | `--port` | `DEVSHARD_PORT` | no | `8080` | Listen port |
 | `--storage-path` | `DEVSHARD_STORAGE_PATH` | no | `~/.cache/gonka/devshard-<escrow-id>.db` | SQLite path for crash recovery |
 | - | `DEVSHARD_API_KEYS` | no | - | Comma-separated public API bearer keys |
 | - | `DEVSHARD_ADMIN_API_KEY` | no | - | Admin bearer key for finalize and `/v1/admin/*` endpoints |
+| - | `DEVSHARD_PUBLIC_API` | no | `http://localhost:9000` | Deprecated; unused by the phase gate (settings compatibility only) |
 | - | `DEVSHARD_CHAIN_ID` | no | queried from REST | Chain ID used when signing admin-created escrow transactions |
 | - | `DEVSHARD_TX_FEE_AMOUNT` | no | `1000000` | Fee amount for admin-created escrow transactions |
 | - | `DEVSHARD_TX_FEE_DENOM` | no | `ngonka` | Fee denom for admin-created escrow transactions |
@@ -279,7 +280,8 @@ Automatic rotation uses two roles:
   PoC/epoch transition.
 
 When `escrow_rotation.enabled` is true, the gateway watches the chain phase
-snapshot from `DEVSHARD_PUBLIC_API` and also replaces escrows that approach the
+snapshot from `DEVSHARD_CHAIN_REST` (`epoch_info`, `get_current_epoch`, and
+ABCI `ActiveParticipants`) and also replaces escrows that approach the
 low-balance or high-nonce limits. When it is false, both epoch rotation and
 depletion replacement are disabled.
 


### PR DESCRIPTION
Use existing EpochInfo + GetCurrentEpoch and ABCI store reads for ActiveParticipants, with gateway-local epoch stage/phase math and slim protobuf decoding so Inference Chain stays untouched.