### PR TITLE
fix(benchmarks): rate PoC nonces against the interval that produced them

### DIFF
--- a/mlnode/packages/benchmarks/scripts/poc_validation/README.md
+++ b/mlnode/packages/benchmarks/scripts/poc_validation/README.md
@@ -128,7 +128,11 @@ Each artifact JSON includes:
 - `vectors` — list of decoded float arrays (or null on failure)
 - `artifacts` — raw server response with base64 vectors
 - `encoding` — `{dtype, k_dim, endian}`
-- `timing` — `{started_at, finished_at, elapsed_seconds, nonces_per_min}`
+- `timing` — `{started_at, finished_at, elapsed_seconds, measured_nonce_count, post_boundary_nonces, nonces_per_min}`.
+  `nonces_per_min` rates `measured_nonce_count` — the nonces delivered inside the
+  measured interval — against `elapsed_seconds`. Nonces delivered while `pow/stop`
+  drains arrive after the interval closed and are reported separately as
+  `post_boundary_nonces`; `artifacts` still holds all of them.
 
 ## Usage
 

--- a/mlnode/packages/benchmarks/scripts/poc_validation/collect_data.py
+++ b/mlnode/packages/benchmarks/scripts/poc_validation/collect_data.py
@@ -407,7 +407,7 @@ def collect_from_server(
         time.sleep(warmup_seconds)
 
     receiver.clear()
-    measured_started_at = time.time()
+    measured_started_at = time.monotonic()
     measured_started_at_iso = datetime.now().isoformat()
 
     elapsed = 0
@@ -418,8 +418,9 @@ def collect_from_server(
         stats = receiver.stats()
         print(f"  [{elapsed:>2d}s] {stats['total_nonces']} nonces")
 
-    measured_finished_at = time.time()
+    measured_finished_at = time.monotonic()
     measured_finished_at_iso = datetime.now().isoformat()
+    measured_artifacts = receiver.collected_artifacts()
 
     stop_generation(server_url)
     time.sleep(1.0)
@@ -434,7 +435,10 @@ def collect_from_server(
 
     stats = receiver.stats()
     elapsed_seconds = max(0.0, measured_finished_at - measured_started_at)
-    nonces_per_min = (len(artifacts) / elapsed_seconds * 60.0) if elapsed_seconds > 0 else 0.0
+    # Callbacks keep arriving while pow/stop drains, after the interval above
+    # has been closed. Rate them against the interval that produced them.
+    measured_nonce_count = len(measured_artifacts)
+    nonces_per_min = (measured_nonce_count / elapsed_seconds * 60.0) if elapsed_seconds > 0 else 0.0
 
     return {
         "collection_mode": "init_generate_callback",
@@ -459,6 +463,8 @@ def collect_from_server(
             "started_at": measured_started_at_iso,
             "finished_at": measured_finished_at_iso,
             "elapsed_seconds": elapsed_seconds,
+            "measured_nonce_count": measured_nonce_count,
+            "post_boundary_nonces": len(artifacts) - measured_nonce_count,
             "nonces_per_min": nonces_per_min,
         },
     }


### PR DESCRIPTION
Root cause found and originally fixed by @vbgd0 in the experiments repo; this ports that fix to the benchmark script here.

## What changed

`collect_data.py` snapshots the callback total at the measurement boundary and rates that against the interval. Nonces delivered during the `pow/stop` drain are reported as `post_boundary_nonces` instead of counted. The interval uses `time.monotonic()`.

## Why

The order was:

1. close the measured interval;
2. call `pow/stop`;
3. wait one second;
4. read the callback total;
5. divide that later total by the earlier interval.

Nonces delivered in steps 2-3 were credited without their time.

The error is not a fixed bias. Callbacks arrive in bulk roughly every five seconds, so a 30-second window either catches a whole extra delivery or none. Measured on MLNode 3.0.16, one B300, NVFP4:

| batch | boundary nonce/min | drained nonce/min | inflation |
|---:|---:|---:|---:|
| 8 | 1872 | 1872 | 0.0 % |
| 16 | 2368 | 2784 | 17.6 % |
| 32 | 2432 | 2880 | 18.4 % |

Because it is intermittent rather than a scale factor, no fixed correction can be applied to numbers already collected.

This is why the DeepSeek V4 Flash weight scale factor came out low: the nonce/min it was derived from was inflated by roughly this amount. The recomputation puts it at 0.246.

## Scope

One measured quantity changes. `artifacts` still carries every nonce received, so vector validation is unaffected, and `collected_nonce_count` still reports the full count.

## Validation

The accounting shape was verified against a live PoC backend on B300 (batch 32: 1216 inside the interval, 1440 after the drain, 224 excluded, 2432 nonce/min). That run used the same logic in the experiment copy of this script; this port has been compiled, not rerun.

## How to verify on your own node

Run `collect_data.py` against a PoC backend and read the new `timing` fields in `poc_artifacts.json`:

- `measured_nonce_count` — nonces delivered inside the measured interval, what `nonces_per_min` now uses;
- `post_boundary_nonces` — nonces delivered during the `pow/stop` drain, previously folded into the rate.

The old figure is `(measured_nonce_count + post_boundary_nonces) / elapsed_seconds * 60`. Comparing the two on the same run shows the inflation directly, and repeating at batch 8, 16 and 32 shows that it is intermittent rather than a constant factor.
