### PR TITLE
fix(devshard): strip v-prefix when stamping rotation protocol version

### DIFF
--- a/devshard/cmd/devshardctl/escrow_recovery_test.go
+++ b/devshard/cmd/devshardctl/escrow_recovery_test.go
@@ -169,7 +169,7 @@ func TestCreateRotationEscrowCarriesProtocolVersionFromV4RoutePrefix(t *testing.
 	assert.Equal(t, "4", record.ProtocolVersion, "v4 route prefix stamps protocol 4, not empty")
 }
 
-// A leading "v" is stripped; the rest of the route version segment is kept.
+// A leading "v" is stripped after taking the major (v2.1.0 -> v2 -> "2").
 func TestRotationEscrowProtocolVersionRouteMapping(t *testing.T) {
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/mainnet-canary")
 	assert.Equal(t, "mainnet-canary", rotationEscrowProtocolVersion())
@@ -178,9 +178,9 @@ func TestRotationEscrowProtocolVersionRouteMapping(t *testing.T) {
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v4")
 	assert.Equal(t, "4", rotationEscrowProtocolVersion())
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v4.1r5")
-	assert.Equal(t, "4.1r5", rotationEscrowProtocolVersion())
+	assert.Equal(t, "4", rotationEscrowProtocolVersion())
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v2.1.0")
-	assert.Equal(t, "2.1.0", rotationEscrowProtocolVersion())
+	assert.Equal(t, "2", rotationEscrowProtocolVersion())
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/3")
 	assert.Equal(t, "3", rotationEscrowProtocolVersion())
 }

--- a/devshard/cmd/devshardctl/escrow_recovery_test.go
+++ b/devshard/cmd/devshardctl/escrow_recovery_test.go
@@ -156,16 +156,31 @@ func TestCreateRotationEscrowCarriesProtocolVersionFromRoutePrefix(t *testing.T)
 	assert.Equal(t, "3", record.ProtocolVersion, "persisted escrow inherits protocol from route prefix")
 }
 
-// A route prefix whose version segment is not a protocol version (e.g. a named
-// versiond runtime) keeps the empty/v1-default behavior; semver-like versions
-// map by their major component.
+func TestCreateRotationEscrowCarriesProtocolVersionFromV4RoutePrefix(t *testing.T) {
+	g, store, settings := newRecoveryGateway(t)
+	stubCreateOnChain(t, "TXPV4", 557)
+	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v4")
+	model := normalizedEscrowRotationModels(settings)[0]
+
+	_, err := g.createRotationEscrow(context.Background(), settings, model, rotationRoleTemp, 10)
+	require.NoError(t, err)
+
+	record := devshardIDs(t, store)["557"]
+	assert.Equal(t, "4", record.ProtocolVersion, "v4 route prefix stamps protocol 4, not empty")
+}
+
+// A leading "v" is stripped; the rest of the route version segment is kept.
 func TestRotationEscrowProtocolVersionRouteMapping(t *testing.T) {
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/mainnet-canary")
-	assert.Empty(t, rotationEscrowProtocolVersion())
+	assert.Equal(t, "mainnet-canary", rotationEscrowProtocolVersion())
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v3")
 	assert.Equal(t, "3", rotationEscrowProtocolVersion())
+	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v4")
+	assert.Equal(t, "4", rotationEscrowProtocolVersion())
+	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v4.1r5")
+	assert.Equal(t, "4.1r5", rotationEscrowProtocolVersion())
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v2.1.0")
-	assert.Equal(t, "2", rotationEscrowProtocolVersion())
+	assert.Equal(t, "2.1.0", rotationEscrowProtocolVersion())
 	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/3")
 	assert.Equal(t, "3", rotationEscrowProtocolVersion())
 }

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -386,12 +386,10 @@ func newRotationDevshardState(result *CreateDevshardEscrowResult, model EscrowRo
 
 // rotationEscrowProtocolVersion is the protocol version stamped on escrows
 // created by rotation/depletion. It is derived from the gateway-wide route
-// prefix (DEVSHARD_ROUTE_PREFIX / build version), so a gateway serving
-// /devshard/v3 mints protocol-v3 escrows. Semver-like route versions map by
-// major (v2.1.0 -> v2), relying on the same naming convention that ties a
-// route version to its protocol. An unparseable version segment (e.g. a
-// named versiond runtime) falls back to the v1 default, matching the
-// pre-existing behavior for explicit registrations without a protocol.
+// prefix (DEVSHARD_ROUTE_PREFIX / build version): a leading "v" is stripped
+// and the rest is kept (v4 -> "4", v4.1r5 -> "4.1r5"). Named runtimes such
+// as mainnet-canary are stamped as-is. An unresolvable prefix falls back to
+// empty (the pre-existing v1-default for registrations without a protocol).
 func rotationEscrowProtocolVersion() string {
 	routePrefix, err := resolveGatewayRoutePrefix()
 	if err != nil {
@@ -403,11 +401,7 @@ func rotationEscrowProtocolVersion() string {
 		log.Printf("escrow_rotation_protocol_version_fallback route_prefix=%q reason=version_segment_unresolved error=%v", routePrefix, err)
 		return ""
 	}
-	normalized := strings.TrimSpace(version)
-	if i := strings.IndexByte(normalized, '.'); i > 0 {
-		normalized = normalized[:i] // e.g. v2.1.0 -> v2
-	}
-	pv, err := types.ParseProtocolVersion(normalized)
+	pv, err := types.ParseProtocolVersion(version)
 	if err != nil {
 		log.Printf("escrow_rotation_protocol_version_fallback route_prefix=%q version=%q reason=unparseable_protocol error=%v", routePrefix, version, err)
 		return ""

--- a/devshard/cmd/devshardctl/escrow_rotator.go
+++ b/devshard/cmd/devshardctl/escrow_rotator.go
@@ -386,10 +386,11 @@ func newRotationDevshardState(result *CreateDevshardEscrowResult, model EscrowRo
 
 // rotationEscrowProtocolVersion is the protocol version stamped on escrows
 // created by rotation/depletion. It is derived from the gateway-wide route
-// prefix (DEVSHARD_ROUTE_PREFIX / build version): a leading "v" is stripped
-// and the rest is kept (v4 -> "4", v4.1r5 -> "4.1r5"). Named runtimes such
-// as mainnet-canary are stamped as-is. An unresolvable prefix falls back to
-// empty (the pre-existing v1-default for registrations without a protocol).
+// prefix (DEVSHARD_ROUTE_PREFIX / build version). Semver-like route versions
+// map by their major (v2.1.0 -> v2, v4.1r5 -> v4); a leading "v" is then
+// stripped (v4 -> "4"). Named runtimes such as mainnet-canary are stamped
+// as-is. An unresolvable prefix falls back to empty (the pre-existing
+// v1-default for registrations without a protocol).
 func rotationEscrowProtocolVersion() string {
 	routePrefix, err := resolveGatewayRoutePrefix()
 	if err != nil {
@@ -401,7 +402,11 @@ func rotationEscrowProtocolVersion() string {
 		log.Printf("escrow_rotation_protocol_version_fallback route_prefix=%q reason=version_segment_unresolved error=%v", routePrefix, err)
 		return ""
 	}
-	pv, err := types.ParseProtocolVersion(version)
+	normalized := strings.TrimSpace(version)
+	if i := strings.IndexByte(normalized, '.'); i > 0 {
+		normalized = normalized[:i] // e.g. v2.1.0 -> v2
+	}
+	pv, err := types.ParseProtocolVersion(normalized)
 	if err != nil {
 		log.Printf("escrow_rotation_protocol_version_fallback route_prefix=%q version=%q reason=unparseable_protocol error=%v", routePrefix, version, err)
 		return ""

--- a/devshard/cmd/devshardctl/gateway_store_test.go
+++ b/devshard/cmd/devshardctl/gateway_store_test.go
@@ -395,8 +395,7 @@ func TestEscrowRotationPreparePromotesRegularEscrowsOnTempCreateFailure(t *testi
 
 // Rotation state must never stamp a hardcoded protocol constant (a guard
 // originally added when the gateway-v2 branches hardcoded ProtocolV2): the
-// protocol is derived from the gateway route prefix, and without a resolvable
-// route version the field stays empty (the pre-existing v1-default behavior).
+// protocol is derived from the gateway route prefix (strip a leading "v").
 func TestNewRotationDevshardStateDerivesProtocolFromRoutePrefix(t *testing.T) {
 	record := newRotationDevshardState(&CreateDevshardEscrowResult{EscrowID: 99}, EscrowRotationModelSettings{
 		ModelID:       "Qwen/Test",
@@ -406,7 +405,7 @@ func TestNewRotationDevshardStateDerivesProtocolFromRoutePrefix(t *testing.T) {
 	require.Equal(t, "99", record.ID)
 	require.Equal(t, "Qwen/Test", record.Model)
 	require.Equal(t, "DEVSHARD_PRIVATE_KEY", record.PrivateKeyEnv)
-	require.Empty(t, record.ProtocolVersion, "no route prefix version -> no protocol stamp")
+	require.Equal(t, "dev", record.ProtocolVersion, "unset route prefix uses build/dev version segment")
 	require.True(t, record.Active)
 	require.Equal(t, rotationRoleTemp, record.RotationRole)
 	require.EqualValues(t, 10, record.RotationEpoch)
@@ -417,6 +416,13 @@ func TestNewRotationDevshardStateDerivesProtocolFromRoutePrefix(t *testing.T) {
 		PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
 	}, rotationRoleTemp, 10)
 	require.Equal(t, "3", record.ProtocolVersion, "protocol derived from route prefix, not hardcoded")
+
+	t.Setenv("DEVSHARD_ROUTE_PREFIX", "/devshard/v4")
+	record = newRotationDevshardState(&CreateDevshardEscrowResult{EscrowID: 101}, EscrowRotationModelSettings{
+		ModelID:       "Qwen/Test",
+		PrivateKeyEnv: "DEVSHARD_PRIVATE_KEY",
+	}, rotationRoleTemp, 10)
+	require.Equal(t, "4", record.ProtocolVersion)
 }
 
 func TestEscrowRotationFinishDoesNotSettleTempWhenRegularCreateFails(t *testing.T) {

--- a/devshard/types/domain.go
+++ b/devshard/types/domain.go
@@ -86,18 +86,23 @@ const (
 )
 
 // ParseProtocolVersion parses a string into a ProtocolVersion.
-// Empty string defaults to ProtocolV1.
+// Empty string defaults to ProtocolV1. A leading "v"/"V" is stripped so
+// route segments like "v4" and "v4.1r5" stamp as "4" and "4.1r5". Any
+// remaining non-empty token is accepted — this is a local registry stamp,
+// not the session/settlement protocol tag.
 func ParseProtocolVersion(s string) (ProtocolVersion, error) {
-	switch strings.TrimSpace(s) {
-	case "", string(ProtocolV1), "v1":
+	raw := strings.TrimSpace(s)
+	if raw == "" {
 		return ProtocolV1, nil
-	case string(ProtocolV2), "v2":
-		return ProtocolV2, nil
-	case string(ProtocolV3), "v3":
-		return ProtocolV3, nil
-	default:
-		return "", fmt.Errorf("unknown protocol version %q", s)
 	}
+	out := raw
+	if out[0] == 'v' || out[0] == 'V' {
+		out = out[1:]
+	}
+	if out == "" {
+		return "", fmt.Errorf("unknown protocol version %q", raw)
+	}
+	return ProtocolVersion(out), nil
 }
 
 // SessionConfig holds session-level parameters.

--- a/devshard/types/domain.go
+++ b/devshard/types/domain.go
@@ -87,9 +87,10 @@ const (
 
 // ParseProtocolVersion parses a string into a ProtocolVersion.
 // Empty string defaults to ProtocolV1. A leading "v"/"V" is stripped so
-// route segments like "v4" and "v4.1r5" stamp as "4" and "4.1r5". Any
-// remaining non-empty token is accepted — this is a local registry stamp,
-// not the session/settlement protocol tag.
+// route segments like "v4" stamp as "4". Any remaining non-empty token is
+// accepted — this is a local registry stamp, not the session/settlement
+// protocol tag. Callers that want a major-only stamp (v2.1.0 -> 2) truncate
+// before calling.
 func ParseProtocolVersion(s string) (ProtocolVersion, error) {
 	raw := strings.TrimSpace(s)
 	if raw == "" {

--- a/devshard/types/domain_test.go
+++ b/devshard/types/domain_test.go
@@ -5,49 +5,40 @@ import (
 	"testing"
 )
 
-func TestParseProtocolVersion_DefaultsToV1(t *testing.T) {
-	got, err := ParseProtocolVersion("")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+func TestParseProtocolVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    ProtocolVersion
+		wantErr bool
+	}{
+		{name: "empty defaults to v1", in: "", want: ProtocolV1},
+		{name: "v1", in: "v1", want: ProtocolV1},
+		{name: "v2", in: "v2", want: ProtocolV2},
+		{name: "v3", in: "v3", want: ProtocolV3},
+		{name: "v4", in: "v4", want: "4"},
+		{name: "bare 4", in: "4", want: "4"},
+		{name: "v4.1r5", in: "v4.1r5", want: "4.1r5"},
+		{name: "legacy semver", in: "0.2.11", want: "0.2.11"},
+		{name: "named runtime", in: "mainnet-canary", want: "mainnet-canary"},
+		{name: "v only", in: "v", wantErr: true},
 	}
-	if got != ProtocolV1 {
-		t.Fatalf("expected empty protocol to default to %s, got %s", ProtocolV1, got)
-	}
-}
-
-func TestParseProtocolVersion_AcceptsRouteStyleV1(t *testing.T) {
-	got, err := ParseProtocolVersion("v1")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if got != ProtocolV1 {
-		t.Fatalf("expected v1 to normalize to %s, got %s", ProtocolV1, got)
-	}
-}
-
-func TestParseProtocolVersion_AcceptsRouteStyleV2(t *testing.T) {
-	got, err := ParseProtocolVersion("v2")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if got != ProtocolV2 {
-		t.Fatalf("expected v2 to normalize to %s, got %s", ProtocolV2, got)
-	}
-}
-
-func TestParseProtocolVersion_AcceptsRouteStyleV3(t *testing.T) {
-	got, err := ParseProtocolVersion("v3")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if got != ProtocolV3 {
-		t.Fatalf("expected v3 to normalize to %s, got %s", ProtocolV3, got)
-	}
-}
-
-func TestParseProtocolVersion_RejectsOldProtocol(t *testing.T) {
-	if _, err := ParseProtocolVersion("0.2.11"); err == nil {
-		t.Fatal("expected old protocol to be rejected")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseProtocolVersion(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseProtocolVersion(%q)=%q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# Strip v-prefix when stamping rotation protocol version

Fixes https://github.com/gonka-ai/gonka/issues/1542

## Summary

- Gateway autorotation on `DEVSHARD_ROUTE_PREFIX=/devshard/v4` logged `unparseable_protocol` on every create because `ParseProtocolVersion` only accepted `v1`/`v2`/`v3`. Rotation and settlement already succeeded; the local `protocol_version` stamp was left empty.
- Replace the closed allowlist with strip-`v` autoparse: `"v4"` → `"4"`. Semver-like routes still keep only the major (`v2.1.0` → `"2"`, `v4.1r5` → `"4"`). No `ProtocolV4` constant — later majors do not need a parser bump.
- This stamp is gateway-DB only (`gateway_devshards.protocol_version` / rotation commitments). Settlement still uses session `StateRootAndProtocolVersion` (e.g. `v4`).

## Behavior

| Route / input | Before | After |
|---|---|---|
| `/devshard/v3` | `"3"` | `"3"` |
| `/devshard/v4` | `""` + fallback log | `"4"` |
| `/devshard/v4.1r5` | `""` + fallback log | `"4"` (major) |
| `/devshard/v2.1.0` | `"2"` | `"2"` (major, unchanged) |
| `/devshard/mainnet-canary` | `""` + fallback log | `"mainnet-canary"` |
| empty string | `"1"` | `"1"` |
| `"v"` only | error | error (unchanged) |

The rotator still cuts at the first `.` before parse (`v2.1.0` → `v2`), matching the original major-only stamp.

Unresolvable route prefixes still fall back to empty and log.

## Out of scope

- Settlement / state-root protocol tag
- Gateway `/status` `session_version`
- Compose healthcheck (`curl` vs `wget`)
- Backfill of existing rows with empty `protocol_version`

## Test plan

- [x] `go test ./types/ ./cmd/devshardctl/ -count=1 -run 'ParseProtocolVersion|RotationEscrowProtocolVersion|CreateRotationEscrowCarriesProtocolVersion|NewRotationDevshardStateDerivesProtocol|ReconcileCommitmentsCarriesProtocolVersion'`
- [ ] Gateway with `DEVSHARD_ROUTE_PREFIX=/devshard/v4`: rotation create logs `escrow_rotation_created` **without** `unparseable_protocol`; DB `protocol_version=4`
- [ ] Settlement payload still carries `state_root_and_protocol_version=v4`
