### PR TITLE
Fix/devshard timeout vote signed slot

### DIFF
--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -592,6 +592,7 @@ func (c *verifierClient) VerifyTimeout(_ context.Context, inferenceID uint64, re
 		InferenceId: inferenceID,
 		Reason:      reason,
 		Accept:      true,
+		VoterSlot:   voterSlot,
 	}
 	data, err := proto.Marshal(content)
 	if err != nil {

--- a/devshard/internal/testutil/testutil.go
+++ b/devshard/internal/testutil/testutil.go
@@ -118,19 +118,21 @@ func SignExecutorReceipt(t *testing.T, signer signing.Signer, escrowID string, i
 	return sig
 }
 
-func SignTimeoutVote(t *testing.T, signer signing.Signer, escrowID string, inferenceID uint64, reason types.TimeoutReason, accept bool) *types.TimeoutVote {
+func SignTimeoutVote(t *testing.T, signer signing.Signer, escrowID string, inferenceID uint64, reason types.TimeoutReason, accept bool, voterSlot uint32) *types.TimeoutVote {
 	t.Helper()
 	content := &types.TimeoutVoteContent{
 		EscrowId:    escrowID,
 		InferenceId: inferenceID,
 		Reason:      reason,
 		Accept:      accept,
+		VoterSlot:   voterSlot,
 	}
 	data, err := deterministicMarshal.Marshal(content)
 	require.NoError(t, err)
 	sig, err := signer.Sign(data)
 	require.NoError(t, err)
 	return &types.TimeoutVote{
+		VoterSlot: voterSlot,
 		Accept:    accept,
 		Signature: sig,
 	}

--- a/devshard/proto/devshard/v1/diff.proto
+++ b/devshard/proto/devshard/v1/diff.proto
@@ -40,11 +40,15 @@ message ExecutorReceiptContent {
 }
 
 // TimeoutVoteContent is what a host signs for a TimeoutVote.
+// voter_slot is included so the signature binds the vote to a specific
+// group slot; verifiers must not be able to reuse a signature under a
+// different claimed VoterSlot.
 message TimeoutVoteContent {
   string escrow_id = 1;
   uint64 inference_id = 2;
   TimeoutReason reason = 3;
   bool   accept = 4;
+  uint32 voter_slot = 5;
 }
 
 // StateSignatureContent is what a host signs for state attestation.

--- a/devshard/protocol/protocol_test.go
+++ b/devshard/protocol/protocol_test.go
@@ -468,8 +468,7 @@ func TestProtocol_Timeout_UserSide(t *testing.T) {
 	// Compose timeout: collect votes from non-executor hosts (slots 0, 2, 3).
 	var votes []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, hostSigners[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hostSigners[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, slot)
 		votes = append(votes, v)
 	}
 

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -1257,6 +1257,7 @@ func (sm *StateMachine) applyTimeout(msg *types.MsgTimeoutInference) error {
 			InferenceId: msg.InferenceId,
 			Reason:      msg.Reason,
 			Accept:      vote.Accept,
+			VoterSlot:   vote.VoterSlot,
 		}
 		voteData, err := deterministicMarshal.Marshal(voteContent)
 		if err != nil {

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -425,8 +425,7 @@ func TestApplyDiff_Timeout_Refused(t *testing.T) {
 
 	var votes []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, slot)
 		votes = append(votes, v)
 	}
 
@@ -465,8 +464,7 @@ func TestApplyDiff_Timeout_Execution(t *testing.T) {
 
 	var votes []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_EXECUTION, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_EXECUTION, true, slot)
 		votes = append(votes, v)
 	}
 
@@ -499,8 +497,7 @@ func TestApplyDiff_Timeout_WrongReason(t *testing.T) {
 	// reason=execution on pending -> fail.
 	var votes []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_EXECUTION, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_EXECUTION, true, slot)
 		votes = append(votes, v)
 	}
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
@@ -519,8 +516,7 @@ func TestApplyDiff_Timeout_WrongReason(t *testing.T) {
 
 	var votes2 []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, slot)
 		votes2 = append(votes2, v)
 	}
 	diff = testutil.SignDiff(t, user, "escrow-1", 3, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
@@ -547,8 +543,7 @@ func TestApplyDiff_Timeout_InsufficientVotes(t *testing.T) {
 	// Only 2 accept votes (need >2 for 5 total slots).
 	var votes []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2} {
-		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, slot)
 		votes = append(votes, v)
 	}
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
@@ -569,8 +564,7 @@ func TestApplyDiff_Timeout_AfterFinish(t *testing.T) {
 
 	var votes []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_EXECUTION, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_EXECUTION, true, slot)
 		votes = append(votes, v)
 	}
 
@@ -607,8 +601,7 @@ func TestApplyDiff_Timeout_MultiSlotWeight(t *testing.T) {
 	// One accept vote from signer2 (slot 4, weight=1) -- not enough alone.
 	// But signer1 (slot 3, weight=1) also votes accept -> total weight=2, still not >2.
 	// Need signer0 to vote (weight=3) for >2.
-	vote := testutil.SignTimeoutVote(t, signers[2], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-	vote.VoterSlot = 4 // signer2's slot
+	vote := testutil.SignTimeoutVote(t, signers[2], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, 4) // signer2's slot
 
 	// Single vote with weight=1 should fail (need >2).
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
@@ -619,8 +612,7 @@ func TestApplyDiff_Timeout_MultiSlotWeight(t *testing.T) {
 	require.ErrorIs(t, err, types.ErrInsufficientVotes)
 
 	// Now add signer0's vote (slot 0, weight=3). Total = 1+3 = 4 > 2.
-	vote0 := testutil.SignTimeoutVote(t, signers[0], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-	vote0.VoterSlot = 0
+	vote0 := testutil.SignTimeoutVote(t, signers[0], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, 0)
 
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
 		InferenceId: 1, Reason: types.TimeoutReason_TIMEOUT_REASON_REFUSED,
@@ -728,8 +720,7 @@ func TestApplyDiff_DuplicateTimeout(t *testing.T) {
 
 	var votes []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, slot)
 		votes = append(votes, v)
 	}
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
@@ -740,8 +731,7 @@ func TestApplyDiff_DuplicateTimeout(t *testing.T) {
 
 	var votes2 []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, slot)
 		votes2 = append(votes2, v)
 	}
 	diff = testutil.SignDiff(t, user, "escrow-1", 3, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
@@ -798,8 +788,7 @@ func TestApplyDiff_FullLifecycle(t *testing.T) {
 				if len(votes) >= 3 {
 					break
 				}
-				v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", infID, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-				v.VoterSlot = slot
+				v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", infID, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, slot)
 				votes = append(votes, v)
 			}
 			nonce++
@@ -973,12 +962,9 @@ func TestApplyDiff_Timeout_DuplicateVoterSlot(t *testing.T) {
 	require.NoError(t, err)
 
 	// Slot 0 votes twice.
-	v0a := testutil.SignTimeoutVote(t, hosts[0], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-	v0a.VoterSlot = 0
-	v0b := testutil.SignTimeoutVote(t, hosts[0], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-	v0b.VoterSlot = 0
-	v2 := testutil.SignTimeoutVote(t, hosts[2], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-	v2.VoterSlot = 2
+	v0a := testutil.SignTimeoutVote(t, hosts[0], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, 0)
+	v0b := testutil.SignTimeoutVote(t, hosts[0], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, 0)
+	v2 := testutil.SignTimeoutVote(t, hosts[2], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, 2)
 
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
 		InferenceId: 1, Reason: types.TimeoutReason_TIMEOUT_REASON_REFUSED, Votes: []*types.TimeoutVote{v0a, v0b, v2},
@@ -2822,8 +2808,7 @@ func TestWarmKey_TimeoutVoteWithWarmKey(t *testing.T) {
 	// Build timeout votes signed by warm keys for slots 0, 2, 3.
 	var votes []*types.TimeoutVote
 	for _, slot := range []uint32{0, 2, 3} {
-		v := testutil.SignTimeoutVote(t, warmSigners[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-		v.VoterSlot = slot
+		v := testutil.SignTimeoutVote(t, warmSigners[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, slot)
 		votes = append(votes, v)
 	}
 

--- a/devshard/state/vote_threshold_freeze_test.go
+++ b/devshard/state/vote_threshold_freeze_test.go
@@ -70,8 +70,7 @@ func TestVoteThreshold_StableAcrossValidationAndTimeout(t *testing.T) {
 	// Four accept timeout votes: weight 4 is not > threshold 4.
 	votes := make([]*types.TimeoutVote, 4)
 	for i := uint32(0); i < 4; i++ {
-		v := testutil.SignTimeoutVote(t, hosts[i], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-		v.VoterSlot = i
+		v := testutil.SignTimeoutVote(t, hosts[i], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, i)
 		votes[i] = v
 	}
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
@@ -82,8 +81,7 @@ func TestVoteThreshold_StableAcrossValidationAndTimeout(t *testing.T) {
 	require.Equal(t, voteThreshold, sm.VoteThreshold())
 
 	// Fifth accept vote resolves timeout; threshold unchanged.
-	v5 := testutil.SignTimeoutVote(t, hosts[4], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
-	v5.VoterSlot = 4
+	v5 := testutil.SignTimeoutVote(t, hosts[4], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true, 4)
 	votes = append(votes, v5)
 	diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
 		InferenceId: 1, Reason: types.TimeoutReason_TIMEOUT_REASON_REFUSED, Votes: votes,

--- a/devshard/transport/server.go
+++ b/devshard/transport/server.go
@@ -576,6 +576,7 @@ func signTimeoutVote(escrowID string, inferenceID uint64, reason types.TimeoutRe
 		InferenceId: inferenceID,
 		Reason:      reason,
 		Accept:      true,
+		VoterSlot:   voterSlot,
 	}
 	voteData, err := proto.Marshal(voteContent)
 	if err != nil {

--- a/devshard/types/diff.pb.go
+++ b/devshard/types/diff.pb.go
@@ -372,12 +372,16 @@ func (x *ExecutorReceiptContent) GetConfirmedAt() int64 {
 }
 
 // TimeoutVoteContent is what a host signs for a TimeoutVote.
+// voter_slot is included so the signature binds the vote to a specific
+// group slot; verifiers must not be able to reuse a signature under a
+// different claimed VoterSlot.
 type TimeoutVoteContent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	EscrowId      string                 `protobuf:"bytes,1,opt,name=escrow_id,json=escrowId,proto3" json:"escrow_id,omitempty"`
 	InferenceId   uint64                 `protobuf:"varint,2,opt,name=inference_id,json=inferenceId,proto3" json:"inference_id,omitempty"`
 	Reason        TimeoutReason          `protobuf:"varint,3,opt,name=reason,proto3,enum=devshard.v1.TimeoutReason" json:"reason,omitempty"`
 	Accept        bool                   `protobuf:"varint,4,opt,name=accept,proto3" json:"accept,omitempty"`
+	VoterSlot     uint32                 `protobuf:"varint,5,opt,name=voter_slot,json=voterSlot,proto3" json:"voter_slot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -438,6 +442,13 @@ func (x *TimeoutVoteContent) GetAccept() bool {
 		return x.Accept
 	}
 	return false
+}
+
+func (x *TimeoutVoteContent) GetVoterSlot() uint32 {
+	if x != nil {
+		return x.VoterSlot
+	}
+	return 0
 }
 
 // StateSignatureContent is what a host signs for state attestation.
@@ -536,12 +547,14 @@ const file_devshard_v1_diff_proto_rawDesc = "" +
 	"\n" +
 	"started_at\x18\x06 \x01(\x03R\tstartedAt\x12\x1b\n" +
 	"\tescrow_id\x18\a \x01(\tR\bescrowId\x12!\n" +
-	"\fconfirmed_at\x18\b \x01(\x03R\vconfirmedAt\"\xa0\x01\n" +
+	"\fconfirmed_at\x18\b \x01(\x03R\vconfirmedAt\"\xbf\x01\n" +
 	"\x12TimeoutVoteContent\x12\x1b\n" +
 	"\tescrow_id\x18\x01 \x01(\tR\bescrowId\x12!\n" +
 	"\finference_id\x18\x02 \x01(\x04R\vinferenceId\x122\n" +
 	"\x06reason\x18\x03 \x01(\x0e2\x1a.devshard.v1.TimeoutReasonR\x06reason\x12\x16\n" +
-	"\x06accept\x18\x04 \x01(\bR\x06accept\"i\n" +
+	"\x06accept\x18\x04 \x01(\bR\x06accept\x12\x1d\n" +
+	"\n" +
+	"voter_slot\x18\x05 \x01(\rR\tvoterSlot\"i\n" +
 	"\x15StateSignatureContent\x12\x1d\n" +
 	"\n" +
 	"state_root\x18\x01 \x01(\fR\tstateRoot\x12\x1b\n" +

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -1374,6 +1374,36 @@ func (s *Session) verifyStateSignature(nonce uint64, postRoot, signature []byte,
 	return nil
 }
 
+// verifyTimeoutVoteSignature recovers the signer of vote.Signature over
+// TimeoutVoteContent (including voter_slot) and requires it to match
+// expectedAddr (warm-key fallback allowed). Caller must already have bound
+// vote.VoterSlot to expectedAddr.
+func (s *Session) verifyTimeoutVoteSignature(
+	inferenceID uint64,
+	reason types.TimeoutReason,
+	vote *types.TimeoutVote,
+	expectedAddr string,
+) error {
+	voteData, err := proto.Marshal(&types.TimeoutVoteContent{
+		EscrowId:    s.escrowID,
+		InferenceId: inferenceID,
+		Reason:      reason,
+		Accept:      vote.Accept,
+		VoterSlot:   vote.VoterSlot,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal timeout vote: %w", err)
+	}
+	recovered, err := s.verifier.RecoverAddress(voteData, vote.Signature)
+	if err != nil {
+		return fmt.Errorf("%w: %v", types.ErrInvalidVoteSig, err)
+	}
+	if recovered != expectedAddr && !s.sm.CheckWarmKey(recovered, expectedAddr) {
+		return fmt.Errorf("%w: expected %s, got %s", types.ErrInvalidVoteSig, expectedAddr, recovered)
+	}
+	return nil
+}
+
 func (s *Session) fetchSignature(ctx context.Context, hostIdx int, nonce uint64, client HostClient) bool {
 	fetcher, ok := client.(SignatureFetcher)
 	if !ok {
@@ -2118,11 +2148,11 @@ func (s *Session) CollectTimeoutVotes(
 			continue // skip failed hosts
 		}
 		if res.vote != nil {
-			// Bind the response to the host we contacted. VoterSlot is not in
-			// the signed TimeoutVoteContent, so a byzantine verifier can claim
-			// another validator's slot; never count weight or append until the
-			// claimed slot belongs to the known responder (same pattern as
-			// fetchSignature / processResponse).
+			// Bind claimed voter_slot to the host we contacted, then verify the
+			// signature over TimeoutVoteContent (which includes voter_slot) so a
+			// byzantine verifier cannot reuse a signature under a different slot
+			// or count foreign weight. Same host-binding idea as fetchSignature /
+			// processResponse.
 			claimedAddr := s.sm.SlotAddress(res.vote.VoterSlot)
 			if claimedAddr == "" || claimedAddr != res.verifierAddr {
 				errors++
@@ -2141,6 +2171,24 @@ func (s *Session) CollectTimeoutVotes(
 					"subsystem", "session", "inference_id", inferenceID,
 					"verifier", res.verifierAddr, "voter_slot", res.vote.VoterSlot,
 					"claimed", claimedAddr)
+				continue
+			}
+			if err := s.verifyTimeoutVoteSignature(inferenceID, reason, res.vote, res.verifierAddr); err != nil {
+				errors++
+				logging.Stage(ctx, "timeout_vote_result",
+					logFields(
+						res.verifierAddr,
+						"outcome", "error",
+						"voter_slot", res.vote.VoterSlot,
+						"running_weight", accWeight,
+						"threshold", voteThreshold,
+						"error", err,
+					)...,
+				)
+				logging.Debug("timeout vote rejected: invalid signature",
+					"subsystem", "session", "inference_id", inferenceID,
+					"verifier", res.verifierAddr, "voter_slot", res.vote.VoterSlot,
+					"error", err)
 				continue
 			}
 			votes = append(votes, res.vote)

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -2118,16 +2118,41 @@ func (s *Session) CollectTimeoutVotes(
 			continue // skip failed hosts
 		}
 		if res.vote != nil {
+			// Bind the response to the host we contacted. VoterSlot is not in
+			// the signed TimeoutVoteContent, so a byzantine verifier can claim
+			// another validator's slot; never count weight or append until the
+			// claimed slot belongs to the known responder (same pattern as
+			// fetchSignature / processResponse).
+			claimedAddr := s.sm.SlotAddress(res.vote.VoterSlot)
+			if claimedAddr == "" || claimedAddr != res.verifierAddr {
+				errors++
+				logging.Stage(ctx, "timeout_vote_result",
+					logFields(
+						res.verifierAddr,
+						"outcome", "error",
+						"voter_slot", res.vote.VoterSlot,
+						"claimed_voter", shortAddress(claimedAddr),
+						"running_weight", accWeight,
+						"threshold", voteThreshold,
+						"error", "voter_slot not owned by responder",
+					)...,
+				)
+				logging.Debug("timeout vote rejected: voter_slot not owned by responder",
+					"subsystem", "session", "inference_id", inferenceID,
+					"verifier", res.verifierAddr, "voter_slot", res.vote.VoterSlot,
+					"claimed", claimedAddr)
+				continue
+			}
 			votes = append(votes, res.vote)
-			voterAddr := s.sm.SlotAddress(res.vote.VoterSlot)
-			weight := s.sm.AddressSlotCount(voterAddr)
+			// Weight from the known responder address, not from the response field.
+			weight := s.sm.AddressSlotCount(res.verifierAddr)
 			accWeight += weight
 			logging.Stage(ctx, "timeout_vote_result",
 				logFields(
 					res.verifierAddr,
 					"outcome", "accept",
 					"voter_slot", res.vote.VoterSlot,
-					"voter", shortAddress(voterAddr),
+					"voter", shortAddress(res.verifierAddr),
 					"weight", weight,
 					"running_weight", accWeight,
 					"threshold", voteThreshold,
@@ -2170,6 +2195,8 @@ func (s *Session) CollectTimeoutVotes(
 }
 
 // HasSufficientTimeoutVotes returns true if the accept votes exceed the vote threshold.
+// Votes must already be responder-bound (CollectTimeoutVotes rejects spoofed
+// voter_slot); weight is derived from each vote's VoterSlot owner.
 func (s *Session) HasSufficientTimeoutVotes(votes []*types.TimeoutVote) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -438,6 +438,10 @@ type mockTimeoutVerifier struct {
 	// claimSlot, when non-nil, overrides the returned voter_slot (used to
 	// simulate a byzantine verifier claiming another validator's slot).
 	claimSlot *uint32
+	// signSlot, when non-nil, is the voter_slot embedded in the signed
+	// TimeoutVoteContent. Defaults to the returned voter_slot. Set differently
+	// from claimSlot/own slot to simulate a signature/slot mismatch.
+	signSlot *uint32
 	// delay, when >0, sleeps before returning (honest slow responders).
 	delay time.Duration
 }
@@ -461,11 +465,16 @@ func (m *mockTimeoutVerifier) VerifyTimeout(ctx context.Context, inferenceID uin
 	if m.claimSlot != nil {
 		voterSlot = *m.claimSlot
 	}
+	signedSlot := voterSlot
+	if m.signSlot != nil {
+		signedSlot = *m.signSlot
+	}
 	content := &types.TimeoutVoteContent{
 		EscrowId:    eid,
 		InferenceId: inferenceID,
 		Reason:      reason,
 		Accept:      true,
+		VoterSlot:   signedSlot,
 	}
 	data, err := proto.Marshal(content)
 	if err != nil {
@@ -568,15 +577,139 @@ func TestCollectTimeoutVotes_RejectsSpoofedVoterSlot(t *testing.T) {
 	}, verifiers, nil)
 	require.NoError(t, err)
 
-	// Malicious verifier only returned a spoofed foreign slot (never its own),
-	// so its address must not appear among collected votes.
+	// Precondition: the spoofed claim alone carries enough weight to have
+	// terminated collection early, so this test only passes because the
+	// responder bind rejected it.
+	require.Greater(t, session.sm.AddressSlotCount(signers[2].Address()), config.VoteThreshold,
+		"spoofed slot must be heavy enough to trip early exit on its own")
+
+	// The spoofed vote and the honest signer[2] vote both claim slots owned by
+	// signer[2]; a collected spoof would show up as a duplicate voter address,
+	// which the state machine rejects for the whole MsgTimeoutInference.
+	seenAddrs := make(map[string]bool, len(votes))
 	for _, v := range votes {
-		require.NotEqual(t, signers[0].Address(), session.sm.SlotAddress(v.VoterSlot),
-			"spoofed response from validator-0 must be dropped")
+		addr := session.sm.SlotAddress(v.VoterSlot)
+		require.False(t, seenAddrs[addr], "duplicate voter address %s implies a spoofed vote was collected", addr)
+		seenAddrs[addr] = true
 	}
 	require.NotEmpty(t, votes, "honest delayed verifiers must still be collected")
 	require.True(t, session.HasSufficientTimeoutVotes(votes),
 		"honest delayed votes must still form a quorum after spoofed response is dropped")
+
+	// Every collected vote must satisfy the same rule applyTimeout enforces:
+	// the recovered signer owns the claimed slot. This is the property the
+	// vulnerability broke — collection returned votes the state machine would
+	// later reject, after the honest RPCs had already been cancelled.
+	requireVotesPassStateMachineRules(t, verifier, "escrow-1", 1,
+		types.TimeoutReason_TIMEOUT_REASON_REFUSED, votes, session)
+}
+
+// requireVotesPassStateMachineRules mirrors StateMachine.applyTimeout's per-vote
+// signature check so collection tests can assert that everything they return
+// would be accepted on apply.
+func requireVotesPassStateMachineRules(
+	t *testing.T,
+	verifier signing.Verifier,
+	escrowID string,
+	inferenceID uint64,
+	reason types.TimeoutReason,
+	votes []*types.TimeoutVote,
+	session *Session,
+) {
+	t.Helper()
+	for _, v := range votes {
+		voterAddr := session.sm.SlotAddress(v.VoterSlot)
+		require.NotEmpty(t, voterAddr, "vote claims slot %d which is not in the group", v.VoterSlot)
+
+		data, err := proto.MarshalOptions{Deterministic: true}.Marshal(&types.TimeoutVoteContent{
+			EscrowId:    escrowID,
+			InferenceId: inferenceID,
+			Reason:      reason,
+			Accept:      v.Accept,
+			VoterSlot:   v.VoterSlot,
+		})
+		require.NoError(t, err)
+
+		recovered, err := verifier.RecoverAddress(data, v.Signature)
+		require.NoError(t, err, "vote from slot %d has an unrecoverable signature", v.VoterSlot)
+		require.Equal(t, voterAddr, recovered,
+			"vote from slot %d recovers to %s, not the slot owner", v.VoterSlot, recovered)
+	}
+}
+
+// TestCollectTimeoutVotes_RejectsSignedSlotMismatch covers the case where a
+// verifier returns its own voter_slot (so the responder-bind check passes) but
+// the signature was produced over TimeoutVoteContent with a different
+// voter_slot. Collection must drop that vote.
+func TestCollectTimeoutVotes_RejectsSignedSlotMismatch(t *testing.T) {
+	signers := make([]*signing.Secp256k1Signer, 3)
+	for i := range signers {
+		signers[i] = testutil.MustGenerateKey(t)
+	}
+	userKey := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(signers)
+	config := testutil.DefaultConfig(len(group))
+	verifier := signing.NewSecp256k1Verifier()
+
+	clients := make([]HostClient, len(group))
+	for i := range signers {
+		sm := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+		h, err := host.NewHost(sm, signers[i], stub.NewInferenceEngine(), "escrow-1", group, nil, host.WithGrace(100))
+		require.NoError(t, err)
+		clients[i] = &InProcessClient{Host: h}
+	}
+
+	userSM := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+	session, err := NewSession(userSM, userKey, "escrow-1", group, clients, verifier)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = session.SendInference(ctx, InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	})
+	require.NoError(t, err)
+
+	executorIdx := int(1 % uint64(len(group)))
+	foreignSlot := group[(executorIdx+1)%len(group)].SlotID
+	// Pick a non-executor host that is not the foreign slot owner if possible.
+	badIdx := 0
+	if badIdx == executorIdx {
+		badIdx = 2
+	}
+
+	verifiers := make(map[int]TimeoutVerifier)
+	for i := range group {
+		if i == executorIdx {
+			continue
+		}
+		m := &mockTimeoutVerifier{
+			accept:  true,
+			signer:  signers[i],
+			group:   group,
+			slotIdx: i,
+		}
+		if i == badIdx {
+			sign := foreignSlot
+			if sign == group[i].SlotID {
+				sign = group[(i+1)%len(group)].SlotID
+			}
+			m.signSlot = &sign // return own slot, sign a different one
+		}
+		verifiers[i] = m
+	}
+
+	votes, err := session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+		Prompt: testutil.TestPrompt, Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}, verifiers, nil)
+	require.NoError(t, err)
+
+	for _, v := range votes {
+		require.NotEqual(t, group[badIdx].SlotID, v.VoterSlot,
+			"vote with signature/slot mismatch must be dropped")
+	}
+	requireVotesPassStateMachineRules(t, verifier, "escrow-1", 1,
+		types.TimeoutReason_TIMEOUT_REASON_REFUSED, votes, session)
 }
 
 // concurrencyMockVerifier is a TimeoutVerifier that records concurrency
@@ -630,6 +763,7 @@ func (m *concurrencyMockVerifier) VerifyTimeout(ctx context.Context, inferenceID
 		InferenceId: inferenceID,
 		Reason:      reason,
 		Accept:      true,
+		VoterSlot:   voterSlot,
 	}
 	data, err := proto.Marshal(content)
 	if err != nil {

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -435,9 +435,21 @@ type mockTimeoutVerifier struct {
 	group    []types.SlotAssignment
 	slotIdx  int
 	escrowID string // defaults to "escrow-1" when empty
+	// claimSlot, when non-nil, overrides the returned voter_slot (used to
+	// simulate a byzantine verifier claiming another validator's slot).
+	claimSlot *uint32
+	// delay, when >0, sleeps before returning (honest slow responders).
+	delay time.Duration
 }
 
-func (m *mockTimeoutVerifier) VerifyTimeout(_ context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, error) {
+func (m *mockTimeoutVerifier) VerifyTimeout(ctx context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, error) {
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return false, nil, 0, ctx.Err()
+		}
+	}
 	if !m.accept {
 		return false, nil, 0, nil
 	}
@@ -446,6 +458,9 @@ func (m *mockTimeoutVerifier) VerifyTimeout(_ context.Context, inferenceID uint6
 		eid = "escrow-1"
 	}
 	voterSlot := m.group[m.slotIdx].SlotID
+	if m.claimSlot != nil {
+		voterSlot = *m.claimSlot
+	}
 	content := &types.TimeoutVoteContent{
 		EscrowId:    eid,
 		InferenceId: inferenceID,
@@ -461,6 +476,107 @@ func (m *mockTimeoutVerifier) VerifyTimeout(_ context.Context, inferenceID uint6
 		return false, nil, 0, err
 	}
 	return true, sig, voterSlot, nil
+}
+
+// TestCollectTimeoutVotes_RejectsSpoofedVoterSlot ensures a byzantine verifier
+// cannot terminate collection early by returning accept=true with a high-weight
+// validator's voter_slot while signing with its own key. Weight and early-exit
+// must bind to the contacted responder; the spoofed vote must be dropped so
+// honest delayed responses can still form a valid quorum.
+func TestCollectTimeoutVotes_RejectsSpoofedVoterSlot(t *testing.T) {
+	// 4 validators, slots [1, 1, 5, 1] (total 8). VoteThreshold = 4; need >4.
+	// Signer[2] owns weight 5. Malicious signer[0] (weight 1) claims one of
+	// signer[2]'s slots. Without the bind check, a single spoofed response
+	// would push running weight to 5 and cancel the remaining honest RPCs.
+	signers := make([]*signing.Secp256k1Signer, 4)
+	for i := range signers {
+		signers[i] = testutil.MustGenerateKey(t)
+	}
+	userKey := testutil.MustGenerateKey(t)
+	group := testutil.MakeMultiSlotGroup(signers, []int{1, 1, 5, 1})
+	numSlots := len(group)
+	config := types.SessionConfig{
+		RefusalTimeout:   60,
+		ExecutionTimeout: 1200,
+		TokenPrice:       1,
+		VoteThreshold:    uint32(numSlots) / 2, // 8/2 = 4
+	}
+	verifier := signing.NewSecp256k1Verifier()
+
+	clients := make([]HostClient, numSlots)
+	for i, slot := range group {
+		slotSigner := signerForSlot(t, signers, slot)
+		sm := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+		engine := stub.NewInferenceEngine()
+		h, err := host.NewHost(sm, slotSigner, engine, "escrow-1", group, nil, host.WithGrace(100))
+		require.NoError(t, err)
+		clients[i] = &InProcessClient{Host: h}
+	}
+
+	userSM := statetest.MustStateMachine(t, "escrow-1", config, group, 100000, userKey.Address(), verifier)
+	session, err := NewSession(userSM, userKey, "escrow-1", group, clients, verifier)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = session.SendInference(ctx, InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	})
+	require.NoError(t, err)
+
+	// Executor = group[1 % 8] (nonce 1). First index owned by signer[1].
+	executorIdx := int(1 % uint64(numSlots))
+	executorAddr := group[executorIdx].ValidatorAddress
+
+	// Pick a slot owned by high-weight signer[2] for the spoof claim.
+	var heavySlot uint32
+	for _, slot := range group {
+		if slot.ValidatorAddress == signers[2].Address() {
+			heavySlot = slot.SlotID
+			break
+		}
+	}
+
+	verifiers := make(map[int]TimeoutVerifier)
+	for i, slot := range group {
+		if slot.ValidatorAddress == executorAddr {
+			continue
+		}
+		slotSigner := signerForSlot(t, signers, slot)
+		m := &mockTimeoutVerifier{
+			accept:  true,
+			signer:  slotSigner,
+			group:   group,
+			slotIdx: i,
+			delay:   50 * time.Millisecond, // honest responders are slower
+		}
+		// First index owned by signer[0]: return immediately with spoofed slot.
+		if slot.ValidatorAddress == signers[0].Address() {
+			claim := heavySlot
+			m.claimSlot = &claim
+			m.delay = 0
+		}
+		verifiers[i] = m
+	}
+
+	votes, err := session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+		Prompt:      testutil.TestPrompt,
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}, verifiers, nil)
+	require.NoError(t, err)
+
+	// Malicious verifier only returned a spoofed foreign slot (never its own),
+	// so its address must not appear among collected votes.
+	for _, v := range votes {
+		require.NotEqual(t, signers[0].Address(), session.sm.SlotAddress(v.VoterSlot),
+			"spoofed response from validator-0 must be dropped")
+	}
+	require.NotEmpty(t, votes, "honest delayed verifiers must still be collected")
+	require.True(t, session.HasSufficientTimeoutVotes(votes),
+		"honest delayed votes must still form a quorum after spoofed response is dropped")
 }
 
 // concurrencyMockVerifier is a TimeoutVerifier that records concurrency


### PR DESCRIPTION
## Summary

- Hardening on top of the gateway-only fix (https://github.com/gonka-ai/gonka/pull/1544): include `voter_slot` in signed `TimeoutVoteContent`, and verify the signature against the known responder during collection so a vote cannot be reused under a different claimed slot.
- The **minimal fix** (responder bind + count weight from the contacted host) lives in a separate PR on `ak/devshard-timeout-vote-responder-bind` and touches **only the gateway** collection path — that alone closes the reported issue.
- This PR is **defense-in-depth / protocol hardening**, not required to stop the attack if the gateway-only PR is merged. It changes the signed preimage and should ship under a new approved protocol name.

## Problem

`CollectTimeoutVotes` fans out `VerifyTimeout` to known verifiers. A byzantine verifier could return `accept=true` with its own valid signature while claiming another validator’s higher-weight `voter_slot`. Collection counted that weight, could stop early and cancel outstanding honest RPCs, then the state machine rejected the invalid vote — so an otherwise available honest timeout quorum was lost.

## Fix (this PR)

1. Add `voter_slot` to `TimeoutVoteContent`; host signs it; state machine verifies over that content.
2. Gateway verifies the signature against the contacted verifier after the responder-bind check (assumes / pairs with the gateway-only bind from `ak/devshard-timeout-vote-responder-bind`).

See also: [gateway-only PR](https://github.com/gonka-ai/gonka/pull/1544)

## Severity (issue): Medium

Authenticated liveness/griefing, not fund theft. Requires a separate byzantine group verifier (executor alone cannot block its own timeout). Early-stop is a race: the malicious reply must be counted before enough honest votes arrive. SM still rejects the spoofed vote, so no false timeout under another validator’s identity.

## Test plan

- [x] `go test ./user/ -run TestCollectTimeoutVotes_`
- [x] `go test ./user/ ./state/ ./protocol/ ./transport/ ./host/`
- [ ] Confirm release uses a new `approved_versions.name` for this signed-slot change
- [ ] Land / link the gateway-only PR on `ak/devshard-timeout-vote-responder-bind`