### PR TITLE
fix: verify host signature in fetchSignature before storing

### DIFF
--- a/devshard/user/fetch_signature_verify_test.go
+++ b/devshard/user/fetch_signature_verify_test.go
@@ -1,0 +1,87 @@
+package user
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/host"
+	"devshard/internal/testutil"
+)
+
+// fakeFetcher implements HostClient + SignatureFetcher. GetSignatures returns
+// whatever the test stages, simulating a byzantine host that serves arbitrary
+// bytes from its local signature store via GET /sessions/:id/signatures.
+type fakeFetcher struct {
+	sigs map[uint32][]byte
+}
+
+func (f *fakeFetcher) Send(_ context.Context, _ host.HostRequest, _ io.Writer, _ func()) (*host.HostResponse, error) {
+	return &host.HostResponse{}, nil
+}
+
+func (f *fakeFetcher) GetSignatures(_ context.Context, _ uint64) (map[uint32][]byte, error) {
+	return f.sigs, nil
+}
+
+// fetchSignature must verify the returned bytes against the canonical
+// StateSignatureContent preimage before storing, mirroring processResponse.
+// A byzantine host that serves arbitrary bytes from its local store must not
+// be able to poison the proxy's signature pool.
+func TestFetchSignature_RejectsUnverifiedGarbage(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	ctx := context.Background()
+
+	// Send one inference so the proxy has a post-state-root for the nonce,
+	// matching the production precondition for any nonce a session would
+	// finalize over.
+	params := InferenceParams{
+		Model:       "llama",
+		Prompt:      testutil.TestPrompt,
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}
+	_, err := session.SendInference(ctx, params)
+	require.NoError(t, err)
+
+	const hostIdx = 0
+	const slot = uint32(0)
+	expectedAddr := session.group[hostIdx].ValidatorAddress
+	require.Equal(t, expectedAddr, session.sm.SlotAddress(slot))
+
+	// Inference 1 routes to host 1 (1 % 3), so host 0 has not contributed a
+	// signature yet — perfect target for the poison attempt.
+	garbage := []byte("NOT-A-REAL-SIGNATURE-JUST-65-BYTES-OF-NOTHING-AT-ALL-AAAAAAAAAAAA")
+	badClient := &fakeFetcher{
+		sigs: map[uint32][]byte{slot: garbage},
+	}
+
+	ok := session.fetchSignature(ctx, hostIdx, 1, badClient)
+	require.False(t, ok, "fetchSignature must reject bytes that don't recover to expectedAddr")
+
+	stored := session.Signatures()[1]
+	if stored != nil {
+		require.Nil(t, stored[slot], "garbage bytes must not be stored under slot 0")
+	}
+}
+
+// processResponse already verifies — keep a parallel assertion so the symmetry
+// stays under test. Same input rejected by both ingestion paths.
+func TestProcessResponse_RejectsUnverifiedGarbage(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+
+	const hostIdx = 0
+	const nonce = uint64(42)
+	garbage := []byte("NOT-A-REAL-SIGNATURE-JUST-65-BYTES-OF-NOTHING-AT-ALL-AAAAAAAAAAAA")
+
+	resp := &host.HostResponse{
+		Nonce:    nonce,
+		StateSig: garbage,
+	}
+
+	err := session.ProcessResponse(hostIdx, resp, nonce)
+	require.Error(t, err, "processResponse must reject garbage signatures")
+}

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -472,24 +472,8 @@ func (s *Session) processResponse(hostIdx int, resp *host.HostResponse, inferenc
 	// Verify and store state signature.
 	if resp.StateSig != nil {
 		expectedAddr := s.group[hostIdx].ValidatorAddress
-		sigContent := &types.StateSignatureContent{
-			StateRoot: resp.StateHash,
-			EscrowId:  s.escrowID,
-			Nonce:     resp.Nonce,
-		}
-		sigData, err := proto.Marshal(sigContent)
-		if err != nil {
-			return fmt.Errorf("marshal state sig content: %w", err)
-		}
-		addr, err := s.verifier.RecoverAddress(sigData, resp.StateSig)
-		if err != nil {
-			return fmt.Errorf("%w: host %d: %v", types.ErrInvalidStateSig, hostIdx, err)
-		}
-		if addr != expectedAddr {
-			if !s.sm.CheckWarmKey(addr, expectedAddr) {
-				return fmt.Errorf("%w: host %d: expected %s, got %s",
-					types.ErrInvalidStateSig, hostIdx, expectedAddr, addr)
-			}
+		if err := s.verifyStateSignature(resp.Nonce, resp.StateHash, resp.StateSig, expectedAddr); err != nil {
+			return fmt.Errorf("host %d: %w", hostIdx, err)
 		}
 
 		// Store for all slots owned by this validator address.
@@ -1176,6 +1160,30 @@ func (s *Session) getFinalizeClients() []HostClient {
 // via the SignatureFetcher interface (GET /signatures?nonce=N). This avoids
 // sending diffs when the host already signed the state via gossip.
 // Returns true if a signature was successfully fetched and stored.
+// verifyStateSignature recovers the signer of signature over the canonical
+// StateSignatureContent{postRoot, escrowID, nonce} preimage and returns an error
+// unless it recovers to expectedAddr (with warm-key fallback). Shared by
+// processResponse (inbound host responses) and fetchSignature (pulled signatures)
+// so a host cannot get bytes that don't verify against its slot into the pool.
+func (s *Session) verifyStateSignature(nonce uint64, postRoot, signature []byte, expectedAddr string) error {
+	sigData, err := proto.Marshal(&types.StateSignatureContent{
+		StateRoot: postRoot,
+		EscrowId:  s.escrowID,
+		Nonce:     nonce,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal state sig content: %w", err)
+	}
+	recovered, err := s.verifier.RecoverAddress(sigData, signature)
+	if err != nil {
+		return fmt.Errorf("%w: %v", types.ErrInvalidStateSig, err)
+	}
+	if recovered != expectedAddr && !s.sm.CheckWarmKey(recovered, expectedAddr) {
+		return fmt.Errorf("%w: expected %s, got %s", types.ErrInvalidStateSig, expectedAddr, recovered)
+	}
+	return nil
+}
+
 func (s *Session) fetchSignature(ctx context.Context, hostIdx int, nonce uint64, client HostClient) bool {
 	fetcher, ok := client.(SignatureFetcher)
 	if !ok {
@@ -1196,10 +1204,22 @@ func (s *Session) fetchSignature(ctx context.Context, hostIdx int, nonce uint64,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	postRoot, ok := s.postStateRootForNonce(nonce)
+	if !ok {
+		logging.Info("fetchSignature: no post-state-root for nonce", "subsystem", "finalize",
+			"escrow", s.escrowID, "nonce", nonce, "host", hostIdx)
+		return false
+	}
+
 	for slotID := range sigs {
 		addr := s.sm.SlotAddress(slotID)
 		if addr != expectedAddr {
 			continue
+		}
+		if err := s.verifyStateSignature(nonce, postRoot, sigs[slotID], expectedAddr); err != nil {
+			logging.Warn("fetchSignature: rejected unverified signature", "subsystem", "finalize",
+				"escrow", s.escrowID, "nonce", nonce, "host", hostIdx, "slot", slotID, "error", err)
+			return false
 		}
 		if _, ok := s.signatures[nonce]; !ok {
 			s.signatures[nonce] = make(map[uint32][]byte)
@@ -1212,6 +1232,8 @@ func (s *Session) fetchSignature(ctx context.Context, hostIdx int, nonce uint64,
 		s.logSignatureProgress(nonce)
 		return true
 	}
+	logging.Info("fetchSignature: no signature from expected host", "subsystem", "finalize",
+		"escrow", s.escrowID, "nonce", nonce, "host", hostIdx)
 	return false
 }
 


### PR DESCRIPTION
Reopening https://github.com/gonka-ai/gonka/pull/1311 originally by @0xMayoor  accidently closed by target branch removal
_____
`processResponse` (`session.go:484`) marshals `StateSignatureContent`, recovers the address from `resp.StateSig`, and rejects unless it matches `expectedAddr`. the sibling `fetchSignature` (`session.go:1179`) doesn't — bytes returned by a host's GET `/sessions/:id/signatures` are stored after only a slot-ownership check.

`processResponse` only stores when `resp.StateSig != nil` (line 473), so a host that withholds its sig in the streaming response always lands in the next missing set — `CollectSignatures` routes it through `fetchSignature` every time. once the bytes are stored, `sigWeight` counts by slot not by validity, `hasQuorum` trips, collection cancels, `Finalize` short-circuits at line 974, settlement ships poisoned and the chain rejects. `s.signatures` is never reset, retries hit the same cache.

the existing TODO at `server.go:114` (restrict GET endpoints to group members) doesn't close this — a byzantine group member passes membership auth and still serves whatever its `HandleGetSignatures` returns raw from local storage. orthogonal to the missing content verification.

Fix: mirror `processResponse:472-493` in `fetchSignature` — `postStateRootForNonce`, marshal, RecoverAddress, match against expectedAddr (warm-key fallback). regression in `fetch_signature_verify_test.go`.

#1284 