### PR TITLE
fix(devshard): verify timeout votes before counting slot weight

### DIFF
--- a/common/queryapi/tests/dapi_contract_test.go
+++ b/common/queryapi/tests/dapi_contract_test.go
@@ -15,20 +15,20 @@ import (
 // public handlers for read-only query routes. edge-api must expose the same keys
 // so existing clients keep working when the proxy steers traffic to edge-api.
 var dapiTopLevelKeys = map[string][]string{
-	"GET /v1/status":                          {"status"},
-	"GET /v1/models":                          {"object", "data"},
-	"GET /v1/governance/models":               {"models"},
-	"GET /v1/governance/models-legacy":        {"model"},
-	"GET /v1/pricing":                         {"unit_of_compute_price", "models"},
-	"GET /v1/versions":                          {"api_version", "node_version", "timestamp"},
-	"GET /v1/epochs/{epoch}/participants":     {"active_participants", "addresses", "active_participants_bytes", "proof_ops", "validators", "block", "excluded_participants"},
+	"GET /v1/status":                      {"status"},
+	"GET /v1/models":                      {"object", "data"},
+	"GET /v1/governance/models":           {"models"},
+	"GET /v1/governance/models-legacy":    {"model"},
+	"GET /v1/pricing":                     {"unit_of_compute_price", "models"},
+	"GET /v1/versions":                    {"api_version", "node_version", "timestamp"},
+	"GET /v1/epochs/{epoch}/participants": {"active_participants", "addresses", "active_participants_bytes", "proof_ops", "validators", "block", "excluded_participants"},
 }
 
 func TestResponseTopLevelKeysMatchDapiContract(t *testing.T) {
 	cases := []struct {
-		name   string
-		keys   []string
-		run    func(t *testing.T) (int, []byte)
+		name string
+		keys []string
+		run  func(t *testing.T) (int, []byte)
 	}{
 		{
 			name: "GET /v1/status",

--- a/common/queryapi/tests/routes_contract_test.go
+++ b/common/queryapi/tests/routes_contract_test.go
@@ -18,7 +18,6 @@ import (
 // verify/debug paths.
 var canonicalPublicReadOnlyRoutes = []string{
 	"/v1/status",
-	"/v1/versions",
 	"/v1/models",
 	"/v1/governance/models",
 	"/v1/governance/models-legacy",
@@ -37,6 +36,10 @@ var canonicalPublicReadOnlyRoutes = []string{
 	"/v1/bridge/addresses",
 }
 
+var edgeAPIOnlyRoutes = []string{
+	"/v1/versions",
+}
+
 // canonicalOptionalReadOnlyRoutes are CPU-heavy verify/debug helpers served by
 // edge-api but private on the proxy unless EDGE_API_EXPOSE_OPTIONAL_ROUTES=true.
 var canonicalOptionalReadOnlyRoutes = []string{
@@ -46,14 +49,18 @@ var canonicalOptionalReadOnlyRoutes = []string{
 	"/v1/debug/verify/{height}",
 }
 
-// canonicalReadOnlyRoutes is the full edge-api OpenAPI surface (public + optional).
+// canonicalReadOnlyRoutes is the full edge-api OpenAPI surface.
 var canonicalReadOnlyRoutes = append(
-	append([]string(nil), canonicalPublicReadOnlyRoutes...),
+	append(
+		append([]string(nil), canonicalPublicReadOnlyRoutes...),
+		edgeAPIOnlyRoutes...,
+	),
 	canonicalOptionalReadOnlyRoutes...,
 )
 
 func TestReadOnlyRouteCount(t *testing.T) {
-	assert.Len(t, canonicalPublicReadOnlyRoutes, 18)
+	assert.Len(t, canonicalPublicReadOnlyRoutes, 17)
+	assert.Len(t, edgeAPIOnlyRoutes, 1)
 	assert.Len(t, canonicalOptionalReadOnlyRoutes, 4)
 	assert.Len(t, canonicalReadOnlyRoutes, 22)
 }
@@ -72,6 +79,17 @@ func TestProxyEntrypointPublicRoutesMatchCanonical(t *testing.T) {
 	want := append([]string(nil), canonicalPublicReadOnlyRoutes...)
 	sort.Strings(want)
 	assert.Equal(t, want, got)
+	assert.NotContains(t, got, "/v1/versions")
+}
+
+func TestProxyEntrypointSkipsVersionsOverride(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	path := filepath.Join(repoRoot, "proxy", "entrypoint.sh")
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `if [ "$route" = "/v1/versions" ]; then`)
 }
 
 func TestProxyEntrypointOptionalRoutesMatchCanonical(t *testing.T) {

--- a/common/queryapi/tests/status_test.go
+++ b/common/queryapi/tests/status_test.go
@@ -22,7 +22,9 @@ func TestGetStatus_Returns200(t *testing.T) {
 
 // -- GetVersions --
 
-type stubNodeInfoServer struct{ cmtservice.UnimplementedServiceServer }
+type stubNodeInfoServer struct {
+	cmtservice.UnimplementedServiceServer
+}
 
 func (s *stubNodeInfoServer) GetNodeInfo(_ context.Context, _ *cmtservice.GetNodeInfoRequest) (*cmtservice.GetNodeInfoResponse, error) {
 	return &cmtservice.GetNodeInfoResponse{
@@ -48,7 +50,9 @@ func TestGetVersions_Returns200(t *testing.T) {
 	assert.Contains(t, body, `"timestamp"`)
 }
 
-type errNodeInfoServer struct{ cmtservice.UnimplementedServiceServer }
+type errNodeInfoServer struct {
+	cmtservice.UnimplementedServiceServer
+}
 
 func (s *errNodeInfoServer) GetNodeInfo(_ context.Context, _ *cmtservice.GetNodeInfoRequest) (*cmtservice.GetNodeInfoResponse, error) {
 	return nil, status.Error(codes.Unavailable, "node down")

--- a/decentralized-api/Dockerfile
+++ b/decentralized-api/Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,id=go-build-cache3,target=/root/.cache/go-build \
 
 COPY decentralized-api/. .
 
-# ARG LDFLAGS
+ARG LDFLAGS
 RUN --mount=type=cache,id=go-build-cache3,target=/root/.cache/go-build \
     --mount=type=cache,id=go-mod-cache3,target=/go/pkg/mod \
     if [ "$BLST_PORTABLE" = "1" ]; then export CGO_CFLAGS="$CGO_CFLAGS -D__BLST_PORTABLE__"; fi; \

--- a/decentralized-api/Makefile
+++ b/decentralized-api/Makefile
@@ -42,6 +42,7 @@ define DOCKER_BUILD
 	@echo "    	GOARCH: $(GOARCH)"
 	@$(DOCKER_BUILD_PREFIX) \
 		--platform $(PLATFORM) \
+		--build-arg LDFLAGS='$(ldflags)' \
 		--build-arg GOOS=$(GOOS) \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg BLST_PORTABLE=$(BLST_PORTABLE) \
@@ -58,6 +59,7 @@ define DOCKER_BUILD_UPGRADE
 	@echo "    	GOARCH: $(GOARCH)"
 	@$(DOCKER_BUILD_UPGRADE_PREFIX) \
 		--platform $(PLATFORM) \
+		--build-arg LDFLAGS='$(ldflags)' \
 		--build-arg GOOS=$(GOOS) \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg DEVSHARD_VERSION=$(DEVSHARD_VERSION) \

--- a/decentralized-api/build_metadata_test.go
+++ b/decentralized-api/build_metadata_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerBuildPassesVersionMetadata(t *testing.T) {
+	makefile, err := os.ReadFile("Makefile")
+	require.NoError(t, err)
+	require.Equal(t, 2, strings.Count(string(makefile), "\n\t\t--build-arg LDFLAGS='$(ldflags)' \\"))
+
+	dockerfile, err := os.ReadFile("Dockerfile")
+	require.NoError(t, err)
+	require.Contains(t, string(dockerfile), "\nARG LDFLAGS\n")
+	require.Contains(t, string(dockerfile), `-ldflags "$LDFLAGS"`)
+}

--- a/decentralized-api/internal/event_listener/integration_test.go
+++ b/decentralized-api/internal/event_listener/integration_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -160,6 +162,7 @@ func (m *MockBrokerChainBridge) GetParams() (*types.QueryParamsResponse, error) 
 
 type MockRandomSeedManager struct {
 	mock.Mock
+	onGenerate func(epochIndex uint64)
 }
 
 func (m *MockRandomSeedManager) ChangeCurrentSeed() {
@@ -176,16 +179,28 @@ func (m *MockRandomSeedManager) RequestMoney(epochIndex uint64) {
 }
 
 func (m *MockRandomSeedManager) CreateNewSeed(epochIndex uint64) (*apiconfig.SeedInfo, error) {
-	m.Called()
-	return nil, nil
+	m.Called(epochIndex)
+	// Match the signature ListRandomSeeds returns after GenerateSeedInfo so
+	// confirmSeedLocally can succeed the same way production restore does.
+	return &apiconfig.SeedInfo{
+		Seed:       1,
+		EpochIndex: epochIndex,
+		Signature:  integrationTestSeedSignature,
+	}, nil
 }
 
 func (m *MockRandomSeedManager) GenerateSeedInfo(epochIndex uint64) {
 	m.Called(epochIndex)
+	if m.onGenerate != nil {
+		m.onGenerate(epochIndex)
+	}
 }
 
 type MockQueryClient struct {
 	mock.Mock
+	listRandomSeedsCalls atomic.Int64
+	mu                   sync.Mutex
+	submittedByEpoch     map[uint64]*types.RandomSeed
 }
 
 func (m *MockQueryClient) EpochInfo(ctx context.Context, req *types.QueryEpochInfoRequest, opts ...grpc.CallOption) (*types.QueryEpochInfoResponse, error) {
@@ -199,6 +214,36 @@ func (m *MockQueryClient) Params(ctx context.Context, req *types.QueryParamsRequ
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.QueryParamsResponse), args.Error(1)
+}
+
+const integrationTestSeedParticipant = "some-address"
+const integrationTestSeedSignature = "integration-test-seed-signature"
+
+// ListRandomSeeds is not testify-expectation based: ensureSeedSubmitted runs
+// asynchronously and can race ExpectedCalls = nil in setLatestEpoch.
+// After GenerateSeedInfo, the seed becomes visible here so later ensures take
+// the confirm path and stop resubmitting (same shape as production).
+func (m *MockQueryClient) ListRandomSeeds(ctx context.Context, req *types.QueryRandomSeedsRequest, opts ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error) {
+	m.listRandomSeedsCalls.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if seed, ok := m.submittedByEpoch[req.EpochIndex]; ok {
+		return &types.QueryRandomSeedsResponse{Seeds: []*types.RandomSeed{seed}}, nil
+	}
+	return &types.QueryRandomSeedsResponse{}, nil
+}
+
+func (m *MockQueryClient) markSeedSubmitted(epochIndex uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.submittedByEpoch == nil {
+		m.submittedByEpoch = make(map[uint64]*types.RandomSeed)
+	}
+	m.submittedByEpoch[epochIndex] = &types.RandomSeed{
+		Participant: integrationTestSeedParticipant,
+		EpochIndex:  epochIndex,
+		Signature:   integrationTestSeedSignature,
+	}
 }
 
 // Test setup helpers
@@ -219,7 +264,11 @@ func createIntegrationTestSetup(reconcilialtionConfig *MlNodeReconciliationConfi
 	os.Setenv("ENFORCED_MODEL_ID", "disabled")
 
 	mockQueryClient := &MockQueryClient{}
-	mockSeedManager := &MockRandomSeedManager{}
+	mockSeedManager := &MockRandomSeedManager{
+		onGenerate: func(epochIndex uint64) {
+			mockQueryClient.markSeedSubmitted(epochIndex)
+		},
+	}
 
 	phaseTracker := &chainphase.ChainPhaseTracker{}
 
@@ -446,7 +495,19 @@ func (setup *IntegrationTestSetup) simulateBlock(height int64) error {
 		Height: height,
 		Hash:   fmt.Sprintf("hash-%d", height),
 	}
-	return setup.Dispatcher.ProcessNewBlock(context.Background(), blockInfo)
+	err := setup.Dispatcher.ProcessNewBlock(context.Background(), blockInfo)
+	setup.waitForSeedEnsureIdle()
+	return err
+}
+
+func (setup *IntegrationTestSetup) waitForSeedEnsureIdle() {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !setup.Dispatcher.seedEnsureInFlight.Load() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 func (setup *IntegrationTestSetup) getNodeClient(nodeId string, port int) *mlnodeclient.MockClient {
@@ -653,6 +714,8 @@ func TestRegularPocScenario(t *testing.T) {
 		assertNodeClient(t, expected, node2Client)
 		i++
 	}
+	require.GreaterOrEqual(t, setup.MockQueryClient.listRandomSeedsCalls.Load(), int64(1),
+		"seed ensure should query ListRandomSeeds at least once during PoC window")
 
 	pocValStart := i
 	pocValEnd := pocValStart + setup.EpochParams.PocValidationDelay + setup.EpochParams.PocValidationDuration

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"decentralized-api/apiconfig"
@@ -29,6 +31,7 @@ import (
 type ChainStateClient interface {
 	EpochInfo(ctx context.Context, req *types.QueryEpochInfoRequest, opts ...grpc.CallOption) (*types.QueryEpochInfoResponse, error)
 	Params(ctx context.Context, req *types.QueryParamsRequest, opts ...grpc.CallOption) (*types.QueryParamsResponse, error)
+	ListRandomSeeds(ctx context.Context, req *types.QueryRandomSeedsRequest, opts ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error)
 }
 
 // StatusFunc defines the function signature for getting node sync status
@@ -80,7 +83,14 @@ type OnNewBlockDispatcher struct {
 	configManager        *apiconfig.ConfigManager
 	epochGroupDataCache  *internal.EpochGroupDataCache
 	lastThresholdEpoch   uint64 // last epoch the per-model thresholds were refreshed for
+
+	seedSubmissionMu   sync.Mutex
+	seedAttemptHeight  int64
+	seedConfirmedEpoch uint64
+	seedEnsureInFlight atomic.Bool
 }
+
+const seedRetryCooldownBlocks int64 = 2
 
 // StatusResponse matches the structure expected by getStatus function
 type StatusResponse struct {
@@ -303,7 +313,7 @@ func (d *OnNewBlockDispatcher) ProcessNewBlock(ctx context.Context, blockInfo ch
 	}
 
 	// 3. Check for phase transitions and stage events
-	d.handlePhaseTransitions(*epochState)
+	d.handlePhaseTransitions(ctx, *epochState)
 
 	// 4. Check if reconciliation should be triggered
 	if d.shouldTriggerReconciliation(*epochState) {
@@ -385,7 +395,7 @@ func (d *OnNewBlockDispatcher) refreshModelValidationThresholds(epoch uint64) {
 	d.lastThresholdEpoch = epoch
 }
 
-func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.EpochState) {
+func (d *OnNewBlockDispatcher) handlePhaseTransitions(ctx context.Context, epochState chainphase.EpochState) {
 	//To work for tests
 	if d.nodeBroker == nil {
 		return
@@ -404,10 +414,24 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 		logging.Warn("Failed to refresh preserved membership cache; continuing with cached snapshot", types.Stages, "error", err)
 	}
 
-	// Check for PoC start for the next epoch. This is the most important transition.
+	if d.isSeedSubmissionWindow(epochContext, blockHeight) {
+		participantAddress := d.nodeBroker.GetParticipantAddress()
+		// Best-effort across the PoC window, not a height-exact stage flip.
+		// Run async so ListRandomSeeds / GenerateSeedInfo cannot delay the
+		// QueueMessage transitions below (same pattern as RequestMoney).
+		// At most one ensure goroutine at a time — avoid per-block spawn pile-up.
+		if d.seedEnsureInFlight.CompareAndSwap(false, true) {
+			go func(epochContext types.EpochContext, blockHeight int64, participantAddress string) {
+				defer d.seedEnsureInFlight.Store(false)
+				// Bound the query/sign path so a hung RPC cannot pin inFlight forever.
+				seedCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				d.ensureSeedSubmitted(seedCtx, epochContext, blockHeight, participantAddress)
+			}(epochContext, blockHeight, participantAddress)
+		}
+	}
+
 	if epochContext.IsStartOfPocStage(blockHeight) {
-		logging.Info("DapiStage:IsStartOfPocStage: generating and submitting PoC seed for upcoming epoch", types.Stages, "blockHeight", blockHeight, "blockHash", blockHash, "epochIndex", epochContext.EpochIndex)
-		d.randomSeedManager.GenerateSeedInfo(epochContext.EpochIndex)
 		return
 	}
 
@@ -553,6 +577,120 @@ func (d *OnNewBlockDispatcher) handlePhaseTransitions(epochState chainphase.Epoc
 			}
 		}
 	}
+}
+
+func (d *OnNewBlockDispatcher) isSeedSubmissionWindow(epochContext types.EpochContext, blockHeight int64) bool {
+	return epochContext.EpochIndex > 0 &&
+		blockHeight >= epochContext.StartOfPoC() &&
+		blockHeight < epochContext.EndOfPoCValidation()
+}
+
+func (d *OnNewBlockDispatcher) ensureSeedSubmitted(
+	ctx context.Context,
+	epochContext types.EpochContext,
+	blockHeight int64,
+	participantAddress string,
+) {
+	if d.queryClient == nil || d.randomSeedManager == nil || d.configManager == nil || participantAddress == "" {
+		return
+	}
+
+	epochIndex := epochContext.EpochIndex
+
+	d.seedSubmissionMu.Lock()
+	defer d.seedSubmissionMu.Unlock()
+
+	if d.seedConfirmedEpoch >= epochIndex {
+		return
+	}
+	// Avoid resubmitting while the previous async SubmitSeed may still be in flight.
+	if d.seedAttemptHeight > 0 && blockHeight-d.seedAttemptHeight < seedRetryCooldownBlocks {
+		return
+	}
+
+	onChainSeed, found, err := d.getParticipantSeed(ctx, epochIndex, participantAddress)
+	if err != nil {
+		logging.Warn("Failed to verify upcoming epoch seed on chain", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress,
+			"blockHeight", blockHeight,
+			"error", err)
+	} else if found {
+		if d.confirmSeedLocally(epochIndex, participantAddress, onChainSeed) {
+			d.seedConfirmedEpoch = epochIndex
+		}
+		return
+	}
+
+	logging.Info("Ensuring PoC seed is submitted for upcoming epoch", types.Claims,
+		"epochIndex", epochIndex,
+		"participant", participantAddress,
+		"blockHeight", blockHeight,
+		"retry", d.seedAttemptHeight > 0)
+	d.seedAttemptHeight = blockHeight
+	d.randomSeedManager.GenerateSeedInfo(epochIndex)
+}
+
+func (d *OnNewBlockDispatcher) getParticipantSeed(
+	ctx context.Context,
+	epochIndex uint64,
+	participantAddress string,
+) (*types.RandomSeed, bool, error) {
+	response, err := d.queryClient.ListRandomSeeds(ctx, &types.QueryRandomSeedsRequest{EpochIndex: epochIndex})
+	if err != nil {
+		return nil, false, err
+	}
+	if response == nil {
+		return nil, false, errors.New("random seeds response is nil")
+	}
+	for _, randomSeed := range response.Seeds {
+		if randomSeed != nil && randomSeed.Participant == participantAddress {
+			return randomSeed, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// confirmSeedLocally syncs local upcoming seed with an on-chain seed.
+// Returns false only on transient restore failure so the next block can retry.
+func (d *OnNewBlockDispatcher) confirmSeedLocally(
+	epochIndex uint64,
+	participantAddress string,
+	onChainSeed *types.RandomSeed,
+) bool {
+	localSeed := d.configManager.GetUpcomingSeed()
+	if localSeed.EpochIndex == epochIndex && localSeed.Signature == onChainSeed.Signature {
+		logging.Info("Confirmed upcoming epoch seed on chain", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress)
+		return true
+	}
+
+	generatedSeed, err := d.randomSeedManager.CreateNewSeed(epochIndex)
+	if err != nil || generatedSeed == nil {
+		logging.Error("On-chain seed exists but local seed could not be restored", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress,
+			"error", err)
+		return false
+	}
+	if generatedSeed.Signature != onChainSeed.Signature {
+		logging.Error("On-chain seed signature does not match local deterministic seed; refusing to overwrite", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress)
+		return true
+	}
+	if err := d.configManager.SetUpcomingSeed(*generatedSeed); err != nil {
+		logging.Error("Failed to restore confirmed upcoming seed locally", types.Claims,
+			"epochIndex", epochIndex,
+			"participant", participantAddress,
+			"error", err)
+		return false
+	}
+	logging.Info("Confirmed upcoming epoch seed on chain", types.Claims,
+		"epochIndex", epochIndex,
+		"participant", participantAddress)
+	return true
 }
 
 // shouldTriggerReconciliation determines if reconciliation should be triggered

--- a/decentralized-api/internal/event_listener/new_block_dispatcher_runtime_cache_test.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher_runtime_cache_test.go
@@ -35,6 +35,14 @@ func (m *mockParamsQueryClient) Params(ctx context.Context, req *types.QueryPara
 	return args.Get(0).(*types.QueryParamsResponse), args.Error(1)
 }
 
+func (m *mockParamsQueryClient) ListRandomSeeds(ctx context.Context, req *types.QueryRandomSeedsRequest, opts ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.QueryRandomSeedsResponse), args.Error(1)
+}
+
 func newRuntimeCacheTestDispatcher(t *testing.T, qc *mockParamsQueryClient) (*OnNewBlockDispatcher, *apiconfig.ConfigManager) {
 	t.Helper()
 

--- a/decentralized-api/internal/event_listener/seed_submission_test.go
+++ b/decentralized-api/internal/event_listener/seed_submission_test.go
@@ -1,0 +1,266 @@
+package event_listener
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"decentralized-api/apiconfig"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+const seedTestParticipant = "gonka1seedtestparticipant"
+
+type seedQueryResult struct {
+	response *types.QueryRandomSeedsResponse
+	err      error
+}
+
+type seedQueryClient struct {
+	mu      sync.Mutex
+	results []seedQueryResult
+	calls   int
+}
+
+func (q *seedQueryClient) EpochInfo(context.Context, *types.QueryEpochInfoRequest, ...grpc.CallOption) (*types.QueryEpochInfoResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (q *seedQueryClient) Params(context.Context, *types.QueryParamsRequest, ...grpc.CallOption) (*types.QueryParamsResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (q *seedQueryClient) ListRandomSeeds(context.Context, *types.QueryRandomSeedsRequest, ...grpc.CallOption) (*types.QueryRandomSeedsResponse, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.calls++
+	if len(q.results) == 0 {
+		return &types.QueryRandomSeedsResponse{}, nil
+	}
+	index := q.calls - 1
+	if index >= len(q.results) {
+		index = len(q.results) - 1
+	}
+	return q.results[index].response, q.results[index].err
+}
+
+type recordingSeedManager struct {
+	mu          sync.Mutex
+	config      *apiconfig.ConfigManager
+	generated   []uint64
+	createdSeed apiconfig.SeedInfo
+	createErr   error
+}
+
+func (m *recordingSeedManager) GenerateSeedInfo(epochIndex uint64) {
+	m.mu.Lock()
+	m.generated = append(m.generated, epochIndex)
+	m.mu.Unlock()
+
+	seed := m.createdSeed
+	seed.EpochIndex = epochIndex
+	_ = m.config.SetUpcomingSeed(seed)
+}
+
+func (m *recordingSeedManager) GetSeedForEpoch(uint64) apiconfig.SeedInfo {
+	return apiconfig.SeedInfo{}
+}
+
+func (m *recordingSeedManager) CreateNewSeed(epochIndex uint64) (*apiconfig.SeedInfo, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	seed := m.createdSeed
+	seed.EpochIndex = epochIndex
+	return &seed, nil
+}
+
+func (m *recordingSeedManager) ChangeCurrentSeed() {}
+
+func (m *recordingSeedManager) RequestMoney(uint64) {}
+
+func (m *recordingSeedManager) generatedCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.generated)
+}
+
+func seedTestEpoch() types.EpochContext {
+	return types.EpochContext{
+		EpochIndex:          2,
+		PocStartBlockHeight: 100,
+		EpochParams: types.EpochParams{
+			PocStageDuration:      20,
+			PocValidationDelay:    2,
+			PocValidationDuration: 10,
+		},
+	}
+}
+
+func newSeedTestDispatcher(results ...seedQueryResult) (*OnNewBlockDispatcher, *recordingSeedManager, *apiconfig.ConfigManager) {
+	config := &apiconfig.ConfigManager{}
+	manager := &recordingSeedManager{
+		config: config,
+		createdSeed: apiconfig.SeedInfo{
+			Seed:      42,
+			Signature: "deterministic-signature",
+		},
+	}
+	return &OnNewBlockDispatcher{
+		queryClient:       &seedQueryClient{results: results},
+		randomSeedManager: manager,
+		configManager:     config,
+	}, manager, config
+}
+
+func chainSeed(signature string) seedQueryResult {
+	return seedQueryResult{response: &types.QueryRandomSeedsResponse{
+		Seeds: []*types.RandomSeed{{
+			Participant: seedTestParticipant,
+			EpochIndex:  2,
+			Signature:   signature,
+		}},
+	}}
+}
+
+func emptySeedQuery() seedQueryResult {
+	return seedQueryResult{response: &types.QueryRandomSeedsResponse{}}
+}
+
+func TestSeedSubmissionWindow(t *testing.T) {
+	dispatcher, _, _ := newSeedTestDispatcher()
+	epoch := seedTestEpoch()
+
+	require.True(t, dispatcher.isSeedSubmissionWindow(epoch, 100))
+	require.True(t, dispatcher.isSeedSubmissionWindow(epoch, 131))
+	require.False(t, dispatcher.isSeedSubmissionWindow(epoch, 99))
+	require.False(t, dispatcher.isSeedSubmissionWindow(epoch, 132))
+	require.False(t, dispatcher.isSeedSubmissionWindow(types.EpochContext{}, 0))
+}
+
+func TestEnsureSeedSubmittedRecoversAfterBoundaryLag(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(emptySeedQuery())
+	oldEpoch := types.EpochContext{
+		EpochIndex:          1,
+		PocStartBlockHeight: 0,
+		EpochParams:         seedTestEpoch().EpochParams,
+	}
+
+	require.False(t, dispatcher.isSeedSubmissionWindow(oldEpoch, 100))
+	require.True(t, dispatcher.isSeedSubmissionWindow(seedTestEpoch(), 101))
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 101, seedTestParticipant)
+	require.Equal(t, 1, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedConfirmsAfterVisibilityDelay(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(
+		emptySeedQuery(),
+		chainSeed("deterministic-signature"),
+	)
+	epoch := seedTestEpoch()
+
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 100, seedTestParticipant)
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 101, seedTestParticipant) // cooldown: no query
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 102, seedTestParticipant)
+
+	require.Equal(t, 1, manager.generatedCount())
+	require.Equal(t, uint64(2), dispatcher.seedConfirmedEpoch)
+}
+
+func TestEnsureSeedSubmittedRetriesAfterCooldown(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(emptySeedQuery())
+	epoch := seedTestEpoch()
+
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 100, seedTestParticipant)
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 101, seedTestParticipant)
+	dispatcher.ensureSeedSubmitted(context.Background(), epoch, 102, seedTestParticipant)
+
+	require.Equal(t, 2, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedRepairsPersistedButUnconfirmedSeed(t *testing.T) {
+	dispatcher, manager, config := newSeedTestDispatcher(emptySeedQuery())
+	require.NoError(t, config.SetUpcomingSeed(apiconfig.SeedInfo{
+		Seed:       42,
+		EpochIndex: 2,
+		Signature:  "deterministic-signature",
+	}))
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 101, seedTestParticipant)
+
+	require.Equal(t, 1, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedRestoresMissingLocalSeed(t *testing.T) {
+	dispatcher, manager, config := newSeedTestDispatcher(chainSeed("deterministic-signature"))
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 102, seedTestParticipant)
+
+	require.Equal(t, 0, manager.generatedCount())
+	require.Equal(t, uint64(2), config.GetUpcomingSeed().EpochIndex)
+	require.Equal(t, "deterministic-signature", config.GetUpcomingSeed().Signature)
+}
+
+func TestEnsureSeedSubmittedDoesNotOverwriteSignatureMismatch(t *testing.T) {
+	dispatcher, manager, config := newSeedTestDispatcher(chainSeed("different-signature"))
+	require.NoError(t, config.SetUpcomingSeed(apiconfig.SeedInfo{
+		Seed:       42,
+		EpochIndex: 2,
+		Signature:  "deterministic-signature",
+	}))
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 102, seedTestParticipant)
+
+	require.Equal(t, 0, manager.generatedCount())
+	require.Equal(t, "deterministic-signature", config.GetUpcomingSeed().Signature)
+	require.Equal(t, uint64(2), dispatcher.seedConfirmedEpoch)
+}
+
+func TestEnsureSeedSubmittedRetriesLocalRestoreAfterFailure(t *testing.T) {
+	dispatcher, manager, config := newSeedTestDispatcher(
+		chainSeed("deterministic-signature"),
+		chainSeed("deterministic-signature"),
+	)
+	manager.createErr = errors.New("signer unavailable")
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 100, seedTestParticipant)
+	require.Equal(t, uint64(0), dispatcher.seedConfirmedEpoch)
+	require.Equal(t, uint64(0), config.GetUpcomingSeed().EpochIndex)
+
+	manager.createErr = nil
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 102, seedTestParticipant)
+
+	require.Equal(t, uint64(2), dispatcher.seedConfirmedEpoch)
+	require.Equal(t, "deterministic-signature", config.GetUpcomingSeed().Signature)
+	require.Equal(t, 0, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedFailsOpenOnQueryError(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(seedQueryResult{err: errors.New("query unavailable")})
+
+	dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 100, seedTestParticipant)
+
+	require.Equal(t, 1, manager.generatedCount())
+}
+
+func TestEnsureSeedSubmittedSerializesDuplicateEvents(t *testing.T) {
+	dispatcher, manager, _ := newSeedTestDispatcher(emptySeedQuery())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dispatcher.ensureSeedSubmitted(context.Background(), seedTestEpoch(), 100, seedTestParticipant)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, manager.generatedCount())
+}

--- a/decentralized-api/internal/seed/seed_test.go
+++ b/decentralized-api/internal/seed/seed_test.go
@@ -1,0 +1,33 @@
+package seed
+
+import (
+	"testing"
+
+	"decentralized-api/apiconfig"
+	"decentralized-api/cosmosclient"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/stretchr/testify/require"
+)
+
+type deterministicSeedSigner struct {
+	cosmosclient.MockCosmosMessageClient
+	privateKey *secp256k1.PrivKey
+}
+
+func (s *deterministicSeedSigner) SignBytes(message []byte) ([]byte, error) {
+	return s.privateKey.Sign(message)
+}
+
+func TestCreateNewSeedIsDeterministicForEpoch(t *testing.T) {
+	signer := &deterministicSeedSigner{privateKey: secp256k1.GenPrivKey()}
+	manager := NewRandomSeedManager(signer, &apiconfig.ConfigManager{})
+
+	first, err := manager.CreateNewSeed(344)
+	require.NoError(t, err)
+	second, err := manager.CreateNewSeed(344)
+	require.NoError(t, err)
+
+	require.Equal(t, first.Seed, second.Seed)
+	require.Equal(t, first.Signature, second.Signature)
+}

--- a/decentralized-api/internal/server/public/deprecated_queryapi.go
+++ b/decentralized-api/internal/server/public/deprecated_queryapi.go
@@ -157,8 +157,7 @@ func (d deprecatedQueryAPI) PostVerifyProof(ctx echo.Context) error {
 }
 
 func (d deprecatedQueryAPI) GetVersions(ctx echo.Context) error {
-	markQueryAPIDeprecated(ctx)
-	return d.inner.GetVersions(ctx)
+	return echo.ErrNotFound
 }
 
 var _ gen.ServerInterface = deprecatedQueryAPI{}

--- a/decentralized-api/internal/server/public/deprecated_queryapi_test.go
+++ b/decentralized-api/internal/server/public/deprecated_queryapi_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -31,4 +32,29 @@ func TestDeprecatedLegacyDapiOnlyRoutes_BridgeLatestMarksDeprecation(t *testing.
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "true", rec.Header().Get("Deprecation"))
 	require.Contains(t, rec.Header().Get("Link"), "edge-api")
+}
+
+func TestVersionsRouteUsesEnrichedDAPIHandler(t *testing.T) {
+	s := NewServer(nil, newTestConfigManager(t), nil, nil, nil, nil)
+
+	s.versionsCache.response = &versionsResponse{
+		Timestamp:   "2026-01-01T00:00:00Z",
+		APIVersion:  map[string]string{"version": "test"},
+		NodeVersion: map[string]string{"version": "test"},
+		MLNodes: []mlnodeVersionResponse{{
+			NodeID:                 "node-1",
+			Version:                "1.0.0",
+			PoCValidationInference: true,
+		}},
+	}
+	s.versionsCache.expiresAt = time.Now().Add(time.Hour)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/versions", nil)
+	rec := httptest.NewRecorder()
+	s.e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"mlnodes"`)
+	require.Contains(t, rec.Body.String(), `"poc_validation_inference":true`)
+	require.Empty(t, rec.Header().Get("Deprecation"))
 }

--- a/decentralized-api/internal/server/public/server.go
+++ b/decentralized-api/internal/server/public/server.go
@@ -156,6 +156,8 @@ func NewServer(
 	// marked Deprecation: true. Prefer edge-api for new proxy configs.
 	s.mountDeprecatedQueryAPIRoutes(e)
 
+	e.GET("/v1/versions", s.getVersions)
+
 	e.Any(deprecatedDevshardV1Prefix, legacyDevshardDeprecated)
 	e.Any(deprecatedDevshardV1Prefix+"/*", legacyDevshardDeprecated)
 	return s

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -285,8 +285,11 @@ func main() {
 	adminServer.Start(addr)
 
 	nmGrpcPort := configManager.GetApiConfig().NodeManagerGrpcPort
-	// port should be set explicitly in the config to start NodeManager GRPC server. 0 means we skip it
-	if nmGrpcPort != 0 {
+	if nmGrpcPort == 0 {
+		nmGrpcPort = 9400
+	}
+	// Negative ports explicitly disable the NodeManager gRPC server.
+	if nmGrpcPort > 0 {
 		nmGrpcServer := grpc.NewServer()
 		nmgen.RegisterNodeManagerServer(nmGrpcServer, nodemanager.NewServer(nodeBroker, configManager, chainPhaseTracker,
 			nodemanager.WithHostEventRing(hostEventRing),

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   api:
     container_name: api
-    image: ghcr.io/product-science/api:0.2.15
+    image: ghcr.io/product-science/api:0.2.15-post3
     volumes:
       - .inference:/root/.inference
       - .dapi:/root/.dapi

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -121,6 +121,11 @@ type nonceOutcome struct {
 // TimeoutResult reports what happened during timeout handling.
 type TimeoutResult struct {
 	Reason string // "execution", "refused", or "" if deadline not reached
+	// Applied is true only when the timeout tx survived the local apply and
+	// went out in the diff. HandleTimeout returns a non-nil error on every
+	// path, including success, so this is the field that distinguishes an
+	// applied timeout from one the state machine rejected.
+	Applied bool
 }
 
 // HasMsgFinish returns true if mempool contains MsgFinishInference for the given nonce.
@@ -1374,6 +1379,32 @@ func (s *Session) verifyStateSignature(nonce uint64, postRoot, signature []byte,
 	return nil
 }
 
+func (s *Session) verifyTimeoutVote(inferenceID uint64, reason types.TimeoutReason, vote *types.TimeoutVote, expectedAddr string) error {
+	voteData, err := proto.Marshal(&types.TimeoutVoteContent{
+		EscrowId:    s.escrowID,
+		InferenceId: inferenceID,
+		Reason:      reason,
+		Accept:      vote.Accept,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal timeout vote content: %w", err)
+	}
+	recovered, err := s.verifier.RecoverAddress(voteData, vote.Signature)
+	if err != nil {
+		return fmt.Errorf("%w: %v", types.ErrInvalidVoteSig, err)
+	}
+	if recovered != expectedAddr &&
+		s.sm.WarmKeys()[vote.VoterSlot] != recovered &&
+		!s.sm.CheckWarmKey(recovered, expectedAddr) {
+		return fmt.Errorf("%w: expected %s, got %s", types.ErrInvalidVoteSig, expectedAddr, recovered)
+	}
+	if owner := s.sm.SlotAddress(vote.VoterSlot); owner != expectedAddr {
+		return fmt.Errorf("%w: slot %d is owned by %s, not by responder %s",
+			types.ErrInvalidVoteSig, vote.VoterSlot, owner, expectedAddr)
+	}
+	return nil
+}
+
 func (s *Session) fetchSignature(ctx context.Context, hostIdx int, nonce uint64, client HostClient) bool {
 	fetcher, ok := client.(SignatureFetcher)
 	if !ok {
@@ -1704,23 +1735,37 @@ func (s *Session) AddPendingTimeoutTx(inferenceID uint64, reason types.TimeoutRe
 // SendPendingDiff creates a diff from pending txs (no new MsgStartInference),
 // applies it locally, and sends it to the next host. Used for timeout submission.
 func (s *Session) SendPendingDiff(ctx context.Context) error {
+	_, err := s.sendPendingDiff(ctx)
+	return err
+}
+
+func (s *Session) sendPendingDiff(ctx context.Context) (types.Diff, error) {
 	s.mu.Lock()
 	diff, hostIdx, err := s.composeDiffLocked(nil)
 	if err != nil {
 		s.mu.Unlock()
-		return err
+		return types.Diff{}, err
 	}
 	catchUp := s.diffsForHost(hostIdx)
 	s.mu.Unlock()
 
 	resp, err := s.clients[hostIdx].Send(ctx, host.HostRequest{Diffs: catchUp, Nonce: diff.Nonce}, nil, nil)
 	if err != nil {
-		return fmt.Errorf("send timeout diff to host %d: %w", hostIdx, err)
+		return diff, fmt.Errorf("send timeout diff to host %d: %w", hostIdx, err)
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.processResponse(hostIdx, resp, diff.Nonce)
+	return diff, s.processResponse(hostIdx, resp, diff.Nonce)
+}
+
+func diffAppliedTimeout(diff types.Diff, inferenceID uint64) bool {
+	for _, tx := range diff.Txs {
+		if t := tx.GetTimeoutInference(); t != nil && t.InferenceId == inferenceID {
+			return true
+		}
+	}
+	return false
 }
 
 // TimeoutVerifiers returns a map of host index -> TimeoutVerifier for all
@@ -1893,10 +1938,16 @@ func (s *Session) HandleTimeout(ctx context.Context, nonce uint64, sendTime time
 
 	if s.HasSufficientTimeoutVotes(votes) {
 		s.AddPendingTimeoutTx(nonce, reason, votes)
-		if err := s.SendPendingDiff(ctx); err != nil {
+		diff, err := s.sendPendingDiff(ctx)
+		if err != nil {
 			logging.Stage(ctx, "timeout_diff_send_failed", logFields("reason", result.Reason, "error", err)...)
 			return result, fmt.Errorf("send timeout diff: %w", err)
 		}
+		if !diffAppliedTimeout(diff, nonce) {
+			logging.Stage(ctx, "timeout_not_applied", logFields("reason", result.Reason, "diff_nonce", diff.Nonce)...)
+			return result, fmt.Errorf("inference %d timeout rejected by state machine at nonce %d", nonce, diff.Nonce)
+		}
+		result.Applied = true
 		logging.Stage(ctx, "timeout_completed", logFields("reason", result.Reason)...)
 		return result, fmt.Errorf("inference %d timed out: %s", nonce, reason)
 	}
@@ -2099,7 +2150,7 @@ func (s *Session) CollectTimeoutVotes(
 
 	voteThreshold := s.sm.VoteThreshold()
 	var accWeight uint32
-	var errors, rejects int
+	var errors, rejects, invalid int
 	for i := 0; i < expected; i++ {
 		res := <-results
 		if res.err != nil {
@@ -2118,6 +2169,29 @@ func (s *Session) CollectTimeoutVotes(
 			continue // skip failed hosts
 		}
 		if res.vote != nil {
+			// Verify before counting. An unverified vote must never contribute
+			// weight, reach the quorum decision, or trigger the early exit
+			// below: applyTimeout rejects the whole MsgTimeoutInference on the
+			// first bad vote, so a single spoofed slot would otherwise discard
+			// an honest quorum that was still in flight.
+			if vErr := s.verifyTimeoutVote(inferenceID, reason, res.vote, res.verifierAddr); vErr != nil {
+				invalid++
+				logging.Stage(ctx, "timeout_vote_result",
+					logFields(
+						res.verifierAddr,
+						"outcome", "invalid",
+						"voter_slot", res.vote.VoterSlot,
+						"running_weight", accWeight,
+						"threshold", voteThreshold,
+						"error", vErr,
+					)...,
+				)
+				logging.Warn("rejected unverified timeout vote",
+					"subsystem", "session", "escrow_id", s.escrowID,
+					"inference_id", inferenceID, "responder", res.verifierAddr,
+					"voter_slot", res.vote.VoterSlot, "error", vErr)
+				continue
+			}
 			votes = append(votes, res.vote)
 			voterAddr := s.sm.SlotAddress(res.vote.VoterSlot)
 			weight := s.sm.AddressSlotCount(voterAddr)
@@ -2154,6 +2228,7 @@ func (s *Session) CollectTimeoutVotes(
 			"accept", len(votes),
 			"weight", accWeight,
 			"reject", rejects,
+			"invalid", invalid,
 			"errors", errors,
 			"threshold", voteThreshold,
 			"verifiers", expected,
@@ -2163,24 +2238,37 @@ func (s *Session) CollectTimeoutVotes(
 	logging.Debug("timeout vote collection",
 		"subsystem", "session", "inference_id", inferenceID,
 		"accept", len(votes), "weight", accWeight,
-		"reject", rejects, "errors", errors,
+		"reject", rejects, "invalid", invalid, "errors", errors,
 		"threshold", voteThreshold, "verifiers", expected)
 
 	return votes, nil
 }
 
-// HasSufficientTimeoutVotes returns true if the accept votes exceed the vote threshold.
+// HasSufficientTimeoutVotes returns true if the accept votes exceed the vote
+// threshold. Votes must already have been verified against their responder --
+// CollectTimeoutVotes only returns verified votes -- since this counts the
+// weight of whatever slot each vote claims.
+//
+// Weight is deduplicated by validator address, matching applyTimeout: one
+// address cannot contribute its slot count more than once regardless of how
+// many of its slots appear in the vote list.
 func (s *Session) HasSufficientTimeoutVotes(votes []*types.TimeoutVote) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	threshold := s.sm.VoteThreshold()
+	counted := make(map[string]bool, len(votes))
 	var accWeight uint32
 	for _, v := range votes {
-		if v.Accept {
-			addr := s.sm.SlotAddress(v.VoterSlot)
-			accWeight += s.sm.AddressSlotCount(addr)
+		if !v.Accept {
+			continue
 		}
+		addr := s.sm.SlotAddress(v.VoterSlot)
+		if counted[addr] {
+			continue
+		}
+		counted[addr] = true
+		accWeight += s.sm.AddressSlotCount(addr)
 	}
 	return accWeight > threshold
 }

--- a/devshard/user/timeout_vote_binding_test.go
+++ b/devshard/user/timeout_vote_binding_test.go
@@ -1,0 +1,457 @@
+package user
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"devshard/host"
+	"devshard/internal/statetest"
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/state"
+	"devshard/stub"
+	"devshard/types"
+)
+
+type slotClaimingVerifier struct {
+	signer      *signing.Secp256k1Signer
+	claimedSlot uint32
+	escrowID    string
+}
+
+func (m *slotClaimingVerifier) VerifyTimeout(_ context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, error) {
+	data, err := proto.Marshal(&types.TimeoutVoteContent{
+		EscrowId:    m.escrowID,
+		InferenceId: inferenceID,
+		Reason:      reason,
+		Accept:      true,
+	})
+	if err != nil {
+		return false, nil, 0, err
+	}
+	sig, err := m.signer.Sign(data)
+	if err != nil {
+		return false, nil, 0, err
+	}
+	return true, sig, m.claimedSlot, nil
+}
+
+type timeoutVoteFixture struct {
+	session *Session
+	userSM  *state.StateMachine
+	signers []*signing.Secp256k1Signer
+	group   []types.SlotAssignment
+	config  types.SessionConfig
+}
+
+func newTimeoutVoteFixture(t *testing.T) *timeoutVoteFixture {
+	t.Helper()
+
+	signers := make([]*signing.Secp256k1Signer, 4)
+	for i := range signers {
+		signers[i] = testutil.MustGenerateKey(t)
+	}
+	userKey := testutil.MustGenerateKey(t)
+	group := testutil.MakeMultiSlotGroup(signers, []int{1, 1, 4, 1})
+	config := types.SessionConfig{
+		RefusalTimeout:   60,
+		ExecutionTimeout: 1200,
+		TokenPrice:       1,
+		FeePerNonce:      5,
+		VoteThreshold:    uint32(len(group)) / 2, // 7/2 = 3, need >3
+	}
+	verifier := signing.NewSecp256k1Verifier()
+
+	clients := make([]HostClient, len(group))
+	for i, slot := range group {
+		var slotSigner *signing.Secp256k1Signer
+		for _, s := range signers {
+			if s.Address() == slot.ValidatorAddress {
+				slotSigner = s
+				break
+			}
+		}
+		sm := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+		h, err := host.NewHost(sm, slotSigner, stub.NewInferenceEngine(), "escrow-1", group, nil, host.WithGrace(100))
+		require.NoError(t, err)
+		clients[i] = &InProcessClient{Host: h}
+	}
+
+	userSM := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+	session, err := NewSession(userSM, userKey, "escrow-1", group, clients, verifier)
+	require.NoError(t, err)
+
+	_, err = session.SendInference(context.Background(), InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.StatusPending, userSM.SnapshotState().Inferences[1].Status)
+
+	return &timeoutVoteFixture{session: session, userSM: userSM, signers: signers, group: group, config: config}
+}
+
+func (f *timeoutVoteFixture) dropHostReceipts() {
+	f.session.mu.Lock()
+	defer f.session.mu.Unlock()
+	f.session.clearPendingTxs()
+}
+
+func (f *timeoutVoteFixture) collect(t *testing.T, verifiers map[int]TimeoutVerifier) []*types.TimeoutVote {
+	t.Helper()
+	votes, err := f.session.CollectTimeoutVotes(context.Background(), 1,
+		types.TimeoutReason_TIMEOUT_REASON_REFUSED,
+		&host.InferencePayload{
+			Prompt: testutil.TestPrompt, Model: "llama",
+			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		}, verifiers, nil)
+	require.NoError(t, err)
+	return votes
+}
+
+func timeoutTxFor(inferenceID uint64, votes []*types.TimeoutVote) *types.DevshardTx {
+	return &types.DevshardTx{
+		Tx: &types.DevshardTx_TimeoutInference{TimeoutInference: &types.MsgTimeoutInference{
+			InferenceId: inferenceID,
+			Reason:      types.TimeoutReason_TIMEOUT_REASON_REFUSED,
+			Votes:       votes,
+		}},
+	}
+}
+
+func TestCollectTimeoutVotes_RejectsSpoofedVoterSlot(t *testing.T) {
+	f := newTimeoutVoteFixture(t)
+
+	const spoofedSlot = uint32(2)
+	require.Equal(t, f.signers[2].Address(), f.userSM.SlotAddress(spoofedSlot))
+	require.Equal(t, uint32(4), f.userSM.AddressSlotCount(f.signers[2].Address()))
+
+	votes := f.collect(t, map[int]TimeoutVerifier{
+		0: &slotClaimingVerifier{signer: f.signers[0], claimedSlot: spoofedSlot, escrowID: "escrow-1"},
+	})
+
+	require.Empty(t, votes, "vote claiming another validator's slot must not be collected")
+	require.False(t, f.session.HasSufficientTimeoutVotes(votes))
+}
+
+type delayedVerifier struct {
+	inner TimeoutVerifier
+	delay time.Duration
+}
+
+func (d *delayedVerifier) VerifyTimeout(ctx context.Context, inferenceID uint64, reason types.TimeoutReason, p *host.InferencePayload, diffs []types.Diff) (bool, []byte, uint32, error) {
+	select {
+	case <-time.After(d.delay):
+	case <-ctx.Done():
+		return false, nil, 0, ctx.Err()
+	}
+	return d.inner.VerifyTimeout(ctx, inferenceID, reason, p, diffs)
+}
+
+func TestCollectTimeoutVotes_SpoofedVoteDoesNotDisplaceHonestQuorum(t *testing.T) {
+	f := newTimeoutVoteFixture(t)
+
+	honest := func(signer *signing.Secp256k1Signer, slotIdx int) TimeoutVerifier {
+		return &delayedVerifier{
+			inner: &mockTimeoutVerifier{accept: true, signer: signer, group: f.group, slotIdx: slotIdx},
+			delay: 50 * time.Millisecond,
+		}
+	}
+
+	// Executor is group[1 % 7] = signers[1], which CollectTimeoutVotes excludes.
+	votes := f.collect(t, map[int]TimeoutVerifier{
+		0: &slotClaimingVerifier{signer: f.signers[0], claimedSlot: 2, escrowID: "escrow-1"}, // spoofer
+		2: honest(f.signers[2], 2),
+		6: honest(f.signers[3], 6),
+	})
+
+	require.NotEmpty(t, votes, "honest votes are still collected after the spoofed one is dropped")
+	for _, v := range votes {
+		require.NotEqual(t, f.signers[0].Address(), f.userSM.SlotAddress(v.VoterSlot),
+			"no vote may be credited to the spoofing responder")
+	}
+	require.True(t, f.session.HasSufficientTimeoutVotes(votes), "honest weight exceeds threshold 3")
+
+	before := f.userSM.SnapshotState()
+	_, applied, err := f.userSM.ApplyLocalBestEffort(before.LatestNonce+1, []*types.DevshardTx{timeoutTxFor(1, votes)})
+	require.NoError(t, err)
+	require.Len(t, applied, 1, "timeout tx applies")
+	require.Equal(t, types.StatusTimedOut, f.userSM.SnapshotState().Inferences[1].Status)
+}
+
+func TestCollectTimeoutVotes_AcceptsPrimarySlotOfMultiSlotHost(t *testing.T) {
+	f := newTimeoutVoteFixture(t)
+
+	// signers[2] owns slots 2..5. Contact it at index 3 while it reports slot 2.
+	require.Equal(t, uint32(3), f.group[3].SlotID)
+	require.Equal(t, f.signers[2].Address(), f.group[3].ValidatorAddress)
+
+	votes := f.collect(t, map[int]TimeoutVerifier{
+		3: &slotClaimingVerifier{signer: f.signers[2], claimedSlot: 2, escrowID: "escrow-1"},
+	})
+
+	require.Len(t, votes, 1, "a host signing for another of its own slots is valid")
+	require.Equal(t, uint32(2), votes[0].VoterSlot)
+	require.True(t, f.session.HasSufficientTimeoutVotes(votes), "weight 4 exceeds threshold 3")
+}
+
+func TestCollectTimeoutVotes_RejectsForeignEscrowSignature(t *testing.T) {
+	f := newTimeoutVoteFixture(t)
+
+	votes := f.collect(t, map[int]TimeoutVerifier{
+		2: &slotClaimingVerifier{signer: f.signers[2], claimedSlot: 2, escrowID: "escrow-other"},
+	})
+
+	require.Empty(t, votes, "vote signed over a different escrow id must not be collected")
+}
+
+func TestHasSufficientTimeoutVotes_DedupesByAddress(t *testing.T) {
+	signers := make([]*signing.Secp256k1Signer, 4)
+	for i := range signers {
+		signers[i] = testutil.MustGenerateKey(t)
+	}
+	userKey := testutil.MustGenerateKey(t)
+	group := testutil.MakeMultiSlotGroup(signers, []int{2, 2, 2, 1})
+	config := types.SessionConfig{
+		RefusalTimeout: 60, ExecutionTimeout: 1200, TokenPrice: 1,
+		VoteThreshold: uint32(len(group)) / 2,
+	}
+	verifier := signing.NewSecp256k1Verifier()
+	sm := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+	clients := make([]HostClient, len(group))
+	session, err := NewSession(sm, userKey, "escrow-1", group, clients, verifier)
+	require.NoError(t, err)
+
+	// Slots 0 and 1 are both owned by signers[0].
+	require.Equal(t, sm.SlotAddress(0), sm.SlotAddress(1))
+	votes := []*types.TimeoutVote{
+		{VoterSlot: 0, Accept: true},
+		{VoterSlot: 1, Accept: true},
+	}
+	require.False(t, session.HasSufficientTimeoutVotes(votes),
+		"one address must contribute weight 2 once, not 2 twice")
+}
+
+func TestApplyTimeout_SingleSpoofedVoteRejectsWholeTx(t *testing.T) {
+	signers := make([]*signing.Secp256k1Signer, 4)
+	for i := range signers {
+		signers[i] = testutil.MustGenerateKey(t)
+	}
+	userKey := testutil.MustGenerateKey(t)
+	group := testutil.MakeMultiSlotGroup(signers, []int{1, 1, 4, 1})
+	config := types.SessionConfig{
+		RefusalTimeout: 60, ExecutionTimeout: 1200, TokenPrice: 1, FeePerNonce: 5,
+		VoteThreshold: uint32(len(group)) / 2, // 3
+	}
+	verifier := signing.NewSecp256k1Verifier()
+
+	signVote := func(s *signing.Secp256k1Signer, slot uint32) *types.TimeoutVote {
+		data, err := proto.Marshal(&types.TimeoutVoteContent{
+			EscrowId: "escrow-1", InferenceId: 1,
+			Reason: types.TimeoutReason_TIMEOUT_REASON_REFUSED, Accept: true,
+		})
+		require.NoError(t, err)
+		sig, err := s.Sign(data)
+		require.NoError(t, err)
+		return &types.TimeoutVote{VoterSlot: slot, Accept: true, Signature: sig}
+	}
+
+	seed := func(sm *state.StateMachine) {
+		_, applied, err := sm.ApplyLocalBestEffort(1, []*types.DevshardTx{{
+			Tx: &types.DevshardTx_StartInference{StartInference: &types.MsgStartInference{
+				InferenceId: 1, Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			}},
+		}})
+		require.NoError(t, err)
+		require.Len(t, applied, 1)
+	}
+
+	// signers[2] (slot 2, weight 4) + signers[3] (slot 6, weight 1) = 5 > 3.
+	honest := []*types.TimeoutVote{signVote(signers[2], 2), signVote(signers[3], 6)}
+	spoofed := signVote(signers[0], 2) // own key, someone else's slot
+
+	clean := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+	seed(clean)
+	_, applied, err := clean.ApplyLocalBestEffort(2, []*types.DevshardTx{timeoutTxFor(1, honest)})
+	require.NoError(t, err)
+	require.Len(t, applied, 1, "honest quorum alone applies")
+	require.Equal(t, types.StatusTimedOut, clean.SnapshotState().Inferences[1].Status)
+
+	poisoned := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+	seed(poisoned)
+	before := poisoned.SnapshotState()
+	all := append(append([]*types.TimeoutVote{}, honest...), spoofed)
+	_, applied, err = poisoned.ApplyLocalBestEffort(2, []*types.DevshardTx{timeoutTxFor(1, all)})
+	require.NoError(t, err, "the surrounding best-effort diff still commits")
+	require.Empty(t, applied, "one spoofed vote rejects the entire timeout tx")
+
+	after := poisoned.SnapshotState()
+	require.Equal(t, types.StatusPending, after.Inferences[1].Status, "inference not timed out")
+	require.Equal(t, before.LatestNonce+1, after.LatestNonce, "nonce still consumed")
+	require.Equal(t, before.Balance-config.FeePerNonce, after.Balance, "fee still charged")
+}
+
+func TestSendPendingDiff_ReportsDroppedTimeoutTx(t *testing.T) {
+	t.Run("dropped", func(t *testing.T) {
+		f := newTimeoutVoteFixture(t)
+		f.dropHostReceipts()
+		data, err := proto.Marshal(&types.TimeoutVoteContent{
+			EscrowId: "escrow-1", InferenceId: 1,
+			Reason: types.TimeoutReason_TIMEOUT_REASON_REFUSED, Accept: true,
+		})
+		require.NoError(t, err)
+		sig, err := f.signers[0].Sign(data)
+		require.NoError(t, err)
+
+		f.session.AddPendingTimeoutTx(1, types.TimeoutReason_TIMEOUT_REASON_REFUSED,
+			[]*types.TimeoutVote{{VoterSlot: 2, Accept: true, Signature: sig}})
+
+		before := f.userSM.SnapshotState()
+		diff, err := f.session.sendPendingDiff(context.Background())
+		require.NoError(t, err)
+		require.False(t, diffAppliedTimeout(diff, 1), "rejected timeout tx is not in the diff")
+
+		after := f.userSM.SnapshotState()
+		require.Equal(t, types.StatusPending, after.Inferences[1].Status)
+		require.Equal(t, before.LatestNonce+1, after.LatestNonce, "nonce consumed anyway")
+	})
+
+	t.Run("applied", func(t *testing.T) {
+		f := newTimeoutVoteFixture(t)
+		f.dropHostReceipts()
+		votes := f.collect(t, map[int]TimeoutVerifier{
+			2: &mockTimeoutVerifier{accept: true, signer: f.signers[2], group: f.group, slotIdx: 2},
+			6: &mockTimeoutVerifier{accept: true, signer: f.signers[3], group: f.group, slotIdx: 6},
+		})
+		require.True(t, f.session.HasSufficientTimeoutVotes(votes))
+
+		f.session.AddPendingTimeoutTx(1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, votes)
+		diff, err := f.session.sendPendingDiff(context.Background())
+		require.NoError(t, err)
+		require.True(t, diffAppliedTimeout(diff, 1))
+		require.Equal(t, types.StatusTimedOut, f.userSM.SnapshotState().Inferences[1].Status)
+	})
+}
+
+func TestCollectTimeoutVotes_WarmKeySignedVotesAccepted(t *testing.T) {
+	session, coldKeys, warmKeys := setupWarmKeySession(t, 3)
+
+	ctx := context.Background()
+	_, err := session.SendInference(ctx, defaultParams)
+	require.NoError(t, err)
+
+	group := session.group
+	executorIdx := int(1 % uint64(len(group)))
+	verifiers := make(map[int]TimeoutVerifier, len(group))
+	for i := range group {
+		if i == executorIdx {
+			continue
+		}
+		verifiers[i] = &mockTimeoutVerifier{accept: true, signer: warmKeys[i], group: group, slotIdx: i}
+	}
+
+	votes, err := session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED,
+		&host.InferencePayload{
+			Prompt: testutil.TestPrompt, Model: "llama",
+			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		}, verifiers, nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, votes, "votes signed by an authorized warm key must be collected")
+	for _, v := range votes {
+		require.Equal(t, coldKeys[v.VoterSlot].Address(), session.StateMachine().SlotAddress(v.VoterSlot))
+	}
+	require.True(t, session.HasSufficientTimeoutVotes(votes))
+}
+
+func TestCollectTimeoutVotes_UnauthorizedWarmKeyRejected(t *testing.T) {
+	session, _, _ := setupWarmKeySession(t, 3)
+
+	ctx := context.Background()
+	_, err := session.SendInference(ctx, defaultParams)
+	require.NoError(t, err)
+
+	group := session.group
+	stranger := testutil.MustGenerateKey(t)
+	executorIdx := int(1 % uint64(len(group)))
+	verifiers := make(map[int]TimeoutVerifier, len(group))
+	for i := range group {
+		if i == executorIdx {
+			continue
+		}
+		verifiers[i] = &mockTimeoutVerifier{accept: true, signer: stranger, group: group, slotIdx: i}
+	}
+
+	votes, err := session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED,
+		&host.InferencePayload{
+			Prompt: testutil.TestPrompt, Model: "llama",
+			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		}, verifiers, nil)
+	require.NoError(t, err)
+	require.Empty(t, votes, "a key the resolver does not authorize must not be counted")
+}
+
+func TestCollectTimeoutVotes_WarmKeyFromCachedBindingWhenResolverFails(t *testing.T) {
+	coldKeys := makeKeys(t, 3)
+	warmKeys := makeKeys(t, 3)
+	accept := acceptResolver(warmKeys, coldKeys)
+	resolverFails := false
+	resolver := state.WarmKeyResolver(func(warmAddr, coldAddr string) (bool, error) {
+		if resolverFails {
+			return false, context.DeadlineExceeded
+		}
+		return accept(warmAddr, coldAddr)
+	})
+
+	userKey := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(coldKeys)
+	config := testutil.DefaultConfig(3)
+	verifier := signing.NewSecp256k1Verifier()
+	smOpts := []state.SMOption{state.WithWarmKeyResolver(resolver)}
+
+	clients := make([]HostClient, 3)
+	for i := range coldKeys {
+		sm, err := state.NewStateMachine("escrow-1", config, group, 100000, userKey.Address(), verifier,
+			testutil.MustMemoryStore(t, "escrow-1", userKey.Address(), config, group, 100000), smOpts...)
+		require.NoError(t, err)
+		h, err := host.NewHost(sm, warmKeys[i], stub.NewInferenceEngine(), "escrow-1", group, nil, host.WithGrace(10))
+		require.NoError(t, err)
+		clients[i] = &InProcessClient{Host: h}
+	}
+	userSM, err := state.NewStateMachine("escrow-1", config, group, 100000, userKey.Address(), verifier,
+		testutil.MustMemoryStore(t, "escrow-1", userKey.Address(), config, group, 100000), smOpts...)
+	require.NoError(t, err)
+	session, err := NewSession(userSM, userKey, "escrow-1", group, clients, verifier)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	for i := 0; i < 4; i++ {
+		_, err = session.SendInference(ctx, defaultParams)
+		require.NoError(t, err)
+	}
+	require.Len(t, userSM.WarmKeys(), 3, "warm bindings cached by the applied receipts")
+
+	resolverFails = true
+
+	executorIdx := int(1 % uint64(len(group)))
+	verifiers := make(map[int]TimeoutVerifier, len(group))
+	for i := range group {
+		if i == executorIdx {
+			continue
+		}
+		verifiers[i] = &mockTimeoutVerifier{accept: true, signer: warmKeys[i], group: group, slotIdx: i}
+	}
+
+	votes, err := session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED,
+		&host.InferencePayload{
+			Prompt: testutil.TestPrompt, Model: "llama",
+			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		}, verifiers, nil)
+	require.NoError(t, err)
+	require.True(t, session.HasSufficientTimeoutVotes(votes),
+		"cached warm bindings must verify without reaching the resolver")
+}

--- a/inference-chain/x/inference/keeper/msg_server_submit_seed_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_submit_seed_test.go
@@ -86,3 +86,24 @@ func TestSubmitSeed(t *testing.T) {
 		})
 	}
 }
+
+func TestSubmitSeedDuplicateIsStateIdempotent(t *testing.T) {
+	k, ms, ctx, _ := setupKeeperWithMocks(t)
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, 10))
+	require.NoError(t, k.SetParticipant(ctx, types.Participant{Index: testutil.Executor}))
+
+	msg := &types.MsgSubmitSeed{
+		Creator:    testutil.Executor,
+		EpochIndex: 11,
+		Signature:  "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	_, err := ms.SubmitSeed(ctx, msg)
+	require.NoError(t, err)
+	_, err = ms.SubmitSeed(ctx, msg)
+	require.NoError(t, err)
+
+	stored, found := k.GetRandomSeed(ctx, msg.EpochIndex, msg.Creator)
+	require.True(t, found)
+	require.Equal(t, msg.Signature, stored.Signature)
+}

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -45,7 +45,6 @@ EDGE_API_ROUTE_PATHS_DEFAULT='
 /v1/restrictions/status
 /v1/restrictions/exemptions
 /v1/restrictions/exemptions/{id}/usage/{account}
-/v1/versions
 /v1/bls/epoch/{id}
 /v1/bls/epochs/{id}
 /v1/bls/signatures/{request_id}
@@ -943,6 +942,9 @@ append_edge_api_route_locations() {
     fi
 
     for route in $routes; do
+        if [ "$route" = "/v1/versions" ]; then
+            continue
+        fi
         # Optional verify/debug group stays private unless explicitly exposed.
         # Skip even if an old EDGE_API_ROUTE_PATHS override still lists them.
         if [ "${EDGE_API_EXPOSE_OPTIONAL_ROUTES}" != "true" ] && edge_api_is_optional_route "$route"; then

--- a/testermint/src/test/kotlin/NodeManagerTests.kt
+++ b/testermint/src/test/kotlin/NodeManagerTests.kt
@@ -1,3 +1,4 @@
+import com.google.gson.JsonObject
 import com.productscience.NodeManagerClient
 import com.productscience.data.InferenceNode
 import com.productscience.data.ModelConfig
@@ -32,6 +33,15 @@ class NodeManagerTests : TestermintTest() {
     fun `acquire and release node over gRPC`() {
         val (_, genesis) = initCluster()
         waitForInferenceState(genesis)
+
+        val versions = genesis.api.get<JsonObject>(genesis.api.getPublicUrl(), "v1/versions")
+        val apiVersion = versions.getAsJsonObject("api_version")
+        assertThat(apiVersion.get("application_name").asString).isEqualTo("decentralized-api")
+        assertThat(apiVersion.get("version").asString).isNotBlank()
+        assertThat(apiVersion.get("commit").asString).isNotBlank()
+        val mlnodes = versions.getAsJsonArray("mlnodes")
+        assertThat(mlnodes.size()).isGreaterThan(0)
+        assertThat(mlnodes.all { it.asJsonObject.has("poc_validation_inference") }).isTrue()
 
         nodeManagerClient(genesis).use { client ->
             val acquireResp = client.acquireMLNode(defaultModel)


### PR DESCRIPTION
A malicious verifier could return an accept vote signed with its own key while claiming another validator's slot. `CollectTimeoutVotes` credited the claimed slot's weight without verifying the signature or binding the slot to the responder, so unowned weight could cross the threshold and end collection early. `applyTimeout` rejects the whole `MsgTimeoutInference` on the first bad vote, so one spoofed vote discarded the honest quorum alongside it, and the best-effort diff dropped the tx silently while still consuming the nonce and fee.

Votes are now verified and bound to the responding verifier before contributing weight, the tally dedupes by validator address to match `applyTimeout`, and `HandleTimeout` reports `timeout_not_applied` when the state machine drops the tx.