### PR TITLE
fix: apply portable BLST flags in api tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,13 @@ node-local-build:
 
 api-test:
 	@echo "Running decentralized-api tests..."
-	@cd decentralized-api && go test ./... -v -short > ../api-test-output.log
+	@cd decentralized-api && \
+		if [ "$(BLST_PORTABLE)" = "1" ]; then \
+			CGO_CFLAGS="$$(go env CGO_CFLAGS) -O2 $(BLST_PORTABLE_CGO_CFLAGS)" \
+				go test ./... -v -short > ../api-test-output.log 2>&1; \
+		else \
+			go test ./... -v -short > ../api-test-output.log 2>&1; \
+		fi
 	@echo "----------------------------------------"
 	@echo "DECENTRALIZED-API TEST SUMMARY:"
 	@PASS_COUNT=$$(grep -c "PASS:" api-test-output.log); \


### PR DESCRIPTION
## Summary

Apply the existing portable BLST CGO flags to `api-test` on Apple Silicon, preventing `SIGILL` crashes in `blst_cgo_init`.

## Changes

- Use `BLST_PORTABLE_CGO_CFLAGS` when `BLST_PORTABLE=1`
- Capture stderr in `api-test-output.log`

## Testing

```bash
make api-test
```

#1537