### PR TITLE
feat(mlnode): mount GET /api/v1/clock for dapi's ping job

### DIFF
--- a/mlnode/packages/api/src/api/app.py
+++ b/mlnode/packages/api/src/api/app.py
@@ -20,6 +20,7 @@ from pow.service.manager import PowManager
 from pow.service.routes import router as pow_router
 
 from api.health import router as health_router
+from api.clock import router as clock_router
 
 from api.service_management import (
     ServiceState,
@@ -145,6 +146,14 @@ app.include_router(
     metrics_router,
     prefix=API_PREFIX,
     tags=["Metrics"],
+)
+
+# Timestamp probe for dapi's ping job. No conflict check — the probe must
+# answer in every service state, like /metrics above.
+app.include_router(
+    clock_router,
+    prefix=API_PREFIX,
+    tags=["Clock"],
 )
 
 app.include_router(

--- a/mlnode/packages/api/src/api/clock.py
+++ b/mlnode/packages/api/src/api/clock.py
@@ -1,0 +1,23 @@
+"""GET /api/v1/clock — timestamp probe for dapi's mlnode ping job.
+
+Contract (devshard/docs/proposals/gateway-host-ping-observability.md,
+"Checklist for the mlnode PR"): 204, empty body, X-Server-Recv-Ns /
+X-Server-Send-Ns in unix nanoseconds, no side effects. dapi computes RTT
+and clock divergence from the two headers; without this endpoint it falls
+back to /readyz + the Date header, which is second-granular.
+"""
+
+import time
+
+from fastapi import APIRouter, Response
+
+router = APIRouter()
+
+
+@router.get("/clock", status_code=204)
+async def clock() -> Response:
+    recv_ns = time.time_ns()
+    response = Response(status_code=204)
+    response.headers["X-Server-Recv-Ns"] = str(recv_ns)
+    response.headers["X-Server-Send-Ns"] = str(time.time_ns())
+    return response

--- a/mlnode/packages/api/tests/unit/test_clock_endpoint.py
+++ b/mlnode/packages/api/tests/unit/test_clock_endpoint.py
@@ -1,0 +1,24 @@
+"""Contract test for GET /api/v1/clock (gateway-host-ping-observability)."""
+
+import time
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.clock import router
+
+
+def test_clock_contract():
+    app = FastAPI()
+    app.include_router(router)
+
+    response = TestClient(app).get("/clock")
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+    recv_ns = int(response.headers["X-Server-Recv-Ns"])
+    send_ns = int(response.headers["X-Server-Send-Ns"])
+    assert send_ns >= recv_ns
+    # Nanosecond scale: within a day of the test's own clock.
+    assert abs(recv_ns - time.time_ns()) < 86_400 * 10**9


### PR DESCRIPTION
Adds the `GET /api/v1/clock` endpoint requested in #1580 ("Required follow-up: MLNode /api/v1/clock"), per the checklist in the proposal appendix.

Two checklist items needed verification rather than code:

- bypass auth / tracing / response cache — mlnode has none of the three; `ProxyMiddleware` passes `/api/*` straight through
- join-proxy allowlist — the join nginx proxies `location /` wholesale (`deploy/join/nginx.conf`), so the path reaches mlnode unchanged and dapi's permanent-404 demotion cannot trigger