### PR TITLE
fix(devshard): return logprobs to clients who explicitly requested them (#1264)

### DIFF
--- a/devshard/cmd/devshardctl/proxy.go
+++ b/devshard/cmd/devshardctl/proxy.go
@@ -232,6 +232,9 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	logRequestStage(ctx, "proxy_request_started", "escrow", p.escrowID, "model", model, "stream", req.Stream, "input_tokens", params.InputLength)
 
+	// Carry the client's original logprobs intent to the response strip boundary.
+	r = r.WithContext(withLogprobClientIntent(r.Context(), logprobClientIntentFromRequest(req)))
+
 	if req.Stream {
 		p.handleStreaming(w, r, params)
 	} else {
@@ -264,6 +267,7 @@ type deferredWriter struct {
 	escrow         string
 	requestID      string
 	clientFlag     *cancelFlag
+	logprobIntent  logprobClientIntent
 	started        bool
 	bytesWritten   int64
 	sawDone        bool
@@ -276,7 +280,7 @@ type deferredWriter struct {
 
 func newDeferredWriter(ctx context.Context, w http.ResponseWriter, escrow string, flag *cancelFlag) *deferredWriter {
 	rid, _ := requestLogFromContext(ctx)
-	return &deferredWriter{ctx: ctx, w: w, escrow: escrow, requestID: rid, clientFlag: flag}
+	return &deferredWriter{ctx: ctx, w: w, escrow: escrow, requestID: rid, clientFlag: flag, logprobIntent: logprobClientIntentFromContext(ctx)}
 }
 
 func (d *deferredWriter) Write(p []byte) (int, error) {
@@ -303,7 +307,7 @@ func (d *deferredWriter) Write(p []byte) (int, error) {
 		d.w.WriteHeader(http.StatusOK)
 		d.started = true
 	}
-	rewritten := rewriteStreamingPayload(p)
+	rewritten := rewriteStreamingPayload(p, d.logprobIntent)
 	if bytes.Contains(rewritten, sseDoneMarker) {
 		d.sawDone = true
 	}
@@ -558,7 +562,7 @@ func (p *Proxy) handleNonStreaming(w http.ResponseWriter, r *http.Request, param
 	}
 
 	assembled := assembleSSEChunks(buf.String())
-	assembled = filterClientInternalFields(assembled)
+	assembled = filterClientInternalFields(assembled, logprobClientIntentFromContext(r.Context()))
 	if rid, ok := requestLogFromContext(r.Context()); ok {
 		w.Header().Set("X-Request-Id", rid)
 	}

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -414,13 +414,13 @@ func TestDeferredWriterTracksForwardedDoneMarker(t *testing.T) {
 
 func TestRewriteStreamingPayload_PassthroughWhenNoConversionNeeded(t *testing.T) {
 	payload := []byte(`data: {"id":"cmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}` + "\n\n")
-	require.Equal(t, payload, rewriteStreamingPayload(payload))
+	require.Equal(t, payload, rewriteStreamingPayload(payload, logprobClientIntent{}))
 }
 
 func TestRewriteStreamingPayload_FiltersLogprobsFromExistingChunks(t *testing.T) {
 	payload := []byte(`data: {"id":"cmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":0,"top_logprobs":[{"token":"Hi","logprob":0}]}]},"finish_reason":null}]}` + "\n\n")
 
-	rewritten := rewriteStreamingPayload(payload)
+	rewritten := rewriteStreamingPayload(payload, logprobClientIntent{})
 
 	require.NotContains(t, string(rewritten), "logprob")
 	require.Contains(t, string(rewritten), `"content":"Hi"`)
@@ -429,7 +429,7 @@ func TestRewriteStreamingPayload_FiltersLogprobsFromExistingChunks(t *testing.T)
 func TestFilterClientInternalFields_RemovesNestedLogprobPayloads(t *testing.T) {
 	payload := []byte(`{"choices":[{"message":{"content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":0,"top_logprobs":[{"token":"Hi","logprob":0}]}]}}]}`)
 
-	filtered := filterClientInternalFields(payload)
+	filtered := filterClientInternalFields(payload, logprobClientIntent{})
 
 	require.JSONEq(t, `{"choices":[{"message":{"content":"Hi"}}]}`, string(filtered))
 }
@@ -437,14 +437,14 @@ func TestFilterClientInternalFields_RemovesNestedLogprobPayloads(t *testing.T) {
 func TestFilterClientInternalFields_RemovesTokenIDsAndPromptTokenIDs(t *testing.T) {
 	payload := []byte(`{"prompt_token_ids":[1,2,3],"choices":[{"message":{"content":"Hi"},"token_ids":[4,5,6]}]}`)
 
-	filtered := filterClientInternalFields(payload)
+	filtered := filterClientInternalFields(payload, logprobClientIntent{})
 
 	require.JSONEq(t, `{"choices":[{"message":{"content":"Hi"}}]}`, string(filtered))
 }
 
 func TestRewriteStreamingPayload_PreservesOriginalBytesWhenConvertibleRewriteFails(t *testing.T) {
 	payload := []byte("data: {\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"\"}}]}\r\n\r\n")
-	require.Equal(t, payload, rewriteStreamingPayload(payload))
+	require.Equal(t, payload, rewriteStreamingPayload(payload, logprobClientIntent{}))
 }
 
 func TestHasMsgFinish(t *testing.T) {

--- a/devshard/cmd/devshardctl/request_filters.go
+++ b/devshard/cmd/devshardctl/request_filters.go
@@ -17,6 +17,16 @@ type chatRequest struct {
 	MaxTokens           uint64 `json:"max_tokens"`
 	MaxCompletionTokens uint64 `json:"max_completion_tokens"`
 	N                   uint64 `json:"n"`
+	// Logprobs and TopLogprobs capture the client's ORIGINAL logprobs intent,
+	// read by DecodeRequest before the PostLimits stage force-enables logprobs
+	// upstream for validation (see the logprobs/top_logprobs ForceLiteral rules
+	// in request_filters_parameters.go, which force logprobs=true and clamp
+	// top_logprobs to TopLogprobsForcedValue on the wire). These hold what the
+	// client asked for, not the forced values, and drive conditional response
+	// stripping so clients who explicitly asked for logprobs get them back. Cf.
+	// logprobClientIntent.
+	Logprobs    bool   `json:"logprobs"`
+	TopLogprobs uint64 `json:"top_logprobs"`
 }
 
 type outputTokenLimits struct {

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -334,6 +334,12 @@ func (ctx *RequestFilterContext) SyncRequestView() error {
 	}
 	req.MaxTokens = ctx.Request.MaxTokens
 	req.MaxCompletionTokens = ctx.Request.MaxCompletionTokens
+	// Preserve the client's ORIGINAL logprobs intent. PostLimits force-sets
+	// logprobs=true / top_logprobs=<forced> in the document for validation, so
+	// re-reading them here would capture the forced values, not what the client
+	// asked. DecodeRequest already captured the original before PostLimits ran.
+	req.Logprobs = ctx.Request.Logprobs
+	req.TopLogprobs = ctx.Request.TopLogprobs
 	ctx.Request = req
 	return nil
 }
@@ -361,6 +367,22 @@ func readChatRequestFields(doc *ChatRequestDocument, req *chatRequest) error {
 	}
 	if err := readUint64Field(doc, "n", &req.N); err != nil {
 		return err
+	}
+	// logprobs/top_logprobs: lenient capture of the client's original intent.
+	// Only an explicit boolean true (and a positive top_logprobs) counts as a
+	// request; any other shape is treated as "not requested" so we never reject a
+	// request the gateway previously accepted -- the PostLimits ForceLiteral
+	// rules overwrite both fields regardless of incoming type. Cf.
+	// logprobClientIntent and conditional response stripping.
+	if raw, ok := doc.Get("logprobs"); ok {
+		if b, isBool := raw.(bool); isBool {
+			req.Logprobs = b
+		}
+	}
+	if raw, ok := doc.Get("top_logprobs"); ok {
+		if n, isNum := devshard.JSONNumericUint64(raw); isNum {
+			req.TopLogprobs = n
+		}
 	}
 	return nil
 }

--- a/devshard/cmd/devshardctl/stream_rewrite.go
+++ b/devshard/cmd/devshardctl/stream_rewrite.go
@@ -2,9 +2,38 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 )
+
+// logprobClientIntent records whether the client's ORIGINAL request asked for
+// logprobs / top_logprobs. The gateway force-enables logprobs upstream for
+// validation, so without this the client-facing strip cannot tell a client who
+// asked for logprobs from one who did not. The zero value (keep nothing) is the
+// historical behavior: strip everything.
+type logprobClientIntent struct {
+	keepLogprobs    bool
+	keepTopLogprobs bool
+}
+
+func logprobClientIntentFromRequest(req chatRequest) logprobClientIntent {
+	return logprobClientIntent{
+		keepLogprobs:    req.Logprobs,
+		keepTopLogprobs: req.Logprobs && req.TopLogprobs > 0,
+	}
+}
+
+type logprobIntentContextKey struct{}
+
+func withLogprobClientIntent(ctx context.Context, intent logprobClientIntent) context.Context {
+	return context.WithValue(ctx, logprobIntentContextKey{}, intent)
+}
+
+func logprobClientIntentFromContext(ctx context.Context) logprobClientIntent {
+	intent, _ := ctx.Value(logprobIntentContextKey{}).(logprobClientIntent)
+	return intent
+}
 
 type streamingRewritePayload struct {
 	ID                string          `json:"id"`
@@ -48,7 +77,7 @@ type rewriteLogprob struct {
 // Only if a host sent SSE-wrapped chat.completion JSON do we synthesize
 // chat.completion.chunk events for the client. The synthetic role chunk exists
 // only in that streaming rewrite.
-func rewriteStreamingPayload(p []byte) []byte {
+func rewriteStreamingPayload(p []byte, intent logprobClientIntent) []byte {
 	needsCompletionRewrite := bytes.Contains(p, []byte(`data: {`)) && bytes.Contains(p, []byte(`"message"`))
 	needsInternalFieldsFilter := containsAnyInternalField(p)
 	if !needsCompletionRewrite && !needsInternalFieldsFilter {
@@ -71,9 +100,9 @@ func rewriteStreamingPayload(p []byte) []byte {
 			continue
 		}
 		payload := bytes.TrimSpace(event[len("data: "):])
-		rewritten, ok := rewriteStreamingDataEvent(payload)
+		rewritten, ok := rewriteStreamingDataEvent(payload, intent)
 		if !ok {
-			filtered := filterClientInternalFields(payload)
+			filtered := filterClientInternalFields(payload, intent)
 			if !bytes.Equal(filtered, payload) {
 				fmt.Fprintf(&out, "data: %s\n\n", filtered)
 				changed = true
@@ -91,7 +120,7 @@ func rewriteStreamingPayload(p []byte) []byte {
 	return out.Bytes()
 }
 
-func rewriteStreamingDataEvent(payload []byte) ([]byte, bool) {
+func rewriteStreamingDataEvent(payload []byte, intent logprobClientIntent) ([]byte, bool) {
 	var resp streamingRewritePayload
 	if err := json.Unmarshal(payload, &resp); err != nil {
 		return nil, false
@@ -116,7 +145,7 @@ func rewriteStreamingDataEvent(payload []byte) ([]byte, bool) {
 			continue
 		}
 		if role := choice.Message.Role; role != "" {
-			writeStreamingChunkEvent(&out, resp, choice.Index, map[string]any{"role": role}, nil, nil)
+			writeStreamingChunkEvent(&out, resp, choice.Index, map[string]any{"role": role}, nil, nil, nil)
 		}
 
 		tokens := []rewriteLogprob(nil)
@@ -130,16 +159,16 @@ func rewriteStreamingDataEvent(payload []byte) ([]byte, bool) {
 				if i == len(tokens)-1 {
 					finish = choice.FinishReason
 				}
-				writeStreamingChunkEvent(&out, resp, choice.Index, delta, finish, choice.StopReason)
+				writeStreamingChunkEvent(&out, resp, choice.Index, delta, finish, choice.StopReason, reconstructChunkLogprobs(token, intent))
 			}
 			continue
 		}
 
 		if choice.Message.Content != "" {
-			writeStreamingChunkEvent(&out, resp, choice.Index, map[string]any{"content": choice.Message.Content}, nil, nil)
+			writeStreamingChunkEvent(&out, resp, choice.Index, map[string]any{"content": choice.Message.Content}, nil, nil, nil)
 		}
 		if choice.FinishReason != nil || len(bytes.TrimSpace(choice.StopReason)) > 0 {
-			writeStreamingChunkEvent(&out, resp, choice.Index, map[string]any{}, choice.FinishReason, choice.StopReason)
+			writeStreamingChunkEvent(&out, resp, choice.Index, map[string]any{}, choice.FinishReason, choice.StopReason, nil)
 		}
 	}
 
@@ -164,11 +193,14 @@ func rewriteStreamingDataEvent(payload []byte) ([]byte, bool) {
 	return out.Bytes(), true
 }
 
-func writeStreamingChunkEvent(out *bytes.Buffer, resp streamingRewritePayload, index int, delta map[string]any, finishReason *string, stopReason json.RawMessage) {
+func writeStreamingChunkEvent(out *bytes.Buffer, resp streamingRewritePayload, index int, delta map[string]any, finishReason *string, stopReason json.RawMessage, logprobs any) {
 	choice := map[string]any{
 		"index":         index,
 		"delta":         delta,
 		"finish_reason": finishReason,
+	}
+	if logprobs != nil {
+		choice["logprobs"] = logprobs
 	}
 	if len(bytes.TrimSpace(stopReason)) > 0 && !bytes.Equal(bytes.TrimSpace(stopReason), []byte("null")) {
 		choice["stop_reason"] = json.RawMessage(bytes.TrimSpace(stopReason))
@@ -190,13 +222,85 @@ func writeStreamingChunkEvent(out *bytes.Buffer, resp streamingRewritePayload, i
 	fmt.Fprintf(out, "data: %s\n\n", b)
 }
 
-var clientStrippedFields = []string{
-	"logprob",
-	"logprobs",
-	"top_logprobs",
+// reconstructChunkLogprobs rebuilds the OpenAI streaming logprobs object for a
+// single synthesized content chunk, but only when the client asked for logprobs.
+// When the client wanted logprobs but not top_logprobs, the top alternatives are
+// emitted as an empty array (OpenAI's shape for logprobs-without-top_logprobs).
+// Returns nil when the client did not request logprobs, so the chunk omits the
+// field entirely.
+func reconstructChunkLogprobs(token rewriteLogprob, intent logprobClientIntent) any {
+	if !intent.keepLogprobs {
+		return nil
+	}
+	entry := map[string]any{
+		"token":   token.Token,
+		"logprob": token.Logprob,
+		"bytes":   token.Bytes,
+	}
+	if intent.keepTopLogprobs {
+		entry["top_logprobs"] = token.TopLogprobs
+	} else {
+		entry["top_logprobs"] = []any{}
+	}
+	return map[string]any{"content": []any{entry}}
+}
+
+// internalStrippedFields are always removed from client-facing responses: they
+// are devshard/vLLM internals the client never asked for and must never see.
+var internalStrippedFields = []string{
 	"token_ids",
 	"prompt_token_ids",
 	"prompt_logprobs",
+}
+
+// strippedFields returns the response fields to remove for this client. The
+// internal fields above are always stripped; the logprob/logprobs payloads are
+// stripped only when the client did not request logprobs -- the gateway force-
+// enables logprobs upstream for validation regardless of what the client asked.
+// top_logprobs is handled separately (emptied, not removed) by emptyTopLogprobs
+// so the response keeps OpenAI's logprobs-without-top_logprobs shape.
+func (intent logprobClientIntent) strippedFields() []string {
+	fields := append([]string(nil), internalStrippedFields...)
+	if !intent.keepLogprobs {
+		fields = append(fields, "logprob", "logprobs")
+	}
+	return fields
+}
+
+// emptyTopLogprobs replaces every top_logprobs array in the response with an
+// empty array. The gateway forces top_logprobs upstream for validation, so a
+// client who asked for logprobs but not top_logprobs would otherwise receive the
+// forced alternatives. OpenAI returns top_logprobs as a present-but-empty array
+// in this case, which this mirrors (matching the streaming-rewrite path's
+// reconstructChunkLogprobs). top_logprobs only appears under logprobs.content[]
+// in a chat completion, so emptying every occurrence is safe.
+func emptyTopLogprobs(v any) bool {
+	switch typed := v.(type) {
+	case map[string]any:
+		changed := false
+		if existing, ok := typed["top_logprobs"]; ok {
+			if arr, isArr := existing.([]any); !isArr || len(arr) > 0 {
+				typed["top_logprobs"] = []any{}
+				changed = true
+			}
+		}
+		for _, child := range typed {
+			if emptyTopLogprobs(child) {
+				changed = true
+			}
+		}
+		return changed
+	case []any:
+		changed := false
+		for _, child := range typed {
+			if emptyTopLogprobs(child) {
+				changed = true
+			}
+		}
+		return changed
+	default:
+		return false
+	}
 }
 
 func containsAnyInternalField(p []byte) bool {
@@ -206,12 +310,18 @@ func containsAnyInternalField(p []byte) bool {
 		bytes.Contains(p, []byte(`"prompt_token_ids"`))
 }
 
-func filterClientInternalFields(payload []byte) []byte {
+func filterClientInternalFields(payload []byte, intent logprobClientIntent) []byte {
 	var v any
 	if err := json.Unmarshal(payload, &v); err != nil {
 		return payload
 	}
-	if !stripClientInternalFields(v) {
+	changed := stripClientInternalFields(v, intent.strippedFields())
+	if intent.keepLogprobs && !intent.keepTopLogprobs {
+		if emptyTopLogprobs(v) {
+			changed = true
+		}
+	}
+	if !changed {
 		return payload
 	}
 	out, err := json.Marshal(v)
@@ -221,18 +331,18 @@ func filterClientInternalFields(payload []byte) []byte {
 	return out
 }
 
-func stripClientInternalFields(v any) bool {
+func stripClientInternalFields(v any, fields []string) bool {
 	switch typed := v.(type) {
 	case map[string]any:
 		changed := false
-		for _, key := range clientStrippedFields {
+		for _, key := range fields {
 			if _, ok := typed[key]; ok {
 				delete(typed, key)
 				changed = true
 			}
 		}
 		for _, child := range typed {
-			if stripClientInternalFields(child) {
+			if stripClientInternalFields(child, fields) {
 				changed = true
 			}
 		}
@@ -240,7 +350,7 @@ func stripClientInternalFields(v any) bool {
 	case []any:
 		changed := false
 		for _, child := range typed {
-			if stripClientInternalFields(child) {
+			if stripClientInternalFields(child, fields) {
 				changed = true
 			}
 		}

--- a/devshard/cmd/devshardctl/stream_rewrite_logprobs_test.go
+++ b/devshard/cmd/devshardctl/stream_rewrite_logprobs_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// parseSSEChunks extracts the JSON data events (excluding [DONE]) from an SSE
+// byte stream so tests can assert on the synthesized chunk objects.
+func parseSSEChunks(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	var events []map[string]any
+	for _, line := range strings.Split(raw, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			continue
+		}
+		var evt map[string]any
+		require.NoError(t, json.Unmarshal([]byte(data), &evt))
+		events = append(events, evt)
+	}
+	return events
+}
+
+// Route A (filterClientInternalFields): when the client asked for logprobs, the
+// logprobs/top_logprobs payloads survive, but the always-internal fields
+// (token_ids, prompt_token_ids, prompt_logprobs) are still stripped.
+func TestFilterClientInternalFields_KeepsLogprobsWhenRequested(t *testing.T) {
+	payload := []byte(`{"prompt_token_ids":[1,2],"choices":[{"message":{"content":"Hi"},"token_ids":[3,4],"logprobs":{"content":[{"token":"Hi","logprob":-0.1,"top_logprobs":[{"token":"Hi","logprob":-0.1}]}]}}]}`)
+
+	filtered := filterClientInternalFields(payload, logprobClientIntent{keepLogprobs: true, keepTopLogprobs: true})
+
+	require.JSONEq(t, `{"choices":[{"message":{"content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.1,"top_logprobs":[{"token":"Hi","logprob":-0.1}]}]}}]}`, string(filtered))
+}
+
+// Route A: logprobs requested but top_logprobs not -- keep logprobs/per-token
+// logprob, but empty the top_logprobs alternatives (the gateway forces those
+// upstream for validation; the client never asked for them). OpenAI's shape is a
+// present-but-empty array, matching the streaming-rewrite path.
+func TestFilterClientInternalFields_EmptiesTopLogprobsWhenNotRequested(t *testing.T) {
+	payload := []byte(`{"choices":[{"message":{"content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.1,"top_logprobs":[{"token":"Hi","logprob":-0.1}]}]}}]}`)
+
+	filtered := filterClientInternalFields(payload, logprobClientIntent{keepLogprobs: true, keepTopLogprobs: false})
+
+	require.JSONEq(t, `{"choices":[{"message":{"content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.1,"top_logprobs":[]}]}}]}`, string(filtered))
+}
+
+// Route A: zero intent (no client request) strips logprobs and top_logprobs --
+// the historical default behavior.
+func TestFilterClientInternalFields_StripsLogprobsByDefault(t *testing.T) {
+	payload := []byte(`{"choices":[{"message":{"content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.1,"top_logprobs":[{"token":"Hi","logprob":-0.1}]}]}}]}`)
+
+	filtered := filterClientInternalFields(payload, logprobClientIntent{})
+
+	require.JSONEq(t, `{"choices":[{"message":{"content":"Hi"}}]}`, string(filtered))
+}
+
+// Route B (SSE-wrapped chat.completion rewrite): when the client asked for
+// logprobs, the synthesized content chunk carries a reconstructed logprobs
+// object with the token, logprob and top_logprobs.
+func TestRewriteStreamingPayload_ReconstructsLogprobsInSynthesizedChunks(t *testing.T) {
+	payload := []byte(`data: {"id":"cmpl-1","object":"chat.completion","created":123,"model":"Qwen","choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.5,"bytes":[72,105],"top_logprobs":[{"token":"Hi","logprob":-0.5},{"token":"Hey","logprob":-1.5}]}]},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1}}` + "\n\n")
+
+	rewritten := rewriteStreamingPayload(payload, logprobClientIntent{keepLogprobs: true, keepTopLogprobs: true})
+	events := parseSSEChunks(t, string(rewritten))
+
+	// role chunk, content chunk, usage chunk.
+	require.Len(t, events, 3)
+	contentChoice := events[1]["choices"].([]any)[0].(map[string]any)
+	require.Equal(t, "Hi", contentChoice["delta"].(map[string]any)["content"])
+	lp := contentChoice["logprobs"].(map[string]any)
+	content := lp["content"].([]any)
+	require.Len(t, content, 1)
+	entry := content[0].(map[string]any)
+	require.Equal(t, "Hi", entry["token"])
+	require.Equal(t, -0.5, entry["logprob"])
+	require.Len(t, entry["top_logprobs"].([]any), 2)
+}
+
+// Route B: logprobs requested but not top_logprobs -- the reconstructed chunk
+// carries the per-token logprob with an empty top_logprobs array.
+func TestRewriteStreamingPayload_ReconstructsLogprobsWithoutTopWhenNotRequested(t *testing.T) {
+	payload := []byte(`data: {"id":"cmpl-1","object":"chat.completion","created":123,"model":"Qwen","choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.5,"bytes":[72,105],"top_logprobs":[{"token":"Hi","logprob":-0.5},{"token":"Hey","logprob":-1.5}]}]},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1}}` + "\n\n")
+
+	rewritten := rewriteStreamingPayload(payload, logprobClientIntent{keepLogprobs: true, keepTopLogprobs: false})
+	events := parseSSEChunks(t, string(rewritten))
+
+	entry := events[1]["choices"].([]any)[0].(map[string]any)["logprobs"].(map[string]any)["content"].([]any)[0].(map[string]any)
+	require.Equal(t, "Hi", entry["token"])
+	require.Empty(t, entry["top_logprobs"].([]any))
+}
+
+// Route A (existing chat.completion.chunk events, not synthesized): the !ok
+// branch of rewriteStreamingPayload routes through filterClientInternalFields
+// with the same intent, so a client who asked for logprobs keeps them on
+// already-chunked SSE events too.
+func TestRewriteStreamingPayload_KeepsLogprobsInExistingChunksWhenRequested(t *testing.T) {
+	payload := []byte(`data: {"id":"cmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.1,"top_logprobs":[{"token":"Hi","logprob":-0.1}]}]},"finish_reason":null}]}` + "\n\n")
+
+	rewritten := rewriteStreamingPayload(payload, logprobClientIntent{keepLogprobs: true, keepTopLogprobs: true})
+	events := parseSSEChunks(t, string(rewritten))
+
+	require.Len(t, events, 1)
+	choice := events[0]["choices"].([]any)[0].(map[string]any)
+	entry := choice["logprobs"].(map[string]any)["content"].([]any)[0].(map[string]any)
+	require.Equal(t, "Hi", entry["token"])
+	require.Len(t, entry["top_logprobs"].([]any), 1)
+}
+
+// Even when the client asked for logprobs, the always-internal fields stay
+// stripped on the synthesized-chunk path. (Structurally guaranteed because
+// chunks are rebuilt from typed structs, but asserted to lock the invariant.)
+func TestRewriteStreamingPayload_StripsInternalFieldsEvenWhenLogprobsRequested(t *testing.T) {
+	payload := []byte(`data: {"id":"cmpl-1","object":"chat.completion","created":123,"model":"Qwen","prompt_token_ids":[1,2],"prompt_logprobs":[{"x":1}],"choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"token_ids":[3,4],"logprobs":{"content":[{"token":"Hi","logprob":-0.5,"bytes":[72,105],"top_logprobs":[{"token":"Hi","logprob":-0.5}]}]},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1}}` + "\n\n")
+
+	rewritten := rewriteStreamingPayload(payload, logprobClientIntent{keepLogprobs: true, keepTopLogprobs: true})
+
+	require.NotContains(t, string(rewritten), "token_ids")
+	require.NotContains(t, string(rewritten), "prompt_logprobs")
+	require.Contains(t, string(rewritten), `"logprob":-0.5`)
+}
+
+// Route B: with no client logprobs request, the synthesized chunks carry no
+// logprobs field at all (historical behavior preserved).
+func TestRewriteStreamingPayload_OmitsLogprobsInSynthesizedChunksByDefault(t *testing.T) {
+	payload := []byte(`data: {"id":"cmpl-1","object":"chat.completion","created":123,"model":"Qwen","choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.5,"top_logprobs":[{"token":"Hi","logprob":-0.5}]}]},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1}}` + "\n\n")
+
+	rewritten := rewriteStreamingPayload(payload, logprobClientIntent{})
+
+	require.NotContains(t, string(rewritten), "logprob")
+}
+
+// The request filter forces logprobs/top_logprobs upstream for validation, but
+// the captured chatRequest must still reflect the client's ORIGINAL intent so
+// the response strip can honor it.
+func TestNormalizeChatRequest_CapturesOriginalLogprobIntent(t *testing.T) {
+	cases := []struct {
+		name            string
+		body            string
+		wantLogprobs    bool
+		wantTopLogprobs uint64
+	}{
+		{
+			name:            "client asked logprobs and top_logprobs",
+			body:            `{"model":"m","messages":[{"role":"user","content":"hi"}],"logprobs":true,"top_logprobs":3}`,
+			wantLogprobs:    true,
+			wantTopLogprobs: 3,
+		},
+		{
+			name:            "client asked logprobs only",
+			body:            `{"model":"m","messages":[{"role":"user","content":"hi"}],"logprobs":true}`,
+			wantLogprobs:    true,
+			wantTopLogprobs: 0,
+		},
+		{
+			name:            "client asked logprobs with explicit top_logprobs 0",
+			body:            `{"model":"m","messages":[{"role":"user","content":"hi"}],"logprobs":true,"top_logprobs":0}`,
+			wantLogprobs:    true,
+			wantTopLogprobs: 0,
+		},
+		{
+			name:            "client asked neither",
+			body:            `{"model":"m","messages":[{"role":"user","content":"hi"}]}`,
+			wantLogprobs:    false,
+			wantTopLogprobs: 0,
+		},
+		{
+			name:            "client explicitly disabled logprobs",
+			body:            `{"model":"m","messages":[{"role":"user","content":"hi"}],"logprobs":false}`,
+			wantLogprobs:    false,
+			wantTopLogprobs: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			updated, req, err := normalizeChatRequest([]byte(tc.body))
+			require.NoError(t, err)
+
+			// The upstream body is still force-enabled for validation...
+			require.Contains(t, string(updated), `"logprobs":true`)
+			// ...but the captured request preserves the client's original intent.
+			require.Equal(t, tc.wantLogprobs, req.Logprobs)
+			require.Equal(t, tc.wantTopLogprobs, req.TopLogprobs)
+
+			intent := logprobClientIntentFromRequest(req)
+			require.Equal(t, tc.wantLogprobs, intent.keepLogprobs)
+			require.Equal(t, tc.wantLogprobs && tc.wantTopLogprobs > 0, intent.keepTopLogprobs)
+		})
+	}
+}


### PR DESCRIPTION
Reopened https://github.com/gonka-ai/gonka/pull/1308 originally created by @redstartechno closed by target branch removal

------
## What problem does this solve?

The devshard gateway returns an OpenAI-compatible API, but it never returns `logprobs`/`top_logprobs` to clients — even when a client explicitly asks for them. Fixes #1264.

## How do you know this is a real problem?

The gateway force-enables logprobs on every upstream request for inference validation (`request_filters_parameters.go`: `newParameter("logprobs").withRule(RequestFilterStagePostLimits, ForceLiteralParameterHandler{Value: true})` and the matching `top_logprobs` rule). It then unconditionally strips `logprob`, `logprobs` and `top_logprobs` from the client-facing response on both response paths:

- non-streaming / chunked streaming: `filterClientInternalFields` → `stripClientInternalFields` deletes those keys recursively;
- the SSE `chat.completion` → `chat.completion.chunk` rewrite (`rewriteStreamingDataEvent`) drops the logprobs entirely when synthesizing chunks.

So a client sending `{"logprobs": true}` or `{"top_logprobs": 5}` receives a response with the field removed — a deviation from OpenAI behavior, where those fields should be returned when requested. (`token_ids`, `prompt_token_ids` and `prompt_logprobs` are genuine internals and must stay stripped.)

## How does this solve the problem?

Conditional stripping driven by the client's **original** request intent:

1. Capture the client's original `logprobs`/`top_logprobs` into `chatRequest` in `readChatRequestFields`, **before** the gateway force-overwrites them. The pre-force values are preserved through `SyncRequestView` (the same pattern already used for `max_tokens`), so the forced upstream values don't clobber the captured intent.
2. Plumb the intent (`logprobClientIntent`) to the two response-strip call sites via request context, mirroring the existing `requestLogFromContext` pattern.
3. Strip `logprob`/`logprobs` only when the client did **not** request logprobs; the internal fields (`token_ids`, `prompt_token_ids`, `prompt_logprobs`) are still stripped unconditionally.
4. Both response paths are covered: the recursive field strip, and the streaming rewrite which now reconstructs the per-chunk `logprobs` object (`reconstructChunkLogprobs`). When logprobs are requested without `top_logprobs`, `top_logprobs` is emitted as a present-but-empty array (OpenAI's shape) on both paths.

The zero value of `logprobClientIntent` is "strip everything" — i.e. the exact prior behavior — so clients that don't ask for logprobs see no change.

## What risks does this introduce? How can we mitigate them?

- **Leaking logprobs to clients who didn't ask.** Mitigated by the safe-default design: intent is captured only from an explicit boolean `logprobs: true` (non-bool shapes are ignored, never rejected), `keep_top_logprobs` is gated on `keep_logprobs`, and the context zero value strips everything. Unit tests assert the default path still strips.
- **Leaking true internal fields.** `token_ids`/`prompt_token_ids`/`prompt_logprobs` are always in the strip set regardless of intent; covered by an existing test.
- **Validation impact.** None — the strip happens at the client-facing proxy boundary; devshard internals consume the pre-boundary host response (see the comment on `rewriteStreamingPayload`). The forced upstream logprobs used for validation are unchanged.
- **Note (not a regression):** the gateway clamps `top_logprobs` to a fixed value upstream for validation determinism, so a client requesting more alternatives than the clamp receives the clamped count. This matches the prior forcing behavior and is independent of this change.

## How do you know this PR fixes the problem?

New unit tests (`stream_rewrite_logprobs_test.go`) assert, for both response paths:

- client requested logprobs (+top_logprobs) → logprobs and top_logprobs returned;
- client requested logprobs without top_logprobs → logprobs returned, top_logprobs emptied;
- no request → logprobs/top_logprobs stripped (prior behavior);
- internals (`token_ids`/`prompt_*`) always stripped;
- the request pipeline captures the original intent even though the upstream body is still force-enabled (`logprobs:true`).

## Which components are affected?

`decentralized-api`'s devshard gateway only (`devshard/cmd/devshardctl/`):
- `stream_rewrite.go` — conditional strip + streaming logprobs reconstruction + intent type/context helpers
- `proxy.go` — capture intent, plumb to both strip sites
- `request_filters.go`, `request_filters_parameters.go` — capture original logprobs intent
- `stream_rewrite_logprobs_test.go` (new), `proxy_test.go` — tests

No chain, consensus, proto, or genesis changes.

## Testing & evidence

`devshard` is a standalone Go module with no cgo dependencies, so the package builds and tests locally:

```
cd devshard
GOTOOLCHAIN=go1.24.2 go build ./cmd/devshardctl/
GOTOOLCHAIN=go1.24.2 go vet ./cmd/devshardctl/
GOTOOLCHAIN=go1.24.2 go test ./cmd/devshardctl/ -run 'TestFilterClientInternalFields|TestRewriteStreamingPayload|TestNormalizeChatRequest_CapturesOriginalLogprobIntent|TestDeferredWriter' -count=1
```

All new and existing related tests pass; `go build` and `go vet` are clean.

### Before
Client request: `{"messages":[...],"logprobs":true,"top_logprobs":3}`
Client response (logprobs requested but stripped):
```
{"choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}
```

### After
Same request, logprobs returned (internals still stripped):
```
{"choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"logprobs":{"content":[{"token":"Hi","logprob":-0.5,"bytes":[72,105],"top_logprobs":[{"token":"Hi","logprob":-0.5},{"token":"Hey","logprob":-1.5}]}]},"finish_reason":"stop"}]}
```
