### PR TITLE
fix(broker): expire stuck ReconcileInfo so nodes can retry

### DIFF
--- a/decentralized-api/broker/broker.go
+++ b/decentralized-api/broker/broker.go
@@ -253,6 +253,19 @@ func (s NodeState) MarshalJSON() ([]byte, error) {
 type ReconcileInfo struct {
 	Status    types.HardwareNodeStatus `json:"status"`
 	PocStatus PocStatus                `json:"poc_status"`
+	// StartedAt is when this reconcile attempt was dispatched. Zero means
+	// unknown/legacy; the watchdog treats that as already expired.
+	StartedAt time.Time `json:"started_at,omitempty"`
+}
+
+func (r *ReconcileInfo) isExpired(now time.Time) bool {
+	if r == nil {
+		return false
+	}
+	if r.StartedAt.IsZero() {
+		return true
+	}
+	return now.Sub(r.StartedAt) >= staleReconcileTimeout
 }
 
 func (s *NodeState) UpdateStatusAt(time time.Time, status types.HardwareNodeStatus) {
@@ -825,6 +838,13 @@ type pocParams struct {
 
 const reconciliationInterval = 30 * time.Second
 
+// staleReconcileTimeout is how long a ReconcileInfo may sit without a result
+// before reconcile aborts it and retries. Must be a few ticker intervals so a
+// lost UpdateNodeResultCommand cannot pin the node out of dispatch forever;
+// phase 1 only cancels on intended-status mismatch, which never fires if the
+// target never changes.
+const staleReconcileTimeout = 3 * reconciliationInterval
+
 // Timeouts for node health checks used in queryNodeStatus
 const (
 	nodeStatusRequestTimeout      = 5 * time.Second
@@ -976,23 +996,41 @@ func (b *Broker) reconcileIfSynced(triggerMsg string) {
 func (b *Broker) reconcile(epochState chainphase.EpochState) {
 	blockHeight := epochState.CurrentBlock.Height
 
-	// Phase 1: Cancel outdated tasks
-	nodesToCancel := make(map[string]func())
+	// Phase 1: abort in-flight reconcile that is outdated (intended status
+	// moved on) or stale (no result for staleReconcileTimeout). Clear even
+	// when cancelInFlightTask is nil, otherwise a lost result pins the node.
+	type reconcileAbort struct {
+		cancel func()
+		reason string
+	}
+	nodesToAbort := make(map[string]reconcileAbort)
+	now := time.Now()
 	b.mu.RLock()
 	for id, node := range b.nodes {
-		if node.State.ReconcileInfo != nil &&
-			(node.State.ReconcileInfo.Status != node.State.IntendedStatus ||
-				node.State.ReconcileInfo.PocStatus != node.State.PocIntendedStatus) {
-			if node.State.cancelInFlightTask != nil {
-				nodesToCancel[id] = node.State.cancelInFlightTask
-			}
+		info := node.State.ReconcileInfo
+		if info == nil {
+			continue
 		}
+		outdated := info.Status != node.State.IntendedStatus ||
+			info.PocStatus != node.State.PocIntendedStatus
+		expired := info.isExpired(now)
+		if !outdated && !expired {
+			continue
+		}
+		reason := "outdated"
+		if expired && !outdated {
+			reason = "stale"
+		}
+		nodesToAbort[id] = reconcileAbort{cancel: node.State.cancelInFlightTask, reason: reason}
 	}
 	b.mu.RUnlock()
 
-	for id, cancel := range nodesToCancel {
-		logging.Info("Cancelling outdated task for node", types.Nodes, "node_id", id, "blockHeight", blockHeight)
-		cancel()
+	for id, abort := range nodesToAbort {
+		logging.Info("Aborting in-flight reconcile for node", types.Nodes,
+			"node_id", id, "reason", abort.reason, "blockHeight", blockHeight)
+		if abort.cancel != nil {
+			abort.cancel()
+		}
 		b.mu.Lock()
 		if node, ok := b.nodes[id]; ok {
 			node.State.ReconcileInfo = nil
@@ -1036,6 +1074,7 @@ func (b *Broker) reconcile(epochState chainphase.EpochState) {
 		currentNode.State.ReconcileInfo = &ReconcileInfo{
 			Status:    intendedStatusCopy,
 			PocStatus: pocIntendedStatusCopy,
+			StartedAt: time.Now(),
 		}
 		currentNode.State.cancelInFlightTask = cancel
 

--- a/decentralized-api/broker/reconcile_watchdog_test.go
+++ b/decentralized-api/broker/reconcile_watchdog_test.go
@@ -1,0 +1,181 @@
+package broker
+
+import (
+	"context"
+	"decentralized-api/chainphase"
+	"decentralized-api/mlnodeclient"
+	"testing"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileInfo_isExpired(t *testing.T) {
+	now := time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC)
+
+	assert.False(t, (*ReconcileInfo)(nil).isExpired(now))
+	assert.True(t, (&ReconcileInfo{}).isExpired(now), "zero StartedAt is stale")
+	assert.False(t, (&ReconcileInfo{StartedAt: now}).isExpired(now))
+	assert.False(t, (&ReconcileInfo{StartedAt: now.Add(-staleReconcileTimeout + time.Second)}).isExpired(now))
+	assert.True(t, (&ReconcileInfo{StartedAt: now.Add(-staleReconcileTimeout)}).isExpired(now))
+	assert.True(t, (&ReconcileInfo{StartedAt: now.Add(-staleReconcileTimeout - time.Second)}).isExpired(now))
+}
+
+func syncedEpochState() chainphase.EpochState {
+	return chainphase.EpochState{
+		CurrentBlock: chainphase.BlockInfo{Height: 1, Hash: "hash-1"},
+		IsSynced:     true,
+	}
+}
+
+func newWatchdogBroker() *Broker {
+	return &Broker{
+		highPriorityCommands: make(chan Command, 20),
+		lowPriorityCommands:  make(chan Command, 20),
+		nodes:                make(map[string]*NodeWithState),
+		nodeWorkGroup:        NewNodeWorkGroup(),
+	}
+}
+
+func attachWorker(t *testing.T, b *Broker, node *NodeWithState) *NodeWorker {
+	t.Helper()
+	worker := NewNodeWorkerWithClient(node.Node.Id, node, mlnodeclient.NewMockClient(), b)
+	t.Cleanup(worker.Shutdown)
+	b.nodeWorkGroup.AddWorker(node.Node.Id, worker)
+	return worker
+}
+
+// nodeStuckStopping is away from its intended STOPPED status so phase 2
+// dispatches StopNodeCommand (no chainBridge / epoch models required).
+func nodeStuckStopping(id string) *NodeWithState {
+	node := createTestNode(id)
+	node.State.CurrentStatus = types.HardwareNodeStatus_INFERENCE
+	node.State.IntendedStatus = types.HardwareNodeStatus_STOPPED
+	node.State.PocCurrentStatus = PocStatusIdle
+	node.State.PocIntendedStatus = PocStatusIdle
+	return node
+}
+
+func stoppingReconcileInfo(startedAt time.Time) *ReconcileInfo {
+	return &ReconcileInfo{
+		Status:    types.HardwareNodeStatus_STOPPED,
+		PocStatus: PocStatusIdle,
+		StartedAt: startedAt,
+	}
+}
+
+func TestReconcile_AbortsStaleReconcileInfoAndRetries(t *testing.T) {
+	broker := newWatchdogBroker()
+	node := nodeStuckStopping("node-stale")
+	cancelled := make(chan struct{})
+	node.State.cancelInFlightTask = func() { close(cancelled) }
+	node.State.ReconcileInfo = stoppingReconcileInfo(time.Now().Add(-staleReconcileTimeout - time.Second))
+	broker.nodes[node.Node.Id] = node
+	attachWorker(t, broker, node)
+
+	broker.reconcile(syncedEpochState())
+
+	select {
+	case <-cancelled:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stale in-flight reconcile was not cancelled")
+	}
+
+	broker.mu.Lock()
+	info := node.State.ReconcileInfo
+	broker.mu.Unlock()
+	require.NotNil(t, info, "phase 2 should dispatch a new attempt after aborting the stale one")
+	assert.Equal(t, types.HardwareNodeStatus_STOPPED, info.Status)
+	assert.False(t, info.StartedAt.IsZero())
+	assert.WithinDuration(t, time.Now(), info.StartedAt, 2*time.Second)
+}
+
+func TestReconcile_LeavesFreshReconcileInfoAlone(t *testing.T) {
+	broker := newWatchdogBroker()
+	node := nodeStuckStopping("node-fresh")
+	started := time.Now().Add(-time.Second)
+	cancelCalled := false
+	node.State.cancelInFlightTask = func() { cancelCalled = true }
+	node.State.ReconcileInfo = stoppingReconcileInfo(started)
+	broker.nodes[node.Node.Id] = node
+	attachWorker(t, broker, node)
+
+	broker.reconcile(syncedEpochState())
+
+	assert.False(t, cancelCalled)
+	broker.mu.Lock()
+	info := node.State.ReconcileInfo
+	broker.mu.Unlock()
+	require.NotNil(t, info)
+	assert.Equal(t, started, info.StartedAt)
+}
+
+func TestReconcile_ZeroStartedAtIsStale(t *testing.T) {
+	broker := newWatchdogBroker()
+	node := nodeStuckStopping("node-legacy")
+	node.State.ReconcileInfo = stoppingReconcileInfo(time.Time{})
+	broker.nodes[node.Node.Id] = node
+	attachWorker(t, broker, node)
+
+	broker.reconcile(syncedEpochState())
+
+	broker.mu.Lock()
+	info := node.State.ReconcileInfo
+	broker.mu.Unlock()
+	require.NotNil(t, info)
+	assert.False(t, info.StartedAt.IsZero(), "legacy zero StartedAt must be expired so a new attempt can start")
+}
+
+func TestReconcile_StaleStillCancelsWhenCancelFuncMissing(t *testing.T) {
+	broker := newWatchdogBroker()
+	node := nodeStuckStopping("node-no-cancel")
+	node.State.ReconcileInfo = stoppingReconcileInfo(time.Now().Add(-staleReconcileTimeout - time.Second))
+	broker.nodes[node.Node.Id] = node
+	attachWorker(t, broker, node)
+
+	broker.reconcile(syncedEpochState())
+
+	broker.mu.Lock()
+	info := node.State.ReconcileInfo
+	broker.mu.Unlock()
+	require.NotNil(t, info)
+	assert.WithinDuration(t, time.Now(), info.StartedAt, 2*time.Second)
+}
+
+func TestReconcile_BlockingExecuteObservesWatchdogCancel(t *testing.T) {
+	broker := newWatchdogBroker()
+	node := nodeStuckStopping("node-block")
+	broker.nodes[node.Node.Id] = node
+	worker := attachWorker(t, broker, node)
+
+	started := make(chan struct{})
+	sawCancel := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	node.State.cancelInFlightTask = cancel
+	node.State.ReconcileInfo = stoppingReconcileInfo(time.Now().Add(-staleReconcileTimeout - time.Second))
+
+	ok := worker.Submit(ctx, &TestCommand{
+		ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+			close(started)
+			<-ctx.Done()
+			close(sawCancel)
+			return NodeResult{Succeeded: false, Error: ctx.Err().Error()}
+		},
+	})
+	require.True(t, ok)
+	select {
+	case <-started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("blocking command did not start")
+	}
+
+	broker.reconcile(syncedEpochState())
+
+	select {
+	case <-sawCancel:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("blocking Execute did not observe watchdog cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- A lost worker result left `ReconcileInfo` set while intended status was unchanged, so reconcile skipped that node for the rest of the process lifetime.
- Stamp each reconcile attempt with `StartedAt` and abort it after three reconcile intervals (90s), then dispatch again.
- Late results from the abandoned attempt are already ignored (`ReconcileInfo` nil or target mismatch).

---

## Problem

Reconcile is the broker loop that makes each ML node’s **current** status match **intended** status (INFERENCE / PoC / STOPPED). It is the only path that *starts* those transitions.

### Happy path (unchanged)

```
intended ≠ current, ReconcileInfo == nil
  → submit worker command (InferenceUp / Stop / PoC …)
  → set ReconcileInfo{Status, PocStatus} + cancelInFlightTask
  → worker Execute → QueueMessage(UpdateNodeResultCommand)
  → apply current status, clear ReconcileInfo
```

Two later ticks must not start a second attempt while the first is in flight. Phase 2 therefore **skips** any node with `ReconcileInfo != nil`.

Phase 1 only **aborts** an in-flight attempt when the target moved:

```
ReconcileInfo.Status ≠ IntendedStatus
  (or PocStatus ≠ PocIntendedStatus)
```

That is the “epoch flipped PoC → inference” case.

### Failure path this PR fixes

The worker never delivers `UpdateNodeResultCommand` (full broker queue, process crash after Execute, result applied after `ReconcileInfo` was already cleared, etc.). **Intended status does not change.**

```
tick 0: dispatch, ReconcileInfo set, no result ever queued

tick 1..∞:
  phase 1: Status == IntendedStatus → do not abort
  phase 2: ReconcileInfo != nil     → do not dispatch
```

The node stays off its intended state for the life of `decentralized-api`. Inference lock also treats `ReconcileInfo != nil` as busy, so the node cannot take work either.

If `cancelInFlightTask` is already nil, the old phase 1 did not even clear `ReconcileInfo` on an outdated target — the same pin.

---

## Fix (new data flow)

`ReconcileInfo` gains `StartedAt` (set at dispatch). After `staleReconcileTimeout` (`3 × reconciliationInterval` = 90s) the attempt is **stale**, even if the target is unchanged.

```
tick 0: dispatch
        ReconcileInfo{Status: INFERENCE, StartedAt: T0}

tick while age < 90s:
  still “in flight” → skip (same as today)

tick when now − T0 ≥ 90s:
  phase 1: expired
           cancel ctx (if any)
           nil ReconcileInfo
  phase 2: intended ≠ current and ReconcileInfo == nil
           dispatch again
           ReconcileInfo{…, StartedAt: T1}

late result from the T0 attempt:
  UpdateNodeResultCommand
    → ReconcileInfo nil, or Status ≠ OriginalTarget
    → ignore (existing safety checks)
```

Zero `StartedAt` (legacy / omitted stamp) is treated as already expired so a forgotten timestamp cannot pin the node.

Phase 1 still aborts on **outdated** target; stale is an extra reason. Abort always clears `ReconcileInfo`, including when there is no cancel func.

**Tradeoff:** a healthy command that runs longer than 90s (slow model load) is cancelled and retried, same as an intended-status change. That is shorter than the 15-minute ML HTTP client timeout. Tune `staleReconcileTimeout` if 90s is too aggressive.

---

## Tests

File: `decentralized-api/broker/reconcile_watchdog_test.go`  
CI: existing **Build and Test API Wrapper** (`go test ./...` in `decentralized-api`). No new job.

| Test | What it pins |
|---|---|
| `TestReconcileInfo_isExpired` | nil / zero / fresh / exactly 90s / older than 90s |
| `TestReconcile_AbortsStaleReconcileInfoAndRetries` | stale matching target → cancel fires **and** phase 2 stamps a new `StartedAt` |
| `TestReconcile_LeavesFreshReconcileInfoAlone` | age 1s → no cancel, `StartedAt` unchanged (no duplicate dispatch) |
| `TestReconcile_ZeroStartedAtIsStale` | missing stamp → retry as if expired |
| `TestReconcile_StaleStillCancelsWhenCancelFuncMissing` | nil `cancelInFlightTask` still clears and redispatches (old phase-1 hole) |
| `TestReconcile_BlockingExecuteObservesWatchdogCancel` | in-flight `Execute` blocked on `ctx.Done()` actually observes the watchdog cancel |

Dispatch in these tests uses intended `STOPPED` (`StopNodeCommand`) so they do not need `chainBridge` / epoch models.

---

## Test plan (reviewer)

- [ ] `go test ./broker/ -race -run 'TestReconcileInfo_isExpired\|TestReconcile_'`
- [ ] Confirm a node with `ReconcileInfo` older than 90s and unchanged intended status is aborted and gets a new attempt on the next reconcile
- [ ] Confirm a node with a fresh `ReconcileInfo` is left alone
- [ ] Confirm a late `UpdateNodeResultCommand` after abort is ignored (existing `commands.go` checks)
