### PR TITLE
fix(inference): key model capacities lookup by epoch index

### DIFF
--- a/inference-chain/x/inference/keeper/query_dynamic_pricing.go
+++ b/inference-chain/x/inference/keeper/query_dynamic_pricing.go
@@ -113,9 +113,10 @@ func (k Keeper) GetAllModelCapacities(goCtx context.Context, req *types.QueryGet
 		}, nil
 	}
 
-	mainEpochData, found := k.GetEpochGroupData(goCtx, uint64(currentEpoch.PocStartBlockHeight), "")
+	// EpochGroupDataMap is keyed by epoch index, not by PoC start height.
+	mainEpochData, found := k.GetEpochGroupData(goCtx, currentEpoch.Index, "")
 	if !found {
-		k.LogError("Failed to get epoch group data for capacity query", types.Pricing)
+		k.LogError("Failed to get epoch group data for capacity query", types.Pricing, "epochIndex", currentEpoch.Index)
 		return &types.QueryGetAllModelCapacitiesResponse{
 			ModelCapacities: modelCapacities,
 		}, nil

--- a/inference-chain/x/inference/keeper/query_dynamic_pricing_test.go
+++ b/inference-chain/x/inference/keeper/query_dynamic_pricing_test.go
@@ -1,0 +1,63 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/productscience/inference/x/inference/types"
+)
+
+// The epoch group data map is keyed by epoch index. The effective epoch's
+// PoC start height is a block height on a different scale, so a lookup by
+// height only succeeds when the two happen to coincide.
+func TestGetAllModelCapacities_LooksUpEpochGroupByIndex(t *testing.T) {
+	k, ctx := setupTestKeeperWithDynamicPricing(t)
+	goCtx := sdk.WrapSDKContext(ctx)
+
+	effectiveEpoch := types.Epoch{
+		Index:               386,
+		PocStartBlockHeight: 5952281,
+	}
+	require.NoError(t, k.SetEpoch(ctx, &effectiveEpoch))
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, effectiveEpoch.Index))
+	k.SetEpochGroupData(ctx, types.EpochGroupData{
+		EpochIndex:          effectiveEpoch.Index,
+		ModelId:             "",
+		PocStartBlockHeight: uint64(effectiveEpoch.PocStartBlockHeight),
+		SubGroupModels:      []string{"model-a", "model-b"},
+	})
+	require.NoError(t, k.CacheModelCapacity(goCtx, "model-a", 1000))
+	require.NoError(t, k.CacheModelCapacity(goCtx, "model-b", 250))
+
+	resp, err := k.GetAllModelCapacities(goCtx, &types.QueryGetAllModelCapacitiesRequest{})
+	require.NoError(t, err)
+	require.Equal(t, []types.ModelCapacity{
+		{ModelId: "model-a", Capacity: 1000},
+		{ModelId: "model-b", Capacity: 250},
+	}, resp.ModelCapacities)
+}
+
+func TestGetAllModelCapacities_SkipsModelsWithoutCachedCapacity(t *testing.T) {
+	k, ctx := setupTestKeeperWithDynamicPricing(t)
+	goCtx := sdk.WrapSDKContext(ctx)
+
+	effectiveEpoch := types.Epoch{
+		Index:               7,
+		PocStartBlockHeight: 900,
+	}
+	require.NoError(t, k.SetEpoch(ctx, &effectiveEpoch))
+	require.NoError(t, k.SetEffectiveEpochIndex(ctx, effectiveEpoch.Index))
+	k.SetEpochGroupData(ctx, types.EpochGroupData{
+		EpochIndex:          effectiveEpoch.Index,
+		ModelId:             "",
+		PocStartBlockHeight: uint64(effectiveEpoch.PocStartBlockHeight),
+		SubGroupModels:      []string{"cached", "uncached"},
+	})
+	require.NoError(t, k.CacheModelCapacity(goCtx, "cached", 42))
+
+	resp, err := k.GetAllModelCapacities(goCtx, &types.QueryGetAllModelCapacitiesRequest{})
+	require.NoError(t, err)
+	require.Equal(t, []types.ModelCapacity{{ModelId: "cached", Capacity: 42}}, resp.ModelCapacities)
+}


### PR DESCRIPTION
## What problem does this solve?

`GetAllModelCapacities` (`x/inference/keeper/query_dynamic_pricing.go`) looks up the root epoch group data with the effective epoch's `PocStartBlockHeight`, but `EpochGroupDataMap` is keyed by `EpochIndex`. The lookup never hits, so the query always returns `200` with an empty `model_capacities` list.

Fixes #1725

## How do you know this is a real problem?

- `SetEpochGroupData` writes the map with `collections.Join(epochGroupData.EpochIndex, epochGroupData.ModelId)`; every other keeper caller of `GetEpochGroupData` passes an epoch index (`collateral.go`, `power.go`, `accountsettle.go`, `epoch_data_transient_cache.go`, `dynamic_pricing.go`). This query is the only one passing a block height.
- `Epoch.Index` and `Epoch.PocStartBlockHeight` differ by four orders of magnitude on mainnet (the issue reports epoch 386 vs height 5952281), so `found` is always false and the handler takes its non-error early return.
- The regression test below fails on the current code with `actual: []types.ModelCapacity(nil)`.

## How does this solve the problem?

Pass `currentEpoch.Index` instead of `uint64(currentEpoch.PocStartBlockHeight)`, and include the index in the not-found log line so the next mismatch is diagnosable.

## What risks does this introduce? How can we mitigate them?

Query-only change; no state transitions or message handlers touched, so no consensus impact. The behavioral change is that the endpoint now returns the cached capacities it was always meant to return. Consumers already handle the populated case (`common/queryapi/models.go` builds a map from the response), and they already tolerated the empty case, so there is no new failure mode. Mitigation: two keeper tests pin the lookup key and the per-model skip behavior.

## How do you know this PR fixes the problem?

The new tests seed an effective epoch whose index and PoC start height differ, store the root epoch group under the index, cache capacities, and call the query. They fail on the old code and pass with the fix (output below). The full `x/inference/keeper` package passes and `go vet` is clean.

## Which components are affected?

- `inference-chain/x/inference/keeper/query_dynamic_pricing.go`
- `inference-chain/x/inference/keeper/query_dynamic_pricing_test.go` (new)

Downstream readers of the query, unchanged but now receiving data: `common/queryapi/models.go` (`GetAllModelCapacities` wrapper) and its callers in `decentralized-api`.

## Testing & evidence

Run in WSL2 (Ubuntu 22.04, go1.24.2 per the module's `go` directive).

### Before

New tests against the unmodified `query_dynamic_pricing.go`:

```
=== RUN   TestGetAllModelCapacities_LooksUpEpochGroupByIndex
ERROR Failed to get epoch group data for capacity query subsystem=Pricing
    query_dynamic_pricing_test.go:37:
        	Error:      	Not equal:
        	            	expected: []types.ModelCapacity{...{ModelId:"model-a", Capacity:0x3e8}, {ModelId:"model-b", Capacity:0xfa}}
        	            	actual  : []types.ModelCapacity(nil)
--- FAIL: TestGetAllModelCapacities_LooksUpEpochGroupByIndex (0.00s)
=== RUN   TestGetAllModelCapacities_SkipsModelsWithoutCachedCapacity
ERROR Failed to get epoch group data for capacity query subsystem=Pricing
    query_dynamic_pricing_test.go:62:
        	Error:      	Not equal:
        	            	expected: []types.ModelCapacity{types.ModelCapacity{ModelId:"cached", Capacity:0x2a}}
        	            	actual  : []types.ModelCapacity(nil)
--- FAIL: TestGetAllModelCapacities_SkipsModelsWithoutCachedCapacity (0.00s)
FAIL
FAIL	github.com/productscience/inference/x/inference/keeper	0.095s
```

### After

```
=== RUN   TestGetAllModelCapacities_LooksUpEpochGroupByIndex
INFO Retrieved all model capacities totalModels=2 subsystem=Pricing
--- PASS: TestGetAllModelCapacities_LooksUpEpochGroupByIndex (0.00s)
=== RUN   TestGetAllModelCapacities_SkipsModelsWithoutCachedCapacity
WARN Failed to get cached capacity for model modelId=uncached error="capacity not found for model: uncached" subsystem=Pricing
INFO Retrieved all model capacities totalModels=1 subsystem=Pricing
--- PASS: TestGetAllModelCapacities_SkipsModelsWithoutCachedCapacity (0.00s)
PASS
ok  	github.com/productscience/inference/x/inference/keeper	0.154s
```

Full package:

```
$ go vet ./x/inference/keeper/ && go test ./x/inference/keeper/ -count=1
ok  	github.com/productscience/inference/x/inference/keeper	15.725s
```
