### PR TITLE
BridgeContract group-key rotation isn't domain-separated 

### DIFF
--- a/decentralized-api/internal/bls/group_validation.go
+++ b/decentralized-api/internal/bls/group_validation.go
@@ -137,7 +137,7 @@ func (bm *BlsManager) ProcessGroupPublicKeyGeneratedToSign(event *chainevents.JS
 }
 
 // computeValidationMessageHash computes the validation message hash using the same format as the chain
-// Format: abi.encodePacked(previous_epoch_id (8 BE), sha256(chain_id) (32), new_group_key_uncompressed_256 (X.c0||X.c1||Y.c0||Y.c1; each 64-byte BE limb))
+// Format: abi.encodePacked(previous_epoch_id (8 BE), sha256(chain_id) (32), keccak256("TRANSITION_OPERATION") (32), new_group_key_uncompressed_256 (X.c0||X.c1||Y.c0||Y.c1; each 64-byte BE limb))
 func (bm *BlsManager) computeValidationMessageHash(groupPublicKey []byte, previousEpochID, newEpochID uint64, chainID string) ([]byte, error) {
 	if len(groupPublicKey) != 96 {
 		return nil, fmt.Errorf("invalid group public key length: expected 96 bytes, got %d", len(groupPublicKey))
@@ -163,6 +163,8 @@ func (bm *BlsManager) computeValidationMessageHash(groupPublicKey []byte, previo
 
 	// Add chain_id (32 bytes)
 	encodedData = append(encodedData, chainIdBytes...)
+
+	encodedData = append(encodedData, blstypes.TransitionOperationTag()...)
 
 	// Append uncompressed G2 (256 bytes): X.c0||X.c1||Y.c0||Y.c1, each 64-byte big-endian (48-byte left-padded)
 	appendFp64 := func(e fp.Element) {

--- a/inference-chain/x/bls/keeper/msg_server_group_validation.go
+++ b/inference-chain/x/bls/keeper/msg_server_group_validation.go
@@ -253,7 +253,7 @@ func (ms msgServer) SubmitGroupKeyValidationSignature(goCtx context.Context, msg
 }
 
 // computeValidationMessageHash computes the message hash for group key validation.
-// Uses Ethereum-compatible abi.encodePacked(previous_epoch_id [8], chain_id [32], new_group_key_uncompressed [256]).
+// Uses Ethereum-compatible abi.encodePacked(previous_epoch_id [8], chain_id [32], TRANSITION_OPERATION [32], new_group_key_uncompressed [256]).
 func (ms msgServer) computeValidationMessageHash(ctx sdk.Context, groupPublicKey []byte, previousEpochId, newEpochId uint64) ([]byte, error) {
 	// Decompress and format group key using helper (blst optimized)
 	g2Uncompressed256, err := ms.Keeper.DecompressG2To256Blst(groupPublicKey)
@@ -274,6 +274,10 @@ func (ms msgServer) computeValidationMessageHash(ctx sdk.Context, groupPublicKey
 
 	// Add chain_id (32 bytes)
 	encodedData = append(encodedData, chainIdBytes...)
+
+	// Add TRANSITION_OPERATION domain tag (32 bytes) at offset 40, mirroring the
+	// MINT_OPERATION / WITHDRAW_OPERATION tags on the other two signed messages.
+	encodedData = append(encodedData, types.TransitionOperationTag()...)
 
 	// Add the 256-byte uncompressed G2 key
 	encodedData = append(encodedData, g2Uncompressed256...)

--- a/inference-chain/x/bls/keeper/transition_domain_separation_test.go
+++ b/inference-chain/x/bls/keeper/transition_domain_separation_test.go
@@ -1,0 +1,88 @@
+package keeper
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/sha3"
+
+	"github.com/productscience/inference/x/bls/types"
+)
+
+func keccak256(parts ...[]byte) []byte {
+	h := sha3.NewLegacyKeccak256()
+	for _, p := range parts {
+		h.Write(p)
+	}
+	return h.Sum(nil)
+}
+
+func TestTransitionOperationTag_PinnedValue(t *testing.T) {
+	tag := types.TransitionOperationTag()
+	require.Len(t, tag, 32)
+	require.Equal(t, keccak256([]byte("TRANSITION_OPERATION")), tag,
+		`TransitionOperationTag must equal keccak256("TRANSITION_OPERATION")`)
+
+	// Returned slice must be a copy: mutating it must not corrupt the package value.
+	tag[0] ^= 0xff
+	require.Equal(t, keccak256([]byte("TRANSITION_OPERATION")), types.TransitionOperationTag(),
+		"TransitionOperationTag must return a fresh copy each call")
+}
+
+func TestRotationMessage_DomainSeparated(t *testing.T) {
+	k := Keeper{}
+
+	const epoch = uint64(314)
+	chainID := make([]byte, 32) // GONKA_CHAIN_ID (32 bytes)
+	for i := range chainID {
+		chainID[i] = 0xAB
+	}
+
+	tag := types.TransitionOperationTag()
+
+	buildRotation := func(withTag bool, key []byte) []byte {
+		ep := make([]byte, 8)
+		binary.BigEndian.PutUint64(ep, epoch)
+		b := append([]byte{}, ep...)
+		b = append(b, chainID...)
+		if withTag {
+			b = append(b, tag...)
+		}
+		b = append(b, key...)
+		return b
+	}
+
+	nsReqId := keccak256([]byte("attacker-creator"), []byte("attacker-request-id"))
+	domain := make([]byte, 32)
+	for i := range domain {
+		domain[i] = 0xCD
+	}
+	data := [][]byte{domain}
+	for i := 0; i < 6; i++ { // 1 domain + 6 chunks + nsReqId slot = 256 bytes after epoch||chainId
+		chunk := make([]byte, 32)
+		for j := range chunk {
+			chunk[j] = byte(0x10 + i)
+		}
+		data = append(data, chunk)
+	}
+	external := k.encodeSigningData(types.SigningData{
+		CurrentEpochId: epoch,
+		ChainId:        chainID,
+		RequestId:      nsReqId,
+		Data:           data,
+	})
+
+	// The "key" the attacker tries to install is everything after epoch||chainId.
+	forgedKey := external[40:] // nsReqId(32) || domain(32) || 6*32 data = 256 bytes
+	require.Len(t, forgedKey, 256)
+
+	require.Equal(t, external, buildRotation(false, forgedKey),
+		"control: pre-fix (untagged) rotation must collide with the external request")
+	newRotation := buildRotation(true, forgedKey)
+	require.Equal(t, tag, newRotation[40:72], "TRANSITION_OPERATION tag must sit at offset 40")
+	require.NotEqual(t, newRotation, external,
+		"post-fix rotation must NOT collide with an external threshold-signing message")
+	require.NotEqual(t, tag, external[40:72],
+		"external request-id slot must not equal the transition tag")
+}

--- a/inference-chain/x/bls/types/transition_operation.go
+++ b/inference-chain/x/bls/types/transition_operation.go
@@ -1,0 +1,27 @@
+package types
+
+import "golang.org/x/crypto/sha3"
+
+// TransitionOperationName is the preimage of the group-key rotation domain tag.
+const TransitionOperationName = "TRANSITION_OPERATION"
+
+// transitionOperationTag is keccak256("TRANSITION_OPERATION"), the 32-byte domain
+// tag inserted at offset 40 of the rotation validation message:
+//
+//	keccak256( previous_epoch_id[8] || gonka_chain_id[32] || TRANSITION_OPERATION[32] || new_group_key[256] )
+//
+var transitionOperationTag = func() [32]byte {
+	h := sha3.NewLegacyKeccak256()
+	h.Write([]byte(TransitionOperationName))
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}()
+
+// TransitionOperationTag returns a fresh copy of the 32-byte domain-separation tag
+// keccak256("TRANSITION_OPERATION") for the group-key rotation message.
+func TransitionOperationTag() []byte {
+	out := make([]byte, 32)
+	copy(out, transitionOperationTag[:])
+	return out
+}

--- a/proposals/ethereum-bridge-contact/contracts/BridgeContract.sol
+++ b/proposals/ethereum-bridge-contact/contracts/BridgeContract.sol
@@ -146,12 +146,17 @@ contract BridgeContract is ERC20, Ownable, ReentrancyGuard {
     // Operation type identifiers for message hash domain separation
     bytes32 constant WITHDRAW_OPERATION = keccak256("WITHDRAW_OPERATION");
     bytes32 constant MINT_OPERATION = keccak256("MINT_OPERATION");
+    bytes32 constant TRANSITION_OPERATION = keccak256("TRANSITION_OPERATION");
     
     // Field modulus p for BLS12-381 (64-byte big-endian, padded)
     bytes constant FP_MODULUS = hex"000000000000000000000000000000001a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab";
     
     // Uncompressed G2 generator (X.c0, X.c1, Y.c0, Y.c1), each 64-byte big-endian (padded)
     bytes constant G2_GENERATOR = hex"00000000000000000000000000000000024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb80000000000000000000000000000000013e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e000000000000000000000000000000000ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801000000000000000000000000000000000606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be";
+
+    // Uncompressed G1 generator (x, y), each 64-byte big-endian (48-byte value, 16-byte left-pad).
+    // Used only as a fixed pairing input for the G2 point-validity check below.
+    bytes constant G1_GENERATOR = hex"0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb0000000000000000000000000000000008b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1";
 
     // =============================================================================
     // EVENTS
@@ -302,6 +307,8 @@ contract BridgeContract is ERC20, Ownable, ReentrancyGuard {
 
         // Verify group public key is 256 bytes (G2 point uncompressed)
         require(groupPublicKey.length == 256, "Invalid group key length");
+
+        require(_isValidG2Point(groupPublicKey), "Invalid G2 group key");
 
         // Verify validation signature against previous epoch
         GroupKey memory newGroupKeyStruct = _bytesToGroupKey(groupPublicKey);
@@ -642,6 +649,28 @@ contract BridgeContract is ERC20, Ownable, ReentrancyGuard {
     }
 
     /**
+     * @dev verify `g2Point` is a valid, in-subgroup G2 point.
+
+     * Implementation leverages the EIP-2537 pairing precompile's mandatory on-curve
+     * and subgroup checks on every input point. The pairing
+     *   e(G1, key) * e(-G1, key)
+     * equals 1 for any valid subgroup `key`, so a well-formed point returns true;
+     * an invalid or non-subgroup `key` makes the precompile fail, returning false.
+     */
+    function _isValidG2Point(bytes memory g2Point) internal view returns (bool) {
+        require(g2Point.length == 256, "Invalid group key length");
+
+        bytes memory negG1 = _negateG1(G1_GENERATOR);
+        bytes memory pairingInput = abi.encodePacked(
+            G1_GENERATOR, g2Point,   // e(G1, key)
+            negG1,        g2Point     // e(-G1, key)
+        );
+
+        (bool success, bytes memory result) = BLS12_PAIRING.staticcall(pairingInput);
+        return success && result.length == 32 && abi.decode(result, (bool));
+    }
+
+    /**
      * @dev Map a 32-byte message hash (as field element) to a G1 point using EIP-2537 MAP_FP_TO_G1
      *      Input must be a 64-byte big-endian field element; we left-pad the 32-byte hash.
      *      Returns 128-byte uncompressed G1 point (x||y), big-endian coords (64-bytes each).
@@ -703,16 +732,23 @@ contract BridgeContract is ERC20, Ownable, ReentrancyGuard {
         require(validationSignature.length == 128, "Invalid validation signature length");
 
         // Compute validation message hash following the format:
-        // abi.encodePacked(previous_epoch_id, chain_id, data[0], data[1], data[2])
-        // where data[0], data[1], data[2] are the 3 parts of the new group public key
-        
+        // abi.encodePacked(previous_epoch_id, chain_id, TRANSITION_OPERATION, part0..part7)
+        // where part0..part7 are the 8 parts of the new group public key.
+        //
+        // TRANSITION_OPERATION is a fixed domain tag at offset 40 (right after the
+        // 8-byte epoch and 32-byte chain id), mirroring the MINT_OPERATION /
+        // WITHDRAW_OPERATION tags on the other two signed messages. Without it, any
+        // group signature over (epoch || GONKA_CHAIN_ID || 256 arbitrary bytes) would
+        // be byte-identical to a rotation authorizing those bytes as the next key.
+
         // Use GONKA chain id (source chain) for transition binding
         bytes32 chainId = GONKA_CHAIN_ID;
-        
-        // Encode message: abi.encodePacked(previousEpochId, chainId, part0..part7)
+
+        // Encode message: abi.encodePacked(previousEpochId, chainId, TRANSITION_OPERATION, part0..part7)
         bytes memory encodedMessage = abi.encodePacked(
             previousEpochId,        // 8 bytes
             chainId,                // 32 bytes
+            TRANSITION_OPERATION,   // 32 bytes - domain separation tag (offset 40)
             newGroupKey.part0,      // 32 bytes - direct access, no intermediate variables
             newGroupKey.part1,      // 32 bytes
             newGroupKey.part2,      // 32 bytes

--- a/proposals/ethereum-bridge-contact/contracts/test/BridgeHarness.sol
+++ b/proposals/ethereum-bridge-contact/contracts/test/BridgeHarness.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../BridgeContract.sol";
+
+/// @dev Test-only harness that exposes BridgeContract internals so the BLS
+/// verification and G2-validity paths can be exercised against the real
+/// EIP-2537 precompiles under a Prague EVM. Not for deployment.
+contract BridgeHarness is BridgeContract {
+    constructor(bytes32 g, bytes32 e) BridgeContract(g, e) {}
+
+    function exposedIsValidG2Point(bytes memory key) external view returns (bool) {
+        return _isValidG2Point(key);
+    }
+
+    function exposedMapMessageToG1(bytes32 messageHash) external view returns (bytes memory) {
+        return _mapMessageToG1(messageHash);
+    }
+
+    /// @dev Raw BLS check against an arbitrary message hash, with no domain tag.
+    function exposedVerifyRaw(
+        bytes memory key,
+        bytes32 messageHash,
+        bytes memory sig
+    ) external view returns (bool) {
+        return _verifyBLSSignature(key, messageHash, sig);
+    }
+
+    function exposedVerifyTransition(
+        bytes memory prevKey,
+        bytes memory newKey,
+        bytes memory sig,
+        uint64 prevEpoch
+    ) external view returns (bool) {
+        return _verifyTransitionSignature(
+            _bytesToGroupKey(prevKey),
+            _bytesToGroupKey(newKey),
+            sig,
+            prevEpoch
+        );
+    }
+
+    /// @dev Reproduces the exact pre-image the contract hashes for a rotation,
+    /// so JS test code signs the identical bytes the verifier checks.
+    function transitionMessageHash(bytes memory newKey, uint64 prevEpoch)
+        external
+        view
+        returns (bytes32)
+    {
+        GroupKey memory k = _bytesToGroupKey(newKey);
+        return keccak256(
+            abi.encodePacked(
+                prevEpoch,
+                GONKA_CHAIN_ID,
+                TRANSITION_OPERATION,
+                k.part0, k.part1, k.part2, k.part3,
+                k.part4, k.part5, k.part6, k.part7
+            )
+        );
+    }
+}

--- a/proposals/ethereum-bridge-contact/test/transition_domain_separation.test.js
+++ b/proposals/ethereum-bridge-contact/test/transition_domain_separation.test.js
@@ -1,0 +1,93 @@
+// End-to-end test for the group-key rotation domain-separation fix, run against
+// the real EIP-2537 BLS precompiles (Prague EVM).
+import { expect } from "chai";
+import hre from "hardhat";
+import { bls12_381 as bls } from "@noble/curves/bls12-381.js";
+import {
+    publicKeyToEip2537Hex,
+    signatureToEip2537Hex,
+} from "../bls.js";
+
+const GONKA_CHAIN_ID = "0x" + "01".repeat(32);
+const ETHEREUM_CHAIN_ID = "0x" + "02".repeat(32);
+
+const SK_N = 0x1234567890abcdef1234567890abcdef1234567890abcdefn;
+const SK_N1 = 0x0fedcba0987654321fedcba0987654321fedcba0987654321n;
+
+function groupKey256(sk) {
+    const compressed = bls.G2.Point.BASE.multiply(sk).toBytes(true); // 96 bytes
+    return publicKeyToEip2537Hex(Buffer.from(compressed).toString("hex"));
+}
+
+// Sign a contract message hash the same way the group would: sig = sk * H(m),
+// where H(m) = MAP_FP_TO_G1(messageHash) is taken from the real precompile (via
+// the harness) so it is byte-identical to what the verifier recomputes.
+async function signMessageHash(harness, messageHash, sk) {
+    const hmPadded = await harness.exposedMapMessageToG1(messageHash); // 0x + 128 bytes
+    const hm = Buffer.from(hmPadded.slice(2), "hex");
+    expect(hm.length).to.equal(128);
+    // EIP-2537 G1 point: [16-byte pad || 48-byte x][16-byte pad || 48-byte y].
+    const raw96 = Buffer.concat([hm.subarray(16, 64), hm.subarray(80, 128)]);
+    const hmPoint = bls.G1.Point.fromBytes(raw96);
+    const sigRaw = hmPoint.multiply(sk).toBytes(false); // 96-byte uncompressed
+    return signatureToEip2537Hex(Buffer.from(sigRaw).toString("hex")); // -> 128 bytes
+}
+
+describe("Group-key rotation domain separation (EIP-2537 e2e)", function () {
+    let ethers, harness, owner, attacker;
+    const N = 5n;
+
+    beforeEach(async function () {
+        const conn = await hre.network.getOrCreate();
+        ethers = conn.ethers;
+        [owner, attacker] = await ethers.getSigners();
+        const Harness = await ethers.getContractFactory("BridgeHarness");
+        harness = await Harness.deploy(GONKA_CHAIN_ID, ETHEREUM_CHAIN_ID);
+        await harness.waitForDeployment();
+        await harness.connect(owner).setGroupKey(N, groupKey256(SK_N));
+        await harness.connect(owner).resetToNormalOperation();
+    });
+
+    it("verifies and installs a legitimately signed rotation", async function () {
+        const newKey = groupKey256(SK_N1);
+        const msgHash = await harness.transitionMessageHash(newKey, N);
+        const sig = await signMessageHash(harness, msgHash, SK_N);
+
+        expect(await harness.exposedVerifyTransition(groupKey256(SK_N), newKey, sig, N))
+            .to.equal(true);
+        await harness.connect(attacker).submitGroupKey(N + 1n, newKey, sig);
+        const meta = await harness.epochMeta();
+        expect(meta.latestEpochId).to.equal(N + 1n);
+    });
+
+    it("rejects a signature over the OLD untagged message (forge replay is dead)", async function () {
+        const newKey = groupKey256(SK_N1);
+        const untaggedHash = ethers.solidityPackedKeccak256(
+            ["uint64", "bytes32", "bytes"],
+            [N, GONKA_CHAIN_ID, newKey]
+        );
+        const forgedSig = await signMessageHash(harness, untaggedHash, SK_N);
+        expect(await harness.exposedVerifyRaw(groupKey256(SK_N), untaggedHash, forgedSig))
+            .to.equal(true);
+        expect(await harness.exposedVerifyTransition(groupKey256(SK_N), newKey, forgedSig, N))
+            .to.equal(false);
+        await expect(
+            harness.connect(attacker).submitGroupKey(N + 1n, newKey, forgedSig)
+        ).to.be.revertedWith("Invalid transition signature");
+    });
+
+    it("_isValidG2Point accepts a real DKG key and rejects a non-curve blob", async function () {
+        expect(await harness.exposedIsValidG2Point(groupKey256(SK_N1))).to.equal(true);
+
+        const garbage = "0x" + "11".repeat(256); // right length, not a G2 point
+        expect(await harness.exposedIsValidG2Point(garbage)).to.equal(false);
+    });
+
+    it("submitGroupKey rejects a non-curve garbage key before storing it", async function () {
+        const garbage = "0x" + "11".repeat(256);
+        const anySig = "0x" + "22".repeat(128);
+        await expect(
+            harness.connect(attacker).submitGroupKey(N + 1n, garbage, anySig)
+        ).to.be.revertedWith("Invalid G2 group key");
+    });
+});


### PR DESCRIPTION
The bridge group-key rotation was the only one of the three BLS-signed messages (mint, withdraw, rotation) without an operation tag. A signature over `epoch || GONKA_CHAIN_ID || <256 arbitrary bytes>` was byte-identical to a rotation authorizing those bytes as the next group key.

Add a `keccak256("TRANSITION_OPERATION")` tag at offset 40 of the rotation validation message, mirroring `MINT_OPERATION` / `WITHDRAW_OPERATION`. Applied in lockstep across all three producers/verifiers:
1.  `x/bls` keeper `computeValidationMessageHash` (aggregate check)
2.  decentralized-api `computeValidationMessageHash` (off-chain signer) via a shared `types.TransitionOperationTag()` source of truth.
Also add a G2 point-validity gate (`_isValidG2Point`) in `submitGroupKey` as a defense against non-curve forged keys.