### PR TITLE
fix(dapi): gate devshard versions cache on block height

### DIFF
--- a/decentralized-api/apiconfig/config_manager.go
+++ b/decentralized-api/apiconfig/config_manager.go
@@ -31,6 +31,7 @@ type ConfigManager struct {
 	WriterProvider            WriteCloserProvider
 	sqlDb                     SqlDatabase
 	modelValidationThresholds []ModelValidationThreshold
+	devshardVersionsHeight    int64
 	mutex                     sync.RWMutex
 	runtimePublishMu          sync.RWMutex
 	runtimePublished          runtimePublishedMarker
@@ -421,9 +422,29 @@ func (cm *ConfigManager) GetTransferAgentAccessCache() TransferAgentAccessCache 
 	return cm.currentConfig.TransferAgentAccessCache
 }
 
+func (cm *ConfigManager) ApplyDevshardVersionsIfNewer(cache DevshardVersionsCache, sourceHeight int64) bool {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+	if sourceHeight < cm.devshardVersionsHeight {
+		logging.Debug("runtime_config: stale devshard escrow cache dropped", types.Config,
+			"sourceHeight", sourceHeight,
+			"acceptedHeight", cm.devshardVersionsHeight,
+			"approvedVersions", len(cache.Versions),
+		)
+		return false
+	}
+	cm.devshardVersionsHeight = sourceHeight
+	cm.setDevshardVersionsLocked(cache)
+	return true
+}
+
 func (cm *ConfigManager) SetDevshardVersions(cache DevshardVersionsCache) {
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()
+	cm.setDevshardVersionsLocked(cache)
+}
+
+func (cm *ConfigManager) setDevshardVersionsLocked(cache DevshardVersionsCache) {
 	prev := cm.currentConfig.DevshardVersionsCache.DevshardRequestsEnabled
 	cm.currentConfig.DevshardVersionsCache = cache
 	if prev != cache.DevshardRequestsEnabled {

--- a/decentralized-api/apiconfig/devshard_versions_height_test.go
+++ b/decentralized-api/apiconfig/devshard_versions_height_test.go
@@ -1,0 +1,95 @@
+package apiconfig_test
+
+import (
+	"sync"
+	"testing"
+
+	"decentralized-api/apiconfig"
+
+	"github.com/stretchr/testify/require"
+)
+
+func devshardCatalog(sha string) apiconfig.DevshardVersionsCache {
+	return apiconfig.DevshardVersionsCache{
+		Versions: []apiconfig.DevshardVersion{
+			{Name: "v4", Binary: "https://example/v4", SHA256: sha},
+		},
+	}
+}
+
+func TestApplyDevshardVersionsIfNewer_RejectsOlderHeight(t *testing.T) {
+	cm := newTestConfigManager()
+
+	require.True(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("aaa"), 100))
+	require.Equal(t, "aaa", cm.GetDevshardVersions().Versions[0].SHA256)
+
+	require.True(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("bbb"), 101))
+	require.Equal(t, "bbb", cm.GetDevshardVersions().Versions[0].SHA256)
+
+	require.False(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("aaa"), 100))
+	require.Equal(t, "bbb", cm.GetDevshardVersions().Versions[0].SHA256)
+}
+
+func TestApplyDevshardVersionsIfNewer_AcceptsSameHeight(t *testing.T) {
+	cm := newTestConfigManager()
+
+	require.True(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("aaa"), 100))
+	require.True(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("bbb"), 100))
+	require.Equal(t, "bbb", cm.GetDevshardVersions().Versions[0].SHA256)
+}
+
+func TestApplyDevshardVersionsIfNewer_StaleWorkerCannotRegressPublishedContent(t *testing.T) {
+	cm := newTestConfigManager()
+	cm.EnsureRuntimeConfigNotifier()
+
+	require.True(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("aaa"), 100))
+	require.True(t, cm.ApplyRuntimeConfigBlockIfChanged(100, 7))
+
+	require.True(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("bbb"), 101))
+	require.True(t, cm.ApplyRuntimeConfigBlockIfChanged(101, 7))
+
+	require.False(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("aaa"), 100))
+	require.False(t, cm.ApplyRuntimeConfigBlockIfChanged(100, 7))
+
+	snap := cm.RuntimeConfigSnapshot(7)
+	require.Equal(t, int64(101), snap.ParamsBlockHeight)
+	require.Equal(t, "bbb", snap.ApprovedVersions[0].SHA256)
+	require.Equal(t, "bbb", cm.GetDevshardVersions().Versions[0].SHA256)
+}
+
+func TestApplyRuntimeConfigBlockIfChanged_StaleHeightDoesNotPublishChangedContent(t *testing.T) {
+	cm := newTestConfigManager()
+	cm.EnsureRuntimeConfigNotifier()
+
+	require.NoError(t, cm.SetValidationParams(apiconfig.ValidationParamsCache{LogprobsMode: "full"}))
+	require.True(t, cm.ApplyRuntimeConfigBlockIfChanged(101, 7))
+
+	require.NoError(t, cm.SetValidationParams(apiconfig.ValidationParamsCache{LogprobsMode: "raw"}))
+	require.False(t, cm.ApplyRuntimeConfigBlockIfChanged(100, 7))
+
+	snap := cm.RuntimeConfigSnapshot(7)
+	require.Equal(t, int64(101), snap.ParamsBlockHeight)
+	require.Equal(t, "full", snap.LogprobsMode)
+}
+
+func TestApplyDevshardVersionsIfNewer_ConcurrentOutOfOrderKeepsNewest(t *testing.T) {
+	cm := newTestConfigManager()
+	require.True(t, cm.ApplyDevshardVersionsIfNewer(devshardCatalog("bbb"), 101))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cm.ApplyDevshardVersionsIfNewer(devshardCatalog("aaa"), 100)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = cm.GetDevshardVersions()
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, "bbb", cm.GetDevshardVersions().Versions[0].SHA256)
+}

--- a/decentralized-api/apiconfig/runtime_config_publish.go
+++ b/decentralized-api/apiconfig/runtime_config_publish.go
@@ -92,6 +92,16 @@ func (cm *ConfigManager) ApplyRuntimeConfigBlockIfChanged(blockHeight int64, epo
 	content := cm.liveRuntimeConfigContent()
 
 	cm.runtimePublishMu.Lock()
+	if cm.runtimePublished.initialized && blockHeight < cm.runtimeParamsBlockHeight {
+		publishedHeight := cm.runtimeParamsBlockHeight
+		cm.runtimePublishMu.Unlock()
+		logging.Debug("runtime_config: publish skipped (stale block height)", types.Config,
+			"blockHeight", blockHeight,
+			"publishedHeight", publishedHeight,
+			"epochID", epochID,
+		)
+		return false
+	}
 	if cm.runtimePublished.initialized &&
 		cm.runtimePublished.epochID == epochID &&
 		cm.runtimePublished.content.equal(content) {
@@ -160,6 +170,10 @@ func copyRuntimeConfigContent(c runtimeConfigContent) runtimeConfigContent {
 
 // ResetRuntimePublishedState clears the last-published marker (tests only).
 func (cm *ConfigManager) ResetRuntimePublishedState() {
+	cm.mutex.Lock()
+	cm.devshardVersionsHeight = 0
+	cm.mutex.Unlock()
+
 	cm.runtimePublishMu.Lock() // writers: publish and test reset
 	defer cm.runtimePublishMu.Unlock()
 	cm.runtimePublished = runtimePublishedMarker{}

--- a/decentralized-api/internal/event_listener/new_block_dispatcher.go
+++ b/decentralized-api/internal/event_listener/new_block_dispatcher.go
@@ -259,8 +259,9 @@ func (d *OnNewBlockDispatcher) ProcessNewBlock(ctx context.Context, blockInfo ch
 
 			// Update devshard versions cache from chain params
 			if params.Params.DevshardEscrowParams != nil {
-				d.configManager.SetDevshardVersions(
+				d.configManager.ApplyDevshardVersionsIfNewer(
 					apiconfig.DevshardVersionsCacheFromParams(params.Params.DevshardEscrowParams),
+					blockInfo.Height,
 				)
 			}
 		}


### PR DESCRIPTION
Fixes a race in DAPI's chain-params projection where an out-of-order `NewBlock` worker could roll the devshard runtime catalog back to a superseded `approved_versions` entry (same version name, older `sha256`) while `params_block_height` stayed at the newer height.

## Root cause

`processBlockEvents` runs **two** workers over the `NewBlock` queue (`event_listener.go:221`). Each `ProcessNewBlock` independently queries `Params` at the node's *latest* state and then writes the result into `ConfigManager`:

- `SetDevshardVersions` replaced the cache unconditionally, and `GET /versions` returns that live cache verbatim (`internal/server/mlnode/server.go:66`).
- `ApplyRuntimeConfigBlockIfChanged` clamped `params_block_height` so it could not decrease, but its content came from `liveRuntimeConfigContent()` - so the marker was monotonic while the content bound to it was not.

A `Params` RPC served before a catalog-changing block, arriving after a faster worker already wrote the newer catalog, therefore published:

`{newer height, superseded params}`

PR #1234 introduced the monotonic marker but did not bind content to it; this closes that residual.

Exposure was bounded - every block re-queries `Params` at latest, so the live cache self-heals on the next block - but within that window `versiond` can poll `/versions`, and `Manager.Reconcile` keys desired state by version **name**, so it would treat the older SHA as a legitimate same-name rolling update.

## What changed

DAPI only:

| File | Change |
|------|--------|
| `apiconfig/config_manager.go` | New `ApplyDevshardVersionsIfNewer(cache, sourceHeight)` gated on a new `devshardVersionsHeight`; `SetDevshardVersions` kept as an unconditional setter for tests/height-less callers via a shared locked helper |
| `apiconfig/runtime_config_publish.go` | `ApplyRuntimeConfigBlockIfChanged` drops the publish when `blockHeight < runtimeParamsBlockHeight`; `ResetRuntimePublishedState` also clears the new height |
| `internal/event_listener/new_block_dispatcher.go` | Call site passes `blockInfo.Height` |
| New test file | Covers the out-of-order worker case and verifies that stale catalog/runtime-config updates cannot overwrite state associated with a newer block height |