### PR TITLE
fix(mlnode): accept DAPI's JSON POSTs sent without Content-Type

### DIFF
--- a/mlnode/packages/api/src/api/app.py
+++ b/mlnode/packages/api/src/api/app.py
@@ -31,7 +31,7 @@ from api.metrics.routes import router as metrics_router, metrics_enabled
 from api.metrics.allowlist import SCHEMA_VERSION, VLLM_ALLOWLIST
 from api.metrics import xid_source
 from api.watcher import watch_managers
-from api.proxy import ProxyMiddleware, start_vllm_proxy, stop_vllm_proxy, setup_vllm_proxy, start_backward_compatibility, stop_backward_compatibility
+from api.proxy import ContentTypeInjector, ProxyMiddleware, start_vllm_proxy, stop_vllm_proxy, setup_vllm_proxy, start_backward_compatibility, stop_backward_compatibility
 
 from common.logger import create_logger
 
@@ -103,6 +103,9 @@ app = FastAPI(lifespan=lifespan)
 app.include_router(health_router)
 
 app.add_middleware(ProxyMiddleware)
+# Wrap ProxyMiddleware so Content-Type is injected before downstream parsing.
+# Last add_middleware = outermost = runs first on each request.
+app.add_middleware(ContentTypeInjector)
 
 app.include_router(
     pow_router,

--- a/mlnode/packages/api/src/api/proxy.py
+++ b/mlnode/packages/api/src/api/proxy.py
@@ -44,6 +44,40 @@ compatibility_server: Optional[object] = None  # uvicorn.Server instance
 health_check_task: Optional[asyncio.Task] = None
 
 
+class ContentTypeInjector:
+    """Plain ASGI middleware: inject ``Content-Type: application/json`` for
+    ``POST /api/*`` requests when the header is missing.
+
+    Network DAPI (Go-http-client/1.1) does not set ``Content-Type`` on JSON
+    POSTs such as ``/api/v1/inference/up`` and
+    ``/api/v1/inference/pow/init/generate``. Whether FastAPI still parses
+    such a body as JSON depends on its version: since ``strict_content_type``
+    (default True in current releases) a header-less body reaches
+    ``model_validate`` unparsed and the request dies with a 422
+    (``Input should be a valid dictionary or object``) before any handler
+    runs — observed in production on the July images. The lock currently
+    pins a forgiving 0.115, but the constraint is ``>=0.115.8``; injecting
+    the header makes acceptance independent of the pin. Requests that carry
+    any Content-Type are passed through untouched.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if (
+            scope["type"] == "http"
+            and scope.get("method") == "POST"
+            and scope.get("path", "").startswith("/api/")
+            and not any(h[0] == b"content-type" for h in scope["headers"])
+        ):
+            scope = dict(scope)
+            scope["headers"] = list(scope["headers"]) + [
+                (b"content-type", b"application/json")
+            ]
+        await self.app(scope, receive, send)
+
+
 class ProxyMiddleware(BaseHTTPMiddleware):
     """Middleware to handle routing between /api and /v1 endpoints."""
     

--- a/mlnode/packages/api/tests/unit/test_content_type_injector.py
+++ b/mlnode/packages/api/tests/unit/test_content_type_injector.py
@@ -1,0 +1,33 @@
+"""DAPI sends JSON POSTs without Content-Type; the injector must add it.
+
+Asserted at the ASGI level (a spy app records the scope) rather than through
+a FastAPI handler: whether FastAPI itself tolerates a missing header depends
+on its version (``strict_content_type``), and a handler-level test would pass
+on the forgiving pin with no middleware at all.
+"""
+
+from fastapi.testclient import TestClient
+from starlette.responses import Response
+
+from api.proxy import ContentTypeInjector
+
+
+def _content_type_seen_by_app(send_headers: dict | None) -> bytes | None:
+    """Run one POST through the injector; return the Content-Type the app saw."""
+    seen = {}
+
+    async def app(scope, receive, send):
+        seen["content-type"] = dict(scope["headers"]).get(b"content-type")
+        await Response(status_code=204)(scope, receive, send)
+
+    client = TestClient(ContentTypeInjector(app))
+    client.post("/api/v1/echo", content=b'{"value": 7}', headers=send_headers)
+    return seen["content-type"]
+
+
+def test_missing_content_type_is_injected():
+    assert _content_type_seen_by_app(None) == b"application/json"
+
+
+def test_existing_content_type_is_not_overwritten():
+    assert _content_type_seen_by_app({"Content-Type": "text/plain"}) == b"text/plain"


### PR DESCRIPTION
DAPI posts JSON to `/api/v1/inference/up` and `/api/v1/inference/pow/init/generate` without a Content-Type header. Whether FastAPI tolerates that depends on its version: since `strict_content_type` (default **True** in current releases) a header-less body reaches `model_validate` unparsed and the request 422s before any handler runs — this is what production hit on the July images. The api lock currently pins a forgiving fastapi 0.115, but the constraint is `>=0.115.8`, so whether the node accepts the network's requests silently rides the pin.

A plain ASGI middleware injects `application/json` on `POST /api/*` when the header is missing; anything carrying a Content-Type passes through untouched. Tests assert at the ASGI level (what the inner app sees in scope) — a handler-level test would pass on the forgiving pin with no middleware at all.

We have shipped this as a build-time layer on top of the published mlnode image since July 24. The root cause lives in DAPI (Go client not setting the header); this keeps mlnode tolerant either way and outlives a DAPI-side fix harmlessly.