### PR TITLE
chore(devshard): accept route v4 in ParseProtocolVersion

### DIFF
--- a/devshard/types/domain.go
+++ b/devshard/types/domain.go
@@ -81,6 +81,7 @@ const (
 	ProtocolV1 ProtocolVersion = "1"
 	ProtocolV2 ProtocolVersion = "2"
 	ProtocolV3 ProtocolVersion = "3"
+	ProtocolV4 ProtocolVersion = "4"
 )
 
 // ParseProtocolVersion parses a string into a ProtocolVersion.
@@ -93,6 +94,8 @@ func ParseProtocolVersion(s string) (ProtocolVersion, error) {
 		return ProtocolV2, nil
 	case string(ProtocolV3), "v3":
 		return ProtocolV3, nil
+	case string(ProtocolV4), "v4":
+		return ProtocolV4, nil
 	default:
 		return "", fmt.Errorf("unknown protocol version %q", s)
 	}

--- a/devshard/types/domain_test.go
+++ b/devshard/types/domain_test.go
@@ -45,6 +45,16 @@ func TestParseProtocolVersion_AcceptsRouteStyleV3(t *testing.T) {
 	}
 }
 
+func TestParseProtocolVersion_AcceptsRouteStyleV4(t *testing.T) {
+	got, err := ParseProtocolVersion("v4")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != ProtocolV4 {
+		t.Fatalf("expected v4 to normalize to %s, got %s", ProtocolV4, got)
+	}
+}
+
 func TestParseProtocolVersion_RejectsOldProtocol(t *testing.T) {
 	if _, err := ParseProtocolVersion("0.2.11"); err == nil {
 		t.Fatal("expected old protocol to be rejected")


### PR DESCRIPTION
Fixes #1542.

- Add ProtocolV4 constant in devshard/types/domain.go
- Accept "v4" in ParseProtocolVersion
- Add TestParseProtocolVersion_AcceptsRouteStyleV4

No behavior change for v1/v2/v3. Only removes noisy unparseable_protocol fallback when DEVSHARD_ROUTE_PREFIX=/devshard/v4.