### PR TITLE
fix(devshard): align RuntimeTestVersion with Effective protocol

### DIFF
--- a/devshard/cmd/devshardd/session/stats_test.go
+++ b/devshard/cmd/devshardd/session/stats_test.go
@@ -90,7 +90,6 @@ func createStoredSessionWithVersion(t *testing.T, store storage.Storage, escrowI
 	}))
 
 	sm, err := state.NewStateMachine(escrowID, config, group, 100000000, user.Address(), verifier, store,
-		state.WithStateRootAndProtocolVersion(types.EffectiveStateRootAndProtocolVersion),
 		state.WithVersion(version),
 	)
 	require.NoError(t, err)

--- a/devshard/internal/testutil/version.go
+++ b/devshard/internal/testutil/version.go
@@ -1,5 +1,11 @@
 package testutil
 
+import "devshard/types"
+
 // RuntimeTestVersion is the protocol / session bind tag used in tests
 // (CreateSessionParams.Version, host boundVersion, state-root version).
-const RuntimeTestVersion = "v2"
+//
+// It tracks EffectiveStateRootAndProtocolVersion so tests stay consistent when
+// the default protocol constant moves (e.g. merge onto gateway-v4 where it is
+// "v4") and when binaries are link-stamped via DEVSHARD_VERSION.
+var RuntimeTestVersion = types.EffectiveStateRootAndProtocolVersion


### PR DESCRIPTION
Stats helpers stop hardcoding v2 while asserting Effective (v4 on gateway-v4), which broke TestStatsShardDetailReturnsStatsOnly.