### PR TITLE
feat(gateway): forward reasoning_effort to vllm

### DIFF
--- a/devshard/cmd/devshardctl/paramvalidators/handlers.go
+++ b/devshard/cmd/devshardctl/paramvalidators/handlers.go
@@ -153,6 +153,19 @@ func (h ForceLiteralParameter) HandleParameter(ctx ParameterContext) error {
 	return nil
 }
 
+// DefaultLiteralParameter writes Value only when absent, so a route default never overrules the caller.
+type DefaultLiteralParameter struct {
+	Value any
+}
+
+func (h DefaultLiteralParameter) HandleParameter(ctx ParameterContext) error {
+	if _, exists := ctx.Document[ctx.Parameter]; exists {
+		return nil
+	}
+	ctx.Document[ctx.Parameter] = h.Value
+	return nil
+}
+
 // CapUintParameter caps a uint64-shaped field to Max.
 type CapUintParameter struct {
 	Min uint64

--- a/devshard/cmd/devshardctl/paramvalidators/reasoning.go
+++ b/devshard/cmd/devshardctl/paramvalidators/reasoning.go
@@ -13,7 +13,9 @@ func (v ReasoningValidator) Validate(vctx ValidatorContext) error {
 	if !ok {
 		return nil
 	}
+	// Record the refusal: on a route that defaults the effort, absent reads as unspecified.
 	if enabled, ok := inner["enabled"].(bool); ok && !enabled {
+		vctx.Document["reasoning_effort"] = "none"
 		return nil
 	}
 	effort, hasEffort := inner["effort"]

--- a/devshard/cmd/devshardctl/paramvalidators/reasoning_effort.go
+++ b/devshard/cmd/devshardctl/paramvalidators/reasoning_effort.go
@@ -10,9 +10,6 @@ var (
 	ErrReasoningEffortValue = errors.New("reasoning_effort: unsupported value")
 )
 
-// Re-check the strip wiring in the catalog whenever a reasoning-capable model is
-// added to devshard: today every routed model is non-reasoning so the catalog
-// strips reasoning_effort for all of them via ModelScopedParameterHandler{Models: nil}.
 type ReasoningEffortValidator struct{}
 
 var allowedReasoningEffortValues = map[string]struct{}{
@@ -22,6 +19,7 @@ var allowedReasoningEffortValues = map[string]struct{}{
 	"medium":  {},
 	"high":    {},
 	"xhigh":   {},
+	"max":     {}, // DeepSeek-V4 only
 }
 
 func (v ReasoningEffortValidator) Validate(vctx ValidatorContext) error {

--- a/devshard/cmd/devshardctl/paramvalidators/reasoning_effort_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/reasoning_effort_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestReasoningEffortValidatorAccepts(t *testing.T) {
 	v := ReasoningEffortValidator{}
-	for _, value := range []string{"none", "minimal", "low", "medium", "high", "xhigh"} {
+	for _, value := range []string{"none", "minimal", "low", "medium", "high", "xhigh", "max"} {
 		t.Run(value, func(t *testing.T) {
 			doc := parseDocument(t, `{"reasoning_effort":"`+value+`"}`)
 			require.NoError(t, v.Validate(ValidatorContext{Document: doc}))
@@ -34,7 +34,7 @@ func TestReasoningEffortValidatorRejects(t *testing.T) {
 		{name: "not a string (bool)", body: `{"reasoning_effort":true}`, wantErr: ErrReasoningEffortShape},
 		{name: "not a string (null)", body: `{"reasoning_effort":null}`, wantErr: ErrReasoningEffortShape},
 		{name: "not a string (object)", body: `{"reasoning_effort":{"effort":"high"}}`, wantErr: ErrReasoningEffortShape},
-		{name: "unknown enum value", body: `{"reasoning_effort":"max"}`, wantErr: ErrReasoningEffortValue},
+		{name: "unknown enum value", body: `{"reasoning_effort":"maximum"}`, wantErr: ErrReasoningEffortValue},
 		{name: "wrong case", body: `{"reasoning_effort":"High"}`, wantErr: ErrReasoningEffortValue},
 		{name: "empty string", body: `{"reasoning_effort":""}`, wantErr: ErrReasoningEffortValue},
 	}

--- a/devshard/cmd/devshardctl/paramvalidators/reasoning_test.go
+++ b/devshard/cmd/devshardctl/paramvalidators/reasoning_test.go
@@ -28,14 +28,16 @@ func TestReasoningValidatorDropsNonEffortKeys(t *testing.T) {
 	require.Equal(t, "medium", doc["reasoning_effort"])
 }
 
-func TestReasoningValidatorEnabledFalseDropsEverything(t *testing.T) {
+// Dropping the wrapper without a trace would leave the request indistinguishable from one that never
+// mentioned reasoning, which a route defaulting the effort reads as permission to fill it in.
+func TestReasoningValidatorEnabledFalseRecordsTheRefusal(t *testing.T) {
 	v := ReasoningValidator{}
 	doc := parseDocument(t, `{"reasoning":{"enabled":false,"effort":"high"}}`)
 
 	require.NoError(t, v.Validate(ValidatorContext{Document: doc}))
 
 	require.NotContains(t, doc, "reasoning")
-	require.NotContains(t, doc, "reasoning_effort", "enabled:false must override any effort")
+	require.Equal(t, "none", doc["reasoning_effort"], "enabled:false must override any effort")
 }
 
 func TestReasoningValidatorEnabledTrueLiftsEffort(t *testing.T) {

--- a/devshard/cmd/devshardctl/request_filters_config.go
+++ b/devshard/cmd/devshardctl/request_filters_config.go
@@ -94,9 +94,13 @@ const (
 // Routed model identifiers. The parameter catalog and the message processor
 // both dispatch on these strings.
 const (
-	kimiK26ModelID    = "moonshotai/Kimi-K2.6"
-	miniMaxM27ModelID = "MiniMaxAI/MiniMax-M2.7"
+	kimiK26ModelID             = "moonshotai/Kimi-K2.6"
+	miniMaxM27ModelID          = "MiniMaxAI/MiniMax-M2.7"
+	deepSeekV4Flash0731ModelID = "deepseek-ai/DeepSeek-V4-Flash-0731"
 )
+
+// An omitted reasoning_effort renders as "high"; "max" is the strongest prefix the encoder defines.
+const deepSeekDefaultReasoningEffort = "max"
 
 // Sentinel content used by message normalization when an upstream tool result is empty.
 const emptyToolResultContent = "<empty tool result>"

--- a/devshard/cmd/devshardctl/request_filters_parameters.go
+++ b/devshard/cmd/devshardctl/request_filters_parameters.go
@@ -457,15 +457,13 @@ func defaultVLLMParameterCatalog() VLLMParameterCatalog {
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.ReasoningValidator{},
 				}),
-			// reasoning_effort: enum-validate then strip. Models: nil keeps the strip
-			// universal until a reasoning-capable model is routed. List models in Models
-			// to start forwarding.
 			newParameter("reasoning_effort").
 				withRule(RequestFilterStagePreValidation, DocumentValidatorHandler{
 					Validator: paramvalidators.ReasoningEffortValidator{},
 				}).
 				withRule(RequestFilterStagePreValidation, ModelScopedParameterHandler{
-					Models:           nil,
+					Models:           []string{deepSeekV4Flash0731ModelID},
+					Handler:          ParameterHandlerAdapter{Handler: paramvalidators.DefaultLiteralParameter{Value: deepSeekDefaultReasoningEffort}},
 					UnmatchedHandler: ParameterHandlerAdapter{Handler: paramvalidators.StripParameter{}},
 				}),
 			// MiniMax-M2.7 has no chat_template knob for enable_thinking (vLLM #36778);

--- a/devshard/cmd/devshardctl/request_filters_test.go
+++ b/devshard/cmd/devshardctl/request_filters_test.go
@@ -2599,26 +2599,95 @@ func TestNormalizeChatRequestExtraBodyEmptyObjectJustDrops(t *testing.T) {
 	require.NotContains(t, raw, "extra_body")
 }
 
-func TestNormalizeChatRequestStripsReasoningEffort(t *testing.T) {
+// vLLM derives enable_thinking from this field, so forwarding it to a route that only
+// declares that variable would flip thinking while the effort level itself goes nowhere.
+func TestNormalizeChatRequestStripsReasoningEffortOffTheReasoningRoute(t *testing.T) {
 	cases := []struct{ name, body string }{
 		{name: "high", body: `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"high"}`},
 		{name: "none", body: `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"none"}`},
 		{name: "xhigh", body: `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`},
+		{name: "max", body: `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"max"}`},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			out, _, err := normalizeChatRequest([]byte(tc.body))
+		for _, model := range []string{kimiK26ModelID, miniMaxM27ModelID, ""} {
+			t.Run(tc.name+"/"+model, func(t *testing.T) {
+				out, _, err := normalizeChatRequestForModel([]byte(tc.body), model)
+				require.NoError(t, err)
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(out, &raw))
+				require.NotContains(t, raw, "reasoning_effort")
+			})
+		}
+	}
+}
+
+// DeepSeek-V4 is the one route whose renderer reads the value, and vLLM merges it into
+// chat_template_kwargs itself, so the top-level field has to survive unmirrored.
+func TestNormalizeChatRequestForwardsReasoningEffortToDeepSeek(t *testing.T) {
+	for _, effort := range []string{"none", "minimal", "low", "medium", "high", "xhigh", "max"} {
+		t.Run(effort, func(t *testing.T) {
+			body := `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"` + effort + `"}`
+			out, _, err := normalizeChatRequestForModel([]byte(body), deepSeekV4Flash0731ModelID)
 			require.NoError(t, err)
 			var raw map[string]any
 			require.NoError(t, json.Unmarshal(out, &raw))
-			require.NotContains(t, raw, "reasoning_effort", "all routed models are non-reasoning today, field must be stripped")
+			require.Equal(t, effort, raw["reasoning_effort"])
+			require.NotContains(t, raw, "chat_template_kwargs", "vLLM does the merge; mirroring here would double it")
+		})
+	}
+}
+
+// An omitted field renders as "high", which is the level reported to degrade into repetition over
+// long tool-calling sessions, so the route defaults to the strongest prefix instead of the encoder's.
+func TestNormalizeChatRequestDefaultsDeepSeekReasoningEffortToMax(t *testing.T) {
+	out, _, err := normalizeChatRequestForModel([]byte(`{"messages":[{"role":"user","content":"hi"}]}`), deepSeekV4Flash0731ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.Equal(t, "max", raw["reasoning_effort"])
+}
+
+// The default fills a gap; it must never overrule a level the caller picked, including a weaker one.
+func TestNormalizeChatRequestKeepsAnExplicitDeepSeekReasoningEffort(t *testing.T) {
+	for _, effort := range []string{"none", "minimal", "low", "medium", "high", "xhigh"} {
+		t.Run(effort, func(t *testing.T) {
+			body := `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"` + effort + `"}`
+			out, _, err := normalizeChatRequestForModel([]byte(body), deepSeekV4Flash0731ModelID)
+			require.NoError(t, err)
+			var raw map[string]any
+			require.NoError(t, json.Unmarshal(out, &raw))
+			require.Equal(t, effort, raw["reasoning_effort"])
+		})
+	}
+}
+
+// reasoning.enabled=false drops the wrapper, so without recording the refusal as "none" the route
+// default would read the gap as unspecified and switch thinking back on at maximum effort.
+func TestNormalizeChatRequestReasoningDisabledSurvivesTheDeepSeekDefault(t *testing.T) {
+	body := `{"messages":[{"role":"user","content":"hi"}],"reasoning":{"enabled":false}}`
+	out, _, err := normalizeChatRequestForModel([]byte(body), deepSeekV4Flash0731ModelID)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.Equal(t, "none", raw["reasoning_effort"])
+}
+
+// The default belongs to the one route that reads the field; elsewhere it would flip thinking.
+func TestNormalizeChatRequestDoesNotDefaultReasoningEffortOffTheReasoningRoute(t *testing.T) {
+	for _, model := range []string{kimiK26ModelID, miniMaxM27ModelID, ""} {
+		t.Run(model, func(t *testing.T) {
+			out, _, err := normalizeChatRequestForModel([]byte(`{"messages":[{"role":"user","content":"hi"}]}`), model)
+			require.NoError(t, err)
+			var raw map[string]any
+			require.NoError(t, json.Unmarshal(out, &raw))
+			require.NotContains(t, raw, "reasoning_effort")
 		})
 	}
 }
 
 func TestNormalizeChatRequestRejectsInvalidReasoningEffort(t *testing.T) {
 	cases := []struct{ name, body string }{
-		{name: "unknown enum", body: `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"max"}`},
+		{name: "unknown enum", body: `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"maximum"}`},
 		{name: "non-string", body: `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":5}`},
 		{name: "empty", body: `{"messages":[{"role":"user","content":"hi"}],"reasoning_effort":""}`},
 	}
@@ -2653,7 +2722,7 @@ func TestNormalizeChatRequestReasoningEnabledFalseOverridesEffort(t *testing.T) 
 }
 
 func TestNormalizeChatRequestReasoningInvalidEffortRejected(t *testing.T) {
-	body := `{"messages":[{"role":"user","content":"hi"}],"reasoning":{"effort":"max"}}`
+	body := `{"messages":[{"role":"user","content":"hi"}],"reasoning":{"effort":"maximum"}}`
 	_, _, err := normalizeChatRequest([]byte(body))
 	require.Error(t, err, "invalid effort must surface from ReasoningEffortValidator after lift")
 	require.Contains(t, err.Error(), "reasoning_effort")

--- a/docs/chat-api/README.md
+++ b/docs/chat-api/README.md
@@ -6,6 +6,7 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M
 - [Per-model overrides: Kimi-K2.6](kimi-k2.6.md)
 - [Per-model overrides: Qwen3-235B-A22B-Instruct-2507](qwen3-235b-a22b-instruct-2507.md)
 - [Per-model overrides: MiniMax-M2.7](minimax-m2.7.md)
+- [Per-model overrides: DeepSeek-V4-Flash-0731](deepseek-v4-flash-0731.md)
 - [Why was my param stripped/rejected?](troubleshooting.md)
 - [Client agents compatibility](agents.md)
 - [Source citations](references.md)
@@ -62,7 +63,7 @@ OpenAI-compatible chat completions, routed to Kimi-K2.6 / Qwen3-235B / MiniMax-M
 | `cache_key` | string | — | silent-strip ([why](troubleshooting.md#strip-cache_key)) | [[Moonshot-1]](references.md#moonshot) |
 | `extra_headers` | object | — | silent-strip ([why](troubleshooting.md#strip-extra_headers)) | [[OpenAI-5]](references.md#openai) |
 | `extra_body` | object | — | unwrap to top-level ([why](troubleshooting.md#unwrap-extra_body)) | [[OpenAI-5]](references.md#openai) |
-| `reasoning_effort` | enum string | — | validated then stripped ([why](troubleshooting.md#strip-reasoning_effort)) | [[vLLM-1]](references.md#vllm), [[OpenAI-4]](references.md#openai) |
+| `reasoning_effort` | enum string | `max` on DeepSeek-V4 only | validated everywhere; on [DeepSeek-V4-Flash-0731](deepseek-v4-flash-0731.md) an explicit value is forwarded and an omitted one defaults to `max`, stripped on every other route ([why](troubleshooting.md#strip-reasoning_effort)) | [[vLLM-1]](references.md#vllm), [[OpenAI-4]](references.md#openai) |
 | `reasoning` | object | — | translate `effort` → `reasoning_effort` ([why](troubleshooting.md#translate-reasoning)) | [[OpenRouter-4]](references.md#openrouter) |
 | `enable_thinking` | bool | — | translate to chat_template_kwargs ([why](troubleshooting.md#translate-enable_thinking)) | [[Qwen-3]](references.md#qwen) |
 | `thinking_config` | object | — | silent-strip ([why](troubleshooting.md#strip-thinking_config)) | — |

--- a/docs/chat-api/deepseek-v4-flash-0731.md
+++ b/docs/chat-api/deepseek-v4-flash-0731.md
@@ -1,0 +1,102 @@
+# DeepSeek-V4-Flash-0731 (`deepseek-ai/DeepSeek-V4-Flash-0731`) — overrides & extensions
+
+Provider: DeepSeek. This doc documents how DeepSeek-V4-Flash-0731 deviates from the [universal contract](README.md). For params that behave the same as universal, see the universal contract directly.
+
+Mirrors the structure of [Kimi-K2.6](kimi-k2.6.md), [Qwen3-235B](qwen3-235b-a22b-instruct-2507.md) and [MiniMax-M2.7](minimax-m2.7.md). This is the only routed model that consumes `reasoning_effort`, so the field's whole contract is documented here rather than in the universal doc.
+
+## Model facts
+
+| Property | Value | Source |
+|----------|-------|--------|
+| Provider | DeepSeek | [[DeepSeek-1]](references.md#deepseek) |
+| vLLM route id | `deepseek-ai/DeepSeek-V4-Flash-0731` | — |
+| Native thinking | yes — on by default when neither `thinking` nor `enable_thinking` is passed | [[vLLM-33]](references.md#vllm) |
+| Reasoning effort levels | three: `low`, `high`, `max` | [[DeepSeek-1]](references.md#deepseek), [[vLLM-33]](references.md#vllm) |
+| Chat rendering | dedicated vLLM tokenizer (`vllm/tokenizers/deepseek_v4.py`), not a Jinja `chat_template` | [[vLLM-33]](references.md#vllm) |
+| Reasoning/tool parsing | dedicated vLLM parser (`vllm/parser/deepseek_v4.py`); the model card lists no `--reasoning-parser` flag | [[vLLM-34]](references.md#vllm), [[DeepSeek-1]](references.md#deepseek) |
+| Engine version floor | vLLM 0.22.0 — see [Deployment requirements](#deployment-requirements) | [[vLLM-35]](references.md#vllm), [[CVE-15]](references.md#security-advisories) |
+
+## Deployment requirements
+
+Infrastructure-level constraints that must hold BEFORE this route is served — enforced by vLLM engine configuration, NOT by the gateway:
+
+- **vLLM ≥ 0.22.0.** Two independent reasons converge on the same floor. The `reasoning_effort` → `enable_thinking` mapping ships in the v0.22.0 milestone ([[vLLM-35]](references.md#vllm)), and [[CVE-15]](references.md#security-advisories) (CVSS 9.1, OpenAI-API authentication bypass, affects 0.3.0 through 0.21.0) is fixed in the same release. A host old enough to ignore `reasoning_effort` is old enough to serve unauthenticated inference.
+- **`--trust-remote-code` is required by the model card** ([[DeepSeek-1]](references.md#deepseek)), which puts the deployment inside the blast radius of [[CVE-12]](references.md#security-advisories). Mitigation is the same as every other route: pin the HuggingFace `revision=<commit-sha>`, never serve `revision=main`.
+- **Effort levels are rendered by the engine, not the weights.** The value is consumed by vLLM's bundled DeepSeek-V4 tokenizer, so two hosts on different vLLM builds can render the same request into different prompts. This is a validation hazard specific to devshard: a verifier replays the inference and compares, so a mixed-build group disagrees on work nobody did wrong. Track it through the per-model capability machinery, not per-request.
+
+## The `reasoning_effort` contract
+
+The wire enum vLLM accepts is `Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]`, and its own field description states that `max` is DeepSeek-V4-specific and not part of the OpenAI spec ([[vLLM-1]](references.md#vllm)). A value outside that set is rejected by vLLM's own request validation, so the gateway's enum check is a fail-fast duplicate rather than the only guard.
+
+`build_chat_params` forwards the value itself into `chat_template_kwargs` **and** derives `enable_thinking` from it, unless the caller set `enable_thinking` explicitly ([[vLLM-1]](references.md#vllm)):
+
+```python
+extra_kwargs = dict(..., reasoning_effort=self.reasoning_effort)
+if self.reasoning_effort is not None and "enable_thinking" not in user_kwargs:
+    extra_kwargs["enable_thinking"] = self.reasoning_effort != "none"
+```
+
+That forwarding is what makes the top-level field sufficient. Unlike Kimi's `thinking`, this route needs no mirroring into `chat_template_kwargs` by the gateway.
+
+**Seven accepted values collapse to three rendered ones** ([[vLLM-33]](references.md#vllm)):
+
+| Wire value | Rendered effort | Thinking | Prompt prefix at message index 0 |
+|---|---|---|---|
+| `none` | dropped | **off** (`thinking_mode="chat"`) | none — thinking mode is off |
+| `minimal` | `low` | on | **empty string** |
+| `low` | `low` | on | **empty string** |
+| `medium` | `low` | on | **empty string** |
+| `high` | `high` | on | "Reasoning Effort: Absolute maximum with no shortcuts permitted…" |
+| `xhigh` | `high` | on | same as `high` |
+| `max` | `max` | on | "Reasoning Effort: Beyond maximum — exhaustive, relentless and uncompromising…" |
+| *absent* | `high` | on (default when neither `thinking` nor `enable_thinking` is passed) | same as `high` |
+
+The levels are prompt prefixes, not sampling knobs: `REASONING_EFFORT_PROMPTS` maps each to a literal instruction block, injected once at message index 0 rather than per turn ([[vLLM-39]](references.md#vllm)). `low` maps to the empty string, so it adds no instruction at all.
+
+The gateway fills the field on this route (see [Gateway wiring](#gateway-wiring)), so the *absent* row above describes the engine's own fallback rather than anything a host receives from us.
+
+**Sending `minimal`, `low` or `medium` asks for less reasoning than sending nothing.** Those three resolve to `low` and inject no instruction, while an omitted field arrives as `max`. A client porting an OpenAI request that habitually carries `reasoning_effort: "medium"` therefore lands two levels below what it would have got by omitting the field. `xhigh` is an alias of `high` — accepted because vLLM accepts it, but it buys nothing over `high` and is billed the same.
+
+The tokenizer's final `else` branch renders any unrecognized string as `high` rather than erroring, so the enum check upstream is what stops a typo from selecting a level the caller did not ask for.
+
+## Parameter overrides
+
+*Delta from [universal contract](README.md#supported-parameters-universal-behavior).*
+
+| Param | Universal | On DeepSeek-V4-Flash-0731 | Why |
+|-------|-----------|---------------------------|-----|
+| `reasoning_effort` | enum-validated then **stripped on every route** | **forward** — the only route that consumes it | [[vLLM-33]](references.md#vllm), [[vLLM-1]](references.md#vllm) |
+| `thinking` / `enable_thinking` | mirrored to `chat_template_kwargs` on Kimi; stripped on MiniMax | both read from `chat_template_kwargs`; default **on** when neither is present | [[vLLM-33]](references.md#vllm) |
+| `thinking_token_budget` | injected/clamped on Kimi; stripped on Qwen and MiniMax | no equivalent knob in this tokenizer — the effort level is the budget control | [[vLLM-33]](references.md#vllm) |
+
+## Native extensions
+
+*Params unique to this route — no equivalent in the universal contract.*
+
+| Param | Type | Behavior | Source |
+|-------|------|----------|--------|
+| `include_reasoning` | bool, default `true` | **Rejected by the top-level allowlist.** Distinct from `reasoning_effort=none`: that suppresses the thinking, this suppresses only its *delivery*, and it carries two effects rather than one. The parser nulls `delta.reasoning` and drops deltas that carried nothing else ([[vLLM-37]](references.md#vllm)), and serving marks reasoning as already ended, so structured-output grammar engages from the first token instead of after `</think>` ([[vLLM-38]](references.md#vllm)) — the thinking-plus-guided-decoding surface with known upstream bugs ([[vLLM-5]](references.md#vllm), [[vLLM-8]](references.md#vllm), [[vLLM-9]](references.md#vllm)). Generation is untouched either way, so the reasoning tokens are still billed through `usage.completion_tokens` while the client never receives them — the hidden-token class documented for `return_token_ids` ([[vLLM-19]](references.md#vllm)). Suppressing display is a client-side concern; suppressing billing is not something this field does. | [[vLLM-1]](references.md#vllm) |
+| `chat_template_kwargs.drop_thinking` | bool, default `true` | Drops prior assistant thinking from rendered history. Passes through the `chat_template_kwargs` bounds/forbidden-key filter unchanged. The default discards prior thinking, the inverse of the round-trip contract MiniMax-M2.7 requires — a client porting between the two routes cannot carry its history handling across. | [[vLLM-33]](references.md#vllm) |
+
+## Response shape
+
+vLLM's canonical response field is `reasoning`; `reasoning_content` is the deprecated alias, renamed forward on input ([[vLLM-1]](references.md#vllm), [[vLLM-36]](references.md#vllm)). The gateway's stream reader accepts both names on `delta` and `message`, so either spelling reaches the client intact.
+
+## Known model-side bugs we work around
+
+- **Empty-thinking history collapse** ([[DeepSeek-2]](references.md#deepseek)): community reports on the model's own discussion thread describe reasoning loops in long tool-calling sessions, attributed to accumulating empty `<think></think>` blocks in history, with degradation reported after roughly 60 such turns. Reported remedy is `{"thinking": true, "reasoning_effort": "max"}`. Community hypothesis, not a vendor statement — no DeepSeek author replies in the thread. One claim in it is contradicted by the encoder: the reporters describe `low` *and* `high` as rendering empty reasoning prefixes, but `REASONING_EFFORT_PROMPTS` gives `high` a full instruction block and only `low` the empty string ([[vLLM-39]](references.md#vllm)). Since both `thinking` and the effort default to on/`high` already, the operative half of the reported remedy is the move from `high` to `max`, not the enabling of thinking. No gateway-side mitigation exists: only a client controlling its own history can avoid accumulating the empty blocks.
+
+## Gateway wiring
+
+`reasoning_effort` is enum-validated on every route and forwarded only here, via `ModelScopedParameterHandler{Models: []string{deepSeekV4Flash0731ModelID}}` in `defaultVLLMParameterCatalog`. The validator's allowed set is the vLLM wire enum including `max`. Nothing is mirrored into `chat_template_kwargs` — vLLM performs that merge itself, and doing it here would write the key twice.
+
+**A request that omits the field is sent as `max`.** The engine's own fallback is `high`, the level the reasoning-loop reports name as degrading, so the route defaults to the strongest prefix the encoder defines rather than inheriting that fallback. The default only fills a gap: any explicit level the caller sends survives untouched, including levels weaker than the default. Because the levels are prompt prefixes, the stronger default lengthens generated reasoning, and those tokens are billed through `usage.completion_tokens` like any others — a caller wanting the shorter behavior sends `high` explicitly.
+
+`reasoning: {"enabled": false}` is recorded as `reasoning_effort: "none"` rather than dropped. Dropping it would leave the request indistinguishable from one that never mentioned reasoning, which this default reads as permission to fill in — so a client disabling reasoning would have received maximum reasoning.
+
+## See also
+- [Troubleshooting](troubleshooting.md)
+- [References](references.md)
+- [Universal contract](README.md)
+- [Kimi-K2.6 overrides](kimi-k2.6.md)
+- [MiniMax-M2.7 overrides](minimax-m2.7.md)

--- a/docs/chat-api/references.md
+++ b/docs/chat-api/references.md
@@ -9,6 +9,7 @@ Namespaces:
 - `[Moonshot-N]` Moonshot (includes Kimi model line)
 - `[Qwen-N]` Qwen
 - `[MiniMax-N]` MiniMax AI (MiniMax-M2 line)
+- `[DeepSeek-N]` DeepSeek (DeepSeek-V4 line)
 - `[SGLang-N]` SGLang (cross-engine parser bug references)
 - `[OpenRouter-N]` OpenRouter
 - `[CVE-N]` security advisories
@@ -63,6 +64,13 @@ Industry/community sources (Ollama blog, OpenAI community thread, arxiv papers) 
 - **[vLLM-30]** [Issue #39573 — thinking budget not enforced with MTP](https://github.com/vllm-project/vllm/issues/39573) — "Without MTP → thinking budget enforced. With MTP → thinking budget NOT enforced." Confirms vLLM-29 end to end.
 - **[vLLM-31]** [Issue #36969 — Kimi-K2.5 emits a stray `</think>` when `enable_thinking` is false](https://github.com/vllm-project/vllm/issues/36969) — top-level `enable_thinking` leaks the tag into `content`; the maintainer's working answer is `chat_template_kwargs: {"thinking": false}`.
 - **[vLLM-32]** [chat_completion/protocol.py source](https://github.com/vllm-project/vllm/blob/v0.20.0/vllm/entrypoints/openai/chat_completion/protocol.py#L183) — `thinking_token_budget` is a declared top-level request field, forwarded to `SamplingParams`; it belongs at the top level, not inside `chat_template_kwargs`.
+- **[vLLM-33]** [tokenizers/deepseek_v4.py source](https://github.com/vllm-project/vllm/blob/main/vllm/tokenizers/deepseek_v4.py) — the bundled DeepSeek-V4 chat renderer. `apply_chat_template` reads `thinking`/`enable_thinking`/`reasoning_effort`/`drop_thinking` from `**kwargs` and collapses the seven-value wire enum onto three rendered levels (`none`→thinking off, `low|minimal|medium`→`low`, `max`→`max`, anything else→`high`).
+- **[vLLM-34]** [parser/deepseek_v4.py source](https://github.com/vllm-project/vllm/blob/main/vllm/parser/deepseek_v4.py) — DeepSeek-V4 reasoning/tool parser; thinking defaults on when neither `thinking` nor `enable_thinking` is present, and is forced off by `reasoning_effort == "none"`.
+- **[vLLM-35]** [PR #43401 — map reasoning_effort to enable_thinking](https://github.com/vllm-project/vllm/pull/43401) — milestone v0.22.0; establishes the engine version floor for `reasoning_effort` having any effect.
+- **[vLLM-36]** [Reasoning outputs feature docs](https://docs.vllm.ai/en/latest/features/reasoning_outputs/) — `--reasoning-parser` values, the `reasoning` response field and its deprecated `reasoning_content` alias, and the `reasoning_effort` → thinking activation rule.
+- **[vLLM-37]** [parser/abstract_parser.py source](https://github.com/vllm-project/vllm/blob/main/vllm/parser/abstract_parser.py) — `include_reasoning=false` nulls `delta_message.reasoning` and drops the delta entirely when it carried no content and no tool calls; the same suppression is duplicated in `parser/engine/parser_engine.py`. Generation is untouched, so the tokens still land in `usage.completion_tokens`.
+- **[vLLM-38]** [chat_completion/serving.py source](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/chat_completion/serving.py) — `if not request.include_reasoning: reasoning_ended = True`, which makes structured-output grammar engage from the first token instead of after the reasoning block closes.
+- **[vLLM-39]** [tokenizers/deepseek_v4_encoding.py source](https://github.com/vllm-project/vllm/blob/main/vllm/tokenizers/deepseek_v4_encoding.py) — `REASONING_EFFORT_PROMPTS` maps the three rendered levels to literal prompt prefixes (`low` → `""`, `high` and `max` → multi-paragraph instruction blocks), `DEFAULT_REASONING_EFFORT = "low"`, and `render_message` appends the prefix only when `index == 0` and `thinking_mode == "thinking"`.
 
 ## Moonshot
 
@@ -85,6 +93,11 @@ Industry/community sources (Ollama blog, OpenAI community thread, arxiv papers) 
 - **[MiniMax-3]** [MiniMax-M2.7 vLLM deployment guide](https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/vllm_deploy_guide.md) — exact CLI invocations, GPU sizing (220 GB weights + 240 GB/1M tokens), 196K max context per sequence, parser flags.
 - **[MiniMax-4]** [MiniMax-M2.7 tool calling guide](https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/tool_calling_guide.md) — `<minimax:tool_call><invoke><parameter>` output format; `role:"tool"` with `content:[{name,type,text}]` array (no `tool_call_id`).
 - **[MiniMax-5]** [MiniMax M2 Tool Use & Interleaved Thinking docs](https://platform.minimax.io/docs/guides/text-m2-function-call) — `extra_body.reasoning_split`, `reasoning_details[]` response field, multi-turn history rules.
+
+## DeepSeek
+
+- **[DeepSeek-1]** [DeepSeek-V4-Flash-0731 model card](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) — states the three supported `reasoning_effort` levels (`low`, `high`, `max`) and the recommended vLLM/SGLang serving invocations, both of which require `--trust-remote-code` and neither of which passes a `--reasoning-parser` flag.
+- **[DeepSeek-2]** [Model discussion #39 — reasoning loops](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/discussions/39) — community thread, no vendor reply. Reports reasoning loops in long tool-calling sessions traced to accumulating empty `<think></think>` blocks, a ~60-turn degradation threshold, and `{"thinking": true, "reasoning_effort": "max"}` as the reported remedy. Cited as the origin of the request, not as evidence.
 
 ## SGLang
 
@@ -116,4 +129,5 @@ Industry/community sources (Ollama blog, OpenAI community thread, arxiv papers) 
 - **[CVE-12]** [CVE-2026-27893 / RAXE-2026-044 (vLLM)](https://raxe.ai/labs/advisories/RAXE-2026-044) — vLLM hardcoded trust_remote_code bypass enables RCE via malicious model repositories; direct mitigation for the MiniMax-M2.7 route is the chain-pinned `HfCommit` SHA in the governance model config.
 - **[CVE-13]** [CVE-2026-22778 (vLLM)](https://www.ox.security/blog/cve-2026-22778-vllm-rce-vulnerability/) — RCE via crafted video link in multimodal content; gateway mitigates by rejecting non-text content parts on all text-only routes (M2.7 included).
 - **[CVE-14]** [CVE-2025-62164 / GHSA-mrw7-hf4f-83pf (vLLM)](https://github.com/advisories/GHSA-mrw7-hf4f-83pf) — tensor deserialization → DoS / potential RCE; pin vLLM ≥ patched release.
+- **[CVE-15]** [CVE-2026-48746 (vLLM)](https://advisories.gitlab.com/pypi/vllm/CVE-2026-48746/) — CVSS 9.1 authentication bypass of the OpenAI-API `AuthenticationMiddleware`: the middleware rebuilt the request path with `URL(scope=scope).path`, which trusts the unsanitized `Host` header, so a crafted header makes the reconstructed path miss the `/v1` prefix check and skip auth entirely. Affects 0.3.0 through 0.21.0, fixed in 0.22.0. An RFC-conforming reverse proxy (nginx) normalizes `Host` and blocks it, so exposure depends on the host's own topology, not ours.
 

--- a/docs/chat-api/troubleshooting.md
+++ b/docs/chat-api/troubleshooting.md
@@ -212,13 +212,13 @@ Every parameter that is stripped / rejected / normalized at the gateway is docum
 
 ### #strip-reasoning_effort
 
-**What**: `reasoning_effort: "none"|"minimal"|"low"|"medium"|"high"|"xhigh"` enum-validated, then field stripped from the request body before forwarding to vLLM.
+**What**: `reasoning_effort: "none"|"minimal"|"low"|"medium"|"high"|"xhigh"|"max"` enum-validated on every route, then stripped on every route **except** `deepseek-ai/DeepSeek-V4-Flash-0731`, where an explicit value is forwarded unchanged and an omitted one is filled in as `"max"`.
 
-**Why**: vLLM declares the enum [[vLLM-1]](references.md#vllm) (sourced from [[OpenAI-4]](references.md#openai) reasoning guide; we exclude `"max"` because no routed model is DeepSeek). Both currently-routed models are non-reasoning — [[Qwen-1]](references.md#qwen) for Qwen3-235B-Instruct-2507, [[Moonshot-1]](references.md#moonshot) for Kimi (schema lacks the field). The validate-then-strip pattern surfaces malformed enum values as a 400 instead of silently forwarding garbage; the strip itself is the documented no-op on both backends.
+**Why**: vLLM declares the enum [[vLLM-1]](references.md#vllm) (sourced from [[OpenAI-4]](references.md#openai) reasoning guide, plus `"max"`, which vLLM documents as DeepSeek-V4-specific and outside the OpenAI spec). The other routed models are non-reasoning — [[Qwen-1]](references.md#qwen) for Qwen3-235B-Instruct-2507, [[Moonshot-1]](references.md#moonshot) for Kimi — but the strip there is not merely a tidy no-op: vLLM *also* derives `enable_thinking` from this field and injects it into `chat_template_kwargs` [[vLLM-1]](references.md#vllm), so forwarding it to a template that declares that variable would silently flip thinking while the effort level itself went nowhere. Validating everywhere and stripping selectively surfaces a malformed enum as a 400 regardless of route.
 
-**When to restore**: when a reasoning-capable model is added to the gateway routes — strip wiring must be revisited then.
+**When to revisit**: when another reasoning-capable model is routed — add it to `Models` on the `reasoning_effort` entry in `defaultVLLMParameterCatalog`, and check its own value mapping first, since the levels are not portable ([DeepSeek-V4 collapses seven wire values onto three](deepseek-v4-flash-0731.md#the-reasoning_effort-contract)).
 
-**Fix (client-side)**: if you're sending `reasoning_effort` and need the behavior, you're on a route that doesn't support it. Either drop the field or wait for a reasoning-capable route to be added.
+**Fix (client-side)**: on any route other than DeepSeek-V4-Flash-0731 the field does nothing — drop it. On DeepSeek-V4-Flash-0731 only `low`, `high` and `max` are distinct: `minimal`/`medium` render as `low` and `xhigh` renders as `high`. Omitting the field there is not neutral — it arrives as `max`, so `minimal`/`low`/`medium` ask for *less* reasoning than sending nothing. To get the engine's own fallback, send `high` explicitly; to turn reasoning off, send `none` (or `reasoning: {"enabled": false}`, which is recorded as `none`).
 
 ## Translations / coercions
 


### PR DESCRIPTION
## Summary

- `reasoning_effort` was enum-validated and then stripped on every route, and `max` — the one value DeepSeek-V4 defines beyond the OpenAI set — was rejected outright, so the field could not reach `deepseek-ai/DeepSeek-V4-Flash-0731`, the routed model that actually reads it.
- Forward the field on that route only; every other route keeps the strip.
- Fill in `max` when the caller omits the field. An explicit level always survives, including levels weaker than the default.
- Add `max` to `ReasoningEffortValidator`, matching the vLLM wire enum.
- Record `reasoning: {"enabled": false}` as `reasoning_effort: "none"` instead of dropping it silently.
- Add `DefaultLiteralParameter` — the write-only-if-absent counterpart to the existing `ForceLiteralParameter`, which can only overwrite.
- Document the route in `docs/chat-api/deepseek-v4-flash-0731.md`, including the value mapping the engine applies:

  | wire value | rendered effort | prompt prefix |
  |---|---|---|
  | `none` | — | thinking off |
  | `minimal` / `low` / `medium` | `low` | empty string |
  | `high` / `xhigh` | `high` | 476 chars |
  | `max` | `max` | 526 chars |

## Why

vLLM's `build_chat_params` merges `reasoning_effort` into `chat_template_kwargs` itself and separately derives `enable_thinking` from it, so the top-level field is sufficient on its own and needs no mirroring the way Kimi's `thinking` does. That same derivation is why the other routes keep the strip: forwarding the field to a template that declares `enable_thinking` would silently flip thinking on or off while the effort level itself went nowhere.

The levels are prompt prefixes rather than sampling knobs — `REASONING_EFFORT_PROMPTS` maps each to a literal instruction block injected once at message index 0. An omitted field resolves to `high`, which is the level the model's own discussion thread names in its reasoning-loop reports, so the route defaults to the strongest prefix the encoder defines rather than inheriting that fallback. One consequence worth knowing when reading the table above: `minimal`, `low` and `medium` all render an empty prefix, so sending them asks for *less* reasoning than sending nothing.

`reasoning: {"enabled": false}` had to stop being dropped. It deleted the wrapper and wrote nothing, leaving the request indistinguishable from one that never mentioned reasoning — which the new default reads as permission to fill the gap. Without this, a client explicitly disabling reasoning would have received maximum reasoning.

No `max_tokens` guard was added, deliberately. Reasoning tokens do count against `max_tokens` in vLLM (vllm-project/vllm#28266) and this route has no budget knob — the tokenizer defines none, `thinking_token_budget` is stripped off-Kimi, and it is a logits processor that vLLM discards under the `--speculative-config` this model's card recommends. The Kimi-style floor was still the wrong thing to copy: its `256` threshold sits next to a budget that can be clamped, which does not exist here, so the equivalent action would be disabling reasoning outright. Epoch 364 gives no reason to: empty-stream share is **2%** on DeepSeek against **2%** on MiniMax-M2.7 and **3%** on Kimi-K2.6, measured while the engine was already defaulting this route to `high`. If that share moves after rollout there will be a measured threshold to fit instead of a borrowed one.

On the prompt side the prefix is not new — the engine was already injecting the `high` block while we stripped the field, so the change adds **50 characters (~12 tokens)** against a 400k-tokens configured window. Admission is unaffected either way: `ContextTotalHint` is parsed out of the host's own rejection message, so the gateway reads the real prompt size from the engine rather than predicting it.

## Tests

- `TestNormalizeChatRequestForwardsReasoningEffortToDeepSeek` — all seven wire values survive on the DeepSeek route, and `chat_template_kwargs` is not written (vLLM performs that merge; mirroring would write the key twice).
- `TestNormalizeChatRequestStripsReasoningEffortOffTheReasoningRoute` — every value, including `max`, is stripped on Kimi, MiniMax and the empty route.
- `TestNormalizeChatRequestDefaultsDeepSeekReasoningEffortToMax` — an omitted field arrives as `max`.
- `TestNormalizeChatRequestKeepsAnExplicitDeepSeekReasoningEffort` — the default never overrules a caller's level, weaker levels included.
- `TestNormalizeChatRequestReasoningDisabledSurvivesTheDeepSeekDefault` — `reasoning: {"enabled": false}` lands as `none`, not `max`.
- `TestNormalizeChatRequestDoesNotDefaultReasoningEffortOffTheReasoningRoute` — no default leaks onto routes that strip the field.
- `TestReasoningValidatorEnabledFalseRecordsTheRefusal` — the refusal is written as `none` rather than dropped.
- `TestReasoningEffortValidatorAccepts` / `TestNormalizeChatRequestRejectsInvalidReasoningEffort` — `max` accepted, unknown strings still rejected.

Mutation-tested: reverting the default, weakening it to `high`, letting it overwrite an explicit value, restoring the silent loss of `enabled:false`, moving the model scope to Kimi, reverting to the universal strip, and removing `max` from the enum are each killed by the above.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/devshardctl/... -count=1` green across all four packages
- [x] `gofmt` clean on every touched file
- [x] 9 mutants introduced, 9 killed
- [x] Value mapping, prefix sizes and version floor verified against vLLM sources and the model card, cited in `docs/chat-api/references.md`