### PR TITLE
test: cover receipt timeout recovery challenge path

### DIFF
--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1176,6 +1176,33 @@ func TestHost_ChallengeReceipt_AlreadyExecuting(t *testing.T) {
 	require.Equal(t, 1, engine.calls, "engine should not be called again")
 }
 
+func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	engine := stub.NewInferenceEngine()
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+
+	receipt, confirmedAt, err := h.ChallengeReceipt(context.Background(), 1, defaultPayload(), []types.Diff{diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt, "challenge must return the executor receipt")
+	require.NotZero(t, confirmedAt, "challenge must return the receipt timestamp")
+
+	confirmTx := findMempoolConfirm(h.MempoolTxs())
+	require.NotNil(t, confirmTx, "challenge receipt must publish MsgConfirmStart for recovery")
+	confirm := confirmTx.GetConfirmStart()
+	require.Equal(t, uint64(1), confirm.InferenceId)
+	require.Equal(t, receipt, confirm.ExecutorSig)
+	require.Equal(t, confirmedAt, confirm.ConfirmedAt)
+}
+
 func TestHost_ChallengeReceipt_AlreadyFinished(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	user := testutil.MustGenerateKey(t)

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1176,7 +1176,8 @@ func TestHost_ChallengeReceipt_AlreadyExecuting(t *testing.T) {
 	require.Equal(t, 1, engine.calls, "engine should not be called again")
 }
 
-func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
+func setupChallengeReceiptHost(t *testing.T, engine devshard.InferenceEngine) (*Host, types.Diff) {
+	t.Helper()
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	user := testutil.MustGenerateKey(t)
 	group := testutil.MakeGroup(hosts)
@@ -1184,11 +1185,17 @@ func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
 	require.NoError(t, err)
-	engine := stub.NewInferenceEngine()
+	if engine == nil {
+		engine = stub.NewInferenceEngine()
+	}
 	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
 	require.NoError(t, err)
-
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	return h, diff
+}
+
+func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
+	h, diff := setupChallengeReceiptHost(t, nil)
 
 	receipt, confirmedAt, err := h.ChallengeReceipt(context.Background(), 1, defaultPayload(), []types.Diff{diff})
 	require.NoError(t, err)
@@ -1201,6 +1208,54 @@ func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
 	require.Equal(t, uint64(1), confirm.InferenceId)
 	require.Equal(t, receipt, confirm.ExecutorSig)
 	require.Equal(t, confirmedAt, confirm.ConfirmedAt)
+}
+
+func TestHost_ChallengeReceipt_ContextTimeoutStillKeepsConfirmStartInMempool(t *testing.T) {
+	engine := newCtxCapturingInferenceEngine()
+	h, diff := setupChallengeReceiptHost(t, engine)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type challengeResult struct {
+		receipt     []byte
+		confirmedAt int64
+		err         error
+	}
+	resultCh := make(chan challengeResult, 1)
+	go func() {
+		receipt, confirmedAt, err := h.ChallengeReceipt(ctx, 1, defaultPayload(), []types.Diff{diff})
+		resultCh <- challengeResult{receipt: receipt, confirmedAt: confirmedAt, err: err}
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("execution never started")
+	}
+
+	var res challengeResult
+	select {
+	case res = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ChallengeReceipt did not return after starting execution")
+	}
+	require.NoError(t, res.err)
+	require.NotEmpty(t, res.receipt)
+	require.NotZero(t, res.confirmedAt)
+
+	cancel()
+
+	confirmTx := findMempoolConfirm(h.MempoolTxs())
+	require.NotNil(t, confirmTx, "cancelled challenge context must not drop recovery MsgConfirmStart")
+	confirm := confirmTx.GetConfirmStart()
+	require.Equal(t, uint64(1), confirm.InferenceId)
+	require.Equal(t, res.receipt, confirm.ExecutorSig)
+	require.Equal(t, res.confirmedAt, confirm.ConfirmedAt)
+
+	close(engine.release)
+	require.Eventually(t, func() bool {
+		return findMempoolFinish(h.MempoolTxs()) != nil
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestHost_ChallengeReceipt_AlreadyFinished(t *testing.T) {

--- a/devshard/host/timeout_test.go
+++ b/devshard/host/timeout_test.go
@@ -130,13 +130,23 @@ func TestVerifyRefused_ReceiptInLocalMempool(t *testing.T) {
 	require.False(t, accept, "should reject: receipt in local mempool")
 }
 
-func TestVerifyRefused_ExecutorUnreachable_ValidRequest(t *testing.T) {
-	st := stateWithPendingFull(1, 1)
-	executor := &mockExecutorClient{challengeReceiptErr: errors.New("unreachable")}
+func TestVerifyRefused_ChallengeErrorAcceptsTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "executor unreachable", err: errors.New("unreachable")},
+		{name: "challenge timeout", err: context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := stateWithPendingFull(1, 1)
+			executor := &mockExecutorClient{challengeReceiptErr: tc.err}
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
-	require.NoError(t, err)
-	require.True(t, accept, "should accept: executor unreachable")
+			accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
+			require.NoError(t, err)
+			require.True(t, accept, "challenge error should be treated as executor unreachable")
+		})
+	}
 }
 
 func TestVerifyRefused_ExecutorReturnsReceipt(t *testing.T) {
@@ -327,4 +337,3 @@ func TestRecoveryTxsFor_FiltersByInferenceID(t *testing.T) {
 	got := RecoveryTxsFor([]*types.DevshardTx{nil, empty, confirm2, confirm1, finish1}, 1)
 	require.Equal(t, []*types.DevshardTx{confirm1, finish1}, got)
 }
-

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -707,6 +707,107 @@ func TestHTTP_RefusedTimeoutChallengeTimeoutThenRecoveryTxIsAvailable(t *testing
 	require.NotNil(t, findConfirmStart(recovery, prepared.Nonce()), "next check must surface executor ConfirmStart as recovery")
 }
 
+func TestHTTP_ExecutionTimeoutRejectedWhenExecutorHasFinish(t *testing.T) {
+	config := testutil.DefaultConfig(3)
+	config.ExecutionTimeout = 0
+	env := setupHTTPEnv(t, 3, 1000000, 100, config)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+
+	receipt, _, err := env.clients[executorIdx].ChallengeReceipt(ctx, prepared.Nonce(), refusedPayload(), env.session.Diffs())
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce())
+	require.NotNil(t, confirmTx)
+
+	require.NoError(t, env.session.ProcessResponse(executorIdx, &host.HostResponse{
+		Receipt:     receipt,
+		ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt,
+	}, prepared.Nonce()))
+	require.NoError(t, env.session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+
+	require.Eventually(t, func() bool {
+		return findFinish(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()) != nil
+	}, 5*time.Second, 20*time.Millisecond)
+
+	votes, recovery, err := env.session.CollectTimeoutVotes(ctx, prepared.Nonce(), types.TimeoutReason_TIMEOUT_REASON_EXECUTION, nil, env.session.TimeoutVerifiers(), env.session.Diffs())
+	require.NoError(t, err)
+	require.Empty(t, votes, "executor finish in mempool must reject execution timeout")
+	require.Empty(t, recovery, "execution-timeout rejection should not publish refused-start recovery")
+}
+
+func TestHTTP_NextRequestSettlesFinishFromExecutorMempool(t *testing.T) {
+	env := setupHTTPEnv(t, 1, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+
+	receipt, _, err := env.clients[executorIdx].ChallengeReceipt(ctx, prepared.Nonce(), refusedPayload(), env.session.Diffs())
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce())
+	require.NotNil(t, confirmTx)
+
+	require.NoError(t, env.session.ProcessResponse(executorIdx, &host.HostResponse{
+		Receipt:     receipt,
+		ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt,
+	}, prepared.Nonce()))
+	require.NoError(t, env.session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+
+	require.Eventually(t, func() bool {
+		return findFinish(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()) != nil
+	}, 5*time.Second, 20*time.Millisecond)
+	require.NotNil(t, findFinish(env.session.PendingTxs(), prepared.Nonce()),
+		"ConfirmStart publish response must pull FinishInference from executor mempool into session pending txs")
+
+	_, err = env.session.SendInference(ctx, defaultParams())
+	require.NoError(t, err)
+	require.Equal(t, types.StatusFinished, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+}
+
+func TestHTTP_ExecutionTimeoutAfterFinishPulledPendingDoesNotTimeout(t *testing.T) {
+	withHTTPTimeoutBuffer(t, 0)
+	config := testutil.DefaultConfig(1)
+	config.ExecutionTimeout = 0
+	env := setupHTTPEnv(t, 1, 1000000, 100, config)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+
+	receipt, _, err := env.clients[executorIdx].ChallengeReceipt(ctx, prepared.Nonce(), refusedPayload(), env.session.Diffs())
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce())
+	require.NotNil(t, confirmTx)
+
+	require.NoError(t, env.session.ProcessResponse(executorIdx, &host.HostResponse{
+		Receipt:     receipt,
+		ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt,
+	}, prepared.Nonce()))
+	require.NoError(t, env.session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+
+	require.Eventually(t, func() bool {
+		return findFinish(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()) != nil
+	}, 5*time.Second, 20*time.Millisecond)
+	require.NotNil(t, findFinish(env.session.PendingTxs(), prepared.Nonce()),
+		"test setup expects FinishInference to be pending before timeout handling starts")
+
+	result, err := env.session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), nil)
+	require.NoError(t, err, "pending FinishInference should be published instead of timing out the started inference")
+	require.Equal(t, "execution", result.Reason)
+	require.Equal(t, types.StatusFinished, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+}
+
 func TestHTTP_StateRecovery(t *testing.T) {
 	env := setupHTTPEnv(t, 3, 100000, 100)
 	ctx := context.Background()

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -480,6 +480,28 @@ func TestHTTP_ChallengeReceipt_RejectsTimeout(t *testing.T) {
 	require.Equal(t, 0, len(votes), "all hosts should reject timeout because executor is alive and produced receipt")
 }
 
+func TestHTTP_RefusedTimeoutChallengeRecoveryLandsInNextDiff(t *testing.T) {
+	env := setupHTTPEnv(t, 5, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), prepared.Nonce())
+	executorIdx := prepared.HostIdx()
+	require.Equal(t, 1, executorIdx)
+
+	result, err := env.session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), refusedPayload())
+	require.NoError(t, err, "reachable executor receipt should recover instead of timing out")
+	require.Equal(t, "refused", result.Reason)
+	require.NotNil(t, findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()),
+		"executor should queue recovery MsgConfirmStart after challenge")
+
+	diffs := env.session.Diffs()
+	require.GreaterOrEqual(t, len(diffs), 2)
+	require.NotNil(t, findConfirmStart(diffs[len(diffs)-1].Txs, prepared.Nonce()),
+		"recovery MsgConfirmStart from challenge should land in the next user diff")
+}
+
 func TestHTTP_StateRecovery(t *testing.T) {
 	env := setupHTTPEnv(t, 3, 100000, 100)
 	ctx := context.Background()

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -36,6 +36,19 @@ type httpTestEnv struct {
 	gossips     []*gossip.Gossip
 }
 
+type recoveryVerifierClient struct {
+	user.HostClient
+	source *recoveryVerifierSource
+}
+
+type recoveryVerifierSource struct {
+	txs []*types.DevshardTx
+}
+
+func (c *recoveryVerifierClient) VerifyTimeout(_ context.Context, _ uint64, _ types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, []*types.DevshardTx, error) {
+	return false, nil, 0, c.source.txs, nil
+}
+
 const httpTestRoutePrefix = "/devshard/v2"
 
 func httpTestClient(baseURL string, escrowID string, signer signing.Signer) *transport.HTTPClient {
@@ -167,6 +180,40 @@ func setupHTTPEnv(t *testing.T, numHosts int, balance, grace uint64, cfgs ...typ
 		stores:      stores,
 		gossips:     gossips,
 	}
+}
+
+func setupHTTPRecoveryVerifierSession(t *testing.T, env *httpTestEnv, recovery []*types.DevshardTx) (*user.Session, *recoveryVerifierSource) {
+	t.Helper()
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine(
+		"escrow-1",
+		env.config,
+		env.group,
+		1000000,
+		env.userSigner.Address(),
+		verifier,
+		testutil.MustMemoryStore(t, "escrow-1", env.userSigner.Address(), env.config, env.group, 1000000),
+	)
+	require.NoError(t, err)
+
+	source := &recoveryVerifierSource{txs: recovery}
+	clients := make([]user.HostClient, len(env.clients))
+	for i, c := range env.clients {
+		clients[i] = &recoveryVerifierClient{HostClient: c, source: source}
+	}
+
+	session, err := user.NewSession(sm, env.userSigner, "escrow-1", env.group, clients, verifier)
+	require.NoError(t, err)
+	return session, source
+}
+
+func withHTTPTimeoutBuffer(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := user.TimeoutBuffer
+	user.TimeoutBuffer = d
+	t.Cleanup(func() {
+		user.TimeoutBuffer = prev
+	})
 }
 
 func TestHTTP_HappyPath(t *testing.T) {
@@ -500,6 +547,85 @@ func TestHTTP_RefusedTimeoutChallengeRecoveryLandsInNextDiff(t *testing.T) {
 	require.GreaterOrEqual(t, len(diffs), 2)
 	require.NotNil(t, findConfirmStart(diffs[len(diffs)-1].Txs, prepared.Nonce()),
 		"recovery MsgConfirmStart from challenge should land in the next user diff")
+}
+
+func TestHTTP_RefusedTimeoutRecoveryDeduplicatesAcrossVerifierRejects(t *testing.T) {
+	env := setupHTTPEnv(t, 5, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), prepared.Nonce())
+
+	_, err = env.session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), refusedPayload())
+	require.NoError(t, err)
+
+	diffs := env.session.Diffs()
+	require.GreaterOrEqual(t, len(diffs), 2)
+	recovery := diffs[len(diffs)-1]
+	require.Equal(t, 1, countConfirmStart(recovery.Txs, prepared.Nonce()),
+		"multiple verifier rejects must not duplicate the executor ConfirmStart in the recovery diff")
+}
+
+func TestHTTP_RefusedTimeoutRecoveryIgnoresUnrelatedMempool(t *testing.T) {
+	env := setupHTTPEnv(t, 3, 1000000, 100)
+	ctx := context.Background()
+	unrelated := []*types.DevshardTx{
+		{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+			InferenceId: 999,
+			ExecutorSig: []byte("other-receipt"),
+			ConfirmedAt: 1000,
+		}}},
+		{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{
+			InferenceId:  999,
+			ResponseHash: []byte("other-response"),
+		}}},
+	}
+	session, _ := setupHTTPRecoveryVerifierSession(t, env, unrelated)
+
+	prepared, err := session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	beforeDiffs := len(session.Diffs())
+
+	_, err = session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), refusedPayload())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient votes")
+	require.Len(t, session.Diffs(), beforeDiffs)
+
+	rec, ok := session.StateMachine().SnapshotState().Inferences[prepared.Nonce()]
+	require.True(t, ok)
+	require.Equal(t, types.StatusPending, rec.Status)
+}
+
+func TestHTTP_ExecutionTimeoutDoesNotUseConfirmStartRecovery(t *testing.T) {
+	withHTTPTimeoutBuffer(t, 0)
+	config := testutil.DefaultConfig(3)
+	config.ExecutionTimeout = 0
+	env := setupHTTPEnv(t, 3, 1000000, 100, config)
+	ctx := context.Background()
+	session, recoverySource := setupHTTPRecoveryVerifierSession(t, env, nil)
+
+	prepared, err := session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+	receipt, _, err := env.hosts[executorIdx].ChallengeReceipt(ctx, prepared.Nonce(), refusedPayload(), session.Diffs())
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce())
+	require.NotNil(t, confirmTx)
+	recoverySource.txs = []*types.DevshardTx{confirmTx}
+
+	resp := &host.HostResponse{Receipt: receipt, ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt}
+	require.NoError(t, session.ProcessResponse(executorIdx, resp, prepared.Nonce()))
+	require.NoError(t, session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+	beforeDiffs := len(session.Diffs())
+
+	_, err = session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient votes")
+	require.Len(t, session.Diffs(), beforeDiffs, "execution timeout must not publish ConfirmStart recovery")
+	require.Equal(t, types.StatusStarted, session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
 }
 
 func TestHTTP_StateRecovery(t *testing.T) {

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -2,6 +2,9 @@ package protocol
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -626,6 +629,82 @@ func TestHTTP_ExecutionTimeoutDoesNotUseConfirmStartRecovery(t *testing.T) {
 	require.Contains(t, err.Error(), "insufficient votes")
 	require.Len(t, session.Diffs(), beforeDiffs, "execution timeout must not publish ConfirmStart recovery")
 	require.Equal(t, types.StatusStarted, session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+}
+
+func TestHTTP_RefusedTimeoutChallengeTimeoutThenRecoveryTxIsAvailable(t *testing.T) {
+	env := setupHTTPEnv(t, 5, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+	challenged := make(chan struct{}, 1)
+	slowExecutor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var req transport.ChallengeReceiptRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		diffs := make([]types.Diff, 0, len(req.Diffs))
+		for i, dj := range req.Diffs {
+			diff, err := transport.DiffFromJSON(dj)
+			require.NoError(t, err, "decode diff %d", i)
+			diffs = append(diffs, diff)
+		}
+
+		receipt, _, err := env.hosts[executorIdx].ChallengeReceipt(r.Context(), req.InferenceID, transport.PayloadFromJSON(req.Payload), diffs)
+		require.NoError(t, err)
+		mempool, err := transport.DevshardTxsToBytes(host.RecoveryTxsFor(env.hosts[executorIdx].MempoolTxs(), req.InferenceID))
+		require.NoError(t, err)
+		select {
+		case challenged <- struct{}{}:
+		default:
+		}
+
+		time.Sleep(500 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(transport.ChallengeReceiptResponse{Receipt: receipt, Mempool: mempool})
+	}))
+	t.Cleanup(slowExecutor.Close)
+
+	slowCfg := transport.DefaultClientConfig()
+	slowCfg.RoutePrefix = httpTestRoutePrefix
+	slowCfg.VerifyTimeout = 100 * time.Millisecond
+	slowClient := transport.NewHTTPClient(slowExecutor.URL, "escrow-1", env.userSigner, slowCfg)
+
+	for _, srv := range env.servers {
+		peers := make(map[int]*transport.HTTPClient)
+		for i, c := range env.clients {
+			peers[i] = c
+		}
+		peers[executorIdx] = slowClient
+		srv.SetPeerClients(peers)
+	}
+
+	votes, recovery, err := env.session.CollectTimeoutVotes(ctx, prepared.Nonce(), types.TimeoutReason_TIMEOUT_REASON_REFUSED, refusedPayload(), env.session.TimeoutVerifiers(), env.session.Diffs())
+	require.NoError(t, err)
+	require.True(t, len(votes) > int(env.config.VoteThreshold), "challenge response timeouts should initially look like executor unreachable")
+	require.Empty(t, recovery)
+
+	select {
+	case <-challenged:
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor was not challenged before verifier timeout")
+	}
+	require.NotNil(t, findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()),
+		"executor must keep ConfirmStart even when verifier times out waiting for challenge response")
+
+	for _, srv := range env.servers {
+		peers := make(map[int]*transport.HTTPClient)
+		for i, c := range env.clients {
+			peers[i] = c
+		}
+		srv.SetPeerClients(peers)
+	}
+
+	votes, recovery, err = env.session.CollectTimeoutVotes(ctx, prepared.Nonce(), types.TimeoutReason_TIMEOUT_REASON_REFUSED, refusedPayload(), env.session.TimeoutVerifiers(), env.session.Diffs())
+	require.NoError(t, err)
+	require.Empty(t, votes, "once the executor recovery tx is reachable, timeout should no longer pass as clean refused")
+	require.NotNil(t, findConfirmStart(recovery, prepared.Nonce()), "next check must surface executor ConfirmStart as recovery")
 }
 
 func TestHTTP_StateRecovery(t *testing.T) {

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -442,6 +442,68 @@ func TestApplyDiff_Timeout_Refused(t *testing.T) {
 	require.Equal(t, uint64(10000), state.Balance)
 }
 
+func TestApplyDiff_PostTimeoutRecoveryDoesNotReviveInference(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+
+	for _, tc := range []struct {
+		name string
+		tx   func(t *testing.T, hosts []*signing.Secp256k1Signer) *types.DevshardTx
+	}{
+		{
+			name: "late confirm start",
+			tx: func(t *testing.T, hosts []*signing.Secp256k1Signer) *types.DevshardTx {
+				execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+				return txConfirm(&types.MsgConfirmStart{InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000})
+			},
+		},
+		{
+			name: "late finish inference",
+			tx: func(t *testing.T, hosts []*signing.Secp256k1Signer) *types.DevshardTx {
+				finishMsg := &types.MsgFinishInference{
+					InferenceId: 1, ResponseHash: []byte("response"),
+					InputTokens: 80, OutputTokens: 40, ExecutorSlot: 1,
+					EscrowId: "escrow-1",
+				}
+				finishMsg.ProposerSig = testutil.SignProposerTx(t, hosts[1], finishMsg)
+				return txFinish(finishMsg)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sm, user := newTestSM(t, hosts, 10000)
+
+			diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
+				InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
+				InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			})})
+			_, err := sm.ApplyDiff(diff)
+			require.NoError(t, err)
+
+			var votes []*types.TimeoutVote
+			for _, slot := range []uint32{0, 2, 3} {
+				v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
+				v.VoterSlot = slot
+				votes = append(votes, v)
+			}
+
+			diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
+				InferenceId: 1, Reason: types.TimeoutReason_TIMEOUT_REASON_REFUSED, Votes: votes,
+			})})
+			_, err = sm.ApplyDiff(diff)
+			require.NoError(t, err)
+			require.Equal(t, types.StatusTimedOut, sm.SnapshotState().Inferences[1].Status)
+
+			diff = testutil.SignDiff(t, user, "escrow-1", 3, []*types.DevshardTx{tc.tx(t, hosts)})
+			_, err = sm.ApplyDiff(diff)
+			require.ErrorIs(t, err, types.ErrInvalidTransition)
+			require.Equal(t, types.StatusTimedOut, sm.SnapshotState().Inferences[1].Status)
+		})
+	}
+}
+
 func TestApplyDiff_Timeout_Execution(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{
 		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -2132,6 +2132,20 @@ func (s *Session) HandleTimeout(ctx context.Context, nonce uint64, sendTime time
 
 	logging.Stage(ctx, "timeout_started", logFields("reason", result.Reason)...)
 
+	if reason == types.TimeoutReason_TIMEOUT_REASON_EXECUTION {
+		s.mu.Lock()
+		hasPendingFinish := HasMsgFinish(s.pendingTxs, nonce)
+		s.mu.Unlock()
+		if hasPendingFinish {
+			if err := s.SendPendingDiff(ctx); err != nil {
+				logging.Stage(ctx, "timeout_recovery_send_failed", logFields("reason", result.Reason, "error", err)...)
+				return result, fmt.Errorf("publish pending finish before execution timeout: %w", err)
+			}
+			logging.Stage(ctx, "timeout_recovery_published", logFields("reason", result.Reason)...)
+			return result, nil
+		}
+	}
+
 	verifiers := s.TimeoutVerifiers()
 	storedDiffs := s.Diffs()
 

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -1289,6 +1289,71 @@ func TestCollectTimeoutVotes_CollectsRejectMempool(t *testing.T) {
 	require.Equal(t, uint64(1), recovery[0].GetConfirmStart().InferenceId)
 }
 
+func TestCollectTimeoutVotes_DeduplicatesRejectRecoveryTxs(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	confirm := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 1,
+		ExecutorSig: []byte("executor-receipt"),
+		ConfirmedAt: 1000,
+	}}}
+	finish := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{
+		InferenceId:  1,
+		ResponseHash: []byte("done"),
+	}}}
+
+	verifiers := map[int]TimeoutVerifier{
+		0: &mockTimeoutVerifier{accept: false, mempool: []*types.DevshardTx{confirm, finish}},
+		2: &mockTimeoutVerifier{accept: false, mempool: []*types.DevshardTx{confirm, finish}},
+	}
+
+	votes, recovery, err := session.CollectTimeoutVotes(context.Background(), 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+		Prompt:      testutil.TestPrompt,
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}, verifiers, nil)
+	require.NoError(t, err)
+	require.Empty(t, votes)
+	require.Len(t, recovery, 2, "duplicate recovery txs from multiple reject votes must collapse by tx type and inference")
+	require.Equal(t, 1, countRecoveryConfirmStart(recovery, 1))
+	require.Equal(t, 1, countRecoveryFinish(recovery, 1))
+}
+
+func TestCollectTimeoutVotes_DropsMalformedOrNilRecoveryTxs(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	unrelatedConfirm := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 99,
+		ExecutorSig: []byte("other-receipt"),
+		ConfirmedAt: 1000,
+	}}}
+	unrelatedFinish := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{
+		InferenceId:  99,
+		ResponseHash: []byte("other"),
+	}}}
+	timeoutTx := &types.DevshardTx{Tx: &types.DevshardTx_TimeoutInference{TimeoutInference: &types.MsgTimeoutInference{
+		InferenceId: 1,
+		Reason:      types.TimeoutReason_TIMEOUT_REASON_REFUSED,
+	}}}
+	malformed := []*types.DevshardTx{nil, {}, unrelatedConfirm, unrelatedFinish, timeoutTx}
+
+	verifiers := map[int]TimeoutVerifier{
+		0: &mockTimeoutVerifier{accept: false, mempool: malformed},
+		2: &mockTimeoutVerifier{accept: false, mempool: malformed},
+	}
+
+	votes, recovery, err := session.CollectTimeoutVotes(context.Background(), 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+		Prompt:      testutil.TestPrompt,
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}, verifiers, nil)
+	require.NoError(t, err)
+	require.Empty(t, votes)
+	require.Empty(t, recovery, "nil, empty, user-proposed, and unrelated txs must not become recovery")
+}
+
 func TestHandleTimeout_RefusedReject_PublishesConfirmStart(t *testing.T) {
 	session, _, _ := setupSession(t, 3, 100000, 10)
 	ctx := context.Background()
@@ -1340,6 +1405,63 @@ func TestHandleTimeout_RefusedReject_PublishesConfirmStart(t *testing.T) {
 	require.Equal(t, types.StatusStarted, peerRec.Status, "peer SM must apply ConfirmStart from the recovery diff")
 }
 
+func TestHandleTimeout_ExecutionTimeoutIgnoresConfirmStartRecovery(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+
+	payload := &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}
+
+	execIdx := int(prepared.diff.Nonce % uint64(len(session.clients)))
+	execHost := session.clients[execIdx].(*InProcessClient).Host
+	receipt, _, err := execHost.ChallengeReceipt(ctx, prepared.diff.Nonce, payload, []types.Diff{prepared.diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+
+	var confirmTx *types.DevshardTx
+	for _, tx := range execHost.MempoolTxs() {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == prepared.diff.Nonce {
+			confirmTx = tx
+			break
+		}
+	}
+	require.NotNil(t, confirmTx)
+
+	session.mu.Lock()
+	session.addPendingTx(confirmTx)
+	session.mu.Unlock()
+	require.NoError(t, session.SendPendingDiff(ctx), "test setup must publish ConfirmStart before execution timeout")
+
+	session.mu.Lock()
+	session.nonceStates[prepared.diff.Nonce].confirmedAt = 1
+	session.mu.Unlock()
+
+	beforeDiffs := len(session.Diffs())
+	for i, c := range session.clients {
+		session.clients[i] = &timeoutRecoveryClient{HostClient: c, mempool: []*types.DevshardTx{confirmTx}}
+	}
+
+	_, err = session.HandleTimeout(ctx, prepared.diff.Nonce, time.Unix(0, 0), payload)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient votes")
+	require.Len(t, session.Diffs(), beforeDiffs, "execution timeout must not publish ConfirmStart recovery diff")
+
+	rec, ok := session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce]
+	require.True(t, ok)
+	require.Equal(t, types.StatusStarted, rec.Status)
+}
+
 func TestHandleTimeout_RefusedReject_UnrelatedMempool(t *testing.T) {
 	session, _, _ := setupSession(t, 3, 100000, 10)
 	ctx := context.Background()
@@ -1374,4 +1496,24 @@ func TestHandleTimeout_RefusedReject_UnrelatedMempool(t *testing.T) {
 	rec, ok := session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce]
 	require.True(t, ok)
 	require.Equal(t, types.StatusPending, rec.Status, "unrelated recovery txs must not be treated as success")
+}
+
+func countRecoveryConfirmStart(txs []*types.DevshardTx, inferenceID uint64) int {
+	var count int
+	for _, tx := range txs {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			count++
+		}
+	}
+	return count
+}
+
+func countRecoveryFinish(txs []*types.DevshardTx, inferenceID uint64) int {
+	var count int
+	for _, tx := range txs {
+		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
+			count++
+		}
+	}
+	return count
 }

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -1245,6 +1245,11 @@ func (c *timeoutRecoveryClient) VerifyTimeout(_ context.Context, _ uint64, _ typ
 	return false, nil, 0, c.mempool, nil
 }
 
+type timeoutVoteClient struct {
+	HostClient
+	*mockTimeoutVerifier
+}
+
 func TestCollectTimeoutVotes_CollectsRejectMempool(t *testing.T) {
 	session, _, _ := setupSession(t, 3, 100000, 10)
 	confirm := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
@@ -1462,6 +1467,77 @@ func TestHandleTimeout_ExecutionTimeoutIgnoresConfirmStartRecovery(t *testing.T)
 	require.Equal(t, types.StatusStarted, rec.Status)
 }
 
+func TestHandleTimeout_ExecutionTimeoutPrefersPendingFinishOverTimeoutVotes(t *testing.T) {
+	prevTimeoutBuffer := TimeoutBuffer
+	TimeoutBuffer = 0
+	t.Cleanup(func() {
+		TimeoutBuffer = prevTimeoutBuffer
+	})
+
+	session, signers, _ := setupSession(t, 3, 100000, 10)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+
+	payload := &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}
+
+	execIdx := int(prepared.diff.Nonce % uint64(len(session.clients)))
+	execHost := session.clients[execIdx].(*InProcessClient).Host
+	receipt, _, err := execHost.ChallengeReceipt(ctx, prepared.diff.Nonce, payload, []types.Diff{prepared.diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findRecoveryConfirmStart(execHost.MempoolTxs(), prepared.diff.Nonce)
+	require.NotNil(t, confirmTx)
+
+	require.NoError(t, session.ProcessResponse(execIdx, &host.HostResponse{
+		Receipt:     receipt,
+		ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt,
+	}, prepared.diff.Nonce))
+	require.NoError(t, session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce].Status)
+
+	require.Eventually(t, func() bool {
+		return findRecoveryFinish(execHost.MempoolTxs(), prepared.diff.Nonce) != nil
+	}, 5*time.Second, 20*time.Millisecond)
+	finishTx := findRecoveryFinish(execHost.MempoolTxs(), prepared.diff.Nonce)
+	require.NotNil(t, finishTx)
+
+	session.mu.Lock()
+	session.addPendingTx(finishTx)
+	session.mu.Unlock()
+	require.NotNil(t, findRecoveryFinish(session.PendingTxs(), prepared.diff.Nonce))
+	session.mu.Lock()
+	session.nonceStates[prepared.diff.Nonce].confirmedAt = 1
+	session.mu.Unlock()
+
+	for i, c := range session.clients {
+		session.clients[i] = &timeoutVoteClient{
+			HostClient: c,
+			mockTimeoutVerifier: &mockTimeoutVerifier{
+				accept:  true,
+				signer:  signers[i],
+				group:   session.group,
+				slotIdx: i,
+			},
+		}
+	}
+
+	result, err := session.HandleTimeout(ctx, prepared.diff.Nonce, time.Unix(0, 0), nil)
+	require.NoError(t, err, "pending FinishInference should be published instead of timeout votes")
+	require.Equal(t, "execution", result.Reason)
+	require.Equal(t, types.StatusFinished, session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce].Status)
+}
+
 func TestHandleTimeout_RefusedReject_UnrelatedMempool(t *testing.T) {
 	session, _, _ := setupSession(t, 3, 100000, 10)
 	ctx := context.Background()
@@ -1516,4 +1592,22 @@ func countRecoveryFinish(txs []*types.DevshardTx, inferenceID uint64) int {
 		}
 	}
 	return count
+}
+
+func findRecoveryConfirmStart(txs []*types.DevshardTx, inferenceID uint64) *types.DevshardTx {
+	for _, tx := range txs {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			return tx
+		}
+	}
+	return nil
+}
+
+func findRecoveryFinish(txs []*types.DevshardTx, inferenceID uint64) *types.DevshardTx {
+	for _, tx := range txs {
+		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
+			return tx
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Add regression coverage for receipt-timeout recovery across host, session, HTTP/protocol, and state-machine layers.
- Cover recovery of `MsgConfirmStart` from challenge responses, including challenge timeout/cancel-adjacent flows.
- Cover `MsgFinishInference` recovery before execution timeout, including executor mempool and session pending paths.
- Fix `HandleTimeout` so a pending `MsgFinishInference` is published before execution-timeout voting.
- Add safety coverage to ensure late `ConfirmStart` / `FinishInference` cannot revive an already timed-out inference.

## Testing

- `go test ./host -count=1`
- `go test ./user -count=1`
- `go test ./protocol -count=1`
- `go test ./state -count=1`
- `git diff --check`