### PR TITLE
fix(devshard): block inference admission during gateway finalize

### DIFF
--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -97,6 +97,12 @@ type devshardRuntime struct {
 	// pendingRaceCleanup counts background race cleanups (refund + loser-signature persistence) still in flight
 	pendingRaceCleanup atomic.Int64
 
+	// finalizing marks a runtime whose finalize request is in flight. It is set
+	// in the same g.mu critical section that observed the drain barrier as
+	// quiet, and admission reads it under that same lock, so no new inference
+	// can slip in between the quiescence check and the finalize handler run.
+	finalizing atomic.Bool
+
 	// settlementPending marks an escrow that has been deactivated and must
 	// be settled once its in-flight requests drain. settlementReason is
 	// written before the flag and read after it in the lock-free drain hook;
@@ -572,6 +578,9 @@ func (rt *devshardRuntime) retireClose(reason string) error {
 func (rt *devshardRuntime) acceptsNewInferences() (bool, string) {
 	if rt == nil || !rt.active.Load() {
 		return false, "inactive"
+	}
+	if rt.finalizing.Load() {
+		return false, "finalize_in_flight"
 	}
 	if rt.proxy == nil || rt.proxy.sm == nil {
 		return true, ""
@@ -1365,6 +1374,11 @@ func (g *Gateway) handleSingleOnly(w http.ResponseWriter, r *http.Request) {
 	g.mu.Unlock()
 	if len(runtimes) == 1 {
 		if r.URL.Path == "/v1/finalize" && r.Method == http.MethodPost {
+			if ok, reason := g.beginFinalizeGate(runtimes[0]); !ok {
+				http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s %s"}}`, runtimes[0].id, reason), http.StatusConflict)
+				return
+			}
+			defer g.endFinalizeGate(runtimes[0])
 			g.finalizeMu.Lock()
 			defer g.finalizeMu.Unlock()
 			log.Printf("gateway_finalize_lock_acquired escrow=%s path=%s", runtimes[0].id, r.URL.Path)
@@ -1561,7 +1575,12 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 			logRequestStage(ctx, "gateway_devshard_limiter_bypassed_during_poc", "escrow", devshardID, "input_tokens", inputTokens, "reason", currentPoCPhaseReason())
 		}
 
-		g.reserveRuntime(rt, inputTokens)
+		if ok, reason := g.reserveRuntimeIfAccepting(rt, inputTokens); !ok {
+			logRequestStage(ctx, "gateway_devshard_unavailable", "escrow", devshardID, "reason", reason)
+			g.recordGatewayRequestOutcome(limitModel, "runtime_unavailable", runtimeSkipReasonKey(reason))
+			http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s is unavailable for new inferences: %s"}}`, devshardID, reason), http.StatusConflict)
+			return
+		}
 		defer g.releaseRuntime(rt, inputTokens)
 		logRequestStage(ctx, "gateway_devshard_runtime_selected", "escrow", devshardID, "input_tokens", inputTokens)
 
@@ -1575,10 +1594,11 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if innerPath == "/v1/finalize" && r.Method == http.MethodPost {
-		if rt.escrowHasBackgroundWork() {
-			http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s has active requests"}}`, devshardID), http.StatusConflict)
+		if ok, reason := g.beginFinalizeGate(rt); !ok {
+			http.Error(w, fmt.Sprintf(`{"error":{"message":"devshard %s %s"}}`, devshardID, reason), http.StatusConflict)
 			return
 		}
+		defer g.endFinalizeGate(rt)
 		g.finalizeMu.Lock()
 		defer g.finalizeMu.Unlock()
 		log.Printf("gateway_finalize_lock_acquired escrow=%s path=%s", devshardID, r.URL.Path)
@@ -1707,6 +1727,36 @@ func (g *Gateway) serveInactiveDevshardMetadata(w http.ResponseWriter, r *http.R
 		})
 	}
 	return true
+}
+
+// beginFinalizeGate takes the drain-barrier check and the finalizing mark in a
+// single g.mu critical section -- the same lock admission holds across its own
+// gate check and reservation -- so no request can be admitted after finalize has
+// observed the runtime as quiet. It reports false plus a refusal reason when
+// another finalize is already in flight or background work has not drained; a
+// second finalize is refused rather than queued on finalizeMu, where it would
+// run after the first one reopened admission.
+func (g *Gateway) beginFinalizeGate(rt *devshardRuntime) (bool, string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if rt.finalizing.Load() {
+		return false, "already has a finalize in flight"
+	}
+	if rt.escrowHasBackgroundWork() {
+		return false, "has active requests"
+	}
+	rt.finalizing.Store(true)
+	return true, ""
+}
+
+// endFinalizeGate reopens admission. After a successful finalize the runtime is
+// protected by other means -- the /devshard/{id} route deactivates it
+// (markDevshardInactiveAfterFinalize), and on the single-runtime route the
+// settled session phase makes acceptsNewInferences refuse -- so clearing the
+// mark changes nothing there; every failure path -- non-2xx, or a panic in the
+// inner handler -- needs it so the runtime stays usable.
+func (g *Gateway) endFinalizeGate(rt *devshardRuntime) {
+	rt.finalizing.Store(false)
 }
 
 func (g *Gateway) markDevshardInactiveAfterFinalize(id string, rt *devshardRuntime) {
@@ -1923,6 +1973,20 @@ func (g *Gateway) runtimeLoad(rt *devshardRuntime, requestModel string) float64 
 		return rt.load(1.0)
 	}
 	return rt.load(g.capacity.EscrowWeightForModel(rt.id, firstNonEmpty(requestModel, rt.model)))
+}
+
+// reserveRuntimeIfAccepting re-runs the admission gate and reserves in one g.mu
+// critical section, mirroring reserveRuntimeForModel. The direct /devshard/{id}
+// chat route gates early, before parsing and limiter admission, so it must
+// re-check at reservation time: a finalize may have closed the gate in between.
+func (g *Gateway) reserveRuntimeIfAccepting(rt *devshardRuntime, inputTokens int64) (bool, string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if ok, reason := rt.acceptsNewInferences(); !ok {
+		return false, reason
+	}
+	g.reserveRuntimeLocked(rt, inputTokens)
+	return true, ""
 }
 
 func (g *Gateway) reserveRuntime(rt *devshardRuntime, inputTokens int64) {

--- a/devshard/cmd/devshardctl/gateway_finalize_admission_test.go
+++ b/devshard/cmd/devshardctl/gateway_finalize_admission_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Finalize settles the session at the current nonce, so it may only run once the
+// runtime is quiet. Checking the drain barrier once and then serving finalize is
+// not enough: admission only looks at rt.active, which stays true for the whole
+// finalize call (it flips in markDevshardInactiveAfterFinalize, after the 2xx),
+// so a chat request can be admitted right behind the check and end up executing
+// against a session that is being finalized. The finalizing gate closes that
+// window by marking the runtime in the same g.mu critical section that observes
+// it as quiet.
+
+// blockingFinalizeRuntime returns a runtime whose handler parks inside finalize
+// until the returned release func is called, plus a signal fired on entry.
+func blockingFinalizeRuntime(t *testing.T, id string, status int) (*devshardRuntime, <-chan struct{}, func()) {
+	t.Helper()
+	entered := make(chan struct{})
+	unblock := make(chan struct{})
+	signalEntered := sync.OnceFunc(func() { close(entered) })
+	rt := &devshardRuntime{
+		id:    id,
+		model: "Qwen/Test",
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			signalEntered()
+			<-unblock
+			w.WriteHeader(status)
+		}),
+	}
+	return rt, entered, sync.OnceFunc(func() { close(unblock) })
+}
+
+// TestFinalizeInFlightBlocksNewInferences pins the TOCTOU: while the finalize
+// handler runs, both admission routes must refuse the runtime and no reservation
+// may be taken.
+func TestFinalizeInFlightBlocksNewInferences(t *testing.T) {
+	rt, entered, release := blockingFinalizeRuntime(t, "12", http.StatusNoContent)
+	defer release()
+	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+
+	finalized := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		g.handleDevshard(rec, httptest.NewRequest(http.MethodPost, "/devshard/12/v1/finalize", nil))
+		finalized <- rec.Code
+	}()
+	<-entered
+
+	ok, reason := rt.acceptsNewInferences()
+	require.False(t, ok, "a runtime with finalize in flight must not accept new inferences")
+	require.Equal(t, "finalize_in_flight", reason)
+
+	_, err := g.reserveRuntimeForModel("Qwen/Test", 1)
+	require.Error(t, err, "pooled admission must not pick a runtime whose finalize is in flight")
+
+	admitted, reason := g.reserveRuntimeIfAccepting(rt, 1)
+	require.False(t, admitted, "direct devshard admission must not reserve a runtime whose finalize is in flight")
+	require.Equal(t, "finalize_in_flight", reason)
+	require.Zero(t, rt.activeUserRequests.Load(), "no request may be reserved while finalize runs")
+
+	release()
+	require.Equal(t, http.StatusNoContent, <-finalized)
+	require.False(t, rt.active.Load(), "a successful finalize leaves the runtime inactive")
+}
+
+// TestSingleOnlyFinalizeInFlightBlocksNewInferences pins the same window on the
+// single-runtime route, which shares the pooled admission path.
+func TestSingleOnlyFinalizeInFlightBlocksNewInferences(t *testing.T) {
+	rt, entered, release := blockingFinalizeRuntime(t, "12", http.StatusOK)
+	defer release()
+	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+
+	finalized := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		g.handleSingleOnly(rec, httptest.NewRequest(http.MethodPost, "/v1/finalize", nil))
+		finalized <- rec.Code
+	}()
+	<-entered
+
+	_, err := g.reserveRuntimeForModel("Qwen/Test", 1)
+	require.Error(t, err, "single-runtime admission must not pick a runtime whose finalize is in flight")
+	require.Zero(t, rt.activeUserRequests.Load())
+
+	release()
+	require.Equal(t, http.StatusOK, <-finalized)
+}
+
+// TestSingleOnlyFinalizeRequiresNoActiveRequests pins the drain-barrier check on
+// the single-runtime route: finalize is refused, not forwarded, while a request
+// is in flight.
+func TestSingleOnlyFinalizeRequiresNoActiveRequests(t *testing.T) {
+	var forwarded bool
+	rt := &devshardRuntime{
+		id:    "12",
+		model: "Qwen/Test",
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			forwarded = true
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+	rt.activeUserRequests.Store(1)
+	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+
+	rec := httptest.NewRecorder()
+	g.handleSingleOnly(rec, httptest.NewRequest(http.MethodPost, "/v1/finalize", nil))
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.False(t, forwarded)
+	require.False(t, rt.finalizing.Load(), "a refused finalize must leave the gate open")
+
+	rt.activeUserRequests.Store(0)
+	rec = httptest.NewRecorder()
+	g.handleSingleOnly(rec, httptest.NewRequest(http.MethodPost, "/v1/finalize", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, forwarded)
+	require.False(t, rt.finalizing.Load())
+}
+
+// TestFailedFinalizeReopensAdmission pins the clearing rule: a finalize that did
+// not succeed must leave the runtime usable for new inferences.
+func TestFailedFinalizeReopensAdmission(t *testing.T) {
+	rt := &devshardRuntime{
+		id:    "12",
+		model: "Qwen/Test",
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"error":{"message":"finalize failed"}}`, http.StatusInternalServerError)
+		}),
+	}
+	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+
+	rec := httptest.NewRecorder()
+	g.handleDevshard(rec, httptest.NewRequest(http.MethodPost, "/devshard/12/v1/finalize", nil))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	require.True(t, rt.active.Load(), "a failed finalize must not deactivate the runtime")
+	require.False(t, rt.finalizing.Load(), "a failed finalize must reopen admission")
+	ok, _ := rt.acceptsNewInferences()
+	require.True(t, ok)
+}
+
+// TestPanickingFinalizeReopensAdmission pins the same rule for a handler that
+// panics: the gate is cleared by defer, so the runtime is not stuck closed.
+func TestPanickingFinalizeReopensAdmission(t *testing.T) {
+	rt := &devshardRuntime{
+		id:    "12",
+		model: "Qwen/Test",
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("finalize exploded")
+		}),
+	}
+	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+
+	func() {
+		defer func() { require.NotNil(t, recover(), "handler panic must propagate") }()
+		g.handleDevshard(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/devshard/12/v1/finalize", nil))
+	}()
+
+	require.False(t, rt.finalizing.Load(), "a panicking finalize must reopen admission")
+	ok, _ := rt.acceptsNewInferences()
+	require.True(t, ok)
+}
+
+// TestConcurrentFinalizeIsRefused pins the double-finalize case: the second
+// finalize must be refused outright, not queued on finalizeMu. A queued one
+// would run after the first finalize's defer reopened the gate, so it would
+// forward with admission open again -- the very window this change closes.
+func TestConcurrentFinalizeIsRefused(t *testing.T) {
+	rt, entered, release := blockingFinalizeRuntime(t, "12", http.StatusNoContent)
+	defer release()
+	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+
+	first := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		g.handleDevshard(rec, httptest.NewRequest(http.MethodPost, "/devshard/12/v1/finalize", nil))
+		first <- rec.Code
+	}()
+	<-entered
+
+	second := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		g.handleDevshard(rec, httptest.NewRequest(http.MethodPost, "/devshard/12/v1/finalize", nil))
+		second <- rec
+	}()
+	select {
+	case rec := <-second:
+		require.Equal(t, http.StatusConflict, rec.Code, "a second finalize must be refused while the first is in flight")
+		require.Contains(t, rec.Body.String(), "already has a finalize in flight", "the refusal must name the real reason")
+	case <-time.After(30 * time.Second):
+		t.Fatal("the second finalize was queued behind the first instead of being refused")
+	}
+
+	release()
+	require.Equal(t, http.StatusNoContent, <-first)
+}
+
+// TestFailedFinalizeAllowsRetry pins the refusal semantics end to end: after a
+// finalize fails, the gate is open again -- admission reserves, and a retried
+// finalize is served instead of being refused as a duplicate.
+func TestFailedFinalizeAllowsRetry(t *testing.T) {
+	var calls atomic.Int64
+	rt := &devshardRuntime{
+		id:    "12",
+		model: "Qwen/Test",
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if calls.Add(1) == 1 {
+				http.Error(w, `{"error":{"message":"finalize failed"}}`, http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+
+	rec := httptest.NewRecorder()
+	g.handleDevshard(rec, httptest.NewRequest(http.MethodPost, "/devshard/12/v1/finalize", nil))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	admitted, reason := g.reserveRuntimeIfAccepting(rt, 1)
+	require.True(t, admitted, "a failed finalize must reopen admission, refused with %q", reason)
+	g.releaseRuntime(rt, 1)
+
+	rec = httptest.NewRecorder()
+	g.handleDevshard(rec, httptest.NewRequest(http.MethodPost, "/devshard/12/v1/finalize", nil))
+	require.Equal(t, http.StatusNoContent, rec.Code, "a retried finalize must not be refused as a duplicate")
+	require.EqualValues(t, 2, calls.Load(), "the retried finalize must reach the runtime")
+	require.False(t, rt.active.Load(), "the successful retry leaves the runtime inactive")
+}

--- a/devshard/e2e/testutil/requests.go
+++ b/devshard/e2e/testutil/requests.go
@@ -126,12 +126,36 @@ func LatestSessionNonce(t *testing.T, client *http.Client, clientURL string) uin
 	return NumericField(t, session, "latest_nonce")
 }
 
+// The gateway refuses finalize with 409 while the escrow still has work in
+// flight, including the background race cleanup that outlives the winning
+// completion response, so a finalize issued right after a completion can be
+// refused for a moment. Retry that case briefly instead of failing the test.
+const (
+	finalizeConflictRetryFor      = 2 * time.Second
+	finalizeConflictRetryInterval = 100 * time.Millisecond
+)
+
 func FinalizeSession(t *testing.T, client *http.Client, clientURL string) map[string]any {
 	t.Helper()
 	DebugLogf(t, "finalizing devshard session")
-	settlement := PostJSON(t, client, clientURL+"/v1/finalize", map[string]any{})
+	settlement := postFinalizeRetryingConflict(t, client, clientURL+"/v1/finalize")
 	settlementJSON, err := json.MarshalIndent(settlement, "", "  ")
 	require.NoError(t, err)
 	t.Logf("SettlementContract:\n%s", settlementJSON)
 	return settlement
+}
+
+func postFinalizeRetryingConflict(t *testing.T, client *http.Client, url string) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(finalizeConflictRetryFor)
+	for {
+		resp := PostJSONRaw(t, client, url, map[string]any{}, AdminAPIKey)
+		if resp.StatusCode != http.StatusConflict || !time.Now().Before(deadline) {
+			require.Less(t, resp.StatusCode, 300, "POST %s returned %d: %s", url, resp.StatusCode, resp.Body)
+			require.NotNil(t, resp.JSON, "response body should be JSON: %s", resp.Body)
+			return resp.JSON
+		}
+		DebugLogf(t, "finalize refused with 409, retrying: %s", resp.Body)
+		time.Sleep(finalizeConflictRetryInterval)
+	}
 }


### PR DESCRIPTION
## What problem does this solve?

A TOCTOU race in the devshardctl gateway between `/v1/finalize` and inference admission: finalize checks `escrowHasBackgroundWork()` once, but `rt.active` stays `true` for the whole finalize call (it only flips in `markDevshardInactiveAfterFinalize`, after a 2xx), and `acceptsNewInferences` checks only `rt.active`. A chat completion can therefore be admitted and executed concurrently with an escrow finalize on the same runtime/session.

## How do you know this is a real problem?

- The drain-barrier contract documented at the `activeUserRequests`/`pendingRaceCleanup` field comment in `gateway.go` says settle and store-close must wait until background work is quiesced. The finalize HTTP path enforces that with a one-shot check that nothing prevents from going stale: `beginFinalizeGate` did not exist, and admission (`reserveRuntimeForModel` → `acceptsNewInferences` → `reserveRuntimeLocked`, all under `g.mu`) has no visibility into an in-flight finalize.
- Reproduced in-process before the fix: with a finalize parked mid-flight inside `rt.handler.ServeHTTP`, `acceptsNewInferences` returned `ok=true` and pooled admission handed out the runtime (probe output below, captured on unpatched `gateway.go`).
- Two adjacent gaps compound it: the single-runtime finalize route (`handleSingleOnly`) had **no** quiescence check at all, and the direct `/devshard/{id}` chat path checked `acceptsNewInferences` early but then reserved unconditionally ~50 lines later (after parsing and the rate limiter), so an admission decision could also go stale against a finalize that started in between.

## How does this solve the problem?

Adds a per-runtime `finalizing` gate (`atomic.Bool`) set atomically with the quiescence check inside one `g.mu` critical section (`beginFinalizeGate`). Since admission's gate-check + counter-increment also runs entirely under `g.mu`, the two decisive actions are now serialized: either admission wins and finalize sees active requests (409), or finalize wins and admission is refused with reason `finalize_in_flight`. The gate:

- refuses a second finalize while one is in flight (409 `already has a finalize in flight`) instead of queueing it on `finalizeMu` — a queued retry would otherwise run after a failed first finalize had already cleared the flag, reopening the race;
- is cleared via an unconditional `defer` on failure or panic so the runtime stays usable (on the `/devshard/{id}` route a successful finalize deactivates the runtime before the clear runs, so there is no `active && !finalizing` window);
- is applied to both finalize routes, and the direct chat path now re-checks admission and reserves in a single `g.mu` section (`reserveRuntimeIfAccepting`), mirroring the pooled path.

## What risks does this introduce? How can we mitigate them?

- **Deliberate behavior change:** single-runtime finalize can now return 409 while requests or race cleanups are draining. Previously it had no quiescence check. This matches the `/devshard/{id}` route's existing contract (same status, same body shape). Because e2e helpers finalize immediately after a completion — while a loser-side race cleanup may still be draining — `e2e/testutil.FinalizeSession` gained a bounded retry (409-only, 100ms interval, 2s budget) that documents the new contract; non-409 behavior is unchanged.
- A second concurrent finalize is now refused rather than serialized behind `finalizeMu`. Callers that relied on fire-and-forget double-submits will see a 409 on the loser; retrying after the winner completes behaves as before.
- The new admission-skip reason is `finalize_in_flight` (not `finalizing`) so metrics don't share a bucket with the session-phase reason `phase=finalizing`.
- `settleDevshardOnChain` is untouched: it already closes admission by flipping `rt.active` inside the same `g.mu` section as its own quiescence check, which is equivalent protection, and its finalize still serializes via `finalizeMu`.

## How do you know this PR fixes the problem?

Fail-first probe on unpatched `gateway.go` (new-symbol-free, deleted after capture), with a finalize parked mid-flight:

```
=== RUN   TestFailFirstFinalizeInFlightBlocksNewInferences
    zz_failfirst_test.go:41: acceptsNewInferences during in-flight finalize: ok=true reason=""
    zz_failfirst_test.go:44:
        	Error:      	An error is expected but got nil.
        	Messages:   	pooled admission must not pick a runtime whose finalize is in flight
--- FAIL: TestFailFirstFinalizeInFlightBlocksNewInferences (0.03s)
FAIL	devshard/cmd/devshardctl	0.112s
```

With the fix, seven new regression tests pin the behavior (admission refused during in-flight finalize on both routes, gate reopens after failed/panicking finalize, concurrent second finalize refused, failed finalize allows retry, single-route drain 409). All are channel-synchronized, no sleeps.

## Which components are affected?

- `devshard/cmd/devshardctl/gateway.go` (+67/−3)
- `devshard/cmd/devshardctl/gateway_finalize_admission_test.go` (new, 238 lines)
- `devshard/e2e/testutil/requests.go` (+25/−1)

## Testing & evidence

- Windows native (`CGO_ENABLED=0`, go1.26.4): finalize suite 10/10 pass; full `./cmd/devshardctl/` shows only the three pre-existing Windows-path failures (`TestResolveAdminStoragePath`, `TestAdminImportDevshardRejectsAbsoluteStoragePath`, `TestResolveBaseStorageDirNormalizesLegacyStateDBPath`), verified identical on pristine main.
- Linux (WSL2): `go test ./cmd/devshardctl/ -run 'Finalize' -race -count=5` → ok; full package with `-race` → ok, no data-race warnings.
- `go vet ./cmd/devshardctl/ ./e2e/...` clean; new files gofmt-clean (pre-existing gofmt drift elsewhere in `gateway.go` left untouched).
- Docker-bound e2e suites were **not** run (no Docker on this machine); the `e2e/testutil` change is compile- and vet-verified only.

### Before

```
--- FAIL: TestFailFirstFinalizeInFlightBlocksNewInferences (0.03s)
    zz_failfirst_test.go:41: acceptsNewInferences during in-flight finalize: ok=true reason=""
FAIL	devshard/cmd/devshardctl	0.112s
```

### After

```
--- PASS: TestFinalizeInFlightBlocksNewInferences (0.03s)
--- PASS: TestSingleOnlyFinalizeInFlightBlocksNewInferences (0.00s)
--- PASS: TestSingleOnlyFinalizeRequiresNoActiveRequests (0.00s)
--- PASS: TestFailedFinalizeReopensAdmission (0.00s)
--- PASS: TestPanickingFinalizeReopensAdmission (0.00s)
--- PASS: TestConcurrentFinalizeIsRefused (0.00s)
--- PASS: TestFailedFinalizeAllowsRetry (0.00s)
--- PASS: TestGatewayHandleDevshardFinalizeRequiresNoActiveRequests (0.03s)
PASS
ok  	devshard/cmd/devshardctl	0.143s

go test ./cmd/devshardctl/ -race -count=1   (WSL)
ok  	devshard/cmd/devshardctl	44.085s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
