### PR TITLE
fix(devshardd): evict in-memory hosts on epoch prune

### DIFF
--- a/common/chain/phase.go
+++ b/common/chain/phase.go
@@ -2,24 +2,16 @@ package chain
 
 import "sync/atomic"
 
-// Phase tracks the current epoch and block height, updated by the event listener.
+// Phase tracks the current chain epoch. In standalone devshardd it is updated
+// from runtime-config OnEpochChange (long-poll or chain-poll fallback), not from
+// per-block Comet subscriptions.
 // It is safe for concurrent access.
 type Phase struct {
-	epochID     atomic.Uint64
-	blockHeight atomic.Int64
+	epochID atomic.Uint64
 }
 
 // EpochID returns the current epoch index.
 func (p *Phase) EpochID() uint64 { return p.epochID.Load() }
 
-// BlockHeight returns the latest observed block height.
-func (p *Phase) BlockHeight() int64 { return p.blockHeight.Load() }
-
-// Update sets epoch and block height. Called on every new block.
-func (p *Phase) Update(epochID uint64, blockHeight int64) {
-	p.epochID.Store(epochID)
-	p.blockHeight.Store(blockHeight)
-}
-
-// SetBlockHeight updates only the block height, used when the epoch query fails.
-func (p *Phase) SetBlockHeight(h int64) { p.blockHeight.Store(h) }
+// SetEpoch stores the current epoch index.
+func (p *Phase) SetEpoch(epochID uint64) { p.epochID.Store(epochID) }

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"time"
 
 	"common/chain"
@@ -17,7 +16,6 @@ import (
 	"common/storage/payloads"
 	devshardpkg "devshard"
 	devshardbridge "devshard/cmd/devshardd/bridge"
-	"devshard/cmd/devshardd/events"
 	"devshard/cmd/devshardd/inference"
 	"devshard/cmd/devshardd/session"
 	chaintx "devshard/cmd/devshardd/tx"
@@ -59,17 +57,6 @@ func (s closeStack) Close() {
 	for i := len(s) - 1; i >= 0; i-- {
 		s[i]()
 	}
-}
-
-type phaseEpochProvider struct {
-	phase *chain.Phase
-}
-
-func (p phaseEpochProvider) CurrentEpochID() uint64 {
-	if p.phase == nil {
-		return 0
-	}
-	return p.phase.EpochID()
 }
 
 func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error) {
@@ -251,10 +238,6 @@ func buildHostManager(
 		return nil, fmt.Errorf("devshard storage: %w", err)
 	}
 	store := devshardstorage.NewManagedStorage(innerStore, sessionEpochRetain, chainParams)
-	if cancel := paramsSetup.RegisterEpochPrune(store); cancel != nil {
-		closers.Add(cancel)
-	}
-	closers.Add(func() { _ = store.Close() })
 
 	leaseValidator := inference.NewLeaseValidator(validator, phase, store, instanceAddr, cfg.ValidationLeaseTTL)
 
@@ -280,12 +263,50 @@ func buildHostManager(
 	manager.SetBinaryVersion(cfg.BinaryLogVersion)
 	chainBridge.OnSettlementFinalizedHandler(manager.HandleSettlementFinalized)
 
+	// Close hosts (and the managed store) on shutdown. Register before the
+	// epoch-change cancel so LIFO shutdown cancels epoch callbacks first.
+	closers.Add(func() { _ = manager.Close() })
+
+	// Single epoch clock: runtime-config OnEpochChange (dapi long-poll or
+	// chain-poll fallback) advances phase + managed-storage horizon, then
+	// prunes DB, evicts in-memory hosts, and drops old payload epochs.
+	applyEpoch := func(newEpoch uint64, pruneAsync bool) {
+		phase.SetEpoch(newEpoch)
+		store.ObserveEpoch(newEpoch)
+		if pruneAsync {
+			store.PruneOnceAsync(ctx)
+		} else {
+			store.PruneOnce(ctx)
+		}
+		if cutoff := store.PruneCutoff(); cutoff > 0 {
+			manager.EvictBefore(cutoff)
+		}
+		if newEpoch >= sessionEpochRetain+1 {
+			expiredPayloadEpoch := newEpoch - sessionEpochRetain
+			if err := payloadStore.DropEpoch(ctx, expiredPayloadEpoch); err != nil {
+				logCleanupError("payload epoch cleanup failed", err)
+			}
+		}
+	}
+	if cancel := chainParams.OnEpochChange(func(_, newEpoch uint64) {
+		applyEpoch(newEpoch, true)
+	}); cancel != nil {
+		closers.Add(cancel)
+	}
+
 	startHostEventsWarm(ctx, cfg, chainBridge, mlClient, store, closers)
 
 	if err := manager.RecoverSessions(); err != nil {
 		slog.Warn("recover sessions failed", "error", err)
 	}
-	store.Start()
+	// Initial snapshot apply does not fire OnEpochChange; seed clocks and catch up.
+	if epoch := chainParams.CurrentEpochID(); epoch > 0 {
+		applyEpoch(epoch, false)
+	} else if boot := phase.EpochID(); boot > 0 {
+		applyEpoch(boot, false)
+	} else {
+		store.Start()
+	}
 
 	retryLoop := session.NewRetryLoop(store, validator, manager, phase, instanceAddr)
 	retryLoop.WithInterval(cfg.ValidationRetryInterval)
@@ -300,24 +321,6 @@ func buildHostManager(
 		defer close(retryLoopDone)
 		retryLoop.Run(retryLoopCtx)
 	}()
-
-	var lastCleanEpoch atomic.Uint64
-	chainRuntime.chainEvents.OnNewBlock(func(bctx context.Context, e events.NewBlockEvent) {
-		currentEpoch := phase.EpochID()
-		if currentEpoch <= lastCleanEpoch.Load() {
-			return
-		}
-		lastCleanEpoch.Store(currentEpoch)
-
-		store.PruneOnceAsync(bctx)
-
-		if currentEpoch >= 4 {
-			expiredPayloadEpoch := currentEpoch - 3
-			if err := payloadStore.DropEpoch(bctx, expiredPayloadEpoch); err != nil {
-				logCleanupError("payload epoch cleanup failed", err)
-			}
-		}
-	})
 
 	return manager, nil
 }

--- a/devshard/cmd/devshardd/chain_events.go
+++ b/devshard/cmd/devshardd/chain_events.go
@@ -8,7 +8,6 @@ import (
 	chainbridge "devshard/cmd/devshardd/bridge"
 	"devshard/cmd/devshardd/events"
 
-	cmtservice "github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	chaintypes "github.com/productscience/inference/x/inference/types"
 )
 
@@ -18,24 +17,16 @@ type chainEventBridge struct {
 	phase    *chain.Phase
 }
 
-// bootstrapPhase fetches the current epoch and latest block height from the
-// chain and seeds the phase before the event listener starts ticking. This
-// ensures phase.EpochID() is correct from the first inference request.
+// bootstrapPhase fetches the current epoch from the chain and seeds phase
+// before runtime-config OnEpochChange starts firing (initial snapshot apply
+// does not emit OnEpochChange).
 func bootstrapPhase(ctx context.Context, chainClient *chain.Client, phase *chain.Phase) {
 	epochResp, err := chainClient.InferenceQueryClient().GetCurrentEpoch(ctx, &chaintypes.QueryGetCurrentEpochRequest{})
 	if err != nil {
 		slog.Warn("phase: failed to bootstrap epoch, starting at 0", "error", err)
 		return
 	}
-
-	blockResp, err := chainClient.CometServiceClient().GetLatestBlock(ctx, &cmtservice.GetLatestBlockRequest{})
-	if err != nil {
-		slog.Warn("phase: failed to bootstrap block height, starting at 0", "error", err)
-		phase.Update(epochResp.Epoch, 0)
-		return
-	}
-
-	phase.Update(epochResp.Epoch, blockResp.SdkBlock.Header.Height)
+	phase.SetEpoch(epochResp.Epoch)
 }
 
 func newChainEventBridge(
@@ -49,16 +40,6 @@ func newChainEventBridge(
 	eventListener := events.NewListener(chainRPCURL)
 	br := chainbridge.NewChainBridge(chainClient, submitter)
 	br.Subscribe(eventListener)
-	eventListener.OnNewBlock(func(bctx context.Context, e events.NewBlockEvent) {
-		// TODO: should this be called for every block?
-		resp, err := chainClient.InferenceQueryClient().GetCurrentEpoch(bctx, &chaintypes.QueryGetCurrentEpochRequest{})
-		if err != nil {
-			slog.Warn("phase: failed to query current epoch", "block", e.BlockHeight, "error", err)
-			phase.SetBlockHeight(e.BlockHeight)
-			return
-		}
-		phase.Update(resp.Epoch, e.BlockHeight)
-	})
 	return &chainEventBridge{
 		listener: eventListener,
 		bridge:   br,
@@ -72,12 +53,6 @@ func (b *chainEventBridge) Bridge() *chainbridge.ChainBridge {
 
 func (b *chainEventBridge) Phase() *chain.Phase {
 	return b.phase
-}
-
-// OnNewBlock registers an additional new-block handler on the underlying listener.
-// Must be called before Start.
-func (b *chainEventBridge) OnNewBlock(h events.NewBlockHandler) {
-	b.listener.OnNewBlock(h)
 }
 
 func (b *chainEventBridge) OnReady(h func(bool)) {

--- a/devshard/cmd/devshardd/lifecycle_test.go
+++ b/devshard/cmd/devshardd/lifecycle_test.go
@@ -108,3 +108,23 @@ func TestReadyReflectsStorageReadiness(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "\"storage_ready\":true")
 }
+
+func TestAdminExposesPprofNotPublic(t *testing.T) {
+	lifecycle := newLifecycleState()
+	e := buildServer(lifecycle)
+	admin := buildAdminServer(lifecycle, func() bool { return true })
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	rec = httptest.NewRecorder()
+	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "goroutine")
+
+	rec = httptest.NewRecorder()
+	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/heap", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotEmpty(t, rec.Body.Bytes())
+}

--- a/devshard/cmd/devshardd/params_provider.go
+++ b/devshard/cmd/devshardd/params_provider.go
@@ -5,21 +5,19 @@ import (
 	"fmt"
 	"log/slog"
 
-	mlnodeclient "common/nodemanager"
 	"common/chain"
+	mlnodeclient "common/nodemanager"
 	devshardpkg "devshard"
 	"devshard/runtimeparams"
-	devshardstorage "devshard/storage"
 )
 
 type epochParamsProvider = runtimeparams.RuntimeProvider
 
 type paramsProviderResult struct {
-	Provider           epochParamsProvider
-	RegisterEpochPrune func(store *devshardstorage.ManagedStorage) (cancel func())
-	Source             string
-	ActiveSource       func() string
-	close              func()
+	Provider     epochParamsProvider
+	Source       string
+	ActiveSource func() string
+	close        func()
 }
 
 func newParamsProvider(
@@ -47,7 +45,7 @@ func newParamsProvider(
 		return nil, err
 	}
 
-	result := &paramsProviderResult{
+	return &paramsProviderResult{
 		Provider: managed.Provider,
 		Source:   managed.Source,
 		ActiveSource: func() string {
@@ -57,18 +55,5 @@ func newParamsProvider(
 			return managed.Source
 		},
 		close: managed.Close,
-	}
-	result.RegisterEpochPrune = func(store *devshardstorage.ManagedStorage) (cancel func()) {
-		return managed.Provider.OnEpochChange(func(_, _ uint64) {
-			store.PruneOnceAsync(ctx)
-		})
-	}
-	return result, nil
-}
-
-func normalizeLogger(logger *slog.Logger) *slog.Logger {
-	if logger != nil {
-		return logger
-	}
-	return slog.Default()
+	}, nil
 }

--- a/devshard/cmd/devshardd/server.go
+++ b/devshard/cmd/devshardd/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"net/http/pprof"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -46,6 +47,17 @@ func buildAdminServer(lifecycle *lifecycleState, storageReady func() bool) *echo
 	})
 	e.GET("/drain/status", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, lifecycle.Status())
+	})
+	// Canonical /debug/pprof/ paths so Index sub-profile links resolve.
+	// Bound only when DEVSHARD_ADMIN_ADDR is set (same network trust as /drain).
+	e.Any("/debug/pprof/", echo.WrapHandler(http.HandlerFunc(pprof.Index)))
+	e.Any("/debug/pprof/cmdline", echo.WrapHandler(http.HandlerFunc(pprof.Cmdline)))
+	e.Any("/debug/pprof/profile", echo.WrapHandler(http.HandlerFunc(pprof.Profile)))
+	e.Any("/debug/pprof/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)))
+	e.Any("/debug/pprof/trace", echo.WrapHandler(http.HandlerFunc(pprof.Trace)))
+	e.Any("/debug/pprof/:name", func(c echo.Context) error {
+		pprof.Handler(c.Param("name")).ServeHTTP(c.Response(), c.Request())
+		return nil
 	})
 
 	return e

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -1,19 +1,23 @@
 package session
 
 import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"runtime/pprof"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
-	"path/filepath"
+	"google.golang.org/protobuf/proto"
 
 	"devshard/bridge"
+	"devshard/internal/testutil"
 	"devshard/signing"
 	"devshard/state"
 	"devshard/storage"
 	"devshard/stub"
-	"devshard/internal/testutil"
 	"devshard/types"
-	"google.golang.org/protobuf/proto"
 )
 
 // mockBridge implements bridge.MainnetBridge for testing recovery.
@@ -45,6 +49,52 @@ func (b *mockBridge) SubmitDisputeState(_ string, _ []byte, _ uint64, _ map[uint
 }
 
 var _ bridge.MainnetBridge = (*mockBridge)(nil)
+
+type countingBridge struct {
+	escrow         *bridge.EscrowInfo
+	getEscrowCalls int
+}
+
+func (b *countingBridge) GetEscrow(string) (*bridge.EscrowInfo, error) {
+	b.getEscrowCalls++
+	return b.escrow, nil
+}
+
+func (b *countingBridge) GetHostInfo(address string) (*bridge.HostInfo, error) {
+	return &bridge.HostInfo{Address: address, URL: "http://localhost"}, nil
+}
+
+func (b *countingBridge) GetValidationThreshold(uint64, string) (*bridge.Decimal, error) {
+	return nil, bridge.ErrNotImplemented
+}
+
+func (b *countingBridge) VerifyWarmKey(string, string) (bool, error) { return false, nil }
+
+func (b *countingBridge) OnEscrowCreated(bridge.EscrowInfo) error { return bridge.ErrNotImplemented }
+func (b *countingBridge) OnSettlementProposed(string, []byte, uint64) error {
+	return bridge.ErrNotImplemented
+}
+func (b *countingBridge) OnSettlementFinalized(string) error { return bridge.ErrNotImplemented }
+func (b *countingBridge) SubmitDisputeState(string, []byte, uint64, map[uint32][]byte) error {
+	return bridge.ErrNotImplemented
+}
+
+var _ bridge.MainnetBridge = (*countingBridge)(nil)
+
+type failingCreateStore struct {
+	storage.Storage
+	err error
+}
+
+func (s *failingCreateStore) CreateSession(storage.CreateSessionParams) error {
+	return s.err
+}
+
+func countHostValidationWorkers() int {
+	var buf bytes.Buffer
+	_ = pprof.Lookup("goroutine").WriteTo(&buf, 2)
+	return bytes.Count(buf.Bytes(), []byte("devshard/host.(*Host).startValidationWorkers.func1"))
+}
 
 func mustGenerateKey(t *testing.T) *signing.Secp256k1Signer {
 	t.Helper()
@@ -379,4 +429,173 @@ func TestRecoverSessions_StateRootMismatch(t *testing.T) {
 	_, ok := mgr.sessions["1"]
 	mgr.sessionsMutex.RUnlock()
 	require.False(t, ok, "corrupt session should be skipped, not recovered")
+}
+
+func TestRecoverSessions_SkipsForeignVersionSessions(t *testing.T) {
+	store := newManagerTestStore(t)
+	_, _, hostSigner := createStoredSessionWithVersion(t, store, "escrow-v2", 7, "foreign", 1)
+
+	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	require.NoError(t, mgr.RecoverSessions())
+
+	mgr.sessionsMutex.RLock()
+	_, ok := mgr.sessions["escrow-v2"]
+	mgr.sessionsMutex.RUnlock()
+	require.False(t, ok, "foreign-version session must be skipped, not treated as failed recovery")
+}
+
+func TestHostManager_EvictBeforeClosesOldSessions(t *testing.T) {
+	store := newManagerTestStore(t)
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	config := defaultConfig(3)
+	for _, sess := range []struct {
+		escrowID string
+		epochID  uint64
+	}{
+		{escrowID: "escrow-old", epochID: 5},
+		{escrowID: "escrow-current", epochID: 7},
+	} {
+		require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+			EscrowID:       sess.escrowID,
+			EpochID:        sess.epochID,
+			Version:        testutil.RuntimeTestVersion,
+			CreatorAddr:    user.Address(),
+			Config:         config,
+			Group:          group,
+			InitialBalance: 100000000,
+		}))
+	}
+
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	require.NoError(t, mgr.RecoverSessions())
+	t.Cleanup(func() { _ = mgr.Close() })
+	beforeEvict := countHostValidationWorkers()
+	require.GreaterOrEqual(t, beforeEvict, 2*20)
+
+	evicted := mgr.EvictBefore(6)
+	require.Equal(t, 1, evicted)
+	require.Eventually(t, func() bool {
+		return countHostValidationWorkers() <= beforeEvict-20
+	}, time.Second, 10*time.Millisecond)
+
+	mgr.sessionsMutex.RLock()
+	_, oldOK := mgr.sessions["escrow-old"]
+	_, currentOK := mgr.sessions["escrow-current"]
+	mgr.sessionsMutex.RUnlock()
+	require.False(t, oldOK)
+	require.True(t, currentOK)
+}
+
+func TestSessionServer_StartsRegisteredHost(t *testing.T) {
+	store := newManagerTestStore(t)
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	addresses := make([]string, len(hosts))
+	for i, h := range hosts {
+		addresses[i] = h.Address()
+	}
+	br := &mockBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       "escrow-start",
+			EpochID:        7,
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+		},
+	}
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+
+	before := countHostValidationWorkers()
+	srv, err := mgr.SessionServer("escrow-start")
+	require.NoError(t, err)
+	t.Cleanup(srv.Host().Close)
+	require.Eventually(t, func() bool {
+		return countHostValidationWorkers() >= before+20
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestSessionServer_FailedCreateDoesNotStartHost(t *testing.T) {
+	base := newManagerTestStore(t)
+	store := &failingCreateStore{Storage: base, err: storage.ErrEpochPruned}
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	addresses := make([]string, len(hosts))
+	for i, h := range hosts {
+		addresses[i] = h.Address()
+	}
+	br := &mockBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       "escrow-pruned",
+			EpochID:        1,
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+		},
+	}
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+
+	before := countHostValidationWorkers()
+	_, err := mgr.SessionServer("escrow-pruned")
+	require.ErrorIs(t, err, storage.ErrEpochPruned)
+	require.Equal(t, before, countHostValidationWorkers())
+}
+
+func TestSessionServer_CachesFailedResolution(t *testing.T) {
+	base := newManagerTestStore(t)
+	store := &failingCreateStore{Storage: base, err: storage.ErrEpochPruned}
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	addresses := make([]string, len(hosts))
+	for i, h := range hosts {
+		addresses[i] = h.Address()
+	}
+	br := &countingBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       "escrow-cache-failure",
+			EpochID:        1,
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+		},
+	}
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+
+	_, err := mgr.SessionServer("escrow-cache-failure")
+	require.ErrorIs(t, err, storage.ErrEpochPruned)
+	_, err = mgr.SessionServer("escrow-cache-failure")
+	require.ErrorIs(t, err, storage.ErrEpochPruned)
+	require.Equal(t, 1, br.getEscrowCalls, "cached failure should avoid rebuilding the same broken escrow")
+}
+
+func TestHostManager_SweepsExpiredResolutionFailures(t *testing.T) {
+	mgr := &HostManager{
+		resolutionFailures: make(map[string]resolutionFailure),
+	}
+	now := time.Unix(1_000, 0)
+	for i := 0; i <= maxResolutionFailures; i++ {
+		mgr.resolutionFailures[fmt.Sprintf("expired-%d", i)] = resolutionFailure{
+			err:       storage.ErrSessionNotFound,
+			expiresAt: now.Add(-time.Second),
+		}
+	}
+
+	mgr.rememberResolutionFailure("fresh", storage.ErrEpochPruned, now)
+
+	require.Len(t, mgr.resolutionFailures, 1)
+	require.Contains(t, mgr.resolutionFailures, "fresh")
+	require.True(t, now.Before(mgr.resolutionFailures["fresh"].expiresAt))
 }

--- a/devshard/cmd/devshardd/session/retry_test.go
+++ b/devshard/cmd/devshardd/session/retry_test.go
@@ -182,7 +182,7 @@ func TestRetryForEscrow_LeaseFromPreviousEpochIsSkipped(t *testing.T) {
 		},
 	}
 	phase := new(chain.Phase)
-	phase.Update(11, 0)
+	phase.SetEpoch(11)
 	rl := &RetryLoop{
 		leases:       leases,
 		manager:      &stubSessionManager{},

--- a/devshard/storage/managed.go
+++ b/devshard/storage/managed.go
@@ -76,6 +76,12 @@ func (m *ManagedStorage) observe(epochID uint64) {
 	}
 }
 
+// ObserveEpoch advances the prune horizon from an external epoch clock
+// (devshardd wires this to runtime-config OnEpochChange).
+func (m *ManagedStorage) ObserveEpoch(epochID uint64) {
+	m.observe(epochID)
+}
+
 // CurrentEpochID returns the epoch observed by the managed pruner. It is used
 // only for temporary payload fallback during epoch-0 migration.
 func (m *ManagedStorage) CurrentEpochID() uint64 {
@@ -83,6 +89,20 @@ func (m *ManagedStorage) CurrentEpochID() uint64 {
 		m.observe(m.epochs.CurrentEpochID())
 	}
 	return m.maxObservedEpoch.Load()
+}
+
+// PruneCutoff returns the exclusive epoch lower bound for retention: every
+// epoch < cutoff is pruneable. Returns 0 when not enough epochs have been
+// observed yet. HostManager uses the same value to EvictBefore in-memory sessions.
+func (m *ManagedStorage) PruneCutoff() uint64 {
+	if m.epochs != nil {
+		m.observe(m.epochs.CurrentEpochID())
+	}
+	maxE := m.maxObservedEpoch.Load()
+	if maxE+1 <= m.retain {
+		return 0
+	}
+	return maxE + 1 - m.retain
 }
 
 // Start runs a single catch-up prune after recovery. Epoch transitions must
@@ -107,14 +127,11 @@ func (m *ManagedStorage) PruneOnceAsync(ctx context.Context) {
 // PruneOnce runs a single retention pass. Exported so tests and epoch hooks can
 // drive pruning without a background loop.
 func (m *ManagedStorage) PruneOnce(_ context.Context) {
-	if m.epochs != nil {
-		m.observe(m.epochs.CurrentEpochID())
-	}
-	maxE := m.maxObservedEpoch.Load()
-	if maxE+1 <= m.retain {
+	cutoff := m.PruneCutoff()
+	if cutoff == 0 {
 		return // not enough epochs yet
 	}
-	cutoff := maxE + 1 - m.retain // every epoch < cutoff is pruneable
+	maxE := m.maxObservedEpoch.Load()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Summary
- On epoch change (dapi long-poll or chain-poll fallback), advance phase + managed-storage horizon, prune DB, **`EvictBefore` in-memory hosts**, and drop expired payload epochs — fixing the case where storage pruned escrows but hosts kept serving them.
- Seed the same path at startup (initial params snapshot does not fire `OnEpochChange`); shut down via `manager.Close()` so hosts and store tear down together.
- Simplify `chain.Phase` to epoch-only; **remove Comet `OnNewBlock` phase/prune/payload cleanup**.
- Mount `/debug/pprof/*` on the admin server (`DEVSHARD_ADMIN_ADDR`); remove the separate loopback `:port+10000` listener.

## Motivation
After the standalone `devshardd` move, epoch prune only cleaned storage. In-memory hosts (and validation workers) could outlive pruned escrow IDs, so the gateway still routed to stale sessions. This restores the prune ↔ evict coupling and uses one epoch clock instead of a second per-block path.

## Why drop `OnNewBlock` epoch work
Per-block handlers were doing the same job as runtime-config **`OnEpochChange`**, but worse for host fleets:

- **Duplicate logic.** New-block already pruned storage and dropped payload epochs; epoch change is the correct clock for that. Keeping both meant two paths that could drift (and still missed `EvictBefore`).
- **Extra node traffic.** Every host’s `devshardd` subscribed to Comet new blocks and called **`GetCurrentEpoch` on each block** to refresh phase. Hosts already get epoch/params via **dapi** (`GetRuntimeConfig` long-poll, with chain-poll fallback). That path is built to fan out epoch updates without N hosts hammering the chain node every block.
- **Unused height.** `phase.BlockHeight` had no consumers in standalone `devshardd`, so the per-block height updates were pure overhead.

Comet WS remains for escrow settlement (and readiness); it is no longer an epoch/prune driver.

## Test plan
- [ ] `go test ./cmd/devshardd/...` and `./storage/...` (from `devshard/`)
- [ ] Confirm `TestHostManager_EvictBeforeClosesOldSessions` and related resolution/recover tests pass
- [ ] With `DEVSHARD_ADMIN_ADDR` set: `curl -sS http://$ADMIN/debug/pprof/` and `go tool pprof http://$ADMIN/debug/pprof/heap`
- [ ] Confirm public listener has no `/debug/pprof/`
- [ ] On epoch advance in a long-lived host: old-epoch sessions leave memory; storage prune cutoff matches `EvictBefore`
- [ ] Confirm hosts no longer issue per-block `GetCurrentEpoch` after new blocks; epoch still advances via dapi runtime-config / fallback