### PR TITLE
`devshard` Credit the executor at the settlement drain for Pending inferences

### DIFF
--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -342,10 +342,11 @@ func WithMaxNonceProvider(p devshard.MaxNonceProvider) HostOption {
 // via CompositeChecker.
 //
 // Production HostManager intentionally does not use this option: settlement
-// protection comes from deterministic drain accounting (settleLiveRecordLocked),
-// not signature withholding. WithGrace must not be paired with finish-gossip
-// recovery — gossip is a best-effort convenience for the user to sequence a
-// real Finish at actual cost; withholding would freeze settlement instead.
+// protection comes from deterministic drain accounting (settleLiveRecordLocked
+// credits reserved on both Started and Pending), not signature withholding.
+// WithGrace must not be paired with finish-gossip recovery — gossip is a
+// best-effort convenience for the user to sequence a real Finish at actual
+// cost; withholding would freeze settlement instead.
 func WithGrace(grace uint64) HostOption {
 	return func(h *Host) {
 		sc := NewStalenessChecker(h.mempool, grace)

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -1489,17 +1489,16 @@ func (sm *StateMachine) applyFinalizeRound() error {
 // still-live inference at the Finalizing->Settlement drain.
 func (sm *StateMachine) settleLiveRecordLocked(rec *types.InferenceRecord) {
 	switch rec.Status {
-	case types.StatusStarted:
-		// Host committed via signed receipt: pay reserved (surplus == 0).
+	case types.StatusStarted, types.StatusPending:
+		// Credit reserved. ConfirmStart is sequenced only by the user, and
+		// delivery (receipt + execute + stream) happens before promotion to
+		// Started, so a still-Pending record at drain cannot be treated as
+		// "no work". Genuine no-work refunds stay on
+		// MsgTimeoutInference(REFUSED), which Missed++ and releases the
+		// reservation. Do not Missed++ here.
 		rec.ActualCost = rec.ReservedCost
 		rec.Status = types.StatusFinished
 		sm.state.HostStats[rec.ExecutorSlot].Cost += rec.ReservedCost
-	case types.StatusPending:
-		// No commitment: refund the reservation to the creator.
-		sm.state.Balance += rec.ReservedCost
-		rec.ActualCost = 0
-		rec.Status = types.StatusTimedOut
-		// Do not Missed++: state cannot distinguish user censorship from host absence.
 	case types.StatusChallenged:
 		// Mid-dispute: keep current tally-driven status; seal as-is.
 	default:

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -2393,7 +2393,7 @@ func TestDrainSettle_StartedAutoFinishes(t *testing.T) {
 	require.Equal(t, uint64(150), sealed.ActualCost)
 }
 
-func TestDrainSettle_PendingRefunds(t *testing.T) {
+func TestDrainSettle_PendingCreditsHost(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{
 		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
 	}
@@ -2412,14 +2412,14 @@ func TestDrainSettle_PendingRefunds(t *testing.T) {
 	advanceToSettlement(t, sm, user, len(hosts))
 
 	after := sm.SnapshotState()
-	require.Equal(t, before.Balance+150, after.Balance)
-	require.Equal(t, uint64(0), after.HostStats[1].Cost)
+	require.Equal(t, before.Balance, after.Balance)
+	require.Equal(t, uint64(150), after.HostStats[1].Cost)
 	require.Equal(t, uint32(0), after.HostStats[1].Missed)
 
 	sealed, ok := sm.LookupSealedInference(1)
 	require.True(t, ok)
-	require.Equal(t, types.StatusTimedOut, sealed.Status)
-	require.Equal(t, uint64(0), sealed.ActualCost)
+	require.Equal(t, types.StatusFinished, sealed.Status)
+	require.Equal(t, uint64(150), sealed.ActualCost)
 }
 
 func TestDrainSettle_ChallengedUnchanged(t *testing.T) {
@@ -2555,7 +2555,7 @@ func TestDrainSettle_MixedDeterministic(t *testing.T) {
 	require.Equal(t, stA.HostStats, stB.HostStats)
 	require.Equal(t, stA.Balance, stB.Balance)
 
-	require.Equal(t, uint64(0), stA.HostStats[1].Cost)
+	require.Equal(t, uint64(150), stA.HostStats[1].Cost)
 	require.Equal(t, uint64(150), stA.HostStats[4].Cost)
 	require.Equal(t, uint64(120), stA.HostStats[2].Cost)
 
@@ -3298,10 +3298,10 @@ func TestSettleLiveRecordLocked_Pending(t *testing.T) {
 	callSettleLiveRecordLocked(t, sm, sm.state.Inferences[1])
 
 	after := sm.SnapshotState()
-	require.Equal(t, types.StatusTimedOut, after.Inferences[1].Status)
-	require.Equal(t, uint64(0), after.Inferences[1].ActualCost)
-	require.Equal(t, before.Balance+rec.ReservedCost, after.Balance)
-	require.Equal(t, uint64(0), after.HostStats[1].Cost)
+	require.Equal(t, types.StatusFinished, after.Inferences[1].Status)
+	require.Equal(t, uint64(150), after.Inferences[1].ActualCost)
+	require.Equal(t, before.Balance, after.Balance)
+	require.Equal(t, uint64(150), after.HostStats[1].Cost)
 	require.Equal(t, uint32(0), after.HostStats[1].Missed)
 }
 


### PR DESCRIPTION
## Summary
- Credit `ReservedCost` at the Finalizing→Settlement drain for both `Pending` and `Started` inferences.
- Closes free-compute via ConfirmStart censorship: delivery can happen before promotion to `Started`, and only the user sequences that promotion.
- Genuine no-work refunds stay on `MsgTimeoutInference(REFUSED)` (`Missed++` + reservation release).

## Notes
- Consensus-affecting: alters `HostStats` / `Balance` at the settlement nonce — group members and gateways must upgrade together.