### PR TITLE
feat(selfcheck): offline broker PoC intended-state self-test

### DIFF
--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -18,6 +18,7 @@ import (
 	"decentralized-api/poc"
 	"decentralized-api/poc/artifacts"
 	"decentralized-api/poc/earlyshare"
+	"decentralized-api/selfcheck"
 	"decentralized-api/statsstorage"
 	"net"
 
@@ -86,6 +87,10 @@ func main() {
 	}
 	if len(os.Args) >= 2 && os.Args[1] == "pre-upgrade" {
 		os.Exit(1)
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "selfcheck" {
+		runSelfcheck()
+		return
 	}
 
 	configManager, err := apiconfig.LoadDefaultConfigManager()
@@ -324,6 +329,27 @@ func main() {
 	}
 
 	os.Exit(1) // Exit with an error for cosmovisor to restart the process
+}
+
+// runSelfcheck drives a one-shot assertion suite that checks the broker's
+// intended-state transitions across PoC phases, against a fresh broker
+// backed by a mocked chain. Prints the report to stderr and exits 0 on
+// PASS, 1 on FAIL. Intended for operator confidence before joining the
+// network: "does my participant binary react to epoch events as expected?"
+// (intended-state level; it does not exercise a real MLnode.)
+func runSelfcheck() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	report, err := selfcheck.Run(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "selfcheck: setup error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprint(os.Stderr, report.String())
+	if !report.Pass {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }
 
 func returnStatus(configManager *apiconfig.ConfigManager) {

--- a/decentralized-api/selfcheck/config.go
+++ b/decentralized-api/selfcheck/config.go
@@ -1,0 +1,35 @@
+package selfcheck
+
+import (
+	"decentralized-api/apiconfig"
+	"os"
+
+	"github.com/knadh/koanf/providers/file"
+)
+
+// newInMemoryConfig builds a ConfigManager backed by a tmpfile, used
+// only during selfcheck. Returns the manager plus a cleanup func that
+// removes the tmpfile.
+func newInMemoryConfig() (*apiconfig.ConfigManager, func(), error) {
+	tmp, err := os.CreateTemp("", "selfcheck-config-*.yaml")
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := tmp.Write([]byte("nodes: []")); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return nil, nil, err
+	}
+	tmp.Close()
+
+	cm := &apiconfig.ConfigManager{
+		KoanProvider:   file.Provider(tmp.Name()),
+		WriterProvider: apiconfig.NewFileWriteCloserProvider(tmp.Name()),
+	}
+	if err := cm.Load(); err != nil {
+		os.Remove(tmp.Name())
+		return nil, nil, err
+	}
+	cleanup := func() { os.Remove(tmp.Name()) }
+	return cm, cleanup, nil
+}

--- a/decentralized-api/selfcheck/evaluator.go
+++ b/decentralized-api/selfcheck/evaluator.go
@@ -1,0 +1,173 @@
+package selfcheck
+
+import (
+	"decentralized-api/broker"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// CheckResult is the outcome of one assertion stage.
+type CheckResult struct {
+	Name    string `json:"name"`
+	Pass    bool   `json:"pass"`
+	Details string `json:"details,omitempty"`
+}
+
+// Report is the aggregate outcome of a selfcheck run. Pass is true iff
+// every stage's Pass is true.
+type Report struct {
+	Pass   bool          `json:"pass"`
+	Stages []CheckResult `json:"stages"`
+}
+
+// String renders the report as a human-readable summary suitable for
+// printing to stderr at the end of a CLI selfcheck invocation.
+func (r Report) String() string {
+	var b strings.Builder
+	if r.Pass {
+		b.WriteString("selfcheck: PASS\n")
+	} else {
+		b.WriteString("selfcheck: FAIL\n")
+	}
+	for _, s := range r.Stages {
+		mark := "PASS"
+		if !s.Pass {
+			mark = "FAIL"
+		}
+		fmt.Fprintf(&b, "  [%s] %s", mark, s.Name)
+		if s.Details != "" {
+			fmt.Fprintf(&b, " — %s", s.Details)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// Evaluator runs assertions against a broker driven through a
+// synthetic PoC cycle by EventDriver. It is intentionally minimal:
+// each stage queries broker state via the public GetNodes API and
+// reports pass/fail. A full PoC artifact simulation is out of scope.
+type Evaluator struct {
+	Broker  *broker.Broker
+	Bridge  *MockChainBridge
+	NodeId  string
+	Timeout time.Duration
+}
+
+// NewEvaluator constructs an Evaluator with a sensible default
+// per-stage poll timeout.
+func NewEvaluator(b *broker.Broker, bridge *MockChainBridge, nodeId string) *Evaluator {
+	return &Evaluator{
+		Broker:  b,
+		Bridge:  bridge,
+		NodeId:  nodeId,
+		Timeout: 5 * time.Second,
+	}
+}
+
+// AssertNodeRegistered waits until the broker reports the synthetic
+// node as registered. Pass iff GetNodes returns an entry for NodeId
+// within Timeout.
+func (e *Evaluator) AssertNodeRegistered() CheckResult {
+	deadline := time.Now().Add(e.Timeout)
+	for time.Now().Before(deadline) {
+		nodes, err := e.Broker.GetNodes()
+		if err != nil {
+			return CheckResult{Name: "node-registered", Pass: false, Details: err.Error()}
+		}
+		for _, n := range nodes {
+			if n.Node.Id == e.NodeId {
+				return CheckResult{Name: "node-registered", Pass: true}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return CheckResult{Name: "node-registered", Pass: false, Details: "timeout waiting for node"}
+}
+
+// AssertEpochModelsPopulated checks that after a chain refresh, the
+// broker has populated EpochMLNodes for the synthetic node — i.e. the
+// chain-bridge wiring is working end-to-end through the broker.
+func (e *Evaluator) AssertEpochModelsPopulated() CheckResult {
+	deadline := time.Now().Add(e.Timeout)
+	for time.Now().Before(deadline) {
+		nodes, err := e.Broker.GetNodes()
+		if err != nil {
+			return CheckResult{Name: "epoch-models-populated", Pass: false, Details: err.Error()}
+		}
+		for _, n := range nodes {
+			if n.Node.Id != e.NodeId {
+				continue
+			}
+			if len(n.State.EpochMLNodes) > 0 {
+				return CheckResult{Name: "epoch-models-populated", Pass: true}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return CheckResult{Name: "epoch-models-populated", Pass: false, Details: "EpochMLNodes empty"}
+}
+
+// AssertHardwareDiffSubmitted checks that the broker reported its
+// node hardware up to the (mocked) chain via SubmitHardwareDiff.
+func (e *Evaluator) AssertHardwareDiffSubmitted() CheckResult {
+	deadline := time.Now().Add(e.Timeout)
+	for time.Now().Before(deadline) {
+		if len(e.Bridge.SubmittedDiffsSnapshot()) > 0 {
+			return CheckResult{Name: "hardware-diff-submitted", Pass: true}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return CheckResult{
+		Name: "hardware-diff-submitted", Pass: false,
+		Details: "broker did not submit hardware diff within timeout",
+	}
+}
+
+// AssertNodeIntendedStatus waits until the broker has driven the
+// synthetic node to the expected intended status. This is the core
+// PoC-lifecycle check: it proves the broker reacted to a phase
+// transition by setting the node's target state, without needing a
+// real MLnode. wantPoC is only checked when non-empty (it distinguishes
+// the GENERATING vs VALIDATING sub-states, both of which map to the
+// POC hardware status).
+func (e *Evaluator) AssertNodeIntendedStatus(name string, wantHW types.HardwareNodeStatus, wantPoC broker.PocStatus) CheckResult {
+	deadline := time.Now().Add(e.Timeout)
+	var lastHW types.HardwareNodeStatus
+	var lastPoC broker.PocStatus
+	for time.Now().Before(deadline) {
+		nodes, err := e.Broker.GetNodes()
+		if err != nil {
+			return CheckResult{Name: name, Pass: false, Details: err.Error()}
+		}
+		for _, n := range nodes {
+			if n.Node.Id != e.NodeId {
+				continue
+			}
+			lastHW, lastPoC = n.State.IntendedStatus, n.State.PocIntendedStatus
+			if lastHW == wantHW && (wantPoC == "" || lastPoC == wantPoC) {
+				return CheckResult{Name: name, Pass: true}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return CheckResult{
+		Name: name, Pass: false,
+		Details: fmt.Sprintf("intended status never reached %v/%v within timeout (last seen %v/%v)",
+			wantHW, wantPoC, lastHW, lastPoC),
+	}
+}
+
+// Combine aggregates stage results into a final Report.
+func (e *Evaluator) Combine(stages ...CheckResult) Report {
+	r := Report{Pass: true, Stages: stages}
+	for _, s := range stages {
+		if !s.Pass {
+			r.Pass = false
+		}
+	}
+	return r
+}

--- a/decentralized-api/selfcheck/event_driver.go
+++ b/decentralized-api/selfcheck/event_driver.go
@@ -1,0 +1,70 @@
+package selfcheck
+
+import (
+	"decentralized-api/broker"
+	"decentralized-api/chainphase"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// EventDriver advances a ChainPhaseTracker through a synthetic PoC
+// cycle and triggers the broker commands that would normally be
+// queued by the production OnNewBlockDispatcher.
+//
+// It does NOT simulate the full PoC artifact protocol — only the
+// chain-side events the broker reacts to:
+//   - epoch group data refresh (Inference phase boundary)
+//   - PoC start trigger        (StartPocCommand)
+//   - validation start         (InitValidateCommand)
+//   - inference-up resume      (InferenceUpAllCommand)
+//
+// The Evaluator inspects broker state between transitions to judge
+// whether the broker is behaving correctly. This is enough to catch
+// onboarding regressions where the broker fails to react to common
+// epoch events.
+type EventDriver struct {
+	Bridge       *MockChainBridge
+	PhaseTracker *chainphase.ChainPhaseTracker
+	Broker       *broker.Broker
+	Epoch        *types.Epoch
+	EpochParams  *types.EpochParams
+}
+
+// PushBlock updates the phase tracker to the given block height and
+// returns the resulting EpochState. The hash is synthetic.
+func (d *EventDriver) PushBlock(height int64) *chainphase.EpochState {
+	d.PhaseTracker.Update(
+		chainphase.BlockInfo{Height: height, Hash: "selfcheck-blk"},
+		d.Epoch,
+		d.EpochParams,
+		true,
+		nil,
+	)
+	return d.PhaseTracker.GetCurrentEpochState()
+}
+
+// RefreshEpochData updates the broker's per-node epoch view from the
+// (mocked) chain. This mirrors what OnNewBlockDispatcher does at the
+// start of every phase transition.
+func (d *EventDriver) RefreshEpochData() error {
+	es := d.PhaseTracker.GetCurrentEpochState()
+	return d.Broker.UpdateNodeWithEpochData(es)
+}
+
+// TriggerStartPoC queues the StartPocCommand the broker would normally
+// receive from OnNewBlockDispatcher when the chain crosses into the
+// PoC generate phase.
+func (d *EventDriver) TriggerStartPoC() error {
+	return d.Broker.QueueMessage(broker.NewStartPocCommand())
+}
+
+// TriggerInitValidate queues the InitValidateCommand for the validation
+// phase transition.
+func (d *EventDriver) TriggerInitValidate() error {
+	return d.Broker.QueueMessage(broker.NewInitValidateCommand())
+}
+
+// TriggerInferenceUpAll resumes inference at end of validation.
+func (d *EventDriver) TriggerInferenceUpAll() error {
+	return d.Broker.QueueMessage(broker.NewInferenceUpAllCommand())
+}

--- a/decentralized-api/selfcheck/mock_chain_bridge.go
+++ b/decentralized-api/selfcheck/mock_chain_bridge.go
@@ -1,0 +1,146 @@
+package selfcheck
+
+import (
+	"decentralized-api/broker"
+	"sync"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// MockChainBridge implements broker.BrokerChainBridge with hardcoded
+// responses that describe a single-participant, single-node, single-model
+// network. It is the foundation for running the real broker in
+// isolation during selfcheck — no chain RPC calls leave the process.
+//
+// All methods are safe for concurrent use.
+type MockChainBridge struct {
+	// ParticipantAddress is "self" — the participant address treated
+	// as active in epoch group data. Must match what NewBroker is
+	// constructed with via participant.CurrenParticipantInfo.
+	ParticipantAddress string
+
+	// ModelId is the single governance model used in the synthetic
+	// epoch group data and reported by GetGovernanceModels.
+	ModelId string
+
+	// NodeId is the MLnode id assigned to ParticipantAddress in the
+	// epoch group data. The selfcheck registers this id into the
+	// broker so EpochMLNodes lookups succeed.
+	NodeId string
+
+	// EpochIndex is the epoch index reported by epoch group responses.
+	EpochIndex uint64
+
+	// SubmittedDiffs records every SubmitHardwareDiff call so the
+	// Evaluator can assert the broker reported its hardware on startup.
+	mu             sync.Mutex
+	SubmittedDiffs []*types.MsgSubmitHardwareDiff
+}
+
+var _ broker.BrokerChainBridge = (*MockChainBridge)(nil)
+
+func (m *MockChainBridge) GetHardwareNodes() (*types.QueryHardwareNodesResponse, error) {
+	return &types.QueryHardwareNodesResponse{
+		Nodes: &types.HardwareNodes{HardwareNodes: nil},
+	}, nil
+}
+
+func (m *MockChainBridge) SubmitHardwareDiff(diff *types.MsgSubmitHardwareDiff) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SubmittedDiffs = append(m.SubmittedDiffs, diff)
+	return nil
+}
+
+func (m *MockChainBridge) GetBlockHash(height int64) (string, error) {
+	return "selfcheck-fake-hash", nil
+}
+
+func (m *MockChainBridge) GetGovernanceModels() (*types.QueryModelsAllResponse, error) {
+	return &types.QueryModelsAllResponse{
+		Model: []types.Model{{Id: m.ModelId}},
+	}, nil
+}
+
+// GetCurrentEpochGroupData returns a parent epoch group that points at
+// the single model subgroup. TotalWeight is non-zero so the v0.2.13
+// broker considers the epoch populated.
+func (m *MockChainBridge) GetCurrentEpochGroupData() (*types.QueryCurrentEpochGroupDataResponse, error) {
+	return &types.QueryCurrentEpochGroupDataResponse{
+		EpochGroupData: types.EpochGroupData{
+			EpochIndex:     m.EpochIndex,
+			SubGroupModels: []string{m.ModelId},
+			TotalWeight:    1,
+		},
+	}, nil
+}
+
+// GetEpochGroupDataByModelId returns:
+//   - The parent group (modelId="") with the subgroup pointer.
+//   - The model-specific subgroup with one ValidationWeights entry
+//     assigning ParticipantAddress's NodeId to the model.
+func (m *MockChainBridge) GetEpochGroupDataByModelId(epochIndex uint64, modelId string) (*types.QueryGetEpochGroupDataResponse, error) {
+	if modelId == "" {
+		return &types.QueryGetEpochGroupDataResponse{
+			EpochGroupData: types.EpochGroupData{
+				EpochIndex:     epochIndex,
+				SubGroupModels: []string{m.ModelId},
+				TotalWeight:    1,
+			},
+		}, nil
+	}
+	return &types.QueryGetEpochGroupDataResponse{
+		EpochGroupData: types.EpochGroupData{
+			EpochIndex:    epochIndex,
+			ModelSnapshot: &types.Model{Id: modelId},
+			ValidationWeights: []*types.ValidationWeight{
+				{
+					MemberAddress: m.ParticipantAddress,
+					Weight:        1,
+					MlNodes: []*types.MLNodeInfo{
+						{NodeId: m.NodeId},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// GetPreservedNodesSnapshot returns an empty snapshot — selfcheck does
+// not exercise preserved-node restoration. Added for v0.2.13 broker
+// interface compatibility.
+func (m *MockChainBridge) GetPreservedNodesSnapshot() (*types.QueryPreservedNodesSnapshotResponse, error) {
+	return &types.QueryPreservedNodesSnapshotResponse{}, nil
+}
+
+func (m *MockChainBridge) GetParams() (*types.QueryParamsResponse, error) {
+	return &types.QueryParamsResponse{
+		Params: types.Params{
+			EpochParams: m.epochParams(),
+		},
+	}, nil
+}
+
+// epochParams produces a deliberately short PoC cycle (a handful of
+// blocks per phase) so the EventDriver can step through a full epoch
+// in under a second of simulated time.
+func (m *MockChainBridge) epochParams() *types.EpochParams {
+	return &types.EpochParams{
+		EpochLength:           100,
+		PocStageDuration:      10,
+		PocExchangeDuration:   5,
+		PocValidationDelay:    1,
+		PocValidationDuration: 10,
+		SetNewValidatorsDelay: 1,
+	}
+}
+
+// SubmittedDiffsSnapshot returns a snapshot of recorded diffs so the
+// Evaluator can inspect them without racing the broker.
+func (m *MockChainBridge) SubmittedDiffsSnapshot() []*types.MsgSubmitHardwareDiff {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*types.MsgSubmitHardwareDiff, len(m.SubmittedDiffs))
+	copy(out, m.SubmittedDiffs)
+	return out
+}

--- a/decentralized-api/selfcheck/run.go
+++ b/decentralized-api/selfcheck/run.go
@@ -1,0 +1,188 @@
+// Package selfcheck provides a standalone mode for the api binary
+// that exercises the broker against a mocked chain to verify the
+// broker's PoC-phase intended-state transitions are wired correctly
+// (it does not exercise a real MLnode), without touching production
+// code paths. It is the implementation of the approach suggested by
+// reviewers on PR #866: keep the broker untouched, drive it with
+// synthetic events, and observe outcomes from a separate evaluator.
+//
+// See proposals/onboarding-clarity-v1/README.md for product context.
+package selfcheck
+
+import (
+	"context"
+	"decentralized-api/apiconfig"
+	"decentralized-api/broker"
+	"decentralized-api/chainphase"
+	"decentralized-api/mlnodeclient"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+const (
+	selfParticipantAddress = "selfcheck-participant"
+	selfNodeId             = "selfcheck-node-1"
+	selfModelId            = "selfcheck-model"
+)
+
+// Run executes the selfcheck and returns a Report. The Report's Pass
+// field is the overall outcome. An error is only returned if setup
+// itself failed (e.g. broker could not be constructed); per-stage
+// assertion failures are surfaced via Report.Pass=false.
+//
+// Run blocks until completion (a few seconds at most) or until ctx is
+// cancelled.
+func Run(ctx context.Context) (Report, error) {
+	// Disable the production "enforced model id" gate for the duration
+	// of this run — selfcheck uses a synthetic model id that the gate
+	// would otherwise reject. Restore the caller's prior value on return
+	// so we don't leak process-wide state into tests or programmatic
+	// callers in the same process.
+	prevEnforced, hadEnforced := os.LookupEnv("ENFORCED_MODEL_ID")
+	os.Setenv("ENFORCED_MODEL_ID", "disabled")
+	defer func() {
+		if hadEnforced {
+			os.Setenv("ENFORCED_MODEL_ID", prevEnforced)
+		} else {
+			os.Unsetenv("ENFORCED_MODEL_ID")
+		}
+	}()
+
+	bridge := &MockChainBridge{
+		ParticipantAddress: selfParticipantAddress,
+		ModelId:            selfModelId,
+		NodeId:             selfNodeId,
+		EpochIndex:         1,
+	}
+
+	phaseParams, err := bridge.GetParams()
+	if err != nil {
+		return Report{}, fmt.Errorf("mock GetParams: %w", err)
+	}
+
+	// Anchor the synthetic epoch so phase math is consistent.
+	const pocStart int64 = 1000
+	epoch := &types.Epoch{Index: 1, PocStartBlockHeight: pocStart}
+	phaseTracker := &chainphase.ChainPhaseTracker{}
+	phaseTracker.UpdateEpochParams(*phaseParams.Params.EpochParams)
+
+	// Configure a single fake node in the in-memory config manager so
+	// the broker reads it as a known node. We use a real
+	// ConfigManager wired to a tmpfile so SetNodes round-trips cleanly.
+	cm, cleanup, err := newInMemoryConfig()
+	if err != nil {
+		return Report{}, fmt.Errorf("newInMemoryConfig: %w", err)
+	}
+	defer cleanup()
+	if err := cm.SetNodes([]apiconfig.InferenceNodeConfig{{
+		Id:            selfNodeId,
+		Host:          "127.0.0.1",
+		InferencePort: 18080,
+		PoCPort:       18080,
+		MaxConcurrent: 1,
+		Models:        map[string]apiconfig.ModelConfig{selfModelId: {}},
+	}}); err != nil {
+		return Report{}, fmt.Errorf("SetNodes: %w", err)
+	}
+
+	mockFactory := mlnodeclient.NewMockClientFactory()
+	participantInfo := &staticParticipant{addr: selfParticipantAddress}
+	nodeBroker := broker.NewBroker(
+		bridge,
+		phaseTracker,
+		participantInfo,
+		"http://selfcheck-callback",
+		mockFactory,
+		cm,
+	)
+
+	// Load the configured node into the broker.
+	for _, n := range cm.GetNodes() {
+		ch := nodeBroker.LoadNodeToBroker(&n)
+		if ch != nil {
+			<-ch
+		}
+	}
+
+	driver := &EventDriver{
+		Bridge:       bridge,
+		PhaseTracker: phaseTracker,
+		Broker:       nodeBroker,
+		Epoch:        epoch,
+		EpochParams:  phaseParams.Params.EpochParams,
+	}
+	driver.PushBlock(pocStart - 50) // Inference phase, well before PoC
+
+	if err := driver.RefreshEpochData(); err != nil {
+		return Report{}, fmt.Errorf("RefreshEpochData: %w", err)
+	}
+
+	// Give the broker's goroutines a beat to process queued commands.
+	if err := waitOrCtx(ctx, 200*time.Millisecond); err != nil {
+		return Report{}, err
+	}
+
+	// nodeSyncWorker runs on a 60s ticker; trigger immediately so
+	// AssertHardwareDiffSubmitted has something to observe within
+	// selfcheck's short window.
+	_ = nodeBroker.QueueMessage(broker.NewSyncNodesCommand())
+
+	ev := NewEvaluator(nodeBroker, bridge, selfNodeId)
+	registered := ev.AssertNodeRegistered()
+	epochPopulated := ev.AssertEpochModelsPopulated()
+	hwSubmitted := ev.AssertHardwareDiffSubmitted()
+
+	// Step the synthetic chain through PoCGenerate -> PoCValidate -> back to
+	// Inference, queueing the same broker commands a real block would, and
+	// assert the broker's intended-state transitions for each phase (no real
+	// MLnode needed). This verifies broker PoC-phase wiring at the
+	// intended-state level — it does NOT assert the MLnode worker actually
+	// completed each operation; that is intentionally out of scope here.
+	ec := types.NewEpochContext(*epoch, *phaseParams.Params.EpochParams)
+
+	// PoC generation phase.
+	driver.PushBlock(ec.StartOfPoC())
+	if err := driver.TriggerStartPoC(); err != nil {
+		return Report{}, fmt.Errorf("TriggerStartPoC: %w", err)
+	}
+	pocGenerate := ev.AssertNodeIntendedStatus("poc-generate",
+		types.HardwareNodeStatus_POC, broker.PocStatusGenerating)
+
+	// PoC validation phase.
+	driver.PushBlock(ec.StartOfPoCValidation())
+	if err := driver.TriggerInitValidate(); err != nil {
+		return Report{}, fmt.Errorf("TriggerInitValidate: %w", err)
+	}
+	pocValidate := ev.AssertNodeIntendedStatus("poc-validate",
+		types.HardwareNodeStatus_POC, broker.PocStatusValidating)
+
+	// Back to inference once validation is over.
+	driver.PushBlock(ec.EndOfPoCValidation())
+	if err := driver.TriggerInferenceUpAll(); err != nil {
+		return Report{}, fmt.Errorf("TriggerInferenceUpAll: %w", err)
+	}
+	inferenceResume := ev.AssertNodeIntendedStatus("inference-resumed",
+		types.HardwareNodeStatus_INFERENCE, "")
+
+	return ev.Combine(registered, epochPopulated, hwSubmitted,
+		pocGenerate, pocValidate, inferenceResume), nil
+}
+
+func waitOrCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// staticParticipant is a CurrenParticipantInfo whose values never
+// change — enough for selfcheck where the participant is hardcoded.
+type staticParticipant struct{ addr string }
+
+func (p *staticParticipant) GetAddress() string { return p.addr }
+func (p *staticParticipant) GetPubKey() string  { return "selfcheck-pubkey" }

--- a/decentralized-api/selfcheck/run_test.go
+++ b/decentralized-api/selfcheck/run_test.go
@@ -1,0 +1,32 @@
+package selfcheck
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestRunPasses asserts that the selfcheck reports PASS on a healthy
+// broker driven by the synthetic chain. Doubles as a regression guard
+// against changes to broker construction that would break the public
+// API the selfcheck depends on.
+func TestRunPasses(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	report, err := Run(ctx)
+	if err != nil {
+		t.Fatalf("Run setup error: %v", err)
+	}
+	if !report.Pass {
+		t.Fatalf("selfcheck did not pass:\n%s", report.String())
+	}
+	if len(report.Stages) == 0 {
+		t.Fatal("expected at least one stage in report")
+	}
+	for _, s := range report.Stages {
+		if !s.Pass {
+			t.Errorf("stage %q failed: %s", s.Name, s.Details)
+		}
+	}
+}


### PR DESCRIPTION
## What this is

A `decentralized-api selfcheck` subcommand: it drives the real broker against a
mocked chain (`MockChainBridge`) through synthetic PoC phases and asserts the
broker's intended-state transitions at each stage. Exit 0 on PASS, 1 on FAIL.

```
selfcheck: PASS
  [PASS] node-registered
  [PASS] epoch-models-populated
  [PASS] hardware-diff-submitted
  [PASS] poc-generate
  [PASS] poc-validate
  [PASS] inference-resumed
```

It is meant for operator confidence before joining the network — "does my
participant binary react to epoch events the way it should?" — without needing
a chain or an MLnode to answer it.

## Why it is a separate PR

Split out of the onboarding work in #1296, which is too large to review as one
change (51 files). #1296 stays open as the umbrella; further slices will follow
the same way #1518 did.

This slice is self-contained: a new `decentralized-api/selfcheck` package plus
26 lines in `main.go` for the subcommand. Nothing existing changes behaviour.

## Scope

It verifies broker PoC-phase wiring at the **intended-state** level. It
deliberately does not exercise a real MLnode worker, so it says nothing about
whether a node actually loads a model — that is what the MLnode test in the
next slice is for.

The approach follows what reviewers suggested on #866: leave the broker
untouched, drive it with synthetic events, and observe outcomes from a separate
evaluator.

## Verification

Both required suites, locally against this head:

- `Build and Test chain` — build clean, `go test ./...` green (38 packages)
- `Build and Test API Wrapper` — build clean, `go test ./...` green, container-backed tests included
- `decentralized-api selfcheck` run end to end against the mocked chain: all six assertions pass, exit 0
