### PR TITLE
fix(devshard): clear host ping on release and retire past host prune

### DIFF
--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -881,6 +881,7 @@ const (
 // checkBalances scans all active runtimes and deactivates any whose
 // escrow is close to exhausting its usable balance or nonce budget.
 func (g *Gateway) checkBalances() {
+	g.retireExpiredEpochEscrows()
 	g.mu.Lock()
 	if !g.settings.EscrowRotation.Enabled {
 		g.mu.Unlock()
@@ -4049,6 +4050,54 @@ func (g *Gateway) sortRuntimeOrderLocked() {
 	slices.SortFunc(g.runtimeOrder, func(a, b *devshardRuntime) int {
 		return strings.Compare(a.id, b.id)
 	})
+}
+
+const epochRetentionRetireReason = "epoch retention prune"
+
+// retireExpiredEpochEscrows drops gateway runtimes whose creation epoch is
+// below the host prune cutoff (retain 3: current + two previous). Settlement
+// is not attempted: chain settle only accepts current or previous epoch.
+func (g *Gateway) retireExpiredEpochEscrows() {
+	if g == nil || g.phaseGate == nil {
+		return
+	}
+	current := g.phaseGate.Snapshot().EpochIndex
+	cutoff := storage.RetentionCutoff(current, storage.DefaultEpochRetain)
+	if cutoff == 0 {
+		return
+	}
+
+	g.mu.Lock()
+	type expired struct {
+		id            string
+		creationEpoch uint64
+	}
+	var stale []expired
+	for _, rt := range g.runtimeOrder {
+		if rt == nil || rt.creationEpoch == 0 || rt.creationEpoch >= cutoff {
+			continue
+		}
+		// Settlement owns the runtime until it succeeds, hits ErrEscrowSettled or
+		// exhausts its retries; every one of those paths retires. Closing the
+		// runtime's store underneath an in-flight settle would strand the funds.
+		if rt.settlementPending.Load() {
+			continue
+		}
+		// runtimeDrained fires the deferred retire once requests finish; without
+		// this the 30s tick re-logs the same deferral until the runtime drains.
+		if rt.retirePending.Load() {
+			continue
+		}
+		stale = append(stale, expired{id: rt.id, creationEpoch: rt.creationEpoch})
+	}
+	g.mu.Unlock()
+
+	for _, e := range stale {
+		log.Printf("escrow_epoch_retention_retire escrow=%s creation_epoch=%d current_epoch=%d cutoff=%d",
+			e.id, e.creationEpoch, current, cutoff)
+		g.deactivateDevshardByIDWithReason(e.id, epochRetentionRetireReason)
+		g.retireRuntime(e.id, epochRetentionRetireReason)
+	}
 }
 
 // retireRuntime drops a runtime from the in-memory registry and closes it,

--- a/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
+++ b/devshard/cmd/devshardctl/gateway_runtime_retire_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"devshard/bridge"
+	"devshard/storage"
 )
 
 // newRetireTestGateway builds a minimal Gateway holding a single active runtime
@@ -28,6 +29,110 @@ func newRetireTestGateway(id string) (*Gateway, *devshardRuntime) {
 		rotationBreakers: make(map[string]*rotationBreaker),
 	}
 	return g, rt
+}
+
+func TestRetentionCutoffMatchesHostPruneHorizon(t *testing.T) {
+	require.Equal(t, uint64(0), storage.RetentionCutoff(1, storage.DefaultEpochRetain))
+	require.Equal(t, uint64(0), storage.RetentionCutoff(2, storage.DefaultEpochRetain))
+	require.Equal(t, uint64(1), storage.RetentionCutoff(3, storage.DefaultEpochRetain))
+	require.Equal(t, uint64(8), storage.RetentionCutoff(10, storage.DefaultEpochRetain))
+}
+
+func TestRetireExpiredEpochEscrowsDropsPastHostCutoff(t *testing.T) {
+	stale := &devshardRuntime{id: "stale", creationEpoch: 7}
+	stale.active.Store(true)
+	kept := &devshardRuntime{id: "kept", creationEpoch: 8}
+	kept.active.Store(true)
+	unspecified := &devshardRuntime{id: "unspecified", creationEpoch: 0}
+	unspecified.active.Store(true)
+
+	g := &Gateway{
+		runtimes: map[string]*devshardRuntime{
+			stale.id:       stale,
+			kept.id:        kept,
+			unspecified.id: unspecified,
+		},
+		runtimeOrder:     []*devshardRuntime{stale, kept, unspecified},
+		rotationBreakers: make(map[string]*rotationBreaker),
+		phaseGate:        &ChainPhaseGate{},
+	}
+	g.phaseGate.storeSnapshot(ChainPhaseSnapshot{EpochIndex: 10})
+
+	g.retireExpiredEpochEscrows()
+
+	_, staleRegistered := g.runtimes[stale.id]
+	require.False(t, staleRegistered, "epoch 7 is below cutoff 8 when current=10 retain=3")
+	require.False(t, stale.active.Load())
+	_, keptRegistered := g.runtimes[kept.id]
+	require.True(t, keptRegistered, "epoch 8 is the first retained epoch")
+	require.True(t, kept.active.Load())
+	_, unspecifiedRegistered := g.runtimes[unspecified.id]
+	require.True(t, unspecifiedRegistered, "creationEpoch 0 is unknown; do not invent a prune")
+}
+
+func TestRetireExpiredEpochEscrowsNoopsBeforeHorizon(t *testing.T) {
+	rt := &devshardRuntime{id: "12", creationEpoch: 1}
+	rt.active.Store(true)
+	g := &Gateway{
+		runtimes:         map[string]*devshardRuntime{rt.id: rt},
+		runtimeOrder:     []*devshardRuntime{rt},
+		rotationBreakers: make(map[string]*rotationBreaker),
+		phaseGate:        &ChainPhaseGate{},
+	}
+	g.phaseGate.storeSnapshot(ChainPhaseSnapshot{EpochIndex: 2})
+
+	g.retireExpiredEpochEscrows()
+
+	_, still := g.runtimes[rt.id]
+	require.True(t, still)
+	require.True(t, rt.active.Load())
+}
+
+func TestRetireExpiredEpochEscrowsDefersWhileBusy(t *testing.T) {
+	rt := &devshardRuntime{id: "12", creationEpoch: 1}
+	rt.active.Store(true)
+	rt.activeUserRequests.Store(1)
+	g := &Gateway{
+		runtimes:         map[string]*devshardRuntime{rt.id: rt},
+		runtimeOrder:     []*devshardRuntime{rt},
+		rotationBreakers: make(map[string]*rotationBreaker),
+		phaseGate:        &ChainPhaseGate{},
+	}
+	g.phaseGate.storeSnapshot(ChainPhaseSnapshot{EpochIndex: 10})
+
+	g.retireExpiredEpochEscrows()
+
+	_, still := g.runtimes[rt.id]
+	require.True(t, still, "busy runtime must stay registered until drain")
+	require.False(t, rt.active.Load(), "admission must close immediately")
+	require.True(t, rt.retirePending.Load())
+
+	// Later ticks must not re-walk a runtime whose retirement is already
+	// queued; runtimeDrained owns it from here.
+	g.retireExpiredEpochEscrows()
+	_, stillAfterSecondTick := g.runtimes[rt.id]
+	require.True(t, stillAfterSecondTick)
+	require.True(t, rt.retirePending.Load())
+}
+
+// A settle in flight reads the runtime's store; retiring closes it. The
+// settlement paths retire on their own, so epoch retention must stand aside.
+func TestRetireExpiredEpochEscrowsSkipsSettlementPending(t *testing.T) {
+	rt := &devshardRuntime{id: "12", creationEpoch: 1}
+	rt.settlementPending.Store(true)
+	g := &Gateway{
+		runtimes:         map[string]*devshardRuntime{rt.id: rt},
+		runtimeOrder:     []*devshardRuntime{rt},
+		rotationBreakers: make(map[string]*rotationBreaker),
+		phaseGate:        &ChainPhaseGate{},
+	}
+	g.phaseGate.storeSnapshot(ChainPhaseSnapshot{EpochIndex: 10})
+
+	g.retireExpiredEpochEscrows()
+
+	_, still := g.runtimes[rt.id]
+	require.True(t, still, "settlement owns the retire for a pending escrow")
+	require.False(t, rt.retirePending.Load())
 }
 
 // TestRetireRuntimeRemovesRuntimeFromRegistry pins the core leak fix: retiring a

--- a/devshard/cmd/devshardctl/hostping.go
+++ b/devshard/cmd/devshardctl/hostping.go
@@ -438,6 +438,14 @@ func (j *hostPingJob) reconcileLoop(ctx context.Context) {
 	}
 }
 
+func (j *hostPingJob) publishTargetCount() {
+	if j == nil || j.metrics == nil || j.targets == nil {
+		return
+	}
+	n, _, _ := j.targets.snapshotStats()
+	j.metrics.SetHostPingTargets(n)
+}
+
 func (j *hostPingJob) ObserveEscrowHost(escrowID, dial, routePrefix, participantKey string) {
 	if j == nil || j.cfg.Disabled {
 		return
@@ -445,9 +453,12 @@ func (j *hostPingJob) ObserveEscrowHost(escrowID, dial, routePrefix, participant
 	if j.targets.ObserveEscrowHost(escrowID, dial, routePrefix, participantKey) {
 		j.InvalidateDial(dial)
 	}
-	if j.metrics != nil && participantKey != "" {
+	// hasEscrow is false after ReleaseEscrow, so a late inference cannot
+	// recreate participant_info for a closed escrow.
+	if j.metrics != nil && participantKey != "" && j.targets.hasEscrow(escrowID) {
 		j.metrics.SetHostPingParticipantInfo(normalizeDial(dial), participantKey, true)
 	}
+	j.publishTargetCount()
 }
 
 // InvalidateDial clears the capability cache for a dial so the next probe
@@ -470,6 +481,7 @@ func (j *hostPingJob) ReleaseEscrow(escrowID string) {
 	for dial, participants := range removed {
 		j.metrics.DeleteHostPingMetrics(dial, participants)
 	}
+	j.publishTargetCount()
 }
 
 type hostDialer interface {

--- a/devshard/cmd/devshardctl/hostping.go
+++ b/devshard/cmd/devshardctl/hostping.go
@@ -288,6 +288,14 @@ func (t *hostPingTargets) refcount(dial string) int {
 	return 0
 }
 
+// dialCount is the O(1) form of snapshotStats' target count. ObserveEscrowHost
+// runs per successful inference, so the gauge publish must not walk the maps.
+func (t *hostPingTargets) dialCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.byDial)
+}
+
 func (t *hostPingTargets) hasEscrow(escrowID string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -442,8 +450,7 @@ func (j *hostPingJob) publishTargetCount() {
 	if j == nil || j.metrics == nil || j.targets == nil {
 		return
 	}
-	n, _, _ := j.targets.snapshotStats()
-	j.metrics.SetHostPingTargets(n)
+	j.metrics.SetHostPingTargets(j.targets.dialCount())
 }
 
 func (j *hostPingJob) ObserveEscrowHost(escrowID, dial, routePrefix, participantKey string) {

--- a/devshard/cmd/devshardctl/hostping_test.go
+++ b/devshard/cmd/devshardctl/hostping_test.go
@@ -140,8 +140,55 @@ func TestHostPingRefcountExhaustivenessTeardownPaths(t *testing.T) {
 			require.Equal(t, 0, job.targets.refcount(dial), "teardown path %s must drop refcount to 0", tc.name)
 			require.Empty(t, job.targets.Targets())
 			assertNoHostPingSeriesForHost(t, metrics, dial)
+			requireHostPingTargets(t, metrics, 0)
 		})
 	}
+}
+
+func TestHostPingTargetsPublishedOnObserveAndRelease(t *testing.T) {
+	metrics := NewDevshardMetrics()
+	job := newHostPingJob(metrics, hostPingConfig{
+		Interval:    defaultHostPingInterval,
+		Timeout:     defaultHostPingTimeout,
+		Concurrency: defaultHostPingConcurrency,
+	})
+	const dial = "http://shared.example:8080"
+
+	job.ObserveEscrowHost("e1", dial, "/devshard/v4", "pk-a")
+	job.ObserveEscrowHost("e2", dial, "/devshard/v4", "pk-b")
+	requireHostPingTargets(t, metrics, 1)
+
+	job.ReleaseEscrow("e1")
+	requireHostPingTargets(t, metrics, 1)
+	require.Equal(t, 1, job.targets.refcount(dial))
+
+	job.ReleaseEscrow("e2")
+	requireHostPingTargets(t, metrics, 0)
+	require.Empty(t, job.targets.Targets())
+}
+
+func TestHostPingObserveAfterReleaseDoesNotRestoreSeries(t *testing.T) {
+	metrics := NewDevshardMetrics()
+	job := newHostPingJob(metrics, hostPingConfig{
+		Interval:    defaultHostPingInterval,
+		Timeout:     defaultHostPingTimeout,
+		Concurrency: defaultHostPingConcurrency,
+	})
+	const dial = "http://late.example:8080"
+	const pk = "pk-late"
+
+	job.ObserveEscrowHost("e1", dial, "/devshard/v4", pk)
+	requireHostPingTargets(t, metrics, 1)
+
+	job.ReleaseEscrow("e1")
+	assertNoHostPingSeriesForHost(t, metrics, dial)
+	requireHostPingTargets(t, metrics, 0)
+
+	job.ObserveEscrowHost("e1", dial, "/devshard/v4", pk)
+	require.False(t, job.targets.hasEscrow("e1"))
+	require.Empty(t, job.targets.Targets())
+	assertNoHostPingSeriesForHost(t, metrics, dial)
+	requireHostPingTargets(t, metrics, 0)
 }
 
 func TestHostPingCleanupCompleteness(t *testing.T) {
@@ -271,6 +318,7 @@ func TestHostPingParticipantInfoDedupeMapping(t *testing.T) {
 	requireMetricGaugeValue(t, families, "devshard_gateway_host_ping_participant_info", map[string]string{"host": dial, "participant_key": "pk-a"}, 1)
 	requireMetricGaugeValue(t, families, "devshard_gateway_host_ping_participant_info", map[string]string{"host": dial, "participant_key": "pk-b"}, 1)
 	require.Len(t, job.targets.Targets(), 1)
+	requireHostPingTargets(t, metrics, 1)
 }
 
 func TestHostPingJoinProbePath(t *testing.T) {
@@ -323,6 +371,13 @@ type fakeDialer struct {
 
 func (f *fakeDialer) BaseURL() string     { return f.base }
 func (f *fakeDialer) RoutePrefix() string { return f.prefix }
+
+func requireHostPingTargets(t *testing.T, metrics *DevshardMetrics, want float64) {
+	t.Helper()
+	families, err := metrics.registry.Gather()
+	require.NoError(t, err)
+	requireMetricGaugeValue(t, families, "devshard_gateway_host_ping_targets", nil, want)
+}
 
 func assertNoHostPingSeriesForHost(t *testing.T, metrics *DevshardMetrics, host string) {
 	t.Helper()

--- a/devshard/cmd/devshardd/app.go
+++ b/devshard/cmd/devshardd/app.go
@@ -30,7 +30,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-const sessionEpochRetain = 3
+const sessionEpochRetain = devshardstorage.DefaultEpochRetain
 
 type chainEventsRunner interface {
 	Start(context.Context) error

--- a/devshard/storage/managed.go
+++ b/devshard/storage/managed.go
@@ -11,11 +11,29 @@ import (
 	"devshard/types"
 )
 
+// DefaultEpochRetain is how many epochs of sessions hosts keep, including
+// the current epoch (current + two previous). Gateway membership must use
+// the same horizon so it stops heartbeating at escrows hosts have pruned.
+const DefaultEpochRetain = 3
+
 // EpochProvider lets ManagedStorage learn the chain's current epoch even
 // when the host is quiet (no CreateSession activity). Optional: if nil,
 // retention is driven entirely by the highest epoch we have ever stored to.
 type EpochProvider interface {
 	CurrentEpochID() uint64
+}
+
+// RetentionCutoff is the exclusive epoch lower bound for DefaultEpochRetain
+// math: every epoch < cutoff is pruneable. Returns 0 until enough epochs
+// have been observed to drop anything (current+1 <= retain).
+func RetentionCutoff(currentEpoch, retain uint64) uint64 {
+	if retain == 0 {
+		retain = 1
+	}
+	if currentEpoch+1 <= retain {
+		return 0
+	}
+	return currentEpoch + 1 - retain
 }
 
 type rangePruner interface {
@@ -99,11 +117,7 @@ func (m *ManagedStorage) PruneCutoff() uint64 {
 	if m.epochs != nil {
 		m.observe(m.epochs.CurrentEpochID())
 	}
-	maxE := m.maxObservedEpoch.Load()
-	if maxE+1 <= m.retain {
-		return 0
-	}
-	return maxE + 1 - m.retain
+	return RetentionCutoff(m.maxObservedEpoch.Load(), m.retain)
 }
 
 // Start runs a single catch-up prune. Call it before session recovery so

--- a/devshard/storage/managed_test.go
+++ b/devshard/storage/managed_test.go
@@ -171,6 +171,15 @@ func sessionsAt(t *testing.T, store Storage) []uint64 {
 	return epochs
 }
 
+func TestRetentionCutoff(t *testing.T) {
+	require.Equal(t, uint64(0), RetentionCutoff(0, DefaultEpochRetain))
+	require.Equal(t, uint64(0), RetentionCutoff(2, DefaultEpochRetain))
+	require.Equal(t, uint64(1), RetentionCutoff(3, DefaultEpochRetain))
+	require.Equal(t, uint64(4), RetentionCutoff(6, DefaultEpochRetain))
+	require.Equal(t, uint64(8), RetentionCutoff(10, 3))
+	require.Equal(t, uint64(5), RetentionCutoff(5, 1))
+}
+
 // TestManaged_RetainsLastN: with retain=3 and observed epochs 1..6, only
 // epochs 4, 5, 6 must remain.
 func TestManaged_RetainsLastN(t *testing.T) {


### PR DESCRIPTION
## Summary

- Publish `host_ping_targets` on escrow observe/release instead of waiting for the ~15s probe tick, so deactivate clears the count with the rest of the host-ping series.
- Ignore a late inference after `ReleaseEscrow`: do not recreate `participant_info` (or the target count) for a closed escrow.
- Retire gateway runtimes whose creation epoch is below the host prune cutoff (retain 3: current + two previous), so idle previous-epoch escrows stop cadence-heartbeating once hosts have already dropped those sessions.

## Why

Deactivate already deleted the per-host gauges (`host_ping_up`, `participant_info`). `host_ping_targets` is a process-level gauge that the scheduler only rewrote on its interval, so live `/metrics` and `TestHostPing/E4_deactivate_clears_series` still saw the pre-deactivate count for ~15s.

A second hole: `hostPingTargets.ObserveEscrowHost` correctly refused a released escrow, but `hostPingJob.ObserveEscrowHost` still called `SetHostPingParticipantInfo`. An inference that finished after close could resurrect that series.

Separately, an epoch switch did not drop previous-epoch runtimes. They stayed in `runtimeOrder`, kept serving, and kept consuming escrow nonces on idle cadence heartbeats. Hosts already prune sessions older than `DefaultEpochRetain` (3). Chain settle only accepts current or previous epoch (`current <= escrow.EpochIndex+1`), so anything past that horizon cannot settle and should not stay resident.

## Behavior

**Host ping.** `ObserveEscrowHost` and `ReleaseEscrow` call `publishTargetCount()`. The gauge is `len(byDial)` via O(1) `dialCount()` — `snapshotStats` still walks maps for the reconcile audit, not per inference. `SetHostPingParticipantInfo` runs only when `targets.hasEscrow(escrowID)` is still true after the observe.

**Epoch retention.** `checkBalances` (30s, including the startup tick) calls `retireExpiredEpochEscrows()` before the rotation-gated balance scan, so this path runs even when escrow rotation is off.

Cutoff is the shared host math: `RetentionCutoff(current, DefaultEpochRetain)` → exclusive lower bound, 0 until `current+1 > retain`. At current=10 / retain=3 the cutoff is 8: epoch 7 retires, epoch 8 stays. `creationEpoch == 0` is unknown and is never invented into a prune. Boot with an unpolled `phaseGate` reports epoch 0 → cutoff 0, so the first tick cannot mass-retire.

For each stale runtime: deactivate (stops admission and releases host-ping) then `retireRuntime`. Busy runtimes stay registered with `retirePending`; `runtimeDrained` owns the close. Settlement-pending runtimes are skipped — settle success / `ErrEscrowSettled` / retry exhaustion already retire, and closing the store under an in-flight settle would strand funds. Already-queued `retirePending` runtimes are skipped so later ticks do not re-log the same deferral.

Settlement is **not** attempted here: those escrows are already past the chain window.

`devshardd` session retain now points at `storage.DefaultEpochRetain` so host prune and gateway membership cannot drift.

## Test plan

- [x] `go test ./cmd/devshardctl/ -run 'HostPingTargetsPublishedOnObserveAndRelease|HostPingObserveAfterReleaseDoesNotRestoreSeries|HostPingRefcountExhaustiveness|HostPingParticipantInfoDedupe'`
- [x] `go test ./cmd/devshardctl/ -run 'RetentionCutoffMatchesHostPruneHorizon|RetireExpiredEpochEscrows'`
- [x] `go test ./storage/ -run 'TestRetentionCutoff|TestManaged_RetainsLastN'`
- [x] `go test -race ./cmd/devshardctl/ -run 'HostPing|Retire|Retention|CheckBalances|Settlement'`
- [x] `go test ./cmd/devshardctl/ ./cmd/devshardd/`
- [ ] Deactivate after serving one chat: `host_ping_up`, `participant_info`, and `host_ping_targets` all 0 on the next `/metrics` scrape (no 15s wait)
- [ ] Leave an idle escrow across 3 epoch boundaries with rotation off: runtime leaves `runtimeOrder`, cadence heartbeats stop, host-ping series for that escrow stay gone
- [ ] Confirm a current- or previous-epoch escrow is not retired by this path and can still settle
