### PR TITLE
fix(poc): apply bootstrap penalties only for launching models

### DIFF
--- a/inference-chain/x/inference/module/bootstrap_penalty.go
+++ b/inference-chain/x/inference/module/bootstrap_penalty.go
@@ -14,7 +14,6 @@ type BootstrapPenaltyMode int
 const (
 	BootstrapPenaltyDirect BootstrapPenaltyMode = iota
 	BootstrapPenaltyDelegate
-	BootstrapPenaltyIntentOK
 	BootstrapPenaltyIntentMissed
 	BootstrapPenaltyNone
 )
@@ -75,6 +74,7 @@ func (am AppModule) resolveBootstrapPenaltyModes(
 	participants []*types.ActiveParticipant,
 	pocStageStartHeight int64,
 	inputs bootstrapPenaltyInputs,
+	previous *previousConfirmedWeights,
 ) (map[string]map[string]BootstrapPenaltyMode, error) {
 	if len(inputs.ReportByModel) == 0 {
 		return map[string]map[string]BootstrapPenaltyMode{}, nil
@@ -87,6 +87,7 @@ func (am AppModule) resolveBootstrapPenaltyModes(
 
 	return ResolveBootstrapPenaltyModes(
 		participants,
+		previousRootMembers(previous),
 		inputs.ReportByModel,
 		inputs.Delegations,
 		inputs.Intents,
@@ -94,8 +95,20 @@ func (am AppModule) resolveBootstrapPenaltyModes(
 	), nil
 }
 
+func previousRootMembers(previous *previousConfirmedWeights) map[string]bool {
+	members := make(map[string]bool)
+	if previous == nil {
+		return members
+	}
+	for addr := range previous.weights {
+		members[addr] = true
+	}
+	return members
+}
+
 func ResolveBootstrapPenaltyModes(
 	participants []*types.ActiveParticipant,
+	previousRoot map[string]bool,
 	reportByModel map[string]*types.BootstrapModelPreEligibility,
 	delegations map[string]map[string]string,
 	intents map[string]map[string]bool,
@@ -110,7 +123,9 @@ func ResolveBootstrapPenaltyModes(
 	modes := make(map[string]map[string]BootstrapPenaltyMode, len(modelIDs))
 	for _, modelID := range modelIDs {
 		report := reportByModel[modelID]
-		preEligible := report != nil && report.PreEligible
+		if report == nil || !report.PreEligible {
+			continue
+		}
 
 		modelModes := make(map[string]BootstrapPenaltyMode)
 		modelDelegations := delegations[modelID]
@@ -123,9 +138,8 @@ func ResolveBootstrapPenaltyModes(
 			}
 
 			addr := participant.Index
-			intentMode := BootstrapPenaltyIntentOK
-			if preEligible {
-				intentMode = BootstrapPenaltyIntentMissed
+			if !previousRoot[addr] {
+				continue
 			}
 			switch {
 			case modelCommitters[addr]:
@@ -133,7 +147,7 @@ func ResolveBootstrapPenaltyModes(
 			case modelDelegations != nil && modelDelegations[addr] != "":
 				modelModes[addr] = BootstrapPenaltyDelegate
 			case modelIntents != nil && modelIntents[addr]:
-				modelModes[addr] = intentMode
+				modelModes[addr] = BootstrapPenaltyIntentMissed
 			default:
 				modelModes[addr] = BootstrapPenaltyNone
 			}

--- a/inference-chain/x/inference/module/delegation_pipeline.go
+++ b/inference-chain/x/inference/module/delegation_pipeline.go
@@ -247,6 +247,7 @@ func (am AppModule) prepareEpochParticipationState(
 		activeParticipants,
 		pocStageStartHeight,
 		bootstrapInputs,
+		previous,
 	)
 	if err != nil {
 		am.LogError("failed to resolve bootstrap penalty modes; skipping bootstrap penalties", types.PoC, "error", err)

--- a/inference-chain/x/inference/module/delegation_weight_adjustment_test.go
+++ b/inference-chain/x/inference/module/delegation_weight_adjustment_test.go
@@ -362,11 +362,23 @@ func TestResolveBootstrapPenaltyModes_PreEligibleFalse(t *testing.T) {
 		"bootstrap-model": {"direct": true},
 	}
 
-	modes := ResolveBootstrapPenaltyModes(participants, reportByModel, delegations, intents, directCommitters)
-	require.Equal(t, BootstrapPenaltyDirect, modes["bootstrap-model"]["direct"])
-	require.Equal(t, BootstrapPenaltyDelegate, modes["bootstrap-model"]["delegator"])
-	require.Equal(t, BootstrapPenaltyIntentOK, modes["bootstrap-model"]["intender"])
-	require.Equal(t, BootstrapPenaltyNone, modes["bootstrap-model"]["none"])
+	modes := ResolveBootstrapPenaltyModes(
+		participants,
+		map[string]bool{"direct": true, "delegator": true, "intender": true, "none": true},
+		reportByModel,
+		delegations,
+		intents,
+		directCommitters,
+	)
+	require.Empty(t, modes)
+}
+
+func TestPreviousRootMembers_IncludesZeroWeightMember(t *testing.T) {
+	members := previousRootMembers(&previousConfirmedWeights{
+		weights: map[string]int64{"zero-weight": 0},
+	})
+
+	require.True(t, members["zero-weight"])
 }
 
 func TestResolveBootstrapPenaltyModes_PreEligibleTrue(t *testing.T) {
@@ -389,11 +401,52 @@ func TestResolveBootstrapPenaltyModes_PreEligibleTrue(t *testing.T) {
 		"bootstrap-model": {"direct": true},
 	}
 
-	modes := ResolveBootstrapPenaltyModes(participants, reportByModel, delegations, intents, directCommitters)
+	modes := ResolveBootstrapPenaltyModes(
+		participants,
+		map[string]bool{"direct": true, "delegator": true, "intender": true, "none": true},
+		reportByModel,
+		delegations,
+		intents,
+		directCommitters,
+	)
 	require.Equal(t, BootstrapPenaltyDirect, modes["bootstrap-model"]["direct"])
 	require.Equal(t, BootstrapPenaltyDelegate, modes["bootstrap-model"]["delegator"])
 	require.Equal(t, BootstrapPenaltyIntentMissed, modes["bootstrap-model"]["intender"])
 	require.Equal(t, BootstrapPenaltyNone, modes["bootstrap-model"]["none"])
+}
+
+func TestResolveBootstrapPenaltyModes_SkipsParticipantOutsidePreviousRoot(t *testing.T) {
+	participants := []*types.ActiveParticipant{
+		{Index: "existing", Weight: 100},
+		{Index: "upcoming-only", Weight: 100},
+	}
+	reportByModel := map[string]*types.BootstrapModelPreEligibility{
+		"bootstrap-model": {ModelId: "bootstrap-model", PreEligible: true},
+	}
+
+	modes := ResolveBootstrapPenaltyModes(
+		participants,
+		map[string]bool{"existing": true},
+		reportByModel,
+		nil,
+		nil,
+		nil,
+	)
+
+	require.Equal(t, BootstrapPenaltyNone, modes["bootstrap-model"]["existing"])
+	require.NotContains(t, modes["bootstrap-model"], "upcoming-only")
+
+	params := DelegationAdjustmentParams{
+		RefusalPenalty:         mathsdk.LegacyZeroDec(),
+		NoParticipationPenalty: mathsdk.LegacyMustNewDecFromStr("0.15"),
+		DelegationShare:        mathsdk.LegacyZeroDec(),
+	}
+	acc := NewPenaltyAccumulator(participants)
+	AccumulateBootstrapPenalties(acc, modes, nil, params, 1, nil)
+
+	penalties := acc.RewardPenalties()
+	require.Len(t, penalties, 1)
+	requirePenalty(t, penalties[0], "existing", mathsdk.LegacyMustNewDecFromStr("0.15"))
 }
 
 func TestAccumulateBootstrapPenalties_MapsIntentMissedAndNone(t *testing.T) {
@@ -430,7 +483,7 @@ func TestAccumulateBootstrapPenalties_MapsIntentMissedAndNone(t *testing.T) {
 	requirePenalty(t, penalties[1], "none", mathsdk.LegacyMustNewDecFromStr("0.5"))
 }
 
-func TestAccumulateBootstrapPenalties_DirectCommitterOnNonPreEligibleNotPenalized(t *testing.T) {
+func TestAccumulateBootstrapPenalties_NonPreEligibleModelNotPenalized(t *testing.T) {
 	participants := []*types.ActiveParticipant{
 		{Index: "direct", Weight: 100},
 		{Index: "none", Weight: 100},
@@ -442,9 +495,15 @@ func TestAccumulateBootstrapPenalties_DirectCommitterOnNonPreEligibleNotPenalize
 		"bootstrap-model": {"direct": true},
 	}
 
-	modes := ResolveBootstrapPenaltyModes(participants, reportByModel, nil, nil, directCommitters)
-	require.Equal(t, BootstrapPenaltyDirect, modes["bootstrap-model"]["direct"])
-	require.Equal(t, BootstrapPenaltyNone, modes["bootstrap-model"]["none"])
+	modes := ResolveBootstrapPenaltyModes(
+		participants,
+		map[string]bool{"direct": true, "none": true},
+		reportByModel,
+		nil,
+		nil,
+		directCommitters,
+	)
+	require.Empty(t, modes)
 
 	params := DelegationAdjustmentParams{
 		RefusalPenalty:         mathsdk.LegacyZeroDec(),
@@ -456,9 +515,8 @@ func TestAccumulateBootstrapPenalties_DirectCommitterOnNonPreEligibleNotPenalize
 	penalties := acc.RewardPenalties()
 
 	require.Equal(t, int64(100), participants[0].Weight) // Direct: untouched
-	require.Equal(t, int64(100), participants[1].Weight) // None: reward-only penalty
-	require.Len(t, penalties, 1)
-	requirePenalty(t, penalties[0], "none", mathsdk.LegacyMustNewDecFromStr("0.5"))
+	require.Equal(t, int64(100), participants[1].Weight) // Non-pre-eligible model: untouched
+	require.Empty(t, penalties)
 }
 
 func TestAccumulateDelegationPenalties_MixedModesAcrossModels(t *testing.T) {


### PR DESCRIPTION
Inactive governance-approved models are incorrectly sent through the bootstrap penalty path after `penalty_start_epoch`.

Issue 1: a host with no intent, delegation, or store commit is scored `BootstrapPenaltyNone` and takes the 15% `no_participation` penalty, even when the model is not pre-eligible. Participants who already set an intent, a delegation, or a store commit were not affected.

Issue 2: the bootstrap snapshot only records intents and delegations for the previous-epoch root group, but penalty resolution scores the upcoming active set. A host absent from that previous group has no snapshot record and also defaults to `None`.

This PR applies bootstrap penalties only when a model is launching (`PreEligible=true`) and only to previous-epoch root hosts, because new participants were not active yet and could not have set intents before. If the model later becomes regularly eligible, the regular delegation path owns it.

Issue found by @maksimenkoff.
