### PR TITLE
fix(mlnode): drop the stock ubuntu user on 24.04 bases so entrypoint.sh can create appuser

### DIFF
--- a/mlnode/packages/api/Dockerfile
+++ b/mlnode/packages/api/Dockerfile
@@ -4,6 +4,11 @@ ARG VLLM_BASE_IMAGE=ghcr.io/gonka-ai/vllm:v0.25.1-poc-v4-cu13-hopper-blackwell@s
 ARG MLNODE_RELEASE_VERSION=unknown
 FROM ${VLLM_BASE_IMAGE} AS base
 
+# Ubuntu 24.04 bases ship a stock `ubuntu` account at UID/GID 1000; entrypoint.sh
+# creates appuser at HOST_UID (default 1000) under `set -e`, so the container
+# would die on `useradd: UID 1000 is not unique` before exec. No-op on 22.04.
+RUN if id ubuntu >/dev/null 2>&1; then userdel -r ubuntu; fi
+
 RUN --mount=type=cache,target=/var/lib/apt/lists \
     --mount=type=cache,target=/root/.cache/pip \
     apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
`ghcr.io/gonka-ai/mlnode:3.0.17` does not start through its own `entrypoint.sh`: the vLLM 0.28 base is Ubuntu 24.04, which ships `ubuntu` at UID 1000, and the script creates `appuser` at `HOST_UID` (default 1000) under `set -e`. The container exits with `useradd: UID 1000 is not unique` before `exec "$@"`. 3.0.16 sat on 22.04.

Reproduced by @clanster on 4×B200 and 4×H200. One line after `FROM`; no-op on 22.04 bases. [#1691](https://github.com/gonka-ai/gonka/issues/1691).
