### PR TITLE
fix(api): return clear message for malformed /v1/participants body

### DIFF
--- a/decentralized-api/internal/server/public/post_participant_handler.go
+++ b/decentralized-api/internal/server/public/post_participant_handler.go
@@ -15,7 +15,7 @@ func (s *Server) submitNewParticipantHandler(ctx echo.Context) error {
 
 	if err := ctx.Bind(&body); err != nil {
 		logging.Error("Failed to decode request body", types.Participants, "error", err)
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
 	}
 
 	logging.Debug("SubmitNewParticipantDto", types.Participants, "body", body)


### PR DESCRIPTION
Fixes #1545.

`POST /v1/participants` currently returns Echo's nested parse error (`unexpected EOF`) when the JSON body is malformed. This leaks parser internals to clients.

## Changes

- Return a fixed 400 message: `"Invalid request body"` instead of the raw bind error.

## Verification

- Manually verified with malformed JSON payloads against `POST /v1/participants`.
- Response is now a clean `400 Bad Request` with body `"Invalid request body"`.

No behavior change for valid requests.
