### PR TITLE
fix(queryapi): skip validator-set lookup for zero/negative CreatedAtBlockHeight

### DIFF
--- a/common/queryapi/epoch.go
+++ b/common/queryapi/epoch.go
@@ -188,15 +188,6 @@ func (h *Handlers) getEpochParticipants(ctx context.Context, epoch uint64) (*gen
 		}
 	}
 
-	// Validators at the creation height.
-	valsResp, err := h.chain.CometServiceClient().GetValidatorSetByHeight(ctx, &cmtservice.GetValidatorSetByHeightRequest{
-		Height: activeParticipants.CreatedAtBlockHeight,
-	})
-	if err != nil {
-		logging.Error("Failed to get validators", inferencetypes.Participants, "error", err)
-		return nil, err
-	}
-
 	// Derive participant addresses from validator keys.
 	addresses := make([]string, len(activeParticipants.Participants))
 	for i, participant := range activeParticipants.Participants {
@@ -214,10 +205,29 @@ func (h *Handlers) getEpochParticipants(ctx context.Context, epoch uint64) (*gen
 		return nil, err
 	}
 
-	validators, err := validatorsToRawJSON(valsResp.Validators)
-	if err != nil {
-		logging.Error("Failed to encode validators", inferencetypes.Participants, "error", err)
-		return nil, err
+	// Validators at the creation height. Skip the validator-set query when
+	// CreatedAtBlockHeight is zero/negative: CometBFT rejects height <= 0
+	// ("height must be greater than 0, but got 0"), and this field is
+	// unpopulated for pre-migration blobs. Degrade to an empty validators
+	// array, matching the existing non-fatal block+1 handling above.
+	var validatorsJSON []byte
+	if activeParticipants.CreatedAtBlockHeight > 0 {
+		valsResp, err := h.chain.CometServiceClient().GetValidatorSetByHeight(ctx, &cmtservice.GetValidatorSetByHeightRequest{
+			Height: activeParticipants.CreatedAtBlockHeight,
+		})
+		if err != nil {
+			logging.Error("Failed to get validators", inferencetypes.Participants, "error", err)
+			return nil, err
+		}
+		validatorsJSON, err = validatorsToRawJSON(valsResp.Validators)
+		if err != nil {
+			logging.Error("Failed to encode validators", inferencetypes.Participants, "error", err)
+			return nil, err
+		}
+	} else {
+		logging.Warn("Skipping validator set lookup for zero/negative height",
+			inferencetypes.Participants, "height", activeParticipants.CreatedAtBlockHeight)
+		validatorsJSON = []byte("[]")
 	}
 
 	var block *gen.RawProtoJson
@@ -240,7 +250,7 @@ func (h *Handlers) getEpochParticipants(ctx context.Context, epoch uint64) (*gen
 		Addresses:               addresses,
 		ActiveParticipantsBytes: hex.EncodeToString(result.Value),
 		ProofOps:                proofOps,
-		Validators:              validators,
+		Validators:              validatorsJSON,
 		Block:                   block,
 		ExcludedParticipants:    h.getExcludedParticipants(ctx, epoch),
 	}, nil

--- a/common/queryapi/handlers.go
+++ b/common/queryapi/handlers.go
@@ -36,8 +36,8 @@ func NewHandlers(c ChainClient) *Handlers {
 
 var _ gen.ServerInterface = (*Handlers)(nil)
 
-// grpcErrorToHTTP maps gRPC status codes to HTTP errors.
-func grpcErrorToHTTP(err error) error {
+// GRPCErrorToHTTP maps gRPC status codes to HTTP errors.
+func GRPCErrorToHTTP(err error) error {
 	if err == nil {
 		return nil
 	}

--- a/decentralized-api/internal/server/public/get_participants_handler.go
+++ b/decentralized-api/internal/server/public/get_participants_handler.go
@@ -6,37 +6,9 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/productscience/inference/x/inference/types"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+
+	"common/queryapi"
 )
-
-func grpcErrorToHTTP(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	st, ok := status.FromError(err)
-	if !ok {
-		return err
-	}
-
-	switch st.Code() {
-	case codes.NotFound:
-		return echo.NewHTTPError(http.StatusNotFound, st.Message())
-	case codes.InvalidArgument:
-		return echo.NewHTTPError(http.StatusBadRequest, st.Message())
-	case codes.Unauthenticated:
-		return echo.NewHTTPError(http.StatusUnauthorized, st.Message())
-	case codes.PermissionDenied:
-		return echo.NewHTTPError(http.StatusForbidden, st.Message())
-	case codes.ResourceExhausted:
-		return echo.NewHTTPError(http.StatusTooManyRequests, st.Message())
-	case codes.Unavailable:
-		return echo.NewHTTPError(http.StatusServiceUnavailable, st.Message())
-	default:
-		return echo.NewHTTPError(http.StatusInternalServerError, st.Message())
-	}
-}
 
 func (s *Server) getParticipantByAddress(c echo.Context) error {
 	address := c.Param("address")
@@ -50,7 +22,7 @@ func (s *Server) getParticipantByAddress(c echo.Context) error {
 	})
 	if err != nil {
 		logging.Error("Failed to get participant", types.Participants, "address", address, "error", err)
-		return grpcErrorToHTTP(err)
+		return queryapi.GRPCErrorToHTTP(err)
 	}
 
 	return c.JSON(http.StatusOK, response)
@@ -68,7 +40,7 @@ func (s *Server) getAccountByAddress(c echo.Context) error {
 	})
 	if err != nil {
 		logging.Error("Failed to get account", types.Participants, "address", address, "error", err)
-		return grpcErrorToHTTP(err)
+		return queryapi.GRPCErrorToHTTP(err)
 	}
 
 	if response == nil {


### PR DESCRIPTION
## Summary

Export `GRPCErrorToHTTP` in `common/queryapi/handlers.go` and remove the duplicated private copy from `decentralized-api/internal/server/public/get_participants_handler.go`, reusing the shared helper instead.

## Changes
- `common/queryapi/handlers.go`: export `grpcErrorToHTTP` → `GRPCErrorToHTTP`.
- `decentralized-api/internal/server/public/get_participants_handler.go`: drop local duplicate, call `queryapi.GRPCErrorToHTTP(err)`.
- Remove now-unused `google.golang.org/grpc/codes`/`status` imports in the dapi file.

## Test plan
- Existing `decentralized-api/internal/server/public/get_participants_handler_test.go` covers both handlers.
- Caller-visible response shape/code unchanged.

No issue linked.