### PR TITLE
fix(devshard): domain-separate proposer signatures so validation votes cannot be retagged

### DIFF
--- a/devshard/cmd/devshardd/session/validation_retry.go
+++ b/devshard/cmd/devshardd/session/validation_retry.go
@@ -7,11 +7,10 @@ import (
 	"log/slog"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	"common/chain"
 	devshardpkg "devshard"
 	"devshard/host"
+	"devshard/signing"
 	"devshard/storage"
 	"devshard/types"
 )
@@ -328,7 +327,7 @@ func submitValidationToMempool(h *host.Host, inferenceID uint64, valid bool) err
 		Valid:         valid,
 		EscrowId:      h.EscrowID(),
 	}
-	data, err := proto.Marshal(msg)
+	data, err := signing.CanonicalProposerBytes(msg)
 	if err != nil {
 		return fmt.Errorf("marshal MsgValidation: %w", err)
 	}

--- a/devshard/host/host.go
+++ b/devshard/host/host.go
@@ -1862,9 +1862,9 @@ func (h *Host) signState(nonce uint64, root []byte) ([]byte, error) {
 	return h.signer.Sign(sigData)
 }
 
-// signProposer marshals msg and signs it, returning the proposer signature.
+// signProposer signs the domain-separated proposer preimage.
 func (h *Host) signProposer(msg proto.Message) ([]byte, error) {
-	data, err := proto.Marshal(msg)
+	data, err := signing.CanonicalProposerBytes(msg)
 	if err != nil {
 		return nil, fmt.Errorf("marshal proposer msg: %w", err)
 	}

--- a/devshard/host/host_test.go
+++ b/devshard/host/host_test.go
@@ -1786,11 +1786,7 @@ func TestHost_ValidationTriggersOnFinishedInference(t *testing.T) {
 		ExecutorSlot: 1,
 		EscrowId:     "escrow-1",
 	}
-	finishData, err := proto.Marshal(finishMsg)
-	require.NoError(t, err)
-	finishSig, err := hosts[1].Sign(finishData)
-	require.NoError(t, err)
-	finishMsg.ProposerSig = finishSig
+	finishMsg.ProposerSig = testutil.SignProposerTx(t, hosts[1], finishMsg)
 	finishTx := &types.DevshardTx{Tx: &types.DevshardTx_FinishInference{FinishInference: finishMsg}}
 	diff3 := testutil.SignDiff(t, user, "escrow-1", 3, []*types.DevshardTx{finishTx})
 

--- a/devshard/internal/testutil/testutil.go
+++ b/devshard/internal/testutil/testutil.go
@@ -110,7 +110,7 @@ func SignDiffWithRoot(t *testing.T, signer signing.Signer, escrowID string, nonc
 
 func SignProposerTx(t *testing.T, signer signing.Signer, msg proto.Message) []byte {
 	t.Helper()
-	data, err := deterministicMarshal.Marshal(msg)
+	data, err := signing.CanonicalProposerBytes(msg)
 	require.NoError(t, err)
 	sig, err := signer.Sign(data)
 	require.NoError(t, err)
@@ -215,7 +215,7 @@ func SignRevealSeed(t *testing.T, signer *signing.Secp256k1Signer, escrowID stri
 		Signature: seedSig,
 		EscrowId:  escrowID,
 	}
-	data, err := deterministicMarshal.Marshal(msg)
+	data, err := signing.CanonicalProposerBytes(msg)
 	require.NoError(t, err)
 	proposerSig, err := signer.Sign(data)
 	require.NoError(t, err)

--- a/devshard/signing/proposer.go
+++ b/devshard/signing/proposer.go
@@ -1,0 +1,71 @@
+package signing
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	"devshard/types"
+)
+
+// Domain strings are bound into every proposer preimage so two proto messages
+// with the same field numbers cannot share a signature. A trailing NUL stops
+// one domain from being a prefix of another.
+const (
+	DomainFinishInference = "devshard.MsgFinishInference.v1"
+	DomainValidation      = "devshard.MsgValidation.v1"
+	DomainValidationVote  = "devshard.MsgValidationVote.v1"
+	DomainRevealSeed      = "devshard.MsgRevealSeed.v1"
+)
+
+var proposerMarshal = proto.MarshalOptions{Deterministic: true}
+
+// CanonicalProposerBytes is the preimage for proposer_sig: domain || 0x00 ||
+// deterministic proto of msg with proposer_sig cleared.
+func CanonicalProposerBytes(msg proto.Message) ([]byte, error) {
+	if msg == nil {
+		return nil, fmt.Errorf("nil proposer message")
+	}
+	domain, ok := proposerDomain(msg)
+	if !ok {
+		return nil, fmt.Errorf("unknown proposer message %T", msg)
+	}
+	cloned := proto.Clone(msg)
+	zeroProposerSig(cloned)
+	body, err := proposerMarshal.Marshal(cloned)
+	if err != nil {
+		return nil, fmt.Errorf("marshal proposer message: %w", err)
+	}
+	out := make([]byte, 0, len(domain)+1+len(body))
+	out = append(out, domain...)
+	out = append(out, 0)
+	return append(out, body...), nil
+}
+
+func proposerDomain(msg proto.Message) (string, bool) {
+	switch msg.(type) {
+	case *types.MsgFinishInference:
+		return DomainFinishInference, true
+	case *types.MsgValidation:
+		return DomainValidation, true
+	case *types.MsgValidationVote:
+		return DomainValidationVote, true
+	case *types.MsgRevealSeed:
+		return DomainRevealSeed, true
+	default:
+		return "", false
+	}
+}
+
+func zeroProposerSig(msg proto.Message) {
+	switch m := msg.(type) {
+	case *types.MsgFinishInference:
+		m.ProposerSig = nil
+	case *types.MsgValidation:
+		m.ProposerSig = nil
+	case *types.MsgValidationVote:
+		m.ProposerSig = nil
+	case *types.MsgRevealSeed:
+		m.ProposerSig = nil
+	}
+}

--- a/devshard/signing/proposer_test.go
+++ b/devshard/signing/proposer_test.go
@@ -1,0 +1,64 @@
+package signing
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"devshard/types"
+)
+
+func TestCanonicalProposerBytes_SeparatesValidationAndVote(t *testing.T) {
+	val := &types.MsgValidation{
+		InferenceId: 1, ValidatorSlot: 2, Valid: false, EscrowId: "escrow-1",
+	}
+	vote := &types.MsgValidationVote{
+		InferenceId: 1, VoterSlot: 2, VoteValid: false, EscrowId: "escrow-1",
+	}
+	a, err := CanonicalProposerBytes(val)
+	require.NoError(t, err)
+	b, err := CanonicalProposerBytes(vote)
+	require.NoError(t, err)
+	require.False(t, bytes.Equal(a, b), "identical fields must not share a preimage")
+	require.True(t, bytes.HasPrefix(a, []byte(DomainValidation+"\x00")))
+	require.True(t, bytes.HasPrefix(b, []byte(DomainValidationVote+"\x00")))
+}
+
+func TestCanonicalProposerBytes_IgnoresExistingSig(t *testing.T) {
+	msg := &types.MsgValidation{InferenceId: 1, ValidatorSlot: 2, EscrowId: "e"}
+	bare, err := CanonicalProposerBytes(msg)
+	require.NoError(t, err)
+	msg.ProposerSig = []byte{1, 2, 3}
+	withSig, err := CanonicalProposerBytes(msg)
+	require.NoError(t, err)
+	require.Equal(t, bare, withSig)
+}
+
+func TestCanonicalProposerBytes_RejectsUnknown(t *testing.T) {
+	_, err := CanonicalProposerBytes(&types.MsgHeartbeat{})
+	require.Error(t, err)
+	_, err = CanonicalProposerBytes(nil)
+	require.Error(t, err)
+}
+
+func TestCanonicalProposerBytes_AllProposerTypesHaveDistinctDomains(t *testing.T) {
+	msgs := []proto.Message{
+		&types.MsgFinishInference{InferenceId: 1, ExecutorSlot: 2, EscrowId: "e"},
+		&types.MsgValidation{InferenceId: 1, ValidatorSlot: 2, EscrowId: "e"},
+		&types.MsgValidationVote{InferenceId: 1, VoterSlot: 2, EscrowId: "e"},
+		&types.MsgRevealSeed{SlotId: 2, EscrowId: "e"},
+	}
+	domains := []string{DomainFinishInference, DomainValidation, DomainValidationVote, DomainRevealSeed}
+	seen := make(map[string]struct{}, len(msgs))
+	for i, msg := range msgs {
+		b, err := CanonicalProposerBytes(msg)
+		require.NoError(t, err)
+		require.True(t, bytes.HasPrefix(b, []byte(domains[i]+"\x00")))
+		key := string(b)
+		_, dup := seen[key]
+		require.False(t, dup, "preimage collision for %T", msg)
+		seen[key] = struct{}{}
+	}
+}

--- a/devshard/state/machine.go
+++ b/devshard/state/machine.go
@@ -1348,9 +1348,7 @@ func (sm *StateMachine) applyValidation(msg *types.MsgValidation) error {
 	}
 
 	// Proposer sig + escrow_id (expensive, after dedup).
-	cloned := proto.Clone(msg).(*types.MsgValidation)
-	cloned.ProposerSig = nil
-	if err := sm.verifyProposerSig(cloned, msg.ProposerSig, sm.slotToAddress[msg.ValidatorSlot], msg.ValidatorSlot); err != nil {
+	if err := sm.verifyProposerSig(msg, msg.ProposerSig, sm.slotToAddress[msg.ValidatorSlot], msg.ValidatorSlot); err != nil {
 		return err
 	}
 	if msg.EscrowId != sm.state.EscrowID {
@@ -1430,9 +1428,7 @@ func (sm *StateMachine) applyValidationVote(msg *types.MsgValidationVote) error 
 	}
 
 	// Verify proposer signature from voter.
-	clonedVV := proto.Clone(msg).(*types.MsgValidationVote)
-	clonedVV.ProposerSig = nil
-	if err := sm.verifyProposerSig(clonedVV, msg.ProposerSig, sm.slotToAddress[msg.VoterSlot], msg.VoterSlot); err != nil {
+	if err := sm.verifyProposerSig(msg, msg.ProposerSig, sm.slotToAddress[msg.VoterSlot], msg.VoterSlot); err != nil {
 		return err
 	}
 
@@ -1767,9 +1763,7 @@ func (sm *StateMachine) recoveredProposerAddress(msg *types.MsgFinishInference) 
 	if msg == nil {
 		return "", fmt.Errorf("%w: nil finish", types.ErrInvalidProposerSig)
 	}
-	cloned := proto.Clone(msg).(*types.MsgFinishInference)
-	cloned.ProposerSig = nil
-	data, err := deterministicMarshal.Marshal(cloned)
+	data, err := signing.CanonicalProposerBytes(msg)
 	if err != nil {
 		return "", fmt.Errorf("marshal for proposer sig: %w", err)
 	}
@@ -1788,16 +1782,15 @@ func (sm *StateMachine) verifyFinishProposerSigLocked(msg *types.MsgFinishInfere
 	if !ok {
 		return fmt.Errorf("%w: slot %d", types.ErrSlotNotInGroup, msg.ExecutorSlot)
 	}
-	cloned := proto.Clone(msg).(*types.MsgFinishInference)
-	cloned.ProposerSig = nil
-	return sm.verifyProposerSig(cloned, msg.ProposerSig, addr, msg.ExecutorSlot)
+	return sm.verifyProposerSig(msg, msg.ProposerSig, addr, msg.ExecutorSlot)
 }
 
-// verifyProposerSig verifies that sig was produced by expectedAddress over
-// msgWithoutSig (the proto message with its proposer_sig field already zeroed).
+// verifyProposerSig verifies that sig was produced by expectedAddress over the
+// domain-separated preimage of msg. CanonicalProposerBytes clears proposer_sig
+// on its own copy, so callers pass the message as received.
 // slotID is used for warm key resolution; pass math.MaxUint32 to skip warm key lookup.
-func (sm *StateMachine) verifyProposerSig(msgWithoutSig proto.Message, sig []byte, expectedAddress string, slotID uint32) error {
-	data, err := deterministicMarshal.Marshal(msgWithoutSig)
+func (sm *StateMachine) verifyProposerSig(msg proto.Message, sig []byte, expectedAddress string, slotID uint32) error {
+	data, err := signing.CanonicalProposerBytes(msg)
 	if err != nil {
 		return fmt.Errorf("marshal for proposer sig: %w", err)
 	}

--- a/devshard/state/proposer_domain_test.go
+++ b/devshard/state/proposer_domain_test.go
@@ -1,0 +1,75 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/types"
+)
+
+func TestProposerSig_VoteCannotAuthenticateValidation(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	sm, user := newTestSM(t, hosts, 10000)
+	applyStartConfirmFinish(t, sm, user, hosts, 1)
+	require.Equal(t, types.StatusFinished, sm.SnapshotState().Inferences[1].Status)
+
+	vote := &types.MsgValidationVote{
+		InferenceId: 1, VoterSlot: 2, VoteValid: false, EscrowId: "escrow-1",
+	}
+	vote.ProposerSig = testutil.SignProposerTx(t, hosts[2], vote)
+	retag := &types.MsgValidation{
+		InferenceId:   vote.InferenceId,
+		ValidatorSlot: vote.VoterSlot,
+		Valid:         vote.VoteValid,
+		EscrowId:      vote.EscrowId,
+		ProposerSig:   vote.ProposerSig,
+	}
+	nonce := sm.SnapshotState().LatestNonce + 1
+	diff := testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txValidation(retag)})
+	_, err := sm.ApplyDiff(diff)
+	require.ErrorIs(t, err, types.ErrInvalidProposerSig)
+	require.False(t, sm.SnapshotState().Inferences[1].ValidatedBy.IsSet(2))
+}
+
+func TestRetaggedValidationDoesNotShadowVote(t *testing.T) {
+	hosts := []*signing.Secp256k1Signer{
+		testutil.MustGenerateKey(t), testutil.MustGenerateKey(t), testutil.MustGenerateKey(t),
+	}
+	sm, user := newTestSM(t, hosts, 10000)
+	applyStartConfirmFinish(t, sm, user, hosts, 1)
+
+	challenge := &types.MsgValidation{InferenceId: 1, ValidatorSlot: 0, Valid: false, EscrowId: "escrow-1"}
+	challenge.ProposerSig = testutil.SignProposerTx(t, hosts[0], challenge)
+	nonce := sm.SnapshotState().LatestNonce + 1
+	_, err := sm.ApplyDiff(testutil.SignDiff(t, user, "escrow-1", nonce, []*types.DevshardTx{txValidation(challenge)}))
+	require.NoError(t, err)
+
+	vote := &types.MsgValidationVote{
+		InferenceId: 1, VoterSlot: 2, VoteValid: false, EscrowId: "escrow-1",
+	}
+	vote.ProposerSig = testutil.SignProposerTx(t, hosts[2], vote)
+	retag := &types.MsgValidation{
+		InferenceId:   vote.InferenceId,
+		ValidatorSlot: vote.VoterSlot,
+		Valid:         vote.VoteValid,
+		EscrowId:      vote.EscrowId,
+		ProposerSig:   append([]byte(nil), vote.ProposerSig...),
+	}
+
+	// Composed retag-first: the retag must not consume the voter's bitmap slot
+	// and leave the real vote to fail as a duplicate.
+	nonce++
+	_, applied, err := sm.ApplyLocalBestEffort(nonce, []*types.DevshardTx{txValidation(retag), txVote(vote)})
+	require.NoError(t, err)
+	require.Len(t, applied, 1)
+	require.NotNil(t, applied[0].GetValidationVote())
+
+	rec := sm.SnapshotState().Inferences[1]
+	require.True(t, rec.ValidatedBy.IsSet(2), "honest vote must land")
+	require.Greater(t, rec.VotesInvalid, uint32(1), "vote weight must count; retag must not occupy the bitmap")
+}


### PR DESCRIPTION
## Summary

- Bind every `proposer_sig` to a type-specific preimage: `domain || 0x00 || deterministic proto(msg with proposer_sig cleared)`.
- Add `signing.CanonicalProposerBytes` as the single place sign and verify agree on those bytes, with one domain per proposer-signed type.
- Wire it through the host signer, the sequencer's validation-retry submit path, the state machine's four verify paths, and the test helpers.
- Reject unknown message types instead of falling back to a bare marshal, so a future proposer-signed type cannot silently share a preimage.

## Why

`MsgValidation` and `MsgValidationVote` are byte-identical on the wire:

```protobuf
    10|message MsgValidation {
  uint64 inference_id = 1;
  uint32 validator_slot = 2;
  bool   valid = 3;
  bytes  proposer_sig = 4;
  string escrow_id = 5;
}

message MsgValidationVote {
  uint64 inference_id = 1;
    20|  uint32 voter_slot = 2;
  bool   vote_valid = 3;
  bytes  proposer_sig = 4;
  string escrow_id = 5;
}
```

The preimage was `deterministicMarshal(msg with proposer_sig nil)` with no type tag, so the same field values produced the same bytes and one signature authenticated both meanings. Both types are host-signed (`host.signProposer`), so a verifier's challenge-phase vote could be retagged as a validation by any group member that saw it.

On a `Challenged` record that retag was load-bearing. `applyValidation` sets `ValidatedBy` but counts vote weight only while the status is `Finished`, so the retag recorded participation with zero weight. The victim's real `MsgValidationVote` then hit the shared bitmap and failed as `ErrDuplicateVote`, and its weight never reached `VotesInvalid`. Repeated across verifiers, this holds the tally under `VoteThreshold` and lets a bad inference escape `Invalidated` — vote suppression using the victim's own signature.

    30|The window is an ordering race: the attacker must land the retag before that verifier's vote is sequenced, which is why this is rated Low. Domain separation removes it outright — the vote signature no longer verifies under the `MsgValidation` domain, whoever relays it.

## Behavior

**Preimage.** `CanonicalProposerBytes(msg)` returns `domain || 0x00 || proto.MarshalOptions{Deterministic: true}` over a clone with `proposer_sig` cleared. The NUL keeps one domain from being a prefix of another. Domains are `devshard.MsgFinishInference.v1`, `MsgValidation.v1`, `MsgValidationVote.v1`, `MsgRevealSeed.v1`.

**Fail closed.** A message type with no domain is an error, not a bare marshal. `nil` is an error.

**Callers pass messages as received.** The helper clears `proposer_sig` on its own copy, so the four state-machine paths (`applyValidation`, `applyValidationVote`, `verifyFinishProposerSigLocked`, `recoveredProposerAddress`) no longer clone and nil the field themselves. That drops one `proto.Clone` per verification on the tx-apply hot path and the async finish-verifier queue.

    40|**Unchanged.** Status gates, dedup order, warm-key resolution, and vote tallying are untouched. Only the bytes being signed change.

## Compatibility

This changes the signed preimage, so it is protocol-breaking under
[`upgrade.md`](./upgrade.md): "Protocol-breaking changes require a **new** approved name."

Existing sessions are unaffected — a binary refuses to attach to a session bound to a different version (`storage.ErrSessionVersionConflict`, `session/manager.go`). But `ApplyLocalPersisted` still verifies proposer sigs while replaying a journal (it relaxes only the max-tokens floor), so a journal written *before* this change cannot be replayed by a binary carrying it. This must land on a version that has not yet shipped with live sessions.

## Relation to the validation protocol proposal

    50|[`proposals/VALIDATION_PROTOCOL_PROPOSAL.md`](./proposals/VALIDATION_PROTOCOL_PROPOSAL.md) makes validator selection a public function of a mainnet beacon, so receivers can check `sender ∈ EligibleValidators(inference_id, context)` at arrival time. That is a good defense, and it is orthogonal to this one.

Eligibility asks *who may speak*. Domain separation asks *which of two things they said*. The retag names the eligible victim as `validator_slot` and carries the victim's real signature, so an eligibility predicate returns true for it; nothing in that check compares the message type against what the signer intended.

The proposal also makes this class of bug more valuable, not less. Phase-2 voting is mandatory for all non-executor hosts today, so `VoteThreshold` survives one lost vote. Under sampled eligibility the set is small, and suppressing one member of a set of one or two is decisive. The proposal additionally introduces `MsgFinishInferenceCommit` and leaves open "whether **invalidation** messages require the **same** eligibility set as **validation**" — more proposer-signed types with overlapping shapes, which is exactly the condition this helper is meant to cover.

Landing the domain now means the beacon work inherits a preimage rule instead of having to add one later behind another version bump.

## Deliberately not included

An earlier draft also rejected `MsgValidation` once a record was `Challenged`. That was dropped:

    60|- It adds nothing on top of domain separation; the retag already fails signature verification.
- It breaks the honest race. A validator that starts while `Finished` and publishes after another host's challenge gets `ErrInvalidTransition`, so the tx is never included in a diff. `Mempool.RemoveIncluded` only evicts txs that appeared in an applied diff, so the entry is stranded. `hasMempoolValidationOrVote` and the retry loop's `validationAlreadyInMempool` then both skip that inference forever, and the validator never publishes the `MsgValidationVote` it would otherwise have sent.
- Where `WithGrace` installs a `StalenessChecker`, the stranded entry makes the host withhold its state signature — the stall described in [`attacks.md`](./attacks.md).

Phase participation rules belong in the eligibility design, not in a hardcoded status transition.

## Test plan

- [x] `go test ./signing/ -run CanonicalProposerBytes` — validation and vote preimages differ; all four types carry distinct domains; an existing `proposer_sig` does not change the bytes; unknown type and nil are errors
- [x] `TestProposerSig_VoteCannotAuthenticateValidation` — a vote signature retagged as `MsgValidation` on a `Finished` record fails with `ErrInvalidProposerSig` and leaves `ValidatedBy` clear
    70|- [x] `TestRetaggedValidationDoesNotShadowVote` — composing retag-then-vote on a `Challenged` record applies only the vote; weight reaches `VotesInvalid`
- [x] `go test ./signing/ ./state/ ./host/ ./user/ ./protocol/ ./transport/ ./cmd/devshardd/... ./cmd/devshardctl/ ./accounting/`
- [x] `go build ./...`; `go vet` clean apart from two pre-existing `stamp_test.go` lock-copy warnings
- [ ] `devshard/storage` Postgres tests (testcontainers unavailable in the sandbox; unrelated to this change)
- [ ] Confirm the target version has no shipped sessions before merge (see Compatibility)
