### PR TITLE
fix(devshard): bound executor-supplied confirmed_at

### DIFF
--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -1713,13 +1713,13 @@ func TestHandleDebugInferences_IncludesSealedInferences(t *testing.T) {
 	require.NoError(t, err)
 
 	start := &types.MsgStartInference{
-		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	_, err = sm.ApplyLocal(1, []*types.DevshardTx{{Tx: &types.DevshardTx_StartInference{StartInference: start}}})
 	require.NoError(t, err)
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], escrowID, 1, []byte("prompt"), "llama", 100, 50, 1000, 2000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], escrowID, 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	_, err = sm.ApplyLocal(2, []*types.DevshardTx{{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 2000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	}}}})
 	require.NoError(t, err)
 	finish := &types.MsgFinishInference{

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -80,7 +80,7 @@ func startTx(inferenceID uint64) *types.DevshardTx {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}}}
 }
 

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -108,7 +108,7 @@ func defaultPayload() *InferencePayload {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 }
 
@@ -272,7 +272,7 @@ func TestHost_ExecutorReceipt(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 		EscrowId:    "escrow-1",
 		ConfirmedAt: resp.ConfirmedAt,
 	}
@@ -704,7 +704,7 @@ func TestHost_PayloadMismatch_InputLengthWorkload(t *testing.T) {
 		Model:       "llama",
 		InputLength: 0,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{
 		{Tx: &types.DevshardTx_StartInference{StartInference: start}},
@@ -717,7 +717,7 @@ func TestHost_PayloadMismatch_InputLengthWorkload(t *testing.T) {
 			Model:       "llama",
 			InputLength: 0,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	})
 	require.ErrorIs(t, err, types.ErrPayloadMismatch)
@@ -739,7 +739,7 @@ func TestHost_PayloadMismatch_MaxTokensWorkload(t *testing.T) {
 		Model:       "llama",
 		InputLength: uint64(len(prompt)),
 		MaxTokens:   1,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{
 		{Tx: &types.DevshardTx_StartInference{StartInference: start}},
@@ -752,7 +752,7 @@ func TestHost_PayloadMismatch_MaxTokensWorkload(t *testing.T) {
 			Model:       "llama",
 			InputLength: uint64(len(prompt)),
 			MaxTokens:   1,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	})
 	require.ErrorIs(t, err, types.ErrPayloadMismatch)
@@ -1231,10 +1231,10 @@ func TestWarmKey_HostFindsSlotByWarmKey(t *testing.T) {
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	}}}
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{confirmTx})
 	_, err = sm.ApplyDiff(diff)
@@ -1392,9 +1392,9 @@ func TestHost_ValidationTriggersOnFinishedInference(t *testing.T) {
 	require.Empty(t, valEngine.getCalls(), "should not validate pending inference")
 
 	// Nonce 2: ConfirmStart (to transition from Pending to Started).
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, 1000, 2000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 2000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	}}}
 	diff2 := testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{confirmTx})
 
@@ -1494,9 +1494,9 @@ func TestHost_ValidationQueueLimitsConcurrentWorkers(t *testing.T) {
 		}))
 		nonce++
 
-		confirmedAt := int64(2000 + i)
+		confirmedAt := testutil.TestConfirmedAt + int64(i)
 		execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-queue", inferenceID,
-			testutil.TestPromptHash[:], "llama", 100, 50, 1000, confirmedAt)
+			testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, confirmedAt)
 		confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
 			InferenceId: inferenceID,
 			ExecutorSig: execSig,
@@ -1639,10 +1639,10 @@ func TestAccumulateGossipSig_WarmKey(t *testing.T) {
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	}}}
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{confirmTx})
 	_, err = sm.ApplyDiff(diff)

--- a/devshard/host/timeout.go
+++ b/devshard/host/timeout.go
@@ -58,7 +58,11 @@ func VerifyRefusedTimeout(
 	// Fast path: check local mempool for MsgConfirmStart or MsgFinishInference.
 	for _, tx := range localMempool {
 		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
-			return false, nil // executor already confirmed
+			// An unapplicable receipt counts as absent, else it would block
+			// the refusal timeout forever.
+			if types.ValidateConfirmedAt(cs.ConfirmedAt, rec.StartedAt) == nil {
+				return false, nil // executor already confirmed
+			}
 		}
 		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
 			return false, nil // executor already finished
@@ -73,6 +77,10 @@ func VerifyRefusedTimeout(
 	// Verifier validates payload against on-chain record (same checks executor does).
 	if err := VerifyPayload(payload, rec.PromptHash, rec.Model, rec.InputLength, rec.MaxTokens, rec.StartedAt); err != nil {
 		return false, nil // bad payload -> reject timeout
+	}
+
+	if types.ValidateConfirmedAt(nowUnix, rec.StartedAt) != nil {
+		return true, nil
 	}
 
 	// Challenge executor: one call that applies diffs + verifies payload + returns receipt.

--- a/devshard/host/timeout_test.go
+++ b/devshard/host/timeout_test.go
@@ -36,7 +36,7 @@ func testPayload() *InferencePayload {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 }
 
@@ -72,7 +72,7 @@ func stateWithPendingFull(inferenceID uint64, executorSlot uint32) types.EscrowS
 				Status:       types.StatusPending,
 				ExecutorSlot: executorSlot,
 				ReservedCost: 150,
-				StartedAt:    1000,
+				StartedAt:    testutil.TestStartedAt,
 				PromptHash:   promptHash[:],
 				Model:        "llama",
 				InputLength:  100,
@@ -121,12 +121,40 @@ func deadlinePassedExecution(st types.EscrowState, inferenceID uint64) int64 {
 func TestVerifyRefused_ReceiptInLocalMempool(t *testing.T) {
 	st := stateWithPendingFull(1, 1)
 	mempool := []*types.DevshardTx{
-		{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{InferenceId: 1}}},
+		{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+			InferenceId: 1,
+			ConfirmedAt: st.Inferences[1].StartedAt + 1,
+		}}},
 	}
 
 	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, mempool, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.NoError(t, err)
 	require.False(t, accept, "should reject: receipt in local mempool")
+}
+
+func TestVerifyRefused_OutOfBoundsReceiptInMempoolDoesNotBlockTimeout(t *testing.T) {
+	st := stateWithPendingFull(1, 1)
+	mempool := []*types.DevshardTx{
+		{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+			InferenceId: 1,
+			ConfirmedAt: st.Inferences[1].StartedAt + types.MaxConfirmationDelaySeconds + 1,
+		}}},
+	}
+	executor := &mockExecutorClient{challengeReceiptErr: errors.New("unreachable")}
+
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, mempool, executor, st.Config, deadlinePassedRefused(st, 1))
+	require.NoError(t, err)
+	require.True(t, accept, "unapplicable receipt must count as absent, not block the timeout")
+}
+
+func TestVerifyRefused_PastConfirmationBoundAcceptsWithoutChallenge(t *testing.T) {
+	st := stateWithPendingFull(1, 1)
+	executor := &mockExecutorClient{challengeReceipt: []byte("receipt")}
+	now := st.Inferences[1].StartedAt + types.MaxConfirmationDelaySeconds + 1
+
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, st.Config, now)
+	require.NoError(t, err)
+	require.True(t, accept, "no admissible receipt can exist past the bound")
 }
 
 func TestVerifyRefused_ExecutorUnreachable_ValidRequest(t *testing.T) {

--- a/devshard/host/validation_obs_drop_test.go
+++ b/devshard/host/validation_obs_drop_test.go
@@ -81,9 +81,9 @@ func driveToValidation(t *testing.T, h *Host, user *signing.Secp256k1Signer, hos
 	apply(1, []*types.DevshardTx{testutil.StartTx(inferenceID)})
 
 	execSig := testutil.SignExecutorReceipt(t, hosts[executorSlot], "escrow-1", inferenceID,
-		testutil.TestPromptHash[:], "llama", 100, 50, 1000, 2000)
+		testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	apply(2, []*types.DevshardTx{{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: 2000,
+		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	}}}})
 
 	finishMsg := &types.MsgFinishInference{

--- a/devshard/host/validation_obs_test.go
+++ b/devshard/host/validation_obs_test.go
@@ -158,12 +158,12 @@ func (r *obsTestRig) driveStartConfirmFinish(inferenceID, startNonce uint64) uin
 	r.t.Helper()
 	executorSlot := uint32(inferenceID % uint64(len(r.group)))
 	executorSigner := r.hosts[executorSlot]
-	confirmedAt := int64(2000) + int64(inferenceID)
+	confirmedAt := testutil.TestConfirmedAt + int64(inferenceID)
 
 	r.applyDiff(startNonce, []*types.DevshardTx{testutil.StartTx(inferenceID)})
 
 	execSig := testutil.SignExecutorReceipt(r.t, executorSigner, r.escrowID, inferenceID,
-		testutil.TestPromptHash[:], "llama", 100, 50, 1000, confirmedAt)
+		testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, confirmedAt)
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
 		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: confirmedAt,
 	}}}
@@ -496,9 +496,9 @@ func TestHost_ValidateAsync_DoesNotRecordObsBeforeDiff(t *testing.T) {
 	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff1}})
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, 1000, 2000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 2000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	}}}
 	finishMsg := &types.MsgFinishInference{
 		InferenceId: 1, ResponseHash: engine.ResponseHash, InputTokens: 80, OutputTokens: 40,
@@ -556,9 +556,9 @@ func TestHost_ValidateAsync_RecordsObsAfterDiffApplied(t *testing.T) {
 	_, err = h.HandleRequest(context.Background(), HostRequest{Diffs: []types.Diff{diff1}})
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, 1000, 2000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 2000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	}}}
 	finishMsg := &types.MsgFinishInference{
 		InferenceId: 1, ResponseHash: engine.ResponseHash, InputTokens: 80, OutputTokens: 40,

--- a/devshard/internal/testutil/testutil.go
+++ b/devshard/internal/testutil/testutil.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -12,6 +13,9 @@ import (
 )
 
 var deterministicMarshal = proto.MarshalOptions{Deterministic: true}
+
+var TestStartedAt = time.Now().Unix()
+var TestConfirmedAt = TestStartedAt + 1
 
 // TestPrompt is exactly 100 bytes and includes max_tokens:50 so host workload
 // checks (input_length == len(prompt), body max_tokens <= declared) pass with
@@ -178,12 +182,16 @@ func SignRevealSeed(t *testing.T, signer *signing.Secp256k1Signer, escrowID stri
 }
 
 func StartTx(inferenceID uint64) *types.DevshardTx {
+	return StartTxAt(inferenceID, TestStartedAt)
+}
+
+func StartTxAt(inferenceID uint64, startedAt int64) *types.DevshardTx {
 	return &types.DevshardTx{Tx: &types.DevshardTx_StartInference{StartInference: &types.MsgStartInference{
 		InferenceId: inferenceID,
 		PromptHash:  TestPromptHash[:],
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   startedAt,
 	}}}
 }

--- a/devshard/protocol/autoseal_agreement_test.go
+++ b/devshard/protocol/autoseal_agreement_test.go
@@ -16,33 +16,34 @@ import (
 )
 
 const (
-	autoSealTestInferenceSealGraceNonces     = 2
-	autoSealTestInferenceSealGraceSeconds   = 5
-	autoSealTestBaseConfirmedAt     = 10_000
-	autoSealAgreementNumHosts       = 16
-	autoSealAgreementPipelinedCount = 80
+	autoSealTestInferenceSealGraceNonces  = 2
+	autoSealTestInferenceSealGraceSeconds = 5
+	autoSealAgreementNumHosts             = 16
+	autoSealAgreementPipelinedCount       = 80
 )
 
+var autoSealTestBaseConfirmedAt = testutil.TestStartedAt
+
 type autoSealEnv struct {
-	session   *user.Session
-	hosts     []*host.Host
-	hostSMs   []*state.StateMachine
-	userSM    *state.StateMachine
-	user      *signing.Secp256k1Signer
+	session     *user.Session
+	hosts       []*host.Host
+	hostSMs     []*state.StateMachine
+	userSM      *state.StateMachine
+	user        *signing.Secp256k1Signer
 	hostSigners []*signing.Secp256k1Signer
-	group     []types.SlotAssignment
-	escrowID  string
+	group       []types.SlotAssignment
+	escrowID    string
 }
 
 func autoSealTestConfig(numHosts int) types.SessionConfig {
 	return types.NormalizeSessionConfig(types.SessionConfig{
-		RefusalTimeout:             60,
-		ExecutionTimeout:           1200,
-		TokenPrice:                 1,
-		VoteThreshold:              uint32(numHosts) / 2,
-		ValidationRate:             0,
-		FeePerNonce:                0,
-		InferenceSealGraceNonces:            autoSealTestInferenceSealGraceNonces,
+		RefusalTimeout:            60,
+		ExecutionTimeout:          1200,
+		TokenPrice:                1,
+		VoteThreshold:             uint32(numHosts) / 2,
+		ValidationRate:            0,
+		FeePerNonce:               0,
+		InferenceSealGraceNonces:  autoSealTestInferenceSealGraceNonces,
 		InferenceSealGraceSeconds: autoSealTestInferenceSealGraceSeconds,
 	}, numHosts)
 }
@@ -155,11 +156,12 @@ func applySignedDiffToUserAndHost(t *testing.T, env *autoSealEnv, nonce uint64, 
 
 func (env *autoSealEnv) startConfirm(t *testing.T, inferenceID, startNonce uint64, confirmedAt int64) {
 	t.Helper()
-	applySignedDiffToUserAndHost(t, env, startNonce, []*types.DevshardTx{testutil.StartTx(inferenceID)})
+	startedAt := confirmedAt - 1
+	applySignedDiffToUserAndHost(t, env, startNonce, []*types.DevshardTx{testutil.StartTxAt(inferenceID, startedAt)})
 
 	executorSlot := uint32(inferenceID % uint64(len(env.group)))
 	execSig := testutil.SignExecutorReceipt(t, env.hostSigners[executorSlot], env.escrowID, inferenceID,
-		testutil.TestPromptHash[:], "llama", 100, 50, 1000, confirmedAt)
+		testutil.TestPromptHash[:], "llama", 100, 50, startedAt, confirmedAt)
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
 		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: confirmedAt,
 	}}}

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -229,7 +229,7 @@ func TestHTTP_Auth_Rejected(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.Error(t, err)
@@ -250,7 +250,7 @@ func TestHTTP_GossipPropagation(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestHTTP_EquivocationDetection(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -301,6 +301,7 @@ func TestHTTP_TimeoutRefused(t *testing.T) {
 
 	// Send one inference. Executor is slot 1%5=1.
 	params := defaultParams()
+	params.StartedAt = testutil.TestStartedAt - env.config.RefusalTimeout - 1
 	_, err := env.session.SendInference(ctx, params)
 	require.NoError(t, err)
 
@@ -332,7 +333,7 @@ func TestHTTP_TimeoutRefused(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   params.StartedAt,
 	}, verifiers, allDiffs)
 	require.NoError(t, err)
 	require.True(t, len(votes) > int(env.config.VoteThreshold), "need >%d votes, got %d", env.config.VoteThreshold, len(votes))
@@ -472,7 +473,7 @@ func TestHTTP_ChallengeReceipt_RejectsTimeout(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}, verifiers, allDiffs)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(votes), "all hosts should reject timeout because executor is alive and produced receipt")
@@ -577,7 +578,7 @@ func TestHTTP_GossipAmplification(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -742,7 +743,7 @@ func TestHTTP_GossipIntegration(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -768,7 +769,7 @@ func TestHTTP_EquivocationViaGossipHTTP(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -798,7 +799,7 @@ func TestHTTP_LazyTxGossipHTTP(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -921,7 +922,7 @@ func TestAttack_GossipUnverifiedNonce(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -953,7 +954,7 @@ func TestAttack_GossipEmptySigBypass(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)

--- a/devshard/protocol/protocol_test.go
+++ b/devshard/protocol/protocol_test.go
@@ -78,7 +78,7 @@ func defaultParams() user.InferenceParams {
 		Prompt:      testutil.TestPrompt,
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 }
 
@@ -229,7 +229,7 @@ func TestProtocol_SignatureWithholding(t *testing.T) {
 		Diffs: []types.Diff{diff1}, Nonce: 1,
 		Payload: &host.InferencePayload{
 			Prompt: testutil.TestPrompt, Model: "llama",
-			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 		},
 	})
 	require.NoError(t, err)
@@ -286,7 +286,7 @@ func TestProtocol_SignatureResumesAfterInclusion(t *testing.T) {
 		Diffs: []types.Diff{diff1}, Nonce: 1,
 		Payload: &host.InferencePayload{
 			Prompt: testutil.TestPrompt, Model: "llama",
-			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 		},
 	})
 	require.NoError(t, err)
@@ -307,7 +307,7 @@ func TestProtocol_SignatureResumesAfterInclusion(t *testing.T) {
 	// Nonce 2: confirm start.
 	receiptContent := &types.ExecutorReceiptContent{
 		InferenceId: 1, PromptHash: testutil.TestPromptHash[:], Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000, EscrowId: "escrow-1",
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt, EscrowId: "escrow-1",
 		ConfirmedAt: resp.ConfirmedAt,
 	}
 	receiptData, _ := proto.Marshal(receiptContent)
@@ -459,7 +459,7 @@ func TestProtocol_Timeout_UserSide(t *testing.T) {
 		Diffs: []types.Diff{diff1}, Nonce: 1,
 		Payload: &host.InferencePayload{
 			Prompt: testutil.TestPrompt, Model: "llama",
-			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 		},
 	})
 	require.NoError(t, err)
@@ -557,12 +557,12 @@ func TestProtocol_VaryingInferenceCosts(t *testing.T) {
 	// Send 6 inferences. Accounting must cover the shared TestPrompt workload;
 	// MaxTokens may over-reserve, InputLength must equal len(prompt).
 	paramsList := []user.InferenceParams{
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: 1000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 100, StartedAt: 2000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: 3000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 75, StartedAt: 4000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: 5000},
-		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: 6000},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 100, StartedAt: testutil.TestStartedAt},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 75, StartedAt: testutil.TestStartedAt},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt},
+		{Model: "llama", Prompt: testutil.TestPrompt, InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt},
 	}
 
 	for _, p := range paramsList {

--- a/devshard/state/confirmed_at_bounds_test.go
+++ b/devshard/state/confirmed_at_bounds_test.go
@@ -1,0 +1,307 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/types"
+)
+
+const oneYearSeconds = int64(365 * 24 * 3600)
+
+func newBoundsTestSM(t *testing.T, escrowID string, hosts []*signing.Secp256k1Signer) (*StateMachine, []types.SlotAssignment) {
+	t.Helper()
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	cfg := types.DefaultSessionConfig(len(hosts))
+	cfg.CreateDevshardFee = 0
+	cfg.FeePerNonce = 0
+	sm, err := NewStateMachine(escrowID, cfg, group, 1_000_000, user.Address(),
+		signing.NewSecp256k1Verifier(),
+		testutil.MustMemoryStore(t, escrowID, user.Address(), cfg, group, 1_000_000))
+	require.NoError(t, err)
+	return sm, group
+}
+
+func boundsTestHosts(t *testing.T, n int) []*signing.Secp256k1Signer {
+	t.Helper()
+	hosts := make([]*signing.Secp256k1Signer, n)
+	for i := range hosts {
+		hosts[i] = testutil.MustGenerateKey(t)
+	}
+	return hosts
+}
+
+func confirmInference(
+	t *testing.T,
+	sm *StateMachine,
+	escrowID string,
+	hosts []*signing.Secp256k1Signer,
+	group []types.SlotAssignment,
+	id, nonce uint64,
+	startedAt, confirmedAt int64,
+) error {
+	t.Helper()
+	execIdx := int(id % uint64(len(group))) // executor slot is group[id % len(group)]
+	sig := testutil.SignExecutorReceipt(t, hosts[execIdx], escrowID, id,
+		[]byte("prompt"), "llama", 10, 5, startedAt, confirmedAt)
+	_, err := sm.ApplyLocal(nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
+		InferenceId: id, ExecutorSig: sig, ConfirmedAt: confirmedAt,
+	})})
+	return err
+}
+
+func driveToFinished(
+	t *testing.T,
+	sm *StateMachine,
+	escrowID string,
+	hosts []*signing.Secp256k1Signer,
+	group []types.SlotAssignment,
+	id, startNonce uint64,
+	startedAt, confirmedAt int64,
+) {
+	t.Helper()
+	startInference(t, sm, id, startNonce, startedAt)
+	require.NoError(t, confirmInference(t, sm, escrowID, hosts, group, id, startNonce+1, startedAt, confirmedAt))
+	finishInference(t, sm, escrowID, hosts, group, id, startNonce+2)
+}
+
+func startInference(t *testing.T, sm *StateMachine, id, nonce uint64, startedAt int64) {
+	t.Helper()
+	_, err := sm.ApplyLocal(nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
+		InferenceId: id, PromptHash: []byte("prompt"), Model: "llama",
+		InputLength: 10, MaxTokens: 5, StartedAt: startedAt,
+	})})
+	require.NoError(t, err)
+}
+
+func finishInference(
+	t *testing.T,
+	sm *StateMachine,
+	escrowID string,
+	hosts []*signing.Secp256k1Signer,
+	group []types.SlotAssignment,
+	id, nonce uint64,
+) {
+	t.Helper()
+	execIdx := int(id % uint64(len(group)))
+	finish := &types.MsgFinishInference{
+		InferenceId:  id,
+		ResponseHash: []byte("response"),
+		InputTokens:  2,
+		OutputTokens: 3,
+		ExecutorSlot: group[execIdx].SlotID,
+		EscrowId:     escrowID,
+	}
+	finish.ProposerSig = testutil.SignProposerTx(t, hosts[execIdx], finish)
+	_, err := sm.ApplyLocal(nonce, []*types.DevshardTx{txFinish(finish)})
+	require.NoError(t, err)
+}
+
+func idleTo(t *testing.T, sm *StateMachine, from, to uint64) {
+	t.Helper()
+	for n := from; n <= to; n++ {
+		_, err := sm.ApplyLocal(n, nil)
+		require.NoError(t, err)
+	}
+}
+
+func TestConfirmStart_ConfirmedAtBounds(t *testing.T) {
+	const (
+		escrowID  = "escrow-bounds"
+		startedAt = int64(1_700_000_000)
+	)
+
+	cases := []struct {
+		name        string
+		confirmedAt int64
+		wantErr     bool
+	}{
+		{"equal_to_started_at", startedAt, false},
+		{"max_delay_exact", startedAt + types.MaxConfirmationDelaySeconds, false},
+		{"max_delay_plus_one", startedAt + types.MaxConfirmationDelaySeconds + 1, true},
+		{"max_skew_exact", startedAt - types.MaxConfirmationSkewSeconds, false},
+		{"max_skew_plus_one", startedAt - types.MaxConfirmationSkewSeconds - 1, true},
+		{"one_year_ahead", startedAt + oneYearSeconds, true},
+		{"one_hour_behind", startedAt - 3600, true},
+		{"zero", 0, true},
+		{"negative", -1, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hosts := boundsTestHosts(t, 5)
+			sm, group := newBoundsTestSM(t, escrowID, hosts)
+
+			const id = uint64(1)
+			startInference(t, sm, id, id, startedAt)
+			err := confirmInference(t, sm, escrowID, hosts, group, id, id+1, startedAt, tc.confirmedAt)
+
+			if tc.wantErr {
+				require.ErrorIs(t, err, types.ErrInvalidConfirmedAt)
+				rec, ok := sm.SnapshotState().Inferences[id]
+				require.True(t, ok)
+				require.Equal(t, types.StatusPending, rec.Status,
+					"rejected confirm must not mutate the record")
+				require.Zero(t, rec.ConfirmedAt)
+				return
+			}
+			require.NoError(t, err)
+			rec, ok := sm.SnapshotState().Inferences[id]
+			require.True(t, ok)
+			require.Equal(t, types.StatusStarted, rec.Status)
+			require.Equal(t, tc.confirmedAt, rec.ConfirmedAt)
+		})
+	}
+}
+
+func TestConfirmStart_FutureConfirmedAtCannotPoisonSealClock(t *testing.T) {
+	const (
+		escrowID    = "escrow-clockpoison"
+		victimID    = uint64(1)
+		attackerID  = uint64(100)
+		sealNonce   = uint64(150) // DefaultAutoSealEveryNNonces
+		honestStart = int64(1_700_000_000)
+	)
+
+	hosts := boundsTestHosts(t, 5)
+	sm, group := newBoundsTestSM(t, escrowID, hosts)
+
+	st := sm.SnapshotState()
+	require.Equal(t, uint32(20), st.Config.InferenceSealGraceNonces)
+	require.Equal(t, uint32(3600), st.Config.InferenceSealGraceSeconds)
+
+	driveToFinished(t, sm, escrowID, hosts, group, victimID, victimID, honestStart, honestStart+2)
+	idleTo(t, sm, victimID+3, attackerID-1)
+
+	startInference(t, sm, attackerID, attackerID, honestStart+600)
+	err := confirmInference(t, sm, escrowID, hosts, group, attackerID, attackerID+1,
+		honestStart+600, honestStart+600+oneYearSeconds)
+	require.ErrorIs(t, err, types.ErrInvalidConfirmedAt,
+		"a validly signed but out-of-bounds receipt must be rejected")
+
+	clock := sm.AutoSealStateClock()
+	require.True(t, clock.Known)
+	require.Equal(t, honestStart+2, clock.Clock, "state clock must not be attacker-controlled")
+
+	idleTo(t, sm, attackerID+1, sealNonce)
+
+	require.Greater(t, sealNonce, victimID+uint64(st.Config.InferenceSealGraceNonces))
+	rec, live := sm.SnapshotState().Inferences[victimID]
+	require.True(t, live, "victim must survive the sweep: its genuine grace has not elapsed")
+	require.Equal(t, types.StatusFinished, rec.Status)
+
+	val := &types.MsgValidation{
+		InferenceId:   victimID,
+		ValidatorSlot: group[2].SlotID,
+		Valid:         false,
+		EscrowId:      escrowID,
+	}
+	val.ProposerSig = testutil.SignProposerTx(t, hosts[2], val)
+	_, err = sm.ApplyLocal(sealNonce+1, []*types.DevshardTx{
+		{Tx: &types.DevshardTx_Validation{Validation: val}},
+	})
+	require.NoError(t, err, "validation must remain possible for a live finished inference")
+	require.Equal(t, types.StatusChallenged, sm.SnapshotState().Inferences[victimID].Status)
+}
+
+func TestConfirmStart_BackdatedConfirmedAtCannotSelfSeal(t *testing.T) {
+	const (
+		escrowID    = "escrow-backdate"
+		badID       = uint64(10)  // attacker's own inference
+		honestID    = uint64(100) // honest traffic that defines the clock
+		sealNonce   = uint64(150)
+		honestStart = int64(1_700_000_000)
+	)
+
+	hosts := boundsTestHosts(t, 5)
+	sm, group := newBoundsTestSM(t, escrowID, hosts)
+
+	grace := int64(sm.SnapshotState().Config.InferenceSealGraceSeconds)
+
+	idleTo(t, sm, 1, badID-1)
+	startInference(t, sm, badID, badID, honestStart)
+	err := confirmInference(t, sm, escrowID, hosts, group, badID, badID+1, honestStart, honestStart-grace)
+	require.ErrorIs(t, err, types.ErrInvalidConfirmedAt,
+		"backdating past the skew bound must be rejected")
+
+	require.NoError(t, confirmInference(t, sm, escrowID, hosts, group, badID, badID+1, honestStart, honestStart+1))
+	finishInference(t, sm, escrowID, hosts, group, badID, badID+2)
+
+	idleTo(t, sm, badID+3, honestID-1)
+	driveToFinished(t, sm, escrowID, hosts, group, honestID, honestID, honestStart+600, honestStart+601)
+	idleTo(t, sm, honestID+3, sealNonce)
+
+	rec, live := sm.SnapshotState().Inferences[badID]
+	require.True(t, live, "record must not self-seal ahead of its validation grace")
+	require.Equal(t, types.StatusFinished, rec.Status)
+	require.LessOrEqual(t, sm.AutoSealStateClock().Clock-rec.ConfirmedAt, grace)
+}
+
+func TestValidateConfirmedAt_BoundsStayBelowSealGrace(t *testing.T) {
+	grace := int64(types.DefaultInferenceSealGraceSeconds)
+	require.Less(t, types.MaxConfirmationDelaySeconds, grace,
+		"a receipt could otherwise advance the seal clock past a full grace period")
+	require.Less(t, types.MaxConfirmationSkewSeconds, grace,
+		"a backdated receipt could otherwise expire its own grace on arrival")
+}
+
+func TestConfirmStart_RejectionKeepsUserAndHostInAgreement(t *testing.T) {
+	const (
+		escrowID    = "escrow-parity"
+		id          = uint64(1)
+		honestStart = int64(1_700_000_000)
+	)
+
+	hosts := boundsTestHosts(t, 5)
+	group := testutil.MakeGroup(hosts)
+	userSigner := testutil.MustGenerateKey(t)
+	cfg := types.DefaultSessionConfig(len(hosts))
+	cfg.CreateDevshardFee = 0
+	cfg.FeePerNonce = 0
+
+	newSM := func() *StateMachine {
+		sm, err := NewStateMachine(escrowID, cfg, group, 1_000_000, userSigner.Address(),
+			signing.NewSecp256k1Verifier(),
+			testutil.MustMemoryStore(t, escrowID, userSigner.Address(), cfg, group, 1_000_000))
+		require.NoError(t, err)
+		return sm
+	}
+	userSM, hostSM := newSM(), newSM()
+
+	startTx := txStart(&types.MsgStartInference{
+		InferenceId: id, PromptHash: []byte("prompt"), Model: "llama",
+		InputLength: 10, MaxTokens: 5, StartedAt: honestStart,
+	})
+	startDiff := testutil.SignDiff(t, userSigner, escrowID, 1, []*types.DevshardTx{startTx})
+	userRoot, err := userSM.ApplyLocal(1, []*types.DevshardTx{startTx})
+	require.NoError(t, err)
+	hostRoot, err := hostSM.ApplyDiff(startDiff)
+	require.NoError(t, err)
+	require.Equal(t, userRoot, hostRoot)
+
+	execIdx := int(id % uint64(len(group)))
+	poisoned := honestStart + oneYearSeconds
+	sig := testutil.SignExecutorReceipt(t, hosts[execIdx], escrowID, id,
+		[]byte("prompt"), "llama", 10, 5, honestStart, poisoned)
+	badConfirm := txConfirm(&types.MsgConfirmStart{
+		InferenceId: id, ExecutorSig: sig, ConfirmedAt: poisoned,
+	})
+
+	userRoot, applied, err := userSM.ApplyLocalBestEffort(2, []*types.DevshardTx{badConfirm})
+	require.NoError(t, err, "best-effort compose must not fail the whole diff")
+	require.Empty(t, applied, "poisoned confirm must be dropped from the composed diff")
+
+	emptyDiff := testutil.SignDiffWithRoot(t, userSigner, escrowID, 2, applied, userRoot)
+	hostRoot, err = hostSM.ApplyDiff(emptyDiff)
+	require.NoError(t, err, "host must accept the diff the user actually composed")
+	require.Equal(t, userRoot, hostRoot, "user and host must agree after rejection")
+
+	forcedDiff := testutil.SignDiff(t, userSigner, escrowID, 3, []*types.DevshardTx{badConfirm})
+	_, err = hostSM.ApplyDiff(forcedDiff)
+	require.ErrorIs(t, err, types.ErrInvalidConfirmedAt)
+	require.Equal(t, uint64(2), hostSM.LatestNonce(), "rejected diff must not advance the host")
+}

--- a/devshard/state/diagnostic_test.go
+++ b/devshard/state/diagnostic_test.go
@@ -22,7 +22,7 @@ func TestCollectInferenceDiagEntries_LiveAndSealed(t *testing.T) {
 	require.NoError(t, sm.SealInference(1))
 
 	_, err := sm.ApplyLocal(4, []*types.DevshardTx{txStart(&types.MsgStartInference{
-		InferenceId: 4, PromptHash: []byte("p2"), Model: "llama", InputLength: 10, MaxTokens: 5, StartedAt: 1000,
+		InferenceId: 4, PromptHash: []byte("p2"), Model: "llama", InputLength: 10, MaxTokens: 5, StartedAt: testutil.TestStartedAt,
 	})})
 	require.NoError(t, err)
 

--- a/devshard/state/gossip_catchup_test.go
+++ b/devshard/state/gossip_catchup_test.go
@@ -90,11 +90,11 @@ func TestGossip_V2_CatchUpAcrossSealBoundary(t *testing.T) {
 	// then finalize and empty ticks through settlement drain).
 	applyDiffPersist(t, leader, leaderStore, user, escrowID, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
-	execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], escrowID, 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], escrowID, 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	applyDiffPersist(t, leader, leaderStore, user, escrowID, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	finishMsg := &types.MsgFinishInference{
 		InferenceId: 1, ResponseHash: []byte("response"),

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -942,6 +942,10 @@ func (sm *StateMachine) applyConfirmStart(msg *types.MsgConfirmStart) error {
 		return fmt.Errorf("%w: expected pending, got %d", types.ErrInvalidTransition, rec.Status)
 	}
 
+	if err := types.ValidateConfirmedAt(msg.ConfirmedAt, rec.StartedAt); err != nil {
+		return err
+	}
+
 	// Verify executor receipt (includes confirmed_at from the executor's wall clock).
 	receiptContent := &types.ExecutorReceiptContent{
 		InferenceId: msg.InferenceId,

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -108,7 +108,7 @@ func TestValidateDiff_DoesNotCommit(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	})}
 	// Build a correctly signed diff via a throwaway SM so PostStateRoot matches.
 	probe, _ := newTestSM(t, hosts, 10000)
@@ -143,7 +143,7 @@ func TestPreviewLocalBestEffort_DoesNotCommit(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	})}
 	vd, err := sm.PreviewLocalBestEffort(1, txs)
 	require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestApplyDiff_StartInference(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -190,15 +190,15 @@ func TestApplyDiff_ConfirmStart(t *testing.T) {
 	// Start inference. Executor slot: 1 % 3 = 1
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
 	// Confirm start with valid executor receipt.
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -213,15 +213,15 @@ func TestApplyDiff_ConfirmStart_InvalidReceipt(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
 	// ConfirmStart with wrong signer (host[0] instead of host[1]).
-	execSig := testutil.SignExecutorReceipt(t, hosts[0], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[0], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrInvalidExecutorSig)
@@ -234,14 +234,14 @@ func TestApplyDiff_FinishInference(t *testing.T) {
 	// Start + confirm.
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -273,14 +273,14 @@ func TestApplyDiff_FinishInference_WrongExecutorSlot(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -303,14 +303,14 @@ func TestApplyDiff_FinishInference_InvalidProposerSig(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -418,7 +418,7 @@ func TestApplyDiff_Timeout_Refused(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -451,14 +451,14 @@ func TestApplyDiff_Timeout_Execution(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -491,7 +491,7 @@ func TestApplyDiff_Timeout_WrongReason(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -510,9 +510,9 @@ func TestApplyDiff_Timeout_WrongReason(t *testing.T) {
 	require.ErrorIs(t, err, types.ErrInvalidTimeoutReason)
 
 	// Confirm start, then reason=refused on started -> fail.
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -539,7 +539,7 @@ func TestApplyDiff_Timeout_InsufficientVotes(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -599,7 +599,7 @@ func TestApplyDiff_Timeout_MultiSlotWeight(t *testing.T) {
 	// Start inference. Executor slot = group[1%5].SlotID = 1 (owned by signer0).
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -683,14 +683,14 @@ func TestApplyDiff_FinalizeRound_HostTxsStillAccepted(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -721,7 +721,7 @@ func TestApplyDiff_DuplicateTimeout(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -756,7 +756,7 @@ func TestApplyDiff_EscrowBalanceCheck(t *testing.T) {
 	sm, user := newTestSM(t, hosts, 10)
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
-		InferenceId: 1, InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InferenceId: 1, InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrInsufficientBalance)
@@ -929,7 +929,7 @@ func TestApplyDiff_InferenceIDMustMatchNonce(t *testing.T) {
 	// inference_id=42 at nonce=1 -> rejected.
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 42, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrInvalidInferenceID)
@@ -944,7 +944,7 @@ func TestApplyDiff_DuplicateInferenceID(t *testing.T) {
 	// First start succeeds.
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -967,7 +967,7 @@ func TestApplyDiff_Timeout_DuplicateVoterSlot(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -1030,7 +1030,7 @@ func TestSnapshotState_DeepCopy(t *testing.T) {
 	// Start an inference to populate state.
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -1061,15 +1061,15 @@ func applyStartConfirmFinish(t *testing.T, sm *StateMachine, user *signing.Secp2
 
 	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: inferenceID, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -1205,7 +1205,7 @@ func TestApplyDiff_CostOverflow_StartInference(t *testing.T) {
 	// InputLength + MaxTokens overflows uint64.
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: math.MaxUint64, MaxTokens: 1, StartedAt: 1000,
+		InputLength: math.MaxUint64, MaxTokens: 1, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrCostOverflow)
@@ -1213,7 +1213,7 @@ func TestApplyDiff_CostOverflow_StartInference(t *testing.T) {
 	// Multiplication overflows: large input * price.
 	diff = testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: math.MaxUint64 / 2, MaxTokens: 1, StartedAt: 1000,
+		InputLength: math.MaxUint64 / 2, MaxTokens: 1, StartedAt: testutil.TestStartedAt,
 	})})
 	// With TokenPrice=1, the mul won't overflow. Use a custom SM with higher price.
 	config := types.SessionConfig{TokenPrice: 3, VoteThreshold: 1}
@@ -1224,7 +1224,7 @@ func TestApplyDiff_CostOverflow_StartInference(t *testing.T) {
 
 	diff = testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: math.MaxUint64 / 2, MaxTokens: 1, StartedAt: 1000,
+		InputLength: math.MaxUint64 / 2, MaxTokens: 1, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err = smHigh.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrCostOverflow)
@@ -1237,7 +1237,7 @@ func TestApplyDiff_AtomicRollback(t *testing.T) {
 	// First: apply a valid start.
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -1247,7 +1247,7 @@ func TestApplyDiff_AtomicRollback(t *testing.T) {
 	// Diff with two txs: a valid confirm, then an invalid finish (wrong executor slot).
 	// The confirm would succeed, modifying state, but the finish fails.
 	// With atomic rollback, the state should be unchanged.
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 
 	finishMsg := &types.MsgFinishInference{
 		InferenceId: 1, ResponseHash: []byte("response"),
@@ -1257,7 +1257,7 @@ func TestApplyDiff_AtomicRollback(t *testing.T) {
 	finishMsg.ProposerSig = testutil.SignProposerTx(t, hosts[2], finishMsg)
 
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{
-		txConfirm(&types.MsgConfirmStart{InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000}),
+		txConfirm(&types.MsgConfirmStart{InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt}),
 		txFinish(finishMsg),
 	})
 	_, err = sm.ApplyDiff(diff)
@@ -1314,7 +1314,7 @@ func TestApplyDiff_FeePerNonce_Deducted(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -1342,7 +1342,7 @@ func TestApplyDiff_FeePerNonce_InsufficientBalance_Rollback(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrInsufficientBalance)
@@ -1398,7 +1398,7 @@ func TestApplyLocalBestEffort_FeePerNonce_InsufficientBalance_Rollback(t *testin
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	})})
 	require.ErrorIs(t, err, types.ErrInsufficientBalance)
 	require.Nil(t, applied)
@@ -1607,15 +1607,15 @@ func applyStartConfirmFinishMultiSlot(t *testing.T, sm *StateMachine, user *sign
 	nonce := sm.SnapshotState().LatestNonce + 1
 	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: inferenceID, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, executorSigner, "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, executorSigner, "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -1645,7 +1645,7 @@ func TestApplyDiff_PostStateRoot_Valid(t *testing.T) {
 
 	txs := []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})}
 
 	// Compute root from the replica.
@@ -1664,7 +1664,7 @@ func TestApplyDiff_PostStateRoot_Mismatch(t *testing.T) {
 
 	txs := []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})}
 
 	// Sign diff with wrong post_state_root.
@@ -1804,15 +1804,15 @@ func applyStartConfirmFinish_Setup(t *testing.T, sm *StateMachine, user *signing
 
 	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: inferenceID, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -1959,15 +1959,15 @@ func TestPhase_FinalizationLeavesValidationCountersZero(t *testing.T) {
 	// Create a finished inference so finalization has existing session data.
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
 	// Confirm + finish so the inference reaches StatusFinished.
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -2019,14 +2019,14 @@ func TestReplayAttack_CrossEscrow(t *testing.T) {
 	// Start + confirm + finish in session A.
 	diff := testutil.SignDiff(t, user, "escrow-A", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err = smA.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-A", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-A", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-A", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = smA.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -2049,14 +2049,14 @@ func TestReplayAttack_CrossEscrow(t *testing.T) {
 
 	diff = testutil.SignDiff(t, user, "escrow-B", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err = smB.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSigB := testutil.SignExecutorReceipt(t, hosts[1], "escrow-B", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSigB := testutil.SignExecutorReceipt(t, hosts[1], "escrow-B", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-B", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSigB, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSigB, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = smB.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -2074,14 +2074,14 @@ func TestFinishInference_CostCapped(t *testing.T) {
 	// Start: reserved = (100+50)*1 = 150.
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -2292,15 +2292,15 @@ func TestV2_FinalizeDrainDeterministicOrder(t *testing.T) {
 		nonce := inferenceID
 		diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 			InferenceId: inferenceID, PromptHash: []byte("prompt"), Model: "llama",
-			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 		})})
 		_, err := sm.ApplyDiff(diff)
 		require.NoError(t, err)
 
-		execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+		execSig := testutil.SignExecutorReceipt(t, hosts[executorSlotIdx], "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 		nonce++
 		diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-			InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: 1000,
+			InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 		})})
 		_, err = sm.ApplyDiff(diff)
 		require.NoError(t, err)
@@ -2401,7 +2401,7 @@ func TestDrainSettle_PendingRefunds(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -2487,7 +2487,7 @@ func TestDrainSettle_MixedDeterministic(t *testing.T) {
 		// inf 1: pending (executor slot 1).
 		diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 			InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 		})})
 		_, err := sm.ApplyDiff(diff)
 		require.NoError(t, err)
@@ -2501,14 +2501,14 @@ func TestDrainSettle_MixedDeterministic(t *testing.T) {
 		// inf 4: started (executor slot 4).
 		diff = testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{txStart(&types.MsgStartInference{
 			InferenceId: 4, PromptHash: []byte("prompt"), Model: "llama",
-			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 		})})
 		_, err = sm.ApplyDiff(diff)
 		require.NoError(t, err)
 
-		execSig := testutil.SignExecutorReceipt(t, hosts[4], "escrow-1", 4, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+		execSig := testutil.SignExecutorReceipt(t, hosts[4], "escrow-1", 4, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 		diff = testutil.SignDiff(t, user, "escrow-1", 5, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-			InferenceId: 4, ExecutorSig: execSig, ConfirmedAt: 1000,
+			InferenceId: 4, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 		})})
 		_, err = sm.ApplyDiff(diff)
 		require.NoError(t, err)
@@ -2520,14 +2520,14 @@ func TestDrainSettle_MixedDeterministic(t *testing.T) {
 		// inf 7: finished (executor slot 2).
 		diff = testutil.SignDiff(t, user, "escrow-1", 7, []*types.DevshardTx{txStart(&types.MsgStartInference{
 			InferenceId: 7, PromptHash: []byte("prompt"), Model: "llama",
-			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 		})})
 		_, err = sm.ApplyDiff(diff)
 		require.NoError(t, err)
 
-		execSig = testutil.SignExecutorReceipt(t, hosts[2], "escrow-1", 7, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+		execSig = testutil.SignExecutorReceipt(t, hosts[2], "escrow-1", 7, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 		diff = testutil.SignDiff(t, user, "escrow-1", 8, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-			InferenceId: 7, ExecutorSig: execSig, ConfirmedAt: 1000,
+			InferenceId: 7, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 		})})
 		_, err = sm.ApplyDiff(diff)
 		require.NoError(t, err)
@@ -2587,16 +2587,16 @@ func applyStartConfirmWithWarmKey(t *testing.T, sm *StateMachine, user *signing.
 
 	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: inferenceID, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
 	// Sign executor receipt with warm key instead of cold key.
-	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", inferenceID, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: inferenceID, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -2632,15 +2632,15 @@ func TestWarmKey_ConfirmStartRejectsUnauthorizedKey(t *testing.T) {
 	nonce := sm.LatestNonce() + 1
 	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, randomKey, "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, randomKey, "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrInvalidExecutorSig)
@@ -2656,15 +2656,15 @@ func TestWarmKey_ConfirmStartNoResolver(t *testing.T) {
 	nonce := sm.LatestNonce() + 1
 	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, randomKey, "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, randomKey, "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.ErrorIs(t, err, types.ErrInvalidExecutorSig)
@@ -2814,7 +2814,7 @@ func TestWarmKey_TimeoutVoteWithWarmKey(t *testing.T) {
 	nonce := sm.LatestNonce() + 1
 	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -2935,13 +2935,13 @@ func TestApplyLocal_WithInjectedWarmKeys(t *testing.T) {
 	// Replay the same txs via ApplyLocal.
 	startTx := txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})
 	_, err = sm2.ApplyLocal(1, []*types.DevshardTx{startTx})
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
-	confirmTx := txConfirm(&types.MsgConfirmStart{InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000})
+	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
+	confirmTx := txConfirm(&types.MsgConfirmStart{InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt})
 	_, err = sm2.ApplyLocal(2, []*types.DevshardTx{confirmTx})
 	require.NoError(t, err)
 
@@ -3015,16 +3015,16 @@ func TestApplyDiff_RevealSeed_PreservesExistingBinding(t *testing.T) {
 	nonce++
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 3, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
 
 	// ConfirmStart with warm key -> creates binding for slot 0.
-	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 3, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 3, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	nonce++
 	diff = testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 3, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 3, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	_, err = sm.ApplyDiff(diff)
 	require.NoError(t, err)
@@ -3284,7 +3284,7 @@ func TestSettleLiveRecordLocked_Pending(t *testing.T) {
 
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
 		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	_, err := sm.ApplyDiff(diff)
 	require.NoError(t, err)

--- a/devshard/state/seal_test.go
+++ b/devshard/state/seal_test.go
@@ -35,13 +35,13 @@ func driveSealInferenceToFinished(t *testing.T, sm *StateMachine, escrowID strin
 	t.Helper()
 
 	_, err := sm.ApplyLocal(1, []*types.DevshardTx{txStart(&types.MsgStartInference{
-		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	require.NoError(t, err)
 
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], escrowID, 1, []byte("prompt"), "llama", 100, 50, 1000, 2000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], escrowID, 1, []byte("prompt"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	_, err = sm.ApplyLocal(2, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 2000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	require.NoError(t, err)
 
@@ -243,25 +243,25 @@ func TestAutoSealStateClock_SkipsUnconfirmedInTailWindow(t *testing.T) {
 	sm, _, _, _ := newSealTestSM(t, "escrow-clock", hosts, false)
 
 	_, err := sm.ApplyLocal(1, []*types.DevshardTx{txStart(&types.MsgStartInference{
-		InferenceId: 1, PromptHash: []byte("pending"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InferenceId: 1, PromptHash: []byte("pending"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	require.NoError(t, err)
 
 	_, err = sm.ApplyLocal(2, []*types.DevshardTx{txStart(&types.MsgStartInference{
-		InferenceId: 2, PromptHash: []byte("confirmed"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InferenceId: 2, PromptHash: []byte("confirmed"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	})})
 	require.NoError(t, err)
-	execSig := testutil.SignExecutorReceipt(t, hosts[2], "escrow-clock", 2, []byte("confirmed"), "llama", 100, 50, 1000, 5000)
+	execSig := testutil.SignExecutorReceipt(t, hosts[2], "escrow-clock", 2, []byte("confirmed"), "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	_, err = sm.ApplyLocal(3, []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
-		InferenceId: 2, ExecutorSig: execSig, ConfirmedAt: 5000,
+		InferenceId: 2, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	})})
 	require.NoError(t, err)
 
 	clock := sm.AutoSealStateClock()
 	require.True(t, clock.Known)
-	require.Equal(t, int64(5000), clock.MinConfirmedAt, "Pending ConfirmedAt=0 must not pull window min to zero")
-	require.Equal(t, int64(5000), clock.MaxConfirmedAt)
-	require.Equal(t, int64(5000), clock.Clock)
+	require.Equal(t, testutil.TestConfirmedAt, clock.MinConfirmedAt, "Pending ConfirmedAt=0 must not pull window min to zero")
+	require.Equal(t, testutil.TestConfirmedAt, clock.MaxConfirmedAt)
+	require.Equal(t, testutil.TestConfirmedAt, clock.Clock)
 }
 
 func TestExportAllInferenceRecords_IncludesSealedFromDB(t *testing.T) {

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -75,7 +75,7 @@ func TestHTTPClient_Send_RoundTrip(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestHTTPClient_GetDiffs(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestHTTPClient_GetMempool(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestHTTPClient_Send_SSE(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, streamSink, nil)
 	require.NoError(t, err)
@@ -295,7 +295,7 @@ func TestHTTPClient_Send_UsesAdmissionController(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.ErrorContains(t, err, "participant request budget exhausted")
@@ -329,7 +329,7 @@ func TestHTTPClient_Send_ObservesUpstream503(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}, nil, nil)
 	require.Error(t, err)

--- a/devshard/transport/server_test.go
+++ b/devshard/transport/server_test.go
@@ -138,7 +138,7 @@ func TestServer_Inference_ValidAuth(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 	}
 	body, err := json.Marshal(ir)
@@ -219,7 +219,7 @@ func TestServer_GetDiffs(t *testing.T) {
 	ir := InferenceRequest{
 		Diffs:   []DiffJSON{dj},
 		Nonce:   1,
-		Payload: &PayloadJSON{Prompt: testutil.TestPrompt, Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000},
+		Payload: &PayloadJSON{Prompt: testutil.TestPrompt, Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt},
 	}
 	body, _ := json.Marshal(ir)
 	rec := env.doPost(t, "/devshard/v2/sessions/escrow-1/chat/completions", body)
@@ -244,7 +244,7 @@ func TestServer_GetMempool(t *testing.T) {
 	ir := InferenceRequest{
 		Diffs:   []DiffJSON{dj},
 		Nonce:   1,
-		Payload: &PayloadJSON{Prompt: testutil.TestPrompt, Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000},
+		Payload: &PayloadJSON{Prompt: testutil.TestPrompt, Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt},
 	}
 	body, _ := json.Marshal(ir)
 	rec := env.doPost(t, "/devshard/v2/sessions/escrow-1/chat/completions", body)
@@ -320,9 +320,9 @@ func TestHandleGossipNonce_WarmKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// inference 1 % 1 = 0, executor = slot 0.
-	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, 1000, 1000)
+	execSig := testutil.SignExecutorReceipt(t, warmSigner, "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000,
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: testutil.TestConfirmedAt,
 	}}}
 	diff2 := testutil.SignDiff(t, userSigner, "escrow-1", 2, []*types.DevshardTx{confirmTx})
 	_, err = sm.ApplyDiff(diff2)
@@ -410,7 +410,7 @@ func TestServer_StreamingInference(t *testing.T) {
 			Model:       "llama",
 			InputLength: 100,
 			MaxTokens:   50,
-			StartedAt:   1000,
+			StartedAt:   testutil.TestStartedAt,
 		},
 		Stream: true,
 	}
@@ -576,7 +576,7 @@ func TestServer_NonExecutor_SSE(t *testing.T) {
 	ir := InferenceRequest{
 		Diffs:   []DiffJSON{dj},
 		Nonce:   1,
-		Payload: &PayloadJSON{Prompt: testutil.TestPrompt, Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000},
+		Payload: &PayloadJSON{Prompt: testutil.TestPrompt, Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt},
 	}
 	body, _ := json.Marshal(ir)
 

--- a/devshard/types/config.go
+++ b/devshard/types/config.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 const (
 	defaultInferenceSealGraceMultiplier = 1 // for tests
 	minInferenceSealGraceNonces         = 20
@@ -12,7 +14,29 @@ const (
 	DefaultAutoSealEveryNNonces uint32 = 150
 	// DefaultValidationRate matches inference-chain DefaultDevshardValidationRate.
 	DefaultValidationRate uint32 = 5000
+
+	// MaxConfirmationDelaySeconds and MaxConfirmationSkewSeconds bound how far
+	// confirmed_at may sit from started_at in either direction. Both must stay
+	// well below InferenceSealGraceSeconds.
+	MaxConfirmationDelaySeconds int64 = 900
+	MaxConfirmationSkewSeconds  int64 = 900
 )
+
+func ValidateConfirmedAt(confirmedAt, startedAt int64) error {
+	if confirmedAt <= 0 {
+		return fmt.Errorf("%w: confirmed_at must be positive, got %d",
+			ErrInvalidConfirmedAt, confirmedAt)
+	}
+	if confirmedAt-startedAt > MaxConfirmationDelaySeconds {
+		return fmt.Errorf("%w: confirmed_at %d is %ds after started_at %d (max %ds)",
+			ErrInvalidConfirmedAt, confirmedAt, confirmedAt-startedAt, startedAt, MaxConfirmationDelaySeconds)
+	}
+	if startedAt-confirmedAt > MaxConfirmationSkewSeconds {
+		return fmt.Errorf("%w: confirmed_at %d is %ds before started_at %d (max skew %ds)",
+			ErrInvalidConfirmedAt, confirmedAt, startedAt-confirmedAt, startedAt, MaxConfirmationSkewSeconds)
+	}
+	return nil
+}
 
 // DefaultInferenceSealGraceNonces returns the canonical seal grace for a session group.
 // Phase 1 uses a nonce gate of 10 * groupSize with a floor of 20 so small

--- a/devshard/types/errors.go
+++ b/devshard/types/errors.go
@@ -7,6 +7,7 @@ var (
 	ErrInvalidUserSig        = errors.New("invalid user signature")
 	ErrInvalidProposerSig    = errors.New("invalid proposer signature: not a group member")
 	ErrInvalidExecutorSig    = errors.New("invalid executor signature")
+	ErrInvalidConfirmedAt    = errors.New("confirmed_at outside deterministic bounds")
 	ErrInsufficientBalance   = errors.New("insufficient escrow balance")
 	ErrMultipleStartMsgs     = errors.New("at most one MsgStartInference per diff")
 	ErrSessionFinalizing     = errors.New("session is finalizing: no new inferences")

--- a/devshard/user/compose_persist_retry_test.go
+++ b/devshard/user/compose_persist_retry_test.go
@@ -78,7 +78,7 @@ func TestSession_ComposeDiff_PersistRetryThenSuccess(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	beforeRetry := promtestutil.ToFloat64(observability.DiffPersistRetryForTest("success"))
 	prepared, err := session.PrepareInference(params)
@@ -101,7 +101,7 @@ func TestSession_ComposeDiff_PersistFirst_FailureLeavesSequencerUnchanged(t *tes
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	beforeExhausted := promtestutil.ToFloat64(observability.DiffPersistRetryForTest("exhausted"))
 	_, err := session.PrepareInference(params)

--- a/devshard/user/fault_test.go
+++ b/devshard/user/fault_test.go
@@ -99,7 +99,7 @@ func runFault(t *testing.T, failPct int) {
 		Prompt:      stressPrompt,
 		InputLength: faultInputLen,
 		MaxTokens:   faultMaxTokens,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 
 	// --- Phase 1: healthy inferences ---
@@ -218,7 +218,7 @@ func runFault(t *testing.T, failPct int) {
 		Model:       faultModel,
 		InputLength: faultInputLen,
 		MaxTokens:   faultMaxTokens,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 	for _, infID := range pendingDeadIDs {
 		votes, err := session.CollectTimeoutVotes(ctx, infID,

--- a/devshard/user/fetch_signature_verify_test.go
+++ b/devshard/user/fetch_signature_verify_test.go
@@ -44,7 +44,7 @@ func TestFetchSignature_RejectsUnverifiedGarbage(t *testing.T) {
 		Prompt:      testutil.TestPrompt,
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 	_, err := session.SendInference(ctx, params)
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestFetchSignature_LiveStateRootWhenDiffsEmpty(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	_, err := session.SendInference(ctx, params)
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestFetchSignature_NoFallbackForNonCurrentNonce(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	_, err := session.SendInference(ctx, params)
 	require.NoError(t, err)

--- a/devshard/user/flush_snapshot_test.go
+++ b/devshard/user/flush_snapshot_test.go
@@ -111,7 +111,7 @@ func TestFlushSnapshot_RetiredEscrowRebuildsWithoutReplay(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	for i := 0; i < numInferences; i++ {
 		_, err := session.SendInference(ctx, params)

--- a/devshard/user/recover_test.go
+++ b/devshard/user/recover_test.go
@@ -87,7 +87,7 @@ func setupRecoverableSession(
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	for i := 0; i < numInferences; i++ {
@@ -128,7 +128,7 @@ func TestRecoverSession_HappyPath(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	resp, err := session.SendInference(ctx, params)
 	require.NoError(t, err)
@@ -208,11 +208,11 @@ func TestRecoverSession_WarmKeyDelta(t *testing.T) {
 
 	// Nonce 1: StartInference + ConfirmStart (status -> Started). No warm keys yet.
 	confirmSig := testutil.SignExecutorReceipt(t, hosts[executorSlot], "escrow-1", 1,
-		testutil.TestPromptHash[:], "llama", 100, 50, 1000, 2000)
+		testutil.TestPromptHash[:], "llama", 100, 50, testutil.TestStartedAt, testutil.TestConfirmedAt)
 	txs1 := []*types.DevshardTx{
 		testutil.StartTx(1),
 		{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
-			InferenceId: 1, ExecutorSig: confirmSig, ConfirmedAt: 2000,
+			InferenceId: 1, ExecutorSig: confirmSig, ConfirmedAt: testutil.TestConfirmedAt,
 		}}},
 	}
 	root1, err := sm.ApplyLocal(1, txs1)

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -516,6 +516,23 @@ func (s *Session) processResponse(hostIdx int, resp *host.HostResponse, inferenc
 	// Queue receipt as MsgConfirmStart for the next diff.
 	// Use inferenceNonce (the logical inference ID), not resp.Nonce (host's latest state).
 	if resp.Receipt != nil {
+		rec, known := s.sm.GetCommittedRecord(inferenceNonce)
+		if known {
+			if err := types.ValidateConfirmedAt(resp.ConfirmedAt, rec.StartedAt); err != nil {
+				logging.Warn("dropping executor receipt with out-of-bounds confirmed_at",
+					"subsystem", "user",
+					"escrow_id", s.escrowID,
+					"inference_id", inferenceNonce,
+					"executor_slot", rec.ExecutorSlot,
+					"started_at", rec.StartedAt,
+					"confirmed_at", resp.ConfirmedAt,
+					"error", err,
+				)
+				resp.Receipt = nil
+			}
+		}
+	}
+	if resp.Receipt != nil {
 		s.addPendingTx(&types.DevshardTx{
 			Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
 				InferenceId: inferenceNonce,

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -97,7 +97,7 @@ func TestUser_RoundRobinSelection(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	// Nonce 1 -> host 1%3=1, nonce 2 -> host 2%3=2, nonce 3 -> host 3%3=0.
@@ -115,7 +115,7 @@ func TestPrepareInference_StartInferenceIsMandatory(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	prepared, err := session.PrepareInference(params)
@@ -135,7 +135,7 @@ func TestUser_PipelinesReceipt(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	// First inference.
@@ -166,7 +166,7 @@ func TestUser_CollectsSignatures(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	_, err := session.SendInference(ctx, params)
@@ -222,7 +222,7 @@ func TestUser_HostError_StateConsistency(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	// Nonce 1 -> host 1 (error client). Should fail.
@@ -245,7 +245,7 @@ func TestUser_Finalize(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	for i := 0; i < 3; i++ {
@@ -268,7 +268,7 @@ func TestUser_Finalize_CollectsSignatures(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	for i := 0; i < 3; i++ {
@@ -298,7 +298,7 @@ func TestUser_Finalize_DiffCount(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	for i := 0; i < 3; i++ {
@@ -321,7 +321,7 @@ func TestUser_PendingTxDedup(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	// Send one inference to populate host mempool.
@@ -386,7 +386,7 @@ func TestCollectTimeoutVotes_WeightEarlyExit(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	_, err = session.SendInference(ctx, params)
@@ -415,7 +415,7 @@ func TestCollectTimeoutVotes_WeightEarlyExit(t *testing.T) {
 		Model:       "llama",
 		InputLength: 100,
 		MaxTokens:   50,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}, verifiers, nil)
 	require.NoError(t, err)
 
@@ -553,7 +553,7 @@ func TestCollectTimeoutVotes_SerializesPerVerifier(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	_, err := session.SendInference(ctx, params)
 	require.NoError(t, err)
@@ -592,7 +592,7 @@ func TestCollectTimeoutVotes_SerializesPerVerifier(t *testing.T) {
 
 	payload := &host.InferencePayload{
 		Prompt: testutil.TestPrompt, Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	type collectResult struct {
@@ -659,7 +659,7 @@ func TestCollectTimeoutVotes_DifferentVerifiersRunInParallel(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	_, err := session.SendInference(ctx, params)
 	require.NoError(t, err)
@@ -697,7 +697,7 @@ func TestCollectTimeoutVotes_DifferentVerifiersRunInParallel(t *testing.T) {
 
 	payload := &host.InferencePayload{
 		Prompt: testutil.TestPrompt, Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	done := make(chan error, 1)
@@ -742,7 +742,7 @@ func TestCollectTimeoutVotes_WaitTimeoutDropsStaleGoroutines(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	_, err := session.SendInference(ctx, params)
 	require.NoError(t, err)
@@ -802,7 +802,7 @@ func TestCollectTimeoutVotes_WaitTimeoutDropsStaleGoroutines(t *testing.T) {
 
 	payload := &host.InferencePayload{
 		Prompt: testutil.TestPrompt, Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	// Launch the blocking first call so all verifier slots are occupied.
@@ -846,7 +846,7 @@ func TestCollectTimeoutVotes_DepthGreaterThanOne(t *testing.T) {
 
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	_, err := session.SendInference(ctx, params)
 	require.NoError(t, err)
@@ -889,7 +889,7 @@ func TestCollectTimeoutVotes_DepthGreaterThanOne(t *testing.T) {
 
 	payload := &host.InferencePayload{
 		Prompt: testutil.TestPrompt, Model: "llama",
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	var wg sync.WaitGroup
@@ -960,7 +960,7 @@ func TestUser_Finalize_SeedRevealAndSettlement(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	// Send 3 inferences (one per host via round-robin).
@@ -1030,7 +1030,7 @@ func TestFinalize_DoubleCall_AfterSuccess(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	for i := 0; i < 3; i++ {
 		_, err := session.SendInference(ctx, params)
@@ -1068,7 +1068,7 @@ func TestFinalize_DoubleCall_InsufficientQuorum(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	for i := 0; i < 5; i++ {
@@ -1100,7 +1100,7 @@ func TestFinalize_SettlementRerun_EmptyDiffsCollectsFromHosts(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	for i := 0; i < 3; i++ {
 		_, err := session.SendInference(ctx, params)
@@ -1150,7 +1150,7 @@ func TestFinalize_SignatureStatus(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 	for i := 0; i < 3; i++ {
 		_, err := session.SendInference(ctx, params)
@@ -1184,7 +1184,7 @@ func TestFinalize_SignatureStatus_InsufficientQuorum(t *testing.T) {
 	ctx := context.Background()
 	params := InferenceParams{
 		Model: "llama", Prompt: testutil.TestPrompt,
-		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 	}
 
 	for i := 0; i < 5; i++ {

--- a/devshard/user/stress_test.go
+++ b/devshard/user/stress_test.go
@@ -213,7 +213,7 @@ func runStress(t *testing.T, numHosts, rounds int) {
 		Prompt:      stressPrompt,
 		InputLength: stressInputLength,
 		MaxTokens:   stressMaxTokens,
-		StartedAt:   1000,
+		StartedAt:   testutil.TestStartedAt,
 	}
 
 	// --- Inference loop ---

--- a/devshard/user/validation_test.go
+++ b/devshard/user/validation_test.go
@@ -114,7 +114,7 @@ func TestSession_Validation_InvalidationConverges(t *testing.T) {
 		MaxTokens:   50,
 	}
 	for i := 1; i <= numInferences; i++ {
-		params.StartedAt = int64(i) * 1000
+		params.StartedAt = testutil.TestStartedAt + int64(i)
 		_, err := session.SendInference(ctx, params)
 		require.NoError(t, err, "inference %d", i)
 	}
@@ -255,7 +255,7 @@ func TestSession_Validation_MultiSlotValidatorCountedOnce(t *testing.T) {
 		MaxTokens:   50,
 	}
 	for i := 1; i <= numInferences; i++ {
-		params.StartedAt = int64(i) * 1000
+		params.StartedAt = testutil.TestStartedAt + int64(i)
 		_, err := session.SendInference(ctx, params)
 		require.NoError(t, err, "inference %d", i)
 	}

--- a/devshard/user/warmkey_test.go
+++ b/devshard/user/warmkey_test.go
@@ -39,7 +39,7 @@ func acceptResolver(warmKeys, coldKeys []*signing.Secp256k1Signer) state.WarmKey
 
 var defaultParams = InferenceParams{
 	Model: "llama", Prompt: testutil.TestPrompt,
-	InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	InputLength: 100, MaxTokens: 50, StartedAt: testutil.TestStartedAt,
 }
 
 // setupWarmKeySession creates a session where hosts sign with warm keys


### PR DESCRIPTION
## Problem

`applyConfirmStart` verified the executor receipt signature but stored `confirmed_at` with no semantic bounds. A signature proves authorship, not sanity - no forgery is needed, the executor signs with the key it is authorised to use.

## Fix

`types.ValidateConfirmedAt` bounds the value against the in-state `started_at` in both directions (±900s), rejecting non-positive values. Relative to `started_at` because `applyConfirmStart` runs on user, host and replay - there is no agreed "now" available, and any wall clock would split consensus.

Bounding alone would have opened a griefing path: a malicious executor parking one unapplicable `MsgConfirmStart` in its mempool blocks the refusal timeout forever, stranding the reserved cost in `Pending`. `VerifyRefusedTimeout` now treats such a receipt as absent and accepts once past the bound.