### PR TITLE
Track live PostgreSQL readiness

### DIFF
--- a/devshard/docs/high-availability-architecture.md
+++ b/devshard/docs/high-availability-architecture.md
@@ -197,6 +197,10 @@ Operator signals (versiond / host logs and Prometheus):
 - `postgres readiness lost` / `postgres readiness recovered` — the live database
   failed or recovered across the two-probe readiness hysteresis. The devshardd
   process stays alive; `/readyz` returns `503` while database readiness is lost.
+  With the default 5-second interval and 5-second probe deadline, a fully
+  blackholed database can take about 20 seconds after the last successful probe
+  to make `/readyz` return `503`. An upstream health checker adds its own polling
+  delay before it removes the replica from traffic.
 - `devshard_postgres_health_probe_total{result="success|database_error"}` —
   outcomes from the dedicated PostgreSQL health connection. A single
   `database_error` can be a transient connection reset and does not make the

--- a/devshard/docs/high-availability-architecture.md
+++ b/devshard/docs/high-availability-architecture.md
@@ -194,6 +194,14 @@ Operator signals (versiond / host logs and Prometheus):
 - `reconcile_fast_forward` — expected on failover onto a lagging replica.
 - `diff_persist_retry` / `devshard_diff_persist_retry_total` — transient Postgres blips.
 - `diff_fork_detected` / `devshard_diff_fork_detected_total` — **must stay 0** in healthy HA; non-zero means real divergence and needs alert investigation.
+- `postgres readiness lost` / `postgres readiness recovered` — the live database
+  failed or recovered across the two-probe readiness hysteresis. The devshardd
+  process stays alive; `/readyz` returns `503` while database readiness is lost.
+- `devshard_postgres_health_probe_total{result="success|database_error"}` —
+  outcomes from the dedicated PostgreSQL health connection.
+- `devshard_postgres_pool_saturated` — whether all application-pool connections
+  were in use at the latest probe. Saturation is reported independently and does
+  not by itself make `/readyz` fail.
 
 Gateway catch-up and sticky failover remain independent: router
 `proxy_next_upstream` moves the HTTP request; host reconcile heals RAM from

--- a/devshard/docs/high-availability-architecture.md
+++ b/devshard/docs/high-availability-architecture.md
@@ -198,7 +198,10 @@ Operator signals (versiond / host logs and Prometheus):
   failed or recovered across the two-probe readiness hysteresis. The devshardd
   process stays alive; `/readyz` returns `503` while database readiness is lost.
 - `devshard_postgres_health_probe_total{result="success|database_error"}` —
-  outcomes from the dedicated PostgreSQL health connection.
+  outcomes from the dedicated PostgreSQL health connection. A single
+  `database_error` can be a transient connection reset and does not make the
+  service unready. Alert on `postgres readiness lost` or a sustained error
+  rate, not on one counter increment.
 - `devshard_postgres_pool_saturated` — whether all application-pool connections
   were in use at the latest probe. Saturation is reported independently and does
   not by itself make `/readyz` fail.

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -454,6 +454,11 @@ down after boot.
 
 - Postgres env vars: `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`.
 - Postgres connect deadline at boot: `PG_CONNECT_TIMEOUT` default `2s`.
+- Live readiness uses one dedicated PostgreSQL connection outside the
+  application pool. Two consecutive database failures make `/readyz` return
+  `503` without terminating devshardd; two successful probes restore readiness.
+  Application-pool saturation is exposed separately and does not by itself
+  change readiness.
 - Storage mode helpers and `.pg-bound`: `devshard/storage/storage_mode.go`.
 - Drain check: `HasSQLiteSessions(storeDir)` or presence of rows in `_meta.db` `escrow_epoch`.
 - Production retention is `retain=3`: current epoch plus two previous epochs.

--- a/devshard/observability/metrics_lifecycle.go
+++ b/devshard/observability/metrics_lifecycle.go
@@ -362,21 +362,20 @@ func SetFallbackDivisor(source string, divisor int) {
 	fallbackDivisor.WithLabelValues(source).Set(float64(divisor))
 }
 
-// IncPostgresHealthProbe records a PostgreSQL health probe result separately
-// from readiness so pool saturation does not masquerade as a database outage.
-func IncPostgresHealthProbe(result string) {
+// ObservePostgresHealthProbe records database reachability independently from
+// application-pool saturation.
+func ObservePostgresHealthProbe(healthy, saturated bool) {
 	ensureMetrics()
-	switch result {
-	case "success", "database_error", "pool_saturated":
-	default:
-		result = "unknown"
+	result := "database_error"
+	if healthy {
+		result = "success"
 	}
 	postgresHealthProbeTotal.WithLabelValues(result).Inc()
-	saturated := 0.0
-	if result == "pool_saturated" {
-		saturated = 1
+	saturationValue := 0.0
+	if saturated {
+		saturationValue = 1
 	}
-	postgresPoolSaturated.Set(saturated)
+	postgresPoolSaturated.Set(saturationValue)
 }
 
 // IncDiffPersistRetry records one AppendDiff retry outcome (Phase 3).

--- a/devshard/observability/metrics_lifecycle.go
+++ b/devshard/observability/metrics_lifecycle.go
@@ -372,10 +372,11 @@ func IncPostgresHealthProbe(result string) {
 		result = "unknown"
 	}
 	postgresHealthProbeTotal.WithLabelValues(result).Inc()
-	postgresPoolSaturated.Set(0)
+	saturated := 0.0
 	if result == "pool_saturated" {
-		postgresPoolSaturated.Set(1)
+		saturated = 1
 	}
+	postgresPoolSaturated.Set(saturated)
 }
 
 // IncDiffPersistRetry records one AppendDiff retry outcome (Phase 3).

--- a/devshard/observability/metrics_lifecycle.go
+++ b/devshard/observability/metrics_lifecycle.go
@@ -159,7 +159,7 @@ func initRegistry() {
 	}, []string{"result"})
 	postgresPoolSaturated = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "devshard_postgres_pool_saturated",
-		Help: "Whether the latest PostgreSQL health probe could not acquire a pooled connection.",
+		Help: "Whether all PostgreSQL application-pool connections were in use at the latest health probe.",
 	})
 
 	diffPersistRetryTotal = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/devshard/observability/metrics_lifecycle.go
+++ b/devshard/observability/metrics_lifecycle.go
@@ -15,27 +15,29 @@ var (
 	runtimeCollectorsOnce sync.Once
 	registry              *prometheus.Registry
 
-	inflight               *prometheus.GaugeVec
-	requestTerminalTotal   *prometheus.CounterVec
-	interruptionTotal      *prometheus.CounterVec
-	sessionResolutionTotal *prometheus.CounterVec
-	receiptOrphanTotal     *prometheus.CounterVec
-	validationTotal        *prometheus.CounterVec
-	validationOrphanTotal  *prometheus.CounterVec
-	validationFaultTotal   *prometheus.CounterVec
-	validationQueueDrops   prometheus.Counter
-	payloadRequestTotal    *prometheus.CounterVec
-	mlnodeAttemptsTotal    *prometheus.CounterVec
-	mlnodeCallSeconds      *prometheus.HistogramVec
-	mlnodeTokens           *prometheus.HistogramVec
-	httpConnections        *prometheus.GaugeVec
-	httpConnectionsTotal   *prometheus.CounterVec
-	validationQueueDepth   *prometheus.GaugeVec
-	mempoolSize            *prometheus.GaugeVec
-	buildInfo              *prometheus.GaugeVec
-	lifecycleInflight      prometheus.Gauge
-	fallbackDivisor        *prometheus.GaugeVec
-	payloadFetchTTFB       prometheus.Histogram
+	inflight                 *prometheus.GaugeVec
+	requestTerminalTotal     *prometheus.CounterVec
+	interruptionTotal        *prometheus.CounterVec
+	sessionResolutionTotal   *prometheus.CounterVec
+	receiptOrphanTotal       *prometheus.CounterVec
+	validationTotal          *prometheus.CounterVec
+	validationOrphanTotal    *prometheus.CounterVec
+	validationFaultTotal     *prometheus.CounterVec
+	validationQueueDrops     prometheus.Counter
+	payloadRequestTotal      *prometheus.CounterVec
+	payloadFetchTTFB         prometheus.Histogram
+	mlnodeAttemptsTotal      *prometheus.CounterVec
+	mlnodeCallSeconds        *prometheus.HistogramVec
+	mlnodeTokens             *prometheus.HistogramVec
+	httpConnections          *prometheus.GaugeVec
+	httpConnectionsTotal     *prometheus.CounterVec
+	validationQueueDepth     *prometheus.GaugeVec
+	mempoolSize              *prometheus.GaugeVec
+	buildInfo                *prometheus.GaugeVec
+	lifecycleInflight        prometheus.Gauge
+	fallbackDivisor          *prometheus.GaugeVec
+	postgresHealthProbeTotal *prometheus.CounterVec
+	postgresPoolSaturated    prometheus.Gauge
 
 	// HA diff/persist consistency (see docs/proposals/ha-diff-persist-consistency.md).
 	diffPersistRetryTotal     *prometheus.CounterVec
@@ -151,6 +153,14 @@ func initRegistry() {
 		Name: "devshardd_fallback_divisor",
 		Help: "Fallback capacity divisor (max(active_escrows, 4)); source is load_map or floor4.",
 	}, []string{"source"})
+	postgresHealthProbeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "devshard_postgres_health_probe_total",
+		Help: "PostgreSQL storage health probe outcomes.",
+	}, []string{"result"})
+	postgresPoolSaturated = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "devshard_postgres_pool_saturated",
+		Help: "Whether the latest PostgreSQL health probe could not acquire a pooled connection.",
+	})
 
 	diffPersistRetryTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "devshard_diff_persist_retry_total",
@@ -187,6 +197,8 @@ func initRegistry() {
 		buildInfo,
 		lifecycleInflight,
 		fallbackDivisor,
+		postgresHealthProbeTotal,
+		postgresPoolSaturated,
 		diffPersistRetryTotal,
 		diffForkDetectedTotal,
 		reconcileFastForwardTotal,
@@ -348,6 +360,22 @@ func SetFallbackDivisor(source string, divisor int) {
 	}
 	fallbackDivisor.Reset()
 	fallbackDivisor.WithLabelValues(source).Set(float64(divisor))
+}
+
+// IncPostgresHealthProbe records a PostgreSQL health probe result separately
+// from readiness so pool saturation does not masquerade as a database outage.
+func IncPostgresHealthProbe(result string) {
+	ensureMetrics()
+	switch result {
+	case "success", "database_error", "pool_saturated":
+	default:
+		result = "unknown"
+	}
+	postgresHealthProbeTotal.WithLabelValues(result).Inc()
+	postgresPoolSaturated.Set(0)
+	if result == "pool_saturated" {
+		postgresPoolSaturated.Set(1)
+	}
 }
 
 // IncDiffPersistRetry records one AppendDiff retry outcome (Phase 3).

--- a/devshard/observability/metrics_lifecycle_test.go
+++ b/devshard/observability/metrics_lifecycle_test.go
@@ -110,21 +110,21 @@ func TestHADiffPersistMetricsIncrement(t *testing.T) {
 	}
 }
 
-func TestIncPostgresHealthProbeTracksOutcomeAndSaturation(t *testing.T) {
+func TestObservePostgresHealthProbeTracksOutcomeAndSaturation(t *testing.T) {
 	ensureMetrics()
 
-	before := testutil.ToFloat64(postgresHealthProbeTotal.WithLabelValues("pool_saturated"))
-	IncPostgresHealthProbe("pool_saturated")
-	if testutil.ToFloat64(postgresHealthProbeTotal.WithLabelValues("pool_saturated"))-before != 1 {
-		t.Fatal("postgres pool-saturated probe counter delta want 1")
+	before := testutil.ToFloat64(postgresHealthProbeTotal.WithLabelValues("success"))
+	ObservePostgresHealthProbe(true, true)
+	if testutil.ToFloat64(postgresHealthProbeTotal.WithLabelValues("success"))-before != 1 {
+		t.Fatal("postgres successful probe counter delta want 1")
 	}
 	if got := testutil.ToFloat64(postgresPoolSaturated); got != 1 {
 		t.Fatalf("postgres pool-saturated gauge = %v, want 1", got)
 	}
 
-	IncPostgresHealthProbe("success")
+	ObservePostgresHealthProbe(false, false)
 	if got := testutil.ToFloat64(postgresPoolSaturated); got != 0 {
-		t.Fatalf("postgres pool-saturated gauge after success = %v, want 0", got)
+		t.Fatalf("postgres pool-saturated gauge after clear = %v, want 0", got)
 	}
 }
 

--- a/devshard/observability/metrics_lifecycle_test.go
+++ b/devshard/observability/metrics_lifecycle_test.go
@@ -110,6 +110,24 @@ func TestHADiffPersistMetricsIncrement(t *testing.T) {
 	}
 }
 
+func TestIncPostgresHealthProbeTracksOutcomeAndSaturation(t *testing.T) {
+	ensureMetrics()
+
+	before := testutil.ToFloat64(postgresHealthProbeTotal.WithLabelValues("pool_saturated"))
+	IncPostgresHealthProbe("pool_saturated")
+	if testutil.ToFloat64(postgresHealthProbeTotal.WithLabelValues("pool_saturated"))-before != 1 {
+		t.Fatal("postgres pool-saturated probe counter delta want 1")
+	}
+	if got := testutil.ToFloat64(postgresPoolSaturated); got != 1 {
+		t.Fatalf("postgres pool-saturated gauge = %v, want 1", got)
+	}
+
+	IncPostgresHealthProbe("success")
+	if got := testutil.ToFloat64(postgresPoolSaturated); got != 0 {
+		t.Fatalf("postgres pool-saturated gauge after success = %v, want 0", got)
+	}
+}
+
 func TestDeleteEscrowMetricsRemovesPerEscrowGauges(t *testing.T) {
 	ensureMetrics()
 	const escrowID = "escrow-metrics-prune"

--- a/devshard/storage/hybrid.go
+++ b/devshard/storage/hybrid.go
@@ -178,7 +178,9 @@ func (h *HybridStorage) postgresBackend() Storage {
 
 // Ready reports whether the router can serve. A degraded / SQLite-only router
 // (no Postgres attached) is always ready for the escrows it owns. When Postgres
-// is attached, readiness tracks its async session-index rebuild.
+// is attached, readiness tracks its async session-index rebuild and live
+// database health. Application-pool saturation is reported separately and does
+// not by itself make the router unready.
 func (h *HybridStorage) Ready() bool {
 	pg := h.postgresBackend()
 	if pg == nil {

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -562,11 +562,7 @@ func (s *Postgres) Close() error {
 	case <-time.After(postgresOpTimeout):
 	}
 	if healthDone != nil {
-		select {
-		case <-healthDone:
-		case <-time.After(postgresHealthTimeout):
-			slog.Warn("devshard storage: postgres health monitor did not stop before pool close")
-		}
+		<-healthDone
 	}
 	s.pool.Close()
 	return nil

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -74,9 +74,10 @@ const (
 	postgresLivePresenceTimeout = 2 * time.Second
 	// postgresHealthInterval and postgresHealthTimeout keep /ready tied to the
 	// live database without issuing a SQL probe for every router health check.
-	// The interval exceeds the timeout so failed probes cannot run back-to-back.
+	// The interval is measured after each completed probe, so even a full-budget
+	// failure cannot start the next probe immediately.
 	postgresHealthInterval = 5 * time.Second
-	postgresHealthTimeout  = time.Second
+	postgresHealthTimeout  = postgresConnectTimeout
 	postgresHealthQuorum   = 2
 	// postgresIndexRepairBatchSize caps rows per DELETE/INSERT when repairing
 	// devshard_session_index so a large divergence does not hold one giant lock.
@@ -88,12 +89,52 @@ type postgresHealthProbeResult string
 const (
 	postgresHealthProbeSuccess       postgresHealthProbeResult = "success"
 	postgresHealthProbeDatabaseError postgresHealthProbeResult = "database_error"
-	postgresHealthProbePoolSaturated postgresHealthProbeResult = "pool_saturated"
 )
 
 type postgresHealthState struct {
 	ready     bool
 	saturated bool
+}
+
+// postgresHealthProbe owns one connection outside the application pool. The
+// monitor is its only caller, so the connection needs no additional locking.
+type postgresHealthProbe struct {
+	config *pgx.ConnConfig
+	conn   *pgx.Conn
+}
+
+func newPostgresHealthProbe(config *pgx.ConnConfig) *postgresHealthProbe {
+	return &postgresHealthProbe{config: config.Copy()}
+}
+
+func (p *postgresHealthProbe) check(ctx context.Context) error {
+	if p.conn == nil || p.conn.IsClosed() {
+		conn, err := pgx.ConnectConfig(ctx, p.config)
+		if err != nil {
+			return fmt.Errorf("connect postgres health probe: %w", err)
+		}
+		p.conn = conn
+		// A completed PostgreSQL startup handshake is sufficient for the first
+		// check. Subsequent checks reuse the connection and issue Ping.
+		return nil
+	}
+
+	if err := p.conn.Ping(ctx); err != nil {
+		conn := p.conn
+		p.conn = nil
+		_ = conn.Close(ctx)
+		return fmt.Errorf("ping postgres health probe connection: %w", err)
+	}
+	return nil
+}
+
+func (p *postgresHealthProbe) close(ctx context.Context) error {
+	if p.conn == nil {
+		return nil
+	}
+	conn := p.conn
+	p.conn = nil
+	return conn.Close(ctx)
 }
 
 const (
@@ -167,6 +208,9 @@ func NewPostgres(ctx context.Context) (*Postgres, error) {
 	// Server-side per-query bounds applied to every pooled connection.
 	cfg.ConnConfig.RuntimeParams["statement_timeout"] = strconv.FormatInt(postgresStatementTimeout.Milliseconds(), 10)
 	cfg.ConnConfig.RuntimeParams["lock_timeout"] = strconv.FormatInt(postgresLockTimeout.Milliseconds(), 10)
+	// Health owns one dedicated connection, leaving every configured pool slot
+	// available to application work and keeping MaxConns an application concern.
+	healthConfig := cfg.ConnConfig.Copy()
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("connect to postgres: %w", err)
@@ -189,33 +233,46 @@ func NewPostgres(ctx context.Context) (*Postgres, error) {
 		healthReady: true,
 		healthDone:  make(chan struct{}),
 	}
-	s.startHealthMonitor()
+	s.startHealthMonitor(healthConfig)
 	s.startIndexRebuild()
 	return s, nil
 }
 
-func (s *Postgres) startHealthMonitor() {
+func (s *Postgres) startHealthMonitor(connConfig *pgx.ConnConfig) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.mu.Lock()
 	s.healthStop = cancel
 	s.mu.Unlock()
 	go func() {
 		defer close(s.healthDone)
-		ticker := time.NewTicker(postgresHealthInterval)
-		defer ticker.Stop()
+		probe := newPostgresHealthProbe(connConfig)
+		defer func() {
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), postgresHealthTimeout)
+			defer closeCancel()
+			if err := probe.close(closeCtx); err != nil {
+				slog.Warn("devshard storage: close postgres health connection", "error", err)
+			}
+		}()
+		timer := time.NewTimer(postgresHealthInterval)
+		defer timer.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
+			case <-timer.C:
 				probeCtx, probeCancel := context.WithTimeout(ctx, postgresHealthTimeout)
-				result, err := s.probeHealth(probeCtx)
+				err := probe.check(probeCtx)
 				probeCancel()
 				if ctx.Err() != nil {
 					return
 				}
-				observability.IncPostgresHealthProbe(string(result))
-				previous, current := s.recordHealthProbe(result)
+				result := postgresHealthProbeSuccess
+				if err != nil {
+					result = postgresHealthProbeDatabaseError
+				}
+				saturated := postgresPoolIsSaturated(s.pool)
+				observability.ObservePostgresHealthProbe(err == nil, saturated)
+				previous, current := s.recordHealthProbe(result, saturated)
 				if previous.ready != current.ready {
 					if current.ready {
 						slog.Info("devshard storage: postgres readiness recovered")
@@ -226,45 +283,29 @@ func (s *Postgres) startHealthMonitor() {
 				if previous.saturated != current.saturated {
 					if current.saturated {
 						stat := s.pool.Stat()
-						slog.Warn("devshard storage: postgres health probe could not acquire a pooled connection",
+						slog.Warn("devshard storage: postgres application pool is saturated",
 							"acquired_connections", stat.AcquiredConns(),
 							"max_connections", stat.MaxConns())
 					} else {
-						slog.Info("devshard storage: postgres health probe pool saturation cleared")
+						slog.Info("devshard storage: postgres application pool saturation cleared")
 					}
 				}
+				timer.Reset(postgresHealthInterval)
 			}
 		}
 	}()
 }
 
-// probeHealth distinguishes database failures from an inconclusive probe that
-// could not acquire a connection because application work occupied the pool.
-func (s *Postgres) probeHealth(ctx context.Context) (postgresHealthProbeResult, error) {
-	stat := s.pool.Stat()
-	poolWasSaturated := stat.MaxConns() > 0 && stat.AcquiredConns() >= stat.MaxConns()
-
-	conn, err := s.pool.Acquire(ctx)
-	if err != nil {
-		err = fmt.Errorf("acquire postgres health probe connection: %w", err)
-		if poolWasSaturated && errors.Is(err, context.DeadlineExceeded) {
-			return postgresHealthProbePoolSaturated, err
-		}
-		return postgresHealthProbeDatabaseError, err
-	}
-	defer conn.Release()
-
-	if err := conn.Ping(ctx); err != nil {
-		return postgresHealthProbeDatabaseError, fmt.Errorf("ping postgres health probe connection: %w", err)
-	}
-	return postgresHealthProbeSuccess, nil
+func postgresPoolIsSaturated(pool *pgxpool.Pool) bool {
+	stat := pool.Stat()
+	return stat.MaxConns() > 0 && stat.AcquiredConns() >= stat.MaxConns()
 }
 
-func (s *Postgres) recordHealthProbe(result postgresHealthProbeResult) (previous, current postgresHealthState) {
+func (s *Postgres) recordHealthProbe(result postgresHealthProbeResult, saturated bool) (previous, current postgresHealthState) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	previous = postgresHealthState{ready: s.healthReady, saturated: s.healthSaturated}
-	s.healthSaturated = result == postgresHealthProbePoolSaturated
+	s.healthSaturated = saturated
 	switch result {
 	case postgresHealthProbeSuccess:
 		s.healthFails = 0
@@ -282,9 +323,6 @@ func (s *Postgres) recordHealthProbe(result postgresHealthProbeResult) (previous
 		if s.healthFails >= postgresHealthQuorum {
 			s.healthReady = false
 		}
-	case postgresHealthProbePoolSaturated:
-		// Saturation says nothing about database reachability. Preserve the last
-		// confirmed health state and its hysteresis counters.
 	}
 	current = postgresHealthState{ready: s.healthReady, saturated: s.healthSaturated}
 	return previous, current

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"devshard/observability"
 	"devshard/types"
 
 	"github.com/jackc/pgx/v5"
@@ -42,15 +43,16 @@ type Postgres struct {
 	knownEpochs map[uint64]struct{}
 	escrowIdx   map[string]uint64
 
-	readyCh     chan struct{}
-	readyOnce   sync.Once
-	indexErr    error
-	indexCancel context.CancelFunc
-	healthReady bool
-	healthFails int
-	healthOKs   int
-	healthStop  context.CancelFunc
-	healthDone  chan struct{}
+	readyCh         chan struct{}
+	readyOnce       sync.Once
+	indexErr        error
+	indexCancel     context.CancelFunc
+	healthReady     bool
+	healthFails     int
+	healthOKs       int
+	healthSaturated bool
+	healthStop      context.CancelFunc
+	healthDone      chan struct{}
 }
 
 const (
@@ -72,13 +74,27 @@ const (
 	postgresLivePresenceTimeout = 2 * time.Second
 	// postgresHealthInterval and postgresHealthTimeout keep /ready tied to the
 	// live database without issuing a SQL probe for every router health check.
-	postgresHealthInterval = time.Second
+	// The interval exceeds the timeout so failed probes cannot run back-to-back.
+	postgresHealthInterval = 5 * time.Second
 	postgresHealthTimeout  = time.Second
 	postgresHealthQuorum   = 2
 	// postgresIndexRepairBatchSize caps rows per DELETE/INSERT when repairing
 	// devshard_session_index so a large divergence does not hold one giant lock.
 	postgresIndexRepairBatchSize = 1000
 )
+
+type postgresHealthProbeResult string
+
+const (
+	postgresHealthProbeSuccess       postgresHealthProbeResult = "success"
+	postgresHealthProbeDatabaseError postgresHealthProbeResult = "database_error"
+	postgresHealthProbePoolSaturated postgresHealthProbeResult = "pool_saturated"
+)
+
+type postgresHealthState struct {
+	ready     bool
+	saturated bool
+}
 
 const (
 	pgSessionsParent               = "devshard_sessions"
@@ -193,14 +209,28 @@ func (s *Postgres) startHealthMonitor() {
 				return
 			case <-ticker.C:
 				probeCtx, probeCancel := context.WithTimeout(ctx, postgresHealthTimeout)
-				err := s.pool.Ping(probeCtx)
+				result, err := s.probeHealth(probeCtx)
 				probeCancel()
-				changed, ready := s.recordHealthProbe(err == nil)
-				if changed {
-					if ready {
+				if ctx.Err() != nil {
+					return
+				}
+				observability.IncPostgresHealthProbe(string(result))
+				previous, current := s.recordHealthProbe(result)
+				if previous.ready != current.ready {
+					if current.ready {
 						slog.Info("devshard storage: postgres readiness recovered")
 					} else {
 						slog.Warn("devshard storage: postgres readiness lost", "error", err)
+					}
+				}
+				if previous.saturated != current.saturated {
+					if current.saturated {
+						stat := s.pool.Stat()
+						slog.Warn("devshard storage: postgres health probe could not acquire a pooled connection",
+							"acquired_connections", stat.AcquiredConns(),
+							"max_connections", stat.MaxConns())
+					} else {
+						slog.Info("devshard storage: postgres health probe pool saturation cleared")
 					}
 				}
 			}
@@ -208,11 +238,35 @@ func (s *Postgres) startHealthMonitor() {
 	}()
 }
 
-func (s *Postgres) recordHealthProbe(ok bool) (changed, ready bool) {
+// probeHealth distinguishes database failures from an inconclusive probe that
+// could not acquire a connection because application work occupied the pool.
+func (s *Postgres) probeHealth(ctx context.Context) (postgresHealthProbeResult, error) {
+	stat := s.pool.Stat()
+	poolWasSaturated := stat.MaxConns() > 0 && stat.AcquiredConns() >= stat.MaxConns()
+
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		err = fmt.Errorf("acquire postgres health probe connection: %w", err)
+		if poolWasSaturated && errors.Is(err, context.DeadlineExceeded) {
+			return postgresHealthProbePoolSaturated, err
+		}
+		return postgresHealthProbeDatabaseError, err
+	}
+	defer conn.Release()
+
+	if err := conn.Ping(ctx); err != nil {
+		return postgresHealthProbeDatabaseError, fmt.Errorf("ping postgres health probe connection: %w", err)
+	}
+	return postgresHealthProbeSuccess, nil
+}
+
+func (s *Postgres) recordHealthProbe(result postgresHealthProbeResult) (previous, current postgresHealthState) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	previous := s.healthReady
-	if ok {
+	previous = postgresHealthState{ready: s.healthReady, saturated: s.healthSaturated}
+	s.healthSaturated = result == postgresHealthProbePoolSaturated
+	switch result {
+	case postgresHealthProbeSuccess:
 		s.healthFails = 0
 		if s.healthOKs < postgresHealthQuorum {
 			s.healthOKs++
@@ -220,7 +274,7 @@ func (s *Postgres) recordHealthProbe(ok bool) (changed, ready bool) {
 		if s.healthOKs >= postgresHealthQuorum {
 			s.healthReady = true
 		}
-	} else {
+	case postgresHealthProbeDatabaseError:
 		s.healthOKs = 0
 		if s.healthFails < postgresHealthQuorum {
 			s.healthFails++
@@ -228,8 +282,12 @@ func (s *Postgres) recordHealthProbe(ok bool) (changed, ready bool) {
 		if s.healthFails >= postgresHealthQuorum {
 			s.healthReady = false
 		}
+	case postgresHealthProbePoolSaturated:
+		// Saturation says nothing about database reachability. Preserve the last
+		// confirmed health state and its hysteresis counters.
 	}
-	return previous != s.healthReady, s.healthReady
+	current = postgresHealthState{ready: s.healthReady, saturated: s.healthSaturated}
+	return previous, current
 }
 
 func (s *Postgres) startIndexRebuild() {
@@ -297,7 +355,8 @@ func (s *Postgres) indexReadyErr() error {
 }
 
 // Ready reports whether the session index is usable and the live database has
-// passed the health hysteresis contract.
+// passed the health hysteresis contract. Pool saturation is reported
+// separately and does not by itself withdraw the replica from traffic.
 func (s *Postgres) Ready() bool {
 	select {
 	case <-s.readyCh:
@@ -506,6 +565,7 @@ func (s *Postgres) Close() error {
 		select {
 		case <-healthDone:
 		case <-time.After(postgresHealthTimeout):
+			slog.Warn("devshard storage: postgres health monitor did not stop before pool close")
 		}
 	}
 	s.pool.Close()

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -46,6 +46,11 @@ type Postgres struct {
 	readyOnce   sync.Once
 	indexErr    error
 	indexCancel context.CancelFunc
+	healthReady bool
+	healthFails int
+	healthOKs   int
+	healthStop  context.CancelFunc
+	healthDone  chan struct{}
 }
 
 const (
@@ -65,6 +70,11 @@ const (
 	// after a failed (often timed-out) create, so it must not extend the lock
 	// hold time by another full op timeout during an outage.
 	postgresLivePresenceTimeout = 2 * time.Second
+	// postgresHealthInterval and postgresHealthTimeout keep /ready tied to the
+	// live database without issuing a SQL probe for every router health check.
+	postgresHealthInterval = time.Second
+	postgresHealthTimeout  = time.Second
+	postgresHealthQuorum   = 2
 	// postgresIndexRepairBatchSize caps rows per DELETE/INSERT when repairing
 	// devshard_session_index so a large divergence does not hold one giant lock.
 	postgresIndexRepairBatchSize = 1000
@@ -160,9 +170,66 @@ func NewPostgres(ctx context.Context) (*Postgres, error) {
 		knownEpochs: make(map[uint64]struct{}),
 		escrowIdx:   make(map[string]uint64),
 		readyCh:     make(chan struct{}),
+		healthReady: true,
+		healthDone:  make(chan struct{}),
 	}
+	s.startHealthMonitor()
 	s.startIndexRebuild()
 	return s, nil
+}
+
+func (s *Postgres) startHealthMonitor() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.healthStop = cancel
+	s.mu.Unlock()
+	go func() {
+		defer close(s.healthDone)
+		ticker := time.NewTicker(postgresHealthInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				probeCtx, probeCancel := context.WithTimeout(ctx, postgresHealthTimeout)
+				err := s.pool.Ping(probeCtx)
+				probeCancel()
+				changed, ready := s.recordHealthProbe(err == nil)
+				if changed {
+					if ready {
+						slog.Info("devshard storage: postgres readiness recovered")
+					} else {
+						slog.Warn("devshard storage: postgres readiness lost", "error", err)
+					}
+				}
+			}
+		}
+	}()
+}
+
+func (s *Postgres) recordHealthProbe(ok bool) (changed, ready bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous := s.healthReady
+	if ok {
+		s.healthFails = 0
+		if s.healthOKs < postgresHealthQuorum {
+			s.healthOKs++
+		}
+		if s.healthOKs >= postgresHealthQuorum {
+			s.healthReady = true
+		}
+	} else {
+		s.healthOKs = 0
+		if s.healthFails < postgresHealthQuorum {
+			s.healthFails++
+		}
+		if s.healthFails >= postgresHealthQuorum {
+			s.healthReady = false
+		}
+	}
+	return previous != s.healthReady, s.healthReady
 }
 
 func (s *Postgres) startIndexRebuild() {
@@ -229,11 +296,17 @@ func (s *Postgres) indexReadyErr() error {
 	return nil
 }
 
-// Ready reports whether the session index rebuild has completed successfully.
+// Ready reports whether the session index is usable and the live database has
+// passed the health hysteresis contract.
 func (s *Postgres) Ready() bool {
 	select {
 	case <-s.readyCh:
-		return s.indexReadyErr() == nil
+		if s.indexReadyErr() != nil {
+			return false
+		}
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.healthReady
 	default:
 		return false
 	}
@@ -415,14 +488,25 @@ func (s *Postgres) insertMissingSessionIndex(ctx context.Context, escrows []stri
 // releases the pool. Subsequent calls return immediately.
 func (s *Postgres) Close() error {
 	s.mu.Lock()
-	cancel := s.indexCancel
+	indexCancel := s.indexCancel
+	healthCancel := s.healthStop
+	healthDone := s.healthDone
 	s.mu.Unlock()
-	if cancel != nil {
-		cancel()
+	if indexCancel != nil {
+		indexCancel()
+	}
+	if healthCancel != nil {
+		healthCancel()
 	}
 	select {
 	case <-s.readyCh:
 	case <-time.After(postgresOpTimeout):
+	}
+	if healthDone != nil {
+		select {
+		case <-healthDone:
+		case <-time.After(postgresHealthTimeout):
+		}
 	}
 	s.pool.Close()
 	return nil

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -441,19 +441,61 @@ func TestPostgres_WaitReady_BlocksUntilIndex(t *testing.T) {
 func TestPostgresReadyUsesHealthHysteresis(t *testing.T) {
 	pg := &Postgres{healthReady: true}
 
-	changed, ready := pg.recordHealthProbe(false)
-	require.False(t, changed)
-	require.True(t, ready)
-	changed, ready = pg.recordHealthProbe(false)
-	require.True(t, changed)
-	require.False(t, ready)
+	previous, current := pg.recordHealthProbe(postgresHealthProbeDatabaseError)
+	require.Equal(t, postgresHealthState{ready: true}, previous)
+	require.Equal(t, postgresHealthState{ready: true}, current)
+	previous, current = pg.recordHealthProbe(postgresHealthProbeDatabaseError)
+	require.Equal(t, postgresHealthState{ready: true}, previous)
+	require.Equal(t, postgresHealthState{}, current)
 
-	changed, ready = pg.recordHealthProbe(true)
-	require.False(t, changed)
-	require.False(t, ready)
-	changed, ready = pg.recordHealthProbe(true)
-	require.True(t, changed)
-	require.True(t, ready)
+	previous, current = pg.recordHealthProbe(postgresHealthProbePoolSaturated)
+	require.Equal(t, postgresHealthState{}, previous)
+	require.Equal(t, postgresHealthState{saturated: true}, current)
+	previous, current = pg.recordHealthProbe(postgresHealthProbePoolSaturated)
+	require.Equal(t, postgresHealthState{saturated: true}, previous)
+	require.Equal(t, postgresHealthState{saturated: true}, current)
+
+	previous, current = pg.recordHealthProbe(postgresHealthProbeSuccess)
+	require.Equal(t, postgresHealthState{saturated: true}, previous)
+	require.Equal(t, postgresHealthState{}, current)
+	previous, current = pg.recordHealthProbe(postgresHealthProbeSuccess)
+	require.Equal(t, postgresHealthState{}, previous)
+	require.Equal(t, postgresHealthState{ready: true}, current)
+}
+
+func TestPostgresHealthProbeDistinguishesPoolSaturation(t *testing.T) {
+	cleanup := setupPostgresContainer(t)
+	defer cleanup()
+
+	cfg, err := pgxpool.ParseConfig("")
+	require.NoError(t, err)
+	cfg.MaxConns = 1
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	defer pool.Close()
+	require.NoError(t, pool.Ping(context.Background()))
+
+	conn, err := pool.Acquire(context.Background())
+	require.NoError(t, err)
+	pg := &Postgres{pool: pool, healthReady: true}
+
+	probeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	result, probeErr := pg.probeHealth(probeCtx)
+	cancel()
+	require.ErrorIs(t, probeErr, context.DeadlineExceeded)
+	require.Equal(t, postgresHealthProbePoolSaturated, result)
+
+	_, current := pg.recordHealthProbe(result)
+	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
+	_, current = pg.recordHealthProbe(result)
+	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
+
+	conn.Release()
+	probeCtx, cancel = context.WithTimeout(context.Background(), time.Second)
+	result, probeErr = pg.probeHealth(probeCtx)
+	cancel()
+	require.NoError(t, probeErr)
+	require.Equal(t, postgresHealthProbeSuccess, result)
 }
 
 func TestPostgresReadyTracksLiveDatabaseLoss(t *testing.T) {
@@ -468,7 +510,7 @@ func TestPostgresReadyTracksLiveDatabaseLoss(t *testing.T) {
 
 	require.NoError(t, container.Stop(context.Background(), nil))
 	require.Eventually(t, func() bool { return !pg.Ready() },
-		5*time.Second, 100*time.Millisecond)
+		20*time.Second, 100*time.Millisecond)
 }
 
 func TestPostgres_NewPostgres_ConnectBudgetDoesNotIncludeIndex(t *testing.T) {

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
-
 )
 
 func postgresContainerWaitStrategy() wait.Strategy {
@@ -32,6 +31,12 @@ func postgresContainerWaitStrategy() wait.Strategy {
 // decentralized-api/payloadstorage/postgres_storage_test.go so dapi-side
 // regressions and devshard-side regressions are caught the same way.
 func setupPostgresContainer(t *testing.T) func() {
+	t.Helper()
+	container := startPostgresContainer(t)
+	return func() { _ = container.Terminate(context.Background()) }
+}
+
+func startPostgresContainer(t *testing.T) testcontainers.Container {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("skipping postgres testcontainers tests in -short mode (requires Docker)")
@@ -58,7 +63,7 @@ func setupPostgresContainer(t *testing.T) func() {
 	t.Setenv("PGUSER", "testuser")
 	t.Setenv("PGPASSWORD", "testpass")
 
-	return func() { _ = container.Terminate(ctx) }
+	return container
 }
 
 func newTestPostgres(t *testing.T) *Postgres {
@@ -431,6 +436,39 @@ func TestPostgres_WaitReady_BlocksUntilIndex(t *testing.T) {
 	require.NoError(t, <-waitErr)
 	require.True(t, pg.Ready())
 	require.NoError(t, pg.CreateSession(paramsForEpoch("after-ready", 1)))
+}
+
+func TestPostgresReadyUsesHealthHysteresis(t *testing.T) {
+	pg := &Postgres{healthReady: true}
+
+	changed, ready := pg.recordHealthProbe(false)
+	require.False(t, changed)
+	require.True(t, ready)
+	changed, ready = pg.recordHealthProbe(false)
+	require.True(t, changed)
+	require.False(t, ready)
+
+	changed, ready = pg.recordHealthProbe(true)
+	require.False(t, changed)
+	require.False(t, ready)
+	changed, ready = pg.recordHealthProbe(true)
+	require.True(t, changed)
+	require.True(t, ready)
+}
+
+func TestPostgresReadyTracksLiveDatabaseLoss(t *testing.T) {
+	container := startPostgresContainer(t)
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	pg, err := NewPostgres(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pg.Close() })
+	require.NoError(t, pg.WaitReady(context.Background()))
+	require.True(t, pg.Ready())
+
+	require.NoError(t, container.Stop(context.Background(), nil))
+	require.Eventually(t, func() bool { return !pg.Ready() },
+		5*time.Second, 100*time.Millisecond)
 }
 
 func TestPostgres_NewPostgres_ConnectBudgetDoesNotIncludeIndex(t *testing.T) {

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -441,31 +441,28 @@ func TestPostgres_WaitReady_BlocksUntilIndex(t *testing.T) {
 func TestPostgresReadyUsesHealthHysteresis(t *testing.T) {
 	pg := &Postgres{healthReady: true}
 
-	previous, current := pg.recordHealthProbe(postgresHealthProbeDatabaseError)
+	previous, current := pg.recordHealthProbe(postgresHealthProbeDatabaseError, true)
 	require.Equal(t, postgresHealthState{ready: true}, previous)
-	require.Equal(t, postgresHealthState{ready: true}, current)
-	previous, current = pg.recordHealthProbe(postgresHealthProbeDatabaseError)
-	require.Equal(t, postgresHealthState{ready: true}, previous)
-	require.Equal(t, postgresHealthState{}, current)
-
-	previous, current = pg.recordHealthProbe(postgresHealthProbePoolSaturated)
-	require.Equal(t, postgresHealthState{}, previous)
-	require.Equal(t, postgresHealthState{saturated: true}, current)
-	previous, current = pg.recordHealthProbe(postgresHealthProbePoolSaturated)
-	require.Equal(t, postgresHealthState{saturated: true}, previous)
+	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
+	previous, current = pg.recordHealthProbe(postgresHealthProbeDatabaseError, true)
+	require.Equal(t, postgresHealthState{ready: true, saturated: true}, previous)
 	require.Equal(t, postgresHealthState{saturated: true}, current)
 
-	previous, current = pg.recordHealthProbe(postgresHealthProbeSuccess)
+	previous, current = pg.recordHealthProbe(postgresHealthProbeSuccess, true)
 	require.Equal(t, postgresHealthState{saturated: true}, previous)
-	require.Equal(t, postgresHealthState{}, current)
-	previous, current = pg.recordHealthProbe(postgresHealthProbeSuccess)
-	require.Equal(t, postgresHealthState{}, previous)
+	require.Equal(t, postgresHealthState{saturated: true}, current)
+	previous, current = pg.recordHealthProbe(postgresHealthProbeSuccess, true)
+	require.Equal(t, postgresHealthState{saturated: true}, previous)
+	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
+
+	previous, current = pg.recordHealthProbe(postgresHealthProbeSuccess, false)
+	require.Equal(t, postgresHealthState{ready: true, saturated: true}, previous)
 	require.Equal(t, postgresHealthState{ready: true}, current)
 }
 
-func TestPostgresHealthProbeDistinguishesPoolSaturation(t *testing.T) {
-	cleanup := setupPostgresContainer(t)
-	defer cleanup()
+func TestPostgresHealthProbeIsIndependentOfApplicationPool(t *testing.T) {
+	container := startPostgresContainer(t)
+	defer func() { _ = container.Terminate(context.Background()) }()
 
 	cfg, err := pgxpool.ParseConfig("")
 	require.NoError(t, err)
@@ -477,32 +474,47 @@ func TestPostgresHealthProbeDistinguishesPoolSaturation(t *testing.T) {
 
 	conn, err := pool.Acquire(context.Background())
 	require.NoError(t, err)
-	released := false
+	defer conn.Release()
+	require.True(t, postgresPoolIsSaturated(pool))
+
+	probe := newPostgresHealthProbe(cfg.ConnConfig)
 	defer func() {
-		if !released {
-			conn.Release()
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := probe.close(closeCtx); err != nil {
+			t.Errorf("close postgres health probe: %v", err)
 		}
 	}()
 	pg := &Postgres{pool: pool, healthReady: true}
 
-	probeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	result, probeErr := pg.probeHealth(probeCtx)
-	cancel()
-	require.ErrorIs(t, probeErr, context.DeadlineExceeded)
-	require.Equal(t, postgresHealthProbePoolSaturated, result)
-
-	_, current := pg.recordHealthProbe(result)
-	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
-	_, current = pg.recordHealthProbe(result)
-	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
-
-	conn.Release()
-	released = true
-	probeCtx, cancel = context.WithTimeout(context.Background(), time.Second)
-	result, probeErr = pg.probeHealth(probeCtx)
+	probeCtx, cancel := context.WithTimeout(context.Background(), postgresHealthTimeout)
+	probeErr := probe.check(probeCtx)
 	cancel()
 	require.NoError(t, probeErr)
-	require.Equal(t, postgresHealthProbeSuccess, result)
+	_, current := pg.recordHealthProbe(postgresHealthProbeSuccess, postgresPoolIsSaturated(pool))
+	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), time.Second)
+	require.NoError(t, probe.conn.Close(closeCtx))
+	closeCancel()
+	probeCtx, cancel = context.WithTimeout(context.Background(), postgresHealthTimeout)
+	probeErr = probe.check(probeCtx)
+	cancel()
+	require.NoError(t, probeErr)
+
+	require.NoError(t, container.Stop(context.Background(), nil))
+	probeCtx, cancel = context.WithTimeout(context.Background(), postgresHealthTimeout)
+	probeErr = probe.check(probeCtx)
+	cancel()
+	require.Error(t, probeErr)
+	_, current = pg.recordHealthProbe(postgresHealthProbeDatabaseError, postgresPoolIsSaturated(pool))
+	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
+	_, current = pg.recordHealthProbe(postgresHealthProbeDatabaseError, postgresPoolIsSaturated(pool))
+	require.Equal(t, postgresHealthState{saturated: true}, current)
+}
+
+func TestPostgresHealthProbeBudgetCoversConnectionSetup(t *testing.T) {
+	require.GreaterOrEqual(t, postgresHealthTimeout, postgresConnectTimeout)
 }
 
 func TestPostgresReadyTracksLiveDatabaseLoss(t *testing.T) {
@@ -517,7 +529,7 @@ func TestPostgresReadyTracksLiveDatabaseLoss(t *testing.T) {
 
 	require.NoError(t, container.Stop(context.Background(), nil))
 	require.Eventually(t, func() bool { return !pg.Ready() },
-		20*time.Second, 100*time.Millisecond)
+		30*time.Second, 100*time.Millisecond)
 }
 
 func TestPostgres_NewPostgres_ConnectBudgetDoesNotIncludeIndex(t *testing.T) {

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -477,6 +477,12 @@ func TestPostgresHealthProbeDistinguishesPoolSaturation(t *testing.T) {
 
 	conn, err := pool.Acquire(context.Background())
 	require.NoError(t, err)
+	released := false
+	defer func() {
+		if !released {
+			conn.Release()
+		}
+	}()
 	pg := &Postgres{pool: pool, healthReady: true}
 
 	probeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -491,6 +497,7 @@ func TestPostgresHealthProbeDistinguishesPoolSaturation(t *testing.T) {
 	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
 
 	conn.Release()
+	released = true
 	probeCtx, cancel = context.WithTimeout(context.Background(), time.Second)
 	result, probeErr = pg.probeHealth(probeCtx)
 	cancel()


### PR DESCRIPTION
## Summary

> This focused PR is based on the PostgreSQL live-readiness work originally implemented in the closed umbrella PRs #1517 and #1587.

Track PostgreSQL availability after devshard storage has started:

- keep one monitor-owned PostgreSQL connection outside the application pool;
- reuse that connection for bounded health checks and reconnect it when needed;
- give connection setup the same 5-second budget as normal PostgreSQL connections;
- schedule each probe 5 seconds after the previous probe finishes;
- mark storage unready after two consecutive database failures;
- restore readiness after two consecutive successful probes;
- observe application-pool saturation independently from database health;
- stop and join the monitor before closing the application pool;
- keep SQLite-only storage behavior unchanged.

## Why

Previously, PostgreSQL readiness represented only successful startup and completion of the initial session-index rebuild. If the database became unavailable later, devshardd stayed alive and could continue reporting ready from stale startup state.

The process should remain alive so a transient database outage does not cause a restart loop, while readiness-aware routing can withdraw it until PostgreSQL recovers.

The health check deliberately does not borrow an application-pool slot. A full pool means that application work is using its configured capacity; it does not prove that PostgreSQL is unavailable. Conversely, a real database failure must still be detected while that pool is full.

## Behavior

This applies whenever a live PostgreSQL backend is attached. In fail-closed `DEVSHARD_STORAGE_MODE=postgres`, two confirmed database failures make `/readyz` return `503` without terminating devshardd. Two successful probes restore readiness. Hybrid storage uses the same PostgreSQL signal while attached. SQLite-only mode is unaffected.

The monitor uses one PostgreSQL connection in addition to the application pool. Application `MaxConns` remains entirely available to application work and is not changed by this PR.

Pool saturation does not by itself change readiness. It is exposed independently through:

- `devshard_postgres_health_probe_total{result="success|database_error"}`;
- `devshard_postgres_pool_saturated`.

This PR does not change storage-mode selection, compare database identities, migrate SQL data, set application-pool capacity, or change the PostgreSQL data-directory layout.

## Validation

- `go test -race ./storage ./observability`
- `go test ./...`
- `go vet ./storage ./observability`
- state-machine coverage for database-health hysteresis and independent saturation;
- Docker coverage proving that a dedicated health check succeeds with `MaxConns=1` fully occupied;
- Docker coverage proving that database loss is still detected while that pool remains occupied;
- reconnect coverage for a closed dedicated connection;
- failure-safe connection cleanup in the saturated-pool test.

## History

This focused PR extracts the PostgreSQL live-readiness work previously developed in the closed umbrella PRs #1517 and #1587 so it can be reviewed and merged independently.
