### PR TITLE
fix(versiond): grow readiness window instead of using a fixed one

### DIFF
--- a/decentralized-api/payloadstorage/managed_storage.go
+++ b/decentralized-api/payloadstorage/managed_storage.go
@@ -2,6 +2,7 @@ package payloadstorage
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -13,7 +14,23 @@ import (
 const (
 	defaultManagedCacheSize = 1000
 	maxPruneLookback        = 10
+	// cleanupInterval is the cleanupLoop tick period. defaultPruneTimeout is
+	// deliberately the same value so a stalled epoch costs at most about one tick
+	// before cleanupLoop is free to run again; sharing the constant makes that
+	// coupling real rather than two literals that could silently drift apart.
+	cleanupInterval = 30 * time.Second
+	// defaultPruneTimeout bounds a single PruneEpoch so a stuck backend cannot
+	// freeze cleanupLoop.
+	defaultPruneTimeout = cleanupInterval
 )
+
+// errPruneInFlight signals that a prune goroutine for this epoch spawned by an
+// earlier tick is still running (it timed out but the ctx-ignoring backend has
+// not returned yet). It is treated exactly like a timeout failure so pruneEpochs
+// stops advancing minPruned and retries next tick, but it deliberately does NOT
+// spawn another goroutine -- that is what caps stuck background prunes at one per
+// epoch instead of one per tick.
+var errPruneInFlight = errors.New("prune already in flight for epoch")
 
 type cachedEntry struct {
 	promptPayload   []byte
@@ -29,11 +46,24 @@ type ManagedStorage struct {
 	retainCount  uint64
 	cacheTTL     time.Duration
 	maxCacheSize int
+	pruneTimeout time.Duration
 
 	mu        sync.RWMutex
 	cache     map[string]*cachedEntry
 	maxEpoch  uint64
 	minPruned uint64
+	// pruning tracks epochs whose background PruneEpoch goroutine is still
+	// outstanding. A ctx-ignoring backend (FileStorage's os.RemoveAll) keeps
+	// running after pruneEpochWithTimeout returns on its deadline; without this
+	// set every tick would spawn a fresh goroutine for the same stuck epoch, so
+	// stuck tasks would accumulate without bound. Guarded by mu.
+	//
+	// A permanently-wedged epoch's marker can outlive its relevance: once the
+	// maxPruneLookback cap laps minPruned past that epoch it is never revisited,
+	// yet the leaked goroutine never returns to clear the entry. That leaves at
+	// most one stale marker per wedged epoch (bounded, negligible), and it is
+	// harmless because nothing ever keys on that epoch again.
+	pruning map[uint64]struct{}
 }
 
 func NewManagedStorage(storage PayloadStorage, retainCount uint64, cacheTTL time.Duration) *ManagedStorage {
@@ -46,7 +76,9 @@ func NewManagedStorageWithSize(storage PayloadStorage, retainCount uint64, cache
 		retainCount:  retainCount,
 		cacheTTL:     cacheTTL,
 		maxCacheSize: maxCacheSize,
+		pruneTimeout: defaultPruneTimeout,
 		cache:        make(map[string]*cachedEntry),
+		pruning:      make(map[uint64]struct{}),
 	}
 	go m.cleanupLoop()
 	return m
@@ -93,7 +125,7 @@ func (m *ManagedStorage) PruneEpoch(ctx context.Context, epochId uint64) error {
 }
 
 func (m *ManagedStorage) cleanupLoop() {
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 
 	for range ticker.C {
@@ -103,7 +135,6 @@ func (m *ManagedStorage) cleanupLoop() {
 
 func (m *ManagedStorage) cleanup() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	now := time.Now()
 	for id, c := range m.cache {
@@ -119,23 +150,94 @@ func (m *ManagedStorage) cleanup() {
 		}
 	}
 
+	var start, threshold uint64
 	if m.maxEpoch > m.retainCount {
-		threshold := m.maxEpoch - m.retainCount
+		threshold = m.maxEpoch - m.retainCount
 
 		if m.minPruned+maxPruneLookback < threshold {
 			m.minPruned = threshold - maxPruneLookback
 		}
+		start = m.minPruned
+	}
+	m.mu.Unlock()
 
-		for epoch := m.minPruned; epoch < threshold; epoch++ {
-			go func(e uint64) {
-				if err := m.storage.PruneEpoch(context.Background(), e); err != nil {
-					logging.Warn("Auto-prune failed", types.PayloadStorage, "epochId", e, "error", err)
-				} else {
-					logging.Info("Auto-pruned epoch", types.PayloadStorage, "epochId", e)
-				}
-			}(epoch)
+	m.pruneEpochs(start, threshold)
+}
+
+// pruneEpochs prunes epochs [start, threshold) in order, advancing minPruned
+// only past epochs that pruned successfully so a failed epoch is retried on
+// the next cleanup tick instead of being skipped forever (#850). Pruning runs
+// outside m.mu so storage I/O does not block cache reads; cleanupLoop is the
+// only caller, so prunes never overlap.
+func (m *ManagedStorage) pruneEpochs(start, threshold uint64) {
+	for epoch := start; epoch < threshold; epoch++ {
+		if err := m.pruneEpochWithTimeout(epoch); err != nil {
+			// errPruneInFlight is the expected steady state under a wedged
+			// ctx-ignoring backend (an earlier goroutine is still running), not a
+			// failure. Return quietly so we do not emit a WARN every tick forever
+			// and trip alerting; pruneEpochWithTimeout already logged it at Info.
+			if errors.Is(err, errPruneInFlight) {
+				return
+			}
+			logging.Warn("Auto-prune failed, will retry on next cleanup", types.PayloadStorage, "epochId", epoch, "error", err)
+			return
 		}
-		m.minPruned = threshold
+		logging.Info("Auto-pruned epoch", types.PayloadStorage, "epochId", epoch)
+
+		m.mu.Lock()
+		m.minPruned = epoch + 1
+		m.mu.Unlock()
+	}
+}
+
+// pruneEpochWithTimeout bounds a single PruneEpoch with m.pruneTimeout so a
+// stuck backend cannot freeze cleanupLoop. The deadline is passed to the
+// backend so ctx-aware stores (Postgres) cancel the in-flight query, and the
+// call also runs in a goroutine so cleanupLoop is released at the deadline even
+// for backends that ignore ctx (FileStorage's os.RemoveAll). A timed-out prune
+// is treated like any other failure: minPruned is not advanced and the epoch is
+// retried on the next cleanup tick. Prunes are idempotent, so a goroutine that
+// completes after the deadline is harmless.
+//
+// The pruning set makes that retry safe under a ctx-ignoring backend: after a
+// timeout the background goroutine keeps running, so we refuse to spawn a second
+// one for the same epoch and instead report errPruneInFlight. That caps live
+// background prunes at one per epoch (rather than one per 30s tick, which would
+// let stuck tasks grow without bound). The goroutine clears the marker when
+// PruneEpoch finally returns, so the next tick starts fresh.
+func (m *ManagedStorage) pruneEpochWithTimeout(epoch uint64) error {
+	// Check-and-set the in-flight marker under a single lock acquisition so two
+	// ticks can never both decide to spawn for the same epoch.
+	m.mu.Lock()
+	if _, inFlight := m.pruning[epoch]; inFlight {
+		m.mu.Unlock()
+		logging.Info("Auto-prune still in flight, skipping respawn", types.PayloadStorage, "epochId", epoch)
+		return errPruneInFlight
+	}
+	m.pruning[epoch] = struct{}{}
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), m.pruneTimeout)
+	defer cancel()
+
+	// Buffered so the prune goroutine never blocks on send if we already
+	// returned via the deadline. The marker is cleared inside the goroutine when
+	// PruneEpoch actually returns (success, error, or ctx-cancel), never at the
+	// deadline -- otherwise a still-running prune would be respawned.
+	done := make(chan error, 1)
+	go func() {
+		err := m.storage.PruneEpoch(ctx, epoch)
+		m.mu.Lock()
+		delete(m.pruning, epoch)
+		m.mu.Unlock()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/decentralized-api/payloadstorage/managed_storage_test.go
+++ b/decentralized-api/payloadstorage/managed_storage_test.go
@@ -3,16 +3,20 @@ package payloadstorage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
 type mockStorage struct {
-	mu      sync.Mutex
-	data    map[string][]byte
-	pruned  []uint64
-	storeCb func(epochId uint64)
+	mu         sync.Mutex
+	data       map[string][]byte
+	pruned     []uint64
+	storeCb    func(epochId uint64)
+	pruneCb    func(epochId uint64) error
+	pruneCtxCb func(ctx context.Context, epochId uint64) error
 }
 
 func newMockStorage() *mockStorage {
@@ -41,8 +45,20 @@ func (m *mockStorage) Retrieve(ctx context.Context, inferenceId string, epochId 
 }
 
 func (m *mockStorage) PruneEpoch(ctx context.Context, epochId uint64) error {
+	// pruneCtxCb runs outside the lock so it can block on ctx (simulating a
+	// stuck backend) without deadlocking observers like getPruned.
+	if m.pruneCtxCb != nil {
+		if err := m.pruneCtxCb(ctx, epochId); err != nil {
+			return err
+		}
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.pruneCb != nil {
+		if err := m.pruneCb(epochId); err != nil {
+			return err
+		}
+	}
 	m.pruned = append(m.pruned, epochId)
 	return nil
 }
@@ -150,11 +166,8 @@ func TestManagedStorage_AutoPruneTriggersInCleanup(t *testing.T) {
 		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
 	}
 
-	// Trigger cleanup manually
+	// Trigger cleanup manually; pruning runs synchronously
 	ms.cleanup()
-
-	// Wait for async prune goroutines
-	time.Sleep(50 * time.Millisecond)
 
 	pruned := mock.getPruned()
 	// threshold = 10 - 2 = 8
@@ -175,7 +188,6 @@ func TestManagedStorage_AutoPruneSkipsOldEpochs(t *testing.T) {
 
 	// Trigger cleanup
 	ms.cleanup()
-	time.Sleep(50 * time.Millisecond)
 
 	pruned := mock.getPruned()
 	// threshold = 100 - 2 = 98
@@ -193,6 +205,251 @@ func TestManagedStorage_AutoPruneSkipsOldEpochs(t *testing.T) {
 	}
 }
 
+func TestManagedStorage_AutoPruneStopsAtFailedEpoch(t *testing.T) {
+	mock := newMockStorage()
+	pruneErr := errors.New("db connection lost")
+	mock.pruneCb = func(epochId uint64) error {
+		if epochId == 3 {
+			return pruneErr
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// threshold = 10 - 2 = 8; epoch 3 fails, so only 0-2 should be pruned
+	ms.cleanup()
+
+	pruned := mock.getPruned()
+	if len(pruned) != 3 {
+		t.Errorf("expected 3 epochs pruned before failure, got %d: %v", len(pruned), pruned)
+	}
+	for _, e := range pruned {
+		if e >= 3 {
+			t.Errorf("epoch %d should not be pruned past the failed epoch 3", e)
+		}
+	}
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 3 {
+		t.Errorf("minPruned should stop at failed epoch 3, got %d", minPruned)
+	}
+}
+
+func TestManagedStorage_AutoPruneRetriesFailedEpoch(t *testing.T) {
+	mock := newMockStorage()
+	failOnce := true
+	mock.pruneCb = func(epochId uint64) error {
+		if epochId == 3 && failOnce {
+			failOnce = false
+			return errors.New("transient failure")
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ctx := context.Background()
+
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// First cleanup: prunes 0-2, fails at 3
+	ms.cleanup()
+	// Second cleanup: retries 3, then continues through 7
+	ms.cleanup()
+
+	pruned := mock.getPruned()
+	// threshold = 8: epochs 0-7 all pruned across the two ticks, none skipped
+	if len(pruned) != 8 {
+		t.Errorf("expected 8 epochs pruned after retry, got %d: %v", len(pruned), pruned)
+	}
+	seen := make(map[uint64]bool)
+	for _, e := range pruned {
+		if seen[e] {
+			t.Errorf("epoch %d pruned more than once", e)
+		}
+		seen[e] = true
+	}
+	for e := uint64(0); e < 8; e++ {
+		if !seen[e] {
+			t.Errorf("epoch %d was never pruned", e)
+		}
+	}
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 8 {
+		t.Errorf("minPruned should reach threshold 8 after retry, got %d", minPruned)
+	}
+}
+
+func TestManagedStorage_AutoPruneTimesOutStuckEpoch(t *testing.T) {
+	mock := newMockStorage()
+	// Epoch 3 blocks until its context is cancelled, simulating a stuck backend
+	// (e.g. a DROP TABLE waiting on a lock). Every other epoch prunes instantly.
+	mock.pruneCtxCb = func(ctx context.Context, epochId uint64) error {
+		if epochId == 3 {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ms.pruneTimeout = 20 * time.Millisecond
+
+	ctx := context.Background()
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// Without the per-epoch timeout the stuck epoch 3 would block cleanupLoop
+	// forever; with it, cleanup returns once the deadline fires.
+	done := make(chan struct{})
+	go func() {
+		ms.cleanup()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup never returned: a stuck epoch froze cleanupLoop (per-epoch prune timeout missing)")
+	}
+
+	pruned := mock.getPruned()
+	if len(pruned) != 3 {
+		t.Errorf("expected epochs 0-2 pruned before the stuck epoch, got %d: %v", len(pruned), pruned)
+	}
+	for _, e := range pruned {
+		if e >= 3 {
+			t.Errorf("epoch %d should not be pruned past the stuck epoch 3", e)
+		}
+	}
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 3 {
+		t.Errorf("minPruned should stop at the stuck epoch 3 so it retries next tick, got %d", minPruned)
+	}
+}
+
+func TestManagedStorage_AutoPruneTimesOutCtxIgnoringBackend(t *testing.T) {
+	mock := newMockStorage()
+	release := make(chan struct{})
+	// Epoch 3 blocks WITHOUT observing ctx, simulating a backend like
+	// FileStorage.os.RemoveAll that ignores cancellation. Only the
+	// goroutine+select wrapper (not a bare ctx) can release cleanupLoop here.
+	mock.pruneCtxCb = func(ctx context.Context, epochId uint64) error {
+		if epochId == 3 {
+			<-release
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ms.pruneTimeout = 20 * time.Millisecond
+	defer close(release) // let the leaked prune goroutine finish after the test
+
+	ctx := context.Background()
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ms.cleanup()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup never returned: a ctx-ignoring backend froze cleanupLoop")
+	}
+
+	pruned := mock.getPruned()
+	// Epochs 0-2 pruned; epoch 3 is still blocked in the background goroutine,
+	// so it is not counted and minPruned stops there for retry.
+	if len(pruned) != 3 {
+		t.Errorf("expected epochs 0-2 pruned before the stuck epoch, got %d: %v", len(pruned), pruned)
+	}
+
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 3 {
+		t.Errorf("minPruned should stop at the stuck epoch 3 for retry, got %d", minPruned)
+	}
+}
+
+func TestManagedStorage_AutoPruneDoesNotStackStuckGoroutines(t *testing.T) {
+	mock := newMockStorage()
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	var stuckInvocations int32
+	// Epoch 3 blocks WITHOUT observing ctx, simulating a ctx-ignoring backend
+	// (FileStorage's os.RemoveAll) whose prune goroutine keeps running after the
+	// deadline. On the OLD code pruneEpochWithTimeout returned on timeout without
+	// tracking that still-running prune, so every cleanup tick spawned a fresh
+	// goroutine for the same stuck epoch -- N ticks meant N live goroutines all
+	// calling PruneEpoch(3) (the maintainer's "stuck tasks keep growing"). The
+	// single-flight guard caps that at exactly one.
+	mock.pruneCtxCb = func(ctx context.Context, epochId uint64) error {
+		if epochId == 3 {
+			atomic.AddInt32(&stuckInvocations, 1)
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+		}
+		return nil
+	}
+	ms := NewManagedStorageWithSize(mock, 2, time.Minute, 100)
+	ms.pruneTimeout = 20 * time.Millisecond
+	defer close(release) // let the single leaked prune goroutine finish after the test
+
+	ctx := context.Background()
+	for i := uint64(0); i <= 10; i++ {
+		ms.Store(ctx, "inf-"+string(rune('a'+i)), i, []byte("p"), []byte("r"))
+	}
+
+	// Drive several cleanup ticks while epoch 3 stays stuck. Tick 1 spawns the
+	// prune goroutine for epoch 3 and times out; ticks 2+ see the in-flight
+	// marker and return without spawning. Old code: 3 invocations (one per tick).
+	const ticks = 3
+	for i := 0; i < ticks; i++ {
+		ms.cleanup()
+	}
+
+	// The stuck prune runs in a background goroutine; wait until it has actually
+	// entered the blocking callback so the count reflects real invocations rather
+	// than an unscheduled goroutine (which would read 0 and spuriously pass/fail).
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stuck prune goroutine never entered PruneEpoch for epoch 3")
+	}
+
+	if got := atomic.LoadInt32(&stuckInvocations); got != 1 {
+		t.Errorf("stuck epoch 3 must be invoked exactly once across %d ticks, got %d "+
+			"(each extra invocation is a leaked background goroutine that never stops)", ticks, got)
+	}
+
+	// Epochs 0-2 pruned once; epoch 3 stuck, so minPruned stops there for retry.
+	ms.mu.RLock()
+	minPruned := ms.minPruned
+	ms.mu.RUnlock()
+	if minPruned != 3 {
+		t.Errorf("minPruned should stop at the stuck epoch 3, got %d", minPruned)
+	}
+}
+
 func TestManagedStorage_NoPruneWhenBelowRetainCount(t *testing.T) {
 	mock := newMockStorage()
 	ms := NewManagedStorageWithSize(mock, 5, time.Minute, 100)
@@ -204,11 +461,9 @@ func TestManagedStorage_NoPruneWhenBelowRetainCount(t *testing.T) {
 	}
 
 	ms.cleanup()
-	time.Sleep(50 * time.Millisecond)
 
 	pruned := mock.getPruned()
 	if len(pruned) != 0 {
 		t.Errorf("should not prune when maxEpoch <= retainCount, got %v", pruned)
 	}
 }
-

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -2534,6 +2534,7 @@ func (g *Gateway) handleAdminState(w http.ResponseWriter, r *http.Request) {
 	}
 	views := make([]adminDevshardView, 0, len(state.Devshards))
 	for _, devshard := range state.Devshards {
+		devshard.PrivateKeyHex = ""
 		view := adminDevshardView{GatewayDevshardState: devshard}
 		if snapshot, ok := runtimeByID[devshard.ID]; ok {
 			s := snapshot

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -804,6 +804,51 @@ func TestGatewayModelsEndpointRejectsUnsupportedMethod(t *testing.T) {
 	require.Equal(t, "GET, HEAD", rec.Header().Get("Allow"))
 }
 
+func TestAdminStateRedactsPrivateKey(t *testing.T) {
+	const privateKey = "super-secret-private-key"
+	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+	require.NoError(t, store.Initialize(GatewaySettings{
+		ChainREST:               "http://node:1317",
+		PublicAPI:               "http://api:9000",
+		DefaultModel:            "Qwen/Test",
+		DefaultRequestMaxTokens: 1000,
+		MaxConcurrentRequests:   2,
+		MaxInputTokensInFlight:  200,
+	}, []GatewayDevshardState{
+		{
+			RuntimeConfig: RuntimeConfig{
+				ID:            "12",
+				PrivateKeyHex: privateKey,
+				PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+				Model:         "Qwen/Test",
+			},
+			Active: true,
+		},
+	}))
+
+	g := NewGateway(nil, NewGatewayLimiter(0, 0), "Qwen/Test")
+	g.store = store
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/state", nil)
+	rec := httptest.NewRecorder()
+	g.handleAdminState(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), privateKey)
+
+	var body struct {
+		Devshards []map[string]any `json:"devshards"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Devshards, 1)
+	require.NotContains(t, body.Devshards[0], "private_key")
+	require.Equal(t, "DEVSHARD_PRIVATE_KEY", body.Devshards[0]["private_key_env"])
+}
+
 func TestAdminDeactivateDevshardAllowsActiveRequestsAndStopsNewChat(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)

--- a/inference-chain/app/upgrades.go
+++ b/inference-chain/app/upgrades.go
@@ -18,6 +18,7 @@ import (
 	"github.com/productscience/inference/app/upgrades/v0_2_13"
 	"github.com/productscience/inference/app/upgrades/v0_2_14"
 	"github.com/productscience/inference/app/upgrades/v0_2_15"
+	"github.com/productscience/inference/app/upgrades/v0_2_16"
 	v0_2_2 "github.com/productscience/inference/app/upgrades/v0_2_2"
 	v0_2_3 "github.com/productscience/inference/app/upgrades/v0_2_3"
 	"github.com/productscience/inference/app/upgrades/v0_2_4"
@@ -71,6 +72,7 @@ func (app *App) setupUpgradeHandlers() {
 	app.setTrackedUpgradeHandler(v0_2_13.UpgradeName, v0_2_13.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.AuthzKeeper, app.GovKeeper))
 	app.setTrackedUpgradeHandler(v0_2_14.UpgradeName, v0_2_14.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.GenesistransferKeeper, app.MintKeeper))
 	app.setTrackedUpgradeHandler(v0_2_15.UpgradeName, v0_2_15.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper, app.AuthzKeeper))
+	app.setTrackedUpgradeHandler(v0_2_16.UpgradeName, v0_2_16.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.InferenceKeeper))
 }
 
 func (app *App) registerMigrations() {

--- a/inference-chain/app/upgrades/v0_2_16/constants.go
+++ b/inference-chain/app/upgrades/v0_2_16/constants.go
@@ -1,0 +1,4 @@
+package v0_2_16
+
+// UpgradeName MUST exactly match the on-chain governance proposal name.
+const UpgradeName = "v0.2.16"

--- a/inference-chain/app/upgrades/v0_2_16/upgrades.go
+++ b/inference-chain/app/upgrades/v0_2_16/upgrades.go
@@ -1,0 +1,45 @@
+// Package v0_2_16 holds the upgrade handler scaffold for the v0.2.16 release.
+//
+// At bootstrap time this stays intentionally small: capability-version fix
+// plus RunMigrations. As upgrade work lands, add migration steps below the
+// capability fix and above RunMigrations.
+//
+// If later work bumps a module ConsensusVersion, it must also register the
+// corresponding migration in app/upgrades.go's registerMigrations().
+package v0_2_16
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	k keeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		k.LogInfo("starting upgrade", types.Upgrades, "version", UpgradeName)
+
+		// Capability state can already exist even when the version map entry is
+		// missing. Set it explicitly so RunMigrations does not re-run InitGenesis.
+		if _, ok := fromVM["capability"]; !ok {
+			fromVM["capability"] = mm.Modules["capability"].(module.HasConsensusVersion).ConsensusVersion()
+		}
+
+		// Future v0.2.16 migration steps land below this line.
+
+		toVM, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return toVM, err
+		}
+
+		k.LogInfo("successfully upgraded", types.Upgrades, "version", UpgradeName)
+		return toVM, nil
+	}
+}

--- a/inference-chain/app/upgrades/v0_2_16/upgrades_test.go
+++ b/inference-chain/app/upgrades/v0_2_16/upgrades_test.go
@@ -1,0 +1,13 @@
+package v0_2_16
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpgradeName pins the future on-chain proposal name. The governance
+// proposal and UpgradeName must stay identical or the handler will not run.
+func TestUpgradeName(t *testing.T) {
+	require.Equal(t, "v0.2.16", UpgradeName)
+}

--- a/versioned/internal/config/config.go
+++ b/versioned/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	BasePort          int
 	ReadyPath         string
 	ReadyTimeout      time.Duration
+	ReadyMaxWait      time.Duration
 	DrainPath         string
 	DrainStatusPath   string
 	DrainTimeout      time.Duration
@@ -44,6 +45,7 @@ func Load() (Config, error) {
 		BasePort:          5000,
 		ReadyPath:         envOrDefault("VERSIOND_READY_PATH", "/ready"),
 		ReadyTimeout:      parseDuration("VERSIOND_READY_TIMEOUT", 60*time.Second),
+		ReadyMaxWait:      parseDuration("VERSIOND_READY_MAX_WAIT", 32*time.Minute),
 		DrainPath:         envOrDefault("VERSIOND_DRAIN_PATH", "/drain"),
 		DrainStatusPath:   envOrDefault("VERSIOND_DRAIN_STATUS_PATH", "/drain/status"),
 		DrainTimeout:      parseDuration("VERSIOND_DRAIN_TIMEOUT", 15*time.Minute),

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -37,6 +37,7 @@ const (
 	storageModePostgres          = "postgres"
 	defaultDevshardShutdownGrace = 10 * time.Minute
 	installedVersionRetain       = 3
+
 )
 
 var (
@@ -114,6 +115,12 @@ func normalizeConfig(cfg config.Config) config.Config {
 	}
 	if cfg.ReadyTimeout <= 0 {
 		cfg.ReadyTimeout = 60 * time.Second
+	}
+	if cfg.ReadyMaxWait <= 0 {
+		cfg.ReadyMaxWait = 32 * time.Minute
+	}
+	if cfg.ReadyMaxWait < cfg.ReadyTimeout {
+		cfg.ReadyMaxWait = cfg.ReadyTimeout
 	}
 	if cfg.DrainPath == "" {
 		cfg.DrainPath = "/drain"
@@ -1112,6 +1119,11 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 	backoff := time.Second
 	lastStart := time.Now()
 
+	// Grows with each failed attempt, capped at ReadyMaxWait: a restart discards the
+	// child's startup work, so a fixed window can loop forever without ever letting
+	// startup finish.
+	readyWindow := m.cfg.ReadyTimeout
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -1139,8 +1151,12 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 			return
 		}
 
-		if !waitForChildServingReady(ctx, c, m.cfg.ReadyPath, m.cfg.ReadyTimeout) {
-			slog.Warn("child did not become ready in time", "version", c.version.Name, "port", c.port, "lifecycle_port", c.lifecyclePort(), "ready_path", m.cfg.ReadyPath)
+		if !waitForChildServingReady(ctx, c, m.cfg.ReadyPath, readyWindow) {
+			slog.Warn("child did not become ready in time; restarting with a longer window",
+				"version", c.version.Name, "port", c.port, "lifecycle_port", c.lifecyclePort(),
+				"ready_path", m.cfg.ReadyPath, "ready_window", readyWindow,
+				"next_ready_window", nextReadyWindow(readyWindow, m.cfg.ReadyMaxWait))
+			readyWindow = nextReadyWindow(readyWindow, m.cfg.ReadyMaxWait)
 			proc.ForceStop()
 			_ = proc.Wait()
 			m.mu.Lock()
@@ -1358,6 +1374,15 @@ func waitForReady(ctx context.Context, port int, path string, timeout time.Durat
 // waitForChildServingReady gates the Starting -> Running transition. Modern
 // devshardd children must be logically ready on their admin listener and also
 // serve health checks on the public listener that receives proxied traffic.
+// nextReadyWindow doubles the readiness window, capped at max.
+func nextReadyWindow(current, max time.Duration) time.Duration {
+	next := current * 2
+	if next > max || next <= 0 {
+		return max
+	}
+	return next
+}
+
 func waitForChildServingReady(ctx context.Context, c *child, path string, timeout time.Duration) bool {
 	if c.adminPort == 0 {
 		return waitForReady(ctx, c.port, path, timeout)

--- a/versioned/internal/process/ready_window_test.go
+++ b/versioned/internal/process/ready_window_test.go
@@ -1,0 +1,79 @@
+package process
+
+import (
+	"testing"
+	"time"
+
+	"versioned/internal/config"
+)
+
+func TestNextReadyWindowDoublesUpToMax(t *testing.T) {
+	max := 32 * time.Minute
+	got := time.Minute
+	want := []time.Duration{
+		2 * time.Minute,
+		4 * time.Minute,
+		8 * time.Minute,
+		16 * time.Minute,
+		32 * time.Minute,
+		32 * time.Minute,
+		32 * time.Minute,
+	}
+	for i, expect := range want {
+		got = nextReadyWindow(got, max)
+		if got != expect {
+			t.Fatalf("step %d: nextReadyWindow = %v, want %v", i+1, got, expect)
+		}
+	}
+}
+
+func TestNextReadyWindowCapsWhenAlreadyAboveMax(t *testing.T) {
+	if got := nextReadyWindow(60*time.Minute, 32*time.Minute); got != 32*time.Minute {
+		t.Fatalf("nextReadyWindow = %v, want %v", got, 32*time.Minute)
+	}
+}
+
+func TestNextReadyWindowHandlesOverflow(t *testing.T) {
+	max := 32 * time.Minute
+	if got := nextReadyWindow(time.Duration(1)<<62, max); got != max {
+		t.Fatalf("nextReadyWindow on overflow = %v, want %v", got, max)
+	}
+}
+
+func TestReadyWindowEventuallyReachesCeiling(t *testing.T) {
+	max := 32 * time.Minute
+	w := 60 * time.Second
+	attempts := 0
+	for w < max {
+		w = nextReadyWindow(w, max)
+		attempts++
+		if attempts > 10 {
+			t.Fatalf("window did not reach ceiling: stuck at %v", w)
+		}
+	}
+	if w != max {
+		t.Fatalf("final window = %v, want %v", w, max)
+	}
+	if attempts != 5 {
+		t.Fatalf("attempts to reach ceiling = %d, want 5 (60s->2m->4m->8m->16m->32m)", attempts)
+	}
+}
+
+func TestManagerDefaultsReadyMaxWait(t *testing.T) {
+	m := NewManager(config.Config{BinDir: t.TempDir(), DataDir: t.TempDir()})
+	if m.cfg.ReadyMaxWait != 32*time.Minute {
+		t.Fatalf("default ReadyMaxWait = %v, want 32m", m.cfg.ReadyMaxWait)
+	}
+}
+
+func TestManagerReadyMaxWaitNeverBelowReadyTimeout(t *testing.T) {
+	m := NewManager(config.Config{
+		BinDir:       t.TempDir(),
+		DataDir:      t.TempDir(),
+		ReadyTimeout: 10 * time.Minute,
+		ReadyMaxWait: time.Minute,
+	})
+	if m.cfg.ReadyMaxWait != 10*time.Minute {
+		t.Fatalf("ReadyMaxWait = %v, want it raised to ReadyTimeout (10m)", m.cfg.ReadyMaxWait)
+	}
+}


### PR DESCRIPTION
## Problem

`versiond` gives each child a fixed 60s to become ready. A child that needs longer is force-stopped and restarted, which discards the startup work it had already done. The next attempt gets the same 60s, so the window never grows and startup can never complete.

This hit two production nodes: `devshardd` v3 restoring a large session store restarted every ~2 minutes indefinitely and never served its port. The child reported no error — it was alive and working, just not finished within the window. Recovery required deleting the data directory, which loses unsealed sessions.

## Fix

Grow the readiness window on each failed attempt: **60s → 2m → 4m → 8m → 16m → 32m**, then keep retrying at that ceiling.

A slow-but-healthy start now gets a window large enough to finish, instead of being cut off at a constant unrelated to how much data the child has to load. Restarts never stop, so a child stuck for a reason that later clears still recovers without operator action.

## Changes

- `internal/config/config.go` — add `ReadyMaxWait` (`VERSIOND_READY_MAX_WAIT`, default 32m)
- `internal/process/manager.go` — grow the readiness window per attempt, capped at `ReadyMaxWait`; add `nextReadyWindow`
- `internal/process/ready_window_test.go` — new: tests for the backoff sequence, the cap, overflow, and config defaults

## Scope

`versioned/` only. Startup work is still discarded between attempts — persisting partial progress would require changes in `devshard/`.