### PR TITLE
fix(security): add dial-time SSRF guard for participant (merging #1491)

### DIFF
--- a/common/httpguard/httpguard.go
+++ b/common/httpguard/httpguard.go
@@ -1,0 +1,101 @@
+// Package httpguard provides a dial-time SSRF guard for HTTP clients that
+// connect to participant-controlled URLs taken from chain state (devshard peer
+// host URLs, executor payload endpoints derived from Participant.InferenceUrl).
+//
+// The guard hooks net.Dialer.Control, which the stdlib calls after DNS
+// resolution and once per candidate IP, with address already "ip:port".
+// Checking there vets every real dial target: each dual-stack candidate and
+// each redirect hop's fresh dial. That is what defeats DNS rebinding, which a
+// resolve-then-connect check cannot -- the gap between the lookup and the
+// connect is exactly the attack.
+//
+// The on-chain registration gate (inference-chain x/inference/utils
+// ValidateURLWithSSRFProtection) can only reject literal private IPs: it runs
+// inside a stateless ValidateBasic, so it must stay deterministic and cannot
+// resolve DNS. This guard is the enforcement point, and it reuses that gate's
+// predicate (utils.IsPrivateIP) so both agree on what "private" means.
+package httpguard
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/productscience/inference/x/inference/utils"
+)
+
+// allowPrivate toggles the guard process-wide. Default false = secure.
+//
+// It is package-level rather than per-client because devshard's transport cache
+// is global and keyed only by baseURL, so a per-client setting could not be
+// threaded into an already-cached dialer. DialControl reads it on every dial,
+// so the toggle applies to clients constructed before it is set (notably the
+// package-level validation.PayloadRetrievalClient).
+var allowPrivate atomic.Bool
+
+// SetAllowPrivate configures whether guarded dialers may connect to
+// private/internal addresses. Callers wire this once at startup from their
+// environment (devshardd reads DEVSHARD_ALLOW_PRIVATE_ADDRESSES). Set true only
+// in local dev / docker-compose / e2e, where hosts register docker-internal
+// hostnames that resolve to private IPs.
+func SetAllowPrivate(allow bool) {
+	allowPrivate.Store(allow)
+}
+
+// AllowPrivate reports whether the guard is currently disabled.
+func AllowPrivate() bool {
+	return allowPrivate.Load()
+}
+
+// DialControl is a net.Dialer.Control hook that rejects connections to
+// private/internal IP addresses unless SetAllowPrivate(true) was called.
+func DialControl(_, address string, _ syscall.RawConn) error {
+	if allowPrivate.Load() {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		// address is already "ip:port" at this point; fail closed.
+		return fmt.Errorf("ssrf guard: cannot parse dial address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("ssrf guard: unresolved dial address %q", address)
+	}
+	if utils.IsPrivateIP(ip) {
+		return fmt.Errorf("ssrf guard: blocked dial to private address %s", ip)
+	}
+	return nil
+}
+
+// NewDialer returns a dialer carrying the guard, with the same timeouts the
+// stdlib default transport uses.
+func NewDialer() *net.Dialer {
+	return &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   DialControl,
+	}
+}
+
+// NewNoRedirectClient builds a guarded *http.Client that also refuses to follow
+// 3xx responses, so a public host cannot redirect a fetch to a private target.
+// The caller observes the 3xx as a non-200 status. Redirect refusal is defense
+// in depth: DialControl already re-checks each hop's dial.
+//
+// The transport is cloned from http.DefaultTransport so proxy/keep-alive/HTTP2
+// behavior matches the stdlib.
+func NewNoRedirectClient(timeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = NewDialer().DialContext
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}

--- a/common/httpguard/httpguard_test.go
+++ b/common/httpguard/httpguard_test.go
@@ -51,6 +51,7 @@ func TestDialControlBlocksPrivateTargets(t *testing.T) {
 		"rfc1918_172":         "172.16.0.1",
 		"rfc1918_192":         "192.168.1.1",
 		"unspecified":         "0.0.0.0",
+		"ipv6_unspecified":    "::",
 		"ipv6_loopback":       "::1",
 		"ipv6_link_local":     "fe80::1",
 		"ipv6_ula":            "fc00::1",

--- a/common/httpguard/httpguard_test.go
+++ b/common/httpguard/httpguard_test.go
@@ -1,0 +1,178 @@
+package httpguard
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// resolveTo builds a client whose dialer is the guarded one but whose DNS
+// answers are forced to target, simulating a participant who registered a
+// hostname resolving (or rebinding) to an address of their choosing.
+func resolveTo(t *testing.T, target string) *http.Client {
+	t.Helper()
+	client := NewNoRedirectClient(5 * time.Second)
+	transport := client.Transport.(*http.Transport)
+	dialer := NewDialer()
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		return dialer.DialContext(ctx, network, net.JoinHostPort(target, port))
+	}
+	return client
+}
+
+func requireBlocked(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected the dial to be blocked, got nil error")
+	}
+	if !strings.Contains(err.Error(), "ssrf guard") {
+		t.Fatalf("expected an ssrf guard error, got %v", err)
+	}
+}
+
+func TestDialControlBlocksPrivateTargets(t *testing.T) {
+	SetAllowPrivate(false)
+
+	// Each case is a hostname that resolves to a private target: the literal
+	// forms an attacker can register plus the ones a naive string check misses.
+	cases := map[string]string{
+		"loopback":            "127.0.0.1",
+		"loopback_upper_8":    "127.5.6.7",
+		"cloud_metadata":      "169.254.169.254",
+		"rfc1918_10":          "10.0.0.1",
+		"rfc1918_172":         "172.16.0.1",
+		"rfc1918_192":         "192.168.1.1",
+		"unspecified":         "0.0.0.0",
+		"ipv6_loopback":       "::1",
+		"ipv6_link_local":     "fe80::1",
+		"ipv6_ula":            "fc00::1",
+		"ipv4_mapped_v6":      "::ffff:10.0.0.1",
+		"ipv4_mapped_meta_v6": "::ffff:169.254.169.254",
+	}
+
+	for name, target := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := resolveTo(t, target)
+			_, err := client.Get("http://ssrf.attacker.tld/")
+			requireBlocked(t, err)
+		})
+	}
+}
+
+// A hostname that resolves to loopback is the core of issue #1470: the on-chain
+// registration gate cannot reject it (no DNS in ValidateBasic), so the dial is
+// where it must fail. Uses a real server to prove the request never lands.
+func TestGuardBlocksHostnameResolvingToLoopback(t *testing.T) {
+	SetAllowPrivate(false)
+
+	var reached bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := resolveTo(t, "127.0.0.1")
+	_, err = client.Get("http://ssrf.attacker.tld:" + port + "/")
+	requireBlocked(t, err)
+	if reached {
+		t.Fatal("guard let the request through to the loopback server")
+	}
+}
+
+// Decimal and hex host forms are alternate spellings of 127.0.0.1. The guard
+// checks the resolved IP, so the spelling is irrelevant -- this pins that.
+func TestGuardBlocksNumericLoopbackSpellings(t *testing.T) {
+	SetAllowPrivate(false)
+
+	for _, raw := range []string{"http://2130706433/", "http://0x7f000001/", "http://127.1/"} {
+		t.Run(raw, func(t *testing.T) {
+			client := NewNoRedirectClient(5 * time.Second)
+			_, err := client.Get(raw)
+			requireBlocked(t, err)
+		})
+	}
+}
+
+// A public host answering 302 -> 127.0.0.1 must not reach the private target.
+// The redirect is refused outright; had it been followed, the new hop's dial
+// would hit the guard too.
+func TestNoRedirectClientDoesNotFollowRedirectToPrivate(t *testing.T) {
+	SetAllowPrivate(true) // let the public-side server on loopback be reachable
+
+	var privateReached bool
+	private := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		privateReached = true
+	}))
+	t.Cleanup(private.Close)
+
+	public := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, private.URL, http.StatusFound)
+	}))
+	t.Cleanup(public.Close)
+
+	client := NewNoRedirectClient(5 * time.Second)
+	resp, err := client.Get(public.URL)
+	if err != nil {
+		t.Fatalf("expected the 3xx to surface as a response, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected the caller to observe 302, got %d", resp.StatusCode)
+	}
+	if privateReached {
+		t.Fatal("client followed the redirect into the private target")
+	}
+}
+
+// Dev/test environments register docker-internal hostnames that resolve to
+// private IPs, so the opt-out has to actually let them through.
+func TestAllowPrivateLetsPrivateTargetsThrough(t *testing.T) {
+	SetAllowPrivate(true)
+	t.Cleanup(func() { SetAllowPrivate(false) })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewNoRedirectClient(5 * time.Second)
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("allowPrivate should permit the loopback dial, got %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestPublicAddressAllowedInBothModes(t *testing.T) {
+	for _, allow := range []bool{false, true} {
+		SetAllowPrivate(allow)
+		if err := DialControl("tcp", "93.184.216.34:80", nil); err != nil {
+			t.Fatalf("public address rejected with allowPrivate=%v: %v", allow, err)
+		}
+	}
+	SetAllowPrivate(false)
+}
+
+func TestDialControlFailsClosedOnMalformedAddress(t *testing.T) {
+	SetAllowPrivate(false)
+	requireBlocked(t, DialControl("tcp", "not-an-address", nil))
+	requireBlocked(t, DialControl("tcp", "still.a.hostname:80", nil))
+}

--- a/common/validation/payload_retrieval.go
+++ b/common/validation/payload_retrieval.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"common/completionapi"
+	"common/httpguard"
 	"common/logging"
 	"common/utils"
 	"context"
@@ -34,9 +35,13 @@ var ErrEpochStale = errors.New("inference epoch too old, validation no longer us
 var ErrPayloadGone = errors.New("payload no longer available on executor")
 
 // PayloadRetrievalClient is the default HTTP client for payload retrieval.
-var PayloadRetrievalClient = &http.Client{
-	Timeout: 30 * time.Second,
-}
+//
+// The request URL is built from the executor's on-chain InferenceUrl, which the
+// executor controls, so this client carries the dial-time SSRF guard and refuses
+// redirects. Without it a participant could register a hostname that resolves
+// (or later rebinds) to loopback/RFC1918/cloud-metadata and make every validator
+// fetching its payloads connect there. See common/httpguard.
+var PayloadRetrievalClient = httpguard.NewNoRedirectClient(30 * time.Second)
 
 // PayloadResponse matches the executor endpoint response.
 // Used by both chain validation and devshard validation paths.

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
+	"common/httpguard"
 	"common/logging"
 	"decentralized-api/participant"
 	"encoding/json"
@@ -40,6 +41,25 @@ import (
 
 	"github.com/productscience/inference/x/inference/types"
 )
+
+// envAllowPrivateAddresses disables the dial-time SSRF guard on outbound dials to
+// participant-controlled URLs. Set true only in local dev / docker-compose / e2e,
+// where participants register docker-internal hostnames that resolve to private
+// IPs. Production leaves it unset (default false = private targets blocked).
+const envAllowPrivateAddresses = "DAPI_ALLOW_PRIVATE_ADDRESSES"
+
+// envBool parses a boolean env var. Unset or unparseable values return fallback.
+func envBool(key string, fallback bool) bool {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
 
 // buildEarlyShareGuard constructs the DAPI-only early-share guard from config.
 // Returns nil (a valid disabled guard) when disabled or when the local sqlite
@@ -95,6 +115,16 @@ func main() {
 
 	if configManager.GetApiConfig().TestMode {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
+	}
+
+	// Wire the dial-time SSRF guard before anything can dial out. Guarded
+	// clients read the flag per dial, so this covers clients built later
+	// (notably poc.ProofClient, constructed per PoC validation round).
+	allowPrivateAddresses := envBool(envAllowPrivateAddresses, false)
+	httpguard.SetAllowPrivate(allowPrivateAddresses)
+	if allowPrivateAddresses {
+		slog.Warn("SSRF guard disabled: dials to private/internal addresses are allowed",
+			"env", envAllowPrivateAddresses)
 	}
 
 	natssrv := server.NewServer(configManager.GetNatsConfig())

--- a/decentralized-api/poc/proof_client.go
+++ b/decentralized-api/poc/proof_client.go
@@ -15,8 +15,8 @@ import (
 	"net/url"
 	"time"
 
+	"common/httpguard"
 	"common/logging"
-	"common/utils"
 	"decentralized-api/cosmosclient"
 	"decentralized-api/poc/artifacts"
 
@@ -96,9 +96,16 @@ func DefaultProofClientConfig() ProofClientConfig {
 }
 
 // NewProofClient creates a new proof client.
+//
+// The proof URL is built from the validatee's on-chain InferenceUrl, which that
+// participant controls, so this client carries the dial-time SSRF guard and
+// refuses redirects. Registration-time validation cannot resolve DNS, so a
+// hostname that resolves (or later rebinds) to loopback/RFC1918/cloud-metadata
+// passes registration and every assigned validator would otherwise dial it
+// during PoC proof retrieval. See common/httpguard.
 func NewProofClient(recorder cosmosclient.CosmosMessageClient, config ProofClientConfig) *ProofClient {
 	return &ProofClient{
-		httpClient: utils.NewHttpClient(config.Timeout),
+		httpClient: httpguard.NewNoRedirectClient(config.Timeout),
 		recorder:   recorder,
 	}
 }

--- a/decentralized-api/poc/ssrf_guard_test.go
+++ b/decentralized-api/poc/ssrf_guard_test.go
@@ -1,0 +1,148 @@
+package poc
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"common/httpguard"
+)
+
+// resolveToLoopback returns a client from NewProofClient whose DNS always
+// answers 127.0.0.1, modelling a participant that registered a public hostname
+// which resolves (or later rebinds) to a private address.
+func resolveToLoopback(t *testing.T) *http.Client {
+	t.Helper()
+	client := NewProofClient(nil, DefaultProofClientConfig()).httpClient
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	inner := transport.DialContext
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		return inner(ctx, network, net.JoinHostPort("127.0.0.1", port))
+	}
+	return client
+}
+
+func requireBlocked(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected the dial to be blocked, got nil error")
+	}
+	if !strings.Contains(err.Error(), "ssrf guard") {
+		t.Fatalf("expected an ssrf guard error, got %v", err)
+	}
+}
+
+// The PoC proof URL comes from the validatee's on-chain InferenceUrl, so the
+// client NewProofClient hands to FetchAndVerifyProofs must fail the dial when
+// that URL resolves to a private target. Registration-time validation cannot
+// catch this (no DNS in ValidateBasic), so the dial is the enforcement point.
+func TestProofClientBlocksPrivateDialTargets(t *testing.T) {
+	httpguard.SetAllowPrivate(false)
+
+	for _, target := range []string{
+		"http://127.0.0.1/v1/poc/proofs",
+		"http://169.254.169.254/v1/poc/proofs",
+		"http://10.0.0.1/v1/poc/proofs",
+		"http://192.168.1.1/v1/poc/proofs",
+		"http://[::1]/v1/poc/proofs",
+	} {
+		t.Run(target, func(t *testing.T) {
+			client := NewProofClient(nil, DefaultProofClientConfig()).httpClient
+			_, err := client.Get(target)
+			requireBlocked(t, err)
+		})
+	}
+}
+
+// A hostname resolving to loopback is the rebinding case the guard exists for:
+// the request must never reach the server behind the private address.
+func TestProofClientBlocksHostnameResolvingToLoopback(t *testing.T) {
+	httpguard.SetAllowPrivate(false)
+
+	var reached bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := resolveToLoopback(t)
+	_, err = client.Get("http://ssrf.attacker.tld:" + port + "/v1/poc/proofs")
+	requireBlocked(t, err)
+	if reached {
+		t.Fatal("guard let the proof request through to the loopback server")
+	}
+}
+
+// Local dev / docker-compose / e2e register docker-internal hostnames that
+// resolve to private IPs, so DAPI_ALLOW_PRIVATE_ADDRESSES must re-open the dial.
+// Without this, PoC proof retrieval would fail closed on every local net.
+func TestProofClientAllowsPrivateWhenToggled(t *testing.T) {
+	httpguard.SetAllowPrivate(true)
+	t.Cleanup(func() { httpguard.SetAllowPrivate(false) })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewProofClient(nil, ProofClientConfig{Timeout: 5 * time.Second}).httpClient
+	resp, err := client.Get(server.URL + "/v1/poc/proofs")
+	if err != nil {
+		t.Fatalf("expected the dial to succeed with the guard disabled, got %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// Redirect refusal is defense in depth: DialControl already re-checks each hop,
+// but a public validatee must not be able to bounce the fetch at all. The caller
+// sees the 3xx as a non-200 status instead of following it.
+func TestProofClientRefusesRedirects(t *testing.T) {
+	httpguard.SetAllowPrivate(true)
+	t.Cleanup(func() { httpguard.SetAllowPrivate(false) })
+
+	var followed bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		followed = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	client := NewProofClient(nil, ProofClientConfig{Timeout: 5 * time.Second}).httpClient
+	resp, err := client.Get(redirector.URL + "/v1/poc/proofs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected the 302 to surface unfollowed, got %d", resp.StatusCode)
+	}
+	if followed {
+		t.Fatal("client followed the redirect")
+	}
+}

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"common/httpguard"
+
 	devshardpkg "devshard"
 	"devshard/gossip"
 	"devshard/host"
@@ -40,6 +42,17 @@ func main() {
 	cfg, err := loadConfig()
 	if err != nil {
 		log.Fatalf("load config: %v", err)
+	}
+
+	// Peer URLs are participant-controlled. Default secure; e2e/compose opt
+	// out via DEVSHARD_ALLOW_PRIVATE_ADDRESSES so Docker-internal gossip works.
+	allowPrivate, err := boolEnv("DEVSHARD_ALLOW_PRIVATE_ADDRESSES", false)
+	if err != nil {
+		log.Fatalf("DEVSHARD_ALLOW_PRIVATE_ADDRESSES: %v", err)
+	}
+	httpguard.SetAllowPrivate(allowPrivate)
+	if allowPrivate {
+		log.Printf("SSRF guard disabled: dials to private/internal addresses are allowed")
 	}
 
 	srv, gsp, err := buildServer(ctx, cfg)

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"common/chain"
+	"common/httpguard"
 	"devshard/bridge"
 	"devshard/state"
 	"devshard/types"
@@ -129,6 +130,11 @@ func main() {
 	initGatewaySlog()
 	ConfigurePoCRequestMode(os.Getenv("DEVSHARD_POC_REQUEST_MODE"))
 	ConfigureCapacityAwareLimits(os.Getenv("DEVSHARD_CAPACITY_AWARE_LIMITS"))
+	// Wire the dial-time SSRF guard before any outbound dial. Host URLs come
+	// from chain state and are participant-controlled; the gateway's own chain
+	// RPC/public-API clients are unguarded, so private self-hosted endpoints
+	// keep working. Default secure; dev/e2e opt out via env.
+	httpguard.SetAllowPrivate(readBoolEnv("DEVSHARD_ALLOW_PRIVATE_ADDRESSES", false))
 	flags := parseCLIFlags()
 	runtimeOpts := mustLoadRuntimeOptions(flags)
 	gatewayStore := mustOpenGatewayStore(runtimeOpts.baseStorageDir)

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -13,6 +13,7 @@ import (
 
 	"common/chain"
 	"common/chainoracle/blocks"
+	"common/httpguard"
 	mlnodeclient "common/nodemanager"
 	commrc "common/runtimeconfig"
 	"common/storage/payloads"
@@ -76,6 +77,15 @@ func (p phaseEpochProvider) CurrentEpochID() uint64 {
 func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error) {
 	if err := os.MkdirAll(cfg.DataDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create data dir %s: %w", cfg.DataDir, err)
+	}
+
+	// Wire the dial-time SSRF guard before anything can dial out. Guarded
+	// clients read the flag per dial, so this also covers the package-level
+	// validation.PayloadRetrievalClient constructed at init.
+	httpguard.SetAllowPrivate(cfg.AllowPrivateAddresses)
+	if cfg.AllowPrivateAddresses {
+		slog.Warn("SSRF guard disabled: dials to private/internal addresses are allowed",
+			"env", "DEVSHARD_ALLOW_PRIVATE_ADDRESSES")
 	}
 
 	var closers closeStack

--- a/devshard/cmd/devshardd/config.go
+++ b/devshard/cmd/devshardd/config.go
@@ -26,14 +26,20 @@ import (
 var sdkConfigOnce sync.Once
 
 type runtimeConfig struct {
-	Port                    int
-	AdminAddr               string
-	DataDir                 string
-	BinaryLogVersion        string
-	RuntimeVersion          string
-	ProtocolVersion         string
-	NodeManagerAddr         string
-	HostEventsEnabled       bool
+	Port              int
+	AdminAddr         string
+	DataDir           string
+	BinaryLogVersion  string
+	RuntimeVersion    string
+	ProtocolVersion   string
+	NodeManagerAddr   string
+	HostEventsEnabled bool
+	// AllowPrivateAddresses disables the dial-time SSRF guard on outbound
+	// connections to participant-controlled URLs (peer devshard hosts, executor
+	// payload endpoints). Default false = secure. Set true only in local dev /
+	// docker-compose / e2e, where hosts register docker-internal hostnames that
+	// resolve to private IPs. Env: DEVSHARD_ALLOW_PRIVATE_ADDRESSES.
+	AllowPrivateAddresses   bool
 	ValidationRetryInterval time.Duration
 	ValidationLeaseTTL      time.Duration
 	ShutdownGrace           time.Duration
@@ -146,6 +152,7 @@ func loadRuntimeConfig(args []string, protocolVersion, linkBinaryVersion string)
 		ProtocolVersion:         protocolVersion,
 		NodeManagerAddr:         envOr("NODE_MANAGER_ADDR", "localhost:9400"),
 		HostEventsEnabled:       envBoolOr("DEVSHARD_HOST_EVENTS_ENABLED", true),
+		AllowPrivateAddresses:   envBoolOr("DEVSHARD_ALLOW_PRIVATE_ADDRESSES", false),
 		ValidationRetryInterval: retryInterval,
 		ValidationLeaseTTL:      leaseTTL,
 		ShutdownGrace:           shutdownGrace,

--- a/devshard/e2e/containers_test.go
+++ b/devshard/e2e/containers_test.go
@@ -159,6 +159,9 @@ func startE2EEnv(ctx context.Context, t *testing.T, images e2eImages, opts e2eEn
 			"DEVSHARD_STORAGE_PATH":  "/tmp/devshardctl",
 			"DEVSHARD_MODEL":         "stub-model",
 			"GATEWAY_MAX_TOKENS_CAP": "4096",
+			// Hosts are Docker DNS names that resolve to private IPs.
+			// Production leaves this unset so the dial-time SSRF guard stays on.
+			"DEVSHARD_ALLOW_PRIVATE_ADDRESSES": "true",
 		},
 		waitPath: "/v1/status",
 	})
@@ -222,6 +225,8 @@ func (e *e2eEnv) startHostWithEnv(ctx context.Context, t *testing.T, index int, 
 		"DEVSHARD_USER_PRIVATE_KEY":  testutil.UserPrivateKey,
 		"DEVSHARD_PEER_URLS":         strings.Join(e.hostURLs, ","),
 		"DEVSHARD_STUB_INFERENCE":    "1",
+		// Peer URLs are compose aliases on the test network (private IPs).
+		"DEVSHARD_ALLOW_PRIVATE_ADDRESSES": "true",
 	}
 	for k, v := range e2eHostSessionEnv() {
 		env[k] = v

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -3,11 +3,14 @@ package protocol
 import (
 	"context"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
+
+	"common/httpguard"
 
 	"devshard/gossip"
 	"devshard/host"
@@ -20,6 +23,15 @@ import (
 	"devshard/types"
 	"devshard/user"
 )
+
+// TestMain enables the permissive dialer for this package's HTTP integration
+// tests, which spin up httptest servers on 127.0.0.1 and reach them through the
+// real transport dialer. Without this the dial-time SSRF guard (default secure)
+// would block the loopback connections.
+func TestMain(m *testing.M) {
+	httpguard.SetAllowPrivate(true)
+	os.Exit(m.Run())
+}
 
 type httpTestEnv struct {
 	session     *user.Session

--- a/devshard/testenv/cmd/gencompose/compose.go
+++ b/devshard/testenv/cmd/gencompose/compose.go
@@ -139,6 +139,9 @@ services:
       KEY_NAME: {{ versiondKeyName $ . }}
       DEVSHARD_VALIDATION_LEASE_TTL: ${DEVSHARD_VALIDATION_LEASE_TTL:-30m}
       DEVSHARD_VALIDATION_RETRY_INTERVAL: ${DEVSHARD_VALIDATION_RETRY_INTERVAL:-5m}
+      # Peers/executors here are compose service names resolving to private IPs,
+      # so the dial-time SSRF guard must be off. Production leaves this unset.
+      DEVSHARD_ALLOW_PRIVATE_ADDRESSES: "true"
       DEVSHARD_OTEL_ENABLED: ${TESTENV_OTEL_ENABLED:-false}
       OTEL_ENDPOINT: ${TESTENV_OTEL_ENDPOINT:-}
 {{ if and (eq $.Versiond.Mode "multi") (isHAReplica $ .) }}
@@ -227,6 +230,8 @@ services:
       DEVSHARD_PRIVATE_KEY: ${TESTENV_USER_PRIVATE_KEY}
       DEVSHARD_ADMIN_API_KEY: ${TESTENV_ADMIN_API_KEY}
       DEVSHARD_STORAGE_DIR: /var/lib/devshardctl
+      # Hosts are compose service names resolving to private IPs; see versiond.
+      DEVSHARD_ALLOW_PRIVATE_ADDRESSES: "true"
       GATEWAY_MAX_TOKENS_CAP: "4096"
     volumes:
       - ./data/devshardctl:/var/lib/devshardctl

--- a/devshard/testenv/scenarios/ssrf_guard_test.go
+++ b/devshard/testenv/scenarios/ssrf_guard_test.go
@@ -1,0 +1,17 @@
+package scenarios
+
+import (
+	"os"
+	"testing"
+
+	"common/httpguard"
+)
+
+// TestMain enables the permissive dialer for this package's tests. Height-sync
+// E2E-in-unit tests POST to httptest servers on 127.0.0.1 through the real
+// transport, which carries the dial-time SSRF guard (secure by default) and
+// would otherwise reject every loopback connection.
+func TestMain(m *testing.M) {
+	httpguard.SetAllowPrivate(true)
+	os.Exit(m.Run())
+}

--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -25,6 +24,7 @@ import (
 	"devshard/types"
 
 	"common/chainoracle/blocks"
+	"common/httpguard"
 
 	devshardpkg "devshard"
 )
@@ -36,10 +36,10 @@ func getTransport(baseURL string) *http.Transport {
 		return t.(*http.Transport)
 	}
 	fallbackAddress := transportAddress(baseURL)
-	dialer := &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}
+	// Dial-time SSRF guard: baseURL is a participant-controlled peer URL, so
+	// every dial is vetted against the private/internal ranges unless the
+	// process explicitly opts out (dev/test). See common/httpguard.
+	dialer := httpguard.NewDialer()
 	t := &http.Transport{
 		MaxIdleConnsPerHost: 4,
 		IdleConnTimeout:     120 * time.Second,

--- a/devshard/transport/ssrf_guard_test.go
+++ b/devshard/transport/ssrf_guard_test.go
@@ -1,0 +1,17 @@
+package transport
+
+import (
+	"os"
+	"testing"
+
+	"common/httpguard"
+)
+
+// TestMain enables the permissive dialer for this package's tests. They point
+// HTTPClient at httptest servers on 127.0.0.1 and dial them through the real
+// transport, which carries the dial-time SSRF guard (secure by default) and
+// would otherwise reject every loopback connection.
+func TestMain(m *testing.M) {
+	httpguard.SetAllowPrivate(true)
+	os.Exit(m.Run())
+}

--- a/devshard/user/ssrf_guard_test.go
+++ b/devshard/user/ssrf_guard_test.go
@@ -1,0 +1,17 @@
+package user
+
+import (
+	"os"
+	"testing"
+
+	"common/httpguard"
+)
+
+// TestMain enables the permissive dialer for this package's tests. Height-sync
+// seed tests point HTTPClient at httptest servers on 127.0.0.1 and dial them
+// through the real transport, which carries the dial-time SSRF guard (secure
+// by default) and would otherwise reject every loopback connection.
+func TestMain(m *testing.M) {
+	httpguard.SetAllowPrivate(true)
+	os.Exit(m.Run())
+}

--- a/inference-chain/x/inference/utils/signature_and_url_validation.go
+++ b/inference-chain/x/inference/utils/signature_and_url_validation.go
@@ -124,6 +124,13 @@ func isPrivateIP(ip net.IP) bool {
 		ip = v4
 	}
 
+	// Unspecified (0.0.0.0 and ::). A dial to either commonly lands on a
+	// loopback-bound listener on dual-stack hosts; 0.0.0.0 was already
+	// blocked, :: was not.
+	if ip.IsUnspecified() {
+		return true
+	}
+
 	// Loopback (127.0.0.0/8, ::1)
 	if ip.IsLoopback() {
 		return true
@@ -151,10 +158,6 @@ func isPrivateIP(ip net.IP) bool {
 		}
 		// 192.168.0.0/16
 		if ip4[0] == 192 && ip4[1] == 168 {
-			return true
-		}
-		// 0.0.0.0
-		if ip4[0] == 0 && ip4[1] == 0 && ip4[2] == 0 && ip4[3] == 0 {
 			return true
 		}
 		// AWS metadata endpoint 169.254.169.254

--- a/inference-chain/x/inference/utils/signature_and_url_validation.go
+++ b/inference-chain/x/inference/utils/signature_and_url_validation.go
@@ -66,6 +66,9 @@ func ValidateURL(fieldName, raw string) error {
 
 // ValidateURLWithSSRFProtection validates URL format and rejects private/internal addresses
 // to prevent SSRF attacks. This should be used for participant-controlled URLs.
+//
+// Deterministic only: no DNS resolution here (ValidateBasic must be pure).
+// The dial-time guard is the real defense against hostname/rebinding SSRF.
 func ValidateURLWithSSRFProtection(fieldName, raw string) error {
 	if err := ValidateURL(fieldName, raw); err != nil {
 		return err
@@ -101,8 +104,26 @@ func isLocalhost(host string) bool {
 		host == "0.0.0.0"
 }
 
+// IsPrivateIP reports whether ip is in a private/internal range that a
+// participant-controlled URL must never be allowed to reach (loopback,
+// link-local, RFC1918, ULA, cloud metadata, etc.). It is the exported wrapper
+// around isPrivateIP so out-of-package dial-time SSRF guards can reuse the exact
+// same policy as the registration gate.
+func IsPrivateIP(ip net.IP) bool {
+	return isPrivateIP(ip)
+}
+
 // isPrivateIP checks if an IP address is in a private/internal range
 func isPrivateIP(ip net.IP) bool {
+	// Normalize IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1, ::ffff:169.254.169.254)
+	// to their 4-byte form so the IPv4 rules below apply. Without this,
+	// ip.To4() inside the IPv4 block already handles mapped addresses, but the
+	// loopback/link-local checks on the mapped form are also covered by the
+	// stdlib methods; normalizing up-front keeps the whole predicate consistent.
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+
 	// Loopback (127.0.0.0/8, ::1)
 	if ip.IsLoopback() {
 		return true

--- a/inference-chain/x/inference/utils/signature_and_url_validation_test.go
+++ b/inference-chain/x/inference/utils/signature_and_url_validation_test.go
@@ -24,6 +24,11 @@ func TestValidateURLWithSSRFProtection(t *testing.T) {
 		require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
 	})
 
+	t.Run("reject_ipv6_unspecified", func(t *testing.T) {
+		err := ValidateURLWithSSRFProtection("inference_url", "http://[::]:8080")
+		require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
+	})
+
 	// Registration gate is intentionally DNS-free (stateless ValidateBasic must
 	// be deterministic), so a hostname always passes here regardless of what it
 	// resolves to. The real defense is the dial-time guard; see IsPrivateIP tests.
@@ -44,7 +49,9 @@ func TestIsPrivateIP(t *testing.T) {
 		"192.168.1.1",            // RFC1918 192.168/16
 		"169.254.169.254",        // cloud metadata / link-local
 		"169.254.0.1",            // link-local
-		"0.0.0.0",                // unspecified
+		"0.0.0.0",                // unspecified IPv4
+		"::",                     // unspecified IPv6
+		"::ffff:0.0.0.0",         // IPv4-mapped unspecified
 		"fe80::1",                // IPv6 link-local
 		"fc00::1",                // IPv6 ULA
 		"fd12:3456::1",           // IPv6 ULA

--- a/inference-chain/x/inference/utils/signature_and_url_validation_test.go
+++ b/inference-chain/x/inference/utils/signature_and_url_validation_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net"
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -22,4 +23,50 @@ func TestValidateURLWithSSRFProtection(t *testing.T) {
 		err := ValidateURLWithSSRFProtection("inference_url", "http://192.168.0.1")
 		require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
 	})
+
+	// Registration gate is intentionally DNS-free (stateless ValidateBasic must
+	// be deterministic), so a hostname always passes here regardless of what it
+	// resolves to. The real defense is the dial-time guard; see IsPrivateIP tests.
+	t.Run("accept_hostname_no_dns_resolution", func(t *testing.T) {
+		require.NoError(t, ValidateURLWithSSRFProtection("inference_url", "http://ssrf.attacker.tld"))
+		require.NoError(t, ValidateURLWithSSRFProtection("inference_url", "http://localtest.me"))
+	})
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1",              // loopback
+		"127.5.6.7",              // loopback /8
+		"::1",                    // IPv6 loopback
+		"10.0.0.1",               // RFC1918 10/8
+		"172.16.0.1",             // RFC1918 172.16/12
+		"172.31.255.255",         // RFC1918 172.16/12 upper
+		"192.168.1.1",            // RFC1918 192.168/16
+		"169.254.169.254",        // cloud metadata / link-local
+		"169.254.0.1",            // link-local
+		"0.0.0.0",                // unspecified
+		"fe80::1",                // IPv6 link-local
+		"fc00::1",                // IPv6 ULA
+		"fd12:3456::1",           // IPv6 ULA
+		"::ffff:127.0.0.1",       // IPv4-mapped IPv6 loopback
+		"::ffff:169.254.169.254", // IPv4-mapped IPv6 metadata
+		"::ffff:10.0.0.1",        // IPv4-mapped IPv6 RFC1918
+	}
+	for _, s := range blocked {
+		ip := net.ParseIP(s)
+		require.NotNil(t, ip, "parse %s", s)
+		require.True(t, IsPrivateIP(ip), "expected %s to be private/blocked", s)
+	}
+
+	allowed := []string{
+		"8.8.8.8",
+		"1.1.1.1",
+		"93.184.216.34",     // example.com
+		"2606:2800:220:1::", // public IPv6
+	}
+	for _, s := range allowed {
+		ip := net.ParseIP(s)
+		require.NotNil(t, ip, "parse %s", s)
+		require.False(t, IsPrivateIP(ip), "expected %s to be public/allowed", s)
+	}
 }

--- a/local-test-net/docker-compose-base.yml
+++ b/local-test-net/docker-compose-base.yml
@@ -54,6 +54,10 @@ services:
       - DEBUG=true
       - IS_TEST_NET=true
       - ENFORCED_MODEL_ID=disabled
+      # Participants register docker-internal hostnames that resolve to private
+      # IPs, so the dial-time SSRF guard must be off here. Production leaves this
+      # unset (default false = private targets blocked).
+      - DAPI_ALLOW_PRIVATE_ADDRESSES=true
       - DAPI_STATS_FILE_STORAGE_ENABLED=true
       # Empty PGHOST falls back to SQLite/file storage in dapi.
       - PGHOST=${PGHOST:-${KEY_NAME}-postgres}

--- a/local-test-net/docker-compose.versiond.yml
+++ b/local-test-net/docker-compose.versiond.yml
@@ -36,6 +36,11 @@ x-versiond: &versiond
     KEYRING_BACKEND: ${KEYRING_BACKEND:-file}
     KEYRING_PASSWORD: ${KEYRING_PASSWORD:-}
     KEYRING_DIR: ${KEYRING_DIR:-/root/.inference}
+    # Local/dev only: peer hosts and executors register docker-internal
+    # hostnames that resolve to private IPs, so devshardd's dial-time SSRF
+    # guard must be disabled. Production leaves this unset (default false =
+    # private targets blocked). Inherited by the devshardd child process.
+    DEVSHARD_ALLOW_PRIVATE_ADDRESSES: "true"
     # devshardd child storage (overridden by docker-compose.devshard-postgres.yml).
     PGHOST: ${PGHOST:-}
     PGPORT: ${PGPORT:-5432}

--- a/testermint/src/main/kotlin/LocalInferencePair.kt
+++ b/testermint/src/main/kotlin/LocalInferencePair.kt
@@ -1131,6 +1131,10 @@ data class LocalInferencePair(
                     // exists in the base dir; a shared base dir makes a second escrow's
                     // proxy load the first escrow's persisted state instead.
                     " DEVSHARD_STORAGE_DIR=/tmp/devshardctl-proxy-${escrowId}" +
+                    // e2e hosts register docker-internal hostnames that resolve to
+                    // private IPs, so the dial-time SSRF guard must be off here.
+                    // Production leaves this unset (default: private targets blocked).
+                    " DEVSHARD_ALLOW_PRIVATE_ADDRESSES=true" +
                     routePrefixEnv +
                     logLevelEnv +
                     " nohup devshardctl >$stderrFile 2>&1 &" +


### PR DESCRIPTION
This is a PR for merging https://github.com/gonka-ai/gonka/pull/1491/ into devshard-v5

Original description:

Fixes #1470.

## Summary

Closes the residual SSRF left after #505/#534. The registration gate only rejects **literal** private IPs and does no DNS resolution, so any participant-controlled `InferenceUrl` hostname passes — and DNS rebinding / attacker-controlled DNS can force validator/TA DAPIs to connect to loopback, cloud metadata (`169.254.169.254`), or RFC1918 during **mandatory** payload retrieval, PoC proof fetch, and TA→executor forwarding.

The real fix is at **dial time**: a `net.Dialer.Control` hook re-checks the resolved IP on **every** connection (including each redirect hop and dual-stack candidate), which is what defeats rebinding. A registration-time resolve alone cannot.

## What changed

**Dial-time guard** applied to all sinks that dial a participant-controlled `InferenceUrl`:

| # | Sink | Location |
|---|------|----------|
| 1 | Validator payload retrieval | `internal/validation/payload_retrieval.go` |
| 2 | PoC proof fetch | `poc/proof_client.go` |
| 3 | TA → executor forward | `internal/server/public/post_chat_handler.go` |
| 4 | devshard payload fetch | `internal/devshard`, `cmd/devshardd` |
| 5 | devshard transport dialer | `devshard/transport` |

New helpers: `decentralized-api/internal/httpguard` (reuses the chain's `utils.IsPrivateIP`) and `devshard/transport/ssrf.go` (a deliberate mirror, since the `devshard` module can't import the chain utils).

**Redirects**: the payload/proof clients refuse redirects (`http.ErrUseLastResponse`), so a public `InferenceUrl` cannot `302` a validator to a private target (attack chain C).

## Correctness: shared clients

The server and devshard HTTP clients are **shared** between the operator's own trusted ML nodes (`node.InferenceUrl()`, routinely on localhost/private ranges) and untrusted participant URLs. Blanket-guarding them would break local ML calls. The guard is therefore applied via **separate clients used only for the participant path** — the trusted local-node path is never guarded.

## Deployment switch (secure by default)

Local dev / docker-compose / testermint register docker-internal hostnames (e.g. `http://genesis-api:9000`) that resolve to private IPs, so a hard dial-time block would break them. A new switch — `DAPI_API__ALLOW_PRIVATE_INFERENCE_URLS` (and `DEVSHARD_ALLOW_PRIVATE_ADDRESSES` for standalone devshardd), **default false = blocked** — is enabled only in those environments (`docker-compose-base.yml`, `DockerGroup.kt`). Production templates leave it unset, so real validators stay protected.

## Registration gate

Intentionally left **DNS-free**: `ValidateBasic` is stateless and must be deterministic across validators — network I/O there would break consensus, and a registration-time lookup can't stop rebinding regardless. A code comment documents this. Also fixes an IPv4-mapped IPv6 gap in `isPrivateIP` so `::ffff:169.254.169.254` is caught.

## Tests

- Dial guard blocks: hostname→`127.0.0.1`, →`169.254.169.254`, public→`302`→private, IPv4-mapped IPv6, decimal/hex host encodings, RFC1918/ULA/link-local.
- `allowPrivate=true` permits all of the above (dev/test regression).
- The trusted local ML path is never guarded.
- Redirects are refused by the payload/proof clients.

Verified with `go build ./...` and `go test ./...` across `decentralized-api`, `devshard`, and `inference-chain` (only pre-existing Docker-dependent testcontainers tests are skipped locally for lack of a Docker host).
