### PR TITLE
fix(mlnode): stop creating appuser in the entrypoints

### DIFF
--- a/mlnode/packages/api/entrypoint.sh
+++ b/mlnode/packages/api/entrypoint.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 set -e
 
-HOST_UID=${HOST_UID:-1000}
-HOST_GID=${HOST_GID:-1001}
-
-if ! getent group appgroup >/dev/null; then
-  echo "Creating group 'appgroup'"
-  groupadd -g "$HOST_GID" appgroup
-else
-  echo "Group 'appgroup' already exists"
-fi
-
-if ! id -u appuser >/dev/null 2>&1; then
-  echo "Creating user 'appuser'"
-  useradd -m -u "$HOST_UID" -g appgroup appuser
-else
-  echo "User 'appuser' already exists"
-fi
-
 # libcuda.so.1 is mounted at runtime by nvidia-docker; create the .so symlink
 # that Triton's linker expects (common issue on Vast.ai / cloud containers).
 if [ -f /lib/x86_64-linux-gnu/libcuda.so.1 ] && [ ! -e /lib/x86_64-linux-gnu/libcuda.so ]; then

--- a/mlnode/packages/pow/README.md
+++ b/mlnode/packages/pow/README.md
@@ -100,16 +100,6 @@ volumes:
 ```
 
 
-#### User and Group
-For convenience, the user and group are created in the container with the same UID and GID as the host user.
-It allows the container to write to the `scripts` and `notebooks` folders without changing the permissions on your local machine.  
-
-To use the same UID and GID as your host user, run the following command:
-```bash
-echo "HOST_UID=$(id -u)" >> .env
-echo "HOST_GID=$(id -g)" >> .env
-```
-
 #### Jupyter
 
 ```bash

--- a/mlnode/packages/pow/entrypoint.sh
+++ b/mlnode/packages/pow/entrypoint.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 set -e
 
-HOST_UID=${HOST_UID:-1000}
-HOST_GID=${HOST_GID:-1001}
-
-if ! getent group appgroup >/dev/null; then
-  echo "Creating group 'appgroup'"
-  groupadd -g "$HOST_GID" appgroup
-else
-  echo "Group 'appgroup' already exists"
-fi
-
-if ! id -u appuser >/dev/null 2>&1; then
-  echo "Creating user 'appuser'"
-  useradd -m -u "$HOST_UID" -g appgroup appuser
-else
-  echo "User 'appuser' already exists"
-fi
-
 source /app/packages/pow/.venv/bin/activate
 
 exec "$@"


### PR DESCRIPTION
Both entrypoints create `appgroup`/`appuser` at `HOST_UID` (default 1000) and then `exec` as root anyway: no `USER` in the Dockerfiles, no `gosu`, no `user:` in any compose file, nothing references the account. The README claim that it makes bind mounts host-writable was never true.

On the vLLM 0.28 base (Ubuntu 24.04, which ships `ubuntu` at UID 1000) the dead code became fatal: `useradd` fails under `set -e` and the container exits before `exec "$@"`. Found by @clanster on 3.0.17, 4×B200 and 4×H200. [#1691](https://github.com/gonka-ai/gonka/issues/1691).

Verified on `ghcr.io/gonka-ai/mlnode:3.0.17`: the stock entrypoint exits 4 before exec; with this change the compose command `uvicorn api.app:app` starts and `/api/v1/state` answers.

Replaces [#1750](https://github.com/gonka-ai/gonka/pull/1750). Running as a non-root user is a separate change: `useradd` at build time, `USER` in the Dockerfile, `user:` in compose.
