### PR TITLE
devshard(fix): Decouple Postgres connect from session-index rebuild

### DIFF
--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -111,7 +111,7 @@ func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error
 	e := buildServer(lifecycle)
 	var admin *echo.Echo
 	if cfg.AdminAddr != "" {
-		admin = buildAdminServer(lifecycle)
+		admin = buildAdminServer(lifecycle, manager.StorageReady)
 	}
 	manager.Register(e.Group(""))
 	chainRuntime.chainEvents.OnReady(lifecycle.SetReady)

--- a/devshard/cmd/devshardd/lifecycle_test.go
+++ b/devshard/cmd/devshardd/lifecycle_test.go
@@ -14,7 +14,7 @@ import (
 func TestLifecycleReadyAndDrainStatus(t *testing.T) {
 	lifecycle := newLifecycleState()
 	e := buildServer(lifecycle)
-	admin := buildAdminServer(lifecycle)
+	admin := buildAdminServer(lifecycle, func() bool { return true })
 	e.GET("/work", func(c echo.Context) error {
 		time.Sleep(20 * time.Millisecond)
 		return c.String(http.StatusOK, "done")
@@ -62,7 +62,7 @@ func TestLifecycleDrainRejectsNewWork(t *testing.T) {
 	lifecycle := newLifecycleState()
 	lifecycle.SetReady(true)
 	e := buildServer(lifecycle)
-	admin := buildAdminServer(lifecycle)
+	admin := buildAdminServer(lifecycle, func() bool { return true })
 	e.GET("/work", func(c echo.Context) error {
 		return c.String(http.StatusOK, "done")
 	})
@@ -89,4 +89,22 @@ func TestLifecycleDrainRejectsNewWork(t *testing.T) {
 	var status drainStatus
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &status))
 	require.Zero(t, status.Inflight)
+}
+
+func TestReadyReflectsStorageReadiness(t *testing.T) {
+	lifecycle := newLifecycleState()
+	lifecycle.SetReady(true)
+	storageReady := false
+	admin := buildAdminServer(lifecycle, func() bool { return storageReady })
+
+	rec := httptest.NewRecorder()
+	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"chain-ready but storage rebuilding must report 503")
+
+	storageReady = true
+	rec = httptest.NewRecorder()
+	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "\"storage_ready\":true")
 }

--- a/devshard/cmd/devshardd/server.go
+++ b/devshard/cmd/devshardd/server.go
@@ -26,7 +26,7 @@ func buildServer(lifecycle *lifecycleState) *echo.Echo {
 	return e
 }
 
-func buildAdminServer(lifecycle *lifecycleState) *echo.Echo {
+func buildAdminServer(lifecycle *lifecycleState, storageReady func() bool) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
@@ -34,10 +34,11 @@ func buildAdminServer(lifecycle *lifecycleState) *echo.Echo {
 
 	e.GET("/ready", func(c echo.Context) error {
 		status := lifecycle.Status()
-		if !status.Ready || status.Draining {
-			return c.JSON(http.StatusServiceUnavailable, status)
+		storeReady := storageReady == nil || storageReady()
+		if !status.Ready || status.Draining || !storeReady {
+			return c.JSON(http.StatusServiceUnavailable, readyResponse(status, storeReady))
 		}
-		return c.JSON(http.StatusOK, status)
+		return c.JSON(http.StatusOK, readyResponse(status, storeReady))
 	})
 	e.POST("/drain", func(c echo.Context) error {
 		lifecycle.StartDrain()
@@ -48,4 +49,14 @@ func buildAdminServer(lifecycle *lifecycleState) *echo.Echo {
 	})
 
 	return e
+}
+
+// readyStatus augments drainStatus with storage readiness for the /ready probe.
+type readyStatus struct {
+	drainStatus
+	StorageReady bool `json:"storage_ready"`
+}
+
+func readyResponse(status drainStatus, storeReady bool) readyStatus {
+	return readyStatus{drainStatus: status, StorageReady: storeReady}
 }

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -111,6 +111,15 @@ func (m *HostManager) SetAvailabilityProvider(p devshardpkg.AvailabilityProvider
 	m.availability = p
 }
 
+// StorageReady reports whether the backing storage is ready to serve. When the
+// store does not expose readiness (e.g. pure SQLite), it is considered ready.
+func (m *HostManager) StorageReady() bool {
+	if r, ok := m.store.(interface{ Ready() bool }); ok {
+		return r.Ready()
+	}
+	return true
+}
+
 // SetMaxNonceProvider enforces chain max_nonce on every host.
 func (m *HostManager) SetMaxNonceProvider(p devshardpkg.MaxNonceProvider) {
 	m.maxNonce = p

--- a/devshard/server/routes.go
+++ b/devshard/server/routes.go
@@ -133,7 +133,7 @@ func recordSessionResolution(c echo.Context, err error, recordChatTerminal bool)
 }
 
 func sessionResolutionStatus(err error) (observability.MetricStatus, observability.Reason) {
-	if errors.Is(err, ErrInitializing) {
+	if errors.Is(err, ErrInitializing) || errors.Is(err, storage.ErrStorageIndexRebuilding) {
 		return observability.MetricStatusError, observability.ReasonInitializing
 	}
 	if errors.Is(err, storage.ErrSessionNotFound) {
@@ -194,7 +194,7 @@ func sessionHTTPError(c echo.Context, err error) error {
 	if errors.As(err, &he) {
 		return he
 	}
-	if errors.Is(err, ErrInitializing) {
+	if errors.Is(err, ErrInitializing) || errors.Is(err, storage.ErrStorageIndexRebuilding) {
 		return transport.HTTPError(c, http.StatusServiceUnavailable, transport.DevshardErrorInitializing, err.Error())
 	}
 	if errors.Is(err, storage.ErrSessionNotFound) {

--- a/devshard/server/routes_test.go
+++ b/devshard/server/routes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"devshard/bridge"
+	"devshard/observability"
 	"devshard/storage"
 	"devshard/transport"
 )
@@ -46,6 +47,23 @@ func TestSessionHTTPErrorInitializing(t *testing.T) {
 	e.HTTPErrorHandler(err, c)
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 	require.Equal(t, transport.DevshardErrorInitializing, rec.Header().Get(transport.HeaderDevshardError))
+}
+
+func TestSessionHTTPErrorIndexRebuilding(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/sessions/x/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := sessionHTTPError(c, fmt.Errorf("init storage session: %w", storage.ErrStorageIndexRebuilding))
+	require.Error(t, err)
+	e.HTTPErrorHandler(err, c)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, transport.DevshardErrorInitializing, rec.Header().Get(transport.HeaderDevshardError))
+
+	status, reason := sessionResolutionStatus(fmt.Errorf("wrap: %w", storage.ErrStorageIndexRebuilding))
+	require.Equal(t, observability.ReasonInitializing, reason)
+	_ = status
 }
 
 func TestSessionHTTPErrorNotFound(t *testing.T) {

--- a/devshard/storage/factory.go
+++ b/devshard/storage/factory.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	defaultPGConnectTimeout    = 2 * time.Second
+	defaultPGIndexTimeout      = 30 * time.Second
 	defaultPGReconnectInterval = 5 * time.Second
 )
 
@@ -73,7 +74,7 @@ func newHAStorage(ctx context.Context, storeDir string) (Storage, error) {
 		return nil, ErrHAPostgresRequired
 	}
 
-	pg, err := openPostgresWithTimeout(ctx)
+	pg, err := openPostgresReady(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrStoragePostgresUnavailable, err)
 	}
@@ -155,7 +156,7 @@ func newStorageFlexible(ctx context.Context, storeDir string) (Storage, error) {
 		return nil, fmt.Errorf("open sqlite drain: %w", err)
 	}
 
-	pg, err := openPostgresWithTimeout(ctx)
+	pg, err := openPostgresReady(ctx)
 	if err != nil {
 		slog.Warn(
 			"devshard storage: postgres unavailable; entering degraded mode while reconnect runs",
@@ -215,12 +216,51 @@ func openPostgresWithTimeout(ctx context.Context) (Storage, error) {
 	return NewPostgres(connectCtx)
 }
 
+// openPostgresReady connects under PG_CONNECT_TIMEOUT then WaitReady under
+// PG_INDEX_TIMEOUT. Used at boot so migrate / routing never see an empty index.
+func openPostgresReady(ctx context.Context) (Storage, error) {
+	pg, err := openPostgresWithTimeout(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := waitPostgresIndexReady(ctx, pg); err != nil {
+		_ = pg.Close()
+		return nil, err
+	}
+	return pg, nil
+}
+
+type postgresIndexWaiter interface {
+	WaitReady(context.Context) error
+}
+
+func waitPostgresIndexReady(ctx context.Context, store Storage) error {
+	w, ok := store.(postgresIndexWaiter)
+	if !ok {
+		return nil
+	}
+	readyCtx, cancel := context.WithTimeout(ctx, pgIndexTimeout())
+	defer cancel()
+	if err := w.WaitReady(readyCtx); err != nil {
+		return err
+	}
+	return nil
+}
+
 func pgConnectTimeout() time.Duration {
 	connectTimeout, err := time.ParseDuration(os.Getenv("PG_CONNECT_TIMEOUT"))
 	if err != nil || connectTimeout <= 0 {
 		return defaultPGConnectTimeout
 	}
 	return connectTimeout
+}
+
+func pgIndexTimeout() time.Duration {
+	indexTimeout, err := time.ParseDuration(os.Getenv("PG_INDEX_TIMEOUT"))
+	if err != nil || indexTimeout <= 0 {
+		return defaultPGIndexTimeout
+	}
+	return indexTimeout
 }
 
 func pgReconnectInterval() time.Duration {

--- a/devshard/storage/hybrid.go
+++ b/devshard/storage/hybrid.go
@@ -83,6 +83,12 @@ type PostgresPromotionWatcher interface {
 	OnPostgresPromoted(func())
 }
 
+// readinessReporter is implemented by backends whose serving readiness may lag
+// their construction (Postgres rebuilds its session index asynchronously).
+type readinessReporter interface {
+	Ready() bool
+}
+
 // newHybridRouter wires the per-session router. Either backend may be nil, but
 // at least one must be non-nil. preferPG selects the backend for brand-new
 // escrows when both backends are present. storeDir enables .pg-bound marker
@@ -168,6 +174,20 @@ func (h *HybridStorage) postgresBackend() Storage {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.pg
+}
+
+// Ready reports whether the router can serve. A degraded / SQLite-only router
+// (no Postgres attached) is always ready for the escrows it owns. When Postgres
+// is attached, readiness tracks its async session-index rebuild.
+func (h *HybridStorage) Ready() bool {
+	pg := h.postgresBackend()
+	if pg == nil {
+		return true
+	}
+	if r, ok := pg.(readinessReporter); ok {
+		return r.Ready()
+	}
+	return true
 }
 
 func (h *HybridStorage) newSessionError() error {
@@ -329,6 +349,12 @@ func (h *HybridStorage) startPostgresReconnect(ctx context.Context, opener stora
 			pg, err := opener(ctx)
 			if err != nil {
 				slog.Warn("devshard storage: postgres reconnect failed; staying in degraded sqlite-owned-only mode",
+					"dir", h.storeDir, "error", err)
+				continue
+			}
+			if err := waitPostgresIndexReady(ctx, pg); err != nil {
+				_ = pg.Close()
+				slog.Warn("devshard storage: postgres reconnect index rebuild failed; staying in degraded sqlite-owned-only mode",
 					"dir", h.storeDir, "error", err)
 				continue
 			}

--- a/devshard/storage/hybrid_test.go
+++ b/devshard/storage/hybrid_test.go
@@ -320,6 +320,46 @@ func TestHybridStorage_ReconnectPromotesDegradedRouter(t *testing.T) {
 	require.Equal(t, "CreateSession", pg.lastMethod, "new sessions must use PG after promotion")
 }
 
+type readyGateStorage struct {
+	recordingStorage
+	readyCh chan struct{}
+	err     error
+}
+
+func (r *readyGateStorage) WaitReady(ctx context.Context) error {
+	select {
+	case <-r.readyCh:
+		return r.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestHybridStorage_ReconnectWaitsForIndexReadyBeforePromote(t *testing.T) {
+	sqlite := &owningRecordingStorage{owned: map[string]struct{}{"sqlite-owned": {}}}
+	h := newDegradedSQLiteRouter(sqlite, t.TempDir(), ErrStoragePostgresUnavailable)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pg := &readyGateStorage{readyCh: make(chan struct{})}
+	h.startPostgresReconnect(ctx, func(context.Context) (Storage, error) {
+		return pg, nil
+	}, 5*time.Millisecond)
+
+	time.Sleep(40 * time.Millisecond)
+	h.mu.RLock()
+	promotedEarly := h.pg == pg
+	h.mu.RUnlock()
+	require.False(t, promotedEarly, "must not promote before WaitReady")
+
+	close(pg.readyCh)
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		return h.pg == pg && !h.degradedOwnerOnly
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestHybridStorage_PromoteClosesIncomingBackendWhenAlreadyPromoted(t *testing.T) {
 	existing := &recordingStorage{}
 	incoming := &recordingStorage{}

--- a/devshard/storage/interface.go
+++ b/devshard/storage/interface.go
@@ -39,6 +39,12 @@ var ErrEpochPruned = errors.New("epoch already pruned")
 // ErrEscrowCacheNotFound is returned when no pre-init escrow cache row exists.
 var ErrEscrowCacheNotFound = errors.New("escrow cache not found")
 
+// ErrStorageIndexRebuilding is returned by escrow-keyed Postgres operations
+// while the session index rebuild has not finished within the per-operation
+// budget. It signals a transient, retryable state (not a hard storage failure),
+// so callers should surface it as "initializing" / 503 rather than a 500.
+var ErrStorageIndexRebuilding = errors.New("devshard postgres session index is rebuilding")
+
 // Storage persists devshard session state and diffs.
 //
 // The store is partitioned by EpochID. PruneEpoch drops everything that

--- a/devshard/storage/leases.go
+++ b/devshard/storage/leases.go
@@ -168,6 +168,9 @@ func (s *SQLite) OwnsPendingLease(_ context.Context, _ string, _ uint64, _ strin
 }
 
 func (s *Postgres) Acquire(ctx context.Context, escrowID string, inferenceID, epochID uint64, instanceAddr string) (bool, error) {
+	if err := s.WaitReady(ctx); err != nil {
+		return false, err
+	}
 	if err := s.ensurePartition(ctx, epochID); err != nil {
 		return false, err
 	}

--- a/devshard/storage/managed.go
+++ b/devshard/storage/managed.go
@@ -147,6 +147,15 @@ func (m *ManagedStorage) Close() error {
 	return m.inner.Close()
 }
 
+// Ready reports whether the wrapped storage can serve. Returns true when the
+// inner backend does not report readiness (e.g. SQLite-only).
+func (m *ManagedStorage) Ready() bool {
+	if r, ok := m.inner.(interface{ Ready() bool }); ok {
+		return r.Ready()
+	}
+	return true
+}
+
 // --- Storage delegation ---
 
 func (m *ManagedStorage) CreateSession(params CreateSessionParams) error {

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,12 +29,23 @@ import (
 // against both. A small unpartitioned escrowID -> epochID index enforces the
 // mainnet-pinned mapping, and the in-memory copy lets escrow-keyed methods
 // route to the right partition without scanning.
+//
+// Connect and index rebuild are separate: NewPostgres returns after pool +
+// migrate succeed, while indexExisting runs in the background. Callers must
+// WaitReady (or use a factory helper that does) before treating the handle as
+// serving; escrow-keyed methods also WaitReady so requests block until rebuild
+// finishes or fails.
 type Postgres struct {
 	pool *pgxpool.Pool
 
 	mu          sync.RWMutex
 	knownEpochs map[uint64]struct{}
 	escrowIdx   map[string]uint64
+
+	readyCh     chan struct{}
+	readyOnce   sync.Once
+	indexErr    error
+	indexCancel context.CancelFunc
 }
 
 const (
@@ -53,6 +65,9 @@ const (
 	// after a failed (often timed-out) create, so it must not extend the lock
 	// hold time by another full op timeout during an outage.
 	postgresLivePresenceTimeout = 2 * time.Second
+	// postgresIndexRepairBatchSize caps rows per DELETE/INSERT when repairing
+	// devshard_session_index so a large divergence does not hold one giant lock.
+	postgresIndexRepairBatchSize = 1000
 )
 
 const (
@@ -112,7 +127,8 @@ func pgValidationLeasesPartition(epochID uint64) string {
 
 // NewPostgres opens a Postgres-backed Storage using the standard libpq env
 // vars (PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD). Schema is created
-// idempotently and the escrow index is rebuilt by scanning devshard_sessions.
+// idempotently. The escrow index is rebuilt asynchronously; use WaitReady
+// (bounded by PG_INDEX_TIMEOUT) before promote/boot paths that need ownership.
 func NewPostgres(ctx context.Context) (*Postgres, error) {
 	cfg, err := pgxpool.ParseConfig("") // reads libpq env vars
 	if err != nil {
@@ -143,83 +159,271 @@ func NewPostgres(ctx context.Context) (*Postgres, error) {
 		pool:        pool,
 		knownEpochs: make(map[uint64]struct{}),
 		escrowIdx:   make(map[string]uint64),
+		readyCh:     make(chan struct{}),
 	}
-	if err := s.indexExisting(ctx); err != nil {
-		pool.Close()
-		return nil, fmt.Errorf("index existing sessions: %w", err)
-	}
+	s.startIndexRebuild()
 	return s, nil
 }
 
-func (s *Postgres) indexExisting(ctx context.Context) error {
-	sessionsOnDisk := make(map[string]uint64)
-	rows, err := s.pool.Query(ctx, `SELECT epoch_id, escrow_id FROM devshard_sessions`)
-	if err != nil {
-		return err
-	}
-	for rows.Next() {
-		var epochID uint64
-		var escrowID string
-		if err := rows.Scan(&epochID, &escrowID); err != nil {
-			rows.Close()
-			return err
-		}
-		if existingEpoch, ok := sessionsOnDisk[escrowID]; ok && existingEpoch != epochID {
-			rows.Close()
-			return fmt.Errorf("%w: escrow %s exists in epochs %d and %d",
-				ErrSessionEpochConflict, escrowID, existingEpoch, epochID)
-		}
-		sessionsOnDisk[escrowID] = epochID
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return err
-	}
+func (s *Postgres) startIndexRebuild() {
+	indexCtx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.indexCancel = cancel
+	s.mu.Unlock()
 
-	indexRows, err := s.pool.Query(ctx, `SELECT escrow_id, epoch_id FROM devshard_session_index`)
-	if err != nil {
-		return err
-	}
-	for indexRows.Next() {
-		var escrowID string
-		var epochID uint64
-		if err := indexRows.Scan(&escrowID, &epochID); err != nil {
-			indexRows.Close()
-			return err
-		}
-		if diskEpoch, ok := sessionsOnDisk[escrowID]; ok && diskEpoch == epochID {
-			continue
-		}
-		if _, err := s.pool.Exec(ctx,
-			`DELETE FROM devshard_session_index WHERE escrow_id = $1 AND epoch_id = $2`,
-			escrowID, epochID,
-		); err != nil {
-			indexRows.Close()
-			return fmt.Errorf("remove stale session index for %s: %w", escrowID, err)
-		}
-	}
-	indexRows.Close()
-	if err := indexRows.Err(); err != nil {
-		return err
-	}
+	go func() {
+		timeoutCtx, timeoutCancel := context.WithTimeout(indexCtx, pgIndexTimeout())
+		defer timeoutCancel()
 
-	for escrowID, epochID := range sessionsOnDisk {
-		if _, err := s.pool.Exec(ctx,
-			`INSERT INTO devshard_session_index (escrow_id, epoch_id)
-			 VALUES ($1, $2)
-			 ON CONFLICT (escrow_id) DO NOTHING`,
-			escrowID, epochID,
-		); err != nil {
-			return fmt.Errorf("repair session index for %s: %w", escrowID, err)
+		start := time.Now()
+		if indexExistingHook != nil {
+			indexExistingHook(timeoutCtx)
 		}
-		s.escrowIdx[escrowID] = epochID
-		s.knownEpochs[epochID] = struct{}{}
+		err := s.indexExisting(timeoutCtx)
+		if err != nil {
+			slog.Warn("devshard storage: postgres session index rebuild failed",
+				"error", err, "duration", time.Since(start))
+		} else {
+			s.mu.RLock()
+			n := len(s.escrowIdx)
+			s.mu.RUnlock()
+			slog.Info("devshard storage: postgres session index rebuild finished",
+				"duration", time.Since(start), "sessions", n)
+		}
+		s.markIndexDone(err)
+	}()
+}
+
+// indexExistingHook is set by tests to delay or observe index rebuild.
+var indexExistingHook func(context.Context)
+
+func (s *Postgres) markIndexDone(err error) {
+	s.mu.Lock()
+	s.indexErr = err
+	s.mu.Unlock()
+	s.readyOnce.Do(func() { close(s.readyCh) })
+}
+
+// WaitReady blocks until the session index rebuild finishes or ctx is done.
+// On rebuild failure it returns the index error (handle must not be promoted).
+func (s *Postgres) WaitReady(ctx context.Context) error {
+	select {
+	case <-s.readyCh:
+		return s.indexReadyErr()
+	case <-ctx.Done():
+		select {
+		case <-s.readyCh:
+			return s.indexReadyErr()
+		default:
+			return fmt.Errorf("wait for postgres session index: %w", ctx.Err())
+		}
+	}
+}
+
+func (s *Postgres) indexReadyErr() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.indexErr != nil {
+		return fmt.Errorf("index existing sessions: %w", s.indexErr)
 	}
 	return nil
 }
 
-// Close releases the pool. Subsequent calls return immediately.
+// Ready reports whether the session index rebuild has completed successfully.
+func (s *Postgres) Ready() bool {
+	select {
+	case <-s.readyCh:
+		return s.indexReadyErr() == nil
+	default:
+		return false
+	}
+}
+
+// waitReadyForOp gates an escrow-keyed operation on the session-index rebuild
+// using a bounded budget (postgresOpTimeout) instead of blocking indefinitely.
+// A still-in-progress rebuild returns ErrStorageIndexRebuilding (retryable /
+// 503); a failed rebuild returns the underlying index error.
+func (s *Postgres) waitReadyForOp() error {
+	select {
+	case <-s.readyCh:
+		return s.indexReadyErr()
+	default:
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), postgresOpTimeout)
+	defer cancel()
+	if err := s.WaitReady(ctx); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return ErrStorageIndexRebuilding
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Postgres) indexExisting(ctx context.Context) error {
+	sessionsOnDisk, err := s.loadSessionsForIndex(ctx)
+	if err != nil {
+		return err
+	}
+
+	staleEscrows, staleEpochs, indexedOK, err := s.diffSessionIndex(ctx, sessionsOnDisk)
+	if err != nil {
+		return err
+	}
+
+	if err := s.deleteStaleSessionIndex(ctx, staleEscrows, staleEpochs); err != nil {
+		return err
+	}
+
+	missingEscrows, missingEpochs := missingSessionIndexRows(sessionsOnDisk, indexedOK)
+	if err := s.insertMissingSessionIndex(ctx, missingEscrows, missingEpochs); err != nil {
+		return err
+	}
+
+	// Publish the rebuilt routing index atomically. Readers are gated on
+	// readyCh, but populate under the lock anyway so the maps are never mutated
+	// off-lock (keeps every escrowIdx/knownEpochs access uniformly synchronized).
+	knownEpochs := make(map[uint64]struct{})
+	escrowIdx := make(map[string]uint64, len(sessionsOnDisk))
+	for escrowID, epochID := range sessionsOnDisk {
+		escrowIdx[escrowID] = epochID
+		knownEpochs[epochID] = struct{}{}
+	}
+	s.mu.Lock()
+	s.escrowIdx = escrowIdx
+	s.knownEpochs = knownEpochs
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Postgres) loadSessionsForIndex(ctx context.Context) (map[string]uint64, error) {
+	sessionsOnDisk := make(map[string]uint64)
+	rows, err := s.pool.Query(ctx, `SELECT epoch_id, escrow_id FROM devshard_sessions`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var epochID uint64
+		var escrowID string
+		if err := rows.Scan(&epochID, &escrowID); err != nil {
+			return nil, err
+		}
+		if existingEpoch, ok := sessionsOnDisk[escrowID]; ok && existingEpoch != epochID {
+			return nil, fmt.Errorf("%w: escrow %s exists in epochs %d and %d",
+				ErrSessionEpochConflict, escrowID, existingEpoch, epochID)
+		}
+		sessionsOnDisk[escrowID] = epochID
+	}
+	return sessionsOnDisk, rows.Err()
+}
+
+// diffSessionIndex compares the durable index to sessionsOnDisk. Matching rows
+// are recorded in indexedOK so the repair INSERT can skip them. Index rows
+// with no matching session (or a wrong epoch) are returned for batch delete.
+func (s *Postgres) diffSessionIndex(
+	ctx context.Context,
+	sessionsOnDisk map[string]uint64,
+) (staleEscrows []string, staleEpochs []int64, indexedOK map[string]struct{}, err error) {
+	indexedOK = make(map[string]struct{})
+	indexRows, err := s.pool.Query(ctx, `SELECT escrow_id, epoch_id FROM devshard_session_index`)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	defer indexRows.Close()
+	for indexRows.Next() {
+		var escrowID string
+		var epochID uint64
+		if err := indexRows.Scan(&escrowID, &epochID); err != nil {
+			return nil, nil, nil, err
+		}
+		if diskEpoch, ok := sessionsOnDisk[escrowID]; ok && diskEpoch == epochID {
+			indexedOK[escrowID] = struct{}{}
+			continue
+		}
+		staleEscrows = append(staleEscrows, escrowID)
+		staleEpochs = append(staleEpochs, int64(epochID))
+	}
+	if err := indexRows.Err(); err != nil {
+		return nil, nil, nil, err
+	}
+	return staleEscrows, staleEpochs, indexedOK, nil
+}
+
+func missingSessionIndexRows(
+	sessionsOnDisk map[string]uint64,
+	indexedOK map[string]struct{},
+) (escrows []string, epochs []int64) {
+	for escrowID, epochID := range sessionsOnDisk {
+		if _, ok := indexedOK[escrowID]; ok {
+			continue
+		}
+		escrows = append(escrows, escrowID)
+		epochs = append(epochs, int64(epochID))
+	}
+	return escrows, epochs
+}
+
+// forEachEscrowEpochBatch invokes fn on each chunk of at most
+// postgresIndexRepairBatchSize (1000) paired escrow/epoch rows.
+func forEachEscrowEpochBatch(escrows []string, epochs []int64, fn func([]string, []int64) error) error {
+	if len(escrows) != len(epochs) {
+		return fmt.Errorf("escrow/epoch batch length mismatch: %d vs %d", len(escrows), len(epochs))
+	}
+	for start := 0; start < len(escrows); start += postgresIndexRepairBatchSize {
+		end := start + postgresIndexRepairBatchSize
+		if end > len(escrows) {
+			end = len(escrows)
+		}
+		if err := fn(escrows[start:end], epochs[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Postgres) deleteStaleSessionIndex(ctx context.Context, escrows []string, epochs []int64) error {
+	return forEachEscrowEpochBatch(escrows, epochs, func(batchEscrows []string, batchEpochs []int64) error {
+		if _, err := s.pool.Exec(ctx,
+			`DELETE FROM devshard_session_index AS i
+			 USING unnest($1::text[], $2::bigint[]) AS t(escrow_id, epoch_id)
+			 WHERE i.escrow_id = t.escrow_id AND i.epoch_id = t.epoch_id`,
+			batchEscrows, batchEpochs,
+		); err != nil {
+			return fmt.Errorf("remove stale session index batch: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *Postgres) insertMissingSessionIndex(ctx context.Context, escrows []string, epochs []int64) error {
+	return forEachEscrowEpochBatch(escrows, epochs, func(batchEscrows []string, batchEpochs []int64) error {
+		if _, err := s.pool.Exec(ctx,
+			`INSERT INTO devshard_session_index (escrow_id, epoch_id)
+			 SELECT t.escrow_id, t.epoch_id
+			 FROM unnest($1::text[], $2::bigint[]) AS t(escrow_id, epoch_id)
+			 ON CONFLICT (escrow_id) DO NOTHING`,
+			batchEscrows, batchEpochs,
+		); err != nil {
+			return fmt.Errorf("repair session index batch: %w", err)
+		}
+		return nil
+	})
+}
+
+// Close cancels an in-flight index rebuild, waits for it to finish, then
+// releases the pool. Subsequent calls return immediately.
 func (s *Postgres) Close() error {
+	s.mu.Lock()
+	cancel := s.indexCancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	select {
+	case <-s.readyCh:
+	case <-time.After(postgresOpTimeout):
+	}
 	s.pool.Close()
 	return nil
 }
@@ -288,6 +492,9 @@ func (s *Postgres) ensurePartition(ctx context.Context, epochID uint64) error {
 }
 
 func (s *Postgres) lookupEpoch(escrowID string) (uint64, error) {
+	if err := s.waitReadyForOp(); err != nil {
+		return 0, err
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	epochID, ok := s.escrowIdx[escrowID]
@@ -310,6 +517,9 @@ func (s *Postgres) HasEscrow(escrowID string) bool {
 // and by prune, so this is an accurate emptiness check without a round trip.
 // The hybrid router uses it to clear the .pg-bound marker once PG is drained.
 func (s *Postgres) HasAnySessions() bool {
+	if err := s.waitReadyForOp(); err != nil {
+		return false
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.escrowIdx) > 0
@@ -317,6 +527,9 @@ func (s *Postgres) HasAnySessions() bool {
 
 // EscrowIDs returns a snapshot of escrows in the in-memory routing index.
 func (s *Postgres) EscrowIDs() []string {
+	if err := s.waitReadyForOp(); err != nil {
+		return nil
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	ids := make([]string, 0, len(s.escrowIdx))
@@ -331,6 +544,9 @@ func (s *Postgres) EscrowIDs() []string {
 // a timed-out CreateSession may have committed server-side without updating
 // the in-memory index, so emptiness must be proven against the DB, not RAM.
 func (s *Postgres) HasAnySessionsLive() (bool, error) {
+	if err := s.waitReadyForOp(); err != nil {
+		return false, err
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), postgresLivePresenceTimeout)
 	defer cancel()
 	var exists bool
@@ -349,6 +565,9 @@ func (s *Postgres) opCtx() (context.Context, context.CancelFunc) {
 }
 
 func (s *Postgres) CreateSession(params CreateSessionParams) error {
+	if err := s.waitReadyForOp(); err != nil {
+		return err
+	}
 	params.Config = types.NormalizeSessionConfig(params.Config, len(params.Group))
 	configJSON, err := json.Marshal(params.Config)
 	if err != nil {
@@ -469,6 +688,9 @@ func (s *Postgres) MarkSettled(escrowID string) error {
 }
 
 func (s *Postgres) ListActiveSessions() ([]ActiveSession, error) {
+	if err := s.waitReadyForOp(); err != nil {
+		return nil, err
+	}
 	ctx, cancel := s.opCtx()
 	defer cancel()
 	rows, err := s.pool.Query(ctx,
@@ -1224,6 +1446,9 @@ func (s *Postgres) GetValidationObservability(escrowID string) ([]SlotValidation
 // escrow index entry that pointed at it. Other epochs are not touched.
 // No-op if the partitions do not exist.
 func (s *Postgres) PruneEpoch(epochID uint64) error {
+	if err := s.waitReadyForOp(); err != nil {
+		return err
+	}
 	ctx, cancel := s.opCtx()
 	defer cancel()
 	for _, partition := range []string{
@@ -1264,6 +1489,9 @@ func (s *Postgres) PruneEpoch(epochID uint64) error {
 func (s *Postgres) pruneBefore(cutoff uint64) error {
 	if cutoff == 0 {
 		return nil
+	}
+	if err := s.waitReadyForOp(); err != nil {
+		return err
 	}
 
 	ctx, cancel := s.opCtx()

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -496,12 +496,38 @@ func (s *Postgres) lookupEpoch(escrowID string) (uint64, error) {
 		return 0, err
 	}
 	s.mu.RLock()
-	defer s.mu.RUnlock()
 	epochID, ok := s.escrowIdx[escrowID]
-	if !ok {
-		return 0, fmt.Errorf("%w: %s", ErrSessionNotFound, escrowID)
+	s.mu.RUnlock()
+	if ok {
+		return epochID, nil
 	}
-	return epochID, nil
+
+	// HA / multi-instance: peers may CreateSession after our boot-time index
+	// rebuild. Fill the in-memory map from the durable index on miss so
+	// SessionServerExisting (/mempool warm) can recover without a restart.
+	ctx, cancel := s.opCtx()
+	defer cancel()
+	var diskEpoch uint64
+	err := s.pool.QueryRow(ctx,
+		`SELECT epoch_id FROM devshard_session_index WHERE escrow_id = $1`,
+		escrowID,
+	).Scan(&diskEpoch)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, fmt.Errorf("%w: %s", ErrSessionNotFound, escrowID)
+		}
+		return 0, fmt.Errorf("lookup session index for %s: %w", escrowID, err)
+	}
+
+	s.mu.Lock()
+	if existing, ok := s.escrowIdx[escrowID]; ok {
+		s.mu.Unlock()
+		return existing, nil
+	}
+	s.escrowIdx[escrowID] = diskEpoch
+	s.knownEpochs[diskEpoch] = struct{}{}
+	s.mu.Unlock()
+	return diskEpoch, nil
 }
 
 // HasEscrow reports whether escrowID is present in the in-memory routing index

--- a/devshard/storage/postgres_migrate_test.go
+++ b/devshard/storage/postgres_migrate_test.go
@@ -130,6 +130,7 @@ func TestSaveSnapshot_SameEpoch_PartitionCreateOnce(t *testing.T) {
 		knownEpochs: make(map[uint64]struct{}),
 		escrowIdx:   make(map[string]uint64),
 	}
+	markPostgresIndexReadyForTest(pg)
 	require.NoError(t, MigratePostgres(ctx, pool))
 
 	const epochID = uint64(42)
@@ -158,6 +159,7 @@ func TestEnsurePartition_CreatesAllParentPartitionsOnce(t *testing.T) {
 		knownEpochs: make(map[uint64]struct{}),
 		escrowIdx:   make(map[string]uint64),
 	}
+	markPostgresIndexReadyForTest(pg)
 	require.NoError(t, MigratePostgres(ctx, pool))
 
 	want := len(postgresPartitionedParents)

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -290,6 +290,176 @@ func TestPostgres_RecoversIndexAcrossReopen(t *testing.T) {
 	require.Len(t, diffs, 2)
 }
 
+// TestPostgres_IndexRepair_MissingAndStale verifies indexExisting batch-repairs
+// a diverged durable index: orphan index rows are deleted, missing rows are
+// inserted, and already-matching rows are left alone.
+func TestPostgres_IndexRepair_MissingAndStale(t *testing.T) {
+	cleanup := setupPostgresContainer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pg, err := NewPostgres(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, pg.CreateSession(paramsForEpoch("keep", 10)))
+	require.NoError(t, pg.CreateSession(paramsForEpoch("missing-idx", 11)))
+	require.NoError(t, pg.ensurePartition(ctx, 12))
+	_, err = pg.pool.Exec(ctx,
+		`INSERT INTO devshard_sessions
+		    (epoch_id, escrow_id, version, creator_addr, config_json, group_json, initial_balance)
+		 VALUES (12, 'orphan-session', 'v-test', 'creator', '{}', '[]', 1)`)
+	require.NoError(t, err)
+	// Drop the index row that CreateSession wrote for missing-idx, leave keep intact,
+	// and plant a stale index row with no matching session.
+	_, err = pg.pool.Exec(ctx, `DELETE FROM devshard_session_index WHERE escrow_id = $1`, "missing-idx")
+	require.NoError(t, err)
+	_, err = pg.pool.Exec(ctx,
+		`INSERT INTO devshard_session_index (escrow_id, epoch_id) VALUES ('stale-idx', 99)`)
+	require.NoError(t, err)
+	require.NoError(t, pg.Close())
+
+	pg2, err := NewPostgres(ctx)
+	require.NoError(t, err)
+	defer pg2.Close()
+
+	require.True(t, pg2.HasEscrow("keep"))
+	require.True(t, pg2.HasEscrow("missing-idx"))
+	require.True(t, pg2.HasEscrow("orphan-session"))
+	require.False(t, pg2.HasEscrow("stale-idx"))
+
+	var keepEpoch, missingEpoch, orphanEpoch uint64
+	require.NoError(t, pg2.pool.QueryRow(ctx,
+		`SELECT epoch_id FROM devshard_session_index WHERE escrow_id = $1`, "keep",
+	).Scan(&keepEpoch))
+	require.NoError(t, pg2.pool.QueryRow(ctx,
+		`SELECT epoch_id FROM devshard_session_index WHERE escrow_id = $1`, "missing-idx",
+	).Scan(&missingEpoch))
+	require.NoError(t, pg2.pool.QueryRow(ctx,
+		`SELECT epoch_id FROM devshard_session_index WHERE escrow_id = $1`, "orphan-session",
+	).Scan(&orphanEpoch))
+	require.Equal(t, uint64(10), keepEpoch)
+	require.Equal(t, uint64(11), missingEpoch)
+	require.Equal(t, uint64(12), orphanEpoch)
+
+	var staleCount int
+	require.NoError(t, pg2.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM devshard_session_index WHERE escrow_id = $1`, "stale-idx",
+	).Scan(&staleCount))
+	require.Equal(t, 0, staleCount)
+}
+
+func TestMissingSessionIndexRows_SkipsIndexed(t *testing.T) {
+	sessions := map[string]uint64{"a": 1, "b": 2, "c": 3}
+	indexedOK := map[string]struct{}{"a": {}, "c": {}}
+	escrows, epochs := missingSessionIndexRows(sessions, indexedOK)
+	require.Len(t, escrows, 1)
+	require.Equal(t, "b", escrows[0])
+	require.Equal(t, []int64{2}, epochs)
+}
+
+func TestForEachEscrowEpochBatch_ChunksBy1000(t *testing.T) {
+	const n = postgresIndexRepairBatchSize + 3
+	escrows := make([]string, n)
+	epochs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		escrows[i] = "e"
+		epochs[i] = int64(i)
+	}
+	var sizes []int
+	err := forEachEscrowEpochBatch(escrows, epochs, func(batchEscrows []string, batchEpochs []int64) error {
+		require.Equal(t, len(batchEscrows), len(batchEpochs))
+		sizes = append(sizes, len(batchEscrows))
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []int{postgresIndexRepairBatchSize, 3}, sizes)
+}
+
+func TestPostgres_WaitReady_BlocksUntilIndex(t *testing.T) {
+	cleanup := setupPostgresContainer(t)
+	defer cleanup()
+
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	indexExistingHook = func(ctx context.Context) {
+		close(entered)
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+	}
+	t.Cleanup(func() { indexExistingHook = nil })
+
+	ctx := context.Background()
+	pg, err := NewPostgres(ctx)
+	require.NoError(t, err)
+	defer pg.Close()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("index hook did not start")
+	}
+	require.False(t, pg.Ready())
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		waitErr <- pg.WaitReady(waitCtx)
+	}()
+
+	select {
+	case err := <-waitErr:
+		t.Fatalf("WaitReady returned before index release: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-waitErr)
+	require.True(t, pg.Ready())
+	require.NoError(t, pg.CreateSession(paramsForEpoch("after-ready", 1)))
+}
+
+func TestPostgres_NewPostgres_ConnectBudgetDoesNotIncludeIndex(t *testing.T) {
+	cleanup := setupPostgresContainer(t)
+	defer cleanup()
+
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	indexExistingHook = func(ctx context.Context) {
+		close(entered)
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+	}
+	t.Cleanup(func() {
+		indexExistingHook = nil
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	connectCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	pg, err := NewPostgres(connectCtx)
+	require.NoError(t, err)
+	defer pg.Close()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("index hook did not start")
+	}
+	require.False(t, pg.Ready(), "index must still be in progress after NewPostgres returns")
+	canceled, cancelWait := context.WithCancel(context.Background())
+	cancelWait()
+	require.Error(t, pg.WaitReady(canceled))
+}
+
 func TestMigrateLegacy_IntoPostgresStorage(t *testing.T) {
 	cleanup := setupPostgresContainer(t)
 	defer cleanup()

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -69,7 +69,19 @@ func newTestPostgres(t *testing.T) *Postgres {
 	pg, err := NewPostgres(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = pg.Close() })
+	require.NoError(t, pg.WaitReady(context.Background()))
 	return pg
+}
+
+// markPostgresIndexReadyForTest marks a manually constructed *Postgres as
+// index-ready so escrow-keyed methods (CreateSession, SaveSnapshot, …) do not
+// block on waitReadyForOp. NewPostgres already starts the async rebuild; this
+// is only for tests that wire pool/maps directly.
+func markPostgresIndexReadyForTest(pg *Postgres) {
+	if pg.readyCh == nil {
+		pg.readyCh = make(chan struct{})
+	}
+	pg.markIndexDone(nil)
 }
 
 func captureStorageLogs(t *testing.T) *bytes.Buffer {
@@ -458,6 +470,179 @@ func TestPostgres_NewPostgres_ConnectBudgetDoesNotIncludeIndex(t *testing.T) {
 	canceled, cancelWait := context.WithCancel(context.Background())
 	cancelWait()
 	require.Error(t, pg.WaitReady(canceled))
+}
+
+func TestPostgres_LookupEpoch_FillsFromDurableIndex(t *testing.T) {
+	cleanup := setupPostgresContainer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pg1, err := NewPostgres(ctx)
+	require.NoError(t, err)
+	require.NoError(t, pg1.WaitReady(ctx))
+	require.NoError(t, pg1.CreateSession(paramsForEpoch("peer-created", 7)))
+	require.NoError(t, pg1.Close())
+
+	// Fresh handle: index rebuild loads the row. Clear the in-memory map to
+	// simulate a peer that created the session after our rebuild finished.
+	pg2, err := NewPostgres(ctx)
+	require.NoError(t, err)
+	defer pg2.Close()
+	require.NoError(t, pg2.WaitReady(ctx))
+
+	pg2.mu.Lock()
+	delete(pg2.escrowIdx, "peer-created")
+	pg2.mu.Unlock()
+	require.False(t, func() bool {
+		pg2.mu.RLock()
+		defer pg2.mu.RUnlock()
+		_, ok := pg2.escrowIdx["peer-created"]
+		return ok
+	}())
+
+	meta, err := pg2.GetSessionMeta("peer-created")
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), meta.EpochID)
+	require.True(t, pg2.HasEscrow("peer-created"),
+		"miss must backfill escrowIdx from durable session_index")
+}
+
+// TestPostgres_HAPeerCreateAfterBootIndex_StalesMemoryAndBackfills reproduces the
+// multi-host race fixed for warm /mempool: instance A finishes async
+// indexExisting, then peer B CreateSession's a new escrow. A's in-memory
+// escrowIdx stays stale until lookupEpoch reads devshard_session_index.
+func TestPostgres_HAPeerCreateAfterBootIndex_StalesMemoryAndBackfills(t *testing.T) {
+	cleanup := setupPostgresContainer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// A is mid-lifecycle after boot: connect + migrate done, index rebuild done.
+	starter, err := NewPostgres(ctx)
+	require.NoError(t, err)
+	defer starter.Close()
+	require.NoError(t, starter.WaitReady(ctx))
+
+	// B is a second process handle on the same Postgres (HA peer).
+	peer, err := NewPostgres(ctx)
+	require.NoError(t, err)
+	defer peer.Close()
+	require.NoError(t, peer.WaitReady(ctx))
+
+	const (
+		escrowID = "ha-peer-created-after-sibling-boot-index"
+		epochID  = uint64(42)
+	)
+
+	// Peer accepts a new session while starter's boot-time index is already a
+	// finished snapshot — starter.escrowIdx will not include this escrow.
+	require.NoError(t, peer.CreateSession(paramsForEpoch(escrowID, epochID)))
+
+	starter.mu.RLock()
+	_, inMem := starter.escrowIdx[escrowID]
+	starter.mu.RUnlock()
+	require.False(t, inMem,
+		"starter boot index must be outdated after peer CreateSession")
+
+	// SessionServerExisting / warm paths call GetSessionMeta → lookupEpoch.
+	// Without durable backfill this returned "session not found".
+	meta, err := starter.GetSessionMeta(escrowID)
+	require.NoError(t, err)
+	require.Equal(t, epochID, meta.EpochID)
+	require.True(t, starter.HasEscrow(escrowID))
+
+	starter.mu.RLock()
+	filled, ok := starter.escrowIdx[escrowID]
+	starter.mu.RUnlock()
+	require.True(t, ok, "lookup must backfill escrowIdx from durable index")
+	require.Equal(t, epochID, filled)
+}
+
+// TestPostgres_HAPeerCreateWhileSiblingIndexRebuild_StillVisibleAfterReady covers
+// the overlapping-start window: peer CreateSession while the sibling is still
+// inside indexExisting (blocked in the test hook). When the rebuild runs after
+// the create, the durable row is present; a later peer create after Ready still
+// requires durable backfill on the starter.
+func TestPostgres_HAPeerCreateWhileSiblingIndexRebuild_StillVisibleAfterReady(t *testing.T) {
+	cleanup := setupPostgresContainer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	peer, err := NewPostgres(ctx)
+	require.NoError(t, err)
+	defer peer.Close()
+	require.NoError(t, peer.WaitReady(ctx))
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	indexExistingHook = func(context.Context) {
+		close(entered)
+		<-release
+	}
+	t.Cleanup(func() {
+		indexExistingHook = nil
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	starterErr := make(chan error, 1)
+	var starter *Postgres
+	go func() {
+		pg, err := NewPostgres(ctx)
+		if err != nil {
+			starterErr <- err
+			return
+		}
+		starter = pg
+		starterErr <- nil
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("starter index rebuild did not start")
+	}
+	select {
+	case err := <-starterErr:
+		require.NoError(t, err, "NewPostgres must return before index finishes")
+	case <-time.After(5 * time.Second):
+		t.Fatal("NewPostgres did not return while index was blocked")
+	}
+	require.NotNil(t, starter)
+	defer starter.Close()
+	require.False(t, starter.Ready(), "starter still indexing")
+
+	const (
+		duringEscrow = "created-while-sibling-indexing"
+		duringEpoch  = uint64(11)
+		afterEscrow  = "created-after-sibling-ready"
+		afterEpoch   = uint64(12)
+	)
+	require.NoError(t, peer.CreateSession(paramsForEpoch(duringEscrow, duringEpoch)))
+
+	close(release)
+	require.NoError(t, starter.WaitReady(ctx))
+
+	// Create that landed before indexExisting's scan must be in starter memory.
+	starter.mu.RLock()
+	duringMem, duringOK := starter.escrowIdx[duringEscrow]
+	starter.mu.RUnlock()
+	require.True(t, duringOK, "indexExisting after peer create must load durable row")
+	require.Equal(t, duringEpoch, duringMem)
+
+	// Post-ready peer create is the stale-index race: memory miss + durable hit.
+	require.NoError(t, peer.CreateSession(paramsForEpoch(afterEscrow, afterEpoch)))
+	starter.mu.RLock()
+	_, afterInMem := starter.escrowIdx[afterEscrow]
+	starter.mu.RUnlock()
+	require.False(t, afterInMem, "post-ready peer create must leave starter memory stale")
+
+	meta, err := starter.GetSessionMeta(afterEscrow)
+	require.NoError(t, err)
+	require.Equal(t, afterEpoch, meta.EpochID)
+	require.True(t, starter.HasEscrow(afterEscrow))
 }
 
 func TestMigrateLegacy_IntoPostgresStorage(t *testing.T) {

--- a/devshard/testenv/citest/sqlite_ha_migration_test.go
+++ b/devshard/testenv/citest/sqlite_ha_migration_test.go
@@ -84,6 +84,8 @@ func TestSQLiteToPostgresHAMigration(t *testing.T) {
 	harness.PatchRouterVersiondHosts(t, stack.ComposePath, hostsBoth)
 	stack.RecreateServices(t, "versiond-router")
 	stack.StartService(t, secondHost)
+	// Force-recreate remaps Docker host ports; refresh probes before waiting.
+	eps = stack.Endpoints(t, cfg)
 	harness.WaitGETOK(t, client, eps.RouterHTTP+"/healthz", 2*time.Minute, "router after expand", stack)
 
 	haHealth := eps.RouterHTTP + "/" + haVersion + "/healthz"
@@ -108,6 +110,8 @@ func TestSQLiteToPostgresHAMigration(t *testing.T) {
 	harness.Step(t, "phase 4: multi-host HA serves with Devshard-Ha + postgres")
 	// Clear gateway limiter / in-flight state left from Phase 2 HA 503s.
 	harness.RestartService(t, stack, "devshardctl")
+	// Stop/start remaps Docker host ports; refresh before probing.
+	eps = stack.Endpoints(t, cfg)
 	harness.WaitGETOK(t, client, eps.GatewayHTTP+"/v1/status", 3*time.Minute, "gateway after restart", stack)
 	harness.WaitGatewayChatReady(t, client, eps.GatewayHTTP, 3*time.Minute, stack)
 	okReq := harness.ChatCompletionRequest{
@@ -123,6 +127,9 @@ func TestSQLiteToPostgresHAMigration(t *testing.T) {
 	// Refresh router DNS after versiond recreate so both HA upstreams are live.
 	stack.RequireServicesRunning(t, legacyHost, secondHost, "versiond-router")
 	stack.RecreateServices(t, "versiond-router")
+	eps = stack.Endpoints(t, cfg)
+	haHealth = eps.RouterHTTP + "/" + haVersion + "/healthz"
+	haURL = harness.RouterSessionURL(eps.RouterHTTP, haVersion, "sqlite-migration-phase0-ha", "/healthz")
 	harness.WaitGETOK(t, client, eps.RouterHTTP+"/healthz", 2*time.Minute, "router after HA refresh", stack)
 	harness.WaitGETOK(t, client, haHealth, 2*time.Minute, "devshardd health via refreshed router", stack)
 


### PR DESCRIPTION
### Summary

- Fixes hosts stuck returning 500s (`postgres storage is configured but
  unavailable: index existing sessions: repair session index for <escrow>:
  timeout`) where one slow/leftover escrow's index repair blocked all live
  sessions.
- Decouples Postgres **connect** (`PG_CONNECT_TIMEOUT`, 2s) from **session
  index rebuild** (`PG_INDEX_TIMEOUT`, new, 30s); rebuild runs asynchronously
  and Postgres is only promoted once its index is ready.
- Makes index repair batched and skip-aware (set-based `unnest` DELETE/INSERT
  chunked at 1000; no writes on the happy path).
- Turns mid-rebuild requests into retryable 503 `initializing` and wires storage
  readiness into `/ready`.

## Problem statement

Hosts running in Postgres storage mode (`PGHOST` set) were failing **all** new
session traffic with HTTP 500s like:

```text
init storage session: devshard postgres storage is configured but unavailable:
index existing sessions: repair session index for 31069:
timeout: context deadline exceeded: escrow 33355
```

Root cause was a coupling in how Postgres storage opened:

1. `NewPostgres` did connect + ping + migrate **and** a full session-index
   rebuild (`indexExisting`) under a single short context
   (`PG_CONNECT_TIMEOUT`, default 2s).
2. `indexExisting` reconciled `devshard_session_index` against
   `devshard_sessions` with **one `INSERT ... ON CONFLICT DO NOTHING` per
   escrow, on every boot/reconnect** — even when the index already matched.
   This is O(N) round-trips and easily blows a 2s budget on a slow/large DB.
3. When the rebuild timed out, `NewPostgres` failed, so the hybrid router stayed
   in **degraded sqlite-owned-only** mode and rejected every new escrow with
   `ErrStoragePostgresUnavailable`.
4. The background reconnect loop retried the same coupled open and kept failing
   with the same `repair session index for <old escrow>` timeout.

Net effect: one stuck/slow index repair on a leftover escrow (e.g. `31069`,
already gone on chain) blocked live escrows (`33355`, `33481`, …) indefinitely.

Secondary issues found in the original repair path:

- Stale-index deletes and repair inserts were per-row (N round-trips).
- The repair loop re-`INSERT`ed every session even when the index row already
  matched — pointless writes on the happy path.

---

## Solution implemented

### 1. Batched, skip-aware index repair

`indexExisting` was refactored into:

- `loadSessionsForIndex` — one `SELECT` of `devshard_sessions` (+ epoch-conflict
  check).
- `diffSessionIndex` — one `SELECT` of `devshard_session_index`; already-correct
  rows are recorded in `indexedOK` and **skipped**, mismatched/orphan rows go to
  a stale list.
- `deleteStaleSessionIndex` / `insertMissingSessionIndex` — set-based
  `DELETE ... USING unnest(...)` and `INSERT ... SELECT unnest(...)`, chunked by
  `postgresIndexRepairBatchSize = 1000` via `forEachEscrowEpochBatch`.

Happy path (index already consistent) now issues **zero** repair DML.

### 2. Connect timeout separated from index rebuild

- `NewPostgres` now returns after connect + ping + migrate; the session-index
  rebuild runs in a background goroutine bounded by a new
  `PG_INDEX_TIMEOUT` (default 30s), independent of `PG_CONNECT_TIMEOUT`.
- New readiness API on `*Postgres`: `WaitReady(ctx)`, `Ready()`, and internal
  `waitReadyForOp()`. `Close()` cancels the in-flight rebuild.
- Boot (`openPostgresReady`) and hybrid **reconnect** now `WaitReady` under
  `PG_INDEX_TIMEOUT` **before** promoting Postgres, so a handle is only promoted
  once its routing index is fully rebuilt (never with an empty index).
- The rebuilt `escrowIdx` / `knownEpochs` maps are published atomically under
  `s.mu` (no off-lock mutation from the goroutine).

### 3. Request gating + readiness signalling

- Escrow-keyed Postgres operations gate on `waitReadyForOp()` (bounded by
  `postgresOpTimeout`), so a request during rebuild **waits** instead of racing
  an empty index. On timeout it returns the new transient sentinel
  `storage.ErrStorageIndexRebuilding`.
- `devshard/server/routes.go` maps `ErrStorageIndexRebuilding` to
  **`initializing` → HTTP 503** (retryable), not a 500 `storage_err`.
- Storage readiness is surfaced through `HybridStorage.Ready()` →
  `ManagedStorage.Ready()` → `HostManager.StorageReady()`, and the admin
  `/ready` endpoint now returns 503 (with `"storage_ready": false`) until the
  index is ready.

### Behavior summary

| Situation | Before | After |
| --- | --- | --- |
| Slow/large index rebuild | Connect fails at 2s → degraded, rejects new escrows | Connect succeeds; rebuild runs up to `PG_INDEX_TIMEOUT`; promote only when ready |
| Happy-path reconnect | O(N) `INSERT ON CONFLICT` per escrow | 1 `SELECT` + set-based diff; zero DML when consistent |
| Request during rebuild | 500 `storage_err` | Waits; on timeout 503 `initializing` (retryable) |
| `/ready` while rebuilding | 200 (storage state ignored) | 503 with `storage_ready:false` |

### Tests

- `storage`: batched repair (missing/stale/kept), skip-indexed unit,
  `forEachEscrowEpochBatch` chunk-by-1000, `WaitReady` blocks until index,
  connect returns before index, reconnect waits for ready before promote
  (all pass under `-race`).
- `server`: `ErrStorageIndexRebuilding` → 503 `initializing` + metric reason.
- `cmd/devshardd`: `/ready` reflects storage readiness.

### New / changed env knobs

| Env | Default | Scope |
| --- | --- | --- |
| `PG_CONNECT_TIMEOUT` | `2s` | dial + ping + migrate only |
| `PG_INDEX_TIMEOUT` | `30s` (new) | async session-index rebuild / `WaitReady` |