### PR TITLE
test(devshard): cover nonce accounting e2e edge dispositions

### DIFF
--- a/devshard/accounting/accounting_test.go
+++ b/devshard/accounting/accounting_test.go
@@ -74,6 +74,465 @@ func TestRestartTurnsLiveStateIntoUnclassified(t *testing.T) {
 	require.Equal(t, uint64(1), record.Unclassified)
 }
 
+func TestTrackerRecordsFinishedUnused(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 11, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordUsage("e1", 1, UsageLoser))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 11}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionFinishedUnused])
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+}
+
+func TestTrackerRecordsFinishedUsageUnknown(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 12, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordUsage("e1", 1, UsageUnknownValue))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 12}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionFinishedUsageUnknown])
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+}
+
+func TestTrackerRecordsUnfinishedExecution(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 13, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolReceiptApplied, types.HostStats{}))
+	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutExecution,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutVoteCollectionFailed,
+		FailureOrigin: FailureHostResponse,
+		DetailReason:  "not_finished",
+	}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 13}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedExecution])
+	require.Equal(t, uint64(1), record.TimeoutOutcomes[TimeoutVoteCollectionFailed])
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+}
+
+func TestTrackerMovesInFlightToFinishedUsed(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 14, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+
+	inFlight := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 14}), "p1")
+	require.Equal(t, uint64(1), inFlight.InFlight)
+	require.Zero(t, inFlight.Dispositions[DispositionFinishedUsed])
+
+	require.NoError(t, tr.RecordUsage("e1", 1, UsageWinner))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{}))
+
+	finished := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 14}), "p1")
+	require.Equal(t, uint64(1), finished.Dispositions[DispositionFinishedUsed])
+	require.Zero(t, finished.InFlight)
+	require.Zero(t, finished.PendingClassification)
+	require.Zero(t, finished.Unclassified)
+	require.Zero(t, finished.Overclassified)
+}
+
+func TestTrackerMovesInFlightToFinishedUnused(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 15, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+
+	inFlight := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 15}), "p1")
+	require.Equal(t, uint64(1), inFlight.InFlight)
+	require.Zero(t, inFlight.Dispositions[DispositionFinishedUnused])
+
+	require.NoError(t, tr.RecordUsage("e1", 1, UsageLoser))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{}))
+
+	finished := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 15}), "p1")
+	require.Equal(t, uint64(1), finished.Dispositions[DispositionFinishedUnused])
+	require.Zero(t, finished.InFlight)
+	require.Zero(t, finished.PendingClassification)
+	require.Zero(t, finished.Unclassified)
+	require.Zero(t, finished.Overclassified)
+}
+
+func TestTrackerMovesInFlightToUnfinishedRefused(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 16, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+
+	inFlight := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 16}), "p1")
+	require.Equal(t, uint64(1), inFlight.InFlight)
+	require.Zero(t, inFlight.Dispositions[DispositionUnfinishedRefused])
+
+	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutRefused,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutVoteCollectionFailed,
+		FailureOrigin: FailureTransportUnknown,
+	}))
+
+	unfinished := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 16}), "p1")
+	require.Equal(t, uint64(1), unfinished.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), unfinished.TimeoutOutcomes[TimeoutVoteCollectionFailed])
+	require.Zero(t, unfinished.InFlight)
+	require.Zero(t, unfinished.PendingClassification)
+	require.Zero(t, unfinished.Unclassified)
+	require.Zero(t, unfinished.Overclassified)
+}
+
+func TestTrackerMovesInFlightToUnfinishedExecution(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 17, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+
+	inFlight := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 17}), "p1")
+	require.Equal(t, uint64(1), inFlight.InFlight)
+	require.Zero(t, inFlight.Dispositions[DispositionUnfinishedExecution])
+
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolReceiptApplied, types.HostStats{}))
+	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutExecution,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutVoteCollectionFailed,
+		FailureOrigin: FailureHostResponse,
+		DetailReason:  "not_finished",
+	}))
+
+	unfinished := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 17}), "p1")
+	require.Equal(t, uint64(1), unfinished.Dispositions[DispositionUnfinishedExecution])
+	require.Equal(t, uint64(1), unfinished.TimeoutOutcomes[TimeoutVoteCollectionFailed])
+	require.Zero(t, unfinished.InFlight)
+	require.Zero(t, unfinished.PendingClassification)
+	require.Zero(t, unfinished.Unclassified)
+	require.Zero(t, unfinished.Overclassified)
+}
+
+func TestTrackerCountsPendingClassification(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 18, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 18}), "p1")
+	require.Equal(t, uint64(1), record.PendingClassification)
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+}
+
+func TestTrackerMovesPendingClassificationToGhost(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 19, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+
+	pending := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 19}), "p1")
+	require.Equal(t, uint64(1), pending.PendingClassification)
+	require.Zero(t, pending.Dispositions[DispositionGhost])
+
+	require.NoError(t, tr.RecordGhost("e1", 1, PhaseNormal, QuarantineNone, NoSendPoCUnavailable, ""))
+
+	ghost := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 19}), "p1")
+	require.Equal(t, uint64(1), ghost.Dispositions[DispositionGhost])
+	require.Zero(t, ghost.PendingClassification)
+	require.Zero(t, ghost.InFlight)
+	require.Zero(t, ghost.Unclassified)
+	require.Zero(t, ghost.Overclassified)
+}
+
+func TestTrackerReportsUnclassifiedWithoutRestart(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 20, "m")
+	require.NoError(t, tr.RecordDiff("e1", 2, false))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 20}), "p1")
+	require.Equal(t, uint64(1), record.AssignedNonces)
+	require.Equal(t, uint64(1), record.Unclassified)
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Overclassified)
+}
+
+func TestTrackerReportsOverclassified(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 21, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, false))
+	require.NoError(t, tr.RecordDiff("e1", 1, false))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 21}), "p1")
+	require.Equal(t, uint64(1), record.AssignedNonces)
+	require.Equal(t, uint64(2), record.Dispositions[DispositionProtocolOnly])
+	require.Equal(t, uint64(1), record.Overclassified)
+	require.Zero(t, record.Unclassified)
+}
+
+func TestTrackerReclassificationMovesCountAtomically(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 22, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutRefused,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutVoteCollectionFailed,
+		FailureOrigin: FailureTransportUnknown,
+	}))
+
+	unfinished := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 22}), "p1")
+	require.Equal(t, uint64(1), unfinished.Dispositions[DispositionUnfinishedRefused])
+
+	require.NoError(t, tr.RecordUsage("e1", 1, UsageWinner))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{}))
+
+	finished := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 22}), "p1")
+	require.Zero(t, finished.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), finished.Dispositions[DispositionFinishedUsed])
+	require.Zero(t, finished.InFlight)
+	require.Zero(t, finished.PendingClassification)
+	require.Zero(t, finished.Unclassified)
+	require.Zero(t, finished.Overclassified)
+}
+
+func TestTrackerRepeatedTimeoutCallbackDoesNotDuplicateCount(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 23, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	timeout := TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutRefused,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutVoteCollectionFailed,
+		FailureOrigin: FailureTransportUnknown,
+	}
+	require.NoError(t, tr.RecordTimeout(timeout))
+	require.NoError(t, tr.RecordTimeout(timeout))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 23}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), record.TimeoutOutcomes[TimeoutVoteCollectionFailed])
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+}
+
+func TestTrackerReceiptAfterTimeoutRecordStaysUnfinishedRefused(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 24, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutRefused,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutVoteCollectionFailed,
+		FailureOrigin: FailureTransportUnknown,
+	}))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolReceiptApplied, types.HostStats{}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 24}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedRefused])
+	require.Zero(t, record.Dispositions[DispositionUnfinishedExecution])
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+}
+
+func TestTrackerFinishAfterNonAppliedTimeoutWins(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 25, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutExecution,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutVoteCollectionFailed,
+		FailureOrigin: FailureHostResponse,
+		DetailReason:  "not_finished",
+	}))
+
+	unfinished := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 25}), "p1")
+	require.Equal(t, uint64(1), unfinished.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), unfinished.TimeoutOutcomes[TimeoutVoteCollectionFailed])
+
+	require.NoError(t, tr.RecordUsage("e1", 1, UsageWinner))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{}))
+
+	finished := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 25}), "p1")
+	require.Zero(t, finished.Dispositions[DispositionUnfinishedRefused])
+	require.Zero(t, finished.TimeoutOutcomes[TimeoutVoteCollectionFailed])
+	require.Equal(t, uint64(1), finished.Dispositions[DispositionFinishedUsed])
+	require.Zero(t, finished.InFlight)
+	require.Zero(t, finished.PendingClassification)
+	require.Zero(t, finished.Unclassified)
+	require.Zero(t, finished.Overclassified)
+}
+
+func TestTrackerFinishAfterAppliedTimeoutDoesNotReclassify(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 26, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutExecution,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutApplied,
+		FailureOrigin: FailureHostResponse,
+		DetailReason:  "not_finished",
+	}))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{Missed: 1}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 26}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), record.TimeoutOutcomes[TimeoutApplied])
+	require.Zero(t, record.Dispositions[DispositionFinishedUsed])
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+	require.Zero(t, record.CrossChecks.ErrorCount)
+}
+
+func TestTrackerRecordsProtocolTimeoutAppliedFromLiveNonce(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 27, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolTimeoutApplied, types.HostStats{Missed: 1}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 27}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), record.TimeoutOutcomes[TimeoutApplied])
+	require.Equal(t, uint64(1), record.ProtocolMisses)
+	require.Equal(t, uint64(1), record.CrossChecks.TimeoutApplied)
+	require.Equal(t, uint64(1), record.CrossChecks.HostMissed)
+	require.Zero(t, record.CrossChecks.ErrorCount)
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+}
+
+func TestTrackerReconcilesAppliedMissesFromHostStats(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 28, "m")
+	require.NoError(t, tr.RecordDiff("e1", 2, false))
+	require.NoError(t, tr.RecordHostStats("e1", 1, types.HostStats{Missed: 1}))
+	require.NoError(t, tr.ReconcileAppliedMisses("e1"))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 28}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), record.TimeoutOutcomes[TimeoutApplied])
+	require.Equal(t, uint64(1), record.ProtocolMisses)
+	require.Equal(t, uint64(1), record.CrossChecks.TimeoutApplied)
+	require.Equal(t, uint64(1), record.CrossChecks.HostMissed)
+	require.Zero(t, record.CrossChecks.ErrorCount)
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+	require.Len(t, record.Counters, 1)
+	require.Empty(t, record.Counters[0].Key.DispatchPhase)
+	require.Empty(t, record.Counters[0].Key.QuarantineMode)
+	require.Empty(t, record.Counters[0].Key.FailureOrigin)
+	require.Empty(t, record.Counters[0].Key.DetailReason)
+}
+
+func TestTrackerReportsHostStatsMissedCrossCheckMismatch(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 29, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolTimeoutApplied, types.HostStats{}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 29}), "p1")
+	require.Equal(t, uint64(1), record.CrossChecks.TimeoutApplied)
+	require.Zero(t, record.CrossChecks.HostMissed)
+	require.Equal(t, uint64(1), record.CrossChecks.ErrorCount)
+}
+
+func TestTrackerReportsHostStatsInvalidCrossCheckMismatch(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 30, "m")
+	require.NoError(t, tr.RecordHostStats("e1", 1, types.HostStats{Invalid: 1}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 30}), "p1")
+	require.Zero(t, record.CrossChecks.RecordedInvalid)
+	require.Equal(t, uint64(1), record.CrossChecks.HostInvalid)
+	require.Equal(t, uint64(1), record.CrossChecks.ErrorCount)
+}
+
+func TestTrackerRecordsUnknownNoSendReason(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 31, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordGhost("e1", 1, PhaseNormal, QuarantineNone, NoSendReason("not_a_reason"), "not_a_detail"))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 31}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionGhost])
+	require.Equal(t, uint64(1), record.UnknownReasonTotal)
+	require.Len(t, record.Counters, 1)
+	require.Equal(t, NoSendUnknown, record.Counters[0].Key.NoSendReason)
+	require.Equal(t, "unknown", record.Counters[0].Key.DetailReason)
+}
+
+func TestTrackerRecordsUnknownTimeoutReasonAndDetail(t *testing.T) {
+	tr := newTestTracker(t)
+	registerEscrow(t, tr, "e1", 32, "m")
+	require.NoError(t, tr.RecordDiff("e1", 1, true))
+	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
+		EscrowID:      "e1",
+		Nonce:         1,
+		Kind:          TimeoutExecution,
+		Phase:         PhaseNormal,
+		Outcome:       TimeoutSkipped,
+		Reason:        TimeoutReason("not_a_timeout_reason"),
+		FailureOrigin: FailureTransportUnknown,
+		DetailReason:  "not_a_detail",
+	}))
+
+	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 32}), "p1")
+	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), record.TimeoutOutcomes[TimeoutSkipped])
+	require.Equal(t, uint64(1), record.UnknownReasonTotal)
+	require.Len(t, record.Counters, 1)
+	require.Equal(t, TimeoutReasonUnknown, record.Counters[0].Key.TimeoutReason)
+	require.Equal(t, "unknown", record.Counters[0].Key.DetailReason)
+}
+
 func TestHTTPFiltersAndMetrics(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 9, "m1")

--- a/devshard/accounting/accounting_test.go
+++ b/devshard/accounting/accounting_test.go
@@ -78,7 +78,7 @@ func TestTrackerRecordsFinishedUnused(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 11, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow, PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordUsage("e1", 1, UsageLoser))
 	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{}))
 
@@ -94,7 +94,7 @@ func TestTrackerRecordsFinishedUsageUnknown(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 12, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow, PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordUsage("e1", 1, UsageUnknownValue))
 	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{}))
 
@@ -110,7 +110,7 @@ func TestTrackerRecordsUnfinishedExecution(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 13, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolReceiptApplied, types.HostStats{}))
 	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
 		EscrowID:      "e1",
@@ -135,7 +135,7 @@ func TestTrackerMovesInFlightToFinishedUsed(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 14, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow, PhaseNormal, QuarantineNone))
 
 	inFlight := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 14}), "p1")
 	require.Equal(t, uint64(1), inFlight.InFlight)
@@ -156,7 +156,7 @@ func TestTrackerMovesInFlightToFinishedUnused(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 15, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow, PhaseNormal, QuarantineNone))
 
 	inFlight := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 15}), "p1")
 	require.Equal(t, uint64(1), inFlight.InFlight)
@@ -175,14 +175,17 @@ func TestTrackerMovesInFlightToFinishedUnused(t *testing.T) {
 
 func TestTrackerMovesInFlightToUnfinishedRefused(t *testing.T) {
 	tr := newTestTracker(t)
+	now := accountingTestNow
+	tr.now = func() time.Time { return now }
 	registerEscrow(t, tr, "e1", 16, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, now, PhaseNormal, QuarantineNone))
 
 	inFlight := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 16}), "p1")
 	require.Equal(t, uint64(1), inFlight.InFlight)
 	require.Zero(t, inFlight.Dispositions[DispositionUnfinishedRefused])
 
+	now = now.Add(2 * time.Minute)
 	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
 		EscrowID:      "e1",
 		Nonce:         1,
@@ -203,14 +206,17 @@ func TestTrackerMovesInFlightToUnfinishedRefused(t *testing.T) {
 
 func TestTrackerMovesInFlightToUnfinishedExecution(t *testing.T) {
 	tr := newTestTracker(t)
+	now := accountingTestNow
+	tr.now = func() time.Time { return now }
 	registerEscrow(t, tr, "e1", 17, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, now, PhaseNormal, QuarantineNone))
 
 	inFlight := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 17}), "p1")
 	require.Equal(t, uint64(1), inFlight.InFlight)
 	require.Zero(t, inFlight.Dispositions[DispositionUnfinishedExecution])
 
+	now = now.Add(2 * time.Minute)
 	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolReceiptApplied, types.HostStats{}))
 	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
 		EscrowID:      "e1",
@@ -279,11 +285,14 @@ func TestTrackerReportsOverclassified(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 21, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, false))
-	require.NoError(t, tr.RecordDiff("e1", 1, false))
+	tr.mu.Lock()
+	tr.escrows["e1"].Counters[CounterKey{SlotID: 1, Disposition: DispositionGhost}]++
+	tr.mu.Unlock()
 
 	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 21}), "p1")
 	require.Equal(t, uint64(1), record.AssignedNonces)
-	require.Equal(t, uint64(2), record.Dispositions[DispositionProtocolOnly])
+	require.Equal(t, uint64(1), record.Dispositions[DispositionProtocolOnly])
+	require.Equal(t, uint64(1), record.Dispositions[DispositionGhost])
 	require.Equal(t, uint64(1), record.Overclassified)
 	require.Zero(t, record.Unclassified)
 }
@@ -292,7 +301,7 @@ func TestTrackerReclassificationMovesCountAtomically(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 22, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
 		EscrowID:      "e1",
 		Nonce:         1,
@@ -321,7 +330,7 @@ func TestTrackerRepeatedTimeoutCallbackDoesNotDuplicateCount(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 23, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	timeout := TimeoutRecord{
 		EscrowID:      "e1",
 		Nonce:         1,
@@ -342,11 +351,11 @@ func TestTrackerRepeatedTimeoutCallbackDoesNotDuplicateCount(t *testing.T) {
 	require.Zero(t, record.Overclassified)
 }
 
-func TestTrackerReceiptAfterTimeoutRecordStaysUnfinishedRefused(t *testing.T) {
+func TestTrackerReceiptAfterTimeoutRecordReclassifiesToExecution(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 24, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
 		EscrowID:      "e1",
 		Nonce:         1,
@@ -358,8 +367,8 @@ func TestTrackerReceiptAfterTimeoutRecordStaysUnfinishedRefused(t *testing.T) {
 	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolReceiptApplied, types.HostStats{}))
 
 	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 24}), "p1")
-	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedRefused])
-	require.Zero(t, record.Dispositions[DispositionUnfinishedExecution])
+	require.Zero(t, record.Dispositions[DispositionUnfinishedRefused])
+	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedExecution])
 	require.Zero(t, record.InFlight)
 	require.Zero(t, record.PendingClassification)
 	require.Zero(t, record.Unclassified)
@@ -370,7 +379,7 @@ func TestTrackerFinishAfterNonAppliedTimeoutWins(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 25, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
 		EscrowID:      "e1",
 		Nonce:         1,
@@ -402,7 +411,7 @@ func TestTrackerFinishAfterAppliedTimeoutDoesNotReclassify(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 26, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
 		EscrowID:      "e1",
 		Nonce:         1,
@@ -412,6 +421,7 @@ func TestTrackerFinishAfterAppliedTimeoutDoesNotReclassify(t *testing.T) {
 		FailureOrigin: FailureHostResponse,
 		DetailReason:  "not_finished",
 	}))
+	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolTimeoutApplied, types.HostStats{Missed: 1}))
 	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolFinishApplied, types.HostStats{Missed: 1}))
 
 	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 26}), "p1")
@@ -429,7 +439,7 @@ func TestTrackerRecordsProtocolTimeoutAppliedFromLiveNonce(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 27, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolTimeoutApplied, types.HostStats{Missed: 1}))
 
 	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 27}), "p1")
@@ -445,36 +455,31 @@ func TestTrackerRecordsProtocolTimeoutAppliedFromLiveNonce(t *testing.T) {
 	require.Zero(t, record.Overclassified)
 }
 
-func TestTrackerReconcilesAppliedMissesFromHostStats(t *testing.T) {
+func TestTrackerDoesNotInventAppliedMissesFromHostStats(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 28, "m")
 	require.NoError(t, tr.RecordDiff("e1", 2, false))
 	require.NoError(t, tr.RecordHostStats("e1", 1, types.HostStats{Missed: 1}))
-	require.NoError(t, tr.ReconcileAppliedMisses("e1"))
 
 	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 28}), "p1")
-	require.Equal(t, uint64(1), record.Dispositions[DispositionUnfinishedRefused])
-	require.Equal(t, uint64(1), record.TimeoutOutcomes[TimeoutApplied])
 	require.Equal(t, uint64(1), record.ProtocolMisses)
-	require.Equal(t, uint64(1), record.CrossChecks.TimeoutApplied)
+	require.Equal(t, uint64(1), record.Unclassified)
+	require.Zero(t, record.Dispositions[DispositionUnfinishedRefused])
+	require.Zero(t, record.TimeoutOutcomes[TimeoutApplied])
+	require.Zero(t, record.CrossChecks.TimeoutApplied)
 	require.Equal(t, uint64(1), record.CrossChecks.HostMissed)
-	require.Zero(t, record.CrossChecks.ErrorCount)
+	require.Equal(t, uint64(1), record.CrossChecks.ErrorCount)
 	require.Zero(t, record.InFlight)
 	require.Zero(t, record.PendingClassification)
-	require.Zero(t, record.Unclassified)
 	require.Zero(t, record.Overclassified)
-	require.Len(t, record.Counters, 1)
-	require.Empty(t, record.Counters[0].Key.DispatchPhase)
-	require.Empty(t, record.Counters[0].Key.QuarantineMode)
-	require.Empty(t, record.Counters[0].Key.FailureOrigin)
-	require.Empty(t, record.Counters[0].Key.DetailReason)
+	require.Empty(t, record.Counters)
 }
 
 func TestTrackerReportsHostStatsMissedCrossCheckMismatch(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 29, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordProtocol("e1", 1, 1, ProtocolTimeoutApplied, types.HostStats{}))
 
 	record := onlyRecord(t, tr.Query(QueryFilter{EpochIndex: 29}), "p1")
@@ -512,7 +517,7 @@ func TestTrackerRecordsUnknownTimeoutReasonAndDetail(t *testing.T) {
 	tr := newTestTracker(t)
 	registerEscrow(t, tr, "e1", 32, "m")
 	require.NoError(t, tr.RecordDiff("e1", 1, true))
-	require.NoError(t, tr.RecordRealSend("e1", 1, PhaseNormal, QuarantineNone))
+	require.NoError(t, tr.RecordRealSend("e1", 1, accountingTestNow.Add(-2*time.Minute), PhaseNormal, QuarantineNone))
 	require.NoError(t, tr.RecordTimeout(TimeoutRecord{
 		EscrowID:      "e1",
 		Nonce:         1,

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -19,6 +19,7 @@ import (
 	devshardpkg "devshard"
 	"devshard/gossip"
 	"devshard/host"
+	"devshard/internal/e2econfig"
 	"devshard/observability"
 	"devshard/signing"
 	"devshard/state"
@@ -154,7 +155,10 @@ func loadConfig() (hostConfig, error) {
 
 func buildServer(ctx context.Context, cfg hostConfig) (*transport.Server, error) {
 	verifier := signing.NewSecp256k1Verifier()
-	sessionConfig := sessionConfigFromEnv(len(cfg.group))
+	sessionConfig, err := sessionConfigFromEnv(len(cfg.group))
+	if err != nil {
+		return nil, err
+	}
 
 	store, err := storage.NewStorage(ctx, cfg.dataDir)
 	if err != nil {
@@ -293,8 +297,8 @@ func (e delayedInferenceEngine) Execute(ctx context.Context, req devshardpkg.Exe
 
 // sessionConfigFromEnv mirrors bridge.SessionConfigAtBind so e2e hosts stay
 // aligned with devshardctl when escrow params come from mock-chain gRPC.
-func sessionConfigFromEnv(groupSize int) types.SessionConfig {
-	return types.SessionConfigFromEscrow(groupSize, types.EscrowSessionFields{
+func sessionConfigFromEnv(groupSize int) (types.SessionConfig, error) {
+	cfg := types.SessionConfigFromEscrow(groupSize, types.EscrowSessionFields{
 		TokenPrice:                uintEnv("DEVSHARD_TOKEN_PRICE", 1),
 		CreateDevshardFee:         uintEnv("DEVSHARD_CREATE_DEVSHARD_FEE", 0),
 		FeePerNonce:               uintEnv("DEVSHARD_FEE_PER_NONCE", 0),
@@ -304,6 +308,12 @@ func sessionConfigFromEnv(groupSize int) types.SessionConfig {
 		ValidationRate:            uint32(uintEnv("DEVSHARD_VALIDATION_RATE", 0)),
 		VoteThresholdFactor:       uint32(uintEnv("DEVSHARD_VOTE_THRESHOLD_FACTOR", 0)),
 	})
+	overrides, err := e2econfig.SessionTimeoutOverridesFromEnv()
+	if err != nil {
+		return types.SessionConfig{}, err
+	}
+	cfg = overrides.Apply(cfg)
+	return types.NormalizeSessionConfig(cfg, groupSize), nil
 }
 
 func groupFromKeys(keys []string) ([]types.SlotAssignment, error) {

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -48,13 +48,20 @@ func main() {
 	if err != nil {
 		log.Fatalf("build server: %v", err)
 	}
+	stubInferenceHTTPStatus, hasStubInferenceHTTPStatus, err := e2econfig.IntFromEnv(e2econfig.StubInferenceHTTPStatusEnv)
+	if err != nil {
+		log.Fatalf("load %s: %v", e2econfig.StubInferenceHTTPStatusEnv, err)
+	}
+	if hasStubInferenceHTTPStatus && (stubInferenceHTTPStatus < http.StatusBadRequest || stubInferenceHTTPStatus > 599) {
+		log.Fatalf("invalid %s: must be an HTTP error status", e2econfig.StubInferenceHTTPStatusEnv)
+	}
 
 	e := echo.New()
 	e.HideBanner = true
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})
-	registerServer(e.Group(devshardpkg.DefaultRoutePrefix()), srv)
+	registerServer(e.Group(devshardpkg.DefaultRoutePrefix()), srv, stubInferenceHTTPStatus)
 
 	addr := ":" + *port
 	log.Printf("devshard-host listening on %s slot=%d address=%s route_prefix=%s",
@@ -66,7 +73,7 @@ func main() {
 
 // registerServer mounts the transport handlers the same way production
 // RegisterLazySessionRoutes does, for a single pre-bound e2e host session.
-func registerServer(g *echo.Group, srv *transport.Server) {
+func registerServer(g *echo.Group, srv *transport.Server, stubInferenceHTTPStatus int) {
 	g.Use(observability.EchoMiddleware())
 	g.Use(observability.RequestIDMiddleware)
 
@@ -77,7 +84,22 @@ func registerServer(g *echo.Group, srv *transport.Server) {
 		}
 	}
 
-	g.POST("/sessions/:id/chat/completions", withAuth(true, srv.HandleInference))
+	inferenceHandler := srv.HandleInference
+	if stubInferenceHTTPStatus != 0 {
+		inferenceHandler = func(c echo.Context) error {
+			message := http.StatusText(stubInferenceHTTPStatus)
+			if message == "" {
+				message = fmt.Sprintf("stub inference HTTP status %d", stubInferenceHTTPStatus)
+			}
+			return c.JSON(stubInferenceHTTPStatus, map[string]any{
+				"error": map[string]string{
+					"message": message,
+				},
+			})
+		}
+	}
+
+	g.POST("/sessions/:id/chat/completions", withAuth(true, inferenceHandler))
 	g.POST("/sessions/:id/verify-timeout", withAuth(false, srv.HandleVerifyTimeout))
 	g.POST("/sessions/:id/challenge-receipt", withAuth(false, srv.HandleChallengeReceipt))
 	g.POST("/sessions/:id/gossip/nonce", withAuth(false, srv.HandleGossipNonce))
@@ -196,6 +218,13 @@ func buildServer(ctx context.Context, cfg hostConfig) (*transport.Server, error)
 	}
 
 	inferenceEngine := devshardpkg.InferenceEngine(stub.NewInferenceEngine())
+	sseErrorMessage, err := e2econfig.StringFromEnv(e2econfig.StubInferenceSSEErrorEnv)
+	if err != nil {
+		return nil, err
+	}
+	if sseErrorMessage != "" {
+		inferenceEngine = sseErrorInferenceEngine{message: sseErrorMessage}
+	}
 	inferenceDelay, err := e2econfig.DurationMillisFromEnv(e2econfig.StubInferenceDelayMillisEnv)
 	if err != nil {
 		return nil, err
@@ -305,6 +334,20 @@ func (e delayedInferenceEngine) Execute(ctx context.Context, req devshardpkg.Exe
 	case <-timer.C:
 		return e.inner.Execute(ctx, req)
 	}
+}
+
+type sseErrorInferenceEngine struct {
+	message string
+}
+
+func (e sseErrorInferenceEngine) Execute(_ context.Context, req devshardpkg.ExecuteRequest) (*devshardpkg.ExecuteResult, error) {
+	if req.ResponseWriter != nil {
+		fmt.Fprintf(req.ResponseWriter, "data: {\"error\":{\"code\":400,\"message\":%s,\"type\":\"BadRequestError\"}}\n\n", strconv.Quote(e.message))
+		if rw, ok := req.ResponseWriter.(http.Flusher); ok {
+			rw.Flush()
+		}
+	}
+	return nil, errors.New(e.message)
 }
 
 // sessionConfigFromEnv mirrors bridge.SessionConfigAtBind so e2e hosts stay

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -190,10 +191,15 @@ func buildServer(ctx context.Context, cfg hostConfig) (*transport.Server, error)
 		return nil, err
 	}
 
+	inferenceEngine := devshardpkg.InferenceEngine(stub.NewInferenceEngine())
+	if delay := stubInferenceDelayFromEnv(); delay > 0 {
+		inferenceEngine = delayedInferenceEngine{inner: inferenceEngine, delay: delay}
+	}
+
 	h, err := host.NewHost(
 		sm,
 		cfg.signer,
-		stub.NewInferenceEngine(),
+		inferenceEngine,
 		cfg.escrowID,
 		cfg.group,
 		nil,
@@ -268,6 +274,23 @@ func recoverHostState(store storage.Storage, sm *state.StateMachine, escrowID st
 	return nil
 }
 
+type delayedInferenceEngine struct {
+	inner devshardpkg.InferenceEngine
+	delay time.Duration
+}
+
+func (e delayedInferenceEngine) Execute(ctx context.Context, req devshardpkg.ExecuteRequest) (*devshardpkg.ExecuteResult, error) {
+	timer := time.NewTimer(e.delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timer.C:
+		return e.inner.Execute(ctx, req)
+	}
+}
+
 // sessionConfigFromEnv mirrors bridge.SessionConfigAtBind so e2e hosts stay
 // aligned with devshardctl when escrow params come from mock-chain gRPC.
 func sessionConfigFromEnv(groupSize int) types.SessionConfig {
@@ -327,6 +350,32 @@ func uintEnv(key string, fallback uint64) uint64 {
 		log.Fatalf("invalid %s: %v", key, err)
 	}
 	return value
+}
+
+func durationMillisEnv(key string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		log.Fatalf("invalid %s: %v", key, err)
+	}
+	if value < 0 {
+		log.Fatalf("invalid %s: must be non-negative", key)
+	}
+	return time.Duration(value) * time.Millisecond
+}
+
+func stubInferenceDelayFromEnv() time.Duration {
+	delay := durationMillisEnv("DEVSHARD_STUB_INFERENCE_DELAY_MS", 0)
+	if delay == 0 {
+		return 0
+	}
+	if os.Getenv("DEVSHARD_E2E") != "1" {
+		log.Fatalf("DEVSHARD_STUB_INFERENCE_DELAY_MS is only supported when DEVSHARD_E2E=1")
+	}
+	return delay
 }
 
 func defaultHostPrivateKeys() []string {

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -196,8 +196,12 @@ func buildServer(ctx context.Context, cfg hostConfig) (*transport.Server, error)
 	}
 
 	inferenceEngine := devshardpkg.InferenceEngine(stub.NewInferenceEngine())
-	if delay := stubInferenceDelayFromEnv(); delay > 0 {
-		inferenceEngine = delayedInferenceEngine{inner: inferenceEngine, delay: delay}
+	inferenceDelay, err := e2econfig.DurationMillisFromEnv(e2econfig.StubInferenceDelayMillisEnv)
+	if err != nil {
+		return nil, err
+	}
+	if inferenceDelay > 0 {
+		inferenceEngine = delayedInferenceEngine{inner: inferenceEngine, delay: inferenceDelay}
 	}
 
 	h, err := host.NewHost(
@@ -217,7 +221,15 @@ func buildServer(ctx context.Context, cfg hostConfig) (*transport.Server, error)
 	}
 	h.Start()
 
-	srv, err := transport.NewServer(h, store, verifier, cfg.userAddress)
+	serverOptions := []transport.ServerOption{}
+	receiptDelay, err := e2econfig.DurationMillisFromEnv(e2econfig.ReceiptDelayMillisEnv)
+	if err != nil {
+		return nil, err
+	}
+	if receiptDelay > 0 {
+		serverOptions = append(serverOptions, transport.WithReceiptDelay(receiptDelay))
+	}
+	srv, err := transport.NewServer(h, store, verifier, cfg.userAddress, serverOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -360,32 +372,6 @@ func uintEnv(key string, fallback uint64) uint64 {
 		log.Fatalf("invalid %s: %v", key, err)
 	}
 	return value
-}
-
-func durationMillisEnv(key string, fallback time.Duration) time.Duration {
-	raw := os.Getenv(key)
-	if raw == "" {
-		return fallback
-	}
-	value, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		log.Fatalf("invalid %s: %v", key, err)
-	}
-	if value < 0 {
-		log.Fatalf("invalid %s: must be non-negative", key)
-	}
-	return time.Duration(value) * time.Millisecond
-}
-
-func stubInferenceDelayFromEnv() time.Duration {
-	delay := durationMillisEnv("DEVSHARD_STUB_INFERENCE_DELAY_MS", 0)
-	if delay == 0 {
-		return 0
-	}
-	if os.Getenv("DEVSHARD_E2E") != "1" {
-		log.Fatalf("DEVSHARD_STUB_INFERENCE_DELAY_MS is only supported when DEVSHARD_E2E=1")
-	}
-	return delay
 }
 
 func defaultHostPrivateKeys() []string {

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -217,7 +217,10 @@ func buildServer(ctx context.Context, cfg hostConfig) (*transport.Server, error)
 		return nil, err
 	}
 
-	inferenceEngine := devshardpkg.InferenceEngine(stub.NewInferenceEngine())
+	inferenceEngine, err := stubInferenceEngineFromEnv()
+	if err != nil {
+		return nil, err
+	}
 	sseErrorMessage, err := e2econfig.StringFromEnv(e2econfig.StubInferenceSSEErrorEnv)
 	if err != nil {
 		return nil, err

--- a/devshard/cmd/devshard-host/stub_engine.go
+++ b/devshard/cmd/devshard-host/stub_engine.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"crypto/sha256"
+
+	devshardpkg "devshard"
+	"devshard/internal/e2econfig"
+	"devshard/stub"
+)
+
+func stubInferenceEngineFromEnv() (devshardpkg.InferenceEngine, error) {
+	stubEngine := stub.NewInferenceEngine()
+	stubResponseBody, err := e2econfig.StringFromEnv(e2econfig.StubInferenceResponseBodyEnv)
+	if err != nil {
+		return nil, err
+	}
+	if stubResponseBody != "" {
+		body := []byte(stubResponseBody)
+		responseHash := sha256.Sum256(body)
+		stubEngine.ResponseBody = body
+		stubEngine.ResponseHash = responseHash[:]
+	}
+	return stubEngine, nil
+}

--- a/devshard/cmd/devshardctl/accounting_test.go
+++ b/devshard/cmd/devshardctl/accounting_test.go
@@ -20,21 +20,10 @@ import (
 )
 
 func TestGatewayAccountingAdapterRecordsEvents(t *testing.T) {
-	tracker, err := accounting.OpenTracker(filepath.Join(t.TempDir(), "accounting.db"), 0, time.Hour)
-	require.NoError(t, err)
-	defer tracker.Close()
+	tracker := newGatewayAccountingTestTracker(t)
 	recorder := accounting.NewRecorder(tracker, nil)
 	require.NotNil(t, recorder)
-	require.NoError(t, tracker.RegisterEscrow(accounting.EscrowMetadata{
-		EscrowID:      "e1",
-		CreationEpoch: 1,
-		Model:         "m",
-		Phase:         accounting.EscrowActive,
-		Slots: []types.SlotAssignment{
-			{SlotID: 0, ValidatorAddress: "p0"},
-			{SlotID: 1, ValidatorAddress: "p1"},
-		},
-	}))
+	registerGatewayAccountingTestEscrow(t, tracker, "e1", 1, "m")
 	require.NoError(t, tracker.RecordDiff("e1", 1, true))
 	recorder.Ghost("e1", 1, "participant_throttled_no_send", "probe")
 	require.NoError(t, tracker.RecordDiff("e1", 2, true))
@@ -476,4 +465,204 @@ func accountingRecordForParticipant(
 	}
 	t.Fatalf("missing participant %s", participant)
 	return accounting.ParticipantRecord{}
+}
+
+func TestGatewayAccountingAdapterRecordsGhostPolicyDimensions(t *testing.T) {
+	resetPoCPhaseStateForTest(t)
+	tracker := newGatewayAccountingTestTracker(t)
+	recorder := accounting.NewRecorder(tracker, nil)
+	registerGatewayAccountingTestEscrow(t, tracker, "e1", 2, "m")
+
+	cases := []struct {
+		name       string
+		reason     string
+		quarantine string
+		wantReason accounting.NoSendReason
+		wantMode   accounting.QuarantineMode
+	}{
+		{
+			name:       "probe quarantine",
+			reason:     "participant_throttled_no_send",
+			quarantine: "probe",
+			wantReason: accounting.NoSendParticipantThrottled,
+			wantMode:   accounting.QuarantineProbe,
+		},
+		{
+			name:       "plain throttling",
+			reason:     "participant_throttled_no_send",
+			quarantine: "none",
+			wantReason: accounting.NoSendParticipantThrottled,
+			wantMode:   accounting.QuarantineNone,
+		},
+		{
+			name:       "capability exclusion",
+			reason:     "participant_capability_no_send",
+			quarantine: "none",
+			wantReason: accounting.NoSendParticipantCapability,
+			wantMode:   accounting.QuarantineNone,
+		},
+		{
+			name:       "stale incompatible request",
+			reason:     "no_compatible_request_after_stale",
+			quarantine: "none",
+			wantReason: accounting.NoSendNoCompatibleAfterStale,
+			wantMode:   accounting.QuarantineNone,
+		},
+		{
+			name:       "unlisted policy",
+			reason:     "some_new_policy",
+			quarantine: "none",
+			wantReason: accounting.NoSendUnknown,
+			wantMode:   accounting.QuarantineNone,
+		},
+	}
+
+	for i, tc := range cases {
+		nonce := uint64(i + 1)
+		require.NoError(t, tracker.RecordDiff("e1", nonce, true), tc.name)
+		recorder.Ghost("e1", nonce, tc.reason, tc.quarantine)
+	}
+
+	record := onlyGatewayAccountingRecord(t, tracker.Query(accounting.QueryFilter{EpochIndex: 2}))
+	for _, tc := range cases {
+		counter := requireGatewayAccountingCounter(t, record, func(key accounting.CounterKey) bool {
+			return key.Disposition == accounting.DispositionGhost &&
+				key.NoSendReason == tc.wantReason &&
+				key.QuarantineMode == tc.wantMode
+		})
+		require.Equal(t, uint64(1), counter.Count, tc.name)
+		if tc.wantReason == accounting.NoSendUnknown {
+			require.Equal(t, "unknown", counter.Key.DetailReason)
+		}
+	}
+	require.Equal(t, uint64(1), record.UnknownReasonTotal)
+}
+
+func TestGatewayAccountingAdapterRecordsPoCGhostPolicyDimensions(t *testing.T) {
+	resetPoCPhaseStateForTest(t)
+	setPoCPhaseState(true, "poc")
+	tracker := newGatewayAccountingTestTracker(t)
+	recorder := accounting.NewRecorder(tracker, currentPoCPhaseReason)
+	registerGatewayAccountingTestEscrow(t, tracker, "e1", 3, "m")
+	require.NoError(t, tracker.RecordDiff("e1", 1, true))
+
+	recorder.Ghost("e1", 1, "poc_unavailable_host", "none")
+
+	record := onlyGatewayAccountingRecord(t, tracker.Query(accounting.QueryFilter{EpochIndex: 3}))
+	counter := requireGatewayAccountingCounter(t, record, func(key accounting.CounterKey) bool {
+		return key.Disposition == accounting.DispositionGhost &&
+			key.DispatchPhase == accounting.PhasePoC &&
+			key.NoSendReason == accounting.NoSendPoCUnavailable &&
+			key.QuarantineMode == accounting.QuarantineNone
+	})
+	require.Equal(t, uint64(1), counter.Count)
+}
+
+func TestGatewayAccountingAdapterRecordsRealSendPolicyDimensions(t *testing.T) {
+	resetPoCPhaseStateForTest(t)
+	tracker := newGatewayAccountingTestTracker(t)
+	recorder := accounting.NewRecorder(tracker, nil)
+	registerGatewayAccountingTestEscrow(t, tracker, "e1", 4, "m")
+
+	require.NoError(t, tracker.RecordDiff("e1", 1, true))
+	recorder.RealSend("e1", 1, time.Now(), "shadow")
+	recorder.Usage("e1", 1, 1)
+	require.NoError(t, tracker.RecordProtocol("e1", 1, 0, accounting.ProtocolFinishApplied, types.HostStats{}))
+
+	require.NoError(t, tracker.RecordDiff("e1", 2, true))
+	recorder.RealSend("e1", 2, time.Now(), "probation")
+	recorder.Usage("e1", 2, 1)
+	require.NoError(t, tracker.RecordProtocol("e1", 2, 0, accounting.ProtocolFinishApplied, types.HostStats{}))
+
+	record := onlyGatewayAccountingRecord(t, tracker.Query(accounting.QueryFilter{EpochIndex: 4}))
+	shadow := requireGatewayAccountingCounter(t, record, func(key accounting.CounterKey) bool {
+		return key.Disposition == accounting.DispositionFinishedUsed &&
+			key.QuarantineMode == accounting.QuarantineShadow
+	})
+	require.Equal(t, uint64(1), shadow.Count)
+	probation := requireGatewayAccountingCounter(t, record, func(key accounting.CounterKey) bool {
+		return key.Disposition == accounting.DispositionFinishedUnused &&
+			key.QuarantineMode == accounting.QuarantineProbation
+	})
+	require.Equal(t, uint64(1), probation.Count)
+}
+
+func TestGatewayAccountingAdapterRecordsPoCRealSendPhaseContext(t *testing.T) {
+	resetPoCPhaseStateForTest(t)
+	setPoCPhaseState(true, "poc")
+	tracker := newGatewayAccountingTestTracker(t)
+	recorder := accounting.NewRecorder(tracker, currentPoCPhaseReason)
+	registerGatewayAccountingTestEscrow(t, tracker, "e1", 5, "m")
+	require.NoError(t, tracker.RecordDiff("e1", 1, true))
+
+	recorder.RealSend("e1", 1, time.Now(), "none")
+	recorder.Usage("e1", 1, 1)
+	require.NoError(t, tracker.RecordProtocol("e1", 1, 0, accounting.ProtocolFinishApplied, types.HostStats{}))
+
+	record := onlyGatewayAccountingRecord(t, tracker.Query(accounting.QueryFilter{EpochIndex: 5}))
+	counter := requireGatewayAccountingCounter(t, record, func(key accounting.CounterKey) bool {
+		return key.Disposition == accounting.DispositionFinishedUsed &&
+			key.DispatchPhase == accounting.PhasePoC &&
+			key.TimeoutEvaluationPhase == "" &&
+			key.QuarantineMode == accounting.QuarantineNone
+	})
+	require.Equal(t, uint64(1), counter.Count)
+}
+
+func TestGatewayAccountingNoNonceConsumedHasNoAccounting(t *testing.T) {
+	resetPoCPhaseStateForTest(t)
+	setPoCPhaseState(true, "poc")
+	tracker := newGatewayAccountingTestTracker(t)
+	registerGatewayAccountingTestEscrow(t, tracker, "e1", 6, "m")
+
+	record := onlyGatewayAccountingRecord(t, tracker.Query(accounting.QueryFilter{EpochIndex: 6}))
+	require.Zero(t, record.AssignedNonces)
+	require.Empty(t, record.Dispositions)
+	require.Empty(t, record.Counters)
+	require.Zero(t, record.InFlight)
+	require.Zero(t, record.PendingClassification)
+	require.Zero(t, record.Unclassified)
+	require.Zero(t, record.Overclassified)
+}
+
+func newGatewayAccountingTestTracker(t *testing.T) *accounting.Tracker {
+	t.Helper()
+	tracker, err := accounting.OpenTracker(filepath.Join(t.TempDir(), "accounting.db"), 0, time.Hour)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tracker.Close()) })
+	return tracker
+}
+
+func registerGatewayAccountingTestEscrow(t *testing.T, tracker *accounting.Tracker, id string, epoch uint64, model string) {
+	t.Helper()
+	require.NoError(t, tracker.RegisterEscrow(accounting.EscrowMetadata{
+		EscrowID:      id,
+		CreationEpoch: epoch,
+		Model:         model,
+		Phase:         accounting.EscrowActive,
+		Slots: []types.SlotAssignment{
+			{SlotID: 0, ValidatorAddress: "p0"},
+		},
+	}))
+}
+
+func onlyGatewayAccountingRecord(t *testing.T, records []accounting.ParticipantRecord) accounting.ParticipantRecord {
+	t.Helper()
+	require.Len(t, records, 1)
+	return records[0]
+}
+
+func requireGatewayAccountingCounter(
+	t *testing.T,
+	record accounting.ParticipantRecord,
+	matches func(accounting.CounterKey) bool,
+) accounting.CounterRecord {
+	t.Helper()
+	for _, counter := range record.Counters {
+		if matches(counter.Key) {
+			return counter
+		}
+	}
+	t.Fatalf("missing counter in %#v", record.Counters)
+	return accounting.CounterRecord{}
 }

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -27,6 +27,7 @@ import (
 	chaintx "common/chain/tx"
 	"devshard/accounting"
 	"devshard/bridge"
+	"devshard/internal/e2econfig"
 	"devshard/runtimeparams"
 	"devshard/storage"
 	"devshard/transport"
@@ -286,14 +287,20 @@ func buildRuntime(cfg RuntimeConfig, deps runtimeBuildDeps) (*devshardRuntime, e
 	}
 	model := resolveRuntimeModel(cfg.Model, escrow.ModelID, deps.defaultModel, cfg.ID)
 	routePrefix := resolveRuntimeRoutePrefix(cfg.RoutePrefix)
+	timeoutOverrides, err := e2econfig.SessionTimeoutOverridesFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("runtime %s: session timeout overrides: %w", cfg.ID, err)
+	}
 	session, sm, err := user.NewHTTPSession(user.HTTPSessionConfig{
-		PrivateKeyHex:    keyHex,
-		EscrowID:         cfg.ID,
-		Bridge:           br,
-		StoragePath:      cfg.StoragePath,
-		RoutePrefix:      routePrefix,
-		RequestAdmission: sharedParticipantRequestLimiter,
-		Escrow:           escrow,
+		PrivateKeyHex:           keyHex,
+		EscrowID:                cfg.ID,
+		Bridge:                  br,
+		StoragePath:             cfg.StoragePath,
+		RoutePrefix:             routePrefix,
+		RequestAdmission:        sharedParticipantRequestLimiter,
+		Escrow:                  escrow,
+		RefusalTimeoutSeconds:   timeoutOverrides.RefusalTimeoutSeconds,
+		ExecutionTimeoutSeconds: timeoutOverrides.ExecutionTimeoutSeconds,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("runtime %s: create session: %w", cfg.ID, err)

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -1263,6 +1263,34 @@ func TestLongNonStreamEmptyResponseRecordsTimingWithoutQuarantine(t *testing.T) 
 	require.GreaterOrEqual(t, involvement.TotalTimeMs, float64(longResponseFailureExemption.Milliseconds()))
 }
 
+func TestLongNonStreamEmptyResponseDoesNotRecordDuringRelaxedPoC(t *testing.T) {
+	setPoCModeForTest(t, pocRequestModeRelaxed)
+	setPoCPhaseState(true, "confirmation_poc")
+	oldWindow := ParticipantPerfWindow
+	ParticipantPerfWindow = 24 * time.Hour
+	t.Cleanup(func() { ParticipantPerfWindow = oldWindow })
+
+	env := setupTestProxyWithClients(t, []user.HostClient{streamContentThenStallClient{}})
+	limiter := NewParticipantRequestLimiter(10, 10)
+	env.proxy.redundancy.participantLimiter = limiter
+	params := defaultParams()
+	params.Stream = false
+
+	inf := &inflight{
+		hostIdx:  0,
+		nonce:    1,
+		sendTime: time.Now().Add(-(longResponseFailureExemption + time.Second)),
+	}
+	inf.setReceiptAt(time.Now().Add(-(longResponseFailureExemption + 900*time.Millisecond)))
+	require.True(t, longNonStreamEmptyFailureExempt(inf, params))
+
+	env.proxy.redundancy.recordStartedAttemptSamples([]*inflight{inf}, params, true)
+
+	stats := env.proxy.redundancy.perf.Stats(0)
+	require.Zero(t, stats.TotalSamples)
+	require.False(t, limiter.IsBlocked(env.session.HostParticipantKey(0)))
+}
+
 func TestFastNonStreamEmptyResponseRecordsParticipantFailure(t *testing.T) {
 	env := setupTestProxyWithClients(t, []user.HostClient{streamContentThenStallClient{}})
 	limiter := NewParticipantRequestLimiter(10, 10)

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -1222,12 +1222,16 @@ func TestLongResponseAfterContentSkipsParticipantFailureAccounting(t *testing.T)
 }
 
 func TestLongNonStreamEmptyResponseRecordsTimingWithoutQuarantine(t *testing.T) {
-	env := setupTestProxyWithClients(t, []user.HostClient{streamContentThenStallClient{}})
-	limiter := NewParticipantRequestLimiter(10, 10)
-	env.proxy.redundancy.participantLimiter = limiter
+	// Relaxed PoC intentionally suppresses empty-stream samples; this test is
+	// only about the long non-stream exemption path.
+	setPoCModeForTest(t, pocRequestModeOff)
 	oldWindow := ParticipantPerfWindow
 	ParticipantPerfWindow = 24 * time.Hour
 	t.Cleanup(func() { ParticipantPerfWindow = oldWindow })
+
+	env := setupTestProxyWithClients(t, []user.HostClient{streamContentThenStallClient{}})
+	limiter := NewParticipantRequestLimiter(10, 10)
+	env.proxy.redundancy.participantLimiter = limiter
 	participantKey := env.session.HostParticipantKey(0)
 	params := defaultParams()
 	params.Stream = false

--- a/devshard/e2e/accounting_test.go
+++ b/devshard/e2e/accounting_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -350,33 +351,89 @@ func TestE2E_AccountingAppliedTimeoutCrossCheck(t *testing.T) {
 }
 
 // Test flow:
-//  1. Start the default three-host environment.
-//  2. Stop the host assigned to the next nonce so the first attempt fails.
-//  3. Send enough sequential completions for the failed participant to be skipped.
-//  4. Poll accounting until the skipped no-send nonce appears as ghost.
-//  5. Assert accounting remains coherent and every assigned nonce is counted once.
+//  1. Start the three-host environment with the nonce-1 host returning HTTP 503.
+//  2. Send enough sequential completions for the throttled participant to be skipped.
+//  3. Let the first 503 teach the gateway to quarantine that participant.
+//  4. Poll accounting until the skipped no-send nonce appears as a throttled probe ghost.
+//  5. Assert accounting records the no-send reason/quarantine dimensions and every assigned nonce is counted once.
 func TestE2E_AccountingFocusedGhostRequestNotSent(t *testing.T) {
-	env, client := startNonStreamingEnv(t)
+	env, client := startNonStreamingEnvWithOptions(t, e2eEnvOptions{
+		hostEnvOverrides: map[int]map[string]string{
+			1: {
+				e2econfig.StubInferenceHTTPStatusEnv: "503",
+			},
+		},
+	})
 
 	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
 		return len(resp.Participants) > 0
 	})
 	beforeGhost := testutil.AccountingDispositionCount(before, "ghost")
+	beforeThrottledProbeGhost := testutil.AccountingGhostCounterCount(before, "participant_throttled_no_send", "probe")
 	beforeAssigned := testutil.AccountingAssignedTotal(before)
 
 	nextSlot := int((testutil.LatestSessionNonce(t, client, env.clientURL) + 1) % uint64(len(env.hostURLs)))
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.DefaultRequestTimeout)
-	t.Cleanup(cancel)
-	env.stopHost(ctx, t, nextSlot)
+	require.Equal(t, 1, nextSlot, "test setup expects the HTTP 503 host to own the first traffic nonce")
 
-	testutil.SendCompletions(t, client, env.clientURL, "accounting focused ghost", len(env.hostURLs)+1)
+	testutil.SendCompletions(t, client, env.clientURL, "accounting focused ghost", len(env.hostURLs)+2)
 
 	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
 		return len(resp.Participants) > 0 &&
 			testutil.AccountingAssignedTotal(resp) > beforeAssigned &&
-			testutil.AccountingDispositionCount(resp, "ghost") > beforeGhost
+			testutil.AccountingDispositionCount(resp, "ghost") > beforeGhost &&
+			testutil.AccountingGhostCounterCount(resp, "participant_throttled_no_send", "probe") > beforeThrottledProbeGhost
 	})
-	require.Greater(t, testutil.AccountingDispositionCount(accounting, "ghost"), beforeGhost, "stopped participant should eventually be skipped as a ghost no-send nonce")
+	require.Greater(t, testutil.AccountingDispositionCount(accounting, "ghost"), beforeGhost, "HTTP 503 participant should eventually be skipped as a ghost no-send nonce")
+	require.Greater(t,
+		testutil.AccountingGhostCounterCount(accounting, "participant_throttled_no_send", "probe"),
+		beforeThrottledProbeGhost,
+		"HTTP 503 participant should be accounted with throttled no-send reason and probe quarantine mode",
+	)
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
+}
+
+// Test flow:
+//  1. Start the three-host environment with the nonce-1 host returning a retriable tool capability error.
+//  2. Send tool completions so the gateway learns that participant cannot serve tool requests.
+//  3. Continue tool traffic until the participant's next assigned slot is skipped as a ghost no-send.
+//  4. Poll accounting until no_send_reason=participant_capability_no_send is visible.
+//  5. Assert the capability ghost is not a quarantine probe and every assigned nonce is counted once.
+func TestE2E_AccountingGhostCapabilityNoSendReason(t *testing.T) {
+	env, client := startNonStreamingEnvWithOptions(t, e2eEnvOptions{
+		hostEnvOverrides: map[int]map[string]string{
+			1: {
+				e2econfig.StubInferenceSSEErrorEnv: testutil.ToolChoiceUnsupportedMessage,
+			},
+		},
+	})
+
+	nextSlot := int((testutil.LatestSessionNonce(t, client, env.clientURL) + 1) % uint64(len(env.hostURLs)))
+	require.Equal(t, 1, nextSlot, "test setup expects the tool-capability-error host to own the first traffic nonce")
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeCapabilityGhost := testutil.AccountingGhostCounterCount(before, "participant_capability_no_send", "none")
+	beforeAssigned := testutil.AccountingAssignedTotal(before)
+
+	for i := 0; i < len(env.hostURLs)+2; i++ {
+		label := fmt.Sprintf("accounting capability ghost %d", i+1)
+		resp := testutil.PostJSONRaw(t, client, env.clientURL+"/v1/chat/completions", testutil.ToolCompletionBody(label, false), testutil.AdminAPIKey)
+		testutil.LogRawResponse(t, label, resp)
+		testutil.RequireOpenAINonStreamingCompletion(t, resp)
+	}
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 &&
+			testutil.AccountingAssignedTotal(resp) > beforeAssigned &&
+			testutil.AccountingGhostCounterCount(resp, "participant_capability_no_send", "none") > beforeCapabilityGhost
+	})
+	require.Greater(t,
+		testutil.AccountingGhostCounterCount(accounting, "participant_capability_no_send", "none"),
+		beforeCapabilityGhost,
+		"tool-capability-incompatible participant should be accounted with capability no-send reason and no quarantine mode",
+	)
 	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
 	testutil.RequireNonceAccountingBalanced(t, accounting)
 }

--- a/devshard/e2e/accounting_test.go
+++ b/devshard/e2e/accounting_test.go
@@ -65,6 +65,71 @@ func TestE2E_AccountingNoResidualAfterFinishedTraffic(t *testing.T) {
 }
 
 // Test flow:
+//  1. Start the three-host environment with the next assigned host delayed.
+//  2. Use pairwise warmup sampling to start one fast secondary immediately.
+//  3. Send one non-streaming completion and wait for the delayed primary to publish finish.
+//  4. Send a non-redundant follow-up request so the gateway commits the pending finish txs.
+//  5. Poll accounting until the winner is finished_used and the delayed loser is finished_unused.
+//  6. Assert the redundant request consumed two finished nonces and accounting still balances.
+func TestE2E_AccountingOverscheduledLoserFinishes(t *testing.T) {
+	env, client := startNonStreamingEnvWithOptions(t, e2eEnvOptions{
+		hostEnvOverrides: map[int]map[string]string{
+			1: {
+				"DEVSHARD_STUB_INFERENCE_DELAY_MS": "800",
+			},
+		},
+	})
+
+	nextSlot := int((testutil.LatestSessionNonce(t, client, env.clientURL) + 1) % uint64(len(env.hostURLs)))
+	require.Equal(t, 1, nextSlot, "test setup expects the delayed host to own the first traffic nonce")
+
+	testutil.PostJSON(t, client, env.clientURL+"/v1/admin/settings", map[string]any{
+		"redundancy": map[string]any{
+			"speed_policy":                     "hybrid",
+			"pairwise_max_proactive_attempts":  1,
+			"pairwise_min_direct_comparisons":  1,
+			"non_stream_no_content_timeout_ms": int64(3000),
+			"non_stream_max_attempt_wait_ms":   int64(3500),
+			"secondary_wait_after_winner_ms":   int64(2500),
+		},
+	})
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeAssigned := testutil.AccountingAssignedTotal(before)
+	beforeUsed := testutil.AccountingDispositionCount(before, "finished_used")
+	beforeUnused := testutil.AccountingDispositionCount(before, "finished_unused")
+
+	resp := testutil.SendCompletionRaw(t, client, env.clientURL, "accounting overscheduled loser finishes", testutil.AdminAPIKey)
+	testutil.LogRawResponse(t, "accounting overscheduled loser finishes completion", resp)
+	testutil.RequireOpenAINonStreamingCompletion(t, resp)
+
+	time.Sleep(2 * time.Second)
+	testutil.PostJSON(t, client, env.clientURL+"/v1/admin/settings", map[string]any{
+		"redundancy": map[string]any{
+			"speed_policy":       "legacy",
+			"receipt_timeout_ms": int64(5000),
+		},
+	})
+	flush := testutil.SendCompletionRaw(t, client, env.clientURL, "accounting overscheduled loser finish flush", testutil.AdminAPIKey)
+	testutil.LogRawResponse(t, "accounting overscheduled loser finish flush completion", flush)
+	testutil.RequireOpenAINonStreamingCompletion(t, flush)
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 &&
+			testutil.AccountingAssignedTotal(resp) >= beforeAssigned+2 &&
+			testutil.AccountingDispositionCount(resp, "finished_used") > beforeUsed &&
+			testutil.AccountingDispositionCount(resp, "finished_unused") > beforeUnused
+	})
+	require.Greater(t, testutil.AccountingDispositionCount(accounting, "finished_used"), beforeUsed, "winner should be counted as finished_used")
+	require.Greater(t, testutil.AccountingDispositionCount(accounting, "finished_unused"), beforeUnused, "finished redundant loser should be counted as finished_unused")
+	require.GreaterOrEqual(t, testutil.AccountingAssignedTotal(accounting), beforeAssigned+2, "redundant send should consume separate nonces for winner and loser")
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
+}
+
+// Test flow:
 //  1. Start the three-host environment with the nonce-1 host delaying inference.
 //  2. Send one non-streaming completion asynchronously so its sent nonce stays live.
 //  3. Poll accounting until the sent nonce appears in the in_flight bucket.

--- a/devshard/e2e/accounting_test.go
+++ b/devshard/e2e/accounting_test.go
@@ -107,6 +107,38 @@ func TestE2E_AccountingLiveInFlightIsCountedOnce(t *testing.T) {
 
 // Test flow:
 //  1. Start the default three-host environment.
+//  2. Stop the host assigned to the next nonce so the first attempt fails.
+//  3. Send enough sequential completions for the failed participant to be skipped.
+//  4. Poll accounting until the skipped no-send nonce appears as ghost.
+//  5. Assert accounting remains coherent and every assigned nonce is counted once.
+func TestE2E_AccountingFocusedGhostRequestNotSent(t *testing.T) {
+	env, client := startNonStreamingEnv(t)
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeGhost := testutil.AccountingDispositionCount(before, "ghost")
+	beforeAssigned := testutil.AccountingAssignedTotal(before)
+
+	nextSlot := int((testutil.LatestSessionNonce(t, client, env.clientURL) + 1) % uint64(len(env.hostURLs)))
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.DefaultRequestTimeout)
+	t.Cleanup(cancel)
+	env.stopHost(ctx, t, nextSlot)
+
+	testutil.SendCompletions(t, client, env.clientURL, "accounting focused ghost", len(env.hostURLs)+1)
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 &&
+			testutil.AccountingAssignedTotal(resp) > beforeAssigned &&
+			testutil.AccountingDispositionCount(resp, "ghost") > beforeGhost
+	})
+	require.Greater(t, testutil.AccountingDispositionCount(accounting, "ghost"), beforeGhost, "stopped participant should eventually be skipped as a ghost no-send nonce")
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
+}
+
+// Test flow:
+//  1. Start the default three-host environment.
 //  2. Stop one devshard-host container.
 //  3. Send a non-streaming completion through devshardctl and assert success.
 //  4. Query accounting for the current epoch and model.

--- a/devshard/e2e/accounting_test.go
+++ b/devshard/e2e/accounting_test.go
@@ -1,0 +1,130 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/e2e/testutil"
+)
+
+// Test flow:
+//  1. Start the default three-host environment.
+//  2. Query accounting before user traffic to capture the initial assigned nonce total.
+//  3. Send several successful non-streaming completions through devshardctl.
+//  4. Wait until accounting shows new assigned nonces and at least one disposition.
+//  5. Assert the accounting API response is coherent and every nonce is counted once.
+func TestE2E_AccountingHappyPath(t *testing.T) {
+	env, client := startNonStreamingEnv(t)
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeAssigned := testutil.AccountingAssignedTotal(before)
+
+	testutil.SendCompletions(t, client, env.clientURL, "accounting happy path", 3)
+
+	after := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 &&
+			testutil.AccountingAssignedTotal(resp) > beforeAssigned &&
+			testutil.AccountingDispositionTotal(resp) > 0
+	})
+	testutil.RequireAccountingResponseCoherent(t, after, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, after)
+	require.Greater(t, testutil.AccountingAssignedTotal(after), beforeAssigned, "assigned nonce count should grow after gateway traffic")
+	require.Greater(t, testutil.AccountingDispositionTotal(after), uint64(0), "gateway traffic should produce at least one disposition")
+}
+
+// Test flow:
+//  1. Start the default three-host environment.
+//  2. Query accounting before user traffic to capture the initial assigned nonce total.
+//  3. Send several successful non-streaming completions through devshardctl.
+//  4. Wait until accounting shows dispositions for the consumed nonces.
+//  5. Assert each participant-model record has no residual accounting gap:
+//     dispositions plus live/residual buckets equal assigned nonces.
+func TestE2E_AccountingNoResidualAfterFinishedTraffic(t *testing.T) {
+	env, client := startNonStreamingEnv(t)
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeAssigned := testutil.AccountingAssignedTotal(before)
+
+	testutil.SendCompletions(t, client, env.clientURL, "accounting no residual", 6)
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 &&
+			testutil.AccountingAssignedTotal(resp) > beforeAssigned &&
+			testutil.AccountingDispositionTotal(resp) > 0
+	})
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
+}
+
+// Test flow:
+//  1. Start the three-host environment with the nonce-1 host delaying inference.
+//  2. Send one non-streaming completion asynchronously so its sent nonce stays live.
+//  3. Poll accounting until the sent nonce appears in the in_flight bucket.
+//  4. Assert in_flight is a current disposition bucket and accounting still balances.
+//  5. Wait for the delayed completion and assert the user request still succeeds.
+func TestE2E_AccountingLiveInFlightIsCountedOnce(t *testing.T) {
+	env, client := startNonStreamingEnvWithOptions(t, e2eEnvOptions{
+		hostEnvOverrides: map[int]map[string]string{
+			1: {
+				"DEVSHARD_STUB_INFERENCE_DELAY_MS": "3000",
+			},
+		},
+	})
+
+	_ = testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+
+	done := make(chan testutil.RawResponseResult, 1)
+	go func() {
+		resp, err := testutil.SendCompletionRawE(client, env.clientURL, "accounting live in-flight", testutil.AdminAPIKey)
+		done <- testutil.RawResponseResult{Response: resp, Err: err}
+	}()
+
+	inFlight := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 && testutil.AccountingInFlightTotal(resp) > 0
+	})
+	require.Greater(t, testutil.AccountingInFlightTotal(inFlight), uint64(0), "accounting should expose the live sent nonce as in_flight")
+	testutil.RequireAccountingResponseCoherent(t, inFlight, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, inFlight)
+
+	select {
+	case result := <-done:
+		require.NoError(t, result.Err)
+		testutil.LogRawResponse(t, "accounting live in-flight completion", result.Response)
+		testutil.RequireOpenAINonStreamingCompletion(t, result.Response)
+	case <-time.After(testutil.DefaultRequestTimeout):
+		t.Fatal("timed out waiting for delayed completion")
+	}
+}
+
+// Test flow:
+//  1. Start the default three-host environment.
+//  2. Stop one devshard-host container.
+//  3. Send a non-streaming completion through devshardctl and assert success.
+//  4. Query accounting for the current epoch and model.
+//  5. Assert accounting remains coherent and every assigned nonce is counted once.
+func TestE2E_AccountingOneHostUnavailable(t *testing.T) {
+	env, client := startNonStreamingEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.DefaultRequestTimeout)
+	t.Cleanup(cancel)
+	env.stopHost(ctx, t, 1)
+
+	resp := testutil.SendCompletionRaw(t, client, env.clientURL, "accounting one host unavailable", testutil.AdminAPIKey)
+	testutil.LogRawResponse(t, "accounting one host unavailable completion", resp)
+	testutil.RequireOpenAINonStreamingCompletion(t, resp)
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 && testutil.AccountingAssignedTotal(resp) > 0
+	})
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
+}

--- a/devshard/e2e/accounting_test.go
+++ b/devshard/e2e/accounting_test.go
@@ -131,6 +131,65 @@ func TestE2E_AccountingOverscheduledLoserFinishes(t *testing.T) {
 }
 
 // Test flow:
+//  1. Start the three-host environment with every host publishing protocol finish but empty user content.
+//  2. Shorten non-streaming no-content/fallback windows so no-winner accounting settles quickly.
+//  3. Send one non-streaming completion through the gateway, then a second one to commit queued finish txs.
+//  4. Poll accounting until a finished protocol nonce has usage=unknown.
+//  5. Assert finished_usage_unknown is counted and every assigned nonce is still counted once.
+func TestE2E_AccountingFinishedUsageUnknown(t *testing.T) {
+	const emptyCompletionBody = `{"choices":[{"message":{"role":"assistant","content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":80,"completion_tokens":0}}`
+
+	env, client := startNonStreamingEnvWithOptions(t, e2eEnvOptions{
+		hostEnvOverrides: map[int]map[string]string{
+			0: {
+				e2econfig.StubInferenceResponseBodyEnv: emptyCompletionBody,
+			},
+			1: {
+				e2econfig.StubInferenceResponseBodyEnv: emptyCompletionBody,
+			},
+			2: {
+				e2econfig.StubInferenceResponseBodyEnv: emptyCompletionBody,
+			},
+		},
+	})
+
+	testutil.PostJSON(t, client, env.clientURL+"/v1/admin/settings", map[string]any{
+		"redundancy": map[string]any{
+			"receipt_timeout_ms":               int64(200),
+			"non_stream_response_floor_ms":     int64(300),
+			"non_stream_no_content_timeout_ms": int64(800),
+			"non_stream_max_attempt_wait_ms":   int64(900),
+			"secondary_wait_after_winner_ms":   int64(250),
+		},
+	})
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeUnknown := testutil.AccountingDispositionCount(before, "finished_usage_unknown")
+	beforeAssigned := testutil.AccountingAssignedTotal(before)
+
+	resp := testutil.SendCompletionRaw(t, client, env.clientURL, "accounting finished usage unknown", testutil.AdminAPIKey)
+	testutil.LogRawResponse(t, "accounting finished usage unknown completion", resp)
+
+	drain := testutil.SendCompletionRaw(t, client, env.clientURL, "accounting finished usage unknown drain", testutil.AdminAPIKey)
+	testutil.LogRawResponse(t, "accounting finished usage unknown drain completion", drain)
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 &&
+			testutil.AccountingAssignedTotal(resp) > beforeAssigned &&
+			testutil.AccountingDispositionCount(resp, "finished_usage_unknown") > beforeUnknown
+	})
+	require.Greater(t,
+		testutil.AccountingDispositionCount(accounting, "finished_usage_unknown"),
+		beforeUnknown,
+		"protocol-finished attempt without a recoverable winner should be counted as finished_usage_unknown",
+	)
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
+}
+
+// Test flow:
 //  1. Start the three-host environment with the nonce-1 host delaying inference.
 //  2. Send one non-streaming completion asynchronously so its sent nonce stays live.
 //  3. Poll accounting until the sent nonce appears in the in_flight bucket.
@@ -251,6 +310,100 @@ func TestE2E_AccountingLiveSendTimeout(t *testing.T) {
 	})
 	require.Less(t, testutil.AccountingInFlightTotal(accounting), inFlightCount, "timed-out live send should leave the in_flight bucket")
 	require.Greater(t, testutil.AccountingUnfinishedTotal(accounting), beforeUnfinished, "timed-out live send should become an unfinished disposition")
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
+}
+
+// Test flow:
+//  1. Start the three-host environment with the next assigned host delaying its receipt.
+//  2. Shorten only this e2e run's protocol and redundancy timeout windows.
+//  3. Send one non-streaming completion and observe the no-receipt nonce in-flight.
+//  4. Stop that executor before it can publish receipt or finish, while a fast secondary wins.
+//  5. Poll accounting until the timed-out no-receipt nonce becomes unfinished_refused.
+//  6. Assert unfinished_execution does not increase and nonce accounting still balances.
+func TestE2E_AccountingNoReceiptTimeoutBecomesUnfinishedRefused(t *testing.T) {
+	const shortProtocolTimeoutSeconds = "1"
+
+	env, client := startNonStreamingEnvWithOptions(t, e2eEnvOptions{
+		hostEnvOverrides: map[int]map[string]string{
+			0: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+			},
+			1: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+				e2econfig.ReceiptDelayMillisEnv:      "8000",
+			},
+			2: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+			},
+		},
+		devshardctlEnvOverrides: map[string]string{
+			e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+			e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+		},
+	})
+
+	nextSlot := int((testutil.LatestSessionNonce(t, client, env.clientURL) + 1) % uint64(len(env.hostURLs)))
+	require.Equal(t, 1, nextSlot, "test setup expects the delayed-receipt host to own the first traffic nonce")
+
+	testutil.PostJSON(t, client, env.clientURL+"/v1/admin/settings", map[string]any{
+		"redundancy": map[string]any{
+			"receipt_timeout_ms":               int64(200),
+			"non_stream_response_floor_ms":     int64(300),
+			"non_stream_no_content_timeout_ms": int64(800),
+			"non_stream_max_attempt_wait_ms":   int64(900),
+			"secondary_wait_after_winner_ms":   int64(250),
+		},
+	})
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeRefused := testutil.AccountingDispositionCount(before, "unfinished_refused")
+	beforeExecution := testutil.AccountingDispositionCount(before, "unfinished_execution")
+	beforeApplied := testutil.AccountingTimeoutOutcomeCount(before, "applied")
+
+	done := make(chan testutil.RawResponseResult, 1)
+	go func() {
+		resp, err := testutil.SendCompletionRawE(client, env.clientURL, "accounting no-receipt unfinished refused", testutil.AdminAPIKey)
+		done <- testutil.RawResponseResult{Response: resp, Err: err}
+	}()
+
+	inFlight := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 && testutil.AccountingInFlightTotal(resp) > 0
+	})
+	inFlightCount := testutil.AccountingInFlightTotal(inFlight)
+	require.Greater(t, inFlightCount, uint64(0), "accounting should expose the no-receipt sent nonce as in_flight")
+	testutil.RequireAccountingResponseCoherent(t, inFlight, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, inFlight)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.DefaultRequestTimeout)
+	t.Cleanup(cancel)
+	env.stopHost(ctx, t, nextSlot)
+
+	select {
+	case result := <-done:
+		require.NoError(t, result.Err)
+		testutil.LogRawResponse(t, "accounting no-receipt unfinished refused completion", result.Response)
+		testutil.RequireOpenAINonStreamingCompletion(t, result.Response)
+	case <-time.After(testutil.DefaultRequestTimeout):
+		t.Fatal("timed out waiting for no-receipt timeout-backed completion")
+	}
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 &&
+			testutil.AccountingInFlightTotal(resp) < inFlightCount &&
+			testutil.AccountingDispositionCount(resp, "unfinished_refused") > beforeRefused &&
+			testutil.AccountingDispositionCount(resp, "unfinished_execution") == beforeExecution &&
+			testutil.AccountingTimeoutOutcomeCount(resp, "applied") > beforeApplied
+	})
+	require.Less(t, testutil.AccountingInFlightTotal(accounting), inFlightCount, "timed-out no-receipt send should leave the in_flight bucket")
+	require.Greater(t, testutil.AccountingDispositionCount(accounting, "unfinished_refused"), beforeRefused, "no-receipt timeout should become unfinished_refused")
+	require.Equal(t, beforeExecution, testutil.AccountingDispositionCount(accounting, "unfinished_execution"), "no-receipt timeout must not become unfinished_execution")
+	require.Greater(t, testutil.AccountingTimeoutOutcomeCount(accounting, "applied"), beforeApplied, "no-receipt timeout should apply at protocol level")
 	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
 	testutil.RequireNonceAccountingBalanced(t, accounting)
 }

--- a/devshard/e2e/accounting_test.go
+++ b/devshard/e2e/accounting_test.go
@@ -255,6 +255,101 @@ func TestE2E_AccountingLiveSendTimeout(t *testing.T) {
 }
 
 // Test flow:
+//  1. Start the three-host environment with the next assigned host delaying its receipt.
+//  2. Shorten only this e2e run's protocol and redundancy timeout windows.
+//  3. Send one non-streaming completion, observe the no-receipt nonce in-flight, then stop that executor.
+//  4. Let a fast secondary win while timeout voting applies a protocol miss for the stopped send.
+//  5. Poll accounting until timeout_outcome=applied and HostStats.Missed move together.
+//  6. Assert the applied timeout cross-check remains clean and nonce accounting still balances.
+func TestE2E_AccountingAppliedTimeoutCrossCheck(t *testing.T) {
+	const shortProtocolTimeoutSeconds = "1"
+
+	env, client := startNonStreamingEnvWithOptions(t, e2eEnvOptions{
+		hostEnvOverrides: map[int]map[string]string{
+			0: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+			},
+			1: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+				"DEVSHARD_E2E_RECEIPT_DELAY_MS":      "8000",
+			},
+			2: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+			},
+		},
+		devshardctlEnvOverrides: map[string]string{
+			e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+			e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+		},
+	})
+
+	nextSlot := int((testutil.LatestSessionNonce(t, client, env.clientURL) + 1) % uint64(len(env.hostURLs)))
+	require.Equal(t, 1, nextSlot, "test setup expects the delayed host to own the first traffic nonce")
+
+	testutil.PostJSON(t, client, env.clientURL+"/v1/admin/settings", map[string]any{
+		"redundancy": map[string]any{
+			"receipt_timeout_ms":               int64(200),
+			"non_stream_response_floor_ms":     int64(300),
+			"non_stream_no_content_timeout_ms": int64(800),
+			"non_stream_max_attempt_wait_ms":   int64(900),
+			"secondary_wait_after_winner_ms":   int64(250),
+		},
+	})
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeApplied := testutil.AccountingTimeoutOutcomeCount(before, "applied")
+	beforeMisses := testutil.AccountingProtocolMissTotal(before)
+
+	done := make(chan testutil.RawResponseResult, 1)
+	go func() {
+		resp, err := testutil.SendCompletionRawE(client, env.clientURL, "accounting applied timeout cross-check", testutil.AdminAPIKey)
+		done <- testutil.RawResponseResult{Response: resp, Err: err}
+	}()
+
+	inFlight := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 && testutil.AccountingInFlightTotal(resp) > 0
+	})
+	require.Greater(t, testutil.AccountingInFlightTotal(inFlight), uint64(0), "accounting should expose the live sent nonce before timeout voting")
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.DefaultRequestTimeout)
+	t.Cleanup(cancel)
+	env.stopHost(ctx, t, nextSlot)
+
+	select {
+	case result := <-done:
+		require.NoError(t, result.Err)
+		testutil.LogRawResponse(t, "accounting applied timeout cross-check completion", result.Response)
+		testutil.RequireOpenAINonStreamingCompletion(t, result.Response)
+	case <-time.After(testutil.DefaultRequestTimeout):
+		t.Fatal("timed out waiting for timeout-backed completion")
+	}
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		applied := testutil.AccountingTimeoutOutcomeCount(resp, "applied")
+		missed := testutil.AccountingProtocolMissTotal(resp)
+		return len(resp.Participants) > 0 &&
+			applied > beforeApplied &&
+			missed > beforeMisses &&
+			applied == missed &&
+			testutil.AccountingCrossCheckTimeoutAppliedTotal(resp) == applied &&
+			testutil.AccountingCrossCheckHostMissedTotal(resp) == missed
+	})
+	applied := testutil.AccountingTimeoutOutcomeCount(accounting, "applied")
+	missed := testutil.AccountingProtocolMissTotal(accounting)
+	require.Greater(t, applied, beforeApplied, "timeout_outcome=applied should increase")
+	require.Equal(t, applied, missed, "applied timeout count should match HostStats.Missed")
+	require.Equal(t, applied, testutil.AccountingCrossCheckTimeoutAppliedTotal(accounting), "cross-check applied side should match timeout outcome count")
+	require.Equal(t, missed, testutil.AccountingCrossCheckHostMissedTotal(accounting), "cross-check missed side should match protocol misses")
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
+}
+
+// Test flow:
 //  1. Start the default three-host environment.
 //  2. Stop the host assigned to the next nonce so the first attempt fails.
 //  3. Send enough sequential completions for the failed participant to be skipped.

--- a/devshard/e2e/accounting_test.go
+++ b/devshard/e2e/accounting_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"devshard/e2e/testutil"
+	"devshard/internal/e2econfig"
 )
 
 // Test flow:
@@ -103,6 +104,89 @@ func TestE2E_AccountingLiveInFlightIsCountedOnce(t *testing.T) {
 	case <-time.After(testutil.DefaultRequestTimeout):
 		t.Fatal("timed out waiting for delayed completion")
 	}
+}
+
+// Test flow:
+//  1. Start the three-host environment with the next assigned host delaying inference.
+//  2. Shorten only this e2e run's protocol and redundancy timeout windows.
+//  3. Send one non-streaming completion asynchronously and observe its sent nonce in-flight.
+//  4. Let redundancy return a fast secondary winner while timeout handling runs for the slow send.
+//  5. Poll accounting until in_flight drops and an unfinished disposition appears.
+func TestE2E_AccountingLiveSendTimeout(t *testing.T) {
+	const shortProtocolTimeoutSeconds = "1"
+
+	env, client := startNonStreamingEnvWithOptions(t, e2eEnvOptions{
+		hostEnvOverrides: map[int]map[string]string{
+			0: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+			},
+			1: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+				"DEVSHARD_STUB_INFERENCE_DELAY_MS":   "8000",
+			},
+			2: {
+				e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+				e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+			},
+		},
+		devshardctlEnvOverrides: map[string]string{
+			e2econfig.RefusalTimeoutSecondsEnv:   shortProtocolTimeoutSeconds,
+			e2econfig.ExecutionTimeoutSecondsEnv: shortProtocolTimeoutSeconds,
+		},
+	})
+
+	nextSlot := int((testutil.LatestSessionNonce(t, client, env.clientURL) + 1) % uint64(len(env.hostURLs)))
+	require.Equal(t, 1, nextSlot, "test setup expects the delayed host to own the first traffic nonce")
+
+	testutil.PostJSON(t, client, env.clientURL+"/v1/admin/settings", map[string]any{
+		"redundancy": map[string]any{
+			"receipt_timeout_ms":               int64(200),
+			"non_stream_response_floor_ms":     int64(300),
+			"non_stream_no_content_timeout_ms": int64(800),
+			"non_stream_max_attempt_wait_ms":   int64(900),
+			"secondary_wait_after_winner_ms":   int64(250),
+		},
+	})
+
+	before := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0
+	})
+	beforeUnfinished := testutil.AccountingUnfinishedTotal(before)
+
+	done := make(chan testutil.RawResponseResult, 1)
+	go func() {
+		resp, err := testutil.SendCompletionRawE(client, env.clientURL, "accounting live send timeout", testutil.AdminAPIKey)
+		done <- testutil.RawResponseResult{Response: resp, Err: err}
+	}()
+
+	inFlight := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 && testutil.AccountingInFlightTotal(resp) > 0
+	})
+	inFlightCount := testutil.AccountingInFlightTotal(inFlight)
+	require.Greater(t, inFlightCount, uint64(0), "accounting should expose the live sent nonce as in_flight")
+	testutil.RequireAccountingResponseCoherent(t, inFlight, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, inFlight)
+
+	select {
+	case result := <-done:
+		require.NoError(t, result.Err)
+		testutil.LogRawResponse(t, "accounting live send timeout completion", result.Response)
+		testutil.RequireOpenAINonStreamingCompletion(t, result.Response)
+	case <-time.After(testutil.DefaultRequestTimeout):
+		t.Fatal("timed out waiting for timeout-backed completion")
+	}
+
+	accounting := testutil.WaitAccountingParticipants(t, client, env.statsURL, "model=stub-model", func(resp testutil.AccountingParticipantsResponse) bool {
+		return len(resp.Participants) > 0 &&
+			testutil.AccountingInFlightTotal(resp) < inFlightCount &&
+			testutil.AccountingUnfinishedTotal(resp) > beforeUnfinished
+	})
+	require.Less(t, testutil.AccountingInFlightTotal(accounting), inFlightCount, "timed-out live send should leave the in_flight bucket")
+	require.Greater(t, testutil.AccountingUnfinishedTotal(accounting), beforeUnfinished, "timed-out live send should become an unfinished disposition")
+	testutil.RequireAccountingResponseCoherent(t, accounting, "stub-model")
+	testutil.RequireNonceAccountingBalanced(t, accounting)
 }
 
 // Test flow:

--- a/devshard/e2e/containers_test.go
+++ b/devshard/e2e/containers_test.go
@@ -33,11 +33,13 @@ type e2eEnv struct {
 	network     testcontainers.Network
 	containers  []namedContainer
 	clientURL   string
+	statsURL    string
 
-	images          e2eImages
-	hostURLs        []string
-	hostVolumeNames []string
-	usePostgres     bool
+	images           e2eImages
+	hostURLs         []string
+	hostVolumeNames  []string
+	hostEnvOverrides map[int]map[string]string
+	usePostgres      bool
 }
 
 type namedContainer struct {
@@ -49,6 +51,7 @@ type containerSpec struct {
 	name              string
 	image             string
 	port              string
+	extraPorts        []string
 	aliases           []string
 	env               map[string]string
 	tmpfs             map[string]string
@@ -60,6 +63,7 @@ type containerSpec struct {
 
 type e2eEnvOptions struct {
 	hostVolumeNames    []string
+	hostEnvOverrides   map[int]map[string]string
 	usePostgresStorage bool
 }
 
@@ -88,11 +92,12 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 	t.Cleanup(func() { _ = network.Remove(context.Background()) })
 
 	env := &e2eEnv{
-		networkName:     networkName,
-		network:         network,
-		images:          images,
-		hostVolumeNames: opts.hostVolumeNames,
-		usePostgres:     opts.usePostgresStorage,
+		networkName:      networkName,
+		network:          network,
+		images:           images,
+		hostVolumeNames:  opts.hostVolumeNames,
+		hostEnvOverrides: opts.hostEnvOverrides,
+		usePostgres:      opts.usePostgresStorage,
 	}
 	if len(opts.hostVolumeNames) > 0 {
 		t.Cleanup(func() { removeDockerVolumes(context.Background(), t, opts.hostVolumeNames) })
@@ -121,7 +126,7 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 		tmpfs: map[string]string{
 			"/tmp/pgdata": "rw",
 		},
-		waitLog: "database system is ready to accept connections",
+		waitLog:           "database system is ready to accept connections",
 		waitLogOccurrence: 2,
 	})
 
@@ -137,20 +142,24 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 	}
 
 	devshardctl := env.startContainer(ctx, t, containerSpec{
-		name:    devshardCtlName,
-		image:   images.devshardctl,
-		port:    "8080/tcp",
+		name:  devshardCtlName,
+		image: images.devshardctl,
+		port:  "8080/tcp",
+		extraPorts: []string{
+			"9091/tcp",
+		},
 		aliases: []string{devshardCtlName},
 		env: map[string]string{
-			"DEVSHARD_ESCROW_ID":       defaultEscrowID,
-			"DEVSHARD_CHAIN_GRPC":      mockChainAlias + ":9090",
-			"DEVSHARD_PUBLIC_API":      "http://" + mockChainAlias + ":9191",
-			"DEVSHARD_PARAMS_SOURCE":   "chain",
-			"DEVSHARD_PRIVATE_KEY":     testutil.EnvDefault("DEVSHARD_E2E_USER_PRIVATE_KEY", testutil.UserPrivateKey),
-			"DEVSHARD_ADMIN_API_KEY":   testutil.AdminAPIKey,
-			"DEVSHARD_STORAGE_PATH":    "/tmp/devshardctl",
-			"DEVSHARD_MODEL":           "stub-model",
-			"GATEWAY_MAX_TOKENS_CAP":   "4096",
+			"DEVSHARD_ESCROW_ID":     defaultEscrowID,
+			"DEVSHARD_CHAIN_GRPC":    mockChainAlias + ":9090",
+			"DEVSHARD_PUBLIC_API":    "http://" + mockChainAlias + ":9191",
+			"DEVSHARD_PARAMS_SOURCE": "chain",
+			"DEVSHARD_PRIVATE_KEY":   testutil.EnvDefault("DEVSHARD_E2E_USER_PRIVATE_KEY", testutil.UserPrivateKey),
+			"DEVSHARD_ADMIN_API_KEY": testutil.AdminAPIKey,
+			"DEVSHARD_STORAGE_PATH":  "/tmp/devshardctl",
+			"DEVSHARD_MODEL":         "stub-model",
+			"GATEWAY_MAX_TOKENS_CAP": "4096",
+			"DEVSHARD_STATS_PORT":    "9091",
 		},
 		waitPath: "/v1/status",
 	})
@@ -161,6 +170,10 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 	require.NoError(t, err)
 	env.clientURL = "http://" + host + ":" + port.Port()
 	testutil.DebugLogf(t, "devshardctl client URL: %s", env.clientURL)
+	statsPort, err := devshardctl.MappedPort(ctx, "9091/tcp")
+	require.NoError(t, err)
+	env.statsURL = "http://" + host + ":" + statsPort.Port()
+	testutil.DebugLogf(t, "devshardctl accounting stats URL: %s", env.statsURL)
 
 	require.NotNil(t, mockChain)
 	require.NotNil(t, postgres)
@@ -213,9 +226,13 @@ func (e *e2eEnv) startHost(ctx context.Context, t *testing.T, index int) testcon
 		"DEVSHARD_HOST_PRIVATE_KEYS": strings.Join(testutil.HostPrivateKeys, ","),
 		"DEVSHARD_USER_PRIVATE_KEY":  testutil.UserPrivateKey,
 		"DEVSHARD_PEER_URLS":         strings.Join(e.hostURLs, ","),
+		"DEVSHARD_E2E":               "1",
 		"DEVSHARD_STUB_INFERENCE":    "1",
 	}
 	for k, v := range e2eHostSessionEnv() {
+		env[k] = v
+	}
+	for k, v := range e.hostEnvOverrides[index] {
 		env[k] = v
 	}
 	var mounts []mount.Mount
@@ -280,6 +297,7 @@ func (e *e2eEnv) startContainer(ctx context.Context, t *testing.T, spec containe
 	t.Helper()
 	testutil.DebugLogf(t, "starting container %s image=%s aliases=%s port=%s waitPath=%s waitLog=%q",
 		spec.name, spec.image, strings.Join(spec.aliases, ","), spec.port, spec.waitPath, spec.waitLog)
+	exposedPorts := append([]string{spec.port}, spec.extraPorts...)
 
 	var waitStrategy wait.Strategy
 	if spec.waitLog != "" {
@@ -300,7 +318,7 @@ func (e *e2eEnv) startContainer(ctx context.Context, t *testing.T, spec containe
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:          spec.image,
 			Env:            spec.env,
-			ExposedPorts:   []string{spec.port},
+			ExposedPorts:   exposedPorts,
 			Networks:       []string{e.networkName},
 			NetworkAliases: map[string][]string{e.networkName: spec.aliases},
 			Tmpfs:          spec.tmpfs,

--- a/devshard/e2e/containers_test.go
+++ b/devshard/e2e/containers_test.go
@@ -62,9 +62,10 @@ type containerSpec struct {
 }
 
 type e2eEnvOptions struct {
-	hostVolumeNames    []string
-	hostEnvOverrides   map[int]map[string]string
-	usePostgresStorage bool
+	hostVolumeNames         []string
+	hostEnvOverrides        map[int]map[string]string
+	usePostgresStorage      bool
+	devshardctlEnvOverrides map[string]string
 }
 
 func startHappyPathEnv(ctx context.Context, t *testing.T, images e2eImages) *e2eEnv {
@@ -141,6 +142,22 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 		env.startHost(ctx, t, i)
 	}
 
+	devshardctlEnv := map[string]string{
+		"DEVSHARD_E2E":           "1",
+		"DEVSHARD_ESCROW_ID":     defaultEscrowID,
+		"DEVSHARD_CHAIN_GRPC":    mockChainAlias + ":9090",
+		"DEVSHARD_PUBLIC_API":    "http://" + mockChainAlias + ":9191",
+		"DEVSHARD_PARAMS_SOURCE": "chain",
+		"DEVSHARD_PRIVATE_KEY":   testutil.EnvDefault("DEVSHARD_E2E_USER_PRIVATE_KEY", testutil.UserPrivateKey),
+		"DEVSHARD_ADMIN_API_KEY": testutil.AdminAPIKey,
+		"DEVSHARD_STORAGE_PATH":  "/tmp/devshardctl",
+		"DEVSHARD_MODEL":         "stub-model",
+		"GATEWAY_MAX_TOKENS_CAP": "4096",
+		"DEVSHARD_STATS_PORT":    "9091",
+	}
+	for k, v := range opts.devshardctlEnvOverrides {
+		devshardctlEnv[k] = v
+	}
 	devshardctl := env.startContainer(ctx, t, containerSpec{
 		name:  devshardCtlName,
 		image: images.devshardctl,
@@ -148,19 +165,8 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 		extraPorts: []string{
 			"9091/tcp",
 		},
-		aliases: []string{devshardCtlName},
-		env: map[string]string{
-			"DEVSHARD_ESCROW_ID":     defaultEscrowID,
-			"DEVSHARD_CHAIN_GRPC":    mockChainAlias + ":9090",
-			"DEVSHARD_PUBLIC_API":    "http://" + mockChainAlias + ":9191",
-			"DEVSHARD_PARAMS_SOURCE": "chain",
-			"DEVSHARD_PRIVATE_KEY":   testutil.EnvDefault("DEVSHARD_E2E_USER_PRIVATE_KEY", testutil.UserPrivateKey),
-			"DEVSHARD_ADMIN_API_KEY": testutil.AdminAPIKey,
-			"DEVSHARD_STORAGE_PATH":  "/tmp/devshardctl",
-			"DEVSHARD_MODEL":         "stub-model",
-			"GATEWAY_MAX_TOKENS_CAP": "4096",
-			"DEVSHARD_STATS_PORT":    "9091",
-		},
+		aliases:  []string{devshardCtlName},
+		env:      devshardctlEnv,
 		waitPath: "/v1/status",
 	})
 

--- a/devshard/e2e/non_streaming_test.go
+++ b/devshard/e2e/non_streaming_test.go
@@ -146,13 +146,18 @@ func TestE2E_NonStreamingRejectsInvalidRequest(t *testing.T) {
 
 func startNonStreamingEnv(t *testing.T) (*e2eEnv, *http.Client) {
 	t.Helper()
+	return startNonStreamingEnvWithOptions(t, e2eEnvOptions{})
+}
+
+func startNonStreamingEnvWithOptions(t *testing.T, opts e2eEnvOptions) (*e2eEnv, *http.Client) {
+	t.Helper()
 	requireE2EEnabled(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
 
 	images := requiredImages(t)
-	env := startHappyPathEnv(ctx, t, images)
+	env := startE2EEnv(ctx, t, images, opts)
 	client := &http.Client{Timeout: testutil.DefaultRequestTimeout}
 	return env, client
 }

--- a/devshard/e2e/testutil/accounting.go
+++ b/devshard/e2e/testutil/accounting.go
@@ -126,6 +126,14 @@ func AccountingDispositionTotal(resp AccountingParticipantsResponse) uint64 {
 	return total
 }
 
+func AccountingDispositionCount(resp AccountingParticipantsResponse, disposition string) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		total += participant.Dispositions[disposition]
+	}
+	return total
+}
+
 func AccountingParticipantDispositionTotal(participant AccountingParticipant) uint64 {
 	var total uint64
 	for _, count := range participant.Dispositions {

--- a/devshard/e2e/testutil/accounting.go
+++ b/devshard/e2e/testutil/accounting.go
@@ -150,6 +150,11 @@ func AccountingInFlightTotal(resp AccountingParticipantsResponse) uint64 {
 	return total
 }
 
+func AccountingUnfinishedTotal(resp AccountingParticipantsResponse) uint64 {
+	return AccountingDispositionCount(resp, "unfinished_refused") +
+		AccountingDispositionCount(resp, "unfinished_execution")
+}
+
 func RequireAccountingResponseCoherent(t *testing.T, resp AccountingParticipantsResponse, expectedModel string) {
 	t.Helper()
 	require.NotZero(t, resp.SchemaVersion, "accounting response should declare a schema version")

--- a/devshard/e2e/testutil/accounting.go
+++ b/devshard/e2e/testutil/accounting.go
@@ -1,0 +1,184 @@
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type AccountingParticipantsResponse struct {
+	SchemaVersion   int                     `json:"schema_version"`
+	RecordingErrors uint64                  `json:"recording_errors"`
+	WriterErrors    uint64                  `json:"writer_errors"`
+	EpochIndex      uint64                  `json:"epoch_index"`
+	Participants    []AccountingParticipant `json:"participants"`
+}
+
+type AccountingParticipant struct {
+	Participant           string            `json:"participant"`
+	Model                 string            `json:"model"`
+	AssignedNonces        uint64            `json:"assigned_nonces"`
+	Dispositions          map[string]uint64 `json:"dispositions"`
+	InFlight              uint64            `json:"in_flight"`
+	TimeoutPending        uint64            `json:"timeout_pending"`
+	PendingClassification uint64            `json:"pending_classification"`
+	Unclassified          uint64            `json:"unclassified"`
+	Overclassified        uint64            `json:"overclassified"`
+	CrossChecks           AccountingChecks  `json:"cross_checks"`
+}
+
+type AccountingChecks struct {
+	ErrorCount uint64 `json:"error_count"`
+}
+
+func WaitAccountingParticipants(
+	t *testing.T,
+	client *http.Client,
+	statsURL string,
+	query string,
+	ready func(AccountingParticipantsResponse) bool,
+) AccountingParticipantsResponse {
+	t.Helper()
+	deadline := time.Now().Add(DefaultRequestTimeout)
+	var last AccountingParticipantsResponse
+	var lastStatus int
+	var lastBody string
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		last, lastStatus, lastBody, lastErr = fetchAccountingParticipants(t, client, statsURL, query)
+		if lastErr == nil && lastStatus >= http.StatusOK && lastStatus < http.StatusMultipleChoices {
+			if ready == nil || ready(last) {
+				return last
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	require.NoError(t, lastErr)
+	require.GreaterOrEqual(t, lastStatus, http.StatusOK, "GET accounting participants: %s", lastBody)
+	require.Less(t, lastStatus, http.StatusMultipleChoices, "GET accounting participants: %s", lastBody)
+	if ready != nil {
+		require.True(t, ready(last), "accounting participants did not reach expected state: %+v", last)
+	}
+	return last
+}
+
+func fetchAccountingParticipants(
+	t *testing.T,
+	client *http.Client,
+	statsURL string,
+	query string,
+) (AccountingParticipantsResponse, int, string, error) {
+	t.Helper()
+	endpoint := strings.TrimRight(statsURL, "/") + "/api/v1/epochs/current/participants"
+	if query != "" {
+		endpoint += "?" + query
+	}
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return AccountingParticipantsResponse{}, 0, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+AdminAPIKey)
+	DebugLogf(t, "GET %s", endpoint)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return AccountingParticipantsResponse{}, 0, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return AccountingParticipantsResponse{}, resp.StatusCode, "", err
+	}
+	DebugLogf(t, "GET %s status=%d response=%s", endpoint, resp.StatusCode, string(body))
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return AccountingParticipantsResponse{}, resp.StatusCode, string(body), nil
+	}
+
+	var decoded AccountingParticipantsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return AccountingParticipantsResponse{}, resp.StatusCode, string(body), fmt.Errorf("decode accounting response: %w", err)
+	}
+	return decoded, resp.StatusCode, string(body), nil
+}
+
+func AccountingAssignedTotal(resp AccountingParticipantsResponse) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		total += participant.AssignedNonces
+	}
+	return total
+}
+
+func AccountingDispositionTotal(resp AccountingParticipantsResponse) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		total += AccountingParticipantDispositionTotal(participant)
+	}
+	return total
+}
+
+func AccountingParticipantDispositionTotal(participant AccountingParticipant) uint64 {
+	var total uint64
+	for _, count := range participant.Dispositions {
+		total += count
+	}
+	return total
+}
+
+func AccountingInFlightTotal(resp AccountingParticipantsResponse) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		total += participant.InFlight
+	}
+	return total
+}
+
+func RequireAccountingResponseCoherent(t *testing.T, resp AccountingParticipantsResponse, expectedModel string) {
+	t.Helper()
+	require.NotZero(t, resp.SchemaVersion, "accounting response should declare a schema version")
+	require.NotZero(t, resp.EpochIndex, "accounting response should resolve the current epoch")
+	require.Zero(t, resp.RecordingErrors, "accounting recorder should not report dropped event errors")
+	require.Zero(t, resp.WriterErrors, "accounting snapshot writer should not report errors")
+	require.NotEmpty(t, resp.Participants, "accounting response should include participant records")
+
+	for _, participant := range resp.Participants {
+		require.NotEmpty(t, participant.Participant, "participant address should be populated")
+		if expectedModel != "" {
+			require.Equal(t, expectedModel, participant.Model)
+		}
+		require.Zero(t, participant.Overclassified, "participant %s should not overclassify assigned nonces", participant.Participant)
+		require.Zero(t, participant.CrossChecks.ErrorCount, "participant %s should not have accounting cross-check errors", participant.Participant)
+	}
+}
+
+func RequireNonceAccountingBalanced(t *testing.T, resp AccountingParticipantsResponse) {
+	t.Helper()
+	for _, participant := range resp.Participants {
+		dispositionTotal := AccountingParticipantDispositionTotal(participant)
+		accounted := dispositionTotal +
+			participant.InFlight +
+			participant.PendingClassification +
+			participant.Unclassified
+
+		require.Equal(t, participant.AssignedNonces, accounted,
+			"participant %s model %s should account every assigned nonce exactly once: dispositions=%d in_flight=%d pending_classification=%d unclassified=%d assigned=%d",
+			participant.Participant,
+			participant.Model,
+			dispositionTotal,
+			participant.InFlight,
+			participant.PendingClassification,
+			participant.Unclassified,
+			participant.AssignedNonces,
+		)
+		require.Zero(t, participant.Overclassified, "participant %s should not overclassify assigned nonces", participant.Participant)
+	}
+}

--- a/devshard/e2e/testutil/accounting.go
+++ b/devshard/e2e/testutil/accounting.go
@@ -21,18 +21,39 @@ type AccountingParticipantsResponse struct {
 }
 
 type AccountingParticipant struct {
-	Participant           string            `json:"participant"`
-	Model                 string            `json:"model"`
-	AssignedNonces        uint64            `json:"assigned_nonces"`
-	Dispositions          map[string]uint64 `json:"dispositions"`
-	TimeoutOutcomes       map[string]uint64 `json:"timeout_outcomes"`
-	ProtocolMisses        uint64            `json:"protocol_misses"`
-	InFlight              uint64            `json:"in_flight"`
-	TimeoutPending        uint64            `json:"timeout_pending"`
-	PendingClassification uint64            `json:"pending_classification"`
-	Unclassified          uint64            `json:"unclassified"`
-	Overclassified        uint64            `json:"overclassified"`
-	CrossChecks           AccountingChecks  `json:"cross_checks"`
+	Participant           string              `json:"participant"`
+	Model                 string              `json:"model"`
+	AssignedNonces        uint64              `json:"assigned_nonces"`
+	Dispositions          map[string]uint64   `json:"dispositions"`
+	TimeoutOutcomes       map[string]uint64   `json:"timeout_outcomes"`
+	ProtocolMisses        uint64              `json:"protocol_misses"`
+	InFlight              uint64              `json:"in_flight"`
+	TimeoutPending        uint64              `json:"timeout_pending"`
+	PendingClassification uint64              `json:"pending_classification"`
+	Unclassified          uint64              `json:"unclassified"`
+	Overclassified        uint64              `json:"overclassified"`
+	CrossChecks           AccountingChecks    `json:"cross_checks"`
+	Counters              []AccountingCounter `json:"counters"`
+}
+
+type AccountingCounter struct {
+	EscrowID string               `json:"escrow_id"`
+	Key      AccountingCounterKey `json:"key"`
+	Count    uint64               `json:"count"`
+}
+
+type AccountingCounterKey struct {
+	SlotID                 uint32 `json:"slot_id"`
+	Disposition            string `json:"disposition"`
+	DispatchPhase          string `json:"dispatch_phase,omitempty"`
+	TimeoutEvaluationPhase string `json:"timeout_evaluation_phase,omitempty"`
+	QuarantineMode         string `json:"quarantine_mode,omitempty"`
+	NoSendReason           string `json:"no_send_reason,omitempty"`
+	FailureOrigin          string `json:"failure_origin,omitempty"`
+	DetailReason           string `json:"detail_reason,omitempty"`
+	TimeoutKind            string `json:"timeout_kind,omitempty"`
+	TimeoutOutcome         string `json:"timeout_outcome,omitempty"`
+	TimeoutReason          string `json:"timeout_reason,omitempty"`
 }
 
 type AccountingChecks struct {
@@ -136,6 +157,25 @@ func AccountingDispositionCount(resp AccountingParticipantsResponse, disposition
 	var total uint64
 	for _, participant := range resp.Participants {
 		total += participant.Dispositions[disposition]
+	}
+	return total
+}
+
+func AccountingGhostCounterCount(resp AccountingParticipantsResponse, noSendReason, quarantineMode string) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		for _, counter := range participant.Counters {
+			if counter.Key.Disposition != "ghost" {
+				continue
+			}
+			if noSendReason != "" && counter.Key.NoSendReason != noSendReason {
+				continue
+			}
+			if quarantineMode != "" && counter.Key.QuarantineMode != quarantineMode {
+				continue
+			}
+			total += counter.Count
+		}
 	}
 	return total
 }

--- a/devshard/e2e/testutil/accounting.go
+++ b/devshard/e2e/testutil/accounting.go
@@ -25,6 +25,8 @@ type AccountingParticipant struct {
 	Model                 string            `json:"model"`
 	AssignedNonces        uint64            `json:"assigned_nonces"`
 	Dispositions          map[string]uint64 `json:"dispositions"`
+	TimeoutOutcomes       map[string]uint64 `json:"timeout_outcomes"`
+	ProtocolMisses        uint64            `json:"protocol_misses"`
 	InFlight              uint64            `json:"in_flight"`
 	TimeoutPending        uint64            `json:"timeout_pending"`
 	PendingClassification uint64            `json:"pending_classification"`
@@ -34,7 +36,11 @@ type AccountingParticipant struct {
 }
 
 type AccountingChecks struct {
-	ErrorCount uint64 `json:"error_count"`
+	TimeoutApplied  uint64 `json:"timeout_applied"`
+	HostMissed      uint64 `json:"host_missed"`
+	RecordedInvalid uint64 `json:"recorded_invalid_transitions"`
+	HostInvalid     uint64 `json:"host_invalid"`
+	ErrorCount      uint64 `json:"error_count"`
 }
 
 func WaitAccountingParticipants(
@@ -130,6 +136,38 @@ func AccountingDispositionCount(resp AccountingParticipantsResponse, disposition
 	var total uint64
 	for _, participant := range resp.Participants {
 		total += participant.Dispositions[disposition]
+	}
+	return total
+}
+
+func AccountingTimeoutOutcomeCount(resp AccountingParticipantsResponse, outcome string) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		total += participant.TimeoutOutcomes[outcome]
+	}
+	return total
+}
+
+func AccountingProtocolMissTotal(resp AccountingParticipantsResponse) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		total += participant.ProtocolMisses
+	}
+	return total
+}
+
+func AccountingCrossCheckTimeoutAppliedTotal(resp AccountingParticipantsResponse) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		total += participant.CrossChecks.TimeoutApplied
+	}
+	return total
+}
+
+func AccountingCrossCheckHostMissedTotal(resp AccountingParticipantsResponse) uint64 {
+	var total uint64
+	for _, participant := range resp.Participants {
+		total += participant.CrossChecks.HostMissed
 	}
 	return total
 }

--- a/devshard/e2e/testutil/client.go
+++ b/devshard/e2e/testutil/client.go
@@ -17,6 +17,11 @@ type RawResponse struct {
 	JSON        map[string]any
 }
 
+type RawResponseResult struct {
+	Response RawResponse
+	Err      error
+}
+
 func LogRawResponse(t *testing.T, label string, resp RawResponse) {
 	t.Helper()
 	t.Logf("%s response: status=%d content_type=%q body=%s", label, resp.StatusCode, resp.ContentType, resp.Body)
@@ -37,25 +42,45 @@ func PostJSONRaw(t *testing.T, client *http.Client, url string, body map[string]
 	return PostRaw(t, client, url, "application/json", data, bearerToken)
 }
 
+func PostJSONRawE(client *http.Client, url string, body map[string]any, bearerToken string) (RawResponse, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return RawResponse{}, err
+	}
+	return PostRawE(client, url, "application/json", data, bearerToken)
+}
+
 func PostRaw(t *testing.T, client *http.Client, url, contentType string, body []byte, bearerToken string) RawResponse {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	DebugLogf(t, "POST %s request=%s", url, string(body))
+	resp, err := PostRawE(client, url, contentType, body, bearerToken)
 	require.NoError(t, err)
+	DebugLogf(t, "POST %s status=%d response=%s", url, resp.StatusCode, resp.Body)
+	return resp
+}
+
+func PostRawE(client *http.Client, url, contentType string, body []byte, bearerToken string) (RawResponse, error) {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return RawResponse{}, err
+	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
 	if bearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+bearerToken)
 	}
-	DebugLogf(t, "POST %s request=%s", url, string(body))
 
 	resp, err := client.Do(req)
-	require.NoError(t, err)
+	if err != nil {
+		return RawResponse{}, err
+	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	DebugLogf(t, "POST %s status=%d response=%s", url, resp.StatusCode, string(respBody))
+	if err != nil {
+		return RawResponse{}, err
+	}
 
 	var decoded map[string]any
 	if len(bytes.TrimSpace(respBody)) > 0 {
@@ -66,7 +91,7 @@ func PostRaw(t *testing.T, client *http.Client, url, contentType string, body []
 		ContentType: resp.Header.Get("Content-Type"),
 		Body:        string(respBody),
 		JSON:        decoded,
-	}
+	}, nil
 }
 
 func GetJSON(t *testing.T, client *http.Client, url string) map[string]any {

--- a/devshard/e2e/testutil/requests.go
+++ b/devshard/e2e/testutil/requests.go
@@ -83,6 +83,25 @@ func ChatCompletionBody(content string, stream bool) map[string]any {
 	return body
 }
 
+const ToolChoiceUnsupportedMessage = "tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set"
+
+func ToolCompletionBody(content string, stream bool) map[string]any {
+	body := ChatCompletionBody(content, stream)
+	body["tool_choice"] = "auto"
+	body["tools"] = []map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "lookup_status",
+			"description": "Return a test status string.",
+			"parameters": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+	}}
+	return body
+}
+
 func readSSEEvents(t *testing.T, body io.Reader) (string, []string) {
 	t.Helper()
 	var raw strings.Builder

--- a/devshard/e2e/testutil/requests.go
+++ b/devshard/e2e/testutil/requests.go
@@ -27,6 +27,10 @@ func SendCompletionRaw(t *testing.T, client *http.Client, clientURL, content, be
 	return PostJSONRaw(t, client, clientURL+"/v1/chat/completions", ChatCompletionBody(content, false), bearerToken)
 }
 
+func SendCompletionRawE(client *http.Client, clientURL, content, bearerToken string) (RawResponse, error) {
+	return PostJSONRawE(client, clientURL+"/v1/chat/completions", ChatCompletionBody(content, false), bearerToken)
+}
+
 type StreamResponse struct {
 	ContentType string
 	Events      []string

--- a/devshard/internal/e2econfig/session_timeouts.go
+++ b/devshard/internal/e2econfig/session_timeouts.go
@@ -1,0 +1,69 @@
+package e2econfig
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"devshard/types"
+)
+
+const (
+	RefusalTimeoutSecondsEnv   = "DEVSHARD_E2E_REFUSAL_TIMEOUT_SECONDS"
+	ExecutionTimeoutSecondsEnv = "DEVSHARD_E2E_EXECUTION_TIMEOUT_SECONDS"
+)
+
+type SessionTimeoutOverrides struct {
+	RefusalTimeoutSeconds   *int64
+	ExecutionTimeoutSeconds *int64
+}
+
+func SessionTimeoutOverridesFromEnv() (SessionTimeoutOverrides, error) {
+	refusalTimeout, ok, err := sessionTimeoutSecondsEnv(RefusalTimeoutSecondsEnv)
+	if err != nil {
+		return SessionTimeoutOverrides{}, err
+	}
+	overrides := SessionTimeoutOverrides{}
+	if ok {
+		overrides.RefusalTimeoutSeconds = &refusalTimeout
+	}
+
+	executionTimeout, ok, err := sessionTimeoutSecondsEnv(ExecutionTimeoutSecondsEnv)
+	if err != nil {
+		return SessionTimeoutOverrides{}, err
+	}
+	if ok {
+		overrides.ExecutionTimeoutSeconds = &executionTimeout
+	}
+
+	return overrides, nil
+}
+
+func (o SessionTimeoutOverrides) Apply(config types.SessionConfig) types.SessionConfig {
+	if o.RefusalTimeoutSeconds != nil {
+		config.RefusalTimeout = *o.RefusalTimeoutSeconds
+	}
+	if o.ExecutionTimeoutSeconds != nil {
+		config.ExecutionTimeout = *o.ExecutionTimeoutSeconds
+	}
+	return config
+}
+
+func sessionTimeoutSecondsEnv(name string) (int64, bool, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0, false, nil
+	}
+	if os.Getenv("DEVSHARD_E2E") != "1" {
+		return 0, false, fmt.Errorf("%s is only supported when DEVSHARD_E2E=1", name)
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	if value < 0 {
+		return 0, false, fmt.Errorf("invalid %s: must be non-negative", name)
+	}
+	return value, true, nil
+}

--- a/devshard/internal/e2econfig/session_timeouts.go
+++ b/devshard/internal/e2econfig/session_timeouts.go
@@ -5,13 +5,16 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"devshard/types"
 )
 
 const (
-	RefusalTimeoutSecondsEnv   = "DEVSHARD_E2E_REFUSAL_TIMEOUT_SECONDS"
-	ExecutionTimeoutSecondsEnv = "DEVSHARD_E2E_EXECUTION_TIMEOUT_SECONDS"
+	RefusalTimeoutSecondsEnv    = "DEVSHARD_E2E_REFUSAL_TIMEOUT_SECONDS"
+	ExecutionTimeoutSecondsEnv  = "DEVSHARD_E2E_EXECUTION_TIMEOUT_SECONDS"
+	StubInferenceDelayMillisEnv = "DEVSHARD_STUB_INFERENCE_DELAY_MS"
+	ReceiptDelayMillisEnv       = "DEVSHARD_E2E_RECEIPT_DELAY_MS"
 )
 
 type SessionTimeoutOverrides struct {
@@ -50,7 +53,19 @@ func (o SessionTimeoutOverrides) Apply(config types.SessionConfig) types.Session
 	return config
 }
 
+func DurationMillisFromEnv(name string) (time.Duration, error) {
+	value, ok, err := e2eInt64Env(name)
+	if err != nil || !ok {
+		return 0, err
+	}
+	return time.Duration(value) * time.Millisecond, nil
+}
+
 func sessionTimeoutSecondsEnv(name string) (int64, bool, error) {
+	return e2eInt64Env(name)
+}
+
+func e2eInt64Env(name string) (int64, bool, error) {
 	raw := strings.TrimSpace(os.Getenv(name))
 	if raw == "" {
 		return 0, false, nil

--- a/devshard/internal/e2econfig/session_timeouts.go
+++ b/devshard/internal/e2econfig/session_timeouts.go
@@ -15,6 +15,8 @@ const (
 	ExecutionTimeoutSecondsEnv  = "DEVSHARD_E2E_EXECUTION_TIMEOUT_SECONDS"
 	StubInferenceDelayMillisEnv = "DEVSHARD_STUB_INFERENCE_DELAY_MS"
 	ReceiptDelayMillisEnv       = "DEVSHARD_E2E_RECEIPT_DELAY_MS"
+	StubInferenceSSEErrorEnv    = "DEVSHARD_STUB_INFERENCE_SSE_ERROR_MESSAGE"
+	StubInferenceHTTPStatusEnv  = "DEVSHARD_STUB_INFERENCE_HTTP_STATUS"
 )
 
 type SessionTimeoutOverrides struct {
@@ -59,6 +61,28 @@ func DurationMillisFromEnv(name string) (time.Duration, error) {
 		return 0, err
 	}
 	return time.Duration(value) * time.Millisecond, nil
+}
+
+func IntFromEnv(name string) (int, bool, error) {
+	value, ok, err := e2eInt64Env(name)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	if int64(int(value)) != value {
+		return 0, false, fmt.Errorf("invalid %s: value exceeds int range", name)
+	}
+	return int(value), true, nil
+}
+
+func StringFromEnv(name string) (string, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return "", nil
+	}
+	if os.Getenv("DEVSHARD_E2E") != "1" {
+		return "", fmt.Errorf("%s is only supported when DEVSHARD_E2E=1", name)
+	}
+	return raw, nil
 }
 
 func sessionTimeoutSecondsEnv(name string) (int64, bool, error) {

--- a/devshard/internal/e2econfig/session_timeouts.go
+++ b/devshard/internal/e2econfig/session_timeouts.go
@@ -11,12 +11,13 @@ import (
 )
 
 const (
-	RefusalTimeoutSecondsEnv    = "DEVSHARD_E2E_REFUSAL_TIMEOUT_SECONDS"
-	ExecutionTimeoutSecondsEnv  = "DEVSHARD_E2E_EXECUTION_TIMEOUT_SECONDS"
-	StubInferenceDelayMillisEnv = "DEVSHARD_STUB_INFERENCE_DELAY_MS"
-	ReceiptDelayMillisEnv       = "DEVSHARD_E2E_RECEIPT_DELAY_MS"
-	StubInferenceSSEErrorEnv    = "DEVSHARD_STUB_INFERENCE_SSE_ERROR_MESSAGE"
-	StubInferenceHTTPStatusEnv  = "DEVSHARD_STUB_INFERENCE_HTTP_STATUS"
+	RefusalTimeoutSecondsEnv     = "DEVSHARD_E2E_REFUSAL_TIMEOUT_SECONDS"
+	ExecutionTimeoutSecondsEnv   = "DEVSHARD_E2E_EXECUTION_TIMEOUT_SECONDS"
+	StubInferenceDelayMillisEnv  = "DEVSHARD_STUB_INFERENCE_DELAY_MS"
+	ReceiptDelayMillisEnv        = "DEVSHARD_E2E_RECEIPT_DELAY_MS"
+	StubInferenceSSEErrorEnv     = "DEVSHARD_STUB_INFERENCE_SSE_ERROR_MESSAGE"
+	StubInferenceHTTPStatusEnv   = "DEVSHARD_STUB_INFERENCE_HTTP_STATUS"
+	StubInferenceResponseBodyEnv = "DEVSHARD_STUB_INFERENCE_RESPONSE_BODY"
 )
 
 type SessionTimeoutOverrides struct {

--- a/devshard/internal/e2econfig/session_timeouts_test.go
+++ b/devshard/internal/e2econfig/session_timeouts_test.go
@@ -1,0 +1,51 @@
+package e2econfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/types"
+)
+
+func TestSessionTimeoutOverridesFromEnv(t *testing.T) {
+	t.Setenv("DEVSHARD_E2E", "1")
+	t.Setenv(RefusalTimeoutSecondsEnv, "2")
+	t.Setenv(ExecutionTimeoutSecondsEnv, "3")
+
+	overrides, err := SessionTimeoutOverridesFromEnv()
+	config := overrides.Apply(types.SessionConfig{
+		RefusalTimeout:   60,
+		ExecutionTimeout: 1200,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, overrides.RefusalTimeoutSeconds)
+	require.NotNil(t, overrides.ExecutionTimeoutSeconds)
+	require.EqualValues(t, 2, config.RefusalTimeout)
+	require.EqualValues(t, 3, config.ExecutionTimeout)
+}
+
+func TestSessionTimeoutOverridesFromEnvRequiresE2E(t *testing.T) {
+	t.Setenv(RefusalTimeoutSecondsEnv, "1")
+
+	_, err := SessionTimeoutOverridesFromEnv()
+
+	require.ErrorContains(t, err, "only supported when DEVSHARD_E2E=1")
+}
+
+func TestSessionTimeoutOverridesFromEnvRejectsInvalidValues(t *testing.T) {
+	t.Setenv("DEVSHARD_E2E", "1")
+
+	t.Run("non numeric", func(t *testing.T) {
+		t.Setenv(RefusalTimeoutSecondsEnv, "soon")
+		_, err := SessionTimeoutOverridesFromEnv()
+		require.ErrorContains(t, err, "invalid "+RefusalTimeoutSecondsEnv)
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		t.Setenv(RefusalTimeoutSecondsEnv, "-1")
+		_, err := SessionTimeoutOverridesFromEnv()
+		require.ErrorContains(t, err, "must be non-negative")
+	})
+}

--- a/devshard/internal/e2econfig/session_timeouts_test.go
+++ b/devshard/internal/e2econfig/session_timeouts_test.go
@@ -2,6 +2,7 @@ package e2econfig
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -48,4 +49,21 @@ func TestSessionTimeoutOverridesFromEnvRejectsInvalidValues(t *testing.T) {
 		_, err := SessionTimeoutOverridesFromEnv()
 		require.ErrorContains(t, err, "must be non-negative")
 	})
+}
+
+func TestDurationMillisFromEnv(t *testing.T) {
+	t.Setenv("DEVSHARD_E2E", "1")
+	t.Setenv(ReceiptDelayMillisEnv, "250")
+
+	value, err := DurationMillisFromEnv(ReceiptDelayMillisEnv)
+
+	require.NoError(t, err)
+	require.Equal(t, 250*time.Millisecond, value)
+}
+
+func TestDurationMillisFromEnvAllowsUnset(t *testing.T) {
+	value, err := DurationMillisFromEnv(ReceiptDelayMillisEnv)
+
+	require.NoError(t, err)
+	require.Zero(t, value)
 }

--- a/devshard/internal/e2econfig/session_timeouts_test.go
+++ b/devshard/internal/e2econfig/session_timeouts_test.go
@@ -67,3 +67,40 @@ func TestDurationMillisFromEnvAllowsUnset(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, value)
 }
+
+func TestIntFromEnv(t *testing.T) {
+	t.Setenv("DEVSHARD_E2E", "1")
+	t.Setenv(StubInferenceHTTPStatusEnv, "503")
+
+	value, ok, err := IntFromEnv(StubInferenceHTTPStatusEnv)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 503, value)
+}
+
+func TestIntFromEnvAllowsUnset(t *testing.T) {
+	value, ok, err := IntFromEnv(StubInferenceHTTPStatusEnv)
+
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Zero(t, value)
+}
+
+func TestStringFromEnv(t *testing.T) {
+	t.Setenv("DEVSHARD_E2E", "1")
+	t.Setenv(StubInferenceSSEErrorEnv, "  upstream tool error  ")
+
+	value, err := StringFromEnv(StubInferenceSSEErrorEnv)
+
+	require.NoError(t, err)
+	require.Equal(t, "upstream tool error", value)
+}
+
+func TestStringFromEnvRequiresE2E(t *testing.T) {
+	t.Setenv(StubInferenceSSEErrorEnv, "upstream tool error")
+
+	_, err := StringFromEnv(StubInferenceSSEErrorEnv)
+
+	require.ErrorContains(t, err, "only supported when DEVSHARD_E2E=1")
+}

--- a/devshard/transport/server.go
+++ b/devshard/transport/server.go
@@ -30,15 +30,16 @@ const contextKeySender = "devshard_sender"
 
 // Server wraps a host.Host and exposes it over HTTP via Echo.
 type Server struct {
-	host        *host.Host
-	store       storage.Storage
-	gossip      *gossip.Gossip // nil until gossip is wired
-	verifier    signing.Verifier
-	userAddr    string               // session user address, allowed alongside group members
-	peerClients map[int]*HTTPClient  // slot index -> client, for timeout verification
-	rateLimit   *rateLimiter         // nil = no limiting
-	maxBodySize int64                // max request body bytes, 0 = no limit
-	bridge      bridge.MainnetBridge // optional, for warm key verification
+	host         *host.Host
+	store        storage.Storage
+	gossip       *gossip.Gossip // nil until gossip is wired
+	verifier     signing.Verifier
+	userAddr     string               // session user address, allowed alongside group members
+	peerClients  map[int]*HTTPClient  // slot index -> client, for timeout verification
+	rateLimit    *rateLimiter         // nil = no limiting
+	maxBodySize  int64                // max request body bytes, 0 = no limit
+	bridge       bridge.MainnetBridge // optional, for warm key verification
+	receiptDelay time.Duration        // optional test hook before receipt SSE write
 }
 
 // ServerOption configures the Server.
@@ -73,6 +74,12 @@ func WithBridge(b bridge.MainnetBridge) ServerOption {
 	return func(s *Server) { s.bridge = b }
 }
 
+// WithReceiptDelay delays the initial receipt SSE event. It is intended for
+// integration tests that need to observe pre-receipt gateway timeout paths.
+func WithReceiptDelay(delay time.Duration) ServerOption {
+	return func(s *Server) { s.receiptDelay = delay }
+}
+
 // NewServer creates an HTTP server wrapping the given host.
 // userAddr is the session user's address -- allowed alongside group members.
 func NewServer(
@@ -99,7 +106,6 @@ func (s *Server) Host() *host.Host { return s.host }
 
 // SetGossip attaches a gossip instance for nonce/tx propagation.
 func (s *Server) SetGossip(g *gossip.Gossip) { s.gossip = g }
-
 
 // writeJSON serializes v with goccy/go-json, bypassing Echo's default serializer.
 // TODO: set a custom echo.JSONSerializer using goccy/go-json on all Echo instances
@@ -355,6 +361,18 @@ func (s *Server) HandleInference(c echo.Context) (err error) {
 		Nonce:       resp.Nonce,
 		Receipt:     resp.Receipt,
 		ConfirmedAt: resp.ConfirmedAt,
+	}
+	if s.receiptDelay > 0 {
+		timer := time.NewTimer(s.receiptDelay)
+		select {
+		case <-c.Request().Context().Done():
+			timer.Stop()
+			if resp.ExecutionJob != nil {
+				s.host.ReleaseExecution(resp.InferenceID)
+			}
+			return nil
+		case <-timer.C:
+		}
 	}
 	receiptWrapper := map[string]interface{}{"devshard_receipt": receiptEvent}
 	if werr := writeSSEEvent(w, receiptWrapper); werr != nil {

--- a/devshard/user/httpsession.go
+++ b/devshard/user/httpsession.go
@@ -14,6 +14,7 @@ import (
 	"devshard/state"
 	"devshard/storage"
 	"devshard/transport"
+	"devshard/types"
 )
 
 // HTTPSessionConfig holds the parameters needed to create an HTTP-backed user session.
@@ -28,6 +29,10 @@ type HTTPSessionConfig struct {
 	// Escrow is an optional pre-fetched chain escrow. When set, NewHTTPSession
 	// skips Bridge.GetEscrow and builds the group from this value.
 	Escrow *bridge.EscrowInfo
+	// Optional bind-time timeout overrides. These are mainly for integration
+	// harnesses that need protocol timeouts shorter than production defaults.
+	RefusalTimeoutSeconds   *int64
+	ExecutionTimeoutSeconds *int64
 }
 
 func deferredWarmKeyResolver(resolve state.WarmKeyResolver) (state.WarmKeyResolver, func()) {
@@ -135,6 +140,13 @@ func NewHTTPSession(cfg HTTPSessionConfig) (*Session, *state.StateMachine, error
 	}
 
 	config := bridge.SessionConfigAtBind(len(group), escrow)
+	if cfg.RefusalTimeoutSeconds != nil {
+		config.RefusalTimeout = *cfg.RefusalTimeoutSeconds
+	}
+	if cfg.ExecutionTimeoutSeconds != nil {
+		config.ExecutionTimeout = *cfg.ExecutionTimeoutSeconds
+	}
+	config = types.NormalizeSessionConfig(config, len(group))
 
 	storagePath := resolveHTTPSessionStoragePath(cfg.EscrowID, cfg.StoragePath)
 	if err := os.MkdirAll(filepath.Dir(storagePath), 0755); err != nil {


### PR DESCRIPTION
## Summary

Adds unit and E2E coverage for gateway-dashboard nonce accounting so every consumed nonce has exactly one current disposition.

#### Nonce accounting schema link: 
https://github.com/gonka-ai/gonka/tree/gm/gateway-dashboard-impl/proposals/gateway-dashboard#nonce-accounting

Also adds small E2E/debug helpers used to force corner-case protocol paths:

- `stubInferenceEngineFromEnv` for overriding stub response body/hash in E2E
- session timeout overrides for shorter timeout-path tests
- receipt/inference delay controls used by focused accounting scenarios

Fixes flaky proxy test coverage for long non-stream empty responses:

- isolates the long non-stream timing test from relaxed PoC global state
- normal mode records timing without quarantine
- relaxed PoC suppresses empty-stream perf samples

## Nonce Accounting

Every `consumed_nonce` has exactly one current disposition:

| Status | Disposition | E2E test coverage |
| --- | --- | --- |
| `protocol_only_nonce` | `protocol_only` | Unit coverage; no focused E2E in this PR |
| `request_not_sent` | `ghost` | `TestE2E_AccountingFocusedGhostRequestNotSent`, `TestE2E_AccountingGhostCapabilityNoSendReason` |
| `real_send + deadline_not_reached` | `in_flight` | `TestE2E_AccountingLiveInFlightIsCountedOnce` |
| `protocol_finish + selected_winner` | `finished_used` | `TestE2E_AccountingHappyPath`, `TestE2E_AccountingNoResidualAfterFinishedTraffic`, `TestE2E_AccountingOverscheduledLoserFinishes` |
| `protocol_finish + known_non_winner` | `finished_unused` | `TestE2E_AccountingOverscheduledLoserFinishes` |
| `protocol_finish + usage_not_recoverable` | `finished_usage_unknown` | `TestE2E_AccountingFinishedUsageUnknown` |
| `deadline_reached_without_finish + no_receipt` | `unfinished_refused` | `TestE2E_AccountingNoReceiptTimeoutBecomesUnfinishedRefused` |
| `deadline_reached_without_finish + receipt_applied` | `unfinished_execution` | `TestE2E_AccountingLiveSendTimeout` |

## Verification

- `go test ./internal/e2econfig ./cmd/devshard-host ./e2e/testutil -count=1`
- `make e2e-images`
- `go test ./e2e -run TestE2E_AccountingFinishedUsageUnknown -count=1 -v`
- `go test ./e2e -run TestE2E_AccountingNoReceiptTimeoutBecomesUnfinishedRefused -count=1 -v`
- `go test ./e2e -run TestE2E_Accounting -count=1 -v`
- `git diff --check`