### PR TITLE
fix(versiond): grow the readiness window for slow starts, not hung ones (follow-up for #1620)

### DIFF
--- a/devshard/docs/rolling-update.md
+++ b/devshard/docs/rolling-update.md
@@ -62,7 +62,9 @@ start NEW child on a NEW port            ← old keeps serving
         │
         ▼
 wait NEW admin /ready == 200 and public /healthz == 2xx
-        │                               (VERSIOND_READY_TIMEOUT; abort keeps old)
+        │                               (VERSIOND_READY_TIMEOUT; initializing
+        │                                may extend to VERSIOND_READY_MAX_WAIT;
+        │                                abort keeps old)
         ▼
 atomic route swap → NEW Target           ← retire OLD Target
         │
@@ -211,12 +213,26 @@ Admin-capable children also allocate a second loopback admin port.
 `waitForChildServingReady` replaces TCP-only accept:
 
 - **Admin-capable:** admin `VERSIOND_READY_PATH` must return `200` **and**
-  public `/healthz` must return `2xx`, within `VERSIOND_READY_TIMEOUT`.
+  public `/healthz` must return `2xx`. The probe always waits at least
+  `VERSIOND_READY_TIMEOUT`. After that the wait extends up to
+  `VERSIOND_READY_MAX_WAIT` when:
+  - `/ready` is reachable and the body reports initializing (`ready: false`
+    and/or `storage_ready: false`, not draining), or
+  - `/ready` is absent (`404`/`405`/`501`) — older v3/v4 binaries never
+    registered the route (Echo's default for a missing path is `404`), so
+    there is no body to inspect and the original growing window applies.
+  An unreachable or draining endpoint fails at the short window so a hung
+  child is restarted promptly.
 - **Legacy (no admin API):** readiness probe on the public port with the
   documented `/ready` → `/healthz` → TCP fallback for the default path only.
+  A public `404` on `/ready` still uses that fallback; if fallback is not
+  ready either, the same growing window applies.
 
-Failure aborts the swap: new child is stopped; old keeps serving; next reconcile
-retries.
+The same gate is used for crash-restarts (`restart=true`) and for the
+rolling-swap path (`restart=false`). Failure aborts the swap: new child is
+stopped; old keeps serving; next reconcile retries. A child that later
+reaches `running` resets the short window so a post-crash hang is detected
+in `VERSIOND_READY_TIMEOUT` again.
 
 #### d) `downloadAndSwap` (blue/green + drain)
 
@@ -275,7 +291,8 @@ children but still waits for reap.
 | Env var | Default | Meaning |
 |---|---|---|
 | `VERSIOND_READY_PATH` | `/ready` | Admin readiness path; public `/healthz` must also pass for admin children |
-| `VERSIOND_READY_TIMEOUT` | `60s` | Max wait for incoming child before aborting swap |
+| `VERSIOND_READY_TIMEOUT` | `60s` | Initial readiness window; unreachable/hung children fail here on restart and on swap |
+| `VERSIOND_READY_MAX_WAIT` | `32m` | Cap while `/ready` reports initializing, or is absent (`404`) on older binaries; used on both the restart path and the rolling-swap path |
 | `VERSIOND_DRAIN_PATH` | `/drain` | POST path to put old child into drain mode |
 | `VERSIOND_DRAIN_STATUS_PATH` | `/drain/status` | Poll path for lifecycle inflight |
 | `VERSIOND_DRAIN_TIMEOUT` | `15m` | Shared deadline for proxy leases + child inflight before SIGTERM |

--- a/versioned/internal/config/config.go
+++ b/versioned/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	BasePort          int
 	ReadyPath         string
 	ReadyTimeout      time.Duration
+	ReadyMaxWait      time.Duration
 	DrainPath         string
 	DrainStatusPath   string
 	DrainTimeout      time.Duration
@@ -71,6 +72,7 @@ func Load() (Config, error) {
 	}{
 		{&cfg.PollInterval, "VERSIOND_POLL_INTERVAL", 30 * time.Second, false},
 		{&cfg.ReadyTimeout, "VERSIOND_READY_TIMEOUT", 60 * time.Second, false},
+		{&cfg.ReadyMaxWait, "VERSIOND_READY_MAX_WAIT", 32 * time.Minute, false},
 		{&cfg.DrainTimeout, "VERSIOND_DRAIN_TIMEOUT", 15 * time.Minute, false},
 		{&cfg.DrainPollInterval, "VERSIOND_DRAIN_POLL_INTERVAL", time.Second, false},
 		{&cfg.DrainKillGrace, "VERSIOND_DRAIN_KILL_GRACE", DefaultDrainKillGrace, false},
@@ -82,6 +84,9 @@ func Load() (Config, error) {
 			return Config{}, err
 		}
 		*d.dst = value
+	}
+	if cfg.ReadyMaxWait < cfg.ReadyTimeout {
+		cfg.ReadyMaxWait = cfg.ReadyTimeout
 	}
 	cfg.ChildShutdownGrace = cfg.DrainKillGrace
 	if isDevshardBinary(cfg.BinaryName) {

--- a/versioned/internal/config/config_test.go
+++ b/versioned/internal/config/config_test.go
@@ -41,6 +41,12 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.BasePort != 5000 {
 		t.Errorf("BasePort = %d, want %d", cfg.BasePort, 5000)
 	}
+	if cfg.ReadyTimeout != 60*time.Second {
+		t.Errorf("ReadyTimeout = %v, want %v", cfg.ReadyTimeout, 60*time.Second)
+	}
+	if cfg.ReadyMaxWait != 32*time.Minute {
+		t.Errorf("ReadyMaxWait = %v, want %v", cfg.ReadyMaxWait, 32*time.Minute)
+	}
 	if cfg.DrainKillGrace != DefaultDrainKillGrace {
 		t.Errorf("DrainKillGrace = %v, want %v", cfg.DrainKillGrace, DefaultDrainKillGrace)
 	}
@@ -97,12 +103,28 @@ func TestLoad_CustomValues(t *testing.T) {
 	}
 }
 
+func TestLoad_ReadyMaxWaitClampedToReadyTimeout(t *testing.T) {
+	t.Setenv("VERSIOND_ORACLE_URL", "http://oracle:8080/versions")
+	t.Setenv("VERSIOND_READY_TIMEOUT", "10m")
+	t.Setenv("VERSIOND_READY_MAX_WAIT", "1m")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ReadyMaxWait != 10*time.Minute {
+		t.Fatalf("ReadyMaxWait = %v, want it raised to ReadyTimeout (10m)", cfg.ReadyMaxWait)
+	}
+}
+
 // A malformed duration refuses to boot rather than silently borrowing the
 // default: a typo in a drain or shutdown budget would otherwise surface during
 // the outage it was meant to bound.
 func TestLoad_MalformedDurationsRefuseToBoot(t *testing.T) {
 	for _, key := range []string{
 		"VERSIOND_POLL_INTERVAL",
+		"VERSIOND_READY_TIMEOUT",
+		"VERSIOND_READY_MAX_WAIT",
 		"VERSIOND_HOST_SHUTDOWN_BUDGET",
 		"VERSIOND_DRAIN_ANNOUNCE",
 		"DEVSHARD_SHUTDOWN_GRACE",

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -154,6 +154,12 @@ func normalizeConfig(cfg config.Config) config.Config {
 	if cfg.ReadyTimeout <= 0 {
 		cfg.ReadyTimeout = 60 * time.Second
 	}
+	if cfg.ReadyMaxWait <= 0 {
+		cfg.ReadyMaxWait = 32 * time.Minute
+	}
+	if cfg.ReadyMaxWait < cfg.ReadyTimeout {
+		cfg.ReadyMaxWait = cfg.ReadyTimeout
+	}
 	if cfg.DrainPath == "" {
 		cfg.DrainPath = "/drain"
 	}
@@ -1565,6 +1571,12 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 	backoff := time.Second
 	lastStart := time.Now()
 
+	// Grows with each failed initializing or legacy-missing-/ready attempt,
+	// capped at ReadyMaxWait. Unreachable/hung children keep the short window
+	// so they restart promptly. Reset to ReadyTimeout when the child reaches
+	// statusRunning.
+	readyWindow := m.cfg.ReadyTimeout
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -1621,8 +1633,21 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 			return
 		}
 
-		if !waitForChildServingReady(ctx, c, m.cfg.ReadyPath, m.cfg.ReadyTimeout) {
-			slog.Warn("child did not become ready in time", "version", c.version.Name, "port", c.port, "lifecycle_port", c.lifecyclePort(), "ready_path", m.cfg.ReadyPath)
+		ready, lastProbe := waitForChildServingReadyUntil(ctx, c, m.cfg.ReadyPath, readyWindow, m.cfg.ReadyMaxWait)
+		if !ready {
+			if probeAllowsReadyWaitExtension(lastProbe) {
+				next := nextReadyWindow(readyWindow, m.cfg.ReadyMaxWait)
+				slog.Warn("child did not become ready in time; restarting with a longer window",
+					"version", c.version.Name, "port", c.port, "lifecycle_port", c.lifecyclePort(),
+					"ready_path", m.cfg.ReadyPath, "ready_window", readyWindow,
+					"next_ready_window", next, "probe", lastProbe.String())
+				readyWindow = next
+			} else {
+				slog.Warn("child did not become ready in time",
+					"version", c.version.Name, "port", c.port, "lifecycle_port", c.lifecyclePort(),
+					"ready_path", m.cfg.ReadyPath, "ready_window", readyWindow,
+					"probe", lastProbe.String())
+			}
 			proc.ForceStop()
 			_ = proc.Wait()
 			m.mu.Lock()
@@ -1654,6 +1679,9 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 
 		m.mu.Lock()
 		transitionGenerationLocked(c, statusRunning)
+		// A later crash-restart must detect a hung child on the short window
+		// again; a grown window is only for a start that is still initializing.
+		readyWindow = m.cfg.ReadyTimeout
 		c.proxyTarget = proxy.NewTarget(fmt.Sprintf("localhost:%d", c.port))
 		c.readyOnce.Do(func() { close(c.ready) })
 		if current, ok := m.processes[c.version.Name]; ok && current == c {
@@ -1824,50 +1852,176 @@ func (c *child) adminAddr() string {
 	return fmt.Sprintf("%s:%d", childLoopbackHost, adminPort)
 }
 
+// nextReadyWindow doubles the readiness window, capped at max.
+func nextReadyWindow(current, max time.Duration) time.Duration {
+	next := current * 2
+	if next > max || next <= 0 {
+		return max
+	}
+	return next
+}
+
+type readyProbeResult int
+
+const (
+	readyProbeUnreachable readyProbeResult = iota
+	readyProbeNotReady
+	readyProbeInitializing
+	readyProbeReadyAbsent
+	readyProbeReady
+)
+
+func (r readyProbeResult) String() string {
+	switch r {
+	case readyProbeUnreachable:
+		return "unreachable"
+	case readyProbeNotReady:
+		return "not_ready"
+	case readyProbeInitializing:
+		return "initializing"
+	case readyProbeReadyAbsent:
+		return "ready_absent"
+	case readyProbeReady:
+		return "ready"
+	default:
+		return "unknown"
+	}
+}
+
+// probeAllowsReadyWaitExtension reports whether a not-yet-ready probe should
+// stretch the window instead of failing at ReadyTimeout. Initializing is the
+// modern /ready body. ready_absent is older binaries (v3/v4): Echo returns
+// 404/405/501 for an unregistered /ready, so there is no body to inspect and
+// the original growing window is the compatibility path.
+func probeAllowsReadyWaitExtension(r readyProbeResult) bool {
+	return r == readyProbeInitializing || r == readyProbeReadyAbsent
+}
+
 // waitForChildServingReady gates the Starting -> Running transition. Modern
 // devshardd children must be logically ready on their admin listener and also
 // serve health checks on the public listener that receives proxied traffic.
 func waitForChildServingReady(ctx context.Context, c *child, path string, timeout time.Duration) bool {
-	adminPort := int(c.adminPort.Load())
-	if adminPort == 0 {
-		return waitForReadiness(
-			ctx,
-			timeout,
-			func(probeCtx context.Context, client *http.Client) bool {
-				ready, viaLegacy := readyEndpointReady(probeCtx, client, c.port, path, true)
-				if viaLegacy {
-					c.noteLegacyFallback(path)
-				}
-				return ready
-			},
-		)
-	}
-	return waitForReadiness(ctx, timeout, func(probeCtx context.Context, client *http.Client) bool {
-		ready, _ := readyEndpointReady(probeCtx, client, adminPort, path, false)
-		return ready && publicEndpointReady(probeCtx, client, c.port)
-	})
+	ready, _ := waitForChildServingReadyUntil(ctx, c, path, timeout, timeout)
+	return ready
 }
 
-func waitForReadiness(
+// waitForChildServingReadyUntil is the same gate with a progress-aware bound.
+// It always waits at least minWait (the process may not have bound a port yet).
+// After that it keeps waiting up to maxWait while /ready is reachable and
+// either reports initializing, or is absent (404/405/501 on older binaries
+// that never registered the route). An unreachable or draining endpoint fails
+// promptly instead of stretching to maxWait.
+func waitForChildServingReadyUntil(
 	ctx context.Context,
-	timeout time.Duration,
-	probe func(context.Context, *http.Client) bool,
-) bool {
-	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	c *child,
+	path string,
+	minWait, maxWait time.Duration,
+) (bool, readyProbeResult) {
+	if maxWait < minWait {
+		maxWait = minWait
+	}
+	start := time.Now()
+	probeCtx, cancel := context.WithTimeout(ctx, maxWait)
 	defer cancel()
 	client := &http.Client{Timeout: 500 * time.Millisecond}
+	last := readyProbeUnreachable
+	extended := false
 	for {
-		if probe(probeCtx, client) {
-			return true
+		last = probeChildServing(probeCtx, client, c, path)
+		if last == readyProbeReady {
+			return true, last
+		}
+		elapsed := time.Since(start)
+		if elapsed >= maxWait {
+			return false, last
+		}
+		if elapsed >= minWait && !probeAllowsReadyWaitExtension(last) {
+			return false, last
+		}
+		if elapsed >= minWait && probeAllowsReadyWaitExtension(last) && !extended {
+			extended = true
+			slog.Info("child still starting; extending readiness wait",
+				"version", c.version.Name, "port", c.port, "elapsed", elapsed,
+				"max_wait", maxWait, "probe", last.String())
 		}
 		retry := time.NewTimer(100 * time.Millisecond)
 		select {
 		case <-probeCtx.Done():
 			retry.Stop()
-			return false
+			return false, last
 		case <-retry.C:
 		}
 	}
+}
+
+func probeChildServing(ctx context.Context, client *http.Client, c *child, path string) readyProbeResult {
+	adminPort := int(c.adminPort.Load())
+	if adminPort == 0 {
+		return probeReadyEndpoint(ctx, client, c.port, path, true, c)
+	}
+	admin := probeReadyEndpoint(ctx, client, adminPort, path, false, nil)
+	if admin != readyProbeReady {
+		return admin
+	}
+	if publicEndpointReady(ctx, client, c.port) {
+		return readyProbeReady
+	}
+	return readyProbeInitializing
+}
+
+func probeReadyEndpoint(
+	ctx context.Context,
+	client *http.Client,
+	port int,
+	path string,
+	allowLegacy bool,
+	c *child,
+) readyProbeResult {
+	readyPath := normalizeHTTPPath(path)
+	status, body, err := getHTTPStatusAndBody(ctx, client, port, readyPath)
+	if err != nil {
+		return readyProbeUnreachable
+	}
+	if status == http.StatusOK {
+		return readyProbeReady
+	}
+	if allowLegacy && legacyReadyFallbackAllowed(readyPath, status) && legacyReady(ctx, client, port) {
+		if c != nil {
+			c.noteLegacyFallback(path)
+		}
+		return readyProbeReady
+	}
+	if status == http.StatusServiceUnavailable && readyBodyInitializing(body) {
+		return readyProbeInitializing
+	}
+	if readyPathAbsent(status) {
+		return readyProbeReadyAbsent
+	}
+	return readyProbeNotReady
+}
+
+func readyPathAbsent(status int) bool {
+	switch status {
+	case http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented:
+		return true
+	default:
+		return false
+	}
+}
+
+func readyBodyInitializing(body []byte) bool {
+	var status struct {
+		Ready        bool `json:"ready"`
+		Draining     bool `json:"draining"`
+		StorageReady bool `json:"storage_ready"`
+	}
+	if err := json.Unmarshal(body, &status); err != nil {
+		return false
+	}
+	if status.Draining {
+		return false
+	}
+	return !status.Ready || !status.StorageReady
 }
 
 // readyEndpointReady reports readiness and whether the answer came through the
@@ -1895,29 +2049,33 @@ func publicEndpointReady(ctx context.Context, client *http.Client, port int) boo
 }
 
 func getHTTPStatus(ctx context.Context, client *http.Client, port int, path string) (int, error) {
+	status, _, err := getHTTPStatusAndBody(ctx, client, port, path)
+	return status, err
+}
+
+func getHTTPStatusAndBody(ctx context.Context, client *http.Client, port int, path string) (int, []byte, error) {
 	url := fmt.Sprintf("http://%s:%d%s", childLoopbackHost, port, normalizeHTTPPath(path))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode, nil
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, body, nil
 }
 
 func legacyReadyFallbackAllowed(path string, status int) bool {
 	if path != "/ready" {
 		return false
 	}
-	switch status {
-	case 0, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented:
-		return true
-	default:
-		return false
-	}
+	return status == 0 || readyPathAbsent(status)
 }
 
 func legacyReady(ctx context.Context, client *http.Client, port int) bool {

--- a/versioned/internal/process/ready_window_test.go
+++ b/versioned/internal/process/ready_window_test.go
@@ -1,0 +1,242 @@
+package process
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"versioned/internal/config"
+)
+
+func TestNextReadyWindowDoublesUpToMax(t *testing.T) {
+	max := 32 * time.Minute
+	got := time.Minute
+	want := []time.Duration{
+		2 * time.Minute,
+		4 * time.Minute,
+		8 * time.Minute,
+		16 * time.Minute,
+		32 * time.Minute,
+		32 * time.Minute,
+		32 * time.Minute,
+	}
+	for i, expect := range want {
+		got = nextReadyWindow(got, max)
+		if got != expect {
+			t.Fatalf("step %d: nextReadyWindow = %v, want %v", i+1, got, expect)
+		}
+	}
+}
+
+func TestNextReadyWindowCapsWhenAlreadyAboveMax(t *testing.T) {
+	if got := nextReadyWindow(60*time.Minute, 32*time.Minute); got != 32*time.Minute {
+		t.Fatalf("nextReadyWindow = %v, want %v", got, 32*time.Minute)
+	}
+}
+
+func TestNextReadyWindowHandlesOverflow(t *testing.T) {
+	max := 32 * time.Minute
+	if got := nextReadyWindow(time.Duration(1)<<62, max); got != max {
+		t.Fatalf("nextReadyWindow on overflow = %v, want %v", got, max)
+	}
+}
+
+func TestReadyWindowEventuallyReachesCeiling(t *testing.T) {
+	max := 32 * time.Minute
+	w := 60 * time.Second
+	attempts := 0
+	for w < max {
+		w = nextReadyWindow(w, max)
+		attempts++
+		if attempts > 10 {
+			t.Fatalf("window did not reach ceiling: stuck at %v", w)
+		}
+	}
+	if w != max {
+		t.Fatalf("final window = %v, want %v", w, max)
+	}
+	if attempts != 5 {
+		t.Fatalf("attempts to reach ceiling = %d, want 5 (60s->2m->4m->8m->16m->32m)", attempts)
+	}
+}
+
+func TestManagerDefaultsReadyMaxWait(t *testing.T) {
+	m := NewManager(config.Config{BinDir: t.TempDir(), DataDir: t.TempDir()})
+	if m.cfg.ReadyMaxWait != 32*time.Minute {
+		t.Fatalf("default ReadyMaxWait = %v, want 32m", m.cfg.ReadyMaxWait)
+	}
+}
+
+func TestManagerReadyMaxWaitNeverBelowReadyTimeout(t *testing.T) {
+	m := NewManager(config.Config{
+		BinDir:       t.TempDir(),
+		DataDir:      t.TempDir(),
+		ReadyTimeout: 10 * time.Minute,
+		ReadyMaxWait: time.Minute,
+	})
+	if m.cfg.ReadyMaxWait != 10*time.Minute {
+		t.Fatalf("ReadyMaxWait = %v, want it raised to ReadyTimeout (10m)", m.cfg.ReadyMaxWait)
+	}
+}
+
+func TestProbeAllowsReadyWaitExtension(t *testing.T) {
+	if !probeAllowsReadyWaitExtension(readyProbeInitializing) {
+		t.Fatal("initializing should extend the window")
+	}
+	if !probeAllowsReadyWaitExtension(readyProbeReadyAbsent) {
+		t.Fatal("missing /ready should extend the window for older binaries")
+	}
+	for _, r := range []readyProbeResult{readyProbeUnreachable, readyProbeNotReady, readyProbeReady} {
+		if probeAllowsReadyWaitExtension(r) {
+			t.Fatalf("%s should not extend the window", r)
+		}
+	}
+}
+
+func TestReadyPathAbsent(t *testing.T) {
+	if !readyPathAbsent(http.StatusNotFound) {
+		t.Fatal("Echo returns 404 for an unregistered /ready; that must count as absent")
+	}
+	if !readyPathAbsent(http.StatusMethodNotAllowed) || !readyPathAbsent(http.StatusNotImplemented) {
+		t.Fatal("405/501 must count as absent, matching the legacy /ready fallback")
+	}
+	if readyPathAbsent(http.StatusServiceUnavailable) || readyPathAbsent(http.StatusOK) {
+		t.Fatal("503/200 are not an absent /ready route")
+	}
+}
+
+func TestReadyBodyInitializing(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "chain not ready", body: `{"ready":false,"draining":false,"storage_ready":true}`, want: true},
+		{name: "storage rebuilding", body: `{"ready":true,"draining":false,"storage_ready":false}`, want: true},
+		{name: "both not ready", body: `{"ready":false,"draining":false,"storage_ready":false}`, want: true},
+		{name: "draining", body: `{"ready":false,"draining":true,"storage_ready":true}`, want: false},
+		{name: "fully ready body", body: `{"ready":true,"draining":false,"storage_ready":true}`, want: false},
+		{name: "unparseable", body: `not json`, want: false},
+		{name: "empty", body: ``, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readyBodyInitializing([]byte(tt.body)); got != tt.want {
+				t.Fatalf("readyBodyInitializing(%s) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitForChildServingReadyExtendsWhileInitializing(t *testing.T) {
+	readyAt := time.Now().Add(350 * time.Millisecond)
+	adminPort, adminShutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ready" {
+			http.NotFound(w, r)
+			return
+		}
+		if time.Now().Before(readyAt) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"ready":false,"draining":false,"storage_ready":false}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ready":true,"draining":false,"storage_ready":true}`))
+	}))
+	defer adminShutdown()
+
+	publicPort, publicShutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer publicShutdown()
+
+	c := &child{port: publicPort}
+	setTestAdminPort(c, adminPort)
+	start := time.Now()
+	ready, last := waitForChildServingReadyUntil(context.Background(), c, "/ready", 80*time.Millisecond, time.Second)
+	if !ready {
+		t.Fatalf("initializing child should be waited for past minWait, last probe = %s", last)
+	}
+	if elapsed := time.Since(start); elapsed < 300*time.Millisecond {
+		t.Fatalf("became ready too fast (%s); expected to wait through initializing", elapsed)
+	}
+}
+
+func TestWaitForChildServingReadyFailsPromptlyWhenUnreachable(t *testing.T) {
+	port, shutdown := startLocalHTTPServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	shutdown()
+
+	c := &child{port: port}
+	start := time.Now()
+	ready, last := waitForChildServingReadyUntil(context.Background(), c, "/ready", 150*time.Millisecond, 2*time.Second)
+	if ready {
+		t.Fatal("unreachable child should not become ready")
+	}
+	if last != readyProbeUnreachable {
+		t.Fatalf("last probe = %s, want unreachable", last)
+	}
+	if elapsed := time.Since(start); elapsed > 600*time.Millisecond {
+		t.Fatalf("elapsed %s, want fail at minWait rather than maxWait", elapsed)
+	}
+}
+
+func TestWaitForChildServingReadyDoesNotExtendWhenDraining(t *testing.T) {
+	adminPort, adminShutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"ready":false,"draining":true,"storage_ready":true}`))
+	}))
+	defer adminShutdown()
+
+	publicPort, publicShutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer publicShutdown()
+
+	c := &child{port: publicPort}
+	setTestAdminPort(c, adminPort)
+	start := time.Now()
+	ready, last := waitForChildServingReadyUntil(context.Background(), c, "/ready", 80*time.Millisecond, time.Second)
+	if ready {
+		t.Fatal("draining child should not be treated as initializing")
+	}
+	if last != readyProbeNotReady {
+		t.Fatalf("last probe = %s, want not_ready", last)
+	}
+	if elapsed := time.Since(start); elapsed > 400*time.Millisecond {
+		t.Fatalf("elapsed %s, want fail at minWait rather than maxWait", elapsed)
+	}
+}
+
+func TestWaitForChildServingReadyExtendsWhenReadyPathAbsent(t *testing.T) {
+	readyAt := time.Now().Add(350 * time.Millisecond)
+	adminPort, adminShutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ready" || time.Now().Before(readyAt) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ready":true,"draining":false,"storage_ready":true}`))
+	}))
+	defer adminShutdown()
+
+	publicPort, publicShutdown := startLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer publicShutdown()
+
+	c := &child{port: publicPort}
+	setTestAdminPort(c, adminPort)
+	start := time.Now()
+	ready, last := waitForChildServingReadyUntil(context.Background(), c, "/ready", 80*time.Millisecond, time.Second)
+	if !ready {
+		t.Fatalf("404 on /ready should keep waiting like the legacy growing window, last probe = %s", last)
+	}
+	if elapsed := time.Since(start); elapsed < 300*time.Millisecond {
+		t.Fatalf("became ready too fast (%s); expected to wait through missing /ready", elapsed)
+	}
+}


### PR DESCRIPTION
# PR summary: versiond growing readiness window

Rebased and review-fixed follow-up of [gonka-ai/gonka#1620](https://github.com/gonka-ai/gonka/pull/1620) onto current `devshard-0.2.15-v5`. The original PR targeted `upgrade-v0.2.16` and picked up unrelated commits after the base change; only [a467dab](https://github.com/gonka-ai/gonka/commit/a467dabbfb2afbacd7d019bd3cc8c0ecfd592b7b) was the readiness-window fix.

## Summary

- Grow versiond's child readiness wait instead of killing a slow-but-alive start at a fixed 60s (the original #1620 problem: `devshardd` restoring a large session store restarted every ~2 minutes and never served its port).
- After `VERSIOND_READY_TIMEOUT` (default 60s), keep waiting up to `VERSIOND_READY_MAX_WAIT` (default 32m) while `/ready` reports initializing, or is absent (`404`/`405`/`501`) on older v3/v4 binaries that never registered the route.
- Fail promptly when the endpoint is unreachable or draining, so a hung child is not left un-restarted for 32 minutes. Reset the short window when the child reaches `running`. The same gate applies to crash-restarts and to the rolling-swap path (`restart=false`).

## Why this is not a straight cherry-pick of #1620

[#1620](https://github.com/gonka-ai/gonka/pull/1620) doubled the window blindly on every failed attempt. Review asked to distinguish slow from hung, reset after a successful start, apply the wait to rolling upgrade, document `VERSIOND_READY_MAX_WAIT`, and gofmt.

| Review comment | What this PR does |
|---|---|
| Reset the window at `statusRunning` | `readyWindow` returns to `ReadyTimeout` so a post-crash hang is detected in 60s again |
| Comment belongs on `waitForChildServingReady` | Restored; `nextReadyWindow` has its own one-liner |
| Use `/ready` body instead of blind doubling | Extend only while the body reports initializing (`ready: false` and/or `storage_ready: false`, not draining) |
| Older binaries have no `/ready` | Echo returns `404` for an unregistered path; treat `404`/`405`/`501` as the original growing window |
| Rolling-upgrade still used a fixed 60s | Swap starts the replacement with `restart=false`, but `runChild` now waits with `ReadyMaxWait` as the cap |
| Docs | `devshard/docs/rolling-update.md` settings table and readiness-gate notes |

## Behavior

1. Wait at least `VERSIOND_READY_TIMEOUT` (the process may not have bound a port yet).
2. If `/ready` is **200** and public `/healthz` is **2xx** → `running`.
3. If `/ready` is reachable and **initializing**, or **absent** (`404`/`405`/`501`) → keep waiting up to `VERSIOND_READY_MAX_WAIT`; on timeout, restart with a doubled window (60s → 2m → 4m → 8m → 16m → 32m).
4. If `/ready` is **unreachable** or **draining** after the short window → restart promptly without growing.
5. On `running`, reset to `ReadyTimeout`.

New setting: `VERSIOND_READY_MAX_WAIT` (default 32m), clamped to be at least `VERSIOND_READY_TIMEOUT`.

## Test plan

- [x] `go test ./internal/config ./internal/process -run 'ReadyWindow|ReadyMaxWait|ReadyBody|ReadyPath|ProbeAllows|WaitForChildServingReady'` in `versioned/`
- [ ] Confirm a modern child whose `/ready` stays 503 with `storage_ready: false` is not killed at 60s and becomes ready once restore finishes
- [ ] Confirm a hung child that never binds `/ready` is restarted at `VERSIOND_READY_TIMEOUT`, not 32m
- [ ] Confirm an older binary that 404s `/ready` still gets the growing window (and public 404 still falls back to `/healthz` then TCP when that is enough)
- [ ] Confirm a rolling SHA swap of a slow postgres `devshardd` is not rolled back at 60s
- [ ] Confirm a crash after `running` uses the 60s window again
