### PR TITLE
Stabilize ML node mock assertions in event listener tests

### DIFF
--- a/decentralized-api/mlnodeclient/mock.go
+++ b/decentralized-api/mlnodeclient/mock.go
@@ -84,13 +84,11 @@ func NewMockClient() *MockClient {
 	}
 }
 
+// WithTryLock serializes test assertions with async mock calls. The name is
+// historical; blocking here avoids flaky failures on transient lock contention.
 func (m *MockClient) WithTryLock(t *testing.T, f func()) {
-	lock := m.Mu.TryLock()
-	if !lock {
-		t.Fatal("TryLock called more than once")
-	} else {
-		defer m.Mu.Unlock()
-	}
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
 
 	f()
 }


### PR DESCRIPTION
## Summary
- fix a flaky API wrapper test failure where `MockClient.WithTryLock` failed immediately on transient lock contention
- serialize test assertions with async mock client calls instead of treating an in-flight background worker as a test failure

Tes failure link: https://github.com/gonka-ai/gonka/actions/runs/31797682156/job/94758260624?pr=1594

## Root cause
`TestRegularPocScenario` can race with `nodeStatusQueryWorker`: the worker may hold the mock client mutex while the test reads call counters. The previous `TryLock` helper failed immediately with `TryLock called more than once`, even though this is expected transient contention in async tests.

## Verification
- attempted `go test ./internal/event_listener -run TestRegularPocScenario -count=5 -v` locally; local Docker runner failed before test execution on `github.com/supranational/blst` (`undefined: Message`), which appears to be local toolchain/arch-specific and not this change.