### PR TITLE
fix(testermint): compile v0.2.14 rehearsal prep

### DIFF
--- a/testermint/upgrade-rehearsal/previous-release-prep.patch
+++ b/testermint/upgrade-rehearsal/previous-release-prep.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 000000000..5a2d131fe
 --- /dev/null
 +++ b/testermint/src/test/kotlin/UpgradeRehearsalPrepTests.kt
-@@ -0,0 +1,121 @@
+@@ -0,0 +1,125 @@
 +import com.productscience.*
 +import org.assertj.core.api.Assertions.assertThat
 +import org.junit.jupiter.api.Tag
@@ -49,7 +49,11 @@ index 000000000..5a2d131fe
 +            modelId = defaultModel,
 +        )
 +
-+        val handle = genesis.startDevshardProxy(escrowId = escrowId, keyName = user.keyName)
++        val handle = genesis.startDevshardProxy(
++            escrowId = escrowId,
++            keyName = user.keyName,
++            routePrefix = devshardVersionedRoutePrefix(),
++        )
 +        var devshardRequests = 0
 +        var settlementVersion = ""
 +        try {
@@ -70,7 +74,7 @@ index 000000000..5a2d131fe
 +                escrowAmount,
 +                requireCompletedValidations = false,
 +            )
-+            settlementVersion = settlement.parsed.version
++            settlementVersion = settlement.parsed.stateRootAndProtocolVersion
 +        } finally {
 +            genesis.stopDevshardProxy(escrowId)
 +        }


### PR DESCRIPTION
## Summary

- pass the versioned devshard route prefix when starting the pre-upgrade proxy
- read the settlement protocol version from `stateRootAndProtocolVersion`
- update the embedded patch hunk size for the added lines

## Why

`testermint/upgrade-rehearsal/previous-release-prep.patch` is applied to the v0.2.14 checkout during upgrade rehearsal preparation. The generated test used an outdated `startDevshardProxy` call and referenced `parsed.version`, so the preparation test no longer matched the v0.2.14 testermint API.

## Validation

- `git apply --check` against `release/v0.2.14` — passed
- applied the patch in a detached `release/v0.2.14` worktree — passed
- `git diff --check` on the applied result — passed
- verified the generated test contains `routePrefix = devshardVersionedRoutePrefix()` and `settlement.parsed.stateRootAndProtocolVersion`
- Gradle `testClasses` was not completed locally because the validation host has no JDK; repository CI is expected to provide the compile result

If accepted, please consider this contribution for the Gonka contributor reward program.
