### PR TITLE
fix(devshard): bound host-bound bodies by bytes instead of hitting 413

### DIFF
--- a/devshard/accounting/detail_reason.go
+++ b/devshard/accounting/detail_reason.go
@@ -20,7 +20,7 @@ func normalizeDetailReason(reason string) string {
 		"sse_event_too_large", "response_body_too_large", "aggregate_response_too_large", "aggregate_fold_too_large",
 		"eof_transport", "client_cancelled", "transport_error", "no_receipt",
 		"not_finished", "http_429", "http_503", "http_forbidden", "http_not_found",
-		"http_timestamp_drift", "http_error", "long_response_after_content",
+		"http_timestamp_drift", "http_error", "http_413", "request_too_large", "catch_up_not_started", "long_response_after_content",
 		"escrow_state_root_diverged", "context_canceled", "timeout_diff_delivery_failed",
 		"timeout_not_applied", "host_served_probe", "poc_unavailable_host", "participant_throttled_no_send",
 		"participant_state_diverged_no_send", "participant_capability_no_send", "no_compatible_request_after_stale",
@@ -44,7 +44,7 @@ func normalizeDeliveryReason(reason string) string {
 		"sse_event_too_large", "response_body_too_large", "aggregate_response_too_large", "aggregate_fold_too_large",
 		"eof_transport", "transport_error", "client_cancelled", "not_finished",
 		"no_receipt", "http_error", "http_429", "http_503", "http_not_found",
-		"http_forbidden", DeliveryClientGone, DeliveryWarmupProbe, DeliveryThrottleProbe:
+		"http_forbidden", "http_413", "request_too_large", "catch_up_not_started", DeliveryClientGone, DeliveryWarmupProbe, DeliveryThrottleProbe:
 		return reason
 	default:
 		return "unknown"

--- a/devshard/accounting/reason_vocabulary_test.go
+++ b/devshard/accounting/reason_vocabulary_test.go
@@ -125,3 +125,16 @@ func TestBothVocabulariesNameTheSameReasons(t *testing.T) {
 			"a reason the timeout vocabulary names must survive the detail vocabulary too")
 	}
 }
+
+func TestTheVocabularyKnowsTheOversizeReasons(t *testing.T) {
+	require.Equal(t, "http_413", normalizeDetailReason("http_413"))
+	require.Equal(t, "request_too_large", normalizeDetailReason("request_too_large"))
+	require.Equal(t, "http_413", normalizeDeliveryReason("http_413"))
+	require.Equal(t, "request_too_large", normalizeDeliveryReason("request_too_large"),
+		"deliveryReasonFor hands a failed attempt's reason straight to this vocabulary")
+	require.Equal(t, FailureGatewayPolicy, FailureOriginFromDetail("request_too_large"),
+		"a body the gateway refused to send is the gateway's own call, not a host fault")
+	require.Equal(t, FailureGatewayPolicy, FailureOriginFromDetail("catch_up_not_started"),
+		"an attempt that never reached a host is the gateway's own serialization, not a host fault")
+	require.Equal(t, "catch_up_not_started", normalizeDeliveryReason("catch_up_not_started"))
+}

--- a/devshard/accounting/types.go
+++ b/devshard/accounting/types.go
@@ -349,6 +349,8 @@ var reasonOrigin = map[string]FailureOrigin{
 	"long_response_after_content":  FailureGatewayPolicy,
 	"timeout_not_applied":          FailureGatewayPolicy,
 	"host_served_probe":            FailureGatewayPolicy,
+	"request_too_large":            FailureGatewayPolicy,
+	"catch_up_not_started":         FailureGatewayPolicy,
 	"nonce_already_finished":       FailureGatewayPolicy,
 	"not_finished":                 FailureHostResponse,
 	"escrow_state_root_diverged":   FailureHostResponse,

--- a/devshard/cmd/devshardctl/gateway.go
+++ b/devshard/cmd/devshardctl/gateway.go
@@ -2294,6 +2294,9 @@ func gatewayStatusCodeForError(err error) int {
 	if errors.As(err, &upstreamErr) && isParticipantThrottleStatus(upstreamErr.StatusCode) {
 		return http.StatusTooManyRequests
 	}
+	if errors.Is(err, user.ErrPromptTooLargeForHost) {
+		return http.StatusRequestEntityTooLarge
+	}
 	return http.StatusBadGateway
 }
 

--- a/devshard/cmd/devshardctl/metrics.go
+++ b/devshard/cmd/devshardctl/metrics.go
@@ -17,6 +17,7 @@ import (
 	"common/probe"
 
 	"devshard/transport"
+	"devshard/user"
 )
 
 type DevshardMetrics struct {
@@ -1273,6 +1274,10 @@ func gatewayAttemptFailureReason(inf *inflight, session nonceFinishedChecker, mo
 	if inf.err != nil {
 		var upstreamErr *transport.UpstreamStatusError
 		switch {
+		case errors.Is(inf.err, user.ErrRequestTooLargeForHost):
+			return "request_too_large"
+		case errors.Is(inf.err, user.ErrCatchUpNotStarted):
+			return "catch_up_not_started"
 		case errors.As(inf.err, &upstreamErr):
 			return gatewayHTTPFailureReason(upstreamErr.StatusCode)
 		case errors.Is(inf.err, ErrAggregateResponseTooLarge):
@@ -1314,6 +1319,8 @@ func gatewayHTTPFailureReason(statusCode int) string {
 		return "http_not_found"
 	case http.StatusUnauthorized:
 		return "http_timestamp_drift"
+	case http.StatusRequestEntityTooLarge:
+		return "http_413"
 	default:
 		if statusCode >= 400 {
 			return "http_error"

--- a/devshard/cmd/devshardctl/oversize_no_blame_test.go
+++ b/devshard/cmd/devshardctl/oversize_no_blame_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/transport"
+	"devshard/types"
+	"devshard/user"
+)
+
+type unfinishedNonceSession struct{}
+
+func (unfinishedNonceSession) IsNonceFinished(uint64) bool { return false }
+
+func failedInflight(err error) *inflight {
+	inf := &inflight{nonce: 7, err: err, done: make(chan struct{})}
+	close(inf.done)
+	return inf
+}
+
+func probeInflight() *inflight {
+	inf := failedInflight(fmt.Errorf("send: %w", user.ErrPromptTooLargeForHost))
+	inf.probe = true
+	return inf
+}
+
+func hostAnswered413() *inflight {
+	return failedInflight(&transport.UpstreamStatusError{
+		Path: "/chat/completions", StatusCode: http.StatusRequestEntityTooLarge, Body: "request body too large",
+	})
+}
+
+func TestEverySpentNonceStillOwesItsVote(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		inf  *inflight
+		owes bool
+	}{
+		{name: "body we refused to send", inf: failedInflight(fmt.Errorf("send: %w", user.ErrPromptTooLargeForHost)), owes: true},
+		{name: "413 the host answered", inf: hostAnswered413(), owes: true},
+		{name: "probe the gateway spent on itself", inf: probeInflight(), owes: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.owes, shouldRunHandleTimeoutOn(testCase.inf, unfinishedNonceSession{}, false))
+		})
+	}
+}
+
+func TestABodyWeRefusedToSendScoresNoHostSample(t *testing.T) {
+	perf := NewPerfTracker(nil)
+	redundancy := &Redundancy{perf: perf, groupSize: 1}
+	inf := failedInflight(fmt.Errorf("send: %w", user.ErrPromptTooLargeForHost))
+
+	redundancy.recordSampleOnce(inf, user.InferenceParams{Model: "llama"}, false)
+
+	require.Zero(t, perf.Stats(inf.hostIdx).TotalSamples,
+		"a body the host never saw cannot count against its responsiveness")
+}
+
+func TestAnUndrainableTailScoresNoHostSample(t *testing.T) {
+	perf := NewPerfTracker(nil)
+	redundancy := &Redundancy{perf: perf, groupSize: 1}
+	inf := failedInflight(fmt.Errorf("send: %w", user.ErrTailTooLargeForHost))
+
+	redundancy.recordSampleOnce(inf, user.InferenceParams{Model: "llama"}, false)
+
+	require.Zero(t, perf.Stats(inf.hostIdx).TotalSamples,
+		"the guard covers the whole refusal family, not only the prompt case")
+}
+
+func TestADrainStateRootDisagreementScoresNoHostSample(t *testing.T) {
+	perf := NewPerfTracker(nil)
+	redundancy := &Redundancy{perf: perf, groupSize: 1}
+	inf := failedInflight(fmt.Errorf("catch-up ahead of nonce 7 to host 0: %w", types.ErrStateHashMismatch))
+
+	redundancy.recordSampleOnce(inf, user.InferenceParams{Model: "llama"}, false)
+
+	require.Zero(t, perf.Stats(inf.hostIdx).TotalSamples,
+		"a state-root disagreement was already exempt when it surfaced through processErr")
+}
+
+func TestAHostAnswer413DoesScoreASample(t *testing.T) {
+	perf := NewPerfTracker(nil)
+	redundancy := &Redundancy{perf: perf, groupSize: 1}
+
+	redundancy.recordSampleOnce(hostAnswered413(), user.InferenceParams{Model: "llama"}, false)
+
+	require.Equal(t, 1, perf.Stats(0).TotalSamples,
+		"a 413 the gateway measured as fitting is the host's answer and stays on its record")
+}
+
+func TestABodyWeRefusedToSendIsNotEscalated(t *testing.T) {
+	redundancy := &Redundancy{}
+	inf := failedInflight(fmt.Errorf("send: %w", user.ErrPromptTooLargeForHost))
+
+	_, escalate := redundancy.escalationForInflight(inf, user.InferenceParams{})
+
+	require.False(t, escalate,
+		"a prompt over the budget is too large for every host in the group, so a new nonce buys nothing")
+}
+
+func TestAnUndrainableTailIsStillEscalated(t *testing.T) {
+	redundancy := &Redundancy{}
+	inf := failedInflight(fmt.Errorf("send: %w", user.ErrTailTooLargeForHost))
+
+	_, escalate := redundancy.escalationForInflight(inf, user.InferenceParams{})
+
+	require.True(t, escalate,
+		"a host that already holds the tail can serve the request, so another host is worth trying")
+}
+
+func TestADrainDivergenceStillBlocksTheHost(t *testing.T) {
+	require.True(t, isStateRootDivergenceError(
+		fmt.Errorf("catch-up ahead of nonce 7 to host 0: %w", types.ErrStateHashMismatch)),
+		"the drain reports the disagreement by sentinel, not in the host's wording")
+	require.False(t, isStateRootDivergenceError(fmt.Errorf("connection refused")))
+}
+
+func TestAnAttemptThatNeverReachedTheHostScoresNoSample(t *testing.T) {
+	perf := NewPerfTracker(nil)
+	redundancy := &Redundancy{perf: perf, groupSize: 1}
+	inf := failedInflight(fmt.Errorf("send: %w", user.ErrCatchUpNotStarted))
+
+	redundancy.recordSampleOnce(inf, user.InferenceParams{Model: "llama"}, false)
+
+	require.Zero(t, perf.Stats(inf.hostIdx).TotalSamples,
+		"an attempt cancelled while queued behind another drain never cost the host anything")
+}

--- a/devshard/cmd/devshardctl/oversize_reason_test.go
+++ b/devshard/cmd/devshardctl/oversize_reason_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/transport"
+	"devshard/user"
+)
+
+func TestTheReasonSeparatesOurRefusalFromTheHosts413(t *testing.T) {
+	ours := &inflight{err: fmt.Errorf("send: %w", user.ErrPromptTooLargeForHost)}
+	require.Equal(t, "request_too_large", gatewayAttemptFailureReason(ours, nil, "m"),
+		"a body we refused to send is not an HTTP outcome at all")
+
+	tail := &inflight{err: fmt.Errorf("send: %w", user.ErrTailTooLargeForHost)}
+	require.Equal(t, "request_too_large", gatewayAttemptFailureReason(tail, nil, "m"),
+		"every refusal in the family reports the same way, not just the prompt one")
+
+	theirs := &inflight{err: &transport.UpstreamStatusError{
+		Path: "/chat/completions", StatusCode: http.StatusRequestEntityTooLarge, Body: "request body too large",
+	}}
+	require.Equal(t, "http_413", gatewayAttemptFailureReason(theirs, nil, "m"),
+		"a 413 from a host we measured as fitting stays the host's answer")
+}
+
+func TestAnOversizeRefusalReachesTheClientAs413(t *testing.T) {
+	require.Equal(t, http.StatusRequestEntityTooLarge,
+		gatewayStatusCodeForError(fmt.Errorf("inference: %w", user.ErrPromptTooLargeForHost)),
+		"a prompt no host can read will not become readable on retry, so 502 invites a pointless one")
+	require.Equal(t, http.StatusBadGateway,
+		gatewayStatusCodeForError(fmt.Errorf("inference: %w", user.ErrTailTooLargeForHost)),
+		"a tail that does not fit is the escrow's own state, not the caller's body")
+	require.Equal(t, http.StatusBadGateway, gatewayStatusCodeForError(fmt.Errorf("boom")),
+		"ordinary upstream failures stay retryable")
+}

--- a/devshard/cmd/devshardctl/redundancy.go
+++ b/devshard/cmd/devshardctl/redundancy.go
@@ -2806,6 +2806,9 @@ func (e *Redundancy) escalationForInflight(inf *inflight, params user.InferenceP
 		if inflightFinished(inf) {
 			return escalationTrigger{}, false
 		}
+		if errors.Is(inf.err, user.ErrPromptTooLargeForHost) {
+			return escalationTrigger{}, false
+		}
 		return escalationTrigger{
 			inf:      inf,
 			deadline: time.Now(),
@@ -3736,7 +3739,10 @@ func (e *Redundancy) recordSampleOnce(inf *inflight, params user.InferenceParams
 		e.maybeRecordCapabilityError(inf)
 		return
 	}
-	if inf != nil && errors.Is(inf.processErr, types.ErrStateHashMismatch) {
+	if inf != nil && (errors.Is(inf.err, user.ErrRequestTooLargeForHost) || errors.Is(inf.err, user.ErrCatchUpNotStarted)) {
+		return
+	}
+	if inf != nil && (errors.Is(inf.processErr, types.ErrStateHashMismatch) || errors.Is(inf.err, types.ErrStateHashMismatch)) {
 		return
 	}
 	if e.longResponseFailureExempt(inf) {
@@ -3852,6 +3858,9 @@ func (e *Redundancy) escrowStateBlockReason(participantKey string) (string, bool
 func isStateRootDivergenceError(err error) bool {
 	if err == nil {
 		return false
+	}
+	if errors.Is(err, types.ErrStateHashMismatch) {
+		return true
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "apply diff nonce") &&

--- a/devshard/transport/wire_size.go
+++ b/devshard/transport/wire_size.go
@@ -1,0 +1,35 @@
+package transport
+
+import (
+	"encoding/base64"
+
+	"google.golang.org/protobuf/proto"
+
+	"devshard/types"
+)
+
+const (
+	diffJSONOverheadBytes         = 96
+	promptJSONOverheadBytes       = 256
+	jsonStringExpansion           = 6
+	bytesJSONOverheadBytes        = 64
+	inferenceEnvelopeReserveBytes = 1 << 20
+)
+
+const CatchUpBudgetBytes = int(DefaultMaxBodySize) - inferenceEnvelopeReserveBytes
+
+func EncodedDiffSize(diff types.Diff) int {
+	content := &types.DiffContent{Nonce: diff.Nonce, Txs: diff.Txs}
+	return diffJSONOverheadBytes +
+		base64.StdEncoding.EncodedLen(proto.Size(content)) +
+		base64.StdEncoding.EncodedLen(len(diff.UserSig)) +
+		base64.StdEncoding.EncodedLen(len(diff.PostStateRoot))
+}
+
+func EncodedPromptSize(prompt []byte, model string) int {
+	return promptJSONOverheadBytes + base64.StdEncoding.EncodedLen(len(prompt)) + jsonStringExpansion*len(model)
+}
+
+func EncodedBytesSize(raw []byte) int {
+	return bytesJSONOverheadBytes + base64.StdEncoding.EncodedLen(len(raw))
+}

--- a/devshard/transport/wire_size_test.go
+++ b/devshard/transport/wire_size_test.go
@@ -1,0 +1,119 @@
+package transport
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/heightsync"
+	"devshard/host"
+	"devshard/types"
+)
+
+func diffWithPayloadSize(txBytes int) types.Diff {
+	return types.Diff{
+		Nonce: 4242,
+		Txs: []*types.DevshardTx{{Tx: &types.DevshardTx_StartInference{StartInference: &types.MsgStartInference{
+			InferenceId: 4242,
+			PromptHash:  make([]byte, txBytes),
+		}}}},
+		UserSig:       make([]byte, 65),
+		PostStateRoot: make([]byte, 32),
+	}
+}
+
+func TestEncodedDiffSizeBoundsTheRealJSON(t *testing.T) {
+	for _, txBytes := range []int{0, 1, 2, 3, 1024, 65536} {
+		t.Run(fmt.Sprintf("tx_bytes=%d", txBytes), func(t *testing.T) {
+			diff := diffWithPayloadSize(txBytes)
+			wire, err := DiffToJSON(diff)
+			require.NoError(t, err)
+			actual, err := json.Marshal(wire)
+			require.NoError(t, err)
+
+			estimate := EncodedDiffSize(diff)
+			require.GreaterOrEqual(t, estimate, len(actual),
+				"the estimate must never undercount, or a chunk built on it overflows the host cap")
+			require.LessOrEqual(t, estimate-len(actual), diffJSONOverheadBytes,
+				"the estimate must stay tight, or the budget wastes most of the body")
+		})
+	}
+}
+
+func TestEncodedDiffSizeCountsAnEmptyDiff(t *testing.T) {
+	estimate := EncodedDiffSize(types.Diff{Nonce: 1})
+	require.Positive(t, estimate, "even an empty diff costs field names on the wire")
+}
+
+func TestEncodedPromptSizeBoundsTheRealJSON(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		promptSize int
+		model      string
+	}{
+		{name: "small prompt", promptSize: 16, model: "llama"},
+		{name: "typical prompt", promptSize: 4096, model: "Qwen/Qwen3-235B-A22B-Instruct-2507"},
+		{name: "model id longer than any fixed reserve", promptSize: 64, model: strings.Repeat("m", 4096)},
+		{name: "model id that JSON has to escape", promptSize: 64, model: strings.Repeat("<", 2048)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			prompt := make([]byte, testCase.promptSize)
+			actual, err := json.Marshal(PayloadJSON{
+				Prompt: prompt, Model: testCase.model,
+				InputLength: uint64(testCase.promptSize), MaxTokens: 4096, StartedAt: 1 << 40,
+			})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, EncodedPromptSize(prompt, testCase.model), len(actual),
+				"a payload the gateway measured as fitting must actually fit")
+		})
+	}
+}
+
+func TestCatchUpBudgetLeavesRoomUnderTheHostCap(t *testing.T) {
+	require.Positive(t, CatchUpBudgetBytes,
+		"a non-positive budget refuses every request the gateway would ever send")
+	require.Less(t, int64(CatchUpBudgetBytes), DefaultMaxBodySize,
+		"the budget must reserve room for the envelope, signatures and the height-sync section")
+}
+
+func TestABodyFilledToTheBudgetStaysUnderTheHostCap(t *testing.T) {
+	const model = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+	prompt := make([]byte, 64<<10)
+	promptBytes := EncodedPromptSize(prompt, model)
+	diff := diffWithPayloadSize(3 * (CatchUpBudgetBytes - promptBytes - 512) / 4)
+	require.LessOrEqual(t, EncodedDiffSize(diff)+promptBytes, CatchUpBudgetBytes,
+		"fixture must sit inside the budget, not below it")
+	require.Greater(t, EncodedDiffSize(diff)+promptBytes, CatchUpBudgetBytes*9/10,
+		"a fixture at half the budget would not test the ceiling")
+
+	wire, err := DiffToJSON(diff)
+	require.NoError(t, err)
+	request := InferenceRequest{
+		Diffs:   []DiffJSON{wire},
+		Nonce:   diff.Nonce,
+		Payload: PayloadToJSON(&host.InferencePayload{Prompt: prompt, Model: model, InputLength: uint64(len(prompt)), MaxTokens: 4096}),
+	}
+
+	body, err := json.Marshal(request)
+	require.NoError(t, err)
+	require.Less(t, int64(len(body)), DefaultMaxBodySize,
+		"a body the budget admits has to pass the host's own reader")
+
+	wrapped, err := MarshalWrappedInferenceRequest(CurrentInferenceEnvelopeSchemaVersion,
+		&heightsync.HeightSyncSection{
+			ChainID: "gonka-mainnet", ProofType: "anchor", Direction: "request",
+			MainnetHeight: 1 << 40, MainnetBlockHashHex: strings.Repeat("a", 64), TimestampUnixMs: 1 << 40,
+			OriginatorSenderID: strings.Repeat("g", 64),
+		}, request)
+	require.NoError(t, err)
+	require.Less(t, int64(len(wrapped)), DefaultMaxBodySize,
+		"the envelope reserve has to cover the envelope")
+
+	envelopeOverhead := len(wrapped) - len(body)
+	require.Positive(t, envelopeOverhead)
+	require.LessOrEqual(t, int64(CatchUpBudgetBytes+envelopeOverhead), DefaultMaxBodySize,
+		"a body filled to the budget plus its envelope must still fit under the host cap")
+}

--- a/devshard/user/catch_up_ahead.go
+++ b/devshard/user/catch_up_ahead.go
@@ -1,0 +1,167 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"devshard/host"
+	"devshard/logging"
+	"devshard/types"
+)
+
+const (
+	defaultVerifierGateWait = 2 * time.Second
+	verifierDrainBudget     = 30 * time.Second
+	catchUpChunkTimeout     = 60 * time.Second
+)
+
+var (
+	ErrRequestTooLargeForHost = errors.New("request exceeds host body budget")
+	ErrPromptTooLargeForHost  = fmt.Errorf("prompt alone exceeds host body budget: %w", ErrRequestTooLargeForHost)
+	ErrTailTooLargeForHost    = fmt.Errorf("undrainable tail exceeds host body budget: %w", ErrRequestTooLargeForHost)
+	ErrCatchUpNotStarted      = errors.New("catch-up did not start")
+)
+
+func newCatchUpGates(hostCount int) []chan struct{} {
+	gates := make([]chan struct{}, hostCount)
+	for i := range gates {
+		gates[i] = make(chan struct{}, 1)
+	}
+	return gates
+}
+
+func (s *Session) diffsUpToNonceLocked(hostIdx int, targetNonce uint64) []types.Diff {
+	lastSent := s.hostSyncNonce[hostIdx]
+	if targetNonce > 0 && lastSent >= targetNonce {
+		lastSent = targetNonce - 1
+	}
+	var tail []types.Diff
+	for _, diff := range s.diffs {
+		if diff.Nonce > lastSent && diff.Nonce <= targetNonce {
+			tail = append(tail, diff)
+		}
+	}
+	return tail
+}
+
+func (s *Session) tailToSendLocked(hostIdx int, targetNonce uint64, reserveBytes, budgetBytes int) ([]types.Diff, bool) {
+	tail := s.diffsUpToNonceLocked(hostIdx, targetNonce)
+	fits := catchUpFitsOneBody(tail, reserveBytes, budgetBytes)
+	if fits && len(tail) > 0 {
+		s.validateCatchUp(tail, targetNonce, hostIdx)
+	}
+	return tail, fits
+}
+
+func (s *Session) deliverCatchUpChunk(ctx context.Context, hostIdx int, client HostClient, chunk []types.Diff) (*host.HostResponse, error) {
+	chunkNonce := chunk[len(chunk)-1].Nonce
+	chunkCtx, cancel := context.WithTimeout(ctx, catchUpChunkTimeout)
+	resp, err := client.Send(chunkCtx, host.HostRequest{Diffs: chunk, Nonce: chunkNonce}, nil, nil)
+	cancel()
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.processResponse(hostIdx, resp, chunkNonce); err != nil {
+		return nil, err
+	}
+	s.logSignatureProgress(resp.Nonce)
+	return resp, nil
+}
+
+func (s *Session) enterCatchUpGate(ctx context.Context, hostIdx int, gateWait time.Duration) (func(), error) {
+	waitCtx := ctx
+	if gateWait > 0 {
+		bounded, cancel := context.WithTimeout(ctx, gateWait)
+		defer cancel()
+		waitCtx = bounded
+	}
+	select {
+	case s.catchUpGate[hostIdx] <- struct{}{}:
+		return func() { <-s.catchUpGate[hostIdx] }, nil
+	case <-waitCtx.Done():
+		return nil, fmt.Errorf("host %d: %w: %w", hostIdx, ErrCatchUpNotStarted, waitCtx.Err())
+	}
+}
+
+func (s *Session) verifierCatchUpTail(ctx context.Context, hostIdx int, reserveBytes int) ([]types.Diff, bool) {
+	s.mu.Lock()
+	targetNonce := s.nonce
+	s.mu.Unlock()
+	if targetNonce == 0 {
+		return nil, false
+	}
+
+	drainCtx, cancel := context.WithTimeout(ctx, verifierDrainBudget)
+	defer cancel()
+	tail, err := s.catchUpTailForHost(drainCtx, hostIdx, targetNonce, reserveBytes, defaultVerifierGateWait)
+	if err != nil {
+		logging.Warn("verifier catch-up ahead failed", "subsystem", "session",
+			"escrow", s.escrowID, "host", hostIdx, "target_nonce", targetNonce, "error", err)
+		return nil, false
+	}
+	return tail, true
+}
+
+func (s *Session) catchUpTailForHost(ctx context.Context, hostIdx int, targetNonce uint64, reserveBytes int, gateWait time.Duration) ([]types.Diff, error) {
+	s.mu.Lock()
+	budgetBytes := s.catchUpBudgetLocked()
+	tail, fits := s.tailToSendLocked(hostIdx, targetNonce, reserveBytes, budgetBytes)
+	s.mu.Unlock()
+	if fits {
+		return tail, nil
+	}
+	if reserveBytes >= budgetBytes {
+		return nil, ErrPromptTooLargeForHost
+	}
+
+	release, err := s.enterCatchUpGate(ctx, hostIdx, gateWait)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	client := s.finalizeClientFor(hostIdx)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		s.mu.Lock()
+		tail, fits = s.tailToSendLocked(hostIdx, targetNonce, reserveBytes, budgetBytes)
+		s.mu.Unlock()
+		if fits {
+			return tail, nil
+		}
+
+		drainableDiffs := tail
+		for len(drainableDiffs) > 0 && drainableDiffs[len(drainableDiffs)-1].Nonce >= targetNonce {
+			drainableDiffs = drainableDiffs[:len(drainableDiffs)-1]
+		}
+		if len(drainableDiffs) == 0 {
+			return nil, ErrTailTooLargeForHost
+		}
+
+		chunk, err := catchUpChunk(drainableDiffs, budgetBytes)
+		if err != nil {
+			return nil, err
+		}
+		chunkNonce := chunk[len(chunk)-1].Nonce
+		logging.Info("ensureHostCaughtUp chunk", "subsystem", "finalize", "escrow", s.escrowID,
+			"nonce", chunkNonce, "host", hostIdx, "target_nonce", targetNonce,
+			"diffs_in_chunk", len(chunk), "tail_diffs", len(tail))
+
+		resp, err := s.deliverCatchUpChunk(ctx, hostIdx, client, chunk)
+		s.publishHeightSyncView()
+		if err != nil {
+			return nil, fmt.Errorf("catch-up ahead of nonce %d to host %d: %w", targetNonce, hostIdx, err)
+		}
+		if resp.Nonce < chunkNonce {
+			return nil, fmt.Errorf("catch-up ahead stalled at nonce %d on host %d", resp.Nonce, hostIdx)
+		}
+	}
+}

--- a/devshard/user/catch_up_ahead_test.go
+++ b/devshard/user/catch_up_ahead_test.go
@@ -1,0 +1,808 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/host"
+	"devshard/internal/testutil"
+	"devshard/transport"
+	"devshard/types"
+)
+
+type sizeRecordingClient struct {
+	InProcessClient
+	mu             sync.Mutex
+	bodySizes      []int
+	nonceRuns      [][]uint64
+	promptedNonces []uint64
+	promptDiffs    []types.Diff
+	sendErr        error
+	sendSignal     chan struct{}
+	sendRelease    chan struct{}
+	staleNonce     bool
+	corruptRoot    bool
+}
+
+func (c *sizeRecordingClient) Send(ctx context.Context, req host.HostRequest, stream io.Writer, receiptHandler func(*host.HostResponse)) (*host.HostResponse, error) {
+	wire, err := transport.HostRequestToJSON(req)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(wire)
+	if err != nil {
+		return nil, err
+	}
+	nonces := make([]uint64, 0, len(req.Diffs))
+	for _, diff := range req.Diffs {
+		nonces = append(nonces, diff.Nonce)
+	}
+
+	c.mu.Lock()
+	c.bodySizes = append(c.bodySizes, len(body))
+	c.nonceRuns = append(c.nonceRuns, nonces)
+	if req.Payload != nil {
+		c.promptedNonces = append(c.promptedNonces, req.Nonce)
+		c.promptDiffs = append([]types.Diff(nil), req.Diffs...)
+	}
+	sendErr := c.sendErr
+	signal, release := c.sendSignal, c.sendRelease
+	c.mu.Unlock()
+
+	if signal != nil {
+		signal <- struct{}{}
+	}
+	if release != nil {
+		<-release
+	}
+	if sendErr != nil {
+		return nil, sendErr
+	}
+	resp, err := c.InProcessClient.Send(ctx, req, stream, receiptHandler)
+	c.mu.Lock()
+	stale := c.staleNonce
+	c.mu.Unlock()
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	c.mu.Lock()
+	corrupt := c.corruptRoot
+	c.mu.Unlock()
+	switch {
+	case stale:
+		answer := *resp
+		answer.Nonce, answer.StateHash, answer.StateSig = 0, nil, nil
+		return &answer, nil
+	case corrupt && len(resp.StateHash) > 0:
+		answer := *resp
+		answer.StateHash = append([]byte(nil), resp.StateHash...)
+		answer.StateHash[0] ^= 0xff
+		return &answer, nil
+	}
+	return resp, err
+}
+
+func (c *sizeRecordingClient) recorded() ([]int, []uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int(nil), c.bodySizes...), append([]uint64(nil), c.promptedNonces...)
+}
+
+func (c *sizeRecordingClient) recordedPromptDiffs() []types.Diff {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]types.Diff(nil), c.promptDiffs...)
+}
+
+func (c *sizeRecordingClient) failSends(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sendErr = err
+}
+
+func (c *sizeRecordingClient) park(t *testing.T) (signal chan struct{}, releaseAll func()) {
+	t.Helper()
+	signal, release := make(chan struct{}, 1), make(chan struct{})
+	c.mu.Lock()
+	c.sendSignal, c.sendRelease = signal, release
+	c.mu.Unlock()
+
+	var once sync.Once
+	releaseAll = func() {
+		once.Do(func() {
+			c.mu.Lock()
+			c.sendSignal, c.sendRelease = nil, nil
+			c.mu.Unlock()
+			close(release)
+			for len(signal) > 0 {
+				<-signal
+			}
+		})
+	}
+	t.Cleanup(releaseAll)
+	return signal, releaseAll
+}
+
+func (c *sizeRecordingClient) clearRecordings() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.bodySizes, c.nonceRuns, c.promptedNonces, c.promptDiffs = nil, nil, nil, nil
+}
+
+func (c *sizeRecordingClient) recordedNonceRuns() [][]uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([][]uint64(nil), c.nonceRuns...)
+}
+
+func budgetOf(t *testing.T, session *Session) int {
+	t.Helper()
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	return session.catchUpBudgetLocked()
+}
+
+func promptOfSize(totalBytes int) []byte {
+	prefix := `{"model":"llama","messages":[{"role":"user","content":"`
+	suffix := fmt.Sprintf(`"}],"max_tokens":%d}`, testutil.TestMaxTokens)
+	padding := totalBytes - len(prefix) - len(suffix)
+	if padding < 1 {
+		padding = 1
+	}
+	return []byte(prefix + strings.Repeat("x", padding) + suffix)
+}
+
+func inferenceParamsFor(promptBytes []byte) InferenceParams {
+	return InferenceParams{
+		Model: "llama", Prompt: promptBytes,
+		InputLength: uint64(len(promptBytes)), MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+}
+
+func backloggedSession(t *testing.T, promptBytes []byte, diffsThatFit int) (*Session, *PreparedInference, *sizeRecordingClient) {
+	t.Helper()
+	session, _, _ := setupSession(t, 3, 1_000_000, 10)
+	for i := 0; i < 12; i++ {
+		_, err := session.sendPendingDiff(context.Background(), nil, nil)
+		require.NoError(t, err)
+	}
+
+	prepared, err := session.PrepareInference(inferenceParamsFor(promptBytes))
+	require.NoError(t, err)
+
+	recorder := &sizeRecordingClient{InProcessClient: *session.clients[prepared.hostIdx].(*InProcessClient)}
+	session.mu.Lock()
+	session.clients[prepared.hostIdx] = recorder
+	session.hostSyncNonce[prepared.hostIdx] = 0
+	session.catchUpBudgetBytes = transport.EncodedPromptSize(promptBytes, "llama") +
+		diffsThatFit*transport.EncodedDiffSize(session.diffs[0])
+	session.mu.Unlock()
+
+	return session, prepared, recorder
+}
+
+func TestTheInferenceDrainsTheBacklogBeforeThePrompt(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+
+	_, err := session.SendOnly(context.Background(), prepared, nil, nil)
+	require.NoError(t, err)
+
+	sizes, prompted := recorder.recorded()
+	require.Greater(t, len(sizes), 1, "a backlog over the budget has to travel in more than one body")
+	for _, bodyBytes := range sizes {
+		require.LessOrEqual(t, bodyBytes, budgetOf(t, session),
+			"no body the gateway builds may exceed what the host will read")
+	}
+	require.Equal(t, []uint64{prepared.diff.Nonce}, prompted,
+		"the prompt rides the last request, never a catch-up chunk")
+}
+
+func TestTheDrainLeavesRoomForThePrompt(t *testing.T) {
+	promptBytes := promptOfSize(4096)
+	session, prepared, recorder := backloggedSession(t, promptBytes, 4)
+
+	session.mu.Lock()
+	tail := session.diffsUpToNonceLocked(prepared.hostIdx, prepared.diff.Nonce)
+	tailBytes := 0
+	for _, diff := range tail {
+		tailBytes += transport.EncodedDiffSize(diff)
+	}
+	session.catchUpBudgetBytes = tailBytes + transport.EncodedPromptSize(promptBytes, "llama") - 1
+	budgetBytes := session.catchUpBudgetBytes
+	session.mu.Unlock()
+
+	_, err := session.SendOnly(context.Background(), prepared, nil, nil)
+	require.NoError(t, err)
+
+	sizes, prompted := recorder.recorded()
+	require.Greater(t, len(sizes), 1, "the prompt's own bytes must be what forces the drain")
+	require.Equal(t, []uint64{prepared.diff.Nonce}, prompted)
+	require.LessOrEqual(t, sizes[len(sizes)-1], budgetBytes,
+		"the body carrying the prompt is the one that must fit")
+}
+
+func TestThePromptRidesTheFreshTailNotTheSnapshot(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 64)
+
+	_, err := session.SendOnly(context.Background(), prepared, nil, nil)
+	require.NoError(t, err)
+
+	tail := recorder.recordedPromptDiffs()
+	require.NotEmpty(t, tail)
+	require.Equal(t, uint64(1), tail[0].Nonce,
+		"the tail must start where the host's cursor is, which the fixture reset to zero")
+	require.Equal(t, prepared.diff.Nonce, tail[len(tail)-1].Nonce,
+		"the tail still has to end at the nonce the host is asked to sign")
+}
+
+func TestTheTailCarriesTheTargetDiffEvenWhenTheCursorPassedIt(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 64)
+
+	require.NoError(t, session.sendCatchUp(context.Background(), prepared.hostIdx))
+	session.mu.Lock()
+	cursor := session.hostSyncNonce[prepared.hostIdx]
+	session.mu.Unlock()
+	require.GreaterOrEqual(t, cursor, prepared.diff.Nonce, "fixture must leave the cursor at or past the target")
+
+	resp, err := session.SendOnly(context.Background(), prepared, nil, nil)
+	require.NoError(t, err)
+
+	tail := recorder.recordedPromptDiffs()
+	require.NotEmpty(t, tail, "an empty body can never authorize execution")
+	require.Equal(t, prepared.diff.Nonce, tail[len(tail)-1].Nonce,
+		"the target's own diff has to be in the body the host reads")
+	require.NotEmpty(t, resp.Receipt, "with the target diff present the host signs the receipt")
+}
+
+func TestAPromptOverTheBudgetNeverSpendsANonce(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 1_000_000, 10)
+	promptBytes := promptOfSize(8192)
+
+	session.mu.Lock()
+	session.catchUpBudgetBytes = transport.EncodedPromptSize(promptBytes, "llama") + minimumDiffReserveBytes
+	nonceBefore, diffsBefore, statesBefore := session.nonce, len(session.diffs), len(session.nonceStates)
+	session.mu.Unlock()
+
+	_, err := session.PrepareInference(inferenceParamsFor(promptBytes))
+
+	require.ErrorIs(t, err, ErrPromptTooLargeForHost)
+	require.ErrorIs(t, err, ErrRequestTooLargeForHost)
+	session.mu.Lock()
+	require.Equal(t, nonceBefore, session.nonce,
+		"a nonce spent here reserves the user's money until a timeout vote releases it")
+	require.Len(t, session.diffs, diffsBefore, "a refused prompt must leave no diff behind")
+	require.Len(t, session.nonceStates, statesBefore, "nor an outcome to track")
+	session.mu.Unlock()
+}
+
+func TestAPromptOneByteUnderTheBoundaryIsAccepted(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 1_000_000, 10)
+	promptBytes := promptOfSize(8192)
+
+	session.mu.Lock()
+	session.catchUpBudgetBytes = transport.EncodedPromptSize(promptBytes, "llama") + minimumDiffReserveBytes + 1
+	session.mu.Unlock()
+
+	prepared, err := session.PrepareInference(inferenceParamsFor(promptBytes))
+
+	require.NoError(t, err, "the guard must refuse only what genuinely cannot fit")
+	require.NotNil(t, prepared)
+}
+
+func TestAPromptOverTheBudgetIsNeverSent(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(4096), 4)
+	session.mu.Lock()
+	session.catchUpBudgetBytes = 2048
+	session.mu.Unlock()
+
+	_, err := session.SendOnly(context.Background(), prepared, nil, nil)
+	require.ErrorIs(t, err, ErrPromptTooLargeForHost)
+
+	sizes, _ := recorder.recorded()
+	require.Empty(t, sizes, "the gateway must not spend a host round trip on a body it measured as too large")
+}
+
+func TestADeadHostDuringTheDrainFailsTheAttempt(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	recorder.failSends(fmt.Errorf("connection refused"))
+
+	_, err := session.SendOnly(context.Background(), prepared, nil, nil)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrRequestTooLargeForHost,
+		"a host that dropped the connection is a host failure, not a body the gateway refused to send")
+}
+
+func TestAWaiterNeitherSendsNorHoldsWhileTheGateIsTaken(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	signal, releaseAll := recorder.park(t)
+
+	holderCtx, cancelHolder := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelHolder()
+	holderDone := make(chan struct{})
+	go func() {
+		defer close(holderDone)
+		_, _ = session.catchUpTailForHost(holderCtx, prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+	}()
+	select {
+	case <-signal:
+	case <-holderCtx.Done():
+		t.Fatal("the holding drain never reached the host")
+	}
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := session.catchUpTailForHost(waiterCtx, prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+		waiterErr <- err
+	}()
+
+	select {
+	case <-signal:
+		t.Fatal("a second drain reached the host while the first one held the gate")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	cancelWaiter()
+	select {
+	case err := <-waiterErr:
+		require.ErrorIs(t, err, ErrCatchUpNotStarted,
+			"a speculative loser must unwind instead of holding on a drain it no longer needs")
+		require.ErrorIs(t, err, context.Canceled, "and it must say why it left")
+	case <-time.After(10 * time.Second):
+		t.Fatal("the waiter never unwound after its context was cancelled")
+	}
+
+	releaseAll()
+	select {
+	case <-holderDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the holding drain never finished after the gate was released")
+	}
+
+	session.mu.Lock()
+	session.hostSyncNonce[prepared.hostIdx] = 0
+	session.mu.Unlock()
+	runsBefore := len(recorder.recordedNonceRuns())
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelDrain()
+	_, err := session.catchUpTailForHost(drainCtx, prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+	require.NoError(t, err, "a released gate lets the next drain through")
+	require.Greater(t, len(recorder.recordedNonceRuns()), runsBefore,
+		"and that drain had work to do, so it proves the gate was free rather than empty")
+}
+
+func TestTheHeartbeatDrainsTheBacklogAndStillDelivers(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 1_000_000, 10)
+	for i := 0; i < 12; i++ {
+		_, err := session.sendPendingDiff(context.Background(), nil, nil)
+		require.NoError(t, err)
+	}
+
+	session.mu.Lock()
+	diff, hostIdx, err := session.composeDiffLocked(nil)
+	require.NoError(t, err)
+	recorder := &sizeRecordingClient{InProcessClient: *session.clients[hostIdx].(*InProcessClient)}
+	session.clients[hostIdx] = recorder
+	session.hostSyncNonce[hostIdx] = 0
+	session.catchUpBudgetBytes = 4 * transport.EncodedDiffSize(session.diffs[0])
+	budgetBytes := session.catchUpBudgetBytes
+	session.mu.Unlock()
+
+	require.NoError(t, session.sendComposedDiff(context.Background(), composedDiff{diff: diff, hostIdx: hostIdx}))
+
+	sizes, _ := recorder.recorded()
+	require.Greater(t, len(sizes), 1, "a backlog over the budget has to travel in more than one body")
+	for _, bodyBytes := range sizes {
+		require.LessOrEqual(t, bodyBytes, budgetBytes,
+			"a heartbeat body is bounded by the same host cap as an inference body")
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	require.Equal(t, diff.Nonce, session.hostSyncNonce[hostIdx],
+		"the composed diff has to reach the host, not just the catch-up chunks")
+}
+
+func TestTheCatchUpSkipsForwardWhenTheHostIsAlreadyAhead(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+
+	require.NoError(t, session.sendCatchUp(context.Background(), prepared.hostIdx))
+	require.Greater(t, len(recorder.recordedNonceRuns()), 1, "fixture must need more than one chunk")
+
+	recorder.clearRecordings()
+	session.mu.Lock()
+	session.hostSyncNonce[prepared.hostIdx] = 0
+	session.mu.Unlock()
+
+	require.NoError(t, session.sendCatchUp(context.Background(), prepared.hostIdx))
+
+	require.Len(t, recorder.recordedNonceRuns(), 1,
+		"a host that answers with a later nonce must not be walked through every remaining chunk")
+}
+
+func TestATailBiggerThanTheBudgetIsRefusedNotShipped(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 64)
+	require.NoError(t, session.sendCatchUp(context.Background(), prepared.hostIdx))
+	recorder.clearRecordings()
+
+	session.mu.Lock()
+	session.catchUpBudgetBytes = 128
+	session.mu.Unlock()
+
+	_, err := session.catchUpTailForHost(context.Background(), prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+
+	require.ErrorIs(t, err, ErrTailTooLargeForHost)
+	require.ErrorIs(t, err, ErrRequestTooLargeForHost)
+	require.Empty(t, recorder.recordedNonceRuns(), "a body that cannot fit must not be sent anyway")
+}
+
+func TestADiffBiggerThanTheBudgetIsRefusedNotShipped(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 64)
+
+	session.mu.Lock()
+	session.hostSyncNonce[prepared.hostIdx] = 0
+	session.catchUpBudgetBytes = 128
+	session.mu.Unlock()
+
+	_, err := session.catchUpTailForHost(context.Background(), prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+
+	require.ErrorIs(t, err, ErrTailTooLargeForHost)
+	require.Empty(t, recorder.recordedNonceRuns(), "a chunk the host would refuse must not leave the gateway")
+}
+
+func TestTheDrainBypassesTheParticipantBudget(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	refusing := &admissionRefusingClient{InProcessClient: recorder.InProcessClient}
+	session.mu.Lock()
+	session.clients[prepared.hostIdx] = refusing
+	session.mu.Unlock()
+
+	_, err := session.catchUpTailForHost(context.Background(), prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+
+	require.NoError(t, err)
+	require.Zero(t, refusing.refusals,
+		"a host locked out by the budget can never catch up, so the drain has to bypass it")
+}
+
+func TestAHeartbeatWhoseDrainFailsDeliversNothing(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 1_000_000, 10)
+	for i := 0; i < 12; i++ {
+		_, err := session.sendPendingDiff(context.Background(), nil, nil)
+		require.NoError(t, err)
+	}
+
+	session.mu.Lock()
+	diff, hostIdx, err := session.composeDiffLocked(nil)
+	require.NoError(t, err)
+	recorder := &sizeRecordingClient{InProcessClient: *session.clients[hostIdx].(*InProcessClient)}
+	recorder.failSends(fmt.Errorf("connection refused"))
+	session.clients[hostIdx] = recorder
+	session.hostSyncNonce[hostIdx] = 0
+	session.catchUpBudgetBytes = 4 * transport.EncodedDiffSize(session.diffs[0])
+	session.mu.Unlock()
+
+	require.NoError(t, session.sendComposedDiff(context.Background(), composedDiff{diff: diff, hostIdx: hostIdx}),
+		"a dead host is not a heartbeat failure; the next turn retries")
+
+	sizes, _ := recorder.recorded()
+	require.Len(t, sizes, 1,
+		"the failed drain chunk is the only body that may leave the gateway: the composed diff must not follow it")
+}
+
+func TestAPromptOverTheBudgetIsRefusedOnACurrentHost(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 64)
+	require.NoError(t, session.sendCatchUp(context.Background(), prepared.hostIdx))
+	recorder.clearRecordings()
+
+	session.mu.Lock()
+	budgetBytes := session.catchUpBudgetBytes
+	session.mu.Unlock()
+
+	_, err := session.catchUpTailForHost(context.Background(), prepared.hostIdx, prepared.diff.Nonce, budgetBytes, 0)
+
+	require.ErrorIs(t, err, ErrPromptTooLargeForHost)
+	require.Empty(t, recorder.recordedNonceRuns())
+}
+
+func TestAHostThatNeverAdvancesStopsTheDrain(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	recorder.mu.Lock()
+	recorder.staleNonce = true
+	recorder.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := session.catchUpTailForHost(ctx, prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+
+	require.ErrorContains(t, err, "stalled at nonce",
+		"a host whose answer never advances would otherwise be asked forever")
+	require.NotErrorIs(t, err, context.DeadlineExceeded, "the loop must stop itself, not time out")
+	require.Len(t, recorder.recordedNonceRuns(), 1, "one unanswered chunk is enough to give up")
+}
+
+func TestTheFinalizeCatchUpWaitsOnTheSameGate(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	signal, releaseAll := recorder.park(t)
+
+	holderCtx, cancelHolder := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelHolder()
+	holderDone := make(chan struct{})
+	go func() {
+		defer close(holderDone)
+		_, _ = session.catchUpTailForHost(holderCtx, prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+	}()
+	select {
+	case <-signal:
+	case <-holderCtx.Done():
+		t.Fatal("the holding drain never reached the host")
+	}
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterErr := make(chan error, 1)
+	go func() { waiterErr <- session.sendCatchUp(waiterCtx, prepared.hostIdx) }()
+	select {
+	case <-signal:
+		t.Fatal("the finalize catch-up reached the host while a drain held the gate")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	cancelWaiter()
+	select {
+	case err := <-waiterErr:
+		require.ErrorIs(t, err, ErrCatchUpNotStarted,
+			"a slot it never reached must not be reported as caught up")
+	case <-time.After(10 * time.Second):
+		t.Fatal("the finalize catch-up never unwound")
+	}
+
+	releaseAll()
+	select {
+	case <-holderDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the holding drain never finished after the gate was released")
+	}
+}
+
+func TestTheFinalizeCatchUpRefusesADiffOverTheBudget(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 64)
+	session.mu.Lock()
+	session.hostSyncNonce[prepared.hostIdx] = 0
+	session.catchUpBudgetBytes = 128
+	session.mu.Unlock()
+
+	err := session.sendCatchUp(context.Background(), prepared.hostIdx)
+
+	require.ErrorIs(t, err, ErrTailTooLargeForHost,
+		"both catch-up paths have to refuse the same body")
+	require.Empty(t, recorder.recordedNonceRuns())
+}
+
+func TestTheHeartbeatDoesNotWaitOutAnInferenceDrain(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	session.mu.Lock()
+	session.heartbeatGateWaitOverride = time.Millisecond
+	var diff types.Diff
+	var hostIdx int
+	for attempt := 0; attempt <= len(session.group); attempt++ {
+		var err error
+		diff, hostIdx, err = session.composeDiffLocked(nil)
+		require.NoError(t, err)
+		if hostIdx == prepared.hostIdx {
+			break
+		}
+	}
+	require.Equal(t, prepared.hostIdx, hostIdx, "fixture needs the heartbeat bound to the busy slot")
+	session.mu.Unlock()
+
+	signal, releaseAll := recorder.park(t)
+	holderCtx, cancelHolder := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelHolder()
+	holderDone := make(chan struct{})
+	go func() {
+		defer close(holderDone)
+		_, _ = session.catchUpTailForHost(holderCtx, prepared.hostIdx, prepared.diff.Nonce, 0, 0)
+	}()
+	select {
+	case <-signal:
+	case <-holderCtx.Done():
+		t.Fatal("the holding drain never reached the host")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- session.sendComposedDiff(context.Background(), composedDiff{diff: diff, hostIdx: hostIdx})
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a busy slot is skipped, not an error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the cadence loop queued behind an inference drain")
+	}
+
+	releaseAll()
+	select {
+	case <-holderDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the holding drain never finished after the gate was released")
+	}
+}
+
+func TestADivergedHostFailsTheDrainByHashNotBySize(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	recorder.mu.Lock()
+	recorder.corruptRoot = true
+	recorder.mu.Unlock()
+
+	_, err := session.SendOnly(context.Background(), prepared, nil, nil)
+
+	require.ErrorIs(t, err, types.ErrStateHashMismatch,
+		"the gateway's own guards key off this sentinel travelling out of the drain")
+	require.NotErrorIs(t, err, ErrRequestTooLargeForHost, "a disagreement is not an oversize refusal")
+}
+
+func TestATargetDiffOverTheBudgetRefusesTheTail(t *testing.T) {
+	promptBytes := promptOfSize(100)
+	session, prepared, recorder := backloggedSession(t, promptBytes, 64)
+	require.NoError(t, session.sendCatchUp(context.Background(), prepared.hostIdx))
+	recorder.clearRecordings()
+
+	session.mu.Lock()
+	tail := session.diffsUpToNonceLocked(prepared.hostIdx, prepared.diff.Nonce)
+	require.Len(t, tail, 1, "fixture needs a current host")
+	session.catchUpBudgetBytes = transport.EncodedPromptSize(promptBytes, "llama") +
+		transport.EncodedDiffSize(tail[0]) - 1
+	session.mu.Unlock()
+
+	_, err := session.SendOnly(context.Background(), prepared, nil, nil)
+
+	require.ErrorIs(t, err, ErrTailTooLargeForHost,
+		"another nonce composes a different diff, so this must stay escalatable")
+	require.Empty(t, recorder.recordedNonceRuns())
+}
+
+func TestTheHeartbeatGateWaitIsBoundedByDefault(t *testing.T) {
+	session, _, _ := setupSession(t, 3, 1_000_000, 10)
+
+	require.LessOrEqual(t, session.heartbeatGateWait(), 2*time.Second,
+		"an unbounded default stalls the whole cadence loop behind one busy slot")
+	require.Positive(t, session.heartbeatGateWait())
+}
+
+func TestAVerifierBodyIsDrainedBeforeItIsBuilt(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	verifierIdx := prepared.hostIdx
+
+	session.mu.Lock()
+	backlogBefore := len(session.diffsForHost(verifierIdx))
+	budgetBytes := session.catchUpBudgetLocked()
+	session.mu.Unlock()
+	require.Greater(t, backlogBefore, 4, "fixture needs a backlog that does not fit one body")
+
+	tail, ok := session.verifierCatchUpTail(context.Background(), verifierIdx, 0)
+
+	require.True(t, ok)
+	require.Less(t, len(tail), backlogBefore, "the verify body must carry less than the whole backlog")
+	require.True(t, catchUpFitsOneBody(tail, 0, budgetBytes),
+		"what is left has to fit the body the verifier will read")
+	require.NotEmpty(t, recorder.recordedNonceRuns(), "the backlog moved by being sent, not by being dropped")
+}
+
+func TestAVerifierBodyLeavesRoomForItsReserve(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 8)
+	verifierIdx := prepared.hostIdx
+
+	session.mu.Lock()
+	budgetBytes := session.catchUpBudgetLocked()
+	session.mu.Unlock()
+
+	noReserveTail, ok := session.verifierCatchUpTail(context.Background(), verifierIdx, 0)
+	require.True(t, ok)
+	require.Greater(t, len(noReserveTail), 1, "fixture needs room to shrink")
+
+	reserveBytes := budgetBytes - transport.EncodedDiffSize(noReserveTail[len(noReserveTail)-1]) - 1
+	session.mu.Lock()
+	session.hostSyncNonce[verifierIdx] = 0
+	session.mu.Unlock()
+	runsBefore := len(recorder.recordedNonceRuns())
+
+	reservedTail, ok := session.verifierCatchUpTail(context.Background(), verifierIdx, reserveBytes)
+
+	require.True(t, ok)
+	require.Len(t, reservedTail, 1, "the reserve has to make the drain go further, or it is not being charged")
+	require.True(t, catchUpFitsOneBody(reservedTail, reserveBytes, budgetBytes))
+	require.Greater(t, len(recorder.recordedNonceRuns()), runsBefore)
+}
+
+func TestAVerifyBodyReserveCountsEveryFieldItCarries(t *testing.T) {
+	payload := &host.InferencePayload{Prompt: promptOfSize(4096), Model: "llama"}
+	artifacts := host.TimeoutArtifacts{FinishTx: make([]byte, 2048), ResponsePayload: make([]byte, 8192)}
+
+	require.Equal(t,
+		transport.EncodedPromptSize(payload.Prompt, payload.Model)+
+			transport.EncodedBytesSize(artifacts.FinishTx)+
+			transport.EncodedBytesSize(artifacts.ResponsePayload),
+		verifyBodyReserveBytes(payload, artifacts))
+	require.Equal(t,
+		transport.EncodedBytesSize(artifacts.FinishTx)+transport.EncodedBytesSize(artifacts.ResponsePayload),
+		verifyBodyReserveBytes(nil, artifacts))
+	require.Equal(t, transport.EncodedPromptSize(payload.Prompt, payload.Model)+
+		transport.EncodedBytesSize(nil)*2,
+		verifyBodyReserveBytes(payload, host.TimeoutArtifacts{}))
+}
+
+func TestADrainThatFailsLeavesTheBodyAsItWas(t *testing.T) {
+	session, prepared, recorder := backloggedSession(t, promptOfSize(100), 4)
+	recorder.failSends(fmt.Errorf("connection refused"))
+
+	session.mu.Lock()
+	backlogBefore := len(session.diffsForHost(prepared.hostIdx))
+	session.mu.Unlock()
+
+	tail, ok := session.verifierCatchUpTail(context.Background(), prepared.hostIdx, 0)
+
+	require.False(t, ok, "a failed drain must tell the caller to fall back")
+	require.Nil(t, tail)
+	require.Len(t, session.catchUpDiffsForVerifier(prepared.hostIdx), backlogBefore,
+		"and it must not have changed what the fallback body carries")
+}
+
+type diffCapturingVerifier struct {
+	nopErrorMiss
+	mu       sync.Mutex
+	captured []types.Diff
+	calls    int
+}
+
+func (v *diffCapturingVerifier) VerifyTimeout(_ context.Context, _ uint64, _ types.TimeoutReason, _ *host.InferencePayload, diffs []types.Diff, _ host.TimeoutArtifacts) (bool, []byte, uint32, []*types.DevshardTx, string, error) {
+	v.mu.Lock()
+	v.captured = append([]types.Diff(nil), diffs...)
+	v.calls++
+	v.mu.Unlock()
+	return false, nil, 0, nil, "", nil
+}
+
+func (v *diffCapturingVerifier) recorded() ([]types.Diff, int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return append([]types.Diff(nil), v.captured...), v.calls
+}
+
+func TestTheVoteBodyCarriesTheDrainedTail(t *testing.T) {
+	session, prepared, _ := backloggedSession(t, promptOfSize(100), 4)
+	verifierIdx := (prepared.hostIdx + 1) % len(session.group)
+	verifierRecorder := &sizeRecordingClient{InProcessClient: *session.clients[verifierIdx].(*InProcessClient)}
+	verifier := &diffCapturingVerifier{}
+
+	session.mu.Lock()
+	session.clients[verifierIdx] = verifierRecorder
+	session.hostSyncNonce[verifierIdx] = 0
+	budgetBytes := session.catchUpBudgetLocked()
+	backlogBefore := len(session.diffsForHost(verifierIdx))
+	session.mu.Unlock()
+	require.Greater(t, backlogBefore, 4)
+
+	payload := &host.InferencePayload{
+		Prompt: promptOfSize(100), Model: "llama",
+		InputLength: 100, MaxTokens: testutil.TestMaxTokens, StartedAt: 1000,
+	}
+	_, _, _, _ = session.CollectTimeoutVotes(context.Background(), prepared.diff.Nonce,
+		types.TimeoutReason_TIMEOUT_REASON_REFUSED, payload,
+		map[int]TimeoutVerifier{verifierIdx: verifier}, nil)
+
+	captured, calls := verifier.recorded()
+	require.Equal(t, 1, calls, "the vote has to reach the verifier")
+	require.NotEmpty(t, captured, "a verifier that knows nothing about the inference cannot vote")
+	require.Less(t, len(captured), backlogBefore, "the body must carry the drained tail, not the whole backlog")
+	require.True(t, catchUpFitsOneBody(captured, verifyBodyReserveBytes(payload, host.TimeoutArtifacts{}), budgetBytes),
+		"and it has to fit beside what else the body carries")
+	require.NotEmpty(t, verifierRecorder.recordedNonceRuns(), "the backlog moved by being sent")
+}

--- a/devshard/user/catch_up_budget.go
+++ b/devshard/user/catch_up_budget.go
@@ -1,0 +1,54 @@
+package user
+
+import (
+	"devshard/host"
+	"devshard/transport"
+	"devshard/types"
+)
+
+const (
+	catchUpChunkSize        = 200
+	minimumDiffReserveBytes = 64 << 10
+)
+
+func (s *Session) catchUpBudgetLocked() int {
+	if s.catchUpBudgetBytes > 0 {
+		return s.catchUpBudgetBytes
+	}
+	return transport.CatchUpBudgetBytes
+}
+
+func countDiffsThatFit(diffs []types.Diff, budgetBytes int) int {
+	maxDiffsPerChunk := min(len(diffs), catchUpChunkSize)
+	usedBytes := 0
+	for i := range maxDiffsPerChunk {
+		usedBytes += transport.EncodedDiffSize(diffs[i])
+		if usedBytes > budgetBytes {
+			return i
+		}
+	}
+	return maxDiffsPerChunk
+}
+
+func catchUpChunk(diffs []types.Diff, budgetBytes int) ([]types.Diff, error) {
+	fittingCount := countDiffsThatFit(diffs, budgetBytes)
+	if fittingCount == 0 {
+		return nil, ErrTailTooLargeForHost
+	}
+	return diffs[:fittingCount], nil
+}
+
+func catchUpFitsOneBody(diffs []types.Diff, reserveBytes, budgetBytes int) bool {
+	if reserveBytes >= budgetBytes {
+		return false
+	}
+	return countDiffsThatFit(diffs, budgetBytes-reserveBytes) == len(diffs)
+}
+
+func verifyBodyReserveBytes(payload *host.InferencePayload, artifacts host.TimeoutArtifacts) int {
+	reserveBytes := transport.EncodedBytesSize(artifacts.FinishTx) + transport.EncodedBytesSize(artifacts.ResponsePayload)
+	if payload != nil {
+		reserveBytes += transport.EncodedPromptSize(payload.Prompt, payload.Model)
+	}
+	return reserveBytes
+}

--- a/devshard/user/catch_up_budget_test.go
+++ b/devshard/user/catch_up_budget_test.go
@@ -1,0 +1,107 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"devshard/transport"
+	"devshard/types"
+)
+
+func diffOfSize(nonce uint64, promptHashBytes int) types.Diff {
+	return types.Diff{
+		Nonce: nonce,
+		Txs: []*types.DevshardTx{{Tx: &types.DevshardTx_StartInference{StartInference: &types.MsgStartInference{
+			InferenceId: nonce,
+			PromptHash:  make([]byte, promptHashBytes),
+		}}}},
+		UserSig:       make([]byte, 65),
+		PostStateRoot: make([]byte, 32),
+	}
+}
+
+func diffsOfSize(count int, promptHashBytes int) []types.Diff {
+	diffs := make([]types.Diff, count)
+	for i := range diffs {
+		diffs[i] = diffOfSize(uint64(i+1), promptHashBytes)
+	}
+	return diffs
+}
+
+func TestTheChunkStopsAtTheByteBudget(t *testing.T) {
+	diffs := diffsOfSize(10, 1024)
+	budgetBytes := transport.EncodedDiffSize(diffs[0]) * 3
+
+	require.Equal(t, 3, countDiffsThatFit(diffs, budgetBytes))
+	require.Equal(t, 3, countDiffsThatFit(diffs, budgetBytes+transport.EncodedDiffSize(diffs[0])-1),
+		"a diff that only partly fits does not travel")
+	require.Equal(t, 4, countDiffsThatFit(diffs, budgetBytes+transport.EncodedDiffSize(diffs[0])),
+		"a diff that exactly fits does travel")
+}
+
+func TestTheChunkKeepsTheCountCap(t *testing.T) {
+	diffs := diffsOfSize(catchUpChunkSize+50, 8)
+
+	require.Equal(t, catchUpChunkSize, countDiffsThatFit(diffs, transport.CatchUpBudgetBytes),
+		"the count cap bounds the per-request work even when the bytes fit")
+}
+
+func TestAnOversizedDiffFitsNowhere(t *testing.T) {
+	diffs := []types.Diff{diffOfSize(1, 4096), diffOfSize(2, 8)}
+	budgetBytes := transport.EncodedDiffSize(diffs[1])
+
+	require.Zero(t, countDiffsThatFit(diffs, budgetBytes),
+		"a diff no body can carry is refused, not shipped into a certain 413")
+	require.Equal(t, 1, countDiffsThatFit(diffs[1:], budgetBytes), "the small one fits on its own")
+}
+
+func TestNoDiffsFitNothing(t *testing.T) {
+	require.Zero(t, countDiffsThatFit(nil, transport.CatchUpBudgetBytes))
+}
+
+func TestOneBodyCountsTheReserveToo(t *testing.T) {
+	diffs := diffsOfSize(3, 1024)
+	diffBytes := transport.EncodedDiffSize(diffs[0]) * 3
+
+	require.True(t, catchUpFitsOneBody(diffs, 0, diffBytes))
+	require.True(t, catchUpFitsOneBody(diffs, 10, diffBytes+10))
+	require.False(t, catchUpFitsOneBody(diffs, 11, diffBytes+10),
+		"the prompt's own bytes have to be charged against the same budget")
+}
+
+func TestOneBodyRefusesAReserveOverTheBudget(t *testing.T) {
+	require.False(t, catchUpFitsOneBody(nil, 101, 100),
+		"a host that needs no diffs still cannot read a prompt over the cap")
+	require.False(t, catchUpFitsOneBody(nil, 100, 100),
+		"a reserve filling the whole budget leaves no room for the diff that must ride with it")
+	require.True(t, catchUpFitsOneBody(nil, 99, 100))
+}
+
+func TestOneBodyRefusesMoreDiffsThanTheCountCap(t *testing.T) {
+	diffs := diffsOfSize(catchUpChunkSize+1, 8)
+
+	require.False(t, catchUpFitsOneBody(diffs, 0, transport.CatchUpBudgetBytes),
+		"the count cap holds even when every diff is tiny")
+}
+
+func TestTheChunkRefusesADiffThatFitsNowhere(t *testing.T) {
+	diffs := []types.Diff{diffOfSize(1, 4096), diffOfSize(2, 8)}
+
+	_, err := catchUpChunk(diffs, transport.EncodedDiffSize(diffs[1]))
+
+	require.ErrorIs(t, err, ErrTailTooLargeForHost)
+	require.ErrorIs(t, err, ErrRequestTooLargeForHost)
+}
+
+func TestTheChunkStopsAtThePrefixThatFits(t *testing.T) {
+	diffs := diffsOfSize(10, 1024)
+	budgetBytes := transport.EncodedDiffSize(diffs[0]) * 3
+
+	chunk, err := catchUpChunk(diffs, budgetBytes)
+
+	require.NoError(t, err)
+	require.Len(t, chunk, 3)
+	require.Equal(t, diffs[0].Nonce, chunk[0].Nonce)
+	require.Equal(t, diffs[2].Nonce, chunk[len(chunk)-1].Nonce)
+}

--- a/devshard/user/heartbeat.go
+++ b/devshard/user/heartbeat.go
@@ -13,6 +13,8 @@ import (
 
 const heartbeatForceReason = "heartbeat"
 
+const defaultHeartbeatGateWait = 2 * time.Second
+
 type composedDiff struct {
 	diff    types.Diff
 	hostIdx int
@@ -377,10 +379,22 @@ func (s *Session) observedHeightLocked() (uint64, []byte, bool) {
 	return 0, nil, false
 }
 
-func (s *Session) sendComposedDiff(ctx context.Context, item composedDiff) error {
+func (s *Session) heartbeatGateWait() time.Duration {
 	s.mu.Lock()
-	catchUp := s.diffsForHost(item.hostIdx)
-	s.mu.Unlock()
+	defer s.mu.Unlock()
+	if s.heartbeatGateWaitOverride > 0 {
+		return s.heartbeatGateWaitOverride
+	}
+	return defaultHeartbeatGateWait
+}
+
+func (s *Session) sendComposedDiff(ctx context.Context, item composedDiff) error {
+	catchUp, err := s.catchUpTailForHost(ctx, item.hostIdx, item.diff.Nonce, 0, s.heartbeatGateWait())
+	if err != nil {
+		logging.Warn("heartbeat catch-up ahead failed", "subsystem", "heightsync",
+			"escrow", s.escrowID, "nonce", item.diff.Nonce, "host", item.hostIdx, "error", err)
+		return nil
+	}
 
 	resp, err := s.clients[item.hostIdx].Send(ctx, host.HostRequest{
 		Diffs:            catchUp,

--- a/devshard/user/session.go
+++ b/devshard/user/session.go
@@ -238,12 +238,15 @@ type Session struct {
 	// admission controller. Multi-slot validators legitimately repeat
 	// the same key here; ParticipantKeys() de-duplicates for views
 	// that want a per-host (not per-slot) list.
-	participantKeys []string
-	clients         []HostClient
-	nonce           uint64
-	diffs           []types.Diff                 // append-only log
-	hostSyncNonce   map[int]uint64               // hostIdx -> last nonce sent
-	pendingTxs      []*types.DevshardTx          // from host mempools, for next diff
+	participantKeys           []string
+	clients                   []HostClient
+	nonce                     uint64
+	diffs                     []types.Diff   // append-only log
+	hostSyncNonce             map[int]uint64 // hostIdx -> last nonce sent
+	catchUpGate               []chan struct{}
+	catchUpBudgetBytes        int
+	heartbeatGateWaitOverride time.Duration
+	pendingTxs                []*types.DevshardTx // from host mempools, for next diff
 	// pendingTxKeys dedups the current pendingTxs slice by tx_type:id. It is
 	// rebuilt from what compose retained, so a tx that failed to apply frees
 	// its key again -- otherwise the first host to propose a bogus tx would
@@ -476,6 +479,7 @@ func NewSession(
 		participantKeys: make([]string, len(group)),
 		clients:         clients,
 		hostSyncNonce:   make(map[int]uint64),
+		catchUpGate:     newCatchUpGates(len(clients)),
 		pendingTxKeys:   make(map[string]struct{}),
 		appliedTxKeys:   make(map[string]struct{}),
 		pinnedFinishIDs: make(map[uint64]int),
@@ -540,6 +544,19 @@ func (s *Session) diffsForHost(hostIdx int) []types.Diff {
 		}
 	}
 	return result
+}
+
+func (s *Session) finalizeClientFor(hostIdx int) HostClient {
+	type admissionBypasser interface {
+		WithoutAdmission() any
+	}
+	client := s.clients[hostIdx]
+	if bypasser, ok := client.(admissionBypasser); ok {
+		if stripped, ok := bypasser.WithoutAdmission().(HostClient); ok {
+			return stripped
+		}
+	}
+	return client
 }
 
 // validateCatchUp warns if the catch-up diffs for a host are non-contiguous
@@ -750,7 +767,6 @@ func (s *Session) ProcessResponse(hostIdx int, resp *host.HostResponse, inferenc
 type PreparedInference struct {
 	diff    types.Diff
 	hostIdx int
-	catchUp []types.Diff
 	params  InferenceParams
 	isProbe bool
 }
@@ -1189,6 +1205,10 @@ func (s *Session) PrepareInferenceFn(chooser ParamsForHost) (*PreparedInference,
 		return nil, err
 	}
 
+	if transport.EncodedPromptSize(params.Prompt, params.Model)+minimumDiffReserveBytes >= s.catchUpBudgetLocked() {
+		return nil, ErrPromptTooLargeForHost
+	}
+
 	promptHash, err := devshard.CanonicalPromptHash(params.Prompt)
 	if err != nil {
 		return nil, fmt.Errorf("canonical prompt hash: %w", err)
@@ -1244,13 +1264,9 @@ func (s *Session) PrepareInferenceFn(chooser ParamsForHost) (*PreparedInference,
 
 	s.nonceStates[nonce] = &nonceOutcome{}
 
-	catchUp := s.diffsForHost(hostIdx)
-	// TODO: remove this when we are sure that there is no bug in CatchUp
-	s.validateCatchUp(catchUp, nonce, hostIdx)
 	return &PreparedInference{
 		diff:    diff,
 		hostIdx: hostIdx,
-		catchUp: catchUp,
 		params:  params,
 		isProbe: probe,
 	}, nil
@@ -1282,9 +1298,15 @@ func (p *PreparedInference) Payload() *host.InferencePayload {
 // without processing it. Use ProcessResponse separately to apply the response
 // to session state. This split allows parallel network I/O with ordered processing.
 func (s *Session) SendOnly(ctx context.Context, p *PreparedInference, stream io.Writer, receiptHandler func()) (*host.HostResponse, error) {
+	reserveBytes := transport.EncodedPromptSize(p.params.Prompt, p.params.Model)
+	catchUp, err := s.catchUpTailForHost(ctx, p.hostIdx, p.diff.Nonce, reserveBytes, 0)
+	if err != nil {
+		return nil, err
+	}
+
 	legacyForce := p.params.ForceHeightSyncAnchor && s.heightSyncK == 0
 	resp, err := s.clients[p.hostIdx].Send(ctx, host.HostRequest{
-		Diffs:                 p.catchUp,
+		Diffs:                 catchUp,
 		Nonce:                 p.diff.Nonce,
 		ForceHeightSyncAnchor: legacyForce,
 		HeightSyncEscrow:      s.heightSyncEscrowHints(),
@@ -1409,115 +1431,106 @@ func (s *Session) sendDiffRound(ctx context.Context, extraTxs []*types.DevshardT
 	return err
 }
 
-// catchUpChunkSize is the maximum number of diffs sent in a single catch-up
-// request. Large sessions can accumulate hundreds of diffs; sending them all
-// at once risks timeouts and oversized request bodies. Chunking lets the host
-// replay state incrementally and the proxy bail out early if any chunk fails.
-const catchUpChunkSize = 200
-
-// catchUpChunkTimeout is the per-chunk timeout for sendCatchUp. Each chunk
-// of 200 diffs gets its own deadline so large catch-ups (thousands of diffs)
-// don't hit a single overall timeout.
-const catchUpChunkTimeout = 60 * time.Second
-
 // sendCatchUp sends existing diffs to a host, admission-free: they are already signed by the group.
 func (s *Session) sendCatchUp(ctx context.Context, hostIdx int) error {
-	return s.sendCatchUpWith(ctx, hostIdx, s.getFinalizeClients()[hostIdx])
+	return s.sendCatchUpWith(ctx, hostIdx, s.finalizeClientFor(hostIdx))
 }
 
 // sendCatchUpWith sends existing diffs to a host using the provided client.
-// Diffs are sent in chunks of catchUpChunkSize with a per-chunk timeout.
-// If any chunk fails (host dead or processResponse error), we stop --
-// there's no point sending later chunks if the host couldn't apply earlier ones.
-// Returns non-nil only on processResponse errors; dead hosts are silently skipped.
 func (s *Session) sendCatchUpWith(ctx context.Context, hostIdx int, client HostClient) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("host %d: %w: %w", hostIdx, ErrCatchUpNotStarted, err)
+	}
+
+	s.mu.Lock()
+	pending := len(s.diffsForHost(hostIdx))
+	s.mu.Unlock()
+	if pending == 0 {
+		return nil
+	}
+
+	release, err := s.enterCatchUpGate(ctx, hostIdx, 0)
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	s.mu.Lock()
 	nonce := s.nonce
 	catchUp := s.diffsForHost(hostIdx)
+	budgetBytes := s.catchUpBudgetLocked()
 	s.mu.Unlock()
 
 	if len(catchUp) == 0 {
 		return nil
 	}
 
-	totalChunks := (len(catchUp) + catchUpChunkSize - 1) / catchUpChunkSize
 	logging.Info("sendCatchUp starting", "subsystem", "finalize", "escrow", s.escrowID,
 		"nonce", nonce, "host", hostIdx,
-		"total_diffs", len(catchUp), "chunks", totalChunks)
+		"total_diffs", len(catchUp), "budget_bytes", budgetBytes)
 
-	chunkIdx := 0
-	for chunkIdx < len(catchUp) {
+	diffIdx := 0
+	chunkNumber := 0
+	for diffIdx < len(catchUp) {
 		if err := ctx.Err(); err != nil {
 			logging.Warn("sendCatchUp context cancelled", "subsystem", "finalize", "escrow", s.escrowID,
 				"nonce", nonce, "host", hostIdx,
-				"chunk", chunkIdx/catchUpChunkSize+1, "error", err)
+				"chunk", chunkNumber+1, "error", err)
 			return nil
 		}
 
-		end := chunkIdx + catchUpChunkSize
-		if end > len(catchUp) {
-			end = len(catchUp)
+		chunk, err := catchUpChunk(catchUp[diffIdx:], budgetBytes)
+		if err != nil {
+			logging.Warn("sendCatchUp diff over budget", "subsystem", "finalize", "escrow", s.escrowID,
+				"nonce", catchUp[diffIdx].Nonce, "host", hostIdx, "budget_bytes", budgetBytes)
+			return fmt.Errorf("catch-up to host %d: %w", hostIdx, err)
 		}
-		chunk := catchUp[chunkIdx:end]
 		chunkNonce := chunk[len(chunk)-1].Nonce
-		chunkNum := chunkIdx/catchUpChunkSize + 1
+		chunkNumber++
 
 		logging.Info("sendCatchUp chunk", "subsystem", "finalize", "escrow", s.escrowID,
 			"nonce", nonce, "host", hostIdx,
-			"chunk", chunkNum, "of", totalChunks,
+			"chunk", chunkNumber,
 			"diffs_in_chunk", len(chunk),
 			"chunk_first_nonce", chunk[0].Nonce,
 			"chunk_last_nonce", chunkNonce)
 
-		chunkCtx, cancel := context.WithTimeout(ctx, catchUpChunkTimeout)
-		resp, err := client.Send(chunkCtx, host.HostRequest{Diffs: chunk, Nonce: chunkNonce}, nil, nil)
-		cancel()
+		resp, err := s.deliverCatchUpChunk(ctx, hostIdx, client, chunk)
 		if err != nil {
 			logging.Warn("sendCatchUp chunk failed", "subsystem", "finalize", "escrow", s.escrowID,
 				"nonce", nonce, "host", hostIdx,
-				"chunk", chunkNum, "error", err)
-			return fmt.Errorf("catch-up chunk %d to host %d: %w", chunkNum, hostIdx, err)
+				"chunk", chunkNumber, "error", err)
+			s.publishHeightSyncView()
+			return fmt.Errorf("catch-up chunk %d to host %d: %w", chunkNumber, hostIdx, err)
 		}
 
 		logging.Info("sendCatchUp chunk response", "subsystem", "finalize", "escrow", s.escrowID,
 			"nonce", nonce, "host", hostIdx,
-			"chunk", chunkNum,
+			"chunk", chunkNumber,
 			"resp_nonce", resp.Nonce, "has_sig", resp.StateSig != nil)
-
-		s.mu.Lock()
-		err = s.processResponse(hostIdx, resp, chunkNonce)
-		if err == nil {
-			s.logSignatureProgress(resp.Nonce)
-		}
-		s.mu.Unlock()
-		if err != nil {
-			s.publishHeightSyncView()
-			return err
-		}
 
 		// Skip forward: if the host is already ahead of what we're about
 		// to send (e.g. it caught up via gossip), jump to the chunk that
 		// contains resp.Nonce+1 to avoid sending diffs the host already has.
-		nextChunkIdx := chunkIdx + catchUpChunkSize
+		nextDiffIdx := diffIdx + len(chunk)
 		if resp.Nonce > chunkNonce {
-			skipTo := 0
+			skipTo := len(catchUp)
 			for i, d := range catchUp {
 				if d.Nonce > resp.Nonce {
 					skipTo = i
 					break
 				}
 			}
-			if skipTo > nextChunkIdx {
-				skippedChunks := (skipTo - nextChunkIdx) / catchUpChunkSize
+			if skipTo > nextDiffIdx {
 				logging.Info("sendCatchUp skip-forward", "subsystem", "finalize", "escrow", s.escrowID,
 					"nonce", nonce, "host", hostIdx,
 					"resp_nonce", resp.Nonce,
-					"skipping_from_idx", nextChunkIdx, "to_idx", skipTo,
-					"skipped_chunks", skippedChunks)
-				nextChunkIdx = skipTo
+					"skipping_from_idx", nextDiffIdx, "to_idx", skipTo,
+					"skipped_diffs", skipTo-nextDiffIdx)
+				nextDiffIdx = skipTo
 			}
 		}
-		chunkIdx = nextChunkIdx
+		diffIdx = nextDiffIdx
 	}
 
 	s.publishHeightSyncView()
@@ -2076,17 +2089,9 @@ func (s *Session) RewindHostCatchUp(hostIdx int, cause string) bool {
 // reach a host the participant budget would refuse. Rebuilt per call: s.clients is small, both callers
 // are network-bound, and a cache would have to be invalidated by anything that swaps a client.
 func (s *Session) getFinalizeClients() []HostClient {
-	type admissionBypasser interface {
-		WithoutAdmission() any
-	}
 	clients := make([]HostClient, len(s.clients))
-	for i, c := range s.clients {
-		clients[i] = c
-		if b, ok := c.(admissionBypasser); ok {
-			if hc, ok := b.WithoutAdmission().(HostClient); ok {
-				clients[i] = hc
-			}
-		}
+	for i := range s.clients {
+		clients[i] = s.finalizeClientFor(i)
 	}
 	return clients
 }
@@ -3133,8 +3138,16 @@ func (s *Session) collectTimeoutVotes(
 				return
 			}
 
-			catchUp := mergeTimeoutCatchUpDiffs(s.catchUpDiffsForVerifier(av.idx), diffs)
-			arts := firstTimeoutArtifacts(artifacts)
+			timeoutArtifacts := firstTimeoutArtifacts(artifacts)
+			drained, ok := s.verifierCatchUpTail(ctx, av.idx, verifyBodyReserveBytes(payload, host.TimeoutArtifacts{}))
+			if err := ctx.Err(); err != nil {
+				results <- voteResult{err: fmt.Errorf("%w: %w", errVoteNotSent, err), verifierIdx: av.idx, verifierAddr: av.verifierAddr}
+				return
+			}
+			if !ok {
+				drained = s.catchUpDiffsForVerifier(av.idx)
+			}
+			catchUp := mergeTimeoutCatchUpDiffs(drained, diffs)
 
 			rec := inflightVerify{
 				Escrow: s.escrowID,
@@ -3151,12 +3164,12 @@ func (s *Session) collectTimeoutVotes(
 			logging.Stage(ctx, "timeout_vote_sent",
 				logFields(av.verifierAddr, "sent_at_ms", rec.SentAt.UnixMilli())...,
 			)
-			accept, sig, voterSlot, mempool, rejectCause, err := av.verifier.VerifyTimeout(ctx, inferenceID, reason, payload, catchUp, arts)
+			accept, sig, voterSlot, mempool, rejectCause, err := av.verifier.VerifyTimeout(ctx, inferenceID, reason, payload, catchUp, timeoutArtifacts)
 			// The slot is held and a vote is idempotent, so an unanswered request is asked once more.
 			if transport.IsTransientWriteError(err) && ctx.Err() == nil {
 				logging.Debug("retrying a vote the peer never answered", "subsystem", "session",
 					"inference_id", inferenceID, "verifier", av.verifierAddr, "error", err)
-				accept, sig, voterSlot, mempool, rejectCause, err = av.verifier.VerifyTimeout(ctx, inferenceID, reason, payload, catchUp, arts)
+				accept, sig, voterSlot, mempool, rejectCause, err = av.verifier.VerifyTimeout(ctx, inferenceID, reason, payload, catchUp, timeoutArtifacts)
 			}
 			logVoteRPC(ctx, logFields, av.verifierAddr, err, accept, time.Since(rec.SentAt))
 			if err != nil {
@@ -3370,7 +3383,16 @@ func (s *Session) CollectErrorMissVotes(
 				results <- voteResult{err: err, verifierIdx: av.idx, verifierAddr: av.verifierAddr}
 				return
 			}
-			accept, sig, voterSlot, mempool, rejectCause, err := av.verifier.VerifyErrorMiss(ctx, inferenceID, mergeTimeoutCatchUpDiffs(s.catchUpDiffsForVerifier(av.idx), diffs), artifacts)
+			drained, ok := s.verifierCatchUpTail(ctx, av.idx, verifyBodyReserveBytes(nil, artifacts))
+			if err := ctx.Err(); err != nil {
+				results <- voteResult{err: fmt.Errorf("%w: %w", errVoteNotSent, err), verifierIdx: av.idx, verifierAddr: av.verifierAddr}
+				return
+			}
+			if !ok {
+				drained = s.catchUpDiffsForVerifier(av.idx)
+			}
+			catchUp := mergeTimeoutCatchUpDiffs(drained, diffs)
+			accept, sig, voterSlot, mempool, rejectCause, err := av.verifier.VerifyErrorMiss(ctx, inferenceID, catchUp, artifacts)
 			if err != nil {
 				results <- voteResult{err: err, verifierIdx: av.idx, verifierAddr: av.verifierAddr}
 				return
@@ -3443,8 +3465,6 @@ func firstTimeoutArtifacts(artifacts []host.TimeoutArtifacts) host.TimeoutArtifa
 	return artifacts[0]
 }
 
-// catchUpDiffsForVerifier returns diffs this host has not yet been sent.
-// The slice is copied under s.mu so the RPC can proceed without holding the lock.
 func (s *Session) catchUpDiffsForVerifier(hostIdx int) []types.Diff {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

- **The catch-up tail was bounded by count, never by bytes.** Every host-bound body carries the diffs the host has not applied yet, chunked at **200 diffs** regardless of their size, and an inference body carries that tail *plus* the prompt. On a long-lived escrow the composed body crossed the host's **10 MiB** cap: the host answered **413**, the gateway charged the attempt to that host, escalated the same oversized body to the next one, and repeated.
- **Bodies are now budgeted in bytes.** `transport.CatchUpBudgetBytes` is `DefaultMaxBodySize` minus a **1 MiB** envelope reserve (**9 MiB**), and `EncodedDiffSize` / `EncodedPromptSize` / `EncodedBytesSize` bound the JSON+base64 wire size of a diff, a prompt and a raw field before anything is sent. The 200-diff cap stays on top of the byte budget.
- **Catch-up ahead.** Before an inference, a heartbeat diff or a verifier vote goes out, the session drains the backlog in admission-free chunks until the remaining tail plus that body's own reserve (the prompt, or the finish tx and response payload) fits one body. A per-host gate serializes drains; the heartbeat and the verifier wait **2 s** for it and fall back to their previous behaviour instead of blocking, with the verifier drain capped at **30 s** and each chunk at **60 s**.
- **The tail is taken at send time, not at prepare time.** `PreparedInference.catchUp` is gone, so a hedged or queued attempt no longer ships a snapshot the session has already moved past.
- **A prompt that cannot fit is refused before a nonce is spent.** `PrepareInferenceFn` rejects a prompt that leaves less than **64 KiB** for diffs, and the refusal reaches the client as **413** instead of a 502 built from someone else's failure.
- **No host is blamed for a body we refused to send.** `request_too_large` and `catch_up_not_started` are `FailureGatewayPolicy`: they take no host sample, and the prompt case stops escalation. A **413** the host itself returns is still its own answer — it stays a host reason (`http_413`) and still scores.
- **Two adjacent corrections.** A drain that fails on a state root now fails by `types.ErrStateHashMismatch` rather than by matching the error string, so it blocks the host as divergence instead of passing as a size failure; and `sendCatchUp` skip-forward jumps to the end of the backlog when the host is already ahead of all of it, instead of walking the chunks it has already applied.

## Why

The tail and the prompt share one body, and a diff count says nothing about how many bytes that body will be. The size has to be known before the body is built, so the estimators bound the encoding rather than measure it: base64 for every byte field, a fixed per-object overhead, and a **6×** worst case for a model id inside a JSON string. The **1 MiB** reserve covers the rest of the envelope, which is why the budget is deliberately short of the host's real cap.

Splitting the tail across bodies is not an option for the request that needs it: a host applies diffs in order, and the inference body must carry the diff for its own nonce. So the earlier diffs are drained in separate admission-free requests — the same path finalize already uses — until what is left fits alongside the payload. The gate exists because an inference and a heartbeat can want the same host at the same moment and would otherwise drain it twice; the heartbeat and the verifier bound their wait so a slow drain degrades them instead of stalling them.

A body the gateway never sent is the gateway's own backlog, not a host's fault, and sampling or escalating it would punish hosts for it. The two refusals split along that line: a prompt over the budget fails identically on every host, so it stops escalation and goes back to the client as 413, while an undrainable tail is per-host state and still escalates to a host whose backlog is shorter.

## Test plan

- [x] `go test ./devshard/user/ ./devshard/transport/ ./devshard/accounting/ ./devshard/cmd/devshardctl/`
- [x] The byte estimators are checked against the real marshalled JSON, and a body filled to the budget is verified to stay under the host cap
- [x] Drain, gate, refusal, no-blame and escalation behaviour covered end to end in `catch_up_ahead_test.go`, `oversize_no_blame_test.go`, `oversize_reason_test.go`
- [ ] e2e stand / live node — not run