### PR TITLE
Persist and migrate devshard PostgreSQL data

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -401,3 +401,17 @@ jobs:
           name: Devshard E2E Tests
           path: devshard/build/test-results/e2e/junit.xml
           reporter: java-junit
+
+  test-devshard-postgres-migration:
+    runs-on: ubuntu-latest
+    name: Test devshard PostgreSQL persistence migration
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check migration scripts
+        run: |
+          shellcheck deploy/join/devshard-postgres-*.sh
+          deploy/join/devshard-postgres-entrypoint_test.sh
+          deploy/join/devshard-postgres-migration-preflight_test.sh
+      - name: Preserve a real PostgreSQL cluster across replacement
+        run: deploy/join/devshard-postgres-upgrade_test.sh

--- a/deploy/join/config.env.template
+++ b/deploy/join/config.env.template
@@ -54,6 +54,13 @@ export QUERY_GAS_LIMIT=10000000
 # export DEVSHARD_POSTGRES_DB=devshardd
 # export DEVSHARD_POSTGRES_USER=devshardd
 # export DEVSHARD_POSTGRES_PASSWORD=<FILLIN>
+# Persistent bind target for PGDATA. On the first replacement, the entrypoint
+# copies an existing v4 anonymous volume here without modifying its rollback copy.
+# export DEVSHARD_POSTGRES_DATA_DIR=./devshards/postgres
+# Set true only for a genuinely new HA installation with no legacy database.
+# export DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=false
+# export DEVSHARD_POSTGRES_STOP_GRACE_PERIOD=5m
+# export DEVSHARD_POSTGRES_START_PERIOD=30m
 
 # PostgreSQL tuning (optional)
 # export POSTGRES_MIN_WAL_SIZE=4GB

--- a/deploy/join/config.env.template
+++ b/deploy/join/config.env.template
@@ -57,10 +57,10 @@ export QUERY_GAS_LIMIT=10000000
 # Persistent bind target for PGDATA. On the first replacement, the entrypoint
 # copies an existing v4 anonymous volume here without modifying its rollback copy.
 # export DEVSHARD_POSTGRES_DATA_DIR=./devshards/postgres
-# Set true for the first start only when enabling HA on an installation that
-# has never used devshard PostgreSQL. Remove the setting immediately after the
-# cluster is created. Never use it to recover a missing anonymous volume.
-# export DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=false
+# For confirmed first-time HA enablement only, pass this override inline to the
+# first `docker compose up` command; do not persist it in config.env:
+# DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true docker compose <same -f options> up -d devshard-postgres
+# Never use the override to recover a missing anonymous volume.
 # export DEVSHARD_POSTGRES_STOP_GRACE_PERIOD=5m
 # export DEVSHARD_POSTGRES_START_PERIOD=30m
 

--- a/deploy/join/config.env.template
+++ b/deploy/join/config.env.template
@@ -57,7 +57,9 @@ export QUERY_GAS_LIMIT=10000000
 # Persistent bind target for PGDATA. On the first replacement, the entrypoint
 # copies an existing v4 anonymous volume here without modifying its rollback copy.
 # export DEVSHARD_POSTGRES_DATA_DIR=./devshards/postgres
-# Set true only for a genuinely new HA installation with no legacy database.
+# Set true for the first start only when enabling HA on an installation that
+# has never used devshard PostgreSQL. Remove the setting immediately after the
+# cluster is created. Never use it to recover a missing anonymous volume.
 # export DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=false
 # export DEVSHARD_POSTGRES_STOP_GRACE_PERIOD=5m
 # export DEVSHARD_POSTGRES_START_PERIOD=30m

--- a/deploy/join/devshard-postgres-entrypoint.sh
+++ b/deploy/join/devshard-postgres-entrypoint.sh
@@ -11,7 +11,7 @@ official_entrypoint=${GONKA_POSTGRES_OFFICIAL_ENTRYPOINT:-/usr/local/bin/docker-
 target_data=${PGDATA:-$persistent_root/data}
 staging_data=$persistent_root/.migrating
 staging_complete=$persistent_root/.gonka-copy-complete
-expected_major=16
+expected_major=
 
 log() {
     printf '%s\n' "gonka-postgres-entrypoint: $*" >&2
@@ -42,7 +42,7 @@ validate_cluster() {
 
 postgres_binding_marker() {
     for storage_root in "$versiond_data" "$versiond2_data"; do
-        [ -d "$storage_root" ] || continue
+        [ -d "$storage_root" ] || return 3
         marker=$(find "$storage_root" -type f -name .pg-bound -print -quit) ||
             return 2
         if [ -n "$marker" ]; then
@@ -51,6 +51,23 @@ postgres_binding_marker() {
         fi
     done
     return 1
+}
+
+detect_postgres_major() {
+    postgres_version=$(postgres --version 2>/dev/null) ||
+        die "cannot determine PostgreSQL server version"
+    case "$postgres_version" in
+        'postgres (PostgreSQL) '*)
+            postgres_version=${postgres_version#'postgres (PostgreSQL) '}
+            expected_major=${postgres_version%%.*}
+            ;;
+        *) die "cannot parse PostgreSQL server version: $postgres_version" ;;
+    esac
+    case "$expected_major" in
+        '' | *[!0-9]*)
+            die "invalid PostgreSQL server major version: $expected_major"
+            ;;
+    esac
 }
 
 ensure_migration_space() {
@@ -90,9 +107,7 @@ case "$target_data" in
 esac
 [ "$legacy_data" != "$target_data" ] || die "legacy and persistent PGDATA are identical"
 [ -x "$official_entrypoint" ] || die "official PostgreSQL entrypoint is not executable"
-case "$expected_major" in
-    '' | *[!0-9]*) die "invalid expected PostgreSQL major version: $expected_major" ;;
-esac
+detect_postgres_major
 mkdir -p "$persistent_root"
 
 if cluster_exists "$target_data"; then
@@ -149,8 +164,12 @@ else
         die "PostgreSQL-bound devshard data exists at $binding_marker but no PostgreSQL cluster is attached; restore the exact legacy volume and do not use DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT"
     else
         marker_status=$?
-        [ "$marker_status" -eq 1 ] ||
-            die "cannot inspect devshard data for PostgreSQL binding markers"
+        case "$marker_status" in
+            1) ;;
+            2) die "cannot inspect devshard data for PostgreSQL binding markers" ;;
+            3) die "required devshard data directories are not mounted; refusing empty PostgreSQL initialization" ;;
+            *) die "unexpected devshard binding-marker inspection status: $marker_status" ;;
+        esac
     fi
 
     if directory_has_entries "$existing_versiond" && [ "$allow_empty" != true ]; then

--- a/deploy/join/devshard-postgres-entrypoint.sh
+++ b/deploy/join/devshard-postgres-entrypoint.sh
@@ -5,10 +5,13 @@ set -eu
 legacy_data=${GONKA_POSTGRES_LEGACY_DATA:-/var/lib/postgresql/data}
 persistent_root=${GONKA_POSTGRES_PERSISTENT_ROOT:-/var/lib/postgresql/gonka}
 existing_versiond=${GONKA_POSTGRES_EXISTING_VERSIOND:-/var/lib/postgresql/gonka-existing-versiond}
+versiond_data=${GONKA_POSTGRES_VERSIOND_DATA:-/var/lib/postgresql/gonka-versiond-data}
+versiond2_data=${GONKA_POSTGRES_VERSIOND2_DATA:-/var/lib/postgresql/gonka-versiond2-data}
 official_entrypoint=${GONKA_POSTGRES_OFFICIAL_ENTRYPOINT:-/usr/local/bin/docker-entrypoint.sh}
 target_data=${PGDATA:-$persistent_root/data}
 staging_data=$persistent_root/.migrating
-staging_complete=$staging_data/.gonka-copy-complete
+staging_complete=$persistent_root/.gonka-copy-complete
+expected_major=16
 
 log() {
     printf '%s\n' "gonka-postgres-entrypoint: $*" >&2
@@ -33,9 +36,21 @@ cluster_exists() {
 validate_cluster() {
     cluster_version=$(cat "$1/PG_VERSION") ||
         die "cannot read $1/PG_VERSION"
-    case "$cluster_version" in
-        '' | *[!0-9]*) die "invalid PostgreSQL cluster version in $1" ;;
-    esac
+    [ "$cluster_version" = "$expected_major" ] ||
+        die "PostgreSQL cluster in $1 uses major version ${cluster_version:-unknown}; expected $expected_major"
+}
+
+postgres_binding_marker() {
+    for storage_root in "$versiond_data" "$versiond2_data"; do
+        [ -d "$storage_root" ] || continue
+        marker=$(find "$storage_root" -type f -name .pg-bound -print -quit) ||
+            return 2
+        if [ -n "$marker" ]; then
+            printf '%s\n' "$marker"
+            return 0
+        fi
+    done
+    return 1
 }
 
 ensure_migration_space() {
@@ -64,6 +79,8 @@ publish_staging() {
     fi
     mv "$staging_data" "$target_data" ||
         die "cannot publish migrated PostgreSQL cluster"
+    rm -f "$staging_complete" ||
+        die "cannot remove PostgreSQL migration completion marker"
     sync
 }
 
@@ -73,10 +90,15 @@ case "$target_data" in
 esac
 [ "$legacy_data" != "$target_data" ] || die "legacy and persistent PGDATA are identical"
 [ -x "$official_entrypoint" ] || die "official PostgreSQL entrypoint is not executable"
+case "$expected_major" in
+    '' | *[!0-9]*) die "invalid expected PostgreSQL major version: $expected_major" ;;
+esac
 mkdir -p "$persistent_root"
 
 if cluster_exists "$target_data"; then
     validate_cluster "$target_data"
+    rm -f "$staging_complete" ||
+        die "cannot remove stale PostgreSQL migration completion marker"
 elif [ -e "$target_data" ] && directory_has_entries "$target_data"; then
     die "persistent PGDATA is non-empty but has no PG_VERSION: $target_data"
 elif cluster_exists "$staging_data" && [ -f "$staging_complete" ]; then
@@ -89,6 +111,8 @@ elif cluster_exists "$legacy_data"; then
     if [ -e "$staging_data" ]; then
         rm -rf "$staging_data" || die "cannot reset stale migration staging data"
     fi
+    rm -f "$staging_complete" ||
+        die "cannot reset stale migration completion marker"
     ensure_migration_space
     mkdir "$staging_data"
 
@@ -120,8 +144,17 @@ else
         *) die "DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT must be true or false" ;;
     esac
 
+    binding_marker=
+    if binding_marker=$(postgres_binding_marker); then
+        die "PostgreSQL-bound devshard data exists at $binding_marker but no PostgreSQL cluster is attached; restore the exact legacy volume and do not use DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT"
+    else
+        marker_status=$?
+        [ "$marker_status" -eq 1 ] ||
+            die "cannot inspect devshard data for PostgreSQL binding markers"
+    fi
+
     if directory_has_entries "$existing_versiond" && [ "$allow_empty" != true ]; then
-        die "existing versiond artifacts found but no PostgreSQL cluster is attached; refusing to initialize an empty database (restore the v4 volume or explicitly set DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true for a new HA database)"
+        die "existing versiond artifacts found but no PostgreSQL cluster or .pg-bound marker is attached; this is either first-time HA enablement or a detached drained database (restore the v4 volume, or set DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true once only for confirmed first-time HA enablement)"
     fi
     log "no existing PostgreSQL cluster found; initializing persistent PGDATA"
 fi

--- a/deploy/join/devshard-postgres-entrypoint.sh
+++ b/deploy/join/devshard-postgres-entrypoint.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+set -eu
+
+legacy_data=${GONKA_POSTGRES_LEGACY_DATA:-/var/lib/postgresql/data}
+persistent_root=${GONKA_POSTGRES_PERSISTENT_ROOT:-/var/lib/postgresql/gonka}
+existing_versiond=${GONKA_POSTGRES_EXISTING_VERSIOND:-/var/lib/postgresql/gonka-existing-versiond}
+official_entrypoint=${GONKA_POSTGRES_OFFICIAL_ENTRYPOINT:-/usr/local/bin/docker-entrypoint.sh}
+target_data=${PGDATA:-$persistent_root/data}
+staging_data=$persistent_root/.migrating
+staging_complete=$staging_data/.gonka-copy-complete
+
+log() {
+    printf '%s\n' "gonka-postgres-entrypoint: $*" >&2
+}
+
+die() {
+    log "$*"
+    exit 1
+}
+
+directory_has_entries() {
+    [ -d "$1" ] || return 1
+    first_entry=$(find "$1" -mindepth 1 -print -quit) ||
+        die "cannot inspect $1"
+    [ -n "$first_entry" ]
+}
+
+cluster_exists() {
+    [ -s "$1/PG_VERSION" ]
+}
+
+validate_cluster() {
+    cluster_version=$(cat "$1/PG_VERSION") ||
+        die "cannot read $1/PG_VERSION"
+    case "$cluster_version" in
+        '' | *[!0-9]*) die "invalid PostgreSQL cluster version in $1" ;;
+    esac
+}
+
+ensure_migration_space() {
+    source_kib=$(du -sk "$legacy_data" | awk '{ print $1 }') ||
+        die "cannot measure PostgreSQL source cluster"
+    free_kib=$(df -Pk "$persistent_root" | awk 'NR == 2 { print $4 }') ||
+        die "cannot measure free space for $persistent_root"
+    case "$source_kib" in
+        '' | *[!0-9]* | 0) die "invalid PostgreSQL source size" ;;
+    esac
+    case "$free_kib" in
+        '' | *[!0-9]*) die "invalid PostgreSQL free-space measurement" ;;
+    esac
+    required_kib=$((source_kib + (source_kib + 9) / 10))
+    log "source is $source_kib KiB; migration requires $required_kib KiB; $free_kib KiB is free"
+    [ "$free_kib" -ge "$required_kib" ] ||
+        die "not enough free space for PostgreSQL migration"
+}
+
+publish_staging() {
+    if [ -e "$target_data" ]; then
+        if directory_has_entries "$target_data"; then
+            die "refusing to replace non-empty incomplete target $target_data"
+        fi
+        rmdir "$target_data" || die "cannot remove empty target $target_data"
+    fi
+    mv "$staging_data" "$target_data" ||
+        die "cannot publish migrated PostgreSQL cluster"
+    sync
+}
+
+case "$target_data" in
+    "$persistent_root"/*) ;;
+    *) die "PGDATA must be below $persistent_root" ;;
+esac
+[ "$legacy_data" != "$target_data" ] || die "legacy and persistent PGDATA are identical"
+[ -x "$official_entrypoint" ] || die "official PostgreSQL entrypoint is not executable"
+mkdir -p "$persistent_root"
+
+if cluster_exists "$target_data"; then
+    validate_cluster "$target_data"
+elif [ -e "$target_data" ] && directory_has_entries "$target_data"; then
+    die "persistent PGDATA is non-empty but has no PG_VERSION: $target_data"
+elif cluster_exists "$staging_data" && [ -f "$staging_complete" ]; then
+    validate_cluster "$staging_data"
+    log "finishing an interrupted atomic migration"
+    publish_staging
+elif cluster_exists "$legacy_data"; then
+    validate_cluster "$legacy_data"
+
+    if [ -e "$staging_data" ]; then
+        rm -rf "$staging_data" || die "cannot reset stale migration staging data"
+    fi
+    ensure_migration_space
+    mkdir "$staging_data"
+
+    log "migrating the preserved v4 PostgreSQL cluster into persistent storage"
+    cp -a "$legacy_data/." "$staging_data/" || die "PostgreSQL cluster copy failed"
+    if [ -e "$staging_data/postmaster.pid" ]; then
+        log "legacy cluster was not shut down cleanly; PostgreSQL will recover it from WAL"
+        rm "$staging_data/postmaster.pid" || die "cannot remove stale postmaster.pid"
+    fi
+    chmod 700 "$staging_data" || die "cannot secure migrated PGDATA"
+    validate_cluster "$staging_data"
+    [ "$(cat "$legacy_data/PG_VERSION")" = "$(cat "$staging_data/PG_VERSION")" ] ||
+        die "migrated PostgreSQL version does not match its source"
+    sync
+    : >"$staging_complete"
+    sync
+    publish_staging
+    printf '%s\n' "$(cat "$target_data/PG_VERSION")" \
+        >"$persistent_root/.migrated-from-v4"
+    log "v4 PostgreSQL migration completed"
+else
+    if [ -e "$staging_data" ] && directory_has_entries "$staging_data"; then
+        die "an incomplete migration exists but its v4 source is unavailable"
+    fi
+
+    allow_empty=${DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT:-false}
+    case "$allow_empty" in
+        true | false) ;;
+        *) die "DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT must be true or false" ;;
+    esac
+
+    if directory_has_entries "$existing_versiond" && [ "$allow_empty" != true ]; then
+        die "existing versiond artifacts found but no PostgreSQL cluster is attached; refusing to initialize an empty database (restore the v4 volume or explicitly set DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true for a new HA database)"
+    fi
+    log "no existing PostgreSQL cluster found; initializing persistent PGDATA"
+fi
+
+exec "$official_entrypoint" "$@"

--- a/deploy/join/devshard-postgres-entrypoint_test.sh
+++ b/deploy/join/devshard-postgres-entrypoint_test.sh
@@ -17,7 +17,10 @@ new_case() {
     legacy="$case_dir/legacy"
     persistent="$case_dir/persistent"
     existing="$case_dir/existing"
-    mkdir -p "$legacy" "$persistent" "$existing"
+    versiond_data="$case_dir/versiond-data"
+    versiond2_data="$case_dir/versiond2-data"
+    mkdir -p "$legacy" "$persistent" "$existing" \
+        "$versiond_data" "$versiond2_data"
 }
 
 run_entrypoint() {
@@ -26,6 +29,8 @@ run_entrypoint() {
         GONKA_POSTGRES_LEGACY_DATA="$legacy" \
         GONKA_POSTGRES_PERSISTENT_ROOT="$persistent" \
         GONKA_POSTGRES_EXISTING_VERSIOND="$existing" \
+        GONKA_POSTGRES_VERSIOND_DATA="$versiond_data" \
+        GONKA_POSTGRES_VERSIOND2_DATA="$versiond2_data" \
         GONKA_POSTGRES_OFFICIAL_ENTRYPOINT=/bin/true \
         PGDATA="$persistent/data" \
         DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT="${allow_empty:-false}" \
@@ -45,6 +50,8 @@ run_entrypoint
     "migration marker was not written"
 [[ ! -e "$persistent/.migrating" ]] || fail \
     "staging directory remained after migration"
+[[ ! -e "$persistent/.gonka-copy-complete" ]] || fail \
+    "migration completion marker leaked into live storage"
 
 new_case reject-insufficient-space
 printf '16\n' > "$legacy/PG_VERSION"
@@ -84,15 +91,18 @@ printf 'legacy\n' > "$legacy/source"
 mkdir -p "$persistent/data"
 printf '16\n' > "$persistent/data/PG_VERSION"
 printf 'current\n' > "$persistent/data/source"
+touch "$persistent/.gonka-copy-complete"
 run_entrypoint
 [[ $(<"$persistent/data/source") == current ]] || fail \
     "an existing persistent cluster was overwritten"
+[[ ! -e "$persistent/.gonka-copy-complete" ]] || fail \
+    "stale migration completion marker survived an existing target"
 
 new_case resume-publish
 mkdir -p "$persistent/.migrating"
 printf '16\n' > "$persistent/.migrating/PG_VERSION"
 printf 'resumed\n' > "$persistent/.migrating/session-row"
-touch "$persistent/.migrating/.gonka-copy-complete"
+touch "$persistent/.gonka-copy-complete"
 run_entrypoint
 [[ $(<"$persistent/data/session-row") == resumed ]] || fail \
     "complete staging data was not published"
@@ -121,8 +131,24 @@ printf 'install metadata\n' > "$existing/v4/install.json"
 if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
     fail "existing installation was allowed to initialize an empty database"
 fi
-grep -q 'refusing to initialize an empty database' "$case_dir/stderr" || fail \
+grep -q 'first-time HA enablement or a detached drained database' \
+    "$case_dir/stderr" || fail \
     "detached-volume failure did not explain the safety guard"
+
+new_case reject-postgres-bound
+mkdir -p "$existing/v4" "$versiond_data/v5"
+printf 'install metadata\n' > "$existing/v4/install.json"
+touch "$versiond_data/v5/.pg-bound"
+allow_empty=true
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "PostgreSQL-bound data was allowed to initialize an empty database"
+fi
+unset allow_empty
+grep -q 'PostgreSQL-bound devshard data exists' "$case_dir/stderr" || fail \
+    "PostgreSQL-bound failure did not identify the data-loss state"
+grep -q 'do not use DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT' \
+    "$case_dir/stderr" || fail \
+    "PostgreSQL-bound failure suggested the destructive override"
 
 new_case explicit-empty
 mkdir -p "$existing/v4"
@@ -142,5 +168,13 @@ if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
 fi
 grep -q 'non-empty but has no PG_VERSION' "$case_dir/stderr" || fail \
     "partial-target failure was not diagnosed"
+
+new_case reject-wrong-major
+printf '15\n' > "$legacy/PG_VERSION"
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "PostgreSQL 15 cluster was accepted by the PostgreSQL 16 image"
+fi
+grep -q 'uses major version 15; expected 16' "$case_dir/stderr" || fail \
+    "wrong-major failure was not diagnosed"
 
 echo "devshard-postgres-entrypoint_test: ok"

--- a/deploy/join/devshard-postgres-entrypoint_test.sh
+++ b/deploy/join/devshard-postgres-entrypoint_test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+entrypoint="$script_dir/devshard-postgres-entrypoint.sh"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+fail() {
+    echo "devshard-postgres-entrypoint_test: $*" >&2
+    exit 1
+}
+
+new_case() {
+    case_dir="$tmpdir/$1"
+    legacy="$case_dir/legacy"
+    persistent="$case_dir/persistent"
+    existing="$case_dir/existing"
+    mkdir -p "$legacy" "$persistent" "$existing"
+}
+
+run_entrypoint() {
+    env \
+        PATH="${entrypoint_path:-$PATH}" \
+        GONKA_POSTGRES_LEGACY_DATA="$legacy" \
+        GONKA_POSTGRES_PERSISTENT_ROOT="$persistent" \
+        GONKA_POSTGRES_EXISTING_VERSIOND="$existing" \
+        GONKA_POSTGRES_OFFICIAL_ENTRYPOINT=/bin/true \
+        PGDATA="$persistent/data" \
+        DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT="${allow_empty:-false}" \
+        "$entrypoint" postgres
+}
+
+new_case migrate
+printf '16\n' > "$legacy/PG_VERSION"
+printf 'preserved\n' > "$legacy/session-row"
+mkdir -p "$existing/v4"
+run_entrypoint
+[[ $(<"$persistent/data/session-row") == preserved ]] || fail \
+    "legacy data was not copied"
+[[ $(<"$legacy/session-row") == preserved ]] || fail \
+    "legacy source was modified"
+[[ -f "$persistent/.migrated-from-v4" ]] || fail \
+    "migration marker was not written"
+[[ ! -e "$persistent/.migrating" ]] || fail \
+    "staging directory remained after migration"
+
+new_case reject-insufficient-space
+printf '16\n' > "$legacy/PG_VERSION"
+printf 'cannot-fit\n' > "$legacy/session-row"
+mkdir -p "$case_dir/bin"
+cat >"$case_dir/bin/df" <<'EOF'
+#!/bin/sh
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf '/dev/fake 100 99 1 99%% /persistent\n'
+EOF
+chmod +x "$case_dir/bin/df"
+entrypoint_path="$case_dir/bin:$PATH"
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "migration started without enough free space"
+fi
+unset entrypoint_path
+grep -q 'not enough free space' "$case_dir/stderr" || fail \
+    "insufficient-space failure was not diagnosed"
+[[ ! -e "$persistent/.migrating" ]] || fail \
+    "staging directory was created after the space check failed"
+
+new_case migrate-crash-state
+printf '16\n' > "$legacy/PG_VERSION"
+printf '1\n' > "$legacy/postmaster.pid"
+printf 'wal-recoverable\n' > "$legacy/session-row"
+run_entrypoint
+[[ $(<"$persistent/data/session-row") == wal-recoverable ]] || fail \
+    "crash-state cluster was not copied"
+[[ ! -e "$persistent/data/postmaster.pid" ]] || fail \
+    "stale postmaster.pid was published"
+[[ -e "$legacy/postmaster.pid" ]] || fail \
+    "rollback source was modified while removing postmaster.pid"
+
+new_case target-wins
+printf '16\n' > "$legacy/PG_VERSION"
+printf 'legacy\n' > "$legacy/source"
+mkdir -p "$persistent/data"
+printf '16\n' > "$persistent/data/PG_VERSION"
+printf 'current\n' > "$persistent/data/source"
+run_entrypoint
+[[ $(<"$persistent/data/source") == current ]] || fail \
+    "an existing persistent cluster was overwritten"
+
+new_case resume-publish
+mkdir -p "$persistent/.migrating"
+printf '16\n' > "$persistent/.migrating/PG_VERSION"
+printf 'resumed\n' > "$persistent/.migrating/session-row"
+touch "$persistent/.migrating/.gonka-copy-complete"
+run_entrypoint
+[[ $(<"$persistent/data/session-row") == resumed ]] || fail \
+    "complete staging data was not published"
+
+new_case recopy-partial-staging
+printf '16\n' > "$legacy/PG_VERSION"
+printf 'complete\n' > "$legacy/session-row"
+mkdir -p "$persistent/.migrating"
+printf 'partial\n' > "$persistent/.migrating/session-row"
+run_entrypoint
+[[ $(<"$persistent/data/session-row") == complete ]] || fail \
+    "partial staging data was not replaced from the intact source"
+
+new_case reject-uncommitted-staging
+mkdir -p "$persistent/.migrating"
+printf '16\n' > "$persistent/.migrating/PG_VERSION"
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "uncommitted staging data was published without its source"
+fi
+grep -q 'incomplete migration exists' "$case_dir/stderr" || fail \
+    "uncommitted-staging failure was not diagnosed"
+
+new_case reject-detached
+mkdir -p "$existing/v4"
+printf 'install metadata\n' > "$existing/v4/install.json"
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "existing installation was allowed to initialize an empty database"
+fi
+grep -q 'refusing to initialize an empty database' "$case_dir/stderr" || fail \
+    "detached-volume failure did not explain the safety guard"
+
+new_case explicit-empty
+mkdir -p "$existing/v4"
+printf 'install metadata\n' > "$existing/v4/install.json"
+allow_empty=true
+run_entrypoint
+unset allow_empty
+
+new_case fresh
+run_entrypoint
+
+new_case reject-partial-target
+mkdir -p "$persistent/data"
+printf 'partial\n' > "$persistent/data/base"
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "partial persistent PGDATA was accepted"
+fi
+grep -q 'non-empty but has no PG_VERSION' "$case_dir/stderr" || fail \
+    "partial-target failure was not diagnosed"
+
+echo "devshard-postgres-entrypoint_test: ok"

--- a/deploy/join/devshard-postgres-entrypoint_test.sh
+++ b/deploy/join/devshard-postgres-entrypoint_test.sh
@@ -6,6 +6,13 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 entrypoint="$script_dir/devshard-postgres-entrypoint.sh"
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
+mkdir -p "$tmpdir/bin"
+cat >"$tmpdir/bin/postgres" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'postgres (PostgreSQL) 16.15'
+EOF
+chmod +x "$tmpdir/bin/postgres"
+test_path="$tmpdir/bin:$PATH"
 
 fail() {
     echo "devshard-postgres-entrypoint_test: $*" >&2
@@ -25,7 +32,7 @@ new_case() {
 
 run_entrypoint() {
     env \
-        PATH="${entrypoint_path:-$PATH}" \
+        PATH="${entrypoint_path:-$test_path}" \
         GONKA_POSTGRES_LEGACY_DATA="$legacy" \
         GONKA_POSTGRES_PERSISTENT_ROOT="$persistent" \
         GONKA_POSTGRES_EXISTING_VERSIOND="$existing" \
@@ -63,7 +70,7 @@ printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
 printf '/dev/fake 100 99 1 99%% /persistent\n'
 EOF
 chmod +x "$case_dir/bin/df"
-entrypoint_path="$case_dir/bin:$PATH"
+entrypoint_path="$case_dir/bin:$test_path"
 if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
     fail "migration started without enough free space"
 fi
@@ -150,6 +157,29 @@ grep -q 'do not use DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT' \
     "$case_dir/stderr" || fail \
     "PostgreSQL-bound failure suggested the destructive override"
 
+new_case reject-postgres-bound-second-root
+mkdir -p "$existing/v4" "$versiond2_data/v5"
+printf 'install metadata\n' > "$existing/v4/install.json"
+touch "$versiond2_data/v5/.pg-bound"
+allow_empty=true
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "PostgreSQL binding in the second data root was ignored"
+fi
+unset allow_empty
+grep -q "$versiond2_data/v5/.pg-bound" "$case_dir/stderr" || fail \
+    "PostgreSQL-bound failure did not identify the second data root"
+
+new_case reject-missing-evidence-mount
+rmdir "$versiond2_data"
+allow_empty=true
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "empty initialization was allowed without both evidence mounts"
+fi
+unset allow_empty
+grep -q 'required devshard data directories are not mounted' \
+    "$case_dir/stderr" || fail \
+    "missing-evidence-mount failure was not diagnosed"
+
 new_case explicit-empty
 mkdir -p "$existing/v4"
 printf 'install metadata\n' > "$existing/v4/install.json"
@@ -176,5 +206,26 @@ if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
 fi
 grep -q 'uses major version 15; expected 16' "$case_dir/stderr" || fail \
     "wrong-major failure was not diagnosed"
+
+new_case reject-wrong-target-major
+mkdir -p "$persistent/data"
+printf '15\n' > "$persistent/data/PG_VERSION"
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "PostgreSQL 15 target was accepted by the PostgreSQL 16 image"
+fi
+grep -q 'uses major version 15; expected 16' "$case_dir/stderr" || fail \
+    "wrong-target-major failure was not diagnosed"
+
+new_case follow-image-major
+mkdir -p "$persistent/data" "$case_dir/bin"
+printf '17\n' > "$persistent/data/PG_VERSION"
+cat >"$case_dir/bin/postgres" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'postgres (PostgreSQL) 17.5'
+EOF
+chmod +x "$case_dir/bin/postgres"
+entrypoint_path="$case_dir/bin:$test_path"
+run_entrypoint
+unset entrypoint_path
 
 echo "devshard-postgres-entrypoint_test: ok"

--- a/deploy/join/devshard-postgres-migration-preflight.sh
+++ b/deploy/join/devshard-postgres-migration-preflight.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+docker_bin=${DOCKER_BIN:-docker}
+helper_image=${POSTGRES_MIGRATION_HELPER_IMAGE:-${DEVSHARD_POSTGRES_IMAGE:-postgres:16-alpine}}
+source_container=
+source_volume=
+target_dir=
+
+fail() {
+    echo "devshard-postgres-migration-preflight: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  devshard-postgres-migration-preflight.sh \
+    (--source-container ID | --source-volume NAME) --target-dir DIR
+
+Checks that the target filesystem has enough free space for an atomic copy of
+the v4 PostgreSQL cluster. Source and target are mounted read-only and are not
+modified.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --source-container)
+            [[ $# -ge 2 ]] || fail "--source-container requires a value"
+            source_container=$2
+            shift 2
+            ;;
+        --source-volume)
+            [[ $# -ge 2 ]] || fail "--source-volume requires a value"
+            source_volume=$2
+            shift 2
+            ;;
+        --target-dir)
+            [[ $# -ge 2 ]] || fail "--target-dir requires a value"
+            target_dir=$2
+            shift 2
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            fail "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ -n $target_dir ]] || fail "--target-dir is required"
+if [[ -n $source_container && -n $source_volume ]]; then
+    fail "use either --source-container or --source-volume, not both"
+fi
+if [[ -z $source_container && -z $source_volume ]]; then
+    fail "one source option is required"
+fi
+command -v "$docker_bin" >/dev/null 2>&1 || fail "$docker_bin is required"
+
+mkdir -p "$target_dir"
+target_dir=$(cd -- "$target_dir" && pwd -P)
+
+probe_script=$(cat <<'PROBE'
+if [ -s "$2/data/PG_VERSION" ]; then
+    printf 'target-ready\n'
+elif [ -s "$2/.migrating/PG_VERSION" ] &&
+    [ -f "$2/.migrating/.gonka-copy-complete" ]; then
+    printf 'staging-ready\n'
+elif [ -s "$1/PG_VERSION" ]; then
+    source_kib=$(du -sk "$1" | cut -f1)
+    reclaimable_kib=0
+    if [ -d "$2/.migrating" ]; then
+        reclaimable_kib=$(du -sk "$2/.migrating" | cut -f1)
+    fi
+    printf 'source %s %s\n' "$source_kib" "$reclaimable_kib"
+else
+    printf 'source-missing\n'
+fi
+PROBE
+)
+
+probe_args=(
+    run --rm
+    --network none
+    --read-only
+    --security-opt no-new-privileges
+    # Inspect an existing Compose :Z bind without relabeling it away from the
+    # running PostgreSQL container.
+    --security-opt label=disable
+    --mount "type=bind,src=$target_dir,dst=/target,readonly"
+)
+
+if [[ -n $source_container ]]; then
+    "$docker_bin" inspect "$source_container" >/dev/null ||
+        fail "source container does not exist: $source_container"
+    probe=$("$docker_bin" "${probe_args[@]}" \
+        --volumes-from "$source_container:ro" \
+        --entrypoint /bin/sh "$helper_image" \
+        -ec "$probe_script" sh /var/lib/postgresql/data /target)
+else
+    "$docker_bin" volume inspect "$source_volume" >/dev/null ||
+        fail "source volume does not exist: $source_volume"
+    probe=$("$docker_bin" "${probe_args[@]}" \
+        --mount "type=volume,src=$source_volume,dst=/source,readonly" \
+        --entrypoint /bin/sh "$helper_image" \
+        -ec "$probe_script" sh /source /target)
+fi
+
+read -r probe_state source_kib reclaimable_kib extra <<<"$probe"
+[[ -z ${extra:-} ]] || fail "unexpected source probe output: $probe"
+case $probe_state in
+    target-ready)
+        echo "PostgreSQL persistent PGDATA already exists; no migration copy is required"
+        exit 0
+        ;;
+    staging-ready)
+        echo "PostgreSQL migration staging is complete; no new copy is required"
+        exit 0
+        ;;
+    source-missing)
+        fail "the selected v4 source has no PostgreSQL PG_VERSION"
+        ;;
+    source) ;;
+    *) fail "unexpected source probe output: $probe" ;;
+esac
+[[ $source_kib =~ ^[1-9][0-9]*$ ]] || fail \
+    "invalid PostgreSQL source size: ${source_kib:-empty}"
+[[ $reclaimable_kib =~ ^[0-9]+$ ]] || fail \
+    "invalid reclaimable staging size: ${reclaimable_kib:-empty}"
+
+free_kib=$(df -Pk -- "$target_dir" | awk 'NR == 2 { print $4 }')
+[[ $free_kib =~ ^[0-9]+$ ]] || fail \
+    "cannot determine free space for $target_dir"
+
+# The migration is a full copy. Keep a 10% reserve for filesystem metadata,
+# WAL growth between this preflight and shutdown, and the completion marker.
+required_kib=$((source_kib + (source_kib + 9) / 10))
+effective_free_kib=$((free_kib + reclaimable_kib))
+printf 'PostgreSQL source: %s KiB; required free: %s KiB; filesystem free: %s KiB; reclaimable staging: %s KiB; effective available: %s KiB\n' \
+    "$source_kib" "$required_kib" "$free_kib" "$reclaimable_kib" \
+    "$effective_free_kib"
+if ((effective_free_kib < required_kib)); then
+    fail "not enough free space for PostgreSQL migration"
+fi

--- a/deploy/join/devshard-postgres-migration-preflight.sh
+++ b/deploy/join/devshard-postgres-migration-preflight.sh
@@ -54,6 +54,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n $target_dir ]] || fail "--target-dir is required"
+[[ $target_dir != *,* ]] || fail \
+    "target directory must not contain a comma: $target_dir"
 if [[ -n $source_container && -n $source_volume ]]; then
     fail "use either --source-container or --source-volume, not both"
 fi
@@ -69,7 +71,7 @@ probe_script=$(cat <<'PROBE'
 if [ -s "$2/data/PG_VERSION" ]; then
     printf 'target-ready\n'
 elif [ -s "$2/.migrating/PG_VERSION" ] &&
-    [ -f "$2/.migrating/.gonka-copy-complete" ]; then
+    [ -f "$2/.gonka-copy-complete" ]; then
     printf 'staging-ready\n'
 elif [ -s "$1/PG_VERSION" ]; then
     source_kib=$(du -sk "$1" | cut -f1)

--- a/deploy/join/devshard-postgres-migration-preflight_test.sh
+++ b/deploy/join/devshard-postgres-migration-preflight_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+preflight="$script_dir/devshard-postgres-migration-preflight.sh"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+fail() {
+    echo "devshard-postgres-migration-preflight_test: $*" >&2
+    exit 1
+}
+
+cat >"$tmpdir/docker" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+printf '%q ' "$@" >>"$DOCKER_LOG"
+printf '\n' >>"$DOCKER_LOG"
+
+case ${1:-} in
+    inspect) exit 0 ;;
+    volume)
+        [[ ${2:-} == inspect ]] || exit 1
+        exit 0
+        ;;
+    run)
+        printf '%s\n' "$DOCKER_PROBE"
+        exit 0
+        ;;
+    *) exit 1 ;;
+esac
+EOF
+chmod +x "$tmpdir/docker"
+
+cat >"$tmpdir/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf '/dev/fake 999999 1 %s 1%% /target\n' "$FREE_KIB"
+EOF
+chmod +x "$tmpdir/df"
+
+run_preflight() {
+    DOCKER_BIN="$tmpdir/docker" \
+        DOCKER_LOG="$tmpdir/docker.log" \
+        DOCKER_PROBE="$DOCKER_PROBE" \
+        FREE_KIB="$FREE_KIB" \
+        PATH="$tmpdir:$PATH" \
+        "$preflight" "$@"
+}
+
+: >"$tmpdir/docker.log"
+target_mount="type=bind\\,src=$tmpdir/target\\,dst=/target\\,readonly"
+DOCKER_PROBE='source 1000 0'
+FREE_KIB=1100
+export DOCKER_PROBE FREE_KIB
+run_preflight --source-container postgres-v4 --target-dir "$tmpdir/target" \
+    >"$tmpdir/pass.stdout"
+grep -q 'required free: 1100 KiB' "$tmpdir/pass.stdout" || fail \
+    "successful preflight did not report its calculation"
+grep -q -- '--volumes-from postgres-v4:ro' "$tmpdir/docker.log" || fail \
+    "container source was not mounted read-only"
+grep -Fq -- "$target_mount" \
+    "$tmpdir/docker.log" || fail \
+    "target directory was not mounted for the container-source probe"
+
+FREE_KIB=1099
+export FREE_KIB
+if run_preflight --source-container postgres-v4 --target-dir "$tmpdir/target" \
+    >"$tmpdir/fail.stdout" 2>"$tmpdir/fail.stderr"; then
+    fail "insufficient free space passed preflight"
+fi
+grep -q 'not enough free space' "$tmpdir/fail.stderr" || fail \
+    "insufficient-space error was not explained"
+
+: >"$tmpdir/docker.log"
+DOCKER_PROBE='source 2000 0'
+FREE_KIB=2200
+export DOCKER_PROBE FREE_KIB
+run_preflight --source-volume postgres-v4-volume \
+    --target-dir "$tmpdir/target" >/dev/null
+grep -q 'volume inspect postgres-v4-volume' "$tmpdir/docker.log" || fail \
+    "volume existence was not checked"
+grep -q 'src=postgres-v4-volume' "$tmpdir/docker.log" || fail \
+    "selected volume was not mounted"
+grep -q 'readonly' "$tmpdir/docker.log" || fail \
+    "volume source was not mounted read-only"
+grep -Fq -- "$target_mount" \
+    "$tmpdir/docker.log" || fail \
+    "target directory was not mounted for the volume-source probe"
+
+DOCKER_PROBE='source 1000 200'
+FREE_KIB=900
+export DOCKER_PROBE FREE_KIB
+run_preflight --source-volume postgres-v4-volume \
+    --target-dir "$tmpdir/target" >"$tmpdir/reclaim.stdout"
+grep -q 'filesystem free: 900 KiB; reclaimable staging: 200 KiB; effective available: 1100 KiB' \
+    "$tmpdir/reclaim.stdout" || fail \
+    "partial staging was not counted as reclaimable space"
+
+FREE_KIB=899
+export FREE_KIB
+if run_preflight --source-volume postgres-v4-volume \
+    --target-dir "$tmpdir/target" \
+    >"$tmpdir/reclaim-fail.stdout" 2>"$tmpdir/reclaim-fail.stderr"; then
+    fail "insufficient effective space passed after staging accounting"
+fi
+
+DOCKER_PROBE='target-ready'
+FREE_KIB=0
+export DOCKER_PROBE FREE_KIB
+run_preflight --source-volume postgres-v4-volume --target-dir "$tmpdir/target" \
+    >"$tmpdir/target.stdout"
+grep -q 'no migration copy is required' "$tmpdir/target.stdout" || fail \
+    "existing persistent PGDATA was not recognized"
+
+DOCKER_PROBE='staging-ready'
+export DOCKER_PROBE
+run_preflight --source-volume postgres-v4-volume --target-dir "$tmpdir/target" \
+    >"$tmpdir/staging.stdout"
+grep -q 'staging is complete' "$tmpdir/staging.stdout" || fail \
+    "committed migration staging was not recognized"
+
+DOCKER_PROBE='source-missing'
+export DOCKER_PROBE
+if run_preflight --source-volume empty-volume --target-dir "$tmpdir/target" \
+    >"$tmpdir/missing.stdout" 2>"$tmpdir/missing.stderr"; then
+    fail "a source without PG_VERSION passed preflight"
+fi
+grep -q 'has no PostgreSQL PG_VERSION' "$tmpdir/missing.stderr" || fail \
+    "missing-cluster error was not explained"
+
+echo "devshard-postgres-migration-preflight_test: ok"

--- a/deploy/join/devshard-postgres-migration-preflight_test.sh
+++ b/deploy/join/devshard-postgres-migration-preflight_test.sh
@@ -65,6 +65,14 @@ grep -Fq -- "$target_mount" \
     "$tmpdir/docker.log" || fail \
     "target directory was not mounted for the container-source probe"
 
+if run_preflight --source-container postgres-v4 \
+    --target-dir "$tmpdir/target,readonly" \
+    >"$tmpdir/comma.stdout" 2>"$tmpdir/comma.stderr"; then
+    fail "target path with mount-option separator passed preflight"
+fi
+grep -q 'must not contain a comma' "$tmpdir/comma.stderr" || fail \
+    "unsafe target path failure was not explained"
+
 FREE_KIB=1099
 export FREE_KIB
 if run_preflight --source-container postgres-v4 --target-dir "$tmpdir/target" \

--- a/deploy/join/devshard-postgres-upgrade_test.sh
+++ b/deploy/join/devshard-postgres-upgrade_test.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+tmpdir=$(mktemp -d)
+project="gonka-pg-upgrade-$$"
+guard_project="$project-guard"
+base="$script_dir/testdata/postgres-v4.compose.yml"
+overlay="$script_dir/testdata/postgres-v5.compose.yml"
+recovery_overlay="$script_dir/docker-compose.versiond-postgres-recovery.yml"
+preflight="$script_dir/devshard-postgres-migration-preflight.sh"
+service=devshard-postgres
+export GONKA_POSTGRES_TEST_DATA="$tmpdir/persistent"
+export GONKA_POSTGRES_TEST_ENTRYPOINT="$script_dir/devshard-postgres-entrypoint.sh"
+export GONKA_POSTGRES_TEST_EXISTING="$tmpdir/existing-versiond"
+
+old_compose=(docker compose --project-name "$project" -f "$base")
+new_compose=(docker compose --project-name "$project" -f "$base" -f "$overlay")
+guard_old_compose=(docker compose --project-name "$guard_project" -f "$base")
+guard_new_compose=(docker compose --project-name "$guard_project" -f "$base" -f "$overlay")
+guard_recovery_compose=(docker compose --project-name "$guard_project" -f "$base" -f "$overlay" -f "$recovery_overlay")
+guard_old_volume=""
+guard_replacement_volume=""
+
+cleanup() {
+    "${new_compose[@]}" down --volumes --remove-orphans --timeout 1 \
+        >/dev/null 2>&1 || true
+    "${guard_new_compose[@]}" down --volumes --remove-orphans --timeout 1 \
+        >/dev/null 2>&1 || true
+    if [[ -n $guard_old_volume ]]; then
+        docker volume rm "$guard_old_volume" >/dev/null 2>&1 || true
+    fi
+    if [[ -n $guard_replacement_volume ]]; then
+        docker volume rm "$guard_replacement_volume" >/dev/null 2>&1 || true
+    fi
+    docker run --rm --entrypoint sh -v "$tmpdir:/cleanup" \
+        postgres:16-alpine -c \
+        'rm -rf /cleanup/* /cleanup/.[!.]* /cleanup/..?*' \
+        >/dev/null 2>&1 || true
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "devshard-postgres-upgrade_test: $*" >&2
+    "${new_compose[@]}" logs "$service" >&2 || true
+    exit 1
+}
+
+wait_for_postgres() {
+    local _
+    local -a compose=("$@")
+    for _ in {1..60}; do
+        if "${compose[@]}" exec -T "$service" \
+            pg_isready -U devshardd -d devshardd >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    fail "PostgreSQL did not become ready"
+}
+
+mkdir -p "$GONKA_POSTGRES_TEST_DATA" \
+    "$GONKA_POSTGRES_TEST_EXISTING/v4"
+printf 'existing v4 installation\n' \
+    >"$GONKA_POSTGRES_TEST_EXISTING/v4/install.json"
+
+"${old_compose[@]}" up -d "$service"
+wait_for_postgres "${old_compose[@]}"
+"${old_compose[@]}" exec -T "$service" psql \
+    -U devshardd -d devshardd -v ON_ERROR_STOP=1 \
+    -c "CREATE TABLE migration_probe (value text NOT NULL);" \
+    -c "INSERT INTO migration_probe VALUES ('preserved-v4-row');" \
+    >/dev/null
+
+old_container=$("${old_compose[@]}" ps -q "$service")
+old_volume=$(docker inspect "$old_container" --format \
+    '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')
+[[ -n $old_volume ]] || fail "v4 PostgreSQL did not use an anonymous volume"
+
+# The operator preflight must inspect the live v4 container without stopping it
+# and approve the target filesystem before Compose performs the first recreate.
+"$preflight" --source-container "$old_container" \
+    --target-dir "$GONKA_POSTGRES_TEST_DATA" >/dev/null
+
+# This is the supported upgrade: recreate in place. Compose carries the old
+# anonymous mount to the new container, whose entrypoint migrates it.
+"${new_compose[@]}" up -d --force-recreate "$service"
+wait_for_postgres "${new_compose[@]}"
+new_container=$("${new_compose[@]}" ps -q "$service")
+preserved_volume=$(docker inspect "$new_container" --format \
+    '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')
+[[ $preserved_volume == "$old_volume" ]] || fail \
+    "Compose did not carry the v4 anonymous volume into the upgrade"
+
+row=$("${new_compose[@]}" exec -T "$service" psql \
+    -U devshardd -d devshardd -Atc \
+    "SELECT value FROM migration_probe;")
+[[ $row == preserved-v4-row ]] || fail "the v4 database row was not migrated"
+"${new_compose[@]}" exec -T "$service" \
+    test -s /var/lib/postgresql/gonka/data/PG_VERSION || fail \
+    "persistent PGDATA was not published"
+preflight_result=$("$preflight" --source-container "$new_container" \
+    --target-dir "$GONKA_POSTGRES_TEST_DATA")
+grep -q 'no migration copy is required' <<<"$preflight_result" || fail \
+    "preflight did not recognize migrated persistent PGDATA"
+
+# Once migrated, even removing the container is safe: the bind-mounted PGDATA
+# is authoritative and the replacement no longer needs the anonymous source.
+"${new_compose[@]}" down
+"${new_compose[@]}" up -d "$service"
+wait_for_postgres "${new_compose[@]}"
+row=$("${new_compose[@]}" exec -T "$service" psql \
+    -U devshardd -d devshardd -Atc \
+    "SELECT value FROM migration_probe;")
+[[ $row == preserved-v4-row ]] || fail \
+    "persistent database row was lost across down/up"
+
+# If an operator removed the v4 container before migration, Docker cannot know
+# which dangling anonymous volume belonged to it. The new service must fail
+# closed rather than initialize an empty database beside an existing install.
+export GONKA_POSTGRES_TEST_DATA="$tmpdir/guard-persistent"
+export GONKA_POSTGRES_TEST_EXISTING="$tmpdir/guard-existing-versiond"
+mkdir -p "$GONKA_POSTGRES_TEST_DATA" \
+    "$GONKA_POSTGRES_TEST_EXISTING/v4"
+printf 'existing v4 installation\n' \
+    >"$GONKA_POSTGRES_TEST_EXISTING/v4/install.json"
+
+"${guard_old_compose[@]}" up -d "$service"
+wait_for_postgres "${guard_old_compose[@]}"
+"${guard_old_compose[@]}" exec -T "$service" psql \
+    -U devshardd -d devshardd -v ON_ERROR_STOP=1 \
+    -c "CREATE TABLE detached_volume_probe (value text NOT NULL);" \
+    -c "INSERT INTO detached_volume_probe VALUES ('recovered-v4-row');" \
+    >/dev/null
+guard_old_container=$("${guard_old_compose[@]}" ps -q "$service")
+guard_old_volume=$(docker inspect "$guard_old_container" --format \
+    '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')
+[[ -n $guard_old_volume ]] || fail \
+    "guard fixture did not create an anonymous v4 volume"
+"${guard_old_compose[@]}" down
+
+"$preflight" --source-volume "$guard_old_volume" \
+    --target-dir "$GONKA_POSTGRES_TEST_DATA" >/dev/null
+
+# A completed staging copy is sufficient for a restart. The detached source
+# volume and host target must both be visible to the helper in this mode.
+restart_target="$tmpdir/recovery-restart"
+mkdir -p "$restart_target/.migrating"
+printf '16\n' >"$restart_target/.migrating/PG_VERSION"
+: >"$restart_target/.migrating/.gonka-copy-complete"
+restart_result=$("$preflight" --source-volume "$guard_old_volume" \
+    --target-dir "$restart_target")
+grep -q 'staging is complete' <<<"$restart_result" || fail \
+    "volume recovery preflight did not recognize completed staging"
+
+"${guard_new_compose[@]}" up -d "$service"
+guard_container=$("${guard_new_compose[@]}" ps -aq "$service")
+for _ in {1..30}; do
+    guard_state=$(docker inspect "$guard_container" --format '{{.State.Status}}')
+    [[ $guard_state == exited ]] && break
+    sleep 0.2
+done
+[[ ${guard_state:-} == exited ]] || fail \
+    "detached-volume guard did not stop PostgreSQL"
+guard_logs=$("${guard_new_compose[@]}" logs --no-color "$service" 2>&1)
+grep -q 'refusing to initialize an empty database' <<<"$guard_logs" || fail \
+    "detached-volume guard did not explain the failure"
+[[ ! -e $GONKA_POSTGRES_TEST_DATA/data/PG_VERSION ]] || fail \
+    "detached-volume guard initialized an empty PostgreSQL cluster"
+
+# The shipped recovery overlay reattaches the selected external volume at the
+# legacy mount. The same entrypoint then performs its validated atomic copy into
+# the persistent PGDATA, so operators never have to guess the target level.
+export DEVSHARD_POSTGRES_LEGACY_VOLUME=$guard_old_volume
+"${guard_recovery_compose[@]}" up -d --force-recreate "$service"
+wait_for_postgres "${guard_recovery_compose[@]}"
+recovery_container=$("${guard_recovery_compose[@]}" ps -q "$service")
+recovery_volume=$(docker inspect "$recovery_container" --format \
+    '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')
+[[ $recovery_volume == "$guard_old_volume" ]] || fail \
+    "recovery container did not mount the selected v4 volume"
+recovered_row=$("${guard_recovery_compose[@]}" exec -T "$service" psql \
+    -U devshardd -d devshardd -Atc \
+    "SELECT value FROM detached_volume_probe;")
+[[ $recovered_row == recovered-v4-row ]] || fail \
+    "detached v4 PostgreSQL volume was not recovered"
+"${guard_recovery_compose[@]}" exec -T "$service" \
+    test -s /var/lib/postgresql/gonka/data/PG_VERSION || fail \
+    "recovery overlay did not publish persistent PGDATA"
+restart_result=$("$preflight" --source-volume "$guard_old_volume" \
+    --target-dir "$GONKA_POSTGRES_TEST_DATA")
+grep -q 'no migration copy is required' <<<"$restart_result" || fail \
+    "volume recovery preflight did not recognize published PGDATA"
+
+# Remove the temporary legacy mount and prove the recovered bind is now the
+# only storage needed by a normal deployment restart.
+"${guard_new_compose[@]}" up -d --force-recreate --renew-anon-volumes "$service"
+wait_for_postgres "${guard_new_compose[@]}"
+replacement_container=$("${guard_new_compose[@]}" ps -q "$service")
+guard_replacement_volume=$(docker inspect "$replacement_container" --format \
+    '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')
+[[ -n $guard_replacement_volume ]] || fail \
+    "normal deployment did not create a replacement anonymous volume"
+[[ $guard_replacement_volume != "$guard_old_volume" ]] || fail \
+    "normal deployment retained the temporary recovery volume"
+docker volume inspect "$guard_old_volume" >/dev/null || fail \
+    "detaching the recovery mount removed its rollback volume"
+recovered_row=$("${guard_new_compose[@]}" exec -T "$service" psql \
+    -U devshardd -d devshardd -Atc \
+    "SELECT value FROM detached_volume_probe;")
+[[ $recovered_row == recovered-v4-row ]] || fail \
+    "recovered PostgreSQL data was lost after detaching the v4 volume"
+
+echo "devshard-postgres-upgrade_test: ok"

--- a/deploy/join/devshard-postgres-upgrade_test.sh
+++ b/deploy/join/devshard-postgres-upgrade_test.sh
@@ -14,6 +14,8 @@ service=devshard-postgres
 export GONKA_POSTGRES_TEST_DATA="$tmpdir/persistent"
 export GONKA_POSTGRES_TEST_ENTRYPOINT="$script_dir/devshard-postgres-entrypoint.sh"
 export GONKA_POSTGRES_TEST_EXISTING="$tmpdir/existing-versiond"
+export GONKA_POSTGRES_TEST_VERSIOND_DATA="$tmpdir/versiond-data"
+export GONKA_POSTGRES_TEST_VERSIOND2_DATA="$tmpdir/versiond2-data"
 
 old_compose=(docker compose --project-name "$project" -f "$base")
 new_compose=(docker compose --project-name "$project" -f "$base" -f "$overlay")
@@ -62,7 +64,9 @@ wait_for_postgres() {
 }
 
 mkdir -p "$GONKA_POSTGRES_TEST_DATA" \
-    "$GONKA_POSTGRES_TEST_EXISTING/v4"
+    "$GONKA_POSTGRES_TEST_EXISTING/v4" \
+    "$GONKA_POSTGRES_TEST_VERSIOND_DATA" \
+    "$GONKA_POSTGRES_TEST_VERSIOND2_DATA"
 printf 'existing v4 installation\n' \
     >"$GONKA_POSTGRES_TEST_EXISTING/v4/install.json"
 
@@ -101,6 +105,8 @@ row=$("${new_compose[@]}" exec -T "$service" psql \
 "${new_compose[@]}" exec -T "$service" \
     test -s /var/lib/postgresql/gonka/data/PG_VERSION || fail \
     "persistent PGDATA was not published"
+[[ ! -e $GONKA_POSTGRES_TEST_DATA/.gonka-copy-complete ]] || fail \
+    "migration completion marker remained after PGDATA publication"
 preflight_result=$("$preflight" --source-container "$new_container" \
     --target-dir "$GONKA_POSTGRES_TEST_DATA")
 grep -q 'no migration copy is required' <<<"$preflight_result" || fail \
@@ -122,8 +128,12 @@ row=$("${new_compose[@]}" exec -T "$service" psql \
 # closed rather than initialize an empty database beside an existing install.
 export GONKA_POSTGRES_TEST_DATA="$tmpdir/guard-persistent"
 export GONKA_POSTGRES_TEST_EXISTING="$tmpdir/guard-existing-versiond"
+export GONKA_POSTGRES_TEST_VERSIOND_DATA="$tmpdir/guard-versiond-data"
+export GONKA_POSTGRES_TEST_VERSIOND2_DATA="$tmpdir/guard-versiond2-data"
 mkdir -p "$GONKA_POSTGRES_TEST_DATA" \
-    "$GONKA_POSTGRES_TEST_EXISTING/v4"
+    "$GONKA_POSTGRES_TEST_EXISTING/v4" \
+    "$GONKA_POSTGRES_TEST_VERSIOND_DATA" \
+    "$GONKA_POSTGRES_TEST_VERSIOND2_DATA"
 printf 'existing v4 installation\n' \
     >"$GONKA_POSTGRES_TEST_EXISTING/v4/install.json"
 
@@ -149,7 +159,7 @@ guard_old_volume=$(docker inspect "$guard_old_container" --format \
 restart_target="$tmpdir/recovery-restart"
 mkdir -p "$restart_target/.migrating"
 printf '16\n' >"$restart_target/.migrating/PG_VERSION"
-: >"$restart_target/.migrating/.gonka-copy-complete"
+: >"$restart_target/.gonka-copy-complete"
 restart_result=$("$preflight" --source-volume "$guard_old_volume" \
     --target-dir "$restart_target")
 grep -q 'staging is complete' <<<"$restart_result" || fail \
@@ -165,10 +175,33 @@ done
 [[ ${guard_state:-} == exited ]] || fail \
     "detached-volume guard did not stop PostgreSQL"
 guard_logs=$("${guard_new_compose[@]}" logs --no-color "$service" 2>&1)
-grep -q 'refusing to initialize an empty database' <<<"$guard_logs" || fail \
+grep -q 'first-time HA enablement or a detached drained database' \
+    <<<"$guard_logs" || fail \
     "detached-volume guard did not explain the failure"
 [[ ! -e $GONKA_POSTGRES_TEST_DATA/data/PG_VERSION ]] || fail \
     "detached-volume guard initialized an empty PostgreSQL cluster"
+
+# A .pg-bound marker is definitive evidence that the detached PostgreSQL
+# cluster owns live devshard state. The first-HA override must not bypass it.
+mkdir -p "$GONKA_POSTGRES_TEST_VERSIOND_DATA/v5"
+touch "$GONKA_POSTGRES_TEST_VERSIOND_DATA/v5/.pg-bound"
+export GONKA_POSTGRES_TEST_ALLOW_EMPTY_INIT=true
+"${guard_new_compose[@]}" up -d --force-recreate "$service"
+guard_container=$("${guard_new_compose[@]}" ps -aq "$service")
+for _ in {1..30}; do
+    guard_state=$(docker inspect "$guard_container" --format '{{.State.Status}}')
+    [[ $guard_state == exited ]] && break
+    sleep 0.2
+done
+unset GONKA_POSTGRES_TEST_ALLOW_EMPTY_INIT
+[[ ${guard_state:-} == exited ]] || fail \
+    "PostgreSQL-bound empty-init guard did not stop PostgreSQL"
+guard_logs=$("${guard_new_compose[@]}" logs --no-color "$service" 2>&1)
+grep -q 'PostgreSQL-bound devshard data exists' <<<"$guard_logs" || fail \
+    "PostgreSQL-bound guard did not identify the data-loss state"
+grep -q 'do not use DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT' \
+    <<<"$guard_logs" || fail \
+    "PostgreSQL-bound guard suggested the destructive override"
 
 # The shipped recovery overlay reattaches the selected external volume at the
 # legacy mount. The same entrypoint then performs its validated atomic copy into

--- a/deploy/join/docker-compose.versiond-postgres-recovery.yml
+++ b/deploy/join/docker-compose.versiond-postgres-recovery.yml
@@ -1,0 +1,12 @@
+# Temporary recovery overlay for a detached v4 PostgreSQL volume.
+# Use only with docker-compose.yml and docker-compose.versiond.yml.
+# Recreate devshard-postgres without this file after migration succeeds.
+services:
+  devshard-postgres:
+    volumes:
+      - devshard-postgres-v4-recovery:/var/lib/postgresql/data
+
+volumes:
+  devshard-postgres-v4-recovery:
+    external: true
+    name: ${DEVSHARD_POSTGRES_LEGACY_VOLUME:?legacy volume is required}

--- a/deploy/join/docker-compose.versiond.yml
+++ b/deploy/join/docker-compose.versiond.yml
@@ -42,11 +42,17 @@ x-versiond: &versiond
 services:
   devshard-postgres:
     container_name: devshard-postgres
-    image: postgres:16-alpine
+    image: ${DEVSHARD_POSTGRES_IMAGE:-postgres:16-alpine}
     environment:
       POSTGRES_DB: ${DEVSHARD_POSTGRES_DB:-devshardd}
       POSTGRES_USER: ${DEVSHARD_POSTGRES_USER:-devshardd}
       POSTGRES_PASSWORD: ${DEVSHARD_POSTGRES_PASSWORD:?DEVSHARD_POSTGRES_PASSWORD is required}
+      # Keep the image-owned /var/lib/postgresql/data volume mounted as the v4
+      # migration source. The durable cluster lives in the bind below.
+      PGDATA: /var/lib/postgresql/gonka/data
+      DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT: ${DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT:-false}
+    entrypoint: ["/usr/local/bin/gonka-postgres-entrypoint"]
+    command: ["postgres"]
     healthcheck:
       test:
         [
@@ -56,6 +62,14 @@ services:
       interval: 2s
       timeout: 3s
       retries: 30
+      start_period: ${DEVSHARD_POSTGRES_START_PERIOD:-30m}
+    volumes:
+      - ${DEVSHARD_POSTGRES_DATA_DIR:-./devshards/postgres}:/var/lib/postgresql/gonka:Z
+      - ./devshard-postgres-entrypoint.sh:/usr/local/bin/gonka-postgres-entrypoint:ro,Z
+      # Existing artifacts prove that an empty target beside a v4 installation
+      # is data loss, not a legitimate first initialization.
+      - ./devshards/bin:/var/lib/postgresql/gonka-existing-versiond:ro,z
+    stop_grace_period: ${DEVSHARD_POSTGRES_STOP_GRACE_PERIOD:-5m}
     restart: always
 
   versiond:

--- a/deploy/join/docker-compose.versiond.yml
+++ b/deploy/join/docker-compose.versiond.yml
@@ -65,10 +65,13 @@ services:
       start_period: ${DEVSHARD_POSTGRES_START_PERIOD:-30m}
     volumes:
       - ${DEVSHARD_POSTGRES_DATA_DIR:-./devshards/postgres}:/var/lib/postgresql/gonka:Z
-      - ./devshard-postgres-entrypoint.sh:/usr/local/bin/gonka-postgres-entrypoint:ro,Z
-      # Existing artifacts prove that an empty target beside a v4 installation
-      # is data loss, not a legitimate first initialization.
+      - ./devshard-postgres-entrypoint.sh:/usr/local/bin/gonka-postgres-entrypoint:ro,z
+      # .pg-bound is definitive evidence that PostgreSQL still owns sessions.
+      # Downloaded artifacts alone leave an explicit first-HA-vs-lost-volume
+      # decision for the operator; both checks happen before empty init.
       - ./devshards/bin:/var/lib/postgresql/gonka-existing-versiond:ro,z
+      - ./devshards/data:/var/lib/postgresql/gonka-versiond-data:ro,z
+      - ./devshards2/data:/var/lib/postgresql/gonka-versiond2-data:ro,z
     stop_grace_period: ${DEVSHARD_POSTGRES_STOP_GRACE_PERIOD:-5m}
     restart: always
 

--- a/deploy/join/testdata/postgres-v4.compose.yml
+++ b/deploy/join/testdata/postgres-v4.compose.yml
@@ -1,0 +1,12 @@
+services:
+  devshard-postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: devshardd
+      POSTGRES_USER: devshardd
+      POSTGRES_PASSWORD: test-only
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U devshardd -d devshardd"]
+      interval: 1s
+      timeout: 2s
+      retries: 30

--- a/deploy/join/testdata/postgres-v5.compose.yml
+++ b/deploy/join/testdata/postgres-v5.compose.yml
@@ -2,10 +2,12 @@ services:
   devshard-postgres:
     environment:
       PGDATA: /var/lib/postgresql/gonka/data
-      DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT: "false"
+      DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT: ${GONKA_POSTGRES_TEST_ALLOW_EMPTY_INIT:-false}
     entrypoint: ["/usr/local/bin/gonka-postgres-entrypoint"]
     command: ["postgres"]
     volumes:
       - ${GONKA_POSTGRES_TEST_DATA:?}:/var/lib/postgresql/gonka
       - ${GONKA_POSTGRES_TEST_ENTRYPOINT:?}:/usr/local/bin/gonka-postgres-entrypoint:ro
       - ${GONKA_POSTGRES_TEST_EXISTING:?}:/var/lib/postgresql/gonka-existing-versiond:ro
+      - ${GONKA_POSTGRES_TEST_VERSIOND_DATA:?}:/var/lib/postgresql/gonka-versiond-data:ro
+      - ${GONKA_POSTGRES_TEST_VERSIOND2_DATA:?}:/var/lib/postgresql/gonka-versiond2-data:ro

--- a/deploy/join/testdata/postgres-v5.compose.yml
+++ b/deploy/join/testdata/postgres-v5.compose.yml
@@ -1,0 +1,11 @@
+services:
+  devshard-postgres:
+    environment:
+      PGDATA: /var/lib/postgresql/gonka/data
+      DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT: "false"
+    entrypoint: ["/usr/local/bin/gonka-postgres-entrypoint"]
+    command: ["postgres"]
+    volumes:
+      - ${GONKA_POSTGRES_TEST_DATA:?}:/var/lib/postgresql/gonka
+      - ${GONKA_POSTGRES_TEST_ENTRYPOINT:?}:/usr/local/bin/gonka-postgres-entrypoint:ro
+      - ${GONKA_POSTGRES_TEST_EXISTING:?}:/var/lib/postgresql/gonka-existing-versiond:ro

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -1,0 +1,22 @@
+# Persistent devshard PostgreSQL data
+
+The versiond HA overlay stores PostgreSQL `PGDATA` in
+`DEVSHARD_POSTGRES_DATA_DIR` (default `./devshards/postgres`). This bind path is
+stable across container replacement and `docker compose down`.
+
+On the first start after an older deployment, `devshard-postgres-entrypoint.sh`
+detects the stopped PostgreSQL 16 cluster in the image-owned anonymous volume,
+checks that the target filesystem has enough free space, and copies it through a
+staging directory. It publishes the copy atomically and leaves the source volume
+unchanged as the rollback copy.
+
+The entrypoint refuses to initialize an empty database when downloaded versiond
+artifacts prove this is an existing installation. Set
+`DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true` only for a deliberate new HA database.
+
+For a detached legacy volume, attach
+`docker-compose.versiond-postgres-recovery.yml` temporarily and set
+`DEVSHARD_POSTGRES_LEGACY_VOLUME` to that volume's exact Docker name. Run
+`devshard-postgres-migration-preflight.sh` before replacement to verify source,
+target, and free-space requirements. Remove the recovery overlay after the bind
+copy is healthy; the legacy volume remains available for explicit rollback.

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -10,9 +10,28 @@ checks that the target filesystem has enough free space, and copies it through a
 staging directory. It publishes the copy atomically and leaves the source volume
 unchanged as the rollback copy.
 
-The entrypoint refuses to initialize an empty database when downloaded versiond
-artifacts prove this is an existing installation. Set
-`DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true` only for a deliberate new HA database.
+The supported upgrade recreates `devshard-postgres` in place. Do not run
+`docker compose down` before the first new-layout start: Compose must carry the
+existing anonymous volume into the replacement container.
+
+```bash
+docker compose <the same ordered -f options> \
+  up -d --force-recreate devshard-postgres
+```
+
+Empty initialization is fail-closed. The entrypoint distinguishes these states:
+
+| Host state | Action |
+| --- | --- |
+| Existing HA PostgreSQL; normal Compose upgrade | Recreate in place and keep the old container until replacement starts. |
+| First HA enablement; versiond files exist but no `.pg-bound` marker exists | Pass `DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true` to the first `docker compose up` command only, then verify PostgreSQL. |
+| `.pg-bound` exists under either versiond data root | Restore the legacy PostgreSQL volume. Empty initialization is rejected even with the override. |
+| The old container was removed before migration | Use the recovery overlay with the exact dangling volume name. |
+
+The `.pg-bound` marker proves that PostgreSQL currently owns devshard sessions;
+it is not a permanent “HA was enabled” marker. It can disappear after every
+PostgreSQL session has drained, so downloaded versiond artifacts remain a
+conservative guard for that ambiguous state.
 
 For a detached legacy volume, attach
 `docker-compose.versiond-postgres-recovery.yml` temporarily and set
@@ -20,3 +39,16 @@ For a detached legacy volume, attach
 `devshard-postgres-migration-preflight.sh` before replacement to verify source,
 target, and free-space requirements. Remove the recovery overlay after the bind
 copy is healthy; the legacy volume remains available for explicit rollback.
+
+The upstream PostgreSQL image declares `/var/lib/postgresql/data` as a volume.
+After migration, a later `down`/`up` can therefore create an unused empty
+anonymous volume even though live `PGDATA` is the persistent bind directory.
+Keep the original migration volume until its rollback window ends. Afterwards,
+inspect candidate volumes and remove only the explicitly identified empty or
+retired volume; do not use an indiscriminate `docker volume prune` during the
+rollback window.
+
+An interrupted copy is restarted from the intact legacy source. This favors a
+verifiable copy over a partially resumed one and can extend the maintenance
+window for a large database. The 30-minute healthcheck start period suppresses
+startup health failures; it does not terminate a copy that takes longer.

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -24,7 +24,7 @@ Empty initialization is fail-closed. The entrypoint distinguishes these states:
 | Host state | Action |
 | --- | --- |
 | Existing HA PostgreSQL; normal Compose upgrade | Recreate in place and keep the old container until replacement starts. |
-| First HA enablement; versiond files exist but no `.pg-bound` marker exists | Pass `DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true` to the first `docker compose up` command only, then verify PostgreSQL. |
+| First HA enablement; versiond files exist but no `.pg-bound` marker exists | Pass `DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true` inline to the first `docker compose up` command only, then verify PostgreSQL. Do not store the override in `config.env`. |
 | `.pg-bound` exists under either versiond data root | Restore the legacy PostgreSQL volume. Empty initialization is rejected even with the override. |
 | The old container was removed before migration | Use the recovery overlay with the exact dangling volume name. |
 
@@ -39,6 +39,24 @@ For a detached legacy volume, attach
 `devshard-postgres-migration-preflight.sh` before replacement to verify source,
 target, and free-space requirements. Remove the recovery overlay after the bind
 copy is healthy; the legacy volume remains available for explicit rollback.
+
+If the old PostgreSQL volume is permanently lost, restoring service requires an
+explicit data-loss decision. All PostgreSQL-owned sessions have already been
+lost in this state. Stop the versiond services, inspect the markers, and remove
+them only after recording that loss:
+
+```bash
+find ./devshards/data ./devshards2/data -type f -name .pg-bound -print
+# After confirming that the PostgreSQL volume cannot be recovered:
+find ./devshards/data ./devshards2/data -type f -name .pg-bound -delete
+DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true \
+  docker compose <the same ordered -f options> \
+  up -d --force-recreate devshard-postgres
+```
+
+Do not add the override to `config.env`. Verify the new PostgreSQL instance
+before restarting versiond. This procedure restores availability with an empty
+database; it does not recover the lost sessions.
 
 The upstream PostgreSQL image declares `/var/lib/postgresql/data` as a volume.
 After migration, a later `down`/`up` can therefore create an unused empty


### PR DESCRIPTION
## Summary

> This focused PR is based on the PostgreSQL persistence and migration work originally implemented in the closed umbrella PRs #1517 and #1587.

Move the devshard PostgreSQL cluster from an image-owned anonymous Docker volume to an explicit persistent host directory, while preserving existing installations:

- store `PGDATA` under `DEVSHARD_POSTGRES_DATA_DIR` (default `./devshards/postgres`);
- detect and copy an existing PostgreSQL 16 cluster from the legacy anonymous volume on first replacement;
- publish the copied cluster atomically through a staging directory;
- preserve the legacy volume as an unchanged rollback source;
- resume safely after an interrupted copy;
- provide a recovery overlay for an already detached legacy volume;
- require explicit opt-in before initializing an empty database on an existing installation.

## Motivation

The PostgreSQL image declares `/var/lib/postgresql/data` as a Docker volume. Because the existing Compose deployment does not assign that volume a stable name or host path, Docker stores the cluster in an anonymous volume.

That layout works for the current container, but the relationship between the deployment and its data is implicit. After the service is removed, the volume can remain detached, and a later `docker compose up` can create a different volume. Using an explicit bind directory makes the data location predictable across container replacement, `docker compose down`, backup, and recovery operations.

PostgreSQL contains the shared session and escrow state used by versiond replicas, so an existing installation also needs a migration path to the new directory. Changing `PGDATA` and the Compose mount alone would leave the existing cluster in the legacy anonymous volume and present an empty target to the replacement container.

## Upgrade behavior

The wrapper entrypoint handles the storage-layout transition before PostgreSQL starts:

1. If the persistent target already contains a valid cluster, it is used directly.
2. Otherwise, an attached legacy PostgreSQL 16 cluster is selected as the migration source.
3. The source and target are validated and available disk space is checked.
4. Data is copied into a staging directory, validated, synchronized, and then moved into place atomically.
5. The legacy volume is left unchanged and remains available as a rollback copy.
6. Subsequent starts use the persistent target without repeating the migration.

If a previous copy was interrupted after completion of the staging phase, the entrypoint finishes publishing it on restart. If the legacy volume is already detached, the recovery overlay allows that volume to be attached explicitly as the source. When existing versiond artifacts are present but neither a valid target nor a migration source can be found, initialization stops with a diagnostic instead of creating a new cluster; a deliberate empty initialization remains available through `DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true`.

## Validation and recovery

- only a valid legacy cluster with `PG_VERSION` is accepted as a migration source;
- the target must be empty or already contain a valid cluster;
- free space must cover the source plus a 10% reserve;
- an incomplete copy is never exposed as `PGDATA`;
- stale `postmaster.pid` is removed from the copy so PostgreSQL can recover from WAL;
- existing versiond artifacts make empty initialization fail closed unless `DEVSHARD_POSTGRES_ALLOW_EMPTY_INIT=true` is explicitly set;
- PostgreSQL receives configurable startup and shutdown budgets.

This is a storage-layout migration only. It does not change the PostgreSQL major version, run a SQL/schema migration, select the devshard storage mode, or alter runtime database readiness.

## Validation

- `shellcheck deploy/join/devshard-postgres-*.sh`
- `deploy/join/devshard-postgres-entrypoint_test.sh`
- `deploy/join/devshard-postgres-migration-preflight_test.sh`
- `deploy/join/devshard-postgres-upgrade_test.sh`

The final test creates a real PostgreSQL 16 cluster in the legacy anonymous volume, writes data, recreates the service with the persistent layout, and verifies that the data survives. The same checks run in the dedicated `Test devshard PostgreSQL persistence migration` CI job.

## History

This focused PR extracts the persistent-PGDATA migration work from #1517 and #1587 so it can be reviewed, tested, and merged independently from routing, graceful lifecycle, database identity, and host-updater changes.
