### PR TITLE
fix(dapi): do not block the broker loop on RemoveNode

### DIFF
--- a/decentralized-api/broker/broker_test.go
+++ b/decentralized-api/broker/broker_test.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"context"
 	"decentralized-api/apiconfig"
 	"decentralized-api/chainphase"
 	"decentralized-api/mlnodeclient"
@@ -949,6 +950,82 @@ func TestNodeRemoval(t *testing.T) {
 	if <-availableNode != nil {
 		t.Fatalf("expected nil, got node")
 	}
+}
+
+func TestRemoveNodeDoesNotBlockStartPocCommand(t *testing.T) {
+	broker := NewTestBroker()
+	mockBridge := broker.chainBridge.(*MockBrokerChainBridge)
+	mockBridge.On("GetBlockHash", mock.Anything).Return("hash", nil).Maybe()
+	mockBridge.On("GetParams").Return(&types.QueryParamsResponse{Params: types.Params{}}, nil).Maybe()
+
+	hung := createTestNode("hung-node")
+	live := createTestNode("live-node")
+	hung.State.IntendedStatus = types.HardwareNodeStatus_INFERENCE
+	live.State.IntendedStatus = types.HardwareNodeStatus_INFERENCE
+
+	broker.mu.Lock()
+	broker.nodes["hung-node"] = hung
+	broker.nodes["live-node"] = live
+	broker.mu.Unlock()
+
+	hungWorker := NewNodeWorkerWithClient("hung-node", hung, mlnodeclient.NewMockClient(), broker)
+	broker.nodeWorkGroup.AddWorker("hung-node", hungWorker)
+
+	started := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.True(t, hungWorker.Submit(ctx, &TestCommand{
+		ExecuteFn: func(ctx context.Context, w *NodeWorker) NodeResult {
+			close(started)
+			<-ctx.Done()
+			return NodeResult{Succeeded: false, Error: ctx.Err().Error()}
+		},
+	}))
+	<-started
+
+	broker.phaseTracker.Update(
+		chainphase.BlockInfo{Height: 105, Hash: "hash-poc"},
+		&types.Epoch{Index: 1, PocStartBlockHeight: 100},
+		&types.EpochParams{
+			EpochLength:           100,
+			EpochMultiplier:       1,
+			PocStageDuration:      20,
+			PocExchangeDuration:   1,
+			PocValidationDelay:    2,
+			PocValidationDuration: 10,
+		},
+		true,
+		nil,
+	)
+	require.Equal(t, types.PoCGeneratePhase, broker.phaseTracker.GetCurrentEpochState().CurrentPhase)
+
+	removeResp := make(chan bool, 2)
+	start := time.Now()
+	queueMessage(t, broker, RemoveNode{NodeId: "hung-node", Response: removeResp})
+
+	select {
+	case removed := <-removeResp:
+		require.True(t, removed)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RemoveNode blocked the broker command loop while a worker HTTP call was in flight")
+	}
+	require.Less(t, time.Since(start), time.Second, "RemoveNode must return without waiting for worker HTTP")
+
+	startPoc := NewStartPocCommand()
+	queueMessage(t, broker, startPoc)
+	select {
+	case <-startPoc.Response:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartPocCommand did not execute; it was likely stuck behind RemoveNode")
+	}
+
+	require.Equal(t, types.HardwareNodeStatus_POC, live.State.IntendedStatus)
+	require.Equal(t, PocStatusGenerating, live.State.PocIntendedStatus)
+
+	broker.mu.RLock()
+	_, hungStillRegistered := broker.nodes["hung-node"]
+	broker.mu.RUnlock()
+	require.False(t, hungStillRegistered)
 }
 
 func TestModelMismatch(t *testing.T) {

--- a/decentralized-api/broker/node_admin_commands.go
+++ b/decentralized-api/broker/node_admin_commands.go
@@ -304,17 +304,32 @@ func (r RemoveNode) GetResponseChannelCapacity() int {
 }
 
 func (command RemoveNode) Execute(b *Broker) {
-	// Remove the worker first (it will wait for pending jobs)
-	b.nodeWorkGroup.RemoveWorker(command.NodeId)
+	// Unregister immediately and never wait on processCommands. Worker HTTP
+	// (inference/up, stop, PoC) can take up to the ML-node client timeout
+	// (15 minutes). Waiting here stalls StartPocCommand for every node.
+	var cancel func()
+	existed := false
 
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	if node, ok := b.nodes[command.NodeId]; ok {
+		existed = true
+		cancel = node.State.cancelInFlightTask
+		node.State.cancelInFlightTask = nil
+		node.State.ReconcileInfo = nil
+		delete(b.nodes, command.NodeId)
+	}
+	b.mu.Unlock()
 
-	if _, ok := b.nodes[command.NodeId]; !ok {
+	if cancel != nil {
+		cancel()
+	}
+
+	b.nodeWorkGroup.RemoveWorker(command.NodeId)
+
+	if !existed {
 		command.Response <- false
 		return
 	}
-	delete(b.nodes, command.NodeId)
 	if b.configManager != nil {
 		if err := b.configManager.DeleteAppliedDeploymentsForNode(context.Background(), command.NodeId); err != nil {
 			logging.Warn("Failed to delete applied deployments for removed node", types.Config,

--- a/decentralized-api/broker/node_worker.go
+++ b/decentralized-api/broker/node_worker.go
@@ -23,6 +23,9 @@ type NodeWorker struct {
 	broker            *Broker
 	commands          chan commandWithContext
 	shutdown          chan struct{}
+	shutdownOnce      sync.Once
+	mu                sync.Mutex
+	stopping          bool
 	wg                sync.WaitGroup
 	availableVersions map[string]bool
 	versionsMu        sync.Mutex
@@ -65,32 +68,58 @@ func (w *NodeWorker) run() {
 	for {
 		select {
 		case item := <-w.commands:
-			result := item.cmd.Execute(item.ctx, w)
-			result.DeploymentGeneration = item.generation
-
-			// Queue a command back to the broker to update the state
-			updateCmd := NewUpdateNodeResultCommand(w.nodeId, result)
-			if err := w.broker.QueueMessage(updateCmd); err != nil {
-				logging.Error("Failed to queue node result update command", types.Nodes,
-					"node_id", w.nodeId, "error", err)
-			}
-			// We don't wait for the response from updateCmd, the worker's job is done.
-			w.wg.Done()
-		case <-w.shutdown:
-			// Drain remaining commands before shutting down
-			close(w.commands)
-			for item := range w.commands {
-				result := item.cmd.Execute(item.ctx, w)
-				result.DeploymentGeneration = item.generation
-				updateCmd := NewUpdateNodeResultCommand(w.nodeId, result)
-				if err := w.broker.QueueMessage(updateCmd); err != nil {
-					logging.Error("Failed to queue node result update command during shutdown", types.Nodes,
-						"node_id", w.nodeId, "error", err)
-				}
+			if w.isStopping() {
+				// select can pick a queued command even after shutdown is signaled.
+				// Drop it instead of starting another ML-node HTTP call.
 				w.wg.Done()
+				dropped := 1 + w.dropQueuedCommands()
+				w.logDropped(dropped)
+				return
 			}
+			w.execute(item)
+		case <-w.shutdown:
+			dropped := w.dropQueuedCommands()
+			w.logDropped(dropped)
 			return
 		}
+	}
+}
+
+func (w *NodeWorker) execute(item commandWithContext) {
+	result := item.cmd.Execute(item.ctx, w)
+	result.DeploymentGeneration = item.generation
+
+	updateCmd := NewUpdateNodeResultCommand(w.nodeId, result)
+	if err := w.broker.QueueMessage(updateCmd); err != nil {
+		logging.Error("Failed to queue node result update command", types.Nodes,
+			"node_id", w.nodeId, "error", err)
+	}
+	w.wg.Done()
+}
+
+func (w *NodeWorker) isStopping() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.stopping
+}
+
+func (w *NodeWorker) dropQueuedCommands() int {
+	dropped := 0
+	for {
+		select {
+		case <-w.commands:
+			dropped++
+			w.wg.Done()
+		default:
+			return dropped
+		}
+	}
+}
+
+func (w *NodeWorker) logDropped(dropped int) {
+	if dropped > 0 {
+		logging.Info("Dropped queued worker commands on shutdown", types.Nodes,
+			"node_id", w.nodeId, "dropped", dropped)
 	}
 }
 
@@ -100,20 +129,30 @@ func (w *NodeWorker) Submit(ctx context.Context, cmd NodeWorkerCommand) bool {
 }
 
 func (w *NodeWorker) submit(ctx context.Context, cmd NodeWorkerCommand, generation uint64) bool {
-	w.wg.Add(1)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.stopping {
+		return false
+	}
 	select {
 	case w.commands <- commandWithContext{cmd: cmd, ctx: ctx, generation: generation}:
+		w.wg.Add(1)
 		return true
 	default:
-		w.wg.Done()
 		return false
 	}
 }
 
-// Shutdown gracefully stops the worker
+// Shutdown stops the worker. The in-flight command may still run until its
+// context is cancelled; queued commands are dropped. Safe to call twice.
 func (w *NodeWorker) Shutdown() {
-	close(w.shutdown)
-	w.wg.Wait() // Wait for all pending commands to complete
+	w.shutdownOnce.Do(func() {
+		w.mu.Lock()
+		w.stopping = true
+		w.mu.Unlock()
+		close(w.shutdown)
+	})
+	w.wg.Wait()
 }
 
 func (w *NodeWorker) RefreshClientImmediate(oldVersion, newVersion string) {
@@ -178,14 +217,18 @@ func (g *NodeWorkGroup) AddWorker(nodeId string, worker *NodeWorker) {
 	g.workers[nodeId] = worker
 }
 
-// RemoveWorker removes and shuts down a worker
+// RemoveWorker unregisters the worker immediately and shuts it down in the
+// background. Must not wait: callers run on the shared broker command loop.
 func (g *NodeWorkGroup) RemoveWorker(nodeId string) {
 	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	if worker, exists := g.workers[nodeId]; exists {
-		worker.Shutdown()
+	worker, exists := g.workers[nodeId]
+	if exists {
 		delete(g.workers, nodeId)
+	}
+	g.mu.Unlock()
+
+	if exists {
+		go worker.Shutdown()
 	}
 }
 

--- a/decentralized-api/broker/node_worker_test.go
+++ b/decentralized-api/broker/node_worker_test.go
@@ -172,35 +172,87 @@ func TestNodeWorker_QueueFull(t *testing.T) {
 	assert.Equal(t, 15, slowCmdFailed, "Should fail exactly 15 commands (beyond queue size)")
 }
 
-func TestNodeWorker_GracefulShutdown(t *testing.T) {
+func TestNodeWorker_ShutdownDropsQueuedCommands(t *testing.T) {
 	broker := NewTestBroker2(10)
 	node := createTestNode("test-node-1")
 	mockClient := mlnodeclient.NewMockClient()
 	worker := NewNodeWorkerWithClient("test-node-1", node, mockClient, broker)
 
-	// Submit commands that will execute during shutdown
-	var executedCount int32
-	for i := 0; i < 5; i++ {
+	started := make(chan struct{})
+	inFlight := &TestCommand{
+		ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+			close(started)
+			time.Sleep(30 * time.Millisecond)
+			return NodeResult{Succeeded: true}
+		},
+	}
+	require.True(t, worker.Submit(context.Background(), inFlight))
+	<-started
+
+	var queuedExecuted int32
+	for i := 0; i < 4; i++ {
 		cmd := &TestCommand{
 			ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
-				atomic.AddInt32(&executedCount, 1)
-				time.Sleep(10 * time.Millisecond)
+				atomic.AddInt32(&queuedExecuted, 1)
 				return NodeResult{Succeeded: true}
 			},
 		}
-		worker.Submit(context.Background(), cmd)
+		require.True(t, worker.Submit(context.Background(), cmd))
 	}
 
-	// Give first command time to start
-	time.Sleep(5 * time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		worker.Shutdown()
+		close(done)
+	}()
 
-	// Shutdown should wait for all commands
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown blocked on queued worker commands")
+	}
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&queuedExecuted),
+		"queued commands must be dropped, not executed, on shutdown")
+}
+
+func TestNodeWorker_SubmitRejectedAfterShutdown(t *testing.T) {
+	broker := NewTestBroker2(4)
+	node := createTestNode("test-node-1")
+	worker := NewNodeWorkerWithClient("test-node-1", node, mlnodeclient.NewMockClient(), broker)
+
 	worker.Shutdown()
 
-	assert.Equal(t, int32(5), atomic.LoadInt32(&executedCount),
-		"All queued commands should execute before shutdown completes")
+	accepted := worker.Submit(context.Background(), &TestCommand{
+		ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+			t.Error("command must not execute after shutdown")
+			return NodeResult{Succeeded: true}
+		},
+	})
+	assert.False(t, accepted, "Submit after shutdown must be rejected")
+}
 
-	assert.Len(t, broker.highPriorityCommands, 5, "Should have 5 results in broker channel")
+func TestNodeWorker_ShutdownDropsCommandWhenSelectPicksWork(t *testing.T) {
+	broker := NewTestBroker2(16)
+	node := createTestNode("test-node-1")
+	worker := NewNodeWorkerWithClient("test-node-1", node, mlnodeclient.NewMockClient(), broker)
+
+	var executed int32
+	for i := 0; i < 10; i++ {
+		cmd := &TestCommand{
+			ExecuteFn: func(ctx context.Context, worker *NodeWorker) NodeResult {
+				atomic.AddInt32(&executed, 1)
+				time.Sleep(20 * time.Millisecond)
+				return NodeResult{Succeeded: true}
+			},
+		}
+		require.True(t, worker.Submit(context.Background(), cmd))
+	}
+
+	worker.Shutdown()
+
+	assert.LessOrEqual(t, atomic.LoadInt32(&executed), int32(1),
+		"at most the in-flight command may run; queued work must be dropped after shutdown")
 }
 
 func TestNodeWorker_Cancellation(t *testing.T) {
@@ -622,6 +674,46 @@ func TestNodeWorkGroup_AddRemoveWorkers(t *testing.T) {
 
 	_, exists1 = group.GetWorker("node-1")
 	assert.False(t, exists1, "Worker 1 should not exist after removal")
+}
+
+func TestNodeWorkGroup_RemoveWorkerDoesNotBlockOnInFlightHTTP(t *testing.T) {
+	group := NewNodeWorkGroup()
+	broker := NewTestBroker2(4)
+
+	hung := createTestNode("hung")
+	other := createTestNode("other")
+	hungWorker := NewNodeWorkerWithClient("hung", hung, mlnodeclient.NewMockClient(), broker)
+	otherWorker := NewNodeWorkerWithClient("other", other, mlnodeclient.NewMockClient(), broker)
+	group.AddWorker("hung", hungWorker)
+	group.AddWorker("other", otherWorker)
+
+	started := make(chan struct{})
+	require.True(t, hungWorker.Submit(context.Background(), &TestCommand{
+		ExecuteFn: func(ctx context.Context, w *NodeWorker) NodeResult {
+			close(started)
+			time.Sleep(300 * time.Millisecond)
+			return NodeResult{Succeeded: true}
+		},
+	}))
+	<-started
+
+	removed := make(chan struct{})
+	go func() {
+		group.RemoveWorker("hung")
+		close(removed)
+	}()
+
+	select {
+	case <-removed:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("RemoveWorker blocked while a worker command was in flight")
+	}
+
+	_, hungExists := group.GetWorker("hung")
+	assert.False(t, hungExists)
+	gotOther, otherExists := group.GetWorker("other")
+	assert.True(t, otherExists)
+	assert.Equal(t, otherWorker, gotOther)
 }
 
 func TestNodeWorker_CheckClientVersionAlive(t *testing.T) {


### PR DESCRIPTION
## Summary
- `RemoveNode` no longer waits on worker HTTP on the shared `processCommands` loop (that wait can last the 15-minute ML-node client timeout and skip PoC generate for every node).
- Unregister immediately, cancel in-flight reconcile, shut the worker down in the background, and drop queued worker commands instead of executing a 15-minute backlog.
- Regression: `StartPocCommand` still runs while a removed node's worker is hung.
