### PR TITLE
fix(deploy): pin Kimi B200 MLA prefill backend off FA4

### DIFF
--- a/deploy/join/node-config-kimik26-B200.json
+++ b/deploy/join/node-config-kimik26-B200.json
@@ -16,6 +16,7 @@
           "--tool-call-parser", "kimi_k2",
           "--reasoning-parser", "kimi_k2",
           "--attention-backend", "FLASHINFER_MLA",
+          "--attention-config", "{\"mla_prefill_backend\":\"TRTLLM_RAGGED\"}",
           "--disable-custom-all-reduce",
           "--gpu-memory-utilization", "0.95",
           "--max-num-seqs", "128",


### PR DESCRIPTION
Kimi K2.6 on Blackwell crashes in the MLA prefill context-chunk path with
`ValueError: Mismatched mO.strides[0]`, killing EngineCore.

vLLM 0.25.1 pins `vllm-flash-attn` at `2c839c3`, five commits before
[`caaa4eb`](https://github.com/vllm-project/flash-attention/commit/caaa4eb59845388a20b1f435ecaafb4bd9517ad8)
which fixes it. First release carrying the fix is v0.26.0.

On Blackwell the MLA prefill backend auto-selects `FLASH_ATTN` at FA4 (the CuTe
path). Adding `--attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED"}'`
selects the next backend in vLLM's own Blackwell priority list, which does not
use that kernel. Confirmed upstream as a working workaround in
vllm-project/vllm#49200.

`--attention-backend FLASHINFER_MLA` does not cover this — it sets
`attention_config.backend`, while the MLA prefill sub-backend has its own selector.

B200 only: `TRTLLM_RAGGED` requires `device_capability.major == 10`, and an
explicitly selected invalid backend raises at startup, so the H200 config must
stay unchanged.
