### PR TITLE
fix: wrap chain query errors with ClassifyQueryError for HTTP 503

### DIFF
--- a/devshard/bridge/grpc.go
+++ b/devshard/bridge/grpc.go
@@ -68,7 +68,7 @@ func (b *GRPCBridge) GetEscrow(escrowID string) (*EscrowInfo, error) {
 	resp, err := b.client.InferenceQueryClient().DevshardEscrow(context.Background(),
 		&inferencetypes.QueryGetDevshardEscrowRequest{Id: id})
 	if err != nil {
-		return nil, fmt.Errorf("DevshardEscrow %s: %w", escrowID, err)
+		return nil, ClassifyQueryError(fmt.Errorf("DevshardEscrow %s: %w", escrowID, err))
 	}
 	if resp == nil || !resp.Found || resp.Escrow == nil {
 		return nil, ErrEscrowNotFound
@@ -112,7 +112,7 @@ func (b *GRPCBridge) GetHostInfo(address string) (*HostInfo, error) {
 	resp, err := b.client.InferenceQueryClient().Participant(context.Background(),
 		&inferencetypes.QueryGetParticipantRequest{Index: address})
 	if err != nil {
-		return nil, fmt.Errorf("Participant %s: %w", address, err)
+		return nil, ClassifyQueryError(fmt.Errorf("Participant %s: %w", address, err))
 	}
 	if resp == nil || resp.Participant.Address == "" {
 		return nil, ErrParticipantNotFound

--- a/devshard/bridge/grpc_test.go
+++ b/devshard/bridge/grpc_test.go
@@ -89,6 +89,14 @@ func TestGRPCBridge_GetEscrow_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, bridge.ErrEscrowNotFound)
 }
 
+func TestGRPCBridge_GetEscrow_TransientQueryError(t *testing.T) {
+	st := seed.Defaults()
+	st.SetEscrowQueryFault(true)
+
+	_, err := startGRPCBridgeWithStore(t, st).GetEscrow("1")
+	require.ErrorIs(t, err, bridge.ErrChainUnavailable)
+}
+
 func TestGRPCBridge_GetHostInfo(t *testing.T) {
 	b := startGRPCBridge(t)
 	host := "gonka1host000000000000000000000000000000000"

--- a/devshard/cmd/devshardd/bridge/chain.go
+++ b/devshard/cmd/devshardd/bridge/chain.go
@@ -102,7 +102,7 @@ func (b *ChainBridge) GetEscrow(escrowID string) (*bridge.EscrowInfo, error) {
 	resp, err := b.client.InferenceQueryClient().DevshardEscrow(context.Background(),
 		&inferencetypes.QueryGetDevshardEscrowRequest{Id: id})
 	if err != nil {
-		return nil, fmt.Errorf("DevshardEscrow %s: %w", escrowID, err)
+		return nil, bridge.ClassifyQueryError(fmt.Errorf("DevshardEscrow %s: %w", escrowID, err))
 	}
 	if resp == nil || !resp.Found || resp.Escrow == nil {
 		return nil, bridge.ErrEscrowNotFound
@@ -141,7 +141,7 @@ func (b *ChainBridge) GetHostInfo(address string) (*bridge.HostInfo, error) {
 	resp, err := b.client.InferenceQueryClient().Participant(context.Background(),
 		&inferencetypes.QueryGetParticipantRequest{Index: address})
 	if err != nil {
-		return nil, fmt.Errorf("Participant %s: %w", address, err)
+		return nil, bridge.ClassifyQueryError(fmt.Errorf("Participant %s: %w", address, err))
 	}
 
 	return &bridge.HostInfo{

--- a/devshard/cmd/devshardd/bridge/chain_test.go
+++ b/devshard/cmd/devshardd/bridge/chain_test.go
@@ -12,6 +12,9 @@ import (
 	"common/chain"
 	shardbridge "devshard/bridge"
 	"devshard/cmd/devshardd/bridge"
+	"devshard/testenv/mockchain/grpcface"
+	"devshard/testenv/mockchain/seed"
+	"devshard/testenv/mockchain/store"
 )
 
 func newTestBridge(t *testing.T, submitter bridge.Submitter) *bridge.ChainBridge {
@@ -23,6 +26,29 @@ func newTestBridge(t *testing.T, submitter bridge.Submitter) *bridge.ChainBridge
 	client := chain.NewFromConn(conn)
 
 	return bridge.NewChainBridge(client, submitter)
+}
+
+func newTestBridgeWithStore(t *testing.T, st *store.Store, submitter bridge.Submitter) *bridge.ChainBridge {
+	t.Helper()
+	srv, lis, err := grpcface.NewInProcessServer(grpcface.Deps{Store: st})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return bridge.NewChainBridge(chain.NewFromConn(conn), submitter)
+}
+
+func TestBridge_GetEscrow_TransientQueryError(t *testing.T) {
+	st := seed.Defaults()
+	st.SetEscrowQueryFault(true)
+
+	_, err := newTestBridgeWithStore(t, st, nil).GetEscrow("1")
+	require.ErrorIs(t, err, shardbridge.ErrChainUnavailable)
 }
 
 func TestBridge_NotificationsNoop(t *testing.T) {

--- a/devshard/testenv/mockchain/grpcface/inference.go
+++ b/devshard/testenv/mockchain/grpcface/inference.go
@@ -59,6 +59,9 @@ func (s *InferenceServer) AccountByAddress(_ context.Context, req *inferencetype
 }
 
 func (s *InferenceServer) Participant(_ context.Context, req *inferencetypes.QueryGetParticipantRequest) (*inferencetypes.QueryGetParticipantResponse, error) {
+	if s.store.ParticipantQueryFaulted() {
+		return nil, status.Error(codes.Unavailable, "participant query faulted (testenv)")
+	}
 	p := s.store.GetParticipant(req.GetIndex())
 	if p == nil {
 		return &inferencetypes.QueryGetParticipantResponse{}, nil

--- a/devshard/testenv/mockchain/store/store.go
+++ b/devshard/testenv/mockchain/store/store.go
@@ -29,8 +29,8 @@ type Store struct {
 	ParamsBlockHeight int64
 	// NextPocStartBlockHeight is the upcoming epoch PoC anchor (EpochContext.NextPoCStart).
 	NextPocStartBlockHeight int64
-	Params                 inferencetypes.Params
-	Epoch             inferencetypes.Epoch
+	Params                  inferencetypes.Params
+	Epoch                   inferencetypes.Epoch
 
 	Participants   map[string]*inferencetypes.Participant
 	Escrows        map[uint64]*inferencetypes.DevshardEscrow
@@ -46,7 +46,8 @@ type Store struct {
 	// escrowQueryFault, when true, makes DevshardEscrow gRPC queries fail. It
 	// lets citest simulate an unavailable request-time escrow fetch path so the
 	// devshardd escrow long-poll warm cache is exercised.
-	escrowQueryFault bool
+	escrowQueryFault      bool
+	participantQueryFault bool
 }
 
 // Account holds Cosmos auth sequence state for LCD tx signing (Phase 3c).
@@ -280,6 +281,20 @@ func (s *Store) EscrowQueryFaulted() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.escrowQueryFault
+}
+
+// ParticipantQueryFaulted reports whether Participant queries should fail.
+func (s *Store) ParticipantQueryFaulted() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.participantQueryFault
+}
+
+// SetParticipantQueryFault toggles Participant query failures (test injection).
+func (s *Store) SetParticipantQueryFault(faulted bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.participantQueryFault = faulted
 }
 
 // AdvanceBlock increments the latest block height and returns the new value.


### PR DESCRIPTION
## Summary

Fixes #1696

This PR wraps `ClassifyQueryError` around chain query errors to ensure transient failures (e.g., RPC timeouts, temporary network issues) return HTTP 503 (Service Unavailable, retryable) instead of HTTP 500 (Internal Server Error, non-retryable).

## Changes

Wrapped `ClassifyQueryError` in the following locations:

### devshard/bridge/grpc.go
- `GetEscrow` method
- `GetHostInfo` method

### devshard/cmd/devshardd/bridge/chain.go
- `GetEscrow` method
- `GetHostInfo` method

## Impact

Clients will now receive proper HTTP 503 status codes for transient chain query failures, allowing them to retry requests appropriately.