### PR TITLE
Fix/poc artifact store active stage

### DIFF
--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -56,6 +56,8 @@ func (m *MockOffChainValidator) ValidateAll(pocStartBlockHeight int64, pocStartB
 
 func (m *MockOffChainValidator) MaybeCaptureEarlyShare(epochState chainphase.EpochState) {}
 
+func (m *MockOffChainValidator) SyncArtifactStoreStage(epochState chainphase.EpochState) {}
+
 type MockOrchestratorChainBridge struct {
 }
 

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -42,8 +42,9 @@ type pocValidator interface {
 	// early-share guard capture the early on-chain commitment near the
 	// first-fraction boundary of the active PoC/CPoC generation window.
 	MaybeCaptureEarlyShare(epochState chainphase.EpochState)
-	// SyncArtifactStoreStage pins the current PoC/CPoC stage in RAM through
-	// validation, and unloads all stores outside that window.
+	// SyncArtifactStoreStage pins the current PoC/CPoC stage height in RAM
+	// while synced. The previous stage is unloaded only when that height
+	// changes (next PoC or confirmation PoC), not merely when leaving validate.
 	SyncArtifactStoreStage(epochState chainphase.EpochState)
 }
 

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -42,6 +42,9 @@ type pocValidator interface {
 	// early-share guard capture the early on-chain commitment near the
 	// first-fraction boundary of the active PoC/CPoC generation window.
 	MaybeCaptureEarlyShare(epochState chainphase.EpochState)
+	// SyncArtifactStoreStage pins the current PoC/CPoC stage in RAM through
+	// validation, and unloads all stores outside that window.
+	SyncArtifactStoreStage(epochState chainphase.EpochState)
 }
 
 // PoCParams contains Proof of Compute parameters
@@ -289,6 +292,10 @@ func (d *OnNewBlockDispatcher) ProcessNewBlock(ctx context.Context, blockInfo ch
 		logging.Info("The blockchain node is still catching up, skipping on new block phase transitions", types.Stages)
 		return nil
 	}
+
+	// Pin/unpin the PoC artifact stage before any generate/validate work on
+	// this block so proof serving cannot race an unloaded store.
+	d.offChainValidator.SyncArtifactStoreStage(*epochState)
 
 	if d.configManager != nil && !strings.HasPrefix(blockInfo.Hash, "hash-") {
 		d.configManager.ApplyRuntimeConfigBlockIfChanged(

--- a/decentralized-api/internal/server/mlnode/post_generated_artifacts_v2_handler.go
+++ b/decentralized-api/internal/server/mlnode/post_generated_artifacts_v2_handler.go
@@ -60,6 +60,17 @@ func (s *Server) postGeneratedArtifactsV2(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "not in PoC generate phase")
 	}
 
+	// Pin before ingest so a race with block-dispatcher Sync (or restart before
+	// the first synced block) cannot drop our own artifacts on ErrStageNotActive.
+	if stageHeight := poc.GetCurrentPocStageHeight(epochState); stageHeight > 0 {
+		s.artifactStore.ActivateStage(stageHeight)
+		if body.BlockHeight != stageHeight {
+			logging.Warn("ArtifactBatchV2-callback. Rejected - block height is not the active PoC stage", types.PoC,
+				"blockHeight", body.BlockHeight, "activeStage", stageHeight)
+			return echo.NewHTTPError(http.StatusBadRequest, "block_height is not the active PoC stage")
+		}
+	}
+
 	// Look up node_id string from node number
 	node, found := s.broker.GetNodeByNodeNum(uint64(body.NodeId))
 	if !found {
@@ -94,7 +105,14 @@ func (s *Server) postGeneratedArtifactsV2(ctx echo.Context) error {
 	// Store artifacts locally for off-chain proofs
 	// Store commits (MsgPoCV2StoreCommit) are submitted by CommitWorker
 	// Weight distributions (MsgMLNodeWeightDistribution) are submitted at end of generation
-	totalCount, nodeDistribution := s.addToLocalStorage(body.BlockHeight, modelID, nodeId, protoArtifacts)
+	totalCount, nodeDistribution, err := s.addToLocalStorage(body.BlockHeight, modelID, nodeId, protoArtifacts)
+	if err != nil {
+		logging.Error("ArtifactBatchV2-callback. Failed to store artifacts", types.PoC,
+			"blockHeight", body.BlockHeight,
+			"modelId", modelID,
+			"error", err)
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "failed to store artifacts")
+	}
 
 	logging.Debug("ArtifactBatchV2-callback. Stored locally", types.PoC,
 		"blockHeight", body.BlockHeight,
@@ -178,16 +196,16 @@ func (s *Server) postValidatedArtifactsV2(ctx echo.Context) error {
 	return ctx.NoContent(http.StatusOK)
 }
 
-func (s *Server) addToLocalStorage(pocStageStartHeight int64, modelID, nodeId string, protoArtifacts []*types.PoCArtifactV2) (uint32, map[string]uint32) {
+func (s *Server) addToLocalStorage(pocStageStartHeight int64, modelID, nodeId string, protoArtifacts []*types.PoCArtifactV2) (uint32, map[string]uint32, error) {
 	if s.artifactStore == nil {
-		return 0, nil
+		return 0, nil, echo.NewHTTPError(http.StatusServiceUnavailable, "artifact store not configured")
 	}
 
 	store, err := s.artifactStore.GetOrCreateStore(pocStageStartHeight, modelID)
 	if err != nil {
 		logging.Error("Failed to get artifact store", types.PoC,
 			"pocStageStartHeight", pocStageStartHeight, "modelId", modelID, "error", err)
-		return 0, nil
+		return 0, nil, err
 	}
 
 	for _, a := range protoArtifacts {
@@ -196,8 +214,9 @@ func (s *Server) addToLocalStorage(pocStageStartHeight int64, modelID, nodeId st
 				continue
 			}
 			logging.Error("Failed to store artifact", types.PoC, "nonce", a.Nonce, "error", err)
+			return 0, nil, err
 		}
 	}
 
-	return store.Count(), store.GetNodeCounts()
+	return store.Count(), store.GetNodeCounts(), nil
 }

--- a/decentralized-api/internal/server/mlnode/post_generated_artifacts_v2_handler.go
+++ b/decentralized-api/internal/server/mlnode/post_generated_artifacts_v2_handler.go
@@ -198,7 +198,7 @@ func (s *Server) postValidatedArtifactsV2(ctx echo.Context) error {
 
 func (s *Server) addToLocalStorage(pocStageStartHeight int64, modelID, nodeId string, protoArtifacts []*types.PoCArtifactV2) (uint32, map[string]uint32, error) {
 	if s.artifactStore == nil {
-		return 0, nil, echo.NewHTTPError(http.StatusServiceUnavailable, "artifact store not configured")
+		return 0, nil, errors.New("artifact store not configured")
 	}
 
 	store, err := s.artifactStore.GetOrCreateStore(pocStageStartHeight, modelID)

--- a/decentralized-api/internal/server/mlnode/server_test.go
+++ b/decentralized-api/internal/server/mlnode/server_test.go
@@ -132,6 +132,7 @@ func newMLNodeTestBroker(t *testing.T, phase types.EpochPhase, modelIDs ...strin
 func TestV2GeneratedCallbackRequiresModelScopedRoute(t *testing.T) {
 	artifactStore := artifacts.NewManagedArtifactStore(t.TempDir(), 3)
 	defer artifactStore.Close()
+	artifactStore.ActivateStage(100)
 
 	server := NewServer(nil, newMLNodeTestBroker(t, types.PoCGeneratePhase, testModelA, testModelB), WithArtifactStore(artifactStore))
 

--- a/decentralized-api/internal/server/public/poc_handler.go
+++ b/decentralized-api/internal/server/public/poc_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"decentralized-api/logging"
+	"decentralized-api/poc"
 	"decentralized-api/poc/artifacts"
 	"encoding/base64"
 	"encoding/binary"
@@ -395,7 +396,10 @@ func (s *Server) preparePocProofRequest(
 		return nil, 0, nil, echo.NewHTTPError(http.StatusUnauthorized, "invalid signature")
 	}
 
-	stageStore, err := s.artifactStore.GetStore(int64(req.PocStageStartBlockHeight), req.ModelId)
+	reqHeight := int64(req.PocStageStartBlockHeight)
+	s.ensureArtifactStagePinned(reqHeight)
+
+	stageStore, err := s.artifactStore.GetStore(reqHeight, req.ModelId)
 	if err != nil {
 		logging.Warn("Stage store not found", types.Validation,
 			"pocStageStartBlockHeight", req.PocStageStartBlockHeight,
@@ -454,6 +458,8 @@ func (s *Server) getPocArtifactsState(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "model_id query parameter required")
 	}
 
+	s.ensureArtifactStagePinned(height)
+
 	store, err := s.artifactStore.GetStore(height, modelID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "not found for height (may be pruned or not yet created)")
@@ -472,6 +478,18 @@ func (s *Server) getPocArtifactsState(ctx echo.Context) error {
 		Count:                    count,
 		RootHash:                 rootHashB64,
 	})
+}
+
+// ensureArtifactStagePinned activates height when it is the current PoC/CPoC
+// stage. Safe no-op for other heights (those stay rejected by GetStore).
+func (s *Server) ensureArtifactStagePinned(height int64) {
+	if s.artifactStore == nil || s.phaseTracker == nil || height <= 0 {
+		return
+	}
+	epochState := s.phaseTracker.GetCurrentEpochState()
+	if cur := poc.GetCurrentPocStageHeight(epochState); cur > 0 && cur == height {
+		s.artifactStore.ActivateStage(cur)
+	}
 }
 
 // buildPocProofsSignPayload builds the binary payload for signature verification.

--- a/decentralized-api/internal/server/public/poc_handler_test.go
+++ b/decentralized-api/internal/server/public/poc_handler_test.go
@@ -334,6 +334,8 @@ func TestGetPocArtifactsState_UsesModelScopedStore(t *testing.T) {
 	store := artifacts.NewManagedArtifactStore(t.TempDir(), 3)
 	defer store.Close()
 
+	store.ActivateStage(100)
+
 	modelStore, err := store.GetOrCreateStore(100, "org/model-a")
 	assert.NoError(t, err)
 	assert.NoError(t, modelStore.AddWithNode(1, []byte("artifact-a"), ""))
@@ -364,6 +366,8 @@ func TestGetPocArtifactsState_UsesModelScopedStore(t *testing.T) {
 func TestPostPocProofs_UsesModelScopedStore(t *testing.T) {
 	store := artifacts.NewManagedArtifactStore(t.TempDir(), 3)
 	defer store.Close()
+
+	store.ActivateStage(100)
 
 	modelAStore, err := store.GetOrCreateStore(100, "model-a")
 	assert.NoError(t, err)
@@ -430,6 +434,8 @@ func TestPostPocProofs_UsesModelScopedStore(t *testing.T) {
 func TestPostPocProofsByNonce_UsesModelScopedStore(t *testing.T) {
 	store := artifacts.NewManagedArtifactStore(t.TempDir(), 3)
 	defer store.Close()
+
+	store.ActivateStage(100)
 
 	modelAStore, err := store.GetOrCreateStore(100, "model-a")
 	assert.NoError(t, err)

--- a/decentralized-api/poc/artifacts/managed_store.go
+++ b/decentralized-api/poc/artifacts/managed_store.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -17,13 +18,25 @@ import (
 	"github.com/productscience/inference/x/inference/types"
 )
 
+// ErrStageNotActive is returned when opening a store for a PoC stage that is
+// not the currently activated stage (or when no stage is active).
+var ErrStageNotActive = errors.New("poc artifact stage is not active")
+
 // ManagedArtifactStore wraps per-(stage, model) ArtifactStores with stage-based pruning.
 // The large retention buffer ensures pruned stores are "cold" with no active use.
+//
+// Only one PoC stage height may be open in RAM at a time. Call ActivateStage at
+// PoC/CPoC generate start (and keep it pinned through validation); call
+// DeactivateStage at validate end. GetStore/GetOrCreateStore refuse any other
+// height so attackers cannot force old trees into memory.
 type ManagedArtifactStore struct {
 	mu          sync.RWMutex
 	baseDir     string
 	stores      map[storeKey]ArtifactStore
 	retainCount int
+	// activeStage is the only stage height allowed in RAM. 0 means inactive:
+	// no store may be opened until ActivateStage.
+	activeStage int64
 	cancel      context.CancelFunc
 	flushCancel context.CancelFunc
 	// pruneHooks are invoked (best-effort) with the stage height whenever a
@@ -94,19 +107,100 @@ func (m *ManagedArtifactStore) getCachedStore(key storeKey) (ArtifactStore, bool
 	return store, ok
 }
 
-func (m *ManagedArtifactStore) putStoreIfAbsent(key storeKey, store ArtifactStore) (ArtifactStore, bool) {
+func (m *ManagedArtifactStore) requireActiveStage(stage int64) error {
+	var active int64
+	m.withReadLock(func() {
+		active = m.activeStage
+	})
+	if active == 0 || active != stage {
+		return fmt.Errorf("%w: requested %d active %d", ErrStageNotActive, stage, active)
+	}
+	return nil
+}
+
+// ActiveStage returns the currently activated PoC stage height, or 0 if none.
+func (m *ManagedArtifactStore) ActiveStage() int64 {
+	var active int64
+	m.withReadLock(func() {
+		active = m.activeStage
+	})
+	return active
+}
+
+// ActivateStage pins stage as the only PoC height allowed in RAM and closes any
+// open stores for other heights. Disk data is kept. Safe to call every block.
+func (m *ManagedArtifactStore) ActivateStage(stage int64) {
+	if stage <= 0 {
+		m.DeactivateStage()
+		return
+	}
+
+	var prev int64
+	m.withWriteLock(func() {
+		prev = m.activeStage
+		m.activeStage = stage
+	})
+	m.unloadRAMExcept(stage)
+	if prev != stage {
+		logging.Info("Activated PoC artifact stage", types.PoC, "stage", stage, "previous", prev)
+	}
+}
+
+// DeactivateStage clears the active stage and unloads every open store from RAM.
+// Disk data is kept. Safe to call every block outside PoC/CPoC windows.
+func (m *ManagedArtifactStore) DeactivateStage() {
+	var prev int64
+	m.withWriteLock(func() {
+		prev = m.activeStage
+		m.activeStage = 0
+	})
+	m.unloadRAMExcept(0)
+	if prev != 0 {
+		logging.Info("Deactivated PoC artifact stage", types.PoC, "previous", prev)
+	}
+}
+
+// unloadRAMExcept closes and drops in-memory stores whose stage != keep.
+// keep == 0 closes everything. Does not delete disk directories.
+func (m *ManagedArtifactStore) unloadRAMExcept(keep int64) {
+	var toClose []ArtifactStore
+	m.withWriteLock(func() {
+		for key, store := range m.stores {
+			if keep != 0 && key.stage == keep {
+				continue
+			}
+			toClose = append(toClose, store)
+			delete(m.stores, key)
+		}
+	})
+	for _, store := range toClose {
+		if store == nil {
+			continue
+		}
+		if err := store.Close(); err != nil {
+			logging.Warn("Failed to close artifact store on unload", types.PoC, "error", err)
+		}
+	}
+}
+
+func (m *ManagedArtifactStore) putStoreIfAbsent(key storeKey, store ArtifactStore) (ArtifactStore, bool, error) {
 	var (
 		existing ArtifactStore
 		loaded   bool
+		err      error
 	)
 	m.withWriteLock(func() {
+		if m.activeStage == 0 || m.activeStage != key.stage {
+			err = fmt.Errorf("%w: requested %d active %d", ErrStageNotActive, key.stage, m.activeStage)
+			return
+		}
 		existing, loaded = m.stores[key]
 		if !loaded {
 			m.stores[key] = store
 			existing = store
 		}
 	})
-	return existing, loaded
+	return existing, loaded, err
 }
 
 func (m *ManagedArtifactStore) snapshotStores() []ArtifactStore {
@@ -225,6 +319,9 @@ func (m *ManagedArtifactStore) GetOrCreateStore(pocStageStartHeight int64, model
 	if err != nil {
 		return nil, err
 	}
+	if err := m.requireActiveStage(pocStageStartHeight); err != nil {
+		return nil, err
+	}
 
 	if store, ok := m.getCachedStore(key); ok {
 		return store, nil
@@ -236,7 +333,11 @@ func (m *ManagedArtifactStore) GetOrCreateStore(pocStageStartHeight int64, model
 		return nil, fmt.Errorf("open store for stage %d model %q: %w", pocStageStartHeight, modelID, err)
 	}
 
-	existing, loaded := m.putStoreIfAbsent(key, store)
+	existing, loaded, err := m.putStoreIfAbsent(key, store)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
 	if loaded {
 		_ = store.Close()
 		return existing, nil
@@ -250,6 +351,9 @@ func (m *ManagedArtifactStore) GetOrCreateStore(pocStageStartHeight int64, model
 func (m *ManagedArtifactStore) GetStore(pocStageStartHeight int64, modelID string) (ArtifactStore, error) {
 	key, err := m.storeKey(pocStageStartHeight, modelID)
 	if err != nil {
+		return nil, err
+	}
+	if err := m.requireActiveStage(pocStageStartHeight); err != nil {
 		return nil, err
 	}
 
@@ -269,7 +373,11 @@ func (m *ManagedArtifactStore) GetStore(pocStageStartHeight int64, modelID strin
 		return nil, fmt.Errorf("open store for stage %d model %q: %w", pocStageStartHeight, modelID, err)
 	}
 
-	existing, loaded := m.putStoreIfAbsent(key, store)
+	existing, loaded, err := m.putStoreIfAbsent(key, store)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
 	if loaded {
 		_ = store.Close()
 		return existing, nil

--- a/decentralized-api/poc/artifacts/managed_store.go
+++ b/decentralized-api/poc/artifacts/managed_store.go
@@ -136,6 +136,11 @@ func (m *ManagedArtifactStore) ActivateStage(stage int64) {
 		return
 	}
 
+	// Already pinned: skip write lock + unload scan (called every block).
+	if m.ActiveStage() == stage {
+		return
+	}
+
 	var prev int64
 	m.withWriteLock(func() {
 		prev = m.activeStage

--- a/decentralized-api/poc/artifacts/managed_store.go
+++ b/decentralized-api/poc/artifacts/managed_store.go
@@ -25,10 +25,11 @@ var ErrStageNotActive = errors.New("poc artifact stage is not active")
 // ManagedArtifactStore wraps per-(stage, model) ArtifactStores with stage-based pruning.
 // The large retention buffer ensures pruned stores are "cold" with no active use.
 //
-// Only one PoC stage height may be open in RAM at a time. Call ActivateStage at
-// PoC/CPoC generate start (and keep it pinned through validation); call
-// DeactivateStage at validate end. GetStore/GetOrCreateStore refuse any other
-// height so attackers cannot force old trees into memory.
+// Only one PoC stage height may be open in RAM at a time. Sync pins
+// GetCurrentPocStageHeight while the node is synced; the pin switches (and the
+// previous stage is unloaded) when the next PoC or confirmation PoC changes
+// that height. GetStore/GetOrCreateStore refuse any other height so attackers
+// cannot force old trees into memory.
 type ManagedArtifactStore struct {
 	mu          sync.RWMutex
 	baseDir     string

--- a/decentralized-api/poc/artifacts/managed_store_test.go
+++ b/decentralized-api/poc/artifacts/managed_store_test.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ func TestManagedArtifactStore_GetOrCreateStore(t *testing.T) {
 	dir := t.TempDir()
 	m := NewManagedArtifactStore(dir, 3)
 	defer m.Close()
+	m.ActivateStage(100)
 
 	store1, err := m.GetOrCreateStore(100, "model-a")
 	if err != nil {
@@ -52,10 +54,78 @@ func TestManagedArtifactStore_GetStore_NotFound(t *testing.T) {
 	dir := t.TempDir()
 	m := NewManagedArtifactStore(dir, 3)
 	defer m.Close()
+	m.ActivateStage(999)
 
 	_, err := m.GetStore(999, "missing-model")
 	if err == nil {
 		t.Error("expected error for non-existent epoch")
+	}
+}
+
+func TestManagedArtifactStore_RefuseInactiveStage(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManagedArtifactStore(dir, 3)
+	defer m.Close()
+
+	_, err := m.GetOrCreateStore(100, "model-a")
+	if !errors.Is(err, ErrStageNotActive) {
+		t.Fatalf("expected ErrStageNotActive with no active stage, got %v", err)
+	}
+
+	m.ActivateStage(100)
+	if _, err := m.GetOrCreateStore(100, "model-a"); err != nil {
+		t.Fatalf("GetOrCreateStore active stage: %v", err)
+	}
+
+	_, err = m.GetStore(200, "model-a")
+	if !errors.Is(err, ErrStageNotActive) {
+		t.Fatalf("expected ErrStageNotActive for other height, got %v", err)
+	}
+
+	m.DeactivateStage()
+	_, err = m.GetStore(100, "model-a")
+	if !errors.Is(err, ErrStageNotActive) {
+		t.Fatalf("expected ErrStageNotActive after deactivate, got %v", err)
+	}
+	if m.ActiveStage() != 0 {
+		t.Fatalf("expected active stage 0, got %d", m.ActiveStage())
+	}
+}
+
+func TestManagedArtifactStore_ActivateUnloadsOtherStages(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManagedArtifactStore(dir, 3)
+	defer m.Close()
+
+	m.ActivateStage(100)
+	store100, err := m.GetOrCreateStore(100, "model-a")
+	if err != nil {
+		t.Fatalf("GetOrCreateStore(100): %v", err)
+	}
+	if err := store100.AddWithNode(1, []byte("a"), ""); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store100.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	m.ActivateStage(200)
+	if got := len(m.snapshotStores()); got != 0 {
+		t.Fatalf("expected no RAM stores after switching stage before open, got %d", got)
+	}
+	if _, err := m.GetStore(100, "model-a"); !errors.Is(err, ErrStageNotActive) {
+		t.Fatalf("expected ErrStageNotActive for previous stage, got %v", err)
+	}
+
+	store200, err := m.GetOrCreateStore(200, "model-a")
+	if err != nil {
+		t.Fatalf("GetOrCreateStore(200): %v", err)
+	}
+	_ = store200
+
+	// Previous stage remains on disk.
+	if _, err := os.Stat(filepath.Join(dir, "100", "model-a")); err != nil {
+		t.Fatalf("stage 100 should remain on disk: %v", err)
 	}
 }
 
@@ -64,6 +134,7 @@ func TestManagedArtifactStore_GetStore_ExistingDir(t *testing.T) {
 
 	// Create epoch 100 with first manager
 	m1 := NewManagedArtifactStore(dir, 3)
+	m1.ActivateStage(100)
 	store, err := m1.GetOrCreateStore(100, "org/model")
 	if err != nil {
 		t.Fatalf("GetOrCreateStore failed: %v", err)
@@ -79,6 +150,7 @@ func TestManagedArtifactStore_GetStore_ExistingDir(t *testing.T) {
 	// New manager should find existing epoch via GetStore
 	m2 := NewManagedArtifactStore(dir, 3)
 	defer m2.Close()
+	m2.ActivateStage(100)
 
 	store2, err := m2.GetStore(100, "org/model")
 	if err != nil {
@@ -93,6 +165,7 @@ func TestManagedArtifactStore_GetStoresForStage(t *testing.T) {
 	dir := t.TempDir()
 	m := NewManagedArtifactStore(dir, 3)
 	defer m.Close()
+	m.ActivateStage(100)
 
 	for _, modelID := range []string{"z-model", "org/model-a", "model-b"} {
 		store, err := m.GetOrCreateStore(100, modelID)
@@ -131,6 +204,7 @@ func TestManagedArtifactStore_PruneStore(t *testing.T) {
 		{200, "model-a"},
 		{300, "model-a"},
 	} {
+		m.ActivateStage(tc.height)
 		if _, err := m.GetOrCreateStore(tc.height, tc.modelID); err != nil {
 			t.Fatalf("GetOrCreateStore(%d, %q) failed: %v", tc.height, tc.modelID, err)
 		}
@@ -154,7 +228,7 @@ func TestManagedArtifactStore_PruneStore(t *testing.T) {
 		t.Error("height 300 directory should still exist")
 	}
 
-	// GetStore should fail for pruned height
+	// GetStore should fail for pruned height (also inactive relative to stage 300)
 	if _, err := m.GetStore(100, "model-a"); err == nil {
 		t.Error("expected error for pruned height")
 	}
@@ -176,6 +250,7 @@ func TestManagedArtifactStore_ListStores(t *testing.T) {
 
 	// Create stores (out of order)
 	for _, height := range []int64{300, 100, 200} {
+		m.ActivateStage(height)
 		if _, err := m.GetOrCreateStore(height, "model-a"); err != nil {
 			t.Fatalf("GetOrCreateStore(%d) failed: %v", height, err)
 		}
@@ -201,6 +276,7 @@ func TestManagedArtifactStore_AutoPrune(t *testing.T) {
 
 	// Create stores at heights 100, 200, 300, 400, 500
 	for _, height := range []int64{100, 200, 300, 400, 500} {
+		m.ActivateStage(height)
 		if _, err := m.GetOrCreateStore(height, "model-a"); err != nil {
 			t.Fatalf("GetOrCreateStore(%d) failed: %v", height, err)
 		}
@@ -233,6 +309,7 @@ func TestManagedArtifactStore_Flush(t *testing.T) {
 	dir := t.TempDir()
 	m := NewManagedArtifactStore(dir, 3)
 	defer m.Close()
+	m.ActivateStage(100)
 
 	store, err := m.GetOrCreateStore(100, "model-a")
 	if err != nil {
@@ -268,6 +345,7 @@ func TestManagedArtifactStore_ParallelModelStores(t *testing.T) {
 		modelCount     = 12
 		writesPerModel = 200
 	)
+	m.ActivateStage(stage)
 
 	var writeWG sync.WaitGroup
 	writeErrs := make(chan error, modelCount)

--- a/decentralized-api/poc/artifacts/smst_cow.go
+++ b/decentralized-api/poc/artifacts/smst_cow.go
@@ -10,7 +10,9 @@ import (
 // SMST_PARALLEL_HASH default on when unset.
 // Profiling overrides:
 //
-//	SMST_COW=0             — in-place Insert (no path-copy)
+//	SMST_COW=0             — Deprecated: in-place Insert (no path-copy). Keep
+//	                         COW enabled in production; this flag is for
+//	                         profiling baselines only.
 //	SMST_DEFERRED_HASH=0   — hash on every insert (upgrade-v0.2.14 baseline)
 //	SMST_SNAPSHOT_IN_MEMORY_CLONE=0  — tip Prebuild rebuilds from artifacts without holding
 //	                         the write lock (upgrade-v0.2.14 Warm/Prebuild path);
@@ -40,6 +42,9 @@ func smstEnvBool(key string, def bool) bool {
 }
 
 // smstCOWEnabledFromEnv reports COW inserts; default true.
+//
+// Deprecated: returning false (SMST_COW=0) selects the legacy in-place Insert
+// path. Production must leave COW enabled.
 func smstCOWEnabledFromEnv() bool {
 	return smstEnvBool(envSMSTCOW, true)
 }

--- a/decentralized-api/poc/artifacts/smst_store.go
+++ b/decentralized-api/poc/artifacts/smst_store.go
@@ -144,7 +144,9 @@ func OpenSMST(dir string) (*SMSTArtifactStore, error) {
 	}
 	s.smst.deferredHash = smstDeferredHashFromEnv()
 	s.smst.parallelHash = smstParallelHashFromEnv()
-
+	if !s.cowEnabled {
+		log.Printf("[WARN] SMST_COW=0: non-COW insert path is deprecated; use only for profiling baselines")
+	}
 
 	if err := s.recover(); err != nil {
 		s.dataFile.Close()
@@ -910,6 +912,9 @@ func (s *SMSTArtifactStore) liveRootHashed() bool {
 
 // insertLeaf adds a leaf via insertCOW (default) or in-place Insert when
 // SMST_COW is disabled. Both paths use deferred hashing.
+//
+// Deprecated: the SMST_COW=0 in-place branch is a profiling baseline only.
+// Production must keep copy-on-write enabled.
 func (s *SMSTArtifactStore) insertLeaf(nonce int32, leafHash []byte) (uint32, error) {
 	if s.cowEnabled {
 		return s.smst.insertCOW(nonce, leafHash)

--- a/decentralized-api/poc/commit_worker_test.go
+++ b/decentralized-api/poc/commit_worker_test.go
@@ -184,6 +184,7 @@ func TestCommitWorker_MaybeSubmitCommit_SkipsUnchanged(t *testing.T) {
 	}
 
 	pocHeight := int64(100)
+	store.ActivateStage(pocHeight)
 
 	// Get or create store and add an artifact
 	artifactStore, err := store.GetOrCreateStore(pocHeight, "model-a")
@@ -222,6 +223,7 @@ func TestCommitWorker_MaybeSubmitCommit_BatchesModels(t *testing.T) {
 	}
 
 	pocHeight := int64(100)
+	store.ActivateStage(pocHeight)
 	for _, tc := range []struct {
 		modelID string
 		nonce   int32
@@ -318,6 +320,7 @@ func TestCommitWorker_SubmitWeightDistribution_NoCommitFound(t *testing.T) {
 
 	store := artifacts.NewManagedArtifactStore(tmpDir, 5)
 	defer store.Close()
+	store.ActivateStage(100)
 
 	_, err = store.GetOrCreateStore(100, "model-a")
 	assert.NoError(t, err)
@@ -330,6 +333,7 @@ func TestCommitWorker_SubmitWeightDistribution_BatchesModels(t *testing.T) {
 
 	store := artifacts.NewManagedArtifactStore(tmpDir, 5)
 	defer store.Close()
+	store.ActivateStage(100)
 
 	for idx, modelID := range []string{"model-a", "org/model-b"} {
 		artifactStore, err := store.GetOrCreateStore(100, modelID)
@@ -379,6 +383,7 @@ func TestCommitWorker_SubmitWeightDistribution_OneModelAlreadyOnChain(t *testing
 
 	store := artifacts.NewManagedArtifactStore(tmpDir, 5)
 	defer store.Close()
+	store.ActivateStage(100)
 
 	for idx, modelID := range []string{"model-a", "org/model-b"} {
 		artifactStore, err := store.GetOrCreateStore(100, modelID)
@@ -428,6 +433,7 @@ func TestCommitWorker_HasPendingWeightDistribution(t *testing.T) {
 
 	store := artifacts.NewManagedArtifactStore(tmpDir, 5)
 	defer store.Close()
+	store.ActivateStage(100)
 
 	for _, modelID := range []string{"model-a", "model-b"} {
 		artifactStore, err := store.GetOrCreateStore(100, modelID)
@@ -469,6 +475,7 @@ func TestCommitWorker_SubmitWeightDistribution_UpdatesLastAttemptOnNoOp(t *testi
 
 	store := artifacts.NewManagedArtifactStore(tmpDir, 5)
 	defer store.Close()
+	store.ActivateStage(100)
 
 	artifactStore, err := store.GetOrCreateStore(100, "model-a")
 	assert.NoError(t, err)

--- a/decentralized-api/poc/phase.go
+++ b/decentralized-api/poc/phase.go
@@ -170,22 +170,25 @@ func ShouldHaveDistributedWeights(epochState *chainphase.EpochState) bool {
 // must keep the current PoC/CPoC stage pinned in RAM (generate through validate,
 // including wind-down). Outside these windows the store must be inactive so
 // proof/artifact opens for old heights are refused.
-func ShouldKeepPocArtifactStageActive(epochState *chainphase.EpochState) bool {
+//
+// decided is false when epoch state is nil or not synced: callers must leave
+// the current pin unchanged (a transient catch-up must not unload mid-PoC).
+func ShouldKeepPocArtifactStageActive(epochState *chainphase.EpochState) (keep bool, decided bool) {
 	if epochState.IsNilOrNotSynced() {
-		return false
+		return false, false
 	}
 	switch epochState.CurrentPhase {
 	case types.PoCGeneratePhase, types.PoCGenerateWindDownPhase,
 		types.PoCValidatePhase, types.PoCValidateWindDownPhase:
-		return true
+		return true, true
 	}
 	if epochState.CurrentPhase == types.InferencePhase &&
 		epochState.ActiveConfirmationPoCEvent != nil {
 		switch epochState.ActiveConfirmationPoCEvent.Phase {
 		case types.ConfirmationPoCPhase_CONFIRMATION_POC_GENERATION,
 			types.ConfirmationPoCPhase_CONFIRMATION_POC_VALIDATION:
-			return true
+			return true, true
 		}
 	}
-	return false
+	return false, true
 }

--- a/decentralized-api/poc/phase.go
+++ b/decentralized-api/poc/phase.go
@@ -165,30 +165,3 @@ func ShouldHaveDistributedWeights(epochState *chainphase.EpochState) bool {
 	}
 	return false
 }
-
-// ShouldKeepPocArtifactStageActive reports whether the managed artifact store
-// must keep the current PoC/CPoC stage pinned in RAM (generate through validate,
-// including wind-down). Outside these windows the store must be inactive so
-// proof/artifact opens for old heights are refused.
-//
-// decided is false when epoch state is nil or not synced: callers must leave
-// the current pin unchanged (a transient catch-up must not unload mid-PoC).
-func ShouldKeepPocArtifactStageActive(epochState *chainphase.EpochState) (keep bool, decided bool) {
-	if epochState.IsNilOrNotSynced() {
-		return false, false
-	}
-	switch epochState.CurrentPhase {
-	case types.PoCGeneratePhase, types.PoCGenerateWindDownPhase,
-		types.PoCValidatePhase, types.PoCValidateWindDownPhase:
-		return true, true
-	}
-	if epochState.CurrentPhase == types.InferencePhase &&
-		epochState.ActiveConfirmationPoCEvent != nil {
-		switch epochState.ActiveConfirmationPoCEvent.Phase {
-		case types.ConfirmationPoCPhase_CONFIRMATION_POC_GENERATION,
-			types.ConfirmationPoCPhase_CONFIRMATION_POC_VALIDATION:
-			return true, true
-		}
-	}
-	return false, true
-}

--- a/decentralized-api/poc/phase.go
+++ b/decentralized-api/poc/phase.go
@@ -165,3 +165,27 @@ func ShouldHaveDistributedWeights(epochState *chainphase.EpochState) bool {
 	}
 	return false
 }
+
+// ShouldKeepPocArtifactStageActive reports whether the managed artifact store
+// must keep the current PoC/CPoC stage pinned in RAM (generate through validate,
+// including wind-down). Outside these windows the store must be inactive so
+// proof/artifact opens for old heights are refused.
+func ShouldKeepPocArtifactStageActive(epochState *chainphase.EpochState) bool {
+	if epochState.IsNilOrNotSynced() {
+		return false
+	}
+	switch epochState.CurrentPhase {
+	case types.PoCGeneratePhase, types.PoCGenerateWindDownPhase,
+		types.PoCValidatePhase, types.PoCValidateWindDownPhase:
+		return true
+	}
+	if epochState.CurrentPhase == types.InferencePhase &&
+		epochState.ActiveConfirmationPoCEvent != nil {
+		switch epochState.ActiveConfirmationPoCEvent.Phase {
+		case types.ConfirmationPoCPhase_CONFIRMATION_POC_GENERATION,
+			types.ConfirmationPoCPhase_CONFIRMATION_POC_VALIDATION:
+			return true
+		}
+	}
+	return false
+}

--- a/decentralized-api/poc/phase_test.go
+++ b/decentralized-api/poc/phase_test.go
@@ -250,7 +250,7 @@ func TestGetCurrentPocStageHeight_NilOrNotSynced(t *testing.T) {
 	assert.Equal(t, int64(0), GetCurrentPocStageHeight(notSynced))
 }
 
-func TestGetCurrentPocStageHeight_ConfirmationSwitchesPinIdentity(t *testing.T) {
+func TestGetCurrentPocStageHeight_ConfirmationPoCChangesActiveStageHeight(t *testing.T) {
 	st := createTestEpochState(types.InferencePhase, 500, 100)
 	assert.Equal(t, int64(100), GetCurrentPocStageHeight(st))
 

--- a/decentralized-api/poc/phase_test.go
+++ b/decentralized-api/poc/phase_test.go
@@ -250,62 +250,18 @@ func TestGetCurrentPocStageHeight_NilOrNotSynced(t *testing.T) {
 	assert.Equal(t, int64(0), GetCurrentPocStageHeight(notSynced))
 }
 
-func TestShouldKeepPocArtifactStageActive(t *testing.T) {
-	tests := []struct {
-		name string
-		phase types.EpochPhase
-		want  bool
-	}{
-		{"generate", types.PoCGeneratePhase, true},
-		{"generate wind down", types.PoCGenerateWindDownPhase, true},
-		{"validate", types.PoCValidatePhase, true},
-		{"validate wind down", types.PoCValidateWindDownPhase, true},
-		{"inference", types.InferencePhase, false},
+func TestGetCurrentPocStageHeight_ConfirmationSwitchesPinIdentity(t *testing.T) {
+	st := createTestEpochState(types.InferencePhase, 500, 100)
+	assert.Equal(t, int64(100), GetCurrentPocStageHeight(st))
+
+	st.ActiveConfirmationPoCEvent = &types.ConfirmationPoCEvent{
+		TriggerHeight: 400,
+		Phase:         types.ConfirmationPoCPhase_CONFIRMATION_POC_GENERATION,
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			st := createTestEpochState(tt.phase, 110, 100)
-			keep, decided := ShouldKeepPocArtifactStageActive(st)
-			assert.True(t, decided)
-			assert.Equal(t, tt.want, keep)
-		})
-	}
+	assert.Equal(t, int64(400), GetCurrentPocStageHeight(st))
 
-	t.Run("confirmation generation", func(t *testing.T) {
-		st := createTestEpochState(types.InferencePhase, 500, 100)
-		st.ActiveConfirmationPoCEvent = &types.ConfirmationPoCEvent{
-			TriggerHeight: 400,
-			Phase:         types.ConfirmationPoCPhase_CONFIRMATION_POC_GENERATION,
-		}
-		keep, decided := ShouldKeepPocArtifactStageActive(st)
-		assert.True(t, decided)
-		assert.True(t, keep)
-	})
-
-	t.Run("confirmation validation", func(t *testing.T) {
-		st := createTestEpochState(types.InferencePhase, 500, 100)
-		st.ActiveConfirmationPoCEvent = &types.ConfirmationPoCEvent{
-			TriggerHeight: 400,
-			Phase:         types.ConfirmationPoCPhase_CONFIRMATION_POC_VALIDATION,
-		}
-		keep, decided := ShouldKeepPocArtifactStageActive(st)
-		assert.True(t, decided)
-		assert.True(t, keep)
-	})
-
-	t.Run("nil makes no decision", func(t *testing.T) {
-		keep, decided := ShouldKeepPocArtifactStageActive(nil)
-		assert.False(t, decided)
-		assert.False(t, keep)
-	})
-
-	t.Run("unsynced makes no decision", func(t *testing.T) {
-		st := createTestEpochState(types.PoCValidatePhase, 200, 100)
-		st.IsSynced = false
-		keep, decided := ShouldKeepPocArtifactStageActive(st)
-		assert.False(t, decided)
-		assert.False(t, keep)
-	})
+	st.ActiveConfirmationPoCEvent.Phase = types.ConfirmationPoCPhase_CONFIRMATION_POC_VALIDATION
+	assert.Equal(t, int64(400), GetCurrentPocStageHeight(st))
 }
 
 func TestShouldAcceptStoreCommit_RegularPoC(t *testing.T) {

--- a/decentralized-api/poc/phase_test.go
+++ b/decentralized-api/poc/phase_test.go
@@ -250,6 +250,48 @@ func TestGetCurrentPocStageHeight_NilOrNotSynced(t *testing.T) {
 	assert.Equal(t, int64(0), GetCurrentPocStageHeight(notSynced))
 }
 
+func TestShouldKeepPocArtifactStageActive(t *testing.T) {
+	tests := []struct {
+		name   string
+		phase  types.EpochPhase
+		want   bool
+	}{
+		{"generate", types.PoCGeneratePhase, true},
+		{"generate wind down", types.PoCGenerateWindDownPhase, true},
+		{"validate", types.PoCValidatePhase, true},
+		{"validate wind down", types.PoCValidateWindDownPhase, true},
+		{"inference", types.InferencePhase, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := createTestEpochState(tt.phase, 110, 100)
+			assert.Equal(t, tt.want, ShouldKeepPocArtifactStageActive(st))
+		})
+	}
+
+	t.Run("confirmation generation", func(t *testing.T) {
+		st := createTestEpochState(types.InferencePhase, 500, 100)
+		st.ActiveConfirmationPoCEvent = &types.ConfirmationPoCEvent{
+			TriggerHeight: 400,
+			Phase:         types.ConfirmationPoCPhase_CONFIRMATION_POC_GENERATION,
+		}
+		assert.True(t, ShouldKeepPocArtifactStageActive(st))
+	})
+
+	t.Run("confirmation validation", func(t *testing.T) {
+		st := createTestEpochState(types.InferencePhase, 500, 100)
+		st.ActiveConfirmationPoCEvent = &types.ConfirmationPoCEvent{
+			TriggerHeight: 400,
+			Phase:         types.ConfirmationPoCPhase_CONFIRMATION_POC_VALIDATION,
+		}
+		assert.True(t, ShouldKeepPocArtifactStageActive(st))
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		assert.False(t, ShouldKeepPocArtifactStageActive(nil))
+	})
+}
+
 func TestShouldAcceptStoreCommit_RegularPoC(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/decentralized-api/poc/phase_test.go
+++ b/decentralized-api/poc/phase_test.go
@@ -252,9 +252,9 @@ func TestGetCurrentPocStageHeight_NilOrNotSynced(t *testing.T) {
 
 func TestShouldKeepPocArtifactStageActive(t *testing.T) {
 	tests := []struct {
-		name   string
-		phase  types.EpochPhase
-		want   bool
+		name string
+		phase types.EpochPhase
+		want  bool
 	}{
 		{"generate", types.PoCGeneratePhase, true},
 		{"generate wind down", types.PoCGenerateWindDownPhase, true},
@@ -265,7 +265,9 @@ func TestShouldKeepPocArtifactStageActive(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			st := createTestEpochState(tt.phase, 110, 100)
-			assert.Equal(t, tt.want, ShouldKeepPocArtifactStageActive(st))
+			keep, decided := ShouldKeepPocArtifactStageActive(st)
+			assert.True(t, decided)
+			assert.Equal(t, tt.want, keep)
 		})
 	}
 
@@ -275,7 +277,9 @@ func TestShouldKeepPocArtifactStageActive(t *testing.T) {
 			TriggerHeight: 400,
 			Phase:         types.ConfirmationPoCPhase_CONFIRMATION_POC_GENERATION,
 		}
-		assert.True(t, ShouldKeepPocArtifactStageActive(st))
+		keep, decided := ShouldKeepPocArtifactStageActive(st)
+		assert.True(t, decided)
+		assert.True(t, keep)
 	})
 
 	t.Run("confirmation validation", func(t *testing.T) {
@@ -284,11 +288,23 @@ func TestShouldKeepPocArtifactStageActive(t *testing.T) {
 			TriggerHeight: 400,
 			Phase:         types.ConfirmationPoCPhase_CONFIRMATION_POC_VALIDATION,
 		}
-		assert.True(t, ShouldKeepPocArtifactStageActive(st))
+		keep, decided := ShouldKeepPocArtifactStageActive(st)
+		assert.True(t, decided)
+		assert.True(t, keep)
 	})
 
-	t.Run("nil", func(t *testing.T) {
-		assert.False(t, ShouldKeepPocArtifactStageActive(nil))
+	t.Run("nil makes no decision", func(t *testing.T) {
+		keep, decided := ShouldKeepPocArtifactStageActive(nil)
+		assert.False(t, decided)
+		assert.False(t, keep)
+	})
+
+	t.Run("unsynced makes no decision", func(t *testing.T) {
+		st := createTestEpochState(types.PoCValidatePhase, 200, 100)
+		st.IsSynced = false
+		keep, decided := ShouldKeepPocArtifactStageActive(st)
+		assert.False(t, decided)
+		assert.False(t, keep)
 	})
 }
 

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -184,6 +184,23 @@ func NewOffChainValidator(
 	}
 }
 
+// SyncArtifactStoreStage keeps only the current PoC/CPoC stage open in RAM for
+// the whole generate→validate window, and refuses/unloads everything else.
+// Called every synced block so a restart mid-window re-pins without waiting
+// for an exact transition height.
+func (v *OffChainValidator) SyncArtifactStoreStage(epochState chainphase.EpochState) {
+	if v.artifactStore == nil {
+		return
+	}
+	if ShouldKeepPocArtifactStageActive(&epochState) {
+		if height := GetCurrentPocStageHeight(&epochState); height > 0 {
+			v.artifactStore.ActivateStage(height)
+			return
+		}
+	}
+	v.artifactStore.DeactivateStage()
+}
+
 // MaybeCaptureEarlyShare is invoked once per block by the dispatcher. From the
 // first-fraction height until the end of the generation window it attempts the
 // early-share capture. The capture query is pinned to the exact first-fraction

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -198,9 +198,14 @@ func (v *OffChainValidator) SyncArtifactStoreStage(epochState chainphase.EpochSt
 		return
 	}
 	if keep {
-		if height := GetCurrentPocStageHeight(&epochState); height > 0 {
-			v.artifactStore.ActivateStage(height)
+		height := GetCurrentPocStageHeight(&epochState)
+		if height <= 0 {
+			// Fail closed: avoid leaving a stale stage pinned if the current
+			// stage height is invalid.
+			v.artifactStore.DeactivateStage()
+			return
 		}
+		v.artifactStore.ActivateStage(height)
 		return
 	}
 	v.artifactStore.DeactivateStage()

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -184,31 +184,22 @@ func NewOffChainValidator(
 	}
 }
 
-// SyncArtifactStoreStage keeps only the current PoC/CPoC stage open in RAM for
-// the whole generate→validate window, and refuses/unloads everything else.
-// Called every synced block so a restart mid-window re-pins without waiting
-// for an exact transition height. If epoch state is nil/unsynced, leaves the
-// current pin alone.
+// SyncArtifactStoreStage pins GetCurrentPocStageHeight in RAM while synced.
+// The previous stage is unloaded only when that height changes (next PoC or
+// confirmation PoC). Nil/unsynced leaves the pin alone. Invalid height leaves
+// the pin alone (do not fail-closed deactivate — that can drop a live tree).
 func (v *OffChainValidator) SyncArtifactStoreStage(epochState chainphase.EpochState) {
 	if v.artifactStore == nil {
 		return
 	}
-	keep, decided := ShouldKeepPocArtifactStageActive(&epochState)
-	if !decided {
+	if epochState.IsNilOrNotSynced() {
 		return
 	}
-	if keep {
-		height := GetCurrentPocStageHeight(&epochState)
-		if height <= 0 {
-			// Fail closed: avoid leaving a stale stage pinned if the current
-			// stage height is invalid.
-			v.artifactStore.DeactivateStage()
-			return
-		}
-		v.artifactStore.ActivateStage(height)
+	height := GetCurrentPocStageHeight(&epochState)
+	if height <= 0 {
 		return
 	}
-	v.artifactStore.DeactivateStage()
+	v.artifactStore.ActivateStage(height)
 }
 
 // MaybeCaptureEarlyShare is invoked once per block by the dispatcher. From the

--- a/decentralized-api/poc/validator.go
+++ b/decentralized-api/poc/validator.go
@@ -187,16 +187,21 @@ func NewOffChainValidator(
 // SyncArtifactStoreStage keeps only the current PoC/CPoC stage open in RAM for
 // the whole generate→validate window, and refuses/unloads everything else.
 // Called every synced block so a restart mid-window re-pins without waiting
-// for an exact transition height.
+// for an exact transition height. If epoch state is nil/unsynced, leaves the
+// current pin alone.
 func (v *OffChainValidator) SyncArtifactStoreStage(epochState chainphase.EpochState) {
 	if v.artifactStore == nil {
 		return
 	}
-	if ShouldKeepPocArtifactStageActive(&epochState) {
+	keep, decided := ShouldKeepPocArtifactStageActive(&epochState)
+	if !decided {
+		return
+	}
+	if keep {
 		if height := GetCurrentPocStageHeight(&epochState); height > 0 {
 			v.artifactStore.ActivateStage(height)
-			return
 		}
+		return
 	}
 	v.artifactStore.DeactivateStage()
 }


### PR DESCRIPTION
## Summary

Pin at most one PoC/CPoC artifact **stage** in RAM, refuse opens for any other height, and mark the non-COW SMST path deprecated. No idle TTL. The pin lasts until the **next** PoC or confirmation PoC changes the stage height (not merely until validate ends).

## Key decisions

- **No TTL.** An idle timer can unload the store during active validation; that is unacceptable.
- **Pin until next PoC/CPoC, not until validate end.** While synced, every block pins `GetCurrentPocStageHeight`. Leaving validate / sitting in inference does **not** deactivate. The previous stage is unloaded only when the height switches (next main PoC or confirmation PoC begins).
- **One stage height in RAM, not one store.** Multiple models for the *same* stage may be open; different stage heights may not.
- **Refuse non-active opens.** `GetStore` / `GetOrCreateStore` fail with `ErrStageNotActive` if no stage is active or the requested height ≠ active. Attackers cannot pull old epochs into memory.
- **Unsynced = no decision.** If epoch state is nil/not synced, leave the current pin unchanged.
- **Invalid height = no decision.** Do not fail-closed deactivate on `height <= 0`; that can drop a live tree.
- **Ingest self-heals the pin.** MLNode artifact callbacks `ActivateStage` after the generate-phase accept check, require `block_height ==` active stage, and return a non-2xx if storage fails (no silent 200 + dropped artifacts).
- **Proof path self-heals for the current stage.** Proof/state handlers pin when the requested height equals the current stage height.
- **Unload closes RAM only.** Disk stage dirs are unchanged by pin/unpin; existing disk prune (`retainCount=10`) still deletes old epochs from disk separately.
- **Non-COW is deprecated.** `SMST_COW=0` remains for profiling only; production keeps COW (default).

## Lifecycle (current behavior)

### 1. Process start

- `ManagedArtifactStore` starts with `activeStage = 0` and an empty in-memory `stores` map.
- On disk, previous stage directories may still exist under `poc-artifacts/<height>/…`.

### 2. Every synced block

Dispatcher calls `SyncArtifactStoreStage` **before** generate/validate work on that block:

1. If epoch state is nil/unsynced → **do nothing** (keep whatever is pinned).
2. Otherwise pin `GetCurrentPocStageHeight()` when `> 0` via `ActivateStage(H)`.
3. Never deactivate merely because we left the generate/validate window.

`ActivateStage(H)`:

- Sets `activeStage = H`.
- Closes and drops every open store whose stage ≠ `H`.
- Disk for other heights is kept.

Height identity:

- Regular PoC / inference without confirmation → `LatestEpoch.PocStartBlockHeight`
- Confirmation PoC during inference (event present) → `ActiveConfirmationPoCEvent.TriggerHeight`

So when CPoC begins, the pin switches to the trigger height and the main-PoC tree is unloaded. When the next main PoC epoch starts, `PocStartBlockHeight` changes and the previous pin is unloaded.

### 3. Artifact ingest (MLNode callback)

1. `ShouldAcceptGeneratedArtifacts` must pass (generate / exchange window / confirmation batch window) — unchanged.
2. `ActivateStage(currentStageHeight)` so ingest cannot lose a race with block Sync.
3. Reject if callback `block_height` ≠ current stage height.
4. `GetOrCreateStore` — on failure return **503**, not 200 with dropped data.

### 4. Proof serving

- Allowed for the **active** stage even during inference (until next PoC/CPoC).
- Other heights still refused (`ErrStageNotActive` → HTTP 404).
- Handlers call `ensureArtifactStagePinned` when the request height equals the current stage.

### 5. Disk prune (unchanged, orthogonal)

- Background cleanup still retains the newest N stage **directories** on disk and prunes older ones.
- That is **not** the RAM pin.

### 6. Mental model

| Moment | `activeStage` | RAM | Open other height? |
|--------|---------------|-----|--------------------|
| Synced, stage identity `H` | `H` | only stores for `H` | no |
| Inference after PoC (no CPoC) | last PoC `H` | still `H` | no |
| CPoC begins (`TriggerHeight=T`) | `T` | only `T` (previous unloaded) | no |
| Next main PoC (`H'`) | `H'` | only `H'` | no |
| Unsynced | unchanged | unchanged | gated by current pin |