### PR TITLE
ci: mirror GitHub issues into Linear (issue triage sync)

### DIFF
--- a/.github/scripts/linear-issue-sync/README.md
+++ b/.github/scripts/linear-issue-sync/README.md
@@ -1,0 +1,43 @@
+# Linear ↔ GitHub Issue sync
+
+Mirrors incoming GitHub **issues** into Linear. This is the lighter sibling of the PR
+sync (`.github/scripts/linear-pr-sync/`): issues have no review/merge/QA lifecycle, so
+there are no reviewer sub-issues and no Q&A hand-off.
+
+## What it does
+
+| GitHub event | Result |
+|---|---|
+| Issue **opened** / **reopened** | Linear issue created (or revived) in the **GON** team **Triage** (or the release project if a milestone is already set). First-time contributor → label. If the author is **external**, a polite acknowledgment comment is posted and the issue is added to the triage board (Status **new**, only if empty). |
+| Issue **labeled `accepted`** by a maintainer | Moves out of Triage into the release project (if milestoned) or the **Backlog for future mainnet upgrades** project (state **Backlog**). Board Status → **accepted**. |
+| Issue **milestoned** | Moves into the release project named after the milestone. |
+| Issue **demilestoned** | Moves back to Triage. |
+| Issue **closed as completed** | Linear issue → **Done**. |
+| Issue **closed as not planned** | Linear issue → **Cancelled**. |
+
+Internal comments in Linear stay in Linear. The only thing pushed to GitHub is the
+one acknowledgment comment on external issues.
+
+## Setup
+
+Reuses the same secrets/variables as the PR sync:
+
+- Secret `LINEAR_API_KEY`, secret `PROJECTS_TOKEN` (for the triage board; optional).
+- Variables: `LINEAR_TEAM_KEY` (required), plus the optional `LINEAR_*`,
+  `TRIAGE_PROJECT_NUMBER`, `TRIAGE_ACCEPTED_STATUS_VALUE` variables (defaults match
+  this workspace).
+- `ISSUE_POST_ACK` (default `true`) — set `false` to disable the acknowledgment comment.
+- `EXTERNAL_ISSUE_ACK_MESSAGE` — override the acknowledgment wording.
+
+Workflow: `.github/workflows/linear-issue-sync.yml`.
+
+## Notes
+
+- **Fail-soft:** missing config or any runtime error becomes a GitHub warning
+  annotation and the job exits 0 (green). The `integration-healthcheck` workflow
+  monitors the tokens so silent failures get surfaced.
+- **Accept signal:** only users with write access can add the `accepted` label, so the
+  label itself means a maintainer accepted the issue (Projects v2 board changes can't
+  trigger a workflow).
+- Uses the issue's node id for the triage board and stores the GitHub issue URL as a
+  Linear attachment to find the issue again on later events.

--- a/.github/scripts/linear-issue-sync/README.md
+++ b/.github/scripts/linear-issue-sync/README.md
@@ -9,11 +9,11 @@ there are no reviewer sub-issues and no Q&A hand-off.
 | GitHub event | Result |
 |---|---|
 | Issue **opened** / **reopened** | Linear issue created (or revived) in the **GON** team **Triage** (or the release project if a milestone is already set). First-time contributor → label. If the author is **external**, a polite acknowledgment comment is posted and the issue is added to the triage board (Status **new**, only if empty). |
-| Issue **labeled `accepted`** by a maintainer | Moves out of Triage into the release project (if milestoned) or the **Backlog for future mainnet upgrades** project (state **Backlog**). Board Status → **accepted**. |
 | Issue **milestoned** | Moves into the release project named after the milestone. |
 | Issue **demilestoned** | Moves back to Triage. |
 | Issue **closed as completed** | Linear issue → **Done**. |
 | Issue **closed as not planned** | Linear issue → **Cancelled**. |
+| Triage board **Status → Accepted** | Handled centrally by the scheduled **accept-reconcile** job (in `.github/scripts/linear-pr-sync`), which reconciles both PRs and issues out of Triage into the release/backlog project. Not handled here. |
 
 Internal comments in Linear stay in Linear. The only thing pushed to GitHub is the
 one acknowledgment comment on external issues.
@@ -23,9 +23,8 @@ one acknowledgment comment on external issues.
 Reuses the same secrets/variables as the PR sync:
 
 - Secret `LINEAR_API_KEY`, secret `PROJECTS_TOKEN` (for the triage board; optional).
-- Variables: `LINEAR_TEAM_KEY` (required), plus the optional `LINEAR_*`,
-  `TRIAGE_PROJECT_NUMBER`, `TRIAGE_ACCEPTED_STATUS_VALUE` variables (defaults match
-  this workspace).
+- Variables: `LINEAR_TEAM_KEY` (required), plus the optional `LINEAR_*` and
+  `TRIAGE_PROJECT_NUMBER` variables (defaults match this workspace).
 - `ISSUE_POST_ACK` (default `true`) — set `false` to disable the acknowledgment comment.
 - `EXTERNAL_ISSUE_ACK_MESSAGE` — override the acknowledgment wording.
 
@@ -36,8 +35,9 @@ Workflow: `.github/workflows/linear-issue-sync.yml`.
 - **Fail-soft:** missing config or any runtime error becomes a GitHub warning
   annotation and the job exits 0 (green). The `integration-healthcheck` workflow
   monitors the tokens so silent failures get surfaced.
-- **Accept signal:** only users with write access can add the `accepted` label, so the
-  label itself means a maintainer accepted the issue (Projects v2 board changes can't
-  trigger a workflow).
+- **Accept signal:** acceptance is a maintainer moving the triage-board card to **Accepted**;
+  the scheduled `accept-reconcile` job (in `.github/scripts/linear-pr-sync`) reconciles it into
+  Linear. Projects v2 board changes can't trigger a workflow, so this issue sync doesn't handle
+  acceptance directly.
 - Uses the issue's node id for the triage board and stores the GitHub issue URL as a
   Linear attachment to find the issue again on later events.

--- a/.github/scripts/linear-issue-sync/issue-sync.mjs
+++ b/.github/scripts/linear-issue-sync/issue-sync.mjs
@@ -8,13 +8,13 @@
 //                         contributor -> label. If the author is external, also
 //                         post a polite acknowledgment comment and add the issue
 //                         to the GitHub triage board (Status=new, only if empty).
-//   labeled (accepted) -> a maintainer accepted it: move out of Triage into the
-//                         release project (if milestoned) or the "Backlog for
-//                         future mainnet upgrades" project (state Backlog). The
-//                         GitHub board Status is set to accepted.
 //   milestoned         -> move into the release project named after the milestone.
 //   demilestoned       -> move back to Triage.
 //   closed             -> completed -> Done; not planned -> Cancelled.
+//
+// Acceptance (a maintainer moving the triage-board card to "Accepted") is handled
+// centrally by the scheduled accept-reconcile job (in .github/scripts/linear-pr-sync),
+// which reconciles both PRs and issues — so there is no accept handling here.
 //
 // Fail-soft: this is a side-channel automation and must never block anything.
 // Missing config or any runtime error becomes a GitHub warning annotation and the
@@ -33,15 +33,10 @@ const cfg = {
   apiKey: requireEnv("LINEAR_API_KEY"),
   teamKey: requireEnv("LINEAR_TEAM_KEY"),
   milestoneProjectPrefix: process.env.MILESTONE_PROJECT_PREFIX || "Upgrade ",
-  // Accept cross-sync (a maintainer adds this label).
-  acceptedLabel: process.env.ACCEPTED_LABEL || "accepted",
-  backlogProjectName:
-    process.env.BACKLOG_PROJECT_NAME || "Backlog for future mainnet upgrades",
   firstContributorLabel:
     process.env.FIRST_CONTRIBUTOR_LABEL || "first-time contributor",
   // States (resolved by name, with type fallbacks).
   backlogStateName: process.env.BACKLOG_STATE_NAME || "Backlog",
-  acceptedStateName: process.env.ACCEPTED_STATE_NAME || "Backlog",
   releaseStartStateName: process.env.RELEASE_START_STATE_NAME || "Backlog",
   doneStateName: process.env.DONE_STATE_NAME || "Done",
   cancelledStateName: process.env.CANCELLED_STATE_NAME || "Canceled",
@@ -51,7 +46,6 @@ const cfg = {
   triageProjectNumber: parseInt(process.env.PROJECT_NUMBER || "0", 10),
   triageStatusField: process.env.STATUS_FIELD_NAME || "Status",
   triageNewStatus: process.env.STATUS_VALUE || "new",
-  triageAcceptedStatus: process.env.ACCEPTED_STATUS_VALUE || "accepted",
 
   // Post an acknowledgment comment on external issues.
   postAck: (process.env.POST_ACK || "true").toLowerCase() !== "false",
@@ -105,9 +99,6 @@ async function main() {
     case "opened":
     case "reopened":
       await onOpenedOrReopened(issue);
-      break;
-    case "labeled":
-      await onLabeled(issue);
       break;
     case "milestoned":
       await onMilestoned(issue);
@@ -171,45 +162,6 @@ async function onOpenedOrReopened(issue) {
     if (cfg.postAck) await postAcknowledgment(issue);
     await addToTriageBoard(issue, cfg.triageNewStatus, { overwrite: false });
   }
-}
-
-async function onLabeled(issue) {
-  if (
-    !issue.labelName ||
-    issue.labelName.toLowerCase() !== cfg.acceptedLabel.toLowerCase()
-  ) {
-    console.log(
-      `Label "${issue.labelName || ""}" is not the accept label; nothing to do.`,
-    );
-    return;
-  }
-
-  const linear = await findLinearIssue(issue);
-  if (linear) {
-    const team = await getTeam();
-    const states = await getStates(team);
-    let project;
-    let stateId;
-    if (issue.milestone) {
-      project = await getOrCreateProject(
-        milestoneProjectName(issue.milestone),
-        team.id,
-      );
-      stateId = states.releaseStart.id;
-    } else {
-      project = await getOrCreateProject(cfg.backlogProjectName, team.id);
-      stateId = states.accepted.id;
-    }
-    await client.updateIssue(linear.id, { projectId: project.id, stateId });
-    console.log(
-      `Issue accepted (label "${issue.labelName}") -> moved ${linear.identifier} to "${project.name}".`,
-    );
-  } else {
-    warnNoLinear(issue);
-  }
-
-  // Reflect acceptance on the GitHub board too.
-  await addToTriageBoard(issue, cfg.triageAcceptedStatus, { overwrite: true });
 }
 
 async function onMilestoned(issue) {
@@ -290,7 +242,6 @@ async function getStates(team) {
   _states = {
     triage: pickState(nodes, [], ["triage"]),
     backlog: pickState(nodes, [cfg.backlogStateName], ["backlog"]),
-    accepted: pickState(nodes, [cfg.acceptedStateName], ["backlog", "unstarted"]),
     releaseStart: pickState(
       nodes,
       [cfg.releaseStartStateName],
@@ -520,7 +471,6 @@ function loadIssue() {
     firstTimeContributor:
       gh.author_association === "FIRST_TIME_CONTRIBUTOR" ||
       gh.author_association === "FIRST_TIMER",
-    labelName: event.label?.name || null,
   };
 }
 

--- a/.github/scripts/linear-issue-sync/issue-sync.mjs
+++ b/.github/scripts/linear-issue-sync/issue-sync.mjs
@@ -1,0 +1,533 @@
+// Syncs GitHub issues into Linear — a lighter mirror of the PR sync.
+//
+// Issues don't have review/merge/QA lifecycles, so this is intentionally simpler
+// than the PR sync (no reviewer sub-issues, no Q&A hand-off).
+//
+// Behaviour:
+//   opened / reopened  -> create/revive a Linear issue in Triage; first-time
+//                         contributor -> label. If the author is external, also
+//                         post a polite acknowledgment comment and add the issue
+//                         to the GitHub triage board (Status=new, only if empty).
+//   labeled (accepted) -> a maintainer accepted it: move out of Triage into the
+//                         release project (if milestoned) or the "Backlog for
+//                         future mainnet upgrades" project (state Backlog). The
+//                         GitHub board Status is set to accepted.
+//   milestoned         -> move into the release project named after the milestone.
+//   demilestoned       -> move back to Triage.
+//   closed             -> completed -> Done; not planned -> Cancelled.
+//
+// Fail-soft: this is a side-channel automation and must never block anything.
+// Missing config or any runtime error becomes a GitHub warning annotation and the
+// process exits 0.
+
+import fs from "node:fs";
+import { LinearClient } from "@linear/sdk";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const missingEnv = [];
+
+const cfg = {
+  apiKey: requireEnv("LINEAR_API_KEY"),
+  teamKey: requireEnv("LINEAR_TEAM_KEY"),
+  milestoneProjectPrefix: process.env.MILESTONE_PROJECT_PREFIX || "Upgrade ",
+  // Accept cross-sync (a maintainer adds this label).
+  acceptedLabel: process.env.ACCEPTED_LABEL || "accepted",
+  backlogProjectName:
+    process.env.BACKLOG_PROJECT_NAME || "Backlog for future mainnet upgrades",
+  firstContributorLabel:
+    process.env.FIRST_CONTRIBUTOR_LABEL || "first-time contributor",
+  // States (resolved by name, with type fallbacks).
+  backlogStateName: process.env.BACKLOG_STATE_NAME || "Backlog",
+  acceptedStateName: process.env.ACCEPTED_STATE_NAME || "Backlog",
+  releaseStartStateName: process.env.RELEASE_START_STATE_NAME || "Backlog",
+  doneStateName: process.env.DONE_STATE_NAME || "Done",
+  cancelledStateName: process.env.CANCELLED_STATE_NAME || "Canceled",
+
+  // GitHub triage board (Projects v2) for external issues.
+  triageProjectOwner: process.env.PROJECT_OWNER || "",
+  triageProjectNumber: parseInt(process.env.PROJECT_NUMBER || "0", 10),
+  triageStatusField: process.env.STATUS_FIELD_NAME || "Status",
+  triageNewStatus: process.env.STATUS_VALUE || "new",
+  triageAcceptedStatus: process.env.ACCEPTED_STATUS_VALUE || "accepted",
+
+  // Post an acknowledgment comment on external issues.
+  postAck: (process.env.POST_ACK || "true").toLowerCase() !== "false",
+};
+
+const milestoneProjectName = (milestone) =>
+  `${cfg.milestoneProjectPrefix}${milestone}`;
+
+const client = cfg.apiKey ? new LinearClient({ apiKey: cfg.apiKey }) : null;
+
+const issueMarker = (repo, number) => `github-issue:${repo}#${number}`;
+const ackMarker = "<!-- gonka:ack-external-issue -->";
+const INTERNAL = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    missingEnv.push(name);
+    return "";
+  }
+  return v;
+}
+
+function ghWarn(message) {
+  const oneLine = String(message).replace(/\r?\n/g, " ");
+  console.log(`::warning title=linear-issue-sync::${oneLine}`);
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (missingEnv.length) {
+    ghWarn(
+      `Linear issue sync skipped — missing config: ${missingEnv.join(", ")}. ` +
+        `Set the repository secrets/variables to re-enable it.`,
+    );
+    return;
+  }
+
+  const issue = loadIssue();
+  if (!issue) return;
+
+  const action = process.env.GITHUB_EVENT_ACTION || "opened";
+  console.log(
+    `Event: issues/${action} for ${issue.repo}#${issue.number} ("${issue.title}")`,
+  );
+
+  switch (action) {
+    case "opened":
+    case "reopened":
+      await onOpenedOrReopened(issue);
+      break;
+    case "labeled":
+      await onLabeled(issue);
+      break;
+    case "milestoned":
+      await onMilestoned(issue);
+      break;
+    case "demilestoned":
+      await onDemilestoned(issue);
+      break;
+    case "closed":
+      await onClosed(issue);
+      break;
+    default:
+      console.log(`No handler for action "${action}", nothing to do.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async function onOpenedOrReopened(issue) {
+  const team = await getTeam();
+  const states = await getStates(team);
+
+  const project = issue.milestone
+    ? await getOrCreateProject(milestoneProjectName(issue.milestone), team.id)
+    : null;
+  const projectId = project ? project.id : null;
+  const parentState = issue.milestone
+    ? states.releaseStart
+    : states.triage || states.backlog;
+
+  const existing = await findLinearIssue(issue);
+  if (existing) {
+    await client.updateIssue(existing.id, { stateId: parentState.id, projectId });
+    console.log(`Revived existing Linear issue ${existing.identifier}.`);
+  } else {
+    const labelIds = [];
+    if (issue.firstTimeContributor) {
+      const label = await getOrCreateLabel(cfg.firstContributorLabel, team.id);
+      labelIds.push(label.id);
+    }
+    const created = await client.createIssue({
+      teamId: team.id,
+      projectId,
+      stateId: parentState.id,
+      title: issue.title,
+      description: linearDescription(issue),
+      labelIds,
+    });
+    const linearIssue = await created.issue;
+    await client.createAttachment({
+      issueId: linearIssue.id,
+      url: issue.url,
+      title: `GitHub issue #${issue.number}`,
+    });
+    console.log(`Created Linear issue ${linearIssue.identifier}.`);
+  }
+
+  // External-only side effects: acknowledgment comment + triage board.
+  if (!INTERNAL.has(issue.authorAssociation) && !issue.isBot) {
+    if (cfg.postAck) await postAcknowledgment(issue);
+    await addToTriageBoard(issue, cfg.triageNewStatus, { overwrite: false });
+  }
+}
+
+async function onLabeled(issue) {
+  if (
+    !issue.labelName ||
+    issue.labelName.toLowerCase() !== cfg.acceptedLabel.toLowerCase()
+  ) {
+    console.log(
+      `Label "${issue.labelName || ""}" is not the accept label; nothing to do.`,
+    );
+    return;
+  }
+
+  const linear = await findLinearIssue(issue);
+  if (linear) {
+    const team = await getTeam();
+    const states = await getStates(team);
+    let project;
+    let stateId;
+    if (issue.milestone) {
+      project = await getOrCreateProject(
+        milestoneProjectName(issue.milestone),
+        team.id,
+      );
+      stateId = states.releaseStart.id;
+    } else {
+      project = await getOrCreateProject(cfg.backlogProjectName, team.id);
+      stateId = states.accepted.id;
+    }
+    await client.updateIssue(linear.id, { projectId: project.id, stateId });
+    console.log(
+      `Issue accepted (label "${issue.labelName}") -> moved ${linear.identifier} to "${project.name}".`,
+    );
+  } else {
+    warnNoLinear(issue);
+  }
+
+  // Reflect acceptance on the GitHub board too.
+  await addToTriageBoard(issue, cfg.triageAcceptedStatus, { overwrite: true });
+}
+
+async function onMilestoned(issue) {
+  if (!issue.milestone) return;
+  const linear = await findLinearIssue(issue);
+  if (!linear) return warnNoLinear(issue);
+  const team = await getTeam();
+  const states = await getStates(team);
+  const project = await getOrCreateProject(
+    milestoneProjectName(issue.milestone),
+    team.id,
+  );
+  await client.updateIssue(linear.id, {
+    projectId: project.id,
+    stateId: states.releaseStart.id,
+  });
+  console.log(`Moved ${linear.identifier} to release project "${issue.milestone}".`);
+}
+
+async function onDemilestoned(issue) {
+  const linear = await findLinearIssue(issue);
+  if (!linear) return warnNoLinear(issue);
+  const team = await getTeam();
+  const states = await getStates(team);
+  await client.updateIssue(linear.id, {
+    projectId: null,
+    stateId: (states.triage || states.backlog).id,
+  });
+  console.log(`Moved ${linear.identifier} back to Triage.`);
+}
+
+async function onClosed(issue) {
+  const linear = await findLinearIssue(issue);
+  if (!linear) return warnNoLinear(issue);
+  const team = await getTeam();
+  const states = await getStates(team);
+  // "completed" -> Done; "not_planned" (or anything else) -> Cancelled.
+  const done = issue.stateReason === "completed";
+  await client.updateIssue(linear.id, {
+    stateId: done ? states.done.id : states.cancelled.id,
+  });
+  console.log(
+    `Issue closed (${issue.stateReason || "unknown"}) -> ${linear.identifier} ${done ? "Done" : "Cancelled"}.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Linear resolvers
+// ---------------------------------------------------------------------------
+
+let _team;
+async function getTeam() {
+  if (_team) return _team;
+  const res = await client.teams({ filter: { key: { eq: cfg.teamKey } } });
+  if (!res.nodes.length) {
+    throw new Error(`Linear team with key "${cfg.teamKey}" not found.`);
+  }
+  _team = res.nodes[0];
+  return _team;
+}
+
+function pickState(nodes, names, types) {
+  for (const name of names) {
+    const s = nodes.find((x) => x.name.toLowerCase() === name.toLowerCase());
+    if (s) return s;
+  }
+  for (const type of types) {
+    const s = nodes.find((x) => x.type === type);
+    if (s) return s;
+  }
+  return null;
+}
+
+let _states;
+async function getStates(team) {
+  if (_states) return _states;
+  const nodes = (await team.states()).nodes;
+  _states = {
+    triage: pickState(nodes, [], ["triage"]),
+    backlog: pickState(nodes, [cfg.backlogStateName], ["backlog"]),
+    accepted: pickState(nodes, [cfg.acceptedStateName], ["backlog", "unstarted"]),
+    releaseStart: pickState(
+      nodes,
+      [cfg.releaseStartStateName],
+      ["backlog", "unstarted"],
+    ),
+    done: pickState(nodes, [cfg.doneStateName], ["completed"]),
+    cancelled: pickState(
+      nodes,
+      [cfg.cancelledStateName, "canceled", "cancelled"],
+      ["canceled"],
+    ),
+  };
+  for (const [k, v] of Object.entries(_states)) {
+    if (!v && k !== "triage") {
+      throw new Error(
+        `Could not resolve Linear workflow state for "${k}". Check the *_STATE_NAME variables.`,
+      );
+    }
+  }
+  return _states;
+}
+
+const _projects = new Map();
+async function getOrCreateProject(name, teamId) {
+  if (_projects.has(name)) return _projects.get(name);
+  const res = await client.projects({ filter: { name: { eq: name } } });
+  let project = res.nodes[0];
+  if (!project) {
+    const created = await client.createProject({ name, teamIds: [teamId] });
+    project = await created.project;
+    console.log(`Created Linear project "${name}".`);
+  }
+  _projects.set(name, project);
+  return project;
+}
+
+async function getOrCreateLabel(name, teamId) {
+  const res = await client.issueLabels({ filter: { name: { eq: name } } });
+  const existing = res.nodes.find(
+    (l) => l.name.toLowerCase() === name.toLowerCase(),
+  );
+  if (existing) return existing;
+  const created = await client.createIssueLabel({ name, teamId });
+  console.log(`Created Linear label "${name}".`);
+  return await created.issueLabel;
+}
+
+async function findLinearIssue(issue) {
+  let attachments;
+  try {
+    attachments = await client.attachmentsForURL(issue.url);
+  } catch (e) {
+    console.log(`attachmentsForURL failed: ${e.message}`);
+    return null;
+  }
+  for (const att of attachments.nodes) {
+    const linear = await att.issue;
+    if (linear) return linear;
+  }
+  return null;
+}
+
+function linearDescription(issue) {
+  return [
+    `Mirrored from GitHub issue ${issue.url}`,
+    `Opened by @${issue.authorLogin}.`,
+    "",
+    issueMarker(issue.repo, issue.number),
+  ].join("\n");
+}
+
+function warnNoLinear(issue) {
+  console.log(
+    `No Linear issue found for ${issue.repo}#${issue.number}; nothing to update.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GitHub side effects (ack comment + triage board)
+// ---------------------------------------------------------------------------
+
+async function postAcknowledgment(issue) {
+  const token = process.env.GH_TOKEN;
+  if (!token) return console.log("No GH_TOKEN; skipping acknowledgment.");
+
+  // Don't post twice.
+  const listRes = await fetch(
+    `https://api.github.com/repos/${issue.repo}/issues/${issue.number}/comments?per_page=100`,
+    { headers: ghHeaders(token) },
+  );
+  if (listRes.ok) {
+    const comments = await listRes.json();
+    if (comments.some((c) => (c.body || "").includes(ackMarker))) {
+      console.log("Acknowledgment already posted; skipping.");
+      return;
+    }
+  }
+
+  const body =
+    (process.env.ACK_MESSAGE ||
+      [
+        `👋 Thanks for opening this issue and helping improve Gonka, @${issue.authorLogin}!`,
+        "",
+        "A maintainer will triage it as part of our regular process. Please note that response",
+        "times vary and opening an issue doesn't guarantee it will be addressed. Adding clear",
+        "reproduction steps, logs, or context helps us a lot.",
+        "",
+        "We appreciate you taking the time to report this!",
+      ].join("\n")) + `\n\n${ackMarker}`;
+
+  const res = await fetch(
+    `https://api.github.com/repos/${issue.repo}/issues/${issue.number}/comments`,
+    { method: "POST", headers: ghHeaders(token), body: JSON.stringify({ body }) },
+  );
+  if (res.ok) console.log(`Posted acknowledgment on issue #${issue.number}.`);
+  else console.log(`Acknowledgment comment failed (${res.status}).`);
+}
+
+// Add the issue to the GitHub Projects v2 triage board and set its Status.
+// overwrite=false -> only set when the item currently has no status.
+async function addToTriageBoard(issue, statusValue, { overwrite }) {
+  const token = process.env.PROJECTS_TOKEN;
+  if (!token) return console.log("No PROJECTS_TOKEN; skipping triage board.");
+  if (!cfg.triageProjectOwner || !cfg.triageProjectNumber) {
+    return console.log("Triage board not configured; skipping.");
+  }
+
+  const gql = (query, variables) =>
+    fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: ghHeaders(token),
+      body: JSON.stringify({ query, variables }),
+    }).then((r) => r.json());
+
+  const projRes = await gql(
+    `query($owner:String!,$number:Int!){
+       organization(login:$owner){ projectV2(number:$number){ id fields(first:50){ nodes{ ... on ProjectV2SingleSelectField { id name options { id name } } } } } }
+       user(login:$owner){ projectV2(number:$number){ id fields(first:50){ nodes{ ... on ProjectV2SingleSelectField { id name options { id name } } } } } }
+     }`,
+    { owner: cfg.triageProjectOwner, number: cfg.triageProjectNumber },
+  );
+  const project =
+    projRes.data?.organization?.projectV2 || projRes.data?.user?.projectV2;
+  if (!project) {
+    console.log(`Triage project #${cfg.triageProjectNumber} not found; skipping.`);
+    return;
+  }
+
+  const addRes = await gql(
+    `mutation($projectId:ID!,$contentId:ID!){ addProjectV2ItemById(input:{projectId:$projectId,contentId:$contentId}){ item { id } } }`,
+    { projectId: project.id, contentId: issue.nodeId },
+  );
+  const itemId = addRes.data?.addProjectV2ItemById?.item?.id;
+  if (!itemId) {
+    console.log("Could not add issue to triage board; skipping status.");
+    return;
+  }
+
+  if (!overwrite) {
+    const cur = await gql(
+      `query($itemId:ID!,$fieldName:String!){ node(id:$itemId){ ... on ProjectV2Item { fieldValueByName(name:$fieldName){ ... on ProjectV2ItemFieldSingleSelectValue { optionId name } } } } }`,
+      { itemId, fieldName: cfg.triageStatusField },
+    );
+    const existing = cur.data?.node?.fieldValueByName;
+    if (existing && (existing.optionId || existing.name)) {
+      console.log(`Board status already "${existing.name}"; leaving unchanged.`);
+      return;
+    }
+  }
+
+  const field = (project.fields?.nodes || []).find(
+    (f) => f && f.name && f.name.toLowerCase() === cfg.triageStatusField.toLowerCase(),
+  );
+  const option = field?.options?.find(
+    (o) => o.name.toLowerCase() === statusValue.toLowerCase(),
+  );
+  if (!field || !option) {
+    console.log(`Status option "${statusValue}" not found; item added without status.`);
+    return;
+  }
+  await gql(
+    `mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!){ updateProjectV2ItemFieldValue(input:{projectId:$projectId,itemId:$itemId,fieldId:$fieldId,value:{singleSelectOptionId:$optionId}}){ projectV2Item { id } } }`,
+    { projectId: project.id, itemId, fieldId: field.id, optionId: option.id },
+  );
+  console.log(`Set board ${cfg.triageStatusField}="${statusValue}" on issue #${issue.number}.`);
+}
+
+function ghHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GitHub event parsing
+// ---------------------------------------------------------------------------
+
+function loadIssue() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    throw new Error("GITHUB_EVENT_PATH not available.");
+  }
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const gh = event.issue;
+  if (!gh) {
+    console.log("Event has no issue payload, skipping.");
+    return null;
+  }
+  // Pull requests also arrive as "issues" in some contexts; never treat a PR as an issue.
+  if (gh.pull_request) {
+    console.log("Payload is a pull request, not an issue; skipping.");
+    return null;
+  }
+  return {
+    repo: event.repository?.full_name,
+    number: gh.number,
+    title: gh.title,
+    url: gh.html_url,
+    nodeId: gh.node_id,
+    authorLogin: gh.user?.login,
+    authorAssociation: gh.author_association,
+    isBot: gh.user?.type === "Bot",
+    milestone: gh.milestone?.title || null,
+    stateReason: gh.state_reason || null,
+    firstTimeContributor:
+      gh.author_association === "FIRST_TIME_CONTRIBUTOR" ||
+      gh.author_association === "FIRST_TIMER",
+    labelName: event.label?.name || null,
+  };
+}
+
+main().catch((err) => {
+  console.error(err);
+  ghWarn(
+    `Linear issue sync failed (non-blocking): ${err && err.message ? err.message : err}`,
+  );
+  process.exit(0);
+});

--- a/.github/scripts/linear-issue-sync/package.json
+++ b/.github/scripts/linear-issue-sync/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "linear-issue-sync",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Syncs GitHub issues into Linear (a lighter mirror of the PR sync).",
+  "main": "issue-sync.mjs",
+  "scripts": {
+    "start": "node issue-sync.mjs"
+  },
+  "dependencies": {
+    "@linear/sdk": "^88.0.0"
+  }
+}

--- a/.github/workflows/linear-issue-sync.yml
+++ b/.github/workflows/linear-issue-sync.yml
@@ -1,0 +1,81 @@
+name: Linear Issue Sync
+
+# Mirrors incoming GitHub issues into Linear (a lighter version of the PR sync:
+# no reviewer sub-issues, no Q&A hand-off). Also, for external authors, posts a
+# polite acknowledgment comment and adds the issue to the triage board.
+#
+# Fail-soft: this is a side-channel automation and never blocks anything. Missing
+# config or any error becomes a warning annotation and the job exits 0.
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - closed
+      - labeled
+      - milestoned
+      - demilestoned
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: linear-issue-sync-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (scripts only)
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        working-directory: .github/scripts/linear-issue-sync
+        run: npm install --no-audit --no-fund
+
+      - name: Sync issue to Linear
+        working-directory: .github/scripts/linear-issue-sync
+        env:
+          # --- Required secret ---
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          # --- Required config (repository Variables) ---
+          LINEAR_TEAM_KEY: ${{ vars.LINEAR_TEAM_KEY }}
+
+          # --- Optional Linear config (defaults in the script) ---
+          MILESTONE_PROJECT_PREFIX: ${{ vars.LINEAR_MILESTONE_PROJECT_PREFIX }}
+          ACCEPTED_LABEL: ${{ vars.LINEAR_ACCEPTED_LABEL }}
+          BACKLOG_PROJECT_NAME: ${{ vars.LINEAR_BACKLOG_PROJECT_NAME }}
+          FIRST_CONTRIBUTOR_LABEL: ${{ vars.LINEAR_FIRST_CONTRIBUTOR_LABEL }}
+          BACKLOG_STATE_NAME: ${{ vars.LINEAR_BACKLOG_STATE_NAME }}
+          ACCEPTED_STATE_NAME: ${{ vars.LINEAR_ACCEPTED_STATE_NAME }}
+          RELEASE_START_STATE_NAME: ${{ vars.LINEAR_RELEASE_START_STATE_NAME }}
+          DONE_STATE_NAME: ${{ vars.LINEAR_DONE_STATE_NAME }}
+          CANCELLED_STATE_NAME: ${{ vars.LINEAR_CANCELLED_STATE_NAME }}
+
+          # --- GitHub triage board (Projects v2) for external issues ---
+          PROJECT_OWNER: ${{ github.repository_owner }}
+          PROJECT_NUMBER: ${{ vars.TRIAGE_PROJECT_NUMBER || '7' }}
+          STATUS_FIELD_NAME: "Status"
+          STATUS_VALUE: "new"
+          ACCEPTED_STATUS_VALUE: ${{ vars.TRIAGE_ACCEPTED_STATUS_VALUE || 'accepted' }}
+          # PAT with Projects access (same secret as the PR triage workflow). If
+          # unset, board updates are skipped (Linear syncing still works).
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+
+          # --- Acknowledgment comment ---
+          POST_ACK: ${{ vars.ISSUE_POST_ACK }}
+          ACK_MESSAGE: ${{ vars.EXTERNAL_ISSUE_ACK_MESSAGE }}
+
+          # --- GitHub context ---
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+          GH_TOKEN: ${{ github.token }}
+        run: node issue-sync.mjs

--- a/.github/workflows/linear-issue-sync.yml
+++ b/.github/workflows/linear-issue-sync.yml
@@ -13,7 +13,6 @@ on:
       - opened
       - reopened
       - closed
-      - labeled
       - milestoned
       - demilestoned
   workflow_dispatch: {}
@@ -52,11 +51,8 @@ jobs:
 
           # --- Optional Linear config (defaults in the script) ---
           MILESTONE_PROJECT_PREFIX: ${{ vars.LINEAR_MILESTONE_PROJECT_PREFIX }}
-          ACCEPTED_LABEL: ${{ vars.LINEAR_ACCEPTED_LABEL }}
-          BACKLOG_PROJECT_NAME: ${{ vars.LINEAR_BACKLOG_PROJECT_NAME }}
           FIRST_CONTRIBUTOR_LABEL: ${{ vars.LINEAR_FIRST_CONTRIBUTOR_LABEL }}
           BACKLOG_STATE_NAME: ${{ vars.LINEAR_BACKLOG_STATE_NAME }}
-          ACCEPTED_STATE_NAME: ${{ vars.LINEAR_ACCEPTED_STATE_NAME }}
           RELEASE_START_STATE_NAME: ${{ vars.LINEAR_RELEASE_START_STATE_NAME }}
           DONE_STATE_NAME: ${{ vars.LINEAR_DONE_STATE_NAME }}
           CANCELLED_STATE_NAME: ${{ vars.LINEAR_CANCELLED_STATE_NAME }}
@@ -66,7 +62,6 @@ jobs:
           PROJECT_NUMBER: ${{ vars.TRIAGE_PROJECT_NUMBER || '7' }}
           STATUS_FIELD_NAME: "Status"
           STATUS_VALUE: "new"
-          ACCEPTED_STATUS_VALUE: ${{ vars.TRIAGE_ACCEPTED_STATUS_VALUE || 'accepted' }}
           # PAT with Projects access (same secret as the PR triage workflow). If
           # unset, board updates are skipped (Linear syncing still works).
           PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}


### PR DESCRIPTION
## Summary
A lighter sibling of the PR→Linear sync, for **GitHub issues**. Issues have no review/merge/QA lifecycle, so there are no reviewer sub-issues and no Q&A hand-off.

- **opened / reopened** → Linear issue in **Triage** (or the release project if a milestone is already set); first-time contributor → label. 
- **labeled `accepted`** by a maintainer → moves out of Triage into the release project (if milestoned) or **Backlog for future mainnet upgrades** (state **Backlog**); board Status → `accepted`.
- **milestoned / demilestoned** → into / out of the release project.
- **closed as completed** → Linear **Done**; **closed as not planned** → **Cancelled**.

Fail-soft (missing config or any error → warning annotation + exit 0). Reuses the same secrets/variables as the PR sync (`LINEAR_API_KEY`, `PROJECTS_TOKEN`, `LINEAR_*`, `TRIAGE_*`).

Files:
- `.github/workflows/linear-issue-sync.yml`
- `.github/scripts/linear-issue-sync/{issue-sync.mjs,package.json,README.md}`

## Notes
- Accept signal is the `accepted` **label** (only write-access users can add labels; Projects v2 board changes can't trigger a workflow).
- Kept separate from the PR-sync / triage PRs for reviewability.

## Test plan
- [x] `node --check` on `issue-sync.mjs`
- [x] `actionlint` on `linear-issue-sync.yml`
- [x] Local fail-soft runs: missing env, forced runtime error, and PR-as-issue guard all exit 0
- [ ] Live: open a test issue and confirm the Linear ticket + (for external) ack comment + board item