### PR TITLE
`broker`: don't stall the broker command loop on node removal

### DIFF
--- a/decentralized-api/broker/broker.go
+++ b/decentralized-api/broker/broker.go
@@ -140,6 +140,10 @@ type Broker struct {
 	configManager        *apiconfig.ConfigManager
 	lockMap              map[string]lockEntry
 	lockMapMu            sync.Mutex
+	// deploymentGeneration is broker-wide and never resets when a node is
+	// deleted or re-registered, so a leftover result from an abandoned worker
+	// cannot share a generation with a new node's first reconcile.
+	deploymentGeneration atomic.Uint64
 }
 
 type lockEntry struct {
@@ -231,8 +235,10 @@ type NodeState struct {
 	PoCValidationInference  bool      `json:"poc_validation_inference"`
 	DeploymentUpdatePending bool      `json:"deployment_update_pending"`
 	DeploymentRetryAfter    time.Time `json:"deployment_retry_after,omitempty"`
-	// DeploymentGeneration increments for each dispatched reconciliation so
-	// late results from a cancelled attempt cannot be applied to a newer one.
+	// DeploymentGeneration is the last broker-wide generation assigned to this
+	// node. Uniqueness comes from Broker.deploymentGeneration, not this field:
+	// a fresh NodeState after re-register starts at 0 and is assigned the next
+	// global value on dispatch.
 	DeploymentGeneration uint64 `json:"deployment_generation,omitempty"`
 
 	// Epoch data for this node, keyed by model_id.
@@ -969,6 +975,10 @@ func (b *Broker) checkAndRefreshClientsIfNeeded() {
 	}
 }
 
+func (b *Broker) nextDeploymentGeneration() uint64 {
+	return b.deploymentGeneration.Add(1)
+}
+
 func (b *Broker) reconcileIfSynced(triggerMsg string) {
 	epochPhaseInfo := b.phaseTracker.GetCurrentEpochState()
 	if epochPhaseInfo.IsNilOrNotSynced() {
@@ -1045,8 +1055,8 @@ func (b *Broker) reconcile(epochState chainphase.EpochState) {
 		ctx, cancel := context.WithCancel(context.Background())
 		intendedStatusCopy := currentNode.State.IntendedStatus
 		pocIntendedStatusCopy := currentNode.State.PocIntendedStatus
-		currentNode.State.DeploymentGeneration++
-		generation := currentNode.State.DeploymentGeneration
+		generation := b.nextDeploymentGeneration()
+		currentNode.State.DeploymentGeneration = generation
 		currentNode.State.ReconcileInfo = &ReconcileInfo{
 			Status:     intendedStatusCopy,
 			PocStatus:  pocIntendedStatusCopy,

--- a/decentralized-api/broker/deployment_state_test.go
+++ b/decentralized-api/broker/deployment_state_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"decentralized-api/apiconfig"
+	"decentralized-api/chainphase"
 	"decentralized-api/mlnodeclient"
 
 	"github.com/productscience/inference/x/inference/types"
@@ -143,6 +144,69 @@ func TestUpdateNodeResultCommand_AcceptsMatchingDeploymentGeneration(t *testing.
 	require.True(t, found)
 	require.Equal(t, "model-b", got.ModelID)
 	require.Equal(t, "fingerprint-b", got.Fingerprint)
+}
+
+func TestReconcile_BrokerWideGenerationSurvivesSameIdReregister(t *testing.T) {
+	b := &Broker{
+		highPriorityCommands: make(chan Command, 8),
+		lowPriorityCommands:  make(chan Command, 8),
+		nodes:                make(map[string]*NodeWithState),
+		nodeWorkGroup:        NewNodeWorkGroup(),
+		phaseTracker:         &chainphase.ChainPhaseTracker{},
+	}
+	const id = "node-7"
+	epoch := chainphase.EpochState{CurrentBlock: chainphase.BlockInfo{Height: 1}}
+
+	first := createTestNodeWithStatus(id, types.HardwareNodeStatus_UNKNOWN)
+	first.State.IntendedStatus = types.HardwareNodeStatus_STOPPED
+	w1 := NewNodeWorkerWithClient(id, first, mlnodeclient.NewMockClient(), b)
+	b.nodes[id] = first
+	b.nodeWorkGroup.AddWorker(id, w1)
+	b.reconcile(epoch)
+	require.NotNil(t, first.State.ReconcileInfo)
+	gen1 := first.State.ReconcileInfo.Generation
+	require.Equal(t, uint64(1), gen1)
+
+	b.nodeWorkGroup.RemoveWorkerAsync(id)
+	delete(b.nodes, id)
+
+	second := createTestNodeWithStatus(id, types.HardwareNodeStatus_UNKNOWN)
+	second.State.IntendedStatus = types.HardwareNodeStatus_STOPPED
+	require.Equal(t, uint64(0), second.State.DeploymentGeneration)
+	w2 := NewNodeWorkerWithClient(id, second, mlnodeclient.NewMockClient(), b)
+	defer w2.Shutdown()
+	b.nodes[id] = second
+	b.nodeWorkGroup.AddWorker(id, w2)
+	b.reconcile(epoch)
+	require.NotNil(t, second.State.ReconcileInfo)
+	gen2 := second.State.ReconcileInfo.Generation
+	require.Equal(t, uint64(2), gen2)
+	require.Equal(t, gen2, second.State.DeploymentGeneration)
+
+	leftover := NewUpdateNodeResultCommand(id, NodeResult{
+		Succeeded:            true,
+		FinalStatus:          types.HardwareNodeStatus_STOPPED,
+		OriginalTarget:       types.HardwareNodeStatus_STOPPED,
+		FinalPocStatus:       PocStatusIdle,
+		OriginalPocTarget:    PocStatusIdle,
+		DeploymentGeneration: gen1,
+	})
+	leftover.Execute(b)
+	require.NotNil(t, second.State.ReconcileInfo)
+	require.Equal(t, gen2, second.State.ReconcileInfo.Generation)
+	require.Equal(t, types.HardwareNodeStatus_UNKNOWN, second.State.CurrentStatus)
+
+	matching := NewUpdateNodeResultCommand(id, NodeResult{
+		Succeeded:            true,
+		FinalStatus:          types.HardwareNodeStatus_STOPPED,
+		OriginalTarget:       types.HardwareNodeStatus_STOPPED,
+		FinalPocStatus:       PocStatusIdle,
+		OriginalPocTarget:    PocStatusIdle,
+		DeploymentGeneration: gen2,
+	})
+	matching.Execute(b)
+	require.Nil(t, second.State.ReconcileInfo)
+	require.Equal(t, types.HardwareNodeStatus_STOPPED, second.State.CurrentStatus)
 }
 
 func TestDeploymentUpdateReadyHonorsRetryBackoff(t *testing.T) {

--- a/decentralized-api/broker/node_admin_commands.go
+++ b/decentralized-api/broker/node_admin_commands.go
@@ -278,8 +278,21 @@ func (r RemoveNode) GetResponseChannelCapacity() int {
 }
 
 func (command RemoveNode) Execute(b *Broker) {
-	// Remove the worker first (it will wait for pending jobs)
-	b.nodeWorkGroup.RemoveWorker(command.NodeId)
+	// Cancel any in-flight worker command before shutting the worker down.
+	// Release b.mu first: the in-flight Execute may itself take b.mu.
+	b.mu.Lock()
+	var cancel func()
+	if node, ok := b.nodes[command.NodeId]; ok {
+		cancel = node.State.cancelInFlightTask
+	}
+	b.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+
+	// Unregister immediately; drain the worker off the broker command loop
+	// so a hung ML call cannot stall LockAvailableNode / inference.
+	b.nodeWorkGroup.RemoveWorkerAsync(command.NodeId)
 
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/decentralized-api/broker/node_worker.go
+++ b/decentralized-api/broker/node_worker.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"decentralized-api/mlnodeclient"
 	"sync"
+	"time"
 
 	"github.com/productscience/inference/x/inference/types"
 )
+
+const defaultWorkerShutdownTimeout = 5 * time.Second
 
 type commandWithContext struct {
 	cmd NodeWorkerCommand
@@ -22,6 +25,8 @@ type NodeWorker struct {
 	broker            *Broker
 	commands          chan commandWithContext
 	shutdown          chan struct{}
+	closed            bool
+	closedMu          sync.Mutex
 	wg                sync.WaitGroup
 	availableVersions map[string]bool
 	versionsMu        sync.Mutex
@@ -91,8 +96,14 @@ func (w *NodeWorker) run() {
 	}
 }
 
-// Submit queues a command for execution on this node
+// Submit queues a command for execution on this node.
+// Returns false if the worker is shut down or the command queue is full.
 func (w *NodeWorker) Submit(ctx context.Context, cmd NodeWorkerCommand) bool {
+	w.closedMu.Lock()
+	defer w.closedMu.Unlock()
+	if w.closed {
+		return false
+	}
 	w.wg.Add(1)
 	select {
 	case w.commands <- commandWithContext{cmd: cmd, ctx: ctx}:
@@ -103,10 +114,45 @@ func (w *NodeWorker) Submit(ctx context.Context, cmd NodeWorkerCommand) bool {
 	}
 }
 
-// Shutdown gracefully stops the worker
+// Shutdown stops the worker, waiting up to defaultWorkerShutdownTimeout for
+// in-flight commands. Callers that need a different bound should use
+// ShutdownWithTimeout.
 func (w *NodeWorker) Shutdown() {
-	close(w.shutdown)
-	w.wg.Wait() // Wait for all pending commands to complete
+	_ = w.ShutdownWithTimeout(defaultWorkerShutdownTimeout)
+}
+
+// ShutdownWithTimeout signals the worker to stop and waits up to d for in-flight
+// commands to finish. It returns true if the worker drained cleanly. Safe to call
+// more than once: only the first call closes the shutdown channel.
+func (w *NodeWorker) ShutdownWithTimeout(d time.Duration) bool {
+	w.closedMu.Lock()
+	alreadyClosed := w.closed
+	if !w.closed {
+		w.closed = true
+		close(w.shutdown)
+	}
+	w.closedMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		if !alreadyClosed {
+			logging.Error("Node worker shutdown timed out; abandoning in-flight command", types.Nodes,
+				"node_id", w.nodeId,
+				"timeout", d,
+				"likely_cause", "in-flight ML call or full broker queue")
+		}
+		return false
+	}
 }
 
 func (w *NodeWorker) RefreshClientImmediate(oldVersion, newVersion string) {
@@ -171,15 +217,30 @@ func (g *NodeWorkGroup) AddWorker(nodeId string, worker *NodeWorker) {
 	g.workers[nodeId] = worker
 }
 
-// RemoveWorker removes and shuts down a worker
+// RemoveWorker unregisters the worker and waits for it to shut down.
 func (g *NodeWorkGroup) RemoveWorker(nodeId string) {
+	if worker := g.unregisterWorker(nodeId); worker != nil {
+		worker.Shutdown()
+	}
+}
+
+// RemoveWorkerAsync unregisters the worker immediately and shuts it down in the
+// background so the caller (the broker command loop) is not blocked.
+func (g *NodeWorkGroup) RemoveWorkerAsync(nodeId string) {
+	if worker := g.unregisterWorker(nodeId); worker != nil {
+		go worker.ShutdownWithTimeout(defaultWorkerShutdownTimeout)
+	}
+}
+
+func (g *NodeWorkGroup) unregisterWorker(nodeId string) *NodeWorker {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-
-	if worker, exists := g.workers[nodeId]; exists {
-		worker.Shutdown()
-		delete(g.workers, nodeId)
+	worker, exists := g.workers[nodeId]
+	if !exists {
+		return nil
 	}
+	delete(g.workers, nodeId)
+	return worker
 }
 
 // GetWorker returns a specific worker (useful for node-specific commands)

--- a/decentralized-api/broker/node_worker_shutdown_test.go
+++ b/decentralized-api/broker/node_worker_shutdown_test.go
@@ -1,0 +1,219 @@
+package broker
+
+import (
+	"context"
+	"decentralized-api/chainphase"
+	"decentralized-api/mlnodeclient"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCommandLoopBroker() *Broker {
+	b := &Broker{
+		highPriorityCommands: make(chan Command, 100),
+		lowPriorityCommands:  make(chan Command, 100),
+		nodes:                make(map[string]*NodeWithState),
+		nodeWorkGroup:        NewNodeWorkGroup(),
+		lockMap:              make(map[string]lockEntry),
+		phaseTracker:         &chainphase.ChainPhaseTracker{},
+	}
+	go b.processCommands()
+	return b
+}
+
+func waitChan[T any](t *testing.T, ch <-chan T, d time.Duration, msg string) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(d):
+		t.Fatal(msg)
+		var zero T
+		return zero
+	}
+}
+
+func TestRemoveNode_DoesNotBlockBrokerLoop(t *testing.T) {
+	broker := newCommandLoopBroker()
+	node := createTestNode("node-7")
+	worker := NewNodeWorkerWithClient(node.Node.Id, node, mlnodeclient.NewMockClient(), broker)
+
+	broker.mu.Lock()
+	broker.nodes[node.Node.Id] = node
+	broker.mu.Unlock()
+	broker.nodeWorkGroup.AddWorker(node.Node.Id, worker)
+
+	started := make(chan struct{})
+	sawCancel := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	node.State.cancelInFlightTask = cancel
+
+	ok := worker.Submit(ctx, &TestCommand{
+		ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+			close(started)
+			<-ctx.Done()
+			close(sawCancel)
+			return NodeResult{Succeeded: false, Error: ctx.Err().Error()}
+		},
+	})
+	require.True(t, ok)
+	waitChan(t, started, 500*time.Millisecond, "command did not start")
+
+	removeResp := make(chan bool, 2)
+	require.NoError(t, broker.QueueMessage(RemoveNode{
+		NodeId:   node.Node.Id,
+		Response: removeResp,
+	}))
+
+	waitChan(t, sawCancel, 500*time.Millisecond, "in-flight Execute did not observe cancellation")
+	removed := waitChan(t, removeResp, 500*time.Millisecond, "RemoveNode blocked the broker loop")
+	assert.True(t, removed)
+
+	_, exists := broker.nodeWorkGroup.GetWorker(node.Node.Id)
+	assert.False(t, exists, "worker must be unregistered even if drain is still running")
+
+	lockResp := make(chan *Node, 2)
+	require.NoError(t, broker.QueueMessage(LockAvailableNode{
+		Model:    "model1",
+		Response: lockResp,
+	}))
+	_ = waitChan(t, lockResp, 500*time.Millisecond, "LockAvailableNode queued after RemoveNode was blocked")
+}
+
+func TestNodeWorker_ShutdownWithFullBrokerQueue(t *testing.T) {
+	broker := NewTestBroker2(1)
+	broker.nodes = make(map[string]*NodeWithState)
+	broker.phaseTracker = &chainphase.ChainPhaseTracker{}
+	broker.highPriorityCommands <- UpdateNodeResultCommand{
+		NodeId:   "filler",
+		Response: make(chan bool, 1),
+	}
+
+	node := createTestNode("node-7")
+	worker := NewNodeWorkerWithClient(node.Node.Id, node, mlnodeclient.NewMockClient(), broker)
+
+	started := make(chan struct{})
+	ok := worker.Submit(context.Background(), &TestCommand{
+		ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+			close(started)
+			return NodeResult{Succeeded: true}
+		},
+	})
+	require.True(t, ok)
+	waitChan(t, started, 500*time.Millisecond, "command did not start")
+
+	drained := worker.ShutdownWithTimeout(100 * time.Millisecond)
+	assert.False(t, drained, "shutdown must time out while QueueMessage is blocked")
+
+	<-broker.highPriorityCommands // filler
+	resultCmd := waitChan(t, broker.highPriorityCommands, 500*time.Millisecond, "abandoned result was not delivered")
+	update, ok := resultCmd.(UpdateNodeResultCommand)
+	require.True(t, ok)
+	update.Execute(broker)
+	assert.False(t, <-update.Response, "late result for a deleted node must be treated as unknown")
+}
+
+func TestNodeWorker_ShutdownWithTimeout_CleanDrain(t *testing.T) {
+	broker := NewTestBroker2(4)
+	node := createTestNode("node-1")
+	worker := NewNodeWorkerWithClient(node.Node.Id, node, mlnodeclient.NewMockClient(), broker)
+
+	var executed int32
+	for i := 0; i < 3; i++ {
+		ok := worker.Submit(context.Background(), &TestCommand{
+			ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+				atomic.AddInt32(&executed, 1)
+				return NodeResult{Succeeded: true}
+			},
+		})
+		require.True(t, ok)
+	}
+
+	assert.True(t, worker.ShutdownWithTimeout(time.Second), "clean drain should succeed")
+	assert.Equal(t, int32(3), atomic.LoadInt32(&executed))
+}
+
+func TestNodeWorker_ShutdownWithTimeout_ReturnsFalseOnHang(t *testing.T) {
+	broker := NewTestBroker2(1)
+	node := createTestNode("node-1")
+	worker := NewNodeWorkerWithClient(node.Node.Id, node, mlnodeclient.NewMockClient(), broker)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ok := worker.Submit(context.Background(), &TestCommand{
+		ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+			close(started)
+			<-release
+			return NodeResult{Succeeded: true}
+		},
+	})
+	require.True(t, ok)
+	waitChan(t, started, 500*time.Millisecond, "command did not start")
+
+	assert.False(t, worker.ShutdownWithTimeout(50*time.Millisecond))
+	close(release)
+	assert.True(t, worker.ShutdownWithTimeout(time.Second), "second wait should observe drain after release")
+}
+
+func TestNodeWorker_ShutdownIdempotent(t *testing.T) {
+	broker := NewTestBroker2(1)
+	node := createTestNode("node-1")
+	worker := NewNodeWorkerWithClient(node.Node.Id, node, mlnodeclient.NewMockClient(), broker)
+
+	worker.Shutdown()
+	worker.Shutdown() // must not panic on a second close
+	assert.False(t, worker.Submit(context.Background(), &TestCommand{}), "submit after shutdown must be rejected")
+}
+
+func TestNodeWorkGroup_RemoveWorkerUnregistersOnTimeout(t *testing.T) {
+	group := NewNodeWorkGroup()
+	broker := NewTestBroker2(1)
+	node := createTestNode("node-1")
+	worker := NewNodeWorkerWithClient(node.Node.Id, node, mlnodeclient.NewMockClient(), broker)
+	group.AddWorker(node.Node.Id, worker)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ok := worker.Submit(context.Background(), &TestCommand{
+		ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+			close(started)
+			<-release
+			return NodeResult{Succeeded: true}
+		},
+	})
+	require.True(t, ok)
+	waitChan(t, started, 500*time.Millisecond, "command did not start")
+
+	group.RemoveWorkerAsync(node.Node.Id)
+	_, exists := group.GetWorker(node.Node.Id)
+	assert.False(t, exists, "worker must be gone from the group even though drain has not finished")
+
+	close(release)
+}
+
+func TestRemoveNode_UnknownId(t *testing.T) {
+	broker := newCommandLoopBroker()
+	resp := make(chan bool, 2)
+	require.NoError(t, broker.QueueMessage(RemoveNode{NodeId: "missing", Response: resp}))
+	assert.False(t, waitChan(t, resp, 500*time.Millisecond, "RemoveNode for unknown id did not return"))
+}
+
+func TestRemoveNode_NilCancelInFlightTask(t *testing.T) {
+	broker := newCommandLoopBroker()
+	node := createTestNode("node-1")
+	worker := NewNodeWorkerWithClient(node.Node.Id, node, mlnodeclient.NewMockClient(), broker)
+	broker.mu.Lock()
+	broker.nodes[node.Node.Id] = node
+	broker.mu.Unlock()
+	broker.nodeWorkGroup.AddWorker(node.Node.Id, worker)
+
+	resp := make(chan bool, 2)
+	require.NoError(t, broker.QueueMessage(RemoveNode{NodeId: node.Node.Id, Response: resp}))
+	assert.True(t, waitChan(t, resp, 500*time.Millisecond, "RemoveNode with nil cancelInFlightTask did not return"))
+	_, exists := broker.nodeWorkGroup.GetWorker(node.Node.Id)
+	assert.False(t, exists)
+}

--- a/devshard/docs/broker-remove-node-shutdown-deadlock-plan.md
+++ b/devshard/docs/broker-remove-node-shutdown-deadlock-plan.md
@@ -1,0 +1,146 @@
+# Broker `RemoveNode` shutdown stall / deadlock — fix plan
+
+**Component:** `decentralized-api/broker`
+**Branch:** `fix/broker-remove-node-shutdown-deadlock`
+**Related:** [PR #1494](https://github.com/gonka-ai/gonka/pull/1494) (`fix(broker): prevent panic submitting to shut-down worker`) — same code path, complementary, should land first
+**Status:** plan — not started
+**Base:** verified against `upgrade-v0.2.16` @ `7b7e4098a`. Line references below are for this tree; on `main` the only relevant difference is that [#1536](https://github.com/gonka-ai/gonka/pull/1536) split the send into a private `submit(ctx, cmd, generation)` behind `Submit`.
+
+Deleting a node can park the broker's **only** command-processing goroutine for up to 15 minutes, and — once a buffer fills during that window — park it forever. Nothing about this requires an unusual configuration: one unresponsive ML node and one `DELETE /admin/v1/nodes/:id` is the whole reproduction.
+
+---
+
+## The cycle
+
+Four independently verifiable facts compose into a wait cycle:
+
+| # | Fact | Location |
+|---|---|---|
+| 1 | `RemoveNode.Execute` runs on the broker's single command goroutine (`go broker.processCommands()`), which dispatches every command serially | `broker.go:396`, `broker.go:421` (`case RemoveNode`) |
+| 2 | It calls `RemoveWorker` → `Shutdown` → `wg.Wait()`, blocking that goroutine until the worker's in-flight `Execute` returns | `node_admin_commands.go:280`, `node_worker.go:175`, `node_worker.go:107` |
+| 3 | Nothing cancels the in-flight context. `reconcile` stores `cancelInFlightTask` but `RemoveNode.Execute` never calls it, and reconcile contexts are `context.WithCancel` — **no deadline** | `broker.go:1033`, `broker.go:1040` |
+| 4 | The worker reaches `wg.Done()` only *after* `w.broker.QueueMessage(updateCmd)`, a **blocking** send on `highPriorityCommands` (capacity 100) | `node_worker.go:71` and `:83`, `broker.go:462`, `broker.go:325` |
+
+Facts 1–3 give a bounded stall; fact 4 turns it unbounded.
+
+### F1 — head-of-line block, up to 15 minutes
+
+`Shutdown` waits for an in-flight `Execute` that nobody cancelled. The mlnodeclient HTTP timeout is **15 minutes** (`mlnodeclient/client.go:35`), so that is the bound per in-flight command. All four worker commands do thread `ctx` into every client call (`node_worker_commands.go`), so they *would* unwind promptly if cancelled — the mechanism exists and is already used by reconcile's phase 1 (`broker.go:993`–`1002`); the removal path simply doesn't use it.
+
+For the duration, **no broker command executes at all.** Blast radius, worst first:
+
+- `LockAvailableNode` / `ReleaseNode` are on the inference request path (`node_lock.go:31` `AcquireMLNode`, `lock_helpers.go:109`). Node acquisition stops, so the participant stops serving inference — even though every other ML node is healthy.
+- The triggering HTTP request hangs too: the handler blocks on `node := <-response` (`internal/server/admin/node_handlers.go:36`).
+- Once `lowPriorityCommands` (10000) and `highPriorityCommands` (100) fill, `QueueMessage` itself blocks and the stall propagates into every HTTP handler that queues a command.
+
+### F2 — permanent deadlock, escalating from F1
+
+The worker can only reach `wg.Done()` after its blocking `QueueMessage`. If `highPriorityCommands` is full, `run()` never gets there, `wg.Wait()` never returns, and **the only goroutine that would drain that buffer is the one parked in `Wait`.** Restart is the only exit.
+
+F1 is what makes F2 likely rather than exotic: during a multi-minute stall the producers keep queueing high-priority commands — one `UpdateNodeResultCommand` per reconciling node, `SetNodesActualStatusCommand`, `SyncNodesCommand` every 60 s, `RegisterNode` batches from `POST /admin/v1/nodes/batch` — so a fleet around 100 nodes fills 100 slots. Note the drain loop inside `run()` (`node_worker.go:83`) has the same blocking send, so shutdown-time draining is equally exposed.
+
+### Relationship to PR #1494
+
+Same path, neither subsumes the other. #1494 stops `Submit` from **panicking** while a worker shuts down; this work stops `Shutdown` from **stalling the broker**. They conflict textually (both edit `Shutdown`), and #1494 is smaller and already reviewed, so it lands first and this branch rebases onto it. There is also a functional reason for that order: step 1 below can leave a worker goroutine alive after `Shutdown` returns, and a `Submit` racing that window is exactly the panic #1494 removes.
+
+---
+
+## Decisions
+
+| # | Question | Decision |
+|---|---|---|
+| D1 | How to stop waiting on a hung ML call | **Cancel before waiting.** `RemoveNode.Execute` reads `State.cancelInFlightTask` under `b.mu` and calls it before `RemoveWorker`. Reuses the existing mechanism and its reconcile precedent — no new plumbing. |
+| D2 | Trust cancellation alone? | **No — bound the wait too.** A future command could ignore `ctx`, or be stuck in a non-cancellable section. `Shutdown` gets a deadline; expiry logs loudly and proceeds. This is also what demotes F2 from permanent to bounded. |
+| D3 | Timeout value | **5 s.** Long enough that a cancelled HTTP call unwinds normally (so the graceful path stays the common path), short enough that no operator reads it as a hang. |
+| D4 | Move the wait off the broker goroutine entirely? | **Not in step 1.** It is the structurally cleanest answer but changes result-ordering semantics on removal. Filed as step 2, to be judged on its own once step 1 has removed the pathology. |
+
+**Why a bounded wait is safe.** After the deadline the worker goroutine may still be running and may still deliver its `UpdateNodeResultCommand` for a node that has since been deleted. That is already handled: `UpdateNodeResultCommand.Execute` logs `Received result for unknown node` and returns (`commands.go:172`–`181`). The abandoned goroutine is bounded by the 15-minute client timeout and exits on its own, since `shutdown` is already closed.
+
+## Non-goals
+
+- Re-architecting the broker away from one serialized command goroutine.
+- Making the worker's result publication non-blocking. Dropping a result leaves `ReconcileInfo` set forever, and reconcile skips any node with `ReconcileInfo != nil` (`broker.go:1007`), so the node would never be reconciled again — strictly worse than a bounded wait. See step 3.
+- Fixing the pre-existing flaky `TestNodeWorker_QueueFull` (15/40 failures under `-race` on untouched code; it asserts exactly 10 accepted submits while `run()` concurrently drains). Separate PR.
+
+---
+
+## Implementation steps
+
+### Step 1 — Cancel, then wait with a deadline *(required; the whole fix)*
+
+**Files:** `broker/node_worker.go`, `broker/node_admin_commands.go`, `broker/node_worker_test.go`, `broker/broker_test.go`.
+
+1. `NodeWorker.ShutdownWithTimeout(d time.Duration) bool` — closes `shutdown` (idempotently, per #1494), then waits on `wg` with a deadline, returning whether it drained cleanly. Implement the bounded wait by having a goroutine `wg.Wait()` and `close(done)`, then `select` on `done` vs `time.After(d)`. Keep `Shutdown()` as `ShutdownWithTimeout(defaultWorkerShutdownTimeout)` so existing callers and tests are unchanged.
+2. On expiry, log at Error with `node_id` and elapsed, naming the likely cause (in-flight ML call or a full broker queue). This is the operator's only signal that a worker was abandoned.
+3. `NodeWorkGroup.RemoveWorker` deletes from the map **regardless** of the return value — a worker that failed to drain must not stay reachable.
+4. `RemoveNode.Execute` cancels first:
+
+```go
+b.mu.Lock()
+cancel := (func())(nil)
+if node, ok := b.nodes[command.NodeId]; ok {
+    cancel = node.State.cancelInFlightTask
+}
+b.mu.Unlock()
+if cancel != nil {
+    cancel()
+}
+b.nodeWorkGroup.RemoveWorker(command.NodeId)
+```
+
+`b.mu` must be released before `RemoveWorker`, because the in-flight `Execute` may itself take `b.mu` (e.g. `resolveSupportedNodeModelID`) — holding it across the wait would substitute one deadlock for another. Note that the existing comment "Remove the worker first (it will wait for pending jobs)" needs updating: the wait is now bounded.
+
+**Exit:** with an ML node that never answers, `DELETE /admin/v1/nodes/:id` returns in well under a second (cancellation path) and the broker keeps processing `LockAvailableNode` throughout. With `highPriorityCommands` artificially full, removal returns within the 5 s deadline instead of never.
+
+### Step 2 — Take the wait off the broker goroutine *(optional follow-up)*
+
+`RemoveNode.Execute` unregisters the worker and hands `ShutdownWithTimeout` to a reaper goroutine, so the command loop never blocks on a worker at all — even for the 5 s worst case, and even if D3's value is later found too generous. Deferred deliberately: it makes a removed node's result land after deletion by design rather than by accident, which deserves its own review rather than riding along with a stall fix.
+
+### Step 3 — `ReconcileInfo` watchdog *(separate issue, separate PR)*
+
+Independent latent bug found while tracing this one: if a result is ever lost, `ReconcileInfo` stays non-nil forever and reconcile skips that node permanently (`broker.go:1007`). Phase 1 only cancels when the *intended* status changed (`broker.go:983`–`989`), so a node whose target never changes is stuck for the process lifetime. Wants a timestamp on `ReconcileInfo` and expiry after a few reconcile intervals. Listed here only so the connection is recorded — it must not expand this branch.
+
+---
+
+## Test plan
+
+All of these are unit tests in `decentralized-api/broker`, run by the existing **Build and Test API Wrapper** job (`go test ./...`). No CI wiring needed. Every test must be deterministic — no sleep-until-hopefully-done.
+
+### F1 — the broker loop keeps running
+
+`TestRemoveNode_DoesNotBlockBrokerLoop`. Register a node with a real broker, submit a command whose `Execute` blocks on `<-ctx.Done()` and records that it saw cancellation, set `State.cancelInFlightTask` as reconcile would, then queue `RemoveNode`. Assert, with channel waits rather than sleeps:
+
+- the blocking `Execute` observed cancellation (proves D1 fired, not just that the timeout expired),
+- a `LockAvailableNode` queued **after** `RemoveNode` gets its response promptly,
+- `RemoveNode`'s own response arrives promptly.
+
+Fail-first: without the cancel in step 1, this test blocks until the 5 s deadline, so give the assertions a budget well under it (a few hundred ms) and it fails on unfixed code for the right reason.
+
+### F2 — a full broker queue cannot wedge shutdown
+
+`TestNodeWorker_ShutdownWithFullBrokerQueue`. `NewTestBroker2(1)`, pre-fill the single `highPriorityCommands` slot, submit one command, wait until `Execute` has started (signal channel), let it finish so `run()` blocks in `QueueMessage`, then assert `ShutdownWithTimeout(100ms)` returns `false` within ~2× the deadline instead of hanging. Fail-first on today's code: it hangs and the test times out.
+
+Then drain the broker channel and assert the abandoned worker's result is delivered and handled as `unknown node` — pinning the D2 safety argument rather than trusting it.
+
+### Regression / no-behaviour-change
+
+- `TestNodeWorker_GracefulShutdown` must still see all 5 queued commands execute — the deadline must not truncate the normal path.
+- New: clean drain returns `true`; timed-out drain returns `false`; `RemoveWorker` deletes the worker from the group in **both** cases (`GetWorker` reports gone).
+- New: `RemoveNode` for an unknown node id, and for a node with `cancelInFlightTask == nil`, both no-op without panicking.
+- Whole package under `-race -count=1`, and the new tests under `-race -count=10`. Expect only the pre-existing `TestNodeWorker_QueueFull` flake (documented above under Non-goals) — anything else is ours.
+
+### Manual / staging check
+
+Point a node config at a host that accepts TCP but never responds (or `DROP` the port), let reconcile dispatch to it, then `DELETE /admin/v1/nodes/:id`. Before: the request hangs and inference requests stop being assigned nodes. After: the request returns immediately and inference continues.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Abandoned worker goroutine after a timed-out drain | Bounded by the 15-minute client timeout; exits on its own via the already-closed `shutdown`; late result handled as `unknown node` (`commands.go:172`) and asserted by a test |
+| A `Submit` racing the abandoned worker | Precisely what [#1494](https://github.com/gonka-ai/gonka/pull/1494) fixes — land it first; without it that race is a process panic |
+| 5 s still too long for the inference path | Step 2 removes broker-loop blocking entirely; D3 is a constant, trivially tunable |
+| Cancelling in-flight work leaves the ML node mid-transition | Already the semantics of reconcile phase 1 (`broker.go:993`); the node is being deleted, so no local state depends on the outcome |
+| Textual conflict with #1494 in `Shutdown` | Rebase onto it; the idempotency guard from #1494 is a prerequisite for closing `shutdown` safely here |


### PR DESCRIPTION
## Summary

- Deleting a node while its worker is in an ML call parked the broker’s **only** command goroutine for up to 15 minutes, and could deadlock it forever if `highPriorityCommands` filled.
- `RemoveNode` now cancels the in-flight reconcile context, unregisters the worker immediately, and drains shutdown off that loop (5s cap).
- `Submit` after close returns `false` instead of panicking.
- Reconcile stamps a **broker-wide** `DeploymentGeneration` (not per-node) so a leftover result after same-id re-register cannot finalize the new node.

---

## Problem

The broker processes every command on a single goroutine (`processCommands`): `RemoveNode`, `LockAvailableNode` / `ReleaseNode` (inference assignment), result updates, sync, register.

### Actors

| Actor | Role |
|---|---|
| Broker loop | Serial `Execute` of every command |
| Node worker | `Execute` (HTTP to ML node, client timeout **15 min**) then **blocking** `QueueMessage(UpdateNodeResultCommand)` on `highPriorityCommands` (cap 100) |
| Reconcile loop | Submits work; stores `cancelInFlightTask` (no deadline) |
| Admin `DELETE /admin/v1/nodes/:id` | Queues `RemoveNode`, then waits on `<-response` |

### Data flow before (hang / deadlock)

```
Reconcile: intended ≠ current
  → ctx, cancel := WithCancel (no timeout)
  → cancelInFlightTask = cancel
  → worker.Submit(InferenceUp / Stop / …)

Worker: Execute(ctx)  →  HTTP to ML node (up to 15 min)
        then QueueMessage(result)  →  highPriorityCommands
        then wg.Done()

DELETE node-7:
  HTTP handler → QueueMessage(RemoveNode) → blocks on response
  Broker loop: RemoveNode.Execute
    → RemoveWorker → Shutdown → wg.Wait()   ← loop is stuck here
    → never calls cancelInFlightTask
```

Two outcomes:

**F1 — head-of-line stall (usual).** Worker is in `Execute`. Nobody cancels `ctx`. `Wait` lasts until the 15-minute HTTP timeout. For that entire time **no** broker command runs: `LockAvailableNode` stops, so the participant stops assigning inference even on healthy nodes. The DELETE request hangs too.

**F2 — deadlock (escalation).** `wg.Done()` runs only *after* a blocking send on `highPriorityCommands`. If that buffer is full (other workers’ results, sync, register batches during F1), `run()` never `Done`s, `Wait` never returns, and the only goroutine that would drain the buffer is the one in `Wait`. Restart is the only exit.

Retrying DELETE does not help: the second `RemoveNode` sits behind the first on the same loop.

`select { case commands <- cmd: default: }` only guards a **full** channel, not a **closed** one. After `Shutdown` closes `commands`, a racing `Submit` (reconcile still holding the worker pointer) panics `send on closed channel` and kills the process ([#1494](https://github.com/gonka-ai/gonka/pull/1494)).

---

## Fix (new data flow)

```
DELETE node-7
  Broker loop: RemoveNode.Execute
    1. under b.mu: copy cancelInFlightTask; unlock
    2. cancel()                         ← D1: HTTP should abort now
    3. RemoveWorkerAsync
         unregister from map immediately
         go ShutdownWithTimeout(5s)     ← D2/D3: wait is bounded and off-loop
    4. delete node from b.nodes
    5. response ← true                  ← loop is free

Worker: Execute sees ctx.Done()
        QueueMessage(result)            ← broker can drain the buffer
        wg.Done()

LockAvailableNode queued after RemoveNode
  → processed promptly (other nodes keep serving)
```

| Decision | What it does |
|---|---|
| **D1** Cancel before waiting | Reuses reconcile’s `cancelInFlightTask`; ML calls already thread `ctx`. Unlock before wait so `Execute` can take `b.mu`. |
| **D2** Bound the wait | Do not trust cancel (ignored `ctx`, or `QueueMessage` blocked). |
| **D3** 5s | Long enough for a cancelled HTTP round-trip; short enough not to look like a hang. |
| **D4 / step 2** Reaper goroutine | Command loop never waits, even for those 5s. |

`ShutdownWithTimeout`: set `closed`, close `shutdown` once, `Wait` with `NewTimer` (stopped on the success path). Timeout → log Error and return `false`; worker is already unregistered. Late `UpdateNodeResultCommand` is “unknown node” (`commands.go`).

`Submit` takes `closedMu` across the non-blocking send: after close it returns `false` (no panic, no `WaitGroup` Add/Wait race).

### Leftover result after same-id re-register (D5)

After a timed-out drain the old `run()` may still live until the 15-minute client timeout. If the operator re-adds the **same node id** before that, the leftover `UpdateNodeResultCommand` is no longer “unknown node”: a new `NodeState` is in `b.nodes`.

`upgrade-v0.2.16` already ignores a result whose `DeploymentGeneration` ≠ `ReconcileInfo.Generation`. That only helps when the numbers differ. Generation used to live on `NodeState` and increment on dispatch (`0 → 1` on the first reconcile). `RegisterNode` builds a **new** `NodeState`, so the counter reset to 0. The abandoned worker’s first attempt and the new node’s first attempt were both generation **1**, same intended status → the stale result applied.

Rejecting reconcile until the old worker dies would close that window, but it would park the re-added node for up to 15 minutes — the wait this PR moved off `DELETE`.

**D5 — broker-wide counter.** `Broker.deploymentGeneration` is an `atomic.Uint64` that only ever goes up for this process. `reconcile` calls `nextDeploymentGeneration()` (`Add(1)`) and copies that value onto `NodeState.DeploymentGeneration` and `ReconcileInfo.Generation`. Delete / re-register does not reset it.

```
DELETE node-7 (worker still in Execute, stamped gen 1)
POST same id
  new NodeState { DeploymentGeneration: 0 }
  first reconcile → nextDeploymentGeneration() → 2
  ReconcileInfo.Generation = 2

old Execute returns, result gen 1
  UpdateNodeResultCommand: 1 ≠ 2 → ignore
new Execute returns, result gen 2
  match → finalize
```

`NodeState.DeploymentGeneration` is only a snapshot of the last value assigned to that node object (JSON / debug). Uniqueness is the broker counter, not the per-node field.

Same-node cancel + redispatch (no delete) still works: 1 then 2 on the same object, as before.

---

## Tests

File: `decentralized-api/broker/node_worker_shutdown_test.go`  
CI: **Build and Test API Wrapper** (`go test ./...` in `decentralized-api`). Deterministic channel waits, no sleep-until-done.

| Test | What it pins |
|---|---|
| `TestRemoveNode_DoesNotBlockBrokerLoop` | D1: in-flight `Execute` sees cancel; `RemoveNode` returns quickly; `LockAvailableNode` after it is not blocked; worker is unregistered |
| `TestNodeWorker_ShutdownWithFullBrokerQueue` | D2: `ShutdownWithTimeout(100ms)` returns `false` while `QueueMessage` is blocked; draining the filler delivers the result; `Execute` treats it as unknown node |
| `TestNodeWorker_ShutdownWithTimeout_CleanDrain` | Normal path still runs all queued commands (deadline does not truncate) |
| `TestNodeWorker_ShutdownWithTimeout_ReturnsFalseOnHang` | Hung `Execute` → `false`; after release, second wait → `true` |
| `TestNodeWorker_ShutdownIdempotent` | Second `Shutdown` does not panic; `Submit` after close is `false` |
| `TestNodeWorkGroup_RemoveWorkerUnregistersOnTimeout` | Async remove drops the map entry before drain finishes |
| `TestRemoveNode_UnknownId` | Missing id → `false`, no panic |
| `TestRemoveNode_NilCancelInFlightTask` | No in-flight cancel → still unregisters and returns `true` |
| `TestReconcile_BrokerWideGenerationSurvivesSameIdReregister` | D5: delete + re-add same id gets gen 2, not 1; leftover gen-1 result is ignored; matching gen 2 finalizes |

Existing `TestNodeWorker_GracefulShutdown` still requires all queued commands to finish on `Shutdown()`.

Existing `TestNodeWorker_GracefulShutdown` still requires all queued commands to finish on `Shutdown()`.

---

## Test plan (reviewer)

- [ ] `go test ./broker/ -race -run 'TestRemoveNode_\|TestNodeWorker_Shutdown\|TestNodeWorkGroup_RemoveWorker\|TestReconcile_BrokerWideGeneration'`
- [ ] Staging: point a node at a host that accepts TCP but never answers, let reconcile dispatch, `DELETE /admin/v1/nodes/:id` — request returns quickly and inference assignment continues
- [ ] Before this PR the same DELETE hung and `LockAvailableNode` stopped
