### PR TITLE
`devshard` Ping the PostgreSQL health probe after reconnect (#1602 follow-up)

### DIFF
--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -114,11 +114,12 @@ func (p *postgresHealthProbe) check(ctx context.Context) error {
 			return fmt.Errorf("connect postgres health probe: %w", err)
 		}
 		p.conn = conn
-		// A completed PostgreSQL startup handshake is sufficient for the first
-		// check. Subsequent checks reuse the connection and issue Ping.
-		return nil
 	}
 
+	// Always Ping, including right after connect. A startup handshake can
+	// succeed while the session is already dying; scoring that reconnect as
+	// healthy reset failure hysteresis and masked a database that kept
+	// killing backends.
 	if err := p.conn.Ping(ctx); err != nil {
 		conn := p.conn
 		p.conn = nil

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -511,6 +513,47 @@ func TestPostgresHealthProbeIsIndependentOfApplicationPool(t *testing.T) {
 	require.Equal(t, postgresHealthState{ready: true, saturated: true}, current)
 	_, current = pg.recordHealthProbe(postgresHealthProbeDatabaseError, postgresPoolIsSaturated(pool))
 	require.Equal(t, postgresHealthState{saturated: true}, current)
+}
+
+func TestPostgresHealthProbePingAfterReconnectWithdraws(t *testing.T) {
+	container := startPostgresContainer(t)
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	admin, err := pgx.Connect(context.Background(), "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.Close(context.Background()) })
+
+	cfg, err := pgxpool.ParseConfig("")
+	require.NoError(t, err)
+	cfg.ConnConfig.AfterConnect = func(ctx context.Context, conn *pgconn.PgConn) error {
+		_, err := admin.Exec(ctx, "SELECT pg_terminate_backend($1)", conn.PID())
+		return err
+	}
+
+	probe := newPostgresHealthProbe(cfg.ConnConfig)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = probe.close(closeCtx)
+	})
+	pg := &Postgres{healthReady: true}
+
+	for i := 0; i < postgresHealthQuorum; i++ {
+		probeCtx, cancel := context.WithTimeout(context.Background(), postgresHealthTimeout)
+		probeErr := probe.check(probeCtx)
+		cancel()
+		require.Error(t, probeErr, "probe %d: handshake-then-kill must fail Ping, not count as a healthy reconnect", i+1)
+		require.ErrorContains(t, probeErr, "ping postgres health probe connection",
+			"probe %d: connect must succeed so the failure is the skipped Ping, not handshake", i+1)
+
+		result := postgresHealthProbeDatabaseError
+		_, current := pg.recordHealthProbe(result, false)
+		if i+1 < postgresHealthQuorum {
+			require.Equal(t, postgresHealthState{ready: true}, current)
+			continue
+		}
+		require.Equal(t, postgresHealthState{}, current)
+	}
 }
 
 func TestPostgresHealthProbeBudgetCoversConnectionSetup(t *testing.T) {


### PR DESCRIPTION
Small follow-up after [#1602](https://github.com/gonka-ai/gonka/pull/1602)

## Summary

- Ping the dedicated PostgreSQL health connection after every connect, not only on later reuse.
- A handshake that succeeds while the session is already dying is a probe failure, so two consecutive failures can still withdraw `/readyz`.
- Cover the handshake-then-kill path so a connect-only success cannot reset failure hysteresis.

## Why

#1602 moved the health probe onto a dedicated `pgx.Conn` outside the application pool. After a failed `Ping` the probe dropped that connection, and the next check treated a successful startup handshake as healthy and returned without querying.

That reset `healthFails` to 0. A database that accepted connects but kept killing backends then alternated `success` / `database_error` forever, so two-sample hysteresis never fired and `/readyz` stayed 200.

## Behavior

`postgresHealthProbe.check` still reconnects when the dedicated connection is missing or closed. It always `Ping`s afterward, including on the first check after connect. Pool saturation is unchanged and still does not affect readiness.

## Test plan

- [x] `go test -race ./storage -run 'TestPostgresHealthProbePingAfterReconnectWithdraws|TestPostgresHealthProbeIsIndependentOfApplicationPool|TestPostgresReadyUsesHealthHysteresis|TestPostgresReadyTracksLiveDatabaseLoss'`
- [ ] Confirm a healthy reconnect still succeeds: close the dedicated connection, next probe reconnects, pings, and stays ready.
- [ ] Confirm handshake-then-kill fails on `Ping` (not connect) and that two consecutive failures set `healthReady` false.
