### PR TITLE
fix(devshard): HA: idempotent AppendDiff, stale-standby reconcile, and persist-first

### DIFF
--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -215,7 +215,6 @@ func (m *HostManager) HandleSettlementFinalized(escrowID string) error {
 	m.sessionsMutex.Lock()
 	srv, hadSession := m.sessions[escrowID]
 	delete(m.sessions, escrowID)
-	delete(m.resolutionFailures, escrowID)
 	m.sessionsMutex.Unlock()
 	if hadSession {
 		srv.Host().Close()
@@ -227,6 +226,9 @@ func (m *HostManager) HandleSettlementFinalized(escrowID string) error {
 		}
 		return err
 	}
+	// Negative-cache so a concurrent/next bind does not recoverStoredSession
+	// the just-settled row (getOrCreate also rejects non-active meta).
+	m.rememberResolutionFailure(escrowID, storage.ErrSessionNotActive, time.Now())
 	return nil
 }
 
@@ -314,7 +316,8 @@ func (m *HostManager) sweepExpiredResolutionFailuresLocked(now time.Time) {
 func isPermanentResolutionFailure(err error) bool {
 	return errors.Is(err, storage.ErrSessionVersionConflict) ||
 		errors.Is(err, storage.ErrSessionEpochConflict) ||
-		errors.Is(err, storage.ErrEpochPruned)
+		errors.Is(err, storage.ErrEpochPruned) ||
+		errors.Is(err, storage.ErrSessionNotActive)
 }
 
 func (m *HostManager) storeSessionIfAbsent(escrowID string, srv *transport.Server) *transport.Server {
@@ -462,6 +465,9 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 	meta, err := m.store.GetSessionMeta(escrowID)
 	if err != nil {
 		return nil, fmt.Errorf("get session meta: %w", err)
+	}
+	if meta.Status != "active" {
+		return nil, fmt.Errorf("%w: escrow %s status %q", storage.ErrSessionNotActive, escrowID, meta.Status)
 	}
 	if meta.Version != "" && meta.Version != m.boundVersion {
 		return nil, fmt.Errorf("%w: stored %s, host %s", storage.ErrSessionVersionConflict, meta.Version, m.boundVersion)

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -270,6 +270,56 @@ func TestRecoverSessions_EmptyStore(t *testing.T) {
 	mgr.sessionsMutex.RUnlock()
 }
 
+// TestHandleSettlementFinalized_DoesNotResurrect pins the A3 stale-escrow
+// contract: after MarkSettled + drop, getOrCreate must not rebuild a live
+// host from the durable settled row (and must negative-cache the miss).
+func TestHandleSettlementFinalized_DoesNotResurrect(t *testing.T) {
+	store := newManagerTestStore(t)
+	slots, user, hostSigner := createStoredSession(t, store, "1", 7, 1)
+	addresses := make([]string, len(slots))
+	for i, s := range slots {
+		addresses[i] = s.ValidatorAddress
+	}
+	br := &mockBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       "1",
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+		},
+	}
+	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	require.NoError(t, mgr.RecoverSessions())
+	_, ok := mgr.existingServer("1")
+	require.True(t, ok, "precondition: session live after recover")
+
+	require.NoError(t, mgr.HandleSettlementFinalized("1"))
+	_, ok = mgr.existingServer("1")
+	require.False(t, ok, "settlement must drop the live session")
+
+	_, err := mgr.getOrCreate("1", nil)
+	require.ErrorIs(t, err, storage.ErrSessionNotActive)
+
+	// Permanent negative cache: a second bind must not re-read/rebuild.
+	_, err = mgr.getOrCreate("1", nil)
+	require.ErrorIs(t, err, storage.ErrSessionNotActive)
+	_, ok = mgr.existingServer("1")
+	require.False(t, ok, "settled session must stay out of the live map")
+}
+
+// TestRecoverStoredSession_RejectsSettledStatus covers the store-only path:
+// even without HandleSettlementFinalized's negative cache, a settled meta row
+// must not be rebuilt into a live host.
+func TestRecoverStoredSession_RejectsSettledStatus(t *testing.T) {
+	store := newManagerTestStore(t)
+	_, _, hostSigner := createStoredSession(t, store, "1", 7, 1)
+	require.NoError(t, store.MarkSettled("1"))
+
+	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	_, err := mgr.recoverStoredSession("1")
+	require.ErrorIs(t, err, storage.ErrSessionNotActive)
+}
+
 func TestRecoverSessions_StateRootMismatch(t *testing.T) {
 	store := newManagerTestStore(t)
 	hosts := make([]*signing.Secp256k1Signer, 3)

--- a/devshard/docs/high-availability-architecture.md
+++ b/devshard/docs/high-availability-architecture.md
@@ -165,6 +165,34 @@ router), `deploy/join/docker-compose.versiond.yml` (2 versiond + router).
 
 > **Multi-instance requires a shared Postgres** — see §4.
 
+### Diff / persist consistency under HA
+
+Sticky routing keeps an escrow on one versiond while healthy, but failover can
+land catch-up on a **stale standby**: another replica already wrote higher
+nonces to shared Postgres while this process still holds an older in-memory
+session. Without extra care, re-applying an already-durable nonce as a bare
+`INSERT` produced SQLSTATE `23505` and HTTP 500 even though durable state was
+correct.
+
+Shipped behaviour on the host (`devshardd`) and gateway (`devshardctl`):
+
+| Mechanism | Behaviour |
+|-----------|-----------|
+| **Idempotent `AppendDiff`** | Same `(epoch, escrow, nonce)` with **identical** payload → success (HA replay). Conflicting bytes → typed fork error + `devshard_diff_fork_detected_total` (never overwrite). |
+| **Lazy reconcile** | Incoming `diff.Nonce > memNonce+1` → load the gap from Postgres (`GetDiffs`), apply durable rows in memory **without** re-inserting, then apply the tip. Emits `reconcile_fast_forward` log + `devshard_reconcile_fast_forward_total`. |
+| **Persist-first** | Validate / preview on a clone → `AppendDiff` (with bounded retry) → commit to the live state machine. Persist failure leaves memory **unchanged** (failure direction is store-ahead or no-op, not memory-ahead). |
+| **Gateway catch-up** | Still driven by per-slot `hostSyncNonce` toward group members; the gateway does **not** address individual versiond HA replicas. |
+
+Operator signals (versiond / host logs and Prometheus):
+
+- `reconcile_fast_forward` — expected on failover onto a lagging replica.
+- `diff_persist_retry` / `devshard_diff_persist_retry_total` — transient Postgres blips.
+- `diff_fork_detected` / `devshard_diff_fork_detected_total` — **must stay 0** in healthy HA; non-zero means real divergence and needs alert investigation.
+
+Gateway catch-up and sticky failover remain independent: router
+`proxy_next_upstream` moves the HTTP request; host reconcile heals RAM from
+shared Postgres when the request arrives.
+
 ---
 
 ## 4. Storage: per-instance SQLite vs shared Postgres

--- a/devshard/docs/release-0.2.14-v4.md
+++ b/devshard/docs/release-0.2.14-v4.md
@@ -48,6 +48,7 @@ unknown modes fall back to exclusive stop/start.
 | **Gateway transport** | Chain queries + escrow tx via gRPC; `--chain-rest` / `DEVSHARD_CHAIN_REST` removed |
 | **Settle confirm** | Settle waits for DeliverTx (`GetTx`) after SYNC CheckTx — same pattern as create |
 | **Failover** | Router retries another HA peer on first upstream 502 / connect failure |
+| **HA diff/persist** | Idempotent identical `AppendDiff` (fork on conflict); lazy RAM reconcile from PG on nonce gap; persist-first so a failed write cannot leave memory ahead of Postgres |
 | **Versionless obs** | Obs GETs never bind; owner chat binds; join rewrite + PG session lookup; `devshard_obs` rate limit |
 | **Status field** | Gateway `protocol_version` → `session_version` (bind / settlement tag) |
 | **Tier A `/v1` reads** | Served by **edge-api** on new proxies; same handlers still dual-served on **dapi** as deprecated |
@@ -218,6 +219,48 @@ prefer edge-api. Also still on dapi (deprecated): `/v1/bridge/block/latest` and
 | `DEVSHARD_POSTGRES_PASSWORD` / `PG*` | Shared DB |
 | `DEVSHARD_CHAIN_GRPC` | Gateway chain gRPC (no LCD) |
 | `KEY_NAME` (+ shared keyring) | **Same** on every HA replica of one participant |
+
+### HA failover and shared-Postgres diffs
+
+On multi-instance HA, sticky routing plus shared Postgres means a standby can
+have **stale in-memory** session state after the primary advanced durable
+nonces. Catch-up after `proxy_next_upstream` failover must not fail with
+Postgres unique violations (`23505`) for already-durable identical diffs.
+
+What operators should expect on v4:
+
+1. **Identical replay is OK** — re-persisting the same nonce/payload succeeds;
+   different bytes at the same nonce fail loudly (`diff_fork_detected` metric /
+   log). Alert if that counter is non-zero outside incident response.
+2. **Stale standby self-heals** — when catch-up skips ahead of RAM, the host
+   fast-forwards from Postgres (`reconcile_fast_forward`) then applies the tip.
+3. **Persist-first** — host and gateway validate/preview, write the diff, then
+   commit memory. A Postgres blip retries briefly (`diff_persist_retry`); hard
+   failure leaves in-memory nonce unchanged (no permanent “RAM ahead of PG”
+   hole). Retry the request after PG recovers.
+4. **Gateway catch-up API unchanged** — still `hostSyncNonce`-driven toward
+   group slots; no per-versiond-replica addressing from the gateway.
+
+Automated coverage: `TestHAStaleStandbyCatchupIdempotent` in testenv citest
+(see [testenv/docs/scenarios.md](../testenv/docs/scenarios.md)). Manual
+walkthrough: [v4-deploy-test-plan.md](./v4-deploy-test-plan.md) **§3.6**.
+
+#### Crash recovery vs ML execution
+
+Persist-first and durable diff replay cover the **journal / state machine**
+only. After a crash (or failover onto a cold process), recovery **replays
+diffs**; it does **not** re-run ML automatically.
+
+| Recovered protocol state | What happens on a later client request |
+| --- | --- |
+| Inference still `Pending` in the SM, this host is the executor, client retries with payload | Host **can execute again** (same reconnect behaviour as before persist-first). Dedup of in-flight / cached bodies is **in-process** (`executing` / `completedResponses`), not durable across restart. |
+| Inference already `Finished` or timed out in later diffs | `signReceipt` will **not** start execution again. |
+
+In-flight payload, live ML job attachment, and on-disk `CachedResponseBody`
+across `devshardd` instances are **not** solved in this release. Work to
+restore interrupted inferences (decouple ML from the user stream, same-nonce
+gateway reconnect, durable executor state for HA) is tracked in
+[gonka-ai/gonka#1466](https://github.com/gonka-ai/gonka/issues/1466).
 
 ### Join docker-compose (must bump for v4)
 
@@ -412,15 +455,25 @@ Full checklists and negative proofs (multi-host + sqlite → 503, migrate invent
 - [ ] Smoke: chat/settle on a NON_HA path and on v4 HA path; Tier A `/v1/` via edge-api
 - [ ] Confirm old proxies (no `EDGE_API_SERVICE_NAME`) still reach Tier A via
       deprecated dapi dual-serve; new proxies should use edge-api
-- [ ] Optional: run §2 lease race, §3 kill/restart, §4 versionless obs, and
-      **§7 rolling update** (same-name SHA with a long stream) from the deploy
-      test plan
+- [ ] Optional: run §2 lease race, §3 kill/restart (incl. **§3.6** stale-standby
+      catch-up / persist hole), §4 versionless obs, and **§7 rolling update**
+      (same-name SHA with a long stream) from the deploy test plan
 - [ ] Confirm HA children report `postgres` via `devshardd --print-storage-mode`
       before expecting blue/green overlap on a governance SHA bump
 
 ---
 
 ## Known follow-ups
+
+### Interrupted inference resume across crash / HA
+
+Durable diffs make protocol status (`Pending` / `Finished` / timeout)
+recoverable, but executor proof path after drop, reboot, or failover still
+depends on process-local state. See
+[gonka-ai/gonka#1466](https://github.com/gonka-ai/gonka/issues/1466) for the
+intended fixes (shared accept/execute path, ML lifetime independent of the
+client stream, same-nonce gateway reconnect, durable payload / receipt /
+cached body for cross-instance resume).
 
 ### Escrow ID: `string` vs `uint64`
 
@@ -438,7 +491,7 @@ with larger protocol bumps rather than a standalone migration.
 
 | Doc | Use |
 | --- | --- |
-| [v4-deploy-test-plan.md](./v4-deploy-test-plan.md) | Deploy + seven operator test plans (§1–§7) |
+| [v4-deploy-test-plan.md](./v4-deploy-test-plan.md) | Deploy + operator test plans (§1–§7; HA diff/persist in §3.6) |
 | [pr-versionless-observability.md](./pr-versionless-observability.md) | Versionless obs design + unit/manual checklist |
 | [high-availability-architecture.md](./high-availability-architecture.md) | Current runtime topology |
 | [storage-design.md](./storage-design.md) | Storage mode selection |

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -283,13 +283,28 @@ Why: A failed backend must remain retryable.
 Consequence: A failed prune leaves `prunedUpTo` unchanged so a later
 `PruneOnce` can retry.
 
+### Live Diff Append Is Idempotent for Identical Replay
+
+Decision: `AppendDiff` treats a second write of the **same**
+`(escrow_id, nonce)` payload as success (`INSERT … ON CONFLICT DO NOTHING`,
+then identity check). A **different** payload at the same nonce returns
+`ErrDiffFork` and increments `devshard_diff_fork_detected_total`.
+
+Why: Multi-instance HA + shared Postgres means at-least-once delivery of
+gateway-sequenced, byte-identical diffs is normal (stale standby catch-up).
+That is not a bug; failing with SQLSTATE 23505 turns a successful durable
+write into an HTTP 500. Conflicting bytes remain a hard error (real fork).
+
+See [proposals/ha-diff-persist-consistency.md](./proposals/ha-diff-persist-consistency.md).
+
 ### Legacy Migration Is Resumable
 
-Decision: `MigrateLegacySQLite` is idempotent at the migration layer, not by
-weakening normal storage writes.
+Decision: `MigrateLegacySQLite` is idempotent at the migration layer; live
+`AppendDiff` is separately idempotent for identical replay (above). Migration
+still verifies already-copied rows against the source after a boot failure.
 
-Why: Live duplicate nonces should still fail. Migration is the only path that
-needs to tolerate partially copied rows after a boot failure.
+Why: Migration may resume after a partial copy; identity checks prevent silent
+forks when a destination row already exists.
 
 Consequence:
 

--- a/devshard/docs/v4-deploy-test-plan.md
+++ b/devshard/docs/v4-deploy-test-plan.md
@@ -318,6 +318,7 @@ make -C versiond-router test-render   # config render only (no live nginx)
 | Legacy pin | `TestLegacyVersionPinnedToSingleHost` | **Yes** — `v1` (in non-HA list) → `versiond_legacy` / `versiond-0` only; other versions still multi-upstream |
 | SQLite → HA-fail → migrate → HA | `TestSQLiteToPostgresHAMigration` | **Yes** — full §1.7 Phases 0–4 |
 | One HA upstream down | `TestVersiondStickySessionFailover` | **No** — first-502 failover to survivor (HA pool) |
+| Stale standby catch-up | `TestHAStaleStandbyCatchupIdempotent` | **No** — primary advances PG, stop it; standby catch-up without `23505` |
 | Gateway chat / gRPC | `TestGatewayChat`, G1–G4 | No |
 | Params / epoch | `TestParamsLongPoll`, `TestEpochSwitch` | No |
 | Faults | A1–A4 | No |
@@ -975,8 +976,10 @@ open a **new** request (which then lands on a survivor).
 
 **Out of scope for this plan:** validation-lease exclusivity (§2), sqlite→migrate
 (§1.7), legacy pin (§1.6). Those are separate. Automated coverage for stop/restart
-semantics also exists as `TestVersiondStickySessionFailover` and
-`TestVersiondRestartSessionPersistence`); this section is the operator walkthrough.
+semantics also exists as `TestVersiondStickySessionFailover`,
+`TestVersiondRestartSessionPersistence`, and
+`TestHAStaleStandbyCatchupIdempotent` (stale-standby catch-up); this section is
+the operator walkthrough.
 
 ### 3.0 Preconditions
 
@@ -1111,12 +1114,92 @@ is up.
 - [ ] Survivors keep serving; dead host shows no new successful handling (§3.2)
 - [ ] Restart killed versiond; logs show it serving again (§3.3)
 - [ ] Multi-upstream fan-out restored after restart (§3.3)
+- [ ] Stale-standby catch-up / persist-hole checks (§3.6)
 
 ### 3.5 Cleanup
 
 ```bash
 cd devshard/testenv
 make down
+```
+
+### 3.6 Diff / persist consistency (failover catch-up + persist hole)
+
+**Goal:** after sticky primary advances shared Postgres, failover onto a lagging
+replica must succeed without SQLSTATE `23505`. Persist blips must not leave a
+permanent memory-ahead gap (persist-first + retry).
+
+**Automated:** `TestHAStaleStandbyCatchupIdempotent` (preferred for catch-up):
+
+```bash
+cd devshard/testenv
+make build-devshardd citest-images
+TESTENV_CITEST=1 go test -tags=testenvci ./citest/ \
+  -run '^TestHAStaleStandbyCatchupIdempotent$' -count=1 -v -timeout 45m
+```
+
+#### Manual — join / shared Postgres
+
+```bash
+cd deploy/join
+docker compose -f docker-compose.yml -f docker-compose.versiond.yml up -d
+docker compose ps
+# Confirm both HA versiond + versiond-router + devshard-postgres healthy
+```
+
+1. Drive gateway chat for one escrow until `LatestNonce` advances (repeat).
+2. Verify durable rows:
+
+```bash
+docker compose exec -it devshard-postgres psql -U devshardd -d devshardd
+```
+
+```sql
+SELECT epoch_id, escrow_id, MAX(nonce) FROM devshard_diffs
+GROUP BY 1,2 ORDER BY 3 DESC LIMIT 10;
+SELECT nonce FROM devshard_diffs WHERE escrow_id = '<ESC>' ORDER BY nonce;
+-- expect contiguous nonces; no duplicate PK possible
+```
+
+3. **Failover catch-up:** identify the sticky primary for that escrow
+   (`X-Upstream-Addr` on `/devshard/<version>/sessions/<escrow>/mempool`), stop
+   that `versiond` service, then send another chat for the same escrow.
+
+| Expect (v4) | Fail |
+| --- | --- |
+| Chat succeeds; gateway `LatestNonce` advances | HTTP 500 |
+| No `23505` / `duplicate key value violates unique constraint` in survivor logs | Unique violation on already-durable nonce |
+| Optional: `reconcile_fast_forward` in survivor logs | Silent durable gap / stuck nonce |
+
+4. **Persist hole:** briefly pause Postgres mid-chat, then unpause:
+
+```bash
+docker compose pause devshard-postgres
+# attempt chat (expect failure / retry pressure)
+docker compose unpause devshard-postgres
+# retry chat
+```
+
+| Expect (v4) | Fail |
+| --- | --- |
+| Persist retried (`diff_persist_retry`); on hard fail in-memory nonce **unchanged** | Memory advanced while PG row missing |
+| After unpause, retry chat persists and advances `LatestNonce` | Same nonce silently swallowed; durable gap remains |
+
+5. Watch signals:
+
+```bash
+docker compose logs -f versiond versiond2 2>&1 | \
+  grep -E 'reconcile_fast_forward|diff_persist_retry|diff_fork_detected'
+```
+
+| Metric / log | Healthy HA |
+| --- | --- |
+| `reconcile_fast_forward` | May appear on failover to a lagging replica |
+| `diff_persist_retry` | May appear under induced PG blips |
+| `diff_fork_detected` | **Must stay 0** (non-zero = real divergence) |
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.versiond.yml down
 ```
 
 ---
@@ -1967,7 +2050,8 @@ docker compose exec versiond-0 wget -q -O - http://127.0.0.1:8080/healthz | jq .
 10. **Seven test plans in this doc:**
    - **§1 Test deployment plan** — rollout, routing, migrate, mixed binding.
    - **§2 Validation race plan** — lease exclusivity under same-key HA.
-   - **§3 High availability plan** — kill / restart versiond; verify via logs.
+   - **§3 High availability plan** — kill / restart versiond; verify via logs;
+     **§3.6** stale-standby catch-up + persist-hole checks.
    - **§4 Versionless observability plan** — obs never binds; rewrite; PG route;
      rate limit; health vs metrics.
    - **§5 Edge-api / deprecated dapi plan** — new proxy → edge-api; old proxy →

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -399,11 +399,7 @@ func (h *Host) HandleRequest(ctx context.Context, req HostRequest) (*HostRespons
 			h.mu.Unlock()
 			return nil, err
 		}
-		if err := h.applyAndPersist(diff); err != nil {
-			h.mu.Unlock()
-			return nil, observability.Classify(observability.ReasonApplyErr, observability.WhereHostApplyDiff, err)
-		}
-		if err := h.applyAndPersist(diff); err != nil {
+		if err := h.applyAndPersistReconciling(ctx, diff); err != nil {
 			h.mu.Unlock()
 			return nil, observability.Classify(observability.ReasonApplyErr, observability.WhereHostApplyDiff, err)
 		}
@@ -543,10 +539,16 @@ func (h *Host) chainMaxNonce() uint32 {
 	return h.maxNonce.MaxNonce()
 }
 
-// applyAndPersist applies a diff, removes included txs from mempool, and persists.
-// Captures WarmKeyDelta (new warm key bindings introduced by this diff) for replay.
-// Caller must hold h.mu.
-func (h *Host) applyAndPersist(diff types.Diff) error {
+// applyAndPersist persists then commits a contiguous next-nonce diff
+// (persist-first). Captures WarmKeyDelta from ValidateDiff for replay.
+//
+// Callers that may see HA catch-up gaps must use applyAndPersistReconciling.
+// AppendDiff is idempotent for identical already-durable rows (Phase 1), so a
+// stale standby that fast-forwarded then re-persists the tip does not fail.
+// Persist uses bounded retry; on exhaustion memory is unchanged (no eviction).
+//
+// Caller must hold h.mu. May unlock briefly during persist backoff.
+func (h *Host) applyAndPersist(ctx context.Context, diff types.Diff) error {
 	currentNonce := h.sm.LatestNonce()
 	if diff.Nonce <= currentNonce {
 		return nil
@@ -554,13 +556,27 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 	if err := h.checkDiffNonceLimitLocked(diff); err != nil {
 		return err
 	}
+
 	phaseBefore := h.sm.Phase()
-	var warmBefore map[uint32]string
 	if h.store != nil {
-		warmBefore = h.sm.WarmKeys()
-	}
-	root, err := h.sm.ApplyDiff(diff)
-	if err != nil {
+		warmBefore := h.sm.WarmKeys()
+		vd, err := h.sm.ValidateDiff(diff)
+		if err != nil {
+			return fmt.Errorf("validate diff nonce %d: %w", diff.Nonce, err)
+		}
+		delta := types.ComputeWarmKeyDelta(warmBefore, vd.WarmAfter)
+		rec := types.DiffRecord{Diff: diff, StateHash: vd.Root, WarmKeyDelta: delta}
+		if err := h.persistDiffRetryLocked(ctx, rec); err != nil {
+			return observability.Classify(observability.ReasonPersistDiffErr, observability.WhereHostApplyDiff, fmt.Errorf("persist diff nonce %d: %w", diff.Nonce, err))
+		}
+		// CommitValidated installs the precomputed post-state (no second
+		// applyCore) and flushes the buffered obs writes. It returns false when
+		// another request committed this nonce while we unlocked for persist
+		// backoff, in which case the diff is already applied.
+		if !h.sm.CommitValidated(vd) {
+			return nil
+		}
+	} else if _, err := h.sm.ApplyDiff(diff); err != nil {
 		return fmt.Errorf("apply diff nonce %d: %w", diff.Nonce, err)
 	}
 	h.mempool.RemoveIncluded(diff.Txs)
@@ -576,15 +592,9 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 	}
 
 	if h.store != nil {
-		warmAfter := h.sm.WarmKeys()
-		delta := types.ComputeWarmKeyDelta(warmBefore, warmAfter)
-		rec := types.DiffRecord{Diff: diff, StateHash: root, WarmKeyDelta: delta}
-		if err := h.store.AppendDiff(h.escrowID, rec); err != nil {
-			return observability.Classify(observability.ReasonPersistDiffErr, observability.WhereHostApplyDiff, fmt.Errorf("persist diff nonce %d: %w", diff.Nonce, err))
-		}
-		// Validation obs recording runs only after successful ApplyDiff. Correctness
-		// depends on ApplyDiff rejecting late/sealed validations before this runs;
-		// do not move recording before ApplyDiff.
+		// Validation obs recording runs only after the diff is committed.
+		// Correctness depends on the trial apply rejecting late/sealed
+		// validations before this runs; do not move recording before commit.
 		h.recordValidationObsFromAppliedDiff(diff.Txs)
 		phaseAfter := h.sm.Phase()
 		settledNow := phaseBefore != types.PhaseSettlement && phaseAfter == types.PhaseSettlement
@@ -592,6 +602,15 @@ func (h *Host) applyAndPersist(diff types.Diff) error {
 		h.maybeSaveSnapshotLocked(diff.Nonce, shouldSnapshot, settledNow)
 	}
 	return nil
+}
+
+// persistDiffRetryLocked retries AppendDiff with backoff, unlocking h.mu during
+// waits so other requests can proceed. On exhaustion returns ErrPersistExhausted
+// without mutating host memory (persist-first: ValidateDiff left the SM
+// unchanged, and the commit happens only after this returns nil). Caller must
+// hold h.mu; it is held again on return. See storage.AppendDiffWithRetry.
+func (h *Host) persistDiffRetryLocked(ctx context.Context, rec types.DiffRecord) error {
+	return storage.AppendDiffWithRetryUnlocked(ctx, h.store, h.escrowID, rec, h.mu.Lock, h.mu.Unlock)
 }
 
 // maybeSaveSnapshotLocked copies the current state when shouldSnapshot is true.
@@ -635,7 +654,7 @@ func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *
 func (h *Host) ApplyCatchUpDiffs(diffs []types.Diff) {
 	h.mu.Lock()
 	for _, diff := range diffs {
-		_ = h.applyAndPersist(diff)
+		_ = h.applyAndPersistReconciling(context.Background(), diff)
 	}
 	staleFinishes := h.collectStaleFinishesLocked()
 	h.mu.Unlock()
@@ -1308,7 +1327,7 @@ func (h *Host) ApplyRecoveredDiffs(ctx context.Context, diffs []types.Diff) ([]g
 	var sigs []gossip.GossipSig
 
 	for _, diff := range diffs {
-		if err := h.applyAndPersist(diff); err != nil {
+		if err := h.applyAndPersistReconciling(ctx, diff); err != nil {
 			return sigs, fmt.Errorf("apply recovered diff nonce %d: %w", diff.Nonce, err)
 		}
 
@@ -1358,7 +1377,7 @@ func (h *Host) challengeReceiptLocked(inferenceID uint64, payload *InferencePayl
 	defer h.mu.Unlock()
 
 	for _, diff := range diffs {
-		if err := h.applyAndPersist(diff); err != nil {
+		if err := h.applyAndPersistReconciling(context.Background(), diff); err != nil {
 			return nil, 0, nil, fmt.Errorf("apply challenge diff nonce %d: %w", diff.Nonce, err)
 		}
 	}

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -174,6 +174,48 @@ func TestHost_AppliesDiffs(t *testing.T) {
 	require.Equal(t, uint64(1), resp.Nonce)
 }
 
+// countingAppendStore wraps Storage and counts AppendDiff calls.
+type countingAppendStore struct {
+	storage.Storage
+	appends atomic.Int32
+}
+
+func (s *countingAppendStore) AppendDiff(escrowID string, rec types.DiffRecord) error {
+	s.appends.Add(1)
+	return s.Storage.AppendDiff(escrowID, rec)
+}
+
+func TestHost_HandleRequest_AppliesDiffOnce(t *testing.T) {
+	// Regression: HandleRequest used to call applyAndPersist twice per diff.
+	// With a store, each new nonce must AppendDiff exactly once.
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+
+	mem := storage.NewMemory()
+	require.NoError(t, mem.CreateSession(storage.CreateSessionParams{
+		EscrowID: "escrow-1", Version: testutil.RuntimeTestVersion,
+		Config: config, Group: group, InitialBalance: 10000, CreatorAddr: user.Address(),
+	}))
+	store := &countingAppendStore{Storage: mem}
+
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, store)
+	require.NoError(t, err)
+	h, err := NewHost(sm, hosts[0], stub.NewInferenceEngine(), "escrow-1", group, nil,
+		WithGrace(10), WithStorage(store), WithVerifier(verifier))
+	require.NoError(t, err)
+
+	diff1 := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	diff2 := testutil.SignDiff(t, user, "escrow-1", 2, nil)
+	resp, err := h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff1, diff2}})
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), resp.Nonce)
+	require.Equal(t, uint64(2), h.LatestNonce())
+	require.Equal(t, int32(2), store.appends.Load(), "each diff must AppendDiff exactly once")
+}
+
 func TestHost_SignsState(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	user := testutil.MustGenerateKey(t)

--- a/devshard/host/persist_retry_test.go
+++ b/devshard/host/persist_retry_test.go
@@ -1,0 +1,128 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/observability"
+	"devshard/signing"
+	"devshard/state"
+	"devshard/storage"
+	"devshard/stub"
+	"devshard/types"
+)
+
+type flakyHostAppendStore struct {
+	storage.Storage
+	failsLeft atomic.Int32
+	calls     atomic.Int32
+}
+
+func (s *flakyHostAppendStore) AppendDiff(escrowID string, rec types.DiffRecord) error {
+	s.calls.Add(1)
+	if s.failsLeft.Add(-1) >= 0 {
+		return errors.New("transient append failure")
+	}
+	return s.Storage.AppendDiff(escrowID, rec)
+}
+
+func signNextStartDiff(t *testing.T, user *signing.Secp256k1Signer, hosts []*signing.Secp256k1Signer, store storage.Storage) types.Diff {
+	t.Helper()
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, store)
+	require.NoError(t, err)
+	txs := []*types.DevshardTx{testutil.StartTx(1)}
+	root, err := sm.ApplyLocal(1, txs)
+	require.NoError(t, err)
+	return testutil.SignDiffWithRoot(t, user, "escrow-1", 1, txs, root)
+}
+
+func TestHost_PersistRetryThenSuccess(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	inner := storage.NewMemory()
+	store := &flakyHostAppendStore{Storage: inner}
+	store.failsLeft.Store(2)
+
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	require.NoError(t, inner.CreateSession(storage.CreateSessionParams{
+		EscrowID: "escrow-1", Version: testutil.RuntimeTestVersion,
+		CreatorAddr: user.Address(), Config: config, Group: group, InitialBalance: 10000,
+	}))
+
+	diff := signNextStartDiff(t, user, hosts, inner)
+	sm0, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, inner)
+	require.NoError(t, err)
+	h, err := NewHost(sm0, hosts[0], stub.NewInferenceEngine(), "escrow-1", group, nil,
+		WithGrace(10), WithStorage(store), WithVerifier(verifier))
+	require.NoError(t, err)
+
+	beforeRetry := promtestutil.ToFloat64(observability.DiffPersistRetryForTest("success"))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = h.HandleRequest(ctx, HostRequest{Diffs: []types.Diff{diff}})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), h.LatestNonce())
+	require.Equal(t, int32(3), store.calls.Load())
+	require.Equal(t, beforeRetry+1, promtestutil.ToFloat64(observability.DiffPersistRetryForTest("success")))
+
+	meta, err := inner.GetSessionMeta("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), meta.LatestNonce)
+}
+
+func TestHost_PersistFirst_FailureLeavesMemoryUnchanged(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	inner := storage.NewMemory()
+	store := &flakyHostAppendStore{Storage: inner}
+	store.failsLeft.Store(100)
+
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	require.NoError(t, inner.CreateSession(storage.CreateSessionParams{
+		EscrowID: "escrow-1", Version: testutil.RuntimeTestVersion,
+		CreatorAddr: user.Address(), Config: config, Group: group, InitialBalance: 10000,
+	}))
+
+	diff := signNextStartDiff(t, user, hosts, inner)
+	sm0, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, inner)
+	require.NoError(t, err)
+	h, err := NewHost(sm0, hosts[0], stub.NewInferenceEngine(), "escrow-1", group, nil,
+		WithGrace(10), WithStorage(store), WithVerifier(verifier))
+	require.NoError(t, err)
+
+	beforeExhausted := promtestutil.ToFloat64(observability.DiffPersistRetryForTest("exhausted"))
+	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
+	require.Error(t, err)
+	require.ErrorIs(t, err, storage.ErrPersistExhausted)
+	require.Equal(t, uint64(0), h.LatestNonce(), "persist-first must not advance memory on persist fail")
+	require.Equal(t, int32(storage.DefaultPersistMaxAttempts), store.calls.Load())
+	require.Equal(t, beforeExhausted+1, promtestutil.ToFloat64(observability.DiffPersistRetryForTest("exhausted")))
+
+	meta, err := inner.GetSessionMeta("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), meta.LatestNonce)
+
+	// Same host, heal store, retry same nonce — no reload required.
+	store.failsLeft.Store(0)
+	store.calls.Store(0)
+	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff}})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), h.LatestNonce())
+	meta, err = inner.GetSessionMeta("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), meta.LatestNonce)
+}

--- a/devshard/host/reconcile.go
+++ b/devshard/host/reconcile.go
@@ -1,0 +1,161 @@
+package host
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"devshard/logging"
+	"devshard/observability"
+	"devshard/types"
+)
+
+// ErrReconcileGap is returned when an incoming diff skips ahead of in-memory
+// LatestNonce and the durable store cannot supply a contiguous fill range.
+var ErrReconcileGap = errors.New("cannot reconcile nonce gap from store")
+
+// applyAndPersistReconciling applies a diff after healing any nonce gap from
+// durable storage (HA stale-standby path). Caller must hold h.mu on entry and
+// still holds it on return; the lock may be released briefly for GetDiffs.
+//
+// Happy path (diff.Nonce == memNonce+1 or stale): no store read.
+// Gap path (diff.Nonce > memNonce+1): load (memNonce+1)..(diff.Nonce-1) from
+// store, apply in memory without AppendDiff, then applyAndPersist the incoming
+// diff (Phase 1 makes an already-durable incoming nonce idempotent).
+func (h *Host) applyAndPersistReconciling(ctx context.Context, diff types.Diff) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		currentNonce := h.sm.LatestNonce()
+		if diff.Nonce <= currentNonce {
+			return nil
+		}
+		if diff.Nonce == currentNonce+1 {
+			return h.applyAndPersist(ctx, diff)
+		}
+
+		// Nonce gap: memory is behind shared durable state.
+		if h.store == nil {
+			return fmt.Errorf("%w: escrow %s mem=%d incoming=%d (no store)",
+				ErrReconcileGap, h.escrowID, currentNonce, diff.Nonce)
+		}
+
+		from := currentNonce + 1
+		to := diff.Nonce - 1
+		escrowID := h.escrowID
+		store := h.store
+
+		h.mu.Unlock()
+		records, err := store.GetDiffs(escrowID, from, to)
+		h.mu.Lock()
+		if err != nil {
+			return fmt.Errorf("reconcile get diffs %d..%d: %w", from, to, err)
+		}
+
+		// Another request may have advanced memory while unlocked.
+		currentNonce = h.sm.LatestNonce()
+		if diff.Nonce <= currentNonce {
+			return nil
+		}
+		if diff.Nonce == currentNonce+1 {
+			return h.applyAndPersist(ctx, diff)
+		}
+
+		from = currentNonce + 1
+		to = diff.Nonce - 1
+		records = filterDiffRecordsFrom(records, from)
+		if !durableRangeComplete(records, from, to) {
+			return fmt.Errorf("%w: escrow %s need %d..%d have %d record(s)",
+				ErrReconcileGap, h.escrowID, from, to, len(records))
+		}
+
+		logging.Info("reconcile_fast_forward",
+			"subsystem", "host",
+			"escrow_id", h.escrowID,
+			"from", from,
+			"to", to,
+			"incoming", diff.Nonce,
+		)
+		observability.IncReconcileFastForward()
+
+		for _, rec := range records {
+			if err := h.applyDurableRecordLocked(rec); err != nil {
+				return err
+			}
+		}
+		// Loop: apply incoming (or heal again if still gapped — shouldn't happen).
+	}
+}
+
+// applyDurableRecordLocked applies a diff that is already durable in the store.
+// It must not AppendDiff. Caller must hold h.mu.
+func (h *Host) applyDurableRecordLocked(rec types.DiffRecord) error {
+	currentNonce := h.sm.LatestNonce()
+	if rec.Nonce <= currentNonce {
+		return nil
+	}
+	if rec.Nonce != currentNonce+1 {
+		return fmt.Errorf("%w: durable apply expected nonce %d, got %d",
+			types.ErrInvalidNonce, currentNonce+1, rec.Nonce)
+	}
+	if err := h.checkDiffNonceLimitLocked(rec.Diff); err != nil {
+		return err
+	}
+
+	phaseBefore := h.sm.Phase()
+	h.sm.InjectWarmKeys(rec.WarmKeyDelta)
+	root, err := h.sm.ApplyDiff(rec.Diff)
+	if err != nil {
+		return fmt.Errorf("reconcile apply durable nonce %d: %w", rec.Nonce, err)
+	}
+	if len(rec.StateHash) > 0 && len(root) > 0 && !bytes.Equal(root, rec.StateHash) {
+		return fmt.Errorf("reconcile state hash mismatch at nonce %d", rec.Nonce)
+	}
+
+	h.mempool.RemoveIncluded(rec.Txs)
+	for _, tx := range rec.Txs {
+		if fi := tx.GetFinishInference(); fi != nil {
+			delete(h.completedResponses, fi.InferenceId)
+		}
+		if ti := tx.GetTimeoutInference(); ti != nil {
+			delete(h.completedResponses, ti.InferenceId)
+		}
+	}
+	h.recordValidationObsFromAppliedDiff(rec.Txs)
+	phaseAfter := h.sm.Phase()
+	settledNow := phaseBefore != types.PhaseSettlement && phaseAfter == types.PhaseSettlement
+	shouldSnapshot := settledNow || rec.Nonce%SnapshotInterval == 0
+	h.maybeSaveSnapshotLocked(rec.Nonce, shouldSnapshot, settledNow)
+	return nil
+}
+
+func filterDiffRecordsFrom(records []types.DiffRecord, from uint64) []types.DiffRecord {
+	if len(records) == 0 {
+		return records
+	}
+	out := records[:0]
+	for _, rec := range records {
+		if rec.Nonce >= from {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
+func durableRangeComplete(records []types.DiffRecord, from, to uint64) bool {
+	if from > to {
+		return true
+	}
+	want := int(to - from + 1)
+	if len(records) != want {
+		return false
+	}
+	for i, rec := range records {
+		if rec.Nonce != from+uint64(i) {
+			return false
+		}
+	}
+	return true
+}

--- a/devshard/host/reconcile_test.go
+++ b/devshard/host/reconcile_test.go
@@ -1,0 +1,204 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/state"
+	"devshard/storage"
+	"devshard/stub"
+	"devshard/types"
+)
+
+type countingGetDiffsStore struct {
+	storage.Storage
+	gets atomic.Int32
+}
+
+func (s *countingGetDiffsStore) GetDiffs(escrowID string, fromNonce, toNonce uint64) ([]types.DiffRecord, error) {
+	s.gets.Add(1)
+	return s.Storage.GetDiffs(escrowID, fromNonce, toNonce)
+}
+
+// seedEscrowDiffs writes signed diffs 1..through into store using a throwaway SM.
+// Returns the signed Diff values for later catch-up requests.
+func seedEscrowDiffs(t *testing.T, store storage.Storage, user *signing.Secp256k1Signer, hosts []*signing.Secp256k1Signer, through uint64) []types.Diff {
+	t.Helper()
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, store)
+	require.NoError(t, err)
+
+	out := make([]types.Diff, 0, through)
+	for n := uint64(1); n <= through; n++ {
+		var txs []*types.DevshardTx
+		if n == 1 {
+			txs = []*types.DevshardTx{testutil.StartTx(1)}
+		}
+		root, err := sm.ApplyLocal(n, txs)
+		require.NoError(t, err)
+		diff := testutil.SignDiffWithRoot(t, user, "escrow-1", n, txs, root)
+		require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{
+			Diff: diff, StateHash: root,
+		}))
+		out = append(out, diff)
+	}
+	return out
+}
+
+// newHostAtNonce builds a Host whose in-memory SM is at memNonce while store
+// already holds durable diffs through durableThrough (must be >= memNonce).
+func newHostAtNonce(
+	t *testing.T,
+	store storage.Storage,
+	user *signing.Secp256k1Signer,
+	hosts []*signing.Secp256k1Signer,
+	memNonce, durableThrough uint64,
+) *Host {
+	t.Helper()
+	require.LessOrEqual(t, memNonce, durableThrough)
+
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID: "escrow-1", Version: testutil.RuntimeTestVersion,
+		CreatorAddr: user.Address(), Config: config, Group: group, InitialBalance: 10000,
+	}))
+	allDiffs := seedEscrowDiffs(t, store, user, hosts, durableThrough)
+
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, store)
+	require.NoError(t, err)
+	for _, d := range allDiffs {
+		if d.Nonce > memNonce {
+			break
+		}
+		_, err := sm.ApplyDiff(d)
+		require.NoError(t, err)
+	}
+	require.Equal(t, memNonce, sm.LatestNonce())
+
+	h, err := NewHost(sm, hosts[0], stub.NewInferenceEngine(), "escrow-1", group, nil,
+		WithGrace(10), WithStorage(store), WithVerifier(verifier))
+	require.NoError(t, err)
+	return h
+}
+
+func TestHost_ReconcileFastForwardOnGap(t *testing.T) {
+	// Standby RAM at K=2, durable PG at N=5, catch-up starts at M+1=4 (K<M<N).
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	inner := storage.NewMemory()
+	store := &countingGetDiffsStore{Storage: inner}
+
+	const memNonce, durableN uint64 = 2, 5
+	h := newHostAtNonce(t, store, user, hosts, memNonce, durableN)
+
+	// Re-read durable diffs for the catch-up request (nonces 4 and 5).
+	recs, err := inner.GetDiffs("escrow-1", 4, 5)
+	require.NoError(t, err)
+	require.Len(t, recs, 2)
+	store.gets.Store(0) // reset after setup reads
+
+	resp, err := h.HandleRequest(context.Background(), HostRequest{
+		Diffs: []types.Diff{recs[0].Diff, recs[1].Diff},
+	})
+	require.NoError(t, err)
+	require.Equal(t, durableN, resp.Nonce)
+	require.Equal(t, durableN, h.LatestNonce())
+	require.GreaterOrEqual(t, store.gets.Load(), int32(1), "gap must trigger GetDiffs")
+
+	// Durable row count unchanged (fast-forward must not re-insert).
+	all, err := inner.GetDiffs("escrow-1", 1, durableN)
+	require.NoError(t, err)
+	require.Len(t, all, int(durableN))
+}
+
+func TestHost_ReconcileHappyPath_NoGetDiffs(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	inner := storage.NewMemory()
+	store := &countingGetDiffsStore{Storage: inner}
+
+	h := newHostAtNonce(t, store, user, hosts, 2, 2)
+	store.gets.Store(0)
+
+	// Contiguous next nonce — no gap, no store read.
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, inner)
+	require.NoError(t, err)
+	for _, rec := range mustGetDiffs(t, inner, 1, 2) {
+		_, err := sm.ApplyDiff(rec.Diff)
+		require.NoError(t, err)
+	}
+	root, err := sm.ApplyLocal(3, nil)
+	require.NoError(t, err)
+	diff3 := testutil.SignDiffWithRoot(t, user, "escrow-1", 3, nil, root)
+
+	store.gets.Store(0)
+	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff3}})
+	require.NoError(t, err)
+	require.Equal(t, int32(0), store.gets.Load(), "happy path must not GetDiffs")
+	require.Equal(t, uint64(3), h.LatestNonce())
+}
+
+func TestHost_ReconcileGapIncomplete_NoPartialApply(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	store := storage.NewMemory()
+
+	// Durable only through 2; memory at 1; request jumps to 5 → need fill 2..4
+	// but store lacks 3..4.
+	h := newHostAtNonce(t, store, user, hosts, 1, 2)
+
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, store)
+	require.NoError(t, err)
+	for _, rec := range mustGetDiffs(t, store, 1, 2) {
+		_, err := sm.ApplyDiff(rec.Diff)
+		require.NoError(t, err)
+	}
+	var root []byte
+	for n := uint64(3); n <= 5; n++ {
+		root, err = sm.ApplyLocal(n, nil)
+		require.NoError(t, err)
+	}
+	diff5 := testutil.SignDiffWithRoot(t, user, "escrow-1", 5, nil, root)
+
+	before := h.LatestNonce()
+	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff5}})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrReconcileGap), "got %v", err)
+	require.Equal(t, before, h.LatestNonce(), "memory must not advance on incomplete gap")
+}
+
+func mustGetDiffs(t *testing.T, store storage.Storage, from, to uint64) []types.DiffRecord {
+	t.Helper()
+	recs, err := store.GetDiffs("escrow-1", from, to)
+	require.NoError(t, err)
+	return recs
+}
+
+func TestDurableRangeComplete(t *testing.T) {
+	recs := []types.DiffRecord{
+		{Diff: types.Diff{Nonce: 3}},
+		{Diff: types.Diff{Nonce: 4}},
+		{Diff: types.Diff{Nonce: 5}},
+	}
+	require.True(t, durableRangeComplete(recs, 3, 5))
+	require.False(t, durableRangeComplete(recs[:2], 3, 5))
+	require.False(t, durableRangeComplete(recs, 2, 5))
+	require.True(t, durableRangeComplete(nil, 5, 4))
+}

--- a/devshard/observability/metrics_lifecycle.go
+++ b/devshard/observability/metrics_lifecycle.go
@@ -34,6 +34,11 @@ var (
 	buildInfo              *prometheus.GaugeVec
 	lifecycleInflight      prometheus.Gauge
 	fallbackDivisor        *prometheus.GaugeVec
+
+	// HA diff/persist consistency (see docs/proposals/ha-diff-persist-consistency.md).
+	diffPersistRetryTotal     *prometheus.CounterVec
+	diffForkDetectedTotal     *prometheus.CounterVec
+	reconcileFastForwardTotal prometheus.Counter
 )
 
 var durationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
@@ -136,6 +141,19 @@ func initRegistry() {
 		Help: "Fallback capacity divisor (max(active_escrows, 4)); source is load_map or floor4.",
 	}, []string{"source"})
 
+	diffPersistRetryTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "devshard_diff_persist_retry_total",
+		Help: "AppendDiff persist retries by result (success, exhausted, identical).",
+	}, []string{"result"})
+	diffForkDetectedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "devshard_diff_fork_detected_total",
+		Help: "Conflicting diff payloads at the same (escrow, nonce).",
+	}, []string{"escrow_id"})
+	reconcileFastForwardTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "devshard_reconcile_fast_forward_total",
+		Help: "Times a host fast-forwarded in-memory state from durable diffs (HA stale standby).",
+	})
+
 	registry.MustRegister(
 		inflight,
 		requestTerminalTotal,
@@ -156,6 +174,9 @@ func initRegistry() {
 		buildInfo,
 		lifecycleInflight,
 		fallbackDivisor,
+		diffPersistRetryTotal,
+		diffForkDetectedTotal,
+		reconcileFastForwardTotal,
 	)
 }
 
@@ -291,4 +312,30 @@ func SetFallbackDivisor(source string, divisor int) {
 	fallbackDivisor.Reset()
 	fallbackDivisor.WithLabelValues(source).Set(float64(divisor))
 }
+
+// IncDiffPersistRetry records one AppendDiff retry outcome (Phase 3).
+// result is typically "success", "exhausted", or "identical".
+func IncDiffPersistRetry(result string) {
+	ensureMetrics()
+	if result == "" {
+		result = "unknown"
+	}
+	diffPersistRetryTotal.WithLabelValues(result).Inc()
+}
+
+// IncDiffForkDetected records a same-nonce conflicting diff payload.
+func IncDiffForkDetected(escrowID string) {
+	ensureMetrics()
+	if escrowID == "" {
+		escrowID = "unknown"
+	}
+	diffForkDetectedTotal.WithLabelValues(escrowID).Inc()
+}
+
+// IncReconcileFastForward records a host RAM catch-up from durable diffs (Phase 2).
+func IncReconcileFastForward() {
+	ensureMetrics()
+	reconcileFastForwardTotal.Inc()
+}
+
 

--- a/devshard/observability/metrics_lifecycle_test.go
+++ b/devshard/observability/metrics_lifecycle_test.go
@@ -68,3 +68,25 @@ func TestIncValidationOrphanIncrementsCounter(t *testing.T) {
 		t.Fatalf("counter delta = %v, want 1", after-before)
 	}
 }
+
+func TestHADiffPersistMetricsIncrement(t *testing.T) {
+	ensureMetrics()
+
+	beforeFork := testutil.ToFloat64(diffForkDetectedTotal.WithLabelValues("esc-metrics"))
+	IncDiffForkDetected("esc-metrics")
+	if testutil.ToFloat64(diffForkDetectedTotal.WithLabelValues("esc-metrics"))-beforeFork != 1 {
+		t.Fatalf("diff_fork_detected delta want 1")
+	}
+
+	beforeRetry := testutil.ToFloat64(diffPersistRetryTotal.WithLabelValues("success"))
+	IncDiffPersistRetry("success")
+	if testutil.ToFloat64(diffPersistRetryTotal.WithLabelValues("success"))-beforeRetry != 1 {
+		t.Fatalf("diff_persist_retry delta want 1")
+	}
+
+	beforeFF := testutil.ToFloat64(reconcileFastForwardTotal)
+	IncReconcileFastForward()
+	if testutil.ToFloat64(reconcileFastForwardTotal)-beforeFF != 1 {
+		t.Fatalf("reconcile_fast_forward delta want 1")
+	}
+}

--- a/devshard/observability/testhelpers.go
+++ b/devshard/observability/testhelpers.go
@@ -9,3 +9,21 @@ func RequestTerminalCounterForTest(terminal Terminal, reason Reason) prometheus.
 	ensureMetrics()
 	return requestTerminalTotal.WithLabelValues(string(terminal), string(reason))
 }
+
+// DiffForkDetectedForTest exposes the fork counter for unit tests.
+func DiffForkDetectedForTest(escrowID string) prometheus.Counter {
+	ensureMetrics()
+	if escrowID == "" {
+		escrowID = "unknown"
+	}
+	return diffForkDetectedTotal.WithLabelValues(escrowID)
+}
+
+// DiffPersistRetryForTest exposes the persist-retry counter for unit tests.
+func DiffPersistRetryForTest(result string) prometheus.Counter {
+	ensureMetrics()
+	if result == "" {
+		result = "unknown"
+	}
+	return diffPersistRetryTotal.WithLabelValues(result)
+}

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -97,7 +97,42 @@ type StateMachine struct {
 	totalSlots         uint32
 
 	warmResolver    WarmKeyResolver       // optional, nil = no warm key support
+
+	// obsDeferred, when non-nil, redirects observability writes made during a
+	// trial apply (ValidateDiff / PreviewLocalBestEffort) into a buffer instead
+	// of the inference store. The buffer is flushed by CommitValidated once the
+	// diff is durably persisted, so persist-first neither double-writes obs
+	// (validate + apply) nor leaves obs rows for a diff that never committed.
+	// Set only while sm.mu is held during a trial apply.
+	obsDeferred *[]deferredObsWrite
 }
+
+// deferredObsWrite is a single observability-store write captured during a
+// trial apply and replayed at commit time. All obs writes are observability
+// only (never part of post_state_root) and best-effort on replay: recovery
+// rebuilds obs from the diff journal.
+type deferredObsWrite struct {
+	id    uint64
+	row   storage.InferenceRow
+	drain bool
+}
+
+// ValidatedDiff carries the precomputed result of a trial apply so a subsequent
+// CommitValidated can install the post-state without re-running applyCore.
+// The mutable snapshot captures exactly the fields applyCore mutates, so
+// installing it is equivalent to re-applying (minus the obs writes, which are
+// buffered in obs and flushed on commit).
+type ValidatedDiff struct {
+	Root      []byte
+	WarmAfter map[uint32]string
+	Applied   []*types.DevshardTx // populated for the best-effort (gateway) path
+	nonce     uint64
+	post      mutableSnapshot
+	obs       []deferredObsWrite
+}
+
+// Nonce reports the nonce this validated diff will commit.
+func (vd *ValidatedDiff) Nonce() uint64 { return vd.nonce }
 
 // SMOption configures optional StateMachine behavior.
 type SMOption func(*StateMachine)
@@ -214,25 +249,59 @@ func NewStateMachine(
 // ApplyDiff validates user signature and post_state_root, then applies the diff.
 // Returns the computed state root.
 func (sm *StateMachine) ApplyDiff(diff types.Diff) ([]byte, error) {
-	// 1. Verify user signature (covers nonce, txs, escrow_id, post_state_root).
-	diffContent := BuildDiffContent(sm.state.EscrowID, diff.Nonce, diff.Txs, diff.PostStateRoot)
-	data, err := deterministicMarshal.Marshal(diffContent)
-	if err != nil {
-		return nil, fmt.Errorf("marshal diff content: %w", err)
+	if err := sm.verifyDiffUserSig(diff); err != nil {
+		return nil, err
 	}
 
-	recovered, err := sm.verifier.RecoverAddress(data, diff.UserSig)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", types.ErrInvalidUserSig, err)
-	}
-	if recovered != sm.userAddress {
-		return nil, fmt.Errorf("%w: expected %s, got %s", types.ErrInvalidUserSig, sm.userAddress, recovered)
-	}
-
-	// 2. Apply txs and verify post_state_root atomically.
+	// Apply txs and verify post_state_root atomically.
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	return sm.applyCore(diff.Nonce, diff.Txs, diff.PostStateRoot, "host")
+}
+
+// ValidateDiff verifies the user signature and trial-applies the diff (nonce,
+// txs, post_state_root) against a snapshot that is restored before return. The
+// live state is unchanged. Used for persist-first: validate → persist →
+// CommitValidated. The returned handle carries the precomputed post-state so
+// CommitValidated installs it without a second applyCore, and buffers the obs
+// writes so they are flushed exactly once, on commit.
+func (sm *StateMachine) ValidateDiff(diff types.Diff) (*ValidatedDiff, error) {
+	if err := sm.verifyDiffUserSig(diff); err != nil {
+		return nil, err
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	pre := sm.snapshotMutable()
+	var obs []deferredObsWrite
+	sm.obsDeferred = &obs
+	root, err := sm.applyCore(diff.Nonce, diff.Txs, diff.PostStateRoot, "host")
+	sm.obsDeferred = nil
+	if err != nil {
+		// applyCore self-restores mutable state on every error path.
+		return nil, err
+	}
+	post := sm.snapshotMutable()
+	warmAfter := copyStringMap(sm.state.WarmKeys)
+	sm.restoreMutable(pre)
+	return &ValidatedDiff{Root: root, WarmAfter: warmAfter, nonce: diff.Nonce, post: post, obs: obs}, nil
+}
+
+func (sm *StateMachine) verifyDiffUserSig(diff types.Diff) error {
+	diffContent := BuildDiffContent(sm.state.EscrowID, diff.Nonce, diff.Txs, diff.PostStateRoot)
+	data, err := deterministicMarshal.Marshal(diffContent)
+	if err != nil {
+		return fmt.Errorf("marshal diff content: %w", err)
+	}
+	recovered, err := sm.verifier.RecoverAddress(data, diff.UserSig)
+	if err != nil {
+		return fmt.Errorf("%w: %v", types.ErrInvalidUserSig, err)
+	}
+	if recovered != sm.userAddress {
+		return fmt.Errorf("%w: expected %s, got %s", types.ErrInvalidUserSig, sm.userAddress, recovered)
+	}
+	return nil
 }
 
 // ApplyLocal applies txs without signature verification. Used by the user
@@ -249,7 +318,89 @@ func (sm *StateMachine) ApplyLocal(nonce uint64, txs []*types.DevshardTx) ([]byt
 func (sm *StateMachine) ApplyLocalBestEffort(nonce uint64, txs []*types.DevshardTx) ([]byte, []*types.DevshardTx, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+	return sm.localBestEffortLocked(nonce, txs)
+}
 
+// PreviewLocalBestEffort is the validate-on-clone form of ApplyLocalBestEffort:
+// it trial-applies candidates and returns a handle carrying root, the applied
+// subset, warm keys and the precomputed post-state, then restores mutable state
+// so the live SM is unchanged. Used for persist-first compose: preview →
+// persist → CommitValidated (which installs the post-state without recompute).
+func (sm *StateMachine) PreviewLocalBestEffort(nonce uint64, txs []*types.DevshardTx) (*ValidatedDiff, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	pre := sm.snapshotMutable()
+	var obs []deferredObsWrite
+	sm.obsDeferred = &obs
+	root, applied, err := sm.localBestEffortLocked(nonce, txs)
+	sm.obsDeferred = nil
+	if err != nil {
+		// localBestEffortLocked self-restores mutable state on every error path.
+		return nil, err
+	}
+	warmAfter := copyStringMap(sm.state.WarmKeys)
+	post := sm.snapshotMutable()
+	sm.restoreMutable(pre)
+	return &ValidatedDiff{Root: root, WarmAfter: warmAfter, Applied: applied, nonce: nonce, post: post, obs: obs}, nil
+}
+
+// CommitValidated installs a previously validated diff's post-state and flushes
+// its buffered observability writes. It reports false without mutating state
+// when the live nonce already advanced to or past the validated nonce (another
+// writer committed the same nonce while persist was in flight); the caller must
+// then treat the diff as already applied. Caller must not hold sm.mu.
+func (sm *StateMachine) CommitValidated(vd *ValidatedDiff) bool {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	// The post snapshot was computed against LatestNonce == vd.nonce-1. It is
+	// only valid to install when the live state is still at that point. Any
+	// mutation to this SM advances the nonce, so an unchanged nonce means no
+	// intervening change; a mismatch means someone else already committed.
+	if vd.nonce != sm.state.LatestNonce+1 {
+		return false
+	}
+	sm.restoreMutable(vd.post)
+	sm.flushDeferredObsLocked(vd.obs)
+	return true
+}
+
+// flushDeferredObsLocked replays observability writes buffered during a trial
+// apply. Best-effort: obs is never part of post_state_root and recovery
+// rebuilds it from the diff journal, so a storage blip here must not fail the
+// commit. Caller must hold sm.mu.
+func (sm *StateMachine) flushDeferredObsLocked(writes []deferredObsWrite) {
+	for _, w := range writes {
+		if err := sm.inferenceStore.InsertSealedInference(sm.state.EscrowID, w.row); err != nil {
+			logging.Warn("failed to persist deferred inference obs; continuing (best-effort, recovery rebuilds from diffs)",
+				"subsystem", "state",
+				"escrow_id", sm.state.EscrowID,
+				"inference_id", w.id,
+				"error", err,
+			)
+			continue
+		}
+		if w.drain {
+			if err := sm.inferenceStore.DrainInferenceValidationObs(sm.state.EscrowID, w.id); err != nil {
+				logging.Warn("failed to drain deferred validation obs; continuing (best-effort)",
+					"subsystem", "state",
+					"escrow_id", sm.state.EscrowID,
+					"inference_id", w.id,
+					"error", err,
+				)
+			}
+		}
+	}
+}
+
+// localBestEffortLocked implements ApplyLocalBestEffort and the trial-apply core
+// of PreviewLocalBestEffort. It applies txs one by one (skipping non-mandatory
+// failures) and, on success, leaves the mutable state advanced to nonce. On any
+// error it self-restores the mutable state before returning. Caller must hold
+// sm.mu. The preview/restore-on-success and warm-key capture that persist-first
+// needs are handled by the PreviewLocalBestEffort wrapper.
+func (sm *StateMachine) localBestEffortLocked(nonce uint64, txs []*types.DevshardTx) ([]byte, []*types.DevshardTx, error) {
 	// Snapshot mutable state so fee charging and root computation remain atomic
 	// with respect to this nonce, matching applyCore semantics.
 	snap := sm.snapshotMutable()
@@ -342,6 +493,15 @@ func (sm *StateMachine) ApplyLocalBestEffort(nonce uint64, txs []*types.Devshard
 		"config_fee_per_nonce", sm.state.Config.FeePerNonce,
 	)
 	return root, applied, nil
+}
+
+func copyStringMap(m map[uint32]string) map[uint32]string {
+	if len(m) == 0 {
+		return nil
+	}
+	cp := make(map[uint32]string, len(m))
+	maps.Copy(cp, m)
+	return cp
 }
 
 // applyCore validates nonce, applies txs, updates nonce, and returns the state root.

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -98,6 +98,66 @@ func TestApplyDiff_UserSigVerification(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateDiff_DoesNotCommit(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	sm, user := newTestSM(t, hosts, 10000)
+
+	txs := []*types.DevshardTx{txStart(&types.MsgStartInference{
+		InferenceId: 1,
+		PromptHash:  []byte("prompt"),
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	})}
+	// Build a correctly signed diff via a throwaway SM so PostStateRoot matches.
+	probe, _ := newTestSM(t, hosts, 10000)
+	root, err := probe.ApplyLocal(1, txs)
+	require.NoError(t, err)
+	diff := testutil.SignDiffWithRoot(t, user, "escrow-1", 1, txs, root)
+
+	vd, err := sm.ValidateDiff(diff)
+	require.NoError(t, err)
+	require.Equal(t, root, vd.Root)
+	require.Equal(t, uint64(0), sm.LatestNonce(), "ValidateDiff must not commit")
+
+	// CommitValidated installs the precomputed post-state without recompute.
+	require.True(t, sm.CommitValidated(vd))
+	require.Equal(t, uint64(1), sm.LatestNonce())
+	committedRoot, err := sm.ComputeStateRoot()
+	require.NoError(t, err)
+	require.Equal(t, root, committedRoot)
+
+	// A second commit of the same handle is a no-op (nonce already advanced).
+	require.False(t, sm.CommitValidated(vd))
+	require.Equal(t, uint64(1), sm.LatestNonce())
+}
+
+func TestPreviewLocalBestEffort_DoesNotCommit(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	sm, _ := newTestSM(t, hosts, 10000)
+
+	txs := []*types.DevshardTx{txStart(&types.MsgStartInference{
+		InferenceId: 1,
+		PromptHash:  []byte("prompt"),
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	})}
+	vd, err := sm.PreviewLocalBestEffort(1, txs)
+	require.NoError(t, err)
+	require.Len(t, vd.Applied, 1)
+	require.NotEmpty(t, vd.Root)
+	require.Equal(t, uint64(0), sm.LatestNonce(), "PreviewLocalBestEffort must not commit")
+
+	root2, applied2, err := sm.ApplyLocalBestEffort(1, txs)
+	require.NoError(t, err)
+	require.Equal(t, vd.Root, root2)
+	require.Len(t, applied2, 1)
+	require.Equal(t, uint64(1), sm.LatestNonce())
+}
+
 func TestApplyDiff_StartInference(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	sm, user := newTestSM(t, hosts, 10000)
@@ -3098,6 +3158,60 @@ type failingObsInsertStore struct {
 
 func (s *failingObsInsertStore) InsertSealedInference(escrowID string, row storage.InferenceRow) error {
 	return fmt.Errorf("injected obs insert failure")
+}
+
+type countingObsInsertStore struct {
+	*storage.Memory
+	inserts int
+}
+
+func (s *countingObsInsertStore) InsertSealedInference(escrowID string, row storage.InferenceRow) error {
+	s.inserts++
+	return s.Memory.InsertSealedInference(escrowID, row)
+}
+
+// TestPersistFirst_ObsDeferredUntilCommit pins the persist-first obs contract:
+// a trial apply (ValidateDiff) writes no observability rows, and CommitValidated
+// flushes them. Without deferral, obs would be written during validate (before
+// persist) and again on apply.
+func TestPersistFirst_ObsDeferredUntilCommit(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+
+	// User-side SM produces a correctly signed challenge diff (Valid:false vote
+	// drives StatusChallenged, which triggers an obs write).
+	userSM, err := NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier,
+		testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	applyStartConfirmFinish(t, userSM, user, hosts, 1)
+	valMsg := &types.MsgValidation{InferenceId: 1, ValidatorSlot: 0, Valid: false, EscrowId: "escrow-1"}
+	valMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], valMsg)
+	nonce := userSM.SnapshotState().LatestNonce + 1
+	root, applied, err := userSM.ApplyLocalBestEffort(nonce, []*types.DevshardTx{txValidation(valMsg)})
+	require.NoError(t, err)
+	diff := testutil.SignDiffWithRoot(t, user, "escrow-1", nonce, applied, root)
+
+	// Host-side SM with a counting obs store.
+	countStore := &countingObsInsertStore{Memory: testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000)}
+	hostSM, err := NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, countStore)
+	require.NoError(t, err)
+	applyStartConfirmFinish(t, hostSM, user, hosts, 1)
+
+	insertsAfterSetup := countStore.inserts
+	vd, err := hostSM.ValidateDiff(diff)
+	require.NoError(t, err)
+	require.Equal(t, nonce-1, hostSM.LatestNonce(), "ValidateDiff must not commit")
+	require.Equal(t, insertsAfterSetup, countStore.inserts, "ValidateDiff must not write obs (deferred)")
+
+	require.True(t, hostSM.CommitValidated(vd))
+	require.Equal(t, nonce, hostSM.LatestNonce())
+	require.Greater(t, countStore.inserts, insertsAfterSetup, "CommitValidated must flush the deferred obs write")
+	require.Equal(t, types.StatusChallenged, hostSM.SnapshotState().Inferences[1].Status)
 }
 
 func TestApplyLocalBestEffort_ChallengeObsInsertFailure_StillApplied(t *testing.T) {

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -642,7 +642,16 @@ func (sm *StateMachine) persistLiveInferenceObsBestEffortLocked(id uint64, rec *
 // On seal, DrainInferenceValidationObs moves live validation counters into sealed storage.
 // Caller must hold sm.mu.
 func (sm *StateMachine) upsertInferenceObsLocked(id, sealedNonce uint64, rec *types.InferenceRecord) error {
-	if err := sm.inferenceStore.InsertSealedInference(sm.state.EscrowID, inferenceObsRow(id, sealedNonce, rec)); err != nil {
+	row := inferenceObsRow(id, sealedNonce, rec)
+	// During a trial apply (persist-first validate/preview) buffer the write and
+	// replay it at commit, so obs is written exactly once and never for a diff
+	// that fails to persist. The row is resolved eagerly here because rec is
+	// mutated/restored after the trial apply returns.
+	if sm.obsDeferred != nil {
+		*sm.obsDeferred = append(*sm.obsDeferred, deferredObsWrite{id: id, row: row, drain: sealedNonce > 0})
+		return nil
+	}
+	if err := sm.inferenceStore.InsertSealedInference(sm.state.EscrowID, row); err != nil {
 		return err
 	}
 	if sealedNonce > 0 {

--- a/devshard/storage/append_diff_idempotent_test.go
+++ b/devshard/storage/append_diff_idempotent_test.go
@@ -1,0 +1,122 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"devshard/observability"
+	"devshard/types"
+)
+
+func runAppendDiff_IdempotentReplay(t *testing.T, store Storage) {
+	t.Helper()
+	require.NoError(t, store.CreateSession(defaultParams()))
+
+	rec := makeDiffRecord(1)
+	require.NoError(t, store.AppendDiff("escrow-1", rec))
+	require.NoError(t, store.AppendDiff("escrow-1", rec), "identical replay must succeed")
+
+	diffs, err := store.GetDiffs("escrow-1", 1, 1)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	require.Equal(t, uint64(1), diffs[0].Nonce)
+	require.Equal(t, rec.StateHash, diffs[0].StateHash)
+
+	meta, err := store.GetSessionMeta("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), meta.LatestNonce)
+}
+
+func runAppendDiff_ForkConflict(t *testing.T, store Storage) {
+	t.Helper()
+	require.NoError(t, store.CreateSession(defaultParams()))
+	require.NoError(t, store.AppendDiff("escrow-1", makeDiffRecord(1)))
+
+	before := testutil.ToFloat64(observability.DiffForkDetectedForTest("escrow-1"))
+
+	conflict := makeDiffRecord(1)
+	conflict.StateHash = []byte("different-hash")
+	err := store.AppendDiff("escrow-1", conflict)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrDiffFork), "got %v", err)
+
+	after := testutil.ToFloat64(observability.DiffForkDetectedForTest("escrow-1"))
+	require.Equal(t, before+1, after, "diff_fork_detected must increment")
+
+	diffs, err := store.GetDiffs("escrow-1", 1, 1)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	require.Equal(t, []byte{1}, diffs[0].StateHash, "original row must stay intact")
+}
+
+func runAppendDiff_MonotonicUnchanged(t *testing.T, store Storage) {
+	t.Helper()
+	require.NoError(t, store.CreateSession(defaultParams()))
+	require.NoError(t, store.AppendDiff("escrow-1", makeDiffRecord(1)))
+	require.NoError(t, store.AppendDiff("escrow-1", makeDiffRecord(2)))
+	require.NoError(t, store.AppendDiff("escrow-1", makeDiffRecord(3)))
+
+	diffs, err := store.GetDiffs("escrow-1", 1, 3)
+	require.NoError(t, err)
+	require.Len(t, diffs, 3)
+	for i, d := range diffs {
+		require.Equal(t, uint64(i+1), d.Nonce)
+	}
+}
+
+func TestMemory_AppendDiff_IdempotentReplay(t *testing.T) {
+	runAppendDiff_IdempotentReplay(t, NewMemory())
+}
+
+func TestMemory_AppendDiff_ForkConflict(t *testing.T) {
+	runAppendDiff_ForkConflict(t, NewMemory())
+}
+
+func TestMemory_AppendDiff_MonotonicUnchanged(t *testing.T) {
+	runAppendDiff_MonotonicUnchanged(t, NewMemory())
+}
+
+func TestSQLite_AppendDiff_IdempotentReplay(t *testing.T) {
+	runAppendDiff_IdempotentReplay(t, newTestSQLite(t))
+}
+
+func TestSQLite_AppendDiff_ForkConflict(t *testing.T) {
+	runAppendDiff_ForkConflict(t, newTestSQLite(t))
+}
+
+func TestSQLite_AppendDiff_MonotonicUnchanged(t *testing.T) {
+	runAppendDiff_MonotonicUnchanged(t, newTestSQLite(t))
+}
+
+func TestPostgres_AppendDiff_IdempotentReplay(t *testing.T) {
+	runAppendDiff_IdempotentReplay(t, newTestPostgres(t))
+}
+
+func TestPostgres_AppendDiff_ForkConflict(t *testing.T) {
+	runAppendDiff_ForkConflict(t, newTestPostgres(t))
+}
+
+func TestPostgres_AppendDiff_MonotonicUnchanged(t *testing.T) {
+	runAppendDiff_MonotonicUnchanged(t, newTestPostgres(t))
+}
+
+// Ensure makeDiffRecord warm-key / txs empty paths still fork on UserSig.
+func TestMemory_AppendDiff_ForkOnUserSig(t *testing.T) {
+	store := NewMemory()
+	require.NoError(t, store.CreateSession(defaultParams()))
+	require.NoError(t, store.AppendDiff("escrow-1", makeDiffRecord(1)))
+
+	conflict := types.DiffRecord{
+		Diff: types.Diff{
+			Nonce:   1,
+			UserSig: []byte("other-sig"),
+		},
+		StateHash:  []byte{1},
+		Signatures: map[uint32][]byte{0: {1}},
+	}
+	err := store.AppendDiff("escrow-1", conflict)
+	require.ErrorIs(t, err, ErrDiffFork)
+}

--- a/devshard/storage/diff_identity.go
+++ b/devshard/storage/diff_identity.go
@@ -1,0 +1,80 @@
+package storage
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"devshard/observability"
+	"devshard/types"
+)
+
+// ErrDiffFork is returned when AppendDiff finds an existing row at the same
+// (escrow, nonce) whose payload differs from the candidate. Identical replay
+// is success (HA at-least-once); a payload conflict is a real state fork.
+var ErrDiffFork = errors.New("diff fork: conflicting payload at same nonce")
+
+// HA assumptions for AppendDiff / host catch-up (proposal §7.5):
+//
+//  1. The gateway (devshardctl) is the single-instance sequencer per escrow, so
+//     composeDiffLocked never races another writer on the same nonce. Persist-
+//     first compose makes persist failure "store unchanged, memory unchanged".
+//  2. Host duplicates under multi-instance HA are byte-identical because the
+//     gateway sequenced them — which is why ON CONFLICT DO NOTHING + identity
+//     check is correct rather than lossy.
+//
+// See docs/proposals/ha-diff-persist-consistency.md.
+
+// checkDiffReplayIdentity returns nil when want and have are the same durable
+// diff payload (idempotent replay). On mismatch it increments
+// diff_fork_detected and returns ErrDiffFork.
+//
+// Compared: UserSig, PostStateRoot, StateHash, Txs, WarmKeyDelta.
+// Not compared: CreatedAt (may differ across writers), Signatures (upserted
+// separately with ON CONFLICT DO UPDATE).
+func checkDiffReplayIdentity(escrowID string, want, have types.DiffRecord) error {
+	if want.Nonce != have.Nonce ||
+		!bytes.Equal(want.UserSig, have.UserSig) ||
+		!bytes.Equal(want.PostStateRoot, have.PostStateRoot) ||
+		!bytes.Equal(want.StateHash, have.StateHash) ||
+		!equalWarmKeyDelta(want.WarmKeyDelta, have.WarmKeyDelta) ||
+		!equalTxs(want.Txs, have.Txs) {
+		observability.IncDiffForkDetected(escrowID)
+		slog.Error("diff_fork_detected",
+			"escrow_id", escrowID,
+			"nonce", want.Nonce,
+			"error", ErrDiffFork,
+		)
+		return fmt.Errorf("%w: escrow %s nonce %d", ErrDiffFork, escrowID, want.Nonce)
+	}
+	return nil
+}
+
+// checkDiffReplayIdentityRaw compares a candidate against durable columns
+// without unmarshaling txs (Postgres/SQLite conflict path).
+func checkDiffReplayIdentityRaw(
+	escrowID string,
+	nonce uint64,
+	wantTxsProto, wantUserSig, wantPost, wantHash []byte,
+	wantWarmJSON *string,
+	haveTxsProto, haveUserSig, havePost, haveHash []byte,
+	haveWarmJSON *string,
+) error {
+	warmEqual := (wantWarmJSON == nil && haveWarmJSON == nil) ||
+		(wantWarmJSON != nil && haveWarmJSON != nil && *wantWarmJSON == *haveWarmJSON)
+	if !bytes.Equal(wantTxsProto, haveTxsProto) ||
+		!bytes.Equal(wantUserSig, haveUserSig) ||
+		!bytes.Equal(wantPost, havePost) ||
+		!bytes.Equal(wantHash, haveHash) ||
+		!warmEqual {
+		observability.IncDiffForkDetected(escrowID)
+		slog.Error("diff_fork_detected",
+			"escrow_id", escrowID,
+			"nonce", nonce,
+			"error", ErrDiffFork,
+		)
+		return fmt.Errorf("%w: escrow %s nonce %d", ErrDiffFork, escrowID, nonce)
+	}
+	return nil
+}

--- a/devshard/storage/interface.go
+++ b/devshard/storage/interface.go
@@ -9,6 +9,10 @@ import (
 // ErrSessionNotFound is returned when a session does not exist in storage.
 var ErrSessionNotFound = errors.New("session not found")
 
+// ErrSessionNotActive is returned when a session exists in storage but is not
+// status "active" (typically "settled"). Callers must not recover or serve it.
+var ErrSessionNotActive = errors.New("session not active")
+
 // ErrSessionEpochConflict is returned when local storage finds the same
 // escrow_id mapped to more than one epoch. Mainnet pins this mapping on the
 // DevshardEscrow, so local storage must not choose a different epoch silently.
@@ -45,6 +49,9 @@ var ErrEscrowCacheNotFound = errors.New("escrow cache not found")
 // so callers should surface it as "initializing" / 503 rather than a 500.
 var ErrStorageIndexRebuilding = errors.New("devshard postgres session index is rebuilding")
 
+// ErrDiffFork is defined in diff_identity.go and returned by AppendDiff when
+// an existing durable row at the same nonce has a conflicting payload.
+
 // Storage persists devshard session state and diffs.
 //
 // The store is partitioned by EpochID. PruneEpoch drops everything that
@@ -57,6 +64,9 @@ type Storage interface {
 	CreateSession(params CreateSessionParams) error
 	MarkSettled(escrowID string) error
 	ListActiveSessions() ([]ActiveSession, error)
+	// AppendDiff persists one diff. Identical replay of the same
+	// (escrow, nonce) payload is idempotent success (HA at-least-once). A
+	// different payload at the same nonce returns ErrDiffFork.
 	AppendDiff(escrowID string, rec types.DiffRecord) error
 	GetDiffs(escrowID string, fromNonce, toNonce uint64) ([]types.DiffRecord, error)
 	AddSignature(escrowID string, nonce uint64, slotID uint32, sig []byte) error

--- a/devshard/storage/memory.go
+++ b/devshard/storage/memory.go
@@ -145,8 +145,20 @@ func (m *Memory) AppendDiff(escrowID string, rec types.DiffRecord) error {
 		return fmt.Errorf("session %s not found", escrowID)
 	}
 
-	if _, exists := s.nonceToIndex[rec.Nonce]; exists {
-		return fmt.Errorf("duplicate nonce %d for session %s", rec.Nonce, escrowID)
+	if idx, exists := s.nonceToIndex[rec.Nonce]; exists {
+		existing := s.diffs[idx]
+		if err := checkDiffReplayIdentity(escrowID, rec, existing); err != nil {
+			return err
+		}
+		// Mirror Postgres/SQLite: upsert signatures on identical replay.
+		if existing.Signatures == nil {
+			existing.Signatures = make(map[uint32][]byte, len(rec.Signatures))
+		}
+		for slotID, sig := range rec.Signatures {
+			existing.Signatures[slotID] = append([]byte(nil), sig...)
+		}
+		s.diffs[idx] = existing
+		return nil
 	}
 
 	rec.Signatures = copySignatures(rec.Signatures)

--- a/devshard/storage/memory_test.go
+++ b/devshard/storage/memory_test.go
@@ -70,20 +70,7 @@ func TestMemory_PruneEpoch_WriteAfter(t *testing.T) {
 	runPruneEpoch_WriteAfter(t, NewMemory())
 }
 
-func TestMemory_DuplicateNonce(t *testing.T) {
-	store := NewMemory()
-	err := store.CreateSession(defaultParams())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = store.AppendDiff("escrow-1", makeDiffRecord(1))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = store.AppendDiff("escrow-1", makeDiffRecord(1))
-	if err == nil {
-		t.Fatal("expected error on duplicate nonce")
-	}
+func TestMemory_DuplicateNonce_IdenticalReplayOK(t *testing.T) {
+	// Identical same-nonce replay is idempotent (HA); see AppendDiff docs.
+	runAppendDiff_IdempotentReplay(t, NewMemory())
 }

--- a/devshard/storage/persist_retry.go
+++ b/devshard/storage/persist_retry.go
@@ -1,0 +1,87 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"devshard/observability"
+	"devshard/types"
+)
+
+// ErrPersistExhausted is returned when AppendDiffWithRetry fails every attempt
+// (excluding ErrDiffFork, which is not retried).
+var ErrPersistExhausted = errors.New("diff persist retries exhausted")
+
+const (
+	// DefaultPersistMaxAttempts is the number of AppendDiff tries (including the first).
+	DefaultPersistMaxAttempts = 4
+	// DefaultPersistBaseDelay is the first backoff; doubles each retry.
+	DefaultPersistBaseDelay = 50 * time.Millisecond
+)
+
+// AppendDiffWithRetry calls store.AppendDiff with bounded exponential backoff.
+// Identical-replay success from Phase 1 AppendDiff ends the loop immediately.
+// ErrDiffFork is returned without retry. On exhaustion wraps ErrPersistExhausted.
+//
+// result label on devshard_diff_persist_retry_total:
+//   - "success" — succeeded after at least one failed attempt
+//   - "exhausted" — all attempts failed
+func AppendDiffWithRetry(ctx context.Context, store Storage, escrowID string, rec types.DiffRecord) error {
+	return AppendDiffWithRetryUnlocked(ctx, store, escrowID, rec, nil, nil)
+}
+
+// AppendDiffWithRetryUnlocked is AppendDiffWithRetry with optional lock/unlock
+// callbacks invoked around each backoff sleep, letting a caller release a mutex
+// while it waits (the host holds h.mu across apply, so it unlocks during
+// backoff; the gateway holds s.mu the whole time and passes nil). unlock is
+// called before sleeping and lock after — including on the ctx-cancel path, so
+// the caller always regains the lock before this returns. Both may be nil.
+func AppendDiffWithRetryUnlocked(ctx context.Context, store Storage, escrowID string, rec types.DiffRecord, lock, unlock func()) error {
+	if store == nil {
+		return fmt.Errorf("AppendDiffWithRetry: nil store")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var last error
+	for attempt := 1; attempt <= DefaultPersistMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		last = store.AppendDiff(escrowID, rec)
+		if last == nil {
+			if attempt > 1 {
+				observability.IncDiffPersistRetry("success")
+			}
+			return nil
+		}
+		if errors.Is(last, ErrDiffFork) {
+			return last
+		}
+		if attempt == DefaultPersistMaxAttempts {
+			break
+		}
+		delay := DefaultPersistBaseDelay * time.Duration(1<<(attempt-1))
+		timer := time.NewTimer(delay)
+		if unlock != nil {
+			unlock()
+		}
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			if lock != nil {
+				lock()
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+		if lock != nil {
+			lock()
+		}
+	}
+	observability.IncDiffPersistRetry("exhausted")
+	return fmt.Errorf("%w: %w", ErrPersistExhausted, last)
+}

--- a/devshard/storage/persist_retry_test.go
+++ b/devshard/storage/persist_retry_test.go
@@ -1,0 +1,93 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/types"
+)
+
+type flakyAppendStore struct {
+	Storage
+	failsLeft atomic.Int32
+	calls     atomic.Int32
+}
+
+func (s *flakyAppendStore) AppendDiff(escrowID string, rec types.DiffRecord) error {
+	s.calls.Add(1)
+	if s.failsLeft.Add(-1) >= 0 {
+		return errors.New("transient append failure")
+	}
+	return s.Storage.AppendDiff(escrowID, rec)
+}
+
+func TestAppendDiffWithRetry_SucceedsAfterTransientFailures(t *testing.T) {
+	inner := NewMemory()
+	require.NoError(t, inner.CreateSession(defaultParams()))
+	store := &flakyAppendStore{Storage: inner}
+	store.failsLeft.Store(2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, AppendDiffWithRetry(ctx, store, "escrow-1", makeDiffRecord(1)))
+	require.Equal(t, int32(3), store.calls.Load())
+	diffs, err := inner.GetDiffs("escrow-1", 1, 1)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+}
+
+func TestAppendDiffWithRetry_Exhausted(t *testing.T) {
+	inner := NewMemory()
+	require.NoError(t, inner.CreateSession(defaultParams()))
+	store := &flakyAppendStore{Storage: inner}
+	store.failsLeft.Store(100)
+
+	err := AppendDiffWithRetry(context.Background(), store, "escrow-1", makeDiffRecord(1))
+	require.ErrorIs(t, err, ErrPersistExhausted)
+	require.Equal(t, int32(DefaultPersistMaxAttempts), store.calls.Load())
+}
+
+func TestAppendDiffWithRetry_ForkNoRetry(t *testing.T) {
+	inner := NewMemory()
+	require.NoError(t, inner.CreateSession(defaultParams()))
+	require.NoError(t, inner.AppendDiff("escrow-1", makeDiffRecord(1)))
+
+	conflict := makeDiffRecord(1)
+	conflict.StateHash = []byte("other")
+	calls := 0
+	store := &countingAppendOnce{Storage: inner, onAppend: func() { calls++ }}
+	err := AppendDiffWithRetry(context.Background(), store, "escrow-1", conflict)
+	require.ErrorIs(t, err, ErrDiffFork)
+	require.Equal(t, 1, calls, "fork must not retry")
+}
+
+type countingAppendOnce struct {
+	Storage
+	onAppend func()
+}
+
+func (s *countingAppendOnce) AppendDiff(escrowID string, rec types.DiffRecord) error {
+	if s.onAppend != nil {
+		s.onAppend()
+	}
+	return s.Storage.AppendDiff(escrowID, rec)
+}
+
+func TestAppendDiffWithRetry_ContextCancel(t *testing.T) {
+	inner := NewMemory()
+	require.NoError(t, inner.CreateSession(defaultParams()))
+	store := &flakyAppendStore{Storage: inner}
+	store.failsLeft.Store(100)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := AppendDiffWithRetry(ctx, store, "escrow-1", makeDiffRecord(1))
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+var _ Storage = (*flakyAppendStore)(nil)

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -766,14 +766,35 @@ func (s *Postgres) AppendDiff(escrowID string, rec types.DiffRecord) error {
 	}
 	defer tx.Rollback(ctx)
 
-	_, err = tx.Exec(ctx,
+	tag, err := tx.Exec(ctx,
 		`INSERT INTO devshard_diffs
 		    (epoch_id, escrow_id, nonce, txs_proto, user_sig, post_state_root, state_hash, warm_keys_json, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (epoch_id, escrow_id, nonce) DO NOTHING`,
 		epochID, escrowID, rec.Nonce, txsProto, rec.UserSig, rec.PostStateRoot, rec.StateHash, warmJSON, rec.CreatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("insert diff: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var haveTxs, haveUserSig, havePost, haveHash []byte
+		var haveWarm *string
+		scanErr := tx.QueryRow(ctx,
+			`SELECT txs_proto, user_sig, post_state_root, state_hash, warm_keys_json
+			 FROM devshard_diffs
+			 WHERE epoch_id = $1 AND escrow_id = $2 AND nonce = $3`,
+			epochID, escrowID, rec.Nonce,
+		).Scan(&haveTxs, &haveUserSig, &havePost, &haveHash, &haveWarm)
+		if scanErr != nil {
+			return fmt.Errorf("read existing diff after conflict: %w", scanErr)
+		}
+		if idErr := checkDiffReplayIdentityRaw(
+			escrowID, rec.Nonce,
+			txsProto, rec.UserSig, rec.PostStateRoot, rec.StateHash, warmJSON,
+			haveTxs, haveUserSig, havePost, haveHash, haveWarm,
+		); idErr != nil {
+			return idErr
+		}
 	}
 
 	for slotID, sig := range rec.Signatures {

--- a/devshard/storage/sqlite.go
+++ b/devshard/storage/sqlite.go
@@ -625,13 +625,33 @@ func (s *SQLite) AppendDiff(escrowID string, rec types.DiffRecord) error {
 	}
 	defer tx.Rollback()
 
-	_, err = tx.Exec(
+	res, err := tx.Exec(
 		`INSERT INTO diffs (escrow_id, nonce, txs_proto, user_sig, post_state_root, state_hash, warm_keys_json, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT (escrow_id, nonce) DO NOTHING`,
 		escrowID, rec.Nonce, txsProto, rec.UserSig, rec.PostStateRoot, rec.StateHash, warmJSON, rec.CreatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("insert diff: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		var haveTxs, haveUserSig, havePost, haveHash []byte
+		var haveWarm *string
+		scanErr := tx.QueryRow(
+			`SELECT txs_proto, user_sig, post_state_root, state_hash, warm_keys_json
+			 FROM diffs WHERE escrow_id = ? AND nonce = ?`,
+			escrowID, rec.Nonce,
+		).Scan(&haveTxs, &haveUserSig, &havePost, &haveHash, &haveWarm)
+		if scanErr != nil {
+			return fmt.Errorf("read existing diff after conflict: %w", scanErr)
+		}
+		if idErr := checkDiffReplayIdentityRaw(
+			escrowID, rec.Nonce,
+			txsProto, rec.UserSig, rec.PostStateRoot, rec.StateHash, warmJSON,
+			haveTxs, haveUserSig, havePost, haveHash, haveWarm,
+		); idErr != nil {
+			return idErr
+		}
 	}
 
 	for slotID, sig := range rec.Signatures {

--- a/devshard/storage/sqlite_test.go
+++ b/devshard/storage/sqlite_test.go
@@ -330,21 +330,9 @@ func TestSQLite_ConcurrentReadWrite(t *testing.T) {
 	require.Len(t, diffs, totalDiffs)
 }
 
-func TestSQLite_DuplicateNonce(t *testing.T) {
-	db := newTestSQLite(t)
-	require.NoError(t, db.CreateSession(defaultParams()))
-
-	err := db.AppendDiff("escrow-1", makeDiffRecord(1))
-	require.NoError(t, err)
-
-	err = db.AppendDiff("escrow-1", makeDiffRecord(1))
-	require.Error(t, err, "duplicate nonce should fail")
-
-	// Verify first diff is intact.
-	diffs, err := db.GetDiffs("escrow-1", 1, 1)
-	require.NoError(t, err)
-	require.Len(t, diffs, 1)
-	require.Equal(t, uint64(1), diffs[0].Nonce)
+func TestSQLite_DuplicateNonce_IdenticalReplayOK(t *testing.T) {
+	// Identical same-nonce replay is idempotent (HA); conflicting bytes still fail.
+	runAppendDiff_IdempotentReplay(t, newTestSQLite(t))
 }
 
 func TestSQLite_LargeSession(t *testing.T) {

--- a/devshard/testenv/.gitignore
+++ b/devshard/testenv/.gitignore
@@ -4,3 +4,9 @@ docker-compose.yml
 config.yaml
 keyring/
 data/
+
+# Per-test scratch stacks created by harness NewStack/BootStack
+# (os.MkdirTemp with a "citest-<suite>-" prefix). Normally removed by
+# t.Cleanup, but left behind when a run is interrupted. Never commit them.
+# Does not match the citest/ source package (no trailing dash).
+citest-*/

--- a/devshard/testenv/Makefile
+++ b/devshard/testenv/Makefile
@@ -78,7 +78,7 @@ list-citest-targets: ## Print runnable citest suite targets (one per line) for t
 .PHONY: obs-up obs-down
 # versiond-0 produces devshard-versiond:latest shared by all versiond-* hosts.
 CITEST_BUILD_SERVICES := mock-chain mock-dapi mock-openai devshardctl versiond-router versiond-0
-STACK_CITEST_PATTERN := ^Test(StackSmoke|RouterStickiness|ParamsLongPoll|EpochSwitch|GatewayChat|Versiond.*|LegacyVersionPinnedToSingleHost|SQLiteToPostgresHAMigration|ValidationLeaseRace.*)$$
+STACK_CITEST_PATTERN := ^Test(StackSmoke|RouterStickiness|ParamsLongPoll|EpochSwitch|GatewayChat|Versiond.*|HAStaleStandbyCatchupIdempotent|LegacyVersionPinnedToSingleHost|SQLiteToPostgresHAMigration|ValidationLeaseRace.*)$$
 
 citest-images: ## Pull hub images and build all compose images required for citest.
 	docker compose $(COMPOSE_BASE) pull devshard-postgres

--- a/devshard/testenv/citest/ha_stale_standby_catchup_test.go
+++ b/devshard/testenv/citest/ha_stale_standby_catchup_test.go
@@ -1,0 +1,96 @@
+//go:build testenvci
+
+package citest
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"devshard/testenv/citest/harness"
+	"devshard/testenv/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHAStaleStandbyCatchupIdempotent verifies HA failover onto a versiond whose
+// in-memory escrow nonce lags shared Postgres: sticky primary advances PG, then
+// is stopped; catch-up on the stale standby must succeed without SQLSTATE 23505.
+func TestHAStaleStandbyCatchupIdempotent(t *testing.T) {
+	harness.SkipUnlessEnv(t, "TESTENV_CITEST")
+	harness.RequireDocker(t)
+
+	stack, cfg, eps := harness.BootStack(t, "citest-ha-stale-standby-*")
+	client := harness.HTTPClient()
+	chatClient := harness.GatewayChatClient()
+	adminKey := harness.TestenvAdminAPIKey
+	t.Cleanup(func() {
+		if t.Failed() {
+			harness.DumpComposeLogs(t, stack, "devshardctl", "versiond-0", "versiond-1", "versiond-router")
+		}
+	})
+
+	harness.WaitStackHealthy(t, stack, eps)
+	harness.WaitGatewayChatReady(t, chatClient, eps.GatewayHTTP, 3*time.Minute, stack)
+	version := cfg.Versiond.VersionName
+	harness.WaitGETOK(t, client, eps.RouterHTTP+"/"+version+"/healthz", 5*time.Minute, "devshardd health via router", stack)
+
+	// Confirm both HA upstreams are sticky-addressable before the escrow scenario.
+	_, upstreamA, _, upstreamB := harness.FindDistinctStickySessions(t, client, eps.RouterHTTP, version)
+	require.NotEqual(t, upstreamA, upstreamB)
+
+	model := config.PrimaryModelID(cfg)
+	harness.Step(t, "warm escrow via gateway chat (sticky primary loads session)")
+	harness.PostGatewayChatCompletion(t, chatClient, eps.GatewayHTTP, adminKey, harness.ChatCompletionRequest{
+		Model: model,
+		Messages: []harness.ChatMessage{
+			{Role: "user", Content: "citest ha stale standby warm"},
+		},
+		MaxTokens: 16,
+	})
+	snapN := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	require.NotEmpty(t, snapN.EscrowID)
+	require.Greater(t, snapN.LatestNonce, uint64(0), "expected durable nonce after warm chat")
+
+	escrowSessionURL := harness.RouterSessionURL(eps.RouterHTTP, version, snapN.EscrowID, "/mempool")
+	primaryUpstream := harness.RequireResponseHeader(t, client, escrowSessionURL, harness.StickyUpstreamHeader)
+	primaryHost := harness.HostIDForUpstream(cfg, primaryUpstream)
+	require.NotEmpty(t, primaryHost, "map escrow sticky upstream %q to host id", primaryUpstream)
+	survivorUpstream := harness.OtherStickyUpstream(primaryUpstream, upstreamA, upstreamB)
+	require.NotEmpty(t, survivorUpstream, "need a survivor distinct from primary %s", primaryUpstream)
+
+	harness.Step(t, "escrow %s sticky → %s (%s); survivor %s; advancing PG on primary",
+		snapN.EscrowID, primaryUpstream, primaryHost, survivorUpstream)
+
+	const advanceChats = 3
+	for i := 0; i < advanceChats; i++ {
+		harness.PostGatewayChatCompletion(t, chatClient, eps.GatewayHTTP, adminKey, harness.ChatCompletionRequest{
+			Model: model,
+			Messages: []harness.ChatMessage{
+				{Role: "user", Content: fmt.Sprintf("citest ha stale standby advance %d", i)},
+			},
+			MaxTokens: 16,
+		})
+	}
+	snapAdvanced := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	harness.RequireGatewaySessionAdvanced(t, snapN, snapAdvanced)
+	require.Greater(t, snapAdvanced.LatestNonce, snapN.LatestNonce,
+		"primary chats must advance durable nonce beyond warm snapshot")
+
+	harness.Step(t, "stop sticky primary %s so catch-up lands on stale standby", primaryHost)
+	stack.StopService(t, primaryHost)
+	harness.WaitStickyFailoverToSurvivor(t, client, escrowSessionURL, primaryUpstream, survivorUpstream, 45*time.Second)
+
+	harness.Step(t, "gateway chat after failover (standby must reconcile + apply without 23505)")
+	harness.PostGatewayChatCompletion(t, chatClient, eps.GatewayHTTP, adminKey, harness.ChatCompletionRequest{
+		Model: model,
+		Messages: []harness.ChatMessage{
+			{Role: "user", Content: "citest ha stale standby after failover"},
+		},
+		MaxTokens: 16,
+	})
+	snapAfter := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	harness.RequireGatewaySessionAdvanced(t, snapAdvanced, snapAfter)
+
+	harness.RequireNoDiffDuplicateKeyInLogs(t, stack, "versiond-0", "versiond-1")
+}

--- a/devshard/testenv/citest/harness/adversarial.go
+++ b/devshard/testenv/citest/harness/adversarial.go
@@ -329,6 +329,8 @@ func PostGatewayChatExpectFailure(t *testing.T, client *http.Client, gatewayURL,
 }
 
 // WaitGatewayChatExpectFailure polls until gateway chat returns HTTP >= 400 or a transport error.
+// Each attempt uses a unique request body so a single early 200 cannot freeze the
+// wait on gateway chat-response cache hits (TTL is long).
 func WaitGatewayChatExpectFailure(t *testing.T, client *http.Client, gatewayURL, adminAPIKey string, req ChatCompletionRequest, wait time.Duration) int {
 	t.Helper()
 	if client == nil {
@@ -336,9 +338,11 @@ func WaitGatewayChatExpectFailure(t *testing.T, client *http.Client, gatewayURL,
 	}
 	var status int
 	var lastBody string
+	attempt := 0
 	ok := AssertEventually(t, wait, 2*time.Second, func() bool {
+		attempt++
 		var transportErr error
-		status, transportErr, lastBody = postGatewayChatHTTPStatus(client, gatewayURL, adminAPIKey, req)
+		status, transportErr, lastBody = postGatewayChatHTTPStatus(client, gatewayURL, adminAPIKey, uniquifyChatRequest(req, attempt))
 		if transportErr != nil {
 			lastBody = transportErr.Error()
 			return true
@@ -352,4 +356,20 @@ func WaitGatewayChatExpectFailure(t *testing.T, client *http.Client, gatewayURL,
 	}
 	require.NotEqual(t, http.StatusOK, status, "gateway chat should not succeed on stale settled escrow: %s", lastBody)
 	return status
+}
+
+// uniquifyChatRequest returns a shallow copy of req whose last user message
+// content is tagged with attempt, changing the gateway chat cache key.
+func uniquifyChatRequest(req ChatCompletionRequest, attempt int) ChatCompletionRequest {
+	out := req
+	if len(req.Messages) == 0 {
+		out.Messages = []ChatMessage{{Role: "user", Content: fmt.Sprintf("citest-unique-%d", attempt)}}
+		return out
+	}
+	msgs := make([]ChatMessage, len(req.Messages))
+	copy(msgs, req.Messages)
+	last := len(msgs) - 1
+	msgs[last].Content = fmt.Sprintf("%s [citest-attempt-%d]", msgs[last].Content, attempt)
+	out.Messages = msgs
+	return out
 }

--- a/devshard/testenv/citest/harness/adversarial_test.go
+++ b/devshard/testenv/citest/harness/adversarial_test.go
@@ -1,0 +1,32 @@
+package harness
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniquifyChatRequestChangesLastMessage(t *testing.T) {
+	req := ChatCompletionRequest{
+		Model: "m",
+		Messages: []ChatMessage{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "hello"},
+		},
+		MaxTokens: 8,
+	}
+	a := uniquifyChatRequest(req, 1)
+	b := uniquifyChatRequest(req, 2)
+	require.Equal(t, "hello", req.Messages[1].Content, "original must be unchanged")
+	require.Equal(t, "sys", a.Messages[0].Content)
+	require.Contains(t, a.Messages[1].Content, "hello")
+	require.Contains(t, a.Messages[1].Content, "citest-attempt-1")
+	require.NotEqual(t, a.Messages[1].Content, b.Messages[1].Content)
+}
+
+func TestUniquifyChatRequestEmptyMessages(t *testing.T) {
+	req := ChatCompletionRequest{Model: "m"}
+	out := uniquifyChatRequest(req, 3)
+	require.Len(t, out.Messages, 1)
+	require.Contains(t, out.Messages[0].Content, "citest-unique-3")
+}

--- a/devshard/testenv/citest/harness/output.go
+++ b/devshard/testenv/citest/harness/output.go
@@ -2,7 +2,10 @@ package harness
 
 import (
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Step logs a citest milestone when verbose (default: always in integration tests).
@@ -36,5 +39,22 @@ func SkipUnlessEnv(t *testing.T, name string) {
 	t.Helper()
 	if os.Getenv(name) != "1" {
 		t.Skipf("set %s=1 to run Docker stack citest", name)
+	}
+}
+
+// RequireNoDiffDuplicateKeyInLogs asserts versiond logs do not contain the
+// Postgres unique-violation signals from bare AppendDiff under HA catch-up.
+func RequireNoDiffDuplicateKeyInLogs(t *testing.T, s *Stack, services ...string) {
+	t.Helper()
+	require.NotNil(t, s)
+	out, err := s.ComposeLogsTail(400, services...)
+	require.NoError(t, err, "compose logs")
+	needles := []string{
+		"23505",
+		"duplicate key value violates unique constraint",
+	}
+	for _, needle := range needles {
+		require.False(t, strings.Contains(out, needle),
+			"versiond logs must not contain %q after HA catch-up (got %d bytes of logs)", needle, len(out))
 	}
 }

--- a/devshard/testenv/citest/harness/router_sticky.go
+++ b/devshard/testenv/citest/harness/router_sticky.go
@@ -43,6 +43,23 @@ func FindDistinctStickySessions(t *testing.T, client *http.Client, routerHTTP, v
 	return "", "", "", ""
 }
 
+// OtherStickyUpstream returns the candidate in {a,b} that is not primary.
+// Addresses are compared after trimming; comma-separated tried-upstream lists
+// are not accepted for primary (callers should pass a single sticky addr).
+func OtherStickyUpstream(primary, a, b string) string {
+	primary = strings.TrimSpace(primary)
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	switch {
+	case primary == a && a != b:
+		return b
+	case primary == b && a != b:
+		return a
+	default:
+		return ""
+	}
+}
+
 // HostIDForUpstream maps nginx upstream addr (host:port) to compose service id.
 func HostIDForUpstream(cfg *config.File, upstreamAddr string) string {
 	if cfg == nil {

--- a/devshard/testenv/citest/harness/router_sticky_test.go
+++ b/devshard/testenv/citest/harness/router_sticky_test.go
@@ -1,0 +1,15 @@
+package harness
+
+import "testing"
+
+func TestOtherStickyUpstream(t *testing.T) {
+	if got := OtherStickyUpstream("a:8080", "a:8080", "b:8080"); got != "b:8080" {
+		t.Fatalf("got %q want b:8080", got)
+	}
+	if got := OtherStickyUpstream("b:8080", "a:8080", "b:8080"); got != "a:8080" {
+		t.Fatalf("got %q want a:8080", got)
+	}
+	if got := OtherStickyUpstream("c:8080", "a:8080", "b:8080"); got != "" {
+		t.Fatalf("got %q want empty", got)
+	}
+}

--- a/devshard/testenv/citest/harness/stack.go
+++ b/devshard/testenv/citest/harness/stack.go
@@ -245,7 +245,15 @@ func (s *Stack) StartService(t *testing.T, service string) {
 
 // ComposeLogs returns tail logs for optional services (all services when empty).
 func (s *Stack) ComposeLogs(services ...string) (string, error) {
-	args := append(append([]string{"compose"}, s.composeFileArgs()...), "logs", "--no-color", "--tail", "120")
+	return s.ComposeLogsTail(120, services...)
+}
+
+// ComposeLogsTail is ComposeLogs with an explicit --tail line count.
+func (s *Stack) ComposeLogsTail(tail int, services ...string) (string, error) {
+	if tail <= 0 {
+		tail = 120
+	}
+	args := append(append([]string{"compose"}, s.composeFileArgs()...), "logs", "--no-color", "--tail", strconv.Itoa(tail))
 	args = append(args, services...)
 	cmd := exec.Command("docker", args...)
 	cmd.Dir = s.WorkDir

--- a/devshard/testenv/docs/scenarios.md
+++ b/devshard/testenv/docs/scenarios.md
@@ -71,6 +71,7 @@ picked up automatically (no workflow edit). For a local sequential subset, use
 | **Gateway chat** | devshardctl → router → devshardd → mock-openai (stream + non-stream) | `TestGatewayChat` |
 | **Versiond failover** | Stop → first-502 failover to survivor | `TestVersiondStickySessionFailover` |
 | **Versiond restart persistence** | Restart preserves the gateway session | `TestVersiondRestartSessionPersistence` |
+| **HA stale standby catch-up** | Sticky primary advances PG, stop it; stale standby catch-up without `23505` | `TestHAStaleStandbyCatchupIdempotent` |
 | **Legacy version pin** | Non-HA path → `VERSIOND_LEGACY_HOST`; HA path remains multi-upstream | `TestLegacyVersionPinnedToSingleHost` |
 | **SQLite to Postgres HA migration** | SQLite single-host, multi-host rejection, migration, HA recovery | `TestSQLiteToPostgresHAMigration` |
 | **Validation lease race** | Same-key HA lease exclusivity, pending stretch, stale reclaim | `TestValidationLeaseRaceCore`, `…PendingStretch`, `…StaleReclaim` |

--- a/devshard/user/compose_persist_retry_test.go
+++ b/devshard/user/compose_persist_retry_test.go
@@ -1,0 +1,128 @@
+package user
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"devshard/host"
+	"devshard/internal/testutil"
+	"devshard/observability"
+	"devshard/signing"
+	"devshard/state"
+	"devshard/storage"
+	"devshard/stub"
+	"devshard/types"
+)
+
+type flakyUserAppendStore struct {
+	storage.Storage
+	failsLeft atomic.Int32
+	calls     atomic.Int32
+}
+
+func (s *flakyUserAppendStore) AppendDiff(escrowID string, rec types.DiffRecord) error {
+	s.calls.Add(1)
+	if s.failsLeft.Add(-1) >= 0 {
+		return errors.New("transient append failure")
+	}
+	return s.Storage.AppendDiff(escrowID, rec)
+}
+
+func setupStoredSession(t *testing.T, store storage.Storage) *Session {
+	t.Helper()
+	numHosts := 3
+	hosts := make([]*signing.Secp256k1Signer, numHosts)
+	for i := range hosts {
+		hosts[i] = testutil.MustGenerateKey(t)
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(numHosts)
+	verifier := signing.NewSecp256k1Verifier()
+
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "escrow-1",
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+
+	clients := make([]HostClient, numHosts)
+	for i := range hosts {
+		hostStore := testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 100000)
+		sm, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier, hostStore)
+		require.NoError(t, err)
+		h, err := host.NewHost(sm, hosts[i], stub.NewInferenceEngine(), "escrow-1", group, nil, host.WithGrace(10))
+		require.NoError(t, err)
+		clients[i] = &InProcessClient{Host: h}
+	}
+
+	userSM, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier, store)
+	require.NoError(t, err)
+	session, err := NewSession(userSM, user, "escrow-1", group, clients, verifier, WithStorage(store))
+	require.NoError(t, err)
+	return session
+}
+
+func TestSession_ComposeDiff_PersistRetryThenSuccess(t *testing.T) {
+	inner := storage.NewMemory()
+	store := &flakyUserAppendStore{Storage: inner}
+	store.failsLeft.Store(2)
+	session := setupStoredSession(t, store)
+
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	beforeRetry := promtestutil.ToFloat64(observability.DiffPersistRetryForTest("success"))
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+	require.Equal(t, uint64(1), session.Nonce())
+	require.Equal(t, int32(3), store.calls.Load())
+	require.Equal(t, beforeRetry+1, promtestutil.ToFloat64(observability.DiffPersistRetryForTest("success")))
+
+	meta, err := inner.GetSessionMeta("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), meta.LatestNonce)
+}
+
+func TestSession_ComposeDiff_PersistFirst_FailureLeavesSequencerUnchanged(t *testing.T) {
+	inner := storage.NewMemory()
+	store := &flakyUserAppendStore{Storage: inner}
+	store.failsLeft.Store(100)
+	session := setupStoredSession(t, store)
+
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	beforeExhausted := promtestutil.ToFloat64(observability.DiffPersistRetryForTest("exhausted"))
+	_, err := session.PrepareInference(params)
+	require.Error(t, err)
+	require.ErrorIs(t, err, storage.ErrPersistExhausted)
+	require.Equal(t, uint64(0), session.Nonce(), "persist-first must not advance sequencer on persist fail")
+	require.Equal(t, int32(storage.DefaultPersistMaxAttempts), store.calls.Load())
+	require.Equal(t, beforeExhausted+1, promtestutil.ToFloat64(observability.DiffPersistRetryForTest("exhausted")))
+
+	meta, err := inner.GetSessionMeta("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), meta.LatestNonce)
+
+	// Same session, heal store, re-compose allocates nonce 1 and persists — no reload.
+	store.failsLeft.Store(0)
+	store.calls.Store(0)
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), prepared.diff.Nonce)
+	require.Equal(t, uint64(1), session.Nonce())
+	meta, err = inner.GetSessionMeta("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), meta.LatestNonce)
+}

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -586,8 +586,14 @@ type HostBinding struct {
 // in the gap between wakeup and lock acquisition).
 type ParamsForHost func(b HostBinding) (params InferenceParams, probe bool, err error)
 
-// composeDiffLocked builds, applies, persists, and returns a new diff.
-// extraTxs are prepended to pending txs. Caller must hold s.mu.
+// composeDiffLocked builds, persists, commits, and returns a new diff
+// (persist-first when a store is configured). extraTxs are prepended to
+// pending txs. Caller must hold s.mu.
+//
+// HA assumption: the gateway is the single-instance sequencer for this escrow,
+// so this path does not race another writer on the same nonce. With a store,
+// PreviewLocalBestEffort leaves the SM unchanged until AppendDiff succeeds,
+// so persist failure cannot leave sequencer nonce/diffs ahead of durable state.
 func (s *Session) composeDiffLocked(extraTxs []*types.DevshardTx) (types.Diff, int, error) {
 	nonce := s.nonce + 1
 	hostIdx := int(nonce % uint64(len(s.group)))
@@ -600,10 +606,39 @@ func (s *Session) composeDiffLocked(extraTxs []*types.DevshardTx) (types.Diff, i
 	candidates = append(candidates, s.pendingTxs...)
 	candidates = append(candidates, extraTxs...)
 
-	var warmBefore map[uint32]string
 	if s.store != nil {
-		warmBefore = s.sm.WarmKeys()
+		warmBefore := s.sm.WarmKeys()
+		vd, err := s.sm.PreviewLocalBestEffort(nonce, candidates)
+		if err != nil {
+			return types.Diff{}, 0, fmt.Errorf("local apply: %w", err)
+		}
+		diff, err := s.signDiff(nonce, vd.Applied, vd.Root)
+		if err != nil {
+			return types.Diff{}, 0, err
+		}
+		delta := types.ComputeWarmKeyDelta(warmBefore, vd.WarmAfter)
+		rec := types.DiffRecord{
+			Diff:         diff,
+			StateHash:    vd.Root,
+			WarmKeyDelta: delta,
+		}
+		if err := s.persistDiffRetryLocked(rec); err != nil {
+			return types.Diff{}, 0, fmt.Errorf("persist diff: %w", err)
+		}
+		// Install the previewed post-state without a second apply (no re-sign,
+		// so a retried compose cannot fork on a new UserSig after a durable
+		// write). The gateway is the single sequencer and holds s.mu across
+		// persist, so the nonce cannot have advanced concurrently.
+		if !s.sm.CommitValidated(vd) {
+			return types.Diff{}, 0, fmt.Errorf("commit diff nonce %d: state advanced concurrently", nonce)
+		}
+		s.diffs = append(s.diffs, diff)
+		s.nonce = nonce
+		s.clearPendingTxs()
+		s.maybeSaveSnapshotLocked()
+		return diff, hostIdx, nil
 	}
+
 	postStateRoot, applied, err := s.sm.ApplyLocalBestEffort(nonce, candidates)
 	if err != nil {
 		return types.Diff{}, 0, fmt.Errorf("local apply: %w", err)
@@ -612,25 +647,18 @@ func (s *Session) composeDiffLocked(extraTxs []*types.DevshardTx) (types.Diff, i
 	if err != nil {
 		return types.Diff{}, 0, err
 	}
-
 	s.diffs = append(s.diffs, diff)
 	s.nonce = nonce
 	s.clearPendingTxs()
-
-	if s.store != nil {
-		warmAfter := s.sm.WarmKeys()
-		delta := types.ComputeWarmKeyDelta(warmBefore, warmAfter)
-		if err := s.store.AppendDiff(s.escrowID, types.DiffRecord{
-			Diff:         diff,
-			StateHash:    postStateRoot,
-			WarmKeyDelta: delta,
-		}); err != nil {
-			return types.Diff{}, 0, fmt.Errorf("persist diff: %w", err)
-		}
-		s.maybeSaveSnapshotLocked()
-	}
-
 	return diff, hostIdx, nil
+}
+
+// persistDiffRetryLocked retries AppendDiff with backoff while holding s.mu.
+// Unlocking during backoff would let a concurrent compose re-sign the same
+// next nonce and risk ErrDiffFork after a durable write. Persist-first means
+// sequencer state is not committed until this returns nil.
+func (s *Session) persistDiffRetryLocked(rec types.DiffRecord) error {
+	return storage.AppendDiffWithRetry(context.Background(), s.store, s.escrowID, rec)
 }
 
 // maybeSaveSnapshotLocked schedules an asynchronous snapshot save when


### PR DESCRIPTION
## Summary

Fixes HA failover onto a **stale standby** `devshardd` that still held an older
in-memory escrow nonce while shared Postgres had already advanced. Catch-up no
longer fails with Postgres unique violations (`23505`) / HTTP 500 for
already-durable identical diffs, and persist failures can no longer leave
memory permanently ahead of the store.

End-state behaviour:

1. **Idempotent `AppendDiff`** — identical `(escrow, nonce)` replay succeeds;
   conflicting bytes → typed fork + `diff_fork_detected` (never overwrite).
2. **Lazy reconcile** — nonce gap → fast-forward durable rows from Postgres,
   then apply the tip (`reconcile_fast_forward`).
3. **Bounded persist retry** — transient PG blips (`diff_persist_retry`).
4. **Persist-first** — validate/preview → persist → commit live SM so a failed
   write leaves memory unchanged.

Design / checklist: [proposals/ha-diff-persist-consistency.md](./proposals/ha-diff-persist-consistency.md),
[proposals/ha-diff-persist-consistency-impl.md](./proposals/ha-diff-persist-consistency-impl.md).

Operator docs (no proposal links in product docs):  
[high-availability-architecture.md](./high-availability-architecture.md),
[release-0.2.14-v4.md](./release-0.2.14-v4.md),
[v4-deploy-test-plan.md](./v4-deploy-test-plan.md) §3.6.

---

## Motivation

Under sticky HA + shared Postgres, replica A can advance durable nonces while
standby B keeps a stale live session. After `proxy_next_upstream` failover,
catch-up on B hit a bare `INSERT` → `23505` even though the durable row was
correct. Separately, apply-then-persist left a memory-ahead hole when
`AppendDiff` failed.

---

## Changes

| Area | Change |
|------|--------|
| **Storage** | Idempotent identical `AppendDiff` (Postgres / SQLite / Memory); fork split; shared `AppendDiffWithRetry` (+ lock/unlock-callback variant so the host releases `h.mu` during backoff) |
| **Host** | Lazy reconcile on nonce gap; persist-first `ValidateDiff` → persist → `CommitValidated` |
| **Gateway** | Persist-first compose (`PreviewLocalBestEffort` → persist → `CommitValidated`); hold session lock during persist retry |
| **State** | `ValidateDiff` / `PreviewLocalBestEffort` trial-apply and return a `ValidatedDiff` handle; `CommitValidated` installs the precomputed post-state (single apply, no recompute) and flushes obs writes buffered during the trial (written once, and never for a diff that fails to persist) |
| **Metrics** | `diff_persist_retry_total`, `diff_fork_detected_total`, `reconcile_fast_forward_total` |
| **testenv** | `TestHAStaleStandbyCatchupIdempotent` (`testenvci`) |
| **Docs** | HA architecture, release notes, deploy test plan §3.6; storage-design wording |

---

## Crash recovery vs ML execution (out of scope here)

Persist-first and durable diff replay cover the **journal / state machine**
only. After a crash, recovery **replays diffs**; it does **not** re-run ML
automatically.

- Still `Pending` in SM, this host is executor, client retries with payload →
  can execute again. Dedup (`executing` / `completedResponses`) is **in-process**,
  not durable.
- Already `Finished` / timed out in later diffs → `signReceipt` will not start
  execution again.

Restoring interrupted inferences across drop / reboot / HA (decouple ML from
the user stream, same-nonce gateway reconnect, durable payload / receipt /
cached body) is **follow-up** work:
[gonka-ai/gonka#1466](https://github.com/gonka-ai/gonka/issues/1466).