### PR TITLE
fix(poc): gate PoC v2 messages by participant permission

### DIFF
--- a/inference-chain/app/ante_poc_period.go
+++ b/inference-chain/app/ante_poc_period.go
@@ -128,11 +128,37 @@ func (ppd PocPeriodValidationDecorator) checkPocMessageTooLate(ctx sdk.Context, 
 	return nil
 }
 
+func (ppd PocPeriodValidationDecorator) checkPocMessageSender(ctx sdk.Context, msg sdk.Msg) error {
+	if ppd.inferenceKeeper == nil {
+		return nil
+	}
+
+	signers, ok := msg.(inferencemodulekeeper.HasSigners)
+	if !ok {
+		return nil
+	}
+
+	for _, signer := range signers.GetSignersStrings() {
+		addr, err := sdk.AccAddressFromBech32(signer)
+		if err != nil {
+			continue
+		}
+		if found, err := ppd.inferenceKeeper.Participants.Has(ctx, addr); err == nil && found {
+			return nil
+		}
+	}
+
+	return inferencetypes.ErrParticipantNotFound
+}
+
 func (ppd PocPeriodValidationDecorator) checkMessage(ctx sdk.Context, msg sdk.Msg) error {
 	switch m := msg.(type) {
 	case *inferencetypes.MsgSubmitPocBatch,
 		*inferencetypes.MsgSubmitPocValidationsV2,
 		*inferencetypes.MsgPoCV2StoreCommit, *inferencetypes.MsgMLNodeWeightDistribution:
+		if err := ppd.checkPocMessageSender(ctx, msg); err != nil {
+			return err
+		}
 		return ppd.checkPocMessageTooLate(ctx, msg)
 
 	case *authztypes.MsgExec:

--- a/inference-chain/app/ante_poc_period_test.go
+++ b/inference-chain/app/ante_poc_period_test.go
@@ -3,7 +3,13 @@ package app
 import (
 	"testing"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	"github.com/productscience/inference/testutil"
+	keepertest "github.com/productscience/inference/testutil/keeper"
+	inferencemodulekeeper "github.com/productscience/inference/x/inference/keeper"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,4 +35,139 @@ func TestPocPeriodValidationDecorator_SimulationMode(t *testing.T) {
 	t.Log("Simulation mode bypasses PoC period validation")
 	require.NotNil(t, decorator)
 	require.NotNil(t, ctx)
+}
+
+// setupPocPeriodAnte returns a CheckTx context positioned inside the PoC
+// validation exchange window (PocStart=100, generation ends at 150, validation
+// runs 156-255) together with a decorator bound to a fresh inference keeper.
+func setupPocPeriodAnte(t *testing.T) (inferencemodulekeeper.Keeper, sdk.Context, PocPeriodValidationDecorator) {
+	t.Helper()
+
+	k, goCtx, _ := keepertest.InferenceKeeperReturningMocks(t)
+	ctx := sdk.UnwrapSDKContext(goCtx).WithBlockHeight(160).WithIsCheckTx(true)
+
+	params, err := k.GetParams(ctx)
+	require.NoError(t, err)
+	params.PocParams = &inferencetypes.PocParams{PocV2Enabled: true}
+	params.EpochParams = &inferencetypes.EpochParams{
+		PocStageDuration:      50,
+		PocExchangeDuration:   20,
+		PocValidationDelay:    5,
+		PocValidationDuration: 100,
+	}
+	require.NoError(t, k.SetParams(ctx, params))
+
+	k.SetEffectiveEpochIndex(ctx, 0)
+	k.SetEpoch(ctx, &inferencetypes.Epoch{Index: 1, PocStartBlockHeight: 100})
+
+	return k, ctx, NewPocPeriodValidationDecorator(&k)
+}
+
+func pocValidationsMsg(creator string) *inferencetypes.MsgSubmitPocValidationsV2 {
+	return &inferencetypes.MsgSubmitPocValidationsV2{
+		Creator:                  creator,
+		PocStageStartBlockHeight: 100,
+		Validations: []*inferencetypes.PoCValidationEntryV2{
+			{ParticipantAddress: testutil.Executor, ModelId: "test-model", ValidatedWeight: 100},
+		},
+	}
+}
+
+func runPocPeriodAnte(t *testing.T, decorator PocPeriodValidationDecorator, ctx sdk.Context, msgs ...sdk.Msg) (bool, error) {
+	t.Helper()
+	nextCalled := false
+	next := func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		nextCalled = true
+		return ctx, nil
+	}
+	_, err := decorator.AnteHandle(ctx, testFeeTx{msgs: msgs}, false, next)
+	return nextCalled, err
+}
+
+func TestPocPeriodValidationDecorator_RejectsNonParticipant(t *testing.T) {
+	testCases := []struct {
+		name string
+		msg  sdk.Msg
+	}{
+		{
+			name: "MsgSubmitPocBatch",
+			msg: &inferencetypes.MsgSubmitPocBatch{
+				Creator:                  testutil.Creator,
+				PocStageStartBlockHeight: 100,
+				NodeId:                   "node-1",
+			},
+		},
+		{
+			name: "MsgSubmitPocValidationsV2",
+			msg:  pocValidationsMsg(testutil.Creator),
+		},
+		{
+			name: "MsgPoCV2StoreCommit",
+			msg: &inferencetypes.MsgPoCV2StoreCommit{
+				Creator:                  testutil.Creator,
+				PocStageStartBlockHeight: 100,
+				Entries: []*inferencetypes.PoCV2CommitEntry{
+					{ModelId: "test-model", Count: 10, RootHash: make([]byte, 32)},
+				},
+			},
+		},
+		{
+			name: "MsgMLNodeWeightDistribution",
+			msg: &inferencetypes.MsgMLNodeWeightDistribution{
+				Creator:                  testutil.Creator,
+				PocStageStartBlockHeight: 100,
+				Entries: []*inferencetypes.MLNodeDistributionEntry{
+					{ModelId: "test-model", Weights: []*inferencetypes.MLNodeWeight{{NodeId: "node-1", Weight: 10}}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx, decorator := setupPocPeriodAnte(t)
+
+			nextCalled, err := runPocPeriodAnte(t, decorator, ctx, tc.msg)
+			require.ErrorIs(t, err, inferencetypes.ErrParticipantNotFound)
+			require.False(t, nextCalled)
+		})
+	}
+}
+
+func TestPocPeriodValidationDecorator_AllowsRegisteredParticipant(t *testing.T) {
+	k, ctx, decorator := setupPocPeriodAnte(t)
+
+	signer := testutil.Creator
+	require.NoError(t, k.Participants.Set(ctx, sdk.MustAccAddressFromBech32(signer), inferencetypes.Participant{
+		Index:   signer,
+		Address: signer,
+	}))
+
+	nextCalled, err := runPocPeriodAnte(t, decorator, ctx, pocValidationsMsg(signer))
+	require.NoError(t, err)
+	require.True(t, nextCalled)
+}
+
+func TestPocPeriodValidationDecorator_RejectsMalformedCreator(t *testing.T) {
+	_, ctx, decorator := setupPocPeriodAnte(t)
+
+	nextCalled, err := runPocPeriodAnte(t, decorator, ctx, pocValidationsMsg("not-a-bech32-address"))
+	require.ErrorIs(t, err, inferencetypes.ErrParticipantNotFound)
+	require.False(t, nextCalled)
+}
+
+func TestPocPeriodValidationDecorator_RejectsNonParticipantInsideMsgExec(t *testing.T) {
+	_, ctx, decorator := setupPocPeriodAnte(t)
+
+	inner, err := codectypes.NewAnyWithValue(pocValidationsMsg(testutil.Creator))
+	require.NoError(t, err)
+
+	execMsg := &authztypes.MsgExec{
+		Grantee: testutil.Executor,
+		Msgs:    []*codectypes.Any{inner},
+	}
+
+	nextCalled, err := runPocPeriodAnte(t, decorator, ctx, execMsg)
+	require.ErrorIs(t, err, inferencetypes.ErrParticipantNotFound)
+	require.False(t, nextCalled)
 }

--- a/inference-chain/x/inference/keeper/msg_server_poc_v2_commit.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_v2_commit.go
@@ -21,7 +21,7 @@ type pocV2CommitUpdate struct {
 
 // PoCV2StoreCommit handles submission of off-chain artifact store commits.
 func (k msgServer) PoCV2StoreCommit(goCtx context.Context, msg *types.MsgPoCV2StoreCommit) (*types.MsgPoCV2StoreCommitResponse, error) {
-	if err := k.CheckPermission(goCtx, msg, NoPermission); err != nil {
+	if err := k.CheckPermission(goCtx, msg, ParticipantPermission); err != nil {
 		return nil, err
 	}
 
@@ -270,7 +270,7 @@ func checkedMul(a, b uint64) (uint64, bool) {
 
 // MLNodeWeightDistribution handles submission of per-node weight distribution.
 func (k msgServer) MLNodeWeightDistribution(goCtx context.Context, msg *types.MsgMLNodeWeightDistribution) (*types.MsgMLNodeWeightDistributionResponse, error) {
-	if err := k.CheckPermission(goCtx, msg, NoPermission); err != nil {
+	if err := k.CheckPermission(goCtx, msg, ParticipantPermission); err != nil {
 		return nil, err
 	}
 

--- a/inference-chain/x/inference/keeper/msg_server_poc_v2_perm_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_v2_perm_test.go
@@ -1,0 +1,68 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/productscience/inference/testutil"
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgServer_SubmitPocValidationsV2_Permissions(t *testing.T) {
+	assertParticipantOnlyPoCV2Message(t, func(signer string) keeper.HasSigners {
+		return &types.MsgSubmitPocValidationsV2{
+			Creator:                  signer,
+			PocStageStartBlockHeight: 100,
+			Validations: []*types.PoCValidationEntryV2{
+				{
+					ParticipantAddress: testutil.Executor,
+					ModelId:            testPoCModelID,
+					ValidatedWeight:    100,
+				},
+			},
+		}
+	})
+}
+
+func TestMsgServer_PoCV2StoreCommit_Permissions(t *testing.T) {
+	assertParticipantOnlyPoCV2Message(t, func(signer string) keeper.HasSigners {
+		return &types.MsgPoCV2StoreCommit{
+			Creator:                  signer,
+			PocStageStartBlockHeight: 100,
+			Entries:                  []*types.PoCV2CommitEntry{makePoCV2CommitEntry(testPoCModelID, 10, 1)},
+		}
+	})
+}
+
+func TestMsgServer_MLNodeWeightDistribution_Permissions(t *testing.T) {
+	assertParticipantOnlyPoCV2Message(t, func(signer string) keeper.HasSigners {
+		return &types.MsgMLNodeWeightDistribution{
+			Creator:                  signer,
+			PocStageStartBlockHeight: 100,
+			Entries: []*types.MLNodeDistributionEntry{
+				{
+					ModelId: testPoCModelID,
+					Weights: []*types.MLNodeWeight{{NodeId: "node-1", Weight: 10}},
+				},
+			},
+		}
+	})
+}
+
+func assertParticipantOnlyPoCV2Message(t *testing.T, build func(signer string) keeper.HasSigners) {
+	t.Helper()
+	k, ms, ctx, _ := setupPermissionsHarness(t)
+
+	signer := testutil.Creator
+	msg := build(signer)
+
+	err := keeper.CheckPermission(ms, ctx, msg, keeper.ParticipantPermission)
+	require.Error(t, err)
+
+	p := types.Participant{Index: signer, Address: signer}
+	require.NoError(t, k.Participants.Set(ctx, sdk.MustAccAddressFromBech32(signer), p))
+	err = keeper.CheckPermission(ms, ctx, msg, keeper.ParticipantPermission)
+	require.NoError(t, err)
+}

--- a/inference-chain/x/inference/keeper/msg_server_poc_v2_test.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_v2_test.go
@@ -15,6 +15,14 @@ import (
 const testPoCModelID = "test-poc-model"
 const testPoCModelID2 = "test-poc-model-2"
 
+func registerPoCParticipant(t *testing.T, k keeper.Keeper, ctx sdk.Context, addr string) {
+	t.Helper()
+	require.NoError(t, k.Participants.Set(ctx, sdk.MustAccAddressFromBech32(addr), types.Participant{
+		Index:   addr,
+		Address: addr,
+	}))
+}
+
 // Test SetPocValidationV2 error handling (no panic)
 func TestSetPocValidationV2_InvalidAddress(t *testing.T) {
 	k, ctx, _ := keepertest.InferenceKeeperReturningMocks(t)
@@ -104,6 +112,8 @@ func TestSubmitPocValidationsV2_DuplicateSkipped(t *testing.T) {
 	}
 	k.SetEpoch(sdkCtx, upcomingEpoch)
 
+	registerPoCParticipant(t, k, sdkCtx, testutil.Validator)
+
 	msgServer := keeper.NewMsgServerImpl(k)
 
 	// First submission should succeed
@@ -154,6 +164,8 @@ func TestSubmitPocValidationsV2_PartialSuccess(t *testing.T) {
 		PocStartBlockHeight: 100,
 	}
 	k.SetEpoch(sdkCtx, upcomingEpoch)
+
+	registerPoCParticipant(t, k, sdkCtx, testutil.Validator)
 
 	msgServer := keeper.NewMsgServerImpl(k)
 
@@ -272,8 +284,7 @@ func TestPoCV2StoreCommit_InvalidCreatorAddress(t *testing.T) {
 		}},
 	}
 	_, err = msgServer.PoCV2StoreCommit(sdkCtx, msg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid")
+	require.ErrorContains(t, err, "decoding bech32 failed")
 }
 
 func setupPoCV2StoreCommitTest(
@@ -310,6 +321,8 @@ func setupPoCV2StoreCommitTest(
 	for _, modelID := range modelIDs {
 		k.SetModel(sdkCtx, &types.Model{Id: modelID})
 	}
+
+	registerPoCParticipant(t, k, sdkCtx, testutil.Executor)
 
 	return k, sdkCtx, keeper.NewMsgServerImpl(k)
 }

--- a/inference-chain/x/inference/keeper/msg_server_poc_validations_v2.go
+++ b/inference-chain/x/inference/keeper/msg_server_poc_validations_v2.go
@@ -11,7 +11,7 @@ import (
 
 // SubmitPocValidationsV2 handles batch submission of PoC v2 validations.
 func (k msgServer) SubmitPocValidationsV2(goCtx context.Context, msg *types.MsgSubmitPocValidationsV2) (*types.MsgSubmitPocValidationsV2Response, error) {
-	if err := k.CheckPermission(goCtx, msg, NoPermission); err != nil {
+	if err := k.CheckPermission(goCtx, msg, ParticipantPermission); err != nil {
 		return nil, err
 	}
 

--- a/inference-chain/x/inference/keeper/permissions.go
+++ b/inference-chain/x/inference/keeper/permissions.go
@@ -111,9 +111,9 @@ var MessagePermissions = map[reflect.Type][]Permission{
 	reflect.TypeOf((*types.MsgSetClaimRecipients)(nil)):               {ParticipantPermission},
 	reflect.TypeOf((*types.MsgSubmitHardwareDiff)(nil)):               {ParticipantPermission},
 	reflect.TypeOf((*types.MsgSubmitPocBatch)(nil)):                   {ParticipantPermission},
-	reflect.TypeOf((*types.MsgSubmitPocValidationsV2)(nil)):           {NoPermission},
-	reflect.TypeOf((*types.MsgPoCV2StoreCommit)(nil)):                 {NoPermission},
-	reflect.TypeOf((*types.MsgMLNodeWeightDistribution)(nil)):         {NoPermission},
+	reflect.TypeOf((*types.MsgSubmitPocValidationsV2)(nil)):           {ParticipantPermission},
+	reflect.TypeOf((*types.MsgPoCV2StoreCommit)(nil)):                 {ParticipantPermission},
+	reflect.TypeOf((*types.MsgMLNodeWeightDistribution)(nil)):         {ParticipantPermission},
 	reflect.TypeOf((*types.MsgSubmitSeed)(nil)):                       {ParticipantPermission},
 	reflect.TypeOf((*types.MsgSubmitUnitOfComputePriceProposal)(nil)): {ActiveParticipantPermission},
 


### PR DESCRIPTION
## Problem
The three PoC v2 transaction types are declared `NoPermission`, so any chain account — with no PoC history and no participant record — can write entries into the PoC stage prefixes:

- `MsgSubmitPocValidationsV2`
- `MsgPoCV2StoreCommit`
- `MsgMLNodeWeightDistribution`

The V1 equivalent, `MsgSubmitPocBatch`, has required `ParticipantPermission` since it was introduced (`permissions.go:113`). The V2 messages dropped that check during the V1→V2 migration.


## Fix

1. `permissions.go` and the three `CheckPermission` call sites move from `NoPermission` to `ParticipantPermission`. The check is already the first statement in each handler, before any storage read or gas charge.
2. A node joining the network is registered but not yet active in the current epoch, and must be able to run its first PoC. `ActiveParticipantPermission` would break onboarding.
3. `PocPeriodValidationDecorator` gains `checkPocMessageSender`, rejecting PoC duty messages from non-participants. The handler check runs only in `DeliverTx`, so on its own it stops the storage write but still lets a non-participant fill blocks for free. This decorator runs only under `ctx.IsCheckTx()`, so it is a mempool admission filter with no consensus impact.
4. It follows messages into authz `MsgExec`, which matters in practice: when a node runs a separate signer key from its main account, `tx_manager.go:828-836` wraps *every* PoC message in `MsgExec` with `grantee = warm key`, `Creator = participant`. Both gates read the granter.
