### PR TITLE
fix(versiond-router): finish graceful shutdown with catalog refresh

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -260,7 +260,7 @@ jobs:
       - name: Render and exercise versiond-router
         run: make -C versiond-router test-render
       - name: Exercise isolated versiond-router fleet rollouts
-        run: make -C versiond-router test-fleet
+        run: make -C versiond-router test-fleet test-shutdown
       - name: Gate router fleet failure scenarios
         run: |
           shellcheck -x deploy/join/versiond-router-fleet.sh deploy/join/versiond-router-fleet-regression_test.sh

--- a/versiond-router/Makefile
+++ b/versiond-router/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all build-docker release test-render test-compose-contract test-fleet
 .PHONY: test-catalog-cache test-hash-ring test-version-routing test-local-compose
 .PHONY: test-join-versiond-healthcheck test-pool-status test-endpoints-render
+.PHONY: test-shutdown
 
 # Renders both the mixed (legacy pinning) and the all-HA shapes, asserts on the
 # result, then runs the real HAProxy from the production image over each one.
@@ -45,6 +46,9 @@ test-compose-contract:
 
 test-fleet:
 	@../deploy/join/versiond-router-fleet_test.sh
+
+test-shutdown:
+	@./shutdown_test.sh
 
 test-pool-status:
 	@./pool-status_test.sh
@@ -413,7 +417,8 @@ test-version-routing:
 		| grep -Fq 'haproxy_backend_active_servers{proxy="router_catalog_serving_status"} 1' \
 		|| fail "accepted-route readiness is not exposed through HAProxy metrics"; \
 	sleep 4; \
-	docker exec gonka-vp-router sh -c 'kill -STOP $$(pidof haproxy)' \
+	: 'Send STOP from outside the PID namespace: HAProxy may be container PID 1'; \
+	docker kill --signal=STOP gonka-vp-router >/dev/null \
 		|| fail "could not suspend HAProxy for the Runtime API timeout test"; \
 	for i in $$(seq 15); do \
 		if docker exec gonka-vp-router /usr/local/lib/router-runtime/catalog-status --state \
@@ -428,7 +433,7 @@ test-version-routing:
 			docker logs --tail 30 gonka-vp-router >&2; \
 			fail "a half-open Runtime API socket did not reach its deadline"; \
 		}; \
-	docker exec gonka-vp-router sh -c 'kill -CONT $$(pidof haproxy)' \
+	docker kill --signal=CONT gonka-vp-router >/dev/null \
 		|| fail "could not resume HAProxy after the Runtime API timeout test"; \
 	for i in $$(seq 20); do \
 		if docker exec gonka-vp-router /usr/local/lib/router-runtime/catalog-status --state \
@@ -1231,8 +1236,12 @@ test-version-routing:
 	docker exec gonka-vp-router /usr/local/lib/router-runtime/catalog-status \
 		/etc/haproxy/versions.map | grep -qx v10 \
 		|| fail "capacity-blocked maintenance replacement removed v10"; \
-	[ "$$(curl -fsS -m 3 http://127.0.0.1:18132/v10/sessions/replacement-held/chat)" = b ] \
-		|| fail "capacity-blocked maintenance replacement stopped the old route"; \
+	: 'Both a and b serve v10 here; preserving the route does not pin this session to b'; \
+	held_host=$$(curl -fsS -m 3 http://127.0.0.1:18132/v10/sessions/replacement-held/chat); \
+	case "$$held_host" in \
+		a|b) ;; \
+		*) fail "capacity-blocked maintenance replacement stopped the old route" ;; \
+	esac; \
 	docker exec gonka-vp-router /usr/local/lib/router-runtime/catalog-cache read \
 		/var/lib/gonka-router/catalog.json 86400 | grep -Fqx v10 \
 		|| fail "capacity-blocked maintenance replacement removed v10 from durable state"; \

--- a/versiond-router/entrypoint.sh
+++ b/versiond-router/entrypoint.sh
@@ -772,4 +772,8 @@ if [ -n "$CATALOG_URL" ]; then
     run_catalog_reconciler &
 fi
 
-exec "$HAPROXY_BIN" -W -db -f "$OUT"
+# This container replaces HAProxy as a whole; it does not reload worker generations.
+# In master-worker mode the master inherits the background reconciler and can
+# wait for it after the last worker drains, keeping docker stop blocked until
+# its kill timeout. Let the serving process own PID 1 and exit after its drain.
+exec "$HAPROXY_BIN" -db -f "$OUT"

--- a/versiond-router/shutdown_test.sh
+++ b/versiond-router/shutdown_test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+tmpdir=$(mktemp -d)
+suffix="$$-$RANDOM"
+network="gonka-router-shutdown-$suffix"
+backend="gonka-router-shutdown-backend-$suffix"
+router="gonka-router-shutdown-router-$suffix"
+image=${ROUTER_SHUTDOWN_IMAGE:-gonka-router-shutdown-test:$suffix}
+built=false
+client_pid=
+cleanup() {
+    docker rm -f "$router" "$backend" >/dev/null 2>&1 || true
+    [[ -z $client_pid ]] || wait "$client_pid" 2>/dev/null || true
+    docker network rm "$network" >/dev/null 2>&1 || true
+    if [[ $built == true ]]; then docker image rm "$image" >/dev/null 2>&1 || true; fi
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+fail() { echo "shutdown_test: $*" >&2; docker logs "$router" >&2 || true; exit 1; }
+
+if [[ -z ${ROUTER_SHUTDOWN_IMAGE:-} ]]; then
+    docker build -q -t "$image" -f "$repo_root/versiond-router/Dockerfile" "$repo_root" >/dev/null
+    built=true
+fi
+cat >"$tmpdir/backend.py" <<'PY'
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import time
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/versions":
+            body = json.dumps({"versions": [{"name": "v5", "binary": "http://backend/v5.zip", "sha256": "a" * 64}]}).encode()
+        elif self.path.endswith("/slow"):
+            body = b"data: start\n\ndata: done\n\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(b"data: start\n\n")
+            self.wfile.flush()
+            time.sleep(3)
+            self.wfile.write(b"data: done\n\n")
+            return
+        else:
+            body = b"ready\n"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_):
+        pass
+
+
+ThreadingHTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+PY
+docker network create "$network" >/dev/null
+docker run -d --name "$backend" --network "$network" --network-alias backend \
+    -v "$tmpdir/backend.py:/backend.py:ro" python:3.12-alpine python /backend.py >/dev/null
+
+start_router() {
+    docker run -d --name "$router" --network "$network" --network-alias router \
+        -e VERSIOND_POOL_HOST=backend -e VERSIOND_VERSIONS=v5 \
+        -e VERSIOND_NON_HA_VERSIONS= -e GONKA_HA=true \
+        -e VERSIOND_ROUTING_CATALOG_URL=http://backend:8080/versions \
+        "$image" >/dev/null
+    local ready=false
+    for _ in $(seq 30); do
+        if docker exec "$router" wget -qO- http://127.0.0.1:8404/readyz >/dev/null 2>&1; then
+            ready=true
+            break
+        fi
+        sleep 1
+    done
+    [[ $ready == true ]] || fail 'router did not become ready'
+}
+stop_router() {
+    docker stop -t 8 "$router" >/dev/null
+    [[ $(docker inspect -f '{{.State.ExitCode}}' "$router") == 0 ]] || \
+        fail 'router needed a forced stop while the catalog reconciler was running'
+}
+
+start_router
+stop_router
+docker rm "$router" >/dev/null
+echo 'shutdown_test: idle router exits without SIGKILL'
+
+start_router
+docker exec "$backend" python -u -c '
+import urllib.request
+with urllib.request.urlopen("http://router:8080/v5/sessions/shutdown/slow", timeout=15) as response:
+    for line in response:
+        print(line.decode(), end="", flush=True)
+' >"$tmpdir/stream" &
+client_pid=$!
+for _ in $(seq 50); do
+    grep -q '^data: start$' "$tmpdir/stream" && break
+    sleep 0.1
+done
+grep -q '^data: start$' "$tmpdir/stream" || fail 'stream did not start'
+stop_router
+wait "$client_pid" || fail 'accepted stream was interrupted'
+client_pid=
+grep -q '^data: done$' "$tmpdir/stream" || fail 'stream did not finish'
+echo 'shutdown_test: accepted stream finishes before router exits'


### PR DESCRIPTION
With catalog refresh running in the background, HAProxy master-worker mode can leave a versiond-router slot running after its last worker has drained. Docker then waits until the stop timeout and kills the container. Run HAProxy directly so the slot exits normally after its accepted connections finish.

Add a Docker regression test for idle shutdown with catalog refresh enabled and for completion of an accepted SSE stream during shutdown, and run it in CI. Send STOP/CONT through Docker in the existing Runtime API fault test so it also works with HAProxy as container PID 1. Correct the v10 route-preservation assertion to accept either of the two eligible backends.

Validation:
- The new shutdown test fails on the original image and passes on the fixed image, including the accepted SSE stream.
- `make -C versiond-router test-render test-endpoints-render test-pool-status`
- `make -C versiond-router test-fleet test-shutdown`
- ShellCheck and shell syntax checks.
- Fresh-install and fleet-operation walkthroughs with real PostgreSQL and HA components in isolated Docker daemons; chain/API/ML prerequisites used project fixtures.

Found while checking the HA setup guide in #1744. This PR contains the router fix, tests and CI change; documentation remains in #1744.
