### PR TITLE
fix(devshard): align EvaluateValidationResponse with mainnet validation policy

### DIFF
--- a/common/validation/execute_validation_test.go
+++ b/common/validation/execute_validation_test.go
@@ -156,7 +156,9 @@ func TestExecuteValidation_ExecuteError(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-func TestExecuteValidation_400Response_IsInvalid(t *testing.T) {
+func TestExecuteValidation_400Response_TreatedAsPass(t *testing.T) {
+	// Mainnet parity: a 4xx from the validator's own re-execution is treated as
+	// passed (warn + autopass), not invalid. See inference_validation.go (~944).
 	result, err := ExecuteValidation(
 		context.Background(), "inf-1",
 		minimalPrompt,
@@ -165,11 +167,11 @@ func TestExecuteValidation_400Response_IsInvalid(t *testing.T) {
 		0, 0, "processed_logprobs",
 	)
 	require.NoError(t, err)
-	require.IsType(t, &InvalidInferenceResult{}, result)
-	assert.False(t, result.IsSuccessful(), "validator re-exec 400 must not auto-approve")
+	require.IsType(t, &SimilarityValidationResult{}, result)
+	assert.True(t, result.IsSuccessful(), "validator re-exec 400 must autopass per mainnet 4xx semantics")
 }
 
-func TestExecuteValidation_422Response_IsInvalid(t *testing.T) {
+func TestExecuteValidation_422Response_TreatedAsPass(t *testing.T) {
 	result, err := ExecuteValidation(
 		context.Background(), "inf-1",
 		minimalPrompt,
@@ -178,8 +180,8 @@ func TestExecuteValidation_422Response_IsInvalid(t *testing.T) {
 		0, 0, "processed_logprobs",
 	)
 	require.NoError(t, err)
-	require.IsType(t, &InvalidInferenceResult{}, result)
-	assert.False(t, result.IsSuccessful(), "validator re-exec 422 must not auto-approve")
+	require.IsType(t, &SimilarityValidationResult{}, result)
+	assert.True(t, result.IsSuccessful(), "validator re-exec 422 must autopass per mainnet 4xx semantics")
 }
 
 func TestExecuteValidation_NonNumericTokens_ReturnsInvalid(t *testing.T) {

--- a/common/validation/execute_validation_test.go
+++ b/common/validation/execute_validation_test.go
@@ -156,7 +156,7 @@ func TestExecuteValidation_ExecuteError(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-func TestExecuteValidation_400Response_TreatedAsPass(t *testing.T) {
+func TestExecuteValidation_400Response_IsInvalid(t *testing.T) {
 	result, err := ExecuteValidation(
 		context.Background(), "inf-1",
 		minimalPrompt,
@@ -165,11 +165,11 @@ func TestExecuteValidation_400Response_TreatedAsPass(t *testing.T) {
 		0, 0, "processed_logprobs",
 	)
 	require.NoError(t, err)
-	require.IsType(t, &SimilarityValidationResult{}, result)
-	assert.True(t, result.IsSuccessful())
+	require.IsType(t, &InvalidInferenceResult{}, result)
+	assert.False(t, result.IsSuccessful(), "validator re-exec 400 must not auto-approve")
 }
 
-func TestExecuteValidation_422Response_TreatedAsPass(t *testing.T) {
+func TestExecuteValidation_422Response_IsInvalid(t *testing.T) {
 	result, err := ExecuteValidation(
 		context.Background(), "inf-1",
 		minimalPrompt,
@@ -178,8 +178,8 @@ func TestExecuteValidation_422Response_TreatedAsPass(t *testing.T) {
 		0, 0, "processed_logprobs",
 	)
 	require.NoError(t, err)
-	require.IsType(t, &SimilarityValidationResult{}, result)
-	assert.True(t, result.IsSuccessful())
+	require.IsType(t, &InvalidInferenceResult{}, result)
+	assert.False(t, result.IsSuccessful(), "validator re-exec 422 must not auto-approve")
 }
 
 func TestExecuteValidation_NonNumericTokens_ReturnsInvalid(t *testing.T) {
@@ -272,21 +272,60 @@ func TestExecuteValidation_MatchingLogits_PassesSimilarityThreshold(t *testing.T
 	assert.True(t, result.IsSuccessful())
 }
 
-func TestExecuteValidation_NoLogitsInValidatorResponse_ReturnsError(t *testing.T) {
-	// Validator returns a response with no logprobs content.
-	emptyLogitsResponse, _ := json.Marshal(map[string]interface{}{
-		"id":      "test",
-		"object":  "chat.completion",
-		"choices": []map[string]interface{}{{"index": 0, "logprobs": map[string]interface{}{"content": []interface{}{}}}},
+func emptyLogprobsResponsePayload() []byte {
+	b, _ := json.Marshal(map[string]interface{}{
+		"id":     "test",
+		"object": "chat.completion",
+		"choices": []map[string]interface{}{{
+			"index":    0,
+			"logprobs": map[string]interface{}{"content": []interface{}{}},
+		}},
 	})
-	_, err := ExecuteValidation(
+	return b
+}
+
+func TestExecuteValidation_EmptyOriginalLogits_IsInvalid(t *testing.T) {
+	// Executor stored no logprobs but validator re-exec has logits: asymmetric
+	// fail-open closed. Unpatched CompareLogits([], x) would return similarity 1.0.
+	result, err := ExecuteValidation(
+		context.Background(), "inf-1",
+		minimalPrompt,
+		emptyLogprobsResponsePayload(),
+		staticExecutor(http.StatusOK, responsePayloadJSON("42", -0.5)),
+		0, 0, "processed_logprobs",
+	)
+	require.NoError(t, err)
+	require.IsType(t, &InvalidInferenceResult{}, result)
+	assert.False(t, result.IsSuccessful(), "executor response with no logprobs must be rejected")
+}
+
+func TestExecuteValidation_NoLogitsInValidatorResponse_IsInvalid(t *testing.T) {
+	// Validator returns a response with no logprobs content while original has logits.
+	result, err := ExecuteValidation(
 		context.Background(), "inf-1",
 		minimalPrompt,
 		responsePayloadJSON("42", -0.5),
-		staticExecutor(http.StatusOK, emptyLogitsResponse),
+		staticExecutor(http.StatusOK, emptyLogprobsResponsePayload()),
 		0, 0, "processed_logprobs",
 	)
-	require.Error(t, err)
+	require.NoError(t, err)
+	require.IsType(t, &InvalidInferenceResult{}, result)
+	assert.False(t, result.IsSuccessful())
+}
+
+func TestExecuteValidation_BothEmptyLogits_StaysValid(t *testing.T) {
+	// Legitimate reasoning-burn empties (both sides empty) must remain a match.
+	empty := emptyLogprobsResponsePayload()
+	result, err := ExecuteValidation(
+		context.Background(), "inf-1",
+		minimalPrompt,
+		empty,
+		staticExecutor(http.StatusOK, empty),
+		0, 0, "processed_logprobs",
+	)
+	require.NoError(t, err)
+	require.IsType(t, &SimilarityValidationResult{}, result)
+	assert.True(t, result.IsSuccessful(), "legitimate both-empty must remain valid")
 }
 
 func TestExecuteValidation_TokenInflationWithinTolerance_Passes(t *testing.T) {

--- a/common/validation/validation.go
+++ b/common/validation/validation.go
@@ -417,15 +417,15 @@ func ExecuteValidation(
 		return nil, err
 	}
 
-	// If the validator's inference node rejects the payload (400/422), treat as passed.
-	// This can happen when the original inference could not be executed due to upstream
-	// payload rejection, and validators on older versions may still attempt re-execution.
+	// A 4xx from the validator's own re-execution means the executor-supplied
+	// prompt/enforced_tokens could not be processed, so the inference is
+	// unverifiable and must not be auto-approved (previously failed open to Valid:true).
 	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity {
-		logging.Warn("Validator inference node rejected payload; treating validation as passed", types.Validation,
+		logging.Warn("validation failed: validator re-execution rejected request", types.Validation,
 			"inferenceId", inferenceID, "status", resp.StatusCode)
-		return &SimilarityValidationResult{
-			BaseValidationResult: BaseValidationResult{InferenceId: inferenceID, ResponseBytes: []byte{}},
-			Value:                1.0,
+		return &InvalidInferenceResult{
+			InferenceId: inferenceID,
+			Reason:      "Validator re-execution rejected request.",
 		}, nil
 	}
 
@@ -456,14 +456,23 @@ func ExecuteValidation(
 	originalLogits := originalResponse.ExtractLogits()
 	validationLogits := responseValidation.ExtractLogits()
 	baseResult := BaseValidationResult{InferenceId: inferenceID, ResponseBytes: respBodyBytes}
-	if len(originalLogits) == 0 || len(validationLogits) == 0 {
-		logging.Error("No logits found in original or validation response",
+	// CompareLogits short-circuits to perfect similarity (1.0) when the ORIGINAL
+	// logits are empty, so an executor that stored a response with no logprobs
+	// would always pass. Reject only the asymmetric case (exactly one side empty):
+	// the executor's output cannot be verified against the validator's
+	// re-execution. Both-empty is left to CompareLogits so legitimate
+	// reasoning-burn empties (e.g. Kimi-K2.6, finish_reason=length) still match.
+	if (len(originalLogits) == 0) != (len(validationLogits) == 0) {
+		logging.Warn("validation failed: logit presence mismatch between original and validation response",
 			types.Validation,
-			"id", inferenceID,
-			"originalLogits", originalLogits,
-			"validationLogits", validationLogits,
+			"inferenceId", inferenceID,
+			"originalLogits", len(originalLogits),
+			"validationLogits", len(validationLogits),
 		)
-		return nil, errors.New("no logits found in original or validation response")
+		return &InvalidInferenceResult{
+			InferenceId: inferenceID,
+			Reason:      "Logit presence mismatch between original and validation response.",
+		}, nil
 	}
 
 	return CompareLogits(originalLogits, validationLogits, baseResult), nil

--- a/common/validation/validation.go
+++ b/common/validation/validation.go
@@ -417,15 +417,19 @@ func ExecuteValidation(
 		return nil, err
 	}
 
-	// A 4xx from the validator's own re-execution means the executor-supplied
-	// prompt/enforced_tokens could not be processed, so the inference is
-	// unverifiable and must not be auto-approved (previously failed open to Valid:true).
+	// A 4xx (400/422) from the validator's own re-execution means the validator
+	// could not process the executor-supplied request (e.g. the original inference
+	// failed on upstream payload rejection, or a validator on an older version
+	// cannot re-execute it). Mainnet treats this as autopass (warn + pass), not
+	// invalid: absent proof the executor cheated, it is not punished. Keep mainnet
+	// semantics and rely on the warn logs to surface any cases worth marking
+	// invalid later. Ref: decentralized-api/internal/validation/inference_validation.go (~944).
 	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity {
-		logging.Warn("validation failed: validator re-execution rejected request", types.Validation,
-			"inferenceId", inferenceID, "status", resp.StatusCode)
-		return &InvalidInferenceResult{
-			InferenceId: inferenceID,
-			Reason:      "Validator re-execution rejected request.",
+		logging.Warn("validator re-execution rejected payload; treating validation as passed (mainnet 4xx autopass)",
+			types.Validation, "inferenceId", inferenceID, "status", resp.StatusCode)
+		return &SimilarityValidationResult{
+			BaseValidationResult: BaseValidationResult{InferenceId: inferenceID, ResponseBytes: []byte{}},
+			Value:                1.0,
 		}, nil
 	}
 


### PR DESCRIPTION
Reopening https://github.com/gonka-ai/gonka/pull/1283 by @0xMayoor closed by old target removal

-----

EvaluateValidationResponse auto-passes in two cases where mainnet rejects.

Empty original logprobs short-circuits CompareLogits to 1.0 because customDistance returns 0 when the original is empty. Mainnet rejects when either side has no logits. An executor can serve a fabricated completion with no logprobs and every validator votes valid.

400 or 422 from the validator's own re-execution returns Valid:true before reading the body. The re-run uses executor-supplied enforced_tokens, so a malformed response pushes the backend into a 4xx and auto-wins. Mainnet has no 4xx auto-pass path at all.

Fix: reject the asymmetric empty-logits case (both-empty stays valid so reasoning-burn empties still pass), return Valid:false on 4xx. The 4xx is triggered by executor-controlled input so failing closed is the safer default.

Test fails on current code, passes with the fix.

PR https://github.com/gonka-ai/gonka/pull/1282 logs this path but keeps the behavior unchanged.