### PR TITLE
Validate shared PostgreSQL before HA admission

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -453,7 +453,9 @@ jobs:
       - name: Check migration scripts
         run: |
           shellcheck deploy/join/devshard-postgres-*.sh
+          shellcheck deploy/join/postgres-deployment-preflight*.sh
           deploy/join/devshard-postgres-entrypoint_test.sh
           deploy/join/devshard-postgres-migration-preflight_test.sh
+          deploy/join/postgres-deployment-preflight_test.sh
       - name: Preserve a real PostgreSQL cluster across replacement
         run: deploy/join/devshard-postgres-upgrade_test.sh

--- a/deploy/join/postgres-deployment-preflight.sh
+++ b/deploy/join/postgres-deployment-preflight.sh
@@ -23,7 +23,7 @@ Example:
   postgres-deployment-preflight.sh -- \
     -f docker-compose.yml -f docker-compose.versiond.yml
 
-The default mode requires both versiond replicas and connects every stable HA
+The default mode requires every versiond replica in the model and connects every stable HA
 devshard generation to one live PostgreSQL proof anchor. --compose-only checks
 only the rendered target topology and cannot be combined with
 --expected-identity.
@@ -74,9 +74,14 @@ config=$("${compose[@]}" config --format json) || fail "cannot render Compose to
 project_name=$(jq -er '.name | strings | select(length > 0)' <<<"$config") || fail \
     "rendered Compose topology has no project name"
 
-for service in versiond versiond2; do
-    jq -e --arg service "$service" '.services | has($service)' \
-        >/dev/null <<<"$config" || fail "Compose topology has no $service service"
+# Every local versiond replica in the model: versiond, versiond2, versiond3, ...
+mapfile -t versiond_services < <(
+    jq -r '.services | keys[] | select(test("^versiond[0-9]*$"))' <<<"$config" | sort -V)
+((${#versiond_services[@]} >= 2)) || fail \
+    "Compose topology needs at least two versiond services to share PostgreSQL; found: ${versiond_services[*]:-none}"
+first_service=${versiond_services[0]}
+
+for service in "${versiond_services[@]}"; do
     mode=$(jq -r --arg service "$service" \
         '.services[$service].environment.DEVSHARD_STORAGE_MODE // ""' <<<"$config")
     [[ $mode == postgres ]] || fail "$service must use DEVSHARD_STORAGE_MODE=postgres"
@@ -88,25 +93,26 @@ for service in versiond versiond2; do
     done
 done
 
-for key in PGHOST PGDATABASE PGUSER; do
-    first=$(jq -r --arg key "$key" \
-        '.services.versiond.environment[$key] // ""' <<<"$config")
-    second=$(jq -r --arg key "$key" \
-        '.services.versiond2.environment[$key] // ""' <<<"$config")
-    [[ -n $first && $first == "$second" ]] || fail \
-        "versiond services must use the same non-empty $key"
+rendered_env() {
+    jq -r --arg service "$1" --arg key "$2" --arg default "${3:-}" \
+        '.services[$service].environment[$key] // $default' <<<"$config"
+}
+
+for service in "${versiond_services[@]:1}"; do
+    for key in PGHOST PGDATABASE PGUSER; do
+        first=$(rendered_env "$first_service" "$key")
+        second=$(rendered_env "$service" "$key")
+        [[ -n $first && $first == "$second" ]] || fail \
+            "versiond services must use the same non-empty $key ($first_service and $service differ)"
+    done
+    [[ $(rendered_env "$first_service" PGPORT 5432) == $(rendered_env "$service" PGPORT 5432) ]] || \
+        fail "versiond services must use the same PGPORT ($first_service and $service differ)"
+    [[ $(rendered_env "$first_service" PG_POOL_MAX_CONNS) == $(rendered_env "$service" PG_POOL_MAX_CONNS) ]] || \
+        fail "versiond services must use the same PG_POOL_MAX_CONNS ($first_service and $service differ)"
 done
-first=$(jq -r '.services.versiond.environment.PGPORT // "5432"' <<<"$config")
-second=$(jq -r '.services.versiond2.environment.PGPORT // "5432"' <<<"$config")
-[[ $first == "$second" ]] || fail "versiond services must use the same PGPORT"
-pool_max_connections=$(jq -r \
-    '.services.versiond.environment.PG_POOL_MAX_CONNS // ""' <<<"$config")
-second=$(jq -r \
-    '.services.versiond2.environment.PG_POOL_MAX_CONNS // ""' <<<"$config")
+pool_max_connections=$(rendered_env "$first_service" PG_POOL_MAX_CONNS)
 is_positive_int32 "$pool_max_connections" || fail \
     "versiond must set PG_POOL_MAX_CONNS to a positive integer"
-[[ $pool_max_connections == "$second" ]] || fail \
-    "versiond services must use the same PG_POOL_MAX_CONNS"
 
 if [[ $compose_only == true ]]; then
     echo "postgres-deployment-preflight: rendered PostgreSQL contract is valid for Compose project '$project_name'"
@@ -122,21 +128,22 @@ container_env() {
 }
 
 containers=()
-for service in versiond versiond2; do
+running=0
+for service in "${versiond_services[@]}"; do
     container=$("${compose[@]}" ps -q "$service") || fail "cannot inspect $service"
     containers+=("$container")
+    [[ -z $container ]] || ((running += 1))
 done
-if [[ -z ${containers[0]} && -z ${containers[1]} ]]; then
+if ((running == 0)); then
     fail "Compose project '$project_name' has no running versiond replicas;" \
         "use the deployment's exact project arguments or select --compose-only explicitly"
 fi
-[[ -n ${containers[0]} && -n ${containers[1]} ]] || fail \
-    "Compose project '$project_name' has only one running versiond replica;" \
+((running == ${#versiond_services[@]})) || fail \
+    "Compose project '$project_name' has only $running of ${#versiond_services[@]} versiond replicas running;" \
     "cannot prove shared PostgreSQL storage"
 
-for index in 0 1; do
-    service=versiond
-    ((index == 0)) || service=versiond2
+for index in "${!containers[@]}"; do
+    service=${versiond_services[index]}
     container=${containers[index]}
     runtime_environment=$("$docker_bin" inspect --format \
         '{{json .Config.Env}}' "$container") || fail \
@@ -316,8 +323,7 @@ proofs=()
 snapshots=()
 identity=
 for index in "${!containers[@]}"; do
-    service=versiond
-    ((index == 0)) || service=versiond2
+    service=${versiond_services[index]}
     proof=$(read_storage_identity "$service" "${containers[index]}") || exit 1
     validate_storage_identity <<<"$proof" || fail \
         "$service returned an invalid PostgreSQL storage proof"
@@ -341,8 +347,7 @@ anchor_generation=$(jq -r '.targets[0].generation' <<<"${proofs[0]}")
 final_nonce=
 final_writer_generation=
 for writer_index in "${!containers[@]}"; do
-    writer_service=versiond
-    ((writer_index == 0)) || writer_service=versiond2
+    writer_service=${versiond_services[writer_index]}
     while IFS= read -r writer_generation; do
         nonce=$(new_challenge_nonce)
         response=$(run_storage_challenge \
@@ -354,7 +359,7 @@ for writer_index in "${!containers[@]}"; do
             "generation $writer_generation did not confirm its PostgreSQL storage challenge write"
 
         response=$(run_storage_challenge \
-            versiond "$anchor_container" "$anchor_snapshot" \
+            "$first_service" "$anchor_container" "$anchor_snapshot" \
             "$anchor_generation" read "$nonce") || exit 1
         validate_challenge_response \
             "$identity" "$anchor_snapshot" "$anchor_generation" \
@@ -366,8 +371,7 @@ for writer_index in "${!containers[@]}"; do
 done
 
 for reader_index in "${!containers[@]}"; do
-    reader_service=versiond
-    ((reader_index == 0)) || reader_service=versiond2
+    reader_service=${versiond_services[reader_index]}
     while IFS= read -r reader_generation; do
         response=$(run_storage_challenge \
             "$reader_service" "${containers[reader_index]}" \
@@ -380,8 +384,7 @@ for reader_index in "${!containers[@]}"; do
 done
 
 for index in "${!containers[@]}"; do
-    service=versiond
-    ((index == 0)) || service=versiond2
+    service=${versiond_services[index]}
     final_proof=$(read_storage_identity "$service" "${containers[index]}") || exit 1
     [[ $(jq -Sc . <<<"$final_proof") == "${proofs[index]}" ]] || fail \
         "PostgreSQL storage generation snapshot changed during the challenge"

--- a/deploy/join/postgres-deployment-preflight.sh
+++ b/deploy/join/postgres-deployment-preflight.sh
@@ -4,8 +4,9 @@ set -Eeuo pipefail
 
 docker_bin=${DOCKER_BIN:-docker}
 expected_identity=
-require_live=false
+compose_only=false
 compose_args=()
+forbidden_libpq=(DATABASE_URL PGHOSTADDR PGSERVICE PGSERVICEFILE PGOPTIONS)
 
 fail() {
     echo "postgres-deployment-preflight: $*" >&2
@@ -14,15 +15,16 @@ fail() {
 
 usage() {
     cat >&2 <<'EOF'
-Usage: postgres-deployment-preflight.sh [--expected-identity UUID] [--require-live] -- COMPOSE_ARGS...
+Usage: postgres-deployment-preflight.sh [--expected-identity UUID] [--compose-only] -- COMPOSE_ARGS...
 
 Example:
   postgres-deployment-preflight.sh -- \
     -f docker-compose.yml -f docker-compose.versiond.yml
 
-The command does not change the deployment. It validates the rendered HA
-PostgreSQL contract and, when both versiond containers exist, exchanges a
-short-lived challenge through every running HA devshard generation.
+The default mode requires both versiond replicas and exchanges a short-lived
+challenge through every running HA devshard generation. --compose-only checks
+only the rendered target topology and cannot be combined with
+--expected-identity.
 EOF
 }
 
@@ -33,8 +35,8 @@ while (($#)); do
             expected_identity=$2
             shift 2
             ;;
-        --require-live)
-            require_live=true
+        --compose-only)
+            compose_only=true
             shift
             ;;
         --)
@@ -54,11 +56,15 @@ while (($#)); do
 done
 
 ((${#compose_args[@]} > 0)) || fail "Compose arguments are required after --"
+[[ $compose_only == false || -z $expected_identity ]] || fail \
+    "--expected-identity requires the live PostgreSQL proof"
 command -v "$docker_bin" >/dev/null 2>&1 || fail "$docker_bin is required"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 
 compose=("$docker_bin" compose "${compose_args[@]}")
 config=$("${compose[@]}" config --format json) || fail "cannot render Compose topology"
+project_name=$(jq -er '.name | strings | select(length > 0)' <<<"$config") || fail \
+    "rendered Compose topology has no project name"
 
 for service in versiond versiond2; do
     jq -e --arg service "$service" '.services | has($service)' \
@@ -66,7 +72,7 @@ for service in versiond versiond2; do
     mode=$(jq -r --arg service "$service" \
         '.services[$service].environment.DEVSHARD_STORAGE_MODE // ""' <<<"$config")
     [[ $mode == postgres ]] || fail "$service must use DEVSHARD_STORAGE_MODE=postgres"
-    for key in DATABASE_URL PGSERVICE PGSERVICEFILE PGOPTIONS; do
+    for key in "${forbidden_libpq[@]}"; do
         value=$(jq -r --arg service "$service" --arg key "$key" \
             '.services[$service].environment[$key] // ""' <<<"$config")
         [[ -z $value ]] || fail \
@@ -86,6 +92,11 @@ first=$(jq -r '.services.versiond.environment.PGPORT // "5432"' <<<"$config")
 second=$(jq -r '.services.versiond2.environment.PGPORT // "5432"' <<<"$config")
 [[ $first == "$second" ]] || fail "versiond services must use the same PGPORT"
 
+if [[ $compose_only == true ]]; then
+    echo "postgres-deployment-preflight: rendered PostgreSQL contract is valid for Compose project '$project_name'"
+    exit 0
+fi
+
 container_env() {
     local container=$1 name=$2 line
     while IFS= read -r line; do
@@ -103,19 +114,18 @@ for service in versiond versiond2; do
     containers+=("$container")
 done
 if [[ -z ${containers[0]} && -z ${containers[1]} ]]; then
-    [[ $require_live == false ]] || fail \
-        "no live versiond replicas; cannot prove shared PostgreSQL storage"
-    echo "postgres-deployment-preflight: rendered contract is valid; no live replicas to compare"
-    exit 0
+    fail "Compose project '$project_name' has no running versiond replicas;" \
+        "use the deployment's exact project arguments or select --compose-only explicitly"
 fi
 [[ -n ${containers[0]} && -n ${containers[1]} ]] || fail \
-    "only one versiond replica is running; cannot prove shared PostgreSQL identity"
+    "Compose project '$project_name' has only one running versiond replica;" \
+    "cannot prove shared PostgreSQL storage"
 
 for index in 0 1; do
     service=versiond
     ((index == 0)) || service=versiond2
     container=${containers[index]}
-    for key in DATABASE_URL PGSERVICE PGSERVICEFILE PGOPTIONS; do
+    for key in "${forbidden_libpq[@]}"; do
         value=$(container_env "$container" "$key") || value=
         [[ -z $value ]] || fail "running $service sets forbidden $key"
     done
@@ -135,7 +145,7 @@ for index in 0 1; do
 done
 
 read_storage_identity() {
-    "$docker_bin" exec "$1" wget -qO- -T 5 \
+    "$docker_bin" exec "$1" /bin/busybox wget -qO- -T 5 \
         http://127.0.0.1:8080/internal/storage-identity
 }
 
@@ -163,7 +173,7 @@ run_storage_challenge() {
         --arg snapshot "$snapshot" \
         --arg generation "$generation" \
         '{operation:$operation, nonce:$nonce, snapshot:$snapshot, generation:$generation}')
-    "$docker_bin" exec "$container" wget -qO- -T 5 \
+    "$docker_bin" exec "$container" /bin/busybox wget -qO- -T 5 \
         --header 'Content-Type: application/json' \
         --post-data "$request" \
         http://127.0.0.1:8080/internal/storage-challenge
@@ -199,7 +209,8 @@ for index in "${!containers[@]}"; do
     service=versiond
     ((index == 0)) || service=versiond2
     proof=$(read_storage_identity "${containers[index]}") || fail \
-        "cannot read PostgreSQL storage proof through $service"
+        "cannot read PostgreSQL storage proof through $service;" \
+        "the live gate requires a proof-capable versiond image and a stable migrated HA devshard child"
     validate_storage_identity <<<"$proof" || fail \
         "$service returned an invalid PostgreSQL storage proof"
     observed_identity=$(jq -r '.identity' <<<"$proof")

--- a/deploy/join/postgres-deployment-preflight.sh
+++ b/deploy/join/postgres-deployment-preflight.sh
@@ -21,8 +21,8 @@ Example:
   postgres-deployment-preflight.sh -- \
     -f docker-compose.yml -f docker-compose.versiond.yml
 
-The default mode requires both versiond replicas and exchanges a short-lived
-challenge through every running HA devshard generation. --compose-only checks
+The default mode requires both versiond replicas and connects every stable HA
+devshard generation to one live PostgreSQL proof anchor. --compose-only checks
 only the rendered target topology and cannot be combined with
 --expected-identity.
 EOF
@@ -98,14 +98,11 @@ if [[ $compose_only == true ]]; then
 fi
 
 container_env() {
-    local container=$1 name=$2 line
-    while IFS= read -r line; do
-        case $line in
-            "$name="*) printf '%s\n' "${line#*=}"; return 0 ;;
-        esac
-    done < <("$docker_bin" inspect --format \
-        '{{range .Config.Env}}{{println .}}{{end}}' "$container")
-    return 1
+    local environment=$1 name=$2
+    jq -er --arg prefix "$name=" '
+        map(select(startswith($prefix)))
+        | if length == 0 then empty else (last | ltrimstr($prefix)) end
+    ' <<<"$environment"
 }
 
 containers=()
@@ -125,28 +122,84 @@ for index in 0 1; do
     service=versiond
     ((index == 0)) || service=versiond2
     container=${containers[index]}
+    runtime_environment=$("$docker_bin" inspect --format \
+        '{{json .Config.Env}}' "$container") || fail \
+        "cannot inspect runtime environment for $service container $container"
+    jq -e 'type == "array" and all(.[]; type == "string")' \
+        >/dev/null <<<"$runtime_environment" || fail \
+        "$service container returned an invalid runtime environment"
     for key in "${forbidden_libpq[@]}"; do
-        value=$(container_env "$container" "$key") || value=
+        value=$(container_env "$runtime_environment" "$key") || value=
         [[ -z $value ]] || fail "running $service sets forbidden $key"
     done
     for key in PGHOST PGDATABASE PGUSER; do
         expected=$(jq -r --arg service "$service" --arg key "$key" \
             '.services[$service].environment[$key] // ""' <<<"$config")
-        actual=$(container_env "$container" "$key") || actual=
+        actual=$(container_env "$runtime_environment" "$key") || actual=
         [[ -n $actual && $actual == "$expected" ]] || fail \
             "running $service has $key='$actual', rendered topology expects '$expected'"
     done
     expected=$(jq -r --arg service "$service" \
         '.services[$service].environment.PGPORT // "5432"' <<<"$config")
-    actual=$(container_env "$container" PGPORT) || actual=5432
+    actual=$(container_env "$runtime_environment" PGPORT) || actual=5432
     [[ -n $actual ]] || actual=5432
     [[ $actual == "$expected" ]] || fail \
         "running $service has PGPORT='$actual', rendered topology expects '$expected'"
 done
 
+versiond_http() {
+    local service=$1 container=$2 description=$3 method=$4 path=$5 payload=${6:-}
+    local diagnostics_file response status details lower_details
+    local -a wget=(/bin/busybox wget -qO- -S -T 5)
+
+    if [[ $method == POST ]]; then
+        wget+=(--header 'Content-Type: application/json' --post-data "$payload")
+    fi
+    wget+=("http://127.0.0.1:8080$path")
+    diagnostics_file=$(mktemp "${TMPDIR:-/tmp}/gonka-postgres-preflight.XXXXXX") || {
+        echo "postgres-deployment-preflight: cannot create HTTP diagnostics file" >&2
+        return 1
+    }
+    if response=$("$docker_bin" exec "$container" "${wget[@]}" \
+        2>"$diagnostics_file"); then
+        rm -f "$diagnostics_file"
+        printf '%s\n' "$response"
+        return 0
+    fi
+
+    status=$(sed -nE \
+        's/.*HTTP\/[^ ]+[[:space:]]+([0-9]{3}).*/\1/p' \
+        "$diagnostics_file" | tail -n 1)
+    details=$(
+        {
+            printf '%s\n' "$response"
+            cat "$diagnostics_file"
+        } | tr '\r\n' '  ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | cut -c1-400
+    )
+    rm -f "$diagnostics_file"
+
+    case $status in
+        404)
+            echo "postgres-deployment-preflight: $service $description returned HTTP 404; the running versiond image does not expose the live storage-proof API" >&2
+            ;;
+        503)
+            echo "postgres-deployment-preflight: $service $description is not ready (HTTP 503); inspect 'docker compose logs $service' for HA child and PostgreSQL state${details:+; details: $details}" >&2
+            ;;
+        *)
+            lower_details=${details,,}
+            if [[ $lower_details == *"timed out"* || $lower_details == *timeout* ]]; then
+                echo "postgres-deployment-preflight: $service $description timed out; inspect 'docker compose logs $service' and PostgreSQL availability" >&2
+            else
+                echo "postgres-deployment-preflight: $service $description request failed${status:+ (HTTP $status)}${details:+: $details}" >&2
+            fi
+            ;;
+    esac
+    return 1
+}
+
 read_storage_identity() {
-    "$docker_bin" exec "$1" /bin/busybox wget -qO- -T 5 \
-        http://127.0.0.1:8080/internal/storage-identity
+    versiond_http "$1" "$2" "storage identity" GET \
+        /internal/storage-identity
 }
 
 validate_storage_identity() {
@@ -165,7 +218,7 @@ validate_storage_identity() {
 }
 
 run_storage_challenge() {
-    local container=$1 snapshot=$2 generation=$3 operation=$4 nonce=$5
+    local service=$1 container=$2 snapshot=$3 generation=$4 operation=$5 nonce=$6
     local request
     request=$(jq -cn \
         --arg operation "$operation" \
@@ -173,10 +226,9 @@ run_storage_challenge() {
         --arg snapshot "$snapshot" \
         --arg generation "$generation" \
         '{operation:$operation, nonce:$nonce, snapshot:$snapshot, generation:$generation}')
-    "$docker_bin" exec "$container" /bin/busybox wget -qO- -T 5 \
-        --header 'Content-Type: application/json' \
-        --post-data "$request" \
-        http://127.0.0.1:8080/internal/storage-challenge
+    versiond_http "$service" "$container" \
+        "storage challenge for generation $generation" POST \
+        /internal/storage-challenge "$request"
 }
 
 validate_challenge_response() {
@@ -208,9 +260,7 @@ identity=
 for index in "${!containers[@]}"; do
     service=versiond
     ((index == 0)) || service=versiond2
-    proof=$(read_storage_identity "${containers[index]}") || fail \
-        "cannot read PostgreSQL storage proof through $service;" \
-        "the live gate requires a proof-capable versiond image and a stable migrated HA devshard child"
+    proof=$(read_storage_identity "$service" "${containers[index]}") || exit 1
     validate_storage_identity <<<"$proof" || fail \
         "$service returned an invalid PostgreSQL storage proof"
     observed_identity=$(jq -r '.identity' <<<"$proof")
@@ -226,36 +276,54 @@ done
 [[ -z $expected_identity || $identity == "$expected_identity" ]] || fail \
     "live PostgreSQL identity changed from $expected_identity to $identity"
 
+anchor_container=${containers[0]}
+anchor_snapshot=${snapshots[0]}
+anchor_generation=$(jq -r '.targets[0].generation' <<<"${proofs[0]}")
+final_nonce=
+final_writer_generation=
 for writer_index in "${!containers[@]}"; do
+    writer_service=versiond
+    ((writer_index == 0)) || writer_service=versiond2
     while IFS= read -r writer_generation; do
         nonce=$(new_challenge_nonce)
         response=$(run_storage_challenge \
-            "${containers[writer_index]}" "${snapshots[writer_index]}" \
-            "$writer_generation" write "$nonce") || fail \
-            "cannot write PostgreSQL storage challenge through generation $writer_generation"
+            "$writer_service" "${containers[writer_index]}" \
+            "${snapshots[writer_index]}" "$writer_generation" write "$nonce") || exit 1
         validate_challenge_response \
             "$identity" "${snapshots[writer_index]}" "$writer_generation" \
             <<<"$response" || fail \
             "generation $writer_generation did not confirm its PostgreSQL storage challenge write"
 
-        for reader_index in "${!containers[@]}"; do
-            while IFS= read -r reader_generation; do
-                response=$(run_storage_challenge \
-                    "${containers[reader_index]}" "${snapshots[reader_index]}" \
-                    "$reader_generation" read "$nonce") || fail \
-                    "cannot read PostgreSQL storage challenge through generation $reader_generation"
-                validate_challenge_response \
-                    "$identity" "${snapshots[reader_index]}" "$reader_generation" \
-                    <<<"$response" || fail \
-                    "generation $reader_generation cannot observe the challenge written by generation $writer_generation"
-            done < <(jq -r '.targets[].generation' <<<"${proofs[reader_index]}")
-        done
+        response=$(run_storage_challenge \
+            versiond "$anchor_container" "$anchor_snapshot" \
+            "$anchor_generation" read "$nonce") || exit 1
+        validate_challenge_response \
+            "$identity" "$anchor_snapshot" "$anchor_generation" \
+            <<<"$response" || fail \
+            "anchor generation $anchor_generation cannot observe the challenge written by generation $writer_generation; serialize preflight runs and retry because another run can replace the nonce before diagnosing separate databases"
+        final_nonce=$nonce
+        final_writer_generation=$writer_generation
     done < <(jq -r '.targets[].generation' <<<"${proofs[writer_index]}")
 done
 
+for reader_index in "${!containers[@]}"; do
+    reader_service=versiond
+    ((reader_index == 0)) || reader_service=versiond2
+    while IFS= read -r reader_generation; do
+        response=$(run_storage_challenge \
+            "$reader_service" "${containers[reader_index]}" \
+            "${snapshots[reader_index]}" "$reader_generation" read "$final_nonce") || exit 1
+        validate_challenge_response \
+            "$identity" "${snapshots[reader_index]}" "$reader_generation" \
+            <<<"$response" || fail \
+            "generation $reader_generation cannot observe the final challenge written by generation $final_writer_generation; serialize preflight runs and retry because another run can replace the nonce before diagnosing separate databases"
+    done < <(jq -r '.targets[].generation' <<<"${proofs[reader_index]}")
+done
+
 for index in "${!containers[@]}"; do
-    final_proof=$(read_storage_identity "${containers[index]}") || fail \
-        "cannot re-read PostgreSQL storage proof after the challenge"
+    service=versiond
+    ((index == 0)) || service=versiond2
+    final_proof=$(read_storage_identity "$service" "${containers[index]}") || exit 1
     [[ $(jq -Sc . <<<"$final_proof") == "${proofs[index]}" ]] || fail \
         "PostgreSQL storage generation snapshot changed during the challenge"
 done

--- a/deploy/join/postgres-deployment-preflight.sh
+++ b/deploy/join/postgres-deployment-preflight.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+docker_bin=${DOCKER_BIN:-docker}
+expected_identity=
+compose_args=()
+
+fail() {
+    echo "postgres-deployment-preflight: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: postgres-deployment-preflight.sh [--expected-identity UUID] -- COMPOSE_ARGS...
+
+Example:
+  postgres-deployment-preflight.sh -- \
+    -f docker-compose.yml -f docker-compose.versiond.yml
+
+The command is read-only. It validates the rendered HA PostgreSQL contract and,
+when both versiond containers exist, proves that they reach the same database.
+EOF
+}
+
+while (($#)); do
+    case $1 in
+        --expected-identity)
+            (($# >= 2)) || fail "--expected-identity requires a value"
+            expected_identity=$2
+            shift 2
+            ;;
+        --)
+            shift
+            compose_args=("$@")
+            break
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+((${#compose_args[@]} > 0)) || fail "Compose arguments are required after --"
+command -v "$docker_bin" >/dev/null 2>&1 || fail "$docker_bin is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+compose=("$docker_bin" compose "${compose_args[@]}")
+config=$("${compose[@]}" config --format json) || fail "cannot render Compose topology"
+
+for service in versiond versiond2; do
+    jq -e --arg service "$service" '.services | has($service)' \
+        >/dev/null <<<"$config" || fail "Compose topology has no $service service"
+    mode=$(jq -r --arg service "$service" \
+        '.services[$service].environment.DEVSHARD_STORAGE_MODE // ""' <<<"$config")
+    [[ $mode == postgres ]] || fail "$service must use DEVSHARD_STORAGE_MODE=postgres"
+    for key in DATABASE_URL PGSERVICE PGSERVICEFILE PGOPTIONS; do
+        value=$(jq -r --arg service "$service" --arg key "$key" \
+            '.services[$service].environment[$key] // ""' <<<"$config")
+        [[ -z $value ]] || fail \
+            "$service must not set $key; it can bypass the verified PostgreSQL identity"
+    done
+done
+
+for key in PGHOST PGDATABASE PGUSER; do
+    first=$(jq -r --arg key "$key" \
+        '.services.versiond.environment[$key] // ""' <<<"$config")
+    second=$(jq -r --arg key "$key" \
+        '.services.versiond2.environment[$key] // ""' <<<"$config")
+    [[ -n $first && $first == "$second" ]] || fail \
+        "versiond services must use the same non-empty $key"
+done
+first=$(jq -r '.services.versiond.environment.PGPORT // "5432"' <<<"$config")
+second=$(jq -r '.services.versiond2.environment.PGPORT // "5432"' <<<"$config")
+[[ $first == "$second" ]] || fail "versiond services must use the same PGPORT"
+
+container_env() {
+    local container=$1 name=$2 line
+    while IFS= read -r line; do
+        case $line in
+            "$name="*) printf '%s\n' "${line#*=}"; return 0 ;;
+        esac
+    done < <("$docker_bin" inspect --format \
+        '{{range .Config.Env}}{{println .}}{{end}}' "$container")
+    return 1
+}
+
+containers=()
+for service in versiond versiond2; do
+    container=$("${compose[@]}" ps -q "$service") || fail "cannot inspect $service"
+    containers+=("$container")
+done
+if [[ -z ${containers[0]} && -z ${containers[1]} ]]; then
+    echo "postgres-deployment-preflight: rendered contract is valid; no live replicas to compare"
+    exit 0
+fi
+[[ -n ${containers[0]} && -n ${containers[1]} ]] || fail \
+    "only one versiond replica is running; cannot prove shared PostgreSQL identity"
+
+for index in 0 1; do
+    service=versiond
+    ((index == 0)) || service=versiond2
+    container=${containers[index]}
+    for key in DATABASE_URL PGSERVICE PGSERVICEFILE PGOPTIONS; do
+        value=$(container_env "$container" "$key") || value=
+        [[ -z $value ]] || fail "running $service sets forbidden $key"
+    done
+    for key in PGHOST PGDATABASE PGUSER; do
+        expected=$(jq -r --arg service "$service" --arg key "$key" \
+            '.services[$service].environment[$key] // ""' <<<"$config")
+        actual=$(container_env "$container" "$key") || actual=
+        [[ -n $actual && $actual == "$expected" ]] || fail \
+            "running $service has $key='$actual', rendered topology expects '$expected'"
+    done
+    expected=$(jq -r --arg service "$service" \
+        '.services[$service].environment.PGPORT // "5432"' <<<"$config")
+    actual=$(container_env "$container" PGPORT) || actual=5432
+    [[ -n $actual ]] || actual=5432
+    [[ $actual == "$expected" ]] || fail \
+        "running $service has PGPORT='$actual', rendered topology expects '$expected'"
+done
+
+read_identity() {
+    "$docker_bin" exec "$1" wget -qO- -T 5 \
+        http://127.0.0.1:8080/internal/storage-identity |
+        jq -er '.identity | strings | select(length > 0)'
+}
+
+first=$(read_identity "${containers[0]}") || fail "cannot read identity through versiond"
+second=$(read_identity "${containers[1]}") || fail "cannot read identity through versiond2"
+[[ $first == "$second" ]] || fail "versiond replicas use different PostgreSQL databases"
+[[ -z $expected_identity || $first == "$expected_identity" ]] || fail \
+    "live PostgreSQL identity changed from $expected_identity to $first"
+printf '%s\n' "$first"

--- a/deploy/join/postgres-deployment-preflight.sh
+++ b/deploy/join/postgres-deployment-preflight.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 
 docker_bin=${DOCKER_BIN:-docker}
 expected_identity=
+require_live=false
 compose_args=()
 
 fail() {
@@ -13,14 +14,15 @@ fail() {
 
 usage() {
     cat >&2 <<'EOF'
-Usage: postgres-deployment-preflight.sh [--expected-identity UUID] -- COMPOSE_ARGS...
+Usage: postgres-deployment-preflight.sh [--expected-identity UUID] [--require-live] -- COMPOSE_ARGS...
 
 Example:
   postgres-deployment-preflight.sh -- \
     -f docker-compose.yml -f docker-compose.versiond.yml
 
-The command is read-only. It validates the rendered HA PostgreSQL contract and,
-when both versiond containers exist, proves that they reach the same database.
+The command does not change the deployment. It validates the rendered HA
+PostgreSQL contract and, when both versiond containers exist, exchanges a
+short-lived challenge through every running HA devshard generation.
 EOF
 }
 
@@ -30,6 +32,10 @@ while (($#)); do
             (($# >= 2)) || fail "--expected-identity requires a value"
             expected_identity=$2
             shift 2
+            ;;
+        --require-live)
+            require_live=true
+            shift
             ;;
         --)
             shift
@@ -97,6 +103,8 @@ for service in versiond versiond2; do
     containers+=("$container")
 done
 if [[ -z ${containers[0]} && -z ${containers[1]} ]]; then
+    [[ $require_live == false ]] || fail \
+        "no live versiond replicas; cannot prove shared PostgreSQL storage"
     echo "postgres-deployment-preflight: rendered contract is valid; no live replicas to compare"
     exit 0
 fi
@@ -126,15 +134,119 @@ for index in 0 1; do
         "running $service has PGPORT='$actual', rendered topology expects '$expected'"
 done
 
-read_identity() {
+read_storage_identity() {
     "$docker_bin" exec "$1" wget -qO- -T 5 \
-        http://127.0.0.1:8080/internal/storage-identity |
-        jq -er '.identity | strings | select(length > 0)'
+        http://127.0.0.1:8080/internal/storage-identity
 }
 
-first=$(read_identity "${containers[0]}") || fail "cannot read identity through versiond"
-second=$(read_identity "${containers[1]}") || fail "cannot read identity through versiond2"
-[[ $first == "$second" ]] || fail "versiond replicas use different PostgreSQL databases"
-[[ -z $expected_identity || $first == "$expected_identity" ]] || fail \
-    "live PostgreSQL identity changed from $expected_identity to $first"
-printf '%s\n' "$first"
+validate_storage_identity() {
+    jq -e '
+        . as $proof
+        | ($proof.identity | type == "string" and length > 0)
+          and ($proof.snapshot | type == "string" and length > 0)
+          and ($proof.children | type == "number" and . > 0 and floor == .)
+          and ($proof.targets | type == "array" and length == $proof.children)
+          and ([$proof.targets[].generation] | length == $proof.children)
+          and ([$proof.targets[].generation] | unique | length == $proof.children)
+          and all($proof.targets[];
+              (.generation | type == "string" and length > 0)
+              and (.version | type == "string" and length > 0))
+    ' >/dev/null
+}
+
+run_storage_challenge() {
+    local container=$1 snapshot=$2 generation=$3 operation=$4 nonce=$5
+    local request
+    request=$(jq -cn \
+        --arg operation "$operation" \
+        --arg nonce "$nonce" \
+        --arg snapshot "$snapshot" \
+        --arg generation "$generation" \
+        '{operation:$operation, nonce:$nonce, snapshot:$snapshot, generation:$generation}')
+    "$docker_bin" exec "$container" wget -qO- -T 5 \
+        --header 'Content-Type: application/json' \
+        --post-data "$request" \
+        http://127.0.0.1:8080/internal/storage-challenge
+}
+
+validate_challenge_response() {
+    local identity=$1 snapshot=$2 generation=$3
+    jq -e \
+        --arg identity "$identity" \
+        --arg snapshot "$snapshot" \
+        --arg generation "$generation" '
+        .identity == $identity
+        and .snapshot == $snapshot
+        and .generation == $generation
+        and .found == true
+    ' >/dev/null
+}
+
+new_challenge_nonce() {
+    local nonce
+    [[ -r /proc/sys/kernel/random/uuid ]] || fail \
+        "cannot generate PostgreSQL storage challenge nonce"
+    IFS= read -r nonce </proc/sys/kernel/random/uuid
+    [[ $nonce =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] || fail \
+        "kernel returned an invalid PostgreSQL storage challenge nonce"
+    printf '%s\n' "$nonce"
+}
+
+proofs=()
+snapshots=()
+identity=
+for index in "${!containers[@]}"; do
+    service=versiond
+    ((index == 0)) || service=versiond2
+    proof=$(read_storage_identity "${containers[index]}") || fail \
+        "cannot read PostgreSQL storage proof through $service"
+    validate_storage_identity <<<"$proof" || fail \
+        "$service returned an invalid PostgreSQL storage proof"
+    observed_identity=$(jq -r '.identity' <<<"$proof")
+    if [[ -z $identity ]]; then
+        identity=$observed_identity
+    elif [[ $observed_identity != "$identity" ]]; then
+        fail "versiond replicas use different PostgreSQL database lineages"
+    fi
+    proofs+=("$(jq -Sc . <<<"$proof")")
+    snapshots+=("$(jq -r '.snapshot' <<<"$proof")")
+done
+
+[[ -z $expected_identity || $identity == "$expected_identity" ]] || fail \
+    "live PostgreSQL identity changed from $expected_identity to $identity"
+
+for writer_index in "${!containers[@]}"; do
+    while IFS= read -r writer_generation; do
+        nonce=$(new_challenge_nonce)
+        response=$(run_storage_challenge \
+            "${containers[writer_index]}" "${snapshots[writer_index]}" \
+            "$writer_generation" write "$nonce") || fail \
+            "cannot write PostgreSQL storage challenge through generation $writer_generation"
+        validate_challenge_response \
+            "$identity" "${snapshots[writer_index]}" "$writer_generation" \
+            <<<"$response" || fail \
+            "generation $writer_generation did not confirm its PostgreSQL storage challenge write"
+
+        for reader_index in "${!containers[@]}"; do
+            while IFS= read -r reader_generation; do
+                response=$(run_storage_challenge \
+                    "${containers[reader_index]}" "${snapshots[reader_index]}" \
+                    "$reader_generation" read "$nonce") || fail \
+                    "cannot read PostgreSQL storage challenge through generation $reader_generation"
+                validate_challenge_response \
+                    "$identity" "${snapshots[reader_index]}" "$reader_generation" \
+                    <<<"$response" || fail \
+                    "generation $reader_generation cannot observe the challenge written by generation $writer_generation"
+            done < <(jq -r '.targets[].generation' <<<"${proofs[reader_index]}")
+        done
+    done < <(jq -r '.targets[].generation' <<<"${proofs[writer_index]}")
+done
+
+for index in "${!containers[@]}"; do
+    final_proof=$(read_storage_identity "${containers[index]}") || fail \
+        "cannot re-read PostgreSQL storage proof after the challenge"
+    [[ $(jq -Sc . <<<"$final_proof") == "${proofs[index]}" ]] || fail \
+        "PostgreSQL storage generation snapshot changed during the challenge"
+done
+
+printf '%s\n' "$identity"

--- a/deploy/join/postgres-deployment-preflight.sh
+++ b/deploy/join/postgres-deployment-preflight.sh
@@ -32,6 +32,7 @@ while (($#)); do
     case $1 in
         --expected-identity)
             (($# >= 2)) || fail "--expected-identity requires a value"
+            [[ -n $2 ]] || fail "--expected-identity requires a non-empty value"
             expected_identity=$2
             shift 2
             ;;
@@ -183,12 +184,12 @@ versiond_http() {
             echo "postgres-deployment-preflight: $service $description returned HTTP 404; the running versiond image does not expose the live storage-proof API" >&2
             ;;
         503)
-            echo "postgres-deployment-preflight: $service $description is not ready (HTTP 503); inspect 'docker compose logs $service' for HA child and PostgreSQL state${details:+; details: $details}" >&2
+            echo "postgres-deployment-preflight: $service $description is not ready (HTTP 503); inspect 'docker logs $container' for HA child and PostgreSQL state${details:+; details: $details}" >&2
             ;;
         *)
             lower_details=${details,,}
             if [[ $lower_details == *"timed out"* || $lower_details == *timeout* ]]; then
-                echo "postgres-deployment-preflight: $service $description timed out; inspect 'docker compose logs $service' and PostgreSQL availability" >&2
+                echo "postgres-deployment-preflight: $service $description timed out; inspect 'docker logs $container' and PostgreSQL availability" >&2
             else
                 echo "postgres-deployment-preflight: $service $description request failed${status:+ (HTTP $status)}${details:+: $details}" >&2
             fi

--- a/deploy/join/postgres-deployment-preflight.sh
+++ b/deploy/join/postgres-deployment-preflight.sh
@@ -267,12 +267,12 @@ validate_connection_budget() {
     local supervisors=${#containers[@]}
     local per_child=$((pool_max_connections + 2))
     local per_supervisor=$((
-        per_child + versiond_lookup_pool_max_connections + schema_initializer_connections
+        versiond_lookup_pool_max_connections + schema_initializer_connections
     ))
-    local required=$((total_targets * per_child + supervisors * per_supervisor))
+    local required=$((2 * total_targets * per_child + supervisors * per_supervisor))
     local available=$((server_max - server_reserved))
     ((required <= available)) || fail \
-        "PostgreSQL connection budget is insufficient: $required required for $total_targets current generations, rolling replacements, readiness/fence sessions, versiond lookup, and schema initialization; $available non-reserved connections available"
+        "PostgreSQL connection budget is insufficient: $required required for $total_targets current generations and their concurrently draining predecessors, readiness/fence sessions, versiond lookup, and schema initialization; $available non-reserved connections available"
 }
 
 run_storage_challenge() {

--- a/deploy/join/postgres-deployment-preflight.sh
+++ b/deploy/join/postgres-deployment-preflight.sh
@@ -7,6 +7,8 @@ expected_identity=
 compose_only=false
 compose_args=()
 forbidden_libpq=(DATABASE_URL PGHOSTADDR PGSERVICE PGSERVICEFILE PGOPTIONS)
+versiond_lookup_pool_max_connections=4
+schema_initializer_connections=1
 
 fail() {
     echo "postgres-deployment-preflight: $*" >&2
@@ -62,6 +64,11 @@ done
 command -v "$docker_bin" >/dev/null 2>&1 || fail "$docker_bin is required"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 
+is_positive_int32() {
+    local value=$1
+    [[ $value =~ ^[1-9][0-9]{0,9}$ ]] && ((value <= 2147483647))
+}
+
 compose=("$docker_bin" compose "${compose_args[@]}")
 config=$("${compose[@]}" config --format json) || fail "cannot render Compose topology"
 project_name=$(jq -er '.name | strings | select(length > 0)' <<<"$config") || fail \
@@ -92,6 +99,14 @@ done
 first=$(jq -r '.services.versiond.environment.PGPORT // "5432"' <<<"$config")
 second=$(jq -r '.services.versiond2.environment.PGPORT // "5432"' <<<"$config")
 [[ $first == "$second" ]] || fail "versiond services must use the same PGPORT"
+pool_max_connections=$(jq -r \
+    '.services.versiond.environment.PG_POOL_MAX_CONNS // ""' <<<"$config")
+second=$(jq -r \
+    '.services.versiond2.environment.PG_POOL_MAX_CONNS // ""' <<<"$config")
+is_positive_int32 "$pool_max_connections" || fail \
+    "versiond must set PG_POOL_MAX_CONNS to a positive integer"
+[[ $pool_max_connections == "$second" ]] || fail \
+    "versiond services must use the same PG_POOL_MAX_CONNS"
 
 if [[ $compose_only == true ]]; then
     echo "postgres-deployment-preflight: rendered PostgreSQL contract is valid for Compose project '$project_name'"
@@ -146,6 +161,9 @@ for index in 0 1; do
     [[ -n $actual ]] || actual=5432
     [[ $actual == "$expected" ]] || fail \
         "running $service has PGPORT='$actual', rendered topology expects '$expected'"
+    actual=$(container_env "$runtime_environment" PG_POOL_MAX_CONNS) || actual=
+    [[ $actual == "$pool_max_connections" ]] || fail \
+        "running $service has PG_POOL_MAX_CONNS='$actual', rendered topology expects '$pool_max_connections'"
 done
 
 versiond_http() {
@@ -214,8 +232,47 @@ validate_storage_identity() {
           and ([$proof.targets[].generation] | unique | length == $proof.children)
           and all($proof.targets[];
               (.generation | type == "string" and length > 0)
-              and (.version | type == "string" and length > 0))
+              and (.version | type == "string" and length > 0)
+              and (.pool_max_connections | type == "number" and . > 0 and floor == .)
+              and (.server_max_connections | type == "number" and . > 0 and floor == .)
+              and (.server_reserved_connections | type == "number" and . >= 0 and floor == .)
+              and (.server_reserved_connections < .server_max_connections))
     ' >/dev/null
+}
+
+validate_connection_budget() {
+    local proof generation target_pool target_server_max target_server_reserved
+    local server_max='' server_reserved='' total_targets=0
+
+    for proof in "${proofs[@]}"; do
+        while IFS=$'\t' read -r generation target_pool target_server_max target_server_reserved; do
+            [[ $target_pool == "$pool_max_connections" ]] || fail \
+                "generation $generation reports PostgreSQL pool capacity $target_pool; rendered topology expects $pool_max_connections"
+            if [[ -z $server_max ]]; then
+                server_max=$target_server_max
+                server_reserved=$target_server_reserved
+            elif [[ $target_server_max != "$server_max" || \
+                $target_server_reserved != "$server_reserved" ]]; then
+                fail "PostgreSQL server capacity differs between HA generations"
+            fi
+            ((total_targets += 1))
+        done < <(jq -r '.targets[] | [
+            .generation,
+            .pool_max_connections,
+            .server_max_connections,
+            .server_reserved_connections
+        ] | @tsv' <<<"$proof")
+    done
+
+    local supervisors=${#containers[@]}
+    local per_child=$((pool_max_connections + 2))
+    local per_supervisor=$((
+        per_child + versiond_lookup_pool_max_connections + schema_initializer_connections
+    ))
+    local required=$((total_targets * per_child + supervisors * per_supervisor))
+    local available=$((server_max - server_reserved))
+    ((required <= available)) || fail \
+        "PostgreSQL connection budget is insufficient: $required required for $total_targets current generations, rolling replacements, readiness/fence sessions, versiond lookup, and schema initialization; $available non-reserved connections available"
 }
 
 run_storage_challenge() {
@@ -276,6 +333,7 @@ done
 
 [[ -z $expected_identity || $identity == "$expected_identity" ]] || fail \
     "live PostgreSQL identity changed from $expected_identity to $identity"
+validate_connection_budget
 
 anchor_container=${containers[0]}
 anchor_snapshot=${snapshots[0]}

--- a/deploy/join/postgres-deployment-preflight_test.sh
+++ b/deploy/join/postgres-deployment-preflight_test.sh
@@ -36,16 +36,37 @@ elif [[ $1 == compose && ${*: -3:1} == ps && ${*: -2:1} == -q ]]; then
     esac
 elif [[ $1 == inspect ]]; then
     container=${*: -1}
+    [[ $container != "$INSPECT_FAILURE_CONTAINER" ]] || {
+        echo 'simulated Docker daemon inspect failure' >&2
+        exit 1
+    }
     runtime_host=pg
     [[ $container != container-2 ]] || runtime_host=$RUNTIME_HOST_TWO
-    printf '%s\n' \
-        DEVSHARD_STORAGE_MODE=postgres "PGHOST=$runtime_host" PGPORT=5432 \
-        PGDATABASE=devshardd PGUSER=user "${RUNTIME_EXTRA:-}"
+    jq -cn \
+        --arg host "$runtime_host" \
+        --arg extra "${RUNTIME_EXTRA:-}" '
+        ["DEVSHARD_STORAGE_MODE=postgres", "PGHOST=" + $host, "PGPORT=5432",
+         "PGDATABASE=devshardd", "PGUSER=user"]
+        + (if $extra == "" then [] else [$extra] end)'
 elif [[ $1 == exec ]]; then
     container=$2
     case $PROOF_API_MODE in
         ready) ;;
-        404 | 503) exit 8 ;;
+        404)
+            echo '  HTTP/1.1 404 Not Found' >&2
+            echo 'wget: server returned error: HTTP/1.1 404 Not Found' >&2
+            exit 8
+            ;;
+        503)
+            printf '{"error":"no stable HA children"}\n'
+            echo '  HTTP/1.1 503 Service Unavailable' >&2
+            echo 'wget: server returned error: HTTP/1.1 503 Service Unavailable' >&2
+            exit 8
+            ;;
+        timeout)
+            echo 'wget: download timed out' >&2
+            exit 1
+            ;;
         *) exit 1 ;;
     esac
     if [[ $container == container-1 ]]; then
@@ -71,8 +92,11 @@ elif [[ $1 == exec ]]; then
                 jq -cn \
                     --arg identity "$identity" \
                     --arg snapshot "$snapshot" \
-                    --arg generation "$generation" \
-                    '{identity:$identity,children:1,snapshot:$snapshot,targets:[{generation:$generation,version:"v5"}]}'
+                    --arg generation_prefix "$generation" \
+                    --argjson children "$TARGETS_PER_REPLICA" '
+                    {identity:$identity, children:$children, snapshot:$snapshot,
+                     targets:[range(1; $children + 1)
+                         | {generation:($generation_prefix + "-" + tostring), version:"v5"}]}'
             fi
             ;;
         */internal/storage-challenge)
@@ -88,7 +112,7 @@ elif [[ $1 == exec ]]; then
             operation=$(jq -er '.operation' <<<"$payload")
             nonce=$(jq -er '.nonce' <<<"$payload")
             [[ $(jq -er '.snapshot' <<<"$payload") == "$snapshot" ]] || exit 1
-            [[ $(jq -er '.generation' <<<"$payload") == "$generation" ]] || exit 1
+            generation=$(jq -er '.generation' <<<"$payload")
             found=false
             if [[ $operation == write ]]; then
                 printf '%s\n' "$nonce" >"$CHALLENGE_STATE_DIR/$database"
@@ -128,6 +152,8 @@ run_preflight() {
         LIVE_MODE="${LIVE_MODE:-both}" INVALID_PROOF="${INVALID_PROOF:-none}" \
         SNAPSHOT_DRIFT="${SNAPSHOT_DRIFT:-false}" \
         PROOF_API_MODE="${PROOF_API_MODE:-ready}" \
+        INSPECT_FAILURE_CONTAINER="${INSPECT_FAILURE_CONTAINER:-none}" \
+        TARGETS_PER_REPLICA="${TARGETS_PER_REPLICA:-1}" \
         CHALLENGE_STATE_DIR="$tmpdir/challenge-state" \
         CHALLENGE_LOG="$tmpdir/challenge.log" \
         "$preflight" "$@" -- -f base.yml -f ha.yml
@@ -141,7 +167,16 @@ grep -qx db-1 "$tmpdir/ok" || fail "matching identity was not returned"
 [[ $(grep -c ' write ' "$tmpdir/challenge.log") -eq 2 ]] || fail \
     "preflight did not write through every generation"
 [[ $(grep -c ' read ' "$tmpdir/challenge.log") -eq 4 ]] || fail \
-    "preflight did not read every writer challenge through every generation"
+    "preflight did not connect every writer and reader to the anchor generation"
+
+TARGETS_PER_REPLICA=2
+export TARGETS_PER_REPLICA
+run_preflight >"$tmpdir/linear-proof"
+unset TARGETS_PER_REPLICA
+[[ $(grep -c ' write ' "$tmpdir/challenge.log") -eq 4 ]] || fail \
+    "linear proof did not write through every generation"
+[[ $(grep -c ' read ' "$tmpdir/challenge.log") -eq 8 ]] || fail \
+    "storage proof did not remain linear as generations increased"
 
 if run_preflight --expected-identity other-database \
     >"$tmpdir/out" 2>"$tmpdir/err"; then
@@ -186,6 +221,15 @@ unset RUNTIME_HOST_TWO
 grep -q "running versiond2 has PGHOST='pg-other'" "$tmpdir/err" || fail \
     "runtime-host mismatch was not diagnosed"
 
+INSPECT_FAILURE_CONTAINER=container-1
+export INSPECT_FAILURE_CONTAINER
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "a Docker inspect failure was accepted as missing runtime variables"
+fi
+unset INSPECT_FAILURE_CONTAINER
+grep -q 'cannot inspect runtime environment for versiond container container-1' \
+    "$tmpdir/err" || fail "Docker inspect failure was not diagnosed"
+
 IDENTITY_TWO=db-2
 export IDENTITY_TWO
 if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
@@ -203,6 +247,8 @@ fi
 unset DATABASE_TWO
 grep -q 'cannot observe the challenge' "$tmpdir/err" || fail \
     "independent-database failure was not diagnosed"
+grep -q 'serialize preflight runs and retry' "$tmpdir/err" || fail \
+    "concurrent-preflight ambiguity was not diagnosed"
 
 SNAPSHOT_DRIFT=true
 export SNAPSHOT_DRIFT
@@ -222,14 +268,23 @@ unset INVALID_PROOF
 grep -q 'invalid PostgreSQL storage proof' "$tmpdir/err" || fail \
     "malformed-proof failure was not diagnosed"
 
-for proof_api_mode in 404 503; do
+for proof_api_mode in 404 503 timeout; do
     PROOF_API_MODE=$proof_api_mode
     export PROOF_API_MODE
     if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
         fail "storage-proof endpoint HTTP $proof_api_mode was accepted"
     fi
-    grep -q 'requires a proof-capable versiond image and a stable migrated HA devshard child' \
-        "$tmpdir/err" || fail "storage-proof HTTP $proof_api_mode was not diagnosed"
+    case $proof_api_mode in
+        404) expected_error='does not expose the live storage-proof API' ;;
+        503) expected_error="not ready (HTTP 503); inspect 'docker compose logs versiond'" ;;
+        timeout) expected_error='storage identity timed out' ;;
+    esac
+    grep -Fq "$expected_error" "$tmpdir/err" || fail \
+        "storage-proof $proof_api_mode was not diagnosed"
+    if [[ $proof_api_mode == 503 ]]; then
+        grep -Fq 'HTTP/1.1 503 Service Unavailable' "$tmpdir/err" || fail \
+            "storage-proof HTTP 503 diagnostics were not preserved"
+    fi
 done
 unset PROOF_API_MODE
 

--- a/deploy/join/postgres-deployment-preflight_test.sh
+++ b/deploy/join/postgres-deployment-preflight_test.sh
@@ -15,8 +15,10 @@ fail() {
 write_config() {
     local first_extra=${1:-} second_extra=${2:-${1:-}}
     local first_host=${3:-pg} second_host=${4:-${3:-pg}}
+    local first_pool=${RENDERED_POOL_ONE:-4}
+    local second_pool=${RENDERED_POOL_TWO:-$first_pool}
     cat >"$tmpdir/config.json" <<EOF
-{"name":"preflight-test","services":{"versiond":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$first_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$first_extra}},"versiond2":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$second_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$second_extra}}}}
+{"name":"preflight-test","services":{"versiond":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$first_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user","PG_POOL_MAX_CONNS":"$first_pool"$first_extra}},"versiond2":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$second_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user","PG_POOL_MAX_CONNS":"$second_pool"$second_extra}}}}
 EOF
 }
 
@@ -42,11 +44,14 @@ elif [[ $1 == inspect ]]; then
     }
     runtime_host=pg
     [[ $container != container-2 ]] || runtime_host=$RUNTIME_HOST_TWO
+    runtime_pool=$RUNTIME_POOL_ONE
+    [[ $container != container-2 ]] || runtime_pool=$RUNTIME_POOL_TWO
     jq -cn \
         --arg host "$runtime_host" \
+        --arg pool "$runtime_pool" \
         --arg extra "${RUNTIME_EXTRA:-}" '
         ["DEVSHARD_STORAGE_MODE=postgres", "PGHOST=" + $host, "PGPORT=5432",
-         "PGDATABASE=devshardd", "PGUSER=user"]
+         "PGDATABASE=devshardd", "PGUSER=user", "PG_POOL_MAX_CONNS=" + $pool]
         + (if $extra == "" then [] else [$extra] end)'
 elif [[ $1 == exec ]]; then
     container=$2
@@ -74,11 +79,17 @@ elif [[ $1 == exec ]]; then
         snapshot=snapshot-1
         generation=generation-1
         database=$DATABASE_ONE
+        pool_max_connections=$PROOF_POOL_ONE
+        server_max_connections=$SERVER_MAX_ONE
+        server_reserved_connections=$SERVER_RESERVED_ONE
     else
         identity=$IDENTITY_TWO
         snapshot=snapshot-2
         generation=generation-2
         database=$DATABASE_TWO
+        pool_max_connections=$PROOF_POOL_TWO
+        server_max_connections=$SERVER_MAX_TWO
+        server_reserved_connections=$SERVER_RESERVED_TWO
     fi
     endpoint=${*: -1}
     case $endpoint in
@@ -93,10 +104,16 @@ elif [[ $1 == exec ]]; then
                     --arg identity "$identity" \
                     --arg snapshot "$snapshot" \
                     --arg generation_prefix "$generation" \
+                    --argjson pool_max_connections "$pool_max_connections" \
+                    --argjson server_max_connections "$server_max_connections" \
+                    --argjson server_reserved_connections "$server_reserved_connections" \
                     --argjson children "$TARGETS_PER_REPLICA" '
                     {identity:$identity, children:$children, snapshot:$snapshot,
                      targets:[range(1; $children + 1)
-                         | {generation:($generation_prefix + "-" + tostring), version:"v5"}]}'
+                         | {generation:($generation_prefix + "-" + tostring), version:"v5",
+                            pool_max_connections:$pool_max_connections,
+                            server_max_connections:$server_max_connections,
+                            server_reserved_connections:$server_reserved_connections}]}'
             fi
             ;;
         */internal/storage-challenge)
@@ -149,6 +166,14 @@ run_preflight() {
         IDENTITY_TWO="${IDENTITY_TWO:-db-1}" RUNTIME_EXTRA="${RUNTIME_EXTRA:-}" \
         DATABASE_ONE="${DATABASE_ONE:-shared}" DATABASE_TWO="${DATABASE_TWO:-shared}" \
         RUNTIME_HOST_TWO="${RUNTIME_HOST_TWO:-pg}" \
+        RUNTIME_POOL_ONE="${RUNTIME_POOL_ONE:-4}" \
+        RUNTIME_POOL_TWO="${RUNTIME_POOL_TWO:-4}" \
+        PROOF_POOL_ONE="${PROOF_POOL_ONE:-4}" \
+        PROOF_POOL_TWO="${PROOF_POOL_TWO:-4}" \
+        SERVER_MAX_ONE="${SERVER_MAX_ONE:-100}" \
+        SERVER_MAX_TWO="${SERVER_MAX_TWO:-100}" \
+        SERVER_RESERVED_ONE="${SERVER_RESERVED_ONE:-3}" \
+        SERVER_RESERVED_TWO="${SERVER_RESERVED_TWO:-3}" \
         LIVE_MODE="${LIVE_MODE:-both}" INVALID_PROOF="${INVALID_PROOF:-none}" \
         SNAPSHOT_DRIFT="${SNAPSHOT_DRIFT:-false}" \
         PROOF_API_MODE="${PROOF_API_MODE:-ready}" \
@@ -185,6 +210,27 @@ unset TARGETS_PER_REPLICA
     "linear proof did not write through every generation"
 [[ $(grep -c ' read ' "$tmpdir/challenge.log") -eq 8 ]] || fail \
     "storage proof did not remain linear as generations increased"
+
+RENDERED_POOL_ONE=0
+export RENDERED_POOL_ONE
+write_config
+if run_preflight --compose-only >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "a non-positive rendered PostgreSQL pool limit was accepted"
+fi
+unset RENDERED_POOL_ONE
+grep -q 'must set PG_POOL_MAX_CONNS to a positive integer' "$tmpdir/err" || fail \
+    "invalid rendered PostgreSQL pool limit was not diagnosed"
+
+RENDERED_POOL_TWO=8
+export RENDERED_POOL_TWO
+write_config
+if run_preflight --compose-only >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "different rendered PostgreSQL pool limits were accepted"
+fi
+unset RENDERED_POOL_TWO
+grep -q 'must use the same PG_POOL_MAX_CONNS' "$tmpdir/err" || fail \
+    "rendered PostgreSQL pool-limit mismatch was not diagnosed"
+write_config
 
 if run_preflight --expected-identity other-database \
     >"$tmpdir/out" 2>"$tmpdir/err"; then
@@ -229,6 +275,15 @@ unset RUNTIME_HOST_TWO
 grep -q "running versiond2 has PGHOST='pg-other'" "$tmpdir/err" || fail \
     "runtime-host mismatch was not diagnosed"
 
+RUNTIME_POOL_TWO=8
+export RUNTIME_POOL_TWO
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "runtime PostgreSQL pool-limit drift was accepted"
+fi
+unset RUNTIME_POOL_TWO
+grep -q "running versiond2 has PG_POOL_MAX_CONNS='8'" "$tmpdir/err" || fail \
+    "runtime PostgreSQL pool-limit mismatch was not diagnosed"
+
 INSPECT_FAILURE_CONTAINER=container-1
 export INSPECT_FAILURE_CONTAINER
 if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
@@ -246,6 +301,34 @@ fi
 unset IDENTITY_TWO
 grep -q 'different PostgreSQL database lineages' "$tmpdir/err" ||
     fail "identity mismatch was not diagnosed"
+
+PROOF_POOL_TWO=8
+export PROOF_POOL_TWO
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "a child pool larger than the rendered contract was accepted"
+fi
+unset PROOF_POOL_TWO
+grep -q 'reports PostgreSQL pool capacity 8' "$tmpdir/err" || fail \
+    "live child-pool mismatch was not diagnosed"
+
+SERVER_MAX_TWO=99
+export SERVER_MAX_TWO
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "different PostgreSQL server capacities were accepted"
+fi
+unset SERVER_MAX_TWO
+grep -q 'server capacity differs between HA generations' "$tmpdir/err" || fail \
+    "PostgreSQL server-capacity mismatch was not diagnosed"
+
+SERVER_MAX_ONE=35
+SERVER_MAX_TWO=35
+export SERVER_MAX_ONE SERVER_MAX_TWO
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "an insufficient PostgreSQL connection budget was accepted"
+fi
+unset SERVER_MAX_ONE SERVER_MAX_TWO
+grep -q 'connection budget is insufficient: 34 required' "$tmpdir/err" || fail \
+    "insufficient PostgreSQL connection budget was not diagnosed"
 
 DATABASE_TWO=clone
 export DATABASE_TWO

--- a/deploy/join/postgres-deployment-preflight_test.sh
+++ b/deploy/join/postgres-deployment-preflight_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+preflight="$script_dir/postgres-deployment-preflight.sh"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+fail() {
+    echo "postgres-deployment-preflight_test: $*" >&2
+    exit 1
+}
+
+write_config() {
+    local extra=${1:-}
+    cat >"$tmpdir/config.json" <<EOF
+{"services":{"versiond":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"pg","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$extra}},"versiond2":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"pg","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$extra}}}}
+EOF
+}
+
+cat >"$tmpdir/docker" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%q ' "$@" >>"$DOCKER_LOG"
+printf '\n' >>"$DOCKER_LOG"
+if [[ $1 == compose && ${*: -3} == "config --format json" ]]; then
+    cat "$CONFIG_JSON"
+elif [[ $1 == compose && ${*: -3:1} == ps && ${*: -2:1} == -q ]]; then
+    [[ ${*: -1} == versiond ]] && printf 'container-1\n' || printf 'container-2\n'
+elif [[ $1 == inspect ]]; then
+    printf '%s\n' \
+        DEVSHARD_STORAGE_MODE=postgres PGHOST=pg PGPORT=5432 \
+        PGDATABASE=devshardd PGUSER=user "${RUNTIME_EXTRA:-}"
+elif [[ $1 == exec ]]; then
+    identity=$IDENTITY_ONE
+    [[ $2 == container-1 ]] || identity=$IDENTITY_TWO
+    printf '{"identity":"%s"}\n' "$identity"
+else
+    exit 1
+fi
+EOF
+chmod +x "$tmpdir/docker"
+
+run_preflight() {
+    : >"$tmpdir/docker.log"
+    DOCKER_BIN="$tmpdir/docker" DOCKER_LOG="$tmpdir/docker.log" \
+        CONFIG_JSON="$tmpdir/config.json" IDENTITY_ONE="${IDENTITY_ONE:-db-1}" \
+        IDENTITY_TWO="${IDENTITY_TWO:-db-1}" RUNTIME_EXTRA="${RUNTIME_EXTRA:-}" \
+        "$preflight" "$@" -- -f base.yml -f ha.yml
+}
+
+write_config
+run_preflight --expected-identity db-1 >"$tmpdir/ok"
+grep -qx db-1 "$tmpdir/ok" || fail "matching identity was not returned"
+! grep -Eq '(^| )((up|start|stop|rm|down|create|update))( |$)' "$tmpdir/docker.log" ||
+    fail "preflight attempted a deployment mutation"
+
+write_config ',"PGOPTIONS":"-c search_path=other"'
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "rendered PGOPTIONS bypass was accepted"
+fi
+grep -q PGOPTIONS "$tmpdir/err" || fail "PGOPTIONS failure was not diagnosed"
+
+write_config
+RUNTIME_EXTRA='PGOPTIONS=-c search_path=other'
+export RUNTIME_EXTRA
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "running PGOPTIONS bypass was accepted"
+fi
+unset RUNTIME_EXTRA
+grep -q PGOPTIONS "$tmpdir/err" || fail "runtime PGOPTIONS failure was not diagnosed"
+
+IDENTITY_TWO=db-2
+export IDENTITY_TWO
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "different live database identities were accepted"
+fi
+unset IDENTITY_TWO
+grep -q 'different PostgreSQL databases' "$tmpdir/err" ||
+    fail "identity mismatch was not diagnosed"
+
+echo "postgres-deployment-preflight_test: ok"

--- a/deploy/join/postgres-deployment-preflight_test.sh
+++ b/deploy/join/postgres-deployment-preflight_test.sh
@@ -169,6 +169,14 @@ grep -qx db-1 "$tmpdir/ok" || fail "matching identity was not returned"
 [[ $(grep -c ' read ' "$tmpdir/challenge.log") -eq 4 ]] || fail \
     "preflight did not connect every writer and reader to the anchor generation"
 
+if run_preflight --expected-identity '' >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "an explicitly empty expected identity was accepted"
+fi
+grep -q -- '--expected-identity requires a non-empty value' "$tmpdir/err" || fail \
+    "empty expected identity was not diagnosed"
+[[ ! -s $tmpdir/docker.log ]] || fail \
+    "empty expected identity reached Docker before argument validation"
+
 TARGETS_PER_REPLICA=2
 export TARGETS_PER_REPLICA
 run_preflight >"$tmpdir/linear-proof"
@@ -276,7 +284,7 @@ for proof_api_mode in 404 503 timeout; do
     fi
     case $proof_api_mode in
         404) expected_error='does not expose the live storage-proof API' ;;
-        503) expected_error="not ready (HTTP 503); inspect 'docker compose logs versiond'" ;;
+        503) expected_error="not ready (HTTP 503); inspect 'docker logs container-1'" ;;
         timeout) expected_error='storage identity timed out' ;;
     esac
     grep -Fq "$expected_error" "$tmpdir/err" || fail \

--- a/deploy/join/postgres-deployment-preflight_test.sh
+++ b/deploy/join/postgres-deployment-preflight_test.sh
@@ -34,6 +34,9 @@ elif [[ $1 == compose && ${*: -3:1} == ps && ${*: -2:1} == -q ]]; then
     case $LIVE_MODE:$service in
         both:versiond) printf 'container-1\n' ;;
         both:versiond2) printf 'container-2\n' ;;
+        three:versiond) printf 'container-1\n' ;;
+        three:versiond2) printf 'container-2\n' ;;
+        three:versiond3) printf 'container-3\n' ;;
         one:versiond) printf 'container-1\n' ;;
     esac
 elif [[ $1 == inspect ]]; then
@@ -425,7 +428,7 @@ if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
     fail "preflight passed with only one versiond replica"
 fi
 unset LIVE_MODE
-grep -q 'has only one running versiond replica' "$tmpdir/err" || fail \
+grep -q 'has only 1 of 2 versiond replicas running' "$tmpdir/err" || fail \
     "partial-replica failure was not diagnosed"
 
 write_config
@@ -434,8 +437,20 @@ mv "$tmpdir/config-without-versiond2.json" "$tmpdir/config.json"
 if run_preflight --compose-only >"$tmpdir/out" 2>"$tmpdir/err"; then
     fail "Compose topology without versiond2 was accepted"
 fi
-grep -q 'Compose topology has no versiond2 service' "$tmpdir/err" || fail \
+grep -q 'needs at least two versiond services' "$tmpdir/err" || fail \
     "missing versiond2 service was not diagnosed"
+
+# Three local replicas: every service is discovered, checked, and challenged.
+write_config
+jq '.services.versiond3 = .services.versiond2' "$tmpdir/config.json" >"$tmpdir/config-three.json"
+mv "$tmpdir/config-three.json" "$tmpdir/config.json"
+LIVE_MODE=three run_preflight >"$tmpdir/out" 2>"$tmpdir/err" || \
+    fail "three-replica preflight failed: $(cat "$tmpdir/err")"
+unset LIVE_MODE
+grep -q '^container-3 write ' "$tmpdir/challenge.log" || fail \
+    "the third replica was not challenged"
+[[ $(<"$tmpdir/out") == db-1 ]] || fail \
+    "three-replica preflight did not print the shared identity"
 
 real_docker_bin=${REAL_DOCKER_BIN:-docker}
 command -v "$real_docker_bin" >/dev/null 2>&1 || fail \

--- a/deploy/join/postgres-deployment-preflight_test.sh
+++ b/deploy/join/postgres-deployment-preflight_test.sh
@@ -16,7 +16,7 @@ write_config() {
     local first_extra=${1:-} second_extra=${2:-${1:-}}
     local first_host=${3:-pg} second_host=${4:-${3:-pg}}
     cat >"$tmpdir/config.json" <<EOF
-{"services":{"versiond":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$first_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$first_extra}},"versiond2":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$second_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$second_extra}}}}
+{"name":"preflight-test","services":{"versiond":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$first_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$first_extra}},"versiond2":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$second_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$second_extra}}}}
 EOF
 }
 
@@ -43,6 +43,11 @@ elif [[ $1 == inspect ]]; then
         PGDATABASE=devshardd PGUSER=user "${RUNTIME_EXTRA:-}"
 elif [[ $1 == exec ]]; then
     container=$2
+    case $PROOF_API_MODE in
+        ready) ;;
+        404 | 503) exit 8 ;;
+        *) exit 1 ;;
+    esac
     if [[ $container == container-1 ]]; then
         identity=$IDENTITY_ONE
         snapshot=snapshot-1
@@ -122,6 +127,7 @@ run_preflight() {
         RUNTIME_HOST_TWO="${RUNTIME_HOST_TWO:-pg}" \
         LIVE_MODE="${LIVE_MODE:-both}" INVALID_PROOF="${INVALID_PROOF:-none}" \
         SNAPSHOT_DRIFT="${SNAPSHOT_DRIFT:-false}" \
+        PROOF_API_MODE="${PROOF_API_MODE:-ready}" \
         CHALLENGE_STATE_DIR="$tmpdir/challenge-state" \
         CHALLENGE_LOG="$tmpdir/challenge.log" \
         "$preflight" "$@" -- -f base.yml -f ha.yml
@@ -144,7 +150,7 @@ fi
 grep -q 'changed from other-database to db-1' "$tmpdir/err" || fail \
     "expected-identity failure was not diagnosed"
 
-for key in DATABASE_URL PGSERVICE PGSERVICEFILE PGOPTIONS; do
+for key in DATABASE_URL PGHOSTADDR PGSERVICE PGSERVICEFILE PGOPTIONS; do
     write_config ",\"$key\":\"override\""
     if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
         fail "rendered $key bypass was accepted"
@@ -216,17 +222,41 @@ unset INVALID_PROOF
 grep -q 'invalid PostgreSQL storage proof' "$tmpdir/err" || fail \
     "malformed-proof failure was not diagnosed"
 
+for proof_api_mode in 404 503; do
+    PROOF_API_MODE=$proof_api_mode
+    export PROOF_API_MODE
+    if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+        fail "storage-proof endpoint HTTP $proof_api_mode was accepted"
+    fi
+    grep -q 'requires a proof-capable versiond image and a stable migrated HA devshard child' \
+        "$tmpdir/err" || fail "storage-proof HTTP $proof_api_mode was not diagnosed"
+done
+unset PROOF_API_MODE
+
 LIVE_MODE=none
 export LIVE_MODE
-run_preflight >"$tmpdir/no-live"
-grep -q 'no live replicas to compare' "$tmpdir/no-live" || fail \
-    "configuration-only preflight did not explain the missing replicas"
-if run_preflight --require-live >"$tmpdir/out" 2>"$tmpdir/err"; then
-    fail "--require-live passed without versiond replicas"
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "live preflight passed without versiond replicas"
 fi
+grep -q "Compose project 'preflight-test' has no running versiond replicas" \
+    "$tmpdir/err" || fail "missing-project replicas were not diagnosed"
+if run_preflight --expected-identity db-1 >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "--expected-identity passed without a live identity"
+fi
+grep -q "has no running versiond replicas" "$tmpdir/err" || fail \
+    "missing expected identity was not diagnosed"
+run_preflight --compose-only >"$tmpdir/compose-only"
+grep -q "rendered PostgreSQL contract is valid for Compose project 'preflight-test'" \
+    "$tmpdir/compose-only" || fail "explicit Compose-only validation failed"
+! grep -q ' ps -q ' "$tmpdir/docker.log" || fail \
+    "Compose-only validation inspected runtime containers"
+if run_preflight --compose-only --expected-identity db-1 \
+    >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "--compose-only accepted --expected-identity"
+fi
+grep -q -- '--expected-identity requires the live PostgreSQL proof' "$tmpdir/err" ||
+    fail "incompatible Compose-only options were not diagnosed"
 unset LIVE_MODE
-grep -q 'cannot prove shared PostgreSQL storage' "$tmpdir/err" || fail \
-    "required-live failure was not diagnosed"
 
 LIVE_MODE=one
 export LIVE_MODE
@@ -234,7 +264,32 @@ if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
     fail "preflight passed with only one versiond replica"
 fi
 unset LIVE_MODE
-grep -q 'only one versiond replica is running' "$tmpdir/err" || fail \
+grep -q 'has only one running versiond replica' "$tmpdir/err" || fail \
     "partial-replica failure was not diagnosed"
+
+write_config
+jq 'del(.services.versiond2)' "$tmpdir/config.json" >"$tmpdir/config-without-versiond2.json"
+mv "$tmpdir/config-without-versiond2.json" "$tmpdir/config.json"
+if run_preflight --compose-only >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "Compose topology without versiond2 was accepted"
+fi
+grep -q 'Compose topology has no versiond2 service' "$tmpdir/err" || fail \
+    "missing versiond2 service was not diagnosed"
+
+real_docker_bin=${REAL_DOCKER_BIN:-docker}
+command -v "$real_docker_bin" >/dev/null 2>&1 || fail \
+    "$real_docker_bin is required for the real Compose render test"
+(
+    cd "$script_dir"
+    DEVSHARD_POSTGRES_PASSWORD=preflight-test \
+        DOCKER_BIN="$real_docker_bin" "$preflight" --compose-only -- \
+        --project-name postgres-preflight-render-test \
+        -f docker-compose.yml -f docker-compose.versiond.yml
+) >"$tmpdir/real-compose" 2>"$tmpdir/real-compose-err" || {
+    cat "$tmpdir/real-compose-err" >&2
+    fail "the real join Compose topology did not pass configuration validation"
+}
+grep -q "Compose project 'postgres-preflight-render-test'" "$tmpdir/real-compose" ||
+    fail "the real Compose project name was not preserved"
 
 echo "postgres-deployment-preflight_test: ok"

--- a/deploy/join/postgres-deployment-preflight_test.sh
+++ b/deploy/join/postgres-deployment-preflight_test.sh
@@ -13,9 +13,10 @@ fail() {
 }
 
 write_config() {
-    local extra=${1:-}
+    local first_extra=${1:-} second_extra=${2:-${1:-}}
+    local first_host=${3:-pg} second_host=${4:-${3:-pg}}
     cat >"$tmpdir/config.json" <<EOF
-{"services":{"versiond":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"pg","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$extra}},"versiond2":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"pg","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$extra}}}}
+{"services":{"versiond":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$first_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$first_extra}},"versiond2":{"environment":{"DEVSHARD_STORAGE_MODE":"postgres","PGHOST":"$second_host","PGPORT":"5432","PGDATABASE":"devshardd","PGUSER":"user"$second_extra}}}}
 EOF
 }
 
@@ -27,26 +28,102 @@ printf '\n' >>"$DOCKER_LOG"
 if [[ $1 == compose && ${*: -3} == "config --format json" ]]; then
     cat "$CONFIG_JSON"
 elif [[ $1 == compose && ${*: -3:1} == ps && ${*: -2:1} == -q ]]; then
-    [[ ${*: -1} == versiond ]] && printf 'container-1\n' || printf 'container-2\n'
+    service=${*: -1}
+    case $LIVE_MODE:$service in
+        both:versiond) printf 'container-1\n' ;;
+        both:versiond2) printf 'container-2\n' ;;
+        one:versiond) printf 'container-1\n' ;;
+    esac
 elif [[ $1 == inspect ]]; then
+    container=${*: -1}
+    runtime_host=pg
+    [[ $container != container-2 ]] || runtime_host=$RUNTIME_HOST_TWO
     printf '%s\n' \
-        DEVSHARD_STORAGE_MODE=postgres PGHOST=pg PGPORT=5432 \
+        DEVSHARD_STORAGE_MODE=postgres "PGHOST=$runtime_host" PGPORT=5432 \
         PGDATABASE=devshardd PGUSER=user "${RUNTIME_EXTRA:-}"
 elif [[ $1 == exec ]]; then
-    identity=$IDENTITY_ONE
-    [[ $2 == container-1 ]] || identity=$IDENTITY_TWO
-    printf '{"identity":"%s"}\n' "$identity"
+    container=$2
+    if [[ $container == container-1 ]]; then
+        identity=$IDENTITY_ONE
+        snapshot=snapshot-1
+        generation=generation-1
+        database=$DATABASE_ONE
+    else
+        identity=$IDENTITY_TWO
+        snapshot=snapshot-2
+        generation=generation-2
+        database=$DATABASE_TWO
+    fi
+    endpoint=${*: -1}
+    case $endpoint in
+        */internal/storage-identity)
+            if [[ $SNAPSHOT_DRIFT == true && -f $CHALLENGE_STATE_DIR/challenged ]]; then
+                snapshot=$snapshot-drift
+            fi
+            if [[ $INVALID_PROOF == "$container" ]]; then
+                printf '{"identity":"%s"}\n' "$identity"
+            else
+                jq -cn \
+                    --arg identity "$identity" \
+                    --arg snapshot "$snapshot" \
+                    --arg generation "$generation" \
+                    '{identity:$identity,children:1,snapshot:$snapshot,targets:[{generation:$generation,version:"v5"}]}'
+            fi
+            ;;
+        */internal/storage-challenge)
+            payload=
+            for ((index = 1; index <= $#; index++)); do
+                if [[ ${!index} == --post-data ]]; then
+                    next=$((index + 1))
+                    payload=${!next}
+                    break
+                fi
+            done
+            [[ -n $payload ]] || exit 1
+            operation=$(jq -er '.operation' <<<"$payload")
+            nonce=$(jq -er '.nonce' <<<"$payload")
+            [[ $(jq -er '.snapshot' <<<"$payload") == "$snapshot" ]] || exit 1
+            [[ $(jq -er '.generation' <<<"$payload") == "$generation" ]] || exit 1
+            found=false
+            if [[ $operation == write ]]; then
+                printf '%s\n' "$nonce" >"$CHALLENGE_STATE_DIR/$database"
+                touch "$CHALLENGE_STATE_DIR/challenged"
+                found=true
+            elif [[ $operation == read && -f $CHALLENGE_STATE_DIR/$database && \
+                $(<"$CHALLENGE_STATE_DIR/$database") == "$nonce" ]]; then
+                found=true
+            fi
+            printf '%s %s %s\n' "$container" "$operation" "$generation" \
+                >>"$CHALLENGE_LOG"
+            jq -cn \
+                --arg identity "$identity" \
+                --arg snapshot "$snapshot" \
+                --arg generation "$generation" \
+                --argjson found "$found" \
+                '{identity:$identity,found:$found,children:1,snapshot:$snapshot,generation:$generation}'
+            ;;
+        *) exit 1 ;;
+    esac
 else
     exit 1
 fi
 EOF
 chmod +x "$tmpdir/docker"
+mkdir "$tmpdir/challenge-state"
 
 run_preflight() {
     : >"$tmpdir/docker.log"
+    : >"$tmpdir/challenge.log"
+    find "$tmpdir/challenge-state" -type f -delete
     DOCKER_BIN="$tmpdir/docker" DOCKER_LOG="$tmpdir/docker.log" \
         CONFIG_JSON="$tmpdir/config.json" IDENTITY_ONE="${IDENTITY_ONE:-db-1}" \
         IDENTITY_TWO="${IDENTITY_TWO:-db-1}" RUNTIME_EXTRA="${RUNTIME_EXTRA:-}" \
+        DATABASE_ONE="${DATABASE_ONE:-shared}" DATABASE_TWO="${DATABASE_TWO:-shared}" \
+        RUNTIME_HOST_TWO="${RUNTIME_HOST_TWO:-pg}" \
+        LIVE_MODE="${LIVE_MODE:-both}" INVALID_PROOF="${INVALID_PROOF:-none}" \
+        SNAPSHOT_DRIFT="${SNAPSHOT_DRIFT:-false}" \
+        CHALLENGE_STATE_DIR="$tmpdir/challenge-state" \
+        CHALLENGE_LOG="$tmpdir/challenge.log" \
         "$preflight" "$@" -- -f base.yml -f ha.yml
 }
 
@@ -55,21 +132,53 @@ run_preflight --expected-identity db-1 >"$tmpdir/ok"
 grep -qx db-1 "$tmpdir/ok" || fail "matching identity was not returned"
 ! grep -Eq '(^| )((up|start|stop|rm|down|create|update))( |$)' "$tmpdir/docker.log" ||
     fail "preflight attempted a deployment mutation"
+[[ $(grep -c ' write ' "$tmpdir/challenge.log") -eq 2 ]] || fail \
+    "preflight did not write through every generation"
+[[ $(grep -c ' read ' "$tmpdir/challenge.log") -eq 4 ]] || fail \
+    "preflight did not read every writer challenge through every generation"
 
-write_config ',"PGOPTIONS":"-c search_path=other"'
-if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
-    fail "rendered PGOPTIONS bypass was accepted"
+if run_preflight --expected-identity other-database \
+    >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "an unexpected live database lineage was accepted"
 fi
-grep -q PGOPTIONS "$tmpdir/err" || fail "PGOPTIONS failure was not diagnosed"
+grep -q 'changed from other-database to db-1' "$tmpdir/err" || fail \
+    "expected-identity failure was not diagnosed"
+
+for key in DATABASE_URL PGSERVICE PGSERVICEFILE PGOPTIONS; do
+    write_config ",\"$key\":\"override\""
+    if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+        fail "rendered $key bypass was accepted"
+    fi
+    grep -q "$key" "$tmpdir/err" || fail \
+        "rendered $key failure was not diagnosed"
+
+    write_config
+    RUNTIME_EXTRA="$key=override"
+    export RUNTIME_EXTRA
+    if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+        fail "running $key bypass was accepted"
+    fi
+    unset RUNTIME_EXTRA
+    grep -q "$key" "$tmpdir/err" || fail \
+        "runtime $key failure was not diagnosed"
+done
+
+write_config '' '' pg pg-other
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "different rendered PostgreSQL hosts were accepted"
+fi
+grep -q 'same non-empty PGHOST' "$tmpdir/err" || fail \
+    "rendered-host mismatch was not diagnosed"
 
 write_config
-RUNTIME_EXTRA='PGOPTIONS=-c search_path=other'
-export RUNTIME_EXTRA
+RUNTIME_HOST_TWO=pg-other
+export RUNTIME_HOST_TWO
 if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
-    fail "running PGOPTIONS bypass was accepted"
+    fail "runtime PostgreSQL host drift was accepted"
 fi
-unset RUNTIME_EXTRA
-grep -q PGOPTIONS "$tmpdir/err" || fail "runtime PGOPTIONS failure was not diagnosed"
+unset RUNTIME_HOST_TWO
+grep -q "running versiond2 has PGHOST='pg-other'" "$tmpdir/err" || fail \
+    "runtime-host mismatch was not diagnosed"
 
 IDENTITY_TWO=db-2
 export IDENTITY_TWO
@@ -77,7 +186,55 @@ if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
     fail "different live database identities were accepted"
 fi
 unset IDENTITY_TWO
-grep -q 'different PostgreSQL databases' "$tmpdir/err" ||
+grep -q 'different PostgreSQL database lineages' "$tmpdir/err" ||
     fail "identity mismatch was not diagnosed"
+
+DATABASE_TWO=clone
+export DATABASE_TWO
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "independent databases with a cloned identity passed the live challenge"
+fi
+unset DATABASE_TWO
+grep -q 'cannot observe the challenge' "$tmpdir/err" || fail \
+    "independent-database failure was not diagnosed"
+
+SNAPSHOT_DRIFT=true
+export SNAPSHOT_DRIFT
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "a generation change during the challenge was accepted"
+fi
+unset SNAPSHOT_DRIFT
+grep -q 'generation snapshot changed' "$tmpdir/err" || fail \
+    "generation-snapshot failure was not diagnosed"
+
+INVALID_PROOF=container-2
+export INVALID_PROOF
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "a malformed storage proof was accepted"
+fi
+unset INVALID_PROOF
+grep -q 'invalid PostgreSQL storage proof' "$tmpdir/err" || fail \
+    "malformed-proof failure was not diagnosed"
+
+LIVE_MODE=none
+export LIVE_MODE
+run_preflight >"$tmpdir/no-live"
+grep -q 'no live replicas to compare' "$tmpdir/no-live" || fail \
+    "configuration-only preflight did not explain the missing replicas"
+if run_preflight --require-live >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "--require-live passed without versiond replicas"
+fi
+unset LIVE_MODE
+grep -q 'cannot prove shared PostgreSQL storage' "$tmpdir/err" || fail \
+    "required-live failure was not diagnosed"
+
+LIVE_MODE=one
+export LIVE_MODE
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "preflight passed with only one versiond replica"
+fi
+unset LIVE_MODE
+grep -q 'only one versiond replica is running' "$tmpdir/err" || fail \
+    "partial-replica failure was not diagnosed"
 
 echo "postgres-deployment-preflight_test: ok"

--- a/deploy/join/postgres-deployment-preflight_test.sh
+++ b/deploy/join/postgres-deployment-preflight_test.sh
@@ -205,11 +205,26 @@ grep -q -- '--expected-identity requires a non-empty value' "$tmpdir/err" || fai
 TARGETS_PER_REPLICA=2
 export TARGETS_PER_REPLICA
 run_preflight >"$tmpdir/linear-proof"
-unset TARGETS_PER_REPLICA
 [[ $(grep -c ' write ' "$tmpdir/challenge.log") -eq 4 ]] || fail \
     "linear proof did not write through every generation"
 [[ $(grep -c ' read ' "$tmpdir/challenge.log") -eq 8 ]] || fail \
     "storage proof did not remain linear as generations increased"
+
+SERVER_MAX_ONE=55
+SERVER_MAX_TWO=55
+export SERVER_MAX_ONE SERVER_MAX_TWO
+if run_preflight >"$tmpdir/out" 2>"$tmpdir/err"; then
+    fail "a connection budget covering only one rolling generation per replica was accepted"
+fi
+grep -q 'connection budget is insufficient: 58 required for 4 current generations' \
+    "$tmpdir/err" || fail "all-version rolling overlap was not included in the connection budget"
+
+SERVER_MAX_ONE=61
+SERVER_MAX_TWO=61
+run_preflight >"$tmpdir/exact-capacity"
+grep -qx db-1 "$tmpdir/exact-capacity" || fail \
+    "the exact all-version rolling connection budget was rejected"
+unset TARGETS_PER_REPLICA SERVER_MAX_ONE SERVER_MAX_TWO
 
 RENDERED_POOL_ONE=0
 export RENDERED_POOL_ONE

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -68,7 +68,8 @@ live check. Do not omit the expected identity to accept an unexpected database;
 an intentional replacement belongs to a new recovery transaction after the old
 database has been restored or its loss has been explicitly accepted.
 
-The live mode requires both versiond replicas and at least one stable HA child.
+The live mode requires every versiond replica in the model (at least two) to
+be running and at least one stable HA child.
 It verifies the shared lineage UUID and connects every generation's writer and
 reader to one anchor generation with short-lived challenges. This linear proof
 detects an independent database while reducing the time in which a child restart

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -89,13 +89,29 @@ not applied the storage-identity migrations returns 503. These responses fail
 closed. The release updater therefore runs `--compose-only` before service
 replacement, starts compatible versiond/devshard generations behind the
 existing traffic path, and runs the live gate before router admission or public
-cutover.
+cutover. The Compose-only phase validates structure and connection selectors;
+image capabilities, downloaded devshard artifacts, credentials, and live
+connectivity are established by the staged candidate and the live phase while
+the updater still owns the rollback baseline.
 
 The live result is a point-in-time admission proof, not a PostgreSQL monitor.
 Run it immediately before admission and do not replace generations between the
 proof and cutover. After admission, the session fence and readiness lifecycle
 from the storage implementation withdraw and restart a child that loses its
 database fence.
+
+The lineage UUID and challenge do not select a recovery point. A backup or
+clone of the same database retains its UUID, and a single shared writable clone
+can satisfy the challenge. Backup freshness, restore approval, and fencing the
+operator-selected PostgreSQL primary remain properties of the database recovery
+procedure. The expected identity prevents an unrelated lineage from being
+admitted; it must not be treated as proof that a restored copy contains every
+session written after that backup.
+
+Storage proof is one gate in admission, not the final fleet-ready signal. The
+release updater separately verifies that every desired route has the required
+number of admitted router replicas before committing the cutover. A successful
+storage proof therefore cannot make a partial version catalog production-ready.
 
 These commands are deployment gates, not a standalone replacement procedure.
 The release updater keeps the old traffic path and rollback baseline until the

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -53,15 +53,27 @@ After proof-capable versiond images and migrated HA devshard children are
 running, perform the live gate before admitting the new topology to production:
 
 ```bash
-./postgres-deployment-preflight.sh --expected-identity "$RECORDED_STORAGE_IDENTITY" -- \
+marker=${DEVSHARD_V5_UPGRADE_MARKER:-.gonka-devshard-v5-upgrade-complete}
+recorded_identity=$(jq -er '.storage.postgres_identity' "$marker")
+./postgres-deployment-preflight.sh --expected-identity "$recorded_identity" -- \
   -f docker-compose.yml -f docker-compose.versiond.yml
 ```
 
 Omit `--expected-identity` only when no storage identity has been committed by
-an earlier successful deployment. The live mode requires both versiond
-replicas. It verifies the shared lineage UUID, writes a unique short-lived
-challenge through every stable HA child generation, requires every other
-generation to read it, and rejects child replacement during the proof.
+an earlier successful deployment. The release updater stores the successful
+identity under `.storage.postgres_identity` in its atomic completion marker and
+reuses it on later runs. A standalone deployment must persist the UUID printed
+on stdout in root-protected deployment state and supply it on every subsequent
+live check. Do not omit the expected identity to accept an unexpected database;
+an intentional replacement belongs to a new recovery transaction after the old
+database has been restored or its loss has been explicitly accepted.
+
+The live mode requires both versiond replicas and at least one stable HA child.
+It verifies the shared lineage UUID and connects every generation's writer and
+reader to one anchor generation with short-lived challenges. This linear proof
+detects an independent database while reducing the time in which a child restart
+can invalidate the snapshot. A final snapshot read rejects replacement during
+the proof.
 
 Both commands must receive the exact Compose files, project directory, and
 project name used by the host. Preserve an existing `-p`/`--project-name` or
@@ -75,6 +87,33 @@ closed. The release updater therefore runs `--compose-only` before service
 replacement, starts compatible versiond/devshard generations behind the
 existing traffic path, and runs the live gate before router admission or public
 cutover.
+
+The live result is a point-in-time admission proof, not a PostgreSQL monitor.
+Run it immediately before admission and do not replace generations between the
+proof and cutover. After admission, the session fence and readiness lifecycle
+from the storage implementation withdraw and restart a child that loses its
+database fence.
+
+These commands are deployment gates, not a standalone replacement procedure.
+The release updater keeps the old traffic path and rollback baseline until the
+live phase succeeds. If PostgreSQL, either versiond replica, or its stable HA
+child fails after `--compose-only`, keep HA admission disabled, repair the
+candidate or restore its captured generation, and rerun the live phase. There is
+no one-replica bypass. A catalog containing only explicitly non-HA children has
+no shared HA workload to prove, so HA admission remains disabled until a stable
+HA child exists.
+
+Serialize live checks. Concurrent runs share one transient challenge field and
+can overwrite each other's nonce, producing a safe failure that must be retried
+before diagnosing separate databases. A generation change also fails the
+single attempt; wait for the fleet to stabilize and rerun. The updater that
+invokes this gate must hold the host deployment lock and apply an outer command
+deadline so a stalled Docker daemon cannot suspend the deployment transaction.
+
+Host-side prerequisites are Linux, `jq`, and Docker Compose 2.24.4 or newer.
+The live phase uses the versiond image's `/bin/busybox wget` command against its
+loopback admin listener. This matches the image healthcheck contract and keeps
+the proof API inaccessible from the deployment network.
 
 For a detached legacy volume, attach
 `docker-compose.versiond-postgres-recovery.yml` temporarily and set

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -39,25 +39,42 @@ it is not a permanent “HA was enabled” marker. It can disappear after every
 PostgreSQL session has drained, so downloaded versiond artifacts remain a
 conservative guard for that ambiguous state.
 
-Before changing an existing HA topology, validate the rendered and running
-PostgreSQL contract without changing the deployment:
+The PostgreSQL gate has two explicit phases. Before replacing services, validate
+the rendered target topology without reading runtime state:
 
 ```bash
 cd deploy/join
 source ./config.env
-./postgres-deployment-preflight.sh -- \
+./postgres-deployment-preflight.sh --compose-only -- \
   -f docker-compose.yml -f docker-compose.versiond.yml
 ```
 
-The command requires both versiond replicas to use PostgreSQL and rejects libpq
-overrides that can bypass the rendered DSN. It first verifies the shared lineage
-UUID, then writes a unique short-lived challenge through every stable HA child
-generation and requires every other generation to read it. A final snapshot
-check rejects child replacement during the proof. The command prints the
-verified UUID; `--expected-identity UUID` additionally prevents switching away
-from a lineage recorded by an earlier successful upgrade, and `--require-live`
-rejects a configuration-only result when the deployment gate requires running
-replicas.
+After proof-capable versiond images and migrated HA devshard children are
+running, perform the live gate before admitting the new topology to production:
+
+```bash
+./postgres-deployment-preflight.sh --expected-identity "$RECORDED_STORAGE_IDENTITY" -- \
+  -f docker-compose.yml -f docker-compose.versiond.yml
+```
+
+Omit `--expected-identity` only when no storage identity has been committed by
+an earlier successful deployment. The live mode requires both versiond
+replicas. It verifies the shared lineage UUID, writes a unique short-lived
+challenge through every stable HA child generation, requires every other
+generation to read it, and rejects child replacement during the proof.
+
+Both commands must receive the exact Compose files, project directory, and
+project name used by the host. Preserve an existing `-p`/`--project-name` or
+`COMPOSE_PROJECT_NAME`; selecting another project fails because its live
+replicas cannot satisfy the gate.
+
+The live endpoints are supplied by the versiond and devshard changes that this
+preflight depends on. A legacy versiond image returns 404, and a child that has
+not applied the storage-identity migrations returns 503. These responses fail
+closed. The release updater therefore runs `--compose-only` before service
+replacement, starts compatible versiond/devshard generations behind the
+existing traffic path, and runs the live gate before router admission or public
+cutover.
 
 For a detached legacy volume, attach
 `docker-compose.versiond-postgres-recovery.yml` temporarily and set

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -75,8 +75,9 @@ detects an independent database while reducing the time in which a child restart
 can invalidate the snapshot. A final snapshot read rejects replacement during
 the proof. It also verifies that every child uses the rendered application-pool
 limit and that PostgreSQL has enough non-reserved connections for the current
-children, one rolling replacement on each versiond replica, readiness and fence
-sessions, versiond lookups, and concurrent schema initializers.
+children, a concurrently draining predecessor for every current generation,
+readiness and fence sessions, versiond lookups, and concurrent schema
+initializers.
 
 Both commands must receive the exact Compose files, project directory, and
 project name used by the host. Preserve an existing `-p`/`--project-name` or

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -40,7 +40,7 @@ PostgreSQL session has drained, so downloaded versiond artifacts remain a
 conservative guard for that ambiguous state.
 
 Before changing an existing HA topology, validate the rendered and running
-PostgreSQL contract without mutating it:
+PostgreSQL contract without changing the deployment:
 
 ```bash
 cd deploy/join
@@ -49,11 +49,15 @@ source ./config.env
   -f docker-compose.yml -f docker-compose.versiond.yml
 ```
 
-The command requires both versiond replicas to use PostgreSQL, rejects libpq
-overrides that can bypass the rendered DSN, compares their live storage UUIDs,
-and prints the verified UUID. Release tooling calls the same gate automatically;
-`--expected-identity UUID` additionally prevents switching away from a database
-recorded by an earlier successful upgrade.
+The command requires both versiond replicas to use PostgreSQL and rejects libpq
+overrides that can bypass the rendered DSN. It first verifies the shared lineage
+UUID, then writes a unique short-lived challenge through every stable HA child
+generation and requires every other generation to read it. A final snapshot
+check rejects child replacement during the proof. The command prints the
+verified UUID; `--expected-identity UUID` additionally prevents switching away
+from a lineage recorded by an earlier successful upgrade, and `--require-live`
+rejects a configuration-only result when the deployment gate requires running
+replicas.
 
 For a detached legacy volume, attach
 `docker-compose.versiond-postgres-recovery.yml` temporarily and set

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -39,6 +39,22 @@ it is not a permanent “HA was enabled” marker. It can disappear after every
 PostgreSQL session has drained, so downloaded versiond artifacts remain a
 conservative guard for that ambiguous state.
 
+Before changing an existing HA topology, validate the rendered and running
+PostgreSQL contract without mutating it:
+
+```bash
+cd deploy/join
+source ./config.env
+./postgres-deployment-preflight.sh -- \
+  -f docker-compose.yml -f docker-compose.versiond.yml
+```
+
+The command requires both versiond replicas to use PostgreSQL, rejects libpq
+overrides that can bypass the rendered DSN, compares their live storage UUIDs,
+and prints the verified UUID. Release tooling calls the same gate automatically;
+`--expected-identity UUID` additionally prevents switching away from a database
+recorded by an earlier successful upgrade.
+
 For a detached legacy volume, attach
 `docker-compose.versiond-postgres-recovery.yml` temporarily and set
 `DEVSHARD_POSTGRES_LEGACY_VOLUME` to that volume's exact Docker name. Run

--- a/devshard/docs/postgres-persistence-migration.md
+++ b/devshard/docs/postgres-persistence-migration.md
@@ -73,7 +73,10 @@ It verifies the shared lineage UUID and connects every generation's writer and
 reader to one anchor generation with short-lived challenges. This linear proof
 detects an independent database while reducing the time in which a child restart
 can invalidate the snapshot. A final snapshot read rejects replacement during
-the proof.
+the proof. It also verifies that every child uses the rendered application-pool
+limit and that PostgreSQL has enough non-reserved connections for the current
+children, one rolling replacement on each versiond replica, readiness and fence
+sessions, versiond lookups, and concurrent schema initializers.
 
 Both commands must receive the exact Compose files, project directory, and
 project name used by the host. Preserve an existing `-p`/`--project-name` or

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -474,11 +474,12 @@ down after boot.
   replicas.
 - The live deployment gate checks that capacity before admission. For `N`
   current HA children, `R` versiond replicas, and application-pool limit `P`, it
-  requires `N * (P + 2) + R * ((P + 2) + 4 + 1)` non-reserved server
-  connections. The second term reserves one overlapping rolling generation,
-  the four-connection versiond session-lookup pool, and one schema-initializer
-  connection per replica. Other applications sharing an external PostgreSQL
-  server remain the database operator's capacity responsibility.
+  requires `2 * N * (P + 2) + R * (4 + 1)` non-reserved server connections.
+  The doubled child term allows every updated version to keep its predecessor
+  alive during asynchronous drain. The per-replica term reserves the
+  four-connection versiond session-lookup pool and one schema-initializer
+  connection. Other applications sharing an external PostgreSQL server remain
+  the database operator's capacity responsibility.
 - Migration bootstrap and all pending application steps are serialized by a
   database-scoped advisory lock. Before starting children in an HA deployment,
   versiond runs `devshardd --initialize-postgres-schema` through a current

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -476,7 +476,9 @@ down after boot.
   current HA children, `R` versiond replicas, and application-pool limit `P`, it
   requires `2 * N * (P + 2) + R * (4 + 1)` non-reserved server connections.
   The doubled child term allows every updated version to keep its predecessor
-  alive during asynchronous drain. The per-replica term reserves the
+  alive during asynchronous drain. Versiond enforces this bound by deferring a
+  second same-name replacement until the first predecessor has finished
+  draining. The per-replica term reserves the
   four-connection versiond session-lookup pool and one schema-initializer
   connection. Other applications sharing an external PostgreSQL server remain
   the database operator's capacity responsibility.

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -472,6 +472,13 @@ down after boot.
   transiently opens a separate pool. External PostgreSQL capacity planning must
   include every simultaneously running child generation on both versiond
   replicas.
+- The live deployment gate checks that capacity before admission. For `N`
+  current HA children, `R` versiond replicas, and application-pool limit `P`, it
+  requires `N * (P + 2) + R * ((P + 2) + 4 + 1)` non-reserved server
+  connections. The second term reserves one overlapping rolling generation,
+  the four-connection versiond session-lookup pool, and one schema-initializer
+  connection per replica. Other applications sharing an external PostgreSQL
+  server remain the database operator's capacity responsibility.
 - Migration bootstrap and all pending application steps are serialized by a
   database-scoped advisory lock. Before starting children in an HA deployment,
   versiond runs `devshardd --initialize-postgres-schema` through a current

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -510,20 +510,22 @@ down after boot.
   challenge detects divergent children when deployment preflight runs; neither
   mechanism elects a PostgreSQL primary or replaces database-layer consensus.
 - HA deployment preflight obtains a stable generation snapshot from each
-  versiond replica. For every HA-routed child generation across those snapshots,
-  it writes a unique random nonce through that one child's application pool and
-  requires every other generation to read it. Each operation names its child
-  generation and carries the original snapshot token; transitional generations
-  and changed snapshots fail closed. Every operation also requires
-  `pg_is_in_recovery() = false`. This catches independent clones, read replicas,
-  cross-wired protocol versions, and configuration differences between a
-  supervisor and its children. A final snapshot read closes the transaction.
-  Deployment tooling serializes the exchange; concurrent challenges can cause
-  only a safe false negative because each write replaces the previous nonce.
-  It must wait for preparing, swapping, and draining generations to settle. On
-  the first rollout it must start a current artifact and initialize the schema
-  before requiring proof support from the fleet; legacy children do not expose
-  the proof API.
+  versiond replica and selects one generation as the proof anchor. Every
+  HA-routed generation writes a unique random nonce through its application pool
+  and the anchor reads it; every generation then reads the final confirmed
+  nonce. This proves that all writers and readers share the anchor's live state
+  with a linear number of requests. Each operation names its child generation
+  and carries the original snapshot token; transitional generations and changed
+  snapshots fail closed. Every operation also requires `pg_is_in_recovery() =
+  false`. This catches independent clones, read replicas, cross-wired protocol
+  versions, and configuration differences between a supervisor and its
+  children. A final snapshot read closes the transaction.
+  Deployment tooling must serialize the exchange; concurrent challenges can
+  cause only a safe false negative because each write replaces the previous
+  nonce. It must wait for preparing, swapping, and draining generations to
+  settle. On the first rollout it must start a current artifact and initialize
+  the schema before requiring proof support from the fleet; legacy children do
+  not expose the proof API.
 - Live readiness uses one dedicated PostgreSQL connection outside the
   application pool. Two consecutive database failures make `/readyz` return
   `503` without terminating devshardd; two successful probes restore readiness.

--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -493,7 +493,10 @@ down after boot.
   PostgreSQL barrier.
 - `devshard_storage_identity.identity` is a durable database-lineage marker.
   Copies restored from one backup retain the same marker, so equality alone is
-  not proof that two hosts currently share a database.
+  not proof that two hosts currently share a database. The live challenge
+  proves that candidate children share one writable state at admission time; it
+  does not establish backup freshness or choose the operator-approved recovery
+  point.
 - Each devshard process also holds a unique session-scoped PostgreSQL advisory
   fence before serving. Every connection subsequently created by its application
   pool must observe that fence in `pg_locks` and report a writable primary before
@@ -532,7 +535,9 @@ down after boot.
   nonce. It must wait for preparing, swapping, and draining generations to
   settle. On the first rollout it must start a current artifact and initialize
   the schema before requiring proof support from the fleet; legacy children do
-  not expose the proof API.
+  not expose the proof API. Route-catalog completeness and minimum-ready replica
+  counts are separate admission checks performed by the router deployment
+  tooling after storage proof succeeds.
 - Live readiness uses one dedicated PostgreSQL connection outside the
   application pool. Two consecutive database failures make `/readyz` return
   `503` without terminating devshardd; two successful probes restore readiness.

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -454,7 +454,7 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 				version:        v,
 				overrideSrc:    overrideSrc,
 				binPath:        binPath,
-				blockedByDrain: !isRunning && isDraining,
+				blockedByDrain: isDraining,
 			})
 			continue
 		}
@@ -510,6 +510,10 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 		if snap.isRunning {
 			matches, metadata, diskBinaryHash, stateErr := installedVersionMatches(filepath.Dir(snap.child.binPath), snap.child.binPath, desiredHash)
 			if stateErr == nil && matches {
+				continue
+			}
+			if snap.isDraining {
+				slog.Info("version replacement deferred while previous child is draining", "version", snap.version.Name)
 				continue
 			}
 			logInstalledVersionMismatch(
@@ -568,11 +572,16 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 		m.downloading[a.version.Name] = struct{}{}
 		scheduledDownloads = append(scheduledDownloads, a)
 	}
+	scheduledSwaps := make([]versionAction, 0, len(toSwap))
 	for _, a := range toSwap {
 		if _, already := m.downloading[a.version.Name]; already {
 			continue
 		}
+		if current, running := m.processes[a.version.Name]; !running || current != a.child || m.versionStartBlockedLocked(a.version.Name) {
+			continue
+		}
 		m.downloading[a.version.Name] = struct{}{}
+		scheduledSwaps = append(scheduledSwaps, a)
 	}
 
 	var toStop []*child
@@ -586,7 +595,7 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 		}
 	}
 
-	changed := len(scheduledDownloads) > 0 || len(toSwap) > 0 || len(toStop) > 0 || started > 0
+	changed := len(scheduledDownloads) > 0 || len(scheduledSwaps) > 0 || len(toStop) > 0 || started > 0
 	if changed {
 		m.rebuildRoutes()
 	}
@@ -613,7 +622,7 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 
 	// Download first, then overlap generations where their storage permits it;
 	// otherwise the stop/start path withdraws the old route before stopping it.
-	for _, a := range toSwap {
+	for _, a := range scheduledSwaps {
 		if err := m.downloadAndSwap(ctx, a.version, a.sha256, a.child); err != nil {
 			slog.Error("swap failed, keeping old version", "version", a.version.Name, "error", err)
 			actionErrs = append(actionErrs, fmt.Errorf("swap %s: %w", a.version.Name, err))
@@ -631,8 +640,9 @@ type versionAction struct {
 	child   *child // non-nil for swap actions
 }
 
-// versionStartBlockedLocked reports whether a retired generation with the same
-// version name still owns the version's data directory.
+// versionStartBlockedLocked reports whether a predecessor with the same version
+// name is still draining. Besides protecting the version's data directory, this
+// bounds each version to one current generation and one predecessor.
 func (m *Manager) versionStartBlockedLocked(name string) bool {
 	return len(m.draining[name]) > 0
 }
@@ -689,6 +699,11 @@ func (m *Manager) reconcileOverride(ctx context.Context, v oracle.Version, overr
 		if m.hostDraining {
 			m.mu.Unlock()
 			return ErrHostDraining
+		}
+		if m.versionStartBlockedLocked(v.Name) {
+			m.mu.Unlock()
+			slog.Info("override replacement deferred while previous child is draining", "version", v.Name)
+			return nil
 		}
 		proxyDrained, retired := m.retireChildForStopStartLocked(existing)
 		m.mu.Unlock()
@@ -924,8 +939,9 @@ func (m *Manager) downloadAndStart(ctx context.Context, v oracle.Version, sha st
 }
 
 // downloadAndSwap downloads the new binary. Shared-storage generations overlap:
-// the replacement starts on a fresh port before the route swap. Other storage
-// modes withdraw and drain the old route before a stop/start replacement.
+// the replacement starts on a fresh port before the route swap, with at most one
+// predecessor per version. Other storage modes withdraw and drain the old route
+// before a stop/start replacement.
 func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha string, old *child) error {
 	dlErr := m.downloadBinary(ctx, v, sha)
 	if dlErr != nil || ctx.Err() != nil {
@@ -944,6 +960,17 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 		delete(m.downloading, v.Name)
 		m.mu.Unlock()
 		return ErrHostDraining
+	}
+	if current, running := m.processes[v.Name]; !running || current != old {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		return fmt.Errorf("current child changed before replacement start")
+	}
+	if m.versionStartBlockedLocked(v.Name) {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		slog.Info("version replacement deferred while previous child is draining", "version", v.Name)
+		return nil
 	}
 	m.mu.Unlock()
 	preflight, err := preflightChildWithAdminProbeContext(
@@ -1008,6 +1035,17 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 		delete(m.downloading, v.Name)
 		m.mu.Unlock()
 		return ErrHostDraining
+	}
+	if current, running := m.processes[v.Name]; !running || current != old {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		return fmt.Errorf("current child changed before replacement start")
+	}
+	if m.versionStartBlockedLocked(v.Name) {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		slog.Info("version replacement deferred while previous child is draining", "version", v.Name)
+		return nil
 	}
 	newChild, startErr := m.newChild(ctx, v, sha, newBinPath, false)
 	if startErr != nil {

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -1660,6 +1660,66 @@ esac
 	}
 }
 
+func TestReconcile_RunningVersionWaitsForDrainingPredecessorBeforeNextSHA(t *testing.T) {
+	dir := t.TempDir()
+	zipData, archiveHash := zipBinary(t, "testapp", []byte("replacement binary"))
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write(zipData)
+	}))
+	defer srv.Close()
+
+	m := NewManager(config.Config{
+		BinDir:     filepath.Join(dir, "bin"),
+		DataDir:    filepath.Join(dir, "data"),
+		BinaryName: "testapp",
+		BasePort:   5000,
+	})
+	current := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: sha256Hex([]byte("current archive")),
+		binPath:       filepath.Join(dir, "missing-current-binary"),
+		port:          9001,
+		status:        statusRunning,
+		restart:       true,
+	}
+	predecessor := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: sha256Hex([]byte("predecessor archive")),
+		port:          9000,
+		status:        statusDraining,
+	}
+	m.processes["v1"] = current
+	m.draining["v1"] = []*child{predecessor}
+
+	err := m.Reconcile(context.Background(), []oracle.Version{{
+		Name:   "v1",
+		Binary: srv.URL,
+		SHA256: archiveHash,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("download requests while predecessor drains = %d, want 0", got)
+	}
+	m.mu.Lock()
+	gotCurrent := m.processes["v1"]
+	draining := len(m.draining["v1"])
+	_, downloading := m.downloading["v1"]
+	m.mu.Unlock()
+	if gotCurrent != current {
+		t.Fatal("running generation changed while its predecessor was draining")
+	}
+	if draining != 1 {
+		t.Fatalf("draining generations = %d, want 1", draining)
+	}
+	if downloading {
+		t.Fatal("replacement was scheduled while its predecessor was draining")
+	}
+}
+
 func TestDownloadAndStart_DoesNotOverlapDrainingChild(t *testing.T) {
 	dir := t.TempDir()
 	zipData, archiveHash := zipBinary(t, "testapp", []byte("test binary"))
@@ -2625,6 +2685,65 @@ esac
 	routes := m.RouteTable().Load().(proxy.RouteTable)
 	if routes["v1"].Address() != "localhost:9001" {
 		t.Fatalf("route = %q, want old child route", routes["v1"].Address())
+	}
+}
+
+func TestDownloadAndSwap_DrainingPredecessorDefersReplacementStart(t *testing.T) {
+	dir := t.TempDir()
+	zipData, archiveHash := zipBinary(t, "testapp", []byte("replacement binary"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(zipData)
+	}))
+	defer srv.Close()
+
+	m := NewManager(config.Config{
+		BinDir:     filepath.Join(dir, "bin"),
+		DataDir:    filepath.Join(dir, "data"),
+		BinaryName: "testapp",
+		BasePort:   6200,
+	})
+	current := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: sha256Hex([]byte("current archive")),
+		port:          9001,
+		status:        statusRunning,
+		restart:       true,
+	}
+	predecessor := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: sha256Hex([]byte("predecessor archive")),
+		port:          9000,
+		status:        statusDraining,
+	}
+	m.processes["v1"] = current
+	m.draining["v1"] = []*child{predecessor}
+	m.downloading["v1"] = struct{}{}
+
+	err := m.downloadAndSwap(context.Background(), oracle.Version{
+		Name:   "v1",
+		Binary: srv.URL,
+		SHA256: archiveHash,
+	}, archiveHash, current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.mu.Lock()
+	gotCurrent := m.processes["v1"]
+	draining := len(m.draining["v1"])
+	children := len(m.children)
+	_, downloading := m.downloading["v1"]
+	m.mu.Unlock()
+	if gotCurrent != current {
+		t.Fatal("running generation changed while its predecessor was draining")
+	}
+	if draining != 1 {
+		t.Fatalf("draining generations = %d, want 1", draining)
+	}
+	if children != 0 {
+		t.Fatalf("replacement children started = %d, want 0", children)
+	}
+	if downloading {
+		t.Fatal("download marker was not cleared after replacement deferral")
 	}
 }
 

--- a/versioned/internal/process/storage_proof.go
+++ b/versioned/internal/process/storage_proof.go
@@ -131,8 +131,7 @@ func (m *Manager) StorageIdentity(ctx context.Context) (StorageProof, error) {
 }
 
 // StorageChallenge addresses exactly one child generation. Deployment tooling
-// repeats this for every writer and asks every target to read that writer's
-// unique nonce.
+// connects every generation's writer and reader to one live proof anchor.
 func (m *Manager) StorageChallenge(
 	ctx context.Context,
 	snapshotToken string,


### PR DESCRIPTION
> This focused PR is based on the PostgreSQL deployment-safety work originally implemented in the closed umbrella PRs #1517 and #1587.

## Merge Order

Merge this PR after #1607, **Prove shared PostgreSQL storage through devshard children**.

The branch is stacked on #1607. Once that PR is merged, its commits will disappear from this PR's effective diff.

## Summary

Add a two-phase deployment gate for the PostgreSQL contract used by HA devshard generations:

1. `--compose-only` validates the complete target Compose model before service replacement.
2. The default live phase verifies the running candidate through its real devshard application pools before router admission or public cutover.

This lets an existing host validate target configuration before mutation while keeping the decisive storage check tied to the processes that will receive production traffic.

## Compose Contract

The configuration phase:

- renders the exact operator-selected Compose model;
- requires both `versiond` services to use PostgreSQL storage mode;
- compares PostgreSQL host, port, database, user, and `PG_POOL_MAX_CONNS` settings;
- requires the two replicas to use the same positive application-pool limit;
- rejects `DATABASE_URL`, `PGHOSTADDR`, `PGSERVICE`, `PGSERVICEFILE`, and `PGOPTIONS` overrides;
- succeeds without runtime state only when `--compose-only` is explicit.

Both phases use the Compose project selected by the supplied arguments. Custom installations must preserve the same project directory, ordered files, and `-p`/`--project-name` or `COMPOSE_PROJECT_NAME` used by the running deployment.

## Live Storage Proof

The live phase requires both running versiond replicas and at least one stable HA child. It:

- compares rendered PostgreSQL settings with each running container;
- reads the lineage UUID and immutable generation snapshot from both replicas;
- writes a unique challenge through every stable HA devshard generation;
- requires one anchor generation to observe every writer;
- requires every generation to observe the final anchor-confirmed challenge;
- re-reads both snapshots so generation replacement during the proof fails closed;
- optionally requires a previously committed lineage UUID with `--expected-identity`;
- requires every live child to report the rendered pool limit and one consistent PostgreSQL server capacity;
- rejects a connection budget that cannot hold the current children, a concurrently draining predecessor for every current generation, readiness/fence sessions, versiond lookup pools, and schema initializers.

Versiond enforces the corresponding runtime bound per version name. While a
predecessor is draining, a later same-name SHA or override remains pending; the
manager rechecks that condition under its lock before scheduling and starting a
replacement. A version therefore has at most one current generation and one
draining predecessor, including during rapid consecutive catalog updates.

A matching UUID alone is insufficient because a database clone preserves it. The linear anchor proof establishes shared live state through every application pool in O(N) requests, while #1607's session fence rejects pool connections to a different writable database branch.

The proof updates only transient challenge fields in `devshard_storage_identity`. It does not start, stop, recreate, or reroute services.

## Proof Boundary

The live exchange proves that the candidate generations share one writable state at that moment. It does not select a PostgreSQL recovery point: a backup or clone of the same lineage keeps the UUID, and one common writable clone can pass the challenge. Backup freshness, restore approval, and single-writer fencing remain part of the PostgreSQL recovery contract.

`--compose-only` validates topology and connection selectors. Target image capabilities, downloaded devshard artifacts, credentials, and connectivity are checked after the updater starts candidates behind the existing traffic path and before it releases rollback.

Storage proof is not the final route-admission signal. The updater separately verifies desired route coverage and minimum-ready router replicas before committing cutover.

## Failure Handling

Runtime inspection now fails closed if Docker cannot return a container environment. Storage API failures distinguish:

- HTTP 404: the running versiond image lacks the proof API;
- HTTP 503: the candidate has no stable proof-capable HA child or PostgreSQL is unavailable;
- request timeout or transport failure.

Diagnostics point to the affected service logs. Concurrent preflights can overwrite the shared transient nonce, so their safe false-negative explicitly asks the operator to serialize and retry before diagnosing separate databases.

The result is a point-in-time admission proof. The updater must hold the host deployment lock, retain the old traffic path and rollback baseline, run the live phase immediately before admission, and apply an outer command deadline. A failed replica is repaired or rolled back before retrying; there is no one-replica bypass that could claim an unproven HA topology is safe.

## Identity Continuity

The release updater stores a successful UUID under `.storage.postgres_identity` in its atomic completion marker and supplies it on later runs. Standalone users must persist the UUID printed on stdout in root-protected deployment state. An intentional database replacement starts a new recovery transaction after restoration or explicit acceptance of the old database's loss.

## Bootstrap Contract

The proof endpoints come from #1607. A legacy versiond image returns 404, and a child that has not applied the storage migrations returns 503. The release sequence is therefore:

1. run `--compose-only` against the target topology;
2. replace versiond replicas behind the existing traffic path;
3. wait for proof-capable migrated HA children;
4. run the live proof with the previously committed identity when one exists;
5. admit the router fleet and perform public cutover.

#1611 is a required release dependency: it supplies locking, staged candidate replacement, rollback retention, marker persistence, route admission, and the outer deadline around this gate. Host-side prerequisites are Linux, `jq`, and Docker Compose 2.24.4 or newer.

## Validation

- `shellcheck deploy/join/postgres-deployment-preflight.sh deploy/join/postgres-deployment-preflight_test.sh`
- `deploy/join/postgres-deployment-preflight_test.sh`
- `deploy/join/devshard-postgres-entrypoint_test.sh`
- `deploy/join/devshard-postgres-migration-preflight_test.sh`
- `deploy/join/devshard-postgres-upgrade_test.sh`
- `go test -race ./cmd/versiond ./internal/process ./internal/sessionversion` in `versioned`
- `go test -race ./cmd/devshardd ./cmd/devshardd/session ./storage/...` in `devshard`

The preflight suite covers the real join Compose render, linear proof scaling, cloned databases with matching UUIDs, snapshot drift, malformed proof responses, pool-limit drift, inconsistent server capacity, insufficient all-version rolling connection budget, distinct 404/503/timeout diagnostics, Docker inspection failure, expected identity without live replicas, absent and partial projects, missing services, rendered/runtime connection drift, and every forbidden libpq override. Versiond manager tests additionally cover a running generation with a draining predecessor when another SHA arrives, plus a predecessor that appears between replacement planning and child start.
