### PR TITLE
fix(local-test-net): bump testapp-server builder to Go 1.25.9

### DIFF
--- a/local-test-net/Dockerfile.testapp-server
+++ b/local-test-net/Dockerfile.testapp-server
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-alpine3.21 AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 RUN apk add --no-cache zip
 
 WORKDIR /build


### PR DESCRIPTION
## What problem does this solve?

The `Integration Tests` workflow is broken on `main`: the `build-images` job fails deterministically in `testapp-server-build-docker`, so no integration run can get past image building (latest example: https://github.com/gonka-ai/gonka/actions/runs/30421345814, commit `182d0820c`).

## How do you know this is a real problem?

`versioned/go.mod` requires `go 1.25.9` since the devshard v4 merge, but the testapp-server builder stage was still `golang:1.24.2-alpine3.21`. Go images ship with `GOTOOLCHAIN=local`, so the toolchain cannot auto-upgrade and `go mod download` fails immediately:

```
#13 [builder 5/8] RUN go mod download
#13 0.126 go: go.mod requires go >= 1.25.9 (running go 1.24.2; GOTOOLCHAIN=local)
make: *** [Makefile:90: testapp-server-build-docker] Error 1
```

Reproduced locally on a pristine `182d0820c` checkout with `make testapp-server-build-docker` — identical error to the CI run above.

## How does this solve the problem?

One-line change: bump the builder base image to `golang:1.25.9-alpine3.23`, matching every other Dockerfile that builds a `go 1.25.9` module (`devshard/*`, `versioned/`, `edge-api/`, `decentralized-api/`).

## What risks does this introduce? How can we mitigate them?

Minimal. The image only compiles the `versioned` test helpers (`e2e/testapp`) and serves the resulting zips over HTTP; the runtime stage (`python:3.12-alpine3.21`) is untouched. The remaining `golang:1.24.2` Dockerfiles (`inference-chain`, `proxy`, `proxy-ssl`) were checked and left alone — their modules still declare `go 1.24.x`, so they are not affected.

## How do you know this PR fixes the problem?

With this change, `make testapp-server-build-docker` completes successfully, and the built container serves all expected artifacts (smoke-tested: `GET /testapp.zip.sha256` returns the checksum; `/srv/files` contains `testapp.zip`, `testapp2.zip`, `testapp-rollout.zip` plus their `.sha256` files).

## Which components are affected?

- `local-test-net/Dockerfile.testapp-server` (builder stage base image only)

## Testing & evidence

Local: Linux (WSL2 Ubuntu 22.04), Docker Engine 29.5.3.

### Before

```
$ git log -1 --format=%h   # pristine main
182d0820c
$ make testapp-server-build-docker
#13 [builder 5/8] RUN go mod download
#13 0.126 go: go.mod requires go >= 1.25.9 (running go 1.24.2; GOTOOLCHAIN=local)
#13 ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
make: *** [Makefile:90: testapp-server-build-docker] Error 1
```

### After

```
$ make testapp-server-build-docker
#17 naming to docker.io/library/testapp-server:latest done
#17 DONE 1.8s
$ docker run -d --rm --name testapp-smoke -p 18099:8080 testapp-server:latest
$ wget -qO- http://localhost:18099/testapp.zip.sha256
289e10bdf5ff0c120d2ba42b29b7f6b20e79f7462ac73ca115b5f48e6abe687e
$ docker exec testapp-smoke ls /srv/files
testapp-rollout.zip  testapp-rollout.zip.sha256  testapp.zip
testapp.zip.sha256   testapp2.zip                testapp2.zip.sha256
```
