### PR TITLE
fix(devshard/host): guard validationQueue reads against concurrent Close

### DIFF
--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -1043,7 +1043,7 @@ func (h *Host) enqueueValidation(job validateJob) {
 	case q <- job:
 		h.validationLifecycleMu.RUnlock()
 		observability.IncValidation(observability.StageValidationPicked, observability.MetricStatusQueued)
-		observability.SetValidationQueueDepth(h.escrowID, len(h.validationQueue))
+		observability.SetValidationQueueDepth(h.escrowID, len(q))
 	default:
 		h.validationLifecycleMu.RUnlock()
 		h.mu.Lock()
@@ -1090,8 +1090,11 @@ func (h *Host) validateAsync(ctx context.Context, job validateJob) {
 		h.mu.Lock()
 		delete(h.validating, job.inferenceID)
 		h.mu.Unlock()
-		if h.validationQueue != nil {
-			observability.SetValidationQueueDepth(h.escrowID, len(h.validationQueue))
+		h.validationLifecycleMu.RLock()
+		queue := h.validationQueue
+		h.validationLifecycleMu.RUnlock()
+		if queue != nil {
+			observability.SetValidationQueueDepth(h.escrowID, len(queue))
 		}
 	}()
 


### PR DESCRIPTION
## What problem does this solve?

`go test ./host/ -race` in the `devshard` module fails on current `main`: `Host.Close` races with the validation-worker cleanup on the `h.validationQueue` field. Any contributor (or CI job) running the host tests with the race detector gets failures on the validation-lifecycle tests, which masks real regressions in `-race` runs.

## How do you know this is a real problem?

Reproducible on unmodified `main` (b53fd8fcd), Linux, `go test ./host/ -race`:

```
WARNING: DATA RACE
  ...
  /devshard/host/host.go:247 +0xe6   (Host.Close: h.validationQueue = nil, under validationLifecycleMu.Lock)
  ...
  /devshard/host/host.go:1093 +0x9c  (validateAsync deferred cleanup: unguarded read)
--- FAIL: TestHost_ValidationTriggersOnFinishedInference (0.02s)
```

`TestHost_ValidationQueueLimitsConcurrentWorkers` and `TestHost_ValidateAsync_DoesNotRecordObsBeforeDiff` fail the same way. The tests register `Close` via `t.Cleanup`, so it runs while validation workers are still draining the queue — same shape as any future non-test caller of `Close`.

To be upfront about impact: today `Host.Close` is only called from tests (no production shutdown path invokes it), and even when the race fires the consequence is a stale metric read, not a panic — `len` on a nil or closed channel is safe. So this is a race-detector-hygiene fix for the current architecture, not a production incident. It still seems worth fixing: the field has a dedicated `validationLifecycleMu` and every other reader uses it; these were the only two sites that didn't.

## How does this solve the problem?

Two unguarded reads of `h.validationQueue`, both feeding the queue-depth metric, are made consistent with the file's existing snapshot-under-RLock idiom (`collectValidationJobs`, `enqueueValidation`'s guard):

- `validateAsync`'s deferred cleanup now snapshots the field under `validationLifecycleMu.RLock()` and measures the snapshot.
- `enqueueValidation`'s success branch now measures its existing snapshot `q` instead of re-reading the raw field after `RUnlock()` (also semantically more precise — it reports the depth of the channel it just sent to).

Measuring `len()` on the snapshot after unlock is race-detector-clean: channel length is read through the runtime's internally synchronized channel state, and `len` on a closed channel is legal.

## What risks does this introduce? How can we mitigate them?

Very low. No behavior change beyond the metric now being read race-free; no new lock nesting (the defer takes `h.mu` and then `validationLifecycleMu` sequentially, never nested; the only nested order elsewhere is `h.mu` → `RLock`, consistent). No deadlock path: `Close` never blocks waiting on workers.

One heads-up rather than a risk: `ak/shared-validation-pool` appears to replace the per-host `validationQueue` entirely. If that refactor is close to landing, feel free to deprioritize this — it fixes the race on the architecture that exists on `main` today.

## How do you know this PR fixes the problem?

Same command that fails on `main` passes with the fix: `go test ./host/ -race -count=3` → `ok devshard/host 4.646s` (all validation-lifecycle tests green under the race detector, three consecutive runs). The existing tests act as the regression tests — no new tests needed, since they already exercise `Close` racing with in-flight workers.

## Which components are affected?

- `devshard/host/host.go` (two metric read sites; 6 insertions, 3 deletions)

## Testing & evidence

Linux (WSL2, go1.25.9 per go.mod):

### Before
```
$ go test ./host/ -race -count=3
WARNING: DATA RACE
  /devshard/host/host.go:247 (Host.Close)
  /devshard/host/host.go:1093 (validateAsync deferred cleanup)
--- FAIL: TestHost_ValidationTriggersOnFinishedInference (0.02s)
FAIL	devshard/host
```

### After
```
$ go test ./host/ -race -count=3
ok  	devshard/host	4.646s

$ go vet ./host/
(clean)
```
