### PR TITLE
Expose host ping probe race on escrow release

### DIFF
--- a/devshard/cmd/devshardctl/hostping_test.go
+++ b/devshard/cmd/devshardctl/hostping_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +14,21 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
+
+type notifyingHostPingSink struct {
+	inner    *hostPingSink
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (s *notifyingHostPingSink) Observe(result probe.Result) {
+	s.inner.Observe(result)
+	s.once.Do(func() { close(s.observed) })
+}
+
+func (s *notifyingHostPingSink) Forget(key string) {
+	s.inner.Forget(key)
+}
 
 func TestHostPingTargetsRefcountAndDedupe(t *testing.T) {
 	targets := newHostPingTargets()
@@ -188,6 +207,74 @@ func TestHostPingObserveAfterReleaseDoesNotRestoreSeries(t *testing.T) {
 	require.False(t, job.targets.hasEscrow("e1"))
 	require.Empty(t, job.targets.Targets())
 	assertNoHostPingSeriesForHost(t, metrics, dial)
+	requireHostPingTargets(t, metrics, 0)
+}
+
+func TestHostPingInFlightProbeAfterReleaseDoesNotRestoreSeries(t *testing.T) {
+	probeStarted := make(chan struct{})
+	unblockProbe := make(chan struct{})
+	var startOnce sync.Once
+	var unblockOnce sync.Once
+	releaseProbe := func() {
+		unblockOnce.Do(func() { close(unblockProbe) })
+	}
+	t.Cleanup(releaseProbe)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startOnce.Do(func() { close(probeStarted) })
+		select {
+		case <-unblockProbe:
+			w.WriteHeader(http.StatusNoContent)
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	metrics := NewDevshardMetrics()
+	job := newHostPingJob(metrics, hostPingConfig{
+		Interval:    10 * time.Second,
+		Timeout:     2 * time.Second,
+		Concurrency: 1,
+	})
+	const escrowID = "e1"
+	const participantKey = "pk-in-flight"
+	job.ObserveEscrowHost(escrowID, server.URL, "", participantKey)
+
+	prober, err := probe.New(probe.Config{
+		Interval:    10 * time.Second,
+		Timeout:     2 * time.Second,
+		Concurrency: 1,
+		Transport:   server.Client().Transport,
+	})
+	require.NoError(t, err)
+	observed := make(chan struct{})
+	sink := &notifyingHostPingSink{
+		inner:    &hostPingSink{metrics: metrics, targets: job.targets},
+		observed: observed,
+	}
+	scheduler := probe.NewScheduler(prober, job.targets, sink, &hostPingObserver{metrics: metrics})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go scheduler.Run(ctx)
+
+	select {
+	case <-probeStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("host ping probe did not start")
+	}
+
+	job.ReleaseEscrow(escrowID)
+	assertNoHostPingSeriesForHost(t, metrics, server.URL)
+	requireHostPingTargets(t, metrics, 0)
+
+	releaseProbe()
+	select {
+	case <-observed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("host ping probe result was not observed")
+	}
+
+	assertNoHostPingSeriesForHost(t, metrics, server.URL)
 	requireHostPingTargets(t, metrics, 0)
 }
 


### PR DESCRIPTION
## Summary

Adds a deterministic regression test exposing a remaining host-ping metrics lifecycle race after #1736.

No production code is changed.

## Scenario

1. The host-ping scheduler starts a real HTTP probe.
2. The test server blocks the response while the probe is in flight.
3. `ReleaseEscrow` removes the target and clears its Prometheus series.
4. The HTTP response is released.
5. The completed probe reaches `hostPingSink.Observe` and recreates metrics for the released host.

The blocking handler only makes the ordering deterministic; in production, the same sequence can occur when an escrow is released while a network request is still in flight.

## Expected behavior

A probe that completes after its escrow has been released must not recreate any host-ping series.

## Current behavior

The test fails because a deleted series is restored:

```text
devshard_gateway_host_clock_divergence_seconds still has
host="http://127.0.0.1:<port>" after cleanup
```

## Reproduction

```bash
go test ./cmd/devshardctl/ \
  -run '^TestHostPingInFlightProbeAfterReleaseDoesNotRestoreSeries$' \
  -count=1
```