### PR TITLE
`devshard` Persist the height-sync floor on snapshot restore

### DIFF
--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -20,6 +20,7 @@ import (
 
 	devshardpkg "devshard"
 	"devshard/gossip"
+	"devshard/heightsync"
 	"devshard/host"
 	"devshard/internal/boolvalue"
 	"devshard/internal/e2econfig"
@@ -353,11 +354,14 @@ func recoverHostState(store storage.Storage, sm *state.StateMachine, escrowID st
 
 	replayFrom := uint64(1)
 	if snapNonce, snapData, snapErr := store.LoadSnapshot(escrowID); snapErr == nil && snapNonce > 0 && snapNonce <= meta.LatestNonce {
-		snapState, err := host.UnmarshalStateSnapshot(snapData)
+		snapState, _, _, floorProto, err := host.UnmarshalStateSnapshotWithCommitted(snapData)
 		if err != nil {
 			return fmt.Errorf("unmarshal snapshot nonce %d: %w", snapNonce, err)
 		}
-		sm.RestoreState(snapState)
+		floor := heightsync.FloorIndexFromProto(heightsync.FloorConfigFor(len(snapState.Group), sm.HeartbeatConfig()), floorProto)
+		if err := sm.RestoreStateWithFloor(snapState, floor); err != nil {
+			return fmt.Errorf("restore snapshot nonce %d: %w", snapNonce, err)
+		}
 		replayFrom = snapNonce + 1
 	} else if snapErr != nil && !errors.Is(snapErr, storage.ErrSnapshotNotFound) {
 		return fmt.Errorf("load snapshot: %w", snapErr)

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -358,7 +358,16 @@ func recoverHostState(store storage.Storage, sm *state.StateMachine, escrowID st
 		if err != nil {
 			return fmt.Errorf("unmarshal snapshot nonce %d: %w", snapNonce, err)
 		}
-		floor := heightsync.FloorIndexFromProto(heightsync.FloorConfigFor(len(snapState.Group), sm.HeartbeatConfig()), floorProto)
+		// A rejected blob degrades to a journal replay; if that cannot run
+		// either, RestoreStateWithFloor fails closed rather than serving L0
+		// from a floor we could not verify.
+		floor, floorErr := heightsync.FloorIndexFromProto(
+			heightsync.FloorConfigFor(len(snapState.Group), sm.HeartbeatConfig()), floorProto)
+		if floorErr != nil {
+			log.Printf("recover_host escrow=%s snapshot_nonce=%d floor_blob_rejected=%v (rebuilding from diffs)",
+				escrowID, snapNonce, floorErr)
+			floor = nil
+		}
 		if err := sm.RestoreStateWithFloor(snapState, floor); err != nil {
 			return fmt.Errorf("restore snapshot nonce %d: %w", snapNonce, err)
 		}

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -74,7 +74,7 @@ func gatewayTestRuntimeForLimits(t *testing.T, id string, balance, nonce uint64)
 	st := sm.ExportState()
 	st.Balance = balance
 	st.LatestNonce = nonce
-	sm.RestoreState(st)
+	require.NoError(t, sm.RestoreState(st))
 
 	return &devshardRuntime{
 		id:    id,

--- a/devshard/cmd/devshardctl/request_accounting_test.go
+++ b/devshard/cmd/devshardctl/request_accounting_test.go
@@ -71,7 +71,7 @@ func TestHandleRequestAccountingReturnsJoinedInferenceCosts(t *testing.T) {
 			ConfirmedAt:  102,
 		},
 	}
-	sm.RestoreState(state)
+	require.NoError(t, sm.RestoreState(state))
 
 	proxy := &Proxy{sm: sm, escrowID: escrowID, perf: perf}
 	req := httptest.NewRequest(http.MethodGet, "/v1/requests/"+requestID, nil)
@@ -176,7 +176,7 @@ func TestHandleRequestAccountingResolvesCachedRequestAliasCosts(t *testing.T) {
 			ConfirmedAt:  102,
 		},
 	}
-	sm.RestoreState(state)
+	require.NoError(t, sm.RestoreState(state))
 
 	proxy := &Proxy{sm: sm, escrowID: escrowID, perf: perf}
 	req := httptest.NewRequest(http.MethodGet, "/v1/requests/"+cachedRequestID, nil)

--- a/devshard/heightsync/floor.go
+++ b/devshard/heightsync/floor.go
@@ -368,21 +368,43 @@ func (f *FloorIndex) Len() int {
 	return len(f.entries)
 }
 
-// Clone returns a deep copy so trial-apply cannot leak into committed state.
+// Clone returns a deep copy so trial-apply and snapshot restore cannot leak
+// into the live index.
 func (f *FloorIndex) Clone() *FloorIndex {
 	if f == nil {
 		return nil
 	}
+	entries := make([]floorEntry, len(f.entries))
+	for i, e := range f.entries {
+		entries[i] = floorEntry{
+			nonce:  e.nonce,
+			height: e.height,
+			hash:   append([]byte(nil), e.hash...),
+			author: e.author,
+		}
+	}
 	claims := make(map[uint32]floorSignerClaim, len(f.claims))
 	for signer, held := range f.claims {
-		claims[signer] = held
+		claims[signer] = floorSignerClaim{
+			height: held.height,
+			hash:   append([]byte(nil), held.hash...),
+		}
 	}
 	return &FloorIndex{
-		entries:   append([]floorEntry(nil), f.entries...),
+		entries:   entries,
 		claims:    claims,
 		cfg:       f.cfg,
 		truncated: f.truncated,
 	}
+}
+
+// ApplyConfig replaces the raise-rule parameters. Snapshot blobs omit cfg;
+// restore recomputes it from the roster.
+func (f *FloorIndex) ApplyConfig(cfg FloorConfig) {
+	if f == nil {
+		return
+	}
+	f.cfg = cfg.withDefaults()
 }
 
 // FloorAuthorLabel names a claim signer for marks and log lines.

--- a/devshard/heightsync/floor.go
+++ b/devshard/heightsync/floor.go
@@ -368,30 +368,20 @@ func (f *FloorIndex) Len() int {
 	return len(f.entries)
 }
 
-// Clone returns a deep copy so trial-apply and snapshot restore cannot leak
-// into the live index.
+// Clone returns a copy so trial-apply cannot leak into committed state. It runs
+// on the apply hot path (snapshotMutable, several times per diff), so the hashes
+// are shared rather than copied: appendEntry and the claim insert each store a
+// fresh slice and nothing rewrites one in place afterwards.
 func (f *FloorIndex) Clone() *FloorIndex {
 	if f == nil {
 		return nil
 	}
-	entries := make([]floorEntry, len(f.entries))
-	for i, e := range f.entries {
-		entries[i] = floorEntry{
-			nonce:  e.nonce,
-			height: e.height,
-			hash:   append([]byte(nil), e.hash...),
-			author: e.author,
-		}
-	}
 	claims := make(map[uint32]floorSignerClaim, len(f.claims))
 	for signer, held := range f.claims {
-		claims[signer] = floorSignerClaim{
-			height: held.height,
-			hash:   append([]byte(nil), held.hash...),
-		}
+		claims[signer] = held
 	}
 	return &FloorIndex{
-		entries:   entries,
+		entries:   append([]floorEntry(nil), f.entries...),
 		claims:    claims,
 		cfg:       f.cfg,
 		truncated: f.truncated,

--- a/devshard/heightsync/floor_proto.go
+++ b/devshard/heightsync/floor_proto.go
@@ -1,6 +1,8 @@
 package heightsync
 
 import (
+	"errors"
+	"fmt"
 	"sort"
 
 	"devshard/types"
@@ -43,33 +45,64 @@ func (f *FloorIndex) ToProto() *types.FloorIndexProto {
 	}
 }
 
+// ErrFloorBlobInvalid marks a snapshot floor that cannot be a fold of any diff
+// sequence. Callers must discard it and rebuild from the journal (or fail
+// closed) rather than serve L0 verdicts from it.
+var ErrFloorBlobInvalid = errors.New("height-sync floor blob invalid")
+
 // FloorIndexFromProto reconstructs a FloorIndex from a snapshot blob.
 // A nil proto means the snapshot omitted the floor (legacy); callers must
 // fall back to a journal replay. An empty proto is a valid fold (no claims).
-func FloorIndexFromProto(cfg FloorConfig, p *types.FloorIndexProto) *FloorIndex {
+//
+// The blob is validated before it is trusted. AsOf binary-searches entries and
+// reads the last one as a running maximum, so a blob whose nonces or heights are
+// out of order would answer F(m) with a height the log never established — and
+// unlike a GetDiffs failure, nothing downstream would notice. Restore treats a
+// present blob as authoritative, so this is the only place that check can live.
+func FloorIndexFromProto(cfg FloorConfig, p *types.FloorIndexProto) (*FloorIndex, error) {
 	if p == nil {
-		return nil
+		return nil, nil
 	}
 	f := NewFloorIndexWith(cfg)
 	if len(p.Entries) > 0 {
-		f.entries = make([]floorEntry, len(p.Entries))
+		f.entries = make([]floorEntry, 0, len(p.Entries))
 		for i, e := range p.Entries {
 			if e == nil {
-				continue
+				return nil, fmt.Errorf("%w: entry %d is missing", ErrFloorBlobInvalid, i)
 			}
-			f.entries[i] = floorEntry{
+			if e.Height == 0 || !StampPresent(e.Hash) {
+				return nil, fmt.Errorf("%w: entry %d has no reference height", ErrFloorBlobInvalid, i)
+			}
+			if n := len(f.entries); n > 0 {
+				prev := f.entries[n-1]
+				if e.Nonce <= prev.nonce {
+					return nil, fmt.Errorf("%w: entry %d nonce %d follows %d",
+						ErrFloorBlobInvalid, i, e.Nonce, prev.nonce)
+				}
+				if e.Height <= prev.height {
+					return nil, fmt.Errorf("%w: entry %d height %d follows %d",
+						ErrFloorBlobInvalid, i, e.Height, prev.height)
+				}
+			}
+			f.entries = append(f.entries, floorEntry{
 				nonce:  e.Nonce,
 				height: e.Height,
 				hash:   append([]byte(nil), e.Hash...),
 				author: e.Author,
-			}
+			})
 		}
 	}
 	if len(p.Claims) > 0 {
 		f.claims = make(map[uint32]floorSignerClaim, len(p.Claims))
-		for _, c := range p.Claims {
+		for i, c := range p.Claims {
 			if c == nil {
-				continue
+				return nil, fmt.Errorf("%w: claim %d is missing", ErrFloorBlobInvalid, i)
+			}
+			if c.Height == 0 || !StampPresent(c.Hash) {
+				return nil, fmt.Errorf("%w: claim %d has no reference height", ErrFloorBlobInvalid, i)
+			}
+			if _, dup := f.claims[c.Signer]; dup {
+				return nil, fmt.Errorf("%w: claim %d repeats signer %d", ErrFloorBlobInvalid, i, c.Signer)
 			}
 			f.claims[c.Signer] = floorSignerClaim{
 				height: c.Height,
@@ -78,5 +111,5 @@ func FloorIndexFromProto(cfg FloorConfig, p *types.FloorIndexProto) *FloorIndex 
 		}
 	}
 	f.truncated = p.Truncated
-	return f
+	return f, nil
 }

--- a/devshard/heightsync/floor_proto.go
+++ b/devshard/heightsync/floor_proto.go
@@ -1,0 +1,82 @@
+package heightsync
+
+import (
+	"sort"
+
+	"devshard/types"
+)
+
+// ToProto serializes the derived floor for the snapshot envelope. It is not
+// hashed into the state root. cfg is omitted and recomputed from the roster
+// on restore.
+func (f *FloorIndex) ToProto() *types.FloorIndexProto {
+	if f == nil {
+		return nil
+	}
+	entries := make([]*types.FloorIndexEntryProto, len(f.entries))
+	for i, e := range f.entries {
+		entries[i] = &types.FloorIndexEntryProto{
+			Nonce:  e.nonce,
+			Height: e.height,
+			Hash:   append([]byte(nil), e.hash...),
+			Author: e.author,
+		}
+	}
+	signers := make([]uint32, 0, len(f.claims))
+	for signer := range f.claims {
+		signers = append(signers, signer)
+	}
+	sort.Slice(signers, func(i, j int) bool { return signers[i] < signers[j] })
+	claims := make([]*types.FloorSignerClaimProto, 0, len(signers))
+	for _, signer := range signers {
+		held := f.claims[signer]
+		claims = append(claims, &types.FloorSignerClaimProto{
+			Signer: signer,
+			Height: held.height,
+			Hash:   append([]byte(nil), held.hash...),
+		})
+	}
+	return &types.FloorIndexProto{
+		Entries:   entries,
+		Claims:    claims,
+		Truncated: f.truncated,
+	}
+}
+
+// FloorIndexFromProto reconstructs a FloorIndex from a snapshot blob.
+// A nil proto means the snapshot omitted the floor (legacy); callers must
+// fall back to a journal replay. An empty proto is a valid fold (no claims).
+func FloorIndexFromProto(cfg FloorConfig, p *types.FloorIndexProto) *FloorIndex {
+	if p == nil {
+		return nil
+	}
+	f := NewFloorIndexWith(cfg)
+	if len(p.Entries) > 0 {
+		f.entries = make([]floorEntry, len(p.Entries))
+		for i, e := range p.Entries {
+			if e == nil {
+				continue
+			}
+			f.entries[i] = floorEntry{
+				nonce:  e.Nonce,
+				height: e.Height,
+				hash:   append([]byte(nil), e.Hash...),
+				author: e.Author,
+			}
+		}
+	}
+	if len(p.Claims) > 0 {
+		f.claims = make(map[uint32]floorSignerClaim, len(p.Claims))
+		for _, c := range p.Claims {
+			if c == nil {
+				continue
+			}
+			f.claims[c.Signer] = floorSignerClaim{
+				height: c.Height,
+				hash:   append([]byte(nil), c.Hash...),
+			}
+		}
+	}
+	f.truncated = p.Truncated
+	return f
+}

--- a/devshard/heightsync/floor_proto_test.go
+++ b/devshard/heightsync/floor_proto_test.go
@@ -1,0 +1,78 @@
+package heightsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/types"
+)
+
+func TestFloorIndexFromProtoNilIsMissingBlob(t *testing.T) {
+	require.Nil(t, FloorIndexFromProto(FloorConfig{}, nil))
+}
+
+func TestFloorIndexFromProtoEmptyIsValidFold(t *testing.T) {
+	got := FloorIndexFromProto(FloorConfig{}, &types.FloorIndexProto{})
+	require.NotNil(t, got)
+	h, hash, known := got.AsOf(1)
+	require.True(t, known)
+	require.Zero(t, h)
+	require.Empty(t, hash)
+	require.False(t, got.truncated)
+}
+
+func TestFloorIndexProtoRoundTrip(t *testing.T) {
+	cfg := FloorConfigFor(3, DefaultHeartbeatConfig())
+	f := NewFloorIndexWith(cfg)
+	hash := []byte{0xaa, 0xbb}
+	f.Observe(1, []FloorClaim{{Signer: 0, Height: 50, Hash: hash}})
+	f.Observe(2, []FloorClaim{{Signer: 1, Height: 50, Hash: hash}})
+
+	p := f.ToProto()
+	require.NotNil(t, p)
+	require.Len(t, p.Entries, 1)
+	require.Len(t, p.Claims, 2)
+	require.False(t, p.Truncated)
+
+	got := FloorIndexFromProto(cfg, p)
+	require.NotNil(t, got)
+
+	wantH, wantHash, wantKnown := f.AsOf(3)
+	gotH, gotHash, gotKnown := got.AsOf(3)
+	require.Equal(t, wantKnown, gotKnown)
+	require.Equal(t, wantH, gotH)
+	require.Equal(t, wantHash, gotHash)
+	require.Equal(t, f.truncated, got.truncated)
+	require.Equal(t, f.Len(), got.Len())
+	require.Equal(t, f.cfg, got.cfg)
+
+	// Restore must not alias the live index's hash backing arrays.
+	got.Observe(3, []FloorClaim{{Signer: 2, Height: 60, Hash: []byte{0xcc}}})
+	liveH, _, _ := f.AsOf(4)
+	require.Equal(t, uint64(50), liveH)
+}
+
+func TestFloorIndexProtoTruncatedRoundTrip(t *testing.T) {
+	p := &types.FloorIndexProto{
+		Truncated: true,
+		Entries: []*types.FloorIndexEntryProto{{
+			Nonce:  100,
+			Height: 50,
+			Hash:   []byte{0x01},
+			Author: 0,
+		}},
+	}
+	got := FloorIndexFromProto(FloorConfig{}, p)
+	require.True(t, got.truncated)
+
+	_, _, known := got.AsOf(1)
+	require.False(t, known, "nonce before the retained window must stay unknown")
+
+	h, hash, known := got.AsOf(101)
+	require.True(t, known)
+	require.Equal(t, uint64(50), h)
+	require.Equal(t, []byte{0x01}, hash)
+
+	require.True(t, got.ToProto().Truncated)
+}

--- a/devshard/heightsync/floor_proto_test.go
+++ b/devshard/heightsync/floor_proto_test.go
@@ -9,11 +9,14 @@ import (
 )
 
 func TestFloorIndexFromProtoNilIsMissingBlob(t *testing.T) {
-	require.Nil(t, FloorIndexFromProto(FloorConfig{}, nil))
+	got, err := FloorIndexFromProto(FloorConfig{}, nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
 }
 
 func TestFloorIndexFromProtoEmptyIsValidFold(t *testing.T) {
-	got := FloorIndexFromProto(FloorConfig{}, &types.FloorIndexProto{})
+	got, err := FloorIndexFromProto(FloorConfig{}, &types.FloorIndexProto{})
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	h, hash, known := got.AsOf(1)
 	require.True(t, known)
@@ -35,7 +38,8 @@ func TestFloorIndexProtoRoundTrip(t *testing.T) {
 	require.Len(t, p.Claims, 2)
 	require.False(t, p.Truncated)
 
-	got := FloorIndexFromProto(cfg, p)
+	got, err := FloorIndexFromProto(cfg, p)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 
 	wantH, wantHash, wantKnown := f.AsOf(3)
@@ -53,6 +57,31 @@ func TestFloorIndexProtoRoundTrip(t *testing.T) {
 	require.Equal(t, uint64(50), liveH)
 }
 
+// TestFloorIndexProtoLongFoldRoundTrip exercises a fold long enough to overflow
+// the retention window, so the validator has to accept a real truncated suffix
+// rather than only the two-entry shapes the other tests build.
+func TestFloorIndexProtoLongFoldRoundTrip(t *testing.T) {
+	cfg := FloorConfigFor(3, DefaultHeartbeatConfig())
+	cfg.Window = 8
+	f := NewFloorIndexWith(cfg)
+	for i := uint64(1); i <= 40; i++ {
+		h := i * 2
+		f.Observe(i, []FloorClaim{{Signer: 0, Height: h, Hash: []byte{byte(i)}}})
+	}
+	require.True(t, f.truncated)
+	require.Equal(t, 8, f.Len())
+
+	got, err := FloorIndexFromProto(cfg, f.ToProto())
+	require.NoError(t, err)
+	for _, m := range []uint64{1, 20, 39, 41} {
+		wantH, wantHash, wantKnown := f.AsOf(m)
+		gotH, gotHash, gotKnown := got.AsOf(m)
+		require.Equal(t, wantKnown, gotKnown, "AsOf(%d)", m)
+		require.Equal(t, wantH, gotH, "AsOf(%d)", m)
+		require.Equal(t, wantHash, gotHash, "AsOf(%d)", m)
+	}
+}
+
 func TestFloorIndexProtoTruncatedRoundTrip(t *testing.T) {
 	p := &types.FloorIndexProto{
 		Truncated: true,
@@ -63,7 +92,8 @@ func TestFloorIndexProtoTruncatedRoundTrip(t *testing.T) {
 			Author: 0,
 		}},
 	}
-	got := FloorIndexFromProto(FloorConfig{}, p)
+	got, err := FloorIndexFromProto(FloorConfig{}, p)
+	require.NoError(t, err)
 	require.True(t, got.truncated)
 
 	_, _, known := got.AsOf(1)
@@ -75,4 +105,42 @@ func TestFloorIndexProtoTruncatedRoundTrip(t *testing.T) {
 	require.Equal(t, []byte{0x01}, hash)
 
 	require.True(t, got.ToProto().Truncated)
+}
+
+// TestFloorIndexFromProtoRejectsUnfoldableBlobs covers the shapes that no diff
+// sequence can produce. AsOf binary-searches entries and reads the last one as a
+// running maximum, so accepting any of these would answer F(m) with a height the
+// log never established — silently, and only on the replica that restored.
+func TestFloorIndexFromProtoRejectsUnfoldableBlobs(t *testing.T) {
+	entry := func(nonce, height uint64) *types.FloorIndexEntryProto {
+		return &types.FloorIndexEntryProto{Nonce: nonce, Height: height, Hash: []byte{0x01}}
+	}
+
+	cases := map[string]*types.FloorIndexProto{
+		"nonce out of order": {Entries: []*types.FloorIndexEntryProto{entry(5, 10), entry(3, 20)}},
+		"repeated nonce":     {Entries: []*types.FloorIndexEntryProto{entry(5, 10), entry(5, 20)}},
+		"height regresses":   {Entries: []*types.FloorIndexEntryProto{entry(5, 20), entry(6, 10)}},
+		"height repeats":     {Entries: []*types.FloorIndexEntryProto{entry(5, 20), entry(6, 20)}},
+		"zero height":        {Entries: []*types.FloorIndexEntryProto{entry(5, 0)}},
+		"missing hash": {Entries: []*types.FloorIndexEntryProto{
+			{Nonce: 5, Height: 10},
+		}},
+		"nil entry": {Entries: []*types.FloorIndexEntryProto{nil}},
+		"nil claim": {Claims: []*types.FloorSignerClaimProto{nil}},
+		"claim without stamp": {Claims: []*types.FloorSignerClaimProto{
+			{Signer: 0, Height: 10},
+		}},
+		"repeated signer": {Claims: []*types.FloorSignerClaimProto{
+			{Signer: 0, Height: 10, Hash: []byte{0x01}},
+			{Signer: 0, Height: 20, Hash: []byte{0x02}},
+		}},
+	}
+
+	for name, p := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := FloorIndexFromProto(FloorConfig{}, p)
+			require.ErrorIs(t, err, ErrFloorBlobInvalid)
+			require.Nil(t, got)
+		})
+	}
 }

--- a/devshard/host/heightsync.go
+++ b/devshard/host/heightsync.go
@@ -188,6 +188,9 @@ func (h *Host) buildHeightAckLocked(item heartbeatTarget, hdr *blocks.Header, hd
 // omitted stamp costs the roster one height claim, while a carried one puts a
 // pair no chain can reconcile under another signature.
 func (h *Host) referenceStamp(producingNonce, height uint64, hash []byte) (uint64, []byte) {
+	if !h.sm.HeightSyncFloorReady() {
+		return 0, nil
+	}
 	floor, floorHash, known := h.sm.HeightSyncFloorAsOf(producingNonce)
 	if !known || floor <= height || !heightsync.StampPresent(floorHash) {
 		return height, hash

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -771,17 +771,18 @@ func (h *Host) maybeSaveSnapshotLocked(nonce uint64, shouldSnapshot, settledNow 
 	state := h.sm.ExportState()
 	committedEntries := h.sm.ExportCommittedEntries()
 	sealedNonces := h.sm.ExportSealedNonces()
+	heightSyncFloor := h.sm.ExportHeightSyncFloor()
 
 	go func() {
 		if !settledNow {
 			defer h.snapshotInFlight.Store(false)
 		}
-		writeSnapshot(store, escrowID, nonce, state, committedEntries, sealedNonces)
+		writeSnapshot(store, escrowID, nonce, state, committedEntries, sealedNonces, heightSyncFloor)
 	}()
 }
 
-func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64) {
-	data, err := MarshalStateSnapshotWithCommitted(state, committedEntries, sealedNonces)
+func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64, heightSyncFloor *types.FloorIndexProto) {
+	data, err := MarshalStateSnapshotWithCommitted(state, committedEntries, sealedNonces, heightSyncFloor)
 	if err != nil {
 		logging.Warn("failed to marshal host snapshot", "escrow_id", escrowID, "nonce", nonce, "error", err)
 		return

--- a/devshard/host/snapshot.go
+++ b/devshard/host/snapshot.go
@@ -9,21 +9,21 @@ import (
 var errEmptySnapshot = errors.New("empty snapshot")
 
 func MarshalStateSnapshot(state *types.EscrowState) ([]byte, error) {
-	return types.MarshalStateSnapshotProto(state, nil, nil)
+	return types.MarshalStateSnapshotProto(state, nil, nil, nil)
 }
 
-func MarshalStateSnapshotWithCommitted(state *types.EscrowState, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64) ([]byte, error) {
-	return types.MarshalStateSnapshotProto(state, committedEntries, sealedNonces)
+func MarshalStateSnapshotWithCommitted(state *types.EscrowState, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64, heightSyncFloor *types.FloorIndexProto) ([]byte, error) {
+	return types.MarshalStateSnapshotProto(state, committedEntries, sealedNonces, heightSyncFloor)
 }
 
 func UnmarshalStateSnapshot(data []byte) (*types.EscrowState, error) {
-	state, _, _, err := UnmarshalStateSnapshotWithCommitted(data)
+	state, _, _, _, err := UnmarshalStateSnapshotWithCommitted(data)
 	return state, err
 }
 
-func UnmarshalStateSnapshotWithCommitted(data []byte) (*types.EscrowState, map[uint64][]byte, map[uint64]uint64, error) {
+func UnmarshalStateSnapshotWithCommitted(data []byte) (*types.EscrowState, map[uint64][]byte, map[uint64]uint64, *types.FloorIndexProto, error) {
 	if len(data) == 0 {
-		return nil, nil, nil, errEmptySnapshot
+		return nil, nil, nil, nil, errEmptySnapshot
 	}
 	return types.UnmarshalStateSnapshotProto(data)
 }

--- a/devshard/host/snapshot_test.go
+++ b/devshard/host/snapshot_test.go
@@ -32,14 +32,45 @@ func TestMarshalStateSnapshotWithCommitted_RoundTrip(t *testing.T) {
 		2: 22,
 	}
 
-	data, err := MarshalStateSnapshotWithCommitted(state, committed, sealed)
+	data, err := MarshalStateSnapshotWithCommitted(state, committed, sealed, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
 
-	roundTripState, roundTripCommitted, roundTripSealed, err := UnmarshalStateSnapshotWithCommitted(data)
+	roundTripState, roundTripCommitted, roundTripSealed, roundTripFloor, err := UnmarshalStateSnapshotWithCommitted(data)
 	require.NoError(t, err)
 	require.Equal(t, state.EscrowID, roundTripState.EscrowID)
 	require.Equal(t, state.LatestNonce, roundTripState.LatestNonce)
 	require.Equal(t, committed, roundTripCommitted)
 	require.Equal(t, sealed, roundTripSealed)
+	require.Nil(t, roundTripFloor)
+}
+
+func TestMarshalStateSnapshotWithCommitted_RoundTripFloor(t *testing.T) {
+	state := &types.EscrowState{
+		EscrowID:                    "escrow-1",
+		StateRootAndProtocolVersion: "v1",
+		LatestNonce:                 42,
+		Inferences:                  map[uint64]*types.InferenceRecord{},
+		HostStats:                   map[uint32]*types.HostStats{0: {}},
+		WarmKeys:                    map[uint32]string{0: "warm-0"},
+	}
+	floor := &types.FloorIndexProto{
+		Truncated: true,
+		Entries: []*types.FloorIndexEntryProto{{
+			Nonce:  3,
+			Height: 50,
+			Hash:   []byte{0xaa},
+			Author: 1,
+		}},
+	}
+
+	data, err := MarshalStateSnapshotWithCommitted(state, nil, nil, floor)
+	require.NoError(t, err)
+
+	_, _, _, roundTripFloor, err := UnmarshalStateSnapshotWithCommitted(data)
+	require.NoError(t, err)
+	require.NotNil(t, roundTripFloor)
+	require.True(t, roundTripFloor.Truncated)
+	require.Equal(t, uint64(50), roundTripFloor.Entries[0].Height)
+	require.Equal(t, []byte{0xaa}, roundTripFloor.Entries[0].Hash)
 }

--- a/devshard/proto/devshard/v1/snapshot.proto
+++ b/devshard/proto/devshard/v1/snapshot.proto
@@ -39,8 +39,9 @@ message EscrowStateProto {
   uint64 latest_nonce = 12;
   bytes sealed_acc = 13;
   // Height-sync escrow commit (hashed into the state root). The turn tracker
-  // is rebuilt from snapshot scalars; the floor is a sibling on
-  // StateSnapshotProto (not hashed) so restore does not reread diffs 1..N.
+  // and floor are rebuilt by replaying diffs 1..latest_nonce; the floor also
+  // rides on StateSnapshotProto (not hashed) as the fallback for when that
+  // replay cannot run.
   uint64 height_sync_forced_start = 14;
   uint64 height_sync_forced_end = 15;
   uint64 height_sync_cadence_swallow_until = 16;
@@ -51,7 +52,9 @@ message EscrowStateProto {
 }
 
 // FloorIndexProto is the derived height-sync floor (entries + per-signer
-// claims). It is not hashed into the state root.
+// claims). It is not hashed into the state root. Entries are ordered by nonce
+// and hold a running maximum height; a reader that cannot confirm that must
+// discard the blob rather than answer F(m) from it.
 message FloorIndexEntryProto {
   uint64 nonce = 1;
   uint64 height = 2;

--- a/devshard/proto/devshard/v1/snapshot.proto
+++ b/devshard/proto/devshard/v1/snapshot.proto
@@ -38,8 +38,9 @@ message EscrowStateProto {
   map<uint32, string> warm_keys = 11;
   uint64 latest_nonce = 12;
   bytes sealed_acc = 13;
-  // Height-sync escrow commit (hashed into the state root). Tracker and floor
-  // are rebuilt from diffs 1..latest_nonce on restore, not persisted here.
+  // Height-sync escrow commit (hashed into the state root). The turn tracker
+  // is rebuilt from snapshot scalars; the floor is a sibling on
+  // StateSnapshotProto (not hashed) so restore does not reread diffs 1..N.
   uint64 height_sync_forced_start = 14;
   uint64 height_sync_forced_end = 15;
   uint64 height_sync_cadence_swallow_until = 16;
@@ -47,6 +48,27 @@ message EscrowStateProto {
   uint64 height_sync_turn_k = 18;
   uint64 height_sync_turn_slots = 19;
   string height_sync_turn_reason = 20;
+}
+
+// FloorIndexProto is the derived height-sync floor (entries + per-signer
+// claims). It is not hashed into the state root.
+message FloorIndexEntryProto {
+  uint64 nonce = 1;
+  uint64 height = 2;
+  bytes hash = 3;
+  uint32 author = 4;
+}
+
+message FloorSignerClaimProto {
+  uint32 signer = 1;
+  uint64 height = 2;
+  bytes hash = 3;
+}
+
+message FloorIndexProto {
+  repeated FloorIndexEntryProto entries = 1;
+  repeated FloorSignerClaimProto claims = 2;
+  bool truncated = 3;
 }
 
 // StateSnapshotProto matches the shared storage/recovery envelope. Hosts do not
@@ -57,4 +79,5 @@ message StateSnapshotProto {
   map<uint64, bytes> committed_entries = 2;
   map<uint64, uint64> sealed_nonces = 3;
   map<int32, uint64> host_sync_nonce = 4;
+  FloorIndexProto height_sync_floor = 5;
 }

--- a/devshard/state/heightsync.go
+++ b/devshard/state/heightsync.go
@@ -192,10 +192,15 @@ func (sm *StateMachine) HeightSyncFloorReady() bool {
 }
 
 // ExportHeightSyncFloor copies the derived floor for the snapshot envelope.
+//
+// A floor that never folded 1..LatestNonce is omitted rather than written out
+// empty. Restore installs a present blob as authoritative, so persisting one
+// from a not-ready machine would launder "we could not rebuild the fold" into
+// "the fold is empty" — the split this blob exists to prevent.
 func (sm *StateMachine) ExportHeightSyncFloor() *types.FloorIndexProto {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
-	if sm.heightSyncFloor == nil {
+	if sm.heightSyncFloor == nil || !sm.floorReady {
 		return nil
 	}
 	return sm.heightSyncFloor.ToProto()

--- a/devshard/state/heightsync.go
+++ b/devshard/state/heightsync.go
@@ -182,6 +182,25 @@ func (sm *StateMachine) HeightSyncFloorAsOf(nonce uint64) (uint64, []byte, bool)
 	return h, append([]byte(nil), hash...), known
 }
 
+// HeightSyncFloorReady reports whether the floor is a consistent fold of
+// 1..LatestNonce. Producers omit stamps when this is false rather than
+// writing a raw oracle tip against a missing F.
+func (sm *StateMachine) HeightSyncFloorReady() bool {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.floorReady
+}
+
+// ExportHeightSyncFloor copies the derived floor for the snapshot envelope.
+func (sm *StateMachine) ExportHeightSyncFloor() *types.FloorIndexProto {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	if sm.heightSyncFloor == nil {
+		return nil
+	}
+	return sm.heightSyncFloor.ToProto()
+}
+
 func (sm *StateMachine) observeHeightSyncLocked(nonce uint64, txs []*types.DevshardTx) {
 	if sm.turnTracker == nil {
 		return
@@ -206,47 +225,70 @@ func (sm *StateMachine) observeHeightSyncLocked(nonce uint64, txs []*types.Devsh
 	sm.state.HeightSyncLatestTurnSeq = sm.turnTracker.MaxTurnSeq()
 }
 
-// rebuildHeightSyncLocked reconstructs the turn tracker and floor from diffs
-// 1..LatestNonce. Both are derived state: the floor's per-signer claims cannot
-// be a persisted scalar, and the tracker is reconstructible from the log.
-// RestoreState copies hashed HeightSync* fields from the snapshot; replaying
-// MsgForceHeightSyncTurn fills them for legacy snapshots that omitted them.
-// A GetDiffs error keeps those snapshot scalars (h_last / latest turn_seq)
-// rather than folding an empty journal over them.
-func (sm *StateMachine) rebuildHeightSyncLocked() {
+// rebuildHeightSyncLocked reconstructs the turn tracker and floor.
+//
+// The journal is the canonical fold (tracker + floor). A snapshot floor is
+// installed only when that replay cannot run, so L0 still agrees after a
+// GetDiffs failure. If LatestNonce > 0 and neither source works, restore
+// fails: an empty floor would skip L0 and split the escrow from any replica
+// that rebuilt.
+func (sm *StateMachine) rebuildHeightSyncLocked(snapFloor *heightsync.FloorIndex) error {
 	savedLast := sm.state.HeightSyncLastCompletedHeight
 	savedSeq := sm.state.HeightSyncLatestTurnSeq
 	slots := uint64(len(sm.state.Group))
 	tracker := heightsync.NewTurnTracker(slots, 0, sm.heartbeatCfg)
-	floor := heightsync.NewFloorIndexWith(
-		heightsync.FloorConfigFor(len(sm.state.Group), sm.heartbeatCfg))
-	if sm.state.LatestNonce == 0 || sm.inferenceStore == nil {
+	cfg := heightsync.FloorConfigFor(len(sm.state.Group), sm.heartbeatCfg)
+	emptyFloor := heightsync.NewFloorIndexWith(cfg)
+
+	install := func(floor *heightsync.FloorIndex, ready bool) {
 		sm.turnTracker = tracker
 		sm.heightSyncFloor = floor
-		return
-	}
-	records, err := sm.inferenceStore.GetDiffs(sm.state.EscrowID, 1, sm.state.LatestNonce)
-	if err != nil {
-		logging.Warn("heightsync: snapshot restore could not load diffs; keeping snapshot h_last",
-			"escrow_id", sm.state.EscrowID, "error", err)
-		tracker.SeedCompleted(savedLast, savedSeq)
-		sm.turnTracker = tracker
-		sm.heightSyncFloor = floor
+		sm.floorReady = ready
 		sm.state.HeightSyncLastCompletedHeight = savedLast
 		sm.state.HeightSyncLatestTurnSeq = savedSeq
-		return
 	}
-	sm.turnTracker = tracker
-	sm.heightSyncFloor = floor
-	for _, rec := range records {
-		for _, tx := range rec.Txs {
-			if msg := tx.GetForceHeightSyncTurn(); msg != nil {
-				_ = sm.applyForceHeightSyncTurn(msg, rec.Nonce)
+
+	if sm.state.LatestNonce == 0 {
+		install(emptyFloor, true)
+		return nil
+	}
+
+	if sm.inferenceStore != nil {
+		records, err := sm.inferenceStore.GetDiffs(sm.state.EscrowID, 1, sm.state.LatestNonce)
+		if err == nil {
+			sm.turnTracker = tracker
+			sm.heightSyncFloor = emptyFloor
+			sm.floorReady = true
+			for _, rec := range records {
+				for _, tx := range rec.Txs {
+					if msg := tx.GetForceHeightSyncTurn(); msg != nil {
+						_ = sm.applyForceHeightSyncTurn(msg, rec.Nonce)
+					}
+				}
+				sm.observeHeightSyncLocked(rec.Nonce, rec.Txs)
 			}
+			sm.clearExpiredHeightSyncFlags()
+			return nil
 		}
-		sm.observeHeightSyncLocked(rec.Nonce, rec.Txs)
+		if snapFloor == nil {
+			logging.Warn("heightsync: snapshot restore could not load diffs",
+				"escrow_id", sm.state.EscrowID, "error", err)
+			tracker.SeedCompleted(savedLast, savedSeq)
+			install(emptyFloor, false)
+			return fmt.Errorf("%w: %v", types.ErrFloorNotRestored, err)
+		}
+		logging.Warn("heightsync: snapshot restore could not load diffs; using snapshot floor",
+			"escrow_id", sm.state.EscrowID, "error", err)
+	} else if snapFloor == nil {
+		install(emptyFloor, false)
+		return fmt.Errorf("%w: no inference store", types.ErrFloorNotRestored)
 	}
-	sm.clearExpiredHeightSyncFlags()
+
+	tracker.SeedCompleted(savedLast, savedSeq)
+	cloned := snapFloor.Clone()
+	cloned.ApplyConfig(cfg)
+	install(cloned, true)
+	return nil
 }
 
 // floorClaimsLocked attributes each Diff-resident height to the identity that

--- a/devshard/state/heightsync_snapshot_test.go
+++ b/devshard/state/heightsync_snapshot_test.go
@@ -59,15 +59,18 @@ func TestHeightSync_SnapshotRestoreAgreesOnRootAndFloor(t *testing.T) {
 	require.Equal(t, uint64(3), st.HeightSyncForcedEnd)
 	require.Equal(t, uint64(10), st.HeightSyncTurnK)
 
-	data, err := types.MarshalStateSnapshotProto(st, nil, nil)
+	data, err := types.MarshalStateSnapshotProto(st, nil, nil, live.ExportHeightSyncFloor())
 	require.NoError(t, err)
-	restoredState, _, _, err := types.UnmarshalStateSnapshotProto(data)
+	restoredState, _, _, floorProto, err := types.UnmarshalStateSnapshotProto(data)
 	require.NoError(t, err)
 	require.Equal(t, st.HeightSyncForcedStart, restoredState.HeightSyncForcedStart)
 	require.Equal(t, st.HeightSyncTurnReason, restoredState.HeightSyncTurnReason)
+	require.NotNil(t, floorProto)
 
 	restored := newSM()
-	restored.RestoreState(restoredState)
+	floor := heightsync.FloorIndexFromProto(heightsync.FloorConfigFor(len(group), restored.HeartbeatConfig()), floorProto)
+	require.NoError(t, restored.RestoreStateWithFloor(restoredState, floor))
+	require.True(t, restored.HeightSyncFloorReady())
 
 	got := restored.ExportState()
 	require.Equal(t, st.HeightSyncForcedStart, got.HeightSyncForcedStart)
@@ -78,12 +81,20 @@ func TestHeightSync_SnapshotRestoreAgreesOnRootAndFloor(t *testing.T) {
 	require.Equal(t, st.HeightSyncTurnSlots, got.HeightSyncTurnSlots)
 	require.Equal(t, st.HeightSyncTurnReason, got.HeightSyncTurnReason)
 
+	journaled := newSM()
+	require.NoError(t, journaled.RestoreState(restoredState))
+	require.True(t, journaled.HeightSyncFloorReady())
+
 	for _, m := range []uint64{2, 3, 4} {
 		wantH, wantHash, wantKnown := live.HeightSyncFloorAsOf(m)
 		gotH, gotHash, gotKnown := restored.HeightSyncFloorAsOf(m)
-		require.Equal(t, wantKnown, gotKnown, "AsOf(%d)", m)
-		require.Equal(t, wantH, gotH, "AsOf(%d)", m)
-		require.Equal(t, wantHash, gotHash, "AsOf(%d)", m)
+		require.Equal(t, wantKnown, gotKnown, "blob AsOf(%d)", m)
+		require.Equal(t, wantH, gotH, "blob AsOf(%d)", m)
+		require.Equal(t, wantHash, gotHash, "blob AsOf(%d)", m)
+		jh, jhash, jknown := journaled.HeightSyncFloorAsOf(m)
+		require.Equal(t, wantKnown, jknown, "journal AsOf(%d)", m)
+		require.Equal(t, wantH, jh, "journal AsOf(%d)", m)
+		require.Equal(t, wantHash, jhash, "journal AsOf(%d)", m)
 	}
 
 	liveRec := live.HeightSyncTurnRecord(1)
@@ -116,7 +127,7 @@ func (s *failGetDiffsStore) GetDiffs(string, uint64, uint64) ([]types.DiffRecord
 	return nil, errors.New("getdiffs failed")
 }
 
-func TestHeightSync_RestoreGetDiffsErrorKeepsLastCompletedHeight(t *testing.T) {
+func TestHeightSync_RestoreGetDiffsErrorFailsClosed(t *testing.T) {
 	hosts := []*signing.Secp256k1Signer{
 		testutil.MustGenerateKey(t),
 		testutil.MustGenerateKey(t),
@@ -150,12 +161,68 @@ func TestHeightSync_RestoreGetDiffsErrorKeepsLastCompletedHeight(t *testing.T) {
 	restored, err := NewStateMachine("escrow-1", config, group, 1_000_000, user.Address(),
 		signing.NewSecp256k1Verifier(), failStore)
 	require.NoError(t, err)
-	restored.RestoreState(st)
+	err = restored.RestoreState(st)
+	require.ErrorIs(t, err, types.ErrFloorNotRestored)
+	require.False(t, restored.HeightSyncFloorReady())
 
-	got := restored.ExportState()
-	require.Equal(t, st.HeightSyncLastCompletedHeight, got.HeightSyncLastCompletedHeight)
-	require.Equal(t, st.HeightSyncLatestTurnSeq, got.HeightSyncLatestTurnSeq)
-	require.Equal(t, st.HeightSyncLastCompletedHeight, restored.HeightSyncCloneTurnTracker().LastCompletedHeight())
+	bad := testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{snapHeartbeat(2, 10, 3, hash)})
+	_, err = restored.ApplyDiff(bad)
+	require.ErrorIs(t, err, types.ErrFloorNotRestored)
+}
+
+func TestHeightSync_RestoreFloorBlobSkipsJournal(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	user := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	store := testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 1_000_000)
+
+	live, err := NewStateMachine("escrow-1", config, group, 1_000_000, user.Address(),
+		signing.NewSecp256k1Verifier(), store)
+	require.NoError(t, err)
+	hash := []byte{0xaa}
+	apply := func(nonce uint64, txs ...*types.DevshardTx) {
+		t.Helper()
+		d := testutil.SignDiff(t, user, "escrow-1", nonce, txs)
+		root, err := live.ApplyDiff(d)
+		require.NoError(t, err)
+		require.NoError(t, store.AppendDiff("escrow-1", types.DiffRecord{Diff: d, StateHash: root}))
+	}
+	apply(1, snapHeartbeat(1, 50, 3, hash))
+	apply(2, snapAck(t, hosts[0], 1, 1, 0, 50, hash))
+	apply(3, snapAck(t, hosts[1], 1, 1, 1, 50, hash))
+
+	st := live.ExportState()
+	floor := heightsync.FloorIndexFromProto(
+		heightsync.FloorConfigFor(len(group), live.HeartbeatConfig()),
+		live.ExportHeightSyncFloor(),
+	)
+
+	failStore := &failGetDiffsStore{Memory: testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 1_000_000)}
+	restored, err := NewStateMachine("escrow-1", config, group, 1_000_000, user.Address(),
+		signing.NewSecp256k1Verifier(), failStore)
+	require.NoError(t, err)
+	require.NoError(t, restored.RestoreStateWithFloor(st, floor))
+	require.True(t, restored.HeightSyncFloorReady())
+
+	for _, m := range []uint64{2, 3, 4} {
+		wantH, wantHash, wantKnown := live.HeightSyncFloorAsOf(m)
+		gotH, gotHash, gotKnown := restored.HeightSyncFloorAsOf(m)
+		require.Equal(t, wantKnown, gotKnown, "AsOf(%d)", m)
+		require.Equal(t, wantH, gotH, "AsOf(%d)", m)
+		require.Equal(t, wantHash, gotHash, "AsOf(%d)", m)
+	}
+
+	// Replica A (journal) and replica B (blob, no journal) both reject a below-floor stamp.
+	bad := testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{snapHeartbeat(2, 10, 3, hash)})
+	_, err = live.ApplyDiff(bad)
+	require.ErrorIs(t, err, heightsync.ErrHeightRegression)
+	_, err = restored.ApplyDiff(bad)
+	require.ErrorIs(t, err, heightsync.ErrHeightRegression)
 }
 
 func snapHeartbeat(turn, height, slots uint64, hash []byte) *types.DevshardTx {

--- a/devshard/state/heightsync_snapshot_test.go
+++ b/devshard/state/heightsync_snapshot_test.go
@@ -68,7 +68,9 @@ func TestHeightSync_SnapshotRestoreAgreesOnRootAndFloor(t *testing.T) {
 	require.NotNil(t, floorProto)
 
 	restored := newSM()
-	floor := heightsync.FloorIndexFromProto(heightsync.FloorConfigFor(len(group), restored.HeartbeatConfig()), floorProto)
+	floor, err := heightsync.FloorIndexFromProto(
+		heightsync.FloorConfigFor(len(group), restored.HeartbeatConfig()), floorProto)
+	require.NoError(t, err)
 	require.NoError(t, restored.RestoreStateWithFloor(restoredState, floor))
 	require.True(t, restored.HeightSyncFloorReady())
 
@@ -168,6 +170,12 @@ func TestHeightSync_RestoreGetDiffsErrorFailsClosed(t *testing.T) {
 	bad := testutil.SignDiff(t, user, "escrow-1", 4, []*types.DevshardTx{snapHeartbeat(2, 10, 3, hash)})
 	_, err = restored.ApplyDiff(bad)
 	require.ErrorIs(t, err, types.ErrFloorNotRestored)
+
+	// The empty floor this machine is holding must never reach a snapshot: a
+	// present blob is authoritative on restore, so writing one here would turn
+	// "could not rebuild" into "the fold is empty" for the next reader.
+	require.Nil(t, restored.ExportHeightSyncFloor())
+	require.NotNil(t, live.ExportHeightSyncFloor())
 }
 
 func TestHeightSync_RestoreFloorBlobSkipsJournal(t *testing.T) {
@@ -197,10 +205,11 @@ func TestHeightSync_RestoreFloorBlobSkipsJournal(t *testing.T) {
 	apply(3, snapAck(t, hosts[1], 1, 1, 1, 50, hash))
 
 	st := live.ExportState()
-	floor := heightsync.FloorIndexFromProto(
+	floor, err := heightsync.FloorIndexFromProto(
 		heightsync.FloorConfigFor(len(group), live.HeartbeatConfig()),
 		live.ExportHeightSyncFloor(),
 	)
+	require.NoError(t, err)
 
 	failStore := &failGetDiffsStore{Memory: testutil.MustMemoryStore(t, "escrow-1", user.Address(), config, group, 1_000_000)}
 	restored, err := NewStateMachine("escrow-1", config, group, 1_000_000, user.Address(),

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -113,6 +113,10 @@ type StateMachine struct {
 	turnTracker     *heightsync.TurnTracker
 	heightSyncFloor *heightsync.FloorIndex
 	heightSyncMarks *heightsync.MarkLog
+	// floorReady is true when heightSyncFloor is a consistent fold of
+	// diffs 1..LatestNonce (including genesis, where that range is empty).
+	// It is not AsOf's known flag: a pruned nonce is unknown on a ready floor.
+	floorReady bool
 
 	// obsDeferred, when non-nil, redirects observability writes made during a
 	// trial apply (ValidateDiff / PreviewLocalBestEffort) into a buffer instead
@@ -268,6 +272,7 @@ func NewStateMachine(
 	sm.turnTracker = heightsync.NewTurnTracker(uint64(len(groupCopy)), 0, sm.heartbeatCfg)
 	sm.heightSyncFloor = heightsync.NewFloorIndexWith(
 		heightsync.FloorConfigFor(len(groupCopy), sm.heartbeatCfg))
+	sm.floorReady = true
 
 	logging.Info("NewStateMachine", "subsystem", "state",
 		"escrow_id", escrowID,
@@ -495,6 +500,10 @@ func (sm *StateMachine) localBestEffortLocked(nonce uint64, txs []*types.Devshar
 		return nil, nil, types.ErrMultipleForceHeightSyncTurnMsgs
 	}
 
+	if !sm.floorReady {
+		return nil, nil, types.ErrFloorNotRestored
+	}
+
 	scope := sm.pushMarkScopeLocked()
 	defer scope.discard()
 
@@ -671,6 +680,10 @@ func (sm *StateMachine) applyCore(nonce uint64, txs []*types.DevshardTx, postSta
 	}
 	if countForceHeightSyncTurn(txs) > 1 {
 		return nil, types.ErrMultipleForceHeightSyncTurnMsgs
+	}
+
+	if !sm.floorReady {
+		return nil, types.ErrFloorNotRestored
 	}
 
 	scope := sm.pushMarkScopeLocked()
@@ -854,15 +867,27 @@ func (sm *StateMachine) ExportState() *types.EscrowState {
 }
 
 // RestoreState replaces the current escrow state with a deep copy from storage.
-func (sm *StateMachine) RestoreState(state *types.EscrowState) {
+// The height-sync floor is rebuilt from the journal, or from a snapshot blob
+// supplied via RestoreStateWithFloor when the journal cannot be replayed.
+func (sm *StateMachine) RestoreState(state *types.EscrowState) error {
+	return sm.RestoreStateWithFloor(state, nil)
+}
+
+// RestoreStateWithFloor is RestoreState with an optional snapshot floor.
+// The journal is preferred so the turn tracker is reconstructed. A non-nil
+// floor is installed when GetDiffs fails, which is the restore hole that
+// previously served an empty index and skipped L0. If LatestNonce > 0 and
+// neither source can reconstruct the fold, restore fails rather than splitting
+// the escrow.
+func (sm *StateMachine) RestoreStateWithFloor(state *types.EscrowState, floor *heightsync.FloorIndex) error {
 	if state == nil {
-		return
+		return nil
 	}
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	sm.state = cloneEscrowState(state)
 	sm.rebuildCommittedEntriesLocked()
-	sm.rebuildHeightSyncLocked()
+	return sm.rebuildHeightSyncLocked(floor)
 }
 
 func cloneEscrowState(src *types.EscrowState) *types.EscrowState {

--- a/devshard/types/errors.go
+++ b/devshard/types/errors.go
@@ -44,4 +44,5 @@ var (
 	ErrEscrowIDMismatch      = errors.New("escrow_id does not match session")
 	ErrNonceLimitExceeded    = errors.New("nonce exceeds chain max_nonce limit")
 	ErrMaxTokensBelowFloor   = errors.New("max_tokens below min_tokens floor")
+	ErrFloorNotRestored      = errors.New("height-sync floor not restored")
 )

--- a/devshard/types/snapshot.pb.go
+++ b/devshard/types/snapshot.pb.go
@@ -207,8 +207,9 @@ type EscrowStateProto struct {
 	LatestNonce                 uint64                           `protobuf:"varint,12,opt,name=latest_nonce,json=latestNonce,proto3" json:"latest_nonce,omitempty"`
 	SealedAcc                   []byte                           `protobuf:"bytes,13,opt,name=sealed_acc,json=sealedAcc,proto3" json:"sealed_acc,omitempty"`
 	// Height-sync escrow commit (hashed into the state root). The turn tracker
-	// is rebuilt from snapshot scalars; the floor is a sibling on
-	// StateSnapshotProto (not hashed) so restore does not reread diffs 1..N.
+	// and floor are rebuilt by replaying diffs 1..latest_nonce; the floor also
+	// rides on StateSnapshotProto (not hashed) as the fallback for when that
+	// replay cannot run.
 	HeightSyncForcedStart         uint64 `protobuf:"varint,14,opt,name=height_sync_forced_start,json=heightSyncForcedStart,proto3" json:"height_sync_forced_start,omitempty"`
 	HeightSyncForcedEnd           uint64 `protobuf:"varint,15,opt,name=height_sync_forced_end,json=heightSyncForcedEnd,proto3" json:"height_sync_forced_end,omitempty"`
 	HeightSyncCadenceSwallowUntil uint64 `protobuf:"varint,16,opt,name=height_sync_cadence_swallow_until,json=heightSyncCadenceSwallowUntil,proto3" json:"height_sync_cadence_swallow_until,omitempty"`
@@ -391,7 +392,9 @@ func (x *EscrowStateProto) GetHeightSyncTurnReason() string {
 }
 
 // FloorIndexProto is the derived height-sync floor (entries + per-signer
-// claims). It is not hashed into the state root.
+// claims). It is not hashed into the state root. Entries are ordered by nonce
+// and hold a running maximum height; a reader that cannot confirm that must
+// discard the blob rather than answer F(m) from it.
 type FloorIndexEntryProto struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Nonce         uint64                 `protobuf:"varint,1,opt,name=nonce,proto3" json:"nonce,omitempty"`

--- a/devshard/types/snapshot.pb.go
+++ b/devshard/types/snapshot.pb.go
@@ -206,8 +206,9 @@ type EscrowStateProto struct {
 	WarmKeys                    map[uint32]string                `protobuf:"bytes,11,rep,name=warm_keys,json=warmKeys,proto3" json:"warm_keys,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	LatestNonce                 uint64                           `protobuf:"varint,12,opt,name=latest_nonce,json=latestNonce,proto3" json:"latest_nonce,omitempty"`
 	SealedAcc                   []byte                           `protobuf:"bytes,13,opt,name=sealed_acc,json=sealedAcc,proto3" json:"sealed_acc,omitempty"`
-	// Height-sync escrow commit (hashed into the state root). Tracker and floor
-	// are rebuilt from diffs 1..latest_nonce on restore, not persisted here.
+	// Height-sync escrow commit (hashed into the state root). The turn tracker
+	// is rebuilt from snapshot scalars; the floor is a sibling on
+	// StateSnapshotProto (not hashed) so restore does not reread diffs 1..N.
 	HeightSyncForcedStart         uint64 `protobuf:"varint,14,opt,name=height_sync_forced_start,json=heightSyncForcedStart,proto3" json:"height_sync_forced_start,omitempty"`
 	HeightSyncForcedEnd           uint64 `protobuf:"varint,15,opt,name=height_sync_forced_end,json=heightSyncForcedEnd,proto3" json:"height_sync_forced_end,omitempty"`
 	HeightSyncCadenceSwallowUntil uint64 `protobuf:"varint,16,opt,name=height_sync_cadence_swallow_until,json=heightSyncCadenceSwallowUntil,proto3" json:"height_sync_cadence_swallow_until,omitempty"`
@@ -389,6 +390,196 @@ func (x *EscrowStateProto) GetHeightSyncTurnReason() string {
 	return ""
 }
 
+// FloorIndexProto is the derived height-sync floor (entries + per-signer
+// claims). It is not hashed into the state root.
+type FloorIndexEntryProto struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Nonce         uint64                 `protobuf:"varint,1,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	Height        uint64                 `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`
+	Hash          []byte                 `protobuf:"bytes,3,opt,name=hash,proto3" json:"hash,omitempty"`
+	Author        uint32                 `protobuf:"varint,4,opt,name=author,proto3" json:"author,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FloorIndexEntryProto) Reset() {
+	*x = FloorIndexEntryProto{}
+	mi := &file_devshard_v1_snapshot_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FloorIndexEntryProto) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FloorIndexEntryProto) ProtoMessage() {}
+
+func (x *FloorIndexEntryProto) ProtoReflect() protoreflect.Message {
+	mi := &file_devshard_v1_snapshot_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FloorIndexEntryProto.ProtoReflect.Descriptor instead.
+func (*FloorIndexEntryProto) Descriptor() ([]byte, []int) {
+	return file_devshard_v1_snapshot_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *FloorIndexEntryProto) GetNonce() uint64 {
+	if x != nil {
+		return x.Nonce
+	}
+	return 0
+}
+
+func (x *FloorIndexEntryProto) GetHeight() uint64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+func (x *FloorIndexEntryProto) GetHash() []byte {
+	if x != nil {
+		return x.Hash
+	}
+	return nil
+}
+
+func (x *FloorIndexEntryProto) GetAuthor() uint32 {
+	if x != nil {
+		return x.Author
+	}
+	return 0
+}
+
+type FloorSignerClaimProto struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Signer        uint32                 `protobuf:"varint,1,opt,name=signer,proto3" json:"signer,omitempty"`
+	Height        uint64                 `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`
+	Hash          []byte                 `protobuf:"bytes,3,opt,name=hash,proto3" json:"hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FloorSignerClaimProto) Reset() {
+	*x = FloorSignerClaimProto{}
+	mi := &file_devshard_v1_snapshot_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FloorSignerClaimProto) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FloorSignerClaimProto) ProtoMessage() {}
+
+func (x *FloorSignerClaimProto) ProtoReflect() protoreflect.Message {
+	mi := &file_devshard_v1_snapshot_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FloorSignerClaimProto.ProtoReflect.Descriptor instead.
+func (*FloorSignerClaimProto) Descriptor() ([]byte, []int) {
+	return file_devshard_v1_snapshot_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *FloorSignerClaimProto) GetSigner() uint32 {
+	if x != nil {
+		return x.Signer
+	}
+	return 0
+}
+
+func (x *FloorSignerClaimProto) GetHeight() uint64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+func (x *FloorSignerClaimProto) GetHash() []byte {
+	if x != nil {
+		return x.Hash
+	}
+	return nil
+}
+
+type FloorIndexProto struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Entries       []*FloorIndexEntryProto  `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	Claims        []*FloorSignerClaimProto `protobuf:"bytes,2,rep,name=claims,proto3" json:"claims,omitempty"`
+	Truncated     bool                     `protobuf:"varint,3,opt,name=truncated,proto3" json:"truncated,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FloorIndexProto) Reset() {
+	*x = FloorIndexProto{}
+	mi := &file_devshard_v1_snapshot_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FloorIndexProto) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FloorIndexProto) ProtoMessage() {}
+
+func (x *FloorIndexProto) ProtoReflect() protoreflect.Message {
+	mi := &file_devshard_v1_snapshot_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FloorIndexProto.ProtoReflect.Descriptor instead.
+func (*FloorIndexProto) Descriptor() ([]byte, []int) {
+	return file_devshard_v1_snapshot_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *FloorIndexProto) GetEntries() []*FloorIndexEntryProto {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
+func (x *FloorIndexProto) GetClaims() []*FloorSignerClaimProto {
+	if x != nil {
+		return x.Claims
+	}
+	return nil
+}
+
+func (x *FloorIndexProto) GetTruncated() bool {
+	if x != nil {
+		return x.Truncated
+	}
+	return false
+}
+
 // StateSnapshotProto matches the shared storage/recovery envelope. Hosts do not
 // use host_sync_nonce, but keeping the field makes snapshots portable across
 // proxy and host recovery code.
@@ -398,13 +589,14 @@ type StateSnapshotProto struct {
 	CommittedEntries map[uint64][]byte      `protobuf:"bytes,2,rep,name=committed_entries,json=committedEntries,proto3" json:"committed_entries,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	SealedNonces     map[uint64]uint64      `protobuf:"bytes,3,rep,name=sealed_nonces,json=sealedNonces,proto3" json:"sealed_nonces,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	HostSyncNonce    map[int32]uint64       `protobuf:"bytes,4,rep,name=host_sync_nonce,json=hostSyncNonce,proto3" json:"host_sync_nonce,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	HeightSyncFloor  *FloorIndexProto       `protobuf:"bytes,5,opt,name=height_sync_floor,json=heightSyncFloor,proto3" json:"height_sync_floor,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
 
 func (x *StateSnapshotProto) Reset() {
 	*x = StateSnapshotProto{}
-	mi := &file_devshard_v1_snapshot_proto_msgTypes[3]
+	mi := &file_devshard_v1_snapshot_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -416,7 +608,7 @@ func (x *StateSnapshotProto) String() string {
 func (*StateSnapshotProto) ProtoMessage() {}
 
 func (x *StateSnapshotProto) ProtoReflect() protoreflect.Message {
-	mi := &file_devshard_v1_snapshot_proto_msgTypes[3]
+	mi := &file_devshard_v1_snapshot_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -429,7 +621,7 @@ func (x *StateSnapshotProto) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateSnapshotProto.ProtoReflect.Descriptor instead.
 func (*StateSnapshotProto) Descriptor() ([]byte, []int) {
-	return file_devshard_v1_snapshot_proto_rawDescGZIP(), []int{3}
+	return file_devshard_v1_snapshot_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *StateSnapshotProto) GetState() *EscrowStateProto {
@@ -456,6 +648,13 @@ func (x *StateSnapshotProto) GetSealedNonces() map[uint64]uint64 {
 func (x *StateSnapshotProto) GetHostSyncNonce() map[int32]uint64 {
 	if x != nil {
 		return x.HostSyncNonce
+	}
+	return nil
+}
+
+func (x *StateSnapshotProto) GetHeightSyncFloor() *FloorIndexProto {
+	if x != nil {
+		return x.HeightSyncFloor
 	}
 	return nil
 }
@@ -515,12 +714,26 @@ const file_devshard_v1_snapshot_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x1b.devshard.v1.HostStatsProtoR\x05value:\x028\x01\x1a;\n" +
 	"\rWarmKeysEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\rR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xa9\x04\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"p\n" +
+	"\x14FloorIndexEntryProto\x12\x14\n" +
+	"\x05nonce\x18\x01 \x01(\x04R\x05nonce\x12\x16\n" +
+	"\x06height\x18\x02 \x01(\x04R\x06height\x12\x12\n" +
+	"\x04hash\x18\x03 \x01(\fR\x04hash\x12\x16\n" +
+	"\x06author\x18\x04 \x01(\rR\x06author\"[\n" +
+	"\x15FloorSignerClaimProto\x12\x16\n" +
+	"\x06signer\x18\x01 \x01(\rR\x06signer\x12\x16\n" +
+	"\x06height\x18\x02 \x01(\x04R\x06height\x12\x12\n" +
+	"\x04hash\x18\x03 \x01(\fR\x04hash\"\xa8\x01\n" +
+	"\x0fFloorIndexProto\x12;\n" +
+	"\aentries\x18\x01 \x03(\v2!.devshard.v1.FloorIndexEntryProtoR\aentries\x12:\n" +
+	"\x06claims\x18\x02 \x03(\v2\".devshard.v1.FloorSignerClaimProtoR\x06claims\x12\x1c\n" +
+	"\ttruncated\x18\x03 \x01(\bR\ttruncated\"\xf3\x04\n" +
 	"\x12StateSnapshotProto\x123\n" +
 	"\x05state\x18\x01 \x01(\v2\x1d.devshard.v1.EscrowStateProtoR\x05state\x12b\n" +
 	"\x11committed_entries\x18\x02 \x03(\v25.devshard.v1.StateSnapshotProto.CommittedEntriesEntryR\x10committedEntries\x12V\n" +
 	"\rsealed_nonces\x18\x03 \x03(\v21.devshard.v1.StateSnapshotProto.SealedNoncesEntryR\fsealedNonces\x12Z\n" +
-	"\x0fhost_sync_nonce\x18\x04 \x03(\v22.devshard.v1.StateSnapshotProto.HostSyncNonceEntryR\rhostSyncNonce\x1aC\n" +
+	"\x0fhost_sync_nonce\x18\x04 \x03(\v22.devshard.v1.StateSnapshotProto.HostSyncNonceEntryR\rhostSyncNonce\x12H\n" +
+	"\x11height_sync_floor\x18\x05 \x01(\v2\x1c.devshard.v1.FloorIndexProtoR\x0fheightSyncFloor\x1aC\n" +
 	"\x15CommittedEntriesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\x04R\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\x1a?\n" +
@@ -543,38 +756,44 @@ func file_devshard_v1_snapshot_proto_rawDescGZIP() []byte {
 	return file_devshard_v1_snapshot_proto_rawDescData
 }
 
-var file_devshard_v1_snapshot_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_devshard_v1_snapshot_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_devshard_v1_snapshot_proto_goTypes = []any{
-	(*SessionConfigProto)(nil),   // 0: devshard.v1.SessionConfigProto
-	(*SlotAssignmentProto)(nil),  // 1: devshard.v1.SlotAssignmentProto
-	(*EscrowStateProto)(nil),     // 2: devshard.v1.EscrowStateProto
-	(*StateSnapshotProto)(nil),   // 3: devshard.v1.StateSnapshotProto
-	nil,                          // 4: devshard.v1.EscrowStateProto.InferencesEntry
-	nil,                          // 5: devshard.v1.EscrowStateProto.HostStatsEntry
-	nil,                          // 6: devshard.v1.EscrowStateProto.WarmKeysEntry
-	nil,                          // 7: devshard.v1.StateSnapshotProto.CommittedEntriesEntry
-	nil,                          // 8: devshard.v1.StateSnapshotProto.SealedNoncesEntry
-	nil,                          // 9: devshard.v1.StateSnapshotProto.HostSyncNonceEntry
-	(*InferenceRecordProto)(nil), // 10: devshard.v1.InferenceRecordProto
-	(*HostStatsProto)(nil),       // 11: devshard.v1.HostStatsProto
+	(*SessionConfigProto)(nil),    // 0: devshard.v1.SessionConfigProto
+	(*SlotAssignmentProto)(nil),   // 1: devshard.v1.SlotAssignmentProto
+	(*EscrowStateProto)(nil),      // 2: devshard.v1.EscrowStateProto
+	(*FloorIndexEntryProto)(nil),  // 3: devshard.v1.FloorIndexEntryProto
+	(*FloorSignerClaimProto)(nil), // 4: devshard.v1.FloorSignerClaimProto
+	(*FloorIndexProto)(nil),       // 5: devshard.v1.FloorIndexProto
+	(*StateSnapshotProto)(nil),    // 6: devshard.v1.StateSnapshotProto
+	nil,                           // 7: devshard.v1.EscrowStateProto.InferencesEntry
+	nil,                           // 8: devshard.v1.EscrowStateProto.HostStatsEntry
+	nil,                           // 9: devshard.v1.EscrowStateProto.WarmKeysEntry
+	nil,                           // 10: devshard.v1.StateSnapshotProto.CommittedEntriesEntry
+	nil,                           // 11: devshard.v1.StateSnapshotProto.SealedNoncesEntry
+	nil,                           // 12: devshard.v1.StateSnapshotProto.HostSyncNonceEntry
+	(*InferenceRecordProto)(nil),  // 13: devshard.v1.InferenceRecordProto
+	(*HostStatsProto)(nil),        // 14: devshard.v1.HostStatsProto
 }
 var file_devshard_v1_snapshot_proto_depIdxs = []int32{
 	0,  // 0: devshard.v1.EscrowStateProto.config:type_name -> devshard.v1.SessionConfigProto
 	1,  // 1: devshard.v1.EscrowStateProto.group:type_name -> devshard.v1.SlotAssignmentProto
-	4,  // 2: devshard.v1.EscrowStateProto.inferences:type_name -> devshard.v1.EscrowStateProto.InferencesEntry
-	5,  // 3: devshard.v1.EscrowStateProto.host_stats:type_name -> devshard.v1.EscrowStateProto.HostStatsEntry
-	6,  // 4: devshard.v1.EscrowStateProto.warm_keys:type_name -> devshard.v1.EscrowStateProto.WarmKeysEntry
-	2,  // 5: devshard.v1.StateSnapshotProto.state:type_name -> devshard.v1.EscrowStateProto
-	7,  // 6: devshard.v1.StateSnapshotProto.committed_entries:type_name -> devshard.v1.StateSnapshotProto.CommittedEntriesEntry
-	8,  // 7: devshard.v1.StateSnapshotProto.sealed_nonces:type_name -> devshard.v1.StateSnapshotProto.SealedNoncesEntry
-	9,  // 8: devshard.v1.StateSnapshotProto.host_sync_nonce:type_name -> devshard.v1.StateSnapshotProto.HostSyncNonceEntry
-	10, // 9: devshard.v1.EscrowStateProto.InferencesEntry.value:type_name -> devshard.v1.InferenceRecordProto
-	11, // 10: devshard.v1.EscrowStateProto.HostStatsEntry.value:type_name -> devshard.v1.HostStatsProto
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	7,  // 2: devshard.v1.EscrowStateProto.inferences:type_name -> devshard.v1.EscrowStateProto.InferencesEntry
+	8,  // 3: devshard.v1.EscrowStateProto.host_stats:type_name -> devshard.v1.EscrowStateProto.HostStatsEntry
+	9,  // 4: devshard.v1.EscrowStateProto.warm_keys:type_name -> devshard.v1.EscrowStateProto.WarmKeysEntry
+	3,  // 5: devshard.v1.FloorIndexProto.entries:type_name -> devshard.v1.FloorIndexEntryProto
+	4,  // 6: devshard.v1.FloorIndexProto.claims:type_name -> devshard.v1.FloorSignerClaimProto
+	2,  // 7: devshard.v1.StateSnapshotProto.state:type_name -> devshard.v1.EscrowStateProto
+	10, // 8: devshard.v1.StateSnapshotProto.committed_entries:type_name -> devshard.v1.StateSnapshotProto.CommittedEntriesEntry
+	11, // 9: devshard.v1.StateSnapshotProto.sealed_nonces:type_name -> devshard.v1.StateSnapshotProto.SealedNoncesEntry
+	12, // 10: devshard.v1.StateSnapshotProto.host_sync_nonce:type_name -> devshard.v1.StateSnapshotProto.HostSyncNonceEntry
+	5,  // 11: devshard.v1.StateSnapshotProto.height_sync_floor:type_name -> devshard.v1.FloorIndexProto
+	13, // 12: devshard.v1.EscrowStateProto.InferencesEntry.value:type_name -> devshard.v1.InferenceRecordProto
+	14, // 13: devshard.v1.EscrowStateProto.HostStatsEntry.value:type_name -> devshard.v1.HostStatsProto
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_devshard_v1_snapshot_proto_init() }
@@ -589,7 +808,7 @@ func file_devshard_v1_snapshot_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_devshard_v1_snapshot_proto_rawDesc), len(file_devshard_v1_snapshot_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/devshard/types/snapshot_codec.go
+++ b/devshard/types/snapshot_codec.go
@@ -161,25 +161,29 @@ func EscrowStateFromProto(msg *EscrowStateProto) *EscrowState {
 }
 
 // MarshalStateSnapshotProto serializes a state snapshot envelope to protobuf.
-func MarshalStateSnapshotProto(state *EscrowState, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64) ([]byte, error) {
+// heightSyncFloor is derived RAM (not hashed); nil omits the field so legacy
+// readers still load the hashed EscrowState.
+func MarshalStateSnapshotProto(state *EscrowState, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64, heightSyncFloor *FloorIndexProto) ([]byte, error) {
 	msg := &StateSnapshotProto{
 		State:            EscrowStateToProto(state),
 		CommittedEntries: cloneBytesMap(committedEntries),
 		SealedNonces:     cloneUint64Map(sealedNonces),
+		HeightSyncFloor:  heightSyncFloor,
 	}
 	return proto.Marshal(msg)
 }
 
 // UnmarshalStateSnapshotProto deserializes a protobuf state snapshot envelope.
-func UnmarshalStateSnapshotProto(data []byte) (*EscrowState, map[uint64][]byte, map[uint64]uint64, error) {
+// A nil height-sync floor means the snapshot predates the field (rebuild from the journal).
+func UnmarshalStateSnapshotProto(data []byte) (*EscrowState, map[uint64][]byte, map[uint64]uint64, *FloorIndexProto, error) {
 	msg := &StateSnapshotProto{}
 	if err := proto.Unmarshal(data, msg); err != nil {
-		return nil, nil, nil, fmt.Errorf("unmarshal state snapshot proto: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("unmarshal state snapshot proto: %w", err)
 	}
 	if msg.State == nil {
-		return nil, nil, nil, fmt.Errorf("unmarshal state snapshot proto: missing state")
+		return nil, nil, nil, nil, fmt.Errorf("unmarshal state snapshot proto: missing state")
 	}
-	return EscrowStateFromProto(msg.State), cloneBytesMap(msg.CommittedEntries), cloneUint64Map(msg.SealedNonces), nil
+	return EscrowStateFromProto(msg.State), cloneBytesMap(msg.CommittedEntries), cloneUint64Map(msg.SealedNonces), msg.HeightSyncFloor, nil
 }
 
 func inferenceRecordToProto(id uint64, rec *InferenceRecord) *InferenceRecordProto {

--- a/devshard/types/snapshot_codec_test.go
+++ b/devshard/types/snapshot_codec_test.go
@@ -91,13 +91,50 @@ func TestMarshalStateSnapshotProtoRoundTrip(t *testing.T) {
 	committed := map[uint64][]byte{1: []byte("entry-one")}
 	sealed := map[uint64]uint64{1: 11}
 
-	data, err := MarshalStateSnapshotProto(state, committed, sealed)
+	data, err := MarshalStateSnapshotProto(state, committed, sealed, nil)
 	require.NoError(t, err)
 
-	roundTripState, roundTripCommitted, roundTripSealed, err := UnmarshalStateSnapshotProto(data)
+	roundTripState, roundTripCommitted, roundTripSealed, roundTripFloor, err := UnmarshalStateSnapshotProto(data)
 	require.NoError(t, err)
 	require.Equal(t, state.EscrowID, roundTripState.EscrowID)
 	require.Equal(t, state.LatestNonce, roundTripState.LatestNonce)
 	require.Equal(t, committed, roundTripCommitted)
 	require.Equal(t, sealed, roundTripSealed)
+	require.Nil(t, roundTripFloor)
+}
+
+func TestMarshalStateSnapshotProtoRoundTripFloor(t *testing.T) {
+	state := &EscrowState{
+		EscrowID:                    "escrow-1",
+		StateRootAndProtocolVersion: "v2",
+		LatestNonce:                 42,
+		Inferences:                  map[uint64]*InferenceRecord{},
+		HostStats:                   map[uint32]*HostStats{0: {}},
+		WarmKeys:                    map[uint32]string{0: "warm-0"},
+	}
+	floor := &FloorIndexProto{
+		Truncated: true,
+		Entries: []*FloorIndexEntryProto{{
+			Nonce:  3,
+			Height: 50,
+			Hash:   []byte{0xaa},
+			Author: 1,
+		}},
+		Claims: []*FloorSignerClaimProto{{
+			Signer: 1,
+			Height: 50,
+			Hash:   []byte{0xaa},
+		}},
+	}
+
+	data, err := MarshalStateSnapshotProto(state, nil, nil, floor)
+	require.NoError(t, err)
+
+	_, _, _, roundTripFloor, err := UnmarshalStateSnapshotProto(data)
+	require.NoError(t, err)
+	require.NotNil(t, roundTripFloor)
+	require.True(t, roundTripFloor.Truncated)
+	require.Equal(t, floor.Entries[0].Height, roundTripFloor.Entries[0].Height)
+	require.Equal(t, floor.Entries[0].Hash, roundTripFloor.Entries[0].Hash)
+	require.Equal(t, floor.Claims[0].Signer, roundTripFloor.Claims[0].Signer)
 }

--- a/devshard/user/heartbeat.go
+++ b/devshard/user/heartbeat.go
@@ -334,6 +334,9 @@ func (s *Session) hasPendingHeightAckLocked() bool {
 // both are better than the sequencer signing a height it has no reason to think
 // exists.
 func (s *Session) referenceStampLocked(nonce uint64) (uint64, []byte, bool) {
+	if !s.sm.HeightSyncFloorReady() {
+		return 0, nil, false
+	}
 	h, hash, ok := s.observedHeightLocked()
 	if !heightsync.StampPresent(hash) {
 		h, hash, ok = 0, nil, false

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -187,7 +187,16 @@ func RecoverSession(
 		if decodeErr != nil {
 			log.Printf("recover_session escrow=%s snapshot_nonce=%d unmarshal_failed=%v (replaying from 1)", escrowID, snapNonce, decodeErr)
 		} else {
-			floor := heightsync.FloorIndexFromProto(heightsync.FloorConfigFor(len(snapState.Group), sm.HeartbeatConfig()), floorProto)
+			// A rejected blob degrades to a journal replay; if that cannot run
+			// either, RestoreStateWithFloor fails closed rather than serving
+			// L0 from a floor we could not verify.
+			floor, floorErr := heightsync.FloorIndexFromProto(
+				heightsync.FloorConfigFor(len(snapState.Group), sm.HeartbeatConfig()), floorProto)
+			if floorErr != nil {
+				log.Printf("recover_session escrow=%s snapshot_nonce=%d floor_blob_rejected=%v (rebuilding from diffs)",
+					escrowID, snapNonce, floorErr)
+				floor = nil
+			}
 			if restErr := sm.RestoreStateWithFloor(snapState, floor); restErr != nil {
 				return nil, nil, fmt.Errorf("restore snapshot nonce %d: %w", snapNonce, restErr)
 			}

--- a/devshard/user/recover.go
+++ b/devshard/user/recover.go
@@ -69,25 +69,26 @@ const snapshotInterval = 500
 // that was stranded behind the prior snapshot self-heals via host-side
 // silent-skip (host.applyAndPersist drops diffs whose Nonce <= currentNonce).
 type sessionSnapshot struct {
-	State            *types.EscrowState `json:"state"`
-	HostSyncNonce    map[int]uint64     `json:"host_sync_nonce,omitempty"`
-	CommittedEntries map[uint64][]byte  `json:"committed_entries,omitempty"`
-	SealedNonces     map[uint64]uint64  `json:"sealed_nonces,omitempty"`
+	State            *types.EscrowState     `json:"state"`
+	HostSyncNonce    map[int]uint64         `json:"host_sync_nonce,omitempty"`
+	CommittedEntries map[uint64][]byte      `json:"committed_entries,omitempty"`
+	SealedNonces     map[uint64]uint64      `json:"sealed_nonces,omitempty"`
+	HeightSyncFloor  *types.FloorIndexProto `json:"height_sync_floor,omitempty"`
 }
 
 // decodeSnapshot decodes the on-disk snapshot blob. Returns the state and
 // the per-host sync cursor (nil for legacy bare-EscrowState snapshots).
-func decodeSnapshot(data []byte) (*types.EscrowState, map[int]uint64, map[uint64][]byte, map[uint64]uint64, error) {
+func decodeSnapshot(data []byte) (*types.EscrowState, map[int]uint64, map[uint64][]byte, map[uint64]uint64, *types.FloorIndexProto, error) {
 	var blob sessionSnapshot
 	if err := json.Unmarshal(data, &blob); err == nil && blob.State != nil {
-		return blob.State, blob.HostSyncNonce, blob.CommittedEntries, blob.SealedNonces, nil
+		return blob.State, blob.HostSyncNonce, blob.CommittedEntries, blob.SealedNonces, blob.HeightSyncFloor, nil
 	}
 	// Legacy format: top-level EscrowState fields. Re-unmarshal as bare.
 	var bare types.EscrowState
 	if err := json.Unmarshal(data, &bare); err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
-	return &bare, nil, nil, nil, nil
+	return &bare, nil, nil, nil, nil, nil
 }
 
 // minHostSyncNonce returns the smallest cursor value across all hosts
@@ -182,11 +183,14 @@ func RecoverSession(
 	replayFrom := uint64(1)
 	snapNonce, snapData, snapErr := store.LoadSnapshot(escrowID)
 	if snapErr == nil && snapNonce > 0 && snapNonce <= meta.LatestNonce {
-		snapState, cursor, committedEntries, sealedNonces, decodeErr := decodeSnapshot(snapData)
+		snapState, cursor, committedEntries, sealedNonces, floorProto, decodeErr := decodeSnapshot(snapData)
 		if decodeErr != nil {
 			log.Printf("recover_session escrow=%s snapshot_nonce=%d unmarshal_failed=%v (replaying from 1)", escrowID, snapNonce, decodeErr)
 		} else {
-			sm.RestoreState(snapState)
+			floor := heightsync.FloorIndexFromProto(heightsync.FloorConfigFor(len(snapState.Group), sm.HeartbeatConfig()), floorProto)
+			if restErr := sm.RestoreStateWithFloor(snapState, floor); restErr != nil {
+				return nil, nil, fmt.Errorf("restore snapshot nonce %d: %w", snapNonce, restErr)
+			}
 			sm.RestoreCommittedEntries(committedEntries)
 			sm.RestoreSealedNonces(sealedNonces)
 			replayFrom = snapNonce + 1
@@ -426,7 +430,7 @@ func saveSnapshot(store storage.Storage, sm *state.StateMachine, escrowID string
 	for k, v := range hostSyncNonce {
 		cursor[k] = v
 	}
-	writeSnapshot(store, escrowID, nonce, sm.ExportState(), cursor, sm.ExportCommittedEntries(), sm.ExportSealedNonces())
+	writeSnapshot(store, escrowID, nonce, sm.ExportState(), cursor, sm.ExportCommittedEntries(), sm.ExportSealedNonces(), sm.ExportHeightSyncFloor())
 }
 
 // writeSnapshot persists a pre-prepared snapshot blob. The caller must
@@ -434,15 +438,15 @@ func saveSnapshot(store storage.Storage, sm *state.StateMachine, escrowID string
 // only the JSON marshal + storage write and can run without any session
 // or state-machine locks held -- this is what enables async background
 // snapshots from the runtime hot path).
-func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64) {
-	_ = writeSnapshotErr(store, escrowID, nonce, state, cursor, committedEntries, sealedNonces)
+func writeSnapshot(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64, heightSyncFloor *types.FloorIndexProto) {
+	_ = writeSnapshotErr(store, escrowID, nonce, state, cursor, committedEntries, sealedNonces, heightSyncFloor)
 }
 
 // writeSnapshotErr is writeSnapshot with an error return, for synchronous
 // callers (e.g. Session.FlushSnapshot on retire) that want to know whether the
 // snapshot landed. It logs on failure exactly like writeSnapshot.
-func writeSnapshotErr(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64) error {
-	blob := sessionSnapshot{State: state, HostSyncNonce: cursor, CommittedEntries: committedEntries, SealedNonces: sealedNonces}
+func writeSnapshotErr(store storage.Storage, escrowID string, nonce uint64, state *types.EscrowState, cursor map[int]uint64, committedEntries map[uint64][]byte, sealedNonces map[uint64]uint64, heightSyncFloor *types.FloorIndexProto) error {
+	blob := sessionSnapshot{State: state, HostSyncNonce: cursor, CommittedEntries: committedEntries, SealedNonces: sealedNonces, HeightSyncFloor: heightSyncFloor}
 	data, err := json.Marshal(blob)
 	if err != nil {
 		log.Printf("recover_session escrow=%s snapshot_marshal_failed=%v", escrowID, err)

--- a/devshard/user/recover_test.go
+++ b/devshard/user/recover_test.go
@@ -2289,3 +2289,34 @@ func TestRecoverSession_ReplaysADiffWrittenBeforeTheMinTokensFloor(t *testing.T)
 	require.NotNil(t, session)
 	require.Equal(t, types.StatusPending, recovered.SnapshotState().Inferences[1].Status)
 }
+
+func TestDecodeSnapshot_HeightSyncFloor(t *testing.T) {
+	blob, err := json.Marshal(sessionSnapshot{
+		State: &types.EscrowState{EscrowID: "escrow-1", LatestNonce: 3},
+		HeightSyncFloor: &types.FloorIndexProto{
+			Truncated: true,
+			Entries: []*types.FloorIndexEntryProto{{
+				Nonce:  3,
+				Height: 50,
+				Hash:   []byte{0xaa},
+				Author: 1,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	st, _, _, _, floor, err := decodeSnapshot(blob)
+	require.NoError(t, err)
+	require.Equal(t, "escrow-1", st.EscrowID)
+	require.NotNil(t, floor)
+	require.True(t, floor.Truncated)
+	require.Equal(t, uint64(50), floor.Entries[0].Height)
+	require.Equal(t, []byte{0xaa}, floor.Entries[0].Hash)
+
+	legacy, err := json.Marshal(types.EscrowState{EscrowID: "escrow-2"})
+	require.NoError(t, err)
+	st2, _, _, _, floor2, err := decodeSnapshot(legacy)
+	require.NoError(t, err)
+	require.Equal(t, "escrow-2", st2.EscrowID)
+	require.Nil(t, floor2)
+}

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -1053,6 +1053,7 @@ func (s *Session) maybeSaveSnapshotLocked() {
 	state := s.sm.ExportState()
 	committedEntries := s.sm.ExportCommittedEntries()
 	sealedNonces := s.sm.ExportSealedNonces()
+	heightSyncFloor := s.sm.ExportHeightSyncFloor()
 	cursor := make(map[int]uint64, len(s.hostSyncNonce))
 	for k, v := range s.hostSyncNonce {
 		cursor[k] = v
@@ -1063,7 +1064,7 @@ func (s *Session) maybeSaveSnapshotLocked() {
 
 	go func() {
 		defer s.snapshotInFlight.Store(false)
-		writeSnapshot(store, escrowID, nonce, state, cursor, committedEntries, sealedNonces)
+		writeSnapshot(store, escrowID, nonce, state, cursor, committedEntries, sealedNonces, heightSyncFloor)
 	}()
 }
 
@@ -1112,6 +1113,7 @@ func (s *Session) FlushSnapshot() error {
 	stateCopy := s.sm.ExportState()
 	committedEntries := s.sm.ExportCommittedEntries()
 	sealedNonces := s.sm.ExportSealedNonces()
+	heightSyncFloor := s.sm.ExportHeightSyncFloor()
 	cursor := make(map[int]uint64, len(s.hostSyncNonce))
 	for k, v := range s.hostSyncNonce {
 		cursor[k] = v
@@ -1121,7 +1123,7 @@ func (s *Session) FlushSnapshot() error {
 	escrowID := s.escrowID
 	s.mu.Unlock()
 
-	return writeSnapshotErr(store, escrowID, nonce, stateCopy, cursor, committedEntries, sealedNonces)
+	return writeSnapshotErr(store, escrowID, nonce, stateCopy, cursor, committedEntries, sealedNonces, heightSyncFloor)
 }
 
 // PrepareInference composes a diff, applies it locally, advances nonce,


### PR DESCRIPTION
Following comment by [bonujel on #1584](https://github.com/gonka-ai/gonka/pull/1584#issuecomment-5448034487).

## Summary

- Persist `FloorIndex` on the snapshot envelope (host protobuf + gateway JSON), not in hashed `EscrowState`.
- Fail restore when `LatestNonce > 0` and neither the journal nor a valid blob can rebuild the fold (`ErrFloorNotRestored`).
- Refuse apply and omit producer stamps while `!floorReady`, so a replica cannot skip L0 with an empty index.
- Validate a present blob before installing it; omit `ExportHeightSyncFloor` unless the floor actually folded.

## Why

[The #1584 comment](https://github.com/gonka-ai/gonka/pull/1584#issuecomment-5448034487) agrees that `max(own_tip, F(m))` is the producer rule, then shows a restore hole that still splits the escrow.

`rebuildHeightSyncLocked` on a `GetDiffs` error used to swallow the error, keep snapshot `h_last`, and install an empty `FloorIndex`. L0 skips when `!known || floor == 0`. Two replicas from the same snapshot then diverged:

```
replica A (journal read ok): ApplyDiff(nonce 4) -> INVALID(height_regression):
                             heartbeat height 10 < floor 50 as of nonce 4
replica B (GetDiffs failed):  ApplyDiff(nonce 4) -> nil; LatestNonce=4
```

`applyCore` rejects the whole diff on L0, so this is not one tx dropped from a set. The state root does not cover `LatestNonce`, so the split is not automatically a root mismatch — it becomes one as soon as an accepted diff charges `FeePerNonce`. The comment also notes that #1649 / #1653 restored the other derived snapshot indexes, which left `heightSyncFloor` as the one still emptied by design.

That is the same split `observeHeightSyncLocked` already refuses to create by folding only on apply.

## Behavior

**Envelope, not root.** `StateSnapshotProto.height_sync_floor = 5` and JSON `height_sync_floor`. Fields 14–20 of `EscrowStateProto` are unchanged. Settlement still hashes only `HeightSyncEscrowCommit` (the seven forced-turn / cadence scalars). `F` is not in `restHash`.

**Journal first, blob as fallback.** Restore still replays diffs `1..LatestNonce` when `GetDiffs` succeeds, because that is what rebuilds the turn tracker. The blob is installed only when that replay cannot run. A missing blob (legacy snapshot) stays a journal rebuild.

**Fail closed.** `LatestNonce > 0` and no journal and no blob → `ErrFloorNotRestored`, `floorReady=false`. Apply and `localBestEffort` reject; host/user `referenceStamp` omit rather than write a raw oracle tip against a missing `F`.

**Blob is validated.** `FloorIndexFromProto` rejects anything no diff sequence can produce (nonces/heights not strictly increasing, missing stamps, nil entries, repeated signers). A rejected blob degrades to a journal replay; restore fails closed only if that cannot run either. `ExportHeightSyncFloor` returns nil unless `floorReady`, so a not-ready machine cannot persist an empty-but-authoritative fold.

**Not this change.** `GetDiffs` returning empty with a nil error is still a successful fold. On a self-consistent store that case does not arise in production (`PruneEpoch` drops sessions, diffs, and snapshots together). It remains the test seam for synthesized `RestoreState` with no journal. Seeding `F` from the oracle is not a substitute: `F` is a function of the applied log, and a local tip would split L0 the same way.

## Test plan

- [x] `go test ./heightsync/ ./types/ ./state/ ./host/ ./user/ ./cmd/devshard-host/ ./cmd/devshardctl/`
- [x] H64 — floor round-trips in the snapshot; root and `HeightSyncFloorAsOf` still match
- [x] H102 — no blob + `GetDiffs` error → restore fails; apply is rejected; export is nil
- [x] A/B split — blob present + `GetDiffs` error → both replicas L0-reject heartbeat height 10 at nonce 4
- [x] Unfoldable blobs (out-of-order nonce/height, nil entry, repeated signer) return `ErrFloorBlobInvalid`
- [ ] Confirm a host restart with a current protobuf snapshot still applies the next heartbeat after restore
- [ ] Confirm a gateway restart from a JSON snapshot with `height_sync_floor` omitted still rebuilds from the journal
