### PR TITLE
Unify devshard boolean environment parsing

### DIFF
--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -18,6 +18,7 @@ import (
 	devshardpkg "devshard"
 	"devshard/gossip"
 	"devshard/host"
+	"devshard/internal/configenv"
 	"devshard/observability"
 	"devshard/signing"
 	"devshard/state"
@@ -364,7 +365,7 @@ func boolEnv(key string, fallback bool) (bool, error) {
 	if raw == "" {
 		return fallback, nil
 	}
-	value, err := strconv.ParseBool(raw)
+	value, err := configenv.ParseBool(raw)
 	if err != nil {
 		return false, fmt.Errorf("parse %s: %w", key, err)
 	}

--- a/devshard/cmd/devshard-host/main_test.go
+++ b/devshard/cmd/devshard-host/main_test.go
@@ -31,13 +31,24 @@ func TestSessionConfigFromEnv_MapsEscrowTimeouts(t *testing.T) {
 }
 
 func TestBoolEnv(t *testing.T) {
-	t.Setenv("DEVSHARD_STUB_EXECUTION_HANG", "true")
+	const key = "DEVSHARD_STUB_EXECUTION_HANG"
 
-	value, err := boolEnv("DEVSHARD_STUB_EXECUTION_HANG", false)
+	t.Setenv(key, "on")
+	value, err := boolEnv(key, false)
 	require.NoError(t, err)
 	require.True(t, value)
 
-	t.Setenv("DEVSHARD_STUB_EXECUTION_HANG", "invalid")
-	_, err = boolEnv("DEVSHARD_STUB_EXECUTION_HANG", false)
+	t.Setenv(key, "f")
+	value, err = boolEnv(key, true)
+	require.NoError(t, err)
+	require.False(t, value)
+
+	t.Setenv(key, "")
+	value, err = boolEnv(key, true)
+	require.NoError(t, err)
+	require.True(t, value, "empty value must preserve the caller fallback")
+
+	t.Setenv(key, "invalid")
+	_, err = boolEnv(key, false)
 	require.Error(t, err)
 }

--- a/devshard/cmd/devshardctl/capacity_aware.go
+++ b/devshard/cmd/devshardctl/capacity_aware.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"strings"
 	"sync/atomic"
+
+	"devshard/internal/configenv"
 )
 
 // capacityAwareLimitsState gates the new capacity-aware behavior:
@@ -13,15 +14,10 @@ var capacityAwareLimitsState atomic.Bool
 
 // ConfigureCapacityAwareLimits enables/disables capacity-aware limiter
 // behavior based on a string value (env var, admin setting, etc.).
-// Recognized truthy values: "1", "true", "on", "yes"; everything else
-// (including empty) disables it.
+// Invalid and empty values disable the behavior.
 func ConfigureCapacityAwareLimits(raw string) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "1", "true", "on", "yes":
-		capacityAwareLimitsState.Store(true)
-	default:
-		capacityAwareLimitsState.Store(false)
-	}
+	enabled, err := configenv.ParseBool(raw)
+	capacityAwareLimitsState.Store(err == nil && enabled)
 }
 
 // capacityAwareLimitsEnabled reports whether the gateway should keep

--- a/devshard/cmd/devshardctl/capacity_aware_test.go
+++ b/devshard/cmd/devshardctl/capacity_aware_test.go
@@ -13,3 +13,22 @@ func setCapacityAwareLimitsForTest(t *testing.T, on bool) {
 		capacityAwareLimitsState.Store(prev)
 	})
 }
+
+func TestConfigureCapacityAwareLimitsUsesDevshardBooleanGrammar(t *testing.T) {
+	setCapacityAwareLimitsForTest(t, false)
+
+	ConfigureCapacityAwareLimits("yes")
+	if !capacityAwareLimitsEnabled() {
+		t.Fatal("yes must enable capacity-aware limits")
+	}
+
+	ConfigureCapacityAwareLimits("f")
+	if capacityAwareLimitsEnabled() {
+		t.Fatal("f must disable capacity-aware limits")
+	}
+
+	ConfigureCapacityAwareLimits("invalid")
+	if capacityAwareLimitsEnabled() {
+		t.Fatal("invalid value must retain the disabled fallback")
+	}
+}

--- a/devshard/cmd/devshardctl/heightsync_env.go
+++ b/devshard/cmd/devshardctl/heightsync_env.go
@@ -17,6 +17,7 @@ import (
 	"devshard/chainoracle/blocks/failover"
 	"devshard/chainoracle/blocks/tipcache"
 	"devshard/heightsync"
+	"devshard/internal/configenv"
 	"devshard/transport"
 )
 
@@ -85,12 +86,8 @@ func parseDurationEnv(name string) (time.Duration, error) {
 }
 
 func heightSyncFlag() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(envHeightSync))) {
-	case "1", "true", "yes":
-		return true
-	default:
-		return false
-	}
+	enabled, err := configenv.ParseBool(os.Getenv(envHeightSync))
+	return err == nil && enabled
 }
 
 func cometRPCForHeightSync(grpcURL string) string {

--- a/devshard/cmd/devshardctl/heightsync_env_test.go
+++ b/devshard/cmd/devshardctl/heightsync_env_test.go
@@ -42,3 +42,14 @@ func TestParseUintEnv(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(10), v)
 }
+
+func TestHeightSyncFlagUsesDevshardBooleanGrammar(t *testing.T) {
+	t.Setenv(envHeightSync, "ON")
+	require.True(t, heightSyncFlag())
+
+	t.Setenv(envHeightSync, "no")
+	require.False(t, heightSyncFlag())
+
+	t.Setenv(envHeightSync, "invalid")
+	require.False(t, heightSyncFlag(), "invalid values retain the disabled fallback")
+}

--- a/devshard/cmd/devshardctl/main.go
+++ b/devshard/cmd/devshardctl/main.go
@@ -16,6 +16,7 @@ import (
 
 	"common/chain"
 	"devshard/bridge"
+	"devshard/internal/configenv"
 	"devshard/state"
 	"devshard/types"
 	"devshard/user"
@@ -761,19 +762,16 @@ func readFloat64Env(name string, fallback float64) float64 {
 }
 
 func readBoolEnv(name string, fallback bool) bool {
-	raw := strings.TrimSpace(strings.ToLower(os.Getenv(name)))
+	raw := strings.TrimSpace(os.Getenv(name))
 	if raw == "" {
 		return fallback
 	}
-	switch raw {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	default:
+	parsed, err := configenv.ParseBool(raw)
+	if err != nil {
 		log.Printf("invalid %s=%q, using %t", name, raw, fallback)
 		return fallback
 	}
+	return parsed
 }
 
 func buildSettlementJSON(p *state.SettlementPayload) (SettlementJSON, error) {

--- a/devshard/cmd/devshardctl/main_test.go
+++ b/devshard/cmd/devshardctl/main_test.go
@@ -32,6 +32,22 @@ func TestBootstrapEscrowRotationSettlementDefaultsDisabled(t *testing.T) {
 	require.False(t, opts.bootstrapSettings.EscrowRotation.SettlementEnabled)
 }
 
+func TestReadBoolEnvUsesDevshardBooleanGrammar(t *testing.T) {
+	const key = "TEST_DEVSHARDCTL_BOOL"
+
+	t.Setenv(key, "t")
+	require.True(t, readBoolEnv(key, false))
+
+	t.Setenv(key, "off")
+	require.False(t, readBoolEnv(key, true))
+
+	t.Setenv(key, "")
+	require.True(t, readBoolEnv(key, true), "empty value must preserve the caller fallback")
+
+	t.Setenv(key, "invalid")
+	require.True(t, readBoolEnv(key, true), "invalid value must preserve the caller fallback")
+}
+
 func TestBuildGatewayRuntimesDeactivatesMissingEscrow(t *testing.T) {
 	store, err := NewGatewayStore(filepath.Join(t.TempDir(), "gateway.db"))
 	require.NoError(t, err)

--- a/devshard/cmd/devshardd/config.go
+++ b/devshard/cmd/devshardd/config.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"devshard/cmd/devshardd/session"
+	"devshard/internal/configenv"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -269,14 +269,14 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-// envBoolOr parses a boolean env var (strconv.ParseBool). Unset or unparseable
-// values return fallback.
+// envBoolOr parses a devshard boolean env var. Unset or unparseable values
+// return fallback.
 func envBoolOr(key string, fallback bool) bool {
 	v := strings.TrimSpace(os.Getenv(key))
 	if v == "" {
 		return fallback
 	}
-	parsed, err := strconv.ParseBool(v)
+	parsed, err := configenv.ParseBool(v)
 	if err != nil {
 		return fallback
 	}

--- a/devshard/cmd/devshardd/config_test.go
+++ b/devshard/cmd/devshardd/config_test.go
@@ -37,3 +37,27 @@ func TestValidateBinaryLogVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvBoolOrUsesDevshardBooleanGrammar(t *testing.T) {
+	const key = "TEST_DEVSHARD_BOOL"
+
+	t.Setenv(key, "on")
+	if !envBoolOr(key, false) {
+		t.Fatal("on must enable the setting")
+	}
+
+	t.Setenv(key, "f")
+	if envBoolOr(key, true) {
+		t.Fatal("f must disable the setting")
+	}
+
+	t.Setenv(key, "")
+	if !envBoolOr(key, true) {
+		t.Fatal("empty value must preserve the caller fallback")
+	}
+
+	t.Setenv(key, "invalid")
+	if !envBoolOr(key, true) {
+		t.Fatal("invalid value must preserve the caller fallback")
+	}
+}

--- a/devshard/cmd/devshardd/session/heightsync.go
+++ b/devshard/cmd/devshardd/session/heightsync.go
@@ -17,6 +17,7 @@ import (
 	"devshard/chainoracle/blocks/tipcache"
 	"devshard/heightsync"
 	"devshard/host"
+	"devshard/internal/configenv"
 	"devshard/transport"
 
 	inferenceTypes "github.com/productscience/inference/x/inference/types"
@@ -130,12 +131,8 @@ func (m *HostManager) CloseHeightSync() {
 }
 
 func heightSyncFlag() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(envHeightSync))) {
-	case "1", "true", "yes":
-		return true
-	default:
-		return false
-	}
+	enabled, err := configenv.ParseBool(os.Getenv(envHeightSync))
+	return err == nil && enabled
 }
 
 func chainRPCFromEnv() string {

--- a/devshard/cmd/devshardd/session/heightsync_test.go
+++ b/devshard/cmd/devshardd/session/heightsync_test.go
@@ -69,3 +69,14 @@ func TestSetHeightSyncFromEnv_FlagWithoutOracleErrors(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, mgr.heightSync)
 }
+
+func TestHeightSyncFlagUsesDevshardBooleanGrammar(t *testing.T) {
+	t.Setenv(envHeightSync, "on")
+	require.True(t, heightSyncFlag())
+
+	t.Setenv(envHeightSync, "F")
+	require.False(t, heightSyncFlag())
+
+	t.Setenv(envHeightSync, "invalid")
+	require.False(t, heightSyncFlag(), "invalid values retain the disabled fallback")
+}

--- a/devshard/internal/configenv/bool.go
+++ b/devshard/internal/configenv/bool.go
@@ -1,0 +1,32 @@
+// Package configenv defines environment-value conventions shared by devshard
+// processes.
+package configenv
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseBool parses the boolean grammar used by devshard environment settings.
+// It ignores surrounding whitespace and letter case. An empty value is false.
+func ParseBool(raw string) (bool, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "":
+		return false, nil
+	case "yes", "on":
+		return true, nil
+	case "no", "off":
+		return false, nil
+	}
+
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf(
+			"%q is not a devshard boolean; use empty/0/f/false/no/off or 1/t/true/yes/on",
+			raw,
+		)
+	}
+	return parsed, nil
+}

--- a/devshard/internal/configenv/bool.go
+++ b/devshard/internal/configenv/bool.go
@@ -24,7 +24,7 @@ func ParseBool(raw string) (bool, error) {
 	parsed, err := strconv.ParseBool(value)
 	if err != nil {
 		return false, fmt.Errorf(
-			"%q is not a devshard boolean; use empty/0/f/false/no/off or 1/t/true/yes/on",
+			"invalid boolean value %q; use empty/0/f/false/no/off for false or 1/t/true/yes/on for true",
 			raw,
 		)
 	}

--- a/devshard/internal/configenv/bool_test.go
+++ b/devshard/internal/configenv/bool_test.go
@@ -1,0 +1,47 @@
+package configenv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    bool
+		wantErr bool
+	}{
+		{name: "empty", raw: "", want: false},
+		{name: "zero", raw: "0", want: false},
+		{name: "f", raw: "f", want: false},
+		{name: "false", raw: "false", want: false},
+		{name: "no", raw: "no", want: false},
+		{name: "off", raw: "off", want: false},
+		{name: "one", raw: "1", want: true},
+		{name: "t", raw: "t", want: true},
+		{name: "true", raw: "true", want: true},
+		{name: "yes", raw: "yes", want: true},
+		{name: "on", raw: "on", want: true},
+		{name: "case and whitespace", raw: "  YeS\t", want: true},
+		{name: "false case and whitespace", raw: "  OFF\n", want: false},
+		{name: "number outside grammar", raw: "2", wantErr: true},
+		{name: "unknown word", raw: "enabled", wantErr: true},
+		{name: "internal whitespace", raw: "t rue", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseBool(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.False(t, got)
+				require.Contains(t, err.Error(), tt.raw)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/devshard/internal/configenv/bool_test.go
+++ b/devshard/internal/configenv/bool_test.go
@@ -37,6 +37,8 @@ func TestParseBool(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				require.False(t, got)
+				require.Contains(t, err.Error(), "invalid boolean value")
+				require.Contains(t, err.Error(), "for false or")
 				require.Contains(t, err.Error(), tt.raw)
 				return
 			}

--- a/devshard/observability/init.go
+++ b/devshard/observability/init.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
+	"devshard/internal/configenv"
 	"devshard/observability/otelutil"
 )
 
@@ -117,7 +117,7 @@ func otelEnabled() bool {
 	if raw == "" {
 		return false
 	}
-	enabled, err := strconv.ParseBool(raw)
+	enabled, err := configenv.ParseBool(raw)
 	if err != nil {
 		logWarn("config.invalid_enabled",
 			"Invalid OpenTelemetry enabled flag; observability will stay disabled",

--- a/devshard/observability/init_bool_test.go
+++ b/devshard/observability/init_bool_test.go
@@ -1,0 +1,20 @@
+package observability
+
+import "testing"
+
+func TestOTelEnabledUsesDevshardBooleanGrammar(t *testing.T) {
+	t.Setenv(envEnabled, "on")
+	if !otelEnabled() {
+		t.Fatal("on must enable OpenTelemetry")
+	}
+
+	t.Setenv(envEnabled, "f")
+	if otelEnabled() {
+		t.Fatal("f must disable OpenTelemetry")
+	}
+
+	t.Setenv(envEnabled, "invalid")
+	if otelEnabled() {
+		t.Fatal("invalid value must retain the disabled fallback")
+	}
+}


### PR DESCRIPTION
## Merge Order

Merge this PR before #1601, **Fail closed on unsafe HA storage**.

#1601 consumes the shared parser added here for `GONKA_HA`; merge this parser first so the HA guard does not maintain a duplicate boolean grammar.

## Summary

- add a shared parser for boolean environment values used by devshard components
- standardize the accepted grammar across existing Go consumers
- preserve each caller's existing default and invalid-value policy
- add parser and integration-level regression tests

## Boolean grammar

Values are trimmed and matched case-insensitively:

- false: empty, `0`, `f`, `false`, `no`, `off`
- true: `1`, `t`, `true`, `yes`, `on`

Unsupported values produce an explicit diagnostic listing the accepted forms.

## Scope

This updates existing production env parsing in `devshardd`, `devshardctl`, `devshard-host`, session height sync, capacity-aware selection, and observability setup. It does not change exact `=1` test gates or test-environment mock parsers.

## Verification

- `go test -race ./internal/configenv ./cmd/devshardd ./cmd/devshardd/session ./cmd/devshardctl ./observability ./cmd/devshard-host`
- `go test ./...`
