### PR TITLE
perf(devshard): gzip the inference answer and accept a gzipped request

### DIFF
--- a/devshard/accounting/detail_reason.go
+++ b/devshard/accounting/detail_reason.go
@@ -17,7 +17,7 @@ func normalizeDetailReason(reason string) string {
 	case "", "none":
 		return ""
 	case "phase_transition_aborted", "error_stream", "empty_stream", "model_burn_empty", "sse_truncated",
-		"sse_event_too_large", "response_body_too_large", "aggregate_response_too_large", "aggregate_fold_too_large",
+		"sse_event_too_large", "sse_stream_too_large", "response_body_too_large", "aggregate_response_too_large", "aggregate_fold_too_large",
 		"eof_transport", "client_cancelled", "transport_error", "no_receipt",
 		"not_finished", "http_429", "http_503", "http_forbidden", "http_not_found",
 		"http_timestamp_drift", "http_error", "long_response_after_content",
@@ -41,7 +41,7 @@ func normalizeDeliveryReason(reason string) string {
 	case "", "none":
 		return ""
 	case "empty_stream", "model_burn_empty", "error_stream", "sse_truncated",
-		"sse_event_too_large", "response_body_too_large", "aggregate_response_too_large", "aggregate_fold_too_large",
+		"sse_event_too_large", "sse_stream_too_large", "response_body_too_large", "aggregate_response_too_large", "aggregate_fold_too_large",
 		"eof_transport", "transport_error", "client_cancelled", "not_finished",
 		"no_receipt", "http_error", "http_429", "http_503", "http_not_found",
 		"http_forbidden", DeliveryClientGone, DeliveryWarmupProbe, DeliveryThrottleProbe:

--- a/devshard/accounting/reason_vocabulary_test.go
+++ b/devshard/accounting/reason_vocabulary_test.go
@@ -100,7 +100,7 @@ func TestNormalizeDeliveryReason_KeepsWhatADeliveryCanBe(t *testing.T) {
 // gateway enforced is a concrete host fault, and collapsing it to unknown loses the per-host report.
 func TestNormalizeReasons_KeepEveryBoundedResponseFailure(t *testing.T) {
 	for _, reason := range []string{
-		"sse_event_too_large", "response_body_too_large",
+		"sse_event_too_large", "sse_stream_too_large", "response_body_too_large",
 		"aggregate_response_too_large", "aggregate_fold_too_large",
 	} {
 		require.Equal(t, reason, normalizeDetailReason(reason))

--- a/devshard/cmd/devshard-host/main.go
+++ b/devshard/cmd/devshard-host/main.go
@@ -107,6 +107,7 @@ func registerLiveness(e *echo.Echo, version string) {
 func registerServer(g *echo.Group, srv *transport.Server, gsp *gossip.Gossip, stubInferenceHTTPStatus int, stubInferenceHTTPMessage string) {
 	g.Use(observability.EchoMiddleware())
 	g.Use(observability.RequestIDMiddleware)
+	g.Use(transport.RequestDecompressionMiddleware)
 
 	withAuth := func(recordChatTerminal bool, handler echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -133,7 +134,7 @@ func registerServer(g *echo.Group, srv *transport.Server, gsp *gossip.Gossip, st
 		}
 	}
 
-	g.POST("/sessions/:id/chat/completions", withAuth(true, inferenceHandler))
+	g.POST("/sessions/:id/chat/completions", withAuth(true, inferenceHandler), transport.ResponseCompressionMiddleware)
 	g.POST("/sessions/:id/height-sync", withAuth(false, srv.HandleHeightSync))
 	g.POST("/sessions/:id/heightsync/repair", withAuth(false, srv.HandleHeightSyncRepair))
 	g.POST("/sessions/:id/verify-timeout", withAuth(false, srv.HandleVerifyTimeout))

--- a/devshard/cmd/devshardctl/compression_env.go
+++ b/devshard/cmd/devshardctl/compression_env.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"devshard/internal/boolvalue"
+)
+
+// envGatewayCompressRequestBodies gzips request bodies on the gateway leg.
+const envGatewayCompressRequestBodies = "DEVSHARD_GATEWAY_COMPRESS_REQUEST_BODIES"
+
+// compressRequestBodiesFromEnv reports whether the gateway compresses requests.
+func compressRequestBodiesFromEnv() (bool, error) {
+	enabled, err := boolvalue.Parse(os.Getenv(envGatewayCompressRequestBodies))
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", envGatewayCompressRequestBodies, err)
+	}
+	return enabled, nil
+}

--- a/devshard/cmd/devshardctl/compression_env_test.go
+++ b/devshard/cmd/devshardctl/compression_env_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The grammar is boolvalue's; what is ours is which variable is read.
+func TestCompressRequestBodiesFromEnv(t *testing.T) {
+	require.Equal(t, "DEVSHARD_GATEWAY_COMPRESS_REQUEST_BODIES", envGatewayCompressRequestBodies,
+		"the operator manual documents this name")
+
+	for _, testCase := range []struct {
+		raw  string
+		want bool
+	}{
+		{"", false},
+		{"false", false},
+		{"on", true},
+		{" True ", true},
+	} {
+		t.Run("value "+testCase.raw, func(t *testing.T) {
+			t.Setenv(envGatewayCompressRequestBodies, testCase.raw)
+
+			enabled, err := compressRequestBodiesFromEnv()
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.want, enabled)
+		})
+	}
+}
+
+// A typo must not read as "off".
+func TestCompressRequestBodiesFromEnv_RefusesAnUnrecognizedValue(t *testing.T) {
+	t.Setenv(envGatewayCompressRequestBodies, "maybe")
+
+	_, err := compressRequestBodiesFromEnv()
+
+	require.Error(t, err)
+}

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -318,6 +318,10 @@ func buildRuntime(cfg RuntimeConfig, deps runtimeBuildDeps) (*devshardRuntime, e
 	if err != nil {
 		return nil, fmt.Errorf("runtime %s: height sync: %w", cfg.ID, err)
 	}
+	compressRequestBodies, err := compressRequestBodiesFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("runtime %s: %w", cfg.ID, err)
+	}
 	session, sm, err := user.NewHTTPSession(user.HTTPSessionConfig{
 		PrivateKeyHex:           keyHex,
 		EscrowID:                cfg.ID,
@@ -326,6 +330,7 @@ func buildRuntime(cfg RuntimeConfig, deps runtimeBuildDeps) (*devshardRuntime, e
 		RoutePrefix:             routePrefix,
 		RequestAdmission:        sharedParticipantRequestLimiter,
 		RequireHeightSeed:       requireHeightSeedFromEnv(),
+		CompressRequestBodies:   compressRequestBodies,
 		Escrow:                  escrow,
 		RefusalTimeoutSeconds:   timeoutOverrides.RefusalTimeoutSeconds,
 		ExecutionTimeoutSeconds: timeoutOverrides.ExecutionTimeoutSeconds,

--- a/devshard/cmd/devshardctl/host_failure_log_test.go
+++ b/devshard/cmd/devshardctl/host_failure_log_test.go
@@ -57,6 +57,7 @@ func TestHostFailureLogFields_NamesTheWayTheStreamDied(t *testing.T) {
 		{"stream ended without a terminator", transport.ErrSSEStreamTruncated, "sse_truncated"},
 		{"host grew a single SSE event past the cap", transport.ErrSSEEventTooLarge, "sse_event_too_large"},
 		{"host grew a non-stream body past the cap", transport.ErrResponseBodyTooLarge, "response_body_too_large"},
+		{"host grew the whole stream past the cap", transport.ErrSSEStreamTooLarge, "sse_stream_too_large"},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/devshard/cmd/devshardctl/metrics.go
+++ b/devshard/cmd/devshardctl/metrics.go
@@ -1283,6 +1283,8 @@ func gatewayAttemptFailureReason(inf *inflight, session nonceFinishedChecker, mo
 			return "sse_truncated"
 		case errors.Is(inf.err, transport.ErrSSEEventTooLarge):
 			return "sse_event_too_large"
+		case errors.Is(inf.err, transport.ErrSSEStreamTooLarge):
+			return "sse_stream_too_large"
 		case errors.Is(inf.err, transport.ErrResponseBodyTooLarge):
 			return "response_body_too_large"
 		case errors.Is(inf.err, io.EOF), errors.Is(inf.err, io.ErrUnexpectedEOF), strings.Contains(strings.ToLower(inf.err.Error()), "eof"):

--- a/devshard/docs/v6-deploy-test-plan.md
+++ b/devshard/docs/v6-deploy-test-plan.md
@@ -1,0 +1,100 @@
+# v6 deploy and test plan (delta from v5)
+
+[v5-deploy-test-plan.md](./v5-deploy-test-plan.md) is the operator walkthrough for the 0.2.15 / v5 line — HA join overlay, router health and catalog admission, the gateway chain follower, host ping, warm cutover. All of it still applies. Do not edit it to describe v6.
+
+This note is what changed for the **0.2.16 / v6** line: the two legs between the gateway and a devshard host are compressed. The response leg needs no flag and no decision. The request leg is behind one, and it is the only switch in this line that can break inference across a whole roster if it is turned on early.
+
+Related: [gzip-in-transit.md](../../docs/proposal/gzip-in-transit.md) (design, measurements, compatibility matrix), [compressed-payloads.md](../../docs/proposal/compressed-payloads.md) (the payload-storage work this builds on), [v5-deploy-test-plan.md](./v5-deploy-test-plan.md).
+
+---
+
+## Scope: two legs, two different stories
+
+| Leg | Ships as | Operator decision |
+| --- | --- | --- |
+| host → gateway (the SSE answer) | **on**, negotiated, no flag | none — check the proxies below once |
+| gateway → host (the request body) | **off**, behind a flag | yes — it has a precondition on the whole roster |
+
+Neither leg persists anything and neither changes host state. Rollback on either is a restart.
+
+## Response compression (no flag)
+
+A host answers gzip when the caller asks for it. Nothing had to change on the calling side: the transport client sets no `Accept-Encoding` of its own and leaves `DisableCompression` off, so Go already asks and already unwraps. An old host that does not compress simply answers as before — this is `Accept-Encoding` negotiation, not a switch, so mixed rosters are fine in both directions.
+
+Measured on the answer shape hosts send today: **4.9x** on a 4096-token completion. What is on the wire changes; what the gateway parses does not.
+
+What to check once, and only if you run a non-standard edge:
+
+- **nginx** — the streaming location already sets `proxy_buffering off`, `proxy_request_buffering off` and `gzip off` (`proxy/entrypoint.sh`, `STREAMING_CONFIG`). `gzip off` stops nginx compressing on its own; it does not unwrap what a host compressed. Do **not** add `gunzip on`.
+- **HAProxy** (`versiond-router/haproxy.cfg.template`) has no compression directives at all and forwards both directions untouched.
+- Any proxy of your own must not decompress a **request** body. See the precondition below for why that specific one is fatal.
+
+## Request compression (`DEVSHARD_GATEWAY_COMPRESS_REQUEST_BODIES`)
+
+The gateway may gzip the request bodies it sends hosts. Requests have no `Accept-Encoding` equivalent — a sender cannot ask whether the far side understands gzip — so this one is **off by default**.
+
+| | |
+| --- | --- |
+| Env | `DEVSHARD_GATEWAY_COMPRESS_REQUEST_BODIES` |
+| Enable | `1` / `t` / `true` / `yes` / `on` (case-insensitive) |
+| Default | **off**. Unset, empty, `0` / `f` / `false` / `no` / `off` leave bodies uncompressed. Any other value fails the runtime rather than reading as off. |
+| What it changes | Bodies from 1 KiB up leave gzipped; the signature still covers the plaintext |
+| Precondition | **Every host in the roster must already decompress.** Ship the read side first |
+| Observability cost | `http.request_content_length` drops off the span for a compressed POST, because the header no longer describes the body once it is unwrapped. `/chat/completions` still reports the decoded size separately; the protocol routes report none |
+| Failure if the precondition is unmet | The host verifies the compressed bytes, recovers a different address, and answers **403 sender-not-in-group** — which reads as a key or registration problem, not a compression one |
+
+That last row is the one to remember. The signature covers the body with no canonicalisation, and ECDSA recovery does not fail on the wrong bytes — it returns somebody else. A host without the read side therefore does not say "I cannot read this"; it says "I do not know you".
+
+---
+
+## Operator checklist
+
+### Response leg (all v6 deploys)
+
+- [ ] No action. Confirm chat still streams token by token after the upgrade; a stalled first token is the symptom to escalate on.
+- [ ] If you run your own edge, confirm it does not set `gunzip on` and does not buffer the `/chat/completions` response.
+
+### Request leg (only when turning the flag on)
+
+- [ ] Confirm **every** host in the roster runs v6 or later. A single host on the old build answers 403 sender-not-in-group for every request the gateway compresses to it.
+- [ ] Turn it on for one gateway first and watch that host's 403 rate, not just the gateway's error rate.
+- [ ] Confirm no proxy between gateway and hosts decompresses request bodies. Decompression must happen at the host, under its verifier.
+- [ ] Rollback is clearing the variable and restarting. Nothing is persisted; hosts need no coordinated change.
+
+---
+
+## Automated tests
+
+These run in the normal `go test` sweep; none needs the stand.
+
+### The signature survives the encoding
+
+```bash
+cd devshard && go test ./server/ -run 'TestCompressedRequest|TestSigningTheCompressedBytes|TestMalformedGzip|TestTruncatedGzip|TestEmptyBodyClaimingGzip' -count=1
+```
+
+Proves a body signed as plaintext and sent compressed verifies through the real routes; that signing the encoding instead recovers a stranger; that a body claiming gzip and not being gzip answers 400 rather than a 5xx; and that the 10 MiB cap bounds the **decoded** body, asserted with a real bomb.
+
+### The stream is not held back
+
+```bash
+cd devshard && go test ./transport/ -run TestServer_CompressedStreamingInferenceStaysFrameByFrame -count=1
+```
+
+Drives the real `HandleInference` with `Accept-Encoding: gzip` and pins two flush points: the receipt reaches the wire before the answer, and the answer before `[DONE]`. Silencing either writer's flush fails it.
+
+### The decoded stream is bounded
+
+```bash
+cd devshard && go test ./transport/ -run TestParseSSE_Stream -count=1
+```
+
+Compression lets an untrusted executor buy a large decoded stream cheaply; `MaxSSEStreamBytes` (256 MiB) bounds it, and the pair of tests pins the boundary exactly.
+
+### End to end
+
+```bash
+cd devshard && make e2e
+```
+
+The stub host mounts the same two middlewares as production, so the stand exercises the mounted path rather than routing around it.

--- a/devshard/internal/testutil/flushrecorder.go
+++ b/devshard/internal/testutil/flushrecorder.go
@@ -1,0 +1,72 @@
+package testutil
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FlushRecorder keeps what had reached the wire at each Flush.
+type FlushRecorder struct {
+	headers     http.Header
+	body        []byte
+	flushes     [][]byte
+	code        int
+	wroteHeader bool
+}
+
+func NewFlushRecorder() *FlushRecorder {
+	return &FlushRecorder{headers: http.Header{}, code: http.StatusOK}
+}
+
+func (r *FlushRecorder) Header() http.Header { return r.headers }
+
+func (r *FlushRecorder) Write(p []byte) (int, error) {
+	r.body = append(r.body, p...)
+	return len(p), nil
+}
+
+// WriteHeader keeps the first code, as httptest.ResponseRecorder does.
+func (r *FlushRecorder) WriteHeader(code int) {
+	if r.wroteHeader {
+		return
+	}
+	r.wroteHeader = true
+	r.code = code
+}
+
+func (r *FlushRecorder) Flush() {
+	r.flushes = append(r.flushes, append([]byte(nil), r.body...))
+}
+
+// Code is the status the handler wrote.
+func (r *FlushRecorder) Code() int { return r.code }
+
+// Body is everything written, in order.
+func (r *FlushRecorder) Body() []byte { return r.body }
+
+// Flushes is one snapshot of the body per Flush, in order.
+func (r *FlushRecorder) Flushes() [][]byte { return r.flushes }
+
+// GzipDecodeSoFar returns what a still-open gzip stream decodes to.
+func GzipDecodeSoFar(t *testing.T, compressed []byte) string {
+	t.Helper()
+	if len(compressed) == 0 {
+		return ""
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return ""
+	}
+	defer reader.Close()
+	var decoded bytes.Buffer
+	if _, err := io.Copy(&decoded, reader); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		require.NoError(t, err)
+	}
+	return decoded.String()
+}

--- a/devshard/internal/testutil/testutil.go
+++ b/devshard/internal/testutil/testutil.go
@@ -1,6 +1,8 @@
 package testutil
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
 	"strings"
 	"testing"
@@ -232,4 +234,15 @@ func StartTx(inferenceID uint64) *types.DevshardTx {
 		MaxTokens:   TestMaxTokens,
 		StartedAt:   1000,
 	}}}
+}
+
+// MustGzip compresses body the way a sender puts it on the wire.
+func MustGzip(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	_, err := writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return compressed.Bytes()
 }

--- a/devshard/server/compressed_request_test.go
+++ b/devshard/server/compressed_request_test.go
@@ -1,0 +1,226 @@
+package server
+
+import (
+	"bytes"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/signing"
+	"devshard/transport"
+)
+
+const (
+	compressedRequestEscrowID = "60453"
+	gzipEncodingName          = "gzip"
+)
+
+// verifyingBinder runs the real auth step and reports what it recovered.
+type verifyingBinder struct {
+	verifier signing.Verifier
+	escrowID string
+	sender   *string
+	bodySize *int
+}
+
+func (b verifyingBinder) BindOwnerChat(c echo.Context) (*transport.Server, error) {
+	sender, body, err := transport.VerifyPOSTAuth(c, b.verifier, b.escrowID, transport.DefaultMaxBodySize)
+	if err != nil {
+		return nil, err
+	}
+	*b.sender = sender
+	*b.bodySize = len(body)
+	return nil, ErrInitializing
+}
+
+// newVerifyingRoutes mounts the production routes behind real auth.
+func newVerifyingRoutes() (*echo.Echo, *string, *int) {
+	var sender string
+	var bodySize int
+	e := echo.New()
+	RegisterLazySessionRoutes(
+		e.Group(""),
+		payloadsOnlyResolver{resolves: compressedRequestEscrowID},
+		verifyingBinder{
+			verifier: signing.NewSecp256k1Verifier(),
+			escrowID: compressedRequestEscrowID,
+			sender:   &sender,
+			bodySize: &bodySize,
+		},
+		nil,
+	)
+	return e, &sender, &bodySize
+}
+
+// signedRequest signs plainBody and sends wireBody.
+func signedRequest(t *testing.T, signer signing.Signer, plainBody, wireBody []byte, contentEncoding string) *http.Request {
+	t.Helper()
+	timestamp := time.Now().Unix()
+	signature, err := transport.SignRequest(signer, compressedRequestEscrowID, plainBody, timestamp)
+	require.NoError(t, err)
+
+	request := httptest.NewRequest(http.MethodPost,
+		"/sessions/"+compressedRequestEscrowID+"/chat/completions", bytes.NewReader(wireBody))
+	request.Header.Set(transport.HeaderSignature, hex.EncodeToString(signature))
+	request.Header.Set(transport.HeaderTimestamp, strconv.FormatInt(timestamp, 10))
+	if contentEncoding != "" {
+		request.Header.Set("Content-Encoding", contentEncoding)
+	}
+	return request
+}
+
+// Compress after signing, decompress before auth: both halves must agree.
+func TestCompressedRequestVerifiesThroughTheRealRoutes(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	e, sender, bodySize := newVerifyingRoutes()
+
+	body := []byte(`{"diffs":[],"nonce":7,"payload":{"prompt":"` + strings.Repeat("A", 8192) + `"}}`)
+	compressed := testutil.MustGzip(t, body)
+	require.Less(t, len(compressed), len(body)/4)
+
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, signedRequest(t, signer, body, compressed, gzipEncodingName))
+
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code, "auth passed; the session is simply not bound")
+	require.Equal(t, signer.Address(), *sender, "the host must recover the sender that signed the plaintext")
+	require.Equal(t, len(body), *bodySize, "auth must see the whole plaintext, not the compressed bytes")
+}
+
+func TestUncompressedRequestStillVerifies(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	e, sender, bodySize := newVerifyingRoutes()
+
+	body := []byte(`{"diffs":[],"nonce":7}`)
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, signedRequest(t, signer, body, body, ""))
+
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.Equal(t, signer.Address(), *sender,
+		"compression is opt-in per request: a sender that does not compress keeps working")
+	require.Equal(t, len(body), *bodySize)
+}
+
+// The cap must bound what the body decodes to, not what arrives.
+func TestCompressedRequestCapAppliesToTheDecompressedBytes(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	e, _, _ := newVerifyingRoutes()
+
+	bomb := make([]byte, transport.DefaultMaxBodySize+1)
+	compressed := testutil.MustGzip(t, bomb)
+	require.Less(t, int64(len(compressed)), transport.DefaultMaxBodySize/10,
+		"the bomb must be small on the wire to be worth testing")
+
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, signedRequest(t, signer, bomb, compressed, gzipEncodingName))
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code)
+}
+
+// Signing the encoding instead of the body recovers somebody else.
+func TestSigningTheCompressedBytesIsRejected(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	e, sender, _ := newVerifyingRoutes()
+
+	compressed := testutil.MustGzip(t, []byte(`{"diffs":[],"nonce":7}`))
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, signedRequest(t, signer, compressed, compressed, gzipEncodingName))
+
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code, "auth ran; the session is simply not bound")
+	require.NotEmpty(t, *sender, "auth must have recovered somebody")
+	require.NotEqual(t, signer.Address(), *sender,
+		"recovery does not fail on the wrong bytes, it yields somebody else — "+
+			"which real admission then rejects as sender-not-in-group")
+}
+
+// Runs before any caller is named, so it must never answer 5xx.
+func TestMalformedGzipRequestIsTheSendersFault(t *testing.T) {
+	e, _, _ := newVerifyingRoutes()
+
+	for _, testCase := range []struct {
+		name string
+		wire string
+	}{
+		{"wrong magic", "this is not gzip"},
+		{"header cut short", "\x1f\x8b\x08"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost,
+				"/sessions/"+compressedRequestEscrowID+"/chat/completions", strings.NewReader(testCase.wire))
+			request.Header.Set("Content-Encoding", gzipEncodingName)
+			recorder := httptest.NewRecorder()
+			e.ServeHTTP(recorder, request)
+
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+			require.Contains(t, recorder.Body.String(), "malformed gzip",
+				"the header check must name itself, not borrow the read-body error")
+		})
+	}
+}
+
+// No header to be wrong about, so it passes through to auth.
+func TestEmptyBodyClaimingGzipIsNotAGzipFault(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	e, sender, bodySize := newVerifyingRoutes()
+
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, signedRequest(t, signer, nil, nil, gzipEncodingName))
+
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code, "auth ran on the empty body")
+	require.Equal(t, signer.Address(), *sender)
+	require.Zero(t, *bodySize, "the body passed through as the empty body it is")
+}
+
+// A good header with a cut stream fails at the read, not the header check.
+func TestTruncatedGzipBodyFailsWhereItIsRead(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	e, _, _ := newVerifyingRoutes()
+
+	body := []byte(`{"diffs":[],"nonce":7,"payload":{"prompt":"` + strings.Repeat("A", 4096) + `"}}`)
+	compressed := testutil.MustGzip(t, body)
+	truncated := compressed[:len(compressed)/2]
+
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, signedRequest(t, signer, body, truncated, gzipEncodingName))
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "read body",
+		"a stream that dies while being read fails where it is read, not at the header check")
+}
+
+// Content codings are case-insensitive.
+func TestCompressedRequestAcceptsAnUppercaseEncoding(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	e, sender, _ := newVerifyingRoutes()
+
+	body := []byte(`{"diffs":[],"nonce":7}`)
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, signedRequest(t, signer, body, testutil.MustGzip(t, body), "GZIP"))
+
+	require.Equal(t, signer.Address(), *sender)
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+}
+
+// The decompression cleanup runs between the two.
+func TestConsecutiveCompressedRequestsBothVerify(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	e, sender, bodySize := newVerifyingRoutes()
+
+	for attempt := 0; attempt < 2; attempt++ {
+		body := []byte(`{"diffs":[],"nonce":` + strconv.Itoa(attempt) + `,"payload":{"prompt":"` +
+			strings.Repeat("A", 4096) + `"}}`)
+		recorder := httptest.NewRecorder()
+		e.ServeHTTP(recorder, signedRequest(t, signer, body, testutil.MustGzip(t, body), gzipEncodingName))
+
+		require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+		require.Equal(t, signer.Address(), *sender)
+		require.Equal(t, len(body), *bodySize)
+	}
+}

--- a/devshard/server/routes.go
+++ b/devshard/server/routes.go
@@ -1,13 +1,11 @@
 package server
 
 import (
-	"compress/gzip"
 	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 
 	devshardpkg "devshard"
 	"devshard/bridge"
@@ -52,9 +50,11 @@ func RegisterLazySessionRoutes(g *echo.Group, resolver SessionResolver, binder O
 	g.Use(observability.EchoMiddleware())
 	g.Use(observability.RequestIDMiddleware)
 	g.Use(canonicalEscrowIDMiddleware)
+	// Before auth: the signature covers the body, not its transfer encoding.
+	g.Use(transport.RequestDecompressionMiddleware)
 
 	g.POST("/sessions/:id/chat/completions", withOwnerChat(binder, true,
-		func(srv *transport.Server) echo.HandlerFunc { return srv.HandleInference }))
+		func(srv *transport.Server) echo.HandlerFunc { return srv.HandleInference }), transport.ResponseCompressionMiddleware)
 	g.POST("/sessions/:id/height-sync", withOwnerChat(binder, false,
 		func(srv *transport.Server) echo.HandlerFunc { return srv.HandleHeightSync }))
 	g.POST("/sessions/:id/heightsync/repair", withSessionAuth(resolver, false,
@@ -78,7 +78,6 @@ func RegisterLazySessionRoutes(g *echo.Group, resolver SessionResolver, binder O
 		func(srv *transport.Server) echo.HandlerFunc { return srv.HandleGetSignatures }))
 
 	if payloadHandler != nil {
-		// Scoped to this route: gzip on the inference stream would buffer it.
 		g.GET("/sessions/:id/payloads", func(c echo.Context) error {
 			srv, err := resolver.SessionServerExisting(c.Param("id"))
 			if err != nil {
@@ -87,7 +86,7 @@ func RegisterLazySessionRoutes(g *echo.Group, resolver SessionResolver, binder O
 			}
 			observability.IncSessionResolution(routeLabel(c), observability.MetricStatusOK, observability.ReasonOK)
 			return payloadHandler.HandlePayloads(c, srv)
-		}, middleware.GzipWithConfig(middleware.GzipConfig{Level: gzip.BestSpeed}))
+		}, transport.ResponseCompressionMiddleware)
 	}
 }
 

--- a/devshard/server/routes_test.go
+++ b/devshard/server/routes_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"devshard/bridge"
+	"devshard/internal/testutil"
 	"devshard/observability"
 	"devshard/storage"
 	"devshard/transport"
@@ -139,21 +140,19 @@ func (h staticPayloadHandler) HandlePayloads(c echo.Context, _ *transport.Server
 	return c.JSONBlob(http.StatusOK, h.body)
 }
 
-// The inference half only says the route passes bytes through: echo leaves a handler-written body
-// uncompressed either way, so it does not prove the middleware is scoped rather than group-wide.
-func TestOnlyThePayloadsRouteCompresses(t *testing.T) {
+func TestPayloadsRouteCompresses(t *testing.T) {
 	body := []byte(`{"inference_id":"1","response_payload":"` + strings.Repeat("A", 8192) + `"}`)
 
 	e := echo.New()
-	RegisterLazySessionRoutes(e.Group(""), payloadsOnlyResolver{resolves: "60453"}, writingBinder{body: body}, staticPayloadHandler{body: body})
+	RegisterLazySessionRoutes(e.Group(""), payloadsOnlyResolver{resolves: compressedRequestEscrowID}, writingBinder{body: body}, staticPayloadHandler{body: body})
 
-	request := httptest.NewRequest(http.MethodGet, "/sessions/60453/payloads", nil)
-	request.Header.Set("Accept-Encoding", "gzip")
+	request := httptest.NewRequest(http.MethodGet, "/sessions/"+compressedRequestEscrowID+"/payloads", nil)
+	request.Header.Set("Accept-Encoding", gzipEncodingName)
 	recorder := httptest.NewRecorder()
 	e.ServeHTTP(recorder, request)
 
 	require.Equal(t, http.StatusOK, recorder.Code)
-	require.Equal(t, "gzip", recorder.Header().Get("Content-Encoding"))
+	require.Equal(t, gzipEncodingName, recorder.Header().Get("Content-Encoding"))
 	require.Less(t, recorder.Body.Len(), len(body)/4, "the compressed body should be a fraction of the payload")
 
 	reader, err := gzip.NewReader(bytes.NewReader(recorder.Body.Bytes()))
@@ -163,20 +162,70 @@ func TestOnlyThePayloadsRouteCompresses(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, string(body), string(decompressed), "the payload must survive the wire unchanged")
 
-	plain := httptest.NewRequest(http.MethodGet, "/sessions/60453/payloads", nil)
+	plain := httptest.NewRequest(http.MethodGet, "/sessions/"+compressedRequestEscrowID+"/payloads", nil)
 	plainRecorder := httptest.NewRecorder()
 	e.ServeHTTP(plainRecorder, plain)
 	require.Equal(t, http.StatusOK, plainRecorder.Code)
 	require.Empty(t, plainRecorder.Header().Get("Content-Encoding"))
 	require.JSONEq(t, string(body), plainRecorder.Body.String())
+}
 
-	streaming := httptest.NewRequest(http.MethodPost, "/sessions/60453/chat/completions", nil)
-	streaming.Header.Set("Accept-Encoding", "gzip")
-	streamingRecorder := httptest.NewRecorder()
-	e.ServeHTTP(streamingRecorder, streaming)
-	require.Equal(t, len(body), streamingRecorder.Body.Len(),
-		"the inference route passes bytes through untouched")
-	require.Empty(t, streamingRecorder.Header().Get("Content-Encoding"))
+// streamingBinder writes one frame per flush, as the handler does.
+type streamingBinder struct{ frames []string }
+
+func (b streamingBinder) BindOwnerChat(c echo.Context) (*transport.Server, error) {
+	for _, frame := range b.frames {
+		if _, err := c.Response().Write([]byte(frame)); err != nil {
+			return nil, err
+		}
+		c.Response().Flush()
+	}
+	return nil, ErrInitializing
+}
+
+// Each frame must reach the caller before the next one is written.
+func TestInferenceRouteStreamsEachFrameAsItIsFlushed(t *testing.T) {
+	first := "data: {\"delta\":\"" + strings.Repeat("alpha ", 200) + "\"}\n\n"
+	second := "data: {\"delta\":\"" + strings.Repeat("bravo ", 200) + "\"}\n\n"
+
+	e := echo.New()
+	RegisterLazySessionRoutes(e.Group(""), payloadsOnlyResolver{resolves: compressedRequestEscrowID},
+		streamingBinder{frames: []string{first, second}}, nil)
+
+	request := httptest.NewRequest(http.MethodPost, "/sessions/"+compressedRequestEscrowID+"/chat/completions", nil)
+	request.Header.Set("Accept-Encoding", gzipEncodingName)
+	recorder := testutil.NewFlushRecorder()
+	e.ServeHTTP(recorder, request)
+
+	require.Equal(t, gzipEncodingName, recorder.Header().Get("Content-Encoding"))
+	require.GreaterOrEqual(t, len(recorder.Flushes()), 2, "one flush per frame must reach the wire")
+
+	var sawFirstAlone bool
+	for _, snapshot := range recorder.Flushes() {
+		decoded := testutil.GzipDecodeSoFar(t, snapshot)
+		if strings.Contains(decoded, "alpha") && !strings.Contains(decoded, "bravo") {
+			sawFirstAlone = true
+			break
+		}
+	}
+	require.True(t, sawFirstAlone, "the first frame must reach the wire before the second is written")
+
+	require.Less(t, len(recorder.Body()), len(first+second)/4, "the whole stream should still compress")
+}
+
+func TestInferenceRouteLeavesAPlainClientAlone(t *testing.T) {
+	body := []byte("data: " + strings.Repeat("A", 8192) + "\n\n")
+
+	e := echo.New()
+	RegisterLazySessionRoutes(e.Group(""), payloadsOnlyResolver{resolves: compressedRequestEscrowID}, writingBinder{body: body}, nil)
+
+	request := httptest.NewRequest(http.MethodPost, "/sessions/"+compressedRequestEscrowID+"/chat/completions", nil)
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, request)
+
+	require.Empty(t, recorder.Header().Get("Content-Encoding"),
+		"compression is negotiated: a client that does not ask keeps the bytes it expects")
+	require.Equal(t, string(body), recorder.Body.String())
 }
 
 type countingBinder struct{ n *int }

--- a/devshard/transport/client.go
+++ b/devshard/transport/client.go
@@ -71,6 +71,9 @@ func transportAddress(baseURL string) string {
 // bufio.Scanner ceiling and the gateway raceWriter classify attempt cap.
 const DefaultMaxSSEEventBytes = 1 << 20
 
+// DefaultMaxSSEStreamBytes caps what one inference stream may decode to.
+const DefaultMaxSSEStreamBytes int64 = 256 << 20
+
 // sseReaderBufferSize is the bufio.Reader size used by parseSSEResponse.
 // Oversize aborts after at most DefaultMaxSSEEventBytes + this much unread
 // data in the reader buffer (not the full attacker payload).
@@ -92,10 +95,14 @@ type ClientConfig struct {
 	HeightSeedTimeout time.Duration
 	StreamCallback    func(nonce uint64, line string) // if set, receives raw SSE data lines during inference
 	RoutePrefix       string                          // path prefix for all session routes; default /devshard/<version>
+	// CompressRequestBodies gzips a POST body; safe once every host decompresses.
+	CompressRequestBodies bool
 	// MaxSSEEventBytes caps a single SSE line (including the trailing newline).
 	// Zero means DefaultMaxSSEEventBytes. Oversize lines abort with
 	// ErrSSEEventTooLarge; they are never silently truncated.
 	MaxSSEEventBytes int
+	// MaxSSEStreamBytes caps one decoded stream. Zero means the default.
+	MaxSSEStreamBytes int64
 	// ParticipantKey is the canonical participant identifier passed to
 	// the admission controller for both AllowRequest and ObserveResult.
 	// Callers MUST use the participant's gonka validator address
@@ -152,6 +159,9 @@ var ErrSSEStreamTruncated = errors.New("sse stream ended without [DONE] or devsh
 // MaxSSEEventBytes before a newline arrives. The oversize payload is discarded;
 // callers should treat this as a transport failure and escalate to another host.
 var ErrSSEEventTooLarge = errors.New("sse event exceeds size limit")
+
+// ErrSSEStreamTooLarge is returned when a stream decodes past MaxSSEStreamBytes.
+var ErrSSEStreamTooLarge = errors.New("sse stream exceeds size limit")
 
 // MaxJSONResponseBytes bounds the legacy non-stream JSON inference body. It
 // matches the gateway's own per-request wire-body ceiling, so a body above it
@@ -560,7 +570,7 @@ func (c *HTTPClient) Send(ctx context.Context, req host.HostRequest, stream io.W
 // the caller could not distinguish a successful completion from a peer /
 // middlebox closing the body early.
 //
-// Line size is hard-capped by MaxSSEEventBytes (default 1 MiB). A malicious
+// Line size is capped by MaxSSEEventBytes, the stream by MaxSSEStreamBytes. A malicious
 // executor can otherwise open `data: ` and stream bytes without ever sending a
 // newline; the old unbounded ReadBytes('\n') grew the returned slice for the
 // whole inference deadline. Oversize aborts with ErrSSEEventTooLarge instead of
@@ -569,6 +579,8 @@ func (c *HTTPClient) Send(ctx context.Context, req host.HostRequest, stream io.W
 func (c *HTTPClient) parseSSEResponse(ctx context.Context, r io.Reader, stream io.Writer, receiptHandler func(*host.HostResponse)) (*host.HostResponse, error) {
 	br := bufio.NewReaderSize(r, sseReaderBufferSize)
 	maxLine := c.maxSSEEventBytes()
+	maxStream := c.maxSSEStreamBytes()
+	var streamBytes int64
 	var result host.HostResponse
 	var writeErrLogged bool
 	var unexpectedLineLogged bool
@@ -578,8 +590,14 @@ func (c *HTTPClient) parseSSEResponse(ctx context.Context, r io.Reader, stream i
 	for {
 		raw, readErr := readBoundedSSELine(br, maxLine)
 		if len(raw) > 0 {
+			streamBytes += int64(len(raw))
 			line := string(bytes.TrimRight(raw, "\r\n"))
+			// Handled before the bound: the line arrived whole.
 			c.handleSSELine(line, stream, receiptHandler, &result, &writeErrLogged, &unexpectedLineLogged, &sawTerminator, &sawMeta)
+			if streamBytes > maxStream {
+				logging.Warn("sse_stream_too_large", "subsystem", "transport", "escrow", c.escrowID, "limit_bytes", maxStream)
+				return &result, fmt.Errorf("%w: %d byte limit", ErrSSEStreamTooLarge, maxStream)
+			}
 		}
 		if readErr != nil {
 			if errors.Is(readErr, ErrSSEEventTooLarge) {
@@ -587,6 +605,13 @@ func (c *HTTPClient) parseSSEResponse(ctx context.Context, r io.Reader, stream i
 				// the host cannot keep streaming into a discarded buffer.
 				logging.Warn("sse_event_too_large", "subsystem", "transport", "escrow", c.escrowID, "limit_bytes", maxLine)
 				return &result, readErr
+			}
+			// A broken transfer: no terminator redeems a cut trailer.
+			if errors.Is(readErr, io.ErrUnexpectedEOF) {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return &result, fmt.Errorf("read SSE stream: %w", ctxErr)
+				}
+				return &result, ErrSSEStreamTruncated
 			}
 			if readErr == io.EOF {
 				// A cancelled context (client disconnect, race resolved, drain)
@@ -616,6 +641,13 @@ func (c *HTTPClient) maxSSEEventBytes() int {
 		return c.config.MaxSSEEventBytes
 	}
 	return DefaultMaxSSEEventBytes
+}
+
+func (c *HTTPClient) maxSSEStreamBytes() int64 {
+	if c != nil && c.config.MaxSSEStreamBytes > 0 {
+		return c.config.MaxSSEStreamBytes
+	}
+	return DefaultMaxSSEStreamBytes
 }
 
 // readBoundedSSELine reads up to and including the next '\n', aborting as soon
@@ -1069,13 +1101,18 @@ func (c *HTTPClient) postRawAttempt(ctx context.Context, path string, body []byt
 		return nil, fmt.Errorf("sign request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	wireBody, contentEncoding := c.encodeRequestBody(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wireBody))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set(c.signatureHeader(), hex.EncodeToString(sig))
 	req.Header.Set(c.timestampHeader(), strconv.FormatInt(ts, 10))
+	if contentEncoding != "" {
+		req.Header.Set("Content-Encoding", contentEncoding)
+	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/devshard/transport/client_compression_test.go
+++ b/devshard/transport/client_compression_test.go
@@ -1,0 +1,166 @@
+package transport
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/signing"
+)
+
+const compressionTestEscrowID = "escrow-compression"
+
+// capturedRequest is what one signed POST put on the wire.
+type capturedRequest struct {
+	contentEncoding string
+	wire            []byte
+	signature       string
+	timestamp       string
+	readErr         error
+}
+
+// compressingClient has the write side turned on.
+func compressingClient(t *testing.T, baseURL string, signer signing.Signer) *HTTPClient {
+	t.Helper()
+	config := DefaultClientConfig()
+	config.CompressRequestBodies = true
+	return NewHTTPClient(baseURL, compressionTestEscrowID, signer, config)
+}
+
+func captureOnePost(t *testing.T) (*httptest.Server, *capturedRequest) {
+	t.Helper()
+	captured := &capturedRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Not require: FailNow off the test goroutine hangs the client.
+		body, err := io.ReadAll(r.Body)
+		captured.readErr = err
+		captured.contentEncoding = r.Header.Get("Content-Encoding")
+		captured.signature = r.Header.Get(HeaderSignature)
+		captured.timestamp = r.Header.Get(HeaderTimestamp)
+		captured.wire = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	return server, captured
+}
+
+// Compression after signing, unwrap before verifying; anything else is 403.
+func TestHTTPClient_Post_CompressesALargeBodyAndStillSignsThePlaintext(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	server, captured := captureOnePost(t)
+
+	client := compressingClient(t, server.URL, signer)
+
+	body := []byte(`{"diffs":[],"nonce":7,"payload":{"prompt":"` + strings.Repeat("A", 8192) + `"}}`)
+	response, err := client.doPostRawOnce(context.Background(), "/sessions/1/chat/completions", body, "application/octet-stream", false)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	require.Equal(t, gzipEncoding, captured.contentEncoding)
+	require.NoError(t, captured.readErr)
+	require.Less(t, len(captured.wire), len(body)/4, "the compressed body should be a fraction of the envelope")
+
+	reader, err := gzip.NewReader(bytes.NewReader(captured.wire))
+	require.NoError(t, err)
+	defer reader.Close()
+	decompressed, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, string(body), string(decompressed))
+
+	signature, err := hex.DecodeString(captured.signature)
+	require.NoError(t, err)
+	timestamp, err := strconv.ParseInt(captured.timestamp, 10, 64)
+	require.NoError(t, err)
+	sender, err := VerifyRequest(signing.NewSecp256k1Verifier(), compressionTestEscrowID, decompressed, signature, timestamp, timestamp)
+	require.NoError(t, err)
+	require.Equal(t, signer.Address(), sender, "the signature must cover the plaintext, not the encoding")
+}
+
+func TestHTTPClient_Post_LeavesASmallBodyUncompressed(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	server, captured := captureOnePost(t)
+
+	client := compressingClient(t, server.URL, signer)
+
+	body := make([]byte, minCompressedBodyBytes-1)
+	response, err := client.doPostRawOnce(context.Background(), "/sessions/1/gossip/nonce", body, "application/json", false)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	require.Empty(t, captured.contentEncoding, "gzip costs more than it saves on a gossip-sized body")
+	require.Equal(t, string(body), string(captured.wire))
+}
+
+func TestHTTPClient_Post_CompressesFromTheThresholdUp(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	server, captured := captureOnePost(t)
+
+	client := compressingClient(t, server.URL, signer)
+
+	body := make([]byte, minCompressedBodyBytes)
+	response, err := client.doPostRawOnce(context.Background(), "/sessions/1/gossip/nonce", body, "application/json", false)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	require.Equal(t, gzipEncoding, captured.contentEncoding, "the threshold is inclusive")
+}
+
+// Go asks for gzip and unwraps it, so the parser never sees an encoded byte.
+func TestParseSSE_ReadsACompressedStreamFromTheHost(t *testing.T) {
+	router := echo.New()
+	router.HideBanner = true
+	router.GET("/stream", func(c echo.Context) error {
+		response := c.Response()
+		response.Header().Set("Content-Type", "text/event-stream")
+		response.WriteHeader(http.StatusOK)
+		for _, frame := range []string{"data: " + strings.Repeat("alpha ", 500) + "\n\n", "data: [DONE]\n\n"} {
+			if _, err := response.Write([]byte(frame)); err != nil {
+				return err
+			}
+			response.Flush()
+		}
+		return nil
+	}, ResponseCompressionMiddleware)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	response, err := http.Get(server.URL + "/stream")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = response.Body.Close() })
+	require.True(t, response.Uncompressed, "the host must have answered gzip and the transport unwrapped it")
+
+	client := &HTTPClient{escrowID: compressionTestEscrowID, config: DefaultClientConfig()}
+	var forwarded bytes.Buffer
+	_, err = client.parseSSEResponse(context.Background(), response.Body, &forwarded, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, forwarded.String(), "alpha")
+	require.Contains(t, forwarded.String(), "[DONE]")
+}
+
+func TestHTTPClient_Post_StaysUncompressedUntilItIsTurnedOn(t *testing.T) {
+	signer := testutil.MustGenerateKey(t)
+	server, captured := captureOnePost(t)
+
+	client := NewHTTPClient(server.URL, compressionTestEscrowID, signer, DefaultClientConfig())
+
+	body := []byte(`{"diffs":[],"nonce":7,"payload":{"prompt":"` + strings.Repeat("A", 8192) + `"}}`)
+	response, err := client.doPostRawOnce(context.Background(), "/sessions/1/chat/completions", body, "application/octet-stream", false)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	require.Empty(t, captured.contentEncoding,
+		"a host that cannot decompress must be reachable until the whole network has the read side")
+	require.Equal(t, string(body), string(captured.wire))
+}

--- a/devshard/transport/client_stream_bound_test.go
+++ b/devshard/transport/client_stream_bound_test.go
@@ -1,0 +1,111 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	streamBoundEscrowID = "escrow-stream-bound"
+	// sseTerminator is the frame a host ends an answer with.
+	sseTerminator = "data: [DONE]\n\n"
+)
+
+// sseFrames renders frames without the terminator, so a bound can sit between.
+func sseFrames(frameCount, contentBytes int) string {
+	var frames strings.Builder
+	for i := 0; i < frameCount; i++ {
+		frames.WriteString("data: {\"choices\":[{\"delta\":{\"content\":\"" + strings.Repeat("A", contentBytes) + "\"}}]}\n\n")
+	}
+	return frames.String()
+}
+
+func streamBoundClient(limit int64) *HTTPClient {
+	config := DefaultClientConfig()
+	config.MaxSSEStreamBytes = limit
+	return &HTTPClient{escrowID: streamBoundEscrowID, config: config}
+}
+
+// The per-line cap misses a stream that stays small per line and never ends.
+func TestParseSSE_StreamPastTheTotalBoundAborts(t *testing.T) {
+	stream := sseFrames(8, 64) + sseTerminator
+	client := streamBoundClient(int64(len(stream)) - 1)
+
+	_, err := client.parseSSEResponse(context.Background(), strings.NewReader(stream), nil, nil)
+
+	require.ErrorIs(t, err, ErrSSEStreamTooLarge)
+}
+
+func TestParseSSE_StreamAtTheTotalBoundCompletes(t *testing.T) {
+	stream := sseFrames(8, 64) + sseTerminator
+	client := streamBoundClient(int64(len(stream)))
+
+	_, err := client.parseSSEResponse(context.Background(), strings.NewReader(stream), nil, nil)
+
+	require.NoError(t, err, "a stream that lands exactly on the bound is within it")
+}
+
+// The crossing line arrived whole; dropping it would lose a meta tail.
+func TestParseSSE_StreamDeliversTheLineThatCrossesTheBound(t *testing.T) {
+	frames := sseFrames(8, 64)
+	client := streamBoundClient(int64(len(frames)))
+	var forwarded bytes.Buffer
+
+	_, err := client.parseSSEResponse(context.Background(), strings.NewReader(frames+sseTerminator), &forwarded, nil)
+
+	require.ErrorIs(t, err, ErrSSEStreamTooLarge)
+	require.Contains(t, forwarded.String(), "[DONE]",
+		"the frame that crossed the bound was complete and must still be handled")
+}
+
+// A committed-but-empty compressed response reads as unexpected EOF.
+func TestParseSSE_UnexpectedEOFIsATruncatedStream(t *testing.T) {
+	client := streamBoundClient(DefaultMaxSSEStreamBytes)
+
+	_, err := client.parseSSEResponse(context.Background(),
+		&truncatedReader{data: []byte("data: {\"choices\":[]}\n\n")}, nil, nil)
+
+	require.ErrorIs(t, err, ErrSSEStreamTruncated)
+}
+
+// resetReader ends with a transport error that is not an EOF.
+type resetReader struct{ remaining string }
+
+func (r *resetReader) Read(p []byte) (int, error) {
+	if r.remaining == "" {
+		return 0, errors.New("connection reset by peer")
+	}
+	n := copy(p, r.remaining)
+	r.remaining = r.remaining[n:]
+	return n, nil
+}
+
+// Only an EOF-shaped end is a truncation.
+func TestParseSSE_NonEOFErrorKeepsItsOwnName(t *testing.T) {
+	client := streamBoundClient(DefaultMaxSSEStreamBytes)
+
+	_, err := client.parseSSEResponse(context.Background(),
+		&resetReader{remaining: "data: {\"choices\":[]}\n\n"}, nil, nil)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrSSEStreamTruncated)
+}
+
+// A stream we cancelled is ours, meta tail or not.
+func TestParseSSE_CancelledStreamWithMetaBlamesTheCaller(t *testing.T) {
+	client := streamBoundClient(DefaultMaxSSEStreamBytes)
+	body := receiptOnlySSE + "data: [DONE]\n\n" + sseMetaWithFinish(t, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := client.parseSSEResponse(ctx, &truncatedReader{data: []byte(body)}, nil, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, userHasFinish(result.Mempool, 1), "the artifact the host did send must survive")
+}

--- a/devshard/transport/client_test.go
+++ b/devshard/transport/client_test.go
@@ -297,7 +297,7 @@ func TestParseSSE_PartialResult(t *testing.T) {
 	require.Equal(t, int64(1000), result.ConfirmedAt)
 }
 
-// truncatedReader returns data followed by an io.ErrUnexpectedEOF to simulate a broken connection.
+// truncatedReader returns data and then io.ErrUnexpectedEOF.
 type truncatedReader struct {
 	data []byte
 	pos  int
@@ -306,11 +306,11 @@ type truncatedReader struct {
 
 func (r *truncatedReader) Read(p []byte) (int, error) {
 	if r.done {
-		return 0, fmt.Errorf("connection reset")
+		return 0, io.ErrUnexpectedEOF
 	}
 	if r.pos >= len(r.data) {
 		r.done = true
-		return 0, fmt.Errorf("connection reset")
+		return 0, io.ErrUnexpectedEOF
 	}
 	n := copy(p, r.data[r.pos:])
 	r.pos += n

--- a/devshard/transport/compression.go
+++ b/devshard/transport/compression.go
@@ -1,0 +1,77 @@
+package transport
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+const (
+	gzipEncoding           = "gzip"
+	minCompressedBodyBytes = 1 << 10
+)
+
+// Pooled here because echo would build a new pool on every request.
+var (
+	// ResponseCompressionMiddleware compresses a response when the caller asks.
+	ResponseCompressionMiddleware = middleware.GzipWithConfig(middleware.GzipConfig{Level: gzip.BestSpeed})
+	gzipRequestReaders            = sync.Pool{New: func() any { return new(gzip.Reader) }}
+	requestCompressors            = sync.Pool{New: func() any {
+		writer, _ := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
+		return writer
+	}}
+)
+
+// RequestDecompressionMiddleware unwraps a request body; mount it before auth.
+func RequestDecompressionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if !strings.EqualFold(c.Request().Header.Get(echo.HeaderContentEncoding), gzipEncoding) {
+			return next(c)
+		}
+		reader := gzipRequestReaders.Get().(*gzip.Reader)
+		compressed := c.Request().Body
+		defer func() {
+			c.Request().Body = compressed
+			_ = compressed.Close()
+			_ = reader.Reset(bytes.NewReader(nil))
+			gzipRequestReaders.Put(reader)
+		}()
+
+		if err := reader.Reset(compressed); err != nil {
+			if errors.Is(err, io.EOF) {
+				return next(c)
+			}
+			return echo.NewHTTPError(http.StatusBadRequest, "malformed gzip request body")
+		}
+		defer reader.Close()
+
+		// Neither header describes the body once the encoding is consumed.
+		c.Request().Header.Del(echo.HeaderContentEncoding)
+		c.Request().Header.Del(echo.HeaderContentLength)
+		c.Request().ContentLength = -1
+		c.Request().Body = reader
+		return next(c)
+	}
+}
+
+// encodeRequestBody gzips a body worth compressing and names the encoding.
+func (c *HTTPClient) encodeRequestBody(body []byte) ([]byte, string) {
+	if !c.config.CompressRequestBodies || len(body) < minCompressedBodyBytes {
+		return body, ""
+	}
+	writer := requestCompressors.Get().(*gzip.Writer)
+	var compressed bytes.Buffer
+	writer.Reset(&compressed)
+	_, _ = writer.Write(body)
+	_ = writer.Close()
+	writer.Reset(io.Discard)
+	requestCompressors.Put(writer)
+	return compressed.Bytes(), gzipEncoding
+}

--- a/devshard/transport/compression_stream_test.go
+++ b/devshard/transport/compression_stream_test.go
@@ -1,0 +1,85 @@
+package transport
+
+import (
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"devshard/internal/testutil"
+	"devshard/types"
+)
+
+// stubAnswerMarker is the content stub.InferenceEngine answers with.
+const stubAnswerMarker = `"content":"stub"`
+
+// requireSnapshotBetween asserts a flush carried written before pending.
+func requireSnapshotBetween(t *testing.T, snapshots [][]byte, written, pending string) {
+	t.Helper()
+	for _, snapshot := range snapshots {
+		decoded := testutil.GzipDecodeSoFar(t, snapshot)
+		if strings.Contains(decoded, written) && !strings.Contains(decoded, pending) {
+			return
+		}
+	}
+	t.Fatalf("no flush carried %q before %q was written; the answer was held back", written, pending)
+}
+
+// Drives the real HandleInference and pins both flushes on the path.
+func TestServer_CompressedStreamingInferenceStaysFrameByFrame(t *testing.T) {
+	env := setupServerEnv(t)
+
+	router := echo.New()
+	router.HideBanner = true
+	router.POST("/devshard/v2/sessions/:id/chat/completions", func(c echo.Context) error {
+		return env.server.AuthMiddleware(env.server.RateLimitMiddleware(true)(env.server.HandleInference))(c)
+	}, ResponseCompressionMiddleware)
+
+	diff := testutil.SignDiff(t, env.userSigner, "escrow-1", 1, []*types.DevshardTx{testutil.StartTx(1)})
+	diffJSON, err := DiffToJSON(diff)
+	require.NoError(t, err)
+	body, err := json.Marshal(InferenceRequest{
+		Diffs: []DiffJSON{diffJSON},
+		Nonce: 1,
+		Payload: &PayloadJSON{
+			Prompt:      testutil.TestPrompt,
+			Model:       "llama",
+			InputLength: 100,
+			MaxTokens:   testutil.TestMaxTokens,
+			StartedAt:   1000,
+		},
+		Stream: true,
+	})
+	require.NoError(t, err)
+
+	timestamp := time.Now().Unix()
+	signature, err := SignRequest(env.userSigner, "escrow-1", body, timestamp)
+	require.NoError(t, err)
+	request := httptest.NewRequest(http.MethodPost,
+		"/devshard/v2/sessions/escrow-1/chat/completions", strings.NewReader(string(body)))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set(HeaderSignature, hex.EncodeToString(signature))
+	request.Header.Set(HeaderTimestamp, strconv.FormatInt(timestamp, 10))
+	request.Header.Set("Accept-Encoding", gzipEncoding)
+
+	recorder := testutil.NewFlushRecorder()
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code())
+	require.Equal(t, gzipEncoding, recorder.Header().Get("Content-Encoding"))
+
+	final := testutil.GzipDecodeSoFar(t, recorder.Body())
+	require.Contains(t, final, "devshard_receipt")
+	require.Contains(t, final, stubAnswerMarker)
+	require.Contains(t, final, "[DONE]")
+
+	requireSnapshotBetween(t, recorder.Flushes(), "devshard_receipt", stubAnswerMarker)
+	requireSnapshotBetween(t, recorder.Flushes(), stubAnswerMarker, "[DONE]")
+}

--- a/devshard/transport/server.go
+++ b/devshard/transport/server.go
@@ -32,7 +32,7 @@ import (
 const (
 	contextKeySender = "devshard_sender"
 
-	// DefaultMaxBodySize matches the public proxy and versiond-router limit.
+	// DefaultMaxBodySize bounds the decompressed body auth reads.
 	// The transport enforces actual bytes read, so it also covers chunked bodies
 	// and deployments that expose devshardd without the public proxy.
 	DefaultMaxBodySize int64 = 10 * 1024 * 1024

--- a/devshard/user/httpsession.go
+++ b/devshard/user/httpsession.go
@@ -31,8 +31,9 @@ type HTTPSessionConfig struct {
 	// returns a host-signed Anchor. Default false in this library; the
 	// gateway sets it from DEVSHARD_REQUIRE_HEIGHT_SEED (default true).
 	RequireHeightSeed bool
-	// ExtraClientConfig is merged into each transport.HTTPClient when non-nil.
-	// Used to attach courier-mode HeightSync (peer-tip cache; no local follower).
+	// CompressRequestBodies gzips a request body on the way to every host.
+	CompressRequestBodies bool
+	// ExtraClientConfig: only its HeightSync fields reach each host client.
 	ExtraClientConfig *transport.ClientConfig
 	// Heartbeat overlays compiled height-sync scheduling knobs. Nil keeps defaults.
 	Heartbeat *heightsync.HeartbeatConfig
@@ -43,6 +44,37 @@ type HTTPSessionConfig struct {
 	// harnesses that need protocol timeouts shorter than production defaults.
 	RefusalTimeoutSeconds   *int64
 	ExecutionTimeoutSeconds *int64
+}
+
+// hostClientConfig is the transport config one host client runs with.
+func hostClientConfig(
+	cfg HTTPSessionConfig,
+	routePrefix, validatorAddress string,
+	sharedPeerTips *transport.HeightSyncPeerTips,
+) transport.ClientConfig {
+	clientConfig := transport.DefaultClientConfig()
+	if cfg.StreamCallback != nil {
+		clientConfig.StreamCallback = cfg.StreamCallback
+	}
+	clientConfig.RoutePrefix = routePrefix
+	clientConfig.CompressRequestBodies = cfg.CompressRequestBodies
+	if cfg.RequestAdmission != nil {
+		clientConfig.ParticipantKey = validatorAddress
+		clientConfig.Admission = cfg.RequestAdmission
+	}
+	if cfg.ExtraClientConfig != nil {
+		if cfg.ExtraClientConfig.HeightSync != nil {
+			clientConfig.HeightSync = cfg.ExtraClientConfig.HeightSync
+			clientConfig.HeightSyncPeerTips = sharedPeerTips
+		}
+		if cfg.ExtraClientConfig.HeightSyncLogOracle != nil {
+			clientConfig.HeightSyncLogOracle = cfg.ExtraClientConfig.HeightSyncLogOracle
+		}
+		if cfg.ExtraClientConfig.HeightSyncRequestMutateHook != nil {
+			clientConfig.HeightSyncRequestMutateHook = cfg.ExtraClientConfig.HeightSyncRequestMutateHook
+		}
+	}
+	return clientConfig
 }
 
 func deferredWarmKeyResolver(resolve state.WarmKeyResolver) (state.WarmKeyResolver, func()) {
@@ -192,32 +224,8 @@ func NewHTTPSession(cfg HTTPSessionConfig) (*Session, *state.StateMachine, error
 			sqlStore.Close()
 			return nil, nil, fmt.Errorf("get host info for %s: %w", slot.ValidatorAddress, err)
 		}
-		cc := transport.DefaultClientConfig()
-		if cfg.StreamCallback != nil {
-			cc.StreamCallback = cfg.StreamCallback
-		}
-		cc.RoutePrefix = routePrefix
-		if cfg.RequestAdmission != nil {
-			cc.ParticipantKey = slot.ValidatorAddress
-			cc.Admission = cfg.RequestAdmission
-		}
-		if cfg.ExtraClientConfig != nil {
-			if cfg.ExtraClientConfig.HeightSync != nil {
-				cc.HeightSync = cfg.ExtraClientConfig.HeightSync
-				cc.HeightSyncPeerTips = sharedPeerTips
-			}
-			if cfg.ExtraClientConfig.HeightSyncLogOracle != nil {
-				cc.HeightSyncLogOracle = cfg.ExtraClientConfig.HeightSyncLogOracle
-			}
-			if cfg.ExtraClientConfig.HeightSyncRequestMutateHook != nil {
-				cc.HeightSyncRequestMutateHook = cfg.ExtraClientConfig.HeightSyncRequestMutateHook
-			}
-		}
-		var clientCfgs []transport.ClientConfig
-		if cfg.StreamCallback != nil || routePrefix != "" || cfg.RequestAdmission != nil || cfg.ExtraClientConfig != nil {
-			clientCfgs = append(clientCfgs, cc)
-		}
-		c := transport.NewHTTPClient(info.URL, cfg.EscrowID, signer, clientCfgs...)
+		c := transport.NewHTTPClient(info.URL, cfg.EscrowID, signer,
+			hostClientConfig(cfg, routePrefix, slot.ValidatorAddress, sharedPeerTips))
 		clientCache[slot.ValidatorAddress] = c
 		clients[i] = c
 	}

--- a/devshard/user/httpsession_client_config_test.go
+++ b/devshard/user/httpsession_client_config_test.go
@@ -1,0 +1,53 @@
+package user
+
+import (
+	"testing"
+
+	"devshard/transport"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubAdmission stands in for the limiter; only its presence is asserted.
+type stubAdmission struct{}
+
+func (stubAdmission) AllowRequest(string, string) error { return nil }
+
+func (stubAdmission) ObserveResult(string, string, int) {}
+
+func (stubAdmission) ObserveTransportFailure(string, string, error) {}
+
+func TestHostClientConfigLeavesCompressionOffByDefault(t *testing.T) {
+	config := hostClientConfig(HTTPSessionConfig{}, "/devshard/v2", "gonka1host", nil)
+
+	require.False(t, config.CompressRequestBodies,
+		"the write side stays off until the whole roster has the read side")
+}
+
+// Anything that stops in this helper never reaches the wire.
+func TestHostClientConfigCarriesCompressionToEachHost(t *testing.T) {
+	config := hostClientConfig(HTTPSessionConfig{CompressRequestBodies: true}, "/devshard/v2", "gonka1host", nil)
+
+	require.True(t, config.CompressRequestBodies)
+}
+
+func TestHostClientConfigCarriesTheRoutePrefixAndParticipant(t *testing.T) {
+	config := hostClientConfig(
+		HTTPSessionConfig{RequestAdmission: stubAdmission{}},
+		"/devshard/v2", "gonka1host", nil,
+	)
+
+	require.Equal(t, "/devshard/v2", config.RoutePrefix, "a dropped prefix routes every request into a 404")
+	require.Equal(t, "gonka1host", config.ParticipantKey,
+		"the admission bucket must key on the same address the rest of the stack uses")
+	require.NotNil(t, config.Admission)
+}
+
+// Passing a config always works only because the client re-defaults the prefix.
+func TestHostClientConfigLeavesAnEmptyPrefixToTheClient(t *testing.T) {
+	config := hostClientConfig(HTTPSessionConfig{}, "", "gonka1host", nil)
+
+	require.Empty(t, config.RoutePrefix)
+	require.Equal(t, transport.DefaultRoutePrefix(),
+		transport.NewHTTPClient("http://127.0.0.1:1", "escrow", nil, config).RoutePrefix())
+}

--- a/docs/proposal/compressed-payloads.md
+++ b/docs/proposal/compressed-payloads.md
@@ -137,7 +137,7 @@ If rollback across this boundary must be supported, the standard two-phase rollo
 
 **Nothing is approximated.** Values are dropped whole or kept exactly. An earlier draft quantised logprobs to float16 — 4.9e-04 relative error, 2.3e-05 on the verdict — and was discarded: a lossless scheme reaches 20.0 B/pos against 10.3 B/pos lossy, which does not justify introducing an error into the number that decides an inference's fate.
 
-**gzip is not applied to the inference stream.** It is scoped to the payload route; on a streamed response it would buffer chunks.
+**gzip is not applied to the inference stream here.** It is scoped to the payload route, on the reading that a streamed response would buffer. Measured since against echo v4.15.1 that reading does not hold, and the transit legs are compressed by [gzip-in-transit.md](gzip-in-transit.md).
 
 ## Verification
 
@@ -147,4 +147,4 @@ If rollback across this boundary must be supported, the standard two-phase rollo
 - Redundancy: all 100 responses / 409 600 positions in the reference corpus pass the pre-drop check.
 - Bounds: a payload file that inflates past 256 MiB is refused rather than read, asserted with a real bomb. The bound turns an unbounded decompression into one failed read rather than an OOM; the largest legitimate payload is ~90 MiB, a 10 MiB request at the body cap plus 300k output tokens.
 - Divergence: an inference driven through a streaming stub asserts both outputs at once — the gateway receives no logprobs, and the payload stored from the same stream still replays the executor's token path with its alternatives intact.
-- Mutation testing: 13 mutants, 11 killed. The two survivors both concern gzip being scoped to one route rather than the whole group; echo leaves a handler-written body uncompressed either way, so no test can distinguish them. That scoping rests on where the middleware is written, not on a test.
+- Mutation testing: 13 mutants, 11 killed. The two survivors both concerned gzip being scoped to one route rather than the whole group, which no test could distinguish at the time. That scoping has since been replaced: the inference route compresses too, and `TestInferenceRouteStreamsEachFrameAsItIsFlushed` distinguishes the mounts.

--- a/docs/proposal/gzip-in-transit.md
+++ b/docs/proposal/gzip-in-transit.md
@@ -1,0 +1,85 @@
+# Proposal: gzip Between the Gateway and a devshard Host
+
+Companion to [compressed-payloads.md](compressed-payloads.md). Operators want [v6-deploy-test-plan.md](../../devshard/docs/v6-deploy-test-plan.md) instead: this is the design record. That proposal made the artifacts smaller by dropping fields and by compressing them at rest and on the payload route. This one compresses the two legs that carry every inference: the request the gateway sends a host, and the SSE answer the host streams back.
+
+## Goal / Problem
+
+Both legs travel uncompressed. Two things make that expensive beyond the obvious.
+
+**The response.** After the four-field strip, what remains is almost entirely per-chunk housekeeping — `id`, `object`, `created`, `model` and the `choices` wrapper — repeated once per token. That is the most compressible shape a stream can have, and it is paid on every inference rather than on a sampled fraction.
+
+**The request.** `PayloadJSON.Prompt` is `[]byte`, so the normalized chat body travels base64 inside the envelope: a flat 1.33x on every prompt, before any content-dependent redundancy.
+
+## Proposal
+
+**1. Compress the response, negotiated.** The inference route serves gzip when the caller asks. No client changes: the transport's `http.Transport` sets no `Accept-Encoding` of its own and leaves `DisableCompression` off, so Go already asks for gzip and unwraps it.
+
+**2. Decompress the request, ahead of authentication.** The signature is `sha256(escrow_id || body || ts_be8)` over the body with no canonicalisation, and the same bytes feed the height-sync request-leg evidence digest a host retains for offline dispute. So the sender signs the plaintext and compresses after; the host decompresses before auth reads the body. Then no hash in the protocol can tell that compression happened.
+
+**3. Bound what a stream decodes to.** `MaxSSEStreamBytes` (256 MiB) caps a whole inference stream. The per-line cap does not see a stream that stays small per line and never ends, and compression makes that cheap for an untrusted executor.
+
+## Impact
+
+Measured on a stand that replays the real logprob corpus in `common/validation/testdata`, counting bytes on the socket with headers and chunked framing included.
+
+**Response leg**, one chunk per token:
+
+| tokens | shape | plain | gzip | |
+|---:|---|---:|---:|---:|
+| 1024 | after the strip | 223.3 KiB | 45.8 KiB | 4.88x |
+| 4096 | after the strip | 892.5 KiB | 181.8 KiB | **4.91x** |
+| 4096 | before the strip | 2.3 MiB | 637.0 KiB | 3.77x |
+
+gzip does better *after* the strip than before it: the two steps multiply rather than compete, because what the strip leaves behind is the repeated housekeeping.
+
+**Request leg**, 256 KiB prompts:
+
+| prompt | plain | gzip | |
+|---|---:|---:|---:|
+| source code | 372.4 KiB | 125.4 KiB | 2.97x |
+| HTML-heavy | 455.2 KiB | 118.6 KiB | 3.84x |
+| prose | 346.7 KiB | 167.8 KiB | 2.07x |
+| incompressible | 341.9 KiB | 242.7 KiB | 1.41x |
+
+The last row is the floor, not an anomaly: gzip reclaims the base64 tax whatever the content.
+
+**Per inference**, a 4096-token answer against a 256 KiB prompt: 1.2 MiB to 307.3 KiB, **4.12x**. Over 100 000 inferences, 120.63 GiB to 29.30 GiB.
+
+## Cost
+
+gzip level 1, single core: 8.8 ms per MiB on the request leg. Level 6 reaches 4.07x against level 1's 3.22x for 23.3 ms per MiB — not worth it on the leg a gateway pays for every request at once. Set against an inference that occupied a GPU for seconds, neither is material.
+
+## Compatibility
+
+| direction | result |
+|---|---|
+| old client <- new host | works — gzip is negotiated by `Accept-Encoding` |
+| new client <- old host | works — the header is ignored and the answer arrives plain |
+| old host <- new sender compressing | **fails** — the host verifies the compressed bytes, recovers a stranger, and answers 403 |
+
+That last row is why the write side ships off. `DEVSHARD_GATEWAY_COMPRESS_REQUEST_BODIES` turns it on once every host in the roster carries the read side; the response leg has no such constraint and needs no gate.
+
+The failure mode deserves naming because it does not look like what it is: ECDSA recovery never fails on the wrong bytes, it recovers a different address. A sender compressing to a host that cannot decompress sees **403 sender-not-in-group**, which reads as a key or registration problem.
+
+## Non-goals
+
+**The flush cadence is not changed.** Flushing per token forces a deflate block boundary per token, and most of what the stream could compress to goes into block headers: the same 4096-token answer reaches 12.3x flushing every 4 tokens and 4.91x flushing every one. Keeping the opening tokens unbatched and batching the tail measured 17x with time-to-first-byte unchanged. That trades against the race — the crown goes to the first attempt producing content — so it belongs in its own change, with its own evidence.
+
+**The gateway's own client leg is not compressed.** The gateway answers clients through `net/http` rather than echo, so it needs its own wrapper.
+
+## What this costs an unauthenticated caller
+
+Decompression has to run above authentication, and the rate limiter lives inside it, so an unnamed caller now buys the work of inflating up to the 10 MiB body cap for as little as ~10 KiB on the wire. The work per request is bounded exactly as before — the cap is enforced on the decoded bytes, so nothing inflates past it — but the bandwidth an attacker spends to buy it drops by about three orders of magnitude. The edge `client_max_body_size` still bounds what arrives. This is a deliberate trade, named here because the ratio changed even though the bound did not.
+
+## Verification
+
+- The signature survives: a request signed as plaintext and sent compressed verifies through the real routes and yields the signer; the same request to a host without decompression yields a stranger.
+- The bound is on the decoded body: a bomb one byte over the 10 MiB cap, under 1 MiB on the wire, is refused 413.
+- The stream is not held back: with one write and one flush per frame, the bytes on the wire at the first flush already decode to the first frame and not the second. Asserted against a recorder that snapshots at each flush.
+- A body that claims gzip and is not answers 400 — for a wrong magic number and for a header cut short. This middleware runs before any caller is named, so it must not let an unnamed one spend the host's 5xx budget. An empty body carries no header to be wrong about and is passed through to be judged by auth like any other unsigned request.
+- The full e2e suite passes with both mounts in place, including in the stub host the stand runs.
+
+- The cadence holds through the real handler, not a stand-in: an inference driven end to end through `HandleInference` with `Accept-Encoding: gzip` has some event readable on the wire before the stream finishes. Verified by mutation — silence every flush on the path and it fails.
+- A stream cut before its trailer is reported as a truncation rather than a generic transport error. Compression makes that reachable: an answer whose headers were flushed and whose body never came is an unterminated gzip stream, which reads as `unexpected EOF`. That is a naming fix, not a scoring one — `Send` returns a stream-parse error without observing it, so no quarantine strike was ever at stake — but `sse_truncated` says what happened and `eof_transport` does not.
+
+Two mutations did not kill anything, and both are recorded rather than papered over. Raising the compressor's `MinLength` leaves the streaming test green, because echo's `Flush` forces the threshold regardless. And `TestInferenceRouteLeavesAPlainClientAlone` pins echo's content negotiation rather than any line of ours; it is kept as a statement of the negotiated contract, not counted as coverage.


### PR DESCRIPTION
## Summary

- A devshard host now serves the inference stream gzipped when the caller asks for it, and unwraps a gzipped request body before auth reads it: **4.9x** on a 4096-token answer, **2.0–3.8x** on the request envelope, **7.6x** per inference with both legs.
- The response leg needs no client change and no flag — `Accept-Encoding` negotiates it, so mixed rosters work in both directions.
- The request leg is off behind `DEVSHARD_GATEWAY_COMPRESS_REQUEST_BODIES` until every host in a roster carries the read side.
- Adds `MaxSSEStreamBytes` (256 MiB) bounding what one stream may decode to, and reports a stream cut before its trailer as `sse_truncated` instead of a generic transport error.
- Operator manual: `devshard/docs/v6-deploy-test-plan.md`. Design and measurements: `docs/proposal/gzip-in-transit.md`.

## Why

Both legs travelled uncompressed. After the four-field strip from the compressed-payloads work, what remains of an answer is almost entirely per-chunk housekeeping repeated once per token — the most compressible shape a stream can have, and it is paid on every inference rather than on a sampled fraction. On the request side `PayloadJSON.Prompt` is `[]byte`, so the normalized chat body travels base64: a flat **1.33x** floor that gzip reclaims whatever the content is.

The request signature is `sha256(escrow_id ‖ body ‖ ts_be8)` over the body with no canonicalisation, and the same bytes feed the height-sync request-leg evidence digest. So the sender signs the plaintext and compresses after, and the host decompresses above auth. Getting that order wrong does not look like a compression fault: ECDSA recovery never fails on the wrong bytes, it returns a different address, so a host without the read side answers **403 sender-not-in-group**. That is why the write side ships off — requests have no `Accept-Encoding` equivalent to negotiate with.

`compressed-payloads.md` recorded gzip on the inference stream as a non-goal because a streamed response "would buffer". That does not hold on echo v4.15.1: `gzipResponseWriter.Flush` flushes the gzip writer on every handler flush. Measured, time to first byte is unchanged and every frame still arrives at its own instant; that document now points here instead.

## Test plan

- [x] `go build`, `go vet` and full package tests across `server`, `transport`, `user`, `accounting`, `devshardctl`, `devshard-host`
- [x] `make e2e` — 39/39, with the stub host mounting the same two middlewares as production
- [x] Mutation-checked the load-bearing claims: silencing either flush on the stream path, and removing the decompression mount, each fail their own assertion
