### PR TITLE
testenv: harden observability smoke debugging

### DIFF
--- a/devshard/testenv/README.md
+++ b/devshard/testenv/README.md
@@ -300,6 +300,12 @@ make citest-observability
 
 Compose images are reused by default (Makefile runs `citest-images` first). For local gateway-image iteration without a separate `make citest-images`, set `TESTENV_CITEST_BUILD=1` so `docker compose up` passes `--build`.
 
+Debugging tips:
+
+- Set `TESTENV_CITEST_KEEP_STACK=1` to keep the generated compose stack/workdir after the test, and `TESTENV_CITEST_DUMP_LOGS=1` to dump compose logs during test cleanup.
+- When running Go tests from a Docker-based runner, set `TESTENV_HOST_ADDR=host.docker.internal` so probes from inside the runner can reach host-published compose ports.
+- On Docker Desktop for macOS, mount this repository into the runner at the same absolute host path. Synthetic paths such as `/work` can make generated bind mounts fail because the host daemon does not have that path shared.
+
 Stop overlay: `make obs-down`.
 
 Requires rebuilding **devshardd** after pulling observability init changes (`make build-devshardd`). Gateway changes need a runtime image rebuild (`make citest-images` or `TESTENV_CITEST_BUILD=1`).

--- a/devshard/testenv/citest/harness/observability.go
+++ b/devshard/testenv/citest/harness/observability.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -42,14 +43,15 @@ func DefaultObservabilityEndpoints() ObservabilityEndpoints {
 
 // ObservabilityEndpointsFor returns host URLs for a profile (unused backends stay set for convenience).
 func ObservabilityEndpointsFor(profile ObsProfile) ObservabilityEndpoints {
+	host := hostPublishedAddr("")
 	return ObservabilityEndpoints{
 		Profile:    profile,
-		Jaeger:     "http://127.0.0.1:11686",
-		Tempo:      "http://127.0.0.1:13200",
-		Alloy:      "http://127.0.0.1:12345",
-		Loki:       "http://127.0.0.1:13101",
-		Prometheus: "http://127.0.0.1:19099",
-		Grafana:    "http://127.0.0.1:13000",
+		Jaeger:     "http://" + net.JoinHostPort(host, "11686"),
+		Tempo:      "http://" + net.JoinHostPort(host, "13200"),
+		Alloy:      "http://" + net.JoinHostPort(host, "12345"),
+		Loki:       "http://" + net.JoinHostPort(host, "13101"),
+		Prometheus: "http://" + net.JoinHostPort(host, "19099"),
+		Grafana:    "http://" + net.JoinHostPort(host, "13000"),
 	}
 }
 
@@ -201,9 +203,9 @@ func WaitObservabilityReady(t *testing.T, obs ObservabilityEndpoints, timeout ti
 		}
 		switch obs.Profile.TraceBackend() {
 		case "tempo":
-			// Tempo /ready returns 503 for ~15s after start ("Ingester not ready");
-			// buildinfo is up earlier and is enough to accept traffic shortly after.
-			if !httpReady(client, obs.Tempo+"/ready") && !httpReady(client, obs.Tempo+"/status/buildinfo") {
+			// Tempo 2.7.1 can panic in statusHandler for /status/buildinfo in this
+			// local-blocks test config, while /ready correctly gates trace reads.
+			if !httpReady(client, obs.Tempo+"/ready") {
 				return false
 			}
 		default:

--- a/devshard/testenv/citest/harness/stack.go
+++ b/devshard/testenv/citest/harness/stack.go
@@ -19,6 +19,12 @@ import (
 
 const defaultStackTimeout = 12 * time.Minute
 
+const (
+	hostAddrEnv       = "TESTENV_HOST_ADDR"
+	keepStackEnv      = "TESTENV_CITEST_KEEP_STACK"
+	dumpLogsOnExitEnv = "TESTENV_CITEST_DUMP_LOGS"
+)
+
 // Stack is a generated compose workdir for Docker citest.
 type Stack struct {
 	WorkDir       string
@@ -53,7 +59,13 @@ func NewStack(t *testing.T, prefix string) *Stack {
 
 	workDir, err := os.MkdirTemp(testenvDir, prefix)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(workDir) })
+	t.Cleanup(func() {
+		if keepStackEnabled() {
+			t.Logf("citest: keeping stack workdir %s because %s=1", workDir, keepStackEnv)
+			return
+		}
+		_ = os.RemoveAll(workDir)
+	})
 
 	return &Stack{
 		WorkDir:     workDir,
@@ -105,7 +117,7 @@ func (s *Stack) LoadConfig(t *testing.T) *config.File {
 	return cfg
 }
 
-// Endpoints reads Docker-assigned localhost ports from a running compose stack.
+// Endpoints reads Docker-assigned host-published ports from a running compose stack.
 func (s *Stack) Endpoints(t *testing.T, cfg *config.File) Endpoints {
 	t.Helper()
 	eps := s.MockChainEndpoints(t, cfg)
@@ -117,7 +129,7 @@ func (s *Stack) Endpoints(t *testing.T, cfg *config.File) Endpoints {
 	return eps
 }
 
-// MockChainEndpoints reads Docker-assigned host ports for a mock-chain-only stack.
+// MockChainEndpoints reads Docker-assigned host-published ports for a mock-chain-only stack.
 func (s *Stack) MockChainEndpoints(t *testing.T, cfg *config.File) Endpoints {
 	t.Helper()
 	return Endpoints{
@@ -141,10 +153,21 @@ func (s *Stack) composePublishedAddr(t *testing.T, service string, targetPort in
 	raw := strings.TrimSpace(string(out))
 	host, port, err := net.SplitHostPort(raw)
 	require.NoError(t, err, "parse docker compose port output %q", raw)
-	if host == "" || host == "0.0.0.0" || host == "::" {
-		host = "127.0.0.1"
-	}
+	host = hostPublishedAddr(host)
 	return net.JoinHostPort(host, port)
+}
+
+func hostPublishedAddr(composeHost string) string {
+	override := strings.TrimSpace(os.Getenv(hostAddrEnv))
+	if override != "" {
+		return override
+	}
+	switch composeHost {
+	case "", "0.0.0.0", "::":
+		return "127.0.0.1"
+	default:
+		return composeHost
+	}
 }
 
 // Up starts the stack with docker compose up (expects citest-images built; pulls missing hub images).
@@ -181,6 +204,14 @@ func ComposeBuildEnabled() bool {
 	return os.Getenv("TESTENV_CITEST_BUILD") == "1"
 }
 
+func keepStackEnabled() bool {
+	return os.Getenv(keepStackEnv) == "1"
+}
+
+func dumpLogsOnExitEnabled() bool {
+	return os.Getenv(dumpLogsOnExitEnv) == "1"
+}
+
 func (s *Stack) composeFileArgs() []string {
 	args := []string{"-f", s.ComposePath}
 	if s.Observability {
@@ -205,7 +236,16 @@ func (s *Stack) composeUp(t *testing.T, build bool, services []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout)
 	defer cancel()
 
-	t.Cleanup(func() { s.Down(t) })
+	t.Cleanup(func() {
+		if dumpLogsOnExitEnabled() {
+			DumpComposeLogs(t, s)
+		}
+		if keepStackEnabled() {
+			t.Logf("citest: keeping compose stack %s because %s=1", filepath.Base(s.WorkDir), keepStackEnv)
+			return
+		}
+		s.Down(t)
+	})
 
 	args := append([]string{"compose"}, s.composeFileArgs()...)
 	args = append(args, "up", "-d", "--wait", "--pull", "missing")


### PR DESCRIPTION
Follow-up for #1558.

## Summary
- add `TESTENV_HOST_ADDR` so Docker-based Go runners can reach host-published compose ports; for local Docker runner usage this can be set to `host.docker.internal`
- add `TESTENV_CITEST_KEEP_STACK=1` to keep the generated compose stack/workdir after a test run for post-pass inspection
- add `TESTENV_CITEST_DUMP_LOGS=1` to dump compose logs during test cleanup, which helps inspect collector/gateway/versiond behavior without rerunning
- stop probing Tempo `/status/buildinfo` during readiness because Tempo 2.7.1 can panic in that handler with the local-blocks test config
- document the local observability smoke debugging workflow and Docker Desktop mount-path gotcha

## Verification
- `go test ./citest/harness -count=1`
- `go test ./citest -tags testenvci -run TestObservabilitySmoke -count=1 -v`
- `TESTENV_CITEST_DUMP_LOGS=1 go test ./citest -tags testenvci -run TestObservabilitySmoke -count=1 -v`  
#### confirmed that a passing smoke run prints `citest: compose logs:` during cleanup
- TESTENV_CITEST_KEEP_STACK=1 go test ./citest -tags testenvci -run TestObservabilitySmoke -count=1 -v
#### confirmed stack remains visible in docker ps after PASS, then cleaned up with docker compose down -v