### PR TITLE
test(devshard): cover unjoined versiond router fleet

### DIFF
--- a/devshard/testenv/Makefile
+++ b/devshard/testenv/Makefile
@@ -71,6 +71,7 @@ dev-logs: ## Follow dev overlay logs.
 
 .PHONY: citest-images citest-stack citest-stack-build list-citest-targets
 .PHONY: citest-validation-lease-race citest-escrow-longpoll
+.PHONY: citest-unjoined-router-fleet
 .PHONY: citest-versiond-rolling-update citest-versiond-host-evacuation citest-adversarial citest-payload-withholding
 .PHONY: citest-observability citest-grpc-transport citest-force-upstream-streaming citest-height-sync citest-height-sync-dapi-compat citest-host-ping test-gateway-smoke
 
@@ -92,6 +93,11 @@ citest-images: gen-compose ## Pull hub images and build all compose images requi
 
 citest-stack: citest-images ## Full stack behavior citests (needs Docker + build-devshardd).
 	TESTENV_CITEST=1 go test -tags=testenvci ./citest/ -run '$(STACK_CITEST_PATTERN)' -count=1 -v -timeout 90m
+
+citest-unjoined-router-fleet: gen-compose ## Two real routers agree on file-backed versiond membership across disjoint networks (#1733).
+	docker compose $(COMPOSE_BASE) pull devshard-postgres
+	docker compose $(COMPOSE_BASE) build mock-chain mock-dapi mock-openai versiond-router versiond-0
+	TESTENV_CITEST=1 go test -tags=testenvci ./citest/ -run '^TestUnjoinedRouterFleet$$' -count=1 -v -timeout 20m
 
 citest-validation-lease-race: citest-images ## Validation lease race, pending stretch, and stale reclaim.
 	TESTENV_CITEST=1 go test -tags=testenvci ./citest/ -run '^TestValidationLeaseRace' -count=1 -v -timeout 45m

--- a/devshard/testenv/citest/harness/unjoined_router_fleet.go
+++ b/devshard/testenv/citest/harness/unjoined_router_fleet.go
@@ -1,0 +1,203 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// VersiondEndpoint is a member of the routers' explicit endpoint file.
+type VersiondEndpoint struct {
+	ID   string `json:"id"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+func (e VersiondEndpoint) Address() string {
+	return net.JoinHostPort(e.Host, strconv.Itoa(e.Port))
+}
+
+// UnjoinedRouterFleet separates real PostgreSQL-backed versionds from routers
+// into two Compose projects. Neither project includes a gateway/public proxy.
+type UnjoinedRouterFleet struct {
+	Versionds  *Stack
+	Routers    *Stack
+	Version    string
+	RouterHTTP []string
+	Endpoints  []VersiondEndpoint
+}
+
+// BootUnjoinedRouterFleet reaches versionds only through Docker-host published
+// ports. A single literal host address keeps the addr-keyed rings comparable;
+// comparing container IPs or matching only the port would hide a wrong route.
+func BootUnjoinedRouterFleet(t *testing.T) *UnjoinedRouterFleet {
+	t.Helper()
+	versionds := NewStack(t, "citest-unjoined-versionds-*")
+	RequireLinuxDevshardd(t, versionds.TestenvDir)
+	WriteStackConfig(t, versionds.WorkDir)
+	versionds.RunGencompose(t)
+	cfg := versionds.LoadConfig(t)
+	requireTwoVersiondHosts(t, cfg)
+	require.True(t, cfg.Postgres.Enabled, "unjoined routers require the real HA pair")
+	prepareUnjoinedVersionds(t, versionds.ComposePath)
+	versionds.UpServices(t, false, "versiond-0", "versiond-1")
+	t.Cleanup(func() {
+		if t.Failed() {
+			DumpComposeLogs(t, versionds)
+		}
+	})
+
+	// On the Linux CI daemon the default bridge gateway is the Docker host,
+	// not either project's network. Ports must bind beyond loopback so routers
+	// can dial this address. The test itself still probes them on localhost.
+	host := strings.TrimSpace(unjoinedDockerOutput(t, "network", "inspect", "bridge",
+		"--format", "{{(index .IPAM.Config 0).Gateway}}"))
+	ip := net.ParseIP(host)
+	require.NotNil(t, ip, "Docker bridge gateway must be a literal IP: %q", host)
+	require.False(t, ip.IsLoopback() || ip.IsUnspecified(), "invalid Docker host address %q", host)
+	fleet := &UnjoinedRouterFleet{Versionds: versionds, Version: cfg.Versiond.VersionName}
+	client := HTTPClient()
+	for _, member := range cfg.Hosts {
+		addr := versionds.composePublishedAddr(t, member.ID, 8080)
+		_, port, err := net.SplitHostPort(addr)
+		require.NoError(t, err)
+		p, err := strconv.Atoi(port)
+		require.NoError(t, err)
+		fleet.Endpoints = append(fleet.Endpoints, VersiondEndpoint{ID: member.ID, Host: host, Port: p})
+		WaitGETOK(t, client, "http://"+addr+"/readyz", 5*time.Minute, member.ID+" readiness")
+		WaitGETOK(t, client, "http://"+addr+"/"+fleet.Version+"/healthz", 5*time.Minute, member.ID+" child health")
+	}
+
+	routers := NewStack(t, "citest-unjoined-routers-*")
+	fleet.Routers = routers
+	body, err := os.ReadFile(filepath.Join(routers.TestenvDir, "docker-compose.unjoined-routers.yml"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(routers.ComposePath, body, 0o644))
+	fixComposePaths(t, routers.ComposePath, routers.TestenvDir)
+	require.NoError(t, os.WriteFile(filepath.Join(routers.WorkDir, ".env"),
+		[]byte("TESTENV_UNJOINED_VERSION="+fleet.Version+"\n"), 0o644))
+	endpoints, err := json.MarshalIndent(fleet.Endpoints, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(routers.WorkDir, "versiond-endpoints.json"), endpoints, 0o644))
+	Step(t, "explicit versiond membership: %s", endpoints)
+	routers.UpServices(t, false, "versiond-router-0", "versiond-router-1")
+	t.Cleanup(func() {
+		if t.Failed() {
+			DumpComposeLogs(t, routers)
+		}
+	})
+	for _, service := range []string{"versiond-router-0", "versiond-router-1"} {
+		fleet.requireUnjoinedRouter(t, service, endpoints)
+		url := "http://" + routers.composePublishedAddr(t, service, 8080)
+		fleet.RouterHTTP = append(fleet.RouterHTTP, url)
+		WaitGETOK(t, client, url+"/healthz", 5*time.Minute, service+" health")
+		admin := "http://" + routers.composePublishedAddr(t, service, 8404)
+		WaitGETOK(t, client, admin+"/readyz?version="+fleet.Version, 5*time.Minute, service+" version readiness")
+		fleet.waitFullPool(t, service)
+	}
+	return fleet
+}
+
+func prepareUnjoinedVersionds(t *testing.T, path string) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var model map[string]any
+	require.NoError(t, yaml.Unmarshal(body, &model))
+	services := model["services"].(map[string]any)
+	delete(services, "versiond-router")
+	delete(services, gatewayComposeService)
+	if volumes, ok := model["volumes"].(map[string]any); ok {
+		delete(volumes, "versiond-router-state")
+	}
+	for _, name := range []string{"versiond-0", "versiond-1"} {
+		service := services[name].(map[string]any)
+		service["ports"] = []string{"8080"} // Random host port on all interfaces.
+		service["environment"].(map[string]any)["GONKA_HA"] = "true"
+	}
+	body, err = yaml.Marshal(model)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, body, 0o644))
+}
+
+func (f *UnjoinedRouterFleet) requireUnjoinedRouter(t *testing.T, service string, endpoints []byte) {
+	t.Helper()
+	routerID := f.Routers.ContainerID(t, service)
+	routerNetworks := unjoinedContainerNetworks(t, routerID)
+	require.Len(t, routerNetworks, 1, "router must have only its own network")
+	for _, endpoint := range f.Endpoints {
+		for network := range unjoinedContainerNetworks(t, f.Versionds.ContainerID(t, endpoint.ID)) {
+			require.NotContains(t, routerNetworks, network, "%s shares a network with %s", service, endpoint.ID)
+		}
+	}
+	// Check that name lookup actually works before asserting pool DNS fails.
+	_, err := f.Routers.ComposeExecOutput(service, "getent", "hosts", "localhost")
+	require.NoError(t, err)
+	out, err := f.Routers.ComposeExecOutput(service, "getent", "hosts", "versiond-pool")
+	require.Error(t, err, "%s unexpectedly resolved versiond-pool: %s", service, out)
+	out, err = f.Routers.ComposeExecOutput(service, "cat", "/etc/haproxy/versiond-endpoints.json")
+	require.NoError(t, err)
+	require.JSONEq(t, string(endpoints), out, "%s must use the canonical membership file", service)
+	Step(t, "%s has no network shared with versionds and cannot resolve versiond-pool", service)
+}
+
+func unjoinedContainerNetworks(t *testing.T, id string) map[string]json.RawMessage {
+	t.Helper()
+	out := unjoinedDockerOutput(t, "inspect", "--format", "{{json .NetworkSettings.Networks}}", id)
+	var networks map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(out), &networks))
+	require.NotEmpty(t, networks)
+	return networks
+}
+
+func unjoinedDockerOutput(t *testing.T, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	require.NoError(t, err, "docker %v: %s", args, out)
+	return string(out)
+}
+
+func (f *UnjoinedRouterFleet) waitFullPool(t *testing.T, service string) {
+	t.Helper()
+	var diagnostic string
+	ok := AssertEventually(t, time.Minute, time.Second, func() bool {
+		out, err := f.Routers.ComposeExecOutput(service, "sh", "-c", routerVersionMapQuery)
+		if err != nil {
+			diagnostic = out
+			return false
+		}
+		backend, err := parseRouterVersionBackend(out, f.Version)
+		if err != nil {
+			diagnostic = err.Error()
+			return false
+		}
+		out, err = f.Routers.ComposeExecOutput(service, routerPoolStatusBin)
+		diagnostic = out
+		if err != nil {
+			return false
+		}
+		// pool-status reports an IP without its port, so both published
+		// endpoints have the same Address here. Count ready server slots;
+		// the test checks full canonical addresses in X-Upstream-Addr.
+		ready := 0
+		for _, slot := range parseRouterPool(out) {
+			if slot.Backend == backend && slot.State == RouterSlotUp {
+				ready++
+			}
+		}
+		return ready == len(f.Endpoints)
+	})
+	require.True(t, ok, "%s did not admit both endpoint slots:\n%s", service, diagnostic)
+}

--- a/devshard/testenv/citest/unjoined_router_fleet_test.go
+++ b/devshard/testenv/citest/unjoined_router_fleet_test.go
@@ -1,0 +1,68 @@
+//go:build testenvci
+
+package citest
+
+import (
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"devshard/testenv/citest/harness"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnjoinedRouterFleet covers #1733 independently of the shared-network
+// stack: real routers/versionds, file membership only, cross-router affinity.
+func TestUnjoinedRouterFleet(t *testing.T) {
+	harness.SkipUnlessEnv(t, "TESTENV_CITEST")
+	harness.RequireDocker(t)
+	fleet := harness.BootUnjoinedRouterFleet(t)
+	client := &http.Client{Timeout: 3 * time.Second}
+	sessionA, upstreamA, sessionB, upstreamB := harness.FindDistinctStickySessions(t, client, fleet.RouterHTTP[0], fleet.Version)
+	require.ElementsMatch(t, []string{fleet.Endpoints[0].Address(), fleet.Endpoints[1].Address()}, []string{upstreamA, upstreamB})
+	// Always stop versiond-0, regardless of which session the search found first.
+	if upstreamA != fleet.Endpoints[0].Address() {
+		sessionA, sessionB = sessionB, sessionA
+		upstreamA, upstreamB = upstreamB, upstreamA
+	}
+	assertSticky := func(session, want string) {
+		t.Helper()
+		for _, router := range fleet.RouterHTTP {
+			url := harness.RouterSessionURL(router, fleet.Version, session, "/healthz")
+			for retry := 0; retry < 8; retry++ {
+				resp, err := client.Get(url)
+				require.NoError(t, err)
+				_, readErr := io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+				require.NoError(t, readErr)
+				// devshardd exposes /healthz, but not /sessions/:id/healthz.
+				// These synthetic paths exercise the router's session hash;
+				// an upstream 404 is expected with today's application routes.
+				// Boot separately requires HTTP 200 from each child's /healthz.
+				require.Contains(t, []int{http.StatusOK, http.StatusNotFound}, resp.StatusCode,
+					"router=%s session=%s retry=%d", router, session, retry)
+				require.Equal(t, want, resp.Header.Get(harness.StickyUpstreamHeader), "router=%s session=%s retry=%d", router, session, retry)
+			}
+		}
+	}
+	harness.Step(t, "both routers must agree on %s -> %s and %s -> %s", sessionA, upstreamA, sessionB, upstreamB)
+	assertSticky(sessionA, upstreamA)
+	assertSticky(sessionB, upstreamB)
+
+	harness.Step(t, "stop versiond-0; both routers must fail over within the same 45s window")
+	fleet.Versionds.StopService(t, "versiond-0")
+	deadline := time.Now().Add(45 * time.Second)
+	for _, router := range fleet.RouterHTTP {
+		remaining := time.Until(deadline)
+		require.Positive(t, remaining, "both routers must converge within one failover window")
+		url := harness.RouterSessionURL(router, fleet.Version, sessionA, "/healthz")
+		harness.WaitStickyFailoverToSurvivor(t, client, url, upstreamA, upstreamB, remaining)
+	}
+	// Require final exact peer equality: a retry history alone must not satisfy
+	// the older, deliberately permissive failover helper.
+	assertSticky(sessionA, upstreamB)
+	assertSticky(sessionB, upstreamB)
+	harness.Step(t, "both routers converged on survivor %s; its existing session retained its mapping", upstreamB)
+}

--- a/devshard/testenv/docker-compose.unjoined-routers.yml
+++ b/devshard/testenv/docker-compose.unjoined-routers.yml
@@ -1,0 +1,33 @@
+# Router-only project for citest-unjoined-router-fleet (#1733).
+# The harness writes the same endpoint file for both slots. Its addresses are
+# Docker-host published ports, reachable without joining the versiond network.
+x-router: &router
+  build:
+    context: ../..
+    dockerfile: versiond-router/Dockerfile
+  image: devshard-versiond-router:latest
+  environment:
+    GONKA_HA: "true"
+    VERSIOND_POOL_ENDPOINTS_FILE: /etc/haproxy/versiond-endpoints.json
+    VERSIOND_NON_HA_VERSIONS: ""
+    VERSIOND_VERSIONS: ${TESTENV_UNJOINED_VERSION:?test protocol required}
+    VERSIOND_ROUTING_ACTIVATION_MIN_READY: "2"
+    VERSIOND_ROUTING_CATALOG_URL: ""
+  volumes:
+    - ./versiond-endpoints.json:/etc/haproxy/versiond-endpoints.json:ro
+  ports:
+    - "127.0.0.1::8080"
+    - "127.0.0.1::8404"
+  networks:
+    - routers
+  stop_grace_period: 5s
+
+services:
+  versiond-router-0:
+    <<: *router
+  versiond-router-1:
+    <<: *router
+
+networks:
+  routers:
+    driver: bridge

--- a/devshard/testenv/docs/scenarios.md
+++ b/devshard/testenv/docs/scenarios.md
@@ -1,8 +1,9 @@
 # Stack citest scenarios
 
-Implemented Go integration tests for the devshard testenv v2 stack. Each scenario
-boots a real Docker Compose stack (mock-chain, mock-dapi, mock-openai, versiond × 2,
-versiond-router, devshardctl, Postgres) and asserts production-like behaviour end to end.
+Implemented Go integration tests for the devshard testenv v2 stack. Most scenarios
+boot a real Docker Compose stack (mock-chain, mock-dapi, mock-openai, versiond × 2,
+versiond-router, devshardctl, Postgres) and assert production-like behaviour end to end.
+The unjoined-router scenario uses two separate Compose projects, described below.
 
 **Design history:** [`testenv-v2-plan.md`](./testenv-v2-plan.md) (planning doc; scenarios below are what shipped).
 
@@ -34,6 +35,7 @@ HTTP/gRPC helpers, log dump on failure.
 cd devshard/testenv
 make build-devshardd
 make citest-stack                 # all core stack behavior tests
+make citest-unjoined-router-fleet # two routers, explicit endpoints, separate networks
 make citest-validation-lease-race # validation lease race only
 make citest-payload-withholding   # executor payload withholding (500 → invalidate)
 make citest-versiond-rolling-update
@@ -72,6 +74,7 @@ picked up automatically (no workflow edit). For a local sequential subset, use
 |----------|------------------|------|
 | **Stack smoke** | Full stack boots; all boundaries healthy | `TestStackSmoke` |
 | **Router stickiness** | Same session → same versiond upstream | `TestRouterStickiness` |
+| **Unjoined router fleet** | Two routers on a separate network agree on explicit versiond endpoints and failover | `TestUnjoinedRouterFleet` |
 | **Params long-poll** | Governance patch wakes `GetRuntimeConfig` | `TestParamsLongPoll` |
 | **Epoch switch** | Epoch advance fast-forwards chain + bumps epoch in long-poll | `TestEpochSwitch` |
 | **Gateway chat** | devshardctl → router → devshardd → mock-openai (stream + non-stream) | `TestGatewayChat` |
@@ -162,6 +165,52 @@ versiond across repeated requests, and at least two distinct upstreams are reach
 
 **Pass criteria:** Stable upstream for session A; at least one session B routes elsewhere.
 Validates deploy/join-style sticky routing before chat or long-poll scenarios depend on it.
+
+---
+
+## Unjoined router fleet
+
+**What we test:** Two real versiond-routers use `VERSIOND_POOL_ENDPOINTS_FILE`
+to reach the same PostgreSQL-backed versiond pair without sharing its Docker
+network. This covers the missing cross-router routing check in
+[issue #1733](https://github.com/gonka-ai/gonka/issues/1733).
+
+**Topology:** Compose A contains two versionds, shared Postgres, and the three
+mocks. Compose B contains two HAProxy routers from
+[`docker-compose.unjoined-routers.yml`](../docker-compose.unjoined-routers.yml).
+Both routers mount the same endpoint JSON. Each endpoint uses the Linux Docker
+daemon's default bridge gateway address and a versiond's randomly published host
+port. Neither router joins a network belonging to Compose A. The scenario uses
+static version configuration and does not start a gateway, public proxy, or
+the fleet CLI. It does not create sessions or run chat, height-sync, or host-ping
+scenarios.
+
+**How:**
+
+1. Wait for both versionds' `/readyz` and `/<version>/healthz`.
+2. Write the canonical `{id, host, port}` entries and start both routers. Verify
+   their network attachments are disjoint from the versionds', their mounted
+   endpoint files match, and `getent hosts versiond-pool` fails inside each router.
+3. Wait for each router's `/healthz`, per-version `/readyz`, and both endpoints
+   to be `UP` in its version backend.
+4. Find two session IDs assigned to different versionds. For each session, send
+   eight `/<version>/sessions/<session>/healthz` requests through each router.
+   Require the exact same canonical `X-Upstream-Addr` on every request. These
+   synthetic session paths currently return an upstream 404 because devshardd
+   only registers `/healthz`; HTTP 200 is also accepted, but gateway failures and
+   other status codes fail the test. Child readiness was checked separately.
+5. Stop `versiond-0`. Within one shared 45-second window, both routers must send
+   its session to `versiond-1`. Repeat the eight-request checks for both sessions:
+   the moved session reaches the survivor, and the survivor's session stays there.
+
+**Pass criteria:** Membership comes from the endpoint file, both routers agree
+on the full upstream address, both versionds receive traffic before the stop,
+and both routers converge on the survivor afterward. Failures dump both Compose
+projects' logs.
+
+Run `make build-devshardd` then `make citest-unjoined-router-fleet` on a Linux
+Docker daemon. This is a separate auto-discovered CI matrix target and is not
+included in `citest-stack`.
 
 ---
 


### PR DESCRIPTION
Existing real-stack tests exercise one router on a shared Docker network. They do not verify that independent routers agree on session routing when versiond membership comes from `VERSIOND_POOL_ENDPOINTS_FILE`.

Add `citest-unjoined-router-fleet` as a separate, automatically discovered CI suite. It starts two real HAProxy routers and two PostgreSQL-backed versionds in disjoint Compose networks, connected through host-published ports. The test checks network separation, failed `versiond-pool` DNS lookup, identical endpoint files, readiness, and exact `X-Upstream-Addr` agreement across repeated requests to both members. After stopping versiond-0, both routers must converge on versiond-1 within one shared 45-second window, while its existing session mapping stays stable.

The scenario uses synthetic session paths for hashing. Their upstream 404 is expected because devshardd registers `/healthz`, not `/sessions/:id/healthz`; child health and readiness must independently return HTTP 200. The scenario and run command are documented in `testenv/docs/scenarios.md`.

Validation:

- `TestUnjoinedRouterFleet` with freshly built versiond, devshardd, router, and mock images in an isolated Docker-in-Docker environment (Alpine/musl): **PASS, 27.09s**.
- `go test ./testenv/... -count=1`: **PASS**.
- Confirmed `list-citest-targets` discovers the new suite independently of `citest-stack`.

Refs #1733.
