### PR TITLE
fix(devshard): let a node replay its own pre-floor diffs on startup

### DIFF
--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -497,7 +497,7 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 
 		for _, rec := range records {
 			sm.InjectWarmKeys(rec.WarmKeyDelta)
-			root, applyErr := sm.ApplyPersisted(rec.Nonce, rec.Txs)
+			root, applyErr := sm.ApplyLocalPersisted(rec.Nonce, rec.Txs)
 			if applyErr != nil {
 				return nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
 			}

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -497,7 +497,7 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 
 		for _, rec := range records {
 			sm.InjectWarmKeys(rec.WarmKeyDelta)
-			root, applyErr := sm.ApplyLocal(rec.Nonce, rec.Txs)
+			root, applyErr := sm.ApplyPersisted(rec.Nonce, rec.Txs)
 			if applyErr != nil {
 				return nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
 			}

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -145,6 +145,48 @@ func populateStore(t *testing.T, store storage.Storage, numDiffs int) ([]types.S
 	return group, user, hosts[0]
 }
 
+// A host that served sub-floor reservations before the floor landed has them in its own diff log, and
+// replaying that log is the only way back up.
+func TestRecoverSessions_ReplaysADiffWrittenBeforeTheMaxTokensFloor(t *testing.T) {
+	store := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, store, 0)
+	config := defaultConfig(3)
+	verifier := signing.NewSecp256k1Verifier()
+
+	sm, err := state.NewStateMachine("1", config, group, 100000, user.Address(), verifier, store,
+		state.WithVersion(testutil.RuntimeTestVersion))
+	require.NoError(t, err)
+
+	txs := []*types.DevshardTx{{Tx: &types.DevshardTx_StartInference{StartInference: &types.MsgStartInference{
+		InferenceId: 1, Model: "llama", InputLength: 100,
+		MaxTokens: testutil.TestMaxTokens - 1, StartedAt: 1000,
+	}}}}
+	_, err = sm.ApplyLocal(1, txs)
+	require.ErrorIs(t, err, types.ErrMaxTokensBelowFloor, "the fixture must be a diff this build refuses to author")
+	root, err := sm.ApplyPersisted(1, txs)
+	require.NoError(t, err)
+	require.NoError(t, store.AppendDiff("1", types.DiffRecord{
+		Diff: signDiffWithRoot(t, user, "1", 1, txs, root), StateHash: root,
+	}))
+
+	addresses := make([]string, len(group))
+	for i, slot := range group {
+		addresses[i] = slot.ValidatorAddress
+	}
+	bridgeStub := &mockBridge{escrow: &bridge.EscrowInfo{
+		EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses,
+	}}
+
+	manager := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(),
+		nil, testutil.RuntimeTestVersion, bridgeStub, nil, nil)
+	require.NoError(t, manager.RecoverSessions())
+
+	manager.sessionsMutex.RLock()
+	_, recovered := manager.sessions["1"]
+	manager.sessionsMutex.RUnlock()
+	require.True(t, recovered, "a session whose diffs predate the floor must still come back up")
+}
+
 func TestRecoverSessions_HappyPath(t *testing.T) {
 	store := newManagerTestStore(t)
 	group, user, hostSigner := populateStore(t, store, 10)

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -163,7 +163,7 @@ func TestRecoverSessions_ReplaysADiffWrittenBeforeTheMaxTokensFloor(t *testing.T
 	}}}}
 	_, err = sm.ApplyLocal(1, txs)
 	require.ErrorIs(t, err, types.ErrMaxTokensBelowFloor, "the fixture must be a diff this build refuses to author")
-	root, err := sm.ApplyPersisted(1, txs)
+	root, err := sm.ApplyLocalPersisted(1, txs)
 	require.NoError(t, err)
 	require.NoError(t, store.AppendDiff("1", types.DiffRecord{
 		Diff: signDiffWithRoot(t, user, "1", 1, txs, root), StateHash: root,

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -91,6 +91,8 @@ type StateMachine struct {
 	// validation lives in committedEntries (and on disk in the snapshot).
 	sealedNonces   map[uint64]uint64
 	inferenceStore storage.Storage
+	// replayingPersisted is written only under mu, by ApplyPersisted.
+	replayingPersisted bool
 
 	// Lookup maps derived from group at construction time.
 	slotToAddress      map[uint32]string
@@ -311,6 +313,16 @@ func (sm *StateMachine) verifyDiffUserSig(diff types.Diff) error {
 func (sm *StateMachine) ApplyLocal(nonce uint64, txs []*types.DevshardTx) ([]byte, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+	return sm.applyCore(nonce, txs, nil, "user")
+}
+
+// ApplyPersisted replays a diff this node already accepted. A diff is part of a recorded state root,
+// so a rule that tightened since it was written cannot undo it by refusing it, only fail to start.
+func (sm *StateMachine) ApplyPersisted(nonce uint64, txs []*types.DevshardTx) ([]byte, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.replayingPersisted = true
+	defer func() { sm.replayingPersisted = false }()
 	return sm.applyCore(nonce, txs, nil, "user")
 }
 
@@ -904,7 +916,7 @@ func (sm *StateMachine) applyStartInference(msg *types.MsgStartInference) error 
 
 	// A sub-floor reservation is refused by the executor's payload check, so the inference would sit
 	// pending until seal. Rejecting here keeps it out of state and off the balance.
-	if msg.MaxTokens < completionapi.MinTokensFloor {
+	if !sm.replayingPersisted && msg.MaxTokens < completionapi.MinTokensFloor {
 		return fmt.Errorf("%w: max_tokens %d, floor %d", types.ErrMaxTokensBelowFloor, msg.MaxTokens, completionapi.MinTokensFloor)
 	}
 

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -91,7 +91,7 @@ type StateMachine struct {
 	// validation lives in committedEntries (and on disk in the snapshot).
 	sealedNonces   map[uint64]uint64
 	inferenceStore storage.Storage
-	// replayingPersisted is written only under mu, by ApplyPersisted.
+	// replayingPersisted is written only under mu, by ApplyLocalPersisted.
 	replayingPersisted bool
 
 	// Lookup maps derived from group at construction time.
@@ -316,9 +316,10 @@ func (sm *StateMachine) ApplyLocal(nonce uint64, txs []*types.DevshardTx) ([]byt
 	return sm.applyCore(nonce, txs, nil, "user")
 }
 
-// ApplyPersisted replays a diff this node already accepted. A diff is part of a recorded state root,
-// so a rule that tightened since it was written cannot undo it by refusing it, only fail to start.
-func (sm *StateMachine) ApplyPersisted(nonce uint64, txs []*types.DevshardTx) ([]byte, error) {
+// ApplyLocalPersisted applies txs without signature verification, replaying a diff this node already
+// accepted. Used by recovery: a diff is part of a recorded state root, so a rule that tightened since
+// it was written cannot undo it by refusing it, only fail to start.
+func (sm *StateMachine) ApplyLocalPersisted(nonce uint64, txs []*types.DevshardTx) ([]byte, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	sm.replayingPersisted = true

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -764,7 +764,7 @@ func TestApplyDiff_EscrowBalanceCheck(t *testing.T) {
 
 // A diff written before the floor existed is already part of a recorded state root. Refusing it on
 // replay cannot undo it, only keep the node from starting.
-func TestApplyPersisted_ReplaysAStartWrittenBeforeTheFloor(t *testing.T) {
+func TestApplyLocalPersisted_ReplaysAStartWrittenBeforeTheFloor(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	sm, _ := newTestSM(t, hosts, 10000)
 	subFloor := func(inferenceID uint64) []*types.DevshardTx {
@@ -777,7 +777,7 @@ func TestApplyPersisted_ReplaysAStartWrittenBeforeTheFloor(t *testing.T) {
 	_, err := sm.ApplyLocal(1, subFloor(1))
 	require.ErrorIs(t, err, types.ErrMaxTokensBelowFloor, "new work still has to meet the floor")
 
-	root, err := sm.ApplyPersisted(1, subFloor(1))
+	root, err := sm.ApplyLocalPersisted(1, subFloor(1))
 	require.NoError(t, err)
 	require.NotEmpty(t, root)
 	require.Len(t, sm.SnapshotState().Inferences, 1)

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -762,6 +762,30 @@ func TestApplyDiff_EscrowBalanceCheck(t *testing.T) {
 	require.ErrorIs(t, err, types.ErrInsufficientBalance)
 }
 
+// A diff written before the floor existed is already part of a recorded state root. Refusing it on
+// replay cannot undo it, only keep the node from starting.
+func TestApplyPersisted_ReplaysAStartWrittenBeforeTheFloor(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	sm, _ := newTestSM(t, hosts, 10000)
+	subFloor := func(inferenceID uint64) []*types.DevshardTx {
+		return []*types.DevshardTx{txStart(&types.MsgStartInference{
+			InferenceId: inferenceID, PromptHash: []byte("prompt"), Model: "llama",
+			InputLength: 100, MaxTokens: testutil.TestMaxTokens - 1, StartedAt: 1000,
+		})}
+	}
+
+	_, err := sm.ApplyLocal(1, subFloor(1))
+	require.ErrorIs(t, err, types.ErrMaxTokensBelowFloor, "new work still has to meet the floor")
+
+	root, err := sm.ApplyPersisted(1, subFloor(1))
+	require.NoError(t, err)
+	require.NotEmpty(t, root)
+	require.Len(t, sm.SnapshotState().Inferences, 1)
+
+	_, err = sm.ApplyLocal(2, subFloor(2))
+	require.ErrorIs(t, err, types.ErrMaxTokensBelowFloor, "the relaxation must not outlive the replay")
+}
+
 func TestApplyDiff_StartInference_RejectsMaxTokensBelowFloor(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	sm, user := newTestSM(t, hosts, 10000)

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -267,7 +267,7 @@ func RecoverSession(
 
 	for _, rec := range records {
 		sm.InjectWarmKeys(rec.WarmKeyDelta)
-		root, applyErr := sm.ApplyLocal(rec.Nonce, rec.Txs)
+		root, applyErr := sm.ApplyPersisted(rec.Nonce, rec.Txs)
 		if applyErr != nil {
 			if errors.Is(applyErr, types.ErrInvalidNonce) {
 				return nil, nil, fmt.Errorf("%w: replay nonce %d: %w",

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -267,7 +267,7 @@ func RecoverSession(
 
 	for _, rec := range records {
 		sm.InjectWarmKeys(rec.WarmKeyDelta)
-		root, applyErr := sm.ApplyPersisted(rec.Nonce, rec.Txs)
+		root, applyErr := sm.ApplyLocalPersisted(rec.Nonce, rec.Txs)
 		if applyErr != nil {
 			if errors.Is(applyErr, types.ErrInvalidNonce) {
 				return nil, nil, fmt.Errorf("%w: replay nonce %d: %w",

--- a/devshard/user/recover_test.go
+++ b/devshard/user/recover_test.go
@@ -166,7 +166,7 @@ func TestRecoverSession_ReplaysADiffWrittenBeforeTheMaxTokensFloor(t *testing.T)
 	writerSM := newTestStateMachine(t, "escrow-1", config, group, 100000, user.Address(), verifier)
 	_, err := writerSM.ApplyLocal(1, subFloor)
 	require.ErrorIs(t, err, types.ErrMaxTokensBelowFloor, "the fixture must be a diff this build refuses to author")
-	root, err := writerSM.ApplyPersisted(1, subFloor)
+	root, err := writerSM.ApplyLocalPersisted(1, subFloor)
 	require.NoError(t, err)
 	require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{
 		Diff:      testutil.SignDiffWithRoot(t, user, "escrow-1", 1, subFloor, root),

--- a/devshard/user/recover_test.go
+++ b/devshard/user/recover_test.go
@@ -135,6 +135,58 @@ func TestRecoverSession_HappyPath(t *testing.T) {
 	require.Equal(t, uint64(numInferences+1), resp.Nonce)
 }
 
+// Production reproduction: a node that had served sub-floor reservations could not restart once the
+// floor landed, because replaying its own persisted diffs re-ran a rule written after they were made.
+func TestRecoverSession_ReplaysADiffWrittenBeforeTheMaxTokensFloor(t *testing.T) {
+	store := newTestStore(t)
+	numHosts := 3
+	hosts := make([]*signing.Secp256k1Signer, numHosts)
+	for i := range hosts {
+		hosts[i] = testutil.MustGenerateKey(t)
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(numHosts)
+	verifier := signing.NewSecp256k1Verifier()
+
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "escrow-1",
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+
+	subFloor := []*types.DevshardTx{{Tx: &types.DevshardTx_StartInference{StartInference: &types.MsgStartInference{
+		InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens - 1, StartedAt: 1000,
+	}}}}
+
+	writerSM := newTestStateMachine(t, "escrow-1", config, group, 100000, user.Address(), verifier)
+	_, err := writerSM.ApplyLocal(1, subFloor)
+	require.ErrorIs(t, err, types.ErrMaxTokensBelowFloor, "the fixture must be a diff this build refuses to author")
+	root, err := writerSM.ApplyPersisted(1, subFloor)
+	require.NoError(t, err)
+	require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{
+		Diff:      testutil.SignDiffWithRoot(t, user, "escrow-1", 1, subFloor, root),
+		StateHash: root,
+	}))
+
+	clients := make([]HostClient, numHosts)
+	for i := range hosts {
+		sm := newTestStateMachine(t, "escrow-1", config, group, 100000, user.Address(), verifier)
+		h, err := host.NewHost(sm, hosts[i], stub.NewInferenceEngine(), "escrow-1", group, nil, host.WithGrace(10))
+		require.NoError(t, err)
+		clients[i] = &InProcessClient{Host: h}
+	}
+
+	session, _, err := RecoverSession(store, user, verifier, "escrow-1", testutil.RuntimeTestVersion, group, clients)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), session.Nonce())
+	require.Len(t, session.Diffs(), 1)
+}
+
 func TestRecoverSession_EmptySession(t *testing.T) {
 	store := newTestStore(t)
 	hosts := make([]*signing.Secp256k1Signer, 3)


### PR DESCRIPTION
## Problem

`enforce inference tokens floor (#1391)` added a `MinTokensFloor` check to `applyStartInference`. That check also runs on **replay**, so a node that served inferences before the floor landed cannot restart — it re-runs a rule written after its own diffs were made:

```
replay nonce 12: max_tokens below min_tokens floor: max_tokens 1, floor 64
```

Refusing the diff undoes nothing. It is already part of a recorded state root; the refusal only keeps the node down.

## Fix

Separate *authoring new work* from *replaying work already accepted*.

- `state.ApplyPersisted` sets `replayingPersisted` under the same mutex as the apply and clears it via `defer`
- the floor check is skipped only on that path
- both replay call sites switch to it: `user/recover.go` (gateway) and `cmd/devshardd/session/manager.go` (host daemon)

Exactly one check is relaxed, and only the one guarding creation of new work. Live traffic still has to meet the floor.

## Tests

| Test | Package | Covers |
|---|---|---|
| `TestApplyPersisted_ReplaysAStartWrittenBeforeTheFloor` | `state` | the policy split, and that the relaxation does not outlive the call |
| `TestRecoverSession_ReplaysADiffWrittenBeforeTheMaxTokensFloor` | `user` | the gateway's recovery path, from a seeded sub-floor diff |
| `TestRecoverSessions_ReplaysADiffWrittenBeforeTheMaxTokensFloor` | `cmd/devshardd/session` | the host daemon's recovery path |

Each fixture asserts `ApplyLocal` still rejects the diff before seeding it, so the test cannot silently stop reproducing the failure.

**Mutation-tested — 4/4 killed**, each verified to compile first: floor ignores the replay flag; flag never cleared; each replay site reverted to `ApplyLocal`.

`state`, `user` and `cmd/devshardd/session` pass in full.
