### PR TITLE
fix(deploy): use fp8 KV cache for Kimi

### DIFF
--- a/deploy/join/node-config-kimik26-B200.json
+++ b/deploy/join/node-config-kimik26-B200.json
@@ -17,6 +17,7 @@
           "--reasoning-parser", "kimi_k2",
           "--attention-backend", "FLASHINFER_MLA",
           "--attention-config", "{\"mla_prefill_backend\":\"TRTLLM_RAGGED\"}",
+          "--kv-cache-dtype", "fp8",
           "--disable-custom-all-reduce",
           "--gpu-memory-utilization", "0.95",
           "--max-num-seqs", "128",

--- a/deploy/join/node-config-kimik26-H200.json
+++ b/deploy/join/node-config-kimik26-H200.json
@@ -16,6 +16,7 @@
           "--tool-call-parser", "kimi_k2",
           "--reasoning-parser", "kimi_k2",
           "--attention-backend", "FLASHMLA",
+          "--kv-cache-dtype", "fp8",
           "--gpu-memory-utilization", "0.90",
           "--max-model-len", "240000"
         ]


### PR DESCRIPTION
PoC self-validation on Kimi: 8.3% mismatch on bf16 KV vs 1.3% on fp8, measured on 8xH200 over 1024 nonces. DeepSeek already ships fp8; Kimi was the only model left on the model default.