### PR TITLE
`devshard` Host challenge receipt async

### DIFF
--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -1908,6 +1908,13 @@ func TestRunInference_SpeculativeFallsThroughMultipleDeadHosts(t *testing.T) {
 	err := env.proxy.redundancy.RunInference(context.Background(), defaultParams(), &buf, nil)
 	require.NoError(t, err)
 
+	// RunInference returns once the live host's stream settles. Dead hosts
+	// may still be finishing on the background finalizer, which is where
+	// RecordRequest runs. Wait for that record before asserting on it.
+	require.Eventually(t, func() bool {
+		return len(env.proxy.perf.RecentRequests()) >= 1
+	}, time.Second, 10*time.Millisecond, "background finalizer should have recorded the request")
+
 	requests := env.proxy.perf.RecentRequests()
 	require.NotEmpty(t, requests)
 

--- a/devshard/cmd/devshardctl/proxy_test.go
+++ b/devshard/cmd/devshardctl/proxy_test.go
@@ -582,9 +582,9 @@ func (c *blockingNonStreamingRecorderClient) MaxTokens() []uint64 {
 	return append([]uint64(nil), c.maxTokens...)
 }
 
-func (c *verifierClient) VerifyTimeout(_ context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, error) {
+func (c *verifierClient) VerifyTimeout(_ context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, []*types.DevshardTx, error) {
 	if !c.accept {
-		return false, nil, 0, nil
+		return false, nil, 0, nil, nil
 	}
 	voterSlot := c.group[c.slotIdx].SlotID
 	content := &types.TimeoutVoteContent{
@@ -595,13 +595,13 @@ func (c *verifierClient) VerifyTimeout(_ context.Context, inferenceID uint64, re
 	}
 	data, err := proto.Marshal(content)
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, nil, err
 	}
 	sig, err := c.signer.Sign(data)
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, nil, err
 	}
-	return true, sig, voterSlot, nil
+	return true, sig, voterSlot, nil, nil
 }
 
 type testProxyEnv struct {

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -401,6 +401,15 @@ func (h *Host) MempoolTxs() []*types.DevshardTx {
 	return h.mempool.Txs()
 }
 
+// AddTx inserts a tx into the local mempool (ProposedAt = 0). Used to copy
+// recovery txs from a challenge-receipt response into a verifier's pool.
+func (h *Host) AddTx(tx *types.DevshardTx) {
+	if tx == nil {
+		return
+	}
+	h.mempool.AddTx(tx)
+}
+
 func (h *Host) EscrowID() string              { return h.escrowID }
 func (h *Host) EpochID() uint64               { return h.epochID }
 func (h *Host) Group() []types.SlotAssignment { return h.group }

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -105,6 +105,11 @@ type AcceptanceChecker interface {
 const (
 	defaultValidationWorkers   = 20
 	defaultValidationQueueSize = 20_000
+
+	// defaultExecutionBudget bounds a detached execution when the session config
+	// carries no ExecutionTimeout (zero is a legal value that
+	// NormalizeSessionConfig deliberately preserves).
+	defaultExecutionBudget = 32 * time.Minute
 )
 
 // Host processes user requests: applies diffs, executes inference, signs state.
@@ -963,10 +968,27 @@ func (h *Host) signReceipt(ctx context.Context, req HostRequest, hdr *blocks.Hea
 // deadline is far shorter than a long generation, and the executor receipt is
 // already signed. Detaching from cancellation keeps MsgFinishInference on track
 // even after the challenging host hangs up.
+//
+// The detached context still carries a deadline. ReleaseExecution only runs when
+// RunExecution returns, so under a plain uncancellable context a wedged engine
+// would hold h.executing[id] for the process lifetime and permanently block this
+// inference; engine node-acquire loops also treat ctx as their only exit.
 func (h *Host) executeAsync(ctx context.Context, job *devshard.ExecuteRequest) {
+	execCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), h.executionBudget())
 	go func() {
-		_, _ = h.RunExecution(context.WithoutCancel(ctx), job)
+		defer cancel()
+		_, _ = h.RunExecution(execCtx, job)
 	}()
+}
+
+// executionBudget is the wall clock a detached execution may use. Past
+// ExecutionTimeout verifiers accept an execution timeout for the inference, so
+// work continuing beyond it can no longer be settled.
+func (h *Host) executionBudget() time.Duration {
+	if secs := h.sm.Config().ExecutionTimeout; secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return defaultExecutionBudget
 }
 
 func (h *Host) ReleaseExecution(inferenceID uint64) {
@@ -1553,15 +1575,44 @@ func (h *Host) challengeReceiptLocked(ctx context.Context, inferenceID uint64, p
 		return nil, 0, nil, fmt.Errorf("sign executor receipt: %w", err)
 	}
 
+	var hasConfirmStart, hasFinish bool
+	for _, tx := range h.mempool.Txs() {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			hasConfirmStart = true
+		}
+		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
+			hasFinish = true
+		}
+	}
+
+	// Publish MsgConfirmStart the way the SSE path does. To the verifier the
+	// receipt is only a liveness proof and is discarded after the timeout vote,
+	// so without ConfirmStart the inference stays pending and applyFinishInference
+	// rejects the MsgFinishInference this execution produces as an invalid
+	// transition -- the work could never be settled. Only reachable while the
+	// record is still pending, so this cannot confirm an already-started
+	// inference. Skipped when one is already queued to avoid stacking entries
+	// that differ only by confirmed_at.
+	if !hasConfirmStart {
+		h.mempool.Add(MempoolEntry{
+			Tx: &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+				InferenceId:       inferenceID,
+				ExecutorSig:       sig,
+				ConfirmedAt:       confirmedAt,
+				ObservedHeight:    obsH,
+				ObservedBlockHash: obsHash,
+			}}},
+			ProposedAt: h.sm.LatestNonce(),
+		})
+	}
+
 	// Dedup: return receipt (proves executor alive) but skip execution
 	// if already in-flight or already finished in mempool.
 	if _, dup := h.executing[inferenceID]; dup {
 		return sig, confirmedAt, nil, nil
 	}
-	for _, tx := range h.mempool.Txs() {
-		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
-			return sig, confirmedAt, nil, nil
-		}
+	if hasFinish {
+		return sig, confirmedAt, nil, nil
 	}
 
 	h.executing[inferenceID] = struct{}{}

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -840,8 +840,14 @@ func (h *Host) signReceipt(req HostRequest) ([]byte, int64, *devshard.ExecuteReq
 
 // executeAsync runs inference and adds MsgFinishInference to the mempool.
 // Delegates to RunExecution which also caches the response body for reconnection.
+// The caller must not wait for the inference: it holds a request context whose
+// deadline is far shorter than a long generation, and the executor receipt is
+// already signed. Detaching from cancellation keeps MsgFinishInference on track
+// even after the challenging host hangs up.
 func (h *Host) executeAsync(ctx context.Context, job *devshard.ExecuteRequest) {
-	_, _ = h.RunExecution(ctx, job)
+	go func() {
+		_, _ = h.RunExecution(context.WithoutCancel(ctx), job)
+	}()
 }
 
 func (h *Host) ReleaseExecution(inferenceID uint64) {

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1176,6 +1176,33 @@ func TestHost_ChallengeReceipt_AlreadyExecuting(t *testing.T) {
 	require.Equal(t, 1, engine.calls, "engine should not be called again")
 }
 
+func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	engine := stub.NewInferenceEngine()
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+
+	receipt, confirmedAt, err := h.ChallengeReceipt(context.Background(), 1, defaultPayload(), []types.Diff{diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt, "challenge must return the executor receipt")
+	require.NotZero(t, confirmedAt, "challenge must return the receipt timestamp")
+
+	confirmTx := findMempoolConfirm(h.MempoolTxs())
+	require.NotNil(t, confirmTx, "challenge receipt must publish MsgConfirmStart for recovery")
+	confirm := confirmTx.GetConfirmStart()
+	require.Equal(t, uint64(1), confirm.InferenceId)
+	require.Equal(t, receipt, confirm.ExecutorSig)
+	require.Equal(t, confirmedAt, confirm.ConfirmedAt)
+}
+
 func TestHost_ChallengeReceipt_AlreadyFinished(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	user := testutil.MustGenerateKey(t)

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1235,6 +1235,43 @@ func (e *blockingInferenceEngine) Execute(ctx context.Context, req devshard.Exec
 	}
 }
 
+// ctxCapturingInferenceEngine blocks like blockingInferenceEngine, but also
+// records the ctx Execute received, so a test can inspect it (e.g. after the
+// request context is cancelled) instead of inferring detachment indirectly.
+type ctxCapturingInferenceEngine struct {
+	inner   *stub.InferenceEngine
+	started chan struct{}
+	release chan struct{}
+
+	mu  sync.Mutex
+	ctx context.Context
+}
+
+func newCtxCapturingInferenceEngine() *ctxCapturingInferenceEngine {
+	return &ctxCapturingInferenceEngine{
+		inner:   stub.NewInferenceEngine(),
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (e *ctxCapturingInferenceEngine) Execute(ctx context.Context, req devshard.ExecuteRequest) (*devshard.ExecuteResult, error) {
+	// Publish ctx before signaling started, so the test can safely read it
+	// as soon as it observes started.
+	e.mu.Lock()
+	e.ctx = ctx
+	e.mu.Unlock()
+	e.started <- struct{}{}
+	<-e.release
+	return e.inner.Execute(ctx, req)
+}
+
+func (e *ctxCapturingInferenceEngine) executionCtx() context.Context {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.ctx
+}
+
 func TestHost_ChallengeReceipt_DoesNotBlockOnExecution(t *testing.T) {
 	// Regression: ChallengeReceipt used to run the inference synchronously, so a
 	// slow execution held the receipt past the verifier's timeout and a live
@@ -1285,6 +1322,53 @@ func TestHost_ChallengeReceipt_DoesNotBlockOnExecution(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return findMempoolFinish(h.MempoolTxs()) != nil
 	}, 5*time.Second, 10*time.Millisecond, "background execution must queue MsgFinishInference")
+}
+
+func TestHost_ChallengeReceipt_ExecutionSurvivesRequestCancel(t *testing.T) {
+	// Regression: ChallengeReceipt must detach execution from the request context
+	// (context.WithoutCancel), so a challenger that cancels/hangs up after
+	// receiving the receipt cannot abort the executor's in-flight inference.
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	engine := newCtxCapturingInferenceEngine()
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, cErr := h.ChallengeReceipt(ctx, 1, defaultPayload(), []types.Diff{diff})
+		errCh <- cErr
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("execution never started")
+	}
+	// executeAsync returns immediately after spawning execution, so
+	// ChallengeReceipt has already returned by the time Execute is running.
+	require.NoError(t, <-errCh)
+
+	execCtx := engine.executionCtx()
+	cancel() // synchronous: any derived context has Err() set once this returns
+	require.NoError(t, execCtx.Err(), "execution context must not observe the request cancellation")
+	require.Nil(t, execCtx.Done(), "execution context must be uncancellable")
+
+	// Execution is still alive; let it finish and confirm it actually
+	// completes, not just that it avoided the cancellation.
+	close(engine.release)
+	require.Eventually(t, func() bool {
+		return findMempoolFinish(h.MempoolTxs()) != nil
+	}, 5*time.Second, 10*time.Millisecond, "background execution must queue MsgFinishInference despite request cancel")
 }
 
 func TestWarmKey_HostFindsSlotByWarmKey(t *testing.T) {

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1176,7 +1176,8 @@ func TestHost_ChallengeReceipt_AlreadyExecuting(t *testing.T) {
 	require.Equal(t, 1, engine.calls, "engine should not be called again")
 }
 
-func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
+func setupChallengeReceiptHost(t *testing.T, engine devshard.InferenceEngine) (*Host, types.Diff) {
+	t.Helper()
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	user := testutil.MustGenerateKey(t)
 	group := testutil.MakeGroup(hosts)
@@ -1184,11 +1185,17 @@ func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
 	verifier := signing.NewSecp256k1Verifier()
 	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
 	require.NoError(t, err)
-	engine := stub.NewInferenceEngine()
+	if engine == nil {
+		engine = stub.NewInferenceEngine()
+	}
 	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
 	require.NoError(t, err)
-
 	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	return h, diff
+}
+
+func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
+	h, diff := setupChallengeReceiptHost(t, nil)
 
 	receipt, confirmedAt, err := h.ChallengeReceipt(context.Background(), 1, defaultPayload(), []types.Diff{diff})
 	require.NoError(t, err)
@@ -1201,6 +1208,54 @@ func TestHost_ChallengeReceipt_PublishesConfirmStartToMempool(t *testing.T) {
 	require.Equal(t, uint64(1), confirm.InferenceId)
 	require.Equal(t, receipt, confirm.ExecutorSig)
 	require.Equal(t, confirmedAt, confirm.ConfirmedAt)
+}
+
+func TestHost_ChallengeReceipt_ContextTimeoutStillKeepsConfirmStartInMempool(t *testing.T) {
+	engine := newCtxCapturingInferenceEngine()
+	h, diff := setupChallengeReceiptHost(t, engine)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type challengeResult struct {
+		receipt     []byte
+		confirmedAt int64
+		err         error
+	}
+	resultCh := make(chan challengeResult, 1)
+	go func() {
+		receipt, confirmedAt, err := h.ChallengeReceipt(ctx, 1, defaultPayload(), []types.Diff{diff})
+		resultCh <- challengeResult{receipt: receipt, confirmedAt: confirmedAt, err: err}
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("execution never started")
+	}
+
+	var res challengeResult
+	select {
+	case res = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ChallengeReceipt did not return after starting execution")
+	}
+	require.NoError(t, res.err)
+	require.NotEmpty(t, res.receipt)
+	require.NotZero(t, res.confirmedAt)
+
+	cancel()
+
+	confirmTx := findMempoolConfirm(h.MempoolTxs())
+	require.NotNil(t, confirmTx, "cancelled challenge context must not drop recovery MsgConfirmStart")
+	confirm := confirmTx.GetConfirmStart()
+	require.Equal(t, uint64(1), confirm.InferenceId)
+	require.Equal(t, res.receipt, confirm.ExecutorSig)
+	require.Equal(t, res.confirmedAt, confirm.ConfirmedAt)
+
+	close(engine.release)
+	require.Eventually(t, func() bool {
+		return findMempoolFinish(h.MempoolTxs()) != nil
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestHost_ChallengeReceipt_AlreadyFinished(t *testing.T) {

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -17,6 +17,7 @@ import (
 	"devshard"
 	"devshard/gossip"
 	"devshard/internal/testutil"
+	"devshard/logging"
 	"devshard/signing"
 	"devshard/state"
 	"devshard/storage"
@@ -1343,6 +1344,7 @@ func TestHost_ChallengeReceipt_ExecutionSurvivesRequestCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ctx, reqID := logging.WithRequestID(ctx, "challenge-1")
 	errCh := make(chan error, 1)
 	go func() {
 		_, _, cErr := h.ChallengeReceipt(ctx, 1, defaultPayload(), []types.Diff{diff})
@@ -1361,7 +1363,21 @@ func TestHost_ChallengeReceipt_ExecutionSurvivesRequestCancel(t *testing.T) {
 	execCtx := engine.executionCtx()
 	cancel() // synchronous: any derived context has Err() set once this returns
 	require.NoError(t, execCtx.Err(), "execution context must not observe the request cancellation")
-	require.Nil(t, execCtx.Done(), "execution context must be uncancellable")
+
+	// WithoutCancel rather than Background: the request's observability values
+	// must survive so the detached execution's logs stay correlated with the
+	// challenge that started it. Assert on a value only the request context
+	// carries -- a bare Background() would satisfy the cancellation check above.
+	gotID, ok := logging.RequestID(execCtx)
+	require.True(t, ok, "execution context must retain the request id")
+	require.Equal(t, reqID, gotID, "detached execution must inherit the request id, not a fresh context")
+
+	// Detached but still bounded. See executeAsync: ReleaseExecution only runs
+	// when RunExecution returns, so an unbounded context would let a wedged
+	// engine hold h.executing[1] for the process lifetime.
+	deadline, hasDeadline := execCtx.Deadline()
+	require.True(t, hasDeadline, "detached execution must carry an execution budget")
+	require.WithinDuration(t, time.Now().Add(h.executionBudget()), deadline, time.Minute)
 
 	// Execution is still alive; let it finish and confirm it actually
 	// completes, not just that it avoided the cancellation.
@@ -1369,6 +1385,102 @@ func TestHost_ChallengeReceipt_ExecutionSurvivesRequestCancel(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return findMempoolFinish(h.MempoolTxs()) != nil
 	}, 5*time.Second, 10*time.Millisecond, "background execution must queue MsgFinishInference despite request cancel")
+}
+
+func TestHost_ChallengeReceipt_ExecutionBudgetReleasesWedgedInference(t *testing.T) {
+	// Detaching execution from the request context removed the only bound on its
+	// runtime. ReleaseExecution runs only when RunExecution returns, so an engine
+	// that never completes must be cut off by the execution budget -- otherwise
+	// h.executing[1] is held for the process lifetime and this host can never
+	// retry or re-serve the inference.
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	config.ExecutionTimeout = 1 // 1s budget instead of the 20m default
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+
+	// An ML node that only returns when its context is done.
+	engine := stub.NewInferenceEngine()
+	engine.BlockUntilContextDone = true
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+	require.Equal(t, time.Second, h.executionBudget())
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	receipt, _, err := h.ChallengeReceipt(ctx, 1, defaultPayload(), []types.Diff{diff})
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	cancel() // challenger hangs up; execution must survive this but not run forever
+
+	require.Eventually(t, func() bool {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		_, executing := h.executing[1]
+		return !executing
+	}, 5*time.Second, 20*time.Millisecond, "execution budget must expire and release the dedup guard")
+}
+
+func TestHost_ChallengeReceipt_PublishesConfirmStartSoFinishCanApply(t *testing.T) {
+	// The verifier treats the receipt as a liveness proof and discards it after
+	// voting, so the challenge path must queue MsgConfirmStart itself. Without it
+	// the inference stays pending and applyFinishInference rejects the
+	// MsgFinishInference this execution produces as an invalid transition,
+	// leaving the work unsettleable.
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	h, err := NewHost(sm, hosts[1], stub.NewInferenceEngine(), "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+
+	startDiff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	receipt, confirmedAt, err := h.ChallengeReceipt(context.Background(), 1, defaultPayload(), []types.Diff{startDiff})
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	require.Eventually(t, func() bool {
+		return findMempoolFinish(h.MempoolTxs()) != nil
+	}, 5*time.Second, 10*time.Millisecond, "background execution must queue MsgFinishInference")
+
+	confirmTx := findMempoolConfirm(h.MempoolTxs())
+	require.NotNil(t, confirmTx, "challenge path must queue MsgConfirmStart alongside the receipt")
+	cs := confirmTx.GetConfirmStart()
+	require.Equal(t, uint64(1), cs.InferenceId)
+	require.Equal(t, receipt, cs.ExecutorSig, "queued ConfirmStart must carry the receipt that was returned")
+	require.Equal(t, confirmedAt, cs.ConfirmedAt)
+
+	// A repeat challenge must not stack a second ConfirmStart differing only by
+	// confirmed_at, which the state machine would reject anyway.
+	_, _, err = h.ChallengeReceipt(context.Background(), 1, defaultPayload(), nil)
+	require.NoError(t, err)
+	var confirmCount int
+	for _, tx := range h.MempoolTxs() {
+		if tx.GetConfirmStart() != nil {
+			confirmCount++
+		}
+	}
+	require.Equal(t, 1, confirmCount, "ConfirmStart must be queued once per inference")
+
+	// The decisive check: the pair the challenge path produced must actually
+	// settle the inference on a peer's state machine.
+	peerSM, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	_, err = peerSM.ApplyDiff(startDiff)
+	require.NoError(t, err)
+	require.Equal(t, types.StatusPending, peerSM.SnapshotState().Inferences[1].Status)
+
+	settleDiff := testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{confirmTx, findMempoolFinish(h.MempoolTxs())})
+	_, err = peerSM.ApplyDiff(settleDiff)
+	require.NoError(t, err, "ConfirmStart + FinishInference from the challenge path must apply")
+	require.Equal(t, types.StatusFinished, peerSM.SnapshotState().Inferences[1].Status)
 }
 
 func TestWarmKey_HostFindsSlotByWarmKey(t *testing.T) {

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1209,6 +1209,84 @@ func TestHost_ChallengeReceipt_AlreadyFinished(t *testing.T) {
 	require.Equal(t, 1, engine.calls, "engine should not be called again")
 }
 
+// blockingInferenceEngine holds Execute open until released, so tests can observe
+// whether the caller waits for the inference to finish.
+type blockingInferenceEngine struct {
+	inner   *stub.InferenceEngine
+	started chan struct{}
+	release chan struct{}
+}
+
+func newBlockingInferenceEngine() *blockingInferenceEngine {
+	return &blockingInferenceEngine{
+		inner:   stub.NewInferenceEngine(),
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (e *blockingInferenceEngine) Execute(ctx context.Context, req devshard.ExecuteRequest) (*devshard.ExecuteResult, error) {
+	e.started <- struct{}{}
+	select {
+	case <-e.release:
+		return e.inner.Execute(ctx, req)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func TestHost_ChallengeReceipt_DoesNotBlockOnExecution(t *testing.T) {
+	// Regression: ChallengeReceipt used to run the inference synchronously, so a
+	// slow execution held the receipt past the verifier's timeout and a live
+	// executor was voted refused-timeout.
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 10000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 10000))
+	require.NoError(t, err)
+	engine := newBlockingInferenceEngine()
+	h, err := NewHost(sm, hosts[1], engine, "escrow-1", group, nil, WithGrace(10))
+	require.NoError(t, err)
+
+	diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+
+	type challengeResult struct {
+		receipt     []byte
+		confirmedAt int64
+		err         error
+	}
+	resultCh := make(chan challengeResult, 1)
+	go func() {
+		receipt, confirmedAt, err := h.ChallengeReceipt(context.Background(), 1, defaultPayload(), []types.Diff{diff})
+		resultCh <- challengeResult{receipt: receipt, confirmedAt: confirmedAt, err: err}
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("execution never started")
+	}
+
+	// Execution is still in flight here, so the receipt can only arrive if
+	// ChallengeReceipt does not wait for it.
+	select {
+	case res := <-resultCh:
+		require.NoError(t, res.err)
+		require.NotNil(t, res.receipt, "receipt must return while execution is still running")
+		require.NotZero(t, res.confirmedAt, "receipt must carry confirmed_at")
+	case <-time.After(5 * time.Second):
+		t.Fatal("ChallengeReceipt blocked on execution instead of returning the receipt")
+	}
+
+	// The execution started by the challenge must still complete in the background.
+	close(engine.release)
+	require.Eventually(t, func() bool {
+		return findMempoolFinish(h.MempoolTxs()) != nil
+	}, 5*time.Second, 10*time.Millisecond, "background execution must queue MsgFinishInference")
+}
+
 func TestWarmKey_HostFindsSlotByWarmKey(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	warmSigner := testutil.MustGenerateKey(t)

--- a/devshard/host/timeout.go
+++ b/devshard/host/timeout.go
@@ -29,6 +29,26 @@ type TxSink interface {
 	AddTx(tx *types.DevshardTx)
 }
 
+// RecoveryTxsFor returns ConfirmStart and FinishInference txs for inferenceID.
+// Challenge and verify-timeout recovery copy only these; the rest of a host
+// mempool snapshot is not recovery-relevant.
+func RecoveryTxsFor(txs []*types.DevshardTx, inferenceID uint64) []*types.DevshardTx {
+	var out []*types.DevshardTx
+	for _, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			out = append(out, tx)
+			continue
+		}
+		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
+			out = append(out, tx)
+		}
+	}
+	return out
+}
+
 // VerifyRefusedTimeout checks if a refused timeout is valid.
 //
 // Flow:
@@ -95,10 +115,8 @@ func VerifyRefusedTimeout(
 			// Copy executor recovery txs into the verifier pool. Same bytes as
 			// the executor queued — do not mint a new ConfirmStart from receipt.
 			if ingest != nil {
-				for _, tx := range mempool {
-					if tx != nil {
-						ingest.AddTx(tx)
-					}
+				for _, tx := range RecoveryTxsFor(mempool, inferenceID) {
+					ingest.AddTx(tx)
 				}
 			}
 			return false, nil // executor produced receipt -> reject timeout

--- a/devshard/host/timeout.go
+++ b/devshard/host/timeout.go
@@ -18,7 +18,15 @@ type ExecutorClient interface {
 	// a signed receipt if it can produce one. Also triggers execution so
 	// the inference actually completes. Returns nil receipt if executor
 	// cannot produce one (not the executor, inference not pending, etc).
-	ChallengeReceipt(ctx context.Context, inferenceID uint64, payload *InferencePayload, diffs []types.Diff) (receipt []byte, err error)
+	// mempool is a snapshot of the executor's pool after the challenge
+	// (typically including MsgConfirmStart). Callers must copy those txs
+	// rather than synthesizing ConfirmStart from the receipt.
+	ChallengeReceipt(ctx context.Context, inferenceID uint64, payload *InferencePayload, diffs []types.Diff) (receipt []byte, mempool []*types.DevshardTx, err error)
+}
+
+// TxSink receives mempool txs copied from a challenge-receipt response.
+type TxSink interface {
+	AddTx(tx *types.DevshardTx)
 }
 
 // VerifyRefusedTimeout checks if a refused timeout is valid.
@@ -39,6 +47,7 @@ func VerifyRefusedTimeout(
 	storedDiffs []types.Diff,
 	localMempool []*types.DevshardTx,
 	executorClient ExecutorClient,
+	ingest TxSink,
 	config types.SessionConfig,
 	nowUnix int64,
 ) (bool, error) {
@@ -77,12 +86,21 @@ func VerifyRefusedTimeout(
 
 	// Challenge executor: one call that applies diffs + verifies payload + returns receipt.
 	if executorClient != nil {
-		receipt, err := executorClient.ChallengeReceipt(ctx, inferenceID, payload, storedDiffs)
+		receipt, mempool, err := executorClient.ChallengeReceipt(ctx, inferenceID, payload, storedDiffs)
 		if err != nil {
 			// Executor unreachable or internal error -> accept timeout.
 			return true, nil
 		}
 		if len(receipt) > 0 {
+			// Copy executor recovery txs into the verifier pool. Same bytes as
+			// the executor queued — do not mint a new ConfirmStart from receipt.
+			if ingest != nil {
+				for _, tx := range mempool {
+					if tx != nil {
+						ingest.AddTx(tx)
+					}
+				}
+			}
 			return false, nil // executor produced receipt -> reject timeout
 		}
 		// Executor reachable but no receipt (refusing to work) -> accept timeout.

--- a/devshard/host/timeout_test.go
+++ b/devshard/host/timeout_test.go
@@ -130,13 +130,23 @@ func TestVerifyRefused_ReceiptInLocalMempool(t *testing.T) {
 	require.False(t, accept, "should reject: receipt in local mempool")
 }
 
-func TestVerifyRefused_ExecutorUnreachable_ValidRequest(t *testing.T) {
-	st := stateWithPendingFull(1, 1)
-	executor := &mockExecutorClient{challengeReceiptErr: errors.New("unreachable")}
+func TestVerifyRefused_ChallengeErrorAcceptsTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "executor unreachable", err: errors.New("unreachable")},
+		{name: "challenge timeout", err: context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := stateWithPendingFull(1, 1)
+			executor := &mockExecutorClient{challengeReceiptErr: tc.err}
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
-	require.NoError(t, err)
-	require.True(t, accept, "should accept: executor unreachable")
+			accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
+			require.NoError(t, err)
+			require.True(t, accept, "challenge error should be treated as executor unreachable")
+		})
+	}
 }
 
 func TestVerifyRefused_ExecutorReturnsReceipt(t *testing.T) {
@@ -327,4 +337,3 @@ func TestRecoveryTxsFor_FiltersByInferenceID(t *testing.T) {
 	got := RecoveryTxsFor([]*types.DevshardTx{nil, empty, confirm2, confirm1, finish1}, 1)
 	require.Equal(t, []*types.DevshardTx{confirm1, finish1}, got)
 }
-

--- a/devshard/host/timeout_test.go
+++ b/devshard/host/timeout_test.go
@@ -280,7 +280,15 @@ func TestVerifyRefused_CopiesChallengeMempool(t *testing.T) {
 	}}}
 	executor := &mockExecutorClient{
 		challengeReceipt: []byte("receipt-sig"),
-		challengeMempool: []*types.DevshardTx{confirm},
+		challengeMempool: []*types.DevshardTx{
+			confirm,
+			{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+				InferenceId: 99,
+				ExecutorSig: []byte("other-receipt"),
+				ConfirmedAt: 1,
+			}}},
+			{},
+		},
 	}
 	verifierPool := NewMempool()
 
@@ -292,6 +300,11 @@ func TestVerifyRefused_CopiesChallengeMempool(t *testing.T) {
 	require.NotNil(t, got, "verifier pool must copy MsgConfirmStart from challenge mempool")
 	require.Equal(t, types.TxHash(confirm), types.TxHash(got))
 	require.Equal(t, []byte("receipt-sig"), got.GetConfirmStart().ExecutorSig)
+	for _, tx := range verifierPool.Txs() {
+		if cs := tx.GetConfirmStart(); cs != nil {
+			require.Equal(t, uint64(1), cs.InferenceId, "verifier must not copy ConfirmStart for other inferences")
+		}
+	}
 
 	accept, err = VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, verifierPool, st.Config, deadlinePassedRefused(st, 1))
 	require.NoError(t, err)
@@ -303,5 +316,15 @@ func TestVerifyRefused_CopiesChallengeMempool(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, confirmCount, "second challenge must not stack a second ConfirmStart")
+}
+
+func TestRecoveryTxsFor_FiltersByInferenceID(t *testing.T) {
+	confirm1 := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{InferenceId: 1}}}
+	confirm2 := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{InferenceId: 2}}}
+	finish1 := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{InferenceId: 1}}}
+	empty := &types.DevshardTx{}
+
+	got := RecoveryTxsFor([]*types.DevshardTx{nil, empty, confirm2, confirm1, finish1}, 1)
+	require.Equal(t, []*types.DevshardTx{confirm1, finish1}, got)
 }
 

--- a/devshard/host/timeout_test.go
+++ b/devshard/host/timeout_test.go
@@ -17,6 +17,7 @@ type mockExecutorClient struct {
 	mempoolErr error
 
 	challengeReceipt    []byte
+	challengeMempool    []*types.DevshardTx
 	challengeReceiptErr error
 }
 
@@ -24,8 +25,8 @@ func (m *mockExecutorClient) GetMempool(_ context.Context) ([]*types.DevshardTx,
 	return m.mempool, m.mempoolErr
 }
 
-func (m *mockExecutorClient) ChallengeReceipt(_ context.Context, _ uint64, _ *InferencePayload, _ []types.Diff) ([]byte, error) {
-	return m.challengeReceipt, m.challengeReceiptErr
+func (m *mockExecutorClient) ChallengeReceipt(_ context.Context, _ uint64, _ *InferencePayload, _ []types.Diff) ([]byte, []*types.DevshardTx, error) {
+	return m.challengeReceipt, m.challengeMempool, m.challengeReceiptErr
 }
 
 var testPrompt = testutil.TestPrompt
@@ -124,7 +125,7 @@ func TestVerifyRefused_ReceiptInLocalMempool(t *testing.T) {
 		{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{InferenceId: 1}}},
 	}
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, mempool, nil, st.Config, deadlinePassedRefused(st, 1))
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, mempool, nil, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.NoError(t, err)
 	require.False(t, accept, "should reject: receipt in local mempool")
 }
@@ -133,7 +134,7 @@ func TestVerifyRefused_ExecutorUnreachable_ValidRequest(t *testing.T) {
 	st := stateWithPendingFull(1, 1)
 	executor := &mockExecutorClient{challengeReceiptErr: errors.New("unreachable")}
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, st.Config, deadlinePassedRefused(st, 1))
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.NoError(t, err)
 	require.True(t, accept, "should accept: executor unreachable")
 }
@@ -142,7 +143,7 @@ func TestVerifyRefused_ExecutorReturnsReceipt(t *testing.T) {
 	st := stateWithPendingFull(1, 1)
 	executor := &mockExecutorClient{challengeReceipt: []byte("receipt-sig")}
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, st.Config, deadlinePassedRefused(st, 1))
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.NoError(t, err)
 	require.False(t, accept, "should reject: executor produced receipt via ChallengeReceipt")
 }
@@ -152,7 +153,7 @@ func TestVerifyRefused_ExecutorReturnsEmptyReceipt(t *testing.T) {
 	// Executor reachable but returns nil receipt (cannot produce one).
 	executor := &mockExecutorClient{challengeReceipt: nil}
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, st.Config, deadlinePassedRefused(st, 1))
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.NoError(t, err)
 	require.True(t, accept, "should accept: executor returned no receipt")
 }
@@ -160,7 +161,7 @@ func TestVerifyRefused_ExecutorReturnsEmptyReceipt(t *testing.T) {
 func TestVerifyRefused_InferenceNotPending(t *testing.T) {
 	st := stateWithStarted(1, 1) // started, not pending
 
-	_, err := VerifyRefusedTimeout(context.Background(), st, 1, nil, nil, nil, nil, st.Config, deadlinePassedRefused(st, 1))
+	_, err := VerifyRefusedTimeout(context.Background(), st, 1, nil, nil, nil, nil, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "expected pending")
 }
@@ -170,7 +171,7 @@ func TestVerifyRefused_DeadlineNotPassed(t *testing.T) {
 	// nowUnix is before the deadline.
 	tooEarly := st.Inferences[1].StartedAt + st.Config.RefusalTimeout - 1
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, nil, st.Config, tooEarly)
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, nil, nil, st.Config, tooEarly)
 	require.NoError(t, err)
 	require.False(t, accept, "should reject: deadline not passed")
 }
@@ -180,7 +181,7 @@ func TestVerifyRefused_NilPayload_Rejects(t *testing.T) {
 	executor := &mockExecutorClient{challengeReceipt: []byte("would-return-receipt")}
 
 	// Nil payload -> error (reject).
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, nil, nil, nil, executor, st.Config, deadlinePassedRefused(st, 1))
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, nil, nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.Error(t, err)
 	require.False(t, accept, "should reject: nil payload")
 	require.Contains(t, err.Error(), "no payload")
@@ -194,7 +195,7 @@ func TestVerifyRefused_PayloadMismatch_Rejects(t *testing.T) {
 	badPayload := testPayload()
 	badPayload.Model = "wrong-model"
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, badPayload, nil, nil, executor, st.Config, deadlinePassedRefused(st, 1))
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, badPayload, nil, nil, executor, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.NoError(t, err)
 	require.False(t, accept, "should reject: payload mismatch")
 }
@@ -256,7 +257,7 @@ func TestVerifyRefused_FinishInMempool(t *testing.T) {
 		{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{InferenceId: 1}}},
 	}
 
-	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, mempool, nil, st.Config, deadlinePassedRefused(st, 1))
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, mempool, nil, nil, st.Config, deadlinePassedRefused(st, 1))
 	require.NoError(t, err)
 	require.False(t, accept, "should reject: MsgFinishInference in local mempool")
 }
@@ -269,3 +270,38 @@ func TestVerifyExecution_DeadlineNotPassed(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, accept, "should reject: deadline not passed")
 }
+
+func TestVerifyRefused_CopiesChallengeMempool(t *testing.T) {
+	st := stateWithPendingFull(1, 1)
+	confirm := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 1,
+		ExecutorSig: []byte("receipt-sig"),
+		ConfirmedAt: 1000,
+	}}}
+	executor := &mockExecutorClient{
+		challengeReceipt: []byte("receipt-sig"),
+		challengeMempool: []*types.DevshardTx{confirm},
+	}
+	verifierPool := NewMempool()
+
+	accept, err := VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, verifierPool, st.Config, deadlinePassedRefused(st, 1))
+	require.NoError(t, err)
+	require.False(t, accept, "should reject: executor produced receipt")
+
+	got := findMempoolConfirm(verifierPool.Txs())
+	require.NotNil(t, got, "verifier pool must copy MsgConfirmStart from challenge mempool")
+	require.Equal(t, types.TxHash(confirm), types.TxHash(got))
+	require.Equal(t, []byte("receipt-sig"), got.GetConfirmStart().ExecutorSig)
+
+	accept, err = VerifyRefusedTimeout(context.Background(), st, 1, testPayload(), nil, nil, executor, verifierPool, st.Config, deadlinePassedRefused(st, 1))
+	require.NoError(t, err)
+	require.False(t, accept)
+	var confirmCount int
+	for _, tx := range verifierPool.Txs() {
+		if tx.GetConfirmStart() != nil {
+			confirmCount++
+		}
+	}
+	require.Equal(t, 1, confirmCount, "second challenge must not stack a second ConfirmStart")
+}
+

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -329,7 +329,7 @@ func TestHTTP_TimeoutRefused(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	votes, err := env.session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+	votes, _, err := env.session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
 		Prompt:      testutil.TestPrompt,
 		Model:       "llama",
 		InputLength: 100,
@@ -404,7 +404,7 @@ func TestHTTP_TimeoutExecution(t *testing.T) {
 		verifiers[i] = env.clients[i]
 	}
 
-	votes, err := env.session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_EXECUTION, nil, verifiers, allDiffs) // nil payload for execution timeout
+	votes, _, err := env.session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_EXECUTION, nil, verifiers, allDiffs) // nil payload for execution timeout
 	require.NoError(t, err)
 	require.True(t, len(votes) > int(env.config.VoteThreshold),
 		"need >%d votes, got %d", env.config.VoteThreshold, len(votes))
@@ -433,7 +433,7 @@ func TestHTTP_TimeoutRejected(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try timeout verification -- should fail because inference is finished.
-	accept, _, _, err := env.clients[2].VerifyTimeout(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, nil, nil)
+	accept, _, _, _, err := env.clients[2].VerifyTimeout(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, nil, nil)
 	require.Error(t, err)
 	require.False(t, accept)
 }
@@ -469,7 +469,7 @@ func TestHTTP_ChallengeReceipt_RejectsTimeout(t *testing.T) {
 		verifiers[i] = env.clients[i]
 	}
 
-	votes, err := env.session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+	votes, _, err := env.session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
 		Prompt:      testutil.TestPrompt,
 		Model:       "llama",
 		InputLength: 100,
@@ -975,4 +975,170 @@ func TestAttack_GossipEmptySigBypass(t *testing.T) {
 	hostClient1 := httpTestClient(env.httpServers[1].URL, "escrow-1", env.signers[0])
 	err = hostClient1.GossipNonce(ctx, 1, resp.StateHash, resp.StateSig, 0)
 	require.NoError(t, err, "real gossip must succeed after rejected bypass attempts")
+}
+
+// T1: withheld payload → refused-timeout votes reject → session recovery
+// diff carries the executor's MsgConfirmStart and a peer SM applies it.
+func TestHTTP_T1_HonestRecovery_ConfirmStartReachesSessionAndPeer(t *testing.T) {
+	env := setupHTTPEnv(t, 3, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), prepared.Nonce())
+	executorIdx := prepared.HostIdx()
+
+	_, err = env.session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), refusedPayload())
+	require.NoError(t, err, "rejected refused-timeout must recover by publishing ConfirmStart")
+
+	diffs := env.session.Diffs()
+	require.GreaterOrEqual(t, len(diffs), 2)
+	recovery := diffs[len(diffs)-1]
+	require.Equal(t, 1, countConfirmStart(recovery.Txs, 1), "recovery diff must carry exactly one ConfirmStart for inference 1")
+	got := findConfirmStart(recovery.Txs, 1)
+	require.NotNil(t, got)
+
+	execConfirm := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), 1)
+	require.NotNil(t, execConfirm, "executor must still hold the challenge ConfirmStart")
+	require.Equal(t, types.TxHash(execConfirm), types.TxHash(got), "session must copy the executor tx, not mint a new ConfirmStart")
+	require.Equal(t, execConfirm.GetConfirmStart().ExecutorSig, got.GetConfirmStart().ExecutorSig)
+	require.Equal(t, execConfirm.GetConfirmStart().ConfirmedAt, got.GetConfirmStart().ConfirmedAt)
+
+	peer := newPeerSM(t, env, 1000000)
+	_, err = peer.ApplyDiff(diffs[0])
+	require.NoError(t, err)
+	require.Equal(t, types.StatusPending, peer.SnapshotState().Inferences[1].Status)
+
+	_, err = peer.ApplyDiff(recovery)
+	require.NoError(t, err)
+	after := peer.SnapshotState().Inferences[1].Status
+	if findFinish(recovery.Txs, 1) != nil {
+		require.Equal(t, types.StatusFinished, after)
+		return
+	}
+	require.Equal(t, types.StatusStarted, after, "peer SM that only saw StartInference must apply ConfirmStart: Pending → Started")
+
+	require.Eventually(t, func() bool {
+		return findFinish(env.hosts[executorIdx].MempoolTxs(), 1) != nil
+	}, 5*time.Second, 20*time.Millisecond, "executor execution should queue FinishInference")
+	finish := findFinish(env.hosts[executorIdx].MempoolTxs(), 1)
+	require.NotNil(t, finish)
+
+	settlePeer := newPeerSM(t, env, 1000000)
+	_, err = settlePeer.ApplyDiff(diffs[0])
+	require.NoError(t, err)
+	settle := testutil.SignDiff(t, env.userSigner, "escrow-1", 2, []*types.DevshardTx{got, finish})
+	_, err = settlePeer.ApplyDiff(settle)
+	require.NoError(t, err, "ConfirmStart + FinishInference sourced after challenge must apply")
+	require.Equal(t, types.StatusFinished, settlePeer.SnapshotState().Inferences[1].Status)
+}
+
+// T2: same challenge as T1, but the user omits ConfirmStart from later diffs.
+// Voting verifiers must keep the pool copy; a later honest inclusion still applies.
+func TestHTTP_T2_OmittedConfirmStart_VotingVerifiersRetainPoolCopy(t *testing.T) {
+	env := setupHTTPEnv(t, 3, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+
+	votes, recovery, err := env.session.CollectTimeoutVotes(ctx, prepared.Nonce(), types.TimeoutReason_TIMEOUT_REASON_REFUSED, refusedPayload(), env.session.TimeoutVerifiers(), env.session.Diffs())
+	require.NoError(t, err)
+	require.Empty(t, votes, "alive executor must cause verifiers to reject the timeout")
+	require.NotNil(t, findConfirmStart(recovery, 1), "reject votes must carry executor ConfirmStart")
+
+	execConfirm := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), 1)
+	require.NotNil(t, execConfirm)
+	wantHash := types.TxHash(execConfirm)
+
+	require.NoError(t, env.session.SendPendingDiff(ctx), "empty pending must still produce a follow-up diff")
+	omitDiffs := env.session.Diffs()
+	require.GreaterOrEqual(t, len(omitDiffs), 2)
+	require.Equal(t, 0, countConfirmStart(omitDiffs[len(omitDiffs)-1].Txs, 1), "user-omitted diff must not include ConfirmStart")
+
+	for i, h := range env.hosts {
+		_, err := h.HandleRequest(ctx, host.HostRequest{Diffs: omitDiffs, Nonce: omitDiffs[len(omitDiffs)-1].Nonce})
+		require.NoError(t, err, "host %d", i)
+		rec, ok := h.SnapshotState().Inferences[1]
+		require.True(t, ok, "host %d", i)
+		require.Equal(t, types.StatusPending, rec.Status, "host %d collective state must stay Pending when ConfirmStart is omitted", i)
+	}
+
+	for i, h := range env.hosts {
+		got := findConfirmStart(h.MempoolTxs(), 1)
+		if i == executorIdx {
+			require.NotNil(t, got, "executor must still hold ConfirmStart")
+			require.Equal(t, wantHash, types.TxHash(got))
+			continue
+		}
+		require.NotNil(t, got, "voting verifier %d must retain ConfirmStart after omission", i)
+		require.Equal(t, wantHash, types.TxHash(got), "verifier %d must keep the same hash as the executor", i)
+	}
+
+	peer := newPeerSM(t, env, 1000000)
+	for _, d := range omitDiffs {
+		_, err := peer.ApplyDiff(d)
+		require.NoError(t, err)
+	}
+	require.Equal(t, types.StatusPending, peer.SnapshotState().Inferences[1].Status)
+
+	honest := testutil.SignDiff(t, env.userSigner, "escrow-1", omitDiffs[len(omitDiffs)-1].Nonce+1, []*types.DevshardTx{execConfirm})
+	_, err = peer.ApplyDiff(honest)
+	require.NoError(t, err, "exact mempool ConfirmStart must still apply after omission")
+	require.Equal(t, types.StatusStarted, peer.SnapshotState().Inferences[1].Status)
+}
+
+func refusedPayload() *host.InferencePayload {
+	p := defaultParams()
+	return &host.InferencePayload{
+		Prompt:      p.Prompt,
+		Model:       p.Model,
+		InputLength: p.InputLength,
+		MaxTokens:   p.MaxTokens,
+		StartedAt:   p.StartedAt,
+	}
+}
+
+func findConfirmStart(txs []*types.DevshardTx, inferenceID uint64) *types.DevshardTx {
+	for _, tx := range txs {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			return tx
+		}
+	}
+	return nil
+}
+
+func findFinish(txs []*types.DevshardTx, inferenceID uint64) *types.DevshardTx {
+	for _, tx := range txs {
+		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
+			return tx
+		}
+	}
+	return nil
+}
+
+func countConfirmStart(txs []*types.DevshardTx, inferenceID uint64) int {
+	n := 0
+	for _, tx := range txs {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			n++
+		}
+	}
+	return n
+}
+
+func newPeerSM(t *testing.T, env *httpTestEnv, balance uint64) *state.StateMachine {
+	t.Helper()
+	sm, err := state.NewStateMachine(
+		"escrow-1",
+		env.config,
+		env.group,
+		balance,
+		env.userSigner.Address(),
+		signing.NewSecp256k1Verifier(),
+		testutil.MustMemoryStore(t, "escrow-1", env.userSigner.Address(), env.config, env.group, balance),
+	)
+	require.NoError(t, err)
+	return sm
 }

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -707,6 +707,107 @@ func TestHTTP_RefusedTimeoutChallengeTimeoutThenRecoveryTxIsAvailable(t *testing
 	require.NotNil(t, findConfirmStart(recovery, prepared.Nonce()), "next check must surface executor ConfirmStart as recovery")
 }
 
+func TestHTTP_ExecutionTimeoutRejectedWhenExecutorHasFinish(t *testing.T) {
+	config := testutil.DefaultConfig(3)
+	config.ExecutionTimeout = 0
+	env := setupHTTPEnv(t, 3, 1000000, 100, config)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+
+	receipt, _, err := env.clients[executorIdx].ChallengeReceipt(ctx, prepared.Nonce(), refusedPayload(), env.session.Diffs())
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce())
+	require.NotNil(t, confirmTx)
+
+	require.NoError(t, env.session.ProcessResponse(executorIdx, &host.HostResponse{
+		Receipt:     receipt,
+		ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt,
+	}, prepared.Nonce()))
+	require.NoError(t, env.session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+
+	require.Eventually(t, func() bool {
+		return findFinish(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()) != nil
+	}, 5*time.Second, 20*time.Millisecond)
+
+	votes, recovery, err := env.session.CollectTimeoutVotes(ctx, prepared.Nonce(), types.TimeoutReason_TIMEOUT_REASON_EXECUTION, nil, env.session.TimeoutVerifiers(), env.session.Diffs())
+	require.NoError(t, err)
+	require.Empty(t, votes, "executor finish in mempool must reject execution timeout")
+	require.Empty(t, recovery, "execution-timeout rejection should not publish refused-start recovery")
+}
+
+func TestHTTP_NextRequestSettlesFinishFromExecutorMempool(t *testing.T) {
+	env := setupHTTPEnv(t, 1, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+
+	receipt, _, err := env.clients[executorIdx].ChallengeReceipt(ctx, prepared.Nonce(), refusedPayload(), env.session.Diffs())
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce())
+	require.NotNil(t, confirmTx)
+
+	require.NoError(t, env.session.ProcessResponse(executorIdx, &host.HostResponse{
+		Receipt:     receipt,
+		ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt,
+	}, prepared.Nonce()))
+	require.NoError(t, env.session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+
+	require.Eventually(t, func() bool {
+		return findFinish(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()) != nil
+	}, 5*time.Second, 20*time.Millisecond)
+	require.NotNil(t, findFinish(env.session.PendingTxs(), prepared.Nonce()),
+		"ConfirmStart publish response must pull FinishInference from executor mempool into session pending txs")
+
+	_, err = env.session.SendInference(ctx, defaultParams())
+	require.NoError(t, err)
+	require.Equal(t, types.StatusFinished, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+}
+
+func TestHTTP_ExecutionTimeoutAfterFinishPulledPendingDoesNotTimeout(t *testing.T) {
+	withHTTPTimeoutBuffer(t, 0)
+	config := testutil.DefaultConfig(1)
+	config.ExecutionTimeout = 0
+	env := setupHTTPEnv(t, 1, 1000000, 100, config)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+
+	receipt, _, err := env.clients[executorIdx].ChallengeReceipt(ctx, prepared.Nonce(), refusedPayload(), env.session.Diffs())
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce())
+	require.NotNil(t, confirmTx)
+
+	require.NoError(t, env.session.ProcessResponse(executorIdx, &host.HostResponse{
+		Receipt:     receipt,
+		ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt,
+	}, prepared.Nonce()))
+	require.NoError(t, env.session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+
+	require.Eventually(t, func() bool {
+		return findFinish(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()) != nil
+	}, 5*time.Second, 20*time.Millisecond)
+	require.NotNil(t, findFinish(env.session.PendingTxs(), prepared.Nonce()),
+		"test setup expects FinishInference to be pending before timeout handling starts")
+
+	result, err := env.session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), nil)
+	require.NoError(t, err, "pending FinishInference should be published instead of timing out the started inference")
+	require.Equal(t, "execution", result.Reason)
+	require.Equal(t, types.StatusFinished, env.session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+}
+
 func TestHTTP_StateRecovery(t *testing.T) {
 	env := setupHTTPEnv(t, 3, 100000, 100)
 	ctx := context.Background()

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -480,6 +480,28 @@ func TestHTTP_ChallengeReceipt_RejectsTimeout(t *testing.T) {
 	require.Equal(t, 0, len(votes), "all hosts should reject timeout because executor is alive and produced receipt")
 }
 
+func TestHTTP_RefusedTimeoutChallengeRecoveryLandsInNextDiff(t *testing.T) {
+	env := setupHTTPEnv(t, 5, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), prepared.Nonce())
+	executorIdx := prepared.HostIdx()
+	require.Equal(t, 1, executorIdx)
+
+	result, err := env.session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), refusedPayload())
+	require.NoError(t, err, "reachable executor receipt should recover instead of timing out")
+	require.Equal(t, "refused", result.Reason)
+	require.NotNil(t, findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()),
+		"executor should queue recovery MsgConfirmStart after challenge")
+
+	diffs := env.session.Diffs()
+	require.GreaterOrEqual(t, len(diffs), 2)
+	require.NotNil(t, findConfirmStart(diffs[len(diffs)-1].Txs, prepared.Nonce()),
+		"recovery MsgConfirmStart from challenge should land in the next user diff")
+}
+
 func TestHTTP_StateRecovery(t *testing.T) {
 	env := setupHTTPEnv(t, 3, 100000, 100)
 	ctx := context.Background()

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -36,6 +36,19 @@ type httpTestEnv struct {
 	gossips     []*gossip.Gossip
 }
 
+type recoveryVerifierClient struct {
+	user.HostClient
+	source *recoveryVerifierSource
+}
+
+type recoveryVerifierSource struct {
+	txs []*types.DevshardTx
+}
+
+func (c *recoveryVerifierClient) VerifyTimeout(_ context.Context, _ uint64, _ types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, []*types.DevshardTx, error) {
+	return false, nil, 0, c.source.txs, nil
+}
+
 const httpTestRoutePrefix = "/devshard/v2"
 
 func httpTestClient(baseURL string, escrowID string, signer signing.Signer) *transport.HTTPClient {
@@ -167,6 +180,40 @@ func setupHTTPEnv(t *testing.T, numHosts int, balance, grace uint64, cfgs ...typ
 		stores:      stores,
 		gossips:     gossips,
 	}
+}
+
+func setupHTTPRecoveryVerifierSession(t *testing.T, env *httpTestEnv, recovery []*types.DevshardTx) (*user.Session, *recoveryVerifierSource) {
+	t.Helper()
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine(
+		"escrow-1",
+		env.config,
+		env.group,
+		1000000,
+		env.userSigner.Address(),
+		verifier,
+		testutil.MustMemoryStore(t, "escrow-1", env.userSigner.Address(), env.config, env.group, 1000000),
+	)
+	require.NoError(t, err)
+
+	source := &recoveryVerifierSource{txs: recovery}
+	clients := make([]user.HostClient, len(env.clients))
+	for i, c := range env.clients {
+		clients[i] = &recoveryVerifierClient{HostClient: c, source: source}
+	}
+
+	session, err := user.NewSession(sm, env.userSigner, "escrow-1", env.group, clients, verifier)
+	require.NoError(t, err)
+	return session, source
+}
+
+func withHTTPTimeoutBuffer(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := user.TimeoutBuffer
+	user.TimeoutBuffer = d
+	t.Cleanup(func() {
+		user.TimeoutBuffer = prev
+	})
 }
 
 func TestHTTP_HappyPath(t *testing.T) {
@@ -500,6 +547,85 @@ func TestHTTP_RefusedTimeoutChallengeRecoveryLandsInNextDiff(t *testing.T) {
 	require.GreaterOrEqual(t, len(diffs), 2)
 	require.NotNil(t, findConfirmStart(diffs[len(diffs)-1].Txs, prepared.Nonce()),
 		"recovery MsgConfirmStart from challenge should land in the next user diff")
+}
+
+func TestHTTP_RefusedTimeoutRecoveryDeduplicatesAcrossVerifierRejects(t *testing.T) {
+	env := setupHTTPEnv(t, 5, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), prepared.Nonce())
+
+	_, err = env.session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), refusedPayload())
+	require.NoError(t, err)
+
+	diffs := env.session.Diffs()
+	require.GreaterOrEqual(t, len(diffs), 2)
+	recovery := diffs[len(diffs)-1]
+	require.Equal(t, 1, countConfirmStart(recovery.Txs, prepared.Nonce()),
+		"multiple verifier rejects must not duplicate the executor ConfirmStart in the recovery diff")
+}
+
+func TestHTTP_RefusedTimeoutRecoveryIgnoresUnrelatedMempool(t *testing.T) {
+	env := setupHTTPEnv(t, 3, 1000000, 100)
+	ctx := context.Background()
+	unrelated := []*types.DevshardTx{
+		{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+			InferenceId: 999,
+			ExecutorSig: []byte("other-receipt"),
+			ConfirmedAt: 1000,
+		}}},
+		{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{
+			InferenceId:  999,
+			ResponseHash: []byte("other-response"),
+		}}},
+	}
+	session, _ := setupHTTPRecoveryVerifierSession(t, env, unrelated)
+
+	prepared, err := session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	beforeDiffs := len(session.Diffs())
+
+	_, err = session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), refusedPayload())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient votes")
+	require.Len(t, session.Diffs(), beforeDiffs)
+
+	rec, ok := session.StateMachine().SnapshotState().Inferences[prepared.Nonce()]
+	require.True(t, ok)
+	require.Equal(t, types.StatusPending, rec.Status)
+}
+
+func TestHTTP_ExecutionTimeoutDoesNotUseConfirmStartRecovery(t *testing.T) {
+	withHTTPTimeoutBuffer(t, 0)
+	config := testutil.DefaultConfig(3)
+	config.ExecutionTimeout = 0
+	env := setupHTTPEnv(t, 3, 1000000, 100, config)
+	ctx := context.Background()
+	session, recoverySource := setupHTTPRecoveryVerifierSession(t, env, nil)
+
+	prepared, err := session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+	receipt, _, err := env.hosts[executorIdx].ChallengeReceipt(ctx, prepared.Nonce(), refusedPayload(), session.Diffs())
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce())
+	require.NotNil(t, confirmTx)
+	recoverySource.txs = []*types.DevshardTx{confirmTx}
+
+	resp := &host.HostResponse{Receipt: receipt, ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt}
+	require.NoError(t, session.ProcessResponse(executorIdx, resp, prepared.Nonce()))
+	require.NoError(t, session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+	beforeDiffs := len(session.Diffs())
+
+	_, err = session.HandleTimeout(ctx, prepared.Nonce(), time.Unix(0, 0), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient votes")
+	require.Len(t, session.Diffs(), beforeDiffs, "execution timeout must not publish ConfirmStart recovery")
+	require.Equal(t, types.StatusStarted, session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
 }
 
 func TestHTTP_StateRecovery(t *testing.T) {

--- a/devshard/protocol/http_test.go
+++ b/devshard/protocol/http_test.go
@@ -2,6 +2,9 @@ package protocol
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -626,6 +629,82 @@ func TestHTTP_ExecutionTimeoutDoesNotUseConfirmStartRecovery(t *testing.T) {
 	require.Contains(t, err.Error(), "insufficient votes")
 	require.Len(t, session.Diffs(), beforeDiffs, "execution timeout must not publish ConfirmStart recovery")
 	require.Equal(t, types.StatusStarted, session.StateMachine().SnapshotState().Inferences[prepared.Nonce()].Status)
+}
+
+func TestHTTP_RefusedTimeoutChallengeTimeoutThenRecoveryTxIsAvailable(t *testing.T) {
+	env := setupHTTPEnv(t, 5, 1000000, 100)
+	ctx := context.Background()
+
+	prepared, err := env.session.PrepareInference(defaultParams())
+	require.NoError(t, err)
+	executorIdx := prepared.HostIdx()
+	challenged := make(chan struct{}, 1)
+	slowExecutor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var req transport.ChallengeReceiptRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		diffs := make([]types.Diff, 0, len(req.Diffs))
+		for i, dj := range req.Diffs {
+			diff, err := transport.DiffFromJSON(dj)
+			require.NoError(t, err, "decode diff %d", i)
+			diffs = append(diffs, diff)
+		}
+
+		receipt, _, err := env.hosts[executorIdx].ChallengeReceipt(r.Context(), req.InferenceID, transport.PayloadFromJSON(req.Payload), diffs)
+		require.NoError(t, err)
+		mempool, err := transport.DevshardTxsToBytes(host.RecoveryTxsFor(env.hosts[executorIdx].MempoolTxs(), req.InferenceID))
+		require.NoError(t, err)
+		select {
+		case challenged <- struct{}{}:
+		default:
+		}
+
+		time.Sleep(500 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(transport.ChallengeReceiptResponse{Receipt: receipt, Mempool: mempool})
+	}))
+	t.Cleanup(slowExecutor.Close)
+
+	slowCfg := transport.DefaultClientConfig()
+	slowCfg.RoutePrefix = httpTestRoutePrefix
+	slowCfg.VerifyTimeout = 100 * time.Millisecond
+	slowClient := transport.NewHTTPClient(slowExecutor.URL, "escrow-1", env.userSigner, slowCfg)
+
+	for _, srv := range env.servers {
+		peers := make(map[int]*transport.HTTPClient)
+		for i, c := range env.clients {
+			peers[i] = c
+		}
+		peers[executorIdx] = slowClient
+		srv.SetPeerClients(peers)
+	}
+
+	votes, recovery, err := env.session.CollectTimeoutVotes(ctx, prepared.Nonce(), types.TimeoutReason_TIMEOUT_REASON_REFUSED, refusedPayload(), env.session.TimeoutVerifiers(), env.session.Diffs())
+	require.NoError(t, err)
+	require.True(t, len(votes) > int(env.config.VoteThreshold), "challenge response timeouts should initially look like executor unreachable")
+	require.Empty(t, recovery)
+
+	select {
+	case <-challenged:
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor was not challenged before verifier timeout")
+	}
+	require.NotNil(t, findConfirmStart(env.hosts[executorIdx].MempoolTxs(), prepared.Nonce()),
+		"executor must keep ConfirmStart even when verifier times out waiting for challenge response")
+
+	for _, srv := range env.servers {
+		peers := make(map[int]*transport.HTTPClient)
+		for i, c := range env.clients {
+			peers[i] = c
+		}
+		srv.SetPeerClients(peers)
+	}
+
+	votes, recovery, err = env.session.CollectTimeoutVotes(ctx, prepared.Nonce(), types.TimeoutReason_TIMEOUT_REASON_REFUSED, refusedPayload(), env.session.TimeoutVerifiers(), env.session.Diffs())
+	require.NoError(t, err)
+	require.Empty(t, votes, "once the executor recovery tx is reachable, timeout should no longer pass as clean refused")
+	require.NotNil(t, findConfirmStart(recovery, prepared.Nonce()), "next check must surface executor ConfirmStart as recovery")
 }
 
 func TestHTTP_StateRecovery(t *testing.T) {

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -442,6 +442,68 @@ func TestApplyDiff_Timeout_Refused(t *testing.T) {
 	require.Equal(t, uint64(10000), state.Balance)
 }
 
+func TestApplyDiff_PostTimeoutRecoveryDoesNotReviveInference(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+
+	for _, tc := range []struct {
+		name string
+		tx   func(t *testing.T, hosts []*signing.Secp256k1Signer) *types.DevshardTx
+	}{
+		{
+			name: "late confirm start",
+			tx: func(t *testing.T, hosts []*signing.Secp256k1Signer) *types.DevshardTx {
+				execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, []byte("prompt"), "llama", 100, 50, 1000, 1000)
+				return txConfirm(&types.MsgConfirmStart{InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 1000})
+			},
+		},
+		{
+			name: "late finish inference",
+			tx: func(t *testing.T, hosts []*signing.Secp256k1Signer) *types.DevshardTx {
+				finishMsg := &types.MsgFinishInference{
+					InferenceId: 1, ResponseHash: []byte("response"),
+					InputTokens: 80, OutputTokens: 40, ExecutorSlot: 1,
+					EscrowId: "escrow-1",
+				}
+				finishMsg.ProposerSig = testutil.SignProposerTx(t, hosts[1], finishMsg)
+				return txFinish(finishMsg)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sm, user := newTestSM(t, hosts, 10000)
+
+			diff := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{txStart(&types.MsgStartInference{
+				InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama",
+				InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+			})})
+			_, err := sm.ApplyDiff(diff)
+			require.NoError(t, err)
+
+			var votes []*types.TimeoutVote
+			for _, slot := range []uint32{0, 2, 3} {
+				v := testutil.SignTimeoutVote(t, hosts[slot], "escrow-1", 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, true)
+				v.VoterSlot = slot
+				votes = append(votes, v)
+			}
+
+			diff = testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{txTimeout(&types.MsgTimeoutInference{
+				InferenceId: 1, Reason: types.TimeoutReason_TIMEOUT_REASON_REFUSED, Votes: votes,
+			})})
+			_, err = sm.ApplyDiff(diff)
+			require.NoError(t, err)
+			require.Equal(t, types.StatusTimedOut, sm.SnapshotState().Inferences[1].Status)
+
+			diff = testutil.SignDiff(t, user, "escrow-1", 3, []*types.DevshardTx{tc.tx(t, hosts)})
+			_, err = sm.ApplyDiff(diff)
+			require.ErrorIs(t, err, types.ErrInvalidTransition)
+			require.Equal(t, types.StatusTimedOut, sm.SnapshotState().Inferences[1].Status)
+		})
+	}
+}
+
 func TestApplyDiff_Timeout_Execution(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{
 		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),

--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -566,8 +566,9 @@ func (c *HTTPClient) SendVerifyTimeout(ctx context.Context, req VerifyTimeoutReq
 	return &resp, nil
 }
 
-// ChallengeReceipt forwards diffs + payload to the executor and returns the receipt.
-func (c *HTTPClient) ChallengeReceipt(ctx context.Context, inferenceID uint64, payload *host.InferencePayload, diffs []types.Diff) ([]byte, error) {
+// ChallengeReceipt forwards diffs + payload to the executor and returns the
+// receipt plus a snapshot of the executor mempool (recovery txs).
+func (c *HTTPClient) ChallengeReceipt(ctx context.Context, inferenceID uint64, payload *host.InferencePayload, diffs []types.Diff) ([]byte, []*types.DevshardTx, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.config.VerifyTimeout)
 	defer cancel()
 
@@ -575,7 +576,7 @@ func (c *HTTPClient) ChallengeReceipt(ctx context.Context, inferenceID uint64, p
 	for i, d := range diffs {
 		dj, err := DiffToJSON(d)
 		if err != nil {
-			return nil, fmt.Errorf("encode diff %d: %w", i, err)
+			return nil, nil, fmt.Errorf("encode diff %d: %w", i, err)
 		}
 		djList[i] = dj
 	}
@@ -587,28 +588,32 @@ func (c *HTTPClient) ChallengeReceipt(ctx context.Context, inferenceID uint64, p
 	}
 	body, err := json.Marshal(req)
 	if err != nil {
-		return nil, fmt.Errorf("marshal: %w", err)
+		return nil, nil, fmt.Errorf("marshal: %w", err)
 	}
 	respBody, err := c.doPost(ctx, "/sessions/"+c.escrowID+"/challenge-receipt", body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var resp ChallengeReceiptResponse
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("unmarshal: %w", err)
+		return nil, nil, fmt.Errorf("unmarshal: %w", err)
 	}
-	return resp.Receipt, nil
+	mempool, err := DevshardTxsFromBytes(resp.Mempool)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode mempool: %w", err)
+	}
+	return resp.Receipt, mempool, nil
 }
 
 // VerifyTimeout implements user.TimeoutVerifier over HTTP.
-func (c *HTTPClient) VerifyTimeout(ctx context.Context, inferenceID uint64, reason types.TimeoutReason, payload *host.InferencePayload, diffs []types.Diff) (bool, []byte, uint32, error) {
+func (c *HTTPClient) VerifyTimeout(ctx context.Context, inferenceID uint64, reason types.TimeoutReason, payload *host.InferencePayload, diffs []types.Diff) (bool, []byte, uint32, []*types.DevshardTx, error) {
 	var djList []DiffJSON
 	if len(diffs) > 0 {
 		djList = make([]DiffJSON, len(diffs))
 		for i, d := range diffs {
 			dj, err := DiffToJSON(d)
 			if err != nil {
-				return false, nil, 0, fmt.Errorf("encode diff %d: %w", i, err)
+				return false, nil, 0, nil, fmt.Errorf("encode diff %d: %w", i, err)
 			}
 			djList[i] = dj
 		}
@@ -620,9 +625,13 @@ func (c *HTTPClient) VerifyTimeout(ctx context.Context, inferenceID uint64, reas
 		Diffs:       djList,
 	})
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, nil, err
 	}
-	return resp.Accept, resp.Signature, resp.VoterSlot, nil
+	mempool, err := DevshardTxsFromBytes(resp.Mempool)
+	if err != nil {
+		return false, nil, 0, nil, fmt.Errorf("decode mempool: %w", err)
+	}
+	return resp.Accept, resp.Signature, resp.VoterSlot, mempool, nil
 }
 
 // GetDiffs fetches stored diffs from a peer.

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -58,6 +58,11 @@ func setupClientTestEnv(t *testing.T) (*HTTPClient, *httptest.Server, *signing.S
 	cfg := DefaultClientConfig()
 	cfg.RoutePrefix = testRoutePrefix
 	client := NewHTTPClient(ts.URL, "escrow-1", userSigner, cfg)
+	// Single-host groups map inference 1 to executor slot 0. Wire the user
+	// client as that peer so /verify-timeout can challenge-receipt itself
+	// (owner is allowed on challenge-receipt). Without this, executorClient
+	// is nil and a refused timeout is accepted.
+	srv.SetPeerClients(map[int]*HTTPClient{0: client})
 	return client, ts, userSigner, group
 }
 
@@ -92,6 +97,63 @@ func TestHTTPClient_Send_RoundTrip(t *testing.T) {
 		}
 	}
 	require.True(t, hasFinish, "mempool should contain MsgFinishInference")
+}
+
+func TestHTTPClient_ChallengeReceipt_ReturnsRecoveryMempool(t *testing.T) {
+	client, _, userSigner, _ := setupClientTestEnv(t)
+	ctx := context.Background()
+
+	diff := testutil.SignDiff(t, userSigner, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	payload := &host.InferencePayload{
+		Prompt:      testutil.TestPrompt,
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}
+
+	receipt, mempool, err := client.ChallengeReceipt(ctx, 1, payload, []types.Diff{diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt, "challenge must return the executor receipt")
+	require.NotEmpty(t, mempool, "client must return executor mempool from challenge response")
+
+	var got *types.MsgConfirmStart
+	for _, tx := range mempool {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == 1 {
+			got = cs
+			break
+		}
+	}
+	require.NotNil(t, got, "returned mempool must include MsgConfirmStart")
+	require.Equal(t, receipt, got.ExecutorSig)
+}
+
+func TestHTTPClient_VerifyTimeout_ReturnsRecoveryMempool(t *testing.T) {
+	client, _, userSigner, _ := setupClientTestEnv(t)
+	ctx := context.Background()
+
+	diff := testutil.SignDiff(t, userSigner, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	payload := &host.InferencePayload{
+		Prompt:      testutil.TestPrompt,
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}
+
+	accept, _, _, mempool, err := client.VerifyTimeout(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, []types.Diff{diff})
+	require.NoError(t, err)
+	require.False(t, accept, "alive executor must reject the refused timeout")
+	require.NotEmpty(t, mempool, "reject must return recovery mempool")
+
+	var got *types.MsgConfirmStart
+	for _, tx := range mempool {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == 1 {
+			got = cs
+			break
+		}
+	}
+	require.NotNil(t, got, "verify-timeout mempool must include MsgConfirmStart")
 }
 
 func TestHTTPClient_Send_ReturnsUpstreamStatusError(t *testing.T) {

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -22,7 +22,7 @@ import (
 	"devshard/types"
 )
 
-func setupClientTestEnv(t *testing.T) (*HTTPClient, *httptest.Server, *signing.Secp256k1Signer, []types.SlotAssignment) {
+func setupClientTestEnv(t *testing.T) (*HTTPClient, *httptest.Server, *signing.Secp256k1Signer, []types.SlotAssignment, *host.Host) {
 	t.Helper()
 	hostSigner := testutil.MustGenerateKey(t)
 	userSigner := testutil.MustGenerateKey(t)
@@ -63,11 +63,11 @@ func setupClientTestEnv(t *testing.T) (*HTTPClient, *httptest.Server, *signing.S
 	// (owner is allowed on challenge-receipt). Without this, executorClient
 	// is nil and a refused timeout is accepted.
 	srv.SetPeerClients(map[int]*HTTPClient{0: client})
-	return client, ts, userSigner, group
+	return client, ts, userSigner, group, h
 }
 
 func TestHTTPClient_Send_RoundTrip(t *testing.T) {
-	client, _, userSigner, _ := setupClientTestEnv(t)
+	client, _, userSigner, _, _ := setupClientTestEnv(t)
 	ctx := context.Background()
 
 	diff := testutil.SignDiff(t, userSigner, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
@@ -100,7 +100,7 @@ func TestHTTPClient_Send_RoundTrip(t *testing.T) {
 }
 
 func TestHTTPClient_ChallengeReceipt_ReturnsRecoveryMempool(t *testing.T) {
-	client, _, userSigner, _ := setupClientTestEnv(t)
+	client, _, userSigner, _, _ := setupClientTestEnv(t)
 	ctx := context.Background()
 
 	diff := testutil.SignDiff(t, userSigner, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
@@ -129,8 +129,14 @@ func TestHTTPClient_ChallengeReceipt_ReturnsRecoveryMempool(t *testing.T) {
 }
 
 func TestHTTPClient_VerifyTimeout_ReturnsRecoveryMempool(t *testing.T) {
-	client, _, userSigner, _ := setupClientTestEnv(t)
+	client, _, userSigner, _, h := setupClientTestEnv(t)
 	ctx := context.Background()
+
+	h.AddTx(&types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 99,
+		ExecutorSig: []byte("other"),
+		ConfirmedAt: 1,
+	}}})
 
 	diff := testutil.SignDiff(t, userSigner, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
 	payload := &host.InferencePayload{
@@ -154,6 +160,7 @@ func TestHTTPClient_VerifyTimeout_ReturnsRecoveryMempool(t *testing.T) {
 		}
 	}
 	require.NotNil(t, got, "verify-timeout mempool must include MsgConfirmStart")
+	requireRecoveryOnlyFor(t, mempool, 1)
 }
 
 func TestHTTPClient_Send_ReturnsUpstreamStatusError(t *testing.T) {
@@ -195,7 +202,7 @@ func TestHTTPClient_Send_NoPayloadUsesQueryTimeout(t *testing.T) {
 }
 
 func TestHTTPClient_GetDiffs(t *testing.T) {
-	client, _, userSigner, _ := setupClientTestEnv(t)
+	client, _, userSigner, _, _ := setupClientTestEnv(t)
 	ctx := context.Background()
 
 	// Send an inference to create a stored diff.
@@ -221,7 +228,7 @@ func TestHTTPClient_GetDiffs(t *testing.T) {
 }
 
 func TestHTTPClient_GetMempool(t *testing.T) {
-	client, _, userSigner, _ := setupClientTestEnv(t)
+	client, _, userSigner, _, _ := setupClientTestEnv(t)
 	ctx := context.Background()
 
 	// Send an inference to populate mempool with MsgFinishInference.
@@ -283,7 +290,7 @@ func (r *truncatedReader) Read(p []byte) (int, error) {
 }
 
 func TestHTTPClient_Send_SSE(t *testing.T) {
-	client, _, userSigner, _ := setupClientTestEnv(t)
+	client, _, userSigner, _, _ := setupClientTestEnv(t)
 	ctx := context.Background()
 
 	var streamLines []string
@@ -342,7 +349,7 @@ func (s *stubAdmissionController) ObserveTransportFailure(participantKey, path s
 }
 
 func TestHTTPClient_Send_UsesAdmissionController(t *testing.T) {
-	client, _, userSigner, _ := setupClientTestEnv(t)
+	client, _, userSigner, _, _ := setupClientTestEnv(t)
 	ctx := context.Background()
 	admission := &stubAdmissionController{err: fmt.Errorf("participant request budget exhausted")}
 	client.config.ParticipantKey = "shared-host"

--- a/devshard/transport/server.go
+++ b/devshard/transport/server.go
@@ -667,7 +667,7 @@ func (s *Server) HandleVerifyTimeout(c echo.Context) (err error) {
 		resp.Signature = sig
 		resp.VoterSlot = voterSlot
 	} else {
-		mempoolBytes, mErr := DevshardTxsToBytes(s.host.MempoolTxs())
+		mempoolBytes, mErr := DevshardTxsToBytes(host.RecoveryTxsFor(s.host.MempoolTxs(), req.InferenceID))
 		if mErr != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, mErr.Error())
 		}
@@ -735,7 +735,7 @@ func (s *Server) HandleChallengeReceipt(c echo.Context) (err error) {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	mempoolBytes, err := DevshardTxsToBytes(s.host.MempoolTxs())
+	mempoolBytes, err := DevshardTxsToBytes(host.RecoveryTxsFor(s.host.MempoolTxs(), req.InferenceID))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/devshard/transport/server.go
+++ b/devshard/transport/server.go
@@ -648,7 +648,7 @@ func (s *Server) HandleVerifyTimeout(c echo.Context) (err error) {
 				}
 			}
 		}
-		accept, err = host.VerifyRefusedTimeout(c.Request().Context(), st, req.InferenceID, PayloadFromJSON(req.Payload), storedDiffs, localMempool, executorClient, st.Config, nowUnix)
+		accept, err = host.VerifyRefusedTimeout(c.Request().Context(), st, req.InferenceID, PayloadFromJSON(req.Payload), storedDiffs, localMempool, executorClient, s.host, st.Config, nowUnix)
 	case types.TimeoutReason_TIMEOUT_REASON_EXECUTION:
 		accept, err = host.VerifyExecutionTimeout(c.Request().Context(), st, req.InferenceID, localMempool, executorClient, st.Config, nowUnix)
 	default:
@@ -666,6 +666,12 @@ func (s *Server) HandleVerifyTimeout(c echo.Context) (err error) {
 		}
 		resp.Signature = sig
 		resp.VoterSlot = voterSlot
+	} else {
+		mempoolBytes, mErr := DevshardTxsToBytes(s.host.MempoolTxs())
+		if mErr != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, mErr.Error())
+		}
+		resp.Mempool = mempoolBytes
 	}
 	return writeJSON(c, http.StatusOK, resp)
 }
@@ -729,7 +735,11 @@ func (s *Server) HandleChallengeReceipt(c echo.Context) (err error) {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	return writeJSON(c, http.StatusOK, ChallengeReceiptResponse{Receipt: receipt})
+	mempoolBytes, err := DevshardTxsToBytes(s.host.MempoolTxs())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return writeJSON(c, http.StatusOK, ChallengeReceiptResponse{Receipt: receipt, Mempool: mempoolBytes})
 }
 
 func (s *Server) HandleGossipNonce(c echo.Context) (err error) {

--- a/devshard/transport/server_test.go
+++ b/devshard/transport/server_test.go
@@ -579,6 +579,12 @@ func TestServer_ChallengeReceipt_ReturnsRecoveryMempool(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	env.server.host.AddTx(&types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 99,
+		ExecutorSig: []byte("other"),
+		ConfirmedAt: 1,
+	}}})
+
 	rec := env.doPostAs(t, "/devshard/v2/sessions/escrow-1/challenge-receipt", body, env.hostSigner)
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
@@ -590,6 +596,8 @@ func TestServer_ChallengeReceipt_ReturnsRecoveryMempool(t *testing.T) {
 	txs, err := DevshardTxsFromBytes(resp.Mempool)
 	require.NoError(t, err)
 	require.True(t, hasConfirmStartTx(txs, 1), "recovery mempool must include MsgConfirmStart")
+	require.False(t, hasConfirmStartTx(txs, 99), "recovery mempool must not include other inferences")
+	requireRecoveryOnlyFor(t, txs, 1)
 }
 
 func hasConfirmStartTx(txs []*types.DevshardTx, inferenceID uint64) bool {
@@ -599,6 +607,21 @@ func hasConfirmStartTx(txs []*types.DevshardTx, inferenceID uint64) bool {
 		}
 	}
 	return false
+}
+
+func requireRecoveryOnlyFor(t *testing.T, txs []*types.DevshardTx, id uint64) {
+	t.Helper()
+	require.NotEmpty(t, txs)
+	for _, tx := range txs {
+		switch {
+		case tx.GetConfirmStart() != nil:
+			require.Equal(t, id, tx.GetConfirmStart().InferenceId)
+		case tx.GetFinishInference() != nil:
+			require.Equal(t, id, tx.GetFinishInference().InferenceId)
+		default:
+			t.Fatalf("unexpected recovery tx type: %T", tx.GetTx())
+		}
+	}
 }
 
 func TestServer_NonExecutor_SSE(t *testing.T) {

--- a/devshard/transport/server_test.go
+++ b/devshard/transport/server_test.go
@@ -561,6 +561,46 @@ func TestServer_ChallengeReceipt_GroupMemberAllowed(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestServer_ChallengeReceipt_ReturnsRecoveryMempool(t *testing.T) {
+	env := setupServerEnv(t)
+	diff := testutil.SignDiff(t, env.userSigner, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	dj, err := DiffToJSON(diff)
+	require.NoError(t, err)
+	body, err := json.Marshal(ChallengeReceiptRequest{
+		InferenceID: 1,
+		Payload: &PayloadJSON{
+			Prompt:      testutil.TestPrompt,
+			Model:       "llama",
+			InputLength: 100,
+			MaxTokens:   50,
+			StartedAt:   1000,
+		},
+		Diffs: []DiffJSON{dj},
+	})
+	require.NoError(t, err)
+
+	rec := env.doPostAs(t, "/devshard/v2/sessions/escrow-1/challenge-receipt", body, env.hostSigner)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ChallengeReceiptResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Receipt, "challenge must return the executor receipt")
+	require.NotEmpty(t, resp.Mempool, "challenge response must return recovery mempool txs")
+
+	txs, err := DevshardTxsFromBytes(resp.Mempool)
+	require.NoError(t, err)
+	require.True(t, hasConfirmStartTx(txs, 1), "recovery mempool must include MsgConfirmStart")
+}
+
+func hasConfirmStartTx(txs []*types.DevshardTx, inferenceID uint64) bool {
+	for _, tx := range txs {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			return true
+		}
+	}
+	return false
+}
+
 func TestServer_NonExecutor_SSE(t *testing.T) {
 	// 3 hosts, request to non-executor.
 	hostSigners := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}

--- a/devshard/transport/types.go
+++ b/devshard/transport/types.go
@@ -57,9 +57,10 @@ type VerifyTimeoutRequest struct {
 
 // VerifyTimeoutResponse is returned by the timeout verification endpoint.
 type VerifyTimeoutResponse struct {
-	Accept    bool   `json:"accept"`
-	Signature []byte `json:"signature,omitempty"` // signed TimeoutVoteContent
-	VoterSlot uint32 `json:"voter_slot"`
+	Accept    bool     `json:"accept"`
+	Signature []byte   `json:"signature,omitempty"` // signed TimeoutVoteContent
+	VoterSlot uint32   `json:"voter_slot"`
+	Mempool   [][]byte `json:"mempool,omitempty"` // recovery txs on reject; each: proto bytes of DevshardTx
 }
 
 // ChallengeReceiptRequest is the JSON body for POST /sessions/:id/challenge-receipt.
@@ -71,7 +72,8 @@ type ChallengeReceiptRequest struct {
 
 // ChallengeReceiptResponse is returned by the challenge-receipt endpoint.
 type ChallengeReceiptResponse struct {
-	Receipt []byte `json:"receipt,omitempty"`
+	Receipt []byte   `json:"receipt,omitempty"`
+	Mempool [][]byte `json:"mempool,omitempty"` // each: proto bytes of DevshardTx
 }
 
 // GossipNonceRequest is the JSON body for POST /sessions/:id/gossip/nonce.

--- a/devshard/user/fault_test.go
+++ b/devshard/user/fault_test.go
@@ -221,7 +221,7 @@ func runFault(t *testing.T, failPct int) {
 		StartedAt:   1000,
 	}
 	for _, infID := range pendingDeadIDs {
-		votes, err := session.CollectTimeoutVotes(ctx, infID,
+		votes, _, err := session.CollectTimeoutVotes(ctx, infID,
 			types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, verifiers, nil)
 		require.NoError(t, err, "collect timeout votes for inference %d", infID)
 		session.addPendingTx(&types.DevshardTx{Tx: &types.DevshardTx_TimeoutInference{

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -2135,7 +2135,7 @@ func (s *Session) HandleTimeout(ctx context.Context, nonce uint64, sendTime time
 	verifiers := s.TimeoutVerifiers()
 	storedDiffs := s.Diffs()
 
-	votes, err := s.CollectTimeoutVotes(ctx, nonce, reason, payload, verifiers, storedDiffs)
+	votes, recovery, err := s.CollectTimeoutVotes(ctx, nonce, reason, payload, verifiers, storedDiffs)
 	if err != nil {
 		return result, fmt.Errorf("collect timeout votes: %w", err)
 	}
@@ -2148,6 +2148,20 @@ func (s *Session) HandleTimeout(ctx context.Context, nonce uint64, sendTime time
 		}
 		logging.Stage(ctx, "timeout_completed", logFields("reason", result.Reason)...)
 		return result, fmt.Errorf("inference %d timed out: %s", nonce, reason)
+	}
+
+	if reason == types.TimeoutReason_TIMEOUT_REASON_REFUSED && len(recovery) > 0 {
+		s.mu.Lock()
+		for _, tx := range recovery {
+			s.addPendingTx(tx)
+		}
+		s.mu.Unlock()
+		if err := s.SendPendingDiff(ctx); err != nil {
+			logging.Stage(ctx, "timeout_recovery_send_failed", logFields("reason", result.Reason, "error", err)...)
+			return result, fmt.Errorf("publish timeout recovery: %w", err)
+		}
+		logging.Stage(ctx, "timeout_recovery_published", logFields("reason", result.Reason)...)
+		return result, nil
 	}
 
 	logging.Stage(ctx, "timeout_insufficient_votes", logFields("reason", result.Reason)...)
@@ -2201,7 +2215,7 @@ func (s *Session) Close() error {
 
 // TimeoutVerifier contacts a host for timeout verification votes.
 type TimeoutVerifier interface {
-	VerifyTimeout(ctx context.Context, inferenceID uint64, reason types.TimeoutReason, payload *host.InferencePayload, diffs []types.Diff) (accept bool, sig []byte, voterSlot uint32, err error)
+	VerifyTimeout(ctx context.Context, inferenceID uint64, reason types.TimeoutReason, payload *host.InferencePayload, diffs []types.Diff) (accept bool, sig []byte, voterSlot uint32, mempool []*types.DevshardTx, err error)
 }
 
 func timeoutReasonLogLabel(reason types.TimeoutReason) string {
@@ -2216,7 +2230,8 @@ func timeoutReasonLogLabel(reason types.TimeoutReason) string {
 }
 
 // CollectTimeoutVotes contacts non-executor hosts to collect signed votes.
-// Returns votes for inclusion in MsgTimeoutInference.
+// Returns accept votes for MsgTimeoutInference and recovery txs copied from
+// reject responses (typically the executor's MsgConfirmStart).
 // Deduplicates verifiers by validator address to avoid duplicate votes
 // when the same validator occupies multiple slots.
 // Diffs are forwarded to verifiers so they can catch up to the inference nonce.
@@ -2227,7 +2242,7 @@ func (s *Session) CollectTimeoutVotes(
 	payload *host.InferencePayload,
 	verifiers map[int]TimeoutVerifier, // hostIdx -> verifier
 	diffs []types.Diff,
-) ([]*types.TimeoutVote, error) {
+) ([]*types.TimeoutVote, []*types.DevshardTx, error) {
 	// Cancel all in-flight verifier RPCs (and unblock any goroutines still
 	// waiting in the per-verifier queue) once we return — typically because
 	// the vote-weight threshold was met early. Without this, leftover
@@ -2266,6 +2281,7 @@ func (s *Session) CollectTimeoutVotes(
 		err          error
 		verifierIdx  int
 		verifierAddr string
+		mempool      []*types.DevshardTx
 	}
 
 	logFields := func(hostAddr string, extra ...any) []any {
@@ -2324,13 +2340,13 @@ func (s *Session) CollectTimeoutVotes(
 				return
 			}
 
-			accept, sig, voterSlot, err := av.verifier.VerifyTimeout(ctx, inferenceID, reason, payload, diffs)
+			accept, sig, voterSlot, mempool, err := av.verifier.VerifyTimeout(ctx, inferenceID, reason, payload, diffs)
 			if err != nil {
 				results <- voteResult{err: err, verifierIdx: av.idx, verifierAddr: av.verifierAddr}
 				return
 			}
 			if !accept {
-				results <- voteResult{verifierIdx: av.idx, verifierAddr: av.verifierAddr} // nil vote, no error
+				results <- voteResult{verifierIdx: av.idx, verifierAddr: av.verifierAddr, mempool: mempool} // nil vote, no error
 				return
 			}
 			results <- voteResult{vote: &types.TimeoutVote{
@@ -2346,6 +2362,8 @@ func (s *Session) CollectTimeoutVotes(
 	}
 
 	var votes []*types.TimeoutVote
+	var recovery []*types.DevshardTx
+	seenRecovery := make(map[string]struct{})
 	expected := len(deduped)
 
 	voteThreshold := s.sm.VoteThreshold()
@@ -2386,6 +2404,16 @@ func (s *Session) CollectTimeoutVotes(
 			)
 		} else {
 			rejects++
+			for _, tx := range res.mempool {
+				key := devshardTxKey(tx)
+				if key != "" {
+					if _, dup := seenRecovery[key]; dup {
+						continue
+					}
+					seenRecovery[key] = struct{}{}
+				}
+				recovery = append(recovery, tx)
+			}
 			logging.Stage(ctx, "timeout_vote_result",
 				logFields(
 					res.verifierAddr,
@@ -2417,7 +2445,7 @@ func (s *Session) CollectTimeoutVotes(
 		"reject", rejects, "errors", errors,
 		"threshold", voteThreshold, "verifiers", expected)
 
-	return votes, nil
+	return votes, recovery, nil
 }
 
 // HasSufficientTimeoutVotes returns true if the accept votes exceed the vote threshold.

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -2132,6 +2132,20 @@ func (s *Session) HandleTimeout(ctx context.Context, nonce uint64, sendTime time
 
 	logging.Stage(ctx, "timeout_started", logFields("reason", result.Reason)...)
 
+	if reason == types.TimeoutReason_TIMEOUT_REASON_EXECUTION {
+		s.mu.Lock()
+		hasPendingFinish := HasMsgFinish(s.pendingTxs, nonce)
+		s.mu.Unlock()
+		if hasPendingFinish {
+			if err := s.SendPendingDiff(ctx); err != nil {
+				logging.Stage(ctx, "timeout_recovery_send_failed", logFields("reason", result.Reason, "error", err)...)
+				return result, fmt.Errorf("publish pending finish before execution timeout: %w", err)
+			}
+			logging.Stage(ctx, "timeout_recovery_published", logFields("reason", result.Reason)...)
+			return result, nil
+		}
+	}
+
 	verifiers := s.TimeoutVerifiers()
 	storedDiffs := s.Diffs()
 

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -2150,9 +2150,13 @@ func (s *Session) HandleTimeout(ctx context.Context, nonce uint64, sendTime time
 		return result, fmt.Errorf("inference %d timed out: %s", nonce, reason)
 	}
 
+	recovery = host.RecoveryTxsFor(recovery, nonce)
 	if reason == types.TimeoutReason_TIMEOUT_REASON_REFUSED && len(recovery) > 0 {
 		s.mu.Lock()
 		for _, tx := range recovery {
+			if tx == nil {
+				continue
+			}
 			s.addPendingTx(tx)
 		}
 		s.mu.Unlock()
@@ -2404,14 +2408,15 @@ func (s *Session) CollectTimeoutVotes(
 			)
 		} else {
 			rejects++
-			for _, tx := range res.mempool {
+			for _, tx := range host.RecoveryTxsFor(res.mempool, inferenceID) {
 				key := devshardTxKey(tx)
-				if key != "" {
-					if _, dup := seenRecovery[key]; dup {
-						continue
-					}
-					seenRecovery[key] = struct{}{}
+				if key == "" {
+					continue
 				}
+				if _, dup := seenRecovery[key]; dup {
+					continue
+				}
+				seenRecovery[key] = struct{}{}
 				recovery = append(recovery, tx)
 			}
 			logging.Stage(ctx, "timeout_vote_result",

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -1253,9 +1253,17 @@ func TestCollectTimeoutVotes_CollectsRejectMempool(t *testing.T) {
 		ConfirmedAt: 1000,
 	}}}
 
+	other := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 999,
+		ExecutorSig: []byte("other"),
+		ConfirmedAt: 1,
+	}}}
+	empty := &types.DevshardTx{}
+	mixed := []*types.DevshardTx{empty, other, confirm}
+
 	verifiers := map[int]TimeoutVerifier{
-		0: &mockTimeoutVerifier{accept: false, mempool: []*types.DevshardTx{confirm}},
-		2: &mockTimeoutVerifier{accept: false, mempool: []*types.DevshardTx{confirm}},
+		0: &mockTimeoutVerifier{accept: false, mempool: mixed},
+		2: &mockTimeoutVerifier{accept: false, mempool: mixed},
 	}
 
 	votes, recovery, err := session.CollectTimeoutVotes(context.Background(), 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
@@ -1277,6 +1285,8 @@ func TestCollectTimeoutVotes_CollectsRejectMempool(t *testing.T) {
 	}
 	require.NotNil(t, got, "reject votes must surface recovery ConfirmStart")
 	require.Equal(t, []byte("executor-receipt"), got.ExecutorSig)
+	require.Len(t, recovery, 1, "recovery must drop empty txs and ConfirmStart for other inferences")
+	require.Equal(t, uint64(1), recovery[0].GetConfirmStart().InferenceId)
 }
 
 func TestHandleTimeout_RefusedReject_PublishesConfirmStart(t *testing.T) {
@@ -1328,4 +1338,40 @@ func TestHandleTimeout_RefusedReject_PublishesConfirmStart(t *testing.T) {
 	peerRec, ok := peerHost.SnapshotState().Inferences[prepared.diff.Nonce]
 	require.True(t, ok)
 	require.Equal(t, types.StatusStarted, peerRec.Status, "peer SM must apply ConfirmStart from the recovery diff")
+}
+
+func TestHandleTimeout_RefusedReject_UnrelatedMempool(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+
+	payload := &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}
+
+	unrelated := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 999,
+		ExecutorSig: []byte("other"),
+		ConfirmedAt: 1,
+	}}}
+	for i, c := range session.clients {
+		session.clients[i] = &timeoutRecoveryClient{HostClient: c, mempool: []*types.DevshardTx{unrelated}}
+	}
+
+	_, err = session.HandleTimeout(ctx, prepared.diff.Nonce, time.Unix(0, 0), payload)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient votes")
+
+	rec, ok := session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce]
+	require.True(t, ok)
+	require.Equal(t, types.StatusPending, rec.Status, "unrelated recovery txs must not be treated as success")
 }

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -434,7 +434,7 @@ func TestCollectTimeoutVotes_WeightEarlyExit(t *testing.T) {
 		verifiers[i] = &mockTimeoutVerifier{accept: true, signer: slotSigner, group: group, slotIdx: i}
 	}
 
-	votes, err := session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+	votes, _, err := session.CollectTimeoutVotes(ctx, 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
 		Prompt:      testutil.TestPrompt,
 		Model:       "llama",
 		InputLength: 100,
@@ -459,11 +459,12 @@ type mockTimeoutVerifier struct {
 	group    []types.SlotAssignment
 	slotIdx  int
 	escrowID string // defaults to "escrow-1" when empty
+	mempool  []*types.DevshardTx
 }
 
-func (m *mockTimeoutVerifier) VerifyTimeout(_ context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, error) {
+func (m *mockTimeoutVerifier) VerifyTimeout(_ context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, []*types.DevshardTx, error) {
 	if !m.accept {
-		return false, nil, 0, nil
+		return false, nil, 0, m.mempool, nil
 	}
 	eid := m.escrowID
 	if eid == "" {
@@ -478,13 +479,13 @@ func (m *mockTimeoutVerifier) VerifyTimeout(_ context.Context, inferenceID uint6
 	}
 	data, err := proto.Marshal(content)
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, nil, err
 	}
 	sig, err := m.signer.Sign(data)
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, nil, err
 	}
-	return true, sig, voterSlot, nil
+	return true, sig, voterSlot, nil, nil
 }
 
 // concurrencyMockVerifier is a TimeoutVerifier that records concurrency
@@ -504,7 +505,7 @@ type concurrencyMockVerifier struct {
 	release       <-chan struct{}       // VerifyTimeout returns when this is closed
 }
 
-func (m *concurrencyMockVerifier) VerifyTimeout(ctx context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, error) {
+func (m *concurrencyMockVerifier) VerifyTimeout(ctx context.Context, inferenceID uint64, reason types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, []*types.DevshardTx, error) {
 	cur := m.perSlotActive[m.slotIdx].Add(1)
 	defer m.perSlotActive[m.slotIdx].Add(-1)
 	if m.totalEntered != nil {
@@ -529,7 +530,7 @@ func (m *concurrencyMockVerifier) VerifyTimeout(ctx context.Context, inferenceID
 		select {
 		case <-m.release:
 		case <-ctx.Done():
-			return false, nil, 0, ctx.Err()
+			return false, nil, 0, nil, ctx.Err()
 		}
 	}
 	voterSlot := m.group[m.slotIdx].SlotID
@@ -541,13 +542,13 @@ func (m *concurrencyMockVerifier) VerifyTimeout(ctx context.Context, inferenceID
 	}
 	data, err := proto.Marshal(content)
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, nil, err
 	}
 	sig, err := m.signer.Sign(data)
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, nil, err
 	}
-	return true, sig, voterSlot, nil
+	return true, sig, voterSlot, nil, nil
 }
 
 // signerForSlot finds the signer whose address matches the slot's validator.
@@ -627,7 +628,7 @@ func TestCollectTimeoutVotes_SerializesPerVerifier(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		go func() {
-			votes, err := session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, buildVerifiers(), nil)
+			votes, _, err := session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, buildVerifiers(), nil)
 			resultsCh <- collectResult{votes: votes, err: err}
 		}()
 	}
@@ -726,7 +727,7 @@ func TestCollectTimeoutVotes_DifferentVerifiersRunInParallel(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, verifiers, nil)
+		_, _, err := session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, verifiers, nil)
 		done <- err
 	}()
 
@@ -832,7 +833,7 @@ func TestCollectTimeoutVotes_WaitTimeoutDropsStaleGoroutines(t *testing.T) {
 	// Launch the blocking first call so all verifier slots are occupied.
 	firstDone := make(chan struct{})
 	go func() {
-		_, _ = session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, firstVerifiers, nil)
+		_, _, _ = session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, firstVerifiers, nil)
 		close(firstDone)
 	}()
 
@@ -845,7 +846,7 @@ func TestCollectTimeoutVotes_WaitTimeoutDropsStaleGoroutines(t *testing.T) {
 	// Now fire the second call. Its goroutines should all time out on the
 	// queue (50ms) and return without calling VerifyTimeout.
 	start := time.Now()
-	votes, err := session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, secondVerifiers, nil)
+	votes, _, err := session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, secondVerifiers, nil)
 	elapsed := time.Since(start)
 	require.NoError(t, err)
 	require.Empty(t, votes, "stale goroutines must not produce votes")
@@ -921,7 +922,7 @@ func TestCollectTimeoutVotes_DepthGreaterThanOne(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, buildVerifiers(), nil)
+			_, _, err := session.CollectTimeoutVotes(ctx, nonce, types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload, buildVerifiers(), nil)
 			require.NoError(t, err)
 		}()
 	}
@@ -1233,4 +1234,98 @@ func TestFinalize_SignatureStatus_InsufficientQuorum(t *testing.T) {
 		require.False(t, finalEntry.HasQuorum)
 		require.Less(t, finalEntry.SigWeight, uint32(4))
 	}
+}
+
+type timeoutRecoveryClient struct {
+	HostClient
+	mempool []*types.DevshardTx
+}
+
+func (c *timeoutRecoveryClient) VerifyTimeout(_ context.Context, _ uint64, _ types.TimeoutReason, _ *host.InferencePayload, _ []types.Diff) (bool, []byte, uint32, []*types.DevshardTx, error) {
+	return false, nil, 0, c.mempool, nil
+}
+
+func TestCollectTimeoutVotes_CollectsRejectMempool(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	confirm := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 1,
+		ExecutorSig: []byte("executor-receipt"),
+		ConfirmedAt: 1000,
+	}}}
+
+	verifiers := map[int]TimeoutVerifier{
+		0: &mockTimeoutVerifier{accept: false, mempool: []*types.DevshardTx{confirm}},
+		2: &mockTimeoutVerifier{accept: false, mempool: []*types.DevshardTx{confirm}},
+	}
+
+	votes, recovery, err := session.CollectTimeoutVotes(context.Background(), 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+		Prompt:      testutil.TestPrompt,
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}, verifiers, nil)
+	require.NoError(t, err)
+	require.Empty(t, votes)
+
+	var got *types.MsgConfirmStart
+	for _, tx := range recovery {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == 1 {
+			got = cs
+			break
+		}
+	}
+	require.NotNil(t, got, "reject votes must surface recovery ConfirmStart")
+	require.Equal(t, []byte("executor-receipt"), got.ExecutorSig)
+}
+
+func TestHandleTimeout_RefusedReject_PublishesConfirmStart(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+
+	payload := &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}
+
+	execIdx := int(prepared.diff.Nonce % uint64(len(session.clients)))
+	execHost := session.clients[execIdx].(*InProcessClient).Host
+	receipt, _, err := execHost.ChallengeReceipt(ctx, prepared.diff.Nonce, payload, []types.Diff{prepared.diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+
+	var confirmTx *types.DevshardTx
+	for _, tx := range execHost.MempoolTxs() {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == prepared.diff.Nonce {
+			confirmTx = tx
+			break
+		}
+	}
+	require.NotNil(t, confirmTx, "executor challenge must queue MsgConfirmStart")
+
+	for i, c := range session.clients {
+		session.clients[i] = &timeoutRecoveryClient{HostClient: c, mempool: []*types.DevshardTx{confirmTx}}
+	}
+
+	_, err = session.HandleTimeout(ctx, prepared.diff.Nonce, time.Unix(0, 0), payload)
+	require.NoError(t, err, "recovery publish must not be treated as a timeout failure")
+
+	rec, ok := session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce]
+	require.True(t, ok)
+	require.Equal(t, types.StatusStarted, rec.Status)
+
+	peerIdx := int((prepared.diff.Nonce + 1) % uint64(len(session.clients)))
+	peerHost := session.clients[peerIdx].(*timeoutRecoveryClient).HostClient.(*InProcessClient).Host
+	peerRec, ok := peerHost.SnapshotState().Inferences[prepared.diff.Nonce]
+	require.True(t, ok)
+	require.Equal(t, types.StatusStarted, peerRec.Status, "peer SM must apply ConfirmStart from the recovery diff")
 }

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -1289,6 +1289,71 @@ func TestCollectTimeoutVotes_CollectsRejectMempool(t *testing.T) {
 	require.Equal(t, uint64(1), recovery[0].GetConfirmStart().InferenceId)
 }
 
+func TestCollectTimeoutVotes_DeduplicatesRejectRecoveryTxs(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	confirm := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 1,
+		ExecutorSig: []byte("executor-receipt"),
+		ConfirmedAt: 1000,
+	}}}
+	finish := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{
+		InferenceId:  1,
+		ResponseHash: []byte("done"),
+	}}}
+
+	verifiers := map[int]TimeoutVerifier{
+		0: &mockTimeoutVerifier{accept: false, mempool: []*types.DevshardTx{confirm, finish}},
+		2: &mockTimeoutVerifier{accept: false, mempool: []*types.DevshardTx{confirm, finish}},
+	}
+
+	votes, recovery, err := session.CollectTimeoutVotes(context.Background(), 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+		Prompt:      testutil.TestPrompt,
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}, verifiers, nil)
+	require.NoError(t, err)
+	require.Empty(t, votes)
+	require.Len(t, recovery, 2, "duplicate recovery txs from multiple reject votes must collapse by tx type and inference")
+	require.Equal(t, 1, countRecoveryConfirmStart(recovery, 1))
+	require.Equal(t, 1, countRecoveryFinish(recovery, 1))
+}
+
+func TestCollectTimeoutVotes_DropsMalformedOrNilRecoveryTxs(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	unrelatedConfirm := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 99,
+		ExecutorSig: []byte("other-receipt"),
+		ConfirmedAt: 1000,
+	}}}
+	unrelatedFinish := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: &types.MsgFinishInference{
+		InferenceId:  99,
+		ResponseHash: []byte("other"),
+	}}}
+	timeoutTx := &types.DevshardTx{Tx: &types.DevshardTx_TimeoutInference{TimeoutInference: &types.MsgTimeoutInference{
+		InferenceId: 1,
+		Reason:      types.TimeoutReason_TIMEOUT_REASON_REFUSED,
+	}}}
+	malformed := []*types.DevshardTx{nil, {}, unrelatedConfirm, unrelatedFinish, timeoutTx}
+
+	verifiers := map[int]TimeoutVerifier{
+		0: &mockTimeoutVerifier{accept: false, mempool: malformed},
+		2: &mockTimeoutVerifier{accept: false, mempool: malformed},
+	}
+
+	votes, recovery, err := session.CollectTimeoutVotes(context.Background(), 1, types.TimeoutReason_TIMEOUT_REASON_REFUSED, &host.InferencePayload{
+		Prompt:      testutil.TestPrompt,
+		Model:       "llama",
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}, verifiers, nil)
+	require.NoError(t, err)
+	require.Empty(t, votes)
+	require.Empty(t, recovery, "nil, empty, user-proposed, and unrelated txs must not become recovery")
+}
+
 func TestHandleTimeout_RefusedReject_PublishesConfirmStart(t *testing.T) {
 	session, _, _ := setupSession(t, 3, 100000, 10)
 	ctx := context.Background()
@@ -1340,6 +1405,63 @@ func TestHandleTimeout_RefusedReject_PublishesConfirmStart(t *testing.T) {
 	require.Equal(t, types.StatusStarted, peerRec.Status, "peer SM must apply ConfirmStart from the recovery diff")
 }
 
+func TestHandleTimeout_ExecutionTimeoutIgnoresConfirmStartRecovery(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+
+	payload := &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}
+
+	execIdx := int(prepared.diff.Nonce % uint64(len(session.clients)))
+	execHost := session.clients[execIdx].(*InProcessClient).Host
+	receipt, _, err := execHost.ChallengeReceipt(ctx, prepared.diff.Nonce, payload, []types.Diff{prepared.diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+
+	var confirmTx *types.DevshardTx
+	for _, tx := range execHost.MempoolTxs() {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == prepared.diff.Nonce {
+			confirmTx = tx
+			break
+		}
+	}
+	require.NotNil(t, confirmTx)
+
+	session.mu.Lock()
+	session.addPendingTx(confirmTx)
+	session.mu.Unlock()
+	require.NoError(t, session.SendPendingDiff(ctx), "test setup must publish ConfirmStart before execution timeout")
+
+	session.mu.Lock()
+	session.nonceStates[prepared.diff.Nonce].confirmedAt = 1
+	session.mu.Unlock()
+
+	beforeDiffs := len(session.Diffs())
+	for i, c := range session.clients {
+		session.clients[i] = &timeoutRecoveryClient{HostClient: c, mempool: []*types.DevshardTx{confirmTx}}
+	}
+
+	_, err = session.HandleTimeout(ctx, prepared.diff.Nonce, time.Unix(0, 0), payload)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient votes")
+	require.Len(t, session.Diffs(), beforeDiffs, "execution timeout must not publish ConfirmStart recovery diff")
+
+	rec, ok := session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce]
+	require.True(t, ok)
+	require.Equal(t, types.StatusStarted, rec.Status)
+}
+
 func TestHandleTimeout_RefusedReject_UnrelatedMempool(t *testing.T) {
 	session, _, _ := setupSession(t, 3, 100000, 10)
 	ctx := context.Background()
@@ -1374,4 +1496,24 @@ func TestHandleTimeout_RefusedReject_UnrelatedMempool(t *testing.T) {
 	rec, ok := session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce]
 	require.True(t, ok)
 	require.Equal(t, types.StatusPending, rec.Status, "unrelated recovery txs must not be treated as success")
+}
+
+func countRecoveryConfirmStart(txs []*types.DevshardTx, inferenceID uint64) int {
+	var count int
+	for _, tx := range txs {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			count++
+		}
+	}
+	return count
+}
+
+func countRecoveryFinish(txs []*types.DevshardTx, inferenceID uint64) int {
+	var count int
+	for _, tx := range txs {
+		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
+			count++
+		}
+	}
+	return count
 }

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -1245,6 +1245,11 @@ func (c *timeoutRecoveryClient) VerifyTimeout(_ context.Context, _ uint64, _ typ
 	return false, nil, 0, c.mempool, nil
 }
 
+type timeoutVoteClient struct {
+	HostClient
+	*mockTimeoutVerifier
+}
+
 func TestCollectTimeoutVotes_CollectsRejectMempool(t *testing.T) {
 	session, _, _ := setupSession(t, 3, 100000, 10)
 	confirm := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
@@ -1462,6 +1467,77 @@ func TestHandleTimeout_ExecutionTimeoutIgnoresConfirmStartRecovery(t *testing.T)
 	require.Equal(t, types.StatusStarted, rec.Status)
 }
 
+func TestHandleTimeout_ExecutionTimeoutPrefersPendingFinishOverTimeoutVotes(t *testing.T) {
+	prevTimeoutBuffer := TimeoutBuffer
+	TimeoutBuffer = 0
+	t.Cleanup(func() {
+		TimeoutBuffer = prevTimeoutBuffer
+	})
+
+	session, signers, _ := setupSession(t, 3, 100000, 10)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+
+	payload := &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}
+
+	execIdx := int(prepared.diff.Nonce % uint64(len(session.clients)))
+	execHost := session.clients[execIdx].(*InProcessClient).Host
+	receipt, _, err := execHost.ChallengeReceipt(ctx, prepared.diff.Nonce, payload, []types.Diff{prepared.diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+	confirmTx := findRecoveryConfirmStart(execHost.MempoolTxs(), prepared.diff.Nonce)
+	require.NotNil(t, confirmTx)
+
+	require.NoError(t, session.ProcessResponse(execIdx, &host.HostResponse{
+		Receipt:     receipt,
+		ConfirmedAt: confirmTx.GetConfirmStart().ConfirmedAt,
+	}, prepared.diff.Nonce))
+	require.NoError(t, session.SendPendingDiff(ctx))
+	require.Equal(t, types.StatusStarted, session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce].Status)
+
+	require.Eventually(t, func() bool {
+		return findRecoveryFinish(execHost.MempoolTxs(), prepared.diff.Nonce) != nil
+	}, 5*time.Second, 20*time.Millisecond)
+	finishTx := findRecoveryFinish(execHost.MempoolTxs(), prepared.diff.Nonce)
+	require.NotNil(t, finishTx)
+
+	session.mu.Lock()
+	session.addPendingTx(finishTx)
+	session.mu.Unlock()
+	require.NotNil(t, findRecoveryFinish(session.PendingTxs(), prepared.diff.Nonce))
+	session.mu.Lock()
+	session.nonceStates[prepared.diff.Nonce].confirmedAt = 1
+	session.mu.Unlock()
+
+	for i, c := range session.clients {
+		session.clients[i] = &timeoutVoteClient{
+			HostClient: c,
+			mockTimeoutVerifier: &mockTimeoutVerifier{
+				accept:  true,
+				signer:  signers[i],
+				group:   session.group,
+				slotIdx: i,
+			},
+		}
+	}
+
+	result, err := session.HandleTimeout(ctx, prepared.diff.Nonce, time.Unix(0, 0), nil)
+	require.NoError(t, err, "pending FinishInference should be published instead of timeout votes")
+	require.Equal(t, "execution", result.Reason)
+	require.Equal(t, types.StatusFinished, session.StateMachine().SnapshotState().Inferences[prepared.diff.Nonce].Status)
+}
+
 func TestHandleTimeout_RefusedReject_UnrelatedMempool(t *testing.T) {
 	session, _, _ := setupSession(t, 3, 100000, 10)
 	ctx := context.Background()
@@ -1516,4 +1592,22 @@ func countRecoveryFinish(txs []*types.DevshardTx, inferenceID uint64) int {
 		}
 	}
 	return count
+}
+
+func findRecoveryConfirmStart(txs []*types.DevshardTx, inferenceID uint64) *types.DevshardTx {
+	for _, tx := range txs {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
+			return tx
+		}
+	}
+	return nil
+}
+
+func findRecoveryFinish(txs []*types.DevshardTx, inferenceID uint64) *types.DevshardTx {
+	for _, tx := range txs {
+		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
+			return tx
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Originally by @redstartechno
https://github.com/gonka-ai/gonka/pull/1460

Extended by

1. Add an execution deadline. `context.WithoutCancel` leaves the detached execution with no bound, so a wedged engine pins `h.executing[id]` forever (verified) and the DAPI-fallback loop in `inference/engine.go:242` spins infinitely. Wrap in `context.WithTimeout(..., ExecutionTimeout)`.
2. Emit `MsgConfirmStart` from `challengeReceiptLocked`, as `signReceipt` does. Without it the inference stays `StatusPending`, so the `MsgFinishInference` the goroutine produces can never apply — the work is unbillable.
3. Test asserts `execCtx.Done() == nil`, which `context.Background()` also satisfies — assert `request_id` survives to actually pin `WithoutCancel`.

