### PR TITLE
fix(gateway): stop 403 quarantine and break no-winner probation deadlock (#1506)

### DIFF
--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -3729,6 +3729,7 @@ func (g *Gateway) handleAdminUnquarantine(w http.ResponseWriter, r *http.Request
 	}
 	var req struct {
 		ParticipantKey string `json:"participant_key"`
+		Full           bool   `json:"full"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":{"message":%q}}`, err.Error()), http.StatusBadRequest)
@@ -3742,10 +3743,16 @@ func (g *Gateway) handleAdminUnquarantine(w http.ResponseWriter, r *http.Request
 		http.Error(w, `{"error":{"message":"participant limiter not configured"}}`, http.StatusServiceUnavailable)
 		return
 	}
-	cleared := g.participantLimiter.ClearQuarantine(req.ParticipantKey)
+	var cleared bool
+	if req.Full {
+		cleared = g.participantLimiter.ForgetParticipant(req.ParticipantKey)
+	} else {
+		cleared = g.participantLimiter.ClearQuarantine(req.ParticipantKey)
+	}
 	writeJSON(w, map[string]any{
 		"participant_key": req.ParticipantKey,
 		"cleared":         cleared,
+		"full":            req.Full,
 	})
 }
 

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -2179,10 +2179,6 @@ func TestParticipantRequestLimiterInferenceRouteFailureUsesShortQuarantine(t *te
 	limiter.ObserveResult("broken-host", "/sessions/38/chat/completions", http.StatusNotFound)
 	require.True(t, limiter.IsBlocked("broken-host"))
 	require.True(t, limiter.allow("broken-host", t0.Add(transportFailureQuarantine+time.Second)))
-
-	limiter.ObserveResult("forbidden-host", "/sessions/38/chat/completions", http.StatusForbidden)
-	require.True(t, limiter.IsBlocked("forbidden-host"))
-	require.True(t, limiter.allow("forbidden-host", t0.Add(transportFailureQuarantine+time.Second)))
 }
 
 func TestParticipantRequestLimiterTimestampDriftUsesShortQuarantine(t *testing.T) {
@@ -2334,6 +2330,60 @@ func TestParticipantRequestLimiterClearQuarantineStartsProbation(t *testing.T) {
 	}
 	limiter.ObserveSuccessfulInference("shared-host")
 	require.False(t, limiter.IsRecentlyQuarantined("shared-host"))
+	require.Equal(t, 0, limiter.TrackedCount())
+}
+
+func TestParticipantRequestLimiterForgetParticipantClearsProbation(t *testing.T) {
+	limiter := NewParticipantRequestLimiter(10, 10)
+	limiter.ObserveResult("shared-host", "/sessions/12/chat/completions", http.StatusServiceUnavailable)
+
+	require.True(t, limiter.ClearQuarantine("shared-host"))
+	require.True(t, limiter.IsRecentlyQuarantined("shared-host"))
+
+	require.True(t, limiter.ForgetParticipant("shared-host"))
+	require.False(t, limiter.IsRecentlyQuarantined("shared-host"))
+	require.False(t, limiter.IsBlocked("shared-host"))
+	_, noWinner := limiter.NoWinnerStatusForModel("shared-host", "")
+	require.False(t, noWinner)
+	require.Equal(t, 0, limiter.TrackedCount())
+
+	require.False(t, limiter.ForgetParticipant("shared-host"))
+	require.False(t, limiter.ForgetParticipant(""))
+}
+
+func TestHandleAdminUnquarantineFullForgetsParticipant(t *testing.T) {
+	g := NewGateway(nil, NewGatewayLimiter(0, 0), "Qwen/Test")
+	limiter := NewParticipantRequestLimiter(10, 10)
+	g.participantLimiter = limiter
+	limiter.ObserveResult("host-a", "/sessions/12/chat/completions", http.StatusServiceUnavailable)
+	limiter.ObserveResult("host-b", "/sessions/12/chat/completions", http.StatusServiceUnavailable)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/participants/unquarantine",
+		strings.NewReader(`{"participant_key":"host-a"}`))
+	rec := httptest.NewRecorder()
+	g.handleAdminUnquarantine(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, limiter.IsRecentlyQuarantined("host-a"))
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/admin/participants/unquarantine",
+		strings.NewReader(`{"participant_key":"host-b","full":true}`))
+	rec = httptest.NewRecorder()
+	g.handleAdminUnquarantine(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.False(t, limiter.IsRecentlyQuarantined("host-b"))
+	require.Equal(t, 1, limiter.TrackedCount())
+}
+
+func TestParticipantRequestLimiterWrongOwner403DoesNotQuarantine(t *testing.T) {
+	limiter := NewParticipantRequestLimiter(10, 10)
+
+	for i := 0; i < 10; i++ {
+		limiter.ObserveResultWithBody("owner-host", "/sessions/23/chat/completions", http.StatusForbidden, `{"message":"restricted to escrow owner"}`)
+	}
+
+	require.False(t, limiter.IsBlocked("owner-host"))
+	require.False(t, limiter.IsRecentlyQuarantined("owner-host"))
+	require.NoError(t, limiter.AllowRequest("owner-host", "/sessions/23/chat/completions"))
 	require.Equal(t, 0, limiter.TrackedCount())
 }
 

--- a/devshard/cmd/devshardctl/participant_limiter.go
+++ b/devshard/cmd/devshardctl/participant_limiter.go
@@ -771,6 +771,21 @@ func (l *ParticipantRequestLimiter) ClearQuarantine(participantKey string) bool 
 	return true
 }
 
+func (l *ParticipantRequestLimiter) ForgetParticipant(participantKey string) bool {
+	if participantKey == "" {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, ok := l.participants[participantKey]; !ok {
+		return false
+	}
+	delete(l.participants, participantKey)
+	l.persistDeleteLocked(participantKey)
+	log.Printf("participant_quarantine_forgotten participant_key=%s", participantKey)
+	return true
+}
+
 func (l *ParticipantRequestLimiter) SetMetrics(metrics *DevshardMetrics) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -1258,8 +1273,6 @@ func participantHTTPQuarantineReason(path string, statusCode int, body string) s
 		return "http_timestamp_drift"
 	case statusCode == http.StatusNotFound && participantPathKind(path) == "inference":
 		return "http_not_found"
-	case statusCode == http.StatusForbidden && participantPathKind(path) == "inference":
-		return "http_forbidden"
 	default:
 		return "transport_failure_quarantine"
 	}
@@ -1271,7 +1284,7 @@ func (l *ParticipantRequestLimiter) participantHTTPQuarantine(path string, statu
 		return l.httpThrottleQuarantine
 	case statusCode == http.StatusUnauthorized && participantPathKind(path) == "inference" && strings.Contains(strings.ToLower(body), "timestamp drift"):
 		return l.transportFailureQuarantine
-	case (statusCode == http.StatusNotFound || statusCode == http.StatusForbidden) && participantPathKind(path) == "inference":
+	case statusCode == http.StatusNotFound && participantPathKind(path) == "inference":
 		return l.transportFailureQuarantine
 	default:
 		return 0

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -847,6 +847,40 @@ func TestRunInference_HappyPath(t *testing.T) {
 	require.True(t, ok, "inference 1 should exist")
 }
 
+func TestRunInference_AllHostsOnProbationCrownsSuspiciousFallback(t *testing.T) {
+	zeroReceiptTimeout(t)
+	setNonStreamingTimeouts(t, 5*time.Second, 10*time.Second, 12*time.Second)
+	env := setupTestProxy(t, 3, nil, true)
+
+	limiter := NewParticipantRequestLimiter(600, 10)
+	env.proxy.redundancy.participantLimiter = limiter
+	keys := env.session.ParticipantKeys()
+	require.Len(t, keys, 3)
+	for _, key := range keys {
+		limiter.ObserveResultWithBody(key, "/sessions/1/chat/completions", http.StatusNotFound, "")
+		require.True(t, limiter.ClearQuarantine(key))
+		status, noWinner := limiter.NoWinnerStatusForModel(key, "llama")
+		require.True(t, noWinner)
+		require.Equal(t, "probation", status.reason)
+	}
+
+	start := time.Now()
+	var buf bytes.Buffer
+	err := env.proxy.redundancy.RunInference(context.Background(), defaultParams(), &buf, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, buf.String())
+	require.Less(t, time.Since(start), 8*time.Second)
+
+	for i := 0; i < participantProbationSuccessesAfterQuarantine; i++ {
+		var next bytes.Buffer
+		require.NoError(t, env.proxy.redundancy.RunInference(context.Background(), defaultParams(), &next, nil))
+	}
+	for _, key := range keys {
+		_, noWinner := limiter.NoWinnerStatusForModel(key, "llama")
+		require.False(t, noWinner, "participant %s should have recovered from probation", key)
+	}
+}
+
 // errSimulatedWinnerTransport is returned by streamContentThenErrClient after
 // it streams a content-bearing SSE chunk so the race crowns a winner.
 var errSimulatedWinnerTransport = errors.New("simulated winner transport failure")

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -2387,7 +2387,11 @@ func (e *Redundancy) awaitRace(streamCtx, settleCtx context.Context, attempts []
 			}
 		}
 		if allInflightsDone(attempts) && escalationC == nil {
-			if !params.Stream && winner == 0 && time.Now().Before(requestStart.Add(nonStreamingNoContentTimeout)) {
+			var fallback *inflight
+			if winner == 0 {
+				fallback = fallbackSuspiciousWinner(attempts)
+			}
+			if !params.Stream && winner == 0 && fallback == nil && time.Now().Before(requestStart.Add(nonStreamingNoContentTimeout)) {
 				if !reducedMaxTokensFallbackStarted && time.Now().Before(requestStart.Add(nonStreamingReducedMaxTokensFallbackDelay)) && len(attempts) < maxAttempts {
 					trigger := attempts[len(attempts)-1]
 					trigger.escalated = true
@@ -2411,13 +2415,11 @@ func (e *Redundancy) awaitRace(streamCtx, settleCtx context.Context, attempts []
 				if nonStreamingTimeoutTimer != nil {
 					stopTimer(nonStreamingTimeoutTimer)
 				}
-				if winner == 0 {
-					if fallback := fallbackSuspiciousWinner(attempts); fallback != nil {
-						if err := race.promoteFallbackWinner(fallback); err != nil {
-							return err
-						}
-						winner = fallback.nonce
+				if winner == 0 && fallback != nil {
+					if err := race.promoteFallbackWinner(fallback); err != nil {
+						return err
 					}
+					winner = fallback.nonce
 				}
 				return e.finishRaceOutcome(settleCtx, attempts, params, decision, winner, raceFinishOptions{recordFailureSamples: true})
 			}

--- a/devshard/docs/host-health.md
+++ b/devshard/docs/host-health.md
@@ -20,9 +20,11 @@ rotation but is effectively skipped.
 |---|---|---|---|
 | HTTP 429 or 503 | 60 min | any | Host reported overload or rate limit |
 | HTTP 404 on inference | 30 min | `/chat/completions` | Escrow not registered on host |
+| HTTP 401 with `timestamp drift` body on inference | 30 min | `/chat/completions` | Gateway clock skew vs host, or signed request aged in queue before send |
 | Non-EOF transport failure on inference | 30 min | `/chat/completions` | Dial timeout, connection refused, TLS error |
 | 3 consecutive EOF transport failures on inference | 30 min | `/chat/completions` | EOF-style stream/read failures. Streak resets on quarantine or on a successful inference. |
 | Transport failure on non-inference | none | `/verify-timeout`, `/gossip/*`, etc. | Logged but not quarantined — a flaky vote RPC should not remove an otherwise healthy inference host |
+| HTTP 403 on inference | none | `/chat/completions` | Not quarantined — `restricted to escrow owner` is a request-level fault (signer/escrow mismatch), identical from every host, and says nothing about host health |
 | 3 consecutive empty streams | 30 min | inference result | Host returns receipt but zero content chunks, three times in a row. Empty streams are only counted when the overall request succeeded via another attempt. Streak resets on quarantine or on a successful inference. |
 | Stalled winner | 30 min | inference result | Host won the race, emitted content, then went silent long enough to trigger the inter-chunk stall timeout (1 min). Immediate quarantine, no streak. |
 
@@ -34,6 +36,22 @@ rotation but is effectively skipped.
 - When quarantine expires and tokens recover to full burst, the host is removed from tracking entirely (persistent record deleted).
 - A successful inference (`ObserveSuccessfulInference`) clears empty-stream and EOF streaks but does not end an active quarantine early.
 
+### Post-quarantine probation
+
+Every exit from quarantine — natural expiry, admin unquarantine, or restart
+with an expired persisted row — leaves the host with 2 failure strikes
+("probation"). While on probation the host receives real traffic but its
+attempts are marked no-winner (`suspicious_winner_deferred`): its content is
+buffered and only crowned as a fallback when no clean host produces content
+first. Each finished, non-empty inference decrements one strike; at zero the
+host leaves tracking.
+
+When every host in an escrow is on probation (e.g. after a mass quarantine),
+the race ends with no crowned winner and the buffered content of the best
+suspicious attempt is promoted to the client immediately, for both streaming
+and non-streaming requests. The settled request then counts toward strike
+recovery, so the pool heals itself instead of deadlocking.
+
 ### Admin override
 
 ```
@@ -44,8 +62,17 @@ Authorization: Bearer $DEVSHARD_ADMIN_API_KEY
 {"participant_key": "gonka1abc...xyz"}
 ```
 
-Immediately clears quarantine and resets the token bucket. The host becomes
-available for the next nonce that maps to it.
+Immediately clears quarantine and resets the token bucket, but keeps the host
+on the normal post-quarantine probation path (2 strikes).
+
+```
+{"participant_key": "gonka1abc...xyz", "full": true}
+```
+
+With `"full": true` the participant is forgotten entirely: quarantine,
+probation strikes, and the persisted throttle row are all removed, as if the
+host had never been throttled. Use this when the quarantine is known to be a
+false positive.
 
 ## PerfTracker (Performance Tracking)
 
@@ -114,7 +141,7 @@ The two systems are independent and can overlap:
 
 ### Quarantine
 
-- `participant_limit_activated` — 429/503 quarantine
+- `participant_limit_activated` — 429/503/404/drift-401 quarantine
 - `participant_limit_transport_failure` — non-EOF inference transport failure quarantine
 - `participant_limit_eof_transport_streak` — EOF inference transport failure streak increment
 - `participant_limit_eof_transport_quarantine` — 3-strike EOF inference transport failure quarantine
@@ -122,6 +149,7 @@ The two systems are independent and can overlap:
 - `participant_limit_empty_stream_quarantine` — 3-strike empty stream on requests that succeeded via another attempt
 - `participant_limit_stalled_winner_quarantine` — stalled winner
 - `participant_quarantine_cleared` — admin override via unquarantine endpoint
+- `participant_quarantine_forgotten` — admin full clear (`"full": true`)
 - `participant_quarantine_ended` — natural expiry
 - `participant_limit_rejected` — request blocked by quarantine
 

--- a/devshard/e2e/containers_test.go
+++ b/devshard/e2e/containers_test.go
@@ -61,6 +61,7 @@ type containerSpec struct {
 type e2eEnvOptions struct {
 	hostVolumeNames    []string
 	usePostgresStorage bool
+	ctlPrivateKey      string
 }
 
 func startHappyPathEnv(ctx context.Context, t *testing.T, images e2eImages) *e2eEnv {
@@ -136,6 +137,10 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 		env.startHost(ctx, t, i)
 	}
 
+	ctlPrivateKey := opts.ctlPrivateKey
+	if ctlPrivateKey == "" {
+		ctlPrivateKey = testutil.EnvDefault("DEVSHARD_E2E_USER_PRIVATE_KEY", testutil.UserPrivateKey)
+	}
 	devshardctl := env.startContainer(ctx, t, containerSpec{
 		name:    devshardCtlName,
 		image:   images.devshardctl,
@@ -146,7 +151,7 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 			"DEVSHARD_CHAIN_GRPC":      mockChainAlias + ":9090",
 			"DEVSHARD_PUBLIC_API":      "http://" + mockChainAlias + ":9191",
 			"DEVSHARD_PARAMS_SOURCE":   "chain",
-			"DEVSHARD_PRIVATE_KEY":     testutil.EnvDefault("DEVSHARD_E2E_USER_PRIVATE_KEY", testutil.UserPrivateKey),
+			"DEVSHARD_PRIVATE_KEY":     ctlPrivateKey,
 			"DEVSHARD_ADMIN_API_KEY":   testutil.AdminAPIKey,
 			"DEVSHARD_STORAGE_PATH":    "/tmp/devshardctl",
 			"DEVSHARD_MODEL":           "stub-model",
@@ -363,6 +368,23 @@ func (e *e2eEnv) terminate(ctx context.Context, t *testing.T) {
 			t.Logf("terminate %s: %v", c.name, err)
 		}
 	}
+}
+
+func (e *e2eEnv) containerLogs(ctx context.Context, t *testing.T, name string) string {
+	t.Helper()
+	for _, c := range e.containers {
+		if c.name != name {
+			continue
+		}
+		logs, err := c.container.Logs(ctx)
+		require.NoError(t, err, "logs for %s", name)
+		body, readErr := io.ReadAll(logs)
+		require.NoError(t, logs.Close())
+		require.NoError(t, readErr, "read logs for %s", name)
+		return string(body)
+	}
+	t.Fatalf("container %s not found", name)
+	return ""
 }
 
 func (e *e2eEnv) dumpContainerLogs(ctx context.Context, t *testing.T) {

--- a/devshard/e2e/quarantine_recovery_test.go
+++ b/devshard/e2e/quarantine_recovery_test.go
@@ -1,0 +1,207 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/e2e/testutil"
+)
+
+const wrongOwnerPrivateKey = "0000000000000000000000000000000000000000000000000000000000000022"
+
+func participantAddresses(t *testing.T) []string {
+	t.Helper()
+	addrs := make([]string, 0, len(testutil.HostPrivateKeys))
+	for _, key := range testutil.HostPrivateKeys {
+		addrs = append(addrs, signerAddress(t, key))
+	}
+	return addrs
+}
+
+func participantThrottleViews(t *testing.T, client *http.Client, clientURL string) map[string]map[string]any {
+	t.Helper()
+	resp := testutil.GetJSON(t, client, clientURL+"/v1/admin/devshards/"+defaultEscrowID+"/participants")
+	raw, ok := resp["participants"].([]any)
+	require.True(t, ok, "participants payload: %v", resp)
+	views := make(map[string]map[string]any, len(raw))
+	for _, entry := range raw {
+		view, ok := entry.(map[string]any)
+		require.True(t, ok, "participant entry: %v", entry)
+		key, _ := view["participant_key"].(string)
+		require.NotEmpty(t, key, "participant entry missing key: %v", entry)
+		views[key] = view
+	}
+	return views
+}
+
+func viewBool(view map[string]any, field string) bool {
+	value, _ := view[field].(bool)
+	return value
+}
+
+func pollParticipantsUntil(t *testing.T, client *http.Client, clientURL, condition string, timeout time.Duration, predicate func(map[string]map[string]any) bool) map[string]map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var views map[string]map[string]any
+	for {
+		views = participantThrottleViews(t, client, clientURL)
+		if predicate(views) {
+			return views
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for participants condition %q, last views: %v", condition, views)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func postChatIgnoreOutcome(t *testing.T, clientURL, content string, timeout time.Duration) {
+	t.Helper()
+	body, err := json.Marshal(testutil.ChatCompletionBody(content, false))
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, clientURL+"/v1/chat/completions", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testutil.AdminAPIKey)
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		testutil.DebugLogf(t, "chat %q ended with client-side error (expected in failure scenarios): %v", content, err)
+		return
+	}
+	defer resp.Body.Close()
+	testutil.DebugLogf(t, "chat %q returned status=%d", content, resp.StatusCode)
+}
+
+func unquarantineParticipant(t *testing.T, client *http.Client, clientURL, participantKey string, full bool) bool {
+	t.Helper()
+	body := map[string]any{"participant_key": participantKey}
+	if full {
+		body["full"] = true
+	}
+	resp := testutil.PostJSON(t, client, clientURL+"/v1/admin/participants/unquarantine", body)
+	cleared, _ := resp["cleared"].(bool)
+	return cleared
+}
+
+func TestE2E_WrongOwner403DoesNotQuarantineHosts(t *testing.T) {
+	requireE2EEnabled(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	images := requiredImages(t)
+	env := startE2EEnv(ctx, t, images, e2eEnvOptions{ctlPrivateKey: wrongOwnerPrivateKey})
+	client := &http.Client{Timeout: testutil.DefaultRequestTimeout}
+
+	postChatIgnoreOutcome(t, env.clientURL, "wrong owner chat", 20*time.Second)
+
+	deadline := time.Now().Add(60 * time.Second)
+	var logs string
+	for {
+		logs = env.containerLogs(ctx, t, devshardCtlName)
+		if strings.Contains(logs, "status 403") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("gateway never observed a wrong-owner 403 from hosts; logs:\n%s", logs)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	require.NotContains(t, logs, "participant_limit_activated",
+		"wrong-owner 403 must not activate participant quarantine")
+
+	views := participantThrottleViews(t, client, env.clientURL)
+	for _, addr := range participantAddresses(t) {
+		view, ok := views[addr]
+		require.True(t, ok, "participant %s missing from admin view: %v", addr, views)
+		require.False(t, viewBool(view, "quarantined"), "participant %s must not be quarantined: %v", addr, view)
+		require.False(t, viewBool(view, "tracked"), "participant %s must not be tracked by the limiter: %v", addr, view)
+	}
+}
+
+func TestE2E_MassQuarantineSoftUnquarantineRecoversWithoutRestart(t *testing.T) {
+	requireE2EEnabled(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	t.Cleanup(cancel)
+
+	images := requiredImages(t)
+	env := startE2EEnv(ctx, t, images, e2eEnvOptions{
+		hostVolumeNames: sqliteHostVolumeNames(t),
+	})
+	client := &http.Client{Timeout: testutil.DefaultRequestTimeout}
+	addrs := participantAddresses(t)
+
+	testutil.SendCompletion(t, client, env.clientURL, "baseline before mass quarantine")
+
+	for i := range env.hostURLs {
+		env.stopHost(ctx, t, i)
+	}
+	postChatIgnoreOutcome(t, env.clientURL, "mass quarantine trigger", 20*time.Second)
+
+	pollParticipantsUntil(t, client, env.clientURL, "all participants quarantined", 60*time.Second,
+		func(views map[string]map[string]any) bool {
+			for _, addr := range addrs {
+				if !viewBool(views[addr], "quarantined") {
+					return false
+				}
+			}
+			return true
+		})
+
+	for i := range env.hostURLs {
+		env.startHost(ctx, t, i)
+	}
+	for _, addr := range addrs {
+		require.True(t, unquarantineParticipant(t, client, env.clientURL, addr, false),
+			"soft unquarantine should clear quarantine state for %s", addr)
+	}
+
+	views := participantThrottleViews(t, client, env.clientURL)
+	for _, addr := range addrs {
+		view := views[addr]
+		require.False(t, viewBool(view, "quarantined"), "participant %s should be out of quarantine: %v", addr, view)
+		require.True(t, viewBool(view, "probationary"), "participant %s should be on probation: %v", addr, view)
+	}
+
+	resp := testutil.SendCompletionRaw(t, client, env.clientURL, "chat with whole escrow on probation", testutil.AdminAPIKey)
+	testutil.LogRawResponse(t, "probation completion", resp)
+	testutil.RequireOpenAINonStreamingCompletion(t, resp)
+
+	for i := 0; i < 3; i++ {
+		views = participantThrottleViews(t, client, env.clientURL)
+		remaining := false
+		for _, addr := range addrs {
+			if viewBool(views[addr], "probationary") {
+				remaining = true
+			}
+		}
+		if !remaining {
+			break
+		}
+		testutil.SendCompletion(t, client, env.clientURL, "probation recovery chat")
+	}
+	views = pollParticipantsUntil(t, client, env.clientURL, "probation fully drained", 30*time.Second,
+		func(views map[string]map[string]any) bool {
+			for _, addr := range addrs {
+				if viewBool(views[addr], "probationary") || viewBool(views[addr], "tracked") {
+					return false
+				}
+			}
+			return true
+		})
+	testutil.DebugLogf(t, "final participant views: %v", views)
+
+	logs := env.containerLogs(ctx, t, devshardCtlName)
+	require.Contains(t, logs, "participant_limit_transport_failure", "mass quarantine should have been transport-triggered")
+	require.Contains(t, logs, "participant_quarantine_cleared", "soft unquarantine should be logged")
+}


### PR DESCRIPTION
## Changes
- **No quarantine on inference 403** (`participant_limiter.go`): a 403 is a verdict on the request's signer, identical from every host — never a host-health signal. 404, drift-401, 429/503 and transport triggers are unchanged. 403s stay visible in transport-error metrics and `send_failed` logs.
- **Immediate suspicious-fallback crowning for non-streaming** (`redundancy.go`): the existing `fallbackSuspiciousWinner` promotion now fires as soon as all attempts are done and nothing is left to try, instead of being starved by the 30-minute non-streaming no-content window. Escalation to untried hosts still takes priority (`escalationC == nil` gate), and the empty-stream reduced-max-tokens fallback is untouched (`fallback == nil` keeps the old path). Settled requests then decrement probation strikes via the normal `ObserveSuccessfulInference` path, so the pool heals itself.
- **Admin full clear** (`gateway.go`): `POST /v1/admin/participants/unquarantine` with `{"full": true}` forgets the participant entirely (quarantine + probation strikes + persisted row). Soft unquarantine behavior is unchanged.