### PR TITLE
fix(devshard): restore public catalog probes and storage lifecycle contracts

### DIFF
--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -88,9 +88,8 @@ func main() {
 	}
 }
 
-// registerLiveness mounts GET /{version}/healthz for the gateway catalog
-// wait (same public path as versiond / the versiond-router). GET /health
-// is the container start probe and is not catalog admission.
+// registerLiveness mounts the public gateway catalog probe and its internal
+// router form. GET /health is the container start probe, not catalog admission.
 func registerLiveness(e *echo.Echo, version string) {
 	ok := func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -98,6 +97,7 @@ func registerLiveness(e *echo.Echo, version string) {
 	e.GET("/health", ok)
 	version = strings.Trim(strings.TrimSpace(version), "/")
 	if version != "" {
+		e.GET(devshardpkg.VersionedRoutePrefix(version)+"/healthz", ok)
 		e.GET("/"+version+"/healthz", ok)
 	}
 }

--- a/devshard/cmd/devshard-host/main_test.go
+++ b/devshard/cmd/devshard-host/main_test.go
@@ -13,17 +13,19 @@ func TestRegisterLiveness_ServesVersionedHealthz(t *testing.T) {
 	e := echo.New()
 	registerLiveness(e, "dev")
 
-	for _, path := range []string{"/health", "/dev/healthz"} {
+	for _, path := range []string{"/health", "/devshard/dev/healthz", "/dev/healthz"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code, path)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/v5/healthz", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusNotFound, rec.Code, "other versions must not look admitted")
+	for _, path := range []string{"/devshard/v5/healthz", "/v5/healthz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusNotFound, rec.Code, "other versions must not look admitted")
+	}
 }
 
 func TestGroupFromKeys_DerivesCompactSlotGroup(t *testing.T) {

--- a/devshard/cmd/devshardd/session/storage_contract_test.go
+++ b/devshard/cmd/devshardd/session/storage_contract_test.go
@@ -1,0 +1,107 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/storage"
+)
+
+type storageContractProbe struct {
+	storage.Storage
+	proof func(context.Context, storage.ProofOperation, string) (storage.StorageProof, error)
+	fatal chan error
+}
+
+func (s *storageContractProbe) StorageProof(ctx context.Context, operation storage.ProofOperation, nonce string) (storage.StorageProof, error) {
+	return s.proof(ctx, operation, nonce)
+}
+
+func (s *storageContractProbe) FatalErrors() <-chan error {
+	return s.fatal
+}
+
+func TestHostManagerStorageProofThroughObsRepairGate(t *testing.T) {
+	backend := &storageContractProbe{Storage: storage.NewMemory()}
+	// Match the production retention wrapper followed by NewHostManager's
+	// observation-repair gate. Deployment probes see only the outer store.
+	managed := storage.NewManagedStorage(backend, 3, nil)
+	mgr := NewHostManager(managed, nil, nil, nil, nil, "v5", nil, nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	const nonce = "e76a4079-785f-43ea-94b2-b6773db1b565"
+	want := storage.StorageProof{
+		Identity: "live-database", Found: true,
+		PoolMaxConnections: 4, ServerMaxConnections: 100, ServerReservedConnections: 3,
+	}
+	for _, operation := range []storage.ProofOperation{
+		storage.ProofIdentity, storage.ProofWriteChallenge, storage.ProofReadChallenge,
+	} {
+		t.Run(string(operation), func(t *testing.T) {
+			backend.proof = func(gotCtx context.Context, gotOperation storage.ProofOperation, gotNonce string) (storage.StorageProof, error) {
+				require.Same(t, ctx, gotCtx)
+				require.Equal(t, operation, gotOperation)
+				require.Equal(t, nonce, gotNonce)
+				return want, nil
+			}
+			got, err := mgr.StorageProof(ctx, operation, nonce)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+
+	backend.proof = func(ctx context.Context, _ storage.ProofOperation, _ string) (storage.StorageProof, error) {
+		return storage.StorageProof{}, ctx.Err()
+	}
+	cancel()
+	got, err := mgr.StorageProof(ctx, storage.ProofIdentity, "")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, got, "an unavailable backend must not produce a successful identity proof")
+}
+
+func TestHostManagerStorageFatalErrorsThroughObsRepairGate(t *testing.T) {
+	backend := &storageContractProbe{Storage: storage.NewMemory(), fatal: make(chan error, 1)}
+	managed := storage.NewManagedStorage(backend, 3, nil)
+	mgr := NewHostManager(managed, nil, nil, nil, nil, "v5", nil, nil, nil)
+	fatalErrors := mgr.StorageFatalErrors()
+	require.NotNil(t, fatalErrors, "the process shutdown watcher must receive the backend fatal channel")
+	require.Equal(t, (<-chan error)(backend.fatal), fatalErrors)
+
+	// A repair in progress must not delay the fence-loss notification that
+	// requires devshardd to exit and versiond to replace it.
+	err := mgr.obsGate.RepairValidationObs("escrow-1", func(storage.Storage) error {
+		fenceLost := errors.New("postgres fence session lost")
+		backend.fatal <- fenceLost
+		select {
+		case got := <-fatalErrors:
+			require.ErrorIs(t, got, fenceLost)
+		default:
+			t.Fatal("the fatal storage error did not reach the process shutdown watcher")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, fatalErrors, mgr.StorageFatalErrors(), "the fatal channel must remain stable across repair")
+}
+
+func TestHostManagerStorageWithoutOptionalContracts(t *testing.T) {
+	for _, managed := range []bool{false, true} {
+		name := "direct"
+		var store storage.Storage = storage.NewMemory()
+		if managed {
+			name = "managed"
+			store = storage.NewManagedStorage(store, 3, nil)
+		}
+		t.Run(name, func(t *testing.T) {
+			mgr := NewHostManager(store, nil, nil, nil, nil, "v5", nil, nil, nil)
+			require.True(t, mgr.StorageReady())
+			require.Nil(t, mgr.StorageFatalErrors())
+			proof, err := mgr.StorageProof(context.Background(), storage.ProofIdentity, "")
+			require.EqualError(t, err, "postgres storage proof is unavailable")
+			require.Empty(t, proof)
+		})
+	}
+}

--- a/devshard/storage/obs_repair_gate.go
+++ b/devshard/storage/obs_repair_gate.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
@@ -64,6 +65,24 @@ func (g *ObsRepairGate) Ready() bool {
 		return r.Ready()
 	}
 	return true
+}
+
+// FatalErrors forwards failures that require replacing the owning process.
+func (g *ObsRepairGate) FatalErrors() <-chan error {
+	if reporter, ok := g.Storage.(interface{ FatalErrors() <-chan error }); ok {
+		return reporter.FatalErrors()
+	}
+	return nil
+}
+
+// StorageProof preserves access to the live PostgreSQL backend through the
+// observation-repair wrapper.
+func (g *ObsRepairGate) StorageProof(ctx context.Context, operation ProofOperation, nonce string) (StorageProof, error) {
+	provider, ok := g.Storage.(ProofProvider)
+	if !ok {
+		return StorageProof{}, errPostgresProofUnavailable
+	}
+	return provider.StorageProof(ctx, operation, nonce)
 }
 
 // PruneCutoff forwards the managed-storage retention horizon so recovery can

--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -301,10 +301,11 @@ type oneShotHooks struct {
 	heightSyncMutate func(*heightsync.HeightSyncSection, uint64)
 }
 
-// CatalogHealthzURL is GET /{version}/healthz at this client's host base
-// (the versiond-router catalog probe). Empty when the client has no
-// versioned prefix or base URL. The GET is unsigned and is not an
-// inference request.
+// CatalogHealthzURL is GET /devshard/{version}/healthz at this client's
+// public host base. The public proxy strips /devshard/ before forwarding
+// to the versiond-router catalog probe; direct routers accept either form.
+// Empty when the client has no valid versioned prefix or base URL. The GET
+// is unsigned and is not an inference request.
 func (c *HTTPClient) CatalogHealthzURL() string {
 	if c == nil {
 		return ""
@@ -317,7 +318,7 @@ func (c *HTTPClient) CatalogHealthzURL() string {
 	if base == "" {
 		return ""
 	}
-	return base + devshardpkg.RouterCatalogHealthzPath(version)
+	return base + devshardpkg.VersionedRoutePrefix(version) + "/healthz"
 }
 
 // NewHTTPClient creates an HTTP client for the devshard transport layer.

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 
+	devshardpkg "devshard"
 	"devshard/host"
 	"devshard/internal/testutil"
 	"devshard/signing"
@@ -69,10 +70,23 @@ func setupClientTestEnv(t *testing.T) (*HTTPClient, *httptest.Server, *signing.S
 }
 
 func TestHTTPClient_CatalogHealthzURL(t *testing.T) {
-	cfg := DefaultClientConfig()
-	cfg.RoutePrefix = "/devshard/v2"
-	c := NewHTTPClient("http://router:8080", "1", nil, cfg)
-	require.Equal(t, "http://router:8080/v2/healthz", c.CatalogHealthzURL())
+	for _, tc := range []struct {
+		name, base, prefix, want string
+	}{
+		{"public host", "https://host.example", "/devshard/v2", "https://host.example/devshard/v2/healthz"},
+		{"direct router", "http://router:8080", "/devshard/v2", "http://router:8080/devshard/v2/healthz"},
+		{"normalized", " https://host.example/ ", " /devshard/v2/ ", "https://host.example/devshard/v2/healthz"},
+		{"default version", "https://host.example", "", "https://host.example" + devshardpkg.DefaultRoutePrefix() + "/healthz"},
+		{"empty base", " ", "/devshard/v2", ""},
+		{"invalid prefix", "https://host.example", "/other/v2", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultClientConfig()
+			cfg.RoutePrefix = tc.prefix
+			c := NewHTTPClient(tc.base, "1", nil, cfg)
+			require.Equal(t, tc.want, c.CatalogHealthzURL())
+		})
+	}
 	require.Empty(t, (*HTTPClient)(nil).CatalogHealthzURL())
 }
 

--- a/devshard/user/catalog.go
+++ b/devshard/user/catalog.go
@@ -15,12 +15,13 @@ type catalogHealthzSource interface {
 	CatalogHealthzURL() string
 }
 
-// WaitRouterCatalog polls GET /{version}/healthz on each HTTP client's host
-// base until one returns 200 or ctx is done. That path is catalog admission
-// on the versiond-router, child health on versiond, and the matching probe
-// on e2e hosts. 503, 404, and dial errors keep waiting — root /healthz is
-// never consulted (router process-up is not this version). In-process
-// clients have no catalog URL and return immediately.
+// WaitRouterCatalog polls GET /devshard/{version}/healthz on each HTTP
+// client's public host base until one returns 200 or ctx is done. The public
+// proxy forwards it to the versiond-router catalog probe /{version}/healthz.
+// Direct routers and e2e hosts also accept the public path. 503, 404, and
+// dial errors keep waiting — root /healthz is never consulted (router
+// process-up is not this version). In-process clients have no catalog URL
+// and return immediately.
 func (s *Session) WaitRouterCatalog(ctx context.Context) error {
 	if s == nil {
 		return nil
@@ -85,7 +86,7 @@ const (
 	catalogProbeAdmitted
 )
 
-// probeRouterCatalog classifies GET /{version}/healthz on the HTTP client bases.
+// probeRouterCatalog classifies the public catalog probes on the HTTP client bases.
 // 200 means this version is serving. Anything else keeps waiting.
 func probeRouterCatalog(client *http.Client, urls []string) catalogProbe {
 	if len(urls) == 0 {

--- a/devshard/user/catalog_test.go
+++ b/devshard/user/catalog_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -27,7 +29,7 @@ func TestWaitRouterCatalog_InProcessSkips(t *testing.T) {
 func TestWaitRouterCatalog_WaitsUntil200(t *testing.T) {
 	var ready atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/healthz" {
+		if r.URL.Path != "/devshard/v2/healthz" {
 			http.NotFound(w, r)
 			return
 		}
@@ -53,6 +55,50 @@ func TestWaitRouterCatalog_WaitsUntil200(t *testing.T) {
 	require.NoError(t, <-errCh)
 }
 
+func TestWaitRouterCatalog_ThroughPublicProxy(t *testing.T) {
+	var ready atomic.Bool
+	var catalogRequests atomic.Int32
+	router := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		catalogRequests.Add(1)
+		if !ready.Load() {
+			http.Error(w, "undeclared", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(router.Close)
+	target, err := url.Parse(router.URL)
+	require.NoError(t, err)
+	// Match the public nginx contract: only /devshard/ reaches the router,
+	// and the prefix is removed before forwarding. Bare /v2/healthz is 404.
+	publicMux := http.NewServeMux()
+	publicMux.Handle("/devshard/", http.StripPrefix("/devshard", httputil.NewSingleHostReverseProxy(target)))
+	public := httptest.NewServer(publicMux)
+	t.Cleanup(public.Close)
+
+	cfg := transport.DefaultClientConfig()
+	cfg.RoutePrefix = "/devshard/v2"
+	client := transport.NewHTTPClient(public.URL, "1", nil, cfg)
+	session := &Session{clients: []HostClient{client}, escrowID: "1"}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- session.WaitRouterCatalog(ctx) }()
+	require.Eventually(t, func() bool { return catalogRequests.Load() > 0 }, time.Second, 10*time.Millisecond,
+		"gateway catalog probe must reach the router through the public prefix")
+	select {
+	case err := <-errCh:
+		t.Fatalf("catalog wait returned before the router admitted the version: %v", err)
+	default:
+	}
+	ready.Store(true)
+	require.NoError(t, <-errCh)
+}
+
 func TestHeartbeatLoop_WaitsForCatalogBeforeFirstTick(t *testing.T) {
 	var height uint64 = 100
 	session := setupBlindHeartbeatSession(t, &height,
@@ -64,7 +110,7 @@ func TestHeartbeatLoop_WaitsForCatalogBeforeFirstTick(t *testing.T) {
 
 	var ready atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/healthz" {
+		if r.URL.Path != "/devshard/v2/healthz" {
 			http.NotFound(w, r)
 			return
 		}
@@ -113,12 +159,12 @@ func TestWaitRouterCatalog_404IsNotAdmission(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
 	defer cancel()
 	require.ErrorIs(t, session.WaitRouterCatalog(ctx), context.DeadlineExceeded,
-		"root /health and /healthz must not count as /{version}/healthz")
+		"root /health and /healthz must not count as /devshard/{version}/healthz")
 }
 
 func TestWaitRouterCatalog_Catalog503KeepsWaiting(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2/healthz" {
+		if r.URL.Path == "/devshard/v2/healthz" {
 			http.Error(w, "undeclared", http.StatusServiceUnavailable)
 			return
 		}

--- a/devshard/user/heightsync_seed_test.go
+++ b/devshard/user/heightsync_seed_test.go
@@ -110,7 +110,7 @@ func setupSeedSession(t *testing.T, seedRPC []bool, opts ...SessionOption) *seed
 		srv, err := transport.NewServer(h, store, verifier, user.Address(), serverOpts...)
 		require.NoError(t, err)
 		e := echo.New()
-		e.GET("/v2/healthz", func(c echo.Context) error {
+		e.GET("/devshard/v2/healthz", func(c echo.Context) error {
 			return c.NoContent(http.StatusOK)
 		})
 		g := e.Group(seedTestRoutePrefix)
@@ -276,7 +276,7 @@ func TestSeed_DeclinedSlotsAreReprobed(t *testing.T) {
 	var hits atomic.Int32
 	inner := env.slots[0].server.Config.Handler
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2/healthz" {
+		if r.URL.Path == "/devshard/v2/healthz" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -556,7 +556,7 @@ func TestSeed_Gap1DeclinedMakesMissedThenReprobeSucceeds(t *testing.T) {
 		i := i
 		inner := env.slots[i].server.Config.Handler
 		proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/v2/healthz" {
+			if r.URL.Path == "/devshard/v2/healthz" {
 				w.WriteHeader(http.StatusOK)
 				return
 			}
@@ -606,7 +606,7 @@ func TestSeed_Gap2ClockStartsAfterCatalog(t *testing.T) {
 	var seedHits atomic.Int32
 	inner := env.slots[0].server.Config.Handler
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2/healthz" {
+		if r.URL.Path == "/devshard/v2/healthz" {
 			if !catalogReady.Load() {
 				http.Error(w, "undeclared", http.StatusServiceUnavailable)
 				return
@@ -652,7 +652,7 @@ func TestSeed_Gap4AdmissionErrorIsRetryLater(t *testing.T) {
 	admission := &seedTestAdmission{err: fmt.Errorf("participant request budget exhausted")}
 	inner := env.slots[0].server.Config.Handler
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2/healthz" {
+		if r.URL.Path == "/devshard/v2/healthz" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}


### PR DESCRIPTION
Gateway catalog admission used the internal `/<version>/healthz` path on the public host URL, which returned 404 behind the join proxy and prevented inference from starting. Use `/devshard/<version>/healthz`, matching the public proxy's prefix stripping. Preserve direct router probes and update the standalone test host and gateway fixtures.

`ObsRepairGate` hid the backend's optional `StorageProof` and `FatalErrors` methods from `HostManager`. This made updater storage checks return 503 and left a child alive but unready after losing its PostgreSQL fence. Forward both contracts through the wrapper, preserving errors, cancellation and unsupported-backend behavior.

Validation:

- Gateway URL, public proxy admission, heartbeat, standalone host and height-seed tests passed. Restoring the original gateway method made the new proxy regression fail.
- HostManager regressions through `ManagedStorage → ObsRepairGate` failed before the storage fix and passed afterward, covering identity/write/read proofs, cancellation, fatal errors during repair and unsupported backends. Existing observation-repair and application fatal-exit tests also passed.
- A fresh isolated Docker deployment used this branch's production devshardd/gateway builds and the unchanged #1611 deployment integration at `9a4ec48886`, with new PostgreSQL data, keys and binary caches. Chain/dapi/ML were project mocks; supervisors downloaded and verified the v5 ZIP normally.
- Startup, three-slot fleet admission, gateway inference, same-escrow continuation after stopping the serving member, and updater `--check` with database challenges all passed without a proxy alias or probe bypass.
- Terminating the actual PostgreSQL fence connection replaced child PID 94 with PID 218 and proof generation 1 with 2. Readiness recovered in 6 seconds with the same database identity. The replacement served a fresh inference; admission and updater preflight passed again afterward.

The fresh run also exposed a separate concurrent payload-table initialization race (`SQLSTATE 23505`); versiond recovered automatically after its startup timeout. That race is not changed here. The run did not validate published release images, an actual updater rollout, production chain integration or uninterrupted in-flight SSE.
