### PR TITLE
fix(devshard): reject non-canonical escrow ids

### DIFF
--- a/devshard/bridge/grpc.go
+++ b/devshard/bridge/grpc.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"common/chain"
+	devshardpkg "devshard"
 
 	inferencetypes "github.com/productscience/inference/x/inference/types"
 )
@@ -47,11 +48,7 @@ func NewGRPCBridgeFromURL(grpcURL string) (*GRPCBridge, error) {
 }
 
 func parseEscrowID(escrowID string) (uint64, error) {
-	id, err := strconv.ParseUint(escrowID, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid escrow id %q: %w", escrowID, err)
-	}
-	return id, nil
+	return devshardpkg.ParseEscrowID(escrowID)
 }
 
 func (b *GRPCBridge) GetEscrow(escrowID string) (*EscrowInfo, error) {
@@ -82,7 +79,7 @@ func (b *GRPCBridge) GetEscrow(escrowID string) (*EscrowInfo, error) {
 	copy(slots, e.Slots)
 
 	return &EscrowInfo{
-		EscrowID:                  escrowID,
+		EscrowID:                  strconv.FormatUint(id, 10),
 		Amount:                    e.Amount,
 		CreatorAddress:            e.Creator,
 		AppHash:                   appHash,

--- a/devshard/bridge/grpc_test.go
+++ b/devshard/bridge/grpc_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"common/chain"
+	devshardpkg "devshard"
 	"devshard/bridge"
 	"devshard/testenv/mockchain/grpcface"
 	"devshard/testenv/mockchain/seed"
@@ -72,6 +73,14 @@ func TestGRPCBridge_GetEscrow_MapsSessionConfigFields(t *testing.T) {
 	require.Equal(t, uint32(67), info.VoteThresholdFactor)
 	require.Equal(t, int64(5), info.RefusalTimeout)
 	require.Equal(t, int64(17), info.ExecutionTimeout)
+}
+
+func TestGRPCBridge_GetEscrow_RejectsNonCanonicalID(t *testing.T) {
+	b := startGRPCBridge(t)
+	for _, raw := range []string{"01", "001", "0", ""} {
+		_, err := b.GetEscrow(raw)
+		require.ErrorIs(t, err, devshardpkg.ErrInvalidEscrowID, "escrow id %q", raw)
+	}
 }
 
 func TestGRPCBridge_GetEscrow_NotFound(t *testing.T) {

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	defaultPort     = "8080"
-	defaultEscrowID = "escrow-1"
+	defaultEscrowID = "1"
 )
 
 func main() {

--- a/devshard/cmd/devshardctl/chain_tx.go
+++ b/devshard/cmd/devshardctl/chain_tx.go
@@ -4,8 +4,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
+
+	devshardpkg "devshard"
 
 	chaintx "common/chain/tx"
 
@@ -115,8 +116,8 @@ func parseEscrowIDString(raw string) (uint64, error) {
 	if raw == "" {
 		return 0, fmt.Errorf("escrow_id is required")
 	}
-	id, err := strconv.ParseUint(raw, 10, 64)
-	if err != nil || id == 0 {
+	id, err := devshardpkg.ParseEscrowID(raw)
+	if err != nil {
 		return 0, fmt.Errorf("invalid escrow_id %q", raw)
 	}
 	return id, nil

--- a/devshard/cmd/devshardctl/chain_tx_encode.go
+++ b/devshard/cmd/devshardctl/chain_tx_encode.go
@@ -50,7 +50,7 @@ func signerFromRequestKey(privateKey, privateKeyEnv string) (*signing.Secp256k1S
 }
 
 func encodeMsgSettleDevshardEscrow(settler string, settlement SettlementJSON) ([]byte, error) {
-	escrowID, err := strconv.ParseUint(strings.TrimSpace(settlement.EscrowID), 10, 64)
+	escrowID, err := parseEscrowIDString(settlement.EscrowID)
 	if err != nil {
 		return nil, fmt.Errorf("parse escrow_id: %w", err)
 	}

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -4266,6 +4266,9 @@ func finalizeRuntimeConfigs(runtimes []RuntimeConfig, defaultModel, baseStorageD
 		if cfg.ID == "" {
 			return nil, fmt.Errorf("runtime config missing id")
 		}
+		if err := devshardpkg.ValidateEscrowID(cfg.ID); err != nil {
+			return nil, fmt.Errorf("runtime config: %w", err)
+		}
 		if _, ok := seen[cfg.ID]; ok {
 			return nil, fmt.Errorf("duplicate runtime id %s", cfg.ID)
 		}

--- a/devshard/cmd/devshardd/bridge/caching.go
+++ b/devshard/cmd/devshardd/bridge/caching.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"log/slog"
 
+	devshardpkg "devshard"
 	"devshard/bridge"
 	"devshard/storage"
 )
@@ -39,6 +40,9 @@ func NewCachingEscrowBridge(inner bridge.MainnetBridge, store EscrowCacheStore, 
 // cache row exists, it serves the cached metadata instead, returning the live
 // error only when the cache also has nothing.
 func (b *CachingEscrowBridge) GetEscrow(escrowID string) (*bridge.EscrowInfo, error) {
+	if err := devshardpkg.ValidateEscrowID(escrowID); err != nil {
+		return nil, err
+	}
 	info, err := b.MainnetBridge.GetEscrow(escrowID)
 	if err == nil {
 		return info, nil

--- a/devshard/cmd/devshardd/bridge/chain.go
+++ b/devshard/cmd/devshardd/bridge/chain.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"common/chain"
+	devshardpkg "devshard"
 	"devshard/bridge"
 	"devshard/cmd/devshardd/events"
 
@@ -82,11 +83,7 @@ func (b *ChainBridge) OnSettlementFinalizedHandler(fn func(string) error) {
 }
 
 func parseEscrowID(escrowID string) (uint64, error) {
-	id, err := strconv.ParseUint(escrowID, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid escrow id %q: %w", escrowID, err)
-	}
-	return id, nil
+	return devshardpkg.ParseEscrowID(escrowID)
 }
 
 // -- MainnetBridge query methods --
@@ -116,7 +113,7 @@ func (b *ChainBridge) GetEscrow(escrowID string) (*bridge.EscrowInfo, error) {
 	copy(slots, e.Slots)
 
 	return &bridge.EscrowInfo{
-		EscrowID:                  escrowID,
+		EscrowID:                  strconv.FormatUint(id, 10),
 		Amount:                    e.Amount,
 		CreatorAddress:            e.Creator,
 		AppHash:                   appHash,

--- a/devshard/cmd/devshardd/session/bind_obs_test.go
+++ b/devshard/cmd/devshardd/session/bind_obs_test.go
@@ -61,7 +61,7 @@ func signedPOST(t *testing.T, e *echo.Echo, signer *signing.Secp256k1Signer, pat
 }
 
 func TestObsGET_DoesNotBindSession(t *testing.T) {
-	const escrowID = "obs-unbound"
+	const escrowID = "9701"
 	mgr, store, _, _ := setupBindTestManager(t, escrowID)
 
 	e := echo.New()
@@ -81,7 +81,7 @@ func TestObsGET_DoesNotBindSession(t *testing.T) {
 }
 
 func TestObsMempoolSignatures_DoNotBindSession(t *testing.T) {
-	const escrowID = "obs-unbound-2"
+	const escrowID = "9702"
 	mgr, store, _, _ := setupBindTestManager(t, escrowID)
 	e := echo.New()
 	mgr.Register(e.Group(""))
@@ -101,7 +101,7 @@ func TestObsMempoolSignatures_DoNotBindSession(t *testing.T) {
 }
 
 func TestGossipUnbound_DoesNotBindSession(t *testing.T) {
-	const escrowID = "gossip-unbound"
+	const escrowID = "9703"
 	mgr, store, _, hostSigner := setupBindTestManager(t, escrowID)
 	e := echo.New()
 	mgr.Register(e.Group(""))
@@ -115,7 +115,7 @@ func TestGossipUnbound_DoesNotBindSession(t *testing.T) {
 }
 
 func TestOwnerChat_BindsSession(t *testing.T) {
-	const escrowID = "owner-bind"
+	const escrowID = "9704"
 	mgr, store, user, _ := setupBindTestManager(t, escrowID)
 	e := echo.New()
 	mgr.Register(e.Group(""))
@@ -140,7 +140,7 @@ func (b *countingGetEscrowBridge) GetEscrow(escrowID string) (*bridge.EscrowInfo
 }
 
 func TestOwnerChat_FirstBindSingleGetEscrow(t *testing.T) {
-	const escrowID = "owner-bind-once"
+	const escrowID = "9705"
 	store := newManagerTestStore(t)
 	hosts := make([]*signing.Secp256k1Signer, 3)
 	for i := range hosts {
@@ -176,7 +176,7 @@ func TestOwnerChat_FirstBindSingleGetEscrow(t *testing.T) {
 }
 
 func TestNonOwnerChat_DoesNotBindSession(t *testing.T) {
-	const escrowID = "non-owner-bind"
+	const escrowID = "9706"
 	mgr, store, _, hostSigner := setupBindTestManager(t, escrowID)
 	e := echo.New()
 	mgr.Register(e.Group(""))
@@ -190,7 +190,7 @@ func TestNonOwnerChat_DoesNotBindSession(t *testing.T) {
 }
 
 func TestSessionServerExisting_NoCreate(t *testing.T) {
-	const escrowID = "existing-miss"
+	const escrowID = "9707"
 	mgr, store, _, _ := setupBindTestManager(t, escrowID)
 
 	_, err := mgr.SessionServerExisting(escrowID)

--- a/devshard/cmd/devshardd/session/escrow_alias_test.go
+++ b/devshard/cmd/devshardd/session/escrow_alias_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/storage"
+	"devshard/stub"
+)
+
+func TestLeadingZeroEscrowAliasRejectedAtBind(t *testing.T) {
+	const escrowID = "9901"
+	const alias = "09901"
+
+	mgr, store, user, _ := setupBindTestManager(t, escrowID)
+	e := echo.New()
+	mgr.Register(e.Group(""))
+
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+
+	rec := signedPOST(t, e, user, "/sessions/"+escrowID+"/chat/completions", escrowID, body)
+	_, err := store.GetSessionMeta(escrowID)
+	require.NoError(t, err, "canonical bind must create the session; http=%d body=%s", rec.Code, rec.Body.String())
+
+	aliasRec := signedPOST(t, e, user, "/sessions/"+alias+"/chat/completions", alias, body)
+	require.Equal(t, http.StatusBadRequest, aliasRec.Code, "body: %s", aliasRec.Body.String())
+
+	_, err = store.GetSessionMeta(alias)
+	require.ErrorIs(t, err, storage.ErrSessionNotFound, "alias must not create a second durable session")
+
+	active, err := store.ListActiveSessions()
+	require.NoError(t, err)
+	require.Len(t, active, 1)
+	require.Equal(t, escrowID, active[0].EscrowID)
+	require.Equal(t, []string{escrowID}, mgr.ActiveEscrowIDs())
+}
+
+func TestLeadingZeroEscrowAliasRejectedOnSessionRoutes(t *testing.T) {
+	const escrowID = "9902"
+	const alias = "09902"
+	mgr, _, _, hostSigner := setupBindTestManager(t, escrowID)
+	e := echo.New()
+	mgr.Register(e.Group(""))
+
+	for _, path := range []string{
+		"/sessions/" + alias + "/diffs",
+		"/sessions/" + alias + "/mempool",
+		"/sessions/" + alias + "/signatures",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusBadRequest, rec.Code, "path=%s body=%s", path, rec.Body.String())
+	}
+
+	gossip := signedPOST(t, e, hostSigner, "/sessions/"+alias+"/gossip/nonce", alias, []byte(`{"nonce":1}`))
+	require.Equal(t, http.StatusBadRequest, gossip.Code, "body: %s", gossip.Body.String())
+}
+
+func TestBindOwnerChatRejectsAliasBeforeAuth(t *testing.T) {
+	const escrowID = "9903"
+	const alias = "009903"
+	mgr, store, user, _ := setupBindTestManager(t, escrowID)
+
+	e := echo.New()
+	e.POST("/sessions/:id/chat/completions", func(c echo.Context) error {
+		_, err := mgr.BindOwnerChat(c)
+		return err
+	})
+
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	rec := signedPOST(t, e, user, "/sessions/"+alias+"/chat/completions", alias, body)
+	require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+
+	_, err := store.GetSessionMeta(alias)
+	require.ErrorIs(t, err, storage.ErrSessionNotFound)
+}
+
+func TestCreateRejectsNonCanonicalEscrowID(t *testing.T) {
+	mgr, _, _, _ := setupBindTestManager(t, "9904")
+
+	_, err := mgr.create("09904", nil)
+	require.ErrorContains(t, err, "invalid escrow id")
+
+	_, err = mgr.getOrCreate("09904", nil)
+	require.ErrorContains(t, err, "invalid escrow id")
+}
+
+func TestRecoverSessionsSkipsNonCanonicalStoredSessions(t *testing.T) {
+	store := newManagerTestStore(t)
+	_, _, hostSigner := createStoredSession(t, store, "9905", 7, 0)
+
+	meta, err := store.GetSessionMeta("9905")
+	require.NoError(t, err)
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "09905",
+		EpochID:        meta.EpochID,
+		Version:        meta.Version,
+		CreatorAddr:    meta.CreatorAddr,
+		Config:         meta.Config,
+		Group:          meta.Group,
+		InitialBalance: meta.InitialBalance,
+	}))
+
+	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil,
+		testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	require.NoError(t, mgr.RecoverSessions())
+
+	require.Equal(t, []string{"9905"}, mgr.ActiveEscrowIDs())
+}

--- a/devshard/cmd/devshardd/session/escrow_alias_test.go
+++ b/devshard/cmd/devshardd/session/escrow_alias_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"devshard/internal/testutil"
+	"devshard/signing"
 	"devshard/storage"
 	"devshard/stub"
 )
@@ -91,14 +92,14 @@ func TestCreateRejectsNonCanonicalEscrowID(t *testing.T) {
 	require.ErrorContains(t, err, "invalid escrow id")
 }
 
-func TestRecoverSessionsSkipsNonCanonicalStoredSessions(t *testing.T) {
-	store := newManagerTestStore(t)
-	_, _, hostSigner := createStoredSession(t, store, "9905", 7, 0)
+func seedNonCanonicalStoredSession(t *testing.T, store storage.Storage, canonical, alias string) *signing.Secp256k1Signer {
+	t.Helper()
+	_, _, hostSigner := createStoredSession(t, store, canonical, 7, 0)
 
-	meta, err := store.GetSessionMeta("9905")
+	meta, err := store.GetSessionMeta(canonical)
 	require.NoError(t, err)
 	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
-		EscrowID:       "09905",
+		EscrowID:       alias,
 		EpochID:        meta.EpochID,
 		Version:        meta.Version,
 		CreatorAddr:    meta.CreatorAddr,
@@ -106,10 +107,44 @@ func TestRecoverSessionsSkipsNonCanonicalStoredSessions(t *testing.T) {
 		Group:          meta.Group,
 		InitialBalance: meta.InitialBalance,
 	}))
+	return hostSigner
+}
+
+func TestRecoverSessionsRetiresNonCanonicalStoredSessions(t *testing.T) {
+	store := newManagerTestStore(t)
+	hostSigner := seedNonCanonicalStoredSession(t, store, "9905", "09905")
 
 	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil,
 		testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
 	require.NoError(t, mgr.RecoverSessions())
 
 	require.Equal(t, []string{"9905"}, mgr.ActiveEscrowIDs())
+
+	meta, err := store.GetSessionMeta("09905")
+	require.NoError(t, err)
+	require.NotEqual(t, "active", meta.Status, "non-canonical row must be retired, not left active")
+
+	active, err := store.ListActiveSessions()
+	require.NoError(t, err)
+	require.Len(t, active, 1)
+	require.Equal(t, "9905", active[0].EscrowID)
+}
+
+func TestStatsDetailCannotResurrectNonCanonicalSession(t *testing.T) {
+	store := newManagerTestStore(t)
+	hostSigner := seedNonCanonicalStoredSession(t, store, "9906", "09906")
+
+	mgr := NewHostManager(currentEpochStore{Storage: store, epoch: 7}, hostSigner,
+		stub.NewInferenceEngine(), stub.NewValidationEngine(), nil,
+		testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+
+	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/09906")
+	require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+
+	_, loaded := mgr.existingServer("09906")
+	require.False(t, loaded, "alias session must not be loaded into memory")
+	require.Empty(t, mgr.ActiveEscrowIDs())
+
+	_, err := mgr.SessionServerExisting("09906")
+	require.ErrorContains(t, err, "invalid escrow id")
 }

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -436,8 +436,12 @@ func (m *HostManager) RecoverSessions() error {
 
 	for _, active := range escrowIDs {
 		if err := devshardpkg.ValidateEscrowID(active.EscrowID); err != nil {
-			logging.Error("skipping devshard session with non-canonical escrow id", inferenceTypes.System,
+			logging.Error("retiring devshard session with non-canonical escrow id", inferenceTypes.System,
 				"escrow_id", active.EscrowID, "error", err)
+			if markErr := m.store.MarkSettled(active.EscrowID); markErr != nil {
+				logging.Error("failed to retire non-canonical devshard session", inferenceTypes.System,
+					"escrow_id", active.EscrowID, "error", markErr)
+			}
 			continue
 		}
 		if _, err := m.recoverAndStoreSession(active.EscrowID); err != nil {
@@ -476,6 +480,9 @@ func (m *HostManager) recoverAndStoreSession(escrowID string) (*transport.Server
 
 // recoverStoredSession replays a single session from storage.
 func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, error) {
+	if err := devshardpkg.ValidateEscrowID(escrowID); err != nil {
+		return nil, err
+	}
 	meta, err := m.store.GetSessionMeta(escrowID)
 	if err != nil {
 		return nil, fmt.Errorf("get session meta: %w", err)

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -173,6 +173,9 @@ func (m *HostManager) SessionServerExisting(escrowID string) (*transport.Server,
 // Auth context (sender + body) is injected for HandleInference.
 func (m *HostManager) BindOwnerChat(c echo.Context) (*transport.Server, error) {
 	escrowID := c.Param("id")
+	if err := devshardpkg.ValidateEscrowID(escrowID); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
 	addr, body, err := transport.VerifyPOSTAuth(c, m.verifier, escrowID, 0)
 	if err != nil {
 		return nil, err
@@ -361,6 +364,9 @@ func (m *HostManager) EvictBefore(cutoffEpoch uint64) int {
 }
 
 func (m *HostManager) create(escrowID string, escrow *bridge.EscrowInfo) (*transport.Server, error) {
+	if err := devshardpkg.ValidateEscrowID(escrowID); err != nil {
+		return nil, err
+	}
 	if escrow == nil {
 		var err error
 		escrow, err = m.bridge.GetEscrow(escrowID)
@@ -429,6 +435,11 @@ func (m *HostManager) RecoverSessions() error {
 	}
 
 	for _, active := range escrowIDs {
+		if err := devshardpkg.ValidateEscrowID(active.EscrowID); err != nil {
+			logging.Error("skipping devshard session with non-canonical escrow id", inferenceTypes.System,
+				"escrow_id", active.EscrowID, "error", err)
+			continue
+		}
 		if _, err := m.recoverAndStoreSession(active.EscrowID); err != nil {
 			if errors.Is(err, storage.ErrSessionVersionConflict) {
 				logging.Info("skipping devshard session with foreign version", inferenceTypes.System,

--- a/devshard/cmd/devshardd/session/stats.go
+++ b/devshard/cmd/devshardd/session/stats.go
@@ -14,6 +14,7 @@ import (
 	"common/logging"
 	inferenceTypes "github.com/productscience/inference/x/inference/types"
 
+	devshardpkg "devshard"
 	"devshard/observability"
 	devshardserver "devshard/server"
 	"devshard/storage"
@@ -401,6 +402,9 @@ func validationObservabilityFromStore(store storage.Storage, escrowID string) st
 func statsHTTPError(err error) error {
 	if errors.Is(err, storage.ErrSessionNotFound) {
 		return echo.NewHTTPError(http.StatusNotFound, "shard not found")
+	}
+	if errors.Is(err, devshardpkg.ErrInvalidEscrowID) {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if errors.Is(err, storage.ErrSessionVersionConflict) || errors.Is(err, storage.ErrSessionEpochConflict) {
 		return echo.NewHTTPError(http.StatusConflict, err.Error())

--- a/devshard/cmd/devshardd/session/stats_test.go
+++ b/devshard/cmd/devshardd/session/stats_test.go
@@ -188,7 +188,7 @@ func TestStatsShardsSkipsSessionsWithUnreadableMeta(t *testing.T) {
 
 func TestStatsShardDetailReturnsStatsOnly(t *testing.T) {
 	base := newManagerTestStore(t)
-	group, user, hostSigner := createStoredSession(t, base, "escrow-detail", 7, 1)
+	group, user, hostSigner := createStoredSession(t, base, "9401", 7, 1)
 	store := currentEpochStore{Storage: base, epoch: 7}
 	addresses := make([]string, len(group))
 	for i, s := range group {
@@ -196,7 +196,7 @@ func TestStatsShardDetailReturnsStatsOnly(t *testing.T) {
 	}
 	br := &mockBridge{
 		escrow: &bridge.EscrowInfo{
-			EscrowID:       "escrow-detail",
+			EscrowID:       "9401",
 			EpochID:        7,
 			Amount:         100000000,
 			CreatorAddress: user.Address(),
@@ -207,7 +207,7 @@ func TestStatsShardDetailReturnsStatsOnly(t *testing.T) {
 	mgr.SetBinaryVersion("0.2.14-v4")
 	require.NoError(t, mgr.RecoverSessions())
 
-	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-detail")
+	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/9401")
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 	require.NotContains(t, rec.Body.String(), "inferences")
 	require.NotContains(t, rec.Body.String(), "proof")
@@ -242,7 +242,7 @@ func TestStatsShardDetailReturnsStatsOnly(t *testing.T) {
 		Group []types.SlotAssignment `json:"group"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Equal(t, "escrow-detail", resp.EscrowID)
+	require.Equal(t, "9401", resp.EscrowID)
 	require.Equal(t, uint64(7), resp.EpochID)
 	require.Equal(t, uint64(1), resp.Nonce)
 	require.Equal(t, testutil.RuntimeTestVersion, resp.Version)
@@ -252,14 +252,14 @@ func TestStatsShardDetailReturnsStatsOnly(t *testing.T) {
 	require.Len(t, resp.HostStats, len(group))
 	require.Equal(t, group, resp.Group)
 
-	cached := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-detail")
+	cached := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/9401")
 	require.Equal(t, http.StatusOK, cached.Code, "body: %s", cached.Body.String())
 	require.Equal(t, rec.Body.String(), cached.Body.String())
 }
 
 func TestStatsShardDetailServesPriorEpochSession(t *testing.T) {
 	base := newManagerTestStore(t)
-	group, user, hostSigner := createStoredSession(t, base, "escrow-prior", 6, 1)
+	group, user, hostSigner := createStoredSession(t, base, "9501", 6, 1)
 	// Chain has advanced; session remains active until prune.
 	store := currentEpochStore{Storage: base, epoch: 7}
 	addresses := make([]string, len(group))
@@ -268,7 +268,7 @@ func TestStatsShardDetailServesPriorEpochSession(t *testing.T) {
 	}
 	br := &mockBridge{
 		escrow: &bridge.EscrowInfo{
-			EscrowID:       "escrow-prior",
+			EscrowID:       "9501",
 			EpochID:        6,
 			Amount:         100000000,
 			CreatorAddress: user.Address(),
@@ -278,7 +278,7 @@ func TestStatsShardDetailServesPriorEpochSession(t *testing.T) {
 	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
 	require.NoError(t, mgr.RecoverSessions())
 
-	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-prior")
+	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/9501")
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
 	var resp struct {
@@ -287,7 +287,7 @@ func TestStatsShardDetailServesPriorEpochSession(t *testing.T) {
 		Nonce    uint64 `json:"nonce"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Equal(t, "escrow-prior", resp.EscrowID)
+	require.Equal(t, "9501", resp.EscrowID)
 	require.Equal(t, uint64(6), resp.EpochID)
 	require.Equal(t, uint64(1), resp.Nonce)
 }
@@ -321,9 +321,9 @@ func (s *countingMetaStore) ListActiveSessions() ([]storage.ActiveSession, error
 
 func TestStatsShardDetailResolvesO1WithoutListScan(t *testing.T) {
 	base := newManagerTestStore(t)
-	group, user, hostSigner := createStoredSession(t, base, "escrow-o1", 7, 1)
-	createStoredSession(t, base, "escrow-noise-a", 7, 0)
-	createStoredSession(t, base, "escrow-noise-b", 7, 0)
+	group, user, hostSigner := createStoredSession(t, base, "9601", 7, 1)
+	createStoredSession(t, base, "9602", 7, 0)
+	createStoredSession(t, base, "9603", 7, 0)
 
 	counting := &countingMetaStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
 	addresses := make([]string, len(group))
@@ -332,7 +332,7 @@ func TestStatsShardDetailResolvesO1WithoutListScan(t *testing.T) {
 	}
 	br := &mockBridge{
 		escrow: &bridge.EscrowInfo{
-			EscrowID:       "escrow-o1",
+			EscrowID:       "9601",
 			EpochID:        7,
 			Amount:         100000000,
 			CreatorAddress: user.Address(),
@@ -344,7 +344,7 @@ func TestStatsShardDetailResolvesO1WithoutListScan(t *testing.T) {
 	counting.metaCalls = 0
 	counting.listCalls = 0
 
-	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-o1")
+	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/9601")
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 	require.Equal(t, 0, counting.listCalls, "detail must not ListActiveSessions")
 	require.Equal(t, 1, counting.metaCalls, "detail should GetSessionMeta once")

--- a/devshard/escrowid.go
+++ b/devshard/escrowid.go
@@ -1,0 +1,28 @@
+package devshard
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+var ErrInvalidEscrowID = errors.New("invalid escrow id")
+
+func ParseEscrowID(raw string) (uint64, error) {
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w %q", ErrInvalidEscrowID, raw)
+	}
+	if id == 0 {
+		return 0, fmt.Errorf("%w %q", ErrInvalidEscrowID, raw)
+	}
+	if canonical := strconv.FormatUint(id, 10); raw != canonical {
+		return 0, fmt.Errorf("%w %q: canonical form is %q", ErrInvalidEscrowID, raw, canonical)
+	}
+	return id, nil
+}
+
+func ValidateEscrowID(raw string) error {
+	_, err := ParseEscrowID(raw)
+	return err
+}

--- a/devshard/escrowid_test.go
+++ b/devshard/escrowid_test.go
@@ -1,0 +1,60 @@
+package devshard
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseEscrowIDAcceptsCanonicalOnly(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want uint64
+	}{
+		{"1", 1},
+		{"123", 123},
+		{"18446744073709551615", 18446744073709551615},
+	} {
+		got, err := ParseEscrowID(tc.raw)
+		if err != nil {
+			t.Fatalf("ParseEscrowID(%q) returned error: %v", tc.raw, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseEscrowID(%q) = %d, want %d", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestParseEscrowIDRejectsNonCanonical(t *testing.T) {
+	for _, raw := range []string{
+		"",
+		"0",
+		"00",
+		"0123",
+		"00123",
+		"000000000000000000000123",
+		"+123",
+		"-123",
+		" 123",
+		"123 ",
+		"1_2",
+		"0x7b",
+		"123abc",
+		"12.3",
+		"18446744073709551616",
+	} {
+		if _, err := ParseEscrowID(raw); err == nil {
+			t.Fatalf("ParseEscrowID(%q) accepted a non-canonical escrow id", raw)
+		} else if !errors.Is(err, ErrInvalidEscrowID) {
+			t.Fatalf("ParseEscrowID(%q) error = %v, want ErrInvalidEscrowID", raw, err)
+		}
+	}
+}
+
+func TestValidateEscrowIDMatchesParse(t *testing.T) {
+	if err := ValidateEscrowID("42"); err != nil {
+		t.Fatalf("ValidateEscrowID(\"42\") returned error: %v", err)
+	}
+	if err := ValidateEscrowID("042"); err == nil {
+		t.Fatal("ValidateEscrowID(\"042\") accepted a leading-zero alias")
+	}
+}

--- a/devshard/observability/ctx.go
+++ b/devshard/observability/ctx.go
@@ -130,6 +130,7 @@ const (
 	ReasonGetEscrowErr                Reason = "get_escrow_err"
 	ReasonStorageErr                  Reason = "storage_err"
 	ReasonSessionResolveErr           Reason = "session_resolve_err"
+	ReasonInvalidEscrowID             Reason = "invalid_escrow_id"
 	ReasonModifyRequestErr            Reason = "modify_request_err"
 	ReasonCanonicalizePromptErr       Reason = "canonicalize_prompt_err"
 	ReasonPayloadStoreErr             Reason = "payload_store_err"

--- a/devshard/server/routes.go
+++ b/devshard/server/routes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	devshardpkg "devshard"
 	"devshard/bridge"
 	"devshard/observability"
 	"devshard/storage"
@@ -38,6 +39,7 @@ type PayloadHandler interface {
 func RegisterLazySessionRoutes(g *echo.Group, resolver SessionResolver, binder OwnerChatBinder, payloadHandler PayloadHandler) {
 	g.Use(observability.EchoMiddleware())
 	g.Use(observability.RequestIDMiddleware)
+	g.Use(canonicalEscrowIDMiddleware)
 
 	g.POST("/sessions/:id/chat/completions", withOwnerChat(binder, true,
 		func(srv *transport.Server) echo.HandlerFunc { return srv.HandleInference }))
@@ -67,6 +69,22 @@ func RegisterLazySessionRoutes(g *echo.Group, resolver SessionResolver, binder O
 			observability.IncSessionResolution(routeLabel(c), observability.MetricStatusOK, observability.ReasonOK)
 			return payloadHandler.HandlePayloads(c, srv)
 		})
+	}
+}
+
+func canonicalEscrowIDMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		escrowID := c.Param("id")
+		if escrowID == "" {
+			return next(c)
+		}
+		if err := devshardpkg.ValidateEscrowID(escrowID); err != nil {
+			observability.IncSessionResolution(routeLabel(c), observability.MetricStatusError, observability.ReasonInvalidEscrowID)
+			observability.Log(c.Request().Context(), observability.LevelWarn, "devshard rejected non-canonical escrow id",
+				observability.StageSessionResolved, observability.WhereRoutesSessionResolve, escrowID, observability.ReasonInvalidEscrowID, err)
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		return next(c)
 	}
 }
 

--- a/devshard/user/httpsession.go
+++ b/devshard/user/httpsession.go
@@ -108,6 +108,9 @@ func NewHTTPSession(cfg HTTPSessionConfig) (*Session, *state.StateMachine, error
 	if cfg.RoutePrefix == "" {
 		return nil, nil, fmt.Errorf("RoutePrefix is required; use /devshard/{version}")
 	}
+	if err := devshardpkg.ValidateEscrowID(cfg.EscrowID); err != nil {
+		return nil, nil, err
+	}
 
 	signer, err := signing.SignerFromHex(cfg.PrivateKeyHex)
 	if err != nil {

--- a/devshard/user/httpsession_test.go
+++ b/devshard/user/httpsession_test.go
@@ -27,7 +27,7 @@ func TestNewHTTPSessionOpenStorageFailureStaysFatal(t *testing.T) {
 
 	_, _, err := NewHTTPSession(HTTPSessionConfig{
 		PrivateKeyHex: privateKeyHex,
-		EscrowID:      "escrow-1",
+		EscrowID:      "9801",
 		Bridge:        httpsessionTestBridge{},
 		StoragePath:   storagePath,
 		RoutePrefix:   "/devshard/dev",
@@ -46,20 +46,20 @@ func TestNewHTTPSessionClassifiesNonSequentialReplay(t *testing.T) {
 	store, err := storage.NewSQLite(storagePath)
 	require.NoError(t, err)
 	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
-		EscrowID:       "escrow-1",
+		EscrowID:       "9801",
 		EpochID:        7,
 		Version:        "dev",
 		CreatorAddr:    "creator",
 		Group:          []types.SlotAssignment{{SlotID: 0, ValidatorAddress: "host-1"}},
 		InitialBalance: 1_000_000,
 	}))
-	require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{Diff: types.Diff{Nonce: 1}}))
-	require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{Diff: types.Diff{Nonce: 3}}))
+	require.NoError(t, store.AppendDiff("9801", types.DiffRecord{Diff: types.Diff{Nonce: 1}}))
+	require.NoError(t, store.AppendDiff("9801", types.DiffRecord{Diff: types.Diff{Nonce: 3}}))
 	require.NoError(t, store.Close())
 
 	_, _, err = NewHTTPSession(HTTPSessionConfig{
 		PrivateKeyHex: privateKeyHex,
-		EscrowID:      "escrow-1",
+		EscrowID:      "9801",
 		Bridge:        httpsessionTestBridge{},
 		StoragePath:   storagePath,
 		RoutePrefix:   "/devshard/dev",
@@ -95,7 +95,7 @@ func TestNewHTTPSessionUsesRouteVersionForStorageBind(t *testing.T) {
 
 	session, _, err := NewHTTPSession(HTTPSessionConfig{
 		PrivateKeyHex: privateKeyHex,
-		EscrowID:      "escrow-1",
+		EscrowID:      "9801",
 		Bridge:        httpsessionTestBridge{},
 		StoragePath:   storagePath,
 		RoutePrefix:   " /devshard/dev/ ",
@@ -107,7 +107,7 @@ func TestNewHTTPSessionUsesRouteVersionForStorageBind(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Close()
 
-	meta, err := store.GetSessionMeta("escrow-1")
+	meta, err := store.GetSessionMeta("9801")
 	require.NoError(t, err)
 	require.Equal(t, "dev", meta.Version)
 }
@@ -122,7 +122,7 @@ func (httpsessionTestBridge) OnSettlementFinalized(string) error { return nil }
 
 func (httpsessionTestBridge) GetEscrow(string) (*bridge.EscrowInfo, error) {
 	return &bridge.EscrowInfo{
-		EscrowID:       "escrow-1",
+		EscrowID:       "9801",
 		Amount:         1_000_000,
 		CreatorAddress: "creator",
 		Slots:          []string{"host-1"},


### PR DESCRIPTION
An escrow owner could bind several independent devshard sessions to one on-chain escrow by spelling the id with leading zeros. `ChainBridge.GetEscrow` parses the path segment with `strconv.ParseUint`, so `123`, `0123` and `00123` all resolve to the same chain escrow, but the raw string was kept as the devshard identity: it became the `HostManager` session key, the singleflight key, the Postgres row key, the state-machine `EscrowID`, and the payload directory. Every alias created a fresh session seeded with the full `escrow.Amount` and reached `engine.Execute`.

The work those sessions do cannot be paid for. Hosts sign `StateSignatureContent{EscrowId: "00123"}` while the chain rebuilds the preimage from `fmt.Sprint(escrow.Id)` in `VerifyDevshardSettlement`, so the quorum never verifies and the escrow cannot be settled for that session. An alias also re-rolls every host's validation-sampling seed, which is derived from `signer.Sign([]byte(escrowID))` — giving the owner a cheap resampling oracle over which inferences get validated.

A chain escrow now has exactly one string identity, `strconv.FormatUint(id, 10)`:
- `devshard/escrowid.go`: `ParseEscrowID` / `ValidateEscrowID` reject non-digits, `0`, overflow, and any spelling that is not the canonical form.
- `server/routes.go`: middleware returns 400 on `/sessions/:id/*` before auth and before session lookup.
- `bridge/grpc.go`, `cmd/devshardd/bridge/chain.go`: canonical parse, and `GetEscrow` returns the canonical id instead of echoing the caller's string. `caching.go` validates before the escrow_cache fallback.
- `session/manager.go`: validated in `BindOwnerChat` and `create`; `RecoverSessions` skips and logs non-canonical stored rows.
- Client side (`devshardctl` runtime config and settlement encode, `user` `NewHTTPSession`), so an operator or SDK user never signs a non-canonical id.