### PR TITLE
feat(mlnode): GLM-5.3-Flash on the vLLM 0.28 residual

### DIFF
--- a/deploy/join/node-config-glm53flash-B200.json
+++ b/deploy/join/node-config-glm53flash-B200.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "node1",
+    "host": "inference",
+    "inference_port": 5000,
+    "poc_port": 8080,
+    "max_concurrent": 500,
+    "models": {
+      "zai-org/GLM-5.3-Flash": {
+        "args": [
+          "--revision", "04c4e9e95c5da8862dced7e5056455116f83a7e0",
+          "--tensor-parallel-size", "4",
+          "--gpu-memory-utilization", "0.90",
+          "--max-num-batched-tokens", "65536",
+          "--disable-custom-all-reduce",
+          "--kv-cache-dtype", "fp8",
+          "--block-size", "2304",
+          "--max-num-seqs", "256",
+          "--no-enable-flashinfer-autotune",
+          "--logprobs-mode", "processed_logprobs",
+          "--enable-auto-tool-choice",
+          "--tool-call-parser", "glm47",
+          "--reasoning-parser", "glm45",
+          "--trust-remote-code"
+        ]
+      }
+    }
+  }
+]

--- a/deploy/join/node-config-glm53flash-B300.json
+++ b/deploy/join/node-config-glm53flash-B300.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "node1",
+    "host": "inference",
+    "inference_port": 5000,
+    "poc_port": 8080,
+    "max_concurrent": 500,
+    "models": {
+      "zai-org/GLM-5.3-Flash": {
+        "args": [
+          "--revision", "04c4e9e95c5da8862dced7e5056455116f83a7e0",
+          "--tensor-parallel-size", "2",
+          "--gpu-memory-utilization", "0.90",
+          "--kv-cache-dtype", "fp8",
+          "--block-size", "2304",
+          "--max-num-seqs", "256",
+          "--no-enable-flashinfer-autotune",
+          "--logprobs-mode", "processed_logprobs",
+          "--enable-auto-tool-choice",
+          "--tool-call-parser", "glm47",
+          "--reasoning-parser", "glm45",
+          "--trust-remote-code"
+        ]
+      }
+    }
+  }
+]

--- a/deploy/join/node-config-glm53flash-H100.json
+++ b/deploy/join/node-config-glm53flash-H100.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "node1",
+    "host": "inference",
+    "inference_port": 5000,
+    "poc_port": 8080,
+    "max_concurrent": 500,
+    "models": {
+      "zai-org/GLM-5.3-Flash": {
+        "args": [
+          "--revision", "04c4e9e95c5da8862dced7e5056455116f83a7e0",
+          "--tensor-parallel-size", "8",
+          "--gpu-memory-utilization", "0.95",
+          "--max-num-batched-tokens", "65536",
+          "--disable-custom-all-reduce",
+          "--kv-cache-dtype", "fp8",
+          "--block-size", "2304",
+          "--max-num-seqs", "256",
+          "--no-enable-flashinfer-autotune",
+          "--logprobs-mode", "processed_logprobs",
+          "--enable-auto-tool-choice",
+          "--tool-call-parser", "glm47",
+          "--reasoning-parser", "glm45",
+          "--trust-remote-code"
+        ]
+      }
+    }
+  }
+]

--- a/deploy/join/node-config-glm53flash-H200.json
+++ b/deploy/join/node-config-glm53flash-H200.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "node1",
+    "host": "inference",
+    "inference_port": 5000,
+    "poc_port": 8080,
+    "max_concurrent": 500,
+    "models": {
+      "zai-org/GLM-5.3-Flash": {
+        "args": [
+          "--revision", "04c4e9e95c5da8862dced7e5056455116f83a7e0",
+          "--tensor-parallel-size", "4",
+          "--gpu-memory-utilization", "0.90",
+          "--kv-cache-dtype", "fp8",
+          "--block-size", "2304",
+          "--max-num-seqs", "256",
+          "--no-enable-flashinfer-autotune",
+          "--logprobs-mode", "processed_logprobs",
+          "--enable-auto-tool-choice",
+          "--tool-call-parser", "glm47",
+          "--reasoning-parser", "glm45",
+          "--trust-remote-code"
+        ]
+      }
+    }
+  }
+]

--- a/mlnode/packages/api/Dockerfile
+++ b/mlnode/packages/api/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.4
 ################################################################################
-ARG VLLM_BASE_IMAGE=ghcr.io/gonka-ai/vllm:v0.25.1-poc-v4-cu13-hopper-blackwell@sha256:82877b425fd8f3c156446452665ef59f371d26d527cc4b65ea592d30500b86da
+# vLLM 0.28 residual for GLM-5.3-Flash: gonka-ai/vllm release/v0.28.0-glm53 + gonka-poc v0.1.4,
+# built with docker/Dockerfile.gonka-poc there. Tag is provisional; pin the published
+# digest (@sha256:...) before merge, as for 0.25.1.
+ARG VLLM_BASE_IMAGE=ghcr.io/gonka-ai/vllm:v0.28.0-glm53-poc-cu13-hopper-blackwell
 ARG MLNODE_RELEASE_VERSION=unknown
 FROM ${VLLM_BASE_IMAGE} AS base
 
@@ -13,7 +16,10 @@ RUN --mount=type=cache,target=/var/lib/apt/lists \
     checkinstall \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --upgrade "setuptools<81" wheel pip \
+    # --ignore-installed: the 0.28 base installs its packages with uv, which leaves no
+    # RECORD for pip to uninstall against; a plain --upgrade fails with
+    # uninstall-no-record-file. No-op on pip-installed bases.
+    && pip install --upgrade --ignore-installed "setuptools<81" wheel pip \
     && curl -fLO https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1u/openssl-1.1.1u.tar.gz \
     && tar -xzf openssl-1.1.1u.tar.gz \
     && cd openssl-1.1.1u \
@@ -32,7 +38,7 @@ RUN ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13 \
     && ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13 \
         /usr/local/lib/libnvrtc.so \
     && ldconfig \
-    && python3 -c "import vllm; assert vllm.__version__.startswith('0.25.1')" \
+    && python3 -c "import vllm; assert vllm.__version__.startswith('0.28.0')" \
     && python3 -c "from gonka_poc.worker import PoCWorkerExtension; from vllm.v1.worker.gpu.sample.replay import ReplayState"
 
 ################################################################################


### PR DESCRIPTION
MLNode on the vLLM 0.28 residual for GLM-5.3-Flash ([gonka-ai/vllm#106](https://github.com/gonka-ai/vllm/pull/106) + [gonka-ai/gonka-vllm-plugins#9](https://github.com/gonka-ai/gonka-vllm-plugins/pull/9)), plus node configs for the four measured arms. Tracking [#1691](https://github.com/gonka-ai/gonka/issues/1691).

`mlnode/packages/api/Dockerfile`, three lines:

- `VLLM_BASE_IMAGE` → `ghcr.io/gonka-ai/vllm:v0.28.0-glm53-poc-cu13-hopper-blackwell`, the `docker/Dockerfile.gonka-poc` build of `release/v0.28.0-glm53`. Tag is provisional: pin the published digest before merge, as for 0.25.1. Until then the build is checked with `--build-arg VLLM_BASE_IMAGE=<any build of that recipe>`.
- version guard `0.25.1` → `0.28.0`.
- `pip install --upgrade --ignore-installed`: the 0.28 base installs with uv, which leaves no RECORD for pip to uninstall against.

`deploy/join/node-config-glm53flash-{H100,H200,B200,B300}.json`: the flags the measurements ran with — fp8 KV cache, `--block-size 2304`, `--max-num-seqs 256`, `--no-enable-flashinfer-autotune`, GLM parsers, HF revision pinned. 8×H100 needs `--gpu-memory-utilization 0.95` to start. No `--max-model-len`: native context is 1 048 576 and no governance value exists yet.

Verified with this base image on 2×B300, 4×B200, 4×H200, 8×H100: [kaitakuai/experiments/2026-09](https://github.com/kaitakuai/experiments/tree/main/2026-09). MLNode itself is at `main` here; the measured images carried the same branch a few commits earlier, differing only in the exporter and version plumbing. Other models on the chain are unchanged and not re-verified on this base, as agreed in #1691.
