### PR TITLE
fix(devshard): serve one completion whatever the broker asked for

### DIFF
--- a/common/completionapi/request.go
+++ b/common/completionapi/request.go
@@ -48,6 +48,9 @@ func ModifyRequestBodyWithLogprobsMode(requestBytes []byte, defaultSeed int32, l
 
 	requestMap["max_tokens"] = maxTokens
 	requestMap["max_completion_tokens"] = maxTokens
+	if _, asked := requestMap["n"]; asked {
+		requestMap["n"] = 1
+	}
 	requestMap["skip_special_tokens"] = false
 	requestMap["return_token_ids"] = true
 	if _, ok := requestMap["seed"]; !ok {

--- a/common/completionapi/request_test.go
+++ b/common/completionapi/request_test.go
@@ -426,3 +426,29 @@ func TestModifyRequestBodyWithLogprobsMode_TestermintInferenceRequestPromptHash(
 	require.NoError(t, err)
 	require.Equal(t, "a5d657a116456a31026dea733abf558bf97d6ea1051e32d2a95ee9e67e2464f6", utils.GenerateSHA256Hash(canonical))
 }
+
+// The executor does not trust the broker that sent the request. A reservation budgets one max_tokens
+// output and validation compares only the first choice, so n>1 is generation nobody checks and nobody
+// is charged for: the broker would buy one completion and be served several.
+func TestModifyRequestBodyForcesASingleCompletion(t *testing.T) {
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}],"n":5}`)
+
+	r, err := ModifyRequestBodyWithLogprobsMode(body, 7, "")
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(r.NewBody, &m))
+	require.Equal(t, float64(1), m["n"], "a broker asking for five completions must be served one")
+}
+
+// A request that never asked for several is left as it was, so the executed body keeps carrying only
+// what the caller actually sent.
+func TestModifyRequestBodyLeavesAnUnaskedCompletionCountAlone(t *testing.T) {
+	r, err := ModifyRequestBodyWithLogprobsMode([]byte(jsonBody), 7, "")
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(r.NewBody, &m))
+	_, present := m["n"]
+	require.False(t, present, "n was added to a request that never carried it")
+}


### PR DESCRIPTION
## Summary

- A broker can send `n > 1` and the executor will honour it: `n` is not validated, clamped or overridden anywhere in `common/completionapi`, so the request generates several completions while the reservation budgets a single `max_tokens` output.
- Validation only ever compares the first choice — `GetEnforcedStr` logs `More than one choice in a non-streamed inference response, defaulting to first one` and carries a standing `TODO` about it — so every extra completion is generation nobody checks.
- `ModifyRequestBodyWithLogprobsMode` now overrides `n` to `1`, beside the existing `max_tokens` / `logprobs` / `return_token_ids` forcing.
- The override applies **only when the caller actually sent `n`**, so a request that never carried it is byte-identical to before.

## Why

The gateway already forces `n → 1` on its own side, but the gateway is the broker: that guard only holds for a broker that chooses to apply it. The party being abused is the executor, which does the generation, and the executor does not trust its caller — it already rewrites `logprobs`, `top_logprobs` and `return_token_ids` on the committed payload for exactly that reason. `n` belongs in the same place and had simply been missed.

The cost is asymmetric in the broker's favour. The reservation is taken against one `max_tokens` output and the chain clamps actual cost to that reservation, so `n = 5` buys one completion and is served five. Four of those five are also unverifiable: `ExecuteValidation` replays the prompt and compares logits, and the comparison reads `choices[0]` and nothing else. The extra work is generated, reported in the executor's token counts, and never validated against anything.

The blast radius is `devshardd` and no wider. The modified body is derived on both sides — the executor runs it (`inference/execute.go`) and the validator replays it (`common/validation/validation.go`) — but `ExecuteValidation` has exactly one caller, `devshard/cmd/devshardd/inference/validator.go`; the mainnet inference path does not use it. Executor and validator are the same binary, so the two sides move together. A mixed-version window during rollout is safe as well: whichever side forces `n` first, the comparison has always looked only at `choices[0]`, and the replay follows the executor's enforced token path.

## Tests

- `TestModifyRequestBodyForcesASingleCompletion` — a body carrying `"n": 5` comes back with `n == 1`.
- `TestModifyRequestBodyLeavesAnUnaskedCompletionCountAlone` — a body that never carried `n` does not gain one, so the executed request keeps only what the caller sent.
- Both were checked by mutation: removing the override fails the first test on its own assertion.

`go test ./completionapi/... ./validation/...` and `go test ./cmd/devshardd/inference/...` are green.

## Test plan

- [x] `go build ./...` in `common` and `devshard`
- [x] `go test ./completionapi/... ./validation/...` — green
- [x] `go test ./cmd/devshardd/inference/...` — green
- [x] Mutation check: override removed → `TestModifyRequestBodyForcesASingleCompletion` fails
