### PR TITLE
Stop readiness waits when a child exits

### DIFF
--- a/versioned/internal/process/manager.go
+++ b/versioned/internal/process/manager.go
@@ -1650,7 +1650,9 @@ func (m *Manager) runChild(ctx context.Context, c *child) {
 			return
 		}
 
-		if !waitForChildServingReady(ctx, c, m.cfg.ReadyPath, m.cfg.ReadyTimeout) {
+		if !waitForChildServingReady(
+			ctx, c, m.cfg.ReadyPath, m.cfg.ReadyTimeout, proc.Done(),
+		) {
 			slog.Warn("child did not become ready in time", "version", c.version.Name, "port", c.port, "lifecycle_port", c.lifecyclePort(), "ready_path", m.cfg.ReadyPath)
 			proc.ForceStop()
 			_ = proc.Wait()
@@ -1989,12 +1991,19 @@ func (c *child) adminAddr() string {
 // waitForChildServingReady gates the Starting -> Running transition. Modern
 // devshardd children must be logically ready on their admin listener and also
 // serve health checks on the public listener that receives proxied traffic.
-func waitForChildServingReady(ctx context.Context, c *child, path string, timeout time.Duration) bool {
+func waitForChildServingReady(
+	ctx context.Context,
+	c *child,
+	path string,
+	timeout time.Duration,
+	processDone <-chan struct{},
+) bool {
 	adminPort := int(c.adminPort.Load())
 	if adminPort == 0 {
 		return waitForReadiness(
 			ctx,
 			timeout,
+			processDone,
 			func(probeCtx context.Context, client *http.Client) bool {
 				ready, viaLegacy := readyEndpointReady(probeCtx, client, c.port, path, true)
 				if viaLegacy {
@@ -2004,7 +2013,7 @@ func waitForChildServingReady(ctx context.Context, c *child, path string, timeou
 			},
 		)
 	}
-	return waitForReadiness(ctx, timeout, func(probeCtx context.Context, client *http.Client) bool {
+	return waitForReadiness(ctx, timeout, processDone, func(probeCtx context.Context, client *http.Client) bool {
 		ready, _ := readyEndpointReady(probeCtx, client, adminPort, path, false)
 		return ready && publicEndpointReady(probeCtx, client, c.port)
 	})
@@ -2013,6 +2022,7 @@ func waitForChildServingReady(ctx context.Context, c *child, path string, timeou
 func waitForReadiness(
 	ctx context.Context,
 	timeout time.Duration,
+	processDone <-chan struct{},
 	probe func(context.Context, *http.Client) bool,
 ) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -2025,6 +2035,9 @@ func waitForReadiness(
 		retry := time.NewTimer(100 * time.Millisecond)
 		select {
 		case <-probeCtx.Done():
+			retry.Stop()
+			return false
+		case <-processDone:
 			retry.Stop()
 			return false
 		case <-retry.C:

--- a/versioned/internal/process/manager_test.go
+++ b/versioned/internal/process/manager_test.go
@@ -2214,6 +2214,7 @@ func TestWaitForChildServingReadyFallsBackToHealthzWhenDefaultReadyMissing(
 		&child{port: port},
 		"/ready",
 		time.Second,
+		nil,
 	) {
 		t.Fatal("expected /ready 404 to fall back to /healthz")
 	}
@@ -2232,6 +2233,7 @@ func TestWaitForChildServingReadyDoesNotFallbackForCustomReadyPath(
 		&child{port: port},
 		"/custom-ready",
 		200*time.Millisecond,
+		nil,
 	) {
 		t.Fatal("custom ready path should not use legacy fallback")
 	}
@@ -2261,7 +2263,7 @@ func TestWaitForChildServingReadyRequiresPublicHealth(t *testing.T) {
 
 	c := &child{port: publicPort}
 	setTestAdminPort(c, adminPort)
-	if waitForChildServingReady(context.Background(), c, "/ready", 200*time.Millisecond) {
+	if waitForChildServingReady(context.Background(), c, "/ready", 200*time.Millisecond, nil) {
 		t.Fatal("admin readiness must not hide an unavailable public listener")
 	}
 	if publicHits.Load() == 0 {
@@ -2269,7 +2271,7 @@ func TestWaitForChildServingReadyRequiresPublicHealth(t *testing.T) {
 	}
 
 	publicReady.Store(true)
-	if !waitForChildServingReady(context.Background(), c, "/ready", time.Second) {
+	if !waitForChildServingReady(context.Background(), c, "/ready", time.Second, nil) {
 		t.Fatal("child should become ready when admin and public endpoints are healthy")
 	}
 }
@@ -2297,11 +2299,25 @@ func TestWaitForChildServingReadyRechecksAdminAndPublicTogether(t *testing.T) {
 
 	c := &child{port: publicPort}
 	setTestAdminPort(c, adminPort)
-	if waitForChildServingReady(context.Background(), c, "/ready", 250*time.Millisecond) {
+	if waitForChildServingReady(context.Background(), c, "/ready", 250*time.Millisecond, nil) {
 		t.Fatal("child became ready without admin and public health at the same time")
 	}
 	if adminHits.Load() < 2 {
 		t.Fatal("admin readiness was not rechecked after public health failed")
+	}
+}
+
+func TestWaitForChildServingReadyStopsWhenProcessExits(t *testing.T) {
+	processDone := make(chan struct{})
+	close(processDone)
+	started := time.Now()
+	if waitForChildServingReady(
+		context.Background(), &child{port: 1}, "/ready", time.Minute, processDone,
+	) {
+		t.Fatal("exited child became ready")
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("readiness waited %v after the child had already exited", elapsed)
 	}
 }
 


### PR DESCRIPTION
> Extracted from the closed transactional updater branch (#1611 history); a standalone versiond fix.

## Summary

While versiond waits for a freshly started `devshardd` to become ready, it polls the child's readiness endpoint until the readiness timeout. A child that exits immediately (for example during a PostgreSQL outage, when fail-closed storage refuses to open) was therefore only noticed at the end of that timeout, delaying the restart backoff by up to the full budget.

## Change

Include the supervised process completion channel in the startup readiness wait. A child that exits enters restart backoff at once instead of consuming the readiness timeout first.

## Validation

- `go test -race ./internal/process/` in `versioned`
