### PR TITLE
`devshard/v4` Restore host snapshot load on v4 session recovery

### DIFF
--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -111,7 +111,7 @@ func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error
 	e := buildServer(lifecycle)
 	var admin *echo.Echo
 	if cfg.AdminAddr != "" {
-		admin = buildAdminServer(lifecycle, manager.StorageReady, manager.RecoveryComplete)
+		admin = buildAdminServer(lifecycle, manager.StorageReady, manager.RecoveryProgressSnapshot)
 	}
 	manager.Register(e.Group(""))
 	chainRuntime.chainEvents.OnReady(lifecycle.SetReady)

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -111,7 +111,7 @@ func buildApp(ctx context.Context, cfg runtimeConfig) (_ *devshardApp, err error
 	e := buildServer(lifecycle)
 	var admin *echo.Echo
 	if cfg.AdminAddr != "" {
-		admin = buildAdminServer(lifecycle, manager.StorageReady)
+		admin = buildAdminServer(lifecycle, manager.StorageReady, manager.RecoveryComplete)
 	}
 	manager.Register(e.Group(""))
 	chainRuntime.chainEvents.OnReady(lifecycle.SetReady)
@@ -281,10 +281,13 @@ func buildHostManager(
 
 	startHostEventsWarm(ctx, cfg, chainBridge, mlClient, store, closers)
 
-	if err := manager.RecoverSessions(); err != nil {
-		slog.Warn("recover sessions failed", "error", err)
-	}
 	store.Start()
+
+	// Recovery used to run inline here, so a host with a large backlog kept the
+	// listener closed and answered 502 until every session was rebuilt. Run it
+	// in the background instead: /ready stays false until the backlog drains,
+	// and any session requested before its turn is recovered on demand.
+	closers.Add(manager.StartRecovery(ctx))
 
 	retryLoop := session.NewRetryLoop(store, validator, manager, phase, instanceAddr)
 	retryLoop.WithInterval(cfg.ValidationRetryInterval)

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -288,9 +288,9 @@ func buildHostManager(
 	// in the background instead: /ready stays false until the backlog drains,
 	// and any session requested before its turn is recovered on demand.
 	closers.Add(manager.StartRecovery(ctx))
-	// A validation-obs rebuild interrupted after its clear leaves the counters
-	// empty, and recovery will not retry once a snapshot exists.
-	closers.Add(manager.WaitObsRepairs)
+	// A validation-obs or sealed-index rebuild interrupted after its clear
+	// leaves those rows empty, and recovery will not retry once a snapshot exists.
+	closers.Add(manager.WaitRecoveryRepairs)
 
 	retryLoop := session.NewRetryLoop(store, validator, manager, phase, instanceAddr)
 	retryLoop.WithInterval(cfg.ValidationRetryInterval)

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -288,6 +288,9 @@ func buildHostManager(
 	// in the background instead: /ready stays false until the backlog drains,
 	// and any session requested before its turn is recovered on demand.
 	closers.Add(manager.StartRecovery(ctx))
+	// A validation-obs rebuild interrupted after its clear leaves the counters
+	// empty, and recovery will not retry once a snapshot exists.
+	closers.Add(manager.WaitObsRepairs)
 
 	retryLoop := session.NewRetryLoop(store, validator, manager, phase, instanceAddr)
 	retryLoop.WithInterval(cfg.ValidationRetryInterval)

--- a/devshard/cmd/devshardd/lifecycle_test.go
+++ b/devshard/cmd/devshardd/lifecycle_test.go
@@ -14,7 +14,7 @@ import (
 func TestLifecycleReadyAndDrainStatus(t *testing.T) {
 	lifecycle := newLifecycleState()
 	e := buildServer(lifecycle)
-	admin := buildAdminServer(lifecycle, func() bool { return true })
+	admin := buildAdminServer(lifecycle, func() bool { return true }, func() bool { return true })
 	e.GET("/work", func(c echo.Context) error {
 		time.Sleep(20 * time.Millisecond)
 		return c.String(http.StatusOK, "done")
@@ -62,7 +62,7 @@ func TestLifecycleDrainRejectsNewWork(t *testing.T) {
 	lifecycle := newLifecycleState()
 	lifecycle.SetReady(true)
 	e := buildServer(lifecycle)
-	admin := buildAdminServer(lifecycle, func() bool { return true })
+	admin := buildAdminServer(lifecycle, func() bool { return true }, func() bool { return true })
 	e.GET("/work", func(c echo.Context) error {
 		return c.String(http.StatusOK, "done")
 	})
@@ -95,7 +95,7 @@ func TestReadyReflectsStorageReadiness(t *testing.T) {
 	lifecycle := newLifecycleState()
 	lifecycle.SetReady(true)
 	storageReady := false
-	admin := buildAdminServer(lifecycle, func() bool { return storageReady })
+	admin := buildAdminServer(lifecycle, func() bool { return storageReady }, func() bool { return true })
 
 	rec := httptest.NewRecorder()
 	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
@@ -107,4 +107,26 @@ func TestReadyReflectsStorageReadiness(t *testing.T) {
 	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "\"storage_ready\":true")
+}
+
+// Session recovery runs in the background so the listener binds immediately;
+// /ready must stay 503 until the backlog drains so traffic is not routed to a
+// host that would recover every requested session on demand.
+func TestReadyReflectsSessionRecoveryProgress(t *testing.T) {
+	lifecycle := newLifecycleState()
+	lifecycle.SetReady(true)
+	recovered := false
+	admin := buildAdminServer(lifecycle, func() bool { return true }, func() bool { return recovered })
+
+	rec := httptest.NewRecorder()
+	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"chain-ready but session recovery still draining must report 503")
+	require.Contains(t, rec.Body.String(), "\"recovery_complete\":false")
+
+	recovered = true
+	rec = httptest.NewRecorder()
+	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "\"recovery_complete\":true")
 }

--- a/devshard/cmd/devshardd/lifecycle_test.go
+++ b/devshard/cmd/devshardd/lifecycle_test.go
@@ -9,12 +9,18 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
+
+	"devshard/cmd/devshardd/session"
 )
+
+func recoveryDone() session.RecoveryProgress {
+	return session.RecoveryProgress{Complete: true}
+}
 
 func TestLifecycleReadyAndDrainStatus(t *testing.T) {
 	lifecycle := newLifecycleState()
 	e := buildServer(lifecycle)
-	admin := buildAdminServer(lifecycle, func() bool { return true }, func() bool { return true })
+	admin := buildAdminServer(lifecycle, func() bool { return true }, recoveryDone)
 	e.GET("/work", func(c echo.Context) error {
 		time.Sleep(20 * time.Millisecond)
 		return c.String(http.StatusOK, "done")
@@ -62,7 +68,7 @@ func TestLifecycleDrainRejectsNewWork(t *testing.T) {
 	lifecycle := newLifecycleState()
 	lifecycle.SetReady(true)
 	e := buildServer(lifecycle)
-	admin := buildAdminServer(lifecycle, func() bool { return true }, func() bool { return true })
+	admin := buildAdminServer(lifecycle, func() bool { return true }, recoveryDone)
 	e.GET("/work", func(c echo.Context) error {
 		return c.String(http.StatusOK, "done")
 	})
@@ -95,7 +101,7 @@ func TestReadyReflectsStorageReadiness(t *testing.T) {
 	lifecycle := newLifecycleState()
 	lifecycle.SetReady(true)
 	storageReady := false
-	admin := buildAdminServer(lifecycle, func() bool { return storageReady }, func() bool { return true })
+	admin := buildAdminServer(lifecycle, func() bool { return storageReady }, recoveryDone)
 
 	rec := httptest.NewRecorder()
 	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
@@ -109,24 +115,38 @@ func TestReadyReflectsStorageReadiness(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "\"storage_ready\":true")
 }
 
-// Session recovery runs in the background so the listener binds immediately;
-// /ready must stay 503 until the backlog drains so traffic is not routed to a
-// host that would recover every requested session on demand.
+// Status 200 means the process can serve. recovery_complete in the body is the
+// warm signal a version cutover waits on; draining and unready storage still 503.
 func TestReadyReflectsSessionRecoveryProgress(t *testing.T) {
 	lifecycle := newLifecycleState()
 	lifecycle.SetReady(true)
-	recovered := false
-	admin := buildAdminServer(lifecycle, func() bool { return true }, func() bool { return recovered })
+	progress := session.RecoveryProgress{
+		Total: 10, Recovered: 3, Failed: 1, VersionSkipped: 2, Pending: 4,
+	}
+	admin := buildAdminServer(lifecycle, func() bool { return true }, func() session.RecoveryProgress {
+		return progress
+	})
 
 	rec := httptest.NewRecorder()
 	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
-	require.Equal(t, http.StatusServiceUnavailable, rec.Code,
-		"chain-ready but session recovery still draining must report 503")
-	require.Contains(t, rec.Body.String(), "\"recovery_complete\":false")
+	require.Equal(t, http.StatusOK, rec.Code,
+		"chain-ready process must serve while session recovery is still draining")
+	require.Contains(t, rec.Body.String(), `"recovery_complete":false`)
+	require.Contains(t, rec.Body.String(), `"sessions_total":10`)
+	require.Contains(t, rec.Body.String(), `"sessions_recovered":3`)
+	require.Contains(t, rec.Body.String(), `"sessions_failed":1`)
+	require.Contains(t, rec.Body.String(), `"sessions_version_skipped":2`)
+	require.Contains(t, rec.Body.String(), `"sessions_pending":4`)
 
-	recovered = true
+	progress = session.RecoveryProgress{Complete: true, Total: 10, Recovered: 7, Failed: 1, VersionSkipped: 2}
 	rec = httptest.NewRecorder()
 	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.Contains(t, rec.Body.String(), "\"recovery_complete\":true")
+	require.Contains(t, rec.Body.String(), `"recovery_complete":true`)
+	require.Contains(t, rec.Body.String(), `"sessions_pending":0`)
+
+	lifecycle.StartDrain()
+	rec = httptest.NewRecorder()
+	admin.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code, "draining must still report 503")
 }

--- a/devshard/cmd/devshardd/server.go
+++ b/devshard/cmd/devshardd/server.go
@@ -26,7 +26,7 @@ func buildServer(lifecycle *lifecycleState) *echo.Echo {
 	return e
 }
 
-func buildAdminServer(lifecycle *lifecycleState, storageReady func() bool) *echo.Echo {
+func buildAdminServer(lifecycle *lifecycleState, storageReady, recoveryComplete func() bool) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
@@ -35,10 +35,11 @@ func buildAdminServer(lifecycle *lifecycleState, storageReady func() bool) *echo
 	e.GET("/ready", func(c echo.Context) error {
 		status := lifecycle.Status()
 		storeReady := storageReady == nil || storageReady()
-		if !status.Ready || status.Draining || !storeReady {
-			return c.JSON(http.StatusServiceUnavailable, readyResponse(status, storeReady))
+		recovered := recoveryComplete == nil || recoveryComplete()
+		if !status.Ready || status.Draining || !storeReady || !recovered {
+			return c.JSON(http.StatusServiceUnavailable, readyResponse(status, storeReady, recovered))
 		}
-		return c.JSON(http.StatusOK, readyResponse(status, storeReady))
+		return c.JSON(http.StatusOK, readyResponse(status, storeReady, recovered))
 	})
 	e.POST("/drain", func(c echo.Context) error {
 		lifecycle.StartDrain()
@@ -51,12 +52,14 @@ func buildAdminServer(lifecycle *lifecycleState, storageReady func() bool) *echo
 	return e
 }
 
-// readyStatus augments drainStatus with storage readiness for the /ready probe.
+// readyStatus augments drainStatus with storage readiness and session recovery
+// progress for the /ready probe.
 type readyStatus struct {
 	drainStatus
-	StorageReady bool `json:"storage_ready"`
+	StorageReady     bool `json:"storage_ready"`
+	RecoveryComplete bool `json:"recovery_complete"`
 }
 
-func readyResponse(status drainStatus, storeReady bool) readyStatus {
-	return readyStatus{drainStatus: status, StorageReady: storeReady}
+func readyResponse(status drainStatus, storeReady, recovered bool) readyStatus {
+	return readyStatus{drainStatus: status, StorageReady: storeReady, RecoveryComplete: recovered}
 }

--- a/devshard/cmd/devshardd/server.go
+++ b/devshard/cmd/devshardd/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 
+	"devshard/cmd/devshardd/session"
 	"devshard/observability"
 )
 
@@ -26,20 +27,29 @@ func buildServer(lifecycle *lifecycleState) *echo.Echo {
 	return e
 }
 
-func buildAdminServer(lifecycle *lifecycleState, storageReady, recoveryComplete func() bool) *echo.Echo {
+func buildAdminServer(lifecycle *lifecycleState, storageReady func() bool, recovery func() session.RecoveryProgress) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
 	e.Use(middleware.Recover())
 
+	// The status code answers "can this process serve": chain up, storage open,
+	// not draining. Recovery is deliberately not part of it — a host with a long
+	// journal would otherwise be force-restarted by versiond's ready timeout
+	// before it ever serves, and escrows lazy-load on demand anyway. Whether the
+	// process is *warm* is the body's recovery_complete, which only a version
+	// cutover with a healthy old generation needs to wait on.
 	e.GET("/ready", func(c echo.Context) error {
 		status := lifecycle.Status()
 		storeReady := storageReady == nil || storageReady()
-		recovered := recoveryComplete == nil || recoveryComplete()
-		if !status.Ready || status.Draining || !storeReady || !recovered {
-			return c.JSON(http.StatusServiceUnavailable, readyResponse(status, storeReady, recovered))
+		progress := session.RecoveryProgress{Complete: true}
+		if recovery != nil {
+			progress = recovery()
 		}
-		return c.JSON(http.StatusOK, readyResponse(status, storeReady, recovered))
+		if !status.Ready || status.Draining || !storeReady {
+			return c.JSON(http.StatusServiceUnavailable, readyResponse(status, storeReady, progress))
+		}
+		return c.JSON(http.StatusOK, readyResponse(status, storeReady, progress))
 	})
 	e.POST("/drain", func(c echo.Context) error {
 		lifecycle.StartDrain()
@@ -53,13 +63,14 @@ func buildAdminServer(lifecycle *lifecycleState, storageReady, recoveryComplete 
 }
 
 // readyStatus augments drainStatus with storage readiness and session recovery
-// progress for the /ready probe.
+// progress for the /ready probe. The recovery counters are flattened into the
+// same object, so "drained with 3 failures" is distinguishable from clean.
 type readyStatus struct {
 	drainStatus
-	StorageReady     bool `json:"storage_ready"`
-	RecoveryComplete bool `json:"recovery_complete"`
+	StorageReady bool `json:"storage_ready"`
+	session.RecoveryProgress
 }
 
-func readyResponse(status drainStatus, storeReady, recovered bool) readyStatus {
-	return readyStatus{drainStatus: status, StorageReady: storeReady, RecoveryComplete: recovered}
+func readyResponse(status drainStatus, storeReady bool, progress session.RecoveryProgress) readyStatus {
+	return readyStatus{drainStatus: status, StorageReady: storeReady, RecoveryProgress: progress}
 }

--- a/devshard/cmd/devshardd/session/bind_obs_test.go
+++ b/devshard/cmd/devshardd/session/bind_obs_test.go
@@ -42,7 +42,7 @@ func setupBindTestManager(t *testing.T, escrowID string) (*HostManager, *storage
 			TokenPrice:     1,
 		},
 	}
-	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	return mgr, store, user, hosts[0]
 }
 
@@ -162,7 +162,7 @@ func TestOwnerChat_FirstBindSingleGetEscrow(t *testing.T) {
 		},
 	}
 	br := &countingGetEscrowBridge{MainnetBridge: inner}
-	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 
 	e := echo.New()
 	mgr.Register(e.Group(""))
@@ -222,7 +222,7 @@ func TestGetOrCreate_RecoversBeforeCreate(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 
 	srv, err := mgr.getOrCreate("1", nil)
 	require.NoError(t, err)

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -815,7 +815,18 @@ func (m *HostManager) recoverStoredSession(escrowID string) (_ *transport.Server
 			obsRepair = &obsRepairJob{
 				records: records,
 				sealed:  storage.SealedInferenceIDsSorted(sm.ExportSealedNonces()),
+				sm:      sm,
 			}
+		} else {
+			fillStarted := time.Now()
+			inserted, fillErr := sm.FillSealedInferenceIndexGaps()
+			if fillErr != nil {
+				return nil, nil, fmt.Errorf("fill sealed inference index: %w", fillErr)
+			}
+			logging.Info("filled sealed inference index gaps", inferenceTypes.System,
+				"escrow_id", escrowID, "inserted", inserted,
+				"sealed_ids", len(sm.ExportSealedNonces()),
+				"duration", time.Since(fillStarted))
 		}
 
 		if replayFrom == 1 || uint64(len(records)) >= host.SnapshotInterval {
@@ -824,10 +835,6 @@ func (m *HostManager) recoverStoredSession(escrowID string) (_ *transport.Server
 					"escrow_id", escrowID, "nonce", meta.LatestNonce, "error", saveErr)
 			}
 		}
-	}
-
-	if err := sm.RebuildSealedInferenceIndex(); err != nil {
-		return nil, nil, fmt.Errorf("rebuild sealed inference index: %w", err)
 	}
 
 	h, err := host.NewHost(sm, m.signer, m.engine, escrowID, meta.Group, nil, m.hostOpts(meta.EpochID)...)
@@ -1179,13 +1186,14 @@ func verifySnapshotRoot(store storage.Storage, sm *state.StateMachine, escrowID 
 type obsRepairJob struct {
 	records []types.DiffRecord
 	sealed  []uint64
+	sm      *state.StateMachine
 }
 
-// startObsRepair rebuilds validation obs for a freshly published session in the
-// background. The gate queues the session's obs writes for the duration, so the
-// rebuild gets the exclusive access it needs without holding up the apply path.
-// Failures leave the counters stale, which is why nothing outside the stats API
-// may depend on them.
+// startObsRepair rebuilds validation obs and the sealed-inference index for a
+// freshly published full-replay session in the background. The gate queues the
+// session's obs writes for the duration, so the rebuild gets exclusive access
+// without holding up the apply path. Failures leave the counters stale, which
+// is why nothing outside the stats API may depend on them.
 func (m *HostManager) startObsRepair(escrowID string, job *obsRepairJob) {
 	if job == nil || m.obsGate == nil {
 		return
@@ -1195,7 +1203,13 @@ func (m *HostManager) startObsRepair(escrowID string, job *obsRepairJob) {
 		defer m.obsRepairWG.Done()
 		startedAt := time.Now()
 		err := m.obsGate.RepairValidationObs(escrowID, func(inner storage.Storage) error {
-			return storage.RebuildValidationObsFromDiffs(inner, escrowID, job.records, job.sealed)
+			if err := storage.RebuildValidationObsFromDiffs(inner, escrowID, job.records, job.sealed); err != nil {
+				return err
+			}
+			if job.sm == nil {
+				return nil
+			}
+			return job.sm.RebuildSealedInferenceIndexFromDiffs(inner, job.records)
 		})
 		if err != nil {
 			logging.Warn("background validation obs rebuild failed", inferenceTypes.System,
@@ -1208,10 +1222,11 @@ func (m *HostManager) startObsRepair(escrowID string, job *obsRepairJob) {
 	}()
 }
 
-// WaitObsRepairs blocks until background obs rebuilds finish. Shutdown must
-// call it: a rebuild interrupted after its clear leaves the counters empty, and
-// recovery will not retry once a snapshot exists.
-func (m *HostManager) WaitObsRepairs() {
+// WaitRecoveryRepairs blocks until background recovery rebuilds finish
+// (validation obs and the sealed-inference index). Shutdown must call it: a
+// rebuild interrupted after its clear leaves those rows empty, and recovery
+// will not retry once a snapshot exists.
+func (m *HostManager) WaitRecoveryRepairs() {
 	m.obsRepairWG.Wait()
 }
 

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -61,6 +61,11 @@ type HostManager struct {
 	recoveryGate     recoveryGate
 	recoveryComplete atomic.Bool
 
+	// obsGate is the same value as store, kept typed so obs rebuilds can run
+	// against the wrapped store while the live writes queue.
+	obsGate     *storage.ObsRepairGate
+	obsRepairWG sync.WaitGroup
+
 	statsMu            sync.Mutex
 	statsShardsCache   *statsShardsResponse
 	statsShardsCached  time.Time
@@ -219,10 +224,14 @@ func NewHostManager(
 	ps PayloadStore,
 	recorder PayloadAuthClient,
 ) *HostManager {
+	// Everything downstream (hosts, state machines, transport) writes through
+	// the gate, which is a pass-through until a rebuild claims an escrow.
+	gate := storage.NewObsRepairGate(store)
 	return &HostManager{
 		sessions:           make(map[string]*transport.Server),
 		resolutionFailures: make(map[string]resolutionFailure),
-		store:              store,
+		store:              gate,
+		obsGate:            gate,
 		signer:             signer,
 		verifier:           signing.NewSecp256k1Verifier(),
 		engine:             engine,
@@ -387,13 +396,15 @@ func (m *HostManager) getOrCreate(escrowID string, escrow *bridge.EscrowInfo) (*
 		}
 
 		// Prefer recovering an already-bound session over CreateSession.
-		srv, err := func() (*transport.Server, error) {
+		srv, obsRepair, err := func() (*transport.Server, *obsRepairJob, error) {
 			m.recoveryGate.begin(escrowID)
 			defer m.recoveryGate.end()
 			return m.recoverStoredSession(escrowID)
 		}()
 		if err == nil {
-			return m.storeSessionIfAbsent(escrowID, srv), nil
+			published := m.storeSessionIfAbsent(escrowID, srv)
+			m.startObsRepair(escrowID, obsRepair)
+			return published, nil
 		}
 		if !errors.Is(err, storage.ErrSessionNotFound) {
 			return nil, err
@@ -687,11 +698,13 @@ func (m *HostManager) recoverAndStoreSession(escrowID string) (*transport.Server
 		if srv, ok := m.existingServer(escrowID); ok {
 			return srv, nil
 		}
-		srv, err := m.recoverStoredSession(escrowID)
+		srv, obsRepair, err := m.recoverStoredSession(escrowID)
 		if err != nil {
 			return nil, err
 		}
-		return m.storeSessionIfAbsent(escrowID, srv), nil
+		published := m.storeSessionIfAbsent(escrowID, srv)
+		m.startObsRepair(escrowID, obsRepair)
+		return published, nil
 	})
 	if err != nil {
 		return nil, err
@@ -702,16 +715,19 @@ func (m *HostManager) recoverAndStoreSession(escrowID string) (*transport.Server
 // recoverStoredSession rebuilds a single session from storage. A host snapshot
 // at nonce N skips replaying diffs 1..N; only N+1..latest are applied. Decode
 // or load failures fall back to a full journal replay (v3 HostManager behavior).
-func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, error) {
+//
+// A non-nil obsRepairJob means the caller should hand it to startObsRepair once
+// the session is published.
+func (m *HostManager) recoverStoredSession(escrowID string) (_ *transport.Server, obsRepair *obsRepairJob, err error) {
 	meta, err := m.store.GetSessionMeta(escrowID)
 	if err != nil {
-		return nil, fmt.Errorf("get session meta: %w", err)
+		return nil, nil, fmt.Errorf("get session meta: %w", err)
 	}
 	if meta.Status != "active" {
-		return nil, fmt.Errorf("%w: escrow %s status %q", storage.ErrSessionNotActive, escrowID, meta.Status)
+		return nil, nil, fmt.Errorf("%w: escrow %s status %q", storage.ErrSessionNotActive, escrowID, meta.Status)
 	}
 	if meta.Version != "" && meta.Version != m.boundVersion {
-		return nil, fmt.Errorf("%w: stored %s, host %s", storage.ErrSessionVersionConflict, meta.Version, m.boundVersion)
+		return nil, nil, fmt.Errorf("%w: stored %s, host %s", storage.ErrSessionVersionConflict, meta.Version, m.boundVersion)
 	}
 	recoveredVersion := meta.Version
 	if recoveredVersion == "" {
@@ -727,7 +743,7 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 	}
 	sm, err := newStateMachine()
 	if err != nil {
-		return nil, fmt.Errorf("create state machine: %w", err)
+		return nil, nil, fmt.Errorf("create state machine: %w", err)
 	}
 
 	replayFrom := uint64(1)
@@ -748,7 +764,7 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 					logging.Error("devshard snapshot failed root check, replaying full history", inferenceTypes.System,
 						"escrow_id", escrowID, "snapshot_nonce", snapNonce, "error", verifyErr)
 					if sm, err = newStateMachine(); err != nil {
-						return nil, fmt.Errorf("recreate state machine after snapshot reject: %w", err)
+						return nil, nil, fmt.Errorf("recreate state machine after snapshot reject: %w", err)
 					}
 				} else {
 					replayFrom = snapNonce + 1
@@ -765,17 +781,17 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 		if replayFrom <= meta.LatestNonce {
 			records, err = m.store.GetDiffs(escrowID, replayFrom, meta.LatestNonce)
 			if err != nil {
-				return nil, fmt.Errorf("get diffs: %w", err)
+				return nil, nil, fmt.Errorf("get diffs: %w", err)
 			}
 			for _, rec := range records {
 				sm.InjectWarmKeys(rec.WarmKeyDelta)
 				root, applyErr := sm.ApplyLocal(rec.Nonce, rec.Txs)
 				if applyErr != nil {
-					return nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
+					return nil, nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
 				}
 				if len(rec.StateHash) > 0 && len(root) > 0 {
 					if !bytes.Equal(root, rec.StateHash) {
-						return nil, fmt.Errorf("state root mismatch at nonce %d", rec.Nonce)
+						return nil, nil, fmt.Errorf("state root mismatch at nonce %d", rec.Nonce)
 					}
 				}
 			}
@@ -783,20 +799,22 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 
 		// Validation obs is written by the live apply path and is durable, so a
 		// restart already has the rows for every nonce a snapshot covers.
-		// Rebuild only when replaying the whole journal, where ApplyLocal
+		// Only a full journal replay needs a rebuild, because ApplyLocal
 		// records no obs and the clear-then-replay is the self-heal for
 		// batches the live path dropped under backpressure. Re-recording a
-		// range incrementally is not an option: the drain removes the live row
-		// that RecordValidationsAppliedOnce dedups against, so a tail replayed
+		// partial range is not an option: the drain removes the live row that
+		// RecordValidationsAppliedOnce dedups against, so a tail replayed
 		// twice would double count.
+		//
+		// Hand it to the gate instead of running it here: it is the expensive
+		// half of recovery (a write transaction per historical seal) and it
+		// would otherwise keep the caller of a cold bind waiting. Reuse the
+		// journal already in hand, whose last nonce the seal set matches;
+		// seals landing later reach the rebuild through the gate queue.
 		if replayFrom == 1 {
-			if err := storage.RebuildValidationObsFromDiffs(
-				m.store,
-				escrowID,
-				records,
-				storage.SealedInferenceIDsSorted(sm.ExportSealedNonces()),
-			); err != nil {
-				return nil, fmt.Errorf("rebuild validation obs: %w", err)
+			obsRepair = &obsRepairJob{
+				records: records,
+				sealed:  storage.SealedInferenceIDsSorted(sm.ExportSealedNonces()),
 			}
 		}
 
@@ -809,12 +827,12 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 	}
 
 	if err := sm.RebuildSealedInferenceIndex(); err != nil {
-		return nil, fmt.Errorf("rebuild sealed inference index: %w", err)
+		return nil, nil, fmt.Errorf("rebuild sealed inference index: %w", err)
 	}
 
 	h, err := host.NewHost(sm, m.signer, m.engine, escrowID, meta.Group, nil, m.hostOpts(meta.EpochID)...)
 	if err != nil {
-		return nil, fmt.Errorf("create host: %w", err)
+		return nil, nil, fmt.Errorf("create host: %w", err)
 	}
 
 	srv, err := transport.NewServer(h, m.store, m.verifier, meta.CreatorAddr,
@@ -823,10 +841,10 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 	)
 	if err != nil {
 		h.Close()
-		return nil, fmt.Errorf("create server: %w", err)
+		return nil, nil, fmt.Errorf("create server: %w", err)
 	}
 
-	return srv, nil
+	return srv, obsRepair, nil
 }
 
 // Register mounts devshard session routes on the given echo group.
@@ -1152,6 +1170,49 @@ func verifySnapshotRoot(store storage.Storage, sm *state.StateMachine, escrowID 
 		return fmt.Errorf("restored root %x does not match journal root %x at nonce %d", got, want, snapNonce)
 	}
 	return nil
+}
+
+// obsRepairJob carries the inputs for a deferred validation-obs rebuild: the
+// journal the recovery already read, and the seal set as of that journal's last
+// nonce. Anything the live path writes while the rebuild runs is queued by the
+// gate and applied after it, so the two never overlap.
+type obsRepairJob struct {
+	records []types.DiffRecord
+	sealed  []uint64
+}
+
+// startObsRepair rebuilds validation obs for a freshly published session in the
+// background. The gate queues the session's obs writes for the duration, so the
+// rebuild gets the exclusive access it needs without holding up the apply path.
+// Failures leave the counters stale, which is why nothing outside the stats API
+// may depend on them.
+func (m *HostManager) startObsRepair(escrowID string, job *obsRepairJob) {
+	if job == nil || m.obsGate == nil {
+		return
+	}
+	m.obsRepairWG.Add(1)
+	go func() {
+		defer m.obsRepairWG.Done()
+		startedAt := time.Now()
+		err := m.obsGate.RepairValidationObs(escrowID, func(inner storage.Storage) error {
+			return storage.RebuildValidationObsFromDiffs(inner, escrowID, job.records, job.sealed)
+		})
+		if err != nil {
+			logging.Warn("background validation obs rebuild failed", inferenceTypes.System,
+				"escrow_id", escrowID, "duration", time.Since(startedAt), "error", err)
+			return
+		}
+		logging.Info("rebuilt validation obs", inferenceTypes.System,
+			"escrow_id", escrowID, "diffs", len(job.records),
+			"sealed_inferences", len(job.sealed), "duration", time.Since(startedAt))
+	}()
+}
+
+// WaitObsRepairs blocks until background obs rebuilds finish. Shutdown must
+// call it: a rebuild interrupted after its clear leaves the counters empty, and
+// recovery will not retry once a snapshot exists.
+func (m *HostManager) WaitObsRepairs() {
+	m.obsRepairWG.Wait()
 }
 
 func saveHostSnapshot(store storage.Storage, sm *state.StateMachine, escrowID string, nonce uint64) error {

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -825,7 +825,7 @@ func (m *HostManager) recoverStoredSession(escrowID string) (_ *transport.Server
 			}
 			logging.Info("filled sealed inference index gaps", inferenceTypes.System,
 				"escrow_id", escrowID, "inserted", inserted,
-				"sealed_ids", len(sm.ExportSealedNonces()),
+				"sealed_ids", sm.SealedNonceCount(),
 				"duration", time.Since(fillStarted))
 		}
 

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -58,6 +58,9 @@ type HostManager struct {
 	availability       devshardpkg.AvailabilityProvider
 	maxNonce           devshardpkg.MaxNonceProvider
 
+	recoveryGate     recoveryGate
+	recoveryComplete atomic.Bool
+
 	statsMu            sync.Mutex
 	statsShardsCache   *statsShardsResponse
 	statsShardsCached  time.Time
@@ -77,6 +80,60 @@ const (
 type resolutionFailure struct {
 	err       error
 	expiresAt time.Time
+}
+
+// recoveryGate lets a session requested by a live caller jump ahead of the
+// background recovery backlog. Background workers check in before each session
+// and park while any on-demand load is in flight, so a request waits at most
+// for the sessions already being recovered rather than for the whole backlog.
+type recoveryGate struct {
+	mu      sync.Mutex
+	cond    *sync.Cond
+	pending int
+	stopped bool
+}
+
+// condLocked lazily builds the cond so a zero-value HostManager still works.
+func (g *recoveryGate) condLocked() *sync.Cond {
+	if g.cond == nil {
+		g.cond = sync.NewCond(&g.mu)
+	}
+	return g.cond
+}
+
+func (g *recoveryGate) begin() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.condLocked()
+	g.pending++
+}
+
+func (g *recoveryGate) end() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.pending > 0 {
+		g.pending--
+	}
+	if g.pending == 0 {
+		g.condLocked().Broadcast()
+	}
+}
+
+// waitTurn blocks a background worker while on-demand loads hold the gate.
+func (g *recoveryGate) waitTurn() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for g.pending > 0 && !g.stopped {
+		g.condLocked().Wait()
+	}
+}
+
+// stop releases parked workers so shutdown cannot block behind the gate.
+func (g *recoveryGate) stop() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.stopped = true
+	g.condLocked().Broadcast()
 }
 
 func NewHostManager(
@@ -163,6 +220,8 @@ func (m *HostManager) SessionServerExisting(escrowID string) (*transport.Server,
 	if srv, ok := m.existingServer(escrowID); ok {
 		return srv, nil
 	}
+	m.recoveryGate.begin()
+	defer m.recoveryGate.end()
 	srv, err := m.recoverAndStoreSession(escrowID)
 	if err != nil {
 		return nil, err
@@ -256,7 +315,11 @@ func (m *HostManager) getOrCreate(escrowID string, escrow *bridge.EscrowInfo) (*
 		}
 
 		// Prefer recovering an already-bound session over CreateSession.
-		srv, err := m.recoverStoredSession(escrowID)
+		srv, err := func() (*transport.Server, error) {
+			m.recoveryGate.begin()
+			defer m.recoveryGate.end()
+			return m.recoverStoredSession(escrowID)
+		}()
 		if err == nil {
 			return m.storeSessionIfAbsent(escrowID, srv), nil
 		}
@@ -427,6 +490,38 @@ func (m *HostManager) create(escrowID string, escrow *bridge.EscrowInfo) (*trans
 // recoverSessionsConcurrency workers in parallel. Call this on startup after
 // constructing the HostManager.
 func (m *HostManager) RecoverSessions() error {
+	return m.RecoverSessionsContext(context.Background())
+}
+
+// StartRecovery runs recovery in the background so the HTTP listener can bind
+// immediately instead of waiting out the backlog; sessions that are requested
+// before their turn are recovered on demand by getOrCreate. RecoveryComplete
+// gates /ready. The returned func waits for the backlog to drain and is safe to
+// call after ctx is cancelled.
+func (m *HostManager) StartRecovery(ctx context.Context) func() {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer m.recoveryComplete.Store(true)
+		if err := m.RecoverSessionsContext(ctx); err != nil {
+			logging.Error("devshard session recovery failed", inferenceTypes.System, "error", err)
+		}
+	}()
+	return func() {
+		m.recoveryGate.stop()
+		<-done
+	}
+}
+
+// RecoveryComplete reports whether background recovery has finished. It is true
+// once the backlog drains, including when recovery was cancelled or failed.
+func (m *HostManager) RecoveryComplete() bool {
+	return m.recoveryComplete.Load()
+}
+
+// RecoverSessionsContext is RecoverSessions with cancellation: a cancelled ctx
+// stops the workers between sessions and leaves the rest to lazy recovery.
+func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 	startedAt := time.Now()
 	active, err := m.store.ListActiveSessions()
 	if err != nil {
@@ -435,7 +530,7 @@ func (m *HostManager) RecoverSessions() error {
 	if len(active) == 0 {
 		logging.Info("completed devshard session recovery", inferenceTypes.System,
 			"session_count", 0, "worker_count", 0, "recovered_count", 0, "failed_count", 0,
-			"version_skipped_count", 0, "duration", time.Since(startedAt))
+			"version_skipped_count", 0, "cancelled_count", 0, "duration", time.Since(startedAt))
 		return nil
 	}
 
@@ -451,11 +546,20 @@ func (m *HostManager) RecoverSessions() error {
 	var recoveredCount atomic.Int64
 	var failedCount atomic.Int64
 	var versionSkippedCount atomic.Int64
+	var cancelledCount atomic.Int64
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for sess := range jobs {
+				// Keep draining on cancel so the feeder cannot block on a
+				// channel no worker is reading any more.
+				if ctx.Err() != nil {
+					cancelledCount.Add(1)
+					continue
+				}
+				// Park while a live request is loading its own session.
+				m.recoveryGate.waitTurn()
 				sessionStartedAt := time.Now()
 				if _, err := m.recoverAndStoreSession(sess.EscrowID); err != nil {
 					if errors.Is(err, storage.ErrSessionVersionConflict) {
@@ -490,6 +594,7 @@ func (m *HostManager) RecoverSessions() error {
 		"recovered_count", recoveredCount.Load(),
 		"failed_count", failedCount.Load(),
 		"version_skipped_count", versionSkippedCount.Load(),
+		"cancelled_count", cancelledCount.Load(),
 		"duration", time.Since(startedAt))
 	return nil
 }
@@ -532,12 +637,15 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 	if recoveredVersion == "" {
 		recoveredVersion = m.boundVersion
 	}
-	sm, err := state.NewStateMachine(
-		escrowID, meta.Config, meta.Group, meta.InitialBalance,
-		meta.CreatorAddr, m.verifier, m.store,
-		state.WithWarmKeyResolver(m.bridge.VerifyWarmKey),
-		state.WithVersion(recoveredVersion),
-	)
+	newStateMachine := func() (*state.StateMachine, error) {
+		return state.NewStateMachine(
+			escrowID, meta.Config, meta.Group, meta.InitialBalance,
+			meta.CreatorAddr, m.verifier, m.store,
+			state.WithWarmKeyResolver(m.bridge.VerifyWarmKey),
+			state.WithVersion(recoveredVersion),
+		)
+	}
+	sm, err := newStateMachine()
 	if err != nil {
 		return nil, fmt.Errorf("create state machine: %w", err)
 	}
@@ -554,9 +662,19 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 				sm.RestoreState(snapState)
 				sm.RestoreCommittedEntries(committedEntries)
 				sm.RestoreSealedNonces(sealedNonces)
-				replayFrom = snapNonce + 1
-				logging.Info("restored devshard snapshot", inferenceTypes.System,
-					"escrow_id", escrowID, "snapshot_nonce", snapNonce, "latest_nonce", meta.LatestNonce)
+				if verifyErr := verifySnapshotRoot(m.store, sm, escrowID, snapNonce); verifyErr != nil {
+					// Restore already mutated sm, so the rejected state has to
+					// be thrown away rather than replayed on top of.
+					logging.Error("devshard snapshot failed root check, replaying full history", inferenceTypes.System,
+						"escrow_id", escrowID, "snapshot_nonce", snapNonce, "error", verifyErr)
+					if sm, err = newStateMachine(); err != nil {
+						return nil, fmt.Errorf("recreate state machine after snapshot reject: %w", err)
+					}
+				} else {
+					replayFrom = snapNonce + 1
+					logging.Info("restored devshard snapshot", inferenceTypes.System,
+						"escrow_id", escrowID, "snapshot_nonce", snapNonce, "latest_nonce", meta.LatestNonce)
+				}
 			}
 		} else if snapErr != nil && !errors.Is(snapErr, storage.ErrSnapshotNotFound) {
 			logging.Error("failed to load devshard snapshot, replaying full history", inferenceTypes.System,
@@ -926,6 +1044,31 @@ func (m *HostManager) existingServer(escrowID string) (*transport.Server, bool) 
 	defer m.sessionsMutex.RUnlock()
 	srv, ok := m.sessions[escrowID]
 	return srv, ok
+}
+
+// verifySnapshotRoot checks a restored snapshot against the state root the
+// journal recorded at the snapshot nonce. Diff replay verifies every nonce this
+// way; without it the snapshot path would trust the blob outright, which
+// matters because the store can be shared between hosts and a snapshot is not
+// self-authenticating. Journals pruned past the snapshot, and records written
+// before state_hash existed, carry no root and cannot be checked.
+func verifySnapshotRoot(store storage.Storage, sm *state.StateMachine, escrowID string, snapNonce uint64) error {
+	records, err := store.GetDiffs(escrowID, snapNonce, snapNonce)
+	if err != nil {
+		return fmt.Errorf("load diff at snapshot nonce: %w", err)
+	}
+	if len(records) == 0 || len(records[0].StateHash) == 0 {
+		return nil
+	}
+	want := records[0].StateHash
+	got, err := sm.ComputeStateRoot()
+	if err != nil {
+		return fmt.Errorf("compute restored state root: %w", err)
+	}
+	if !bytes.Equal(got, want) {
+		return fmt.Errorf("restored root %x does not match journal root %x at nonce %d", got, want, snapNonce)
+	}
+	return nil
 }
 
 func saveHostSnapshot(store storage.Storage, sm *state.StateMachine, escrowID string, nonce uint64) error {

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -58,8 +58,9 @@ type HostManager struct {
 	availability       devshardpkg.AvailabilityProvider
 	maxNonce           devshardpkg.MaxNonceProvider
 
-	recoveryGate     recoveryGate
-	recoveryComplete atomic.Bool
+	recoveryGate   recoveryGate
+	backlogDrained atomic.Bool
+	recoveryCounts recoveryCounters
 
 	// obsGate is the same value as store, kept typed so obs rebuilds can run
 	// against the wrapped store while the live writes queue.
@@ -85,6 +86,33 @@ const (
 type resolutionFailure struct {
 	err       error
 	expiresAt time.Time
+}
+
+// recoveryCounters is the recovery progress /ready reports. They were log-only
+// on the completion line, which made "drained with three corrupt sessions"
+// indistinguishable from a clean boot to anything watching a rolling update.
+//
+// repairs counts in-flight validation-obs / sealed-index rebuilds. A
+// full-replay escrow is published long before that work finishes, and a
+// cutover that treated that as warm would route traffic at a host mid-wipe.
+type recoveryCounters struct {
+	total          atomic.Int64
+	recovered      atomic.Int64
+	failed         atomic.Int64
+	versionSkipped atomic.Int64
+	cancelled      atomic.Int64
+	repairs        atomic.Int64
+}
+
+// RecoveryProgress is the /ready body's view of session recovery. Complete is
+// what a version cutover polls; the counters say why it is not true yet.
+type RecoveryProgress struct {
+	Complete       bool  `json:"recovery_complete"`
+	Total          int64 `json:"sessions_total"`
+	Recovered      int64 `json:"sessions_recovered"`
+	Failed         int64 `json:"sessions_failed"`
+	VersionSkipped int64 `json:"sessions_version_skipped"`
+	Pending        int64 `json:"sessions_pending"`
 }
 
 // recoveryGate lets sessions a live caller asked for jump ahead of the cold
@@ -308,6 +336,47 @@ func (m *HostManager) SessionServerExisting(escrowID string) (*transport.Server,
 		return nil, err
 	}
 	return srv, nil
+}
+
+// ReloadStaleSession drops a live session whose in-memory nonce fell behind
+// the shared store (the overlap-warm case) and recovers it again. A client
+// that keeps sending a nonce that is simply wrong hits RememberStaleNonce
+// after the retry still fails, so this cannot spin on every request.
+func (m *HostManager) ReloadStaleSession(escrowID string, stale *transport.Server) (*transport.Server, error) {
+	now := time.Now()
+	if err := m.cachedResolutionFailure(escrowID, now); err != nil {
+		return nil, err
+	}
+	m.evictSession(escrowID, stale)
+	m.recoveryGate.begin(escrowID)
+	defer m.recoveryGate.end()
+	srv, err := m.recoverAndStoreSession(escrowID)
+	if err != nil {
+		m.rememberResolutionFailure(escrowID, err, now)
+		return nil, err
+	}
+	logging.Info("recovered stale in-memory session", inferenceTypes.System, "escrow_id", escrowID)
+	return srv, nil
+}
+
+// RememberStaleNonce negative-caches a nonce mismatch that survived a reload,
+// so a bogus client cannot evict-and-recover on every request. Short TTL: a
+// genuine catch-up during overlap is not a permanent failure.
+func (m *HostManager) RememberStaleNonce(escrowID string) {
+	m.rememberResolutionFailure(escrowID, types.ErrInvalidNonce, time.Now())
+}
+
+func (m *HostManager) evictSession(escrowID string, stale *transport.Server) {
+	m.sessionsMutex.Lock()
+	current, ok := m.sessions[escrowID]
+	if !ok || (stale != nil && current != stale) {
+		m.sessionsMutex.Unlock()
+		return
+	}
+	delete(m.sessions, escrowID)
+	m.sessionsMutex.Unlock()
+	current.Host().Close()
+	observability.DeleteEscrowMetrics(escrowID)
 }
 
 // BindOwnerChat verifies the request as the escrow owner, then returns an
@@ -578,14 +647,19 @@ func (m *HostManager) RecoverSessions() error {
 
 // StartRecovery runs recovery in the background so the HTTP listener can bind
 // immediately instead of waiting out the backlog; sessions that are requested
-// before their turn are recovered on demand by getOrCreate. RecoveryComplete
-// gates /ready. The returned func waits for the backlog to drain and is safe to
-// call after ctx is cancelled.
+// before their turn are recovered on demand by getOrCreate. The returned func
+// waits for the backlog to drain and is safe to call after ctx is cancelled.
+//
+// /ready reports 200 throughout: recovery gates the warm signal in the body,
+// not the status code.
 func (m *HostManager) StartRecovery(ctx context.Context) func() {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		defer m.recoveryComplete.Store(true)
+		defer func() {
+			m.backlogDrained.Store(true)
+			m.publishRecoveryProgress()
+		}()
 		if err := m.RecoverSessionsContext(ctx); err != nil {
 			logging.Error("devshard session recovery failed", inferenceTypes.System, "error", err)
 		}
@@ -596,10 +670,42 @@ func (m *HostManager) StartRecovery(ctx context.Context) func() {
 	}
 }
 
-// RecoveryComplete reports whether background recovery has finished. It is true
-// once the backlog drains, including when recovery was cancelled or failed.
+// RecoveryComplete reports whether this process is warm: the backlog has
+// drained (including when recovery was cancelled or failed) and no background
+// obs / sealed-index rebuild is still running. A cutover that ignored the
+// second half would publish a host whose sealed-inference index is mid-rebuild.
 func (m *HostManager) RecoveryComplete() bool {
-	return m.recoveryComplete.Load()
+	return m.backlogDrained.Load() && m.recoveryCounts.repairs.Load() == 0
+}
+
+// RecoveryProgressSnapshot is the /ready body's recovery view. Pending counts
+// the sessions still queued plus the repairs still running; the counters are
+// read without a lock, so a snapshot taken mid-increment can lag by one.
+func (m *HostManager) RecoveryProgressSnapshot() RecoveryProgress {
+	c := &m.recoveryCounts
+	total := c.total.Load()
+	recovered := c.recovered.Load()
+	failed := c.failed.Load()
+	versionSkipped := c.versionSkipped.Load()
+	queued := int64(0)
+	if !m.backlogDrained.Load() {
+		queued = max(total-recovered-failed-versionSkipped-c.cancelled.Load(), 0)
+	}
+	return RecoveryProgress{
+		Complete:       m.RecoveryComplete(),
+		Total:          total,
+		Recovered:      recovered,
+		Failed:         failed,
+		VersionSkipped: versionSkipped,
+		Pending:        queued + c.repairs.Load(),
+	}
+}
+
+// publishRecoveryProgress mirrors the snapshot onto Prometheus so a rolling
+// update can be watched without polling probe bodies.
+func (m *HostManager) publishRecoveryProgress() {
+	p := m.RecoveryProgressSnapshot()
+	observability.SetSessionRecovery(p.Total, p.Recovered, p.Failed, p.VersionSkipped, p.Pending, p.Complete)
 }
 
 // RecoverSessionsContext is RecoverSessions with cancellation: a cancelled ctx
@@ -610,6 +716,14 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("list active sessions: %w", err)
 	}
+	counts := &m.recoveryCounts
+	counts.total.Store(int64(len(active)))
+	counts.recovered.Store(0)
+	counts.failed.Store(0)
+	counts.versionSkipped.Store(0)
+	counts.cancelled.Store(0)
+	m.publishRecoveryProgress()
+
 	if len(active) == 0 {
 		logging.Info("completed devshard session recovery", inferenceTypes.System,
 			"session_count", 0, "worker_count", 0, "recovered_count", 0, "failed_count", 0,
@@ -629,10 +743,6 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 		prioritize: m.recoveryGate.isRequested,
 	}
 	var wg sync.WaitGroup
-	var recoveredCount atomic.Int64
-	var failedCount atomic.Int64
-	var versionSkippedCount atomic.Int64
-	var cancelledCount atomic.Int64
 	var prioritizedCount atomic.Int64
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
@@ -644,7 +754,8 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 					return
 				}
 				if ctx.Err() != nil {
-					cancelledCount.Add(1)
+					counts.cancelled.Add(1)
+					m.publishRecoveryProgress()
 					continue
 				}
 				// A session a caller already asked for runs immediately; a
@@ -657,20 +768,23 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 				sessionStartedAt := time.Now()
 				if _, err := m.recoverAndStoreSession(sess.EscrowID); err != nil {
 					if errors.Is(err, storage.ErrSessionVersionConflict) {
-						versionSkippedCount.Add(1)
+						counts.versionSkipped.Add(1)
+						m.publishRecoveryProgress()
 						logging.Info("skipping devshard session with foreign version", inferenceTypes.System,
 							"escrow_id", sess.EscrowID, "epoch_id", sess.EpochID,
 							"host_version", m.boundVersion,
 							"duration", time.Since(sessionStartedAt), "error", err)
 						continue
 					}
-					failedCount.Add(1)
+					counts.failed.Add(1)
+					m.publishRecoveryProgress()
 					logging.Error("skipping corrupt session", inferenceTypes.System,
 						"escrow_id", sess.EscrowID, "epoch_id", sess.EpochID,
 						"duration", time.Since(sessionStartedAt), "error", err)
 					continue
 				}
-				recoveredCount.Add(1)
+				counts.recovered.Add(1)
+				m.publishRecoveryProgress()
 				logging.Info("recovered devshard session", inferenceTypes.System,
 					"escrow_id", sess.EscrowID, "epoch_id", sess.EpochID,
 					"duration", time.Since(sessionStartedAt))
@@ -681,10 +795,10 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 
 	logging.Info("completed devshard session recovery", inferenceTypes.System,
 		"session_count", len(active), "worker_count", workers,
-		"recovered_count", recoveredCount.Load(),
-		"failed_count", failedCount.Load(),
-		"version_skipped_count", versionSkippedCount.Load(),
-		"cancelled_count", cancelledCount.Load(),
+		"recovered_count", counts.recovered.Load(),
+		"failed_count", counts.failed.Load(),
+		"version_skipped_count", counts.versionSkipped.Load(),
+		"cancelled_count", counts.cancelled.Load(),
 		"prioritized_count", prioritizedCount.Load(),
 		"duration", time.Since(startedAt))
 	return nil
@@ -1199,8 +1313,14 @@ func (m *HostManager) startObsRepair(escrowID string, job *obsRepairJob) {
 		return
 	}
 	m.obsRepairWG.Add(1)
+	m.recoveryCounts.repairs.Add(1)
+	m.publishRecoveryProgress()
 	go func() {
 		defer m.obsRepairWG.Done()
+		defer func() {
+			m.recoveryCounts.repairs.Add(-1)
+			m.publishRecoveryProgress()
+		}()
 		startedAt := time.Now()
 		err := m.obsGate.RepairValidationObs(escrowID, func(inner storage.Storage) error {
 			if err := storage.RebuildValidationObsFromDiffs(inner, escrowID, job.records, job.sealed); err != nil {

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/singleflight"
@@ -67,9 +68,10 @@ type HostManager struct {
 }
 
 const (
-	resolutionFailureTTL  = 30 * time.Second
-	permanentFailureTTL   = 10 * time.Minute
-	maxResolutionFailures = 1024
+	recoverSessionsConcurrency = 8
+	resolutionFailureTTL       = 30 * time.Second
+	permanentFailureTTL        = 10 * time.Minute
+	maxResolutionFailures      = 1024
 )
 
 type resolutionFailure struct {
@@ -421,26 +423,74 @@ func (m *HostManager) create(escrowID string, escrow *bridge.EscrowInfo) (*trans
 // RecoverSessions rebuilds in-memory sessions from the shared store.
 // For each active session it restores a host snapshot when one exists, then
 // replays only the post-snapshot diffs through a fresh StateMachine (injecting
-// warm key deltas from the stored DiffRecords). Call this on startup after
+// warm key deltas from the stored DiffRecords). Recovery runs up to
+// recoverSessionsConcurrency workers in parallel. Call this on startup after
 // constructing the HostManager.
 func (m *HostManager) RecoverSessions() error {
-	escrowIDs, err := m.store.ListActiveSessions()
+	startedAt := time.Now()
+	active, err := m.store.ListActiveSessions()
 	if err != nil {
 		return fmt.Errorf("list active sessions: %w", err)
 	}
-
-	for _, active := range escrowIDs {
-		if _, err := m.recoverAndStoreSession(active.EscrowID); err != nil {
-			if errors.Is(err, storage.ErrSessionVersionConflict) {
-				logging.Info("skipping devshard session with foreign version", inferenceTypes.System,
-					"escrow_id", active.EscrowID, "error", err)
-				continue
-			}
-			logging.Error("skipping corrupt session", inferenceTypes.System,
-				"escrow_id", active.EscrowID, "error", err)
-		}
+	if len(active) == 0 {
+		logging.Info("completed devshard session recovery", inferenceTypes.System,
+			"session_count", 0, "worker_count", 0, "recovered_count", 0, "failed_count", 0,
+			"version_skipped_count", 0, "duration", time.Since(startedAt))
+		return nil
 	}
 
+	workers := recoverSessionsConcurrency
+	if len(active) < workers {
+		workers = len(active)
+	}
+	logging.Info("starting devshard session recovery", inferenceTypes.System,
+		"session_count", len(active), "worker_count", workers)
+
+	jobs := make(chan storage.ActiveSession)
+	var wg sync.WaitGroup
+	var recoveredCount atomic.Int64
+	var failedCount atomic.Int64
+	var versionSkippedCount atomic.Int64
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for sess := range jobs {
+				sessionStartedAt := time.Now()
+				if _, err := m.recoverAndStoreSession(sess.EscrowID); err != nil {
+					if errors.Is(err, storage.ErrSessionVersionConflict) {
+						versionSkippedCount.Add(1)
+						logging.Info("skipping devshard session with foreign version", inferenceTypes.System,
+							"escrow_id", sess.EscrowID, "epoch_id", sess.EpochID,
+							"host_version", m.boundVersion,
+							"duration", time.Since(sessionStartedAt), "error", err)
+						continue
+					}
+					failedCount.Add(1)
+					logging.Error("skipping corrupt session", inferenceTypes.System,
+						"escrow_id", sess.EscrowID, "epoch_id", sess.EpochID,
+						"duration", time.Since(sessionStartedAt), "error", err)
+					continue
+				}
+				recoveredCount.Add(1)
+				logging.Info("recovered devshard session", inferenceTypes.System,
+					"escrow_id", sess.EscrowID, "epoch_id", sess.EpochID,
+					"duration", time.Since(sessionStartedAt))
+			}
+		}()
+	}
+	for _, sess := range active {
+		jobs <- sess
+	}
+	close(jobs)
+	wg.Wait()
+
+	logging.Info("completed devshard session recovery", inferenceTypes.System,
+		"session_count", len(active), "worker_count", workers,
+		"recovered_count", recoveredCount.Load(),
+		"failed_count", failedCount.Load(),
+		"version_skipped_count", versionSkippedCount.Load(),
+		"duration", time.Since(startedAt))
 	return nil
 }
 

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -781,20 +781,23 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 			}
 		}
 
-		obsRecords := records
-		if replayFrom > 1 {
-			obsRecords, err = m.store.GetDiffs(escrowID, 1, meta.LatestNonce)
-			if err != nil {
-				return nil, fmt.Errorf("get diffs for validation obs rebuild: %w", err)
+		// Validation obs is written by the live apply path and is durable, so a
+		// restart already has the rows for every nonce a snapshot covers.
+		// Rebuild only when replaying the whole journal, where ApplyLocal
+		// records no obs and the clear-then-replay is the self-heal for
+		// batches the live path dropped under backpressure. Re-recording a
+		// range incrementally is not an option: the drain removes the live row
+		// that RecordValidationsAppliedOnce dedups against, so a tail replayed
+		// twice would double count.
+		if replayFrom == 1 {
+			if err := storage.RebuildValidationObsFromDiffs(
+				m.store,
+				escrowID,
+				records,
+				storage.SealedInferenceIDsSorted(sm.ExportSealedNonces()),
+			); err != nil {
+				return nil, fmt.Errorf("rebuild validation obs: %w", err)
 			}
-		}
-		if err := storage.RebuildValidationObsFromDiffs(
-			m.store,
-			escrowID,
-			obsRecords,
-			storage.SealedInferenceIDsSorted(sm.ExportSealedNonces()),
-		); err != nil {
-			return nil, fmt.Errorf("rebuild validation obs: %w", err)
 		}
 
 		if replayFrom == 1 || uint64(len(records)) >= host.SnapshotInterval {

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -419,9 +419,10 @@ func (m *HostManager) create(escrowID string, escrow *bridge.EscrowInfo) (*trans
 }
 
 // RecoverSessions rebuilds in-memory sessions from the shared store.
-// For each active session, it replays all diffs through a fresh StateMachine,
-// injecting warm key deltas from the stored DiffRecords. Call this on startup
-// after constructing the HostManager.
+// For each active session it restores a host snapshot when one exists, then
+// replays only the post-snapshot diffs through a fresh StateMachine (injecting
+// warm key deltas from the stored DiffRecords). Call this on startup after
+// constructing the HostManager.
 func (m *HostManager) RecoverSessions() error {
 	escrowIDs, err := m.store.ListActiveSessions()
 	if err != nil {
@@ -463,7 +464,9 @@ func (m *HostManager) recoverAndStoreSession(escrowID string) (*transport.Server
 	return v.(*transport.Server), nil
 }
 
-// recoverStoredSession replays a single session from storage.
+// recoverStoredSession rebuilds a single session from storage. A host snapshot
+// at nonce N skips replaying diffs 1..N; only N+1..latest are applied. Decode
+// or load failures fall back to a full journal replay (v3 HostManager behavior).
 func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, error) {
 	meta, err := m.store.GetSessionMeta(escrowID)
 	if err != nil {
@@ -489,33 +492,73 @@ func (m *HostManager) recoverStoredSession(escrowID string) (*transport.Server, 
 		return nil, fmt.Errorf("create state machine: %w", err)
 	}
 
+	replayFrom := uint64(1)
 	if meta.LatestNonce > 0 {
-		records, err := m.store.GetDiffs(escrowID, 1, meta.LatestNonce)
-		if err != nil {
-			return nil, fmt.Errorf("get diffs: %w", err)
+		snapNonce, snapData, snapErr := m.store.LoadSnapshot(escrowID)
+		if snapErr == nil && snapNonce > 0 && snapNonce <= meta.LatestNonce {
+			snapState, committedEntries, sealedNonces, decodeErr := host.UnmarshalStateSnapshotWithCommitted(snapData)
+			if decodeErr != nil {
+				logging.Error("failed to decode devshard snapshot, replaying full history", inferenceTypes.System,
+					"escrow_id", escrowID, "snapshot_nonce", snapNonce, "error", decodeErr)
+			} else {
+				sm.RestoreState(snapState)
+				sm.RestoreCommittedEntries(committedEntries)
+				sm.RestoreSealedNonces(sealedNonces)
+				replayFrom = snapNonce + 1
+				logging.Info("restored devshard snapshot", inferenceTypes.System,
+					"escrow_id", escrowID, "snapshot_nonce", snapNonce, "latest_nonce", meta.LatestNonce)
+			}
+		} else if snapErr != nil && !errors.Is(snapErr, storage.ErrSnapshotNotFound) {
+			logging.Error("failed to load devshard snapshot, replaying full history", inferenceTypes.System,
+				"escrow_id", escrowID, "error", snapErr)
 		}
 
-		for _, rec := range records {
-			sm.InjectWarmKeys(rec.WarmKeyDelta)
-			root, applyErr := sm.ApplyLocal(rec.Nonce, rec.Txs)
-			if applyErr != nil {
-				return nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
+		var records []types.DiffRecord
+		if replayFrom <= meta.LatestNonce {
+			records, err = m.store.GetDiffs(escrowID, replayFrom, meta.LatestNonce)
+			if err != nil {
+				return nil, fmt.Errorf("get diffs: %w", err)
 			}
-			if len(rec.StateHash) > 0 && len(root) > 0 {
-				if !bytes.Equal(root, rec.StateHash) {
-					return nil, fmt.Errorf("state root mismatch at nonce %d", rec.Nonce)
+			for _, rec := range records {
+				sm.InjectWarmKeys(rec.WarmKeyDelta)
+				root, applyErr := sm.ApplyLocal(rec.Nonce, rec.Txs)
+				if applyErr != nil {
+					return nil, fmt.Errorf("replay nonce %d: %w", rec.Nonce, applyErr)
+				}
+				if len(rec.StateHash) > 0 && len(root) > 0 {
+					if !bytes.Equal(root, rec.StateHash) {
+						return nil, fmt.Errorf("state root mismatch at nonce %d", rec.Nonce)
+					}
 				}
 			}
 		}
 
+		obsRecords := records
+		if replayFrom > 1 {
+			obsRecords, err = m.store.GetDiffs(escrowID, 1, meta.LatestNonce)
+			if err != nil {
+				return nil, fmt.Errorf("get diffs for validation obs rebuild: %w", err)
+			}
+		}
 		if err := storage.RebuildValidationObsFromDiffs(
 			m.store,
 			escrowID,
-			records,
+			obsRecords,
 			storage.SealedInferenceIDsSorted(sm.ExportSealedNonces()),
 		); err != nil {
 			return nil, fmt.Errorf("rebuild validation obs: %w", err)
 		}
+
+		if replayFrom == 1 || uint64(len(records)) >= host.SnapshotInterval {
+			if saveErr := saveHostSnapshot(m.store, sm, escrowID, meta.LatestNonce); saveErr != nil {
+				logging.Error("failed to save devshard recovery snapshot", inferenceTypes.System,
+					"escrow_id", escrowID, "nonce", meta.LatestNonce, "error", saveErr)
+			}
+		}
+	}
+
+	if err := sm.RebuildSealedInferenceIndex(); err != nil {
+		return nil, fmt.Errorf("rebuild sealed inference index: %w", err)
 	}
 
 	h, err := host.NewHost(sm, m.signer, m.engine, escrowID, meta.Group, nil, m.hostOpts(meta.EpochID)...)
@@ -833,6 +876,17 @@ func (m *HostManager) existingServer(escrowID string) (*transport.Server, bool) 
 	defer m.sessionsMutex.RUnlock()
 	srv, ok := m.sessions[escrowID]
 	return srv, ok
+}
+
+func saveHostSnapshot(store storage.Storage, sm *state.StateMachine, escrowID string, nonce uint64) error {
+	data, err := host.MarshalStateSnapshotWithCommitted(sm.ExportState(), sm.ExportCommittedEntries(), sm.ExportSealedNonces())
+	if err != nil {
+		return fmt.Errorf("marshal snapshot: %w", err)
+	}
+	if err := store.SaveSnapshot(escrowID, nonce, data); err != nil {
+		return fmt.Errorf("save snapshot: %w", err)
+	}
+	return nil
 }
 
 func (m *HostManager) hostOpts(epochID uint64) []host.HostOption {

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -179,6 +179,20 @@ func (g *recoveryGate) isRequested(escrowID string) bool {
 	return ok
 }
 
+// firstRemainingRequested is the demand lookup for recoveryQueue: O(demand),
+// not O(backlog). Which demanded escrow is chosen is unspecified; any remaining
+// demanded ID beats cold list order.
+func (g *recoveryGate) firstRemainingRequested(remaining map[string]storage.ActiveSession) (string, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for id := range g.requested {
+		if _, ok := remaining[id]; ok {
+			return id, true
+		}
+	}
+	return "", false
+}
+
 // waitTurn parks a background worker that is about to recover a cold session
 // while on-demand loads are in flight. Workers assigned an already-demanded
 // escrow are never parked: pausing them would only delay the caller.
@@ -208,37 +222,65 @@ func (g *recoveryGate) stop() {
 // escrows a live caller has already asked for. Requests that arrive mid
 // recovery reorder whatever is left, so demand keeps overtaking cold sessions
 // instead of being fixed at startup.
+//
+// Remaining sessions are indexed by ID once at construction. next() walks the
+// (bounded) demand set and looks those IDs up, rather than scanning the
+// backlog to ask whether each row is demanded.
 type recoveryQueue struct {
-	mu         sync.Mutex
-	pending    []storage.ActiveSession
-	prioritize func(escrowID string) bool
+	mu       sync.Mutex
+	byID     map[string]storage.ActiveSession
+	order    []string
+	cold     int
+	demanded func(remaining map[string]storage.ActiveSession) (string, bool)
+}
+
+func newRecoveryQueue(sessions []storage.ActiveSession, demanded func(map[string]storage.ActiveSession) (string, bool)) *recoveryQueue {
+	byID := make(map[string]storage.ActiveSession, len(sessions))
+	order := make([]string, len(sessions))
+	for i, s := range sessions {
+		byID[s.EscrowID] = s
+		order[i] = s.EscrowID
+	}
+	return &recoveryQueue{byID: byID, order: order, demanded: demanded}
+}
+
+func (q *recoveryQueue) takeLocked(id string) (storage.ActiveSession, bool) {
+	sess, ok := q.byID[id]
+	if !ok {
+		return storage.ActiveSession{}, false
+	}
+	delete(q.byID, id)
+	return sess, true
 }
 
 // next returns the highest-priority remaining session, or false when drained.
 func (q *recoveryQueue) next() (storage.ActiveSession, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if len(q.pending) == 0 {
+	if len(q.byID) == 0 {
 		return storage.ActiveSession{}, false
 	}
-	idx := 0
-	if q.prioritize != nil {
-		for i, sess := range q.pending {
-			if q.prioritize(sess.EscrowID) {
-				idx = i
-				break
+	if q.demanded != nil {
+		if id, ok := q.demanded(q.byID); ok {
+			if sess, taken := q.takeLocked(id); taken {
+				return sess, true
 			}
 		}
 	}
-	sess := q.pending[idx]
-	q.pending = append(q.pending[:idx], q.pending[idx+1:]...)
-	return sess, true
+	for q.cold < len(q.order) {
+		id := q.order[q.cold]
+		q.cold++
+		if sess, ok := q.takeLocked(id); ok {
+			return sess, true
+		}
+	}
+	return storage.ActiveSession{}, false
 }
 
 func (q *recoveryQueue) remaining() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return len(q.pending)
+	return len(q.byID)
 }
 
 func NewHostManager(
@@ -738,10 +780,7 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 	logging.Info("starting devshard session recovery", inferenceTypes.System,
 		"session_count", len(active), "worker_count", workers)
 
-	queue := &recoveryQueue{
-		pending:    append([]storage.ActiveSession(nil), active...),
-		prioritize: m.recoveryGate.isRequested,
-	}
+	queue := newRecoveryQueue(active, m.recoveryGate.firstRemainingRequested)
 	var wg sync.WaitGroup
 	var prioritizedCount atomic.Int64
 	for i := 0; i < workers; i++ {

--- a/devshard/cmd/devshardd/session/manager.go
+++ b/devshard/cmd/devshardd/session/manager.go
@@ -82,16 +82,24 @@ type resolutionFailure struct {
 	expiresAt time.Time
 }
 
-// recoveryGate lets a session requested by a live caller jump ahead of the
-// background recovery backlog. Background workers check in before each session
-// and park while any on-demand load is in flight, so a request waits at most
-// for the sessions already being recovered rather than for the whole backlog.
+// recoveryGate lets sessions a live caller asked for jump ahead of the cold
+// recovery backlog. Every escrow that reaches getOrCreate is remembered for the
+// rest of the recovery window, which does two things: the queue hands those
+// escrows out first, and a worker already recovering one of them keeps running
+// instead of parking, since that work is exactly what the caller is waiting on.
+// Only workers about to pick up a cold session park while a request is
+// in flight, so a request waits at most for the cold sessions already running.
 type recoveryGate struct {
-	mu      sync.Mutex
-	cond    *sync.Cond
-	pending int
-	stopped bool
+	mu        sync.Mutex
+	cond      *sync.Cond
+	inFlight  int
+	requested map[string]struct{}
+	stopped   bool
 }
+
+// maxRequestedRecoveryEscrows bounds the demand set. Past the cap ordering
+// degrades to list order rather than growing memory without limit.
+const maxRequestedRecoveryEscrows = 4096
 
 // condLocked lazily builds the cond so a zero-value HostManager still works.
 func (g *recoveryGate) condLocked() *sync.Cond {
@@ -101,29 +109,56 @@ func (g *recoveryGate) condLocked() *sync.Cond {
 	return g.cond
 }
 
-func (g *recoveryGate) begin() {
+// begin marks an escrow as demanded and records an in-flight on-demand load.
+// The broadcast lets a worker parked on this escrow notice it is now
+// prioritized and resume instead of waiting for the request to finish.
+func (g *recoveryGate) begin(escrowID string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	g.condLocked()
-	g.pending++
+	if g.requested == nil {
+		g.requested = make(map[string]struct{})
+	}
+	if len(g.requested) < maxRequestedRecoveryEscrows {
+		g.requested[escrowID] = struct{}{}
+	}
+	g.inFlight++
+	g.condLocked().Broadcast()
 }
 
+// end releases one on-demand load. The escrow stays in the demand set so a
+// later backlog pass still treats it as warm.
 func (g *recoveryGate) end() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if g.pending > 0 {
-		g.pending--
+	if g.inFlight > 0 {
+		g.inFlight--
 	}
-	if g.pending == 0 {
+	if g.inFlight == 0 {
 		g.condLocked().Broadcast()
 	}
 }
 
-// waitTurn blocks a background worker while on-demand loads hold the gate.
-func (g *recoveryGate) waitTurn() {
+// isRequested reports whether a live caller has asked for this escrow.
+func (g *recoveryGate) isRequested(escrowID string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	for g.pending > 0 && !g.stopped {
+	_, ok := g.requested[escrowID]
+	return ok
+}
+
+// waitTurn parks a background worker that is about to recover a cold session
+// while on-demand loads are in flight. Workers assigned an already-demanded
+// escrow are never parked: pausing them would only delay the caller.
+func (g *recoveryGate) waitTurn(escrowID string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for !g.stopped {
+		if _, prioritized := g.requested[escrowID]; prioritized {
+			return
+		}
+		if g.inFlight == 0 {
+			return
+		}
 		g.condLocked().Wait()
 	}
 }
@@ -134,6 +169,43 @@ func (g *recoveryGate) stop() {
 	defer g.mu.Unlock()
 	g.stopped = true
 	g.condLocked().Broadcast()
+}
+
+// recoveryQueue hands backlog sessions to the recovery workers, preferring
+// escrows a live caller has already asked for. Requests that arrive mid
+// recovery reorder whatever is left, so demand keeps overtaking cold sessions
+// instead of being fixed at startup.
+type recoveryQueue struct {
+	mu         sync.Mutex
+	pending    []storage.ActiveSession
+	prioritize func(escrowID string) bool
+}
+
+// next returns the highest-priority remaining session, or false when drained.
+func (q *recoveryQueue) next() (storage.ActiveSession, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.pending) == 0 {
+		return storage.ActiveSession{}, false
+	}
+	idx := 0
+	if q.prioritize != nil {
+		for i, sess := range q.pending {
+			if q.prioritize(sess.EscrowID) {
+				idx = i
+				break
+			}
+		}
+	}
+	sess := q.pending[idx]
+	q.pending = append(q.pending[:idx], q.pending[idx+1:]...)
+	return sess, true
+}
+
+func (q *recoveryQueue) remaining() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.pending)
 }
 
 func NewHostManager(
@@ -220,7 +292,7 @@ func (m *HostManager) SessionServerExisting(escrowID string) (*transport.Server,
 	if srv, ok := m.existingServer(escrowID); ok {
 		return srv, nil
 	}
-	m.recoveryGate.begin()
+	m.recoveryGate.begin(escrowID)
 	defer m.recoveryGate.end()
 	srv, err := m.recoverAndStoreSession(escrowID)
 	if err != nil {
@@ -316,7 +388,7 @@ func (m *HostManager) getOrCreate(escrowID string, escrow *bridge.EscrowInfo) (*
 
 		// Prefer recovering an already-bound session over CreateSession.
 		srv, err := func() (*transport.Server, error) {
-			m.recoveryGate.begin()
+			m.recoveryGate.begin(escrowID)
 			defer m.recoveryGate.end()
 			return m.recoverStoredSession(escrowID)
 		}()
@@ -541,25 +613,36 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 	logging.Info("starting devshard session recovery", inferenceTypes.System,
 		"session_count", len(active), "worker_count", workers)
 
-	jobs := make(chan storage.ActiveSession)
+	queue := &recoveryQueue{
+		pending:    append([]storage.ActiveSession(nil), active...),
+		prioritize: m.recoveryGate.isRequested,
+	}
 	var wg sync.WaitGroup
 	var recoveredCount atomic.Int64
 	var failedCount atomic.Int64
 	var versionSkippedCount atomic.Int64
 	var cancelledCount atomic.Int64
+	var prioritizedCount atomic.Int64
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for sess := range jobs {
-				// Keep draining on cancel so the feeder cannot block on a
-				// channel no worker is reading any more.
+			for {
+				sess, ok := queue.next()
+				if !ok {
+					return
+				}
 				if ctx.Err() != nil {
 					cancelledCount.Add(1)
 					continue
 				}
-				// Park while a live request is loading its own session.
-				m.recoveryGate.waitTurn()
+				// A session a caller already asked for runs immediately; a
+				// cold one yields until no request is in flight.
+				if m.recoveryGate.isRequested(sess.EscrowID) {
+					prioritizedCount.Add(1)
+				} else {
+					m.recoveryGate.waitTurn(sess.EscrowID)
+				}
 				sessionStartedAt := time.Now()
 				if _, err := m.recoverAndStoreSession(sess.EscrowID); err != nil {
 					if errors.Is(err, storage.ErrSessionVersionConflict) {
@@ -583,10 +666,6 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 			}
 		}()
 	}
-	for _, sess := range active {
-		jobs <- sess
-	}
-	close(jobs)
 	wg.Wait()
 
 	logging.Info("completed devshard session recovery", inferenceTypes.System,
@@ -595,6 +674,7 @@ func (m *HostManager) RecoverSessionsContext(ctx context.Context) error {
 		"failed_count", failedCount.Load(),
 		"version_skipped_count", versionSkippedCount.Load(),
 		"cancelled_count", cancelledCount.Load(),
+		"prioritized_count", prioritizedCount.Load(),
 		"duration", time.Since(startedAt))
 	return nil
 }

--- a/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
+++ b/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
@@ -76,20 +76,27 @@ func waitFor(t *testing.T, what string, cond func() bool) {
 }
 
 func TestRecoveryQueue_HandsOutRequestedSessionsFirst(t *testing.T) {
-	requested := map[string]bool{"4": true}
-	q := &recoveryQueue{
-		pending: []storage.ActiveSession{
+	requested := map[string]struct{}{"4": {}}
+	q := newRecoveryQueue(
+		[]storage.ActiveSession{
 			{EscrowID: "1"}, {EscrowID: "2"}, {EscrowID: "3"}, {EscrowID: "4"}, {EscrowID: "5"},
 		},
-		prioritize: func(id string) bool { return requested[id] },
-	}
+		func(remaining map[string]storage.ActiveSession) (string, bool) {
+			for id := range requested {
+				if _, ok := remaining[id]; ok {
+					return id, true
+				}
+			}
+			return "", false
+		},
+	)
 
 	sess, ok := q.next()
 	require.True(t, ok)
 	require.Equal(t, "4", sess.EscrowID, "a demanded escrow must be handed out before cold ones")
 
 	// A request arriving mid-recovery reorders whatever is left.
-	requested["3"] = true
+	requested["3"] = struct{}{}
 	sess, ok = q.next()
 	require.True(t, ok)
 	require.Equal(t, "3", sess.EscrowID, "demand arriving mid-drain must overtake the remaining backlog")
@@ -107,7 +114,7 @@ func TestRecoveryQueue_HandsOutRequestedSessionsFirst(t *testing.T) {
 }
 
 func TestRecoveryQueue_DrainsWithoutPrioritizer(t *testing.T) {
-	q := &recoveryQueue{pending: []storage.ActiveSession{{EscrowID: "1"}, {EscrowID: "2"}}}
+	q := newRecoveryQueue([]storage.ActiveSession{{EscrowID: "1"}, {EscrowID: "2"}}, nil)
 	first, ok := q.next()
 	require.True(t, ok)
 	require.Equal(t, "1", first.EscrowID)
@@ -116,6 +123,23 @@ func TestRecoveryQueue_DrainsWithoutPrioritizer(t *testing.T) {
 	require.Equal(t, "2", second.EscrowID)
 	_, ok = q.next()
 	require.False(t, ok)
+}
+
+func TestRecoveryQueue_DemandLookupUsesRemainingIndex(t *testing.T) {
+	var gate recoveryGate
+	const n = 64
+	sessions := make([]storage.ActiveSession, n)
+	for i := range sessions {
+		sessions[i] = storage.ActiveSession{EscrowID: strconv.Itoa(i + 1)}
+	}
+	q := newRecoveryQueue(sessions, gate.firstRemainingRequested)
+
+	gate.begin(strconv.Itoa(n))
+	defer gate.end()
+
+	sess, ok := q.next()
+	require.True(t, ok)
+	require.Equal(t, strconv.Itoa(n), sess.EscrowID, "demand is an ID lookup in the remaining map, not a scan of backlog prefix")
 }
 
 func TestRecoveryGate_ParksColdWorkerUntilOnDemandDone(t *testing.T) {

--- a/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
+++ b/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
@@ -40,7 +40,7 @@ func seedRecoveryManager(t *testing.T, store storage.Storage, count int) *HostMa
 	for i, slot := range group {
 		addresses[i] = slot.ValidatorAddress
 	}
-	return waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil,
+	return waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil,
 		testutil.RuntimeTestVersion, &mockBridge{
 			escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
 		}, nil, nil))

--- a/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
+++ b/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
@@ -40,10 +40,10 @@ func seedRecoveryManager(t *testing.T, store storage.Storage, count int) *HostMa
 	for i, slot := range group {
 		addresses[i] = slot.ValidatorAddress
 	}
-	return NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil,
+	return waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil,
 		testutil.RuntimeTestVersion, &mockBridge{
 			escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
-		}, nil, nil)
+		}, nil, nil))
 }
 
 func (m *HostManager) loadedSessionCount() int {

--- a/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
+++ b/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
@@ -1,0 +1,206 @@
+package session
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/bridge"
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/storage"
+	"devshard/stub"
+)
+
+// seedRecoveryManager creates count active sessions and a manager bound to them.
+func seedRecoveryManager(t *testing.T, store storage.Storage, count int) *HostManager {
+	t.Helper()
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	for i := 1; i <= count; i++ {
+		require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+			EscrowID:       strconv.Itoa(i),
+			EpochID:        7,
+			Version:        testutil.RuntimeTestVersion,
+			CreatorAddr:    user.Address(),
+			Config:         defaultConfig(3),
+			Group:          group,
+			InitialBalance: 100000,
+		}))
+	}
+	addresses := make([]string, len(group))
+	for i, slot := range group {
+		addresses[i] = slot.ValidatorAddress
+	}
+	return NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil,
+		testutil.RuntimeTestVersion, &mockBridge{
+			escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
+		}, nil, nil)
+}
+
+func (m *HostManager) loadedSessionCount() int {
+	m.sessionsMutex.RLock()
+	defer m.sessionsMutex.RUnlock()
+	return len(m.sessions)
+}
+
+func TestRecoveryGate_ParksBackgroundWorkerUntilOnDemandDone(t *testing.T) {
+	var gate recoveryGate
+	gate.begin()
+
+	parked := make(chan struct{})
+	go func() {
+		gate.waitTurn()
+		close(parked)
+	}()
+
+	select {
+	case <-parked:
+		t.Fatal("worker passed the gate while an on-demand load was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	gate.end()
+	select {
+	case <-parked:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker was not released after the on-demand load finished")
+	}
+}
+
+func TestRecoveryGate_NestedOnDemandLoadsHoldTheGate(t *testing.T) {
+	var gate recoveryGate
+	gate.begin()
+	gate.begin()
+
+	parked := make(chan struct{})
+	go func() {
+		gate.waitTurn()
+		close(parked)
+	}()
+
+	gate.end()
+	select {
+	case <-parked:
+		t.Fatal("gate released while a second on-demand load was still in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	gate.end()
+	select {
+	case <-parked:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker was not released after the last on-demand load finished")
+	}
+}
+
+// stop must release parked workers so shutdown cannot deadlock behind the gate.
+func TestRecoveryGate_StopReleasesParkedWorker(t *testing.T) {
+	var gate recoveryGate
+	gate.begin()
+
+	parked := make(chan struct{})
+	go func() {
+		gate.waitTurn()
+		close(parked)
+	}()
+
+	gate.stop()
+	select {
+	case <-parked:
+	case <-time.After(3 * time.Second):
+		t.Fatal("stop did not release the parked worker")
+	}
+}
+
+func TestRecoveryGate_IdleGateDoesNotBlock(t *testing.T) {
+	var gate recoveryGate
+	done := make(chan struct{})
+	go func() {
+		gate.waitTurn()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("idle gate blocked a background worker")
+	}
+}
+
+// A session a live caller is waiting on must not queue behind the backlog: the
+// background workers park while an on-demand load holds the gate.
+func TestRecoverSessions_OnDemandLoadParksBackgroundWorkers(t *testing.T) {
+	inner := newManagerTestStore(t)
+	mgr := seedRecoveryManager(t, inner, 16)
+
+	mgr.recoveryGate.begin()
+
+	done := make(chan error, 1)
+	go func() { done <- mgr.RecoverSessions() }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("recovery drained the backlog while an on-demand load held the gate: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.Zero(t, mgr.loadedSessionCount(), "workers must not recover sessions while parked")
+
+	mgr.recoveryGate.end()
+	require.NoError(t, <-done)
+	require.Equal(t, 16, mgr.loadedSessionCount())
+}
+
+func TestRecoverSessionsContext_CancelledSkipsRemaining(t *testing.T) {
+	inner := newManagerTestStore(t)
+	mgr := seedRecoveryManager(t, inner, 8)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, mgr.RecoverSessionsContext(ctx), "cancellation is not a recovery failure")
+	require.Zero(t, mgr.loadedSessionCount(), "cancelled recovery must leave sessions to lazy recovery")
+}
+
+func TestStartRecovery_MarksCompleteWhenBacklogDrains(t *testing.T) {
+	inner := newManagerTestStore(t)
+	mgr := seedRecoveryManager(t, inner, 4)
+
+	mgr.recoveryGate.begin()
+	wait := mgr.StartRecovery(context.Background())
+	require.False(t, mgr.RecoveryComplete(), "recovery must not report complete while the backlog is pending")
+
+	mgr.recoveryGate.end()
+	wait()
+	require.True(t, mgr.RecoveryComplete())
+	require.Equal(t, 4, mgr.loadedSessionCount())
+}
+
+// The wait func returned by StartRecovery is the shutdown hook, so it has to
+// return even when workers are parked behind the gate.
+func TestStartRecovery_WaitReleasesParkedWorkers(t *testing.T) {
+	inner := newManagerTestStore(t)
+	mgr := seedRecoveryManager(t, inner, 16)
+
+	mgr.recoveryGate.begin()
+	defer mgr.recoveryGate.end()
+	wait := mgr.StartRecovery(context.Background())
+
+	returned := make(chan struct{})
+	go func() {
+		wait()
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown blocked behind the recovery gate")
+	}
+	require.True(t, mgr.RecoveryComplete())
+}

--- a/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
+++ b/devshard/cmd/devshardd/session/manager_recovery_priority_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -51,19 +52,85 @@ func (m *HostManager) loadedSessionCount() int {
 	return len(m.sessions)
 }
 
-func TestRecoveryGate_ParksBackgroundWorkerUntilOnDemandDone(t *testing.T) {
+func (m *HostManager) loadedSessionIDs() []string {
+	m.sessionsMutex.RLock()
+	defer m.sessionsMutex.RUnlock()
+	out := make([]string, 0, len(m.sessions))
+	for id := range m.sessions {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// waitFor polls until cond holds, so tests do not depend on worker scheduling.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestRecoveryQueue_HandsOutRequestedSessionsFirst(t *testing.T) {
+	requested := map[string]bool{"4": true}
+	q := &recoveryQueue{
+		pending: []storage.ActiveSession{
+			{EscrowID: "1"}, {EscrowID: "2"}, {EscrowID: "3"}, {EscrowID: "4"}, {EscrowID: "5"},
+		},
+		prioritize: func(id string) bool { return requested[id] },
+	}
+
+	sess, ok := q.next()
+	require.True(t, ok)
+	require.Equal(t, "4", sess.EscrowID, "a demanded escrow must be handed out before cold ones")
+
+	// A request arriving mid-recovery reorders whatever is left.
+	requested["3"] = true
+	sess, ok = q.next()
+	require.True(t, ok)
+	require.Equal(t, "3", sess.EscrowID, "demand arriving mid-drain must overtake the remaining backlog")
+
+	var rest []string
+	for {
+		sess, ok := q.next()
+		if !ok {
+			break
+		}
+		rest = append(rest, sess.EscrowID)
+	}
+	require.Equal(t, []string{"1", "2", "5"}, rest, "cold sessions keep list order")
+	require.Zero(t, q.remaining())
+}
+
+func TestRecoveryQueue_DrainsWithoutPrioritizer(t *testing.T) {
+	q := &recoveryQueue{pending: []storage.ActiveSession{{EscrowID: "1"}, {EscrowID: "2"}}}
+	first, ok := q.next()
+	require.True(t, ok)
+	require.Equal(t, "1", first.EscrowID)
+	second, ok := q.next()
+	require.True(t, ok)
+	require.Equal(t, "2", second.EscrowID)
+	_, ok = q.next()
+	require.False(t, ok)
+}
+
+func TestRecoveryGate_ParksColdWorkerUntilOnDemandDone(t *testing.T) {
 	var gate recoveryGate
-	gate.begin()
+	gate.begin("requested")
 
 	parked := make(chan struct{})
 	go func() {
-		gate.waitTurn()
+		gate.waitTurn("cold")
 		close(parked)
 	}()
 
 	select {
 	case <-parked:
-		t.Fatal("worker passed the gate while an on-demand load was in flight")
+		t.Fatal("cold worker passed the gate while an on-demand load was in flight")
 	case <-time.After(50 * time.Millisecond):
 	}
 
@@ -71,18 +138,76 @@ func TestRecoveryGate_ParksBackgroundWorkerUntilOnDemandDone(t *testing.T) {
 	select {
 	case <-parked:
 	case <-time.After(3 * time.Second):
-		t.Fatal("worker was not released after the on-demand load finished")
+		t.Fatal("cold worker was not released after the on-demand load finished")
 	}
+}
+
+// Work on an already-demanded escrow is what the caller is waiting for, so it
+// must never be parked, however many on-demand loads are in flight.
+func TestRecoveryGate_DoesNotParkRequestedEscrow(t *testing.T) {
+	var gate recoveryGate
+	gate.begin("a")
+	gate.begin("b")
+
+	done := make(chan struct{})
+	go func() {
+		gate.waitTurn("a")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("a worker recovering a demanded escrow was parked")
+	}
+}
+
+// A cold worker that parks must resume as soon as its own escrow is demanded,
+// without waiting for the unrelated request to finish.
+func TestRecoveryGate_PromotesParkedWorkerWhenItsEscrowIsRequested(t *testing.T) {
+	var gate recoveryGate
+	gate.begin("other")
+
+	resumed := make(chan struct{})
+	go func() {
+		gate.waitTurn("target")
+		close(resumed)
+	}()
+
+	select {
+	case <-resumed:
+		t.Fatal("cold worker ran while an unrelated request was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	gate.begin("target")
+	defer gate.end()
+	select {
+	case <-resumed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("parked worker was not promoted when its escrow became demanded")
+	}
+}
+
+// The demand marker outlives the request so a later backlog pass still treats
+// the escrow as warm.
+func TestRecoveryGate_RequestedMarkerIsSticky(t *testing.T) {
+	var gate recoveryGate
+	gate.begin("5")
+	require.True(t, gate.isRequested("5"))
+	gate.end()
+	require.True(t, gate.isRequested("5"), "demand must survive the request that recorded it")
+	require.False(t, gate.isRequested("6"))
 }
 
 func TestRecoveryGate_NestedOnDemandLoadsHoldTheGate(t *testing.T) {
 	var gate recoveryGate
-	gate.begin()
-	gate.begin()
+	gate.begin("a")
+	gate.begin("b")
 
 	parked := make(chan struct{})
 	go func() {
-		gate.waitTurn()
+		gate.waitTurn("cold")
 		close(parked)
 	}()
 
@@ -97,18 +222,18 @@ func TestRecoveryGate_NestedOnDemandLoadsHoldTheGate(t *testing.T) {
 	select {
 	case <-parked:
 	case <-time.After(3 * time.Second):
-		t.Fatal("worker was not released after the last on-demand load finished")
+		t.Fatal("cold worker was not released after the last on-demand load finished")
 	}
 }
 
 // stop must release parked workers so shutdown cannot deadlock behind the gate.
 func TestRecoveryGate_StopReleasesParkedWorker(t *testing.T) {
 	var gate recoveryGate
-	gate.begin()
+	gate.begin("requested")
 
 	parked := make(chan struct{})
 	go func() {
-		gate.waitTurn()
+		gate.waitTurn("cold")
 		close(parked)
 	}()
 
@@ -124,7 +249,7 @@ func TestRecoveryGate_IdleGateDoesNotBlock(t *testing.T) {
 	var gate recoveryGate
 	done := make(chan struct{})
 	go func() {
-		gate.waitTurn()
+		gate.waitTurn("cold")
 		close(done)
 	}()
 	select {
@@ -134,27 +259,79 @@ func TestRecoveryGate_IdleGateDoesNotBlock(t *testing.T) {
 	}
 }
 
-// A session a live caller is waiting on must not queue behind the backlog: the
-// background workers park while an on-demand load holds the gate.
-func TestRecoverSessions_OnDemandLoadParksBackgroundWorkers(t *testing.T) {
+func TestRecoveryGate_RequestedSetIsBounded(t *testing.T) {
+	var gate recoveryGate
+	for i := 0; i < maxRequestedRecoveryEscrows+10; i++ {
+		gate.begin(strconv.Itoa(i))
+		gate.end()
+	}
+	gate.mu.Lock()
+	defer gate.mu.Unlock()
+	require.Len(t, gate.requested, maxRequestedRecoveryEscrows,
+		"demand set must not grow without bound")
+}
+
+// The end-to-end priority contract: demanded sessions are dequeued first and
+// run to completion while a request is in flight, and only cold sessions wait.
+func TestRecoverSessions_RunsRequestedSessionsWhileColdOnesWait(t *testing.T) {
 	inner := newManagerTestStore(t)
 	mgr := seedRecoveryManager(t, inner, 16)
 
-	mgr.recoveryGate.begin()
+	// Two live callers are waiting on these; neither request has finished.
+	mgr.recoveryGate.begin("12")
+	mgr.recoveryGate.begin("15")
+
+	done := make(chan error, 1)
+	go func() { done <- mgr.RecoverSessions() }()
+
+	waitFor(t, "demanded sessions to be recovered", func() bool {
+		return mgr.loadedSessionCount() >= 2
+	})
+	require.Equal(t, []string{"12", "15"}, mgr.loadedSessionIDs(),
+		"only the demanded sessions may be recovered while requests are in flight")
+
+	select {
+	case err := <-done:
+		t.Fatalf("recovery drained cold sessions while requests were in flight: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.Equal(t, []string{"12", "15"}, mgr.loadedSessionIDs(),
+		"cold sessions must stay parked until the requests finish")
+
+	mgr.recoveryGate.end()
+	mgr.recoveryGate.end()
+	require.NoError(t, <-done)
+	require.Equal(t, 16, mgr.loadedSessionCount())
+}
+
+// With every worker busy on demanded sessions, nothing should be parked: the
+// backlog drains even though on-demand loads are in flight the whole time.
+func TestRecoverSessions_AllRequestedBacklogNeverParks(t *testing.T) {
+	const sessions = 6
+	inner := newManagerTestStore(t)
+	mgr := seedRecoveryManager(t, inner, sessions)
+
+	for i := 1; i <= sessions; i++ {
+		mgr.recoveryGate.begin(strconv.Itoa(i))
+	}
+	// Every remaining session is demanded, so recovery must complete without
+	// waiting for these requests to finish.
+	defer func() {
+		for i := 1; i <= sessions; i++ {
+			mgr.recoveryGate.end()
+		}
+	}()
 
 	done := make(chan error, 1)
 	go func() { done <- mgr.RecoverSessions() }()
 
 	select {
 	case err := <-done:
-		t.Fatalf("recovery drained the backlog while an on-demand load held the gate: %v", err)
-	case <-time.After(100 * time.Millisecond):
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovery parked workers even though every session was demanded")
 	}
-	require.Zero(t, mgr.loadedSessionCount(), "workers must not recover sessions while parked")
-
-	mgr.recoveryGate.end()
-	require.NoError(t, <-done)
-	require.Equal(t, 16, mgr.loadedSessionCount())
+	require.Equal(t, sessions, mgr.loadedSessionCount())
 }
 
 func TestRecoverSessionsContext_CancelledSkipsRemaining(t *testing.T) {
@@ -172,7 +349,7 @@ func TestStartRecovery_MarksCompleteWhenBacklogDrains(t *testing.T) {
 	inner := newManagerTestStore(t)
 	mgr := seedRecoveryManager(t, inner, 4)
 
-	mgr.recoveryGate.begin()
+	mgr.recoveryGate.begin("cold-request")
 	wait := mgr.StartRecovery(context.Background())
 	require.False(t, mgr.RecoveryComplete(), "recovery must not report complete while the backlog is pending")
 
@@ -188,7 +365,7 @@ func TestStartRecovery_WaitReleasesParkedWorkers(t *testing.T) {
 	inner := newManagerTestStore(t)
 	mgr := seedRecoveryManager(t, inner, 16)
 
-	mgr.recoveryGate.begin()
+	mgr.recoveryGate.begin("cold-request")
 	defer mgr.recoveryGate.end()
 	wait := mgr.StartRecovery(context.Background())
 

--- a/devshard/cmd/devshardd/session/manager_recovery_workers_test.go
+++ b/devshard/cmd/devshardd/session/manager_recovery_workers_test.go
@@ -61,7 +61,7 @@ func TestRecoverSessions_UsesEightWorkers(t *testing.T) {
 	for i, slot := range group {
 		addresses[i] = slot.ValidatorAddress
 	}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
 		escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
 	}, nil, nil))
 
@@ -120,7 +120,7 @@ func TestRecoverSessions_CapsWorkersToSessionCount(t *testing.T) {
 	for i, slot := range group {
 		addresses[i] = slot.ValidatorAddress
 	}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
 		escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
 	}, nil, nil))
 

--- a/devshard/cmd/devshardd/session/manager_recovery_workers_test.go
+++ b/devshard/cmd/devshardd/session/manager_recovery_workers_test.go
@@ -61,9 +61,9 @@ func TestRecoverSessions_UsesEightWorkers(t *testing.T) {
 	for i, slot := range group {
 		addresses[i] = slot.ValidatorAddress
 	}
-	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
 		escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
-	}, nil, nil)
+	}, nil, nil))
 
 	done := make(chan error, 1)
 	go func() { done <- mgr.RecoverSessions() }()
@@ -120,9 +120,9 @@ func TestRecoverSessions_CapsWorkersToSessionCount(t *testing.T) {
 	for i, slot := range group {
 		addresses[i] = slot.ValidatorAddress
 	}
-	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
 		escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
-	}, nil, nil)
+	}, nil, nil))
 
 	done := make(chan error, 1)
 	go func() { done <- mgr.RecoverSessions() }()

--- a/devshard/cmd/devshardd/session/manager_recovery_workers_test.go
+++ b/devshard/cmd/devshardd/session/manager_recovery_workers_test.go
@@ -1,0 +1,144 @@
+package session
+
+import (
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/bridge"
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/storage"
+	"devshard/stub"
+)
+
+type inflightMetaStore struct {
+	storage.Storage
+	inFlight atomic.Int32
+	max      atomic.Int32
+	release  chan struct{}
+}
+
+func (s *inflightMetaStore) GetSessionMeta(escrowID string) (*storage.SessionMeta, error) {
+	n := s.inFlight.Add(1)
+	defer s.inFlight.Add(-1)
+	for {
+		old := s.max.Load()
+		if n <= old || s.max.CompareAndSwap(old, n) {
+			break
+		}
+	}
+	<-s.release
+	return s.Storage.GetSessionMeta(escrowID)
+}
+
+func TestRecoverSessions_UsesEightWorkers(t *testing.T) {
+	const sessions = 16
+	inner := newManagerTestStore(t)
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	for i := 1; i <= sessions; i++ {
+		require.NoError(t, inner.CreateSession(storage.CreateSessionParams{
+			EscrowID:       strconv.Itoa(i),
+			EpochID:        7,
+			Version:        testutil.RuntimeTestVersion,
+			CreatorAddr:    user.Address(),
+			Config:         defaultConfig(3),
+			Group:          group,
+			InitialBalance: 100000,
+		}))
+	}
+
+	store := &inflightMetaStore{Storage: inner, release: make(chan struct{})}
+	addresses := make([]string, len(group))
+	for i, slot := range group {
+		addresses[i] = slot.ValidatorAddress
+	}
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
+		escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
+	}, nil, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- mgr.RecoverSessions() }()
+
+	deadline := time.After(3 * time.Second)
+	for store.max.Load() < int32(recoverSessionsConcurrency) {
+		select {
+		case <-deadline:
+			t.Fatalf("recovery never reached %d concurrent workers, max=%d", recoverSessionsConcurrency, store.max.Load())
+		case err := <-done:
+			t.Fatalf("RecoverSessions returned before workers were saturated: max=%d err=%v", store.max.Load(), err)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	close(store.release)
+	require.NoError(t, <-done)
+	require.Equal(t, int32(recoverSessionsConcurrency), store.max.Load())
+
+	mgr.sessionsMutex.RLock()
+	defer mgr.sessionsMutex.RUnlock()
+	require.Len(t, mgr.sessions, sessions)
+}
+
+func TestRecoverSessions_CapsWorkersToSessionCount(t *testing.T) {
+	inner := newManagerTestStore(t)
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	require.NoError(t, inner.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "1",
+		EpochID:        7,
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         defaultConfig(3),
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+	require.NoError(t, inner.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "2",
+		EpochID:        7,
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         defaultConfig(3),
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+
+	store := &inflightMetaStore{Storage: inner, release: make(chan struct{})}
+	addresses := make([]string, len(group))
+	for i, slot := range group {
+		addresses[i] = slot.ValidatorAddress
+	}
+	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{
+		escrow: &bridge.EscrowInfo{EscrowID: "1", Amount: 100000, CreatorAddress: user.Address(), Slots: addresses},
+	}, nil, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- mgr.RecoverSessions() }()
+
+	deadline := time.After(3 * time.Second)
+	for store.max.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("recovery never reached 2 concurrent workers, max=%d", store.max.Load())
+		case err := <-done:
+			t.Fatalf("RecoverSessions returned before both sessions overlapped: max=%d err=%v", store.max.Load(), err)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	close(store.release)
+	require.NoError(t, <-done)
+	require.Equal(t, int32(2), store.max.Load(), "must not spawn more workers than sessions")
+}

--- a/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
+++ b/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -42,17 +43,27 @@ func (s *recordingStore) ranges() []diffRange {
 	return out
 }
 
-// obsCallStore counts the destructive obs rebuild entry point.
+// obsCallStore counts the destructive obs rebuild entry point, and can hold it
+// open so a test can observe recovery finishing without it.
 type obsCallStore struct {
 	storage.Storage
-	mu     sync.Mutex
-	clears int
+	mu      sync.Mutex
+	clears  int
+	entered chan struct{}
+	release chan struct{}
 }
 
 func (s *obsCallStore) ClearValidationObs(escrowID string) error {
 	s.mu.Lock()
 	s.clears++
 	s.mu.Unlock()
+	if s.entered != nil {
+		close(s.entered)
+		s.entered = nil
+	}
+	if s.release != nil {
+		<-s.release
+	}
 	return s.Storage.ClearValidationObs(escrowID)
 }
 
@@ -335,22 +346,37 @@ func TestRecoverSessions_SnapshotPathLeavesValidationObsAlone(t *testing.T) {
 	store := &obsCallStore{Storage: inner}
 	mgr := recoverTestManager(t, store, hostSigner, user, group)
 	require.NoError(t, mgr.RecoverSessions())
+	mgr.WaitObsRepairs()
 
 	require.Zero(t, store.clearCalls(), "a restored snapshot must not clear durable obs rows")
 }
 
 // Replaying the whole journal is the one case that must rebuild: ApplyLocal
 // records no obs, and the clear-then-replay is what repairs batches the live
-// path dropped under backpressure.
-func TestRecoverSessions_FullReplayRebuildsValidationObs(t *testing.T) {
+// path dropped under backpressure. The rebuild runs in the background, so it
+// must not have touched obs by the time recovery returns.
+func TestRecoverSessions_FullReplayRebuildsValidationObsInBackground(t *testing.T) {
 	inner := newManagerTestStore(t)
 	group, user, hostSigner := populateStore(t, inner, 10)
 
-	store := &obsCallStore{Storage: inner}
+	store := &obsCallStore{Storage: inner, release: make(chan struct{})}
 	mgr := recoverTestManager(t, store, hostSigner, user, group)
-	require.NoError(t, mgr.RecoverSessions())
 
-	require.Equal(t, 1, store.clearCalls(), "full replay must rebuild obs from the journal")
+	// The rebuild is pinned inside ClearValidationObs, so recovery can only
+	// return if it no longer waits for it.
+	done := make(chan error, 1)
+	go func() { done <- mgr.RecoverSessions() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovery blocked on the background obs rebuild")
+	}
+	require.Equal(t, 1, mgr.loadedSessionCount(), "the session must be published before the rebuild finishes")
+
+	close(store.release)
+	mgr.WaitObsRepairs()
+	require.Equal(t, 1, store.clearCalls(), "the background rebuild must still run")
 }
 
 func TestRecoverSessions_SnapshotMatchesFullReplayWithLiveInferences(t *testing.T) {

--- a/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
+++ b/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -73,6 +74,85 @@ func (s *obsCallStore) clearCalls() int {
 	return s.clears
 }
 
+type sealedDeleteStore struct {
+	storage.Storage
+	mu      sync.Mutex
+	deletes int
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *sealedDeleteStore) DeleteSealedInferences(escrowID string) error {
+	s.mu.Lock()
+	s.deletes++
+	entered := s.entered
+	s.entered = nil
+	s.mu.Unlock()
+	if entered != nil {
+		close(entered)
+	}
+	if s.release != nil {
+		<-s.release
+	}
+	return s.Storage.DeleteSealedInferences(escrowID)
+}
+
+func (s *sealedDeleteStore) deleteCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.deletes
+}
+
+func populateFinishedAndSeal(t *testing.T, store storage.Storage) ([]types.SlotAssignment, *signing.Secp256k1Signer, *signing.Secp256k1Signer) {
+	t.Helper()
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i] = mustGenerateKey(t)
+	}
+	user := mustGenerateKey(t)
+	group := makeGroup(hosts)
+	config := defaultConfig(3)
+	verifier := signing.NewSecp256k1Verifier()
+
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       "1",
+		EpochID:        7,
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}))
+
+	sm, err := state.NewStateMachine("1", config, group, 100000, user.Address(), verifier, store,
+		state.WithVersion(testutil.RuntimeTestVersion))
+	require.NoError(t, err)
+
+	apply := func(nonce uint64, txs []*types.DevshardTx) {
+		t.Helper()
+		root, err := sm.ApplyLocal(nonce, txs)
+		require.NoError(t, err)
+		diff := signDiffWithRoot(t, user, "1", nonce, txs, root)
+		require.NoError(t, store.AppendDiff("1", types.DiffRecord{Diff: diff, StateHash: root}))
+	}
+
+	start := startTx(1)
+	apply(1, []*types.DevshardTx{start})
+	execSig := testutil.SignExecutorReceipt(t, hosts[1], "1", 1, start.GetStartInference().GetPromptHash(),
+		"llama", 100, 50, 1000, 2000)
+	apply(2, []*types.DevshardTx{&types.DevshardTx{Tx: &types.DevshardTx_ConfirmStart{ConfirmStart: &types.MsgConfirmStart{
+		InferenceId: 1, ExecutorSig: execSig, ConfirmedAt: 2000,
+	}}}})
+	finish := &types.MsgFinishInference{
+		InferenceId: 1, ResponseHash: []byte("response"), InputTokens: 10, OutputTokens: 20,
+		ExecutorSlot: 1, EscrowId: "1",
+	}
+	finish.ProposerSig = testutil.SignProposerTx(t, hosts[1], finish)
+	apply(3, []*types.DevshardTx{&types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: finish}}})
+	require.NoError(t, sm.SealInference(1))
+	return group, user, hosts[0]
+}
+
 type loadSnapshotErrStore struct {
 	storage.Storage
 	err error
@@ -106,7 +186,7 @@ func recoverTestManager(t *testing.T, store storage.Storage, hostSigner *signing
 			Slots:          addresses,
 		},
 	}
-	return waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	return waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 }
 
 func saveSnapshotThrough(t *testing.T, store storage.Storage, through uint64) {
@@ -346,7 +426,7 @@ func TestRecoverSessions_SnapshotPathLeavesValidationObsAlone(t *testing.T) {
 	store := &obsCallStore{Storage: inner}
 	mgr := recoverTestManager(t, store, hostSigner, user, group)
 	require.NoError(t, mgr.RecoverSessions())
-	mgr.WaitObsRepairs()
+	mgr.WaitRecoveryRepairs()
 
 	require.Zero(t, store.clearCalls(), "a restored snapshot must not clear durable obs rows")
 }
@@ -382,8 +462,108 @@ func TestRecoverSessions_FullReplayRebuildsValidationObsInBackground(t *testing.
 	require.Equal(t, 1, mgr.loadedSessionCount(), "the session must be published before the rebuild finishes")
 
 	close(store.release)
-	mgr.WaitObsRepairs()
+	mgr.WaitRecoveryRepairs()
 	require.Equal(t, 1, store.clearCalls(), "the background rebuild must still run")
+}
+
+func TestRecoverSessions_SnapshotPathLeavesSealedInferenceRows(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 10)
+	saveSnapshotThrough(t, inner, 7)
+
+	planted := storage.InferenceRow{
+		InferenceID: 99, SealedNonce: 7, ObsPresent: true,
+		SealedModel: "llama", SealedInputTokens: 10, SealedOutputTokens: 20,
+	}
+	require.NoError(t, inner.InsertSealedInference("1", planted))
+
+	store := &sealedDeleteStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+	mgr.WaitRecoveryRepairs()
+
+	require.Zero(t, store.deleteCalls(), "a restored snapshot must not wipe sealed-inference rows")
+	after, ok, err := inner.GetSealedInference("1", 99)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, planted, after)
+}
+
+func TestRecoverSessions_FullReplayRebuildsSealedIndexInBackground(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateFinishedAndSeal(t, inner)
+
+	store := &sealedDeleteStore{Storage: inner, release: make(chan struct{})}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	t.Cleanup(func() {
+		select {
+		case <-store.release:
+		default:
+			close(store.release)
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- mgr.RecoverSessions() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovery blocked on the background sealed-index rebuild")
+	}
+	require.Equal(t, 1, mgr.loadedSessionCount(), "the session must be published before the rebuild finishes")
+
+	close(store.release)
+	mgr.WaitRecoveryRepairs()
+	require.Equal(t, 1, store.deleteCalls(), "the background rebuild must still run")
+
+	row, ok, err := inner.GetSealedInference("1", 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, row.ObsPresent, "full-replay from-diffs must restore rich rows")
+	require.Equal(t, "llama", row.SealedModel)
+}
+
+// Step 4 keeps recovery_complete on the backlog drain. A full-replay child
+// can be "complete" while WaitRecoveryRepairs is still blocked on the wipe.
+// Step 8 is the one that must wait on the waiter.
+func TestStartRecovery_CompleteBeforeSealedIndexRepair(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateFinishedAndSeal(t, inner)
+
+	entered := make(chan struct{})
+	store := &sealedDeleteStore{Storage: inner, entered: entered, release: make(chan struct{})}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	t.Cleanup(func() {
+		select {
+		case <-store.release:
+		default:
+			close(store.release)
+		}
+	})
+
+	wait := mgr.StartRecovery(context.Background())
+	wait()
+	require.True(t, mgr.RecoveryComplete(), "recovery_complete follows the backlog until step 8")
+	require.Equal(t, 1, mgr.loadedSessionCount())
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sealed-index rebuild never started")
+	}
+}
+
+func TestRecoverSessions_RejectedSnapshotRebuildsSealedIndex(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 10)
+	saveMismatchedSnapshot(t, inner, 5, 7)
+
+	store := &sealedDeleteStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+	mgr.WaitRecoveryRepairs()
+	require.Equal(t, 1, store.deleteCalls(), "a rejected snapshot must take the full-replay sealed rebuild")
 }
 
 func TestRecoverSessions_SnapshotMatchesFullReplayWithLiveInferences(t *testing.T) {

--- a/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
+++ b/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
@@ -524,10 +524,7 @@ func TestRecoverSessions_FullReplayRebuildsSealedIndexInBackground(t *testing.T)
 	require.Equal(t, "llama", row.SealedModel)
 }
 
-// Step 4 keeps recovery_complete on the backlog drain. A full-replay child
-// can be "complete" while WaitRecoveryRepairs is still blocked on the wipe.
-// Step 8 is the one that must wait on the waiter.
-func TestStartRecovery_CompleteBeforeSealedIndexRepair(t *testing.T) {
+func TestStartRecovery_CompleteAfterSealedIndexRepair(t *testing.T) {
 	inner := newManagerTestStore(t)
 	group, user, hostSigner := populateFinishedAndSeal(t, inner)
 
@@ -544,14 +541,23 @@ func TestStartRecovery_CompleteBeforeSealedIndexRepair(t *testing.T) {
 
 	wait := mgr.StartRecovery(context.Background())
 	wait()
-	require.True(t, mgr.RecoveryComplete(), "recovery_complete follows the backlog until step 8")
-	require.Equal(t, 1, mgr.loadedSessionCount())
+	require.Equal(t, 1, mgr.loadedSessionCount(), "the session is published before the rebuild finishes")
+	progress := mgr.RecoveryProgressSnapshot()
+	require.False(t, progress.Complete, "recovery_complete waits for the sealed-index rebuild, not just the backlog")
+	require.Equal(t, int64(1), progress.Total)
+	require.Equal(t, int64(1), progress.Recovered)
+	require.Greater(t, progress.Pending, int64(0))
 
 	select {
 	case <-entered:
 	case <-time.After(5 * time.Second):
 		t.Fatal("sealed-index rebuild never started")
 	}
+	close(store.release)
+	mgr.WaitRecoveryRepairs()
+	progress = mgr.RecoveryProgressSnapshot()
+	require.True(t, progress.Complete)
+	require.Zero(t, progress.Pending)
 }
 
 func TestRecoverSessions_RejectedSnapshotRebuildsSealedIndex(t *testing.T) {

--- a/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
+++ b/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
@@ -106,7 +106,7 @@ func recoverTestManager(t *testing.T, store storage.Storage, hostSigner *signing
 			Slots:          addresses,
 		},
 	}
-	return NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	return waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 }
 
 func saveSnapshotThrough(t *testing.T, store storage.Storage, through uint64) {
@@ -361,6 +361,13 @@ func TestRecoverSessions_FullReplayRebuildsValidationObsInBackground(t *testing.
 
 	store := &obsCallStore{Storage: inner, release: make(chan struct{})}
 	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	t.Cleanup(func() {
+		select {
+		case <-store.release:
+		default:
+			close(store.release)
+		}
+	})
 
 	// The rebuild is pinned inside ClearValidationObs, so recovery can only
 	// return if it no longer waits for it.

--- a/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
+++ b/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
@@ -1,0 +1,265 @@
+package session
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/bridge"
+	"devshard/host"
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/state"
+	"devshard/storage"
+	"devshard/stub"
+	"devshard/types"
+)
+
+type diffRange struct {
+	from, to uint64
+}
+
+type recordingStore struct {
+	storage.Storage
+	mu    sync.Mutex
+	calls []diffRange
+}
+
+func (s *recordingStore) GetDiffs(escrowID string, fromNonce, toNonce uint64) ([]types.DiffRecord, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, diffRange{fromNonce, toNonce})
+	s.mu.Unlock()
+	return s.Storage.GetDiffs(escrowID, fromNonce, toNonce)
+}
+
+func (s *recordingStore) ranges() []diffRange {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]diffRange, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+type loadSnapshotErrStore struct {
+	storage.Storage
+	err error
+}
+
+func (s *loadSnapshotErrStore) LoadSnapshot(string) (uint64, []byte, error) {
+	return 0, nil, s.err
+}
+
+type snapshotBlobStore struct {
+	storage.Storage
+	nonce uint64
+	data  []byte
+}
+
+func (s *snapshotBlobStore) LoadSnapshot(string) (uint64, []byte, error) {
+	return s.nonce, s.data, nil
+}
+
+func recoverTestManager(t *testing.T, store storage.Storage, hostSigner *signing.Secp256k1Signer, user *signing.Secp256k1Signer, group []types.SlotAssignment) *HostManager {
+	t.Helper()
+	addresses := make([]string, len(group))
+	for i, slot := range group {
+		addresses[i] = slot.ValidatorAddress
+	}
+	br := &mockBridge{
+		escrow: &bridge.EscrowInfo{
+			EscrowID:       "1",
+			Amount:         100000,
+			CreatorAddress: user.Address(),
+			Slots:          addresses,
+		},
+	}
+	return NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+}
+
+func saveSnapshotThrough(t *testing.T, store storage.Storage, through uint64) {
+	t.Helper()
+	meta, err := store.GetSessionMeta("1")
+	require.NoError(t, err)
+	sm, err := state.NewStateMachine("1", meta.Config, meta.Group, meta.InitialBalance,
+		meta.CreatorAddr, signing.NewSecp256k1Verifier(), store,
+		state.WithVersion(testutil.RuntimeTestVersion))
+	require.NoError(t, err)
+	records, err := store.GetDiffs("1", 1, through)
+	require.NoError(t, err)
+	require.Len(t, records, int(through))
+	for _, rec := range records {
+		_, err := sm.ApplyLocal(rec.Nonce, rec.Txs)
+		require.NoError(t, err)
+	}
+	require.NoError(t, saveHostSnapshot(store, sm, "1", through))
+}
+
+func recoveredHostState(t *testing.T, mgr *HostManager) types.EscrowState {
+	t.Helper()
+	mgr.sessionsMutex.RLock()
+	defer mgr.sessionsMutex.RUnlock()
+	srv, ok := mgr.sessions["1"]
+	require.True(t, ok, "session must exist after recovery")
+	require.NotNil(t, srv.Host())
+	return srv.Host().SnapshotState()
+}
+
+func fullReplayState(t *testing.T, store storage.Storage) types.EscrowState {
+	t.Helper()
+	meta, err := store.GetSessionMeta("1")
+	require.NoError(t, err)
+	sm, err := state.NewStateMachine("1", meta.Config, meta.Group, meta.InitialBalance,
+		meta.CreatorAddr, signing.NewSecp256k1Verifier(), store,
+		state.WithVersion(testutil.RuntimeTestVersion))
+	require.NoError(t, err)
+	if meta.LatestNonce == 0 {
+		return sm.SnapshotState()
+	}
+	records, err := store.GetDiffs("1", 1, meta.LatestNonce)
+	require.NoError(t, err)
+	for _, rec := range records {
+		_, err := sm.ApplyLocal(rec.Nonce, rec.Txs)
+		require.NoError(t, err)
+	}
+	return sm.SnapshotState()
+}
+
+func TestRecoverSessions_RestoresSnapshotAndReplaysOnlyTail(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 10)
+	saveSnapshotThrough(t, inner, 7)
+
+	store := &recordingStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	got := recoveredHostState(t, mgr)
+	want := fullReplayState(t, inner)
+	require.Equal(t, want.LatestNonce, got.LatestNonce)
+	require.Equal(t, want.Balance, got.Balance)
+	require.Equal(t, want.Phase, got.Phase)
+
+	calls := store.ranges()
+	require.NotEmpty(t, calls)
+	require.Equal(t, diffRange{8, 10}, calls[0], "apply path must fetch only post-snapshot diffs")
+	require.Equal(t, diffRange{1, 10}, calls[1], "obs rebuild still reads the journal")
+}
+
+func TestRecoverSessions_SnapshotCurrentSkipsDiffApply(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 10)
+	saveSnapshotThrough(t, inner, 10)
+
+	store := &recordingStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	got := recoveredHostState(t, mgr)
+	require.Equal(t, uint64(10), got.LatestNonce)
+	require.Equal(t, []diffRange{{1, 10}}, store.ranges(), "current snapshot applies nothing; obs still rebuilds from the journal")
+}
+
+func TestRecoverSessions_NoSnapshotReplaysFromOne(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 10)
+
+	store := &recordingStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	got := recoveredHostState(t, mgr)
+	require.Equal(t, uint64(10), got.LatestNonce)
+	require.Equal(t, []diffRange{{1, 10}}, store.ranges())
+}
+
+func TestRecoverSessions_SavesSnapshotAfterFullReplay(t *testing.T) {
+	store := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, store, 10)
+	_, _, err := store.LoadSnapshot("1")
+	require.ErrorIs(t, err, storage.ErrSnapshotNotFound)
+
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	nonce, data, err := store.LoadSnapshot("1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), nonce)
+	state, committed, sealed, err := host.UnmarshalStateSnapshotWithCommitted(data)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), state.LatestNonce)
+	require.NotNil(t, committed)
+	_ = sealed
+}
+
+func TestRecoverSessions_CorruptSnapshotReplaysFromOne(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 6)
+	require.NoError(t, inner.SaveSnapshot("1", 4, []byte("not-a-protobuf-snapshot")))
+
+	store := &recordingStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	got := recoveredHostState(t, mgr)
+	require.Equal(t, uint64(6), got.LatestNonce)
+	require.Equal(t, []diffRange{{1, 6}}, store.ranges(), "undecodable snapshot must fall back to a full replay")
+}
+
+func TestRecoverSessions_SnapshotAheadOfLatestIgnored(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 5)
+	saveSnapshotThrough(t, inner, 5)
+	require.NoError(t, inner.SaveSnapshot("1", 99, []byte("future-nonce-blob")))
+
+	store := &recordingStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	got := recoveredHostState(t, mgr)
+	require.Equal(t, uint64(5), got.LatestNonce)
+	require.Equal(t, []diffRange{{1, 5}}, store.ranges(), "snapshot nonce past latest_nonce must be ignored")
+}
+
+func TestRecoverSessions_LoadSnapshotErrorReplaysFromOne(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 4)
+	store := &loadSnapshotErrStore{Storage: inner, err: errors.New("sqlite busy")}
+
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+	require.Equal(t, uint64(4), recoveredHostState(t, mgr).LatestNonce)
+}
+
+func TestRecoverSessions_EmptySnapshotBlobReplaysFromOne(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 3)
+	store := &recordingStore{Storage: &snapshotBlobStore{Storage: inner, nonce: 2, data: nil}}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+	require.Equal(t, uint64(3), recoveredHostState(t, mgr).LatestNonce)
+	require.Equal(t, []diffRange{{1, 3}}, store.ranges())
+}
+
+func TestRecoverSessions_SnapshotMatchesFullReplayWithLiveInferences(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 12)
+	saveSnapshotThrough(t, inner, 5)
+
+	mgr := recoverTestManager(t, inner, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	got := recoveredHostState(t, mgr)
+	want := fullReplayState(t, inner)
+	require.Equal(t, want.LatestNonce, got.LatestNonce)
+	require.Equal(t, want.Balance, got.Balance)
+	require.Equal(t, len(want.Inferences), len(got.Inferences))
+	for id, rec := range want.Inferences {
+		gotRec, ok := got.Inferences[id]
+		require.True(t, ok, "inference %d missing after snapshot+tail recovery", id)
+		require.Equal(t, rec.Status, gotRec.Status)
+		require.Equal(t, rec.MaxTokens, gotRec.MaxTokens)
+		require.Equal(t, rec.ReservedCost, gotRec.ReservedCost)
+	}
+}

--- a/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
+++ b/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
@@ -42,6 +42,26 @@ func (s *recordingStore) ranges() []diffRange {
 	return out
 }
 
+// obsCallStore counts the destructive obs rebuild entry point.
+type obsCallStore struct {
+	storage.Storage
+	mu     sync.Mutex
+	clears int
+}
+
+func (s *obsCallStore) ClearValidationObs(escrowID string) error {
+	s.mu.Lock()
+	s.clears++
+	s.mu.Unlock()
+	return s.Storage.ClearValidationObs(escrowID)
+}
+
+func (s *obsCallStore) clearCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.clears
+}
+
 type loadSnapshotErrStore struct {
 	storage.Storage
 	err error
@@ -163,8 +183,7 @@ func TestRecoverSessions_RestoresSnapshotAndReplaysOnlyTail(t *testing.T) {
 
 	require.Equal(t, []diffRange{
 		{7, 7},  // root check against the journal at the snapshot nonce
-		{8, 10}, // apply path fetches only post-snapshot diffs
-		{1, 10}, // obs rebuild still reads the journal
+		{8, 10}, // the tail is the only range read: obs tops up from it too
 	}, store.ranges())
 }
 
@@ -179,8 +198,8 @@ func TestRecoverSessions_SnapshotCurrentSkipsDiffApply(t *testing.T) {
 
 	got := recoveredHostState(t, mgr)
 	require.Equal(t, uint64(10), got.LatestNonce)
-	require.Equal(t, []diffRange{{10, 10}, {1, 10}}, store.ranges(),
-		"current snapshot applies nothing; only the root check and obs rebuild read diffs")
+	require.Equal(t, []diffRange{{10, 10}}, store.ranges(),
+		"a current snapshot reads one diff for the root check and nothing else")
 }
 
 func TestRecoverSessions_NoSnapshotReplaysFromOne(t *testing.T) {
@@ -302,6 +321,36 @@ func TestRecoverSessions_RejectedSnapshotDoesNotPoisonReplay(t *testing.T) {
 	require.Equal(t, want.LatestNonce, got.LatestNonce)
 	require.Equal(t, want.Balance, got.Balance)
 	require.Equal(t, want.SealedAcc, got.SealedAcc)
+}
+
+// Validation obs rows are written by the live apply path and are durable, so
+// the history a snapshot covers is already recorded. Clearing and rebuilding it
+// would delete good rows, re-read the whole journal, and pay a write
+// transaction per historical seal to rewrite what was already there.
+func TestRecoverSessions_SnapshotPathLeavesValidationObsAlone(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 10)
+	saveSnapshotThrough(t, inner, 7)
+
+	store := &obsCallStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	require.Zero(t, store.clearCalls(), "a restored snapshot must not clear durable obs rows")
+}
+
+// Replaying the whole journal is the one case that must rebuild: ApplyLocal
+// records no obs, and the clear-then-replay is what repairs batches the live
+// path dropped under backpressure.
+func TestRecoverSessions_FullReplayRebuildsValidationObs(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 10)
+
+	store := &obsCallStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	require.Equal(t, 1, store.clearCalls(), "full replay must rebuild obs from the journal")
 }
 
 func TestRecoverSessions_SnapshotMatchesFullReplayWithLiveInferences(t *testing.T) {

--- a/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
+++ b/devshard/cmd/devshardd/session/manager_snapshot_recovery_test.go
@@ -96,6 +96,26 @@ func saveSnapshotThrough(t *testing.T, store storage.Storage, through uint64) {
 	require.NoError(t, saveHostSnapshot(store, sm, "1", through))
 }
 
+// saveMismatchedSnapshot writes a decodable snapshot whose state is only
+// advanced to stateThrough while claiming to be at claimNonce, i.e. a blob that
+// decodes cleanly but does not reproduce the journal's root at its own nonce.
+func saveMismatchedSnapshot(t *testing.T, store storage.Storage, stateThrough, claimNonce uint64) {
+	t.Helper()
+	meta, err := store.GetSessionMeta("1")
+	require.NoError(t, err)
+	sm, err := state.NewStateMachine("1", meta.Config, meta.Group, meta.InitialBalance,
+		meta.CreatorAddr, signing.NewSecp256k1Verifier(), store,
+		state.WithVersion(testutil.RuntimeTestVersion))
+	require.NoError(t, err)
+	records, err := store.GetDiffs("1", 1, stateThrough)
+	require.NoError(t, err)
+	for _, rec := range records {
+		_, err := sm.ApplyLocal(rec.Nonce, rec.Txs)
+		require.NoError(t, err)
+	}
+	require.NoError(t, saveHostSnapshot(store, sm, "1", claimNonce))
+}
+
 func recoveredHostState(t *testing.T, mgr *HostManager) types.EscrowState {
 	t.Helper()
 	mgr.sessionsMutex.RLock()
@@ -141,10 +161,11 @@ func TestRecoverSessions_RestoresSnapshotAndReplaysOnlyTail(t *testing.T) {
 	require.Equal(t, want.Balance, got.Balance)
 	require.Equal(t, want.Phase, got.Phase)
 
-	calls := store.ranges()
-	require.NotEmpty(t, calls)
-	require.Equal(t, diffRange{8, 10}, calls[0], "apply path must fetch only post-snapshot diffs")
-	require.Equal(t, diffRange{1, 10}, calls[1], "obs rebuild still reads the journal")
+	require.Equal(t, []diffRange{
+		{7, 7},  // root check against the journal at the snapshot nonce
+		{8, 10}, // apply path fetches only post-snapshot diffs
+		{1, 10}, // obs rebuild still reads the journal
+	}, store.ranges())
 }
 
 func TestRecoverSessions_SnapshotCurrentSkipsDiffApply(t *testing.T) {
@@ -158,7 +179,8 @@ func TestRecoverSessions_SnapshotCurrentSkipsDiffApply(t *testing.T) {
 
 	got := recoveredHostState(t, mgr)
 	require.Equal(t, uint64(10), got.LatestNonce)
-	require.Equal(t, []diffRange{{1, 10}}, store.ranges(), "current snapshot applies nothing; obs still rebuilds from the journal")
+	require.Equal(t, []diffRange{{10, 10}, {1, 10}}, store.ranges(),
+		"current snapshot applies nothing; only the root check and obs rebuild read diffs")
 }
 
 func TestRecoverSessions_NoSnapshotReplaysFromOne(t *testing.T) {
@@ -240,6 +262,46 @@ func TestRecoverSessions_EmptySnapshotBlobReplaysFromOne(t *testing.T) {
 	require.NoError(t, mgr.RecoverSessions())
 	require.Equal(t, uint64(3), recoveredHostState(t, mgr).LatestNonce)
 	require.Equal(t, []diffRange{{1, 3}}, store.ranges())
+}
+
+// A snapshot is not self-authenticating and the store can be shared between
+// hosts, so a blob that does not reproduce the journal's root at its own nonce
+// must be discarded rather than trusted for nonces 1..N.
+func TestRecoverSessions_SnapshotRootMismatchReplaysFromOne(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 10)
+	saveMismatchedSnapshot(t, inner, 5, 7)
+
+	store := &recordingStore{Storage: inner}
+	mgr := recoverTestManager(t, store, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	require.Equal(t, []diffRange{{7, 7}, {1, 10}}, store.ranges(),
+		"a rejected snapshot must fall back to a full replay")
+
+	got := recoveredHostState(t, mgr)
+	want := fullReplayState(t, inner)
+	require.Equal(t, want.LatestNonce, got.LatestNonce)
+	require.Equal(t, want.Balance, got.Balance)
+	require.Equal(t, want.Phase, got.Phase)
+	require.Equal(t, len(want.Inferences), len(got.Inferences))
+}
+
+// The rejected snapshot's partial state must not leak into the replay: a state
+// machine that was already restored is thrown away, not replayed on top of.
+func TestRecoverSessions_RejectedSnapshotDoesNotPoisonReplay(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 8)
+	saveMismatchedSnapshot(t, inner, 3, 6)
+
+	mgr := recoverTestManager(t, inner, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+
+	got := recoveredHostState(t, mgr)
+	want := fullReplayState(t, inner)
+	require.Equal(t, want.LatestNonce, got.LatestNonce)
+	require.Equal(t, want.Balance, got.Balance)
+	require.Equal(t, want.SealedAcc, got.SealedAcc)
 }
 
 func TestRecoverSessions_SnapshotMatchesFullReplayWithLiveInferences(t *testing.T) {

--- a/devshard/cmd/devshardd/session/manager_stale_nonce_test.go
+++ b/devshard/cmd/devshardd/session/manager_stale_nonce_test.go
@@ -1,0 +1,83 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/signing"
+	"devshard/state"
+	"devshard/storage"
+	"devshard/types"
+)
+
+func appendStoreAhead(t *testing.T, store storage.Storage, user *signing.Secp256k1Signer) uint64 {
+	t.Helper()
+	meta, err := store.GetSessionMeta("1")
+	require.NoError(t, err)
+	sm, err := state.NewStateMachine("1", meta.Config, meta.Group, meta.InitialBalance,
+		meta.CreatorAddr, signing.NewSecp256k1Verifier(), store,
+		state.WithVersion(meta.Version))
+	require.NoError(t, err)
+	if meta.LatestNonce > 0 {
+		records, err := store.GetDiffs("1", 1, meta.LatestNonce)
+		require.NoError(t, err)
+		for _, rec := range records {
+			_, err := sm.ApplyLocal(rec.Nonce, rec.Txs)
+			require.NoError(t, err)
+		}
+	}
+	next := meta.LatestNonce + 1
+	txs := []*types.DevshardTx{startTx(next)}
+	root, err := sm.ApplyLocal(next, txs)
+	require.NoError(t, err)
+	require.NoError(t, store.AppendDiff("1", types.DiffRecord{
+		Diff:      signDiffWithRoot(t, user, "1", next, txs, root),
+		StateHash: root,
+	}))
+	return next
+}
+
+func TestReloadStaleSession_CatchesUpToStoreAhead(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 5)
+	mgr := recoverTestManager(t, inner, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+	mgr.WaitRecoveryRepairs()
+
+	stale, ok := mgr.existingServer("1")
+	require.True(t, ok)
+	require.Equal(t, uint64(5), stale.Host().LatestNonce())
+
+	want := appendStoreAhead(t, inner, user)
+	next, err := mgr.ReloadStaleSession("1", stale)
+	require.NoError(t, err)
+	require.Equal(t, want, next.Host().LatestNonce())
+	live, ok := mgr.existingServer("1")
+	require.True(t, ok)
+	require.Equal(t, next, live)
+	require.NotEqual(t, stale, live)
+}
+
+func TestReloadStaleSession_NegativeCachesBogusNonce(t *testing.T) {
+	inner := newManagerTestStore(t)
+	group, user, hostSigner := populateStore(t, inner, 3)
+	mgr := recoverTestManager(t, inner, hostSigner, user, group)
+	require.NoError(t, mgr.RecoverSessions())
+	mgr.WaitRecoveryRepairs()
+
+	stale, ok := mgr.existingServer("1")
+	require.True(t, ok)
+	mgr.RememberStaleNonce("1")
+
+	_, err := mgr.ReloadStaleSession("1", stale)
+	require.ErrorIs(t, err, types.ErrInvalidNonce)
+
+	live, ok := mgr.existingServer("1")
+	require.True(t, ok)
+	require.Equal(t, stale, live, "a cached mismatch must not evict the live session")
+	require.Equal(t, uint64(3), live.Host().LatestNonce())
+
+	_, err = mgr.ReloadStaleSession("1", stale)
+	require.ErrorIs(t, err, types.ErrInvalidNonce)
+}

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -316,7 +316,7 @@ func TestRecoverStoredSession_RejectsSettledStatus(t *testing.T) {
 	require.NoError(t, store.MarkSettled("1"))
 
 	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
-	_, err := mgr.recoverStoredSession("1")
+	_, _, err := mgr.recoverStoredSession("1")
 	require.ErrorIs(t, err, storage.ErrSessionNotActive)
 }
 

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 
 	"devshard/bridge"
+	"devshard/internal/testutil"
 	"devshard/signing"
 	"devshard/state"
 	"devshard/storage"
 	"devshard/stub"
-	"devshard/internal/testutil"
 	"devshard/types"
 	"google.golang.org/protobuf/proto"
 )
@@ -102,11 +102,11 @@ func newManagerTestStore(t *testing.T) *storage.SQLite {
 	return db
 }
 
-// waitObsRepairsOnCleanup keeps a full-replay recovery from racing t.TempDir:
+// waitRecoveryRepairsOnCleanup keeps a full-replay recovery from racing t.TempDir:
 // startObsRepair still holds the SQLite WAL after RecoverSessions returns.
-func waitObsRepairsOnCleanup(t *testing.T, mgr *HostManager) *HostManager {
+func waitRecoveryRepairsOnCleanup(t *testing.T, mgr *HostManager) *HostManager {
 	t.Helper()
-	t.Cleanup(mgr.WaitObsRepairs)
+	t.Cleanup(mgr.WaitRecoveryRepairs)
 	return mgr
 }
 
@@ -171,7 +171,7 @@ func TestRecoverSessions_HappyPath(t *testing.T) {
 		},
 	}
 
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	err := mgr.RecoverSessions()
 	require.NoError(t, err)
 
@@ -216,7 +216,7 @@ func TestRecoverSessions_Nonce0(t *testing.T) {
 		},
 	}
 
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	err := mgr.RecoverSessions()
 	require.NoError(t, err)
 
@@ -255,7 +255,7 @@ func TestCreateSession_BindsConfiguredVersion(t *testing.T) {
 	}
 
 	const standaloneVersion = "v0.2.11"
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, standaloneVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, standaloneVersion, br, nil, nil))
 	_, err := mgr.getOrCreate("1", nil)
 	require.NoError(t, err)
 
@@ -269,7 +269,7 @@ func TestRecoverSessions_EmptyStore(t *testing.T) {
 	signer := mustGenerateKey(t)
 	br := &mockBridge{}
 
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, signer, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, signer, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	err := mgr.RecoverSessions()
 	require.NoError(t, err)
 
@@ -296,7 +296,7 @@ func TestHandleSettlementFinalized_DoesNotResurrect(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	require.NoError(t, mgr.RecoverSessions())
 	_, ok := mgr.existingServer("1")
 	require.True(t, ok, "precondition: session live after recover")
@@ -323,7 +323,7 @@ func TestRecoverStoredSession_RejectsSettledStatus(t *testing.T) {
 	_, _, hostSigner := createStoredSession(t, store, "1", 7, 1)
 	require.NoError(t, store.MarkSettled("1"))
 
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 	_, _, err := mgr.recoverStoredSession("1")
 	require.ErrorIs(t, err, storage.ErrSessionNotActive)
 }
@@ -379,7 +379,7 @@ func TestRecoverSessions_StateRootMismatch(t *testing.T) {
 		},
 	}
 
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, mustGenerateKey(t), stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, mustGenerateKey(t), stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	err = mgr.RecoverSessions()
 	require.NoError(t, err)
 

--- a/devshard/cmd/devshardd/session/manager_test.go
+++ b/devshard/cmd/devshardd/session/manager_test.go
@@ -102,6 +102,14 @@ func newManagerTestStore(t *testing.T) *storage.SQLite {
 	return db
 }
 
+// waitObsRepairsOnCleanup keeps a full-replay recovery from racing t.TempDir:
+// startObsRepair still holds the SQLite WAL after RecoverSessions returns.
+func waitObsRepairsOnCleanup(t *testing.T, mgr *HostManager) *HostManager {
+	t.Helper()
+	t.Cleanup(mgr.WaitObsRepairs)
+	return mgr
+}
+
 // populateStore creates a session and appends diffs. Returns group, user signer,
 // and the first host signer (for use as HostManager signer -- must be in group).
 func populateStore(t *testing.T, store storage.Storage, numDiffs int) ([]types.SlotAssignment, *signing.Secp256k1Signer, *signing.Secp256k1Signer) {
@@ -163,7 +171,7 @@ func TestRecoverSessions_HappyPath(t *testing.T) {
 		},
 	}
 
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	err := mgr.RecoverSessions()
 	require.NoError(t, err)
 
@@ -208,7 +216,7 @@ func TestRecoverSessions_Nonce0(t *testing.T) {
 		},
 	}
 
-	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	err := mgr.RecoverSessions()
 	require.NoError(t, err)
 
@@ -247,7 +255,7 @@ func TestCreateSession_BindsConfiguredVersion(t *testing.T) {
 	}
 
 	const standaloneVersion = "v0.2.11"
-	mgr := NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, standaloneVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hosts[0], stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, standaloneVersion, br, nil, nil))
 	_, err := mgr.getOrCreate("1", nil)
 	require.NoError(t, err)
 
@@ -261,7 +269,7 @@ func TestRecoverSessions_EmptyStore(t *testing.T) {
 	signer := mustGenerateKey(t)
 	br := &mockBridge{}
 
-	mgr := NewHostManager(store, signer, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, signer, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	err := mgr.RecoverSessions()
 	require.NoError(t, err)
 
@@ -288,7 +296,7 @@ func TestHandleSettlementFinalized_DoesNotResurrect(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	require.NoError(t, mgr.RecoverSessions())
 	_, ok := mgr.existingServer("1")
 	require.True(t, ok, "precondition: session live after recover")
@@ -315,7 +323,7 @@ func TestRecoverStoredSession_RejectsSettledStatus(t *testing.T) {
 	_, _, hostSigner := createStoredSession(t, store, "1", 7, 1)
 	require.NoError(t, store.MarkSettled("1"))
 
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 	_, _, err := mgr.recoverStoredSession("1")
 	require.ErrorIs(t, err, storage.ErrSessionNotActive)
 }
@@ -371,7 +379,7 @@ func TestRecoverSessions_StateRootMismatch(t *testing.T) {
 		},
 	}
 
-	mgr := NewHostManager(store, mustGenerateKey(t), stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, mustGenerateKey(t), stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	err = mgr.RecoverSessions()
 	require.NoError(t, err)
 

--- a/devshard/cmd/devshardd/session/stats_test.go
+++ b/devshard/cmd/devshardd/session/stats_test.go
@@ -113,7 +113,7 @@ func TestStatsShardsListsNonPrunedActiveWithoutDetails(t *testing.T) {
 	createStoredSession(t, base, "escrow-old", 6, 0)
 
 	counting := &countingListStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 	mgr.SetBinaryVersion("0.2.14-v4-r2")
 
 	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards")
@@ -160,7 +160,7 @@ func TestStatsShardsSkipsForeignVersionSessions(t *testing.T) {
 	createStoredSessionWithVersion(t, base, "escrow-v2", 7, "foreign", 0)
 
 	store := currentEpochStore{Storage: base, epoch: 7}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec := requestStats(t, mgr, "/v1/devshard", "/stats/shards")
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
@@ -179,7 +179,7 @@ func TestStatsShardsSkipsSessionsWithUnreadableMeta(t *testing.T) {
 		escrowID:  "escrow-bad-meta",
 		metaError: storage.ErrSessionNotFound,
 	}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards")
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
@@ -204,7 +204,7 @@ func TestStatsShardDetailReturnsStatsOnly(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	mgr.SetBinaryVersion("0.2.14-v4")
 	require.NoError(t, mgr.RecoverSessions())
 
@@ -276,7 +276,7 @@ func TestStatsShardDetailServesPriorEpochSession(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	require.NoError(t, mgr.RecoverSessions())
 
 	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-prior")
@@ -298,7 +298,7 @@ func TestStatsShardDetailSkipsForeignVersionSession(t *testing.T) {
 	_, _, hostSigner := createStoredSessionWithVersion(t, base, "escrow-v2", 7, "foreign", 0)
 
 	store := currentEpochStore{Storage: base, epoch: 7}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec := requestStats(t, mgr, "/v1/devshard", "/stats/shards/escrow-v2")
 	require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
@@ -342,7 +342,7 @@ func TestStatsShardDetailResolvesO1WithoutListScan(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	require.NoError(t, mgr.RecoverSessions())
 	counting.metaCalls.Store(0)
 	counting.listCalls.Store(0)
@@ -357,7 +357,7 @@ func TestStatsShardDetailNegativeCacheSkipsStoreOnRepeatMiss(t *testing.T) {
 	base := newManagerTestStore(t)
 	_, _, hostSigner := createStoredSession(t, base, "escrow-other", 7, 0)
 	counting := &countingMetaStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/missing-escrow")
 	require.Equal(t, http.StatusNotFound, rec1.Code, "body: %s", rec1.Body.String())
@@ -374,7 +374,7 @@ func TestStatsShardDetailNegativeCacheForVersionMismatch(t *testing.T) {
 	base := newManagerTestStore(t)
 	_, _, hostSigner := createStoredSessionWithVersion(t, base, "escrow-foreign", 7, "foreign", 0)
 	counting := &countingMetaStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-foreign")
 	require.Equal(t, http.StatusNotFound, rec1.Code)
@@ -392,7 +392,7 @@ func TestStatsShardDetailSkipsSettledSession(t *testing.T) {
 	require.NoError(t, base.MarkSettled("escrow-settled"))
 
 	counting := &countingMetaStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
-	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
+	mgr := waitRecoveryRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-settled")
 	require.Equal(t, http.StatusNotFound, rec1.Code, "body: %s", rec1.Body.String())

--- a/devshard/cmd/devshardd/session/stats_test.go
+++ b/devshard/cmd/devshardd/session/stats_test.go
@@ -113,7 +113,7 @@ func TestStatsShardsListsNonPrunedActiveWithoutDetails(t *testing.T) {
 	createStoredSession(t, base, "escrow-old", 6, 0)
 
 	counting := &countingListStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
-	mgr := NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 	mgr.SetBinaryVersion("0.2.14-v4-r2")
 
 	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards")
@@ -160,7 +160,7 @@ func TestStatsShardsSkipsForeignVersionSessions(t *testing.T) {
 	createStoredSessionWithVersion(t, base, "escrow-v2", 7, "foreign", 0)
 
 	store := currentEpochStore{Storage: base, epoch: 7}
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec := requestStats(t, mgr, "/v1/devshard", "/stats/shards")
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
@@ -179,7 +179,7 @@ func TestStatsShardsSkipsSessionsWithUnreadableMeta(t *testing.T) {
 		escrowID:  "escrow-bad-meta",
 		metaError: storage.ErrSessionNotFound,
 	}
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards")
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
@@ -204,7 +204,7 @@ func TestStatsShardDetailReturnsStatsOnly(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	mgr.SetBinaryVersion("0.2.14-v4")
 	require.NoError(t, mgr.RecoverSessions())
 
@@ -276,7 +276,7 @@ func TestStatsShardDetailServesPriorEpochSession(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	require.NoError(t, mgr.RecoverSessions())
 
 	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-prior")
@@ -298,7 +298,7 @@ func TestStatsShardDetailSkipsForeignVersionSession(t *testing.T) {
 	_, _, hostSigner := createStoredSessionWithVersion(t, base, "escrow-v2", 7, "foreign", 0)
 
 	store := currentEpochStore{Storage: base, epoch: 7}
-	mgr := NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(store, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec := requestStats(t, mgr, "/v1/devshard", "/stats/shards/escrow-v2")
 	require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
@@ -342,7 +342,7 @@ func TestStatsShardDetailResolvesO1WithoutListScan(t *testing.T) {
 			Slots:          addresses,
 		},
 	}
-	mgr := NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil))
 	require.NoError(t, mgr.RecoverSessions())
 	counting.metaCalls.Store(0)
 	counting.listCalls.Store(0)
@@ -357,7 +357,7 @@ func TestStatsShardDetailNegativeCacheSkipsStoreOnRepeatMiss(t *testing.T) {
 	base := newManagerTestStore(t)
 	_, _, hostSigner := createStoredSession(t, base, "escrow-other", 7, 0)
 	counting := &countingMetaStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
-	mgr := NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/missing-escrow")
 	require.Equal(t, http.StatusNotFound, rec1.Code, "body: %s", rec1.Body.String())
@@ -374,7 +374,7 @@ func TestStatsShardDetailNegativeCacheForVersionMismatch(t *testing.T) {
 	base := newManagerTestStore(t)
 	_, _, hostSigner := createStoredSessionWithVersion(t, base, "escrow-foreign", 7, "foreign", 0)
 	counting := &countingMetaStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
-	mgr := NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-foreign")
 	require.Equal(t, http.StatusNotFound, rec1.Code)
@@ -392,7 +392,7 @@ func TestStatsShardDetailSkipsSettledSession(t *testing.T) {
 	require.NoError(t, base.MarkSettled("escrow-settled"))
 
 	counting := &countingMetaStore{Storage: currentEpochStore{Storage: base, epoch: 7}}
-	mgr := NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil)
+	mgr := waitObsRepairsOnCleanup(t, NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, &mockBridge{}, nil, nil))
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-settled")
 	require.Equal(t, http.StatusNotFound, rec1.Code, "body: %s", rec1.Body.String())

--- a/devshard/cmd/devshardd/session/stats_test.go
+++ b/devshard/cmd/devshardd/session/stats_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -45,11 +46,11 @@ func (s metaErrorStore) GetSessionMeta(escrowID string) (*storage.SessionMeta, e
 
 type countingListStore struct {
 	storage.Storage
-	listCalls int
+	listCalls atomic.Int64
 }
 
 func (s *countingListStore) ListActiveSessions() ([]storage.ActiveSession, error) {
-	s.listCalls++
+	s.listCalls.Add(1)
 	return s.Storage.ListActiveSessions()
 }
 
@@ -147,7 +148,7 @@ func TestStatsShardsListsNonPrunedActiveWithoutDetails(t *testing.T) {
 	cached := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards")
 	require.Equal(t, http.StatusOK, cached.Code, "body: %s", cached.Body.String())
 	require.Equal(t, rec.Body.String(), cached.Body.String())
-	require.Equal(t, 1, counting.listCalls)
+	require.Equal(t, int64(1), counting.listCalls.Load())
 
 	rootMounted := requestStats(t, mgr, "", "/stats/shards")
 	require.Equal(t, http.StatusOK, rootMounted.Code, "body: %s", rootMounted.Body.String())
@@ -303,19 +304,21 @@ func TestStatsShardDetailSkipsForeignVersionSession(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
 }
 
+// Counters are atomic because session recovery calls the store from several
+// workers at once.
 type countingMetaStore struct {
 	storage.Storage
-	metaCalls int
-	listCalls int
+	metaCalls atomic.Int64
+	listCalls atomic.Int64
 }
 
 func (s *countingMetaStore) GetSessionMeta(escrowID string) (*storage.SessionMeta, error) {
-	s.metaCalls++
+	s.metaCalls.Add(1)
 	return s.Storage.GetSessionMeta(escrowID)
 }
 
 func (s *countingMetaStore) ListActiveSessions() ([]storage.ActiveSession, error) {
-	s.listCalls++
+	s.listCalls.Add(1)
 	return s.Storage.ListActiveSessions()
 }
 
@@ -341,13 +344,13 @@ func TestStatsShardDetailResolvesO1WithoutListScan(t *testing.T) {
 	}
 	mgr := NewHostManager(counting, hostSigner, stub.NewInferenceEngine(), stub.NewValidationEngine(), nil, testutil.RuntimeTestVersion, br, nil, nil)
 	require.NoError(t, mgr.RecoverSessions())
-	counting.metaCalls = 0
-	counting.listCalls = 0
+	counting.metaCalls.Store(0)
+	counting.listCalls.Store(0)
 
 	rec := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-o1")
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
-	require.Equal(t, 0, counting.listCalls, "detail must not ListActiveSessions")
-	require.Equal(t, 1, counting.metaCalls, "detail should GetSessionMeta once")
+	require.Equal(t, int64(0), counting.listCalls.Load(), "detail must not ListActiveSessions")
+	require.Equal(t, int64(1), counting.metaCalls.Load(), "detail should GetSessionMeta once")
 }
 
 func TestStatsShardDetailNegativeCacheSkipsStoreOnRepeatMiss(t *testing.T) {
@@ -358,13 +361,13 @@ func TestStatsShardDetailNegativeCacheSkipsStoreOnRepeatMiss(t *testing.T) {
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/missing-escrow")
 	require.Equal(t, http.StatusNotFound, rec1.Code, "body: %s", rec1.Body.String())
-	require.Equal(t, 0, counting.listCalls)
-	require.Equal(t, 1, counting.metaCalls)
+	require.Equal(t, int64(0), counting.listCalls.Load())
+	require.Equal(t, int64(1), counting.metaCalls.Load())
 
 	rec2 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/missing-escrow")
 	require.Equal(t, http.StatusNotFound, rec2.Code, "body: %s", rec2.Body.String())
-	require.Equal(t, 0, counting.listCalls)
-	require.Equal(t, 1, counting.metaCalls, "negative cache must skip GetSessionMeta on repeat miss")
+	require.Equal(t, int64(0), counting.listCalls.Load())
+	require.Equal(t, int64(1), counting.metaCalls.Load(), "negative cache must skip GetSessionMeta on repeat miss")
 }
 
 func TestStatsShardDetailNegativeCacheForVersionMismatch(t *testing.T) {
@@ -375,12 +378,12 @@ func TestStatsShardDetailNegativeCacheForVersionMismatch(t *testing.T) {
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-foreign")
 	require.Equal(t, http.StatusNotFound, rec1.Code)
-	require.Equal(t, 1, counting.metaCalls)
-	require.Equal(t, 0, counting.listCalls)
+	require.Equal(t, int64(1), counting.metaCalls.Load())
+	require.Equal(t, int64(0), counting.listCalls.Load())
 
 	rec2 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-foreign")
 	require.Equal(t, http.StatusNotFound, rec2.Code)
-	require.Equal(t, 1, counting.metaCalls, "version mismatch should be negatively cached")
+	require.Equal(t, int64(1), counting.metaCalls.Load(), "version mismatch should be negatively cached")
 }
 
 func TestStatsShardDetailSkipsSettledSession(t *testing.T) {
@@ -393,8 +396,8 @@ func TestStatsShardDetailSkipsSettledSession(t *testing.T) {
 
 	rec1 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-settled")
 	require.Equal(t, http.StatusNotFound, rec1.Code, "body: %s", rec1.Body.String())
-	require.Equal(t, 1, counting.metaCalls)
-	require.Equal(t, 0, counting.listCalls)
+	require.Equal(t, int64(1), counting.metaCalls.Load())
+	require.Equal(t, int64(0), counting.listCalls.Load())
 
 	// Settled must not be revived into the live session map.
 	_, ok := mgr.existingServer("escrow-settled")
@@ -402,5 +405,5 @@ func TestStatsShardDetailSkipsSettledSession(t *testing.T) {
 
 	rec2 := requestStats(t, mgr, statsTestRoutePrefix, "/stats/shards/escrow-settled")
 	require.Equal(t, http.StatusNotFound, rec2.Code)
-	require.Equal(t, 1, counting.metaCalls, "settled miss should be negatively cached")
+	require.Equal(t, int64(1), counting.metaCalls.Load(), "settled miss should be negatively cached")
 }

--- a/devshard/docs/ready-on-boot-warm-cutover-plan.md
+++ b/devshard/docs/ready-on-boot-warm-cutover-plan.md
@@ -1,0 +1,145 @@
+# Ready on boot, warm on cutover
+
+Companion to [sealed-inference-index-rebuild-plan.md](sealed-inference-index-rebuild-plan.md),
+which removes the per-escrow write storm this design would otherwise push onto
+the lazy-load request path.
+
+## Problem
+
+`devshardd` `/ready` currently answers 503 until session recovery finishes
+(`cmd/devshardd/server.go:39` includes `recovered` in the 503 condition). Versiond
+gates the `Starting → Running` transition on that probe with a 60s
+`VERSIOND_READY_TIMEOUT` (`versioned/internal/process/manager.go:169-170`), so a
+host with a long journal is force-stopped and restarted forever, never serving.
+
+The fix is to separate two different questions that one probe is answering today:
+
+- **Can this process serve?** Chain reachable, storage open, not draining. True
+  within seconds of boot.
+- **Is this process warm?** The recovery backlog is drained, so no request pays a
+  cold replay. Minutes to hours.
+
+Status code answers the first. A body field, `recovery_complete`, answers the
+second. Only one caller needs the second: a version replacement that has a
+healthy old generation to keep serving in the meantime.
+
+## Flows
+
+### A. v4 versiond, solo restart or boot
+
+Spawn → `waitForChildServingReady` sees admin `/ready` 200 immediately and public
+`/healthz` 2xx → `statusRunning`, `rebuildRoutes`, published. Traffic arrives;
+escrows lazy-load through `getOrCreate` with the demand priority queue from
+`7e704795f`. The 1s monitor keeps seeing 200.
+
+**This is the fix.** Today the child is killed at the 60s `ReadyTimeout`.
+
+### B. v4 versiond, version replacement (postgres overlap)
+
+Unchanged and cold. `waitForChildReady` returns as soon as `/ready` is 200
+(`manager.go:1020`), routes swap, old drains, every escrow lazy-loads after
+cutover.
+
+Accepted tradeoff: an un-updated versiond cannot know about the field, and per
+the staleness finding below, cold is the safe direction.
+
+### C. v5 versiond, solo restart or boot
+
+Same as A. Publish on status code; read `recovery_complete` only to log and
+export progress. No gate, because there is no warm generation to fall back on —
+waiting would just be an outage.
+
+### D. v5 versiond, version replacement (postgres overlap)
+
+New behaviour. After `waitForChildReady` returns and **before** the
+`m.processes` swap at `manager.go:1028-1055`, poll admin `/ready` and wait for
+`recovery_complete: true`.
+
+That window is already traffic-free: `runChild` calls `rebuildRoutes` only if
+`m.processes[name] == c` (`manager.go:1690`), and during overlap that is still
+the old child, so the new one is `Running` but unpublished. Then swap,
+`rebuildRoutes`, `drainAfterProxy(old)`.
+
+### Bail-outs
+
+All of these cut over or abort rather than hang:
+
+| Condition | Action |
+| --- | --- |
+| `recovery_complete` absent from the body | Skip the wait, cut over (old child, flow B semantics) |
+| Old child stops being `Running` | Abandon the wait and publish immediately — a warming-but-unpublished child plus a dead old child is an outage |
+| `hostDraining` or `ctx` done | Abort, stop the new child |
+| `VERSIOND_RECOVERY_TIMEOUT` elapsed | Abort, old keeps serving, retry next reconcile |
+
+## The staleness finding
+
+Pre-warming is only safe with a self-heal. During a long warm-up the old child
+keeps applying diffs to the shared store, so a session the new child recovered
+early is behind by the time it is published. The first request then fails with
+`types.ErrInvalidNonce` and there is no eviction path — the stale session stays
+resident.
+
+So the child-side eviction (workstream item 3 below) is **not optional**; without
+it, flow D is less safe than flow B.
+
+## Workstreams
+
+### Child (devshardd, this branch)
+
+1. `/ready`: drop `recovered` from the 503 condition; keep `recovery_complete` in
+   `readyStatus`.
+2. Promote the recovery counters from log-only to state and body:
+   `sessions_total`, `sessions_recovered`, `sessions_failed`,
+   `sessions_version_skipped`, `sessions_pending`. This is what makes "backlog
+   drained with 3 failures" visible instead of indistinguishable from clean.
+3. Evict and re-recover on `types.ErrInvalidNonce`, reusing the existing
+   `resolutionFailures` negative-cache pattern so a genuinely bad client cannot
+   spin the reload.
+4. Prometheus gauge for recovery progress, so swap progress is observable
+   without parsing probe bodies.
+
+Tests: `/ready` 200 during recovery; 503 while draining and when storage is
+unready; body counters; nonce-mismatch eviction reloads and then succeeds;
+eviction is rate-limited.
+
+### Versiond (v5)
+
+1. Probe helper returning status plus `recoveryComplete *bool`. `getHTTPStatus`
+   (`manager.go:2059`) is status-only today.
+2. `VERSIOND_RECOVERY_TIMEOUT`, default 30m. Must not reuse the 60s
+   `ReadyTimeout`.
+3. The wait, in the overlap branch of `downloadAndSwap` only.
+4. The bail-outs from flow D.
+5. Gate applies only to devshard children with an admin port
+   (`devshardAdminEligible` plus a non-zero admin port).
+6. `watchChildReadiness` untouched, pinned by a test that it never consults the
+   body — if recovery ever gates the monitor, the host leaves the HAProxy pool
+   for the whole backlog.
+
+Tests: overlap waits then cuts over; absent field skips; old-child death
+abandons the wait; timeout aborts with the old child still routed; solo start and
+the stop/start branch never wait.
+
+### Docs
+
+`rolling-update.md` §1.3 probe table and the swap section; v4 release notes. The
+rule changes from "new ready before traffic" to "new warm before traffic,
+overlap only".
+
+## Sequencing
+
+1. Child items 1 and 3 together — item 1 alone makes flow A work but exposes
+   flow D to staleness, and item 3 is the mitigation.
+2. Sealed-inference gap fill (companion doc, steps 1–3) — otherwise every
+   lazy-loaded escrow pays ~1.5M writes on a request goroutine.
+3. Child items 2 and 4, the observability half.
+4. Versiond items, which are useless until the child ships the field.
+
+## Out of scope
+
+- Returning `503 Retry-After` instead of blocking on singleflight for a first
+  request to an unrecovered escrow. A client-contract decision, tracked
+  separately.
+- Old versiond against a new child: accepted cold cutover (flow B).
+- Repairing validation obs for an escrow booted from a snapshot whose obs rows
+  are empty. Pre-existing.

--- a/devshard/docs/restore-host-loadsnapshot.md
+++ b/devshard/docs/restore-host-loadsnapshot.md
@@ -1,0 +1,257 @@
+## Problem
+
+v4 `devshardd` dropped two pieces of the v3 host recovery path when `HostManager.recoverStoredSession` moved into the standalone binary (`b53fd8fcd`):
+
+1. It no longer called `LoadSnapshot`. Every restart replayed diffs from nonce 1.
+2. Recovery ran on a single worker, inline, before the HTTP listener bound.
+
+On a host with a long journal that produced hours of catch-up, `/ready` stayed false, the parent answered 502, and live traffic never reached the child. Logs of the failing window show no snapshot restore lines and a serial `recovered devshard session` trail that lasted for hours.
+
+A third defect sat on the same path: snapshot recovery wiped sealed-inference stats (`RebuildSealedInferenceIndex` deleted every row and reinserted a bare one), so a restart that should have been a tail catch-up also paid one unbatched insert per sealed id and dropped `ObsPresent` columns.
+
+## Decisions
+
+These are the design calls that hold across the fifteen commits. Each later commit is a refinement of one of them, not a reversal — except `/ready`, which commit 3 gated on recovery and commit 15 split into status vs body once the wipe was off the lazy-load path.
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Snapshot load | Restore v3 `LoadSnapshot` on the v4 host recovery path. Decode/load failure falls back to a full journal replay. | A snapshot at nonce N skips diffs `1..N`. That is the difference between a tail catch-up and hours of replay. |
+| Snapshot integrity | After restore, verify the snapshot root against the journal diff at nonce N. On mismatch, throw the restored SM away and replay from 1. | Diff replay already checks every nonce it applies. The snapshot path used to trust the blob outright, including on a store v4 can share between hosts. |
+| Recovery concurrency | 8 workers, same as v3. | Snapshots alone are not enough on a host with many sessions: serial recovery still blocks listen. |
+| Bind vs recover | Bind the listener first. Recover in the background. A session a live caller needs is recovered on demand by `getOrCreate` instead of waiting out the backlog. | Removes the 502 window. |
+| `/ready` status vs body | Status 200 = can serve (chain up, storage open, not draining). Body `recovery_complete` = warm (backlog drained **and** background repairs finished). | Commit 3 gated 503 on recovery so versiond would not publish a cold child. Once snapshot recovery stopped wiping stats, 503-until-recovered became the outage: versiond's 60s ready timeout killed the child before it ever served. Status is flow A (solo boot). The body field is flow D (overlap cutover with a healthy old generation). |
+| Demand vs cold backlog | Remember every escrow that reaches `getOrCreate` for the rest of the recovery window and dequeue those first. Only workers picking up a **cold** session park. A parked worker resumes as soon as its own escrow is demanded. A fully demanded backlog never pauses. | The first non-blocking version parked **every** worker whenever a request was in flight, including workers already recovering the session the caller wanted. |
+| Stale in-memory session | On `types.ErrInvalidNonce` from apply, evict the live session, recover it again, retry the handler once. A mismatch that survives the reload is negative-cached at the short TTL (`resolutionFailureTTL`), not `permanentFailureTTL`. | During overlap the old generation keeps writing the shared store. A session the new child recovered early is behind by publish time. Without eviction, flow D is worse than a cold cutover. |
+| Validation obs, snapshot path | Do **not** rebuild. Live apply already wrote durable rows for every nonce the snapshot covers. | Rebuilding on this path re-read the whole journal and paid one write transaction per historical seal to rewrite rows that were already correct. |
+| Validation obs, full replay | Must rebuild. `ApplyLocal` records no obs, and the clear-then-replay is the self-heal for batches the live path dropped under backpressure. | This is the only path that needs the rebuild. |
+| Incremental / partial-range rebuild | Rejected. | `DrainInferenceValidationObs` deletes the live row `RecordValidationsAppliedOnce` dedups against. Replaying a tail twice double-counts. A storage test pins this. |
+| Validation obs, scheduling | End restoration without filling obs. Run the rebuild in the background after the session is published. Queue concurrent obs writes for that escrow and apply them after the rebuild. | Inline rebuild was the expensive half of recovery (a write txn per historical seal) and a cold bind waited it out. Queueing is equivalent to sequential execution because the rebuild covers `1..N` and live diffs during the window are past `N`. |
+| Why queueing is safe | Obs writes are already best-effort. Recording is dropped under backpressure. The persist-first path (`ValidateDiff` → `CommitValidated`) already defers drains via `deferredObsWrite` and logs failures rather than failing a commit. | An earlier objection that seal drains were fail-closed was wrong for the production path. |
+| Gate bounds | Queue cap 8192 ops (drop newest, report). Flush cap 64 rounds, then close and apply the remainder write-through. Concurrent repairs for one escrow are rejected. | A continuously busy escrow must not hold the gate open forever. Overflow matches the live path, which already drops obs under backpressure. |
+| Sealed-inference index, snapshot path | Gap fill only. List existing ids, insert a bare row for each sealed id that is missing, never delete, never downgrade `ObsPresent = true`. | The stored rows are durable and the restored state is root-verified. The wipe-rebuild dropped stats and wrote O(sealed) on every restart, including the path that should write nothing. |
+| Sealed-inference index, full replay | Wipe is defensible (divergent history). Rebuild from the journal inside the same `ObsRepairGate` window as validation obs, after the session is published. | Same scheduling argument as obs: the session must be live before the expensive half runs. |
+| Batching | Chunk the transaction **and** the statement. Postgres: one `unnest` upsert per 500-row chunk. SQLite: prepare the upsert once per chunk. Drain: set-at-a-time, not one txn per id. Record: 500-entry writes. | Chunking the transaction bought Postgres nothing (~3058ms vs ~3006ms at 20k): it pays per round trip, not per commit. One statement per row was the remaining cost. |
+| Post-wipe load | `BulkInsertSealedInferences`: Postgres `COPY`, no per-row conflict probe, fallback to the upsert on unique violation. SQLite keeps the batched upsert (in-process b-tree, not a round trip). Drain: one data-modifying CTE instead of `INSERT`+`DELETE` in an explicit transaction. | The full-replay rebuild has just wiped the escrow, so inserts cannot conflict. The leftover ~99ms/20k on the upsert was the conflict probe, not the protocol. `COPY` is ~30ms; the CTE drain is ~58ms from ~81ms. |
+| Shutdown | `WaitRecoveryRepairs` is a closer (renamed from `WaitObsRepairs`). | A rebuild interrupted after its clear leaves the counters empty, and recovery will not retry once a snapshot exists. The waiter now covers both validation obs and the sealed-inference index. |
+| Warm signal | `recovery_complete` is true only after the backlog drains **and** `WaitRecoveryRepairs` returns. Promote the log-only counters onto the `/ready` body and `devshardd_session_recovery`. | A full-replay child is published long before its sealed-inference index is rebuilt. Declaring that warm would route overlap traffic at a host mid-wipe. |
+
+## Out of scope (deliberate)
+
+- An escrow recovered from a snapshot whose obs is genuinely empty still never gets repaired. The cheap fix is rebuilding when `GetValidationObservability` comes back empty.
+- While a rebuild runs, `/stats` under-reports for that escrow (tables are cleared and refilling). Nothing outside stats reads them.
+- Blocking versus `503 Retry-After` for a first request to an unrecovered escrow; that is a client-contract decision.
+- Versiond overlap wait on `recovery_complete` (companion plan Step 9). That is a v5 `versiond` change and is useless until this child ships the field and the eviction.
+- Rolling-update docs stay on the old probe contract until that versiond wait lands.
+
+---
+
+## Commits
+
+### 1. `3d25e29f5` — `fix(devshard): restore host snapshot load on v4 session recovery`
+
+**Decision.** Put `LoadSnapshot` back on the v4 host recovery path, matching v3 `RecoverSession`. On decode or load failure, fall back to a full journal replay rather than failing the session.
+
+**Changed.**
+
+- `recoverStoredSession` loads a host snapshot when `snapNonce > 0 && snapNonce <= meta.LatestNonce`, restores SM / committed entries / sealed nonces, then replays only `snapNonce+1..latest`.
+- After a successful (or full) replay, save a recovery snapshot when the replay was from 1 or the tail was at least `SnapshotInterval`.
+- Tests in `manager_snapshot_recovery_test.go`: restore + tail replay, current snapshot skips apply, empty blob and load error fall back to nonce 1.
+
+### 2. `0d4c965c2` — `fix(devshard): restore 8-worker session recovery on v4`
+
+**Decision.** Recovery concurrency is independent of snapshot load. Restore v3's 8-worker pool so a large host does not recover sessions one at a time.
+
+**Changed.**
+
+- `RecoverSessions` fans work across `recoverSessionsConcurrency` (8) workers, capped at the session count.
+- Per-session recover/fail/version-skip counters and logs.
+- Tests in `manager_recovery_workers_test.go`: parallel recovery, worker cap, version-conflict skip.
+
+### 3. `a13ea92de` — `fix(devshard): unblock bind during recovery and verify restored snapshots`
+
+**Decisions.**
+
+1. Bind first, recover in the background. A live `getOrCreate` recovers the requested session immediately instead of queueing behind the backlog.
+2. After restoring a snapshot, verify its root against the journal diff at that nonce. On mismatch, recreate the SM and replay from 1. Diff replay already checks every nonce it applies; the snapshot path must not skip `1..N`.
+3. Gate `/ready` 503 on `RecoveryComplete` (revised in commit 15 once the wipe was off the request path).
+
+**Changed.**
+
+- `StartRecovery` / `RecoveryComplete` / `RecoverSessionsContext` (cancellable).
+- First-cut `recoveryGate`: park workers while a request is in flight (refined in commit 4).
+- `app.go` starts recovery as a closer after `store.Start()`, so the listener binds immediately.
+- `buildAdminServer` takes `recoveryComplete`; `/ready` stays 503 until the backlog drains (until commit 15).
+- `verifySnapshotRoot` in `recoverStoredSession`.
+- Tests: `/ready` reflects recovery progress; snapshot root mismatch replays from 1.
+
+### 4. `7e704795f` — `fix(devshard): order recovery backlog by demand instead of parking all workers`
+
+**Decision.** The gate in commit 3 paused every worker whenever *any* request was in flight, including workers recovering the session the caller wanted. Replace that with a demand-ordered queue:
+
+- Sticky marker: an escrow that hits `getOrCreate` stays prioritized for the rest of the recovery window.
+- Workers dequeue demanded sessions first.
+- Only a worker about to pick up a **cold** session parks.
+- A parked worker whose escrow becomes demanded resumes.
+- If every remaining session is demanded, nobody parks.
+
+**Changed.**
+
+- `recoveryGate` + `recoveryQueue` in `manager.go`.
+- Priority tests: parking, preemption, promotion, boundedness, sticky marker, mid-drain reordering, end-to-end concurrent demand.
+- `countingMetaStore` counters in `stats_test.go` made atomic: concurrent recovery races them once workers are no longer serialized by the old channel handoff.
+
+### 5. `c09f15ec4` — `perf(devshard): skip the obs rebuild when a snapshot covers the history`
+
+**Decisions.**
+
+- Snapshot path: skip obs rebuild. Rows for those nonces are already durable.
+- Full replay (`replayFrom == 1`): still rebuild. That is the self-heal.
+- Incremental / partial-range top-up: **not valid**. Drain deletes the dedup row, so a tail replayed twice double-counts. `TopUpValidationObsFromDiffs` and `SealedInferenceIDsSortedFrom` were removed after an idempotency test found this.
+
+**Changed.**
+
+- `recoverStoredSession` rebuilds obs only when `replayFrom == 1`.
+- `RebuildValidationObsFromDiffs` is explicitly clear-then-replay.
+- `TestRecordValidationsAppliedOnce_NotDedupedAfterDrain` pins the hazard.
+- Snapshot-path test asserts obs tables are not cleared.
+
+### 6. `3d2fd05d1` — `perf(devshard): rebuild validation obs in the background behind a write gate`
+
+**Decisions.**
+
+- End restoration without filling obs. Publish the session, then start a background repair with the journal already in hand and the seal set as of that journal's last nonce.
+- `ObsRepairGate` wraps the store. Idle = pass-through. During a repair for escrow E, `RecordValidationsAppliedOnce` and `DrainInferenceValidationObs` for E are queued in arrival order and applied after the rebuild writes to the inner store (so the rebuild cannot queue behind itself).
+- Rebuild covers `1..N`; live diffs during the window are past `N`; queued writes never overlap the rebuild range, so the drain/dedup hazard from commit 5 does not arise.
+- Queue 8192, drop newest, report. Flush 64 rounds then close. Concurrent repair for the same escrow rejected. Shutdown waits (`WaitObsRepairs`, renamed in commit 8).
+
+**Changed.**
+
+- New `storage/obs_repair_gate.go` (+ tests: idle transparency, rebuild bypasses queue, queued write survives the clear, record-then-drain order, per-escrow isolation, overflow, flush-after-rebuild-error, concurrent writers).
+- `HostManager` always wraps the store in the gate. `startObsRepair` / `WaitObsRepairs`.
+- `app.go` registers `WaitObsRepairs` as a closer.
+- Full-replay test asserts recovery returns before the rebuild finishes, then waits and checks the rebuild still ran.
+
+### 7. `9af175e43` — `fix(devshard): wait for obs repairs before test TempDir cleanup`
+
+**Decision.** A full-replay recovery returns before `startObsRepair` finishes. Tests that tear down with `t.TempDir` must wait, or the rebuild still holds the SQLite WAL when cleanup removes it.
+
+**Changed.**
+
+- `HostManager` teardown waits for repairs.
+- The held-rebuild test unblocks `release` if it fails before closing it.
+- CI failure of `TestRecoverSessions_LoadSnapshotErrorReplaysFromOne` was cleanup, not the recovery assertion.
+
+### 8. `b7596d472` — `fix(devshard): stop wiping sealed-inference stats on snapshot recovery`
+
+**Decisions.**
+
+- Snapshot path: gap fill only. Never delete, never downgrade a rich row. Normally writes nothing.
+- Full replay: wipe is defensible, but rebuild from the journal in the same background `ObsRepairGate` window as validation obs, in 500-row transactions, after the session is published.
+- Rename `WaitObsRepairs` → `WaitRecoveryRepairs`. `recovery_complete` still follows the backlog drain until commit 15.
+- Keep `RebuildSealedInferenceIndex` as a gap-fill wrapper so the v3 `user/recover.go` path stops losing stats without restructuring it.
+
+**Changed.**
+
+- `SealedInferenceIDs` / `InsertSealedInferences` on every backend. `ObsRepairGate` queues sealed-inference inserts during a repair.
+- `FillSealedInferenceIndexGaps` / `RebuildSealedInferenceIndexFromDiffs`.
+- `recoverStoredSession` picks by `replayFrom`.
+- Snapshot-path test: planted rich rows survive, `DeleteSealedInferences` is never called. Full-replay test: session published before the wipe, rich rows after `WaitRecoveryRepairs`. `TestStartRecovery_CompleteBeforeSealedIndexRepair` pins that `recovery_complete` still followed the backlog (flipped in commit 15).
+
+### 9. `021e5044b` — `perf(devshard): keep the sealed-index rebuilds off the state machine lock`
+
+**Decision.** The from-diffs fold held `sm.mu.RLock` across the journal walk, and the gap fill held the write lock across listing and every insert. `ApplyDiff` takes the write lock, so a background repair on an already-published session stalled the apply path for the length of the replay.
+
+**Changed.**
+
+- Both rebuilds snapshot escrow id, group, config, seal nonces, live records, then walk and write outside the lock.
+- Gap fill counts gaps before allocating, so the common no-gap restart allocates nothing instead of a millions-long `[]InferenceRow`.
+- Recovery log reads `SealedNonceCount()` instead of cloning the seal-nonce map for its length.
+
+### 10. `801f87e60` — `perf(devshard): batch the obs half of the full-replay repair`
+
+**Decision.** Profiling showed the sealed-index work was the smaller half. `RebuildValidationObsFromDiffs` issued one `RecordValidationsAppliedOnce` per journal record and one `DrainInferenceValidationObs` per sealed id, each drain its own begin/select/insert/delete/commit.
+
+**Changed.**
+
+- `DrainInferenceValidationObsBatch`: chunked set-at-a-time move plus delete.
+- Records accumulate into 500-entry writes.
+- Shared backend test pins batch drain against per-id semantics on Memory, SQLite, Postgres.
+- At 20k SQLite: drain ~841ms → ~66ms, record ~325ms → ~52ms.
+
+### 11. `4426262cf` — `perf(devshard): batch the sealed-inference upsert, not just its transaction`
+
+**Decision.** `InsertSealedInferences` chunked the transaction but still issued a statement per row, so Postgres paid a round trip per inference and SQLite re-parsed the upsert for every row.
+
+**Changed.**
+
+- Postgres: one `INSERT ... SELECT FROM unnest(...)` per chunk, same upsert clause. Ids repeated inside a chunk collapse to the last value first (`ON CONFLICT DO UPDATE` cannot touch a row twice).
+- SQLite: prepare the upsert once per chunk transaction.
+- Shared test pins every sealed column, overwrite of an existing row, and in-chunk duplicate.
+- At 20k SQLite: ~431ms → ~50ms. `pg_stat_statements` shows `ceil(sealed/500)` calls instead of `sealed`.
+
+### 12. `6481fc2c7` — `test(devshard): benchmark the rebuild against Postgres, not just SQLite`
+
+**Decision.** The batching work was measured on SQLite, where the cost is per commit. On Postgres it is per round trip, and the two disagree about what "batched" means.
+
+**Changed.**
+
+- `BenchmarkPostgres*` counterparts, including the chunked-transaction-per-row shape so the wash stays visible (~3058ms vs ~3006ms unbatched at 20k).
+- Comparison recorded in `sealed-inference-index-rebuild-plan.md`.
+- Per-row forms had Postgres 5–16× behind SQLite; set-at-a-time forms brought them within ~1.4×.
+
+### 13. `20449866a` — `fix(devshard/host): guard validationQueue reads against concurrent Close`
+
+**Decision.** Backport of #1512. Not caused by this branch's recovery work, but `go test -race` failed `TestHost_ValidationTriggersOnFinishedInference` and `TestSession_Validation_InvalidationConverges` on this tree because `t.Cleanup(h.Close)` races workers still draining the queue.
+
+**Changed.**
+
+- `validateAsync` deferred cleanup and `enqueueValidation` success branch snapshot `h.validationQueue` under `RLock` instead of reading the field after unlock / without the lock.
+- `Close()` closes the channel and nils the field under the write lock.
+
+### 14. `45e7ea264` — `perf(devshard/storage): load the rebuilt sealed index with COPY`
+
+**Decisions.**
+
+- The full-replay rebuild wipes then loads, so inserts cannot conflict. The leftover ~99ms/20k on the `unnest` upsert was the per-row conflict probe (~163µs RTT × not the bottleneck; chunk-size sweeps past 500 and `synchronous_commit=off` moved nothing).
+- `BulkInsertSealedInferences`: Postgres `COPY`, fallback to the upsert on unique violation so a wrong "no rows yet" precondition costs speed rather than the rebuild.
+- Drain: one data-modifying CTE instead of four round trips per chunk (`BEGIN`/`INSERT`/`DELETE`/`COMMIT`).
+- SQLite keeps a single path.
+
+**Changed.**
+
+- Interface method on every backend; `ObsRepairGate` queues bulk as an ordinary upsert batch (the "rows do not exist yet" precondition cannot survive being deferred past the rebuild).
+- `RebuildSealedInferenceIndexFromDiffs` calls the bulk path.
+- At 20k: Postgres load ~99ms → ~30ms, drain ~81ms → ~58ms. Full-replay repair ~145ms Postgres vs ~165ms SQLite, so Postgres is no longer the slower backend for it.
+
+### 15. `4c7022ee3` — `feat(devshard): serve during recovery and wait to call it warm`
+
+**Decisions.** Companion ready-on-boot items 1–4, together, so a 200-during-recovery child cannot look warm mid-wipe and cannot sit stale behind the old generation's writes.
+
+- `/ready` 200 as soon as the process can serve. Drop `recovered` from the 503 condition. Keep `storage_ready` and `draining`.
+- `recovery_complete` true only after the backlog drains **and** `WaitRecoveryRepairs` returns. `sessions_pending` includes both the queue and in-flight repairs.
+- Promote the log-only counters onto the body and `devshardd_session_recovery`.
+- On `ErrInvalidNonce` from apply: evict, recover, retry once. Surviving mismatch → `RememberStaleNonce` at the short TTL.
+
+**Changed.**
+
+- `buildAdminServer` takes `RecoveryProgressSnapshot`. Status 200 while `recovery_complete` is still false; 503 while draining or storage unready.
+- `HandleInference` and `ChallengeReceipt` `SetInternal` the apply error so `retryIfStale` can `errors.Is` the nonce mismatch.
+- `ReloadStaleSession` / `RememberStaleNonce` / `evictSession`.
+- Tests: `/ready` 200 during recovery with body counters; `TestStartRecovery_CompleteAfterSealedIndexRepair` (was "before"); store-ahead reload succeeds; bogus nonce is negative-cached and does not re-enter recovery.
+
+---
+
+## Test plan
+
+- [x] `go test -race ./storage/ ./state/ ./user/ ./cmd/devshardd/...` from `devshard/` (green under `-race` on this branch, including the #1512 backport).
+- [x] Snapshot restore + bind-first (unit): tail-only replay, `StartRecovery` reports the backlog drained, listener is not blocked. `/ready` is now **200 during recovery** with `recovery_complete: false` (`TestReadyReflectsSessionRecoveryProgress`). Still open: cold start of a real v4 host with a long journal (`restored devshard snapshot` in logs, listener binds immediately, `/ready` 200).
+- [x] Demanded session recovers before cold backlog (unit: `TestRecoverSessions_RunsRequestedSessionsWhileColdOnesWait`). Still open: `prioritized_count` in a live completion log.
+- [x] Corrupt / mismatched snapshot blob falls back to full replay (unit: `TestRecoverSessions_CorruptSnapshotReplaysFromOne`, `TestRecoverSessions_SnapshotRootMismatchReplaysFromOne`). Still open: log line `devshard snapshot failed root check` on a real host.
+- [x] Full-replay path publishes the session before obs / sealed-index rebuild finishes (unit: `TestRecoverSessions_FullReplayRebuildsValidationObsInBackground`, `TestRecoverSessions_FullReplayRebuildsSealedIndexInBackground`). Still open: stats eventually match after `rebuilt validation obs`.
+- [x] Snapshot path leaves sealed-inference stats intact and never calls `DeleteSealedInferences` (`TestRecoverSessions_SnapshotPathLeavesSealedInferenceRows`). Gap fill on an already-indexed set inserts 0 (`TestFillSealedInferenceIndexGaps_Idempotent`).
+- [x] `recovery_complete` stays false until `WaitRecoveryRepairs` returns (`TestStartRecovery_CompleteAfterSealedIndexRepair`).
+- [x] Store-ahead apply evicts and recovers; a bogus nonce is negative-cached (`TestReloadStaleSession_CatchesUpToStoreAhead`, `TestReloadStaleSession_NegativeCachesBogusNonce`).
+- [x] Postgres vs SQLite rebuild benches (`BenchmarkPostgres*`, including `BulkInsert` / CTE drain). Linearized 1.5M: snapshot path ~0.5s reads and zero writes; full replay ~12s SQLite / ~11s Postgres, off the publish path.
+- [ ] Shutdown during a full-replay rebuild: process waits for the repair; counters are not left empty. (`WaitRecoveryRepairs` is wired as a closer; no test covers interrupt-after-clear.)
+- [ ] Operator restart with a long journal and a current snapshot: sealed-inference stats identical before and after; log `filled sealed inference index gaps inserted=0`.
+- [ ] Versiond overlap wait on `recovery_complete` (v5, not this branch).

--- a/devshard/docs/sealed-inference-index-rebuild-plan.md
+++ b/devshard/docs/sealed-inference-index-rebuild-plan.md
@@ -234,8 +234,8 @@ From `devshard/`. `-run '^$'` skips unit tests (including Docker Postgres):
 
 ```
 GOMODCACHE="$HOME/go/pkg/mod" GOCACHE="$HOME/Library/Caches/go-build" \
-  go test -run '^$' -bench 'BenchmarkSealedInference|BenchmarkFillSealed' -benchmem -benchtime=1x \
-  ./storage/ ./state/
+  go test -run '^$' -bench 'BenchmarkSealedInference|BenchmarkFillSealed|BenchmarkValidationObs' \
+  -benchmem -benchtime=1x ./storage/ ./state/
 ```
 
 Use `-count=3` locally when you want variance; CI should stay at `-benchtime=1x` and n≤20k.
@@ -246,7 +246,9 @@ Use `-count=3` locally when you want variance; CI should stay at `-benchtime=1x`
 | `BenchmarkFillSealedInferenceIndexGaps_NoGaps` | Snapshot restart with durable rows | `inserted=0`; ~8ms at 20k, matching the list |
 | `BenchmarkFillSealedInferenceIndexGaps_AllMissing` | Cold index (still no delete) | Batched inserts only; ~425ms at 20k SQLite |
 | `BenchmarkSealedInferenceIndex_UnbatchedInsert` | Pre-fix recovery (1 Exec/id) | Baseline; ~780ms at 20k SQLite |
-| `BenchmarkSealedInferenceIndex_BatchedInsert` | Full-replay repair after 1–3 | Same 20k in 500-row txs; ~430ms SQLite. Postgres win is RTT (1.5M statements → ~3k), not this local ratio. |
+| `BenchmarkSealedInferenceIndex_BatchedInsert` | Full-replay repair after 1–3 | Same 20k in 500-row txs; ~430ms SQLite. Postgres win is commits, not round trips — see [Residual performance risks](#residual-performance-risks). |
+| `BenchmarkValidationObsDrain_PerID` / `_Batched` | The other half of the same repair | ~841ms vs ~66ms at 20k; the batched form is what the rebuild calls |
+| `BenchmarkValidationObsRecord_PerDiff` / `_Chunked` | Journal replay into obs | ~325ms vs ~52ms at 20k |
 
 Do not run production 1.5M in CI. Linearize from 20k:
 
@@ -284,29 +286,34 @@ Found reviewing the Steps 1–5 code. None of these are regressions against the
 pre-fix behaviour; they are the costs that survived it, ordered by impact.
 Measured on SQLite, Apple M4 Max, n=20k, `-benchtime=1x`.
 
-1. **The full-replay repair is dominated by the obs half, not the sealed index.**
-   `RebuildValidationObsFromDiffs` does one `RecordValidationsAppliedOnce` per
-   journal record (~299ms/20k) and one `DrainInferenceValidationObs` per sealed
-   id (~813ms/20k, each its own begin/select/insert/delete/commit). The batched
-   sealed-index insert this plan added is ~431ms/20k, about 28% of the ~1.5s
-   window. Extrapolated to 1.5M the repair is ~2min per escrow. Batching the
-   drain by id range is the next real win.
-2. **Postgres inserts still cost one round trip per row.** `InsertSealedInferences`
+1. **Postgres inserts still cost one round trip per row.** `InsertSealedInferences`
    chunks commits, not statements. `AppendDiffs` already uses `pgx.CopyFrom` for
    the journal; pipelining here would turn 1.5M round trips into ~3k. SQLite
    likewise re-parses the insert per row instead of preparing once per chunk,
-   which is most of why batched is only ~1.7× unbatched locally.
-3. **Whole-set materialisation.** Both rebuilds build the full `[]InferenceRow`
+   which is most of why batched is only ~1.7× unbatched locally. With the obs
+   half batched (below), this insert is now the dominant term in a full-replay
+   repair: ~431ms of the ~549ms 20k window.
+2. **Whole-set materialisation.** Both rebuilds build the full `[]InferenceRow`
    before writing (`InferenceRow` is ~200B plus three byte slices), and the
    from-diffs fold holds a `*InferenceRecord` per inference in the journal. At
    1.5M that is hundreds of MB of transient heap during recovery. Streaming by
    chunk would cap it.
-4. **`ObsRepairGate.queueFor` takes one process-wide mutex on every obs write.**
+3. **`ObsRepairGate.queueFor` takes one process-wide mutex on every obs write.**
    It runs on the live seal path for every escrow even when no repair is in
    flight, so all escrows serialize on it. An `atomic` fast path or `RWMutex`
    would remove that.
 
-Fixed while reviewing: the from-diffs fold and the gap fill both used to hold
+Fixed while reviewing: **the full-replay repair was dominated by the obs half,
+not the sealed index.** `RebuildValidationObsFromDiffs` did one
+`RecordValidationsAppliedOnce` per journal record and one
+`DrainInferenceValidationObs` per sealed id, the latter its own
+begin/select/insert/delete/commit. At 20k that was ~841ms of drain and ~325ms
+of record against ~431ms for the sealed insert this plan added. The drain is
+now a chunked set-at-a-time move (`DrainInferenceValidationObsBatch`, ~66ms,
+12.8×) and the records accumulate into 500-entry writes (~52ms, 6.3×), which
+takes the whole repair from ~1.6s to ~0.55s per 20k.
+
+Also fixed: the from-diffs fold and the gap fill both used to hold
 `sm.mu` across the journal walk and all of their storage I/O, which stalled
 `ApplyDiff` on a published session; both now snapshot what they need and work
 outside the lock. The gap fill counts its gaps before allocating, so the

--- a/devshard/docs/sealed-inference-index-rebuild-plan.md
+++ b/devshard/docs/sealed-inference-index-rebuild-plan.md
@@ -1,0 +1,411 @@
+# Sealed-inference index rebuild: stats loss and startup cost
+
+Companion to [ready-on-boot-warm-cutover-plan.md](ready-on-boot-warm-cutover-plan.md),
+which makes this the write storm on the lazy-load request path.
+
+`RebuildSealedInferenceIndex` runs unconditionally on every session recovery. It
+destroys the sealed-inference observability columns that the live path wrote, and
+it does one delete plus one unbatched insert per sealed inference on the recovery
+path (~1.5M inserts for the incident node). This document records the diagnosis
+and the plan to fix it.
+
+## Diagnosis
+
+### 1. It wipes, then writes bare rows
+
+`state/seal.go:587` deletes every sealed-inference row for the escrow, then
+reinserts one row per sealed id:
+
+```go
+if err := sm.inferenceStore.DeleteSealedInferences(sm.state.EscrowID); err != nil {
+        return err
+}
+// for each id in sealedNonces, sorted:
+row := storage.InferenceRow{InferenceID: id, SealedNonce: nonce}
+if cached, ok := sm.committedEntries[id]; ok {
+        if entryID, rec, err := unmarshalInferenceEntry(cached); err == nil && entryID == id {
+                row = inferenceObsRow(id, nonce, rec)
+        }
+}
+if err := sm.inferenceStore.InsertSealedInference(sm.state.EscrowID, row); err != nil {
+        return err
+}
+```
+
+`storage.InferenceRow{InferenceID: id, SealedNonce: nonce}` leaves `ObsPresent`
+at its zero value, `false`. The rich row is only produced by the
+`committedEntries` branch.
+
+### 2. That branch is dead for exactly the ids being iterated
+
+The loop is `for id := range sm.sealedNonces`, and both seal paths remove the
+committed entry as they add the id to `sealedNonces`:
+
+- `SealInference` (`state/seal.go:529-539`): `sm.sealedNonces[id] = sealedNonce`,
+  then `delete(sm.committedEntries, id)`.
+- The auto-seal drain (`state/seal.go:239-240`): identical ordering.
+
+The snapshot cannot reintroduce them either, because it persists
+`ExportCommittedEntries()`, which the seal has already pruned. So
+`committedEntries[id]` is provably absent for every sealed id, and **every
+reinserted row is bare**.
+
+### 3. A bare row reads as missing
+
+```go
+func (sm *StateMachine) lookupSealedInferenceLocked(id uint64) (types.InferenceRecord, bool) {
+        row, ok, err := sm.inferenceStore.GetSealedInference(sm.state.EscrowID, id)
+        if err != nil || !ok || !row.ObsPresent {
+                return types.InferenceRecord{}, false
+        }
+```
+
+`ExportAllInferenceRecords` calls this, gets `false`, falls through to
+`hydrateCommittedInferenceLocked`, which also fails because the id is not in
+`committedEntries` — so the inference disappears from the export entirely. The
+status, votes, model, and token columns that `inferenceObsRow` wrote on the live
+path with `ObsPresent: true` are lost on every restart.
+
+### 4. The write volume is real
+
+One `DeleteSealedInferences` plus one unbatched `InsertSealedInference` per
+sealed id. The call sits at `cmd/devshardd/session/manager.go:829`, outside the
+`if meta.LatestNonce > 0` block, so **the snapshot path pays it too**. The same
+call exists on the v3 path at `user/recover.go:335`.
+
+### Why the dead branch matters
+
+It reveals the intent: the author wanted to preserve the rich record and reached
+for `committedEntries` as the source, but the seal empties that map by
+construction. The rich data still lives in the **diff journal** — the same source
+`RebuildValidationObsFromDiffs` already walks. That is where the full-replay
+variant should read from.
+
+## Interaction with the ready-on-boot / lazy-load design
+
+Two ways this collides with the design on this branch.
+
+- **It runs on the lazy-load request path.** With `/ready` returning 200 at boot,
+  a first request to an unrecovered escrow already blocks through a full replay.
+  This adds a wipe plus one insert per sealed inference on that request
+  goroutine, which makes the blocking concern materially worse.
+- **It defeats the warm cutover gate.** A pre-warmed blue/green child would
+  report `recovery_complete: true` having just emptied sealed-inference stats for
+  every escrow it touched, trading cold latency for silently missing stats.
+
+## Design
+
+Reuse the split already established for validation obs, keyed on the same
+`replayFrom == 1` predicate.
+
+| Path | Behaviour |
+| --- | --- |
+| Snapshot restored (`replayFrom > 1`) | Gap fill only. Never delete, never downgrade an `ObsPresent = true` row. Normally writes nothing. |
+| Full replay (`replayFrom == 1`) | Wipe is defensible, but read rich rows from the diff journal and run it as a background repair behind `ObsRepairGate`. |
+
+Rationale for keeping the wipe on full replay: after a rejected snapshot or a
+fresh reconstruction, stored rows may belong to a divergent history and should
+go. Rationale for the gap fill on the snapshot path: the stored rows are durable
+and the restored state is root-verified, so the only legitimate work is
+materialising `id → sealed_nonce` for ids that have no row at all — which is what
+bare rows exist for, per the `InferenceRow` comment about pruning.
+
+## Step-by-step plan
+
+### Step 1 — storage: bulk id listing (prerequisite)
+
+The gap fill must not issue 1.5M `GetSealedInference` reads. Today the only bulk
+reader is `SQLite.listSealedInferences` (`storage/sqlite_migrate_list.go:21`),
+which is unexported and SQLite-only.
+
+1. Add to the `Storage` interface:
+   `SealedInferenceIDs(escrowID string) (map[uint64]uint64, error)` — returns
+   `inferenceID → sealedNonce` for **every** stored row, including
+   `ObsPresent = false` (bare index) rows. After the wipe-rebuild bug has run,
+   every row is bare; listing only rich rows would make the snapshot-path gap
+   fill rewrite 1.5M existing rows. The caller skips any id already present,
+   which is how it tells “already indexed” from “missing”.
+   Also add `InsertSealedInferences` so gap fill and from-diffs batch writes
+   in chunked transactions instead of one round trip per id.
+2. Implement on `SQLite`, `Postgres`, `Memory`, `HybridStorage`, `ManagedStorage`.
+   `ObsRepairGate` queues sealed-inference inserts while a repair is in
+   progress (reads still pass through).
+3. Reuse the existing `sealed_inferences` query shape; add an index on
+   `(epoch_id, escrow_id)` only if the plan shows a scan. Postgres already
+   keys `(epoch_id, escrow_id, inference_id)`.
+
+Tests: extend `runSealedInferenceLifecycle` in `storage/shared_test.go` so every
+backend is covered by one assertion set.
+
+### Step 2 — state: split the rebuild into two entry points
+
+Replace the single `RebuildSealedInferenceIndex` with:
+
+- `FillSealedInferenceIndexGaps() (inserted int, err error)` — reads
+  `SealedInferenceIDs`, inserts a bare row for each id in `sealedNonces` that is
+  absent and not live, and touches nothing else. No delete.
+- `RebuildSealedInferenceIndexFromDiffs(records []types.DiffRecord) error` — the
+  full-replay variant: delete for the escrow, then insert rows built from the
+  journal so `ObsPresent = true` wherever the journal carries the record, falling
+  back to a bare row otherwise.
+
+Both batch their inserts in a single transaction rather than one round trip per
+id.
+
+Keep `RebuildSealedInferenceIndex` as a thin wrapper over the gap fill for the v3
+`user/recover.go` caller, so that path stops losing stats without restructuring
+it.
+
+Tests in `state/seal_test.go`:
+
+- A sealed id with a rich stored row survives the gap fill (`ObsPresent` stays
+  true, votes/model/tokens unchanged).
+- A sealed id with no row gets a bare row with the correct `sealed_nonce`.
+- A live id gets no row.
+- Repeated gap fills are idempotent and write nothing on the second run.
+- The from-diffs variant produces `ObsPresent = true` rows, and drops rows for
+  ids absent from the replayed history.
+
+### Step 3 — recovery: choose per path
+
+In `cmd/devshardd/session/manager.go` `recoverStoredSession`, move the call
+inside the recovery branch and pick by `replayFrom`:
+
+- `replayFrom > 1`: call `FillSealedInferenceIndexGaps` inline. It is cheap and
+  keeps the published session immediately correct.
+- `replayFrom == 1`: attach the journal to the existing `obsRepairJob` and let
+  the background repair run the from-diffs rebuild inside the same
+  `RepairValidationObs` critical section, so one gate window covers both
+  rebuilds.
+
+`obsRepairJob` already carries `records` and `sealed`, so no new plumbing is
+needed beyond invoking the second rebuild in `startObsRepair`.
+
+Tests in `manager_snapshot_recovery_test.go`:
+
+- Snapshot path: a pre-existing rich row is intact after recovery, and
+  `DeleteSealedInferences` is never called (assert via the store wrapper).
+- Full replay: the session is published before the sealed-index rebuild
+  finishes, and after `WaitRecoveryRepairs` the rows are rich.
+- Rejected-snapshot path (root mismatch) takes the full-replay branch.
+
+### Step 4 — rename the waiter (counters land in Step 8)
+
+- Rename `WaitObsRepairs` to `WaitRecoveryRepairs` (it now waits for both
+  rebuilds) and update `app.go` plus the `waitObsRepairsOnCleanup` test helper.
+- Do not flip `recovery_complete` on this waiter until Step 8 also counts
+  sealed-index repair. Shipping the field early would make a pre-warmed child
+  look warm after wiping stats (see companion *defeats the warm cutover gate*).
+
+### Step 5 — verification
+
+- `go test -race ./storage/ ./state/ ./cmd/devshardd/...` from `devshard/`
+  (`-skip 'Postgres|MigrateSQLiteToPostgres'` if Docker is unavailable).
+- Snapshot path (unit): planted rich rows survive recovery and
+  `DeleteSealedInferences` is never called
+  (`TestRecoverSessions_SnapshotPathLeavesSealedInferenceRows`). Gap fill on
+  an already-indexed set inserts 0
+  (`TestFillSealedInferenceIndexGaps_Idempotent`,
+  `BenchmarkFillSealedInferenceIndexGaps_NoGaps`).
+- Full-replay path (unit): the session is published before the wipe, and after
+  `WaitRecoveryRepairs` the rows are rich
+  (`TestRecoverSessions_FullReplayRebuildsSealedIndexInBackground`).
+- `recovery_complete` still follows the backlog, not the waiter
+  (`TestStartRecovery_CompleteBeforeSealedIndexRepair`). Step 8 flips that.
+- Operator restart with a long journal and a current snapshot: sealed-inference
+  stats are identical before and after, and the recovery log reports
+  `filled sealed inference index gaps inserted=0` (or a handful) with a
+  duration that does not scale with sealed-row count.
+- Restart with no snapshot: stats are briefly incomplete, then match after
+  `rebuilt validation obs` (`sealed_inferences` and `duration` on that line).
+
+See [Measuring the 1–3 fix](#measuring-the-1-3-fix) for benches and log fields.
+
+## Measuring the 1–3 fix
+
+The claim is: a snapshot restart no longer does 1.5M writes, and a full replay
+still writes but in chunked transactions off the publish path. Measure those
+two separately. Do not use `/ready` time — it still waits on the recovery
+backlog until Step 6.
+
+### Microbenchmarks (repeatable, no cluster)
+
+From `devshard/`. `-run '^$'` skips unit tests (including Docker Postgres):
+
+```
+GOMODCACHE="$HOME/go/pkg/mod" GOCACHE="$HOME/Library/Caches/go-build" \
+  go test -run '^$' -bench 'BenchmarkSealedInference|BenchmarkFillSealed' -benchmem -benchtime=1x \
+  ./storage/ ./state/
+```
+
+Use `-count=3` locally when you want variance; CI should stay at `-benchtime=1x` and n≤20k.
+
+| Bench | What it stands in for | Healthy result |
+| --- | --- | --- |
+| `BenchmarkSealedInferenceIDs` | Snapshot gap fill's only I/O | One `SELECT id, nonce` scan; ~8ms at 20k SQLite on Apple M4 Max |
+| `BenchmarkFillSealedInferenceIndexGaps_NoGaps` | Snapshot restart with durable rows | `inserted=0`; ~8ms at 20k, matching the list |
+| `BenchmarkFillSealedInferenceIndexGaps_AllMissing` | Cold index (still no delete) | Batched inserts only; ~425ms at 20k SQLite |
+| `BenchmarkSealedInferenceIndex_UnbatchedInsert` | Pre-fix recovery (1 Exec/id) | Baseline; ~780ms at 20k SQLite |
+| `BenchmarkSealedInferenceIndex_BatchedInsert` | Full-replay repair after 1–3 | Same 20k in 500-row txs; ~430ms SQLite. Postgres win is RTT (1.5M statements → ~3k), not this local ratio. |
+
+Do not run production 1.5M in CI. Linearize from 20k:
+
+- Snapshot path: list 20k ≈ 8ms → 1.5M ≈ 0.6s of reads and **zero writes**.
+- Pre-fix snapshot/full-replay: unbatched 20k ≈ 0.78s → 1.5M ≈ 59s of SQLite inserts, plus a delete. Postgres is worse (one round trip per id).
+- Full replay after 1–3: batched 20k ≈ 0.43s → 1.5M ≈ 32s of SQLite writes, **off the publish path**.
+
+The headline win is snapshot writes going from O(sealed) to 0, not the ~1.7× SQLite batched/unbatched ratio. Measure that with logs and `pg_stat_statements`, not with `/ready`.
+
+### Restart logs (one escrow, production-shaped)
+
+On a host with a current snapshot:
+
+1. Capture sealed stats before stop: `GET /v1/state` (or `ExportAllInferenceRecords` via admin) for a busy escrow — counts of status/model/tokens.
+2. Restart.
+3. Grep:
+   - `filled sealed inference index gaps` — `inserted` should be 0 or tens, `duration` milliseconds, `sealed_ids` in the millions is fine because it is a map length not a write count.
+   - `DeleteSealedInferences` must not appear on the snapshot path (no `rebuilt validation obs` for that escrow).
+4. Re-fetch stats; they must match step 1.
+
+On a host with the snapshot removed (full replay):
+
+1. Same pre-capture.
+2. Restart.
+3. `recovered devshard session` returns while `rebuilt validation obs` is still running (`duration` on that line is the repair, including the sealed-index rebuild; `sealed_inferences` is the seal set size).
+4. After that line, stats match step 1 and `ObsPresent` is true.
+
+### Storage counters
+
+Postgres: `pg_stat_statements` for `INSERT INTO devshard_sealed_inferences` — snapshot restart should show no such statements for recovered escrows; full replay should show ~`ceil(sealed/500)` statements per escrow, not `sealed` statements. SQLite: WAL bytes during recovery; snapshot restart should not grow WAL by O(sealed).
+
+### What not to use yet
+
+- `/ready` 200 latency — still gated on `recovered` until Step 6.
+- `recovery_complete` — Step 8, and it must wait on `WaitRecoveryRepairs` so a full-replay child is not declared warm mid-wipe.
+- Request-path latency on first chat after boot — still includes journal replay for unrecovered escrows; 1–3 only removed the extra wipe from that goroutine on the snapshot path.
+
+## Ready-on-boot / warm cutover (after the gap fill)
+
+The companion [ready-on-boot-warm-cutover-plan.md](ready-on-boot-warm-cutover-plan.md)
+is not a parallel track. It is the next work on this branch once Steps 1–3's
+snapshot half is in: `/ready` can then return 200 during recovery without putting
+a wipe-and-1.5M-insert on the first request goroutine, and `recovery_complete`
+can wait on both validation-obs and sealed-index repair.
+
+Do **not** drop `recovered` from the 503 condition (companion child item 1)
+before Step 3's snapshot half. That is the opposite order from the companion's
+own sequencing list, and it is the one that is safe: a 200-during-recovery child
+that still runs today's `RebuildSealedInferenceIndex` at
+`session/manager.go:829` would make the lazy-load path strictly worse.
+
+Versiond overlap wait (companion flows C/D) is a v5 `versioned` change. It is
+listed as Step 9 so the sequence is complete; it is not this v4 restore branch.
+
+### Step 6 — `/ready` 200 as soon as the process can serve
+
+Companion child item 1. `cmd/devshardd/server.go:35-42`: drop `recovered` from
+the 503 condition. Keep `storage_ready` and `draining`. Keep
+`recovery_complete` on `readyStatus` (`server.go:57-65`).
+
+Status code = can serve. Body field = backlog drained. `waitForChildServingReady`
+in versiond already keys on status, so flow A (solo boot) starts working as soon
+as this ships.
+
+Tests: `/ready` is 200 while `recoveryComplete()` is still false; 503 while
+draining or storage is unready; body still has `recovery_complete: false` until
+the waiter from Step 4/8 flips.
+
+### Step 7 — evict and re-recover on `types.ErrInvalidNonce`
+
+Companion child item 3. Required on the same commit as Step 6: a published
+child that recovered early will sit behind the old generation's writes to the
+shared store. The first request then fails `ErrInvalidNonce` and, today, the
+stale `*transport.Server` stays in `m.sessions`.
+
+On nonce mismatch from a live session (apply / gossip / owner chat):
+
+1. Drop it from `HostManager.sessions`, `Close` the host, delete escrow metrics.
+2. `recoverStoredSession` again (same `recoveryGate` / singleflight as
+   `getOrCreate` at `session/manager.go:379`).
+3. Reuse `resolutionFailures` (`manager.go:427-456`) so a client that keeps
+   sending a bad nonce cannot spin reload. A genuine catch-up mismatch is not
+   a permanent failure — short TTL, not `permanentFailureTTL`.
+
+Tests: a session recovered at nonce N, then a store-ahead apply of N+1, evicts
+and succeeds; a bogus nonce is negative-cached and does not re-enter recovery
+on every request.
+
+### Step 8 — recovery counters include sealed-index repair
+
+This is Step 4 plus companion child items 2 and 4, done together so
+`recovery_complete: true` cannot mean "validation obs rebuilt, sealed index
+still wiping."
+
+- Rename `WaitObsRepairs` → `WaitRecoveryRepairs`; `recoveryComplete()` is
+  true only after boot recovery **and** that waiter.
+- Promote the log-only counters from `completed devshard session recovery`
+  (`manager.go:682-689`) onto `readyStatus` and a Prometheus gauge:
+  `sessions_total`, `sessions_recovered`, `sessions_failed`,
+  `sessions_version_skipped`, `sessions_pending`.
+- Pending includes both the recovery queue and in-flight sealed-index /
+  validation-obs repair jobs.
+
+Tests: body counters during recovery; `recovery_complete` stays false until
+`WaitRecoveryRepairs` returns; a full-replay escrow that is published but still
+in `startObsRepair` does not flip the field.
+
+### Step 9 — versiond overlap wait (v5, not this branch)
+
+Companion versiond items 1–6. After `waitForChildReady` at
+`versioned/internal/process/manager.go:1020` and **before** the
+`m.processes` swap at `1029-1055`, poll admin `/ready` until
+`recovery_complete: true`.
+
+- New helper: status plus `recoveryComplete *bool`. Today's `getHTTPStatus`
+  (`manager.go:2059`) is status-only and must stay that way for
+  `watchChildReadiness` (`manager.go:305`) — pin with a test that the monitor
+  never reads the body.
+- `VERSIOND_RECOVERY_TIMEOUT`, default 30m. Do not reuse the 60s
+  `ReadyTimeout` (`manager.go:169-170`).
+- Bail-outs from companion flow D: missing field → cut over cold; old child
+  leaves `Running` → publish immediately; `hostDraining` / ctx done / timeout
+  → abort, old keeps the route.
+- Gate: overlap branch only, `devshardAdminEligible` plus a non-zero admin
+  port. Solo start and the stop/start branch never wait.
+
+### Step 10 — update rolling-update docs
+
+After the child `/ready` split (Steps 6–8) and the v5 overlap wait (Step 9),
+update [rolling-update.md](rolling-update.md):
+
+- §1.3 probe table: status 200 means the process can serve, not that recovery
+  is done. Document `recovery_complete` on the body as the warm signal.
+- Swap / flow summary: the overlap rule changes from “new ready before
+  traffic” to “new **warm** before traffic, overlap only”. Solo boot and
+  stop/start stay on status 200 (flow A/C).
+- v4 release notes if they still describe `/ready` 503-until-recovered as the
+  versiond publish gate.
+
+Do not edit those docs before Steps 6–9 land; the current text matches the
+code until then.
+
+## Sequencing
+
+1. **Steps 1–3 snapshot half** — stop per-restart stats loss and take the
+   ~1.5M writes off every recovery, including the soon-to-be-lazy request path.
+2. **Steps 6 and 7 together** — `/ready` 200 during recovery, plus nonce
+   eviction. Step 6 alone is flow A; without Step 7, flow D is worse than
+   today's cold cutover.
+3. **Step 3's full-replay-from-diffs half**, then **Step 8** — background
+   repair, then `recovery_complete` that actually waits for it.
+4. **Step 5** verification against a long journal (snapshot and no-snapshot).
+5. **Step 9** on v5 versiond, which is useless until this child ships the
+   field and the eviction.
+6. **Step 10** docs, once the probe and overlap wait match the new contract.
+
+## Out of scope
+
+- Blocking versus `503 Retry-After` for a first request to an unrecovered
+  escrow; that is a client-contract decision.
+- Repairing validation obs for an escrow booted from a snapshot whose obs rows
+  are empty; pre-existing and tracked separately.

--- a/devshard/docs/sealed-inference-index-rebuild-plan.md
+++ b/devshard/docs/sealed-inference-index-rebuild-plan.md
@@ -276,7 +276,45 @@ On a host with the snapshot removed (full replay):
 
 ### Storage counters
 
-Postgres: `pg_stat_statements` for `INSERT INTO devshard_sealed_inferences` — snapshot restart should show no such statements for recovered escrows; full replay should show ~`ceil(sealed/500)` statements per escrow, not `sealed` statements. SQLite: WAL bytes during recovery; snapshot restart should not grow WAL by O(sealed).
+Postgres: `pg_stat_statements` for `INSERT INTO devshard_sealed_inferences` — snapshot restart should show **no calls** for recovered escrows. Full replay still shows `sealed` calls, because `InsertSealedInferences` chunks the *commits* (one tx per 500 rows) and not the round trips; only `xact_commit` in `pg_stat_database` drops to ~`ceil(sealed/500)`. Cutting the round trips needs `CopyFrom`, see [Residual performance risks](#residual-performance-risks). SQLite: WAL bytes during recovery; snapshot restart should not grow WAL by O(sealed).
+
+## Residual performance risks
+
+Found reviewing the Steps 1–5 code. None of these are regressions against the
+pre-fix behaviour; they are the costs that survived it, ordered by impact.
+Measured on SQLite, Apple M4 Max, n=20k, `-benchtime=1x`.
+
+1. **The full-replay repair is dominated by the obs half, not the sealed index.**
+   `RebuildValidationObsFromDiffs` does one `RecordValidationsAppliedOnce` per
+   journal record (~299ms/20k) and one `DrainInferenceValidationObs` per sealed
+   id (~813ms/20k, each its own begin/select/insert/delete/commit). The batched
+   sealed-index insert this plan added is ~431ms/20k, about 28% of the ~1.5s
+   window. Extrapolated to 1.5M the repair is ~2min per escrow. Batching the
+   drain by id range is the next real win.
+2. **Postgres inserts still cost one round trip per row.** `InsertSealedInferences`
+   chunks commits, not statements. `AppendDiffs` already uses `pgx.CopyFrom` for
+   the journal; pipelining here would turn 1.5M round trips into ~3k. SQLite
+   likewise re-parses the insert per row instead of preparing once per chunk,
+   which is most of why batched is only ~1.7× unbatched locally.
+3. **Whole-set materialisation.** Both rebuilds build the full `[]InferenceRow`
+   before writing (`InferenceRow` is ~200B plus three byte slices), and the
+   from-diffs fold holds a `*InferenceRecord` per inference in the journal. At
+   1.5M that is hundreds of MB of transient heap during recovery. Streaming by
+   chunk would cap it.
+4. **`ObsRepairGate.queueFor` takes one process-wide mutex on every obs write.**
+   It runs on the live seal path for every escrow even when no repair is in
+   flight, so all escrows serialize on it. An `atomic` fast path or `RWMutex`
+   would remove that.
+
+Fixed while reviewing: the from-diffs fold and the gap fill both used to hold
+`sm.mu` across the journal walk and all of their storage I/O, which stalled
+`ApplyDiff` on a published session; both now snapshot what they need and work
+outside the lock. The gap fill counts its gaps before allocating, so the
+no-gap case allocates nothing instead of growing a millions-long
+`[]InferenceRow`. The recovery log reads `SealedNonceCount()` rather than
+cloning the whole seal-nonce map for its length. `SealedInferenceIDs` builds
+its map without a size hint in SQLite and Postgres, which measured negligible
+next to the row scan and is left alone.
 
 ### What not to use yet
 

--- a/devshard/docs/sealed-inference-index-rebuild-plan.md
+++ b/devshard/docs/sealed-inference-index-rebuild-plan.md
@@ -212,8 +212,8 @@ Tests in `manager_snapshot_recovery_test.go`:
 - Full-replay path (unit): the session is published before the wipe, and after
   `WaitRecoveryRepairs` the rows are rich
   (`TestRecoverSessions_FullReplayRebuildsSealedIndexInBackground`).
-- `recovery_complete` still follows the backlog, not the waiter
-  (`TestStartRecovery_CompleteBeforeSealedIndexRepair`). Step 8 flips that.
+- `recovery_complete` waits for the backlog **and** `WaitRecoveryRepairs`
+  (`TestStartRecovery_CompleteAfterSealedIndexRepair`).
 - Operator restart with a long journal and a current snapshot: sealed-inference
   stats are identical before and after, and the recovery log reports
   `filled sealed inference index gaps inserted=0` (or a handful) with a
@@ -438,6 +438,10 @@ Tests: `/ready` is 200 while `recoveryComplete()` is still false; 503 while
 draining or storage is unready; body still has `recovery_complete: false` until
 the waiter from Step 4/8 flips.
 
+Implemented: `cmd/devshardd/server.go` keys 503 on chain/storage/drain only;
+`TestReadyReflectsSessionRecoveryProgress` pins 200-during-recovery plus the
+counter fields.
+
 ### Step 7 — evict and re-recover on `types.ErrInvalidNonce`
 
 Companion child item 3. Required on the same commit as Step 6: a published
@@ -525,6 +529,8 @@ code until then.
 5. **Step 9** on v5 versiond, which is useless until this child ships the
    field and the eviction.
 6. **Step 10** docs, once the probe and overlap wait match the new contract.
+
+Steps 1–8 are on this branch. Step 9 is v5 versiond; Step 10 follows it.
 
 ## Out of scope
 

--- a/devshard/docs/sealed-inference-index-rebuild-plan.md
+++ b/devshard/docs/sealed-inference-index-rebuild-plan.md
@@ -126,7 +126,9 @@ which is unexported and SQLite-only.
    fill rewrite 1.5M existing rows. The caller skips any id already present,
    which is how it tells “already indexed” from “missing”.
    Also add `InsertSealedInferences` so gap fill and from-diffs batch writes
-   in chunked transactions instead of one round trip per id.
+   in chunked transactions instead of one round trip per id, and
+   `BulkInsertSealedInferences` for the from-diffs load, which follows a wipe
+   and so needs no conflict handling at all.
 2. Implement on `SQLite`, `Postgres`, `Memory`, `HybridStorage`, `ManagedStorage`.
    `ObsRepairGate` queues sealed-inference inserts while a repair is in
    progress (reads still pass through).
@@ -255,49 +257,63 @@ Use `-count=3` locally when you want variance; CI should stay at `-benchtime=1x`
 | `BenchmarkFillSealedInferenceIndexGaps_NoGaps` | Snapshot restart with durable rows | `inserted=0`; ~8ms at 20k, matching the list |
 | `BenchmarkFillSealedInferenceIndexGaps_AllMissing` | Cold index (still no delete) | Batched inserts only; ~425ms at 20k SQLite before the prepared-statement fix |
 | `BenchmarkSealedInferenceIndex_UnbatchedInsert` | Pre-fix recovery (1 Exec/id) | Baseline; ~650ms at 20k SQLite |
-| `BenchmarkSealedInferenceIndex_BatchedInsert` | Full-replay repair | Same 20k in 500-row txs, upsert prepared once per chunk; ~50ms SQLite. Postgres writes one `unnest` statement per chunk. |
-| `BenchmarkValidationObsDrain_PerID` / `_Batched` | The other half of the same repair | ~841ms vs ~66ms at 20k; the batched form is what the rebuild calls |
-| `BenchmarkValidationObsRecord_PerDiff` / `_Chunked` | Journal replay into obs | ~325ms vs ~52ms at 20k |
+| `BenchmarkSealedInferenceIndex_BatchedInsert` | Gap fill's inserts, where rows may exist | Same 20k in 500-row txs, upsert prepared once per chunk; ~49ms SQLite, ~99ms Postgres (one `unnest` statement per chunk) |
+| `BenchmarkPostgresSealedInferenceIndex_BulkInsert` | Full-replay repair's load after the wipe | `COPY`, no per-row conflict probe; ~30ms at 20k, ~3× the upsert. SQLite has no separate path and reuses the batched insert. |
+| `BenchmarkValidationObsDrain_PerID` / `_Batched` | The other half of the same repair | ~846ms vs ~65ms at 20k; the batched form is what the rebuild calls |
+| `BenchmarkValidationObsRecord_PerDiff` / `_Chunked` | Journal replay into obs | ~320ms vs ~51ms at 20k |
 | `BenchmarkPostgres*` | All of the above on Postgres | See [Postgres vs SQLite](#postgres-vs-sqlite) |
 | `BenchmarkPostgresSealedInferenceIndex_ChunkedTxPerRow` | The insert between steps 1–3 and the batching fix | ~3058ms at 20k, i.e. no better than unbatched: on Postgres the cost was round trips, not commits |
 
 ### Postgres vs SQLite
 
-Both at n=20k, Apple M4 Max, `-benchtime=1x`. Postgres is a `postgres:18.1`
-container reached over the Docker bridge, so its round trip is closer to a
-same-host TCP hop than to a production network: the per-row rows below are
-optimistic, and a real deployment separates them further.
+Both at n=20k, Apple M4 Max, `-benchtime=1x -count=3` (median). Postgres is a
+`postgres:18.1` container reached over the Docker bridge, so its round trip is
+closer to a same-host TCP hop than to a production network: the per-row rows
+below are optimistic, and a real deployment separates them further.
 
 | Per repair, 20k rows | SQLite | Postgres | PG / SQLite |
 | --- | --- | --- | --- |
-| `SealedInferenceIDs` (the snapshot path's only I/O) | ~8ms | ~4ms | 0.5× |
-| Insert, one statement per row, no tx | ~646ms | ~3006ms | 4.7× |
-| Insert, chunked tx, still one statement per row | ~431ms | ~3058ms | 7.1× |
-| Insert, one `unnest` / prepared upsert per chunk | ~50ms | ~91ms | 1.8× |
-| Drain, one transaction per id | ~841ms | ~13658ms | 16× |
-| Drain, chunked set-at-a-time | ~66ms | ~81ms | 1.2× |
-| Record, one write per journal record | ~325ms | ~3064ms | 9.4× |
-| Record, 500-entry chunks | ~52ms | ~54ms | 1.0× |
+| `SealedInferenceIDs` (the snapshot path's only I/O) | ~7ms | ~4ms | 0.6× |
+| Insert, one statement per row, no tx | ~637ms | ~3095ms | 4.9× |
+| Insert, chunked tx, still one statement per row | ~431ms | ~2962ms | 6.9× |
+| Insert, one `unnest` / prepared upsert per chunk | ~49ms | ~99ms | 2.0× |
+| Load into empty space (`COPY` on Postgres) | ~49ms | ~30ms | 0.6× |
+| Drain, one transaction per id | ~846ms | ~14023ms | 16.6× |
+| Drain, chunked set-at-a-time | ~65ms | ~58ms | 0.9× |
+| Record, one write per journal record | ~320ms | ~2951ms | 9.2× |
+| Record, 500-entry chunks | ~51ms | ~57ms | 1.1× |
 
-Two things fall out of this.
+Three things fall out of this.
 
-**Chunking the transaction bought Postgres nothing.** 3006ms unbatched against
-3058ms in 500-row transactions is a wash, while the same change on SQLite cut
+**Chunking the transaction bought Postgres nothing.** 3095ms unbatched against
+2962ms in 500-row transactions is a wash, while the same change on SQLite cut
 the insert by a third. SQLite pays per commit, so grouping commits helps;
 Postgres pays per round trip, so grouping commits while still sending a
 statement per row helps not at all. The per-row cost lands where you would
-expect from that: ~150µs per insert, and ~683µs per drain, which is about five
+expect from that: ~155µs per insert, and ~700µs per drain, which is about five
 round trips for the drain's begin/select/insert/delete/commit.
 
-**The batched forms put the two backends within ~1.4× of each other**, where the
-per-row forms had Postgres 5–16× behind. Reads were never the problem — the
-snapshot gap fill's only query is *faster* on Postgres.
+**What is left of the batched cost is not the protocol.** A bare round trip to
+this container measures ~163µs and a chunk carries 500 rows, so the ~99ms
+upsert is not 40 statements of network time — it is the per-row conflict probe.
+Dropping it where the caller has just wiped the escrow (`COPY`, no `ON
+CONFLICT` possible) gives ~30ms, and the same reasoning applied to the drain's
+`INSERT`+`DELETE` pair — one data-modifying CTE instead of a transaction around
+two statements — gives ~58ms from ~81ms. Sweeping the chunk size found nothing
+past ~500 rows, and `synchronous_commit = off` changed neither, which is the
+same conclusion from the other direction: the remaining time is server-side row
+work.
+
+**Postgres is now the faster backend for the full-replay repair**, at ~145ms
+per 20k against SQLite's ~165ms, where the per-row forms had it 5–17× behind.
+Reads were never the problem — the snapshot gap fill's only query is faster on
+Postgres too.
 
 Do not run production 1.5M in CI. Linearize from 20k:
 
-- Snapshot path: list 20k ≈ 8ms SQLite / ≈ 4ms Postgres → 1.5M ≈ 0.6s / 0.3s of reads and **zero writes**.
-- Pre-fix full replay: ≈ 1.8s per 20k SQLite → 1.5M ≈ 2.3min. Postgres ≈ 19.7s per 20k → 1.5M ≈ **25min**, on top of a full wipe.
-- Full replay now: ≈ 0.17s per 20k SQLite → 1.5M ≈ 13s. Postgres ≈ 0.23s per 20k → 1.5M ≈ 17s, **off the publish path**.
+- Snapshot path: list 20k ≈ 7ms SQLite / ≈ 4ms Postgres → 1.5M ≈ 0.5s / 0.3s of reads and **zero writes**.
+- Pre-fix full replay: ≈ 1.8s per 20k SQLite → 1.5M ≈ 2.3min. Postgres ≈ 20.1s per 20k → 1.5M ≈ **25min**, on top of a full wipe.
+- Full replay now: ≈ 0.165s per 20k SQLite → 1.5M ≈ 12s. Postgres ≈ 0.145s per 20k → 1.5M ≈ 11s, **off the publish path**.
 
 The headline win is still snapshot writes going from O(sealed) to 0. Measure that with logs and `pg_stat_statements`, not with `/ready`.
 
@@ -321,7 +337,7 @@ On a host with the snapshot removed (full replay):
 
 ### Storage counters
 
-Postgres: `pg_stat_statements` for `INSERT INTO devshard_sealed_inferences` — snapshot restart should show **no calls** for recovered escrows, and full replay ~`ceil(sealed/500)` calls, since a chunk is now one `unnest` statement rather than 500 round trips. SQLite: WAL bytes during recovery; snapshot restart should not grow WAL by O(sealed).
+Postgres: `pg_stat_statements` for `INSERT INTO devshard_sealed_inferences` — snapshot restart should show **no calls** for recovered escrows, and gap fill ~`ceil(gaps/500)` calls, since a chunk is now one `unnest` statement rather than 500 round trips. Full replay does not appear there at all: it loads with `COPY`, ~`ceil(sealed/50000)` of them, visible as `COPY` in `pg_stat_activity` rather than as an insert. SQLite: WAL bytes during recovery; snapshot restart should not grow WAL by O(sealed).
 
 ## Residual performance risks
 
@@ -343,23 +359,37 @@ Fixed while reviewing: **chunking the transaction was not the same as batching
 the write.** `InsertSealedInferences` still issued a statement per row inside
 each chunk, so Postgres paid a round trip per inference and SQLite re-parsed
 the upsert 1.5M times. On Postgres the chunked transaction measured no better
-than no batching at all (~3058ms vs ~3006ms at 20k). Postgres now writes one
-`unnest` statement per chunk (~91ms) and SQLite prepares the upsert once per
-chunk (~431ms → ~50ms), and `pg_stat_statements` shows `ceil(sealed/500)` calls
+than no batching at all (~2962ms vs ~3095ms at 20k). Postgres now writes one
+`unnest` statement per chunk (~99ms) and SQLite prepares the upsert once per
+chunk (~431ms → ~49ms), and `pg_stat_statements` shows `ceil(sealed/500)` calls
 rather than `sealed`.
+
+Also fixed: **the batched Postgres writes were still paying for conflict
+handling neither rebuild needs.** The full-replay path deletes the escrow's
+rows and then loads them back, so its inserts can never conflict, but it went
+through the same `unnest` upsert as gap fill. `BulkInsertSealedInferences`
+loads with `COPY` instead (~99ms → ~30ms at 20k), falling back to the upsert if
+a row does collide, so a wrong precondition costs speed rather than the
+rebuild. The batch drain likewise wrapped an `INSERT` and a `DELETE` in an
+explicit transaction — four round trips per chunk — and is now one
+data-modifying CTE with the same atomicity (~81ms → ~58ms). Together these put
+the full-replay repair at ~145ms per 20k on Postgres against ~165ms on SQLite,
+i.e. Postgres is no longer the slower backend for it. SQLite keeps one path:
+its conflict probe is a b-tree lookup in-process, not a round trip, so
+`BulkInsertSealedInferences` there is the batched upsert.
 
 Also fixed: **the full-replay repair was dominated by the obs half,
 not the sealed index.** `RebuildValidationObsFromDiffs` did one
 `RecordValidationsAppliedOnce` per journal record and one
 `DrainInferenceValidationObs` per sealed id, the latter its own
-begin/select/insert/delete/commit. At 20k that was ~841ms of drain and ~325ms
+begin/select/insert/delete/commit. At 20k that was ~846ms of drain and ~320ms
 of record against ~431ms for the sealed insert this plan added. The drain is
-now a chunked set-at-a-time move (`DrainInferenceValidationObsBatch`, ~66ms,
-12.8×) and the records accumulate into 500-entry writes (~52ms, 6.3×). On
-Postgres the same two changes are worth far more — the drain was ~13.7s at 20k,
-five round trips per inference — and with the insert fix above the whole repair
-goes from ~1.8s to ~0.17s per 20k on SQLite and from ~19.7s to ~0.23s on
-Postgres.
+now a chunked set-at-a-time move (`DrainInferenceValidationObsBatch`, ~65ms,
+13×) and the records accumulate into 500-entry writes (~51ms, 6.3×). On
+Postgres the same two changes are worth far more — the drain was ~14s at 20k,
+five round trips per inference — and with the insert fixes above the whole
+repair goes from ~1.8s to ~0.165s per 20k on SQLite and from ~20.1s to ~0.145s
+on Postgres.
 
 Also fixed: the from-diffs fold and the gap fill both used to hold
 `sm.mu` across the journal walk and all of their storage I/O, which stalled

--- a/devshard/docs/sealed-inference-index-rebuild-plan.md
+++ b/devshard/docs/sealed-inference-index-rebuild-plan.md
@@ -244,19 +244,19 @@ Use `-count=3` locally when you want variance; CI should stay at `-benchtime=1x`
 | --- | --- | --- |
 | `BenchmarkSealedInferenceIDs` | Snapshot gap fill's only I/O | One `SELECT id, nonce` scan; ~8ms at 20k SQLite on Apple M4 Max |
 | `BenchmarkFillSealedInferenceIndexGaps_NoGaps` | Snapshot restart with durable rows | `inserted=0`; ~8ms at 20k, matching the list |
-| `BenchmarkFillSealedInferenceIndexGaps_AllMissing` | Cold index (still no delete) | Batched inserts only; ~425ms at 20k SQLite |
-| `BenchmarkSealedInferenceIndex_UnbatchedInsert` | Pre-fix recovery (1 Exec/id) | Baseline; ~780ms at 20k SQLite |
-| `BenchmarkSealedInferenceIndex_BatchedInsert` | Full-replay repair after 1–3 | Same 20k in 500-row txs; ~430ms SQLite. Postgres win is commits, not round trips — see [Residual performance risks](#residual-performance-risks). |
+| `BenchmarkFillSealedInferenceIndexGaps_AllMissing` | Cold index (still no delete) | Batched inserts only; ~425ms at 20k SQLite before the prepared-statement fix |
+| `BenchmarkSealedInferenceIndex_UnbatchedInsert` | Pre-fix recovery (1 Exec/id) | Baseline; ~650ms at 20k SQLite |
+| `BenchmarkSealedInferenceIndex_BatchedInsert` | Full-replay repair | Same 20k in 500-row txs, upsert prepared once per chunk; ~50ms SQLite. Postgres writes one `unnest` statement per chunk. |
 | `BenchmarkValidationObsDrain_PerID` / `_Batched` | The other half of the same repair | ~841ms vs ~66ms at 20k; the batched form is what the rebuild calls |
 | `BenchmarkValidationObsRecord_PerDiff` / `_Chunked` | Journal replay into obs | ~325ms vs ~52ms at 20k |
 
 Do not run production 1.5M in CI. Linearize from 20k:
 
 - Snapshot path: list 20k ≈ 8ms → 1.5M ≈ 0.6s of reads and **zero writes**.
-- Pre-fix snapshot/full-replay: unbatched 20k ≈ 0.78s → 1.5M ≈ 59s of SQLite inserts, plus a delete. Postgres is worse (one round trip per id).
-- Full replay after 1–3: batched 20k ≈ 0.43s → 1.5M ≈ 32s of SQLite writes, **off the publish path**.
+- Pre-fix full replay: 841ms drain + 325ms record + 780ms unbatched insert ≈ 1.95s per 20k → 1.5M ≈ 2.4min, on top of a full wipe.
+- Full replay now: 66ms + 52ms + 50ms ≈ 0.17s per 20k → 1.5M ≈ 13s of SQLite writes, **off the publish path**.
 
-The headline win is snapshot writes going from O(sealed) to 0, not the ~1.7× SQLite batched/unbatched ratio. Measure that with logs and `pg_stat_statements`, not with `/ready`.
+The headline win is still snapshot writes going from O(sealed) to 0. Measure that with logs and `pg_stat_statements`, not with `/ready`.
 
 ### Restart logs (one escrow, production-shaped)
 
@@ -278,7 +278,7 @@ On a host with the snapshot removed (full replay):
 
 ### Storage counters
 
-Postgres: `pg_stat_statements` for `INSERT INTO devshard_sealed_inferences` — snapshot restart should show **no calls** for recovered escrows. Full replay still shows `sealed` calls, because `InsertSealedInferences` chunks the *commits* (one tx per 500 rows) and not the round trips; only `xact_commit` in `pg_stat_database` drops to ~`ceil(sealed/500)`. Cutting the round trips needs `CopyFrom`, see [Residual performance risks](#residual-performance-risks). SQLite: WAL bytes during recovery; snapshot restart should not grow WAL by O(sealed).
+Postgres: `pg_stat_statements` for `INSERT INTO devshard_sealed_inferences` — snapshot restart should show **no calls** for recovered escrows, and full replay ~`ceil(sealed/500)` calls, since a chunk is now one `unnest` statement rather than 500 round trips. SQLite: WAL bytes during recovery; snapshot restart should not grow WAL by O(sealed).
 
 ## Residual performance risks
 
@@ -286,32 +286,33 @@ Found reviewing the Steps 1–5 code. None of these are regressions against the
 pre-fix behaviour; they are the costs that survived it, ordered by impact.
 Measured on SQLite, Apple M4 Max, n=20k, `-benchtime=1x`.
 
-1. **Postgres inserts still cost one round trip per row.** `InsertSealedInferences`
-   chunks commits, not statements. `AppendDiffs` already uses `pgx.CopyFrom` for
-   the journal; pipelining here would turn 1.5M round trips into ~3k. SQLite
-   likewise re-parses the insert per row instead of preparing once per chunk,
-   which is most of why batched is only ~1.7× unbatched locally. With the obs
-   half batched (below), this insert is now the dominant term in a full-replay
-   repair: ~431ms of the ~549ms 20k window.
-2. **Whole-set materialisation.** Both rebuilds build the full `[]InferenceRow`
+1. **Whole-set materialisation.** Both rebuilds build the full `[]InferenceRow`
    before writing (`InferenceRow` is ~200B plus three byte slices), and the
    from-diffs fold holds a `*InferenceRecord` per inference in the journal. At
    1.5M that is hundreds of MB of transient heap during recovery. Streaming by
    chunk would cap it.
-3. **`ObsRepairGate.queueFor` takes one process-wide mutex on every obs write.**
+2. **`ObsRepairGate.queueFor` takes one process-wide mutex on every obs write.**
    It runs on the live seal path for every escrow even when no repair is in
    flight, so all escrows serialize on it. An `atomic` fast path or `RWMutex`
    would remove that.
 
-Fixed while reviewing: **the full-replay repair was dominated by the obs half,
+Fixed while reviewing: **chunking the transaction was not the same as batching
+the write.** `InsertSealedInferences` still issued a statement per row inside
+each chunk, so Postgres paid a round trip per inference and SQLite re-parsed
+the upsert 1.5M times. Postgres now writes one `unnest` statement per chunk and
+SQLite prepares the upsert once per chunk, which takes the 20k insert from
+~431ms to ~50ms and makes `pg_stat_statements` show `ceil(sealed/500)` calls
+rather than `sealed`.
+
+Also fixed: **the full-replay repair was dominated by the obs half,
 not the sealed index.** `RebuildValidationObsFromDiffs` did one
 `RecordValidationsAppliedOnce` per journal record and one
 `DrainInferenceValidationObs` per sealed id, the latter its own
 begin/select/insert/delete/commit. At 20k that was ~841ms of drain and ~325ms
 of record against ~431ms for the sealed insert this plan added. The drain is
 now a chunked set-at-a-time move (`DrainInferenceValidationObsBatch`, ~66ms,
-12.8×) and the records accumulate into 500-entry writes (~52ms, 6.3×), which
-takes the whole repair from ~1.6s to ~0.55s per 20k.
+12.8×) and the records accumulate into 500-entry writes (~52ms, 6.3×). With the
+insert fix above, the whole repair goes from ~1.95s to ~0.17s per 20k.
 
 Also fixed: the from-diffs fold and the gap fill both used to hold
 `sm.mu` across the journal walk and all of their storage I/O, which stalled

--- a/devshard/docs/sealed-inference-index-rebuild-plan.md
+++ b/devshard/docs/sealed-inference-index-rebuild-plan.md
@@ -238,6 +238,15 @@ GOMODCACHE="$HOME/go/pkg/mod" GOCACHE="$HOME/Library/Caches/go-build" \
   -benchmem -benchtime=1x ./storage/ ./state/
 ```
 
+The `BenchmarkPostgres*` set is the same shapes against a testcontainers
+Postgres, so it needs Docker and is not covered by the command above:
+
+```
+GOMODCACHE="$HOME/go/pkg/mod" GOCACHE="$HOME/Library/Caches/go-build" \
+  go test -run '^$' -bench 'BenchmarkPostgres' -benchmem -benchtime=1x \
+  -timeout 30m ./storage/
+```
+
 Use `-count=3` locally when you want variance; CI should stay at `-benchtime=1x` and n≤20k.
 
 | Bench | What it stands in for | Healthy result |
@@ -249,12 +258,46 @@ Use `-count=3` locally when you want variance; CI should stay at `-benchtime=1x`
 | `BenchmarkSealedInferenceIndex_BatchedInsert` | Full-replay repair | Same 20k in 500-row txs, upsert prepared once per chunk; ~50ms SQLite. Postgres writes one `unnest` statement per chunk. |
 | `BenchmarkValidationObsDrain_PerID` / `_Batched` | The other half of the same repair | ~841ms vs ~66ms at 20k; the batched form is what the rebuild calls |
 | `BenchmarkValidationObsRecord_PerDiff` / `_Chunked` | Journal replay into obs | ~325ms vs ~52ms at 20k |
+| `BenchmarkPostgres*` | All of the above on Postgres | See [Postgres vs SQLite](#postgres-vs-sqlite) |
+| `BenchmarkPostgresSealedInferenceIndex_ChunkedTxPerRow` | The insert between steps 1–3 and the batching fix | ~3058ms at 20k, i.e. no better than unbatched: on Postgres the cost was round trips, not commits |
+
+### Postgres vs SQLite
+
+Both at n=20k, Apple M4 Max, `-benchtime=1x`. Postgres is a `postgres:18.1`
+container reached over the Docker bridge, so its round trip is closer to a
+same-host TCP hop than to a production network: the per-row rows below are
+optimistic, and a real deployment separates them further.
+
+| Per repair, 20k rows | SQLite | Postgres | PG / SQLite |
+| --- | --- | --- | --- |
+| `SealedInferenceIDs` (the snapshot path's only I/O) | ~8ms | ~4ms | 0.5× |
+| Insert, one statement per row, no tx | ~646ms | ~3006ms | 4.7× |
+| Insert, chunked tx, still one statement per row | ~431ms | ~3058ms | 7.1× |
+| Insert, one `unnest` / prepared upsert per chunk | ~50ms | ~91ms | 1.8× |
+| Drain, one transaction per id | ~841ms | ~13658ms | 16× |
+| Drain, chunked set-at-a-time | ~66ms | ~81ms | 1.2× |
+| Record, one write per journal record | ~325ms | ~3064ms | 9.4× |
+| Record, 500-entry chunks | ~52ms | ~54ms | 1.0× |
+
+Two things fall out of this.
+
+**Chunking the transaction bought Postgres nothing.** 3006ms unbatched against
+3058ms in 500-row transactions is a wash, while the same change on SQLite cut
+the insert by a third. SQLite pays per commit, so grouping commits helps;
+Postgres pays per round trip, so grouping commits while still sending a
+statement per row helps not at all. The per-row cost lands where you would
+expect from that: ~150µs per insert, and ~683µs per drain, which is about five
+round trips for the drain's begin/select/insert/delete/commit.
+
+**The batched forms put the two backends within ~1.4× of each other**, where the
+per-row forms had Postgres 5–16× behind. Reads were never the problem — the
+snapshot gap fill's only query is *faster* on Postgres.
 
 Do not run production 1.5M in CI. Linearize from 20k:
 
-- Snapshot path: list 20k ≈ 8ms → 1.5M ≈ 0.6s of reads and **zero writes**.
-- Pre-fix full replay: 841ms drain + 325ms record + 780ms unbatched insert ≈ 1.95s per 20k → 1.5M ≈ 2.4min, on top of a full wipe.
-- Full replay now: 66ms + 52ms + 50ms ≈ 0.17s per 20k → 1.5M ≈ 13s of SQLite writes, **off the publish path**.
+- Snapshot path: list 20k ≈ 8ms SQLite / ≈ 4ms Postgres → 1.5M ≈ 0.6s / 0.3s of reads and **zero writes**.
+- Pre-fix full replay: ≈ 1.8s per 20k SQLite → 1.5M ≈ 2.3min. Postgres ≈ 19.7s per 20k → 1.5M ≈ **25min**, on top of a full wipe.
+- Full replay now: ≈ 0.17s per 20k SQLite → 1.5M ≈ 13s. Postgres ≈ 0.23s per 20k → 1.5M ≈ 17s, **off the publish path**.
 
 The headline win is still snapshot writes going from O(sealed) to 0. Measure that with logs and `pg_stat_statements`, not with `/ready`.
 
@@ -299,9 +342,10 @@ Measured on SQLite, Apple M4 Max, n=20k, `-benchtime=1x`.
 Fixed while reviewing: **chunking the transaction was not the same as batching
 the write.** `InsertSealedInferences` still issued a statement per row inside
 each chunk, so Postgres paid a round trip per inference and SQLite re-parsed
-the upsert 1.5M times. Postgres now writes one `unnest` statement per chunk and
-SQLite prepares the upsert once per chunk, which takes the 20k insert from
-~431ms to ~50ms and makes `pg_stat_statements` show `ceil(sealed/500)` calls
+the upsert 1.5M times. On Postgres the chunked transaction measured no better
+than no batching at all (~3058ms vs ~3006ms at 20k). Postgres now writes one
+`unnest` statement per chunk (~91ms) and SQLite prepares the upsert once per
+chunk (~431ms → ~50ms), and `pg_stat_statements` shows `ceil(sealed/500)` calls
 rather than `sealed`.
 
 Also fixed: **the full-replay repair was dominated by the obs half,
@@ -311,8 +355,11 @@ not the sealed index.** `RebuildValidationObsFromDiffs` did one
 begin/select/insert/delete/commit. At 20k that was ~841ms of drain and ~325ms
 of record against ~431ms for the sealed insert this plan added. The drain is
 now a chunked set-at-a-time move (`DrainInferenceValidationObsBatch`, ~66ms,
-12.8×) and the records accumulate into 500-entry writes (~52ms, 6.3×). With the
-insert fix above, the whole repair goes from ~1.95s to ~0.17s per 20k.
+12.8×) and the records accumulate into 500-entry writes (~52ms, 6.3×). On
+Postgres the same two changes are worth far more — the drain was ~13.7s at 20k,
+five round trips per inference — and with the insert fix above the whole repair
+goes from ~1.8s to ~0.17s per 20k on SQLite and from ~19.7s to ~0.23s on
+Postgres.
 
 Also fixed: the from-diffs fold and the gap fill both used to hold
 `sm.mu` across the journal walk and all of their storage I/O, which stalled

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -1043,7 +1043,7 @@ func (h *Host) enqueueValidation(job validateJob) {
 	case q <- job:
 		h.validationLifecycleMu.RUnlock()
 		observability.IncValidation(observability.StageValidationPicked, observability.MetricStatusQueued)
-		observability.SetValidationQueueDepth(h.escrowID, len(h.validationQueue))
+		observability.SetValidationQueueDepth(h.escrowID, len(q))
 	default:
 		h.validationLifecycleMu.RUnlock()
 		h.mu.Lock()
@@ -1090,8 +1090,11 @@ func (h *Host) validateAsync(ctx context.Context, job validateJob) {
 		h.mu.Lock()
 		delete(h.validating, job.inferenceID)
 		h.mu.Unlock()
-		if h.validationQueue != nil {
-			observability.SetValidationQueueDepth(h.escrowID, len(h.validationQueue))
+		h.validationLifecycleMu.RLock()
+		queue := h.validationQueue
+		h.validationLifecycleMu.RUnlock()
+		if queue != nil {
+			observability.SetValidationQueueDepth(h.escrowID, len(queue))
 		}
 	}()
 

--- a/devshard/observability/metrics_lifecycle.go
+++ b/devshard/observability/metrics_lifecycle.go
@@ -34,6 +34,7 @@ var (
 	buildInfo              *prometheus.GaugeVec
 	lifecycleInflight      prometheus.Gauge
 	fallbackDivisor        *prometheus.GaugeVec
+	sessionRecovery        *prometheus.GaugeVec
 
 	// HA diff/persist consistency (see docs/proposals/ha-diff-persist-consistency.md).
 	diffPersistRetryTotal     *prometheus.CounterVec
@@ -140,6 +141,10 @@ func initRegistry() {
 		Name: "devshardd_fallback_divisor",
 		Help: "Fallback capacity divisor (max(active_escrows, 4)); source is load_map or floor4.",
 	}, []string{"source"})
+	sessionRecovery = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "devshardd_session_recovery",
+		Help: "Devshardd session recovery progress: total, recovered, failed, version_skipped, pending, complete.",
+	}, []string{"kind"})
 
 	diffPersistRetryTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "devshard_diff_persist_retry_total",
@@ -174,6 +179,7 @@ func initRegistry() {
 		buildInfo,
 		lifecycleInflight,
 		fallbackDivisor,
+		sessionRecovery,
 		diffPersistRetryTotal,
 		diffForkDetectedTotal,
 		reconcileFastForwardTotal,
@@ -206,6 +212,20 @@ func IncInflight(stage Stage) func() {
 func SetLifecycleInflight(n int64) {
 	ensureMetrics()
 	lifecycleInflight.Set(float64(n))
+}
+
+func SetSessionRecovery(total, recovered, failed, versionSkipped, pending int64, complete bool) {
+	ensureMetrics()
+	sessionRecovery.WithLabelValues("total").Set(float64(total))
+	sessionRecovery.WithLabelValues("recovered").Set(float64(recovered))
+	sessionRecovery.WithLabelValues("failed").Set(float64(failed))
+	sessionRecovery.WithLabelValues("version_skipped").Set(float64(versionSkipped))
+	sessionRecovery.WithLabelValues("pending").Set(float64(pending))
+	completeVal := 0.0
+	if complete {
+		completeVal = 1
+	}
+	sessionRecovery.WithLabelValues("complete").Set(completeVal)
 }
 
 func IncTerminal(terminal Terminal, reason Reason) {

--- a/devshard/server/routes.go
+++ b/devshard/server/routes.go
@@ -11,6 +11,7 @@ import (
 	"devshard/observability"
 	"devshard/storage"
 	"devshard/transport"
+	"devshard/types"
 )
 
 // ErrInitializing means devshard storage is not ready to serve session state yet.
@@ -30,6 +31,13 @@ type OwnerChatBinder interface {
 // PayloadHandler serves GET /sessions/:id/payloads for a resolved session.
 type PayloadHandler interface {
 	HandlePayloads(c echo.Context, srv *transport.Server) error
+}
+
+// StaleSessionReloader evicts an in-memory session that fell behind the shared
+// store and recovers it again. HostManager implements this; tests may not.
+type StaleSessionReloader interface {
+	ReloadStaleSession(escrowID string, stale *transport.Server) (*transport.Server, error)
+	RememberStaleNonce(escrowID string)
 }
 
 // RegisterLazySessionRoutes mounts the standard devshard HTTP surface on g.
@@ -81,7 +89,9 @@ func withSession(
 			return sessionHTTPError(c, err)
 		}
 		observability.IncSessionResolution(routeLabel(c), observability.MetricStatusOK, observability.ReasonOK)
-		return pick(srv)(c)
+		return retryIfStale(c, resolver, srv, pick(srv)(c), func(next *transport.Server) error {
+			return pick(next)(c)
+		})
 	}
 }
 
@@ -99,7 +109,10 @@ func withSessionAuth(
 		observability.IncSessionResolution(routeLabel(c), observability.MetricStatusOK, observability.ReasonOK)
 		handler := pick(srv)
 		wrapped := srv.RateLimitMiddleware(recordChatTerminal)(handler)
-		return srv.AuthMiddleware(wrapped)(c)
+		return retryIfStale(c, resolver, srv, srv.AuthMiddleware(wrapped)(c), func(next *transport.Server) error {
+			h := pick(next)
+			return next.AuthMiddleware(next.RateLimitMiddleware(recordChatTerminal)(h))(c)
+		})
 	}
 }
 
@@ -116,7 +129,9 @@ func withOwnerChat(
 		}
 		observability.IncSessionResolution(routeLabel(c), observability.MetricStatusOK, observability.ReasonOK)
 		handler := pick(srv)
-		return srv.RateLimitMiddleware(recordChatTerminal)(handler)(c)
+		return retryIfStale(c, binder, srv, srv.RateLimitMiddleware(recordChatTerminal)(handler)(c), func(next *transport.Server) error {
+			return next.RateLimitMiddleware(recordChatTerminal)(pick(next))(c)
+		})
 	}
 }
 
@@ -207,4 +222,30 @@ func sessionHTTPError(c echo.Context, err error) error {
 		return echo.NewHTTPError(http.StatusConflict, err.Error())
 	}
 	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+}
+
+func isInvalidNonce(err error) bool {
+	return err != nil && errors.Is(err, types.ErrInvalidNonce)
+}
+
+// retryIfStale reloads a session that failed apply with ErrInvalidNonce and
+// retries the handler once. A second mismatch is treated as a bad client nonce
+// and negative-cached rather than spinning reload.
+func retryIfStale(c echo.Context, source any, stale *transport.Server, err error, retry func(*transport.Server) error) error {
+	if !isInvalidNonce(err) {
+		return err
+	}
+	reloader, ok := source.(StaleSessionReloader)
+	if !ok {
+		return err
+	}
+	next, reloadErr := reloader.ReloadStaleSession(c.Param("id"), stale)
+	if reloadErr != nil {
+		return err
+	}
+	err = retry(next)
+	if isInvalidNonce(err) {
+		reloader.RememberStaleNonce(c.Param("id"))
+	}
+	return err
 }

--- a/devshard/server/routes_test.go
+++ b/devshard/server/routes_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"devshard/observability"
 	"devshard/storage"
 	"devshard/transport"
+	"devshard/types"
 )
 
 func testEchoContext(t *testing.T) echo.Context {
@@ -105,4 +107,71 @@ func TestSessionHTTPErrorDefault(t *testing.T) {
 	httpErr, ok := sessionHTTPError(c, fmt.Errorf("boom")).(*echo.HTTPError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusInternalServerError, httpErr.Code)
+}
+
+type fakeStaleReloader struct {
+	reloads     int
+	remembered  int
+	next        *transport.Server
+	reloadErr   error
+}
+
+func (f *fakeStaleReloader) ReloadStaleSession(string, *transport.Server) (*transport.Server, error) {
+	f.reloads++
+	return f.next, f.reloadErr
+}
+
+func (f *fakeStaleReloader) RememberStaleNonce(string) { f.remembered++ }
+
+func staleRetryContext(t *testing.T) echo.Context {
+	t.Helper()
+	c := testEchoContext(t)
+	c.SetParamNames("id")
+	c.SetParamValues("escrow-1")
+	return c
+}
+
+func TestRetryIfStale_ReloadsAndSucceeds(t *testing.T) {
+	stale, next := &transport.Server{}, &transport.Server{}
+	f := &fakeStaleReloader{next: next}
+	var saw *transport.Server
+	err := retryIfStale(staleRetryContext(t), f, stale, fmt.Errorf("wrap: %w", types.ErrInvalidNonce), func(s *transport.Server) error {
+		saw = s
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, f.reloads)
+	require.Equal(t, next, saw)
+	require.Zero(t, f.remembered)
+}
+
+func TestRetryIfStale_RemembersBogusNonce(t *testing.T) {
+	stale, next := &transport.Server{}, &transport.Server{}
+	f := &fakeStaleReloader{next: next}
+	err := retryIfStale(staleRetryContext(t), f, stale, fmt.Errorf("wrap: %w", types.ErrInvalidNonce), func(*transport.Server) error {
+		return fmt.Errorf("still: %w", types.ErrInvalidNonce)
+	})
+	require.ErrorIs(t, err, types.ErrInvalidNonce)
+	require.Equal(t, 1, f.reloads)
+	require.Equal(t, 1, f.remembered)
+}
+
+func TestRetryIfStale_IgnoresOtherErrors(t *testing.T) {
+	f := &fakeStaleReloader{next: &transport.Server{}}
+	orig := errors.New("not a nonce")
+	err := retryIfStale(staleRetryContext(t), f, &transport.Server{}, orig, func(*transport.Server) error {
+		t.Fatal("retry must not run for other errors")
+		return nil
+	})
+	require.Equal(t, orig, err)
+	require.Zero(t, f.reloads)
+}
+
+func TestRetryIfStale_SkipsWithoutReloader(t *testing.T) {
+	orig := fmt.Errorf("wrap: %w", types.ErrInvalidNonce)
+	err := retryIfStale(staleRetryContext(t), struct{}{}, &transport.Server{}, orig, func(*transport.Server) error {
+		t.Fatal("retry must not run without a reloader")
+		return nil
+	})
+	require.Equal(t, orig, err)
 }

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -604,37 +604,69 @@ func (sm *StateMachine) RebuildSealedInferenceIndex() error {
 	return err
 }
 
+// SealedNonceCount returns the size of the seal set. Callers that only need the
+// count must not use ExportSealedNonces, which clones the whole map.
+func (sm *StateMachine) SealedNonceCount() int {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return len(sm.sealedNonces)
+}
+
 // FillSealedInferenceIndexGaps inserts a bare index row for each sealed id that
 // has no stored row and is not live. It never deletes and never overwrites an
 // existing row (rich or bare).
+//
+// The seal set is snapshotted under the lock and the storage work runs without
+// it: listing every stored id and inserting the gaps would otherwise hold the
+// state machine for the length of the batch. An id sealed after the snapshot
+// writes its own row on the live path, so it is not a gap this pass has to see.
 func (sm *StateMachine) FillSealedInferenceIndexGaps() (int, error) {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+	sm.mu.RLock()
+	store := sm.inferenceStore
+	escrowID := sm.state.EscrowID
+	sealedNonces := maps.Clone(sm.sealedNonces)
+	live := make(map[uint64]struct{}, len(sm.state.Inferences))
+	for id := range sm.state.Inferences {
+		live[id] = struct{}{}
+	}
+	sm.mu.RUnlock()
 
-	existing, err := sm.inferenceStore.SealedInferenceIDs(sm.state.EscrowID)
+	existing, err := store.SealedInferenceIDs(escrowID)
 	if err != nil {
 		return 0, err
 	}
-	ids := make([]uint64, 0, len(sm.sealedNonces))
-	for id := range sm.sealedNonces {
+	ids := make([]uint64, 0, len(sealedNonces))
+	for id := range sealedNonces {
 		ids = append(ids, id)
 	}
 	slices.Sort(ids)
-	rows := make([]storage.InferenceRow, 0)
-	for _, id := range ids {
-		if _, live := sm.state.Inferences[id]; live {
-			continue
+
+	// Count first so the row slice is allocated exactly once. The common case
+	// is zero gaps over a seal set in the millions, where growing a slice of
+	// InferenceRow by doubling would copy hundreds of MB for nothing.
+	missing := 0
+	isGap := func(id uint64) bool {
+		if _, isLive := live[id]; isLive {
+			return false
 		}
-		if _, ok := existing[id]; ok {
-			continue
-		}
-		nonce, ok := sm.sealedNonces[id]
-		if !ok {
-			nonce = sm.state.LatestNonce
-		}
-		rows = append(rows, storage.InferenceRow{InferenceID: id, SealedNonce: nonce})
+		_, stored := existing[id]
+		return !stored
 	}
-	if err := sm.inferenceStore.InsertSealedInferences(sm.state.EscrowID, rows); err != nil {
+	for _, id := range ids {
+		if isGap(id) {
+			missing++
+		}
+	}
+	if missing == 0 {
+		return 0, nil
+	}
+	rows := make([]storage.InferenceRow, 0, missing)
+	for _, id := range ids {
+		if isGap(id) {
+			rows = append(rows, storage.InferenceRow{InferenceID: id, SealedNonce: sealedNonces[id]})
+		}
+	}
+	if err := store.InsertSealedInferences(escrowID, rows); err != nil {
 		return 0, err
 	}
 	return len(rows), nil
@@ -650,14 +682,23 @@ func (sm *StateMachine) RebuildSealedInferenceIndexFromDiffs(store storage.Stora
 	}
 
 	sm.mu.RLock()
-	folded := sm.foldInferenceRecordsFromDiffsLocked(records)
 	escrowID := sm.state.EscrowID
+	group := append([]types.SlotAssignment(nil), sm.state.Group...)
+	price := sm.state.Config.TokenPrice
+	threshold := sm.state.Config.VoteThreshold
 	sealedNonces := maps.Clone(sm.sealedNonces)
 	live := make(map[uint64]*types.InferenceRecord, len(sm.state.Inferences))
 	for id, rec := range sm.state.Inferences {
 		live[id] = cloneInferenceRecord(rec)
 	}
 	sm.mu.RUnlock()
+
+	// Fold outside the lock. This walks the whole journal, and ApplyDiff takes
+	// the write lock, so holding the read lock here would stall the apply path
+	// of an already-published session for the length of the replay. The fold
+	// needs only the group and config captured above plus the slot lookup maps,
+	// which are immutable after construction.
+	folded := sm.foldInferenceRecordsFromDiffs(group, price, threshold, records)
 
 	if err := store.DeleteSealedInferences(escrowID); err != nil {
 		return err
@@ -691,14 +732,15 @@ func (sm *StateMachine) RebuildSealedInferenceIndexFromDiffs(store storage.Stora
 	return store.InsertSealedInferences(escrowID, rows)
 }
 
-func (sm *StateMachine) foldInferenceRecordsFromDiffsLocked(records []types.DiffRecord) map[uint64]*types.InferenceRecord {
+// foldInferenceRecordsFromDiffs replays the journal into inference records.
+// group, price and threshold are passed in so the caller can release sm.mu
+// before the walk; everything else it reads is immutable after construction.
+func (sm *StateMachine) foldInferenceRecordsFromDiffs(group []types.SlotAssignment, price uint64, threshold uint32, records []types.DiffRecord) map[uint64]*types.InferenceRecord {
 	out := make(map[uint64]*types.InferenceRecord)
-	if len(sm.state.Group) == 0 {
+	if len(group) == 0 {
 		return out
 	}
-	price := sm.state.Config.TokenPrice
-	threshold := sm.state.Config.VoteThreshold
-	groupLen := uint64(len(sm.state.Group))
+	groupLen := uint64(len(group))
 	for _, rec := range records {
 		for _, tx := range rec.Txs {
 			switch inner := tx.GetTx().(type) {
@@ -716,7 +758,7 @@ func (sm *StateMachine) foldInferenceRecordsFromDiffsLocked(records []types.Diff
 				}
 				out[msg.InferenceId] = &types.InferenceRecord{
 					Status:       types.StatusPending,
-					ExecutorSlot: sm.state.Group[msg.InferenceId%groupLen].SlotID,
+					ExecutorSlot: group[msg.InferenceId%groupLen].SlotID,
 					Model:        msg.Model,
 					PromptHash:   append([]byte(nil), msg.PromptHash...),
 					InputLength:  msg.InputLength,

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 
 	"devshard/logging"
@@ -584,37 +585,247 @@ func (sm *StateMachine) lookupSealedInferenceLocked(id uint64) (types.InferenceR
 	return inferenceRecordFromObsRow(row), true
 }
 
+func cloneInferenceRecord(rec *types.InferenceRecord) *types.InferenceRecord {
+	if rec == nil {
+		return nil
+	}
+	cp := *rec
+	if len(rec.PromptHash) > 0 {
+		cp.PromptHash = append([]byte(nil), rec.PromptHash...)
+	}
+	if len(rec.ResponseHash) > 0 {
+		cp.ResponseHash = append([]byte(nil), rec.ResponseHash...)
+	}
+	return &cp
+}
+
 func (sm *StateMachine) RebuildSealedInferenceIndex() error {
+	_, err := sm.FillSealedInferenceIndexGaps()
+	return err
+}
+
+// FillSealedInferenceIndexGaps inserts a bare index row for each sealed id that
+// has no stored row and is not live. It never deletes and never overwrites an
+// existing row (rich or bare).
+func (sm *StateMachine) FillSealedInferenceIndexGaps() (int, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	if err := sm.inferenceStore.DeleteSealedInferences(sm.state.EscrowID); err != nil {
-		return err
+	existing, err := sm.inferenceStore.SealedInferenceIDs(sm.state.EscrowID)
+	if err != nil {
+		return 0, err
 	}
 	ids := make([]uint64, 0, len(sm.sealedNonces))
 	for id := range sm.sealedNonces {
 		ids = append(ids, id)
 	}
 	slices.Sort(ids)
+	rows := make([]storage.InferenceRow, 0)
 	for _, id := range ids {
 		if _, live := sm.state.Inferences[id]; live {
+			continue
+		}
+		if _, ok := existing[id]; ok {
 			continue
 		}
 		nonce, ok := sm.sealedNonces[id]
 		if !ok {
 			nonce = sm.state.LatestNonce
 		}
-		row := storage.InferenceRow{InferenceID: id, SealedNonce: nonce}
-		if cached, ok := sm.committedEntries[id]; ok {
-			if entryID, rec, err := unmarshalInferenceEntry(cached); err == nil && entryID == id {
-				row = inferenceObsRow(id, nonce, rec)
-			}
+		rows = append(rows, storage.InferenceRow{InferenceID: id, SealedNonce: nonce})
+	}
+	if err := sm.inferenceStore.InsertSealedInferences(sm.state.EscrowID, rows); err != nil {
+		return 0, err
+	}
+	return len(rows), nil
+}
+
+// RebuildSealedInferenceIndexFromDiffs wipes the escrow's sealed-inference rows
+// and reinserts them from the diff journal plus current live RAM records.
+// store should be the underlying store when called inside ObsRepairGate so the
+// wipe bypasses the live-write queue.
+func (sm *StateMachine) RebuildSealedInferenceIndexFromDiffs(store storage.Storage, records []types.DiffRecord) error {
+	if store == nil {
+		store = sm.inferenceStore
+	}
+
+	sm.mu.RLock()
+	folded := sm.foldInferenceRecordsFromDiffsLocked(records)
+	escrowID := sm.state.EscrowID
+	sealedNonces := maps.Clone(sm.sealedNonces)
+	live := make(map[uint64]*types.InferenceRecord, len(sm.state.Inferences))
+	for id, rec := range sm.state.Inferences {
+		live[id] = cloneInferenceRecord(rec)
+	}
+	sm.mu.RUnlock()
+
+	if err := store.DeleteSealedInferences(escrowID); err != nil {
+		return err
+	}
+
+	ids := make([]uint64, 0, len(sealedNonces))
+	for id := range sealedNonces {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	rows := make([]storage.InferenceRow, 0, len(sealedNonces)+len(live))
+	for _, id := range ids {
+		if _, isLive := live[id]; isLive {
+			continue
 		}
-		if err := sm.inferenceStore.InsertSealedInference(sm.state.EscrowID, row); err != nil {
-			return err
+		nonce := sealedNonces[id]
+		if rec, ok := folded[id]; ok {
+			rows = append(rows, inferenceObsRow(id, nonce, rec))
+		} else {
+			rows = append(rows, storage.InferenceRow{InferenceID: id, SealedNonce: nonce})
 		}
 	}
-	return nil
+	liveIDs := make([]uint64, 0, len(live))
+	for id := range live {
+		liveIDs = append(liveIDs, id)
+	}
+	slices.Sort(liveIDs)
+	for _, id := range liveIDs {
+		rows = append(rows, inferenceObsRow(id, 0, live[id]))
+	}
+	return store.InsertSealedInferences(escrowID, rows)
+}
+
+func (sm *StateMachine) foldInferenceRecordsFromDiffsLocked(records []types.DiffRecord) map[uint64]*types.InferenceRecord {
+	out := make(map[uint64]*types.InferenceRecord)
+	if len(sm.state.Group) == 0 {
+		return out
+	}
+	price := sm.state.Config.TokenPrice
+	threshold := sm.state.Config.VoteThreshold
+	groupLen := uint64(len(sm.state.Group))
+	for _, rec := range records {
+		for _, tx := range rec.Txs {
+			switch inner := tx.GetTx().(type) {
+			case *types.DevshardTx_StartInference:
+				msg := inner.StartInference
+				if msg == nil {
+					continue
+				}
+				if _, exists := out[msg.InferenceId]; exists {
+					continue
+				}
+				reserved, err := tokenCost(msg.InputLength, msg.MaxTokens, price)
+				if err != nil {
+					continue
+				}
+				out[msg.InferenceId] = &types.InferenceRecord{
+					Status:       types.StatusPending,
+					ExecutorSlot: sm.state.Group[msg.InferenceId%groupLen].SlotID,
+					Model:        msg.Model,
+					PromptHash:   append([]byte(nil), msg.PromptHash...),
+					InputLength:  msg.InputLength,
+					MaxTokens:    msg.MaxTokens,
+					ReservedCost: reserved,
+					StartedAt:    msg.StartedAt,
+				}
+			case *types.DevshardTx_ConfirmStart:
+				msg := inner.ConfirmStart
+				if msg == nil {
+					continue
+				}
+				inf := out[msg.InferenceId]
+				if inf == nil {
+					continue
+				}
+				inf.Status = types.StatusStarted
+				inf.ConfirmedAt = msg.ConfirmedAt
+			case *types.DevshardTx_FinishInference:
+				msg := inner.FinishInference
+				if msg == nil {
+					continue
+				}
+				inf := out[msg.InferenceId]
+				if inf == nil {
+					continue
+				}
+				actual, err := tokenCost(msg.InputTokens, msg.OutputTokens, price)
+				if err != nil {
+					continue
+				}
+				if actual > inf.ReservedCost {
+					actual = inf.ReservedCost
+				}
+				inf.Status = types.StatusFinished
+				inf.ResponseHash = append([]byte(nil), msg.ResponseHash...)
+				inf.InputTokens = msg.InputTokens
+				inf.OutputTokens = msg.OutputTokens
+				inf.ActualCost = actual
+			case *types.DevshardTx_TimeoutInference:
+				msg := inner.TimeoutInference
+				if msg == nil {
+					continue
+				}
+				inf := out[msg.InferenceId]
+				if inf == nil {
+					continue
+				}
+				inf.Status = types.StatusTimedOut
+			case *types.DevshardTx_Validation:
+				msg := inner.Validation
+				if msg == nil {
+					continue
+				}
+				inf := out[msg.InferenceId]
+				if inf == nil {
+					continue
+				}
+				if found, _ := sm.addressHasValidated(inf, msg.ValidatorSlot); found {
+					continue
+				}
+				inf.ValidatedBy.Set(msg.ValidatorSlot)
+				if inf.Status != types.StatusFinished {
+					continue
+				}
+				weight := sm.addressToSlotCount[sm.slotToAddress[msg.ValidatorSlot]]
+				if msg.Valid {
+					inf.VotesValid += weight
+				} else {
+					inf.VotesInvalid += weight
+					inf.Status = types.StatusChallenged
+				}
+			case *types.DevshardTx_ValidationVote:
+				msg := inner.ValidationVote
+				if msg == nil {
+					continue
+				}
+				inf := out[msg.InferenceId]
+				if inf == nil {
+					continue
+				}
+				if inf.Status == types.StatusValidated || inf.Status == types.StatusInvalidated {
+					continue
+				}
+				if inf.Status != types.StatusChallenged {
+					continue
+				}
+				if found, _ := sm.addressHasValidated(inf, msg.VoterSlot); found {
+					continue
+				}
+				voterAddr := sm.slotToAddress[msg.VoterSlot]
+				weight := sm.addressToSlotCount[voterAddr]
+				for _, slot := range sm.addressToSlots[voterAddr] {
+					inf.ValidatedBy.Set(slot)
+				}
+				if msg.VoteValid {
+					inf.VotesValid += weight
+				} else {
+					inf.VotesInvalid += weight
+				}
+				if inf.VotesInvalid > threshold {
+					inf.Status = types.StatusInvalidated
+				} else if inf.VotesValid > threshold {
+					inf.Status = types.StatusValidated
+				}
+			}
+		}
+	}
+	return out
 }
 
 // persistLiveInferenceObsLocked upserts the current live inference snapshot

--- a/devshard/state/seal.go
+++ b/devshard/state/seal.go
@@ -729,7 +729,10 @@ func (sm *StateMachine) RebuildSealedInferenceIndexFromDiffs(store storage.Stora
 	for _, id := range liveIDs {
 		rows = append(rows, inferenceObsRow(id, 0, live[id]))
 	}
-	return store.InsertSealedInferences(escrowID, rows)
+	// The wipe above emptied the escrow, so this is a load into empty space
+	// rather than an upsert. On Postgres that is the difference between COPY
+	// and a per-row conflict probe.
+	return store.BulkInsertSealedInferences(escrowID, rows)
 }
 
 // foldInferenceRecordsFromDiffs replays the journal into inference records.

--- a/devshard/state/seal_bench_test.go
+++ b/devshard/state/seal_bench_test.go
@@ -1,0 +1,117 @@
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/storage"
+)
+
+func benchFillSQLite(b *testing.B, escrowID string) (*StateMachine, *storage.SQLite) {
+	b.Helper()
+	store, err := storage.NewSQLite(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = store.Close() })
+	return benchFillSM(b, store, escrowID), store
+}
+
+func benchFillSM(b *testing.B, store storage.Storage, escrowID string) *StateMachine {
+	b.Helper()
+	user, err := signing.GenerateKey()
+	if err != nil {
+		b.Fatal(err)
+	}
+	hosts := make([]*signing.Secp256k1Signer, 3)
+	for i := range hosts {
+		hosts[i], err = signing.GenerateKey()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	group := testutil.MakeGroup(hosts)
+	config := testutil.DefaultConfig(len(hosts))
+	if err := store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       escrowID,
+		EpochID:        1,
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    user.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: 100000,
+	}); err != nil {
+		b.Fatal(err)
+	}
+	sm, err := NewStateMachine(escrowID, config, group, 100000, user.Address(),
+		signing.NewSecp256k1Verifier(), store, WithVersion(testutil.RuntimeTestVersion))
+	if err != nil {
+		b.Fatal(err)
+	}
+	return sm
+}
+
+func benchSealedNonces(n int) (map[uint64]uint64, []storage.InferenceRow) {
+	nonces := make(map[uint64]uint64, n)
+	rows := make([]storage.InferenceRow, n)
+	for i := 0; i < n; i++ {
+		id := uint64(i + 1)
+		nonces[id] = id
+		rows[i] = storage.InferenceRow{
+			InferenceID: id, SealedNonce: id, ObsPresent: true, SealedModel: "llama",
+		}
+	}
+	return nonces, rows
+}
+
+// Snapshot restart: every sealed id already has a row, so Fill writes nothing.
+func BenchmarkFillSealedInferenceIndexGaps_NoGaps(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			sm, store := benchFillSQLite(b, "bench-fill")
+			nonces, rows := benchSealedNonces(n)
+			if err := store.InsertSealedInferences("bench-fill", rows); err != nil {
+				b.Fatal(err)
+			}
+			sm.RestoreSealedNonces(nonces)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				inserted, err := sm.FillSealedInferenceIndexGaps()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if inserted != 0 {
+					b.Fatalf("inserted %d, want 0", inserted)
+				}
+			}
+		})
+	}
+}
+
+// Worst-case gap fill: every sealed id is missing (still no delete).
+func BenchmarkFillSealedInferenceIndexGaps_AllMissing(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			sm, store := benchFillSQLite(b, "bench-fill-miss")
+			nonces, _ := benchSealedNonces(n)
+			sm.RestoreSealedNonces(nonces)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := store.DeleteSealedInferences("bench-fill-miss"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				inserted, err := sm.FillSealedInferenceIndexGaps()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if inserted != n {
+					b.Fatalf("inserted %d, want %d", inserted, n)
+				}
+			}
+		})
+	}
+}

--- a/devshard/state/seal_test.go
+++ b/devshard/state/seal_test.go
@@ -294,3 +294,149 @@ func TestExportAllInferenceRecords_IncludesSealedFromDB(t *testing.T) {
 	require.True(t, row.ObsPresent)
 	require.Equal(t, uint32(types.StatusFinished), row.SealedStatus)
 }
+
+func finishedInferenceDiffs(escrowID string) []types.DiffRecord {
+	return []types.DiffRecord{
+		{Diff: types.Diff{Nonce: 1, Txs: []*types.DevshardTx{txStart(&types.MsgStartInference{
+			InferenceId: 1, PromptHash: []byte("prompt"), Model: "llama", InputLength: 100, MaxTokens: 50, StartedAt: 1000,
+		})}}},
+		{Diff: types.Diff{Nonce: 2, Txs: []*types.DevshardTx{txConfirm(&types.MsgConfirmStart{
+			InferenceId: 1, ConfirmedAt: 2000,
+		})}}},
+		{Diff: types.Diff{Nonce: 3, Txs: []*types.DevshardTx{txFinish(&types.MsgFinishInference{
+			InferenceId: 1, ResponseHash: []byte("response"), InputTokens: 10, OutputTokens: 20,
+			ExecutorSlot: 1, EscrowId: escrowID,
+		})}}},
+	}
+}
+
+func TestFillSealedInferenceIndexGaps_PreservesRichRow(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	sm, store, _, _ := newSealTestSM(t, "escrow-gap-rich", hosts, true)
+	driveSealInferenceToFinished(t, sm, "escrow-gap-rich", hosts)
+	require.NoError(t, sm.SealInference(1))
+
+	before, ok, err := store.GetSealedInference("escrow-gap-rich", 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, before.ObsPresent)
+
+	inserted, err := sm.FillSealedInferenceIndexGaps()
+	require.NoError(t, err)
+	require.Zero(t, inserted)
+
+	after, ok, err := store.GetSealedInference("escrow-gap-rich", 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, before, after)
+}
+
+func TestFillSealedInferenceIndexGaps_InsertsBareForMissing(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	sm, store, _, _ := newSealTestSM(t, "escrow-gap-bare", hosts, true)
+	driveSealInferenceToFinished(t, sm, "escrow-gap-bare", hosts)
+	require.NoError(t, sm.SealInference(1))
+
+	before, ok, err := store.GetSealedInference("escrow-gap-bare", 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, store.DeleteSealedInferences("escrow-gap-bare"))
+
+	inserted, err := sm.FillSealedInferenceIndexGaps()
+	require.NoError(t, err)
+	require.Equal(t, 1, inserted)
+
+	row, ok, err := store.GetSealedInference("escrow-gap-bare", 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, row.ObsPresent)
+	require.Equal(t, before.SealedNonce, row.SealedNonce)
+}
+
+func TestFillSealedInferenceIndexGaps_SkipsLive(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	sm, store, _, _ := newSealTestSM(t, "escrow-gap-live", hosts, true)
+	driveSealInferenceToFinished(t, sm, "escrow-gap-live", hosts)
+
+	inserted, err := sm.FillSealedInferenceIndexGaps()
+	require.NoError(t, err)
+	require.Zero(t, inserted)
+	_, ok, err := store.GetSealedInference("escrow-gap-live", 1)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestFillSealedInferenceIndexGaps_Idempotent(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	sm, store, _, _ := newSealTestSM(t, "escrow-gap-idem", hosts, true)
+	driveSealInferenceToFinished(t, sm, "escrow-gap-idem", hosts)
+	require.NoError(t, sm.SealInference(1))
+	require.NoError(t, store.DeleteSealedInferences("escrow-gap-idem"))
+
+	inserted, err := sm.FillSealedInferenceIndexGaps()
+	require.NoError(t, err)
+	require.Equal(t, 1, inserted)
+	inserted, err = sm.FillSealedInferenceIndexGaps()
+	require.NoError(t, err)
+	require.Zero(t, inserted)
+}
+
+func TestRebuildSealedInferenceIndexFromDiffs_RestoresRichAndDropsStale(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+		testutil.MustGenerateKey(t),
+	}
+	escrowID := "escrow-from-diffs"
+	sm, store, _, _ := newSealTestSM(t, escrowID, hosts, true)
+	driveSealInferenceToFinished(t, sm, escrowID, hosts)
+	live, ok := sm.GetInference(1)
+	require.True(t, ok)
+	require.NoError(t, sm.SealInference(1))
+
+	require.NoError(t, store.InsertSealedInference(escrowID, storage.InferenceRow{
+		InferenceID: 99, SealedNonce: 1, ObsPresent: true, SealedModel: "stale",
+	}))
+
+	require.NoError(t, sm.RebuildSealedInferenceIndexFromDiffs(store, finishedInferenceDiffs(escrowID)))
+
+	row, ok, err := store.GetSealedInference(escrowID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, row.ObsPresent)
+	require.Equal(t, live.Model, row.SealedModel)
+	require.Equal(t, live.ActualCost, row.SealedActualCost)
+	require.Equal(t, live.InputTokens, row.SealedInputTokens)
+	require.Equal(t, live.OutputTokens, row.SealedOutputTokens)
+	require.Equal(t, uint32(live.Status), row.SealedStatus)
+
+	_, ok, err = store.GetSealedInference(escrowID, 99)
+	require.NoError(t, err)
+	require.False(t, ok, "ids absent from replayed history must be dropped")
+}

--- a/devshard/storage/hybrid.go
+++ b/devshard/storage/hybrid.go
@@ -631,6 +631,17 @@ func (h *HybridStorage) InsertSealedInference(escrowID string, row InferenceRow)
 	return b.InsertSealedInference(escrowID, row)
 }
 
+func (h *HybridStorage) BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	b, err := h.routed(escrowID)
+	if err != nil {
+		return err
+	}
+	return b.BulkInsertSealedInferences(escrowID, rows)
+}
+
 func (h *HybridStorage) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
 	if len(rows) == 0 {
 		return nil

--- a/devshard/storage/hybrid.go
+++ b/devshard/storage/hybrid.go
@@ -682,6 +682,14 @@ func (h *HybridStorage) DrainInferenceValidationObs(escrowID string, inferenceID
 	return b.DrainInferenceValidationObs(escrowID, inferenceID)
 }
 
+func (h *HybridStorage) DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error {
+	b, err := h.routed(escrowID)
+	if err != nil {
+		return err
+	}
+	return b.DrainInferenceValidationObsBatch(escrowID, inferenceIDs)
+}
+
 func (h *HybridStorage) GetValidationObservability(escrowID string) ([]SlotValidationObs, error) {
 	b, err := h.routed(escrowID)
 	if err != nil {

--- a/devshard/storage/hybrid.go
+++ b/devshard/storage/hybrid.go
@@ -631,6 +631,17 @@ func (h *HybridStorage) InsertSealedInference(escrowID string, row InferenceRow)
 	return b.InsertSealedInference(escrowID, row)
 }
 
+func (h *HybridStorage) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	b, err := h.routed(escrowID)
+	if err != nil {
+		return err
+	}
+	return b.InsertSealedInferences(escrowID, rows)
+}
+
 func (h *HybridStorage) GetSealedInference(escrowID string, inferenceID uint64) (InferenceRow, bool, error) {
 	b, err := h.routed(escrowID)
 	if err != nil {
@@ -645,6 +656,14 @@ func (h *HybridStorage) DeleteSealedInferences(escrowID string) error {
 		return err
 	}
 	return b.DeleteSealedInferences(escrowID)
+}
+
+func (h *HybridStorage) SealedInferenceIDs(escrowID string) (map[uint64]uint64, error) {
+	b, err := h.routed(escrowID)
+	if err != nil {
+		return nil, err
+	}
+	return b.SealedInferenceIDs(escrowID)
 }
 
 func (h *HybridStorage) RecordValidationsAppliedOnce(escrowID string, entries []ValidationObsEntry) error {
@@ -760,7 +779,6 @@ func (h *HybridStorage) pruneBefore(cutoff uint64) error {
 	h.maybeClearPGBound("range_prune", "cutoff", cutoff)
 	return nil
 }
-
 
 func (h *HybridStorage) ClearValidationObs(escrowID string) error {
 	b, err := h.routed(escrowID)

--- a/devshard/storage/hybrid_test.go
+++ b/devshard/storage/hybrid_test.go
@@ -93,6 +93,10 @@ func (r *recordingStorage) RecordValidationsAppliedOnce(escrowID string, entries
 	r.lastMethod = "RecordValidationsAppliedOnce"
 	return nil
 }
+func (r *recordingStorage) DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error {
+	r.lastMethod = "DrainInferenceValidationObsBatch"
+	return nil
+}
 func (r *recordingStorage) DrainInferenceValidationObs(escrowID string, inferenceID uint64) error {
 	r.lastMethod = "DrainInferenceValidationObs"
 	return nil

--- a/devshard/storage/hybrid_test.go
+++ b/devshard/storage/hybrid_test.go
@@ -68,6 +68,10 @@ func (r *recordingStorage) InsertSealedInference(escrowID string, row InferenceR
 	r.lastMethod = "InsertSealedInference"
 	return nil
 }
+func (r *recordingStorage) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	r.lastMethod = "InsertSealedInferences"
+	return nil
+}
 func (r *recordingStorage) GetSealedInference(escrowID string, inferenceID uint64) (InferenceRow, bool, error) {
 	r.lastMethod = "GetSealedInference"
 	return InferenceRow{}, false, nil
@@ -75,6 +79,10 @@ func (r *recordingStorage) GetSealedInference(escrowID string, inferenceID uint6
 func (r *recordingStorage) DeleteSealedInferences(escrowID string) error {
 	r.lastMethod = "DeleteSealedInferences"
 	return nil
+}
+func (r *recordingStorage) SealedInferenceIDs(escrowID string) (map[uint64]uint64, error) {
+	r.lastMethod = "SealedInferenceIDs"
+	return nil, nil
 }
 func (r *recordingStorage) ClearValidationObs(escrowID string) error {
 	r.lastMethod = "ClearValidationObs"
@@ -275,9 +283,16 @@ func TestHybridStorage_forwardsStorageMethods(t *testing.T) {
 	require.NoError(t, h.InsertSealedInference("e", InferenceRow{}))
 	require.Equal(t, "InsertSealedInference", rec.lastMethod)
 
+	require.NoError(t, h.InsertSealedInferences("e", []InferenceRow{{}}))
+	require.Equal(t, "InsertSealedInferences", rec.lastMethod)
+
 	_, _, err = h.GetSealedInference("e", 1)
 	require.NoError(t, err)
 	require.Equal(t, "GetSealedInference", rec.lastMethod)
+
+	_, err = h.SealedInferenceIDs("e")
+	require.NoError(t, err)
+	require.Equal(t, "SealedInferenceIDs", rec.lastMethod)
 
 	require.NoError(t, h.DeleteSealedInferences("e"))
 	require.Equal(t, "DeleteSealedInferences", rec.lastMethod)

--- a/devshard/storage/hybrid_test.go
+++ b/devshard/storage/hybrid_test.go
@@ -72,6 +72,10 @@ func (r *recordingStorage) InsertSealedInferences(escrowID string, rows []Infere
 	r.lastMethod = "InsertSealedInferences"
 	return nil
 }
+func (r *recordingStorage) BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	r.lastMethod = "BulkInsertSealedInferences"
+	return nil
+}
 func (r *recordingStorage) GetSealedInference(escrowID string, inferenceID uint64) (InferenceRow, bool, error) {
 	r.lastMethod = "GetSealedInference"
 	return InferenceRow{}, false, nil
@@ -289,6 +293,9 @@ func TestHybridStorage_forwardsStorageMethods(t *testing.T) {
 
 	require.NoError(t, h.InsertSealedInferences("e", []InferenceRow{{}}))
 	require.Equal(t, "InsertSealedInferences", rec.lastMethod)
+
+	require.NoError(t, h.BulkInsertSealedInferences("e", []InferenceRow{{}}))
+	require.Equal(t, "BulkInsertSealedInferences", rec.lastMethod)
 
 	_, _, err = h.GetSealedInference("e", 1)
 	require.NoError(t, err)

--- a/devshard/storage/interface.go
+++ b/devshard/storage/interface.go
@@ -82,6 +82,13 @@ type Storage interface {
 	// InsertSealedInferences upserts many sealed-inference rows in chunked
 	// transactions. An empty slice is a no-op.
 	InsertSealedInferences(escrowID string, rows []InferenceRow) error
+	// BulkInsertSealedInferences loads rows that are expected not to exist yet,
+	// as after DeleteSealedInferences. Backends may take a bulk path that has
+	// no per-row conflict probe (Postgres uses COPY), which is the difference
+	// between minutes and seconds on a full-replay rebuild. Rows that do
+	// collide still land as an upsert, so the result matches
+	// InsertSealedInferences either way; only the speed differs.
+	BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error
 	GetSealedInference(escrowID string, inferenceID uint64) (InferenceRow, bool, error)
 	DeleteSealedInferences(escrowID string) error
 	// SealedInferenceIDs returns inferenceID → sealedNonce for every sealed-

--- a/devshard/storage/interface.go
+++ b/devshard/storage/interface.go
@@ -79,8 +79,16 @@ type Storage interface {
 	// InsertSealedInference upserts the per-inference observability snapshot
 	// (insert or update on conflict).
 	InsertSealedInference(escrowID string, row InferenceRow) error
+	// InsertSealedInferences upserts many sealed-inference rows in chunked
+	// transactions. An empty slice is a no-op.
+	InsertSealedInferences(escrowID string, rows []InferenceRow) error
 	GetSealedInference(escrowID string, inferenceID uint64) (InferenceRow, bool, error)
 	DeleteSealedInferences(escrowID string) error
+	// SealedInferenceIDs returns inferenceID → sealedNonce for every sealed-
+	// inference row, including ObsPresent=false (bare index) rows. Gap fill
+	// skips these so a restart after the wipe-rebuild bug does not rewrite
+	// existing rows.
+	SealedInferenceIDs(escrowID string) (map[uint64]uint64, error)
 	// ClearValidationObs removes all live and sealed validation observability
 	// rows for an escrow. Used when rebuilding obs from the diff journal.
 	ClearValidationObs(escrowID string) error
@@ -181,8 +189,8 @@ type ActiveSession struct {
 // state root) for GET /v1/state after RAM prune. Late MsgValidation on
 // sealed ids still returns ErrInferenceSealed and does not read this snapshot.
 type InferenceRow struct {
-	InferenceID uint64
-	SealedNonce uint64
+	InferenceID        uint64
+	SealedNonce        uint64
 	ObsPresent         bool
 	SealedStatus       uint32
 	SealedExecutorSlot uint32

--- a/devshard/storage/interface.go
+++ b/devshard/storage/interface.go
@@ -100,6 +100,11 @@ type Storage interface {
 	RecordValidationsAppliedOnce(escrowID string, entries []ValidationObsEntry) error
 	// DrainInferenceValidationObs moves live counters for an inference into sealed storage (called on seal).
 	DrainInferenceValidationObs(escrowID string, inferenceID uint64) error
+	// DrainInferenceValidationObsBatch is the many-ids form, used when recovery
+	// drains the whole seal set. The single-id form is one transaction per
+	// inference, which dominates a full-replay repair. Backends chunk
+	// internally; the result is the same as draining each id in turn.
+	DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error
 	// GetValidationObservability returns live + sealed validation counters aggregated by slot.
 	GetValidationObservability(escrowID string) ([]SlotValidationObs, error)
 	// PutEscrowCache stores chain-fetched escrow metadata for later lazy bind.

--- a/devshard/storage/managed.go
+++ b/devshard/storage/managed.go
@@ -247,6 +247,10 @@ func (m *ManagedStorage) DrainInferenceValidationObs(escrowID string, inferenceI
 	return m.inner.DrainInferenceValidationObs(escrowID, inferenceID)
 }
 
+func (m *ManagedStorage) DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error {
+	return m.inner.DrainInferenceValidationObsBatch(escrowID, inferenceIDs)
+}
+
 func (m *ManagedStorage) GetValidationObservability(escrowID string) ([]SlotValidationObs, error) {
 	return m.inner.GetValidationObservability(escrowID)
 }

--- a/devshard/storage/managed.go
+++ b/devshard/storage/managed.go
@@ -223,6 +223,10 @@ func (m *ManagedStorage) InsertSealedInferences(escrowID string, rows []Inferenc
 	return m.inner.InsertSealedInferences(escrowID, rows)
 }
 
+func (m *ManagedStorage) BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	return m.inner.BulkInsertSealedInferences(escrowID, rows)
+}
+
 func (m *ManagedStorage) GetSealedInference(escrowID string, inferenceID uint64) (InferenceRow, bool, error) {
 	return m.inner.GetSealedInference(escrowID, inferenceID)
 }

--- a/devshard/storage/managed.go
+++ b/devshard/storage/managed.go
@@ -219,12 +219,20 @@ func (m *ManagedStorage) InsertSealedInference(escrowID string, row InferenceRow
 	return m.inner.InsertSealedInference(escrowID, row)
 }
 
+func (m *ManagedStorage) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	return m.inner.InsertSealedInferences(escrowID, rows)
+}
+
 func (m *ManagedStorage) GetSealedInference(escrowID string, inferenceID uint64) (InferenceRow, bool, error) {
 	return m.inner.GetSealedInference(escrowID, inferenceID)
 }
 
 func (m *ManagedStorage) DeleteSealedInferences(escrowID string) error {
 	return m.inner.DeleteSealedInferences(escrowID)
+}
+
+func (m *ManagedStorage) SealedInferenceIDs(escrowID string) (map[uint64]uint64, error) {
+	return m.inner.SealedInferenceIDs(escrowID)
 }
 
 func (m *ManagedStorage) ClearValidationObs(escrowID string) error {

--- a/devshard/storage/managed_test.go
+++ b/devshard/storage/managed_test.go
@@ -128,6 +128,9 @@ func (s *legacyOnlyStorage) ClearValidationObs(escrowID string) error {
 func (s *legacyOnlyStorage) RecordValidationsAppliedOnce(escrowID string, entries []ValidationObsEntry) error {
 	return s.inner.RecordValidationsAppliedOnce(escrowID, entries)
 }
+func (s *legacyOnlyStorage) DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error {
+	return s.inner.DrainInferenceValidationObsBatch(escrowID, inferenceIDs)
+}
 func (s *legacyOnlyStorage) DrainInferenceValidationObs(escrowID string, inferenceID uint64) error {
 	return s.inner.DrainInferenceValidationObs(escrowID, inferenceID)
 }

--- a/devshard/storage/managed_test.go
+++ b/devshard/storage/managed_test.go
@@ -110,6 +110,9 @@ func (s *legacyOnlyStorage) LoadSnapshot(escrowID string) (uint64, []byte, error
 func (s *legacyOnlyStorage) InsertSealedInference(escrowID string, row InferenceRow) error {
 	return s.inner.InsertSealedInference(escrowID, row)
 }
+func (s *legacyOnlyStorage) BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	return s.inner.BulkInsertSealedInferences(escrowID, rows)
+}
 func (s *legacyOnlyStorage) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
 	return s.inner.InsertSealedInferences(escrowID, rows)
 }

--- a/devshard/storage/managed_test.go
+++ b/devshard/storage/managed_test.go
@@ -110,11 +110,17 @@ func (s *legacyOnlyStorage) LoadSnapshot(escrowID string) (uint64, []byte, error
 func (s *legacyOnlyStorage) InsertSealedInference(escrowID string, row InferenceRow) error {
 	return s.inner.InsertSealedInference(escrowID, row)
 }
+func (s *legacyOnlyStorage) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	return s.inner.InsertSealedInferences(escrowID, rows)
+}
 func (s *legacyOnlyStorage) GetSealedInference(escrowID string, inferenceID uint64) (InferenceRow, bool, error) {
 	return s.inner.GetSealedInference(escrowID, inferenceID)
 }
 func (s *legacyOnlyStorage) DeleteSealedInferences(escrowID string) error {
 	return s.inner.DeleteSealedInferences(escrowID)
+}
+func (s *legacyOnlyStorage) SealedInferenceIDs(escrowID string) (map[uint64]uint64, error) {
+	return s.inner.SealedInferenceIDs(escrowID)
 }
 func (s *legacyOnlyStorage) ClearValidationObs(escrowID string) error {
 	return s.inner.ClearValidationObs(escrowID)

--- a/devshard/storage/memory.go
+++ b/devshard/storage/memory.go
@@ -454,9 +454,31 @@ func (m *Memory) DrainInferenceValidationObs(escrowID string, inferenceID uint64
 	if !ok {
 		return fmt.Errorf("session %s not found", escrowID)
 	}
+	m.drainInferenceValidationObsLocked(s, inferenceID)
+	return nil
+}
+
+func (m *Memory) DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error {
+	if len(inferenceIDs) == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[escrowID]
+	if !ok {
+		return fmt.Errorf("session %s not found", escrowID)
+	}
+	for _, id := range inferenceIDs {
+		m.drainInferenceValidationObsLocked(s, id)
+	}
+	return nil
+}
+
+func (m *Memory) drainInferenceValidationObsLocked(s *sessionData, inferenceID uint64) {
 	bySlot := s.inferenceValidationObs[inferenceID]
 	if len(bySlot) == 0 {
-		return nil
+		return
 	}
 	if s.sealedValidationObs == nil {
 		s.sealedValidationObs = make(map[uint64]map[uint32]SlotValidationObs)
@@ -474,7 +496,6 @@ func (m *Memory) DrainInferenceValidationObs(escrowID string, inferenceID uint64
 		sealed[slotID] = cur
 	}
 	delete(s.inferenceValidationObs, inferenceID)
-	return nil
 }
 
 func (m *Memory) GetValidationObservability(escrowID string) ([]SlotValidationObs, error) {

--- a/devshard/storage/memory.go
+++ b/devshard/storage/memory.go
@@ -307,6 +307,10 @@ func (m *Memory) InsertSealedInference(escrowID string, row InferenceRow) error 
 	return m.InsertSealedInferences(escrowID, []InferenceRow{row})
 }
 
+func (m *Memory) BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	return m.InsertSealedInferences(escrowID, rows)
+}
+
 func (m *Memory) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
 	if len(rows) == 0 {
 		return nil

--- a/devshard/storage/memory.go
+++ b/devshard/storage/memory.go
@@ -41,21 +41,21 @@ type snapshotData struct {
 }
 
 type sessionData struct {
-	escrowID      string
-	epochID       uint64
-	version       string
-	creatorAddr   string
-	config        types.SessionConfig
-	group         []types.SlotAssignment
-	balance       uint64
-	diffs         []types.DiffRecord
-	nonceToIndex  map[uint64]int
-	lastFinalized uint64
-	status        string // "active", "settled"
-	snapshot      *snapshotData
-	inferences              map[uint64]InferenceRow
-	inferenceValidationObs  map[uint64]map[uint32]SlotValidationObs
-	sealedValidationObs     map[uint64]map[uint32]SlotValidationObs
+	escrowID               string
+	epochID                uint64
+	version                string
+	creatorAddr            string
+	config                 types.SessionConfig
+	group                  []types.SlotAssignment
+	balance                uint64
+	diffs                  []types.DiffRecord
+	nonceToIndex           map[uint64]int
+	lastFinalized          uint64
+	status                 string // "active", "settled"
+	snapshot               *snapshotData
+	inferences             map[uint64]InferenceRow
+	inferenceValidationObs map[uint64]map[uint32]SlotValidationObs
+	sealedValidationObs    map[uint64]map[uint32]SlotValidationObs
 }
 
 // Memory is an in-memory storage implementation for testing.
@@ -95,15 +95,15 @@ func (m *Memory) CreateSession(params CreateSessionParams) error {
 	}
 
 	m.sessions[params.EscrowID] = &sessionData{
-		escrowID:     params.EscrowID,
-		epochID:      params.EpochID,
-		version:      requestedVersion,
-		creatorAddr:  params.CreatorAddr,
-		config:       params.Config,
-		group:        copyGroup(params.Group),
-		balance:      params.InitialBalance,
-		nonceToIndex: make(map[uint64]int),
-		status:       "active",
+		escrowID:               params.EscrowID,
+		epochID:                params.EpochID,
+		version:                requestedVersion,
+		creatorAddr:            params.CreatorAddr,
+		config:                 params.Config,
+		group:                  copyGroup(params.Group),
+		balance:                params.InitialBalance,
+		nonceToIndex:           make(map[uint64]int),
+		status:                 "active",
 		inferences:             make(map[uint64]InferenceRow),
 		inferenceValidationObs: make(map[uint64]map[uint32]SlotValidationObs),
 		sealedValidationObs:    make(map[uint64]map[uint32]SlotValidationObs),
@@ -304,6 +304,13 @@ func (m *Memory) LoadSnapshot(escrowID string) (uint64, []byte, error) {
 }
 
 func (m *Memory) InsertSealedInference(escrowID string, row InferenceRow) error {
+	return m.InsertSealedInferences(escrowID, []InferenceRow{row})
+}
+
+func (m *Memory) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -311,7 +318,9 @@ func (m *Memory) InsertSealedInference(escrowID string, row InferenceRow) error 
 	if !ok {
 		return fmt.Errorf("session %s not found", escrowID)
 	}
-	s.inferences[row.InferenceID] = row
+	for _, row := range rows {
+		s.inferences[row.InferenceID] = row
+	}
 	return nil
 }
 
@@ -340,6 +349,21 @@ func (m *Memory) DeleteSealedInferences(escrowID string) error {
 	}
 	s.inferences = make(map[uint64]InferenceRow)
 	return nil
+}
+
+func (m *Memory) SealedInferenceIDs(escrowID string) (map[uint64]uint64, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	s, ok := m.sessions[escrowID]
+	if !ok {
+		return nil, fmt.Errorf("session %s not found", escrowID)
+	}
+	out := make(map[uint64]uint64, len(s.inferences))
+	for id, row := range s.inferences {
+		out[id] = row.SealedNonce
+	}
+	return out, nil
 }
 
 func (m *Memory) ClearValidationObs(escrowID string) error {

--- a/devshard/storage/memory_test.go
+++ b/devshard/storage/memory_test.go
@@ -42,6 +42,10 @@ func TestMemory_SealedInferenceLifecycle(t *testing.T) {
 	runSealedInferenceLifecycle(t, NewMemory())
 }
 
+func TestMemory_SealedInferenceBatchInsert(t *testing.T) {
+	runSealedInferenceBatchInsert(t, NewMemory())
+}
+
 func TestMemory_ValidationObsBatchDrain(t *testing.T) {
 	runValidationObsBatchDrain(t, NewMemory())
 }

--- a/devshard/storage/memory_test.go
+++ b/devshard/storage/memory_test.go
@@ -46,6 +46,10 @@ func TestMemory_SealedInferenceBatchInsert(t *testing.T) {
 	runSealedInferenceBatchInsert(t, NewMemory())
 }
 
+func TestMemory_SealedInferenceBulkInsert(t *testing.T) {
+	runSealedInferenceBulkInsert(t, NewMemory())
+}
+
 func TestMemory_ValidationObsBatchDrain(t *testing.T) {
 	runValidationObsBatchDrain(t, NewMemory())
 }

--- a/devshard/storage/memory_test.go
+++ b/devshard/storage/memory_test.go
@@ -42,6 +42,10 @@ func TestMemory_SealedInferenceLifecycle(t *testing.T) {
 	runSealedInferenceLifecycle(t, NewMemory())
 }
 
+func TestMemory_ValidationObsBatchDrain(t *testing.T) {
+	runValidationObsBatchDrain(t, NewMemory())
+}
+
 func TestMemory_AddSignature(t *testing.T) {
 	runAddSignature(t, NewMemory())
 }

--- a/devshard/storage/obs_rebuild_bench_test.go
+++ b/devshard/storage/obs_rebuild_bench_test.go
@@ -1,0 +1,103 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+)
+
+func benchObsEntries(n int) []ValidationObsEntry {
+	entries := make([]ValidationObsEntry, n)
+	for i := 0; i < n; i++ {
+		entries[i] = ValidationObsEntry{InferenceID: uint64(i + 1), SlotID: 1}
+	}
+	return entries
+}
+
+func benchSealedIDs(n int) []uint64 {
+	ids := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		ids[i] = uint64(i + 1)
+	}
+	return ids
+}
+
+// The drain the rebuild used to do: one transaction per sealed id.
+func BenchmarkValidationObsDrain_PerID(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			db := benchSQLite(b)
+			ids := benchSealedIDs(n)
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.RecordValidationsAppliedOnce("escrow-1", benchObsEntries(n)); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				for _, id := range ids {
+					if err := db.DrainInferenceValidationObs("escrow-1", id); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+// The batched form: chunked set-at-a-time move plus delete.
+func BenchmarkValidationObsDrain_Batched(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			db := benchSQLite(b)
+			ids := benchSealedIDs(n)
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.RecordValidationsAppliedOnce("escrow-1", benchObsEntries(n)); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				if err := db.DrainInferenceValidationObsBatch("escrow-1", ids); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// The record half: one call per journal record, which the rebuild used to do,
+// versus the accumulated chunks it does now.
+func BenchmarkValidationObsRecord_PerDiff(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			db := benchSQLite(b)
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < n; j++ {
+					if err := db.RecordValidationsAppliedOnce("escrow-1", []ValidationObsEntry{
+						{InferenceID: uint64(j + 1), SlotID: 1},
+					}); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkValidationObsRecord_Chunked(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			db := benchSQLite(b)
+			entries := benchObsEntries(n)
+			for i := 0; i < b.N; i++ {
+				for start := 0; start < n; start += validationObsRebuildChunk {
+					end := start + validationObsRebuildChunk
+					if end > n {
+						end = n
+					}
+					if err := db.RecordValidationsAppliedOnce("escrow-1", entries[start:end]); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/devshard/storage/obs_repair_gate.go
+++ b/devshard/storage/obs_repair_gate.go
@@ -124,6 +124,19 @@ func (g *ObsRepairGate) InsertSealedInference(escrowID string, row InferenceRow)
 	return g.Storage.InsertSealedInference(escrowID, row)
 }
 
+// BulkInsertSealedInferences queues as an ordinary upsert batch during a
+// repair: the bulk path's "these rows do not exist yet" precondition cannot
+// survive being deferred past the rebuild that is writing the same rows.
+func (g *ObsRepairGate) BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	if q := g.queueFor(escrowID); q != nil {
+		return g.InsertSealedInferences(escrowID, rows)
+	}
+	return g.Storage.BulkInsertSealedInferences(escrowID, rows)
+}
+
 func (g *ObsRepairGate) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
 	if len(rows) == 0 {
 		return nil

--- a/devshard/storage/obs_repair_gate.go
+++ b/devshard/storage/obs_repair_gate.go
@@ -43,11 +43,13 @@ type obsQueue struct {
 	dropped int
 }
 
-// obsOp is a queued obs write. Exactly one of the two forms is set.
+// obsOp is a queued obs write. Exactly one of the forms is set.
 type obsOp struct {
-	entries []ValidationObsEntry
-	drainID uint64
-	drain   bool
+	entries     []ValidationObsEntry
+	drainID     uint64
+	drain       bool
+	sealedRow   *InferenceRow
+	sealedBatch []InferenceRow
 }
 
 func NewObsRepairGate(inner Storage) *ObsRepairGate {
@@ -85,6 +87,44 @@ func (g *ObsRepairGate) DrainInferenceValidationObs(escrowID string, inferenceID
 		return nil
 	}
 	return g.Storage.DrainInferenceValidationObs(escrowID, inferenceID)
+}
+
+func cloneInferenceRow(row InferenceRow) InferenceRow {
+	out := row
+	if len(row.SealedValidatedBy) > 0 {
+		out.SealedValidatedBy = append([]byte(nil), row.SealedValidatedBy...)
+	}
+	if len(row.SealedPromptHash) > 0 {
+		out.SealedPromptHash = append([]byte(nil), row.SealedPromptHash...)
+	}
+	if len(row.SealedResponseHash) > 0 {
+		out.SealedResponseHash = append([]byte(nil), row.SealedResponseHash...)
+	}
+	return out
+}
+
+func (g *ObsRepairGate) InsertSealedInference(escrowID string, row InferenceRow) error {
+	if q := g.queueFor(escrowID); q != nil {
+		cloned := cloneInferenceRow(row)
+		q.push(obsOp{sealedRow: &cloned})
+		return nil
+	}
+	return g.Storage.InsertSealedInference(escrowID, row)
+}
+
+func (g *ObsRepairGate) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	if q := g.queueFor(escrowID); q != nil {
+		cloned := make([]InferenceRow, len(rows))
+		for i := range rows {
+			cloned[i] = cloneInferenceRow(rows[i])
+		}
+		q.push(obsOp{sealedBatch: cloned})
+		return nil
+	}
+	return g.Storage.InsertSealedInferences(escrowID, rows)
 }
 
 // queueFor returns the active queue for an escrow, or nil to write through.
@@ -190,9 +230,14 @@ func (g *ObsRepairGate) applyOps(escrowID string, ops []obsOp) error {
 	var firstErr error
 	for _, op := range ops {
 		var err error
-		if op.drain {
+		switch {
+		case op.drain:
 			err = g.Storage.DrainInferenceValidationObs(escrowID, op.drainID)
-		} else {
+		case op.sealedRow != nil:
+			err = g.Storage.InsertSealedInference(escrowID, *op.sealedRow)
+		case len(op.sealedBatch) > 0:
+			err = g.Storage.InsertSealedInferences(escrowID, op.sealedBatch)
+		default:
 			err = g.Storage.RecordValidationsAppliedOnce(escrowID, op.entries)
 		}
 		if err != nil && firstErr == nil {

--- a/devshard/storage/obs_repair_gate.go
+++ b/devshard/storage/obs_repair_gate.go
@@ -1,0 +1,203 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+)
+
+// maxQueuedObsOps bounds the per-escrow queue held during a repair. Overflow
+// drops the newest ops, matching the live path, which already drops obs batches
+// when too many writes are in flight. Dropped counters are recovered by the
+// next repair.
+const maxQueuedObsOps = 8192
+
+// ObsRepairGate wraps a Storage so a validation-obs rebuild can run in the
+// background against a live escrow.
+//
+// A rebuild is only correct with exclusive access: it clears both obs tables
+// and refills them from the diff journal, and a concurrent write would be
+// counted twice, because the drain deletes the live row that
+// RecordValidationsAppliedOnce dedups against. Rather than block the apply
+// path, the gate queues live obs writes for that escrow in arrival order and
+// applies them once the rebuild finishes, which yields the same result as
+// running them after it. The rebuild covers the journal up to the nonce it
+// started at, and diffs applied during the window are past that nonce, so the
+// two never overlap.
+//
+// Queueing is safe because obs writes are already best-effort everywhere:
+// recording is dropped under backpressure and deferred drains are logged and
+// skipped rather than failing a commit. Every other method, reads included,
+// passes straight through.
+type ObsRepairGate struct {
+	Storage
+
+	mu     sync.Mutex
+	queues map[string]*obsQueue
+}
+
+// obsQueue has its own lock so a queued write never contends with the gate
+// map. Lock order is always gate then queue; push only ever takes the queue.
+type obsQueue struct {
+	mu      sync.Mutex
+	ops     []obsOp
+	dropped int
+}
+
+// obsOp is a queued obs write. Exactly one of the two forms is set.
+type obsOp struct {
+	entries []ValidationObsEntry
+	drainID uint64
+	drain   bool
+}
+
+func NewObsRepairGate(inner Storage) *ObsRepairGate {
+	return &ObsRepairGate{Storage: inner}
+}
+
+// Ready forwards the optional readiness probe, which callers type-assert on the
+// outermost store.
+func (g *ObsRepairGate) Ready() bool {
+	if r, ok := g.Storage.(interface{ Ready() bool }); ok {
+		return r.Ready()
+	}
+	return true
+}
+
+// RepairInProgress reports whether an escrow's obs writes are being queued.
+func (g *ObsRepairGate) RepairInProgress(escrowID string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, ok := g.queues[escrowID]
+	return ok
+}
+
+func (g *ObsRepairGate) RecordValidationsAppliedOnce(escrowID string, entries []ValidationObsEntry) error {
+	if q := g.queueFor(escrowID); q != nil {
+		q.push(obsOp{entries: append([]ValidationObsEntry(nil), entries...)})
+		return nil
+	}
+	return g.Storage.RecordValidationsAppliedOnce(escrowID, entries)
+}
+
+func (g *ObsRepairGate) DrainInferenceValidationObs(escrowID string, inferenceID uint64) error {
+	if q := g.queueFor(escrowID); q != nil {
+		q.push(obsOp{drainID: inferenceID, drain: true})
+		return nil
+	}
+	return g.Storage.DrainInferenceValidationObs(escrowID, inferenceID)
+}
+
+// queueFor returns the active queue for an escrow, or nil to write through.
+// The queue is returned while the gate lock is dropped, so push takes its own
+// lock; ops appended after a drain round still get picked up by the next one.
+func (g *ObsRepairGate) queueFor(escrowID string) *obsQueue {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.queues[escrowID]
+}
+
+func (q *obsQueue) push(op obsOp) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.ops) >= maxQueuedObsOps {
+		q.dropped++
+		return
+	}
+	q.ops = append(q.ops, op)
+}
+
+// RepairValidationObs runs rebuild with exclusive access to an escrow's obs
+// rows, then applies everything the live path wrote in the meantime. rebuild
+// receives the underlying store so its own writes bypass the queue.
+//
+// Concurrent repairs for one escrow are rejected rather than serialized: the
+// caller would otherwise wait out a full journal replay holding nothing useful.
+func (g *ObsRepairGate) RepairValidationObs(escrowID string, rebuild func(Storage) error) error {
+	if err := g.open(escrowID); err != nil {
+		return err
+	}
+	rebuildErr := rebuild(g.Storage)
+	// Flush regardless: on failure the queued writes are still the only record
+	// of what the live path did during the window.
+	flushErr := g.drainAndClose(escrowID)
+	if rebuildErr != nil {
+		return rebuildErr
+	}
+	return flushErr
+}
+
+func (g *ObsRepairGate) open(escrowID string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.queues == nil {
+		g.queues = make(map[string]*obsQueue)
+	}
+	if _, busy := g.queues[escrowID]; busy {
+		return fmt.Errorf("validation obs repair already running for escrow %s", escrowID)
+	}
+	g.queues[escrowID] = &obsQueue{}
+	return nil
+}
+
+// maxObsDrainRounds bounds the flush so a continuously busy escrow cannot keep
+// the gate open indefinitely. After the last round the gate closes and any
+// remaining ops are applied with the gate already open to write-through, which
+// can only reorder writes the live path itself treats as best-effort.
+const maxObsDrainRounds = 64
+
+func (g *ObsRepairGate) drainAndClose(escrowID string) error {
+	var firstErr error
+	totalDropped := 0
+	for round := 0; ; round++ {
+		g.mu.Lock()
+		q := g.queues[escrowID]
+		if q == nil {
+			g.mu.Unlock()
+			break
+		}
+		ops, dropped := q.take()
+		totalDropped += dropped
+		last := len(ops) == 0 || round >= maxObsDrainRounds
+		if last {
+			// Closing while holding the gate lock means no writer can observe
+			// an empty queue and still be queued.
+			delete(g.queues, escrowID)
+		}
+		g.mu.Unlock()
+
+		if err := g.applyOps(escrowID, ops); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		if last {
+			break
+		}
+	}
+	if firstErr == nil && totalDropped > 0 {
+		return fmt.Errorf("validation obs repair for escrow %s dropped %d queued writes", escrowID, totalDropped)
+	}
+	return firstErr
+}
+
+func (q *obsQueue) take() ([]obsOp, int) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	ops, dropped := q.ops, q.dropped
+	q.ops, q.dropped = nil, 0
+	return ops, dropped
+}
+
+func (g *ObsRepairGate) applyOps(escrowID string, ops []obsOp) error {
+	var firstErr error
+	for _, op := range ops {
+		var err error
+		if op.drain {
+			err = g.Storage.DrainInferenceValidationObs(escrowID, op.drainID)
+		} else {
+			err = g.Storage.RecordValidationsAppliedOnce(escrowID, op.entries)
+		}
+		if err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("apply queued validation obs write: %w", err)
+		}
+	}
+	return firstErr
+}

--- a/devshard/storage/obs_repair_gate.go
+++ b/devshard/storage/obs_repair_gate.go
@@ -48,6 +48,7 @@ type obsOp struct {
 	entries     []ValidationObsEntry
 	drainID     uint64
 	drain       bool
+	drainBatch  []uint64
 	sealedRow   *InferenceRow
 	sealedBatch []InferenceRow
 }
@@ -87,6 +88,17 @@ func (g *ObsRepairGate) DrainInferenceValidationObs(escrowID string, inferenceID
 		return nil
 	}
 	return g.Storage.DrainInferenceValidationObs(escrowID, inferenceID)
+}
+
+func (g *ObsRepairGate) DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error {
+	if len(inferenceIDs) == 0 {
+		return nil
+	}
+	if q := g.queueFor(escrowID); q != nil {
+		q.push(obsOp{drainBatch: append([]uint64(nil), inferenceIDs...)})
+		return nil
+	}
+	return g.Storage.DrainInferenceValidationObsBatch(escrowID, inferenceIDs)
 }
 
 func cloneInferenceRow(row InferenceRow) InferenceRow {
@@ -233,6 +245,8 @@ func (g *ObsRepairGate) applyOps(escrowID string, ops []obsOp) error {
 		switch {
 		case op.drain:
 			err = g.Storage.DrainInferenceValidationObs(escrowID, op.drainID)
+		case len(op.drainBatch) > 0:
+			err = g.Storage.DrainInferenceValidationObsBatch(escrowID, op.drainBatch)
 		case op.sealedRow != nil:
 			err = g.Storage.InsertSealedInference(escrowID, *op.sealedRow)
 		case len(op.sealedBatch) > 0:

--- a/devshard/storage/obs_repair_gate_test.go
+++ b/devshard/storage/obs_repair_gate_test.go
@@ -1,0 +1,205 @@
+package storage
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/types"
+)
+
+var errRebuildFailed = errors.New("rebuild failed")
+
+func newGateTestStore(t *testing.T) *ObsRepairGate {
+	t.Helper()
+	inner := NewMemory()
+	require.NoError(t, inner.CreateSession(CreateSessionParams{EscrowID: "escrow-1", EpochID: 1, Version: "test"}))
+	return NewObsRepairGate(inner)
+}
+
+func gateObsForSlot(t *testing.T, store Storage, slotID uint32) SlotValidationObs {
+	t.Helper()
+	rows, err := store.GetValidationObservability("escrow-1")
+	require.NoError(t, err)
+	for _, r := range rows {
+		if r.SlotID == slotID {
+			return r
+		}
+	}
+	return SlotValidationObs{SlotID: slotID}
+}
+
+// With no repair running the gate must be invisible.
+func TestObsRepairGate_PassesThroughWhenIdle(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	require.False(t, gate.RepairInProgress("escrow-1"))
+	require.NoError(t, gate.RecordValidationsAppliedOnce("escrow-1", []ValidationObsEntry{{InferenceID: 7, SlotID: 2}}))
+
+	require.Equal(t, uint32(1), gateObsForSlot(t, gate, 2).CompletedValidations)
+}
+
+// The rebuild's own writes must bypass the queue, or it would queue its work
+// behind itself and deadlock its own flush.
+func TestObsRepairGate_RebuildWritesBypassTheQueue(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	err := gate.RepairValidationObs("escrow-1", func(inner Storage) error {
+		require.True(t, gate.RepairInProgress("escrow-1"))
+		return RebuildValidationObsFromDiffs(inner, "escrow-1", []types.DiffRecord{{
+			Diff: types.Diff{Nonce: 1, Txs: []*types.DevshardTx{validationTx(7, 2)}},
+		}}, nil)
+	})
+	require.NoError(t, err)
+
+	require.False(t, gate.RepairInProgress("escrow-1"))
+	require.Equal(t, uint32(1), gateObsForSlot(t, gate, 2).CompletedValidations)
+}
+
+// A live write during the window must land after the rebuild, not be lost and
+// not be counted twice.
+func TestObsRepairGate_QueuedWriteAppliedAfterRebuild(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	err := gate.RepairValidationObs("escrow-1", func(inner Storage) error {
+		if err := RebuildValidationObsFromDiffs(inner, "escrow-1", []types.DiffRecord{{
+			Diff: types.Diff{Nonce: 1, Txs: []*types.DevshardTx{validationTx(7, 2)}},
+		}}, nil); err != nil {
+			return err
+		}
+		// Stands in for the live apply path writing while the rebuild runs.
+		require.NoError(t, gate.RecordValidationsAppliedOnce("escrow-1",
+			[]ValidationObsEntry{{InferenceID: 9, SlotID: 3}}))
+		require.Equal(t, uint32(0), gateObsForSlot(t, gate, 3).CompletedValidations,
+			"the queued write must not be visible yet")
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(1), gateObsForSlot(t, gate, 2).CompletedValidations, "rebuilt row")
+	require.Equal(t, uint32(1), gateObsForSlot(t, gate, 3).CompletedValidations, "queued row")
+}
+
+// The clear would otherwise wipe a live write, and re-recording a drained
+// inference would double count it. Queueing must avoid both.
+func TestObsRepairGate_QueuedWriteSurvivesTheClear(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	err := gate.RepairValidationObs("escrow-1", func(inner Storage) error {
+		// Live write arrives before the rebuild clears the tables.
+		require.NoError(t, gate.RecordValidationsAppliedOnce("escrow-1",
+			[]ValidationObsEntry{{InferenceID: 9, SlotID: 3}}))
+		return RebuildValidationObsFromDiffs(inner, "escrow-1", []types.DiffRecord{{
+			Diff: types.Diff{Nonce: 1, Txs: []*types.DevshardTx{validationTx(7, 2)}},
+		}}, nil)
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(1), gateObsForSlot(t, gate, 3).CompletedValidations,
+		"a write queued before the clear must still be applied once")
+}
+
+// Queued drains have to keep their order relative to the record they follow,
+// otherwise the drain runs against a row that does not exist yet.
+func TestObsRepairGate_QueuePreservesRecordThenDrainOrder(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	err := gate.RepairValidationObs("escrow-1", func(inner Storage) error {
+		require.NoError(t, gate.RecordValidationsAppliedOnce("escrow-1",
+			[]ValidationObsEntry{{InferenceID: 9, SlotID: 3}}))
+		require.NoError(t, gate.DrainInferenceValidationObs("escrow-1", 9))
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The drain moved the row into sealed storage; the union still reports it
+	// exactly once.
+	require.Equal(t, uint32(1), gateObsForSlot(t, gate, 3).CompletedValidations)
+}
+
+func TestObsRepairGate_RejectsConcurrentRepairForSameEscrow(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	err := gate.RepairValidationObs("escrow-1", func(Storage) error {
+		return gate.RepairValidationObs("escrow-1", func(Storage) error {
+			t.Fatal("a second repair must not run for the same escrow")
+			return nil
+		})
+	})
+	require.ErrorContains(t, err, "already running")
+}
+
+// Queueing is keyed per escrow, so a repair on one must not swallow another's
+// live writes.
+func TestObsRepairGate_OtherEscrowsAreUnaffected(t *testing.T) {
+	inner := NewMemory()
+	require.NoError(t, inner.CreateSession(CreateSessionParams{EscrowID: "escrow-1", EpochID: 1, Version: "test"}))
+	require.NoError(t, inner.CreateSession(CreateSessionParams{EscrowID: "escrow-2", EpochID: 1, Version: "test"}))
+	gate := NewObsRepairGate(inner)
+
+	err := gate.RepairValidationObs("escrow-1", func(Storage) error {
+		require.NoError(t, gate.RecordValidationsAppliedOnce("escrow-2",
+			[]ValidationObsEntry{{InferenceID: 7, SlotID: 4}}))
+		rows, err := gate.GetValidationObservability("escrow-2")
+		require.NoError(t, err)
+		require.Len(t, rows, 1, "another escrow's write must not be queued")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestObsRepairGate_QueueOverflowIsReported(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	err := gate.RepairValidationObs("escrow-1", func(Storage) error {
+		for i := 0; i < maxQueuedObsOps+5; i++ {
+			require.NoError(t, gate.DrainInferenceValidationObs("escrow-1", uint64(i)))
+		}
+		return nil
+	})
+	require.ErrorContains(t, err, "dropped 5 queued writes")
+}
+
+// A rebuild failure must not strand the gate: the queue still has to flush and
+// the escrow has to return to write-through.
+func TestObsRepairGate_FlushesAndClosesAfterRebuildFailure(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	err := gate.RepairValidationObs("escrow-1", func(Storage) error {
+		require.NoError(t, gate.RecordValidationsAppliedOnce("escrow-1",
+			[]ValidationObsEntry{{InferenceID: 9, SlotID: 3}}))
+		return errRebuildFailed
+	})
+	require.ErrorIs(t, err, errRebuildFailed)
+
+	require.False(t, gate.RepairInProgress("escrow-1"), "the gate must not stay open")
+	require.Equal(t, uint32(1), gateObsForSlot(t, gate, 3).CompletedValidations,
+		"queued writes are the only record of the window and must still be applied")
+}
+
+func TestObsRepairGate_ConcurrentWritersDuringRepair(t *testing.T) {
+	gate := newGateTestStore(t)
+
+	const writers = 8
+	var wg sync.WaitGroup
+	err := gate.RepairValidationObs("escrow-1", func(inner Storage) error {
+		for i := 0; i < writers; i++ {
+			wg.Add(1)
+			go func(slot uint32) {
+				defer wg.Done()
+				_ = gate.RecordValidationsAppliedOnce("escrow-1",
+					[]ValidationObsEntry{{InferenceID: uint64(slot) + 100, SlotID: slot}})
+			}(uint32(i))
+		}
+		wg.Wait()
+		return RebuildValidationObsFromDiffs(inner, "escrow-1", nil, nil)
+	})
+	require.NoError(t, err)
+
+	for slot := uint32(0); slot < writers; slot++ {
+		require.Equal(t, uint32(1), gateObsForSlot(t, gate, slot).CompletedValidations,
+			"write from slot %d lost", slot)
+	}
+}

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -1288,6 +1288,54 @@ func (s *Postgres) InsertSealedInference(escrowID string, row InferenceRow) erro
 	return postgresExecInsertSealedInference(ctx, s.pool, epochID, escrowID, row)
 }
 
+const postgresInsertSealedInferencesSQL = `INSERT INTO devshard_sealed_inferences (
+			epoch_id, escrow_id, inference_id, sealed_nonce,
+			obs_present, sealed_status, sealed_executor_slot,
+			sealed_votes_valid, sealed_votes_invalid, sealed_validated_by,
+			sealed_model, sealed_prompt_hash, sealed_response_hash,
+			sealed_input_length, sealed_max_tokens,
+			sealed_input_tokens, sealed_output_tokens,
+			sealed_reserved_cost, sealed_actual_cost,
+			sealed_started_at, sealed_confirmed_at
+		)
+		SELECT $1, $2, t.* FROM unnest(
+			$3::bigint[], $4::bigint[], $5::boolean[], $6::int[], $7::int[],
+			$8::int[], $9::int[], $10::bytea[], $11::text[], $12::bytea[],
+			$13::bytea[], $14::bigint[], $15::bigint[], $16::bigint[],
+			$17::bigint[], $18::bigint[], $19::bigint[], $20::bigint[],
+			$21::bigint[]
+		) AS t(
+			inference_id, sealed_nonce, obs_present, sealed_status,
+			sealed_executor_slot, sealed_votes_valid, sealed_votes_invalid,
+			sealed_validated_by, sealed_model, sealed_prompt_hash,
+			sealed_response_hash, sealed_input_length, sealed_max_tokens,
+			sealed_input_tokens, sealed_output_tokens, sealed_reserved_cost,
+			sealed_actual_cost, sealed_started_at, sealed_confirmed_at
+		)
+		ON CONFLICT (epoch_id, escrow_id, inference_id) DO UPDATE SET
+			sealed_nonce = EXCLUDED.sealed_nonce,
+			obs_present = EXCLUDED.obs_present,
+			sealed_status = EXCLUDED.sealed_status,
+			sealed_executor_slot = EXCLUDED.sealed_executor_slot,
+			sealed_votes_valid = EXCLUDED.sealed_votes_valid,
+			sealed_votes_invalid = EXCLUDED.sealed_votes_invalid,
+			sealed_validated_by = EXCLUDED.sealed_validated_by,
+			sealed_model = EXCLUDED.sealed_model,
+			sealed_prompt_hash = EXCLUDED.sealed_prompt_hash,
+			sealed_response_hash = EXCLUDED.sealed_response_hash,
+			sealed_input_length = EXCLUDED.sealed_input_length,
+			sealed_max_tokens = EXCLUDED.sealed_max_tokens,
+			sealed_input_tokens = EXCLUDED.sealed_input_tokens,
+			sealed_output_tokens = EXCLUDED.sealed_output_tokens,
+			sealed_reserved_cost = EXCLUDED.sealed_reserved_cost,
+			sealed_actual_cost = EXCLUDED.sealed_actual_cost,
+			sealed_started_at = EXCLUDED.sealed_started_at,
+			sealed_confirmed_at = EXCLUDED.sealed_confirmed_at`
+
+// InsertSealedInferences upserts a chunk per statement instead of a statement
+// per row. Chunking the transaction alone still cost a round trip per
+// inference, which is what made a 1.5M-row rebuild a network problem rather
+// than a write problem.
 func (s *Postgres) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
 	if len(rows) == 0 {
 		return nil
@@ -1301,24 +1349,79 @@ func (s *Postgres) InsertSealedInferences(escrowID string, rows []InferenceRow) 
 		if end > len(rows) {
 			end = len(rows)
 		}
-		ctx, cancel := s.opCtx()
-		tx, err := s.pool.Begin(ctx)
-		if err != nil {
-			cancel()
-			return fmt.Errorf("insert sealed inferences begin: %w", err)
+		if err := s.insertSealedInferenceChunk(epochID, escrowID, rows[start:end]); err != nil {
+			return err
 		}
-		for i := start; i < end; i++ {
-			if err := postgresExecInsertSealedInference(ctx, tx, epochID, escrowID, rows[i]); err != nil {
-				_ = tx.Rollback(ctx)
-				cancel()
-				return err
-			}
+	}
+	return nil
+}
+
+func (s *Postgres) insertSealedInferenceChunk(epochID uint64, escrowID string, rows []InferenceRow) error {
+	// ON CONFLICT DO UPDATE cannot touch the same row twice in one statement,
+	// so collapse ids repeated inside the chunk to the last value, which is
+	// what the row-at-a-time form produced.
+	deduped := make([]InferenceRow, 0, len(rows))
+	at := make(map[uint64]int, len(rows))
+	for _, row := range rows {
+		if i, seen := at[row.InferenceID]; seen {
+			deduped[i] = row
+			continue
 		}
-		if err := tx.Commit(ctx); err != nil {
-			cancel()
-			return fmt.Errorf("insert sealed inferences commit: %w", err)
-		}
-		cancel()
+		at[row.InferenceID] = len(deduped)
+		deduped = append(deduped, row)
+	}
+
+	n := len(deduped)
+	inferenceIDs := make([]int64, n)
+	sealedNonces := make([]int64, n)
+	obsPresent := make([]bool, n)
+	statuses := make([]int32, n)
+	executorSlots := make([]int32, n)
+	votesValid := make([]int32, n)
+	votesInvalid := make([]int32, n)
+	validatedBy := make([][]byte, n)
+	models := make([]string, n)
+	promptHashes := make([][]byte, n)
+	responseHashes := make([][]byte, n)
+	inputLengths := make([]int64, n)
+	maxTokens := make([]int64, n)
+	inputTokens := make([]int64, n)
+	outputTokens := make([]int64, n)
+	reservedCosts := make([]int64, n)
+	actualCosts := make([]int64, n)
+	startedAt := make([]int64, n)
+	confirmedAt := make([]int64, n)
+	for i, row := range deduped {
+		inferenceIDs[i] = int64(row.InferenceID)
+		sealedNonces[i] = int64(row.SealedNonce)
+		obsPresent[i] = row.ObsPresent
+		statuses[i] = int32(row.SealedStatus)
+		executorSlots[i] = int32(row.SealedExecutorSlot)
+		votesValid[i] = int32(row.SealedVotesValid)
+		votesInvalid[i] = int32(row.SealedVotesInvalid)
+		validatedBy[i] = row.SealedValidatedBy
+		models[i] = row.SealedModel
+		promptHashes[i] = row.SealedPromptHash
+		responseHashes[i] = row.SealedResponseHash
+		inputLengths[i] = int64(row.SealedInputLength)
+		maxTokens[i] = int64(row.SealedMaxTokens)
+		inputTokens[i] = int64(row.SealedInputTokens)
+		outputTokens[i] = int64(row.SealedOutputTokens)
+		reservedCosts[i] = int64(row.SealedReservedCost)
+		actualCosts[i] = int64(row.SealedActualCost)
+		startedAt[i] = row.SealedStartedAt
+		confirmedAt[i] = row.SealedConfirmedAt
+	}
+
+	ctx, cancel := s.opCtx()
+	defer cancel()
+	if _, err := s.pool.Exec(ctx, postgresInsertSealedInferencesSQL,
+		epochID, escrowID, inferenceIDs, sealedNonces, obsPresent, statuses,
+		executorSlots, votesValid, votesInvalid, validatedBy, models,
+		promptHashes, responseHashes, inputLengths, maxTokens, inputTokens,
+		outputTokens, reservedCosts, actualCosts, startedAt, confirmedAt,
+	); err != nil {
+		return fmt.Errorf("insert sealed inferences: %w", err)
 	}
 	return nil
 }

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -1227,15 +1227,7 @@ func (s *Postgres) LoadSnapshot(escrowID string) (uint64, []byte, error) {
 	return nonce, data, nil
 }
 
-func (s *Postgres) InsertSealedInference(escrowID string, row InferenceRow) error {
-	epochID, err := s.lookupEpoch(escrowID)
-	if err != nil {
-		return err
-	}
-	ctx, cancel := s.opCtx()
-	defer cancel()
-	_, err = s.pool.Exec(ctx,
-		`INSERT INTO devshard_sealed_inferences (
+const postgresInsertSealedInferenceSQL = `INSERT INTO devshard_sealed_inferences (
 			epoch_id, escrow_id, inference_id, sealed_nonce,
 			obs_present, sealed_status, sealed_executor_slot,
 			sealed_votes_valid, sealed_votes_invalid, sealed_validated_by,
@@ -1263,7 +1255,14 @@ func (s *Postgres) InsertSealedInference(escrowID string, row InferenceRow) erro
 			sealed_reserved_cost = EXCLUDED.sealed_reserved_cost,
 			sealed_actual_cost = EXCLUDED.sealed_actual_cost,
 			sealed_started_at = EXCLUDED.sealed_started_at,
-			sealed_confirmed_at = EXCLUDED.sealed_confirmed_at`,
+			sealed_confirmed_at = EXCLUDED.sealed_confirmed_at`
+
+type postgresExecer interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
+
+func postgresExecInsertSealedInference(ctx context.Context, exec postgresExecer, epochID uint64, escrowID string, row InferenceRow) error {
+	_, err := exec.Exec(ctx, postgresInsertSealedInferenceSQL,
 		epochID, escrowID, row.InferenceID, row.SealedNonce, row.ObsPresent,
 		row.SealedStatus, row.SealedExecutorSlot,
 		row.SealedVotesValid, row.SealedVotesInvalid, row.SealedValidatedBy,
@@ -1275,6 +1274,51 @@ func (s *Postgres) InsertSealedInference(escrowID string, row InferenceRow) erro
 	)
 	if err != nil {
 		return fmt.Errorf("insert sealed inference: %w", err)
+	}
+	return nil
+}
+
+func (s *Postgres) InsertSealedInference(escrowID string, row InferenceRow) error {
+	epochID, err := s.lookupEpoch(escrowID)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := s.opCtx()
+	defer cancel()
+	return postgresExecInsertSealedInference(ctx, s.pool, epochID, escrowID, row)
+}
+
+func (s *Postgres) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	epochID, err := s.lookupEpoch(escrowID)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(rows); start += sealedInferenceInsertChunk {
+		end := start + sealedInferenceInsertChunk
+		if end > len(rows) {
+			end = len(rows)
+		}
+		ctx, cancel := s.opCtx()
+		tx, err := s.pool.Begin(ctx)
+		if err != nil {
+			cancel()
+			return fmt.Errorf("insert sealed inferences begin: %w", err)
+		}
+		for i := start; i < end; i++ {
+			if err := postgresExecInsertSealedInference(ctx, tx, epochID, escrowID, rows[i]); err != nil {
+				_ = tx.Rollback(ctx)
+				cancel()
+				return err
+			}
+		}
+		if err := tx.Commit(ctx); err != nil {
+			cancel()
+			return fmt.Errorf("insert sealed inferences commit: %w", err)
+		}
+		cancel()
 	}
 	return nil
 }
@@ -1330,6 +1374,36 @@ func (s *Postgres) DeleteSealedInferences(escrowID string) error {
 		return fmt.Errorf("delete sealed inferences: %w", err)
 	}
 	return nil
+}
+
+func (s *Postgres) SealedInferenceIDs(escrowID string) (map[uint64]uint64, error) {
+	epochID, err := s.lookupEpoch(escrowID)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := s.opCtx()
+	defer cancel()
+	rows, err := s.pool.Query(ctx,
+		`SELECT inference_id, sealed_nonce FROM devshard_sealed_inferences
+		  WHERE epoch_id = $1 AND escrow_id = $2`,
+		epochID, escrowID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list sealed inference ids: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[uint64]uint64)
+	for rows.Next() {
+		var id, nonce uint64
+		if err := rows.Scan(&id, &nonce); err != nil {
+			return nil, fmt.Errorf("scan sealed inference id: %w", err)
+		}
+		out[id] = nonce
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (s *Postgres) ClearValidationObs(escrowID string) error {

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -68,6 +68,9 @@ const (
 	// postgresIndexRepairBatchSize caps rows per DELETE/INSERT when repairing
 	// devshard_session_index so a large divergence does not hold one giant lock.
 	postgresIndexRepairBatchSize = 1000
+	// pgUniqueViolation is SQLSTATE 23505, returned when COPY hits a row the
+	// caller expected not to exist.
+	pgUniqueViolation = "23505"
 )
 
 const (
@@ -1356,6 +1359,79 @@ func (s *Postgres) InsertSealedInferences(escrowID string, rows []InferenceRow) 
 	return nil
 }
 
+var postgresSealedInferenceColumns = []string{
+	"epoch_id", "escrow_id", "inference_id", "sealed_nonce",
+	"obs_present", "sealed_status", "sealed_executor_slot",
+	"sealed_votes_valid", "sealed_votes_invalid", "sealed_validated_by",
+	"sealed_model", "sealed_prompt_hash", "sealed_response_hash",
+	"sealed_input_length", "sealed_max_tokens",
+	"sealed_input_tokens", "sealed_output_tokens",
+	"sealed_reserved_cost", "sealed_actual_cost",
+	"sealed_started_at", "sealed_confirmed_at",
+}
+
+// BulkInsertSealedInferences loads rows with COPY. What is left of the upsert
+// path's cost is the per-row conflict probe, not the protocol, so dropping the
+// probe is worth about 3x — enough to make Postgres the faster backend here.
+// A collision means the caller's range was not empty after all; that chunk
+// falls back to the upsert rather than failing the rebuild.
+func (s *Postgres) BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	epochID, err := s.lookupEpoch(escrowID)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(rows); start += sealedInferenceCopyChunk {
+		end := start + sealedInferenceCopyChunk
+		if end > len(rows) {
+			end = len(rows)
+		}
+		chunk := rows[start:end]
+		if err := s.copySealedInferenceChunk(epochID, escrowID, chunk); err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
+				if err := s.InsertSealedInferences(escrowID, chunk); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Postgres) copySealedInferenceChunk(epochID uint64, escrowID string, rows []InferenceRow) error {
+	ctx, cancel := s.opCtx()
+	defer cancel()
+	if err := s.ensurePartition(ctx, epochID); err != nil {
+		return err
+	}
+	_, err := s.pool.CopyFrom(ctx,
+		pgx.Identifier{pgInferencesParent},
+		postgresSealedInferenceColumns,
+		pgx.CopyFromSlice(len(rows), func(i int) ([]any, error) {
+			r := rows[i]
+			return []any{
+				int64(epochID), escrowID, int64(r.InferenceID), int64(r.SealedNonce),
+				r.ObsPresent, int32(r.SealedStatus), int32(r.SealedExecutorSlot),
+				int32(r.SealedVotesValid), int32(r.SealedVotesInvalid), r.SealedValidatedBy,
+				r.SealedModel, r.SealedPromptHash, r.SealedResponseHash,
+				int64(r.SealedInputLength), int64(r.SealedMaxTokens),
+				int64(r.SealedInputTokens), int64(r.SealedOutputTokens),
+				int64(r.SealedReservedCost), int64(r.SealedActualCost),
+				r.SealedStartedAt, r.SealedConfirmedAt,
+			}, nil
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("copy sealed inferences: %w", err)
+	}
+	return nil
+}
+
 func (s *Postgres) insertSealedInferenceChunk(epochID uint64, escrowID string, rows []InferenceRow) error {
 	// ON CONFLICT DO UPDATE cannot touch the same row twice in one statement,
 	// so collapse ids repeated inside the chunk to the last value, which is
@@ -1654,39 +1730,35 @@ func (s *Postgres) DrainInferenceValidationObsBatch(escrowID string, inferenceID
 // rows are unique per (epoch, escrow, inference, slot), so no source row
 // conflicts with another row of the same statement and the accumulate applies
 // per target row, exactly as in the single-id form.
+//
+// The move is one data-modifying CTE rather than an explicit transaction around
+// an INSERT and a DELETE: same atomicity, but one round trip per chunk instead
+// of four, which is what the cost is made of once the rows are batched.
 func (s *Postgres) drainValidationObsChunk(epochID uint64, escrowID string, ids []int64) error {
 	ctx, cancel := s.opCtx()
 	defer cancel()
 	if err := s.ensurePartition(ctx, epochID); err != nil {
 		return err
 	}
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("drain inference validation obs begin: %w", err)
-	}
-	defer tx.Rollback(ctx)
-
-	if _, err := tx.Exec(ctx,
-		`INSERT INTO devshard_sealed_validation_obs (epoch_id, escrow_id, inference_id, slot_id, required_validations, completed_validations)
-		 SELECT epoch_id, escrow_id, inference_id, slot_id, required_validations, completed_validations
-		   FROM devshard_inference_validation_obs
-		  WHERE epoch_id = $1 AND escrow_id = $2 AND inference_id = ANY($3::bigint[])
+	if _, err := s.pool.Exec(ctx,
+		`WITH moved AS (
+		   DELETE FROM devshard_inference_validation_obs
+		    WHERE epoch_id = $1 AND escrow_id = $2 AND inference_id = ANY($3::bigint[])
+		   RETURNING epoch_id, escrow_id, inference_id, slot_id,
+		             required_validations, completed_validations
+		 )
+		 INSERT INTO devshard_sealed_validation_obs (
+		   epoch_id, escrow_id, inference_id, slot_id,
+		   required_validations, completed_validations)
+		 SELECT epoch_id, escrow_id, inference_id, slot_id,
+		        required_validations, completed_validations
+		   FROM moved
 		 ON CONFLICT (epoch_id, escrow_id, inference_id, slot_id) DO UPDATE SET
 		   required_validations = devshard_sealed_validation_obs.required_validations + EXCLUDED.required_validations,
 		   completed_validations = devshard_sealed_validation_obs.completed_validations + EXCLUDED.completed_validations`,
 		epochID, escrowID, ids,
 	); err != nil {
-		return fmt.Errorf("drain inference validation obs insert: %w", err)
-	}
-	if _, err := tx.Exec(ctx,
-		`DELETE FROM devshard_inference_validation_obs
-		  WHERE epoch_id = $1 AND escrow_id = $2 AND inference_id = ANY($3::bigint[])`,
-		epochID, escrowID, ids,
-	); err != nil {
-		return fmt.Errorf("drain inference validation obs delete: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("drain inference validation obs commit: %w", err)
+		return fmt.Errorf("drain inference validation obs: %w", err)
 	}
 	return nil
 }

--- a/devshard/storage/postgres.go
+++ b/devshard/storage/postgres.go
@@ -1523,6 +1523,71 @@ func (s *Postgres) DrainInferenceValidationObs(escrowID string, inferenceID uint
 	return tx.Commit(ctx)
 }
 
+func (s *Postgres) DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error {
+	if len(inferenceIDs) == 0 {
+		return nil
+	}
+	epochID, err := s.lookupEpoch(escrowID)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(inferenceIDs); start += validationObsRebuildChunk {
+		end := start + validationObsRebuildChunk
+		if end > len(inferenceIDs) {
+			end = len(inferenceIDs)
+		}
+		ids := make([]int64, 0, end-start)
+		for _, id := range inferenceIDs[start:end] {
+			ids = append(ids, int64(id))
+		}
+		if err := s.drainValidationObsChunk(epochID, escrowID, ids); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// drainValidationObsChunk moves and deletes one id chunk set-at-a-time. Live
+// rows are unique per (epoch, escrow, inference, slot), so no source row
+// conflicts with another row of the same statement and the accumulate applies
+// per target row, exactly as in the single-id form.
+func (s *Postgres) drainValidationObsChunk(epochID uint64, escrowID string, ids []int64) error {
+	ctx, cancel := s.opCtx()
+	defer cancel()
+	if err := s.ensurePartition(ctx, epochID); err != nil {
+		return err
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("drain inference validation obs begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO devshard_sealed_validation_obs (epoch_id, escrow_id, inference_id, slot_id, required_validations, completed_validations)
+		 SELECT epoch_id, escrow_id, inference_id, slot_id, required_validations, completed_validations
+		   FROM devshard_inference_validation_obs
+		  WHERE epoch_id = $1 AND escrow_id = $2 AND inference_id = ANY($3::bigint[])
+		 ON CONFLICT (epoch_id, escrow_id, inference_id, slot_id) DO UPDATE SET
+		   required_validations = devshard_sealed_validation_obs.required_validations + EXCLUDED.required_validations,
+		   completed_validations = devshard_sealed_validation_obs.completed_validations + EXCLUDED.completed_validations`,
+		epochID, escrowID, ids,
+	); err != nil {
+		return fmt.Errorf("drain inference validation obs insert: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM devshard_inference_validation_obs
+		  WHERE epoch_id = $1 AND escrow_id = $2 AND inference_id = ANY($3::bigint[])`,
+		epochID, escrowID, ids,
+	); err != nil {
+		return fmt.Errorf("drain inference validation obs delete: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("drain inference validation obs commit: %w", err)
+	}
+	return nil
+}
+
 func (s *Postgres) GetValidationObservability(escrowID string) ([]SlotValidationObs, error) {
 	epochID, err := s.lookupEpoch(escrowID)
 	if err != nil {

--- a/devshard/storage/postgres_bench_test.go
+++ b/devshard/storage/postgres_bench_test.go
@@ -184,6 +184,29 @@ func BenchmarkPostgresSealedInferenceIndex_BatchedInsert(b *testing.B) {
 	}
 }
 
+// The post-wipe load: COPY, no per-row conflict probe. This is the path the
+// full-replay rebuild takes, and the only reason the upsert form above still
+// exists is gap fill, where rows may already be present.
+func BenchmarkPostgresSealedInferenceIndex_BulkInsert(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			rows := benchSealedRows(n, true)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.DeleteSealedInferences("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				if err := db.BulkInsertSealedInferences("escrow-1", rows); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkPostgresValidationObsDrain_PerID(b *testing.B) {
 	db := benchPostgres(b)
 	for _, n := range []int{2_000, 20_000} {

--- a/devshard/storage/postgres_bench_test.go
+++ b/devshard/storage/postgres_bench_test.go
@@ -1,0 +1,282 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+// benchPostgres starts one container for the whole benchmark function and
+// returns a ready store with escrow-1 created. Sub-benchmarks share it and
+// clean up their own rows, so the container cost is paid once.
+//
+// The container is reached over the Docker bridge, so its round trip is closer
+// to a same-host TCP hop than to a production network. Numbers that turn on
+// round trips are therefore optimistic here, not pessimistic.
+func benchPostgres(b *testing.B) *Postgres {
+	b.Helper()
+	if testing.Short() {
+		b.Skip("skipping postgres benchmarks in -short mode (requires Docker)")
+	}
+	ctx := context.Background()
+	container, err := postgres.Run(ctx,
+		"postgres:18.1-bookworm",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(postgresContainerWaitStrategy()),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	port, err := container.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Setenv("PGHOST", host)
+	b.Setenv("PGPORT", port.Port())
+	b.Setenv("PGDATABASE", "testdb")
+	b.Setenv("PGUSER", "testuser")
+	b.Setenv("PGPASSWORD", "testpass")
+
+	pg, err := NewPostgres(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = pg.Close() })
+	if err := pg.WaitReady(ctx); err != nil {
+		b.Fatal(err)
+	}
+	if err := pg.CreateSession(defaultParams()); err != nil {
+		b.Fatal(err)
+	}
+	return pg
+}
+
+// postgresInsertSealedChunkedPerRow is the shape InsertSealedInferences had
+// before the unnest upsert: a transaction per chunk, but still one statement —
+// and so one round trip — per row. Kept here to price that difference.
+func postgresInsertSealedChunkedPerRow(b *testing.B, s *Postgres, escrowID string, rows []InferenceRow) {
+	b.Helper()
+	epochID, err := s.lookupEpoch(escrowID)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for start := 0; start < len(rows); start += sealedInferenceInsertChunk {
+		end := start + sealedInferenceInsertChunk
+		if end > len(rows) {
+			end = len(rows)
+		}
+		ctx, cancel := s.opCtx()
+		tx, err := s.pool.Begin(ctx)
+		if err != nil {
+			cancel()
+			b.Fatal(err)
+		}
+		for i := start; i < end; i++ {
+			if err := postgresExecInsertSealedInference(ctx, tx, epochID, escrowID, rows[i]); err != nil {
+				_ = tx.Rollback(ctx)
+				cancel()
+				b.Fatal(err)
+			}
+		}
+		if err := tx.Commit(ctx); err != nil {
+			cancel()
+			b.Fatal(err)
+		}
+		cancel()
+	}
+}
+
+func BenchmarkPostgresSealedInferenceIDs(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			if err := db.DeleteSealedInferences("escrow-1"); err != nil {
+				b.Fatal(err)
+			}
+			if err := db.InsertSealedInferences("escrow-1", benchSealedRows(n, true)); err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ids, err := db.SealedInferenceIDs("escrow-1")
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(ids) != n {
+					b.Fatalf("got %d ids, want %d", len(ids), n)
+				}
+			}
+		})
+	}
+}
+
+// Pre-fix recovery: one autocommit statement per sealed id.
+func BenchmarkPostgresSealedInferenceIndex_UnbatchedInsert(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			rows := benchSealedRows(n, false)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.DeleteSealedInferences("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				for _, row := range rows {
+					if err := db.InsertSealedInference("escrow-1", row); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+// The intermediate: chunked transactions, still a round trip per row.
+func BenchmarkPostgresSealedInferenceIndex_ChunkedTxPerRow(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			rows := benchSealedRows(n, true)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.DeleteSealedInferences("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				postgresInsertSealedChunkedPerRow(b, db, "escrow-1", rows)
+			}
+		})
+	}
+}
+
+// Current: one unnest upsert per chunk.
+func BenchmarkPostgresSealedInferenceIndex_BatchedInsert(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			rows := benchSealedRows(n, true)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.DeleteSealedInferences("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				if err := db.InsertSealedInferences("escrow-1", rows); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPostgresValidationObsDrain_PerID(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			ids := benchSealedIDs(n)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.ClearValidationObs("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				if err := db.RecordValidationsAppliedOnce("escrow-1", benchObsEntries(n)); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				for _, id := range ids {
+					if err := db.DrainInferenceValidationObs("escrow-1", id); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPostgresValidationObsDrain_Batched(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			ids := benchSealedIDs(n)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.ClearValidationObs("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				if err := db.RecordValidationsAppliedOnce("escrow-1", benchObsEntries(n)); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				if err := db.DrainInferenceValidationObsBatch("escrow-1", ids); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPostgresValidationObsRecord_PerDiff(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.ClearValidationObs("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				for j := 0; j < n; j++ {
+					if err := db.RecordValidationsAppliedOnce("escrow-1", []ValidationObsEntry{
+						{InferenceID: uint64(j + 1), SlotID: 1},
+					}); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPostgresValidationObsRecord_Chunked(b *testing.B) {
+	db := benchPostgres(b)
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			entries := benchObsEntries(n)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.ClearValidationObs("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				for start := 0; start < n; start += validationObsRebuildChunk {
+					end := start + validationObsRebuildChunk
+					if end > n {
+						end = n
+					}
+					if err := db.RecordValidationsAppliedOnce("escrow-1", entries[start:end]); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -152,6 +152,9 @@ func TestPostgres_SaveLoadSnapshot(t *testing.T) {
 func TestPostgres_SealedInferenceLifecycle(t *testing.T) {
 	runSealedInferenceLifecycle(t, newTestPostgres(t))
 }
+func TestPostgres_SealedInferenceBatchInsert(t *testing.T) {
+	runSealedInferenceBatchInsert(t, newTestPostgres(t))
+}
 func TestPostgres_ValidationObsBatchDrain(t *testing.T) {
 	runValidationObsBatchDrain(t, newTestPostgres(t))
 }

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -152,6 +152,9 @@ func TestPostgres_SaveLoadSnapshot(t *testing.T) {
 func TestPostgres_SealedInferenceLifecycle(t *testing.T) {
 	runSealedInferenceLifecycle(t, newTestPostgres(t))
 }
+func TestPostgres_ValidationObsBatchDrain(t *testing.T) {
+	runValidationObsBatchDrain(t, newTestPostgres(t))
+}
 func TestPostgres_AddSignature(t *testing.T) {
 	runAddSignature(t, newTestPostgres(t))
 }

--- a/devshard/storage/postgres_test.go
+++ b/devshard/storage/postgres_test.go
@@ -155,6 +155,9 @@ func TestPostgres_SealedInferenceLifecycle(t *testing.T) {
 func TestPostgres_SealedInferenceBatchInsert(t *testing.T) {
 	runSealedInferenceBatchInsert(t, newTestPostgres(t))
 }
+func TestPostgres_SealedInferenceBulkInsert(t *testing.T) {
+	runSealedInferenceBulkInsert(t, newTestPostgres(t))
+}
 func TestPostgres_ValidationObsBatchDrain(t *testing.T) {
 	runValidationObsBatchDrain(t, newTestPostgres(t))
 }

--- a/devshard/storage/sealed.go
+++ b/devshard/storage/sealed.go
@@ -5,3 +5,9 @@ package storage
 // round-trip storm. Chunked transactions keep each commit inside the timeout
 // without going back to one RTT per inference.
 const sealedInferenceInsertChunk = 500
+
+// sealedInferenceCopyChunk bounds rows per COPY on the post-wipe load path.
+// COPY does no per-row conflict probe, so it can carry far more rows per
+// statement than the upsert; the chunk exists only to keep one call inside
+// statement_timeout and postgresOpTimeout.
+const sealedInferenceCopyChunk = 50_000

--- a/devshard/storage/sealed.go
+++ b/devshard/storage/sealed.go
@@ -1,0 +1,7 @@
+package storage
+
+// sealedInferenceInsertChunk bounds rows per write transaction. Postgres
+// statement_timeout is 5s; one Exec per id would also be a restart-time
+// round-trip storm. Chunked transactions keep each commit inside the timeout
+// without going back to one RTT per inference.
+const sealedInferenceInsertChunk = 500

--- a/devshard/storage/sealed_bench_test.go
+++ b/devshard/storage/sealed_bench_test.go
@@ -1,0 +1,100 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+)
+
+func benchSQLite(b *testing.B) *SQLite {
+	b.Helper()
+	db, err := NewSQLite(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { db.Close() })
+	if err := db.CreateSession(defaultParams()); err != nil {
+		b.Fatal(err)
+	}
+	return db
+}
+
+func benchSealedRows(n int, obsPresent bool) []InferenceRow {
+	rows := make([]InferenceRow, n)
+	for i := 0; i < n; i++ {
+		rows[i] = InferenceRow{
+			InferenceID:        uint64(i + 1),
+			SealedNonce:        uint64(i + 1),
+			ObsPresent:         obsPresent,
+			SealedModel:        "llama",
+			SealedInputTokens:  10,
+			SealedOutputTokens: 20,
+		}
+	}
+	return rows
+}
+
+// Snapshot restart after steps 1–3: list existing ids, write nothing.
+func BenchmarkSealedInferenceIDs(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			db := benchSQLite(b)
+			if err := db.InsertSealedInferences("escrow-1", benchSealedRows(n, true)); err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ids, err := db.SealedInferenceIDs("escrow-1")
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(ids) != n {
+					b.Fatalf("got %d ids, want %d", len(ids), n)
+				}
+			}
+		})
+	}
+}
+
+// Pre-fix recovery: one Exec per sealed id (plus a delete).
+func BenchmarkSealedInferenceIndex_UnbatchedInsert(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			db := benchSQLite(b)
+			rows := benchSealedRows(n, false)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.DeleteSealedInferences("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				for _, row := range rows {
+					if err := db.InsertSealedInference("escrow-1", row); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Full-replay repair after steps 1–3: chunked transactions.
+func BenchmarkSealedInferenceIndex_BatchedInsert(b *testing.B) {
+	for _, n := range []int{2_000, 20_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			db := benchSQLite(b)
+			rows := benchSealedRows(n, true)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				if err := db.DeleteSealedInferences("escrow-1"); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				if err := db.InsertSealedInferences("escrow-1", rows); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/devshard/storage/shared_test.go
+++ b/devshard/storage/shared_test.go
@@ -365,6 +365,43 @@ func runSealedInferenceBatchInsert(t *testing.T, store Storage) {
 	require.NoError(t, store.InsertSealedInferences("escrow-1", nil))
 }
 
+// runSealedInferenceBulkInsert pins the post-wipe load path: it must be
+// indistinguishable from the upsert to callers, including when its "no rows
+// exist yet" precondition turns out to be false, since Postgres reaches that
+// case only through a COPY error and a retry.
+func runSealedInferenceBulkInsert(t *testing.T, store Storage) {
+	t.Helper()
+
+	require.NoError(t, store.CreateSession(defaultParams()))
+	require.NoError(t, store.BulkInsertSealedInferences("escrow-1", nil))
+
+	rich := testInferenceRow(7)
+	rich.ObsPresent = true
+	rich.SealedModel = "llama"
+	rich.SealedValidatedBy = []byte{0x0f, 0xf0}
+	bare := InferenceRow{InferenceID: 8, SealedNonce: 12}
+	require.NoError(t, store.BulkInsertSealedInferences("escrow-1", []InferenceRow{rich, bare}))
+
+	got, ok, err := store.GetSealedInference("escrow-1", 7)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, rich, got, "every sealed column must survive the bulk load")
+
+	ids, err := store.SealedInferenceIDs("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, map[uint64]uint64{7: rich.SealedNonce, 8: 12}, ids)
+
+	// Precondition violated: the rows are already there. The load must still
+	// end with the new values rather than failing the rebuild.
+	rich.SealedNonce = 99
+	rich.SealedModel = "mistral"
+	require.NoError(t, store.BulkInsertSealedInferences("escrow-1", []InferenceRow{rich}))
+	got, ok, err = store.GetSealedInference("escrow-1", 7)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, rich, got)
+}
+
 // runValidationObsBatchDrain pins the batch drain against the per-id form it
 // replaced in the rebuild: same sealed totals, live rows gone, ids with nothing
 // live tolerated, and accumulate onto an existing sealed row.

--- a/devshard/storage/shared_test.go
+++ b/devshard/storage/shared_test.go
@@ -281,10 +281,26 @@ func runSealedInferenceLifecycle(t *testing.T, store Storage) {
 	require.True(t, ok)
 	require.Equal(t, uint32(5), got.SealedStatus)
 
+	ids, err := store.SealedInferenceIDs("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, map[uint64]uint64{1: 42}, ids)
+
+	rich := testInferenceRow(2)
+	rich.ObsPresent = true
+	rich.SealedModel = "llama"
+	require.NoError(t, store.InsertSealedInferences("escrow-1", []InferenceRow{rich}))
+	ids, err = store.SealedInferenceIDs("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), ids[1])
+	require.Equal(t, uint64(42), ids[2], "bare and rich rows both appear so gap fill can skip existing rows")
+
 	require.NoError(t, store.DeleteSealedInferences("escrow-1"))
 	_, ok, err = store.GetSealedInference("escrow-1", 1)
 	require.NoError(t, err)
 	require.False(t, ok)
+	ids, err = store.SealedInferenceIDs("escrow-1")
+	require.NoError(t, err)
+	require.Empty(t, ids)
 }
 
 func runAddSignature(t *testing.T, store Storage) {

--- a/devshard/storage/shared_test.go
+++ b/devshard/storage/shared_test.go
@@ -303,6 +303,68 @@ func runSealedInferenceLifecycle(t *testing.T, store Storage) {
 	require.Empty(t, ids)
 }
 
+// runSealedInferenceBatchInsert pins the set-at-a-time upsert against the
+// row-at-a-time form it replaced: every column round-trips, an existing row is
+// overwritten, and an id repeated inside one batch keeps the last value.
+func runSealedInferenceBatchInsert(t *testing.T, store Storage) {
+	t.Helper()
+
+	require.NoError(t, store.CreateSession(defaultParams()))
+
+	rich := InferenceRow{
+		InferenceID:        7,
+		SealedNonce:        11,
+		ObsPresent:         true,
+		SealedStatus:       3,
+		SealedExecutorSlot: 2,
+		SealedVotesValid:   4,
+		SealedVotesInvalid: 1,
+		SealedValidatedBy:  []byte{0x0f, 0xf0},
+		SealedModel:        "llama",
+		SealedPromptHash:   []byte("prompt"),
+		SealedResponseHash: []byte("response"),
+		SealedInputLength:  100,
+		SealedMaxTokens:    50,
+		SealedInputTokens:  10,
+		SealedOutputTokens: 20,
+		SealedReservedCost: 150,
+		SealedActualCost:   30,
+		SealedStartedAt:    1000,
+		SealedConfirmedAt:  2000,
+	}
+	bare := InferenceRow{InferenceID: 8, SealedNonce: 12}
+	require.NoError(t, store.InsertSealedInference("escrow-1", InferenceRow{InferenceID: 8, SealedNonce: 1}))
+
+	// Inference 9 appears twice in the same batch; the later row must win.
+	first := InferenceRow{InferenceID: 9, SealedNonce: 13}
+	last := InferenceRow{InferenceID: 9, SealedNonce: 14, ObsPresent: true, SealedModel: "mistral"}
+
+	require.NoError(t, store.InsertSealedInferences("escrow-1", []InferenceRow{rich, bare, first, last}))
+
+	got, ok, err := store.GetSealedInference("escrow-1", 7)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, rich, got, "every sealed column must survive the batch insert")
+
+	got, ok, err = store.GetSealedInference("escrow-1", 8)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(12), got.SealedNonce, "the batch upsert must overwrite an existing row")
+	require.False(t, got.ObsPresent)
+
+	got, ok, err = store.GetSealedInference("escrow-1", 9)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(14), got.SealedNonce)
+	require.Equal(t, "mistral", got.SealedModel)
+
+	ids, err := store.SealedInferenceIDs("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, map[uint64]uint64{7: 11, 8: 12, 9: 14}, ids)
+
+	require.NoError(t, store.InsertSealedInferences("escrow-1", nil))
+}
+
 // runValidationObsBatchDrain pins the batch drain against the per-id form it
 // replaced in the rebuild: same sealed totals, live rows gone, ids with nothing
 // live tolerated, and accumulate onto an existing sealed row.

--- a/devshard/storage/shared_test.go
+++ b/devshard/storage/shared_test.go
@@ -303,6 +303,49 @@ func runSealedInferenceLifecycle(t *testing.T, store Storage) {
 	require.Empty(t, ids)
 }
 
+// runValidationObsBatchDrain pins the batch drain against the per-id form it
+// replaced in the rebuild: same sealed totals, live rows gone, ids with nothing
+// live tolerated, and accumulate onto an existing sealed row.
+func runValidationObsBatchDrain(t *testing.T, store Storage) {
+	t.Helper()
+
+	require.NoError(t, store.CreateSession(defaultParams()))
+
+	for _, id := range []uint64{1, 2, 3} {
+		require.NoError(t, store.RecordValidationsAppliedOnce("escrow-1", []ValidationObsEntry{
+			{InferenceID: id, SlotID: 0},
+			{InferenceID: id, SlotID: 1},
+		}))
+	}
+	// Inference 2 drains twice, so its sealed row is accumulated onto rather
+	// than inserted; ids 4 and 5 have no live rows at all.
+	require.NoError(t, store.DrainInferenceValidationObs("escrow-1", 2))
+	require.NoError(t, store.RecordValidationsAppliedOnce("escrow-1", []ValidationObsEntry{
+		{InferenceID: 2, SlotID: 0},
+	}))
+
+	require.NoError(t, store.DrainInferenceValidationObsBatch("escrow-1", []uint64{1, 2, 3, 4, 5}))
+
+	rows, err := store.GetValidationObservability("escrow-1")
+	require.NoError(t, err)
+	bySlot := make(map[uint32]SlotValidationObs, len(rows))
+	for _, r := range rows {
+		bySlot[r.SlotID] = r
+	}
+	require.Equal(t, uint32(4), bySlot[0].CompletedValidations, "slot 0 drained 3 inferences plus the re-recorded one")
+	require.Equal(t, uint32(4), bySlot[0].RequiredValidations)
+	require.Equal(t, uint32(3), bySlot[1].CompletedValidations)
+	require.Equal(t, uint32(3), bySlot[1].RequiredValidations)
+
+	// A second batch drain is a no-op: the live rows are already gone.
+	require.NoError(t, store.DrainInferenceValidationObsBatch("escrow-1", []uint64{1, 2, 3}))
+	again, err := store.GetValidationObservability("escrow-1")
+	require.NoError(t, err)
+	require.Equal(t, rows, again)
+
+	require.NoError(t, store.DrainInferenceValidationObsBatch("escrow-1", nil))
+}
+
 func runAddSignature(t *testing.T, store Storage) {
 	t.Helper()
 

--- a/devshard/storage/sqlite.go
+++ b/devshard/storage/sqlite.go
@@ -910,17 +910,11 @@ func (s *SQLite) LoadSnapshot(escrowID string) (uint64, []byte, error) {
 	return nonce, data, nil
 }
 
-func (s *SQLite) InsertSealedInference(escrowID string, row InferenceRow) error {
-	p, _, err := s.poolFor(escrowID)
-	if err != nil {
-		return err
-	}
-	obsPresent := 0
-	if row.ObsPresent {
-		obsPresent = 1
-	}
-	_, err = p.writeDB.Exec(
-		`INSERT INTO sealed_inferences (
+type sqliteExec interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+const sqliteInsertSealedInferenceSQL = `INSERT INTO sealed_inferences (
 			escrow_id, inference_id, sealed_nonce,
 			obs_present, sealed_status, sealed_executor_slot,
 			sealed_votes_valid, sealed_votes_invalid, sealed_validated_by,
@@ -948,7 +942,15 @@ func (s *SQLite) InsertSealedInference(escrowID string, row InferenceRow) error 
 			sealed_reserved_cost = excluded.sealed_reserved_cost,
 			sealed_actual_cost = excluded.sealed_actual_cost,
 			sealed_started_at = excluded.sealed_started_at,
-			sealed_confirmed_at = excluded.sealed_confirmed_at`,
+			sealed_confirmed_at = excluded.sealed_confirmed_at`
+
+func sqliteExecInsertSealedInference(exec sqliteExec, escrowID string, row InferenceRow) error {
+	obsPresent := 0
+	if row.ObsPresent {
+		obsPresent = 1
+	}
+	_, err := exec.Exec(
+		sqliteInsertSealedInferenceSQL,
 		escrowID, row.InferenceID, row.SealedNonce,
 		obsPresent, row.SealedStatus, row.SealedExecutorSlot,
 		row.SealedVotesValid, row.SealedVotesInvalid, row.SealedValidatedBy,
@@ -960,6 +962,44 @@ func (s *SQLite) InsertSealedInference(escrowID string, row InferenceRow) error 
 	)
 	if err != nil {
 		return fmt.Errorf("insert sealed inference: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLite) InsertSealedInference(escrowID string, row InferenceRow) error {
+	p, _, err := s.poolFor(escrowID)
+	if err != nil {
+		return err
+	}
+	return sqliteExecInsertSealedInference(p.writeDB, escrowID, row)
+}
+
+func (s *SQLite) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	p, _, err := s.poolFor(escrowID)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(rows); start += sealedInferenceInsertChunk {
+		end := start + sealedInferenceInsertChunk
+		if end > len(rows) {
+			end = len(rows)
+		}
+		tx, err := p.writeDB.Begin()
+		if err != nil {
+			return fmt.Errorf("insert sealed inferences begin: %w", err)
+		}
+		for i := start; i < end; i++ {
+			if err := sqliteExecInsertSealedInference(tx, escrowID, rows[i]); err != nil {
+				_ = tx.Rollback()
+				return err
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("insert sealed inferences commit: %w", err)
+		}
 	}
 	return nil
 }
@@ -1010,6 +1050,33 @@ func (s *SQLite) DeleteSealedInferences(escrowID string) error {
 		return fmt.Errorf("delete sealed inferences: %w", err)
 	}
 	return nil
+}
+
+func (s *SQLite) SealedInferenceIDs(escrowID string) (map[uint64]uint64, error) {
+	p, _, err := s.poolFor(escrowID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := p.readDB.Query(
+		`SELECT inference_id, sealed_nonce FROM sealed_inferences WHERE escrow_id = ?`,
+		escrowID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list sealed inference ids: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[uint64]uint64)
+	for rows.Next() {
+		var id, nonce uint64
+		if err := rows.Scan(&id, &nonce); err != nil {
+			return nil, fmt.Errorf("scan sealed inference id: %w", err)
+		}
+		out[id] = nonce
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (s *SQLite) ClearValidationObs(escrowID string) error {
@@ -1080,7 +1147,7 @@ func (s *SQLite) DrainInferenceValidationObs(escrowID string, inferenceID uint64
 		return fmt.Errorf("drain inference validation obs select: %w", err)
 	}
 	type row struct {
-		slotID               uint32
+		slotID              uint32
 		required, completed uint32
 	}
 	var live []row

--- a/devshard/storage/sqlite.go
+++ b/devshard/storage/sqlite.go
@@ -1184,6 +1184,63 @@ func (s *SQLite) DrainInferenceValidationObs(escrowID string, inferenceID uint64
 	return tx.Commit()
 }
 
+func (s *SQLite) DrainInferenceValidationObsBatch(escrowID string, inferenceIDs []uint64) error {
+	if len(inferenceIDs) == 0 {
+		return nil
+	}
+	p, _, err := s.poolFor(escrowID)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(inferenceIDs); start += validationObsRebuildChunk {
+		end := start + validationObsRebuildChunk
+		if end > len(inferenceIDs) {
+			end = len(inferenceIDs)
+		}
+		chunk := inferenceIDs[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(chunk)), ",")
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, escrowID)
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+
+		tx, err := p.writeDB.Begin()
+		if err != nil {
+			return fmt.Errorf("drain inference validation obs begin: %w", err)
+		}
+		// Move and delete set-at-a-time. Live rows are unique per
+		// (escrow, inference, slot), so no source row conflicts with another
+		// row of the same statement and the accumulate is per target row,
+		// exactly as in the single-id form.
+		if _, err := tx.Exec(
+			`INSERT INTO sealed_validation_obs (escrow_id, inference_id, slot_id, required_validations, completed_validations)
+			 SELECT escrow_id, inference_id, slot_id, required_validations, completed_validations
+			   FROM inference_validation_obs
+			  WHERE escrow_id = ? AND inference_id IN (`+placeholders+`)
+			 ON CONFLICT(escrow_id, inference_id, slot_id) DO UPDATE SET
+			   required_validations = sealed_validation_obs.required_validations + excluded.required_validations,
+			   completed_validations = sealed_validation_obs.completed_validations + excluded.completed_validations`,
+			args...,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("drain inference validation obs insert: %w", err)
+		}
+		if _, err := tx.Exec(
+			`DELETE FROM inference_validation_obs
+			  WHERE escrow_id = ? AND inference_id IN (`+placeholders+`)`,
+			args...,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("drain inference validation obs delete: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("drain inference validation obs commit: %w", err)
+		}
+	}
+	return nil
+}
+
 func (s *SQLite) GetValidationObservability(escrowID string) ([]SlotValidationObs, error) {
 	p, _, err := s.poolFor(escrowID)
 	if err != nil {

--- a/devshard/storage/sqlite.go
+++ b/devshard/storage/sqlite.go
@@ -999,6 +999,13 @@ func (s *SQLite) InsertSealedInferences(escrowID string, rows []InferenceRow) er
 	return nil
 }
 
+// BulkInsertSealedInferences has no separate bulk path on SQLite: writes are
+// in-process, so the upsert's conflict probe is a b-tree lookup rather than a
+// round trip and the prepared chunk insert is already the fast path.
+func (s *SQLite) BulkInsertSealedInferences(escrowID string, rows []InferenceRow) error {
+	return s.InsertSealedInferences(escrowID, rows)
+}
+
 func sqliteInsertSealedInferenceChunk(db *sql.DB, escrowID string, rows []InferenceRow) error {
 	tx, err := db.Begin()
 	if err != nil {

--- a/devshard/storage/sqlite.go
+++ b/devshard/storage/sqlite.go
@@ -944,13 +944,12 @@ const sqliteInsertSealedInferenceSQL = `INSERT INTO sealed_inferences (
 			sealed_started_at = excluded.sealed_started_at,
 			sealed_confirmed_at = excluded.sealed_confirmed_at`
 
-func sqliteExecInsertSealedInference(exec sqliteExec, escrowID string, row InferenceRow) error {
+func sqliteSealedInferenceArgs(escrowID string, row InferenceRow) []any {
 	obsPresent := 0
 	if row.ObsPresent {
 		obsPresent = 1
 	}
-	_, err := exec.Exec(
-		sqliteInsertSealedInferenceSQL,
+	return []any{
 		escrowID, row.InferenceID, row.SealedNonce,
 		obsPresent, row.SealedStatus, row.SealedExecutorSlot,
 		row.SealedVotesValid, row.SealedVotesInvalid, row.SealedValidatedBy,
@@ -959,8 +958,11 @@ func sqliteExecInsertSealedInference(exec sqliteExec, escrowID string, row Infer
 		row.SealedInputTokens, row.SealedOutputTokens,
 		row.SealedReservedCost, row.SealedActualCost,
 		row.SealedStartedAt, row.SealedConfirmedAt,
-	)
-	if err != nil {
+	}
+}
+
+func sqliteExecInsertSealedInference(exec sqliteExec, escrowID string, row InferenceRow) error {
+	if _, err := exec.Exec(sqliteInsertSealedInferenceSQL, sqliteSealedInferenceArgs(escrowID, row)...); err != nil {
 		return fmt.Errorf("insert sealed inference: %w", err)
 	}
 	return nil
@@ -974,6 +976,9 @@ func (s *SQLite) InsertSealedInference(escrowID string, row InferenceRow) error 
 	return sqliteExecInsertSealedInference(p.writeDB, escrowID, row)
 }
 
+// InsertSealedInferences prepares the upsert once per chunk instead of letting
+// database/sql re-prepare it for every row, which is most of the per-row cost
+// on a rebuild that writes the whole seal set.
 func (s *SQLite) InsertSealedInferences(escrowID string, rows []InferenceRow) error {
 	if len(rows) == 0 {
 		return nil
@@ -987,19 +992,36 @@ func (s *SQLite) InsertSealedInferences(escrowID string, rows []InferenceRow) er
 		if end > len(rows) {
 			end = len(rows)
 		}
-		tx, err := p.writeDB.Begin()
-		if err != nil {
-			return fmt.Errorf("insert sealed inferences begin: %w", err)
+		if err := sqliteInsertSealedInferenceChunk(p.writeDB, escrowID, rows[start:end]); err != nil {
+			return err
 		}
-		for i := start; i < end; i++ {
-			if err := sqliteExecInsertSealedInference(tx, escrowID, rows[i]); err != nil {
-				_ = tx.Rollback()
-				return err
-			}
+	}
+	return nil
+}
+
+func sqliteInsertSealedInferenceChunk(db *sql.DB, escrowID string, rows []InferenceRow) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("insert sealed inferences begin: %w", err)
+	}
+	stmt, err := tx.Prepare(sqliteInsertSealedInferenceSQL)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("insert sealed inferences prepare: %w", err)
+	}
+	for _, row := range rows {
+		if _, err := stmt.Exec(sqliteSealedInferenceArgs(escrowID, row)...); err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			return fmt.Errorf("insert sealed inference: %w", err)
 		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("insert sealed inferences commit: %w", err)
-		}
+	}
+	if err := stmt.Close(); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("insert sealed inferences close: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("insert sealed inferences commit: %w", err)
 	}
 	return nil
 }

--- a/devshard/storage/sqlite_test.go
+++ b/devshard/storage/sqlite_test.go
@@ -128,6 +128,10 @@ func TestSQLite_SealedInferenceLifecycle(t *testing.T) {
 	runSealedInferenceLifecycle(t, newTestSQLite(t))
 }
 
+func TestSQLite_SealedInferenceBatchInsert(t *testing.T) {
+	runSealedInferenceBatchInsert(t, newTestSQLite(t))
+}
+
 func TestSQLite_ValidationObsBatchDrain(t *testing.T) {
 	runValidationObsBatchDrain(t, newTestSQLite(t))
 }

--- a/devshard/storage/sqlite_test.go
+++ b/devshard/storage/sqlite_test.go
@@ -128,6 +128,10 @@ func TestSQLite_SealedInferenceLifecycle(t *testing.T) {
 	runSealedInferenceLifecycle(t, newTestSQLite(t))
 }
 
+func TestSQLite_ValidationObsBatchDrain(t *testing.T) {
+	runValidationObsBatchDrain(t, newTestSQLite(t))
+}
+
 func TestSQLite_AddSignature(t *testing.T) {
 	runAddSignature(t, newTestSQLite(t))
 }

--- a/devshard/storage/sqlite_test.go
+++ b/devshard/storage/sqlite_test.go
@@ -132,6 +132,10 @@ func TestSQLite_SealedInferenceBatchInsert(t *testing.T) {
 	runSealedInferenceBatchInsert(t, newTestSQLite(t))
 }
 
+func TestSQLite_SealedInferenceBulkInsert(t *testing.T) {
+	runSealedInferenceBulkInsert(t, newTestSQLite(t))
+}
+
 func TestSQLite_ValidationObsBatchDrain(t *testing.T) {
 	runValidationObsBatchDrain(t, newTestSQLite(t))
 }

--- a/devshard/storage/validation_obs_rebuild.go
+++ b/devshard/storage/validation_obs_rebuild.go
@@ -36,6 +36,11 @@ func ValidationObsEntriesFromTxs(txs []*types.DevshardTx) []ValidationObsEntry {
 // from the canonical diff journal. It clears live and sealed obs tables, replays
 // validation txs from records in nonce order, then drains live rows for each
 // sealed inference id. Idempotent w.r.t. diff content.
+//
+// Only the clear makes this safe to re-run: the drain deletes the live row
+// that RecordValidationsAppliedOnce dedups against, so replaying a range on top
+// of already-drained rows would count those validations a second time. Callers
+// must pass the whole journal, never a partial range.
 func RebuildValidationObsFromDiffs(store Storage, escrowID string, records []types.DiffRecord, sealedInferenceIDs []uint64) error {
 	if store == nil {
 		return fmt.Errorf("validation obs rebuild: nil store")

--- a/devshard/storage/validation_obs_rebuild.go
+++ b/devshard/storage/validation_obs_rebuild.go
@@ -32,6 +32,12 @@ func ValidationObsEntriesFromTxs(txs []*types.DevshardTx) []ValidationObsEntry {
 	return entries
 }
 
+// validationObsRebuildChunk bounds entries per record write and ids per drain
+// transaction during a rebuild. Same rationale as sealedInferenceInsertChunk:
+// keep each commit inside the Postgres statement timeout without paying a
+// round trip per journal record or a transaction per inference.
+const validationObsRebuildChunk = 500
+
 // RebuildValidationObsFromDiffs rebuilds validation observability for an escrow
 // from the canonical diff journal. It clears live and sealed obs tables, replays
 // validation txs from records in nonce order, then drains live rows for each
@@ -48,21 +54,40 @@ func RebuildValidationObsFromDiffs(store Storage, escrowID string, records []typ
 	if err := store.ClearValidationObs(escrowID); err != nil {
 		return fmt.Errorf("validation obs rebuild: clear: %w", err)
 	}
+	// Accumulate across records instead of writing once per nonce: the write is
+	// ON CONFLICT DO NOTHING keyed on (inference_id, slot_id), so merging
+	// records is indistinguishable from applying them one at a time.
+	pending := make([]ValidationObsEntry, 0, validationObsRebuildChunk)
+	flush := func() error {
+		if len(pending) == 0 {
+			return nil
+		}
+		if err := store.RecordValidationsAppliedOnce(escrowID, pending); err != nil {
+			return fmt.Errorf("validation obs rebuild: record: %w", err)
+		}
+		pending = pending[:0]
+		return nil
+	}
 	for _, rec := range records {
 		entries := ValidationObsEntriesFromTxs(rec.Txs)
 		if len(entries) == 0 {
 			continue
 		}
-		if err := store.RecordValidationsAppliedOnce(escrowID, entries); err != nil {
-			return fmt.Errorf("validation obs rebuild: record nonce %d: %w", rec.Nonce, err)
+		pending = append(pending, entries...)
+		if len(pending) >= validationObsRebuildChunk {
+			if err := flush(); err != nil {
+				return err
+			}
 		}
 	}
+	if err := flush(); err != nil {
+		return err
+	}
+
 	ids := append([]uint64(nil), sealedInferenceIDs...)
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	for _, inferenceID := range ids {
-		if err := store.DrainInferenceValidationObs(escrowID, inferenceID); err != nil {
-			return fmt.Errorf("validation obs rebuild: drain inference %d: %w", inferenceID, err)
-		}
+	if err := store.DrainInferenceValidationObsBatch(escrowID, ids); err != nil {
+		return fmt.Errorf("validation obs rebuild: drain: %w", err)
 	}
 	return nil
 }

--- a/devshard/storage/validation_obs_rebuild_test.go
+++ b/devshard/storage/validation_obs_rebuild_test.go
@@ -105,6 +105,23 @@ func TestRebuildValidationObsFromDiffs_ReplacesPriorState(t *testing.T) {
 	require.Equal(t, uint32(1), rows[0].CompletedValidations)
 }
 
+// Recording is only deduped while the live row survives: the drain deletes it,
+// so re-recording an inference that already sealed counts it a second time.
+// This is why the rebuild has to clear first and why recovery must never
+// replay a partial range of diffs on top of stored obs.
+func TestRecordValidationsAppliedOnce_NotDedupedAfterDrain(t *testing.T) {
+	store := setupObsTestStore(t)
+
+	recordOnce(t, store, "escrow-1", 7, 2)
+	require.NoError(t, store.DrainInferenceValidationObs("escrow-1", 7))
+	require.Equal(t, uint32(1), obsForSlot(t, store, 2).CompletedValidations)
+
+	recordOnce(t, store, "escrow-1", 7, 2)
+	require.NoError(t, store.DrainInferenceValidationObs("escrow-1", 7))
+	require.Equal(t, uint32(2), obsForSlot(t, store, 2).CompletedValidations,
+		"the drain removes the dedup row, so a repeated record double counts")
+}
+
 func TestValidationObsEntriesFromTxs_DedupWithinDiff(t *testing.T) {
 	txs := []*types.DevshardTx{validationTx(7, 2), validationTx(7, 2)}
 	entries := ValidationObsEntriesFromTxs(txs)

--- a/devshard/transport/server.go
+++ b/devshard/transport/server.go
@@ -335,7 +335,7 @@ func (s *Server) HandleInference(c echo.Context) (err error) {
 				"HandleInference: requests disabled", echo.NewHTTPError(http.StatusServiceUnavailable, err.Error()))
 		}
 		return observability.FailNoReceipt(ctx, s.host.EscrowID(), reason, where,
-			"HandleInference: handle request", echo.NewHTTPError(http.StatusInternalServerError, err.Error()))
+			"HandleInference: handle request", echo.NewHTTPError(http.StatusInternalServerError, err.Error()).SetInternal(err))
 	}
 	observability.Request.SetInferenceID(op, resp.InferenceID)
 	observability.Request.SetInferenceResponse(op, resp.Nonce, resp.ExecutionExpected, resp.CachedResponseBody != nil)
@@ -624,7 +624,7 @@ func (s *Server) HandleChallengeReceipt(c echo.Context) (err error) {
 
 	receipt, _, err := s.host.ChallengeReceipt(c.Request().Context(), req.InferenceID, PayloadFromJSON(req.Payload), diffs)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error()).SetInternal(err)
 	}
 
 	return writeJSON(c, http.StatusOK, ChallengeReceiptResponse{Receipt: receipt})

--- a/devshard/user/session_close_test.go
+++ b/devshard/user/session_close_test.go
@@ -40,10 +40,16 @@ func (s *closeCountingStore) LoadSnapshot(string) (uint64, []byte, error) {
 	return 0, nil, storage.ErrSnapshotNotFound
 }
 func (s *closeCountingStore) InsertSealedInference(string, storage.InferenceRow) error { return nil }
+func (s *closeCountingStore) InsertSealedInferences(string, []storage.InferenceRow) error {
+	return nil
+}
 func (s *closeCountingStore) GetSealedInference(string, uint64) (storage.InferenceRow, bool, error) {
 	return storage.InferenceRow{}, false, nil
 }
 func (s *closeCountingStore) DeleteSealedInferences(string) error { return nil }
+func (s *closeCountingStore) SealedInferenceIDs(string) (map[uint64]uint64, error) {
+	return nil, nil
+}
 func (s *closeCountingStore) RecordValidationsAppliedOnce(string, []storage.ValidationObsEntry) error {
 	return nil
 }
@@ -51,7 +57,7 @@ func (s *closeCountingStore) DrainInferenceValidationObs(string, uint64) error {
 func (s *closeCountingStore) GetValidationObservability(string) ([]storage.SlotValidationObs, error) {
 	return nil, nil
 }
-func (s *closeCountingStore) ClearValidationObs(string) error { return nil }
+func (s *closeCountingStore) ClearValidationObs(string) error              { return nil }
 func (s *closeCountingStore) PutEscrowCache(storage.EscrowCacheInfo) error { return nil }
 func (s *closeCountingStore) GetEscrowCache(string) (*storage.EscrowCacheInfo, error) {
 	return nil, storage.ErrEscrowCacheNotFound

--- a/devshard/user/session_close_test.go
+++ b/devshard/user/session_close_test.go
@@ -43,6 +43,9 @@ func (s *closeCountingStore) InsertSealedInference(string, storage.InferenceRow)
 func (s *closeCountingStore) InsertSealedInferences(string, []storage.InferenceRow) error {
 	return nil
 }
+func (s *closeCountingStore) BulkInsertSealedInferences(string, []storage.InferenceRow) error {
+	return nil
+}
 func (s *closeCountingStore) GetSealedInference(string, uint64) (storage.InferenceRow, bool, error) {
 	return storage.InferenceRow{}, false, nil
 }

--- a/devshard/user/session_close_test.go
+++ b/devshard/user/session_close_test.go
@@ -54,6 +54,9 @@ func (s *closeCountingStore) RecordValidationsAppliedOnce(string, []storage.Vali
 	return nil
 }
 func (s *closeCountingStore) DrainInferenceValidationObs(string, uint64) error { return nil }
+func (s *closeCountingStore) DrainInferenceValidationObsBatch(string, []uint64) error {
+	return nil
+}
 func (s *closeCountingStore) GetValidationObservability(string) ([]storage.SlotValidationObs, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Problem

v4 `devshardd` dropped two pieces of the v3 host recovery path when `HostManager.recoverStoredSession` moved into the standalone binary (`b53fd8fcd`):

1. It no longer called `LoadSnapshot`. Every restart replayed diffs from nonce 1.
2. Recovery ran on a single worker, inline, before the HTTP listener bound.

On a host with a long journal that produced hours of catch-up, `/ready` stayed false, the parent answered 502, and live traffic never reached the child. Logs of the failing window show no snapshot restore lines and a serial `recovered devshard session` trail that lasted for hours.

A third defect sat on the same path: snapshot recovery wiped sealed-inference stats (`RebuildSealedInferenceIndex` deleted every row and reinserted a bare one), so a restart that should have been a tail catch-up also paid one unbatched insert per sealed id and dropped `ObsPresent` columns.

## Decisions

These are the design calls that hold across the fifteen commits. Each later commit is a refinement of one of them, not a reversal — except `/ready`, which commit 3 gated on recovery and commit 15 split into status vs body once the wipe was off the lazy-load path.

| Decision | Choice | Why |
| --- | --- | --- |
| Snapshot load | Restore v3 `LoadSnapshot` on the v4 host recovery path. Decode/load failure falls back to a full journal replay. | A snapshot at nonce N skips diffs `1..N`. That is the difference between a tail catch-up and hours of replay. |
| Snapshot integrity | After restore, verify the snapshot root against the journal diff at nonce N. On mismatch, throw the restored SM away and replay from 1. | Diff replay already checks every nonce it applies. The snapshot path used to trust the blob outright, including on a store v4 can share between hosts. |
| Recovery concurrency | 8 workers, same as v3. | Snapshots alone are not enough on a host with many sessions: serial recovery still blocks listen. |
| Bind vs recover | Bind the listener first. Recover in the background. A session a live caller needs is recovered on demand by `getOrCreate` instead of waiting out the backlog. | Removes the 502 window. |
| `/ready` status vs body | Status 200 = can serve (chain up, storage open, not draining). Body `recovery_complete` = warm (backlog drained **and** background repairs finished). | Commit 3 gated 503 on recovery so versiond would not publish a cold child. Once snapshot recovery stopped wiping stats, 503-until-recovered became the outage: versiond's 60s ready timeout killed the child before it ever served. Status is flow A (solo boot). The body field is flow D (overlap cutover with a healthy old generation). |
| Demand vs cold backlog | Remember every escrow that reaches `getOrCreate` for the rest of the recovery window and dequeue those first. Only workers picking up a **cold** session park. A parked worker resumes as soon as its own escrow is demanded. A fully demanded backlog never pauses. | The first non-blocking version parked **every** worker whenever a request was in flight, including workers already recovering the session the caller wanted. |
| Stale in-memory session | On `types.ErrInvalidNonce` from apply, evict the live session, recover it again, retry the handler once. A mismatch that survives the reload is negative-cached at the short TTL (`resolutionFailureTTL`), not `permanentFailureTTL`. | During overlap the old generation keeps writing the shared store. A session the new child recovered early is behind by publish time. Without eviction, flow D is worse than a cold cutover. |
| Validation obs, snapshot path | Do **not** rebuild. Live apply already wrote durable rows for every nonce the snapshot covers. | Rebuilding on this path re-read the whole journal and paid one write transaction per historical seal to rewrite rows that were already correct. |
| Validation obs, full replay | Must rebuild. `ApplyLocal` records no obs, and the clear-then-replay is the self-heal for batches the live path dropped under backpressure. | This is the only path that needs the rebuild. |
| Incremental / partial-range rebuild | Rejected. | `DrainInferenceValidationObs` deletes the live row `RecordValidationsAppliedOnce` dedups against. Replaying a tail twice double-counts. A storage test pins this. |
| Validation obs, scheduling | End restoration without filling obs. Run the rebuild in the background after the session is published. Queue concurrent obs writes for that escrow and apply them after the rebuild. | Inline rebuild was the expensive half of recovery (a write txn per historical seal) and a cold bind waited it out. Queueing is equivalent to sequential execution because the rebuild covers `1..N` and live diffs during the window are past `N`. |
| Why queueing is safe | Obs writes are already best-effort. Recording is dropped under backpressure. The persist-first path (`ValidateDiff` → `CommitValidated`) already defers drains via `deferredObsWrite` and logs failures rather than failing a commit. | An earlier objection that seal drains were fail-closed was wrong for the production path. |
| Gate bounds | Queue cap 8192 ops (drop newest, report). Flush cap 64 rounds, then close and apply the remainder write-through. Concurrent repairs for one escrow are rejected. | A continuously busy escrow must not hold the gate open forever. Overflow matches the live path, which already drops obs under backpressure. |
| Sealed-inference index, snapshot path | Gap fill only. List existing ids, insert a bare row for each sealed id that is missing, never delete, never downgrade `ObsPresent = true`. | The stored rows are durable and the restored state is root-verified. The wipe-rebuild dropped stats and wrote O(sealed) on every restart, including the path that should write nothing. |
| Sealed-inference index, full replay | Wipe is defensible (divergent history). Rebuild from the journal inside the same `ObsRepairGate` window as validation obs, after the session is published. | Same scheduling argument as obs: the session must be live before the expensive half runs. |
| Batching | Chunk the transaction **and** the statement. Postgres: one `unnest` upsert per 500-row chunk. SQLite: prepare the upsert once per chunk. Drain: set-at-a-time, not one txn per id. Record: 500-entry writes. | Chunking the transaction bought Postgres nothing (~3058ms vs ~3006ms at 20k): it pays per round trip, not per commit. One statement per row was the remaining cost. |
| Post-wipe load | `BulkInsertSealedInferences`: Postgres `COPY`, no per-row conflict probe, fallback to the upsert on unique violation. SQLite keeps the batched upsert (in-process b-tree, not a round trip). Drain: one data-modifying CTE instead of `INSERT`+`DELETE` in an explicit transaction. | The full-replay rebuild has just wiped the escrow, so inserts cannot conflict. The leftover ~99ms/20k on the upsert was the conflict probe, not the protocol. `COPY` is ~30ms; the CTE drain is ~58ms from ~81ms. |
| Shutdown | `WaitRecoveryRepairs` is a closer (renamed from `WaitObsRepairs`). | A rebuild interrupted after its clear leaves the counters empty, and recovery will not retry once a snapshot exists. The waiter now covers both validation obs and the sealed-inference index. |
| Warm signal | `recovery_complete` is true only after the backlog drains **and** `WaitRecoveryRepairs` returns. Promote the log-only counters onto the `/ready` body and `devshardd_session_recovery`. | A full-replay child is published long before its sealed-inference index is rebuilt. Declaring that warm would route overlap traffic at a host mid-wipe. |

## Out of scope (deliberate)

- An escrow recovered from a snapshot whose obs is genuinely empty still never gets repaired. The cheap fix is rebuilding when `GetValidationObservability` comes back empty.
- While a rebuild runs, `/stats` under-reports for that escrow (tables are cleared and refilling). Nothing outside stats reads them.
- Blocking versus `503 Retry-After` for a first request to an unrecovered escrow; that is a client-contract decision.
- Versiond overlap wait on `recovery_complete` (companion plan Step 9). That is a v5 `versiond` change and is useless until this child ships the field and the eviction.
- Rolling-update docs stay on the old probe contract until that versiond wait lands.

---

## Commits

### 1. `3d25e29f5` — `fix(devshard): restore host snapshot load on v4 session recovery`

**Decision.** Put `LoadSnapshot` back on the v4 host recovery path, matching v3 `RecoverSession`. On decode or load failure, fall back to a full journal replay rather than failing the session.

**Changed.**

- `recoverStoredSession` loads a host snapshot when `snapNonce > 0 && snapNonce <= meta.LatestNonce`, restores SM / committed entries / sealed nonces, then replays only `snapNonce+1..latest`.
- After a successful (or full) replay, save a recovery snapshot when the replay was from 1 or the tail was at least `SnapshotInterval`.
- Tests in `manager_snapshot_recovery_test.go`: restore + tail replay, current snapshot skips apply, empty blob and load error fall back to nonce 1.

### 2. `0d4c965c2` — `fix(devshard): restore 8-worker session recovery on v4`

**Decision.** Recovery concurrency is independent of snapshot load. Restore v3's 8-worker pool so a large host does not recover sessions one at a time.

**Changed.**

- `RecoverSessions` fans work across `recoverSessionsConcurrency` (8) workers, capped at the session count.
- Per-session recover/fail/version-skip counters and logs.
- Tests in `manager_recovery_workers_test.go`: parallel recovery, worker cap, version-conflict skip.

### 3. `a13ea92de` — `fix(devshard): unblock bind during recovery and verify restored snapshots`

**Decisions.**

1. Bind first, recover in the background. A live `getOrCreate` recovers the requested session immediately instead of queueing behind the backlog.
2. After restoring a snapshot, verify its root against the journal diff at that nonce. On mismatch, recreate the SM and replay from 1. Diff replay already checks every nonce it applies; the snapshot path must not skip `1..N`.
3. Gate `/ready` 503 on `RecoveryComplete` (revised in commit 15 once the wipe was off the request path).

**Changed.**

- `StartRecovery` / `RecoveryComplete` / `RecoverSessionsContext` (cancellable).
- First-cut `recoveryGate`: park workers while a request is in flight (refined in commit 4).
- `app.go` starts recovery as a closer after `store.Start()`, so the listener binds immediately.
- `buildAdminServer` takes `recoveryComplete`; `/ready` stays 503 until the backlog drains (until commit 15).
- `verifySnapshotRoot` in `recoverStoredSession`.
- Tests: `/ready` reflects recovery progress; snapshot root mismatch replays from 1.

### 4. `7e704795f` — `fix(devshard): order recovery backlog by demand instead of parking all workers`

**Decision.** The gate in commit 3 paused every worker whenever *any* request was in flight, including workers recovering the session the caller wanted. Replace that with a demand-ordered queue:

- Sticky marker: an escrow that hits `getOrCreate` stays prioritized for the rest of the recovery window.
- Workers dequeue demanded sessions first.
- Only a worker about to pick up a **cold** session parks.
- A parked worker whose escrow becomes demanded resumes.
- If every remaining session is demanded, nobody parks.

**Changed.**

- `recoveryGate` + `recoveryQueue` in `manager.go`.
- Priority tests: parking, preemption, promotion, boundedness, sticky marker, mid-drain reordering, end-to-end concurrent demand.
- `countingMetaStore` counters in `stats_test.go` made atomic: concurrent recovery races them once workers are no longer serialized by the old channel handoff.

### 5. `c09f15ec4` — `perf(devshard): skip the obs rebuild when a snapshot covers the history`

**Decisions.**

- Snapshot path: skip obs rebuild. Rows for those nonces are already durable.
- Full replay (`replayFrom == 1`): still rebuild. That is the self-heal.
- Incremental / partial-range top-up: **not valid**. Drain deletes the dedup row, so a tail replayed twice double-counts. `TopUpValidationObsFromDiffs` and `SealedInferenceIDsSortedFrom` were removed after an idempotency test found this.

**Changed.**

- `recoverStoredSession` rebuilds obs only when `replayFrom == 1`.
- `RebuildValidationObsFromDiffs` is explicitly clear-then-replay.
- `TestRecordValidationsAppliedOnce_NotDedupedAfterDrain` pins the hazard.
- Snapshot-path test asserts obs tables are not cleared.

### 6. `3d2fd05d1` — `perf(devshard): rebuild validation obs in the background behind a write gate`

**Decisions.**

- End restoration without filling obs. Publish the session, then start a background repair with the journal already in hand and the seal set as of that journal's last nonce.
- `ObsRepairGate` wraps the store. Idle = pass-through. During a repair for escrow E, `RecordValidationsAppliedOnce` and `DrainInferenceValidationObs` for E are queued in arrival order and applied after the rebuild writes to the inner store (so the rebuild cannot queue behind itself).
- Rebuild covers `1..N`; live diffs during the window are past `N`; queued writes never overlap the rebuild range, so the drain/dedup hazard from commit 5 does not arise.
- Queue 8192, drop newest, report. Flush 64 rounds then close. Concurrent repair for the same escrow rejected. Shutdown waits (`WaitObsRepairs`, renamed in commit 8).

**Changed.**

- New `storage/obs_repair_gate.go` (+ tests: idle transparency, rebuild bypasses queue, queued write survives the clear, record-then-drain order, per-escrow isolation, overflow, flush-after-rebuild-error, concurrent writers).
- `HostManager` always wraps the store in the gate. `startObsRepair` / `WaitObsRepairs`.
- `app.go` registers `WaitObsRepairs` as a closer.
- Full-replay test asserts recovery returns before the rebuild finishes, then waits and checks the rebuild still ran.

### 7. `9af175e43` — `fix(devshard): wait for obs repairs before test TempDir cleanup`

**Decision.** A full-replay recovery returns before `startObsRepair` finishes. Tests that tear down with `t.TempDir` must wait, or the rebuild still holds the SQLite WAL when cleanup removes it.

**Changed.**

- `HostManager` teardown waits for repairs.
- The held-rebuild test unblocks `release` if it fails before closing it.
- CI failure of `TestRecoverSessions_LoadSnapshotErrorReplaysFromOne` was cleanup, not the recovery assertion.

### 8. `b7596d472` — `fix(devshard): stop wiping sealed-inference stats on snapshot recovery`

**Decisions.**

- Snapshot path: gap fill only. Never delete, never downgrade a rich row. Normally writes nothing.
- Full replay: wipe is defensible, but rebuild from the journal in the same background `ObsRepairGate` window as validation obs, in 500-row transactions, after the session is published.
- Rename `WaitObsRepairs` → `WaitRecoveryRepairs`. `recovery_complete` still follows the backlog drain until commit 15.
- Keep `RebuildSealedInferenceIndex` as a gap-fill wrapper so the v3 `user/recover.go` path stops losing stats without restructuring it.

**Changed.**

- `SealedInferenceIDs` / `InsertSealedInferences` on every backend. `ObsRepairGate` queues sealed-inference inserts during a repair.
- `FillSealedInferenceIndexGaps` / `RebuildSealedInferenceIndexFromDiffs`.
- `recoverStoredSession` picks by `replayFrom`.
- Snapshot-path test: planted rich rows survive, `DeleteSealedInferences` is never called. Full-replay test: session published before the wipe, rich rows after `WaitRecoveryRepairs`. `TestStartRecovery_CompleteBeforeSealedIndexRepair` pins that `recovery_complete` still followed the backlog (flipped in commit 15).

### 9. `021e5044b` — `perf(devshard): keep the sealed-index rebuilds off the state machine lock`

**Decision.** The from-diffs fold held `sm.mu.RLock` across the journal walk, and the gap fill held the write lock across listing and every insert. `ApplyDiff` takes the write lock, so a background repair on an already-published session stalled the apply path for the length of the replay.

**Changed.**

- Both rebuilds snapshot escrow id, group, config, seal nonces, live records, then walk and write outside the lock.
- Gap fill counts gaps before allocating, so the common no-gap restart allocates nothing instead of a millions-long `[]InferenceRow`.
- Recovery log reads `SealedNonceCount()` instead of cloning the seal-nonce map for its length.

### 10. `801f87e60` — `perf(devshard): batch the obs half of the full-replay repair`

**Decision.** Profiling showed the sealed-index work was the smaller half. `RebuildValidationObsFromDiffs` issued one `RecordValidationsAppliedOnce` per journal record and one `DrainInferenceValidationObs` per sealed id, each drain its own begin/select/insert/delete/commit.

**Changed.**

- `DrainInferenceValidationObsBatch`: chunked set-at-a-time move plus delete.
- Records accumulate into 500-entry writes.
- Shared backend test pins batch drain against per-id semantics on Memory, SQLite, Postgres.
- At 20k SQLite: drain ~841ms → ~66ms, record ~325ms → ~52ms.

### 11. `4426262cf` — `perf(devshard): batch the sealed-inference upsert, not just its transaction`

**Decision.** `InsertSealedInferences` chunked the transaction but still issued a statement per row, so Postgres paid a round trip per inference and SQLite re-parsed the upsert for every row.

**Changed.**

- Postgres: one `INSERT ... SELECT FROM unnest(...)` per chunk, same upsert clause. Ids repeated inside a chunk collapse to the last value first (`ON CONFLICT DO UPDATE` cannot touch a row twice).
- SQLite: prepare the upsert once per chunk transaction.
- Shared test pins every sealed column, overwrite of an existing row, and in-chunk duplicate.
- At 20k SQLite: ~431ms → ~50ms. `pg_stat_statements` shows `ceil(sealed/500)` calls instead of `sealed`.

### 12. `6481fc2c7` — `test(devshard): benchmark the rebuild against Postgres, not just SQLite`

**Decision.** The batching work was measured on SQLite, where the cost is per commit. On Postgres it is per round trip, and the two disagree about what "batched" means.

**Changed.**

- `BenchmarkPostgres*` counterparts, including the chunked-transaction-per-row shape so the wash stays visible (~3058ms vs ~3006ms unbatched at 20k).
- Comparison recorded in `sealed-inference-index-rebuild-plan.md`.
- Per-row forms had Postgres 5–16× behind SQLite; set-at-a-time forms brought them within ~1.4×.

### 13. `20449866a` — `fix(devshard/host): guard validationQueue reads against concurrent Close`

**Decision.** Backport of #1512. Not caused by this branch's recovery work, but `go test -race` failed `TestHost_ValidationTriggersOnFinishedInference` and `TestSession_Validation_InvalidationConverges` on this tree because `t.Cleanup(h.Close)` races workers still draining the queue.

**Changed.**

- `validateAsync` deferred cleanup and `enqueueValidation` success branch snapshot `h.validationQueue` under `RLock` instead of reading the field after unlock / without the lock.
- `Close()` closes the channel and nils the field under the write lock.

### 14. `45e7ea264` — `perf(devshard/storage): load the rebuilt sealed index with COPY`

**Decisions.**

- The full-replay rebuild wipes then loads, so inserts cannot conflict. The leftover ~99ms/20k on the `unnest` upsert was the per-row conflict probe (~163µs RTT × not the bottleneck; chunk-size sweeps past 500 and `synchronous_commit=off` moved nothing).
- `BulkInsertSealedInferences`: Postgres `COPY`, fallback to the upsert on unique violation so a wrong "no rows yet" precondition costs speed rather than the rebuild.
- Drain: one data-modifying CTE instead of four round trips per chunk (`BEGIN`/`INSERT`/`DELETE`/`COMMIT`).
- SQLite keeps a single path.

**Changed.**

- Interface method on every backend; `ObsRepairGate` queues bulk as an ordinary upsert batch (the "rows do not exist yet" precondition cannot survive being deferred past the rebuild).
- `RebuildSealedInferenceIndexFromDiffs` calls the bulk path.
- At 20k: Postgres load ~99ms → ~30ms, drain ~81ms → ~58ms. Full-replay repair ~145ms Postgres vs ~165ms SQLite, so Postgres is no longer the slower backend for it.

### 15. `4c7022ee3` — `feat(devshard): serve during recovery and wait to call it warm`

**Decisions.** Companion ready-on-boot items 1–4, together, so a 200-during-recovery child cannot look warm mid-wipe and cannot sit stale behind the old generation's writes.

- `/ready` 200 as soon as the process can serve. Drop `recovered` from the 503 condition. Keep `storage_ready` and `draining`.
- `recovery_complete` true only after the backlog drains **and** `WaitRecoveryRepairs` returns. `sessions_pending` includes both the queue and in-flight repairs.
- Promote the log-only counters onto the body and `devshardd_session_recovery`.
- On `ErrInvalidNonce` from apply: evict, recover, retry once. Surviving mismatch → `RememberStaleNonce` at the short TTL.

**Changed.**

- `buildAdminServer` takes `RecoveryProgressSnapshot`. Status 200 while `recovery_complete` is still false; 503 while draining or storage unready.
- `HandleInference` and `ChallengeReceipt` `SetInternal` the apply error so `retryIfStale` can `errors.Is` the nonce mismatch.
- `ReloadStaleSession` / `RememberStaleNonce` / `evictSession`.
- Tests: `/ready` 200 during recovery with body counters; `TestStartRecovery_CompleteAfterSealedIndexRepair` (was "before"); store-ahead reload succeeds; bogus nonce is negative-cached and does not re-enter recovery.

---

## Test plan

- [x] `go test -race ./storage/ ./state/ ./user/ ./cmd/devshardd/...` from `devshard/` (green under `-race` on this branch, including the #1512 backport).
- [x] Snapshot restore + bind-first (unit): tail-only replay, `StartRecovery` reports the backlog drained, listener is not blocked. `/ready` is now **200 during recovery** with `recovery_complete: false` (`TestReadyReflectsSessionRecoveryProgress`). Still open: cold start of a real v4 host with a long journal (`restored devshard snapshot` in logs, listener binds immediately, `/ready` 200).
- [x] Demanded session recovers before cold backlog (unit: `TestRecoverSessions_RunsRequestedSessionsWhileColdOnesWait`). Still open: `prioritized_count` in a live completion log.
- [x] Corrupt / mismatched snapshot blob falls back to full replay (unit: `TestRecoverSessions_CorruptSnapshotReplaysFromOne`, `TestRecoverSessions_SnapshotRootMismatchReplaysFromOne`). Still open: log line `devshard snapshot failed root check` on a real host.
- [x] Full-replay path publishes the session before obs / sealed-index rebuild finishes (unit: `TestRecoverSessions_FullReplayRebuildsValidationObsInBackground`, `TestRecoverSessions_FullReplayRebuildsSealedIndexInBackground`). Still open: stats eventually match after `rebuilt validation obs`.
- [x] Snapshot path leaves sealed-inference stats intact and never calls `DeleteSealedInferences` (`TestRecoverSessions_SnapshotPathLeavesSealedInferenceRows`). Gap fill on an already-indexed set inserts 0 (`TestFillSealedInferenceIndexGaps_Idempotent`).
- [x] `recovery_complete` stays false until `WaitRecoveryRepairs` returns (`TestStartRecovery_CompleteAfterSealedIndexRepair`).
- [x] Store-ahead apply evicts and recovers; a bogus nonce is negative-cached (`TestReloadStaleSession_CatchesUpToStoreAhead`, `TestReloadStaleSession_NegativeCachesBogusNonce`).
- [x] Postgres vs SQLite rebuild benches (`BenchmarkPostgres*`, including `BulkInsert` / CTE drain). Linearized 1.5M: snapshot path ~0.5s reads and zero writes; full replay ~12s SQLite / ~11s Postgres, off the publish path.
- [ ] Shutdown during a full-replay rebuild: process waits for the repair; counters are not left empty. (`WaitRecoveryRepairs` is wired as a closer; no test covers interrupt-after-clear.)
- [ ] Operator restart with a long journal and a current snapshot: sealed-inference stats identical before and after; log `filled sealed inference index gaps inserted=0`.
- [ ] Versiond overlap wait on `recovery_complete` (v5, not this branch).
