### PR TITLE
feat(chain): fall back to CometBFT RPC when chain gRPC is unreachable

### DIFF
--- a/common/chain/client.go
+++ b/common/chain/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	blstypes "github.com/productscience/inference/x/bls/types"
@@ -49,8 +50,13 @@ type InferenceClient interface {
 // Client provides blockchain queries via gRPC.
 // Consumers that need mocking define their own narrow interfaces
 // with only the methods they call.
+//
+// queryConn serves the module query clients and may be a fallback connection;
+// conn is always the direct gRPC connection and is what Conn() exposes for
+// transaction signing and broadcasting.
 type Client struct {
-	conn grpc.ClientConnInterface
+	conn      grpc.ClientConnInterface
+	queryConn grpc.ClientConnInterface
 }
 
 // TLSEnabled reports whether CHAIN_GRPC_TLS requests TLS for chain gRPC dials.
@@ -78,39 +84,73 @@ func DialOption() grpc.DialOption {
 // cfg is assumed valid — config.Load guarantees this.
 // Transport is plaintext unless CHAIN_GRPC_TLS is truthy.
 func New(grpcURL string) (*Client, error) {
+	conn, err := dialDirect(grpcURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{conn: conn, queryConn: conn}, nil
+}
+
+// NewWithRPCFallback dials the chain gRPC endpoint and prepares a CometBFT RPC
+// connection used for queries whenever gRPC is unreachable. Queries start on
+// gRPC, move to RPC on transport failure, and move back once a probe every
+// DefaultRPCProbeInterval finds gRPC reachable again — no restart needed.
+//
+// Conn() still returns the direct gRPC connection, so transactions never run
+// over the fallback.
+func NewWithRPCFallback(grpcURL, rpcURL string) (*Client, error) {
+	conn, err := dialDirect(grpcURL)
+	if err != nil {
+		return nil, err
+	}
+	rpcConn, err := newRPCQueryConn(rpcURL)
+	if err != nil {
+		return nil, err
+	}
+	fallback := newFallbackConn(conn, rpcConn, DefaultRPCProbeInterval, time.Now)
+	return &Client{conn: conn, queryConn: fallback}, nil
+}
+
+func dialDirect(grpcURL string) (grpc.ClientConnInterface, error) {
 	conn, err := grpc.NewClient(grpcURL, DialOption())
 	if err != nil {
 		return nil, fmt.Errorf("chain: dial %s: %w", grpcURL, err)
 	}
-	return &Client{conn: observability.NewObservedConn(conn)}, nil
+	return observability.NewObservedConn(conn), nil
 }
 
 // NewFromConn creates a Client from an existing connection.
 // Intended for tests that use in-process gRPC servers.
 func NewFromConn(conn grpc.ClientConnInterface) *Client {
-	return &Client{conn: conn}
+	return &Client{conn: conn, queryConn: conn}
 }
 
-// Conn returns the underlying gRPC connection.
+// Conn returns the direct gRPC connection. Transaction signing and broadcasting
+// use this so they never silently run over the query fallback.
 func (c *Client) Conn() grpc.ClientConnInterface { return c.conn }
+
+// QueryConn returns the connection queries run on. It equals Conn() unless the
+// client was built with NewWithRPCFallback. Use it for query clients this
+// package does not expose directly.
+func (c *Client) QueryConn() grpc.ClientConnInterface { return c.queryConn }
 
 // InferenceQueryClient returns a query client for the inference module.
 func (c *Client) InferenceQueryClient() InferenceClient {
-	return inferencetypes.NewQueryClient(c.conn)
+	return inferencetypes.NewQueryClient(c.queryConn)
 }
 
 // BLSQueryClient returns a query client for the BLS module.
 func (c *Client) BLSQueryClient() blstypes.QueryClient {
-	return blstypes.NewQueryClient(c.conn)
+	return blstypes.NewQueryClient(c.queryConn)
 }
 
 // RestrictionsQueryClient returns a query client for the restrictions module.
 func (c *Client) RestrictionsQueryClient() restrictionstypes.QueryClient {
-	return restrictionstypes.NewQueryClient(c.conn)
+	return restrictionstypes.NewQueryClient(c.queryConn)
 }
 
 // CometServiceClient returns a client for CometBFT node services
 // (node info, block queries, ABCI queries).
 func (c *Client) CometServiceClient() cmtservice.ServiceClient {
-	return cmtservice.NewServiceClient(c.conn)
+	return cmtservice.NewServiceClient(c.queryConn)
 }

--- a/common/chain/client.go
+++ b/common/chain/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -69,6 +71,29 @@ func TLSEnabled() bool {
 	}
 }
 
+// DefaultCometRPCPort is the port CometBFT serves JSON-RPC on by default.
+const DefaultCometRPCPort = "26657"
+
+// RPCURLFromGRPCURL derives a CometBFT RPC endpoint from a chain gRPC endpoint
+// by keeping the host and swapping in the standard RPC port. Every deployment we
+// ship co-locates the two, so this lets the query fallback work without a second
+// mandatory setting. Returns "" when no host can be extracted.
+func RPCURLFromGRPCURL(grpcURL string) string {
+	host := strings.TrimSpace(grpcURL)
+	if i := strings.Index(host, "://"); i >= 0 {
+		host = host[i+len("://"):]
+	}
+	// gRPC targets may carry a resolver prefix such as "dns:///node:9090".
+	host = strings.Trim(host, "/")
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if host == "" {
+		return ""
+	}
+	return "http://" + net.JoinHostPort(host, DefaultCometRPCPort)
+}
+
 // DialOption returns the transport credential DialOption for chain gRPC.
 // Default is insecure; set CHAIN_GRPC_TLS=true for system-root TLS.
 func DialOption() grpc.DialOption {
@@ -111,6 +136,27 @@ func NewWithRPCFallback(grpcURL, rpcURL string) (*Client, error) {
 	return &Client{conn: conn, queryConn: fallback}, nil
 }
 
+// NewWithQueryFallback is NewWithRPCFallback with the endpoint policy every
+// service shares: rpcURL may be empty, in which case it is derived from the gRPC
+// host, and a client that cannot determine an RPC endpoint at all still runs on
+// gRPC alone. Callers pass whatever their own env vars gave them and get the
+// same behaviour everywhere.
+//
+// Degrading rather than failing is deliberate: a fallback meant to keep queries
+// working must not be the reason a deployment stops booting.
+func NewWithQueryFallback(grpcURL, rpcURL string) (*Client, error) {
+	resolved := strings.TrimSpace(rpcURL)
+	if resolved == "" {
+		resolved = RPCURLFromGRPCURL(grpcURL)
+	}
+	if resolved == "" {
+		slog.Warn("chain: no CometBFT RPC endpoint, queries run on direct gRPC only",
+			"grpc_url", grpcURL)
+		return New(grpcURL)
+	}
+	return NewWithRPCFallback(grpcURL, resolved)
+}
+
 func dialDirect(grpcURL string) (grpc.ClientConnInterface, error) {
 	conn, err := grpc.NewClient(grpcURL, DialOption())
 	if err != nil {
@@ -132,6 +178,10 @@ func (c *Client) Conn() grpc.ClientConnInterface { return c.conn }
 // QueryConn returns the connection queries run on. It equals Conn() unless the
 // client was built with NewWithRPCFallback. Use it for query clients this
 // package does not expose directly.
+//
+// Queries only. When this is a fallback conn, broadcasting a transaction
+// through it is rejected rather than silently retried across transports. Use
+// Conn() for transactions either way.
 func (c *Client) QueryConn() grpc.ClientConnInterface { return c.queryConn }
 
 // InferenceQueryClient returns a query client for the inference module.

--- a/common/chain/client_test.go
+++ b/common/chain/client_test.go
@@ -53,3 +53,59 @@ func TestNew_WithTLSEnvStillDials(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, c.Conn())
 }
+
+func TestRPCURLFromGRPCURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"host and port", "node:9090", "http://node:26657"},
+		{"host only", "node", "http://node:26657"},
+		{"ipv4", "10.0.0.4:9090", "http://10.0.0.4:26657"},
+		{"ipv6", "[::1]:9090", "http://[::1]:26657"},
+		{"scheme is dropped", "http://node:9090", "http://node:26657"},
+		{"grpc resolver prefix", "dns:///node:9090", "http://node:26657"},
+		{"surrounding space", "  node:9090  ", "http://node:26657"},
+		{"empty", "", ""},
+		{"no host", "://", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, chain.RPCURLFromGRPCURL(tc.in))
+		})
+	}
+}
+
+func TestNewWithRPCFallback_AcceptsDerivedRPCURL(t *testing.T) {
+	rpcURL := chain.RPCURLFromGRPCURL("node:9090")
+	c, err := chain.NewWithRPCFallback("node:9090", rpcURL)
+	require.NoError(t, err)
+	assert.NotNil(t, c.CometServiceClient())
+}
+
+func TestNewWithRPCFallback_RequiresRPCURL(t *testing.T) {
+	_, err := chain.NewWithRPCFallback("node:9090", "")
+	require.Error(t, err, "the explicit constructor must not silently skip the fallback")
+}
+
+func TestNewWithQueryFallback_DerivesMissingRPCURL(t *testing.T) {
+	c, err := chain.NewWithQueryFallback("node:9090", "")
+	require.NoError(t, err)
+	assert.NotEqual(t, c.Conn(), c.QueryConn(), "queries must run on the fallback conn")
+}
+
+func TestNewWithQueryFallback_KeepsExplicitRPCURL(t *testing.T) {
+	c, err := chain.NewWithQueryFallback("node:9090", "http://other:36657")
+	require.NoError(t, err)
+	assert.NotEqual(t, c.Conn(), c.QueryConn())
+}
+
+func TestNewWithQueryFallback_WithoutAnyRPCEndpointStaysOnGRPC(t *testing.T) {
+	// A gRPC target with no host leaves nothing to derive from. Adding a
+	// resilience feature must not stop a service from booting, so the client
+	// runs on gRPC alone.
+	c, err := chain.NewWithQueryFallback("://", "")
+	require.NoError(t, err)
+	assert.Equal(t, c.Conn(), c.QueryConn(), "queries must fall back to the direct conn")
+}

--- a/common/chain/fallback.go
+++ b/common/chain/fallback.go
@@ -1,0 +1,176 @@
+package chain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	blstypes "github.com/productscience/inference/x/bls/types"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
+	restrictionstypes "github.com/productscience/inference/x/restrictions/types"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// DefaultRPCProbeInterval is how long queries stay on CometBFT RPC before a
+// single request is allowed to probe direct gRPC again.
+const DefaultRPCProbeInterval = 30 * time.Minute
+
+// fallbackConn routes unary query invocations over direct chain gRPC while that
+// endpoint is reachable, and over CometBFT RPC/ABCI while it is not.
+//
+// The switch is driven entirely by observed transport failures, so a node that
+// enables gRPC later is picked up without restarting anything: after
+// probeInterval on RPC, exactly one request is routed over gRPC, and success
+// makes gRPC primary again.
+type fallbackConn struct {
+	direct grpc.ClientConnInterface
+	rpc    grpc.ClientConnInterface
+
+	probeInterval time.Duration
+	now           func() time.Time
+
+	mu          sync.Mutex
+	usingRPC    bool
+	probing     bool
+	nextProbeAt time.Time
+}
+
+func newFallbackConn(direct, rpc grpc.ClientConnInterface, probeInterval time.Duration, now func() time.Time) *fallbackConn {
+	return &fallbackConn{
+		direct:        direct,
+		rpc:           rpc,
+		probeInterval: probeInterval,
+		now:           now,
+	}
+}
+
+// route decides where the next invocation goes. When it returns probe=true the
+// caller owns the single in-flight gRPC probe and must release it via
+// probeSucceeded or probeFailed.
+func (c *fallbackConn) route() (useRPC, probe bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.usingRPC {
+		return false, false
+	}
+	if !c.probing && !c.now().Before(c.nextProbeAt) {
+		c.probing = true
+		return false, true
+	}
+	return true, false
+}
+
+// enterRPC switches queries to RPC and reports whether this call caused the
+// transition, so concurrent failures log once.
+func (c *fallbackConn) enterRPC() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.usingRPC {
+		return false
+	}
+	c.usingRPC = true
+	c.nextProbeAt = c.now().Add(c.probeInterval)
+	return true
+}
+
+func (c *fallbackConn) probeSucceeded() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.usingRPC = false
+	c.probing = false
+	c.nextProbeAt = time.Time{}
+}
+
+func (c *fallbackConn) probeFailed() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.probing = false
+	c.nextProbeAt = c.now().Add(c.probeInterval)
+}
+
+func (c *fallbackConn) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
+	useRPC, probe := c.route()
+	if useRPC {
+		return c.rpc.Invoke(ctx, method, args, reply, opts...)
+	}
+
+	err := c.direct.Invoke(ctx, method, args, reply, opts...)
+	if !isTransportDown(err) {
+		// Any other outcome, including application errors, proves gRPC is
+		// reachable — keep it primary.
+		if probe {
+			c.probeSucceeded()
+			slog.Info("chain: direct gRPC reachable again, queries back on gRPC", "method", method)
+		}
+		return err
+	}
+
+	if probe {
+		c.probeFailed()
+	} else if c.enterRPC() {
+		slog.Warn("chain: direct gRPC unreachable, queries falling back to CometBFT RPC",
+			"method", method, "error", err, "retry_after", c.probeInterval)
+	}
+	return c.rpc.Invoke(ctx, method, args, reply, opts...)
+}
+
+// NewStream always uses direct gRPC: the RPC/ABCI transport cannot serve
+// streams, so there is nothing to fall back to.
+func (c *fallbackConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return c.direct.NewStream(ctx, desc, method, opts...)
+}
+
+// isTransportDown reports whether err means the chain gRPC endpoint is
+// unreachable, as opposed to the query itself being rejected.
+func isTransportDown(err error) bool {
+	if err == nil {
+		return false
+	}
+	if st, ok := status.FromError(err); ok {
+		return st.Code() == codes.Unavailable
+	}
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.ECONNREFUSED)
+}
+
+// newRPCQueryConn builds a Cosmos SDK client.Context that serves generated query
+// clients over CometBFT RPC. With no GRPCClient set, Context.Invoke wraps each
+// query as an ABCI query against the node's gRPC query router.
+func newRPCQueryConn(rpcURL string) (grpc.ClientConnInterface, error) {
+	if strings.TrimSpace(rpcURL) == "" {
+		return nil, fmt.Errorf("chain: comet rpc url is required for query fallback")
+	}
+	node, err := client.NewClientFromNode(rpcURL)
+	if err != nil {
+		return nil, fmt.Errorf("chain: comet rpc client %s: %w", rpcURL, err)
+	}
+
+	registry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(registry)
+	authtypes.RegisterInterfaces(registry)
+	inferencetypes.RegisterInterfaces(registry)
+	blstypes.RegisterInterfaces(registry)
+	restrictionstypes.RegisterInterfaces(registry)
+
+	return client.Context{}.
+		WithClient(node).
+		WithNodeURI(rpcURL).
+		WithCodec(codec.NewProtoCodec(registry)).
+		WithInterfaceRegistry(registry), nil
+}

--- a/common/chain/fallback.go
+++ b/common/chain/fallback.go
@@ -23,11 +23,21 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"common/observability"
 )
 
 // DefaultRPCProbeInterval is how long queries stay on CometBFT RPC before a
 // single request is allowed to probe direct gRPC again.
 const DefaultRPCProbeInterval = 30 * time.Minute
+
+// broadcastTxMethod is the one method on the tx service that is not a query.
+// The fallback rejects it outright because both of its transports would get it
+// wrong: client.Context.Invoke special-cases the request type and broadcasts it
+// over CometBFT instead of querying, and a transport failure here is retried on
+// the other transport, which for a broadcast means submitting the same signed
+// transaction twice. Transactions belong on Client.Conn().
+const broadcastTxMethod = "/cosmos.tx.v1beta1.Service/BroadcastTx"
 
 // fallbackConn routes unary query invocations over direct chain gRPC while that
 // endpoint is reachable, and over CometBFT RPC/ABCI while it is not.
@@ -50,6 +60,10 @@ type fallbackConn struct {
 }
 
 func newFallbackConn(direct, rpc grpc.ClientConnInterface, probeInterval time.Duration, now func() time.Time) *fallbackConn {
+	// Publish the starting transport so the gauge exists from process start.
+	// Without it "no comet-rpc series" is ambiguous between healthy and
+	// never-reported.
+	observability.Chain.SetQueryTransport(observability.TransportGRPC)
 	return &fallbackConn{
 		direct:        direct,
 		rpc:           rpc,
@@ -103,30 +117,117 @@ func (c *fallbackConn) probeFailed() {
 	c.nextProbeAt = c.now().Add(c.probeInterval)
 }
 
+// probeNoVerdict releases the probe as if it had never run: the attempt proved
+// nothing either way, so it must neither change transports nor push back a
+// probe window that has already come due.
+func (c *fallbackConn) probeNoVerdict() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.probing = false
+}
+
 func (c *fallbackConn) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
+	if method == broadcastTxMethod {
+		return status.Errorf(codes.InvalidArgument,
+			"chain: %s must not run on the query fallback; broadcast transactions on Client.Conn()", method)
+	}
+
 	useRPC, probe := c.route()
 	if useRPC {
 		return c.rpc.Invoke(ctx, method, args, reply, opts...)
 	}
 
 	err := c.direct.Invoke(ctx, method, args, reply, opts...)
-	if !isTransportDown(err) {
-		// Any other outcome, including application errors, proves gRPC is
-		// reachable — keep it primary.
-		if probe {
-			c.probeSucceeded()
-			slog.Info("chain: direct gRPC reachable again, queries back on gRPC", "method", method)
-		}
-		return err
-	}
 
 	if probe {
-		c.probeFailed()
-	} else if c.enterRPC() {
+		switch classifyProbe(ctx, err) {
+		case grpcAnswered:
+			c.probeSucceeded()
+			observability.Chain.SetQueryTransport(observability.TransportGRPC)
+			slog.Info("chain: direct gRPC reachable again, queries back on gRPC", "method", method)
+			return err
+
+		case noVerdict:
+			// The caller went away or ran out of time, so this attempt says
+			// nothing about gRPC. Reading it as reachable would move every
+			// query back onto an endpoint that was never shown to answer. The
+			// caller is already gone, so an RPC retry would only fail too.
+			c.probeNoVerdict()
+			slog.Debug("chain: gRPC probe ended without a verdict, staying on CometBFT RPC",
+				"method", method, "error", err)
+			return err
+
+		default: // grpcDown
+			c.probeFailed()
+			// One line per probe interval is the heartbeat that keeps a
+			// long-running fallback visible: without it the only trace of a
+			// week on RPC is a single warning from the day it started.
+			slog.Warn("chain: direct gRPC still unreachable, queries staying on CometBFT RPC",
+				"method", method, "error", err, "retry_after", c.probeInterval)
+			return c.retryOnRPC(ctx, method, err, args, reply, opts)
+		}
+	}
+
+	if !isTransportDown(err) {
+		return err
+	}
+	if c.enterRPC() {
+		observability.Chain.SetQueryTransport(observability.TransportCometRPC)
 		slog.Warn("chain: direct gRPC unreachable, queries falling back to CometBFT RPC",
 			"method", method, "error", err, "retry_after", c.probeInterval)
 	}
-	return c.rpc.Invoke(ctx, method, args, reply, opts...)
+	return c.retryOnRPC(ctx, method, err, args, reply, opts)
+}
+
+// retryOnRPC serves a request that direct gRPC could not, keeping the original
+// transport error attached. Without it a node that is unreachable on both ports
+// reports only the RPC-side failure, which hides why the fallback engaged.
+func (c *fallbackConn) retryOnRPC(
+	ctx context.Context,
+	method string,
+	grpcErr error,
+	args, reply any,
+	opts []grpc.CallOption,
+) error {
+	rpcErr := c.rpc.Invoke(ctx, method, args, reply, opts...)
+	if rpcErr == nil {
+		return nil
+	}
+	return fmt.Errorf("chain: %s failed on gRPC (%w) and on CometBFT RPC: %w", method, grpcErr, rpcErr)
+}
+
+// probeVerdict is what a probe attempt proved about the direct gRPC endpoint.
+type probeVerdict int
+
+const (
+	// grpcAnswered means the endpoint replied, even if the reply was an
+	// application error.
+	grpcAnswered probeVerdict = iota
+	// grpcDown means the transport itself failed.
+	grpcDown
+	// noVerdict means the attempt ended before either could be established,
+	// because the caller canceled it or its deadline expired.
+	noVerdict
+)
+
+func classifyProbe(ctx context.Context, err error) probeVerdict {
+	if isTransportDown(err) {
+		return grpcDown
+	}
+	if err == nil {
+		return grpcAnswered
+	}
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded:
+		return noVerdict
+	}
+	// A wrapper may surface a bare context error instead of a gRPC status, and
+	// a context that is already done means the attempt was cut short whatever
+	// the error says.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+		return noVerdict
+	}
+	return grpcAnswered
 }
 
 // NewStream always uses direct gRPC: the RPC/ABCI transport cannot serve
@@ -151,7 +252,20 @@ func isTransportDown(err error) bool {
 
 // newRPCQueryConn builds a Cosmos SDK client.Context that serves generated query
 // clients over CometBFT RPC. With no GRPCClient set, Context.Invoke wraps each
-// query as an ABCI query against the node's gRPC query router.
+// query as an ABCI query against the node's gRPC query router. It is wrapped in
+// the same span recorder as the direct conn, tagged with its own transport, so
+// switching to the fallback changes which transport spans report rather than
+// making them stop.
+//
+// Known limitation: module queries (inference, BLS, restrictions) are registered
+// on that router by every node, but the CometBFT service
+// (cosmos.base.tendermint.v1beta1) is registered only when app.toml sets
+// grpc.enable or api.enable, because the SDK gates RegisterTendermintService on
+// them. grpc.enable defaults to true and no deployment here turns it off, so in
+// practice those queries resolve; a node with both disabled would answer them
+// with Unimplemented while module queries kept working. Serving them from
+// CometBFT's own /status, /block and /validators endpoints would close that gap
+// if such a node ever needs supporting.
 func newRPCQueryConn(rpcURL string) (grpc.ClientConnInterface, error) {
 	if strings.TrimSpace(rpcURL) == "" {
 		return nil, fmt.Errorf("chain: comet rpc url is required for query fallback")
@@ -168,9 +282,11 @@ func newRPCQueryConn(rpcURL string) (grpc.ClientConnInterface, error) {
 	blstypes.RegisterInterfaces(registry)
 	restrictionstypes.RegisterInterfaces(registry)
 
-	return client.Context{}.
+	rpcCtx := client.Context{}.
 		WithClient(node).
 		WithNodeURI(rpcURL).
 		WithCodec(codec.NewProtoCodec(registry)).
-		WithInterfaceRegistry(registry), nil
+		WithInterfaceRegistry(registry)
+
+	return observability.NewObservedConnWithTransport(rpcCtx, observability.TransportCometRPC), nil
 }

--- a/common/chain/fallback_internal_test.go
+++ b/common/chain/fallback_internal_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
 
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -194,6 +196,73 @@ func TestFallback_ProbeSucceedsOnApplicationError(t *testing.T) {
 	assert.Equal(t, 1, rpc.calls())
 }
 
+// onRPC reports whether queries are currently served over CometBFT RPC. An
+// aborted probe re-probes immediately, so call counts alone cannot tell a
+// retried probe apart from a restored gRPC transport.
+func onRPC(c *fallbackConn) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.usingRPC
+}
+
+func TestFallback_CanceledProbeDoesNotRestoreGRPC(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+	require.Equal(t, 1, direct.calls())
+	require.True(t, onRPC(fb))
+
+	// The probe is cut short by its caller, which says nothing about whether
+	// gRPC is reachable.
+	direct.setErr(status.Error(codes.Canceled, "context canceled"))
+	clock.advance(testProbeInterval)
+	require.Error(t, invoke(fb))
+
+	assert.Equal(t, 2, direct.calls())
+	assert.Equal(t, 1, rpc.calls(), "a probe with no verdict must not retry on RPC")
+	assert.True(t, onRPC(fb), "an aborted probe must not restore gRPC")
+}
+
+func TestFallback_ProbeWithDoneContextDoesNotRestoreGRPC(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+
+	// A bare context error rather than a gRPC status must read the same way.
+	direct.setErr(context.Canceled)
+	clock.advance(testProbeInterval)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Error(t, fb.Invoke(ctx, "/test.Service/Query", &struct{}{}, &struct{}{}))
+
+	assert.Equal(t, 2, direct.calls())
+	assert.True(t, onRPC(fb), "an aborted probe must not restore gRPC")
+}
+
+func TestFallback_AbortedProbeDoesNotDelayTheNextProbe(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+
+	direct.setErr(status.Error(codes.DeadlineExceeded, "timeout"))
+	clock.advance(testProbeInterval)
+	require.Error(t, invoke(fb))
+	require.Equal(t, 2, direct.calls())
+	require.True(t, onRPC(fb))
+
+	// The aborted attempt did not consume the probe window, so the next request
+	// probes again straight away rather than waiting another whole interval.
+	direct.setErr(nil)
+	require.NoError(t, invoke(fb))
+	assert.Equal(t, 3, direct.calls())
+	assert.False(t, onRPC(fb), "a probe that answered restores gRPC")
+	assert.Equal(t, 1, rpc.calls())
+}
+
 func TestFallback_OnlyOneRequestProbesGRPC(t *testing.T) {
 	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
 	fb, clock := newTestFallback(direct, rpc)
@@ -227,6 +296,176 @@ func TestFallback_OnlyOneRequestProbesGRPC(t *testing.T) {
 	// back, so every request still hit RPC once.
 	assert.Equal(t, 2, direct.calls())
 	assert.Equal(t, concurrent+1, rpc.calls())
+}
+
+func TestFallback_BothTransportsDownReportsBothErrors(t *testing.T) {
+	rpcErr := status.Error(codes.Internal, "abci query failed")
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{err: rpcErr}
+	fb, _ := newTestFallback(direct, rpc)
+
+	err := invoke(fb)
+	require.Error(t, err)
+
+	// Reporting only the RPC failure hides why the fallback engaged at all, so
+	// both causes must stay reachable.
+	assert.ErrorIs(t, err, errUnavailable, "the original gRPC failure must survive")
+	assert.ErrorIs(t, err, rpcErr, "the RPC failure must survive")
+	assert.Contains(t, err.Error(), "/test.Service/Query")
+
+	// status.FromError unwraps to the first cause, so a node that answers on
+	// neither transport reports Unavailable rather than the RPC-side code.
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+	assert.Contains(t, err.Error(), "abci query failed")
+}
+
+func TestFallback_FailedProbeWithDeadRPCReportsBothErrors(t *testing.T) {
+	rpcErr := status.Error(codes.Internal, "abci query failed")
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+
+	rpc.setErr(rpcErr)
+	clock.advance(testProbeInterval)
+	err := invoke(fb)
+	require.Error(t, err)
+
+	assert.ErrorIs(t, err, errUnavailable)
+	assert.ErrorIs(t, err, rpcErr)
+}
+
+func TestFallback_SuccessfulRPCRetryHidesTheGRPCError(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, _ := newTestFallback(direct, rpc)
+
+	// Callers must not see an error for a request the fallback served.
+	require.NoError(t, invoke(fb))
+}
+
+// logCounter counts records emitted at a given level, to assert that a
+// transition is announced once rather than once per racing request.
+type logCounter struct {
+	mu    sync.Mutex
+	level slog.Level
+	count int
+}
+
+func (h *logCounter) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *logCounter) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if r.Level == h.level {
+		h.count++
+	}
+	return nil
+}
+
+func (h *logCounter) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *logCounter) WithGroup(string) slog.Handler      { return h }
+
+func (h *logCounter) total() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.count
+}
+
+func TestFallback_ConcurrentFailuresAnnounceFallbackOnce(t *testing.T) {
+	counter := &logCounter{level: slog.LevelWarn}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(counter))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	release := make(chan struct{})
+	direct := &stubConn{err: errUnavailable, block: release}
+	rpc := &stubConn{}
+	fb, _ := newTestFallback(direct, rpc)
+
+	const concurrent = 8
+	var wg sync.WaitGroup
+	wg.Add(concurrent)
+	for range concurrent {
+		go func() {
+			defer wg.Done()
+			_ = invoke(fb)
+		}()
+	}
+
+	// Hold every request inside the gRPC call so they all routed while
+	// usingRPC was still false, then let them fail together and race on the
+	// transition.
+	require.Eventually(t, func() bool { return direct.calls() == concurrent },
+		time.Second, time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, concurrent, direct.calls(), "every request tries gRPC before the switch")
+	assert.Equal(t, concurrent, rpc.calls(), "and every request is then served over RPC")
+	assert.Equal(t, 1, counter.total(), "the transition must be logged once, not once per request")
+}
+
+func TestFallback_EveryProbeIntervalReannouncesTheDegradation(t *testing.T) {
+	counter := &logCounter{level: slog.LevelWarn}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(counter))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+
+	// Announcing only the transition would leave a service that has been on
+	// RPC for a week looking exactly like one that never fell back at all.
+	for range 2 {
+		clock.advance(testProbeInterval)
+		require.NoError(t, invoke(fb))
+	}
+
+	assert.Equal(t, 3, counter.total(), "the transition plus one line per failed probe")
+}
+
+// txServiceClient is the client any caller would build on QueryConn if they
+// mistook it for a general-purpose conn. Driving the test through it rather than
+// the method string checks the guard against the name the SDK actually emits.
+func txServiceClient(conn grpc.ClientConnInterface) txtypes.ServiceClient {
+	return txtypes.NewServiceClient(conn)
+}
+
+func TestFallback_RejectsTxBroadcastOnBothTransports(t *testing.T) {
+	direct, rpc := &stubConn{}, &stubConn{}
+	fb, _ := newTestFallback(direct, rpc)
+
+	_, err := txServiceClient(fb).BroadcastTx(context.Background(), &txtypes.BroadcastTxRequest{})
+	require.Error(t, err)
+
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "Client.Conn()")
+	assert.Zero(t, direct.calls(), "a broadcast must not reach either transport")
+	assert.Zero(t, rpc.calls())
+}
+
+func TestFallback_TxServiceQueriesStillRoute(t *testing.T) {
+	direct, rpc := &stubConn{}, &stubConn{}
+	fb, _ := newTestFallback(direct, rpc)
+
+	// Only broadcasting is barred. GetTx and friends are ordinary queries and
+	// must keep working, fallback included.
+	_, err := txServiceClient(fb).GetTx(context.Background(), &txtypes.GetTxRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, direct.calls())
+}
+
+func TestQueryConn_RejectsBroadcastEvenWhenGRPCIsHealthy(t *testing.T) {
+	c, err := NewWithRPCFallback("localhost:9090", "http://localhost:26657")
+	require.NoError(t, err)
+
+	// Failing closed from the first call is the point: a broadcast that worked
+	// until the day gRPC dropped would submit the same signed transaction on
+	// both transports exactly when nobody is watching.
+	_, err = txServiceClient(c.QueryConn()).BroadcastTx(context.Background(), &txtypes.BroadcastTxRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 func TestFallback_StreamsAlwaysUseDirectGRPC(t *testing.T) {
@@ -278,7 +517,9 @@ func TestNewWithRPCFallback_QueriesUseFallbackTxUsesDirect(t *testing.T) {
 	require.True(t, isFallback, "queries must go through the fallback conn")
 	_, txIsFallback := c.Conn().(*fallbackConn)
 	assert.False(t, txIsFallback, "transactions must stay on direct gRPC")
-	assert.Equal(t, c.Conn(), fallback.direct)
+	// observability.ObservedConn is a struct value rather than a pointer, so
+	// equality is the identity check available here.
+	assert.Equal(t, c.Conn(), fallback.direct, "the fallback must probe the conn txs use")
 	assert.Equal(t, DefaultRPCProbeInterval, fallback.probeInterval)
 }
 

--- a/common/chain/fallback_internal_test.go
+++ b/common/chain/fallback_internal_test.go
@@ -1,0 +1,299 @@
+package chain
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const testProbeInterval = 30 * time.Minute
+
+// stubConn records the methods invoked on it and returns a scripted error.
+type stubConn struct {
+	mu      sync.Mutex
+	methods []string
+	err     error
+	// block, when non-nil, holds every Invoke until it is closed.
+	block chan struct{}
+}
+
+func (s *stubConn) Invoke(_ context.Context, method string, _, _ any, _ ...grpc.CallOption) error {
+	s.mu.Lock()
+	s.methods = append(s.methods, method)
+	block := s.block
+	err := s.err
+	s.mu.Unlock()
+
+	if block != nil {
+		<-block
+	}
+	return err
+}
+
+func (s *stubConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	s.mu.Lock()
+	s.methods = append(s.methods, "stream")
+	s.mu.Unlock()
+	return nil, s.err
+}
+
+func (s *stubConn) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+
+func (s *stubConn) calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.methods)
+}
+
+// fakeClock is a manually advanced clock for probe-interval assertions.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func newTestFallback(direct, rpc *stubConn) (*fallbackConn, *fakeClock) {
+	clock := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	return newFallbackConn(direct, rpc, testProbeInterval, clock.Now), clock
+}
+
+func invoke(c *fallbackConn) error {
+	return c.Invoke(context.Background(), "/test.Service/Query", &struct{}{}, &struct{}{})
+}
+
+var errUnavailable = status.Error(codes.Unavailable, "connection refused")
+
+func TestFallback_HealthyGRPCNeverTouchesRPC(t *testing.T) {
+	direct, rpc := &stubConn{}, &stubConn{}
+	fb, _ := newTestFallback(direct, rpc)
+
+	for range 3 {
+		require.NoError(t, invoke(fb))
+	}
+
+	assert.Equal(t, 3, direct.calls())
+	assert.Zero(t, rpc.calls())
+}
+
+func TestFallback_ApplicationErrorsStayOnGRPC(t *testing.T) {
+	appErr := status.Error(codes.NotFound, "no such participant")
+	direct, rpc := &stubConn{err: appErr}, &stubConn{}
+	fb, _ := newTestFallback(direct, rpc)
+
+	require.ErrorIs(t, invoke(fb), appErr)
+	require.ErrorIs(t, invoke(fb), appErr)
+
+	assert.Equal(t, 2, direct.calls())
+	assert.Zero(t, rpc.calls(), "application errors must not trigger fallback")
+}
+
+func TestFallback_DisconnectRetriesSameRequestOnRPC(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, _ := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb), "the failed request must be retried on RPC")
+	assert.Equal(t, 1, direct.calls())
+	assert.Equal(t, 1, rpc.calls())
+}
+
+func TestFallback_RPCModeIsStickyUntilProbeInterval(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+	require.Equal(t, 1, direct.calls())
+
+	// Well inside the probe interval: nothing should reach gRPC again.
+	clock.advance(testProbeInterval - time.Second)
+	for range 5 {
+		require.NoError(t, invoke(fb))
+	}
+	assert.Equal(t, 1, direct.calls())
+	assert.Equal(t, 6, rpc.calls())
+}
+
+func TestFallback_ProbeRestoresGRPCAfterInterval(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+	require.Equal(t, 1, direct.calls())
+
+	// gRPC comes back (e.g. the node enabled :9090) and the interval elapses.
+	direct.setErr(nil)
+	clock.advance(testProbeInterval)
+
+	require.NoError(t, invoke(fb))
+	assert.Equal(t, 2, direct.calls())
+	assert.Equal(t, 1, rpc.calls(), "the probe succeeded, so no RPC retry")
+
+	// Subsequent requests go straight to gRPC.
+	require.NoError(t, invoke(fb))
+	assert.Equal(t, 3, direct.calls())
+	assert.Equal(t, 1, rpc.calls())
+}
+
+func TestFallback_FailedProbeRetriesOnRPCAndResetsInterval(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+	clock.advance(testProbeInterval)
+
+	// Probe fails: the request still succeeds via RPC.
+	require.NoError(t, invoke(fb))
+	assert.Equal(t, 2, direct.calls())
+	assert.Equal(t, 2, rpc.calls())
+
+	// A fresh interval started, so the next request does not probe again.
+	require.NoError(t, invoke(fb))
+	assert.Equal(t, 2, direct.calls())
+	assert.Equal(t, 3, rpc.calls())
+}
+
+func TestFallback_ProbeSucceedsOnApplicationError(t *testing.T) {
+	appErr := status.Error(codes.InvalidArgument, "bad epoch")
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+
+	// An application error proves the transport is up, so gRPC becomes primary
+	// again and the error surfaces to the caller.
+	direct.setErr(appErr)
+	clock.advance(testProbeInterval)
+	require.ErrorIs(t, invoke(fb), appErr)
+
+	require.ErrorIs(t, invoke(fb), appErr)
+	assert.Equal(t, 3, direct.calls())
+	assert.Equal(t, 1, rpc.calls())
+}
+
+func TestFallback_OnlyOneRequestProbesGRPC(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, clock := newTestFallback(direct, rpc)
+
+	require.NoError(t, invoke(fb))
+	require.Equal(t, 1, direct.calls())
+	clock.advance(testProbeInterval)
+
+	// Hold the probe in flight so concurrent callers see probing == true.
+	release := make(chan struct{})
+	direct.mu.Lock()
+	direct.block = release
+	direct.mu.Unlock()
+
+	const concurrent = 8
+	var wg sync.WaitGroup
+	wg.Add(concurrent)
+	for range concurrent {
+		go func() {
+			defer wg.Done()
+			_ = invoke(fb)
+		}()
+	}
+
+	// Give the goroutines time to route before releasing the probe.
+	assert.Eventually(t, func() bool { return rpc.calls() >= concurrent-1 }, time.Second, time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	// Exactly one of the concurrent requests probed gRPC; it failed and fell
+	// back, so every request still hit RPC once.
+	assert.Equal(t, 2, direct.calls())
+	assert.Equal(t, concurrent+1, rpc.calls())
+}
+
+func TestFallback_StreamsAlwaysUseDirectGRPC(t *testing.T) {
+	direct, rpc := &stubConn{err: errUnavailable}, &stubConn{}
+	fb, _ := newTestFallback(direct, rpc)
+
+	// Force RPC mode first.
+	require.NoError(t, invoke(fb))
+
+	_, err := fb.NewStream(context.Background(), &grpc.StreamDesc{}, "/test.Service/Stream")
+	require.Error(t, err, "RPC/ABCI cannot serve streams, so the direct error surfaces")
+	assert.Equal(t, 1, rpc.calls(), "the stream must not be attempted over RPC")
+}
+
+func TestIsTransportDown(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unavailable", errUnavailable, true},
+		{"not found", status.Error(codes.NotFound, "missing"), false},
+		{"invalid argument", status.Error(codes.InvalidArgument, "bad request"), false},
+		{"canceled", status.Error(codes.Canceled, "context canceled"), false},
+		{"deadline exceeded", status.Error(codes.DeadlineExceeded, "timeout"), false},
+		{"eof", io.EOF, true},
+		{"connection refused", syscall.ECONNREFUSED, true},
+		{"wrapped connection refused", errors.New("dial: " + syscall.ECONNREFUSED.Error()), false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isTransportDown(tc.err))
+		})
+	}
+}
+
+func TestNewWithRPCFallback_QueriesUseFallbackTxUsesDirect(t *testing.T) {
+	c, err := NewWithRPCFallback("localhost:9090", "http://localhost:26657")
+	require.NoError(t, err)
+
+	assert.NotNil(t, c.InferenceQueryClient())
+	assert.NotNil(t, c.BLSQueryClient())
+	assert.NotNil(t, c.RestrictionsQueryClient())
+	assert.NotNil(t, c.CometServiceClient())
+
+	fallback, isFallback := c.QueryConn().(*fallbackConn)
+	require.True(t, isFallback, "queries must go through the fallback conn")
+	_, txIsFallback := c.Conn().(*fallbackConn)
+	assert.False(t, txIsFallback, "transactions must stay on direct gRPC")
+	assert.Equal(t, c.Conn(), fallback.direct)
+	assert.Equal(t, DefaultRPCProbeInterval, fallback.probeInterval)
+}
+
+func TestNewWithRPCFallback_RejectsMissingRPCURL(t *testing.T) {
+	_, err := NewWithRPCFallback("localhost:9090", "  ")
+	require.ErrorContains(t, err, "comet rpc url is required")
+}
+
+func TestNewWithRPCFallback_RejectsUnparsableRPCURL(t *testing.T) {
+	_, err := NewWithRPCFallback("localhost:9090", "http://[::1")
+	require.ErrorContains(t, err, "comet rpc client")
+}
+
+func TestNew_QueryConnIsDirectConn(t *testing.T) {
+	c, err := New("localhost:9090")
+	require.NoError(t, err)
+	assert.Equal(t, c.Conn(), c.QueryConn())
+}

--- a/common/chain/fallback_rpcconn_test.go
+++ b/common/chain/fallback_rpcconn_test.go
@@ -1,0 +1,117 @@
+package chain
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const inferenceParamsMethod = "/inference.inference.Query/Params"
+
+// fakeCometRPC serves CometBFT JSON-RPC abci_query calls, recording the ABCI
+// path each request asked for.
+func fakeCometRPC(t *testing.T, resp abci.ResponseQuery, paths *[]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var req rpctypes.RPCRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		require.Equal(t, "abci_query", req.Method)
+
+		var params struct {
+			Path string `json:"path"`
+		}
+		require.NoError(t, json.Unmarshal(req.Params, &params))
+		if paths != nil {
+			*paths = append(*paths, params.Path)
+		}
+
+		out, err := json.Marshal(rpctypes.NewRPCSuccessResponse(
+			req.ID, &coretypes.ResultABCIQuery{Response: resp},
+		))
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(out)
+	}))
+}
+
+func TestRPCQueryConn_DecodesModuleQueryResponse(t *testing.T) {
+	want := inferencetypes.QueryParamsResponse{Params: inferencetypes.DefaultParams()}
+	payload, err := want.Marshal()
+	require.NoError(t, err)
+
+	var paths []string
+	srv := fakeCometRPC(t, abci.ResponseQuery{Code: 0, Value: payload, Height: 42}, &paths)
+	defer srv.Close()
+
+	conn, err := newRPCQueryConn(srv.URL)
+	require.NoError(t, err)
+
+	var got inferencetypes.QueryParamsResponse
+	err = conn.Invoke(context.Background(), inferenceParamsMethod, &inferencetypes.QueryParamsRequest{}, &got)
+	require.NoError(t, err)
+	require.Equal(t, want.Params, got.Params)
+
+	// The gRPC method name is used verbatim as the ABCI query path, which is
+	// what the node's gRPC query router expects.
+	require.Equal(t, []string{inferenceParamsMethod}, paths)
+}
+
+func TestRPCQueryConn_SurfacesABCIErrorAsGRPCStatus(t *testing.T) {
+	srv := fakeCometRPC(t, abci.ResponseQuery{
+		Code:      uint32(codes.NotFound),
+		Log:       "not found",
+		Codespace: "inference",
+	}, nil)
+	defer srv.Close()
+
+	conn, err := newRPCQueryConn(srv.URL)
+	require.NoError(t, err)
+
+	var got inferencetypes.QueryParamsResponse
+	err = conn.Invoke(context.Background(), inferenceParamsMethod, &inferencetypes.QueryParamsRequest{}, &got)
+	require.Error(t, err)
+
+	// Application-level failures must not look like a dead transport, or the
+	// fallback would flap between gRPC and RPC.
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.NotEqual(t, codes.Unavailable, st.Code())
+	require.False(t, isTransportDown(err))
+}
+
+func TestFallbackConn_ServesQueriesOverRPCAfterGRPCDies(t *testing.T) {
+	want := inferencetypes.QueryParamsResponse{Params: inferencetypes.DefaultParams()}
+	payload, err := want.Marshal()
+	require.NoError(t, err)
+
+	srv := fakeCometRPC(t, abci.ResponseQuery{Code: 0, Value: payload, Height: 7}, nil)
+	defer srv.Close()
+
+	rpcConn, err := newRPCQueryConn(srv.URL)
+	require.NoError(t, err)
+
+	direct := &stubConn{err: errUnavailable}
+	clock := &fakeClock{}
+	client := &Client{
+		conn:      direct,
+		queryConn: newFallbackConn(direct, rpcConn, DefaultRPCProbeInterval, clock.Now),
+	}
+
+	resp, err := client.InferenceQueryClient().Params(context.Background(), &inferencetypes.QueryParamsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, want.Params, resp.Params)
+}

--- a/common/chain/fallback_rpcconn_test.go
+++ b/common/chain/fallback_rpcconn_test.go
@@ -11,13 +11,23 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
+	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	inferencetypes "github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"common/observability"
 )
 
-const inferenceParamsMethod = "/inference.inference.Query/Params"
+const (
+	inferenceParamsMethod = "/inference.inference.Query/Params"
+	cometNodeInfoMethod   = "/cosmos.base.tendermint.v1beta1.Service/GetNodeInfo"
+)
 
 // fakeCometRPC serves CometBFT JSON-RPC abci_query calls, recording the ABCI
 // path each request asked for.
@@ -93,6 +103,26 @@ func TestRPCQueryConn_SurfacesABCIErrorAsGRPCStatus(t *testing.T) {
 	require.False(t, isTransportDown(err))
 }
 
+func TestRPCQueryConn_CometServiceGoesThroughTheABCIRouter(t *testing.T) {
+	// This pins the fallback's one known gap. CometBFT service queries are
+	// tunnelled as ABCI queries like any other, so they depend on the node
+	// having registered that service on its gRPC query router — which the SDK
+	// only does when app.toml sets grpc.enable or api.enable. A node with both
+	// off answers Unimplemented here while module queries keep working.
+	var paths []string
+	srv := fakeCometRPC(t, abci.ResponseQuery{Code: 0}, &paths)
+	defer srv.Close()
+
+	conn, err := newRPCQueryConn(srv.URL)
+	require.NoError(t, err)
+
+	var got cmtservice.GetNodeInfoResponse
+	_ = conn.Invoke(context.Background(), cometNodeInfoMethod, &cmtservice.GetNodeInfoRequest{}, &got)
+
+	// Not /status: the request is a store-router query addressed by method name.
+	require.Equal(t, []string{cometNodeInfoMethod}, paths)
+}
+
 func TestFallbackConn_ServesQueriesOverRPCAfterGRPCDies(t *testing.T) {
 	want := inferencetypes.QueryParamsResponse{Params: inferencetypes.DefaultParams()}
 	payload, err := want.Marshal()
@@ -114,4 +144,46 @@ func TestFallbackConn_ServesQueriesOverRPCAfterGRPCDies(t *testing.T) {
 	resp, err := client.InferenceQueryClient().Params(context.Background(), &inferencetypes.QueryParamsRequest{})
 	require.NoError(t, err)
 	require.Equal(t, want.Params, resp.Params)
+}
+
+func TestFallbackConn_RPCQueriesAreStillTraced(t *testing.T) {
+	want := inferencetypes.QueryParamsResponse{Params: inferencetypes.DefaultParams()}
+	payload, err := want.Marshal()
+	require.NoError(t, err)
+
+	srv := fakeCometRPC(t, abci.ResponseQuery{Code: 0, Value: payload, Height: 7}, nil)
+	defer srv.Close()
+
+	recorder := tracetest.NewSpanRecorder()
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)))
+	t.Cleanup(func() { otel.SetTracerProvider(previous) })
+
+	rpcConn, err := newRPCQueryConn(srv.URL)
+	require.NoError(t, err)
+
+	// The direct conn is unwrapped, so any span here came from the RPC side.
+	direct := &stubConn{err: errUnavailable}
+	fallback := newFallbackConn(direct, rpcConn, DefaultRPCProbeInterval, (&fakeClock{}).Now)
+
+	_, err = inferencetypes.NewQueryClient(fallback).Params(
+		context.Background(), &inferencetypes.QueryParamsRequest{})
+	require.NoError(t, err)
+
+	// Falling back must change what the spans say, not stop them: losing
+	// tracing on the degraded path blinds you exactly when it matters.
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "chain.grpc.query", spans[0].Name())
+	require.Equal(t, observability.TransportCometRPC, spanAttr(spans[0].Attributes(), "chain.transport"))
+	require.Equal(t, "Params", spanAttr(spans[0].Attributes(), "rpc.method"))
+}
+
+func spanAttr(attrs []attribute.KeyValue, key string) string {
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
 }

--- a/common/go.mod
+++ b/common/go.mod
@@ -29,7 +29,9 @@ require (
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
+	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.47.0
@@ -227,7 +229,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.20.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect

--- a/common/observability/chain.go
+++ b/common/observability/chain.go
@@ -3,9 +3,21 @@ package observability
 import (
 	"context"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// Transports name the paths a chain query can take. They label spans and the
+// active-transport gauge, so a service running degraded is visible rather than
+// merely slower.
+const (
+	TransportGRPC     = "grpc"
+	TransportCometRPC = "comet-rpc"
+)
+
+const transportAttr = "chain.transport"
 
 // ChainTracer instruments Cosmos chain queries. Mirrors decentralized-api
 // observability.Chain for ABCI store and gRPC query spans.
@@ -13,6 +25,40 @@ type ChainTracer struct{}
 
 // Chain is the process-wide chain tracer shorthand.
 var Chain ChainTracer
+
+// chainTransportActive carries 1 for the transport queries currently run on and
+// 0 for the others, so an alert on the comet-rpc series firing for longer than a
+// blip catches a fallback nobody noticed. The global meter delegates to whatever
+// provider the process installs and stays a no-op when it installs none.
+var chainTransportActive = newTransportGauge()
+
+func newTransportGauge() metric.Int64Gauge {
+	gauge, err := otel.Meter(string(tracerName.Chain)).Int64Gauge(
+		"chain.query.transport.active",
+		metric.WithDescription("1 for the transport chain queries currently run on, 0 for the others"),
+	)
+	if err != nil {
+		return nil
+	}
+	return gauge
+}
+
+// SetQueryTransport records which transport chain queries are being served by.
+// Callers report every transition, including the initial one, so the gauge is
+// never absent for a live client.
+func (*ChainTracer) SetQueryTransport(active string) {
+	if chainTransportActive == nil {
+		return
+	}
+	for _, transport := range []string{TransportGRPC, TransportCometRPC} {
+		value := int64(0)
+		if transport == active {
+			value = 1
+		}
+		chainTransportActive.Record(context.Background(), value,
+			metric.WithAttributes(attribute.String(transportAttr, transport)))
+	}
+}
 
 // StartStoreQuery opens the span around an ABCI store query.
 func (*ChainTracer) StartStoreQuery(ctx context.Context, storeKey string, withProof bool, height int64) (context.Context, *Operation) {
@@ -30,8 +76,9 @@ func (*ChainTracer) StartStoreQuery(ctx context.Context, storeKey string, withPr
 	)
 }
 
-// StartGRPCQuery opens the span around a Cosmos gRPC query.
-func (*ChainTracer) StartGRPCQuery(ctx context.Context, service, method string) (context.Context, *Operation) {
+// StartGRPCQuery opens the span around a Cosmos gRPC query. transport names the
+// path actually carrying it, which is not always direct gRPC.
+func (*ChainTracer) StartGRPCQuery(ctx context.Context, service, method, transport string) (context.Context, *Operation) {
 	return StartOperation(
 		ctx,
 		tracerName.Chain,
@@ -41,6 +88,7 @@ func (*ChainTracer) StartGRPCQuery(ctx context.Context, service, method string) 
 			attribute.String("rpc.system", "grpc"),
 			attribute.String("rpc.service", service),
 			attribute.String("rpc.method", method),
+			attribute.String(transportAttr, transport),
 		},
 	)
 }

--- a/common/observability/chain_test.go
+++ b/common/observability/chain_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
@@ -31,6 +33,58 @@ func TestChainStartStoreQueryCreatesSpan(t *testing.T) {
 	require.Equal(t, true, attrBool(spans[0].Attributes(), "query.with_proof"))
 	require.Equal(t, int64(42), attrInt64(spans[0].Attributes(), "query.height"))
 	_ = ctx
+}
+
+// TestChainSetQueryTransportRecordsTheActiveTransport must be the only test in
+// this binary that installs a meter provider: the gauge is built from the global
+// meter at package init, and OTel binds such an instrument to the first provider
+// installed and no other.
+func TestChainSetQueryTransportRecordsTheActiveTransport(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	observability.Chain.SetQueryTransport(observability.TransportCometRPC)
+
+	// Both series are reported every time. A gauge that only emitted the
+	// active transport would leave the previous one stuck at 1 forever.
+	require.Equal(t, map[string]int64{
+		observability.TransportGRPC:     0,
+		observability.TransportCometRPC: 1,
+	}, collectTransportGauge(t, reader))
+
+	observability.Chain.SetQueryTransport(observability.TransportGRPC)
+
+	require.Equal(t, map[string]int64{
+		observability.TransportGRPC:     1,
+		observability.TransportCometRPC: 0,
+	}, collectTransportGauge(t, reader))
+}
+
+func collectTransportGauge(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &collected))
+
+	for _, scope := range collected.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "chain.query.transport.active" {
+				continue
+			}
+			gauge, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok, "expected an int64 gauge, got %T", m.Data)
+
+			values := make(map[string]int64, len(gauge.DataPoints))
+			for _, point := range gauge.DataPoints {
+				transport, ok := point.Attributes.Value("chain.transport")
+				require.True(t, ok, "every point must name its transport")
+				values[transport.AsString()] = point.Value
+			}
+			return values
+		}
+	}
+	t.Fatal("chain.query.transport.active was never recorded")
+	return nil
 }
 
 func attrString(attrs []attribute.KeyValue, key string) string {

--- a/common/observability/grpc.go
+++ b/common/observability/grpc.go
@@ -16,11 +16,19 @@ import (
 // (same split as decentralized-api/cosmosclient/query.go vs query_client_conn.go).
 type ObservedConn struct {
 	grpc.ClientConnInterface
+	transport string
 }
 
 // NewObservedConn returns a conn wrapper that records OTel spans.
 func NewObservedConn(conn grpc.ClientConnInterface) ObservedConn {
-	return ObservedConn{ClientConnInterface: conn}
+	return NewObservedConnWithTransport(conn, TransportGRPC)
+}
+
+// NewObservedConnWithTransport is NewObservedConn for a conn that reaches the
+// chain by something other than direct gRPC. The transport lands on every span
+// so a query served by a fallback is distinguishable from a healthy one.
+func NewObservedConnWithTransport(conn grpc.ClientConnInterface, transport string) ObservedConn {
+	return ObservedConn{ClientConnInterface: conn, transport: transport}
 }
 
 func (c ObservedConn) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
@@ -29,7 +37,7 @@ func (c ObservedConn) Invoke(ctx context.Context, method string, args any, reply
 	}
 
 	service, rpcMethod := splitGRPCMethod(method)
-	queryCtx, queryOp := Chain.StartGRPCQuery(ctx, service, rpcMethod)
+	queryCtx, queryOp := Chain.StartGRPCQuery(ctx, service, rpcMethod, c.transportName())
 	var (
 		err     error
 		spanErr error
@@ -49,6 +57,15 @@ func (c ObservedConn) Invoke(ctx context.Context, method string, args any, reply
 
 func (c ObservedConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	return c.ClientConnInterface.NewStream(ctx, desc, method, opts...)
+}
+
+// transportName keeps the zero value meaning direct gRPC, which is what every
+// ObservedConn was before transports were labelled.
+func (c ObservedConn) transportName() string {
+	if c.transport == "" {
+		return TransportGRPC
+	}
+	return c.transport
 }
 
 func splitGRPCMethod(fullMethod string) (string, string) {

--- a/common/observability/grpc_test.go
+++ b/common/observability/grpc_test.go
@@ -1,0 +1,75 @@
+package observability_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"google.golang.org/grpc"
+
+	"common/observability"
+)
+
+// stubConn answers every invocation without touching a network.
+type stubConn struct{}
+
+func (stubConn) Invoke(context.Context, string, any, any, ...grpc.CallOption) error { return nil }
+
+func (stubConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, nil
+}
+
+func recordSpans(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)))
+	t.Cleanup(func() { otel.SetTracerProvider(previous) })
+	return recorder
+}
+
+func TestObservedConnLabelsSpansWithItsTransport(t *testing.T) {
+	cases := []struct {
+		name string
+		conn observability.ObservedConn
+		want string
+	}{
+		{"direct", observability.NewObservedConn(stubConn{}), observability.TransportGRPC},
+		{
+			"fallback",
+			observability.NewObservedConnWithTransport(stubConn{}, observability.TransportCometRPC),
+			observability.TransportCometRPC,
+		},
+		// A conn built without a transport predates the label and was always
+		// direct gRPC, so it must not report an empty one.
+		{"zero value", observability.ObservedConn{ClientConnInterface: stubConn{}}, observability.TransportGRPC},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := recordSpans(t)
+
+			require.NoError(t, tc.conn.Invoke(
+				context.Background(), "/inference.inference.Query/Params", nil, nil))
+
+			spans := recorder.Ended()
+			require.Len(t, spans, 1)
+			require.Equal(t, tc.want, attrString(spans[0].Attributes(), "chain.transport"))
+		})
+	}
+}
+
+func TestObservedConnSkipsABCIQuery(t *testing.T) {
+	recorder := recordSpans(t)
+
+	// Call sites wrap these in chain.store.query spans themselves, so a span
+	// here would double-count them.
+	conn := observability.NewObservedConn(stubConn{})
+	require.NoError(t, conn.Invoke(
+		context.Background(), "/cosmos.base.tendermint.v1beta1.Service/ABCIQuery", nil, nil))
+
+	require.Empty(t, recorder.Ended())
+}

--- a/deploy/join/docker-compose.edge-api-multi.yml
+++ b/deploy/join/docker-compose.edge-api-multi.yml
@@ -13,6 +13,7 @@ x-edge-api: &edge-api
   environment:
     - EDGE_API_PORT=18080
     - CHAIN_GRPC_URL=node:9090
+    - CHAIN_RPC_URL=http://node:26657
     - EDGE_API_OTEL_ENABLED=${EDGE_API_OTEL_ENABLED:-false}
     - OTEL_ENDPOINT=${OTEL_ENDPOINT:-}
     - OTEL_HEADERS=${OTEL_HEADERS:-}

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -93,6 +93,7 @@ services:
     environment:
       - EDGE_API_PORT=18080
       - CHAIN_GRPC_URL=node:9090
+      - CHAIN_RPC_URL=http://node:26657
       - EDGE_API_OTEL_ENABLED=${EDGE_API_OTEL_ENABLED:-false}
       - OTEL_ENDPOINT=${OTEL_ENDPOINT:-}
       - OTEL_HEADERS=${OTEL_HEADERS:-}

--- a/devshard/bridge/grpc.go
+++ b/devshard/bridge/grpc.go
@@ -31,8 +31,13 @@ func NewGRPCBridge(client *chain.Client) *GRPCBridge {
 	return &GRPCBridge{client: client}
 }
 
-// NewGRPCBridgeFromURL dials grpcURL and returns a bridge. Caller must not close
-// the underlying connection while the bridge is in use.
+// NewGRPCBridgeFromURL dials grpcURL and returns a bridge on direct gRPC only.
+// Caller must not close the underlying connection while the bridge is in use.
+//
+// Production wiring builds the bridge from the gateway's chain client
+// (NewGRPCBridge), so it inherits that client's CometBFT RPC query fallback.
+// This constructor exists for tests that want to exercise gRPC itself, where a
+// silent fallback would hide the failure under test.
 func NewGRPCBridgeFromURL(grpcURL string) (*GRPCBridge, error) {
 	client, err := chain.New(grpcURL)
 	if err != nil {

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -115,7 +115,6 @@ const (
 type bootstrapOptions struct {
 	escrowID          string
 	privateKeyHex     string
-	chainGRPC         string
 	publicAPI         string
 	defaultModel      string
 	storagePath       string
@@ -178,7 +177,6 @@ func mustLoadBootstrapOptions(flags cliFlags, baseStorageDir string) bootstrapOp
 		multiMode:      strings.TrimSpace(os.Getenv("DEVSHARDS_JSON")) != "",
 		escrowID:       firstNonEmpty(flags.escrowID, os.Getenv("DEVSHARD_ESCROW_ID")),
 		privateKeyHex:  firstNonEmpty(flags.privateKey, os.Getenv("DEVSHARD_PRIVATE_KEY")),
-		chainGRPC:      effectiveChainGRPC(flags, ""),
 		publicAPI:      envOverride(flags.publicAPI, os.Getenv("DEVSHARD_PUBLIC_API"), defaultPublicAPIURL),
 		defaultModel:   envOverride(flags.model, os.Getenv("DEVSHARD_MODEL"), defaultModelName),
 		storagePath:    firstNonEmpty(flags.storagePath, os.Getenv("DEVSHARD_STORAGE_PATH")),
@@ -357,20 +355,23 @@ func mustBootstrapGatewayState(gatewayStore *GatewayStore, opts bootstrapOptions
 	}
 }
 
-func resolveChainGRPCURL() string {
-	return firstNonEmpty(
-		os.Getenv("DEVSHARD_CHAIN_GRPC"),
-		os.Getenv("NODE_GRPC_URL"),
-		defaultChainGRPCURL,
-	)
-}
-
+// effectiveChainGRPC resolves the chain gRPC endpoint the gateway stores in its
+// settings. Only mustBuildGateway dials it; the other callers persist or repair
+// the setting, which is why the CometBFT RPC endpoint is resolved at the dial
+// site instead of being threaded through here.
 func effectiveChainGRPC(flags cliFlags, persisted string) string {
 	envVal := firstNonEmpty(os.Getenv("DEVSHARD_CHAIN_GRPC"), os.Getenv("NODE_GRPC_URL"))
 	if strings.TrimSpace(persisted) != "" && persisted != defaultChainGRPCURL {
 		return strings.TrimSpace(persisted)
 	}
 	return envOverride(flags.chainGRPC, envVal, defaultChainGRPCURL)
+}
+
+// effectiveChainRPC returns the explicitly configured CometBFT RPC endpoint for
+// the gateway's chain query fallback. Empty means unset, which lets
+// chain.NewWithQueryFallback derive it from the gRPC host.
+func effectiveChainRPC() string {
+	return strings.TrimSpace(firstNonEmpty(os.Getenv("DEVSHARD_CHAIN_RPC"), os.Getenv("NODE_RPC_URL")))
 }
 
 func mustBuildGateway(gatewayStore *GatewayStore, gatewayState GatewayState, baseStorageDir string, flags cliFlags) *Gateway {
@@ -380,7 +381,7 @@ func mustBuildGateway(gatewayStore *GatewayStore, gatewayState GatewayState, bas
 	RequestMaxTokensCap = gatewayState.Settings.RequestMaxTokensCap
 	applyGatewayTuningSettings(gatewayState.Settings)
 
-	chainClient, err := chain.New(gatewayState.Settings.ChainGRPC)
+	chainClient, err := chain.NewWithQueryFallback(gatewayState.Settings.ChainGRPC, effectiveChainRPC())
 	if err != nil {
 		log.Fatalf("dial chain gRPC %s: %v", gatewayState.Settings.ChainGRPC, err)
 	}

--- a/devshard/cmd/devshardctl/main_test.go
+++ b/devshard/cmd/devshardctl/main_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"common/chain"
 	"devshard/bridge"
 	"devshard/user"
 )
@@ -477,6 +478,32 @@ func TestResolveMaxConcurrentRuntimeBuildsParsesOverride(t *testing.T) {
 			require.Equal(t, tc.want, resolveMaxConcurrentRuntimeBuilds())
 		})
 	}
+}
+
+func TestEffectiveChainRPCUnsetLeavesDerivationToCommonChain(t *testing.T) {
+	t.Setenv("DEVSHARD_CHAIN_RPC", "")
+	t.Setenv("NODE_RPC_URL", "")
+	require.Empty(t, effectiveChainRPC())
+}
+
+func TestEffectiveChainRPCPrefersEnv(t *testing.T) {
+	t.Setenv("NODE_RPC_URL", "http://from-node-env:26657")
+	require.Equal(t, "http://from-node-env:26657", effectiveChainRPC())
+
+	t.Setenv("DEVSHARD_CHAIN_RPC", "http://explicit:36657")
+	require.Equal(t, "http://explicit:36657", effectiveChainRPC())
+}
+
+func TestGatewayChainClientUsesQueryFallback(t *testing.T) {
+	t.Setenv("DEVSHARD_CHAIN_RPC", "")
+	t.Setenv("NODE_RPC_URL", "")
+
+	client, err := chain.NewWithQueryFallback("node:9090", effectiveChainRPC())
+	require.NoError(t, err)
+
+	// Queries must not run on the raw gRPC conn, or the gateway loses the
+	// fallback; txs must keep using it, or they could run over ABCI.
+	require.NotEqual(t, client.Conn(), client.QueryConn())
 }
 
 func TestRepairPersistedGatewayEndpointSettingsBackfillsBlankPublicAPI(t *testing.T) {

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -145,7 +145,7 @@ func buildChainRuntime(ctx context.Context, nodeConfig ChainNodeConfig) (*chainR
 		return nil, fmt.Errorf("api account: %w", err)
 	}
 
-	chainClient, err := chain.NewWithRPCFallback(nodeConfig.ChainGrpcUrl, nodeConfig.ChainRpcUrl)
+	chainClient, err := chain.NewWithQueryFallback(nodeConfig.ChainGrpcUrl, nodeConfig.ChainRpcUrl)
 	if err != nil {
 		return nil, fmt.Errorf("chain client: %w", err)
 	}

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -130,7 +130,8 @@ func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error
 
 func buildChainRuntime(ctx context.Context, nodeConfig ChainNodeConfig) (*chainRuntime, error) {
 	slog.Info("chain node",
-		"url", nodeConfig.ChainRpcUrl,
+		"grpc_url", nodeConfig.ChainGrpcUrl,
+		"rpc_url", nodeConfig.ChainRpcUrl,
 		"keyring_backend", nodeConfig.KeyringBackend,
 		"keyring_dir", nodeConfig.KeyringDir)
 
@@ -144,7 +145,7 @@ func buildChainRuntime(ctx context.Context, nodeConfig ChainNodeConfig) (*chainR
 		return nil, fmt.Errorf("api account: %w", err)
 	}
 
-	chainClient, err := chain.New(nodeConfig.ChainGrpcUrl)
+	chainClient, err := chain.NewWithRPCFallback(nodeConfig.ChainGrpcUrl, nodeConfig.ChainRpcUrl)
 	if err != nil {
 		return nil, fmt.Errorf("chain client: %w", err)
 	}

--- a/devshard/cmd/devshardd/chain_client.go
+++ b/devshard/cmd/devshardd/chain_client.go
@@ -45,7 +45,7 @@ func newChainIdentity(
 }
 
 func (c *chainIdentity) NewInferenceQueryClient() inferencetypes.QueryClient {
-	return inferencetypes.NewQueryClient(c.client.Conn())
+	return inferencetypes.NewQueryClient(c.client.QueryConn())
 }
 
 func (c *chainIdentity) GetAccountAddress() string {

--- a/devshard/docs/high-availability-architecture.md
+++ b/devshard/docs/high-availability-architecture.md
@@ -66,11 +66,13 @@ name when running multi-instance overlays).
 poc-batches, restrictions, BLS, bridge addresses, verify-proof/block, debug
 helpers, versions).
 
-- **Transport:** chain **gRPC only** via `common/chain.Client`
-  (`CHAIN_GRPC_URL`, default `:9090`); a few routes use CometBFT gRPC
-  (`cmtservice`) and ABCI store queries. No Tendermint HTTP RPC.
+- **Transport:** chain gRPC via `common/chain.Client` (`CHAIN_GRPC_URL`, e.g.
+  `node:9090`); a few routes use CometBFT gRPC (`cmtservice`) and ABCI store
+  queries. When gRPC is unreachable, queries fall back to CometBFT RPC
+  (`CHAIN_RPC_URL`, e.g. `http://node:26657`) and probe gRPC again every 30
+  minutes. Both env vars are required at startup.
 - **Stateless:** no DB, no keyring, no ML nodes, no broker. Each request is
-  served directly from chain gRPC. Dependencies are `common/chain`,
+  served directly from the chain. Dependencies are `common/chain`,
   `common/logging`, `common/utils`, `edge-api/observability`.
 - **Entry / wiring:** `edge-api/cmd/edge-api/main.go`,
   `edge-api/internal/server/server.go`, handlers under `edge-api/queryapi/`.

--- a/devshard/docs/high-availability-architecture.md
+++ b/devshard/docs/high-availability-architecture.md
@@ -67,10 +67,14 @@ poc-batches, restrictions, BLS, bridge addresses, verify-proof/block, debug
 helpers, versions).
 
 - **Transport:** chain gRPC via `common/chain.Client` (`CHAIN_GRPC_URL`, e.g.
-  `node:9090`); a few routes use CometBFT gRPC (`cmtservice`) and ABCI store
-  queries. When gRPC is unreachable, queries fall back to CometBFT RPC
-  (`CHAIN_RPC_URL`, e.g. `http://node:26657`) and probe gRPC again every 30
-  minutes. Both env vars are required at startup.
+  `node:9090`, required at startup); a few routes use CometBFT gRPC
+  (`cmtservice`) and ABCI store queries. When gRPC is unreachable, queries fall
+  back to CometBFT RPC (`CHAIN_RPC_URL`, default `http://<gRPC host>:26657`) and
+  probe gRPC again every 30 minutes. Which transport is live shows up on the
+  `chain.query.transport.active` gauge and the `chain.transport` span attribute.
+  RPC-mode queries go over ABCI, so the CometBFT service routes need the node to
+  have `grpc.enable` or `api.enable` set — true by default, but see the
+  limitation in the v4 release notes.
 - **Stateless:** no DB, no keyring, no ML nodes, no broker. Each request is
   served directly from the chain. Dependencies are `common/chain`,
   `common/logging`, `common/utils`, `edge-api/observability`.

--- a/devshard/docs/release-0.2.14-v4.md
+++ b/devshard/docs/release-0.2.14-v4.md
@@ -46,7 +46,7 @@ unknown modes fall back to exclusive stop/start.
 | **Rolling updates** | Same-name SHA swap: blue/green overlap + drain when both children report `postgres`; else stop/start. Private admin `/ready`, `/drain`, `/drain/status` |
 | **Validation** | Shared Postgres leases (`devshard_validation_leases`); SQLite leases are no-ops |
 | **Gateway transport** | Chain queries + escrow tx via gRPC; `--chain-rest` / `DEVSHARD_CHAIN_REST` removed |
-| **Query fallback** | edge-api / devshardd chain queries fall back to CometBFT RPC when gRPC is down, and probe back every 30 min; txs stay gRPC-only |
+| **Query fallback** | edge-api / devshardd / gateway chain queries fall back to CometBFT RPC when gRPC is down, and probe back every 30 min; txs stay gRPC-only |
 | **Settle confirm** | Settle waits for DeliverTx (`GetTx`) after SYNC CheckTx — same pattern as create |
 | **Failover** | Router retries another HA peer on first upstream 502 / connect failure |
 | **HA diff/persist** | Idempotent identical `AppendDiff` (fork on conflict); lazy RAM reconcile from PG on nonce gap; persist-first so a failed write cannot leave memory ahead of Postgres |
@@ -81,23 +81,28 @@ unknown modes fall back to exclusive stop/start.
 
 Join / testenv compose already seeds `DEVSHARD_CHAIN_GRPC` only.
 
-### edge-api / devshardd: chain query fallback to CometBFT RPC
+### edge-api / devshardd / gateway: chain query fallback to CometBFT RPC
 
-edge-api and devshardd still prefer direct chain gRPC (`:9090`), but their
-chain **queries** now fall back to CometBFT RPC (`:26657`) when gRPC is
-unreachable. This covers nodes that run with gRPC disabled or with `:9090` not
-published, which previously made every query fail.
+edge-api, devshardd and the devshardctl gateway still prefer direct chain gRPC
+(`:9090`), but their chain **queries** now fall back to CometBFT RPC (`:26657`)
+when gRPC is unreachable. This covers nodes with `:9090` not published, bound to
+`localhost`, or firewalled, which previously made every query fail. A node with
+gRPC fully disabled is covered for module queries only — see the limitation
+below.
 
-Both endpoints are required configuration:
+Only the gRPC endpoint is required. The RPC endpoint defaults to the same host on
+port `26657`, so an existing deployment gains the fallback without new settings:
 
 | Service | gRPC | CometBFT RPC |
 | --- | --- | --- |
-| edge-api | `CHAIN_GRPC_URL=node:9090` | `CHAIN_RPC_URL=http://node:26657` |
+| edge-api | `CHAIN_GRPC_URL=node:9090` (required) | `CHAIN_RPC_URL` (default `http://<gRPC host>:26657`) |
 | devshardd | `NODE_GRPC_URL` (default `<NODE_HOST>:9090`) | `NODE_RPC_URL` (default `http://<NODE_HOST>:26657`) |
+| gateway | `DEVSHARD_CHAIN_GRPC` / `NODE_GRPC_URL` | `DEVSHARD_CHAIN_RPC` / `NODE_RPC_URL` (default `http://<gRPC host>:26657`) |
 
-edge-api now **exits at startup** if `CHAIN_GRPC_URL` or `CHAIN_RPC_URL` is
-missing. It used to default the gRPC endpoint to `localhost:9090`, which turned
-a misconfigured stack into a stream of connection errors at query time.
+edge-api still **exits at startup** if `CHAIN_GRPC_URL` is missing. It used to
+default that endpoint to `localhost:9090`, which turned a misconfigured stack
+into a stream of connection errors at query time. A derived `CHAIN_RPC_URL` is
+logged once at startup so an unexpected host is visible in the logs.
 
 How the switch works:
 
@@ -110,19 +115,65 @@ How the switch works:
    answers, it becomes primary again; if not, that request retries on RPC and
    another 30 minutes starts.
 
+A probe that is canceled or times out proves nothing about gRPC, so it neither
+restores gRPC nor consumes the probe window: the next request probes again.
+
 The recovery probe means a node that enables gRPC later is picked up without
 restarting edge-api or devshardd.
 
+When a query fails on both transports the returned error names both causes, so a
+fully unreachable node does not look like a plain ABCI failure.
+
 Transactions are unaffected: devshardd's tx manager and the gateway keep using
 the direct gRPC connection, and gRPC streams have no RPC equivalent so they
-also stay direct.
+also stay direct. Broadcasting a transaction over the *query* connection is
+rejected outright rather than served: Cosmos's `client.Context` turns a
+`BroadcastTx` into a CometBFT broadcast instead of a query, and the fallback
+retries a failed request on the other transport — which for a broadcast means
+submitting the same signed transaction twice.
+
+#### Seeing that a service is on the fallback
+
+Both transports are instrumented the same way, so switching changes what the
+telemetry says rather than silencing it:
+
+| Signal | On gRPC | On CometBFT RPC |
+| --- | --- | --- |
+| `chain.grpc.query` spans | `chain.transport=grpc` | `chain.transport=comet-rpc` |
+| `chain.query.transport.active` gauge | `grpc`=1, `comet-rpc`=0 | `grpc`=0, `comet-rpc`=1 |
+| Logs | — | one warning on the switch, then one per failed 30-min probe |
+
+The gauge is the thing to alert on: `comet-rpc`=1 held for longer than a brief
+blip means the node's `:9090` has been unreachable that whole time. The
+per-probe warning is the same signal in the logs, so a service that has been
+degraded for a week no longer looks identical to one that never fell back. Both
+report from process start, so an absent `comet-rpc` series means healthy rather
+than unreported.
+
+#### Known limitation: CometBFT service queries
 
 RPC-mode queries run as ABCI queries against the node's gRPC query router.
-Module queries (inference, BLS, restrictions) are always registered there. The
-CometBFT service queries (node info, blocks, validator sets) are registered
-only when the node has `grpc.enable` or `api.enable` set in `app.toml`; both
-default to enabled, but a node with both off serves neither transport for those
-routes.
+Module queries (inference, BLS, restrictions) are always registered there, so
+they work on any node. The CometBFT service queries (node info, blocks,
+validator sets, and the ABCI store queries behind epoch proofs) are registered
+only when the node has `grpc.enable` or `api.enable` set in `app.toml`, because
+the SDK gates `RegisterTendermintService` on those two flags.
+
+`grpc.enable` defaults to **true** and nothing in this repo turns it off, so
+every deployment we ship resolves these queries normally — including the cases
+this fallback targets, where gRPC is enabled but bound to `localhost` or not
+published. A node with **both** flags disabled is the exception: module queries
+would keep working while `/v1/versions`, `/v1/epochs/{epoch}/participants`,
+`/v1/debug/verify/{height}`, `POST /v1/verify-block`, and devshardd's startup
+chain-ID lookup returned `Unimplemented`.
+
+Closing that gap means serving those methods from CometBFT's own `/status`,
+`/block`, `/validators` and `/abci_query` endpoints, which are available
+regardless of `app.toml`. That is deliberately not done here: no node we operate
+is configured that way, and the change is not worth carrying untested against a
+real gRPC-disabled node. `common/chain.newRPCQueryConn` documents the same
+constraint, and `TestRPCQueryConn_CometServiceGoesThroughTheABCIRouter` pins the
+behaviour so the limitation is visible in the test suite rather than only here.
 
 ### Gateway status: `protocol_version` → `session_version`
 

--- a/devshard/docs/release-0.2.14-v4.md
+++ b/devshard/docs/release-0.2.14-v4.md
@@ -46,6 +46,7 @@ unknown modes fall back to exclusive stop/start.
 | **Rolling updates** | Same-name SHA swap: blue/green overlap + drain when both children report `postgres`; else stop/start. Private admin `/ready`, `/drain`, `/drain/status` |
 | **Validation** | Shared Postgres leases (`devshard_validation_leases`); SQLite leases are no-ops |
 | **Gateway transport** | Chain queries + escrow tx via gRPC; `--chain-rest` / `DEVSHARD_CHAIN_REST` removed |
+| **Query fallback** | edge-api / devshardd chain queries fall back to CometBFT RPC when gRPC is down, and probe back every 30 min; txs stay gRPC-only |
 | **Settle confirm** | Settle waits for DeliverTx (`GetTx`) after SYNC CheckTx — same pattern as create |
 | **Failover** | Router retries another HA peer on first upstream 502 / connect failure |
 | **HA diff/persist** | Idempotent identical `AppendDiff` (fork on conflict); lazy RAM reconcile from PG on nonce gap; persist-first so a failed write cannot leave memory ahead of Postgres |
@@ -79,6 +80,49 @@ unknown modes fall back to exclusive stop/start.
    `gonka-mainnet`).
 
 Join / testenv compose already seeds `DEVSHARD_CHAIN_GRPC` only.
+
+### edge-api / devshardd: chain query fallback to CometBFT RPC
+
+edge-api and devshardd still prefer direct chain gRPC (`:9090`), but their
+chain **queries** now fall back to CometBFT RPC (`:26657`) when gRPC is
+unreachable. This covers nodes that run with gRPC disabled or with `:9090` not
+published, which previously made every query fail.
+
+Both endpoints are required configuration:
+
+| Service | gRPC | CometBFT RPC |
+| --- | --- | --- |
+| edge-api | `CHAIN_GRPC_URL=node:9090` | `CHAIN_RPC_URL=http://node:26657` |
+| devshardd | `NODE_GRPC_URL` (default `<NODE_HOST>:9090`) | `NODE_RPC_URL` (default `http://<NODE_HOST>:26657`) |
+
+edge-api now **exits at startup** if `CHAIN_GRPC_URL` or `CHAIN_RPC_URL` is
+missing. It used to default the gRPC endpoint to `localhost:9090`, which turned
+a misconfigured stack into a stream of connection errors at query time.
+
+How the switch works:
+
+1. Queries start on gRPC.
+2. A transport failure (gRPC `Unavailable`, closed connection) moves queries to
+   RPC and retries that same request there, so the caller sees no error.
+3. Queries stay on RPC for 30 minutes. Application errors never trigger a
+   switch, so a `NotFound` response does not cost a probe.
+4. After 30 minutes exactly one request is routed over gRPC as a probe. If gRPC
+   answers, it becomes primary again; if not, that request retries on RPC and
+   another 30 minutes starts.
+
+The recovery probe means a node that enables gRPC later is picked up without
+restarting edge-api or devshardd.
+
+Transactions are unaffected: devshardd's tx manager and the gateway keep using
+the direct gRPC connection, and gRPC streams have no RPC equivalent so they
+also stay direct.
+
+RPC-mode queries run as ABCI queries against the node's gRPC query router.
+Module queries (inference, BLS, restrictions) are always registered there. The
+CometBFT service queries (node info, blocks, validator sets) are registered
+only when the node has `grpc.enable` or `api.enable` set in `app.toml`; both
+default to enabled, but a node with both off serves neither transport for those
+routes.
 
 ### Gateway status: `protocol_version` → `session_version`
 
@@ -297,6 +341,7 @@ docker compose -f docker-compose.yml -f docker-compose.edge-api-multi.yml up -d
     environment:
       - EDGE_API_PORT=18080
       - CHAIN_GRPC_URL=node:9090
+      - CHAIN_RPC_URL=http://node:26657
       - EDGE_API_OTEL_ENABLED=${EDGE_API_OTEL_ENABLED:-false}
       - OTEL_ENDPOINT=${OTEL_ENDPOINT:-}
       - OTEL_HEADERS=${OTEL_HEADERS:-}

--- a/devshard/docs/v4-deploy-test-plan.md
+++ b/devshard/docs/v4-deploy-test-plan.md
@@ -152,6 +152,7 @@ Relevant excerpts (tags shown are current compose pins — bump for v4):
     environment:
       - EDGE_API_PORT=18080
       - CHAIN_GRPC_URL=node:9090
+      - CHAIN_RPC_URL=http://node:26657
     depends_on:
       - node
     restart: always

--- a/edge-api/cmd/edge-api/main.go
+++ b/edge-api/cmd/edge-api/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -17,11 +18,11 @@ import (
 )
 
 const (
-	defaultPort        = 18080
-	defaultChainGRPC   = "localhost:9090"
-	envPort            = "EDGE_API_PORT"
-	envChainGRPCURL    = "CHAIN_GRPC_URL"
-	shutdownTimeout    = 10 * time.Second
+	defaultPort     = 18080
+	envPort         = "EDGE_API_PORT"
+	envChainGRPCURL = "CHAIN_GRPC_URL"
+	envChainRPCURL  = "CHAIN_RPC_URL"
+	shutdownTimeout = 10 * time.Second
 )
 
 func main() {
@@ -29,6 +30,7 @@ func main() {
 	slog.Info("edge-api starting",
 		"port", cfg.Port,
 		"chain_grpc", cfg.ChainGRPCURL,
+		"chain_rpc", cfg.ChainRPCURL,
 	)
 
 	shutdownObs, err := observability.Init(context.Background(), observability.Config{
@@ -44,7 +46,7 @@ func main() {
 		_ = shutdownObs(ctx)
 	}()
 
-	chainClient, err := chain.New(cfg.ChainGRPCURL)
+	chainClient, err := chain.NewWithRPCFallback(cfg.ChainGRPCURL, cfg.ChainRPCURL)
 	if err != nil {
 		slog.Error("chain client", "error", err)
 		os.Exit(1)
@@ -82,8 +84,11 @@ func main() {
 type config struct {
 	Port         int
 	ChainGRPCURL string
+	ChainRPCURL  string
 }
 
+// loadConfig requires both chain endpoints explicitly. Defaulting to localhost
+// used to hide misconfiguration behind connection errors at query time.
 func loadConfig() config {
 	port := defaultPort
 	if v := os.Getenv(envPort); v != "" {
@@ -95,13 +100,21 @@ func loadConfig() config {
 		port = p
 	}
 
-	grpcURL := os.Getenv(envChainGRPCURL)
+	grpcURL := strings.TrimSpace(os.Getenv(envChainGRPCURL))
 	if grpcURL == "" {
-		grpcURL = defaultChainGRPC
+		slog.Error("missing required env", "env", envChainGRPCURL, "example", "node:9090")
+		os.Exit(1)
+	}
+
+	rpcURL := strings.TrimSpace(os.Getenv(envChainRPCURL))
+	if rpcURL == "" {
+		slog.Error("missing required env", "env", envChainRPCURL, "example", "http://node:26657")
+		os.Exit(1)
 	}
 
 	return config{
 		Port:         port,
 		ChainGRPCURL: grpcURL,
+		ChainRPCURL:  rpcURL,
 	}
 }

--- a/edge-api/cmd/edge-api/main.go
+++ b/edge-api/cmd/edge-api/main.go
@@ -26,7 +26,15 @@ const (
 )
 
 func main() {
-	cfg := loadConfig()
+	cfg, err := loadConfig()
+	if err != nil {
+		slog.Error("config", "error", err)
+		os.Exit(1)
+	}
+	if cfg.ChainRPCDerived {
+		slog.Warn("chain rpc endpoint derived from gRPC host; set it explicitly to override",
+			"env", envChainRPCURL, "chain_rpc", cfg.ChainRPCURL)
+	}
 	slog.Info("edge-api starting",
 		"port", cfg.Port,
 		"chain_grpc", cfg.ChainGRPCURL,
@@ -46,7 +54,7 @@ func main() {
 		_ = shutdownObs(ctx)
 	}()
 
-	chainClient, err := chain.NewWithRPCFallback(cfg.ChainGRPCURL, cfg.ChainRPCURL)
+	chainClient, err := chain.NewWithQueryFallback(cfg.ChainGRPCURL, cfg.ChainRPCURL)
 	if err != nil {
 		slog.Error("chain client", "error", err)
 		os.Exit(1)
@@ -85,36 +93,45 @@ type config struct {
 	Port         int
 	ChainGRPCURL string
 	ChainRPCURL  string
+	// ChainRPCDerived records that ChainRPCURL was guessed from the gRPC host
+	// rather than configured, so main can say so once at startup.
+	ChainRPCDerived bool
 }
 
-// loadConfig requires both chain endpoints explicitly. Defaulting to localhost
-// used to hide misconfiguration behind connection errors at query time.
-func loadConfig() config {
+// loadConfig requires CHAIN_GRPC_URL explicitly: defaulting it to localhost used
+// to hide misconfiguration behind connection errors at query time. The CometBFT
+// RPC endpoint is derived from that host when unset, so adding the query
+// fallback does not break a deployment that only sets the gRPC endpoint.
+func loadConfig() (config, error) {
 	port := defaultPort
 	if v := os.Getenv(envPort); v != "" {
 		p, err := strconv.Atoi(v)
 		if err != nil {
-			slog.Error("invalid port", "env", envPort, "value", v, "error", err)
-			os.Exit(1)
+			return config{}, fmt.Errorf("%s=%q: %w", envPort, v, err)
 		}
 		port = p
 	}
 
 	grpcURL := strings.TrimSpace(os.Getenv(envChainGRPCURL))
 	if grpcURL == "" {
-		slog.Error("missing required env", "env", envChainGRPCURL, "example", "node:9090")
-		os.Exit(1)
+		return config{}, fmt.Errorf("%s is required (example: node:9090)", envChainGRPCURL)
 	}
 
 	rpcURL := strings.TrimSpace(os.Getenv(envChainRPCURL))
+	derived := false
 	if rpcURL == "" {
-		slog.Error("missing required env", "env", envChainRPCURL, "example", "http://node:26657")
-		os.Exit(1)
+		rpcURL = chain.RPCURLFromGRPCURL(grpcURL)
+		if rpcURL == "" {
+			return config{}, fmt.Errorf("%s is unset and cannot be derived from %s=%q",
+				envChainRPCURL, envChainGRPCURL, grpcURL)
+		}
+		derived = true
 	}
 
 	return config{
-		Port:         port,
-		ChainGRPCURL: grpcURL,
-		ChainRPCURL:  rpcURL,
-	}
+		Port:            port,
+		ChainGRPCURL:    grpcURL,
+		ChainRPCURL:     rpcURL,
+		ChainRPCDerived: derived,
+	}, nil
 }

--- a/edge-api/cmd/edge-api/main_test.go
+++ b/edge-api/cmd/edge-api/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig_DerivesRPCURLFromGRPCHost(t *testing.T) {
+	// Adding the query fallback must not break a deployment that only sets the
+	// gRPC endpoint, so the RPC endpoint is derived from the same host.
+	t.Setenv(envChainGRPCURL, "node:9090")
+	t.Setenv(envChainRPCURL, "")
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "node:9090", cfg.ChainGRPCURL)
+	assert.Equal(t, "http://node:26657", cfg.ChainRPCURL)
+	assert.True(t, cfg.ChainRPCDerived)
+	assert.Equal(t, defaultPort, cfg.Port)
+}
+
+func TestLoadConfig_ExplicitRPCURLWins(t *testing.T) {
+	t.Setenv(envChainGRPCURL, "node:9090")
+	t.Setenv(envChainRPCURL, "http://other:36657")
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://other:36657", cfg.ChainRPCURL)
+	assert.False(t, cfg.ChainRPCDerived)
+}
+
+func TestLoadConfig_RequiresGRPCURL(t *testing.T) {
+	t.Setenv(envChainGRPCURL, "")
+	t.Setenv(envChainRPCURL, "http://node:26657")
+
+	_, err := loadConfig()
+	require.ErrorContains(t, err, envChainGRPCURL)
+}
+
+func TestLoadConfig_RejectsUnparsablePort(t *testing.T) {
+	t.Setenv(envChainGRPCURL, "node:9090")
+	t.Setenv(envPort, "not-a-port")
+
+	_, err := loadConfig()
+	require.ErrorContains(t, err, envPort)
+}
+
+func TestLoadConfig_ReadsPort(t *testing.T) {
+	t.Setenv(envChainGRPCURL, "node:9090")
+	t.Setenv(envPort, "19090")
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, 19090, cfg.Port)
+}

--- a/local-test-net/docker-compose-base.yml
+++ b/local-test-net/docker-compose-base.yml
@@ -77,6 +77,7 @@ services:
     environment:
       - EDGE_API_PORT=18080
       - CHAIN_GRPC_URL=${KEY_NAME}-node:9090
+      - CHAIN_RPC_URL=http://${KEY_NAME}-node:26657
       - EDGE_API_OTEL_ENABLED=${EDGE_API_OTEL_ENABLED:-false}
       - OTEL_ENDPOINT=${OTEL_ENDPOINT:-}
       - OTEL_HEADERS=${OTEL_HEADERS:-}

--- a/local-test-net/docker-compose.edge-api.yml
+++ b/local-test-net/docker-compose.edge-api.yml
@@ -17,6 +17,7 @@ x-edge-api: &edge-api
   environment:
     EDGE_API_PORT: "18080"
     CHAIN_GRPC_URL: ${KEY_NAME}-node:9090
+    CHAIN_RPC_URL: http://${KEY_NAME}-node:26657
     EDGE_API_OTEL_ENABLED: ${EDGE_API_OTEL_ENABLED:-false}
     OTEL_ENDPOINT: ${OTEL_ENDPOINT:-}
     OTEL_HEADERS: ${OTEL_HEADERS:-}


### PR DESCRIPTION
edge-api and devshardd failed every chain query against a node that ran with grpc disabled or :9090 unpublished. Direct gRPC stays primary for performance, but queries now switch to CometBFT RPC/ABCI on transport failure and retry the same request there, so callers see no error.

Recovery is lazy instead of restart-driven: after 30 minutes on RPC, one request probes gRPC, and any answer (including an application error) makes it primary again. A node that enables gRPC later is picked up without restarting the services around it.