### PR TITLE
test(devshard): add snapshot recovery validation coverage

### DIFF
--- a/devshard/Makefile
+++ b/devshard/Makefile
@@ -1,4 +1,4 @@
-.PHONY: proto test integration-test stress-test fault-test ci-testenv-unit ci-testenv-integration devshard-gateway-release e2e e2e-test e2e-images
+.PHONY: proto test integration-test stress-test snapshot-recovery-stress-test fault-test ci-testenv-unit ci-testenv-integration devshard-gateway-release e2e e2e-test e2e-images
 
 DEVSHARD_VERSION ?= dev
 DEVSHARD_PROTOCOL_VERSION ?= v3
@@ -69,6 +69,9 @@ integration-test:
 
 stress-test:
 	go test ./user/ ./storage/ -tags stress -run TestStress -v -timeout 30m -count=1
+
+snapshot-recovery-stress-test:
+	go test ./user/ -tags stress -run TestStressSnapshotRecoveryBudget -timeout 30m -count=1
 
 fault-test:
 	go test ./user/ -tags stress -run TestFault -v -timeout 10m -count=1

--- a/devshard/testenv/citest/harness/config.go
+++ b/devshard/testenv/citest/harness/config.go
@@ -16,6 +16,8 @@ import (
 type MultiConfigOpts struct {
 	Hosts          int
 	EscrowSlots    int
+	MaxNonce       uint32
+	EscrowAmount   uint64
 	ValidationRate uint32 // 0 = default; else params + seed escrow snapshot
 }
 
@@ -61,6 +63,14 @@ func WriteMultiConfig(t *testing.T, dir string, opts MultiConfigOpts) {
 
 	paramsRate := ""
 	escrowRate := ""
+	paramsMaxNonce := ""
+	escrowAmount := ""
+	if opts.MaxNonce > 0 {
+		paramsMaxNonce = fmt.Sprintf("\n  max_nonce: %d", opts.MaxNonce)
+	}
+	if opts.EscrowAmount > 0 {
+		escrowAmount = fmt.Sprintf("\n    amount: %d", opts.EscrowAmount)
+	}
 	if opts.ValidationRate > 0 {
 		paramsRate = fmt.Sprintf("\n  validation_rate: %d", opts.ValidationRate)
 		escrowRate = fmt.Sprintf("\n    validation_rate: %d", opts.ValidationRate)
@@ -78,7 +88,7 @@ epoch:
   poc_start_block_height: 100
   epoch_length: 400
 params:
-  devshard_requests_enabled: true%s
+  devshard_requests_enabled: true%s%s
 mock_chain:
   grpc_port: %d
   rpc_port: %d
@@ -110,12 +120,12 @@ warm_grantee:
   private_key_hex: TODO
 escrows:
   - id: 1
-    model_id: test-model%s
+    model_id: test-model%s%s
 grantees:
   - granter_address: ""
     message_type_url: /inference.inference.MsgStartInference
     grantees: [""]
-`, paramsRate, chainGRPC, chainRPC, chainTestenv, dapiGRPC, dapiHTTP, openAIHTTP, routerPort, gatewayPort, opts.EscrowSlots, hosts.String(), escrowRate)
+`, paramsMaxNonce, paramsRate, chainGRPC, chainRPC, chainTestenv, dapiGRPC, dapiHTTP, openAIHTTP, routerPort, gatewayPort, opts.EscrowSlots, hosts.String(), escrowAmount, escrowRate)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(skeleton), 0o644))
 }
 

--- a/devshard/testenv/citest/harness/config_test.go
+++ b/devshard/testenv/citest/harness/config_test.go
@@ -47,6 +47,21 @@ func TestWriteMultiConfig_CustomValidationRate(t *testing.T) {
 	require.Equal(t, uint32(7500), cfg.Escrows[0].ValidationRate)
 }
 
+func TestWriteMultiConfig_CustomNonceAndAmount(t *testing.T) {
+	dir := t.TempDir()
+	WriteMultiConfig(t, dir, MultiConfigOpts{
+		Hosts:        2,
+		EscrowSlots:  2,
+		MaxNonce:     1500,
+		EscrowAmount: 100_000_000,
+	})
+
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, uint32(1500), cfg.Params.MaxNonce)
+	require.Equal(t, uint64(100_000_000), cfg.Escrows[0].Amount)
+}
+
 func TestWriteStackConfig_GencomposeProducesTwoVersiondServices(t *testing.T) {
 	if os.Getenv("TESTENV_HARNESS_GENCOMPOSE") != "1" {
 		t.Skip("set TESTENV_HARNESS_GENCOMPOSE=1 to run gencompose harness test")

--- a/devshard/testenv/citest/versiond_snapshot_recovery_test.go
+++ b/devshard/testenv/citest/versiond_snapshot_recovery_test.go
@@ -1,0 +1,347 @@
+//go:build testenvci
+
+package citest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"devshard/host"
+	"devshard/testenv/citest/harness"
+	"devshard/testenv/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	snapshotRecoveryWarnThreshold = 30 * time.Second
+	snapshotRecoveryFailThreshold = 60 * time.Second
+)
+
+// TestVersiondSnapshotRecoveryUsesSnapshotAfterRestart verifies the production
+// versiond stack can recover a long-enough journal through a persisted host
+// snapshot instead of replaying from nonce 1.
+func TestVersiondSnapshotRecoveryUsesSnapshotAfterRestart(t *testing.T) {
+	harness.SkipUnlessEnv(t, "TESTENV_CITEST")
+	harness.RequireDocker(t)
+
+	stack := harness.NewStack(t, "citest-versiond-snapshot-recovery-*")
+	harness.RequireLinuxDevshardd(t, stack.TestenvDir)
+	harness.WriteMultiConfig(t, stack.WorkDir, harness.MultiConfigOpts{
+		Hosts:        2,
+		EscrowSlots:  2,
+		MaxNonce:     uint32(host.SnapshotInterval * 3),
+		EscrowAmount: config.DefaultEscrowAmount * 100,
+	})
+	stack.RunGencompose(t)
+	cfg := stack.LoadConfig(t)
+	require.Len(t, cfg.Hosts, 2, "expected 2 versiond hosts")
+	stack.Up(t)
+	eps := stack.Endpoints(t, cfg)
+	summary := snapshotRecoverySummary{
+		TestName:  t.Name(),
+		Hosts:     harness.VersiondHostIDs(cfg),
+		Threshold: snapshotRecoveryThresholds(),
+	}
+	summaryArtifactWritten := false
+	defer func() {
+		if !summaryArtifactWritten {
+			writeSnapshotRecoverySummary(t, summary)
+		}
+	}()
+
+	client := harness.HTTPClient()
+	chatClient := harness.GatewayChatClient()
+	adminKey := harness.TestenvAdminAPIKey
+	t.Cleanup(func() {
+		if t.Failed() {
+			harness.DumpComposeLogs(t, stack, "devshardctl", "versiond-0", "versiond-1", "versiond-router", "devshard-postgres")
+		}
+	})
+
+	harness.WaitStackHealthy(t, stack, eps)
+	harness.WaitGatewayChatReady(t, chatClient, eps.GatewayHTTP, 3*time.Minute, stack)
+	harness.WaitGETOK(t, client, eps.RouterHTTP+"/"+cfg.Versiond.VersionName+"/healthz", 5*time.Minute, "devshardd health via router", stack)
+
+	model := config.PrimaryModelID(cfg)
+	snap0 := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	require.NotEmpty(t, snap0.EscrowID)
+	summary.EscrowID = snap0.EscrowID
+
+	targetNonce := nextSnapshotNonce(snap0.LatestNonce)
+	summary.TargetSnapshotNonce = targetNonce
+	harness.Step(t, "advance gateway session %s to snapshot nonce %d", snap0.EscrowID, targetNonce)
+	warmupStartedAt := time.Now()
+	snapAtSnapshot := advanceGatewaySessionToNonce(t, chatClient, client, eps.GatewayHTTP, adminKey, model, targetNonce)
+	summary.WarmupMs = millisSince(warmupStartedAt)
+	summary.LatestNonceBeforeRestart = snapAtSnapshot.LatestNonce
+	harness.Step(t, "snapshot warmup finished in %s at latest nonce %d", time.Duration(summary.WarmupMs)*time.Millisecond, snapAtSnapshot.LatestNonce)
+	require.Equal(t, snap0.EscrowID, snapAtSnapshot.EscrowID, "escrow id changed while advancing to snapshot")
+
+	snapshotWaitStartedAt := time.Now()
+	snapshotNonce := waitPostgresSnapshotNonce(t, stack, cfg, snapAtSnapshot.EscrowID, targetNonce, 3*time.Minute)
+	summary.SnapshotWaitMs = millisSince(snapshotWaitStartedAt)
+	summary.PostgresSnapshotNonce = snapshotNonce
+	require.GreaterOrEqual(t, snapshotNonce, targetNonce)
+
+	hostIDs := harness.VersiondHostIDs(cfg)
+	harness.Step(t, "restart all versiond instances (%v) and demand-load the snapshotted session", hostIDs)
+	recoveryStartedAt := time.Now()
+	harness.RestartServices(t, stack, hostIDs...)
+	harness.WaitVersiondSessionHealthy(t, stack, cfg, eps, snapAtSnapshot.EscrowID)
+	summary.HostDemandLoadMs = make(map[string]int64, len(hostIDs))
+	for _, hostID := range hostIDs {
+		summary.HostDemandLoadMs[hostID] = waitVersiondHostSessionMempool(t, stack, hostID, snapAtSnapshot.EscrowID, 3*time.Minute).Milliseconds()
+	}
+	summary.RestartRecoveryMs = millisSince(recoveryStartedAt)
+	harness.Step(t, "versiond restart recovery finished in %s", time.Duration(summary.RestartRecoveryMs)*time.Millisecond)
+	if time.Duration(summary.RestartRecoveryMs)*time.Millisecond > snapshotRecoveryWarnThreshold {
+		t.Logf("citest: WARNING snapshot restart recovery exceeded warning threshold: got=%s threshold=%s",
+			time.Duration(summary.RestartRecoveryMs)*time.Millisecond, snapshotRecoveryWarnThreshold)
+	}
+	require.LessOrEqual(t, time.Duration(summary.RestartRecoveryMs)*time.Millisecond, snapshotRecoveryFailThreshold,
+		"snapshot restart recovery exceeded threshold")
+
+	snapAfterRestart := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	summary.LatestNonceAfterRestart = snapAfterRestart.LatestNonce
+	harness.RequireGatewaySessionStable(t, snapAtSnapshot, snapAfterRestart)
+
+	logs, err := stack.ComposeLogsTail(5000, hostIDs...)
+	require.NoError(t, err)
+	summary.RestoredSnapshotLogSeen = strings.Contains(logs, "restored devshard snapshot") &&
+		strings.Contains(logs, "escrow_id="+snapAtSnapshot.EscrowID)
+	summary.SnapshotErrorLogSeen = strings.Contains(logs, "failed to load devshard snapshot") ||
+		strings.Contains(logs, "failed to decode devshard snapshot") ||
+		strings.Contains(logs, "devshard snapshot failed root check")
+	require.True(t, summary.RestoredSnapshotLogSeen, "expected restored devshard snapshot log for escrow %s", snapAtSnapshot.EscrowID)
+	require.False(t, summary.SnapshotErrorLogSeen, "unexpected snapshot fallback/error log")
+
+	harness.Step(t, "continue gateway chat after snapshot recovery")
+	chatAfterRestartStartedAt := time.Now()
+	resp := harness.PostGatewayChatCompletion(t, chatClient, eps.GatewayHTTP, adminKey, harness.ChatCompletionRequest{
+		Model: model,
+		Messages: []harness.ChatMessage{
+			{Role: "user", Content: "citest versiond snapshot recovery after restart"},
+		},
+		MaxTokens: 4,
+	})
+	summary.PostRestartChatMs = millisSince(chatAfterRestartStartedAt)
+	harness.RequireMockOpenAIContent(t, resp.Choices[0].Message.Content)
+	snapAfterChat := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	summary.LatestNonceAfterChat = snapAfterChat.LatestNonce
+	harness.RequireGatewaySessionAdvanced(t, snapAfterRestart, snapAfterChat)
+
+	if artifactDir, ok := writeSnapshotRecoverySummary(t, summary); ok {
+		summaryArtifactWritten = true
+		validateSnapshotRecoveryArtifacts(t, artifactDir, summary)
+	}
+}
+
+type snapshotRecoverySummary struct {
+	TestName                 string                  `json:"test_name"`
+	EscrowID                 string                  `json:"escrow_id,omitempty"`
+	Hosts                    []string                `json:"hosts,omitempty"`
+	TargetSnapshotNonce      uint64                  `json:"target_snapshot_nonce,omitempty"`
+	PostgresSnapshotNonce    uint64                  `json:"postgres_snapshot_nonce,omitempty"`
+	LatestNonceBeforeRestart uint64                  `json:"latest_nonce_before_restart,omitempty"`
+	LatestNonceAfterRestart  uint64                  `json:"latest_nonce_after_restart,omitempty"`
+	LatestNonceAfterChat     uint64                  `json:"latest_nonce_after_chat,omitempty"`
+	WarmupMs                 int64                   `json:"warmup_ms,omitempty"`
+	SnapshotWaitMs           int64                   `json:"snapshot_wait_ms,omitempty"`
+	RestartRecoveryMs        int64                   `json:"restart_recovery_ms,omitempty"`
+	HostDemandLoadMs         map[string]int64        `json:"host_demand_load_ms,omitempty"`
+	PostRestartChatMs        int64                   `json:"post_restart_chat_ms,omitempty"`
+	RestoredSnapshotLogSeen  bool                    `json:"restored_snapshot_log_seen"`
+	SnapshotErrorLogSeen     bool                    `json:"snapshot_error_log_seen"`
+	Threshold                snapshotRecoveryBudgets `json:"threshold"`
+}
+
+type snapshotRecoveryBudgets struct {
+	RestartRecoveryWarnMs int64 `json:"restart_recovery_warn_ms"`
+	RestartRecoveryFailMs int64 `json:"restart_recovery_fail_ms"`
+}
+
+func snapshotRecoveryThresholds() snapshotRecoveryBudgets {
+	return snapshotRecoveryBudgets{
+		RestartRecoveryWarnMs: snapshotRecoveryWarnThreshold.Milliseconds(),
+		RestartRecoveryFailMs: snapshotRecoveryFailThreshold.Milliseconds(),
+	}
+}
+
+func millisSince(startedAt time.Time) int64 {
+	return time.Since(startedAt).Milliseconds()
+}
+
+func writeSnapshotRecoverySummary(t *testing.T, summary snapshotRecoverySummary) (string, bool) {
+	t.Helper()
+	dir := strings.TrimSpace(os.Getenv("TESTENV_CITEST_ARTIFACT_DIR"))
+	if dir == "" {
+		return "", false
+	}
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	data, err := json.MarshalIndent(summary, "", "  ")
+	require.NoError(t, err)
+	path := filepath.Join(dir, "versiond-snapshot-recovery-summary.json")
+	require.NoError(t, os.WriteFile(path, append(data, '\n'), 0o644))
+	t.Logf("citest: wrote snapshot recovery summary artifact %s", path)
+	return dir, true
+}
+
+func validateSnapshotRecoveryArtifacts(t *testing.T, artifactDir string, want snapshotRecoverySummary) {
+	t.Helper()
+	path := filepath.Join(artifactDir, "versiond-snapshot-recovery-summary.json")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.True(t, json.Valid(data), "summary artifact is not valid JSON: %s", path)
+
+	var got snapshotRecoverySummary
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, want.TestName, got.TestName)
+	require.Equal(t, want.EscrowID, got.EscrowID)
+	require.Equal(t, want.Hosts, got.Hosts)
+	require.Equal(t, want.TargetSnapshotNonce, got.TargetSnapshotNonce)
+	require.Equal(t, want.PostgresSnapshotNonce, got.PostgresSnapshotNonce)
+	require.Equal(t, want.LatestNonceBeforeRestart, got.LatestNonceBeforeRestart)
+	require.Equal(t, want.LatestNonceAfterRestart, got.LatestNonceAfterRestart)
+	require.Equal(t, want.LatestNonceAfterChat, got.LatestNonceAfterChat)
+	require.Equal(t, want.HostDemandLoadMs, got.HostDemandLoadMs)
+	require.Equal(t, want.Threshold, got.Threshold)
+
+	require.Positive(t, got.WarmupMs)
+	require.Positive(t, got.SnapshotWaitMs)
+	require.Positive(t, got.RestartRecoveryMs)
+	require.Positive(t, got.PostRestartChatMs)
+	require.True(t, got.RestoredSnapshotLogSeen)
+	require.False(t, got.SnapshotErrorLogSeen)
+	require.LessOrEqual(t, time.Duration(got.RestartRecoveryMs)*time.Millisecond, snapshotRecoveryFailThreshold)
+	t.Logf("citest: validated snapshot recovery artifact %s", path)
+}
+
+func nextSnapshotNonce(latest uint64) uint64 {
+	interval := uint64(host.SnapshotInterval)
+	return ((latest / interval) + 1) * interval
+}
+
+func advanceGatewaySessionToNonce(
+	t *testing.T,
+	chatClient *http.Client,
+	statusClient *http.Client,
+	gatewayURL, adminKey, model string,
+	targetNonce uint64,
+) harness.GatewaySessionSnapshot {
+	t.Helper()
+
+	maxRequests := int(host.SnapshotInterval) + 50
+	var snap harness.GatewaySessionSnapshot
+	for i := 1; i <= maxRequests; i++ {
+		resp := harness.PostGatewayChatCompletion(t, chatClient, gatewayURL, adminKey, harness.ChatCompletionRequest{
+			Model: model,
+			Messages: []harness.ChatMessage{
+				{Role: "user", Content: fmt.Sprintf("citest snapshot recovery warmup %03d", i)},
+			},
+			MaxTokens: 4,
+		})
+		harness.RequireMockOpenAIContent(t, resp.Choices[0].Message.Content)
+
+		if i == 1 || i%25 == 0 {
+			snap = harness.GetGatewaySessionSnapshot(t, statusClient, gatewayURL, adminKey)
+			harness.Step(t, "snapshot warmup request %d/%d reached latest nonce %d", i, maxRequests, snap.LatestNonce)
+			if snap.LatestNonce >= targetNonce {
+				return snap
+			}
+		}
+	}
+
+	snap = harness.GetGatewaySessionSnapshot(t, statusClient, gatewayURL, adminKey)
+	require.GreaterOrEqual(t, snap.LatestNonce, targetNonce,
+		"gateway session did not reach snapshot nonce after %d requests", maxRequests)
+	return snap
+}
+
+func waitPostgresSnapshotNonce(t *testing.T, stack *harness.Stack, cfg *config.File, escrowID string, minNonce uint64, timeout time.Duration) uint64 {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	var lastRaw string
+	for time.Now().Before(deadline) {
+		nonce, raw, err := postgresSnapshotNonce(stack, cfg, escrowID)
+		if err == nil && nonce >= minNonce {
+			harness.Step(t, "postgres snapshot for escrow %s reached nonce %d", escrowID, nonce)
+			return nonce
+		}
+		lastErr = err
+		lastRaw = raw
+		time.Sleep(2 * time.Second)
+	}
+
+	t.Fatalf("snapshot for escrow %s did not reach nonce %d within %s; lastRaw=%q lastErr=%v",
+		escrowID, minNonce, timeout, lastRaw, lastErr)
+	return 0
+}
+
+func postgresSnapshotNonce(stack *harness.Stack, cfg *config.File, escrowID string) (uint64, string, error) {
+	user, db, pass := postgresCreds(cfg)
+	query := fmt.Sprintf("SELECT COALESCE(MAX(nonce), 0) FROM devshard_snapshots WHERE escrow_id = '%s'", strings.ReplaceAll(escrowID, "'", "''"))
+	raw, err := stack.ComposeExecOutput("devshard-postgres",
+		"env", "PGPASSWORD="+pass,
+		"psql", "-U", user, "-d", db, "-At", "-c", query)
+	if err != nil {
+		return 0, raw, err
+	}
+	nonce, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 64)
+	if err != nil {
+		return 0, raw, fmt.Errorf("parse snapshot nonce %q: %w", raw, err)
+	}
+	return nonce, raw, nil
+}
+
+func postgresCreds(cfg *config.File) (user, db, pass string) {
+	user = config.DefaultPostgresUser
+	db = config.DefaultPostgresDB
+	pass = config.DefaultPostgresPassword
+	if cfg != nil {
+		if cfg.Postgres.User != "" {
+			user = cfg.Postgres.User
+		}
+		if cfg.Postgres.Database != "" {
+			db = cfg.Postgres.Database
+		}
+		if cfg.Postgres.Password != "" {
+			pass = cfg.Postgres.Password
+		}
+	}
+	return user, db, pass
+}
+
+func waitVersiondHostSessionMempool(t *testing.T, stack *harness.Stack, service, escrowID string, timeout time.Duration) time.Duration {
+	t.Helper()
+
+	startedAt := time.Now()
+	deadline := time.Now().Add(timeout)
+	url := "http://127.0.0.1:8080/sessions/" + escrowID + "/mempool"
+	var lastErr error
+	var lastRaw string
+	for time.Now().Before(deadline) {
+		raw, err := stack.ComposeExecOutput(service, "wget", "-q", "-O", "-", url)
+		if err == nil {
+			elapsed := time.Since(startedAt)
+			harness.Step(t, "%s recovered session %s via direct mempool probe in %s", service, escrowID, elapsed)
+			return elapsed
+		}
+		lastErr = err
+		lastRaw = raw
+		time.Sleep(2 * time.Second)
+	}
+
+	t.Fatalf("%s did not serve mempool for session %s within %s; lastRaw=%q lastErr=%v",
+		service, escrowID, timeout, lastRaw, lastErr)
+	return 0
+}

--- a/devshard/testenv/citest/versiond_snapshot_recovery_test.go
+++ b/devshard/testenv/citest/versiond_snapshot_recovery_test.go
@@ -23,6 +23,7 @@ import (
 const (
 	snapshotRecoveryWarnThreshold = 30 * time.Second
 	snapshotRecoveryFailThreshold = 60 * time.Second
+	corruptSnapshotHex            = "6e6f742d612d70726f746f2d736e617073686f74" // "not-a-proto-snapshot"
 )
 
 // TestVersiondSnapshotRecoveryUsesSnapshotAfterRestart verifies the production
@@ -142,6 +143,87 @@ func TestVersiondSnapshotRecoveryUsesSnapshotAfterRestart(t *testing.T) {
 		summaryArtifactWritten = true
 		validateSnapshotRecoveryArtifacts(t, artifactDir, summary)
 	}
+}
+
+// TestVersiondSnapshotRecoveryCorruptSnapshotFallsBack verifies a corrupt
+// persisted snapshot does not strand a production versiond host: recovery logs
+// the rejected snapshot, replays the journal from nonce 1, repairs the snapshot,
+// and the session remains usable.
+func TestVersiondSnapshotRecoveryCorruptSnapshotFallsBack(t *testing.T) {
+	harness.SkipUnlessEnv(t, "TESTENV_CITEST")
+	harness.RequireDocker(t)
+
+	stack := harness.NewStack(t, "citest-versiond-corrupt-snapshot-*")
+	harness.RequireLinuxDevshardd(t, stack.TestenvDir)
+	harness.WriteMultiConfig(t, stack.WorkDir, harness.MultiConfigOpts{
+		Hosts:        2,
+		EscrowSlots:  2,
+		MaxNonce:     uint32(host.SnapshotInterval * 3),
+		EscrowAmount: config.DefaultEscrowAmount * 100,
+	})
+	stack.RunGencompose(t)
+	cfg := stack.LoadConfig(t)
+	require.Len(t, cfg.Hosts, 2, "expected 2 versiond hosts")
+	stack.Up(t)
+	eps := stack.Endpoints(t, cfg)
+
+	client := harness.HTTPClient()
+	chatClient := harness.GatewayChatClient()
+	adminKey := harness.TestenvAdminAPIKey
+	t.Cleanup(func() {
+		if t.Failed() {
+			harness.DumpComposeLogs(t, stack, "devshardctl", "versiond-0", "versiond-1", "versiond-router", "devshard-postgres")
+		}
+	})
+
+	harness.WaitStackHealthy(t, stack, eps)
+	harness.WaitGatewayChatReady(t, chatClient, eps.GatewayHTTP, 3*time.Minute, stack)
+	harness.WaitGETOK(t, client, eps.RouterHTTP+"/"+cfg.Versiond.VersionName+"/healthz", 5*time.Minute, "devshardd health via router", stack)
+
+	model := config.PrimaryModelID(cfg)
+	snap0 := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	require.NotEmpty(t, snap0.EscrowID)
+
+	targetNonce := nextSnapshotNonce(snap0.LatestNonce)
+	harness.Step(t, "advance gateway session %s to snapshot nonce %d", snap0.EscrowID, targetNonce)
+	snapAtSnapshot := advanceGatewaySessionToNonce(t, chatClient, client, eps.GatewayHTTP, adminKey, model, targetNonce)
+	require.Equal(t, snap0.EscrowID, snapAtSnapshot.EscrowID, "escrow id changed while advancing to snapshot")
+	snapshotNonce := waitPostgresSnapshotNonce(t, stack, cfg, snapAtSnapshot.EscrowID, targetNonce, 3*time.Minute)
+	require.GreaterOrEqual(t, snapshotNonce, targetNonce)
+
+	corruptPostgresSnapshot(t, stack, cfg, snapAtSnapshot.EscrowID)
+
+	hostIDs := harness.VersiondHostIDs(cfg)
+	recoveryHost := hostIDs[0]
+	harness.Step(t, "restart %s and demand-load session %s with corrupt snapshot", recoveryHost, snapAtSnapshot.EscrowID)
+	recoveryStartedAt := time.Now()
+	harness.RestartService(t, stack, recoveryHost)
+	elapsed := waitVersiondHostSessionMempool(t, stack, recoveryHost, snapAtSnapshot.EscrowID, 3*time.Minute)
+	harness.Step(t, "%s corrupt snapshot fallback finished in %s (direct load %s)", recoveryHost, time.Since(recoveryStartedAt), elapsed)
+	require.LessOrEqual(t, time.Since(recoveryStartedAt), snapshotRecoveryFailThreshold,
+		"corrupt snapshot fallback exceeded threshold")
+
+	logs, err := stack.ComposeLogsTail(5000, recoveryHost)
+	require.NoError(t, err)
+	require.Contains(t, logs, "failed to decode devshard snapshot, replaying full history")
+	require.Contains(t, logs, "escrow_id="+snapAtSnapshot.EscrowID)
+	require.NotContains(t, logs, "restored devshard snapshot")
+	requirePostgresSnapshotRepaired(t, stack, cfg, snapAtSnapshot.EscrowID)
+
+	snapAfterFallback := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	harness.RequireGatewaySessionStable(t, snapAtSnapshot, snapAfterFallback)
+
+	harness.Step(t, "continue gateway chat after corrupt snapshot fallback")
+	resp := harness.PostGatewayChatCompletion(t, chatClient, eps.GatewayHTTP, adminKey, harness.ChatCompletionRequest{
+		Model: model,
+		Messages: []harness.ChatMessage{
+			{Role: "user", Content: "citest versiond corrupt snapshot fallback after restart"},
+		},
+		MaxTokens: 4,
+	})
+	harness.RequireMockOpenAIContent(t, resp.Choices[0].Message.Content)
+	snapAfterChat := harness.GetGatewaySessionSnapshot(t, client, eps.GatewayHTTP, adminKey)
+	harness.RequireGatewaySessionAdvanced(t, snapAfterFallback, snapAfterChat)
 }
 
 type snapshotRecoverySummary struct {
@@ -301,6 +383,30 @@ func postgresSnapshotNonce(stack *harness.Stack, cfg *config.File, escrowID stri
 		return 0, raw, fmt.Errorf("parse snapshot nonce %q: %w", raw, err)
 	}
 	return nonce, raw, nil
+}
+
+func corruptPostgresSnapshot(t *testing.T, stack *harness.Stack, cfg *config.File, escrowID string) {
+	t.Helper()
+	user, db, pass := postgresCreds(cfg)
+	query := fmt.Sprintf("UPDATE devshard_snapshots SET state_data = decode('%s', 'hex') WHERE escrow_id = '%s'",
+		corruptSnapshotHex, strings.ReplaceAll(escrowID, "'", "''"))
+	raw := stack.ComposeExec(t, "devshard-postgres",
+		"env", "PGPASSWORD="+pass,
+		"psql", "-U", user, "-d", db, "-At", "-c", query)
+	require.Contains(t, raw, "UPDATE 1")
+	harness.Step(t, "corrupted postgres snapshot for escrow %s", escrowID)
+}
+
+func requirePostgresSnapshotRepaired(t *testing.T, stack *harness.Stack, cfg *config.File, escrowID string) {
+	t.Helper()
+	user, db, pass := postgresCreds(cfg)
+	query := fmt.Sprintf("SELECT encode(state_data, 'hex') FROM devshard_snapshots WHERE escrow_id = '%s'",
+		strings.ReplaceAll(escrowID, "'", "''"))
+	raw := stack.ComposeExec(t, "devshard-postgres",
+		"env", "PGPASSWORD="+pass,
+		"psql", "-U", user, "-d", db, "-At", "-c", query)
+	require.NotEqual(t, corruptSnapshotHex, strings.TrimSpace(raw), "corrupt snapshot was not repaired")
+	harness.Step(t, "postgres snapshot for escrow %s was repaired after full replay fallback", escrowID)
 }
 
 func postgresCreds(cfg *config.File) (user, db, pass string) {

--- a/devshard/user/snapshot_recovery_stress_test.go
+++ b/devshard/user/snapshot_recovery_stress_test.go
@@ -1,0 +1,280 @@
+//go:build stress
+
+package user
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/host"
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/state"
+	"devshard/storage"
+	"devshard/stub"
+	"devshard/types"
+)
+
+const (
+	defaultSnapshotRecoveryStressSessions = 100
+	defaultSnapshotRecoveryStressTail     = 100
+	defaultSnapshotRecoveryStressHosts    = 3
+	snapshotRecoveryStressBalance         = 10_000_000
+)
+
+type snapshotRecoveryStressFixture struct {
+	escrowID string
+	group    []types.SlotAssignment
+	hosts    []*signing.Secp256k1Signer
+	user     *signing.Secp256k1Signer
+	root     []byte
+}
+
+type snapshotRecoveryStressGetDiffsStore struct {
+	storage.Storage
+	mu    sync.Mutex
+	calls []snapshotRecoveryStressGetDiffsCall
+}
+
+type snapshotRecoveryStressGetDiffsCall struct {
+	escrowID string
+	from     uint64
+	to       uint64
+	records  int
+}
+
+func (s *snapshotRecoveryStressGetDiffsStore) GetDiffs(escrowID string, from, to uint64) ([]types.DiffRecord, error) {
+	recs, err := s.Storage.GetDiffs(escrowID, from, to)
+	s.mu.Lock()
+	s.calls = append(s.calls, snapshotRecoveryStressGetDiffsCall{
+		escrowID: escrowID,
+		from:     from,
+		to:       to,
+		records:  len(recs),
+	})
+	s.mu.Unlock()
+	return recs, err
+}
+
+func (s *snapshotRecoveryStressGetDiffsStore) snapshot() []snapshotRecoveryStressGetDiffsCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]snapshotRecoveryStressGetDiffsCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+// TestStressSnapshotRecoveryBudget verifies that snapshot-backed recovery keeps
+// the replay budget bounded across many active sessions. The current recovery
+// path still performs one full-journal read per session to rebuild validation
+// observability, so this test budgets for that known cost while preventing a
+// second full replay caused by snapshots being ignored.
+func TestStressSnapshotRecoveryBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping snapshot recovery stress test in short mode")
+	}
+
+	numSessions := stressEnvInt(t, "DEVSHARD_SNAPSHOT_RECOVERY_STRESS_SESSIONS", defaultSnapshotRecoveryStressSessions)
+	numHosts := stressEnvInt(t, "DEVSHARD_SNAPSHOT_RECOVERY_STRESS_HOSTS", defaultSnapshotRecoveryStressHosts)
+	tail := stressEnvInt(t, "DEVSHARD_SNAPSHOT_RECOVERY_STRESS_TAIL", defaultSnapshotRecoveryStressTail)
+	require.Positive(t, numSessions)
+	require.Positive(t, numHosts)
+	require.Positive(t, tail)
+
+	snapshotNonce := uint64(snapshotInterval)
+	latestNonce := snapshotNonce + uint64(tail)
+	store := newTestStore(t)
+
+	populateStartedAt := time.Now()
+	fixtures := make([]snapshotRecoveryStressFixture, 0, numSessions)
+	for i := 0; i < numSessions; i++ {
+		escrowID := fmt.Sprintf("snapshot-recovery-stress-%04d", i)
+		fixtures = append(fixtures, buildSnapshotRecoveryStressSession(
+			t, store, escrowID, numHosts, snapshotNonce, latestNonce,
+		))
+	}
+	t.Logf("populated %d sessions at latest_nonce=%d with snapshots at nonce=%d in %s",
+		numSessions, latestNonce, snapshotNonce, time.Since(populateStartedAt))
+
+	spy := &snapshotRecoveryStressGetDiffsStore{Storage: store}
+	recoverStartedAt := time.Now()
+	verifier := signing.NewSecp256k1Verifier()
+	for _, fixture := range fixtures {
+		clients := buildSnapshotRecoveryStressClients(t, fixture.escrowID, fixture.group, fixture.hosts, fixture.user, latestNonce)
+		recovered, recoveredSM, err := RecoverSession(spy, fixture.user, verifier, fixture.escrowID, testutil.RuntimeTestVersion, fixture.group, clients)
+		require.NoError(t, err, "recover %s", fixture.escrowID)
+		require.Equal(t, latestNonce, recovered.Nonce(), "recover nonce %s", fixture.escrowID)
+
+		root, err := recoveredSM.ComputeStateRoot()
+		require.NoError(t, err)
+		require.Equal(t, fixture.root, root, "state root %s", fixture.escrowID)
+	}
+	recoverDuration := time.Since(recoverStartedAt)
+
+	calls := spy.snapshot()
+	totalCalls, totalRecords := snapshotRecoveryStressTotals(calls)
+	tailCalls, tailRecords := snapshotRecoveryStressRangeTotals(calls, snapshotNonce+1, latestNonce)
+	backfillCalls, backfillRecords := snapshotRecoveryStressBackfillTotals(calls, snapshotNonce)
+	fullCalls, fullRecords := snapshotRecoveryStressRangeTotals(calls, 1, latestNonce)
+
+	expectedTailRecords := numSessions * tail
+	maxExpectedBackfillRecords := numSessions * numHosts
+	currentKnownFullReadBudget := numSessions * int(latestNonce)
+	maxExpectedRecords := currentKnownFullReadBudget + expectedTailRecords + maxExpectedBackfillRecords
+
+	t.Logf("recovered %d sessions in %s", numSessions, recoverDuration)
+	t.Logf("GetDiffs budget: calls=%d records=%d tail_calls=%d tail_records=%d backfill_calls=%d backfill_records=%d full_calls=%d full_records=%d max_expected_records=%d",
+		totalCalls, totalRecords, tailCalls, tailRecords, backfillCalls, backfillRecords, fullCalls, fullRecords, maxExpectedRecords)
+
+	require.Equal(t, numSessions, tailCalls, "snapshot recovery should replay exactly one post-snapshot tail per session")
+	require.Equal(t, expectedTailRecords, tailRecords, "snapshot recovery replayed an unexpected number of post-snapshot records")
+	require.LessOrEqual(t, backfillRecords, maxExpectedBackfillRecords, "snapshot backfill should stay bounded by host cursor lag")
+	require.LessOrEqual(t, fullCalls, numSessions, "snapshot recovery performed more than the known validation-observability full read per session")
+	require.LessOrEqual(t, totalRecords, maxExpectedRecords, "total GetDiffs budget suggests snapshots were ignored")
+}
+
+func buildSnapshotRecoveryStressSession(
+	t *testing.T,
+	store storage.Storage,
+	escrowID string,
+	numHosts int,
+	snapshotNonce uint64,
+	latestNonce uint64,
+) snapshotRecoveryStressFixture {
+	t.Helper()
+
+	hostSigners := make([]*signing.Secp256k1Signer, numHosts)
+	for i := range hostSigners {
+		hostSigners[i] = testutil.MustGenerateKey(t)
+	}
+	userKey := testutil.MustGenerateKey(t)
+	group := testutil.MakeGroup(hostSigners)
+	config := snapshotRecoveryStressConfig(numHosts, latestNonce)
+	verifier := signing.NewSecp256k1Verifier()
+
+	require.NoError(t, store.CreateSession(storage.CreateSessionParams{
+		EscrowID:       escrowID,
+		Version:        testutil.RuntimeTestVersion,
+		CreatorAddr:    userKey.Address(),
+		Config:         config,
+		Group:          group,
+		InitialBalance: snapshotRecoveryStressBalance,
+	}))
+
+	clients := buildSnapshotRecoveryStressClients(t, escrowID, group, hostSigners, userKey, latestNonce)
+	userStore := testutil.MustMemoryStore(t, escrowID, userKey.Address(), config, group, snapshotRecoveryStressBalance)
+	userSM, err := state.NewStateMachine(escrowID, config, group, snapshotRecoveryStressBalance, userKey.Address(), verifier, userStore)
+	require.NoError(t, err)
+	session, err := NewSession(userSM, userKey, escrowID, group, clients, verifier, WithStorage(store))
+	require.NoError(t, err)
+
+	params := InferenceParams{
+		Model:       "llama",
+		Prompt:      testutil.TestPrompt,
+		InputLength: 100,
+		MaxTokens:   50,
+		StartedAt:   1000,
+	}
+	ctx := context.Background()
+	for session.Nonce() < snapshotNonce {
+		_, err := session.SendInference(ctx, params)
+		require.NoError(t, err, "advance %s to snapshot nonce", escrowID)
+	}
+	require.Equal(t, snapshotNonce, session.Nonce())
+	require.NoError(t, session.FlushSnapshot())
+	snapNonce, _, err := store.LoadSnapshot(escrowID)
+	require.NoError(t, err)
+	require.Equal(t, snapshotNonce, snapNonce, "snapshot nonce %s", escrowID)
+
+	for session.Nonce() < latestNonce {
+		_, err := session.SendInference(ctx, params)
+		require.NoError(t, err, "advance %s after snapshot", escrowID)
+	}
+
+	root, err := userSM.ComputeStateRoot()
+	require.NoError(t, err)
+
+	return snapshotRecoveryStressFixture{
+		escrowID: escrowID,
+		group:    group,
+		hosts:    hostSigners,
+		user:     userKey,
+		root:     root,
+	}
+}
+
+func buildSnapshotRecoveryStressClients(
+	t *testing.T,
+	escrowID string,
+	group []types.SlotAssignment,
+	hostSigners []*signing.Secp256k1Signer,
+	userKey *signing.Secp256k1Signer,
+	latestNonce uint64,
+) []HostClient {
+	t.Helper()
+
+	config := snapshotRecoveryStressConfig(len(hostSigners), latestNonce)
+	verifier := signing.NewSecp256k1Verifier()
+	clients := make([]HostClient, len(hostSigners))
+	for i := range hostSigners {
+		hostStore := testutil.MustMemoryStore(t, escrowID, userKey.Address(), config, group, snapshotRecoveryStressBalance)
+		sm, err := state.NewStateMachine(escrowID, config, group, snapshotRecoveryStressBalance, userKey.Address(), verifier, hostStore)
+		require.NoError(t, err)
+		h, err := host.NewHost(sm, hostSigners[i], stub.NewInferenceEngine(), escrowID, group, nil, host.WithGrace(latestNonce+100))
+		require.NoError(t, err)
+		clients[i] = &InProcessClient{Host: h}
+	}
+	return clients
+}
+
+func snapshotRecoveryStressTotals(calls []snapshotRecoveryStressGetDiffsCall) (callCount int, recordCount int) {
+	for _, call := range calls {
+		callCount++
+		recordCount += call.records
+	}
+	return callCount, recordCount
+}
+
+func snapshotRecoveryStressRangeTotals(calls []snapshotRecoveryStressGetDiffsCall, from, to uint64) (callCount int, recordCount int) {
+	for _, call := range calls {
+		if call.from == from && call.to == to {
+			callCount++
+			recordCount += call.records
+		}
+	}
+	return callCount, recordCount
+}
+
+func snapshotRecoveryStressBackfillTotals(calls []snapshotRecoveryStressGetDiffsCall, snapshotNonce uint64) (callCount int, recordCount int) {
+	for _, call := range calls {
+		if call.to == snapshotNonce && call.from > 1 {
+			callCount++
+			recordCount += call.records
+		}
+	}
+	return callCount, recordCount
+}
+
+func snapshotRecoveryStressConfig(numHosts int, latestNonce uint64) types.SessionConfig {
+	cfg := testutil.DefaultConfig(numHosts)
+	cfg.AutoSealEveryNNonces = uint32(latestNonce + 1)
+	return cfg
+}
+
+func stressEnvInt(t *testing.T, name string, fallback int) int {
+	t.Helper()
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	require.NoError(t, err, "parse %s", name)
+	return value
+}


### PR DESCRIPTION
## Summary

Adds release-validation coverage for v4 snapshot recovery:

- verifies prod-like `versiond` restart restores sessions from snapshots
- verifies corrupt persisted snapshots fall back to full replay and repair the snapshot
- adds a targeted stress test that guards the `GetDiffs` recovery budget across many sessions
- adds a `make snapshot-recovery-stress-test` target for manual release checks

### Harness config changes

- Extends `MultiConfigOpts` with `MaxNonce` and `EscrowAmount`.
- `MaxNonce` is written into top-level `params.max_nonce`.
- `EscrowAmount` is written into the seeded escrow config as `escrows[].amount`.
- This lets recovery citests create longer-lived prod-like sessions without relying on default limits.
- The snapshot recovery tests use this to safely advance sessions past the snapshot boundary and still have enough escrow balance/nonces for post-restart validation.
- Adds unit coverage in `TestWriteMultiConfig_CustomNonceAndAmount` to verify both fields are emitted and loaded correctly.

## Test Steps

### Positive e2e: snapshot restore after restart

- Start a prod-like testenv stack with 2 `versiond` hosts.
- Drive a gateway session to the snapshot boundary.
- Verify the snapshot exists in Postgres.
- Restart all `versiond` instances.
- Demand-load the session directly from each host.
- Assert logs show snapshot restore and no snapshot errors.
- Continue gateway chat and verify nonce advances.

### Negative e2e: corrupt snapshot fallback

- Start the same prod-like stack.
- Drive a gateway session to the snapshot boundary.
- Corrupt `devshard_snapshots.state_data` in Postgres.
- Restart one `versiond` host.
- Demand-load the session from that host.
- Assert logs show corrupt snapshot fallback to full replay.
- Assert the snapshot is repaired in Postgres.
- Continue gateway chat and verify nonce advances.

### Stress: snapshot recovery budget

- Create many active sessions in-process.
- Advance each session to snapshot nonce `500`.
- Flush a valid snapshot.
- Advance each session by a post-snapshot tail.
- Recover all sessions through `RecoverSession`.
- Count every `GetDiffs` range via spy storage.
- Assert recovery reads only bounded post-snapshot tail/backfill, plus the current known validation-observability full read.

## Validation

- Positive e2e: passed, ~75s
- Negative e2e: passed, ~73s
- Stress `100 sessions / tail 100`: passed, ~87-89s
- Stress `200 sessions / tail 100`: passed, ~177s

Commands:

```bash
TESTENV_CITEST=1 TESTENV_CITEST_ARTIFACT_DIR=/tmp/devshard-citest-artifacts go test -tags=testenvci ./testenv/citest -run '^TestVersiondSnapshotRecoveryUsesSnapshotAfterRestart$' -count=1 -v -timeout 30m

TESTENV_CITEST=1 go test -tags=testenvci ./testenv/citest -run '^TestVersiondSnapshotRecoveryCorruptSnapshotFallsBack$' -count=1 -v -timeout 30m

make -C devshard snapshot-recovery-stress-test