### PR TITLE
Self-declared hardware model list can relabel PoC weight into an unvalidated model subgroup

### DIFF
--- a/inference-chain/x/inference/module/model_assignment.go
+++ b/inference-chain/x/inference/module/model_assignment.go
@@ -239,6 +239,50 @@ func compareBoolSlices(a, b []bool) int {
 	}
 }
 
+func validatedModelNodes(p *types.ActiveParticipant) map[string][]*types.MLNodeInfo {
+	validated := make(map[string][]*types.MLNodeInfo, len(p.Models))
+	for i, modelId := range p.Models {
+		if modelId == "" || i >= len(p.MlNodes) || p.MlNodes[i] == nil {
+			continue
+		}
+		for _, node := range p.MlNodes[i].MlNodes {
+			if node == nil || node.NodeId == "" {
+				continue
+			}
+			validated[modelId] = append(validated[modelId], node)
+		}
+	}
+	return validated
+}
+
+type nodeOwner struct {
+	modelId string
+	node    *types.MLNodeInfo
+}
+
+func resolveNodeOwnerModel(validated map[string][]*types.MLNodeInfo) (map[string]nodeOwner, []string) {
+	owner := make(map[string]nodeOwner)
+	contested := make(map[string]bool)
+
+	for _, modelId := range sortedKeys(validated) {
+		for _, node := range validated[modelId] {
+			current, seen := owner[node.NodeId]
+			if !seen {
+				owner[node.NodeId] = nodeOwner{modelId: modelId, node: node}
+				continue
+			}
+			if current.modelId != modelId {
+				contested[node.NodeId] = true
+			}
+			if compareMLNodePreference(node, current.node) > 0 {
+				owner[node.NodeId] = nodeOwner{modelId: modelId, node: node}
+			}
+		}
+	}
+
+	return owner, sortedKeys(contested)
+}
+
 func (e *EpochMLNodeData) GetAllIndividualNodeWeights() []int64 {
 	weights := make([]int64, 0)
 	for _, modelId := range sortedKeys(e.data) {
@@ -391,75 +435,57 @@ func (ma *ModelAssigner) setModelsForParticipants(ctx context.Context, participa
 			continue
 		}
 
-		var originalMLNodes []*types.MLNodeInfo
-		for _, modelNodes := range p.MlNodes {
-			if modelNodes != nil {
-				originalMLNodes = append(originalMLNodes, modelNodes.MlNodes...)
-			}
-		}
-		ma.LogInfo("Original MLNodes", types.Allocation, "flow_context", FlowContext, "step", "pre_legacy_distribution", "participant_index", p.Index, "ml_nodes", originalMLNodes)
-
-		if len(originalMLNodes) > 0 {
-			dedupedNodes, dedupStats := dedupMLNodesById(originalMLNodes)
-			ma.logMLNodeDedupStats(
-				"Duplicate ML nodes detected before participant assignment",
-				dedupStats,
-				"flow_context", FlowContext,
-				"step", "dedup_participant_nodes",
-				"participant_index", p.Index,
-			)
-			originalMLNodes = dedupedNodes
-		}
-
-		for _, mlNode := range originalMLNodes {
-			mlNode.TimeslotAllocation = []bool{true, false} // [PRE_POC_SLOT, POC_SLOT]
-		}
-		ma.LogInfo("Initialized all ML nodes to PRE_POC_SLOT=true, POC_SLOT=false", types.Allocation, "flow_context", FlowContext, "step", "init_slots", "participant_index", p.Index)
-
-		assignedMLNodes := make(map[string]bool)
-		var supportedModels []string
-		var newMLNodeArrays []*types.ModelMLNodes
+		validated := validatedModelNodes(p)
+		ma.LogInfo("Validated model assignment before hardware filter", types.Allocation, "flow_context", FlowContext, "step", "pre_hardware_filter", "participant_index", p.Index, "validated_models", sortedKeys(validated))
 
 		supportedModelsByNode := supportedModelsByNode(hardwareNodes, governanceModels)
 		for _, nodeId := range sortedKeys(supportedModelsByNode) {
-			supportedModels := supportedModelsByNode[nodeId]
-			ma.LogInfo("Supported models by node", types.Allocation, "flow_context", FlowContext, "step", "supported_models_by_node", "node_id", nodeId, "supported_models", supportedModels)
+			ma.LogInfo("Supported models by node", types.Allocation, "flow_context", FlowContext, "step", "supported_models_by_node", "node_id", nodeId, "supported_models", supportedModelsByNode[nodeId])
 		}
 
-		// For each governance model, pick the available MLNodes that have the model as first supported model
+		owner, contested := resolveNodeOwnerModel(validated)
+		if len(contested) > 0 {
+			ma.LogWarn("ML node claimed by multiple models, keeping highest-weight claim", types.Allocation,
+				"flow_context", FlowContext, "step", "contested_nodes",
+				"participant_index", p.Index, "node_ids", contested)
+		}
+
+		keptByModel := make(map[string][]*types.MLNodeInfo, len(validated))
+		var droppedNodes []string
+		for _, nodeId := range sortedKeys(owner) {
+			o := owner[nodeId]
+			if !slices.Contains(supportedModelsByNode[nodeId], o.modelId) {
+				droppedNodes = append(droppedNodes, nodeId+"@"+o.modelId)
+				ma.LogWarn("Dropping PoC-validated ML node: hardware does not declare its model", types.Allocation,
+					"flow_context", FlowContext, "step", "hardware_filter_drop",
+					"participant_index", p.Index, "node_id", nodeId,
+					"validated_model", o.modelId, "poc_weight", o.node.PocWeight,
+					"declared_models", supportedModelsByNode[nodeId])
+				continue
+			}
+			o.node.TimeslotAllocation = []bool{true, false} // [PRE_POC_SLOT, POC_SLOT]
+			keptByModel[o.modelId] = append(keptByModel[o.modelId], o.node)
+		}
+
+		var supportedModels []string
+		var newMLNodeArrays []*types.ModelMLNodes
 		for _, model := range governanceModels {
-			ma.LogInfo("Attempting to assign ML node for model", types.Allocation, "flow_context", FlowContext, "step", "model_assignment_loop", "participant_index", p.Index, "model_id", model.Id)
-			var modelMLNodes []*types.MLNodeInfo
-
-			for _, mlNode := range originalMLNodes {
-				if assignedMLNodes[mlNode.NodeId] {
-					ma.LogInfo("Skipping already assigned ML node", types.Allocation, "flow_context", FlowContext, "step", "node_already_assigned", "participant_index", p.Index, "model_id", model.Id, "node_id", mlNode.NodeId)
-					continue
-				}
-
-				if slices.Contains(supportedModelsByNode[mlNode.NodeId], model.Id) {
-					ma.LogInfo("Found supporting and unassigned ML node for model", types.Allocation, "flow_context", FlowContext, "step", "assign_node_to_model", "participant_index", p.Index, "model_id", model.Id, "node_id", mlNode.NodeId)
-					modelMLNodes = append(modelMLNodes, mlNode)
-					assignedMLNodes[mlNode.NodeId] = true
-				}
+			modelMLNodes := keptByModel[model.Id]
+			if len(modelMLNodes) == 0 {
+				ma.LogInfo("No validated ML nodes for this model", types.Allocation, "flow_context", FlowContext, "step", "no_validated_nodes", "participant_index", p.Index, "model_id", model.Id)
+				continue
 			}
-
-			if len(modelMLNodes) > 0 {
-				supportedModels = append(supportedModels, model.Id)
-				newMLNodeArrays = append(newMLNodeArrays, &types.ModelMLNodes{MlNodes: modelMLNodes})
-				ma.LogInfo("Assigned ML nodes to model", types.Allocation, "flow_context", FlowContext, "step", "model_assignment_complete", "participant_index", p.Index, "model_id", model.Id, "assigned_nodes", modelMLNodes)
-			} else {
-				ma.LogInfo("No available ML nodes support this model", types.Allocation, "flow_context", FlowContext, "step", "no_supporting_nodes", "participant_index", p.Index, "model_id", model.Id)
-			}
+			supportedModels = append(supportedModels, model.Id)
+			newMLNodeArrays = append(newMLNodeArrays, &types.ModelMLNodes{MlNodes: modelMLNodes})
+			ma.LogInfo("Assigned ML nodes to model", types.Allocation, "flow_context", FlowContext, "step", "model_assignment_complete", "participant_index", p.Index, "model_id", model.Id, "assigned_nodes", modelMLNodes)
 		}
 
-		var unassignedMLNodes []*types.MLNodeInfo
-		for _, mlNode := range originalMLNodes {
-			if !assignedMLNodes[mlNode.NodeId] {
-				unassignedMLNodes = append(unassignedMLNodes, mlNode)
-			}
+		if len(droppedNodes) > 0 {
+			ma.LogWarn("Participant lost validated ML nodes to the hardware filter", types.Allocation,
+				"flow_context", FlowContext, "step", "hardware_filter_summary",
+				"participant_index", p.Index, "dropped", droppedNodes,
+				"remaining_models", supportedModels)
 		}
-		ma.LogInfo("Unassigned MLNodes", types.Allocation, "flow_context", FlowContext, "step", "unassigned_nodes", "participant_index", p.Index, "unassigned_nodes", unassignedMLNodes)
 
 		p.MlNodes = newMLNodeArrays
 		p.Models = supportedModels

--- a/inference-chain/x/inference/module/model_assignment_binding_test.go
+++ b/inference-chain/x/inference/module/model_assignment_binding_test.go
@@ -1,0 +1,406 @@
+package inference
+
+import (
+	"context"
+	"testing"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	bindingModelLarge = "Qwen/QwQ-32B"
+	bindingModelSmall = "Qwen/Qwen2.5-7B-Instruct"
+)
+
+func bindingGovernanceModels() []types.Model {
+	return []types.Model{
+		{ProposedBy: "genesis", Id: bindingModelLarge, VRam: 32, ThroughputPerNonce: 1000},
+		{ProposedBy: "genesis", Id: bindingModelSmall, VRam: 16, ThroughputPerNonce: 10000},
+	}
+}
+
+func TestSetModelsForParticipants_HardwareCannotRelabelValidatedModel(t *testing.T) {
+	ctx := context.Background()
+	participantAddress := "gonka1relabelparticipant0000000000000000000000"
+
+	mockKeeper := &mockKeeperForModelAssigner{
+		governanceModels: bindingGovernanceModels(),
+		hardwareNodes: map[string]*types.HardwareNodes{
+			participantAddress: {
+				Participant: participantAddress,
+				HardwareNodes: []*types.HardwareNode{
+					{LocalId: "node-1", Models: []string{bindingModelLarge, bindingModelSmall}},
+				},
+			},
+		},
+	}
+
+	participants := []*types.ActiveParticipant{
+		{
+			Index:  participantAddress,
+			Models: []string{bindingModelSmall},
+			MlNodes: []*types.ModelMLNodes{
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "node-1", PocWeight: 100}}},
+			},
+		},
+	}
+
+	NewModelAssigner(mockKeeper, mockLogger{}).setModelsForParticipants(ctx, participants, types.Epoch{Index: 1})
+
+	p := participants[0]
+	require.Equal(t, []string{bindingModelSmall}, p.Models,
+		"weight must stay in the model that was actually proved, even though the node declares the larger model first")
+	require.Len(t, p.MlNodes, 1)
+	require.Len(t, p.MlNodes[0].MlNodes, 1)
+	require.Equal(t, "node-1", p.MlNodes[0].MlNodes[0].NodeId)
+	require.Equal(t, int64(100), p.MlNodes[0].MlNodes[0].PocWeight)
+	require.Equal(t, []bool{true, false}, p.MlNodes[0].MlNodes[0].TimeslotAllocation)
+}
+
+func TestSetModelsForParticipants_HardwareVetoDropsNodeInsteadOfMoving(t *testing.T) {
+	ctx := context.Background()
+	participantAddress := "gonka1vetoparticipant000000000000000000000000000"
+
+	mockKeeper := &mockKeeperForModelAssigner{
+		governanceModels: bindingGovernanceModels(),
+		hardwareNodes: map[string]*types.HardwareNodes{
+			participantAddress: {
+				Participant: participantAddress,
+				HardwareNodes: []*types.HardwareNode{
+					{LocalId: "node-1", Models: []string{bindingModelLarge}},
+				},
+			},
+		},
+	}
+
+	participants := []*types.ActiveParticipant{
+		{
+			Index:  participantAddress,
+			Models: []string{bindingModelSmall},
+			MlNodes: []*types.ModelMLNodes{
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "node-1", PocWeight: 100}}},
+			},
+		},
+	}
+
+	NewModelAssigner(mockKeeper, mockLogger{}).setModelsForParticipants(ctx, participants, types.Epoch{Index: 1})
+
+	p := participants[0]
+	require.Empty(t, p.Models, "node no longer declares the model it proved, so nothing survives")
+	require.Empty(t, p.MlNodes)
+}
+
+func TestSetModelsForParticipants_NodeMissingFromHardwareIsDropped(t *testing.T) {
+	ctx := context.Background()
+	participantAddress := "gonka1missingnodeparticipant00000000000000000"
+
+	mockKeeper := &mockKeeperForModelAssigner{
+		governanceModels: bindingGovernanceModels(),
+		hardwareNodes: map[string]*types.HardwareNodes{
+			participantAddress: {
+				Participant: participantAddress,
+				HardwareNodes: []*types.HardwareNode{
+					{LocalId: "node-1", Models: []string{bindingModelSmall}},
+				},
+			},
+		},
+	}
+
+	participants := []*types.ActiveParticipant{
+		{
+			Index:  participantAddress,
+			Models: []string{bindingModelSmall},
+			MlNodes: []*types.ModelMLNodes{
+				{MlNodes: []*types.MLNodeInfo{
+					{NodeId: "node-1", PocWeight: 100},
+					{NodeId: "ghost-node", PocWeight: 900},
+				}},
+			},
+		},
+	}
+
+	NewModelAssigner(mockKeeper, mockLogger{}).setModelsForParticipants(ctx, participants, types.Epoch{Index: 1})
+
+	p := participants[0]
+	require.Equal(t, []string{bindingModelSmall}, p.Models)
+	require.Len(t, p.MlNodes[0].MlNodes, 1)
+	require.Equal(t, "node-1", p.MlNodes[0].MlNodes[0].NodeId)
+}
+
+func TestSetModelsForParticipants_MultiModelKeepsPerNodeBinding(t *testing.T) {
+	ctx := context.Background()
+	participantAddress := "gonka1multimodelparticipant0000000000000000000"
+
+	mockKeeper := &mockKeeperForModelAssigner{
+		governanceModels: bindingGovernanceModels(),
+		hardwareNodes: map[string]*types.HardwareNodes{
+			participantAddress: {
+				Participant: participantAddress,
+				HardwareNodes: []*types.HardwareNode{
+					{LocalId: "node-large", Models: []string{bindingModelLarge, bindingModelSmall}},
+					{LocalId: "node-small", Models: []string{bindingModelLarge, bindingModelSmall}},
+				},
+			},
+		},
+	}
+
+	participants := []*types.ActiveParticipant{
+		{
+			Index:  participantAddress,
+			Models: []string{bindingModelLarge, bindingModelSmall},
+			MlNodes: []*types.ModelMLNodes{
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "node-large", PocWeight: 40}}},
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "node-small", PocWeight: 60}}},
+			},
+		},
+	}
+
+	NewModelAssigner(mockKeeper, mockLogger{}).setModelsForParticipants(ctx, participants, types.Epoch{Index: 1})
+
+	p := participants[0]
+	require.Equal(t, []string{bindingModelLarge, bindingModelSmall}, p.Models)
+	require.Len(t, p.MlNodes, 2)
+	require.Len(t, p.MlNodes[0].MlNodes, 1)
+	require.Equal(t, "node-large", p.MlNodes[0].MlNodes[0].NodeId)
+	require.Len(t, p.MlNodes[1].MlNodes, 1)
+	require.Equal(t, "node-small", p.MlNodes[1].MlNodes[0].NodeId)
+}
+
+func TestSetModelsForParticipants_ContestedNodeResolvesToOneModel(t *testing.T) {
+	ctx := context.Background()
+	participantAddress := "gonka1contestedparticipant000000000000000000000"
+
+	mockKeeper := &mockKeeperForModelAssigner{
+		governanceModels: bindingGovernanceModels(),
+		hardwareNodes: map[string]*types.HardwareNodes{
+			participantAddress: {
+				Participant: participantAddress,
+				HardwareNodes: []*types.HardwareNode{
+					{LocalId: "node-1", Models: []string{bindingModelLarge, bindingModelSmall}},
+				},
+			},
+		},
+	}
+
+	participants := []*types.ActiveParticipant{
+		{
+			Index:  participantAddress,
+			Models: []string{bindingModelLarge, bindingModelSmall},
+			MlNodes: []*types.ModelMLNodes{
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "node-1", PocWeight: 10}}},
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "node-1", PocWeight: 70}}},
+			},
+		},
+	}
+
+	NewModelAssigner(mockKeeper, mockLogger{}).setModelsForParticipants(ctx, participants, types.Epoch{Index: 1})
+
+	p := participants[0]
+	require.Equal(t, []string{bindingModelSmall}, p.Models, "higher-weight claim wins the node")
+	require.Len(t, p.MlNodes, 1)
+	require.Len(t, p.MlNodes[0].MlNodes, 1)
+	require.Equal(t, int64(70), p.MlNodes[0].MlNodes[0].PocWeight)
+}
+
+func TestSetModelsForParticipants_PreservedBindingSurvives(t *testing.T) {
+	ctx := context.Background()
+	participantAddress := "gonka1preservedparticipant000000000000000000000"
+
+	mockKeeper := &mockKeeperForModelAssigner{
+		governanceModels: bindingGovernanceModels(),
+		hardwareNodes: map[string]*types.HardwareNodes{
+			participantAddress: {
+				Participant: participantAddress,
+				HardwareNodes: []*types.HardwareNode{
+					{LocalId: "inference-node", Models: []string{bindingModelSmall}, Status: types.HardwareNodeStatus_INFERENCE},
+				},
+			},
+		},
+	}
+
+	participants := []*types.ActiveParticipant{
+		{
+			Index:  participantAddress,
+			Models: []string{bindingModelSmall},
+			MlNodes: []*types.ModelMLNodes{
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "inference-node", PocWeight: 55}}},
+			},
+		},
+	}
+
+	NewModelAssigner(mockKeeper, mockLogger{}).setModelsForParticipants(ctx, participants, types.Epoch{Index: 1})
+
+	p := participants[0]
+	require.Equal(t, []string{bindingModelSmall}, p.Models)
+	require.Len(t, p.MlNodes, 1)
+	require.Equal(t, int64(55), p.MlNodes[0].MlNodes[0].PocWeight)
+}
+
+func TestSetModelsForParticipants_RelabelDoesNotReachTargetSubgroup(t *testing.T) {
+	ctx := context.Background()
+	participantAddress := "gonka1subgroupparticipant0000000000000000000000"
+	epoch := types.Epoch{Index: 1}
+
+	mockKeeper := &mockKeeperForModelAssigner{
+		governanceModels: bindingGovernanceModels(),
+		hardwareNodes: map[string]*types.HardwareNodes{
+			participantAddress: {
+				Participant: participantAddress,
+				HardwareNodes: []*types.HardwareNode{
+					{LocalId: "node-1", Models: []string{bindingModelLarge, bindingModelSmall}},
+				},
+			},
+		},
+		perfSummaries: map[string]map[uint64]types.EpochPerformanceSummary{
+			participantAddress: {0: {ParticipantId: participantAddress, EpochIndex: 0, RewardedCoins: 1}},
+		},
+		params: &types.Params{
+			EpochParams: &types.EpochParams{
+				PocSlotAllocation: &types.Decimal{Value: 5, Exponent: -1},
+			},
+		},
+	}
+
+	participants := []*types.ActiveParticipant{
+		{
+			Index:  participantAddress,
+			Models: []string{bindingModelSmall},
+			MlNodes: []*types.ModelMLNodes{
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "node-1", PocWeight: 100}}},
+			},
+		},
+	}
+
+	assigner := NewModelAssigner(mockKeeper, mockLogger{})
+	assigner.setModelsForParticipants(ctx, participants, epoch)
+	mockKeeper.populateSubgroupsFromParticipants(epoch.Index, participants)
+
+	smallGroup, foundSmall := mockKeeper.GetEpochGroupData(ctx, epoch.Index, bindingModelSmall)
+	require.True(t, foundSmall, "participant belongs to the model it proved")
+	require.Len(t, smallGroup.ValidationWeights, 1)
+	require.Equal(t, participantAddress, smallGroup.ValidationWeights[0].MemberAddress)
+	require.Equal(t, int64(100), smallGroup.ValidationWeights[0].MlNodes[0].PocWeight)
+
+	largeGroup, foundLarge := mockKeeper.GetEpochGroupData(ctx, epoch.Index, bindingModelLarge)
+	require.False(t, foundLarge && len(largeGroup.ValidationWeights) > 0,
+		"participant must not appear in the subgroup of a model it never proved")
+
+	snapshot, err := assigner.SamplePreservedForEpisode(ctx, epoch, 777)
+	require.NoError(t, err)
+	for _, modelNodes := range snapshot.ModelPreservedNodes {
+		if modelNodes.ModelId != bindingModelLarge {
+			continue
+		}
+		for _, p := range modelNodes.Participants {
+			require.NotEqual(t, participantAddress, p.ParticipantId,
+				"relabeled weight must not be preserved into the target model")
+		}
+	}
+}
+
+func TestSetModelsForParticipants_RelabelDoesNotInflateConfirmationWeight(t *testing.T) {
+	coefficients := types.ConfirmationWeightCoefficients([]*types.ConfirmationWeightScale{
+		{ModelId: bindingModelSmall, WeightScaleFactor: types.DecimalFromFloat(1.0)},
+		{ModelId: bindingModelLarge, WeightScaleFactor: types.DecimalFromFloat(3.0)},
+	})
+
+	newParticipant := func(addr string) *types.ActiveParticipant {
+		return &types.ActiveParticipant{
+			Index:  addr,
+			Models: []string{bindingModelSmall},
+			MlNodes: []*types.ModelMLNodes{
+				{MlNodes: []*types.MLNodeInfo{{NodeId: "node-1", PocWeight: 100}}},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name             string
+		declaredModels   []string
+		expectedModels   []string
+		expectedConfWeig int64
+	}{
+		{
+			name:             "declares only the unproved model",
+			declaredModels:   []string{bindingModelLarge},
+			expectedModels:   nil,
+			expectedConfWeig: 0,
+		},
+		{
+			name:             "declares both models",
+			declaredModels:   []string{bindingModelLarge, bindingModelSmall},
+			expectedModels:   []string{bindingModelSmall},
+			expectedConfWeig: 100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			participantAddress := "gonka1confweightparticipant00000000000000000"
+
+			mockKeeper := &mockKeeperForModelAssigner{
+				governanceModels: bindingGovernanceModels(),
+				hardwareNodes: map[string]*types.HardwareNodes{
+					participantAddress: {
+						Participant:   participantAddress,
+						HardwareNodes: []*types.HardwareNode{{LocalId: "node-1", Models: tc.declaredModels}},
+					},
+				},
+			}
+
+			participants := []*types.ActiveParticipant{newParticipant(participantAddress)}
+			require.Equal(t, int64(100),
+				types.ConfirmationWeightOfParticipantWithCoefficients(participants[0], coefficients),
+				"confirmation weight before assignment")
+
+			NewModelAssigner(mockKeeper, mockLogger{}).setModelsForParticipants(ctx, participants, types.Epoch{Index: 1})
+
+			require.Equal(t, tc.expectedModels, participants[0].Models)
+			require.Equal(t, tc.expectedConfWeig,
+				types.ConfirmationWeightOfParticipantWithCoefficients(participants[0], coefficients),
+				"relabeling must not apply the target model's coefficient")
+		})
+	}
+}
+
+func TestValidatedModelNodes_IgnoresUnpairedModels(t *testing.T) {
+	p := &types.ActiveParticipant{
+		Models: []string{bindingModelLarge, bindingModelSmall, ""},
+		MlNodes: []*types.ModelMLNodes{
+			{MlNodes: []*types.MLNodeInfo{{NodeId: "a", PocWeight: 1}, {NodeId: "", PocWeight: 9}, nil}},
+		},
+	}
+
+	validated := validatedModelNodes(p)
+	require.Len(t, validated, 1)
+	require.Len(t, validated[bindingModelLarge], 1)
+	require.Equal(t, "a", validated[bindingModelLarge][0].NodeId)
+}
+
+func TestResolveNodeOwnerModel_PrefersHighestWeightAndReportsContested(t *testing.T) {
+	validated := map[string][]*types.MLNodeInfo{
+		bindingModelLarge: {{NodeId: "shared", PocWeight: 5}, {NodeId: "solo", PocWeight: 3}},
+		bindingModelSmall: {{NodeId: "shared", PocWeight: 50}},
+	}
+
+	owner, contested := resolveNodeOwnerModel(validated)
+
+	require.Equal(t, []string{"shared"}, contested)
+	require.Equal(t, bindingModelSmall, owner["shared"].modelId)
+	require.Equal(t, int64(50), owner["shared"].node.PocWeight)
+	require.Equal(t, bindingModelLarge, owner["solo"].modelId)
+}
+
+func TestResolveNodeOwnerModel_WithinModelDuplicateIsNotContested(t *testing.T) {
+	validated := map[string][]*types.MLNodeInfo{
+		bindingModelLarge: {{NodeId: "dup", PocWeight: 10}, {NodeId: "dup", PocWeight: 25}},
+	}
+
+	owner, contested := resolveNodeOwnerModel(validated)
+
+	require.Empty(t, contested)
+	require.Len(t, owner, 1)
+	require.Equal(t, int64(25), owner["dup"].node.PocWeight)
+}

--- a/inference-chain/x/inference/module/model_assignment_test.go
+++ b/inference-chain/x/inference/module/model_assignment_test.go
@@ -984,8 +984,12 @@ func TestSetModelsForParticipants_ManyNodesManyModels(t *testing.T) {
 					MlNodes: []*types.MLNodeInfo{
 						{NodeId: "mlnode1", PocWeight: 30},
 						{NodeId: "mlnode2", PocWeight: 25},
-						{NodeId: "mlnode3", PocWeight: 20},
 						{NodeId: "mlnode4", PocWeight: 25},
+					},
+				},
+				{
+					MlNodes: []*types.MLNodeInfo{
+						{NodeId: "mlnode3", PocWeight: 20},
 					},
 				},
 			},


### PR DESCRIPTION
`setModelsForParticipants` rebuilt each participant's `Models`/`MlNodes` from the self-reported hardware list, discarding the per-model binding produced by PoC validation and preserved-node carryover.

Hardware may now only constrain that binding, never extend it.