### PR TITLE
fix(devshard): reject host-injected user txs at the mempool boundary

### DIFF
--- a/devshard/bridge/grpc.go
+++ b/devshard/bridge/grpc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"common/chain"
 	devshardpkg "devshard"
@@ -14,6 +15,10 @@ import (
 )
 
 const warmKeyMsgTypeGRPC = "/inference.inference.MsgStartInference"
+
+// warmKeyQueryTimeout bounds a single grantee lookup. WarmKeyResolver has no
+// context parameter, so the deadline has to be applied here.
+const warmKeyQueryTimeout = 10 * time.Second
 
 type warmCacheKey struct {
 	host string
@@ -154,7 +159,11 @@ func (b *GRPCBridge) VerifyWarmKey(warmAddress, validatorAddress string) (bool, 
 		return cached.(bool), nil
 	}
 
-	resp, err := b.client.InferenceQueryClient().GranteesByMessageType(context.Background(),
+	// Callers reach this from state-machine apply while holding session locks,
+	// so an unresponsive node must not stall the escrow indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), warmKeyQueryTimeout)
+	defer cancel()
+	resp, err := b.client.InferenceQueryClient().GranteesByMessageType(ctx,
 		&inferencetypes.QueryGranteesByMessageTypeRequest{
 			GranterAddress: validatorAddress,
 			MessageTypeUrl: warmKeyMsgTypeGRPC,

--- a/devshard/cmd/devshardd/bridge/chain.go
+++ b/devshard/cmd/devshardd/bridge/chain.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strconv"
 	"sync"
+	"time"
 
 	"common/chain"
 	devshardpkg "devshard"
@@ -17,6 +18,10 @@ import (
 )
 
 const warmKeyMsgTypeGRPC = "/inference.inference.MsgStartInference"
+
+// warmKeyQueryTimeout bounds a single grantee lookup. WarmKeyResolver has no
+// context parameter, so the deadline has to be applied here.
+const warmKeyQueryTimeout = 10 * time.Second
 
 type warmCacheKey struct {
 	host string
@@ -174,7 +179,11 @@ func (b *ChainBridge) VerifyWarmKey(warmAddress, validatorAddress string) (bool,
 		return cached.(bool), nil
 	}
 
-	resp, err := b.client.InferenceQueryClient().GranteesByMessageType(context.Background(),
+	// Callers reach this from state-machine apply while holding session locks,
+	// so an unresponsive node must not stall the escrow indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), warmKeyQueryTimeout)
+	defer cancel()
+	resp, err := b.client.InferenceQueryClient().GranteesByMessageType(ctx,
 		&inferencetypes.QueryGranteesByMessageTypeRequest{
 			GranterAddress: validatorAddress,
 			MessageTypeUrl: warmKeyMsgTypeGRPC,

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -942,6 +942,19 @@ func (sm *StateMachine) Inference(id uint64) (*types.InferenceRecord, bool) {
 	return copyInferenceRecord(rec), true
 }
 
+// InferenceExecutorSlot returns the executor slot of a live inference record.
+// Unlike Inference it does not deep-copy the record, so it is cheap enough for
+// per-response admission checks.
+func (sm *StateMachine) InferenceExecutorSlot(id uint64) (uint32, bool) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	rec, ok := sm.state.Inferences[id]
+	if !ok || rec == nil {
+		return 0, false
+	}
+	return rec.ExecutorSlot, true
+}
+
 // InferenceStatusCounts returns the total number of inferences and a per-status
 // breakdown, computed under the read lock without deep-copying any records.
 func (sm *StateMachine) InferenceStatusCounts() (int, map[types.InferenceStatus]int) {
@@ -1714,6 +1727,40 @@ func (sm *StateMachine) VerifyFinishProposerSig(msg *types.MsgFinishInference) e
 		return nil
 	}
 	return fmt.Errorf("%w: expected %s, got %s", types.ErrInvalidProposerSig, expected, recovered)
+}
+
+// RejectFinishProposerSigLocal reports a proposer-signature failure that can be
+// decided from local state alone: the executor slot's cold key plus any warm
+// binding already cached in state. It never consults the warm-key resolver, so
+// it makes no network call and never takes the write lock.
+//
+// A nil return means "accepted, or not yet decidable". A mismatch is decidable
+// when the slot already has a warm binding, or when no resolver is configured
+// at all, because in neither case could the bridge change the answer. Otherwise
+// the signature may still belong to an unresolved warm key, and that is left to
+// apply-time verification via VerifyFinishProposerSig. Callers must therefore
+// treat nil as "may enqueue", not as "authenticated".
+func (sm *StateMachine) RejectFinishProposerSigLocal(msg *types.MsgFinishInference) error {
+	recovered, err := sm.recoveredProposerAddress(msg)
+	if err != nil {
+		return err
+	}
+
+	sm.mu.RLock()
+	expected, ok := sm.slotToAddress[msg.ExecutorSlot]
+	cached, hasCached := sm.state.WarmKeys[msg.ExecutorSlot]
+	canResolve := sm.warmResolver != nil
+	sm.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("%w: slot %d", types.ErrSlotNotInGroup, msg.ExecutorSlot)
+	}
+	if recovered == expected || (hasCached && cached == recovered) {
+		return nil
+	}
+	if hasCached || !canResolve {
+		return fmt.Errorf("%w: expected %s, got %s", types.ErrInvalidProposerSig, expected, recovered)
+	}
+	return nil
 }
 
 func (sm *StateMachine) recoveredProposerAddress(msg *types.MsgFinishInference) (string, error) {

--- a/devshard/state/machine_test.go
+++ b/devshard/state/machine_test.go
@@ -2743,6 +2743,66 @@ func TestWarmKey_ConfirmStartWithWarmKey(t *testing.T) {
 	require.True(t, sm.IsWarmKeyAddress(warmSigner.Address()))
 }
 
+// TestRejectFinishProposerSigLocal covers the admission-time check the user
+// session runs on every host mempool Finish. It must decide from local state
+// only: the escrow stalls if a host response can block on a bridge query.
+func TestRejectFinishProposerSigLocal(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
+	warmSigner := testutil.MustGenerateKey(t)
+	stranger := testutil.MustGenerateKey(t)
+	executorIdx := 1
+
+	finishFrom := func(t *testing.T, signer *signing.Secp256k1Signer, slot uint32) *types.MsgFinishInference {
+		t.Helper()
+		msg := &types.MsgFinishInference{
+			InferenceId: 1, ResponseHash: []byte("hash"),
+			InputTokens: 80, OutputTokens: 40, ExecutorSlot: slot, EscrowId: "escrow-1",
+		}
+		msg.ProposerSig = testutil.SignProposerTx(t, signer, msg)
+		return msg
+	}
+
+	t.Run("executor cold key accepted", func(t *testing.T) {
+		sm, _ := newTestSM(t, hosts, 10000)
+		require.NoError(t, sm.RejectFinishProposerSigLocal(finishFrom(t, hosts[executorIdx], uint32(executorIdx))))
+	})
+
+	t.Run("stranger rejected when no resolver is configured", func(t *testing.T) {
+		sm, _ := newTestSM(t, hosts, 10000)
+		require.ErrorIs(t, sm.RejectFinishProposerSigLocal(finishFrom(t, stranger, uint32(executorIdx))),
+			types.ErrInvalidProposerSig)
+	})
+
+	t.Run("unknown slot rejected", func(t *testing.T) {
+		sm, _ := newTestSM(t, hosts, 10000)
+		require.ErrorIs(t, sm.RejectFinishProposerSigLocal(finishFrom(t, hosts[executorIdx], 99)),
+			types.ErrSlotNotInGroup)
+	})
+
+	t.Run("stranger allowed through when a warm key could still resolve", func(t *testing.T) {
+		var calls int
+		sm, _ := newTestSMWithWarmKey(t, hosts, 10000, func(string, string) (bool, error) {
+			calls++
+			return false, nil
+		})
+		require.NoError(t, sm.RejectFinishProposerSigLocal(finishFrom(t, stranger, uint32(executorIdx))),
+			"undecidable without the bridge, so apply-time verification owns it")
+		require.Zero(t, calls, "admission check must never call the warm key resolver")
+	})
+
+	t.Run("cached warm key decides both ways", func(t *testing.T) {
+		sm, user := newTestSMWithWarmKey(t, hosts, 10000, func(warmAddr, coldAddr string) (bool, error) {
+			return warmAddr == warmSigner.Address() && coldAddr == hosts[executorIdx].Address(), nil
+		})
+		applyStartConfirmWithWarmKey(t, sm, user, hosts, warmSigner, 1, executorIdx)
+		require.Equal(t, warmSigner.Address(), sm.SnapshotState().WarmKeys[uint32(executorIdx)])
+
+		require.NoError(t, sm.RejectFinishProposerSigLocal(finishFrom(t, warmSigner, uint32(executorIdx))))
+		require.ErrorIs(t, sm.RejectFinishProposerSigLocal(finishFrom(t, stranger, uint32(executorIdx))),
+			types.ErrInvalidProposerSig)
+	})
+}
+
 func TestWarmKey_ConfirmStartRejectsUnauthorizedKey(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t)}
 	randomKey := testutil.MustGenerateKey(t)

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -356,7 +356,7 @@ func finishRecover(sess *Session, sm *state.StateMachine) (*Session, *state.Stat
 	}
 	restoreHeartbeatProducer(sess, sm)
 	if sess.store == nil {
-		restorePendingTxKeys(sess, nil)
+		restoreAppliedTxKeys(sess, nil)
 		return sess, sm, nil
 	}
 	meta, err := sess.store.GetSessionMeta(sess.escrowID)
@@ -370,7 +370,7 @@ func finishRecover(sess *Session, sm *state.StateMachine) (*Session, *state.Stat
 			return nil, nil, fmt.Errorf("get diffs for validation obs rebuild: %w", err)
 		}
 	}
-	restorePendingTxKeys(sess, records)
+	restoreAppliedTxKeys(sess, records)
 	if err := storage.RebuildValidationObsFromDiffs(
 		sess.store,
 		sess.escrowID,
@@ -382,7 +382,9 @@ func finishRecover(sess *Session, sm *state.StateMachine) (*Session, *state.Stat
 	return sess, sm, nil
 }
 
-func restorePendingTxKeys(sess *Session, records []types.DiffRecord) {
+// restoreAppliedTxKeys re-seeds the applied-key set from the reconstructed diff
+// log so a host mempool copy of an already-included tx is not re-queued.
+func restoreAppliedTxKeys(sess *Session, records []types.DiffRecord) {
 	if sess == nil {
 		return
 	}
@@ -391,14 +393,14 @@ func restorePendingTxKeys(sess *Session, records []types.DiffRecord) {
 	for _, diff := range sess.diffs {
 		for _, tx := range diff.Txs {
 			if key := devshardTxKey(tx); key != "" {
-				sess.pendingTxKeys[key] = struct{}{}
+				sess.appliedTxKeys[key] = struct{}{}
 			}
 		}
 	}
 	for _, rec := range records {
 		for _, tx := range rec.Diff.Txs {
 			if key := devshardTxKey(tx); key != "" {
-				sess.pendingTxKeys[key] = struct{}{}
+				sess.appliedTxKeys[key] = struct{}{}
 			}
 		}
 	}

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -241,10 +241,18 @@ type Session struct {
 	participantKeys []string
 	clients         []HostClient
 	nonce           uint64
-	diffs           []types.Diff        // append-only log
-	hostSyncNonce   map[int]uint64      // hostIdx -> last nonce sent
-	pendingTxs      []*types.DevshardTx // from host mempools, for next diff
-	pendingTxKeys   map[string]struct{} // dedup set keyed by tx_type:id
+	diffs           []types.Diff                 // append-only log
+	hostSyncNonce   map[int]uint64               // hostIdx -> last nonce sent
+	pendingTxs      []*types.DevshardTx          // from host mempools, for next diff
+	// pendingTxKeys dedups the current pendingTxs slice by tx_type:id. It is
+	// rebuilt from what compose retained, so a tx that failed to apply frees
+	// its key again -- otherwise the first host to propose a bogus tx would
+	// permanently shadow the honest tx sharing that key.
+	pendingTxKeys map[string]struct{}
+	// appliedTxKeys holds tx_type:id for txs that actually landed in a diff,
+	// so another host's mempool copy is not re-queued after the fact. Only
+	// this set survives across compose rounds.
+	appliedTxKeys map[string]struct{}
 	// pinnedFinishIDs holds inference IDs whose pending Finish and ErrorMiss
 	// must not be drained by a concurrent composeDiffLocked (heartbeat,
 	// PrepareInference, unrelated SendPendingDiff). HandleErrorMiss pins
@@ -470,6 +478,7 @@ func NewSession(
 		clients:         clients,
 		hostSyncNonce:   make(map[int]uint64),
 		pendingTxKeys:   make(map[string]struct{}),
+		appliedTxKeys:   make(map[string]struct{}),
 		pinnedFinishIDs: make(map[uint64]int),
 		signatures:      make(map[uint64]map[uint32][]byte),
 		nonceStates:     make(map[uint64]*nonceOutcome),
@@ -827,7 +836,7 @@ func (s *Session) composeDiffLockedInclude(extraTxs []*types.DevshardTx, include
 		}
 		s.diffs = append(s.diffs, diff)
 		s.nonce = nonce
-		s.retainPendingLocked(held)
+		s.retainPendingLocked(held, vd.Applied)
 		s.maybeSaveSnapshotLocked()
 		s.observeTurnLocked(diff)
 		s.diffObserver(diff)
@@ -844,7 +853,7 @@ func (s *Session) composeDiffLockedInclude(extraTxs []*types.DevshardTx, include
 	}
 	s.diffs = append(s.diffs, diff)
 	s.nonce = nonce
-	s.retainPendingLocked(held)
+	s.retainPendingLocked(held, applied)
 	s.observeTurnLocked(diff)
 	s.diffObserver(diff)
 	return diff, hostIdx, nil
@@ -923,11 +932,20 @@ func (s *Session) splitPendingForComposeLocked(includePinned []uint64) (candidat
 	return candidates, held
 }
 
-func (s *Session) retainPendingLocked(held []*types.DevshardTx) {
-	s.pendingTxs = held
-	if len(s.pendingTxKeys) <= maxPendingTxKeys {
-		return
+// retainPendingLocked installs the txs compose held back and records the ones
+// it actually applied. Candidates that were dropped by best-effort apply are
+// deliberately not remembered: freeing their key lets an honest tx with the
+// same tx_type:id be queued on a later response.
+func (s *Session) retainPendingLocked(held, applied []*types.DevshardTx) {
+	for _, tx := range applied {
+		if key := devshardTxKey(tx); key != "" {
+			s.appliedTxKeys[key] = struct{}{}
+		}
 	}
+	if len(s.appliedTxKeys) > maxAppliedTxKeys {
+		clear(s.appliedTxKeys)
+	}
+	s.pendingTxs = held
 	clear(s.pendingTxKeys)
 	for _, tx := range held {
 		if key := devshardTxKey(tx); key != "" {
@@ -1705,31 +1723,93 @@ func (s *Session) signDiff(nonce uint64, txs []*types.DevshardTx, postStateRoot 
 }
 
 // devshardTxKey returns a dedup key for host-proposed txs.
-// Returns "" for user-proposed types (start, finalize, timeout).
+// Returns "" when tx is nil, the inner message is nil, or the type is not
+// deduped (user/sequencer types and unknown txs). Dedup identity only; whether
+// a host may enqueue a type is hostMayProposeTx.
 func devshardTxKey(tx *types.DevshardTx) string {
+	if tx == nil {
+		return ""
+	}
 	switch inner := tx.GetTx().(type) {
 	case *types.DevshardTx_FinishInference:
+		if inner.FinishInference == nil {
+			return ""
+		}
 		return fmt.Sprintf("finish:%d", inner.FinishInference.InferenceId)
 	case *types.DevshardTx_ConfirmStart:
+		if inner.ConfirmStart == nil {
+			return ""
+		}
 		return fmt.Sprintf("confirm:%d", inner.ConfirmStart.InferenceId)
 	case *types.DevshardTx_Validation:
+		if inner.Validation == nil {
+			return ""
+		}
 		return fmt.Sprintf("validation:%d:%d", inner.Validation.InferenceId, inner.Validation.ValidatorSlot)
 	case *types.DevshardTx_ValidationVote:
+		if inner.ValidationVote == nil {
+			return ""
+		}
 		return fmt.Sprintf("vote:%d:%d", inner.ValidationVote.InferenceId, inner.ValidationVote.VoterSlot)
 	case *types.DevshardTx_RevealSeed:
+		if inner.RevealSeed == nil {
+			return ""
+		}
 		return fmt.Sprintf("reveal_seed:%d", inner.RevealSeed.SlotId)
 	case *types.DevshardTx_HeightAck:
+		if inner.HeightAck == nil {
+			return ""
+		}
 		return fmt.Sprintf("height_ack:%d:%d", inner.HeightAck.TurnSeq, inner.HeightAck.SlotId)
 	default:
 		return ""
 	}
 }
 
-// addPendingTx appends tx to pendingTxs if not a duplicate.
+// hostMayProposeTx is the response-boundary allowlist. It is independent of
+// devshardTxKey: adding a dedup key for Start must not start enqueueing Starts.
+// Nil inner messages are rejected so a oneof with a nil payload cannot panic
+// later or sneak past the allowlist.
+func hostMayProposeTx(tx *types.DevshardTx) bool {
+	if tx == nil {
+		return false
+	}
+	switch inner := tx.GetTx().(type) {
+	case *types.DevshardTx_FinishInference:
+		return inner.FinishInference != nil
+	case *types.DevshardTx_ConfirmStart:
+		return inner.ConfirmStart != nil
+	case *types.DevshardTx_Validation:
+		return inner.Validation != nil
+	case *types.DevshardTx_ValidationVote:
+		return inner.ValidationVote != nil
+	case *types.DevshardTx_RevealSeed:
+		return inner.RevealSeed != nil
+	case *types.DevshardTx_HeightAck:
+		return inner.HeightAck != nil
+	default:
+		return false
+	}
+}
+
+// hostRecoveryDedupKey is the CollectTimeoutVotes / CollectErrorMissVotes
+// identity for mempool copies. User-proposed types never become recovery.
+func hostRecoveryDedupKey(tx *types.DevshardTx) string {
+	if !hostMayProposeTx(tx) {
+		return ""
+	}
+	return devshardTxKey(tx)
+}
+
+// addPendingTx appends tx to pendingTxs unless its key is already queued or
+// already landed in a diff.
 func (s *Session) addPendingTx(tx *types.DevshardTx) {
+	if tx == nil {
+		return
+	}
 	key := devshardTxKey(tx)
 	if key != "" {
-		if _, dup := s.pendingTxKeys[key]; dup {
+		if s.txKeyQueuedOrApplied(key) {
 			return
 		}
 		s.pendingTxKeys[key] = struct{}{}
@@ -1737,12 +1817,113 @@ func (s *Session) addPendingTx(tx *types.DevshardTx) {
 	s.pendingTxs = append(s.pendingTxs, tx)
 }
 
-// addPendingFromHostLocked queues a mempool/receipt tx from one host response.
-// A host-signed raise that does not match this hop's response-leg envelope is
-// dropped (spec §14 rule 2). In-process and omit-section hops leave HasEnvelope
-// unset and skip the check.
+func (s *Session) txKeyQueuedOrApplied(key string) bool {
+	if _, dup := s.pendingTxKeys[key]; dup {
+		return true
+	}
+	_, applied := s.appliedTxKeys[key]
+	return applied
+}
+
+// hostTxInferenceID returns the inference a host-proposed tx acts on. HeightAck
+// and RevealSeed are slot-scoped rather than inference-scoped.
+func hostTxInferenceID(tx *types.DevshardTx) (uint64, bool) {
+	switch {
+	case tx.GetConfirmStart() != nil:
+		return tx.GetConfirmStart().InferenceId, true
+	case tx.GetFinishInference() != nil:
+		return tx.GetFinishInference().InferenceId, true
+	case tx.GetValidation() != nil:
+		return tx.GetValidation().InferenceId, true
+	case tx.GetValidationVote() != nil:
+		return tx.GetValidationVote().InferenceId, true
+	default:
+		return 0, false
+	}
+}
+
+// rejectUnverifiedHostTx returns a non-nil error when local state can already
+// prove tx cannot apply. Two checks, both map lookups on the hot path:
+//
+// The inference must be live. applyConfirmStart, applyValidation and
+// applyValidationVote all reject an id that is absent or sealed, so admitting
+// one only buys an expensive signature recovery at compose time. Rejecting
+// here also stops a host from parking unbounded made-up ids in pending, which
+// matters now that a tx failing to apply releases its dedup key.
+//
+// A Finish must additionally come from the assigned executor. Confirm and
+// validation still authenticate on apply; Finish is checked here so an
+// unsigned or wrong-slot one cannot sit in pending and ride into a later Diff.
+// That signature check is deliberately resolver-free: a Finish signed by a warm
+// key for a slot with no cached binding is undecidable without a bridge round
+// trip, so it is allowed through and authenticated on apply. Blocking a host
+// response on a chain query would stall every inference on the session.
+func (s *Session) rejectUnverifiedHostTx(tx *types.DevshardTx) error {
+	inferenceID, scoped := hostTxInferenceID(tx)
+	if !scoped {
+		return nil
+	}
+	if s.sm == nil {
+		// Nothing to authenticate against, so admit nothing: an inference-scoped
+		// tx is only admissible when a live record backs it.
+		return types.ErrInferenceNotFound
+	}
+	executorSlot, ok := s.sm.InferenceExecutorSlot(inferenceID)
+	if !ok {
+		return types.ErrInferenceNotFound
+	}
+	fi := tx.GetFinishInference()
+	if fi == nil {
+		return nil
+	}
+	if fi.ExecutorSlot != executorSlot {
+		return types.ErrWrongExecutorSlot
+	}
+	if fi.EscrowId != s.escrowID {
+		return types.ErrEscrowIDMismatch
+	}
+	return s.sm.RejectFinishProposerSigLocal(fi)
+}
+
+// recoveryHostIdx marks a tx recovered from a timeout vote rather than read off
+// one host's response, so there is no response envelope or owning slot set.
+const recoveryHostIdx = -1
+
+// addPendingFromHostLocked queues a mempool/receipt tx from one host response
+// or timeout-recovery copy. User/sequencer types are dropped. Finish must be
+// signed by the assigned executor of a live inference. A host-signed raise
+// that does not match this hop's response-leg envelope is dropped (spec §14
+// rule 2). In-process, recovery, and omit-section hops leave HasEnvelope unset
+// and skip the envelope check.
 func (s *Session) addPendingFromHostLocked(hostIdx int, resp *host.HostResponse, tx *types.DevshardTx) {
 	if tx == nil {
+		return
+	}
+	if !hostMayProposeTx(tx) {
+		logging.Warn("dropped user-proposed tx from host mempool",
+			"subsystem", "session", "escrow", s.escrowID, "host_idx", hostIdx,
+			"tx_type", fmt.Sprintf("%T", tx.GetTx()))
+		return
+	}
+	// Settle dedup before verifying: every host gossips the same Finish, and
+	// signature recovery is far more expensive than the map lookup that would
+	// discard the result anyway. The envelope filter below can swap tx for a
+	// stamped copy, but never changes its dedup key.
+	if key := devshardTxKey(tx); key != "" && s.txKeyQueuedOrApplied(key) {
+		return
+	}
+	if err := s.rejectUnverifiedHostTx(tx); err != nil {
+		// A tx for an inference the sequencer no longer tracks is ordinary
+		// late gossip after auto-seal, not evidence of a misbehaving host.
+		if errors.Is(err, types.ErrInferenceNotFound) {
+			logging.Debug("dropped host tx for unknown or sealed inference",
+				"subsystem", "session", "escrow", s.escrowID, "host_idx", hostIdx,
+				"tx_type", fmt.Sprintf("%T", tx.GetTx()))
+		} else {
+			logging.Warn("dropped host Finish not signed by inference executor",
+				"subsystem", "session", "escrow", s.escrowID, "host_idx", hostIdx,
+				"error", err)
+		}
 		return
 	}
 	if resp != nil && resp.HasEnvelope {
@@ -1774,15 +1955,17 @@ func (s *Session) ownSlotsLocked(hostIdx int) map[uint32]struct{} {
 	return out
 }
 
-const maxPendingTxKeys = 100_000
+const maxAppliedTxKeys = 100_000
 
-// clearPendingTxs resets the pending tx slice. The dedup key set is preserved
-// so that txs already applied in earlier diffs are not re-added from another
-// host's mempool. The key set is bulk-cleared only when it exceeds the cap.
+// clearPendingTxs drops the pending tx slice and the keys that were reserving
+// a slot in it. Keys of txs already applied in earlier diffs are preserved, so
+// another host's mempool copy is still not re-added. The applied set is
+// bulk-cleared only when it exceeds the cap.
 func (s *Session) clearPendingTxs() {
 	s.pendingTxs = nil
-	if len(s.pendingTxKeys) > maxPendingTxKeys {
-		clear(s.pendingTxKeys)
+	clear(s.pendingTxKeys)
+	if len(s.appliedTxKeys) > maxAppliedTxKeys {
+		clear(s.appliedTxKeys)
 	}
 }
 
@@ -2602,10 +2785,7 @@ func (s *Session) HandleTimeout(ctx context.Context, nonce uint64, sendTime time
 	if reason == types.TimeoutReason_TIMEOUT_REASON_REFUSED && len(recovery) > 0 {
 		s.mu.Lock()
 		for _, tx := range recovery {
-			if tx == nil {
-				continue
-			}
-			s.addPendingTx(tx)
+			s.addPendingFromHostLocked(recoveryHostIdx, nil, tx)
 		}
 		s.mu.Unlock()
 		if err := s.SendPendingDiff(ctx); err != nil {
@@ -3074,7 +3254,7 @@ func (s *Session) collectTimeoutVotes(
 				rejectCauses = append(rejectCauses, res.rejectCause)
 			}
 			for _, tx := range host.RecoveryTxsFor(res.mempool, inferenceID) {
-				key := devshardTxKey(tx)
+				key := hostRecoveryDedupKey(tx)
 				if key == "" {
 					continue
 				}
@@ -3230,9 +3410,9 @@ func (s *Session) CollectErrorMissVotes(
 			}
 			logging.Stage(ctx, "timeout_vote_result", logFields(res.verifierAddr, "accept", false, "reject_cause", res.rejectCause)...)
 			for _, tx := range host.RecoveryTxsFor(res.mempool, inferenceID) {
-				key := devshardTxKey(tx)
+				key := hostRecoveryDedupKey(tx)
 				if key == "" {
-					key = fmt.Sprintf("%p", tx)
+					continue
 				}
 				if _, ok := seenRecovery[key]; ok {
 					continue

--- a/devshard/user/session_test.go
+++ b/devshard/user/session_test.go
@@ -369,7 +369,10 @@ func TestUser_PendingTxDedup(t *testing.T) {
 }
 
 func TestPendingTxDedupKeys_HostProposedIdentity(t *testing.T) {
-	session := &Session{pendingTxKeys: make(map[string]struct{})}
+	session := &Session{
+		pendingTxKeys: make(map[string]struct{}),
+		appliedTxKeys: make(map[string]struct{}),
+	}
 
 	keyed := []struct {
 		name string
@@ -429,10 +432,21 @@ func TestPendingTxDedupKeys_HostProposedIdentity(t *testing.T) {
 			session.addPendingTx(tc.tx)
 			require.Len(t, session.PendingTxs(), before+1,
 				"same host-proposed tx key must not be queued twice")
+
+			// Draining the queue without applying anything must release the
+			// key, so an honest tx is not shadowed by one that never landed.
 			session.clearPendingTxs()
 			session.addPendingTx(tc.tx)
+			require.Len(t, session.PendingTxs(), 1,
+				"a key that never applied must be reusable")
+
+			// Once it applies, the key is retained and later mempool copies
+			// from other hosts are ignored.
+			session.retainPendingLocked(nil, []*types.DevshardTx{tc.tx})
+			session.addPendingTx(tc.tx)
 			require.Empty(t, session.PendingTxs(),
-				"clearing applied pending txs preserves the dedup key")
+				"an applied tx must not be re-queued from another host mempool")
+			session.clearPendingTxs()
 		})
 	}
 
@@ -460,6 +474,561 @@ func TestPendingTxDedupKeys_HostProposedIdentity(t *testing.T) {
 	session.addPendingTx(unkeyedHeartbeat)
 	require.Len(t, session.PendingTxs(), before+4,
 		"user-authored/unkeyed txs are outside host-proposed pending dedup")
+}
+
+func TestHostMayProposeTx(t *testing.T) {
+	require.False(t, hostMayProposeTx(nil))
+	require.False(t, hostMayProposeTx(&types.DevshardTx{}))
+	require.False(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_StartInference{
+		StartInference: &types.MsgStartInference{InferenceId: 2},
+	}}))
+	require.False(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_TimeoutInference{
+		TimeoutInference: &types.MsgTimeoutInference{InferenceId: 1},
+	}}))
+	require.False(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_FinalizeRound{
+		FinalizeRound: &types.MsgFinalizeRound{},
+	}}))
+	require.False(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_Heartbeat{
+		Heartbeat: &types.MsgHeartbeat{TurnSeq: 1},
+	}}))
+	require.False(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_ForceHeightSyncTurn{
+		ForceHeightSyncTurn: &types.MsgForceHeightSyncTurn{TriggerNonce: 1},
+	}}))
+	require.False(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_ErrorMiss{
+		ErrorMiss: &types.MsgErrorMiss{InferenceId: 1},
+	}}))
+	require.False(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_FinishInference{}}),
+		"nil inner Finish must not pass the allowlist")
+	require.True(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_FinishInference{
+		FinishInference: &types.MsgFinishInference{InferenceId: 1},
+	}}))
+	require.True(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{
+		ConfirmStart: &types.MsgConfirmStart{InferenceId: 1},
+	}}))
+	require.True(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_Validation{
+		Validation: &types.MsgValidation{InferenceId: 1, ValidatorSlot: 2},
+	}}))
+	require.True(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_ValidationVote{
+		ValidationVote: &types.MsgValidationVote{InferenceId: 1, VoterSlot: 2},
+	}}))
+	require.True(t, hostMayProposeTx(&types.DevshardTx{Tx: &types.DevshardTx_HeightAck{
+		HeightAck: &types.MsgHeightAck{TurnSeq: 1, SlotId: 0},
+	}}))
+}
+
+func TestDevshardTxKey_NilInnerDoesNotPanic(t *testing.T) {
+	require.Empty(t, devshardTxKey(nil))
+	require.Empty(t, devshardTxKey(&types.DevshardTx{}))
+	require.Empty(t, devshardTxKey(&types.DevshardTx{Tx: &types.DevshardTx_FinishInference{}}))
+	require.Empty(t, devshardTxKey(&types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{}}))
+	require.Empty(t, devshardTxKey(&types.DevshardTx{Tx: &types.DevshardTx_Validation{}}))
+	require.Empty(t, devshardTxKey(&types.DevshardTx{Tx: &types.DevshardTx_ValidationVote{}}))
+	require.Empty(t, devshardTxKey(&types.DevshardTx{Tx: &types.DevshardTx_RevealSeed{}}))
+	require.Empty(t, devshardTxKey(&types.DevshardTx{Tx: &types.DevshardTx_HeightAck{}}))
+	require.Equal(t, "finish:7", devshardTxKey(&types.DevshardTx{Tx: &types.DevshardTx_FinishInference{
+		FinishInference: &types.MsgFinishInference{InferenceId: 7},
+	}}))
+}
+
+func TestProcessResponse_DropsUserProposedMempoolTxs(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 100)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+	_, err := session.SendInference(ctx, params)
+	require.NoError(t, err)
+
+	injectedStart := injectedStartTx(2)
+	injectedTimeout := &types.DevshardTx{Tx: &types.DevshardTx_TimeoutInference{
+		TimeoutInference: &types.MsgTimeoutInference{InferenceId: 1},
+	}}
+	injectedFinalize := &types.DevshardTx{Tx: &types.DevshardTx_FinalizeRound{
+		FinalizeRound: &types.MsgFinalizeRound{},
+	}}
+	honestAck := &types.DevshardTx{Tx: &types.DevshardTx_HeightAck{
+		HeightAck: &types.MsgHeightAck{TurnSeq: 1, SlotId: 0},
+	}}
+
+	err = session.ProcessResponse(0, &host.HostResponse{
+		Nonce: session.Nonce(),
+		Mempool: []*types.DevshardTx{
+			injectedStart, injectedTimeout, injectedFinalize, honestAck,
+		},
+	}, 1)
+	require.NoError(t, err)
+
+	pending := session.PendingTxs()
+	require.Nil(t, findPendingStart(pending, 2), "host Mempool Start must not be queued")
+	require.Nil(t, findPendingTimeout(pending, 1), "host Mempool Timeout must not be queued")
+	require.Nil(t, findPendingFinalize(pending), "host Mempool Finalize must not be queued")
+	require.NotNil(t, findPendingHeightAck(pending, 1, 0), "host-proposed HeightAck must still queue")
+	require.Equal(t, types.PhaseActive, session.StateMachine().SnapshotState().Phase)
+}
+
+// TestSendInference_HostInjectedStartIsDropped is the attack-shaped fixture:
+// the selected participant returns a valid nonce-1 receipt/Finish and also
+// appends an unsigned Start(2) to the same Mempool. The gateway must keep
+// Confirm/Finish and drop Start so ordinary Finalize cannot reserve attacker
+// cost on nonce 2.
+func TestSendInference_HostInjectedStartIsDropped(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 8_000_000_000, 100)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+
+	execIdx := 1 // nonce 1 % 3
+	wrapHostWithMempoolInjection(session, execIdx, []*types.DevshardTx{
+		injectedStartTx(2),
+		{Tx: &types.DevshardTx_TimeoutInference{TimeoutInference: &types.MsgTimeoutInference{InferenceId: 1}}},
+		{Tx: &types.DevshardTx_FinalizeRound{FinalizeRound: &types.MsgFinalizeRound{}}},
+	})
+
+	resp, err := session.SendInference(ctx, params)
+	require.NoError(t, err)
+	require.NotNil(t, findPendingStart(resp.Mempool, 2), "fixture must place Start2 on the host response")
+	require.NotNil(t, findPendingFinalize(resp.Mempool), "fixture must place Finalize on the host response")
+	require.True(t, HasMsgFinish(resp.Mempool, 1), "honest Finish1 must still be on the response")
+
+	pending := session.PendingTxs()
+	require.Nil(t, findPendingStart(pending, 2), "injected Start2 must not enter pending")
+	require.Nil(t, findPendingTimeout(pending, 1), "injected Timeout must not enter pending")
+	require.Nil(t, findPendingFinalize(pending), "injected Finalize must not enter pending")
+	require.NotNil(t, findRecoveryFinish(pending, 1), "host Finish1 must still be queued")
+	require.Equal(t, types.PhaseActive, session.StateMachine().SnapshotState().Phase)
+	_, hasInjected := session.StateMachine().Inference(2)
+	require.False(t, hasInjected)
+
+	require.NoError(t, session.Finalize(ctx))
+	requireNoInjectedStartInDiffs(t, session, 1)
+	_, hasInjected = session.StateMachine().Inference(2)
+	require.False(t, hasInjected, "injected Start must not create an inference record")
+	st := session.StateMachine().SnapshotState()
+	for slot, hs := range st.HostStats {
+		require.Less(t, hs.Cost, uint64(799_999_800),
+			"slot %d must not be paid the injected reservation", slot)
+	}
+}
+
+func TestSendInference_HostInjectedStartDoesNotBlockNextUserInference(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 8_000_000_000, 100)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+
+	wrapHostWithMempoolInjection(session, 1, []*types.DevshardTx{injectedStartTx(2)})
+	resp, err := session.SendInference(ctx, params)
+	require.NoError(t, err)
+	require.NotNil(t, findPendingStart(resp.Mempool, 2))
+	require.Nil(t, findPendingStart(session.PendingTxs(), 2))
+
+	resp2, err := session.SendInference(ctx, params)
+	require.NoError(t, err, "dropped Start2 must not make the next user Start fail compose")
+	require.Equal(t, uint64(2), resp2.Nonce)
+
+	rec, ok := session.StateMachine().Inference(2)
+	require.True(t, ok, "nonce 2 must be the creator's next inference")
+	require.Equal(t, uint64(testutil.TestMaxTokens), rec.MaxTokens, "nonce 2 must use creator params, not the injected reservation")
+	require.Equal(t, uint64(100+testutil.TestMaxTokens), rec.ReservedCost)
+
+	foundUserStart2 := false
+	for _, d := range session.Diffs() {
+		for _, tx := range d.Txs {
+			start := tx.GetStartInference()
+			if start == nil || start.InferenceId != 2 {
+				continue
+			}
+			foundUserStart2 = true
+			require.Equal(t, uint64(testutil.TestMaxTokens), start.MaxTokens)
+		}
+	}
+	require.True(t, foundUserStart2, "creator Start2 must be in a signed Diff")
+}
+
+func TestProcessResponse_InjectedStartDoesNotReserveOnFinalize(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 8_000_000_000, 100)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+	_, err := session.SendInference(ctx, params)
+	require.NoError(t, err)
+
+	err = session.ProcessResponse(1, &host.HostResponse{
+		Nonce:   session.Nonce(),
+		Mempool: []*types.DevshardTx{injectedStartTx(2)},
+	}, 1)
+	require.NoError(t, err)
+	require.Nil(t, findPendingStart(session.PendingTxs(), 2))
+
+	require.NoError(t, session.Finalize(ctx))
+	requireNoInjectedStartInDiffs(t, session, 1)
+	_, hasInjected := session.StateMachine().Inference(2)
+	require.False(t, hasInjected, "injected Start must not create an inference record")
+}
+
+// TestProcessResponse_ForgedConfirmDoesNotShadowHonestConfirm covers the dedup
+// half of the injection surface. A dedup key is claimed at enqueue time, so a
+// host that races in a bogus ConfirmStart used to burn confirm:<id> for the
+// lifetime of the session: the tx failed to apply and was discarded, but its
+// key survived and silently dropped the executor's real ConfirmStart, leaving
+// the inference unconfirmable and settling it at full reserved cost. Keys are
+// now retained only for txs that actually applied.
+func TestProcessResponse_ForgedConfirmDoesNotShadowHonestConfirm(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 100)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+	nonce := prepared.diff.Nonce
+	execIdx := int(nonce % uint64(len(session.clients)))
+	execHost := session.clients[execIdx].(*InProcessClient).Host
+
+	_, _, err = execHost.ChallengeReceipt(ctx, nonce, &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}, []types.Diff{prepared.diff})
+	require.NoError(t, err)
+
+	var honestConfirm *types.DevshardTx
+	for _, tx := range execHost.MempoolTxs() {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == nonce {
+			honestConfirm = tx
+			break
+		}
+	}
+	require.NotNil(t, honestConfirm, "fixture must produce the executor's ConfirmStart")
+
+	forged := &types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: nonce,
+		ExecutorSig: []byte("not-a-signature"),
+		ConfirmedAt: 1000,
+	}}}
+
+	// A non-executor host wins the race to confirm:<id>.
+	nonExecIdx := (execIdx + 1) % len(session.clients)
+	require.NoError(t, session.ProcessResponse(nonExecIdx, &host.HostResponse{
+		Nonce:   nonce,
+		Mempool: []*types.DevshardTx{forged},
+	}, nonce))
+	require.NotNil(t, findPendingConfirm(session.PendingTxs(), nonce),
+		"fixture must queue the forged ConfirmStart")
+
+	require.NoError(t, session.SendPendingDiff(ctx))
+	require.Nil(t, findPendingConfirm(session.PendingTxs(), nonce),
+		"forged ConfirmStart must be dropped by best-effort apply")
+	rec, ok := session.StateMachine().Inference(nonce)
+	require.True(t, ok)
+	require.NotEqual(t, types.StatusStarted, rec.Status,
+		"forged ConfirmStart must not start the inference")
+
+	require.NoError(t, session.ProcessResponse(execIdx, &host.HostResponse{
+		Nonce:   session.Nonce(),
+		Mempool: []*types.DevshardTx{honestConfirm},
+	}, nonce))
+	require.NotNil(t, findPendingConfirm(session.PendingTxs(), nonce),
+		"executor ConfirmStart must not be shadowed by the failed forgery")
+
+	require.NoError(t, session.SendPendingDiff(ctx))
+	rec, ok = session.StateMachine().Inference(nonce)
+	require.True(t, ok)
+	require.Equal(t, types.StatusStarted, rec.Status,
+		"honest ConfirmStart must still be able to start the inference")
+}
+
+// TestProcessResponse_AppliedConfirmIsNotRequeued is the counterpart: once a tx
+// actually lands in a diff, another host's mempool copy must stay out.
+func TestProcessResponse_AppliedConfirmIsNotRequeued(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 100)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+	nonce := prepared.diff.Nonce
+	execIdx := int(nonce % uint64(len(session.clients)))
+	execHost := session.clients[execIdx].(*InProcessClient).Host
+
+	_, _, err = execHost.ChallengeReceipt(ctx, nonce, &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}, []types.Diff{prepared.diff})
+	require.NoError(t, err)
+
+	var honestConfirm *types.DevshardTx
+	for _, tx := range execHost.MempoolTxs() {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == nonce {
+			honestConfirm = tx
+			break
+		}
+	}
+	require.NotNil(t, honestConfirm)
+
+	require.NoError(t, session.ProcessResponse(execIdx, &host.HostResponse{
+		Nonce: nonce, Mempool: []*types.DevshardTx{honestConfirm},
+	}, nonce))
+	require.NoError(t, session.SendPendingDiff(ctx))
+	rec, ok := session.StateMachine().Inference(nonce)
+	require.True(t, ok)
+	require.Equal(t, types.StatusStarted, rec.Status)
+
+	require.NoError(t, session.ProcessResponse((execIdx+1)%len(session.clients), &host.HostResponse{
+		Nonce: session.Nonce(), Mempool: []*types.DevshardTx{honestConfirm},
+	}, nonce))
+	require.Nil(t, findPendingConfirm(session.PendingTxs(), nonce),
+		"a ConfirmStart already in a diff must not be re-queued from another mempool")
+}
+
+// TestProcessResponse_DropsHostTxForUnknownInference pins the admission-time
+// existence check. Confirm, Validation and Vote for an id the sequencer does
+// not track can never apply, so admitting them only buys a signature recovery
+// at compose time -- and, since a failed tx now releases its dedup key, would
+// let a host park unbounded made-up ids in pending and replay them every round.
+func TestProcessResponse_DropsHostTxForUnknownInference(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 100)
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+	nonce := prepared.diff.Nonce
+
+	const unknownID = 4242
+	require.NoError(t, session.ProcessResponse(0, &host.HostResponse{
+		Nonce: nonce,
+		Mempool: []*types.DevshardTx{
+			{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+				InferenceId: unknownID, ExecutorSig: []byte("sig"), ConfirmedAt: 1000,
+			}}},
+			{Tx: &types.DevshardTx_Validation{Validation: &types.MsgValidation{
+				InferenceId: unknownID, ValidatorSlot: 0, Valid: true,
+			}}},
+			{Tx: &types.DevshardTx_ValidationVote{ValidationVote: &types.MsgValidationVote{
+				InferenceId: unknownID, VoterSlot: 0,
+			}}},
+			// Slot-scoped txs carry no inference id and must be unaffected.
+			{Tx: &types.DevshardTx_HeightAck{HeightAck: &types.MsgHeightAck{TurnSeq: 1, SlotId: 0}}},
+		},
+	}, nonce))
+
+	pending := session.PendingTxs()
+	require.Nil(t, findPendingConfirm(pending, unknownID),
+		"ConfirmStart for an unknown inference must not queue")
+	for _, tx := range pending {
+		if v := tx.GetValidation(); v != nil {
+			require.NotEqual(t, uint64(unknownID), v.InferenceId,
+				"Validation for an unknown inference must not queue")
+		}
+		if v := tx.GetValidationVote(); v != nil {
+			require.NotEqual(t, uint64(unknownID), v.InferenceId,
+				"ValidationVote for an unknown inference must not queue")
+		}
+	}
+	require.NotNil(t, findPendingHeightAck(pending, 1, 0),
+		"slot-scoped HeightAck must still queue")
+}
+
+func TestProcessResponse_DropsFinishNotSignedByExecutor(t *testing.T) {
+	session, hosts, _ := setupSession(t, 3, 100000, 100)
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+	nonce := prepared.diff.Nonce
+	execIdx := int(nonce % uint64(len(session.group)))
+
+	unsigned := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{
+		FinishInference: &types.MsgFinishInference{
+			InferenceId: nonce, ExecutorSlot: uint32(execIdx), EscrowId: "escrow-1",
+		},
+	}}
+	wrongSigner := signedFinishTx(t, hosts, nonce, execIdx, (execIdx+1)%len(hosts))
+	wrongSlot := signedFinishTx(t, hosts, nonce, (execIdx+1)%len(hosts), (execIdx+1)%len(hosts))
+	unknown := signedFinishTx(t, hosts, 99, execIdx, execIdx)
+	valid := signedFinishTx(t, hosts, nonce, execIdx, execIdx)
+
+	require.NoError(t, session.ProcessResponse(execIdx, &host.HostResponse{
+		Nonce:   nonce,
+		Mempool: []*types.DevshardTx{unsigned, wrongSigner, wrongSlot, unknown},
+	}, nonce))
+	require.Nil(t, findRecoveryFinish(session.PendingTxs(), nonce), "unsigned or wrong-executor Finish must not queue")
+	require.Nil(t, findRecoveryFinish(session.PendingTxs(), 99), "Finish for an unknown inference must not queue")
+
+	require.NoError(t, session.ProcessResponse(execIdx, &host.HostResponse{
+		Nonce:   nonce,
+		Mempool: []*types.DevshardTx{valid},
+	}, nonce))
+	require.NotNil(t, findRecoveryFinish(session.PendingTxs(), nonce), "executor-signed Finish must queue")
+}
+
+func TestHandleTimeout_RecoveryDropsInjectedStartAndUnsignedFinish(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 100000, 10)
+	ctx := context.Background()
+	params := InferenceParams{
+		Model: "llama", Prompt: testutil.TestPrompt,
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+	prepared, err := session.PrepareInference(params)
+	require.NoError(t, err)
+	nonce := prepared.diff.Nonce
+	execIdx := int(nonce % uint64(len(session.clients)))
+	execHost := session.clients[execIdx].(*InProcessClient).Host
+
+	payload := &host.InferencePayload{
+		Prompt:      params.Prompt,
+		Model:       params.Model,
+		InputLength: params.InputLength,
+		MaxTokens:   params.MaxTokens,
+		StartedAt:   params.StartedAt,
+	}
+	receipt, _, err := execHost.ChallengeReceipt(ctx, nonce, payload, []types.Diff{prepared.diff})
+	require.NoError(t, err)
+	require.NotEmpty(t, receipt)
+
+	var confirmTx *types.DevshardTx
+	for _, tx := range execHost.MempoolTxs() {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == nonce {
+			confirmTx = tx
+			break
+		}
+	}
+	require.NotNil(t, confirmTx)
+
+	unsignedFinish := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{
+		FinishInference: &types.MsgFinishInference{
+			InferenceId: nonce, ExecutorSlot: uint32(execIdx), EscrowId: "escrow-1",
+		},
+	}}
+	injected := []*types.DevshardTx{confirmTx, unsignedFinish, injectedStartTx(2)}
+	for i, c := range session.clients {
+		session.clients[i] = &timeoutRecoveryClient{HostClient: c, mempool: injected}
+	}
+
+	_, err = session.HandleTimeout(ctx, nonce, time.Unix(0, 0), payload)
+	require.NoError(t, err, "valid ConfirmStart recovery must still publish")
+
+	rec, ok := session.StateMachine().SnapshotState().Inferences[nonce]
+	require.True(t, ok)
+	require.Equal(t, types.StatusStarted, rec.Status)
+	_, hasInjected := session.StateMachine().Inference(2)
+	require.False(t, hasInjected)
+	require.Nil(t, findPendingStart(session.PendingTxs(), 2))
+	requireNoInjectedStartInDiffs(t, session, nonce)
+	for _, d := range session.Diffs() {
+		for _, tx := range d.Txs {
+			require.Nil(t, tx.GetFinishInference(), "unsigned recovery Finish must not land in a Diff")
+		}
+	}
+}
+
+func injectedStartTx(inferenceID uint64) *types.DevshardTx {
+	return &types.DevshardTx{Tx: &types.DevshardTx_StartInference{
+		StartInference: &types.MsgStartInference{
+			InferenceId: inferenceID, Model: "llama", InputLength: 100, MaxTokens: 799_999_800,
+		},
+	}}
+}
+
+type mempoolInjectingClient struct {
+	HostClient
+	extra []*types.DevshardTx
+}
+
+func wrapHostWithMempoolInjection(session *Session, hostIdx int, extra []*types.DevshardTx) {
+	session.clients[hostIdx] = &mempoolInjectingClient{HostClient: session.clients[hostIdx], extra: extra}
+}
+
+func (c *mempoolInjectingClient) Send(ctx context.Context, req host.HostRequest, stream io.Writer, receiptHandler func(*host.HostResponse)) (*host.HostResponse, error) {
+	resp, err := c.HostClient.Send(ctx, req, stream, receiptHandler)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	cloned := make([]*types.DevshardTx, len(resp.Mempool), len(resp.Mempool)+len(c.extra))
+	copy(cloned, resp.Mempool)
+	resp.Mempool = append(cloned, c.extra...)
+	return resp, nil
+}
+
+func (c *mempoolInjectingClient) GetSignatures(ctx context.Context, nonce uint64) (map[uint32][]byte, error) {
+	if f, ok := c.HostClient.(SignatureFetcher); ok {
+		return f.GetSignatures(ctx, nonce)
+	}
+	return nil, fmt.Errorf("inner client has no signatures")
+}
+
+func requireNoInjectedStartInDiffs(t *testing.T, session *Session, creatorStartID uint64) {
+	t.Helper()
+	for _, d := range session.Diffs() {
+		for _, tx := range d.Txs {
+			start := tx.GetStartInference()
+			if start == nil {
+				continue
+			}
+			require.Equal(t, creatorStartID, start.InferenceId, "only the creator-composed Start may land in a Diff")
+		}
+	}
+}
+
+func findPendingStart(txs []*types.DevshardTx, inferenceID uint64) *types.MsgStartInference {
+	for _, tx := range txs {
+		if start := tx.GetStartInference(); start != nil && start.InferenceId == inferenceID {
+			return start
+		}
+	}
+	return nil
+}
+
+func findPendingFinalize(txs []*types.DevshardTx) *types.MsgFinalizeRound {
+	for _, tx := range txs {
+		if fin := tx.GetFinalizeRound(); fin != nil {
+			return fin
+		}
+	}
+	return nil
+}
+
+func findPendingHeightAck(txs []*types.DevshardTx, turnSeq uint64, slotID uint32) *types.MsgHeightAck {
+	for _, tx := range txs {
+		ack := tx.GetHeightAck()
+		if ack != nil && ack.TurnSeq == turnSeq && ack.SlotId == slotID {
+			return ack
+		}
+	}
+	return nil
+}
+
+func signedFinishTx(t *testing.T, hosts []*signing.Secp256k1Signer, nonce uint64, executorSlot, signerIdx int) *types.DevshardTx {
+	t.Helper()
+	msg := &types.MsgFinishInference{
+		InferenceId:  nonce,
+		ResponseHash: []byte("hash"),
+		InputTokens:  80,
+		OutputTokens: 40,
+		ExecutorSlot: uint32(executorSlot),
+		EscrowId:     "escrow-1",
+	}
+	msg.ProposerSig = testutil.SignProposerTx(t, hosts[signerIdx], msg)
+	return &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: msg}}
 }
 
 func TestProcessResponse_NilReturnsNamedError(t *testing.T) {
@@ -1774,6 +2343,15 @@ func findRecoveryConfirmStart(txs []*types.DevshardTx, inferenceID uint64) *type
 func findRecoveryFinish(txs []*types.DevshardTx, inferenceID uint64) *types.DevshardTx {
 	for _, tx := range txs {
 		if fi := tx.GetFinishInference(); fi != nil && fi.InferenceId == inferenceID {
+			return tx
+		}
+	}
+	return nil
+}
+
+func findPendingConfirm(txs []*types.DevshardTx, inferenceID uint64) *types.DevshardTx {
+	for _, tx := range txs {
+		if cs := tx.GetConfirmStart(); cs != nil && cs.InferenceId == inferenceID {
 			return tx
 		}
 	}


### PR DESCRIPTION
## Summary

- Drop user/sequencer transaction types (`Start`, `Timeout`, `Finalize`, `Heartbeat`, `ErrorMiss`, `ForceHeightSyncTurn`) at the host-response boundary so a participant cannot enqueue them from unsigned `Mempool`.
- Authenticate host `Finish` at queue time against the live inference executor without calling the warm-key bridge, and require any inference-scoped host tx to name a live inference.
- Split pending vs applied dedup keys so a tx that fails to apply cannot permanently shadow the honest copy sharing that key.
- Bound warm-key grantee lookups with a 10s deadline so apply-time resolver calls cannot stall an escrow indefinitely.

## Why

A host's HTTP/SSE state signature covers `state_root`, `escrow_id`, and `nonce` — not `Mempool`. The gateway treated every mempool tx as pending for the next signed Diff. An attacker-authored `MsgStartInference` therefore entered the creator's sequencer with no inner creator signature, reserved escrow on apply, and settled at full reserved cost on `Finalize` if never finished.

The same confused-deputy path existed on timeout recovery: `CollectTimeoutVotes` / `HandleTimeout` copied mempool txs into `pendingTxs` without the response-boundary filter.

A related hole lived in dedup: `pendingTxKeys` was claimed at enqueue and kept after a failed apply. A forged `ConfirmStart` for a live inference burned `confirm:<id>` for the session, so the executor's real confirm could never queue and the inference settled at reserved cost. Freeing keys on failure fixed that, but then a flood of confirms for made-up IDs could replay every round and pay signature recovery inside `applyConfirmStart`.

## Behavior

**Allowlist (independent of dedup).** `hostMayProposeTx` is the only gate for host-originated txs. Hosts may propose `Finish`, `ConfirmStart`, `Validation`, `ValidationVote`, `RevealSeed`, and `HeightAck`. Nil inner oneof payloads are rejected. Adding a dedup key for `Start` later cannot start enqueueing Starts.

**Admission.** `addPendingFromHostLocked` (mempool, receipt-synthesized confirm, and timeout recovery) drops anything off the allowlist, then:

1. Dedups against currently queued *and already applied* keys before any crypto.
2. Rejects inference-scoped txs whose id is absent or sealed (`InferenceExecutorSlot`). HeightAck / RevealSeed are slot-scoped and pass through.
3. For `Finish`, additionally checks executor slot, escrow id, and a resolver-free proposer sig (`RejectFinishProposerSigLocal`). A warm-key Finish with no cached binding is left for apply-time `VerifyFinishProposerSig` so a host response cannot block on chain RPC while holding `s.mu`.

**Dedup lifetime.** `pendingTxKeys` is rebuilt from what compose retained. `appliedTxKeys` records txs that actually landed in a Diff and is what snapshot recovery reseeds (`restoreAppliedTxKeys`). A failed apply releases the key so an honest tx can still enqueue.

**Timeout recovery.** `hostRecoveryDedupKey` never identities user-proposed types. `HandleTimeout` routes recovery through `addPendingFromHostLocked`. Empty/malformed recovery txs are skipped rather than pointer-keyed.

**Bridge.** Both `VerifyWarmKey` implementations apply a 10s context deadline on `GranteesByMessageType`.

## Test plan

- [x] `go test ./user/ -run 'HostMayProposeTx|DevshardTxKey_NilInner|DropsUserProposedMempoolTxs|HostInjectedStart|InjectedStartDoesNotReserve|DropsFinishNotSignedByExecutor|HandleTimeout_RecoveryDropsInjected|ForgedConfirmDoesNotShadow|AppliedConfirmIsNotRequeued|DropsHostTxForUnknownInference|PendingTxDedupKeys'`
- [x] `go test -race ./user/... ./state/... ./protocol/... ./host/...`
- [x] `TestRejectFinishProposerSigLocal` — cold key accepted; stranger rejected with no resolver; undecidable with resolver and call count stays 0; cached warm key decides both ways
- [ ] Confirm a warm-key executor Finish still queues and applies on the first inference for that slot (binding learned at apply, not admission)
- [ ] Confirm timeout-refused recovery still republishes honest Confirm/Finish and still drops injected Start
- [ ] Confirm Finalize after a dropped injected Start does not create inference id 2 or credit attacker reserved cost
