### PR TITLE
feat(dapi): serve block headers and proofs over NodeManager gRPC

### DIFF
--- a/common/chainoracle/blocks/nmclient/lookup.go
+++ b/common/chainoracle/blocks/nmclient/lookup.go
@@ -1,0 +1,111 @@
+// Package nmclient is the unary NodeManager consumer of GetBlockHeader
+// and ProveBlockPath. Live tip is Comet NewBlock, not a gRPC stream.
+package nmclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"common/chainoracle/blocks"
+	"common/chainoracle/blocks/nmrpc"
+	"common/nodemanager/gen"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Lookup implements blocks.BlockOracle over a NodeManager stub.
+type Lookup struct {
+	client gen.NodeManagerClient
+}
+
+// New returns a unary lookup. client must be non-nil.
+func New(client gen.NodeManagerClient) (*Lookup, error) {
+	if client == nil {
+		return nil, errors.New("nmclient: nil NodeManager client")
+	}
+	return &Lookup{client: client}, nil
+}
+
+func (l *Lookup) Latest(ctx context.Context) (*blocks.Header, error) {
+	return l.header(ctx, 0)
+}
+
+func (l *Lookup) At(ctx context.Context, height int64) (*blocks.Header, error) {
+	if height <= 0 {
+		return nil, fmt.Errorf("nmclient: At: %w", blocks.ErrHeaderNotFound)
+	}
+	return l.header(ctx, height)
+}
+
+func (l *Lookup) header(ctx context.Context, height int64) (*blocks.Header, error) {
+	if l == nil || l.client == nil {
+		return nil, blocks.ErrHeaderNotFound
+	}
+	resp, err := l.client.GetBlockHeader(ctx, &gen.GetBlockHeaderRequest{Height: height})
+	if err != nil {
+		return nil, mapHeaderErr(err)
+	}
+	h := nmrpc.HeaderFromProto(resp.GetHeader())
+	if h == nil {
+		return nil, blocks.ErrHeaderNotFound
+	}
+	return h, nil
+}
+
+func (l *Lookup) Prove(ctx context.Context, path string, height int64) (*blocks.Proof, error) {
+	if l == nil || l.client == nil {
+		return nil, blocks.ErrProveNotImplemented
+	}
+	resp, err := l.client.ProveBlockPath(ctx, &gen.ProveBlockPathRequest{Height: height, Path: path})
+	if err != nil {
+		return nil, mapProveErr(err)
+	}
+	p := nmrpc.ProofFromProto(resp.GetProof())
+	if p == nil {
+		return nil, blocks.ErrHeaderNotFound
+	}
+	return p, nil
+}
+
+func (l *Lookup) Subscribe(context.Context, int64) (<-chan *blocks.Header, error) {
+	return nil, errors.New("nmclient: no subscribe; use the Comet tip")
+}
+
+// mapHeaderErr keeps a missing height, a dapi without the RPC, and a dapi
+// with no oracle configured on the same quiet path HTTP 404 on /block/* takes.
+// Transport and other codes stay verbatim so failover can tell them apart.
+func mapHeaderErr(err error) error {
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	switch st.Code() {
+	case codes.NotFound, codes.Unimplemented, codes.FailedPrecondition:
+		return fmt.Errorf("%w: %s", blocks.ErrHeaderNotFound, st.Message())
+	default:
+		return err
+	}
+}
+
+// mapProveErr differs from mapHeaderErr on Unimplemented: to a Prove caller a
+// hash-only oracle and a dapi missing the RPC both mean "no proof available",
+// which is what ErrProveNotImplemented already says. Matching on the status
+// message instead would break the moment a producer reworded it.
+func mapProveErr(err error) error {
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	switch st.Code() {
+	case codes.Unimplemented:
+		return blocks.ErrProveNotImplemented
+	case codes.NotFound, codes.FailedPrecondition:
+		return fmt.Errorf("%w: %s", blocks.ErrHeaderNotFound, st.Message())
+	default:
+		return err
+	}
+}
+
+var _ blocks.BlockOracle = (*Lookup)(nil)

--- a/common/chainoracle/blocks/nmclient/lookup_test.go
+++ b/common/chainoracle/blocks/nmclient/lookup_test.go
@@ -1,0 +1,155 @@
+package nmclient_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"common/chainoracle/blocks"
+	"common/chainoracle/blocks/nmclient"
+	"common/chainoracle/blocks/nmrpc"
+	"common/nodemanager/gen"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+type stubOracle struct {
+	hdr   *blocks.Header
+	proof *blocks.Proof
+	prove error
+	atErr error
+}
+
+func (s stubOracle) Latest(context.Context) (*blocks.Header, error) {
+	if s.atErr != nil {
+		return nil, s.atErr
+	}
+	return s.hdr, nil
+}
+func (s stubOracle) At(context.Context, int64) (*blocks.Header, error) {
+	if s.atErr != nil {
+		return nil, s.atErr
+	}
+	if s.hdr == nil {
+		return nil, blocks.ErrHeaderNotFound
+	}
+	return s.hdr, nil
+}
+func (s stubOracle) Prove(context.Context, string, int64) (*blocks.Proof, error) {
+	if s.prove != nil {
+		return nil, s.prove
+	}
+	return s.proof, nil
+}
+func (stubOracle) Subscribe(context.Context, int64) (<-chan *blocks.Header, error) {
+	ch := make(chan *blocks.Header)
+	close(ch)
+	return ch, nil
+}
+
+type nmServer struct {
+	gen.UnimplementedNodeManagerServer
+	oracle blocks.BlockOracle
+}
+
+func (s *nmServer) GetBlockHeader(ctx context.Context, req *gen.GetBlockHeaderRequest) (*gen.GetBlockHeaderResponse, error) {
+	return nmrpc.GetBlockHeader(ctx, s.oracle, req)
+}
+func (s *nmServer) ProveBlockPath(ctx context.Context, req *gen.ProveBlockPathRequest) (*gen.ProveBlockPathResponse, error) {
+	return nmrpc.ProveBlockPath(ctx, s.oracle, req)
+}
+
+func dialNM(t *testing.T, srv gen.NodeManagerServer) gen.NodeManagerClient {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	gs := grpc.NewServer()
+	gen.RegisterNodeManagerServer(gs, srv)
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return gen.NewNodeManagerClient(conn)
+}
+
+func TestLookup_AtProveAndUnimplemented(t *testing.T) {
+	hdr := blocks.HashOnlyHeader(3, time.Unix(9, 0).UTC(), "gonka-test", []byte{3})
+	proof := &blocks.Proof{Path: "/escrow/1", Value: []byte{9}}
+	client := dialNM(t, &nmServer{oracle: stubOracle{hdr: hdr, proof: proof}})
+	lookup, err := nmclient.New(client)
+	require.NoError(t, err)
+
+	got, err := lookup.At(context.Background(), 3)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), got.Height)
+	require.Equal(t, []byte{3}, got.BlockHash)
+
+	latest, err := lookup.Latest(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(3), latest.Height)
+
+	p, err := lookup.Prove(context.Background(), "/escrow/1", 3)
+	require.NoError(t, err)
+	require.Equal(t, proof.Path, p.Path)
+	require.Equal(t, proof.Value, p.Value)
+
+	empty := dialNM(t, &nmServer{oracle: stubOracle{prove: blocks.ErrProveNotImplemented, hdr: hdr}})
+	elookup, err := nmclient.New(empty)
+	require.NoError(t, err)
+	_, err = elookup.Prove(context.Background(), "/escrow/1", 3)
+	require.ErrorIs(t, err, blocks.ErrProveNotImplemented)
+}
+
+// An old dapi has neither RPC. A header caller must see the same quiet miss as
+// HTTP 404; a Prove caller must see "no proof", not "no header".
+func TestLookup_OldServerUnimplemented(t *testing.T) {
+	client := dialNM(t, &gen.UnimplementedNodeManagerServer{})
+	lookup, err := nmclient.New(client)
+	require.NoError(t, err)
+
+	_, err = lookup.At(context.Background(), 1)
+	require.ErrorIs(t, err, blocks.ErrHeaderNotFound)
+
+	_, err = lookup.Latest(context.Background())
+	require.ErrorIs(t, err, blocks.ErrHeaderNotFound)
+
+	_, err = lookup.Prove(context.Background(), "/escrow/1", 1)
+	require.ErrorIs(t, err, blocks.ErrProveNotImplemented)
+}
+
+// A dapi that is up but has no oracle configured is a miss, not a transport error.
+func TestLookup_NoOracleConfiguredIsQuietMiss(t *testing.T) {
+	client := dialNM(t, &nmServer{oracle: nil})
+	lookup, err := nmclient.New(client)
+	require.NoError(t, err)
+
+	_, err = lookup.At(context.Background(), 1)
+	require.ErrorIs(t, err, blocks.ErrHeaderNotFound)
+
+	_, err = lookup.Prove(context.Background(), "/escrow/1", 1)
+	require.ErrorIs(t, err, blocks.ErrHeaderNotFound)
+}
+
+// A transport / upstream failure must not be laundered into a quiet miss:
+// failover has to tell "no route" from "this dapi is up, its RPC failed".
+func TestLookup_TransportErrorIsNotAMiss(t *testing.T) {
+	hdr := blocks.HashOnlyHeader(1, time.Unix(1, 0).UTC(), "gonka-test", []byte{1})
+	client := dialNM(t, &nmServer{oracle: stubOracle{hdr: hdr, atErr: errors.New("i/o timeout")}})
+	lookup, err := nmclient.New(client)
+	require.NoError(t, err)
+
+	_, err = lookup.At(context.Background(), 1)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, blocks.ErrHeaderNotFound)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}

--- a/common/chainoracle/blocks/nmrpc/rpc.go
+++ b/common/chainoracle/blocks/nmrpc/rpc.go
@@ -1,0 +1,82 @@
+// Package nmrpc is the NodeManager gRPC twin of GET /block/:height and
+// GET /block/:height/prove. It talks to the same BlockOracle the HTTP
+// mount uses; live tip stays Comet NewBlock, not a gRPC stream.
+package nmrpc
+
+import (
+	"context"
+	"errors"
+
+	"common/chainoracle/blocks"
+	"common/nodemanager/gen"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// GetBlockHeader serves NodeManager.GetBlockHeader. Height 0 is Latest().
+func GetBlockHeader(ctx context.Context, oracle blocks.BlockOracle, req *gen.GetBlockHeaderRequest) (*gen.GetBlockHeaderResponse, error) {
+	if oracle == nil {
+		return nil, status.Error(codes.FailedPrecondition, "block header: oracle not configured")
+	}
+	height := int64(0)
+	if req != nil {
+		height = req.GetHeight()
+	}
+	if height < 0 {
+		return nil, status.Error(codes.InvalidArgument, "block header: negative height")
+	}
+	var (
+		h   *blocks.Header
+		err error
+	)
+	if height == 0 {
+		h, err = oracle.Latest(ctx)
+	} else {
+		h, err = oracle.At(ctx, height)
+	}
+	if err != nil {
+		return nil, statusFromOracleErr(err)
+	}
+	if h == nil {
+		return nil, status.Error(codes.NotFound, blocks.ErrHeaderNotFound.Error())
+	}
+	return &gen.GetBlockHeaderResponse{Header: HeaderToProto(h)}, nil
+}
+
+// ProveBlockPath serves NodeManager.ProveBlockPath.
+func ProveBlockPath(ctx context.Context, oracle blocks.BlockOracle, req *gen.ProveBlockPathRequest) (*gen.ProveBlockPathResponse, error) {
+	if oracle == nil {
+		return nil, status.Error(codes.FailedPrecondition, "block proof: oracle not configured")
+	}
+	if req == nil || req.GetPath() == "" {
+		return nil, status.Error(codes.InvalidArgument, "block proof: path is required")
+	}
+	if req.GetHeight() < 0 {
+		return nil, status.Error(codes.InvalidArgument, "block proof: negative height")
+	}
+	p, err := oracle.Prove(ctx, req.GetPath(), req.GetHeight())
+	if err != nil {
+		return nil, statusFromOracleErr(err)
+	}
+	if p == nil {
+		return nil, status.Error(codes.NotFound, blocks.ErrHeaderNotFound.Error())
+	}
+	return &gen.ProveBlockPathResponse{Proof: ProofToProto(p)}, nil
+}
+
+func statusFromOracleErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, blocks.ErrHeaderNotFound) {
+		return status.Error(codes.NotFound, err.Error())
+	}
+	if errors.Is(err, blocks.ErrProveNotImplemented) {
+		return status.Error(codes.Unimplemented, err.Error())
+	}
+	if st, ok := status.FromError(err); ok {
+		return st.Err()
+	}
+	return status.Error(codes.Unavailable, err.Error())
+}

--- a/common/chainoracle/blocks/nmrpc/rpc_test.go
+++ b/common/chainoracle/blocks/nmrpc/rpc_test.go
@@ -1,0 +1,122 @@
+package nmrpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"common/chainoracle/blocks"
+	"common/nodemanager/gen"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type stubOracle struct {
+	latest *blocks.Header
+	at     map[int64]*blocks.Header
+	atErr  error
+	proof  *blocks.Proof
+	prove  error
+}
+
+func (s stubOracle) Latest(context.Context) (*blocks.Header, error) {
+	if s.latest == nil {
+		return nil, blocks.ErrHeaderNotFound
+	}
+	return s.latest, nil
+}
+func (s stubOracle) At(_ context.Context, height int64) (*blocks.Header, error) {
+	if s.atErr != nil {
+		return nil, s.atErr
+	}
+	h, ok := s.at[height]
+	if !ok {
+		return nil, blocks.ErrHeaderNotFound
+	}
+	return h, nil
+}
+func (s stubOracle) Prove(context.Context, string, int64) (*blocks.Proof, error) {
+	if s.prove != nil {
+		return nil, s.prove
+	}
+	return s.proof, nil
+}
+func (stubOracle) Subscribe(context.Context, int64) (<-chan *blocks.Header, error) {
+	ch := make(chan *blocks.Header)
+	close(ch)
+	return ch, nil
+}
+
+func TestGetBlockHeader_AtAndLatest(t *testing.T) {
+	hdr := blocks.HashOnlyHeader(4, time.Unix(10, 0).UTC(), "gonka-test", []byte{4})
+	o := stubOracle{latest: hdr, at: map[int64]*blocks.Header{4: hdr}}
+
+	got, err := GetBlockHeader(context.Background(), o, &gen.GetBlockHeaderRequest{Height: 4})
+	require.NoError(t, err)
+	require.Equal(t, int64(4), got.Header.Height)
+	require.Equal(t, []byte{4}, got.Header.BlockHash)
+	require.Equal(t, "gonka-test", got.Header.ChainId)
+
+	latest, err := GetBlockHeader(context.Background(), o, &gen.GetBlockHeaderRequest{Height: 0})
+	require.NoError(t, err)
+	require.Equal(t, int64(4), latest.Header.Height)
+}
+
+func TestGetBlockHeader_StatusCodes(t *testing.T) {
+	_, err := GetBlockHeader(context.Background(), nil, &gen.GetBlockHeaderRequest{Height: 1})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	_, err = GetBlockHeader(context.Background(), stubOracle{}, &gen.GetBlockHeaderRequest{Height: -1})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	_, err = GetBlockHeader(context.Background(), stubOracle{}, &gen.GetBlockHeaderRequest{Height: 9})
+	require.Equal(t, codes.NotFound, status.Code(err))
+
+	_, err = GetBlockHeader(context.Background(), stubOracle{atErr: errors.New("i/o timeout")}, &gen.GetBlockHeaderRequest{Height: 1})
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+func TestProveBlockPath_MockProofAndUnimplemented(t *testing.T) {
+	want := &blocks.Proof{Path: "/escrow/1", Value: []byte{1}, Ops: [][]byte{{2}}}
+	got, err := ProveBlockPath(context.Background(), stubOracle{proof: want}, &gen.ProveBlockPathRequest{Height: 4, Path: "/escrow/1"})
+	require.NoError(t, err)
+	require.Equal(t, "/escrow/1", got.Proof.Path)
+	require.Equal(t, []byte{1}, got.Proof.Value)
+	require.Equal(t, [][]byte{{2}}, got.Proof.Ops)
+
+	_, err = ProveBlockPath(context.Background(), stubOracle{prove: blocks.ErrProveNotImplemented}, &gen.ProveBlockPathRequest{Height: 4, Path: "/escrow/1"})
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+	_, err = ProveBlockPath(context.Background(), stubOracle{}, &gen.ProveBlockPathRequest{Height: 4})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestHeaderProofRoundTrip(t *testing.T) {
+	h := &blocks.Header{
+		Height:             8,
+		Time:               time.Unix(1_700_000_000, 5).UTC(),
+		ChainID:            "gonka-test",
+		BlockHash:          []byte{1, 2, 3},
+		AppHash:            []byte{4},
+		ValidatorsHash:     []byte{5},
+		NextValidatorsHash: []byte{6},
+		Commit: blocks.Commit{
+			Height:  8,
+			Round:   1,
+			BlockID: []byte{7},
+			Signatures: []blocks.CommitSig{{
+				ValidatorAddress: []byte{8},
+				Timestamp:        time.Unix(1_700_000_001, 0).UTC(),
+				Signature:        []byte{9},
+			}},
+		},
+	}
+	got := HeaderFromProto(HeaderToProto(h))
+	require.Equal(t, h, got)
+
+	p := &blocks.Proof{Path: "/k", Value: []byte{1}, Ops: [][]byte{{2, 3}}}
+	require.Equal(t, p, ProofFromProto(ProofToProto(p)))
+}

--- a/common/chainoracle/blocks/nmrpc/wire.go
+++ b/common/chainoracle/blocks/nmrpc/wire.go
@@ -1,0 +1,131 @@
+package nmrpc
+
+import (
+	"time"
+
+	"common/chainoracle/blocks"
+	"common/nodemanager/gen"
+)
+
+// HeaderToProto maps a BlockOracle header onto the NodeManager wire type.
+func HeaderToProto(h *blocks.Header) *gen.BlockHeader {
+	if h == nil {
+		return nil
+	}
+	out := &gen.BlockHeader{
+		Height:             h.Height,
+		TimeUnixNano:       h.Time.UTC().UnixNano(),
+		ChainId:            h.ChainID,
+		BlockHash:          append([]byte(nil), h.BlockHash...),
+		AppHash:            append([]byte(nil), h.AppHash...),
+		ValidatorsHash:     append([]byte(nil), h.ValidatorsHash...),
+		NextValidatorsHash: append([]byte(nil), h.NextValidatorsHash...),
+		Commit: &gen.BlockCommit{
+			Height:  h.Commit.Height,
+			Round:   h.Commit.Round,
+			BlockId: append([]byte(nil), h.Commit.BlockID...),
+		},
+	}
+	if h.Time.IsZero() {
+		out.TimeUnixNano = 0
+	}
+	if len(h.Commit.Signatures) == 0 {
+		return out
+	}
+	out.Commit.Signatures = make([]*gen.BlockCommitSig, len(h.Commit.Signatures))
+	for i, s := range h.Commit.Signatures {
+		ts := int64(0)
+		if !s.Timestamp.IsZero() {
+			ts = s.Timestamp.UTC().UnixNano()
+		}
+		out.Commit.Signatures[i] = &gen.BlockCommitSig{
+			ValidatorAddress:  append([]byte(nil), s.ValidatorAddress...),
+			TimestampUnixNano: ts,
+			Signature:         append([]byte(nil), s.Signature...),
+		}
+	}
+	return out
+}
+
+// HeaderFromProto is the inverse of HeaderToProto.
+func HeaderFromProto(p *gen.BlockHeader) *blocks.Header {
+	if p == nil {
+		return nil
+	}
+	h := &blocks.Header{
+		Height:             p.GetHeight(),
+		ChainID:            p.GetChainId(),
+		BlockHash:          append([]byte(nil), p.GetBlockHash()...),
+		AppHash:            append([]byte(nil), p.GetAppHash()...),
+		ValidatorsHash:     append([]byte(nil), p.GetValidatorsHash()...),
+		NextValidatorsHash: append([]byte(nil), p.GetNextValidatorsHash()...),
+	}
+	if p.GetTimeUnixNano() != 0 {
+		h.Time = time.Unix(0, p.GetTimeUnixNano()).UTC()
+	}
+	c := p.GetCommit()
+	if c == nil {
+		return h
+	}
+	h.Commit = blocks.Commit{
+		Height:  c.GetHeight(),
+		Round:   c.GetRound(),
+		BlockID: append([]byte(nil), c.GetBlockId()...),
+	}
+	sigs := c.GetSignatures()
+	if len(sigs) == 0 {
+		return h
+	}
+	h.Commit.Signatures = make([]blocks.CommitSig, len(sigs))
+	for i, s := range sigs {
+		var ts time.Time
+		if s.GetTimestampUnixNano() != 0 {
+			ts = time.Unix(0, s.GetTimestampUnixNano()).UTC()
+		}
+		h.Commit.Signatures[i] = blocks.CommitSig{
+			ValidatorAddress: append([]byte(nil), s.GetValidatorAddress()...),
+			Timestamp:        ts,
+			Signature:        append([]byte(nil), s.GetSignature()...),
+		}
+	}
+	return h
+}
+
+// ProofToProto maps a BlockOracle proof onto the NodeManager wire type.
+func ProofToProto(p *blocks.Proof) *gen.BlockProof {
+	if p == nil {
+		return nil
+	}
+	out := &gen.BlockProof{
+		Path:  p.Path,
+		Value: append([]byte(nil), p.Value...),
+	}
+	if len(p.Ops) == 0 {
+		return out
+	}
+	out.Ops = make([][]byte, len(p.Ops))
+	for i, op := range p.Ops {
+		out.Ops[i] = append([]byte(nil), op...)
+	}
+	return out
+}
+
+// ProofFromProto is the inverse of ProofToProto.
+func ProofFromProto(p *gen.BlockProof) *blocks.Proof {
+	if p == nil {
+		return nil
+	}
+	out := &blocks.Proof{
+		Path:  p.GetPath(),
+		Value: append([]byte(nil), p.GetValue()...),
+	}
+	ops := p.GetOps()
+	if len(ops) == 0 {
+		return out
+	}
+	out.Ops = make([][]byte, len(ops))
+	for i, op := range ops {
+		out.Ops[i] = append([]byte(nil), op...)
+	}
+	return out
+}

--- a/common/nodemanager/gen/nodemanager.pb.go
+++ b/common/nodemanager/gen/nodemanager.pb.go
@@ -1356,6 +1356,482 @@ func (x *ListNodeCapacityResponse) GetServedAtUnix() int64 {
 	return 0
 }
 
+// GetBlockHeaderRequest looks up a committed header. Height 0 means Latest().
+type GetBlockHeaderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Height        int64                  `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetBlockHeaderRequest) Reset() {
+	*x = GetBlockHeaderRequest{}
+	mi := &file_nodemanager_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBlockHeaderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBlockHeaderRequest) ProtoMessage() {}
+
+func (x *GetBlockHeaderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_nodemanager_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBlockHeaderRequest.ProtoReflect.Descriptor instead.
+func (*GetBlockHeaderRequest) Descriptor() ([]byte, []int) {
+	return file_nodemanager_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *GetBlockHeaderRequest) GetHeight() int64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+type GetBlockHeaderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Header        *BlockHeader           `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetBlockHeaderResponse) Reset() {
+	*x = GetBlockHeaderResponse{}
+	mi := &file_nodemanager_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetBlockHeaderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetBlockHeaderResponse) ProtoMessage() {}
+
+func (x *GetBlockHeaderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_nodemanager_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetBlockHeaderResponse.ProtoReflect.Descriptor instead.
+func (*GetBlockHeaderResponse) Descriptor() ([]byte, []int) {
+	return file_nodemanager_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *GetBlockHeaderResponse) GetHeader() *BlockHeader {
+	if x != nil {
+		return x.Header
+	}
+	return nil
+}
+
+// ProveBlockPathRequest is GET /block/:height/prove?path=. Hash-only
+// producers return Unimplemented (HTTP 501).
+type ProveBlockPathRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Height        int64                  `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
+	Path          string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProveBlockPathRequest) Reset() {
+	*x = ProveBlockPathRequest{}
+	mi := &file_nodemanager_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProveBlockPathRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProveBlockPathRequest) ProtoMessage() {}
+
+func (x *ProveBlockPathRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_nodemanager_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProveBlockPathRequest.ProtoReflect.Descriptor instead.
+func (*ProveBlockPathRequest) Descriptor() ([]byte, []int) {
+	return file_nodemanager_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ProveBlockPathRequest) GetHeight() int64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+func (x *ProveBlockPathRequest) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+type ProveBlockPathResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Proof         *BlockProof            `protobuf:"bytes,1,opt,name=proof,proto3" json:"proof,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProveBlockPathResponse) Reset() {
+	*x = ProveBlockPathResponse{}
+	mi := &file_nodemanager_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProveBlockPathResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProveBlockPathResponse) ProtoMessage() {}
+
+func (x *ProveBlockPathResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_nodemanager_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProveBlockPathResponse.ProtoReflect.Descriptor instead.
+func (*ProveBlockPathResponse) Descriptor() ([]byte, []int) {
+	return file_nodemanager_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ProveBlockPathResponse) GetProof() *BlockProof {
+	if x != nil {
+		return x.Proof
+	}
+	return nil
+}
+
+// BlockHeader is the gRPC shape of chainoracle/blocks.Header.
+type BlockHeader struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Height             int64                  `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
+	TimeUnixNano       int64                  `protobuf:"varint,2,opt,name=time_unix_nano,json=timeUnixNano,proto3" json:"time_unix_nano,omitempty"`
+	ChainId            string                 `protobuf:"bytes,3,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+	BlockHash          []byte                 `protobuf:"bytes,4,opt,name=block_hash,json=blockHash,proto3" json:"block_hash,omitempty"`
+	AppHash            []byte                 `protobuf:"bytes,5,opt,name=app_hash,json=appHash,proto3" json:"app_hash,omitempty"`
+	ValidatorsHash     []byte                 `protobuf:"bytes,6,opt,name=validators_hash,json=validatorsHash,proto3" json:"validators_hash,omitempty"`
+	NextValidatorsHash []byte                 `protobuf:"bytes,7,opt,name=next_validators_hash,json=nextValidatorsHash,proto3" json:"next_validators_hash,omitempty"`
+	Commit             *BlockCommit           `protobuf:"bytes,8,opt,name=commit,proto3" json:"commit,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *BlockHeader) Reset() {
+	*x = BlockHeader{}
+	mi := &file_nodemanager_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BlockHeader) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlockHeader) ProtoMessage() {}
+
+func (x *BlockHeader) ProtoReflect() protoreflect.Message {
+	mi := &file_nodemanager_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlockHeader.ProtoReflect.Descriptor instead.
+func (*BlockHeader) Descriptor() ([]byte, []int) {
+	return file_nodemanager_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *BlockHeader) GetHeight() int64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+func (x *BlockHeader) GetTimeUnixNano() int64 {
+	if x != nil {
+		return x.TimeUnixNano
+	}
+	return 0
+}
+
+func (x *BlockHeader) GetChainId() string {
+	if x != nil {
+		return x.ChainId
+	}
+	return ""
+}
+
+func (x *BlockHeader) GetBlockHash() []byte {
+	if x != nil {
+		return x.BlockHash
+	}
+	return nil
+}
+
+func (x *BlockHeader) GetAppHash() []byte {
+	if x != nil {
+		return x.AppHash
+	}
+	return nil
+}
+
+func (x *BlockHeader) GetValidatorsHash() []byte {
+	if x != nil {
+		return x.ValidatorsHash
+	}
+	return nil
+}
+
+func (x *BlockHeader) GetNextValidatorsHash() []byte {
+	if x != nil {
+		return x.NextValidatorsHash
+	}
+	return nil
+}
+
+func (x *BlockHeader) GetCommit() *BlockCommit {
+	if x != nil {
+		return x.Commit
+	}
+	return nil
+}
+
+type BlockCommit struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Height        int64                  `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
+	Round         int32                  `protobuf:"varint,2,opt,name=round,proto3" json:"round,omitempty"`
+	BlockId       []byte                 `protobuf:"bytes,3,opt,name=block_id,json=blockId,proto3" json:"block_id,omitempty"`
+	Signatures    []*BlockCommitSig      `protobuf:"bytes,4,rep,name=signatures,proto3" json:"signatures,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BlockCommit) Reset() {
+	*x = BlockCommit{}
+	mi := &file_nodemanager_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BlockCommit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlockCommit) ProtoMessage() {}
+
+func (x *BlockCommit) ProtoReflect() protoreflect.Message {
+	mi := &file_nodemanager_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlockCommit.ProtoReflect.Descriptor instead.
+func (*BlockCommit) Descriptor() ([]byte, []int) {
+	return file_nodemanager_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *BlockCommit) GetHeight() int64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+func (x *BlockCommit) GetRound() int32 {
+	if x != nil {
+		return x.Round
+	}
+	return 0
+}
+
+func (x *BlockCommit) GetBlockId() []byte {
+	if x != nil {
+		return x.BlockId
+	}
+	return nil
+}
+
+func (x *BlockCommit) GetSignatures() []*BlockCommitSig {
+	if x != nil {
+		return x.Signatures
+	}
+	return nil
+}
+
+type BlockCommitSig struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	ValidatorAddress  []byte                 `protobuf:"bytes,1,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
+	TimestampUnixNano int64                  `protobuf:"varint,2,opt,name=timestamp_unix_nano,json=timestampUnixNano,proto3" json:"timestamp_unix_nano,omitempty"`
+	Signature         []byte                 `protobuf:"bytes,3,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *BlockCommitSig) Reset() {
+	*x = BlockCommitSig{}
+	mi := &file_nodemanager_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BlockCommitSig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlockCommitSig) ProtoMessage() {}
+
+func (x *BlockCommitSig) ProtoReflect() protoreflect.Message {
+	mi := &file_nodemanager_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlockCommitSig.ProtoReflect.Descriptor instead.
+func (*BlockCommitSig) Descriptor() ([]byte, []int) {
+	return file_nodemanager_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *BlockCommitSig) GetValidatorAddress() []byte {
+	if x != nil {
+		return x.ValidatorAddress
+	}
+	return nil
+}
+
+func (x *BlockCommitSig) GetTimestampUnixNano() int64 {
+	if x != nil {
+		return x.TimestampUnixNano
+	}
+	return 0
+}
+
+func (x *BlockCommitSig) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+type BlockProof struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Ops           [][]byte               `protobuf:"bytes,3,rep,name=ops,proto3" json:"ops,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BlockProof) Reset() {
+	*x = BlockProof{}
+	mi := &file_nodemanager_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BlockProof) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlockProof) ProtoMessage() {}
+
+func (x *BlockProof) ProtoReflect() protoreflect.Message {
+	mi := &file_nodemanager_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlockProof.ProtoReflect.Descriptor instead.
+func (*BlockProof) Descriptor() ([]byte, []int) {
+	return file_nodemanager_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *BlockProof) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *BlockProof) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *BlockProof) GetOps() [][]byte {
+	if x != nil {
+		return x.Ops
+	}
+	return nil
+}
+
 var File_nodemanager_proto protoreflect.FileDescriptor
 
 const file_nodemanager_proto_rawDesc = "" +
@@ -1458,7 +1934,42 @@ const file_nodemanager_proto_rawDesc = "" +
 	"\x06status\x18\x05 \x01(\tR\x06status\"v\n" +
 	"\x18ListNodeCapacityResponse\x124\n" +
 	"\x05nodes\x18\x01 \x03(\v2\x1e.nodemanager.NodeCapacityEntryR\x05nodes\x12$\n" +
-	"\x0eserved_at_unix\x18\x02 \x01(\x03R\fservedAtUnix*V\n" +
+	"\x0eserved_at_unix\x18\x02 \x01(\x03R\fservedAtUnix\"/\n" +
+	"\x15GetBlockHeaderRequest\x12\x16\n" +
+	"\x06height\x18\x01 \x01(\x03R\x06height\"J\n" +
+	"\x16GetBlockHeaderResponse\x120\n" +
+	"\x06header\x18\x01 \x01(\v2\x18.nodemanager.BlockHeaderR\x06header\"C\n" +
+	"\x15ProveBlockPathRequest\x12\x16\n" +
+	"\x06height\x18\x01 \x01(\x03R\x06height\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\"G\n" +
+	"\x16ProveBlockPathResponse\x12-\n" +
+	"\x05proof\x18\x01 \x01(\v2\x17.nodemanager.BlockProofR\x05proof\"\xad\x02\n" +
+	"\vBlockHeader\x12\x16\n" +
+	"\x06height\x18\x01 \x01(\x03R\x06height\x12$\n" +
+	"\x0etime_unix_nano\x18\x02 \x01(\x03R\ftimeUnixNano\x12\x19\n" +
+	"\bchain_id\x18\x03 \x01(\tR\achainId\x12\x1d\n" +
+	"\n" +
+	"block_hash\x18\x04 \x01(\fR\tblockHash\x12\x19\n" +
+	"\bapp_hash\x18\x05 \x01(\fR\aappHash\x12'\n" +
+	"\x0fvalidators_hash\x18\x06 \x01(\fR\x0evalidatorsHash\x120\n" +
+	"\x14next_validators_hash\x18\a \x01(\fR\x12nextValidatorsHash\x120\n" +
+	"\x06commit\x18\b \x01(\v2\x18.nodemanager.BlockCommitR\x06commit\"\x93\x01\n" +
+	"\vBlockCommit\x12\x16\n" +
+	"\x06height\x18\x01 \x01(\x03R\x06height\x12\x14\n" +
+	"\x05round\x18\x02 \x01(\x05R\x05round\x12\x19\n" +
+	"\bblock_id\x18\x03 \x01(\fR\ablockId\x12;\n" +
+	"\n" +
+	"signatures\x18\x04 \x03(\v2\x1b.nodemanager.BlockCommitSigR\n" +
+	"signatures\"\x8b\x01\n" +
+	"\x0eBlockCommitSig\x12+\n" +
+	"\x11validator_address\x18\x01 \x01(\fR\x10validatorAddress\x12.\n" +
+	"\x13timestamp_unix_nano\x18\x02 \x01(\x03R\x11timestampUnixNano\x12\x1c\n" +
+	"\tsignature\x18\x03 \x01(\fR\tsignature\"H\n" +
+	"\n" +
+	"BlockProof\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\x12\x10\n" +
+	"\x03ops\x18\x03 \x03(\fR\x03ops*V\n" +
 	"\x0eReleaseOutcome\x12\v\n" +
 	"\aSUCCESS\x10\x00\x12\x13\n" +
 	"\x0fTRANSPORT_ERROR\x10\x01\x12\x15\n" +
@@ -1469,13 +1980,15 @@ const file_nodemanager_proto_rawDesc = "" +
 	"\x1eHOST_EVENT_KIND_ESCROW_CREATED\x10\x03\x12\"\n" +
 	"\x1eHOST_EVENT_KIND_ESCROW_SETTLED\x10\x04\x12)\n" +
 	"%HOST_EVENT_KIND_MAINTENANCE_SCHEDULED\x10\x05\x12(\n" +
-	"$HOST_EVENT_KIND_MAINTENANCE_CANCELED\x10\x062\xd7\x03\n" +
+	"$HOST_EVENT_KIND_MAINTENANCE_CANCELED\x10\x062\x8d\x05\n" +
 	"\vNodeManager\x12V\n" +
 	"\rAcquireMLNode\x12!.nodemanager.AcquireMLNodeRequest\x1a\".nodemanager.AcquireMLNodeResponse\x12V\n" +
 	"\rReleaseMLNode\x12!.nodemanager.ReleaseMLNodeRequest\x1a\".nodemanager.ReleaseMLNodeResponse\x12_\n" +
 	"\x10GetRuntimeConfig\x12$.nodemanager.GetRuntimeConfigRequest\x1a%.nodemanager.GetRuntimeConfigResponse\x12V\n" +
 	"\rGetHostEvents\x12!.nodemanager.GetHostEventsRequest\x1a\".nodemanager.GetHostEventsResponse\x12_\n" +
-	"\x10ListNodeCapacity\x12$.nodemanager.ListNodeCapacityRequest\x1a%.nodemanager.ListNodeCapacityResponseB\x18Z\x16common/nodemanager/genb\x06proto3"
+	"\x10ListNodeCapacity\x12$.nodemanager.ListNodeCapacityRequest\x1a%.nodemanager.ListNodeCapacityResponse\x12Y\n" +
+	"\x0eGetBlockHeader\x12\".nodemanager.GetBlockHeaderRequest\x1a#.nodemanager.GetBlockHeaderResponse\x12Y\n" +
+	"\x0eProveBlockPath\x12\".nodemanager.ProveBlockPathRequest\x1a#.nodemanager.ProveBlockPathResponseB\x18Z\x16common/nodemanager/genb\x06proto3"
 
 var (
 	file_nodemanager_proto_rawDescOnce sync.Once
@@ -1490,7 +2003,7 @@ func file_nodemanager_proto_rawDescGZIP() []byte {
 }
 
 var file_nodemanager_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_nodemanager_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_nodemanager_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_nodemanager_proto_goTypes = []any{
 	(ReleaseOutcome)(0),              // 0: nodemanager.ReleaseOutcome
 	(HostEventKind)(0),               // 1: nodemanager.HostEventKind
@@ -1512,6 +2025,14 @@ var file_nodemanager_proto_goTypes = []any{
 	(*ListNodeCapacityRequest)(nil),  // 17: nodemanager.ListNodeCapacityRequest
 	(*NodeCapacityEntry)(nil),        // 18: nodemanager.NodeCapacityEntry
 	(*ListNodeCapacityResponse)(nil), // 19: nodemanager.ListNodeCapacityResponse
+	(*GetBlockHeaderRequest)(nil),    // 20: nodemanager.GetBlockHeaderRequest
+	(*GetBlockHeaderResponse)(nil),   // 21: nodemanager.GetBlockHeaderResponse
+	(*ProveBlockPathRequest)(nil),    // 22: nodemanager.ProveBlockPathRequest
+	(*ProveBlockPathResponse)(nil),   // 23: nodemanager.ProveBlockPathResponse
+	(*BlockHeader)(nil),              // 24: nodemanager.BlockHeader
+	(*BlockCommit)(nil),              // 25: nodemanager.BlockCommit
+	(*BlockCommitSig)(nil),           // 26: nodemanager.BlockCommitSig
+	(*BlockProof)(nil),               // 27: nodemanager.BlockProof
 }
 var file_nodemanager_proto_depIdxs = []int32{
 	0,  // 0: nodemanager.ReleaseMLNodeRequest.outcome:type_name -> nodemanager.ReleaseOutcome
@@ -1525,21 +2046,29 @@ var file_nodemanager_proto_depIdxs = []int32{
 	12, // 8: nodemanager.GetHostEventsResponse.events:type_name -> nodemanager.HostEvent
 	16, // 9: nodemanager.GetHostEventsResponse.escrow_load:type_name -> nodemanager.EscrowLoad
 	18, // 10: nodemanager.ListNodeCapacityResponse.nodes:type_name -> nodemanager.NodeCapacityEntry
-	2,  // 11: nodemanager.NodeManager.AcquireMLNode:input_type -> nodemanager.AcquireMLNodeRequest
-	4,  // 12: nodemanager.NodeManager.ReleaseMLNode:input_type -> nodemanager.ReleaseMLNodeRequest
-	6,  // 13: nodemanager.NodeManager.GetRuntimeConfig:input_type -> nodemanager.GetRuntimeConfigRequest
-	11, // 14: nodemanager.NodeManager.GetHostEvents:input_type -> nodemanager.GetHostEventsRequest
-	17, // 15: nodemanager.NodeManager.ListNodeCapacity:input_type -> nodemanager.ListNodeCapacityRequest
-	3,  // 16: nodemanager.NodeManager.AcquireMLNode:output_type -> nodemanager.AcquireMLNodeResponse
-	5,  // 17: nodemanager.NodeManager.ReleaseMLNode:output_type -> nodemanager.ReleaseMLNodeResponse
-	7,  // 18: nodemanager.NodeManager.GetRuntimeConfig:output_type -> nodemanager.GetRuntimeConfigResponse
-	15, // 19: nodemanager.NodeManager.GetHostEvents:output_type -> nodemanager.GetHostEventsResponse
-	19, // 20: nodemanager.NodeManager.ListNodeCapacity:output_type -> nodemanager.ListNodeCapacityResponse
-	16, // [16:21] is the sub-list for method output_type
-	11, // [11:16] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	24, // 11: nodemanager.GetBlockHeaderResponse.header:type_name -> nodemanager.BlockHeader
+	27, // 12: nodemanager.ProveBlockPathResponse.proof:type_name -> nodemanager.BlockProof
+	25, // 13: nodemanager.BlockHeader.commit:type_name -> nodemanager.BlockCommit
+	26, // 14: nodemanager.BlockCommit.signatures:type_name -> nodemanager.BlockCommitSig
+	2,  // 15: nodemanager.NodeManager.AcquireMLNode:input_type -> nodemanager.AcquireMLNodeRequest
+	4,  // 16: nodemanager.NodeManager.ReleaseMLNode:input_type -> nodemanager.ReleaseMLNodeRequest
+	6,  // 17: nodemanager.NodeManager.GetRuntimeConfig:input_type -> nodemanager.GetRuntimeConfigRequest
+	11, // 18: nodemanager.NodeManager.GetHostEvents:input_type -> nodemanager.GetHostEventsRequest
+	17, // 19: nodemanager.NodeManager.ListNodeCapacity:input_type -> nodemanager.ListNodeCapacityRequest
+	20, // 20: nodemanager.NodeManager.GetBlockHeader:input_type -> nodemanager.GetBlockHeaderRequest
+	22, // 21: nodemanager.NodeManager.ProveBlockPath:input_type -> nodemanager.ProveBlockPathRequest
+	3,  // 22: nodemanager.NodeManager.AcquireMLNode:output_type -> nodemanager.AcquireMLNodeResponse
+	5,  // 23: nodemanager.NodeManager.ReleaseMLNode:output_type -> nodemanager.ReleaseMLNodeResponse
+	7,  // 24: nodemanager.NodeManager.GetRuntimeConfig:output_type -> nodemanager.GetRuntimeConfigResponse
+	15, // 25: nodemanager.NodeManager.GetHostEvents:output_type -> nodemanager.GetHostEventsResponse
+	19, // 26: nodemanager.NodeManager.ListNodeCapacity:output_type -> nodemanager.ListNodeCapacityResponse
+	21, // 27: nodemanager.NodeManager.GetBlockHeader:output_type -> nodemanager.GetBlockHeaderResponse
+	23, // 28: nodemanager.NodeManager.ProveBlockPath:output_type -> nodemanager.ProveBlockPathResponse
+	22, // [22:29] is the sub-list for method output_type
+	15, // [15:22] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_nodemanager_proto_init() }
@@ -1553,7 +2082,7 @@ func file_nodemanager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_nodemanager_proto_rawDesc), len(file_nodemanager_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   18,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/nodemanager/gen/nodemanager_grpc.pb.go
+++ b/common/nodemanager/gen/nodemanager_grpc.pb.go
@@ -24,6 +24,8 @@ const (
 	NodeManager_GetRuntimeConfig_FullMethodName = "/nodemanager.NodeManager/GetRuntimeConfig"
 	NodeManager_GetHostEvents_FullMethodName    = "/nodemanager.NodeManager/GetHostEvents"
 	NodeManager_ListNodeCapacity_FullMethodName = "/nodemanager.NodeManager/ListNodeCapacity"
+	NodeManager_GetBlockHeader_FullMethodName   = "/nodemanager.NodeManager/GetBlockHeader"
+	NodeManager_ProveBlockPath_FullMethodName   = "/nodemanager.NodeManager/ProveBlockPath"
 )
 
 // NodeManagerClient is the client API for NodeManager service.
@@ -35,6 +37,10 @@ type NodeManagerClient interface {
 	GetRuntimeConfig(ctx context.Context, in *GetRuntimeConfigRequest, opts ...grpc.CallOption) (*GetRuntimeConfigResponse, error)
 	GetHostEvents(ctx context.Context, in *GetHostEventsRequest, opts ...grpc.CallOption) (*GetHostEventsResponse, error)
 	ListNodeCapacity(ctx context.Context, in *ListNodeCapacityRequest, opts ...grpc.CallOption) (*ListNodeCapacityResponse, error)
+	// Unary twins of HTTP GET /block/:height and GET /block/:height/prove.
+	// Live tip remains Comet NewBlock, not a gRPC stream.
+	GetBlockHeader(ctx context.Context, in *GetBlockHeaderRequest, opts ...grpc.CallOption) (*GetBlockHeaderResponse, error)
+	ProveBlockPath(ctx context.Context, in *ProveBlockPathRequest, opts ...grpc.CallOption) (*ProveBlockPathResponse, error)
 }
 
 type nodeManagerClient struct {
@@ -90,6 +96,24 @@ func (c *nodeManagerClient) ListNodeCapacity(ctx context.Context, in *ListNodeCa
 	return out, nil
 }
 
+func (c *nodeManagerClient) GetBlockHeader(ctx context.Context, in *GetBlockHeaderRequest, opts ...grpc.CallOption) (*GetBlockHeaderResponse, error) {
+	out := new(GetBlockHeaderResponse)
+	err := c.cc.Invoke(ctx, NodeManager_GetBlockHeader_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nodeManagerClient) ProveBlockPath(ctx context.Context, in *ProveBlockPathRequest, opts ...grpc.CallOption) (*ProveBlockPathResponse, error) {
+	out := new(ProveBlockPathResponse)
+	err := c.cc.Invoke(ctx, NodeManager_ProveBlockPath_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // NodeManagerServer is the server API for NodeManager service.
 // All implementations must embed UnimplementedNodeManagerServer
 // for forward compatibility
@@ -99,6 +123,10 @@ type NodeManagerServer interface {
 	GetRuntimeConfig(context.Context, *GetRuntimeConfigRequest) (*GetRuntimeConfigResponse, error)
 	GetHostEvents(context.Context, *GetHostEventsRequest) (*GetHostEventsResponse, error)
 	ListNodeCapacity(context.Context, *ListNodeCapacityRequest) (*ListNodeCapacityResponse, error)
+	// Unary twins of HTTP GET /block/:height and GET /block/:height/prove.
+	// Live tip remains Comet NewBlock, not a gRPC stream.
+	GetBlockHeader(context.Context, *GetBlockHeaderRequest) (*GetBlockHeaderResponse, error)
+	ProveBlockPath(context.Context, *ProveBlockPathRequest) (*ProveBlockPathResponse, error)
 	mustEmbedUnimplementedNodeManagerServer()
 }
 
@@ -120,6 +148,12 @@ func (UnimplementedNodeManagerServer) GetHostEvents(context.Context, *GetHostEve
 }
 func (UnimplementedNodeManagerServer) ListNodeCapacity(context.Context, *ListNodeCapacityRequest) (*ListNodeCapacityResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListNodeCapacity not implemented")
+}
+func (UnimplementedNodeManagerServer) GetBlockHeader(context.Context, *GetBlockHeaderRequest) (*GetBlockHeaderResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetBlockHeader not implemented")
+}
+func (UnimplementedNodeManagerServer) ProveBlockPath(context.Context, *ProveBlockPathRequest) (*ProveBlockPathResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProveBlockPath not implemented")
 }
 func (UnimplementedNodeManagerServer) mustEmbedUnimplementedNodeManagerServer() {}
 
@@ -224,6 +258,42 @@ func _NodeManager_ListNodeCapacity_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _NodeManager_GetBlockHeader_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetBlockHeaderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NodeManagerServer).GetBlockHeader(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NodeManager_GetBlockHeader_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NodeManagerServer).GetBlockHeader(ctx, req.(*GetBlockHeaderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NodeManager_ProveBlockPath_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ProveBlockPathRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NodeManagerServer).ProveBlockPath(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NodeManager_ProveBlockPath_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NodeManagerServer).ProveBlockPath(ctx, req.(*ProveBlockPathRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // NodeManager_ServiceDesc is the grpc.ServiceDesc for NodeManager service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -250,6 +320,14 @@ var NodeManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListNodeCapacity",
 			Handler:    _NodeManager_ListNodeCapacity_Handler,
+		},
+		{
+			MethodName: "GetBlockHeader",
+			Handler:    _NodeManager_GetBlockHeader_Handler,
+		},
+		{
+			MethodName: "ProveBlockPath",
+			Handler:    _NodeManager_ProveBlockPath_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/common/nodemanager/nodemanager.proto
+++ b/common/nodemanager/nodemanager.proto
@@ -10,6 +10,10 @@ service NodeManager {
   rpc GetRuntimeConfig(GetRuntimeConfigRequest) returns (GetRuntimeConfigResponse);
   rpc GetHostEvents(GetHostEventsRequest) returns (GetHostEventsResponse);
   rpc ListNodeCapacity(ListNodeCapacityRequest) returns (ListNodeCapacityResponse);
+  // Unary twins of HTTP GET /block/:height and GET /block/:height/prove.
+  // Live tip remains Comet NewBlock, not a gRPC stream.
+  rpc GetBlockHeader(GetBlockHeaderRequest) returns (GetBlockHeaderResponse);
+  rpc ProveBlockPath(ProveBlockPathRequest) returns (ProveBlockPathResponse);
 }
 
 message AcquireMLNodeRequest {
@@ -173,4 +177,55 @@ message NodeCapacityEntry {
 message ListNodeCapacityResponse {
   repeated NodeCapacityEntry nodes = 1;
   int64 served_at_unix = 2;
+}
+
+// GetBlockHeaderRequest looks up a committed header. Height 0 means Latest().
+message GetBlockHeaderRequest {
+  int64 height = 1;
+}
+
+message GetBlockHeaderResponse {
+  BlockHeader header = 1;
+}
+
+// ProveBlockPathRequest is GET /block/:height/prove?path=. Hash-only
+// producers return Unimplemented (HTTP 501).
+message ProveBlockPathRequest {
+  int64 height = 1;
+  string path = 2;
+}
+
+message ProveBlockPathResponse {
+  BlockProof proof = 1;
+}
+
+// BlockHeader is the gRPC shape of chainoracle/blocks.Header.
+message BlockHeader {
+  int64 height = 1;
+  int64 time_unix_nano = 2;
+  string chain_id = 3;
+  bytes block_hash = 4;
+  bytes app_hash = 5;
+  bytes validators_hash = 6;
+  bytes next_validators_hash = 7;
+  BlockCommit commit = 8;
+}
+
+message BlockCommit {
+  int64 height = 1;
+  int32 round = 2;
+  bytes block_id = 3;
+  repeated BlockCommitSig signatures = 4;
+}
+
+message BlockCommitSig {
+  bytes validator_address = 1;
+  int64 timestamp_unix_nano = 2;
+  bytes signature = 3;
+}
+
+message BlockProof {
+  string path = 1;
+  bytes value = 2;
+  repeated bytes ops = 3;
 }

--- a/common/runtimeconfig/client/grpc_provider_test.go
+++ b/common/runtimeconfig/client/grpc_provider_test.go
@@ -254,6 +254,16 @@ func (r *recordingClient) ListNodeCapacity(ctx context.Context, in *gen.ListNode
 	return r.inner.ListNodeCapacity(ctx, in, opts...)
 }
 
+func (r *recordingClient) GetBlockHeader(ctx context.Context, in *gen.GetBlockHeaderRequest, opts ...grpc.CallOption) (*gen.GetBlockHeaderResponse, error) {
+	return r.inner.GetBlockHeader(ctx, in, opts...)
+}
+
+func (r *recordingClient) ProveBlockPath(ctx context.Context, in *gen.ProveBlockPathRequest, opts ...grpc.CallOption) (*gen.ProveBlockPathResponse, error) {
+	return r.inner.ProveBlockPath(ctx, in, opts...)
+}
+
+var _ gen.NodeManagerClient = (*recordingClient)(nil)
+
 func TestGRPCProvider_LongPoll_ServerTimeoutDoesNotApply(t *testing.T) {
 	srv := testserver.New()
 	handlers := []testserver.Handler{testserver.FullConfig(TestRuntimeConfigProto(100, 1, "raw"))}

--- a/decentralized-api/internal/server/public/chainoracle.go
+++ b/decentralized-api/internal/server/public/chainoracle.go
@@ -29,7 +29,8 @@ func NewChainOracle(rpcURL string) (*observer.Oracle, error) {
 }
 
 // WithChainOracle mounts GET /block/:height from the shared oracle (same
-// instance the NewBlock listener Observes into).
+// instance the NewBlock listener Observes into). NodeManager gRPC
+// GetBlockHeader / ProveBlockPath use that same oracle via WithBlockOracle.
 func WithChainOracle(o blocks.BlockOracle) ServerOption {
 	return func(s *Server) {
 		s.chainOracle = o

--- a/decentralized-api/main.go
+++ b/decentralized-api/main.go
@@ -312,10 +312,17 @@ func main() {
 	// Negative ports explicitly disable the NodeManager gRPC server.
 	if nmGrpcPort > 0 {
 		nmGrpcServer := grpc.NewServer()
-		nmgen.RegisterNodeManagerServer(nmGrpcServer, nodemanager.NewServer(nodeBroker, configManager, chainPhaseTracker,
+		nmOpts := []nodemanager.ServerOption{
 			nodemanager.WithHostEventRing(hostEventRing),
 			nodemanager.WithEscrowLoadTracker(escrowLoadTracker),
-		))
+		}
+		// Guard like the HTTP mount below: a nil *observer.Oracle passed as an
+		// interface is not nil, so GetBlockHeader would answer NotFound for a
+		// disabled oracle instead of FailedPrecondition.
+		if chainOracle != nil {
+			nmOpts = append(nmOpts, nodemanager.WithBlockOracle(chainOracle))
+		}
+		nmgen.RegisterNodeManagerServer(nmGrpcServer, nodemanager.NewServer(nodeBroker, configManager, chainPhaseTracker, nmOpts...))
 		reflection.Register(nmGrpcServer)
 		nodeManagerAddr := fmt.Sprintf(":%v", nmGrpcPort)
 		nmLis, err := net.Listen("tcp", nodeManagerAddr)

--- a/decentralized-api/nodemanager/block_rpc_test.go
+++ b/decentralized-api/nodemanager/block_rpc_test.go
@@ -1,0 +1,76 @@
+package nodemanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"common/chainoracle/blocks"
+	"common/nodemanager/gen"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type blockStub struct {
+	hdr   *blocks.Header
+	proof *blocks.Proof
+	prove error
+}
+
+func (s blockStub) Latest(context.Context) (*blocks.Header, error) { return s.hdr, nil }
+func (s blockStub) At(context.Context, int64) (*blocks.Header, error) {
+	if s.hdr == nil {
+		return nil, blocks.ErrHeaderNotFound
+	}
+	return s.hdr, nil
+}
+func (s blockStub) Prove(context.Context, string, int64) (*blocks.Proof, error) {
+	if s.prove != nil {
+		return nil, s.prove
+	}
+	return s.proof, nil
+}
+func (blockStub) Subscribe(context.Context, int64) (<-chan *blocks.Header, error) {
+	ch := make(chan *blocks.Header)
+	close(ch)
+	return ch, nil
+}
+
+func TestGetBlockHeader_UsesSharedOracle(t *testing.T) {
+	hdr := blocks.HashOnlyHeader(12, time.Unix(50, 0).UTC(), "gonka-test", []byte{0xab})
+	srv := NewServer(nil, nil, nil, WithBlockOracle(blockStub{hdr: hdr}))
+
+	resp, err := srv.GetBlockHeader(context.Background(), &gen.GetBlockHeaderRequest{Height: 12})
+	require.NoError(t, err)
+	require.Equal(t, int64(12), resp.Header.Height)
+	require.Equal(t, []byte{0xab}, resp.Header.BlockHash)
+	require.Equal(t, "gonka-test", resp.Header.ChainId)
+}
+
+func TestGetBlockHeader_NilOracleFailedPrecondition(t *testing.T) {
+	srv := NewServer(nil, nil, nil)
+	_, err := srv.GetBlockHeader(context.Background(), &gen.GetBlockHeaderRequest{Height: 1})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestProveBlockPath_UnimplementedOnHashOnly(t *testing.T) {
+	hdr := blocks.HashOnlyHeader(1, time.Unix(1, 0).UTC(), "gonka-test", []byte{1})
+	srv := NewServer(nil, nil, nil, WithBlockOracle(blockStub{hdr: hdr, prove: blocks.ErrProveNotImplemented}))
+	_, err := srv.ProveBlockPath(context.Background(), &gen.ProveBlockPathRequest{Height: 1, Path: "/escrow/1"})
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+func TestProveBlockPath_ReturnsOracleProof(t *testing.T) {
+	proof := &blocks.Proof{Path: "/escrow/1", Value: []byte{1, 2}, Ops: [][]byte{{3}}}
+	srv := NewServer(nil, nil, nil, WithBlockOracle(blockStub{
+		hdr:   blocks.HashOnlyHeader(1, time.Unix(1, 0).UTC(), "gonka-test", []byte{1}),
+		proof: proof,
+	}))
+	resp, err := srv.ProveBlockPath(context.Background(), &gen.ProveBlockPathRequest{Height: 1, Path: "/escrow/1"})
+	require.NoError(t, err)
+	require.Equal(t, proof.Path, resp.Proof.Path)
+	require.Equal(t, proof.Value, resp.Proof.Value)
+	require.Equal(t, proof.Ops, resp.Proof.Ops)
+}

--- a/decentralized-api/nodemanager/server.go
+++ b/decentralized-api/nodemanager/server.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"time"
 
-	"decentralized-api/apiconfig"
-	"decentralized-api/broker"
-	"decentralized-api/chainphase"
+	"common/chainoracle/blocks"
+	"common/chainoracle/blocks/nmrpc"
 	"common/logging"
 	"common/nodemanager/gen"
 	"common/runtimeconfig"
+	"decentralized-api/apiconfig"
+	"decentralized-api/broker"
+	"decentralized-api/chainphase"
 
 	"github.com/productscience/inference/x/inference/types"
 	"google.golang.org/grpc/codes"
@@ -36,6 +38,7 @@ type Server struct {
 	runtimeConfig *runtimeconfig.Server
 	hostEvents    *apiconfig.HostEventRing
 	escrowLoad    *broker.EscrowLoadTracker
+	blockOracle   blocks.BlockOracle
 }
 
 // ServerOption configures optional Server dependencies.
@@ -50,6 +53,12 @@ func WithHostEventRing(ring *apiconfig.HostEventRing) ServerOption {
 // populate GetHostEventsResponse.escrow_load.
 func WithEscrowLoadTracker(t *broker.EscrowLoadTracker) ServerOption {
 	return func(s *Server) { s.escrowLoad = t }
+}
+
+// WithBlockOracle serves GetBlockHeader / ProveBlockPath from the same
+// BlockOracle as HTTP GET /block/:height. Nil (omitted) → FailedPrecondition.
+func WithBlockOracle(o blocks.BlockOracle) ServerOption {
+	return func(s *Server) { s.blockOracle = o }
 }
 
 // NewServer creates a NodeManager gRPC server. configManager and phaseTracker are
@@ -148,6 +157,14 @@ func (s *Server) GetRuntimeConfig(ctx context.Context, req *gen.GetRuntimeConfig
 		return nil, status.Error(codes.FailedPrecondition, "runtime config: config manager not configured")
 	}
 	return s.runtimeConfig.Handle(ctx, req)
+}
+
+func (s *Server) GetBlockHeader(ctx context.Context, req *gen.GetBlockHeaderRequest) (*gen.GetBlockHeaderResponse, error) {
+	return nmrpc.GetBlockHeader(ctx, s.blockOracle, req)
+}
+
+func (s *Server) ProveBlockPath(ctx context.Context, req *gen.ProveBlockPathRequest) (*gen.ProveBlockPathResponse, error) {
+	return nmrpc.ProveBlockPath(ctx, s.blockOracle, req)
 }
 
 func currentEpochID(pt *chainphase.ChainPhaseTracker) uint64 {

--- a/devshard/testenv/mockdapi/blockgrpc.go
+++ b/devshard/testenv/mockdapi/blockgrpc.go
@@ -1,0 +1,120 @@
+package mockdapi
+
+import (
+	"context"
+	"fmt"
+
+	cblocks "common/chainoracle/blocks"
+	"devshard/chainoracle/blocks"
+)
+
+// commonBlockOracle adapts the mock observer onto the common BlockOracle
+// the NodeManager gRPC handlers already speak.
+type commonBlockOracle struct {
+	inner blocks.BlockOracle
+}
+
+func (o commonBlockOracle) Latest(ctx context.Context) (*cblocks.Header, error) {
+	h, err := o.inner.Latest(ctx)
+	if err != nil {
+		return nil, mapMockOracleErr(ctx, err)
+	}
+	return toCommonHeader(h), nil
+}
+
+func (o commonBlockOracle) At(ctx context.Context, height int64) (*cblocks.Header, error) {
+	h, err := o.inner.At(ctx, height)
+	if err != nil {
+		return nil, mapMockOracleErr(ctx, err)
+	}
+	return toCommonHeader(h), nil
+}
+
+func (o commonBlockOracle) Prove(ctx context.Context, path string, height int64) (*cblocks.Proof, error) {
+	p, err := o.inner.Prove(ctx, path, height)
+	if err != nil {
+		return nil, mapMockOracleErr(ctx, err)
+	}
+	return toCommonProof(p), nil
+}
+
+func (o commonBlockOracle) Subscribe(ctx context.Context, fromHeight int64) (<-chan *cblocks.Header, error) {
+	ch, err := o.inner.Subscribe(ctx, fromHeight)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan *cblocks.Header)
+	go func() {
+		defer close(out)
+		for h := range ch {
+			select {
+			case <-ctx.Done():
+				return
+			case out <- toCommonHeader(h):
+			}
+		}
+	}()
+	return out, nil
+}
+
+func mapMockOracleErr(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return fmt.Errorf("%w: %v", cblocks.ErrHeaderNotFound, err)
+}
+
+func toCommonHeader(h *blocks.Header) *cblocks.Header {
+	if h == nil {
+		return nil
+	}
+	out := &cblocks.Header{
+		Height:             h.Height,
+		Time:               h.Time,
+		ChainID:            h.ChainID,
+		BlockHash:          append([]byte(nil), h.BlockHash...),
+		AppHash:            append([]byte(nil), h.AppHash...),
+		ValidatorsHash:     append([]byte(nil), h.ValidatorsHash...),
+		NextValidatorsHash: append([]byte(nil), h.NextValidatorsHash...),
+		Commit: cblocks.Commit{
+			Height:  h.Commit.Height,
+			Round:   h.Commit.Round,
+			BlockID: append([]byte(nil), h.Commit.BlockID...),
+		},
+	}
+	if len(h.Commit.Signatures) == 0 {
+		return out
+	}
+	out.Commit.Signatures = make([]cblocks.CommitSig, len(h.Commit.Signatures))
+	for i, s := range h.Commit.Signatures {
+		out.Commit.Signatures[i] = cblocks.CommitSig{
+			ValidatorAddress: append([]byte(nil), s.ValidatorAddress...),
+			Timestamp:        s.Timestamp,
+			Signature:        append([]byte(nil), s.Signature...),
+		}
+	}
+	return out
+}
+
+func toCommonProof(p *blocks.Proof) *cblocks.Proof {
+	if p == nil {
+		return nil
+	}
+	out := &cblocks.Proof{
+		Path:  p.Path,
+		Value: append([]byte(nil), p.Value...),
+	}
+	if len(p.Ops) == 0 {
+		return out
+	}
+	out.Ops = make([][]byte, len(p.Ops))
+	for i, op := range p.Ops {
+		out.Ops[i] = append([]byte(nil), op...)
+	}
+	return out
+}
+
+var _ cblocks.BlockOracle = commonBlockOracle{}

--- a/devshard/testenv/mockdapi/hostevents.go
+++ b/devshard/testenv/mockdapi/hostevents.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"common/chainoracle/blocks"
+	"common/chainoracle/blocks/nmrpc"
 	"common/nodemanager/gen"
 	"devshard/chainoracle/params"
 
@@ -96,11 +98,20 @@ func (r *hostEventRing) since(cursor, clientGen uint64, want map[gen.HostEventKi
 // long-poll warm scenario. Other RPCs are inherited from the embedded params server.
 type nodeManagerServer struct {
 	*params.Server
-	ring *hostEventRing
+	ring   *hostEventRing
+	oracle blocks.BlockOracle
 }
 
-func newNodeManagerServer(paramsSrv *params.Server, ring *hostEventRing) *nodeManagerServer {
-	return &nodeManagerServer{Server: paramsSrv, ring: ring}
+func newNodeManagerServer(paramsSrv *params.Server, ring *hostEventRing, oracle blocks.BlockOracle) *nodeManagerServer {
+	return &nodeManagerServer{Server: paramsSrv, ring: ring, oracle: oracle}
+}
+
+func (s *nodeManagerServer) GetBlockHeader(ctx context.Context, req *gen.GetBlockHeaderRequest) (*gen.GetBlockHeaderResponse, error) {
+	return nmrpc.GetBlockHeader(ctx, s.oracle, req)
+}
+
+func (s *nodeManagerServer) ProveBlockPath(ctx context.Context, req *gen.ProveBlockPathRequest) (*gen.ProveBlockPathResponse, error) {
+	return nmrpc.ProveBlockPath(ctx, s.oracle, req)
 }
 
 // GetHostEvents implements the NodeManager long-poll over the mock ring.

--- a/devshard/testenv/mockdapi/hostevents_test.go
+++ b/devshard/testenv/mockdapi/hostevents_test.go
@@ -19,7 +19,7 @@ func escrowSub() []gen.HostEventKind {
 
 func TestHostEvents_ImmediateAndCursorUnchanged(t *testing.T) {
 	ring := newHostEventRing()
-	srv := newNodeManagerServer(nil, ring)
+	srv := newNodeManagerServer(nil, ring, nil)
 	ring.AppendEscrowCreated(&gen.EscrowPayload{EscrowId: 7})
 
 	resp, err := srv.GetHostEvents(context.Background(), &gen.GetHostEventsRequest{
@@ -41,7 +41,7 @@ func TestHostEvents_ImmediateAndCursorUnchanged(t *testing.T) {
 
 func TestHostEvents_LongPollWakesOnAppend(t *testing.T) {
 	ring := newHostEventRing()
-	srv := newNodeManagerServer(nil, ring)
+	srv := newNodeManagerServer(nil, ring, nil)
 	go func() {
 		time.Sleep(150 * time.Millisecond)
 		ring.AppendEscrowCreated(&gen.EscrowPayload{EscrowId: 42})
@@ -59,7 +59,7 @@ func TestHostEvents_LongPollWakesOnAppend(t *testing.T) {
 
 func TestHostEvents_GenerationMismatchResets(t *testing.T) {
 	ring := newHostEventRing()
-	srv := newNodeManagerServer(nil, ring)
+	srv := newNodeManagerServer(nil, ring, nil)
 
 	resp, err := srv.GetHostEvents(context.Background(), &gen.GetHostEventsRequest{
 		Cursor: 0, Generation: 999, Subscribe: escrowSub(),
@@ -70,7 +70,7 @@ func TestHostEvents_GenerationMismatchResets(t *testing.T) {
 
 func TestHostEvents_SubscribeRequired(t *testing.T) {
 	ring := newHostEventRing()
-	srv := newNodeManagerServer(nil, ring)
+	srv := newNodeManagerServer(nil, ring, nil)
 
 	_, err := srv.GetHostEvents(context.Background(), &gen.GetHostEventsRequest{Cursor: 0})
 	require.Error(t, err)

--- a/devshard/testenv/mockdapi/service.go
+++ b/devshard/testenv/mockdapi/service.go
@@ -195,7 +195,7 @@ func (s *Service) runChainPoll(ctx context.Context) error {
 
 func (s *Service) serveGRPCOn(ctx context.Context, lis net.Listener) error {
 	gs := grpc.NewServer()
-	gen.RegisterNodeManagerServer(gs, newNodeManagerServer(s.paramsSrv, s.hostEvents))
+	gen.RegisterNodeManagerServer(gs, newNodeManagerServer(s.paramsSrv, s.hostEvents, commonBlockOracle{inner: s.blockMock}))
 	s.grpcServer = gs
 	go func() {
 		<-ctx.Done()

--- a/devshard/testenv/mockdapi/service_test.go
+++ b/devshard/testenv/mockdapi/service_test.go
@@ -187,6 +187,38 @@ func TestMockDAPI_VersionsJSON(t *testing.T) {
 	require.Equal(t, updated, cfg)
 }
 
+func TestMockDAPI_GetBlockHeaderMatchesHTTP(t *testing.T) {
+	bed := startBed(t)
+	t.Cleanup(bed.cleanup)
+
+	httpResp, err := http.Get(bed.httpURL + "/block/1")
+	require.NoError(t, err)
+	defer httpResp.Body.Close()
+	require.Equal(t, http.StatusOK, httpResp.StatusCode)
+	var httpHdr struct {
+		Height    int64  `json:"Height"`
+		ChainID   string `json:"ChainID"`
+		BlockHash []byte `json:"BlockHash"`
+	}
+	require.NoError(t, json.NewDecoder(httpResp.Body).Decode(&httpHdr))
+
+	conn, err := grpc.NewClient(bed.grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	client := gen.NewNodeManagerClient(conn)
+
+	grpcResp, err := client.GetBlockHeader(context.Background(), &gen.GetBlockHeaderRequest{Height: 1})
+	require.NoError(t, err)
+	require.Equal(t, httpHdr.Height, grpcResp.Header.Height)
+	require.Equal(t, httpHdr.ChainID, grpcResp.Header.ChainId)
+	require.Equal(t, httpHdr.BlockHash, grpcResp.Header.BlockHash)
+
+	proof, err := client.ProveBlockPath(context.Background(), &gen.ProveBlockPathRequest{Height: 1, Path: "/escrow/1"})
+	require.NoError(t, err)
+	require.Equal(t, "/escrow/1", proof.Proof.Path)
+	require.NotEmpty(t, proof.Proof.Value)
+}
+
 func TestMockDAPI_BlockStreamMonotonic(t *testing.T) {
 	bed := startBed(t)
 	t.Cleanup(bed.cleanup)


### PR DESCRIPTION
## Summary
- Add unary `GetBlockHeader` and `ProveBlockPath` on NodeManager gRPC as twins of HTTP `GET /block/:height` and `GET /block/:height/prove`.
- Both RPCs read the same `BlockOracle` as the HTTP mount (`WithBlockOracle`). No second producer, and no gRPC stream — live tip stays Comet NewBlock.
- Proto is additive only. Omit the oracle and both RPCs answer `FailedPrecondition`. `nmrpc` holds handlers + wire mapping; `nmclient` is a gRPC `BlockOracle` for hosts (no production caller yet). mock-dapi serves the same RPCs for testenv.

It's followup for https://github.com/gonka-ai/gonka/pull/1622 that adds grpc for same functionality endpoints as /block, at node manager server