### PR TITLE
fix(devshard): reject bind against settled escrow

### DIFF
--- a/decentralized-api/payloadstorage/managed_storage.go
+++ b/decentralized-api/payloadstorage/managed_storage.go
@@ -2,6 +2,7 @@ package payloadstorage
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -13,7 +14,23 @@ import (
 const (
 	defaultManagedCacheSize = 1000
 	maxPruneLookback        = 10
+	// cleanupInterval is the cleanupLoop tick period. defaultPruneTimeout is
+	// deliberately the same value so a stalled epoch costs at most about one tick
+	// before cleanupLoop is free to run again; sharing the constant makes that
+	// coupling real rather than two literals that could silently drift apart.
+	cleanupInterval = 30 * time.Second
+	// defaultPruneTimeout bounds a single PruneEpoch so a stuck backend cannot
+	// freeze cleanupLoop.
+	defaultPruneTimeout = cleanupInterval
 )
+
+// errPruneInFlight signals that a prune goroutine for this epoch spawned by an
+// earlier tick is still running (it timed out but the ctx-ignoring backend has
+// not returned yet). It is treated exactly like a timeout failure so pruneEpochs
+// stops advancing minPruned and retries next tick, but it deliberately does NOT
+// spawn another goroutine -- that is what caps stuck background prunes at one per
+// epoch instead of one per tick.
+var errPruneInFlight = errors.New("prune already in flight for epoch")
 
 type cachedEntry struct {
 	promptPayload   []byte
@@ -29,11 +46,24 @@ type ManagedStorage struct {
 	retainCount  uint64
 	cacheTTL     time.Duration
 	maxCacheSize int
+	pruneTimeout time.Duration
 
 	mu        sync.RWMutex
 	cache     map[string]*cachedEntry
 	maxEpoch  uint64
 	minPruned uint64
+	// pruning tracks epochs whose background PruneEpoch goroutine is still
+	// outstanding. A ctx-ignoring backend (FileStorage's os.RemoveAll) keeps
+	// running after pruneEpochWithTimeout returns on its deadline; without this
+	// set every tick would spawn a fresh goroutine for the same stuck epoch, so
+	// stuck tasks would accumulate without bound. Guarded by mu.
+	//
+	// A permanently-wedged epoch's marker can outlive its relevance: once the
+	// maxPruneLookback cap laps minPruned past that epoch it is never revisited,
+	// yet the leaked goroutine never returns to clear the entry. That leaves at
+	// most one stale marker per wedged epoch (bounded, negligible), and it is
+	// harmless because nothing ever keys on that epoch again.
+	pruning map[uint64]struct{}
 }
 
 func NewManagedStorage(storage PayloadStorage, retainCount uint64, cacheTTL time.Duration) *ManagedStorage {
@@ -46,7 +76,9 @@ func NewManagedStorageWithSize(storage PayloadStorage, retainCount uint64, cache
 		retainCount:  retainCount,
 		cacheTTL:     cacheTTL,
 		maxCacheSize: maxCacheSize,
+		pruneTimeout: defaultPruneTimeout,
 		cache:        make(map[string]*cachedEntry),
+		pruning:      make(map[uint64]struct{}),
 	}
 	go m.cleanupLoop()
 	return m
@@ -93,7 +125,7 @@ func (m *ManagedStorage) PruneEpoch(ctx context.Context, epochId uint64) error {
 }
 
 func (m *ManagedStorage) cleanupLoop() {
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 
 	for range ticker.C {
@@ -103,7 +135,6 @@ func (m *ManagedStorage) cleanupLoop() {
 
 func (m *ManagedStorage) cleanup() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	now := time.Now()
 	for id, c := range m.cache {
@@ -119,23 +150,94 @@ func (m *ManagedStorage) cleanup() {
 		}
 	}
 
+	var start, threshold uint64
 	if m.maxEpoch > m.retainCount {
-		threshold := m.maxEpoch - m.retainCount
+		threshold = m.maxEpoch - m.retainCount
 
 		if m.minPruned+maxPruneLookback < threshold {
 			m.minPruned = threshold - maxPruneLookback
 		}
+		start = m.minPruned
+	}
+	m.mu.Unlock()
 
-		for epoch := m.minPruned; epoch < threshold; epoch++ {
-			go func(e uint64) {
-				if err := m.storage.PruneEpoch(context.Background(), e); err != nil {
-					logging.Warn("Auto-prune failed", types.PayloadStorage, "epochId", e, "error", err)
-				} else {
-					logging.Info("Auto-pruned epoch", types.PayloadStorage, "epochId", e)
-				}
-			}(epoch)
+	m.pruneEpochs(start, threshold)
+}
+
+// pruneEpochs prunes epochs [start, threshold) in order, advancing minPruned
+// only past epochs that pruned successfully so a failed epoch is retried on
+// the next cleanup tick instead of being skipped forever (#850). Pruning runs
+// outside m.mu so storage I/O does not block cache reads; cleanupLoop is the
+// only caller, so prunes never overlap.
+func (m *ManagedStorage) pruneEpochs(start, threshold uint64) {
+	for epoch := start; epoch < threshold; epoch++ {
+		if err := m.pruneEpochWithTimeout(epoch); err != nil {
+			// errPruneInFlight is the expected steady state under a wedged
+			// ctx-ignoring backend (an earlier goroutine is still running), not a
+			// failure. Return quietly so we do not emit a WARN every tick forever
+			// and trip alerting; pruneEpochWithTimeout already logged it at Info.
+			if errors.Is(err, errPruneInFlight) {
+				return
+			}
+			logging.Warn("Auto-prune failed, will retry on next cleanup", types.PayloadStorage, "epochId", epoch, "error", err)
+			return
 		}
-		m.minPruned = threshold
+		logging.Info("Auto-pruned epoch", types.PayloadStorage, "epochId", epoch)
+
+		m.mu.Lock()
+		m.minPruned = epoch + 1
+		m.mu.Unlock()
+	}
+}
+
+// pruneEpochWithTimeout bounds a single PruneEpoch with m.pruneTimeout so a
+// stuck backend cannot freeze cleanupLoop. The deadline is passed to the
+// backend so ctx-aware stores (Postgres) cancel the in-flight query, and the
+// call also runs in a goroutine so cleanupLoop is released at the deadline even
+// for backends that ignore ctx (FileStorage's os.RemoveAll). A timed-out prune
+// is treated like any other failure: minPruned is not advanced and the epoch is
+// retried on the next cleanup tick. Prunes are idempotent, so a goroutine that
+// completes after the deadline is harmless.
+//
+// The pruning set makes that retry safe under a ctx-ignoring backend: after a
+// timeout the background goroutine keeps running, so we refuse to spawn a second
+// one for the same epoch and instead report errPruneInFlight. That caps live
+// background prunes at one per epoch (rather than one per 30s tick, which would
+// let stuck tasks grow without bound). The goroutine clears the marker when
+// PruneEpoch finally returns, so the next tick starts fresh.
+func (m *ManagedStorage) pruneEpochWithTimeout(epoch uint64) error {
+	// Check-and-set the in-flight marker under a single lock acquisition so two
+	// ticks can never both decide to spawn for the same epoch.
+	m.mu.Lock()
+	if _, inFlight := m.pruning[epoch]; inFlight {
+		m.mu.Unlock()
+		logging.Info("Auto-prune still in flight, skipping respawn", types.PayloadStorage, "epochId", epoch)
+		return errPruneInFlight
+	}
+	m.pruning[epoch] = struct{}{}
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), m.pruneTimeout)
+	defer cancel()
+
+	// Buffered so the prune goroutine never blocks on send if we already
+	// returned via the deadline. The marker is cleared inside the goroutine when
+	// PruneEpoch actually returns (success, error, or ctx-cancel), never at the
+	// deadline -- otherwise a still-running prune would be respawned.
+	done := make(chan error, 1)
+	go func() {
+		err := m.storage.PruneEpoch(ctx, epoch)
+		m.mu.Lock()
+		delete(m.pruning, epoch)
+		m.mu.Unlock()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/decentralized-api/payloadstorage/managed_storage_test.go
+++ b/decentralized-api/payloadstorage/managed_storage_test.go
@@ -3,16 +3,20 @@ package payloadstorage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
 type mockStorage struct {
-	mu      sync.Mutex
-	data    map[string][]byte
-	pruned  []uint64
-	storeCb func(epochId uint64)
+	mu         sync.Mutex
+	data       map[string][]byte
+	pruned     []uint64
+	storeCb    func(epochId uint64)
+	pruneCb    func(epochId uint64) error
+	pruneCtxCb func(ctx context.Context, epochId uint64) error
 }
 
 func newMockStorage() *mockStorage {
@@ -41,8 +45,20 @@ func (m *mockStorage) Retrieve(ctx context.Context, inferenceId string, epochId 
 }
 
 func (m *mockStorage) PruneEpoch(ctx context.Context, epochId uint64) error {
+	// pruneCtxCb runs outside the lock so it can block on ctx (simulating a
+	// stuck backend) without deadlocking observers like getPruned.
+	if m.pruneCtxCb != nil {
+		if err := m.pruneCtxCb(ctx, epochId); err != nil {
+			return err
+		}
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.pruneCb != nil {
+		if err := m.pruneCb(epochId); err != nil {
+			return err
+		}
+	}
 	m.pruned = append(m.pruned, epochId)
 	return nil
 }
@@ -150,11 +166,8 @@ func TestManagedStorage_AutoPruneTriggersInCleanup(t *testing.T) {
 		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
 	}
 
-	// Trigger cleanup manually
+	// Trigger cleanup manually; pruning runs synchronously
 	ms.cleanup()
-
-	// Wait for async prune goroutines
-	time.Sleep(50 * time.Millisecond)
 
 	pruned := mock.getPruned()
 	// threshold = 10 - 2 = 8
@@ -175,7 +188,6 @@ func TestManagedStorage_AutoPruneSkipsOldEpochs(t *testing.T) {
 
 	// Trigger cleanup
 	ms.cleanup()
-	time.Sleep(50 * time.Millisecond)
 
 	pruned := mock.getPruned()
 	// threshold = 100 - 2 = 98
@@ -193,6 +205,251 @@ func TestManagedStorage_AutoPruneSkipsOldEpochs(t *testing.T) {
 	}
 }
 
+func TestManagedStorage_AutoPruneStopsAtFailedEpoch(t *testing.T) {
+	mock := newMockStorage()
+	pruneErr := errors.New("db connection lost")
+	mock.pruneCb = func(epochId uint64) error {
+		if epochId == 3 {
+			return pruneErr
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// threshold = 10 - 2 = 8; epoch 3 fails, so only 0-2 should be pruned
+	ms.cleanup()
+
+	pruned := mock.getPruned()
+	if len(pruned) != 3 {
+		t.Errorf("expected 3 epochs pruned before failure, got %d: %v", len(pruned), pruned)
+	}
+	for _, e := range pruned {
+		if e >= 3 {
+			t.Errorf("epoch %d should not be pruned past the failed epoch 3", e)
+		}
+	}
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 3 {
+		t.Errorf("minPruned should stop at failed epoch 3, got %d", minPruned)
+	}
+}
+
+func TestManagedStorage_AutoPruneRetriesFailedEpoch(t *testing.T) {
+	mock := newMockStorage()
+	failOnce := true
+	mock.pruneCb = func(epochId uint64) error {
+		if epochId == 3 && failOnce {
+			failOnce = false
+			return errors.New("transient failure")
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// First cleanup: prunes 0-2, fails at 3
+	ms.cleanup()
+	// Second cleanup: retries 3, then continues through 7
+	ms.cleanup()
+
+	pruned := mock.getPruned()
+	// threshold = 8: epochs 0-7 all pruned across the two ticks, none skipped
+	if len(pruned) != 8 {
+		t.Errorf("expected 8 epochs pruned after retry, got %d: %v", len(pruned), pruned)
+	}
+	seen := make(map[uint64]bool)
+	for _, e := range pruned {
+		if seen[e] {
+			t.Errorf("epoch %d pruned more than once", e)
+		}
+		seen[e] = true
+	}
+	for e := uint64(0); e < 8; e++ {
+		if !seen[e] {
+			t.Errorf("epoch %d was never pruned", e)
+		}
+	}
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 8 {
+		t.Errorf("minPruned should reach threshold 8 after retry, got %d", minPruned)
+	}
+}
+
+func TestManagedStorage_AutoPruneTimesOutStuckEpoch(t *testing.T) {
+	mock := newMockStorage()
+	// Epoch 3 blocks until its context is cancelled, simulating a stuck backend
+	// (e.g. a DROP TABLE waiting on a lock). Every other epoch prunes instantly.
+	mock.pruneCtxCb = func(ctx context.Context, epochId uint64) error {
+		if epochId == 3 {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ms.pruneTimeout = 20 * time.Millisecond
+
+	ctx := context.Background()
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// Without the per-epoch timeout the stuck epoch 3 would block cleanupLoop
+	// forever; with it, cleanup returns once the deadline fires.
+	done := make(chan struct{})
+	go func() {
+		ms.cleanup()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup never returned: a stuck epoch froze cleanupLoop (per-epoch prune timeout missing)")
+	}
+
+	pruned := mock.getPruned()
+	if len(pruned) != 3 {
+		t.Errorf("expected epochs 0-2 pruned before the stuck epoch, got %d: %v", len(pruned), pruned)
+	}
+	for _, e := range pruned {
+		if e >= 3 {
+			t.Errorf("epoch %d should not be pruned past the stuck epoch 3", e)
+		}
+	}
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 3 {
+		t.Errorf("minPruned should stop at the stuck epoch 3 so it retries next tick, got %d", minPruned)
+	}
+}
+
+func TestManagedStorage_AutoPruneTimesOutCtxIgnoringBackend(t *testing.T) {
+	mock := newMockStorage()
+	release := make(chan struct{})
+	// Epoch 3 blocks WITHOUT observing ctx, simulating a backend like
+	// FileStorage.os.RemoveAll that ignores cancellation. Only the
+	// goroutine+select wrapper (not a bare ctx) can release cleanupLoop here.
+	mock.pruneCtxCb = func(ctx context.Context, epochId uint64) error {
+		if epochId == 3 {
+			<-release
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ms.pruneTimeout = 20 * time.Millisecond
+	defer close(release) // let the leaked prune goroutine finish after the test
+
+	ctx := context.Background()
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ms.cleanup()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup never returned: a ctx-ignoring backend froze cleanupLoop")
+	}
+
+	pruned := mock.getPruned()
+	// Epochs 0-2 pruned; epoch 3 is still blocked in the background goroutine,
+	// so it is not counted and minPruned stops there for retry.
+	if len(pruned) != 3 {
+		t.Errorf("expected epochs 0-2 pruned before the stuck epoch, got %d: %v", len(pruned), pruned)
+	}
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 3 {
+		t.Errorf("minPruned should stop at the stuck epoch 3 for retry, got %d", minPruned)
+	}
+}
+
+func TestManagedStorage_AutoPruneDoesNotStackStuckGoroutines(t *testing.T) {
+	mock := newMockStorage()
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	var stuckInvocations int32
+	// Epoch 3 blocks WITHOUT observing ctx, simulating a ctx-ignoring backend
+	// (FileStorage's os.RemoveAll) whose prune goroutine keeps running after the
+	// deadline. On the OLD code pruneEpochWithTimeout returned on timeout without
+	// tracking that still-running prune, so every cleanup tick spawned a fresh
+	// goroutine for the same stuck epoch -- N ticks meant N live goroutines all
+	// calling PruneEpoch(3) (the maintainer's "stuck tasks keep growing"). The
+	// single-flight guard caps that at exactly one.
+	mock.pruneCtxCb = func(ctx context.Context, epochId uint64) error {
+		if epochId == 3 {
+			atomic.AddInt32(&stuckInvocations, 1)
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ms.pruneTimeout = 20 * time.Millisecond
+	defer close(release) // let the single leaked prune goroutine finish after the test
+
+	ctx := context.Background()
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// Drive several cleanup ticks while epoch 3 stays stuck. Tick 1 spawns the
+	// prune goroutine for epoch 3 and times out; ticks 2+ see the in-flight
+	// marker and return without spawning. Old code: 3 invocations (one per tick).
+	const ticks = 3
+	for i := 0; i < ticks; i++ {
+		ms.cleanup()
+	}
+
+	// The stuck prune runs in a background goroutine; wait until it has actually
+	// entered the blocking callback so the count reflects real invocations rather
+	// than an unscheduled goroutine (which would read 0 and spuriously pass/fail).
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stuck prune goroutine never entered PruneEpoch for epoch 3")
+	}
+
+	if got := atomic.LoadInt32(&stuckInvocations); got != 1 {
+		t.Errorf("stuck epoch 3 must be invoked exactly once across %d ticks, got %d "+
+			"(each extra invocation is a leaked background goroutine that never stops)", ticks, got)
+	}
+
+	// Epochs 0-2 pruned once; epoch 3 stuck, so minPruned stops there for retry.
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 3 {
+		t.Errorf("minPruned should stop at the stuck epoch 3, got %d", minPruned)
+	}
+}
+
 func TestManagedStorage_NoPruneWhenBelowRetainCount(t *testing.T) {
 	mock := newMockStorage()
 	ms := NewManagedStorageWithSize(mock, 5, time.Minute, 100)
@@ -204,11 +461,9 @@ func TestManagedStorage_NoPruneWhenBelowRetainCount(t *testing.T) {
 	}
 
 	ms.cleanup()
-	time.Sleep(50 * time.Millisecond)
 
 	pruned := mock.getPruned()
 	if len(pruned) != 0 {
 		t.Errorf("should not prune when maxEpoch <= retainCount, got %v", pruned)
 	}
 }
-

--- a/devshard/bridge/errors.go
+++ b/devshard/bridge/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrNotImplemented      = errors.New("not implemented")
 	ErrEscrowNotFound      = errors.New("escrow not found")
 	ErrParticipantNotFound = errors.New("participant not found")
+	ErrEscrowSettled       = errors.New("escrow already settled")
 	// ErrChainUnavailable means the chain/query path is temporarily unreachable.
 	// Lazy session create should map this to HTTP 503 so clients can retry.
 	ErrChainUnavailable = errors.New("chain unavailable")
@@ -23,7 +24,8 @@ func ClassifyQueryError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, ErrEscrowNotFound) || errors.Is(err, ErrParticipantNotFound) || errors.Is(err, ErrChainUnavailable) {
+	if errors.Is(err, ErrEscrowNotFound) || errors.Is(err, ErrParticipantNotFound) ||
+		errors.Is(err, ErrChainUnavailable) || errors.Is(err, ErrEscrowSettled) {
 		return err
 	}
 	switch status.Code(err) {

--- a/devshard/bridge/grpc.go
+++ b/devshard/bridge/grpc.go
@@ -97,6 +97,7 @@ func (b *GRPCBridge) GetEscrow(escrowID string) (*EscrowInfo, error) {
 		ValidationRate:            e.ValidationRate,
 		VoteThresholdFactor:       e.VoteThresholdFactor,
 		EpochID:                   e.EpochIndex,
+		Settled:                   e.Settled,
 	}, nil
 }
 

--- a/devshard/bridge/interface.go
+++ b/devshard/bridge/interface.go
@@ -38,6 +38,7 @@ type EscrowInfo struct {
 	// EpochID is the chain epoch_index recorded on the on-chain DevshardEscrow.
 	// Storage uses it as the partition/pruning key.
 	EpochID uint64
+	Settled bool
 }
 
 type HostInfo struct {

--- a/devshard/cmd/devshardctl/escrow_checker.go
+++ b/devshard/cmd/devshardctl/escrow_checker.go
@@ -23,14 +23,15 @@ func NewEscrowChecker(newBridge func() bridge.MainnetBridge) *EscrowChecker {
 	}
 }
 
-// TriggerCheck queries the chain for the given escrow. If confirmed missing,
-// calls deactivate. If another check for the same escrow is already in flight,
-// this call returns immediately (the in-flight check will handle deactivation).
-func (ec *EscrowChecker) TriggerCheck(escrowID string, deactivate func()) {
+// TriggerCheck queries the chain for the given escrow. If confirmed missing or
+// settled, calls deactivate with the reason. If another check for the same
+// escrow is already in flight, this call returns immediately (the in-flight
+// check will handle deactivation).
+func (ec *EscrowChecker) TriggerCheck(escrowID string, deactivate func(reason string)) {
 	ec.triggerCheck(escrowID, deactivate)
 }
 
-func (ec *EscrowChecker) triggerCheck(escrowID string, deactivate func()) {
+func (ec *EscrowChecker) triggerCheck(escrowID string, deactivate func(reason string)) {
 	ec.mu.Lock()
 	if ec.inflight[escrowID] {
 		ec.mu.Unlock()
@@ -55,14 +56,19 @@ func (ec *EscrowChecker) triggerCheck(escrowID string, deactivate func()) {
 		log.Printf("escrow %s chain check skipped: bridge unavailable", escrowID)
 		return
 	}
-	_, err := br.GetEscrow(escrowID)
+	info, err := br.GetEscrow(escrowID)
 	if err != nil {
 		if errors.Is(err, bridge.ErrEscrowNotFound) {
 			log.Printf("escrow %s confirmed missing on chain, deactivating devshard", escrowID)
-			deactivate()
+			deactivate("escrow confirmed missing on chain")
 		} else {
 			log.Printf("escrow %s chain check failed (keeping active): %v", escrowID, err)
 		}
+		return
+	}
+	if info != nil && info.Settled {
+		log.Printf("escrow %s confirmed settled on chain, deactivating devshard", escrowID)
+		deactivate("escrow confirmed settled on chain")
 		return
 	}
 	log.Printf("escrow %s verified on chain, host reported false escrow-not-found", escrowID)

--- a/devshard/cmd/devshardctl/escrow_checker_test.go
+++ b/devshard/cmd/devshardctl/escrow_checker_test.go
@@ -120,7 +120,7 @@ func TestEscrowCheckerDeduplicates(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			checker.TriggerCheck("42", func() {
+			checker.TriggerCheck("42", func(string) {
 				deactivated.Add(1)
 			})
 		}()
@@ -140,7 +140,7 @@ func TestEscrowCheckerKeepsActiveWhenFound(t *testing.T) {
 	checker := NewEscrowChecker(func() bridge.MainnetBridge { return stub })
 	var deactivated atomic.Int64
 
-	checker.TriggerCheck("42", func() {
+	checker.TriggerCheck("42", func(string) {
 		deactivated.Add(1)
 	})
 
@@ -156,7 +156,7 @@ func TestEscrowCheckerKeepsActiveOnChainError(t *testing.T) {
 	checker := NewEscrowChecker(func() bridge.MainnetBridge { return stub })
 	var deactivated atomic.Int64
 
-	checker.TriggerCheck("42", func() {
+	checker.TriggerCheck("42", func(string) {
 		deactivated.Add(1)
 	})
 
@@ -194,6 +194,78 @@ func TestRedundancyCallsEscrowMissing(t *testing.T) {
 	ctx := mustRequestLogContext()
 	r.checkEscrowMissing(ctx, attempts)
 	require.Equal(t, int64(1), called.Load())
+}
+
+func TestRedundancyCallsEscrowMissingOnSettled(t *testing.T) {
+	var called atomic.Int64
+	r := &Redundancy{
+		devshardID: "test-escrow",
+		onEscrowMissing: func() {
+			called.Add(1)
+		},
+	}
+
+	attempts := []*inflight{
+		{
+			hostID: "host-a",
+			nonce:  1,
+			err: &transport.UpstreamStatusError{
+				Path:       "/sessions/test-escrow/chat/completions",
+				StatusCode: http.StatusConflict,
+				Body:       `{"message":"escrow already settled: escrow test-escrow"}`,
+			},
+			done: closedChan(),
+		},
+	}
+
+	ctx := mustRequestLogContext()
+	r.checkEscrowMissing(ctx, attempts)
+	require.Equal(t, int64(1), called.Load())
+}
+
+func TestEscrowCheckerDeactivatesOnSettled(t *testing.T) {
+	stub := &stubMainnetBridge{
+		getEscrow: func(escrowID string) (*bridge.EscrowInfo, error) {
+			return &bridge.EscrowInfo{EscrowID: escrowID, Settled: true}, nil
+		},
+	}
+	checker := NewEscrowChecker(func() bridge.MainnetBridge { return stub })
+	var reason string
+	var deactivated atomic.Int64
+
+	checker.TriggerCheck("42", func(r string) {
+		reason = r
+		deactivated.Add(1)
+	})
+
+	assert.Equal(t, int64(1), deactivated.Load(), "settled escrow must deactivate the devshard")
+	assert.Contains(t, reason, "settled")
+}
+
+func TestIsUpstreamEscrowSettled(t *testing.T) {
+	settled := &transport.UpstreamStatusError{
+		Path:       "/sessions/1/chat/completions",
+		StatusCode: http.StatusConflict,
+		Body:       `{"message":"escrow already settled: escrow 1"}`,
+	}
+	assert.True(t, transport.IsUpstreamEscrowSettled(settled))
+	assert.True(t, transport.IsUpstreamEscrowSettled(fmt.Errorf("send to host: %w", settled)))
+	assert.False(t, transport.IsUpstreamEscrowNotFound(settled))
+
+	versionConflict := &transport.UpstreamStatusError{
+		Path:       "/sessions/1/chat/completions",
+		StatusCode: http.StatusConflict,
+		Body:       `{"message":"session version conflict: stored v1, host v2"}`,
+	}
+	assert.False(t, transport.IsUpstreamEscrowSettled(versionConflict))
+
+	headerOnly := &transport.UpstreamStatusError{
+		Path:          "/sessions/1/chat/completions",
+		StatusCode:    http.StatusConflict,
+		Body:          `{"error":"conflict"}`,
+		DevshardError: transport.DevshardErrorEscrowSettled,
+	}
+	assert.True(t, transport.IsUpstreamEscrowSettled(headerOnly))
 }
 
 func TestRedundancyNoCallbackWithoutEscrowError(t *testing.T) {

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -280,6 +280,9 @@ func buildRuntime(cfg RuntimeConfig, deps runtimeBuildDeps) (*devshardRuntime, e
 	if err != nil {
 		return nil, fmt.Errorf("runtime %s: get escrow: %w", cfg.ID, err)
 	}
+	if escrow.Settled {
+		return nil, fmt.Errorf("runtime %s: %w", cfg.ID, bridge.ErrEscrowSettled)
+	}
 	model := resolveRuntimeModel(cfg.Model, escrow.ModelID, deps.defaultModel, cfg.ID)
 	routePrefix := resolveRuntimeRoutePrefix(cfg.RoutePrefix)
 	session, sm, err := user.NewHTTPSession(user.HTTPSessionConfig{
@@ -3941,7 +3944,7 @@ func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
 	if g.escrowChecker != nil {
 		rt.proxy.redundancy.onEscrowMissing = func() {
 			go g.escrowChecker.TriggerCheck(escrowID, func(reason string) {
-				g.deactivateDevshardByID(escrowID)
+				g.deactivateDevshardByIDWithReason(escrowID, reason)
 				// Escrow is terminal on chain (missing or settled) -- nothing to settle.
 				g.retireRuntime(escrowID, reason)
 			})
@@ -4104,6 +4107,15 @@ func (g *Gateway) retireRotatedDevshard(ctx context.Context, id, reason string, 
 	}
 	log.Printf("escrow_rotation_settling escrow=%s reason=%q", id, reason)
 	if _, err := gatewaySettleDevshardOnChain(g, ctx, id, adminSettleEscrowRequest{}); err != nil {
+		// Already settled on chain: there is nothing left to broadcast, so
+		// retire instead of failing the rotation forever.
+		if errors.Is(err, bridge.ErrEscrowSettled) {
+			log.Printf("escrow_rotation_already_settled escrow=%s reason=%q", id, reason)
+			g.clearSettlementPending(id)
+			g.deactivateDevshardByIDWithReason(id, "escrow settled on chain")
+			g.retireRuntime(id, reason)
+			return true, nil
+		}
 		return false, err
 	}
 	g.retireRuntime(id, reason)
@@ -4222,6 +4234,15 @@ func (g *Gateway) scheduleAutoSettlement(id, reason string) {
 				g.clearSettlementPending(id)
 				log.Printf("auto_settle_confirmed escrow=%s reason=%s tx_hash=%s settler=%s",
 					id, reason, result.TxHash, result.Settler)
+				g.retireRuntime(id, reason)
+				return
+			}
+			if errors.Is(err, bridge.ErrEscrowSettled) {
+				// Terminal: the chain already recorded settlement, so retrying
+				// can only fail. Clear the pending flag so restarts stop
+				// reconciling an escrow that is already done.
+				g.clearSettlementPending(id)
+				log.Printf("auto_settle_already_settled escrow=%s reason=%s", id, reason)
 				g.retireRuntime(id, reason)
 				return
 			}

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -2534,6 +2534,7 @@ func (g *Gateway) handleAdminState(w http.ResponseWriter, r *http.Request) {
 	}
 	views := make([]adminDevshardView, 0, len(state.Devshards))
 	for _, devshard := range state.Devshards {
+		devshard.PrivateKeyHex = ""
 		view := adminDevshardView{GatewayDevshardState: devshard}
 		if snapshot, ok := runtimeByID[devshard.ID]; ok {
 			s := snapshot

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -3940,10 +3940,10 @@ func (g *Gateway) attachEscrowChecker(rt *devshardRuntime) {
 	modelID := rt.model
 	if g.escrowChecker != nil {
 		rt.proxy.redundancy.onEscrowMissing = func() {
-			go g.escrowChecker.TriggerCheck(escrowID, func() {
+			go g.escrowChecker.TriggerCheck(escrowID, func(reason string) {
 				g.deactivateDevshardByID(escrowID)
-				// Escrow no longer exists on chain -- nothing to settle.
-				g.retireRuntime(escrowID, "escrow confirmed missing on chain")
+				// Escrow is terminal on chain (missing or settled) -- nothing to settle.
+				g.retireRuntime(escrowID, reason)
 			})
 		}
 	}

--- a/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
+++ b/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"devshard/bridge"
 )
 
 // newRetireTestGateway builds a minimal Gateway holding a single active runtime
@@ -122,6 +125,24 @@ func TestRetireRotatedDevshardRetiresWithoutSettlement(t *testing.T) {
 
 	_, stillRegistered := g.runtimes["12"]
 	require.False(t, stillRegistered, "no-settle rotation must retire the runtime")
+}
+
+func TestRetireRotatedDevshardRetiresWhenAlreadySettled(t *testing.T) {
+	g, _ := newRetireTestGateway("12")
+	settings := GatewaySettings{EscrowRotation: EscrowRotationSettings{SettlementEnabled: true}}
+
+	oldSettle := gatewaySettleDevshardOnChain
+	gatewaySettleDevshardOnChain = func(_ *Gateway, _ context.Context, id string, _ adminSettleEscrowRequest) (*SettleDevshardEscrowResult, error) {
+		return nil, fmt.Errorf("rehydrate devshard %s for settlement: runtime %s: %w", id, id, bridge.ErrEscrowSettled)
+	}
+	t.Cleanup(func() { gatewaySettleDevshardOnChain = oldSettle })
+
+	settled, err := g.retireRotatedDevshard(context.Background(), "12", "rotated", settings)
+	require.NoError(t, err)
+	require.True(t, settled)
+
+	_, stillRegistered := g.runtimes["12"]
+	require.False(t, stillRegistered, "already-settled rotation must retire the runtime")
 }
 
 // TestRetireRotatedDevshardRetiresAfterSettlement covers the settle terminal

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -804,6 +804,51 @@ func TestGatewayModelsEndpointRejectsUnsupportedMethod(t *testing.T) {
 	require.Equal(t, "GET, HEAD", rec.Header().Get("Allow"))
 }
 
+func TestAdminStateRedactsPrivateKey(t *testing.T) {
+	const privateKey = "super-secret-private-key"
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, []GatewayDevshardState{
+		{
+			RuntimeConfig: RuntimeConfig{
+				ID:            "12",
+				PrivateKeyHex: privateKey,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+				Model:         "Qwen/Test",
+			},
+			Active: true,
+		},
+	}))
+
+	g := NewGateway(nil, NewGatewayLimiter(0, 0), "Qwen/Test")
+	g.store = store
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/state", nil)
+	rec := httptest.NewRecorder()
+	g.handleAdminState(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), privateKey)
+
+	var body struct {
+		Devshards []map[string]any `json:"devshards"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Devshards, 1)
+	require.NotContains(t, body.Devshards[0], "private_key")
+	require.Equal(t, "DEVSHARD_PRIVATE_KEY", body.Devshards[0]["private_key_env"])
+}
+
 func TestAdminDeactivateDevshardAllowsActiveRequestsAndStopsNewChat(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -1054,7 +1054,7 @@ func TestEscrowCheckerUsesBridgeGetEscrow(t *testing.T) {
 	})
 
 	deactivated := false
-	ec.TriggerCheck("83", func() { deactivated = true })
+	ec.TriggerCheck("83", func(string) { deactivated = true })
 	require.Equal(t, "83", gotID)
 	require.True(t, deactivated)
 }

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -502,12 +502,15 @@ func buildGatewayRuntimes(gatewayStore *GatewayStore, gatewayState *GatewayState
 				continue
 			}
 			brokenLocalState := errors.Is(res.err, user.ErrLocalStateUnrecoverable)
-			if brokenLocalState || errors.Is(res.err, bridge.ErrEscrowNotFound) || errors.Is(res.err, errRuntimePrivateKeyMissing) {
+			if brokenLocalState || errors.Is(res.err, bridge.ErrEscrowNotFound) ||
+				errors.Is(res.err, bridge.ErrEscrowSettled) || errors.Is(res.err, errRuntimePrivateKeyMissing) {
 				reason := "runtime could not be loaded"
 				if brokenLocalState {
 					reason = "local state unrecoverable"
 				} else if errors.Is(res.err, bridge.ErrEscrowNotFound) {
 					reason = "escrow missing on chain"
+				} else if errors.Is(res.err, bridge.ErrEscrowSettled) {
+					reason = "escrow settled on chain"
 				} else if errors.Is(res.err, errRuntimePrivateKeyMissing) {
 					reason = "private key missing"
 				}

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -4192,8 +4192,17 @@ func (e *Redundancy) checkEscrowMissing(ctx context.Context, attempts []*infligh
 		return
 	}
 	for _, inf := range attempts {
-		if inf.err != nil && transport.IsUpstreamEscrowNotFound(inf.err) {
+		if inf.err == nil {
+			continue
+		}
+		if transport.IsUpstreamEscrowNotFound(inf.err) {
 			logRequestStage(ctx, "escrow_not_found_reported_by_host",
+				"escrow", e.devshardID, "host", inf.hostID, "nonce", inf.nonce)
+			e.onEscrowMissing()
+			return
+		}
+		if transport.IsUpstreamEscrowSettled(inf.err) {
+			logRequestStage(ctx, "escrow_settled_reported_by_host",
 				"escrow", e.devshardID, "host", inf.hostID, "nonce", inf.nonce)
 			e.onEscrowMissing()
 			return

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -280,7 +280,7 @@ func buildHostManager(
 	manager.SetBinaryVersion(cfg.BinaryLogVersion)
 	chainBridge.OnSettlementFinalizedHandler(manager.HandleSettlementFinalized)
 
-	startHostEventsWarm(ctx, cfg, chainBridge, mlClient, store, closers)
+	startHostEventsWarm(ctx, cfg, chainBridge, mlClient, store, manager.HandleSettlementFinalized, closers)
 
 	if err := manager.RecoverSessions(); err != nil {
 		slog.Warn("recover sessions failed", "error", err)
@@ -332,13 +332,14 @@ func startHostEventsWarm(
 	chainBridge *devshardbridge.ChainBridge,
 	mlClient *mlnodeclient.Client,
 	store devshardstorage.Storage,
+	onSettled func(escrowID string) error,
 	closers *closeStack,
 ) {
 	if !cfg.HostEventsEnabled {
 		slog.Info("hostevents: escrow long-poll warm disabled (DEVSHARD_HOST_EVENTS_ENABLED=false)")
 		return
 	}
-	sink := newEscrowWarmSink(chainBridge, store, slog.Default())
+	sink := newEscrowWarmSink(chainBridge, store, slog.Default(), onSettled)
 	hostCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	closers.Add(func() {

--- a/devshard/cmd/devshardd/bridge/caching.go
+++ b/devshard/cmd/devshardd/bridge/caching.go
@@ -1,7 +1,6 @@
 package bridge
 
 import (
-	"fmt"
 	"log/slog"
 
 	"devshard/bridge"
@@ -51,11 +50,6 @@ func (b *CachingEscrowBridge) GetEscrow(escrowID string) (*bridge.EscrowInfo, er
 	if cacheErr != nil || cached == nil {
 		return nil, err
 	}
-	if cached.Settled {
-		b.log.Warn("escrow: warm cache row is settled, refusing fallback",
-			"escrow_id", escrowID, "live_err", err)
-		return nil, fmt.Errorf("%w: escrow %s", bridge.ErrEscrowSettled, escrowID)
-	}
 	b.log.Info("escrow: serving from long-poll warm cache (live fetch failed)",
 		"escrow_id", escrowID, "live_err", err)
 	return EscrowInfoFromCache(cached), nil
@@ -78,7 +72,6 @@ func EscrowCacheFromInfo(e *bridge.EscrowInfo) storage.EscrowCacheInfo {
 		ValidationRate:            e.ValidationRate,
 		VoteThresholdFactor:       e.VoteThresholdFactor,
 		EpochID:                   e.EpochID,
-		Settled:                   e.Settled,
 	}
 }
 
@@ -99,6 +92,5 @@ func EscrowInfoFromCache(c *storage.EscrowCacheInfo) *bridge.EscrowInfo {
 		ValidationRate:            c.ValidationRate,
 		VoteThresholdFactor:       c.VoteThresholdFactor,
 		EpochID:                   c.EpochID,
-		Settled:                   c.Settled,
 	}
 }

--- a/devshard/cmd/devshardd/bridge/caching.go
+++ b/devshard/cmd/devshardd/bridge/caching.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"fmt"
 	"log/slog"
 
 	"devshard/bridge"
@@ -50,6 +51,11 @@ func (b *CachingEscrowBridge) GetEscrow(escrowID string) (*bridge.EscrowInfo, er
 	if cacheErr != nil || cached == nil {
 		return nil, err
 	}
+	if cached.Settled {
+		b.log.Warn("escrow: warm cache row is settled, refusing fallback",
+			"escrow_id", escrowID, "live_err", err)
+		return nil, fmt.Errorf("%w: escrow %s", bridge.ErrEscrowSettled, escrowID)
+	}
 	b.log.Info("escrow: serving from long-poll warm cache (live fetch failed)",
 		"escrow_id", escrowID, "live_err", err)
 	return EscrowInfoFromCache(cached), nil
@@ -72,6 +78,7 @@ func EscrowCacheFromInfo(e *bridge.EscrowInfo) storage.EscrowCacheInfo {
 		ValidationRate:            e.ValidationRate,
 		VoteThresholdFactor:       e.VoteThresholdFactor,
 		EpochID:                   e.EpochID,
+		Settled:                   e.Settled,
 	}
 }
 
@@ -92,5 +99,6 @@ func EscrowInfoFromCache(c *storage.EscrowCacheInfo) *bridge.EscrowInfo {
 		ValidationRate:            c.ValidationRate,
 		VoteThresholdFactor:       c.VoteThresholdFactor,
 		EpochID:                   c.EpochID,
+		Settled:                   c.Settled,
 	}
 }

--- a/devshard/cmd/devshardd/bridge/caching_test.go
+++ b/devshard/cmd/devshardd/bridge/caching_test.go
@@ -67,17 +67,39 @@ func TestCachingEscrowBridge_ReturnsLiveErrOnCacheMiss(t *testing.T) {
 	require.ErrorIs(t, err, liveErr)
 }
 
+func TestCachingEscrowBridge_RefusesSettledCacheRow(t *testing.T) {
+	inner := &fakeBridge{err: errors.New("chain down")}
+	cache := &fakeCacheStore{info: &storage.EscrowCacheInfo{
+		EscrowID: "1", CreatorAddress: "gonka1owner", EpochID: 9, Settled: true,
+	}}
+	b := NewCachingEscrowBridge(inner, cache, nil)
+
+	_, err := b.GetEscrow("1")
+	require.ErrorIs(t, err, bridge.ErrEscrowSettled)
+}
+
+func TestCachingEscrowBridge_PassesThroughSettledFromChain(t *testing.T) {
+	inner := &fakeBridge{escrow: &bridge.EscrowInfo{EscrowID: "1", Settled: true}}
+	b := NewCachingEscrowBridge(inner, &fakeCacheStore{err: storage.ErrEscrowCacheNotFound}, nil)
+
+	got, err := b.GetEscrow("1")
+	require.NoError(t, err)
+	require.True(t, got.Settled)
+}
+
 func TestEscrowCacheRoundTrip(t *testing.T) {
 	in := &bridge.EscrowInfo{
 		EscrowID: "2", Amount: 1, CreatorAddress: "c", Slots: []string{"a", "b"},
-		TokenPrice: 3, ValidationRate: 4, VoteThresholdFactor: 5, EpochID: 6,
+		TokenPrice: 3, ValidationRate: 4, VoteThresholdFactor: 5, EpochID: 6, Settled: true,
 	}
 	cache := EscrowCacheFromInfo(in)
 	require.Equal(t, uint32(5), cache.VoteThresholdFactor)
+	require.True(t, cache.Settled)
 
 	out := EscrowInfoFromCache(&cache)
 	require.Equal(t, in.CreatorAddress, out.CreatorAddress)
 	require.Equal(t, in.Slots, out.Slots)
 	require.Equal(t, in.VoteThresholdFactor, out.VoteThresholdFactor)
 	require.Equal(t, in.EpochID, out.EpochID)
+	require.True(t, out.Settled)
 }

--- a/devshard/cmd/devshardd/bridge/caching_test.go
+++ b/devshard/cmd/devshardd/bridge/caching_test.go
@@ -67,17 +67,6 @@ func TestCachingEscrowBridge_ReturnsLiveErrOnCacheMiss(t *testing.T) {
 	require.ErrorIs(t, err, liveErr)
 }
 
-func TestCachingEscrowBridge_RefusesSettledCacheRow(t *testing.T) {
-	inner := &fakeBridge{err: errors.New("chain down")}
-	cache := &fakeCacheStore{info: &storage.EscrowCacheInfo{
-		EscrowID: "1", CreatorAddress: "gonka1owner", EpochID: 9, Settled: true,
-	}}
-	b := NewCachingEscrowBridge(inner, cache, nil)
-
-	_, err := b.GetEscrow("1")
-	require.ErrorIs(t, err, bridge.ErrEscrowSettled)
-}
-
 func TestCachingEscrowBridge_PassesThroughSettledFromChain(t *testing.T) {
 	inner := &fakeBridge{escrow: &bridge.EscrowInfo{EscrowID: "1", Settled: true}}
 	b := NewCachingEscrowBridge(inner, &fakeCacheStore{err: storage.ErrEscrowCacheNotFound}, nil)
@@ -90,16 +79,14 @@ func TestCachingEscrowBridge_PassesThroughSettledFromChain(t *testing.T) {
 func TestEscrowCacheRoundTrip(t *testing.T) {
 	in := &bridge.EscrowInfo{
 		EscrowID: "2", Amount: 1, CreatorAddress: "c", Slots: []string{"a", "b"},
-		TokenPrice: 3, ValidationRate: 4, VoteThresholdFactor: 5, EpochID: 6, Settled: true,
+		TokenPrice: 3, ValidationRate: 4, VoteThresholdFactor: 5, EpochID: 6,
 	}
 	cache := EscrowCacheFromInfo(in)
 	require.Equal(t, uint32(5), cache.VoteThresholdFactor)
-	require.True(t, cache.Settled)
 
 	out := EscrowInfoFromCache(&cache)
 	require.Equal(t, in.CreatorAddress, out.CreatorAddress)
 	require.Equal(t, in.Slots, out.Slots)
 	require.Equal(t, in.VoteThresholdFactor, out.VoteThresholdFactor)
 	require.Equal(t, in.EpochID, out.EpochID)
-	require.True(t, out.Settled)
 }

--- a/devshard/cmd/devshardd/bridge/chain.go
+++ b/devshard/cmd/devshardd/bridge/chain.go
@@ -131,6 +131,7 @@ func (b *ChainBridge) GetEscrow(escrowID string) (*bridge.EscrowInfo, error) {
 		ValidationRate:            e.ValidationRate,
 		VoteThresholdFactor:       e.VoteThresholdFactor,
 		EpochID:                   e.EpochIndex,
+		Settled:                   e.Settled,
 	}, nil
 }
 

--- a/devshard/cmd/devshardd/hostevents_sink.go
+++ b/devshard/cmd/devshardd/hostevents_sink.go
@@ -16,16 +16,17 @@ import (
 // It uses the live (non-caching) bridge so the warm write always reflects chain
 // truth; the caching bridge is only used on the read/bind side.
 type escrowWarmSink struct {
-	bridge bridge.MainnetBridge
-	store  devshardstorage.Storage
-	log    *slog.Logger
+	bridge    bridge.MainnetBridge
+	store     devshardstorage.Storage
+	log       *slog.Logger
+	onSettled func(escrowID string) error
 }
 
-func newEscrowWarmSink(b bridge.MainnetBridge, store devshardstorage.Storage, log *slog.Logger) *escrowWarmSink {
+func newEscrowWarmSink(b bridge.MainnetBridge, store devshardstorage.Storage, log *slog.Logger, onSettled func(string) error) *escrowWarmSink {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &escrowWarmSink{bridge: b, store: store, log: log}
+	return &escrowWarmSink{bridge: b, store: store, log: log, onSettled: onSettled}
 }
 
 // WarmEscrow fetches escrow metadata from chain and caches it for lazy bind.
@@ -45,12 +46,19 @@ func (s *escrowWarmSink) WarmEscrow(escrowID string) error {
 	return nil
 }
 
-// OnEscrowSettled drops the warm cache row for a settled escrow.
+// OnEscrowSettled drops the warm cache row and finalizes any live session so a
+// missed websocket event cannot leave a settled escrow serving inference.
 func (s *escrowWarmSink) OnEscrowSettled(escrowID string) error {
 	if err := s.store.DeleteEscrowCache(escrowID); err != nil {
 		return fmt.Errorf("drop escrow cache %s: %w", escrowID, err)
 	}
 	s.log.Debug("hostevents: dropped settled escrow from cache", "escrow_id", escrowID)
+	if s.onSettled == nil {
+		return nil
+	}
+	if err := s.onSettled(escrowID); err != nil {
+		return fmt.Errorf("finalize settled escrow %s: %w", escrowID, err)
+	}
 	return nil
 }
 

--- a/devshard/cmd/devshardd/hostevents_sink.go
+++ b/devshard/cmd/devshardd/hostevents_sink.go
@@ -34,6 +34,10 @@ func (s *escrowWarmSink) WarmEscrow(escrowID string) error {
 	if err != nil {
 		return fmt.Errorf("warm escrow %s: %w", escrowID, err)
 	}
+	if info.Settled {
+		s.log.Debug("hostevents: skipping warm of settled escrow", "escrow_id", escrowID)
+		return s.OnEscrowSettled(escrowID)
+	}
 	if err := s.store.PutEscrowCache(devshardbridge.EscrowCacheFromInfo(info)); err != nil {
 		return fmt.Errorf("cache escrow %s: %w", escrowID, err)
 	}

--- a/devshard/cmd/devshardd/hostevents_sink_test.go
+++ b/devshard/cmd/devshardd/hostevents_sink_test.go
@@ -50,6 +50,20 @@ func TestEscrowWarmSink_WarmEscrowChainErrorDoesNotCache(t *testing.T) {
 	require.ErrorIs(t, err, devshardstorage.ErrEscrowCacheNotFound)
 }
 
+func TestEscrowWarmSink_WarmSettledEscrowDoesNotCache(t *testing.T) {
+	store := devshardstorage.NewMemory()
+	require.NoError(t, store.PutEscrowCache(devshardstorage.EscrowCacheInfo{EscrowID: "1", EpochID: 3}))
+	br := &sinkFakeBridge{escrow: &bridge.EscrowInfo{
+		EscrowID: "1", CreatorAddress: "gonka1owner", EpochID: 3, Settled: true,
+	}}
+	sink := newEscrowWarmSink(br, store, nil)
+
+	require.NoError(t, sink.WarmEscrow("1"))
+
+	_, err := store.GetEscrowCache("1")
+	require.ErrorIs(t, err, devshardstorage.ErrEscrowCacheNotFound)
+}
+
 func TestEscrowWarmSink_OnEscrowSettledDropsCache(t *testing.T) {
 	store := devshardstorage.NewMemory()
 	require.NoError(t, store.PutEscrowCache(devshardstorage.EscrowCacheInfo{EscrowID: "1", EpochID: 1}))

--- a/devshard/cmd/devshardd/hostevents_sink_test.go
+++ b/devshard/cmd/devshardd/hostevents_sink_test.go
@@ -28,7 +28,7 @@ func TestEscrowWarmSink_WarmEscrowPopulatesCache(t *testing.T) {
 	br := &sinkFakeBridge{escrow: &bridge.EscrowInfo{
 		EscrowID: "1", CreatorAddress: "gonka1owner", EpochID: 3, Amount: 100, VoteThresholdFactor: 2,
 	}}
-	sink := newEscrowWarmSink(br, store, nil)
+	sink := newEscrowWarmSink(br, store, nil, nil)
 
 	require.NoError(t, sink.WarmEscrow("1"))
 
@@ -42,7 +42,7 @@ func TestEscrowWarmSink_WarmEscrowPopulatesCache(t *testing.T) {
 func TestEscrowWarmSink_WarmEscrowChainErrorDoesNotCache(t *testing.T) {
 	store := devshardstorage.NewMemory()
 	br := &sinkFakeBridge{err: errors.New("chain down")}
-	sink := newEscrowWarmSink(br, store, nil)
+	sink := newEscrowWarmSink(br, store, nil, nil)
 
 	require.Error(t, sink.WarmEscrow("1"))
 
@@ -56,18 +56,44 @@ func TestEscrowWarmSink_WarmSettledEscrowDoesNotCache(t *testing.T) {
 	br := &sinkFakeBridge{escrow: &bridge.EscrowInfo{
 		EscrowID: "1", CreatorAddress: "gonka1owner", EpochID: 3, Settled: true,
 	}}
-	sink := newEscrowWarmSink(br, store, nil)
+	var finalized []string
+	sink := newEscrowWarmSink(br, store, nil, func(id string) error {
+		finalized = append(finalized, id)
+		return nil
+	})
 
 	require.NoError(t, sink.WarmEscrow("1"))
 
 	_, err := store.GetEscrowCache("1")
 	require.ErrorIs(t, err, devshardstorage.ErrEscrowCacheNotFound)
+	require.Equal(t, []string{"1"}, finalized, "warming a settled escrow must finalize the session")
+}
+
+func TestEscrowWarmSink_OnEscrowSettledFinalizesSession(t *testing.T) {
+	store := devshardstorage.NewMemory()
+	var finalized []string
+	sink := newEscrowWarmSink(&sinkFakeBridge{}, store, nil, func(id string) error {
+		finalized = append(finalized, id)
+		return nil
+	})
+
+	require.NoError(t, sink.OnEscrowSettled("7"))
+	require.Equal(t, []string{"7"}, finalized)
+}
+
+func TestEscrowWarmSink_OnEscrowSettledPropagatesFinalizeError(t *testing.T) {
+	store := devshardstorage.NewMemory()
+	sink := newEscrowWarmSink(&sinkFakeBridge{}, store, nil, func(string) error {
+		return errors.New("mark settled failed")
+	})
+
+	require.Error(t, sink.OnEscrowSettled("7"))
 }
 
 func TestEscrowWarmSink_OnEscrowSettledDropsCache(t *testing.T) {
 	store := devshardstorage.NewMemory()
 	require.NoError(t, store.PutEscrowCache(devshardstorage.EscrowCacheInfo{EscrowID: "1", EpochID: 1}))
-	sink := newEscrowWarmSink(&sinkFakeBridge{}, store, nil)
+	sink := newEscrowWarmSink(&sinkFakeBridge{}, store, nil, nil)
 
 	require.NoError(t, sink.OnEscrowSettled("1"))
 

--- a/devshard/cmd/devshardd/session/bind_obs_test.go
+++ b/devshard/cmd/devshardd/session/bind_obs_test.go
@@ -129,6 +129,25 @@ func TestOwnerChat_BindsSession(t *testing.T) {
 	require.Equal(t, user.Address(), meta.CreatorAddr)
 }
 
+func TestOwnerChat_SettledEscrow_DoesNotBindSession(t *testing.T) {
+	const escrowID = "owner-bind-settled"
+	mgr, store, user, _ := setupBindTestManager(t, escrowID)
+	mgr.bridge.(*mockBridge).escrow.Settled = true
+	e := echo.New()
+	mgr.Register(e.Group(""))
+
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	rec := signedPOST(t, e, user, "/sessions/"+escrowID+"/chat/completions", escrowID, body)
+	require.Equal(t, http.StatusConflict, rec.Code, "body: %s", rec.Body.String())
+
+	_, err := store.GetSessionMeta(escrowID)
+	require.ErrorIs(t, err, storage.ErrSessionNotFound)
+
+	active, err := store.ListActiveSessions()
+	require.NoError(t, err)
+	require.Empty(t, active)
+}
+
 type countingGetEscrowBridge struct {
 	bridge.MainnetBridge
 	calls int

--- a/devshard/cmd/devshardd/session/bind_obs_test.go
+++ b/devshard/cmd/devshardd/session/bind_obs_test.go
@@ -148,6 +148,25 @@ func TestOwnerChat_SettledEscrow_DoesNotBindSession(t *testing.T) {
 	require.Empty(t, active)
 }
 
+func TestOwnerChat_SettledLocalRow_ReturnsConflict(t *testing.T) {
+	const escrowID = "owner-bind-settled-row"
+	mgr, store, user, _ := setupBindTestManager(t, escrowID)
+	e := echo.New()
+	mgr.Register(e.Group(""))
+
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	signedPOST(t, e, user, "/sessions/"+escrowID+"/chat/completions", escrowID, body)
+	meta, err := store.GetSessionMeta(escrowID)
+	require.NoError(t, err, "precondition: first chat must bind the session")
+	require.Equal(t, "active", meta.Status)
+
+	require.NoError(t, mgr.HandleSettlementFinalized(escrowID))
+
+	rec := signedPOST(t, e, user, "/sessions/"+escrowID+"/chat/completions", escrowID, body)
+	require.Equal(t, http.StatusConflict, rec.Code, "body: %s", rec.Body.String())
+	require.Equal(t, transport.DevshardErrorEscrowSettled, rec.Header().Get(transport.HeaderDevshardError))
+}
+
 type countingGetEscrowBridge struct {
 	bridge.MainnetBridge
 	calls int

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -197,6 +197,10 @@ func (m *HostManager) BindOwnerChat(c echo.Context) (*transport.Server, error) {
 	if escrow == nil || escrow.CreatorAddress == "" || addr != escrow.CreatorAddress {
 		return nil, echo.NewHTTPError(http.StatusForbidden, "restricted to escrow owner")
 	}
+	if escrow.Settled {
+		m.rememberResolutionFailure(escrowID, bridge.ErrEscrowSettled, time.Now())
+		return nil, fmt.Errorf("%w: escrow %s", bridge.ErrEscrowSettled, escrowID)
+	}
 
 	// Pass the already-fetched escrow so create() does not GetEscrow again.
 	srv, err = m.getOrCreate(escrowID, escrow)
@@ -222,15 +226,16 @@ func (m *HostManager) HandleSettlementFinalized(escrowID string) error {
 		observability.DeleteEscrowMetrics(escrowID)
 	}
 
+	// Negative-cache so a concurrent/next bind does not recoverStoredSession
+	// the just-settled row (getOrCreate also rejects non-active meta).
+	m.rememberResolutionFailure(escrowID, bridge.ErrEscrowSettled, time.Now())
+
 	if err := m.store.MarkSettled(escrowID); err != nil {
 		if errors.Is(err, storage.ErrSessionNotFound) && !hadSession {
 			return nil
 		}
 		return err
 	}
-	// Negative-cache so a concurrent/next bind does not recoverStoredSession
-	// the just-settled row (getOrCreate also rejects non-active meta).
-	m.rememberResolutionFailure(escrowID, storage.ErrSessionNotActive, time.Now())
 	return nil
 }
 
@@ -256,7 +261,11 @@ func (m *HostManager) getOrCreate(escrowID string, escrow *bridge.EscrowInfo) (*
 		// Prefer recovering an already-bound session over CreateSession.
 		srv, err := m.recoverStoredSession(escrowID)
 		if err == nil {
-			return m.storeSessionIfAbsent(escrowID, srv), nil
+			installed, storeErr := m.storeSessionIfAbsent(escrowID, srv)
+			if storeErr != nil {
+				return nil, storeErr
+			}
+			return installed, nil
 		}
 		if !errors.Is(err, storage.ErrSessionNotFound) {
 			return nil, err
@@ -267,7 +276,11 @@ func (m *HostManager) getOrCreate(escrowID string, escrow *bridge.EscrowInfo) (*
 			return nil, err
 		}
 
-		return m.storeSessionIfAbsent(escrowID, srv), nil
+		installed, storeErr := m.storeSessionIfAbsent(escrowID, srv)
+		if storeErr != nil {
+			return nil, storeErr
+		}
+		return installed, nil
 	})
 
 	if err != nil {
@@ -319,20 +332,44 @@ func isPermanentResolutionFailure(err error) bool {
 	return errors.Is(err, storage.ErrSessionVersionConflict) ||
 		errors.Is(err, storage.ErrSessionEpochConflict) ||
 		errors.Is(err, storage.ErrEpochPruned) ||
-		errors.Is(err, storage.ErrSessionNotActive)
+		errors.Is(err, storage.ErrSessionNotActive) ||
+		errors.Is(err, bridge.ErrEscrowSettled)
 }
 
-func (m *HostManager) storeSessionIfAbsent(escrowID string, srv *transport.Server) *transport.Server {
+// storeSessionIfAbsent installs srv unless the escrow was settled while the
+// caller was building it. The settled tombstone is re-checked under
+// sessionsMutex so a settlement racing create/recover cannot be erased by the
+// unconditional resolutionFailures delete below.
+func (m *HostManager) storeSessionIfAbsent(escrowID string, srv *transport.Server) (*transport.Server, error) {
+	installed, settled := m.installSession(escrowID, srv, time.Now())
+	if settled {
+		srv.Host().Close()
+		if err := m.store.MarkSettled(escrowID); err != nil && !errors.Is(err, storage.ErrSessionNotFound) {
+			logging.Error("failed to mark racing session settled", inferenceTypes.System,
+				"escrow_id", escrowID, "error", err)
+		}
+		return nil, fmt.Errorf("%w: escrow %s", bridge.ErrEscrowSettled, escrowID)
+	}
+	if installed != srv {
+		srv.Host().Close()
+	}
+	return installed, nil
+}
+
+func (m *HostManager) installSession(escrowID string, srv *transport.Server, now time.Time) (*transport.Server, bool) {
 	m.sessionsMutex.Lock()
 	defer m.sessionsMutex.Unlock()
 	if existing, ok := m.sessions[escrowID]; ok {
-		srv.Host().Close()
-		return existing
+		return existing, false
+	}
+	if cached, ok := m.resolutionFailures[escrowID]; ok &&
+		now.Before(cached.expiresAt) && errors.Is(cached.err, bridge.ErrEscrowSettled) {
+		return nil, true
 	}
 	delete(m.resolutionFailures, escrowID)
 	m.sessions[escrowID] = srv
 	srv.Host().Start()
-	return srv
+	return srv, false
 }
 
 // EvictBefore drops in-memory sessions whose epoch is below cutoffEpoch and
@@ -367,6 +404,9 @@ func (m *HostManager) create(escrowID string, escrow *bridge.EscrowInfo) (*trans
 		if err != nil {
 			return nil, fmt.Errorf("get escrow: %w", err)
 		}
+	}
+	if escrow.Settled {
+		return nil, fmt.Errorf("%w: escrow %s", bridge.ErrEscrowSettled, escrowID)
 	}
 
 	group, err := bridge.BuildGroupFromEscrow(escrow)
@@ -455,7 +495,11 @@ func (m *HostManager) recoverAndStoreSession(escrowID string) (*transport.Server
 		if err != nil {
 			return nil, err
 		}
-		return m.storeSessionIfAbsent(escrowID, srv), nil
+		installed, storeErr := m.storeSessionIfAbsent(escrowID, srv)
+		if storeErr != nil {
+			return nil, storeErr
+		}
+		return installed, nil
 	})
 	if err != nil {
 		return nil, err

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"path/filepath"
@@ -256,6 +257,159 @@ func TestCreateSession_BindsConfiguredVersion(t *testing.T) {
 	require.Equal(t, standaloneVersion, meta.Version)
 }
 
+func TestCreate_RejectsSettledEscrow(t *testing.T) {
+	store := newManagerTestStore(t)
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	addresses := make([]string, len(group))
+	for i, s := range group {
+		addresses[i] = s.ValidatorAddress
+	}
+
+	br := &mockBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       "1",
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+			Settled:        true,
+		},
+	}
+
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	_, err := mgr.getOrCreate("1", nil)
+	require.ErrorIs(t, err, bridge.ErrEscrowSettled)
+
+	_, err = store.GetSessionMeta("1")
+	require.ErrorIs(t, err, storage.ErrSessionNotFound)
+
+	_, err = mgr.getOrCreate("1", nil)
+	require.ErrorIs(t, err, bridge.ErrEscrowSettled)
+}
+
+func TestHandleSettlementFinalized_NoLocalRow_BlocksColdBind(t *testing.T) {
+	store := newManagerTestStore(t)
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	addresses := make([]string, len(group))
+	for i, s := range group {
+		addresses[i] = s.ValidatorAddress
+	}
+
+	br := &mockBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       "1",
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+		},
+	}
+
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	require.NoError(t, mgr.HandleSettlementFinalized("1"))
+
+	_, err := mgr.getOrCreate("1", nil)
+	require.ErrorIs(t, err, bridge.ErrEscrowSettled)
+
+	_, err = store.GetSessionMeta("1")
+	require.ErrorIs(t, err, storage.ErrSessionNotFound)
+}
+
+// TestStoreSessionIfAbsent_RejectsSettlementRacingCreate covers the interleaving
+// where settlement lands after create() read an open escrow but before the built
+// server is installed: the tombstone must survive, no session may go live, and
+// the row create() already wrote must not stay active for RecoverSessions.
+func TestStoreSessionIfAbsent_RejectsSettlementRacingCreate(t *testing.T) {
+	store := newManagerTestStore(t)
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	addresses := make([]string, len(group))
+	for i, s := range group {
+		addresses[i] = s.ValidatorAddress
+	}
+
+	escrow := &bridge.EscrowInfo{
+		EscrowID:       "1",
+		EpochID:        7,
+		Amount:         100000,
+		CreatorAddress: user.Address(),
+		Slots:          addresses,
+	}
+	br := &mockBridge{escrow: escrow}
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+
+	require.NoError(t, mgr.HandleSettlementFinalized("1"))
+
+	srv, err := mgr.create("1", escrow)
+	require.NoError(t, err)
+
+	_, err = mgr.storeSessionIfAbsent("1", srv)
+	require.ErrorIs(t, err, bridge.ErrEscrowSettled)
+
+	_, ok := mgr.existingServer("1")
+	require.False(t, ok, "settled escrow must not get a live session")
+
+	meta, err := store.GetSessionMeta("1")
+	require.NoError(t, err)
+	require.NotEqual(t, "active", meta.Status, "racing row must not stay active")
+
+	active, err := store.ListActiveSessions()
+	require.NoError(t, err)
+	require.Empty(t, active)
+
+	_, err = mgr.getOrCreate("1", nil)
+	require.ErrorIs(t, err, bridge.ErrEscrowSettled, "tombstone must survive the rejected install")
+}
+
+func TestInstallSession_IgnoresTransientAndExpiredFailures(t *testing.T) {
+	store := newManagerTestStore(t)
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	addresses := make([]string, len(group))
+	for i, s := range group {
+		addresses[i] = s.ValidatorAddress
+	}
+
+	escrow := &bridge.EscrowInfo{
+		EscrowID:       "1",
+		EpochID:        7,
+		Amount:         100000,
+		CreatorAddress: user.Address(),
+		Slots:          addresses,
+	}
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{escrow: escrow}, nil, nil)
+
+	now := time.Now()
+	mgr.rememberResolutionFailure("1", bridge.ErrChainUnavailable, now)
+
+	srv, err := mgr.create("1", escrow)
+	require.NoError(t, err)
+	installed, err := mgr.storeSessionIfAbsent("1", srv)
+	require.NoError(t, err, "a transient failure must not block install")
+	require.Equal(t, srv, installed)
+
+	mgr.EvictBefore(8)
+	mgr.rememberResolutionFailure("2", bridge.ErrEscrowSettled, now)
+	_, settled := mgr.installSession("2", srv, now.Add(permanentFailureTTL+time.Second))
+	require.False(t, settled, "an expired settled tombstone must not block install")
+}
+
 func TestRecoverSessions_EmptyStore(t *testing.T) {
 	store := newManagerTestStore(t)
 	signer := mustGenerateKey(t)
@@ -298,11 +452,11 @@ func TestHandleSettlementFinalized_DoesNotResurrect(t *testing.T) {
 	require.False(t, ok, "settlement must drop the live session")
 
 	_, err := mgr.getOrCreate("1", nil)
-	require.ErrorIs(t, err, storage.ErrSessionNotActive)
+	require.ErrorIs(t, err, bridge.ErrEscrowSettled)
 
 	// Permanent negative cache: a second bind must not re-read/rebuild.
 	_, err = mgr.getOrCreate("1", nil)
-	require.ErrorIs(t, err, storage.ErrSessionNotActive)
+	require.ErrorIs(t, err, bridge.ErrEscrowSettled)
 	_, ok = mgr.existingServer("1")
 	require.False(t, ok, "settled session must stay out of the live map")
 }

--- a/devshard/observability/ctx.go
+++ b/devshard/observability/ctx.go
@@ -128,6 +128,7 @@ const (
 	ReasonEpochConflict               Reason = "epoch_conflict"
 	ReasonBuildGroupErr               Reason = "build_group_err"
 	ReasonGetEscrowErr                Reason = "get_escrow_err"
+	ReasonEscrowSettled               Reason = "escrow_settled"
 	ReasonStorageErr                  Reason = "storage_err"
 	ReasonSessionResolveErr           Reason = "session_resolve_err"
 	ReasonModifyRequestErr            Reason = "modify_request_err"

--- a/devshard/server/routes.go
+++ b/devshard/server/routes.go
@@ -139,7 +139,7 @@ func sessionResolutionStatus(err error) (observability.MetricStatus, observabili
 	if errors.Is(err, storage.ErrSessionNotFound) {
 		return observability.MetricStatusError, observability.ReasonSessionResolveErr
 	}
-	if errors.Is(err, bridge.ErrEscrowSettled) {
+	if errors.Is(err, bridge.ErrEscrowSettled) || errors.Is(err, storage.ErrSessionNotActive) {
 		return observability.MetricStatusError, observability.ReasonEscrowSettled
 	}
 	if errors.Is(err, bridge.ErrChainUnavailable) {
@@ -206,7 +206,7 @@ func sessionHTTPError(c echo.Context, err error) error {
 	if errors.Is(err, bridge.ErrChainUnavailable) {
 		return transport.HTTPError(c, http.StatusServiceUnavailable, transport.DevshardErrorChainUnavailable, err.Error())
 	}
-	if errors.Is(err, bridge.ErrEscrowSettled) {
+	if errors.Is(err, bridge.ErrEscrowSettled) || errors.Is(err, storage.ErrSessionNotActive) {
 		return transport.HTTPError(c, http.StatusConflict, transport.DevshardErrorEscrowSettled, err.Error())
 	}
 	if errors.Is(err, storage.ErrSessionVersionConflict) || errors.Is(err, storage.ErrSessionEpochConflict) {

--- a/devshard/server/routes.go
+++ b/devshard/server/routes.go
@@ -139,6 +139,9 @@ func sessionResolutionStatus(err error) (observability.MetricStatus, observabili
 	if errors.Is(err, storage.ErrSessionNotFound) {
 		return observability.MetricStatusError, observability.ReasonSessionResolveErr
 	}
+	if errors.Is(err, bridge.ErrEscrowSettled) {
+		return observability.MetricStatusError, observability.ReasonEscrowSettled
+	}
 	if errors.Is(err, bridge.ErrChainUnavailable) {
 		return observability.MetricStatusError, observability.ReasonGetEscrowErr
 	}
@@ -202,6 +205,9 @@ func sessionHTTPError(c echo.Context, err error) error {
 	}
 	if errors.Is(err, bridge.ErrChainUnavailable) {
 		return transport.HTTPError(c, http.StatusServiceUnavailable, transport.DevshardErrorChainUnavailable, err.Error())
+	}
+	if errors.Is(err, bridge.ErrEscrowSettled) {
+		return transport.HTTPError(c, http.StatusConflict, transport.DevshardErrorEscrowSettled, err.Error())
 	}
 	if errors.Is(err, storage.ErrSessionVersionConflict) || errors.Is(err, storage.ErrSessionEpochConflict) {
 		return echo.NewHTTPError(http.StatusConflict, err.Error())

--- a/devshard/storage/interface.go
+++ b/devshard/storage/interface.go
@@ -122,6 +122,7 @@ type EscrowCacheInfo struct {
 	ValidationRate            uint32   `json:"validation_rate"`
 	VoteThresholdFactor       uint32   `json:"vote_threshold_factor"`
 	EpochID                   uint64   `json:"epoch_id"`
+	Settled                   bool     `json:"settled,omitempty"`
 }
 
 // ValidationObsEntry identifies one validation or validation-vote application

--- a/devshard/storage/interface.go
+++ b/devshard/storage/interface.go
@@ -122,7 +122,6 @@ type EscrowCacheInfo struct {
 	ValidationRate            uint32   `json:"validation_rate"`
 	VoteThresholdFactor       uint32   `json:"vote_threshold_factor"`
 	EpochID                   uint64   `json:"epoch_id"`
-	Settled                   bool     `json:"settled,omitempty"`
 }
 
 // ValidationObsEntry identifies one validation or validation-vote application

--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -109,9 +109,9 @@ type requestAdmissionBodyObserver interface {
 var ErrSSEStreamTruncated = errors.New("sse stream ended without [DONE] or devshard_receipt")
 
 type UpstreamStatusError struct {
-	Path       string
-	StatusCode int
-	Body       string
+	Path          string
+	StatusCode    int
+	Body          string
 	DevshardError string
 }
 

--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -112,6 +112,7 @@ type UpstreamStatusError struct {
 	Path       string
 	StatusCode int
 	Body       string
+	DevshardError string
 }
 
 func (e *UpstreamStatusError) Error() string {
@@ -133,6 +134,20 @@ func IsUpstreamEscrowNotFound(err error) bool {
 	}
 	return ue.StatusCode == http.StatusInternalServerError &&
 		strings.Contains(ue.Body, "escrow not found")
+}
+
+// IsUpstreamEscrowSettled returns true if err is an UpstreamStatusError whose
+// body indicates the host refused to serve an escrow already settled on chain.
+func IsUpstreamEscrowSettled(err error) bool {
+	var ue *UpstreamStatusError
+	if !errors.As(err, &ue) {
+		return false
+	}
+	if ue.DevshardError == DevshardErrorEscrowSettled {
+		return true
+	}
+	return ue.StatusCode == http.StatusConflict &&
+		strings.Contains(ue.Body, "escrow already settled")
 }
 
 func DefaultClientConfig() ClientConfig {
@@ -638,9 +653,10 @@ func (c *HTTPClient) doPostRaw(ctx context.Context, path string, body []byte) (*
 		resp.Body.Close()
 		c.observeResultWithBody(path, resp.StatusCode, string(respBody))
 		return nil, &UpstreamStatusError{
-			Path:       path,
-			StatusCode: resp.StatusCode,
-			Body:       string(respBody),
+			Path:          path,
+			StatusCode:    resp.StatusCode,
+			Body:          string(respBody),
+			DevshardError: resp.Header.Get(HeaderDevshardError),
 		}
 	}
 	c.observeResult(path, resp.StatusCode)
@@ -680,9 +696,10 @@ func (c *HTTPClient) doGet(ctx context.Context, url string) ([]byte, error) {
 		respBody, _ := io.ReadAll(resp.Body)
 		c.observeResultWithBody(url, resp.StatusCode, string(respBody))
 		return nil, &UpstreamStatusError{
-			Path:       url,
-			StatusCode: resp.StatusCode,
-			Body:       string(respBody),
+			Path:          url,
+			StatusCode:    resp.StatusCode,
+			Body:          string(respBody),
+			DevshardError: resp.Header.Get(HeaderDevshardError),
 		}
 	}
 	c.observeResult(url, resp.StatusCode)

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -112,6 +112,24 @@ func TestHTTPClient_Send_ReturnsUpstreamStatusError(t *testing.T) {
 	require.Contains(t, statusErr.Body, "bad signature")
 }
 
+func TestHTTPClient_Send_CapturesDevshardErrorHeader(t *testing.T) {
+	userSigner := testutil.MustGenerateKey(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(HeaderDevshardError, DevshardErrorEscrowSettled)
+		http.Error(w, "escrow already settled: escrow 1", http.StatusConflict)
+	}))
+	t.Cleanup(ts.Close)
+
+	client := NewHTTPClient(ts.URL, "escrow-1", userSigner)
+	_, err := client.Send(context.Background(), host.HostRequest{Nonce: 1}, nil, nil)
+	require.Error(t, err)
+
+	var statusErr *UpstreamStatusError
+	require.True(t, errors.As(err, &statusErr))
+	require.Equal(t, DevshardErrorEscrowSettled, statusErr.DevshardError)
+	require.True(t, IsUpstreamEscrowSettled(err))
+}
+
 func TestHTTPClient_Send_NoPayloadUsesQueryTimeout(t *testing.T) {
 	signer := testutil.MustGenerateKey(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/devshard/transport/httperror.go
+++ b/devshard/transport/httperror.go
@@ -14,6 +14,7 @@ const (
 	DevshardErrorInitializing     = "initializing"
 	DevshardErrorNotImplemented   = "not_implemented"
 	DevshardErrorChainUnavailable = "chain_unavailable"
+	DevshardErrorEscrowSettled    = "escrow_settled"
 )
 
 // HTTPError returns an echo HTTP error and sets X-Devshard-Error when devshardCode is non-empty.

--- a/inference-chain/app/upgrades.go
+++ b/inference-chain/app/upgrades.go
@@ -18,6 +18,7 @@ import (
 	"github.com/productscience/inference/app/upgrades/v0_2_13"
 	"github.com/productscience/inference/app/upgrades/v0_2_14"
 	"github.com/productscience/inference/app/upgrades/v0_2_15"
+	"github.com/productscience/inference/app/upgrades/v0_2_16"
 	v0_2_2 "github.com/productscience/inference/app/upgrades/v0_2_2"
 	v0_2_3 "github.com/productscience/inference/app/upgrades/v0_2_3"
 	"github.com/productscience/inference/app/upgrades/v0_2_4"
@@ -71,6 +72,7 @@ func (app *App) setupUpgradeHandlers() {
 	app.setTrackedUpgradeHandler(v0_2_13.UpgradeName, v0_2_13.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.AuthzKeeper, app.GovKeeper))
 	app.setTrackedUpgradeHandler(v0_2_14.UpgradeName, v0_2_14.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.GenesistransferKeeper, app.MintKeeper))
 	app.setTrackedUpgradeHandler(v0_2_15.UpgradeName, v0_2_15.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.AuthzKeeper))
+	app.setTrackedUpgradeHandler(v0_2_16.UpgradeName, v0_2_16.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper))
 }
 
 func (app *App) registerMigrations() {

--- a/inference-chain/app/upgrades/v0_2_16/constants.go
+++ b/inference-chain/app/upgrades/v0_2_16/constants.go
@@ -1,0 +1,4 @@
+package v0_2_16
+
+// UpgradeName MUST exactly match the on-chain governance proposal name.
+const UpgradeName = "v0.2.16"

--- a/inference-chain/app/upgrades/v0_2_16/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_16/upgrades.go
@@ -1,0 +1,45 @@
+// Package v0_2_16 holds the upgrade handler scaffold for the v0.2.16 release.
+//
+// At bootstrap time this stays intentionally small: capability-version fix
+// plus RunMigrations. As upgrade work lands, add migration steps below the
+// capability fix and above RunMigrations.
+//
+// If later work bumps a module ConsensusVersion, it must also register the
+// corresponding migration in app/upgrades.go's registerMigrations().
+package v0_2_16
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	k keeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		k.LogInfo("starting upgrade", types.Upgrades, "version", UpgradeName)
+
+		// Capability state can already exist even when the version map entry is
+		// missing. Set it explicitly so RunMigrations does not re-run InitGenesis.
+		if _, ok := fromVM["capability"]; !ok {
+			fromVM["capability"] = mm.Modules["capability"].(module.HasConsensusVersion).ConsensusVersion()
+		}
+
+		// Future v0.2.16 migration steps land below this line.
+
+		toVM, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return toVM, err
+		}
+
+		k.LogInfo("successfully upgraded", types.Upgrades, "version", UpgradeName)
+		return toVM, nil
+	}
+}

--- a/inference-chain/app/upgrades/v0_2_16/upgrades_test.go
+++ b/inference-chain/app/upgrades/v0_2_16/upgrades_test.go
@@ -1,0 +1,13 @@
+package v0_2_16
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpgradeName pins the future on-chain proposal name. The governance
+// proposal and UpgradeName must stay identical or the handler will not run.
+func TestUpgradeName(t *testing.T) {
+	require.Equal(t, "v0.2.16", UpgradeName)
+}


### PR DESCRIPTION
## Problem

`EscrowInfo` dropped the on-chain `settled` flag at the bridge boundary, so devshardd could lazily bind a new session against an escrow that was already settled - work the host can never be paid for, since the chain rejects a second settle (`VerifyDevshardSettlement`, `devshard_settlement.go:86`).


## Changes

**Plumb the flag** — `EscrowInfo.Settled`, mapped in both bridge implementations (`bridge/grpc.go`, `cmd/devshardd/bridge/chain.go`).

**Gate the bind path** (`session/manager.go`)
- `create()` rejects settled escrows — the choke point for all bind entry points
- `BindOwnerChat` rejects early, after the owner check so escrow state doesn't leak to non-owners
- `ErrEscrowSettled` added to `isPermanentResolutionFailure` (10-min cache)
- `HandleSettlementFinalized` negative-caches before `MarkSettled`, covering hosts with no local row
- `storeSessionIfAbsent` re-checks the settled tombstone **under `sessionsMutex`**, closing a TOCTOU where a settlement landing mid-`create()` was erased by the unconditional `resolutionFailures` delete. On rejection it closes the server and marks the row settled so `RecoverSessions` can't resurrect it. Matches only `ErrEscrowSettled`, so a concurrent transient failure can't block a legitimate create.

**Close the stale-cache path** — `EscrowCacheInfo.Settled` (rides the existing `escrow_json` blob, no migration); the warm sink drops rather than caches a settled escrow; a settled cache row is refused instead of serving stale metadata during a chain outage.

**Gateway self-healing** — a bare 409 matched none of the existing terminal-escrow detection, so the gateway would have kept a dead devshard active, retrying every host in the group. Added `X-Devshard-Error: escrow_settled`, captured it in
`UpstreamStatusError` (code first, body match retained for old hosts), wired it into `checkEscrowMissing`, and taught `EscrowChecker` to deactivate when the chain itself reports `Settled` — previously it logged "false escrow-not-found" and kept the runtime alive, since a settled escrow *is* still found on chain.