### PR TITLE
fix(devshard): restore snapshot-only recovery indexes

### DIFF
--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -588,14 +588,25 @@ func (sm *StateMachine) RebuildSealedInferenceIndex() error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	if err := sm.inferenceStore.DeleteSealedInferences(sm.state.EscrowID); err != nil {
-		return err
-	}
 	ids := make([]uint64, 0, len(sm.sealedNonces))
 	for id := range sm.sealedNonces {
 		ids = append(ids, id)
 	}
 	slices.Sort(ids)
+
+	existing := make(map[uint64]storage.InferenceRow, len(ids))
+	for _, id := range ids {
+		row, ok, err := sm.inferenceStore.GetSealedInference(sm.state.EscrowID, id)
+		if err != nil {
+			return err
+		}
+		if ok {
+			existing[id] = row
+		}
+	}
+	if err := sm.inferenceStore.DeleteSealedInferences(sm.state.EscrowID); err != nil {
+		return err
+	}
 	for _, id := range ids {
 		if _, live := sm.state.Inferences[id]; live {
 			continue
@@ -609,6 +620,9 @@ func (sm *StateMachine) RebuildSealedInferenceIndex() error {
 			if entryID, rec, err := unmarshalInferenceEntry(cached); err == nil && entryID == id {
 				row = inferenceObsRow(id, nonce, rec)
 			}
+		} else if existingRow, ok := existing[id]; ok {
+			existingRow.SealedNonce = nonce
+			row = existingRow
 		}
 		if err := sm.inferenceStore.InsertSealedInference(sm.state.EscrowID, row); err != nil {
 			return err

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -69,23 +69,25 @@ const snapshotInterval = 500
 // that was stranded behind the prior snapshot self-heals via host-side
 // silent-skip (host.applyAndPersist drops diffs whose Nonce <= currentNonce).
 type sessionSnapshot struct {
-	State         *types.EscrowState `json:"state"`
-	HostSyncNonce map[int]uint64     `json:"host_sync_nonce,omitempty"`
+	State            *types.EscrowState `json:"state"`
+	HostSyncNonce    map[int]uint64     `json:"host_sync_nonce,omitempty"`
+	CommittedEntries map[uint64][]byte  `json:"committed_entries,omitempty"`
+	SealedNonces     map[uint64]uint64  `json:"sealed_nonces,omitempty"`
 }
 
 // decodeSnapshot decodes the on-disk snapshot blob. Returns the state and
 // the per-host sync cursor (nil for legacy bare-EscrowState snapshots).
-func decodeSnapshot(data []byte) (*types.EscrowState, map[int]uint64, error) {
+func decodeSnapshot(data []byte) (*types.EscrowState, map[int]uint64, map[uint64][]byte, map[uint64]uint64, error) {
 	var blob sessionSnapshot
 	if err := json.Unmarshal(data, &blob); err == nil && blob.State != nil {
-		return blob.State, blob.HostSyncNonce, nil
+		return blob.State, blob.HostSyncNonce, blob.CommittedEntries, blob.SealedNonces, nil
 	}
 	// Legacy format: top-level EscrowState fields. Re-unmarshal as bare.
 	var bare types.EscrowState
 	if err := json.Unmarshal(data, &bare); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return &bare, nil, nil
+	return &bare, nil, nil, nil, nil
 }
 
 // minHostSyncNonce returns the smallest cursor value across all hosts
@@ -180,11 +182,13 @@ func RecoverSession(
 	replayFrom := uint64(1)
 	snapNonce, snapData, snapErr := store.LoadSnapshot(escrowID)
 	if snapErr == nil && snapNonce > 0 && snapNonce <= meta.LatestNonce {
-		snapState, cursor, decodeErr := decodeSnapshot(snapData)
+		snapState, cursor, committedEntries, sealedNonces, decodeErr := decodeSnapshot(snapData)
 		if decodeErr != nil {
 			log.Printf("recover_session escrow=%s snapshot_nonce=%d unmarshal_failed=%v (replaying from 1)", escrowID, snapNonce, decodeErr)
 		} else {
 			sm.RestoreState(snapState)
+			sm.RestoreCommittedEntries(committedEntries)
+			sm.RestoreSealedNonces(sealedNonces)
 			replayFrom = snapNonce + 1
 			sess.nonce = snapNonce
 			snapshotCursor = cursor
@@ -422,7 +426,7 @@ func saveSnapshot(store storage.Storage, sm *state.StateMachine, escrowID string
 	for k, v := range hostSyncNonce {
 		cursor[k] = v
 	}
-	writeSnapshot(store, escrowID, nonce, sm.ExportState(), cursor)
+	writeSnapshot(store, escrowID, nonce, sm.ExportState(), cursor, sm.ExportCommittedEntries(), sm.ExportSealedNonces())
 }
 
 // writeSnapshot persists a pre-prepared snapshot blob. The caller must
@@ -430,15 +434,15 @@ func saveSnapshot(store storage.Storage, sm *state.StateMachine, escrowID string
 // only the JSON marshal + storage write and can run without any session
 // or state-machine locks held -- this is what enables async background
 // snapshots from the runtime hot path).
-func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64) {
-	_ = writeSnapshotErr(store, escrowID, nonce, state, cursor)
+func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64) {
+	_ = writeSnapshotErr(store, escrowID, nonce, state, cursor, committedEntries, sealedNonces)
 }
 
 // writeSnapshotErr is writeSnapshot with an error return, for synchronous
 // callers (e.g. Session.FlushSnapshot on retire) that want to know whether the
 // snapshot landed. It logs on failure exactly like writeSnapshot.
-func writeSnapshotErr(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64) error {
-	blob := sessionSnapshot{State: state, HostSyncNonce: cursor}
+func writeSnapshotErr(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64) error {
+	blob := sessionSnapshot{State: state, HostSyncNonce: cursor, CommittedEntries: committedEntries, SealedNonces: sealedNonces}
 	data, err := json.Marshal(blob)
 	if err != nil {
 		log.Printf("recover_session escrow=%s snapshot_marshal_failed=%v", escrowID, err)

--- a/devshard/user/recover_test.go
+++ b/devshard/user/recover_test.go
@@ -1624,6 +1624,205 @@ func TestRecoverSession_SnapshotOnly_RestoresPendingTxDedupKeys(t *testing.T) {
 	require.Equal(t, rootBefore, rootAfter)
 }
 
+func TestRecoverSession_SnapshotOnly_RestoresPendingTxDedupKeysForHostProposedTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		tx   *types.DevshardTx
+	}{
+		{
+			name: "finish",
+			tx: &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{
+				FinishInference: &types.MsgFinishInference{InferenceId: 7, ExecutorSlot: 1, EscrowId: "escrow-1"},
+			}},
+		},
+		{
+			name: "confirm",
+			tx: &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{
+				ConfirmStart: &types.MsgConfirmStart{InferenceId: 7},
+			}},
+		},
+		{
+			name: "validation",
+			tx: &types.DevshardTx{Tx: &types.DevshardTx_Validation{
+				Validation: &types.MsgValidation{InferenceId: 7, ValidatorSlot: 1, EscrowId: "escrow-1"},
+			}},
+		},
+		{
+			name: "validation_vote",
+			tx: &types.DevshardTx{Tx: &types.DevshardTx_ValidationVote{
+				ValidationVote: &types.MsgValidationVote{InferenceId: 7, VoterSlot: 2, EscrowId: "escrow-1"},
+			}},
+		},
+		{
+			name: "reveal_seed",
+			tx: &types.DevshardTx{Tx: &types.DevshardTx_RevealSeed{
+				RevealSeed: &types.MsgRevealSeed{SlotId: 2, EscrowId: "escrow-1"},
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recovered := recoverSnapshotOnlyWithDurableHostTx(t, tc.tx)
+			t.Cleanup(func() { _ = recovered.Close() })
+
+			rootBefore, err := recovered.StateMachine().ComputeStateRoot()
+			require.NoError(t, err)
+			require.NoError(t, recovered.ProcessResponse(0, &host.HostResponse{
+				Nonce:   recovered.Nonce(),
+				Mempool: []*types.DevshardTx{tc.tx},
+			}, recovered.Nonce()))
+			require.Empty(t, recovered.PendingTxs(),
+				"duplicate %s from a durable pre-snapshot diff must not re-enter pending", tc.name)
+			require.Equal(t, uint64(1), recovered.Nonce())
+			rootAfter, err := recovered.StateMachine().ComputeStateRoot()
+			require.NoError(t, err)
+			require.Equal(t, rootBefore, rootAfter)
+		})
+	}
+}
+
+func TestRecoverSession_SnapshotOnly_RestoresSealedInferenceIndexes(t *testing.T) {
+	store := newTestStore(t)
+	const escrowID = "escrow-1"
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       escrowID,
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+
+	sm, err := state.NewStateMachine(escrowID, config, group, 100000, user.Address(), verifier, store,
+		state.WithStateRootAndProtocolVersion(testutil.RuntimeTestVersion))
+	require.NoError(t, err)
+	appendAppliedDiff := func(nonce uint64, txs []*types.DevshardTx) {
+		t.Helper()
+		root, err := sm.ApplyLocal(nonce, txs)
+		require.NoError(t, err)
+		diff := testutil.SignDiffWithRoot(t, user, escrowID, nonce, txs, root)
+		require.NoError(t, store.AppendDiff(escrowID, types.DiffRecord{Diff: diff, StateHash: root}))
+	}
+
+	promptHash, err := devshard.CanonicalPromptHash(testutil.TestPrompt)
+	require.NoError(t, err)
+	appendAppliedDiff(1, []*types.DevshardTx{{Tx: &types.DevshardTx_StartInference{
+		StartInference: &types.MsgStartInference{
+			InferenceId: 1, PromptHash: promptHash, Model: "llama",
+			InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		},
+	}}})
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], escrowID, 1, promptHash, "llama", 100, 50, 1000, 2000)
+	appendAppliedDiff(2, []*types.DevshardTx{{Tx: &types.DevshardTx_ConfirmStart{
+		ConfirmStart: &types.MsgConfirmStart{InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 2000},
+	}}})
+	finish := &types.MsgFinishInference{
+		InferenceId: 1, ResponseHash: []byte("response"),
+		InputTokens: 10, OutputTokens: 20, ExecutorSlot: 1, EscrowId: escrowID,
+	}
+	finish.ProposerSig = testutil.SignProposerTx(t, hosts[1], finish)
+	appendAppliedDiff(3, []*types.DevshardTx{{Tx: &types.DevshardTx_FinishInference{FinishInference: finish}}})
+
+	require.NoError(t, sm.SealInference(1))
+	_, live := sm.SnapshotState().Inferences[1]
+	require.False(t, live, "precondition: sealed inference must be absent from live state")
+	before, ok := sm.ExportAllInferenceRecords()[1]
+	require.True(t, ok)
+	require.Equal(t, types.StatusFinished, before.Status)
+	row, ok, err := store.GetSealedInference(escrowID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, row.ObsPresent)
+
+	saveSnapshot(store, sm, escrowID, 3, map[int]uint64{0: 3, 1: 3, 2: 3})
+	spy := &replaySpyStore{Storage: store}
+	recovered, recSM, err := RecoverSession(spy, user, verifier, escrowID, testutil.RuntimeTestVersion, group,
+		buildRecoveryClients(t, hosts, group, user))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = recovered.Close() })
+	require.Equal(t, uint64(3), recovered.Nonce())
+	require.Empty(t, recovered.Diffs(), "all hosts are caught up, so recovery should be snapshot-only")
+	require.Zero(t, spy.replayedRecords(3), "must use snapshot-only early return")
+
+	records := recSM.ExportAllInferenceRecords()
+	got, ok := records[1]
+	require.True(t, ok, "sealed inference must remain visible after snapshot-only recovery")
+	require.Equal(t, types.StatusFinished, got.Status)
+	require.Equal(t, "llama", got.Model)
+	require.Equal(t, uint64(10), got.InputTokens)
+	require.Equal(t, uint64(20), got.OutputTokens)
+	sealed, ok := recSM.LookupSealedInference(1)
+	require.True(t, ok)
+	require.Equal(t, got.Status, sealed.Status)
+	_, live = recSM.SnapshotState().Inferences[1]
+	require.False(t, live, "sealed inference must not be resurrected into live state")
+
+	lateValidation := &types.MsgValidation{
+		InferenceId:   1,
+		ValidatorSlot: 2,
+		Valid:         false,
+		EscrowId:      escrowID,
+	}
+	lateValidation.ProposerSig = testutil.SignProposerTx(t, hosts[2], lateValidation)
+	_, err = recSM.ApplyLocal(4, []*types.DevshardTx{{Tx: &types.DevshardTx_Validation{
+		Validation: lateValidation,
+	}}})
+	require.ErrorIs(t, err, types.ErrInferenceSealed)
+}
+
+func recoverSnapshotOnlyWithDurableHostTx(t *testing.T, tx *types.DevshardTx) *Session {
+	t.Helper()
+	store := newTestStore(t)
+	const escrowID = "escrow-1"
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	verifier := signing.NewSecp256k1Verifier()
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       escrowID,
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+	diff := types.Diff{Nonce: 1, Txs: []*types.DevshardTx{tx}}
+	require.NoError(t, store.AppendDiff(escrowID, types.DiffRecord{Diff: diff}))
+
+	stateSnapshot := newTestStateMachine(t, escrowID, config, group, 100000, user.Address(), verifier).SnapshotState()
+	stateSnapshot.LatestNonce = 1
+	blob, err := json.Marshal(sessionSnapshot{
+		State:         &stateSnapshot,
+		HostSyncNonce: map[int]uint64{0: 1, 1: 1, 2: 1},
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.SaveSnapshot(escrowID, 1, blob))
+
+	spy := &replaySpyStore{Storage: store}
+	recovered, _, err := RecoverSession(spy, user, verifier, escrowID, testutil.RuntimeTestVersion, group,
+		buildRecoveryClients(t, hosts, group, user))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), recovered.Nonce())
+	require.Empty(t, recovered.Diffs(), "all hosts are caught up, so recovery should be snapshot-only")
+	require.Zero(t, spy.replayedRecords(1), "must use snapshot-only early return")
+	return recovered
+}
+
 // buildRecoveryClients creates a fresh set of in-process host clients for
 // recovery, mirroring setupRecoverableSession's client factory.
 func buildRecoveryClients(t *testing.T, hosts []*signing.Secp256k1Signer, group []types.SlotAssignment, user *signing.Secp256k1Signer) []HostClient {

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -888,6 +888,8 @@ func (s *Session) maybeSaveSnapshotLocked() {
 	// Deep-copy state and cursor under the session lock; release before
 	// any disk IO. ExportState takes its own SM RLock for the deep copy.
 	state := s.sm.ExportState()
+	committedEntries := s.sm.ExportCommittedEntries()
+	sealedNonces := s.sm.ExportSealedNonces()
 	cursor := make(map[int]uint64, len(s.hostSyncNonce))
 	for k, v := range s.hostSyncNonce {
 		cursor[k] = v
@@ -898,7 +900,7 @@ func (s *Session) maybeSaveSnapshotLocked() {
 
 	go func() {
 		defer s.snapshotInFlight.Store(false)
-		writeSnapshot(store, escrowID, nonce, state, cursor)
+		writeSnapshot(store, escrowID, nonce, state, cursor, committedEntries, sealedNonces)
 	}()
 }
 
@@ -945,6 +947,8 @@ func (s *Session) FlushSnapshot() error {
 	// Deep-copy state and cursor under the session lock, mirroring
 	// maybeSaveSnapshotLocked, then release before the disk write.
 	stateCopy := s.sm.ExportState()
+	committedEntries := s.sm.ExportCommittedEntries()
+	sealedNonces := s.sm.ExportSealedNonces()
 	cursor := make(map[int]uint64, len(s.hostSyncNonce))
 	for k, v := range s.hostSyncNonce {
 		cursor[k] = v
@@ -954,7 +958,7 @@ func (s *Session) FlushSnapshot() error {
 	escrowID := s.escrowID
 	s.mu.Unlock()
 
-	return writeSnapshotErr(store, escrowID, nonce, stateCopy, cursor)
+	return writeSnapshotErr(store, escrowID, nonce, stateCopy, cursor, committedEntries, sealedNonces)
 }
 
 // PrepareInference composes a diff, applies it locally, advances nonce,


### PR DESCRIPTION
## Summary

- Persist and restore snapshot-side `committedEntries` and `sealedNonces` so snapshot-only recovery keeps sealed inference indexes intact.
- Preserve existing sealed inference rows when rebuilding the sealed inference index and the committed entry is no longer available.
- Add snapshot-only recovery coverage for host-proposed pending tx dedup keys across:
  - `FinishInference`
  - `ConfirmStart`
  - `Validation`
  - `ValidationVote`
  - `RevealSeed`
- Add regression coverage that sealed inference records remain queryable after snapshot-only recovery and duplicate sealed-inference mutations are still rejected.

## Motivation

The previous fix restored `pendingTxKeys` from the durable diff journal when snapshot-only recovery skips the normal diff replay loop. This PR expands the same class of recovery checks to additional runtime / derived indexes that are not represented directly in SQL state but still affect post-restart behavior.

Without these fields, a recovered session can have the correct `EscrowState` while losing process-derived indexes needed for deduplication, sealed inference lookup, or duplicate inference guards.

## Testing

- `go test ./user -run 'TestRecoverSession_SnapshotOnly_RestoresPendingTxDedupKeys|TestRecoverSession_SnapshotOnly_RestoresSealedInferenceIndexes'`
- `go test ./state`
- `go test ./user`