### PR TITLE
Add graceful versiond host evacuation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -224,17 +224,17 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Run Tests (fork PRs)
+      - name: Run Tests with race detector (fork PRs)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
-        run: go test ./... -v
+        run: go test -race ./... -v
 
       - name: Install go-junit-report
         if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
         run: go install github.com/jstemmer/go-junit-report/v2@v2.1.0
 
-      - name: Run Tests and Generate JUnit Report
+      - name: Run Tests with race detector and Generate JUnit Report
         if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-        run: go test ./... -v 2>&1 | go-junit-report -set-exit-code > junit-report.xml
+        run: go test -race ./... -v 2>&1 | go-junit-report -set-exit-code > junit-report.xml
 
       - name: Publish Test Results
         uses: actions/upload-artifact@v4
@@ -358,6 +358,9 @@ jobs:
 
       - name: Build
         run: go build ./...
+
+      - name: Run devshardd lifecycle tests with race detector
+        run: go test -race ./cmd/devshardd
 
       - name: Run Tests (fork PRs)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork

--- a/.github/workflows/versiond-host-evacuation.yml
+++ b/.github/workflows/versiond-host-evacuation.yml
@@ -1,0 +1,53 @@
+# The one suite that exercises the whole Track B contract against a real stack:
+# a host leaves rotation before it stops accepting, its stream finishes, the
+# session recovers on the survivor, and the host rejoins only when ready. It was
+# briefly demoted to the manually-dispatched matrix; review put it back — the
+# properties it pins are exactly the ones a routine-looking change breaks.
+name: versiond host evacuation
+
+on:
+  pull_request:
+    paths:
+      - 'versioned/**'
+      - 'versiond-router/**'
+      - 'common/storage/**'
+      # devshardd and the devshardctl gateway span packages across the module;
+      # storage recovery, routing, state and transport changes all affect this
+      # acceptance contract. Documentation alone does not need the 40m stack.
+      - 'devshard/**'
+      - '!devshard/docs/**'
+      - '!devshard/**/*.md'
+      - '.github/workflows/versiond-host-evacuation.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: versiond-host-evacuation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    name: versiond host evacuation
+    defaults:
+      run:
+        working-directory: ./devshard/testenv
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.9'
+          cache-dependency-path: devshard/go.sum
+
+      - name: Generate test environment
+        run: make gen-compose
+
+      - name: Build linux devshardd
+        run: make build-devshardd
+
+      - name: Run host evacuation acceptance test
+        run: make citest-versiond-host-evacuation

--- a/deploy/join/config.env.template
+++ b/deploy/join/config.env.template
@@ -20,6 +20,16 @@ export PORT=8080
 export INFERENCE_PORT=5050
 export KEYRING_BACKEND=file
 
+# versiond reports unready before it starts draining, then uses one absolute
+# budget for child drain, process stop, and HTTP shutdown. Docker's grace is the
+# outer SIGKILL reserve and must remain larger than the internal budget.
+export VERSIOND_DRAIN_ANNOUNCE=5s
+export VERSIOND_HOST_SHUTDOWN_BUDGET=25m
+export VERSIOND_STOP_GRACE_PERIOD=30m
+# A fresh host can spend most of this period downloading approved artifacts;
+# a passing /readyz check still marks it healthy immediately.
+export VERSIOND_HEALTH_START_PERIOD=30m
+
 # Observability (docs/observability/observability-overview.md)
 # Jaeger and Grafana UIs are disabled by default. Set credentials below first,
 # then set JAEGER_ENABLED=true and/or GRAFANA_ENABLED=true to expose them via proxy.

--- a/deploy/join/docker-compose.versiond.yml
+++ b/deploy/join/docker-compose.versiond.yml
@@ -21,6 +21,10 @@ x-versiond: &versiond
     # Keep supervisor preflight aligned with the router: these versions remain
     # single-owner and do not require the HA storage contract.
     - VERSIOND_NON_HA_VERSIONS=${VERSIOND_NON_HA_VERSIONS-v1 v2 v3}
+    - VERSIOND_HOST_SHUTDOWN_BUDGET=${VERSIOND_HOST_SHUTDOWN_BUDGET:-25m}
+    # Keep serving after /readyz starts failing so the active router check can
+    # withdraw this host before admission closes.
+    - VERSIOND_DRAIN_ANNOUNCE=${VERSIOND_DRAIN_ANNOUNCE:-5s}
     - NODE_MANAGER_ADDR=api:${NODE_MANAGER_GRPC_PORT:-9400}
     - NODE_HOST=node
     - KEY_NAME=${KEY_NAME}
@@ -47,6 +51,22 @@ x-versiond: &versiond
       condition: service_started
     devshard-postgres:
       condition: service_healthy
+  healthcheck:
+    test:
+      [
+        "CMD",
+        "/bin/busybox",
+        "wget",
+        "-q",
+        "-O",
+        "/dev/null",
+        "http://127.0.0.1:8080/readyz",
+      ]
+    interval: 2s
+    timeout: 3s
+    retries: 3
+    start_period: ${VERSIOND_HEALTH_START_PERIOD:-30m}
+  stop_grace_period: ${VERSIOND_STOP_GRACE_PERIOD:-30m}
   restart: always
 
 services:

--- a/deploy/join/docker-compose.versiond.yml
+++ b/deploy/join/docker-compose.versiond.yml
@@ -51,17 +51,18 @@ x-versiond: &versiond
       condition: service_started
     devshard-postgres:
       condition: service_healthy
+  # The pinned transition image predates /readyz. Fall back to its liveness
+  # endpoint only for an explicit 404; a lifecycle 503 must stay unhealthy.
   healthcheck:
     test:
-      [
-        "CMD",
-        "/bin/busybox",
-        "wget",
-        "-q",
-        "-O",
-        "/dev/null",
-        "http://127.0.0.1:8080/readyz",
-      ]
+      - CMD-SHELL
+      - >-
+        output=$$(/bin/busybox wget -S -O /dev/null
+        http://127.0.0.1:8080/readyz 2>&1);
+        status=$$?;
+        if [ "$$status" -eq 0 ]; then exit 0; fi;
+        case "$$output" in *"HTTP/"*" 404 "*) exec /bin/busybox wget -q
+        -O /dev/null http://127.0.0.1:8080/healthz ;; *) exit "$$status" ;; esac
     interval: 2s
     timeout: 3s
     retries: 3

--- a/deploy/join/docker-compose.yml
+++ b/deploy/join/docker-compose.yml
@@ -107,6 +107,10 @@ services:
     environment:
       - VERSIOND_ORACLE_URL=http://api:9100/versions
       - VERSIOND_BINARY_NAME=devshardd
+      - VERSIOND_HOST_SHUTDOWN_BUDGET=${VERSIOND_HOST_SHUTDOWN_BUDGET:-25m}
+      # The base deployment has no versiond load balancer, so there is nothing
+      # to announce to before closing admission.
+      - VERSIOND_DRAIN_ANNOUNCE=0s
       - NODE_MANAGER_ADDR=api:${NODE_MANAGER_GRPC_PORT:-9400}
       - NODE_HOST=node
       - KEY_NAME=${KEY_NAME}
@@ -124,6 +128,8 @@ services:
       - ./devshards/data:/opt/versiond/data
     depends_on:
       - api
+    # External SIGKILL backstop after versiond's complete internal budget.
+    stop_grace_period: ${VERSIOND_STOP_GRACE_PERIOD:-30m}
     restart: always
 
   bridge:

--- a/devshard/cmd/devshardd/lifecycle.go
+++ b/devshard/cmd/devshardd/lifecycle.go
@@ -1,19 +1,80 @@
 package main
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"devshard/observability"
 
 	"github.com/labstack/echo/v4"
 )
 
+type lifecyclePhase string
+
+const (
+	lifecyclePhaseStarting     lifecyclePhase = "starting"
+	lifecyclePhaseServing      lifecyclePhase = "serving"
+	lifecyclePhaseDisconnected lifecyclePhase = "disconnected"
+	lifecyclePhaseDraining     lifecyclePhase = "draining"
+)
+
+type lifecycleEvent string
+
+const (
+	lifecycleEventChainReady        lifecycleEvent = "chain_ready"
+	lifecycleEventChainDisconnected lifecycleEvent = "chain_disconnected"
+	lifecycleEventDrainRequested    lifecycleEvent = "drain_requested"
+)
+
+type lifecyclePhaseSpec struct {
+	ready       bool
+	draining    bool
+	accepting   bool
+	transitions map[lifecycleEvent]lifecyclePhase
+}
+
+var lifecyclePhaseTable = map[lifecyclePhase]lifecyclePhaseSpec{
+	lifecyclePhaseStarting: {
+		accepting: true,
+		transitions: map[lifecycleEvent]lifecyclePhase{
+			lifecycleEventChainReady:        lifecyclePhaseServing,
+			lifecycleEventChainDisconnected: lifecyclePhaseStarting,
+			lifecycleEventDrainRequested:    lifecyclePhaseDraining,
+		},
+	},
+	lifecyclePhaseServing: {
+		ready:     true,
+		accepting: true,
+		transitions: map[lifecycleEvent]lifecyclePhase{
+			lifecycleEventChainReady:        lifecyclePhaseServing,
+			lifecycleEventChainDisconnected: lifecyclePhaseDisconnected,
+			lifecycleEventDrainRequested:    lifecyclePhaseDraining,
+		},
+	},
+	lifecyclePhaseDisconnected: {
+		accepting: true,
+		transitions: map[lifecycleEvent]lifecyclePhase{
+			lifecycleEventChainReady:        lifecyclePhaseServing,
+			lifecycleEventChainDisconnected: lifecyclePhaseDisconnected,
+			lifecycleEventDrainRequested:    lifecyclePhaseDraining,
+		},
+	},
+	lifecyclePhaseDraining: {
+		draining: true,
+		transitions: map[lifecycleEvent]lifecyclePhase{
+			lifecycleEventChainReady:        lifecyclePhaseDraining,
+			lifecycleEventChainDisconnected: lifecyclePhaseDraining,
+			lifecycleEventDrainRequested:    lifecyclePhaseDraining,
+		},
+	},
+}
+
 type lifecycleState struct {
-	ready    atomic.Bool
-	draining atomic.Bool
-	inflight atomic.Int64
+	mu       sync.Mutex
+	phase    lifecyclePhase
+	inflight int64
 }
 
 type drainStatus struct {
@@ -24,29 +85,87 @@ type drainStatus struct {
 
 func newLifecycleState() *lifecycleState {
 	observability.SetLifecycleInflight(0)
-	return &lifecycleState{}
+	return &lifecycleState{phase: lifecyclePhaseStarting}
 }
 
 func (s *lifecycleState) SetReady(ready bool) {
-	s.ready.Store(ready)
+	event := lifecycleEventChainDisconnected
+	if ready {
+		event = lifecycleEventChainReady
+	}
+	s.transition(event)
 }
 
 func (s *lifecycleState) StartDrain() {
-	s.draining.Store(true)
-	s.ready.Store(false)
+	s.transition(lifecycleEventDrainRequested)
+}
+
+func nextLifecyclePhase(
+	from lifecyclePhase,
+	event lifecycleEvent,
+) (lifecyclePhase, bool) {
+	spec, ok := lifecyclePhaseTable[from]
+	if !ok {
+		return "", false
+	}
+	next, ok := spec.transitions[event]
+	return next, ok
+}
+
+func (s *lifecycleState) transition(event lifecycleEvent) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	next, ok := nextLifecyclePhase(s.phase, event)
+	if !ok {
+		slog.Error(
+			"invalid devshard lifecycle transition",
+			"from", s.phase,
+			"event", event,
+		)
+		return false
+	}
+	s.phase = next
+	return true
 }
 
 func (s *lifecycleState) Status() drainStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	spec, ok := lifecyclePhaseTable[s.phase]
+	if !ok {
+		return drainStatus{
+			Draining: true,
+			Inflight: s.inflight,
+		}
+	}
 	return drainStatus{
-		Ready:    s.ready.Load(),
-		Draining: s.draining.Load(),
-		Inflight: s.inflight.Load(),
+		Ready:    spec.ready,
+		Draining: spec.draining,
+		Inflight: s.inflight,
 	}
 }
 
-func (s *lifecycleState) addInflight(delta int64) {
-	inflight := s.inflight.Add(delta)
-	observability.SetLifecycleInflight(inflight)
+func (s *lifecycleState) acquire() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	spec, ok := lifecyclePhaseTable[s.phase]
+	if !ok || !spec.accepting {
+		return false
+	}
+	s.inflight++
+	observability.SetLifecycleInflight(s.inflight)
+	return true
+}
+
+func (s *lifecycleState) release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inflight == 0 {
+		slog.Error("devshard lifecycle request released without admission")
+		return
+	}
+	s.inflight--
+	observability.SetLifecycleInflight(s.inflight)
 }
 
 func (s *lifecycleState) middleware(next echo.HandlerFunc) echo.HandlerFunc {
@@ -54,13 +173,10 @@ func (s *lifecycleState) middleware(next echo.HandlerFunc) echo.HandlerFunc {
 		if isLifecycleBypassPath(c.Request().URL.Path) {
 			return next(c)
 		}
-		// Count first so drain cannot report idle after this request is admitted.
-		s.addInflight(1)
-		if s.draining.Load() {
-			s.addInflight(-1)
+		if !s.acquire() {
 			return echo.NewHTTPError(http.StatusServiceUnavailable, "devshardd is draining")
 		}
-		defer s.addInflight(-1)
+		defer s.release()
 		return next(c)
 	}
 }

--- a/devshard/cmd/devshardd/lifecycle.go
+++ b/devshard/cmd/devshardd/lifecycle.go
@@ -54,6 +54,11 @@ var lifecyclePhaseTable = map[lifecyclePhase]lifecyclePhaseSpec{
 		},
 	},
 	lifecyclePhaseDisconnected: {
+		// A chain reconnect is a correlated dependency event: every replica sees
+		// it at once. The child has completed initial startup and can still serve
+		// its existing shard state, so keep it in rotation while the listener
+		// reconnects. Storage readiness remains an independent /ready gate.
+		ready:     true,
 		accepting: true,
 		transitions: map[lifecycleEvent]lifecyclePhase{
 			lifecycleEventChainReady:        lifecyclePhaseServing,

--- a/devshard/cmd/devshardd/lifecycle_test.go
+++ b/devshard/cmd/devshardd/lifecycle_test.go
@@ -4,12 +4,165 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLifecycleTransitionTableInvariants(t *testing.T) {
+	states := []lifecyclePhase{
+		lifecyclePhaseStarting,
+		lifecyclePhaseServing,
+		lifecyclePhaseDisconnected,
+		lifecyclePhaseDraining,
+	}
+	events := []lifecycleEvent{
+		lifecycleEventChainReady,
+		lifecycleEventChainDisconnected,
+		lifecycleEventDrainRequested,
+	}
+
+	require.Len(t, lifecyclePhaseTable, len(states))
+	for _, from := range states {
+		spec, ok := lifecyclePhaseTable[from]
+		require.Truef(t, ok, "missing lifecycle phase %s", from)
+		require.Lenf(t, spec.transitions, len(events), "transitions from %s", from)
+		for _, event := range events {
+			to, exists := nextLifecyclePhase(from, event)
+			require.Truef(t, exists, "missing transition for %s + %s", from, event)
+			_, targetKnown := lifecyclePhaseTable[to]
+			require.Truef(t, targetKnown, "transition %s + %s targets unknown phase %s", from, event, to)
+		}
+
+		to, _ := nextLifecyclePhase(from, lifecycleEventDrainRequested)
+		require.Equalf(t, lifecyclePhaseDraining, to,
+			"drain request from %s must close admission", from)
+	}
+
+	for _, event := range events {
+		to, ok := nextLifecyclePhase(lifecyclePhaseDraining, event)
+		require.True(t, ok)
+		require.Equalf(t, lifecyclePhaseDraining, to,
+			"draining must absorb late %s events", event)
+	}
+
+	_, ok := nextLifecyclePhase("unknown", lifecycleEventDrainRequested)
+	require.False(t, ok, "unknown lifecycle state accepted an event")
+	_, ok = nextLifecyclePhase(lifecyclePhaseServing, "unknown")
+	require.False(t, ok, "unknown lifecycle event was accepted")
+}
+
+func TestLifecyclePhaseTableProjections(t *testing.T) {
+	type projection struct {
+		ready     bool
+		draining  bool
+		accepting bool
+	}
+	expected := map[lifecyclePhase]projection{
+		lifecyclePhaseStarting: {
+			accepting: true,
+		},
+		lifecyclePhaseServing: {
+			ready:     true,
+			accepting: true,
+		},
+		lifecyclePhaseDisconnected: {
+			accepting: true,
+		},
+		lifecyclePhaseDraining: {
+			draining: true,
+		},
+	}
+
+	require.Len(t, lifecyclePhaseTable, len(expected))
+	for phase, want := range expected {
+		spec, ok := lifecyclePhaseTable[phase]
+		require.Truef(t, ok, "missing lifecycle phase %s", phase)
+		require.Equal(t, want.ready, spec.ready, "ready projection for %s", phase)
+		require.Equal(t, want.draining, spec.draining, "draining projection for %s", phase)
+		require.Equal(t, want.accepting, spec.accepting, "admission projection for %s", phase)
+		require.Falsef(
+			t,
+			spec.ready && spec.draining,
+			"phase %s projects both ready and draining",
+			phase,
+		)
+	}
+}
+
+func TestLifecycleTracksChainReconnect(t *testing.T) {
+	lifecycle := newLifecycleState()
+	require.False(t, lifecycle.Status().Ready)
+
+	lifecycle.SetReady(true)
+	require.True(t, lifecycle.Status().Ready)
+
+	lifecycle.SetReady(false)
+	status := lifecycle.Status()
+	require.False(t, status.Ready)
+	require.False(t, status.Draining)
+
+	lifecycle.SetReady(true)
+	require.True(t, lifecycle.Status().Ready)
+}
+
+func TestLifecycleDrainAbsorbsLateChainEvents(t *testing.T) {
+	lifecycle := newLifecycleState()
+	lifecycle.SetReady(true)
+	lifecycle.StartDrain()
+
+	lifecycle.SetReady(false)
+	lifecycle.SetReady(true)
+	lifecycle.StartDrain()
+
+	status := lifecycle.Status()
+	require.False(t, status.Ready)
+	require.True(t, status.Draining)
+}
+
+func TestLifecycleDrainKeepsAdmittedRequestInflight(t *testing.T) {
+	lifecycle := newLifecycleState()
+	lifecycle.SetReady(true)
+	e := buildServer(lifecycle)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	finishRequest := sync.OnceFunc(func() {
+		close(release)
+		<-finished
+	})
+	t.Cleanup(finishRequest)
+	e.GET("/work", func(c echo.Context) error {
+		close(started)
+		<-release
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	go func() {
+		defer close(finished)
+		e.ServeHTTP(
+			httptest.NewRecorder(),
+			httptest.NewRequest(http.MethodGet, "/work", nil),
+		)
+	}()
+	<-started
+
+	lifecycle.StartDrain()
+	status := lifecycle.Status()
+	require.True(t, status.Draining)
+	require.EqualValues(t, 1, status.Inflight)
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/work", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.EqualValues(t, 1, lifecycle.Status().Inflight)
+
+	finishRequest()
+	require.Zero(t, lifecycle.Status().Inflight)
+}
 
 func TestLifecycleReadyAndDrainStatus(t *testing.T) {
 	lifecycle := newLifecycleState()

--- a/devshard/cmd/devshardd/lifecycle_test.go
+++ b/devshard/cmd/devshardd/lifecycle_test.go
@@ -70,6 +70,7 @@ func TestLifecyclePhaseTableProjections(t *testing.T) {
 			accepting: true,
 		},
 		lifecyclePhaseDisconnected: {
+			ready:     true,
 			accepting: true,
 		},
 		lifecyclePhaseDraining: {
@@ -102,7 +103,8 @@ func TestLifecycleTracksChainReconnect(t *testing.T) {
 
 	lifecycle.SetReady(false)
 	status := lifecycle.Status()
-	require.False(t, status.Ready)
+	require.True(t, status.Ready,
+		"a reconnect after initial readiness must not withdraw every replica")
 	require.False(t, status.Draining)
 
 	lifecycle.SetReady(true)

--- a/devshard/docs/rolling-update.md
+++ b/devshard/docs/rolling-update.md
@@ -127,10 +127,12 @@ Lifecycle controls live on a **loopback admin** listener when versiond sets
 `DEVSHARD_ADMIN_ADDR=127.0.0.1:<port>` (after `--print-admin-api-version`
 succeeds). Those paths are **not** registered on the public Echo instance.
 
-1. **`GET /ready` (admin)** — `200` when chain-event subscriptions report ready
-   and the child is not draining; otherwise `503`. versiond also requires
-   public `/healthz` `2xx` before publishing the route for admin-capable
-   children (`waitForChildServingReady`).
+1. **`GET /ready` (admin)** — initial startup requires the chain-event
+   subscriptions to connect. A later reconnect keeps returning `200` because
+   it affects all replicas together while they can still serve existing shard
+   state. Draining or unavailable storage returns `503`. versiond also requires
+   public `/healthz` `2xx` before publishing the route for admin-capable children
+   (`waitForChildServingReady`).
 2. **`GET /drain/status` (admin)** — `{ready, draining, inflight}` from the
    lifecycle middleware (all non-lifecycle HTTP, including full SSE duration).
    Same count as Prometheus `devshardd_lifecycle_inflight_requests`.

--- a/devshard/docs/versiond-host-evacuation.md
+++ b/devshard/docs/versiond-host-evacuation.md
@@ -146,6 +146,11 @@ that can extend the host shutdown budget. On expiry, versiond forces remaining
 children and HTTP connections, then confirms child reap during the external
 runtime reserve.
 
+The startup contract requires
+`VERSIOND_DRAIN_ANNOUNCE + max(VERSIOND_DRAIN_KILL_GRACE, DEVSHARD_SHUTDOWN_GRACE) < VERSIOND_HOST_SHUTDOWN_BUDGET`.
+`versiond` validates this before starting, so a termination grace cannot silently
+consume the time reserved for admission and child drain.
+
 ## Health and readiness contracts
 
 Endpoints, all on the traffic listener (`:8080`):

--- a/devshard/docs/versiond-host-evacuation.md
+++ b/devshard/docs/versiond-host-evacuation.md
@@ -163,12 +163,21 @@ caller could abuse — it exposes strictly less than `/healthz` already does.
   monitor normally withdraws a failed vouch within one probe interval (1s); a
   probe can take up to its 2s timeout, and an answer no monitor has refreshed
   for 5s expires on its own;
-- the manager has run every desired version at least once (`Converged`).
+- the manager has run its complete desired set together at least once
+  (`Converged`).
 
 `Converged` latches. Once a versiond has run its full desired set, a later
 download or child restart does not retract it. Without the latch, a routine
 same-name SHA bump would briefly un-converge every host at once and evict the
 entire pool — the failure mode readiness exists to prevent.
+
+A fresh versiond that has never run the complete set remains unready on the
+coarse endpoint by design. That endpoint may receive an undeclared version and
+cannot safely claim readiness from unrelated children. Exact
+`/readyz?version=<v>` checks still admit every version the host can serve.
+Remembering versions that happened to run at different times would weaken the
+coarse contract: it could report ready even though the host never served the
+whole set at one time.
 
 `/readyz?version=<v>` is the question the balancer actually has, and it needs no
 convergence latch and no view of the desired set: either a running child serves
@@ -190,11 +199,12 @@ not a routing one.
 contract existing clients parse. Reconcile failures currently have no
 machine-readable exposure; a metric is where that belongs.
 
-A host that fails to install one version is handled by the per-version check
-above rather than by the host-level one: it drops out of that version's pool and
-keeps serving the rest. Gating the *host* on it instead would be the correlated
-failure again — the same archive fails on every host, so the whole pool would
-leave at once over a version most traffic does not even use.
+After initial convergence, a host that fails to install one version is handled
+by the per-version check above: it drops out of that version's pool and keeps
+serving the rest. The latched coarse endpoint also stays available. Gating that
+endpoint on every later reconcile would be the correlated failure again — the
+same archive fails on every host, so the whole pool would leave at once over a
+version most traffic does not even use.
 
 If a condition is ever found under which accepting traffic is genuinely unsafe,
 it belongs in its own typed condition rather than in the generic reconcile error.

--- a/devshard/docs/versiond-host-evacuation.md
+++ b/devshard/docs/versiond-host-evacuation.md
@@ -183,6 +183,12 @@ download or child restart does not retract it. Without the latch, a routine
 same-name SHA bump would briefly un-converge every host at once and evict the
 entire pool — the failure mode readiness exists to prevent.
 
+The join Compose healthcheck intentionally probes this coarse `/readyz`
+contract. A fresh host that has not yet run its complete desired set therefore
+remains Docker `unhealthy`, even when some precise per-version routes are already
+available; HAProxy continues to evaluate those routes with
+`/readyz?version=<v>`.
+
 A fresh versiond that has never run the complete set remains unready on the
 coarse endpoint by design. That endpoint may receive an undeclared version and
 cannot safely claim readiness from unrelated children. Exact

--- a/devshard/docs/versiond-host-evacuation.md
+++ b/devshard/docs/versiond-host-evacuation.md
@@ -1,0 +1,238 @@
+# versiond host evacuation
+
+Status: implemented design and operator contract for rolling-update Track B.
+
+This document defines how an operator removes, replaces, or upgrades a whole
+`versiond` host without terminating requests that are already running. It is the
+implementation contract for `rolling-update.md` section 1.8. Child binary rolling
+updates remain a separate operation managed inside one live `versiond`
+([rolling-update.md](./rolling-update.md), Track A).
+
+## The operator contract
+
+There are no evacuation commands. The lifecycle of a host is the lifecycle of
+its container:
+
+| Intent | Command | What makes it safe |
+| --- | --- | --- |
+| Evacuate / stop | `docker compose stop versiond2` | versiond fails `/readyz` first, then stops accepting; the router removes it before it stops taking work |
+| Replace / restart | `docker compose up -d versiond2` | it rejoins the pool only once `/readyz` returns 200 |
+| Add a host | start another container on the pool alias | DNS gains an A record; the router finds it within seconds |
+| Decommission | remove the service from the desired deployment and remove its container | DNS loses the record permanently; `restart: always` cannot bring it back |
+| Inspect what the router believes | `docker compose exec versiond-router /usr/local/lib/versiond-router/pool-status` | read-only; the router keeps no other state |
+
+This works because the router derives everything it needs by observation:
+membership from DNS, health from active `/readyz` checks. Nothing has to be told
+about the change, so nothing can be told about it incorrectly.
+
+## Safety invariants
+
+1. A host stops receiving new work **before** it stops accepting it. versiond
+   reports unready for `VERSIOND_DRAIN_ANNOUNCE` (default 5s) while still
+   serving, and the router's 1s health check removes it inside that window.
+2. A draining host cannot accept new proxy work or start, swap, or restart a
+   child process.
+3. A proxy admission lease covers the complete response, including the full
+   lifetime of an SSE stream.
+4. Child lifecycle HTTP calls and polling never run while the process manager
+   mutex is held.
+5. `SIGKILL` is only an external backstop after a configured timeout. A second
+   `SIGINT` is the explicit interactive force command; repeated `SIGTERM` is
+   idempotent. Every child process is reaped before `versiond` exits.
+6. Taking a host out of rotation is stopping its versiond. There is no
+   router-side drain: HAProxy server slots are reused, so a drain outlives the
+   host it was meant for and is inherited by whichever host DNS puts there next.
+7. The external kill grace must exceed versiond's single absolute shutdown
+   budget, so `SIGKILL` remains a backstop rather than a competing deadline.
+8. An established request stays on its original router connection and versiond
+   generation. A later request for the same HA escrow may recover on another host
+   from shared Postgres; legacy SQLite escrows never enter the HA pool.
+9. A host that has never converged is not routed to through the host-level
+   pool: coarse readiness is a statement about capacity to serve, not about
+   having finished booting. Per-version pools are narrower on purpose — they
+   route each version the host already serves — so a host mid-install takes
+   traffic for what it has and nothing else.
+
+Earlier revisions promised that the last active upstream could not be drained
+away. Nothing enforces that now: stopping a container is a Docker operation and
+cannot be intercepted, so evacuating one host at a time is a procedure, not
+something software can pretend to own.
+
+## State machines
+
+The `versiond` process owns this host lifecycle:
+
+```text
+starting -> serving -> announcing -> draining -> stopping -> stopped
+     |          |           |            |           |
+     +----------+-----------+------------+-----------+-> forcing -> stopped
+```
+
+- `starting`: health is available, proxy admission is closed.
+- `serving`: proxy admission is open and reconcile may change children.
+- `announcing`: **still accepting**, but already reporting unready. This is the
+  window in which the load balancer notices and stops routing here.
+- `draining`: admission and desired-state changes are closed; accepted requests
+  and child lifecycle work are allowed to finish.
+- `stopping`: children have received `SIGTERM` and are in their process grace.
+- `forcing`: an internal deadline or explicit interrupt escalated remaining
+  children.
+- `stopped`: all children have been reaped and the HTTP server has stopped.
+
+The host FSM is table-driven. Each state specification owns its allowed targets,
+its admission policy, and whether it advertises readiness; `serving` is the only
+state that both accepts new proxy leases and advertises readiness, and
+`announcing` is the only state that accepts without advertising. Unknown states
+and transitions are rejected without changing lifecycle or admission state.
+
+This state machine is intentionally separate from each child's process FSM
+(`running -> terminating -> killing -> exited`). The host FSM decides when a
+child should stop; the process FSM owns signal delivery, escalation, and reap.
+The process FSM is event-driven and table-defined: each state/event pair chooses
+the next state and `SIGTERM`, `SIGKILL`, or finish action. Finish is reachable
+only through the process-exited event produced by `cmd.Wait`.
+
+Each child generation has a lifecycle above the OS process FSM:
+
+```text
+preparing -> starting -> running -> retiring -> draining -> stopping -> stopped
+                 |          |
+                 +-> failed <-+
+                       |
+                       +-> starting
+```
+
+`retiring` removes the generation from route admission, `draining` waits for
+proxy and child lifecycle counters, and `stopping` owns post-`SIGTERM` grace.
+Every reconcile is also registered as a cancellable control operation. Entering
+host `draining` cancels these operations before waiting for the poll worker, so
+downloads, preflight probes, readiness, and non-overlap stop/start waits cannot
+hide the force path.
+
+**The router has no state machine.** Each server slot is either resolved and
+passing checks (taking traffic), resolved and failing checks (not taking
+traffic), administratively drained, or unresolved. All four are derived, none
+are stored, and a router restart rebuilds the full picture within a couple of
+seconds.
+
+## Context ownership
+
+`versiond` uses separate cancellation domains:
+
+- poll context: oracle fetches, downloads, readiness waits, and reconcile;
+- child lifetime context: owned by `process.Manager`, never by a poll tick;
+- host shutdown context: one absolute deadline shared by the announce window,
+  poll unwind, admission drain, graceful child stop, and HTTP shutdown.
+
+Cancelling the poll context must not signal a running child. This separation is
+required because host evacuation stops reconciliation before it drains work. The
+host supervisor listens for force signals while canceled reconcile work is
+unwinding, including during the announce window — an operator who wants to skip
+the wait can interrupt again. Poll unwind receives at most ten percent of the
+host budget, capped at five seconds. If a worker ignores cancellation, versiond
+logs the failure and continues teardown; the manager drain barrier already
+rejects new reconcile operations and disables child restart. Child process grace
+may impose a shorter phase-local limit, but no phase receives a fresh deadline
+that can extend the host shutdown budget. On expiry, versiond forces remaining
+children and HTTP connections, then confirms child reap during the external
+runtime reserve.
+
+## Health and readiness contracts
+
+Endpoints, all on the traffic listener (`:8080`):
+
+| Endpoint | Answers | Used by |
+| --- | --- | --- |
+| `GET /healthz` | the legacy JSON array of per-version child state | operators, dashboards, existing clients |
+| `GET /readyz?version=<v>` | `200` when a running child serves `<v>` **and** still reports itself ready | the router's per-version health check |
+| `GET /readyz` | `200` when this host should receive new work at all | the router's check for non-version paths, and for every version when none is declared |
+
+`/readyz` is on the public listener on purpose. It is not a private admin
+control: it is the contract the load balancer reads, and there is nothing in it a
+caller could abuse — it exposes strictly less than `/healthz` already does.
+
+`/readyz` returns 200 when **all** of:
+
+- the host FSM advertises readiness (`serving`), and is accepting;
+- at least one child is running **and** its live readiness is current — a child
+  that lost its chain subscription is running but not serving. The monitor
+  normally withdraws the vouch within one probe interval (1s); a probe can take
+  up to its 2s timeout, and an answer no monitor has refreshed for 5s expires on
+  its own;
+- the manager has run every desired version at least once (`Converged`).
+
+`Converged` latches. Once a versiond has run its full desired set, a later
+download or child restart does not retract it. Without the latch, a routine
+same-name SHA bump would briefly un-converge every host at once and evict the
+entire pool — the failure mode readiness exists to prevent.
+
+`/readyz?version=<v>` is the question the balancer actually has, and it needs no
+convergence latch and no view of the desired set: either a running child serves
+that version here or it does not. It reads the same route table the proxy uses,
+so the answer cannot disagree with what a request would get, and it re-asks the
+child — readiness is checked once at start, but a child can lose it afterwards,
+and a route held open to a child that has gone unready is a route to a host that
+cannot serve. Draining still takes
+every version out at once, or the announce window would not empty the host.
+
+**A failed reconcile is not a readiness failure.** Every versiond reads the same
+oracle, so anything gated on the outcome of that read fails everywhere at once:
+one unreachable oracle, or one bad archive, would empty the pool while every
+child is still running and able to serve. The failure is kept in versiond's
+internal `Degraded` condition and logged; it is a deployment problem,
+not a routing one.
+
+`/healthz` is deliberately unchanged and does not carry it — that array is a
+contract existing clients parse. Reconcile failures currently have no
+machine-readable exposure; a metric is where that belongs.
+
+A host that fails to install one version is handled by the per-version check
+above rather than by the host-level one: it drops out of that version's pool and
+keeps serving the rest. Gating the *host* on it instead would be the correlated
+failure again — the same archive fails on every host, so the whole pool would
+leave at once over a version most traffic does not even use.
+
+If a condition is ever found under which accepting traffic is genuinely unsafe,
+it belongs in its own typed condition rather than in the generic reconcile error.
+
+`GET /healthz` keeps the exact legacy JSON array for existing clients. Query
+parameters do not select a second schema.
+
+## Failure policy
+
+| Situation | Behaviour |
+| --- | --- |
+| Host stops answering `/readyz` | removed from routing after one failed check (1s) |
+| Host answers `/readyz` again | restored after two passing checks |
+| Host disappears from DNS | slot empties; no further traffic |
+| Router restarts | rebuilds membership and health from scratch in ~2s; in-flight requests on the old process are lost |
+| Every host unready | requests get `503` from the router; there is nowhere correct to send them |
+| Host stops mid-stream (`docker kill`) | that stream fails; this is why `stop` has a grace period and `kill` does not |
+| Shutdown budget expires | remaining children are forced and reaped, then versiond exits |
+
+`503` is never retried onto another host: a draining host and the HA storage
+guard both answer `503`, and retrying would hit the same condition next door.
+Connection failures, empty responses, and upstream `502`s are retried, because
+those prove the request did not run. Non-idempotent methods are never replayed.
+
+## Verifying it
+
+```console
+$ make -C devshard/testenv citest-versiond-host-evacuation
+ok  	devshard/testenv/citest	TestVersiondHostEvacuation
+```
+
+The acceptance test drives the full lifecycle against a real stack: it starts a
+paused SSE stream through the host it is about to evacuate, stops that host, and
+asserts that the router stops routing there while the stream is still running,
+that the stream completes, that the session is recoverable on the survivor, that
+a continuity probe never sees a failure during the whole evacuation, and that the
+restarted host rejoins the pool only after it reports ready.
+
+## Related docs
+
+| Doc | Use |
+| --- | --- |
+| [versiond-router/README.md](../../versiond-router/README.md) | Router routing, per-version health, and how to read the pool |
+| [rolling-update.md](./rolling-update.md) | Same-name SHA blue/green inside one versiond (Track A) |
+| [high-availability-architecture.md](./high-availability-architecture.md) | Where each component sits |

--- a/devshard/docs/versiond-host-evacuation.md
+++ b/devshard/docs/versiond-host-evacuation.md
@@ -131,8 +131,10 @@ unwinding, including during the announce window — an operator who wants to ski
 the wait can interrupt again. Poll unwind receives at most ten percent of the
 host budget, capped at five seconds. If a worker ignores cancellation, versiond
 logs the failure and continues teardown; the manager drain barrier already
-rejects new reconcile operations and disables child restart. Child process grace
-may impose a shorter phase-local limit, but no phase receives a fresh deadline
+rejects new reconcile operations and disables child restart. Within the same
+absolute deadline, versiond reserves a final tail equal to the child process
+grace. Admission and child-idle waits stop at the earlier drain deadline, leaving
+that tail for `SIGTERM` and HTTP shutdown. No phase receives a fresh deadline
 that can extend the host shutdown budget. On expiry, versiond forces remaining
 children and HTTP connections, then confirms child reap during the external
 runtime reserve.

--- a/devshard/docs/versiond-host-evacuation.md
+++ b/devshard/docs/versiond-host-evacuation.md
@@ -117,6 +117,13 @@ seconds.
 
 ## Context ownership
 
+All versiond duration settings use Go duration syntax and require an explicit
+unit, for example `30s`, `5m`, or `1h30m`. A legacy value such as
+`VERSIOND_POLL_INTERVAL=30` now fails startup instead of silently falling back;
+change it to `30s` before upgrading. Invalid and non-positive values fail
+closed, except `VERSIOND_DRAIN_ANNOUNCE=0s`, which is valid for a topology with
+no load balancer handoff.
+
 `versiond` uses separate cancellation domains:
 
 - poll context: oracle fetches, downloads, readiness waits, and reconcile;

--- a/devshard/docs/versiond-host-evacuation.md
+++ b/devshard/docs/versiond-host-evacuation.md
@@ -155,10 +155,12 @@ caller could abuse — it exposes strictly less than `/healthz` already does.
 
 - the host FSM advertises readiness (`serving`), and is accepting;
 - at least one child is running **and** its live readiness is current — a child
-  that lost its chain subscription is running but not serving. The monitor
-  normally withdraws the vouch within one probe interval (1s); a probe can take
-  up to its 2s timeout, and an answer no monitor has refreshed for 5s expires on
-  its own;
+  whose storage is unavailable is running but not serving. A reconnect of the
+  shared chain listener stays route-ready after initial startup because every
+  replica sees that dependency event together while admission remains open. The
+  monitor normally withdraws a failed vouch within one probe interval (1s); a
+  probe can take up to its 2s timeout, and an answer no monitor has refreshed
+  for 5s expires on its own;
 - the manager has run every desired version at least once (`Converged`).
 
 `Converged` latches. Once a versiond has run its full desired set, a later

--- a/devshard/testenv/Makefile
+++ b/devshard/testenv/Makefile
@@ -70,7 +70,7 @@ dev-logs: ## Follow dev overlay logs.
 
 .PHONY: citest-images citest-stack citest-stack-build list-citest-targets
 .PHONY: citest-validation-lease-race citest-escrow-longpoll
-.PHONY: citest-versiond-rolling-update citest-adversarial citest-payload-withholding
+.PHONY: citest-versiond-rolling-update citest-versiond-host-evacuation citest-adversarial citest-payload-withholding
 .PHONY: citest-observability citest-grpc-transport citest-height-sync citest-height-sync-dapi-compat test-gateway-smoke
 
 # citest-images and citest-stack-build are build/helper rules, not standalone
@@ -105,6 +105,9 @@ citest-escrow-longpoll: citest-images ## Escrow long-poll warm; first inference 
 
 citest-versiond-rolling-update: citest-images ## Same-version versiond rolling update and fallback.
 	TESTENV_CITEST=1 go test -tags=testenvci ./citest/ -run 'TestVersiondRollingUpdate' -count=1 -v -timeout 30m
+
+citest-versiond-host-evacuation: citest-images ## Router-controlled versiond host evacuation and replacement.
+	TESTENV_CITEST=1 go test -tags=testenvci ./citest/ -run '^TestVersiondHostEvacuation$$' -count=1 -v -timeout 30m
 
 citest-adversarial: citest-images ## Phase 9 adversarial citest (TESTENV_CITEST=1).
 	TESTENV_CITEST=1 go test -tags=testenvci ./citest/ -run 'TestA1_|TestA2_|TestA3_|TestA4_' -count=1 -v -timeout 30m

--- a/devshard/testenv/README.md
+++ b/devshard/testenv/README.md
@@ -211,7 +211,9 @@ go test ./testenv/... -count=1
 ### Stack citest (Docker)
 
 The stack suite covers smoke, routing, runtime updates, gateway behavior,
-versiond lifecycle, storage migration, validation leases, and rolling updates.
+versiond lifecycle, storage migration, validation leases, rolling updates, and
+router-observed host evacuation. The evacuation scenario verifies SSE
+continuity, graceful exit, survivor recovery and readiness-gated rejoin.
 Tests use behavior-oriented names and isolated stacks on dedicated subnets with
 Docker-assigned localhost ports, so they can run while a dev `make up` stack is
 active.
@@ -222,6 +224,7 @@ make build-devshardd
 make citest-stack                  # all core stack behavior tests
 make citest-validation-lease-race # validation lease race only
 make citest-versiond-rolling-update
+make citest-versiond-host-evacuation
 # or: ./scripts/run-stack-citest.sh
 ```
 
@@ -242,6 +245,11 @@ sessions to fail over on the first upstream connection failure.
 `TestValidationLeaseRace*` exercises lease exclusivity across a same-key HA pair
 and a solo executor. `TestVersiondRollingUpdate*` separately checks same-version
 sha replacement with Postgres overlap and the hybrid stop-then-start fallback.
+
+`TestVersiondHostEvacuation` stops one versiond while an SSE response is active,
+requires HAProxy to withdraw it before listener shutdown, verifies survivor
+recovery through shared Postgres, and admits the host again only after it
+converges.
 
 **Phase 9 adversarial** (`make citest-adversarial`): A1 lost first SSE chunk, A2 ML 503, A3 stale escrow on chain gRPC, A4 bad warm-key grantees. Fault hooks: `mock-openai` `/testenv/fault`, mock-chain `/testenv/escrow` + `/testenv/grantees` (via mock-dapi).
 

--- a/devshard/testenv/citest/harness/adversarial.go
+++ b/devshard/testenv/citest/harness/adversarial.go
@@ -62,7 +62,19 @@ func ResetMockOpenAIFault(t *testing.T, client *http.Client, mockOpenAIURL strin
 		DropFirstChunk:   &f,
 		PartialStream:    &f,
 		StreamChunkDelay: &zero,
+		PauseStream:      &f,
 	})
+}
+
+func ReleaseMockOpenAIStreams(t *testing.T, client *http.Client, mockOpenAIURL string) {
+	t.Helper()
+	if client == nil {
+		client = HTTPClient()
+	}
+	resp, err := client.Post(mockOpenAIURL+"/testenv/stream/release", "application/json", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "POST mock-openai stream release")
 }
 
 // PatchTestenvGrantees replaces warm-key grantees for a validator via mock-dapi.

--- a/devshard/testenv/citest/harness/compose_patch.go
+++ b/devshard/testenv/citest/harness/compose_patch.go
@@ -20,9 +20,10 @@ func PatchComposeEnvKey(t *testing.T, composePath, key, value string) {
 	require.NoError(t, os.WriteFile(composePath, updated, 0o644))
 }
 
-// PatchRouterHADeployment changes the authoritative HA declaration. Tests that
-// disable it must also keep only one pool member usable, because the router has
-// a runtime multi-host fallback.
+// PatchRouterHADeployment changes the authoritative HA declaration. The router
+// also has a runtime multi-host fallback, so tests that disable this declaration
+// must keep only one pool host usable. Recreate the router afterwards for the
+// declaration to take effect.
 func PatchRouterHADeployment(t *testing.T, composePath string, ha bool) {
 	t.Helper()
 	value := `""`
@@ -150,4 +151,43 @@ func EnableHeightSyncPeerMatrixCompose(t *testing.T, composePath string) {
 	PatchComposeInsertEnvAfterAll(t, composePath, "DEVSHARD_PUBLIC_API",
 		`DEVSHARD_GATEWAY_HEIGHTSYNC_PEER_MATRIX: "1"`,
 	)
+}
+
+// PatchComposeServiceEnv replaces one `KEY: ...` line inside a single service
+// block and returns the value it replaced. Unlike PatchComposeEnvKey this does
+// not touch the other services, which is what makes it usable for putting one
+// host into a state its siblings are not in.
+func PatchComposeServiceEnv(t *testing.T, composePath, service, key, value string) string {
+	t.Helper()
+	body, err := os.ReadFile(composePath)
+	require.NoError(t, err)
+
+	lines := strings.Split(string(body), "\n")
+	start := -1
+	for i, line := range lines {
+		if line == "  "+service+":" {
+			start = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, start, 0, "compose %s: service %q not found", composePath, service)
+
+	entry := regexp.MustCompile(`^(\s+` + regexp.QuoteMeta(key) + `:\s*)(.*)$`)
+	for i := start + 1; i < len(lines); i++ {
+		// A line indented by two or less starts the next service or a top-level
+		// key, so the service block has ended.
+		if trimmed := strings.TrimLeft(lines[i], " "); trimmed != "" &&
+			len(lines[i])-len(trimmed) <= 2 {
+			break
+		}
+		m := entry.FindStringSubmatch(lines[i])
+		if m == nil {
+			continue
+		}
+		lines[i] = m[1] + value
+		require.NoError(t, os.WriteFile(composePath, []byte(strings.Join(lines, "\n")), 0o644))
+		return strings.TrimSpace(m[2])
+	}
+	t.Fatalf("compose %s: service %q has no %q entry", composePath, service, key)
+	return ""
 }

--- a/devshard/testenv/citest/harness/compose_patch_test.go
+++ b/devshard/testenv/citest/harness/compose_patch_test.go
@@ -112,6 +112,32 @@ func TestParseRouterPool(t *testing.T) {
 	}, slots)
 }
 
+func TestParseRouterVersionBackend(t *testing.T) {
+	out := "# id (file) description\n" +
+		"0x1 v2 versiond_dynamic_1\n" +
+		"0x2 version=v2 versiond_dynamic_1\n" +
+		"0x3 v4 versiond_pool_v4\n"
+
+	backend, err := parseRouterVersionBackend(out, "v2")
+	require.NoError(t, err)
+	require.Equal(t, "versiond_dynamic_1", backend)
+
+	backend, err = parseRouterVersionBackend(out, "v4")
+	require.NoError(t, err)
+	require.Equal(t, "versiond_pool_v4", backend)
+
+	_, err = parseRouterVersionBackend(out, "v9")
+	require.ErrorContains(t, err, `version "v9" is not present`)
+}
+
+func TestParseRouterVersionBackendRejectsConflictingEntries(t *testing.T) {
+	_, err := parseRouterVersionBackend(
+		"0x1 v2 versiond_dynamic_1\n0x2 v2 versiond_dynamic_2\n",
+		"v2",
+	)
+	require.ErrorContains(t, err, `version "v2" maps to multiple backends`)
+}
+
 func TestPatchComposeServiceEnv(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "docker-compose.yml")

--- a/devshard/testenv/citest/harness/compose_patch_test.go
+++ b/devshard/testenv/citest/harness/compose_patch_test.go
@@ -17,6 +17,9 @@ services:
   versiond-0:
     environment:
       DEVSHARD_STORAGE_MODE: postgres
+  versiond-router:
+    environment:
+      VERSIOND_POOL_HOST: "versiond-pool"
       GONKA_HA: "true"
 `), 0o644))
 
@@ -87,4 +90,61 @@ services:
 	body, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Contains(t, string(body), `DEVSHARD_GATEWAY_HEIGHTSYNC_PEER_MATRIX: "1"`)
+}
+
+// The same host is a separate server in every backend, with its own state, so
+// the parse has to keep them apart or a wait would settle on whichever backend
+// happened to be printed last.
+func TestParseRouterPool(t *testing.T) {
+	slots := parseRouterPool("versiond_ha_pool\n" +
+		"  versiond1\t172.30.0.10\tUP\n" +
+		"  versiond2\t172.30.0.11\tUP\n" +
+		"  2 server(s) taking traffic\n" +
+		"versiond_pool_v2\n" +
+		"  versiond1\t172.30.0.10\tDOWN\n" +
+		"  versiond2\t172.30.0.11\tDRAIN\n" +
+		"  1 server(s) taking traffic\n")
+	require.Equal(t, []RouterSlot{
+		{Backend: "versiond_ha_pool", Name: "versiond1", Address: "172.30.0.10", State: RouterSlotUp},
+		{Backend: "versiond_ha_pool", Name: "versiond2", Address: "172.30.0.11", State: RouterSlotUp},
+		{Backend: "versiond_pool_v2", Name: "versiond1", Address: "172.30.0.10", State: RouterSlotDown},
+		{Backend: "versiond_pool_v2", Name: "versiond2", Address: "172.30.0.11", State: RouterSlotDrain},
+	}, slots)
+}
+
+func TestPatchComposeServiceEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+services:
+  versiond-0:
+    environment:
+      VERSIOND_ORACLE_URL: http://mock-dapi:9100/versions
+      KEY_NAME: versiond-0
+  versiond-1:
+    environment:
+      VERSIOND_ORACLE_URL: http://mock-dapi:9100/versions
+      KEY_NAME: versiond-0
+volumes:
+  VERSIOND_ORACLE_URL: not-an-env-entry
+`), 0o644))
+
+	previous := PatchComposeServiceEnv(t, path, "versiond-1", "VERSIOND_ORACLE_URL", "http://127.0.0.1:1/versions")
+	require.Equal(t, "http://mock-dapi:9100/versions", previous)
+
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	text := string(body)
+
+	// Exactly one host moved; the sibling and the unrelated block are untouched,
+	// which is the whole point of scoping the patch to one service.
+	require.Equal(t, 1, strings.Count(text, "VERSIOND_ORACLE_URL: http://127.0.0.1:1/versions"))
+	require.Equal(t, 1, strings.Count(text, "VERSIOND_ORACLE_URL: http://mock-dapi:9100/versions"))
+	require.Contains(t, text, "VERSIOND_ORACLE_URL: not-an-env-entry")
+
+	restored := PatchComposeServiceEnv(t, path, "versiond-1", "VERSIOND_ORACLE_URL", previous)
+	require.Equal(t, "http://127.0.0.1:1/versions", restored)
+	body, err = os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, 2, strings.Count(string(body), "VERSIOND_ORACLE_URL: http://mock-dapi:9100/versions"))
 }

--- a/devshard/testenv/citest/harness/container.go
+++ b/devshard/testenv/citest/harness/container.go
@@ -1,0 +1,48 @@
+package harness
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ContainerID resolves a compose service to its container ID.
+func (s *Stack) ContainerID(t *testing.T, service string) string {
+	t.Helper()
+	id, err := s.containerID(service)
+	require.NoError(t, err)
+	return id
+}
+
+func (s *Stack) containerID(service string) (string, error) {
+	args := append([]string{"compose"}, s.composeFileArgs()...)
+	args = append(args, "ps", "-q", service)
+	cmd := exec.Command("docker", args...)
+	cmd.Dir = s.WorkDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolve container ID for %s: %w: %s", service, err, output)
+	}
+	ids := strings.Fields(string(output))
+	if len(ids) != 1 {
+		return "", fmt.Errorf("resolve container ID for %s: got %d IDs", service, len(ids))
+	}
+	return ids[0], nil
+}
+
+func containerExitCode(containerID string) (int, error) {
+	cmd := exec.Command("docker", "inspect", "--format", "{{.State.ExitCode}}", containerID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("inspect exit code for container %s: %w: %s", containerID, err, output)
+	}
+	exitCode, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	if err != nil {
+		return 0, fmt.Errorf("parse exit code for container %s: %w", containerID, err)
+	}
+	return exitCode, nil
+}

--- a/devshard/testenv/citest/harness/router_pool.go
+++ b/devshard/testenv/citest/harness/router_pool.go
@@ -51,6 +51,12 @@ func routerPool(stack *Stack) ([]RouterSlot, error) {
 // harness is its primary consumer.
 const routerPoolStatusBin = "/usr/local/lib/versiond-router/pool-status"
 
+const routerVersionMapQuery = `
+map=${VERSIOND_ROUTER_VERSIONS_MAP:-/etc/haproxy/versions.map}
+sock=${HAPROXY_RECONCILER_SOCKET:-/var/run/haproxy/reconciler.sock}
+printf 'show map %s\n' "$map" | socat stdio "UNIX-CONNECT:$sock"
+`
+
 // parseRouterPool reads pool-status output: each backend followed by its
 // indented servers.
 func parseRouterPool(out string) []RouterSlot {
@@ -78,8 +84,47 @@ func parseRouterPool(out string) []RouterSlot {
 	return slots
 }
 
-// VersionPoolBackend is the backend a declared version is routed through.
-func VersionPoolBackend(version string) string { return "versiond_pool_" + version }
+// WaitRouterVersionBackend resolves the backend currently assigned to version
+// through HAProxy's runtime map. Static bootstrap versions use versiond_pool_*
+// names, while governance versions use versiond_dynamic_* slots, so callers
+// must not derive the backend name from the version itself.
+func WaitRouterVersionBackend(t *testing.T, stack *Stack, version string, timeout time.Duration) string {
+	t.Helper()
+	var backend string
+	var lastErr error
+	ok := AssertEventually(t, timeout, 250*time.Millisecond, func() bool {
+		backend, lastErr = routerVersionBackend(stack, version)
+		return lastErr == nil
+	})
+	require.True(t, ok, "router never mapped version %q to a backend: %v", version, lastErr)
+	return backend
+}
+
+func routerVersionBackend(stack *Stack, version string) (string, error) {
+	out, err := stack.ComposeExecOutput("versiond-router", "sh", "-c", routerVersionMapQuery)
+	if err != nil {
+		return "", fmt.Errorf("show versions map: %w: %s", err, out)
+	}
+	return parseRouterVersionBackend(out, version)
+}
+
+func parseRouterVersionBackend(out, version string) (string, error) {
+	backend := ""
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 || strings.HasPrefix(fields[0], "#") || fields[1] != version {
+			continue
+		}
+		if backend != "" && backend != fields[2] {
+			return "", fmt.Errorf("version %q maps to multiple backends: %q and %q", version, backend, fields[2])
+		}
+		backend = fields[2]
+	}
+	if backend == "" {
+		return "", fmt.Errorf("version %q is not present in the router versions map", version)
+	}
+	return backend, nil
+}
 
 // RouterPoolHostState maps each versiond host to the state the router sees in
 // one backend. Hosts the router cannot resolve at all are simply absent.

--- a/devshard/testenv/citest/harness/router_pool.go
+++ b/devshard/testenv/citest/harness/router_pool.go
@@ -1,0 +1,154 @@
+package harness
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"devshard/testenv/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Router pool states as reported by the router's pool-status diagnostic.
+const (
+	RouterSlotUp    = "UP"
+	RouterSlotDown  = "DOWN"
+	RouterSlotDrain = "DRAIN"
+)
+
+// RouterSlot is one server slot in one of the router's backends. Backend matters:
+// the same host is a separate server in each, with its own health and therefore
+// its own state.
+type RouterSlot struct {
+	Backend string
+	Name    string
+	Address string
+	State   string
+}
+
+// RouterPool asks the router what it currently believes about the pool. This is
+// the whole control surface now: membership arrives over DNS and health over
+// active /readyz checks, so the router's own view is the only authority.
+func RouterPool(t *testing.T, stack *Stack) []RouterSlot {
+	t.Helper()
+	slots, err := routerPool(stack)
+	require.NoError(t, err)
+	return slots
+}
+
+func routerPool(stack *Stack) ([]RouterSlot, error) {
+	out, err := stack.ComposeExecOutput("versiond-router", routerPoolStatusBin)
+	if err != nil {
+		return nil, fmt.Errorf("pool-status: %w: %s", err, out)
+	}
+	return parseRouterPool(out), nil
+}
+
+// routerPoolStatusBin is the router's read-only pool diagnostic. Off PATH on
+// purpose — it is an internal formatter over the HAProxy Runtime API, and this
+// harness is its primary consumer.
+const routerPoolStatusBin = "/usr/local/lib/versiond-router/pool-status"
+
+// parseRouterPool reads pool-status output: each backend followed by its
+// indented servers.
+func parseRouterPool(out string) []RouterSlot {
+	var slots []RouterSlot
+	backend := ""
+	for _, line := range strings.Split(out, "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			backend = strings.TrimSpace(line)
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			continue
+		}
+		slots = append(slots, RouterSlot{
+			Backend: backend,
+			Name:    fields[0],
+			Address: fields[1],
+			State:   fields[2],
+		})
+	}
+	return slots
+}
+
+// VersionPoolBackend is the backend a declared version is routed through.
+func VersionPoolBackend(version string) string { return "versiond_pool_" + version }
+
+// RouterPoolHostState maps each versiond host to the state the router sees in
+// one backend. Hosts the router cannot resolve at all are simply absent.
+func RouterPoolHostState(t *testing.T, stack *Stack, cfg *config.File, backend string) map[string]string {
+	t.Helper()
+	byHost := make(map[string]string)
+	for _, slot := range RouterPool(t, stack) {
+		if slot.Backend != backend {
+			continue
+		}
+		if host := HostIDForUpstream(cfg, slot.Address); host != "" {
+			byHost[host] = slot.State
+		}
+	}
+	return byHost
+}
+
+// WaitRouterPoolState blocks until the router reports the host in wantState,
+// where the empty string means "not in the pool at all". A router that is itself
+// restarting is a normal transient here, so an unreachable router is retried
+// rather than failed.
+func WaitRouterPoolState(
+	t *testing.T,
+	stack *Stack,
+	cfg *config.File,
+	backend, host, wantState string,
+	timeout time.Duration,
+) {
+	t.Helper()
+	var last string
+	ok := AssertEventually(t, timeout, 250*time.Millisecond, func() bool {
+		slots, err := routerPool(stack)
+		if err != nil {
+			last = "unreachable"
+			return false
+		}
+		last = ""
+		for _, slot := range slots {
+			if slot.Backend == backend && HostIDForUpstream(cfg, slot.Address) == host {
+				last = slot.State
+			}
+		}
+		return last == wantState
+	})
+	require.True(t, ok, "router never saw %s as %q in %s (last %q)", host, wantState, backend, last)
+}
+
+// RouterServingHosts lists the hosts currently taking new traffic in a backend.
+func RouterServingHosts(t *testing.T, stack *Stack, cfg *config.File, backend string) []string {
+	t.Helper()
+	var serving []string
+	for host, state := range RouterPoolHostState(t, stack, cfg, backend) {
+		if state == RouterSlotUp {
+			serving = append(serving, host)
+		}
+	}
+	return serving
+}
+
+// DescribeRouterPool renders the pool for failure messages.
+func DescribeRouterPool(t *testing.T, stack *Stack, cfg *config.File) string {
+	t.Helper()
+	var b strings.Builder
+	for _, slot := range RouterPool(t, stack) {
+		host := HostIDForUpstream(cfg, slot.Address)
+		if host == "" {
+			host = "?"
+		}
+		fmt.Fprintf(&b, "%s/%s(%s)=%s ", slot.Backend, host, slot.Address, slot.State)
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/devshard/testenv/citest/harness/router_session_test.go
+++ b/devshard/testenv/citest/harness/router_session_test.go
@@ -1,12 +1,38 @@
 package harness
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
 func TestRouterSessionURL_StickyPath(t *testing.T) {
 	got := RouterSessionURL("http://127.0.0.1:18080", "v2", "escrow-42", "/healthz")
 	require.Equal(t, "http://127.0.0.1:18080/v2/sessions/escrow-42/healthz", got)
+}
+
+func TestGetSuccessfulResponseHeaderRejectsHTTPFailure(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Header:     http.Header{StickyUpstreamHeader: []string{"versiond-2"}},
+			Body:       http.NoBody,
+		}, nil
+	})}
+
+	value, err := GetSuccessfulResponseHeader(
+		client,
+		"http://router/v1/sessions/escrow/healthz",
+		StickyUpstreamHeader,
+	)
+	require.Error(t, err)
+	require.Empty(t, value)
 }

--- a/devshard/testenv/citest/harness/stack.go
+++ b/devshard/testenv/citest/harness/stack.go
@@ -17,7 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultStackTimeout = 12 * time.Minute
+const (
+	defaultStackTimeout       = 12 * time.Minute
+	composeCleanupStopTimeout = 5 * time.Second
+)
 
 // Stack is a generated compose workdir for Docker citest.
 type Stack struct {
@@ -211,10 +214,18 @@ func (s *Stack) Down(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	args := append([]string{"compose"}, s.composeFileArgs()...)
-	args = append(args, "down", "-v")
+	args = append(args,
+		"down",
+		"--volumes",
+		"--remove-orphans",
+		"--timeout", strconv.Itoa(int(composeCleanupStopTimeout/time.Second)),
+	)
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Dir = s.WorkDir
-	_, _ = cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("docker compose cleanup: %v\n%s", err, out)
+	}
 }
 
 // StopService stops a compose service without removing volumes (fault injection).
@@ -228,6 +239,40 @@ func (s *Stack) StopService(t *testing.T, service string) {
 	if err != nil {
 		t.Fatalf("docker compose stop %s: %v\n%s", service, err, out)
 	}
+}
+
+// ServiceStopResult records Docker's terminal state after a compose stop. Exit
+// code 137 proves Docker had to consume its SIGKILL backstop even though the
+// compose command itself reports success.
+type ServiceStopResult struct {
+	ContainerID string
+	ExitCode    int
+}
+
+// StopServiceGracefully sends the container stop signal and gives versiond a
+// caller-controlled grace before Docker's SIGKILL backstop. It returns errors
+// instead of failing a test so callers can run it concurrently with live work.
+func (s *Stack) StopServiceGracefully(service string, grace time.Duration) (ServiceStopResult, error) {
+	containerID, err := s.containerID(service)
+	if err != nil {
+		return ServiceStopResult{}, err
+	}
+	graceSeconds := int((grace + time.Second - 1) / time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), grace+30*time.Second)
+	defer cancel()
+	args := append([]string{"compose"}, s.composeFileArgs()...)
+	args = append(args, "stop", "--timeout", strconv.Itoa(graceSeconds), service)
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Dir = s.WorkDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return ServiceStopResult{}, fmt.Errorf("docker compose stop %s: %w: %s", service, err, out)
+	}
+	exitCode, err := containerExitCode(containerID)
+	if err != nil {
+		return ServiceStopResult{}, err
+	}
+	return ServiceStopResult{ContainerID: containerID, ExitCode: exitCode}, nil
 }
 
 // StartService starts a previously stopped compose service.
@@ -315,6 +360,15 @@ func (s *Stack) RequireServicesRunning(t *testing.T, services ...string) {
 	for _, name := range services {
 		require.Contains(t, running, name, "service %s not running; running=%v", name, running)
 	}
+}
+
+func (s *Stack) ServiceRunning(service string) (bool, error) {
+	running, err := s.runningServices()
+	if err != nil {
+		return false, err
+	}
+	_, ok := running[service]
+	return ok, nil
 }
 
 func (s *Stack) runningServices() (map[string]struct{}, error) {

--- a/devshard/testenv/citest/harness/stack_boot.go
+++ b/devshard/testenv/citest/harness/stack_boot.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -188,13 +189,30 @@ func RouterSessionURL(routerHTTP, version, sessionID, suffix string) string {
 
 // GetResponseHeader performs GET and returns the named response header (body discarded).
 func GetResponseHeader(client *http.Client, url, header string) (string, error) {
-	resp, err := client.Get(url)
+	value, _, err := getResponseHeader(client, url, header)
+	return value, err
+}
+
+// GetSuccessfulResponseHeader also requires a successful HTTP response.
+func GetSuccessfulResponseHeader(client *http.Client, url, header string) (string, error) {
+	value, status, err := getResponseHeader(client, url, header)
 	if err != nil {
 		return "", err
 	}
+	if status < http.StatusOK || status >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("GET %s returned status %d", url, status)
+	}
+	return value, nil
+}
+
+func getResponseHeader(client *http.Client, url, header string) (string, int, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", 0, err
+	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	return resp.Header.Get(header), nil
+	return resp.Header.Get(header), resp.StatusCode, nil
 }
 
 // RequireResponseHeader GETs url and requires a non-empty header value.
@@ -203,5 +221,19 @@ func RequireResponseHeader(t *testing.T, client *http.Client, url, header string
 	value, err := GetResponseHeader(client, url, header)
 	require.NoError(t, err)
 	require.NotEmpty(t, value, "missing response header %q from %s (rebuild versiond-router?)", header, url)
+	return value
+}
+
+// RequireSuccessfulResponseHeader requires both 2xx and a non-empty header.
+func RequireSuccessfulResponseHeader(
+	t *testing.T,
+	client *http.Client,
+	url string,
+	header string,
+) string {
+	t.Helper()
+	value, err := GetSuccessfulResponseHeader(client, url, header)
+	require.NoError(t, err)
+	require.NotEmpty(t, value, "missing response header %q from %s", header, url)
 	return value
 }

--- a/devshard/testenv/citest/harness/versiond_rolling.go
+++ b/devshard/testenv/citest/harness/versiond_rolling.go
@@ -100,6 +100,23 @@ func TryVersiondHealth(stack *Stack, service string) ([]VersiondHealthEntry, err
 	return entries, nil
 }
 
+// TryVersiondReady probes the readiness endpoint the router health-checks.
+// It is on the traffic listener on purpose: a versiond that answers /readyz
+// with 200 is exactly a versiond the router may send work to.
+//
+// version selects which question to ask. Empty asks the host-level one; a name
+// asks the per-version one, which is what the router uses for a declared
+// version — and the two do not turn 200 at the same moment, so a test that waits
+// on the router's view has to probe the same endpoint the router does.
+func TryVersiondReady(stack *Stack, service, version string) error {
+	url := "http://127.0.0.1:8080/readyz"
+	if version != "" {
+		url += "?version=" + version
+	}
+	_, err := stack.ComposeExecOutput(service, "wget", "-q", "-O", "/dev/null", url)
+	return err
+}
+
 // HasVersiondHealthEntry reports whether health contains the wanted version state.
 func HasVersiondHealthEntry(entries []VersiondHealthEntry, name, status, sha string) bool {
 	for _, e := range entries {

--- a/devshard/testenv/citest/versiond_host_evacuation_test.go
+++ b/devshard/testenv/citest/versiond_host_evacuation_test.go
@@ -19,6 +19,10 @@ import (
 
 const (
 	hostEvacuationShutdownBudget = 90 * time.Second
+	// The acceptance test compresses production's minute-scale shutdown
+	// contract. Keep the same phase ordering while leaving 70s for admission
+	// and child drain after the 5s announcement.
+	hostEvacuationChildShutdownGrace = 15 * time.Second
 	// Docker's SIGKILL backstop must sit outside versiond's own shutdown
 	// budget. The exit-code assertion below proves that this reserve was not
 	// consumed by a stuck process.
@@ -55,6 +59,10 @@ func TestVersiondHostEvacuation(t *testing.T) {
 		harness.PatchComposeEnvKey(t, stack.ComposePath, "VERSIOND_NON_HA_VERSIONS", `""`)
 		harness.PatchComposeEnvKey(t, stack.ComposePath, "VERSIOND_HOST_SHUTDOWN_BUDGET",
 			`"`+hostEvacuationShutdownBudget.String()+`"`)
+		harness.PatchComposeInsertEnvAfterAll(t, stack.ComposePath, "VERSIOND_HOST_SHUTDOWN_BUDGET",
+			`VERSIOND_DRAIN_KILL_GRACE: "`+hostEvacuationChildShutdownGrace.String()+`"`,
+			`DEVSHARD_SHUTDOWN_GRACE: "`+hostEvacuationChildShutdownGrace.String()+`"`,
+		)
 	})
 	client := harness.GatewayChatClient()
 	t.Cleanup(func() {

--- a/devshard/testenv/citest/versiond_host_evacuation_test.go
+++ b/devshard/testenv/citest/versiond_host_evacuation_test.go
@@ -66,7 +66,7 @@ func TestVersiondHostEvacuation(t *testing.T) {
 	// Declared versions are routed and health-checked through their own pool, so
 	// that is the pool whose view of a host the test has to read.
 	version := env.cfg.Versiond.VersionName
-	pool := harness.VersionPoolBackend(version)
+	pool := harness.WaitRouterVersionBackend(t, env.stack, version, hostEvacuationObservationTimeout)
 	escrowID := harness.GetGatewayEscrowID(t, client, env.eps.GatewayHTTP)
 	harness.Step(t, "binding escrow %s through the owner chat path", escrowID)
 	harness.PostGatewayChatCompletion(t, client, env.eps.GatewayHTTP,
@@ -96,6 +96,12 @@ func TestVersiondHostEvacuation(t *testing.T) {
 	}
 
 	harness.Step(t, "both hosts are in the router pool before evacuation")
+	// Observe the steady precondition instead of sampling it once while the
+	// router may still be reconciling DNS membership and active health checks.
+	for _, host := range env.hosts {
+		harness.WaitRouterPoolState(t, env.stack, env.cfg, pool, host,
+			harness.RouterSlotUp, hostEvacuationObservationTimeout)
+	}
 	require.ElementsMatch(t, env.hosts, harness.RouterServingHosts(t, env.stack, env.cfg, pool),
 		"pool: %s", harness.DescribeRouterPool(t, env.stack, env.cfg))
 
@@ -113,6 +119,7 @@ func TestVersiondHostEvacuation(t *testing.T) {
 	// The harness publishes random host ports, and Docker picks a new one when
 	// the container comes back, so every endpoint has to be re-resolved.
 	env.eps = env.stack.Endpoints(t, env.cfg)
+	pool = harness.WaitRouterVersionBackend(t, env.stack, version, hostEvacuationObservationTimeout)
 	harness.WaitRouterPoolState(t, env.stack, env.cfg, pool, targetHost,
 		harness.RouterSlotUp, hostEvacuationObservationTimeout)
 	requireSessionAvailableOnHost(t, env, escrowID, targetHost,

--- a/devshard/testenv/citest/versiond_host_evacuation_test.go
+++ b/devshard/testenv/citest/versiond_host_evacuation_test.go
@@ -1,0 +1,395 @@
+//go:build testenvci
+
+package citest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"devshard/testenv/citest/harness"
+	"devshard/testenv/config"
+	"devshard/testenv/mockopenai"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	hostEvacuationShutdownBudget = 90 * time.Second
+	// Docker's SIGKILL backstop must sit outside versiond's own shutdown
+	// budget. The exit-code assertion below proves that this reserve was not
+	// consumed by a stuck process.
+	hostEvacuationDockerStopGrace    = 2 * time.Minute
+	hostEvacuationObservationTimeout = 60 * time.Second
+	hostReplacementReadyTimeout      = 3 * time.Minute
+	// All checks made while the old stream is deliberately paused share this
+	// one budget. They must release the stream with enough of versiond's own
+	// shutdown budget left for request completion and child reaping.
+	hostEvacuationPreReleaseBudget       = hostEvacuationShutdownBudget - 30*time.Second
+	hostEvacuationStreamCompletionBudget = hostEvacuationShutdownBudget -
+		15*time.Second
+	hostEvacuationGracefulExitBudget = hostEvacuationShutdownBudget +
+		15*time.Second
+	// Refused instantly inside the container, so the host under barrier fails
+	// its reconcile immediately and keeps failing it.
+	unreachableOracleURL = "http://127.0.0.1:1/versions"
+)
+
+// TestVersiondHostEvacuation verifies the whole Track B host lifecycle with no
+// control plane in it: stopping a versiond takes it out of rotation before it
+// stops accepting, its established stream still finishes, the session is
+// recoverable on the survivor, and starting the host again puts it back into
+// the pool once — and only once — it reports ready.
+//
+// Everything the operator does here is `docker compose stop` and
+// `docker compose start`. Membership is DNS and health is measured, so there is
+// nothing else to keep in sync.
+func TestVersiondHostEvacuation(t *testing.T) {
+	harness.SkipUnlessEnv(t, "TESTENV_CITEST")
+	harness.RequireDocker(t)
+
+	env := bootVersiondRollingStack(t, "citest-versiond-host-evacuation-*", true, func(stack *harness.Stack, cfg *config.File) {
+		harness.PatchComposeEnvKey(t, stack.ComposePath, "VERSIOND_NON_HA_VERSIONS", `""`)
+		harness.PatchComposeEnvKey(t, stack.ComposePath, "VERSIOND_HOST_SHUTDOWN_BUDGET",
+			`"`+hostEvacuationShutdownBudget.String()+`"`)
+	})
+	client := harness.GatewayChatClient()
+	t.Cleanup(func() {
+		if t.Failed() {
+			harness.DumpComposeLogs(t, env.stack,
+				env.hosts[0], env.hosts[1], "versiond-router", "devshardctl")
+		}
+	})
+	// Declared versions are routed and health-checked through their own pool, so
+	// that is the pool whose view of a host the test has to read.
+	version := env.cfg.Versiond.VersionName
+	pool := harness.VersionPoolBackend(version)
+	escrowID := harness.GetGatewayEscrowID(t, client, env.eps.GatewayHTTP)
+	harness.Step(t, "binding escrow %s through the owner chat path", escrowID)
+	harness.PostGatewayChatCompletion(t, client, env.eps.GatewayHTTP,
+		harness.TestenvAdminAPIKey, harness.ChatCompletionRequest{
+			Model:     "test-model",
+			MaxTokens: 16,
+			Messages: []harness.ChatMessage{{
+				Role:    "user",
+				Content: "initialize the versiond host evacuation session",
+			}},
+		})
+	stickySessionURL := func() string {
+		return harness.RouterSessionURL(
+			env.eps.RouterHTTP,
+			env.cfg.Versiond.VersionName,
+			escrowID,
+			"/mempool",
+		)
+	}
+	targetUpstream := harness.RequireSuccessfulResponseHeader(
+		t, client, stickySessionURL(), harness.StickyUpstreamHeader)
+	targetHost := harness.HostIDForUpstream(env.cfg, targetUpstream)
+	require.Contains(t, env.hosts, targetHost)
+	survivorHost := env.hosts[0]
+	if survivorHost == targetHost {
+		survivorHost = env.hosts[1]
+	}
+
+	harness.Step(t, "both hosts are in the router pool before evacuation")
+	require.ElementsMatch(t, env.hosts, harness.RouterServingHosts(t, env.stack, env.cfg, pool),
+		"pool: %s", harness.DescribeRouterPool(t, env.stack, env.cfg))
+
+	// A restarted router rebuilds the pool from a fresh DNS answer, and nothing
+	// guarantees the addresses come back in the same order. If ring position
+	// followed the slot they landed in rather than the host itself, every
+	// session would silently re-home on a routine router restart.
+	//
+	// This exercises a real restart but cannot force the adverse ordering, so it
+	// is a smoke test rather than the proof; the proof is deterministic and
+	// lives in `make -C versiond-router test-hash-ring`.
+	harness.Step(t, "restarting the router must not re-home %s", escrowID)
+	env.stack.StopService(t, "versiond-router")
+	env.stack.StartService(t, "versiond-router")
+	// The harness publishes random host ports, and Docker picks a new one when
+	// the container comes back, so every endpoint has to be re-resolved.
+	env.eps = env.stack.Endpoints(t, env.cfg)
+	harness.WaitRouterPoolState(t, env.stack, env.cfg, pool, targetHost,
+		harness.RouterSlotUp, hostEvacuationObservationTimeout)
+	requireSessionAvailableOnHost(t, env, escrowID, targetHost,
+		hostEvacuationObservationTimeout)
+
+	pauseStream := true
+	harness.PatchMockOpenAIFault(t, client, env.eps.MockOpenAIHTTP, mockopenai.FaultPatch{
+		PauseStream: &pauseStream,
+	})
+
+	accepted, streamResult := harness.StartGatewayChatCompletionStream(
+		client,
+		env.eps.GatewayHTTP,
+		harness.TestenvAdminAPIKey,
+		harness.ChatCompletionRequest{
+			Model:     "test-model",
+			MaxTokens: 64,
+			Messages: []harness.ChatMessage{{
+				Role:    "user",
+				Content: "long stream across versiond host evacuation",
+			}},
+		},
+	)
+	requireVersiondStreamStillRunning(t, accepted, streamResult, "host evacuation stream")
+
+	harness.Step(t, "evacuating %s with docker compose stop", targetHost)
+	// Nothing may fail while the host leaves: the announce window exists so the
+	// router observes the failing health check before versiond stops accepting.
+	// Use the target escrow's sticky path: the same URL was resolved to targetHost
+	// above, so this probe necessarily crosses the host being evacuated rather
+	// than whichever host owns a constant version-level health path.
+	probeURL := stickySessionURL()
+	probeUpstream := harness.RequireSuccessfulResponseHeader(
+		t, client, probeURL, harness.StickyUpstreamHeader)
+	require.Equal(t, targetHost, harness.HostIDForUpstream(env.cfg, probeUpstream),
+		"continuity probe is not pinned to the host selected for evacuation")
+	probeCtx, stopProbe := context.WithCancel(context.Background())
+	probeErr, err := startHostEvacuationContinuityProbe(probeCtx, client, probeURL)
+	require.NoError(t, err)
+	defer stopProbe()
+
+	type stopOutcome struct {
+		result harness.ServiceStopResult
+		err    error
+	}
+	evacuationResult := make(chan stopOutcome, 1)
+	evacuationStarted := time.Now()
+	preReleaseDeadline := evacuationStarted.Add(hostEvacuationPreReleaseBudget)
+	streamCompletionDeadline := evacuationStarted.Add(hostEvacuationStreamCompletionBudget)
+	gracefulExitDeadline := evacuationStarted.Add(hostEvacuationGracefulExitBudget)
+	go func() {
+		result, stopErr := env.stack.StopServiceGracefully(targetHost, hostEvacuationDockerStopGrace)
+		evacuationResult <- stopOutcome{result: result, err: stopErr}
+	}()
+
+	harness.Step(t, "the router stops routing to %s while it is still serving", targetHost)
+	harness.WaitRouterPoolState(t, env.stack, env.cfg, pool, targetHost,
+		harness.RouterSlotDown, remainingUntil(t, preReleaseDeadline, "router drain announcement"))
+	requireNewRouterRequestsAvoidHost(t, client, env, escrowID, targetHost,
+		remainingUntil(t, preReleaseDeadline, "new-request failover"))
+
+	harness.Step(t, "versiond stays alive while its internal FSM drains the established stream")
+	running, err := env.stack.ServiceRunning(targetHost)
+	require.NoError(t, err)
+	require.True(t, running, "target versiond exited before its accepted stream completed")
+	requireVersiondStreamStillRunning(t, accepted, streamResult, "host evacuation stream")
+
+	harness.Step(t, "the same escrow is recovered on the surviving host")
+	requireSessionAvailableOnHost(t, env, escrowID, survivorHost,
+		remainingUntil(t, preReleaseDeadline, "survivor session recovery"))
+
+	harness.Step(t, "releasing the old stream before versiond exits")
+	releaseClient := *client
+	releaseClient.Timeout = remainingUntil(t, streamCompletionDeadline, "stream release request")
+	harness.ReleaseMockOpenAIStreams(t, &releaseClient, env.eps.MockOpenAIHTTP)
+	var result harness.GatewayStreamResult
+	select {
+	case result = <-streamResult:
+	case <-time.After(remainingUntil(t, streamCompletionDeadline, "old stream completion")):
+		t.Fatal("accepted stream did not finish inside the versiond shutdown budget")
+	}
+	require.NoError(t, result.Err)
+	require.Equal(t, http.StatusOK, result.Status, "stream body: %s", result.Body)
+	require.True(t, result.SawDone, "stream missing [DONE]")
+	harness.RequireMockOpenAIContent(t, result.Content)
+
+	select {
+	case outcome := <-evacuationResult:
+		require.NoError(t, outcome.err)
+		require.Equal(t, 0, outcome.result.ExitCode,
+			"versiond did not complete its handled SIGTERM shutdown; container %s exited with code %d",
+			outcome.result.ContainerID, outcome.result.ExitCode)
+	case <-time.After(remainingUntil(t, gracefulExitDeadline, "versiond graceful exit")):
+		t.Fatal("versiond did not exit before the Docker SIGKILL backstop")
+	}
+	running, err = env.stack.ServiceRunning(targetHost)
+	require.NoError(t, err)
+	require.False(t, running, "target versiond is still running after graceful stop")
+
+	stopProbe()
+	select {
+	case err := <-probeErr:
+		require.NoError(t, err, "traffic failed while the host was leaving the pool")
+	case <-time.After(5 * time.Second):
+		t.Fatal("continuity probe did not stop")
+	}
+
+	harness.Step(t, "a decommissioned host simply stops resolving; no router change")
+	harness.WaitRouterPoolState(t, env.stack, env.cfg, pool, targetHost, "", hostEvacuationObservationTimeout)
+	require.Equal(t, []string{survivorHost}, harness.RouterServingHosts(t, env.stack, env.cfg, pool))
+	requireSessionAvailableOnHost(t, env, escrowID, survivorHost,
+		hostEvacuationObservationTimeout)
+
+	harness.Step(t, "%s comes back up but cannot converge: it must stay out of the pool", targetHost)
+	// A host that is up but not yet able to serve must not be routed to. Racing
+	// a normal start is no way to check that — a fast child wins and the window
+	// never gets observed — so the host is brought back behind a barrier it
+	// cannot pass: an oracle that refuses connections. It boots, appears in DNS
+	// and stays there, but never learns what to run, so /readyz keeps failing
+	// for exactly as long as the test holds the barrier up.
+	//
+	// Only this host is repointed. The survivor keeps its oracle and keeps
+	// serving, which also pins that one host's trouble does not become the
+	// pool's.
+	oracleURL := harness.PatchComposeServiceEnv(t, env.stack.ComposePath, targetHost,
+		"VERSIOND_ORACLE_URL", unreachableOracleURL)
+	env.stack.RecreateServices(t, targetHost)
+
+	harness.WaitRouterPoolState(t, env.stack, env.cfg, pool, targetHost,
+		harness.RouterSlotDown, hostEvacuationObservationTimeout)
+	require.Error(t, harness.TryVersiondReady(env.stack, targetHost, version),
+		"%s should report unready while it cannot reach its oracle", targetHost)
+	requireNewRouterRequestsAvoidHost(t, client, env, escrowID, targetHost,
+		hostEvacuationObservationTimeout)
+	requireSessionAvailableOnHost(t, env, escrowID, survivorHost,
+		hostEvacuationObservationTimeout)
+
+	harness.Step(t, "lifting the barrier: %s rejoins once it reports ready", targetHost)
+	harness.PatchComposeServiceEnv(t, env.stack.ComposePath, targetHost,
+		"VERSIOND_ORACLE_URL", oracleURL)
+	env.stack.RecreateServices(t, targetHost)
+
+	harness.WaitRouterPoolState(t, env.stack, env.cfg, pool, targetHost,
+		harness.RouterSlotUp, hostReplacementReadyTimeout)
+	require.NoError(t, harness.TryVersiondReady(env.stack, targetHost, version))
+
+	harness.Step(t, "consistent hashing returns the escrow to %s", targetHost)
+	requireSessionAvailableOnHost(t, env, escrowID, targetHost,
+		hostEvacuationObservationTimeout)
+}
+
+func requireSessionAvailableOnHost(
+	t *testing.T,
+	env versiondRollingTestStack,
+	escrowID string,
+	wantHost string,
+	timeout time.Duration,
+) {
+	t.Helper()
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+	}
+	if timeout < client.Timeout {
+		client.Timeout = timeout
+	}
+	deadline := time.Now().Add(timeout)
+	available := harness.AssertEventually(t, timeout, 250*time.Millisecond, func() bool {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+		client.Timeout = min(5*time.Second, remaining)
+		resp, err := client.Get(harness.RouterSessionURL(
+			env.eps.RouterHTTP,
+			env.cfg.Versiond.VersionName,
+			escrowID,
+			"/mempool",
+		))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK &&
+			harness.HostIDForUpstream(
+				env.cfg,
+				resp.Header.Get(harness.StickyUpstreamHeader),
+			) == wantHost
+	})
+	require.True(t, available, "escrow %s was not available on %s", escrowID, wantHost)
+}
+
+func requireNewRouterRequestsAvoidHost(
+	t *testing.T,
+	client *http.Client,
+	env versiondRollingTestStack,
+	escrowID string,
+	targetHost string,
+	timeout time.Duration,
+) {
+	t.Helper()
+	probeClient := *client
+	deadline := time.Now().Add(timeout)
+	avoided := harness.AssertEventually(t, timeout, 100*time.Millisecond, func() bool {
+		for i := 0; i < 4; i++ {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return false
+			}
+			probeClient.Timeout = min(5*time.Second, remaining)
+			upstream, err := harness.GetSuccessfulResponseHeader(
+				&probeClient,
+				harness.RouterSessionURL(
+					env.eps.RouterHTTP,
+					env.cfg.Versiond.VersionName,
+					escrowID,
+					"/mempool",
+				),
+				harness.StickyUpstreamHeader,
+			)
+			if err != nil || harness.HostIDForUpstream(env.cfg, upstream) == targetHost {
+				return false
+			}
+		}
+		return true
+	})
+	require.True(t, avoided, "new router requests still reached %s", targetHost)
+}
+
+func remainingUntil(t *testing.T, deadline time.Time, stage string) time.Duration {
+	t.Helper()
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		t.Fatalf("host evacuation exceeded its shared deadline before %s", stage)
+	}
+	return remaining
+}
+
+func startHostEvacuationContinuityProbe(
+	ctx context.Context,
+	client *http.Client,
+	url string,
+) (<-chan error, error) {
+	probe := func() error {
+		resp, err := client.Get(url)
+		if err != nil {
+			return err
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("continuity probe %s: HTTP %d", url, resp.StatusCode)
+		}
+		return nil
+	}
+	if err := probe(); err != nil {
+		return nil, err
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(300 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				errCh <- nil
+				return
+			case <-ticker.C:
+				if err := probe(); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}
+	}()
+	return errCh, nil
+}

--- a/devshard/testenv/cmd/gencompose/compose.go
+++ b/devshard/testenv/cmd/gencompose/compose.go
@@ -124,6 +124,7 @@ services:
     environment:
       VERSIOND_ORACLE_URL: http://{{ $.MockDapi.Host }}:{{ $.MockDapi.HTTPPort }}/versions
       VERSIOND_POLL_INTERVAL: "{{ $.Versiond.PollInterval }}"
+      VERSIOND_HOST_SHUTDOWN_BUDGET: "25m"
       VERSIOND_BIN_DIR: /opt/versiond/bin
       VERSIOND_DATA_DIR: /opt/versiond/data
       VERSIOND_BINARY_NAME: devshardd
@@ -199,6 +200,7 @@ services:
       - mock-dapi
       - mock-openai
 {{ end }}
+    stop_grace_period: 30m
     restart: unless-stopped
 {{ end }}
 
@@ -235,6 +237,8 @@ services:
 {{ range .Hosts }}
       - {{ .ID }}
 {{ end }}
+    # Compose starts the replacement only after this container exits. Bound the
+    # soft stop so one long stream cannot leave the test stack without a router.
     stop_signal: SIGUSR1
     stop_grace_period: 10s
     restart: unless-stopped

--- a/devshard/testenv/cmd/gencompose/main_test.go
+++ b/devshard/testenv/cmd/gencompose/main_test.go
@@ -303,6 +303,8 @@ func TestWriteCompose_MockChainService(t *testing.T) {
 	require.Contains(t, text, `VERSIOND_NON_HA_VERSIONS: "v1"`)
 	require.Contains(t, text, "versiond-router-state:/var/lib/gonka-router",
 		"a replacement router must retain its last-known-good catalog")
+	require.Equal(t, 3, strings.Count(text, "stop_grace_period: 30m"),
+		"only the three stateful versiond hosts need the long drain backstop")
 	require.Contains(t, text, "stop_grace_period: 10s",
 		"the stateless router replacement must not wait behind a long SSE stream")
 	require.Contains(t, text, "VERSIOND_ORACLE_URL")

--- a/devshard/testenv/docs/scenarios.md
+++ b/devshard/testenv/docs/scenarios.md
@@ -37,6 +37,7 @@ make citest-stack                 # all core stack behavior tests
 make citest-validation-lease-race # validation lease race only
 make citest-payload-withholding   # executor payload withholding (500 → invalidate)
 make citest-versiond-rolling-update
+make citest-versiond-host-evacuation
 make citest-escrow-longpoll       # escrow long-poll warm (rebuilds devshardd)
 ```
 
@@ -78,6 +79,7 @@ picked up automatically (no workflow edit). For a local sequential subset, use
 | **Validation lease race** | Same-key HA lease exclusivity, pending stretch, stale reclaim | `TestValidationLeaseRaceCore`, `…PendingStretch`, `…StaleReclaim` |
 | **Payload withholding** | Executor `GET /payloads` 500 → Challenged/Invalidated; D7 off releases the lease | `TestPayloadWithholding_AllCallers500_Invalidates`, `…SelectiveValidator_Challenges`, `…D7Off_LeaseReleasedAndReacquired` |
 | **Versiond rolling update** | Postgres blue/green drain and hybrid fallback | `TestVersiondRollingUpdateSameVersionSHA`, `…HybridFallback` |
+| **Versiond host evacuation** | Router withdrawal, SSE completion, survivor recovery and readiness-gated rejoin | `TestVersiondHostEvacuation` |
 | **Escrow long-poll warm** | DAPI escrow-created host event → devshardd `escrow_cache` prefetch → first inference binds from cache with the live escrow query faulted | `TestEscrowLongPollWarmWithoutInferenceNode` |
 
 Source files under `devshard/testenv/citest/` use the same behavior-oriented
@@ -246,6 +248,30 @@ converge to the new sha without ever reporting an old draining child.
 
 Tests: `TestVersiondRollingUpdateSameVersionSHA` and
 `TestVersiondRollingUpdateHybridFallback`.
+
+---
+
+## Versiond host evacuation
+
+**What we test:** stopping a versiond container first withdraws it from the
+HAProxy pool, then lets accepted work finish within a bounded shutdown budget.
+The surviving replica recovers the session from shared PostgreSQL, while a
+restarted host stays out of rotation until its requested version is ready.
+
+**How:**
+
+1. Boot two versiond pool members and pin an active SSE response to one host.
+2. Stop that host and require its per-version backend slot to leave service
+   while the accepted stream still completes with `[DONE]`.
+3. Require new traffic and the existing session to work through the survivor.
+4. Start the host with convergence deliberately blocked; it must remain out of
+   rotation even though its DNS address exists.
+5. Restore convergence and require HAProxy to admit it again.
+
+**Pass criteria:** no continuity probe fails, accepted work is not truncated,
+the stopped process exits without Docker SIGKILL, and rejoin is readiness-gated.
+
+Test: `TestVersiondHostEvacuation`.
 
 ---
 

--- a/devshard/testenv/mockopenai/config.go
+++ b/devshard/testenv/mockopenai/config.go
@@ -26,10 +26,11 @@ func DefaultConfig() Config {
 // FaultConfig holds runtime fault-injection knobs (env or POST /testenv/fault).
 type FaultConfig struct {
 	Latency          time.Duration
-	HTTPStatus       int  // 0 = OK
+	HTTPStatus       int // 0 = OK
 	DropFirstChunk   bool
 	PartialStream    bool // omit final chunk + [DONE]
 	StreamChunkDelay time.Duration
+	PauseStream      bool // pause after first content chunk until testenv release
 }
 
 // FaultPatch is the JSON body for POST /testenv/fault.
@@ -39,6 +40,7 @@ type FaultPatch struct {
 	DropFirstChunk   *bool `json:"drop_first_chunk,omitempty"`
 	PartialStream    *bool `json:"partial_stream,omitempty"`
 	StreamChunkDelay *int  `json:"stream_chunk_delay_ms,omitempty"`
+	PauseStream      *bool `json:"pause_stream,omitempty"`
 }
 
 func (p FaultPatch) apply(dst *FaultConfig) {
@@ -56,6 +58,9 @@ func (p FaultPatch) apply(dst *FaultConfig) {
 	}
 	if p.StreamChunkDelay != nil {
 		dst.StreamChunkDelay = time.Duration(*p.StreamChunkDelay) * time.Millisecond
+	}
+	if p.PauseStream != nil {
+		dst.PauseStream = *p.PauseStream
 	}
 }
 

--- a/devshard/testenv/mockopenai/server.go
+++ b/devshard/testenv/mockopenai/server.go
@@ -15,14 +15,18 @@ import (
 
 // Server serves OpenAI-compatible /v1/chat/completions.
 type Server struct {
-	echo  *echo.Echo
-	mu    sync.RWMutex
-	fault FaultConfig
+	echo       *echo.Echo
+	mu         sync.RWMutex
+	fault      FaultConfig
+	streamGate chan struct{}
 }
 
 // NewServer builds the HTTP server.
 func NewServer(cfg Config) *Server {
 	s := &Server{fault: cfg.Faults}
+	if s.fault.PauseStream {
+		s.streamGate = make(chan struct{})
+	}
 	if s.fault.StreamChunkDelay <= 0 {
 		s.fault.StreamChunkDelay = 5 * time.Millisecond
 	}
@@ -31,20 +35,48 @@ func NewServer(cfg Config) *Server {
 	e.POST("/v1/chat/completions", s.handleChatCompletions)
 	e.GET("/healthz", func(c echo.Context) error { return c.String(http.StatusOK, "ok") })
 	e.POST("/testenv/fault", s.handleFaultPatch)
+	e.POST("/testenv/stream/release", s.handleStreamRelease)
 	s.echo = e
 	return s
-}
-
-func (s *Server) faults() FaultConfig {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.fault
 }
 
 func (s *Server) patchFault(p FaultPatch) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if p.PauseStream != nil {
+		if *p.PauseStream {
+			s.releaseStreamLocked()
+			s.streamGate = make(chan struct{})
+		} else {
+			s.releaseStreamLocked()
+		}
+	}
 	p.apply(&s.fault)
+}
+
+func (s *Server) streamFaults() (FaultConfig, <-chan struct{}) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.fault, s.streamGate
+}
+
+func (s *Server) releaseStreamLocked() {
+	if s.streamGate == nil {
+		return
+	}
+	select {
+	case <-s.streamGate:
+	default:
+		close(s.streamGate)
+	}
+}
+
+func (s *Server) handleStreamRelease(c echo.Context) error {
+	s.mu.Lock()
+	s.releaseStreamLocked()
+	s.fault.PauseStream = false
+	s.mu.Unlock()
+	return c.JSON(http.StatusOK, map[string]string{"status": "released"})
 }
 
 func (s *Server) handleFaultPatch(c echo.Context) error {
@@ -57,7 +89,7 @@ func (s *Server) handleFaultPatch(c echo.Context) error {
 }
 
 func (s *Server) handleChatCompletions(c echo.Context) error {
-	f := s.faults()
+	f, streamGate := s.streamFaults()
 	if f.Latency > 0 {
 		time.Sleep(f.Latency)
 	}
@@ -80,7 +112,7 @@ func (s *Server) handleChatCompletions(c echo.Context) error {
 
 	text := completionText(body)
 	if req.Stream {
-		return s.streamCompletion(c, req.Model, text, body, f)
+		return s.streamCompletion(c, req.Model, text, body, f, streamGate)
 	}
 	return s.jsonCompletion(c, req.Model, text, body)
 }
@@ -102,8 +134,8 @@ func (s *Server) jsonCompletion(c echo.Context, model, text string, body []byte)
 				"role":    "assistant",
 				"content": text,
 			},
-			"logprobs":       nil,
-			"finish_reason":  "stop",
+			"logprobs":      nil,
+			"finish_reason": "stop",
 		}},
 		"usage": map[string]any{
 			"prompt_tokens":     promptTok,
@@ -114,7 +146,14 @@ func (s *Server) jsonCompletion(c echo.Context, model, text string, body []byte)
 	return c.JSON(http.StatusOK, resp)
 }
 
-func (s *Server) streamCompletion(c echo.Context, model, text string, body []byte, f FaultConfig) error {
+func (s *Server) streamCompletion(
+	c echo.Context,
+	model string,
+	text string,
+	body []byte,
+	f FaultConfig,
+	streamGate <-chan struct{},
+) error {
 	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "no-cache")
 	c.Response().Header().Set("Connection", "keep-alive")
@@ -157,6 +196,7 @@ func (s *Server) streamCompletion(c echo.Context, model, text string, body []byt
 		tokens = []rune(" ")
 	}
 	first := true
+	paused := false
 	for i, r := range tokens {
 		if first && f.DropFirstChunk {
 			first = false
@@ -165,6 +205,14 @@ func (s *Server) streamCompletion(c echo.Context, model, text string, body []byt
 		first = false
 		if err := writeChunk(map[string]any{"content": string(r)}, nil); err != nil {
 			return err
+		}
+		if !paused && f.PauseStream && streamGate != nil {
+			paused = true
+			select {
+			case <-streamGate:
+			case <-c.Request().Context().Done():
+				return c.Request().Context().Err()
+			}
 		}
 		if f.PartialStream && i == len(tokens)/2 {
 			return nil

--- a/devshard/testenv/mockopenai/server_test.go
+++ b/devshard/testenv/mockopenai/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"common/completionapi"
 	"devshard/testenv/mockopenai"
@@ -83,6 +84,116 @@ func TestChatCompletions_StreamCompletionAPI(t *testing.T) {
 	content, err := cr.GetEnforcedStr()
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(content, "mock-openai:"))
+}
+
+func TestChatCompletions_StreamPauseCanBeReleased(t *testing.T) {
+	srv := httptest.NewServer(mockopenai.NewServer(mockopenai.Config{
+		Faults: mockopenai.FaultConfig{
+			PauseStream:      true,
+			StreamChunkDelay: time.Millisecond,
+		},
+	}).Handler())
+	defer srv.Close()
+
+	body := []byte(`{"model":"test-model","stream":true,"messages":[{"role":"user","content":"pause"}]}`)
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	require.True(t, scanner.Scan(), "stream did not publish its first chunk")
+	require.True(t, strings.HasPrefix(scanner.Text(), "data: "))
+	done := make(chan error, 1)
+	go func() {
+		for scanner.Scan() {
+		}
+		done <- scanner.Err()
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("paused stream completed before release: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release, err := http.Post(srv.URL+"/testenv/stream/release", "application/json", nil)
+	require.NoError(t, err)
+	_ = release.Body.Close()
+	require.Equal(t, http.StatusOK, release.StatusCode)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("stream did not complete after release")
+	}
+}
+
+func TestChatCompletions_StreamPauseCanBeRearmed(t *testing.T) {
+	srv := httptest.NewServer(mockopenai.NewServer(mockopenai.Config{
+		Faults: mockopenai.FaultConfig{
+			PauseStream:      true,
+			StreamChunkDelay: time.Millisecond,
+		},
+	}).Handler())
+	defer srv.Close()
+
+	body := []byte(`{"model":"test-model","stream":true,"messages":[{"role":"user","content":"pause"}]}`)
+	startPausedStream := func() (*http.Response, <-chan error) {
+		resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", bytes.NewReader(body))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		scanner := bufio.NewScanner(resp.Body)
+		require.True(t, scanner.Scan(), "stream did not publish its first chunk")
+		require.True(t, strings.HasPrefix(scanner.Text(), "data: "))
+		done := make(chan error, 1)
+		go func() {
+			for scanner.Scan() {
+			}
+			done <- scanner.Err()
+		}()
+		return resp, done
+	}
+	assertPaused := func(done <-chan error) {
+		select {
+		case err := <-done:
+			t.Fatalf("paused stream completed before release: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	release := func() {
+		resp, err := http.Post(srv.URL+"/testenv/stream/release", "application/json", nil)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	waitReleased := func(resp *http.Response, done <-chan error) {
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("stream did not complete after release")
+		}
+		_ = resp.Body.Close()
+	}
+
+	firstResp, firstDone := startPausedStream()
+	assertPaused(firstDone)
+	release()
+	waitReleased(firstResp, firstDone)
+
+	patch, err := http.Post(
+		srv.URL+"/testenv/fault",
+		"application/json",
+		strings.NewReader(`{"pause_stream":true}`),
+	)
+	require.NoError(t, err)
+	_ = patch.Body.Close()
+	require.Equal(t, http.StatusOK, patch.StatusCode)
+
+	secondResp, secondDone := startPausedStream()
+	assertPaused(secondDone)
+	release()
+	waitReleased(secondResp, secondDone)
 }
 
 func TestChatCompletions_FaultHTTPStatus(t *testing.T) {

--- a/local-test-net/docker-compose.versiond.yml
+++ b/local-test-net/docker-compose.versiond.yml
@@ -17,6 +17,8 @@
 x-versiond: &versiond
   image: versiond:latest
   platform: ${DOCKER_PLATFORM:-linux/amd64}
+  # Outer Docker backstop; versiond owns the smaller internal shutdown budget.
+  stop_grace_period: 30m
   build:
     context: ./versioned
     dockerfile: Dockerfile

--- a/versiond-router/Makefile
+++ b/versiond-router/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all build-docker release test-render
 .PHONY: test-catalog-cache test-hash-ring test-version-routing test-local-compose test-join-compose
+.PHONY: test-join-versiond-healthcheck
 
 # Renders both the mixed (legacy pinning) and the all-HA shapes, asserts on the
 # result, then runs the real HAProxy from the production image over each one.
@@ -163,6 +164,81 @@ test-join-compose:
 
 test-catalog-cache:
 	@../router-runtime/catalog-cache_test.sh
+
+# The join deployment temporarily supports both the pinned pre-/readyz image
+# and the replacement built from this release. A 404 means the endpoint does
+# not exist and may fall back to liveness; a real 503 must remain unready.
+test-join-versiond-healthcheck:
+	@set -eu; \
+	tmpdir=$$(mktemp -d); \
+	netns=gonka-versiond-healthcheck-probe; \
+	cleanup() { \
+		docker rm -f $$netns >/dev/null 2>&1 || true; \
+		rm -rf "$$tmpdir"; \
+	}; \
+	trap cleanup EXIT; \
+	fail() { echo "test-join-versiond-healthcheck: $$1" >&2; exit 1; }; \
+	DEVSHARD_POSTGRES_PASSWORD=test \
+		docker compose --project-directory ../deploy/join \
+		-f ../deploy/join/docker-compose.yml \
+		-f ../deploy/join/docker-compose.versiond.yml \
+		config --format json > "$$tmpdir/compose.json"; \
+	python3 -c 'import json, sys; test = json.load(open(sys.argv[1]))["services"]["versiond"]["healthcheck"]["test"]; assert test[0] == "CMD-SHELL"; print(test[1].replace("$$$$", "$$"))' \
+		"$$tmpdir/compose.json" > "$$tmpdir/healthcheck.sh"; \
+	grep -q '/readyz' "$$tmpdir/healthcheck.sh" \
+		|| fail "rendered healthcheck does not probe readiness"; \
+	grep -q '/healthz' "$$tmpdir/healthcheck.sh" \
+		|| fail "rendered healthcheck has no legacy fallback"; \
+	printf '%s\n' \
+		'import http.server, os' \
+		'READY = int(os.environ["READY_STATUS"])' \
+		'HEALTHY = int(os.environ["HEALTH_STATUS"])' \
+		'class H(http.server.BaseHTTPRequestHandler):' \
+		'    def do_GET(self):' \
+		'        status = 200 if self.path == "/live" else READY if self.path == "/readyz" else HEALTHY if self.path == "/healthz" else 404' \
+		'        self.send_response(status)' \
+		'        self.send_header("Content-Length", "0")' \
+		'        self.end_headers()' \
+		'    def log_message(self, *args): pass' \
+		'http.server.ThreadingHTTPServer(("", 8080), H).serve_forever()' \
+		> "$$tmpdir/server.py"; \
+	start_server() { \
+		docker rm -f $$netns >/dev/null 2>&1 || true; \
+		docker run -d --name $$netns \
+			-e READY_STATUS="$$1" -e HEALTH_STATUS="$$2" \
+			-v "$$tmpdir/server.py:/server.py:ro" \
+			python:3.12-alpine python /server.py >/dev/null; \
+		for _ in $$(seq 40); do \
+			if docker run --rm --network container:$$netns \
+				--entrypoint /bin/busybox \
+				ghcr.io/product-science/versiond:0.2.15 \
+				wget -q -O /dev/null http://127.0.0.1:8080/live \
+				>/dev/null 2>&1; then \
+				return 0; \
+			fi; \
+			sleep 0.1; \
+		done; \
+		fail "mock server did not start"; \
+	}; \
+	run_healthcheck() { \
+		docker run --rm --network container:$$netns \
+			--entrypoint /bin/sh \
+			ghcr.io/product-science/versiond:0.2.15 \
+			-c "$$(cat "$$tmpdir/healthcheck.sh")"; \
+	}; \
+	start_server 200 503; \
+	run_healthcheck || fail "ready versiond was rejected"; \
+	start_server 503 200; \
+	if run_healthcheck >/dev/null 2>&1; then \
+		fail "readiness failure was hidden by the liveness fallback"; \
+	fi; \
+	start_server 404 200; \
+	run_healthcheck || fail "legacy versiond was rejected"; \
+	start_server 404 503; \
+	if run_healthcheck >/dev/null 2>&1; then \
+		fail "legacy liveness failure was accepted"; \
+	fi; \
+	echo 'test-join-versiond-healthcheck: ok'
 
 # Which versiond serves an escrow must depend on who is in the pool, not on the
 # order DNS happened to hand the addresses to server-template. That is invisible
@@ -1463,7 +1539,7 @@ test-version-routing:
 		|| fail "catalog reconciliation did not recover after clock rollback"; \
 	echo "test-version-routing: ok"
 
-test-render: test-local-compose test-join-compose test-catalog-cache test-hash-ring test-version-routing
+test-render: test-local-compose test-join-compose test-join-versiond-healthcheck test-catalog-cache test-hash-ring test-version-routing
 	@set -eu; \
 	tmpdir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmpdir"' EXIT; \

--- a/versiond-router/Makefile
+++ b/versiond-router/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build-docker release test-render
 .PHONY: test-catalog-cache test-hash-ring test-version-routing test-local-compose test-join-compose
-.PHONY: test-join-versiond-healthcheck
+.PHONY: test-join-versiond-healthcheck test-pool-status
 
 # Renders both the mixed (legacy pinning) and the all-HA shapes, asserts on the
 # result, then runs the real HAProxy from the production image over each one.
@@ -164,6 +164,9 @@ test-join-compose:
 
 test-catalog-cache:
 	@../router-runtime/catalog-cache_test.sh
+
+test-pool-status:
+	@./pool-status_test.sh
 
 # The join deployment temporarily supports both the pinned pre-/readyz image
 # and the replacement built from this release. A 404 means the endpoint does
@@ -1539,7 +1542,7 @@ test-version-routing:
 		|| fail "catalog reconciliation did not recover after clock rollback"; \
 	echo "test-version-routing: ok"
 
-test-render: test-local-compose test-join-compose test-join-versiond-healthcheck test-catalog-cache test-hash-ring test-version-routing
+test-render: test-local-compose test-join-compose test-join-versiond-healthcheck test-catalog-cache test-pool-status test-hash-ring test-version-routing
 	@set -eu; \
 	tmpdir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmpdir"' EXIT; \

--- a/versiond-router/Makefile
+++ b/versiond-router/Makefile
@@ -32,6 +32,8 @@ test-local-compose:
 	jq -e '(.services["versiond-router"] | has("stop_signal") | not) and .services["versiond-router"].stop_grace_period == "10s"' \
 		"$$tmp_json" >/dev/null \
 		|| { echo 'test-local-compose: Compose overrides the image stop signal or loses the bounded grace' >&2; exit 1; }; \
+	grep -q 'stop_grace_period: 30m0s' "$$tmp" \
+		|| { echo 'test-local-compose: versiond drain backstop is missing' >&2; exit 1; }; \
 	echo 'test-local-compose: ok'
 
 test-join-compose:

--- a/versiond-router/pool-status
+++ b/versiond-router/pool-status
@@ -25,27 +25,41 @@ runtime() {
     printf '%s\n' "$1" | socat stdio "$SOCK"
 }
 
+stats_raw=$(mktemp)
 stats_file=$(mktemp)
-trap 'rm -f "$stats_file"' EXIT
+backends_file=$(mktemp)
+backend_names_file=$(mktemp)
+servers_file=$(mktemp)
+trap 'rm -f "$stats_raw" "$stats_file" "$backends_file" "$backend_names_file" "$servers_file"' EXIT
+
+runtime_to_file() {
+    command=$1
+    target=$2
+    if ! runtime "$command" > "$target"; then
+        echo "pool-status: HAProxy Runtime API command failed: $command" >&2
+        return 1
+    fi
+}
+
 # `show servers state` preserves DNS/runtime administrative flags that do not
 # by themselves say whether HAProxy is sending traffic to a server. In
 # particular, a dynamically enabled server may remain marked with the DNS
 # runtime-maintenance bit while `show stat` correctly reports it as UP.
-runtime "show stat" | awk -F, 'NR > 1 && $2 != "BACKEND" {
+runtime_to_file "show stat" "$stats_raw"
+if ! grep -q '^# pxname,svname,' "$stats_raw"; then
+    echo "pool-status: HAProxy Runtime API returned invalid show stat output" >&2
+    exit 1
+fi
+awk -F, 'NR > 1 && $2 != "BACKEND" {
     print $1 "\t" $2 "\t" $18
-}' > "$stats_file"
+}' "$stats_raw" > "$stats_file"
 
-backends() {
-    runtime "show backend" | grep -v '^#' | grep -v '^$'
-}
+runtime_to_file "show backend" "$backends_file"
+awk '!/^#/ && NF { print $1 }' "$backends_file" > "$backend_names_file"
 
 # `show servers state` supplies the resolved address, which is not populated in
 # the stats CSV for DNS server-template entries. Slots a DNS answer has never
 # filled carry no address and are skipped.
-servers() {
-    runtime "show servers state $1" | awk 'NR > 2 && NF > 7 && $5 != "-"'
-}
-
 serving_count() {
     awk -F '\t' -v backend="$1" '
         $1 == backend && $3 ~ /^UP/ { n++ }
@@ -53,9 +67,10 @@ serving_count() {
     ' "$stats_file"
 }
 
-for backend in $(backends); do
+while IFS= read -r backend; do
+    runtime_to_file "show servers state $backend" "$servers_file"
     printf '%s\n' "$backend"
-    servers "$backend" | awk -v backend="$backend" -v stats_file="$stats_file" '
+    awk -v backend="$backend" -v stats_file="$stats_file" '
     BEGIN {
         while ((getline line < stats_file) > 0) {
             split(line, fields, "\t")
@@ -69,6 +84,6 @@ for backend in $(backends); do
         else if (current ~ /^(DRAIN|MAINT|NOLB)/)   state = "DRAIN"
         else                                         state = "DOWN"
         print "  " $4 "\t" $5 "\t" state
-    }'
+    }' "$servers_file"
     printf '  %s server(s) taking traffic\n' "$(serving_count "$backend")"
-done
+done < "$backend_names_file"

--- a/versiond-router/pool-status
+++ b/versiond-router/pool-status
@@ -25,27 +25,49 @@ runtime() {
     printf '%s\n' "$1" | socat stdio "$SOCK"
 }
 
+stats_file=$(mktemp)
+trap 'rm -f "$stats_file"' EXIT
+# `show servers state` preserves DNS/runtime administrative flags that do not
+# by themselves say whether HAProxy is sending traffic to a server. In
+# particular, a dynamically enabled server may remain marked with the DNS
+# runtime-maintenance bit while `show stat` correctly reports it as UP.
+runtime "show stat" | awk -F, 'NR > 1 && $2 != "BACKEND" {
+    print $1 "\t" $2 "\t" $18
+}' > "$stats_file"
+
 backends() {
     runtime "show backend" | grep -v '^#' | grep -v '^$'
 }
 
-# `show servers state` columns: 4 = srv_name, 5 = srv_addr, 6 = srv_op_state
-# (2 means UP), 7 = srv_admin_state. Slots a DNS answer has never filled carry no
-# address and are skipped.
+# `show servers state` supplies the resolved address, which is not populated in
+# the stats CSV for DNS server-template entries. Slots a DNS answer has never
+# filled carry no address and are skipped.
 servers() {
     runtime "show servers state $1" | awk 'NR > 2 && NF > 7 && $5 != "-"'
 }
 
 serving_count() {
-    servers "$1" | awk '$6 == 2 && $7 == 0 { n++ } END { print n + 0 }'
+    awk -F '\t' -v backend="$1" '
+        $1 == backend && $3 ~ /^UP/ { n++ }
+        END { print n + 0 }
+    ' "$stats_file"
 }
 
 for backend in $(backends); do
     printf '%s\n' "$backend"
-    servers "$backend" | awk '{
-        if ($7 != 0)      state = "DRAIN"
-        else if ($6 == 2) state = "UP"
-        else              state = "DOWN"
+    servers "$backend" | awk -v backend="$backend" -v stats_file="$stats_file" '
+    BEGIN {
+        while ((getline line < stats_file) > 0) {
+            split(line, fields, "\t")
+            if (fields[1] == backend) status[fields[2]] = fields[3]
+        }
+        close(stats_file)
+    }
+    {
+        current = status[$4]
+        if (current ~ /^UP/)                         state = "UP"
+        else if (current ~ /^(DRAIN|MAINT|NOLB)/)   state = "DRAIN"
+        else                                         state = "DOWN"
         print "  " $4 "\t" $5 "\t" state
     }'
     printf '  %s server(s) taking traffic\n' "$(serving_count "$backend")"

--- a/versiond-router/pool-status_test.sh
+++ b/versiond-router/pool-status_test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir "$TMPDIR/bin"
+cat > "$TMPDIR/bin/socat" <<'EOF'
+#!/bin/sh
+set -eu
+command=$(cat)
+if [ "$command" = "${FAIL_COMMAND:-}" ]; then
+    exit 1
+fi
+case "$command" in
+    "show stat")
+        printf '%s\n' '# pxname,svname,status'
+        awk 'BEGIN {
+            printf "versiond_ha_pool,versiond-pool1"
+            for (field = 3; field < 18; field++) printf ","
+            print ",UP"
+        }'
+        ;;
+    "show backend")
+        printf '%s\n' '# name' 'versiond_ha_pool'
+        ;;
+    "show servers state versiond_ha_pool")
+        printf '%s\n' '# header' '# fields' \
+            '1 2 3 versiond-pool1 192.0.2.10 6 7 8'
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$TMPDIR/bin/socat"
+
+PATH="$TMPDIR/bin:$PATH" HAPROXY_SOCKET=unused \
+    "$ROOT/pool-status" > "$TMPDIR/status"
+grep -q "versiond-pool1.*192.0.2.10.*UP" "$TMPDIR/status"
+grep -q '1 server(s) taking traffic' "$TMPDIR/status"
+
+for command in "show stat" "show backend" "show servers state versiond_ha_pool"; do
+    if PATH="$TMPDIR/bin:$PATH" HAPROXY_SOCKET=unused FAIL_COMMAND="$command" \
+        "$ROOT/pool-status" > /dev/null 2>&1; then
+        echo "pool-status accepted failed Runtime API command: $command" >&2
+        exit 1
+    fi
+done
+
+echo "pool-status_test: ok"

--- a/versioned/cmd/versiond/main.go
+++ b/versioned/cmd/versiond/main.go
@@ -255,6 +255,7 @@ type hostShutdownManager interface {
 	RequestChildrenDrain(context.Context) error
 	WaitChildrenIdle(context.Context) error
 	Shutdown(context.Context) error
+	ShutdownGrace() time.Duration
 	ForceStopChildren()
 }
 
@@ -277,18 +278,21 @@ func shutdownHost(
 	if forceRequested(force) {
 		cancelShutdown()
 	}
+	drainDeadline := deadline.Add(-mgr.ShutdownGrace())
+	drainCtx, cancelDrain := context.WithDeadline(shutdownCtx, drainDeadline)
 	stopForceWatch := cancelOnSignal(shutdownCtx, cancelShutdown, force)
 	stopEscalationWatch := watchShutdownEscalation(shutdownCtx, srv, mgr, hostLifecycle)
 	defer func() {
 		stopEscalationWatch()
 		stopForceWatch()
+		cancelDrain()
 		cancelShutdown()
 	}()
 
 	if err := waitForPollWorker(
-		shutdownCtx,
+		drainCtx,
 		pollDone,
-		pollWorkerUnwindBudget(time.Until(deadline)),
+		pollWorkerUnwindBudget(time.Until(drainDeadline)),
 	); err != nil {
 		// BeginHostDrain already prevents new generation commits and disables
 		// child restart. Teardown can therefore continue without trusting a
@@ -296,7 +300,7 @@ func shutdownHost(
 		switch {
 		case errors.Is(err, context.DeadlineExceeded):
 			slog.Warn(
-				"host shutdown budget exhausted before poll worker unwound; continuing teardown",
+				"host drain budget exhausted before poll worker unwound; continuing teardown",
 				"error", err,
 			)
 		case errors.Is(err, context.Canceled):
@@ -312,14 +316,14 @@ func shutdownHost(
 		}
 	}
 
-	if err := hostLifecycle.WaitIdle(shutdownCtx); err != nil {
+	if err := hostLifecycle.WaitIdle(drainCtx); err != nil {
 		slog.Warn("host proxy drain incomplete", "error", err, "inflight", hostLifecycle.Snapshot().Inflight)
 	}
-	if shutdownCtx.Err() == nil {
-		if err := mgr.RequestChildrenDrain(shutdownCtx); err != nil {
+	if drainCtx.Err() == nil {
+		if err := mgr.RequestChildrenDrain(drainCtx); err != nil {
 			slog.Warn("one or more child drain requests failed", "error", err)
 		}
-		if err := mgr.WaitChildrenIdle(shutdownCtx); err != nil {
+		if err := mgr.WaitChildrenIdle(drainCtx); err != nil {
 			slog.Warn("child drain incomplete", "error", err)
 		}
 	}

--- a/versioned/cmd/versiond/main.go
+++ b/versioned/cmd/versiond/main.go
@@ -2,22 +2,29 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
 	"versioned/internal/config"
 	"versioned/internal/health"
+	"versioned/internal/host"
 	"versioned/internal/oracle"
 	"versioned/internal/process"
 	"versioned/internal/proxy"
 	"versioned/internal/sessionversion"
 )
+
+const maxPollWorkerUnwindWait = 5 * time.Second
+
+var errPollWorkerUnwindTimeout = errors.New("poll worker unwind timeout")
 
 func main() {
 	if err := run(context.Background()); err != nil {
@@ -37,10 +44,15 @@ func run(ctx context.Context) error {
 		"VERSIOND_BINARY_NAME", os.Getenv("VERSIOND_BINARY_NAME"),
 	)
 
-	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
-	defer cancel()
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(signals)
+
+	pollCtx, cancelPoll := context.WithCancel(ctx)
+	defer cancelPoll()
 
 	mgr := process.NewManager(cfg)
+	hostLifecycle := host.NewController()
 	oracleClient := oracle.NewClient(cfg.OracleURL)
 
 	lookup, err := sessionversion.OpenFromEnv(ctx)
@@ -52,24 +64,21 @@ func run(ctx context.Context) error {
 		defer lookup.Close()
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", health.Handler(mgr.Status))
 	var proxyOpts []proxy.HandlerOption
 	if lookup != nil {
 		proxyOpts = append(proxyOpts, proxy.WithSessionVersionLookup(lookup))
 	}
-	mux.Handle("/", proxy.Handler(mgr.RouteTable(), proxyOpts...))
 
 	listenAddr := config.ListenAddr()
 	srv := &http.Server{
 		Addr:    listenAddr,
-		Handler: mux,
+		Handler: publicHandler(mgr, hostLifecycle, proxyOpts...),
 	}
-
 	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", listenAddr, err)
 	}
+	defer srv.Close()
 	go func() {
 		slog.Info("starting proxy server", "addr", listenAddr)
 		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
@@ -77,55 +86,498 @@ func run(ctx context.Context) error {
 		}
 	}()
 
-	// Initial fetch + reconcile
-	if versions, err := oracleClient.Fetch(ctx); err != nil {
-		slog.Error("initial oracle fetch failed", "error", err)
-	} else if err := mgr.Reconcile(ctx, versions.Versions); err != nil {
-		slog.Error("initial reconcile failed", "error", err)
-	}
+	go promoteHostWhenAvailable(pollCtx, mgr, hostLifecycle)
 
-	// Poll loop
+	pollDone := make(chan struct{})
 	go func() {
-		ticker := time.NewTicker(cfg.PollInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				versions, err := oracleClient.Fetch(ctx)
-				if err != nil {
-					slog.Error("oracle fetch failed, keeping current versions", "error", err)
-					continue
-				}
-				// Guard against empty responses killing all running children.
-				// An empty version list from the API is likely a misconfiguration,
-				// not an intentional "stop everything" signal.
-				if len(versions.Versions) == 0 && len(mgr.Status()) > 0 {
-					slog.Warn("oracle returned empty version list, keeping current versions")
-					continue
-				}
-				if err := mgr.Reconcile(ctx, versions.Versions); err != nil {
-					slog.Error("reconcile failed", "error", err)
-				}
-			}
-		}
+		defer close(pollDone)
+		runPollLoop(pollCtx, cfg.PollInterval, oracleClient, mgr)
 	}()
 
-	<-ctx.Done()
-	slog.Info("shutting down")
-
-	httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer httpShutdownCancel()
-	if err := srv.Shutdown(httpShutdownCtx); err != nil {
-		slog.Warn("http server shutdown incomplete", "error", err)
+	select {
+	case <-ctx.Done():
+		slog.Info("host shutdown requested", "reason", ctx.Err())
+	case sig := <-signals:
+		slog.Info("host shutdown requested", "signal", sig.String())
 	}
 
-	managerShutdownCtx, managerShutdownCancel := context.WithTimeout(context.Background(), mgr.ShutdownTimeout())
-	defer managerShutdownCancel()
-	if err := mgr.Shutdown(managerShutdownCtx); err != nil {
-		slog.Warn("manager shutdown incomplete", "error", err)
+	force := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	go watchForceSignals(signals, shutdownDone, force)
+	defer close(shutdownDone)
+
+	// The one absolute deadline starts at the signal: the announce window spends
+	// from the same budget as poll unwind, admission drain, child stop and HTTP
+	// shutdown, exactly as the shutdown contract states — not in addition to it.
+	budget := cfg.HostShutdownBudget
+	if budget <= 0 {
+		budget = config.DefaultHostShutdownBudget
+	}
+	shutdownDeadline := time.Now().Add(budget)
+
+	if err := beginHostDrain(
+		cfg.DrainAnnounce,
+		mgr,
+		hostLifecycle,
+		force,
+		cancelPoll,
+	); err != nil {
+		return err
 	}
 
+	return shutdownHost(srv, mgr, hostLifecycle, force, pollDone, shutdownDeadline)
+}
+
+func runPollLoop(
+	ctx context.Context,
+	interval time.Duration,
+	oracleClient *oracle.Client,
+	mgr *process.Manager,
+) {
+	reconcileOnce(ctx, oracleClient, mgr)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reconcileOnce(ctx, oracleClient, mgr)
+		}
+	}
+}
+
+func reconcileOnce(ctx context.Context, oracleClient *oracle.Client, mgr *process.Manager) {
+	versions, err := oracleClient.Fetch(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			mgr.ReportReconcileError(fmt.Errorf("oracle fetch: %w", err))
+			slog.Error("oracle fetch failed, keeping current versions", "error", err)
+		}
+		return
+	}
+	// An empty API response is treated as an upstream fault while this host owns
+	// children. Intentional removals still arrive as a non-empty desired set.
+	if len(versions.Versions) == 0 && len(mgr.Status()) > 0 {
+		mgr.ReportReconcileError(errors.New("oracle returned an empty version list"))
+		slog.Warn("oracle returned empty version list, keeping current versions")
+		return
+	}
+	if err := mgr.Reconcile(ctx, versions.Versions); err != nil &&
+		!errors.Is(err, process.ErrHostDraining) && ctx.Err() == nil {
+		slog.Error("reconcile failed", "error", err)
+	}
+}
+
+type hostAvailabilityProvider interface {
+	Available() <-chan struct{}
+	Conditions() process.Conditions
+}
+
+func promoteHostWhenAvailable(
+	ctx context.Context,
+	mgr hostAvailabilityProvider,
+	hostLifecycle *host.Controller,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-mgr.Available():
+		}
+		if !mgr.Conditions().Available {
+			continue
+		}
+		// Promotion and BeginDrain race under the controller lock. If drain won,
+		// promotion is an expected no-op rather than a failed transition.
+		hostLifecycle.Promote()
+		return
+	}
+}
+
+type hostDrainManager interface {
+	BeginHostDrain()
+}
+
+// beginHostDrain is the load-balancer handoff above the shutdown machinery.
+// A serving host first becomes unready while admission remains open, freezes
+// reconcile, and waits for the router to observe that state. Only then does it
+// close admission. A host that never served skips the announce window.
+func beginHostDrain(
+	announce time.Duration,
+	mgr hostDrainManager,
+	hostLifecycle *host.Controller,
+	force <-chan struct{},
+	cancelPoll context.CancelFunc,
+) error {
+	// Choosing announcing versus direct drain must be atomic with availability
+	// promotion, or a starting host could become serving after shutdown begins.
+	announcing, err := hostLifecycle.BeginDrain()
+	if err != nil {
+		return err
+	}
+	// Freeze desired-state changes and cancel every active generation operation.
+	// Child process contexts stay alive until the drain phase stops or forces them.
+	mgr.BeginHostDrain()
+	cancelPoll()
+	if announcing {
+		awaitDrainAnnouncement(announce, force)
+		return hostLifecycle.Transition(host.StateDraining)
+	}
 	return nil
+}
+
+func watchForceSignals(signals <-chan os.Signal, shutdownDone <-chan struct{}, force chan<- struct{}) {
+	for {
+		select {
+		case sig := <-signals:
+			if channelClosed(shutdownDone) {
+				return
+			}
+			if !shouldForceShutdown(sig) {
+				slog.Warn("duplicate SIGTERM ignored while host is draining")
+				continue
+			}
+			slog.Warn("forcing host shutdown after interrupt", "signal", sig.String())
+			close(force)
+			return
+		case <-shutdownDone:
+			return
+		}
+	}
+}
+
+func shouldForceShutdown(sig os.Signal) bool {
+	return sig != syscall.SIGTERM
+}
+
+type hostShutdownManager interface {
+	RequestChildrenDrain(context.Context) error
+	WaitChildrenIdle(context.Context) error
+	Shutdown(context.Context) error
+	ForceStopChildren()
+}
+
+type hostHTTPServer interface {
+	Shutdown(context.Context) error
+	Close() error
+}
+
+func shutdownHost(
+	srv hostHTTPServer,
+	mgr hostShutdownManager,
+	hostLifecycle *host.Controller,
+	force <-chan struct{},
+	pollDone <-chan struct{},
+	deadline time.Time,
+) error {
+	// The deadline was fixed when the shutdown signal arrived; whatever the
+	// announce window consumed is already gone from it.
+	shutdownCtx, cancelShutdown := context.WithDeadline(context.Background(), deadline)
+	if forceRequested(force) {
+		cancelShutdown()
+	}
+	stopForceWatch := cancelOnSignal(shutdownCtx, cancelShutdown, force)
+	stopEscalationWatch := watchShutdownEscalation(shutdownCtx, srv, mgr, hostLifecycle)
+	defer func() {
+		stopEscalationWatch()
+		stopForceWatch()
+		cancelShutdown()
+	}()
+
+	if err := waitForPollWorker(
+		shutdownCtx,
+		pollDone,
+		pollWorkerUnwindBudget(time.Until(deadline)),
+	); err != nil {
+		// BeginHostDrain already prevents new generation commits and disables
+		// child restart. Teardown can therefore continue without trusting a
+		// reconcile implementation to honor cancellation forever.
+		switch {
+		case errors.Is(err, context.DeadlineExceeded):
+			slog.Warn(
+				"host shutdown budget exhausted before poll worker unwound; continuing teardown",
+				"error", err,
+			)
+		case errors.Is(err, context.Canceled):
+			slog.Warn(
+				"host shutdown was forced before poll worker unwound; continuing teardown",
+				"error", err,
+			)
+		default:
+			slog.Warn(
+				"poll worker did not unwind within its allowance; continuing teardown",
+				"error", err,
+			)
+		}
+	}
+
+	if err := hostLifecycle.WaitIdle(shutdownCtx); err != nil {
+		slog.Warn("host proxy drain incomplete", "error", err, "inflight", hostLifecycle.Snapshot().Inflight)
+	}
+	if shutdownCtx.Err() == nil {
+		if err := mgr.RequestChildrenDrain(shutdownCtx); err != nil {
+			slog.Warn("one or more child drain requests failed", "error", err)
+		}
+		if err := mgr.WaitChildrenIdle(shutdownCtx); err != nil {
+			slog.Warn("child drain incomplete", "error", err)
+		}
+	}
+
+	forced := shutdownCtx.Err() != nil
+	if forced {
+		if err := transitionHostToForcing(hostLifecycle); err != nil {
+			return err
+		}
+	} else if err := hostLifecycle.Transition(host.StateStopping); err != nil {
+		return err
+	}
+
+	httpDone := make(chan error, 1)
+	go func() {
+		httpDone <- srv.Shutdown(shutdownCtx)
+	}()
+	managerErr := mgr.Shutdown(shutdownCtx)
+	httpErr := <-httpDone
+	if shutdownCtx.Err() != nil {
+		forced = true
+		if err := transitionHostToForcing(hostLifecycle); err != nil {
+			return err
+		}
+	}
+	if managerErr != nil {
+		slog.Warn("manager shutdown required forced escalation", "error", managerErr)
+	}
+	if httpErr != nil {
+		if !forced {
+			return fmt.Errorf("shutdown HTTP servers: %w", httpErr)
+		}
+		slog.Warn("HTTP server shutdown required forced close", "error", httpErr)
+	}
+	if err := hostLifecycle.Transition(host.StateStopped); err != nil {
+		return err
+	}
+	return nil
+}
+
+func pollWorkerUnwindBudget(hostBudget time.Duration) time.Duration {
+	wait := hostBudget / 10
+	if wait <= 0 {
+		return 0
+	}
+	if wait > maxPollWorkerUnwindWait {
+		return maxPollWorkerUnwindWait
+	}
+	return wait
+}
+
+func waitForPollWorker(
+	ctx context.Context,
+	pollDone <-chan struct{},
+	timeout time.Duration,
+) error {
+	select {
+	case <-pollDone:
+		return nil
+	default:
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if timeout <= 0 {
+		return fmt.Errorf("%w: no wait budget remains", errPollWorkerUnwindTimeout)
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-pollDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return fmt.Errorf("%w after %s", errPollWorkerUnwindTimeout, timeout)
+	}
+}
+
+func readinessHandler(mgr *process.Manager, hostLifecycle *host.Controller) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		hostStatus := hostLifecycle.Snapshot()
+		// ?version=<name> asks the precise question the router wants answered
+		// before it sends a request: can you serve *this* version. Without it the
+		// answer is the coarse host-level one.
+		if version := r.URL.Query().Get("version"); version != "" {
+			if !versiondReadyForVersion(hostStatus, mgr, version) {
+				http.Error(w, "no route for version "+version, http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ready\n"))
+			return
+		}
+		if !versiondReady(hostStatus, mgr.Conditions()) {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready\n"))
+	}
+}
+
+func publicHandler(
+	mgr *process.Manager,
+	hostLifecycle *host.Controller,
+	proxyOpts ...proxy.HandlerOption,
+) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", health.Handler(mgr.Status))
+	mux.HandleFunc("/readyz", readinessHandler(mgr, hostLifecycle))
+	mux.Handle(
+		"/",
+		hostLifecycle.Admission(proxy.Handler(mgr.RouteTable(), proxyOpts...)),
+	)
+	return mux
+}
+
+// versiondReady answers the load balancer's question — may this host take new
+// traffic right now — and deliberately not "did the last control-plane poll
+// succeed".
+//
+// The difference matters because every versiond reads the same oracle. Anything
+// that gates readiness on the outcome of that read is a fleet-wide correlated
+// failure: one unreachable oracle, or one bad archive, and every host leaves the
+// pool at the same instant while their children are still running and perfectly
+// able to serve. Reconciliation failures are therefore reported through
+// Conditions.Degraded and the logs, and are not a readiness gate.
+//
+// For the same reason Converged is a latch rather than a live check: requiring
+// convergence would evict the whole pool on a routine same-name SHA bump,
+// because every host starts downloading at once. A host that has never run its
+// desired set stays out of rotation; a later download does not retract
+// readiness.
+//
+// This host-level answer is necessarily coarse: it cannot say that one version
+// out of several is missing here. versiondReadyForVersion answers that precisely
+// and the router asks it per version, so this is the fallback for a version the
+// router has not been told about.
+// Serving is deliberately "at least one live-ready child", not "every child":
+// a version whose children went unready everywhere at once — the correlated
+// case — would otherwise empty the pool and take the healthy versions with it.
+// Per-version pools are the precise tool for a single broken version; this
+// coarse answer only has to be honest about "can this host serve anything".
+func versiondReady(hostStatus host.Snapshot, conditions process.Conditions) bool {
+	return hostStatus.Ready &&
+		hostStatus.Accepting &&
+		conditions.Available &&
+		conditions.Serving &&
+		conditions.Converged
+}
+
+// versiondReadyForVersion answers "may this host take traffic for this one
+// version", which is the question a balancer actually has when it is about to
+// route a request. It needs no convergence latch and no view of the desired set:
+// either a running child serves that version here or it does not, and a host
+// missing one version keeps serving every other.
+//
+// The host-level gates still apply. Draining has to make every version unready
+// at once, or the announce window would not empty the host.
+func versiondReadyForVersion(
+	hostStatus host.Snapshot,
+	mgr interface{ ServesVersion(string) bool },
+	version string,
+) bool {
+	return hostStatus.Ready &&
+		hostStatus.Accepting &&
+		mgr.ServesVersion(version)
+}
+
+// awaitDrainAnnouncement keeps serving while the balancer observes the failing
+// health check. An explicit force signal cuts it short.
+func awaitDrainAnnouncement(window time.Duration, force <-chan struct{}) {
+	if window <= 0 {
+		return
+	}
+	timer := time.NewTimer(window)
+	defer timer.Stop()
+	slog.Info("announcing drain; still serving accepted traffic", "window", window)
+	select {
+	case <-force:
+	case <-timer.C:
+	}
+}
+
+func watchShutdownEscalation(
+	ctx context.Context,
+	srv hostHTTPServer,
+	mgr hostShutdownManager,
+	hostLifecycle *host.Controller,
+) func() {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			if channelClosed(done) {
+				return
+			}
+			slog.Warn(
+				"host shutdown escalation requested",
+				"reason", ctx.Err(),
+				"proxy_inflight", hostLifecycle.Snapshot().Inflight,
+			)
+			mgr.ForceStopChildren()
+			_ = srv.Close()
+		case <-done:
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() { close(done) })
+	}
+}
+
+func channelClosed(done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
+}
+
+func transitionHostToForcing(hostLifecycle *host.Controller) error {
+	state := hostLifecycle.Snapshot().State
+	if state == host.StateForcing || state == host.StateStopped {
+		return nil
+	}
+	return hostLifecycle.Transition(host.StateForcing)
+}
+
+func cancelOnSignal(parent context.Context, cancel context.CancelFunc, signal <-chan struct{}) func() {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-signal:
+			cancel()
+		case <-parent.Done():
+		case <-done:
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() { close(done) })
+	}
+}
+
+func forceRequested(force <-chan struct{}) bool {
+	select {
+	case <-force:
+		return true
+	default:
+		return false
+	}
 }

--- a/versioned/cmd/versiond/main.go
+++ b/versioned/cmd/versiond/main.go
@@ -281,7 +281,12 @@ func shutdownHost(
 	drainDeadline := deadline.Add(-mgr.ShutdownGrace())
 	drainCtx, cancelDrain := context.WithDeadline(shutdownCtx, drainDeadline)
 	stopForceWatch := cancelOnSignal(shutdownCtx, cancelShutdown, force)
-	stopEscalationWatch := watchShutdownEscalation(shutdownCtx, srv, mgr, hostLifecycle)
+	forceShutdown, stopEscalationWatch := watchShutdownEscalation(
+		shutdownCtx,
+		srv,
+		mgr,
+		hostLifecycle,
+	)
 	defer func() {
 		stopEscalationWatch()
 		stopForceWatch()
@@ -330,6 +335,7 @@ func shutdownHost(
 
 	forced := shutdownCtx.Err() != nil
 	if forced {
+		forceShutdown()
 		if err := transitionHostToForcing(hostLifecycle); err != nil {
 			return err
 		}
@@ -345,6 +351,7 @@ func shutdownHost(
 	httpErr := <-httpDone
 	if shutdownCtx.Err() != nil {
 		forced = true
+		forceShutdown()
 		if err := transitionHostToForcing(hostLifecycle); err != nil {
 			return err
 		}
@@ -520,14 +527,11 @@ func watchShutdownEscalation(
 	srv hostHTTPServer,
 	mgr hostShutdownManager,
 	hostLifecycle *host.Controller,
-) func() {
+) (force func(), stop func()) {
 	done := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-			if channelClosed(done) {
-				return
-			}
+	var forceOnce sync.Once
+	force = func() {
+		forceOnce.Do(func() {
 			slog.Warn(
 				"host shutdown escalation requested",
 				"reason", ctx.Err(),
@@ -535,13 +539,23 @@ func watchShutdownEscalation(
 			)
 			mgr.ForceStopChildren()
 			_ = srv.Close()
+		})
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			if channelClosed(done) {
+				return
+			}
+			force()
 		case <-done:
 		}
 	}()
-	var once sync.Once
-	return func() {
-		once.Do(func() { close(done) })
+	var stopOnce sync.Once
+	stop = func() {
+		stopOnce.Do(func() { close(done) })
 	}
+	return force, stop
 }
 
 func channelClosed(done <-chan struct{}) bool {

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -881,9 +881,9 @@ func TestVersiondReadyTracksTrafficCapacityNotConvergence(t *testing.T) {
 		t.Fatal("serving host with a running child is not ready")
 	}
 
-	// A child process can exist while unable to take a request — devshardd
-	// reports itself unready when its chain subscription drops. Available alone
-	// must not keep the host in the pool.
+	// A child process can exist while unable to take a request, for example when
+	// its storage is unavailable. Available alone must not keep the host in the
+	// pool.
 	conditions.Serving = false
 	if versiondReady(status, conditions) {
 		t.Fatal("host whose children are running but not live-ready is ready")

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -22,6 +22,7 @@ type fakeHostShutdownManager struct {
 	calls            []string
 	waitChildrenIdle func(context.Context) error
 	shutdown         func(context.Context) error
+	shutdownGrace    time.Duration
 	forceCalled      chan struct{}
 	forceOnce        sync.Once
 }
@@ -105,6 +106,10 @@ func (m *fakeHostShutdownManager) Shutdown(ctx context.Context) error {
 		return m.shutdown(ctx)
 	}
 	return nil
+}
+
+func (m *fakeHostShutdownManager) ShutdownGrace() time.Duration {
+	return m.shutdownGrace
 }
 
 func (m *fakeHostShutdownManager) ForceStopChildren() {
@@ -769,6 +774,60 @@ func TestShutdownHostWaitsForChildIdleBeforeManagerShutdown(t *testing.T) {
 	)
 	if got := hostLifecycle.Snapshot().State; got != host.StateStopped {
 		t.Fatalf("host state = %s, want stopped", got)
+	}
+}
+
+func TestShutdownHostReservesChildTerminationGrace(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatal(err)
+	}
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	mgr := newFakeHostShutdownManager()
+	mgr.shutdownGrace = 10 * time.Minute
+	drainDeadline := make(chan time.Time, 1)
+	shutdownDeadline := make(chan time.Time, 1)
+	mgr.waitChildrenIdle = func(ctx context.Context) error {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("child drain context has no deadline")
+		}
+		drainDeadline <- deadline
+		return nil
+	}
+	mgr.shutdown = func(ctx context.Context) error {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("manager shutdown context has no deadline")
+		}
+		shutdownDeadline <- deadline
+		return nil
+	}
+	force := make(chan struct{})
+	pollDone := make(chan struct{})
+	close(pollDone)
+	outerDeadline := time.Now().Add(time.Hour)
+
+	if err := shutdownHost(
+		server.Config,
+		mgr,
+		hostLifecycle,
+		force,
+		pollDone,
+		outerDeadline,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := <-drainDeadline; !got.Equal(outerDeadline.Add(-mgr.shutdownGrace)) {
+		t.Fatalf("drain deadline = %s, want %s", got, outerDeadline.Add(-mgr.shutdownGrace))
+	}
+	if got := <-shutdownDeadline; !got.Equal(outerDeadline) {
+		t.Fatalf("shutdown deadline = %s, want %s", got, outerDeadline)
 	}
 }
 

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -1,0 +1,1129 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"versioned/internal/config"
+	"versioned/internal/host"
+	"versioned/internal/process"
+)
+
+type fakeHostShutdownManager struct {
+	mu               sync.Mutex
+	calls            []string
+	waitChildrenIdle func(context.Context) error
+	shutdown         func(context.Context) error
+	forceCalled      chan struct{}
+	forceOnce        sync.Once
+}
+
+func newFakeHostShutdownManager() *fakeHostShutdownManager {
+	return &fakeHostShutdownManager{forceCalled: make(chan struct{})}
+}
+
+type fakeHostDrainManager struct {
+	beginOnce sync.Once
+	began     chan struct{}
+}
+
+func newFakeHostDrainManager() *fakeHostDrainManager {
+	return &fakeHostDrainManager{began: make(chan struct{})}
+}
+
+func (m *fakeHostDrainManager) BeginHostDrain() {
+	m.beginOnce.Do(func() { close(m.began) })
+}
+
+type fakeHostAvailabilityProvider struct {
+	available  chan struct{}
+	conditions process.Conditions
+}
+
+type blockingHostDrainManager struct {
+	began   chan struct{}
+	release chan struct{}
+}
+
+func (m *blockingHostDrainManager) BeginHostDrain() {
+	close(m.began)
+	<-m.release
+}
+
+type racingHostHTTPServer struct {
+	shutdownStarted chan struct{}
+	release         <-chan struct{}
+	startOnce       sync.Once
+}
+
+func (s *racingHostHTTPServer) Shutdown(ctx context.Context) error {
+	s.startOnce.Do(func() { close(s.shutdownStarted) })
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *racingHostHTTPServer) Close() error {
+	return nil
+}
+
+func (p *fakeHostAvailabilityProvider) Available() <-chan struct{} {
+	return p.available
+}
+
+func (p *fakeHostAvailabilityProvider) Conditions() process.Conditions {
+	return p.conditions
+}
+
+func (m *fakeHostShutdownManager) RequestChildrenDrain(context.Context) error {
+	m.record("request_children_drain")
+	return nil
+}
+
+func (m *fakeHostShutdownManager) WaitChildrenIdle(ctx context.Context) error {
+	m.record("wait_children_idle")
+	if m.waitChildrenIdle != nil {
+		return m.waitChildrenIdle(ctx)
+	}
+	return nil
+}
+
+func (m *fakeHostShutdownManager) Shutdown(ctx context.Context) error {
+	m.record("shutdown")
+	if m.shutdown != nil {
+		return m.shutdown(ctx)
+	}
+	return nil
+}
+
+func (m *fakeHostShutdownManager) ForceStopChildren() {
+	m.record("force_stop_children")
+	m.forceOnce.Do(func() {
+		close(m.forceCalled)
+	})
+}
+
+func (m *fakeHostShutdownManager) record(call string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, call)
+}
+
+func (m *fakeHostShutdownManager) callLog() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return strings.Join(m.calls, "\n")
+}
+
+func TestBeginHostDrainAnnouncesBeforeClosingAdmission(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatal(err)
+	}
+	mgr := newFakeHostDrainManager()
+	pollCtx, cancelPoll := context.WithCancel(context.Background())
+	force := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		result <- beginHostDrain(
+			time.Hour,
+			mgr,
+			hostLifecycle,
+			force,
+			cancelPoll,
+		)
+	}()
+
+	select {
+	case <-mgr.began:
+	case <-time.After(time.Second):
+		t.Fatal("manager drain barrier was not raised")
+	}
+	select {
+	case <-pollCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("poll loop was not canceled before the announce wait")
+	}
+
+	snapshot := hostLifecycle.Snapshot()
+	if snapshot.State != host.StateAnnouncing || snapshot.Ready || !snapshot.Accepting {
+		t.Fatalf("announce snapshot = %+v, want unready and accepting", snapshot)
+	}
+	response := httptest.NewRecorder()
+	hostLifecycle.Admission(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/v1", nil))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("announce admission status = %d, want %d", response.Code, http.StatusNoContent)
+	}
+
+	select {
+	case err := <-result:
+		t.Fatalf("announce window ended early: %v", err)
+	default:
+	}
+	close(force)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("host did not enter draining after the announce window")
+	}
+	snapshot = hostLifecycle.Snapshot()
+	if snapshot.State != host.StateDraining || snapshot.Accepting {
+		t.Fatalf("post-announce snapshot = %+v, want draining and closed admission", snapshot)
+	}
+}
+
+func TestBeginHostDrainSkipsAnnouncementBeforeFirstServing(t *testing.T) {
+	hostLifecycle := host.NewController()
+	mgr := newFakeHostDrainManager()
+	started := time.Now()
+
+	err := beginHostDrain(
+		time.Hour,
+		mgr,
+		hostLifecycle,
+		make(chan struct{}),
+		func() {},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("never-serving host waited through announce window: %s", elapsed)
+	}
+	if got := hostLifecycle.Snapshot().State; got != host.StateDraining {
+		t.Fatalf("host state = %s, want draining", got)
+	}
+}
+
+func TestBeginHostDrainForceCutsAnnouncementShort(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatal(err)
+	}
+	mgr := newFakeHostDrainManager()
+	force := make(chan struct{})
+	close(force)
+	started := time.Now()
+
+	err := beginHostDrain(time.Hour, mgr, hostLifecycle, force, func() {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("force did not cut announce window short: %s", elapsed)
+	}
+}
+
+func TestPromoteHostWhenAvailableHonorsDrainState(t *testing.T) {
+	t.Run("starting host becomes serving", func(t *testing.T) {
+		provider := &fakeHostAvailabilityProvider{
+			available:  make(chan struct{}, 1),
+			conditions: process.Conditions{Available: true},
+		}
+		provider.available <- struct{}{}
+		hostLifecycle := host.NewController()
+
+		promoteHostWhenAvailable(context.Background(), provider, hostLifecycle)
+
+		if got := hostLifecycle.Snapshot().State; got != host.StateServing {
+			t.Fatalf("host state = %s, want serving", got)
+		}
+	})
+
+	t.Run("draining host cannot be reopened", func(t *testing.T) {
+		provider := &fakeHostAvailabilityProvider{
+			available:  make(chan struct{}, 1),
+			conditions: process.Conditions{Available: true},
+		}
+		provider.available <- struct{}{}
+		hostLifecycle := host.NewController()
+		if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+			t.Fatal(err)
+		}
+
+		promoteHostWhenAvailable(context.Background(), provider, hostLifecycle)
+
+		if got := hostLifecycle.Snapshot().State; got != host.StateDraining {
+			t.Fatalf("host state = %s, want draining", got)
+		}
+	})
+}
+
+func TestBeginHostDrainCannotRaceAvailabilityPromotion(t *testing.T) {
+	hostLifecycle := host.NewController()
+	mgr := &blockingHostDrainManager{
+		began:   make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	t.Cleanup(func() {
+		select {
+		case <-mgr.release:
+		default:
+			close(mgr.release)
+		}
+	})
+	drainDone := make(chan error, 1)
+	go func() {
+		drainDone <- beginHostDrain(
+			time.Hour,
+			mgr,
+			hostLifecycle,
+			make(chan struct{}),
+			func() {},
+		)
+	}()
+
+	select {
+	case <-mgr.began:
+	case <-time.After(time.Second):
+		t.Fatal("host drain did not reach the manager barrier")
+	}
+	if got := hostLifecycle.Snapshot().State; got != host.StateDraining {
+		t.Fatalf("host state at manager barrier = %s, want draining", got)
+	}
+
+	provider := &fakeHostAvailabilityProvider{
+		available:  make(chan struct{}, 1),
+		conditions: process.Conditions{Available: true},
+	}
+	provider.available <- struct{}{}
+	promoteHostWhenAvailable(context.Background(), provider, hostLifecycle)
+	if got := hostLifecycle.Snapshot().State; got != host.StateDraining {
+		t.Fatalf("availability promotion reopened draining host as %s", got)
+	}
+
+	close(mgr.release)
+	if err := <-drainDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestShutdownHostCompletesLifecycle(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatal(err)
+	}
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	mgr := process.NewManager(config.Config{
+		BasePort:       5000,
+		DrainKillGrace: time.Second,
+	})
+	force := make(chan struct{})
+	pollDone := make(chan struct{})
+	close(pollDone)
+
+	if err := shutdownHost(
+		server.Config,
+		mgr,
+		hostLifecycle,
+		force,
+		pollDone,
+		time.Now().Add(time.Second),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := hostLifecycle.Snapshot().State; got != host.StateStopped {
+		t.Fatalf("host state = %s, want stopped", got)
+	}
+}
+
+func TestShutdownHostHonorsForceSignal(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	mgr := process.NewManager(config.Config{BasePort: 5000})
+	force := make(chan struct{})
+	close(force)
+	pollDone := make(chan struct{})
+	close(pollDone)
+
+	if err := shutdownHost(
+		server.Config,
+		mgr,
+		hostLifecycle,
+		force,
+		pollDone,
+		time.Now().Add(time.Hour),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := hostLifecycle.Snapshot().State; got != host.StateStopped {
+		t.Fatalf("host state = %s, want stopped", got)
+	}
+}
+
+func TestShutdownHostBudgetCapsProxyAndHTTPDrain(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatal(err)
+	}
+
+	requestStarted := make(chan struct{})
+	handlerDone := make(chan struct{})
+	server := httptest.NewServer(hostLifecycle.Admission(http.HandlerFunc(
+		func(_ http.ResponseWriter, r *http.Request) {
+			close(requestStarted)
+			<-r.Context().Done()
+			close(handlerDone)
+		},
+	)))
+	t.Cleanup(server.Close)
+	requestDone := make(chan struct{})
+	go func() {
+		response, _ := server.Client().Get(server.URL + "/v1")
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		close(requestDone)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("proxy request did not start")
+	}
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := process.NewManager(config.Config{BasePort: 5000})
+	force := make(chan struct{})
+	pollDone := make(chan struct{})
+	close(pollDone)
+	budget := 50 * time.Millisecond
+	started := time.Now()
+
+	if err := shutdownHost(
+		server.Config,
+		mgr,
+		hostLifecycle,
+		force,
+		pollDone,
+		time.Now().Add(budget),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("shutdown took %s, want one bounded deadline", elapsed)
+	}
+	if got := hostLifecycle.Snapshot().State; got != host.StateStopped {
+		t.Fatalf("host state = %s, want stopped", got)
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP handler survived shutdown escalation")
+	}
+	select {
+	case <-requestDone:
+	case <-time.After(time.Second):
+		t.Fatal("proxy request did not return after shutdown")
+	}
+}
+
+func TestShutdownHostContinuesWhenPollWorkerDoesNotUnwind(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	mgr := newFakeHostShutdownManager()
+	force := make(chan struct{})
+	pollDone := make(chan struct{})
+	t.Cleanup(func() { close(pollDone) })
+
+	result := make(chan error, 1)
+	go func() {
+		result <- shutdownHost(
+			server.Config,
+			mgr,
+			hostLifecycle,
+			force,
+			pollDone,
+			time.Now().Add(3*time.Second),
+		)
+	}()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown remained blocked on the poll worker")
+	}
+	assertCallOrder(
+		t,
+		mgr.callLog(),
+		"request_children_drain",
+		"wait_children_idle",
+		"shutdown",
+	)
+	if got := hostLifecycle.Snapshot().State; got != host.StateStopped {
+		t.Fatalf("host state = %s, want stopped", got)
+	}
+}
+
+func TestShutdownHostForceDoesNotWaitForPollWorker(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	mgr := newFakeHostShutdownManager()
+	mgr.shutdown = func(ctx context.Context) error {
+		select {
+		case <-mgr.forceCalled:
+			return ctx.Err()
+		case <-time.After(time.Second):
+			return errors.New("shutdown escalation did not force child stop")
+		}
+	}
+	force := make(chan struct{})
+	close(force)
+	pollDone := make(chan struct{})
+	t.Cleanup(func() { close(pollDone) })
+
+	result := make(chan error, 1)
+	go func() {
+		result <- shutdownHost(
+			server.Config,
+			mgr,
+			hostLifecycle,
+			force,
+			pollDone,
+			time.Now().Add(time.Hour),
+		)
+	}()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("forced shutdown remained blocked on the poll worker")
+	}
+	calls := mgr.callLog()
+	if strings.Contains(calls, "request_children_drain") ||
+		strings.Contains(calls, "wait_children_idle") {
+		t.Fatalf("forced shutdown attempted graceful child drain:\n%s", calls)
+	}
+	if !strings.Contains(calls, "force_stop_children") {
+		t.Fatalf("forced shutdown did not force child stop:\n%s", calls)
+	}
+	if got := hostLifecycle.Snapshot().State; got != host.StateStopped {
+		t.Fatalf("host state = %s, want stopped", got)
+	}
+}
+
+func TestShutdownHostForceRaceAlwaysReachesStopped(t *testing.T) {
+	const iterations = 64
+	for iteration := 0; iteration < iterations; iteration++ {
+		hostLifecycle := host.NewController()
+		if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+			t.Fatal(err)
+		}
+		release := make(chan struct{})
+		server := &racingHostHTTPServer{
+			shutdownStarted: make(chan struct{}),
+			release:         release,
+		}
+		managerStarted := make(chan struct{})
+		mgr := newFakeHostShutdownManager()
+		mgr.shutdown = func(ctx context.Context) error {
+			close(managerStarted)
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		force := make(chan struct{})
+		pollDone := make(chan struct{})
+		close(pollDone)
+		result := make(chan error, 1)
+		go func() {
+			result <- shutdownHost(
+				server,
+				mgr,
+				hostLifecycle,
+				force,
+				pollDone,
+				time.Now().Add(time.Second),
+			)
+		}()
+
+		select {
+		case <-server.shutdownStarted:
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d HTTP shutdown did not start", iteration)
+		}
+		select {
+		case <-managerStarted:
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d manager shutdown did not start", iteration)
+		}
+		start := make(chan struct{})
+		var racers sync.WaitGroup
+		racers.Add(2)
+		go func() {
+			defer racers.Done()
+			<-start
+			close(force)
+		}()
+		go func() {
+			defer racers.Done()
+			<-start
+			close(release)
+		}()
+		close(start)
+		racers.Wait()
+
+		select {
+		case err := <-result:
+			if err != nil {
+				t.Fatalf("iteration %d shutdown: %v", iteration, err)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d shutdown did not finish", iteration)
+		}
+		snapshot := hostLifecycle.Snapshot()
+		if snapshot.State != host.StateStopped || snapshot.Inflight != 0 {
+			t.Fatalf("iteration %d final snapshot = %+v", iteration, snapshot)
+		}
+	}
+}
+
+func TestPollWorkerUnwindBudgetReservesShutdownTime(t *testing.T) {
+	tests := []struct {
+		name   string
+		budget time.Duration
+		want   time.Duration
+	}{
+		{
+			name:   "production budget is capped",
+			budget: config.DefaultHostShutdownBudget,
+			want:   maxPollWorkerUnwindWait,
+		},
+		{
+			name:   "short budget keeps ninety percent",
+			budget: 20 * time.Second,
+			want:   2 * time.Second,
+		},
+		{
+			name:   "sub-tick budget reserves no wait",
+			budget: time.Nanosecond,
+			want:   0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pollWorkerUnwindBudget(tt.budget); got != tt.want {
+				t.Fatalf(
+					"pollWorkerUnwindBudget(%s) = %s, want %s",
+					tt.budget,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestWaitForPollWorkerReportsWaitEndReason(t *testing.T) {
+	pollDone := make(chan struct{})
+
+	t.Run("forced cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := waitForPollWorker(ctx, pollDone, time.Second)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("wait error = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("shutdown deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		err := waitForPollWorker(ctx, pollDone, time.Second)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("wait error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+
+	t.Run("unwind allowance elapsed", func(t *testing.T) {
+		err := waitForPollWorker(
+			context.Background(),
+			pollDone,
+			10*time.Millisecond,
+		)
+		if !errors.Is(err, errPollWorkerUnwindTimeout) {
+			t.Fatalf("wait error = %v, want poll worker timeout", err)
+		}
+	})
+
+	t.Run("no unwind allowance", func(t *testing.T) {
+		err := waitForPollWorker(context.Background(), pollDone, 0)
+		if !errors.Is(err, errPollWorkerUnwindTimeout) {
+			t.Fatalf("wait error = %v, want poll worker timeout", err)
+		}
+	})
+}
+
+func TestShutdownHostWaitsForChildIdleBeforeManagerShutdown(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatal(err)
+	}
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	waitStarted := make(chan struct{})
+	childIdle := make(chan struct{})
+	mgr := newFakeHostShutdownManager()
+	mgr.waitChildrenIdle = func(ctx context.Context) error {
+		close(waitStarted)
+		select {
+		case <-childIdle:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	force := make(chan struct{})
+	pollDone := make(chan struct{})
+	close(pollDone)
+
+	result := make(chan error, 1)
+	go func() {
+		result <- shutdownHost(
+			server.Config,
+			mgr,
+			hostLifecycle,
+			force,
+			pollDone,
+			time.Now().Add(time.Second),
+		)
+	}()
+
+	select {
+	case <-waitStarted:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not start waiting for child idle")
+	}
+	if calls := mgr.callLog(); strings.Contains(calls, "\nshutdown") {
+		t.Fatalf("manager shutdown started before child became idle:\n%s", calls)
+	}
+	if got := hostLifecycle.Snapshot().State; got != host.StateDraining {
+		t.Fatalf("host state = %s while child is busy, want draining", got)
+	}
+
+	close(childIdle)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not finish after child became idle")
+	}
+	assertCallOrder(
+		t,
+		mgr.callLog(),
+		"request_children_drain",
+		"wait_children_idle",
+		"shutdown",
+	)
+	if got := hostLifecycle.Snapshot().State; got != host.StateStopped {
+		t.Fatalf("host state = %s, want stopped", got)
+	}
+}
+
+// The absolute deadline is fixed when the shutdown signal arrives, before the
+// announce window runs; shutdownHost must spend what remains of it, not restart
+// the clock from the configured budget. A deadline that is already nearly gone
+// escalates immediately, however generous the budget looks.
+func TestShutdownHostHonoursTheDeadlineNotTheBudget(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatal(err)
+	}
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	mgr := newFakeHostShutdownManager()
+	mgr.waitChildrenIdle = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	mgr.shutdown = func(ctx context.Context) error {
+		select {
+		case <-mgr.forceCalled:
+			return ctx.Err()
+		case <-time.After(time.Second):
+			t.Fatal("an expired deadline did not force the shutdown; the budget restarted the clock")
+			return nil
+		}
+	}
+	force := make(chan struct{})
+	pollDone := make(chan struct{})
+	close(pollDone)
+
+	if err := shutdownHost(
+		server.Config,
+		mgr,
+		hostLifecycle,
+		force,
+		pollDone,
+		time.Now().Add(30*time.Millisecond),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if calls := mgr.callLog(); !strings.Contains(calls, "force_stop_children") {
+		t.Fatalf("hour-long budget masked the expired deadline:\n%s", calls)
+	}
+}
+
+func TestShutdownHostChildIdleTimeoutForcesAndContinues(t *testing.T) {
+	hostLifecycle := host.NewController()
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatal(err)
+	}
+	if err := hostLifecycle.Transition(host.StateDraining); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	mgr := newFakeHostShutdownManager()
+	mgr.waitChildrenIdle = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	mgr.shutdown = func(ctx context.Context) error {
+		select {
+		case <-mgr.forceCalled:
+			return ctx.Err()
+		case <-time.After(time.Second):
+			t.Fatal("shutdown escalation did not force child stop")
+			return nil
+		}
+	}
+	force := make(chan struct{})
+	pollDone := make(chan struct{})
+	close(pollDone)
+
+	if err := shutdownHost(
+		server.Config,
+		mgr,
+		hostLifecycle,
+		force,
+		pollDone,
+		time.Now().Add(30*time.Millisecond),
+	); err != nil {
+		t.Fatal(err)
+	}
+	calls := mgr.callLog()
+	assertCallOrder(
+		t,
+		calls,
+		"request_children_drain",
+		"wait_children_idle",
+		"shutdown",
+	)
+	if !strings.Contains(calls, "force_stop_children") {
+		t.Fatalf("child idle timeout did not force child stop:\n%s", calls)
+	}
+	if got := hostLifecycle.Snapshot().State; got != host.StateStopped {
+		t.Fatalf("host state = %s, want stopped", got)
+	}
+}
+
+func TestVersiondReadyTracksTrafficCapacityNotConvergence(t *testing.T) {
+	status := host.Snapshot{State: host.StateServing, Accepting: true, Ready: true}
+	conditions := process.Conditions{Available: true, Serving: true, Converged: true}
+	if !versiondReady(status, conditions) {
+		t.Fatal("serving host with a running child is not ready")
+	}
+
+	// A child process can exist while unable to take a request — devshardd
+	// reports itself unready when its chain subscription drops. Available alone
+	// must not keep the host in the pool.
+	conditions.Serving = false
+	if versiondReady(status, conditions) {
+		t.Fatal("host whose children are running but not live-ready is ready")
+	}
+	conditions.Serving = true
+
+	// A routine same-name SHA bump makes every host progress at once. Evicting
+	// them all would take the pool down, so progressing must stay ready.
+	conditions.Progressing = true
+	if !versiondReady(status, conditions) {
+		t.Fatal("progressing host lost readiness; the whole pool would drop out")
+	}
+	conditions.Progressing = false
+
+	conditions.Converged = false
+	if versiondReady(status, conditions) {
+		t.Fatal("host that never converged is ready")
+	}
+	conditions.Converged = true
+
+	// Every versiond reads the same oracle, so a failed reconcile is almost
+	// always failing everywhere at once. Gating on it would turn an oracle blip
+	// into an empty pool while every child is still serving.
+	conditions.Degraded = true
+	if !versiondReady(status, conditions) {
+		t.Fatal("a reconcile failure took a serving host out of rotation; " +
+			"one oracle hiccup would empty the pool")
+	}
+	conditions.Degraded = false
+
+	conditions.Available = false
+	if versiondReady(status, conditions) {
+		t.Fatal("host without a running child is ready")
+	}
+	conditions.Available = true
+
+	// announcing still accepts work but must already report unready.
+	status.State = host.StateAnnouncing
+	status.Ready = false
+	if versiondReady(status, conditions) {
+		t.Fatal("announcing host is ready")
+	}
+}
+
+type fakeVersionServer map[string]bool
+
+func (f fakeVersionServer) ServesVersion(name string) bool { return f[name] }
+
+// The question a balancer actually has is about the version it is about to
+// route, and a host missing one version must keep serving the others.
+func TestVersiondReadyForVersionAnswersPerVersion(t *testing.T) {
+	status := host.Snapshot{State: host.StateServing, Accepting: true, Ready: true}
+	serves := fakeVersionServer{"v4": true}
+
+	if !versiondReadyForVersion(status, serves, "v4") {
+		t.Fatal("host with a running v4 route is not ready for v4")
+	}
+	if versiondReadyForVersion(status, serves, "v5") {
+		t.Fatal("host without a v5 route is ready for v5")
+	}
+
+	// No convergence latch and no view of the desired set: a host that has never
+	// run its full set still serves what it does have.
+	if !versiondReadyForVersion(status, serves, "v4") {
+		t.Fatal("per-version readiness should not depend on overall convergence")
+	}
+
+	// Draining has to take every version out at once, or the announce window
+	// would never empty the host.
+	status.State = host.StateAnnouncing
+	status.Ready = false
+	if versiondReadyForVersion(status, serves, "v4") {
+		t.Fatal("announcing host is still ready for v4")
+	}
+}
+
+func TestReadinessAnswersTheVersionItWasAskedAbout(t *testing.T) {
+	hostLifecycle := host.NewController()
+	mgr := process.NewManager(config.Config{BasePort: 5000})
+	if err := hostLifecycle.Transition(host.StateServing); err != nil {
+		t.Fatalf("transition to serving: %v", err)
+	}
+	srv := httptest.NewServer(readinessHandler(mgr, hostLifecycle))
+	defer srv.Close()
+
+	// No child runs, so every version is unserved — including the unqualified
+	// host-level question.
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		for _, path := range []string{"/readyz", "/readyz?version=v4"} {
+			req, err := http.NewRequest(method, srv.URL+path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("%s %s: %v", method, path, err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusServiceUnavailable {
+				t.Fatalf("%s %s = %d, want 503", method, path, resp.StatusCode)
+			}
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/readyz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /readyz = %d, want 405", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Allow"); got != "GET, HEAD" {
+		t.Fatalf("POST /readyz Allow = %q, want GET, HEAD", got)
+	}
+}
+
+func TestReadinessIsServedOnTheTrafficListener(t *testing.T) {
+	hostLifecycle := host.NewController()
+	mgr := process.NewManager(config.Config{BasePort: 5000})
+
+	response := httptest.NewRecorder()
+	publicHandler(mgr, hostLifecycle).ServeHTTP(
+		response,
+		httptest.NewRequest(http.MethodGet, "/readyz", nil),
+	)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf(
+			"/readyz status = %d, want %d",
+			response.Code,
+			http.StatusServiceUnavailable,
+		)
+	}
+	if got := response.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("/readyz Cache-Control = %q, want no-store", got)
+	}
+}
+
+func TestCancelOnSignalCancelsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	signal := make(chan struct{})
+	stop := cancelOnSignal(ctx, cancel, signal)
+	defer stop()
+	close(signal)
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("force signal did not cancel context")
+	}
+}
+
+func TestShouldForceShutdown(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  os.Signal
+		want bool
+	}{
+		{name: "duplicate SIGTERM", sig: syscall.SIGTERM, want: false},
+		{name: "SIGINT escalation", sig: syscall.SIGINT, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldForceShutdown(tt.sig); got != tt.want {
+				t.Fatalf("shouldForceShutdown(%s) = %t, want %t", tt.sig, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWatchForceSignalsForcesOnSIGINT(t *testing.T) {
+	signals := make(chan os.Signal)
+	shutdownDone := make(chan struct{})
+	force := make(chan struct{})
+	go watchForceSignals(signals, shutdownDone, force)
+
+	signals <- syscall.SIGTERM
+	sentSIGINT := make(chan struct{})
+	go func() {
+		signals <- syscall.SIGINT
+		close(sentSIGINT)
+	}()
+	select {
+	case <-sentSIGINT:
+	case <-time.After(time.Second):
+		t.Fatal("watcher stopped after duplicate SIGTERM")
+	}
+	select {
+	case <-force:
+	case <-time.After(time.Second):
+		t.Fatal("SIGINT did not force host shutdown")
+	}
+}
+
+func TestWatchForceSignalsPrefersCompletedShutdown(t *testing.T) {
+	signals := make(chan os.Signal, 1)
+	signals <- syscall.SIGINT
+	shutdownDone := make(chan struct{})
+	close(shutdownDone)
+	force := make(chan struct{})
+	watcherDone := make(chan struct{})
+	go func() {
+		watchForceSignals(signals, shutdownDone, force)
+		close(watcherDone)
+	}()
+
+	select {
+	case <-watcherDone:
+	case <-time.After(time.Second):
+		t.Fatal("force watcher did not observe completed shutdown")
+	}
+	select {
+	case <-force:
+		t.Fatal("queued signal forced an already completed shutdown")
+	default:
+	}
+}
+
+func TestChannelClosed(t *testing.T) {
+	open := make(chan struct{})
+	if channelClosed(open) {
+		t.Fatal("open channel reported closed")
+	}
+	close(open)
+	if !channelClosed(open) {
+		t.Fatal("closed channel reported open")
+	}
+}
+
+func assertCallOrder(t *testing.T, calls string, fragments ...string) {
+	t.Helper()
+	position := -1
+	for _, fragment := range fragments {
+		next := strings.Index(calls[position+1:], fragment)
+		if next < 0 {
+			t.Fatalf("call %q missing or out of order:\n%s", fragment, calls)
+		}
+		position += next + 1
+	}
+}

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -391,14 +391,21 @@ func TestShutdownHostBudgetCapsProxyAndHTTPDrain(t *testing.T) {
 
 	requestStarted := make(chan struct{})
 	handlerDone := make(chan struct{})
+	releaseHandler := make(chan struct{})
 	server := httptest.NewServer(hostLifecycle.Admission(http.HandlerFunc(
 		func(_ http.ResponseWriter, r *http.Request) {
 			close(requestStarted)
-			<-r.Context().Done()
+			select {
+			case <-r.Context().Done():
+			case <-releaseHandler:
+			}
 			close(handlerDone)
 		},
 	)))
-	t.Cleanup(server.Close)
+	t.Cleanup(func() {
+		close(releaseHandler)
+		server.Close()
+	})
 	requestDone := make(chan struct{})
 	go func() {
 		response, _ := server.Client().Get(server.URL + "/v1")

--- a/versioned/internal/config/config.go
+++ b/versioned/internal/config/config.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	DefaultDrainKillGrace     = 10 * time.Minute
-	DefaultHostShutdownBudget = 25 * time.Minute
+	DefaultDrainKillGrace        = 10 * time.Minute
+	DefaultDevshardShutdownGrace = 10 * time.Minute
+	DefaultHostShutdownBudget    = 25 * time.Minute
 	// DefaultDrainAnnounce must exceed the load balancer's health-check
 	// detection time (interval x fall) so no request is refused before the
 	// balancer has withdrawn this upstream.
@@ -19,19 +20,22 @@ const (
 )
 
 type Config struct {
-	OracleURL          string
-	PollInterval       time.Duration
-	BinDir             string
-	DataDir            string
-	BinaryName         string
-	BasePort           int
-	ReadyPath          string
-	ReadyTimeout       time.Duration
-	DrainPath          string
-	DrainStatusPath    string
-	DrainTimeout       time.Duration
-	DrainPollInterval  time.Duration
-	DrainKillGrace     time.Duration
+	OracleURL         string
+	PollInterval      time.Duration
+	BinDir            string
+	DataDir           string
+	BinaryName        string
+	BasePort          int
+	ReadyPath         string
+	ReadyTimeout      time.Duration
+	DrainPath         string
+	DrainStatusPath   string
+	DrainTimeout      time.Duration
+	DrainPollInterval time.Duration
+	DrainKillGrace    time.Duration
+	// ChildShutdownGrace is the effective max of the supervisor kill grace and
+	// the supervised binary's own SIGTERM shutdown budget.
+	ChildShutdownGrace time.Duration
 	HostShutdownBudget time.Duration
 	DrainAnnounce      time.Duration
 	Overrides          map[string]string // version name -> local binary path
@@ -79,7 +83,25 @@ func Load() (Config, error) {
 		}
 		*d.dst = value
 	}
-	if err := validateDrainAnnounce(cfg.DrainAnnounce, cfg.HostShutdownBudget); err != nil {
+	cfg.ChildShutdownGrace = cfg.DrainKillGrace
+	if isDevshardBinary(cfg.BinaryName) {
+		devshardGrace, err := parseDuration(
+			"DEVSHARD_SHUTDOWN_GRACE",
+			DefaultDevshardShutdownGrace,
+			false,
+		)
+		if err != nil {
+			return Config{}, err
+		}
+		if devshardGrace > cfg.ChildShutdownGrace {
+			cfg.ChildShutdownGrace = devshardGrace
+		}
+	}
+	if err := validateShutdownBudget(
+		cfg.DrainAnnounce,
+		cfg.ChildShutdownGrace,
+		cfg.HostShutdownBudget,
+	); err != nil {
 		return Config{}, err
 	}
 
@@ -88,6 +110,7 @@ func Load() (Config, error) {
 		"oracle_url", cfg.OracleURL,
 		"binary_name", cfg.BinaryName,
 		"drain_announce", cfg.DrainAnnounce,
+		"child_shutdown_grace", cfg.ChildShutdownGrace,
 		"host_shutdown_budget", cfg.HostShutdownBudget,
 		"force_versions", cfg.ForceVersions,
 		"override_versions", sortedOverrideKeys(cfg.Overrides),
@@ -171,6 +194,15 @@ func envOrDefault(key, fallback string) string {
 	return fallback
 }
 
+func isDevshardBinary(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "devshard", "devshardd":
+		return true
+	default:
+		return false
+	}
+}
+
 // MinDrainAnnounce is the shortest announce window that guarantees the load
 // balancer observes the failing check before admission closes. The router
 // (versiond-router/haproxy.cfg.template) probes with `inter 1s` and grants each
@@ -181,14 +213,11 @@ func envOrDefault(key, fallback string) string {
 // still routes here, and the requests in between are refused.
 const MinDrainAnnounce = 5 * time.Second
 
-// validateDrainAnnounce accepts zero — the explicit "no balancer in front" —
-// but not a window too short for the balancer to see, nor one that swallows the
-// shutdown budget the announce phase is part of.
-func validateDrainAnnounce(announce, budget time.Duration) error {
-	if announce == 0 {
-		return nil
-	}
-	if announce < MinDrainAnnounce {
+// validateShutdownBudget accepts a zero announce window — the explicit "no
+// balancer in front" — but reserves both the announce window and the slowest
+// child's SIGTERM grace inside the one absolute host shutdown budget.
+func validateShutdownBudget(announce, childGrace, budget time.Duration) error {
+	if announce != 0 && announce < MinDrainAnnounce {
 		return fmt.Errorf(
 			"VERSIOND_DRAIN_ANNOUNCE=%s is below %s: the balancer needs up to ~4s to observe the failing check (inter 1s, timeout check 3s), and a shorter window closes admission while traffic still arrives; use 0 to declare there is no balancer",
 			announce, MinDrainAnnounce)
@@ -197,6 +226,12 @@ func validateDrainAnnounce(announce, budget time.Duration) error {
 		return fmt.Errorf(
 			"VERSIOND_DRAIN_ANNOUNCE=%s must be below VERSIOND_HOST_SHUTDOWN_BUDGET=%s: the announce window is part of the budget, not in addition to it",
 			announce, budget)
+	}
+	remainingAfterAnnounce := budget - announce
+	if childGrace >= remainingAfterAnnounce {
+		return fmt.Errorf(
+			"effective child shutdown grace=%s plus VERSIOND_DRAIN_ANNOUNCE=%s must be below VERSIOND_HOST_SHUTDOWN_BUDGET=%s: reserve time for request and child drain before SIGTERM",
+			childGrace, announce, budget)
 	}
 	return nil
 }

--- a/versioned/internal/config/config.go
+++ b/versioned/internal/config/config.go
@@ -9,24 +9,33 @@ import (
 	"time"
 )
 
-const DefaultDrainKillGrace = 10 * time.Minute
+const (
+	DefaultDrainKillGrace     = 10 * time.Minute
+	DefaultHostShutdownBudget = 25 * time.Minute
+	// DefaultDrainAnnounce must exceed the load balancer's health-check
+	// detection time (interval x fall) so no request is refused before the
+	// balancer has withdrawn this upstream.
+	DefaultDrainAnnounce = 5 * time.Second
+)
 
 type Config struct {
-	OracleURL         string
-	PollInterval      time.Duration
-	BinDir            string
-	DataDir           string
-	BinaryName        string
-	BasePort          int
-	ReadyPath         string
-	ReadyTimeout      time.Duration
-	DrainPath         string
-	DrainStatusPath   string
-	DrainTimeout      time.Duration
-	DrainPollInterval time.Duration
-	DrainKillGrace    time.Duration
-	Overrides         map[string]string // version name -> local binary path
-	ForceVersions     []string          // version names that must run regardless of oracle
+	OracleURL          string
+	PollInterval       time.Duration
+	BinDir             string
+	DataDir            string
+	BinaryName         string
+	BasePort           int
+	ReadyPath          string
+	ReadyTimeout       time.Duration
+	DrainPath          string
+	DrainStatusPath    string
+	DrainTimeout       time.Duration
+	DrainPollInterval  time.Duration
+	DrainKillGrace     time.Duration
+	HostShutdownBudget time.Duration
+	DrainAnnounce      time.Duration
+	Overrides          map[string]string // version name -> local binary path
+	ForceVersions      []string          // version names that must run regardless of oracle
 }
 
 func Load() (Config, error) {
@@ -36,27 +45,50 @@ func Load() (Config, error) {
 	}
 
 	cfg := Config{
-		OracleURL:         oracleURL,
-		PollInterval:      parseDuration("VERSIOND_POLL_INTERVAL", 30*time.Second),
-		BinDir:            envOrDefault("VERSIOND_BIN_DIR", "/opt/versiond/bin"),
-		DataDir:           envOrDefault("VERSIOND_DATA_DIR", "/opt/versiond/data"),
-		BinaryName:        envOrDefault("VERSIOND_BINARY_NAME", "devshard"),
-		BasePort:          5000,
-		ReadyPath:         envOrDefault("VERSIOND_READY_PATH", "/ready"),
-		ReadyTimeout:      parseDuration("VERSIOND_READY_TIMEOUT", 60*time.Second),
-		DrainPath:         envOrDefault("VERSIOND_DRAIN_PATH", "/drain"),
-		DrainStatusPath:   envOrDefault("VERSIOND_DRAIN_STATUS_PATH", "/drain/status"),
-		DrainTimeout:      parseDuration("VERSIOND_DRAIN_TIMEOUT", 15*time.Minute),
-		DrainPollInterval: parseDuration("VERSIOND_DRAIN_POLL_INTERVAL", time.Second),
-		DrainKillGrace:    parseDuration("VERSIOND_DRAIN_KILL_GRACE", DefaultDrainKillGrace),
-		Overrides:         loadOverrides(),
-		ForceVersions:     loadForceVersions(),
+		OracleURL:       oracleURL,
+		BinDir:          envOrDefault("VERSIOND_BIN_DIR", "/opt/versiond/bin"),
+		DataDir:         envOrDefault("VERSIOND_DATA_DIR", "/opt/versiond/data"),
+		BinaryName:      envOrDefault("VERSIOND_BINARY_NAME", "devshard"),
+		BasePort:        5000,
+		ReadyPath:       envOrDefault("VERSIOND_READY_PATH", "/ready"),
+		DrainPath:       envOrDefault("VERSIOND_DRAIN_PATH", "/drain"),
+		DrainStatusPath: envOrDefault("VERSIOND_DRAIN_STATUS_PATH", "/drain/status"),
+		Overrides:       loadOverrides(),
+		ForceVersions:   loadForceVersions(),
+	}
+	for _, d := range []struct {
+		dst      *time.Duration
+		key      string
+		fallback time.Duration
+		// allowZero: only the announce window may be zero — the explicit "no
+		// balancer in front". A zero interval or timeout is never meaningful
+		// (time.NewTicker(0) panics), so everything else stays strictly positive.
+		allowZero bool
+	}{
+		{&cfg.PollInterval, "VERSIOND_POLL_INTERVAL", 30 * time.Second, false},
+		{&cfg.ReadyTimeout, "VERSIOND_READY_TIMEOUT", 60 * time.Second, false},
+		{&cfg.DrainTimeout, "VERSIOND_DRAIN_TIMEOUT", 15 * time.Minute, false},
+		{&cfg.DrainPollInterval, "VERSIOND_DRAIN_POLL_INTERVAL", time.Second, false},
+		{&cfg.DrainKillGrace, "VERSIOND_DRAIN_KILL_GRACE", DefaultDrainKillGrace, false},
+		{&cfg.HostShutdownBudget, "VERSIOND_HOST_SHUTDOWN_BUDGET", DefaultHostShutdownBudget, false},
+		{&cfg.DrainAnnounce, "VERSIOND_DRAIN_ANNOUNCE", DefaultDrainAnnounce, true},
+	} {
+		value, err := parseDuration(d.key, d.fallback, d.allowZero)
+		if err != nil {
+			return Config{}, err
+		}
+		*d.dst = value
+	}
+	if err := validateDrainAnnounce(cfg.DrainAnnounce, cfg.HostShutdownBudget); err != nil {
+		return Config{}, err
 	}
 
 	slog.Info(
 		"versiond config loaded",
 		"oracle_url", cfg.OracleURL,
 		"binary_name", cfg.BinaryName,
+		"drain_announce", cfg.DrainAnnounce,
+		"host_shutdown_budget", cfg.HostShutdownBudget,
 		"force_versions", cfg.ForceVersions,
 		"override_versions", sortedOverrideKeys(cfg.Overrides),
 	)
@@ -139,16 +171,52 @@ func envOrDefault(key, fallback string) string {
 	return fallback
 }
 
-func parseDuration(key string, fallback time.Duration) time.Duration {
+// MinDrainAnnounce is the shortest announce window that guarantees the load
+// balancer observes the failing check before admission closes. The router
+// (versiond-router/haproxy.cfg.template) probes with `inter 1s` and grants each
+// probe `timeout check 3s`, so the worst case is a probe answered "ready" just
+// before the flip that legally completes 3s later, plus 1s until the next probe
+// begins and fails: ~4s until the host is out of rotation, and one more second
+// of margin. A shorter window means versiond stops accepting while the router
+// still routes here, and the requests in between are refused.
+const MinDrainAnnounce = 5 * time.Second
+
+// validateDrainAnnounce accepts zero — the explicit "no balancer in front" —
+// but not a window too short for the balancer to see, nor one that swallows the
+// shutdown budget the announce phase is part of.
+func validateDrainAnnounce(announce, budget time.Duration) error {
+	if announce == 0 {
+		return nil
+	}
+	if announce < MinDrainAnnounce {
+		return fmt.Errorf(
+			"VERSIOND_DRAIN_ANNOUNCE=%s is below %s: the balancer needs up to ~4s to observe the failing check (inter 1s, timeout check 3s), and a shorter window closes admission while traffic still arrives; use 0 to declare there is no balancer",
+			announce, MinDrainAnnounce)
+	}
+	if announce >= budget {
+		return fmt.Errorf(
+			"VERSIOND_DRAIN_ANNOUNCE=%s must be below VERSIOND_HOST_SHUTDOWN_BUDGET=%s: the announce window is part of the budget, not in addition to it",
+			announce, budget)
+	}
+	return nil
+}
+
+// parseDuration rejects a malformed or non-positive value instead of silently
+// substituting the default: a typo in a drain or shutdown budget would
+// otherwise be discovered during the outage it was meant to bound.
+func parseDuration(key string, fallback time.Duration, allowZero bool) (time.Duration, error) {
 	v := os.Getenv(key)
 	if v == "" {
-		return fallback
+		return fallback, nil
 	}
 	d, err := time.ParseDuration(v)
-	if err != nil || d <= 0 {
-		return fallback
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q: %w", key, v, err)
 	}
-	return d
+	if d < 0 || (d == 0 && !allowZero) {
+		return 0, fmt.Errorf("%s=%q must be positive", key, v)
+	}
+	return d, nil
 }
 
 func sortedOverrideKeys(overrides map[string]string) []string {

--- a/versioned/internal/config/config_test.go
+++ b/versioned/internal/config/config_test.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -40,6 +44,20 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.DrainKillGrace != DefaultDrainKillGrace {
 		t.Errorf("DrainKillGrace = %v, want %v", cfg.DrainKillGrace, DefaultDrainKillGrace)
 	}
+	if cfg.HostShutdownBudget != DefaultHostShutdownBudget {
+		t.Errorf(
+			"HostShutdownBudget = %v, want %v",
+			cfg.HostShutdownBudget,
+			DefaultHostShutdownBudget,
+		)
+	}
+	if cfg.DrainAnnounce != DefaultDrainAnnounce {
+		t.Errorf(
+			"DrainAnnounce = %v, want %v",
+			cfg.DrainAnnounce,
+			DefaultDrainAnnounce,
+		)
+	}
 }
 
 func TestLoad_CustomValues(t *testing.T) {
@@ -48,6 +66,8 @@ func TestLoad_CustomValues(t *testing.T) {
 	t.Setenv("VERSIOND_BIN_DIR", "/tmp/bin")
 	t.Setenv("VERSIOND_DATA_DIR", "/tmp/data")
 	t.Setenv("VERSIOND_BINARY_NAME", "myapp")
+	t.Setenv("VERSIOND_HOST_SHUTDOWN_BUDGET", "12m")
+	t.Setenv("VERSIOND_DRAIN_ANNOUNCE", "9s")
 
 	cfg, err := Load()
 	if err != nil {
@@ -62,18 +82,77 @@ func TestLoad_CustomValues(t *testing.T) {
 	if cfg.BinaryName != "myapp" {
 		t.Errorf("BinaryName = %q, want %q", cfg.BinaryName, "myapp")
 	}
+	if cfg.HostShutdownBudget != 12*time.Minute {
+		t.Errorf("HostShutdownBudget = %v, want %v", cfg.HostShutdownBudget, 12*time.Minute)
+	}
+	if cfg.DrainAnnounce != 9*time.Second {
+		t.Errorf("DrainAnnounce = %v, want %v", cfg.DrainAnnounce, 9*time.Second)
+	}
 }
 
-func TestLoad_InvalidPollInterval(t *testing.T) {
-	t.Setenv("VERSIOND_ORACLE_URL", "http://oracle:8080/versions")
-	t.Setenv("VERSIOND_POLL_INTERVAL", "notaduration")
+// A malformed duration refuses to boot rather than silently borrowing the
+// default: a typo in a drain or shutdown budget would otherwise surface during
+// the outage it was meant to bound.
+func TestLoad_MalformedDurationsRefuseToBoot(t *testing.T) {
+	for _, key := range []string{
+		"VERSIOND_POLL_INTERVAL",
+		"VERSIOND_HOST_SHUTDOWN_BUDGET",
+		"VERSIOND_DRAIN_ANNOUNCE",
+	} {
+		t.Run(key, func(t *testing.T) {
+			t.Setenv("VERSIOND_ORACLE_URL", "http://oracle:8080/versions")
+			t.Setenv(key, "notaduration")
+			if _, err := Load(); err == nil {
+				t.Fatalf("%s=notaduration was silently accepted", key)
+			}
+		})
+	}
+}
 
+// Zero means "no ticker" for an interval, which panics, so only the announce
+// window — where zero is the explicit "no balancer in front" — may be zero.
+func TestLoad_ZeroDurations(t *testing.T) {
+	t.Setenv("VERSIOND_ORACLE_URL", "http://oracle:8080/versions")
+	t.Setenv("VERSIOND_POLL_INTERVAL", "0s")
+	if _, err := Load(); err == nil {
+		t.Fatal("a zero poll interval was accepted; NewTicker(0) panics")
+	}
+
+	t.Setenv("VERSIOND_POLL_INTERVAL", "")
+	t.Setenv("VERSIOND_DRAIN_ANNOUNCE", "0s")
 	cfg, err := Load()
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("zero announce must mean no balancer, got: %v", err)
 	}
-	if cfg.PollInterval != 30*time.Second {
-		t.Errorf("PollInterval = %v, want fallback %v", cfg.PollInterval, 30*time.Second)
+	if cfg.DrainAnnounce != 0 {
+		t.Fatalf("DrainAnnounce = %v, want 0", cfg.DrainAnnounce)
+	}
+}
+
+// The announce window has a floor and a ceiling: the balancer probes once a
+// second, so a shorter window can fall entirely between probes; and the window
+// is part of the shutdown budget, so it cannot swallow it.
+func TestLoad_DrainAnnounceBounds(t *testing.T) {
+	t.Setenv("VERSIOND_ORACLE_URL", "http://oracle:8080/versions")
+
+	for _, tooShort := range []string{"500ms", "2s", "4s"} {
+		t.Setenv("VERSIOND_HOST_SHUTDOWN_BUDGET", "")
+		t.Setenv("VERSIOND_DRAIN_ANNOUNCE", tooShort)
+		if _, err := Load(); err == nil {
+			t.Fatalf("announce %s was accepted; the router needs ~4s to observe the failing check", tooShort)
+		}
+	}
+
+	t.Setenv("VERSIOND_DRAIN_ANNOUNCE", "10s")
+	t.Setenv("VERSIOND_HOST_SHUTDOWN_BUDGET", "10s")
+	if _, err := Load(); err == nil {
+		t.Fatal("an announce window as long as the whole budget was accepted")
+	}
+
+	t.Setenv("VERSIOND_DRAIN_ANNOUNCE", "5s")
+	t.Setenv("VERSIOND_HOST_SHUTDOWN_BUDGET", "90s")
+	if _, err := Load(); err != nil {
+		t.Fatalf("valid announce/budget pair refused: %v", err)
 	}
 }
 
@@ -164,4 +243,119 @@ func TestLoad_ForceVersionsDottedWithOverride(t *testing.T) {
 	if _, ok := cfg.Overrides["v0.2.11"]; !ok {
 		t.Fatal("forced version v0.2.11 should match override set via VERSIOND_OVERRIDE_v0_2_11")
 	}
+}
+
+// The floor is derived from the router's health-check settings, which live in
+// config templates no compiler connects to this package — so this test reads
+// the real templates rather than restating their numbers. Every backend that
+// health-checks versiond counts: the per-version pools and the host-level pool
+// share one server-template, but versiond_legacy carries its own check
+// directive, and legacy-pinned traffic deserves the same announce guarantee.
+// The worst case is therefore the maximum over every checked server.
+//
+// Editing any `inter`, `fall`, or `timeout check` without revisiting
+// MinDrainAnnounce fails here; so does a checked server that stops declaring
+// either health-check parameter (HAProxy would silently substitute its own
+// default), and so does moving or renaming a template — loudly, because a
+// skipped contract is a disabled one.
+func TestMinDrainAnnounceCoversTheRouterDetectionWorstCase(t *testing.T) {
+	templates := []string{
+		"../../../versiond-router/haproxy.cfg.template",
+		"../../../versiond-router/pool-backend.cfg.template",
+	}
+
+	detectionInterval := maxCheckedServerDetectionInterval(t, templates)
+	checkTimeout := maxTemplateDuration(t, templates,
+		regexp.MustCompile(`(?m)^[\t ]*timeout check ([0-9]+m?s)`))
+
+	// Worst case: a probe answered "ready" just before the flip legally
+	// concludes checkTimeout later, followed by every failed check required to
+	// mark the server down.
+	const margin = time.Second
+	worstDetection := checkTimeout + detectionInterval
+	if MinDrainAnnounce < worstDetection+margin {
+		t.Fatalf(
+			"MinDrainAnnounce=%s does not cover the router's worst-case detection %s (timeout check %s + inter*fall %s) plus %s margin",
+			MinDrainAnnounce, worstDetection, checkTimeout, detectionInterval, margin)
+	}
+}
+
+// Anchored to directives at line start: the templates' comments mention these
+// settings by name, and a comment must no more supply a contract value than
+// satisfy a render assert.
+var (
+	serverLine  = regexp.MustCompile(`(?m)^[\t ]*server(-template)? [^\n]*`)
+	serverInter = regexp.MustCompile(` inter ([0-9]+m?s)`)
+	serverFall  = regexp.MustCompile(` fall ([0-9]+)`)
+)
+
+func maxCheckedServerDetectionInterval(t *testing.T, paths []string) time.Duration {
+	t.Helper()
+	var max time.Duration
+	found := 0
+	for _, path := range paths {
+		for _, line := range serverLine.FindAllString(readTemplate(t, path), -1) {
+			if !strings.Contains(line, " check") {
+				continue
+			}
+			m := serverInter.FindStringSubmatch(line)
+			if m == nil {
+				t.Fatalf("%s: a checked server does not declare `inter`; HAProxy would silently use its own default:\n%s",
+					path, line)
+			}
+			fall := serverFall.FindStringSubmatch(line)
+			if fall == nil {
+				t.Fatalf("%s: a checked server does not declare `fall`; HAProxy would silently use its own default:\n%s",
+					path, line)
+			}
+			failures, err := strconv.Atoi(fall[1])
+			if err != nil {
+				t.Fatalf("%s: invalid fall count %q: %v", path, fall[1], err)
+			}
+			found++
+			if d := parseTemplateDuration(t, path, m[1]) * time.Duration(failures); d > max {
+				max = d
+			}
+		}
+	}
+	if found == 0 {
+		t.Fatal("no checked servers found in the router templates; the MinDrainAnnounce derivation has lost its source")
+	}
+	return max
+}
+
+func maxTemplateDuration(t *testing.T, paths []string, directive *regexp.Regexp) time.Duration {
+	t.Helper()
+	var max time.Duration
+	found := 0
+	for _, path := range paths {
+		for _, m := range directive.FindAllStringSubmatch(readTemplate(t, path), -1) {
+			found++
+			if d := parseTemplateDuration(t, path, m[1]); d > max {
+				max = d
+			}
+		}
+	}
+	if found == 0 {
+		t.Fatalf("no template contains %v; the MinDrainAnnounce derivation has lost its source", directive)
+	}
+	return max
+}
+
+func readTemplate(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the router template this contract is derived from is unreadable: %v", err)
+	}
+	return string(body)
+}
+
+func parseTemplateDuration(t *testing.T, path, raw string) time.Duration {
+	t.Helper()
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		t.Fatalf("%s: %v", path, err)
+	}
+	return d
 }

--- a/versioned/internal/config/config_test.go
+++ b/versioned/internal/config/config_test.go
@@ -44,6 +44,13 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.DrainKillGrace != DefaultDrainKillGrace {
 		t.Errorf("DrainKillGrace = %v, want %v", cfg.DrainKillGrace, DefaultDrainKillGrace)
 	}
+	if cfg.ChildShutdownGrace != DefaultDevshardShutdownGrace {
+		t.Errorf(
+			"ChildShutdownGrace = %v, want %v",
+			cfg.ChildShutdownGrace,
+			DefaultDevshardShutdownGrace,
+		)
+	}
 	if cfg.HostShutdownBudget != DefaultHostShutdownBudget {
 		t.Errorf(
 			"HostShutdownBudget = %v, want %v",
@@ -98,6 +105,7 @@ func TestLoad_MalformedDurationsRefuseToBoot(t *testing.T) {
 		"VERSIOND_POLL_INTERVAL",
 		"VERSIOND_HOST_SHUTDOWN_BUDGET",
 		"VERSIOND_DRAIN_ANNOUNCE",
+		"DEVSHARD_SHUTDOWN_GRACE",
 	} {
 		t.Run(key, func(t *testing.T) {
 			t.Setenv("VERSIOND_ORACLE_URL", "http://oracle:8080/versions")
@@ -150,9 +158,93 @@ func TestLoad_DrainAnnounceBounds(t *testing.T) {
 	}
 
 	t.Setenv("VERSIOND_DRAIN_ANNOUNCE", "5s")
-	t.Setenv("VERSIOND_HOST_SHUTDOWN_BUDGET", "90s")
+	t.Setenv("VERSIOND_HOST_SHUTDOWN_BUDGET", "11m")
 	if _, err := Load(); err != nil {
 		t.Fatalf("valid announce/budget pair refused: %v", err)
+	}
+}
+
+func TestLoad_ShutdownBudgetReservesDrainBeforeChildGrace(t *testing.T) {
+	tests := []struct {
+		name          string
+		binary        string
+		drainGrace    string
+		devshardGrace string
+		announce      string
+		budget        string
+		wantGrace     time.Duration
+		wantErr       bool
+	}{
+		{
+			name:       "drain kill grace consumes the budget",
+			binary:     "devshardd",
+			drainGrace: "30m",
+			announce:   "5s",
+			budget:     "25m",
+			wantErr:    true,
+		},
+		{
+			name:          "devshard shutdown grace consumes the budget",
+			binary:        "devshardd",
+			devshardGrace: "30m",
+			announce:      "5s",
+			budget:        "25m",
+			wantErr:       true,
+		},
+		{
+			name:          "announce and grace exactly consume the budget",
+			binary:        "devshardd",
+			devshardGrace: "10m",
+			announce:      "5s",
+			budget:        "10m5s",
+			wantErr:       true,
+		},
+		{
+			name:          "devshard uses its larger shutdown grace",
+			binary:        "devshardd",
+			drainGrace:    "30s",
+			devshardGrace: "2m",
+			announce:      "5s",
+			budget:        "3m",
+			wantGrace:     2 * time.Minute,
+		},
+		{
+			name:          "non-devshard ignores devshard grace",
+			binary:        "testapp",
+			drainGrace:    "30s",
+			devshardGrace: "30m",
+			announce:      "0s",
+			budget:        "1m",
+			wantGrace:     30 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("VERSIOND_ORACLE_URL", "http://oracle:8080/versions")
+			t.Setenv("VERSIOND_BINARY_NAME", tt.binary)
+			t.Setenv("VERSIOND_DRAIN_KILL_GRACE", tt.drainGrace)
+			t.Setenv("DEVSHARD_SHUTDOWN_GRACE", tt.devshardGrace)
+			t.Setenv("VERSIOND_DRAIN_ANNOUNCE", tt.announce)
+			t.Setenv("VERSIOND_HOST_SHUTDOWN_BUDGET", tt.budget)
+
+			cfg, err := Load()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("configuration consumed the whole host budget without an error")
+				}
+				if !strings.Contains(err.Error(), "effective child shutdown grace") {
+					t.Fatalf("error = %q, want effective grace explanation", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("valid shutdown budget refused: %v", err)
+			}
+			if cfg.ChildShutdownGrace != tt.wantGrace {
+				t.Fatalf("ChildShutdownGrace = %s, want %s", cfg.ChildShutdownGrace, tt.wantGrace)
+			}
+		})
 	}
 }
 

--- a/versioned/internal/health/health.go
+++ b/versioned/internal/health/health.go
@@ -17,6 +17,6 @@ type StatusEntry struct {
 func Handler(statusFn func() []StatusEntry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(statusFn())
+		_ = json.NewEncoder(w).Encode(statusFn())
 	}
 }

--- a/versioned/internal/health/health_test.go
+++ b/versioned/internal/health/health_test.go
@@ -1,0 +1,26 @@
+package health
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandlerReturnsLegacyArray(t *testing.T) {
+	handler := Handler(func() []StatusEntry {
+		return []StatusEntry{{Name: "v1", Port: 5000, Status: "running"}}
+	})
+	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.Code)
+	}
+	want := `[{"name":"v1","port":5000,"status":"running"}]`
+	if got := strings.TrimSpace(response.Body.String()); got != want {
+		t.Fatalf("body = %s, want legacy array %s", got, want)
+	}
+}

--- a/versioned/internal/host/lifecycle.go
+++ b/versioned/internal/host/lifecycle.go
@@ -1,0 +1,252 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+type State string
+
+const (
+	StateStarting   State = "starting"
+	StateServing    State = "serving"
+	StateAnnouncing State = "announcing"
+	StateDraining   State = "draining"
+	StateStopping   State = "stopping"
+	StateForcing    State = "forcing"
+	StateStopped    State = "stopped"
+)
+
+var ErrInvalidTransition = errors.New("invalid versiond host state transition")
+
+// stateSpec.accepting decides whether new proxy work may acquire a lease.
+// stateSpec.ready decides what GET /readyz reports to the load balancer.
+//
+// announcing accepts work but is already unready: the balancer needs a moment
+// to observe the failing health check and stop routing here. Serving through
+// that window is what makes it safe to signal the process before the balancer
+// has reacted; refusing immediately would surface as client errors instead.
+type stateSpec struct {
+	accepting bool
+	ready     bool
+	targets   []State
+}
+
+var stateTable = map[State]stateSpec{
+	StateStarting: {
+		// No path to announcing: announcing keeps accepting while balancers
+		// notice, and a starting host has never accepted. Reaching announcing
+		// from here would open admission for the first time on the way down,
+		// taking work no balancer will see drained. Shutdown from starting goes
+		// straight to draining.
+		targets: []State{
+			StateServing,
+			StateDraining,
+			StateForcing,
+		},
+	},
+	StateServing: {
+		accepting: true,
+		ready:     true,
+		targets: []State{
+			StateAnnouncing,
+			StateDraining,
+			StateForcing,
+		},
+	},
+	StateAnnouncing: {
+		accepting: true,
+		targets: []State{
+			StateDraining,
+			StateForcing,
+		},
+	},
+	StateDraining: {
+		targets: []State{
+			StateStopping,
+			StateForcing,
+		},
+	},
+	StateStopping: {
+		targets: []State{
+			StateStopped,
+			StateForcing,
+		},
+	},
+	StateForcing: {
+		targets: []State{StateStopped},
+	},
+	StateStopped: {},
+}
+
+type Snapshot struct {
+	State     State
+	Accepting bool
+	Ready     bool
+	Inflight  int64
+	Idle      bool
+}
+
+// Controller owns the versiond host lifecycle and admission lease. The lease
+// spans the complete proxied response, including the lifetime of an SSE stream.
+type Controller struct {
+	mu       sync.Mutex
+	state    State
+	inflight int64
+	idle     chan struct{}
+}
+
+func NewController() *Controller {
+	idle := make(chan struct{})
+	close(idle)
+	return &Controller{
+		state: StateStarting,
+		idle:  idle,
+	}
+}
+
+// Promote atomically publishes a starting host as serving. A concurrent drain
+// wins by changing the state first; availability observed before that barrier
+// must not reopen the host afterwards.
+func (c *Controller) Promote() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != StateStarting || !validTransition(c.state, StateServing) {
+		return false
+	}
+	c.state = StateServing
+	return true
+}
+
+func (c *Controller) Transition(next State) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !validTransition(c.state, next) {
+		return fmt.Errorf("%w: %s -> %s", ErrInvalidTransition, c.state, next)
+	}
+	c.state = next
+	return nil
+}
+
+// BeginDrain atomically chooses the shutdown edge for the host's current
+// lifecycle. A serving host must announce before admission closes; a host that
+// never served goes directly to draining. Keeping this choice under the FSM
+// lock prevents a concurrent availability promotion from reopening a starting
+// host after shutdown has begun.
+func (c *Controller) BeginDrain() (announcing bool, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if validTransition(c.state, StateAnnouncing) {
+		c.state = StateAnnouncing
+		return true, nil
+	}
+	if validTransition(c.state, StateDraining) {
+		c.state = StateDraining
+		return false, nil
+	}
+	return false, fmt.Errorf(
+		"%w: cannot begin drain from %s",
+		ErrInvalidTransition,
+		c.state,
+	)
+}
+
+func validTransition(from, to State) bool {
+	spec, fromKnown := stateTable[from]
+	_, toKnown := stateTable[to]
+	if !fromKnown || !toKnown {
+		return false
+	}
+	if from == to {
+		return true
+	}
+	for _, target := range spec.targets {
+		if target == to {
+			return true
+		}
+	}
+	return false
+}
+
+func acceptsWork(state State) bool {
+	spec, ok := stateTable[state]
+	return ok && spec.accepting
+}
+
+func advertisesReady(state State) bool {
+	spec, ok := stateTable[state]
+	return ok && spec.ready
+}
+
+func (c *Controller) Snapshot() Snapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.snapshotLocked()
+}
+
+func (c *Controller) snapshotLocked() Snapshot {
+	return Snapshot{
+		State:     c.state,
+		Accepting: acceptsWork(c.state),
+		Ready:     advertisesReady(c.state),
+		Inflight:  c.inflight,
+		Idle:      c.inflight == 0,
+	}
+}
+
+func (c *Controller) WaitIdle(ctx context.Context) error {
+	c.mu.Lock()
+	idle := c.idle
+	c.mu.Unlock()
+
+	select {
+	case <-idle:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Admission rejects new proxy work unless the host is serving. Lifecycle
+// endpoints must be registered outside this middleware so operators can still
+// observe a draining host.
+func (c *Controller) Admission(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !c.acquire() {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "versiond host is not accepting new work", http.StatusServiceUnavailable)
+			return
+		}
+		defer c.release()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (c *Controller) acquire() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !acceptsWork(c.state) {
+		return false
+	}
+	if c.inflight == 0 {
+		c.idle = make(chan struct{})
+	}
+	c.inflight++
+	return true
+}
+
+func (c *Controller) release() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inflight == 0 {
+		return
+	}
+	c.inflight--
+	if c.inflight == 0 {
+		close(c.idle)
+	}
+}

--- a/versioned/internal/host/lifecycle_test.go
+++ b/versioned/internal/host/lifecycle_test.go
@@ -1,0 +1,356 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestControllerTransitions(t *testing.T) {
+	c := NewController()
+	for _, state := range []State{StateServing, StateDraining, StateStopping, StateStopped} {
+		if err := c.Transition(state); err != nil {
+			t.Fatalf("transition to %s: %v", state, err)
+		}
+	}
+	if err := c.Transition(StateServing); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("stopped -> serving error = %v, want invalid transition", err)
+	}
+}
+
+func TestBeginDrainChoosesTheCurrentLifecycleEdge(t *testing.T) {
+	t.Run("starting host skips announcement", func(t *testing.T) {
+		c := NewController()
+		announcing, err := c.BeginDrain()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if announcing {
+			t.Fatal("starting host entered announcement")
+		}
+		if got := c.Snapshot().State; got != StateDraining {
+			t.Fatalf("host state = %s, want draining", got)
+		}
+	})
+
+	t.Run("serving host announces first", func(t *testing.T) {
+		c := NewController()
+		if err := c.Transition(StateServing); err != nil {
+			t.Fatal(err)
+		}
+		announcing, err := c.BeginDrain()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !announcing {
+			t.Fatal("serving host skipped announcement")
+		}
+		snapshot := c.Snapshot()
+		if snapshot.State != StateAnnouncing || snapshot.Ready || !snapshot.Accepting {
+			t.Fatalf("announcement snapshot = %+v", snapshot)
+		}
+	})
+}
+
+func TestPromoteAndBeginDrainAreAtomic(t *testing.T) {
+	const iterations = 128
+	for iteration := 0; iteration < iterations; iteration++ {
+		c := NewController()
+		start := make(chan struct{})
+		promoted := make(chan bool, 1)
+		announcement := make(chan bool, 1)
+		drainErr := make(chan error, 1)
+
+		go func() {
+			<-start
+			promoted <- c.Promote()
+		}()
+		go func() {
+			<-start
+			announcing, err := c.BeginDrain()
+			announcement <- announcing
+			drainErr <- err
+		}()
+		close(start)
+
+		if err := <-drainErr; err != nil {
+			t.Fatalf("iteration %d: begin drain: %v", iteration, err)
+		}
+		promotionWon := <-promoted
+		announcing := <-announcement
+		state := c.Snapshot().State
+		switch {
+		case promotionWon && announcing && state == StateAnnouncing:
+		case !promotionWon && !announcing && state == StateDraining:
+		default:
+			t.Fatalf(
+				"iteration %d: promoted=%t announcing=%t state=%s",
+				iteration,
+				promotionWon,
+				announcing,
+				state,
+			)
+		}
+	}
+}
+
+func TestControllerConcurrentAdmissionAndDrain(t *testing.T) {
+	const (
+		iterations = 64
+		workers    = 32
+	)
+	for iteration := 0; iteration < iterations; iteration++ {
+		c := NewController()
+		if err := c.Transition(StateServing); err != nil {
+			t.Fatal(err)
+		}
+		handler := c.Admission(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		start := make(chan struct{})
+		statuses := make([]int, workers)
+		var wg sync.WaitGroup
+		for worker := range workers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				response := httptest.NewRecorder()
+				handler.ServeHTTP(
+					response,
+					httptest.NewRequest(http.MethodGet, "/v1", nil),
+				)
+				statuses[worker] = response.Code
+			}()
+		}
+		drainDone := make(chan error, 1)
+		go func() {
+			<-start
+			announcing, err := c.BeginDrain()
+			if err == nil && announcing {
+				err = c.Transition(StateDraining)
+			}
+			drainDone <- err
+		}()
+
+		close(start)
+		wg.Wait()
+		if err := <-drainDone; err != nil {
+			t.Fatal(err)
+		}
+		for worker, status := range statuses {
+			if status != http.StatusNoContent && status != http.StatusServiceUnavailable {
+				t.Fatalf("iteration %d worker %d status = %d", iteration, worker, status)
+			}
+		}
+
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/v1", nil))
+		if response.Code != http.StatusServiceUnavailable {
+			t.Fatalf("iteration %d post-drain status = %d, want 503", iteration, response.Code)
+		}
+		snapshot := c.Snapshot()
+		if snapshot.State != StateDraining || snapshot.Inflight != 0 || !snapshot.Idle {
+			t.Fatalf("iteration %d final snapshot = %+v", iteration, snapshot)
+		}
+	}
+}
+
+func TestStateTableTransitionMatrix(t *testing.T) {
+	states := []State{
+		StateStarting,
+		StateServing,
+		StateAnnouncing,
+		StateDraining,
+		StateStopping,
+		StateForcing,
+		StateStopped,
+	}
+	allowed := map[State]map[State]bool{
+		// starting -> announcing is deliberately absent: announcing accepts,
+		// and a host that never served must not open admission while shutting
+		// down.
+		StateStarting: {
+			StateStarting: true,
+			StateServing:  true,
+			StateDraining: true,
+			StateForcing:  true,
+		},
+		StateServing: {
+			StateServing:    true,
+			StateAnnouncing: true,
+			StateDraining:   true,
+			StateForcing:    true,
+		},
+		StateAnnouncing: {
+			StateAnnouncing: true,
+			StateDraining:   true,
+			StateForcing:    true,
+		},
+		StateDraining: {
+			StateDraining: true,
+			StateStopping: true,
+			StateForcing:  true,
+		},
+		StateStopping: {
+			StateStopping: true,
+			StateForcing:  true,
+			StateStopped:  true,
+		},
+		StateForcing: {
+			StateForcing: true,
+			StateStopped: true,
+		},
+		StateStopped: {
+			StateStopped: true,
+		},
+	}
+
+	for _, from := range states {
+		for _, to := range states {
+			if got, want := validTransition(from, to), allowed[from][to]; got != want {
+				t.Errorf("validTransition(%s, %s) = %t, want %t", from, to, got, want)
+			}
+		}
+	}
+	if validTransition("unknown", "unknown") {
+		t.Fatal("unknown host state accepted a self-transition")
+	}
+}
+
+func TestStateTableSeparatesAdmissionFromReadiness(t *testing.T) {
+	states := []State{
+		StateStarting,
+		StateServing,
+		StateAnnouncing,
+		StateDraining,
+		StateStopping,
+		StateForcing,
+		StateStopped,
+	}
+	if len(stateTable) != len(states) {
+		t.Fatalf("host state table has %d states, want %d", len(stateTable), len(states))
+	}
+
+	accepting := map[State]bool{}
+	ready := map[State]bool{}
+	for state, spec := range stateTable {
+		if spec.accepting {
+			accepting[state] = true
+		}
+		if spec.ready {
+			ready[state] = true
+		}
+		if spec.ready && !spec.accepting {
+			t.Errorf("%s advertises ready without accepting work", state)
+		}
+		for _, target := range spec.targets {
+			if _, ok := stateTable[target]; !ok {
+				t.Errorf("%s targets unknown host state %s", state, target)
+			}
+		}
+	}
+
+	// announcing is the drain window: still serving, already unready.
+	if !accepting[StateServing] || !accepting[StateAnnouncing] || len(accepting) != 2 {
+		t.Fatalf("accepting states = %v, want serving and announcing", accepting)
+	}
+	if !ready[StateServing] || len(ready) != 1 {
+		t.Fatalf("ready states = %v, want serving only", ready)
+	}
+	if len(stateTable[StateStopped].targets) != 0 {
+		t.Fatal("stopped host state has outgoing targets")
+	}
+}
+
+func TestControllerForceTransition(t *testing.T) {
+	for _, state := range []State{StateStarting, StateServing, StateDraining, StateStopping} {
+		t.Run(string(state), func(t *testing.T) {
+			c := NewController()
+			if state != StateStarting {
+				if err := c.Transition(StateServing); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if state == StateDraining || state == StateStopping {
+				if err := c.Transition(StateDraining); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if state == StateStopping {
+				if err := c.Transition(StateStopping); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := c.Transition(StateForcing); err != nil {
+				t.Fatalf("%s -> forcing: %v", state, err)
+			}
+			if err := c.Transition(StateStopped); err != nil {
+				t.Fatalf("forcing -> stopped: %v", err)
+			}
+		})
+	}
+}
+
+func TestAdmissionHoldsLeaseForCompleteRequest(t *testing.T) {
+	c := NewController()
+	if err := c.Transition(StateServing); err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	handler := c.Admission(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		resp, err := http.Get(server.URL)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			err = resp.Body.Close()
+		}
+		done <- err
+	}()
+	<-started
+
+	if got := c.Snapshot().Inflight; got != 1 {
+		t.Fatalf("inflight = %d, want 1", got)
+	}
+	if err := c.Transition(StateDraining); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("new request status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := c.WaitIdle(waitCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitIdle error = %v, want deadline exceeded", err)
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if err := c.WaitIdle(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/versioned/internal/process/binary_version.go
+++ b/versioned/internal/process/binary_version.go
@@ -41,20 +41,21 @@ type childPreflight struct {
 	haDeployment *bool
 }
 
-// preflightChild verifies a downloaded binary when --print-* flags are
-// available. Legacy binaries (released before the flags) fall back per flag:
+// preflightChildWithAdminProbeContext verifies a downloaded binary when
+// --print-* flags are available. Legacy binaries fall back per flag:
 //   - --print-binary-version missing: use slotName for DEVSHARD_BINARY_LOG_VERSION
 //   - --print-protocol-version missing: trust governance slot, skip embed check
-func preflightChild(binPath, slotName string) (childPreflight, error) {
-	return preflightChildWithAdminProbe(binPath, slotName, false)
-}
-
-func preflightChildWithAdminProbe(binPath, slotName string, probeAdmin bool) (childPreflight, error) {
+func preflightChildWithAdminProbeContext(
+	ctx context.Context,
+	binPath string,
+	slotName string,
+	probeAdmin bool,
+) (childPreflight, error) {
 	if _, err := os.Stat(binPath); err != nil {
 		return childPreflight{}, fmt.Errorf("binary not found: %w", err)
 	}
 
-	binaryLogVersion, binErr := readBinaryLogVersion(binPath)
+	binaryLogVersion, binErr := readBinaryLogVersionContext(ctx, binPath)
 	if binErr != nil {
 		if !errors.Is(binErr, errVersionFlagUnsupported) {
 			return childPreflight{}, fmt.Errorf("read binary log version: %w", binErr)
@@ -68,7 +69,7 @@ func preflightChildWithAdminProbe(binPath, slotName string, probeAdmin bool) (ch
 		binaryLogVersion = slotName
 	}
 
-	embeddedProtocol, protoErr := readProtocolVersion(binPath)
+	embeddedProtocol, protoErr := readProtocolVersionContext(ctx, binPath)
 	if protoErr != nil {
 		if !errors.Is(protoErr, errVersionFlagUnsupported) {
 			return childPreflight{}, fmt.Errorf("read protocol version: %w", protoErr)
@@ -96,7 +97,7 @@ func preflightChildWithAdminProbe(binPath, slotName string, probeAdmin bool) (ch
 		}
 		childHA = &ha
 
-		if _, adminErr := readAdminAPIVersion(binPath); adminErr != nil {
+		if _, adminErr := readAdminAPIVersionContext(ctx, binPath); adminErr != nil {
 			if !errors.Is(adminErr, errVersionFlagUnsupported) {
 				return childPreflight{}, fmt.Errorf("read admin api version: %w", adminErr)
 			}
@@ -104,7 +105,7 @@ func preflightChildWithAdminProbe(binPath, slotName string, probeAdmin bool) (ch
 			adminSupported = true
 		}
 
-		mode, modeErr := readStorageMode(binPath)
+		mode, modeErr := readStorageModeContext(ctx, binPath)
 		if modeErr != nil {
 			if !errors.Is(modeErr, errVersionFlagUnsupported) {
 				return childPreflight{}, fmt.Errorf("read storage mode: %w", modeErr)
@@ -172,12 +173,13 @@ func parseHADeployment(raw string) (bool, error) {
 	}
 }
 
-// readEmbeddedVersion runs binPath with flag and returns trimmed stdout.
-func readEmbeddedVersion(binPath, flag string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), embeddedVersionProbeTimeout)
+// readEmbeddedVersionContext runs binPath with flag and returns trimmed stdout.
+func readEmbeddedVersionContext(parent context.Context, binPath, flag string) (string, error) {
+	ctx, cancel := context.WithTimeout(parent, embeddedVersionProbeTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, binPath, flag)
+	cmd.WaitDelay = time.Second
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -219,18 +221,18 @@ func isUnsupportedVersionFlagError(err error, output string) bool {
 		strings.Contains(msg, "unrecognized option")
 }
 
-func readBinaryLogVersion(binPath string) (string, error) {
-	return readEmbeddedVersion(binPath, printBinaryVersionFlag)
+func readBinaryLogVersionContext(ctx context.Context, binPath string) (string, error) {
+	return readEmbeddedVersionContext(ctx, binPath, printBinaryVersionFlag)
 }
 
-func readProtocolVersion(binPath string) (string, error) {
-	return readEmbeddedVersion(binPath, printProtocolVersionFlag)
+func readProtocolVersionContext(ctx context.Context, binPath string) (string, error) {
+	return readEmbeddedVersionContext(ctx, binPath, printProtocolVersionFlag)
 }
 
-func readAdminAPIVersion(binPath string) (string, error) {
-	return readEmbeddedVersion(binPath, printAdminAPIVersionFlag)
+func readAdminAPIVersionContext(ctx context.Context, binPath string) (string, error) {
+	return readEmbeddedVersionContext(ctx, binPath, printAdminAPIVersionFlag)
 }
 
-func readStorageMode(binPath string) (string, error) {
-	return readEmbeddedVersion(binPath, printStorageModeFlag)
+func readStorageModeContext(ctx context.Context, binPath string) (string, error) {
+	return readEmbeddedVersionContext(ctx, binPath, printStorageModeFlag)
 }

--- a/versioned/internal/process/conditions.go
+++ b/versioned/internal/process/conditions.go
@@ -1,0 +1,84 @@
+package process
+
+type Conditions struct {
+	Available   bool
+	Progressing bool
+	Reconciled  bool
+	Degraded    bool
+	// Serving means at least one running child whose live readiness is current.
+	// Available says a child process exists; Serving says it can take a request
+	// right now — a child that lost its chain subscription is running but not
+	// serving.
+	Serving bool
+	// Converged latches once the manager has run every desired version at least
+	// once. It never clears, so a later download or restart does not retract it.
+	Converged      bool
+	Desired        int
+	Running        int
+	ReconcileError string
+}
+
+func (m *Manager) Conditions() Conditions {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	conditions := m.conditions
+	conditions.Running = runningChildrenLocked(m.processes)
+	conditions.Available = conditions.Running > 0
+	conditions.Serving = servingChildrenLocked(m.processes) > 0
+	converged := conditions.Running == conditions.Desired
+	if converged && conditions.Desired > 0 {
+		m.everConverged = true
+	}
+	progressing := !converged || len(m.downloading) > 0
+	conditions.Reconciled = conditions.Reconciled && !progressing
+	conditions.Progressing = progressing && conditions.ReconcileError == ""
+	conditions.Degraded = conditions.ReconcileError != ""
+	conditions.Converged = m.everConverged
+	return conditions
+}
+
+func (m *Manager) recordReconcileResult(desired int, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.conditions.Desired = desired
+	m.conditions.Reconciled = err == nil
+	m.conditions.ReconcileError = ""
+	if err != nil {
+		m.conditions.ReconcileError = err.Error()
+	}
+}
+
+// ReportReconcileError records a failure before Manager.Reconcile can run,
+// such as an unavailable or invalid oracle response.
+func (m *Manager) ReportReconcileError(err error) {
+	if err == nil {
+		return
+	}
+	m.mu.Lock()
+	m.conditions.Reconciled = false
+	m.conditions.ReconcileError = err.Error()
+	m.mu.Unlock()
+}
+
+// servingChildrenLocked counts running children the readiness monitor currently
+// vouches for — the same predicate ServesVersion applies per version, so the
+// coarse and the per-version answers cannot drift apart.
+func servingChildrenLocked(children map[string]*child) int {
+	serving := 0
+	for _, child := range children {
+		if child.status == statusRunning && child.servingFresh() {
+			serving++
+		}
+	}
+	return serving
+}
+
+func runningChildrenLocked(children map[string]*child) int {
+	running := 0
+	for _, child := range children {
+		if child.status == statusRunning {
+			running++
+		}
+	}
+	return running
+}

--- a/versioned/internal/process/conditions.go
+++ b/versioned/internal/process/conditions.go
@@ -7,8 +7,8 @@ type Conditions struct {
 	Degraded    bool
 	// Serving means at least one running child whose live readiness is current.
 	// Available says a child process exists; Serving says it can take a request
-	// right now — a child that lost its chain subscription is running but not
-	// serving.
+	// right now. A child that is draining or whose storage became unavailable is
+	// running but not serving.
 	Serving bool
 	// Converged latches once the manager has run every desired version at least
 	// once. It never clears, so a later download or restart does not retract it.

--- a/versioned/internal/process/generation.go
+++ b/versioned/internal/process/generation.go
@@ -1,0 +1,161 @@
+package process
+
+import "log/slog"
+
+type generationState string
+
+const (
+	statusPreparing generationState = "preparing"
+	statusStarting  generationState = "starting"
+	statusRunning   generationState = "running"
+	statusRetiring  generationState = "retiring"
+	statusDraining  generationState = "draining"
+	statusStopping  generationState = "stopping"
+	statusStopped   generationState = "stopped"
+	statusFailed    generationState = "failed"
+)
+
+const unorderedGenerationPhase = -1
+
+type generationStateSpec struct {
+	phase        int
+	healthStatus string
+	targets      []generationState
+}
+
+var generationStateTable = map[generationState]generationStateSpec{
+	statusPreparing: {
+		phase:        0,
+		healthStatus: "starting",
+		targets: []generationState{
+			statusStarting,
+			statusRetiring,
+			statusStopping,
+			statusFailed,
+			statusStopped,
+		},
+	},
+	statusStarting: {
+		phase:        1,
+		healthStatus: "starting",
+		targets: []generationState{
+			statusRunning,
+			statusRetiring,
+			statusStopping,
+			statusFailed,
+			statusStopped,
+		},
+	},
+	statusRunning: {
+		phase:        2,
+		healthStatus: "running",
+		targets: []generationState{
+			statusRetiring,
+			statusStopping,
+			statusFailed,
+			statusStopped,
+		},
+	},
+	statusRetiring: {
+		phase:        3,
+		healthStatus: "draining",
+		targets: []generationState{
+			statusDraining,
+			statusStopping,
+			statusStopped,
+		},
+	},
+	statusDraining: {
+		phase:        4,
+		healthStatus: "draining",
+		targets: []generationState{
+			statusStopping,
+			statusStopped,
+		},
+	},
+	statusStopping: {
+		phase:        5,
+		healthStatus: "draining",
+		targets:      []generationState{statusStopped},
+	},
+	statusStopped: {
+		phase:        6,
+		healthStatus: "stopped",
+	},
+	statusFailed: {
+		phase:        unorderedGenerationPhase,
+		healthStatus: "stopped",
+		targets: []generationState{
+			statusStarting,
+			statusRetiring,
+			statusStopping,
+			statusStopped,
+		},
+	},
+}
+
+func validGenerationTransition(from, to generationState) bool {
+	spec, fromKnown := generationStateTable[from]
+	_, toKnown := generationStateTable[to]
+	if !fromKnown || !toKnown {
+		return false
+	}
+	if from == to {
+		return true
+	}
+	for _, target := range spec.targets {
+		if target == to {
+			return true
+		}
+	}
+	return false
+}
+
+// transitionGenerationLocked advances one child generation. Manager.mu must
+// be held so lifecycle changes and route publication remain one transaction.
+func transitionGenerationLocked(c *child, next generationState) bool {
+	if validGenerationTransition(c.status, next) {
+		c.status = next
+		return true
+	}
+	// Drain and shutdown run concurrently. A later phase may win before a
+	// slower worker publishes its earlier phase; that stale transition is
+	// already satisfied and must not move the generation backwards.
+	if generationPhase(c.status) >= 0 &&
+		generationPhase(next) >= 0 &&
+		generationPhase(c.status) > generationPhase(next) {
+		return true
+	}
+	slog.Error(
+		"invalid child generation transition",
+		"version", c.version.Name,
+		"sha256", c.archiveSHA256,
+		"from", c.status,
+		"to", next,
+	)
+	return false
+}
+
+func generationPhase(state generationState) int {
+	spec, ok := generationStateTable[state]
+	if !ok {
+		return unorderedGenerationPhase
+	}
+	return spec.phase
+}
+
+func transitionGenerationFailureLocked(c *child) {
+	if c.restart {
+		transitionGenerationLocked(c, statusFailed)
+		return
+	}
+	transitionGenerationLocked(c, statusStopping)
+}
+
+func healthGenerationStatus(state generationState) string {
+	spec, ok := generationStateTable[state]
+	if !ok {
+		return "stopped"
+	}
+	return spec.healthStatus
+}

--- a/versioned/internal/process/generation_test.go
+++ b/versioned/internal/process/generation_test.go
@@ -1,0 +1,404 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"versioned/internal/config"
+	"versioned/internal/oracle"
+)
+
+func TestGenerationLifecycle(t *testing.T) {
+	c := &child{status: statusPreparing}
+	for _, state := range []generationState{
+		statusStarting,
+		statusRunning,
+		statusRetiring,
+		statusDraining,
+		statusStopping,
+		statusStopped,
+	} {
+		if !transitionGenerationLocked(c, state) {
+			t.Fatalf("transition to %s rejected from %s", state, c.status)
+		}
+	}
+	if validGenerationTransition(c.status, statusRunning) {
+		t.Fatal("terminal generation returned to running")
+	}
+}
+
+func TestGenerationTransitionTable(t *testing.T) {
+	states := []generationState{
+		statusPreparing,
+		statusStarting,
+		statusRunning,
+		statusRetiring,
+		statusDraining,
+		statusStopping,
+		statusStopped,
+		statusFailed,
+	}
+	allowed := map[generationState]map[generationState]bool{
+		statusPreparing: {
+			statusPreparing: true,
+			statusStarting:  true,
+			statusRetiring:  true,
+			statusStopping:  true,
+			statusStopped:   true,
+			statusFailed:    true,
+		},
+		statusStarting: {
+			statusStarting: true,
+			statusRunning:  true,
+			statusRetiring: true,
+			statusStopping: true,
+			statusStopped:  true,
+			statusFailed:   true,
+		},
+		statusRunning: {
+			statusRunning:  true,
+			statusRetiring: true,
+			statusStopping: true,
+			statusStopped:  true,
+			statusFailed:   true,
+		},
+		statusRetiring: {
+			statusRetiring: true,
+			statusDraining: true,
+			statusStopping: true,
+			statusStopped:  true,
+		},
+		statusDraining: {
+			statusDraining: true,
+			statusStopping: true,
+			statusStopped:  true,
+		},
+		statusStopping: {
+			statusStopping: true,
+			statusStopped:  true,
+		},
+		statusStopped: {
+			statusStopped: true,
+		},
+		statusFailed: {
+			statusFailed:   true,
+			statusStarting: true,
+			statusRetiring: true,
+			statusStopping: true,
+			statusStopped:  true,
+		},
+	}
+
+	for _, from := range states {
+		for _, to := range states {
+			if got, want := validGenerationTransition(from, to), allowed[from][to]; got != want {
+				t.Errorf("validGenerationTransition(%s, %s) = %t, want %t", from, to, got, want)
+			}
+		}
+	}
+	if validGenerationTransition("unknown", "unknown") {
+		t.Fatal("unknown generation state accepted a self-transition")
+	}
+}
+
+func TestGenerationStateTableMetadata(t *testing.T) {
+	tests := []struct {
+		state        generationState
+		phase        int
+		healthStatus string
+	}{
+		{state: statusPreparing, phase: 0, healthStatus: "starting"},
+		{state: statusStarting, phase: 1, healthStatus: "starting"},
+		{state: statusRunning, phase: 2, healthStatus: "running"},
+		{state: statusRetiring, phase: 3, healthStatus: "draining"},
+		{state: statusDraining, phase: 4, healthStatus: "draining"},
+		{state: statusStopping, phase: 5, healthStatus: "draining"},
+		{state: statusStopped, phase: 6, healthStatus: "stopped"},
+		{state: statusFailed, phase: unorderedGenerationPhase, healthStatus: "stopped"},
+	}
+	if len(generationStateTable) != len(tests) {
+		t.Fatalf("generation state table has %d states, want %d", len(generationStateTable), len(tests))
+	}
+	for _, test := range tests {
+		if got := generationPhase(test.state); got != test.phase {
+			t.Errorf("generationPhase(%s) = %d, want %d", test.state, got, test.phase)
+		}
+		if got := healthGenerationStatus(test.state); got != test.healthStatus {
+			t.Errorf(
+				"healthGenerationStatus(%s) = %q, want %q",
+				test.state,
+				got,
+				test.healthStatus,
+			)
+		}
+	}
+}
+
+func TestGenerationStateTableTargetsAdvancePhase(t *testing.T) {
+	for state, spec := range generationStateTable {
+		for _, target := range spec.targets {
+			targetSpec, ok := generationStateTable[target]
+			if !ok {
+				t.Errorf("%s targets unknown generation state %s", state, target)
+				continue
+			}
+			if spec.phase == unorderedGenerationPhase ||
+				targetSpec.phase == unorderedGenerationPhase {
+				continue
+			}
+			if targetSpec.phase <= spec.phase {
+				t.Errorf(
+					"%s phase %d targets non-advancing %s phase %d",
+					state,
+					spec.phase,
+					target,
+					targetSpec.phase,
+				)
+			}
+		}
+	}
+}
+
+func TestGenerationTransitionTreatsLaterPhaseAsAlreadySatisfied(t *testing.T) {
+	c := &child{status: statusDraining}
+	if !transitionGenerationLocked(c, statusRetiring) {
+		t.Fatal("stale retirement transition was rejected")
+	}
+	if c.status != statusDraining {
+		t.Fatalf("stale transition moved generation back to %s", c.status)
+	}
+}
+
+func TestGenerationHealthStatusKeepsRetirementOutOfRoutes(t *testing.T) {
+	for _, state := range []generationState{statusRetiring, statusDraining, statusStopping} {
+		if got := healthGenerationStatus(state); got != "draining" {
+			t.Fatalf("health status for %s = %q, want draining", state, got)
+		}
+	}
+}
+
+func TestConditionsReportPartialConvergenceAsProgressing(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	m.mu.Lock()
+	m.conditions = Conditions{Desired: 2, Reconciled: true}
+	m.processes["v1"] = &child{status: statusRunning}
+	m.processes["v2"] = &child{status: statusStarting}
+	m.mu.Unlock()
+
+	conditions := m.Conditions()
+	if !conditions.Available || conditions.Reconciled ||
+		!conditions.Progressing || conditions.Degraded {
+		t.Fatalf("unexpected partial conditions: %+v", conditions)
+	}
+	if conditions.ReconcileError != "" {
+		t.Fatalf("expected no failure during progress, got %q", conditions.ReconcileError)
+	}
+
+	m.mu.Lock()
+	m.processes["v2"].status = statusRunning
+	m.mu.Unlock()
+	conditions = m.Conditions()
+	if !conditions.Available || !conditions.Reconciled ||
+		conditions.Progressing || conditions.Degraded {
+		t.Fatalf("unexpected converged conditions: %+v", conditions)
+	}
+}
+
+func TestConditionsKeepServingWhenReconcileSourceFails(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	m.mu.Lock()
+	m.conditions = Conditions{Desired: 1, Reconciled: true}
+	m.processes["v1"] = &child{status: statusRunning}
+	m.mu.Unlock()
+	m.ReportReconcileError(errors.New("oracle unavailable"))
+
+	conditions := m.Conditions()
+	if !conditions.Available || conditions.Reconciled || !conditions.Degraded {
+		t.Fatalf("unexpected source failure conditions: %+v", conditions)
+	}
+	if conditions.ReconcileError != "oracle unavailable" {
+		t.Fatalf("reconcile error = %q", conditions.ReconcileError)
+	}
+	// The child is still running, so the host can still serve. Every versiond
+	// reads the same oracle, so retracting convergence here would take the whole
+	// pool out of rotation over one unreachable control plane.
+	if !conditions.Converged {
+		t.Fatalf("a failed oracle read retracted convergence: %+v", conditions)
+	}
+}
+
+// A new SHA that will not download reaches Degraded by a different route than an
+// unreachable oracle: through the reconcile result rather than ReportReconcileError.
+// The old child is deliberately kept running (see downloadAndSwap), so the host
+// can still serve, and the conditions a balancer consumes must say so — this
+// failure arrives on every host at once, since they all read the same archive.
+func TestConditionsKeepServingWhenAnUpdateFailsToInstall(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	m.mu.Lock()
+	m.conditions = Conditions{Desired: 1, Reconciled: true}
+	m.processes["v1"] = &child{status: statusRunning}
+	m.mu.Unlock()
+	if !m.Conditions().Converged {
+		t.Fatal("host should have converged on its running child")
+	}
+
+	m.recordReconcileResult(1, errors.New("download or start v2: archive sha mismatch"))
+
+	conditions := m.Conditions()
+	if !conditions.Available {
+		t.Fatalf("the old child is still running but the host reports unavailable: %+v", conditions)
+	}
+	if !conditions.Converged {
+		t.Fatalf("a failed install retracted convergence: %+v", conditions)
+	}
+	if !conditions.Degraded || conditions.ReconcileError == "" {
+		t.Fatalf("the failure must still be reported as degraded: %+v", conditions)
+	}
+}
+
+func TestConditionsReportBinaryReplacementAsProgressing(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	m.mu.Lock()
+	m.conditions = Conditions{Desired: 1, Reconciled: true}
+	m.processes["v1"] = &child{status: statusRunning}
+	m.downloading["v1"] = struct{}{}
+	m.mu.Unlock()
+
+	conditions := m.Conditions()
+	if !conditions.Available || conditions.Reconciled ||
+		!conditions.Progressing || conditions.Degraded {
+		t.Fatalf("unexpected replacement conditions: %+v", conditions)
+	}
+}
+
+func TestAvailabilityEventRearmsAfterRouteLoss(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	addRunning := func() {
+		m.mu.Lock()
+		m.processes["v1"] = &child{
+			version: oracle.Version{Name: "v1"},
+			port:    5000,
+			status:  statusRunning,
+		}
+		m.rebuildRoutes()
+		m.mu.Unlock()
+	}
+	remove := func() {
+		m.mu.Lock()
+		delete(m.processes, "v1")
+		m.rebuildRoutes()
+		m.mu.Unlock()
+	}
+
+	addRunning()
+	select {
+	case <-m.Available():
+	case <-time.After(time.Second):
+		t.Fatal("initial availability event was not published")
+	}
+	remove()
+	addRunning()
+	select {
+	case <-m.Available():
+	case <-time.After(time.Second):
+		t.Fatal("availability event was not rearmed")
+	}
+}
+
+func TestHostDrainCancelsBlockedReconcileOperation(t *testing.T) {
+	dir := t.TempDir()
+	overridePath := filepath.Join(dir, "override")
+	if err := os.WriteFile(overridePath, []byte("replacement"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stopCalled := make(chan struct{})
+	existing := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: "old",
+		binPath:       filepath.Join(dir, "installed"),
+		status:        statusRunning,
+		done:          make(chan struct{}),
+		stop:          func() { close(stopCalled) },
+		restart:       true,
+	}
+	m := NewManager(config.Config{
+		BinDir:    filepath.Join(dir, "bin"),
+		DataDir:   filepath.Join(dir, "data"),
+		BasePort:  5000,
+		Overrides: map[string]string{"v1": overridePath},
+	})
+	m.mu.Lock()
+	m.processes["v1"] = existing
+	m.children[existing] = struct{}{}
+	m.mu.Unlock()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- m.Reconcile(context.Background(), []oracle.Version{{Name: "v1"}})
+	}()
+	select {
+	case <-stopCalled:
+	case <-time.After(time.Second):
+		t.Fatal("override reconcile did not enter child wait")
+	}
+
+	m.BeginHostDrain()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, ErrHostDraining) {
+			t.Fatalf("reconcile error = %v, want cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("host drain did not cancel blocked reconcile")
+	}
+}
+
+func TestPreflightHonorsCallerCancellation(t *testing.T) {
+	binPath := filepath.Join(t.TempDir(), "probe")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err := preflightChildWithAdminProbeContext(ctx, binPath, "v1", true)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("preflight error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("canceled preflight took %s", elapsed)
+	}
+}
+
+// The coarse readiness answer must use the same live-readiness predicate as the
+// per-version one: a running child is not a serving child until its monitor
+// vouches for it, and a vouch that has gone stale is no vouch at all.
+func TestConditionsServingRequiresALiveReadyChild(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	c := &child{status: statusRunning}
+	m.mu.Lock()
+	m.conditions = Conditions{Desired: 1}
+	m.processes["v1"] = c
+	m.mu.Unlock()
+
+	if got := m.Conditions(); !got.Available || got.Serving {
+		t.Fatalf("running child without a fresh vouch: Available=%v Serving=%v",
+			got.Available, got.Serving)
+	}
+
+	c.serving.Store(true)
+	c.servingAt.Store(time.Now().UnixNano())
+	if got := m.Conditions(); !got.Serving {
+		t.Fatalf("live-ready child not reflected in Serving: %+v", got)
+	}
+
+	c.servingAt.Store(time.Now().Add(-2 * childReadyStale).UnixNano())
+	if got := m.Conditions(); got.Serving {
+		t.Fatal("a stale readiness answer still counts as serving")
+	}
+}

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -1470,6 +1470,13 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	return ctx.Err()
 }
 
+// ShutdownGrace is the SIGTERM-to-SIGKILL allowance needed by the slowest
+// child. The host shutdown coordinator reserves this tail before spending the
+// rest of its absolute budget on request and lifecycle drain.
+func (m *Manager) ShutdownGrace() time.Duration {
+	return m.childStopTimeout()
+}
+
 func (m *Manager) clearStoppedChildren() {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -27,11 +27,6 @@ import (
 )
 
 const (
-	statusStarting = "starting"
-	statusRunning  = "running"
-	statusDraining = "draining"
-	statusStopped  = "stopped"
-
 	childLoopbackHost            = "127.0.0.1"
 	maxChildPort                 = 65535
 	storageModePostgres          = "postgres"
@@ -42,6 +37,7 @@ const (
 var (
 	errChildPortPoolExhausted = errors.New("child port pool exhausted")
 	errLegacyDrainStatus      = errors.New("drain status endpoint unavailable")
+	ErrHostDraining           = errors.New("versiond host is draining")
 )
 
 type child struct {
@@ -51,16 +47,45 @@ type child struct {
 	storageMode   string
 	binPath       string
 	port          int
-	adminPort     int
+	adminPort     atomic.Int64
 	stop          context.CancelFunc
 	forceStopCh   chan struct{}
 	forceStopOnce sync.Once
 	done          chan struct{} // closed when runChild exits
 	ready         chan struct{} // closed after readiness succeeds
 	readyOnce     sync.Once
-	proxyTarget   *proxy.Target
-	status        string
-	restart       bool
+	// serving is this generation's own live readiness, refreshed by a monitor
+	// started when it begins running. It is per generation on purpose: a probe
+	// answered by a child that has since been swapped out must not decide
+	// anything about its replacement.
+	serving   atomic.Bool
+	servingAt atomic.Int64
+	// legacyWarned rate-limits the legacy-fallback warning to once per
+	// generation: the monitor re-probes every second, and a legacy child
+	// without /ready would otherwise write the same line forever.
+	legacyWarned atomic.Bool
+	proxyTarget  *proxy.Target
+	status       generationState
+	restart      bool
+}
+
+// servingFresh reports whether this generation's readiness monitor currently
+// vouches for it. An answer older than childReadyStale is not an answer: a
+// monitor that has stopped must not freeze the child at "ready".
+func (c *child) servingFresh() bool {
+	if !c.serving.Load() {
+		return false
+	}
+	return time.Since(time.Unix(0, c.servingAt.Load())) < childReadyStale
+}
+
+// noteLegacyFallback records, once per generation, that readiness came through
+// the legacy /healthz fallback rather than /ready.
+func (c *child) noteLegacyFallback(path string) {
+	if c.legacyWarned.CompareAndSwap(false, true) {
+		slog.Warn("ready path unavailable; using legacy readiness fallback",
+			"version", c.version.Name, "port", c.port, "ready_path", path)
+	}
 }
 
 func (c *child) Stop() {
@@ -81,25 +106,40 @@ func (c *child) Done() <-chan struct{} {
 }
 
 type Manager struct {
-	cfg            config.Config
-	processes      map[string]*child
-	draining       map[string][]*child
-	downloading    map[string]struct{}
-	allocatedPorts map[int]struct{}
-	reservedPorts  map[int]struct{}
-	mu             sync.Mutex
-	routes         atomic.Value // proxy.RouteTable
+	cfg             config.Config
+	processes       map[string]*child
+	draining        map[string][]*child
+	children        map[*child]struct{}
+	downloading     map[string]struct{}
+	allocatedPorts  map[int]struct{}
+	reservedPorts   map[int]struct{}
+	operations      map[uint64]controlOperation
+	nextOperationID uint64
+	conditions      Conditions
+	everConverged   bool
+	available       chan struct{}
+	childCtx        context.Context
+	cancelChildren  context.CancelFunc
+	hostDraining    bool
+	mu              sync.Mutex
+	routes          atomic.Value // proxy.RouteTable
 }
 
 func NewManager(cfg config.Config) *Manager {
 	cfg = normalizeConfig(cfg)
+	childCtx, cancelChildren := context.WithCancel(context.Background())
 	m := &Manager{
 		cfg:            cfg,
 		processes:      make(map[string]*child),
 		draining:       make(map[string][]*child),
+		children:       make(map[*child]struct{}),
 		downloading:    make(map[string]struct{}),
 		allocatedPorts: make(map[int]struct{}),
 		reservedPorts:  reservedChildPorts(),
+		operations:     make(map[uint64]controlOperation),
+		childCtx:       childCtx,
+		cancelChildren: cancelChildren,
+		available:      make(chan struct{}, 1),
 	}
 	m.routes.Store(proxy.RouteTable{})
 	return m
@@ -196,38 +236,147 @@ func (m *Manager) RouteTable() *atomic.Value {
 	return &m.routes
 }
 
+// childReadyInterval matches the balancer's own cadence: readiness that is
+// refreshed less often than it is asked about would report a stale answer, and
+// refreshing it more often only adds load. childReadyStale is the point past
+// which a missing refresh is treated as unready — a monitor that has stopped
+// must not freeze the answer at "ready" forever.
+const (
+	childReadyInterval = time.Second
+	childReadyTimeout  = 2 * time.Second
+	childReadyStale    = 5 * time.Second
+)
+
+// ServesVersion reports whether this host can serve the named version right now.
+// It is a pure read of state a monitor keeps current, so a balancer checking
+// every second cannot turn into a probe of the child every second, and no number
+// of concurrent callers can fan out into concurrent probes.
+//
+// Two things have to hold, and neither implies the other. The route table — the
+// same one the proxy uses, so the answer cannot disagree with what a request
+// would get — must have a target for the version. And the generation behind it
+// must still be reporting itself ready: readiness is checked once when a child
+// starts, but a child can lose it afterwards, and a route held open to a child
+// that has gone unready is a route to a host that cannot serve.
+func (m *Manager) ServesVersion(name string) bool {
+	routes, ok := m.routes.Load().(proxy.RouteTable)
+	if !ok {
+		return false
+	}
+	if _, served := routes[name]; !served {
+		return false
+	}
+
+	m.mu.Lock()
+	c := m.processes[name]
+	running := c != nil && c.status == statusRunning
+	m.mu.Unlock()
+	return running && c.servingFresh()
+}
+
+// watchChildReadiness keeps one generation's serving flag current. It is bound to
+// the generation, so a swap simply ends this monitor and starts the next one; a
+// late answer can only ever be written to the child that was asked.
+func (m *Manager) watchChildReadiness(ctx context.Context, c *child) {
+	ticker := time.NewTicker(childReadyInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		m.mu.Lock()
+		stillRunning := c.status == statusRunning
+		port := c.lifecyclePort()
+		publicPort := c.port
+		allowLegacy := int(c.adminPort.Load()) == 0
+		path := m.cfg.ReadyPath
+		m.mu.Unlock()
+		if !stillRunning {
+			return
+		}
+
+		probeCtx, cancel := context.WithTimeout(ctx, childReadyTimeout)
+		client := &http.Client{Timeout: childReadyTimeout}
+		ready, viaLegacy := readyEndpointReady(probeCtx, client, port, path, allowLegacy)
+		if viaLegacy {
+			c.noteLegacyFallback(path)
+		}
+		if ready && !allowLegacy {
+			ready = publicEndpointReady(probeCtx, client, publicPort)
+		}
+		cancel()
+
+		c.serving.Store(ready)
+		c.servingAt.Store(time.Now().UnixNano())
+	}
+}
+
+func (m *Manager) Available() <-chan struct{} {
+	return m.available
+}
+
 func (m *Manager) Status() []health.StatusEntry {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	return m.statusLocked()
+}
+
+func (m *Manager) statusLocked() []health.StatusEntry {
 	out := make([]health.StatusEntry, 0, len(m.processes)+len(m.draining))
 	for _, c := range m.processes {
-		out = append(out, health.StatusEntry{
-			Name:          c.version.Name,
-			Port:          c.port,
-			Status:        c.status,
-			SHA256:        c.archiveSHA256,
-			BinaryVersion: c.binaryVersion,
-		})
+		out = append(out, statusEntry(c))
 	}
 	for _, children := range m.draining {
 		for _, c := range children {
-			out = append(out, health.StatusEntry{
-				Name:          c.version.Name,
-				Port:          c.port,
-				Status:        c.status,
-				SHA256:        c.archiveSHA256,
-				BinaryVersion: c.binaryVersion,
-			})
+			out = append(out, statusEntry(c))
 		}
 	}
+	sortStatusEntries(out)
 	return out
+}
+
+func statusEntry(c *child) health.StatusEntry {
+	return health.StatusEntry{
+		Name:          c.version.Name,
+		Port:          c.port,
+		Status:        healthGenerationStatus(c.status),
+		SHA256:        c.archiveSHA256,
+		BinaryVersion: c.binaryVersion,
+	}
+}
+
+func sortStatusEntries(entries []health.StatusEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Name != entries[j].Name {
+			return entries[i].Name < entries[j].Name
+		}
+		if entries[i].Status != entries[j].Status {
+			return entries[i].Status < entries[j].Status
+		}
+		return entries[i].Port < entries[j].Port
+	})
 }
 
 // Reconcile compares desired state against local state and converges.
 // The desired sha256 is the archive identity from the oracle. Downloaded
 // versions also record local install metadata so we can distinguish archive
 // identity from the extracted executable bytes on disk.
-func (m *Manager) Reconcile(ctx context.Context, desired []oracle.Version) error {
+func (m *Manager) Reconcile(parent context.Context, desired []oracle.Version) error {
+	ctx, operationID, err := m.beginOperation(parent, operationReconcile)
+	if err != nil {
+		return err
+	}
+	defer m.endOperation(operationID)
+	desiredCount, err := m.reconcile(ctx, desired)
+	m.recordReconcileResult(desiredCount, err)
+	return err
+}
+
+func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int, error) {
+
 	// Step 0: build desired set, injecting forced versions.
 	desiredSet := make(map[string]oracle.Version, len(desired))
 	for _, v := range desired {
@@ -295,12 +444,16 @@ func (m *Manager) Reconcile(ctx context.Context, desired []oracle.Version) error
 	m.mu.Unlock()
 
 	// Phase B (no lock): resolve hashes, do disk I/O for overrides and hash checks.
+	var actionErrs []error
 	for _, o := range overrides {
 		if o.blockedByDrain {
 			slog.Info("version start deferred while previous child is draining", "version", o.version.Name)
 			continue
 		}
-		m.reconcileOverride(ctx, o.version, o.overrideSrc, o.binPath)
+		if err := m.reconcileOverride(ctx, o.version, o.overrideSrc, o.binPath); err != nil {
+			slog.Error("override reconcile failed", "version", o.version.Name, "error", err)
+			actionErrs = append(actionErrs, fmt.Errorf("override %s: %w", o.version.Name, err))
+		}
 	}
 
 	var toDownload []versionAction
@@ -316,6 +469,10 @@ func (m *Manager) Reconcile(ctx context.Context, desired []oracle.Version) error
 		desiredHash, err := snap.version.ResolvedSHA256()
 		if err != nil {
 			slog.Error("cannot resolve sha256, skipping", "version", snap.version.Name, "error", err)
+			actionErrs = append(
+				actionErrs,
+				fmt.Errorf("resolve sha256 for %s: %w", snap.version.Name, err),
+			)
 			continue
 		}
 		desiredHashes[snap.version.Name] = desiredHash
@@ -355,6 +512,10 @@ func (m *Manager) Reconcile(ctx context.Context, desired []oracle.Version) error
 
 	// Phase C (lock): apply decisions -- start ready children, mark downloads, stop removed.
 	m.mu.Lock()
+	if m.hostDraining {
+		m.mu.Unlock()
+		return len(desiredSet), ErrHostDraining
+	}
 	var startErrs []error
 	started := 0
 	for _, a := range toStart {
@@ -392,7 +553,7 @@ func (m *Manager) Reconcile(ctx context.Context, desired []oracle.Version) error
 	for name, c := range m.processes {
 		if _, wanted := desiredSet[name]; !wanted {
 			toStop = append(toStop, c)
-			c.status = statusDraining
+			transitionGenerationLocked(c, statusRetiring)
 			c.restart = false
 			delete(m.processes, name)
 			m.draining[name] = append(m.draining[name], c)
@@ -420,18 +581,21 @@ func (m *Manager) Reconcile(ctx context.Context, desired []oracle.Version) error
 	for _, a := range scheduledDownloads {
 		if err := m.downloadAndStart(ctx, a.version, a.sha256); err != nil {
 			slog.Error("download or start failed, skipping", "version", a.version.Name, "error", err)
+			actionErrs = append(actionErrs, fmt.Errorf("download or start %s: %w", a.version.Name, err))
 		}
 	}
 
-	// Zero-downtime swaps -- download THEN stop old process.
+	// Download first, then overlap generations where their storage permits it;
+	// otherwise the stop/start path withdraws the old route before stopping it.
 	for _, a := range toSwap {
 		if err := m.downloadAndSwap(ctx, a.version, a.sha256, a.child); err != nil {
 			slog.Error("swap failed, keeping old version", "version", a.version.Name, "error", err)
+			actionErrs = append(actionErrs, fmt.Errorf("swap %s: %w", a.version.Name, err))
 		}
 	}
 
 	m.gcInstalledVersions(desiredHashes)
-	return errors.Join(startErrs...)
+	return len(desiredSet), errors.Join(append(startErrs, actionErrs...)...)
 }
 
 type versionAction struct {
@@ -449,7 +613,14 @@ func (m *Manager) versionStartBlockedLocked(name string) bool {
 
 // reconcileOverride handles a version with a local override binary.
 // Does disk I/O outside the lock, then takes the lock to update state.
-func (m *Manager) reconcileOverride(ctx context.Context, v oracle.Version, overrideSrc, binPath string) {
+func (m *Manager) reconcileOverride(ctx context.Context, v oracle.Version, overrideSrc, binPath string) error {
+	m.mu.Lock()
+	if m.hostDraining {
+		m.mu.Unlock()
+		return ErrHostDraining
+	}
+	m.mu.Unlock()
+
 	if stat, statErr := os.Stat(overrideSrc); statErr != nil {
 		slog.Error(
 			"override path missing or unreadable",
@@ -458,7 +629,7 @@ func (m *Manager) reconcileOverride(ctx context.Context, v oracle.Version, overr
 			"env_key", fmt.Sprintf("VERSIOND_OVERRIDE_%s", strings.ReplaceAll(v.Name, ".", "_")),
 			"error", statErr,
 		)
-		return
+		return statErr
 	} else if stat.IsDir() {
 		slog.Error(
 			"override path points to directory, expected file",
@@ -466,13 +637,13 @@ func (m *Manager) reconcileOverride(ctx context.Context, v oracle.Version, overr
 			"path", overrideSrc,
 			"env_key", fmt.Sprintf("VERSIOND_OVERRIDE_%s", strings.ReplaceAll(v.Name, ".", "_")),
 		)
-		return
+		return fmt.Errorf("override path %s is a directory", overrideSrc)
 	}
 
 	srcHash, err := download.HashFile(overrideSrc)
 	if err != nil {
 		slog.Error("override source unreadable", "version", v.Name, "path", overrideSrc, "error", err)
-		return
+		return err
 	}
 	overrideID := "override:" + srcHash
 
@@ -484,55 +655,60 @@ func (m *Manager) reconcileOverride(ctx context.Context, v oracle.Version, overr
 	if isRunning && existing.binPath == binPath && existing.archiveSHA256 == overrideID {
 		diskHash, hashErr := download.HashFile(binPath)
 		if hashErr == nil && diskHash == srcHash {
-			return // already running the same override binary
+			return nil // already running the same override binary
 		}
 	}
 	if isRunning {
-		// Override source changed: stop old, copy new, start.
+		m.mu.Lock()
+		if m.hostDraining {
+			m.mu.Unlock()
+			return ErrHostDraining
+		}
+		proxyDrained, retired := m.retireChildForStopStartLocked(existing)
+		m.mu.Unlock()
+		if !retired {
+			return nil
+		}
+
+		// Override source changed: withdraw the route, let requests that already
+		// own its target lease finish, then stop, copy and start.
 		slog.Info("override binary changed, restarting", "version", v.Name)
-		existing.Stop()
-		waitForChild(existing)
+		if err := m.stopRetiredChild(ctx, existing, proxyDrained); err != nil {
+			return err
+		}
 	}
 
 	// Disk I/O outside the lock.
 	binDir := filepath.Join(m.cfg.BinDir, v.Name)
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		slog.Error("override mkdir failed", "version", v.Name, "error", err)
-		return
+		return err
 	}
 
 	if err := atomicCopy(overrideSrc, binPath); err != nil {
 		slog.Error("override copy failed", "version", v.Name, "error", err)
-		return
+		return err
 	}
 
 	slog.Info("using override binary", "version", v.Name, "path", overrideSrc)
 
 	m.mu.Lock()
-	// Verify the process is still the one we captured before deleting.
-	// A concurrent reconcile could have replaced it.
-	if isRunning {
-		if current, ok := m.processes[v.Name]; ok {
-			if current != existing {
-				m.mu.Unlock()
-				return
-			}
-			delete(m.processes, v.Name)
-		} else if m.versionStartBlockedLocked(v.Name) {
-			m.mu.Unlock()
-			return
-		}
-	} else if _, running := m.processes[v.Name]; running || m.versionStartBlockedLocked(v.Name) {
+	if m.hostDraining {
 		m.mu.Unlock()
-		return
+		return ErrHostDraining
+	}
+	if _, running := m.processes[v.Name]; running || m.versionStartBlockedLocked(v.Name) {
+		m.mu.Unlock()
+		return nil
 	}
 	if err := m.startChild(ctx, v, overrideID, binPath, true); err != nil {
 		m.mu.Unlock()
 		slog.Error("override start failed", "version", v.Name, "error", err)
-		return
+		return err
 	}
 	m.rebuildRoutes()
 	m.mu.Unlock()
+	return nil
 }
 
 func versionNames(vs []oracle.Version) []string {
@@ -708,7 +884,7 @@ func (m *Manager) downloadAndStart(ctx context.Context, v oracle.Version, sha st
 	delete(m.downloading, v.Name)
 	_, running := m.processes[v.Name]
 	var startErr error
-	if dlErr == nil && ctx.Err() == nil && !running && !m.versionStartBlockedLocked(v.Name) {
+	if dlErr == nil && ctx.Err() == nil && !m.hostDraining && !running && !m.versionStartBlockedLocked(v.Name) {
 		startErr = m.startChild(ctx, v, sha, m.installBinPath(v.Name, sha), true)
 	}
 	m.mu.Unlock()
@@ -721,8 +897,9 @@ func (m *Manager) downloadAndStart(ctx context.Context, v oracle.Version, sha st
 	return nil
 }
 
-// downloadAndSwap downloads the new binary, starts it on a fresh port, swaps the
-// route after readiness, and drains the old child out of band.
+// downloadAndSwap downloads the new binary. Shared-storage generations overlap:
+// the replacement starts on a fresh port before the route swap. Other storage
+// modes withdraw and drain the old route before a stop/start replacement.
 func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha string, old *child) error {
 	dlErr := m.downloadBinary(ctx, v, sha)
 	if dlErr != nil || ctx.Err() != nil {
@@ -736,7 +913,19 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 	}
 
 	newBinPath := m.installBinPath(v.Name, sha)
-	preflight, err := preflightChildWithAdminProbe(newBinPath, v.Name, m.devshardAdminEligible())
+	m.mu.Lock()
+	if m.hostDraining {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		return ErrHostDraining
+	}
+	m.mu.Unlock()
+	preflight, err := preflightChildWithAdminProbeContext(
+		ctx,
+		newBinPath,
+		v.Name,
+		m.devshardAdminEligible(),
+	)
 	if err != nil {
 		m.mu.Lock()
 		delete(m.downloading, v.Name)
@@ -745,12 +934,40 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 	}
 	if !m.rollingOverlapAllowed(v.Name, old, preflight.storageMode) {
 		slog.Warn("rolling overlap disabled without shared storage; falling back to stop/start swap", "version", v.Name)
-		old.Stop()
-		waitForChild(old)
+		m.mu.Lock()
+		if m.hostDraining {
+			delete(m.downloading, v.Name)
+			m.mu.Unlock()
+			return ErrHostDraining
+		}
+		proxyDrained, retired := m.retireChildForStopStartLocked(old)
+		m.mu.Unlock()
+		if !retired {
+			m.mu.Lock()
+			delete(m.downloading, v.Name)
+			m.mu.Unlock()
+			return fmt.Errorf("current child changed before stop/start swap")
+		}
+		if err := m.stopRetiredChild(ctx, old, proxyDrained); err != nil {
+			m.mu.Lock()
+			delete(m.downloading, v.Name)
+			m.mu.Unlock()
+			return err
+		}
+
 		m.mu.Lock()
 		delete(m.downloading, v.Name)
-		if current, ok := m.processes[v.Name]; ok && current == old {
-			delete(m.processes, v.Name)
+		if m.hostDraining {
+			m.mu.Unlock()
+			return ErrHostDraining
+		}
+		if err := ctx.Err(); err != nil {
+			m.mu.Unlock()
+			return err
+		}
+		if _, running := m.processes[v.Name]; running || m.versionStartBlockedLocked(v.Name) {
+			m.mu.Unlock()
+			return fmt.Errorf("version %s became active while stop/start swap was draining", v.Name)
 		}
 		startErr := m.startChild(ctx, v, sha, newBinPath, true)
 		m.mu.Unlock()
@@ -761,6 +978,11 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 	}
 
 	m.mu.Lock()
+	if m.hostDraining {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		return ErrHostDraining
+	}
 	newChild, startErr := m.newChild(ctx, v, sha, newBinPath, false)
 	if startErr != nil {
 		delete(m.downloading, v.Name)
@@ -771,7 +993,7 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 	go m.runChild(newChild.ctx, newChild.child)
 	if err := waitForChildReady(ctx, newChild.child); err != nil {
 		newChild.child.Stop()
-		waitForChild(newChild.child)
+		_ = waitForChildContext(ctx, newChild.child)
 		m.mu.Lock()
 		delete(m.downloading, v.Name)
 		m.mu.Unlock()
@@ -780,19 +1002,25 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 
 	m.mu.Lock()
 	delete(m.downloading, v.Name)
+	if m.hostDraining {
+		m.mu.Unlock()
+		newChild.child.Stop()
+		_ = waitForChildContext(ctx, newChild.child)
+		return ErrHostDraining
+	}
 	if current, ok := m.processes[v.Name]; !ok || current != old {
 		m.mu.Unlock()
 		newChild.child.Stop()
-		waitForChild(newChild.child)
+		_ = waitForChildContext(ctx, newChild.child)
 		return fmt.Errorf("current child changed during swap")
 	}
 	if newChild.child.status != statusRunning || childDone(newChild.child) {
 		m.mu.Unlock()
 		newChild.child.Stop()
-		waitForChild(newChild.child)
+		_ = waitForChildContext(ctx, newChild.child)
 		return fmt.Errorf("new child stopped before swap")
 	}
-	old.status = statusDraining
+	transitionGenerationLocked(old, statusRetiring)
 	old.restart = false
 	delete(m.processes, v.Name)
 	m.draining[v.Name] = append(m.draining[v.Name], old)
@@ -982,12 +1210,15 @@ type childStart struct {
 	ctx   context.Context
 }
 
-func (m *Manager) newChild(ctx context.Context, v oracle.Version, sha, binPath string, restart bool) (childStart, error) {
+func (m *Manager) newChild(_ context.Context, v oracle.Version, sha, binPath string, restart bool) (childStart, error) {
+	if m.hostDraining {
+		return childStart{}, ErrHostDraining
+	}
 	port, err := m.assignPort()
 	if err != nil {
 		return childStart{}, fmt.Errorf("allocate public port for version %s: %w", v.Name, err)
 	}
-	childCtx, childCancel := context.WithCancel(ctx)
+	childCtx, childCancel := context.WithCancel(m.childCtx)
 	c := &child{
 		version:       v,
 		archiveSHA256: sha,
@@ -997,14 +1228,18 @@ func (m *Manager) newChild(ctx context.Context, v oracle.Version, sha, binPath s
 		forceStopCh:   make(chan struct{}),
 		done:          make(chan struct{}),
 		ready:         make(chan struct{}),
-		status:        statusStarting,
+		status:        statusPreparing,
 		restart:       restart,
 	}
+	m.children[c] = struct{}{}
 	return childStart{child: c, ctx: childCtx}, nil
 }
 
 // startChild must be called with m.mu held.
 func (m *Manager) startChild(ctx context.Context, v oracle.Version, sha, binPath string, restart bool) error {
+	if m.hostDraining {
+		return ErrHostDraining
+	}
 	start, err := m.newChild(ctx, v, sha, binPath, restart)
 	if err != nil {
 		return err
@@ -1015,24 +1250,192 @@ func (m *Manager) startChild(ctx context.Context, v oracle.Version, sha, binPath
 	return nil
 }
 
-func (m *Manager) Shutdown(ctx context.Context) error {
+// BeginHostDrain freezes desired-state changes and crash restarts while the
+// host admission layer waits for already accepted proxy requests to finish.
+func (m *Manager) BeginHostDrain() {
 	m.mu.Lock()
-	children := make([]*child, 0, len(m.processes)+len(m.draining))
-	for _, c := range m.processes {
+	m.hostDraining = true
+	for c := range m.children {
+		c.restart = false
+	}
+	m.downloading = make(map[string]struct{})
+	m.mu.Unlock()
+	m.cancelOperations()
+}
+
+// RequestChildrenDrain removes every child route before issuing lifecycle
+// drain requests. Calls run concurrently and never hold m.mu during network I/O.
+func (m *Manager) RequestChildrenDrain(ctx context.Context) error {
+	children := m.prepareChildrenForDrain()
+	errCh := make(chan error, len(children))
+	var wg sync.WaitGroup
+	for _, c := range children {
+		wg.Add(1)
+		go func(c *child) {
+			defer wg.Done()
+			if err := m.requestDrain(ctx, c); err != nil {
+				errCh <- fmt.Errorf("request drain for %s: %w", c.version.Name, err)
+			}
+		}(c)
+	}
+	wg.Wait()
+	close(errCh)
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// WaitChildrenIdle waits for every child-side lifecycle counter to reach zero.
+// Legacy children without a status endpoint receive the configured compatibility
+// grace before they are considered drained.
+func (m *Manager) WaitChildrenIdle(ctx context.Context) error {
+	children := m.snapshotChildren()
+	errCh := make(chan error, len(children))
+	var wg sync.WaitGroup
+	for _, c := range children {
+		wg.Add(1)
+		go func(c *child) {
+			defer wg.Done()
+			if err := m.waitChildIdle(ctx, c); err != nil {
+				errCh <- fmt.Errorf("wait for %s to drain: %w", c.version.Name, err)
+			}
+		}(c)
+	}
+	wg.Wait()
+	close(errCh)
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) waitChildIdle(ctx context.Context, c *child) error {
+	for {
+		select {
+		case <-c.done:
+			return nil
+		default:
+		}
+
+		inflight, err := m.fetchInflight(ctx, c)
+		if err == nil && inflight == 0 {
+			return nil
+		}
+		if errors.Is(err, errLegacyDrainStatus) {
+			slog.Warn(
+				"drain status endpoint unavailable; waiting legacy drain grace",
+				"version", c.version.Name,
+				"port", c.port,
+				"grace", m.cfg.DrainKillGrace,
+			)
+			timer := time.NewTimer(m.cfg.DrainKillGrace)
+			defer timer.Stop()
+			select {
+			case <-c.done:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-timer.C:
+				return nil
+			}
+		}
+		if err != nil {
+			slog.Warn("child drain status failed; retrying", "version", c.version.Name, "error", err)
+		}
+		timer := time.NewTimer(m.cfg.DrainPollInterval)
+		select {
+		case <-c.done:
+			timer.Stop()
+			return nil
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (m *Manager) prepareChildrenForDrain() []*child {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hostDraining = true
+	children := m.allChildrenLocked()
+	for _, c := range children {
+		c.restart = false
+		if !childDone(c) {
+			transitionGenerationLocked(c, statusRetiring)
+		}
+		delete(m.processes, c.version.Name)
+		m.appendDrainingLocked(c)
+	}
+	m.downloading = make(map[string]struct{})
+	m.rebuildRoutes()
+	return children
+}
+
+func (m *Manager) appendDrainingLocked(target *child) {
+	for _, c := range m.draining[target.version.Name] {
+		if c == target {
+			return
+		}
+	}
+	m.draining[target.version.Name] = append(m.draining[target.version.Name], target)
+}
+
+func (m *Manager) allChildrenLocked() []*child {
+	seen := make(map[*child]struct{}, len(m.children)+len(m.processes)+len(m.draining))
+	children := make([]*child, 0, len(m.children)+len(m.processes)+len(m.draining))
+	appendChild := func(c *child) {
+		if c == nil {
+			return
+		}
+		if _, ok := seen[c]; ok {
+			return
+		}
+		seen[c] = struct{}{}
 		children = append(children, c)
-		c.Stop()
+	}
+	for c := range m.children {
+		appendChild(c)
+	}
+	for _, c := range m.processes {
+		appendChild(c)
 	}
 	for _, draining := range m.draining {
 		for _, c := range draining {
-			children = append(children, c)
-			c.Stop()
+			appendChild(c)
 		}
 	}
-	m.processes = make(map[string]*child)
-	m.draining = make(map[string][]*child)
-	m.downloading = make(map[string]struct{})
-	m.rebuildRoutes()
-	m.mu.Unlock()
+	return children
+}
+
+func (m *Manager) snapshotChildren() []*child {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.allChildrenLocked()
+}
+
+func (m *Manager) ForceStopChildren() {
+	m.cancelOperations()
+	m.cancelChildren()
+	for _, c := range m.snapshotChildren() {
+		c.ForceStop()
+	}
+}
+
+func (m *Manager) Shutdown(ctx context.Context) error {
+	children := m.prepareChildrenForDrain()
+	defer m.clearStoppedChildren()
+	for _, c := range children {
+		m.mu.Lock()
+		transitionGenerationLocked(c, statusStopping)
+		m.mu.Unlock()
+		c.Stop()
+	}
+	m.cancelChildren()
 
 	if len(children) == 0 {
 		return nil
@@ -1067,25 +1470,42 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (m *Manager) ShutdownTimeout() time.Duration {
-	return m.childStopTimeout()
+func (m *Manager) clearStoppedChildren() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.processes = make(map[string]*child)
+	m.draining = make(map[string][]*child)
+	m.children = make(map[*child]struct{})
+	m.downloading = make(map[string]struct{})
+	m.rebuildRoutes()
 }
 
 func waitForChild(c *child) {
 	<-c.Done()
 }
 
+func waitForChildContext(ctx context.Context, c *child) error {
+	select {
+	case <-c.Done():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (m *Manager) runChild(ctx context.Context, c *child) {
 	defer close(c.done)
 	defer func() {
 		m.mu.Lock()
+		transitionGenerationLocked(c, statusStopped)
+		delete(m.children, c)
 		if current, ok := m.processes[c.version.Name]; ok && current == c {
 			delete(m.processes, c.version.Name)
 			m.rebuildRoutes()
 		}
 		m.removeDrainingLocked(c)
 		m.releasePort(c.port)
-		m.releasePort(c.adminPort)
+		m.releasePort(int(c.adminPort.Load()))
 		m.mu.Unlock()
 	}()
 
@@ -1095,24 +1515,33 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 		return
 	}
 
-	preflight, err := preflightChildWithAdminProbe(c.binPath, c.version.Name, m.devshardAdminEligible())
+	preflight, err := preflightChildWithAdminProbeContext(
+		ctx,
+		c.binPath,
+		c.version.Name,
+		m.devshardAdminEligible(),
+	)
 	if err != nil {
 		slog.Error("child preflight failed", "version", c.version.Name, "bin", c.binPath, "error", err)
+		m.mu.Lock()
+		transitionGenerationFailureLocked(c)
+		m.mu.Unlock()
 		return
 	}
 	m.mu.Lock()
 	c.binaryVersion = preflight.binaryLogVersion
 	c.storageMode = preflight.storageMode
-	if preflight.adminAPISupported && c.adminPort == 0 {
+	if preflight.adminAPISupported && c.adminPort.Load() == 0 {
 		adminPort, portErr := m.assignPort()
 		if portErr != nil {
-			c.status = statusStopped
+			transitionGenerationFailureLocked(c)
 			m.mu.Unlock()
 			slog.Error("allocate child admin port failed", "version", c.version.Name, "error", portErr)
 			return
 		}
-		c.adminPort = adminPort
+		c.adminPort.Store(int64(adminPort))
 	}
+	transitionGenerationLocked(c, statusStarting)
 	adminAddr := c.adminAddr()
 	m.mu.Unlock()
 
@@ -1135,13 +1564,42 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 		cmd.Stderr = os.Stderr
 
 		lastStart = time.Now()
-		slog.Info("starting child", "version", c.version.Name, "port", c.port, "admin_addr", adminAddr, "sha256", c.archiveSHA256)
 
+		// The fork is linearised with the drain barrier: the guard and
+		// cmd.Start happen under the same m.mu that BeginHostDrain and
+		// prepareChildrenForDrain take, so only two orders exist — the process
+		// starts before the barrier and the drain sees and stops it, or the
+		// barrier is up first and the process never starts. A guard that
+		// released the lock before forking would only narrow the window:
+		// retirement could land between the check and cmd.Start.
+		//
+		// Both halves of the barrier matter. BeginHostDrain sets hostDraining
+		// long before RequestChildrenDrain retires the generations, and a child
+		// finishing its preflight during the announce window sits in `starting`
+		// — still legal by phase, already frozen by contract. The orphan would
+		// get no route, yet WaitChildrenIdle would out-wait its startup on a
+		// port nobody listens on: an evacuation stretched by a whole preflight
+		// and ready timeout for a child that exists only to be killed.
+		// startSupervisedProcess is fork/exec plus watcher goroutines; it does
+		// no child I/O, so holding m.mu across it does not violate the
+		// no-network-under-mutex rule.
+		m.mu.Lock()
+		if m.hostDraining || generationPhase(c.status) >= generationPhase(statusRetiring) {
+			slog.Info("child start suppressed; the host is draining or the generation retired",
+				"version", c.version.Name, "status", c.status, "host_draining", m.hostDraining)
+			m.mu.Unlock()
+			return
+		}
+		if c.status == statusFailed {
+			transitionGenerationLocked(c, statusStarting)
+		}
+		slog.Info("starting child", "version", c.version.Name, "port", c.port, "admin_addr", adminAddr, "sha256", c.archiveSHA256)
 		proc, err := startSupervisedProcess(cmd, ctx.Done(), c.forceStopCh, m.childStopTimeout())
+		m.mu.Unlock()
 		if err != nil {
 			slog.Error("child start failed", "version", c.version.Name, "error", err)
 			m.mu.Lock()
-			c.status = statusStopped
+			transitionGenerationFailureLocked(c)
 			m.mu.Unlock()
 			return
 		}
@@ -1151,8 +1609,8 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 			proc.ForceStop()
 			_ = proc.Wait()
 			m.mu.Lock()
-			c.status = statusStopped
 			restart := c.restart
+			transitionGenerationFailureLocked(c)
 			if current, ok := m.processes[c.version.Name]; ok && current == c {
 				m.rebuildRoutes()
 			}
@@ -1169,8 +1627,16 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 			}
 			continue
 		}
+		// Seed the readiness flag before anything can see the route. close(c.ready)
+		// wakes the swap path, which publishes this generation itself, and a
+		// published route whose flag is still false answers 503 to the balancer's
+		// next per-version check — with fall 1, one such answer evicts the host,
+		// and a fleet-wide rolling update would blink the whole pool.
+		c.serving.Store(true)
+		c.servingAt.Store(time.Now().UnixNano())
+
 		m.mu.Lock()
-		c.status = statusRunning
+		transitionGenerationLocked(c, statusRunning)
 		c.proxyTarget = proxy.NewTarget(fmt.Sprintf("localhost:%d", c.port))
 		c.readyOnce.Do(func() { close(c.ready) })
 		if current, ok := m.processes[c.version.Name]; ok && current == c {
@@ -1178,7 +1644,20 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 		}
 		m.mu.Unlock()
 
+		// The monitor owns the flag from here. Its context is scoped to this
+		// process attempt and it is awaited after the process exits: a monitor
+		// left running through a quick crash-restart could otherwise finish a
+		// probe of the dead process and write the answer over the next attempt's.
+		monitorCtx, cancelMonitor := context.WithCancel(ctx)
+		monitorDone := make(chan struct{})
+		go func() {
+			defer close(monitorDone)
+			m.watchChildReadiness(monitorCtx, c)
+		}()
+
 		err = proc.Wait()
+		cancelMonitor()
+		<-monitorDone
 
 		select {
 		case <-ctx.Done():
@@ -1189,8 +1668,8 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 		slog.Error("child exited", "version", c.version.Name, "error", err)
 
 		m.mu.Lock()
-		c.status = statusStopped
 		restart := c.restart
+		transitionGenerationFailureLocked(c)
 		if current, ok := m.processes[c.version.Name]; ok && current == c {
 			m.rebuildRoutes()
 		}
@@ -1303,7 +1782,6 @@ func (m *Manager) rollingOverlapAllowed(versionName string, old *child, newMode 
 		)
 		return false
 	}
-
 	if newMode != storageModePostgres {
 		slog.Warn(
 			"rolling overlap disabled: new devshard storage mode is not postgres",
@@ -1336,35 +1814,41 @@ func childDone(c *child) bool {
 }
 
 func (c *child) lifecyclePort() int {
-	if c.adminPort != 0 {
-		return c.adminPort
+	if adminPort := int(c.adminPort.Load()); adminPort != 0 {
+		return adminPort
 	}
 	return c.port
 }
 
 func (c *child) adminAddr() string {
-	if c.adminPort == 0 {
+	adminPort := int(c.adminPort.Load())
+	if adminPort == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%s:%d", childLoopbackHost, c.adminPort)
-}
-
-func waitForReady(ctx context.Context, port int, path string, timeout time.Duration) bool {
-	return waitForReadiness(ctx, timeout, func(probeCtx context.Context, client *http.Client) bool {
-		return readyEndpointReady(probeCtx, client, port, path, true)
-	})
+	return fmt.Sprintf("%s:%d", childLoopbackHost, adminPort)
 }
 
 // waitForChildServingReady gates the Starting -> Running transition. Modern
 // devshardd children must be logically ready on their admin listener and also
 // serve health checks on the public listener that receives proxied traffic.
 func waitForChildServingReady(ctx context.Context, c *child, path string, timeout time.Duration) bool {
-	if c.adminPort == 0 {
-		return waitForReady(ctx, c.port, path, timeout)
+	adminPort := int(c.adminPort.Load())
+	if adminPort == 0 {
+		return waitForReadiness(
+			ctx,
+			timeout,
+			func(probeCtx context.Context, client *http.Client) bool {
+				ready, viaLegacy := readyEndpointReady(probeCtx, client, c.port, path, true)
+				if viaLegacy {
+					c.noteLegacyFallback(path)
+				}
+				return ready
+			},
+		)
 	}
 	return waitForReadiness(ctx, timeout, func(probeCtx context.Context, client *http.Client) bool {
-		return readyEndpointReady(probeCtx, client, c.adminPort, path, false) &&
-			publicEndpointReady(probeCtx, client, c.port)
+		ready, _ := readyEndpointReady(probeCtx, client, adminPort, path, false)
+		return ready && publicEndpointReady(probeCtx, client, c.port)
 	})
 }
 
@@ -1390,20 +1874,23 @@ func waitForReadiness(
 	}
 }
 
-func readyEndpointReady(ctx context.Context, client *http.Client, port int, path string, allowLegacy bool) bool {
+// readyEndpointReady reports readiness and whether the answer came through the
+// legacy /healthz fallback. Logging that fallback is the caller's job: this runs
+// once a second per child from the monitor, and only the caller knows the
+// generation it belongs to.
+func readyEndpointReady(ctx context.Context, client *http.Client, port int, path string, allowLegacy bool) (ready, viaLegacy bool) {
 	readyPath := normalizeHTTPPath(path)
 	status, err := getHTTPStatus(ctx, client, port, readyPath)
 	if err != nil {
-		return false
+		return false, false
 	}
 	if status == http.StatusOK {
-		return true
+		return true, false
 	}
 	if allowLegacy && legacyReadyFallbackAllowed(readyPath, status) && legacyReady(ctx, client, port) {
-		slog.Warn("ready path unavailable; using legacy readiness fallback", "port", port, "ready_path", readyPath, "status", status)
-		return true
+		return true, true
 	}
-	return false
+	return false, false
 }
 
 func publicEndpointReady(ctx context.Context, client *http.Client, port int) bool {
@@ -1477,24 +1964,24 @@ func normalizeHTTPPath(path string) string {
 	return "/" + path
 }
 
-func (m *Manager) requestDrain(c *child) {
+func (m *Manager) requestDrain(ctx context.Context, c *child) error {
 	lifecyclePort := c.lifecyclePort()
 	url := fmt.Sprintf("http://%s:%d%s", childLoopbackHost, lifecyclePort, normalizeHTTPPath(m.cfg.DrainPath))
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	requestCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, url, nil)
 	if err != nil {
-		return
+		return err
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		slog.Warn("drain request failed", "version", c.version.Name, "port", c.port, "lifecycle_port", lifecyclePort, "error", err)
-		return
+		return err
 	}
 	_ = resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		slog.Warn("drain request returned non-success", "version", c.version.Name, "port", c.port, "lifecycle_port", lifecyclePort, "status", resp.StatusCode)
+		return fmt.Errorf("drain request returned %d", resp.StatusCode)
 	}
+	return nil
 }
 
 func (m *Manager) drainAfterProxy(c *child, proxyDrained <-chan struct{}) {
@@ -1510,12 +1997,13 @@ func (m *Manager) drainAfterProxy(c *child, proxyDrained <-chan struct{}) {
 	case <-timer.C:
 		slog.Warn("proxy drain timeout reached", "version", c.version.Name, "port", c.port)
 	}
-	m.requestDrain(c)
+	m.mu.Lock()
+	transitionGenerationLocked(c, statusDraining)
+	m.mu.Unlock()
+	if err := m.requestDrain(context.Background(), c); err != nil {
+		slog.Warn("drain request failed", "version", c.version.Name, "port", c.port, "error", err)
+	}
 	m.drainAndStopBefore(c, deadline)
-}
-
-func (m *Manager) drainAndStop(c *child) {
-	m.drainAndStopBefore(c, time.Now().Add(m.cfg.DrainTimeout))
 }
 
 func (m *Manager) drainAndStopBefore(c *child, deadline time.Time) {
@@ -1525,7 +2013,7 @@ func (m *Manager) drainAndStopBefore(c *child, deadline time.Time) {
 			return
 		default:
 		}
-		inflight, err := m.fetchInflight(c)
+		inflight, err := m.fetchInflight(context.Background(), c)
 		if errors.Is(err, errLegacyDrainStatus) {
 			slog.Warn(
 				"drain status endpoint unavailable; using legacy drain grace",
@@ -1562,6 +2050,9 @@ func (m *Manager) drainAndStopBefore(c *child, deadline time.Time) {
 		case <-time.After(m.cfg.DrainPollInterval):
 		}
 	}
+	m.mu.Lock()
+	transitionGenerationLocked(c, statusStopping)
+	m.mu.Unlock()
 	c.Stop()
 	waitForChild(c)
 }
@@ -1575,11 +2066,72 @@ func retireProxyTarget(c *child) <-chan struct{} {
 	return drained
 }
 
-func (m *Manager) fetchInflight(c *child) (int64, error) {
-	url := fmt.Sprintf("http://%s:%d%s", childLoopbackHost, c.lifecyclePort(), normalizeHTTPPath(m.cfg.DrainStatusPath))
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+// retireChildForStopStartLocked atomically withdraws one expected generation
+// before a replacement that cannot overlap it. New proxy requests immediately
+// reload a route table without this target; requests that already acquired it
+// remain counted by the returned lease channel. Manager.mu must be held.
+func (m *Manager) retireChildForStopStartLocked(c *child) (<-chan struct{}, bool) {
+	current, ok := m.processes[c.version.Name]
+	if !ok || current != c {
+		return nil, false
+	}
+	transitionGenerationLocked(c, statusRetiring)
+	c.restart = false
+	delete(m.processes, c.version.Name)
+	m.appendDrainingLocked(c)
+	m.rebuildRoutes()
+	return retireProxyTarget(c), true
+}
+
+// stopRetiredChild waits only for requests already admitted by versiond. The
+// configured timeout remains the safety boundary; after it, the child's own
+// graceful shutdown is the final chance for an unusually long request.
+func (m *Manager) stopRetiredChild(
+	ctx context.Context,
+	c *child,
+	proxyDrained <-chan struct{},
+) error {
+	timer := time.NewTimer(m.cfg.DrainTimeout)
+	defer timer.Stop()
+	select {
+	case <-c.done:
+		m.mu.Lock()
+		m.removeDrainingLocked(c)
+		m.mu.Unlock()
+		return nil
+	case <-proxyDrained:
+		slog.Info("proxy requests drained before stop/start", "version", c.version.Name, "port", c.port)
+	case <-ctx.Done():
+		go m.drainAfterProxy(c, proxyDrained)
+		return ctx.Err()
+	case <-timer.C:
+		slog.Warn("proxy drain timeout reached before stop/start", "version", c.version.Name, "port", c.port)
+	}
+
+	m.mu.Lock()
+	transitionGenerationLocked(c, statusStopping)
+	m.mu.Unlock()
+	c.Stop()
+	if err := waitForChildContext(ctx, c); err != nil {
+		return err
+	}
+	// Production runChild removes this entry before closing done. Keeping this
+	// idempotent cleanup here also makes the helper's lifecycle contract explicit.
+	m.mu.Lock()
+	m.removeDrainingLocked(c)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *Manager) fetchInflight(ctx context.Context, c *child) (int64, error) {
+	return m.fetchInflightAt(ctx, c.version.Name, c.port, c.lifecyclePort())
+}
+
+func (m *Manager) fetchInflightAt(ctx context.Context, versionName string, port, lifecyclePort int) (int64, error) {
+	url := fmt.Sprintf("http://%s:%d%s", childLoopbackHost, lifecyclePort, normalizeHTTPPath(m.cfg.DrainStatusPath))
+	requestCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, url, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -1616,7 +2168,7 @@ func (m *Manager) fetchInflight(c *child) (int64, error) {
 	case status.Count != nil:
 		return *status.Count, nil
 	default:
-		return 0, fmt.Errorf("drain status missing inflight count")
+		return 0, fmt.Errorf("drain status missing inflight count for %s on port %d", versionName, port)
 	}
 }
 
@@ -1651,6 +2203,12 @@ func (m *Manager) rebuildRoutes() {
 		}
 	}
 	m.routes.Store(routes)
+	if len(routes) > 0 {
+		select {
+		case m.available <- struct{}{}:
+		default:
+		}
+	}
 	for version, target := range previous {
 		if routes[version] != target {
 			target.Retire()

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -27,11 +27,10 @@ import (
 )
 
 const (
-	childLoopbackHost            = "127.0.0.1"
-	maxChildPort                 = 65535
-	storageModePostgres          = "postgres"
-	defaultDevshardShutdownGrace = 10 * time.Minute
-	installedVersionRetain       = 3
+	childLoopbackHost      = "127.0.0.1"
+	maxChildPort           = 65535
+	storageModePostgres    = "postgres"
+	installedVersionRetain = 3
 )
 
 var (
@@ -169,6 +168,17 @@ func normalizeConfig(cfg config.Config) config.Config {
 	}
 	if cfg.DrainKillGrace <= 0 {
 		cfg.DrainKillGrace = config.DefaultDrainKillGrace
+	}
+	if cfg.ChildShutdownGrace <= 0 {
+		cfg.ChildShutdownGrace = cfg.DrainKillGrace
+		name := strings.ToLower(strings.TrimSpace(cfg.BinaryName))
+		if (name == "devshard" || name == "devshardd") &&
+			config.DefaultDevshardShutdownGrace > cfg.ChildShutdownGrace {
+			cfg.ChildShutdownGrace = config.DefaultDevshardShutdownGrace
+		}
+	}
+	if cfg.ChildShutdownGrace < cfg.DrainKillGrace {
+		cfg.ChildShutdownGrace = cfg.DrainKillGrace
 	}
 	return cfg
 }
@@ -1744,28 +1754,7 @@ func childEnv(binaryLogVersion, adminAddr string, haDeployment *bool) []string {
 }
 
 func (m *Manager) childStopTimeout() time.Duration {
-	timeout := m.cfg.DrainKillGrace
-	name := strings.ToLower(m.cfg.BinaryName)
-	if name != "devshard" && name != "devshardd" {
-		return timeout
-	}
-	shutdownGrace := parseDevshardShutdownGrace(os.Getenv("DEVSHARD_SHUTDOWN_GRACE"))
-	if shutdownGrace > timeout {
-		return shutdownGrace
-	}
-	return timeout
-}
-
-func parseDevshardShutdownGrace(raw string) time.Duration {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return defaultDevshardShutdownGrace
-	}
-	d, err := time.ParseDuration(raw)
-	if err != nil || d <= 0 {
-		return defaultDevshardShutdownGrace
-	}
-	return d
+	return m.cfg.ChildShutdownGrace
 }
 
 func (m *Manager) rollingOverlapAllowed(versionName string, old *child, newMode string) bool {

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -972,20 +972,25 @@ func TestRollingOverlapAllowedRequiresPostgresForDevshard(t *testing.T) {
 	}
 }
 
-func TestChildStopTimeoutHonorsDevshardShutdownGrace(t *testing.T) {
-	t.Setenv("DEVSHARD_SHUTDOWN_GRACE", "")
+func TestChildStopTimeoutUsesEffectiveConfiguredGrace(t *testing.T) {
 	devshardMgr := NewManager(config.Config{BinaryName: "devshardd", DrainKillGrace: 30 * time.Second})
-	if got := devshardMgr.childStopTimeout(); got != defaultDevshardShutdownGrace {
+	if got := devshardMgr.childStopTimeout(); got != config.DefaultDevshardShutdownGrace {
 		t.Fatalf("childStopTimeout = %s, want default devshard grace", got)
 	}
 
-	t.Setenv("DEVSHARD_SHUTDOWN_GRACE", "2m")
-	devshardMgr = NewManager(config.Config{BinaryName: "devshardd", DrainKillGrace: 30 * time.Second})
+	devshardMgr = NewManager(config.Config{
+		BinaryName:         "devshardd",
+		DrainKillGrace:     30 * time.Second,
+		ChildShutdownGrace: 2 * time.Minute,
+	})
 	if got := devshardMgr.childStopTimeout(); got != 2*time.Minute {
-		t.Fatalf("childStopTimeout = %s, want DEVSHARD_SHUTDOWN_GRACE", got)
+		t.Fatalf("childStopTimeout = %s, want configured child shutdown grace", got)
 	}
-	t.Setenv("DEVSHARD_SHUTDOWN_GRACE", "5s")
-	devshardMgr = NewManager(config.Config{BinaryName: "devshardd", DrainKillGrace: 30 * time.Second})
+	devshardMgr = NewManager(config.Config{
+		BinaryName:         "devshardd",
+		DrainKillGrace:     30 * time.Second,
+		ChildShutdownGrace: 5 * time.Second,
+	})
 	if got := devshardMgr.childStopTimeout(); got != 30*time.Second {
 		t.Fatalf("childStopTimeout = %s, want VERSIOND_DRAIN_KILL_GRACE", got)
 	}

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -2828,10 +2828,10 @@ func zipBinary(t *testing.T, binaryName string, data []byte) ([]byte, string) {
 	return zipData, sha256Hex(zipData)
 }
 
-// A child is probed for readiness once when it starts, but it can lose readiness
-// afterwards — devshardd reports itself unready when its chain subscription
-// drops. If versiond kept answering 200 for that version the balancer would hold
-// a route open to a host that cannot serve.
+// A child is probed for readiness once when it starts, but it can lose serving
+// readiness afterwards, for example when its storage becomes unavailable. If
+// versiond kept answering 200 for that version the balancer would hold a route
+// open to a host that cannot serve.
 func TestServesVersion_FollowsTheChildLosingReadiness(t *testing.T) {
 	ready := atomic.Bool{}
 	ready.Store(true)

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -144,7 +145,12 @@ func TestParseHADeployment(t *testing.T) {
 }
 
 func TestPreflightChild_MissingBinary(t *testing.T) {
-	_, err := preflightChild(filepath.Join(t.TempDir(), "missing"), "v2")
+	_, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		filepath.Join(t.TempDir(), "missing"),
+		"v2",
+		false,
+	)
 	if err == nil {
 		t.Fatal("expected error for missing binary")
 	}
@@ -161,7 +167,12 @@ exit 2
 		t.Fatal(err)
 	}
 
-	preflight, err := preflightChild(binPath, "v2")
+	preflight, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +194,12 @@ esac
 		t.Fatal(err)
 	}
 
-	preflight, err := preflightChild(binPath, "v2")
+	preflight, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +221,12 @@ esac
 		t.Fatal(err)
 	}
 
-	preflight, err := preflightChild(binPath, "v2")
+	preflight, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +249,12 @@ esac
 		t.Fatal(err)
 	}
 
-	_, err := preflightChild(binPath, "v2")
+	_, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		false,
+	)
 	if err == nil {
 		t.Fatal("expected protocol mismatch error")
 	}
@@ -248,7 +274,12 @@ esac
 		t.Fatal(err)
 	}
 
-	preflight, err := preflightChild(binPath, "v2")
+	preflight, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +302,12 @@ esac
 		t.Fatal(err)
 	}
 
-	preflight, err := preflightChildWithAdminProbe(binPath, "v2", true)
+	preflight, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		true,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +335,12 @@ esac
 		t.Fatal(err)
 	}
 
-	preflight, err := preflightChildWithAdminProbe(binPath, "v2", true)
+	preflight, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		true,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +368,12 @@ esac
 		t.Fatal(err)
 	}
 
-	if _, err := preflightChildWithAdminProbe(binPath, "v2", true); err == nil {
+	if _, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		true,
+	); err == nil {
 		t.Fatal("expected storage mode probe error to fail preflight")
 	}
 }
@@ -360,7 +406,12 @@ func TestPreflightChild_HAStorageContract(t *testing.T) {
 				binPath = writeStorageModeLegacyBinary(t, dir, "candidate")
 			}
 
-			preflight, err := preflightChildWithAdminProbe(binPath, "v2", true)
+			preflight, err := preflightChildWithAdminProbeContext(
+				context.Background(),
+				binPath,
+				"v2",
+				true,
+			)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected HA storage preflight error")
@@ -398,7 +449,12 @@ esac
 		t.Fatal(err)
 	}
 
-	if _, err := preflightChild(binPath, "v2"); err == nil {
+	if _, err := preflightChildWithAdminProbeContext(
+		context.Background(),
+		binPath,
+		"v2",
+		false,
+	); err == nil {
 		t.Fatal("expected timeout probing protocol version to fail closed")
 	}
 }
@@ -568,12 +624,116 @@ func TestStatusIncludesDrainingChildrenButRoutesDoNot(t *testing.T) {
 	}
 	var sawDraining bool
 	for _, status := range statuses {
-		if status.Status == statusDraining && status.Port == 9001 && status.SHA256 == "old-sha" {
+		if status.Status == "draining" && status.Port == 9001 && status.SHA256 == "old-sha" {
 			sawDraining = true
 		}
 	}
 	if !sawDraining {
 		t.Fatalf("draining child not reported in status: %+v", statuses)
+	}
+}
+
+func TestChildLifetimeIsIndependentFromReconcileContext(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	reconcileCtx, cancelReconcile := context.WithCancel(context.Background())
+	m.mu.Lock()
+	start, err := m.newChild(
+		reconcileCtx,
+		oracle.Version{Name: "v1"},
+		"sha",
+		"/tmp/testapp",
+		true,
+	)
+	m.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cancelReconcile()
+	select {
+	case <-start.ctx.Done():
+		t.Fatal("cancelling reconcile context stopped the child lifetime")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	start.child.Stop()
+	select {
+	case <-start.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("child stop did not cancel its lifetime context")
+	}
+}
+
+func TestBeginHostDrainRejectsReconcileAndDisablesRestart(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	c := &child{
+		version: oracle.Version{Name: "v1"},
+		done:    make(chan struct{}),
+		status:  statusRunning,
+		restart: true,
+	}
+	m.mu.Lock()
+	m.processes[c.version.Name] = c
+	m.children[c] = struct{}{}
+	m.mu.Unlock()
+
+	m.BeginHostDrain()
+	m.mu.Lock()
+	hostDraining := m.hostDraining
+	m.mu.Unlock()
+	if !hostDraining {
+		t.Fatal("manager should report host draining")
+	}
+	if c.restart {
+		t.Fatal("host drain should disable child restart")
+	}
+	if err := m.Reconcile(context.Background(), nil); !errors.Is(err, ErrHostDraining) {
+		t.Fatalf("Reconcile error = %v, want ErrHostDraining", err)
+	}
+}
+
+func TestRequestChildrenDrainRemovesRouteBeforeLifecycleRequest(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000})
+	var drainCalled atomic.Bool
+	adminPort, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/drain" {
+			http.NotFound(w, r)
+			return
+		}
+		if _, ok := m.RouteTable().Load().(proxy.RouteTable)["v1"]; ok {
+			t.Error("child route was still published during lifecycle drain request")
+		}
+		drainCalled.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer shutdown()
+
+	c := &child{
+		version:     oracle.Version{Name: "v1"},
+		port:        9001,
+		done:        make(chan struct{}),
+		status:      statusRunning,
+		restart:     true,
+		proxyTarget: proxy.NewTarget("localhost:9001"),
+	}
+	setTestAdminPort(c, adminPort)
+	m.mu.Lock()
+	m.processes[c.version.Name] = c
+	m.children[c] = struct{}{}
+	m.rebuildRoutes()
+	m.mu.Unlock()
+
+	if err := m.RequestChildrenDrain(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !drainCalled.Load() {
+		t.Fatal("child drain endpoint was not called")
+	}
+	if c.status != statusRetiring {
+		t.Fatalf("child status = %q, want retiring", c.status)
+	}
+	if c.restart {
+		t.Fatal("draining child should not restart")
 	}
 }
 
@@ -824,10 +984,6 @@ func TestChildStopTimeoutHonorsDevshardShutdownGrace(t *testing.T) {
 	if got := devshardMgr.childStopTimeout(); got != 2*time.Minute {
 		t.Fatalf("childStopTimeout = %s, want DEVSHARD_SHUTDOWN_GRACE", got)
 	}
-	if got := devshardMgr.ShutdownTimeout(); got != 2*time.Minute {
-		t.Fatalf("ShutdownTimeout = %s, want DEVSHARD_SHUTDOWN_GRACE", got)
-	}
-
 	t.Setenv("DEVSHARD_SHUTDOWN_GRACE", "5s")
 	devshardMgr = NewManager(config.Config{BinaryName: "devshardd", DrainKillGrace: 30 * time.Second})
 	if got := devshardMgr.childStopTimeout(); got != 30*time.Second {
@@ -1575,6 +1731,97 @@ func TestDrainAfterProxyWaitsBeforeRequestingChildDrain(t *testing.T) {
 	}
 }
 
+func TestStopStartWithdrawsRouteAndWaitsForProxyLease(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseRequest) }) }
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(func() {
+		release()
+		backend.Close()
+	})
+
+	m := NewManager(config.Config{
+		BasePort:     5000,
+		DrainTimeout: time.Second,
+	})
+	childDone := make(chan struct{})
+	stopCalled := make(chan struct{})
+	var stopOnce sync.Once
+	c := &child{
+		version:     oracle.Version{Name: "v1"},
+		port:        9001,
+		done:        childDone,
+		status:      statusRunning,
+		restart:     true,
+		proxyTarget: proxy.NewTarget(strings.TrimPrefix(backend.URL, "http://")),
+		stop: func() {
+			stopOnce.Do(func() {
+				close(stopCalled)
+				close(childDone)
+			})
+		},
+	}
+	m.mu.Lock()
+	m.processes["v1"] = c
+	m.rebuildRoutes()
+	m.mu.Unlock()
+
+	proxyServer := httptest.NewServer(proxy.Handler(m.RouteTable()))
+	defer proxyServer.Close()
+	requestDone := make(chan error, 1)
+	go func() {
+		resp, err := http.Get(proxyServer.URL + "/v1/work")
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		requestDone <- err
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("proxy request did not acquire the old target")
+	}
+
+	m.mu.Lock()
+	proxyDrained, retired := m.retireChildForStopStartLocked(c)
+	m.mu.Unlock()
+	if !retired {
+		t.Fatal("current child was not retired")
+	}
+	if _, routed := m.RouteTable().Load().(proxy.RouteTable)["v1"]; routed {
+		t.Fatal("retired child remained published in the route table")
+	}
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- m.stopRetiredChild(context.Background(), c, proxyDrained)
+	}()
+	select {
+	case <-stopCalled:
+		t.Fatal("child stopped while an acquired proxy request was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	if err := <-requestDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-stopDone; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-stopCalled:
+	case <-time.After(time.Second):
+		t.Fatal("child was not stopped after its proxy lease drained")
+	}
+}
+
 func TestReconcile_RemovedLegacyVersionUsesDrainGraceBeforeCancel(t *testing.T) {
 	dir := t.TempDir()
 	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1667,7 +1914,9 @@ func TestInstalledVersionMatches_DetectsBinaryHashMismatch(t *testing.T) {
 	}
 }
 
-func TestWaitForReadyFallsBackToHealthzWhenDefaultReadyMissing(t *testing.T) {
+func TestWaitForChildServingReadyFallsBackToHealthzWhenDefaultReadyMissing(
+	t *testing.T,
+) {
 	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/healthz" {
 			w.WriteHeader(http.StatusOK)
@@ -1677,18 +1926,30 @@ func TestWaitForReadyFallsBackToHealthzWhenDefaultReadyMissing(t *testing.T) {
 	}))
 	defer shutdown()
 
-	if !waitForReady(context.Background(), port, "/ready", time.Second) {
+	if !waitForChildServingReady(
+		context.Background(),
+		&child{port: port},
+		"/ready",
+		time.Second,
+	) {
 		t.Fatal("expected /ready 404 to fall back to /healthz")
 	}
 }
 
-func TestWaitForReadyDoesNotFallbackForCustomReadyPath(t *testing.T) {
+func TestWaitForChildServingReadyDoesNotFallbackForCustomReadyPath(
+	t *testing.T,
+) {
 	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer shutdown()
 
-	if waitForReady(context.Background(), port, "/custom-ready", 200*time.Millisecond) {
+	if waitForChildServingReady(
+		context.Background(),
+		&child{port: port},
+		"/custom-ready",
+		200*time.Millisecond,
+	) {
 		t.Fatal("custom ready path should not use legacy fallback")
 	}
 }
@@ -1715,7 +1976,8 @@ func TestWaitForChildServingReadyRequiresPublicHealth(t *testing.T) {
 	}))
 	defer publicShutdown()
 
-	c := &child{port: publicPort, adminPort: adminPort}
+	c := &child{port: publicPort}
+	setTestAdminPort(c, adminPort)
 	if waitForChildServingReady(context.Background(), c, "/ready", 200*time.Millisecond) {
 		t.Fatal("admin readiness must not hide an unavailable public listener")
 	}
@@ -1750,7 +2012,8 @@ func TestWaitForChildServingReadyRechecksAdminAndPublicTogether(t *testing.T) {
 	}))
 	defer publicShutdown()
 
-	c := &child{port: publicPort, adminPort: adminPort}
+	c := &child{port: publicPort}
+	setTestAdminPort(c, adminPort)
 	if waitForChildServingReady(context.Background(), c, "/ready", 250*time.Millisecond) {
 		t.Fatal("child became ready without admin and public health at the same time")
 	}
@@ -1759,7 +2022,7 @@ func TestWaitForChildServingReadyRechecksAdminAndPublicTogether(t *testing.T) {
 	}
 }
 
-func TestDrainAndStop_LegacyDrainStatusUsesShortGrace(t *testing.T) {
+func TestDrainAndStopBefore_LegacyDrainStatusUsesShortGrace(t *testing.T) {
 	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
@@ -1784,7 +2047,7 @@ func TestDrainAndStop_LegacyDrainStatusUsesShortGrace(t *testing.T) {
 	}
 
 	start := time.Now()
-	m.drainAndStop(c)
+	m.drainAndStopBefore(c, time.Now().Add(m.cfg.DrainTimeout))
 	if !cancelled {
 		t.Fatal("legacy child should be cancelled after short drain grace")
 	}
@@ -1823,13 +2086,15 @@ func TestLifecycleRequestsUseAdminPortWhenAvailable(t *testing.T) {
 		DrainStatusPath: "/drain/status",
 	})
 	c := &child{
-		version:   oracle.Version{Name: "v1"},
-		port:      publicPort,
-		adminPort: adminPort,
+		version: oracle.Version{Name: "v1"},
+		port:    publicPort,
 	}
+	setTestAdminPort(c, adminPort)
 
-	m.requestDrain(c)
-	inflight, err := m.fetchInflight(c)
+	if err := m.requestDrain(context.Background(), c); err != nil {
+		t.Fatal(err)
+	}
+	inflight, err := m.fetchInflight(context.Background(), c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1847,7 +2112,7 @@ func TestLifecycleRequestsUseAdminPortWhenAvailable(t *testing.T) {
 	}
 }
 
-func TestDrainAndStop_WaitsForIdleBeforeCancel(t *testing.T) {
+func TestDrainAndStopBefore_WaitsForIdleBeforeCancel(t *testing.T) {
 	var statusRequests int32
 	var cancelled atomic.Bool
 	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1880,7 +2145,7 @@ func TestDrainAndStop_WaitsForIdleBeforeCancel(t *testing.T) {
 		},
 	}
 
-	m.drainAndStop(c)
+	m.drainAndStopBefore(c, time.Now().Add(m.cfg.DrainTimeout))
 	if !cancelled.Load() {
 		t.Fatal("idle child should be cancelled after drain")
 	}
@@ -1889,7 +2154,7 @@ func TestDrainAndStop_WaitsForIdleBeforeCancel(t *testing.T) {
 	}
 }
 
-func TestDrainAndStop_TimesOutWithInflightWork(t *testing.T) {
+func TestDrainAndStopBefore_TimesOutWithInflightWork(t *testing.T) {
 	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]int64{"inflight": 1})
 	}))
@@ -1914,12 +2179,94 @@ func TestDrainAndStop_TimesOutWithInflightWork(t *testing.T) {
 	}
 
 	start := time.Now()
-	m.drainAndStop(c)
+	m.drainAndStopBefore(c, time.Now().Add(m.cfg.DrainTimeout))
 	if !cancelled {
 		t.Fatal("child should be cancelled after drain timeout")
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("drain timeout path took %s", elapsed)
+	}
+}
+
+func TestWaitChildrenIdlePollsUntilInflightReachesZero(t *testing.T) {
+	var idle atomic.Bool
+	var firstStatus sync.Once
+	firstStatusSeen := make(chan struct{})
+	adminPort, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstStatus.Do(func() {
+			close(firstStatusSeen)
+		})
+		inflight := int64(1)
+		if idle.Load() {
+			inflight = 0
+		}
+		_ = json.NewEncoder(w).Encode(map[string]int64{"inflight": inflight})
+	}))
+	defer shutdown()
+
+	m := NewManager(config.Config{
+		BasePort:          5000,
+		DrainPollInterval: 5 * time.Millisecond,
+	})
+	c := &child{
+		version: oracle.Version{Name: "v1"},
+		done:    make(chan struct{}),
+	}
+	setTestAdminPort(c, adminPort)
+	m.mu.Lock()
+	m.children[c] = struct{}{}
+	m.mu.Unlock()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- m.WaitChildrenIdle(context.Background())
+	}()
+	select {
+	case <-firstStatusSeen:
+	case <-time.After(time.Second):
+		t.Fatal("child drain status was not polled")
+	}
+	select {
+	case err := <-result:
+		t.Fatalf("WaitChildrenIdle returned while work was in flight: %v", err)
+	default:
+	}
+
+	idle.Store(true)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitChildrenIdle did not return after the child became idle")
+	}
+}
+
+func TestWaitChildrenIdleReturnsDeadlineWhileWorkRemainsInflight(t *testing.T) {
+	adminPort, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]int64{"inflight": 1})
+	}))
+	defer shutdown()
+
+	m := NewManager(config.Config{
+		BasePort:          5000,
+		DrainPollInterval: 5 * time.Millisecond,
+	})
+	c := &child{
+		version: oracle.Version{Name: "v1"},
+		done:    make(chan struct{}),
+	}
+	setTestAdminPort(c, adminPort)
+	m.mu.Lock()
+	m.children[c] = struct{}{}
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	err := m.WaitChildrenIdle(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitChildrenIdle error = %v, want context deadline exceeded", err)
 	}
 }
 
@@ -2354,6 +2701,10 @@ func startLocalHTTPServer(t *testing.T, handler http.Handler) (int, func()) {
 	return ln.Addr().(*net.TCPAddr).Port, shutdown
 }
 
+func setTestAdminPort(c *child, port int) {
+	c.adminPort.Store(int64(port))
+}
+
 func writeStorageModeProbeBinary(t *testing.T, dir, name, storageMode string) string {
 	t.Helper()
 	binPath := filepath.Join(dir, name)
@@ -2475,4 +2826,340 @@ func zipBinary(t *testing.T, binaryName string, data []byte) ([]byte, string) {
 
 	zipData := buf.Bytes()
 	return zipData, sha256Hex(zipData)
+}
+
+// A child is probed for readiness once when it starts, but it can lose readiness
+// afterwards — devshardd reports itself unready when its chain subscription
+// drops. If versiond kept answering 200 for that version the balancer would hold
+// a route open to a host that cannot serve.
+func TestServesVersion_FollowsTheChildLosingReadiness(t *testing.T) {
+	ready := atomic.Bool{}
+	ready.Store(true)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ready" && !ready.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	port := serverPort(t, srv)
+
+	m := NewManager(config.Config{BasePort: 5000, ReadyPath: "/ready"})
+	c := &child{status: statusRunning, port: port, version: oracle.Version{Name: "v4"}}
+	c.serving.Store(true)
+	c.servingAt.Store(time.Now().UnixNano())
+	m.mu.Lock()
+	m.processes["v4"] = c
+	m.rebuildRoutes()
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.watchChildReadiness(ctx, c)
+
+	if !m.ServesVersion("v4") {
+		t.Fatal("a running, ready child does not serve its version")
+	}
+
+	ready.Store(false)
+	if !waitFor(2*time.Second, func() bool { return !m.ServesVersion("v4") }) {
+		t.Fatal("child reports unready but versiond still offers the version")
+	}
+
+	ready.Store(true)
+	if !waitFor(2*time.Second, func() bool { return m.ServesVersion("v4") }) {
+		t.Fatal("child is ready again but versiond does not offer the version")
+	}
+
+	// An unknown version is not served whatever the child says.
+	if m.ServesVersion("v9") {
+		t.Fatal("a version with no route is served")
+	}
+}
+
+// A monitor that has stopped reporting must not leave the answer frozen at
+// "ready": the last thing it said gets old, and old is not an answer.
+func TestServesVersion_StaleReadinessIsNotReadiness(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000, ReadyPath: "/ready"})
+	c := &child{status: statusRunning, port: 1, version: oracle.Version{Name: "v4"}}
+	c.serving.Store(true)
+	c.servingAt.Store(time.Now().Add(-2 * childReadyStale).UnixNano())
+	m.mu.Lock()
+	m.processes["v4"] = c
+	m.rebuildRoutes()
+	m.mu.Unlock()
+
+	if m.ServesVersion("v4") {
+		t.Fatal("a readiness answer older than childReadyStale still counts as ready")
+	}
+}
+
+// Readiness belongs to the generation that was asked. A probe answered by a
+// child that has since been swapped out must not decide anything about its
+// replacement.
+func TestServesVersion_ReadinessIsPerGeneration(t *testing.T) {
+	m := NewManager(config.Config{BasePort: 5000, ReadyPath: "/ready"})
+	old := &child{status: statusRunning, port: 1, version: oracle.Version{Name: "v4"}}
+	old.serving.Store(false)
+	old.servingAt.Store(time.Now().UnixNano())
+
+	replacement := &child{status: statusRunning, port: 2, version: oracle.Version{Name: "v4"}}
+	replacement.serving.Store(true)
+	replacement.servingAt.Store(time.Now().UnixNano())
+
+	m.mu.Lock()
+	m.processes["v4"] = replacement
+	m.rebuildRoutes()
+	m.mu.Unlock()
+
+	if !m.ServesVersion("v4") {
+		t.Fatal("the unready generation that was replaced still decides the answer")
+	}
+
+	// And the reverse: a healthy old generation cannot vouch for an unready one.
+	replacement.serving.Store(false)
+	if m.ServesVersion("v4") {
+		t.Fatal("the current generation is unready but the version is still offered")
+	}
+	_ = old
+}
+
+func waitFor(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return cond()
+}
+
+func serverPort(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split %s: %v", srv.URL, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("port %q: %v", portStr, err)
+	}
+	return port
+}
+
+// The contract the crash-restart path relies on: once the monitor's context is
+// cancelled and its goroutine has been awaited, it writes nothing more. A
+// monitor that survived into the next process attempt would overwrite that
+// attempt's answers with probes of the dead process.
+func TestWatchChildReadiness_WritesNothingAfterCancelAndAwait(t *testing.T) {
+	ready := atomic.Bool{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ready" && !ready.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := NewManager(config.Config{BasePort: 5000, ReadyPath: "/ready"})
+	c := &child{status: statusRunning, port: serverPort(t, srv), version: oracle.Version{Name: "v4"}}
+	c.serving.Store(true)
+	c.servingAt.Store(time.Now().UnixNano())
+	m.mu.Lock()
+	m.processes["v4"] = c
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.watchChildReadiness(ctx, c)
+	}()
+
+	// The monitor is alive and writing: it must observe the unready child.
+	if !waitFor(3*time.Second, func() bool { return !c.serving.Load() }) {
+		t.Fatal("monitor never observed the unready child")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("cancelled monitor did not exit; the restart path would block on it")
+	}
+
+	// From here any write is a bug: flip the child to ready and give a leaked
+	// prober ample time to have finished a probe it might have had in flight.
+	stamp := c.servingAt.Load()
+	ready.Store(true)
+	time.Sleep(2 * childReadyInterval)
+	if c.serving.Load() || c.servingAt.Load() != stamp {
+		t.Fatal("monitor wrote after cancel+await; a restarted child would inherit its answers")
+	}
+}
+
+// The legacy /healthz fallback is worth one line per generation, not one per
+// probe: the monitor asks every second.
+func TestNoteLegacyFallbackWarnsOncePerGeneration(t *testing.T) {
+	c := &child{version: oracle.Version{Name: "v4"}}
+	if !c.legacyWarned.CompareAndSwap(false, false) {
+		t.Fatal("fresh child already marked as warned")
+	}
+	c.noteLegacyFallback("/ready")
+	if !c.legacyWarned.Load() {
+		t.Fatal("first fallback did not latch the warning")
+	}
+	// A second call must find the latch set; the log side is the CAS.
+	c.noteLegacyFallback("/ready")
+}
+
+// The probe distinguishes real readiness from the legacy fallback so the caller
+// can decide what to log; the fallback only engages when it is allowed.
+func TestReadyEndpointReadyReportsTheLegacyFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ready" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	port := serverPort(t, srv)
+	client := &http.Client{Timeout: time.Second}
+
+	ready, viaLegacy := readyEndpointReady(context.Background(), client, port, "/ready", true)
+	if !ready || !viaLegacy {
+		t.Fatalf("fallback path: ready=%v viaLegacy=%v, want true/true", ready, viaLegacy)
+	}
+	ready, viaLegacy = readyEndpointReady(context.Background(), client, port, "/ready", false)
+	if ready || viaLegacy {
+		t.Fatalf("fallback disallowed: ready=%v viaLegacy=%v, want false/false", ready, viaLegacy)
+	}
+}
+
+// prepareChildrenForDrain can retire a generation at any point during its long
+// preflight, and transitionGenerationLocked deliberately tolerates the stale
+// transitions that follow — so only an explicit check before the fork keeps
+// BeginHostDrain's contract that restarts are frozen. Without it the retired
+// generation still starts an OS process that no route will ever reach, and the
+// evacuation has to out-wait its startup for nothing.
+func TestRunChildDoesNotForkARetiredGeneration(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "forked")
+	bin := filepath.Join(dir, "child.sh")
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"--print-binary-version) echo test-1; exit 0 ;;\n" +
+		"--print-protocol-version) echo v4; exit 0 ;;\n" +
+		"--print-*) echo test-1; exit 0 ;;\n" +
+		"esac\n" +
+		"touch " + marker + "\n" +
+		"exec sleep 60\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(config.Config{
+		BasePort:   5000,
+		DataDir:    t.TempDir(),
+		BinaryName: "testapp",
+		// Long enough that a forked child provably reaches its marker before
+		// the failed readiness wait force-stops it: with a zero timeout the
+		// SIGKILL races the shell to the touch, and the assertion below would
+		// pass even with the guard removed.
+		ReadyTimeout: 3 * time.Second,
+	})
+	c := &child{
+		version:     oracle.Version{Name: "v4"},
+		binPath:     bin,
+		port:        5001,
+		status:      statusRetiring,
+		done:        make(chan struct{}),
+		ready:       make(chan struct{}),
+		forceStopCh: make(chan struct{}),
+	}
+	m.mu.Lock()
+	m.children[c] = struct{}{}
+	m.mu.Unlock()
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		m.runChild(context.Background(), c)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(15 * time.Second):
+		t.Fatal("runChild did not return promptly for a retired generation")
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("a retired generation forked a child process after the drain freeze")
+	}
+}
+
+// BeginHostDrain freezes restarts long before RequestChildrenDrain retires the
+// generations. A child that finishes its preflight inside that gap — the
+// announce window, the proxy-lease wait — is still `starting` by phase, so the
+// phase half of the guard alone would let it fork after the barrier. The
+// hostDraining half must stop it.
+func TestRunChildDoesNotForkAfterBeginHostDrain(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "forked")
+	bin := filepath.Join(dir, "child.sh")
+	// The probes sleep, so the preflight is a wide, reliable window in which the
+	// test can raise the drain barrier.
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"--print-binary-version) sleep 1; echo test-1; exit 0 ;;\n" +
+		"--print-protocol-version) sleep 1; echo v4; exit 0 ;;\n" +
+		"--print-*) echo test-1; exit 0 ;;\n" +
+		"esac\n" +
+		"touch " + marker + "\n" +
+		"exec sleep 60\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(config.Config{
+		BasePort:     5000,
+		DataDir:      t.TempDir(),
+		BinaryName:   "testapp",
+		ReadyTimeout: 3 * time.Second,
+	})
+	c := &child{
+		version:     oracle.Version{Name: "v4"},
+		binPath:     bin,
+		port:        5001,
+		status:      statusStarting,
+		done:        make(chan struct{}),
+		ready:       make(chan struct{}),
+		forceStopCh: make(chan struct{}),
+	}
+	m.mu.Lock()
+	m.children[c] = struct{}{}
+	m.mu.Unlock()
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		m.runChild(context.Background(), c)
+	}()
+
+	// Land inside the sleeping preflight, exactly where an evacuation's
+	// announce window would find this child.
+	time.Sleep(300 * time.Millisecond)
+	m.BeginHostDrain()
+
+	select {
+	case <-finished:
+	case <-time.After(15 * time.Second):
+		t.Fatal("runChild did not return after the drain barrier")
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("a child forked after BeginHostDrain froze restarts")
+	}
 }

--- a/versioned/internal/process/operations.go
+++ b/versioned/internal/process/operations.go
@@ -1,0 +1,67 @@
+package process
+
+import (
+	"context"
+	"log/slog"
+)
+
+type operationKind string
+
+const operationReconcile operationKind = "reconcile"
+
+type controlOperation struct {
+	kind   operationKind
+	cancel context.CancelFunc
+}
+
+func (m *Manager) beginOperation(
+	parent context.Context,
+	kind operationKind,
+) (context.Context, uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hostDraining {
+		return nil, 0, ErrHostDraining
+	}
+	ctx, cancel := context.WithCancel(parent)
+	m.nextOperationID++
+	id := m.nextOperationID
+	m.operations[id] = controlOperation{kind: kind, cancel: cancel}
+	return ctx, id, nil
+}
+
+func (m *Manager) endOperation(id uint64) {
+	m.mu.Lock()
+	operation, ok := m.operations[id]
+	if ok {
+		delete(m.operations, id)
+	}
+	m.mu.Unlock()
+	if ok {
+		operation.cancel()
+	}
+}
+
+func (m *Manager) cancelOperations() {
+	m.mu.Lock()
+	type registeredOperation struct {
+		id uint64
+		controlOperation
+	}
+	operations := make([]registeredOperation, 0, len(m.operations))
+	for id, operation := range m.operations {
+		operations = append(operations, registeredOperation{
+			id:               id,
+			controlOperation: operation,
+		})
+	}
+	m.mu.Unlock()
+	for _, operation := range operations {
+		slog.Info(
+			"canceling process manager operation",
+			"operation_id", operation.id,
+			"kind", operation.kind,
+		)
+		operation.cancel()
+	}
+}

--- a/versioned/internal/process/supervised_process.go
+++ b/versioned/internal/process/supervised_process.go
@@ -20,6 +20,64 @@ const (
 	processStateExited
 )
 
+type processEvent uint8
+
+const (
+	processEventStopRequested processEvent = iota
+	processEventForceRequested
+	processEventGraceExpired
+	processEventExited
+)
+
+type processAction uint8
+
+const (
+	processActionSignalTerm processAction = iota
+	processActionSignalKill
+	processActionFinish
+)
+
+type processTransitionKey struct {
+	state processState
+	event processEvent
+}
+
+type processTransitionSpec struct {
+	next   processState
+	action processAction
+}
+
+var processTransitionTable = map[processTransitionKey]processTransitionSpec{
+	{state: processStateRunning, event: processEventStopRequested}: {
+		next:   processStateTerminating,
+		action: processActionSignalTerm,
+	},
+	{state: processStateRunning, event: processEventForceRequested}: {
+		next:   processStateKilling,
+		action: processActionSignalKill,
+	},
+	{state: processStateRunning, event: processEventExited}: {
+		next:   processStateExited,
+		action: processActionFinish,
+	},
+	{state: processStateTerminating, event: processEventForceRequested}: {
+		next:   processStateKilling,
+		action: processActionSignalKill,
+	},
+	{state: processStateTerminating, event: processEventGraceExpired}: {
+		next:   processStateKilling,
+		action: processActionSignalKill,
+	},
+	{state: processStateTerminating, event: processEventExited}: {
+		next:   processStateExited,
+		action: processActionFinish,
+	},
+	{state: processStateKilling, event: processEventExited}: {
+		next:   processStateExited,
+		action: processActionFinish,
+	},
+}
+
 func (s processState) String() string {
 	switch s {
 	case processStateRunning:
@@ -32,6 +90,21 @@ func (s processState) String() string {
 		return "exited"
 	default:
 		return fmt.Sprintf("processState(%d)", s)
+	}
+}
+
+func (e processEvent) String() string {
+	switch e {
+	case processEventStopRequested:
+		return "stop_requested"
+	case processEventForceRequested:
+		return "force_requested"
+	case processEventGraceExpired:
+		return "grace_expired"
+	case processEventExited:
+		return "exited"
+	default:
+		return fmt.Sprintf("processEvent(%d)", e)
 	}
 }
 
@@ -87,45 +160,61 @@ func (p *supervisedProcess) run() {
 		waitCh <- p.cmd.Wait()
 	}()
 
-	var err error
-	select {
-	case err = <-waitCh:
-		p.complete(err)
-		return
-	case <-p.stop:
-		p.transition(processStateTerminating)
-		p.signal(syscall.SIGTERM)
-	case <-p.force:
-		err = p.killAndWait(waitCh)
-		p.complete(err)
-		return
-	case <-p.externalForce:
-		err = p.killAndWait(waitCh)
-		p.complete(err)
-		return
+	stopCh := p.stop
+	forceCh := (<-chan struct{})(p.force)
+	externalForceCh := p.externalForce
+	var graceTimer *time.Timer
+	var graceCh <-chan time.Time
+	stopGraceTimer := func() {
+		if graceTimer != nil {
+			graceTimer.Stop()
+			graceTimer = nil
+			graceCh = nil
+		}
 	}
+	defer stopGraceTimer()
 
-	timer := time.NewTimer(p.grace)
-	defer timer.Stop()
-	select {
-	case err = <-waitCh:
-	case <-timer.C:
-		err = p.killAndWait(waitCh)
-	case <-p.force:
-		err = p.killAndWait(waitCh)
-	case <-p.externalForce:
-		err = p.killAndWait(waitCh)
+	for {
+		var event processEvent
+		var waitErr error
+		select {
+		case waitErr = <-waitCh:
+			event = processEventExited
+		case <-stopCh:
+			stopCh = nil
+			event = processEventStopRequested
+		case <-forceCh:
+			forceCh = nil
+			event = processEventForceRequested
+		case <-externalForceCh:
+			externalForceCh = nil
+			event = processEventForceRequested
+		case <-graceCh:
+			graceCh = nil
+			event = processEventGraceExpired
+		}
+
+		transition, ok := p.applyEvent(event)
+		if !ok {
+			continue
+		}
+		switch transition.action {
+		case processActionSignalTerm:
+			p.signal(syscall.SIGTERM)
+			graceTimer = time.NewTimer(p.grace)
+			graceCh = graceTimer.C
+		case processActionSignalKill:
+			stopGraceTimer()
+			stopCh = nil
+			forceCh = nil
+			externalForceCh = nil
+			p.signal(syscall.SIGKILL)
+		case processActionFinish:
+			stopGraceTimer()
+			p.finish(waitErr)
+			return
+		}
 	}
-	p.complete(err)
-}
-
-func (p *supervisedProcess) killAndWait(waitCh <-chan error) error {
-	p.transition(processStateKilling)
-	p.mu.Lock()
-	p.escalated = true
-	p.mu.Unlock()
-	p.signal(syscall.SIGKILL)
-	return <-waitCh
 }
 
 func (p *supervisedProcess) signal(signal syscall.Signal) {
@@ -156,47 +245,31 @@ func signalProcessGroup(process *os.Process, signal syscall.Signal) error {
 	return nil
 }
 
-func (p *supervisedProcess) transition(next processState) {
+func (p *supervisedProcess) applyEvent(
+	event processEvent,
+) (processTransitionSpec, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !validProcessTransition(p.state, next) {
+	key := processTransitionKey{state: p.state, event: event}
+	transition, ok := processTransitionTable[key]
+	if !ok {
 		slog.Error(
-			"invalid child process state transition",
-			"from", p.state.String(),
-			"to", next.String(),
-			"pid", p.cmd.Process.Pid,
-		)
-		return
-	}
-	p.state = next
-}
-
-func validProcessTransition(from, to processState) bool {
-	switch from {
-	case processStateRunning:
-		return to == processStateTerminating || to == processStateKilling || to == processStateExited
-	case processStateTerminating:
-		return to == processStateKilling || to == processStateExited
-	case processStateKilling:
-		return to == processStateExited
-	case processStateExited:
-		return false
-	default:
-		return false
-	}
-}
-
-func (p *supervisedProcess) complete(err error) {
-	p.mu.Lock()
-	if validProcessTransition(p.state, processStateExited) {
-		p.state = processStateExited
-	} else {
-		slog.Error(
-			"invalid child process completion state",
+			"invalid child process event",
 			"state", p.state.String(),
+			"event", event.String(),
 			"pid", p.cmd.Process.Pid,
 		)
+		return processTransitionSpec{}, false
 	}
+	p.state = transition.next
+	if transition.action == processActionSignalKill {
+		p.escalated = true
+	}
+	return transition, true
+}
+
+func (p *supervisedProcess) finish(err error) {
+	p.mu.Lock()
 	p.err = err
 	p.mu.Unlock()
 	close(p.done)

--- a/versioned/internal/process/supervised_process_test.go
+++ b/versioned/internal/process/supervised_process_test.go
@@ -30,6 +30,7 @@ func TestSupervisedProcessHelper(t *testing.T) {
 		signal.Notify(term, syscall.SIGTERM)
 	case "ignore-term":
 		signal.Ignore(syscall.SIGTERM)
+	case "exit":
 	default:
 		os.Exit(2)
 	}
@@ -39,11 +40,172 @@ func TestSupervisedProcessHelper(t *testing.T) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
+	if os.Getenv(supervisedProcessHelperEnv) == "exit" {
+		return
+	}
 	if term != nil {
 		<-term
 		return
 	}
 	select {}
+}
+
+func TestProcessTransitionTable(t *testing.T) {
+	states := []processState{
+		processStateRunning,
+		processStateTerminating,
+		processStateKilling,
+		processStateExited,
+	}
+	events := []processEvent{
+		processEventStopRequested,
+		processEventForceRequested,
+		processEventGraceExpired,
+		processEventExited,
+	}
+	expected := map[processTransitionKey]processTransitionSpec{
+		{state: processStateRunning, event: processEventStopRequested}: {
+			next:   processStateTerminating,
+			action: processActionSignalTerm,
+		},
+		{state: processStateRunning, event: processEventForceRequested}: {
+			next:   processStateKilling,
+			action: processActionSignalKill,
+		},
+		{state: processStateRunning, event: processEventExited}: {
+			next:   processStateExited,
+			action: processActionFinish,
+		},
+		{state: processStateTerminating, event: processEventForceRequested}: {
+			next:   processStateKilling,
+			action: processActionSignalKill,
+		},
+		{state: processStateTerminating, event: processEventGraceExpired}: {
+			next:   processStateKilling,
+			action: processActionSignalKill,
+		},
+		{state: processStateTerminating, event: processEventExited}: {
+			next:   processStateExited,
+			action: processActionFinish,
+		},
+		{state: processStateKilling, event: processEventExited}: {
+			next:   processStateExited,
+			action: processActionFinish,
+		},
+	}
+
+	for _, state := range states {
+		for _, event := range events {
+			key := processTransitionKey{state: state, event: event}
+			got, gotOK := processTransitionTable[key]
+			want, wantOK := expected[key]
+			if gotOK != wantOK || got != want {
+				t.Errorf(
+					"transition for %s + %s = %+v, %t; want %+v, %t",
+					state,
+					event,
+					got,
+					gotOK,
+					want,
+					wantOK,
+				)
+			}
+		}
+	}
+}
+
+func TestProcessTransitionTableActionsMatchTargets(t *testing.T) {
+	knownStates := map[processState]bool{
+		processStateRunning:     true,
+		processStateTerminating: true,
+		processStateKilling:     true,
+		processStateExited:      true,
+	}
+	knownEvents := map[processEvent]bool{
+		processEventStopRequested:  true,
+		processEventForceRequested: true,
+		processEventGraceExpired:   true,
+		processEventExited:         true,
+	}
+	exitEdges := make(map[processState]bool)
+	for key, transition := range processTransitionTable {
+		if !knownStates[key.state] {
+			t.Errorf("transition has unknown source state %s", key.state)
+		}
+		if !knownEvents[key.event] {
+			t.Errorf("transition has unknown event %s", key.event)
+		}
+		if !knownStates[transition.next] {
+			t.Errorf("%s + %s targets unknown state %s", key.state, key.event, transition.next)
+		}
+		switch transition.action {
+		case processActionSignalTerm:
+			if transition.next != processStateTerminating {
+				t.Errorf("SIGTERM action targets %s", transition.next)
+			}
+		case processActionSignalKill:
+			if transition.next != processStateKilling {
+				t.Errorf("SIGKILL action targets %s", transition.next)
+			}
+		case processActionFinish:
+			if key.event != processEventExited ||
+				transition.next != processStateExited {
+				t.Errorf(
+					"finish action maps %s + %s to %s",
+					key.state,
+					key.event,
+					transition.next,
+				)
+			}
+			exitEdges[key.state] = true
+		default:
+			t.Errorf("%s + %s has unknown action %d", key.state, key.event, transition.action)
+		}
+	}
+	for _, state := range []processState{
+		processStateRunning,
+		processStateTerminating,
+		processStateKilling,
+	} {
+		if !exitEdges[state] {
+			t.Errorf("%s has no process-exited edge", state)
+		}
+	}
+}
+
+func TestSupervisedProcessNaturalExitReaps(t *testing.T) {
+	stop := make(chan struct{})
+	force := make(chan struct{})
+	proc := startSupervisedTestProcess(t, "exit", time.Second, stop, force)
+
+	if err := waitForSupervisedProcess(proc, 5*time.Second); err != nil {
+		t.Fatalf("natural process exit: %v", err)
+	}
+	if proc.Escalated() {
+		t.Fatal("naturally exited process recorded escalation")
+	}
+	if got := proc.State(); got != processStateExited {
+		t.Fatalf("process state = %s, want exited", got)
+	}
+	assertProcessReaped(t, proc)
+}
+
+func TestSupervisedProcessForceStopsRunningProcessAndReaps(t *testing.T) {
+	stop := make(chan struct{})
+	force := make(chan struct{})
+	proc := startSupervisedTestProcess(t, "ignore-term", time.Hour, stop, force)
+
+	proc.ForceStop()
+	if err := waitForSupervisedProcess(proc, time.Second); err == nil {
+		t.Fatal("SIGKILLed process returned a nil wait error")
+	}
+	if !proc.Escalated() {
+		t.Fatal("forced process did not record SIGKILL escalation")
+	}
+	if got := proc.State(); got != processStateExited {
+		t.Fatalf("process state = %s, want exited", got)
+	}
+	assertProcessReaped(t, proc)
 }
 
 func TestSupervisedProcessStopsGracefullyAndReaps(t *testing.T) {


### PR DESCRIPTION
> This focused PR is based on the graceful lifecycle work originally implemented in the closed umbrella PRs #1517 and #1587.

## Merge Order

The prerequisites are already merged into `devshard-0.2.15-v5`:

- #1599 supplies the HAProxy versiond router and its per-version health checks;
- #1606 supplies dynamic version-catalog reconciliation.

Both are present in the base, so no prerequisite remains. The branch retains the original stacked commit history, so the **Commits** tab may still show historical router commits; the effective scope is the **Files changed** diff against the current base.

## Summary

Add a bounded graceful host lifecycle to `versiond`. A container stop, replacement, or upgrade now gives requests already accepted by the host a drain window before child processes are terminated. The configured deadline and an explicit force interrupt remain authoritative, so graceful completion is bounded rather than unconditional.

The change:

- exposes host-level and per-version readiness through `/readyz`;
- announces withdrawal while admission remains open long enough for HAProxy to observe it;
- freezes reconciliation, generation starts, swaps, and crash restarts as soon as shutdown begins;
- closes new admission after the announcement and waits for accepted proxied HTTP responses and SSE streams;
- removes child routes, calls the devshardd drain endpoints, and waits for child lifecycle counters;
- reserves a real SIGTERM grace inside one absolute host shutdown budget;
- escalates remaining connections and processes on deadline or an additional `SIGINT`;
- keeps Docker stop grace as the outer SIGKILL backstop;
- adds a real two-host Docker acceptance test for evacuation, recovery, rejoin, and decommission.

## Host Shutdown Sequence

On the first `SIGTERM` or `SIGINT`, versiond establishes one absolute deadline and performs these steps:

1. Atomically move a serving host to `announcing`. `/readyz` becomes unready while admission remains open.
2. Immediately freeze desired-state changes, disable child restarts, cancel active generation operations, and stop the oracle poller. This barrier is active during the announcement window, so a child that was still in preflight cannot start after evacuation began.
3. Wait for `VERSIOND_DRAIN_ANNOUNCE`, then enter `draining` and close new proxy admission. An additional `SIGINT` can shorten the wait; repeated `SIGTERM` is idempotent.
4. Give the poll worker a bounded unwind allowance, wait for accepted proxy leases, remove every child route, call each child's `/drain`, and poll `/drain/status` until idle. Network calls never hold the process-manager mutex.
5. Before the absolute deadline's reserved tail, enter `stopping`, shut down the versiond HTTP server, send `SIGTERM` to children, and wait for process exit.
6. If the deadline expires or force was requested, close remaining HTTP connections, send `SIGKILL` where needed, and still wait until every child is reaped before versiond exits.

The lifecycle is represented by an explicit table-driven host state machine:

```text
starting -> serving -> announcing -> draining -> stopping -> stopped
     |          |           |            |           |
     +----------+-----------+------------+-----------+-> forcing -> stopped
```

This host FSM coordinates with the existing child-generation and supervised-process state machines. The drain barrier and `cmd.Start` are checked under the same manager lock, closing the race between a retiring generation and process creation.

## Readiness Behavior

- `GET /readyz` answers whether the host may receive generic new work.
- `GET /readyz?version=<name>` answers whether the internal proxy currently has a running, live-ready route for that exact version.
- `GET /healthz` keeps its existing response format for current clients.

Coarse `/readyz` requires a serving and accepting host, at least one live-ready child, and one initial point at which the complete desired version set ran together. That convergence condition latches after the first success, so a later download or child restart does not withdraw every host simultaneously.

Per-version readiness uses the same route table as the internal proxy and continuously refreshes each generation's child readiness. A host can therefore remain eligible for healthy versions while another version is unavailable. A shared chain-listener reconnect remains route-ready after initial startup because admission stays open and the dependency failure is correlated across replicas; lifecycle drain and loss of actual child serving readiness still withdraw the route.

The join Compose healthcheck intentionally probes coarse `/readyz`. A fresh partially converged host may therefore be Docker `unhealthy` while HAProxy already uses its healthy per-version routes. For compatibility with the pinned pre-lifecycle image, Compose falls back to `/healthz` only when `/readyz` returns an explicit `404`; a real readiness `503` remains unhealthy.

## Shutdown Budget Contract

The relevant defaults are:

- `VERSIOND_DRAIN_ANNOUNCE=5s`: HAProxy observation window before admission closes;
- `VERSIOND_DRAIN_KILL_GRACE=10m`: supervisor compatibility/termination grace;
- `DEVSHARD_SHUTDOWN_GRACE=10m`: devshardd's own SIGTERM shutdown grace;
- `VERSIOND_HOST_SHUTDOWN_BUDGET=25m`: absolute internal deadline beginning at the first signal;
- `VERSIOND_STOP_GRACE_PERIOD=30m`: external Docker SIGKILL backstop;
- `VERSIOND_HEALTH_START_PERIOD=30m`: initial Compose healthcheck allowance for artifact installation.

At startup, versiond resolves the effective child grace once and rejects a configuration unless:

```text
VERSIOND_DRAIN_ANNOUNCE
  + max(VERSIOND_DRAIN_KILL_GRACE, DEVSHARD_SHUTDOWN_GRACE)
  < VERSIOND_HOST_SHUTDOWN_BUDGET
```

This preserves positive time for request and child drain before SIGTERM. Versiond-owned duration values use Go syntax with explicit units (`30s`, `5m`, `1h30m`); malformed and non-positive values fail versiond startup. `VERSIOND_DRAIN_ANNOUNCE=0s` remains the explicit single-host/no-balancer mode.

The deployment must separately keep `VERSIOND_STOP_GRACE_PERIOD` greater than `VERSIOND_HOST_SHUTDOWN_BUDGET`; their `30m` and `25m` defaults preserve that external reserve.

## Operator and Router Behavior

Stopping one versiond Compose service evacuates it. Starting or recreating that service returns it to traffic only after readiness passes. Permanent decommission means removing the service from the desired Compose deployment so `restart: always` cannot recreate membership.

The read-only `versiond-router/pool-status` command reports DNS slots and active HAProxy state. Runtime API failures now fail the command instead of fabricating an all-DOWN pool, so acceptance tests and operator inspection cannot report success from an unreadable stats socket.

## Validation

- `go test -race ./internal/... ./cmd/...` and `go vet ./internal/... ./cmd/...` in `versioned`;
- race coverage for the devshardd lifecycle and test harness;
- `make -C versiond-router test-render`, including live HAProxy rendering, version routing, hash stability, Compose contracts, and `pool-status` failures;
- `make -C devshard/testenv citest-versiond-host-evacuation` against a real Docker stack.

The acceptance test holds an SSE request open on the host being evacuated, verifies that HAProxy withdraws that exact sticky host while the stream continues, checks uninterrupted requests and session recovery through the survivor, requires a handled exit code rather than Docker SIGKILL, keeps an unconverged restarted host out of the pool, and verifies rejoin only after readiness recovers.

## Scope

This PR covers versiond host evacuation, the devshardd child lifecycle required by it, supporting router-status correctness, deployment timing, and the end-to-end acceptance harness. Router implementation (#1599) and dynamic catalog reconciliation (#1606) are already separate merged changes. PostgreSQL persistence, storage identity, router fleet management, public ingress redundancy, and host update orchestration remain separate PRs.
