### PR TITLE
test(devshard): fix nil-deref flake in StateRootDivergence proxy test

### DIFF
--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -1329,6 +1329,9 @@ func TestRunInference_StateRootDivergenceBlocksParticipantForEscrow(t *testing.T
 
 	var first bytes.Buffer
 	require.NoError(t, env.proxy.redundancy.RunInference(context.Background(), defaultParams(), &first, nil))
+	require.Eventually(t, func() bool {
+		return divergent.LastRequest() != nil
+	}, time.Second, 10*time.Millisecond, "divergent host was never sent the request")
 	require.EqualValues(t, 1, divergent.LastRequest().Nonce)
 	require.Eventually(t, func() bool {
 		_, blocked := env.proxy.redundancy.escrowStateBlockReason(env.session.HostParticipantKey(1))


### PR DESCRIPTION
## What problem does this solve?

`TestRunInference_StateRootDivergenceBlocksParticipantForEscrow` in `devshard/cmd/devshardctl/proxy_test.go` intermittently panics on CI with a nil-pointer dereference at the `divergent.LastRequest().Nonce` assertion, failing the "Build and Test Devshard" job on unrelated PRs.

## How do you know this is a real problem?

- Observed on CI 2026-07-22 during a re-run on PR #1458: nil-deref panic at the `LastRequest().Nonce` assertion in this test.
- Reproduced locally on unmodified `main` (b53fd8fcd) under scheduling stress: `GOMAXPROCS=2 go test -race -count=100 -cpu=1,2,4 -run 'TestRunInference_StateRootDivergence'` →
  ```
  --- FAIL: TestRunInference_StateRootDivergenceBlocksParticipantForEscrow (0.01s)
  panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
      /home/.../devshard/cmd/devshardctl/proxy_test.go:1332 +0x20f
  FAIL	devshard/cmd/devshardctl	8.224s
  ```

## How does this solve the problem?

The race: `Redundancy.awaitRace` returns to `RunInference` as soon as the winning attempt finishes and hands still-pending speculative losers to a background finalizer. Host 1 (`divergent`) is a losing speculative attempt, and each attempt's `killableClient.Send()` — which records `LastRequest` — runs in a per-attempt goroutine. So `RunInference` can return before host 1's goroutine has reached `Send()`, leaving `LastRequest()` nil when the test asserts immediately after.

The fix waits for the request to be recorded before dereferencing, using the file's existing idiom (`require.Eventually`, same 1s/10ms convention as the nine existing uses — including the escrow-blocked wait immediately below the same assertion):

```go
require.Eventually(t, func() bool {
    return divergent.LastRequest() != nil
}, time.Second, 10*time.Millisecond, "divergent host was never sent the request")
require.EqualValues(t, 1, divergent.LastRequest().Nonce)
```

The second `LastRequest().Nonce` assertion later in the test (after the second `RunInference`) is intentionally left without a wait: at that point `LastRequest` is already guaranteed non-nil by the first assertion (the mock never resets it), and the assertion's purpose there is that the blocked host received *no new* request (nonce still 1), so a wait would be vacuous.

## What risks does this introduce? How can we mitigate them?

Test-only change, no production code touched. The 1-second wait introduces no tighter timing bound than the test already has: the pre-existing `require.Eventually` for the escrow-blocked state (same 1s/10ms) depends on the same goroutine progressing strictly past `Send()`, so any runner slow enough to starve the new wait would already have flaked on the existing one.

## How do you know this PR fixes the problem?

The same stress invocation that reproduces the panic on unmodified main passes with the fix: `-race -count=100 -cpu=1,2,4` → `ok devshard/cmd/devshardctl 66.380s` (100/100), plus `-race -count=20` → 20/20, and 50/50 without `-race`. Full package suite unaffected (the only failures on my Windows host are the three pre-existing `TestResolveAdminStoragePath`/storage-path tests, which fail identically on unmodified main).

## Which components are affected?

- `devshard/cmd/devshardctl/proxy_test.go` (test only)

## Testing & evidence

Linux (WSL2, go1.25.9 per go.mod), on unmodified main vs fixed branch:

### Before
```
$ GOMAXPROCS=2 go test ./cmd/devshardctl/ -race -count=100 -cpu=1,2,4 -run 'TestRunInference_StateRootDivergence'
--- FAIL: TestRunInference_StateRootDivergenceBlocksParticipantForEscrow (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
devshard/cmd/devshardctl.TestRunInference_StateRootDivergenceBlocksParticipantForEscrow(...)
    devshard/cmd/devshardctl/proxy_test.go:1332 +0x20f
FAIL	devshard/cmd/devshardctl	8.224s
```

### After
```
$ GOMAXPROCS=2 go test ./cmd/devshardctl/ -race -count=100 -cpu=1,2,4 -run 'TestRunInference_StateRootDivergence'
ok  	devshard/cmd/devshardctl	66.380s

$ go vet ./cmd/devshardctl/
(clean)
```
