### PR TITLE
fix: normalize malformed participant request errors

### DIFF
--- a/decentralized-api/internal/server/public/post_participant_handler.go
+++ b/decentralized-api/internal/server/public/post_participant_handler.go
@@ -15,7 +15,7 @@ func (s *Server) submitNewParticipantHandler(ctx echo.Context) error {
 
 	if err := ctx.Bind(&body); err != nil {
 		logging.Error("Failed to decode request body", types.Participants, "error", err)
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body").SetInternal(err)
 	}
 
 	logging.Debug("SubmitNewParticipantDto", types.Participants, "body", body)

--- a/decentralized-api/internal/server/public/post_participant_handler_test.go
+++ b/decentralized-api/internal/server/public/post_participant_handler_test.go
@@ -1,0 +1,39 @@
+package public
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	servermiddleware "decentralized-api/internal/server/middleware"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitNewParticipantHandler_MalformedJSON(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = servermiddleware.TransparentErrorHandler
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/participants",
+		strings.NewReader(`{"address":`),
+	)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	server := &Server{}
+
+	err := server.submitNewParticipantHandler(ctx)
+	require.Error(t, err)
+
+	e.HTTPErrorHandler(err, ctx)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	t.Logf("response body: %s", rec.Body.String())
+}


### PR DESCRIPTION
## Summary

Fix the malformed JSON response for `POST /v1/participants`.

Previously, the handler returned a nested parser error:

```json
{"error":{"message":"unexpected EOF"}}
```

Related #1545