### PR TITLE
Bound version replacements to one predecessor

### DIFF
--- a/devshard/docs/storage-design.md
+++ b/devshard/docs/storage-design.md
@@ -470,8 +470,18 @@ down after boot.
 - Each PostgreSQL-backed child uses its application pool plus two dedicated
   sessions: one for readiness and one for the advisory fence. Schema bootstrap
   transiently opens a separate pool. External PostgreSQL capacity planning must
-  include every simultaneously running child generation on both versiond
-  replicas.
+  include every simultaneously running child generation on every versiond
+  replica.
+- A version has at most one current generation and one draining predecessor
+  per versiond. When a further same-name replacement arrives while the
+  predecessor is still draining, versiond defers it and retries on the next
+  reconcile instead of starting a third generation; a replacement whose current
+  child changed between planning and start is re-planned. This bounds the
+  PostgreSQL connections a version can hold: for `N` current HA children,
+  `R` versiond replicas and pool limit `P`, size `max_connections` for at
+  least `2 * N * (P + 2) + R * 5` non-reserved connections (the doubled child
+  term is the draining predecessor; the per-replica term is versiond's
+  four-connection session-lookup pool plus one schema-initializer session).
 - Migration bootstrap and all pending application steps are serialized by a
   database-scoped advisory lock. Before starting children in an HA deployment,
   versiond runs `devshardd --initialize-postgres-schema` through a current

--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -454,7 +454,7 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 				version:        v,
 				overrideSrc:    overrideSrc,
 				binPath:        binPath,
-				blockedByDrain: !isRunning && isDraining,
+				blockedByDrain: isDraining,
 			})
 			continue
 		}
@@ -510,6 +510,10 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 		if snap.isRunning {
 			matches, metadata, diskBinaryHash, stateErr := installedVersionMatches(filepath.Dir(snap.child.binPath), snap.child.binPath, desiredHash)
 			if stateErr == nil && matches {
+				continue
+			}
+			if snap.isDraining {
+				slog.Info("version replacement deferred while previous child is draining", "version", snap.version.Name)
 				continue
 			}
 			logInstalledVersionMismatch(
@@ -568,11 +572,16 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 		m.downloading[a.version.Name] = struct{}{}
 		scheduledDownloads = append(scheduledDownloads, a)
 	}
+	scheduledSwaps := make([]versionAction, 0, len(toSwap))
 	for _, a := range toSwap {
 		if _, already := m.downloading[a.version.Name]; already {
 			continue
 		}
+		if current, running := m.processes[a.version.Name]; !running || current != a.child || m.versionStartBlockedLocked(a.version.Name) {
+			continue
+		}
 		m.downloading[a.version.Name] = struct{}{}
+		scheduledSwaps = append(scheduledSwaps, a)
 	}
 
 	var toStop []*child
@@ -586,7 +595,7 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 		}
 	}
 
-	changed := len(scheduledDownloads) > 0 || len(toSwap) > 0 || len(toStop) > 0 || started > 0
+	changed := len(scheduledDownloads) > 0 || len(scheduledSwaps) > 0 || len(toStop) > 0 || started > 0
 	if changed {
 		m.rebuildRoutes()
 	}
@@ -613,7 +622,7 @@ func (m *Manager) reconcile(ctx context.Context, desired []oracle.Version) (int,
 
 	// Download first, then overlap generations where their storage permits it;
 	// otherwise the stop/start path withdraws the old route before stopping it.
-	for _, a := range toSwap {
+	for _, a := range scheduledSwaps {
 		if err := m.downloadAndSwap(ctx, a.version, a.sha256, a.child); err != nil {
 			slog.Error("swap failed, keeping old version", "version", a.version.Name, "error", err)
 			actionErrs = append(actionErrs, fmt.Errorf("swap %s: %w", a.version.Name, err))
@@ -631,8 +640,9 @@ type versionAction struct {
 	child   *child // non-nil for swap actions
 }
 
-// versionStartBlockedLocked reports whether a retired generation with the same
-// version name still owns the version's data directory.
+// versionStartBlockedLocked reports whether a predecessor with the same version
+// name is still draining. Besides protecting the version's data directory, this
+// bounds each version to one current generation and one predecessor.
 func (m *Manager) versionStartBlockedLocked(name string) bool {
 	return len(m.draining[name]) > 0
 }
@@ -689,6 +699,11 @@ func (m *Manager) reconcileOverride(ctx context.Context, v oracle.Version, overr
 		if m.hostDraining {
 			m.mu.Unlock()
 			return ErrHostDraining
+		}
+		if m.versionStartBlockedLocked(v.Name) {
+			m.mu.Unlock()
+			slog.Info("override replacement deferred while previous child is draining", "version", v.Name)
+			return nil
 		}
 		proxyDrained, retired := m.retireChildForStopStartLocked(existing)
 		m.mu.Unlock()
@@ -924,8 +939,9 @@ func (m *Manager) downloadAndStart(ctx context.Context, v oracle.Version, sha st
 }
 
 // downloadAndSwap downloads the new binary. Shared-storage generations overlap:
-// the replacement starts on a fresh port before the route swap. Other storage
-// modes withdraw and drain the old route before a stop/start replacement.
+// the replacement starts on a fresh port before the route swap, with at most one
+// predecessor per version. Other storage modes withdraw and drain the old route
+// before a stop/start replacement.
 func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha string, old *child) error {
 	dlErr := m.downloadBinary(ctx, v, sha)
 	if dlErr != nil || ctx.Err() != nil {
@@ -944,6 +960,17 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 		delete(m.downloading, v.Name)
 		m.mu.Unlock()
 		return ErrHostDraining
+	}
+	if current, running := m.processes[v.Name]; !running || current != old {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		return fmt.Errorf("current child changed before replacement start")
+	}
+	if m.versionStartBlockedLocked(v.Name) {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		slog.Info("version replacement deferred while previous child is draining", "version", v.Name)
+		return nil
 	}
 	m.mu.Unlock()
 	preflight, err := preflightChildWithAdminProbeContext(
@@ -1008,6 +1035,17 @@ func (m *Manager) downloadAndSwap(ctx context.Context, v oracle.Version, sha str
 		delete(m.downloading, v.Name)
 		m.mu.Unlock()
 		return ErrHostDraining
+	}
+	if current, running := m.processes[v.Name]; !running || current != old {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		return fmt.Errorf("current child changed before replacement start")
+	}
+	if m.versionStartBlockedLocked(v.Name) {
+		delete(m.downloading, v.Name)
+		m.mu.Unlock()
+		slog.Info("version replacement deferred while previous child is draining", "version", v.Name)
+		return nil
 	}
 	newChild, startErr := m.newChild(ctx, v, sha, newBinPath, false)
 	if startErr != nil {

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -1660,6 +1660,66 @@ esac
 	}
 }
 
+func TestReconcile_RunningVersionWaitsForDrainingPredecessorBeforeNextSHA(t *testing.T) {
+	dir := t.TempDir()
+	zipData, archiveHash := zipBinary(t, "testapp", []byte("replacement binary"))
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write(zipData)
+	}))
+	defer srv.Close()
+
+	m := NewManager(config.Config{
+		BinDir:     filepath.Join(dir, "bin"),
+		DataDir:    filepath.Join(dir, "data"),
+		BinaryName: "testapp",
+		BasePort:   5000,
+	})
+	current := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: sha256Hex([]byte("current archive")),
+		binPath:       filepath.Join(dir, "missing-current-binary"),
+		port:          9001,
+		status:        statusRunning,
+		restart:       true,
+	}
+	predecessor := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: sha256Hex([]byte("predecessor archive")),
+		port:          9000,
+		status:        statusDraining,
+	}
+	m.processes["v1"] = current
+	m.draining["v1"] = []*child{predecessor}
+
+	err := m.Reconcile(context.Background(), []oracle.Version{{
+		Name:   "v1",
+		Binary: srv.URL,
+		SHA256: archiveHash,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("download requests while predecessor drains = %d, want 0", got)
+	}
+	m.mu.Lock()
+	gotCurrent := m.processes["v1"]
+	draining := len(m.draining["v1"])
+	_, downloading := m.downloading["v1"]
+	m.mu.Unlock()
+	if gotCurrent != current {
+		t.Fatal("running generation changed while its predecessor was draining")
+	}
+	if draining != 1 {
+		t.Fatalf("draining generations = %d, want 1", draining)
+	}
+	if downloading {
+		t.Fatal("replacement was scheduled while its predecessor was draining")
+	}
+}
+
 func TestDownloadAndStart_DoesNotOverlapDrainingChild(t *testing.T) {
 	dir := t.TempDir()
 	zipData, archiveHash := zipBinary(t, "testapp", []byte("test binary"))
@@ -2625,6 +2685,65 @@ esac
 	routes := m.RouteTable().Load().(proxy.RouteTable)
 	if routes["v1"].Address() != "localhost:9001" {
 		t.Fatalf("route = %q, want old child route", routes["v1"].Address())
+	}
+}
+
+func TestDownloadAndSwap_DrainingPredecessorDefersReplacementStart(t *testing.T) {
+	dir := t.TempDir()
+	zipData, archiveHash := zipBinary(t, "testapp", []byte("replacement binary"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(zipData)
+	}))
+	defer srv.Close()
+
+	m := NewManager(config.Config{
+		BinDir:     filepath.Join(dir, "bin"),
+		DataDir:    filepath.Join(dir, "data"),
+		BinaryName: "testapp",
+		BasePort:   6200,
+	})
+	current := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: sha256Hex([]byte("current archive")),
+		port:          9001,
+		status:        statusRunning,
+		restart:       true,
+	}
+	predecessor := &child{
+		version:       oracle.Version{Name: "v1"},
+		archiveSHA256: sha256Hex([]byte("predecessor archive")),
+		port:          9000,
+		status:        statusDraining,
+	}
+	m.processes["v1"] = current
+	m.draining["v1"] = []*child{predecessor}
+	m.downloading["v1"] = struct{}{}
+
+	err := m.downloadAndSwap(context.Background(), oracle.Version{
+		Name:   "v1",
+		Binary: srv.URL,
+		SHA256: archiveHash,
+	}, archiveHash, current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.mu.Lock()
+	gotCurrent := m.processes["v1"]
+	draining := len(m.draining["v1"])
+	children := len(m.children)
+	_, downloading := m.downloading["v1"]
+	m.mu.Unlock()
+	if gotCurrent != current {
+		t.Fatal("running generation changed while its predecessor was draining")
+	}
+	if draining != 1 {
+		t.Fatalf("draining generations = %d, want 1", draining)
+	}
+	if children != 0 {
+		t.Fatalf("replacement children started = %d, want 0", children)
+	}
+	if downloading {
+		t.Fatal("download marker was not cleared after replacement deferral")
 	}
 }
 


### PR DESCRIPTION
> Extracted from #1608, which is closed: the PostgreSQL preflight around this fix is not shipped, but the versiond change stands on its own.

## Summary

A same-name SHA change starts a replacement `devshardd` on a fresh port and lets the previous generation drain (blue/green, see `rolling-update.md`). Nothing stopped a second SHA change from starting a third generation while the first predecessor was still draining. Each generation holds its own PostgreSQL application pool plus readiness and fence sessions, so rapid consecutive catalog updates could stack draining generations and exhaust the shared server's connection budget for every version and every versiond replica at once.

## Change

- A version has at most one current generation and one draining predecessor. A further replacement is deferred with a log line and retried on the next reconcile.
- A running version with a draining predecessor blocks the next start too, not only a stopped one.
- Before starting a replacement, the manager re-checks under its lock that the current child is still the one the replacement was planned for; a child that changed in between is re-planned instead of started twice.
- `storage-design.md` documents the resulting bound and the `max_connections` sizing it allows: `2 * N * (P + 2) + R * 5` non-reserved connections for `N` current HA children, `R` versiond replicas and pool limit `P`.

## Validation

- `go test -race ./internal/process/` in `versioned`
- new tests: a running generation with a draining predecessor when another SHA arrives; a predecessor that appears between replacement planning and child start
