### PR TITLE
Proposal: Cache-Served Token Pricing

### DIFF
--- a/common/completionapi/openai.go
+++ b/common/completionapi/openai.go
@@ -133,8 +133,20 @@ type Logprob struct {
 }
 
 type Usage struct {
-	PromptTokens     uint64 `json:"prompt_tokens"`
-	CompletionTokens uint64 `json:"completion_tokens"`
+	PromptTokens        uint64               `json:"prompt_tokens"`
+	CompletionTokens    uint64               `json:"completion_tokens"`
+	TotalTokens         uint64               `json:"total_tokens,omitempty"`
+	PromptTokensDetails *PromptTokensDetails `json:"prompt_tokens_details,omitempty"`
+}
+
+// PromptTokensDetails carries provider-reported prompt-cache metadata. When a
+// provider serves a prompt prefix from cache, the cached token count is the
+// authoritative number for downstream cached-input billing and caching
+// telemetry. The field is preserved losslessly so that gateway round-trips
+// through the typed Response struct never drop it.
+type PromptTokensDetails struct {
+	CachedTokens   uint64 `json:"cached_tokens,omitempty"`
+	UncachedTokens uint64 `json:"uncached_tokens,omitempty"`
 }
 
 func (u *Usage) IsEmpty() bool {

--- a/common/completionapi/responseprocessor_test.go
+++ b/common/completionapi/responseprocessor_test.go
@@ -65,6 +65,7 @@ func TestCompletionTokenCountForStreamedResponse(t *testing.T) {
 	expectedUsage := &Usage{
 		PromptTokens:     31,
 		CompletionTokens: 10,
+		TotalTokens:      41,
 	}
 	require.NotNil(t, usage, "expected usage to be not nil")
 	require.Equal(t, *expectedUsage, *usage, "expected usage to be %v, got %v", *expectedUsage, *usage)
@@ -171,6 +172,7 @@ func TestCompletionTokenCountForWholeResponse(t *testing.T) {
 	expectedUsage := &Usage{
 		PromptTokens:     31,
 		CompletionTokens: 10,
+		TotalTokens:      41,
 	}
 	require.NotNil(t, usage, "expected usage to be not nil")
 	require.Equal(t, *expectedUsage, *usage, "expected usage to be %v, got %v", *expectedUsage, *usage)

--- a/common/completionapi/usage_test.go
+++ b/common/completionapi/usage_test.go
@@ -1,0 +1,111 @@
+package completionapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const cachedUsageJSON = `{
+  "id": "cmpl-cached-usage-001",
+  "object": "chat.completion",
+  "created": 1722197602,
+  "model": "Qwen/Qwen2.5-7B-Instruct",
+  "choices": [
+    {
+      "index": 0,
+      "message": { "role": "assistant", "content": "ok" },
+      "logprobs": null,
+      "finish_reason": "stop",
+      "stop_reason": null
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 48025,
+    "completion_tokens": 16,
+    "total_tokens": 48041,
+    "prompt_tokens_details": {
+      "cached_tokens": 48003,
+      "uncached_tokens": 4024
+    }
+  }
+}`
+
+func TestUsage_ParsesProviderCacheMetadata(t *testing.T) {
+	resp, err := NewCompletionResponseFromBytes([]byte(cachedUsageJSON))
+	require.NoError(t, err)
+
+	usage, err := resp.GetUsage()
+	require.NoError(t, err)
+	require.Equal(t, uint64(48025), usage.PromptTokens)
+	require.Equal(t, uint64(16), usage.CompletionTokens)
+	require.Equal(t, uint64(48041), usage.TotalTokens)
+	require.NotNil(t, usage.PromptTokensDetails)
+	require.Equal(t, uint64(48003), usage.PromptTokensDetails.CachedTokens)
+	require.Equal(t, uint64(4024), usage.PromptTokensDetails.UncachedTokens)
+}
+
+func TestUsage_RoundTripPreservesCacheMetadata(t *testing.T) {
+	resp, err := NewCompletionResponseFromBytes([]byte(cachedUsageJSON))
+	require.NoError(t, err)
+
+	usage, err := resp.GetUsage()
+	require.NoError(t, err)
+
+	reMarshaled, err := json.Marshal(usage)
+	require.NoError(t, err)
+
+	var reparsed Usage
+	require.NoError(t, json.Unmarshal(reMarshaled, &reparsed))
+	require.NotNil(t, reparsed.PromptTokensDetails)
+	require.Equal(t, uint64(48003), reparsed.PromptTokensDetails.CachedTokens)
+	require.Equal(t, uint64(48041), reparsed.TotalTokens)
+}
+
+func TestUsage_NullPromptTokensDetailsIsNotAnError(t *testing.T) {
+	nullDetails := `{
+  "id": "cmpl-null-details",
+  "object": "chat.completion",
+  "created": 1722197602,
+  "model": "Qwen/Qwen2.5-7B-Instruct",
+  "choices": [
+    {
+      "index": 0,
+      "message": { "role": "assistant", "content": "ok" },
+      "logprobs": null,
+      "finish_reason": "stop",
+      "stop_reason": null
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 100,
+    "completion_tokens": 10,
+    "total_tokens": 110,
+    "prompt_tokens_details": null
+  }
+}`
+	resp, err := NewCompletionResponseFromBytes([]byte(nullDetails))
+	require.NoError(t, err)
+
+	usage, err := resp.GetUsage()
+	require.NoError(t, err)
+	require.Nil(t, usage.PromptTokensDetails)
+	require.Equal(t, uint64(100), usage.PromptTokens)
+	require.False(t, usage.IsEmpty())
+}
+
+func TestUsage_StreamedResponseCarriesCacheMetadata(t *testing.T) {
+	lines := []string{
+		`data: {"id":"cmpl-stream","object":"chat.completion.chunk","created":1722197602,"model":"Qwen/Qwen2.5-7B-Instruct","choices":[{"index":0,"delta":{"content":"ok"},"logprobs":null,"finish_reason":null}]}`,
+		`data: {"id":"cmpl-stream","object":"chat.completion.chunk","created":1722197602,"model":"Qwen/Qwen2.5-7B-Instruct","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":48025,"completion_tokens":16,"total_tokens":48041,"prompt_tokens_details":{"cached_tokens":48003,"uncached_tokens":4024}}}`,
+		`data: [DONE]`,
+	}
+	resp, err := NewCompletionResponseFromLines(lines)
+	require.NoError(t, err)
+
+	usage, err := resp.GetUsage()
+	require.NoError(t, err)
+	require.NotNil(t, usage.PromptTokensDetails)
+	require.Equal(t, uint64(48003), usage.PromptTokensDetails.CachedTokens)
+}

--- a/mlnode/packages/api/src/api/inference/vllm/runner.py
+++ b/mlnode/packages/api/src/api/inference/vllm/runner.py
@@ -170,6 +170,13 @@ class VLLMRunner(IVLLMRunner):
         # summary and disable it deliberately.
         if "--enable-prefix-caching" not in self.additional_args:
             self.additional_args.append("--enable-prefix-caching")
+        # --enable-prompt-tokens-details makes vLLM emit
+        # usage.prompt_tokens_details.cached_tokens on cache hits — the
+        # telemetry this PR's completionapi contract preserves end-to-end.
+        # Required alongside prefix caching, otherwise cache reuse stays
+        # invisible to gateways and clients.
+        if "--enable-prompt-tokens-details" not in self.additional_args:
+            self.additional_args.append("--enable-prompt-tokens-details")
         self.processes: List[subprocess.Popen] = []
         self._hb = {}
         self._hb_lock = threading.Lock()
@@ -184,6 +191,8 @@ class VLLMRunner(IVLLMRunner):
             "model": self.model,
             "dtype": self.dtype,
             "prefix_caching": "--enable-prefix-caching" in self.additional_args,
+            "prompt_tokens_details": "--enable-prompt-tokens-details"
+            in self.additional_args,
             "max_num_seqs": self._get_arg_value("--max-num-seqs", default=0),
             "max_model_len": self._get_arg_value("--max-model-len", default=0),
             "tensor_parallel_size": self._get_arg_value("--tensor-parallel-size", default=0),

--- a/mlnode/packages/api/src/api/inference/vllm/runner.py
+++ b/mlnode/packages/api/src/api/inference/vllm/runner.py
@@ -164,6 +164,12 @@ class VLLMRunner(IVLLMRunner):
             self.additional_args.extend(
                 ["--worker-extension-cls", self.WORKER_EXTENSION_CLASS]
             )
+        # Prompt/prefix caching is the basis for KV-cache reuse across
+        # requests. Make it explicit instead of relying on the vLLM default
+        # so hosts and operators can see the effective setting in the config
+        # summary and disable it deliberately.
+        if "--enable-prefix-caching" not in self.additional_args:
+            self.additional_args.append("--enable-prefix-caching")
         self.processes: List[subprocess.Popen] = []
         self._hb = {}
         self._hb_lock = threading.Lock()
@@ -177,6 +183,7 @@ class VLLMRunner(IVLLMRunner):
         return {
             "model": self.model,
             "dtype": self.dtype,
+            "prefix_caching": "--enable-prefix-caching" in self.additional_args,
             "max_num_seqs": self._get_arg_value("--max-num-seqs", default=0),
             "max_model_len": self._get_arg_value("--max-model-len", default=0),
             "tensor_parallel_size": self._get_arg_value("--tensor-parallel-size", default=0),

--- a/mlnode/packages/api/tests/unit/test_runner_prefix_caching.py
+++ b/mlnode/packages/api/tests/unit/test_runner_prefix_caching.py
@@ -31,3 +31,22 @@ def test_prefix_caching_disabled_explicitly():
 def test_config_summary_reports_prefix_caching():
     runner = VLLMRunner(model="test-model", dtype="auto")
     assert runner.get_config_summary()["prefix_caching"] is True
+
+
+def test_prompt_tokens_details_enabled_by_default():
+    runner = VLLMRunner(model="test-model", dtype="auto")
+    assert "--enable-prompt-tokens-details" in runner.additional_args
+
+
+def test_prompt_tokens_details_not_duplicated_when_already_passed():
+    runner = VLLMRunner(
+        model="test-model",
+        dtype="auto",
+        additional_args=["--enable-prompt-tokens-details"],
+    )
+    assert runner.additional_args.count("--enable-prompt-tokens-details") == 1
+
+
+def test_config_summary_reports_prompt_tokens_details():
+    runner = VLLMRunner(model="test-model", dtype="auto")
+    assert runner.get_config_summary()["prompt_tokens_details"] is True

--- a/mlnode/packages/api/tests/unit/test_runner_prefix_caching.py
+++ b/mlnode/packages/api/tests/unit/test_runner_prefix_caching.py
@@ -1,0 +1,33 @@
+"""Unit tests for vLLM prefix-caching launch defaults."""
+
+from api.inference.vllm.runner import VLLMRunner
+
+
+def test_prefix_caching_enabled_by_default():
+    runner = VLLMRunner(model="test-model", dtype="auto")
+    assert "--enable-prefix-caching" in runner.additional_args
+
+
+def test_prefix_caching_not_duplicated_when_already_passed():
+    runner = VLLMRunner(
+        model="test-model",
+        dtype="auto",
+        additional_args=["--enable-prefix-caching"],
+    )
+    assert runner.additional_args.count("--enable-prefix-caching") == 1
+
+
+def test_prefix_caching_disabled_explicitly():
+    runner = VLLMRunner(
+        model="test-model",
+        dtype="auto",
+        additional_args=[],
+    )
+    # Flag can be removed deliberately by operators; summary must reflect it.
+    runner.additional_args.remove("--enable-prefix-caching")
+    assert runner.get_config_summary()["prefix_caching"] is False
+
+
+def test_config_summary_reports_prefix_caching():
+    runner = VLLMRunner(model="test-model", dtype="auto")
+    assert runner.get_config_summary()["prefix_caching"] is True

--- a/proposals/cache-served-token-pricing/proposal.md
+++ b/proposals/cache-served-token-pricing/proposal.md
@@ -1,0 +1,163 @@
+# Proposal: Cache-Served Token Pricing
+
+**Author:** Aung Myat Moe — operator of the Fusion gateway (`api.fusioncode.app`), a broker serving `deepseek-ai/DeepSeek-V4-Flash-0731`, `MiniMaxAI/MiniMax-M2.7`, and `moonshotai/Kimi-K2.6` through the Gonka network.
+
+**Status:** Proposal — open for discussion and feedback.
+**Category:** Tokenomics / Inference pricing.
+
+## Summary
+
+The network already performs real per-host KV prefix caching, but GNK is billed
+flat per token — cached tokens cost the same as fresh ones. This proposal makes
+**cache-served tokens bill at a reduced rate**, so the network's actual hardware
+savings flow to brokers and their clients, and the network wins more
+cache-heavy workloads (agents, long stable system prompts) that currently go to
+centralized providers with native cache discounts (e.g. DeepSeek's ~90% cached-
+input price).
+
+## Motivation
+
+Live measurement on 2026-08-24 against `api.openbroker.gonka.gg`
+(`deepseek-ai/DeepSeek-V4-Flash-0731`, 52k-token prompt):
+
+| Request | Latency | `prompt_tokens_details` |
+|---|---|---|
+| Cold prefix | 12–31 s | `null` |
+| Changed suffix (same host) | ~5 s | `null` |
+| Exact replay (same host) | 23–41 ms | `null` |
+
+The latency collapse proves vLLM is reusing the GPU KV cache per host. Yet GNK
+billing is flat: **15 nGNK per token for every token**, cached or not (verified
+from the OpenBroker usage API and ledger). Downstream brokers therefore cannot
+offer cache-based pricing, so the network is structurally uncompetitive for
+cache-heavy traffic — the exact traffic DeepSeek's own API discounts ~90%.
+
+Fixing this has three prerequisites, one of which is already in flight:
+
+1. **Telemetry** — make vLLM report cache hits
+   (`--enable-prefix-caching` + `--enable-prompt-tokens-details`, so
+   `usage.prompt_tokens_details.cached_tokens` is populated). In review as
+   PR #1633.
+2. **Accounting** — the Finish payload must carry the cached-token count so it
+   can be validated and billed (extends the token counts self-reported on
+   Finish, see #1474).
+3. **Pricing** — this proposal: bill the cached portion of each request at a
+   discounted per-token rate.
+
+## How the discount is earned (why hosts still profit)
+
+Host cost is dominated by **prefill** — attention over every token. A KV-cache
+hit means the prefill was already computed: the host spends ~0 compute on
+cached tokens and only generates the new completion. Cached tokens are nearly
+pure revenue. A discounted cached rate still pays the host *more than idle
+GPU time* and increases utilization, so hosts are economically better off —
+the discount is a utilization incentive, not a loss.
+
+## Proposed pricing model
+
+Per-request GNK cost becomes:
+
+```
+cost = input_rate × fresh_input_tokens
+     + cached_rate × cached_tokens
+     + output_rate × completion_tokens
+```
+
+- `cached_rate = input_rate × DISCOUNT` (proposed default `DISCOUNT = 0.10`,
+  i.e. cached tokens cost 10% of fresh — mirroring DeepSeek's cached-input
+  economics; negotiable per model).
+- Exact-response replays deduplicated at the gateway already cost zero
+  upstream and are unaffected.
+- Only provider-reported `prompt_tokens_details.cached_tokens` counts are
+  credited — never locally estimated values (the estimate is a stopgap for
+  client visibility only, not a billing input).
+
+With today's flat rate of 15 nGNK/token and `DISCOUNT = 0.10`:
+
+| Component | nGNK/token (example) |
+|---|---|
+| Fresh input | 15.0 |
+| Cached input | 1.5 |
+| Output | 15.0 (unchanged) |
+
+A request with 50k cached + 2k fresh input + 16 output tokens drops from
+`780,240 nGNK` to `82,740 nGNK` — an ~89% reduction, matching the real
+hardware savings.
+
+## Implementation options
+
+### Option A — Gateway-level (fast, no chain change)
+
+The public gateway (OpenBroker / brokers) already receives
+`prompt_tokens_details.cached_tokens` once PR #1633 lands. The gateway applies
+the discount when computing the GNK deduction for each request. Pro:
+
+- Ships in days, no chain upgrade, no validation change.
+- Host payout and broker billing both reflect the discount immediately.
+
+Con:
+
+- Discount policy lives in gateway code, not on-chain — less auditable and
+  could diverge between gateways/brokers.
+
+### Option B — On-chain (structural, auditable)
+
+Extend the inference Finish/validation payloads (input/output counts today,
+see #1474 and `common/validation/validation.go`) with a `cached_tokens` count.
+`inference-chain` billing (see `x/inference/epochgroup/unit_of_compute_price.go`)
+then computes the discounted cost. Pro:
+
+- Single source of truth, validated, all brokers and hosts see the same rule.
+- Enables per-model discount factors via existing epoch/params mechanisms.
+
+Con:
+
+- Requires chain upgrade + validation changes (validation must bound
+  `cached_tokens ≤ prompt_tokens` and detect inflated cache claims, in the
+  spirit of the existing `TokenCountInflated` checks).
+
+**Recommended path:** start with Option A to capture the economics now, then
+land Option B as the durable protocol rule.
+
+## Open questions
+
+1. **Trust** — cached counts are host-reported (like token counts today).
+   Should validation re-check cache claims (e.g. reject `cached_tokens` when
+   the validator's own re-execution saw no shared prefix)? Same risk class as
+   #1474.
+2. **Discount factor** — fixed 0.10, or per-model
+   (models with cheaper prefill → smaller discount)? Should it be governed via
+   epoch params?
+3. **Minimum cacheable prefix** — DeepSeek counts cache only above a minimum
+   cached length; should the network too, to avoid tiny-prefix gaming?
+4. **Host payout floor** — hosts still pay electricity/bandwidth per request;
+   is there a per-request minimum so cached-only requests never cost hosts
+   money?
+5. **Interplay with dynamic pricing** — how does this interact with the
+   tokenomics-v2 dynamic-pricing proposal (per-model utilization-based price)?
+
+## Impact
+
+- **Who is affected:** all brokers and developers using the OpenBroker/Gonka
+  API; hosts (payout per token); downstream billing systems.
+- **Network-wide or limited:** network-wide — pricing applies to every
+  request.
+- **Likelihood:** common — cache hits already occur today (verified
+  per-host); the discount simply prices them correctly.
+- **Severity (Impact × Likelihood):** Medium-High — affects revenue for hosts
+  and cost for brokers, but is a pure pricing change with no service risk.
+- **Affected components:** inference-chain tokenomics
+  (`x/inference`), gateway/broker billing, validation
+  (`common/validation`), mlnode vLLM flags (PR #1633).
+
+## Who this helps
+
+- **Brokers** — pass real cache discounts to clients, compete with
+  centralized providers on cache-heavy workloads.
+- **Clients** — agents and tools with stable system prompts pay closer to
+  what the hardware actually costs.
+- **Hosts** — higher utilization from the workloads the discount attracts,
+  earning more total GNK despite the per-token discount.
+- **The network** — a pricing moat: centralized DeepSeek does this; a
+  decentralized network that prices cache honestly wins the same workloads
+  while keeping its other per-token advantages.


### PR DESCRIPTION
## Summary

The network already performs real per-host KV prefix caching (verified: 12–31s cold → ~5s changed-suffix → 23–41ms exact replay on the same shard, 52k-token prompt), yet GNK is billed flat per token — cached tokens cost the same as fresh. This proposal bills cache-served tokens at a reduced rate (proposed 10% of fresh input), so real hardware savings flow to brokers/clients and the network wins cache-heavy workloads that currently go to centralized providers with native cache discounts.

## Key points

- **Motivation:** live latency evidence + flat 15 nGNK/token billing (verified via the OpenBroker usage API); network is structurally uncompetitive for cache-heavy agents/tools.
- **Why hosts still profit:** cost is prefill-dominated; cached tokens cost ~0 compute — a discounted rate still beats idle GPU time and raises utilization.
- **Pricing model:** `cost = fresh_input×rate + cached_tokens×(rate×0.10) + output×rate`; example request drops ~89%, matching real hardware savings.
- **Two implementation paths:** Option A (gateway-level, ships in days, no chain change) → Option B (on-chain via Finish payload + validation, durable). Recommended: A now, B as the protocol rule.
- **Prerequisite telemetry already in flight:** PR #1633 (`--enable-prefix-caching` + `--enable-prompt-tokens-details`).
- **Open questions:** trust/validation of host-reported cache counts (same class as #1474), discount factor governance, minimum cacheable prefix, host payout floor, interplay with tokenomics-v2 dynamic pricing.

## Impact

Network-wide pricing change; affects hosts (payout), brokers, and clients. Pure pricing change — no service risk. Mirrors DeepSeek's cached-input economics to make the network price cache honestly.