### PR TITLE
fix(devshard): reject incomplete stream cache entries

### DIFF
--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -1554,14 +1554,7 @@ func (g *Gateway) handlePooledChat(w http.ResponseWriter, r *http.Request) {
 	if capture := g.serveChatToRuntime(rt, "/v1/chat/completions", body, w, r); capture != nil {
 		sourceRequestID, _ := requestLogFromContext(ctx)
 		entry, reason := capture.cacheEntry(rt.id, stream, sourceRequestID, r.Context().Err())
-		if reason == "" {
-			g.chatCache.Set(cacheKey, entry, time.Now())
-			g.metrics.RecordChatCache(requestModel, "stored")
-			logRequestStage(ctx, "gateway_cache_stored", "escrow", rt.id, "model", requestModel, "stream", stream, "bytes", len(entry.Body))
-		} else {
-			g.metrics.RecordChatCache(requestModel, "skipped_"+reason)
-			logRequestStage(ctx, "gateway_cache_skipped", "escrow", rt.id, "model", requestModel, "stream", stream, "reason", reason)
-		}
+		g.storeChatCache(ctx, "gateway_cache", cacheKey, rt.id, requestModel, stream, entry, reason)
 	}
 }
 
@@ -1692,14 +1685,7 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 		if capture := g.serveChatToRuntime(rt, innerPath, body, w, r); capture != nil {
 			sourceRequestID, _ := requestLogFromContext(ctx)
 			entry, reason := capture.cacheEntry(rt.id, stream, sourceRequestID, r.Context().Err())
-			if reason == "" {
-				g.chatCache.Set(cacheKey, entry, time.Now())
-				g.metrics.RecordChatCache(limitModel, "stored")
-				logRequestStage(ctx, "gateway_devshard_cache_stored", "escrow", rt.id, "model", limitModel, "stream", stream, "bytes", len(entry.Body))
-			} else {
-				g.metrics.RecordChatCache(limitModel, "skipped_"+reason)
-				logRequestStage(ctx, "gateway_devshard_cache_skipped", "escrow", rt.id, "model", limitModel, "stream", stream, "reason", reason)
-			}
+			g.storeChatCache(ctx, "gateway_devshard_cache", cacheKey, rt.id, limitModel, stream, entry, reason)
 		}
 		return
 	}
@@ -1861,6 +1847,19 @@ func (g *Gateway) serveChatToRuntime(rt *devshardRuntime, path string, body []by
 	capture := &gatewayChatCacheCapture{ResponseWriter: w}
 	rt.handler.ServeHTTP(capture, req)
 	return capture
+}
+
+func (g *Gateway) storeChatCache(ctx context.Context, stage, cacheKey, escrow, model string, stream bool, entry cachedChatResponse, reason string) {
+	if reason == "" && !g.chatCache.Set(cacheKey, entry, time.Now()) {
+		reason = "too_large"
+	}
+	if reason != "" {
+		g.metrics.RecordChatCache(model, "skipped_"+reason)
+		logRequestStage(ctx, stage+"_skipped", "escrow", escrow, "model", model, "stream", stream, "reason", reason)
+		return
+	}
+	g.metrics.RecordChatCache(model, "stored")
+	logRequestStage(ctx, stage+"_stored", "escrow", escrow, "model", model, "stream", stream, "bytes", len(entry.Body))
 }
 
 func (g *Gateway) recordGatewayRequestOutcome(model, outcome, reason string) {

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -1516,6 +1516,7 @@ func (g *Gateway) handlePooledChat(w http.ResponseWriter, r *http.Request) {
 	cacheKey := chatCacheKey(requestModel, body, clientIntent)
 	stream := chatRequestStream(body)
 	if entry, ok := g.chatCache.Get(cacheKey, time.Now()); ok {
+		g.metrics.RecordChatCache(requestModel, "hit")
 		logRequestStage(ctx, "gateway_cache_hit", "escrow", entry.EscrowID, "model", requestModel, "stream", stream)
 		g.recordCachedAccountingAlias(ctx, entry)
 		serveCachedChatResponse(w, r, entry)
@@ -1552,9 +1553,14 @@ func (g *Gateway) handlePooledChat(w http.ResponseWriter, r *http.Request) {
 
 	if capture := g.serveChatToRuntime(rt, "/v1/chat/completions", body, w, r); capture != nil {
 		sourceRequestID, _ := requestLogFromContext(ctx)
-		if entry, ok := capture.cacheEntry(rt.id, stream, sourceRequestID, r.Context().Err()); ok {
+		entry, reason := capture.cacheEntry(rt.id, stream, sourceRequestID, r.Context().Err())
+		if reason == "" {
 			g.chatCache.Set(cacheKey, entry, time.Now())
+			g.metrics.RecordChatCache(requestModel, "stored")
 			logRequestStage(ctx, "gateway_cache_stored", "escrow", rt.id, "model", requestModel, "stream", stream, "bytes", len(entry.Body))
+		} else {
+			g.metrics.RecordChatCache(requestModel, "skipped_"+reason)
+			logRequestStage(ctx, "gateway_cache_skipped", "escrow", rt.id, "model", requestModel, "stream", stream, "reason", reason)
 		}
 	}
 }
@@ -1655,6 +1661,7 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 		cacheKey := chatCacheKey(limitModel, body, clientIntent)
 		stream := chatRequestStream(body)
 		if entry, ok := g.chatCache.Get(cacheKey, time.Now()); ok {
+			g.metrics.RecordChatCache(limitModel, "hit")
 			logRequestStage(ctx, "gateway_devshard_cache_hit", "escrow", entry.EscrowID, "model", limitModel, "stream", stream)
 			g.recordCachedAccountingAlias(ctx, entry)
 			g.recordGatewayRequestOutcome(limitModel, "cached", "cache_hit")
@@ -1684,9 +1691,14 @@ func (g *Gateway) handleDevshard(w http.ResponseWriter, r *http.Request) {
 
 		if capture := g.serveChatToRuntime(rt, innerPath, body, w, r); capture != nil {
 			sourceRequestID, _ := requestLogFromContext(ctx)
-			if entry, ok := capture.cacheEntry(rt.id, stream, sourceRequestID, r.Context().Err()); ok {
+			entry, reason := capture.cacheEntry(rt.id, stream, sourceRequestID, r.Context().Err())
+			if reason == "" {
 				g.chatCache.Set(cacheKey, entry, time.Now())
+				g.metrics.RecordChatCache(limitModel, "stored")
 				logRequestStage(ctx, "gateway_devshard_cache_stored", "escrow", rt.id, "model", limitModel, "stream", stream, "bytes", len(entry.Body))
+			} else {
+				g.metrics.RecordChatCache(limitModel, "skipped_"+reason)
+				logRequestStage(ctx, "gateway_devshard_cache_skipped", "escrow", rt.id, "model", limitModel, "stream", stream, "reason", reason)
 			}
 		}
 		return

--- a/devshard/cmd/devshardctl/gateway_mockenv_helpers_test.go
+++ b/devshard/cmd/devshardctl/gateway_mockenv_helpers_test.go
@@ -234,14 +234,14 @@ func mockenvChatBody(model, prompt string) string {
 func writeMockenvChatJSON(w http.ResponseWriter, id, model string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprintf(w, `{"id":"chatcmpl-%s","model":%q,"choices":[{"message":{"role":"assistant","content":"from %s"}}]}`, id, model, id)
+	_, _ = fmt.Fprintf(w, `{"id":"chatcmpl-%s","model":%q,"choices":[{"index":0,"message":{"role":"assistant","content":"from %s"},"finish_reason":"stop"}]}`, id, model, id)
 }
 
 func writeMockenvChatSSE(w http.ResponseWriter, id, model string) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprintf(w, "data: {\"id\":\"chatcmpl-%s\",\"object\":\"chat.completion.chunk\",\"model\":%q,\"choices\":[{\"delta\":{\"content\":\"from %s\"},\"finish_reason\":null}]}\n\n", id, model, id)
+	_, _ = fmt.Fprintf(w, "data: {\"id\":\"chatcmpl-%s\",\"object\":\"chat.completion.chunk\",\"model\":%q,\"choices\":[{\"index\":0,\"delta\":{\"content\":\"from %s\"},\"finish_reason\":\"stop\"}]}\n\n", id, model, id)
 	_, _ = io.WriteString(w, "data: [DONE]\n\n")
 }
 

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -1470,7 +1470,7 @@ func TestGatewayPooledChatCachesStreamingResponseWithFreshRequestID(t *testing.T
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Cache-Control", "no-cache")
 			w.WriteHeader(http.StatusOK)
-			_, _ = fmt.Fprint(w, `data: {"id":"chatcmpl-original","object":"chat.completion.chunk","choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`+"\n\n")
+			_, _ = fmt.Fprint(w, `data: {"id":"chatcmpl-original","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":"stop"}]}`+"\n\n")
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -1417,7 +1417,7 @@ func TestGatewayPooledChatCachesNonStreamingResponseWithFreshRequestID(t *testin
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"chatcmpl-original","choices":[{"message":{"role":"assistant","content":"hello"}}]}`))
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-original","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`))
 		}),
 	}
 	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
@@ -1591,7 +1591,7 @@ func TestGatewayChatCacheSharedAcrossDifferentEscrowRoutes(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"chatcmpl-12","choices":[{"message":{"role":"assistant","content":"from escrow 12"}}]}`))
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-12","choices":[{"index":0,"message":{"role":"assistant","content":"from escrow 12"},"finish_reason":"stop"}]}`))
 		}),
 	}
 	rt44 := &devshardRuntime{
@@ -1601,7 +1601,7 @@ func TestGatewayChatCacheSharedAcrossDifferentEscrowRoutes(t *testing.T) {
 			calls44.Add(1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"chatcmpl-44","choices":[{"message":{"role":"assistant","content":"from escrow 44"}}]}`))
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-44","choices":[{"index":0,"message":{"role":"assistant","content":"from escrow 44"},"finish_reason":"stop"}]}`))
 		}),
 	}
 	g := NewGateway([]*devshardRuntime{rt12, rt44}, NewGatewayLimiter(0, 0), "Qwen/Test")

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -1503,6 +1503,8 @@ func TestGatewayPooledChatCachesStreamingResponseWithFreshRequestID(t *testing.T
 	require.NotEmpty(t, rec.Header().Get("X-Request-Id"))
 	require.NotEqual(t, firstRequestID, rec.Header().Get("X-Request-Id"))
 	require.EqualValues(t, 1, calls.Load())
+	requireChatCacheCount(t, g, "stored", 1)
+	requireChatCacheCount(t, g, "hit", 1)
 }
 
 func TestGatewayPooledChatDoesNotCacheTransientErrorResponse(t *testing.T) {
@@ -1578,6 +1580,7 @@ func TestGatewayPooledChatDoesNotCacheIncompleteResponse(t *testing.T) {
 				require.Equal(t, http.StatusOK, rec.Code)
 			}
 			require.EqualValues(t, 2, calls.Load(), "incomplete responses must not be served from cache")
+			requireChatCacheCount(t, g, "skipped_incomplete", 2)
 		})
 	}
 }
@@ -3344,6 +3347,25 @@ func requireMetricGaugeValue(t *testing.T, families []*dto.MetricFamily, name st
 		}
 	}
 	t.Fatalf("metric %s with labels %v not found", name, labels)
+}
+
+func requireChatCacheCount(t *testing.T, g *Gateway, result string, want float64) {
+	t.Helper()
+	families, err := g.metrics.registry.Gather()
+	require.NoError(t, err)
+	labels := map[string]string{"model": "Qwen/Test", "result": result}
+	for _, family := range families {
+		if family.GetName() != "devshard_gateway_chat_cache_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metricLabelsMatch(metric, labels) {
+				require.Equal(t, want, metric.Counter.GetValue())
+				return
+			}
+		}
+	}
+	t.Fatalf("chat cache metric %s not found", result)
 }
 
 func metricLabelsMatch(metric *dto.Metric, want map[string]string) bool {

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -1537,9 +1537,6 @@ func TestGatewayPooledChatDoesNotCacheTransientErrorResponse(t *testing.T) {
 	require.EqualValues(t, 2, calls.Load(), "transient error responses must not be served from cache")
 }
 
-// A stream that ends with `[DONE]` but no terminal choice reason is the
-// production shape of a hard-timeout truncation: it must reach the runtime
-// again on retry instead of replaying the truncated body for the cache TTL.
 func TestGatewayPooledChatDoesNotCacheIncompleteResponse(t *testing.T) {
 	tests := map[string]struct {
 		body        string

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -1537,6 +1537,7 @@ func TestGatewayPooledChatDoesNotCacheTransientErrorResponse(t *testing.T) {
 	require.Equal(t, http.StatusBadGateway, rec.Code)
 	require.Equal(t, "12", rec.Header().Get("X-Devshard-ID"))
 	require.EqualValues(t, 2, calls.Load(), "transient error responses must not be served from cache")
+	requireChatCacheCount(t, g, "skipped_status", 2)
 }
 
 func TestGatewayPooledChatDoesNotCacheIncompleteResponse(t *testing.T) {

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -1537,6 +1537,54 @@ func TestGatewayPooledChatDoesNotCacheTransientErrorResponse(t *testing.T) {
 	require.EqualValues(t, 2, calls.Load(), "transient error responses must not be served from cache")
 }
 
+// A stream that ends with `[DONE]` but no terminal choice reason is the
+// production shape of a hard-timeout truncation: it must reach the runtime
+// again on retry instead of replaying the truncated body for the cache TTL.
+func TestGatewayPooledChatDoesNotCacheIncompleteResponse(t *testing.T) {
+	tests := map[string]struct {
+		body        string
+		contentType string
+		response    string
+	}{
+		"streaming": {
+			body:        `{"model":"Qwen/Test","stream":true,"messages":[{"role":"user","content":"hello"}]}`,
+			contentType: "text/event-stream",
+			response: `data: {"id":"chatcmpl-partial","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n" +
+				"data: [DONE]\n\n",
+		},
+		"non-streaming": {
+			body:        `{"model":"Qwen/Test","messages":[{"role":"user","content":"hello"}]}`,
+			contentType: "application/json",
+			response:    `{"id":"chatcmpl-partial","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"partial"},"finish_reason":null}]}`,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var calls atomic.Int32
+			rt := &devshardRuntime{
+				id:    "12",
+				model: "Qwen/Test",
+				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					calls.Add(1)
+					w.Header().Set("Content-Type", tt.contentType)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(tt.response))
+				}),
+			}
+			g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+			g.settings.ModelLimits = []GatewayModelLimitSettings{{ModelID: "Qwen/Test", AccessMode: string(gatewayAccessModeOpen)}}
+
+			for range 2 {
+				req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(tt.body))
+				rec := httptest.NewRecorder()
+				g.handlePooledChat(rec, req)
+				require.Equal(t, http.StatusOK, rec.Code)
+			}
+			require.EqualValues(t, 2, calls.Load(), "incomplete responses must not be served from cache")
+		})
+	}
+}
+
 func TestGatewayPooledChatCachesOpenAIStyleBadRequestWithFreshRequestID(t *testing.T) {
 	var calls atomic.Int32
 	rt := &devshardRuntime{

--- a/devshard/cmd/devshardctl/gateway_test.go
+++ b/devshard/cmd/devshardctl/gateway_test.go
@@ -1586,6 +1586,32 @@ func TestGatewayPooledChatDoesNotCacheIncompleteResponse(t *testing.T) {
 	}
 }
 
+func TestGatewayPooledChatReportsOversizedResponseAsSkipped(t *testing.T) {
+	var calls atomic.Int32
+	rt := &devshardRuntime{
+		id:    "12",
+		model: "Qwen/Test",
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"index":0,"message":{"content":"` + strings.Repeat("x", 4096) + `"},"finish_reason":"stop"}]}`))
+		}),
+	}
+	g := NewGateway([]*devshardRuntime{rt}, NewGatewayLimiter(0, 0), "Qwen/Test")
+	g.chatCache = newChatResponseCache(0, 1024)
+	g.settings.ModelLimits = []GatewayModelLimitSettings{{ModelID: "Qwen/Test", AccessMode: string(gatewayAccessModeOpen)}}
+	body := `{"model":"Qwen/Test","messages":[{"role":"user","content":"hello"}]}`
+
+	for range 2 {
+		rec := httptest.NewRecorder()
+		g.handlePooledChat(rec, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body)))
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+	require.EqualValues(t, 2, calls.Load())
+	requireChatCacheCount(t, g, "skipped_too_large", 2)
+}
+
 func TestGatewayPooledChatCachesOpenAIStyleBadRequestWithFreshRequestID(t *testing.T) {
 	var calls atomic.Int32
 	rt := &devshardRuntime{

--- a/devshard/cmd/devshardctl/metrics.go
+++ b/devshard/cmd/devshardctl/metrics.go
@@ -57,6 +57,7 @@ type DevshardMetrics struct {
 	timeoutActions         *prometheus.CounterVec
 	errorMissRejects       *prometheus.CounterVec
 	errorMissVerifyRejects *prometheus.CounterVec
+	chatCache              *prometheus.CounterVec
 
 	// Host ping observability (common/probe sink). Fleet warm RTT histogram
 	// cannot share the gauge name, so it uses _warm_rtt_seconds.
@@ -364,6 +365,13 @@ func NewDevshardMetrics() *DevshardMetrics {
 			},
 			[]string{"cause", "completeness"},
 		),
+		chatCache: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "devshard_gateway_chat_cache_total",
+				Help: "Total chat response cache outcomes by model: hit, stored, or skipped_<reason> (incomplete, no_choices, transient_error, status, request_error, write_error, empty_body).",
+			},
+			[]string{"model", "result"},
+		),
 		hostPingUp: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "devshard_gateway_host_ping_up",
@@ -467,6 +475,7 @@ func NewDevshardMetrics() *DevshardMetrics {
 		m.timeoutActions,
 		m.errorMissRejects,
 		m.errorMissVerifyRejects,
+		m.chatCache,
 		m.hostPingUp,
 		m.hostPingRTT,
 		m.hostPingWarmRTT,
@@ -534,6 +543,13 @@ func (m *DevshardMetrics) RecordLimitRejection(reason string) {
 		return
 	}
 	m.gatewayLimitRejections.WithLabelValues(reason).Inc()
+}
+
+func (m *DevshardMetrics) RecordChatCache(model, result string) {
+	if m == nil {
+		return
+	}
+	m.chatCache.WithLabelValues(normalizeModelID(model), result).Inc()
 }
 
 func (m *DevshardMetrics) RecordParticipantLimitRejection(participantKey, model, scope string) {

--- a/devshard/cmd/devshardctl/metrics.go
+++ b/devshard/cmd/devshardctl/metrics.go
@@ -368,7 +368,7 @@ func NewDevshardMetrics() *DevshardMetrics {
 		chatCache: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "devshard_gateway_chat_cache_total",
-				Help: "Total chat response cache outcomes by model: hit, stored, or skipped_<reason> (incomplete, no_choices, transient_error, status, request_error, write_error, empty_body).",
+				Help: "Total chat response cache outcomes by model: hit, stored, or skipped_<reason>.",
 			},
 			[]string{"model", "result"},
 		),

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -290,6 +290,10 @@ func cacheableResponse(statusCode int, body []byte) bool {
 	return false
 }
 
+// cacheableChatResponse adds semantic completion on top of cacheableResponse:
+// a 2xx chat body is replayable only when every observed choice ended with a
+// terminal reason, whether the client asked for a stream or received the
+// aggregated non-streaming shape.
 func cacheableChatResponse(statusCode int, body []byte, stream bool) bool {
 	if !cacheableResponse(statusCode, body) {
 		return false
@@ -297,12 +301,21 @@ func cacheableChatResponse(statusCode int, body []byte, stream bool) bool {
 	if statusCode == 0 {
 		statusCode = http.StatusOK
 	}
-	return !stream || statusCode < 200 || statusCode >= 300 || completeStreamingChatResponse(body)
+	if statusCode < 200 || statusCode >= 300 {
+		return true
+	}
+	if stream {
+		return completeStreamingChatResponse(body)
+	}
+	return completeChatChoices(bytes.TrimSpace(body))
 }
 
+// completeStreamingChatResponse requires `[DONE]` after every observed choice
+// carried a terminal reason. A `[DONE]` written before that (or with no choice
+// events at all) is framing, not completion.
 func completeStreamingChatResponse(body []byte) bool {
-	seen := make(map[int]struct{})
-	finished := make(map[int]struct{})
+	seen := make(map[string]struct{})
+	finished := make(map[string]struct{})
 	for _, line := range bytes.Split(body, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if !bytes.HasPrefix(line, []byte("data:")) {
@@ -310,36 +323,56 @@ func completeStreamingChatResponse(body []byte) bool {
 		}
 		payload := bytes.TrimSpace(line[len("data:"):])
 		if bytes.Equal(payload, []byte("[DONE]")) {
-			if len(seen) == 0 {
-				return false
-			}
-			for index := range seen {
-				if _, ok := finished[index]; !ok {
-					return false
-				}
-			}
-			return true
+			return len(seen) > 0 && len(finished) == len(seen)
 		}
-		if !bytes.Contains(payload, []byte(`"choices"`)) {
-			continue
-		}
-		var event struct {
-			Choices []struct {
-				Index        int    `json:"index"`
-				FinishReason string `json:"finish_reason"`
-			} `json:"choices"`
-		}
-		if err := json.Unmarshal(payload, &event); err != nil {
-			continue
-		}
-		for _, choice := range event.Choices {
-			seen[choice.Index] = struct{}{}
-			if strings.TrimSpace(choice.FinishReason) != "" {
-				finished[choice.Index] = struct{}{}
-			}
-		}
+		trackChoiceCompletion(payload, seen, finished)
 	}
 	return false
+}
+
+// completeChatChoices checks a single aggregated chat.completion payload: the
+// non-streaming path folds a truncated stream into a normal-looking object
+// whose choices simply never got a terminal reason.
+func completeChatChoices(payload []byte) bool {
+	seen := make(map[string]struct{})
+	finished := make(map[string]struct{})
+	trackChoiceCompletion(payload, seen, finished)
+	return len(seen) > 0 && len(finished) == len(seen)
+}
+
+// trackChoiceCompletion records each choice in payload by index and marks it
+// finished when finish_reason or stop_reason carries a non-null value. Fields
+// are decoded as raw JSON so a host that types index or the reasons unusually
+// still has its choices tracked instead of dropping the whole event.
+func trackChoiceCompletion(payload []byte, seen, finished map[string]struct{}) {
+	if !bytes.Contains(payload, []byte(`"choices"`)) {
+		return
+	}
+	var event struct {
+		Choices []struct {
+			Index        json.RawMessage `json:"index"`
+			FinishReason json.RawMessage `json:"finish_reason"`
+			StopReason   json.RawMessage `json:"stop_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return
+	}
+	for _, choice := range event.Choices {
+		index := string(bytes.TrimSpace(choice.Index))
+		if index == "" {
+			index = "0"
+		}
+		seen[index] = struct{}{}
+		if jsonValuePresent(choice.FinishReason) || jsonValuePresent(choice.StopReason) {
+			finished[index] = struct{}{}
+		}
+	}
+}
+
+func jsonValuePresent(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null")) && !bytes.Equal(trimmed, []byte(`""`))
 }
 
 func responseBodyHasNonCacheableError(body []byte) bool {

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -134,9 +134,6 @@ func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.T
 	if c == nil || key == "" || len(entry.Body) == 0 || strings.TrimSpace(entry.EscrowID) == "" {
 		return
 	}
-	if !cacheableChatResponse(entry.StatusCode, entry.Body, entry.Stream) {
-		return
-	}
 	if entry.ExpiresAt.IsZero() {
 		entry.ExpiresAt = now.Add(c.ttl)
 	}
@@ -243,21 +240,23 @@ func (w *gatewayChatCacheCapture) statusCode() int {
 	return w.status
 }
 
-// cacheEntry builds a cache entry from the captured response, rejecting it
-// when the request itself failed (requestErr, e.g. a client disconnect) or
-// the response is not a deterministic, cacheable outcome (see
-// cacheableResponse).
-func (w *gatewayChatCacheCapture) cacheEntry(escrowID string, stream bool, sourceRequestID string, requestErr error) (cachedChatResponse, bool) {
-	if w == nil || w.writeErr != nil || w.body.Len() == 0 {
-		return cachedChatResponse{}, false
-	}
-	if requestErr != nil {
-		return cachedChatResponse{}, false
+// cacheEntry builds a cache entry from the captured response. The returned
+// reason is empty when the entry is cacheable and otherwise names why it was
+// skipped: request_error, write_error, empty_body, status, transient_error,
+// incomplete, no_choices.
+func (w *gatewayChatCacheCapture) cacheEntry(escrowID string, stream bool, sourceRequestID string, requestErr error) (cachedChatResponse, string) {
+	switch {
+	case w == nil || w.body.Len() == 0:
+		return cachedChatResponse{}, "empty_body"
+	case w.writeErr != nil:
+		return cachedChatResponse{}, "write_error"
+	case requestErr != nil:
+		return cachedChatResponse{}, "request_error"
 	}
 	statusCode := w.statusCode()
 	body := w.body.Bytes()
-	if !cacheableChatResponse(statusCode, body, stream) {
-		return cachedChatResponse{}, false
+	if reason := cacheableChatResponse(statusCode, body, stream); reason != "" {
+		return cachedChatResponse{}, reason
 	}
 	return cachedChatResponse{
 		EscrowID:        escrowID,
@@ -266,91 +265,127 @@ func (w *gatewayChatCacheCapture) cacheEntry(escrowID string, stream bool, sourc
 		ContentType:     w.Header().Get("Content-Type"),
 		Body:            append([]byte(nil), body...),
 		SourceRequestID: sourceRequestID,
-	}, true
+	}, ""
 }
 
 // cacheableResponse reports whether a response is a deterministic outcome
 // safe to replay for a duplicate request: any 2xx, or a 400 whose OpenAI-style
 // error body is itself deterministic (bad request shape), as opposed to a
 // transient failure (rate limit, timeout, capability exhaustion, ...).
-func cacheableResponse(statusCode int, body []byte) bool {
-	if len(body) == 0 || responseBodyHasNonCacheableError(body) {
-		return false
+// The result is empty when cacheable, otherwise the skip reason.
+func cacheableResponse(statusCode int, body []byte) string {
+	if len(body) == 0 {
+		return "empty_body"
+	}
+	if responseBodyHasNonCacheableError(body) {
+		return "transient_error"
 	}
 	if statusCode == 0 {
 		statusCode = http.StatusOK
 	}
 	if statusCode >= 200 && statusCode < 300 {
-		return true
+		return ""
 	}
 	if statusCode == http.StatusBadRequest {
-		details, ok := jsonErrorPayloadDetails(body)
-		return ok && isCacheableOpenAIErrorDetails(details)
+		if details, ok := jsonErrorPayloadDetails(body); ok && isCacheableOpenAIErrorDetails(details) {
+			return ""
+		}
 	}
-	return false
+	return "status"
 }
 
 // cacheableChatResponse layers semantic completion on cacheableResponse: a 2xx
 // chat body replays only when every observed choice carries a terminal reason.
-// Deterministic error bodies (a host rejection streams as a 200 SSE error
-// event) stay cacheable as before.
-func cacheableChatResponse(statusCode int, body []byte, stream bool) bool {
-	if !cacheableResponse(statusCode, body) {
-		return false
+// A deterministic error body with no choices (a host rejection streams as a
+// 200 SSE error event) stays cacheable; an error after a partial choice does not.
+func cacheableChatResponse(statusCode int, body []byte, stream bool) string {
+	if reason := cacheableResponse(statusCode, body); reason != "" {
+		return reason
 	}
-	if statusCode == 0 {
-		statusCode = http.StatusOK
+	if statusCode != 0 && (statusCode < 200 || statusCode >= 300) {
+		return ""
 	}
-	if statusCode < 200 || statusCode >= 300 {
-		return true
-	}
+	var state choiceCompletion
 	if stream {
-		if completeStreamingChatResponse(body) {
+		state = foldStreamCompletion(body)
+	} else {
+		state.ingest(bytes.TrimSpace(body))
+		state.done = true
+	}
+	return state.reason()
+}
+
+type choiceCompletion struct {
+	seen     map[string]struct{}
+	finished map[string]struct{}
+	sawError bool
+	done     bool
+}
+
+func (s *choiceCompletion) reason() string {
+	switch {
+	case len(s.seen) == 0 && s.sawError:
+		return ""
+	case len(s.seen) == 0:
+		return "no_choices"
+	case !s.done || len(s.finished) != len(s.seen):
+		return "incomplete"
+	}
+	return ""
+}
+
+// foldStreamCompletion walks SSE events the way aggregateSSEStreamReader does:
+// a blank line ends an event and consecutive data: lines are joined. A `[DONE]`
+// before every observed choice is terminal is framing, not completion.
+func foldStreamCompletion(body []byte) choiceCompletion {
+	var state choiceCompletion
+	var event []byte
+	ingest := func() bool {
+		data := bytes.TrimSpace(event)
+		event = event[:0]
+		if len(data) == 0 {
+			return false
+		}
+		if bytes.Equal(data, []byte("[DONE]")) {
+			state.done = true
 			return true
 		}
-	} else if completeChatChoices(bytes.TrimSpace(body)) {
-		return true
+		state.ingest(data)
+		return false
 	}
-	return responseBodyHasErrorPayload(body)
-}
-
-func responseBodyHasErrorPayload(body []byte) bool {
-	if _, ok := sseChunkErrorDetails(body); ok {
-		return true
-	}
-	_, ok := jsonErrorPayloadDetails(body)
-	return ok
-}
-
-// A `[DONE]` before every observed choice is terminal is framing, not completion.
-func completeStreamingChatResponse(body []byte) bool {
-	seen := make(map[string]struct{})
-	finished := make(map[string]struct{})
 	for _, line := range bytes.Split(body, []byte("\n")) {
-		line = bytes.TrimSpace(line)
-		if !bytes.HasPrefix(line, []byte("data:")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 {
+			if ingest() {
+				return state
+			}
 			continue
 		}
-		payload := bytes.TrimSpace(line[len("data:"):])
-		if bytes.Equal(payload, []byte("[DONE]")) {
-			return len(seen) > 0 && len(finished) == len(seen)
+		if !bytes.HasPrefix(trimmed, []byte("data:")) {
+			continue
 		}
-		trackChoiceCompletion(payload, seen, finished)
+		if len(event) > 0 {
+			event = append(event, '\n')
+		}
+		event = append(event, bytes.TrimSpace(trimmed[len("data:"):])...)
 	}
-	return false
+	ingest()
+	return state
 }
 
-func completeChatChoices(payload []byte) bool {
-	seen := make(map[string]struct{})
-	finished := make(map[string]struct{})
-	trackChoiceCompletion(payload, seen, finished)
-	return len(seen) > 0 && len(finished) == len(seen)
-}
-
-// Fields are raw JSON so an oddly typed index or reason does not drop the event.
-func trackChoiceCompletion(payload []byte, seen, finished map[string]struct{}) {
+// ingest records each choice by index and marks it finished on a terminal
+// finish_reason or stop_reason; a finished choice stays finished, as in the
+// aggregator. Fields are raw JSON so an oddly typed index does not drop the event.
+func (s *choiceCompletion) ingest(payload []byte) {
+	if isHostErrorPayload(payload) {
+		s.sawError = true
+		return
+	}
 	if !bytes.Contains(payload, []byte(`"choices"`)) {
 		return
+	}
+	if normalized, replaced := replaceNonFiniteNumbers(payload); replaced {
+		payload = normalized
 	}
 	var event struct {
 		Choices []struct {
@@ -362,21 +397,36 @@ func trackChoiceCompletion(payload []byte, seen, finished map[string]struct{}) {
 	if err := json.Unmarshal(payload, &event); err != nil {
 		return
 	}
+	if s.seen == nil {
+		s.seen = make(map[string]struct{})
+		s.finished = make(map[string]struct{})
+	}
 	for _, choice := range event.Choices {
 		index := string(bytes.TrimSpace(choice.Index))
 		if index == "" {
 			index = "0"
 		}
-		seen[index] = struct{}{}
-		if jsonValuePresent(choice.FinishReason) || jsonValuePresent(choice.StopReason) {
-			finished[index] = struct{}{}
+		s.seen[index] = struct{}{}
+		if terminalReason(choice.FinishReason) || terminalReason(choice.StopReason) {
+			s.finished[index] = struct{}{}
 		}
 	}
 }
 
-func jsonValuePresent(raw json.RawMessage) bool {
+// terminalReason accepts a non-empty string or a number (vLLM stop_reason may be
+// a token id); null, booleans, and empty strings are not terminal.
+func terminalReason(raw json.RawMessage) bool {
 	trimmed := bytes.TrimSpace(raw)
-	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null")) && !bytes.Equal(trimmed, []byte(`""`))
+	if len(trimmed) == 0 {
+		return false
+	}
+	switch trimmed[0] {
+	case '"':
+		return len(trimmed) > 2
+	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return true
+	}
+	return false
 }
 
 func responseBodyHasNonCacheableError(body []byte) bool {

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -126,10 +126,11 @@ func (c *chatResponseCache) Get(key string, now time.Time) (cachedChatResponse, 
 	return entry, true
 }
 
-// Set stores without re-validating: cacheEntry is the only gate.
-func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.Time) {
+// Set stores without re-validating: cacheEntry is the only gate. It reports
+// false when the entry does not fit under the byte cap.
+func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.Time) bool {
 	if c == nil || key == "" || len(entry.Body) == 0 || strings.TrimSpace(entry.EscrowID) == "" {
-		return
+		return false
 	}
 	if entry.ExpiresAt.IsZero() {
 		entry.ExpiresAt = now.Add(c.ttl)
@@ -148,9 +149,8 @@ func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.T
 	// the limit. This is a dedup cache -- evicting a "wrong" entry only
 	// costs one cache miss, so eviction order isn't worth tracking.
 	if chatCacheEntrySize(entry) > c.maxBytes {
-		// Entry is too large to fit under the cap; don't cache it.
 		c.deleteLocked(key)
-		return
+		return false
 	}
 	for other := range c.entries {
 		if c.totalBytes <= c.maxBytes {
@@ -160,6 +160,7 @@ func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.T
 			c.deleteLocked(other)
 		}
 	}
+	return true
 }
 
 // Stats reports the current entry count and approximate retained bytes.

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -122,8 +122,6 @@ func (c *chatResponseCache) Get(key string, now time.Time) (cachedChatResponse, 
 		c.deleteLocked(key)
 		return cachedChatResponse{}, false
 	}
-	// Set is the only producer (the cache is process memory), so Get keeps the
-	// pre-existing error screen only and does not repeat the completion scan.
 	if responseBodyHasNonCacheableError(entry.Body) {
 		c.deleteLocked(key)
 		return cachedChatResponse{}, false
@@ -292,12 +290,10 @@ func cacheableResponse(statusCode int, body []byte) bool {
 	return false
 }
 
-// cacheableChatResponse adds semantic completion on top of cacheableResponse:
-// a 2xx chat body is replayable only when every observed choice ended with a
-// terminal reason, whether the client asked for a stream or received the
-// aggregated non-streaming shape. Deterministic error bodies (already vetted by
-// cacheableResponse) stay replayable: the streaming handler emits a host
-// rejection as a 200 SSE error event, so they never carry choices.
+// cacheableChatResponse layers semantic completion on cacheableResponse: a 2xx
+// chat body replays only when every observed choice carries a terminal reason.
+// Deterministic error bodies (a host rejection streams as a 200 SSE error
+// event) stay cacheable as before.
 func cacheableChatResponse(statusCode int, body []byte, stream bool) bool {
 	if !cacheableResponse(statusCode, body) {
 		return false
@@ -326,9 +322,7 @@ func responseBodyHasErrorPayload(body []byte) bool {
 	return ok
 }
 
-// completeStreamingChatResponse requires `[DONE]` after every observed choice
-// carried a terminal reason. A `[DONE]` written before that (or with no choice
-// events at all) is framing, not completion.
+// A `[DONE]` before every observed choice is terminal is framing, not completion.
 func completeStreamingChatResponse(body []byte) bool {
 	seen := make(map[string]struct{})
 	finished := make(map[string]struct{})
@@ -346,9 +340,6 @@ func completeStreamingChatResponse(body []byte) bool {
 	return false
 }
 
-// completeChatChoices checks a single aggregated chat.completion payload: the
-// non-streaming path folds a truncated stream into a normal-looking object
-// whose choices simply never got a terminal reason.
 func completeChatChoices(payload []byte) bool {
 	seen := make(map[string]struct{})
 	finished := make(map[string]struct{})
@@ -356,10 +347,7 @@ func completeChatChoices(payload []byte) bool {
 	return len(seen) > 0 && len(finished) == len(seen)
 }
 
-// trackChoiceCompletion records each choice in payload by index and marks it
-// finished when finish_reason or stop_reason carries a non-null value. Fields
-// are decoded as raw JSON so a host that types index or the reasons unusually
-// still has its choices tracked instead of dropping the whole event.
+// Fields are raw JSON so an oddly typed index or reason does not drop the event.
 func trackChoiceCompletion(payload []byte, seen, finished map[string]struct{}) {
 	if !bytes.Contains(payload, []byte(`"choices"`)) {
 		return

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -122,7 +122,9 @@ func (c *chatResponseCache) Get(key string, now time.Time) (cachedChatResponse, 
 		c.deleteLocked(key)
 		return cachedChatResponse{}, false
 	}
-	if !cacheableChatResponse(entry.StatusCode, entry.Body, entry.Stream) {
+	// Set is the only producer (the cache is process memory), so Get keeps the
+	// pre-existing error screen only and does not repeat the completion scan.
+	if responseBodyHasNonCacheableError(entry.Body) {
 		c.deleteLocked(key)
 		return cachedChatResponse{}, false
 	}
@@ -293,7 +295,9 @@ func cacheableResponse(statusCode int, body []byte) bool {
 // cacheableChatResponse adds semantic completion on top of cacheableResponse:
 // a 2xx chat body is replayable only when every observed choice ended with a
 // terminal reason, whether the client asked for a stream or received the
-// aggregated non-streaming shape.
+// aggregated non-streaming shape. Deterministic error bodies (already vetted by
+// cacheableResponse) stay replayable: the streaming handler emits a host
+// rejection as a 200 SSE error event, so they never carry choices.
 func cacheableChatResponse(statusCode int, body []byte, stream bool) bool {
 	if !cacheableResponse(statusCode, body) {
 		return false
@@ -305,9 +309,21 @@ func cacheableChatResponse(statusCode int, body []byte, stream bool) bool {
 		return true
 	}
 	if stream {
-		return completeStreamingChatResponse(body)
+		if completeStreamingChatResponse(body) {
+			return true
+		}
+	} else if completeChatChoices(bytes.TrimSpace(body)) {
+		return true
 	}
-	return completeChatChoices(bytes.TrimSpace(body))
+	return responseBodyHasErrorPayload(body)
+}
+
+func responseBodyHasErrorPayload(body []byte) bool {
+	if _, ok := sseChunkErrorDetails(body); ok {
+		return true
+	}
+	_, ok := jsonErrorPayloadDetails(body)
+	return ok
 }
 
 // completeStreamingChatResponse requires `[DONE]` after every observed choice

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -122,14 +122,11 @@ func (c *chatResponseCache) Get(key string, now time.Time) (cachedChatResponse, 
 		c.deleteLocked(key)
 		return cachedChatResponse{}, false
 	}
-	if responseBodyHasNonCacheableError(entry.Body) {
-		c.deleteLocked(key)
-		return cachedChatResponse{}, false
-	}
 	entry.Body = append([]byte(nil), entry.Body...)
 	return entry, true
 }
 
+// Set stores without re-validating: cacheEntry is the only gate.
 func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.Time) {
 	if c == nil || key == "" || len(entry.Body) == 0 || strings.TrimSpace(entry.EscrowID) == "" {
 		return
@@ -407,26 +404,22 @@ func (s *choiceCompletion) ingest(payload []byte) {
 			index = "0"
 		}
 		s.seen[index] = struct{}{}
-		if terminalReason(choice.FinishReason) || terminalReason(choice.StopReason) {
+		if terminalString(choice.FinishReason) || terminalString(choice.StopReason) || jsonNumber(choice.StopReason) {
 			s.finished[index] = struct{}{}
 		}
 	}
 }
 
-// terminalReason accepts a non-empty string or a number (vLLM stop_reason may be
-// a token id); null, booleans, and empty strings are not terminal.
-func terminalReason(raw json.RawMessage) bool {
+// finish_reason is terminal only as a non-empty string; stop_reason may also be
+// a token id. null, booleans, and empty strings are never terminal.
+func terminalString(raw json.RawMessage) bool {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 {
-		return false
-	}
-	switch trimmed[0] {
-	case '"':
-		return len(trimmed) > 2
-	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-		return true
-	}
-	return false
+	return len(trimmed) > 2 && trimmed[0] == '"'
+}
+
+func jsonNumber(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && (trimmed[0] == '-' || (trimmed[0] >= '0' && trimmed[0] <= '9'))
 }
 
 func responseBodyHasNonCacheableError(body []byte) bool {

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -121,7 +122,7 @@ func (c *chatResponseCache) Get(key string, now time.Time) (cachedChatResponse, 
 		c.deleteLocked(key)
 		return cachedChatResponse{}, false
 	}
-	if responseBodyHasNonCacheableError(entry.Body) {
+	if !cacheableChatResponse(entry.StatusCode, entry.Body, entry.Stream) {
 		c.deleteLocked(key)
 		return cachedChatResponse{}, false
 	}
@@ -133,7 +134,7 @@ func (c *chatResponseCache) Set(key string, entry cachedChatResponse, now time.T
 	if c == nil || key == "" || len(entry.Body) == 0 || strings.TrimSpace(entry.EscrowID) == "" {
 		return
 	}
-	if !cacheableResponse(entry.StatusCode, entry.Body) {
+	if !cacheableChatResponse(entry.StatusCode, entry.Body, entry.Stream) {
 		return
 	}
 	if entry.ExpiresAt.IsZero() {
@@ -255,7 +256,7 @@ func (w *gatewayChatCacheCapture) cacheEntry(escrowID string, stream bool, sourc
 	}
 	statusCode := w.statusCode()
 	body := w.body.Bytes()
-	if !cacheableResponse(statusCode, body) {
+	if !cacheableChatResponse(statusCode, body, stream) {
 		return cachedChatResponse{}, false
 	}
 	return cachedChatResponse{
@@ -285,6 +286,58 @@ func cacheableResponse(statusCode int, body []byte) bool {
 	if statusCode == http.StatusBadRequest {
 		details, ok := jsonErrorPayloadDetails(body)
 		return ok && isCacheableOpenAIErrorDetails(details)
+	}
+	return false
+}
+
+func cacheableChatResponse(statusCode int, body []byte, stream bool) bool {
+	if !cacheableResponse(statusCode, body) {
+		return false
+	}
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	return !stream || statusCode < 200 || statusCode >= 300 || completeStreamingChatResponse(body)
+}
+
+func completeStreamingChatResponse(body []byte) bool {
+	seen := make(map[int]struct{})
+	finished := make(map[int]struct{})
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if bytes.Equal(payload, []byte("[DONE]")) {
+			if len(seen) == 0 {
+				return false
+			}
+			for index := range seen {
+				if _, ok := finished[index]; !ok {
+					return false
+				}
+			}
+			return true
+		}
+		if !bytes.Contains(payload, []byte(`"choices"`)) {
+			continue
+		}
+		var event struct {
+			Choices []struct {
+				Index        int    `json:"index"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal(payload, &event); err != nil {
+			continue
+		}
+		for _, choice := range event.Choices {
+			seen[choice.Index] = struct{}{}
+			if strings.TrimSpace(choice.FinishReason) != "" {
+				finished[choice.Index] = struct{}{}
+			}
+		}
 	}
 	return false
 }

--- a/devshard/cmd/devshardctl/response_cache.go
+++ b/devshard/cmd/devshardctl/response_cache.go
@@ -239,16 +239,17 @@ func (w *gatewayChatCacheCapture) statusCode() int {
 
 // cacheEntry builds a cache entry from the captured response. The returned
 // reason is empty when the entry is cacheable and otherwise names why it was
-// skipped: request_error, write_error, empty_body, status, transient_error,
-// incomplete, no_choices.
+// skipped. The capture buffers every body it sees, including the ones it then
+// refuses; a truncated multi-megabyte stream is held and scanned once just to
+// be dropped. Deciding incrementally in Write would avoid that.
 func (w *gatewayChatCacheCapture) cacheEntry(escrowID string, stream bool, sourceRequestID string, requestErr error) (cachedChatResponse, string) {
 	switch {
-	case w == nil || w.body.Len() == 0:
-		return cachedChatResponse{}, "empty_body"
-	case w.writeErr != nil:
-		return cachedChatResponse{}, "write_error"
 	case requestErr != nil:
 		return cachedChatResponse{}, "request_error"
+	case w == nil || w.writeErr != nil:
+		return cachedChatResponse{}, "write_error"
+	case w.body.Len() == 0:
+		return cachedChatResponse{}, "empty_body"
 	}
 	statusCode := w.statusCode()
 	body := w.body.Bytes()

--- a/devshard/cmd/devshardctl/response_cache_test.go
+++ b/devshard/cmd/devshardctl/response_cache_test.go
@@ -33,6 +33,42 @@ func TestGatewayChatCacheCaptureAllowsSuccessfulResponse(t *testing.T) {
 	require.JSONEq(t, `{"choices":[{"message":{"content":"ok"}}]}`, string(entry.Body))
 }
 
+func TestGatewayChatCacheCaptureAllowsCompleteStreamingResponse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	capture := &gatewayChatCacheCapture{ResponseWriter: rec}
+	_, err := capture.Write([]byte(
+		`data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" +
+			"data: [DONE]\n\n",
+	))
+	require.NoError(t, err)
+
+	entry, ok := capture.cacheEntry("escrow-1", true, "req-source", nil)
+
+	require.True(t, ok)
+	require.True(t, entry.Stream)
+}
+
+func TestGatewayChatCacheCaptureRejectsIncompleteStreamingResponse(t *testing.T) {
+	tests := map[string]string{
+		"partial without done": `data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n",
+		"synthetic done":       `data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n" + "data: [DONE]\n\n",
+		"finish without done":  `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			capture := &gatewayChatCacheCapture{ResponseWriter: rec}
+			_, err := capture.Write([]byte(body))
+			require.NoError(t, err)
+
+			entry, ok := capture.cacheEntry("escrow-1", true, "req-source", nil)
+
+			require.False(t, ok)
+			require.Empty(t, entry.Body)
+		})
+	}
+}
+
 func TestGatewayChatCacheCaptureAllowsDeterministicOpenAIStyleBadRequest(t *testing.T) {
 	rec := httptest.NewRecorder()
 	capture := &gatewayChatCacheCapture{ResponseWriter: rec}
@@ -192,6 +228,26 @@ func TestChatResponseCacheDropsPreviouslyCachedNonCacheableErrors(t *testing.T) 
 	}
 
 	entry, ok := cache.Get("bad", time.Now())
+
+	require.False(t, ok)
+	require.Empty(t, entry.Body)
+}
+
+func TestChatResponseCacheGetDropsPreviouslyCachedIncompleteStream(t *testing.T) {
+	cache := newChatResponseCache(time.Minute, 0)
+	now := time.Now()
+	cache.entries["incomplete"] = cachedChatResponse{
+		EscrowID:   "escrow-1",
+		Stream:     true,
+		StatusCode: http.StatusOK,
+		Body: []byte(
+			`data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n" +
+				"data: [DONE]\n\n",
+		),
+		ExpiresAt: now.Add(time.Minute),
+	}
+
+	entry, ok := cache.Get("incomplete", now)
 
 	require.False(t, ok)
 	require.Empty(t, entry.Body)

--- a/devshard/cmd/devshardctl/response_cache_test.go
+++ b/devshard/cmd/devshardctl/response_cache_test.go
@@ -55,10 +55,11 @@ func TestGatewayChatCacheCaptureRejectsIncompleteNonStreamingResponse(t *testing
 
 func TestGatewayChatCacheCaptureAllowsCompleteStreamingResponse(t *testing.T) {
 	tests := map[string]string{
-		"finish_reason":      `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + "data: [DONE]\n\n",
-		"stop_reason only":   `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null,"stop_reason":128009}]}` + "\n\n" + "data: [DONE]\n\n",
-		"string index":       `data: {"choices":[{"index":"0","delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + "data: [DONE]\n\n",
-		"usage chunk before": `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + `data: {"choices":[],"usage":{"completion_tokens":1}}` + "\n\n" + "data: [DONE]\n\n",
+		"finish_reason":       `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + "data: [DONE]\n\n",
+		"stop_reason only":    `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null,"stop_reason":128009}]}` + "\n\n" + "data: [DONE]\n\n",
+		"string index":        `data: {"choices":[{"index":"0","delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + "data: [DONE]\n\n",
+		"usage chunk before":  `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + `data: {"choices":[],"usage":{"completion_tokens":1}}` + "\n\n" + "data: [DONE]\n\n",
+		"deterministic error": `data: {"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}` + "\n\n" + "data: [DONE]\n\n",
 	}
 	for name, body := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -262,10 +263,11 @@ func TestChatResponseCacheDropsPreviouslyCachedNonCacheableErrors(t *testing.T) 
 	require.Empty(t, entry.Body)
 }
 
-func TestChatResponseCacheGetDropsPreviouslyCachedIncompleteStream(t *testing.T) {
+func TestChatResponseCacheSetRejectsIncompleteStream(t *testing.T) {
 	cache := newChatResponseCache(time.Minute, 0)
 	now := time.Now()
-	cache.entries["incomplete"] = cachedChatResponse{
+
+	cache.Set("incomplete", cachedChatResponse{
 		EscrowID:   "escrow-1",
 		Stream:     true,
 		StatusCode: http.StatusOK,
@@ -273,11 +275,9 @@ func TestChatResponseCacheGetDropsPreviouslyCachedIncompleteStream(t *testing.T)
 			`data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n" +
 				"data: [DONE]\n\n",
 		),
-		ExpiresAt: now.Add(time.Minute),
-	}
+	}, now)
 
-	entry, ok := cache.Get("incomplete", now)
-
-	require.False(t, ok)
-	require.Empty(t, entry.Body)
+	count, totalBytes := cache.Stats()
+	require.Equal(t, 0, count)
+	require.Equal(t, int64(0), totalBytes)
 }

--- a/devshard/cmd/devshardctl/response_cache_test.go
+++ b/devshard/cmd/devshardctl/response_cache_test.go
@@ -15,9 +15,9 @@ func TestGatewayChatCacheCaptureRejectsCanceledRequestError(t *testing.T) {
 	capture := &gatewayChatCacheCapture{ResponseWriter: rec}
 	writeGatewayJSONError(capture, http.StatusBadGateway, context.Canceled.Error())
 
-	entry, ok := capture.cacheEntry("escrow-1", false, "req-source", context.Canceled)
+	entry, reason := capture.cacheEntry("escrow-1", false, "req-source", context.Canceled)
 
-	require.False(t, ok)
+	require.Equal(t, "request_error", reason)
 	require.Empty(t, entry.Body)
 }
 
@@ -26,40 +26,53 @@ func TestGatewayChatCacheCaptureAllowsSuccessfulResponse(t *testing.T) {
 	capture := &gatewayChatCacheCapture{ResponseWriter: rec}
 	writeJSONPayload(capture, http.StatusOK, []byte(`{"choices":[{"index":0,"message":{"content":"ok"},"finish_reason":"stop"}]}`))
 
-	entry, ok := capture.cacheEntry("escrow-1", false, "req-source", nil)
+	entry, reason := capture.cacheEntry("escrow-1", false, "req-source", nil)
 
-	require.True(t, ok)
+	require.Empty(t, reason)
 	require.Equal(t, http.StatusOK, entry.StatusCode)
 	require.JSONEq(t, `{"choices":[{"index":0,"message":{"content":"ok"},"finish_reason":"stop"}]}`, string(entry.Body))
 }
 
 func TestGatewayChatCacheCaptureRejectsIncompleteNonStreamingResponse(t *testing.T) {
-	tests := map[string]string{
-		"aggregated truncation": `{"id":"cmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"partial"},"finish_reason":null}]}`,
-		"no choices":            `{"id":"cmpl-1","object":"chat.completion","choices":[]}`,
-		"second choice open":    `{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":"stop"},{"index":1,"message":{"content":"b"},"finish_reason":null}]}`,
+	tests := map[string]struct{ body, reason string }{
+		"aggregated truncation": {`{"id":"cmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"partial"},"finish_reason":null}]}`, "incomplete"},
+		"no choices":            {`{"id":"cmpl-1","object":"chat.completion","choices":[]}`, "no_choices"},
+		"second choice open":    {`{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":"stop"},{"index":1,"message":{"content":"b"},"finish_reason":null}]}`, "incomplete"},
+		"empty finish_reason":   {`{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":""}]}`, "incomplete"},
+		"boolean finish_reason": {`{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":false}]}`, "incomplete"},
 	}
-	for name, body := range tests {
+	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			capture := &gatewayChatCacheCapture{ResponseWriter: rec}
-			writeJSONPayload(capture, http.StatusOK, []byte(body))
+			writeJSONPayload(capture, http.StatusOK, []byte(tt.body))
 
-			entry, ok := capture.cacheEntry("escrow-1", false, "req-source", nil)
+			entry, reason := capture.cacheEntry("escrow-1", false, "req-source", nil)
 
-			require.False(t, ok)
+			require.Equal(t, tt.reason, reason)
 			require.Empty(t, entry.Body)
 		})
 	}
 }
 
+// vLLM sends content, the terminal chunk, and usage as separate events; the
+// fixtures keep that shape so completion has to be carried across events.
+const (
+	sseContentChunk  = `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}` + "\n\n"
+	sseTerminalChunk = `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n"
+	sseUsageChunk    = `data: {"choices":[],"usage":{"completion_tokens":1}}` + "\n\n"
+	sseDone          = "data: [DONE]\n\n"
+)
+
 func TestGatewayChatCacheCaptureAllowsCompleteStreamingResponse(t *testing.T) {
 	tests := map[string]string{
-		"finish_reason":       `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + "data: [DONE]\n\n",
-		"stop_reason only":    `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null,"stop_reason":128009}]}` + "\n\n" + "data: [DONE]\n\n",
-		"string index":        `data: {"choices":[{"index":"0","delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + "data: [DONE]\n\n",
-		"usage chunk before":  `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + `data: {"choices":[],"usage":{"completion_tokens":1}}` + "\n\n" + "data: [DONE]\n\n",
-		"deterministic error": `data: {"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}` + "\n\n" + "data: [DONE]\n\n",
+		"vllm shape":          sseContentChunk + sseTerminalChunk + sseUsageChunk + sseDone,
+		"stop_reason only":    sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":null,"stop_reason":128009}]}` + "\n\n" + sseDone,
+		"string index":        `data: {"choices":[{"index":"0","delta":{"content":"ok"},"finish_reason":null}]}` + "\n\n" + `data: {"choices":[{"index":"0","delta":{},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
+		"null after finish":   sseContentChunk + sseTerminalChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":null}]}` + "\n\n" + sseDone,
+		"multi-line event":    sseContentChunk + `data: {"choices":[{"index":0,` + "\n" + `data: "delta":{},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
+		"non-finite logprob":  sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"logprobs":{"content":[{"token":"x","logprob":-Infinity}]},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
+		"deterministic error": `data: {"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}` + "\n\n" + sseDone,
 	}
 	for name, body := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -68,32 +81,38 @@ func TestGatewayChatCacheCaptureAllowsCompleteStreamingResponse(t *testing.T) {
 			_, err := capture.Write([]byte(body))
 			require.NoError(t, err)
 
-			entry, ok := capture.cacheEntry("escrow-1", true, "req-source", nil)
+			entry, reason := capture.cacheEntry("escrow-1", true, "req-source", nil)
 
-			require.True(t, ok)
+			require.Empty(t, reason)
 			require.True(t, entry.Stream)
 		})
 	}
 }
 
 func TestGatewayChatCacheCaptureRejectsIncompleteStreamingResponse(t *testing.T) {
-	tests := map[string]string{
-		"partial without done": `data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n",
-		"synthetic done":       `data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n" + "data: [DONE]\n\n",
-		"finish without done":  `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
-		"done only":            "data: [DONE]\n\n",
-		"second choice open":   `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{"content":"b"},"finish_reason":null}]}` + "\n\n" + "data: [DONE]\n\n",
+	tests := map[string]struct{ body, reason string }{
+		"partial without done":       {sseContentChunk, "incomplete"},
+		"synthetic done":             {sseContentChunk + sseDone, "incomplete"},
+		"finish without done":        {sseContentChunk + sseTerminalChunk, "incomplete"},
+		"done only":                  {sseDone, "no_choices"},
+		"second choice open":         {sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{"content":"b"},"finish_reason":null}]}` + "\n\n" + sseDone, "incomplete"},
+		"empty finish_reason":        {sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":""}]}` + "\n\n" + sseDone, "incomplete"},
+		"boolean stop_reason":        {sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":null,"stop_reason":false}]}` + "\n\n" + sseDone, "incomplete"},
+		"partial then winner error":  {sseContentChunk + `data: {"error":{"message":"inference: winner inference incomplete (nonce_finished=false)"}}` + "\n\n", "incomplete"},
+		"partial then host error":    {sseContentChunk + `data: {"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}` + "\n\n" + sseDone, "incomplete"},
+		"partial then empty stream":  {sseContentChunk + `data: {"error":{"message":"empty content stream"}}` + "\n\n" + sseDone, "incomplete"},
+		"partial then upstream time": {sseContentChunk + `data: {"error":{"message":"upstream timeout"}}` + "\n\n", "transient_error"},
 	}
-	for name, body := range tests {
+	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			capture := &gatewayChatCacheCapture{ResponseWriter: rec}
-			_, err := capture.Write([]byte(body))
+			_, err := capture.Write([]byte(tt.body))
 			require.NoError(t, err)
 
-			entry, ok := capture.cacheEntry("escrow-1", true, "req-source", nil)
+			entry, reason := capture.cacheEntry("escrow-1", true, "req-source", nil)
 
-			require.False(t, ok)
+			require.Equal(t, tt.reason, reason)
 			require.Empty(t, entry.Body)
 		})
 	}
@@ -104,9 +123,9 @@ func TestGatewayChatCacheCaptureAllowsDeterministicOpenAIStyleBadRequest(t *test
 	capture := &gatewayChatCacheCapture{ResponseWriter: rec}
 	writeJSONPayload(capture, http.StatusBadRequest, []byte(`{"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}`))
 
-	entry, ok := capture.cacheEntry("escrow-1", false, "req-source", nil)
+	entry, reason := capture.cacheEntry("escrow-1", false, "req-source", nil)
 
-	require.True(t, ok)
+	require.Empty(t, reason)
 	require.Equal(t, http.StatusBadRequest, entry.StatusCode)
 	require.JSONEq(t, `{"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}`, string(entry.Body))
 }
@@ -116,31 +135,43 @@ func TestGatewayChatCacheCaptureRejectsRuntimeAndCapabilityErrors(t *testing.T) 
 		name   string
 		status int
 		body   string
+		reason string
 	}{
 		{
 			name:   "context canceled",
 			status: http.StatusBadGateway,
 			body:   `{"error":{"message":"context canceled"}}`,
+			reason: "transient_error",
 		},
 		{
 			name:   "rate limited",
 			status: http.StatusTooManyRequests,
 			body:   `{"error":{"message":"rate limit exceeded","type":"RateLimitError","code":429}}`,
+			reason: "transient_error",
 		},
 		{
 			name:   "unsupported model",
 			status: http.StatusBadRequest,
 			body:   `{"error":{"message":"unsupported model \"Nope/Model\"","type":"BadRequestError","code":400}}`,
+			reason: "transient_error",
 		},
 		{
 			name:   "context length",
 			status: http.StatusBadRequest,
 			body:   `{"error":{"message":"This model's maximum context length is 131072 tokens. However, you requested 150000 tokens.","type":"BadRequestError","code":400}}`,
+			reason: "transient_error",
 		},
 		{
 			name:   "server error",
 			status: http.StatusInternalServerError,
 			body:   `{"error":{"message":"internal server error","type":"InternalServerError","code":500}}`,
+			reason: "transient_error",
+		},
+		{
+			name:   "unexpected status",
+			status: http.StatusBadGateway,
+			body:   `{"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}`,
+			reason: "status",
 		},
 	}
 
@@ -150,9 +181,9 @@ func TestGatewayChatCacheCaptureRejectsRuntimeAndCapabilityErrors(t *testing.T) 
 			capture := &gatewayChatCacheCapture{ResponseWriter: rec}
 			writeJSONPayload(capture, tt.status, []byte(tt.body))
 
-			entry, ok := capture.cacheEntry("escrow-1", false, "req-source", nil)
+			entry, reason := capture.cacheEntry("escrow-1", false, "req-source", nil)
 
-			require.False(t, ok)
+			require.Equal(t, tt.reason, reason)
 			require.Empty(t, entry.Body)
 		})
 	}
@@ -261,23 +292,4 @@ func TestChatResponseCacheDropsPreviouslyCachedNonCacheableErrors(t *testing.T) 
 
 	require.False(t, ok)
 	require.Empty(t, entry.Body)
-}
-
-func TestChatResponseCacheSetRejectsIncompleteStream(t *testing.T) {
-	cache := newChatResponseCache(time.Minute, 0)
-	now := time.Now()
-
-	cache.Set("incomplete", cachedChatResponse{
-		EscrowID:   "escrow-1",
-		Stream:     true,
-		StatusCode: http.StatusOK,
-		Body: []byte(
-			`data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n" +
-				"data: [DONE]\n\n",
-		),
-	}, now)
-
-	count, totalBytes := cache.Stats()
-	require.Equal(t, 0, count)
-	require.Equal(t, int64(0), totalBytes)
 }

--- a/devshard/cmd/devshardctl/response_cache_test.go
+++ b/devshard/cmd/devshardctl/response_cache_test.go
@@ -41,6 +41,15 @@ func TestGatewayChatCacheCaptureAllowsSuccessfulResponse(t *testing.T) {
 	require.JSONEq(t, `{"choices":[{"index":0,"message":{"content":"ok"},"finish_reason":"stop"}]}`, string(entry.Body))
 }
 
+func TestGatewayChatCacheCaptureAllowsMultiChoiceNonStreamingResponse(t *testing.T) {
+	capture := &gatewayChatCacheCapture{ResponseWriter: httptest.NewRecorder()}
+	writeJSONPayload(capture, http.StatusOK, []byte(`{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":"stop"},{"index":1,"message":{"content":"b"},"finish_reason":"length"}]}`))
+
+	_, reason := capture.cacheEntry("escrow-1", false, "req-source", nil)
+
+	require.Empty(t, reason)
+}
+
 func TestGatewayChatCacheCaptureRejectsIncompleteNonStreamingResponse(t *testing.T) {
 	tests := map[string]struct{ body, reason string }{
 		"aggregated truncation": {`{"id":"cmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"partial"},"finish_reason":null}]}`, "incomplete"},

--- a/devshard/cmd/devshardctl/response_cache_test.go
+++ b/devshard/cmd/devshardctl/response_cache_test.go
@@ -24,28 +24,55 @@ func TestGatewayChatCacheCaptureRejectsCanceledRequestError(t *testing.T) {
 func TestGatewayChatCacheCaptureAllowsSuccessfulResponse(t *testing.T) {
 	rec := httptest.NewRecorder()
 	capture := &gatewayChatCacheCapture{ResponseWriter: rec}
-	writeJSONPayload(capture, http.StatusOK, []byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	writeJSONPayload(capture, http.StatusOK, []byte(`{"choices":[{"index":0,"message":{"content":"ok"},"finish_reason":"stop"}]}`))
 
 	entry, ok := capture.cacheEntry("escrow-1", false, "req-source", nil)
 
 	require.True(t, ok)
 	require.Equal(t, http.StatusOK, entry.StatusCode)
-	require.JSONEq(t, `{"choices":[{"message":{"content":"ok"}}]}`, string(entry.Body))
+	require.JSONEq(t, `{"choices":[{"index":0,"message":{"content":"ok"},"finish_reason":"stop"}]}`, string(entry.Body))
+}
+
+func TestGatewayChatCacheCaptureRejectsIncompleteNonStreamingResponse(t *testing.T) {
+	tests := map[string]string{
+		"aggregated truncation": `{"id":"cmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"partial"},"finish_reason":null}]}`,
+		"no choices":            `{"id":"cmpl-1","object":"chat.completion","choices":[]}`,
+		"second choice open":    `{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":"stop"},{"index":1,"message":{"content":"b"},"finish_reason":null}]}`,
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			capture := &gatewayChatCacheCapture{ResponseWriter: rec}
+			writeJSONPayload(capture, http.StatusOK, []byte(body))
+
+			entry, ok := capture.cacheEntry("escrow-1", false, "req-source", nil)
+
+			require.False(t, ok)
+			require.Empty(t, entry.Body)
+		})
+	}
 }
 
 func TestGatewayChatCacheCaptureAllowsCompleteStreamingResponse(t *testing.T) {
-	rec := httptest.NewRecorder()
-	capture := &gatewayChatCacheCapture{ResponseWriter: rec}
-	_, err := capture.Write([]byte(
-		`data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" +
-			"data: [DONE]\n\n",
-	))
-	require.NoError(t, err)
+	tests := map[string]string{
+		"finish_reason":      `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + "data: [DONE]\n\n",
+		"stop_reason only":   `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null,"stop_reason":128009}]}` + "\n\n" + "data: [DONE]\n\n",
+		"string index":       `data: {"choices":[{"index":"0","delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + "data: [DONE]\n\n",
+		"usage chunk before": `data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n" + `data: {"choices":[],"usage":{"completion_tokens":1}}` + "\n\n" + "data: [DONE]\n\n",
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			capture := &gatewayChatCacheCapture{ResponseWriter: rec}
+			_, err := capture.Write([]byte(body))
+			require.NoError(t, err)
 
-	entry, ok := capture.cacheEntry("escrow-1", true, "req-source", nil)
+			entry, ok := capture.cacheEntry("escrow-1", true, "req-source", nil)
 
-	require.True(t, ok)
-	require.True(t, entry.Stream)
+			require.True(t, ok)
+			require.True(t, entry.Stream)
+		})
+	}
 }
 
 func TestGatewayChatCacheCaptureRejectsIncompleteStreamingResponse(t *testing.T) {
@@ -53,6 +80,8 @@ func TestGatewayChatCacheCaptureRejectsIncompleteStreamingResponse(t *testing.T)
 		"partial without done": `data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n",
 		"synthetic done":       `data: {"choices":[{"index":0,"delta":{"reasoning":"still working"},"finish_reason":null}]}` + "\n\n" + "data: [DONE]\n\n",
 		"finish without done":  `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		"done only":            "data: [DONE]\n\n",
+		"second choice open":   `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{"content":"b"},"finish_reason":null}]}` + "\n\n" + "data: [DONE]\n\n",
 	}
 	for name, body := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -133,7 +162,7 @@ func okBody(marker byte, size int) []byte {
 	for i := range filler {
 		filler[i] = 'a' + (marker+byte(i))%26
 	}
-	return []byte(`{"choices":[{"message":{"content":"` + string(filler) + `"}}]}`)
+	return []byte(`{"choices":[{"index":0,"message":{"content":"` + string(filler) + `"},"finish_reason":"stop"}]}`)
 }
 
 func cacheEntryForTest(marker byte, bodySize int) cachedChatResponse {

--- a/devshard/cmd/devshardctl/response_cache_test.go
+++ b/devshard/cmd/devshardctl/response_cache_test.go
@@ -21,6 +21,14 @@ func TestGatewayChatCacheCaptureRejectsCanceledRequestError(t *testing.T) {
 	require.Empty(t, entry.Body)
 }
 
+func TestGatewayChatCacheCaptureReportsRequestErrorBeforeEmptyBody(t *testing.T) {
+	capture := &gatewayChatCacheCapture{ResponseWriter: httptest.NewRecorder()}
+
+	_, reason := capture.cacheEntry("escrow-1", true, "req-source", context.Canceled)
+
+	require.Equal(t, "request_error", reason)
+}
+
 func TestGatewayChatCacheCaptureAllowsSuccessfulResponse(t *testing.T) {
 	rec := httptest.NewRecorder()
 	capture := &gatewayChatCacheCapture{ResponseWriter: rec}
@@ -67,13 +75,14 @@ const (
 
 func TestGatewayChatCacheCaptureAllowsCompleteStreamingResponse(t *testing.T) {
 	tests := map[string]string{
-		"vllm shape":          sseContentChunk + sseTerminalChunk + sseUsageChunk + sseDone,
-		"stop_reason only":    sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":null,"stop_reason":128009}]}` + "\n\n" + sseDone,
-		"string index":        `data: {"choices":[{"index":"0","delta":{"content":"ok"},"finish_reason":null}]}` + "\n\n" + `data: {"choices":[{"index":"0","delta":{},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
-		"null after finish":   sseContentChunk + sseTerminalChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":null}]}` + "\n\n" + sseDone,
-		"multi-line event":    sseContentChunk + `data: {"choices":[{"index":0,` + "\n" + `data: "delta":{},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
-		"non-finite logprob":  sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"logprobs":{"content":[{"token":"x","logprob":-Infinity}]},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
-		"deterministic error": `data: {"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}` + "\n\n" + sseDone,
+		"vllm shape":           sseContentChunk + sseTerminalChunk + sseUsageChunk + sseDone,
+		"stop_reason only":     sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":null,"stop_reason":128009}]}` + "\n\n" + sseDone,
+		"string index":         `data: {"choices":[{"index":"0","delta":{"content":"ok"},"finish_reason":null}]}` + "\n\n" + `data: {"choices":[{"index":"0","delta":{},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
+		"null after finish":    sseContentChunk + sseTerminalChunk + `data: {"choices":[{"index":0,"delta":{},"finish_reason":null}]}` + "\n\n" + sseDone,
+		"multi-line event":     sseContentChunk + `data: {"choices":[{"index":0,` + "\n" + `data: "delta":{},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
+		"non-finite logprob":   sseContentChunk + `data: {"choices":[{"index":0,"delta":{},"logprobs":{"content":[{"token":"x","logprob":-Infinity}]},"finish_reason":"stop"}]}` + "\n\n" + sseDone,
+		"deterministic error":  `data: {"error":{"message":"bad response_format schema","type":"BadRequestError","code":400}}` + "\n\n" + sseDone,
+		"two choices finished": `data: {"choices":[{"index":0,"delta":{"content":"a"},"finish_reason":null},{"index":1,"delta":{"content":"b"},"finish_reason":null}]}` + "\n\n" + `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{},"finish_reason":"length"}]}` + "\n\n" + sseDone,
 	}
 	for name, body := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/devshard/cmd/devshardctl/response_cache_test.go
+++ b/devshard/cmd/devshardctl/response_cache_test.go
@@ -40,6 +40,7 @@ func TestGatewayChatCacheCaptureRejectsIncompleteNonStreamingResponse(t *testing
 		"second choice open":    {`{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":"stop"},{"index":1,"message":{"content":"b"},"finish_reason":null}]}`, "incomplete"},
 		"empty finish_reason":   {`{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":""}]}`, "incomplete"},
 		"boolean finish_reason": {`{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":false}]}`, "incomplete"},
+		"numeric finish_reason": {`{"choices":[{"index":0,"message":{"content":"a"},"finish_reason":0}]}`, "incomplete"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -277,19 +278,4 @@ func TestChatResponseCacheGetDeletesExpiredAndAdjustsBytes(t *testing.T) {
 	count, totalBytes := cache.Stats()
 	require.Equal(t, 0, count)
 	require.Equal(t, int64(0), totalBytes)
-}
-
-func TestChatResponseCacheDropsPreviouslyCachedNonCacheableErrors(t *testing.T) {
-	cache := newChatResponseCache(time.Minute, 0)
-	cache.entries["bad"] = cachedChatResponse{
-		EscrowID:   "escrow-1",
-		StatusCode: http.StatusBadGateway,
-		Body:       []byte(`{"error":{"message":"context canceled"}}`),
-		ExpiresAt:  time.Now().Add(time.Minute),
-	}
-
-	entry, ok := cache.Get("bad", time.Now())
-
-	require.False(t, ok)
-	require.Empty(t, entry.Body)
 }

--- a/devshard/docs/proxy-architecture.md
+++ b/devshard/docs/proxy-architecture.md
@@ -209,8 +209,8 @@ The gateway has a short-lived in-memory chat response cache keyed by normalized 
 It is responsible for:
 
 - serving repeated equivalent requests without consuming another devshard nonce
-- caching both streaming and non-streaming successful responses
-- avoiding cache entries for retriable capability errors
+- caching both streaming and non-streaming responses only when every choice carries a terminal `finish_reason` or `stop_reason` (a truncated generation, even one closed with `[DONE]`, is never replayed)
+- avoiding cache entries for retriable capability errors and other transient failures
 - preserving request/escrow headers when serving cached responses
 
 Request accounting records per-request attempts and cache aliases so operators can explain which request produced a cached response and which escrow/nonce attempts were involved.


### PR DESCRIPTION
## Summary

- require semantic completion before caching a successful chat response, for both the streaming and the aggregated non-streaming shape;
- a choice is terminal when `finish_reason` or `stop_reason` carries a non-null value (matching `rewriteStreamingDataEvent`);
- streaming bodies additionally require `[DONE]` after every observed choice is terminal;
- deterministic error bodies keep their existing cacheability, including the streaming shape where a host rejection is emitted as a 200 SSE error event;
- validation runs once, in `cacheEntry`; `Set` and `Get` do not re-scan the body. An entry that does not fit the byte cap is reported as `skipped_too_large`.
- every skip is logged as `gateway_cache_skipped` with a reason and counted in `devshard_gateway_chat_cache_total{result="skipped_<reason>"}`.

## Problem

The current cache accepts any non-empty HTTP 2xx body. A hard timeout or other mid-stream termination can therefore store partial reasoning or content. Identical requests then receive the same truncated body for the one-hour cache TTL. A synthetic `[DONE]` marker does not prove that model generation finished, and the non-streaming aggregator folds the same truncation into a `chat.completion` whose choices have `finish_reason: null`.

Fixes #1722.

## Review focus

`trackChoiceCompletion` records every observed choice index (decoded as raw JSON, so unusually typed `index`/reason fields do not drop the event) and marks it finished on a non-null `finish_reason` or `stop_reason`. `completeStreamingChatResponse` requires `[DONE]` after all observed choices are finished; `completeChatChoices` applies the same scan to a single aggregated JSON payload. A body with no complete choices is still cacheable only if it is a deterministic error payload that `cacheableResponse` already vetted.

## Testing

- `go test ./cmd/devshardctl -count=1` on `gateway-v5`
- `TestGatewayPooledChatDoesNotCacheIncompleteResponse` reproduces the production shape end-to-end through `handlePooledChat` for both request modes: the second identical request must reach the runtime.
- Unit cases that fail on the previous validator: aggregated non-streaming truncation, `stop_reason`-only termination, string-typed `index`, multi-choice with one open choice, deterministic error stream.
