### PR TITLE
fix(mlnode): align installed version with release

### DIFF
--- a/mlnode/Makefile
+++ b/mlnode/Makefile
@@ -94,7 +94,8 @@ build-release:
 	docker build \
 		-t $(IMAGE_NAME) \
 		-f packages/api/Dockerfile \
-		--target app \
+		--target release \
+		--build-arg MLNODE_VERSION=$(VERSION) \
 		$(PROJECT_ROOT)
 
 	docker tag $(IMAGE_NAME) $(IMAGE_NAME_GITHUB)

--- a/mlnode/packages/api/Dockerfile
+++ b/mlnode/packages/api/Dockerfile
@@ -92,6 +92,18 @@ WORKDIR /app
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 
+################################################################################
+FROM app AS release
+
+ARG MLNODE_VERSION
+
+RUN --mount=type=bind,source=packages/api/pyproject.toml,target=/tmp/pyproject.toml \
+    declared_version="$(python3 -c 'import tomllib; print(tomllib.load(open("/tmp/pyproject.toml", "rb"))["tool"]["poetry"]["version"])')" \
+    && if [ "$declared_version" != "$MLNODE_VERSION" ]; then \
+        echo "error: MLNode version $declared_version does not match image tag $MLNODE_VERSION"; \
+        exit 1; \
+    fi
+
 
 ################################################################################
 FROM builder AS test

--- a/mlnode/packages/api/pyproject.toml
+++ b/mlnode/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mlnode-api"
-version = "0.2.0"
+version = "3.0.14-post2"
 description = "MLNode API package"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Problem

The MLNode image is tagged with its release version, but packages/api/pyproject.toml still declared version 0.2.0. MLNode reports that installed metadata through /api/v1/state, and DAPI forwards it through /v1/versions. A 3.0.14-post2 image therefore reported 0.2.0.

## Change

- Declare the current MLNode version as 3.0.14-post2
- Build release images through a release-only Docker target
- Pass the image tag to that target and fail the build unless it exactly matches the version declared in pyproject.toml

The check is release-only, so development, application and test image targets remain unchanged. No API fields or runtime version overrides are added.

## Reproduction before this change

TestNet:
```bash
curl -fsS http://89.169.111.79:8000/v1/versions | jq ".mlnodes"
```
The endpoint reports MLNode version 0.2.0 while the same response reports the TestNet API and chain as the v0.2.15 release family.

Mainnet:
```bash
curl -fsS http://node1.gonka.ai:8000/v1/versions | jq ".mlnodes"
# equivalent TLS endpoint:
curl -fsS https://node1.gonka.ai:8443/v1/versions | jq ".mlnodes"
```
Both endpoints report MLNode version 0.2.0 although they report API and chain v0.2.15 releases.

## Verification

- The PR changes only mlnode/Makefile, mlnode/packages/api/Dockerfile and mlnode/packages/api/pyproject.toml
- git diff --check
- A complete release-target build with MLNODE_VERSION=3.0.14-post2 succeeds
- The built image reports installed MLNode metadata as 3.0.14.post2, the PEP 440 canonical form of 3.0.14-post2
- A release-target build with mismatched MLNODE_VERSION=0.2.0 fails with the expected version mismatch
