### PR TITLE
Fix: retry seed recording

### DIFF
--- a/common/queryapi/tests/dapi_contract_test.go
+++ b/common/queryapi/tests/dapi_contract_test.go
@@ -15,20 +15,20 @@ import (
 // public handlers for read-only query routes. edge-api must expose the same keys
 // so existing clients keep working when the proxy steers traffic to edge-api.
 var dapiTopLevelKeys = map[string][]string{
-	"GET /v1/status":                          {"status"},
-	"GET /v1/models":                          {"object", "data"},
-	"GET /v1/governance/models":               {"models"},
-	"GET /v1/governance/models-legacy":        {"model"},
-	"GET /v1/pricing":                         {"unit_of_compute_price", "models"},
-	"GET /v1/versions":                          {"api_version", "node_version", "timestamp"},
-	"GET /v1/epochs/{epoch}/participants":     {"active_participants", "addresses", "active_participants_bytes", "proof_ops", "validators", "block", "excluded_participants"},
+	"GET /v1/status":                      {"status"},
+	"GET /v1/models":                      {"object", "data"},
+	"GET /v1/governance/models":           {"models"},
+	"GET /v1/governance/models-legacy":    {"model"},
+	"GET /v1/pricing":                     {"unit_of_compute_price", "models"},
+	"GET /v1/versions":                    {"api_version", "node_version", "timestamp"},
+	"GET /v1/epochs/{epoch}/participants": {"active_participants", "addresses", "active_participants_bytes", "proof_ops", "validators", "block", "excluded_participants"},
 }
 
 func TestResponseTopLevelKeysMatchDapiContract(t *testing.T) {
 	cases := []struct {
-		name   string
-		keys   []string
-		run    func(t *testing.T) (int, []byte)
+		name string
+		keys []string
+		run  func(t *testing.T) (int, []byte)
 	}{
 		{
 			name: "GET /v1/status",

--- a/common/queryapi/tests/routes_contract_test.go
+++ b/common/queryapi/tests/routes_contract_test.go
@@ -18,7 +18,6 @@ import (
 // verify/debug paths.
 var canonicalPublicReadOnlyRoutes = []string{
 	"/v1/status",
-	"/v1/versions",
 	"/v1/models",
 	"/v1/governance/models",
 	"/v1/governance/models-legacy",
@@ -37,6 +36,10 @@ var canonicalPublicReadOnlyRoutes = []string{
 	"/v1/bridge/addresses",
 }
 
+var edgeAPIOnlyRoutes = []string{
+	"/v1/versions",
+}
+
 // canonicalOptionalReadOnlyRoutes are CPU-heavy verify/debug helpers served by
 // edge-api but private on the proxy unless EDGE_API_EXPOSE_OPTIONAL_ROUTES=true.
 var canonicalOptionalReadOnlyRoutes = []string{
@@ -46,14 +49,18 @@ var canonicalOptionalReadOnlyRoutes = []string{
 	"/v1/debug/verify/{height}",
 }
 
-// canonicalReadOnlyRoutes is the full edge-api OpenAPI surface (public + optional).
+// canonicalReadOnlyRoutes is the full edge-api OpenAPI surface.
 var canonicalReadOnlyRoutes = append(
-	append([]string(nil), canonicalPublicReadOnlyRoutes...),
+	append(
+		append([]string(nil), canonicalPublicReadOnlyRoutes...),
+		edgeAPIOnlyRoutes...,
+	),
 	canonicalOptionalReadOnlyRoutes...,
 )
 
 func TestReadOnlyRouteCount(t *testing.T) {
-	assert.Len(t, canonicalPublicReadOnlyRoutes, 18)
+	assert.Len(t, canonicalPublicReadOnlyRoutes, 17)
+	assert.Len(t, edgeAPIOnlyRoutes, 1)
 	assert.Len(t, canonicalOptionalReadOnlyRoutes, 4)
 	assert.Len(t, canonicalReadOnlyRoutes, 22)
 }
@@ -72,6 +79,17 @@ func TestProxyEntrypointPublicRoutesMatchCanonical(t *testing.T) {
 	want := append([]string(nil), canonicalPublicReadOnlyRoutes...)
 	sort.Strings(want)
 	assert.Equal(t, want, got)
+	assert.NotContains(t, got, "/v1/versions")
+}
+
+func TestProxyEntrypointSkipsVersionsOverride(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	path := filepath.Join(repoRoot, "proxy", "entrypoint.sh")
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `if [ "$route" = "/v1/versions" ]; then`)
 }
 
 func TestProxyEntrypointOptionalRoutesMatchCanonical(t *testing.T) {

--- a/common/queryapi/tests/status_test.go
+++ b/common/queryapi/tests/status_test.go
@@ -22,7 +22,9 @@ func TestGetStatus_Returns200(t *testing.T) {
 
 // -- GetVersions --
 
-type stubNodeInfoServer struct{ cmtservice.UnimplementedServiceServer }
+type stubNodeInfoServer struct {
+	cmtservice.UnimplementedServiceServer
+}
 
 func (s *stubNodeInfoServer) GetNodeInfo(_ context.Context, _ *cmtservice.GetNodeInfoRequest) (*cmtservice.GetNodeInfoResponse, error) {
 	return &cmtservice.GetNodeInfoResponse{
@@ -48,7 +50,9 @@ func TestGetVersions_Returns200(t *testing.T) {
 	assert.Contains(t, body, `"timestamp"`)
 }
 
-type errNodeInfoServer struct{ cmtservice.UnimplementedServiceServer }
+type errNodeInfoServer struct {
+	cmtservice.UnimplementedServiceServer
+}
 
 func (s *errNodeInfoServer) GetNodeInfo(_ context.Context, _ *cmtservice.GetNodeInfoRequest) (*cmtservice.GetNodeInfoResponse, error) {
 	return nil, status.Error(codes.Unavailable, "node down")

--- a/decentralized-api/Dockerfile
+++ b/decentralized-api/Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,id=go-build-cache3,target=/root/.cache/go-build \
 
 COPY decentralized-api/. .
 
-# ARG LDFLAGS
+ARG LDFLAGS
 RUN --mount=type=cache,id=go-build-cache3,target=/root/.cache/go-build \
     --mount=type=cache,id=go-mod-cache3,target=/go/pkg/mod \
     if [ "$BLST_PORTABLE" = "1" ]; then export CGO_CFLAGS="$CGO_CFLAGS -D__BLST_PORTABLE__"; fi; \

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -42,6 +42,7 @@ define DOCKER_BUILD
 	@echo "    	GOARCH: $(GOARCH)"
 	@$(DOCKER_BUILD_PREFIX) \
 		--platform $(PLATFORM) \
+		--build-arg LDFLAGS='$(ldflags)' \
 		--build-arg GOOS=$(GOOS) \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg BLST_PORTABLE=$(BLST_PORTABLE) \
@@ -58,6 +59,7 @@ define DOCKER_BUILD_UPGRADE
 	@echo "    	GOARCH: $(GOARCH)"
 	@$(DOCKER_BUILD_UPGRADE_PREFIX) \
 		--platform $(PLATFORM) \
+		--build-arg LDFLAGS='$(ldflags)' \
 		--build-arg GOOS=$(GOOS) \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg DEVSHARD_VERSION=$(DEVSHARD_VERSION) \

--- a/decentralized-api/build_metadata_test.go
+++ b/decentralized-api/build_metadata_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerBuildPassesVersionMetadata(t *testing.T) {
+	makefile, err := os.ReadFile("Makefile")
+	require.NoError(t, err)
+	require.Equal(t, 2, strings.Count(string(makefile), "\n\t\t--build-arg LDFLAGS='$(ldflags)' \\"))
+
+	dockerfile, err := os.ReadFile("Dockerfile")
+	require.NoError(t, err)
+	require.Contains(t, string(dockerfile), "\nARG LDFLAGS\n")
+	require.Contains(t, string(dockerfile), `-ldflags "$LDFLAGS"`)
+}

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -160,6 +162,7 @@ func (m *MockBrokerChainBridge) GetParams() (*types.QueryParamsResponse, error) 
 
 type MockRandomSeedManager struct {
 	mock.Mock
+	onGenerate func(epochIndex uint64)
 }
 
 func (m *MockRandomSeedManager) ChangeCurrentSeed() {
@@ -176,16 +179,28 @@ func (m *MockRandomSeedManager) RequestMoney(epochIndex uint64) {
 }
 
 func (m *MockRandomSeedManager) CreateNewSeed(epochIndex uint64) (*apiconfig.SeedInfo, error) {
-	m.Called()
-	return nil, nil
+	m.Called(epochIndex)
+	// Match the signature ListRandomSeeds returns after GenerateSeedInfo so
+	// confirmSeedLocally can succeed the same way production restore does.
+	return &apiconfig.SeedInfo{
+		Seed:       1,
+		EpochIndex: epochIndex,
+		Signature:  integrationTestSeedSignature,
+	}, nil
 }
 
 func (m *MockRandomSeedManager) GenerateSeedInfo(epochIndex uint64) {
 	m.Called(epochIndex)
+	if m.onGenerate != nil {
+		m.onGenerate(epochIndex)
+	}
 }
 
 type MockQueryClient struct {
 	mock.Mock
+	listRandomSeedsCalls atomic.Int64
+	mu                   sync.Mutex
+	submittedByEpoch     map[uint64]*types.RandomSeed
 }
 
 func (m *MockQueryClient) EpochInfo(ctx context.Context, req *types.QueryEpochInfoRequest, opts ...grpc.CallOption) (*types.QueryEpochInfoResponse, error) {
@@ -201,12 +216,34 @@ func (m *MockQueryClient) Params(ctx context.Context, req *types.QueryParamsRequ
 	return args.Get(0).(*types.QueryParamsResponse), args.Error(1)
 }
 
+const integrationTestSeedParticipant = "some-address"
+const integrationTestSeedSignature = "integration-test-seed-signature"
+
+// ListRandomSeeds is not testify-expectation based: ensureSeedSubmitted runs
+// asynchronously and can race ExpectedCalls = nil in setLatestEpoch.
+// After GenerateSeedInfo, the seed becomes visible here so later ensures take
+// the confirm path and stop resubmitting (same shape as production).
 func (m *MockQueryClient) ListRandomSeeds(ctx context.Context, req *types.QueryRandomSeedsRequest, opts ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error) {
-	args := m.Called(ctx, req)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+	m.listRandomSeedsCalls.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if seed, ok := m.submittedByEpoch[req.EpochIndex]; ok {
+		return &types.QueryRandomSeedsResponse{Seeds: []*types.RandomSeed{seed}}, nil
 	}
-	return args.Get(0).(*types.QueryRandomSeedsResponse), args.Error(1)
+	return &types.QueryRandomSeedsResponse{}, nil
+}
+
+func (m *MockQueryClient) markSeedSubmitted(epochIndex uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.submittedByEpoch == nil {
+		m.submittedByEpoch = make(map[uint64]*types.RandomSeed)
+	}
+	m.submittedByEpoch[epochIndex] = &types.RandomSeed{
+		Participant: integrationTestSeedParticipant,
+		EpochIndex:  epochIndex,
+		Signature:   integrationTestSeedSignature,
+	}
 }
 
 // Test setup helpers
@@ -227,7 +264,11 @@ func createIntegrationTestSetup(reconcilialtionConfig *MlNodeReconciliationConfi
 	os.Setenv("ENFORCED_MODEL_ID", "disabled")
 
 	mockQueryClient := &MockQueryClient{}
-	mockSeedManager := &MockRandomSeedManager{}
+	mockSeedManager := &MockRandomSeedManager{
+		onGenerate: func(epochIndex uint64) {
+			mockQueryClient.markSeedSubmitted(epochIndex)
+		},
+	}
 
 	phaseTracker := &chainphase.ChainPhaseTracker{}
 
@@ -324,7 +365,6 @@ func createIntegrationTestSetup(reconcilialtionConfig *MlNodeReconciliationConfi
 			ValidationParams: validationParams,
 		},
 	}, nil)
-	mockQueryClient.On("ListRandomSeeds", mock.Anything, mock.Anything).Return(&types.QueryRandomSeedsResponse{}, nil)
 
 	// Setup mock expectations for RandomSeedManager
 	mockSeedManager.On("ChangeCurrentSeed").Return()
@@ -418,7 +458,6 @@ func (setup *IntegrationTestSetup) setLatestEpoch(blockHeight int64, epoch types
 			},
 		},
 	}, nil)
-	setup.MockQueryClient.On("ListRandomSeeds", mock.Anything, mock.Anything).Return(&types.QueryRandomSeedsResponse{}, nil)
 }
 
 func (setup *IntegrationTestSetup) transitionChainStateToNextEpoch(blockHeight int64) {
@@ -456,7 +495,19 @@ func (setup *IntegrationTestSetup) simulateBlock(height int64) error {
 		Height: height,
 		Hash:   fmt.Sprintf("hash-%d", height),
 	}
-	return setup.Dispatcher.ProcessNewBlock(context.Background(), blockInfo)
+	err := setup.Dispatcher.ProcessNewBlock(context.Background(), blockInfo)
+	setup.waitForSeedEnsureIdle()
+	return err
+}
+
+func (setup *IntegrationTestSetup) waitForSeedEnsureIdle() {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !setup.Dispatcher.seedEnsureInFlight.Load() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 func (setup *IntegrationTestSetup) getNodeClient(nodeId string, port int) *mlnodeclient.MockClient {
@@ -663,6 +714,8 @@ func TestRegularPocScenario(t *testing.T) {
 		assertNodeClient(t, expected, node2Client)
 		i++
 	}
+	require.GreaterOrEqual(t, setup.MockQueryClient.listRandomSeedsCalls.Load(), int64(1),
+		"seed ensure should query ListRandomSeeds at least once during PoC window")
 
 	pocValStart := i
 	pocValEnd := pocValStart + setup.EpochParams.PocValidationDelay + setup.EpochParams.PocValidationDuration

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -201,6 +201,14 @@ func (m *MockQueryClient) Params(ctx context.Context, req *types.QueryParamsRequ
 	return args.Get(0).(*types.QueryParamsResponse), args.Error(1)
 }
 
+func (m *MockQueryClient) ListRandomSeeds(ctx context.Context, req *types.QueryRandomSeedsRequest, opts ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.QueryRandomSeedsResponse), args.Error(1)
+}
+
 // Test setup helpers
 
 type IntegrationTestSetup struct {
@@ -316,6 +324,7 @@ func createIntegrationTestSetup(reconcilialtionConfig *MlNodeReconciliationConfi
 			ValidationParams: validationParams,
 		},
 	}, nil)
+	mockQueryClient.On("ListRandomSeeds", mock.Anything, mock.Anything).Return(&types.QueryRandomSeedsResponse{}, nil)
 
 	// Setup mock expectations for RandomSeedManager
 	mockSeedManager.On("ChangeCurrentSeed").Return()
@@ -409,6 +418,7 @@ func (setup *IntegrationTestSetup) setLatestEpoch(blockHeight int64, epoch types
 			},
 		},
 	}, nil)
+	setup.MockQueryClient.On("ListRandomSeeds", mock.Anything, mock.Anything).Return(&types.QueryRandomSeedsResponse{}, nil)
 }
 
 func (setup *IntegrationTestSetup) transitionChainStateToNextEpoch(blockHeight int64) {

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -604,8 +604,9 @@ func (d *OnNewBlockDispatcher) ensureSeedSubmitted(
 			"blockHeight", blockHeight,
 			"error", err)
 	} else if found {
-		d.confirmSeedLocally(epochIndex, participantAddress, onChainSeed)
-		d.seedConfirmedEpoch = epochIndex
+		if d.confirmSeedLocally(epochIndex, participantAddress, onChainSeed) {
+			d.seedConfirmedEpoch = epochIndex
+		}
 		return
 	}
 
@@ -640,17 +641,20 @@ func (d *OnNewBlockDispatcher) getParticipantSeed(
 	return nil, false, nil
 }
 
+// confirmSeedLocally returns true when we should stop further seed work for this
+// epoch: local state matches/restored, or an intentional signature mismatch.
+// Transient restore failures return false so a later block can retry restore.
 func (d *OnNewBlockDispatcher) confirmSeedLocally(
 	epochIndex uint64,
 	participantAddress string,
 	onChainSeed *types.RandomSeed,
-) {
+) bool {
 	localSeed := d.configManager.GetUpcomingSeed()
 	if localSeed.EpochIndex == epochIndex && localSeed.Signature == onChainSeed.Signature {
 		logging.Info("Confirmed upcoming epoch seed on chain", types.Claims,
 			"epochIndex", epochIndex,
 			"participant", participantAddress)
-		return
+		return true
 	}
 
 	generatedSeed, err := d.randomSeedManager.CreateNewSeed(epochIndex)
@@ -659,24 +663,25 @@ func (d *OnNewBlockDispatcher) confirmSeedLocally(
 			"epochIndex", epochIndex,
 			"participant", participantAddress,
 			"error", err)
-		return
+		return false
 	}
 	if generatedSeed.Signature != onChainSeed.Signature {
 		logging.Error("On-chain seed signature does not match local deterministic seed; refusing to overwrite", types.Claims,
 			"epochIndex", epochIndex,
 			"participant", participantAddress)
-		return
+		return true
 	}
 	if err := d.configManager.SetUpcomingSeed(*generatedSeed); err != nil {
 		logging.Error("Failed to restore confirmed upcoming seed locally", types.Claims,
 			"epochIndex", epochIndex,
 			"participant", participantAddress,
 			"error", err)
-		return
+		return false
 	}
 	logging.Info("Confirmed upcoming epoch seed on chain", types.Claims,
 		"epochIndex", epochIndex,
 		"participant", participantAddress)
+	return true
 }
 
 // shouldTriggerReconciliation determines if reconciliation should be triggered

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -84,7 +84,6 @@ type OnNewBlockDispatcher struct {
 	lastThresholdEpoch   uint64 // last epoch the per-model thresholds were refreshed for
 
 	seedSubmissionMu   sync.Mutex
-	seedAttemptEpoch   uint64
 	seedAttemptHeight  int64
 	seedConfirmedEpoch uint64
 }
@@ -417,8 +416,6 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(ctx context.Context, epoch
 		d.ensureSeedSubmitted(ctx, epochContext, blockHeight, d.nodeBroker.GetParticipantAddress())
 	}
 
-	// Keep the start block dedicated to PoC startup. Seed repair on later blocks
-	// must not return early because stage transitions can share those heights.
 	if epochContext.IsStartOfPocStage(blockHeight) {
 		return
 	}
@@ -591,8 +588,8 @@ func (d *OnNewBlockDispatcher) ensureSeedSubmitted(
 	if d.seedConfirmedEpoch >= epochIndex {
 		return
 	}
-	// Skip chain queries during retry cooldown; confirmation can wait a block.
-	if d.seedAttemptEpoch == epochIndex && blockHeight-d.seedAttemptHeight < seedRetryCooldownBlocks {
+	// Avoid resubmitting while the previous async SubmitSeed may still be in flight.
+	if d.seedAttemptHeight > 0 && blockHeight-d.seedAttemptHeight < seedRetryCooldownBlocks {
 		return
 	}
 
@@ -614,10 +611,8 @@ func (d *OnNewBlockDispatcher) ensureSeedSubmitted(
 		"epochIndex", epochIndex,
 		"participant", participantAddress,
 		"blockHeight", blockHeight,
-		"retry", d.seedAttemptEpoch == epochIndex)
-	d.seedAttemptEpoch = epochIndex
+		"retry", d.seedAttemptHeight > 0)
 	d.seedAttemptHeight = blockHeight
-	// Sign + NATS enqueue only; durability comes from later chain confirmation.
 	d.randomSeedManager.GenerateSeedInfo(epochIndex)
 }
 
@@ -641,9 +636,8 @@ func (d *OnNewBlockDispatcher) getParticipantSeed(
 	return nil, false, nil
 }
 
-// confirmSeedLocally returns true when we should stop further seed work for this
-// epoch: local state matches/restored, or an intentional signature mismatch.
-// Transient restore failures return false so a later block can retry restore.
+// confirmSeedLocally syncs local upcoming seed with an on-chain seed.
+// Returns false only on transient restore failure so the next block can retry.
 func (d *OnNewBlockDispatcher) confirmSeedLocally(
 	epochIndex uint64,
 	participantAddress string,

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"decentralized-api/apiconfig"
@@ -29,6 +30,7 @@ import (
 type ChainStateClient interface {
 	EpochInfo(ctx context.Context, req *types.QueryEpochInfoRequest, opts ...grpc.CallOption) (*types.QueryEpochInfoResponse, error)
 	Params(ctx context.Context, req *types.QueryParamsRequest, opts ...grpc.CallOption) (*types.QueryParamsResponse, error)
+	ListRandomSeeds(ctx context.Context, req *types.QueryRandomSeedsRequest, opts ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error)
 }
 
 // StatusFunc defines the function signature for getting node sync status
@@ -80,7 +82,14 @@ type OnNewBlockDispatcher struct {
 	configManager        *apiconfig.ConfigManager
 	epochGroupDataCache  *internal.EpochGroupDataCache
 	lastThresholdEpoch   uint64 // last epoch the per-model thresholds were refreshed for
+
+	seedSubmissionMu   sync.Mutex
+	seedAttemptEpoch   uint64
+	seedAttemptHeight  int64
+	seedConfirmedEpoch uint64
 }
+
+const seedRetryCooldownBlocks int64 = 2
 
 // StatusResponse matches the structure expected by getStatus function
 type StatusResponse struct {
@@ -303,7 +312,7 @@ func (d *OnNewBlockDispatcher) ProcessNewBlock(ctx context.Context, blockInfo ch
 	}
 
 	// 3. Check for phase transitions and stage events
-	d.handlePhaseTransitions(*epochState)
+	d.handlePhaseTransitions(ctx, *epochState)
 
 	// 4. Check if reconciliation should be triggered
 	if d.shouldTriggerReconciliation(*epochState) {
@@ -385,7 +394,7 @@ func (d *OnNewBlockDispatcher) refreshModelValidationThresholds(epoch uint64) {
 	d.lastThresholdEpoch = epoch
 }
 
-func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.EpochState) {
+func (d *OnNewBlockDispatcher) handlePhaseTransitions(ctx context.Context, epochState chainphase.EpochState) {
 	//To work for tests
 	if d.nodeBroker == nil {
 		return
@@ -404,10 +413,13 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 		logging.Warn("Failed to refresh preserved membership cache; continuing with cached snapshot", types.Stages, "error", err)
 	}
 
-	// Check for PoC start for the next epoch. This is the most important transition.
+	if d.isSeedSubmissionWindow(epochContext, blockHeight) {
+		d.ensureSeedSubmitted(ctx, epochContext, blockHeight, d.nodeBroker.GetParticipantAddress())
+	}
+
+	// Keep the start block dedicated to PoC startup. Seed repair on later blocks
+	// must not return early because stage transitions can share those heights.
 	if epochContext.IsStartOfPocStage(blockHeight) {
-		logging.Info("DapiStage:IsStartOfPocStage: generating and submitting PoC seed for upcoming epoch", types.Stages, "blockHeight", blockHeight, "blockHash", blockHash, "epochIndex", epochContext.EpochIndex)
-		d.randomSeedManager.GenerateSeedInfo(epochContext.EpochIndex)
 		return
 	}
 
@@ -553,6 +565,118 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 			}
 		}
 	}
+}
+
+func (d *OnNewBlockDispatcher) isSeedSubmissionWindow(epochContext types.EpochContext, blockHeight int64) bool {
+	return epochContext.EpochIndex > 0 &&
+		blockHeight >= epochContext.StartOfPoC() &&
+		blockHeight < epochContext.EndOfPoCValidation()
+}
+
+func (d *OnNewBlockDispatcher) ensureSeedSubmitted(
+	ctx context.Context,
+	epochContext types.EpochContext,
+	blockHeight int64,
+	participantAddress string,
+) {
+	if d.queryClient == nil || d.randomSeedManager == nil || d.configManager == nil || participantAddress == "" {
+		return
+	}
+
+	epochIndex := epochContext.EpochIndex
+
+	d.seedSubmissionMu.Lock()
+	defer d.seedSubmissionMu.Unlock()
+
+	if d.seedConfirmedEpoch >= epochIndex {
+		return
+	}
+	// Skip chain queries during retry cooldown; confirmation can wait a block.
+	if d.seedAttemptEpoch == epochIndex && blockHeight-d.seedAttemptHeight < seedRetryCooldownBlocks {
+		return
+	}
+
+	onChainSeed, found, err := d.getParticipantSeed(ctx, epochIndex, participantAddress)
+	if err != nil {
+		logging.Warn("Failed to verify upcoming epoch seed on chain", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress,
+			"blockHeight", blockHeight,
+			"error", err)
+	} else if found {
+		d.confirmSeedLocally(epochIndex, participantAddress, onChainSeed)
+		d.seedConfirmedEpoch = epochIndex
+		return
+	}
+
+	logging.Info("Ensuring PoC seed is submitted for upcoming epoch", types.Claims,
+		"epochIndex", epochIndex,
+		"participant", participantAddress,
+		"blockHeight", blockHeight,
+		"retry", d.seedAttemptEpoch == epochIndex)
+	d.seedAttemptEpoch = epochIndex
+	d.seedAttemptHeight = blockHeight
+	// Sign + NATS enqueue only; durability comes from later chain confirmation.
+	d.randomSeedManager.GenerateSeedInfo(epochIndex)
+}
+
+func (d *OnNewBlockDispatcher) getParticipantSeed(
+	ctx context.Context,
+	epochIndex uint64,
+	participantAddress string,
+) (*types.RandomSeed, bool, error) {
+	response, err := d.queryClient.ListRandomSeeds(ctx, &types.QueryRandomSeedsRequest{EpochIndex: epochIndex})
+	if err != nil {
+		return nil, false, err
+	}
+	if response == nil {
+		return nil, false, errors.New("random seeds response is nil")
+	}
+	for _, randomSeed := range response.Seeds {
+		if randomSeed != nil && randomSeed.Participant == participantAddress {
+			return randomSeed, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func (d *OnNewBlockDispatcher) confirmSeedLocally(
+	epochIndex uint64,
+	participantAddress string,
+	onChainSeed *types.RandomSeed,
+) {
+	localSeed := d.configManager.GetUpcomingSeed()
+	if localSeed.EpochIndex == epochIndex && localSeed.Signature == onChainSeed.Signature {
+		logging.Info("Confirmed upcoming epoch seed on chain", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress)
+		return
+	}
+
+	generatedSeed, err := d.randomSeedManager.CreateNewSeed(epochIndex)
+	if err != nil || generatedSeed == nil {
+		logging.Error("On-chain seed exists but local seed could not be restored", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress,
+			"error", err)
+		return
+	}
+	if generatedSeed.Signature != onChainSeed.Signature {
+		logging.Error("On-chain seed signature does not match local deterministic seed; refusing to overwrite", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress)
+		return
+	}
+	if err := d.configManager.SetUpcomingSeed(*generatedSeed); err != nil {
+		logging.Error("Failed to restore confirmed upcoming seed locally", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress,
+			"error", err)
+		return
+	}
+	logging.Info("Confirmed upcoming epoch seed on chain", types.Claims,
+		"epochIndex", epochIndex,
+		"participant", participantAddress)
 }
 
 // shouldTriggerReconciliation determines if reconciliation should be triggered

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"decentralized-api/apiconfig"
@@ -86,6 +87,7 @@ type OnNewBlockDispatcher struct {
 	seedSubmissionMu   sync.Mutex
 	seedAttemptHeight  int64
 	seedConfirmedEpoch uint64
+	seedEnsureInFlight atomic.Bool
 }
 
 const seedRetryCooldownBlocks int64 = 2
@@ -413,7 +415,20 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(ctx context.Context, epoch
 	}
 
 	if d.isSeedSubmissionWindow(epochContext, blockHeight) {
-		d.ensureSeedSubmitted(ctx, epochContext, blockHeight, d.nodeBroker.GetParticipantAddress())
+		participantAddress := d.nodeBroker.GetParticipantAddress()
+		// Best-effort across the PoC window, not a height-exact stage flip.
+		// Run async so ListRandomSeeds / GenerateSeedInfo cannot delay the
+		// QueueMessage transitions below (same pattern as RequestMoney).
+		// At most one ensure goroutine at a time — avoid per-block spawn pile-up.
+		if d.seedEnsureInFlight.CompareAndSwap(false, true) {
+			go func(epochContext types.EpochContext, blockHeight int64, participantAddress string) {
+				defer d.seedEnsureInFlight.Store(false)
+				// Bound the query/sign path so a hung RPC cannot pin inFlight forever.
+				seedCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				d.ensureSeedSubmitted(seedCtx, epochContext, blockHeight, participantAddress)
+			}(epochContext, blockHeight, participantAddress)
+		}
 	}
 
 	if epochContext.IsStartOfPocStage(blockHeight) {

--- a/decentralized-api/internal/event_listener/new_block_dispatcher_runtime_cache_test.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher_runtime_cache_test.go
@@ -35,6 +35,14 @@ func (m *mockParamsQueryClient) Params(ctx context.Context, req *types.QueryPara
 	return args.Get(0).(*types.QueryParamsResponse), args.Error(1)
 }
 
+func (m *mockParamsQueryClient) ListRandomSeeds(ctx context.Context, req *types.QueryRandomSeedsRequest, opts ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.QueryRandomSeedsResponse), args.Error(1)
+}
+
 func newRuntimeCacheTestDispatcher(t *testing.T, qc *mockParamsQueryClient) (*OnNewBlockDispatcher, *apiconfig.ConfigManager) {
 	t.Helper()
 

--- a/decentralized-api/internal/event_listener/seed_submission_test.go
+++ b/decentralized-api/internal/event_listener/seed_submission_test.go
@@ -1,0 +1,247 @@
+package event_listener
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"decentralized-api/apiconfig"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+const seedTestParticipant = "gonka1seedtestparticipant"
+
+type seedQueryResult struct {
+	response *types.QueryRandomSeedsResponse
+	err      error
+}
+
+type seedQueryClient struct {
+	mu      sync.Mutex
+	results []seedQueryResult
+	calls   int
+}
+
+func (q *seedQueryClient) EpochInfo(context.Context, *types.QueryEpochInfoRequest, ...grpc.CallOption) (*types.QueryEpochInfoResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (q *seedQueryClient) Params(context.Context, *types.QueryParamsRequest, ...grpc.CallOption) (*types.QueryParamsResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (q *seedQueryClient) ListRandomSeeds(context.Context, *types.QueryRandomSeedsRequest, ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.calls++
+	if len(q.results) == 0 {
+		return &types.QueryRandomSeedsResponse{}, nil
+	}
+	index := q.calls - 1
+	if index >= len(q.results) {
+		index = len(q.results) - 1
+	}
+	return q.results[index].response, q.results[index].err
+}
+
+type recordingSeedManager struct {
+	mu          sync.Mutex
+	config      *apiconfig.ConfigManager
+	generated   []uint64
+	createdSeed apiconfig.SeedInfo
+	createErr   error
+}
+
+func (m *recordingSeedManager) GenerateSeedInfo(epochIndex uint64) {
+	m.mu.Lock()
+	m.generated = append(m.generated, epochIndex)
+	m.mu.Unlock()
+
+	seed := m.createdSeed
+	seed.EpochIndex = epochIndex
+	_ = m.config.SetUpcomingSeed(seed)
+}
+
+func (m *recordingSeedManager) GetSeedForEpoch(uint64) apiconfig.SeedInfo {
+	return apiconfig.SeedInfo{}
+}
+
+func (m *recordingSeedManager) CreateNewSeed(epochIndex uint64) (*apiconfig.SeedInfo, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	seed := m.createdSeed
+	seed.EpochIndex = epochIndex
+	return &seed, nil
+}
+
+func (m *recordingSeedManager) ChangeCurrentSeed() {}
+
+func (m *recordingSeedManager) RequestMoney(uint64) {}
+
+func (m *recordingSeedManager) generatedCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.generated)
+}
+
+func seedTestEpoch() types.EpochContext {
+	return types.EpochContext{
+		EpochIndex:          2,
+		PocStartBlockHeight: 100,
+		EpochParams: types.EpochParams{
+			PocStageDuration:      20,
+			PocValidationDelay:    2,
+			PocValidationDuration: 10,
+		},
+	}
+}
+
+func newSeedTestDispatcher(results ...seedQueryResult) (*OnNewBlockDispatcher, *recordingSeedManager, *apiconfig.ConfigManager) {
+	config := &apiconfig.ConfigManager{}
+	manager := &recordingSeedManager{
+		config: config,
+		createdSeed: apiconfig.SeedInfo{
+			Seed:      42,
+			Signature: "deterministic-signature",
+		},
+	}
+	return &OnNewBlockDispatcher{
+		queryClient:       &seedQueryClient{results: results},
+		randomSeedManager: manager,
+		configManager:     config,
+	}, manager, config
+}
+
+func chainSeed(signature string) seedQueryResult {
+	return seedQueryResult{response: &types.QueryRandomSeedsResponse{
+		Seeds: []*types.RandomSeed{{
+			Participant: seedTestParticipant,
+			EpochIndex:  2,
+			Signature:   signature,
+		}},
+	}}
+}
+
+func emptySeedQuery() seedQueryResult {
+	return seedQueryResult{response: &types.QueryRandomSeedsResponse{}}
+}
+
+func TestSeedSubmissionWindow(t *testing.T) {
+	dispatcher, _, _ := newSeedTestDispatcher()
+	epoch := seedTestEpoch()
+
+	require.True(t, dispatcher.isSeedSubmissionWindow(epoch, 100))
+	require.True(t, dispatcher.isSeedSubmissionWindow(epoch, 131))
+	require.False(t, dispatcher.isSeedSubmissionWindow(epoch, 99))
+	require.False(t, dispatcher.isSeedSubmissionWindow(epoch, 132))
+	require.False(t, dispatcher.isSeedSubmissionWindow(types.EpochContext{}, 0))
+}
+
+func TestEnsureSeedSubmittedRecoversAfterBoundaryLag(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(emptySeedQuery())
+	oldEpoch := types.EpochContext{
+		EpochIndex:          1,
+		PocStartBlockHeight: 0,
+		EpochParams:         seedTestEpoch().EpochParams,
+	}
+
+	require.False(t, dispatcher.isSeedSubmissionWindow(oldEpoch, 100))
+	require.True(t, dispatcher.isSeedSubmissionWindow(seedTestEpoch(), 101))
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 101, seedTestParticipant)
+	require.Equal(t, 1, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedConfirmsAfterVisibilityDelay(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(
+		emptySeedQuery(),
+		chainSeed("deterministic-signature"),
+	)
+	epoch := seedTestEpoch()
+
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 100, seedTestParticipant)
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 101, seedTestParticipant) // cooldown: no query
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 102, seedTestParticipant)
+
+	require.Equal(t, 1, manager.generatedCount())
+	require.Equal(t, uint64(2), dispatcher.seedConfirmedEpoch)
+}
+
+func TestEnsureSeedSubmittedRetriesAfterCooldown(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(emptySeedQuery())
+	epoch := seedTestEpoch()
+
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 100, seedTestParticipant)
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 101, seedTestParticipant)
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 102, seedTestParticipant)
+
+	require.Equal(t, 2, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedRepairsPersistedButUnconfirmedSeed(t *testing.T) {
+	dispatcher, manager, config := newSeedTestDispatcher(emptySeedQuery())
+	require.NoError(t, config.SetUpcomingSeed(apiconfig.SeedInfo{
+		Seed:       42,
+		EpochIndex: 2,
+		Signature:  "deterministic-signature",
+	}))
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 101, seedTestParticipant)
+
+	require.Equal(t, 1, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedRestoresMissingLocalSeed(t *testing.T) {
+	dispatcher, manager, config := newSeedTestDispatcher(chainSeed("deterministic-signature"))
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 102, seedTestParticipant)
+
+	require.Equal(t, 0, manager.generatedCount())
+	require.Equal(t, uint64(2), config.GetUpcomingSeed().EpochIndex)
+	require.Equal(t, "deterministic-signature", config.GetUpcomingSeed().Signature)
+}
+
+func TestEnsureSeedSubmittedDoesNotOverwriteSignatureMismatch(t *testing.T) {
+	dispatcher, manager, config := newSeedTestDispatcher(chainSeed("different-signature"))
+	require.NoError(t, config.SetUpcomingSeed(apiconfig.SeedInfo{
+		Seed:       42,
+		EpochIndex: 2,
+		Signature:  "deterministic-signature",
+	}))
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 102, seedTestParticipant)
+
+	require.Equal(t, 0, manager.generatedCount())
+	require.Equal(t, "deterministic-signature", config.GetUpcomingSeed().Signature)
+	require.Equal(t, uint64(2), dispatcher.seedConfirmedEpoch)
+}
+
+func TestEnsureSeedSubmittedFailsOpenOnQueryError(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(seedQueryResult{err: errors.New("query unavailable")})
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 100, seedTestParticipant)
+
+	require.Equal(t, 1, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedSerializesDuplicateEvents(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(emptySeedQuery())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 100, seedTestParticipant)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, manager.generatedCount())
+}

--- a/decentralized-api/internal/event_listener/seed_submission_test.go
+++ b/decentralized-api/internal/event_listener/seed_submission_test.go
@@ -222,6 +222,25 @@ func TestEnsureSeedSubmittedDoesNotOverwriteSignatureMismatch(t *testing.T) {
 	require.Equal(t, uint64(2), dispatcher.seedConfirmedEpoch)
 }
 
+func TestEnsureSeedSubmittedRetriesLocalRestoreAfterFailure(t *testing.T) {
+	dispatcher, manager, config := newSeedTestDispatcher(
+		chainSeed("deterministic-signature"),
+		chainSeed("deterministic-signature"),
+	)
+	manager.createErr = errors.New("signer unavailable")
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 100, seedTestParticipant)
+	require.Equal(t, uint64(0), dispatcher.seedConfirmedEpoch)
+	require.Equal(t, uint64(0), config.GetUpcomingSeed().EpochIndex)
+
+	manager.createErr = nil
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 102, seedTestParticipant)
+
+	require.Equal(t, uint64(2), dispatcher.seedConfirmedEpoch)
+	require.Equal(t, "deterministic-signature", config.GetUpcomingSeed().Signature)
+	require.Equal(t, 0, manager.generatedCount())
+}
+
 func TestEnsureSeedSubmittedFailsOpenOnQueryError(t *testing.T) {
 	dispatcher, manager, _ := newSeedTestDispatcher(seedQueryResult{err: errors.New("query unavailable")})
 

--- a/decentralized-api/internal/seed/seed_test.go
+++ b/decentralized-api/internal/seed/seed_test.go
@@ -1,0 +1,33 @@
+package seed
+
+import (
+	"testing"
+
+	"decentralized-api/apiconfig"
+	"decentralized-api/cosmosclient"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/stretchr/testify/require"
+)
+
+type deterministicSeedSigner struct {
+	cosmosclient.MockCosmosMessageClient
+	privateKey *secp256k1.PrivKey
+}
+
+func (s *deterministicSeedSigner) SignBytes(message []byte) ([]byte, error) {
+	return s.privateKey.Sign(message)
+}
+
+func TestCreateNewSeedIsDeterministicForEpoch(t *testing.T) {
+	signer := &deterministicSeedSigner{privateKey: secp256k1.GenPrivKey()}
+	manager := NewRandomSeedManager(signer, &apiconfig.ConfigManager{})
+
+	first, err := manager.CreateNewSeed(344)
+	require.NoError(t, err)
+	second, err := manager.CreateNewSeed(344)
+	require.NoError(t, err)
+
+	require.Equal(t, first.Seed, second.Seed)
+	require.Equal(t, first.Signature, second.Signature)
+}

--- a/decentralized-api/internal/server/public/deprecated_queryapi.go
+++ b/decentralized-api/internal/server/public/deprecated_queryapi.go
@@ -157,8 +157,7 @@ func (d deprecatedQueryAPI) PostVerifyProof(ctx echo.Context) error {
 }
 
 func (d deprecatedQueryAPI) GetVersions(ctx echo.Context) error {
-	markQueryAPIDeprecated(ctx)
-	return d.inner.GetVersions(ctx)
+	return echo.ErrNotFound
 }
 
 var _ gen.ServerInterface = deprecatedQueryAPI{}

--- a/decentralized-api/internal/server/public/deprecated_queryapi_test.go
+++ b/decentralized-api/internal/server/public/deprecated_queryapi_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -31,4 +32,29 @@ func TestDeprecatedLegacyDapiOnlyRoutes_BridgeLatestMarksDeprecation(t *testing.
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "true", rec.Header().Get("Deprecation"))
 	require.Contains(t, rec.Header().Get("Link"), "edge-api")
+}
+
+func TestVersionsRouteUsesEnrichedDAPIHandler(t *testing.T) {
+	s := NewServer(nil, newTestConfigManager(t), nil, nil, nil, nil)
+
+	s.versionsCache.response = &versionsResponse{
+		Timestamp:   "2026-01-01T00:00:00Z",
+		APIVersion:  map[string]string{"version": "test"},
+		NodeVersion: map[string]string{"version": "test"},
+		MLNodes: []mlnodeVersionResponse{{
+			NodeID:                 "node-1",
+			Version:                "1.0.0",
+			PoCValidationInference: true,
+		}},
+	}
+	s.versionsCache.expiresAt = time.Now().Add(time.Hour)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/versions", nil)
+	rec := httptest.NewRecorder()
+	s.e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"mlnodes"`)
+	require.Contains(t, rec.Body.String(), `"poc_validation_inference":true`)
+	require.Empty(t, rec.Header().Get("Deprecation"))
 }

--- a/decentralized-api/internal/server/public/server.go
+++ b/decentralized-api/internal/server/public/server.go
@@ -156,6 +156,8 @@ func NewServer(
 	// marked Deprecation: true. Prefer edge-api for new proxy configs.
 	s.mountDeprecatedQueryAPIRoutes(e)
 
+	e.GET("/v1/versions", s.getVersions)
+
 	e.Any(deprecatedDevshardV1Prefix, legacyDevshardDeprecated)
 	e.Any(deprecatedDevshardV1Prefix+"/*", legacyDevshardDeprecated)
 	return s

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -285,8 +285,11 @@ func main() {
 	adminServer.Start(addr)
 
 	nmGrpcPort := configManager.GetApiConfig().NodeManagerGrpcPort
-	// port should be set explicitly in the config to start NodeManager GRPC server. 0 means we skip it
-	if nmGrpcPort != 0 {
+	if nmGrpcPort == 0 {
+		nmGrpcPort = 9400
+	}
+	// Negative ports explicitly disable the NodeManager gRPC server.
+	if nmGrpcPort > 0 {
 		nmGrpcServer := grpc.NewServer()
 		nmgen.RegisterNodeManagerServer(nmGrpcServer, nodemanager.NewServer(nodeBroker, configManager, chainPhaseTracker,
 			nodemanager.WithHostEventRing(hostEventRing),

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   api:
     container_name: api
-    image: ghcr.io/product-science/api:0.2.15
+    image: ghcr.io/product-science/api:0.2.15-post2
     volumes:
       - .inference:/root/.inference
       - .dapi:/root/.dapi

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   api:
     container_name: api
-    image: ghcr.io/product-science/api:0.2.15-post2
+    image: ghcr.io/product-science/api:0.2.15-post3
     volumes:
       - .inference:/root/.inference
       - .dapi:/root/.dapi

--- a/inference-chain/x/inference/keeper/msg_server_submit_seed_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_seed_test.go
@@ -86,3 +86,24 @@ func TestSubmitSeed(t *testing.T) {
 		})
 	}
 }
+
+func TestSubmitSeedDuplicateIsStateIdempotent(t *testing.T) {
+	k, ms, ctx, _ := setupKeeperWithMocks(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 10))
+	require.NoError(t, k.SetParticipant(ctx, types.Participant{Index: testutil.Executor}))
+
+	msg := &types.MsgSubmitSeed{
+		Creator:    testutil.Executor,
+		EpochIndex: 11,
+		Signature:  "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	_, err := ms.SubmitSeed(ctx, msg)
+	require.NoError(t, err)
+	_, err = ms.SubmitSeed(ctx, msg)
+	require.NoError(t, err)
+
+	stored, found := k.GetRandomSeed(ctx, msg.EpochIndex, msg.Creator)
+	require.True(t, found)
+	require.Equal(t, msg.Signature, stored.Signature)
+}

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -45,7 +45,6 @@ EDGE_API_ROUTE_PATHS_DEFAULT='
 /v1/restrictions/status
 /v1/restrictions/exemptions
 /v1/restrictions/exemptions/{id}/usage/{account}
-/v1/versions
 /v1/bls/epoch/{id}
 /v1/bls/epochs/{id}
 /v1/bls/signatures/{request_id}
@@ -943,6 +942,9 @@ append_edge_api_route_locations() {
     fi
 
     for route in $routes; do
+        if [ "$route" = "/v1/versions" ]; then
+            continue
+        fi
         # Optional verify/debug group stays private unless explicitly exposed.
         # Skip even if an old EDGE_API_ROUTE_PATHS override still lists them.
         if [ "${EDGE_API_EXPOSE_OPTIONAL_ROUTES}" != "true" ] && edge_api_is_optional_route "$route"; then

--- a/testermint/src/test/kotlin/NodeManagerTests.kt
+++ b/testermint/src/test/kotlin/NodeManagerTests.kt
@@ -1,3 +1,4 @@
+import com.google.gson.JsonObject
 import com.productscience.NodeManagerClient
 import com.productscience.data.InferenceNode
 import com.productscience.data.ModelConfig
@@ -32,6 +33,15 @@ class NodeManagerTests : TestermintTest() {
     fun `acquire and release node over gRPC`() {
         val (_, genesis) = initCluster()
         waitForInferenceState(genesis)
+
+        val versions = genesis.api.get<JsonObject>(genesis.api.getPublicUrl(), "v1/versions")
+        val apiVersion = versions.getAsJsonObject("api_version")
+        assertThat(apiVersion.get("application_name").asString).isEqualTo("decentralized-api")
+        assertThat(apiVersion.get("version").asString).isNotBlank()
+        assertThat(apiVersion.get("commit").asString).isNotBlank()
+        val mlnodes = versions.getAsJsonArray("mlnodes")
+        assertThat(mlnodes.size()).isGreaterThan(0)
+        assertThat(mlnodes.all { it.asJsonObject.has("poc_validation_inference") }).isTrue()
 
         nodeManagerClient(genesis).use { client ->
             val acquireResp = client.acquireMLNode(defaultModel)


### PR DESCRIPTION
### PoC Seed Stability

- Recover missed seed submissions after epoch-boundary lag and retry local seed restoration after transient failures (such as signer unavailability) to prevent validators from getting zeroed [`d1d6d03`](https://github.com/gonka-ai/gonka/commit/d1d6d038e21b3de193db0611390fede97fc56e12), [`ea13258`](https://github.com/gonka-ai/gonka/commit/ea13258babfbd9e5a77f3d6438a33f40eb201bca), [`4601969`](https://github.com/gonka-ai/gonka/commit/460196998f1d4b303ff343e36be43c34b7f6612c)

### API

- Fix: return `/v1/versions` with enriched DAPI version info (including ML node details) [`21ed5c6`](https://github.com/gonka-ai/gonka/commit/21ed5c6377c5ad66067b5a5ee1cf8f6ecac34c42)
- Set default Node Manager gRPC port to 9400 to make sure it works on custom configurations [`6806e15`](https://github.com/gonka-ai/gonka/commit/6806e1590a9d4994ed1912f382f3d3a57db640eb)

### Deployments

- Update the default join stack configuration to use the latest `v0.2.15-post2` API image [`1c59f14`](https://github.com/gonka-ai/gonka/commit/1c59f140cc3135024db09a9aefa020e3ccebf62c)