### PR TITLE
Validation retry tests + Fix validation retry recovery and lease release semantics

### DIFF
--- a/devshard/cmd/devshardd/config_test.go
+++ b/devshard/cmd/devshardd/config_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"devshard/cmd/devshardd/session"
+)
 
 func TestValidateBinaryLogVersion(t *testing.T) {
 	t.Parallel()
@@ -59,5 +63,41 @@ func TestEnvBoolOrUsesDevshardBooleanGrammar(t *testing.T) {
 	t.Setenv(key, "invalid")
 	if !envBoolOr(key, true) {
 		t.Fatal("invalid value must preserve the caller fallback")
+	}
+}
+
+func TestLoadRuntimeConfig_VoteFalseOnFetchFailureDefaultAndOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "unset defaults on", want: true},
+		{name: "false disables", env: "false", want: false},
+		{name: "true enables", env: "true", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DEVSHARD_BINARY_LOG_VERSION", "")
+			t.Setenv("DEVSHARD_VALIDATION_RETRY_INTERVAL", "")
+			t.Setenv("DEVSHARD_VALIDATION_LEASE_TTL", "")
+			t.Setenv("DEVSHARD_SHUTDOWN_GRACE", "")
+			t.Setenv("DEVSHARD_VALIDATION_VOTE_FALSE_ON_FETCH_FAILURE", tt.env)
+
+			cfg, err := loadRuntimeConfig(nil, "v2", "dev-log")
+			if err != nil {
+				t.Fatalf("loadRuntimeConfig: %v", err)
+			}
+			if cfg.VoteFalseOnFetchFailure != tt.want {
+				t.Fatalf("VoteFalseOnFetchFailure got %v, want %v", cfg.VoteFalseOnFetchFailure, tt.want)
+			}
+			if cfg.ValidationRetryInterval != session.DefaultValidationRetryInterval {
+				t.Fatalf("ValidationRetryInterval got %s, want %s", cfg.ValidationRetryInterval, session.DefaultValidationRetryInterval)
+			}
+			if cfg.ValidationLeaseTTL != session.DefaultValidationLeaseTTL {
+				t.Fatalf("ValidationLeaseTTL got %s, want %s", cfg.ValidationLeaseTTL, session.DefaultValidationLeaseTTL)
+			}
+		})
 	}
 }

--- a/devshard/cmd/devshardd/inference/validate_fetch_test.go
+++ b/devshard/cmd/devshardd/inference/validate_fetch_test.go
@@ -68,6 +68,27 @@ func TestFetchPayloadsHTTPWithRetry(t *testing.T) {
 		assert.Equal(t, int32(2), n.Load())
 	})
 
+	t.Run("malformed 200 retries then restored response succeeds", func(t *testing.T) {
+		var n atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if n.Add(1) == 1 {
+				_, _ = w.Write([]byte(`{"inference_id":"1"`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(commonvalidation.PayloadResponse{
+				InferenceId: "1",
+			})
+		}))
+		t.Cleanup(srv.Close)
+
+		resp, err := fetchPayloadsHTTPWithRetry(context.Background(), srv.Client(), srv.URL, "val", 1, 10, "sig", 0)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "1", resp.InferenceId)
+		assert.Equal(t, int32(2), n.Load())
+	})
+
 	t.Run("cancelled context stops immediately", func(t *testing.T) {
 		var n atomic.Int32
 		ctx, cancel := context.WithCancel(context.Background())

--- a/devshard/cmd/devshardd/inference/validator_test.go
+++ b/devshard/cmd/devshardd/inference/validator_test.go
@@ -372,6 +372,30 @@ func TestLeaseValidator_ReleaseValidationLease_NoAcquire_NoOp(t *testing.T) {
 	require.Empty(t, store.releaseCalls)
 }
 
+func TestLeaseValidator_ReleaseValidationLease_ErrorForgetsAcquire(t *testing.T) {
+	releaseErr := errors.New("release failed")
+	store := &stubLeases{
+		acquireFn: func(_ context.Context, _ string, _ uint64, _ uint64, _ string) (bool, error) {
+			return true, nil
+		},
+		releaseFn: func(_ context.Context, _ string, _, _ uint64, _ string) error {
+			return releaseErr
+		},
+	}
+	c := newTestLeaseValidator(store, successInner)
+
+	_, err := c.Validate(context.Background(), makeReq())
+	require.NoError(t, err)
+
+	err = c.ReleaseValidationLease(context.Background(), "escrow-1", 42)
+	require.ErrorIs(t, err, releaseErr)
+	require.Equal(t, []string{"escrow-1/42/0/validator-addr"}, store.releaseCalls)
+
+	err = c.ReleaseValidationLease(context.Background(), "escrow-1", 42)
+	require.NoError(t, err)
+	require.Len(t, store.releaseCalls, 1, "release error must still forget the local acquire")
+}
+
 type stubChainParams struct{}
 
 func (stubChainParams) LogprobsMode() string { return "" }
@@ -516,6 +540,26 @@ func TestValidator_Validate_ExecutorFaultClassification(t *testing.T) {
 			phaseEpoch: 10,
 			reqEpoch:   10,
 			wantFalse:  true,
+		},
+		{
+			name: "malformed prompt with switch off errors",
+			fetch: func(context.Context, devshardpkg.ValidateRequest, string, uint64) ([]byte, []byte, error) {
+				return []byte("not-json"), validResponse, nil
+			},
+			voteFalse:  false,
+			phaseEpoch: 10,
+			reqEpoch:   10,
+			wantErr:    true,
+		},
+		{
+			name: "malformed response with switch off errors",
+			fetch: func(context.Context, devshardpkg.ValidateRequest, string, uint64) ([]byte, []byte, error) {
+				return validPrompt, []byte("not-json"), nil
+			},
+			voteFalse:  false,
+			phaseEpoch: 10,
+			reqEpoch:   10,
+			wantErr:    true,
 		},
 		{
 			name:  "local ML 503 does not vote",

--- a/devshard/cmd/devshardd/session/validation_retry.go
+++ b/devshard/cmd/devshardd/session/validation_retry.go
@@ -42,7 +42,7 @@ const (
 )
 
 // ValidationRetryLoop scans for stale validation leases and re-runs validation for each
-// active in-memory session. A lease is stale when status = 'pending' and
+// active in-memory session. A lease is stale when status is pending/submitted and
 // claimed_at < now() - leaseTTL (default 30m). FOR UPDATE SKIP LOCKED in the
 // underlying query ensures concurrent instances each pick a different row.
 type ValidationRetryLoop struct {
@@ -168,8 +168,9 @@ func (r *ValidationRetryLoop) releaseOwnedLease(ctx context.Context, escrowID st
 
 // retryStaleValidation reconstructs a ValidateRequest from in-memory session state, runs
 // validation via the inner engine, submits the result to the host's mempool,
-// and marks the lease complete. Challenged inferences are released so the
-// hot path can publish MsgValidationVote.
+// and marks the lease submitted. Stale submitted leases remain retryable because
+// the mempool tx is not durable until it is applied as a diff. Challenged
+// inferences are released so the hot path can publish MsgValidationVote.
 func (r *ValidationRetryLoop) retryStaleValidation(ctx context.Context, escrowID string, inferenceID, epochID uint64) error {
 	acquiredAt := time.Now()
 	h, ok := r.manager.hostSnapshot(escrowID)
@@ -190,6 +191,22 @@ func (r *ValidationRetryLoop) retryStaleValidation(ctx context.Context, escrowID
 			"escrow", escrowID, "inference", inferenceID)
 		r.releaseOwnedLease(ctx, escrowID, inferenceID, epochID)
 		return nil
+	}
+
+	liveHost, isLiveHost := h.(*host.Host)
+	if isLiveHost {
+		if validationAlreadyAppliedByHost(liveHost, inferenceID) {
+			slog.Info("devshardd: validation retry: validation already applied, skipping",
+				"escrow", escrowID, "inference", inferenceID)
+			r.markLeaseResult(ctx, escrowID, inferenceID, epochID, storage.LeaseStatusSkipped)
+			return nil
+		}
+		if validationAlreadyInMempool(liveHost, inferenceID) {
+			slog.Info("devshardd: validation retry: validation already in mempool",
+				"escrow", escrowID, "inference", inferenceID)
+			r.markLeaseResult(ctx, escrowID, inferenceID, epochID, storage.LeaseStatusSubmitted)
+			return nil
+		}
 	}
 
 	result, err := r.inner.Validate(ctx, req)
@@ -215,12 +232,11 @@ func (r *ValidationRetryLoop) retryStaleValidation(ctx context.Context, escrowID
 		return nil
 	}
 
-	host, ok := h.(*host.Host)
-	if !ok {
+	if !isLiveHost {
 		r.releaseOwnedLease(ctx, escrowID, inferenceID, epochID)
 		return fmt.Errorf("submit to mempool: host snapshot is not *host.Host")
 	}
-	if err := submitValidationToMempool(host, req.InferenceID, result.Valid); err != nil {
+	if err := submitValidationToMempool(liveHost, req.InferenceID, result.Valid); err != nil {
 		r.releaseOwnedLease(ctx, escrowID, inferenceID, epochID)
 		return fmt.Errorf("submit to mempool: %w", err)
 	}
@@ -229,6 +245,36 @@ func (r *ValidationRetryLoop) retryStaleValidation(ctx context.Context, escrowID
 	slog.Info("devshardd: validation retry: validation submitted",
 		"escrow", escrowID, "inference", inferenceID, "valid", result.Valid)
 	return nil
+}
+
+func validationAlreadyAppliedByHost(h *host.Host, inferenceID uint64) bool {
+	st := h.SnapshotState()
+	rec, ok := st.Inferences[inferenceID]
+	if !ok {
+		return false
+	}
+	for slot := range h.SlotIDs() {
+		if rec.ValidatedBy.IsSet(slot) {
+			return true
+		}
+	}
+	return false
+}
+
+func validationAlreadyInMempool(h *host.Host, inferenceID uint64) bool {
+	for _, tx := range h.MempoolTxs() {
+		if v := tx.GetValidation(); v != nil && v.InferenceId == inferenceID {
+			if h.SlotIDs()[v.ValidatorSlot] {
+				return true
+			}
+		}
+		if v := tx.GetValidationVote(); v != nil && v.InferenceId == inferenceID {
+			if h.SlotIDs()[v.VoterSlot] {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // lookupValidateTarget reconstructs a ValidateRequest from the host's current

--- a/devshard/cmd/devshardd/session/validation_retry_test.go
+++ b/devshard/cmd/devshardd/session/validation_retry_test.go
@@ -370,6 +370,161 @@ func TestRetryStaleValidation_ValidateError_Releases(t *testing.T) {
 	require.Equal(t, []string{"escrow-1/7/3/addr"}, leases.releaseCalls)
 }
 
+func TestRetryStaleValidationsForEscrow_TransientErrorReleaseThenHotPathReacquireSubmits(t *testing.T) {
+	h := newFinishedRetryHost(t)
+	leases := storage.NewMemory()
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, leases, "escrow-1", 1, 3, "old-owner"))
+
+	validateCalls := 0
+	inner := &stubEngine{
+		validateFn: func(_ context.Context, _ devshardpkg.ValidateRequest) (*devshardpkg.ValidateResult, error) {
+			validateCalls++
+			if validateCalls == 1 {
+				return nil, errors.New("local ml 503")
+			}
+			return &devshardpkg.ValidateResult{Valid: true}, nil
+		},
+	}
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        inner,
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+
+	assert.Equal(t, 1, inner.calls)
+	require.False(t, ownsMemoryLease(ctx, t, leases, "escrow-1", 1, 3, "addr"),
+		"release deletes the stale row; retry must not immediately reacquire it")
+
+	won, err := leases.Acquire(ctx, "escrow-1", 1, 3, "hot-path")
+	require.NoError(t, err)
+	require.True(t, won, "hot path should be able to recreate the released lease")
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+
+	assert.Equal(t, 2, inner.calls)
+	owned, err := leases.OwnsPendingLease(ctx, "escrow-1", 1, 3, "addr")
+	require.NoError(t, err)
+	require.False(t, owned, "submitted lease must no longer be pending")
+
+	var found bool
+	for _, tx := range h.HostMempool().Txs() {
+		if v := tx.GetValidation(); v != nil && v.InferenceId == 1 {
+			found = true
+			assert.True(t, v.Valid)
+		}
+	}
+	require.True(t, found, "second retry should publish MsgValidation")
+}
+
+func TestRetryStaleValidation_OwnershipLostAfterValidate_DoesNotSubmit(t *testing.T) {
+	h := newFinishedRetryHost(t)
+	leases := &stubStaleLeaseStore{
+		ownsFn: func(_ context.Context, _ string, _, _ uint64, _ string) (bool, error) {
+			return false, nil
+		},
+	}
+	inner := &stubEngine{}
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        inner,
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     DefaultValidationLeaseTTL,
+	}
+
+	err := rl.retryStaleValidation(context.Background(), "escrow-1", 1, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 1, inner.calls)
+	require.Empty(t, leases.releaseCalls, "lost ownership means this instance no longer owns a row to release")
+	require.Empty(t, leases.setResultCalls, "lost ownership must not be marked submitted")
+	for _, tx := range h.HostMempool().Txs() {
+		require.Nil(t, tx.GetValidation(), "must not publish MsgValidation after ownership is lost")
+	}
+}
+
+func TestRetryStaleValidation_SetResultLeaseNotOwnedAfterSubmit_IsBenign(t *testing.T) {
+	h := newFinishedRetryHost(t)
+	leases := &stubStaleLeaseStore{
+		setResultFn: func(_ context.Context, _ string, _, _ uint64, _ storage.LeaseStatus, _ string) error {
+			return storage.ErrLeaseNotOwned
+		},
+	}
+	inner := &stubEngine{}
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        inner,
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     DefaultValidationLeaseTTL,
+	}
+
+	err := rl.retryStaleValidation(context.Background(), "escrow-1", 1, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 1, inner.calls)
+	require.Empty(t, leases.releaseCalls)
+	require.Equal(t, []string{"escrow-1/1/3/submitted"}, leases.setResultCalls)
+
+	var found bool
+	for _, tx := range h.HostMempool().Txs() {
+		if v := tx.GetValidation(); v != nil && v.InferenceId == 1 {
+			found = true
+			assert.True(t, v.Valid)
+		}
+	}
+	require.True(t, found, "mempool submit should remain successful when SetResult loses ownership")
+}
+
+func TestRetryStaleValidation_OwnsPendingLeaseErrorAfterValidate_Releases(t *testing.T) {
+	h := newFinishedRetryHost(t)
+	leases := &stubStaleLeaseStore{
+		ownsFn: func(_ context.Context, _ string, _, _ uint64, _ string) (bool, error) {
+			return false, errors.New("database unavailable")
+		},
+	}
+	inner := &stubEngine{}
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        inner,
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     DefaultValidationLeaseTTL,
+	}
+
+	err := rl.retryStaleValidation(context.Background(), "escrow-1", 1, 3)
+	require.ErrorContains(t, err, "owns pending lease")
+	assert.Equal(t, 1, inner.calls)
+	require.Equal(t, []string{"escrow-1/1/3/addr"}, leases.releaseCalls)
+	require.Empty(t, leases.setResultCalls)
+	for _, tx := range h.HostMempool().Txs() {
+		require.Nil(t, tx.GetValidation(), "must not publish MsgValidation when ownership check errors")
+	}
+}
+
+func acquireMemoryLease(ctx context.Context, store *storage.Memory, escrowID string, inferenceID, epochID uint64, instanceAddr string) error {
+	won, err := store.Acquire(ctx, escrowID, inferenceID, epochID, instanceAddr)
+	if err != nil {
+		return err
+	}
+	if !won {
+		return fmt.Errorf("memory lease was not acquired")
+	}
+	return nil
+}
+
+func ownsMemoryLease(ctx context.Context, t *testing.T, store *storage.Memory, escrowID string, inferenceID, epochID uint64, instanceAddr string) bool {
+	t.Helper()
+	owned, err := store.OwnsPendingLease(ctx, escrowID, inferenceID, epochID, instanceAddr)
+	require.NoError(t, err)
+	return owned
+}
+
 func TestRetryStaleValidation_TTLExceededAfterValidate_Releases(t *testing.T) {
 	leases := &stubStaleLeaseStore{}
 	inner := &stubEngine{}

--- a/devshard/cmd/devshardd/session/validation_retry_test.go
+++ b/devshard/cmd/devshardd/session/validation_retry_test.go
@@ -753,30 +753,14 @@ func TestRetryStaleValidation_MempoolValidationAppliesThroughPeerEndpoint(t *tes
 func TestRetryStaleValidation_LazyRecoveredManagerMempoolEndpoint(t *testing.T) {
 	const escrowID = "1"
 	store, hosts, user, group := newStoredFinishedRetrySession(t, escrowID)
-	addresses := make([]string, len(group))
-	for i, slot := range group {
-		addresses[i] = slot.ValidatorAddress
-	}
-	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), nil, nil, testutil.RuntimeTestVersion, &mockBridge{
-		escrow: &bridge.EscrowInfo{
-			EscrowID:       escrowID,
-			EpochID:        7,
-			Amount:         100000,
-			CreatorAddress: user.Address(),
-			Slots:          addresses,
-			TokenPrice:     1,
-		},
-	}, nil, nil)
+	mgr := newRetryHostManager(t, store, hosts[0], user, group, escrowID)
 	t.Cleanup(func() { require.NoError(t, mgr.Close()) })
 
 	e := echo.New()
 	mgr.Register(e.Group(""))
 	require.Empty(t, mgr.ActiveEscrowIDs(), "precondition: manager starts with no live sessions")
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/sessions/"+escrowID+"/mempool", nil)
-	e.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code, "lazy /mempool route must recover the stored session: %s", rec.Body.String())
+	_ = managerMempoolEndpointTxs(t, e, escrowID)
 	require.Equal(t, []string{escrowID}, mgr.ActiveEscrowIDs())
 
 	ctx := context.Background()
@@ -792,11 +776,7 @@ func TestRetryStaleValidation_LazyRecoveredManagerMempoolEndpoint(t *testing.T) 
 	time.Sleep(60 * time.Millisecond)
 	rl.retryStaleValidationsForEscrow(ctx, escrowID)
 
-	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/sessions/"+escrowID+"/mempool", nil)
-	e.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
-	txs := decodeMempoolResponse(t, rec)
+	txs := managerMempoolEndpointTxs(t, e, escrowID)
 
 	var found bool
 	for _, tx := range txs {
@@ -807,6 +787,144 @@ func TestRetryStaleValidation_LazyRecoveredManagerMempoolEndpoint(t *testing.T) 
 		}
 	}
 	require.True(t, found, "lazy manager /mempool must expose retry-produced MsgValidation")
+}
+
+func TestRetryStaleValidation_RestartedManagerReclaimsPendingLease(t *testing.T) {
+	const escrowID = "1"
+	store, hosts, user, group := newStoredFinishedRetrySession(t, escrowID)
+	first := newRetryHostManager(t, store, hosts[0], user, group, escrowID)
+	e1 := echo.New()
+	first.Register(e1.Group(""))
+	_ = managerMempoolEndpointTxs(t, e1, escrowID)
+
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, store, escrowID, 1, 7, "old-owner"))
+	require.NoError(t, first.Close())
+
+	restarted := newRetryHostManager(t, store, hosts[0], user, group, escrowID)
+	t.Cleanup(func() { require.NoError(t, restarted.Close()) })
+	e2 := echo.New()
+	restarted.Register(e2.Group(""))
+	_ = managerMempoolEndpointTxs(t, e2, escrowID)
+	require.Equal(t, []string{escrowID}, restarted.ActiveEscrowIDs())
+
+	rl := &ValidationRetryLoop{
+		leases:       store,
+		inner:        &stubEngine{},
+		manager:      restarted,
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, escrowID)
+
+	var found bool
+	for _, tx := range managerMempoolEndpointTxs(t, e2, escrowID) {
+		if v := tx.GetValidation(); v != nil && v.InferenceId == 1 {
+			found = true
+			require.True(t, v.Valid)
+			require.NotEmpty(t, v.ProposerSig)
+		}
+	}
+	require.True(t, found, "restarted manager must reclaim stale pending lease and expose MsgValidation")
+}
+
+func TestRetryStaleValidation_ObsoleteLeaseAfterLazyRecoveryStaysOutOfMempool(t *testing.T) {
+	const escrowID = "1"
+	store, hosts, user, group := newStoredFinishedRetrySession(t, escrowID)
+	mgr := newRetryHostManager(t, store, hosts[0], user, group, escrowID)
+	t.Cleanup(func() { require.NoError(t, mgr.Close()) })
+	e := echo.New()
+	mgr.Register(e.Group(""))
+	_ = managerMempoolEndpointTxs(t, e, escrowID)
+
+	validationMsg := &types.MsgValidation{
+		InferenceId:   1,
+		ValidatorSlot: 0,
+		Valid:         false,
+		EscrowId:      escrowID,
+	}
+	validationMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], validationMsg)
+	voteMsg := &types.MsgValidationVote{
+		InferenceId: 1,
+		VoterSlot:   1,
+		VoteValid:   false,
+		EscrowId:    escrowID,
+	}
+	voteMsg.ProposerSig = testutil.SignProposerTx(t, hosts[1], voteMsg)
+	terminalDiff := testutil.SignDiff(t, user, escrowID, 4, []*types.DevshardTx{
+		{Tx: &types.DevshardTx_Validation{Validation: validationMsg}},
+		{Tx: &types.DevshardTx_ValidationVote{ValidationVote: voteMsg}},
+	})
+	dj, err := transport.DiffToJSON(terminalDiff)
+	require.NoError(t, err)
+	body, err := json.Marshal(transport.InferenceRequest{Diffs: []transport.DiffJSON{dj}})
+	require.NoError(t, err)
+	rec := signedPOST(t, e, user, "/sessions/"+escrowID+"/chat/completions", escrowID, body)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	h, ok := mgr.hostSnapshot(escrowID)
+	require.True(t, ok)
+	require.Equal(t, types.StatusInvalidated, h.SnapshotState().Inferences[1].Status)
+
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, store, escrowID, 1, 7, "old-owner"))
+	rl := &ValidationRetryLoop{
+		leases:       store,
+		inner:        &stubEngine{},
+		manager:      mgr,
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, escrowID)
+
+	owned, err := store.OwnsPendingLease(ctx, escrowID, 1, 7, "addr")
+	require.NoError(t, err)
+	require.False(t, owned, "obsolete stale lease must be moved out of pending")
+	for _, tx := range managerMempoolEndpointTxs(t, e, escrowID) {
+		require.Nil(t, tx.GetValidation(), "obsolete retry must not publish MsgValidation through manager route")
+	}
+}
+
+func TestRetryStaleValidation_MempoolTxNotDurableAcrossManagerRestart(t *testing.T) {
+	const escrowID = "1"
+	store, hosts, user, group := newStoredFinishedRetrySession(t, escrowID)
+	first := newRetryHostManager(t, store, hosts[0], user, group, escrowID)
+	e1 := echo.New()
+	first.Register(e1.Group(""))
+	_ = managerMempoolEndpointTxs(t, e1, escrowID)
+
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, store, escrowID, 1, 7, "old-owner"))
+	rl := &ValidationRetryLoop{
+		leases:       store,
+		inner:        &stubEngine{},
+		manager:      first,
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, escrowID)
+	require.True(t, hasValidationTx(managerMempoolEndpointTxs(t, e1, escrowID), 1),
+		"precondition: retry produced a local mempool validation before restart")
+	require.NoError(t, first.Close())
+
+	restarted := newRetryHostManager(t, store, hosts[0], user, group, escrowID)
+	t.Cleanup(func() { require.NoError(t, restarted.Close()) })
+	e2 := echo.New()
+	restarted.Register(e2.Group(""))
+
+	require.False(t, hasValidationTx(managerMempoolEndpointTxs(t, e2, escrowID), 1),
+		"retry-produced mempool tx must not be durable unless applied as a diff")
+	h, ok := restarted.hostSnapshot(escrowID)
+	require.True(t, ok)
+	rec := h.SnapshotState().Inferences[1]
+	require.Equal(t, types.StatusFinished, rec.Status)
+	require.False(t, rec.ValidatedBy.IsSet(group[0].SlotID))
 }
 
 func mempoolEndpointTxs(t *testing.T, h *host.Host) []*types.DevshardTx {
@@ -825,6 +943,15 @@ func mempoolEndpointTxs(t *testing.T, h *host.Host) []*types.DevshardTx {
 	return decodeMempoolResponse(t, rec)
 }
 
+func managerMempoolEndpointTxs(t *testing.T, e *echo.Echo, escrowID string) []*types.DevshardTx {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sessions/"+escrowID+"/mempool", nil)
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	return decodeMempoolResponse(t, rec)
+}
+
 func decodeMempoolResponse(t *testing.T, rec *httptest.ResponseRecorder) []*types.DevshardTx {
 	t.Helper()
 	var body struct {
@@ -834,6 +961,33 @@ func decodeMempoolResponse(t *testing.T, rec *httptest.ResponseRecorder) []*type
 	txs, err := transport.DevshardTxsFromBytes(body.Txs)
 	require.NoError(t, err)
 	return txs
+}
+
+func hasValidationTx(txs []*types.DevshardTx, inferenceID uint64) bool {
+	for _, tx := range txs {
+		if v := tx.GetValidation(); v != nil && v.InferenceId == inferenceID {
+			return true
+		}
+	}
+	return false
+}
+
+func newRetryHostManager(t *testing.T, store storage.Storage, signer *signing.Secp256k1Signer, user *signing.Secp256k1Signer, group []types.SlotAssignment, escrowID string) *HostManager {
+	t.Helper()
+	addresses := make([]string, len(group))
+	for i, slot := range group {
+		addresses[i] = slot.ValidatorAddress
+	}
+	return NewHostManager(store, signer, stub.NewInferenceEngine(), nil, nil, testutil.RuntimeTestVersion, &mockBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       escrowID,
+			EpochID:        7,
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+			TokenPrice:     1,
+		},
+	}, nil, nil)
 }
 
 func newStoredFinishedRetrySession(t *testing.T, escrowID string) (*storage.Memory, []*signing.Secp256k1Signer, *signing.Secp256k1Signer, []types.SlotAssignment) {

--- a/devshard/cmd/devshardd/session/validation_retry_test.go
+++ b/devshard/cmd/devshardd/session/validation_retry_test.go
@@ -429,6 +429,70 @@ func TestRetryStaleValidationsForEscrow_TransientErrorReleaseThenHotPathReacquir
 	require.True(t, found, "second retry should publish MsgValidation")
 }
 
+func TestRetryStaleValidationsForEscrow_StaleSubmittedWithLocalMempoolDoesNotRevalidate(t *testing.T) {
+	h := newFinishedRetryHost(t)
+	leases := storage.NewMemory()
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, leases, "escrow-1", 1, 3, "old-owner"))
+
+	inner := &stubEngine{}
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        inner,
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+	require.Equal(t, 1, inner.calls)
+	require.True(t, hasValidationTx(h.MempoolTxs(), 1))
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+
+	require.Equal(t, 1, inner.calls, "local mempool already has the submitted validation")
+	require.True(t, hasValidationTx(h.MempoolTxs(), 1))
+}
+
+func TestRetryStaleValidationsForEscrow_StaleSubmittedAlreadyAppliedDoesNotRepublish(t *testing.T) {
+	h, hosts, user := newFinishedRetryHostWithSigners(t)
+	ctx := context.Background()
+	validatorSlot := h.PrimarySlot()
+	validationMsg := &types.MsgValidation{
+		InferenceId:   1,
+		ValidatorSlot: validatorSlot,
+		Valid:         true,
+		EscrowId:      "escrow-1",
+	}
+	validationMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], validationMsg)
+	validationDiff := testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{
+		{Tx: &types.DevshardTx_Validation{Validation: validationMsg}},
+	})
+	_, err := h.HandleRequest(ctx, host.HostRequest{Diffs: []types.Diff{validationDiff}})
+	require.NoError(t, err)
+	require.True(t, h.SnapshotState().Inferences[1].ValidatedBy.IsSet(validatorSlot))
+
+	leases := storage.NewMemory()
+	require.NoError(t, acquireMemoryLease(ctx, leases, "escrow-1", 1, 3, "old-owner"))
+	require.NoError(t, leases.SetResult(ctx, "escrow-1", 1, 3, storage.LeaseStatusSubmitted, "old-owner"))
+	inner := &stubEngine{}
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        inner,
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+
+	require.Equal(t, 0, inner.calls, "durably applied validation must not be revalidated")
+	require.False(t, hasValidationTx(h.MempoolTxs(), 1))
+}
+
 func TestRetryStaleValidation_OwnershipLostAfterValidate_DoesNotSubmit(t *testing.T) {
 	h := newFinishedRetryHost(t)
 	leases := &stubStaleLeaseStore{
@@ -889,7 +953,7 @@ func TestRetryStaleValidation_ObsoleteLeaseAfterLazyRecoveryStaysOutOfMempool(t 
 	}
 }
 
-func TestRetryStaleValidation_MempoolTxNotDurableAcrossManagerRestart(t *testing.T) {
+func TestRetryStaleValidation_SubmittedMempoolLossRepublishesAfterManagerRestart(t *testing.T) {
 	const escrowID = "1"
 	store, hosts, user, group := newStoredFinishedRetrySession(t, escrowID)
 	first := newRetryHostManager(t, store, hosts[0], user, group, escrowID)
@@ -925,6 +989,19 @@ func TestRetryStaleValidation_MempoolTxNotDurableAcrossManagerRestart(t *testing
 	rec := h.SnapshotState().Inferences[1]
 	require.Equal(t, types.StatusFinished, rec.Status)
 	require.False(t, rec.ValidatedBy.IsSet(group[0].SlotID))
+
+	rl = &ValidationRetryLoop{
+		leases:       store,
+		inner:        &stubEngine{},
+		manager:      restarted,
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, escrowID)
+
+	require.True(t, hasValidationTx(managerMempoolEndpointTxs(t, e2, escrowID), 1),
+		"stale submitted lease must be retryable when the previous mempool tx was lost before diff apply")
 }
 
 func mempoolEndpointTxs(t *testing.T, h *host.Host) []*types.DevshardTx {

--- a/devshard/cmd/devshardd/session/validation_retry_test.go
+++ b/devshard/cmd/devshardd/session/validation_retry_test.go
@@ -897,46 +897,29 @@ func TestRetryStaleValidation_RestartedManagerReclaimsPendingLease(t *testing.T)
 func TestRetryStaleValidation_ObsoleteLeaseAfterLazyRecoveryStaysOutOfMempool(t *testing.T) {
 	const escrowID = "1"
 	store, hosts, user, group := newStoredFinishedRetrySession(t, escrowID)
+	appendTerminalInvalidationDiffToStore(t, store, escrowID, hosts, user)
+
 	mgr := newRetryHostManager(t, store, hosts[0], user, group, escrowID)
 	t.Cleanup(func() { require.NoError(t, mgr.Close()) })
 	e := echo.New()
 	mgr.Register(e.Group(""))
+	require.Empty(t, mgr.ActiveEscrowIDs(), "precondition: manager starts with no live sessions")
+
 	_ = managerMempoolEndpointTxs(t, e, escrowID)
+	require.Equal(t, []string{escrowID}, mgr.ActiveEscrowIDs())
 
-	validationMsg := &types.MsgValidation{
-		InferenceId:   1,
-		ValidatorSlot: 0,
-		Valid:         false,
-		EscrowId:      escrowID,
-	}
-	validationMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], validationMsg)
-	voteMsg := &types.MsgValidationVote{
-		InferenceId: 1,
-		VoterSlot:   1,
-		VoteValid:   false,
-		EscrowId:    escrowID,
-	}
-	voteMsg.ProposerSig = testutil.SignProposerTx(t, hosts[1], voteMsg)
-	terminalDiff := testutil.SignDiff(t, user, escrowID, 4, []*types.DevshardTx{
-		{Tx: &types.DevshardTx_Validation{Validation: validationMsg}},
-		{Tx: &types.DevshardTx_ValidationVote{ValidationVote: voteMsg}},
-	})
-	dj, err := transport.DiffToJSON(terminalDiff)
-	require.NoError(t, err)
-	body, err := json.Marshal(transport.InferenceRequest{Diffs: []transport.DiffJSON{dj}})
-	require.NoError(t, err)
-	rec := signedPOST(t, e, user, "/sessions/"+escrowID+"/chat/completions", escrowID, body)
-	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
-
+	require.False(t, hasValidationTx(managerMempoolEndpointTxs(t, e, escrowID), 1),
+		"lazy recovery must not synthesize a validation mempool tx for terminal persisted state")
 	h, ok := mgr.hostSnapshot(escrowID)
 	require.True(t, ok)
 	require.Equal(t, types.StatusInvalidated, h.SnapshotState().Inferences[1].Status)
 
 	ctx := context.Background()
 	require.NoError(t, acquireMemoryLease(ctx, store, escrowID, 1, 7, "old-owner"))
+	inner := &stubEngine{}
 	rl := &ValidationRetryLoop{
 		leases:       store,
-		inner:        &stubEngine{},
+		inner:        inner,
 		manager:      mgr,
 		instanceAddr: "addr",
 		leaseTTL:     50 * time.Millisecond,
@@ -945,6 +928,7 @@ func TestRetryStaleValidation_ObsoleteLeaseAfterLazyRecoveryStaysOutOfMempool(t 
 	time.Sleep(60 * time.Millisecond)
 	rl.retryStaleValidationsForEscrow(ctx, escrowID)
 
+	require.Equal(t, 0, inner.calls, "retry must observe recovered terminal state before validation")
 	owned, err := store.OwnsPendingLease(ctx, escrowID, 1, 7, "addr")
 	require.NoError(t, err)
 	require.False(t, owned, "obsolete stale lease must be moved out of pending")
@@ -1092,6 +1076,67 @@ func newStoredFinishedRetrySession(t *testing.T, escrowID string) (*storage.Memo
 		require.NoError(t, store.AppendDiff(escrowID, types.DiffRecord{Diff: signed, StateHash: root}))
 	}
 	return store, hosts, user, group
+}
+
+func appendTerminalInvalidationDiffToStore(t *testing.T, store storage.Storage, escrowID string, hosts []*signing.Secp256k1Signer, user *signing.Secp256k1Signer) {
+	t.Helper()
+	require.Len(t, hosts, 2)
+
+	meta, err := store.GetSessionMeta(escrowID)
+	require.NoError(t, err)
+	require.Len(t, meta.Group, 2)
+
+	version := meta.Version
+	if version == "" {
+		version = testutil.RuntimeTestVersion
+	}
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine(
+		escrowID,
+		meta.Config,
+		meta.Group,
+		meta.InitialBalance,
+		meta.CreatorAddr,
+		verifier,
+		store,
+		state.WithVersion(version),
+	)
+	require.NoError(t, err)
+	if meta.LatestNonce > 0 {
+		records, err := store.GetDiffs(escrowID, 1, meta.LatestNonce)
+		require.NoError(t, err)
+		for _, rec := range records {
+			sm.InjectWarmKeys(rec.WarmKeyDelta)
+			_, err := sm.ApplyLocal(rec.Nonce, rec.Txs)
+			require.NoError(t, err)
+		}
+	}
+
+	validationMsg := &types.MsgValidation{
+		InferenceId:   1,
+		ValidatorSlot: meta.Group[0].SlotID,
+		Valid:         false,
+		EscrowId:      escrowID,
+	}
+	validationMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], validationMsg)
+	voteMsg := &types.MsgValidationVote{
+		InferenceId: 1,
+		VoterSlot:   meta.Group[1].SlotID,
+		VoteValid:   false,
+		EscrowId:    escrowID,
+	}
+	voteMsg.ProposerSig = testutil.SignProposerTx(t, hosts[1], voteMsg)
+	txs := []*types.DevshardTx{
+		{Tx: &types.DevshardTx_Validation{Validation: validationMsg}},
+		{Tx: &types.DevshardTx_ValidationVote{ValidationVote: voteMsg}},
+	}
+	nonce := sm.SnapshotState().LatestNonce + 1
+	root, err := sm.ApplyLocal(nonce, txs)
+	require.NoError(t, err)
+	require.Equal(t, types.StatusInvalidated, sm.SnapshotState().Inferences[1].Status)
+
+	signed := testutil.SignDiffWithRoot(t, user, escrowID, nonce, txs, root)
+	require.NoError(t, store.AppendDiff(escrowID, types.DiffRecord{Diff: signed, StateHash: root}))
 }
 
 func newFinishedRetryHost(t *testing.T) *host.Host {

--- a/devshard/cmd/devshardd/session/validation_retry_test.go
+++ b/devshard/cmd/devshardd/session/validation_retry_test.go
@@ -2,22 +2,28 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"common/chain"
 	devshardpkg "devshard"
+	"devshard/bridge"
 	"devshard/host"
 	"devshard/internal/testutil"
 	"devshard/signing"
 	"devshard/state"
 	"devshard/storage"
 	"devshard/stub"
+	"devshard/transport"
 	"devshard/types"
 )
 
@@ -582,31 +588,308 @@ func TestRetryStaleValidation_Finished_SubmitsInline(t *testing.T) {
 	require.True(t, found, "MsgValidation should be in mempool")
 }
 
+func TestRetryStaleValidation_ReclaimedValidationAppearsInMempoolEndpoint(t *testing.T) {
+	h := newFinishedRetryHost(t)
+	leases := storage.NewMemory()
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, leases, "escrow-1", 1, 3, "old-owner"))
+
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        &stubEngine{},
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+
+	txs := mempoolEndpointTxs(t, h)
+
+	var found bool
+	for _, tx := range txs {
+		if v := tx.GetValidation(); v != nil && v.InferenceId == 1 {
+			found = true
+			require.True(t, v.Valid)
+			require.NotEmpty(t, v.ProposerSig)
+		}
+	}
+	require.True(t, found, "reclaimed retry validation must be visible through /mempool")
+}
+
+func TestRetryStaleValidation_TerminalInferenceDoesNotAppearInMempoolEndpoint(t *testing.T) {
+	h, hosts, user := newFinishedRetryHostWithSigners(t)
+	validationMsg := &types.MsgValidation{
+		InferenceId:   1,
+		ValidatorSlot: 0,
+		Valid:         false,
+		EscrowId:      "escrow-1",
+	}
+	validationMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], validationMsg)
+	voteMsg := &types.MsgValidationVote{
+		InferenceId: 1,
+		VoterSlot:   1,
+		VoteValid:   false,
+		EscrowId:    "escrow-1",
+	}
+	voteMsg.ProposerSig = testutil.SignProposerTx(t, hosts[1], voteMsg)
+	validationDiff := testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{
+		{Tx: &types.DevshardTx_Validation{Validation: validationMsg}},
+		{Tx: &types.DevshardTx_ValidationVote{ValidationVote: voteMsg}},
+	})
+	_, err := h.HandleRequest(context.Background(), host.HostRequest{Diffs: []types.Diff{validationDiff}})
+	require.NoError(t, err)
+	require.Equal(t, types.StatusInvalidated, h.SnapshotState().Inferences[1].Status)
+
+	leases := storage.NewMemory()
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, leases, "escrow-1", 1, 3, "old-owner"))
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        &stubEngine{},
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+
+	owned, err := leases.OwnsPendingLease(ctx, "escrow-1", 1, 3, "addr")
+	require.NoError(t, err)
+	require.False(t, owned, "terminal retry must mark the stale lease skipped")
+	for _, tx := range mempoolEndpointTxs(t, h) {
+		require.Nil(t, tx.GetValidation(), "terminal retry must not publish obsolete MsgValidation")
+	}
+}
+
+func TestRetryStaleValidation_ChallengedInferenceDoesNotAppearInMempoolEndpoint(t *testing.T) {
+	h, hosts, user := newFinishedRetryHostWithSigners(t)
+	validationMsg := &types.MsgValidation{
+		InferenceId:   1,
+		ValidatorSlot: 0,
+		Valid:         false,
+		EscrowId:      "escrow-1",
+	}
+	validationMsg.ProposerSig = testutil.SignProposerTx(t, hosts[0], validationMsg)
+	challengeDiff := testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{
+		{Tx: &types.DevshardTx_Validation{Validation: validationMsg}},
+	})
+	_, err := h.HandleRequest(context.Background(), host.HostRequest{Diffs: []types.Diff{challengeDiff}})
+	require.NoError(t, err)
+	require.Equal(t, types.StatusChallenged, h.SnapshotState().Inferences[1].Status)
+
+	leases := storage.NewMemory()
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, leases, "escrow-1", 1, 3, "old-owner"))
+	inner := &stubEngine{}
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        inner,
+		manager:      &stubSessionManager{snap: h},
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+
+	require.Equal(t, 0, inner.calls, "retry loop must leave challenged validation to the hot path")
+	owned, err := leases.OwnsPendingLease(ctx, "escrow-1", 1, 3, "addr")
+	require.NoError(t, err)
+	require.False(t, owned, "challenged retry must release the reclaimed lease")
+	for _, tx := range mempoolEndpointTxs(t, h) {
+		require.Nil(t, tx.GetValidation(), "challenged retry must not publish MsgValidation")
+	}
+}
+
+func TestRetryStaleValidation_MempoolValidationAppliesThroughPeerEndpoint(t *testing.T) {
+	producer, consumer, hosts, user := newFinishedRetryHostPair(t)
+	leases := storage.NewMemory()
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, leases, "escrow-1", 1, 3, "old-owner"))
+	rl := &ValidationRetryLoop{
+		leases:       leases,
+		inner:        &stubEngine{},
+		manager:      &stubSessionManager{snap: producer},
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, "escrow-1")
+
+	var validationTx *types.DevshardTx
+	for _, tx := range mempoolEndpointTxs(t, producer) {
+		if v := tx.GetValidation(); v != nil && v.InferenceId == 1 {
+			validationTx = tx
+			break
+		}
+	}
+	require.NotNil(t, validationTx, "producer /mempool must expose reclaimed validation")
+
+	validationDiff := testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{validationTx})
+	dj, err := transport.DiffToJSON(validationDiff)
+	require.NoError(t, err)
+	body, err := json.Marshal(transport.InferenceRequest{Diffs: []transport.DiffJSON{dj}})
+	require.NoError(t, err)
+
+	e := echo.New()
+	verifier := signing.NewSecp256k1Verifier()
+	store := storage.NewMemory()
+	srv, err := transport.NewServer(consumer, store, verifier, user.Address())
+	require.NoError(t, err)
+	e.POST("/sessions/:id/chat/completions", srv.AuthMiddleware(srv.HandleInference))
+	rec := signedPOST(t, e, user, "/sessions/escrow-1/chat/completions", "escrow-1", body)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	consumerRec := consumer.SnapshotState().Inferences[1]
+	require.Equal(t, types.StatusFinished, consumerRec.Status, "single valid vote records participation but does not exceed threshold")
+	require.True(t, consumerRec.ValidatedBy.IsSet(hosts[0].SlotID), "peer endpoint must apply validator participation")
+	require.Equal(t, uint32(1), consumerRec.VotesValid)
+}
+
+func TestRetryStaleValidation_LazyRecoveredManagerMempoolEndpoint(t *testing.T) {
+	const escrowID = "1"
+	store, hosts, user, group := newStoredFinishedRetrySession(t, escrowID)
+	addresses := make([]string, len(group))
+	for i, slot := range group {
+		addresses[i] = slot.ValidatorAddress
+	}
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), nil, nil, testutil.RuntimeTestVersion, &mockBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       escrowID,
+			EpochID:        7,
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+			TokenPrice:     1,
+		},
+	}, nil, nil)
+	t.Cleanup(func() { require.NoError(t, mgr.Close()) })
+
+	e := echo.New()
+	mgr.Register(e.Group(""))
+	require.Empty(t, mgr.ActiveEscrowIDs(), "precondition: manager starts with no live sessions")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sessions/"+escrowID+"/mempool", nil)
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "lazy /mempool route must recover the stored session: %s", rec.Body.String())
+	require.Equal(t, []string{escrowID}, mgr.ActiveEscrowIDs())
+
+	ctx := context.Background()
+	require.NoError(t, acquireMemoryLease(ctx, store, escrowID, 1, 7, "old-owner"))
+	rl := &ValidationRetryLoop{
+		leases:       store,
+		inner:        &stubEngine{},
+		manager:      mgr,
+		instanceAddr: "addr",
+		leaseTTL:     50 * time.Millisecond,
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	rl.retryStaleValidationsForEscrow(ctx, escrowID)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/sessions/"+escrowID+"/mempool", nil)
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	txs := decodeMempoolResponse(t, rec)
+
+	var found bool
+	for _, tx := range txs {
+		if v := tx.GetValidation(); v != nil && v.InferenceId == 1 {
+			found = true
+			require.True(t, v.Valid)
+			require.NotEmpty(t, v.ProposerSig)
+		}
+	}
+	require.True(t, found, "lazy manager /mempool must expose retry-produced MsgValidation")
+}
+
+func mempoolEndpointTxs(t *testing.T, h *host.Host) []*types.DevshardTx {
+	t.Helper()
+	store := storage.NewMemory()
+	verifier := signing.NewSecp256k1Verifier()
+	srv, err := transport.NewServer(h, store, verifier, "")
+	require.NoError(t, err)
+
+	e := echo.New()
+	e.GET("/sessions/:id/mempool", srv.HandleGetMempool)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sessions/escrow-1/mempool", nil)
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	return decodeMempoolResponse(t, rec)
+}
+
+func decodeMempoolResponse(t *testing.T, rec *httptest.ResponseRecorder) []*types.DevshardTx {
+	t.Helper()
+	var body struct {
+		Txs [][]byte `json:"txs"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	txs, err := transport.DevshardTxsFromBytes(body.Txs)
+	require.NoError(t, err)
+	return txs
+}
+
+func newStoredFinishedRetrySession(t *testing.T, escrowID string) (*storage.Memory, []*signing.Secp256k1Signer, *signing.Secp256k1Signer, []types.SlotAssignment) {
+	t.Helper()
+	hosts, user, group, diffs := newFinishedRetryFixtureForEscrow(t, escrowID)
+	store := storage.NewMemory()
+	config := retrySessionConfig()
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       escrowID,
+		EpochID:        7,
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine(escrowID, config, group, 100000, user.Address(), verifier, store, state.WithVersion(testutil.RuntimeTestVersion))
+	require.NoError(t, err)
+	for _, diff := range diffs {
+		root, err := sm.ApplyLocal(diff.Nonce, diff.Txs)
+		require.NoError(t, err)
+		signed := testutil.SignDiffWithRoot(t, user, escrowID, diff.Nonce, diff.Txs, root)
+		require.NoError(t, store.AppendDiff(escrowID, types.DiffRecord{Diff: signed, StateHash: root}))
+	}
+	return store, hosts, user, group
+}
+
 func newFinishedRetryHost(t *testing.T) *host.Host {
+	t.Helper()
+	h, _, _ := newFinishedRetryHostWithSigners(t)
+	return h
+}
+
+func newFinishedRetryHostWithSigners(t *testing.T) (*host.Host, []*signing.Secp256k1Signer, *signing.Secp256k1Signer) {
+	t.Helper()
+	hosts, user, group, diffs := newFinishedRetryFixtureForEscrow(t, "escrow-1")
+	h := newRetryHostFromDiffs(t, hosts, user, group, diffs)
+	return h, hosts, user
+}
+
+func newFinishedRetryHostPair(t *testing.T) (*host.Host, *host.Host, []types.SlotAssignment, *signing.Secp256k1Signer) {
+	t.Helper()
+	hosts, user, group, diffs := newFinishedRetryFixtureForEscrow(t, "escrow-1")
+	return newRetryHostFromDiffs(t, hosts, user, group, diffs), newRetryHostFromDiffs(t, hosts, user, group, diffs), group, user
+}
+
+func newFinishedRetryFixtureForEscrow(t *testing.T, escrowID string) ([]*signing.Secp256k1Signer, *signing.Secp256k1Signer, []types.SlotAssignment, []types.Diff) {
 	t.Helper()
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	user := testutil.MustGenerateKey(t)
 	group := testutil.MakeGroup(hosts)
-	config := types.SessionConfig{
-		RefusalTimeout:   60,
-		ExecutionTimeout: 1200,
-		TokenPrice:       1,
-		VoteThreshold:    1,
-		ValidationRate:   10000,
-	}
-	verifier := signing.NewSecp256k1Verifier()
-	sm, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 100000))
-	require.NoError(t, err)
-
 	engine := stub.NewInferenceEngine()
-	h, err := host.NewHost(sm, hosts[0], engine, "escrow-1", group, nil)
-	require.NoError(t, err)
-
-	diff1 := testutil.SignDiff(t, user, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
-	_, err = h.HandleRequest(context.Background(), host.HostRequest{Diffs: []types.Diff{diff1}})
-	require.NoError(t, err)
-
-	execSig := testutil.SignExecutorReceipt(t, hosts[1], "escrow-1", 1, testutil.TestPromptHash[:], "llama", 100, 50, 1000, 2000)
+	diff1 := testutil.SignDiff(t, user, escrowID, 1, []*types.DevshardTx{testutil.StartTx(1)})
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], escrowID, 1, testutil.TestPromptHash[:], "llama", 100, 50, 1000, 2000)
 	confirmTx := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
 		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 2000,
 	}}}
@@ -616,13 +899,36 @@ func newFinishedRetryHost(t *testing.T) *host.Host {
 		InputTokens:  80,
 		OutputTokens: 40,
 		ExecutorSlot: 1,
-		EscrowId:     "escrow-1",
+		EscrowId:     escrowID,
 	}
 	finishMsg.ProposerSig = testutil.SignProposerTx(t, hosts[1], finishMsg)
 	finishTx := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: finishMsg}}
-	diff2 := testutil.SignDiff(t, user, "escrow-1", 2, []*types.DevshardTx{confirmTx})
-	diff3 := testutil.SignDiff(t, user, "escrow-1", 3, []*types.DevshardTx{finishTx})
-	_, err = h.HandleRequest(context.Background(), host.HostRequest{Diffs: []types.Diff{diff2, diff3}})
+	diff2 := testutil.SignDiff(t, user, escrowID, 2, []*types.DevshardTx{confirmTx})
+	diff3 := testutil.SignDiff(t, user, escrowID, 3, []*types.DevshardTx{finishTx})
+	return hosts, user, group, []types.Diff{diff1, diff2, diff3}
+}
+
+func newRetryHostFromDiffs(t *testing.T, hosts []*signing.Secp256k1Signer, user *signing.Secp256k1Signer, group []types.SlotAssignment, diffs []types.Diff) *host.Host {
+	t.Helper()
+	config := retrySessionConfig()
+	verifier := signing.NewSecp256k1Verifier()
+	sm, err := state.NewStateMachine("escrow-1", config, group, 100000, user.Address(), verifier, testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 100000))
+	require.NoError(t, err)
+
+	engine := stub.NewInferenceEngine()
+	h, err := host.NewHost(sm, hosts[0], engine, "escrow-1", group, nil)
+	require.NoError(t, err)
+	_, err = h.HandleRequest(context.Background(), host.HostRequest{Diffs: diffs})
 	require.NoError(t, err)
 	return h
+}
+
+func retrySessionConfig() types.SessionConfig {
+	return types.SessionConfig{
+		RefusalTimeout:   60,
+		ExecutionTimeout: 1200,
+		TokenPrice:       1,
+		VoteThreshold:    1,
+		ValidationRate:   10000,
+	}
 }

--- a/devshard/host/validation_release_test.go
+++ b/devshard/host/validation_release_test.go
@@ -322,6 +322,117 @@ func TestHost_ValidateAsync_ReleasesOnNonSubmitPaths(t *testing.T) {
 	}
 }
 
+func TestHost_ValidateAsync_ErrorReleaseCooldownThenRecollects(t *testing.T) {
+	rec := &recordingLeaseRecorder{}
+	validator := &scriptedValidationEngine{err: errors.New("local ml 503")}
+	h, hosts, user := newTwoHostValidationHost(t, validator)
+	h.validationRecorder = rec
+	applyInferenceTo(t, h, hosts, user, types.StatusFinished)
+
+	h.validationLifecycleMu.Lock()
+	h.validationQueue = make(chan validateJob, defaultValidationQueueSize)
+	h.validationLifecycleMu.Unlock()
+
+	h.validateAsync(context.Background(), testValidateJob())
+
+	_, _, release := rec.counts()
+	require.Equal(t, 1, release, "validation error must release the owned lease")
+	_, onCooldown := cooldownUntil(h, 1)
+	require.True(t, onCooldown, "validation error must stamp cooldown")
+
+	jobs := collectValidationJobsLocked(h)
+	for _, job := range jobs {
+		require.NotEqual(t, uint64(1), job.inferenceID, "cooldown must block immediate re-pick")
+	}
+
+	h.mu.Lock()
+	h.validationCooldown[1] = time.Now().Add(-time.Nanosecond)
+	delete(h.validating, 1)
+	h.mu.Unlock()
+
+	jobs = collectValidationJobsLocked(h)
+	var found bool
+	for _, job := range jobs {
+		if job.inferenceID == 1 {
+			found = true
+		}
+	}
+	require.True(t, found, "expired cooldown must allow the same inference to be collected again")
+	_, still := cooldownUntil(h, 1)
+	require.False(t, still, "expired cooldown entry must be cleared when the job is collected")
+}
+
+func TestHost_ValidateAsync_SubmitAbandonedLostOwnershipReleasesWithoutCooldown(t *testing.T) {
+	rec := &recordingLeaseRecorder{allowErr: devshard.ErrValidationLeaseAbandoned}
+	validator := &scriptedValidationEngine{result: &devshard.ValidateResult{Valid: true}}
+	h, hosts, user := newTwoHostValidationHost(t, validator)
+	h.validationRecorder = rec
+	applyInferenceTo(t, h, hosts, user, types.StatusFinished)
+
+	h.validateAsync(context.Background(), testValidateJob())
+
+	allow, mark, release := rec.counts()
+	require.Equal(t, 1, allow)
+	require.Equal(t, 0, mark)
+	require.Equal(t, 1, release, "lost ownership must release the local remembered lease")
+	require.False(t, mempoolHasValidation(h, 1), "abandoned submit must not publish validation")
+	_, onCooldown := cooldownUntil(h, 1)
+	require.False(t, onCooldown, "lost ownership should not throttle future collection")
+}
+
+func TestHost_ValidateAsync_SubmitAbandonedTTLExceededReleasesAndCooldowns(t *testing.T) {
+	rec := &recordingLeaseRecorder{
+		allowErr: fmt.Errorf("%w: %w", devshard.ErrValidationLeaseAbandoned, devshard.ErrValidationLeaseTTLExceeded),
+	}
+	validator := &scriptedValidationEngine{result: &devshard.ValidateResult{Valid: true}}
+	h, hosts, user := newTwoHostValidationHost(t, validator)
+	h.validationRecorder = rec
+	applyInferenceTo(t, h, hosts, user, types.StatusFinished)
+
+	h.validateAsync(context.Background(), testValidateJob())
+
+	allow, mark, release := rec.counts()
+	require.Equal(t, 1, allow)
+	require.Equal(t, 0, mark)
+	require.Equal(t, 1, release, "TTL abandonment must release the local remembered lease")
+	require.False(t, mempoolHasValidation(h, 1), "abandoned submit must not publish validation")
+	until, onCooldown := cooldownUntil(h, 1)
+	require.True(t, onCooldown, "TTL exceeded should throttle immediate recollection")
+	require.True(t, until.After(time.Now()), "cooldown must be in the future")
+	require.True(t, time.Until(until) <= validationCooldown)
+}
+
+func TestHost_ValidateAsync_AllowSubmitGenericErrorReleasesWithoutCooldown(t *testing.T) {
+	rec := &recordingLeaseRecorder{allowErr: errors.New("owns pending lease: database unavailable")}
+	validator := &scriptedValidationEngine{result: &devshard.ValidateResult{Valid: true}}
+	h, hosts, user := newTwoHostValidationHost(t, validator)
+	h.validationRecorder = rec
+	applyInferenceTo(t, h, hosts, user, types.StatusFinished)
+
+	h.validationLifecycleMu.Lock()
+	h.validationQueue = make(chan validateJob, defaultValidationQueueSize)
+	h.validationLifecycleMu.Unlock()
+
+	h.validateAsync(context.Background(), testValidateJob())
+
+	allow, mark, release := rec.counts()
+	require.Equal(t, 1, allow)
+	require.Equal(t, 0, mark)
+	require.Equal(t, 1, release, "submit gate errors must release the remembered lease")
+	require.False(t, mempoolHasValidation(h, 1), "submit gate errors must not publish validation")
+	_, onCooldown := cooldownUntil(h, 1)
+	require.False(t, onCooldown, "generic submit gate errors currently do not stamp cooldown")
+
+	jobs := collectValidationJobsLocked(h)
+	var found bool
+	for _, job := range jobs {
+		if job.inferenceID == 1 {
+			found = true
+		}
+	}
+	require.True(t, found, "without cooldown, the same inference is immediately collectible again")
+}
+
 func TestHost_ChallengedInferencePublishesValidationVote(t *testing.T) {
 	rec := &recordingLeaseRecorder{}
 	valEngine := &trackingValidationEngine{valid: true}
@@ -433,4 +544,24 @@ func TestHost_CollectValidationJobs_PrunesCooldownForEvictedInferences(t *testin
 	_ = collectValidationJobsLocked(h)
 	_, ok := cooldownUntil(h, 99)
 	require.False(t, ok, "cooldown for an inference no longer in the live set must be pruned")
+}
+
+func TestHost_CollectValidationJobs_QueueFullDoesNotAcquireOrCooldown(t *testing.T) {
+	h, hosts, user := newTwoHostValidationHost(t, stub.NewValidationEngine())
+	applyInferenceTo(t, h, hosts, user, types.StatusFinished)
+
+	h.validationLifecycleMu.Lock()
+	h.validationQueue = make(chan validateJob, 1)
+	h.validationQueue <- testValidateJob()
+	h.validationLifecycleMu.Unlock()
+
+	jobs := collectValidationJobsLocked(h)
+	require.Empty(t, jobs, "full validation queue must skip collection")
+
+	h.mu.Lock()
+	_, validating := h.validating[1]
+	_, onCooldown := h.validationCooldown[1]
+	h.mu.Unlock()
+	require.False(t, validating, "queue-full collection must not reserve the inference")
+	require.False(t, onCooldown, "queue-full collection must not stamp cooldown")
 }

--- a/devshard/storage/leases.go
+++ b/devshard/storage/leases.go
@@ -43,28 +43,32 @@ type LeaseStore interface {
 }
 
 type memoryLease struct {
-	epochID      uint64
 	instanceAddr string
 	claimedAt    time.Time
 	status       LeaseStatus
+}
+
+type memoryLeaseKey struct {
+	epochID     uint64
+	inferenceID uint64
 }
 
 func (m *Memory) Acquire(_ context.Context, escrowID string, inferenceID, epochID uint64, instanceAddr string) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.validationLeases == nil {
-		m.validationLeases = make(map[string]map[uint64]memoryLease)
+		m.validationLeases = make(map[string]map[memoryLeaseKey]memoryLease)
 	}
 	byInference := m.validationLeases[escrowID]
 	if byInference == nil {
-		byInference = make(map[uint64]memoryLease)
+		byInference = make(map[memoryLeaseKey]memoryLease)
 		m.validationLeases[escrowID] = byInference
 	}
-	if _, exists := byInference[inferenceID]; exists {
+	key := memoryLeaseKey{epochID: epochID, inferenceID: inferenceID}
+	if _, exists := byInference[key]; exists {
 		return false, nil
 	}
-	byInference[inferenceID] = memoryLease{
-		epochID:      epochID,
+	byInference[key] = memoryLease{
 		instanceAddr: instanceAddr,
 		claimedAt:    time.Now(),
 		status:       LeaseStatusPending,
@@ -81,28 +85,26 @@ func (m *Memory) AcquireOneStale(_ context.Context, escrowID, instanceAddr strin
 	}
 	cutoff := time.Now().Add(-ttl)
 	var (
-		foundID    uint64
-		foundEpoch uint64
-		found      bool
+		foundKey memoryLeaseKey
+		found    bool
 	)
-	for inferenceID, lease := range byInference {
+	for key, lease := range byInference {
 		if (lease.status != LeaseStatusPending && lease.status != LeaseStatusSubmitted) || !lease.claimedAt.Before(cutoff) {
 			continue
 		}
-		foundID = inferenceID
-		foundEpoch = lease.epochID
+		foundKey = key
 		found = true
 		break
 	}
 	if !found {
 		return 0, 0, nil
 	}
-	lease := byInference[foundID]
+	lease := byInference[foundKey]
 	lease.instanceAddr = instanceAddr
 	lease.claimedAt = time.Now()
 	lease.status = LeaseStatusPending
-	byInference[foundID] = lease
-	return foundID, foundEpoch, nil
+	byInference[foundKey] = lease
+	return foundKey.inferenceID, foundKey.epochID, nil
 }
 
 func (m *Memory) SetResult(_ context.Context, escrowID string, inferenceID, epochID uint64, status LeaseStatus, instanceAddr string) error {
@@ -112,13 +114,14 @@ func (m *Memory) SetResult(_ context.Context, escrowID string, inferenceID, epoc
 	if byInference == nil {
 		return ErrLeaseNotOwned
 	}
-	lease, ok := byInference[inferenceID]
-	if !ok || lease.status != LeaseStatusPending || lease.instanceAddr != instanceAddr || lease.epochID != epochID {
+	key := memoryLeaseKey{epochID: epochID, inferenceID: inferenceID}
+	lease, ok := byInference[key]
+	if !ok || lease.status != LeaseStatusPending || lease.instanceAddr != instanceAddr {
 		return ErrLeaseNotOwned
 	}
 	lease.status = status
 	lease.claimedAt = time.Now()
-	byInference[inferenceID] = lease
+	byInference[key] = lease
 	return nil
 }
 
@@ -129,11 +132,12 @@ func (m *Memory) OwnsPendingLease(_ context.Context, escrowID string, inferenceI
 	if byInference == nil {
 		return false, nil
 	}
-	lease, ok := byInference[inferenceID]
+	key := memoryLeaseKey{epochID: epochID, inferenceID: inferenceID}
+	lease, ok := byInference[key]
 	if !ok {
 		return false, nil
 	}
-	return lease.status == LeaseStatusPending && lease.instanceAddr == instanceAddr && lease.epochID == epochID, nil
+	return lease.status == LeaseStatusPending && lease.instanceAddr == instanceAddr, nil
 }
 
 func (m *Memory) Release(_ context.Context, escrowID string, inferenceID, epochID uint64, instanceAddr string) error {
@@ -143,11 +147,12 @@ func (m *Memory) Release(_ context.Context, escrowID string, inferenceID, epochI
 	if byInference == nil {
 		return nil
 	}
-	lease, ok := byInference[inferenceID]
-	if !ok || lease.status != LeaseStatusPending || lease.instanceAddr != instanceAddr || lease.epochID != epochID {
+	key := memoryLeaseKey{epochID: epochID, inferenceID: inferenceID}
+	lease, ok := byInference[key]
+	if !ok || lease.status != LeaseStatusPending || lease.instanceAddr != instanceAddr {
 		return nil
 	}
-	delete(byInference, inferenceID)
+	delete(byInference, key)
 	if len(byInference) == 0 {
 		delete(m.validationLeases, escrowID)
 	}
@@ -156,9 +161,9 @@ func (m *Memory) Release(_ context.Context, escrowID string, inferenceID, epochI
 
 func (m *Memory) pruneValidationLeasesBefore(cutoff uint64) {
 	for escrowID, byInference := range m.validationLeases {
-		for inferenceID, lease := range byInference {
-			if lease.epochID < cutoff {
-				delete(byInference, inferenceID)
+		for key := range byInference {
+			if key.epochID < cutoff {
+				delete(byInference, key)
 			}
 		}
 		if len(byInference) == 0 {

--- a/devshard/storage/leases.go
+++ b/devshard/storage/leases.go
@@ -26,6 +26,9 @@ var ErrLeaseNotOwned = errors.New("validation lease not owned or not pending")
 // LeaseStore deduplicates validation work across devshardd instances.
 type LeaseStore interface {
 	Acquire(ctx context.Context, escrowID string, inferenceID, epochID uint64, instanceAddr string) (bool, error)
+	// AcquireOneStale claims a pending or submitted lease whose claimed_at is
+	// older than ttl. Submitted leases are retryable because the corresponding
+	// validation tx may have lived only in a volatile mempool.
 	AcquireOneStale(ctx context.Context, escrowID, instanceAddr string, ttl time.Duration) (uint64, uint64, error)
 	// SetResult updates status only when instanceAddr still owns a pending lease
 	// in epochID. epochID is part of the primary key and the partition key.
@@ -83,7 +86,7 @@ func (m *Memory) AcquireOneStale(_ context.Context, escrowID, instanceAddr strin
 		found      bool
 	)
 	for inferenceID, lease := range byInference {
-		if lease.status != LeaseStatusPending || !lease.claimedAt.Before(cutoff) {
+		if (lease.status != LeaseStatusPending && lease.status != LeaseStatusSubmitted) || !lease.claimedAt.Before(cutoff) {
 			continue
 		}
 		foundID = inferenceID
@@ -97,6 +100,7 @@ func (m *Memory) AcquireOneStale(_ context.Context, escrowID, instanceAddr strin
 	lease := byInference[foundID]
 	lease.instanceAddr = instanceAddr
 	lease.claimedAt = time.Now()
+	lease.status = LeaseStatusPending
 	byInference[foundID] = lease
 	return foundID, foundEpoch, nil
 }
@@ -113,6 +117,7 @@ func (m *Memory) SetResult(_ context.Context, escrowID string, inferenceID, epoc
 		return ErrLeaseNotOwned
 	}
 	lease.status = status
+	lease.claimedAt = time.Now()
 	byInference[inferenceID] = lease
 	return nil
 }
@@ -221,13 +226,13 @@ func (s *Postgres) AcquireOneStale(ctx context.Context, escrowID, instanceAddr s
 		     SELECT epoch_id, escrow_id, inference_id
 		     FROM devshard_validation_leases
 		     WHERE escrow_id = $2
-		       AND status = 'pending'
+		       AND status IN ('pending', 'submitted')
 		       AND claimed_at < now() - make_interval(secs => $3)
 		     LIMIT 1
 		     FOR UPDATE SKIP LOCKED
 		 )
 		 UPDATE devshard_validation_leases v
-		 SET instance_address = $1, claimed_at = now()
+		 SET instance_address = $1, claimed_at = now(), status = 'pending'
 		 FROM candidate
 		 WHERE v.epoch_id = candidate.epoch_id
 		   AND v.escrow_id = candidate.escrow_id
@@ -249,7 +254,7 @@ func (s *Postgres) SetResult(ctx context.Context, escrowID string, inferenceID, 
 		return err
 	}
 	tag, err := s.pool.Exec(ctx,
-		`UPDATE devshard_validation_leases SET status = $1
+		`UPDATE devshard_validation_leases SET status = $1, claimed_at = now()
 		 WHERE epoch_id = $2 AND escrow_id = $3 AND inference_id = $4
 		   AND instance_address = $5 AND status = 'pending'`,
 		status, epochID, escrowID, inferenceID, instanceAddr,

--- a/devshard/storage/leases_test.go
+++ b/devshard/storage/leases_test.go
@@ -69,6 +69,31 @@ func TestMemoryLease_AcquireOneStale_PicksStale(t *testing.T) {
 	require.Equal(t, uint64(10), epochID)
 }
 
+func TestMemoryLease_AcquireOneStale_PicksStaleSubmitted(t *testing.T) {
+	store := NewMemory()
+	ctx := context.Background()
+
+	won, err := store.Acquire(ctx, "escrow-submitted", 1, 10, "instance-1")
+	require.NoError(t, err)
+	require.True(t, won)
+	require.NoError(t, store.SetResult(ctx, "escrow-submitted", 1, 10, LeaseStatusSubmitted, "instance-1"))
+
+	store.mu.Lock()
+	lease := store.validationLeases["escrow-submitted"][1]
+	lease.claimedAt = time.Now().Add(-time.Hour)
+	store.validationLeases["escrow-submitted"][1] = lease
+	store.mu.Unlock()
+
+	inferenceID, epochID, err := store.AcquireOneStale(ctx, "escrow-submitted", "instance-2", 30*time.Minute)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), inferenceID)
+	require.Equal(t, uint64(10), epochID)
+
+	owned, err := store.OwnsPendingLease(ctx, "escrow-submitted", 1, 10, "instance-2")
+	require.NoError(t, err)
+	require.True(t, owned)
+}
+
 func TestMemoryLease_SetResult_RequiresOwner(t *testing.T) {
 	store := NewMemory()
 	ctx := context.Background()
@@ -167,6 +192,32 @@ func TestMemoryLease_Release(t *testing.T) {
 
 func TestPostgresLease_Release(t *testing.T) {
 	runLeaseReleaseTests(t, newTestPostgres(t))
+}
+
+func TestPostgresLease_AcquireOneStale_PicksStaleSubmitted(t *testing.T) {
+	store := newTestPostgres(t)
+	ctx := context.Background()
+
+	won, err := store.Acquire(ctx, "escrow-submitted", 1, 10, "instance-1")
+	require.NoError(t, err)
+	require.True(t, won)
+	require.NoError(t, store.SetResult(ctx, "escrow-submitted", 1, 10, LeaseStatusSubmitted, "instance-1"))
+	_, err = store.pool.Exec(ctx,
+		`UPDATE devshard_validation_leases
+		 SET claimed_at = now() - interval '1 hour'
+		 WHERE epoch_id = $1 AND escrow_id = $2 AND inference_id = $3`,
+		uint64(10), "escrow-submitted", uint64(1),
+	)
+	require.NoError(t, err)
+
+	inferenceID, epochID, err := store.AcquireOneStale(ctx, "escrow-submitted", "instance-2", 30*time.Minute)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), inferenceID)
+	require.Equal(t, uint64(10), epochID)
+
+	owned, err := store.OwnsPendingLease(ctx, "escrow-submitted", 1, 10, "instance-2")
+	require.NoError(t, err)
+	require.True(t, owned)
 }
 
 func runLeaseReleaseTests(t *testing.T, store LeaseStore) {

--- a/devshard/storage/leases_test.go
+++ b/devshard/storage/leases_test.go
@@ -50,18 +50,47 @@ func TestMemoryLease_Acquire_ConcurrentSingleWinner(t *testing.T) {
 	require.Equal(t, 1, winCount)
 }
 
+func TestMemoryLease_Acquire_AllowsSameInferenceDifferentEpoch(t *testing.T) {
+	runLeaseEpochIdentityTests(t, NewMemory())
+}
+
+func TestPostgresLease_Acquire_AllowsSameInferenceDifferentEpoch(t *testing.T) {
+	runLeaseEpochIdentityTests(t, newTestPostgres(t))
+}
+
+func runLeaseEpochIdentityTests(t *testing.T, store LeaseStore) {
+	t.Helper()
+	ctx := context.Background()
+
+	won, err := store.Acquire(ctx, "escrow-identity", 1, 10, "instance-1")
+	require.NoError(t, err)
+	require.True(t, won)
+
+	won, err = store.Acquire(ctx, "escrow-identity", 1, 11, "instance-1")
+	require.NoError(t, err)
+	require.True(t, won, "same escrow/inference in a different epoch must be a distinct lease")
+
+	won, err = store.Acquire(ctx, "escrow-identity", 1, 10, "instance-2")
+	require.NoError(t, err)
+	require.False(t, won, "same epoch/escrow/inference must still deduplicate")
+
+	owned, err := store.OwnsPendingLease(ctx, "escrow-identity", 1, 10, "instance-1")
+	require.NoError(t, err)
+	require.True(t, owned)
+
+	require.NoError(t, store.Release(ctx, "escrow-identity", 1, 10, "instance-1"))
+	owned, err = store.OwnsPendingLease(ctx, "escrow-identity", 1, 11, "instance-1")
+	require.NoError(t, err)
+	require.True(t, owned, "releasing one epoch must not release another")
+}
+
 func TestMemoryLease_AcquireOneStale_PicksStale(t *testing.T) {
 	store := NewMemory()
 	ctx := context.Background()
 
 	_, err := store.Acquire(ctx, "escrow-1", 1, 10, "instance-1")
 	require.NoError(t, err)
-
-	store.mu.Lock()
-	lease := store.validationLeases["escrow-1"][1]
-	lease.claimedAt = time.Now().Add(-time.Hour)
-	store.validationLeases["escrow-1"][1] = lease
-	store.mu.Unlock()
+	ageMemoryLease(t, store, "escrow-1", 1, 10, time.Hour)
 
 	inferenceID, epochID, err := store.AcquireOneStale(ctx, "escrow-1", "instance-2", 30*time.Minute)
 	require.NoError(t, err)
@@ -77,12 +106,7 @@ func TestMemoryLease_AcquireOneStale_PicksStaleSubmitted(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, won)
 	require.NoError(t, store.SetResult(ctx, "escrow-submitted", 1, 10, LeaseStatusSubmitted, "instance-1"))
-
-	store.mu.Lock()
-	lease := store.validationLeases["escrow-submitted"][1]
-	lease.claimedAt = time.Now().Add(-time.Hour)
-	store.validationLeases["escrow-submitted"][1] = lease
-	store.mu.Unlock()
+	ageMemoryLease(t, store, "escrow-submitted", 1, 10, time.Hour)
 
 	inferenceID, epochID, err := store.AcquireOneStale(ctx, "escrow-submitted", "instance-2", 30*time.Minute)
 	require.NoError(t, err)
@@ -120,12 +144,7 @@ func TestMemoryLease_SetResult_RejectsAfterStaleSteal(t *testing.T) {
 
 	_, err := store.Acquire(ctx, "escrow-1", 1, 10, "instance-1")
 	require.NoError(t, err)
-
-	store.mu.Lock()
-	lease := store.validationLeases["escrow-1"][1]
-	lease.claimedAt = time.Now().Add(-time.Hour)
-	store.validationLeases["escrow-1"][1] = lease
-	store.mu.Unlock()
+	ageMemoryLease(t, store, "escrow-1", 1, 10, time.Hour)
 
 	_, _, err = store.AcquireOneStale(ctx, "escrow-1", "instance-2", 30*time.Minute)
 	require.NoError(t, err)
@@ -133,6 +152,17 @@ func TestMemoryLease_SetResult_RejectsAfterStaleSteal(t *testing.T) {
 	err = store.SetResult(ctx, "escrow-1", 1, 10, LeaseStatusSubmitted, "instance-1")
 	require.ErrorIs(t, err, ErrLeaseNotOwned)
 	require.NoError(t, store.SetResult(ctx, "escrow-1", 1, 10, LeaseStatusSubmitted, "instance-2"))
+}
+
+func ageMemoryLease(t *testing.T, store *Memory, escrowID string, inferenceID, epochID uint64, age time.Duration) {
+	t.Helper()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	key := memoryLeaseKey{epochID: epochID, inferenceID: inferenceID}
+	lease, ok := store.validationLeases[escrowID][key]
+	require.True(t, ok)
+	lease.claimedAt = time.Now().Add(-age)
+	store.validationLeases[escrowID][key] = lease
 }
 
 // SQLite is single-instance, so its lease store is a deliberate no-op: Acquire

--- a/devshard/storage/memory.go
+++ b/devshard/storage/memory.go
@@ -41,28 +41,28 @@ type snapshotData struct {
 }
 
 type sessionData struct {
-	escrowID      string
-	epochID       uint64
-	version       string
-	creatorAddr   string
-	config        types.SessionConfig
-	group         []types.SlotAssignment
-	balance       uint64
-	diffs         []types.DiffRecord
-	nonceToIndex  map[uint64]int
-	lastFinalized uint64
-	status        string // "active", "settled"
-	snapshot      *snapshotData
-	inferences              map[uint64]InferenceRow
-	inferenceValidationObs  map[uint64]map[uint32]SlotValidationObs
-	sealedValidationObs     map[uint64]map[uint32]SlotValidationObs
+	escrowID               string
+	epochID                uint64
+	version                string
+	creatorAddr            string
+	config                 types.SessionConfig
+	group                  []types.SlotAssignment
+	balance                uint64
+	diffs                  []types.DiffRecord
+	nonceToIndex           map[uint64]int
+	lastFinalized          uint64
+	status                 string // "active", "settled"
+	snapshot               *snapshotData
+	inferences             map[uint64]InferenceRow
+	inferenceValidationObs map[uint64]map[uint32]SlotValidationObs
+	sealedValidationObs    map[uint64]map[uint32]SlotValidationObs
 }
 
 // Memory is an in-memory storage implementation for testing.
 type Memory struct {
 	mu               sync.RWMutex
 	sessions         map[string]*sessionData
-	validationLeases map[string]map[uint64]memoryLease
+	validationLeases map[string]map[memoryLeaseKey]memoryLease
 	escrowCache      map[string]EscrowCacheInfo
 }
 
@@ -95,15 +95,15 @@ func (m *Memory) CreateSession(params CreateSessionParams) error {
 	}
 
 	m.sessions[params.EscrowID] = &sessionData{
-		escrowID:     params.EscrowID,
-		epochID:      params.EpochID,
-		version:      requestedVersion,
-		creatorAddr:  params.CreatorAddr,
-		config:       params.Config,
-		group:        copyGroup(params.Group),
-		balance:      params.InitialBalance,
-		nonceToIndex: make(map[uint64]int),
-		status:       "active",
+		escrowID:               params.EscrowID,
+		epochID:                params.EpochID,
+		version:                requestedVersion,
+		creatorAddr:            params.CreatorAddr,
+		config:                 params.Config,
+		group:                  copyGroup(params.Group),
+		balance:                params.InitialBalance,
+		nonceToIndex:           make(map[uint64]int),
+		status:                 "active",
 		inferences:             make(map[uint64]InferenceRow),
 		inferenceValidationObs: make(map[uint64]map[uint32]SlotValidationObs),
 		sealedValidationObs:    make(map[uint64]map[uint32]SlotValidationObs),


### PR DESCRIPTION
## Changes

- Add validation retry coverage for stale lease reclaim and endpoint behavior.
- Add host cooldown and validation lease race coverage.
- Add e2e coverage for withholding executor scenarios.
- Replace the old session retry path with `ValidationRetryLoop`.
- Extend validation lease storage semantics for:
  - stale `pending` leases
  - stale `submitted` leases
  - epoch-scoped lease ownership
  - explicit lease release on non-submit paths
- Add bounded payload retrieval for validation fetches.
- Add validation fault/test hooks for deterministic retry and withholding tests.
- Add metrics/test coverage around validation lifecycle behavior.

## Fixes

- Fix validation retry so executor-attributable payload fetch failures produce `Valid:false` instead of leaving validation stuck.
- Fix validation leases being left `pending` after failed/non-submit retry paths.
- Fix stale `submitted` validation leases being ignored by retry recovery.
- Fix retry recovery to respect lease ownership before submitting validation results.
- Fix retry behavior after manager/session restart, including cases where validation tx existed only in volatile mempool.
- Fix withholding executor behavior so payload fetches are bounded and cannot hold a validation worker indefinitely.
- Fix retry release behavior for `Challenged` inferences so the hot path can publish the validation vote.

## Why stale `submitted` leases are retried

`submitted` means the retry loop already produced a validation result and pushed the validation tx into the host mempool. It does **not** mean the tx became durable.

If the process restarts after mempool submit but before the tx is applied into a diff, the Postgres lease can remain `submitted` while the actual validation tx is lost with the volatile mempool. Previously that state could become stuck forever: the lease was no longer `pending`, but there was also no durable validation result.

This PR treats stale `submitted` leases as retryable. On recovery, the retry loop checks the live host state first:

- if validation is already applied, it marks the lease skipped;
- if validation is still in mempool, it keeps/marks it submitted;
- if the mempool tx was lost, it revalidates and republishes safely under lease ownership.

That makes `submitted` a recoverable intermediate state instead of a terminal assumption.