### PR TITLE
fix(mlnode): link libnvrtc.so where the linker looks

### DIFF
--- a/mlnode/packages/api/Dockerfile
+++ b/mlnode/packages/api/Dockerfile
@@ -29,6 +29,8 @@ ENV PATH="/usr/local/openssl-1.1/bin:${PATH}" \
 
 RUN ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13 \
         /usr/local/cuda/lib64/libnvrtc.so \
+    && ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13 \
+        /usr/local/lib/libnvrtc.so \
     && ldconfig \
     && python3 -c "import vllm; assert vllm.__version__.startswith('0.25.1')" \
     && python3 -c "from gonka_poc.worker import PoCWorkerExtension; from vllm.v1.worker.gpu.sample.replay import ReplayState"


### PR DESCRIPTION
Hopper does not start on `mlnode:3.0.14-post2-vllm0.25.1-rc1`: the engine fails on its first JIT link because `-lnvrtc` does not resolve.

The image does carry a symlink, but only at `/usr/local/cuda/lib64/libnvrtc.so`, which is not on the default library search path. Verified on the published rc1 image — a probe build that links a trivial program with `-lnvrtc` fails there, and succeeds once the same link exists under `/usr/local/lib`.

Not Hopper-specific in origin: the library is missing from the search path for every card, it just surfaces on Hopper because that is where the JIT path runs by default.
