### PR TITLE
mlnode for vLLM 0.25.1: metrics exporter + heartbeat liveness + reviewed fixes

### DIFF
--- a/deploy/join/docker-compose.mlnode.yml
+++ b/deploy/join/docker-compose.mlnode.yml
@@ -1,7 +1,13 @@
 services:
   mlnode-308:
     # ghcr.io/product-science/mlnode:3.0.12-post6-blackwell
-    image: ghcr.io/gonka-ai/mlnode:3.0.14-post2
+    # Release-candidate for the vLLM 0.25.1 stack (B300 + DeepSeek-V4-Flash):
+    # every layer from upstream sources — gonka-ai/vllm release/v0.25.1
+    # @04a165c0 (#78 port + #79/#80/#82) + gonka-ai/gonka-vllm-plugins v0.1.1
+    # + this repo's mlnode with the metrics exporter and heartbeat liveness
+    # (the two commits carried by this branch). Swap for the gonka-ai-built
+    # tag when the release image is cut.
+    image: ghcr.io/kaitakuai/mlnode-b300-deepseek-v4-flash:0.2.14-vllm0.25.1-overlay-k9@sha256:ef5260aefa5cc46fbbdee6783d3492d399ae0a8fb649c03a12f731707edcc11b
     hostname: mlnode-308
     volumes:
       - ${HF_HOME:-${HOME}/.cache}:/root/.cache

--- a/docs/adr/mlnode-monitoring-metrics-v1.md
+++ b/docs/adr/mlnode-monitoring-metrics-v1.md
@@ -1,0 +1,176 @@
+# ADR: ML-node monitoring — metrics and interface contract v1
+
+Status: **accepted** (team-approved 2026-07-10)
+Related: [operator guide](../observability.md), [decision log](../decision-log.md)
+
+## Context
+
+ML-node monitoring architecture (v0.5): an exporter inside mlnode → a
+collector + public endpoint in dapi → consumers store data on their side.
+This ADR fixes the Phase 0 contract: the final allowlist, formats,
+off-behavior, numeric limits and the schema versioning rules.
+
+## Decisions
+
+### D1. Allowlist v1 (verified against live vLLM 0.20.0 and v0.23.0 sources)
+
+Verification performed 2026-07-08:
+
+- live `/metrics` of vLLM **0.20.0** (production ML node, Kimi-K2.6): every
+  family below present;
+- vLLM sources **v0.20.0 vs v0.23.0** (`vllm/v1/metrics/*.py`): metric name
+  sets identical (42/42), label names identical — no version skew for the
+  allowlist. A live 0.23 run is deferred to the Phase 4 E2E stand (Open-1).
+
+**vLLM P0** (labels: `model_name`, `replica`): `vllm:num_requests_waiting`,
+`vllm:num_requests_running`, `vllm:kv_cache_usage_perc`,
+`vllm:num_preemptions_total`, `vllm:time_to_first_token_seconds`,
+`vllm:request_queue_time_seconds`, `vllm:prompt_tokens_total`,
+`vllm:generation_tokens_total`, `vllm:request_success_total`
+(`finished_reason`: stop|length|abort|error|repetition — captured live).
+
+**vLLM P1**: `vllm:inter_token_latency_seconds`,
+`vllm:e2e_request_latency_seconds`, `vllm:prefix_cache_queries_total`,
+`vllm:prefix_cache_hits_total`, `vllm:request_prompt_tokens`,
+`vllm:request_generation_tokens`, `vllm:iteration_tokens_total`,
+`vllm:cache_config_info`.
+
+Version-gated families (`*_by_reason`, `*_by_source`, `mm_cache_*`,
+`external_prefix_cache_*`, `estimated_*`) are **out of v1** (present in the
+0.20 fork, no upstream guarantee).
+
+**GPU/host P0** (prefix `mlnode_`, labels `gpu_index`, `gpu_model`):
+core + HBM temperature (sensor-gated), power draw + enforced limit,
+SM clock + max SM clock, clocks-event-reasons bitmask, VRAM used/free,
+ECC DBE aggregate, PCIe replay counter,
+`mlnode_gpu_xid_events_total{gpu_index,xid}` (see D11),
+host CPU busy/steal ratios, memory used/limit from the cgroup
+(v2 with v1 fallback), HF-cache free disk space.
+No sensor ⇒ no series (never a fake zero/N-A value).
+
+**Gonka-specific**: `mlnode_config_info` (P0; labels `model_name`, `dtype`,
+`replicas`, `max_num_seqs`, `max_model_len`, `tensor_parallel_size`,
+`pipeline_parallel_size` — empty numeric value = argument not passed
+explicitly, effective vLLM default unknown to mlnode),
+`mlnode_version_info` (P2).
+
+**Source timestamps**: `mlnode_source_scrape_timestamp_seconds{source}` is a
+mandatory part of the schema (invariant 4: a hung vLLM is visible by data
+age). The vLLM source carries an additional `replica` label so one hung
+replica out of N is individually detectable.
+
+### D2. `model_name` normalization (added after live verification)
+
+In production the vLLM `model_name` label contains the **local HF-cache
+path** (`/root/.cache/huggingface/hub/models--org--name/snapshots/<sha>`) —
+a placement detail (violates invariant 5). The exporter MUST rewrite
+`model_name` to the served name (`org/name`). The internal vLLM `engine`
+label is dropped; replica identity is the `replica="0..N-1"` label
+(positional instance index). A Phase 1 unit test enforces the absence of
+paths, hostnames, IPs and ports in label values.
+
+### D3. mlnode exporter response format
+
+- `GET /api/v1/metrics` on the mlnode API port (the dapi collector reaches
+  it via `Node.PoCUrl()`).
+- Format: **Prometheus text exposition v0.0.4**,
+  `Content-Type: text/plain; version=0.0.4`.
+- Content: exactly the allowlist (filter enforced in code); python-client
+  `*_created` noise stripped; replicas fanned out over healthy proxy
+  backends, each labeled `replica`.
+- Implementation renders filtered text directly — no prometheus_client
+  global registry (it is not a declared dependency and the exporter relays
+  foreign metrics rather than owning them).
+
+### D4. `GONKA_METRICS` behavior
+
+- Values: `full` (default) | `off`; anything else is treated as `full` with
+  a startup warning. Read via `os.getenv` in the handler (repo idiom).
+- `off` ⇒ **HTTP 404**. The route is always registered; a disabled node is
+  indistinguishable from a pre-metrics image, which keeps the dapi
+  upgrade path trivial (Phase 2 AC).
+- Honesty mechanics: the allowlist lives in the repository; the mlnode
+  startup log states the export mode; vLLM replicas run with
+  `VLLM_NO_USAGE_STATS=1`.
+
+### D5. dapi public endpoint format
+
+- **Aggregated** endpoint `GET /v1/metrics` on the public Echo server
+  (:9000, exposed through the existing nginx `/v1/*` location).
+- Response: Prometheus text exposition; all ML-node series of this network
+  node with an added `node_id` label and **per-sample timestamps** (ms) set
+  to the collection time — a silent node is served with its old timestamp.
+- A node answering 404/timeout/`off` is simply absent (no zero stubs).
+- Rejected alternative: per-node endpoints (consumers would need discovery;
+  one scrape per network node is the point).
+
+### D6. Rate limit
+
+Echo `RateLimiter` middleware (in-memory, per-IP — existing repo pattern):
+**rate 1 req/s, burst 5, expires 3 min** ⇒ 429. Rationale: the useful
+consumer frequency equals the buffer update cadence (45 s); 1 rps leaves
+headroom for retries and several consumers behind one NAT. An optional
+stricter nginx zone is a Phase 2 deliverable only if needed.
+
+### D7. dapi buffer ceilings
+
+- Only the **latest** snapshot per node_id is stored.
+- Max **2 MiB** of filtered text per node_id (read limit; larger ⇒ snapshot
+  rejected, error counter logged).
+- Max **5 000 series** per node_id (protection from a malicious/broken node;
+  honest maximum ≈ 1–2 k series per replica).
+- Snapshot TTL **5 min** (evicted on timer and on read).
+- Collector RSS budget: ≤ **64 MiB** at 16 nodes.
+- Polling: **45 s** ticker, per-node `context.WithTimeout` **10 s**, an
+  isolated worker goroutine (MLNodeBackgroundManager pattern) with a
+  WaitGroup fan-out; never on the broker command queue (invariant 6).
+
+### D8. Timestamps
+
+- mlnode exporter: gauge `mlnode_source_scrape_timestamp_seconds{source}`
+  (unix seconds, float) per source; `source="vllm"` also carries `replica`.
+- dapi: per-sample timestamps (unix ms) in the exposition output = the
+  moment of successful collection from the node.
+
+### D9. Schema version and change rules
+
+- Series `gonka_metrics_schema_info{version="1"} 1` in the exporter output.
+- Any change to the allowlist or label semantics = version bump + an entry
+  in the changelog section of `docs/observability.md` in the same PR.
+- Adding a series is minor-compatible (still logged in the changelog);
+  removing/renaming = major bump.
+
+### D10. dapi libraries (Go)
+
+- Parsing node responses: `github.com/prometheus/common/expfmt` (already in
+  the dependency tree as indirect).
+- Exposition: `expfmt` encoder (no client_golang registry — dapi relays
+  foreign metrics).
+- Rate limit: Echo middleware (already used in the repo).
+- Kill switches: `ApiConfig` fields (koanf) ⇒
+  `DAPI_API__METRICS_COLLECTOR_ENABLED`, `DAPI_API__METRICS_ENDPOINT_ENABLED`
+  (default `true` from the Phase 5 release); gated in `main.go`.
+
+### D11. XID mechanism (closes Open-2)
+
+XID critical errors are captured via the **NVML event API**
+(`nvmlDeviceRegisterEvents` + a listener thread) and exported as
+`mlnode_gpu_xid_events_total{gpu_index,xid}` (no events ⇒ no series).
+Verified working in all five target environments, including unprivileged
+rented containers; `dmesg` is readable only on bare hosts and was rejected.
+The listener is joined and its event set freed before `nvmlShutdown()`.
+
+## Open questions
+
+- **Open-1**: a live allowlist check against vLLM 0.23 — on the Phase 4
+  stand (source-level parity already verified; low risk).
+- **Open-3** (= architecture question 2): an optional
+  node_exporter + dcgm-exporter profile for sidecar-capable environments —
+  out of v1.
+
+## Verification artifacts
+
+Live 0.20 snapshot, v0.20/v0.23 source diffs, the production B300 exporter
+response, the 5/5 NVML environment matrix and the differential overhead
+measurement (0.205% of a core vs the <1% AC) are attached to the
+introducing PR.

--- a/docs/adr/mlnode-monitoring-metrics-v1.md
+++ b/docs/adr/mlnode-monitoring-metrics-v1.md
@@ -43,7 +43,7 @@ Version-gated families (`*_by_reason`, `*_by_source`, `mm_cache_*`,
 core + HBM temperature (sensor-gated), power draw + enforced limit,
 SM clock + max SM clock, clocks-event-reasons bitmask, VRAM used/free,
 ECC DBE aggregate, PCIe replay counter,
-`mlnode_gpu_xid_events_total{gpu_index,xid}` (see D11),
+`mlnode_gpu_xid_events_total{gpu_index,xid}` (see D9),
 host CPU busy/steal ratios, memory used/limit from the cgroup
 (v2 with v1 fallback), HF-cache free disk space.
 No sensor ⇒ no series (never a fake zero/N-A value).
@@ -55,9 +55,9 @@ explicitly, effective vLLM default unknown to mlnode),
 `mlnode_version_info` (P2).
 
 **Source timestamps**: `mlnode_source_scrape_timestamp_seconds{source}` is a
-mandatory part of the schema (invariant 4: a hung vLLM is visible by data
-age). The vLLM source carries an additional `replica` label so one hung
-replica out of N is individually detectable.
+mandatory part of the schema. It records successful source collection, not
+scheduler progress. The vLLM source carries an additional `replica` label so
+one failed replica scrape out of N is individually detectable.
 
 ### D2. `model_name` normalization (added after live verification)
 
@@ -99,9 +99,9 @@ paths, hostnames, IPs and ports in label values.
   exposed through dedicated exact-match nginx locations rather than the generic
   `/v1/*` one (see D6).
 - Response: Prometheus text exposition; all ML-node series of this network node
-  with an added `node_id` label. Staleness is conveyed by the exporter's own
-  `mlnode_source_scrape_timestamp_seconds` plus `mlnode_up`, rather than by
-  per-sample timestamps — as built, dapi does not stamp samples.
+  with an added `node_id` label. Scrape freshness is conveyed by the exporter's
+  own `mlnode_source_scrape_timestamp_seconds` plus `mlnode_up`; dapi does not
+  stamp individual samples.
 - Three states: `mlnode_up{node_id} 1` scraped fine; `0` reachable but the
   scrape failed or exceeded a ceiling; a node answering 404 (metrics off, or an
   image predating the exporter) is absent entirely, with no zero stubs and no
@@ -111,8 +111,7 @@ paths, hostnames, IPs and ports in label values.
 ≤5 min buffer, per-sample timestamps). The implementation is a pull-through
 cache instead: a merged snapshot is cached 10 s and rebuilds are
 single-flighted, so N external scrapers still cost the ML nodes one fan-out per
-TTL, and there is no polling while nobody is looking. The staleness signals the
-poller design wanted are covered by the two metrics above.
+TTL, and there is no polling while nobody is looking.
 - Rejected alternative: per-node endpoints (consumers would need discovery;
   one scrape per network node is the point).
 
@@ -130,27 +129,7 @@ The in-app limiter was dropped accordingly. Residual risk: a deployment that
 strips the shipped proxy runs the endpoint unlimited; compute stays bounded
 regardless by the cached single-flight fan-out.
 
-### D7. dapi buffer ceilings
-
-- Only the **latest** snapshot per node_id is stored.
-- Max **2 MiB** of filtered text per node_id (read limit; larger ⇒ snapshot
-  rejected, error counter logged).
-- Max **5 000 series** per node_id (protection from a malicious/broken node;
-  honest maximum ≈ 1–2 k series per replica).
-- Snapshot TTL **5 min** (evicted on timer and on read).
-- Collector RSS budget: ≤ **64 MiB** at 16 nodes.
-- Polling: **45 s** ticker, per-node `context.WithTimeout` **10 s**, an
-  isolated worker goroutine (MLNodeBackgroundManager pattern) with a
-  WaitGroup fan-out; never on the broker command queue (invariant 6).
-
-### D8. Timestamps
-
-- mlnode exporter: gauge `mlnode_source_scrape_timestamp_seconds{source}`
-  (unix seconds, float) per source; `source="vllm"` also carries `replica`.
-- dapi: per-sample timestamps (unix ms) in the exposition output = the
-  moment of successful collection from the node.
-
-### D9. Schema version and change rules
+### D7. Schema version and change rules
 
 - Series `gonka_metrics_schema_info{version="1"} 1` in the exporter output.
 - Any change to the allowlist or label semantics = version bump + an entry
@@ -158,7 +137,7 @@ regardless by the cached single-flight fan-out.
 - Adding a series is minor-compatible (still logged in the changelog);
   removing/renaming = major bump.
 
-### D10. dapi libraries (Go)
+### D8. dapi libraries (Go)
 
 - Parsing node responses: `github.com/prometheus/common/expfmt` (already in
   the dependency tree as indirect).
@@ -170,7 +149,7 @@ regardless by the cached single-flight fan-out.
   effect without a restart. One switch, not two: as built, the collector and
   the endpoint are one component.
 
-### D11. XID mechanism (closes Open-2)
+### D9. XID mechanism (closes Open-2)
 
 XID critical errors are captured via the **NVML event API**
 (`nvmlDeviceRegisterEvents` + a listener thread) and exported as

--- a/docs/adr/mlnode-monitoring-metrics-v1.md
+++ b/docs/adr/mlnode-monitoring-metrics-v1.md
@@ -95,22 +95,40 @@ paths, hostnames, IPs and ports in label values.
 
 ### D5. dapi public endpoint format
 
-- **Aggregated** endpoint `GET /v1/metrics` on the public Echo server
-  (:9000, exposed through the existing nginx `/v1/*` location).
-- Response: Prometheus text exposition; all ML-node series of this network
-  node with an added `node_id` label and **per-sample timestamps** (ms) set
-  to the collection time — a silent node is served with its old timestamp.
-- A node answering 404/timeout/`off` is simply absent (no zero stubs).
+- **Aggregated** endpoint `GET /v1/mlnodes/metrics` on the public server,
+  exposed through dedicated exact-match nginx locations rather than the generic
+  `/v1/*` one (see D6).
+- Response: Prometheus text exposition; all ML-node series of this network node
+  with an added `node_id` label. Staleness is conveyed by the exporter's own
+  `mlnode_source_scrape_timestamp_seconds` plus `mlnode_up`, rather than by
+  per-sample timestamps — as built, dapi does not stamp samples.
+- Three states: `mlnode_up{node_id} 1` scraped fine; `0` reachable but the
+  scrape failed or exceeded a ceiling; a node answering 404 (metrics off, or an
+  image predating the exporter) is absent entirely, with no zero stubs and no
+  up-series. The last case is what makes a dapi-first rollout safe.
+
+**As-built deviation.** This ADR specified a background poller (45 s cadence,
+≤5 min buffer, per-sample timestamps). The implementation is a pull-through
+cache instead: a merged snapshot is cached 10 s and rebuilds are
+single-flighted, so N external scrapers still cost the ML nodes one fan-out per
+TTL, and there is no polling while nobody is looking. The staleness signals the
+poller design wanted are covered by the two metrics above.
 - Rejected alternative: per-node endpoints (consumers would need discovery;
   one scrape per network node is the point).
 
 ### D6. Rate limit
 
-Echo `RateLimiter` middleware (in-memory, per-IP — existing repo pattern):
-**rate 1 req/s, burst 5, expires 3 min** ⇒ 429. Rationale: the useful
-consumer frequency equals the buffer update cadence (45 s); 1 rps leaves
-headroom for retries and several consumers behind one NAT. An optional
-stricter nginx zone is a Phase 2 deliverable only if needed.
+A dedicated nginx zone (`metrics_zone`, per-IP) rather than application
+middleware ⇒ 429 over the limit. Defaults are set in the proxy entrypoint and
+tunable via `METRICS_RATE_LIMIT_RPM` and `METRICS_BURST`.
+
+**As-built deviation.** This ADR specified Echo `RateLimiter` middleware at
+1 req/s burst 5. Enforcing it in the proxy instead keeps scraping consumers out
+of the `api_zone` budget shared with inference and API clients, so exhausting
+one cannot affect the other — and leaves a single source of truth for limits.
+The in-app limiter was dropped accordingly. Residual risk: a deployment that
+strips the shipped proxy runs the endpoint unlimited; compute stays bounded
+regardless by the cached single-flight fan-out.
 
 ### D7. dapi buffer ceilings
 
@@ -146,10 +164,11 @@ stricter nginx zone is a Phase 2 deliverable only if needed.
   the dependency tree as indirect).
 - Exposition: `expfmt` encoder (no client_golang registry — dapi relays
   foreign metrics).
-- Rate limit: Echo middleware (already used in the repo).
-- Kill switches: `ApiConfig` fields (koanf) ⇒
-  `DAPI_API__METRICS_COLLECTOR_ENABLED`, `DAPI_API__METRICS_ENDPOINT_ENABLED`
-  (default `true` from the Phase 5 release); gated in `main.go`.
+- Rate limit: nginx `metrics_zone` in the proxy (see D6).
+- Kill switch: `ApiConfig` field (koanf) ⇒
+  `DAPI_API__MLNODE_METRICS_DISABLED=true`, evaluated per request so it takes
+  effect without a restart. One switch, not two: as built, the collector and
+  the endpoint are one component.
 
 ### D11. XID mechanism (closes Open-2)
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,0 +1,6 @@
+# Decision Log
+
+| Date | Decision | Details |
+| --- | --- | --- |
+| 2026-07-10 | ML-node metrics schema v1: allowlist contract, `GONKA_METRICS=full\|off` (default `full`, `off` => 404), public pull via dapi, no central collection | [ADR](adr/mlnode-monitoring-metrics-v1.md), [operator guide](observability.md) |
+| 2026-07-10 | XID surfaced via NVML event API (works in unprivileged containers); dmesg rejected (host-only) | [ADR](adr/mlnode-monitoring-metrics-v1.md) Open-2 |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,104 @@
+# Gonka ML-node observability (schema v1)
+
+## What this is
+
+Every Gonka network node publishes fresh (≤ 5 min) operational metrics of its
+ML nodes through a public endpoint. There is no central collection: any
+network participant pulls the metrics into their own storage
+(Prometheus/VictoriaMetrics) and builds their own dashboards.
+
+## For ML-node operators
+
+- Export is enabled by default: `GONKA_METRICS=full`.
+- To disable: `GONKA_METRICS=off` — the endpoint answers 404, the node
+  disappears from the network node's public output, inference is unaffected.
+  Values other than `full`/`off` are treated as `full` with a startup warning.
+- What is exported: strictly the fixed schema v1 allowlist below. No request
+  or prompt data, no hostnames/IPs/ports/provider details/local paths. The
+  set changes only with a schema version bump and a changelog entry.
+- The mlnode startup log states the export mode.
+- vLLM vendor telemetry is disabled (`VLLM_NO_USAGE_STATS=1`).
+
+## For network-node operators
+
+- The dapi collector polls ML nodes from its inventory every 45 s (10 s
+  timeout per node), buffers snapshots in memory for ≤ 5 min and serves them
+  on the public `GET /v1/metrics` with a rate limit (1 req/s, burst 5,
+  per-IP ⇒ 429).
+- Kill switches without a release restart:
+  `DAPI_API__METRICS_COLLECTOR_ENABLED=false`,
+  `DAPI_API__METRICS_ENDPOINT_ENABLED=false`.
+- ML nodes on pre-metrics images (404) are silently absent from the output.
+
+## For consumers
+
+- `GET https://<network-node>/v1/metrics` — Prometheus text exposition, all
+  ML nodes of that network node, label `node_id`, per-sample timestamps
+  (collection time; an aging timestamp = the node went silent or its vLLM is
+  hung).
+- Use `rate()`/`increase()` on counters: a vLLM restart (model switch)
+  resets them.
+- Aggregate request-length histograms per model only (buckets depend on
+  `max_model_len`).
+- The network phase (inference/PoC) is not part of the metrics — join it
+  from chain data (reference example: Phase 3 deliverable).
+
+## Schema v1 (allowlist)
+
+The schema version is announced by the series
+`gonka_metrics_schema_info{version="1"}`.
+
+### vLLM (labels: `model_name` — served name, `replica`)
+
+P0: `vllm:num_requests_waiting`, `vllm:num_requests_running`,
+`vllm:kv_cache_usage_perc`, `vllm:num_preemptions_total`,
+`vllm:time_to_first_token_seconds`, `vllm:request_queue_time_seconds`,
+`vllm:prompt_tokens_total`, `vllm:generation_tokens_total`,
+`vllm:request_success_total{finished_reason}`.
+
+P1: `vllm:inter_token_latency_seconds`, `vllm:e2e_request_latency_seconds`,
+`vllm:prefix_cache_queries_total`, `vllm:prefix_cache_hits_total`,
+`vllm:request_prompt_tokens`, `vllm:request_generation_tokens`,
+`vllm:iteration_tokens_total`, `vllm:cache_config_info`.
+
+`replica` is the positional index of the vLLM instance on the node. The
+internal vLLM `engine` label is dropped; `model_name` is normalized to the
+served model name (never a local cache path).
+
+### GPU / host (labels: `gpu_index`, `gpu_model`; no sensor ⇒ no series)
+
+`mlnode_gpu_temp_core_celsius`, `mlnode_gpu_temp_hbm_celsius`,
+`mlnode_gpu_power_draw_watts`, `mlnode_gpu_power_limit_watts`,
+`mlnode_gpu_sm_clock_hertz`, `mlnode_gpu_sm_clock_max_hertz`,
+`mlnode_gpu_clocks_event_reasons`, `mlnode_gpu_memory_used_bytes`,
+`mlnode_gpu_memory_free_bytes`, `mlnode_gpu_ecc_dbe_total`,
+`mlnode_gpu_pcie_replay_total`,
+`mlnode_gpu_xid_events_total{gpu_index,xid}` (counter of XID critical errors
+observed via the NVML event API since process start; no events ⇒ no series),
+`mlnode_host_cpu_busy_ratio`, `mlnode_host_cpu_steal_ratio`,
+`mlnode_host_memory_used_bytes`, `mlnode_host_memory_limit_bytes` (cgroup
+v2 with a v1 fallback; no limit configured ⇒ no series),
+`mlnode_host_hf_cache_free_bytes`.
+
+Note: `utilization.gpu` is deliberately NOT exported as a saturation metric
+(memory-bound decode and PoC both show 100% with half-idle SMs).
+
+### Service series
+
+- `mlnode_config_info{model_name, dtype, replicas, max_num_seqs,
+  max_model_len, tensor_parallel_size, pipeline_parallel_size}` — an empty
+  numeric label value means the argument was not passed explicitly and the
+  effective vLLM default is unknown to mlnode; consumers cannot compute the
+  saturation ratio for such nodes.
+- `mlnode_version_info{version}`.
+- `mlnode_source_scrape_timestamp_seconds{source}` with
+  `source="vllm"|"nvml"|"host"`; the vLLM source additionally carries a
+  `replica` label so a single hung replica is detectable by its aging
+  timestamp.
+- `gonka_metrics_schema_info{version}`.
+
+## Changelog
+
+- v1 (2026-07-10): initial schema.
+- v1 (2026-07-14): exporter-owned families now carry `# HELP`/`# TYPE`
+  metadata (counters typed as counters end-to-end); no series change.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -21,21 +21,30 @@ network participant pulls the metrics into their own storage
 
 ## For network-node operators
 
-- The dapi collector polls ML nodes from its inventory every 45 s (10 s
-  timeout per node), buffers snapshots in memory for ≤ 5 min and serves them
-  on the public `GET /v1/metrics` with a rate limit (1 req/s, burst 5,
-  per-IP ⇒ 429).
-- Kill switches without a release restart:
-  `DAPI_API__METRICS_COLLECTOR_ENABLED=false`,
-  `DAPI_API__METRICS_ENDPOINT_ENABLED=false`.
-- ML nodes on pre-metrics images (404) are silently absent from the output.
+- dapi federates the ML nodes of its inventory on the public
+  `GET /v1/mlnodes/metrics`. It scrapes them on demand rather than on a timer:
+  a merged snapshot is cached for 10 s and rebuilds are single-flighted, so any
+  number of external scrapers costs the ML nodes at most one fan-out per TTL.
+- Per-node ceilings: 2 MiB of body and 5000 series. A node over either is
+  rejected and reported down rather than allowed to inflate the output.
+- Rate limiting lives in the proxy's dedicated nginx `metrics_zone`, not in the
+  application, so scrapers never compete with inference clients for the same
+  budget. Defaults are per-IP and tunable via `METRICS_RATE_LIMIT_RPM` and
+  `METRICS_BURST`; over the limit is a 429.
+- Kill switch without a rebuild: `DAPI_API__MLNODE_METRICS_DISABLED=true`.
+- Three-state node semantics: `mlnode_up{node_id} 1` scraped fine,
+  `mlnode_up{node_id} 0` reachable but the scrape failed or was over a ceiling,
+  and a node answering 404 — metrics off, or an image predating the exporter —
+  is absent from the output entirely, with no zeros and no up-series. That is
+  what makes the dapi-first upgrade order safe.
 
 ## For consumers
 
-- `GET https://<network-node>/v1/metrics` — Prometheus text exposition, all
-  ML nodes of that network node, label `node_id`, per-sample timestamps
-  (collection time; an aging timestamp = the node went silent or its vLLM is
-  hung).
+- `GET https://<network-node>/v1/mlnodes/metrics` — Prometheus text exposition,
+  all ML nodes of that network node, label `node_id`. Staleness is visible two
+  ways: `mlnode_source_scrape_timestamp_seconds` stops advancing when a node's
+  vLLM hangs (the node keeps serving its last good copy), and `mlnode_up` drops
+  to 0 when the node itself stops answering.
 - Use `rate()`/`increase()` on counters: a vLLM restart (model switch)
   resets them.
 - Aggregate request-length histograms per model only (buckets depend on

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -41,10 +41,10 @@ network participant pulls the metrics into their own storage
 ## For consumers
 
 - `GET https://<network-node>/v1/mlnodes/metrics` — Prometheus text exposition,
-  all ML nodes of that network node, label `node_id`. Staleness is visible two
-  ways: `mlnode_source_scrape_timestamp_seconds` stops advancing when a node's
-  vLLM hangs (the node keeps serving its last good copy), and `mlnode_up` drops
-  to 0 when the node itself stops answering.
+  all ML nodes of that network node, label `node_id`. A source timestamp stops
+  when that source can no longer be scraped; `mlnode_up` drops to 0 when the
+  node exporter itself stops answering. Scheduler progress is represented by
+  `vllm:iteration_tokens_total` together with the running/waiting gauges.
 - Use `rate()`/`increase()` on counters: a vLLM restart (model switch)
   resets them.
 - Aggregate request-length histograms per model only (buckets depend on
@@ -102,8 +102,7 @@ Note: `utilization.gpu` is deliberately NOT exported as a saturation metric
 - `mlnode_version_info{version}`.
 - `mlnode_source_scrape_timestamp_seconds{source}` with
   `source="vllm"|"nvml"|"host"`; the vLLM source additionally carries a
-  `replica` label so a single hung replica is detectable by its aging
-  timestamp.
+  `replica` label so a failed replica scrape is individually visible.
 - `gonka_metrics_schema_info{version}`.
 
 ## Changelog

--- a/mlnode/packages/api/src/api/app.py
+++ b/mlnode/packages/api/src/api/app.py
@@ -27,21 +27,39 @@ from api.service_management import (
     API_PREFIX
 )
 from api.routes import router as api_router
+from api.metrics.routes import router as metrics_router, metrics_enabled
+from api.metrics.allowlist import SCHEMA_VERSION, VLLM_ALLOWLIST
+from api.metrics import xid_source
 from api.watcher import watch_managers
 from api.proxy import ProxyMiddleware, start_vllm_proxy, stop_vllm_proxy, setup_vllm_proxy, start_backward_compatibility, stop_backward_compatibility
 
+from common.logger import create_logger
+
+logger = create_logger(__name__)
 
 WATCH_INTERVAL = 2
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Honesty mechanics: operators must see the export mode in the startup log
+    if metrics_enabled():
+        logger.info(
+            f"metrics export: GONKA_METRICS=full, schema v{SCHEMA_VERSION}, "
+            f"{len(VLLM_ALLOWLIST)} vLLM families + GPU/host"
+        )
+    else:
+        logger.info("metrics export: GONKA_METRICS=off, /api/v1/metrics disabled")
+
     app.state.service_state = ServiceState.STOPPED
     app.state.pow_manager = PowManager()
     app.state.inference_manager = InferenceManager()
     app.state.train_manager = TrainManager()
     app.state.model_manager = ModelManager()
     app.state.gpu_manager = GPUManager()
+
+    if metrics_enabled() and app.state.gpu_manager.is_cuda_available():
+        xid_source.start()
 
     await start_vllm_proxy()
 
@@ -67,6 +85,7 @@ async def lifespan(app: FastAPI):
     if app.state.train_manager.is_running():
         app.state.train_manager.stop()
 
+    xid_source.stop()
     app.state.gpu_manager._shutdown_nvml()
 
     await stop_vllm_proxy()
@@ -117,6 +136,15 @@ app.include_router(
     api_router,
     prefix=API_PREFIX,
     tags=["API"],
+)
+
+# Always registered; GONKA_METRICS=off makes the handler answer 404 so a
+# disabled node looks identical to a pre-metrics image (no conflict check:
+# metrics must work in any service state).
+app.include_router(
+    metrics_router,
+    prefix=API_PREFIX,
+    tags=["Metrics"],
 )
 
 app.include_router(

--- a/mlnode/packages/api/src/api/gpu/manager.py
+++ b/mlnode/packages/api/src/api/gpu/manager.py
@@ -126,6 +126,90 @@ class GPUManager:
     async def get_devices_async(self) -> List[GPUDevice]:
         return await asyncio.to_thread(self.get_devices)
 
+    @staticmethod
+    def _try_sensor(fn, *args):
+        """Missing sensor => None => the metric series is simply absent."""
+        try:
+            return fn(*args)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _read_hbm_temp(handle):
+        value = pynvml.nvmlDeviceGetFieldValues(
+            handle, [pynvml.NVML_FI_DEV_MEMORY_TEMP])[0]
+        temp = value.value.uiVal
+        if value.nvmlReturn != pynvml.NVML_SUCCESS or not 0 < temp < 200:
+            return None
+        return temp
+
+    # Schema v1 GPU fields: metric name -> reader(handle). Missing sensor or
+    # unsupported call => None => no series (e.g. HBM temp / ECC on GDDR cards).
+    # Throttle bitmask was renamed ThrottleReasons -> ClocksEventReasons in
+    # newer NVML; HBM temp only exists via field values (no MEMORY member in
+    # the temperature enum of nvidia-ml-py).
+    _METRIC_READERS = {
+        "mlnode_gpu_temp_core_celsius":
+            lambda h: pynvml.nvmlDeviceGetTemperature(h, pynvml.NVML_TEMPERATURE_GPU),
+        "mlnode_gpu_temp_hbm_celsius":
+            lambda h: GPUManager._read_hbm_temp(h),
+        "mlnode_gpu_power_draw_watts":
+            lambda h: pynvml.nvmlDeviceGetPowerUsage(h) / 1000.0,
+        "mlnode_gpu_power_limit_watts":
+            lambda h: pynvml.nvmlDeviceGetEnforcedPowerLimit(h) / 1000.0,
+        "mlnode_gpu_sm_clock_hertz":
+            lambda h: pynvml.nvmlDeviceGetClockInfo(h, pynvml.NVML_CLOCK_SM) * 1e6,
+        "mlnode_gpu_sm_clock_max_hertz":
+            lambda h: pynvml.nvmlDeviceGetMaxClockInfo(h, pynvml.NVML_CLOCK_SM) * 1e6,
+        "mlnode_gpu_clocks_event_reasons": lambda h: (
+            getattr(pynvml, "nvmlDeviceGetCurrentClocksEventReasons", None)
+            or pynvml.nvmlDeviceGetCurrentClocksThrottleReasons
+        )(h),
+        "mlnode_gpu_ecc_dbe_total":
+            lambda h: pynvml.nvmlDeviceGetTotalEccErrors(
+                h, pynvml.NVML_MEMORY_ERROR_TYPE_UNCORRECTED, pynvml.NVML_AGGREGATE_ECC),
+        "mlnode_gpu_pcie_replay_total":
+            lambda h: pynvml.nvmlDeviceGetPcieReplayCounter(h),
+    }
+
+    def collect_metrics(self) -> List[dict]:
+        """Per-GPU raw fields for the metrics exporter (schema v1).
+
+        Returns one dict per GPU: {"gpu_index", "gpu_model", "fields"} where
+        fields holds only the sensors this environment actually exposes.
+        """
+        if not self._nvml_initialized:
+            return []
+
+        try:
+            device_count = pynvml.nvmlDeviceGetCount()
+        except Exception as e:
+            logger.error(f"Error enumerating GPU devices for metrics: {e}")
+            return []
+
+        samples = []
+        for i in range(device_count):
+            handle = self._try_sensor(pynvml.nvmlDeviceGetHandleByIndex, i)
+            if handle is None:
+                continue
+            name = self._try_sensor(pynvml.nvmlDeviceGetName, handle) or "Unknown"
+            fields = {
+                metric: float(value)
+                for metric, reader in self._METRIC_READERS.items()
+                if (value := self._try_sensor(reader, handle)) is not None
+            }
+            # One atomic memory snapshot feeding both fields (both-or-neither)
+            mem_info = self._try_sensor(pynvml.nvmlDeviceGetMemoryInfo, handle)
+            if mem_info is not None:
+                fields["mlnode_gpu_memory_used_bytes"] = float(mem_info.used)
+                fields["mlnode_gpu_memory_free_bytes"] = float(mem_info.free)
+            samples.append({"gpu_index": str(i), "gpu_model": name, "fields": fields})
+
+        return samples
+
+    async def collect_metrics_async(self) -> List[dict]:
+        return await asyncio.to_thread(self.collect_metrics)
+
     def get_driver_info(self) -> DriverInfo:
         """
         Get CUDA driver version information from NVML.

--- a/mlnode/packages/api/src/api/health.py
+++ b/mlnode/packages/api/src/api/health.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from typing import List, Dict, Any
 
@@ -64,7 +65,7 @@ async def get_health_data(request: Request) -> HealthResponse:
         ),
         inference=ManagerStatus(
             running=inference_manager.is_running(),
-            healthy=inference_manager.is_healthy(),
+            healthy=await asyncio.to_thread(inference_manager.is_healthy),
         ),
         train=ManagerStatus(
             running=train_manager.is_running(), healthy=train_manager.is_healthy()
@@ -125,7 +126,7 @@ async def get_readiness(request: Request, response: Response):
     is_ready = True
     # If inference is the active service, readiness depends on its health
     if request.app.state.service_state == ServiceState.INFERENCE:
-        if not inference_manager.is_healthy():
+        if not await asyncio.to_thread(inference_manager.is_healthy):
             is_ready = False
     
     # Add similar checks for POW and TRAIN if they have specific readiness requirements

--- a/mlnode/packages/api/src/api/inference/manager.py
+++ b/mlnode/packages/api/src/api/inference/manager.py
@@ -48,7 +48,7 @@ class InferenceManager(IManager):
     ):
         if self.is_running():
             raise Exception("VLLMRunner is already running. Stop it first.")
-        
+
         self.vllm_runner = self.runner_class(
             model=init_request.model,
             dtype=init_request.dtype,
@@ -116,7 +116,7 @@ class InferenceManager(IManager):
             self._startup_task = None
             self._exception = None
             proxy_module.shutdown_event.clear()
-            
+
             # Update state to reflect completion
             with self._lock:
                 self._state = ManagerState.STOPPED

--- a/mlnode/packages/api/src/api/inference/vllm/runner.py
+++ b/mlnode/packages/api/src/api/inference/vllm/runner.py
@@ -64,6 +64,21 @@ class VLLMRunner(IVLLMRunner):
         self.additional_args = additional_args or []
         self.processes: List[subprocess.Popen] = []
 
+    def get_config_summary(self) -> dict:
+        """Public config snapshot for observability (metrics exporter).
+
+        Zero for the numeric fields means "not passed explicitly" — the
+        effective vLLM default is not known to mlnode.
+        """
+        return {
+            "model": self.model,
+            "dtype": self.dtype,
+            "max_num_seqs": self._get_arg_value("--max-num-seqs", default=0),
+            "max_model_len": self._get_arg_value("--max-model-len", default=0),
+            "tensor_parallel_size": self._get_arg_value("--tensor-parallel-size", default=0),
+            "pipeline_parallel_size": self._get_arg_value("--pipeline-parallel-size", default=0),
+        }
+
     def _get_arg_value(self, name: str, default: int = 1) -> int:
         if name in self.additional_args:
             try:
@@ -129,6 +144,8 @@ class VLLMRunner(IVLLMRunner):
 
             env = os.environ.copy()
             env["VLLM_USE_V1"] = "0"
+            # Metrics trust contract: no vendor telemetry from vLLM
+            env["VLLM_NO_USAGE_STATS"] = "1"
 
             start_gpu = i * gpus_per_instance
             if total_gpus > 0:

--- a/mlnode/packages/api/src/api/inference/vllm/runner.py
+++ b/mlnode/packages/api/src/api/inference/vllm/runner.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import time
 import requests
@@ -22,6 +23,87 @@ WAIT_FOR_SERVER_TIMEOUT = 1200
 WAIT_FOR_SERVER_CHECK_INTERVAL = 3
 
 logger = create_logger(__name__)
+
+HANG_CONSECUTIVE = 3
+
+# (metric suffix, cross-series reduce). Sum/max across ALL series: /metrics
+# can briefly expose several registries mid-restart.
+_HEARTBEAT_SERIES = (
+    ("iteration_tokens_total_count", sum),
+    ("num_requests_running", max),
+    ("num_requests_waiting", max),
+)
+
+
+def _int_env(name: str, default: int) -> int:
+    """os.environ[name] as int; unset/empty -> default, garbage -> default + warning."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer -- using %d", name, raw, default)
+        return default
+
+
+def _scrape_heartbeat(host: str, port: int):
+    """(iters, running, waiting) floats from /metrics; None per unreadable value.
+    Raises requests.ConnectionError when the instance is unreachable (dead)."""
+    try:
+        txt = requests.get(f"http://{host}:{port}/metrics", timeout=3).text
+    except requests.exceptions.ConnectTimeout:
+        # Saturation, not death: the caller's grace window decides.
+        return None, None, None
+    except requests.ConnectionError:
+        raise
+    except Exception:
+        return None, None, None
+    values = []
+    for name, reduce_fn in _HEARTBEAT_SERIES:
+        try:
+            series = re.findall(rf"(?m)^vllm:{name}\S*\s+([0-9eE.+-]+)", txt)
+            values.append(reduce_fn(float(x) for x in series) if series else None)
+        except Exception:
+            values.append(None)
+    return tuple(values)
+
+
+def _heartbeat_verdict(port: int, st: dict, iters, running, waiting, now: float, grace: int) -> bool:
+    """Advance one port's heartbeat state (mutates st); True = instance alive.
+    Branch order is semantic -- reorder only with the unit tests in hand."""
+    read_ok = iters is not None or running is not None or waiting is not None
+    has_work = (running is not None and running > 0) or (waiting is not None and waiting > 0)
+    # Fresh baseline on either: legitimate idle (readable scrape, no work) or a
+    # stepping engine -- ANY counter change counts, including the reset after an
+    # engine restart (a ">" test would false-HUNG on the stale high baseline).
+    # A blind scrape (all None) is neither: refreshing on it would silently
+    # disable hang detection.
+    if (read_ok and not has_work) or (
+        iters is not None and (st["iter"] is None or iters != st["iter"])
+    ):
+        st["ts"] = now
+        st["iter"] = iters
+        st["hung"] = 0
+        return True
+    if iters is None:
+        # Counter unreadable: alive only within grace.
+        return now - st["ts"] <= grace
+    if now - st["ts"] > grace:
+        # Frozen with work past grace: require consecutive verdicts so one
+        # confused scrape cannot start the restart escalation.
+        st["hung"] += 1
+        if st["hung"] >= HANG_CONSECUTIVE:
+            logger.error(
+                "vLLM instance on port %s: scheduler heartbeat frozen >%ss "
+                "over %d consecutive checks with running=%s waiting=%s -- "
+                "reporting unhealthy for restart",
+                port, grace, st["hung"], running, waiting,
+            )
+            return False
+        return True
+    st["hung"] = 0
+    return True
 
 
 class IVLLMRunner(ITrackableTask):
@@ -63,6 +145,7 @@ class VLLMRunner(IVLLMRunner):
         self.dtype = dtype
         self.additional_args = additional_args or []
         self.processes: List[subprocess.Popen] = []
+        self._hb = {}  # per-port heartbeat state; outlives engine restarts
 
     def get_config_summary(self) -> dict:
         """Public config snapshot for observability (metrics exporter).
@@ -241,15 +324,28 @@ class VLLMRunner(IVLLMRunner):
     def is_available(self) -> bool:
         if not self.is_running():
             return False
-        try:
-            # Check if any backend is available
-            for port in range(self.VLLM_PORT + 1, self.VLLM_PORT + len(self.processes) + 1):
-                resp = requests.get(f"http://{self.VLLM_HOST}:{port}/health", timeout=2)
-                if resp.status_code == 200:
-                    return True
-            return False
-        except (requests.ConnectionError, requests.Timeout):
-            return False
+        # Scheduler-heartbeat liveness. vLLM /health returns 200 even when the
+        # scheduler is deadlocked (check_health only reads the `errored` flag)
+        # and misses its deadline while merely busy. The iteration counter
+        # advances on every engine step and freezes only on a real stall; the
+        # grace window also absorbs the counter's observed pre-stall flatline.
+        grace = _int_env("MLNODE_HANG_GRACE_SEC", 120)
+        now = time.time()
+        healthy = True
+        # Check every instance: a hang must not hide behind a healthy sibling.
+        for port in range(self.VLLM_PORT + 1, self.VLLM_PORT + len(self.processes) + 1):
+            try:
+                iters, running, waiting = _scrape_heartbeat(self.VLLM_HOST, port)
+            except requests.ConnectionError:
+                # Refused/unreachable -> this instance is dead.
+                return False
+            st = self._hb.setdefault(port, {"ts": now, "iter": iters, "hung": 0})
+            if grace <= 0:
+                # Detection disabled: only process death / refusal mark unhealthy.
+                continue
+            ok = _heartbeat_verdict(port, st, iters, running, waiting, now, grace)
+            healthy = healthy and ok
+        return healthy
 
     def get_error_if_exist(self) -> Optional[str]:
         for p in self.processes:

--- a/mlnode/packages/api/src/api/inference/vllm/runner.py
+++ b/mlnode/packages/api/src/api/inference/vllm/runner.py
@@ -9,6 +9,8 @@ import shutil
 import shlex
 import psutil
 import signal
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Optional, List
 from abc import abstractmethod
@@ -48,10 +50,11 @@ def _int_env(name: str, default: int) -> int:
 
 
 def _scrape_heartbeat(host: str, port: int):
-    """(iters, running, waiting) floats from /metrics; None per unreadable value.
-    Raises requests.ConnectionError when the instance is unreachable (dead)."""
+    """Read the scheduler heartbeat values from one vLLM replica."""
     try:
-        txt = requests.get(f"http://{host}:{port}/metrics", timeout=3).text
+        response = requests.get(f"http://{host}:{port}/metrics", timeout=3)
+        response.raise_for_status()
+        txt = response.text
     except requests.exceptions.ConnectTimeout:
         # Saturation, not death: the caller's grace window decides.
         return None, None, None
@@ -69,40 +72,52 @@ def _scrape_heartbeat(host: str, port: int):
     return tuple(values)
 
 
-def _heartbeat_verdict(port: int, st: dict, iters, running, waiting, now: float, grace: int) -> bool:
-    """Advance one port's heartbeat state (mutates st); True = instance alive.
-    Branch order is semantic -- reorder only with the unit tests in hand."""
-    read_ok = iters is not None or running is not None or waiting is not None
-    has_work = (running is not None and running > 0) or (waiting is not None and waiting > 0)
-    # Fresh baseline on either: legitimate idle (readable scrape, no work) or a
-    # stepping engine -- ANY counter change counts, including the reset after an
-    # engine restart (a ">" test would false-HUNG on the stale high baseline).
-    # A blind scrape (all None) is neither: refreshing on it would silently
-    # disable hang detection.
-    if (read_ok and not has_work) or (
-        iters is not None and (st["iter"] is None or iters != st["iter"])
-    ):
+def _scrape_heartbeats(host: str, ports: list[int]):
+    """Scrape every replica within one per-request timeout window."""
+    with ThreadPoolExecutor(max_workers=len(ports)) as pool:
+        futures = {port: pool.submit(_scrape_heartbeat, host, port) for port in ports}
+        return {port: future.result() for port, future in futures.items()}
+
+
+def _heartbeat_verdict(
+    port: int, st: dict, iters, running, waiting, now: float, grace: int
+) -> bool:
+    """Advance one replica's heartbeat state and return its liveness."""
+    if grace <= 0:
+        return True
+
+    complete = all(value is not None for value in (iters, running, waiting))
+    if not st["seen"]:
+        if not complete:
+            return False
+        st.update(ts=now, iter=iters, hung=0, seen=True)
+        return True
+
+    idle = complete and running == 0 and waiting == 0
+    progressed = iters is not None and iters != st["iter"]
+    if idle or progressed:
         st["ts"] = now
         st["iter"] = iters
         st["hung"] = 0
         return True
-    if iters is None:
-        # Counter unreadable: alive only within grace.
-        return now - st["ts"] <= grace
-    if now - st["ts"] > grace:
-        # Frozen with work past grace: require consecutive verdicts so one
-        # confused scrape cannot start the restart escalation.
-        st["hung"] += 1
-        if st["hung"] >= HANG_CONSECUTIVE:
-            logger.error(
-                "vLLM instance on port %s: scheduler heartbeat frozen >%ss "
-                "over %d consecutive checks with running=%s waiting=%s -- "
-                "reporting unhealthy for restart",
-                port, grace, st["hung"], running, waiting,
-            )
-            return False
+
+    if now - st["ts"] <= grace:
+        st["hung"] = 0
         return True
-    st["hung"] = 0
+
+    st["hung"] += 1
+    if st["hung"] >= HANG_CONSECUTIVE:
+        logger.error(
+            "vLLM instance on port %s: scheduler heartbeat frozen >%ss "
+            "over %d consecutive checks with running=%s waiting=%s -- "
+            "reporting unhealthy for restart",
+            port,
+            grace,
+            st["hung"],
+            running,
+            waiting,
+        )
+        return False
     return True
 
 
@@ -145,7 +160,8 @@ class VLLMRunner(IVLLMRunner):
         self.dtype = dtype
         self.additional_args = additional_args or []
         self.processes: List[subprocess.Popen] = []
-        self._hb = {}  # per-port heartbeat state; outlives engine restarts
+        self._hb = {}
+        self._hb_lock = threading.Lock()
 
     def get_config_summary(self) -> dict:
         """Public config snapshot for observability (metrics exporter).
@@ -207,6 +223,9 @@ class VLLMRunner(IVLLMRunner):
 
         self._verify_and_fix_env()
 
+        vllm_module = os.getenv(
+            "MLNODE_VLLM_MODULE", "vllm.entrypoints.openai.api_server"
+        )
         backend_ports = []
         for i in range(instances):
             sleep_time = 5 * i
@@ -214,7 +233,7 @@ class VLLMRunner(IVLLMRunner):
             backend_ports.append(port)
             vllm_command = [
                 self.vllm_python_path,
-                "-m", "vllm.entrypoints.openai.api_server",
+                "-m", vllm_module,
                 "--model", self.model,
                 "--dtype", self.dtype,
                 "--port", str(port),
@@ -306,7 +325,8 @@ class VLLMRunner(IVLLMRunner):
 
     def _wait_for_server(self) -> bool:
         start_time = time.time()
-        while time.time() - start_time < WAIT_FOR_SERVER_TIMEOUT:
+        timeout = _int_env("VLLM_RUNNER_TIMEOUT", WAIT_FOR_SERVER_TIMEOUT)
+        while time.time() - start_time < timeout:
             if not self.is_running():
                 raise RuntimeError(f"vLLM process exited prematurely: {self.get_error_if_exist()}")
 
@@ -315,7 +335,7 @@ class VLLMRunner(IVLLMRunner):
 
             time.sleep(WAIT_FOR_SERVER_CHECK_INTERVAL)
 
-        logger.error("vLLM server did not become available within timeout.")
+        logger.error("vLLM server did not become available within %d seconds", timeout)
         return False
 
     def is_running(self) -> bool:
@@ -324,28 +344,31 @@ class VLLMRunner(IVLLMRunner):
     def is_available(self) -> bool:
         if not self.is_running():
             return False
-        # Scheduler-heartbeat liveness. vLLM /health returns 200 even when the
-        # scheduler is deadlocked (check_health only reads the `errored` flag)
-        # and misses its deadline while merely busy. The iteration counter
-        # advances on every engine step and freezes only on a real stall; the
-        # grace window also absorbs the counter's observed pre-stall flatline.
-        grace = _int_env("MLNODE_HANG_GRACE_SEC", 120)
-        now = time.time()
-        healthy = True
-        # Check every instance: a hang must not hide behind a healthy sibling.
-        for port in range(self.VLLM_PORT + 1, self.VLLM_PORT + len(self.processes) + 1):
+        with self._hb_lock:
+            grace = _int_env("MLNODE_HANG_GRACE_SEC", 120)
+            now = time.monotonic()
+            healthy = True
+            ports = list(
+                range(
+                    self.VLLM_PORT + 1,
+                    self.VLLM_PORT + len(self.processes) + 1,
+                )
+            )
             try:
-                iters, running, waiting = _scrape_heartbeat(self.VLLM_HOST, port)
+                scrapes = _scrape_heartbeats(self.VLLM_HOST, ports)
             except requests.ConnectionError:
-                # Refused/unreachable -> this instance is dead.
                 return False
-            st = self._hb.setdefault(port, {"ts": now, "iter": iters, "hung": 0})
-            if grace <= 0:
-                # Detection disabled: only process death / refusal mark unhealthy.
-                continue
-            ok = _heartbeat_verdict(port, st, iters, running, waiting, now, grace)
-            healthy = healthy and ok
-        return healthy
+
+            for port, (iters, running, waiting) in scrapes.items():
+                st = self._hb.setdefault(
+                    port,
+                    {"ts": now, "iter": None, "hung": 0, "seen": False},
+                )
+                ok = _heartbeat_verdict(
+                    port, st, iters, running, waiting, now, grace
+                )
+                healthy = healthy and ok
+            return healthy
 
     def get_error_if_exist(self) -> Optional[str]:
         for p in self.processes:

--- a/mlnode/packages/api/src/api/metrics/allowlist.py
+++ b/mlnode/packages/api/src/api/metrics/allowlist.py
@@ -1,0 +1,35 @@
+"""Metrics schema v1: the allowlist is the contract.
+
+Changing this set (or label semantics) requires a schema version bump and a
+changelog entry. See docs/observability.md.
+"""
+
+SCHEMA_VERSION = "1"
+
+# vLLM metric families exported as-is (after label rewriting).
+# Series names map to a family by stripping _bucket/_sum/_count suffixes.
+VLLM_ALLOWLIST = frozenset({
+    # P0
+    "vllm:num_requests_waiting",
+    "vllm:num_requests_running",
+    "vllm:kv_cache_usage_perc",
+    "vllm:num_preemptions_total",
+    "vllm:time_to_first_token_seconds",
+    "vllm:request_queue_time_seconds",
+    "vllm:prompt_tokens_total",
+    "vllm:generation_tokens_total",
+    "vllm:request_success_total",
+    # P1
+    "vllm:inter_token_latency_seconds",
+    "vllm:e2e_request_latency_seconds",
+    "vllm:prefix_cache_queries_total",
+    "vllm:prefix_cache_hits_total",
+    "vllm:request_prompt_tokens",
+    "vllm:request_generation_tokens",
+    "vllm:iteration_tokens_total",
+    "vllm:cache_config_info",
+})
+
+# Labels stripped from vLLM series: `engine` is an internal index (replica
+# identity is carried by the `replica` label we add ourselves).
+VLLM_DROPPED_LABELS = frozenset({"engine"})

--- a/mlnode/packages/api/src/api/metrics/host_source.py
+++ b/mlnode/packages/api/src/api/metrics/host_source.py
@@ -1,0 +1,126 @@
+"""Host-level metrics: CPU from /proc/stat, memory from cgroup, HF-cache disk.
+
+Memory comes from the cgroup (v2 with v1 fallback), not /proc/meminfo: inside
+a container meminfo shows the host, while the OOM decision is made against the
+cgroup limit. No readable source => no series.
+"""
+
+import os
+import shutil
+import threading
+from typing import Dict, List, Optional, Tuple
+
+from common.logger import create_logger
+
+from api.metrics import render
+
+logger = create_logger(__name__)
+
+PROC_STAT = "/proc/stat"
+CGROUP_V2_BASE = "/sys/fs/cgroup"
+CGROUP_V1_MEM_BASE = "/sys/fs/cgroup/memory"
+
+# Previous /proc/stat sample for ratio computation: (busy, steal, total).
+# collect() runs via asyncio.to_thread, so concurrent scrapes (dapi collector
+# + an operator's own Prometheus) may race on it — guarded by _cpu_lock.
+# Each caller's ratio covers "since whoever scraped last"; that varying-window
+# semantic is acceptable for gauges polled at a fixed cadence.
+_prev_cpu: Optional[Tuple[float, float, float]] = None
+_cpu_lock = threading.Lock()
+
+
+def _read_first_line(path: str) -> Optional[str]:
+    try:
+        with open(path) as f:
+            return f.readline().strip()
+    except OSError:
+        return None
+
+
+def _read_int(path: str) -> Optional[int]:
+    line = _read_first_line(path)
+    if line is None or line == "max":
+        return None
+    try:
+        return int(line)
+    except ValueError:
+        return None
+
+
+def _cpu_sample() -> Optional[Tuple[float, float, float]]:
+    line = _read_first_line(PROC_STAT)
+    if not line or not line.startswith("cpu "):
+        return None
+    fields = [float(x) for x in line.split()[1:]]
+    if len(fields) < 8:
+        return None
+    user, nice, system, idle, iowait, irq, softirq, steal = fields[:8]
+    total = sum(fields[:8])
+    busy = total - idle - iowait
+    return busy, steal, total
+
+
+def collect_cpu() -> Dict[str, float]:
+    """CPU busy/steal ratios over the interval since the previous scrape.
+
+    The first scrape after startup yields no series (no interval yet).
+    """
+    global _prev_cpu
+    sample = _cpu_sample()
+    if sample is None:
+        return {}
+    result: Dict[str, float] = {}
+    with _cpu_lock:
+        if _prev_cpu is not None:
+            d_busy = sample[0] - _prev_cpu[0]
+            d_steal = sample[1] - _prev_cpu[1]
+            d_total = sample[2] - _prev_cpu[2]
+            if d_total > 0:
+                result["mlnode_host_cpu_busy_ratio"] = max(0.0, d_busy / d_total)
+                result["mlnode_host_cpu_steal_ratio"] = max(0.0, d_steal / d_total)
+        _prev_cpu = sample
+    return result
+
+
+def collect_memory() -> Dict[str, float]:
+    """Cgroup v2 (memory.current/memory.max) with a cgroup v1 fallback."""
+    result: Dict[str, float] = {}
+    used = _read_int(os.path.join(CGROUP_V2_BASE, "memory.current"))
+    limit = _read_int(os.path.join(CGROUP_V2_BASE, "memory.max"))
+    if used is None:
+        used = _read_int(os.path.join(CGROUP_V1_MEM_BASE, "memory.usage_in_bytes"))
+        v1_limit = _read_int(os.path.join(CGROUP_V1_MEM_BASE, "memory.limit_in_bytes"))
+        # v1 reports "no limit" as a huge page-aligned number instead of "max"
+        if v1_limit is not None and v1_limit < (1 << 60):
+            limit = v1_limit
+    if used is not None:
+        result["mlnode_host_memory_used_bytes"] = float(used)
+    if limit is not None:
+        result["mlnode_host_memory_limit_bytes"] = float(limit)
+    return result
+
+
+def collect_hf_cache_disk() -> Dict[str, float]:
+    hf_home = os.getenv("HF_HOME", "/root/.cache")
+    try:
+        usage = shutil.disk_usage(hf_home)
+    except OSError:
+        return {}
+    return {"mlnode_host_hf_cache_free_bytes": float(usage.free)}
+
+
+def collect() -> List[str]:
+    lines: List[str] = []
+    values: Dict[str, float] = {}
+    values.update(collect_cpu())
+    values.update(collect_memory())
+    values.update(collect_hf_cache_disk())
+    for name in sorted(values):
+        lines.append(render.series(name, {}, values[name]))
+    return lines
+
+
+def reset():
+    """Forget the previous CPU sample (tests)."""
+    global _prev_cpu
+    _prev_cpu = None

--- a/mlnode/packages/api/src/api/metrics/render.py
+++ b/mlnode/packages/api/src/api/metrics/render.py
@@ -1,0 +1,80 @@
+"""Shared Prometheus text-exposition rendering (single escaping authority)."""
+
+from typing import Dict
+
+from common.logger import create_logger
+
+logger = create_logger(__name__)
+
+
+def escape(value: str) -> str:
+    # backslash first; the text format requires \n escaping in label values —
+    # one raw newline would corrupt the node's whole exposition downstream
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def series(name: str, labels: Dict[str, str], value: float) -> str:
+    if labels:
+        inner = ",".join(f'{k}="{escape(str(v))}"' for k, v in labels.items())
+        return f"{name}{{{inner}}} {value}"
+    return f"{name} {value}"
+
+
+# Metadata for every exporter-owned family (schema v1). The dapi federation
+# re-exports what we emit: without TYPE these all degrade to "untyped" and
+# counters lose counter semantics in strict consumers.
+FAMILY_META = {
+    "gonka_metrics_schema_info": ("gauge", "Metrics schema version exported by this node."),
+    "mlnode_version_info": ("gauge", "mlnode API package version."),
+    "mlnode_config_info": ("gauge", "Effective inference configuration of this node."),
+    "mlnode_source_scrape_timestamp_seconds": ("gauge", "Unix time of the last successful collection per source."),
+    "mlnode_gpu_temp_core_celsius": ("gauge", "GPU core temperature."),
+    "mlnode_gpu_temp_hbm_celsius": ("gauge", "GPU HBM memory temperature (absent on GDDR cards)."),
+    "mlnode_gpu_power_draw_watts": ("gauge", "Current GPU power draw."),
+    "mlnode_gpu_power_limit_watts": ("gauge", "Enforced GPU power limit."),
+    "mlnode_gpu_sm_clock_hertz": ("gauge", "Current SM clock."),
+    "mlnode_gpu_sm_clock_max_hertz": ("gauge", "Maximum SM clock."),
+    "mlnode_gpu_clocks_event_reasons": ("gauge", "NVML clocks event/throttle reasons bitmask."),
+    "mlnode_gpu_memory_used_bytes": ("gauge", "GPU memory used."),
+    "mlnode_gpu_memory_free_bytes": ("gauge", "GPU memory free."),
+    "mlnode_gpu_ecc_dbe_total": ("counter", "Aggregate ECC double-bit errors."),
+    "mlnode_gpu_pcie_replay_total": ("counter", "PCIe replay counter."),
+    "mlnode_gpu_xid_events_total": ("counter", "XID critical errors observed since process start."),
+    "mlnode_host_cpu_busy_ratio": ("gauge", "Host CPU busy fraction since the previous scrape."),
+    "mlnode_host_cpu_steal_ratio": ("gauge", "Host CPU steal fraction since the previous scrape."),
+    "mlnode_host_memory_used_bytes": ("gauge", "Container memory usage from the cgroup."),
+    "mlnode_host_memory_limit_bytes": ("gauge", "Container memory limit from the cgroup (absent when unlimited)."),
+    "mlnode_host_hf_cache_free_bytes": ("gauge", "Free disk space of the HF cache volume."),
+}
+
+
+def _family_of(line: str) -> str:
+    return line.split("{", 1)[0].split(" ", 1)[0]
+
+
+_warned_unlisted: set = set()
+
+
+def grouped_with_meta(lines) -> list:
+    """Group exporter-owned sample lines by family, prefixing HELP/TYPE.
+
+    The exposition format wants a family's samples contiguous under its TYPE
+    header; sources emit per-GPU / per-source, so regrouping happens here.
+    """
+    families: dict = {}
+    for line in lines:
+        families.setdefault(_family_of(line), []).append(line)
+    out = []
+    for family in sorted(families):
+        meta = FAMILY_META.get(family)
+        if meta:
+            kind, help_text = meta
+            out.append(f"# HELP {family} {help_text}")
+            out.append(f"# TYPE {family} {kind}")
+        elif family not in _warned_unlisted:
+            # a family missing here silently degrades to untyped downstream —
+            # schema additions must come with a FAMILY_META entry
+            logger.warning(f"metric family {family} has no FAMILY_META entry")
+            _warned_unlisted.add(family)
+        out.extend(families[family])
+    return out

--- a/mlnode/packages/api/src/api/metrics/routes.py
+++ b/mlnode/packages/api/src/api/metrics/routes.py
@@ -1,0 +1,207 @@
+"""GET /api/v1/metrics — the node metrics exporter (schema v1).
+
+Gated by GONKA_METRICS=full|off (default: full). `off` returns 404 so a
+disabled node is indistinguishable from a node running a pre-metrics image;
+the dapi collector treats both as "not present in the output".
+
+Exports exactly the schema v1 allowlist and never any placement details
+(hostname/IP/ports/provider/local paths) — enforced by unit tests.
+"""
+
+import asyncio
+import os
+import time
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import PlainTextResponse
+
+from common.logger import create_logger
+
+import api.proxy as proxy_module
+from api.metrics import host_source, vllm_source, xid_source
+from api.metrics.allowlist import SCHEMA_VERSION
+from api.metrics import render
+from api.metrics.render import series as _series
+
+logger = create_logger(__name__)
+
+router = APIRouter()
+
+CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+# Budgets for the local (thread-pool) stages. They bound two things: the
+# handler's worst-case response time (which must stay inside the dapi
+# collector's 5 s per-node budget together with the vLLM stage), and the
+# damage of a stalled syscall — a statvfs on a dead HF-cache mount parks a
+# worker forever, so it must cost one leaked worker per stall episode, not
+# one per scrape.
+NVML_TIMEOUT_SECONDS = 1.0
+HOST_TIMEOUT_SECONDS = 1.0
+
+
+# Abandoned-but-still-pending stage tasks, keyed by source name. While a
+# source's previous task is parked on a stalled syscall, new scrapes skip
+# that source instead of parking another worker — the leak is bounded to
+# one worker per source per stall episode.
+_pending_stages: dict = {}
+_warned_stalled: set = set()
+
+
+async def _bounded(coro, timeout: float, source: str):
+    """Await coro for at most timeout seconds, abandoning it on expiry.
+
+    wait_for is useless here: an executor future cannot be cancelled once
+    its thread is running, so wait_for would block until the stalled
+    syscall returns. asyncio.wait lets us walk away instead. The abandoned
+    task is deliberately NOT cancelled: its still-pending state is the very
+    signal the re-entry guard checks (cancelling would mark it done while
+    the worker thread stays parked, and the guard would never engage).
+    """
+    previous = _pending_stages.get(source)
+    if previous is not None:
+        if not previous.done():
+            coro.close()  # skip path: the incoming coroutine is never awaited
+            if source not in _warned_stalled:
+                logger.warning(f"{source} collection still stalled, skipping until it returns")
+                _warned_stalled.add(source)
+            raise TimeoutError(f"{source} collection stalled")
+        _pending_stages.pop(source, None)
+        _warned_stalled.discard(source)
+
+    task = asyncio.ensure_future(coro)
+    # register before any await so a concurrent scraper sees this attempt
+    _pending_stages[source] = task
+    # a late result must not log "Task exception was never retrieved"
+    task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+    done, _ = await asyncio.wait({task}, timeout=timeout)
+    if not done:
+        raise TimeoutError(f"{source} collection exceeded {timeout}s")
+    _pending_stages.pop(source, None)
+    return task.result()
+
+
+_warned_bad_value = False
+_warned_config_info = False
+
+
+def metrics_enabled() -> bool:
+    global _warned_bad_value
+    value = os.getenv("GONKA_METRICS", "full").strip().lower()
+    if value not in ("full", "off") and not _warned_bad_value:
+        logger.warning(
+            f"unrecognized GONKA_METRICS={value!r}, treating as 'full' (valid: full|off)"
+        )
+        _warned_bad_value = True
+    return value != "off"
+
+
+def _config_info_lines(request: Request) -> List[str]:
+    manager = getattr(request.app.state, "inference_manager", None)
+    runner = getattr(manager, "vllm_runner", None) if manager else None
+    if runner is None:
+        return []
+    summary = runner.get_config_summary()
+    labels = {
+        "model_name": vllm_source.normalize_model_name(summary["model"]),
+        "dtype": summary["dtype"],
+        "replicas": str(len(proxy_module.vllm_backend_ports)),
+    }
+    # Empty label value = the argument was not passed explicitly and the
+    # effective vLLM default is not known to mlnode (documented in schema)
+    for label in ("max_num_seqs", "max_model_len",
+                  "tensor_parallel_size", "pipeline_parallel_size"):
+        value = summary[label]
+        labels[label] = str(value) if value else ""
+    return [_series("mlnode_config_info", labels, 1)]
+
+
+_api_version: Optional[str] = None
+
+
+def _version_info_lines() -> List[str]:
+    global _api_version
+    if _api_version is None:
+        try:
+            from importlib.metadata import version
+            _api_version = version("mlnode-api")
+        except Exception:
+            _api_version = "unknown"
+    return [_series("mlnode_version_info", {"version": _api_version}, 1)]
+
+
+@router.get("/metrics")
+async def get_metrics(request: Request):
+    if not metrics_enabled():
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    now = time.time()
+
+    try:
+        vllm_lines, vllm_timestamps = await vllm_source.collect(now)
+    except Exception as e:
+        logger.warning(f"vLLM metrics collection failed: {e}")
+        vllm_lines, vllm_timestamps = [], {}
+
+    # Exporter-owned series; regrouped by family with HELP/TYPE at the end
+    # (vLLM passthrough above carries its own metadata).
+    own: List[str] = [
+        _series("gonka_metrics_schema_info", {"version": SCHEMA_VERSION}, 1)
+    ]
+    for replica, ts in sorted(vllm_timestamps.items()):
+        own.append(
+            _series(
+                "mlnode_source_scrape_timestamp_seconds",
+                {"source": "vllm", "replica": replica},
+                ts,
+            )
+        )
+
+    gpu_manager = getattr(request.app.state, "gpu_manager", None)
+    if gpu_manager is not None:
+        try:
+            samples = await _bounded(
+                gpu_manager.collect_metrics_async(), NVML_TIMEOUT_SECONDS, "NVML"
+            )
+        except Exception as e:
+            logger.warning(f"NVML metrics collection failed: {e}")
+            samples = []
+        for sample in samples:
+            labels = {"gpu_index": sample["gpu_index"], "gpu_model": sample["gpu_model"]}
+            for name, value in sorted(sample["fields"].items()):
+                own.append(_series(name, labels, value))
+        if samples:
+            own.append(
+                _series("mlnode_source_scrape_timestamp_seconds", {"source": "nvml"}, now)
+            )
+
+    own.extend(xid_source.collect())
+
+    try:
+        # /proc reads + disk_usage are blocking I/O; a stalled HF-cache mount
+        # must not freeze the event loop that also serves inference traffic
+        host_lines = await _bounded(
+            asyncio.to_thread(host_source.collect), HOST_TIMEOUT_SECONDS, "host"
+        )
+    except Exception as e:
+        logger.warning(f"host metrics collection failed: {e}")
+        host_lines = []
+    own.extend(host_lines)
+    if host_lines:
+        own.append(
+            _series("mlnode_source_scrape_timestamp_seconds", {"source": "host"}, now)
+        )
+
+    global _warned_config_info
+    try:
+        own.extend(_config_info_lines(request))
+    except Exception as e:
+        # warn once: on fork images whose runner lacks the accessor this is
+        # a permanent condition, not a per-scrape event
+        if not _warned_config_info:
+            logger.warning(f"config info collection failed: {e}")
+            _warned_config_info = True
+    own.extend(_version_info_lines())
+
+    lines = vllm_lines + render.grouped_with_meta(own)
+    return PlainTextResponse("\n".join(lines) + "\n", media_type=CONTENT_TYPE)

--- a/mlnode/packages/api/src/api/metrics/routes.py
+++ b/mlnode/packages/api/src/api/metrics/routes.py
@@ -1,11 +1,7 @@
-"""GET /api/v1/metrics — the node metrics exporter (schema v1).
+"""Schema-v1 node metrics exporter.
 
-Gated by GONKA_METRICS=full|off (default: full). `off` returns 404 so a
-disabled node is indistinguishable from a node running a pre-metrics image;
-the dapi collector treats both as "not present in the output".
-
-Exports exactly the schema v1 allowlist and never any placement details
-(hostname/IP/ports/provider/local paths) — enforced by unit tests.
+GONKA_METRICS=off returns 404. Output is restricted to the schema allowlist
+and excludes placement details.
 """
 
 import asyncio
@@ -30,34 +26,18 @@ router = APIRouter()
 
 CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
-# Budgets for the local (thread-pool) stages. They bound two things: the
-# handler's worst-case response time (which must stay inside the dapi
-# collector's 5 s per-node budget together with the vLLM stage), and the
-# damage of a stalled syscall — a statvfs on a dead HF-cache mount parks a
-# worker forever, so it must cost one leaked worker per stall episode, not
-# one per scrape.
+# Keep the sequential stages within dapi's 5 s per-node budget.
 NVML_TIMEOUT_SECONDS = 1.0
 HOST_TIMEOUT_SECONDS = 1.0
 
 
-# Abandoned-but-still-pending stage tasks, keyed by source name. While a
-# source's previous task is parked on a stalled syscall, new scrapes skip
-# that source instead of parking another worker — the leak is bounded to
-# one worker per source per stall episode.
+# A pending task prevents repeated workers for the same stalled source.
 _pending_stages: dict = {}
 _warned_stalled: set = set()
 
 
 async def _bounded(coro, timeout: float, source: str):
-    """Await coro for at most timeout seconds, abandoning it on expiry.
-
-    wait_for is useless here: an executor future cannot be cancelled once
-    its thread is running, so wait_for would block until the stalled
-    syscall returns. asyncio.wait lets us walk away instead. The abandoned
-    task is deliberately NOT cancelled: its still-pending state is the very
-    signal the re-entry guard checks (cancelling would mark it done while
-    the worker thread stays parked, and the guard would never engage).
-    """
+    """Bound a stage without cancelling its possibly stalled worker."""
     previous = _pending_stages.get(source)
     if previous is not None:
         if not previous.done():
@@ -70,14 +50,13 @@ async def _bounded(coro, timeout: float, source: str):
         _warned_stalled.discard(source)
 
     task = asyncio.ensure_future(coro)
-    # register before any await so a concurrent scraper sees this attempt
     _pending_stages[source] = task
-    # a late result must not log "Task exception was never retrieved"
     task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
     done, _ = await asyncio.wait({task}, timeout=timeout)
     if not done:
         raise TimeoutError(f"{source} collection exceeded {timeout}s")
-    _pending_stages.pop(source, None)
+    if _pending_stages.get(source) is task:
+        _pending_stages.pop(source, None)
     return task.result()
 
 

--- a/mlnode/packages/api/src/api/metrics/vllm_source.py
+++ b/mlnode/packages/api/src/api/metrics/vllm_source.py
@@ -1,0 +1,178 @@
+"""Fetch, filter and relabel vLLM /metrics from backend replicas.
+
+Only families from the allowlist pass through. The `model_name` label value is
+normalized to the served model name: vLLM reports the local HF-cache path when
+the model was loaded from disk, and local paths must never leave the node.
+"""
+
+import asyncio
+import re
+from typing import Dict, List, Optional, Tuple
+
+from common.logger import create_logger
+
+import api.proxy as proxy_module
+from api.metrics.allowlist import VLLM_ALLOWLIST, VLLM_DROPPED_LABELS
+
+logger = create_logger(__name__)
+
+# Non-greedy org group: HF encodes org/name as models--org--name and model
+# names may themselves contain "--" (org names may not).
+_HF_CACHE_PATH_RE = re.compile(r"models--([^/\"]+?)--([^/\"]+)")
+_LABEL_RE = re.compile(r'(\w+)="((?:[^"\\]|\\.)*)"')
+_SERIES_RE = re.compile(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{.*\})?\s+(.+)$")
+_ORG_NAME_RE = re.compile(r"[\w.-]+/[\w.-]+")
+_SUFFIXES = ("_bucket", "_sum", "_count")
+
+# Our own timeout per replica scrape; never inherit call_backend's 60s — a
+# hung replica must not stall the exporter. Sized so the worst-case handler
+# response stays well under the dapi collector's 5 s per-node budget:
+# a hung replica must yield stale-with-aging-timestamp, not mlnode_up 0.
+SCRAPE_TIMEOUT_SECONDS = 2.5
+
+# Last successful scrape per replica index: (series_lines, unix_ts).
+# A hung vLLM keeps serving its stale copy with an aging timestamp, which is
+# exactly how consumers are supposed to detect it (design invariant 4).
+_last_good: Dict[str, Tuple[List[str], float]] = {}
+# Proxy setup generation the cache belongs to; a mismatch in collect() means
+# vLLM was (re)started — possibly with another model — and the cache is stale.
+_cache_generation: int = -1
+# HELP/TYPE metadata is identical across replicas; kept from the most recent
+# successful scrape of any replica so it survives replica 0 being down.
+_last_meta: List[str] = []
+
+
+def normalize_model_name(value: str) -> str:
+    """Map any filesystem path to a served model name.
+
+    HF-cache layout yields `org/name`; any other absolute path (models loaded
+    from a local directory) falls back to its basename — a path must never
+    leave the node (invariant 5), even at the cost of losing the org prefix.
+    """
+    m = _HF_CACHE_PATH_RE.search(value)
+    if m:
+        return f"{m.group(1)}/{m.group(2)}"
+    if "/" in value and not _ORG_NAME_RE.fullmatch(value):
+        # absolute or relative local path: keep only the basename
+        return value.rstrip("/").rsplit("/", 1)[-1]
+    return value
+
+
+def _family_name(series_name: str) -> str:
+    if series_name in VLLM_ALLOWLIST:
+        return series_name
+    for suffix in _SUFFIXES:
+        if series_name.endswith(suffix):
+            return series_name[: -len(suffix)]
+    return series_name
+
+
+def _rewrite_labels(label_block: Optional[str], replica: str) -> str:
+    labels = []
+    if label_block:
+        for name, value in _LABEL_RE.findall(label_block):
+            if name in VLLM_DROPPED_LABELS:
+                continue
+            if name == "model_name":
+                value = normalize_model_name(value)
+            labels.append((name, value))
+    labels.append(("replica", replica))
+    inner = ",".join(f'{n}="{v}"' for n, v in labels)
+    return "{" + inner + "}"
+
+
+def filter_vllm_metrics(text: str, replica: str) -> Tuple[List[str], List[str]]:
+    """Reduce one replica's exposition text to the allowlist.
+
+    Returns (meta_lines, series_lines): HELP/TYPE metadata separately, since
+    it is per-family (not per-replica) and is emitted once by the caller.
+    """
+    meta: List[str] = []
+    series: List[str] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith("#"):
+            parts = line.split(None, 3)
+            if len(parts) >= 3 and parts[1] in ("HELP", "TYPE"):
+                if _family_name(parts[2]) in VLLM_ALLOWLIST:
+                    meta.append(line)
+            continue
+        m = _SERIES_RE.match(line)
+        if not m:
+            continue
+        name, label_block, value = m.groups()
+        if name.endswith("_created"):
+            continue
+        if _family_name(name) not in VLLM_ALLOWLIST:
+            continue
+        series.append(f"{name}{_rewrite_labels(label_block, replica)} {value}")
+    return meta, series
+
+
+async def _scrape_replica(port: int, replica: str) -> Optional[Tuple[List[str], List[str]]]:
+    try:
+        resp = await asyncio.wait_for(
+            proxy_module.call_backend(port, "GET", "/metrics"),
+            timeout=SCRAPE_TIMEOUT_SECONDS,
+        )
+        if resp.status_code == 200:
+            return filter_vllm_metrics(resp.text, replica)
+    except Exception as e:
+        logger.warning(f"metrics scrape failed for replica {replica} (port {port}): {e}")
+    return None
+
+
+async def collect(now: float) -> Tuple[List[str], Dict[str, float]]:
+    """Scrape all healthy replicas concurrently; fall back to last good copies.
+
+    Returns (exposition_lines, {replica: last_success_ts}).
+    """
+    global _last_meta, _cache_generation
+    # Lazy invalidation: any vLLM (re)start bumps the proxy setup generation.
+    # Older proxy modules (fork images) lack the counter — invalidation is
+    # then simply off, matching their pre-metrics behavior.
+    generation = getattr(proxy_module, "vllm_setup_generation", _cache_generation)
+    if _cache_generation != generation:
+        _last_good.clear()
+        _last_meta = []
+        _cache_generation = generation
+
+    generation_at_entry = _cache_generation
+    all_ports = list(proxy_module.vllm_backend_ports)
+    healthy = set(proxy_module.get_healthy_backends())
+
+    targets = [
+        (str(idx), port) for idx, port in enumerate(all_ports) if port in healthy
+    ]
+    results = await asyncio.gather(
+        *(_scrape_replica(port, replica) for replica, port in targets)
+    )
+    # A model switch may have happened while we were suspended in gather:
+    # writing these results would resurrect the previous model's series
+    # right after another scraper invalidated the cache.
+    generation_now = getattr(proxy_module, "vllm_setup_generation", generation_at_entry)
+    if generation_now == generation_at_entry:
+        for (replica, _), result in zip(targets, results):
+            if result is not None:
+                meta, series = result
+                _last_good[replica] = (series, now)
+                if meta:
+                    _last_meta = meta
+
+    lines: List[str] = list(_last_meta)
+    timestamps: Dict[str, float] = {}
+    for idx in range(len(all_ports)):
+        replica = str(idx)
+        if replica in _last_good:
+            series, ts = _last_good[replica]
+            lines.extend(series)
+            timestamps[replica] = ts
+    return lines, timestamps
+
+
+def reset_cache():
+    """Drop cached scrapes and metadata (called on model start/stop/switch)."""
+    global _last_meta
+    _last_good.clear()
+    _last_meta = []

--- a/mlnode/packages/api/src/api/metrics/vllm_source.py
+++ b/mlnode/packages/api/src/api/metrics/vllm_source.py
@@ -7,7 +7,7 @@ the model was loaded from disk, and local paths must never leave the node.
 
 import asyncio
 import re
-from typing import Dict, List, Optional, Tuple
+import threading
 
 from common.logger import create_logger
 
@@ -24,22 +24,24 @@ _SERIES_RE = re.compile(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{.*\})?\s+(.+)$")
 _ORG_NAME_RE = re.compile(r"[\w.-]+/[\w.-]+")
 _SUFFIXES = ("_bucket", "_sum", "_count")
 
-# Our own timeout per replica scrape; never inherit call_backend's 60s — a
-# hung replica must not stall the exporter. Sized so the worst-case handler
-# response stays well under the dapi collector's 5 s per-node budget:
-# a hung replica must yield stale-with-aging-timestamp, not mlnode_up 0.
 SCRAPE_TIMEOUT_SECONDS = 2.5
 
-# Last successful scrape per replica index: (series_lines, unix_ts).
-# A hung vLLM keeps serving its stale copy with an aging timestamp, which is
-# exactly how consumers are supposed to detect it (design invariant 4).
-_last_good: Dict[str, Tuple[List[str], float]] = {}
-# Proxy setup generation the cache belongs to; a mismatch in collect() means
-# vLLM was (re)started — possibly with another model — and the cache is stale.
+_last_good: dict[str, tuple[list[str], float]] = {}
+_last_good_sequence: dict[str, int] = {}
 _cache_generation: int = -1
-# HELP/TYPE metadata is identical across replicas; kept from the most recent
-# successful scrape of any replica so it survives replica 0 being down.
-_last_meta: List[str] = []
+_last_meta: list[str] = []
+_last_meta_sequence = -1
+_scrape_sequence = 0
+_cache_lock = threading.Lock()
+
+
+def _invalidate_cache(generation: int) -> None:
+    global _cache_generation, _last_meta, _last_meta_sequence
+    _last_good.clear()
+    _last_good_sequence.clear()
+    _last_meta = []
+    _last_meta_sequence = -1
+    _cache_generation = generation
 
 
 def normalize_model_name(value: str) -> str:
@@ -67,7 +69,7 @@ def _family_name(series_name: str) -> str:
     return series_name
 
 
-def _rewrite_labels(label_block: Optional[str], replica: str) -> str:
+def _rewrite_labels(label_block: str | None, replica: str) -> str:
     labels = []
     if label_block:
         for name, value in _LABEL_RE.findall(label_block):
@@ -81,22 +83,25 @@ def _rewrite_labels(label_block: Optional[str], replica: str) -> str:
     return "{" + inner + "}"
 
 
-def filter_vllm_metrics(text: str, replica: str) -> Tuple[List[str], List[str]]:
+def filter_vllm_metrics(text: str, replica: str) -> tuple[list[str], list[str]]:
     """Reduce one replica's exposition text to the allowlist.
 
     Returns (meta_lines, series_lines): HELP/TYPE metadata separately, since
     it is per-family (not per-replica) and is emitted once by the caller.
     """
-    meta: List[str] = []
-    series: List[str] = []
+    meta: list[str] = []
+    series: list[str] = []
     for line in text.splitlines():
         if not line.strip():
             continue
         if line.startswith("#"):
             parts = line.split(None, 3)
-            if len(parts) >= 3 and parts[1] in ("HELP", "TYPE"):
-                if _family_name(parts[2]) in VLLM_ALLOWLIST:
-                    meta.append(line)
+            if (
+                len(parts) >= 3
+                and parts[1] in ("HELP", "TYPE")
+                and _family_name(parts[2]) in VLLM_ALLOWLIST
+            ):
+                meta.append(line)
             continue
         m = _SERIES_RE.match(line)
         if not m:
@@ -110,7 +115,9 @@ def filter_vllm_metrics(text: str, replica: str) -> Tuple[List[str], List[str]]:
     return meta, series
 
 
-async def _scrape_replica(port: int, replica: str) -> Optional[Tuple[List[str], List[str]]]:
+async def _scrape_replica(
+    port: int, replica: str
+) -> tuple[list[str], list[str]] | None:
     try:
         resp = await asyncio.wait_for(
             proxy_module.call_backend(port, "GET", "/metrics"),
@@ -119,26 +126,24 @@ async def _scrape_replica(port: int, replica: str) -> Optional[Tuple[List[str], 
         if resp.status_code == 200:
             return filter_vllm_metrics(resp.text, replica)
     except Exception as e:
-        logger.warning(f"metrics scrape failed for replica {replica} (port {port}): {e}")
+        logger.warning(
+            f"metrics scrape failed for replica {replica} (port {port}): {e}"
+        )
     return None
 
 
-async def collect(now: float) -> Tuple[List[str], Dict[str, float]]:
+async def collect(now: float) -> tuple[list[str], dict[str, float]]:
     """Scrape all healthy replicas concurrently; fall back to last good copies.
 
     Returns (exposition_lines, {replica: last_success_ts}).
     """
-    global _last_meta, _cache_generation
-    # Lazy invalidation: any vLLM (re)start bumps the proxy setup generation.
-    # Older proxy modules (fork images) lack the counter — invalidation is
-    # then simply off, matching their pre-metrics behavior.
-    generation = getattr(proxy_module, "vllm_setup_generation", _cache_generation)
-    if _cache_generation != generation:
-        _last_good.clear()
-        _last_meta = []
-        _cache_generation = generation
-
-    generation_at_entry = _cache_generation
+    global _last_meta, _last_meta_sequence, _scrape_sequence
+    with _cache_lock:
+        generation = getattr(proxy_module, "vllm_setup_generation", _cache_generation)
+        if _cache_generation != generation:
+            _invalidate_cache(generation)
+        _scrape_sequence += 1
+        sequence = _scrape_sequence
     all_ports = list(proxy_module.vllm_backend_ports)
     healthy = set(proxy_module.get_healthy_backends())
 
@@ -148,31 +153,28 @@ async def collect(now: float) -> Tuple[List[str], Dict[str, float]]:
     results = await asyncio.gather(
         *(_scrape_replica(port, replica) for replica, port in targets)
     )
-    # A model switch may have happened while we were suspended in gather:
-    # writing these results would resurrect the previous model's series
-    # right after another scraper invalidated the cache.
-    generation_now = getattr(proxy_module, "vllm_setup_generation", generation_at_entry)
-    if generation_now == generation_at_entry:
+    with _cache_lock:
+        generation_now = getattr(proxy_module, "vllm_setup_generation", generation)
+        if generation_now != generation:
+            if _cache_generation == generation:
+                _invalidate_cache(generation_now)
+            return [], {}
+
         for (replica, _), result in zip(targets, results):
-            if result is not None:
+            if result is not None and sequence > _last_good_sequence.get(replica, -1):
                 meta, series = result
                 _last_good[replica] = (series, now)
-                if meta:
+                _last_good_sequence[replica] = sequence
+                if meta and sequence > _last_meta_sequence:
                     _last_meta = meta
+                    _last_meta_sequence = sequence
 
-    lines: List[str] = list(_last_meta)
-    timestamps: Dict[str, float] = {}
-    for idx in range(len(all_ports)):
-        replica = str(idx)
-        if replica in _last_good:
-            series, ts = _last_good[replica]
-            lines.extend(series)
-            timestamps[replica] = ts
-    return lines, timestamps
-
-
-def reset_cache():
-    """Drop cached scrapes and metadata (called on model start/stop/switch)."""
-    global _last_meta
-    _last_good.clear()
-    _last_meta = []
+        lines: list[str] = list(_last_meta)
+        timestamps: dict[str, float] = {}
+        for idx in range(len(all_ports)):
+            replica = str(idx)
+            if replica in _last_good:
+                series, ts = _last_good[replica]
+                lines.extend(series)
+                timestamps[replica] = ts
+        return lines, timestamps

--- a/mlnode/packages/api/src/api/metrics/xid_source.py
+++ b/mlnode/packages/api/src/api/metrics/xid_source.py
@@ -1,0 +1,119 @@
+"""XID critical error counter via the NVML event API.
+
+dmesg is not readable in unprivileged containers, while event registration
+works even on rented container environments, so the NVML
+event API is the v1 mechanism. If registration fails (very old drivers,
+exotic virtualization) the listener quietly stays off and no series appear.
+"""
+
+import threading
+from collections import Counter
+from typing import Dict, List, Optional, Tuple
+
+import pynvml
+
+from common.logger import create_logger
+
+from api.metrics import render
+
+logger = create_logger(__name__)
+
+_WAIT_TIMEOUT_MS = 2000
+
+_lock = threading.Lock()
+_counts: Counter = Counter()  # (gpu_index, xid) -> count
+_listener: Optional[threading.Thread] = None
+_event_set = None
+_stop = threading.Event()
+
+
+def _listen(event_set, uuid_to_index: Dict[bytes, str]):
+    while not _stop.is_set():
+        try:
+            data = pynvml.nvmlEventSetWait(event_set, _WAIT_TIMEOUT_MS)
+        except pynvml.NVMLError_Timeout:
+            continue
+        except Exception as e:
+            logger.warning(f"XID listener stopped: {e}")
+            return
+        if data.eventType != pynvml.nvmlEventTypeXidCriticalError:
+            continue
+        try:
+            uuid = pynvml.nvmlDeviceGetUUID(data.device)
+            index = uuid_to_index.get(uuid, "unknown")
+        except Exception:
+            index = "unknown"
+        xid = int(data.eventData)
+        with _lock:
+            _counts[(index, xid)] += 1
+        logger.error(f"GPU XID {xid} on gpu_index={index}")
+
+
+def start():
+    """Register for XID events and start the listener thread (idempotent)."""
+    global _listener, _event_set
+    if _listener is not None:
+        return
+    event_set = None
+    try:
+        event_set = pynvml.nvmlEventSetCreate()
+        uuid_to_index: Dict[bytes, str] = {}
+        for i in range(pynvml.nvmlDeviceGetCount()):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+            pynvml.nvmlDeviceRegisterEvents(
+                handle, pynvml.nvmlEventTypeXidCriticalError, event_set
+            )
+            uuid_to_index[pynvml.nvmlDeviceGetUUID(handle)] = str(i)
+    except Exception as e:
+        logger.warning(f"XID event API unavailable, XID series disabled: {e}")
+        if event_set is not None:
+            _free_event_set(event_set)
+        return
+    _stop.clear()
+    _event_set = event_set
+    _listener = threading.Thread(
+        target=_listen, args=(event_set, uuid_to_index), daemon=True, name="xid-listener"
+    )
+    _listener.start()
+    logger.info(f"XID listener started for {len(uuid_to_index)} GPU(s)")
+
+
+def _free_event_set(event_set):
+    try:
+        pynvml.nvmlEventSetFree(event_set)
+    except Exception:
+        pass
+
+
+def stop():
+    """Stop the listener and free NVML resources.
+
+    Must run BEFORE nvmlShutdown(): joins the thread so nothing is blocked in
+    nvmlEventSetWait when the NVML session goes away.
+    """
+    global _listener, _event_set
+    _stop.set()
+    if _listener is not None:
+        # wait timeout is 2s, so the thread notices _stop within that
+        _listener.join(timeout=_WAIT_TIMEOUT_MS / 1000 + 1)
+        _listener = None
+    if _event_set is not None:
+        _free_event_set(_event_set)
+        _event_set = None
+
+
+def collect() -> List[str]:
+    """Exposition lines for accumulated XID counts (none => no series)."""
+    with _lock:
+        items: List[Tuple[Tuple[str, int], int]] = sorted(_counts.items())
+    return [
+        render.series(
+            "mlnode_gpu_xid_events_total", {"gpu_index": index, "xid": str(xid)}, count
+        )
+        for (index, xid), count in items
+    ]
+
+
+def reset():
+    with _lock:
+        _counts.clear()

--- a/mlnode/packages/api/src/api/proxy.py
+++ b/mlnode/packages/api/src/api/proxy.py
@@ -21,6 +21,9 @@ LIMITS = httpx.Limits(
 )
 
 vllm_backend_ports: List[int] = []
+# Bumped on every setup_vllm_proxy() call (i.e. each vLLM (re)start);
+# lets consumers like the metrics exporter detect a model switch lazily.
+vllm_setup_generation: int = 0
 vllm_healthy: Dict[int, bool] = {}
 vllm_counts: Dict[int, int] = {}
 poc_status_by_port: Dict[int, str] = {}  # PoC status: "IDLE", "GENERATING", "STOPPED", or ""
@@ -245,8 +248,9 @@ async def _health_check_vllm(interval: float = 2.0):
 
 def setup_vllm_proxy(backend_ports: List[int]):
     """Setup vLLM proxy with given backend ports."""
-    global vllm_backend_ports, vllm_counts
+    global vllm_backend_ports, vllm_counts, vllm_setup_generation
     vllm_backend_ports = backend_ports
+    vllm_setup_generation += 1
     vllm_counts = {p: 0 for p in vllm_backend_ports}
     vllm_healthy.update({p: False for p in vllm_backend_ports})
     poc_status_by_port.update({p: "" for p in vllm_backend_ports})

--- a/mlnode/packages/api/src/api/proxy.py
+++ b/mlnode/packages/api/src/api/proxy.py
@@ -25,6 +25,9 @@ vllm_backend_ports: List[int] = []
 # lets consumers like the metrics exporter detect a model switch lazily.
 vllm_setup_generation: int = 0
 vllm_healthy: Dict[int, bool] = {}
+# /health prober damping -- contract in _apply_health_damping.
+HEALTH_FAIL_STREAK: int = 3
+vllm_health_fail_streak: Dict[int, int] = {}
 vllm_counts: Dict[int, int] = {}
 poc_status_by_port: Dict[int, str] = {}  # PoC status: "IDLE", "GENERATING", "STOPPED", or ""
 pow_generate_rr_index: int = 0
@@ -192,6 +195,19 @@ async def call_backend(port: int, method: str, path: str, json_body: dict = None
         raise ValueError(f"Unsupported method: {method}")
 
 
+def _apply_health_damping(port: int, probe_ok: bool) -> bool:
+    """Damped health verdict: unhealthy only after HEALTH_FAIL_STREAK
+    consecutive probe failures, instant recovery on success; a backend that
+    has never succeeded (startup) stays down regardless of streak."""
+    if probe_ok:
+        vllm_health_fail_streak[port] = 0
+        return True
+    vllm_health_fail_streak[port] = vllm_health_fail_streak.get(port, 0) + 1
+    if vllm_healthy.get(port) and vllm_health_fail_streak[port] < HEALTH_FAIL_STREAK:
+        return True
+    return False
+
+
 async def _health_check_vllm(interval: float = 2.0):
     """Health check for vLLM backends and manage compatibility server."""
     logger.info("Health check loop started, checking every %s seconds", interval)
@@ -208,11 +224,13 @@ async def _health_check_vllm(interval: float = 2.0):
                 if vllm_client is None:
                     logger.warning(f"Health check skipped for port {p}: vllm_client is None")
                     continue
-                r = await vllm_client.get(f"http://{VLLM_HOST}:{p}/health", timeout=2)
+                r = await vllm_client.get(f"http://{VLLM_HOST}:{p}/health", timeout=10)
                 ok = r.status_code == 200
                 logger.debug("Health check for port %d: status=%d, ok=%s", p, r.status_code, ok)
             except Exception as e:
                 logger.debug("Health check for port %d failed: %s", p, e)
+
+            ok = _apply_health_damping(p, ok)
 
             prev = vllm_healthy.get(p)
             if prev != ok:

--- a/mlnode/packages/api/src/api/watcher.py
+++ b/mlnode/packages/api/src/api/watcher.py
@@ -24,7 +24,7 @@ async def watch_managers(
     while True:
         await asyncio.sleep(interval)
         for manager in managers:
-            if not manager.is_healthy():
+            if not await asyncio.to_thread(manager.is_healthy):
                 unhealthy_counts[manager] += 1
                 logger.error(f"Manager {manager.__class__.__name__} is unhealthy (count: {unhealthy_counts[manager]}/{MAX_UNHEALTHY_COUNT})")
                 

--- a/mlnode/packages/api/tests/unit/test_health_endpoints.py
+++ b/mlnode/packages/api/tests/unit/test_health_endpoints.py
@@ -1,18 +1,15 @@
+import asyncio
 import pytest
+import threading
 import time
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock, AsyncMock
 from fastapi import FastAPI, Response
 from fastapi.testclient import TestClient
 from api.health import (
     router,
     get_health_data,
+    get_readiness,
     HealthResponse,
-    ReadinessResponse,
-    ManagerStatus,
-    ManagersInfo,
-    GPUInfo,
-    cache,
-    CACHE_TTL,
 )
 from api.service_management import ServiceState
 from api.gpu.types import GPUDevice
@@ -177,6 +174,29 @@ class TestGetHealthData:
         assert health_data.gpu.available is False
         assert health_data.gpu.count == 0
         assert health_data.status == "unhealthy"  # GPU unavailable makes system unhealthy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["health", "readiness"])
+async def test_inference_health_check_does_not_block_event_loop(endpoint):
+    request = MockRequest()
+    request.app.state.service_state = ServiceState.INFERENCE
+    release = threading.Event()
+    request.app.state.inference_manager.is_healthy.side_effect = (
+        lambda: release.wait(timeout=1) or True
+    )
+
+    if endpoint == "health":
+        call = get_health_data(request)
+    else:
+        call = get_readiness(request, Response())
+    task = asyncio.create_task(call)
+    started = time.monotonic()
+    await asyncio.sleep(0.05)
+    assert time.monotonic() - started < 0.5
+
+    release.set()
+    await task
 
 
 # ============================================================================

--- a/mlnode/packages/api/tests/unit/test_metrics_exporter.py
+++ b/mlnode/packages/api/tests/unit/test_metrics_exporter.py
@@ -1,0 +1,502 @@
+import asyncio
+import re
+import time
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.proxy as proxy_module
+from api.gpu.manager import GPUManager
+from api.metrics import host_source, vllm_source
+from api.metrics.allowlist import VLLM_ALLOWLIST
+from api.metrics.routes import router
+from api.metrics.vllm_source import filter_vllm_metrics, normalize_model_name
+
+HF_CACHE_MODEL = (
+    "/root/.cache/huggingface/hub/models--moonshotai--Kimi-K2.6/"
+    "snapshots/7eb5002f6aadc958aed6a9177b7ed26bb94011bb"
+)
+
+# Canonical vLLM /metrics excerpt: allowlist families, a non-allowlist family,
+# a _created series and the engine/model_name labels to be rewritten.
+CANONICAL_VLLM_METRICS = f"""\
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{{engine="0",model_name="{HF_CACHE_MODEL}"}} 144.0
+# HELP vllm:request_success_total Count of successfully processed requests.
+# TYPE vllm:request_success_total counter
+vllm:request_success_total{{engine="0",finished_reason="stop",model_name="{HF_CACHE_MODEL}"}} 773.0
+vllm:request_success_created{{engine="0",finished_reason="stop",model_name="{HF_CACHE_MODEL}"}} 1.75e+09
+# HELP vllm:time_to_first_token_seconds Histogram of time to first token.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_bucket{{engine="0",le="0.001",model_name="{HF_CACHE_MODEL}"}} 0.0
+vllm:time_to_first_token_seconds_count{{engine="0",model_name="{HF_CACHE_MODEL}"}} 3447.0
+vllm:time_to_first_token_seconds_sum{{engine="0",model_name="{HF_CACHE_MODEL}"}} 481575.5
+# HELP vllm:num_requests_waiting_by_reason Not in allowlist.
+# TYPE vllm:num_requests_waiting_by_reason gauge
+vllm:num_requests_waiting_by_reason{{engine="0",model_name="{HF_CACHE_MODEL}",reason="capacity"}} 144.0
+python_gc_objects_collected_total{{generation="0"}} 146351.0
+"""
+
+
+@pytest.fixture(autouse=True)
+def metrics_state(monkeypatch):
+    vllm_source.reset_cache()
+    host_source.reset()
+    monkeypatch.setattr(proxy_module, "vllm_backend_ports", [5001, 5002])
+    monkeypatch.setattr(proxy_module, "vllm_healthy", {5001: True, 5002: True})
+    yield
+    vllm_source.reset_cache()
+    host_source.reset()
+
+
+@pytest.fixture
+def gpu_manager():
+    manager = MagicMock(spec=GPUManager)
+    manager.collect_metrics_async = AsyncMock(return_value=[])
+    return manager
+
+
+@pytest.fixture
+def client(monkeypatch, gpu_manager):
+    response = MagicMock(status_code=200, text=CANONICAL_VLLM_METRICS)
+    monkeypatch.setattr(proxy_module, "call_backend", AsyncMock(return_value=response))
+
+    app = FastAPI()
+    app.state.gpu_manager = gpu_manager
+    app.state.inference_manager = MagicMock(vllm_runner=None)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_off_returns_404(client, monkeypatch):
+    monkeypatch.setenv("GONKA_METRICS", "off")
+    response = client.get("/metrics")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not Found"}
+
+
+def test_default_is_full(client, monkeypatch):
+    monkeypatch.delenv("GONKA_METRICS", raising=False)
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+
+
+def test_exports_exactly_allowlist_families(client):
+    body = client.get("/metrics").text
+    exported = {
+        re.sub(r"_(bucket|sum|count)$", "", line.split("{")[0])
+        for line in body.splitlines()
+        if line.startswith("vllm:")
+    }
+    assert exported <= VLLM_ALLOWLIST
+    assert "vllm:num_requests_waiting" in exported
+    assert "vllm:request_success_total" in exported
+    assert "vllm:time_to_first_token_seconds" in exported
+    # not in allowlist / not vllm => filtered out
+    assert "vllm:num_requests_waiting_by_reason" not in body
+    assert "python_gc_objects_collected_total" not in body
+    assert "_created" not in body
+
+
+def test_no_placement_labels(client):
+    """Invariant 5: no hostname/IP/ports/provider/local paths in the output."""
+    body = client.get("/metrics").text
+    label_values = re.findall(r'="((?:[^"\\]|\\.)*)"', body)
+    for value in label_values:
+        assert "/" not in value or re.fullmatch(r"[\w.-]+/[\w.-]+", value), value
+        assert ".cache" not in value
+        assert "127.0.0.1" not in value
+    label_names = set(re.findall(r'(\w+)="', body))
+    assert not label_names & {"hostname", "ip", "port", "host", "provider", "engine"}
+
+
+def test_model_name_normalized(client):
+    body = client.get("/metrics").text
+    assert 'model_name="moonshotai/Kimi-K2.6"' in body
+    assert "/root/.cache" not in body
+
+
+def test_replicas_distinguishable(client):
+    body = client.get("/metrics").text
+    waiting = [l for l in body.splitlines() if l.startswith("vllm:num_requests_waiting{")]
+    replicas = {re.search(r'replica="(\d+)"', l).group(1) for l in waiting}
+    assert replicas == {"0", "1"}
+
+
+def test_schema_and_source_timestamps_present(client):
+    body = client.get("/metrics").text
+    assert 'gonka_metrics_schema_info{version="1"} 1' in body
+    assert 'mlnode_source_scrape_timestamp_seconds{source="vllm",replica="0"}' in body
+
+
+def test_hung_replica_keeps_stale_timestamp(client, monkeypatch):
+    first = client.get("/metrics").text
+    ts_line = [
+        l for l in first.splitlines()
+        if l.startswith('mlnode_source_scrape_timestamp_seconds{source="vllm",replica="1"')
+    ][0]
+
+    # replica 1 stops answering /metrics but stays "healthy"
+    async def flaky(port, method, path):
+        if port == 5002:
+            raise TimeoutError("frozen")
+        return MagicMock(status_code=200, text=CANONICAL_VLLM_METRICS)
+
+    monkeypatch.setattr(proxy_module, "call_backend", flaky)
+    second = client.get("/metrics").text
+
+    # stale copy still served, timestamp did not advance
+    assert ts_line in second
+    waiting = [l for l in second.splitlines() if l.startswith("vllm:num_requests_waiting{")]
+    assert {re.search(r'replica="(\d+)"', l).group(1) for l in waiting} == {"0", "1"}
+
+
+def test_gpu_fields_rendered(client, gpu_manager):
+    gpu_manager.collect_metrics_async = AsyncMock(return_value=[
+        {
+            "gpu_index": "0",
+            "gpu_model": "NVIDIA B300 SXM6 AC",
+            "fields": {
+                "mlnode_gpu_temp_core_celsius": 71.0,
+                "mlnode_gpu_power_draw_watts": 812.5,
+            },
+        }
+    ])
+    body = client.get("/metrics").text
+    assert (
+        'mlnode_gpu_temp_core_celsius{gpu_index="0",gpu_model="NVIDIA B300 SXM6 AC"} 71.0'
+        in body
+    )
+    assert 'mlnode_source_scrape_timestamp_seconds{source="nvml"}' in body
+
+
+def test_no_gpu_no_series(client, gpu_manager):
+    gpu_manager.collect_metrics_async = AsyncMock(return_value=[])
+    body = client.get("/metrics").text
+    assert "mlnode_gpu_" not in body
+    assert 'source="nvml"' not in body
+
+
+def test_xid_counter_rendered(client):
+    from api.metrics import xid_source
+    xid_source.reset()
+    with xid_source._lock:
+        xid_source._counts[("0", 79)] += 1
+    try:
+        body = client.get("/metrics").text
+        assert 'mlnode_gpu_xid_events_total{gpu_index="0",xid="79"} 1' in body
+    finally:
+        xid_source.reset()
+
+
+def test_no_xid_events_no_series(client):
+    from api.metrics import xid_source
+    xid_source.reset()
+    body = client.get("/metrics").text
+    assert "mlnode_gpu_xid_events_total" not in body
+
+
+def test_normalize_model_name():
+    assert normalize_model_name(HF_CACHE_MODEL) == "moonshotai/Kimi-K2.6"
+    assert normalize_model_name("Qwen/Qwen2.5-0.5B-Instruct") == "Qwen/Qwen2.5-0.5B-Instruct"
+    # model names may contain "--"; the org group must not swallow them
+    assert normalize_model_name("hub/models--org--some--model/snapshots/x") == "org/some--model"
+    # models loaded from a local directory: path never leaves the node
+    assert normalize_model_name("/root/autodl-tmp/models/MiniMax-M2.7") == "MiniMax-M2.7"
+    assert normalize_model_name("/data/weights/foo/") == "foo"
+
+
+def test_filter_returns_meta_separately():
+    meta, series = filter_vllm_metrics(CANONICAL_VLLM_METRICS, "1")
+    assert any(l.startswith("# TYPE vllm:num_requests_waiting") for l in meta)
+    assert not any(l.startswith("#") for l in series)
+    assert all('replica="1"' in l for l in series)
+
+
+def test_meta_present_even_when_replica_zero_down(client, monkeypatch):
+    async def only_replica_one(port, method, path):
+        if port == 5001:
+            raise TimeoutError("replica 0 down")
+        return MagicMock(status_code=200, text=CANONICAL_VLLM_METRICS)
+
+    monkeypatch.setattr(proxy_module, "call_backend", only_replica_one)
+    body = client.get("/metrics").text
+    assert "# TYPE vllm:num_requests_waiting gauge" in body
+    assert 'replica="1"' in body
+
+
+def test_model_switch_invalidates_cache(client, monkeypatch):
+    client.get("/metrics")
+    assert vllm_source._last_good  # cache warm
+
+    # model switch = setup_vllm_proxy() call = generation bump; the new
+    # replicas are not scrapeable yet
+    async def all_down(port, method, path):
+        raise TimeoutError("loading new model")
+
+    monkeypatch.setattr(proxy_module, "call_backend", all_down)
+    monkeypatch.setattr(
+        proxy_module, "vllm_setup_generation", proxy_module.vllm_setup_generation + 1
+    )
+    body = client.get("/metrics").text
+    # stale series of the previous model must NOT survive the switch
+    assert not any(line.startswith("vllm:") for line in body.splitlines())
+
+
+def test_label_value_escaping_preserved():
+    text = (
+        '# TYPE vllm:request_success_total counter\n'
+        'vllm:request_success_total{engine="0",finished_reason="st\\"op",'
+        f'model_name="{HF_CACHE_MODEL}"}} 1.0\n'
+    )
+    _, series = filter_vllm_metrics(text, "0")
+    assert len(series) == 1
+    assert 'finished_reason="st\\"op"' in series[0]
+
+
+def test_unrecognized_gonka_metrics_value_treated_as_full(client, monkeypatch):
+    monkeypatch.setenv("GONKA_METRICS", "false")
+    response = client.get("/metrics")
+    assert response.status_code == 200  # contract is full|off; still exports
+
+
+def test_host_memory_cgroup_v2_with_v1_fallback(tmp_path, monkeypatch):
+    v2 = tmp_path / "v2"
+    v2.mkdir()
+    (v2 / "memory.current").write_text("1073741824\n")
+    (v2 / "memory.max").write_text("max\n")
+    monkeypatch.setattr(host_source, "CGROUP_V2_BASE", str(v2))
+    monkeypatch.setattr(host_source, "CGROUP_V1_MEM_BASE", str(tmp_path / "absent"))
+    values = host_source.collect_memory()
+    assert values["mlnode_host_memory_used_bytes"] == 1073741824.0
+    assert "mlnode_host_memory_limit_bytes" not in values  # "max" => no limit series
+
+    v1 = tmp_path / "v1"
+    v1.mkdir()
+    (v1 / "memory.usage_in_bytes").write_text("536870912\n")
+    (v1 / "memory.limit_in_bytes").write_text("2147483648\n")
+    monkeypatch.setattr(host_source, "CGROUP_V2_BASE", str(tmp_path / "absent"))
+    monkeypatch.setattr(host_source, "CGROUP_V1_MEM_BASE", str(v1))
+    values = host_source.collect_memory()
+    assert values["mlnode_host_memory_used_bytes"] == 536870912.0
+    assert values["mlnode_host_memory_limit_bytes"] == 2147483648.0
+
+
+def test_host_cpu_ratio_needs_two_samples(monkeypatch):
+    samples = iter([
+        (1000.0, 10.0, 2000.0),
+        (1060.0, 14.0, 2100.0),
+    ])
+    monkeypatch.setattr(host_source, "_cpu_sample", lambda: next(samples))
+    assert host_source.collect_cpu() == {}  # first scrape: no interval yet
+    values = host_source.collect_cpu()
+    assert values["mlnode_host_cpu_busy_ratio"] == pytest.approx(0.6)
+    assert values["mlnode_host_cpu_steal_ratio"] == pytest.approx(0.04)
+
+
+def test_own_families_carry_help_and_type(client, gpu_manager):
+    gpu_manager.collect_metrics_async = AsyncMock(return_value=[
+        {"gpu_index": "0", "gpu_model": "G", "fields": {"mlnode_gpu_pcie_replay_total": 0.0}},
+        {"gpu_index": "1", "gpu_model": "G", "fields": {"mlnode_gpu_pcie_replay_total": 1.0}},
+    ])
+    body = client.get("/metrics").text
+    assert "# TYPE mlnode_gpu_pcie_replay_total counter" in body
+    assert "# TYPE gonka_metrics_schema_info gauge" in body
+    assert "# TYPE mlnode_source_scrape_timestamp_seconds gauge" in body
+    # samples of one family are contiguous under its TYPE header
+    lines = body.splitlines()
+    idx = lines.index("# TYPE mlnode_gpu_pcie_replay_total counter")
+    assert lines[idx + 1].startswith("mlnode_gpu_pcie_replay_total{")
+    assert lines[idx + 2].startswith("mlnode_gpu_pcie_replay_total{")
+
+
+def test_fork_runner_without_accessor_degrades_gracefully(client):
+    class LegacyRunner:
+        model = "org/model"
+        dtype = "auto"
+
+    client.app.state.inference_manager = MagicMock(vllm_runner=LegacyRunner())
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "mlnode_config_info" not in response.text  # degraded, not 500
+
+
+def test_fork_proxy_without_generation_counter(client, monkeypatch):
+    monkeypatch.delattr(proxy_module, "vllm_setup_generation", raising=False)
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "vllm:num_requests_waiting" in response.text  # invalidation off, series intact
+
+
+def test_every_emitted_gpu_family_has_meta():
+    from api.gpu.manager import GPUManager
+    from api.metrics.render import FAMILY_META
+
+    emitted = set(GPUManager._METRIC_READERS) | {
+        "mlnode_gpu_memory_used_bytes",
+        "mlnode_gpu_memory_free_bytes",
+    }
+    missing = emitted - set(FAMILY_META)
+    assert not missing, f"families without FAMILY_META entries: {missing}"
+
+
+def test_setup_vllm_proxy_bumps_generation():
+    before = proxy_module.vllm_setup_generation
+    proxy_module.setup_vllm_proxy([5001])
+    assert proxy_module.vllm_setup_generation == before + 1
+
+
+def test_config_info_normalizes_model_and_keeps_unset_empty(client):
+    runner = MagicMock()
+    runner.get_config_summary.return_value = {
+        "model": HF_CACHE_MODEL,
+        "dtype": "auto",
+        "max_num_seqs": 128,
+        "max_model_len": 0,
+        "tensor_parallel_size": 0,
+        "pipeline_parallel_size": 0,
+    }
+    client.app.state.inference_manager = MagicMock(vllm_runner=runner)
+    body = client.get("/metrics").text
+    line = [l for l in body.splitlines() if l.startswith("mlnode_config_info{")][0]
+    assert 'model_name="moonshotai/Kimi-K2.6"' in line  # normalized, not the path
+    assert "/root/.cache" not in line
+    assert 'max_num_seqs="128"' in line
+    assert 'max_model_len=""' in line  # unset => empty per schema contract
+
+
+@pytest.mark.asyncio
+async def test_stalled_local_stage_degrades_not_hangs(gpu_manager, monkeypatch):
+    # ASGITransport keeps one persistent loop: TestClient would join the
+    # deliberately-abandoned worker thread at loop shutdown and hide the
+    # handler's true latency.
+    from httpx import ASGITransport, AsyncClient
+    from api.metrics import routes as routes_module
+
+    response_mock = MagicMock(status_code=200, text=CANONICAL_VLLM_METRICS)
+    monkeypatch.setattr(proxy_module, "call_backend", AsyncMock(return_value=response_mock))
+
+    async def stuck():
+        await asyncio.sleep(30)
+
+    gpu_manager.collect_metrics_async = MagicMock(side_effect=stuck)
+    monkeypatch.setattr(routes_module, "NVML_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(routes_module, "HOST_TIMEOUT_SECONDS", 0.05)
+    # short stall: the leaked worker is joined at test-teardown loop close
+    monkeypatch.setattr(routes_module.host_source, "collect", lambda: time.sleep(3))
+
+    app = FastAPI()
+    app.state.gpu_manager = gpu_manager
+    app.state.inference_manager = MagicMock(vllm_runner=None)
+    app.include_router(router)
+
+    start = time.monotonic()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/metrics")
+    elapsed = time.monotonic() - start
+
+    assert response.status_code == 200
+    assert elapsed < 1.0, f"stalled local stages must not delay the response (took {elapsed:.2f}s)"
+    assert "mlnode_gpu_" not in response.text  # degraded to missing series
+
+
+def test_inflight_scrape_across_generation_bump_discarded(client, monkeypatch):
+    client.get("/metrics")
+    assert vllm_source._last_good
+
+    gate = asyncio.Event()
+
+    async def slow_backend(port, method, path):
+        await gate.wait()
+        return MagicMock(status_code=200, text=CANONICAL_VLLM_METRICS)
+
+    monkeypatch.setattr(proxy_module, "call_backend", slow_backend)
+
+    async def race():
+        vllm_source.reset_cache()
+        task = asyncio.create_task(vllm_source.collect(1.0))  # suspends in gather
+        await asyncio.sleep(0.05)
+        # model switch happens while the scrape is in flight
+        proxy_module.vllm_setup_generation += 1
+        vllm_source._last_good.clear()
+        vllm_source._cache_generation = proxy_module.vllm_setup_generation
+        gate.set()
+        await task
+        return dict(vllm_source._last_good)
+
+    cache_after = asyncio.get_event_loop_policy().new_event_loop().run_until_complete(race())
+    assert cache_after == {}  # stale in-flight results were discarded
+
+
+def test_escape_label_values():
+    from api.metrics.render import escape
+
+    assert escape('a"b') == 'a\\"b'
+    assert escape("a\\b") == "a\\\\b"
+    assert escape("a\nb") == "a\\nb"
+
+
+def test_stage_budgets_fit_dapi_per_node_timeout():
+    # dapi's collector allows 5s per node; stages run sequentially
+    from api.metrics.routes import HOST_TIMEOUT_SECONDS, NVML_TIMEOUT_SECONDS
+    from api.metrics.vllm_source import SCRAPE_TIMEOUT_SECONDS
+
+    assert SCRAPE_TIMEOUT_SECONDS + NVML_TIMEOUT_SECONDS + HOST_TIMEOUT_SECONDS < 5
+
+
+def test_relative_local_path_normalized():
+    # multi-segment relative path is clearly a path => basename
+    assert normalize_model_name("local/models/MiniMax-M2.7") == "MiniMax-M2.7"
+    # a single-slash value is indistinguishable from a canonical HF id => kept
+    assert normalize_model_name("org/model") == "org/model"
+
+
+@pytest.mark.asyncio
+async def test_stalled_stage_not_reentered():
+    import threading
+
+    from api.metrics import routes as routes_module
+
+    routes_module._pending_stages.clear()
+    routes_module._warned_stalled.clear()
+    release = threading.Event()
+    submissions = {"n": 0}
+
+    def stalled():
+        submissions["n"] += 1
+        release.wait()
+
+    with pytest.raises(TimeoutError):
+        await routes_module._bounded(asyncio.to_thread(stalled), 0.05, "test-src")
+    # real scrapes arrive many loop iterations later — yield the loop
+    await asyncio.sleep(0.05)
+    with pytest.raises(TimeoutError):
+        await routes_module._bounded(asyncio.to_thread(stalled), 10, "test-src")
+    assert submissions["n"] == 1  # second call skipped: no new worker parked
+
+    release.set()
+    await asyncio.sleep(0.1)  # let the parked thread finish
+    # source recovers once the abandoned task completes
+    result = await routes_module._bounded(asyncio.to_thread(lambda: 42), 1, "test-src")
+    assert result == 42
+    routes_module._pending_stages.clear()
+    routes_module._warned_stalled.clear()
+    release = asyncio.Event()
+
+    async def stall():
+        await release.wait()
+
+    with pytest.raises(TimeoutError):
+        await routes_module._bounded(stall(), 0.05, "test-src")
+    # previous task still parked: a second call must skip instantly
+    start = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await routes_module._bounded(stall(), 10, "test-src")
+    assert time.monotonic() - start < 0.05  # skipped, not re-parked
+    release.set()
+    await asyncio.sleep(0)
+    routes_module._pending_stages.clear()

--- a/mlnode/packages/api/tests/unit/test_metrics_exporter.py
+++ b/mlnode/packages/api/tests/unit/test_metrics_exporter.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import threading
 import time
 
 import pytest
@@ -43,12 +44,12 @@ python_gc_objects_collected_total{{generation="0"}} 146351.0
 
 @pytest.fixture(autouse=True)
 def metrics_state(monkeypatch):
-    vllm_source.reset_cache()
+    vllm_source._invalidate_cache(-1)
     host_source.reset()
     monkeypatch.setattr(proxy_module, "vllm_backend_ports", [5001, 5002])
     monkeypatch.setattr(proxy_module, "vllm_healthy", {5001: True, 5002: True})
     yield
-    vllm_source.reset_cache()
+    vllm_source._invalidate_cache(-1)
     host_source.reset()
 
 
@@ -133,14 +134,16 @@ def test_schema_and_source_timestamps_present(client):
     assert 'mlnode_source_scrape_timestamp_seconds{source="vllm",replica="0"}' in body
 
 
-def test_hung_replica_keeps_stale_timestamp(client, monkeypatch):
+def test_failed_replica_scrape_keeps_stale_timestamp(client, monkeypatch):
     first = client.get("/metrics").text
-    ts_line = [
-        l for l in first.splitlines()
-        if l.startswith('mlnode_source_scrape_timestamp_seconds{source="vllm",replica="1"')
-    ][0]
+    ts_line = next(
+        line
+        for line in first.splitlines()
+        if line.startswith(
+            'mlnode_source_scrape_timestamp_seconds{source="vllm",replica="1"'
+        )
+    )
 
-    # replica 1 stops answering /metrics but stays "healthy"
     async def flaky(port, method, path):
         if port == 5002:
             raise TimeoutError("frozen")
@@ -149,7 +152,6 @@ def test_hung_replica_keeps_stale_timestamp(client, monkeypatch):
     monkeypatch.setattr(proxy_module, "call_backend", flaky)
     second = client.get("/metrics").text
 
-    # stale copy still served, timestamp did not advance
     assert ts_line in second
     waiting = [l for l in second.splitlines() if l.startswith("vllm:num_requests_waiting{")]
     assert {re.search(r'replica="(\d+)"', l).group(1) for l in waiting} == {"0", "1"}
@@ -362,7 +364,7 @@ def test_config_info_normalizes_model_and_keeps_unset_empty(client):
     }
     client.app.state.inference_manager = MagicMock(vllm_runner=runner)
     body = client.get("/metrics").text
-    line = [l for l in body.splitlines() if l.startswith("mlnode_config_info{")][0]
+    line = next(l for l in body.splitlines() if l.startswith("mlnode_config_info{"))
     assert 'model_name="moonshotai/Kimi-K2.6"' in line  # normalized, not the path
     assert "/root/.cache" not in line
     assert 'max_num_seqs="128"' in line
@@ -380,14 +382,16 @@ async def test_stalled_local_stage_degrades_not_hangs(gpu_manager, monkeypatch):
     response_mock = MagicMock(status_code=200, text=CANONICAL_VLLM_METRICS)
     monkeypatch.setattr(proxy_module, "call_backend", AsyncMock(return_value=response_mock))
 
+    async_release = asyncio.Event()
+    thread_release = threading.Event()
+
     async def stuck():
-        await asyncio.sleep(30)
+        await async_release.wait()
 
     gpu_manager.collect_metrics_async = MagicMock(side_effect=stuck)
     monkeypatch.setattr(routes_module, "NVML_TIMEOUT_SECONDS", 0.05)
     monkeypatch.setattr(routes_module, "HOST_TIMEOUT_SECONDS", 0.05)
-    # short stall: the leaked worker is joined at test-teardown loop close
-    monkeypatch.setattr(routes_module.host_source, "collect", lambda: time.sleep(3))
+    monkeypatch.setattr(routes_module.host_source, "collect", thread_release.wait)
 
     app = FastAPI()
     app.state.gpu_manager = gpu_manager
@@ -403,9 +407,18 @@ async def test_stalled_local_stage_degrades_not_hangs(gpu_manager, monkeypatch):
     assert elapsed < 1.0, f"stalled local stages must not delay the response (took {elapsed:.2f}s)"
     assert "mlnode_gpu_" not in response.text  # degraded to missing series
 
+    pending = list(routes_module._pending_stages.values())
+    async_release.set()
+    thread_release.set()
+    await asyncio.gather(*pending)
+    routes_module._pending_stages.clear()
 
-def test_inflight_scrape_across_generation_bump_discarded(client, monkeypatch):
-    client.get("/metrics")
+
+@pytest.mark.asyncio
+async def test_inflight_scrape_across_generation_bump_discarded(monkeypatch):
+    response = MagicMock(status_code=200, text=CANONICAL_VLLM_METRICS)
+    monkeypatch.setattr(proxy_module, "call_backend", AsyncMock(return_value=response))
+    await vllm_source.collect(0.0)
     assert vllm_source._last_good
 
     gate = asyncio.Event()
@@ -416,20 +429,57 @@ def test_inflight_scrape_across_generation_bump_discarded(client, monkeypatch):
 
     monkeypatch.setattr(proxy_module, "call_backend", slow_backend)
 
-    async def race():
-        vllm_source.reset_cache()
-        task = asyncio.create_task(vllm_source.collect(1.0))  # suspends in gather
-        await asyncio.sleep(0.05)
-        # model switch happens while the scrape is in flight
-        proxy_module.vllm_setup_generation += 1
-        vllm_source._last_good.clear()
-        vllm_source._cache_generation = proxy_module.vllm_setup_generation
-        gate.set()
-        await task
-        return dict(vllm_source._last_good)
+    task = asyncio.create_task(vllm_source.collect(1.0))
+    await asyncio.sleep(0)
+    proxy_module.vllm_setup_generation += 1
+    gate.set()
+    lines, timestamps = await task
+    assert lines == []
+    assert timestamps == {}
+    assert vllm_source._last_good == {}
 
-    cache_after = asyncio.get_event_loop_policy().new_event_loop().run_until_complete(race())
-    assert cache_after == {}  # stale in-flight results were discarded
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("generation_bump", [False, True])
+async def test_late_scrape_cannot_overwrite_newer_cache(
+    monkeypatch, generation_bump
+):
+    monkeypatch.setattr(proxy_module, "vllm_backend_ports", [5001])
+    monkeypatch.setattr(proxy_module, "vllm_healthy", {5001: True})
+    vllm_source._invalidate_cache(proxy_module.vllm_setup_generation)
+
+    old_release = asyncio.Event()
+    calls = 0
+
+    async def backend(port, method, path):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await old_release.wait()
+            value = "111.0"
+        else:
+            value = "222.0"
+        return MagicMock(
+            status_code=200,
+            text=CANONICAL_VLLM_METRICS.replace("144.0", value),
+        )
+
+    monkeypatch.setattr(proxy_module, "call_backend", backend)
+    older = asyncio.create_task(vllm_source.collect(1.0))
+    await asyncio.sleep(0)
+    if generation_bump:
+        proxy_module.vllm_setup_generation += 1
+    await vllm_source.collect(2.0)
+    old_release.set()
+    old_lines, old_timestamps = await older
+
+    series, timestamp = vllm_source._last_good["0"]
+    assert timestamp == 2.0
+    assert any("222.0" in line for line in series)
+    assert not any("111.0" in line for line in series)
+    if generation_bump:
+        assert old_lines == []
+        assert old_timestamps == {}
 
 
 def test_escape_label_values():
@@ -500,3 +550,42 @@ async def test_stalled_stage_not_reentered():
     release.set()
     await asyncio.sleep(0)
     routes_module._pending_stages.clear()
+
+
+@pytest.mark.asyncio
+async def test_completed_waiter_does_not_remove_new_stage(monkeypatch):
+    from api.metrics import routes as routes_module
+
+    routes_module._pending_stages.clear()
+    first_wait_finished = asyncio.Event()
+    release_first_waiter = asyncio.Event()
+    release_second_stage = asyncio.Event()
+    real_wait = asyncio.wait
+    wait_calls = 0
+
+    async def controlled_wait(*args, **kwargs):
+        nonlocal wait_calls
+        wait_calls += 1
+        done, pending = await real_wait(*args, **kwargs)
+        if wait_calls == 1:
+            first_wait_finished.set()
+            await release_first_waiter.wait()
+        return done, pending
+
+    monkeypatch.setattr(routes_module.asyncio, "wait", controlled_wait)
+    first = asyncio.create_task(routes_module._bounded(asyncio.sleep(0), 1, "src"))
+    await first_wait_finished.wait()
+
+    second = asyncio.create_task(
+        routes_module._bounded(release_second_stage.wait(), 1, "src")
+    )
+    await asyncio.sleep(0)
+    second_task = routes_module._pending_stages["src"]
+
+    release_first_waiter.set()
+    await first
+    assert routes_module._pending_stages.get("src") is second_task
+
+    release_second_stage.set()
+    await second
+    assert "src" not in routes_module._pending_stages

--- a/mlnode/packages/api/tests/unit/test_proxy.py
+++ b/mlnode/packages/api/tests/unit/test_proxy.py
@@ -443,3 +443,60 @@ async def test_resource_cleanup_verification():
     # Verify backend counts reset
     for port in [5001, 5002]:
         assert proxy_module.vllm_counts[port] == 0 
+
+# ---------------------------------------------------------------------------
+# Health-probe damping (_apply_health_damping)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def clean_health_state():
+    """Reset the module-level health dicts around each damping test."""
+    saved_healthy = dict(proxy_module.vllm_healthy)
+    saved_streak = dict(proxy_module.vllm_health_fail_streak)
+    proxy_module.vllm_healthy.clear()
+    proxy_module.vllm_health_fail_streak.clear()
+    yield
+    proxy_module.vllm_healthy.clear()
+    proxy_module.vllm_healthy.update(saved_healthy)
+    proxy_module.vllm_health_fail_streak.clear()
+    proxy_module.vllm_health_fail_streak.update(saved_streak)
+
+
+def _drive(port, probes, start_healthy):
+    """Feed a probe sequence through the damping and record verdicts, updating
+    vllm_healthy the same way _health_check_vllm does."""
+    proxy_module.vllm_healthy[port] = start_healthy
+    out = []
+    for probe in probes:
+        ok = proxy_module._apply_health_damping(port, probe)
+        proxy_module.vllm_healthy[port] = ok
+        out.append(ok)
+    return out
+
+
+def test_damping_startup_stays_down_until_first_success(clean_health_state):
+    assert _drive(5001, [False, False, True], start_healthy=False) == [False, False, True]
+
+
+def test_damping_two_blips_still_healthy(clean_health_state):
+    """Missed /health deadlines on a busy-but-alive engine (up to
+    HEALTH_FAIL_STREAK-1 in a row) must not stop the compatibility server."""
+    assert _drive(5001, [True, False, False, True], start_healthy=True) == [True, True, True, True]
+
+
+def test_damping_three_consecutive_failures_is_down(clean_health_state):
+    assert _drive(5001, [True, False, False, False], start_healthy=True) == [True, True, True, False]
+
+
+def test_damping_recovers_instantly_on_success(clean_health_state):
+    assert _drive(5001, [False, False, False, True], start_healthy=True) == [True, True, False, True]
+
+
+def test_damping_ports_are_independent(clean_health_state):
+    proxy_module.vllm_healthy.update({5001: True, 5002: True})
+    # 5001 fails 3x -> down; 5002 keeps succeeding -> up
+    for _ in range(3):
+        proxy_module.vllm_healthy[5001] = proxy_module._apply_health_damping(5001, False)
+        proxy_module.vllm_healthy[5002] = proxy_module._apply_health_damping(5002, True)
+    assert proxy_module.vllm_healthy[5001] is False
+    assert proxy_module.vllm_healthy[5002] is True

--- a/mlnode/packages/api/tests/unit/test_proxy.py
+++ b/mlnode/packages/api/tests/unit/test_proxy.py
@@ -1,21 +1,17 @@
 import pytest
 import asyncio
 import httpx
+import pytest_asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import Request
-from fastapi.testclient import TestClient
 from aiohttp import web
 
 from api.proxy import (
     ProxyMiddleware, 
-    setup_vllm_proxy, 
+    setup_vllm_proxy,
     start_vllm_proxy, 
     stop_vllm_proxy,
-    shutdown_event,
-    active_proxy_tasks,
-    tasks_lock,
     _proxy_request_to_backend,
-    _release_vllm_backend,
 )
 import api.proxy as proxy_module
 
@@ -51,7 +47,7 @@ async def test_proxy_middleware_routes_v1_to_vllm(proxy_middleware, mock_request
         
         # Test /v1 routing
         mock_request.url.path = "/v1/models"
-        result = await proxy_middleware.dispatch(mock_request, call_next)
+        await proxy_middleware.dispatch(mock_request, call_next)
         
         # Should call proxy, not call_next
         mock_proxy.assert_called_once_with(mock_request)
@@ -68,7 +64,7 @@ async def test_proxy_middleware_routes_api_to_main(proxy_middleware, mock_reques
     
     # Test /api routing
     mock_request.url.path = "/api/v1/inference"
-    result = await proxy_middleware.dispatch(mock_request, call_next)
+    await proxy_middleware.dispatch(mock_request, call_next)
     
     # Should call call_next, not proxy
     call_next.assert_called_once_with(mock_request)
@@ -84,7 +80,7 @@ async def test_proxy_middleware_default_routing(proxy_middleware, mock_request):
     
     # Test default routing
     mock_request.url.path = "/health"
-    result = await proxy_middleware.dispatch(mock_request, call_next)
+    await proxy_middleware.dispatch(mock_request, call_next)
     
     # Should call call_next
     call_next.assert_called_once_with(mock_request)
@@ -160,30 +156,27 @@ async def test_start_stop_vllm_proxy():
 # Graceful Shutdown Tests
 # ============================================================================
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def mock_backend_server():
-    """Create a mock aiohttp backend server for testing."""
     app = web.Application()
-    
+    release = asyncio.Event()
+
     async def slow_handler(request):
-        """Simulate a slow inference request."""
-        await asyncio.sleep(10)  # Long running operation
-        return web.Response(text="completed")
-    
-    async def instant_handler(request):
-        """Simulate an instant response."""
-        return web.Response(text="ok")
-    
-    app.router.add_get('/slow', slow_handler)
-    app.router.add_get('/instant', instant_handler)
-    
+        response = web.StreamResponse()
+        await response.prepare(request)
+        await release.wait()
+        return response
+
+    app.router.add_get("/slow", slow_handler)
+
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, '127.0.0.1', 8765)
+    site = web.TCPSite(runner, "127.0.0.1", 8765)
     await site.start()
-    
-    yield 'http://127.0.0.1:8765'
-    
+
+    yield 8765
+
+    release.set()
     await runner.cleanup()
 
 
@@ -239,66 +232,51 @@ async def reset_proxy_state():
 
 @pytest.mark.asyncio
 async def test_task_cancellation_during_active_request(mock_backend_server):
-    """Test that active proxy tasks are cancelled during shutdown."""
-    # Setup backend
-    setup_vllm_proxy([5001])
-    proxy_module.vllm_healthy[5001] = True
-    await start_vllm_proxy()
-    
-    # Create a mock request
+    setup_vllm_proxy([mock_backend_server])
+    proxy_module.vllm_healthy[mock_backend_server] = True
+    proxy_module.vllm_client = httpx.AsyncClient()
+
     mock_request = MagicMock(spec=Request)
     mock_request.method = "GET"
     mock_request.headers = {}
     mock_request.query_params = {}
-    mock_request.stream = AsyncMock(return_value=iter([]))
-    
-    # Track streaming task
-    streaming_started = asyncio.Event()
-    streaming_task = None
-    
+
+    async def empty_body():
+        if False:
+            yield b""
+
+    mock_request.stream = empty_body
+
     async def track_and_stream():
-        nonlocal streaming_task
-        # Start the proxy request
         try:
             response = await _proxy_request_to_backend(mock_request, "/slow")
-            streaming_started.set()
-            
-            # Consume the response (this will register the task)
-            # For StreamingResponse, body_iterator is the generator
-            if hasattr(response, 'body_iterator'):
-                async for chunk in response.body_iterator:
-                    pass
+            async for _ in response.body_iterator:
+                pass
         except asyncio.CancelledError:
-            pass  # Expected during shutdown
-    
-    # Start the streaming task
+            pass
+
     streaming_task = asyncio.create_task(track_and_stream())
-    
-    # Wait a bit for task registration
-    await asyncio.sleep(0.1)
-    
-    # Verify task is registered
-    async with proxy_module.tasks_lock:
-        initial_task_count = len(proxy_module.active_proxy_tasks)
-    
-    # Trigger shutdown
+    for _ in range(100):
+        async with proxy_module.tasks_lock:
+            if streaming_task in proxy_module.active_proxy_tasks:
+                break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("streaming task was not registered")
+
     proxy_module.shutdown_event.set()
-    
-    # Cancel the streaming task (simulating what manager would do)
+
     async with proxy_module.tasks_lock:
         tasks = list(proxy_module.active_proxy_tasks)
         proxy_module.active_proxy_tasks.clear()
-    
+
     for task in tasks:
         task.cancel()
-    
-    # Wait for cancellation to complete
+
     await asyncio.gather(*tasks, return_exceptions=True)
-    
-    # Verify tasks were cleared
     async with proxy_module.tasks_lock:
-        assert len(proxy_module.active_proxy_tasks) == 0
-    
+        assert not proxy_module.active_proxy_tasks
+
     await stop_vllm_proxy()
 
 
@@ -442,7 +420,7 @@ async def test_resource_cleanup_verification():
     
     # Verify backend counts reset
     for port in [5001, 5002]:
-        assert proxy_module.vllm_counts[port] == 0 
+        assert proxy_module.vllm_counts[port] == 0
 
 # ---------------------------------------------------------------------------
 # Health-probe damping (_apply_health_damping)

--- a/mlnode/packages/api/tests/unit/test_runner_heartbeat.py
+++ b/mlnode/packages/api/tests/unit/test_runner_heartbeat.py
@@ -1,0 +1,275 @@
+"""Unit tests for VLLMRunner.is_available() scheduler-heartbeat liveness.
+
+The check replaces vLLM's /health probe (wrong in both directions: false-positive
+under load, false-negative on a silent deadlock) with a read of the Prometheus
+counter vllm:iteration_tokens_total_count, which advances on every engine step
+and freezes only when the engine loop stalls.
+
+These tests drive is_available() over a controlled clock and mocked /metrics
+responses, covering the steady state, the hardened race conditions
+(counter-reset on engine restart, multi-process /metrics, blind scrapes,
+ConnectTimeout-vs-refused classification), multi-instance aggregation, and the
+config edge cases (grace disabled, malformed env).
+"""
+import re
+
+import pytest
+import requests as real_requests
+
+from api.inference.vllm import runner as runner_mod
+from api.inference.vllm.runner import VLLMRunner
+
+
+class _FakeResp:
+    def __init__(self, text):
+        self.text = text
+
+
+class _Clock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+def _metrics(iters=None, running=None, waiting=None, series=1):
+    """Render a minimal /metrics body. `series` repeats the counter/gauge lines
+    to emulate more than one engine registry exposed on the same port."""
+    lines = []
+    for k in range(series):
+        if iters is not None:
+            lines.append(f'vllm:iteration_tokens_total_count{{engine="{k}"}} {iters}')
+        if running is not None:
+            lines.append(f'vllm:num_requests_running{{engine="{k}"}} {running}')
+        if waiting is not None:
+            lines.append(f'vllm:num_requests_waiting{{engine="{k}"}} {waiting}')
+    return "\n".join(lines) + "\n"
+
+
+def _make_runner(monkeypatch, n_instances=1):
+    """A VLLMRunner with __init__ bypassed, `n_instances` live processes, a
+    controllable clock, and a per-port mockable /metrics endpoint."""
+    r = object.__new__(VLLMRunner)
+    r.VLLM_HOST = "127.0.0.1"
+    r.VLLM_PORT = 5000
+    r._hb = {}  # __init__ is bypassed; mirror its heartbeat-state init
+    proc = type("P", (), {"poll": staticmethod(lambda: None)})()
+    r.processes = [proc] * n_instances
+
+    clock = _Clock()
+    monkeypatch.setattr(runner_mod.time, "time", clock)
+
+    # per-port response/exception; "*" is the default for unlisted ports
+    state = {"*": {"resp": _metrics(iters=100, running=40, waiting=0), "exc": None}}
+
+    def fake_get(url, timeout=None):
+        port = int(url.split(":")[-1].split("/")[0])
+        s = state.get(port, state["*"])
+        if s["exc"] is not None:
+            raise s["exc"]
+        return _FakeResp(s["resp"])
+
+    monkeypatch.setattr(runner_mod.requests, "get", fake_get)
+
+    r._clock = clock
+    r._state = state
+    return r
+
+
+@pytest.fixture
+def runner(monkeypatch):
+    return _make_runner(monkeypatch, n_instances=1)
+
+
+def _serve(runner, port="*", **kw):
+    runner._state[port] = {"resp": _metrics(**kw), "exc": None}
+
+
+def _fail(runner, exc, port="*"):
+    runner._state[port] = {"resp": "", "exc": exc}
+
+
+def test_process_dead_is_unavailable(runner):
+    runner.processes = []  # is_running() -> False
+    assert runner.is_available() is False
+
+
+def test_advancing_counter_is_alive(runner):
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True  # baseline
+    runner._clock.advance(2)
+    _serve(runner, iters=185, running=40, waiting=0)
+    assert runner.is_available() is True
+
+
+def test_counter_regression_rebaselines(runner):
+    """Engine subprocess restarts and its counter resets to ~0 while work is
+    present. A '>' test would false-HUNG; '!=' must re-baseline and stay alive."""
+    _serve(runner, iters=90000, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(2)
+    _serve(runner, iters=5, running=40, waiting=0)  # fresh engine, counter reset
+    assert runner.is_available() is True
+    assert runner._hb[5001]["iter"] == 5  # re-baselined to the new low value
+
+
+def test_multiprocess_metrics_sum_advances(runner):
+    """Two registries on one port: the summed counter advances while either
+    engine steps, so the node is not read as frozen."""
+    _serve(runner, iters=100, running=40, waiting=0, series=2)  # sum=200
+    assert runner.is_available() is True
+    assert runner._hb[5001]["iter"] == 200
+    runner._clock.advance(2)
+    _serve(runner, iters=150, running=40, waiting=0, series=2)  # sum=300
+    assert runner.is_available() is True
+
+
+def test_idle_engine_is_alive(runner):
+    """No work (running==0 and waiting==0) with a frozen counter is a legitimate
+    idle-wait, not a hang."""
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(500)  # way past grace
+    _serve(runner, iters=100, running=0, waiting=0)  # counter frozen but no work
+    assert runner.is_available() is True
+
+
+def test_real_hang_reports_unhealthy_after_consecutive(runner, monkeypatch):
+    """Work present, counter frozen past grace: unhealthy only after
+    HANG_CONSECUTIVE (3) verdicts, so a single confused scrape cannot escalate."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True  # baseline @ t=1000
+    runner._clock.advance(200)  # past 120s grace, counter still 100, work present
+    assert runner.is_available() is True   # hung count 1/3
+    runner._clock.advance(2)
+    assert runner.is_available() is True   # hung count 2/3
+    runner._clock.advance(2)
+    assert runner.is_available() is False  # hung count 3/3 -> unhealthy
+
+
+def test_grace_recovers_before_escalation(runner, monkeypatch):
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(200)
+    assert runner.is_available() is True   # 1/3
+    runner._clock.advance(2)
+    _serve(runner, iters=300, running=40, waiting=0)  # engine steps again
+    assert runner.is_available() is True   # re-baselined, hung count reset
+    assert runner._hb[5001]["hung"] == 0
+
+
+def test_partial_scrape_missing_counter_uses_grace(runner, monkeypatch):
+    """Counter series absent but gauges present (work ongoing): alive within
+    grace, dead once grace is exceeded with no counter to prove liveness."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(60)
+    _serve(runner, iters=None, running=40, waiting=0)  # counter gone
+    assert runner.is_available() is True   # within grace (60s <= 120s)
+    runner._clock.advance(100)             # now 160s since baseline
+    _serve(runner, iters=None, running=40, waiting=0)
+    assert runner.is_available() is False
+
+
+def test_full_scrape_failure_is_not_masked_as_idle(runner, monkeypatch):
+    """Regression guard for the idle-shortcut hole: a total /metrics failure
+    (every value None) must NOT refresh the baseline and report healthy, which
+    would silently disable hang detection. It must fall through to grace."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True   # baseline @ t=1000
+    base_ts = runner._hb[5001]["ts"]
+    runner._clock.advance(30)
+    _serve(runner, iters=None, running=None, waiting=None)  # blind scrape
+    assert runner.is_available() is True   # within grace
+    assert runner._hb[5001]["ts"] == base_ts  # baseline NOT refreshed blindly
+    runner._clock.advance(200)             # 230s since baseline, still blind
+    _serve(runner, iters=None, running=None, waiting=None)
+    assert runner.is_available() is False  # grace exceeded -> unhealthy
+
+
+def test_connection_refused_is_dead(runner):
+    _fail(runner, real_requests.ConnectionError())
+    assert runner.is_available() is False
+
+
+def test_connect_timeout_uses_grace_not_dead(runner, monkeypatch):
+    """ConnectTimeout subclasses ConnectionError in requests, but a full SYN
+    backlog on a saturated server is not death: it must take the grace path,
+    not the immediate-dead path."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True   # baseline
+    runner._clock.advance(2)
+    _fail(runner, real_requests.exceptions.ConnectTimeout())
+    assert runner.is_available() is True   # within grace -> alive
+    runner._clock.advance(200)             # past grace, still timing out
+    assert runner.is_available() is False  # grace exceeded -> unhealthy
+
+
+def test_hang_detection_disabled_when_grace_zero(runner, monkeypatch):
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "0")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(100000)  # arbitrarily long freeze with work present
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True  # detection off
+
+
+def test_grace_zero_tolerates_blind_scrapes(runner, monkeypatch):
+    """grace=0 must disable ALL hang escalation, including the blind-scrape
+    path: a slow /metrics must not mark the node dead when detection is off."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "0")
+    _serve(runner, iters=100, running=40, waiting=0)
+    assert runner.is_available() is True
+    runner._clock.advance(500)
+    _fail(runner, TimeoutError())  # scrape fails entirely
+    assert runner.is_available() is True   # still alive: detection disabled
+    # but a refused connection still means dead even with detection off
+    _fail(runner, real_requests.ConnectionError())
+    assert runner.is_available() is False
+
+
+def test_malformed_grace_env_does_not_raise(runner, monkeypatch):
+    """An empty or garbage MLNODE_HANG_GRACE_SEC must not raise out of
+    is_available (a fleet-wide env templating mistake would otherwise turn
+    every health poll into an exception -> watcher kill-loop)."""
+    for bad in ("", "  ", "abc", "12.5"):
+        monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", bad)
+        _serve(runner, iters=100, running=40, waiting=0)
+        assert runner.is_available() is True  # falls back to default 120
+
+
+def test_multi_instance_hang_in_one_instance_reported(monkeypatch):
+    """Instance 3 freezes with work while instances 1/2/4 keep stepping: the
+    node must go unhealthy after grace + consecutive verdicts."""
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
+    r = _make_runner(monkeypatch, n_instances=4)
+    _serve(r, iters=100, running=40, waiting=0)          # default: advancing...
+    _serve(r, port=5003, iters=777, running=20, waiting=0)  # ...incl. 5003
+    assert r.is_available() is True  # baseline for all ports
+
+    step = 100
+    for tick in range(1, 4):
+        r._clock.advance(200 if tick == 1 else 2)
+        step += 85
+        _serve(r, iters=step, running=40, waiting=0)     # others advance
+        _serve(r, port=5003, iters=777, running=20, waiting=0)  # 5003 frozen
+        expected = tick < 3  # unhealthy on the 3rd consecutive frozen verdict
+        assert r.is_available() is expected, f"tick {tick}"
+
+
+def test_multi_instance_refused_port_is_dead(monkeypatch):
+    """A refused connection on ANY instance means that engine's API server is
+    gone: the node reports dead even if other instances are healthy."""
+    r = _make_runner(monkeypatch, n_instances=4)
+    _serve(r, iters=100, running=40, waiting=0)
+    _fail(r, real_requests.ConnectionError(), port=5002)
+    assert r.is_available() is False

--- a/mlnode/packages/api/tests/unit/test_runner_heartbeat.py
+++ b/mlnode/packages/api/tests/unit/test_runner_heartbeat.py
@@ -1,28 +1,24 @@
-"""Unit tests for VLLMRunner.is_available() scheduler-heartbeat liveness.
+"""Unit tests for vLLM scheduler-heartbeat liveness."""
 
-The check replaces vLLM's /health probe (wrong in both directions: false-positive
-under load, false-negative on a silent deadlock) with a read of the Prometheus
-counter vllm:iteration_tokens_total_count, which advances on every engine step
-and freezes only when the engine loop stalls.
-
-These tests drive is_available() over a controlled clock and mocked /metrics
-responses, covering the steady state, the hardened race conditions
-(counter-reset on engine restart, multi-process /metrics, blind scrapes,
-ConnectTimeout-vs-refused classification), multi-instance aggregation, and the
-config edge cases (grace disabled, malformed env).
-"""
-import re
+import asyncio
+import threading
+import time
+from contextlib import suppress
 
 import pytest
 import requests as real_requests
-
 from api.inference.vllm import runner as runner_mod
 from api.inference.vllm.runner import VLLMRunner
 
 
 class _FakeResp:
-    def __init__(self, text):
+    def __init__(self, text, status_code=200):
         self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise real_requests.HTTPError(response=self)
 
 
 class _Clock:
@@ -37,8 +33,6 @@ class _Clock:
 
 
 def _metrics(iters=None, running=None, waiting=None, series=1):
-    """Render a minimal /metrics body. `series` repeats the counter/gauge lines
-    to emulate more than one engine registry exposed on the same port."""
     lines = []
     for k in range(series):
         if iters is not None:
@@ -51,17 +45,16 @@ def _metrics(iters=None, running=None, waiting=None, series=1):
 
 
 def _make_runner(monkeypatch, n_instances=1):
-    """A VLLMRunner with __init__ bypassed, `n_instances` live processes, a
-    controllable clock, and a per-port mockable /metrics endpoint."""
     r = object.__new__(VLLMRunner)
     r.VLLM_HOST = "127.0.0.1"
     r.VLLM_PORT = 5000
     r._hb = {}  # __init__ is bypassed; mirror its heartbeat-state init
+    r._hb_lock = threading.Lock()
     proc = type("P", (), {"poll": staticmethod(lambda: None)})()
     r.processes = [proc] * n_instances
 
     clock = _Clock()
-    monkeypatch.setattr(runner_mod.time, "time", clock)
+    monkeypatch.setattr(runner_mod.time, "monotonic", clock)
 
     # per-port response/exception; "*" is the default for unlisted ports
     state = {"*": {"resp": _metrics(iters=100, running=40, waiting=0), "exc": None}}
@@ -93,6 +86,11 @@ def _fail(runner, exc, port="*"):
     runner._state[port] = {"resp": "", "exc": exc}
 
 
+def _assert_unhealthy_after_damping(runner):
+    for expected in (True, True, False):
+        assert runner.is_available() is expected
+
+
 def test_process_dead_is_unavailable(runner):
     runner.processes = []  # is_running() -> False
     assert runner.is_available() is False
@@ -106,9 +104,22 @@ def test_advancing_counter_is_alive(runner):
     assert runner.is_available() is True
 
 
+@pytest.mark.parametrize(
+    "response",
+    [_FakeResp(""), _FakeResp("not metrics", status_code=503)],
+    ids=["missing-series", "http-error"],
+)
+def test_first_scrape_must_be_complete(runner, monkeypatch, response):
+    monkeypatch.setattr(
+        runner_mod.requests,
+        "get",
+        lambda *args, **kwargs: response,
+    )
+    assert runner.is_available() is False
+    assert runner._hb[5001]["seen"] is False
+
+
 def test_counter_regression_rebaselines(runner):
-    """Engine subprocess restarts and its counter resets to ~0 while work is
-    present. A '>' test would false-HUNG; '!=' must re-baseline and stay alive."""
     _serve(runner, iters=90000, running=40, waiting=0)
     assert runner.is_available() is True
     runner._clock.advance(2)
@@ -118,8 +129,6 @@ def test_counter_regression_rebaselines(runner):
 
 
 def test_multiprocess_metrics_sum_advances(runner):
-    """Two registries on one port: the summed counter advances while either
-    engine steps, so the node is not read as frozen."""
     _serve(runner, iters=100, running=40, waiting=0, series=2)  # sum=200
     assert runner.is_available() is True
     assert runner._hb[5001]["iter"] == 200
@@ -129,8 +138,6 @@ def test_multiprocess_metrics_sum_advances(runner):
 
 
 def test_idle_engine_is_alive(runner):
-    """No work (running==0 and waiting==0) with a frozen counter is a legitimate
-    idle-wait, not a hang."""
     _serve(runner, iters=100, running=40, waiting=0)
     assert runner.is_available() is True
     runner._clock.advance(500)  # way past grace
@@ -139,17 +146,11 @@ def test_idle_engine_is_alive(runner):
 
 
 def test_real_hang_reports_unhealthy_after_consecutive(runner, monkeypatch):
-    """Work present, counter frozen past grace: unhealthy only after
-    HANG_CONSECUTIVE (3) verdicts, so a single confused scrape cannot escalate."""
     monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
     _serve(runner, iters=100, running=40, waiting=0)
     assert runner.is_available() is True  # baseline @ t=1000
     runner._clock.advance(200)  # past 120s grace, counter still 100, work present
-    assert runner.is_available() is True   # hung count 1/3
-    runner._clock.advance(2)
-    assert runner.is_available() is True   # hung count 2/3
-    runner._clock.advance(2)
-    assert runner.is_available() is False  # hung count 3/3 -> unhealthy
+    _assert_unhealthy_after_damping(runner)
 
 
 def test_grace_recovers_before_escalation(runner, monkeypatch):
@@ -157,61 +158,39 @@ def test_grace_recovers_before_escalation(runner, monkeypatch):
     _serve(runner, iters=100, running=40, waiting=0)
     assert runner.is_available() is True
     runner._clock.advance(200)
-    assert runner.is_available() is True   # 1/3
+    assert runner.is_available() is True  # 1/3
     runner._clock.advance(2)
     _serve(runner, iters=300, running=40, waiting=0)  # engine steps again
-    assert runner.is_available() is True   # re-baselined, hung count reset
+    assert runner.is_available() is True  # re-baselined, hung count reset
     assert runner._hb[5001]["hung"] == 0
 
 
-def test_partial_scrape_missing_counter_uses_grace(runner, monkeypatch):
-    """Counter series absent but gauges present (work ongoing): alive within
-    grace, dead once grace is exceeded with no counter to prove liveness."""
+@pytest.mark.parametrize(
+    ("metrics", "error"),
+    [
+        ({"iters": None, "running": 40, "waiting": 0}, None),
+        ({"iters": None, "running": 0, "waiting": 0}, None),
+        ({"iters": None, "running": None, "waiting": None}, None),
+        (None, real_requests.exceptions.ConnectTimeout()),
+    ],
+    ids=["missing-counter", "partial-idle", "blind", "connect-timeout"],
+)
+def test_unproven_progress_uses_grace(runner, monkeypatch, metrics, error):
     monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
     _serve(runner, iters=100, running=40, waiting=0)
     assert runner.is_available() is True
+    baseline = runner._hb[5001]["ts"]
+
+    if error is not None:
+        _fail(runner, error)
+    else:
+        _serve(runner, **metrics)
     runner._clock.advance(60)
-    _serve(runner, iters=None, running=40, waiting=0)  # counter gone
-    assert runner.is_available() is True   # within grace (60s <= 120s)
-    runner._clock.advance(100)             # now 160s since baseline
-    _serve(runner, iters=None, running=40, waiting=0)
-    assert runner.is_available() is False
+    assert runner.is_available() is True
+    assert runner._hb[5001]["ts"] == baseline
 
-
-def test_full_scrape_failure_is_not_masked_as_idle(runner, monkeypatch):
-    """Regression guard for the idle-shortcut hole: a total /metrics failure
-    (every value None) must NOT refresh the baseline and report healthy, which
-    would silently disable hang detection. It must fall through to grace."""
-    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
-    _serve(runner, iters=100, running=40, waiting=0)
-    assert runner.is_available() is True   # baseline @ t=1000
-    base_ts = runner._hb[5001]["ts"]
-    runner._clock.advance(30)
-    _serve(runner, iters=None, running=None, waiting=None)  # blind scrape
-    assert runner.is_available() is True   # within grace
-    assert runner._hb[5001]["ts"] == base_ts  # baseline NOT refreshed blindly
-    runner._clock.advance(200)             # 230s since baseline, still blind
-    _serve(runner, iters=None, running=None, waiting=None)
-    assert runner.is_available() is False  # grace exceeded -> unhealthy
-
-
-def test_connection_refused_is_dead(runner):
-    _fail(runner, real_requests.ConnectionError())
-    assert runner.is_available() is False
-
-
-def test_connect_timeout_uses_grace_not_dead(runner, monkeypatch):
-    """ConnectTimeout subclasses ConnectionError in requests, but a full SYN
-    backlog on a saturated server is not death: it must take the grace path,
-    not the immediate-dead path."""
-    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
-    _serve(runner, iters=100, running=40, waiting=0)
-    assert runner.is_available() is True   # baseline
-    runner._clock.advance(2)
-    _fail(runner, real_requests.exceptions.ConnectTimeout())
-    assert runner.is_available() is True   # within grace -> alive
-    runner._clock.advance(200)             # past grace, still timing out
-    assert runner.is_available() is False  # grace exceeded -> unhealthy
+    runner._clock.advance(100)
+    _assert_unhealthy_after_damping(runner)
 
 
 def test_hang_detection_disabled_when_grace_zero(runner, monkeypatch):
@@ -224,35 +203,68 @@ def test_hang_detection_disabled_when_grace_zero(runner, monkeypatch):
 
 
 def test_grace_zero_tolerates_blind_scrapes(runner, monkeypatch):
-    """grace=0 must disable ALL hang escalation, including the blind-scrape
-    path: a slow /metrics must not mark the node dead when detection is off."""
     monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "0")
     _serve(runner, iters=100, running=40, waiting=0)
     assert runner.is_available() is True
     runner._clock.advance(500)
     _fail(runner, TimeoutError())  # scrape fails entirely
-    assert runner.is_available() is True   # still alive: detection disabled
+    assert runner.is_available() is True  # still alive: detection disabled
     # but a refused connection still means dead even with detection off
     _fail(runner, real_requests.ConnectionError())
     assert runner.is_available() is False
 
 
+def test_first_blind_scrape_allowed_when_grace_zero(runner, monkeypatch):
+    monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "0")
+    _fail(runner, TimeoutError())
+    assert runner.is_available() is True
+    assert runner._hb[5001]["seen"] is False
+
+
 def test_malformed_grace_env_does_not_raise(runner, monkeypatch):
-    """An empty or garbage MLNODE_HANG_GRACE_SEC must not raise out of
-    is_available (a fleet-wide env templating mistake would otherwise turn
-    every health poll into an exception -> watcher kill-loop)."""
     for bad in ("", "  ", "abc", "12.5"):
         monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", bad)
         _serve(runner, iters=100, running=40, waiting=0)
         assert runner.is_available() is True  # falls back to default 120
 
 
+def test_runner_startup_timeout_uses_environment(monkeypatch):
+    runner = object.__new__(VLLMRunner)
+    runner.is_running = lambda: True
+    runner.is_available = lambda: False
+    clock = iter([0, 6, 7])
+    monkeypatch.setenv("VLLM_RUNNER_TIMEOUT", "7")
+    monkeypatch.setattr(runner_mod.time, "time", lambda: next(clock))
+    monkeypatch.setattr(runner_mod.time, "sleep", lambda _: None)
+    monkeypatch.setattr(runner_mod.logger, "error", lambda *args: None)
+
+    assert runner._wait_for_server() is False
+
+
+def test_runner_uses_image_vllm_module(monkeypatch):
+    runner = VLLMRunner(model="dummy-model")
+    commands = []
+    process = type("P", (), {"poll": staticmethod(lambda: None)})()
+    monkeypatch.setenv("MLNODE_VLLM_MODULE", "gonka_poc.entrypoint.api_router")
+    monkeypatch.setattr(runner_mod.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(runner, "_verify_and_fix_env", lambda: None)
+    monkeypatch.setattr(runner, "_wait_for_server", lambda: True)
+    monkeypatch.setattr(runner_mod, "setup_vllm_proxy", lambda ports: None)
+    monkeypatch.setattr(
+        runner_mod.subprocess,
+        "Popen",
+        lambda command, **kwargs: commands.append(command) or process,
+    )
+
+    runner.start()
+
+    assert "-m gonka_poc.entrypoint.api_router" in commands[0][2]
+
+
 def test_multi_instance_hang_in_one_instance_reported(monkeypatch):
-    """Instance 3 freezes with work while instances 1/2/4 keep stepping: the
-    node must go unhealthy after grace + consecutive verdicts."""
     monkeypatch.setenv("MLNODE_HANG_GRACE_SEC", "120")
     r = _make_runner(monkeypatch, n_instances=4)
-    _serve(r, iters=100, running=40, waiting=0)          # default: advancing...
+    _serve(r, iters=100, running=40, waiting=0)  # default: advancing...
     _serve(r, port=5003, iters=777, running=20, waiting=0)  # ...incl. 5003
     assert r.is_available() is True  # baseline for all ports
 
@@ -260,16 +272,78 @@ def test_multi_instance_hang_in_one_instance_reported(monkeypatch):
     for tick in range(1, 4):
         r._clock.advance(200 if tick == 1 else 2)
         step += 85
-        _serve(r, iters=step, running=40, waiting=0)     # others advance
+        _serve(r, iters=step, running=40, waiting=0)  # others advance
         _serve(r, port=5003, iters=777, running=20, waiting=0)  # 5003 frozen
         expected = tick < 3  # unhealthy on the 3rd consecutive frozen verdict
         assert r.is_available() is expected, f"tick {tick}"
 
 
 def test_multi_instance_refused_port_is_dead(monkeypatch):
-    """A refused connection on ANY instance means that engine's API server is
-    gone: the node reports dead even if other instances are healthy."""
     r = _make_runner(monkeypatch, n_instances=4)
     _serve(r, iters=100, running=40, waiting=0)
     _fail(r, real_requests.ConnectionError(), port=5002)
     assert r.is_available() is False
+
+
+def test_multi_instance_scrapes_run_concurrently(monkeypatch):
+    r = _make_runner(monkeypatch, n_instances=4)
+    barrier = threading.Barrier(4)
+
+    def synchronized_get(url, timeout=None):
+        barrier.wait(timeout=1)
+        return _FakeResp(_metrics(iters=100, running=0, waiting=0))
+
+    monkeypatch.setattr(runner_mod.requests, "get", synchronized_get)
+    assert r.is_available() is True
+
+
+def test_concurrent_health_checks_are_serialized(runner, monkeypatch):
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def blocking_get(url, timeout=None):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call = calls
+        if call == 1:
+            first_started.set()
+            release_first.wait(timeout=1)
+        return _FakeResp(_metrics(iters=call, running=0, waiting=0))
+
+    monkeypatch.setattr(runner_mod.requests, "get", blocking_get)
+    first = threading.Thread(target=runner.is_available)
+    second = threading.Thread(target=runner.is_available)
+    first.start()
+    assert first_started.wait(timeout=1)
+    second.start()
+    time.sleep(0.05)
+    assert calls == 1
+    release_first.set()
+    first.join(timeout=1)
+    second.join(timeout=1)
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_manager_watcher_does_not_block_event_loop():
+    from api.watcher import watch_managers
+
+    release = threading.Event()
+
+    class BlockingManager:
+        def is_healthy(self):
+            release.wait(timeout=1)
+            return True
+
+    task = asyncio.create_task(watch_managers(None, [BlockingManager()], interval=0))
+    started = time.monotonic()
+    await asyncio.sleep(0.05)
+    assert time.monotonic() - started < 0.5
+
+    release.set()
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
## Replacement for #1531

This PR is the reviewed replacement for #1531. It preserves the complete commit history from that PR and adds commit 1b07e5c6c with the fixes found during review.

Why this is not parallel duplicate work: the original head branch belongs to kaitakuai and could not be updated with the available credentials. This branch exists to carry the same work plus the reviewed fixes in one mergeable head. Once maintainers select this PR, #1531 should be closed as superseded.

## Inherited from #1531

- #1501 schema-v1 MLNode metrics exporter
- #1421 vLLM scheduler-heartbeat liveness and damped proxy probing
- documentation corrections describing the implemented DAPI/exporter behavior
- pinned vLLM 0.25.1 DeepSeek-V4-Flash release-candidate MLNode image

The original commits are retained unchanged before the review-fix commit.

## Review fixes added here

- scrape all vLLM replicas concurrently instead of multiplying the timeout by replica count
- reject HTTP-error heartbeat responses and require a complete first heartbeat baseline
- serialize heartbeat state mutation and use monotonic time for grace tracking
- keep grace=0 as a real hang-detection disable switch
- move the newly blocking inference health checks off the asyncio event loop
- protect exporter cache mutation and prevent older concurrent scrapes from overwriting newer replica data
- discard results from an old model generation without clearing a newer generation cache
- prevent an older completed metrics-stage waiter from removing its replacement task
- honor image-provided MLNODE_VLLM_MODULE so the gonka_poc routes are actually loaded
- honor image-provided VLLM_RUNNER_TIMEOUT while keeping the old 1200-second default
- reduce test duplication and remove obsolete or speculative documentation claims

## Deliberately not changed

- no runner lifecycle, shutdown, restart, survivor, or FlashInfer-cache changes
- no heartbeat response cache and no background node-state poller
- no Prometheus family or schema-v1 contract changes
- no redesign of the existing proxy health damping
- no multimodal or image-input changes
- no card-profile, host-driver, or deployment logic beyond the image pin inherited from #1531

## Validation

- 106 affected unit tests passed in the pinned K9 image on a B300 Linux host
- targeted Ruff F/E9 checks passed
- git diff --check passed
- DeepSeek-V4-Flash startup completed after 1217.44 seconds, proving the image timeout override works beyond the former fixed 1200-second ceiling
- process command confirmed gonka_poc.entrypoint.api_router rather than the default vLLM entrypoint
- /api/v1/pow routes were present and healthy
- regular chat-completions smoke test returned exactly OK
- PoC with batch 16 and seq_len 1024 processed 1488 nonces in 60.253 seconds: 1481.755 nonce/min
- PoC stopped cleanly and the MLNode remained healthy with the backend IDLE

Batch 32 is not valid with this image profile: 32 x 1024 requires 32768 batched tokens while the pinned profile forces max-num-batched-tokens=16384. The measured compatible profile therefore uses batch 16.

## Before merge

- run repository CI on this head
- verify the schema-v1 endpoint through the DAPI collector, including disabled and stale-source behavior
- run a multi-replica test on a node with enough GPUs to confirm per-replica heartbeat timing and exporter labels
- decide whether the B300 TP=1 RC image is intentionally suitable for the shared compose path; the image profile is not a fleet-wide B200, H200, or H100 configuration
- retain only one of this PR and #1531 to avoid merging the same inherited commits twice

## AI assistance disclosure

OpenAI Codex was used for review, test refactoring, implementation of the review fixes, B300 deployment verification, and drafting this description. The human submitter is responsible for reviewing every changed line and validating the commands and results above.