### PR TITLE
feat(participant): cache active-set membership for admin handlers

### DIFF
--- a/decentralized-api/internal/server/admin/server.go
+++ b/decentralized-api/internal/server/admin/server.go
@@ -6,6 +6,7 @@ import (
 	cosmos_client "decentralized-api/cosmosclient"
 	"decentralized-api/internal/server/middleware"
 	pserver "decentralized-api/internal/server/public"
+	"decentralized-api/participant"
 	"decentralized-api/payloadstorage"
 	"net/http"
 	_ "net/http/pprof"
@@ -26,14 +27,24 @@ import (
 	restrictionstypes "github.com/productscience/inference/x/restrictions/types"
 )
 
+// participantActivity is the cached "is this participant in the active set?"
+// signal admin handlers read, so answering it costs no chain RPC per request.
+// Narrow interface rather than the concrete *participant.ActivityTracker so
+// tests can drive the active and unknown states directly.
+type participantActivity interface {
+	IsActive() bool
+	IsKnown() bool
+}
+
 type Server struct {
-	e              *echo.Echo
-	nodeBroker     *broker.Broker
-	configManager  *apiconfig.ConfigManager
-	recorder       cosmos_client.CosmosMessageClient
-	cdc            *codec.ProtoCodec
-	blockQueue     *pserver.BridgeQueue
-	payloadStorage payloadstorage.PayloadStorage
+	e               *echo.Echo
+	nodeBroker      *broker.Broker
+	configManager   *apiconfig.ConfigManager
+	recorder        cosmos_client.CosmosMessageClient
+	cdc             *codec.ProtoCodec
+	blockQueue      *pserver.BridgeQueue
+	payloadStorage  payloadstorage.PayloadStorage
+	activityTracker participantActivity
 }
 
 func NewServer(
@@ -41,19 +52,28 @@ func NewServer(
 	nodeBroker *broker.Broker,
 	configManager *apiconfig.ConfigManager,
 	blockQueue *pserver.BridgeQueue,
-	payloadStorage payloadstorage.PayloadStorage) *Server {
+	payloadStorage payloadstorage.PayloadStorage,
+	activityTracker *participant.ActivityTracker) *Server {
 	cdc := getCodec()
+
+	// Assign through a nil check: storing a typed nil pointer in the interface
+	// field would make `s.activityTracker != nil` true and panic on first use.
+	var activity participantActivity
+	if activityTracker != nil {
+		activity = activityTracker
+	}
 
 	e := echo.New()
 	e.HTTPErrorHandler = middleware.TransparentErrorHandler
 	s := &Server{
-		e:              e,
-		nodeBroker:     nodeBroker,
-		configManager:  configManager,
-		recorder:       recorder,
-		cdc:            cdc,
-		blockQueue:     blockQueue,
-		payloadStorage: payloadStorage,
+		e:               e,
+		nodeBroker:      nodeBroker,
+		configManager:   configManager,
+		recorder:        recorder,
+		cdc:             cdc,
+		blockQueue:      blockQueue,
+		payloadStorage:  payloadStorage,
+		activityTracker: activity,
 	}
 
 	e.Use(middleware.LoggingMiddleware)

--- a/decentralized-api/internal/server/admin/server_test.go
+++ b/decentralized-api/internal/server/admin/server_test.go
@@ -136,7 +136,7 @@ func setupTestServer(t *testing.T) (*Server, *apiconfig.ConfigManager, *mlnodecl
 	nodeBroker := broker.NewBroker(bridge, phaseTracker, mockParticipant, "", mockClientFactory, configManager)
 
 	// 5. Server
-	s := NewServer(mockCosmos, nodeBroker, configManager, nil, nil)
+	s := NewServer(mockCosmos, nodeBroker, configManager, nil, nil, nil)
 
 	return s, configManager, mockClientFactory
 }

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -133,6 +133,11 @@ func main() {
 	chainBridge := broker.NewBrokerChainBridgeImpl(recorder, configManager.GetChainNodeConfig().Url)
 	nodeBroker := broker.NewBroker(chainBridge, chainPhaseTracker, participantInfo, configManager.GetApiConfig().PoCCallbackUrl, &mlnodeclient.HttpClientFactory{}, configManager)
 
+	// Background tracker for "is this participant in the current active set?" —
+	// admin handlers read its cached answer so they don't trigger a chain RPC
+	// per request. Started below once the cancellable context is available.
+	activityTracker := participant.NewActivityTracker(recorder, participantInfo.GetAddress(), 30*time.Second)
+
 	nodes := configManager.GetNodes()
 	for _, node := range nodes {
 		responseChan := nodeBroker.LoadNodeToBroker(&node)
@@ -193,6 +198,10 @@ func main() {
 
 	// Create a cancellable context for the entire system
 	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start the participant activity tracker so admin handlers can answer
+	// "is this participant active?" without a per-request RPC.
+	activityTracker.Start(ctx)
 	defer cancel() // Ensure resources are cleaned up
 
 	// Start periodic config auto-flush of dynamic data to DB
@@ -281,7 +290,7 @@ func main() {
 
 	addr = fmt.Sprintf(":%v", configManager.GetApiConfig().AdminServerPort)
 	logging.Info("start admin server on addr", types.Server, "addr", addr)
-	adminServer := adminserver.NewServer(recorder, nodeBroker, configManager, blockQueue, payloadStore)
+	adminServer := adminserver.NewServer(recorder, nodeBroker, configManager, blockQueue, payloadStore, activityTracker)
 	adminServer.Start(addr)
 
 	nmGrpcPort := configManager.GetApiConfig().NodeManagerGrpcPort

--- a/decentralized-api/participant/activity_tracker.go
+++ b/decentralized-api/participant/activity_tracker.go
@@ -1,0 +1,158 @@
+package participant
+
+import (
+	"common/logging"
+	"context"
+	"decentralized-api/cosmosclient"
+	"sync/atomic"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// activityState is the tri-state cached by ActivityTracker. It starts
+// Unknown and only becomes Active/Inactive once a refresh succeeds, so
+// callers can distinguish "not yet known" from "known inactive".
+type activityState int32
+
+const (
+	activityUnknown activityState = iota
+	activityInactive
+	activityActive
+)
+
+// defaultRefreshTimeout bounds a single chain query so a hung RPC cannot
+// wedge the refresher goroutine (which would otherwise leave the cached
+// value unboundedly stale).
+const defaultRefreshTimeout = 5 * time.Second
+
+// ActivityTracker caches whether the current participant is part of
+// the active epoch group. The result is refreshed periodically by a
+// background goroutine so that admin HTTP handlers can call
+// IsActive() without making any chain RPC calls per request.
+//
+// "Active" means the participant has at least one MLnode assigned to
+// some model subgroup in the current epoch group data.
+type ActivityTracker struct {
+	queryClient    queryClient
+	address        string
+	interval       time.Duration
+	refreshTimeout time.Duration
+
+	state atomic.Int32
+}
+
+// queryClient is a narrow interface over cosmosclient.CosmosMessageClient
+// covering only what the tracker needs. Defined to make unit testing
+// straightforward.
+type queryClient interface {
+	NewInferenceQueryClient() types.QueryClient
+}
+
+// NewActivityTracker constructs a tracker but does not start it. Call
+// Start to launch the background refresher.
+func NewActivityTracker(client cosmosclient.CosmosMessageClient, address string, interval time.Duration) *ActivityTracker {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	return &ActivityTracker{
+		queryClient:    client,
+		address:        address,
+		interval:       interval,
+		refreshTimeout: defaultRefreshTimeout,
+	}
+}
+
+// IsActive returns true only when the most recent successful refresh saw
+// the participant in the active set. It is false both for "known inactive"
+// and for "not yet known"; use IsKnown to tell those apart.
+func (t *ActivityTracker) IsActive() bool {
+	return activityState(t.state.Load()) == activityActive
+}
+
+// IsKnown reports whether at least one refresh has succeeded, i.e. whether
+// IsActive reflects a real observation rather than the startup default.
+func (t *ActivityTracker) IsKnown() bool {
+	return activityState(t.state.Load()) != activityUnknown
+}
+
+// Start launches a goroutine that refreshes IsActive() immediately and
+// then every interval until ctx is cancelled. Start returns without
+// blocking: the initial refresh runs inside the goroutine so a slow or
+// unresponsive chain RPC can't hold up API startup (IsActive() stays
+// false until the first successful refresh).
+func (t *ActivityTracker) Start(ctx context.Context) {
+	go func() {
+		t.refresh(ctx)
+		ticker := time.NewTicker(t.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				t.refresh(ctx)
+			}
+		}
+	}()
+}
+
+func (t *ActivityTracker) refresh(ctx context.Context) {
+	// Bound each refresh so a hung-but-not-erroring RPC cannot block the
+	// refresher loop forever (which would leave the cached value stale and
+	// stop all future ticks from being processed).
+	timeout := t.refreshTimeout
+	if timeout <= 0 {
+		timeout = defaultRefreshTimeout
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	active, err := t.query(queryCtx)
+	if err != nil {
+		// Chain may not be ready at startup; keep the previous value
+		// (including Unknown) rather than flipping it on transient errors.
+		logging.Debug("ActivityTracker refresh failed", types.Participants, "error", err)
+		return
+	}
+	newState := activityInactive
+	if active {
+		newState = activityActive
+	}
+	if activityState(t.state.Swap(int32(newState))) != newState {
+		logging.Info("Participant active status changed", types.Participants, "active", active)
+	}
+}
+
+func (t *ActivityTracker) query(ctx context.Context) (bool, error) {
+	q := t.queryClient.NewInferenceQueryClient()
+	parentResp, err := q.CurrentEpochGroupData(ctx, &types.QueryCurrentEpochGroupDataRequest{})
+	if err != nil {
+		return false, err
+	}
+	if parentResp == nil {
+		return false, nil
+	}
+	epochIndex := parentResp.EpochGroupData.EpochIndex
+	for _, modelId := range parentResp.EpochGroupData.SubGroupModels {
+		subResp, err := q.EpochGroupData(ctx, &types.QueryGetEpochGroupDataRequest{
+			EpochIndex: epochIndex,
+			ModelId:    modelId,
+		})
+		if err != nil {
+			// Transient RPC failure: surface the error so refresh keeps the
+			// previous value instead of flipping an active participant to
+			// inactive on a missing subgroup.
+			return false, err
+		}
+		if subResp == nil {
+			continue
+		}
+		for _, w := range subResp.EpochGroupData.ValidationWeights {
+			if w.MemberAddress == t.address && len(w.MlNodes) > 0 {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/decentralized-api/participant/activity_tracker_test.go
+++ b/decentralized-api/participant/activity_tracker_test.go
@@ -1,0 +1,177 @@
+package participant
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type fakeActivityQuerySource struct {
+	client *fakeActivityQueryClient
+}
+
+func (f fakeActivityQuerySource) NewInferenceQueryClient() types.QueryClient {
+	return f.client
+}
+
+type fakeActivityQueryClient struct {
+	types.QueryClient
+
+	parentResp     *types.QueryCurrentEpochGroupDataResponse
+	parentErr      error
+	subgroupResp   map[string]*types.QueryGetEpochGroupDataResponse
+	subgroupErr    map[string]error
+	blockUntilDone bool
+}
+
+func (f *fakeActivityQueryClient) CurrentEpochGroupData(
+	ctx context.Context,
+	_ *types.QueryCurrentEpochGroupDataRequest,
+	_ ...grpc.CallOption,
+) (*types.QueryCurrentEpochGroupDataResponse, error) {
+	if f.blockUntilDone {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if f.parentErr != nil {
+		return nil, f.parentErr
+	}
+	return f.parentResp, nil
+}
+
+func (f *fakeActivityQueryClient) EpochGroupData(
+	_ context.Context,
+	req *types.QueryGetEpochGroupDataRequest,
+	_ ...grpc.CallOption,
+) (*types.QueryGetEpochGroupDataResponse, error) {
+	if err := f.subgroupErr[req.ModelId]; err != nil {
+		return nil, err
+	}
+	return f.subgroupResp[req.ModelId], nil
+}
+
+func newActivityTrackerForTest(client *fakeActivityQueryClient) *ActivityTracker {
+	return &ActivityTracker{
+		queryClient:    fakeActivityQuerySource{client: client},
+		address:        "participant-1",
+		interval:       time.Hour,
+		refreshTimeout: time.Second,
+	}
+}
+
+func TestActivityTracker_refresh_marksKnownActive_whenParticipantHasMLNode(t *testing.T) {
+	// Given
+	tracker := newActivityTrackerForTest(&fakeActivityQueryClient{
+		parentResp: parentGroup("model-a"),
+		subgroupResp: map[string]*types.QueryGetEpochGroupDataResponse{
+			"model-a": subgroup("participant-1", "node-1"),
+		},
+	})
+
+	// When
+	tracker.refresh(context.Background())
+
+	// Then
+	require.True(t, tracker.IsKnown())
+	require.True(t, tracker.IsActive())
+}
+
+func TestActivityTracker_refresh_marksKnownInactive_whenParticipantAbsent(t *testing.T) {
+	// Given
+	tracker := newActivityTrackerForTest(&fakeActivityQueryClient{
+		parentResp: parentGroup("model-a"),
+		subgroupResp: map[string]*types.QueryGetEpochGroupDataResponse{
+			"model-a": subgroup("other-participant", "node-2"),
+		},
+	})
+
+	// When
+	tracker.refresh(context.Background())
+
+	// Then
+	require.True(t, tracker.IsKnown())
+	require.False(t, tracker.IsActive())
+}
+
+func TestActivityTracker_refresh_keepsUnknown_whenInitialQueryFails(t *testing.T) {
+	// Given
+	tracker := newActivityTrackerForTest(&fakeActivityQueryClient{
+		parentErr: errors.New("chain unavailable"),
+	})
+
+	// When
+	tracker.refresh(context.Background())
+
+	// Then
+	require.False(t, tracker.IsKnown())
+	require.False(t, tracker.IsActive())
+}
+
+func TestActivityTracker_refresh_preservesPreviousState_whenSubgroupQueryFails(t *testing.T) {
+	// Given
+	client := &fakeActivityQueryClient{
+		parentResp: parentGroup("model-a"),
+		subgroupResp: map[string]*types.QueryGetEpochGroupDataResponse{
+			"model-a": subgroup("participant-1", "node-1"),
+		},
+	}
+	tracker := newActivityTrackerForTest(client)
+	tracker.refresh(context.Background())
+	require.True(t, tracker.IsActive())
+
+	client.subgroupResp = map[string]*types.QueryGetEpochGroupDataResponse{}
+	client.subgroupErr = map[string]error{"model-a": errors.New("subgroup timeout")}
+
+	// When
+	tracker.refresh(context.Background())
+
+	// Then
+	require.True(t, tracker.IsKnown())
+	require.True(t, tracker.IsActive())
+}
+
+func TestActivityTracker_refresh_returnsAfterTimeout_whenQueryHangs(t *testing.T) {
+	// Given
+	tracker := newActivityTrackerForTest(&fakeActivityQueryClient{
+		blockUntilDone: true,
+	})
+	tracker.refreshTimeout = 20 * time.Millisecond
+
+	// When
+	started := time.Now()
+	tracker.refresh(context.Background())
+
+	// Then
+	require.Less(t, time.Since(started), 500*time.Millisecond)
+	require.False(t, tracker.IsKnown())
+	require.False(t, tracker.IsActive())
+}
+
+func parentGroup(modelID string) *types.QueryCurrentEpochGroupDataResponse {
+	return &types.QueryCurrentEpochGroupDataResponse{
+		EpochGroupData: types.EpochGroupData{
+			EpochIndex:     7,
+			SubGroupModels: []string{modelID},
+		},
+	}
+}
+
+func subgroup(participantAddress, nodeID string) *types.QueryGetEpochGroupDataResponse {
+	return &types.QueryGetEpochGroupDataResponse{
+		EpochGroupData: types.EpochGroupData{
+			ValidationWeights: []*types.ValidationWeight{
+				{
+					MemberAddress: participantAddress,
+					MlNodes: []*types.MLNodeInfo{
+						{NodeId: nodeID},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## What this is

Admin handlers need to answer "is this participant in the current epoch's active
set?". Asking the chain per request turns one admin call into N+1 RPCs, so this
caches the answer and refreshes it in the background instead.

`ActivityTracker` polls `CurrentEpochGroupData` on an interval and exposes a
tri-state:

- **Active** — the participant has at least one MLnode assigned in the current epoch group
- **Inactive** — refreshed successfully, and it does not
- **Unknown** — no refresh has succeeded yet

`IsActive()` and `IsKnown()` let a caller tell "known inactive" apart from "not
yet known", which matters at startup when the chain may not be reachable.

## Details worth a second look

Each refresh is bounded by its own timeout, so a hung-but-not-erroring RPC
cannot wedge the refresher and leave the cached value stale indefinitely. A
failed refresh keeps the previous value rather than flipping it on a transient
error.

The admin `Server` takes the tracker through a narrow `participantActivity`
interface rather than the concrete type, so tests can drive Active and Unknown
directly. Assignment goes through a nil check — storing a typed nil pointer in
an interface field would make a `!= nil` guard true and panic on first use.

## Why it is a separate PR

Split out of the onboarding work in #1296, which is too large to review as one
change. This is the shared dependency underneath the remaining slices: both the
pre-PoC MLnode test and the onboarding state endpoints read this signal, so it
is worth landing on its own first.

Second slice after #1644. #1296 stays open as the umbrella.

## Verification

Both required suites, locally against this head, with Docker available so the
container-backed tests actually run:

- `Build and Test chain` — build clean, `go test ./...` green
- `Build and Test API Wrapper` — build clean, `go test ./...` green
