### PR TITLE
fix(mlnodeclient): report MLnode HTTP failures instead of silently succeeding

### DIFF
--- a/common/utils/http.go
+++ b/common/utils/http.go
@@ -5,6 +5,7 @@ import (
 	"common/logging"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -25,8 +26,11 @@ func SendPostJsonRequest(ctx context.Context, client *http.Client, url string, p
 		// Create a POST request with no body if payload is nil.
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	} else {
-		// Marshal the payload to JSON.
-		jsonData, err := json.Marshal(payload)
+		// Marshal the payload to JSON. Note: assign with = (not :=) so a
+		// marshalling or request-construction failure is not swallowed by a
+		// shadowed err, which previously could return (nil, nil).
+		var jsonData []byte
+		jsonData, err = json.Marshal(payload)
 		if err != nil {
 			return nil, err
 		}
@@ -38,7 +42,17 @@ func SendPostJsonRequest(ctx context.Context, client *http.Client, url string, p
 	}
 	if req == nil {
 		logging.Error("SendPostJsonRequest. Failed to create HTTP request", types.Server, "url", url, "payload", payload)
-		return nil, err
+		return nil, fmt.Errorf("failed to create POST request for %s", url)
+	}
+	// Declare the body we are actually sending. This is not fixing a live
+	// failure: FastAPI falls back to JSON parsing when no content-type header is
+	// present at all (routing.py, the `if not content_type_value` branch), which
+	// is why these calls have worked without it. Send it because it is correct,
+	// it matches what SendDeleteJsonRequest already does, and it is what keeps
+	// these calls working if strict content-type checking is ever enabled
+	// upstream (a proxy, or a stricter framework default).
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	return client.Do(req)

--- a/decentralized-api/mlnodeclient/client.go
+++ b/decentralized-api/mlnodeclient/client.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/productscience/inference/x/inference/types"
@@ -44,12 +46,49 @@ func (api *Client) Stop(ctx context.Context) error {
 		return err
 	}
 
-	_, err = utils.SendPostJsonRequest(ctx, &api.client, requestUrl, nil)
+	resp, err := utils.SendPostJsonRequest(ctx, &api.client, requestUrl, nil)
 	if err != nil {
 		return err
 	}
+	defer drainAndClose(resp)
+
+	// The MLnode only answers 200 for /stop; anything else means the node did
+	// not stop. Reporting success on a 4xx/5xx let callers (broker redeploy,
+	// node-status reconciliation) proceed against a node still running a model.
+	if resp.StatusCode != http.StatusOK {
+		return &StatusError{Op: "stop", StatusCode: resp.StatusCode, Body: readErrorBody(resp)}
+	}
 
 	return nil
+}
+
+// maxErrorBodyBytes caps how much of an error response body is read into an
+// error message, so a misbehaving or non-MLnode endpoint cannot make us buffer
+// an unbounded response.
+const maxErrorBodyBytes = 4 << 10
+
+// readErrorBody returns a bounded, single-line excerpt of resp.Body for use in
+// error messages. Never returns an error: a body we cannot read simply yields
+// an empty excerpt.
+func readErrorBody(resp *http.Response) string {
+	if resp == nil || resp.Body == nil {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(body))
+}
+
+// drainAndClose closes resp.Body after discarding any remainder, so the
+// underlying connection can be reused instead of being torn down.
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxErrorBodyBytes))
+	_ = resp.Body.Close()
 }
 
 type MLNodeState string
@@ -170,11 +209,23 @@ func (api *Client) InferenceUp(ctx context.Context, model string, args []string)
 
 	logging.Info("Sending inference/up request to node", types.PoC, "inferenceUpUrl", inferenceUpUrl, "body", dto)
 
-	_, err = utils.SendPostJsonRequest(ctx, &api.client, inferenceUpUrl, dto)
+	resp, err := utils.SendPostJsonRequest(ctx, &api.client, inferenceUpUrl, dto)
 	if err != nil {
 		logging.Error("Failed to send inference/up request", types.PoC, "error", err, "inferenceUpUrl", inferenceUpUrl, "inferenceUpDto", dto)
+		return err
 	}
-	return err
+	defer drainAndClose(resp)
+
+	// The MLnode answers 409 when vLLM is already running or still starting, and
+	// 500 when startup failed. Treating those as success — the old behavior, where
+	// only transport errors were reported — meant callers believed a model was
+	// loaded when it was not, so the broker marked a failed launch healthy.
+	if resp.StatusCode != http.StatusOK {
+		statusErr := &StatusError{Op: "inference/up", StatusCode: resp.StatusCode, Body: readErrorBody(resp)}
+		logging.Error("inference/up returned a non-OK status", types.PoC, "error", statusErr, "inferenceUpUrl", inferenceUpUrl, "inferenceUpDto", dto)
+		return statusErr
+	}
+	return nil
 }
 
 // vLLMModelsResponse represents the OpenAI-compatible /v1/models response from vLLM

--- a/decentralized-api/mlnodeclient/client.go
+++ b/decentralized-api/mlnodeclient/client.go
@@ -62,12 +62,13 @@ func (api *Client) Stop(ctx context.Context) error {
 	return nil
 }
 
-// maxErrorBodyBytes caps how much of an error response body is read into an
-// error message, so a misbehaving or non-MLnode endpoint cannot make us buffer
-// an unbounded response.
+// maxErrorBodyBytes caps how much of a response body we read: both the excerpt
+// kept in an error message and the remainder discarded before close. It keeps a
+// misbehaving or non-MLnode endpoint from making us buffer or drain an
+// unbounded response.
 const maxErrorBodyBytes = 4 << 10
 
-// readErrorBody returns a bounded, single-line excerpt of resp.Body for use in
+// readErrorBody returns a bounded single-line excerpt of resp.Body for use in
 // error messages. Never returns an error: a body we cannot read simply yields
 // an empty excerpt.
 func readErrorBody(resp *http.Response) string {
@@ -78,11 +79,19 @@ func readErrorBody(resp *http.Response) string {
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(body))
+	// Fold every whitespace run into a single space. Trimming the ends is not
+	// enough: an excerpt from an arbitrary endpoint (an HTML error page, a
+	// Python traceback) would otherwise spread one error over several log lines.
+	return strings.Join(strings.Fields(string(body)), " ")
 }
 
-// drainAndClose closes resp.Body after discarding any remainder, so the
-// underlying connection can be reused instead of being torn down.
+// drainAndClose closes resp.Body, first discarding up to maxErrorBodyBytes of
+// whatever the caller left unread, so the underlying connection can go back to
+// the idle pool instead of being torn down. An MLnode error body is a short
+// JSON object, so in practice the remainder is fully consumed and the
+// connection is kept. A body past the cap is deliberately left unread: losing
+// one pooled connection is cheaper than draining an endpoint that may not be an
+// MLnode at all.
 func drainAndClose(resp *http.Response) {
 	if resp == nil || resp.Body == nil {
 		return

--- a/decentralized-api/mlnodeclient/client_test.go
+++ b/decentralized-api/mlnodeclient/client_test.go
@@ -60,7 +60,9 @@ func TestClient_InferenceUpChecksStatus(t *testing.T) {
 				if r.URL.Path != inferenceUpPath {
 					t.Errorf("path = %s, want %s", r.URL.Path, inferenceUpPath)
 				}
-				// FastAPI cannot parse a JSON body without the content type.
+				// We now declare the body we send. FastAPI would parse it either
+				// way (it falls back to JSON when no content-type header is
+				// present), so this pins the header, not a behavior change.
 				if ct := r.Header.Get("Content-Type"); ct != "application/json" {
 					t.Errorf("Content-Type = %q, want application/json", ct)
 				}
@@ -125,6 +127,49 @@ func TestClient_StopChecksStatus(t *testing.T) {
 		}
 		if statusErr.StatusCode != http.StatusInternalServerError {
 			t.Errorf("StatusCode = %d, want 500", statusErr.StatusCode)
+		}
+	})
+}
+
+// TestReadErrorBodyExcerpt pins the two properties the excerpt promises, since
+// the body comes from an endpoint we do not control: it stays on one log line,
+// and it stays bounded.
+func TestReadErrorBodyExcerpt(t *testing.T) {
+	t.Run("multi-line body is folded onto one line", func(t *testing.T) {
+		// A Python traceback or an HTML error page from something that is not an
+		// MLnode. Trimming the ends would leave the interior newlines and spread
+		// one error across several log lines.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = io.WriteString(w, "\n<html>\n  <body>\n\tBad Gateway\n  </body>\n</html>\n")
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).Stop(context.Background())
+		if err == nil {
+			t.Fatal("expected an error for a 502")
+		}
+		if msg := err.Error(); strings.ContainsAny(msg, "\n\r\t") {
+			t.Errorf("error message is not single-line: %q", msg)
+		}
+		if !strings.Contains(err.Error(), "Bad Gateway") {
+			t.Errorf("error %q lost the body content", err)
+		}
+	})
+
+	t.Run("oversized body is capped", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, strings.Repeat("x", maxErrorBodyBytes*4))
+		}))
+		defer srv.Close()
+
+		var statusErr *StatusError
+		if err := newTestClient(srv).Stop(context.Background()); !errors.As(err, &statusErr) {
+			t.Fatalf("error %v is not a StatusError", err)
+		}
+		if len(statusErr.Body) > maxErrorBodyBytes {
+			t.Errorf("excerpt is %d bytes, want at most %d", len(statusErr.Body), maxErrorBodyBytes)
 		}
 	})
 }

--- a/decentralized-api/mlnodeclient/client_test.go
+++ b/decentralized-api/mlnodeclient/client_test.go
@@ -1,0 +1,227 @@
+package mlnodeclient
+
+import (
+	"context"
+	"decentralized-api/utils"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestClient points a Client at srv for both the PoC and inference URLs.
+func newTestClient(srv *httptest.Server) *Client {
+	return NewNodeClient(srv.URL, srv.URL)
+}
+
+// TestClient_InferenceUpChecksStatus covers the false-positive that mattered
+// most: the MLnode answers 409 when vLLM is already running or starting, and the
+// old implementation discarded the response and reported success. The broker
+// then treated a failed launch as healthy instead of retrying it.
+func TestClient_InferenceUpChecksStatus(t *testing.T) {
+	cases := []struct {
+		name        string
+		status      int
+		body        string
+		wantErr     bool
+		wantRetry   bool
+		wantMessage string
+	}{
+		{name: "ok", status: http.StatusOK, body: `{"status":"OK"}`},
+		{
+			name:        "already running",
+			status:      http.StatusConflict,
+			body:        `{"detail":"VLLM is already running."}`,
+			wantErr:     true,
+			wantRetry:   true,
+			wantMessage: "already running",
+		},
+		{
+			name:      "startup failed",
+			status:    http.StatusInternalServerError,
+			body:      `{"detail":"Failed to start VLLM"}`,
+			wantErr:   true,
+			wantRetry: true,
+		},
+		{
+			name:      "validation error",
+			status:    http.StatusUnprocessableEntity,
+			body:      `{"detail":"bad request"}`,
+			wantErr:   true,
+			wantRetry: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != inferenceUpPath {
+					t.Errorf("path = %s, want %s", r.URL.Path, inferenceUpPath)
+				}
+				// FastAPI cannot parse a JSON body without the content type.
+				if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+					t.Errorf("Content-Type = %q, want application/json", ct)
+				}
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+
+			err := newTestClient(srv).InferenceUp(context.Background(), "model-a", []string{"--flag"})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("status %d: expected an error", tc.status)
+				}
+				if got := IsTransientStatus(err); got != tc.wantRetry {
+					t.Errorf("IsTransientStatus = %v, want %v (err=%v)", got, tc.wantRetry, err)
+				}
+				if tc.wantMessage != "" && !strings.Contains(err.Error(), tc.wantMessage) {
+					t.Errorf("error %q does not mention %q", err, tc.wantMessage)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestClient_StopChecksStatus guards the same class of bug on /stop: the MLnode
+// only answers 200, so any other status means the node did not stop. Reporting
+// success there let the broker's redeploy and the pre-PoC test proceed against a
+// node still running a model.
+func TestClient_StopChecksStatus(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != stopPath {
+				t.Errorf("path = %s, want %s", r.URL.Path, stopPath)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		if err := newTestClient(srv).Stop(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"detail":"could not stop"}`)
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).Stop(context.Background())
+		if err == nil {
+			t.Fatal("a non-200 /stop must be reported as a failure")
+		}
+		var statusErr *StatusError
+		if !errors.As(err, &statusErr) {
+			t.Fatalf("error %v is not a StatusError", err)
+		}
+		if statusErr.StatusCode != http.StatusInternalServerError {
+			t.Errorf("StatusCode = %d, want 500", statusErr.StatusCode)
+		}
+	})
+}
+
+// TestSendPostJsonRequest_ContentType documents the header change's actual
+// blast radius. SendPostJsonRequest is shared: every caller with a non-nil
+// payload now declares application/json, while a nil payload still sends no
+// body and no header. This is not fixing a live failure — FastAPI falls back to
+// JSON parsing when no content-type is present — it makes the request honest and
+// keeps it working under strict content-type checking.
+func TestSendPostJsonRequest_ContentType(t *testing.T) {
+	t.Run("payload declares application/json", func(t *testing.T) {
+		got := make(chan string, 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got <- r.Header.Get("Content-Type")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		client := &http.Client{}
+		resp, err := utils.SendPostJsonRequest(context.Background(), client, srv.URL, map[string]string{"k": "v"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer resp.Body.Close()
+		if ct := <-got; ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+	})
+
+	t.Run("nil payload sends no content type", func(t *testing.T) {
+		got := make(chan string, 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got <- r.Header.Get("Content-Type")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		client := &http.Client{}
+		resp, err := utils.SendPostJsonRequest(context.Background(), client, srv.URL, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer resp.Body.Close()
+		if ct := <-got; ct != "" {
+			t.Errorf("Content-Type = %q, want empty for a bodyless POST", ct)
+		}
+	})
+
+	t.Run("unmarshalable payload returns an error, never (nil, nil)", func(t *testing.T) {
+		// Guards the shadowed-err fix: a marshalling failure used to be
+		// swallowed, and the function could return no response and no error —
+		// leaving the caller to dereference a nil response.
+		client := &http.Client{}
+		resp, err := utils.SendPostJsonRequest(context.Background(), client, "http://127.0.0.1:1", func() {})
+		if err == nil {
+			t.Fatal("expected an error for an unmarshalable payload")
+		}
+		if resp != nil {
+			t.Errorf("expected no response alongside the error, got %v", resp)
+			resp.Body.Close()
+		}
+	})
+}
+
+// TestStatusErrorClassification pins the transient/permanent split callers use
+// to decide whether retrying makes sense.
+func TestStatusErrorClassification(t *testing.T) {
+	cases := []struct {
+		status int
+		want   bool
+	}{
+		{status: http.StatusConflict, want: true},        // vLLM already running
+		{status: http.StatusTooManyRequests, want: true}, //
+		{status: http.StatusRequestTimeout, want: true},  //
+		{status: http.StatusInternalServerError, want: true},
+		{status: http.StatusBadGateway, want: true},
+		{status: http.StatusBadRequest, want: false},
+		{status: http.StatusNotFound, want: false},
+		{status: http.StatusUnprocessableEntity, want: false},
+	}
+	for _, tc := range cases {
+		err := &StatusError{Op: "op", StatusCode: tc.status}
+		if got := err.Transient(); got != tc.want {
+			t.Errorf("status %d: Transient() = %v, want %v", tc.status, got, tc.want)
+		}
+		if !IsStatusError(err) {
+			t.Errorf("status %d: IsStatusError should be true", tc.status)
+		}
+		if got := IsTransientStatus(err); got != tc.want {
+			t.Errorf("status %d: IsTransientStatus = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+
+	// A plain error carries no status, so it is neither.
+	plain := errors.New("connection refused")
+	if IsStatusError(plain) || IsTransientStatus(plain) {
+		t.Error("a non-status error must not be classified as a StatusError")
+	}
+}

--- a/decentralized-api/mlnodeclient/client_test.go
+++ b/decentralized-api/mlnodeclient/client_test.go
@@ -1,8 +1,8 @@
 package mlnodeclient
 
 import (
+	"common/utils"
 	"context"
-	"decentralized-api/utils"
 	"errors"
 	"io"
 	"net/http"

--- a/decentralized-api/mlnodeclient/errors.go
+++ b/decentralized-api/mlnodeclient/errors.go
@@ -1,6 +1,10 @@
 package mlnodeclient
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
 
 // ErrAPINotImplemented indicates that the ML node doesn't support this API endpoint.
 // This typically happens when an older version of the ML node is running.
@@ -25,4 +29,53 @@ func NewAPINotImplementedError(endpoint string, statusCode int) error {
 		Endpoint:   endpoint,
 		StatusCode: statusCode,
 	}
+}
+
+// StatusError is returned when the MLnode answered with a non-OK HTTP status.
+// It carries the status code so callers can distinguish a deterministic
+// rejection (the request itself is wrong, e.g. 422) from a transient one (the
+// node is busy or temporarily broken, e.g. 409 / 5xx) without pattern-matching
+// error strings.
+type StatusError struct {
+	Op         string // short operation name, e.g. "inference/up"
+	StatusCode int
+	Body       string // bounded excerpt of the response body
+}
+
+func (e *StatusError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("%s failed with status %d", e.Op, e.StatusCode)
+	}
+	return fmt.Sprintf("%s failed with status %d: %s", e.Op, e.StatusCode, e.Body)
+}
+
+// Transient reports whether retrying the same request could plausibly succeed
+// later: the node is busy (409 Conflict — vLLM already running or starting),
+// rate-limited, timed out, or hit a server-side failure. A 4xx that describes
+// the request itself (400/404/422) would fail again identically.
+func (e *StatusError) Transient() bool {
+	switch e.StatusCode {
+	case http.StatusConflict, http.StatusTooManyRequests, http.StatusRequestTimeout:
+		return true
+	}
+	return e.StatusCode >= 500
+}
+
+// IsTransientStatus reports whether err is (or wraps) a StatusError whose
+// status is worth retrying. False for non-status errors, which callers
+// classify separately (a transport error is transient by nature).
+func IsTransientStatus(err error) bool {
+	var statusErr *StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.Transient()
+	}
+	return false
+}
+
+// IsStatusError reports whether err is (or wraps) a StatusError, i.e. the
+// MLnode answered but rejected the request — as opposed to a transport-level
+// failure where no reply was received at all.
+func IsStatusError(err error) bool {
+	var statusErr *StatusError
+	return errors.As(err, &statusErr)
 }


### PR DESCRIPTION
## What this is

`Stop` and `InferenceUp` discard the HTTP response and return only transport
errors, so **any** status the MLnode replies with is treated as success. The
MLnode does use status to signal refusal:

- `/api/v1/inference/up` → **409** when vLLM is already running or still
  starting (`mlnode/packages/api/src/api/inference/routes.py:26-29`), **500**
  when startup failed
- `/api/v1/stop` → only ever **200**

So a caller could be told a model was loaded when it was not, and the broker
could mark a failed launch healthy.

Pre-existing since `c3577272a` (#1348). Split out of the onboarding work in
#1296 at @bonujel's request: these calls sit on the broker's production PoC and
inference path, so they should get reviewed on their own rather than inside an
onboarding diff.

## Behavior change on a live path

`/inference/up` answering 409 now marks the node `FAILED` where it previously
reported success. A concrete way to reach that state, for anyone auditing the
blast radius:

mlnode's `/api/v1/stop` only calls `_async_stop()` when `is_running()` is true
(`routes.py:82-85`), but during startup `is_running()` is false while
`is_starting()` is true (`manager.py:162, 222`). So a stop-then-up against a
*starting* node leaves the startup task alive, `/inference/up` returns 409, and
`InferenceUpNodeCommand` records `FAILED`.

It self-heals through the status query worker and the reconciler, and the new
outcome is the truthful one — the old silent success is the bug. Calling it out
because it is a live-path change, not because it needs reverting.

## Changes

- Check the response status on `Stop` and `InferenceUp`.
- Add `StatusError`, so callers can separate transient refusals
  (409 / 429 / 408 / 5xx) from deterministic ones (400 / 404 / 422) without
  pattern-matching error strings. `IsStatusError` / `IsTransientStatus` are the
  helpers; `Transient()` keeps the policy in one place.
- Bound the error-body excerpt (4 KiB) and drain + close response bodies so the
  connection can be reused.
- Fix a shadowed `err` in `utils.SendPostJsonRequest`: a marshalling failure was
  swallowed and the function could return `(nil, nil)`, leaving the caller to
  dereference a nil response.
- Declare `Content-Type: application/json` when there is a payload.

### On the Content-Type change specifically

This is **not** fixing a live failure, and it would be wrong to describe it as
one. FastAPI falls back to parsing the body as JSON when no `content-type` header
is present at all — `fastapi/routing.py`, the `if not content_type_value` branch
(verified in the installed 0.128.8; the same branch exists in the 0.115.8 floor
mlnode pins). That is why the PoC v2 path has worked without it all along.

It is sent because the request should describe what it carries, it matches what
`SendDeleteJsonRequest` already does, and it is what keeps these calls working if
strict content-type checking is ever enabled upstream (a proxy, or a stricter
framework default).

`SendPostJsonRequest` is shared, so the header now goes out from every call site
with a non-nil payload: `CheckModelStatus`, `DownloadModel`, `DeleteModel`,
`InferenceUp`, and the PoC v2 path (`InitGenerateV2`, `GenerateV2`,
`StopPowV2`). `Client.Stop` passes nil, sends no body, and is unaffected —
covered by a test either way.

## Tests

New `mlnodeclient/client_test.go`:

- `/inference/up` 200 / 409 / 500 / 422, asserting both the error and its
  transient classification
- `/stop` 200 and 500, asserting the error is a `StatusError` carrying the code
- the Content-Type matrix: payload sends the header, nil payload sends none, and
  an unmarshalable payload returns an error rather than `(nil, nil)`
- the full transient/permanent status table

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean
- `go test` green for `mlnodeclient` and `utils`, plus `broker`,
  `internal/server/mlnode` and `poc` — the packages that actually drive these
  calls
