### PR TITLE
fix(queryapi): skip validator-set lookup for zero creation height in epoch participants

### DIFF
--- a/common/queryapi/epoch.go
+++ b/common/queryapi/epoch.go
@@ -189,12 +189,19 @@ func (h *Handlers) getEpochParticipants(ctx context.Context, epoch uint64) (*gen
 	}
 
 	// Validators at the creation height.
-	valsResp, err := h.chain.CometServiceClient().GetValidatorSetByHeight(ctx, &cmtservice.GetValidatorSetByHeightRequest{
-		Height: activeParticipants.CreatedAtBlockHeight,
-	})
-	if err != nil {
-		logging.Error("Failed to get validators", inferencetypes.Participants, "error", err)
-		return nil, err
+	var valsResp *cmtservice.GetValidatorSetByHeightResponse
+	if activeParticipants.CreatedAtBlockHeight <= 0 {
+		// Non-fatal: CometBFT rejects height <= 0, so skip the call rather than fail the request.
+		logging.Warn("Skipping validator set lookup for zero/negative height", inferencetypes.Participants,
+			"height", activeParticipants.CreatedAtBlockHeight)
+	} else {
+		valsResp, err = h.chain.CometServiceClient().GetValidatorSetByHeight(ctx, &cmtservice.GetValidatorSetByHeightRequest{
+			Height: activeParticipants.CreatedAtBlockHeight,
+		})
+		if err != nil {
+			logging.Error("Failed to get validators", inferencetypes.Participants, "error", err)
+			return nil, err
+		}
 	}
 
 	// Derive participant addresses from validator keys.
@@ -214,7 +221,11 @@ func (h *Handlers) getEpochParticipants(ctx context.Context, epoch uint64) (*gen
 		return nil, err
 	}
 
-	validators, err := validatorsToRawJSON(valsResp.Validators)
+	var vals []*cmtservice.Validator
+	if valsResp != nil {
+		vals = valsResp.Validators
+	}
+	validators, err := validatorsToRawJSON(vals)
 	if err != nil {
 		logging.Error("Failed to encode validators", inferencetypes.Participants, "error", err)
 		return nil, err

--- a/common/queryapi/openapi.yaml
+++ b/common/queryapi/openapi.yaml
@@ -557,7 +557,7 @@ components:
         # cmtservice.ProofOps — absent when not requested
         proof_ops:
           $ref: '#/components/schemas/RawProtoJson'
-        # cmtservice.Validator
+        # cmtservice.Validator — empty when the creation height is unavailable
         validators:
           type: array
           items:

--- a/common/queryapi/tests/epoch_participants_zero_height_test.go
+++ b/common/queryapi/tests/epoch_participants_zero_height_test.go
@@ -1,0 +1,96 @@
+package queryapitest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
+	"github.com/golang/protobuf/proto"
+	inferencetypes "github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestEpochParticipantsZeroHeightSkipsValidatorLookup covers the case where a
+// stored ActiveParticipants blob has CreatedAtBlockHeight == 0 (blobs written
+// before the created_at_block_height proto field existed decode with the zero
+// value). CometBFT rejects GetValidatorSetByHeight for
+// height <= 0 with "height must be greater than 0, but got 0" — the handler
+// must treat that as non-fatal and still return the participants data instead
+// of surfacing a 500.
+func TestEpochParticipantsZeroHeightSkipsValidatorLookup(t *testing.T) {
+	srv := &stubEpochParticipantsZeroHeightComet{}
+	inf := &stubEpochParticipantsInference{}
+	h := handlersWithInferenceAndComet(t, inf, srv)
+
+	ctx, rec := echoContext(t, http.MethodGet, "/v1/epochs/1/participants")
+	require.NoError(t, h.GetEpochParticipants(ctx, "1"))
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	assert.False(t, srv.validatorSetCalled, "GetValidatorSetByHeight must not be called for height <= 0")
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+
+	assert.Contains(t, got, "active_participants")
+	assert.NotEmpty(t, got["active_participants_bytes"])
+
+	validators, ok := got["validators"].([]any)
+	require.True(t, ok, "validators should still be a JSON array, body=%s", rec.Body.String())
+	assert.Empty(t, validators)
+}
+
+type stubEpochParticipantsZeroHeightComet struct {
+	cmtservice.UnimplementedServiceServer
+	value              []byte
+	validatorSetCalled bool
+}
+
+func (s *stubEpochParticipantsZeroHeightComet) ABCIQuery(_ context.Context, req *cmtservice.ABCIQueryRequest) (*cmtservice.ABCIQueryResponse, error) {
+	if s.value == nil {
+		ap := inferencetypes.ActiveParticipants{
+			CreatedAtBlockHeight: 0,
+			EpochGroupId:         1,
+		}
+		var err error
+		s.value, err = proto.Marshal(&ap)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if req.Prove {
+		return &cmtservice.ABCIQueryResponse{
+			Code:  0,
+			Value: s.value,
+			ProofOps: &cmtservice.ProofOps{
+				Ops: []cmtservice.ProofOp{{Type: "iavl:v", Key: []byte("key"), Data: []byte("value")}},
+			},
+			Height: 0,
+		}, nil
+	}
+	return &cmtservice.ABCIQueryResponse{Code: 0, Value: s.value}, nil
+}
+
+func (s *stubEpochParticipantsZeroHeightComet) GetBlockByHeight(_ context.Context, req *cmtservice.GetBlockByHeightRequest) (*cmtservice.GetBlockByHeightResponse, error) {
+	return &cmtservice.GetBlockByHeightResponse{
+		SdkBlock: &cmtservice.Block{
+			Header: cmtservice.Header{
+				Height:  req.Height,
+				ChainID: "gonka-test",
+				AppHash: []byte("apphash"),
+			},
+		},
+	}, nil
+}
+
+func (s *stubEpochParticipantsZeroHeightComet) GetValidatorSetByHeight(_ context.Context, _ *cmtservice.GetValidatorSetByHeightRequest) (*cmtservice.GetValidatorSetByHeightResponse, error) {
+	s.validatorSetCalled = true
+	// Mirrors the real CometBFT node's rejection of non-positive heights, so
+	// this test fails loudly (instead of silently passing) if the handler
+	// regresses and calls this for a zero height.
+	return nil, status.Error(codes.InvalidArgument, "height must be greater than 0, but got 0")
+}


### PR DESCRIPTION
## What problem does this solve?

`GET /v1/epochs/{N}/participants` fails outright when the stored `ActiveParticipants` blob has `CreatedAtBlockHeight == 0`: `getEpochParticipants` passes that height straight to `GetValidatorSetByHeight`, CometBFT rejects any height ≤ 0 (`height must be greater than 0, but got 0`), and the error propagates to the HTTP layer — even though the participants data itself was already fetched and unmarshaled successfully.

This is the code-level fatal path identified while investigating #983. **It deliberately does not claim to fix that issue**: as established in the issue thread, the live symptom observed on public nodes today is a 404 for past epochs (reachability of the zero-height path is unresolved and looks operational rather than code-level). This PR closes the latent bug so the endpoint degrades gracefully if/when a zero-height blob is served, matching how the same function already handles other partial-data conditions.

## How do you know this is a real problem?

- Reproducible in a regression test against unmodified code: a stubbed Comet service returning `ActiveParticipants{CreatedAtBlockHeight: 0}` plus a CometBFT-faithful `GetValidatorSetByHeight` error makes the handler return the error instead of the data (output below).
- Zero is a legitimately decodable value: blobs written before the `created_at_block_height` field was added to `activeparticipants.proto` decode with the zero value (the only production writer, `x/inference` EndBlock, always writes a positive height — so zero specifically indicates a pre-field blob).
- The handling is asymmetric within one function: `GetBlockByHeight` failure a few lines earlier is non-fatal (logged, degraded response), while the validator-set call at the same zero height kills the whole response.

## How does this solve the problem?

In `getEpochParticipants`, when `CreatedAtBlockHeight <= 0`, skip the `GetValidatorSetByHeight` call, log a warning, and return the response with an empty `validators` array. Real call failures at valid heights are still fatal, unchanged. One nil-guard added where the validator response is consumed (`validatorsToRawJSON(nil)` already yields `[]`, never `null`). The `validators` schema comment in `openapi.yaml` now documents the degraded case, mirroring the existing `block` field annotation.

## What risks does this introduce? How can we mitigate them?

- **Contract:** consumers see `"validators": []` instead of an error. An empty array is already a reachable value today (a valid-height valset response with zero validators), the field is a required non-nullable array in the schema, and the `block` field already established the degraded-response precedent in this endpoint — so no consumer-visible type change.
- **Proof path untouched:** the diff starts after the ABCI proof query; proof semantics at height 0 (= "latest") are pre-existing and out of scope here.
- Height > 0 behavior is byte-identical to before (same call, same error handling).

## How do you know this PR fixes the problem?

Fail-first regression test, real outputs below: the new test fails on unmodified `epoch.go` with the exact CometBFT error surfacing, and passes with the fix (endpoint returns 200, participants present, `validators` empty, and the doomed RPC is never issued).

## Which components are affected?

- `common/queryapi/epoch.go` — zero-height guard + nil-safe validator consumption (+18/−7)
- `common/queryapi/openapi.yaml` — one-line schema comment for the degraded `validators` case
- `common/queryapi/tests/epoch_participants_zero_height_test.go` — new regression test

## Testing & evidence

Environment: Windows native, Go 1.26.4 (`common/go.mod` pins go 1.25.9), `CGO_ENABLED=1 go test -tags nolink_libwasmvm ./queryapi/...`.

- New test `TestEpochParticipantsZeroHeightSkipsValidatorLookup`: proven to fail on unmodified code (below), passes with the fix.
- Full `./queryapi/...` suite: all packages pass (incl. golden and compatibility tests). `go vet` clean.
- `gofmt`: new test file clean; `epoch.go` was already flagged on `main` before this change (CRLF checkout artifact), not introduced here.

### Before

```
ERROR Failed to get validators subsystem=Participants error="rpc error: code = InvalidArgument desc = height must be greater than 0, but got 0"
--- FAIL: TestEpochParticipantsZeroHeightSkipsValidatorLookup
    code=400, message=height must be greater than 0, but got 0
```

### After

```
WARN Skipping validator set lookup for zero/negative height subsystem=Participants height=0
--- PASS: TestEpochParticipantsZeroHeightSkipsValidatorLookup
ok      common/queryapi/tests
```
