### PR TITLE
Prove shared PostgreSQL storage through devshard children

### DIFF
--- a/deploy/join/config.env.template
+++ b/deploy/join/config.env.template
@@ -73,6 +73,9 @@ export QUERY_GAS_LIMIT=10000000
 # Never use the override to recover a missing anonymous volume.
 # export DEVSHARD_POSTGRES_STOP_GRACE_PERIOD=5m
 # export DEVSHARD_POSTGRES_START_PERIOD=30m
+# Maximum application-pool connections per running HA devshard generation.
+# Each generation also owns one readiness and one session-fence connection.
+# export DEVSHARD_POSTGRES_POOL_MAX_CONNS=4
 
 # Versiond router policy for docker-compose.versiond.yml. Keep pre-HA versions
 # on their single SQLite owner and route HA-capable versions through independent

--- a/deploy/join/devshard-postgres-entrypoint.sh
+++ b/deploy/join/devshard-postgres-entrypoint.sh
@@ -70,6 +70,16 @@ detect_postgres_major() {
     esac
 }
 
+validate_runtime_family() {
+    libc_version=$(ldd --version 2>&1 || :)
+    case "$libc_version" in
+        musl\ libc*) ;;
+        *)
+            die "bundled devshard PostgreSQL requires a musl-based image; changing the libc family requires a dedicated PostgreSQL migration"
+            ;;
+    esac
+}
+
 ensure_migration_space() {
     source_kib=$(du -sk "$legacy_data" | awk '{ print $1 }') ||
         die "cannot measure PostgreSQL source cluster"
@@ -108,6 +118,7 @@ esac
 [ "$legacy_data" != "$target_data" ] || die "legacy and persistent PGDATA are identical"
 [ -x "$official_entrypoint" ] || die "official PostgreSQL entrypoint is not executable"
 detect_postgres_major
+validate_runtime_family
 mkdir -p "$persistent_root"
 
 if cluster_exists "$target_data"; then

--- a/deploy/join/devshard-postgres-entrypoint.sh
+++ b/deploy/join/devshard-postgres-entrypoint.sh
@@ -75,7 +75,7 @@ validate_runtime_family() {
     case "$libc_version" in
         musl\ libc*) ;;
         *)
-            die "bundled devshard PostgreSQL requires a musl-based image; changing the libc family requires a dedicated PostgreSQL migration"
+            die "the selected PostgreSQL image is not compatible with the existing devshard PGDATA; use the release image or migrate the cluster before changing image variants"
             ;;
     esac
 }

--- a/deploy/join/devshard-postgres-entrypoint_test.sh
+++ b/deploy/join/devshard-postgres-entrypoint_test.sh
@@ -11,7 +11,12 @@ cat >"$tmpdir/bin/postgres" <<'EOF'
 #!/bin/sh
 printf '%s\n' 'postgres (PostgreSQL) 16.15'
 EOF
-chmod +x "$tmpdir/bin/postgres"
+cat >"$tmpdir/bin/ldd" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'musl libc (x86_64)' 'Version 1.2.6'
+exit 1
+EOF
+chmod +x "$tmpdir/bin/postgres" "$tmpdir/bin/ldd"
 test_path="$tmpdir/bin:$PATH"
 
 fail() {
@@ -215,6 +220,25 @@ if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
 fi
 grep -q 'uses major version 15; expected 16' "$case_dir/stderr" || fail \
     "wrong-target-major failure was not diagnosed"
+
+new_case reject-glibc-runtime
+mkdir -p "$persistent/data" "$case_dir/bin"
+printf '16\n' > "$persistent/data/PG_VERSION"
+printf 'preserved\n' > "$persistent/data/session-row"
+cat >"$case_dir/bin/ldd" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'ldd (Debian GLIBC 2.36) 2.36'
+EOF
+chmod +x "$case_dir/bin/ldd"
+entrypoint_path="$case_dir/bin:$test_path"
+if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    fail "a glibc image was allowed to open the musl PostgreSQL cluster"
+fi
+unset entrypoint_path
+grep -q 'requires a musl-based image' "$case_dir/stderr" || fail \
+    "unsupported-libc failure was not diagnosed"
+[[ $(<"$persistent/data/session-row") == preserved ]] || fail \
+    "unsupported runtime modified PGDATA before failing"
 
 new_case follow-image-major
 mkdir -p "$persistent/data" "$case_dir/bin"

--- a/deploy/join/devshard-postgres-entrypoint_test.sh
+++ b/deploy/join/devshard-postgres-entrypoint_test.sh
@@ -235,7 +235,8 @@ if run_entrypoint >"$case_dir/stdout" 2>"$case_dir/stderr"; then
     fail "a glibc image was allowed to open the musl PostgreSQL cluster"
 fi
 unset entrypoint_path
-grep -q 'requires a musl-based image' "$case_dir/stderr" || fail \
+grep -q 'not compatible with the existing devshard PGDATA' \
+    "$case_dir/stderr" || fail \
     "unsupported-libc failure was not diagnosed"
 [[ $(<"$persistent/data/session-row") == preserved ]] || fail \
     "unsupported runtime modified PGDATA before failing"

--- a/deploy/join/devshard-postgres-upgrade_test.sh
+++ b/deploy/join/devshard-postgres-upgrade_test.sh
@@ -63,6 +63,27 @@ wait_for_postgres() {
     fail "PostgreSQL did not become ready"
 }
 
+seed_probe() {
+    local table=$1
+    local value=$2
+    local _
+    shift 2
+    local -a compose=("$@")
+    local sql="CREATE TABLE IF NOT EXISTS $table (value text PRIMARY KEY); INSERT INTO $table VALUES ('$value') ON CONFLICT DO NOTHING;"
+
+    # pg_isready can succeed immediately before a transient server restart.
+    # Confirm readiness with the idempotent write the fixture actually needs.
+    for _ in {1..10}; do
+        if "${compose[@]}" exec -T "$service" psql \
+            -U devshardd -d devshardd -v ON_ERROR_STOP=1 \
+            -c "$sql" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    fail "PostgreSQL did not remain ready for fixture setup"
+}
+
 mkdir -p "$GONKA_POSTGRES_TEST_DATA" \
     "$GONKA_POSTGRES_TEST_EXISTING/v4" \
     "$GONKA_POSTGRES_TEST_VERSIOND_DATA" \
@@ -72,11 +93,7 @@ printf 'existing v4 installation\n' \
 
 "${old_compose[@]}" up -d "$service"
 wait_for_postgres "${old_compose[@]}"
-"${old_compose[@]}" exec -T "$service" psql \
-    -U devshardd -d devshardd -v ON_ERROR_STOP=1 \
-    -c "CREATE TABLE migration_probe (value text NOT NULL);" \
-    -c "INSERT INTO migration_probe VALUES ('preserved-v4-row');" \
-    >/dev/null
+seed_probe migration_probe preserved-v4-row "${old_compose[@]}"
 
 old_container=$("${old_compose[@]}" ps -q "$service")
 old_volume=$(docker inspect "$old_container" --format \
@@ -139,11 +156,8 @@ printf 'existing v4 installation\n' \
 
 "${guard_old_compose[@]}" up -d "$service"
 wait_for_postgres "${guard_old_compose[@]}"
-"${guard_old_compose[@]}" exec -T "$service" psql \
-    -U devshardd -d devshardd -v ON_ERROR_STOP=1 \
-    -c "CREATE TABLE detached_volume_probe (value text NOT NULL);" \
-    -c "INSERT INTO detached_volume_probe VALUES ('recovered-v4-row');" \
-    >/dev/null
+seed_probe detached_volume_probe recovered-v4-row \
+    "${guard_old_compose[@]}"
 guard_old_container=$("${guard_old_compose[@]}" ps -q "$service")
 guard_old_volume=$(docker inspect "$guard_old_container" --format \
     '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')

--- a/deploy/join/docker-compose.versiond.yml
+++ b/deploy/join/docker-compose.versiond.yml
@@ -39,6 +39,9 @@ x-versiond: &versiond
     - PGDATABASE=${DEVSHARD_POSTGRES_DB:-devshardd}
     - PGUSER=${DEVSHARD_POSTGRES_USER:-devshardd}
     - PGPASSWORD=${DEVSHARD_POSTGRES_PASSWORD:?DEVSHARD_POSTGRES_PASSWORD is required}
+    # Bound every child independently; pgx's CPU-sized default is unsafe when
+    # several versions and generations share one PostgreSQL server.
+    - PG_POOL_MAX_CONNS=${DEVSHARD_POSTGRES_POOL_MAX_CONNS:-4}
     # Postgres-only payloads/sessions. Fail boot if PG is down; migrate local
     # SQLite sessions into Postgres once at startup (no file/sqlite fallback).
     - DEVSHARD_STORAGE_MODE=postgres

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -33,11 +33,15 @@ import (
 
 const sessionEpochRetain = 3
 
+type chainEventsRunner interface {
+	Start(context.Context) error
+}
+
 type devshardApp struct {
-	server        *echo.Echo
-	adminServer   *echo.Echo
+	server        appHTTPServer
+	adminServer   appHTTPServer
 	adminAddr     string
-	chainEvents   *chainEventBridge
+	chainEvents   chainEventsRunner
 	port          int
 	lifecycle     *lifecycleState
 	shutdownGrace time.Duration
@@ -131,10 +135,14 @@ func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error
 	}
 	manager.Register(e.Group(""))
 	chainRuntime.chainEvents.OnReady(lifecycle.SetReady)
+	var adminServer appHTTPServer
+	if admin != nil {
+		adminServer = admin
+	}
 
 	return &devshardApp{
 		server:        e,
-		adminServer:   admin,
+		adminServer:   adminServer,
 		adminAddr:     cfg.AdminAddr,
 		chainEvents:   chainRuntime.chainEvents,
 		port:          cfg.Port,
@@ -408,6 +416,12 @@ func logCleanupError(msg string, err error) {
 	slog.Warn(msg, "error", err)
 }
 
+type appHTTPServer interface {
+	Start(string) error
+	Close() error
+	Shutdown(context.Context) error
+}
+
 func (a *devshardApp) Run(ctx context.Context) error {
 	defer a.close()
 
@@ -425,7 +439,7 @@ func (a *devshardApp) Run(ctx context.Context) error {
 		err  error
 	}
 	errCh := make(chan serverError, 2)
-	startServer := func(name string, server *echo.Echo, addr string) {
+	startServer := func(name string, server appHTTPServer, addr string) {
 		go func() {
 			slog.Info("listening", "server", name, "addr", addr)
 			if err := server.Start(addr); err != nil && err != http.ErrServerClosed {
@@ -440,6 +454,7 @@ func (a *devshardApp) Run(ctx context.Context) error {
 
 	var runErr error
 	chainEventsStopped := false
+	forceShutdown := false
 	select {
 	case <-ctx.Done():
 		slog.Info("shutdown requested")
@@ -454,10 +469,19 @@ func (a *devshardApp) Run(ctx context.Context) error {
 		}
 	case err := <-a.storageErrors:
 		runErr = fmt.Errorf("terminal storage failure: %w", err)
+		forceShutdown = true
 	}
 
 	a.lifecycle.StartDrain()
 	cancel()
+	if forceShutdown {
+		_ = a.server.Close()
+		if a.adminServer != nil {
+			_ = a.adminServer.Close()
+		}
+		slog.Warn("devshardd stopped after terminal storage failure")
+		return runErr
+	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), a.shutdownGrace)
 	defer shutdownCancel()

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -41,6 +41,7 @@ type devshardApp struct {
 	port          int
 	lifecycle     *lifecycleState
 	shutdownGrace time.Duration
+	storageErrors <-chan error
 	close         func()
 }
 
@@ -139,6 +140,7 @@ func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error
 		port:          cfg.Port,
 		lifecycle:     lifecycle,
 		shutdownGrace: cfg.ShutdownGrace,
+		storageErrors: manager.StorageFatalErrors(),
 		close:         closers.Close,
 	}, nil
 }
@@ -450,6 +452,8 @@ func (a *devshardApp) Run(ctx context.Context) error {
 		} else {
 			runErr = fmt.Errorf("chain events listener stopped")
 		}
+	case err := <-a.storageErrors:
+		runErr = fmt.Errorf("terminal storage failure: %w", err)
 	}
 
 	a.lifecycle.StartDrain()

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -126,7 +126,7 @@ func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error
 	e := buildServer(lifecycle)
 	var admin *echo.Echo
 	if cfg.AdminAddr != "" {
-		admin = buildAdminServer(lifecycle, manager.StorageReady)
+		admin = buildAdminServer(lifecycle, manager.StorageReady, manager.StorageProof)
 	}
 	manager.Register(e.Group(""))
 	chainRuntime.chainEvents.OnReady(lifecycle.SetReady)

--- a/devshard/cmd/devshardd/app_test.go
+++ b/devshard/cmd/devshardd/app_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordingAppHTTPServer struct {
+	closeCalls    int
+	shutdownCalls int
+	stop          chan struct{}
+	stopOnce      sync.Once
+}
+
+func (s *recordingAppHTTPServer) Start(string) error {
+	if s.stop == nil {
+		s.stop = make(chan struct{})
+	}
+	<-s.stop
+	return http.ErrServerClosed
+}
+
+func (s *recordingAppHTTPServer) Close() error {
+	s.closeCalls++
+	if s.stop != nil {
+		s.stopOnce.Do(func() { close(s.stop) })
+	}
+	return nil
+}
+
+func (s *recordingAppHTTPServer) Shutdown(context.Context) error {
+	s.shutdownCalls++
+	if s.stop != nil {
+		s.stopOnce.Do(func() { close(s.stop) })
+	}
+	return nil
+}
+
+type blockingChainEvents struct{}
+
+func (blockingChainEvents) Start(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestDevshardAppReturnsImmediatelyOnTerminalStorageFailure(t *testing.T) {
+	storageErrors := make(chan error, 1)
+	storageErrors <- errors.New("fence lost")
+	closed := make(chan struct{})
+	server := &recordingAppHTTPServer{stop: make(chan struct{})}
+	app := &devshardApp{
+		server:        server,
+		chainEvents:   blockingChainEvents{},
+		port:          0,
+		lifecycle:     newLifecycleState(),
+		shutdownGrace: 10 * time.Minute,
+		storageErrors: storageErrors,
+		close:         func() { close(closed) },
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- app.Run(context.Background()) }()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "terminal storage failure") {
+			t.Fatalf("Run error = %v, want terminal storage failure", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("terminal storage failure waited for the graceful shutdown budget")
+	}
+	if server.closeCalls != 1 || server.shutdownCalls != 0 {
+		t.Fatalf("server stop calls: Close=%d Shutdown=%d, want Close=1 Shutdown=0",
+			server.closeCalls, server.shutdownCalls)
+	}
+	select {
+	case <-closed:
+	default:
+		t.Fatal("application resources were not closed")
+	}
+}

--- a/devshard/cmd/devshardd/lifecycle_test.go
+++ b/devshard/cmd/devshardd/lifecycle_test.go
@@ -169,7 +169,7 @@ func TestLifecycleDrainKeepsAdmittedRequestInflight(t *testing.T) {
 func TestLifecycleReadyAndDrainStatus(t *testing.T) {
 	lifecycle := newLifecycleState()
 	e := buildServer(lifecycle)
-	admin := buildAdminServer(lifecycle, func() bool { return true })
+	admin := buildAdminServer(lifecycle, func() bool { return true }, nil)
 	e.GET("/work", func(c echo.Context) error {
 		time.Sleep(20 * time.Millisecond)
 		return c.String(http.StatusOK, "done")
@@ -217,7 +217,7 @@ func TestLifecycleDrainRejectsNewWork(t *testing.T) {
 	lifecycle := newLifecycleState()
 	lifecycle.SetReady(true)
 	e := buildServer(lifecycle)
-	admin := buildAdminServer(lifecycle, func() bool { return true })
+	admin := buildAdminServer(lifecycle, func() bool { return true }, nil)
 	e.GET("/work", func(c echo.Context) error {
 		return c.String(http.StatusOK, "done")
 	})
@@ -250,7 +250,7 @@ func TestReadyReflectsStorageReadiness(t *testing.T) {
 	lifecycle := newLifecycleState()
 	lifecycle.SetReady(true)
 	storageReady := false
-	admin := buildAdminServer(lifecycle, func() bool { return storageReady })
+	admin := buildAdminServer(lifecycle, func() bool { return storageReady }, nil)
 
 	rec := httptest.NewRecorder()
 	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))

--- a/devshard/cmd/devshardd/main.go
+++ b/devshard/cmd/devshardd/main.go
@@ -27,6 +27,9 @@ var Version = "dev"
 var BinaryVersion = "dev-log"
 
 func main() {
+	if code, handled := maybeInitializePostgres(context.Background(), os.Args[1:], os.Stderr); handled {
+		os.Exit(code)
+	}
 	if code, handled := maybePrintVersion(os.Args[1:], os.Stdout, os.Stderr); handled {
 		os.Exit(code)
 	}

--- a/devshard/cmd/devshardd/server.go
+++ b/devshard/cmd/devshardd/server.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -8,6 +11,7 @@ import (
 
 	"devshard/heightsync"
 	"devshard/observability"
+	"devshard/storage"
 )
 
 // buildServer creates the Echo instance for devshardd session traffic only.
@@ -30,7 +34,13 @@ func buildServer(lifecycle *lifecycleState) *echo.Echo {
 	return e
 }
 
-func buildAdminServer(lifecycle *lifecycleState, storageReady func() bool) *echo.Echo {
+type storageProofFunc func(context.Context, storage.ProofOperation, string) (storage.StorageProof, error)
+
+func buildAdminServer(
+	lifecycle *lifecycleState,
+	storageReady func() bool,
+	storageProof storageProofFunc,
+) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
@@ -51,8 +61,43 @@ func buildAdminServer(lifecycle *lifecycleState, storageReady func() bool) *echo
 	e.GET("/drain/status", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, lifecycle.Status())
 	})
+	e.GET("/storage/identity", func(c echo.Context) error {
+		return runStorageProof(c, storageProof, storage.ProofIdentity, "")
+	})
+	e.POST("/storage/challenge", func(c echo.Context) error {
+		var request struct {
+			Operation storage.ProofOperation `json:"operation"`
+			Nonce     string                 `json:"nonce"`
+		}
+		decoder := json.NewDecoder(c.Request().Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&request); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid storage challenge")
+		}
+		if request.Operation != storage.ProofWriteChallenge && request.Operation != storage.ProofReadChallenge {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid storage challenge operation")
+		}
+		return runStorageProof(c, storageProof, request.Operation, request.Nonce)
+	})
 
 	return e
+}
+
+func runStorageProof(
+	c echo.Context,
+	proof storageProofFunc,
+	operation storage.ProofOperation,
+	nonce string,
+) error {
+	if proof == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "postgres storage proof unavailable")
+	}
+	result, err := proof(c.Request().Context(), operation, nonce)
+	if err != nil {
+		slog.Warn("devshard storage proof failed", "operation", operation, "error", err)
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "postgres storage proof unavailable")
+	}
+	return c.JSON(http.StatusOK, result)
 }
 
 // readyStatus augments drainStatus with storage readiness for the /ready probe.

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -161,6 +161,15 @@ func (m *HostManager) StorageReady() bool {
 	return true
 }
 
+// StorageFatalErrors reports storage failures that require replacing this
+// devshardd process rather than waiting for readiness recovery.
+func (m *HostManager) StorageFatalErrors() <-chan error {
+	if reporter, ok := m.store.(interface{ FatalErrors() <-chan error }); ok {
+		return reporter.FatalErrors()
+	}
+	return nil
+}
+
 // StorageProof uses the same storage object as inference and session traffic.
 // Deployment checks therefore cannot accidentally validate a separate pool.
 func (m *HostManager) StorageProof(

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -161,6 +161,20 @@ func (m *HostManager) StorageReady() bool {
 	return true
 }
 
+// StorageProof uses the same storage object as inference and session traffic.
+// Deployment checks therefore cannot accidentally validate a separate pool.
+func (m *HostManager) StorageProof(
+	ctx context.Context,
+	operation storage.ProofOperation,
+	nonce string,
+) (storage.StorageProof, error) {
+	provider, ok := m.store.(storage.ProofProvider)
+	if !ok {
+		return storage.StorageProof{}, errors.New("postgres storage proof is unavailable")
+	}
+	return provider.StorageProof(ctx, operation, nonce)
+}
+
 // SetMaxNonceProvider enforces chain max_nonce on every host.
 func (m *HostManager) SetMaxNonceProvider(p devshardpkg.MaxNonceProvider) {
 	m.maxNonce = p

--- a/devshard/cmd/devshardd/storage_proof_test.go
+++ b/devshard/cmd/devshardd/storage_proof_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"devshard/storage"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminStorageProofEndpoints(t *testing.T) {
+	proof := func(_ context.Context, operation storage.ProofOperation, nonce string) (storage.StorageProof, error) {
+		return storage.StorageProof{Identity: "database-1", Found: operation == storage.ProofWriteChallenge && nonce != ""}, nil
+	}
+	admin := buildAdminServer(newLifecycleState(), func() bool { return true }, proof)
+
+	identity := httptest.NewRecorder()
+	admin.ServeHTTP(identity, httptest.NewRequest(http.MethodGet, "/storage/identity", nil))
+	require.Equal(t, http.StatusOK, identity.Code)
+	require.JSONEq(t, `{"identity":"database-1"}`, identity.Body.String())
+
+	challenge := httptest.NewRecorder()
+	admin.ServeHTTP(challenge, httptest.NewRequest(http.MethodPost, "/storage/challenge",
+		strings.NewReader(`{"operation":"write","nonce":"8aa1c262-ea39-43c2-928c-263e966cc9b4"}`)))
+	require.Equal(t, http.StatusOK, challenge.Code)
+	require.JSONEq(t, `{"identity":"database-1","found":true}`, challenge.Body.String())
+
+	invalid := httptest.NewRecorder()
+	admin.ServeHTTP(invalid, httptest.NewRequest(http.MethodPost, "/storage/challenge",
+		strings.NewReader(`{"operation":"delete","nonce":"x"}`)))
+	require.Equal(t, http.StatusBadRequest, invalid.Code)
+}

--- a/devshard/cmd/devshardd/version.go
+++ b/devshard/cmd/devshardd/version.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 
 	"common/storage/mode"
+	"devshard/storage"
 )
 
 const (
@@ -12,7 +14,19 @@ const (
 	printProtocolVersionFlag = "--print-protocol-version"
 	printAdminAPIVersionFlag = "--print-admin-api-version"
 	printStorageModeFlag     = "--print-storage-mode"
+	initializePostgresFlag   = "--initialize-postgres-schema"
 )
+
+func maybeInitializePostgres(ctx context.Context, args []string, stderr io.Writer) (int, bool) {
+	if len(args) != 1 || args[0] != initializePostgresFlag {
+		return 0, false
+	}
+	if err := storage.InitializePostgresSchema(ctx); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1, true
+	}
+	return 0, true
+}
 
 func maybePrintVersion(args []string, stdout, stderr io.Writer) (int, bool) {
 	if len(args) != 1 {

--- a/devshard/cmd/devshardd/version_test.go
+++ b/devshard/cmd/devshardd/version_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
@@ -47,6 +48,13 @@ func TestMaybePrintStorageMode(t *testing.T) {
 				t.Fatalf("stderr = %q, want it to contain %q", stderr.String(), tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestMaybeInitializePostgresRecognizesOnlyExplicitCommand(t *testing.T) {
+	var stderr bytes.Buffer
+	if code, handled := maybeInitializePostgres(context.Background(), []string{"--unknown"}, &stderr); handled || code != 0 {
+		t.Fatalf("unknown command handled=%v code=%d", handled, code)
 	}
 }
 

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -14,6 +14,12 @@ The supported upgrade recreates `devshard-postgres` in place. Do not run
 `docker compose down` before the first new-layout start: Compose must carry the
 existing anonymous volume into the replacement container.
 
+The bundled database uses the PostgreSQL Alpine/musl image family. Its
+entrypoint rejects a glibc-based replacement before touching `PGDATA`, even
+when the PostgreSQL major version matches. Moving the cluster to another libc
+family requires a dedicated PostgreSQL migration that rebuilds
+collation-dependent database objects.
+
 ```bash
 docker compose <the same ordered -f options> \
   up -d --force-recreate devshard-postgres

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -463,7 +463,10 @@ down after boot.
   downloaded artifact. Children that predate this command wait behind the
   initialization barrier. Concurrent versiond replicas may run the initializer,
   but the database lock serializes them. This gives fresh mixed-version installs
-  the same deterministic schema ordering as normal upgrades.
+  the same deterministic schema ordering as normal upgrades. Versiond first
+  classifies every desired binary; when the entire desired catalog predates the
+  initializer command, it preserves the legacy startup behavior instead of
+  waiting for a capability that is not present.
 - `devshard_storage_identity.identity` is a durable database-lineage marker.
   Copies restored from one backup retain the same marker, so equality alone is
   not proof that two hosts currently share a database.

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -463,9 +463,10 @@ down after boot.
   PostgreSQL-backed devshard generation. The explicit default replaces pgx's
   CPU-sized default so versiond replicas and overlapping generations cannot
   each reserve a host-sized pool.
-- The session-fence check runs every `5s` with a separate `30s` timeout. A
-  timeout invalidates that PostgreSQL session and triggers child replacement;
-  ordinary readiness probes retain their shorter `5s` budget.
+- The session-fence check runs in its own loop every `5s` with a `30s` timeout.
+  A timeout invalidates that PostgreSQL session and triggers child replacement;
+  independent readiness probes retain their shorter `5s` budget and can remove
+  the child from traffic while the terminal fence decision is still pending.
 - Each PostgreSQL-backed child uses its application pool plus two dedicated
   sessions: one for readiness and one for the advisory fence. Schema bootstrap
   transiently opens a separate pool. External PostgreSQL capacity planning must

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -474,11 +474,14 @@ down after boot.
   fence before serving. Every connection subsequently created by its application
   pool must observe that fence in `pg_locks` and report a writable primary before
   pgx admits it. Advisory locks are not WAL-replicated, so a promoted fork does
-  not inherit the fence. A DNS or load-balancer endpoint may expose multiple
+  not inherit the fence. The fence session is monitored for the entire child
+  lifetime. Losing it terminates devshardd so versiond can replace the child and
+  establish a fresh fence. A DNS or load-balancer endpoint may expose multiple
   addresses for one logical writer, but it cannot silently mix independent
-  writable branches within one child pool. Losing the fence session is
-  fail-closed for new connections; restoring service on a promoted writer
-  requires restarting the child so it establishes a fresh fence.
+  writable branches within one child pool. The endpoint must preserve PostgreSQL
+  session semantics; transaction-pooling proxies such as PgBouncer in transaction
+  mode are unsupported because the advisory lock must stay bound to one backend
+  session.
 - The PostgreSQL endpoint remains responsible for cluster-level writer fencing:
   it must expose at most one writable primary for a logical database. The
   advisory fence prevents one child pool from crossing branches, and the live

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -458,16 +458,21 @@ down after boot.
   It includes time waiting for another devshard migrator to release the
   database-scoped migration lock.
 - Migration bootstrap and all pending application steps are serialized by a
-  database-scoped advisory lock. Binaries predating this lock cannot join that
-  coordination protocol. A fresh empty database must therefore be initialized
-  by a current devshardd before starting a mixed set of legacy and current
-  children. Normal upgrades already have the legacy schema applied. The current
-  Compose fresh-install path does not enforce this ordering; until deployment
-  tooling provides an explicit init stage, a legacy child can lose the initial
-  migration race, roll back, and converge through versiond restart/backoff.
+  database-scoped advisory lock. Before starting children in an HA deployment,
+  versiond runs `devshardd --initialize-postgres-schema` through a current
+  downloaded artifact. Children that predate this command wait behind the
+  initialization barrier. Concurrent versiond replicas may run the initializer,
+  but the database lock serializes them. This gives fresh mixed-version installs
+  the same deterministic schema ordering as normal upgrades.
 - `devshard_storage_identity.identity` is a durable database-lineage marker.
   Copies restored from one backup retain the same marker, so equality alone is
   not proof that two hosts currently share a database.
+- Each devshard process also writes a unique token to
+  `devshard_connection_lineage` before serving. Every connection subsequently
+  created by its application pool must observe that token and report a writable
+  primary before pgx admits it. A DNS or load-balancer endpoint may therefore
+  expose multiple addresses for one logical writer, but it cannot silently mix
+  independent writable clones within one child pool.
 - HA deployment preflight obtains a stable generation snapshot from each
   versiond replica. For every HA-routed child generation across those snapshots,
   it writes a unique random nonce through that one child's application pool and

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -467,12 +467,20 @@ down after boot.
 - `devshard_storage_identity.identity` is a durable database-lineage marker.
   Copies restored from one backup retain the same marker, so equality alone is
   not proof that two hosts currently share a database.
-- Each devshard process also writes a unique token to
-  `devshard_connection_lineage` before serving. Every connection subsequently
-  created by its application pool must observe that token and report a writable
-  primary before pgx admits it. A DNS or load-balancer endpoint may therefore
-  expose multiple addresses for one logical writer, but it cannot silently mix
-  independent writable clones within one child pool.
+- Each devshard process also holds a unique session-scoped PostgreSQL advisory
+  fence before serving. Every connection subsequently created by its application
+  pool must observe that fence in `pg_locks` and report a writable primary before
+  pgx admits it. Advisory locks are not WAL-replicated, so a promoted fork does
+  not inherit the fence. A DNS or load-balancer endpoint may expose multiple
+  addresses for one logical writer, but it cannot silently mix independent
+  writable branches within one child pool. Losing the fence session is
+  fail-closed for new connections; restoring service on a promoted writer
+  requires restarting the child so it establishes a fresh fence.
+- The PostgreSQL endpoint remains responsible for cluster-level writer fencing:
+  it must expose at most one writable primary for a logical database. The
+  advisory fence prevents one child pool from crossing branches, and the live
+  challenge detects divergent children when deployment preflight runs; neither
+  mechanism elects a PostgreSQL primary or replaces database-layer consensus.
 - HA deployment preflight obtains a stable generation snapshot from each
   versiond replica. For every HA-routed child generation across those snapshots,
   it writes a unique random nonce through that one child's application pool and

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -457,6 +457,9 @@ down after boot.
 - Postgres schema migration deadline: `PG_MIGRATION_TIMEOUT` default `2m`.
   It includes time waiting for another devshard migrator to release the
   database-scoped migration lock.
+- The session-fence check runs every `5s` with a separate `30s` timeout. A
+  timeout invalidates that PostgreSQL session and triggers child replacement;
+  ordinary readiness probes retain their shorter `5s` budget.
 - Migration bootstrap and all pending application steps are serialized by a
   database-scoped advisory lock. Before starting children in an HA deployment,
   versiond runs `devshardd --initialize-postgres-schema` through a current

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -461,17 +461,24 @@ down after boot.
   database-scoped advisory lock. Binaries predating this lock cannot join that
   coordination protocol. A fresh empty database must therefore be initialized
   by a current devshardd before starting a mixed set of legacy and current
-  children. Normal upgrades already have the legacy schema applied.
+  children. Normal upgrades already have the legacy schema applied. The current
+  Compose fresh-install path does not enforce this ordering; until deployment
+  tooling provides an explicit init stage, a legacy child can lose the initial
+  migration race, roll back, and converge through versiond restart/backoff.
 - `devshard_storage_identity.identity` is a durable database-lineage marker.
   Copies restored from one backup retain the same marker, so equality alone is
   not proof that two hosts currently share a database.
-- HA deployment preflight proves live sharing with two random challenges. Host
-  A writes through every running devshardd application pool and host B reads;
-  then B writes a different nonce and A reads. Each operation also requires
+- HA deployment preflight obtains a stable generation snapshot from each
+  versiond replica. For every HA-routed child generation across those snapshots,
+  it writes a unique random nonce through that one child's application pool and
+  requires every other generation to read it. Each operation names its child
+  generation and carries the original snapshot token; transitional generations
+  and changed snapshots fail closed. Every operation also requires
   `pg_is_in_recovery() = false`. This catches independent clones, read replicas,
-  and configuration differences between a supervisor and its children.
-  Deployment tooling serializes this exchange; concurrent challenges can only
-  cause a safe false negative because each write replaces the previous nonce.
+  cross-wired protocol versions, and configuration differences between a
+  supervisor and its children. A final snapshot read closes the transaction.
+  Deployment tooling serializes the exchange; concurrent challenges can cause
+  only a safe false negative because each write replaces the previous nonce.
 - Live readiness uses one dedicated PostgreSQL connection outside the
   application pool. Two consecutive database failures make `/readyz` return
   `503` without terminating devshardd; two successful probes restore readiness.

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -459,6 +459,10 @@ down after boot.
 - Postgres schema migration deadline: `PG_MIGRATION_TIMEOUT` default `2m`.
   It includes time waiting for another devshard migrator to release the
   database-scoped migration lock.
+- Application pool limit: `PG_POOL_MAX_CONNS`, default `4`, per running
+  PostgreSQL-backed devshard generation. The explicit default replaces pgx's
+  CPU-sized default so versiond replicas and overlapping generations cannot
+  each reserve a host-sized pool.
 - The session-fence check runs every `5s` with a separate `30s` timeout. A
   timeout invalidates that PostgreSQL session and triggers child replacement;
   ordinary readiness probes retain their shorter `5s` budget.

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -454,6 +454,24 @@ down after boot.
 
 - Postgres env vars: `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`.
 - Postgres connect deadline at boot: `PG_CONNECT_TIMEOUT` default `2s`.
+- Postgres schema migration deadline: `PG_MIGRATION_TIMEOUT` default `2m`.
+  It includes time waiting for another devshard migrator to release the
+  database-scoped migration lock.
+- Migration bootstrap and all pending application steps are serialized by a
+  database-scoped advisory lock. Binaries predating this lock cannot join that
+  coordination protocol. A fresh empty database must therefore be initialized
+  by a current devshardd before starting a mixed set of legacy and current
+  children. Normal upgrades already have the legacy schema applied.
+- `devshard_storage_identity.identity` is a durable database-lineage marker.
+  Copies restored from one backup retain the same marker, so equality alone is
+  not proof that two hosts currently share a database.
+- HA deployment preflight proves live sharing with two random challenges. Host
+  A writes through every running devshardd application pool and host B reads;
+  then B writes a different nonce and A reads. Each operation also requires
+  `pg_is_in_recovery() = false`. This catches independent clones, read replicas,
+  and configuration differences between a supervisor and its children.
+  Deployment tooling serializes this exchange; concurrent challenges can only
+  cause a safe false negative because each write replaces the previous nonce.
 - Live readiness uses one dedicated PostgreSQL connection outside the
   application pool. Two consecutive database failures make `/readyz` return
   `503` without terminating devshardd; two successful probes restore readiness.

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -469,7 +469,9 @@ down after boot.
   the same deterministic schema ordering as normal upgrades. Versiond first
   classifies every desired binary; when the entire desired catalog predates the
   initializer command, it preserves the legacy startup behavior instead of
-  waiting for a capability that is not present.
+  waiting for a capability that is not present. Versions explicitly listed in
+  `VERSIOND_NON_HA_VERSIONS` retain single-host SQLite ownership and bypass this
+  PostgreSQL barrier.
 - `devshard_storage_identity.identity` is a durable database-lineage marker.
   Copies restored from one backup retain the same marker, so equality alone is
   not proof that two hosts currently share a database.

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -487,7 +487,8 @@ down after boot.
   writable branches within one child pool. The endpoint must preserve PostgreSQL
   session semantics; transaction-pooling proxies such as PgBouncer in transaction
   mode are unsupported because the advisory lock must stay bound to one backend
-  session.
+  session. The dedicated fence session disables `idle_session_timeout`; its
+  lifetime is controlled by devshardd and the active fence check instead.
 - The PostgreSQL endpoint remains responsible for cluster-level writer fencing:
   it must expose at most one writable primary for a logical database. The
   advisory fence prevents one child pool from crossing branches, and the live

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -475,8 +475,9 @@ down after boot.
   pool must observe that fence in `pg_locks` and report a writable primary before
   pgx admits it. Advisory locks are not WAL-replicated, so a promoted fork does
   not inherit the fence. The fence session is monitored for the entire child
-  lifetime. Losing it terminates devshardd so versiond can replace the child and
-  establish a fresh fence. A DNS or load-balancer endpoint may expose multiple
+  lifetime. Losing it withdraws readiness and force-closes devshardd listeners
+  so versiond can immediately replace the child and establish a fresh fence. A
+  DNS or load-balancer endpoint may expose multiple
   addresses for one logical writer, but it cannot silently mix independent
   writable branches within one child pool. The endpoint must preserve PostgreSQL
   session semantics; transaction-pooling proxies such as PgBouncer in transaction

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -452,7 +452,9 @@ down after boot.
 
 ## Operational Notes
 
-- Postgres env vars: `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`.
+- Postgres env vars: `PGHOST` (or `PGSERVICE`), `PGPORT`, `PGDATABASE`,
+  `PGUSER`, `PGPASSWORD`. The schema bootstrap uses the same pgx environment
+  selectors as the child storage path.
 - Postgres connect deadline at boot: `PG_CONNECT_TIMEOUT` default `2s`.
 - Postgres schema migration deadline: `PG_MIGRATION_TIMEOUT` default `2m`.
   It includes time waiting for another devshard migrator to release the
@@ -460,6 +462,11 @@ down after boot.
 - The session-fence check runs every `5s` with a separate `30s` timeout. A
   timeout invalidates that PostgreSQL session and triggers child replacement;
   ordinary readiness probes retain their shorter `5s` budget.
+- Each PostgreSQL-backed child uses its application pool plus two dedicated
+  sessions: one for readiness and one for the advisory fence. Schema bootstrap
+  transiently opens a separate pool. External PostgreSQL capacity planning must
+  include every simultaneously running child generation on both versiond
+  replicas.
 - Migration bootstrap and all pending application steps are serialized by a
   database-scoped advisory lock. Before starting children in an HA deployment,
   versiond runs `devshardd --initialize-postgres-schema` through a current
@@ -488,7 +495,10 @@ down after boot.
   session semantics; transaction-pooling proxies such as PgBouncer in transaction
   mode are unsupported because the advisory lock must stay bound to one backend
   session. The dedicated fence session disables `idle_session_timeout`; its
-  lifetime is controlled by devshardd and the active fence check instead.
+  lifetime is controlled by devshardd and the active fence check instead. This
+  terminal path resets in-flight requests rather than waiting for the normal
+  shutdown grace; the replacement then follows versiond's restart backoff,
+  capped at `60s`.
 - The PostgreSQL endpoint remains responsible for cluster-level writer fencing:
   it must expose at most one writable primary for a logical database. The
   advisory fence prevents one child pool from crossing branches, and the live
@@ -505,6 +515,10 @@ down after boot.
   supervisor and its children. A final snapshot read closes the transaction.
   Deployment tooling serializes the exchange; concurrent challenges can cause
   only a safe false negative because each write replaces the previous nonce.
+  It must wait for preparing, swapping, and draining generations to settle. On
+  the first rollout it must start a current artifact and initialize the schema
+  before requiring proof support from the fleet; legacy children do not expose
+  the proof API.
 - Live readiness uses one dedicated PostgreSQL connection outside the
   application pool. Two consecutive database failures make `/readyz` return
   `503` without terminating devshardd; two successful probes restore readiness.

--- a/devshard/go.mod
+++ b/devshard/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cosmos/gogoproto v1.7.0
 	github.com/ethereum/go-ethereum v1.17.2
 	github.com/goccy/go-json v0.10.5
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/productscience/inference v0.0.0-00010101000000-000000000000
@@ -158,7 +159,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect

--- a/devshard/storage/factory.go
+++ b/devshard/storage/factory.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	defaultPGConnectTimeout    = 2 * time.Second
+	defaultPGMigrationTimeout  = 2 * time.Minute
 	defaultPGIndexTimeout      = 30 * time.Second
 	defaultPGReconnectInterval = 5 * time.Second
 )
@@ -211,9 +212,7 @@ func openSQLiteDrain(storeDir string) (Storage, bool, error) {
 }
 
 func openPostgresWithTimeout(ctx context.Context) (Storage, error) {
-	connectCtx, cancel := context.WithTimeout(ctx, pgConnectTimeout())
-	defer cancel()
-	return NewPostgres(connectCtx)
+	return newPostgres(ctx, pgConnectTimeout(), pgMigrationTimeout())
 }
 
 // openPostgresReady connects under PG_CONNECT_TIMEOUT then WaitReady under
@@ -261,6 +260,14 @@ func pgIndexTimeout() time.Duration {
 		return defaultPGIndexTimeout
 	}
 	return indexTimeout
+}
+
+func pgMigrationTimeout() time.Duration {
+	timeout, err := time.ParseDuration(os.Getenv("PG_MIGRATION_TIMEOUT"))
+	if err != nil || timeout <= 0 {
+		return defaultPGMigrationTimeout
+	}
+	return timeout
 }
 
 func pgReconnectInterval() time.Duration {

--- a/devshard/storage/factory_timeout_test.go
+++ b/devshard/storage/factory_timeout_test.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPGMigrationTimeout(t *testing.T) {
+	t.Setenv("PG_MIGRATION_TIMEOUT", "45s")
+	require.Equal(t, 45*time.Second, pgMigrationTimeout())
+
+	t.Setenv("PG_MIGRATION_TIMEOUT", "invalid")
+	require.Equal(t, defaultPGMigrationTimeout, pgMigrationTimeout())
+
+	t.Setenv("PG_MIGRATION_TIMEOUT", "0")
+	require.Equal(t, defaultPGMigrationTimeout, pgMigrationTimeout())
+}

--- a/devshard/storage/hybrid.go
+++ b/devshard/storage/hybrid.go
@@ -38,6 +38,10 @@ type HybridStorage struct {
 
 	reconnectStop chan struct{}
 	reconnectDone chan struct{}
+	fatalErrors   chan error
+	fatalStop     chan struct{}
+	fatalOnce     sync.Once
+	fatalStopOnce sync.Once
 
 	onPromoted []func()
 	promoted   bool
@@ -97,16 +101,27 @@ type readinessReporter interface {
 // NewHybridStorage wraps a single backend. Every call is forwarded to it. Used
 // by unit tests that need a HybridStorage without dual-backend routing.
 func NewHybridStorage(backend Storage) *HybridStorage {
-	return &HybridStorage{sqlite: backend, degradedOwnerOnly: false}
+	h := &HybridStorage{
+		sqlite:            backend,
+		degradedOwnerOnly: false,
+		fatalErrors:       make(chan error, 1),
+		fatalStop:         make(chan struct{}),
+	}
+	h.forwardFatalErrors(backend)
+	return h
 }
 
 func newHybridRouter(sqlite, pg Storage, preferPG bool, storeDir string) *HybridStorage {
-	return &HybridStorage{
-		sqlite:   sqlite,
-		pg:       pg,
-		preferPG: preferPG,
-		storeDir: storeDir,
+	h := &HybridStorage{
+		sqlite:      sqlite,
+		pg:          pg,
+		preferPG:    preferPG,
+		storeDir:    storeDir,
+		fatalErrors: make(chan error, 1),
+		fatalStop:   make(chan struct{}),
 	}
+	h.forwardFatalErrors(pg)
+	return h
 }
 
 func newDegradedSQLiteRouter(sqlite Storage, storeDir string, newSessionErr error) *HybridStorage {
@@ -115,6 +130,8 @@ func newDegradedSQLiteRouter(sqlite Storage, storeDir string, newSessionErr erro
 		storeDir:          storeDir,
 		degradedOwnerOnly: true,
 		newSessionErr:     newSessionErr,
+		fatalErrors:       make(chan error, 1),
+		fatalStop:         make(chan struct{}),
 	}
 }
 
@@ -194,11 +211,32 @@ func (h *HybridStorage) Ready() bool {
 
 // FatalErrors forwards terminal failures from the active Postgres backend.
 func (h *HybridStorage) FatalErrors() <-chan error {
-	pg := h.postgresBackend()
-	if reporter, ok := pg.(interface{ FatalErrors() <-chan error }); ok {
-		return reporter.FatalErrors()
+	return h.fatalErrors
+}
+
+func (h *HybridStorage) forwardFatalErrors(backend Storage) {
+	reporter, ok := backend.(interface{ FatalErrors() <-chan error })
+	if !ok {
+		return
 	}
-	return nil
+	errors := reporter.FatalErrors()
+	if errors == nil {
+		return
+	}
+	go func() {
+		select {
+		case err := <-errors:
+			if err != nil {
+				h.fatalOnce.Do(func() {
+					select {
+					case h.fatalErrors <- err:
+					case <-h.fatalStop:
+					}
+				})
+			}
+		case <-h.fatalStop:
+		}
+	}()
 }
 
 func (h *HybridStorage) newSessionError() error {
@@ -400,6 +438,7 @@ func (h *HybridStorage) promotePostgres(pg Storage) error {
 	h.promoted = true
 	hooks := append([]func(){}, h.onPromoted...)
 	h.mu.Unlock()
+	h.forwardFatalErrors(pg)
 	slog.Info("devshard storage: postgres reconnected; leaving degraded sqlite-owned-only mode", "dir", h.storeDir)
 	h.logConflictedEscrows("postgres promotion")
 	for _, hook := range hooks {
@@ -841,6 +880,7 @@ func (h *HybridStorage) Release(ctx context.Context, escrowID string, inferenceI
 }
 
 func (h *HybridStorage) Close() error {
+	h.fatalStopOnce.Do(func() { close(h.fatalStop) })
 	h.mu.Lock()
 	stop := h.reconnectStop
 	done := h.reconnectDone

--- a/devshard/storage/hybrid.go
+++ b/devshard/storage/hybrid.go
@@ -192,6 +192,15 @@ func (h *HybridStorage) Ready() bool {
 	return true
 }
 
+// FatalErrors forwards terminal failures from the active Postgres backend.
+func (h *HybridStorage) FatalErrors() <-chan error {
+	pg := h.postgresBackend()
+	if reporter, ok := pg.(interface{ FatalErrors() <-chan error }); ok {
+		return reporter.FatalErrors()
+	}
+	return nil
+}
+
 func (h *HybridStorage) newSessionError() error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/devshard/storage/hybrid_test.go
+++ b/devshard/storage/hybrid_test.go
@@ -127,6 +127,15 @@ type failingPGStorage struct {
 	liveCheckCalls int
 }
 
+type fatalStorage struct {
+	recordingStorage
+	fatal chan error
+}
+
+func (s *fatalStorage) FatalErrors() <-chan error {
+	return s.fatal
+}
+
 func (f *failingPGStorage) CreateSession(params CreateSessionParams) error {
 	f.lastMethod = "CreateSession"
 	return f.err
@@ -400,6 +409,26 @@ func TestHybridStorage_PromotionHookFiresAfterReconnectAndImmediatelyAfterPromot
 			return false
 		}
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestHybridStorage_ForwardsFatalErrorFromPromotedPostgres(t *testing.T) {
+	h := newDegradedSQLiteRouter(nil, t.TempDir(), ErrStoragePostgresUnavailable)
+	t.Cleanup(func() { _ = h.Close() })
+	lifetimeErrors := h.FatalErrors()
+	require.NotNil(t, lifetimeErrors)
+
+	pg := &fatalStorage{fatal: make(chan error, 1)}
+	require.NoError(t, h.promotePostgres(pg))
+	want := errors.New("postgres fence session lost")
+	pg.fatal <- want
+
+	select {
+	case got := <-lifetimeErrors:
+		require.ErrorIs(t, got, want)
+	case <-time.After(time.Second):
+		t.Fatal("fatal error from promoted PostgreSQL was not forwarded")
+	}
+	require.Equal(t, lifetimeErrors, h.FatalErrors(), "hybrid fatal channel must remain stable after promotion")
 }
 
 func TestHybridStorage_ClearsPGBoundAfterFailedPGCreateWhenProvablyEmpty(t *testing.T) {

--- a/devshard/storage/managed.go
+++ b/devshard/storage/managed.go
@@ -156,6 +156,14 @@ func (m *ManagedStorage) Ready() bool {
 	return true
 }
 
+// FatalErrors forwards failures that require replacing the owning process.
+func (m *ManagedStorage) FatalErrors() <-chan error {
+	if reporter, ok := m.inner.(interface{ FatalErrors() <-chan error }); ok {
+		return reporter.FatalErrors()
+	}
+	return nil
+}
+
 // --- Storage delegation ---
 
 func (m *ManagedStorage) CreateSession(params CreateSessionParams) error {

--- a/devshard/storage/migrate/pg.go
+++ b/devshard/storage/migrate/pg.go
@@ -85,11 +85,13 @@ func applyPGStep(ctx context.Context, pool *pgxpool.Pool, step Step) error {
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	var maxApplied int
-	if err := tx.QueryRow(ctx, `SELECT COALESCE(MAX(id), 0) FROM schema_migrations`).Scan(&maxApplied); err != nil {
+	var applied bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE id = $1)
+	`, step.ID).Scan(&applied); err != nil {
 		return fmt.Errorf("migrate: read schema_migrations: %w", err)
 	}
-	if step.ID <= maxApplied {
+	if applied {
 		if err := tx.Commit(ctx); err != nil {
 			return fmt.Errorf("migrate: commit skipped step %d (%s): %w", step.ID, step.Name, err)
 		}

--- a/devshard/storage/migrate/pg.go
+++ b/devshard/storage/migrate/pg.go
@@ -4,8 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// pgMigrationLockNamespace is "GONK" encoded as an int32. The second advisory
+// lock key is the database name hash, so independent databases do not block
+// each other while every devshard migrator for one database is serialized.
+const pgMigrationLockNamespace int32 = 0x474f4e4b
 
 const pgBootstrapSQL = `
 CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -21,33 +27,63 @@ func ApplyPG(ctx context.Context, pool *pgxpool.Pool, steps []Step) error {
 	if err := validateSteps(steps); err != nil {
 		return err
 	}
-	if _, err := pool.Exec(ctx, pgBootstrapSQL); err != nil {
+	if err := bootstrapPG(ctx, pool); err != nil {
 		return fmt.Errorf("migrate: bootstrap schema_migrations: %w", err)
 	}
 
-	var maxApplied int
-	if err := pool.QueryRow(ctx, `SELECT COALESCE(MAX(id), 0) FROM schema_migrations`).Scan(&maxApplied); err != nil {
-		return fmt.Errorf("migrate: read schema_migrations: %w", err)
-	}
-
 	for _, step := range steps {
-		if step.ID <= maxApplied {
-			continue
-		}
 		if err := applyPGStep(ctx, pool, step); err != nil {
 			return err
 		}
-		maxApplied = step.ID
 	}
 	return nil
 }
 
-func applyPGStep(ctx context.Context, pool *pgxpool.Pool, step Step) error {
+func bootstrapPG(ctx context.Context, pool *pgxpool.Pool) error {
+	tx, err := beginLockedPGMigrationTx(ctx, pool)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, pgBootstrapSQL); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func beginLockedPGMigrationTx(ctx context.Context, pool *pgxpool.Pool) (pgx.Tx, error) {
 	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock($1, hashtext(current_database()))`,
+		pgMigrationLockNamespace,
+	); err != nil {
+		_ = tx.Rollback(context.Background())
+		return nil, fmt.Errorf("acquire advisory lock: %w", err)
+	}
+	return tx, nil
+}
+
+func applyPGStep(ctx context.Context, pool *pgxpool.Pool, step Step) error {
+	tx, err := beginLockedPGMigrationTx(ctx, pool)
 	if err != nil {
 		return fmt.Errorf("migrate: begin step %d (%s): %w", step.ID, step.Name, err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+
+	var maxApplied int
+	if err := tx.QueryRow(ctx, `SELECT COALESCE(MAX(id), 0) FROM schema_migrations`).Scan(&maxApplied); err != nil {
+		return fmt.Errorf("migrate: read schema_migrations: %w", err)
+	}
+	if step.ID <= maxApplied {
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("migrate: commit skipped step %d (%s): %w", step.ID, step.Name, err)
+		}
+		return nil
+	}
 
 	if len(step.Statements) == 0 {
 		return fmt.Errorf("migrate: step %d (%s): no statements", step.ID, step.Name)

--- a/devshard/storage/migrate/pg.go
+++ b/devshard/storage/migrate/pg.go
@@ -57,6 +57,17 @@ func beginLockedPGMigrationTx(ctx context.Context, pool *pgxpool.Pool) (pgx.Tx, 
 	if err != nil {
 		return nil, err
 	}
+	// Application queries use short server-side timeouts. A migration waiting
+	// behind another migrator is normal coordination, so let the caller's context
+	// bound this transaction instead of failing the process on lock_timeout.
+	if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = 0`); err != nil {
+		_ = tx.Rollback(context.Background())
+		return nil, fmt.Errorf("disable migration lock timeout: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `SET LOCAL statement_timeout = 0`); err != nil {
+		_ = tx.Rollback(context.Background())
+		return nil, fmt.Errorf("disable migration statement timeout: %w", err)
+	}
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock($1, hashtext(current_database()))`,
 		pgMigrationLockNamespace,

--- a/devshard/storage/migrate/pg.go
+++ b/devshard/storage/migrate/pg.go
@@ -21,20 +21,40 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 );
 `
 
-// ApplyPG runs pending migrations on pool in ascending step ID order.
-// Each step runs in its own transaction.
+// ApplyPG runs pending migrations on one connection under one advisory lock.
+// The transaction makes a failed migration batch retryable as a whole and
+// avoids one lock round trip for every already-applied step at process boot.
 func ApplyPG(ctx context.Context, pool *pgxpool.Pool, steps []Step) error {
 	if err := validateSteps(steps); err != nil {
 		return err
 	}
+	// Keep the migration ledger even when a later application step rolls back.
+	// This is a separate short locked transaction; all real steps below still
+	// share one lock acquisition and one transaction.
 	if err := bootstrapPG(ctx, pool); err != nil {
 		return fmt.Errorf("migrate: bootstrap schema_migrations: %w", err)
 	}
+	tx, err := beginLockedPGMigrationTx(ctx, pool)
+	if err != nil {
+		return fmt.Errorf("migrate: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	applied, err := appliedPGStepIDs(ctx, tx)
+	if err != nil {
+		return err
+	}
 
 	for _, step := range steps {
-		if err := applyPGStep(ctx, pool, step); err != nil {
+		if _, ok := applied[step.ID]; ok {
+			continue
+		}
+		if err := applyPGStep(ctx, tx, step); err != nil {
 			return err
 		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("migrate: commit: %w", err)
 	}
 	return nil
 }
@@ -45,11 +65,31 @@ func bootstrapPG(ctx context.Context, pool *pgxpool.Pool) error {
 		return err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
-
 	if _, err := tx.Exec(ctx, pgBootstrapSQL); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)
+}
+
+func appliedPGStepIDs(ctx context.Context, tx pgx.Tx) (map[int]struct{}, error) {
+	rows, err := tx.Query(ctx, `SELECT id FROM schema_migrations`)
+	if err != nil {
+		return nil, fmt.Errorf("migrate: read schema_migrations: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[int]struct{})
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("migrate: scan schema_migrations: %w", err)
+		}
+		applied[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("migrate: read schema_migrations: %w", err)
+	}
+	return applied, nil
 }
 
 func beginLockedPGMigrationTx(ctx context.Context, pool *pgxpool.Pool) (pgx.Tx, error) {
@@ -58,8 +98,8 @@ func beginLockedPGMigrationTx(ctx context.Context, pool *pgxpool.Pool) (pgx.Tx, 
 		return nil, err
 	}
 	// Application queries use short server-side timeouts. A migration waiting
-	// behind another migrator is normal coordination, so let the caller's context
-	// bound this transaction instead of failing the process on lock_timeout.
+	// behind another migrator is normal coordination, so let the dedicated
+	// migration context bound this transaction.
 	if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = 0`); err != nil {
 		_ = tx.Rollback(context.Background())
 		return nil, fmt.Errorf("disable migration lock timeout: %w", err)
@@ -78,26 +118,7 @@ func beginLockedPGMigrationTx(ctx context.Context, pool *pgxpool.Pool) (pgx.Tx, 
 	return tx, nil
 }
 
-func applyPGStep(ctx context.Context, pool *pgxpool.Pool, step Step) error {
-	tx, err := beginLockedPGMigrationTx(ctx, pool)
-	if err != nil {
-		return fmt.Errorf("migrate: begin step %d (%s): %w", step.ID, step.Name, err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
-	var applied bool
-	if err := tx.QueryRow(ctx, `
-		SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE id = $1)
-	`, step.ID).Scan(&applied); err != nil {
-		return fmt.Errorf("migrate: read schema_migrations: %w", err)
-	}
-	if applied {
-		if err := tx.Commit(ctx); err != nil {
-			return fmt.Errorf("migrate: commit skipped step %d (%s): %w", step.ID, step.Name, err)
-		}
-		return nil
-	}
-
+func applyPGStep(ctx context.Context, tx pgx.Tx, step Step) error {
 	if len(step.Statements) == 0 {
 		return fmt.Errorf("migrate: step %d (%s): no statements", step.ID, step.Name)
 	}
@@ -111,9 +132,6 @@ func applyPGStep(ctx context.Context, pool *pgxpool.Pool, step Step) error {
 		step.ID, step.Name,
 	); err != nil {
 		return fmt.Errorf("migrate: record step %d (%s): %w", step.ID, step.Name, err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("migrate: commit step %d (%s): %w", step.ID, step.Name, err)
 	}
 	return nil
 }

--- a/devshard/storage/migrate/pg_test.go
+++ b/devshard/storage/migrate/pg_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func testPGPool(t *testing.T) *pgxpool.Pool {
+	return testPGPoolWithRuntimeParams(t, nil)
+}
+
+func testPGPoolWithRuntimeParams(t *testing.T, runtimeParams map[string]string) *pgxpool.Pool {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("skipping postgres migration tests in -short mode (requires Docker)")
@@ -38,7 +42,12 @@ func testPGPool(t *testing.T) *pgxpool.Pool {
 		dsn = fmt.Sprintf("postgres://testuser:testpass@%s:%s/testdb?sslmode=disable", host, port.Port())
 	}
 
-	pool, err := pgxpool.New(ctx, dsn)
+	cfg, err := pgxpool.ParseConfig(dsn)
+	require.NoError(t, err)
+	for key, value := range runtimeParams {
+		cfg.ConnConfig.RuntimeParams[key] = value
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	require.NoError(t, err)
 	require.NoError(t, pool.Ping(ctx))
 	t.Cleanup(pool.Close)
@@ -67,7 +76,10 @@ func TestApplyPG_Idempotent(t *testing.T) {
 
 func TestApplyPG_ConcurrentCallersSerialize(t *testing.T) {
 	ctx := context.Background()
-	pool := testPGPool(t)
+	pool := testPGPoolWithRuntimeParams(t, map[string]string{
+		"lock_timeout":      "50",
+		"statement_timeout": "50",
+	})
 
 	steps := []migrate.Step{
 		{

--- a/devshard/storage/migrate/pg_test.go
+++ b/devshard/storage/migrate/pg_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -60,6 +61,47 @@ func TestApplyPG_Idempotent(t *testing.T) {
 	require.Equal(t, 2, n2)
 
 	exists, err := migrate.TableExistsPG(ctx, pool, "widget")
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestApplyPG_ConcurrentCallersSerialize(t *testing.T) {
+	ctx := context.Background()
+	pool := testPGPool(t)
+
+	steps := []migrate.Step{
+		{
+			ID:   1,
+			Name: "concurrent_create",
+			Statements: []string{
+				`SELECT pg_sleep(0.2)`,
+				`CREATE TABLE concurrent_migration_probe (id INT PRIMARY KEY)`,
+			},
+		},
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- migrate.ApplyPG(ctx, pool, steps)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	n, err := migrate.AppliedPG(ctx, pool)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	exists, err := migrate.TableExistsPG(ctx, pool, "concurrent_migration_probe")
 	require.NoError(t, err)
 	require.True(t, exists)
 }

--- a/devshard/storage/migrate/pg_test.go
+++ b/devshard/storage/migrate/pg_test.go
@@ -130,6 +130,33 @@ func TestApplyPG_RejectsOutOfOrderIDs(t *testing.T) {
 	require.True(t, errors.Is(err, migrate.ErrOutOfOrder))
 }
 
+func TestApplyPG_AppliesMissingStepBelowHigherID(t *testing.T) {
+	ctx := context.Background()
+	pool := testPGPool(t)
+	step13 := migrate.Step{
+		ID:         13,
+		Name:       "prototype_successor",
+		Statements: []string{`CREATE TABLE migration_step_13 (id INT PRIMARY KEY)`},
+	}
+
+	require.NoError(t, migrate.ApplyPG(ctx, pool, []migrate.Step{step13}))
+	require.NoError(t, migrate.ApplyPG(ctx, pool, []migrate.Step{
+		{
+			ID:         12,
+			Name:       "late_reserved_step",
+			Statements: []string{`CREATE TABLE migration_step_12 (id INT PRIMARY KEY)`},
+		},
+		step13,
+	}))
+
+	n, err := migrate.AppliedPG(ctx, pool)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	exists, err := migrate.TableExistsPG(ctx, pool, "migration_step_12")
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
 func TestApplyPG_StepWithoutIFNotExists(t *testing.T) {
 	ctx := context.Background()
 	pool := testPGPool(t)

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -287,77 +287,134 @@ func configurePostgresPool(cfg *pgxpool.Config) error {
 }
 
 func (s *Postgres) startHealthMonitor(connConfig *pgx.ConnConfig) {
+	probe := newPostgresHealthProbe(connConfig)
+	s.startPostgresMonitors(postgresMonitorConfig{
+		interval:      postgresHealthInterval,
+		healthTimeout: postgresHealthTimeout,
+		fenceTimeout:  postgresFenceCheckTimeout,
+		healthCheck:   probe.check,
+		healthClose:   probe.close,
+		fenceCheck:    s.connectionGuard.check,
+		poolSaturated: func() bool { return postgresPoolIsSaturated(s.pool) },
+	})
+}
+
+type postgresMonitorConfig struct {
+	interval      time.Duration
+	healthTimeout time.Duration
+	fenceTimeout  time.Duration
+	healthCheck   func(context.Context) error
+	healthClose   func(context.Context) error
+	fenceCheck    func(context.Context) error
+	poolSaturated func() bool
+}
+
+func (s *Postgres) startPostgresMonitors(config postgresMonitorConfig) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.mu.Lock()
 	s.healthStop = cancel
 	s.mu.Unlock()
-	go func() {
-		defer close(s.healthDone)
-		probe := newPostgresHealthProbe(connConfig)
-		defer func() {
-			closeCtx, closeCancel := context.WithTimeout(context.Background(), postgresHealthTimeout)
-			defer closeCancel()
-			if err := probe.close(closeCtx); err != nil {
-				slog.Warn("devshard storage: close postgres health connection", "error", err)
-			}
-		}()
-		timer := time.NewTimer(postgresHealthInterval)
-		defer timer.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-timer.C:
-				fenceCtx, fenceCancel := context.WithTimeout(ctx, postgresFenceCheckTimeout)
-				if err := s.connectionGuard.check(fenceCtx); err != nil {
-					fenceCancel()
-					if ctx.Err() != nil {
-						return
-					}
-					s.mu.Lock()
-					s.healthReady = false
-					s.mu.Unlock()
-					fatalErr := fmt.Errorf("postgres fence session lost: %w", err)
-					slog.Error("devshard storage: postgres fence session lost; terminating process", "error", err)
-					s.fatalErrors <- fatalErr
-					return
-				}
-				fenceCancel()
 
-				probeCtx, probeCancel := context.WithTimeout(ctx, postgresHealthTimeout)
-				err := probe.check(probeCtx)
-				probeCancel()
-				if ctx.Err() != nil {
-					return
-				}
-				result := postgresHealthProbeSuccess
-				if err != nil {
-					result = postgresHealthProbeDatabaseError
-				}
-				saturated := postgresPoolIsSaturated(s.pool)
-				observability.ObservePostgresHealthProbe(err == nil, saturated)
-				previous, current := s.recordHealthProbe(result, saturated)
-				if previous.ready != current.ready {
-					if current.ready {
-						slog.Info("devshard storage: postgres readiness recovered")
-					} else {
-						slog.Warn("devshard storage: postgres readiness lost", "error", err)
-					}
-				}
-				if previous.saturated != current.saturated {
-					if current.saturated {
-						stat := s.pool.Stat()
-						slog.Warn("devshard storage: postgres application pool is saturated",
-							"acquired_connections", stat.AcquiredConns(),
-							"max_connections", stat.MaxConns())
-					} else {
-						slog.Info("devshard storage: postgres application pool saturation cleared")
-					}
-				}
-				timer.Reset(postgresHealthInterval)
-			}
+	var monitors sync.WaitGroup
+	monitors.Add(2)
+	go func() {
+		defer monitors.Done()
+		s.runPostgresReadinessMonitor(ctx, config)
+	}()
+	go func() {
+		defer monitors.Done()
+		s.runPostgresFenceMonitor(ctx, cancel, config)
+	}()
+	go func() {
+		monitors.Wait()
+		close(s.healthDone)
+	}()
+}
+
+func (s *Postgres) runPostgresReadinessMonitor(ctx context.Context, config postgresMonitorConfig) {
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), config.healthTimeout)
+		defer closeCancel()
+		if err := config.healthClose(closeCtx); err != nil {
+			slog.Warn("devshard storage: close postgres health connection", "error", err)
 		}
 	}()
+	timer := time.NewTimer(config.interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		probeCtx, probeCancel := context.WithTimeout(ctx, config.healthTimeout)
+		err := config.healthCheck(probeCtx)
+		probeCancel()
+		if ctx.Err() != nil {
+			return
+		}
+		result := postgresHealthProbeSuccess
+		if err != nil {
+			result = postgresHealthProbeDatabaseError
+		}
+		saturated := config.poolSaturated()
+		observability.ObservePostgresHealthProbe(err == nil, saturated)
+		previous, current := s.recordHealthProbe(result, saturated)
+		if previous.ready != current.ready {
+			if current.ready {
+				slog.Info("devshard storage: postgres readiness recovered")
+			} else {
+				slog.Warn("devshard storage: postgres readiness lost", "error", err)
+			}
+		}
+		if previous.saturated != current.saturated {
+			if current.saturated {
+				stat := s.pool.Stat()
+				slog.Warn("devshard storage: postgres application pool is saturated",
+					"acquired_connections", stat.AcquiredConns(),
+					"max_connections", stat.MaxConns())
+			} else {
+				slog.Info("devshard storage: postgres application pool saturation cleared")
+			}
+		}
+		timer.Reset(config.interval)
+	}
+}
+
+func (s *Postgres) runPostgresFenceMonitor(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	config postgresMonitorConfig,
+) {
+	timer := time.NewTimer(config.interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		fenceCtx, fenceCancel := context.WithTimeout(ctx, config.fenceTimeout)
+		err := config.fenceCheck(fenceCtx)
+		fenceCancel()
+		if err == nil {
+			timer.Reset(config.interval)
+			continue
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		s.mu.Lock()
+		s.healthReady = false
+		s.mu.Unlock()
+		fatalErr := fmt.Errorf("postgres fence session lost: %w", err)
+		slog.Error("devshard storage: postgres fence session lost; terminating process", "error", err)
+		s.fatalErrors <- fatalErr
+		cancel()
+		return
+	}
 }
 
 // FatalErrors reports storage failures that require replacing this process.

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -214,7 +214,10 @@ func newPostgres(ctx context.Context, connectTimeout, migrationTimeout time.Dura
 	// Server-side per-query bounds applied to every pooled connection.
 	cfg.ConnConfig.RuntimeParams["statement_timeout"] = strconv.FormatInt(postgresStatementTimeout.Milliseconds(), 10)
 	cfg.ConnConfig.RuntimeParams["lock_timeout"] = strconv.FormatInt(postgresLockTimeout.Milliseconds(), 10)
-	connectionGuard := newPostgresConnectionGuard()
+	connectionGuard, err := newPostgresConnectionGuard()
+	if err != nil {
+		return nil, err
+	}
 	connectionGuard.installValidator(cfg)
 	// Health owns one dedicated connection, leaving every configured pool slot
 	// available to application work and keeping MaxConns an application concern.
@@ -236,7 +239,7 @@ func newPostgres(ctx context.Context, connectTimeout, migrationTimeout time.Dura
 		pool.Close()
 		return nil, err
 	}
-	if err := connectionGuard.arm(migrationCtx, pool); err != nil {
+	if err := connectionGuard.arm(migrationCtx, pool, cfg.ConnConfig); err != nil {
 		pool.Close()
 		return nil, err
 	}
@@ -621,7 +624,7 @@ func (s *Postgres) Close() error {
 	}
 	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), postgresOpTimeout)
 	defer cleanupCancel()
-	s.connectionGuard.remove(cleanupCtx, s.pool)
+	s.connectionGuard.close(cleanupCtx)
 	s.pool.Close()
 	return nil
 }

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -54,6 +54,7 @@ type Postgres struct {
 	healthSaturated bool
 	healthStop      context.CancelFunc
 	healthDone      chan struct{}
+	fatalErrors     chan error
 }
 
 const (
@@ -252,6 +253,7 @@ func newPostgres(ctx context.Context, connectTimeout, migrationTimeout time.Dura
 		readyCh:         make(chan struct{}),
 		healthReady:     true,
 		healthDone:      make(chan struct{}),
+		fatalErrors:     make(chan error, 1),
 	}
 	s.startHealthMonitor(healthConfig)
 	s.startIndexRebuild()
@@ -281,6 +283,19 @@ func (s *Postgres) startHealthMonitor(connConfig *pgx.ConnConfig) {
 				return
 			case <-timer.C:
 				probeCtx, probeCancel := context.WithTimeout(ctx, postgresHealthTimeout)
+				if err := s.connectionGuard.check(probeCtx); err != nil {
+					probeCancel()
+					if ctx.Err() != nil {
+						return
+					}
+					s.mu.Lock()
+					s.healthReady = false
+					s.mu.Unlock()
+					fatalErr := fmt.Errorf("postgres fence session lost: %w", err)
+					slog.Error("devshard storage: postgres fence session lost; terminating process", "error", err)
+					s.fatalErrors <- fatalErr
+					return
+				}
 				err := probe.check(probeCtx)
 				probeCancel()
 				if ctx.Err() != nil {
@@ -314,6 +329,13 @@ func (s *Postgres) startHealthMonitor(connConfig *pgx.ConnConfig) {
 			}
 		}
 	}()
+}
+
+// FatalErrors reports storage failures that require replacing this process.
+// A lost session fence cannot be re-armed safely while old pool connections
+// may still exist, so versiond must start a fresh child generation.
+func (s *Postgres) FatalErrors() <-chan error {
+	return s.fatalErrors
 }
 
 func postgresPoolIsSaturated(pool *pgxpool.Pool) bool {

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -81,6 +81,10 @@ const (
 	postgresHealthInterval = 5 * time.Second
 	postgresHealthTimeout  = postgresConnectTimeout
 	postgresHealthQuorum   = 2
+	// A timed-out pgx query closes the session and therefore releases its
+	// advisory fence. Give this terminal check a wider budget than ordinary
+	// readiness probes so transient database stalls do not replace every child.
+	postgresFenceCheckTimeout = 30 * time.Second
 	// postgresIndexRepairBatchSize caps rows per DELETE/INSERT when repairing
 	// devshard_session_index so a large divergence does not hold one giant lock.
 	postgresIndexRepairBatchSize = 1000
@@ -282,9 +286,9 @@ func (s *Postgres) startHealthMonitor(connConfig *pgx.ConnConfig) {
 			case <-ctx.Done():
 				return
 			case <-timer.C:
-				probeCtx, probeCancel := context.WithTimeout(ctx, postgresHealthTimeout)
-				if err := s.connectionGuard.check(probeCtx); err != nil {
-					probeCancel()
+				fenceCtx, fenceCancel := context.WithTimeout(ctx, postgresFenceCheckTimeout)
+				if err := s.connectionGuard.check(fenceCtx); err != nil {
+					fenceCancel()
 					if ctx.Err() != nil {
 						return
 					}
@@ -296,6 +300,9 @@ func (s *Postgres) startHealthMonitor(connConfig *pgx.ConnConfig) {
 					s.fatalErrors <- fatalErr
 					return
 				}
+				fenceCancel()
+
+				probeCtx, probeCancel := context.WithTimeout(ctx, postgresHealthTimeout)
 				err := probe.check(probeCtx)
 				probeCancel()
 				if ctx.Err() != nil {

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -198,11 +198,15 @@ func pgValidationLeasesPartition(epochID uint64) string {
 // idempotently. The escrow index is rebuilt asynchronously; use WaitReady
 // (bounded by PG_INDEX_TIMEOUT) before promote/boot paths that need ownership.
 func NewPostgres(ctx context.Context) (*Postgres, error) {
+	return newPostgres(ctx, postgresConnectTimeout, defaultPGMigrationTimeout)
+}
+
+func newPostgres(ctx context.Context, connectTimeout, migrationTimeout time.Duration) (*Postgres, error) {
 	cfg, err := pgxpool.ParseConfig("") // reads libpq env vars
 	if err != nil {
 		return nil, fmt.Errorf("parse postgres config: %w", err)
 	}
-	cfg.ConnConfig.ConnectTimeout = postgresConnectTimeout
+	cfg.ConnConfig.ConnectTimeout = connectTimeout
 	if cfg.ConnConfig.RuntimeParams == nil {
 		cfg.ConnConfig.RuntimeParams = make(map[string]string)
 	}
@@ -212,16 +216,20 @@ func NewPostgres(ctx context.Context) (*Postgres, error) {
 	// Health owns one dedicated connection, leaving every configured pool slot
 	// available to application work and keeping MaxConns an application concern.
 	healthConfig := cfg.ConnConfig.Copy()
-	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	connectCtx, cancelConnect := context.WithTimeout(ctx, connectTimeout)
+	defer cancelConnect()
+	pool, err := pgxpool.NewWithConfig(connectCtx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("connect to postgres: %w", err)
 	}
-	if err := pool.Ping(ctx); err != nil {
+	if err := pool.Ping(connectCtx); err != nil {
 		pool.Close()
 		return nil, fmt.Errorf("ping postgres: %w", err)
 	}
 
-	if err := MigratePostgres(ctx, pool); err != nil {
+	migrationCtx, cancelMigration := context.WithTimeout(ctx, migrationTimeout)
+	defer cancelMigration()
+	if err := MigratePostgres(migrationCtx, pool); err != nil {
 		pool.Close()
 		return nil, err
 	}

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -81,6 +82,10 @@ const (
 	postgresHealthInterval = 5 * time.Second
 	postgresHealthTimeout  = postgresConnectTimeout
 	postgresHealthQuorum   = 2
+	// pgx otherwise scales the default pool to runtime.NumCPU. Versiond runs
+	// several devshard processes per host, so a CPU-sized pool per generation
+	// can exhaust PostgreSQL before application load reaches its own limits.
+	defaultPostgresPoolMaxConns int32 = 4
 	// A timed-out pgx query closes the session and therefore releases its
 	// advisory fence. Give this terminal check a wider budget than ordinary
 	// readiness probes so transient database stalls do not replace every child.
@@ -212,6 +217,9 @@ func newPostgres(ctx context.Context, connectTimeout, migrationTimeout time.Dura
 	if err != nil {
 		return nil, fmt.Errorf("parse postgres config: %w", err)
 	}
+	if err := configurePostgresPool(cfg); err != nil {
+		return nil, err
+	}
 	cfg.ConnConfig.ConnectTimeout = connectTimeout
 	if cfg.ConnConfig.RuntimeParams == nil {
 		cfg.ConnConfig.RuntimeParams = make(map[string]string)
@@ -262,6 +270,20 @@ func newPostgres(ctx context.Context, connectTimeout, migrationTimeout time.Dura
 	s.startHealthMonitor(healthConfig)
 	s.startIndexRebuild()
 	return s, nil
+}
+
+func configurePostgresPool(cfg *pgxpool.Config) error {
+	raw := strings.TrimSpace(os.Getenv("PG_POOL_MAX_CONNS"))
+	if raw == "" {
+		cfg.MaxConns = defaultPostgresPoolMaxConns
+		return nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || value <= 0 {
+		return fmt.Errorf("PG_POOL_MAX_CONNS must be a positive integer, got %q", raw)
+	}
+	cfg.MaxConns = int32(value)
+	return nil
 }
 
 func (s *Postgres) startHealthMonitor(connConfig *pgx.ConnConfig) {

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -37,7 +37,8 @@ import (
 // serving; escrow-keyed methods also WaitReady so requests block until rebuild
 // finishes or fails.
 type Postgres struct {
-	pool *pgxpool.Pool
+	pool            *pgxpool.Pool
+	connectionGuard *postgresConnectionGuard
 
 	mu          sync.RWMutex
 	knownEpochs map[uint64]struct{}
@@ -213,6 +214,8 @@ func newPostgres(ctx context.Context, connectTimeout, migrationTimeout time.Dura
 	// Server-side per-query bounds applied to every pooled connection.
 	cfg.ConnConfig.RuntimeParams["statement_timeout"] = strconv.FormatInt(postgresStatementTimeout.Milliseconds(), 10)
 	cfg.ConnConfig.RuntimeParams["lock_timeout"] = strconv.FormatInt(postgresLockTimeout.Milliseconds(), 10)
+	connectionGuard := newPostgresConnectionGuard()
+	connectionGuard.installValidator(cfg)
 	// Health owns one dedicated connection, leaving every configured pool slot
 	// available to application work and keeping MaxConns an application concern.
 	healthConfig := cfg.ConnConfig.Copy()
@@ -233,14 +236,19 @@ func newPostgres(ctx context.Context, connectTimeout, migrationTimeout time.Dura
 		pool.Close()
 		return nil, err
 	}
+	if err := connectionGuard.arm(migrationCtx, pool); err != nil {
+		pool.Close()
+		return nil, err
+	}
 
 	s := &Postgres{
-		pool:        pool,
-		knownEpochs: make(map[uint64]struct{}),
-		escrowIdx:   make(map[string]uint64),
-		readyCh:     make(chan struct{}),
-		healthReady: true,
-		healthDone:  make(chan struct{}),
+		pool:            pool,
+		connectionGuard: connectionGuard,
+		knownEpochs:     make(map[uint64]struct{}),
+		escrowIdx:       make(map[string]uint64),
+		readyCh:         make(chan struct{}),
+		healthReady:     true,
+		healthDone:      make(chan struct{}),
 	}
 	s.startHealthMonitor(healthConfig)
 	s.startIndexRebuild()
@@ -611,6 +619,9 @@ func (s *Postgres) Close() error {
 	if healthDone != nil {
 		<-healthDone
 	}
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), postgresOpTimeout)
+	defer cleanupCancel()
+	s.connectionGuard.remove(cleanupCtx, s.pool)
 	s.pool.Close()
 	return nil
 }

--- a/devshard/storage/postgres_connection_guard.go
+++ b/devshard/storage/postgres_connection_guard.go
@@ -2,25 +2,39 @@ package storage
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"sync/atomic"
 
-	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // postgresConnectionGuard binds one application pool to the writable database
-// selected during startup. Every later connection must observe this process's
-// token, including connections created after DNS or load-balancer changes.
+// selected during startup. The session advisory lock is deliberately outside
+// durable storage: WAL replication cannot copy it to a promoted fork.
 type postgresConnectionGuard struct {
-	token string
-	armed atomic.Bool
+	key       int32
+	armed     atomic.Bool
+	fenceConn *pgx.Conn
 }
 
-func newPostgresConnectionGuard() *postgresConnectionGuard {
-	return &postgresConnectionGuard{token: uuid.NewString()}
+const postgresConnectionGuardNamespace int32 = 0x474f4e4b // "GONK"
+
+func newPostgresConnectionGuard() (*postgresConnectionGuard, error) {
+	var raw [4]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return nil, fmt.Errorf("generate postgres connection fence: %w", err)
+	}
+	key := int32(binary.BigEndian.Uint32(raw[:]) & math.MaxInt32)
+	if key == 0 {
+		key = 1
+	}
+	return &postgresConnectionGuard{key: key}, nil
 }
 
 func (g *postgresConnectionGuard) installValidator(cfg *pgxpool.Config) {
@@ -36,39 +50,55 @@ func (g *postgresConnectionGuard) installValidator(cfg *pgxpool.Config) {
 		}
 		result := conn.ExecParams(ctx, `
 SELECT EXISTS (
-    SELECT 1 FROM devshard_connection_lineage WHERE token = $1::uuid
-) AND NOT pg_is_in_recovery()`, [][]byte{[]byte(g.token)}, nil, nil, nil).Read()
+    SELECT 1
+    FROM pg_locks
+    WHERE locktype = 'advisory'
+      AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+      AND classid = $1::bigint::oid
+      AND objid = $2::bigint::oid
+      AND objsubid = 2
+      AND granted
+) AND NOT pg_is_in_recovery()`, [][]byte{
+			[]byte(fmt.Sprint(postgresConnectionGuardNamespace)),
+			[]byte(fmt.Sprint(g.key)),
+		}, nil, nil, nil).Read()
 		if result.Err != nil {
-			return fmt.Errorf("verify postgres connection lineage: %w", result.Err)
+			return fmt.Errorf("verify postgres connection fence: %w", result.Err)
 		}
 		if len(result.Rows) != 1 || len(result.Rows[0]) != 1 {
-			return errors.New("verify postgres connection lineage: unexpected query result")
+			return errors.New("verify postgres connection fence: unexpected query result")
 		}
 		if string(result.Rows[0][0]) != "t" {
-			return errors.New("postgres connection does not belong to the initialized writable database")
+			return errors.New("postgres connection does not belong to the fenced writable database")
 		}
 		return nil
 	}
 }
 
-func (g *postgresConnectionGuard) arm(ctx context.Context, pool *pgxpool.Pool) error {
-	if _, err := pool.Exec(ctx, `
-INSERT INTO devshard_connection_lineage (token) VALUES ($1::uuid)
-ON CONFLICT (token) DO NOTHING`, g.token); err != nil {
-		return fmt.Errorf("seed postgres connection lineage: %w", err)
+func (g *postgresConnectionGuard) arm(ctx context.Context, pool *pgxpool.Pool, cfg *pgx.ConnConfig) error {
+	conn, err := pgx.ConnectConfig(ctx, cfg.Copy())
+	if err != nil {
+		return fmt.Errorf("connect postgres fence session: %w", err)
 	}
+	if _, err := conn.Exec(ctx,
+		`SELECT pg_advisory_lock($1, $2)`, postgresConnectionGuardNamespace, g.key); err != nil {
+		_ = conn.Close(context.Background())
+		return fmt.Errorf("acquire postgres connection fence: %w", err)
+	}
+	g.fenceConn = conn
 	g.armed.Store(true)
 	// Initialization has no concurrent application users. Reset removes every
-	// connection opened before the validator was armed, so all serving traffic
-	// goes through the connection-level check.
+	// connection opened before the fence was armed, so all serving traffic goes
+	// through the connection-level check.
 	pool.Reset()
 	return nil
 }
 
-func (g *postgresConnectionGuard) remove(ctx context.Context, pool *pgxpool.Pool) {
-	if g == nil || pool == nil || !g.armed.Load() {
+func (g *postgresConnectionGuard) close(ctx context.Context) {
+	if g == nil || g.fenceConn == nil {
 		return
 	}
-	_, _ = pool.Exec(ctx,
-		`DELETE FROM devshard_connection_lineage WHERE token = $1::uuid`, g.token)
+	g.armed.Store(false)
+	_ = g.fenceConn.Close(ctx)
+	g.fenceConn = nil
 }

--- a/devshard/storage/postgres_connection_guard.go
+++ b/devshard/storage/postgres_connection_guard.go
@@ -1,0 +1,74 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// postgresConnectionGuard binds one application pool to the writable database
+// selected during startup. Every later connection must observe this process's
+// token, including connections created after DNS or load-balancer changes.
+type postgresConnectionGuard struct {
+	token string
+	armed atomic.Bool
+}
+
+func newPostgresConnectionGuard() *postgresConnectionGuard {
+	return &postgresConnectionGuard{token: uuid.NewString()}
+}
+
+func (g *postgresConnectionGuard) installValidator(cfg *pgxpool.Config) {
+	previous := cfg.ConnConfig.ValidateConnect
+	cfg.ConnConfig.ValidateConnect = func(ctx context.Context, conn *pgconn.PgConn) error {
+		if previous != nil {
+			if err := previous(ctx, conn); err != nil {
+				return err
+			}
+		}
+		if !g.armed.Load() {
+			return nil
+		}
+		result := conn.ExecParams(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM devshard_connection_lineage WHERE token = $1::uuid
+) AND NOT pg_is_in_recovery()`, [][]byte{[]byte(g.token)}, nil, nil, nil).Read()
+		if result.Err != nil {
+			return fmt.Errorf("verify postgres connection lineage: %w", result.Err)
+		}
+		if len(result.Rows) != 1 || len(result.Rows[0]) != 1 {
+			return errors.New("verify postgres connection lineage: unexpected query result")
+		}
+		if string(result.Rows[0][0]) != "t" {
+			return errors.New("postgres connection does not belong to the initialized writable database")
+		}
+		return nil
+	}
+}
+
+func (g *postgresConnectionGuard) arm(ctx context.Context, pool *pgxpool.Pool) error {
+	if _, err := pool.Exec(ctx, `
+INSERT INTO devshard_connection_lineage (token) VALUES ($1::uuid)
+ON CONFLICT (token) DO NOTHING`, g.token); err != nil {
+		return fmt.Errorf("seed postgres connection lineage: %w", err)
+	}
+	g.armed.Store(true)
+	// Initialization has no concurrent application users. Reset removes every
+	// connection opened before the validator was armed, so all serving traffic
+	// goes through the connection-level check.
+	pool.Reset()
+	return nil
+}
+
+func (g *postgresConnectionGuard) remove(ctx context.Context, pool *pgxpool.Pool) {
+	if g == nil || pool == nil || !g.armed.Load() {
+		return
+	}
+	_, _ = pool.Exec(ctx,
+		`DELETE FROM devshard_connection_lineage WHERE token = $1::uuid`, g.token)
+}

--- a/devshard/storage/postgres_connection_guard.go
+++ b/devshard/storage/postgres_connection_guard.go
@@ -94,6 +94,30 @@ func (g *postgresConnectionGuard) arm(ctx context.Context, pool *pgxpool.Pool, c
 	return nil
 }
 
+func (g *postgresConnectionGuard) check(ctx context.Context) error {
+	if g == nil || !g.armed.Load() || g.fenceConn == nil {
+		return errors.New("postgres connection fence is not armed")
+	}
+	var held bool
+	if err := g.fenceConn.QueryRow(ctx, `
+SELECT EXISTS (
+    SELECT 1
+    FROM pg_locks
+    WHERE locktype = 'advisory'
+      AND pid = pg_backend_pid()
+      AND classid = $1::bigint::oid
+      AND objid = $2::bigint::oid
+      AND objsubid = 2
+      AND granted
+) AND NOT pg_is_in_recovery()`, postgresConnectionGuardNamespace, g.key).Scan(&held); err != nil {
+		return fmt.Errorf("check postgres connection fence: %w", err)
+	}
+	if !held {
+		return errors.New("postgres connection fence is no longer held on the writable database")
+	}
+	return nil
+}
+
 func (g *postgresConnectionGuard) close(ctx context.Context) {
 	if g == nil || g.fenceConn == nil {
 		return

--- a/devshard/storage/postgres_connection_guard.go
+++ b/devshard/storage/postgres_connection_guard.go
@@ -80,6 +80,10 @@ func (g *postgresConnectionGuard) arm(ctx context.Context, pool *pgxpool.Pool, c
 	if err != nil {
 		return fmt.Errorf("connect postgres fence session: %w", err)
 	}
+	if _, err := conn.Exec(ctx, `SET idle_session_timeout = 0`); err != nil {
+		_ = conn.Close(context.Background())
+		return fmt.Errorf("disable postgres fence idle timeout: %w", err)
+	}
 	if _, err := conn.Exec(ctx,
 		`SELECT pg_advisory_lock($1, $2)`, postgresConnectionGuardNamespace, g.key); err != nil {
 		_ = conn.Close(context.Background())

--- a/devshard/storage/postgres_connection_guard_test.go
+++ b/devshard/storage/postgres_connection_guard_test.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresConnectionGuardDisablesIdleSessionTimeout(t *testing.T) {
+	container := startPostgresContainer(t)
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	cfg, err := pgxpool.ParseConfig("")
+	require.NoError(t, err)
+	guard, err := newPostgresConnectionGuard()
+	require.NoError(t, err)
+	guard.installValidator(cfg)
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	require.NoError(t, guard.arm(context.Background(), pool, cfg.ConnConfig))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		guard.close(ctx)
+	})
+
+	var idleTimeout string
+	require.NoError(t, guard.fenceConn.QueryRow(context.Background(),
+		"SHOW idle_session_timeout").Scan(&idleTimeout))
+	require.Equal(t, "0", idleTimeout)
+}

--- a/devshard/storage/postgres_migrate.go
+++ b/devshard/storage/postgres_migrate.go
@@ -11,7 +11,10 @@ import (
 )
 
 // postgresMigrationSteps is the ordered forward-only schema for devshard Postgres parents.
-// Per-epoch partitions are created lazily via ensurePartition only.
+// ApplyPG executes all pending steps in one transaction, so statements that
+// require running outside a transaction (for example CREATE INDEX CONCURRENTLY)
+// need a separate migration primitive. Per-epoch partitions are created lazily
+// via ensurePartition only.
 var postgresMigrationSteps = []migrate.Step{
 	{
 		ID:   1,

--- a/devshard/storage/postgres_migrate.go
+++ b/devshard/storage/postgres_migrate.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -223,6 +224,41 @@ func MigratePostgres(ctx context.Context, pool *pgxpool.Pool) error {
 		return fmt.Errorf("devshard postgres migrate: %w", err)
 	}
 	return nil
+}
+
+// InitializePostgresSchema applies the current schema without starting a
+// devshard server. Versiond uses this as the lock-aware initialization stage
+// before it permits legacy children to start against a fresh shared database.
+func InitializePostgresSchema(ctx context.Context) error {
+	cfg, err := pgxpool.ParseConfig("")
+	if err != nil {
+		return fmt.Errorf("parse postgres config: %w", err)
+	}
+	connectTimeout := pgConnectTimeout()
+	cfg.ConnConfig.ConnectTimeout = connectTimeout
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = make(map[string]string)
+	}
+	cfg.ConnConfig.RuntimeParams["statement_timeout"] = strconv.FormatInt(postgresStatementTimeout.Milliseconds(), 10)
+	cfg.ConnConfig.RuntimeParams["lock_timeout"] = strconv.FormatInt(postgresLockTimeout.Milliseconds(), 10)
+
+	connectCtx, cancelConnect := context.WithTimeout(ctx, connectTimeout)
+	pool, err := pgxpool.NewWithConfig(connectCtx, cfg)
+	if err == nil {
+		err = pool.Ping(connectCtx)
+	}
+	cancelConnect()
+	if err != nil {
+		if pool != nil {
+			pool.Close()
+		}
+		return fmt.Errorf("connect to postgres for schema initialization: %w", err)
+	}
+	defer pool.Close()
+
+	migrationCtx, cancelMigration := context.WithTimeout(ctx, pgMigrationTimeout())
+	defer cancelMigration()
+	return MigratePostgres(migrationCtx, pool)
 }
 
 // PostgresMigrationSteps returns a copy of registered Postgres migration steps (for tests).

--- a/devshard/storage/postgres_migrate.go
+++ b/devshard/storage/postgres_migrate.go
@@ -204,7 +204,16 @@ VALUES (
 		Statements: []string{`
 ALTER TABLE devshard_storage_identity
     ADD COLUMN IF NOT EXISTS challenge UUID,
-    ADD COLUMN IF NOT EXISTS challenged_at TIMESTAMPTZ`},
+	    ADD COLUMN IF NOT EXISTS challenged_at TIMESTAMPTZ`},
+	},
+	{
+		ID:   15,
+		Name: "devshard_connection_lineage",
+		Statements: []string{`
+CREATE TABLE IF NOT EXISTS devshard_connection_lineage (
+    token      UUID        PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`},
 	},
 }
 

--- a/devshard/storage/postgres_migrate.go
+++ b/devshard/storage/postgres_migrate.go
@@ -207,15 +207,6 @@ ALTER TABLE devshard_storage_identity
     ADD COLUMN IF NOT EXISTS challenge UUID,
 	    ADD COLUMN IF NOT EXISTS challenged_at TIMESTAMPTZ`},
 	},
-	{
-		ID:   15,
-		Name: "devshard_connection_lineage",
-		Statements: []string{`
-CREATE TABLE IF NOT EXISTS devshard_connection_lineage (
-    token      UUID        PRIMARY KEY,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-)`},
-	},
 }
 
 // MigratePostgres applies all pending devshard Postgres parent-table migrations.

--- a/devshard/storage/postgres_migrate.go
+++ b/devshard/storage/postgres_migrate.go
@@ -181,6 +181,23 @@ CREATE TABLE IF NOT EXISTS devshard_escrow_cache (
 			`CREATE INDEX IF NOT EXISTS devshard_escrow_cache_by_epoch ON devshard_escrow_cache(epoch_id)`,
 		},
 	},
+	{
+		// Migration 12 was used by an unreleased HA prototype. Keep the next ID
+		// stable so databases created by that prototype can converge safely.
+		ID:   13,
+		Name: "devshard_storage_identity",
+		Statements: []string{`
+CREATE TABLE IF NOT EXISTS devshard_storage_identity (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    identity  UUID    NOT NULL
+)`, `
+INSERT INTO devshard_storage_identity (singleton, identity)
+VALUES (
+    TRUE,
+    md5(current_database() || clock_timestamp()::text || random()::text)::uuid
+)
+ON CONFLICT (singleton) DO NOTHING`},
+	},
 }
 
 // MigratePostgres applies all pending devshard Postgres parent-table migrations.

--- a/devshard/storage/postgres_migrate.go
+++ b/devshard/storage/postgres_migrate.go
@@ -194,7 +194,7 @@ CREATE TABLE IF NOT EXISTS devshard_storage_identity (
 INSERT INTO devshard_storage_identity (singleton, identity)
 VALUES (
     TRUE,
-    md5(current_database() || clock_timestamp()::text || random()::text)::uuid
+    gen_random_uuid()
 )
 ON CONFLICT (singleton) DO NOTHING`},
 	},

--- a/devshard/storage/postgres_migrate.go
+++ b/devshard/storage/postgres_migrate.go
@@ -196,7 +196,15 @@ VALUES (
     TRUE,
     gen_random_uuid()
 )
-ON CONFLICT (singleton) DO NOTHING`},
+		ON CONFLICT (singleton) DO NOTHING`},
+	},
+	{
+		ID:   14,
+		Name: "devshard_storage_challenge",
+		Statements: []string{`
+ALTER TABLE devshard_storage_identity
+    ADD COLUMN IF NOT EXISTS challenge UUID,
+    ADD COLUMN IF NOT EXISTS challenged_at TIMESTAMPTZ`},
 	},
 }
 

--- a/devshard/storage/postgres_migrate.go
+++ b/devshard/storage/postgres_migrate.go
@@ -228,6 +228,9 @@ func InitializePostgresSchema(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("parse postgres config: %w", err)
 	}
+	if err := configurePostgresPool(cfg); err != nil {
+		return err
+	}
 	connectTimeout := pgConnectTimeout()
 	cfg.ConnConfig.ConnectTimeout = connectTimeout
 	if cfg.ConnConfig.RuntimeParams == nil {

--- a/devshard/storage/postgres_migrate_test.go
+++ b/devshard/storage/postgres_migrate_test.go
@@ -129,6 +129,22 @@ SELECT identity::text FROM devshard_storage_identity WHERE singleton`).Scan(&ide
 	require.Equal(t, storageIdentity, identityAfterRerun)
 }
 
+func TestInitializePostgresSchemaFromEnvironment(t *testing.T) {
+	_, cleanup := setupDevshardPostgresPool(t, nil)
+	defer cleanup()
+
+	require.NoError(t, InitializePostgresSchema(context.Background()))
+
+	cfg, err := pgxpool.ParseConfig("")
+	require.NoError(t, err)
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	defer pool.Close()
+	count, err := migrate.AppliedPG(context.Background(), pool)
+	require.NoError(t, err)
+	require.Equal(t, len(PostgresMigrationSteps()), count)
+}
+
 func TestSaveSnapshot_SameEpoch_PartitionCreateOnce(t *testing.T) {
 	ctx := context.Background()
 	tracer := &postgresPartitionDDLTracer{}

--- a/devshard/storage/postgres_migrate_test.go
+++ b/devshard/storage/postgres_migrate_test.go
@@ -107,7 +107,7 @@ func TestMigratePostgres_Idempotent(t *testing.T) {
 SELECT identity::text FROM devshard_storage_identity WHERE singleton`).Scan(&storageIdentity)
 	require.NoError(t, err)
 	require.Regexp(t,
-		`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+		`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
 		storageIdentity,
 	)
 

--- a/devshard/storage/postgres_migrate_test.go
+++ b/devshard/storage/postgres_migrate_test.go
@@ -24,7 +24,8 @@ func (t *postgresPartitionDDLTracer) TraceQueryStart(ctx context.Context, _ *pgx
 	return ctx
 }
 
-func (t *postgresPartitionDDLTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+func (t *postgresPartitionDDLTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {
+}
 
 func (t *postgresPartitionDDLTracer) record(sql string) {
 	upper := strings.ToUpper(sql)
@@ -97,6 +98,18 @@ func TestMigratePostgres_Idempotent(t *testing.T) {
 	exists, err := migrate.TableExistsPG(ctx, pool, "devshard_escrow_cache")
 	require.NoError(t, err)
 	require.True(t, exists, "missing table devshard_escrow_cache")
+	exists, err = migrate.TableExistsPG(ctx, pool, "devshard_storage_identity")
+	require.NoError(t, err)
+	require.True(t, exists, "missing table devshard_storage_identity")
+
+	var storageIdentity string
+	err = pool.QueryRow(ctx, `
+SELECT identity::text FROM devshard_storage_identity WHERE singleton`).Scan(&storageIdentity)
+	require.NoError(t, err)
+	require.Regexp(t,
+		`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+		storageIdentity,
+	)
 
 	var indexCount int
 	err = pool.QueryRow(ctx, `
@@ -109,6 +122,11 @@ WHERE schemaname = 'public' AND indexname = 'devshard_session_index_by_epoch'`).
 	n2, err := migrate.AppliedPG(ctx, pool)
 	require.NoError(t, err)
 	require.Equal(t, n1, n2)
+	var identityAfterRerun string
+	err = pool.QueryRow(ctx, `
+SELECT identity::text FROM devshard_storage_identity WHERE singleton`).Scan(&identityAfterRerun)
+	require.NoError(t, err)
+	require.Equal(t, storageIdentity, identityAfterRerun)
 }
 
 func TestSaveSnapshot_SameEpoch_PartitionCreateOnce(t *testing.T) {

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -545,6 +545,11 @@ func TestPostgresHealthProbeBudgetCoversConnectionSetup(t *testing.T) {
 	require.GreaterOrEqual(t, postgresHealthTimeout, postgresConnectTimeout)
 }
 
+func TestPostgresFenceCheckHasIndependentBudget(t *testing.T) {
+	require.Greater(t, postgresFenceCheckTimeout, postgresHealthTimeout)
+	require.Equal(t, 30*time.Second, postgresFenceCheckTimeout)
+}
+
 func TestPostgresReadyTracksLiveDatabaseLoss(t *testing.T) {
 	container := startPostgresContainer(t)
 	t.Cleanup(func() { _ = container.Terminate(context.Background()) })

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -560,6 +560,33 @@ func TestPostgresReadyTracksLiveDatabaseLoss(t *testing.T) {
 		30*time.Second, 100*time.Millisecond)
 }
 
+func TestPostgresFenceSessionLossIsTerminal(t *testing.T) {
+	container := startPostgresContainer(t)
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	pg, err := NewPostgres(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pg.Close() })
+	require.NoError(t, pg.WaitReady(context.Background()))
+
+	admin, err := pgx.Connect(context.Background(), "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.Close(context.Background()) })
+	pid := pg.connectionGuard.fenceConn.PgConn().PID()
+	var terminated bool
+	require.NoError(t, admin.QueryRow(context.Background(),
+		"SELECT pg_terminate_backend($1)", pid).Scan(&terminated))
+	require.True(t, terminated)
+
+	select {
+	case fatalErr := <-pg.FatalErrors():
+		require.ErrorContains(t, fatalErr, "postgres fence session lost")
+	case <-time.After(2*postgresHealthInterval + postgresHealthTimeout):
+		t.Fatal("postgres fence loss did not terminate the storage lifecycle")
+	}
+	require.False(t, pg.Ready())
+}
+
 func TestPostgres_NewPostgres_ConnectBudgetDoesNotIncludeIndex(t *testing.T) {
 	cleanup := setupPostgresContainer(t)
 	defer cleanup()

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -580,6 +580,65 @@ func TestPostgresFenceCheckHasIndependentBudget(t *testing.T) {
 	require.Equal(t, 30*time.Second, postgresFenceCheckTimeout)
 }
 
+func TestPostgresReadinessDoesNotWaitForFenceCheck(t *testing.T) {
+	healthChecks := make(chan struct{}, postgresHealthQuorum)
+	fenceStarted := make(chan struct{}, 1)
+	pg := &Postgres{
+		healthReady: true,
+		healthDone:  make(chan struct{}),
+		fatalErrors: make(chan error, 1),
+	}
+	pg.startPostgresMonitors(postgresMonitorConfig{
+		interval:      time.Millisecond,
+		healthTimeout: 10 * time.Millisecond,
+		fenceTimeout:  time.Second,
+		healthCheck: func(context.Context) error {
+			select {
+			case healthChecks <- struct{}{}:
+			default:
+			}
+			return errors.New("database unavailable")
+		},
+		healthClose: func(context.Context) error { return nil },
+		fenceCheck: func(ctx context.Context) error {
+			fenceStarted <- struct{}{}
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		poolSaturated: func() bool { return false },
+	})
+	t.Cleanup(func() {
+		pg.mu.Lock()
+		cancel := pg.healthStop
+		pg.mu.Unlock()
+		cancel()
+		<-pg.healthDone
+	})
+
+	select {
+	case <-fenceStarted:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("fence monitor did not start")
+	}
+	for range postgresHealthQuorum {
+		select {
+		case <-healthChecks:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("readiness probe was blocked by the in-flight fence check")
+		}
+	}
+	require.Eventually(t, func() bool {
+		pg.mu.RLock()
+		defer pg.mu.RUnlock()
+		return !pg.healthReady
+	}, 100*time.Millisecond, time.Millisecond)
+	select {
+	case err := <-pg.fatalErrors:
+		t.Fatalf("blocked fence check became terminal before its deadline: %v", err)
+	default:
+	}
+}
+
 func TestPostgresReadyTracksLiveDatabaseLoss(t *testing.T) {
 	container := startPostgresContainer(t)
 	t.Cleanup(func() { _ = container.Terminate(context.Background()) })

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -85,6 +85,36 @@ func captureStorageLogs(t *testing.T) *bytes.Buffer {
 	return &buf
 }
 
+func TestConfigurePostgresPool(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    int32
+		wantErr bool
+	}{
+		{name: "default", want: defaultPostgresPoolMaxConns},
+		{name: "explicit", value: "12", want: 12},
+		{name: "trimmed", value: " 8 ", want: 8},
+		{name: "zero", value: "0", wantErr: true},
+		{name: "negative", value: "-1", wantErr: true},
+		{name: "not an integer", value: "many", wantErr: true},
+		{name: "overflow", value: "2147483648", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PG_POOL_MAX_CONNS", tt.value)
+			cfg := &pgxpool.Config{}
+			err := configurePostgresPool(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, cfg.MaxConns)
+		})
+	}
+}
+
 func readStorageLogEntries(t *testing.T, buf *bytes.Buffer) []map[string]any {
 	t.Helper()
 	decoder := json.NewDecoder(bytes.NewReader(buf.Bytes()))

--- a/devshard/storage/proof.go
+++ b/devshard/storage/proof.go
@@ -1,0 +1,118 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// ProofOperation is an operation used by deployment preflight to prove that
+// independent devshard processes use the same live writable PostgreSQL.
+type ProofOperation string
+
+const (
+	ProofIdentity       ProofOperation = "identity"
+	ProofWriteChallenge ProofOperation = "write"
+	ProofReadChallenge  ProofOperation = "read"
+)
+
+// StorageProof reports the durable lineage marker and whether a challenge was
+// observed through this storage handle. Identity alone is not proof of a shared
+// live database because snapshots and replicas preserve it.
+type StorageProof struct {
+	Identity string `json:"identity"`
+	Found    bool   `json:"found,omitempty"`
+}
+
+// ProofProvider is implemented by storage wrappers that can reach the actual
+// PostgreSQL backend used for devshard session traffic.
+type ProofProvider interface {
+	StorageProof(context.Context, ProofOperation, string) (StorageProof, error)
+}
+
+var errPostgresProofUnavailable = errors.New("postgres storage proof is unavailable")
+
+// StorageProof performs the proof through the application pool. Every
+// operation rejects a standby; write additionally proves that this connection
+// can mutate the database.
+func (s *Postgres) StorageProof(ctx context.Context, operation ProofOperation, nonce string) (StorageProof, error) {
+	switch operation {
+	case ProofIdentity, ProofWriteChallenge, ProofReadChallenge:
+	default:
+		return StorageProof{}, fmt.Errorf("unknown storage proof operation %q", operation)
+	}
+	if operation != ProofIdentity {
+		if _, err := uuid.Parse(nonce); err != nil {
+			return StorageProof{}, fmt.Errorf("invalid storage challenge nonce: %w", err)
+		}
+	}
+	if s == nil || s.pool == nil {
+		return StorageProof{}, errPostgresProofUnavailable
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return StorageProof{}, fmt.Errorf("begin storage proof: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+
+	var inRecovery bool
+	if err := tx.QueryRow(ctx, `SELECT pg_is_in_recovery()`).Scan(&inRecovery); err != nil {
+		return StorageProof{}, fmt.Errorf("check postgres recovery state: %w", err)
+	}
+	if inRecovery {
+		return StorageProof{}, errors.New("postgres storage is a recovery replica")
+	}
+
+	proof := StorageProof{}
+	switch operation {
+	case ProofIdentity:
+		err = tx.QueryRow(ctx, `
+			SELECT identity::text
+			FROM devshard_storage_identity
+			WHERE singleton`).Scan(&proof.Identity)
+	case ProofWriteChallenge:
+		err = tx.QueryRow(ctx, `
+			UPDATE devshard_storage_identity
+			SET challenge = $1::uuid, challenged_at = NOW()
+			WHERE singleton
+			RETURNING identity::text`, nonce).Scan(&proof.Identity)
+		proof.Found = err == nil
+	case ProofReadChallenge:
+		err = tx.QueryRow(ctx, `
+			SELECT identity::text, COALESCE(challenge = $1::uuid, FALSE)
+			FROM devshard_storage_identity
+			WHERE singleton`, nonce).Scan(&proof.Identity, &proof.Found)
+	}
+	if err != nil {
+		return StorageProof{}, fmt.Errorf("perform storage proof %s: %w", operation, err)
+	}
+	if proof.Identity == "" {
+		return StorageProof{}, errors.New("postgres storage identity is empty")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return StorageProof{}, fmt.Errorf("commit storage proof: %w", err)
+	}
+	return proof, nil
+}
+
+// StorageProof forwards through the currently attached PostgreSQL backend.
+func (h *HybridStorage) StorageProof(ctx context.Context, operation ProofOperation, nonce string) (StorageProof, error) {
+	pg := h.postgresBackend()
+	provider, ok := pg.(ProofProvider)
+	if !ok {
+		return StorageProof{}, errPostgresProofUnavailable
+	}
+	return provider.StorageProof(ctx, operation, nonce)
+}
+
+// StorageProof preserves the proof capability through the retention wrapper.
+func (m *ManagedStorage) StorageProof(ctx context.Context, operation ProofOperation, nonce string) (StorageProof, error) {
+	provider, ok := m.inner.(ProofProvider)
+	if !ok {
+		return StorageProof{}, errPostgresProofUnavailable
+	}
+	return provider.StorageProof(ctx, operation, nonce)
+}

--- a/devshard/storage/proof.go
+++ b/devshard/storage/proof.go
@@ -56,7 +56,11 @@ func (s *Postgres) StorageProof(ctx context.Context, operation ProofOperation, n
 	if err != nil {
 		return StorageProof{}, fmt.Errorf("begin storage proof: %w", err)
 	}
-	defer func() { _ = tx.Rollback(context.Background()) }()
+	defer func() {
+		rollbackCtx, cancel := context.WithTimeout(context.Background(), postgresStatementTimeout)
+		defer cancel()
+		_ = tx.Rollback(rollbackCtx)
+	}()
 
 	var inRecovery bool
 	if err := tx.QueryRow(ctx, `SELECT pg_is_in_recovery()`).Scan(&inRecovery); err != nil {

--- a/devshard/storage/proof.go
+++ b/devshard/storage/proof.go
@@ -22,8 +22,11 @@ const (
 // observed through this storage handle. Identity alone is not proof of a shared
 // live database because snapshots and replicas preserve it.
 type StorageProof struct {
-	Identity string `json:"identity"`
-	Found    bool   `json:"found,omitempty"`
+	Identity                  string `json:"identity"`
+	Found                     bool   `json:"found,omitempty"`
+	PoolMaxConnections        int32  `json:"pool_max_connections,omitempty"`
+	ServerMaxConnections      int32  `json:"server_max_connections,omitempty"`
+	ServerReservedConnections int32  `json:"server_reserved_connections,omitempty"`
 }
 
 // ProofProvider is implemented by storage wrappers that can reach the actual
@@ -73,10 +76,18 @@ func (s *Postgres) StorageProof(ctx context.Context, operation ProofOperation, n
 	proof := StorageProof{}
 	switch operation {
 	case ProofIdentity:
+		proof.PoolMaxConnections = s.pool.Stat().MaxConns()
 		err = tx.QueryRow(ctx, `
-			SELECT identity::text
+			SELECT identity::text,
+			       current_setting('max_connections')::integer,
+			       current_setting('superuser_reserved_connections')::integer
+			         + COALESCE(current_setting('reserved_connections', true), '0')::integer
 			FROM devshard_storage_identity
-			WHERE singleton`).Scan(&proof.Identity)
+			WHERE singleton`).Scan(
+			&proof.Identity,
+			&proof.ServerMaxConnections,
+			&proof.ServerReservedConnections,
+		)
 	case ProofWriteChallenge:
 		err = tx.QueryRow(ctx, `
 			UPDATE devshard_storage_identity

--- a/devshard/storage/proof_test.go
+++ b/devshard/storage/proof_test.go
@@ -59,6 +59,46 @@ func TestStorageProofRejectsClonedIdentityOnIndependentDatabase(t *testing.T) {
 	require.False(t, cloneProof.Found, "live challenge must not cross independent databases")
 }
 
+func TestPostgresConnectionGuardRejectsIndependentClone(t *testing.T) {
+	ctx := context.Background()
+	bootstrapPool, cleanup := setupDevshardPostgresPool(t, nil)
+	defer cleanup()
+	require.NoError(t, MigratePostgres(ctx, bootstrapPool))
+
+	_, err := bootstrapPool.Exec(ctx, `CREATE DATABASE connection_guard_clone`)
+	require.NoError(t, err)
+	cloneConfig := bootstrapPool.Config().Copy()
+	cloneConfig.ConnConfig.Database = "connection_guard_clone"
+	clonePool, err := pgxpool.NewWithConfig(ctx, cloneConfig)
+	require.NoError(t, err)
+	require.NoError(t, MigratePostgres(ctx, clonePool))
+
+	var identity string
+	require.NoError(t, bootstrapPool.QueryRow(ctx, `
+		SELECT identity::text FROM devshard_storage_identity WHERE singleton`).Scan(&identity))
+	_, err = clonePool.Exec(ctx, `
+		UPDATE devshard_storage_identity SET identity = $1::uuid WHERE singleton`, identity)
+	require.NoError(t, err)
+	clonePool.Close()
+
+	guard := newPostgresConnectionGuard()
+	primaryConfig := bootstrapPool.Config().Copy()
+	guard.installValidator(primaryConfig)
+	primaryPool, err := pgxpool.NewWithConfig(ctx, primaryConfig)
+	require.NoError(t, err)
+	defer primaryPool.Close()
+	require.NoError(t, guard.arm(ctx, primaryPool))
+	require.NoError(t, primaryPool.Ping(ctx), "the database containing the process token must remain usable")
+
+	guardedCloneConfig := cloneConfig.Copy()
+	guard.installValidator(guardedCloneConfig)
+	guardedClonePool, err := pgxpool.NewWithConfig(ctx, guardedCloneConfig)
+	require.NoError(t, err)
+	defer guardedClonePool.Close()
+	require.Error(t, guardedClonePool.Ping(ctx),
+		"a clone with the same durable identity but without the process token must be rejected")
+}
+
 func TestStorageProofRejectsInvalidNonce(t *testing.T) {
 	_, err := (&Postgres{}).StorageProof(context.Background(), ProofReadChallenge, "not-a-uuid")
 	require.Error(t, err)

--- a/devshard/storage/proof_test.go
+++ b/devshard/storage/proof_test.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageProofUsesLiveSharedPostgres(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := setupDevshardPostgresPool(t, nil)
+	defer cleanup()
+	require.NoError(t, MigratePostgres(ctx, pool))
+
+	first := &Postgres{pool: pool}
+	peer := &Postgres{pool: pool}
+	nonce := uuid.NewString()
+	written, err := first.StorageProof(ctx, ProofWriteChallenge, nonce)
+	require.NoError(t, err)
+	require.True(t, written.Found)
+	observed, err := peer.StorageProof(ctx, ProofReadChallenge, nonce)
+	require.NoError(t, err)
+	require.True(t, observed.Found)
+	require.Equal(t, written.Identity, observed.Identity)
+}
+
+func TestStorageProofRejectsClonedIdentityOnIndependentDatabase(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := setupDevshardPostgresPool(t, nil)
+	defer cleanup()
+	require.NoError(t, MigratePostgres(ctx, pool))
+
+	_, err := pool.Exec(ctx, `CREATE DATABASE storage_proof_clone`)
+	require.NoError(t, err)
+	cloneConfig := pool.Config().Copy()
+	cloneConfig.ConnConfig.Database = "storage_proof_clone"
+	clonePool, err := pgxpool.NewWithConfig(ctx, cloneConfig)
+	require.NoError(t, err)
+	defer clonePool.Close()
+	require.NoError(t, clonePool.Ping(ctx))
+	require.NoError(t, MigratePostgres(ctx, clonePool))
+
+	var identity string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT identity::text FROM devshard_storage_identity WHERE singleton`).Scan(&identity))
+	_, err = clonePool.Exec(ctx, `
+		UPDATE devshard_storage_identity SET identity = $1::uuid WHERE singleton`, identity)
+	require.NoError(t, err)
+
+	nonce := uuid.NewString()
+	_, err = (&Postgres{pool: pool}).StorageProof(ctx, ProofWriteChallenge, nonce)
+	require.NoError(t, err)
+	cloneProof, err := (&Postgres{pool: clonePool}).StorageProof(ctx, ProofReadChallenge, nonce)
+	require.NoError(t, err)
+	require.Equal(t, identity, cloneProof.Identity, "lineage marker was deliberately cloned")
+	require.False(t, cloneProof.Found, "live challenge must not cross independent databases")
+}
+
+func TestStorageProofRejectsInvalidNonce(t *testing.T) {
+	_, err := (&Postgres{}).StorageProof(context.Background(), ProofReadChallenge, "not-a-uuid")
+	require.Error(t, err)
+}
+
+func TestStorageProofRequiresWritablePostgres(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := setupDevshardPostgresPool(t, nil)
+	defer cleanup()
+	require.NoError(t, MigratePostgres(ctx, pool))
+
+	readOnlyConfig := pool.Config().Copy()
+	readOnlyConfig.ConnConfig.RuntimeParams["default_transaction_read_only"] = "on"
+	readOnlyPool, err := pgxpool.NewWithConfig(ctx, readOnlyConfig)
+	require.NoError(t, err)
+	defer readOnlyPool.Close()
+	require.NoError(t, readOnlyPool.Ping(ctx))
+
+	_, err = (&Postgres{pool: readOnlyPool}).StorageProof(ctx, ProofWriteChallenge, uuid.NewString())
+	require.Error(t, err)
+}

--- a/devshard/storage/proof_test.go
+++ b/devshard/storage/proof_test.go
@@ -17,6 +17,10 @@ func TestStorageProofUsesLiveSharedPostgres(t *testing.T) {
 
 	first := &Postgres{pool: pool}
 	peer := &Postgres{pool: pool}
+	identity, err := first.StorageProof(ctx, ProofIdentity, "")
+	require.NoError(t, err)
+	require.Equal(t, pool.Stat().MaxConns(), identity.PoolMaxConnections)
+	require.Greater(t, identity.ServerMaxConnections, identity.ServerReservedConnections)
 	nonce := uuid.NewString()
 	written, err := first.StorageProof(ctx, ProofWriteChallenge, nonce)
 	require.NoError(t, err)

--- a/devshard/storage/proof_test.go
+++ b/devshard/storage/proof_test.go
@@ -81,13 +81,15 @@ func TestPostgresConnectionGuardRejectsIndependentClone(t *testing.T) {
 	require.NoError(t, err)
 	clonePool.Close()
 
-	guard := newPostgresConnectionGuard()
+	guard, err := newPostgresConnectionGuard()
+	require.NoError(t, err)
 	primaryConfig := bootstrapPool.Config().Copy()
 	guard.installValidator(primaryConfig)
 	primaryPool, err := pgxpool.NewWithConfig(ctx, primaryConfig)
 	require.NoError(t, err)
 	defer primaryPool.Close()
-	require.NoError(t, guard.arm(ctx, primaryPool))
+	require.NoError(t, guard.arm(ctx, primaryPool, primaryConfig.ConnConfig))
+	defer guard.close(ctx)
 	require.NoError(t, primaryPool.Ping(ctx), "the database containing the process token must remain usable")
 
 	guardedCloneConfig := cloneConfig.Copy()
@@ -96,7 +98,13 @@ func TestPostgresConnectionGuardRejectsIndependentClone(t *testing.T) {
 	require.NoError(t, err)
 	defer guardedClonePool.Close()
 	require.Error(t, guardedClonePool.Ping(ctx),
-		"a clone with the same durable identity but without the process token must be rejected")
+		"a clone with the same durable identity but without the session fence must be rejected")
+
+	require.NoError(t, guard.fenceConn.Close(ctx))
+	guard.fenceConn = nil
+	primaryPool.Reset()
+	require.Error(t, primaryPool.Ping(ctx),
+		"new connections must fail closed after the non-replicated fence session disappears")
 }
 
 func TestStorageProofRejectsInvalidNonce(t *testing.T) {

--- a/devshard/user/error_timeout_test.go
+++ b/devshard/user/error_timeout_test.go
@@ -308,40 +308,35 @@ func TestHandleErrorMiss_PinnedFinishSurvivesConcurrentCompose(t *testing.T) {
 	session.mu.Unlock()
 
 	started := make(chan struct{})
+	composed := make(chan struct{})
 	var once sync.Once
 	for i, c := range session.clients {
 		session.clients[i] = &timeoutVoteClient{
 			HostClient: c,
 			mockTimeoutVerifier: &mockTimeoutVerifier{
-				accept:   true,
-				signer:   hosts[i],
-				group:    session.group,
-				slotIdx:  i,
-				delay:    80 * time.Millisecond,
-				onVerify: func() { once.Do(func() { close(started) }) },
+				accept:  true,
+				signer:  hosts[i],
+				group:   session.group,
+				slotIdx: i,
+				onVerify: func() {
+					once.Do(func() {
+						close(started)
+						<-composed
+					})
+				},
 			},
 		}
 	}
 
-	var wg sync.WaitGroup
-	done := make(chan struct{})
-	wg.Add(1)
+	composeErr := make(chan error, 1)
 	go func() {
-		defer wg.Done()
 		<-started
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				_ = session.SendPendingDiff(context.Background())
-			}
-		}
+		composeErr <- session.SendPendingDiff(context.Background())
+		close(composed)
 	}()
 
 	_, err := session.HandleErrorMiss(context.Background(), nonce, finishBytes, payload)
-	close(done)
-	wg.Wait()
+	require.NoError(t, <-composeErr)
 	require.ErrorIs(t, err, ErrInferenceMissed)
 	require.Equal(t, types.StatusTimedOut, session.StateMachine().SnapshotState().Inferences[nonce].Status)
 

--- a/versioned/cmd/versiond/main.go
+++ b/versioned/cmd/versiond/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -73,7 +74,7 @@ func run(ctx context.Context) error {
 	listenAddr := config.ListenAddr()
 	srv := &http.Server{
 		Addr:    listenAddr,
-		Handler: publicHandler(mgr, hostLifecycle, lookup, proxyOpts...),
+		Handler: publicHandler(mgr, hostLifecycle, mgr, proxyOpts...),
 	}
 	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
@@ -444,13 +445,14 @@ func readinessHandler(mgr *process.Manager, hostLifecycle *host.Controller) http
 func publicHandler(
 	mgr *process.Manager,
 	hostLifecycle *host.Controller,
-	storageIdentity storageIdentityReader,
+	storage storageVerifier,
 	proxyOpts ...proxy.HandlerOption,
 ) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", health.Handler(mgr.Status))
 	mux.HandleFunc("/readyz", readinessHandler(mgr, hostLifecycle))
-	mux.HandleFunc("/internal/storage-identity", storageIdentityHandler(storageIdentity))
+	mux.HandleFunc("/internal/storage-identity", storageIdentityHandler(storage))
+	mux.HandleFunc("/internal/storage-challenge", storageChallengeHandler(storage))
 	mux.Handle(
 		"/",
 		hostLifecycle.Admission(proxy.Handler(mgr.RouteTable(), proxyOpts...)),
@@ -459,13 +461,19 @@ func publicHandler(
 }
 
 type storageIdentityReader interface {
-	StorageIdentity(context.Context) (string, error)
+	StorageIdentity(context.Context) (process.StorageProof, error)
+}
+
+type storageChallengeRunner interface {
+	StorageChallenge(context.Context, string, string) (process.StorageProof, error)
+}
+
+type storageVerifier interface {
+	storageIdentityReader
+	storageChallengeRunner
 }
 
 func storageIdentityHandler(reader storageIdentityReader) http.HandlerFunc {
-	type response struct {
-		Identity string `json:"identity"`
-	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		host, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err != nil || !net.ParseIP(host).IsLoopback() {
@@ -481,16 +489,54 @@ func storageIdentityHandler(reader storageIdentityReader) http.HandlerFunc {
 			http.Error(w, "postgres storage identity unavailable", http.StatusServiceUnavailable)
 			return
 		}
-		// OpenFromEnv returns *sessionversion.Lookup. A nil pointer converted to
-		// this interface is non-nil, so StorageIdentity deliberately handles a
-		// nil receiver and turns the unavailable lookup into the same 503.
-		identity, err := reader.StorageIdentity(r.Context())
+		proof, err := reader.StorageIdentity(r.Context())
 		if err != nil {
+			slog.Warn("versiond storage identity unavailable", "error", err)
 			http.Error(w, "postgres storage identity unavailable", http.StatusServiceUnavailable)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(response{Identity: identity})
+		_ = json.NewEncoder(w).Encode(proof)
+	}
+}
+
+type storageChallengeRequest struct {
+	Operation string `json:"operation"`
+	Nonce     string `json:"nonce"`
+}
+
+func storageChallengeHandler(runner storageChallengeRunner) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil || !net.ParseIP(host).IsLoopback() {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if runner == nil {
+			http.Error(w, "postgres storage challenge unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		var request storageChallengeRequest
+		decoder := json.NewDecoder(io.LimitReader(r.Body, 4096))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&request); err != nil ||
+			(request.Operation != "write" && request.Operation != "read") || request.Nonce == "" {
+			http.Error(w, "invalid storage challenge", http.StatusBadRequest)
+			return
+		}
+		proof, err := runner.StorageChallenge(r.Context(), request.Operation, request.Nonce)
+		if err != nil {
+			slog.Warn("versiond storage challenge failed", "operation", request.Operation, "error", err)
+			http.Error(w, "postgres storage challenge unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(proof)
 	}
 }
 

--- a/versioned/cmd/versiond/main.go
+++ b/versioned/cmd/versiond/main.go
@@ -481,6 +481,9 @@ func storageIdentityHandler(reader storageIdentityReader) http.HandlerFunc {
 			http.Error(w, "postgres storage identity unavailable", http.StatusServiceUnavailable)
 			return
 		}
+		// OpenFromEnv returns *sessionversion.Lookup. A nil pointer converted to
+		// this interface is non-nil, so StorageIdentity deliberately handles a
+		// nil receiver and turns the unavailable lookup into the same 503.
 		identity, err := reader.StorageIdentity(r.Context())
 		if err != nil {
 			http.Error(w, "postgres storage identity unavailable", http.StatusServiceUnavailable)

--- a/versioned/cmd/versiond/main.go
+++ b/versioned/cmd/versiond/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -72,7 +73,7 @@ func run(ctx context.Context) error {
 	listenAddr := config.ListenAddr()
 	srv := &http.Server{
 		Addr:    listenAddr,
-		Handler: publicHandler(mgr, hostLifecycle, proxyOpts...),
+		Handler: publicHandler(mgr, hostLifecycle, lookup, proxyOpts...),
 	}
 	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
@@ -443,16 +444,51 @@ func readinessHandler(mgr *process.Manager, hostLifecycle *host.Controller) http
 func publicHandler(
 	mgr *process.Manager,
 	hostLifecycle *host.Controller,
+	storageIdentity storageIdentityReader,
 	proxyOpts ...proxy.HandlerOption,
 ) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", health.Handler(mgr.Status))
 	mux.HandleFunc("/readyz", readinessHandler(mgr, hostLifecycle))
+	mux.HandleFunc("/internal/storage-identity", storageIdentityHandler(storageIdentity))
 	mux.Handle(
 		"/",
 		hostLifecycle.Admission(proxy.Handler(mgr.RouteTable(), proxyOpts...)),
 	)
 	return mux
+}
+
+type storageIdentityReader interface {
+	StorageIdentity(context.Context) (string, error)
+}
+
+func storageIdentityHandler(reader storageIdentityReader) http.HandlerFunc {
+	type response struct {
+		Identity string `json:"identity"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil || !net.ParseIP(host).IsLoopback() {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if reader == nil {
+			http.Error(w, "postgres storage identity unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		identity, err := reader.StorageIdentity(r.Context())
+		if err != nil {
+			http.Error(w, "postgres storage identity unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response{Identity: identity})
+	}
 }
 
 // versiondReady answers the load balancer's question — may this host take new

--- a/versioned/cmd/versiond/main.go
+++ b/versioned/cmd/versiond/main.go
@@ -465,7 +465,7 @@ type storageIdentityReader interface {
 }
 
 type storageChallengeRunner interface {
-	StorageChallenge(context.Context, string, string) (process.StorageProof, error)
+	StorageChallenge(context.Context, string, string, string, string) (process.StorageProof, error)
 }
 
 type storageVerifier interface {
@@ -501,8 +501,10 @@ func storageIdentityHandler(reader storageIdentityReader) http.HandlerFunc {
 }
 
 type storageChallengeRequest struct {
-	Operation string `json:"operation"`
-	Nonce     string `json:"nonce"`
+	Operation  string `json:"operation"`
+	Nonce      string `json:"nonce"`
+	Snapshot   string `json:"snapshot"`
+	Generation string `json:"generation"`
 }
 
 func storageChallengeHandler(runner storageChallengeRunner) http.HandlerFunc {
@@ -525,11 +527,18 @@ func storageChallengeHandler(runner storageChallengeRunner) http.HandlerFunc {
 		decoder := json.NewDecoder(io.LimitReader(r.Body, 4096))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(&request); err != nil ||
-			(request.Operation != "write" && request.Operation != "read") || request.Nonce == "" {
+			(request.Operation != "write" && request.Operation != "read") ||
+			request.Nonce == "" || request.Snapshot == "" || request.Generation == "" {
 			http.Error(w, "invalid storage challenge", http.StatusBadRequest)
 			return
 		}
-		proof, err := runner.StorageChallenge(r.Context(), request.Operation, request.Nonce)
+		proof, err := runner.StorageChallenge(
+			r.Context(),
+			request.Snapshot,
+			request.Generation,
+			request.Operation,
+			request.Nonce,
+		)
 		if err != nil {
 			slog.Warn("versiond storage challenge failed", "operation", request.Operation, "error", err)
 			http.Error(w, "postgres storage challenge unavailable", http.StatusServiceUnavailable)

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -1099,7 +1099,13 @@ func (s staticStorageIdentity) StorageIdentity(context.Context) (process.Storage
 		Identity: string(s),
 		Children: 1,
 		Snapshot: "snapshot-1",
-		Targets:  []process.StorageProofTarget{{Generation: "1", Version: "v5"}},
+		Targets: []process.StorageProofTarget{{
+			Generation:                "1",
+			Version:                   "v5",
+			PoolMaxConnections:        4,
+			ServerMaxConnections:      100,
+			ServerReservedConnections: 3,
+		}},
 	}, nil
 }
 
@@ -1136,7 +1142,7 @@ func TestStorageIdentityIsLocalOnly(t *testing.T) {
 	if localResponse.Code != http.StatusOK {
 		t.Fatalf("local storage identity status = %d, want 200", localResponse.Code)
 	}
-	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\",\"children\":1,\"snapshot\":\"snapshot-1\",\"targets\":[{\"generation\":\"1\",\"version\":\"v5\"}]}\n" {
+	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\",\"children\":1,\"snapshot\":\"snapshot-1\",\"targets\":[{\"generation\":\"1\",\"version\":\"v5\",\"pool_max_connections\":4,\"server_max_connections\":100,\"server_reserved_connections\":3}]}\n" {
 		t.Fatalf("local storage identity response = %q", got)
 	}
 

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -15,6 +15,7 @@ import (
 	"versioned/internal/config"
 	"versioned/internal/host"
 	"versioned/internal/process"
+	"versioned/internal/sessionversion"
 )
 
 type fakeHostShutdownManager struct {
@@ -1098,6 +1099,12 @@ func (s staticStorageIdentity) StorageIdentity(context.Context) (string, error) 
 	return string(s), nil
 }
 
+type unavailableStorageIdentity struct{}
+
+func (unavailableStorageIdentity) StorageIdentity(context.Context) (string, error) {
+	return "", errors.New("identity unavailable")
+}
+
 func TestStorageIdentityIsLocalOnly(t *testing.T) {
 	handler := storageIdentityHandler(staticStorageIdentity("database-1"))
 
@@ -1118,6 +1125,50 @@ func TestStorageIdentityIsLocalOnly(t *testing.T) {
 	}
 	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\"}\n" {
 		t.Fatalf("local storage identity response = %q", got)
+	}
+
+	ipv6 := httptest.NewRequest(http.MethodGet, "/internal/storage-identity", nil)
+	ipv6.RemoteAddr = "[::1]:1234"
+	ipv6Response := httptest.NewRecorder()
+	handler.ServeHTTP(ipv6Response, ipv6)
+	if ipv6Response.Code != http.StatusOK {
+		t.Fatalf("IPv6 loopback storage identity status = %d, want 200", ipv6Response.Code)
+	}
+
+	post := httptest.NewRequest(http.MethodPost, "/internal/storage-identity", nil)
+	post.RemoteAddr = "127.0.0.1:1234"
+	postResponse := httptest.NewRecorder()
+	handler.ServeHTTP(postResponse, post)
+	if postResponse.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST storage identity status = %d, want 405", postResponse.Code)
+	}
+	if got := postResponse.Header().Get("Allow"); got != http.MethodGet {
+		t.Fatalf("POST storage identity Allow = %q, want GET", got)
+	}
+}
+
+func TestStorageIdentityUnavailable(t *testing.T) {
+	var typedNilLookup *sessionversion.Lookup
+	tests := []struct {
+		name   string
+		reader storageIdentityReader
+	}{
+		{name: "nil interface", reader: nil},
+		{name: "typed nil lookup", reader: typedNilLookup},
+		{name: "query failure", reader: unavailableStorageIdentity{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/internal/storage-identity", nil)
+			request.RemoteAddr = "127.0.0.1:1234"
+			response := httptest.NewRecorder()
+
+			storageIdentityHandler(tt.reader).ServeHTTP(response, request)
+
+			if response.Code != http.StatusServiceUnavailable {
+				t.Fatalf("storage identity status = %d, want 503", response.Code)
+			}
+		})
 	}
 }
 

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -15,7 +15,6 @@ import (
 	"versioned/internal/config"
 	"versioned/internal/host"
 	"versioned/internal/process"
-	"versioned/internal/sessionversion"
 )
 
 type fakeHostShutdownManager struct {
@@ -1095,14 +1094,23 @@ func TestReadinessIsServedOnTheTrafficListener(t *testing.T) {
 
 type staticStorageIdentity string
 
-func (s staticStorageIdentity) StorageIdentity(context.Context) (string, error) {
-	return string(s), nil
+func (s staticStorageIdentity) StorageIdentity(context.Context) (process.StorageProof, error) {
+	return process.StorageProof{Identity: string(s), Children: 1}, nil
 }
 
 type unavailableStorageIdentity struct{}
 
-func (unavailableStorageIdentity) StorageIdentity(context.Context) (string, error) {
-	return "", errors.New("identity unavailable")
+func (unavailableStorageIdentity) StorageIdentity(context.Context) (process.StorageProof, error) {
+	return process.StorageProof{}, errors.New("identity unavailable")
+}
+
+type staticStorageChallenge struct {
+	proof process.StorageProof
+	err   error
+}
+
+func (s staticStorageChallenge) StorageChallenge(context.Context, string, string) (process.StorageProof, error) {
+	return s.proof, s.err
 }
 
 func TestStorageIdentityIsLocalOnly(t *testing.T) {
@@ -1123,7 +1131,7 @@ func TestStorageIdentityIsLocalOnly(t *testing.T) {
 	if localResponse.Code != http.StatusOK {
 		t.Fatalf("local storage identity status = %d, want 200", localResponse.Code)
 	}
-	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\"}\n" {
+	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\",\"children\":1}\n" {
 		t.Fatalf("local storage identity response = %q", got)
 	}
 
@@ -1148,13 +1156,11 @@ func TestStorageIdentityIsLocalOnly(t *testing.T) {
 }
 
 func TestStorageIdentityUnavailable(t *testing.T) {
-	var typedNilLookup *sessionversion.Lookup
 	tests := []struct {
 		name   string
 		reader storageIdentityReader
 	}{
 		{name: "nil interface", reader: nil},
-		{name: "typed nil lookup", reader: typedNilLookup},
 		{name: "query failure", reader: unavailableStorageIdentity{}},
 	}
 	for _, tt := range tests {
@@ -1169,6 +1175,45 @@ func TestStorageIdentityUnavailable(t *testing.T) {
 				t.Fatalf("storage identity status = %d, want 503", response.Code)
 			}
 		})
+	}
+}
+
+func TestStorageChallengeIsLocalAndValidated(t *testing.T) {
+	runner := staticStorageChallenge{proof: process.StorageProof{
+		Identity: "database-1",
+		Found:    true,
+		Children: 2,
+	}}
+	handler := storageChallengeHandler(runner)
+
+	external := httptest.NewRequest(http.MethodPost, "/internal/storage-challenge",
+		strings.NewReader(`{"operation":"write","nonce":"8aa1c262-ea39-43c2-928c-263e966cc9b4"}`))
+	external.RemoteAddr = "192.0.2.10:1234"
+	externalResponse := httptest.NewRecorder()
+	handler.ServeHTTP(externalResponse, external)
+	if externalResponse.Code != http.StatusNotFound {
+		t.Fatalf("external storage challenge status = %d, want 404", externalResponse.Code)
+	}
+
+	local := httptest.NewRequest(http.MethodPost, "/internal/storage-challenge",
+		strings.NewReader(`{"operation":"write","nonce":"8aa1c262-ea39-43c2-928c-263e966cc9b4"}`))
+	local.RemoteAddr = "127.0.0.1:1234"
+	localResponse := httptest.NewRecorder()
+	handler.ServeHTTP(localResponse, local)
+	if localResponse.Code != http.StatusOK {
+		t.Fatalf("local storage challenge status = %d, want 200", localResponse.Code)
+	}
+	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\",\"found\":true,\"children\":2}\n" {
+		t.Fatalf("local storage challenge response = %q", got)
+	}
+
+	invalid := httptest.NewRequest(http.MethodPost, "/internal/storage-challenge",
+		strings.NewReader(`{"operation":"delete","nonce":"x"}`))
+	invalid.RemoteAddr = "127.0.0.1:1234"
+	invalidResponse := httptest.NewRecorder()
+	handler.ServeHTTP(invalidResponse, invalid)
+	if invalidResponse.Code != http.StatusBadRequest {
+		t.Fatalf("invalid storage challenge status = %d, want 400", invalidResponse.Code)
 	}
 }
 

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -1095,7 +1095,12 @@ func TestReadinessIsServedOnTheTrafficListener(t *testing.T) {
 type staticStorageIdentity string
 
 func (s staticStorageIdentity) StorageIdentity(context.Context) (process.StorageProof, error) {
-	return process.StorageProof{Identity: string(s), Children: 1}, nil
+	return process.StorageProof{
+		Identity: string(s),
+		Children: 1,
+		Snapshot: "snapshot-1",
+		Targets:  []process.StorageProofTarget{{Generation: "1", Version: "v5"}},
+	}, nil
 }
 
 type unavailableStorageIdentity struct{}
@@ -1109,7 +1114,7 @@ type staticStorageChallenge struct {
 	err   error
 }
 
-func (s staticStorageChallenge) StorageChallenge(context.Context, string, string) (process.StorageProof, error) {
+func (s staticStorageChallenge) StorageChallenge(context.Context, string, string, string, string) (process.StorageProof, error) {
 	return s.proof, s.err
 }
 
@@ -1131,7 +1136,7 @@ func TestStorageIdentityIsLocalOnly(t *testing.T) {
 	if localResponse.Code != http.StatusOK {
 		t.Fatalf("local storage identity status = %d, want 200", localResponse.Code)
 	}
-	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\",\"children\":1}\n" {
+	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\",\"children\":1,\"snapshot\":\"snapshot-1\",\"targets\":[{\"generation\":\"1\",\"version\":\"v5\"}]}\n" {
 		t.Fatalf("local storage identity response = %q", got)
 	}
 
@@ -1180,14 +1185,16 @@ func TestStorageIdentityUnavailable(t *testing.T) {
 
 func TestStorageChallengeIsLocalAndValidated(t *testing.T) {
 	runner := staticStorageChallenge{proof: process.StorageProof{
-		Identity: "database-1",
-		Found:    true,
-		Children: 2,
+		Identity:   "database-1",
+		Found:      true,
+		Children:   2,
+		Snapshot:   "snapshot-1",
+		Generation: "generation-1",
 	}}
 	handler := storageChallengeHandler(runner)
 
 	external := httptest.NewRequest(http.MethodPost, "/internal/storage-challenge",
-		strings.NewReader(`{"operation":"write","nonce":"8aa1c262-ea39-43c2-928c-263e966cc9b4"}`))
+		strings.NewReader(`{"operation":"write","nonce":"8aa1c262-ea39-43c2-928c-263e966cc9b4","snapshot":"snapshot-1","generation":"generation-1"}`))
 	external.RemoteAddr = "192.0.2.10:1234"
 	externalResponse := httptest.NewRecorder()
 	handler.ServeHTTP(externalResponse, external)
@@ -1196,19 +1203,19 @@ func TestStorageChallengeIsLocalAndValidated(t *testing.T) {
 	}
 
 	local := httptest.NewRequest(http.MethodPost, "/internal/storage-challenge",
-		strings.NewReader(`{"operation":"write","nonce":"8aa1c262-ea39-43c2-928c-263e966cc9b4"}`))
+		strings.NewReader(`{"operation":"write","nonce":"8aa1c262-ea39-43c2-928c-263e966cc9b4","snapshot":"snapshot-1","generation":"generation-1"}`))
 	local.RemoteAddr = "127.0.0.1:1234"
 	localResponse := httptest.NewRecorder()
 	handler.ServeHTTP(localResponse, local)
 	if localResponse.Code != http.StatusOK {
 		t.Fatalf("local storage challenge status = %d, want 200", localResponse.Code)
 	}
-	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\",\"found\":true,\"children\":2}\n" {
+	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\",\"found\":true,\"children\":2,\"snapshot\":\"snapshot-1\",\"generation\":\"generation-1\"}\n" {
 		t.Fatalf("local storage challenge response = %q", got)
 	}
 
 	invalid := httptest.NewRequest(http.MethodPost, "/internal/storage-challenge",
-		strings.NewReader(`{"operation":"delete","nonce":"x"}`))
+		strings.NewReader(`{"operation":"delete","nonce":"x","snapshot":"snapshot-1","generation":"generation-1"}`))
 	invalid.RemoteAddr = "127.0.0.1:1234"
 	invalidResponse := httptest.NewRecorder()
 	handler.ServeHTTP(invalidResponse, invalid)

--- a/versioned/cmd/versiond/main_test.go
+++ b/versioned/cmd/versiond/main_test.go
@@ -1076,7 +1076,7 @@ func TestReadinessIsServedOnTheTrafficListener(t *testing.T) {
 	mgr := process.NewManager(config.Config{BasePort: 5000})
 
 	response := httptest.NewRecorder()
-	publicHandler(mgr, hostLifecycle).ServeHTTP(
+	publicHandler(mgr, hostLifecycle, nil).ServeHTTP(
 		response,
 		httptest.NewRequest(http.MethodGet, "/readyz", nil),
 	)
@@ -1089,6 +1089,35 @@ func TestReadinessIsServedOnTheTrafficListener(t *testing.T) {
 	}
 	if got := response.Header().Get("Cache-Control"); got != "no-store" {
 		t.Fatalf("/readyz Cache-Control = %q, want no-store", got)
+	}
+}
+
+type staticStorageIdentity string
+
+func (s staticStorageIdentity) StorageIdentity(context.Context) (string, error) {
+	return string(s), nil
+}
+
+func TestStorageIdentityIsLocalOnly(t *testing.T) {
+	handler := storageIdentityHandler(staticStorageIdentity("database-1"))
+
+	external := httptest.NewRequest(http.MethodGet, "/internal/storage-identity", nil)
+	external.RemoteAddr = "192.0.2.10:1234"
+	externalResponse := httptest.NewRecorder()
+	handler.ServeHTTP(externalResponse, external)
+	if externalResponse.Code != http.StatusNotFound {
+		t.Fatalf("external storage identity status = %d, want 404", externalResponse.Code)
+	}
+
+	local := httptest.NewRequest(http.MethodGet, "/internal/storage-identity", nil)
+	local.RemoteAddr = "127.0.0.1:1234"
+	localResponse := httptest.NewRecorder()
+	handler.ServeHTTP(localResponse, local)
+	if localResponse.Code != http.StatusOK {
+		t.Fatalf("local storage identity status = %d, want 200", localResponse.Code)
+	}
+	if got := localResponse.Body.String(); got != "{\"identity\":\"database-1\"}\n" {
+		t.Fatalf("local storage identity response = %q", got)
 	}
 }
 

--- a/versioned/internal/process/binary_version.go
+++ b/versioned/internal/process/binary_version.go
@@ -18,6 +18,7 @@ const (
 	printProtocolVersionFlag = "--print-protocol-version"
 	printAdminAPIVersionFlag = "--print-admin-api-version"
 	printStorageModeFlag     = "--print-storage-mode"
+	initializePostgresFlag   = "--initialize-postgres-schema"
 	envHADeployment          = "GONKA_HA"
 	envNonHAVersions         = "VERSIOND_NON_HA_VERSIONS"
 )
@@ -235,4 +236,28 @@ func readAdminAPIVersionContext(ctx context.Context, binPath string) (string, er
 
 func readStorageModeContext(ctx context.Context, binPath string) (string, error) {
 	return readEmbeddedVersionContext(ctx, binPath, printStorageModeFlag)
+}
+
+func initializePostgresSchemaContext(ctx context.Context, binPath string, env []string) (bool, error) {
+	cmd := exec.CommandContext(ctx, binPath, initializePostgresFlag)
+	cmd.Env = env
+	cmd.WaitDelay = time.Second
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	message := strings.TrimSpace(output.String())
+	if isUnsupportedVersionFlagError(err, message) {
+		return false, nil
+	}
+	if ctx.Err() != nil {
+		return true, fmt.Errorf("initialize postgres schema with %s: %w", binPath, ctx.Err())
+	}
+	if message != "" {
+		return true, fmt.Errorf("initialize postgres schema with %s: %w: %s", binPath, err, message)
+	}
+	return true, fmt.Errorf("initialize postgres schema with %s: %w", binPath, err)
 }

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -123,6 +123,8 @@ type Manager struct {
 	proofEpoch          string
 	storageInitDone     chan struct{}
 	storageInitOnce     sync.Once
+	storageInitExpected map[string]struct{}
+	storageInitLegacy   map[string]struct{}
 	conditions          Conditions
 	everConverged       bool
 	available           chan struct{}
@@ -137,19 +139,21 @@ func NewManager(cfg config.Config) *Manager {
 	cfg = normalizeConfig(cfg)
 	childCtx, cancelChildren := context.WithCancel(context.Background())
 	m := &Manager{
-		cfg:             cfg,
-		processes:       make(map[string]*child),
-		draining:        make(map[string][]*child),
-		children:        make(map[*child]struct{}),
-		downloading:     make(map[string]struct{}),
-		allocatedPorts:  make(map[int]struct{}),
-		reservedPorts:   reservedChildPorts(),
-		operations:      make(map[uint64]controlOperation),
-		childCtx:        childCtx,
-		cancelChildren:  cancelChildren,
-		available:       make(chan struct{}, 1),
-		proofEpoch:      rand.Text(),
-		storageInitDone: make(chan struct{}),
+		cfg:                 cfg,
+		processes:           make(map[string]*child),
+		draining:            make(map[string][]*child),
+		children:            make(map[*child]struct{}),
+		downloading:         make(map[string]struct{}),
+		allocatedPorts:      make(map[int]struct{}),
+		reservedPorts:       reservedChildPorts(),
+		operations:          make(map[uint64]controlOperation),
+		childCtx:            childCtx,
+		cancelChildren:      cancelChildren,
+		available:           make(chan struct{}, 1),
+		proofEpoch:          rand.Text(),
+		storageInitDone:     make(chan struct{}),
+		storageInitExpected: make(map[string]struct{}),
+		storageInitLegacy:   make(map[string]struct{}),
 	}
 	m.routes.Store(proxy.RouteTable{})
 	return m
@@ -419,6 +423,7 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 		"force_versions", m.cfg.ForceVersions,
 		"desired_versions", versionNamesMap(desiredSet),
 	)
+	m.configureStorageInitCandidates(desiredSet)
 
 	// Phase A (lock): snapshot state, identify overrides.
 	m.mu.Lock()
@@ -1767,6 +1772,7 @@ func (m *Manager) ensurePostgresSchemaInitialized(ctx context.Context, c *child,
 		m.storageInitOnce.Do(func() { close(m.storageInitDone) })
 		return nil
 	}
+	m.noteLegacyStorageInitializer(c.version.Name)
 
 	slog.Info("legacy child waiting for lock-aware PostgreSQL schema initialization",
 		"version", c.version.Name)
@@ -1776,6 +1782,47 @@ func (m *Manager) ensurePostgresSchemaInitialized(ctx context.Context, c *child,
 	case <-m.storageInitDone:
 		return nil
 	}
+}
+
+func (m *Manager) configureStorageInitCandidates(desired map[string]oracle.Version) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	select {
+	case <-m.storageInitDone:
+		return
+	default:
+	}
+	expected := make(map[string]struct{}, len(desired))
+	for name := range desired {
+		expected[name] = struct{}{}
+	}
+	legacy := make(map[string]struct{}, len(m.storageInitLegacy))
+	for name := range m.storageInitLegacy {
+		if _, ok := expected[name]; ok {
+			legacy[name] = struct{}{}
+		}
+	}
+	m.storageInitExpected = expected
+	m.storageInitLegacy = legacy
+	m.closeLegacyOnlyStorageInitLocked()
+}
+
+func (m *Manager) noteLegacyStorageInitializer(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, expected := m.storageInitExpected[name]; !expected {
+		return
+	}
+	m.storageInitLegacy[name] = struct{}{}
+	m.closeLegacyOnlyStorageInitLocked()
+}
+
+func (m *Manager) closeLegacyOnlyStorageInitLocked() {
+	if len(m.storageInitExpected) == 0 || len(m.storageInitLegacy) != len(m.storageInitExpected) {
+		return
+	}
+	slog.Info("desired devshard catalog has no lock-aware PostgreSQL initializer; preserving legacy startup")
+	m.storageInitOnce.Do(func() { close(m.storageInitDone) })
 }
 
 func (m *Manager) waitForRestartBackoff(ctx context.Context, c *child, backoff time.Duration) bool {

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -44,15 +45,19 @@ type child struct {
 	archiveSHA256 string
 	binaryVersion string
 	storageMode   string
-	binPath       string
-	port          int
-	adminPort     atomic.Int64
-	stop          context.CancelFunc
-	forceStopCh   chan struct{}
-	forceStopOnce sync.Once
-	done          chan struct{} // closed when runChild exits
-	ready         chan struct{} // closed after readiness succeeds
-	readyOnce     sync.Once
+	// haDeployment is populated by binary preflight. Nil means the generation
+	// has not yet established whether it belongs to the HA PostgreSQL set.
+	haDeployment    *bool
+	proofGeneration uint64
+	binPath         string
+	port            int
+	adminPort       atomic.Int64
+	stop            context.CancelFunc
+	forceStopCh     chan struct{}
+	forceStopOnce   sync.Once
+	done            chan struct{} // closed when runChild exits
+	ready           chan struct{} // closed after readiness succeeds
+	readyOnce       sync.Once
 	// serving is this generation's own live readiness, refreshed by a monitor
 	// started when it begins running. It is per generation on purpose: a probe
 	// answered by a child that has since been swapped out must not decide
@@ -105,23 +110,25 @@ func (c *child) Done() <-chan struct{} {
 }
 
 type Manager struct {
-	cfg             config.Config
-	processes       map[string]*child
-	draining        map[string][]*child
-	children        map[*child]struct{}
-	downloading     map[string]struct{}
-	allocatedPorts  map[int]struct{}
-	reservedPorts   map[int]struct{}
-	operations      map[uint64]controlOperation
-	nextOperationID uint64
-	conditions      Conditions
-	everConverged   bool
-	available       chan struct{}
-	childCtx        context.Context
-	cancelChildren  context.CancelFunc
-	hostDraining    bool
-	mu              sync.Mutex
-	routes          atomic.Value // proxy.RouteTable
+	cfg                 config.Config
+	processes           map[string]*child
+	draining            map[string][]*child
+	children            map[*child]struct{}
+	downloading         map[string]struct{}
+	allocatedPorts      map[int]struct{}
+	reservedPorts       map[int]struct{}
+	operations          map[uint64]controlOperation
+	nextOperationID     uint64
+	nextProofGeneration uint64
+	proofEpoch          string
+	conditions          Conditions
+	everConverged       bool
+	available           chan struct{}
+	childCtx            context.Context
+	cancelChildren      context.CancelFunc
+	hostDraining        bool
+	mu                  sync.Mutex
+	routes              atomic.Value // proxy.RouteTable
 }
 
 func NewManager(cfg config.Config) *Manager {
@@ -139,6 +146,7 @@ func NewManager(cfg config.Config) *Manager {
 		childCtx:       childCtx,
 		cancelChildren: cancelChildren,
 		available:      make(chan struct{}, 1),
+		proofEpoch:     rand.Text(),
 	}
 	m.routes.Store(proxy.RouteTable{})
 	return m
@@ -1548,6 +1556,12 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 	m.mu.Lock()
 	c.binaryVersion = preflight.binaryLogVersion
 	c.storageMode = preflight.storageMode
+	if preflight.haDeployment != nil {
+		ha := *preflight.haDeployment
+		c.haDeployment = &ha
+	} else {
+		c.haDeployment = nil
+	}
 	if preflight.adminAPISupported && c.adminPort.Load() == 0 {
 		adminPort, portErr := m.assignPort()
 		if portErr != nil {
@@ -1653,6 +1667,8 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 		c.servingAt.Store(time.Now().UnixNano())
 
 		m.mu.Lock()
+		m.nextProofGeneration++
+		c.proofGeneration = m.nextProofGeneration
 		transitionGenerationLocked(c, statusRunning)
 		c.proxyTarget = proxy.NewTarget(fmt.Sprintf("localhost:%d", c.port))
 		c.readyOnce.Do(func() { close(c.ready) })

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -1744,7 +1744,12 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 }
 
 func (m *Manager) ensurePostgresSchemaInitialized(ctx context.Context, c *child, preflight childPreflight) error {
-	if !m.devshardAdminEligible() || os.Getenv("PGHOST") == "" {
+	if !m.devshardAdminEligible() || !postgresChildStorageConfigured() {
+		return nil
+	}
+	// Explicitly pinned versions retain their single-host SQLite ownership and
+	// must remain available while the shared PostgreSQL tier is unavailable.
+	if preflight.haDeployment != nil && !*preflight.haDeployment {
 		return nil
 	}
 	ha, err := parseHADeployment(os.Getenv(envHADeployment))
@@ -1783,6 +1788,11 @@ func (m *Manager) ensurePostgresSchemaInitialized(ctx context.Context, c *child,
 	case <-m.storageInitDone:
 		return nil
 	}
+}
+
+func postgresChildStorageConfigured() bool {
+	return strings.TrimSpace(os.Getenv("PGHOST")) != "" ||
+		strings.TrimSpace(os.Getenv("PGSERVICE")) != ""
 }
 
 type storageInitCandidate struct {

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -1808,6 +1808,10 @@ func (m *Manager) resolveStorageInitCandidates(desired map[string]oracle.Version
 	}
 	expected := make(map[storageInitCandidate]struct{}, len(desired))
 	for name, version := range desired {
+		ha, err := childHADeployment(name)
+		if err == nil && !ha {
+			continue
+		}
 		artifact := ""
 		if overrideSrc, override := m.cfg.Overrides[name]; override {
 			if hash, err := download.HashFile(overrideSrc); err == nil {
@@ -1845,6 +1849,10 @@ func (m *Manager) configureStorageInitCandidates(expected map[storageInitCandida
 	}
 	m.storageInitExpected = expected
 	m.storageInitLegacy = legacy
+	if len(expected) == 0 {
+		m.storageInitOnce.Do(func() { close(m.storageInitDone) })
+		return
+	}
 	m.closeLegacyOnlyStorageInitLocked()
 }
 

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -1801,6 +1801,11 @@ type storageInitCandidate struct {
 }
 
 func (m *Manager) resolveStorageInitCandidates(desired map[string]oracle.Version) map[storageInitCandidate]struct{} {
+	select {
+	case <-m.storageInitDone:
+		return nil
+	default:
+	}
 	expected := make(map[storageInitCandidate]struct{}, len(desired))
 	for name, version := range desired {
 		artifact := ""

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -123,8 +123,8 @@ type Manager struct {
 	proofEpoch          string
 	storageInitDone     chan struct{}
 	storageInitOnce     sync.Once
-	storageInitExpected map[string]struct{}
-	storageInitLegacy   map[string]struct{}
+	storageInitExpected map[storageInitCandidate]struct{}
+	storageInitLegacy   map[storageInitCandidate]struct{}
 	conditions          Conditions
 	everConverged       bool
 	available           chan struct{}
@@ -152,8 +152,8 @@ func NewManager(cfg config.Config) *Manager {
 		available:           make(chan struct{}, 1),
 		proofEpoch:          rand.Text(),
 		storageInitDone:     make(chan struct{}),
-		storageInitExpected: make(map[string]struct{}),
-		storageInitLegacy:   make(map[string]struct{}),
+		storageInitExpected: make(map[storageInitCandidate]struct{}),
+		storageInitLegacy:   make(map[storageInitCandidate]struct{}),
 	}
 	m.routes.Store(proxy.RouteTable{})
 	return m
@@ -423,7 +423,7 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 		"force_versions", m.cfg.ForceVersions,
 		"desired_versions", versionNamesMap(desiredSet),
 	)
-	m.configureStorageInitCandidates(desiredSet)
+	m.configureStorageInitCandidates(m.resolveStorageInitCandidates(desiredSet))
 
 	// Phase A (lock): snapshot state, identify overrides.
 	m.mu.Lock()
@@ -1772,10 +1772,11 @@ func (m *Manager) ensurePostgresSchemaInitialized(ctx context.Context, c *child,
 		m.storageInitOnce.Do(func() { close(m.storageInitDone) })
 		return nil
 	}
-	m.noteLegacyStorageInitializer(c.version.Name)
+	candidate := storageInitCandidate{version: c.version.Name, artifact: c.archiveSHA256}
+	m.noteLegacyStorageInitializer(candidate)
 
 	slog.Info("legacy child waiting for lock-aware PostgreSQL schema initialization",
-		"version", c.version.Name)
+		"version", c.version.Name, "artifact", c.archiveSHA256)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -1784,7 +1785,36 @@ func (m *Manager) ensurePostgresSchemaInitialized(ctx context.Context, c *child,
 	}
 }
 
-func (m *Manager) configureStorageInitCandidates(desired map[string]oracle.Version) {
+type storageInitCandidate struct {
+	version  string
+	artifact string
+}
+
+func (m *Manager) resolveStorageInitCandidates(desired map[string]oracle.Version) map[storageInitCandidate]struct{} {
+	expected := make(map[storageInitCandidate]struct{}, len(desired))
+	for name, version := range desired {
+		artifact := ""
+		if overrideSrc, override := m.cfg.Overrides[name]; override {
+			if hash, err := download.HashFile(overrideSrc); err == nil {
+				artifact = "override:" + hash
+			} else {
+				// Keep an unresolved override distinct from every runnable artifact.
+				// Its normal reconcile path will report the underlying file error.
+				artifact = "unresolved-override:" + overrideSrc
+			}
+		} else if hash, err := version.ResolvedSHA256(); err == nil {
+			artifact = hash
+		} else {
+			// Invalid catalog entries cannot start, but must not let reports from
+			// an older artifact close the initialization barrier.
+			artifact = "unresolved-catalog:" + version.SHA256 + "\x00" + version.Binary
+		}
+		expected[storageInitCandidate{version: name, artifact: artifact}] = struct{}{}
+	}
+	return expected
+}
+
+func (m *Manager) configureStorageInitCandidates(expected map[storageInitCandidate]struct{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	select {
@@ -1792,14 +1822,10 @@ func (m *Manager) configureStorageInitCandidates(desired map[string]oracle.Versi
 		return
 	default:
 	}
-	expected := make(map[string]struct{}, len(desired))
-	for name := range desired {
-		expected[name] = struct{}{}
-	}
-	legacy := make(map[string]struct{}, len(m.storageInitLegacy))
-	for name := range m.storageInitLegacy {
-		if _, ok := expected[name]; ok {
-			legacy[name] = struct{}{}
+	legacy := make(map[storageInitCandidate]struct{}, len(m.storageInitLegacy))
+	for candidate := range m.storageInitLegacy {
+		if _, ok := expected[candidate]; ok {
+			legacy[candidate] = struct{}{}
 		}
 	}
 	m.storageInitExpected = expected
@@ -1807,13 +1833,13 @@ func (m *Manager) configureStorageInitCandidates(desired map[string]oracle.Versi
 	m.closeLegacyOnlyStorageInitLocked()
 }
 
-func (m *Manager) noteLegacyStorageInitializer(name string) {
+func (m *Manager) noteLegacyStorageInitializer(candidate storageInitCandidate) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, expected := m.storageInitExpected[name]; !expected {
+	if _, expected := m.storageInitExpected[candidate]; !expected {
 		return
 	}
-	m.storageInitLegacy[name] = struct{}{}
+	m.storageInitLegacy[candidate] = struct{}{}
 	m.closeLegacyOnlyStorageInitLocked()
 }
 

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -121,6 +121,8 @@ type Manager struct {
 	nextOperationID     uint64
 	nextProofGeneration uint64
 	proofEpoch          string
+	storageInitDone     chan struct{}
+	storageInitOnce     sync.Once
 	conditions          Conditions
 	everConverged       bool
 	available           chan struct{}
@@ -135,18 +137,19 @@ func NewManager(cfg config.Config) *Manager {
 	cfg = normalizeConfig(cfg)
 	childCtx, cancelChildren := context.WithCancel(context.Background())
 	m := &Manager{
-		cfg:            cfg,
-		processes:      make(map[string]*child),
-		draining:       make(map[string][]*child),
-		children:       make(map[*child]struct{}),
-		downloading:    make(map[string]struct{}),
-		allocatedPorts: make(map[int]struct{}),
-		reservedPorts:  reservedChildPorts(),
-		operations:     make(map[uint64]controlOperation),
-		childCtx:       childCtx,
-		cancelChildren: cancelChildren,
-		available:      make(chan struct{}, 1),
-		proofEpoch:     rand.Text(),
+		cfg:             cfg,
+		processes:       make(map[string]*child),
+		draining:        make(map[string][]*child),
+		children:        make(map[*child]struct{}),
+		downloading:     make(map[string]struct{}),
+		allocatedPorts:  make(map[int]struct{}),
+		reservedPorts:   reservedChildPorts(),
+		operations:      make(map[uint64]controlOperation),
+		childCtx:        childCtx,
+		cancelChildren:  cancelChildren,
+		available:       make(chan struct{}, 1),
+		proofEpoch:      rand.Text(),
+		storageInitDone: make(chan struct{}),
 	}
 	m.routes.Store(proxy.RouteTable{})
 	return m
@@ -1553,6 +1556,13 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 		m.mu.Unlock()
 		return
 	}
+	if err := m.ensurePostgresSchemaInitialized(ctx, c, preflight); err != nil {
+		slog.Error("postgres schema initialization barrier failed", "version", c.version.Name, "error", err)
+		m.mu.Lock()
+		transitionGenerationFailureLocked(c)
+		m.mu.Unlock()
+		return
+	}
 	m.mu.Lock()
 	c.binaryVersion = preflight.binaryLogVersion
 	c.storageMode = preflight.storageMode
@@ -1725,6 +1735,46 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 		if backoff > 60*time.Second {
 			backoff = 60 * time.Second
 		}
+	}
+}
+
+func (m *Manager) ensurePostgresSchemaInitialized(ctx context.Context, c *child, preflight childPreflight) error {
+	if !m.devshardAdminEligible() || os.Getenv("PGHOST") == "" {
+		return nil
+	}
+	ha, err := parseHADeployment(os.Getenv(envHADeployment))
+	if err != nil {
+		return fmt.Errorf("read HA deployment mode: %w", err)
+	}
+	if !ha {
+		return nil
+	}
+	select {
+	case <-m.storageInitDone:
+		return nil
+	default:
+	}
+
+	supported, err := initializePostgresSchemaContext(
+		ctx,
+		c.binPath,
+		childEnv(preflight.binaryLogVersion, "", preflight.haDeployment),
+	)
+	if err != nil {
+		return err
+	}
+	if supported {
+		m.storageInitOnce.Do(func() { close(m.storageInitDone) })
+		return nil
+	}
+
+	slog.Info("legacy child waiting for lock-aware PostgreSQL schema initialization",
+		"version", c.version.Name)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.storageInitDone:
+		return nil
 	}
 }
 

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -346,6 +346,33 @@ func TestResolvedStorageInitCandidatesSkipWorkAfterInitialization(t *testing.T) 
 	}
 }
 
+func TestResolvedStorageInitCandidatesExcludeNonHAVersions(t *testing.T) {
+	t.Setenv(envHADeployment, "true")
+	t.Setenv(envNonHAVersions, "v1")
+	m := NewManager(config.Config{})
+
+	got := m.resolveStorageInitCandidates(map[string]oracle.Version{
+		"v1": {Name: "v1", SHA256: strings.Repeat("1", 64)},
+		"v5": {Name: "v5", SHA256: strings.Repeat("5", 64)},
+	})
+	if len(got) != 1 {
+		t.Fatalf("resolved candidates = %v, want only v5", got)
+	}
+	if _, ok := got[storageInitCandidate{version: "v5", artifact: strings.Repeat("5", 64)}]; !ok {
+		t.Fatalf("resolved candidates = %v, want v5 artifact", got)
+	}
+}
+
+func TestEmptyHAInitializerSetCompletesBarrier(t *testing.T) {
+	m := NewManager(config.Config{})
+	m.configureStorageInitCandidates(nil)
+	select {
+	case <-m.storageInitDone:
+	default:
+		t.Fatal("empty HA initializer set did not complete the barrier")
+	}
+}
+
 func TestPostgresSchemaInitializationIgnoresStaleSHAClassification(t *testing.T) {
 	t.Setenv(envHADeployment, "true")
 	t.Setenv("PGHOST", "postgres")

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -203,15 +203,16 @@ exit 2
 	}
 
 	m := NewManager(config.Config{BinaryName: "devshardd"})
-	m.configureStorageInitCandidates(map[string]oracle.Version{
-		"legacy":  {Name: "legacy"},
-		"current": {Name: "current"},
+	m.configureStorageInitCandidates(map[storageInitCandidate]struct{}{
+		{version: "legacy", artifact: "legacy-sha"}:   {},
+		{version: "current", artifact: "current-sha"}: {},
 	})
 	legacyDone := make(chan error, 1)
 	go func() {
 		legacyDone <- m.ensurePostgresSchemaInitialized(context.Background(), &child{
-			version: oracle.Version{Name: "legacy"},
-			binPath: legacyBin,
+			version:       oracle.Version{Name: "legacy"},
+			archiveSHA256: "legacy-sha",
+			binPath:       legacyBin,
 		}, childPreflight{binaryLogVersion: "legacy", haDeployment: boolPointer(false)})
 	}()
 
@@ -222,8 +223,9 @@ exit 2
 	}
 
 	err := m.ensurePostgresSchemaInitialized(context.Background(), &child{
-		version: oracle.Version{Name: "current"},
-		binPath: currentBin,
+		version:       oracle.Version{Name: "current"},
+		archiveSHA256: "current-sha",
+		binPath:       currentBin,
 	}, childPreflight{binaryLogVersion: "current", haDeployment: boolPointer(true)})
 	if err != nil {
 		t.Fatal(err)
@@ -251,15 +253,16 @@ exit 2
 	}
 
 	m := NewManager(config.Config{BinaryName: "devshardd"})
-	m.configureStorageInitCandidates(map[string]oracle.Version{
-		"legacy-a": {Name: "legacy-a"},
-		"legacy-b": {Name: "legacy-b"},
+	m.configureStorageInitCandidates(map[storageInitCandidate]struct{}{
+		{version: "legacy-a", artifact: "legacy-a-sha"}: {},
+		{version: "legacy-b", artifact: "legacy-b-sha"}: {},
 	})
 	firstDone := make(chan error, 1)
 	go func() {
 		firstDone <- m.ensurePostgresSchemaInitialized(context.Background(), &child{
-			version: oracle.Version{Name: "legacy-a"},
-			binPath: legacyBin,
+			version:       oracle.Version{Name: "legacy-a"},
+			archiveSHA256: "legacy-a-sha",
+			binPath:       legacyBin,
 		}, childPreflight{binaryLogVersion: "legacy-a", haDeployment: boolPointer(false)})
 	}()
 	select {
@@ -271,8 +274,9 @@ exit 2
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	err := m.ensurePostgresSchemaInitialized(ctx, &child{
-		version: oracle.Version{Name: "legacy-b"},
-		binPath: legacyBin,
+		version:       oracle.Version{Name: "legacy-b"},
+		archiveSHA256: "legacy-b-sha",
+		binPath:       legacyBin,
 	}, childPreflight{binaryLogVersion: "legacy-b", haDeployment: boolPointer(false)})
 	if err != nil {
 		t.Fatal(err)
@@ -284,6 +288,92 @@ exit 2
 		}
 	case <-time.After(time.Second):
 		t.Fatal("legacy-only catalog did not start after every desired binary was classified")
+	}
+}
+
+func TestPostgresSchemaInitializationIgnoresStaleSHAClassification(t *testing.T) {
+	t.Setenv(envHADeployment, "true")
+	t.Setenv("PGHOST", "postgres")
+	dir := t.TempDir()
+	currentBin := filepath.Join(dir, "current")
+	legacyBin := filepath.Join(dir, "legacy")
+	entered := filepath.Join(dir, "entered")
+	release := filepath.Join(dir, "release")
+	t.Setenv("INIT_ENTERED", entered)
+	t.Setenv("INIT_RELEASE", release)
+	if err := os.WriteFile(currentBin, []byte(`#!/bin/sh
+case "$1" in
+--initialize-postgres-schema) exit 0 ;;
+*) echo "unknown flag: $1" >&2; exit 2 ;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyBin, []byte(`#!/bin/sh
+touch "$INIT_ENTERED"
+while [ ! -e "$INIT_RELEASE" ]; do sleep 0.01; done
+echo "unknown flag: $1" >&2
+exit 2
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(config.Config{BinaryName: "devshardd"})
+	oldCandidate := storageInitCandidate{version: "v5", artifact: "old-sha"}
+	newCandidate := storageInitCandidate{version: "v5", artifact: "new-sha"}
+	m.configureStorageInitCandidates(map[storageInitCandidate]struct{}{oldCandidate: {}})
+	oldDone := make(chan error, 1)
+	go func() {
+		oldDone <- m.ensurePostgresSchemaInitialized(context.Background(), &child{
+			version:       oracle.Version{Name: "v5"},
+			archiveSHA256: "old-sha",
+			binPath:       legacyBin,
+		}, childPreflight{binaryLogVersion: "v5-old", haDeployment: boolPointer(false)})
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(entered); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("old artifact did not enter initializer classification")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	m.configureStorageInitCandidates(map[storageInitCandidate]struct{}{newCandidate: {}})
+	if err := os.WriteFile(release, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-oldDone:
+		t.Fatalf("stale SHA closed the replacement barrier: %v", err)
+	case <-m.storageInitDone:
+		t.Fatal("stale SHA classified the replacement artifact as legacy")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	err := m.ensurePostgresSchemaInitialized(context.Background(), &child{
+		version:       oracle.Version{Name: "v5"},
+		archiveSHA256: "new-sha",
+		binPath:       currentBin,
+	}, childPreflight{binaryLogVersion: "v5", haDeployment: boolPointer(true)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-m.storageInitDone:
+	default:
+		t.Fatal("replacement artifact did not complete PostgreSQL initialization")
+	}
+	select {
+	case err := <-oldDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stale child did not leave the barrier after replacement initialization")
 	}
 }
 

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -213,7 +213,7 @@ exit 2
 			version:       oracle.Version{Name: "legacy"},
 			archiveSHA256: "legacy-sha",
 			binPath:       legacyBin,
-		}, childPreflight{binaryLogVersion: "legacy", haDeployment: boolPointer(false)})
+		}, childPreflight{binaryLogVersion: "legacy", haDeployment: boolPointer(true)})
 	}()
 
 	select {
@@ -263,7 +263,7 @@ exit 2
 			version:       oracle.Version{Name: "legacy-a"},
 			archiveSHA256: "legacy-a-sha",
 			binPath:       legacyBin,
-		}, childPreflight{binaryLogVersion: "legacy-a", haDeployment: boolPointer(false)})
+		}, childPreflight{binaryLogVersion: "legacy-a", haDeployment: boolPointer(true)})
 	}()
 	select {
 	case err := <-firstDone:
@@ -277,7 +277,7 @@ exit 2
 		version:       oracle.Version{Name: "legacy-b"},
 		archiveSHA256: "legacy-b-sha",
 		binPath:       legacyBin,
-	}, childPreflight{binaryLogVersion: "legacy-b", haDeployment: boolPointer(false)})
+	}, childPreflight{binaryLogVersion: "legacy-b", haDeployment: boolPointer(true)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,6 +288,47 @@ exit 2
 		}
 	case <-time.After(time.Second):
 		t.Fatal("legacy-only catalog did not start after every desired binary was classified")
+	}
+}
+
+func TestPostgresSchemaInitializationDoesNotBlockNonHAChild(t *testing.T) {
+	t.Setenv(envHADeployment, "true")
+	t.Setenv("PGHOST", "unavailable-postgres")
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "initializer-called")
+	t.Setenv("INIT_MARKER", marker)
+	legacyBin := filepath.Join(dir, "legacy")
+	if err := os.WriteFile(legacyBin, []byte(`#!/bin/sh
+touch "$INIT_MARKER"
+exit 1
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(config.Config{BinaryName: "devshardd"})
+	err := m.ensurePostgresSchemaInitialized(context.Background(), &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: "legacy-sha",
+		binPath:       legacyBin,
+	}, childPreflight{binaryLogVersion: "v1", haDeployment: boolPointer(false)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("non-HA child invoked PostgreSQL initializer: %v", err)
+	}
+}
+
+func TestPostgresChildStorageConfigured(t *testing.T) {
+	for _, key := range []string{"PGHOST", "PGSERVICE"} {
+		t.Run(key, func(t *testing.T) {
+			t.Setenv("PGHOST", "")
+			t.Setenv("PGSERVICE", "")
+			t.Setenv(key, "configured")
+			if !postgresChildStorageConfigured() {
+				t.Fatalf("%s did not select PostgreSQL child storage", key)
+			}
+		})
 	}
 }
 
@@ -328,7 +369,7 @@ exit 2
 			version:       oracle.Version{Name: "v5"},
 			archiveSHA256: "old-sha",
 			binPath:       legacyBin,
-		}, childPreflight{binaryLogVersion: "v5-old", haDeployment: boolPointer(false)})
+		}, childPreflight{binaryLogVersion: "v5-old", haDeployment: boolPointer(true)})
 	}()
 	deadline := time.Now().Add(time.Second)
 	for {

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -181,6 +181,59 @@ exit 2
 	}
 }
 
+func TestPostgresSchemaInitializationPrecedesLegacyChildren(t *testing.T) {
+	t.Setenv(envHADeployment, "true")
+	t.Setenv("PGHOST", "postgres")
+	dir := t.TempDir()
+	currentBin := filepath.Join(dir, "current")
+	legacyBin := filepath.Join(dir, "legacy")
+	if err := os.WriteFile(currentBin, []byte(`#!/bin/sh
+case "$1" in
+--initialize-postgres-schema) exit 0 ;;
+*) echo "unknown flag: $1" >&2; exit 2 ;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyBin, []byte(`#!/bin/sh
+echo "unknown flag: $1" >&2
+exit 2
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(config.Config{BinaryName: "devshardd"})
+	legacyDone := make(chan error, 1)
+	go func() {
+		legacyDone <- m.ensurePostgresSchemaInitialized(context.Background(), &child{
+			version: oracle.Version{Name: "legacy"},
+			binPath: legacyBin,
+		}, childPreflight{binaryLogVersion: "legacy", haDeployment: boolPointer(false)})
+	}()
+
+	select {
+	case err := <-legacyDone:
+		t.Fatalf("legacy initialization barrier returned before a current child initialized the schema: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	err := m.ensurePostgresSchemaInitialized(context.Background(), &child{
+		version: oracle.Version{Name: "current"},
+		binPath: currentBin,
+	}, childPreflight{binaryLogVersion: "current", haDeployment: boolPointer(true)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-legacyDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("legacy child did not pass the barrier after schema initialization")
+	}
+}
+
 func TestPreflightChild_ProtocolFlagUnsupported(t *testing.T) {
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "binary-only-stamp")

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -332,6 +332,20 @@ func TestPostgresChildStorageConfigured(t *testing.T) {
 	}
 }
 
+func TestResolvedStorageInitCandidatesSkipWorkAfterInitialization(t *testing.T) {
+	m := NewManager(config.Config{
+		Overrides: map[string]string{"v5": filepath.Join(t.TempDir(), "missing-override")},
+	})
+	m.storageInitOnce.Do(func() { close(m.storageInitDone) })
+
+	got := m.resolveStorageInitCandidates(map[string]oracle.Version{
+		"v5": {Name: "v5"},
+	})
+	if len(got) != 0 {
+		t.Fatalf("resolved candidates after initialization = %v, want none", got)
+	}
+}
+
 func TestPostgresSchemaInitializationIgnoresStaleSHAClassification(t *testing.T) {
 	t.Setenv(envHADeployment, "true")
 	t.Setenv("PGHOST", "postgres")

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -203,6 +203,10 @@ exit 2
 	}
 
 	m := NewManager(config.Config{BinaryName: "devshardd"})
+	m.configureStorageInitCandidates(map[string]oracle.Version{
+		"legacy":  {Name: "legacy"},
+		"current": {Name: "current"},
+	})
 	legacyDone := make(chan error, 1)
 	go func() {
 		legacyDone <- m.ensurePostgresSchemaInitialized(context.Background(), &child{
@@ -231,6 +235,55 @@ exit 2
 		}
 	case <-time.After(time.Second):
 		t.Fatal("legacy child did not pass the barrier after schema initialization")
+	}
+}
+
+func TestPostgresSchemaInitializationAllowsLegacyOnlyCatalog(t *testing.T) {
+	t.Setenv(envHADeployment, "true")
+	t.Setenv("PGHOST", "postgres")
+	dir := t.TempDir()
+	legacyBin := filepath.Join(dir, "legacy")
+	if err := os.WriteFile(legacyBin, []byte(`#!/bin/sh
+echo "unknown flag: $1" >&2
+exit 2
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(config.Config{BinaryName: "devshardd"})
+	m.configureStorageInitCandidates(map[string]oracle.Version{
+		"legacy-a": {Name: "legacy-a"},
+		"legacy-b": {Name: "legacy-b"},
+	})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- m.ensurePostgresSchemaInitialized(context.Background(), &child{
+			version: oracle.Version{Name: "legacy-a"},
+			binPath: legacyBin,
+		}, childPreflight{binaryLogVersion: "legacy-a", haDeployment: boolPointer(false)})
+	}()
+	select {
+	case err := <-firstDone:
+		t.Fatalf("first legacy child passed before every desired binary was classified: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := m.ensurePostgresSchemaInitialized(ctx, &child{
+		version: oracle.Version{Name: "legacy-b"},
+		binPath: legacyBin,
+	}, childPreflight{binaryLogVersion: "legacy-b", haDeployment: boolPointer(false)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("legacy-only catalog did not start after every desired binary was classified")
 	}
 }
 

--- a/versioned/internal/process/storage_proof.go
+++ b/versioned/internal/process/storage_proof.go
@@ -1,0 +1,157 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+// StorageProof is the aggregate answer from every running devshard child on
+// this versiond host.
+type StorageProof struct {
+	Identity string `json:"identity"`
+	Found    bool   `json:"found,omitempty"`
+	Children int    `json:"children"`
+}
+
+type childStorageProof struct {
+	Identity string `json:"identity"`
+	Found    bool   `json:"found,omitempty"`
+}
+
+type storageChallengeRequest struct {
+	Operation string `json:"operation"`
+	Nonce     string `json:"nonce"`
+}
+
+const childStorageProofTimeout = 3 * time.Second
+
+// StorageIdentity reads the lineage marker through every running child's
+// application storage. Equal identities are useful for detecting accidental
+// database replacement, but callers must also run a two-way live challenge to
+// prove that hosts share one writable PostgreSQL.
+func (m *Manager) StorageIdentity(ctx context.Context) (StorageProof, error) {
+	return m.aggregateChildStorageProof(ctx, http.MethodGet, "/storage/identity", nil)
+}
+
+// StorageChallenge executes a write or read through every running child's
+// application storage pool.
+func (m *Manager) StorageChallenge(ctx context.Context, operation, nonce string) (StorageProof, error) {
+	if operation != "write" && operation != "read" {
+		return StorageProof{}, fmt.Errorf("invalid storage challenge operation %q", operation)
+	}
+	body, err := json.Marshal(storageChallengeRequest{Operation: operation, Nonce: nonce})
+	if err != nil {
+		return StorageProof{}, err
+	}
+	return m.aggregateChildStorageProof(ctx, http.MethodPost, "/storage/challenge", body)
+}
+
+func (m *Manager) runningStorageChildren() []*child {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	children := make([]*child, 0, len(m.processes))
+	for _, c := range m.processes {
+		if c != nil && c.status == statusRunning && !childDone(c) {
+			children = append(children, c)
+		}
+	}
+	sort.Slice(children, func(i, j int) bool { return children[i].version.Name < children[j].version.Name })
+	return children
+}
+
+func (m *Manager) aggregateChildStorageProof(
+	ctx context.Context,
+	method string,
+	path string,
+	body []byte,
+) (StorageProof, error) {
+	children := m.runningStorageChildren()
+	if len(children) == 0 {
+		return StorageProof{}, errors.New("no running devshard children")
+	}
+
+	type result struct {
+		version string
+		proof   childStorageProof
+		err     error
+	}
+	results := make(chan result, len(children))
+	var wg sync.WaitGroup
+	for _, c := range children {
+		wg.Add(1)
+		go func(c *child) {
+			defer wg.Done()
+			proof, err := requestChildStorageProof(ctx, c, method, path, body)
+			results <- result{version: c.version.Name, proof: proof, err: err}
+		}(c)
+	}
+	wg.Wait()
+	close(results)
+
+	aggregate := StorageProof{Found: true, Children: len(children)}
+	var errs []error
+	for result := range results {
+		if result.err != nil {
+			errs = append(errs, fmt.Errorf("child %s: %w", result.version, result.err))
+			continue
+		}
+		if result.proof.Identity == "" {
+			errs = append(errs, fmt.Errorf("child %s: empty storage identity", result.version))
+			continue
+		}
+		if aggregate.Identity == "" {
+			aggregate.Identity = result.proof.Identity
+		} else if aggregate.Identity != result.proof.Identity {
+			errs = append(errs, fmt.Errorf("child %s: storage identity mismatch", result.version))
+		}
+		aggregate.Found = aggregate.Found && result.proof.Found
+	}
+	if err := errors.Join(errs...); err != nil {
+		return StorageProof{}, err
+	}
+	return aggregate, nil
+}
+
+func requestChildStorageProof(
+	ctx context.Context,
+	c *child,
+	method string,
+	path string,
+	body []byte,
+) (childStorageProof, error) {
+	addr := c.adminAddr()
+	if addr == "" {
+		return childStorageProof{}, errors.New("child has no storage-proof admin API")
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, childStorageProofTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, method, "http://"+addr+path, bytes.NewReader(body))
+	if err != nil {
+		return childStorageProof{}, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return childStorageProof{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return childStorageProof{}, fmt.Errorf("storage proof returned %s: %s", resp.Status, bytes.TrimSpace(message))
+	}
+	var proof childStorageProof
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&proof); err != nil {
+		return childStorageProof{}, fmt.Errorf("decode storage proof: %w", err)
+	}
+	return proof, nil
+}

--- a/versioned/internal/process/storage_proof.go
+++ b/versioned/internal/process/storage_proof.go
@@ -17,8 +17,11 @@ import (
 )
 
 type StorageProofTarget struct {
-	Generation string `json:"generation"`
-	Version    string `json:"version"`
+	Generation                string `json:"generation"`
+	Version                   string `json:"version"`
+	PoolMaxConnections        int32  `json:"pool_max_connections"`
+	ServerMaxConnections      int32  `json:"server_max_connections"`
+	ServerReservedConnections int32  `json:"server_reserved_connections"`
 }
 
 // StorageProof carries a stable generation snapshot and either the aggregate
@@ -33,8 +36,11 @@ type StorageProof struct {
 }
 
 type childStorageProof struct {
-	Identity string `json:"identity"`
-	Found    bool   `json:"found,omitempty"`
+	Identity                  string `json:"identity"`
+	Found                     bool   `json:"found,omitempty"`
+	PoolMaxConnections        int32  `json:"pool_max_connections"`
+	ServerMaxConnections      int32  `json:"server_max_connections"`
+	ServerReservedConnections int32  `json:"server_reserved_connections"`
 }
 
 type storageChallengeRequest struct {
@@ -93,14 +99,25 @@ func (m *Manager) StorageIdentity(ctx context.Context) (StorageProof, error) {
 			errs = append(errs, fmt.Errorf("child %s: empty storage identity", result.target.version))
 			continue
 		}
+		if result.proof.PoolMaxConnections <= 0 {
+			errs = append(errs, fmt.Errorf("child %s: invalid PostgreSQL pool capacity", result.target.version))
+			continue
+		}
+		if result.proof.ServerMaxConnections <= result.proof.ServerReservedConnections {
+			errs = append(errs, fmt.Errorf("child %s: invalid PostgreSQL server capacity", result.target.version))
+			continue
+		}
 		if proof.Identity == "" {
 			proof.Identity = result.proof.Identity
 		} else if proof.Identity != result.proof.Identity {
 			errs = append(errs, fmt.Errorf("child %s: storage identity mismatch", result.target.version))
 		}
 		proof.Targets = append(proof.Targets, StorageProofTarget{
-			Generation: result.target.generation,
-			Version:    result.target.version,
+			Generation:                result.target.generation,
+			Version:                   result.target.version,
+			PoolMaxConnections:        result.proof.PoolMaxConnections,
+			ServerMaxConnections:      result.proof.ServerMaxConnections,
+			ServerReservedConnections: result.proof.ServerReservedConnections,
 		})
 	}
 	if err := errors.Join(errs...); err != nil {

--- a/versioned/internal/process/storage_proof.go
+++ b/versioned/internal/process/storage_proof.go
@@ -3,22 +3,33 @@ package process
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"sort"
-	"sync"
+	"strconv"
+	"strings"
 	"time"
 )
 
-// StorageProof is the aggregate answer from every running devshard child on
-// this versiond host.
+type StorageProofTarget struct {
+	Generation string `json:"generation"`
+	Version    string `json:"version"`
+}
+
+// StorageProof carries a stable generation snapshot and either the aggregate
+// lineage identity or one addressed generation's challenge result.
 type StorageProof struct {
-	Identity string `json:"identity"`
-	Found    bool   `json:"found,omitempty"`
-	Children int    `json:"children"`
+	Identity   string               `json:"identity"`
+	Found      bool                 `json:"found,omitempty"`
+	Children   int                  `json:"children"`
+	Snapshot   string               `json:"snapshot"`
+	Generation string               `json:"generation,omitempty"`
+	Targets    []StorageProofTarget `json:"targets,omitempty"`
 }
 
 type childStorageProof struct {
@@ -31,93 +42,194 @@ type storageChallengeRequest struct {
 	Nonce     string `json:"nonce"`
 }
 
-const childStorageProofTimeout = 3 * time.Second
-
-// StorageIdentity reads the lineage marker through every running child's
-// application storage. Equal identities are useful for detecting accidental
-// database replacement, but callers must also run a two-way live challenge to
-// prove that hosts share one writable PostgreSQL.
-func (m *Manager) StorageIdentity(ctx context.Context) (StorageProof, error) {
-	return m.aggregateChildStorageProof(ctx, http.MethodGet, "/storage/identity", nil)
+type storageProofSnapshot struct {
+	token   string
+	targets []storageProofSnapshotTarget
 }
 
-// StorageChallenge executes a write or read through every running child's
-// application storage pool.
-func (m *Manager) StorageChallenge(ctx context.Context, operation, nonce string) (StorageProof, error) {
-	if operation != "write" && operation != "read" {
-		return StorageProof{}, fmt.Errorf("invalid storage challenge operation %q", operation)
-	}
-	body, err := json.Marshal(storageChallengeRequest{Operation: operation, Nonce: nonce})
+type storageProofSnapshotTarget struct {
+	generation string
+	version    string
+	child      *child
+}
+
+type storageProofResult struct {
+	target storageProofSnapshotTarget
+	proof  childStorageProof
+	err    error
+}
+
+const childStorageProofTimeout = 3 * time.Second
+
+// StorageIdentity reads the lineage marker through every stable HA child. The
+// returned target list is the address book for per-generation challenges.
+func (m *Manager) StorageIdentity(ctx context.Context) (StorageProof, error) {
+	snapshot, err := m.storageProofSnapshot()
 	if err != nil {
 		return StorageProof{}, err
 	}
-	return m.aggregateChildStorageProof(ctx, http.MethodPost, "/storage/challenge", body)
-}
 
-func (m *Manager) runningStorageChildren() []*child {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	children := make([]*child, 0, len(m.processes))
-	for _, c := range m.processes {
-		if c != nil && c.status == statusRunning && !childDone(c) {
-			children = append(children, c)
-		}
-	}
-	sort.Slice(children, func(i, j int) bool { return children[i].version.Name < children[j].version.Name })
-	return children
-}
-
-func (m *Manager) aggregateChildStorageProof(
-	ctx context.Context,
-	method string,
-	path string,
-	body []byte,
-) (StorageProof, error) {
-	children := m.runningStorageChildren()
-	if len(children) == 0 {
-		return StorageProof{}, errors.New("no running devshard children")
+	results := make(chan storageProofResult, len(snapshot.targets))
+	for _, target := range snapshot.targets {
+		go func(target storageProofSnapshotTarget) {
+			proof, requestErr := requestChildStorageProof(ctx, target.child, http.MethodGet, "/storage/identity", nil)
+			results <- storageProofResult{target: target, proof: proof, err: requestErr}
+		}(target)
 	}
 
-	type result struct {
-		version string
-		proof   childStorageProof
-		err     error
+	proof := StorageProof{
+		Children: len(snapshot.targets),
+		Snapshot: snapshot.token,
+		Targets:  make([]StorageProofTarget, 0, len(snapshot.targets)),
 	}
-	results := make(chan result, len(children))
-	var wg sync.WaitGroup
-	for _, c := range children {
-		wg.Add(1)
-		go func(c *child) {
-			defer wg.Done()
-			proof, err := requestChildStorageProof(ctx, c, method, path, body)
-			results <- result{version: c.version.Name, proof: proof, err: err}
-		}(c)
-	}
-	wg.Wait()
-	close(results)
-
-	aggregate := StorageProof{Found: true, Children: len(children)}
 	var errs []error
-	for result := range results {
+	for range snapshot.targets {
+		result := <-results
 		if result.err != nil {
-			errs = append(errs, fmt.Errorf("child %s: %w", result.version, result.err))
+			errs = append(errs, fmt.Errorf("child %s: %w", result.target.version, result.err))
 			continue
 		}
 		if result.proof.Identity == "" {
-			errs = append(errs, fmt.Errorf("child %s: empty storage identity", result.version))
+			errs = append(errs, fmt.Errorf("child %s: empty storage identity", result.target.version))
 			continue
 		}
-		if aggregate.Identity == "" {
-			aggregate.Identity = result.proof.Identity
-		} else if aggregate.Identity != result.proof.Identity {
-			errs = append(errs, fmt.Errorf("child %s: storage identity mismatch", result.version))
+		if proof.Identity == "" {
+			proof.Identity = result.proof.Identity
+		} else if proof.Identity != result.proof.Identity {
+			errs = append(errs, fmt.Errorf("child %s: storage identity mismatch", result.target.version))
 		}
-		aggregate.Found = aggregate.Found && result.proof.Found
+		proof.Targets = append(proof.Targets, StorageProofTarget{
+			Generation: result.target.generation,
+			Version:    result.target.version,
+		})
 	}
 	if err := errors.Join(errs...); err != nil {
 		return StorageProof{}, err
 	}
-	return aggregate, nil
+	sort.Slice(proof.Targets, func(i, j int) bool { return proof.Targets[i].Generation < proof.Targets[j].Generation })
+	if err := m.verifyStorageProofSnapshot(snapshot.token); err != nil {
+		return StorageProof{}, err
+	}
+	return proof, nil
+}
+
+// StorageChallenge addresses exactly one child generation. Deployment tooling
+// repeats this for every writer and asks every target to read that writer's
+// unique nonce.
+func (m *Manager) StorageChallenge(
+	ctx context.Context,
+	snapshotToken string,
+	generation string,
+	operation string,
+	nonce string,
+) (StorageProof, error) {
+	if operation != "write" && operation != "read" {
+		return StorageProof{}, fmt.Errorf("invalid storage challenge operation %q", operation)
+	}
+	snapshot, err := m.storageProofSnapshot()
+	if err != nil {
+		return StorageProof{}, err
+	}
+	if snapshotToken == "" || snapshot.token != snapshotToken {
+		return StorageProof{}, errors.New("storage proof generation snapshot changed")
+	}
+	var selected *storageProofSnapshotTarget
+	for i := range snapshot.targets {
+		if snapshot.targets[i].generation == generation {
+			selected = &snapshot.targets[i]
+			break
+		}
+	}
+	if selected == nil {
+		return StorageProof{}, fmt.Errorf("unknown storage proof generation %q", generation)
+	}
+
+	body, err := json.Marshal(storageChallengeRequest{Operation: operation, Nonce: nonce})
+	if err != nil {
+		return StorageProof{}, err
+	}
+	childProof, err := requestChildStorageProof(ctx, selected.child, http.MethodPost, "/storage/challenge", body)
+	if err != nil {
+		return StorageProof{}, fmt.Errorf("child %s: %w", selected.version, err)
+	}
+	if err := m.verifyStorageProofSnapshot(snapshot.token); err != nil {
+		return StorageProof{}, err
+	}
+	return StorageProof{
+		Identity:   childProof.Identity,
+		Found:      childProof.Found,
+		Children:   len(snapshot.targets),
+		Snapshot:   snapshot.token,
+		Generation: selected.generation,
+	}, nil
+}
+
+func (m *Manager) storageProofSnapshot() (storageProofSnapshot, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.devshardAdminEligible() {
+		return storageProofSnapshot{}, errors.New("storage proof is available only for devshard children")
+	}
+
+	targets := make([]storageProofSnapshotTarget, 0, len(m.children))
+	for c := range m.children {
+		if childDone(c) {
+			continue
+		}
+		if c.haDeployment == nil {
+			return storageProofSnapshot{}, fmt.Errorf("child %s has not completed HA preflight", c.version.Name)
+		}
+		if !*c.haDeployment {
+			continue
+		}
+		if c.status != statusRunning {
+			return storageProofSnapshot{}, fmt.Errorf("HA child %s is %s", c.version.Name, c.status)
+		}
+		if current := m.processes[c.version.Name]; current != c {
+			return storageProofSnapshot{}, fmt.Errorf("HA child %s is not the current routed generation", c.version.Name)
+		}
+		if c.storageMode != storageModePostgres {
+			return storageProofSnapshot{}, fmt.Errorf("HA child %s storage mode is %q", c.version.Name, c.storageMode)
+		}
+		if c.adminAddr() == "" || c.proofGeneration == 0 {
+			return storageProofSnapshot{}, fmt.Errorf("HA child %s has no storage proof generation", c.version.Name)
+		}
+		targets = append(targets, storageProofSnapshotTarget{
+			generation: strconv.FormatUint(c.proofGeneration, 10),
+			version:    c.version.Name,
+			child:      c,
+		})
+	}
+	if len(targets) == 0 {
+		return storageProofSnapshot{}, errors.New("no stable HA devshard children")
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].generation == targets[j].generation {
+			return targets[i].version < targets[j].version
+		}
+		return targets[i].generation < targets[j].generation
+	})
+
+	hash := sha256.New()
+	_, _ = io.WriteString(hash, m.proofEpoch)
+	for _, target := range targets {
+		_, _ = io.WriteString(hash, "\x00"+target.generation+"\x00"+target.version)
+	}
+	return storageProofSnapshot{
+		token:   hex.EncodeToString(hash.Sum(nil)),
+		targets: targets,
+	}, nil
+}
+
+func (m *Manager) verifyStorageProofSnapshot(expected string) error {
+	current, err := m.storageProofSnapshot()
+	if err != nil {
+		return err
+	}
+	if current.token != expected {
+		return errors.New("storage proof generation snapshot changed")
+	}
+	return nil
 }
 
 func requestChildStorageProof(
@@ -147,7 +259,7 @@ func requestChildStorageProof(
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		message, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return childStorageProof{}, fmt.Errorf("storage proof returned %s: %s", resp.Status, bytes.TrimSpace(message))
+		return childStorageProof{}, fmt.Errorf("storage proof returned %s: %s", resp.Status, strings.TrimSpace(string(message)))
 	}
 	var proof childStorageProof
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&proof); err != nil {

--- a/versioned/internal/process/storage_proof_test.go
+++ b/versioned/internal/process/storage_proof_test.go
@@ -2,73 +2,197 @@ package process
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 
 	"versioned/internal/config"
 	"versioned/internal/oracle"
 )
 
-func TestStorageProofAggregatesEveryRunningChild(t *testing.T) {
-	mgr := NewManager(config.Config{BasePort: 5000})
-	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
-		t.Fatal("StorageIdentity() succeeded before any child was running")
+type fakeProofDatabase struct {
+	mu       sync.Mutex
+	identity string
+	nonces   map[string]bool
+}
+
+func newFakeProofDatabase(identity string) *fakeProofDatabase {
+	return &fakeProofDatabase{identity: identity, nonces: make(map[string]bool)}
+}
+
+func (db *fakeProofDatabase) handler(w http.ResponseWriter, r *http.Request) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	proof := childStorageProof{Identity: db.identity}
+	switch r.URL.Path {
+	case "/storage/identity":
+	case "/storage/challenge":
+		var request storageChallengeRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		switch request.Operation {
+		case "write":
+			db.nonces[request.Nonce] = true
+			proof.Found = true
+		case "read":
+			proof.Found = db.nonces[request.Nonce]
+		default:
+			http.Error(w, "bad operation", http.StatusBadRequest)
+			return
+		}
+	default:
+		http.NotFound(w, r)
+		return
 	}
-	addStorageProofChild(t, mgr, "v4", "database-1", true)
-	addStorageProofChild(t, mgr, "v5", "database-1", true)
+	_ = json.NewEncoder(w).Encode(proof)
+}
+
+func TestStorageProofAddressesOneGeneration(t *testing.T) {
+	mgr := newStorageProofManager()
+	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
+		t.Fatal("StorageIdentity() succeeded before any HA child was running")
+	}
+	db1 := newFakeProofDatabase("cloned-database")
+	db2 := newFakeProofDatabase("cloned-database")
+	first := addStorageProofChild(t, mgr, "v4", db1)
+	second := addStorageProofChild(t, mgr, "v5", db2)
 
 	identity, err := mgr.StorageIdentity(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if identity.Identity != "database-1" || identity.Children != 2 {
+	if identity.Identity != "cloned-database" || identity.Children != 2 || len(identity.Targets) != 2 {
 		t.Fatalf("StorageIdentity() = %+v", identity)
 	}
-	challenge, err := mgr.StorageChallenge(t.Context(), "read", "8aa1c262-ea39-43c2-928c-263e966cc9b4")
+
+	const nonce = "8aa1c262-ea39-43c2-928c-263e966cc9b4"
+	written, err := mgr.StorageChallenge(t.Context(), identity.Snapshot, generationName(first), "write", nonce)
+	if err != nil || !written.Found {
+		t.Fatalf("write challenge = %+v, %v", written, err)
+	}
+	seenByWriter, err := mgr.StorageChallenge(t.Context(), identity.Snapshot, generationName(first), "read", nonce)
+	if err != nil || !seenByWriter.Found {
+		t.Fatalf("writer read challenge = %+v, %v", seenByWriter, err)
+	}
+	seenByClone, err := mgr.StorageChallenge(t.Context(), identity.Snapshot, generationName(second), "read", nonce)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !challenge.Found || challenge.Children != 2 {
-		t.Fatalf("StorageChallenge() = %+v", challenge)
+	if seenByClone.Found {
+		t.Fatal("addressed write was broadcast to an independent cloned database")
+	}
+}
+
+func TestStorageProofRejectsTransitioningGenerationsAndStaleSnapshot(t *testing.T) {
+	mgr := newStorageProofManager()
+	current := addStorageProofChild(t, mgr, "v4", newFakeProofDatabase("database-1"))
+	identity, err := mgr.StorageIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	candidate := haProofChild("v5", 99)
+	for _, state := range []generationState{statusStarting, statusRetiring, statusDraining} {
+		candidate.status = state
+		mgr.children[candidate] = struct{}{}
+		if _, err := mgr.StorageIdentity(t.Context()); err == nil {
+			t.Fatalf("StorageIdentity() succeeded while an HA generation was %s", state)
+		}
+		delete(mgr.children, candidate)
+	}
+	candidate.status = statusRunning
+	mgr.children[candidate] = struct{}{}
+	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
+		t.Fatal("StorageIdentity() succeeded for an unpublished running candidate")
+	}
+	delete(mgr.children, candidate)
+
+	current.proofGeneration++
+	if _, err := mgr.StorageChallenge(
+		t.Context(),
+		identity.Snapshot,
+		generationName(current),
+		"read",
+		"8aa1c262-ea39-43c2-928c-263e966cc9b4",
+	); err == nil {
+		t.Fatal("StorageChallenge() accepted a stale generation snapshot")
+	}
+}
+
+func TestStorageProofExcludesDeclaredNonHAChildren(t *testing.T) {
+	mgr := newStorageProofManager()
+	addStorageProofChild(t, mgr, "v5", newFakeProofDatabase("database-1"))
+	nonHA := &child{
+		version:      oracle.Version{Name: "v4"},
+		status:       statusRunning,
+		done:         make(chan struct{}),
+		haDeployment: boolPointer(false),
+	}
+	mgr.children[nonHA] = struct{}{}
+	mgr.processes["v4"] = nonHA
+
+	proof, err := mgr.StorageIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proof.Children != 1 || len(proof.Targets) != 1 || proof.Targets[0].Version != "v5" {
+		t.Fatalf("StorageIdentity() included non-HA child: %+v", proof)
+	}
+}
+
+func TestStorageProofFailsClosedForHAChildWithoutProofAPI(t *testing.T) {
+	mgr := newStorageProofManager()
+	legacy := haProofChild("v5", 1)
+	mgr.children[legacy] = struct{}{}
+	mgr.processes["v5"] = legacy
+	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
+		t.Fatal("StorageIdentity() succeeded for HA child without admin storage proof")
 	}
 }
 
 func TestStorageProofFailsOnChildIdentityMismatch(t *testing.T) {
-	mgr := NewManager(config.Config{BasePort: 5000})
-	addStorageProofChild(t, mgr, "v4", "database-1", true)
-	addStorageProofChild(t, mgr, "v5", "database-2", true)
+	mgr := newStorageProofManager()
+	addStorageProofChild(t, mgr, "v4", newFakeProofDatabase("database-1"))
+	addStorageProofChild(t, mgr, "v5", newFakeProofDatabase("database-2"))
 	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
 		t.Fatal("StorageIdentity() succeeded with mismatched child storage")
 	}
 }
 
-func TestStorageProofFailsClosedForLegacyChild(t *testing.T) {
-	mgr := NewManager(config.Config{BasePort: 5000})
-	mgr.processes["v4"] = &child{
-		version: oracle.Version{Name: "v4"},
-		status:  statusRunning,
-		done:    make(chan struct{}),
-	}
-	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
-		t.Fatal("StorageIdentity() succeeded for child without admin storage proof")
+func newStorageProofManager() *Manager {
+	return NewManager(config.Config{BasePort: 5000, BinaryName: "devshardd"})
+}
+
+func addStorageProofChild(t *testing.T, mgr *Manager, version string, db *fakeProofDatabase) *child {
+	t.Helper()
+	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(db.handler))
+	t.Cleanup(shutdown)
+	mgr.nextProofGeneration++
+	c := haProofChild(version, mgr.nextProofGeneration)
+	c.adminPort.Store(int64(port))
+	mgr.children[c] = struct{}{}
+	mgr.processes[version] = c
+	return c
+}
+
+func haProofChild(version string, generation uint64) *child {
+	return &child{
+		version:         oracle.Version{Name: version},
+		storageMode:     storageModePostgres,
+		haDeployment:    boolPointer(true),
+		proofGeneration: generation,
+		status:          statusRunning,
+		done:            make(chan struct{}),
 	}
 }
 
-func addStorageProofChild(t *testing.T, mgr *Manager, version, identity string, found bool) {
-	t.Helper()
-	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/storage/identity" && r.URL.Path != "/storage/challenge" {
-			http.NotFound(w, r)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(childStorageProof{Identity: identity, Found: found})
-	}))
-	t.Cleanup(shutdown)
-	c := &child{
-		version: oracle.Version{Name: version},
-		status:  statusRunning,
-		done:    make(chan struct{}),
-	}
-	c.adminPort.Store(int64(port))
-	mgr.processes[version] = c
+func generationName(c *child) string {
+	return fmt.Sprintf("%d", c.proofGeneration)
+}
+
+func boolPointer(value bool) *bool {
+	return &value
 }

--- a/versioned/internal/process/storage_proof_test.go
+++ b/versioned/internal/process/storage_proof_test.go
@@ -11,6 +11,9 @@ import (
 
 func TestStorageProofAggregatesEveryRunningChild(t *testing.T) {
 	mgr := NewManager(config.Config{BasePort: 5000})
+	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
+		t.Fatal("StorageIdentity() succeeded before any child was running")
+	}
 	addStorageProofChild(t, mgr, "v4", "database-1", true)
 	addStorageProofChild(t, mgr, "v5", "database-1", true)
 

--- a/versioned/internal/process/storage_proof_test.go
+++ b/versioned/internal/process/storage_proof_test.go
@@ -12,19 +12,33 @@ import (
 )
 
 type fakeProofDatabase struct {
-	mu       sync.Mutex
-	identity string
-	nonces   map[string]bool
+	mu                        sync.Mutex
+	identity                  string
+	poolMaxConnections        int32
+	serverMaxConnections      int32
+	serverReservedConnections int32
+	nonces                    map[string]bool
 }
 
 func newFakeProofDatabase(identity string) *fakeProofDatabase {
-	return &fakeProofDatabase{identity: identity, nonces: make(map[string]bool)}
+	return &fakeProofDatabase{
+		identity:                  identity,
+		poolMaxConnections:        4,
+		serverMaxConnections:      100,
+		serverReservedConnections: 3,
+		nonces:                    make(map[string]bool),
+	}
 }
 
 func (db *fakeProofDatabase) handler(w http.ResponseWriter, r *http.Request) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	proof := childStorageProof{Identity: db.identity}
+	proof := childStorageProof{
+		Identity:                  db.identity,
+		PoolMaxConnections:        db.poolMaxConnections,
+		ServerMaxConnections:      db.serverMaxConnections,
+		ServerReservedConnections: db.serverReservedConnections,
+	}
 	switch r.URL.Path {
 	case "/storage/identity":
 	case "/storage/challenge":
@@ -66,6 +80,12 @@ func TestStorageProofAddressesOneGeneration(t *testing.T) {
 	}
 	if identity.Identity != "cloned-database" || identity.Children != 2 || len(identity.Targets) != 2 {
 		t.Fatalf("StorageIdentity() = %+v", identity)
+	}
+	for _, target := range identity.Targets {
+		if target.PoolMaxConnections != 4 || target.ServerMaxConnections != 100 ||
+			target.ServerReservedConnections != 3 {
+			t.Fatalf("StorageIdentity() target capacity = %+v", target)
+		}
 	}
 
 	const nonce = "8aa1c262-ea39-43c2-928c-263e966cc9b4"
@@ -159,6 +179,16 @@ func TestStorageProofFailsOnChildIdentityMismatch(t *testing.T) {
 	addStorageProofChild(t, mgr, "v5", newFakeProofDatabase("database-2"))
 	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
 		t.Fatal("StorageIdentity() succeeded with mismatched child storage")
+	}
+}
+
+func TestStorageProofFailsOnInvalidConnectionCapacity(t *testing.T) {
+	mgr := newStorageProofManager()
+	db := newFakeProofDatabase("database-1")
+	db.poolMaxConnections = 0
+	addStorageProofChild(t, mgr, "v5", db)
+	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
+		t.Fatal("StorageIdentity() accepted an invalid application pool capacity")
 	}
 }
 

--- a/versioned/internal/process/storage_proof_test.go
+++ b/versioned/internal/process/storage_proof_test.go
@@ -1,0 +1,71 @@
+package process
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"versioned/internal/config"
+	"versioned/internal/oracle"
+)
+
+func TestStorageProofAggregatesEveryRunningChild(t *testing.T) {
+	mgr := NewManager(config.Config{BasePort: 5000})
+	addStorageProofChild(t, mgr, "v4", "database-1", true)
+	addStorageProofChild(t, mgr, "v5", "database-1", true)
+
+	identity, err := mgr.StorageIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Identity != "database-1" || identity.Children != 2 {
+		t.Fatalf("StorageIdentity() = %+v", identity)
+	}
+	challenge, err := mgr.StorageChallenge(t.Context(), "read", "8aa1c262-ea39-43c2-928c-263e966cc9b4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !challenge.Found || challenge.Children != 2 {
+		t.Fatalf("StorageChallenge() = %+v", challenge)
+	}
+}
+
+func TestStorageProofFailsOnChildIdentityMismatch(t *testing.T) {
+	mgr := NewManager(config.Config{BasePort: 5000})
+	addStorageProofChild(t, mgr, "v4", "database-1", true)
+	addStorageProofChild(t, mgr, "v5", "database-2", true)
+	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
+		t.Fatal("StorageIdentity() succeeded with mismatched child storage")
+	}
+}
+
+func TestStorageProofFailsClosedForLegacyChild(t *testing.T) {
+	mgr := NewManager(config.Config{BasePort: 5000})
+	mgr.processes["v4"] = &child{
+		version: oracle.Version{Name: "v4"},
+		status:  statusRunning,
+		done:    make(chan struct{}),
+	}
+	if _, err := mgr.StorageIdentity(t.Context()); err == nil {
+		t.Fatal("StorageIdentity() succeeded for child without admin storage proof")
+	}
+}
+
+func addStorageProofChild(t *testing.T, mgr *Manager, version, identity string, found bool) {
+	t.Helper()
+	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/storage/identity" && r.URL.Path != "/storage/challenge" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(childStorageProof{Identity: identity, Found: found})
+	}))
+	t.Cleanup(shutdown)
+	c := &child{
+		version: oracle.Version{Name: version},
+		status:  statusRunning,
+		done:    make(chan struct{}),
+	}
+	c.adminPort.Store(int64(port))
+	mgr.processes[version] = c
+}

--- a/versioned/internal/sessionversion/lookup.go
+++ b/versioned/internal/sessionversion/lookup.go
@@ -98,3 +98,26 @@ func (l *Lookup) LookupSessionVersion(ctx context.Context, escrowID string) (str
 	}
 	return *version, true, nil
 }
+
+// StorageIdentity returns the durable identity created by the devshard schema.
+// It lets deployment tooling prove that independently configured supervisors
+// resolve to the same database, rather than merely comparing libpq settings.
+func (l *Lookup) StorageIdentity(ctx context.Context) (string, error) {
+	if l == nil || l.pool == nil {
+		return "", errors.New("postgres session lookup is unavailable")
+	}
+	qctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	var identity string
+	if err := l.pool.QueryRow(qctx, `
+		SELECT identity::text
+		FROM devshard_storage_identity
+		WHERE singleton`).Scan(&identity); err != nil {
+		return "", fmt.Errorf("read devshard storage identity: %w", err)
+	}
+	if identity == "" {
+		return "", errors.New("devshard storage identity is empty")
+	}
+	return identity, nil
+}

--- a/versioned/internal/sessionversion/lookup.go
+++ b/versioned/internal/sessionversion/lookup.go
@@ -102,6 +102,8 @@ func (l *Lookup) LookupSessionVersion(ctx context.Context, escrowID string) (str
 // StorageIdentity returns the durable identity created by the devshard schema.
 // It lets deployment tooling prove that independently configured supervisors
 // resolve to the same database, rather than merely comparing libpq settings.
+// The nil receiver check is required because a typed nil *Lookup is non-nil
+// after conversion to versiond's storageIdentityReader interface.
 func (l *Lookup) StorageIdentity(ctx context.Context) (string, error) {
 	if l == nil || l.pool == nil {
 		return "", errors.New("postgres session lookup is unavailable")

--- a/versioned/internal/sessionversion/lookup.go
+++ b/versioned/internal/sessionversion/lookup.go
@@ -98,28 +98,3 @@ func (l *Lookup) LookupSessionVersion(ctx context.Context, escrowID string) (str
 	}
 	return *version, true, nil
 }
-
-// StorageIdentity returns the durable identity created by the devshard schema.
-// It lets deployment tooling prove that independently configured supervisors
-// resolve to the same database, rather than merely comparing libpq settings.
-// The nil receiver check is required because a typed nil *Lookup is non-nil
-// after conversion to versiond's storageIdentityReader interface.
-func (l *Lookup) StorageIdentity(ctx context.Context) (string, error) {
-	if l == nil || l.pool == nil {
-		return "", errors.New("postgres session lookup is unavailable")
-	}
-	qctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	var identity string
-	if err := l.pool.QueryRow(qctx, `
-		SELECT identity::text
-		FROM devshard_storage_identity
-		WHERE singleton`).Scan(&identity); err != nil {
-		return "", fmt.Errorf("read devshard storage identity: %w", err)
-	}
-	if identity == "" {
-		return "", errors.New("devshard storage identity is empty")
-	}
-	return identity, nil
-}


### PR DESCRIPTION
> This focused PR is based on the PostgreSQL safety work originally implemented in the closed umbrella PRs #1517 and #1587.

## Merge Order

Merge this PR after #1604, **Add graceful versiond host evacuation**. The branch uses the per-child loopback admin listener introduced there. #1604 itself depends on #1599.

## Summary

Add a deployment-facing proof that all running devshard children use the same live writable PostgreSQL:

- assign the devshard schema a durable UUID lineage marker;
- execute storage checks through each child's real application pool;
- publish a stable snapshot of HA-routed PostgreSQL child generations;
- address every challenge to exactly one generation and application pool;
- bind every application-pool connection to the writable database selected at startup;
- reject standby PostgreSQL connections and fail closed when any child cannot prove its storage;
- initialize the schema before mixed current/legacy child startup;
- serialize schema migrations under a database-scoped lock with a separate migration timeout;
- cap every devshard application pool with `PG_POOL_MAX_CONNS` (default `4`);
- run fast readiness probes independently from the longer terminal session-fence check.

## Why both identity and a live challenge are needed

Migration 13 creates a singleton `devshard_storage_identity` row with a generated UUID. The UUID survives container recreation, PostgreSQL restart, and migration reruns, so deployment tooling can detect accidental replacement with a newly initialized database.

A backup, snapshot, or streaming replica preserves that UUID. Matching UUIDs therefore establish database lineage, but do not by themselves prove that two processes currently share one writable database.

Migration 14 adds a single challenge value to the same row. Deployment tooling first obtains a stable HA-generation snapshot from each versiond replica. It can then address a write or read to one exact generation and verify that the snapshot is unchanged before and after the request. #1608 uses this primitive for a linear anchor proof: every generation writes once, the anchor observes every writer, and every generation observes the final confirmed nonce.

Every operation also requires `pg_is_in_recovery() = false`. Independent clones with the same UUID, read replicas, cross-wired protocol versions, and child-specific connection differences fail the live exchange.

Each `devshardd` also holds a process-specific session advisory fence before it starts serving. The pgx connection validator requires every subsequently created pool connection to observe that live fence on a writable primary. PostgreSQL does not WAL-replicate session locks, so a promoted fork cannot inherit admission from the former primary. Losing the fence is fail-closed for new connections; restarting the child establishes a new fence on the selected writer.

The PostgreSQL endpoint remains responsible for cluster-level single-writer election and fencing. The application fence prevents one child pool from crossing writable branches, while the deployment challenge detects divergence between children; neither attempts to replace PostgreSQL replication consensus.

## Child storage contract

`devshardd` exposes two endpoints on its existing loopback admin listener:

```text
GET  /storage/identity
POST /storage/challenge
```

These handlers call the `Storage` object already used for devshard session traffic. Proofs therefore follow the child's actual `PG*` settings, DNS resolution, connection pool, and PostgreSQL role.

Versiond exposes the aggregate contract on its traffic listener for loopback peers only:

```text
GET  /internal/storage-identity
POST /internal/storage-challenge
```

`GET /internal/storage-identity` returns the common lineage identity, an opaque snapshot token, and one target ID per stable HA generation. `POST /internal/storage-challenge` requires that snapshot token and one target ID, then contacts only that child. Versiond verifies the snapshot before and after the child request.

The snapshot excludes versions explicitly declared through `VERSIOND_NON_HA_VERSIONS`. It returns `503` while any HA generation is preparing, starting, unpublished, retiring, or draining, and also when a HA child predates the proof API, is unreachable, uses non-PostgreSQL storage, or reports a different identity. A fresh process attempt receives a new generation ID, so a crash/restart invalidates an in-progress proof. `VERSIOND_DISABLE_SESSION_LOOKUP` no longer disables storage verification because session lookup and deployment proof are separate concerns.

## Connection capacity and failure detection

Each PostgreSQL-backed devshard generation now has a deterministic application-pool cap. `PG_POOL_MAX_CONNS` defaults to `4` instead of pgx's CPU-sized default. Identity responses report the child pool limit and PostgreSQL `max_connections`/reserved capacity so #1608 can reject an unsafe deployment budget before admission.

Readiness and fence monitoring use separate loops. The short readiness probe can withdraw a child during a network blackhole without waiting for the 30-second terminal fence decision. If the session fence is lost, devshardd force-closes its listeners and exits so versiond can create a fresh child.

## Migration startup

Migration bootstrap remains durable even when an application step fails. Pending steps then run in one transaction under one advisory lock, with applied IDs loaded once. `PG_CONNECT_TIMEOUT` bounds connection establishment; `PG_MIGRATION_TIMEOUT` (default `2m`) independently bounds migration work and waiting for another migrator.

The advisory lock coordinates current binaries. In an HA deployment, versiond classifies migration capability across the complete desired catalog. For a mixed catalog it invokes `devshardd --initialize-postgres-schema` on a current downloaded artifact while legacy binaries wait behind the initialization barrier. Concurrent versiond replicas may run the initializer, but the database advisory lock serializes them. When every desired binary predates this command, versiond releases the legacy-only catalog after classification instead of waiting indefinitely for a capability that is absent.

## Intended deployment use

The host updater will serialize the addressed linear challenge before admitting HA topology changes. Concurrent challenge runs can cause only a safe false negative because a write replaces the previous nonce.

## Validation

- `go test -race ./cmd/devshardd ./cmd/devshardd/session ./storage/...` in `devshard`;
- `go test -race ./cmd/versiond ./internal/process ./internal/sessionversion` in `versioned`;
- real PostgreSQL integration tests for pool capacity, readiness, and fence loss.

Tests cover PostgreSQL 16 migrations, strict pool-limit parsing, reported server capacity, readiness withdrawal while a fence check is blocked, concurrent migrators under short SQL timeouts, preserved UUID lineage, session-fence loss and connection-level rejection of an independent clone, two pools sharing one database, two independent databases with an intentionally cloned UUID, read-only PostgreSQL, addressed writes, cross-wired child databases, generation snapshot invalidation, transitional generations, mixed current-before-legacy ordering, legacy-only catalog release, declared non-HA exclusion, legacy HA-child failure, loopback access, malformed requests, and unavailable responses.

## Scope

This PR provides the PostgreSQL proof primitive used by HA deployment preflight. PGDATA persistence, PostgreSQL data movement, router admission, and host-update orchestration remain in their focused PRs.
