### PR TITLE
Gm/gateway v3 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build devshardd-release print-devshard-version print-devshard-protocol-version versiond-build-docker testapp-server-build-docker
+.PHONY: release decentralized-api-release inference-chain-release tmkms-release proxy-release proxy-ssl-release bridge-release versiond-release check-docker build-testermint run-blockchain-tests test-blockchain local-build api-local-build node-local-build api-test node-test mock-server-build-docker proxy-build-docker proxy-ssl-build-docker bridge-build-docker run-bls-tests devshardctl-build devshardd-build devshardd-release devshard-gateway-release print-devshard-version print-devshard-protocol-version versiond-build-docker testapp-server-build-docker
 
 # For binary release: default linux/amd64 before local Docker defaults.
 DEVSHARDD_RELEASE_DOCKER_PLATFORM := $(if $(DOCKER_PLATFORM),$(DOCKER_PLATFORM),linux/amd64)
@@ -12,6 +12,8 @@ VERSION ?= $(shell git describe --always)
 DEVSHARD_VERSION ?= dev
 # State-root / settlement protocol tag (not versiond runtime name). See devshard/docs/protocol-version.md.
 DEVSHARD_PROTOCOL_VERSION ?= v2
+DEVSHARD_GATEWAY_IMAGE ?= ghcr.io/gonka-ai/devshard-gateway
+DEVSHARD_GATEWAY_TAGS ?=
 
 print-devshard-version:
 	@echo $(DEVSHARD_VERSION)
@@ -186,6 +188,15 @@ devshardd-release:
 		shasum -a 256 "$$release_dir/devshardd.zip" | awk '{print $$1}' > "$$release_dir/devshardd.zip.sha256"; \
 		echo "Built $$release_dir/devshardd.zip"; \
 		echo "SHA256: $$(cat "$$release_dir/devshardd.zip.sha256")"
+
+devshard-gateway-release: DEVSHARD_PROTOCOL_VERSION = v3
+devshard-gateway-release:
+	@$(MAKE) -C devshard devshard-gateway-release \
+		DEVSHARD_VERSION=$(DEVSHARD_VERSION) \
+		DEVSHARD_PROTOCOL_VERSION=$(DEVSHARD_PROTOCOL_VERSION) \
+		DEVSHARD_GATEWAY_IMAGE=$(DEVSHARD_GATEWAY_IMAGE) \
+		DEVSHARD_GATEWAY_TAGS="$(DEVSHARD_GATEWAY_TAGS)" \
+		PLATFORM=$(PLATFORM)
 
 node-local-build:
 	@echo "Building inference-chain locally..."

--- a/deploy/join/observability/grafana/dashboards/gonka-gateway-observability.json
+++ b/deploy/join/observability/grafana/dashboards/gonka-gateway-observability.json
@@ -653,7 +653,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 44
+        "y": 37
       },
       "id": 99,
       "targets": [
@@ -1570,6 +1570,67 @@
       ],
       "title": "Non-Inference Transport Errors by Path",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Escrows disabled because local state recovery failed during startup of the current gateway process. The signal clears after a later restart because already-inactive escrows are not retried.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "cellOptions": {
+              "type": "color-background"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "QUARANTINED"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 8,
+        "y": 132
+      },
+      "id": 116,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "devshard_gateway_startup_skipped_escrow{model=~\"$model\",escrow_id=~\"$escrow_id\",reason=\"local_recovery_failed\"} == 1",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Startup Recovery Quarantines - Current Process",
+      "type": "table"
     }
   ],
   "refresh": "30s",

--- a/devshard/Makefile
+++ b/devshard/Makefile
@@ -1,4 +1,24 @@
-.PHONY: proto test integration-test stress-test fault-test
+.PHONY: proto test integration-test stress-test fault-test devshard-gateway-release
+
+DEVSHARD_VERSION ?= dev
+DEVSHARD_PROTOCOL_VERSION ?= v3
+DEVSHARD_GATEWAY_IMAGE ?= ghcr.io/gonka-ai/devshard-gateway
+DEVSHARD_GATEWAY_TAGS ?=
+PLATFORM ?= linux/amd64
+
+devshard-gateway-release:
+	@if [ -z "$(strip $(DEVSHARD_GATEWAY_TAGS))" ]; then \
+		echo "DEVSHARD_GATEWAY_TAGS is required" >&2; \
+		exit 1; \
+	fi
+	docker buildx build \
+		--platform $(PLATFORM) \
+		--build-arg DEVSHARD_VERSION=$(DEVSHARD_VERSION) \
+		--build-arg DEVSHARD_PROTOCOL_VERSION=$(DEVSHARD_PROTOCOL_VERSION) \
+		$(foreach tag,$(strip $(DEVSHARD_GATEWAY_TAGS)),-t $(DEVSHARD_GATEWAY_IMAGE):$(tag)) \
+		-f Dockerfile \
+		--push \
+		.
 
 proto:
 	PATH="$$HOME/go/bin:$$PATH" protoc --proto_path=proto --go_out=. --go_opt=module=devshard proto/devshard/v1/*.proto

--- a/devshard/cmd/devshardctl/gateway_dashboard_test.go
+++ b/devshard/cmd/devshardctl/gateway_dashboard_test.go
@@ -249,10 +249,15 @@ func TestGatewayDashboardHasNoGridOverlap(t *testing.T) {
 		title, _ := panel["title"].(string)
 		grid, ok := panel["gridPos"].(map[string]any)
 		require.True(t, ok, "panel %q missing gridPos", title)
-		x := int(grid["x"].(float64))
-		y := int(grid["y"].(float64))
-		w := int(grid["w"].(float64))
-		h := int(grid["h"].(float64))
+		gridInt := func(field string) int {
+			v, numeric := grid[field].(float64)
+			require.True(t, numeric, "panel %q gridPos.%s is not a number", title, field)
+			return int(v)
+		}
+		x := gridInt("x")
+		y := gridInt("y")
+		w := gridInt("w")
+		h := gridInt("h")
 		for yy := y; yy < y+h; yy++ {
 			for xx := x; xx < x+w; xx++ {
 				key := [2]int{xx, yy}

--- a/devshard/cmd/devshardctl/gateway_dashboard_test.go
+++ b/devshard/cmd/devshardctl/gateway_dashboard_test.go
@@ -1,0 +1,837 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewayDashboardReferencesRegisteredMetrics(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	registered := registeredGatewayMetricNames(t)
+	for _, metric := range dashboardMetricNames(data) {
+		if metricRegistered(metric, registered) {
+			continue
+		}
+		t.Errorf("dashboard references unregistered metric %q", metric)
+	}
+}
+
+func TestGatewayDashboardHasRequiredControlsAndRows(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	variables := dashboardVariables(t, dashboard)
+	for _, name := range []string{"model", "participant_key", "escrow_id", "reason", "min_attempts"} {
+		v, ok := variables[name]
+		require.True(t, ok, "missing dashboard variable %q", name)
+		require.NotEqual(t, float64(2), v["hide"], "dashboard variable %q must be visible", name)
+	}
+	require.Equal(t, "participant_key (optional drilldown)", variables["participant_key"]["label"])
+	require.Equal(t, "reason (optional detail filter)", variables["reason"]["label"])
+
+	rows := dashboardRows(t, dashboard)
+	for _, title := range []string{
+		"Overall Gateway Health",
+		"Suspect Addresses (start here)",
+		"Explain Selected Participant",
+		"Global Cost and Policy Pressure",
+		"Escrow and Runtime Diagnostics",
+	} {
+		require.Contains(t, rows, title, "missing dashboard row %q", title)
+	}
+
+	panels := dashboardPanels(t, dashboard)
+	panelTitles := dashboardPanelTitles(t, panels)
+	for _, title := range []string{
+		"Average Request Rate",
+		"Range User Success Rate",
+		"Range Critical User Failures",
+		"Range Cache Hit Share",
+		"Gateway Capacity Scale",
+		"Worst Model Capacity Scale",
+		"Model Capacity Scale by Model",
+		"HTTP Chat Route p95 (gateway-wide)",
+		"Gateway Admission Rejections by Reason (gateway-wide)",
+		"Successful Requests with Hidden Participant Failures by Reason",
+		"Suspect Address Scorecard",
+		"Real Attempts Started by Role and Reason",
+		"Terminal Attempts by Outcome and Visibility",
+		"Failed Attempts by Reason and Visibility",
+		"User-Visible Winner Share by Participant",
+		"Participant Receipt p95 by Address",
+		"Participant TTFT / First Content p95 by Address",
+		"Participant Prefill per Input Token p95 by Address",
+		"Participant Total Attempt Time p95 by Address",
+		"No-Receipt and Empty-Stream Rates",
+		"Transport and EOF Failure Rates",
+		"Current Participant Quarantine Mode",
+		"Winner Failures After User-Visible Content",
+		"Global Sent Attempts per User Request",
+		"Global Failed Sends per Successful User Request",
+		"Extra Real Sends per User Request",
+		"Ghost or No-Send Slots per User Request",
+		"Top Skipped-Slot Reasons",
+		"Timeout Actions by Kind and Action",
+		"Timeout Skip and Failure Reasons Over Time",
+		"Model x Escrow No-Send Pressure",
+		"Runtime Picker Choices by Model and Escrow",
+		"Escrow Blocked Participant Count",
+	} {
+		require.Contains(t, panelTitles, title, "missing dashboard panel %q", title)
+	}
+	for _, panel := range panels {
+		title, _ := panel["title"].(string)
+		if !strings.Contains(title, "Heatmap") {
+			continue
+		}
+		require.Equal(t, "heatmap", panel["type"], "panel %q says heatmap but is type %q", title, panel["type"])
+	}
+	require.NotContains(t, string(data), `reason=~".*`, "dashboard should use bounded reason values, not broad reason regexes")
+}
+
+func TestGatewayDashboardStartsWithOverallHealth(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	rows := dashboardRowTitles(t, dashboard)
+	require.NotEmpty(t, rows)
+	require.Equal(t, "Overall Gateway Health", rows[0], "first real dashboard row must be health-only")
+	require.Equal(t, []string{
+		"Overall Gateway Health",
+		"Nonce Consumption",
+		"Suspect Addresses (start here)",
+		"Explain Selected Participant",
+		"Global Cost and Policy Pressure",
+		"Escrow and Runtime Diagnostics",
+	}, rows)
+
+	for _, title := range []string{
+		"Gateway Scrape",
+		"Average Request Rate",
+		"Range User Success Rate",
+		"Range Critical User Failures",
+		"Range Cache Hit Share",
+		"Gateway Capacity Scale",
+		"Worst Model Capacity Scale",
+		"Model Capacity Scale by Model",
+		"What Users Saw by Outcome and Reason",
+		"Top User-Visible Failure Reasons",
+		"Successful Requests with Hidden Participant Failures by Reason",
+		"HTTP Chat Route p95 (gateway-wide)",
+		"Gateway Admission Rejections by Reason (gateway-wide)",
+		"Active Requests and Input Tokens",
+	} {
+		panel := dashboardPanelByTitle(t, dashboard, title)
+		expr := strings.Join(panelTargetExprs(panel), "\n")
+		require.NotContains(t, expr, "participant_key", "health panel %q must not require participant selection", title)
+	}
+}
+
+func TestGatewayDashboardStaysCompact(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+	panels := dashboardPanels(t, dashboard)
+
+	require.LessOrEqual(t, len(dashboardRowTitles(t, dashboard)), 6, "dashboard must stay focused")
+	dataPanels := 0
+	for _, panel := range panels {
+		switch panel["type"] {
+		case "row":
+			continue
+		case "text":
+			t.Fatalf("dashboard must not use text-flow panels: %q", panel["title"])
+		default:
+			dataPanels++
+		}
+	}
+	require.LessOrEqual(t, dataPanels, 45, "dashboard has too many data panels")
+
+	panelTitles := dashboardPanelTitles(t, panels)
+	for _, title := range []string{
+		"Read This First",
+		"Failure Drilldown Guide",
+		"Protocol Feedback",
+		"Participant Scorecard for Selected Suspect",
+		"Hidden Failures for This Participant",
+		"Timeout Work for This Participant",
+		"Diagnostic Gateway Mechanics",
+		"Worst Attempt Failure Rates by Address",
+		"Participants with Hidden Loser Failures",
+		"Participants with Policy Pressure",
+		"Hidden Loser Failures by Participant",
+		"Skipped Quarantine Slots by Participant",
+		"Participants Requiring Extra Sends",
+		"Participants with No-Winner Pressure",
+		"Participants Entering Quarantine or No-Winner Modes",
+		"Suspect Participants by Problem Events per Sent Attempt",
+		"Suspect Participants by Problem Event Count",
+		"Slow Participants by p95 First Content",
+	} {
+		require.NotContains(t, panelTitles, title, "deleted/duplicated panel or row %q returned", title)
+	}
+}
+
+func TestGatewayDashboardRestoresKeyHealthSignals(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	scale := dashboardPanelByTitle(t, dashboard, "Model Capacity Scale by Model")
+	scaleExpr := strings.Join(panelTargetExprs(scale), "\n")
+	require.Contains(t, scaleExpr, `devshard_gateway_capacity_scale_by_model{model=~"$model"}`)
+	require.NotContains(t, scaleExpr, "participant_key")
+
+	hidden := dashboardPanelByTitle(t, dashboard, "Successful Requests with Hidden Participant Failures by Reason")
+	require.Contains(t, strings.Join(panelTargetExprs(hidden), "\n"), "devshard_gateway_user_requests_with_hidden_failure_total")
+
+	timeout := dashboardPanelByTitle(t, dashboard, "Timeout Actions by Kind and Action")
+	timeoutExpr := strings.Join(panelTargetExprs(timeout), "\n")
+	require.Contains(t, timeoutExpr, "devshard_gateway_timeout_actions_total")
+	require.Contains(t, timeoutExpr, "by (kind, action)")
+}
+
+func TestGatewayDashboardShowsCurrentProcessRecoveryQuarantines(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	panel := dashboardPanelByTitle(t, dashboard, "Startup Recovery Quarantines - Current Process")
+	require.Equal(t, "table", panel["type"])
+	require.Contains(t, panel["description"], "current gateway process")
+	targets := panelTargets(t, panel)
+	require.Len(t, targets, 1)
+	require.Equal(t, true, targets[0]["instant"])
+	require.Equal(t, "table", targets[0]["format"])
+	require.Equal(t,
+		`devshard_gateway_startup_skipped_escrow{model=~"$model",escrow_id=~"$escrow_id",reason="local_recovery_failed"} == 1`,
+		targets[0]["expr"],
+	)
+}
+
+func TestGatewayDashboardHasNoGridOverlap(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	occupied := make(map[[2]int]string)
+	for _, panel := range dashboardPanels(t, dashboard) {
+		title, _ := panel["title"].(string)
+		grid, ok := panel["gridPos"].(map[string]any)
+		require.True(t, ok, "panel %q missing gridPos", title)
+		x := int(grid["x"].(float64))
+		y := int(grid["y"].(float64))
+		w := int(grid["w"].(float64))
+		h := int(grid["h"].(float64))
+		for yy := y; yy < y+h; yy++ {
+			for xx := x; xx < x+w; xx++ {
+				key := [2]int{xx, yy}
+				if other, exists := occupied[key]; exists {
+					t.Fatalf("panels %q and %q overlap at x=%d y=%d", other, title, xx, yy)
+				}
+				occupied[key] = title
+			}
+		}
+	}
+}
+
+func TestGatewayDashboardSuspectPanelsDiscoverParticipants(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	rows := dashboardRowTitles(t, dashboard)
+	require.GreaterOrEqual(t, len(rows), 3)
+	require.Equal(t, "Nonce Consumption", rows[1], "nonce row must stay after overall health")
+	require.Equal(t, "Suspect Addresses (start here)", rows[2], "suspect row must come after nonce consumption")
+
+	participantModelGroup := regexp.MustCompile(`by \([^)]*participant_key[^)]*model`)
+	panel := dashboardPanelByTitle(t, dashboard, "Suspect Address Scorecard")
+	expr := strings.Join(panelTargetExprs(panel), "\n")
+	require.Contains(t, expr, `participant_key!="unknown"`, "scorecard must exclude unknown participant attribution")
+	require.Regexp(t, participantModelGroup, expr, "scorecard must group by participant_key and model")
+	require.NotContains(t, expr, `reason=~"$reason"`, "scorecard must not require reason selection")
+	for _, forbidden := range []string{"escrow_id", "devshard_id", "host_idx", "address"} {
+		require.NotContains(t, expr, forbidden, "scorecard must not use %s as identity", forbidden)
+	}
+}
+
+func TestGatewayDashboardSuspectPanelsLinkToParticipantDrilldown(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	panel := dashboardPanelByTitle(t, dashboard, "Suspect Address Scorecard")
+	links := panelFieldLinks(panel)
+	require.NotEmpty(t, links, "scorecard must offer drilldown links")
+	require.Contains(t, strings.Join(links, "\n"), "var-participant_key=${__data.fields.participant_key}", "scorecard must link selected participant into the dashboard variable")
+	require.Contains(t, strings.Join(links, "\n"), "var-model=${__data.fields.model}", "scorecard must link selected model into the dashboard variable")
+}
+
+func TestGatewayDashboardSuspectScorecardRendersReadableTable(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	panel := dashboardPanelByTitle(t, dashboard, "Suspect Address Scorecard")
+	require.Equal(t, "table", panel["type"], "scorecard must be a table")
+	require.GreaterOrEqual(t, len(panelTargets(t, panel)), 10, "scorecard must have explicit evidence targets")
+	for _, target := range panelTargets(t, panel) {
+		require.Equal(t, "table", target["format"], "scorecard must ask Prometheus for table data")
+	}
+	require.NotEmpty(t, panelTransformationByID(t, panel, "merge"), "scorecard must merge evidence targets")
+	organize := panelTransformationByID(t, panel, "organize")
+	options, ok := organize["options"].(map[string]any)
+	require.True(t, ok, "scorecard organize transform missing options")
+	excluded, ok := options["excludeByName"].(map[string]any)
+	require.True(t, ok, "scorecard must hide noisy columns")
+	require.Equal(t, true, excluded["Time"], "scorecard must hide Time column")
+	renames, ok := options["renameByName"].(map[string]any)
+	require.True(t, ok, "scorecard must rename value columns")
+	renamed := make(map[string]struct{})
+	for _, value := range renames {
+		if name, ok := value.(string); ok {
+			renamed[name] = struct{}{}
+		}
+	}
+	for _, column := range []string{
+		"participant_key",
+		"model",
+		"started_attempts\ncount",
+		"finished_attempts\ncount",
+		"failure_rate\nfailed/finished",
+		"issues_per_started\ncount/start",
+		"issue_count\ncount",
+		"failed_attempts\ncount",
+		"no_send_slots\ncount",
+		"no_winner_attempts\ncount",
+		"timeout_skipped_failed\ncount",
+		"inference_transport_errors\ncount",
+		"limit_rejections\ncount",
+		"p95_ttft_first_content\nseconds",
+		"p95_receipt\nseconds",
+		"p95_prefill_per_input_token\nseconds",
+		"p95_total_attempt\nseconds",
+	} {
+		require.Contains(t, renamed, column, "scorecard missing readable column %q", column)
+	}
+	require.NotContains(t, renamed, "transport_errors\ncount", "scorecard transport errors must be inference-only")
+}
+
+func TestGatewayDashboardAvoidsAmbiguousPanels(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+	panels := dashboardPanels(t, dashboard)
+
+	titles := make(map[string]struct{})
+	queries := make(map[string]string)
+	for _, panel := range panels {
+		title, _ := panel["title"].(string)
+		require.NotEmpty(t, title, "panel missing title")
+		require.NotContains(t, title, "host_idx", "dashboard timing must be address-level, not host-slot level")
+		require.NotContains(t, title, "Host Timing", "dashboard timing must be address-level, not host-slot level")
+		require.NotContains(t, title, "Escrow Slot", "dashboard timing must be address-level, not host-slot level")
+		require.NotEqual(t, "Diagnostic CTTFL per Input Token p95", title, "CTTFL panel title is too easy to confuse with user-visible TTFT")
+		if _, exists := titles[title]; exists {
+			t.Fatalf("duplicate panel title %q", title)
+		}
+		titles[title] = struct{}{}
+
+		expr := strings.Join(panelTargetExprs(panel), "\n")
+		if expr == "" {
+			continue
+		}
+		if otherTitle, exists := queries[expr]; exists {
+			t.Fatalf("duplicate PromQL in panels %q and %q: %s", otherTitle, title, expr)
+		}
+		queries[expr] = title
+	}
+}
+
+func TestGatewayDashboardDoesNotUseHostSlotTiming(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(data), "host_idx", "dashboard must not require mapping host slots to participant addresses")
+	for _, metric := range []string{
+		"devshard_host_receipt_seconds",
+		"devshard_host_first_token_seconds",
+		"devshard_host_cttfl_seconds_per_input_token",
+		"devshard_host_total_time_seconds",
+	} {
+		require.NotContains(t, string(data), metric, "dashboard must use participant timing metrics instead of host-slot timing metrics")
+	}
+}
+
+func TestGatewayDashboardParticipantTimingByAddressAndModel(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	for title, metric := range map[string]string{
+		"Participant Receipt p95 by Address":                 "devshard_gateway_participant_receipt_seconds_bucket",
+		"Participant TTFT / First Content p95 by Address":    "devshard_gateway_participant_first_content_seconds_bucket",
+		"Participant Prefill per Input Token p95 by Address": "devshard_gateway_participant_prefill_seconds_per_input_token_bucket",
+		"Participant Total Attempt Time p95 by Address":      "devshard_gateway_participant_total_attempt_seconds_bucket",
+	} {
+		panel := dashboardPanelByTitle(t, dashboard, title)
+		expr := strings.Join(panelTargetExprs(panel), "\n")
+		require.Contains(t, expr, metric, "panel %q must use participant timing metric", title)
+		require.Contains(t, expr, "by (participant_key, model, le)", "panel %q must group timing by participant_key and model", title)
+		for _, forbidden := range []string{"host_idx", "devshard_id", "address"} {
+			require.NotContains(t, expr, forbidden, "panel %q must not use %s as timing identity", title, forbidden)
+		}
+	}
+}
+
+func TestGatewayDashboardUsesEscrowFilterForDevshardDiagnostics(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	for _, title := range []string{
+		"Escrow Blocked Participant Count",
+		"Runtime Picker Choices by Model and Escrow",
+		"Non-Inference Transport Errors by Path",
+	} {
+		if title == "Non-Inference Transport Errors by Path" {
+			continue
+		}
+		panel := dashboardPanelByTitle(t, dashboard, title)
+		for _, expr := range panelTargetExprs(panel) {
+			require.Contains(t, expr, `devshard_id=~"$escrow_id"`, "panel %q must honor the visible escrow_id filter", title)
+		}
+	}
+}
+
+func TestGatewayDashboardSeparatesInferenceTransportErrors(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	scorecard := dashboardPanelByTitle(t, dashboard, "Suspect Address Scorecard")
+	scorecardExpr := strings.Join(panelTargetExprs(scorecard), "\n")
+	require.Contains(t, scorecardExpr, `path_kind="inference"`, "scorecard transport errors must be inference-path only")
+	require.NotContains(t, scorecardExpr, `path_kind!="inference"`, "scorecard must not include non-inference transport diagnostics")
+
+	diagnostic := dashboardPanelByTitle(t, dashboard, "Non-Inference Transport Errors by Path")
+	diagnosticExpr := strings.Join(panelTargetExprs(diagnostic), "\n")
+	require.Contains(t, diagnosticExpr, `path_kind!="inference"`, "non-inference transport errors belong in diagnostics")
+	require.Contains(t, diagnosticExpr, "by (path_kind, status)", "diagnostic transport panel should explain which path failed")
+}
+
+func TestGatewayDashboardParticipantPanelsUseParticipantKey(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	for _, title := range []string{
+		"User-Visible Winner Share by Participant",
+		"Participant Receipt p95 by Address",
+		"Participant TTFT / First Content p95 by Address",
+		"Participant Prefill per Input Token p95 by Address",
+		"Participant Total Attempt Time p95 by Address",
+		"No-Receipt and Empty-Stream Rates",
+		"Transport and EOF Failure Rates",
+		"Current Participant Quarantine Mode",
+		"Winner Failures After User-Visible Content",
+	} {
+		panel := dashboardPanelByTitle(t, dashboard, title)
+		expr := strings.Join(panelTargetExprs(panel), "\n")
+		require.Contains(t, expr, "participant_key", "panel %q must support address-level investigation", title)
+		require.NotContains(t, expr, "host_idx", "panel %q must not use host_idx as participant identity", title)
+	}
+}
+
+func TestGatewayDashboardParticipantQualityDoesNotGroupByEscrow(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	escrowGroup := regexp.MustCompile(`by \([^)]*escrow_id`)
+	for _, title := range []string{
+		"Real Attempts Started by Role and Reason",
+		"Terminal Attempts by Outcome and Visibility",
+		"Failed Attempts by Reason and Visibility",
+		"User-Visible Winner Share by Participant",
+		"Participant TTFT / First Content p95 by Address",
+		"Participant Total Attempt Time p95 by Address",
+		"No-Receipt and Empty-Stream Rates",
+		"Transport and EOF Failure Rates",
+		"Current Participant Quarantine Mode",
+		"Winner Failures After User-Visible Content",
+	} {
+		panel := dashboardPanelByTitle(t, dashboard, title)
+		expr := strings.Join(panelTargetExprs(panel), "\n")
+		require.False(t, escrowGroup.MatchString(expr), "panel %q must not group default participant quality by escrow_id", title)
+	}
+}
+
+func TestGatewayDashboardFailureRateDenominatorsIgnoreReason(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	for _, title := range []string{
+		"No-Receipt and Empty-Stream Rates",
+		"Transport and EOF Failure Rates",
+	} {
+		panel := dashboardPanelByTitle(t, dashboard, title)
+		expr := strings.Join(panelTargetExprs(panel), "\n")
+		require.Contains(t, expr, "clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_terminal_total", "panel %q denominator must use finished attempts grouped by participant_key and model", title)
+		require.NotContains(t, expr, "clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total", "panel %q denominator must not use started attempts", title)
+		require.NotContains(t, expr, "clamp_min(sum by (participant_key, model, reason) (increase(", "panel %q denominator must not include failure reason", title)
+	}
+}
+
+func TestGatewayDashboardScorecardDoesNotCompareFailuresToStarts(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	panel := dashboardPanelByTitle(t, dashboard, "Suspect Address Scorecard")
+	expr := strings.Join(panelTargetExprs(panel), "\n")
+	require.Contains(t, expr, "devshard_gateway_attempts_terminal_total", "scorecard must expose finished attempts for failure comparisons")
+	require.NotContains(t, expr, "failed_attempts / clamp_min(sum by (participant_key, model) (increase(devshard_gateway_attempts_started_total", "failed attempts must not be compared to started attempts")
+
+	organize := panelTransformationByID(t, panel, "organize")
+	options, ok := organize["options"].(map[string]any)
+	require.True(t, ok, "scorecard organize transform missing options")
+	renames, ok := options["renameByName"].(map[string]any)
+	require.True(t, ok, "scorecard must rename value columns")
+	values := make(map[string]struct{})
+	for _, value := range renames {
+		if name, ok := value.(string); ok {
+			values[name] = struct{}{}
+		}
+	}
+	require.Contains(t, values, "started_attempts\ncount")
+	require.Contains(t, values, "finished_attempts\ncount")
+	require.Contains(t, values, "failure_rate\nfailed/finished")
+	require.NotContains(t, values, "sent_attempts")
+	require.NotContains(t, values, "issue_rate")
+}
+
+func TestGatewayDashboardScorecardCountColumnsAreRounded(t *testing.T) {
+	path := gatewayDashboardPath(t)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var dashboard map[string]any
+	require.NoError(t, json.Unmarshal(data, &dashboard))
+
+	panel := dashboardPanelByTitle(t, dashboard, "Suspect Address Scorecard")
+	countRefs := map[string]string{
+		"A": "started_attempts",
+		"B": "finished_attempts",
+		"E": "issue_count",
+		"F": "failed_attempts",
+		"G": "no_send_slots",
+		"H": "no_winner_attempts",
+		"I": "timeout_skipped_failed",
+		"J": "inference_transport_errors",
+		"K": "limit_rejections",
+	}
+	for _, target := range panelTargets(t, panel) {
+		refID, _ := target["refId"].(string)
+		name, ok := countRefs[refID]
+		if !ok {
+			continue
+		}
+		expr, _ := target["expr"].(string)
+		require.Contains(t, expr, "round(", "scorecard count column %s (%s) must round Prometheus increase() extrapolation", refID, name)
+	}
+}
+
+func gatewayDashboardPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(repoRootFromCwd(t), "deploy", "join", "observability", "grafana", "dashboards", "gonka-gateway-observability.json")
+}
+
+func repoRootFromCwd(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "deploy", "join", "observability")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate repo root containing deploy/join/observability")
+	return ""
+}
+
+func registeredGatewayMetricNames(t *testing.T) map[string]struct{} {
+	t.Helper()
+	metrics := NewDevshardMetrics()
+	metrics.registry.MustRegister(newGatewayMetricsCollectorWithHostConnections(nil, nil))
+
+	names := make(map[string]struct{})
+	families, err := metrics.registry.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		names[family.GetName()] = struct{}{}
+	}
+
+	descCh := make(chan *prometheus.Desc, 256)
+	go func() {
+		defer close(descCh)
+		metrics.registry.Describe(descCh)
+	}()
+	descRe := regexp.MustCompile(`fqName: "([^"]+)"`)
+	for desc := range descCh {
+		if match := descRe.FindStringSubmatch(desc.String()); len(match) == 2 {
+			names[match[1]] = struct{}{}
+		}
+	}
+	return names
+}
+
+func dashboardMetricNames(data []byte) []string {
+	expr := regexp.MustCompile(`devshard_(?:gateway|http|host|runtime|speculative|inference)[a-zA-Z0-9_]*`)
+	seen := make(map[string]struct{})
+	for _, metric := range expr.FindAllString(string(data), -1) {
+		seen[metric] = struct{}{}
+	}
+
+	metrics := make([]string, 0, len(seen))
+	for metric := range seen {
+		metrics = append(metrics, metric)
+	}
+	return metrics
+}
+
+func metricRegistered(metric string, registered map[string]struct{}) bool {
+	if _, ok := registered[metric]; ok {
+		return true
+	}
+	for _, suffix := range []string{"_bucket", "_sum", "_count"} {
+		if strings.HasSuffix(metric, suffix) {
+			if _, ok := registered[strings.TrimSuffix(metric, suffix)]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func dashboardVariables(t *testing.T, dashboard map[string]any) map[string]map[string]any {
+	t.Helper()
+	templating, ok := dashboard["templating"].(map[string]any)
+	require.True(t, ok, "missing templating section")
+	list, ok := templating["list"].([]any)
+	require.True(t, ok, "missing templating list")
+
+	variables := make(map[string]map[string]any)
+	for _, item := range list {
+		variable, ok := item.(map[string]any)
+		require.True(t, ok, "dashboard variable must be an object")
+		name, ok := variable["name"].(string)
+		require.True(t, ok, "dashboard variable missing name")
+		variables[name] = variable
+	}
+	return variables
+}
+
+func dashboardRows(t *testing.T, dashboard map[string]any) map[string]struct{} {
+	t.Helper()
+	panels := dashboardPanels(t, dashboard)
+
+	rows := make(map[string]struct{})
+	for _, item := range panels {
+		panel := item
+		if panel["type"] != "row" {
+			continue
+		}
+		title, ok := panel["title"].(string)
+		require.True(t, ok, "row panel missing title")
+		rows[title] = struct{}{}
+	}
+	return rows
+}
+
+func dashboardRowTitles(t *testing.T, dashboard map[string]any) []string {
+	t.Helper()
+	panels := dashboardPanels(t, dashboard)
+
+	rows := make([]string, 0)
+	for _, panel := range panels {
+		if panel["type"] != "row" {
+			continue
+		}
+		title, ok := panel["title"].(string)
+		require.True(t, ok, "row panel missing title")
+		rows = append(rows, title)
+	}
+	return rows
+}
+
+func dashboardPanels(t *testing.T, dashboard map[string]any) []map[string]any {
+	t.Helper()
+	items, ok := dashboard["panels"].([]any)
+	require.True(t, ok, "missing panels")
+
+	panels := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		panel, ok := item.(map[string]any)
+		require.True(t, ok, "panel must be an object")
+		panels = append(panels, panel)
+	}
+	return panels
+}
+
+func dashboardPanelTitles(t *testing.T, panels []map[string]any) map[string]struct{} {
+	t.Helper()
+	titles := make(map[string]struct{})
+	for _, panel := range panels {
+		title, ok := panel["title"].(string)
+		require.True(t, ok, "panel missing title")
+		titles[title] = struct{}{}
+	}
+	return titles
+}
+
+func dashboardPanelByTitle(t *testing.T, dashboard map[string]any, title string) map[string]any {
+	t.Helper()
+	for _, panel := range dashboardPanels(t, dashboard) {
+		if panel["title"] == title {
+			return panel
+		}
+	}
+	t.Fatalf("missing dashboard panel %q", title)
+	return nil
+}
+
+func panelTargetExprs(panel map[string]any) []string {
+	targets := panelTargets(nil, panel)
+	exprs := make([]string, 0, len(targets))
+	for _, target := range targets {
+		expr, ok := target["expr"].(string)
+		if !ok || expr == "" {
+			continue
+		}
+		exprs = append(exprs, expr)
+	}
+	return exprs
+}
+
+func panelTargets(t *testing.T, panel map[string]any) []map[string]any {
+	if t != nil {
+		t.Helper()
+	}
+	items, _ := panel["targets"].([]any)
+	targets := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		target, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+func panelTransformationByID(t *testing.T, panel map[string]any, id string) map[string]any {
+	t.Helper()
+	items, _ := panel["transformations"].([]any)
+	for _, item := range items {
+		transformation, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if transformation["id"] == id {
+			return transformation
+		}
+	}
+	t.Fatalf("panel %q missing transformation %q", panel["title"], id)
+	return nil
+}
+
+func panelFieldLinks(panel map[string]any) []string {
+	fieldConfig, _ := panel["fieldConfig"].(map[string]any)
+	defaults, _ := fieldConfig["defaults"].(map[string]any)
+	items, _ := defaults["links"].([]any)
+	links := make([]string, 0, len(items))
+	for _, item := range items {
+		link, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		url, ok := link["url"].(string)
+		if !ok || url == "" {
+			continue
+		}
+		links = append(links, url)
+	}
+	return links
+}

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -17,18 +17,26 @@ import (
 	"devshard/bridge"
 	"devshard/state"
 	"devshard/types"
+	"devshard/user"
 )
 
 type adminAuthContextKey struct{}
 type adminAPIKeySuffixContextKey struct{}
 
 const (
-	defaultChainRESTURL          = "http://localhost:1317"
-	defaultPublicAPIURL          = "http://localhost:9000"
-	defaultModelName             = "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
-	defaultListenPort            = "8080"
-	defaultMaxConcurrentRequests = 512
+	defaultChainRESTURL            = "http://localhost:1317"
+	defaultPublicAPIURL            = "http://localhost:9000"
+	defaultModelName               = "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
+	defaultListenPort              = "8080"
+	defaultMaxConcurrentRequests   = 512
+	startupSkipReasonLocalRecovery = "local_recovery_failed"
 )
+
+type startupSkippedEscrow struct {
+	EscrowID string
+	Model    string
+	Reason   string
+}
 
 type SettlementJSON struct {
 	EscrowID string `json:"escrow_id"`
@@ -360,7 +368,7 @@ func mustBuildGateway(gatewayStore *GatewayStore, gatewayState GatewayState, bas
 	}
 	perf := NewPerfTracker(perfStore)
 
-	runtimes, err := buildGatewayRuntimes(gatewayStore, &gatewayState, baseStorageDir, perf)
+	runtimes, startupSkipped, err := buildGatewayRuntimes(gatewayStore, &gatewayState, baseStorageDir, perf)
 	if err != nil {
 		perfStore.Close()
 		log.Fatalf("create runtimes: %v", err)
@@ -375,11 +383,18 @@ func mustBuildGateway(gatewayStore *GatewayStore, gatewayState GatewayState, bas
 		gatewayState.Settings.ModelLimits,
 	)
 	gateway := NewManagedGateway(runtimes, limiter, gatewayState.Settings, baseStorageDir, gatewayStore, perf)
+	recordStartupSkippedEscrows(gateway.metrics, startupSkipped)
 	gateway.perfStore = perfStore
 	return gateway
 }
 
-func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState, baseStorageDir string, perf *PerfTracker) ([]*devshardRuntime, error) {
+func recordStartupSkippedEscrows(metrics *DevshardMetrics, skipped []startupSkippedEscrow) {
+	for _, escrow := range skipped {
+		metrics.RecordStartupSkippedEscrow(escrow.EscrowID, escrow.Model, escrow.Reason)
+	}
+}
+
+func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState, baseStorageDir string, perf *PerfTracker) ([]*devshardRuntime, []startupSkippedEscrow, error) {
 	// Load only ACTIVE devshards at boot. Inactive devshards (deactivated,
 	// finalized, or settled) stay in the registry but are not built into
 	// memory-resident runtimes: keeping hundreds of dormant escrows resident
@@ -407,7 +422,7 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 	}
 	allCfgs, err := finalizeRuntimeConfigs(allCfgs, gatewayState.Settings.DefaultModel, baseStorageDir)
 	if err != nil {
-		return nil, fmt.Errorf("finalize gateway runtime configs: %w", err)
+		return nil, nil, fmt.Errorf("finalize gateway runtime configs: %w", err)
 	}
 
 	type buildResult struct {
@@ -431,6 +446,7 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 
 	runtimes := make([]*devshardRuntime, len(allCfgs))
 	var skipped []int
+	var startupSkipped []startupSkippedEscrow
 	var firstFatal error
 	for range allCfgs {
 		res := <-ch
@@ -441,9 +457,12 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 				skipped = append(skipped, res.idx)
 				continue
 			}
-			if errors.Is(res.err, bridge.ErrEscrowNotFound) || errors.Is(res.err, errRuntimePrivateKeyMissing) {
+			brokenLocalState := errors.Is(res.err, user.ErrLocalStateUnrecoverable)
+			if brokenLocalState || errors.Is(res.err, bridge.ErrEscrowNotFound) || errors.Is(res.err, errRuntimePrivateKeyMissing) {
 				reason := "runtime could not be loaded"
-				if errors.Is(res.err, bridge.ErrEscrowNotFound) {
+				if brokenLocalState {
+					reason = "local state unrecoverable"
+				} else if errors.Is(res.err, bridge.ErrEscrowNotFound) {
 					reason = "escrow missing on chain"
 				} else if errors.Is(res.err, errRuntimePrivateKeyMissing) {
 					reason = "private key missing"
@@ -458,6 +477,13 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 				}
 				markDevshardInactive(gatewayState, cfg.ID)
 				skipped = append(skipped, res.idx)
+				if brokenLocalState {
+					startupSkipped = append(startupSkipped, startupSkippedEscrow{
+						EscrowID: cfg.ID,
+						Model:    firstNonEmpty(cfg.Model, gatewayState.Settings.DefaultModel),
+						Reason:   startupSkipReasonLocalRecovery,
+					})
+				}
 				continue
 			}
 			if firstFatal == nil {
@@ -473,7 +499,7 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 				rt.close()
 			}
 		}
-		return nil, firstFatal
+		return nil, nil, firstFatal
 	}
 
 	// Mark inactive runtimes so they're excluded from inference routing
@@ -503,7 +529,15 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 	}
 	log.Printf("build_runtimes_parallel count=%d active=%d inactive=%d skipped=%d skipped_inactive=%d total_elapsed_ms=%d",
 		len(out), activeCount, inactiveCount, len(skipped), skippedInactive, time.Since(t0).Milliseconds())
-	return out, nil
+	if len(startupSkipped) > 0 {
+		escrowIDs := make([]string, 0, len(startupSkipped))
+		for _, skippedEscrow := range startupSkipped {
+			escrowIDs = append(escrowIDs, skippedEscrow.EscrowID)
+		}
+		log.Printf("devshard_gateway_startup_degraded deactivated_escrows=%d reason=%s escrow_ids=%q",
+			len(startupSkipped), startupSkipReasonLocalRecovery, strings.Join(escrowIDs, ","))
+	}
+	return out, startupSkipped, nil
 }
 
 func markDevshardInactive(gatewayState *GatewayState, id string) {

--- a/devshard/cmd/devshardctl/main_test.go
+++ b/devshard/cmd/devshardctl/main_test.go
@@ -1,17 +1,21 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"devshard/bridge"
+	"devshard/user"
 )
 
 func TestBootstrapEscrowRotationSettlementEnabledEnv(t *testing.T) {
@@ -66,7 +70,7 @@ func TestBuildGatewayRuntimesDeactivatesMissingEscrow(t *testing.T) {
 		gatewayRuntimeBuilder = savedBuilder
 	})
 
-	runtimes, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+	runtimes, _, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
 	require.NoError(t, err)
 	require.Len(t, runtimes, 1)
 	require.Equal(t, "24", runtimes[0].id)
@@ -118,7 +122,7 @@ func TestBuildGatewayRuntimesDeactivatesMissingPrivateKey(t *testing.T) {
 		gatewayRuntimeBuilder = savedBuilder
 	})
 
-	runtimes, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+	runtimes, _, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
 	require.NoError(t, err)
 	require.Len(t, runtimes, 1)
 	require.Equal(t, "24", runtimes[0].id)
@@ -162,11 +166,165 @@ func TestBuildGatewayRuntimesPreservesActiveOnOtherErrors(t *testing.T) {
 		gatewayRuntimeBuilder = savedBuilder
 	})
 
-	_, err = buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+	_, _, err = buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
 	require.Error(t, err)
 
 	reloaded, ok, err := store.LoadState()
 	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, reloaded.Devshards[0].Active)
+}
+
+func TestBuildGatewayRuntimesDeactivatesUnrecoverableLocalState(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, []GatewayDevshardState{
+		{RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Test"}, Active: true},
+		{RuntimeConfig: RuntimeConfig{ID: "24", PrivateKeyHex: "secret", Model: "Qwen/Test"}, Active: true},
+	}))
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, _, defaultModel string, _ *PerfTracker) (*devshardRuntime, error) {
+		if cfg.ID == "12" {
+			return nil, fmt.Errorf("runtime %s: create session: recover session: %w: replay nonce 151: expected 7",
+				cfg.ID, user.ErrLocalStateUnrecoverable)
+		}
+		return &devshardRuntime{id: cfg.ID, model: defaultModel}, nil
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
+
+	var logs bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+	})
+
+	runtimes, skipped, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+
+	require.NoError(t, err)
+	require.Len(t, runtimes, 1)
+	require.Equal(t, "24", runtimes[0].id)
+	require.Equal(t, []startupSkippedEscrow{{
+		EscrowID: "12",
+		Model:    "Qwen/Test",
+		Reason:   startupSkipReasonLocalRecovery,
+	}}, skipped)
+	require.False(t, state.Devshards[0].Active)
+	require.True(t, state.Devshards[1].Active)
+
+	reloaded, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, reloaded.Devshards[0].Active)
+	require.True(t, reloaded.Devshards[1].Active)
+
+	gateway := NewGateway(runtimes, NewGatewayLimiter(0, 0), "Qwen/Test")
+	require.NotContains(t, gateway.runtimes, "12")
+	chosen, err := gateway.reserveRuntimeForModel("Qwen/Test", 1)
+	require.NoError(t, err)
+	require.Equal(t, "24", chosen.id)
+	gateway.releaseRuntime(chosen, 1)
+
+	require.Contains(t, logs.String(), "devshard 12 local state unrecoverable, marking inactive and skipping runtime")
+	require.Contains(t, logs.String(), "replay nonce 151: expected 7")
+	require.Contains(t, logs.String(), "devshard_gateway_startup_degraded")
+	require.Contains(t, logs.String(), "reason=local_recovery_failed")
+}
+
+func TestBuildGatewayRuntimesKeepsCreateStorageSessionFailureFatal(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Test"},
+		Active:        true,
+	}}))
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, _, _ string, _ *PerfTracker) (*devshardRuntime, error) {
+		// NewHTTPSession does not classify create-storage or disk-full failures
+		// with ErrLocalStateUnrecoverable; they arrive as plain wrapped errors.
+		return nil, fmt.Errorf("runtime %s: create session: create storage session: %w", cfg.ID,
+			&os.PathError{Op: "write", Path: "gateway.db", Err: syscall.ENOSPC})
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
+
+	_, skipped, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+
+	require.ErrorContains(t, err, "create storage session")
+	require.Empty(t, skipped)
+	require.True(t, state.Devshards[0].Active)
+
+	reloaded, ok, loadErr := store.LoadState()
+	require.NoError(t, loadErr)
+	require.True(t, ok)
+	require.True(t, reloaded.Devshards[0].Active, "create-storage failure must not deactivate escrow or rotation will refill")
+}
+
+func TestBuildGatewayRuntimesFailsWhenRecoveryQuarantineCannotPersist(t *testing.T) {
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, []GatewayDevshardState{{
+		RuntimeConfig: RuntimeConfig{ID: "12", PrivateKeyHex: "secret", Model: "Qwen/Test"},
+		Active:        true,
+	}}))
+	_, err = store.db.Exec(`
+		CREATE TRIGGER fail_recovery_quarantine
+		BEFORE UPDATE OF active ON gateway_devshards
+		WHEN NEW.id = '12' AND NEW.active = 0
+		BEGIN
+			SELECT RAISE(ABORT, 'forced quarantine persistence failure');
+		END`)
+	require.NoError(t, err)
+	state, ok, err := store.LoadState()
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	savedBuilder := gatewayRuntimeBuilder
+	gatewayRuntimeBuilder = func(cfg RuntimeConfig, _, _ string, _ *PerfTracker) (*devshardRuntime, error) {
+		return nil, fmt.Errorf("recover session: %w: broken local state", user.ErrLocalStateUnrecoverable)
+	}
+	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
+
+	_, _, err = buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+
+	require.ErrorContains(t, err, "deactivate devshard 12")
+	require.ErrorContains(t, err, "forced quarantine persistence failure")
+	reloaded, ok, loadErr := store.LoadState()
+	require.NoError(t, loadErr)
 	require.True(t, ok)
 	require.True(t, reloaded.Devshards[0].Active)
 }
@@ -211,7 +369,7 @@ func measurePeakRuntimeBuildConcurrency(t *testing.T, n int) int64 {
 	}
 	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
 
-	runtimes, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+	runtimes, _, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
 	require.NoError(t, err)
 	require.Len(t, runtimes, n)
 	return peakInFlight.Load()
@@ -291,7 +449,7 @@ func TestBuildGatewayRuntimesBoundedFanoutSurvivesRateLimitingLCD(t *testing.T) 
 	}
 	t.Cleanup(func() { gatewayRuntimeBuilder = savedBuilder })
 
-	runtimes, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
+	runtimes, _, err := buildGatewayRuntimes(store, &state, t.TempDir(), NewPerfTracker(nil))
 
 	require.False(t, rateLimited.Load(), "fan-out exceeded the LCD's concurrency tolerance and tripped a 429")
 	require.NoError(t, err, "bounded startup must survive a rate-limiting LCD")

--- a/devshard/cmd/devshardctl/metrics.go
+++ b/devshard/cmd/devshardctl/metrics.go
@@ -26,6 +26,7 @@ type DevshardMetrics struct {
 	gatewayLimitRejections     *prometheus.CounterVec
 	participantLimitRejections *prometheus.CounterVec
 	participantTransportErrors *prometheus.CounterVec
+	startupSkippedEscrows      *prometheus.GaugeVec
 	speculativeDecisions       *prometheus.CounterVec
 	speculativeAttempts        *prometheus.CounterVec
 	inferenceTimeouts          *prometheus.CounterVec
@@ -137,6 +138,13 @@ func NewDevshardMetrics() *DevshardMetrics {
 				Help: "Total participant-bound transport request errors by participant, model, request kind, and upstream status.",
 			},
 			[]string{"participant_key", "model", "path_kind", "status"},
+		),
+		startupSkippedEscrows: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "devshard_gateway_startup_skipped_escrow",
+				Help: "Escrows persistently disabled because local state recovery failed during startup.",
+			},
+			[]string{"escrow_id", "model", "reason"},
 		),
 		speculativeDecisions: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -315,6 +323,7 @@ func NewDevshardMetrics() *DevshardMetrics {
 		m.gatewayLimitRejections,
 		m.participantLimitRejections,
 		m.participantTransportErrors,
+		m.startupSkippedEscrows,
 		m.speculativeDecisions,
 		m.speculativeAttempts,
 		m.inferenceTimeouts,
@@ -408,6 +417,17 @@ func (m *DevshardMetrics) RecordParticipantTransportError(participantKey, model,
 		metricLabel(pathKind, "unknown"),
 		strconv.Itoa(statusCode),
 	).Inc()
+}
+
+func (m *DevshardMetrics) RecordStartupSkippedEscrow(escrowID, model, reason string) {
+	if m == nil {
+		return
+	}
+	m.startupSkippedEscrows.WithLabelValues(
+		metricLabel(escrowID, "unknown"),
+		metricLabel(model, "unknown"),
+		metricLabel(reason, "unknown"),
+	).Set(1)
 }
 
 func (m *DevshardMetrics) RecordSpeculativeDecision(reason string) {

--- a/devshard/cmd/devshardctl/metrics_test.go
+++ b/devshard/cmd/devshardctl/metrics_test.go
@@ -74,6 +74,24 @@ func TestGatewayCoreV1MetricsRecordBoundedLabels(t *testing.T) {
 	requireMetricCounterValue(t, families, "devshard_gateway_timeout_actions_total", map[string]string{"participant_key": "participant-1", "model": "Qwen/Test", "kind": "execution", "action": "completed", "reason": "none"}, 1)
 }
 
+func TestStartupSkippedEscrowMetric(t *testing.T) {
+	m := NewDevshardMetrics()
+
+	recordStartupSkippedEscrows(m, []startupSkippedEscrow{{
+		EscrowID: "32269",
+		Model:    "Qwen/Test",
+		Reason:   startupSkipReasonLocalRecovery,
+	}})
+
+	families, err := m.registry.Gather()
+	require.NoError(t, err)
+	requireMetricGaugeValue(t, families, "devshard_gateway_startup_skipped_escrow", map[string]string{
+		"escrow_id": "32269",
+		"model":     "Qwen/Test",
+		"reason":    "local_recovery_failed",
+	}, 1)
+}
+
 func TestGatewayMetricsCollectorIncludesParticipantQuarantineState(t *testing.T) {
 	limiter := NewParticipantRequestLimiter(10, 10)
 	for i := 0; i < emptyStreamQuarantineThreshold; i++ {

--- a/devshard/user/httpsession.go
+++ b/devshard/user/httpsession.go
@@ -28,6 +28,18 @@ type HTTPSessionConfig struct {
 	ProtocolVersion  types.ProtocolVersion // optional: defaults to ProtocolV1
 }
 
+func deferredWarmKeyResolver(resolve state.WarmKeyResolver) (state.WarmKeyResolver, func()) {
+	recoveryComplete := false
+	return func(warmAddr, coldAddr string) (bool, error) {
+			if !recoveryComplete {
+				return false, nil
+			}
+			return resolve(warmAddr, coldAddr)
+		}, func() {
+			recoveryComplete = true
+		}
+}
+
 func resolveHTTPSessionStoragePath(escrowID, configured string) string {
 	if configured != "" {
 		return configured
@@ -174,14 +186,16 @@ func NewHTTPSession(cfg HTTPSessionConfig) (*Session, *state.StateMachine, error
 	// Check if there is an existing session to recover from.
 	_, metaErr := sqlStore.GetSessionMeta(cfg.EscrowID)
 	if metaErr == nil {
+		warmKeyResolver, enableWarmKeyResolver := deferredWarmKeyResolver(cfg.Bridge.VerifyWarmKey)
 		session, recSM, recErr := RecoverSession(sqlStore, signer, verifier, cfg.EscrowID, sessionVersion, group, clients,
-			state.WithWarmKeyResolver(cfg.Bridge.VerifyWarmKey),
+			state.WithWarmKeyResolver(warmKeyResolver),
 			state.WithProtocolVersion(pv),
 		)
 		if recErr != nil {
 			sqlStore.Close()
 			return nil, nil, fmt.Errorf("recover session: %w", recErr)
 		}
+		enableWarmKeyResolver()
 		session.SetParticipantKeys(participantKeys)
 		return session, recSM, nil
 	}

--- a/devshard/user/httpsession.go
+++ b/devshard/user/httpsession.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	devshardpkg "devshard"
 	"devshard/bridge"
@@ -29,15 +30,14 @@ type HTTPSessionConfig struct {
 }
 
 func deferredWarmKeyResolver(resolve state.WarmKeyResolver) (state.WarmKeyResolver, func()) {
-	recoveryComplete := false
-	return func(warmAddr, coldAddr string) (bool, error) {
-			if !recoveryComplete {
-				return false, nil
-			}
-			return resolve(warmAddr, coldAddr)
-		}, func() {
-			recoveryComplete = true
+	var recoveryComplete atomic.Bool
+	resolver := func(warmAddr, coldAddr string) (bool, error) {
+		if !recoveryComplete.Load() {
+			return false, nil
 		}
+		return resolve(warmAddr, coldAddr)
+	}
+	return resolver, func() { recoveryComplete.Store(true) }
 }
 
 func resolveHTTPSessionStoragePath(escrowID, configured string) string {

--- a/devshard/user/httpsession_test.go
+++ b/devshard/user/httpsession_test.go
@@ -1,6 +1,9 @@
 package user
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"devshard/bridge"
@@ -14,6 +17,78 @@ func TestNewHTTPSessionRequiresRoutePrefix(t *testing.T) {
 	_, _, err := NewHTTPSession(HTTPSessionConfig{})
 	require.ErrorContains(t, err, "RoutePrefix is required")
 	require.ErrorContains(t, err, "/devshard/{version}")
+	require.False(t, errors.Is(err, ErrLocalStateUnrecoverable))
+}
+
+func TestNewHTTPSessionOpenStorageFailureStaysFatal(t *testing.T) {
+	const privateKeyHex = "0000000000000000000000000000000000000000000000000000000000000001"
+	storagePath := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(storagePath, []byte("occupied"), 0o600))
+
+	_, _, err := NewHTTPSession(HTTPSessionConfig{
+		PrivateKeyHex:   privateKeyHex,
+		EscrowID:        "escrow-1",
+		Bridge:          httpsessionTestBridge{},
+		StoragePath:     storagePath,
+		RoutePrefix:     "/devshard/dev",
+		ProtocolVersion: types.ProtocolV1,
+	})
+
+	// Open errors are environmental (permissions, disk), not proven history
+	// corruption: they must not carry the deactivate-and-skip sentinel.
+	require.Error(t, err)
+	require.ErrorContains(t, err, "open storage")
+	require.False(t, errors.Is(err, ErrLocalStateUnrecoverable))
+}
+
+func TestNewHTTPSessionClassifiesNonSequentialReplay(t *testing.T) {
+	const privateKeyHex = "0000000000000000000000000000000000000000000000000000000000000001"
+	storagePath := filepath.Join(t.TempDir(), "session")
+	store, err := storage.NewSQLite(storagePath)
+	require.NoError(t, err)
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "escrow-1",
+		EpochID:        7,
+		Version:        "dev",
+		CreatorAddr:    "creator",
+		Group:          []types.SlotAssignment{{SlotID: 0, ValidatorAddress: "host-1"}},
+		InitialBalance: 1_000_000,
+	}))
+	require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{Diff: types.Diff{Nonce: 1}}))
+	require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{Diff: types.Diff{Nonce: 3}}))
+	require.NoError(t, store.Close())
+
+	_, _, err = NewHTTPSession(HTTPSessionConfig{
+		PrivateKeyHex:   privateKeyHex,
+		EscrowID:        "escrow-1",
+		Bridge:          httpsessionTestBridge{},
+		StoragePath:     storagePath,
+		RoutePrefix:     "/devshard/dev",
+		ProtocolVersion: types.ProtocolV1,
+	})
+
+	require.ErrorIs(t, err, ErrLocalStateUnrecoverable)
+	require.ErrorContains(t, err, "recover session")
+	require.ErrorContains(t, err, "missing nonce 2, next stored nonce is 3")
+}
+
+func TestDeferredWarmKeyResolverAvoidsExternalCallsDuringRecovery(t *testing.T) {
+	calls := 0
+	resolver, enable := deferredWarmKeyResolver(func(_, _ string) (bool, error) {
+		calls++
+		return true, nil
+	})
+
+	ok, err := resolver("warm", "cold")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Zero(t, calls)
+
+	enable()
+	ok, err = resolver("warm", "cold")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, calls)
 }
 
 func TestNewHTTPSessionUsesRouteVersionForStorageBind(t *testing.T) {

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -14,6 +14,33 @@ import (
 	"devshard/types"
 )
 
+// ErrLocalStateUnrecoverable marks a proven integrity failure in persisted
+// diff history: a nonce gap, a missing tail, or a state-root mismatch during
+// replay. Gateway startup deactivates and skips such escrows (like
+// bridge.ErrEscrowNotFound). Transient failures (I/O errors, full disk, chain
+// timeouts) are never classified and stay fatal, so escrow rotation cannot
+// mint replacements into a broken environment.
+var ErrLocalStateUnrecoverable = errors.New("local session state unrecoverable")
+
+// validateDiffRange verifies the stored diffs cover [from, to] contiguously.
+// A missing tail (diffs end before latest_nonce) would otherwise recover
+// silently behind the hosts.
+func validateDiffRange(records []types.DiffRecord, from, to uint64) error {
+	expected := from
+	for _, rec := range records {
+		if rec.Nonce != expected {
+			return fmt.Errorf("%w: missing nonce %d, next stored nonce is %d",
+				ErrLocalStateUnrecoverable, expected, rec.Nonce)
+		}
+		expected++
+	}
+	if expected <= to {
+		return fmt.Errorf("%w: missing trailing nonces %d..%d",
+			ErrLocalStateUnrecoverable, expected, to)
+	}
+	return nil
+}
+
 // snapshotInterval controls how often a state snapshot is saved -- both
 // during diff replay at recovery time AND during runtime via
 // Session.maybeSaveSnapshotLocked. After replay finishes, a final
@@ -151,6 +178,7 @@ func RecoverSession(
 	// below so any stranded host can self-heal.
 	var snapshotCursor map[int]uint64
 	legacySnapshot := false
+	snapshotRestored := false
 	replayFrom := uint64(1)
 	snapNonce, snapData, snapErr := store.LoadSnapshot(escrowID)
 	if snapErr == nil && snapNonce > 0 && snapNonce <= meta.LatestNonce {
@@ -163,6 +191,7 @@ func RecoverSession(
 			sess.nonce = snapNonce
 			snapshotCursor = cursor
 			legacySnapshot = cursor == nil
+			snapshotRestored = true
 			log.Printf("recover_session escrow=%s snapshot_restored nonce=%d replay_from=%d total=%d skipped=%d host_cursors=%d legacy=%t",
 				escrowID, snapNonce, replayFrom, meta.LatestNonce, snapNonce, len(cursor), legacySnapshot)
 		}
@@ -186,12 +215,18 @@ func RecoverSession(
 	// small. For a legacy snapshot (cursor unknown) min returns 0 and we
 	// load the entire pre-snapshot history once -- a one-time slow
 	// recovery that self-heals stranded hosts.
-	if snapNonce > 0 {
+	//
+	// Gated on snapshotRestored, not snapNonce: an ignored snapshot (future
+	// nonce, decode failure) replays from 1, which already covers the range.
+	if snapshotRestored {
 		backfillFrom := minHostSyncNonce(sess.hostSyncNonce, len(group)) + 1
 		if backfillFrom <= snapNonce {
 			backfillRecords, berr := store.GetDiffs(escrowID, backfillFrom, snapNonce)
 			if berr != nil {
 				return nil, nil, fmt.Errorf("get backfill diffs %d..%d: %w", backfillFrom, snapNonce, berr)
+			}
+			if verr := validateDiffRange(backfillRecords, backfillFrom, snapNonce); verr != nil {
+				return nil, nil, fmt.Errorf("backfill diffs %d..%d: %w", backfillFrom, snapNonce, verr)
 			}
 			log.Printf("recover_session escrow=%s diff_backfill from=%d to=%d count=%d",
 				escrowID, backfillFrom, snapNonce, len(backfillRecords))
@@ -215,6 +250,9 @@ func RecoverSession(
 	if err != nil {
 		return nil, nil, fmt.Errorf("get diffs: %w", err)
 	}
+	if err := validateDiffRange(records, replayFrom, meta.LatestNonce); err != nil {
+		return nil, nil, err
+	}
 
 	log.Printf("recover_session escrow=%s replaying diffs %d..%d (%d records)", escrowID, replayFrom, meta.LatestNonce, len(records))
 
@@ -222,11 +260,16 @@ func RecoverSession(
 		sm.InjectWarmKeys(rec.WarmKeyDelta)
 		root, applyErr := sm.ApplyLocal(rec.Nonce, rec.Txs)
 		if applyErr != nil {
+			if errors.Is(applyErr, types.ErrInvalidNonce) {
+				return nil, nil, fmt.Errorf("%w: replay nonce %d: %w",
+					ErrLocalStateUnrecoverable, rec.Nonce, applyErr)
+			}
 			return nil, nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
 		}
 		if len(rec.StateHash) > 0 && len(root) > 0 {
 			if !bytes.Equal(root, rec.StateHash) {
-				return nil, nil, fmt.Errorf("state root mismatch at nonce %d", rec.Nonce)
+				return nil, nil, fmt.Errorf("%w: state root mismatch at nonce %d",
+					ErrLocalStateUnrecoverable, rec.Nonce)
 			}
 		}
 

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -251,7 +251,7 @@ func RecoverSession(
 		return nil, nil, fmt.Errorf("get diffs: %w", err)
 	}
 	if err := validateDiffRange(records, replayFrom, meta.LatestNonce); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("replay diffs %d..%d: %w", replayFrom, meta.LatestNonce, err)
 	}
 
 	log.Printf("recover_session escrow=%s replaying diffs %d..%d (%d records)", escrowID, replayFrom, meta.LatestNonce, len(records))

--- a/devshard/user/recover_test.go
+++ b/devshard/user/recover_test.go
@@ -623,3 +623,121 @@ func TestRecoverSession_EmptyVersionRejected(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "session version required")
 }
+
+// validateDiffRange proves persisted-history integrity before replay. Both a
+// gap in the middle and a missing tail (diffs end before latest_nonce, which
+// would otherwise recover silently behind the hosts) must carry the
+// deactivate-and-skip sentinel; a contiguous range must pass.
+func TestValidateDiffRange(t *testing.T) {
+	recs := func(nonces ...uint64) []types.DiffRecord {
+		out := make([]types.DiffRecord, len(nonces))
+		for i, n := range nonces {
+			out[i] = types.DiffRecord{Diff: types.Diff{Nonce: n}}
+		}
+		return out
+	}
+
+	require.NoError(t, validateDiffRange(recs(1, 2, 3), 1, 3))
+	require.NoError(t, validateDiffRange(recs(7, 8), 7, 8))
+	require.NoError(t, validateDiffRange(nil, 5, 4), "empty range after snapshot")
+
+	// Mid-range gap: the escrow 32269 shape (1..6 stored, then 151).
+	err := validateDiffRange(recs(1, 2, 3, 4, 5, 6, 151, 152), 1, 152)
+	require.ErrorIs(t, err, ErrLocalStateUnrecoverable)
+	require.ErrorContains(t, err, "missing nonce 7, next stored nonce is 151")
+
+	// Missing tail: latest_nonce points past the stored diffs.
+	err = validateDiffRange(recs(1, 2, 3, 4, 5, 6), 1, 152)
+	require.ErrorIs(t, err, ErrLocalStateUnrecoverable)
+	require.ErrorContains(t, err, "missing trailing nonces 7..152")
+
+	// Missing head right after a snapshot.
+	err = validateDiffRange(recs(12), 11, 12)
+	require.ErrorIs(t, err, ErrLocalStateUnrecoverable)
+	require.ErrorContains(t, err, "missing nonce 11")
+}
+
+// TestRecoverSession_BackfillGapUnrecoverable verifies a missing diff inside
+// the required pre-snapshot backfill range [min host cursor+1, snapNonce] is
+// a proven integrity failure. The snapshot here is current (nothing to
+// replay), so without backfill validation recovery returns success with a
+// non-contiguous sess.diffs and the stranded host rejects catch-up forever
+// with "invalid nonce: must be sequential".
+func TestRecoverSession_BackfillGapUnrecoverable(t *testing.T) {
+	store := newTestStore(t)
+	numHosts := 3
+
+	hosts := make([]*signing.Secp256k1Signer, numHosts)
+	for i := range hosts {
+		hosts[i] = testutil.MustGenerateKey(t)
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(numHosts)
+	verifier := signing.NewSecp256k1Verifier()
+
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "escrow-1",
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+	// Diff 3 is lost; latest_nonce lands on 4.
+	for _, n := range []uint64{1, 2, 4} {
+		require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{Diff: types.Diff{Nonce: n}}))
+	}
+	// Snapshot is current at 4, so nothing is replayed. Host 0 is stranded at
+	// nonce 2 and needs the backfill range 3..4, which has a hole.
+	sm := newTestStateMachine(t, "escrow-1", config, group, 100000, user.Address(), verifier)
+	saveSnapshot(store, sm, "escrow-1", 4, map[int]uint64{0: 2, 1: 4, 2: 4})
+
+	_, _, err := RecoverSession(store, user, verifier, "escrow-1", testutil.RuntimeTestVersion, group,
+		buildRecoveryClients(t, hosts, group, user))
+
+	require.ErrorIs(t, err, ErrLocalStateUnrecoverable)
+	require.ErrorContains(t, err, "backfill diffs 3..4")
+	require.ErrorContains(t, err, "missing nonce 3, next stored nonce is 4")
+}
+
+// A snapshot ahead of latest_nonce is ignored and recovery replays from 1.
+// The backfill validation must not run against the ignored snapshot's nonce:
+// contiguous history through latest_nonce is fully recoverable and must not
+// be classified as missing a tail.
+func TestRecoverSession_IgnoredFutureSnapshotRecovers(t *testing.T) {
+	store := newTestStore(t)
+	numHosts := 3
+
+	hosts := make([]*signing.Secp256k1Signer, numHosts)
+	for i := range hosts {
+		hosts[i] = testutil.MustGenerateKey(t)
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(numHosts)
+	verifier := signing.NewSecp256k1Verifier()
+
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "escrow-1",
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+	for _, n := range []uint64{1, 2, 3} {
+		require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{Diff: types.Diff{Nonce: n}}))
+	}
+	// Snapshot claims nonce 5 while latest_nonce is 3 (e.g. session row lost
+	// a write the async snapshot kept).
+	sm := newTestStateMachine(t, "escrow-1", config, group, 100000, user.Address(), verifier)
+	saveSnapshot(store, sm, "escrow-1", 5, map[int]uint64{0: 5, 1: 5, 2: 5})
+
+	session, _, err := RecoverSession(store, user, verifier, "escrow-1", testutil.RuntimeTestVersion, group,
+		buildRecoveryClients(t, hosts, group, user))
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), session.Nonce())
+	require.Len(t, session.Diffs(), 3)
+}


### PR DESCRIPTION
## Summary

- Detect nonce gaps, missing tails, and state-root mismatches during session recovery.
- Deactivate and skip only escrows with proven local history corruption.
- Keep environmental failures such as disk, I/O, and chain errors fatal to prevent escrow rotation from minting replacements into a broken environment.
- Validate both replay and pre-snapshot backfill ranges.
- Add startup quarantine logs, metrics, and a Grafana panel.