### PR TITLE
fix(devshard): remove host psql dependency from storage checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -292,12 +292,7 @@ jobs:
       - name: Check PostgreSQL replacement history and recovery
         run: python3 deploy/join/updater-postgres_test.py
       - name: Check remote storage against real PostgreSQL
-        run: |
-          if ! command -v psql >/dev/null; then
-            sudo apt-get update
-            sudo apt-get install -y postgresql-client
-          fi
-          python3 deploy/join/versiond-storage-check_test.py
+        run: python3 deploy/join/versiond-storage-check_test.py
 
   test-public-proxy-router:
     runs-on: ubuntu-latest

--- a/deploy/join/pool-postgres.env.template
+++ b/deploy/join/pool-postgres.env.template
@@ -9,9 +9,9 @@ PGDATABASE=devshardd
 PGUSER=devshardd
 PGPASSWORD=
 
-# Match the pool's TLS settings. Certificate paths are on the host running
-# this check, where the PostgreSQL client (psql) is installed.
-# PGSSLMODE=verify-full
-# PGSSLROOTCERT=/absolute/path/to/root.crt
-# PGSSLCERT=/absolute/path/to/client.crt
-# PGSSLKEY=/absolute/path/to/client.key
+# psql runs in Docker using host networking. PGHOST must be a host name or IP
+# reachable from this machine; local Unix socket paths are not mounted.
+# The client image is DEVSHARD_POSTGRES_IMAGE, defaulting to postgres:16-alpine.
+# Explicit TLS settings are unsupported; PGSSLMODE=disable is allowed.
+# Do not disable TLS required by a provider to use this check.
+# PGSSLMODE=disable

--- a/deploy/join/pool-postgres.env.template
+++ b/deploy/join/pool-postgres.env.template
@@ -9,9 +9,13 @@ PGDATABASE=devshardd
 PGUSER=devshardd
 PGPASSWORD=
 
-# psql runs in Docker using host networking. PGHOST must be a host name or IP
-# reachable from this machine; local Unix socket paths are not mounted.
-# The client image is DEVSHARD_POSTGRES_IMAGE, defaulting to postgres:16-alpine.
+# psql runs in Docker using host networking. PGHOST must be a TCP host name or
+# IP reachable from that container; local Unix socket paths are not mounted.
+# For password authentication, set PGPASSWORD above; the host's .pgpass is not read.
+# Set the client image here or export it in the shell. config.env is not read.
+# This setting does not change the database server image.
+# VERSIOND_STORAGE_CHECK_IMAGE=postgres:16-alpine
+# A missing image is downloaded before the deployment lock, with a 5-minute timeout.
 # Explicit TLS settings are unsupported; PGSSLMODE=disable is allowed.
 # Do not disable TLS required by a provider to use this check.
 # PGSSLMODE=disable

--- a/deploy/join/update-devshard.sh
+++ b/deploy/join/update-devshard.sh
@@ -55,8 +55,11 @@ config.env is read from this directory (or GONKA_CONFIG_ENV).
 
 Storage checking writes a control value through each process's database pool.
 Run checks one host at a time, before admitting new/replaced replicas to traffic.
-The client uses DEVSHARD_POSTGRES_IMAGE (default postgres:16-alpine) and host
-networking. Explicit TLS settings are unsupported; PGSSLMODE=disable is allowed.
+The client uses VERSIOND_STORAGE_CHECK_IMAGE (default postgres:16-alpine) and
+host networking. Set the image in --reference-env or export it in the shell;
+config.env is not read in this mode. Missing images are downloaded before
+taking the deployment lock, with a five-minute timeout.
+Explicit TLS settings are unsupported; PGSSLMODE=disable is allowed.
 
 Compose files come from COMPOSE_FILE when set, otherwise from the labels of
 the running versiond container, otherwise from the stock files.

--- a/deploy/join/update-devshard.sh
+++ b/deploy/join/update-devshard.sh
@@ -50,11 +50,13 @@ config.env is read from this directory (or GONKA_CONFIG_ENV).
   --check-storage  verify running HA devshard processes against an independently
                    configured PostgreSQL; no config.env or Compose required
   --reference-env  shell file with the known working pool's PGHOST, PGDATABASE,
-                   PGUSER and connection/TLS settings (requires local psql)
+                   PGUSER and connection settings (psql runs in Docker)
   --container      versiond container to check; repeat for several (default: versiond)
 
 Storage checking writes a control value through each process's database pool.
 Run checks one host at a time, before admitting new/replaced replicas to traffic.
+The client uses DEVSHARD_POSTGRES_IMAGE (default postgres:16-alpine) and host
+networking. Explicit TLS settings are unsupported; PGSSLMODE=disable is allowed.
 
 Compose files come from COMPOSE_FILE when set, otherwise from the labels of
 the running versiond container, otherwise from the stock files.

--- a/deploy/join/versiond-storage-check.sh
+++ b/deploy/join/versiond-storage-check.sh
@@ -9,13 +9,14 @@ check_versiond_storage() (
     local storage_docker=$1 storage_script_dir=$2 storage_config_env=$3 reference_env=$4
     local name tool lock_dir key reference_identity proof state id running project
     local checked index snapshot generation nonce request response observed current
+    local storage_image=${DEVSHARD_POSTGRES_IMAGE:-postgres:16-alpine}
     local -a containers reference_keys reference_args ids proofs generations
     shift 4
     containers=("$@")
     ((${#containers[@]} > 0)) || containers=(versiond)
     [[ -f $reference_env && -r $reference_env ]] || fail "cannot read reference settings: $reference_env"
     [[ $reference_env == */* ]] || reference_env=./$reference_env
-    for tool in "$storage_docker" jq psql timeout flock sha256sum; do
+    for tool in "$storage_docker" jq timeout flock sha256sum; do
         command -v "$tool" >/dev/null 2>&1 || fail "$tool is required for --check-storage"
     done
     for name in "${containers[@]}"; do
@@ -38,9 +39,9 @@ check_versiond_storage() (
 
     # Isolate libpq from the caller's PGHOST/PGSERVICE/PGOPTIONS, and from any
     # replica configuration. The reference file uses config.env shell syntax.
-    # Only these settings are passed to psql, including TLS paths on this host.
+    # Only these settings are passed to the containerized PostgreSQL client.
     reference_keys=(PGHOST PGPORT PGDATABASE PGUSER PGPASSWORD PGSSLMODE
-        PGSSLROOTCERT PGSSLCERT PGSSLKEY PGTARGETSESSIONATTRS PGCONNECT_TIMEOUT)
+        PGTARGETSESSIONATTRS PGCONNECT_TIMEOUT)
     for key in ${!PG@}; do unset "$key"; done
     # shellcheck disable=SC1090
     source "$reference_env"
@@ -48,18 +49,35 @@ check_versiond_storage() (
         [[ -n ${!key:-} ]] || fail "$reference_env must set $key explicitly"
     done
     for key in ${!PG@}; do
+        if [[ $key == PGSSL* && -n ${!key} && \
+            ( $key != PGSSLMODE || ${!key} != disable ) ]]; then
+            fail "$reference_env sets unsupported TLS setting $key; --check-storage supports PostgreSQL without explicit TLS configuration (PGSSLMODE=disable is allowed)"
+        fi
         [[ " ${reference_keys[*]} " == *" $key "* || -z ${!key:-} ]] || \
             fail "$reference_env sets unsupported $key; use explicit connection settings"
     done
     reference_args=()
     for key in "${reference_keys[@]}"; do
-        [[ -z ${!key:-} ]] || reference_args+=("$key=${!key}")
+        [[ -z ${!key:-} ]] || reference_args+=(--env "$key=${!key}")
     done
-    reference_psql() {
-        timeout 60 env -i PATH="$PATH" PGCONNECT_TIMEOUT=5 \
-            "${reference_args[@]}" PGOPTIONS='-c statement_timeout=10000' \
-            psql -X -w -qAt -v ON_ERROR_STOP=1 -c "$1"
-    }
+    # Download once, outside the per-query timeout. Pull progress goes to stderr.
+    "$storage_docker" image inspect "$storage_image" >/dev/null 2>&1 || \
+        "$storage_docker" pull "$storage_image" >&2 || \
+        fail "cannot prepare PostgreSQL client image $storage_image"
+    reference_psql() (
+        local client_name
+        client_name="gonka-storage-psql-$(cat /proc/sys/kernel/random/uuid)"
+        # A killed Docker CLI can leave its container running; remove it on exit.
+        trap '"$storage_docker" rm -f "$client_name" >/dev/null 2>&1 || true' EXIT
+        trap 'exit 130' INT
+        trap 'exit 143' TERM
+        timeout 60 "$storage_docker" run --rm --init --name "$client_name" \
+            --network host --read-only \
+            --env PGCONNECT_TIMEOUT=5 "${reference_args[@]}" \
+            --env 'PGOPTIONS=-c statement_timeout=10000' \
+            --entrypoint psql "$storage_image" \
+            -X -w -qAt -v ON_ERROR_STOP=1 -c "$1"
+    )
     reference_identity=$(reference_psql \
         'SELECT identity::text FROM devshard_storage_identity WHERE singleton AND NOT pg_is_in_recovery()') || \
         fail "cannot read the reference PostgreSQL database; check --reference-env and connectivity"

--- a/deploy/join/versiond-storage-check.sh
+++ b/deploy/join/versiond-storage-check.sh
@@ -9,7 +9,7 @@ check_versiond_storage() (
     local storage_docker=$1 storage_script_dir=$2 storage_config_env=$3 reference_env=$4
     local name tool lock_dir key reference_identity proof state id running project
     local checked index snapshot generation nonce request response observed current
-    local storage_image=${DEVSHARD_POSTGRES_IMAGE:-postgres:16-alpine}
+    local storage_image
     local -a containers reference_keys reference_args ids proofs generations
     shift 4
     containers=("$@")
@@ -23,19 +23,6 @@ check_versiond_storage() (
         [[ $name =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]] || fail "invalid container name: $name"
     done
     "$storage_docker" info >/dev/null 2>&1 || fail "cannot reach the Docker daemon"
-
-    # Use the same local lock as the updater. Cross-host checks must still run
-    # sequentially: PostgreSQL has a single challenge field, not a nonce log.
-    # shellcheck source=deploy/join/deployment-lock.sh
-    source "$storage_script_dir/deployment-lock.sh"
-    lock_dir=$(cd -- "$(dirname -- "$storage_config_env")" && pwd -P)
-    project=$("$storage_docker" inspect --format '{{index .Config.Labels "com.docker.compose.project"}}' "${containers[0]}") || \
-        fail "cannot inspect container ${containers[0]}"
-    [[ $project != '<no value>' ]] || project=
-    # Unlabelled standalone containers have no Compose project. Give their
-    # local checks a stable identity without borrowing an unrelated proxy's.
-    project=${project:-versiond-storage-check}
-    gonka_acquire_deployment_lock "$lock_dir" "$project" || exit 1
 
     # Isolate libpq from the caller's PGHOST/PGSERVICE/PGOPTIONS, and from any
     # replica configuration. The reference file uses config.env shell syntax.
@@ -60,18 +47,33 @@ check_versiond_storage() (
     for key in "${reference_keys[@]}"; do
         [[ -z ${!key:-} ]] || reference_args+=(--env "$key=${!key}")
     done
-    # Download once, outside the per-query timeout. Pull progress goes to stderr.
+    storage_image=${VERSIOND_STORAGE_CHECK_IMAGE:-postgres:16-alpine}
+    # Prepare the client before taking the deployment lock so a slow registry
+    # cannot block other deployment operations. Pull progress goes to stderr.
     "$storage_docker" image inspect "$storage_image" >/dev/null 2>&1 || \
-        "$storage_docker" pull "$storage_image" >&2 || \
-        fail "cannot prepare PostgreSQL client image $storage_image"
+        timeout --kill-after=5 300 "$storage_docker" pull "$storage_image" >&2 || \
+        fail "cannot prepare PostgreSQL client image $storage_image (download failed or timed out)"
+
+    # Use the same local lock as the updater. Cross-host checks must still run
+    # sequentially: PostgreSQL has a single challenge field, not a nonce log.
+    # shellcheck source=deploy/join/deployment-lock.sh
+    source "$storage_script_dir/deployment-lock.sh"
+    lock_dir=$(cd -- "$(dirname -- "$storage_config_env")" && pwd -P)
+    project=$("$storage_docker" inspect --format '{{index .Config.Labels "com.docker.compose.project"}}' "${containers[0]}") || \
+        fail "cannot inspect container ${containers[0]}"
+    [[ $project != '<no value>' ]] || project=
+    # Unlabelled standalone containers have no Compose project. Give their
+    # local checks a stable identity without borrowing an unrelated proxy's.
+    project=${project:-versiond-storage-check}
+    gonka_acquire_deployment_lock "$lock_dir" "$project" || exit 1
+
     reference_psql() (
         local client_name
         client_name="gonka-storage-psql-$(cat /proc/sys/kernel/random/uuid)"
         # A killed Docker CLI can leave its container running; remove it on exit.
-        trap '"$storage_docker" rm -f "$client_name" >/dev/null 2>&1 || true' EXIT
-        trap 'exit 130' INT
-        trap 'exit 143' TERM
-        timeout 60 "$storage_docker" run --rm --init --name "$client_name" \
+        trap '"$storage_docker" rm -fv "$client_name" >/dev/null 2>&1 || true' EXIT
+        # Keep the CLI in the caller's process group so Ctrl+C reaches it too.
+        timeout --foreground 60 "$storage_docker" run --rm --init --name "$client_name" \
             --network host --read-only \
             --env PGCONNECT_TIMEOUT=5 "${reference_args[@]}" \
             --env 'PGOPTIONS=-c statement_timeout=10000' \

--- a/deploy/join/versiond-storage-check_test.py
+++ b/deploy/join/versiond-storage-check_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Exercise --check-storage with Docker, BusyBox, psql and real databases.
+"""Exercise --check-storage with Docker, BusyBox and real databases.
 
 Only the versiond proof API is a stand-in; its addressed writes go to actual
 PostgreSQL databases. No running deployment or fixed container names are used.
@@ -9,6 +9,7 @@ import fcntl
 import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -36,6 +37,12 @@ class StorageCheck(unittest.TestCase):
         cls.identity = str(uuid.uuid4())
         cls.join = cls.root / "join"
         cls.join.mkdir()
+        # Every check runs without a host psql, including tests of failure paths.
+        cls.cli_bin = cls.root / "cli-bin"
+        cls.cli_bin.mkdir()
+        for tool in ("bash", "cat", "dirname", "docker", "flock", "jq", "sha256sum", "timeout"):
+            (cls.cli_bin / tool).symlink_to(shutil.which(tool))
+        assert shutil.which("psql", path=str(cls.cli_bin)) is None
         # Deliberately no config.env, Compose files, node, api, proxy or fleet.
         for name in ("update-devshard.sh", "versiond-storage-check.sh", "deployment-lock.sh"):
             shutil.copy2(SOURCE / name, cls.join / name)
@@ -106,8 +113,9 @@ class StorageCheck(unittest.TestCase):
 
     @classmethod
     def sql(cls, statement, database="reference"):
-        return run("psql", "-XwqAt", "-v", "ON_ERROR_STOP=1", "-c", statement,
-                   env=dict(cls.pg_env, PGDATABASE=database)).stdout.strip()
+        return run("docker", "exec", "-e", "PGPASSWORD=test-password", cls.pg,
+                   "psql", "-h", "127.0.0.1", "-U", "postgres", "-d", database,
+                   "-XwqAt", "-v", "ON_ERROR_STOP=1", "-c", statement).stdout.strip()
 
     @classmethod
     def configure(cls, member=0, *, mode="normal", databases=None):
@@ -120,7 +128,7 @@ class StorageCheck(unittest.TestCase):
             self.configure(i)
         self.sql("UPDATE devshard_storage_identity SET challenge = NULL")
 
-    def check(self, *, members=None, reference=None, extra=(), lock_path=None):
+    def check(self, *, members=None, reference=None, extra=(), lock_path=None, env_overrides=None):
         args = [str(self.join / "update-devshard.sh"), "--check-storage",
                 "--reference-env", str(reference or self.reference)]
         for member in members or self.members[:1]:
@@ -128,9 +136,11 @@ class StorageCheck(unittest.TestCase):
         # These inherited settings must never override the reference file.
         env = dict(os.environ, PGHOST="wrong.invalid", PGDATABASE="wrong",
                    PGPASSWORD="inherited-secret", PGSERVICE="wrong-service",
-                   PGOPTIONS="-c search_path=wrong", GONKA_CONFIG_ENV=str(self.join / "config.env"))
+                   PGOPTIONS="-c search_path=wrong", GONKA_CONFIG_ENV=str(self.join / "config.env"),
+                   PATH=str(self.cli_bin), DEVSHARD_POSTGRES_IMAGE="postgres:16-alpine")
         if lock_path:
             env["GONKA_DEPLOYMENT_LOCK"] = str(lock_path)
+        env.update(env_overrides or {})
         result = subprocess.run([*args, *extra], capture_output=True, text=True,
                                 env=env, timeout=90)
         self.assertNotIn("test-password", result.stdout + result.stderr)
@@ -193,6 +203,73 @@ class StorageCheck(unittest.TestCase):
         bad = self.root / "bad-reference.env"
         bad.write_text(self.reference.read_text() + "PGPASSWORD='wrong-password'\n")
         self.assert_failed(self.check(reference=bad), "cannot read the reference PostgreSQL")
+
+    def test_explicit_ssl_disable(self):
+        plain = self.root / "plain-reference.env"
+        plain.write_text(self.reference.read_text() + "PGSSLMODE=disable\n")
+        result = self.check(reference=plain, env_overrides={"DEVSHARD_POSTGRES_IMAGE": self.image})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Storage check passed", result.stdout)
+
+    def test_unsupported_tls_settings(self):
+        for key, value in (("PGSSLMODE", "verify-full"), ("PGSSLMODE", "require"),
+                           ("PGSSLROOTCERT", "/missing/root.crt"),
+                           ("PGSSLCERT", "/missing/client.crt"),
+                           ("PGSSLKEY", "/missing/client.key")):
+            with self.subTest(key=key, value=value):
+                unsupported = self.root / "tls-reference.env"
+                unsupported.write_text(self.reference.read_text() + f"{key}={value}\n")
+                self.assert_failed(self.check(reference=unsupported), f"unsupported TLS setting {key}")
+                self.assertEqual(self.sql("SELECT challenge FROM devshard_storage_identity"), "")
+
+    def test_client_image_pull_failure(self):
+        wrapper = self.root / "docker-pull-failure"
+        wrapper.write_text(
+            "#!/bin/bash\n"
+            'if [[ $1 == image && $2 == inspect ]] || [[ $1 == pull ]]; then exit 1; fi\n'
+            f"exec {shlex.quote(shutil.which('docker'))} \"$@\"\n")
+        wrapper.chmod(0o755)
+        self.assert_failed(self.check(env_overrides={"DOCKER_BIN": str(wrapper)}),
+                           "cannot prepare PostgreSQL client image")
+        self.assertEqual(self.sql("SELECT challenge FROM devshard_storage_identity"), "")
+
+    def test_client_cleanup_after_timeout(self):
+        directory = self.root / "timeout-test"
+        directory.mkdir()
+        name_file = directory / "client-name"
+        docker = shlex.quote(shutil.which("docker"))
+        wrapper = directory / "docker-wrapper"
+        wrapper.write_text(
+            "#!/bin/bash\n"
+            'if [[ $1 == run ]]; then\n'
+            '  while (($#)); do\n'
+            '    if [[ $1 == --name ]]; then name=$2; break; fi\n'
+            '    shift\n'
+            '  done\n'
+            f'  {docker} run -d --rm --name "$name" --network none --read-only '
+            '--entrypoint sleep postgres:16-alpine 300 >/dev/null || exit 1\n'
+            f'  printf "%s\\n" "$name" > {shlex.quote(str(name_file))}\n'
+            f'  exec {shlex.quote(shutil.which("sleep"))} 300\n'
+            'fi\n'
+            f'exec {docker} "$@"\n')
+        wrapper.chmod(0o755)
+        # Kill the CLI without signalling its container: cleanup must remove it.
+        timer = directory / "timeout"
+        timer.write_text("#!/bin/bash\nshift\n"
+                         f'exec {shlex.quote(shutil.which("timeout"))} --signal=KILL 5 "$@"\n')
+        timer.chmod(0o755)
+        try:
+            result = self.check(env_overrides={"DOCKER_BIN": str(wrapper),
+                                               "PATH": f"{directory}:{self.cli_bin}"})
+            self.assert_failed(result, "cannot read the reference PostgreSQL")
+            self.assertTrue(name_file.exists(), "client container was never started")
+            client = name_file.read_text().strip()
+            inspected = subprocess.run(["docker", "inspect", client], capture_output=True, text=True)
+            self.assertNotEqual(inspected.returncode, 0, "timed-out client container was retained")
+            self.assertEqual(self.sql("SELECT challenge FROM devshard_storage_identity"), "")
+        finally:
+            if name_file.exists():
+                subprocess.run(["docker", "rm", "-f", name_file.read_text().strip()], capture_output=True)
 
     def test_updater_capacity_against_real_postgres(self):
         # Run the host updater's actual SQL preflight against this isolated

--- a/deploy/join/versiond-storage-check_test.py
+++ b/deploy/join/versiond-storage-check_test.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import shlex
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
@@ -128,7 +129,7 @@ class StorageCheck(unittest.TestCase):
             self.configure(i)
         self.sql("UPDATE devshard_storage_identity SET challenge = NULL")
 
-    def check(self, *, members=None, reference=None, extra=(), lock_path=None, env_overrides=None):
+    def check_command(self, *, members=None, reference=None, extra=(), lock_path=None, env_overrides=None):
         args = [str(self.join / "update-devshard.sh"), "--check-storage",
                 "--reference-env", str(reference or self.reference)]
         for member in members or self.members[:1]:
@@ -137,11 +138,18 @@ class StorageCheck(unittest.TestCase):
         env = dict(os.environ, PGHOST="wrong.invalid", PGDATABASE="wrong",
                    PGPASSWORD="inherited-secret", PGSERVICE="wrong-service",
                    PGOPTIONS="-c search_path=wrong", GONKA_CONFIG_ENV=str(self.join / "config.env"),
-                   PATH=str(self.cli_bin), DEVSHARD_POSTGRES_IMAGE="postgres:16-alpine")
+                   PATH=str(self.cli_bin), GONKA_DEPLOYMENT_LOCK=str(self.root / "deployment.lock"))
+        # Keep independent test fixtures and host shell startup files isolated.
+        env.pop("BASH_ENV", None)
+        env.pop("VERSIOND_STORAGE_CHECK_IMAGE", None)
         if lock_path:
             env["GONKA_DEPLOYMENT_LOCK"] = str(lock_path)
         env.update(env_overrides or {})
-        result = subprocess.run([*args, *extra], capture_output=True, text=True,
+        return [*args, *extra], env
+
+    def check(self, **kwargs):
+        args, env = self.check_command(**kwargs)
+        result = subprocess.run(args, capture_output=True, text=True,
                                 env=env, timeout=90)
         self.assertNotIn("test-password", result.stdout + result.stderr)
         self.assertNotIn("inherited-secret", result.stdout + result.stderr)
@@ -207,7 +215,7 @@ class StorageCheck(unittest.TestCase):
     def test_explicit_ssl_disable(self):
         plain = self.root / "plain-reference.env"
         plain.write_text(self.reference.read_text() + "PGSSLMODE=disable\n")
-        result = self.check(reference=plain, env_overrides={"DEVSHARD_POSTGRES_IMAGE": self.image})
+        result = self.check(reference=plain)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Storage check passed", result.stdout)
 
@@ -233,10 +241,98 @@ class StorageCheck(unittest.TestCase):
                            "cannot prepare PostgreSQL client image")
         self.assertEqual(self.sql("SELECT challenge FROM devshard_storage_identity"), "")
 
+    def test_client_image_selection(self):
+        observed = self.root / "client-images"
+        wrapper = self.root / "docker-image-observer"
+        wrapper.write_text(
+            "#!/bin/bash\n"
+            'args=("$@")\n'
+            'if [[ $1 == image && $2 == inspect ]]; then\n'
+            f'  printf "inspect %s\\n" "$3" >> {shlex.quote(str(observed))}\n'
+            'elif [[ $1 == run ]]; then\n'
+            '  while (($#)) && [[ $1 != --entrypoint ]]; do shift; done\n'
+            '  shift 2\n'
+            f'  printf "run %s\\n" "$1" >> {shlex.quote(str(observed))}\n'
+            'elif [[ $1 == pull ]]; then exit 1\n'
+            'fi\n'
+            f'exec {shlex.quote(shutil.which("docker"))} "${{args[@]}}"\n')
+        wrapper.chmod(0o755)
+        for source in ("default", "server-setting", "shell", "reference"):
+            with self.subTest(source=source):
+                observed.write_text("")
+                reference = self.root / "image-reference.env"
+                reference.write_text(self.reference.read_text())
+                settings = {"DOCKER_BIN": str(wrapper)}
+                expected = "postgres:16-alpine"
+                if source == "server-setting":
+                    settings["DEVSHARD_POSTGRES_IMAGE"] = "server-only:must-not-be-used"
+                elif source == "shell":
+                    settings["VERSIOND_STORAGE_CHECK_IMAGE"] = expected = self.image
+                elif source == "reference":
+                    reference.write_text(reference.read_text() +
+                                         f"VERSIOND_STORAGE_CHECK_IMAGE={self.image}\n")
+                    expected = self.image
+                result = self.check(reference=reference, env_overrides=settings)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(observed.read_text().splitlines(),
+                                 [f"inspect {expected}", *[f"run {expected}"] * 3])
+
+        # Choosing the client must leave the real Compose server image unchanged.
+        env = dict(os.environ, KEY_NAME="test", DEVSHARD_POSTGRES_PASSWORD="test-password")
+        env.pop("DEVSHARD_POSTGRES_IMAGE", None)
+        compose = ["docker", "compose", "-f", str(SOURCE / "docker-compose.yml"),
+                   "-f", str(SOURCE / "docker-compose.versiond.yml"), "config", "--format", "json"]
+        before = json.loads(run(*compose, env=env).stdout)["services"]["devshard-postgres"]["image"]
+        env["VERSIOND_STORAGE_CHECK_IMAGE"] = self.image
+        after = json.loads(run(*compose, env=env).stdout)["services"]["devshard-postgres"]["image"]
+        self.assertEqual(before, after)
+        self.assertTrue(after.startswith("postgres@sha256:"), after)
+
+    def test_client_pull_timeout_does_not_hold_lock(self):
+        directory = self.root / "pull-timeout"
+        directory.mkdir()
+        started = directory / "started"
+        wrapper = directory / "docker-wrapper"
+        wrapper.write_text(
+            "#!/bin/bash\n"
+            'if [[ $1 == image && $2 == inspect ]]; then exit 1; fi\n'
+            'if [[ $1 == pull ]]; then\n'
+            f'  echo started > {shlex.quote(str(started))}\n'
+            f'  exec {shlex.quote(shutil.which("sleep"))} 30\n'
+            'fi\n'
+            f'exec {shlex.quote(shutil.which("docker"))} "$@"\n')
+        wrapper.chmod(0o755)
+        timer = directory / "timeout"
+        timer.write_text(
+            '#!/bin/bash\n[[ $1 == --kill-after=* ]] && shift\nshift\n'
+            f'exec {shlex.quote(shutil.which("timeout"))} --kill-after=1 2 "$@"\n')
+        timer.chmod(0o755)
+        lock_path = directory / "deployment.lock"
+        args, env = self.check_command(lock_path=lock_path, env_overrides={
+            "DOCKER_BIN": str(wrapper), "PATH": f"{directory}:{self.cli_bin}"})
+        process = subprocess.Popen(args, env=env, text=True, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, start_new_session=True)
+        try:
+            deadline = time.monotonic() + 5
+            while not started.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            self.assertTrue(started.exists(), "image download was never started")
+            with lock_path.open("a") as lock:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                stdout, stderr = process.communicate(timeout=5)
+            self.assert_failed(subprocess.CompletedProcess(args, process.returncode, stdout, stderr),
+                               "download failed or timed out")
+            self.assertEqual(self.sql("SELECT challenge FROM devshard_storage_identity"), "")
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.communicate()
+
     def test_client_cleanup_after_timeout(self):
         directory = self.root / "timeout-test"
         directory.mkdir()
         name_file = directory / "client-name"
+        mounts_file = directory / "client-mounts"
         docker = shlex.quote(shutil.which("docker"))
         wrapper = directory / "docker-wrapper"
         wrapper.write_text(
@@ -249,13 +345,14 @@ class StorageCheck(unittest.TestCase):
             f'  {docker} run -d --rm --name "$name" --network none --read-only '
             '--entrypoint sleep postgres:16-alpine 300 >/dev/null || exit 1\n'
             f'  printf "%s\\n" "$name" > {shlex.quote(str(name_file))}\n'
+            f'  {docker} inspect --format \'{{{{json .Mounts}}}}\' "$name" > {shlex.quote(str(mounts_file))}\n'
             f'  exec {shlex.quote(shutil.which("sleep"))} 300\n'
             'fi\n'
             f'exec {docker} "$@"\n')
         wrapper.chmod(0o755)
         # Kill the CLI without signalling its container: cleanup must remove it.
         timer = directory / "timeout"
-        timer.write_text("#!/bin/bash\nshift\n"
+        timer.write_text('#!/bin/bash\n[[ $1 == --foreground ]] && shift\nshift\n'
                          f'exec {shlex.quote(shutil.which("timeout"))} --signal=KILL 5 "$@"\n')
         timer.chmod(0o755)
         try:
@@ -266,10 +363,84 @@ class StorageCheck(unittest.TestCase):
             client = name_file.read_text().strip()
             inspected = subprocess.run(["docker", "inspect", client], capture_output=True, text=True)
             self.assertNotEqual(inspected.returncode, 0, "timed-out client container was retained")
+            volumes = [m["Name"] for m in json.loads(mounts_file.read_text()) if m["Type"] == "volume"]
+            self.assertTrue(volumes, "client image must exercise anonymous volume cleanup")
+            for volume in volumes:
+                inspected = subprocess.run(["docker", "volume", "inspect", volume], capture_output=True)
+                self.assertNotEqual(inspected.returncode, 0, "client volume was retained")
             self.assertEqual(self.sql("SELECT challenge FROM devshard_storage_identity"), "")
         finally:
             if name_file.exists():
-                subprocess.run(["docker", "rm", "-f", name_file.read_text().strip()], capture_output=True)
+                subprocess.run(["docker", "rm", "-fv", name_file.read_text().strip()], capture_output=True)
+            if mounts_file.exists():
+                for mount in json.loads(mounts_file.read_text()):
+                    if mount["Type"] == "volume":
+                        subprocess.run(["docker", "volume", "rm", mount["Name"]], capture_output=True)
+
+    def test_client_cleanup_after_signals(self):
+        self.sql("CREATE DATABASE signal_reference")
+        self.sql("CREATE VIEW devshard_storage_identity AS "
+                 f"SELECT true AS singleton, '{self.identity}'::uuid AS identity FROM pg_sleep(30)",
+                 "signal_reference")
+        reference = self.root / "signal-reference.env"
+        reference.write_text(self.reference.read_text() + "PGDATABASE=signal_reference\n")
+        try:
+            for signum in (signal.SIGTERM, signal.SIGINT):
+                with self.subTest(signal=signum.name):
+                    name_file = self.root / "signal-client-name"
+                    name_file.unlink(missing_ok=True)
+                    wrapper = self.root / "docker-signal-observer"
+                    wrapper.write_text(
+                        '#!/bin/bash\nargs=("$@")\n'
+                        'if [[ $1 == run ]]; then\n'
+                        '  while (($#)) && [[ $1 != --name ]]; do shift; done\n'
+                        f'  printf "%s\\n" "$2" > {shlex.quote(str(name_file))}\n'
+                        'fi\n'
+                        f'exec {shlex.quote(shutil.which("docker"))} "${{args[@]}}"\n')
+                    wrapper.chmod(0o755)
+                    args, env = self.check_command(reference=reference,
+                                                   env_overrides={"DOCKER_BIN": str(wrapper)})
+                    process = subprocess.Popen(args, env=env, text=True, stdout=subprocess.PIPE,
+                                               stderr=subprocess.PIPE, start_new_session=True)
+                    client = None
+                    volumes = []
+                    try:
+                        deadline = time.monotonic() + 8
+                        while time.monotonic() < deadline:
+                            if name_file.exists() and self.sql(
+                                    "SELECT count(*) FROM pg_stat_activity "
+                                    "WHERE datname='signal_reference' AND wait_event='PgSleep'") == "1":
+                                break
+                            time.sleep(0.05)
+                        else:
+                            self.fail("reference query never reached PostgreSQL")
+                        client = name_file.read_text().strip()
+                        state = json.loads(run("docker", "inspect", client).stdout)[0]
+                        volumes = [m["Name"] for m in state["Mounts"] if m["Type"] == "volume"]
+                        self.assertTrue(volumes)
+                        os.killpg(process.pid, signum)
+                        stdout, _ = process.communicate(timeout=4)
+                        self.assertNotEqual(process.returncode, 0)
+                        self.assertNotIn("Storage check passed", stdout)
+                        inspected = subprocess.run(["docker", "inspect", client], capture_output=True)
+                        self.assertNotEqual(inspected.returncode, 0, "interrupted client was retained")
+                        for volume in volumes:
+                            inspected = subprocess.run(["docker", "volume", "inspect", volume], capture_output=True)
+                            self.assertNotEqual(inspected.returncode, 0, "interrupted client volume was retained")
+                    finally:
+                        if not client and name_file.exists():
+                            client = name_file.read_text().strip()
+                        if client:
+                            subprocess.run(["docker", "rm", "-fv", client], capture_output=True)
+                        if process.poll() is None:
+                            os.killpg(process.pid, signal.SIGKILL)
+                        process.communicate(timeout=15)
+                        for volume in volumes:
+                            subprocess.run(["docker", "volume", "rm", volume], capture_output=True)
+                        self.sql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                                 "WHERE datname='signal_reference'")
+        finally:
+            self.sql("DROP DATABASE signal_reference WITH (FORCE)")
 
     def test_updater_capacity_against_real_postgres(self):
         # Run the host updater's actual SQL preflight against this isolated

--- a/devshard/docs/release-0.2.15-v5.md
+++ b/devshard/docs/release-0.2.15-v5.md
@@ -275,9 +275,10 @@ The host updater supports the bundled PostgreSQL and an external writable
 PostgreSQL endpoint reachable from the deployment network without custom TLS
 configuration. PostgreSQL TLS deployment and certificate management are outside
 this updater's scope. It rejects explicitly configured `PGSSL*` options,
-except `PGSSLMODE=disable`; leave them unset for the stock deployment. This
-restriction applies to host updates, not the separate `--check-storage` command
-whose reference connection uses a local PostgreSQL client.
+except `PGSSLMODE=disable`; leave them unset for the stock deployment. The
+separate `--check-storage` command now runs its PostgreSQL client in Docker
+and has the same restriction. It no longer uses host TLS certificate files.
+Do not disable TLS required by a provider to use these commands.
 
 The write probe opens PostgreSQL with the model's credentials from a temporary
 helper container. It creates and drops a temporary table, so a read-only
@@ -528,15 +529,29 @@ On each **remote machine**:
 2. Copy `.inference/keyring-file` from the network node into `./.inference`;
    the same `KEY_NAME` and `KEYRING_PASSWORD` apply.
 3. `docker compose -f docker-compose.versiond-remote.yml up -d --wait`.
-4. Install `psql` (the PostgreSQL client) and `jq` on this host. Copy
+4. Install `jq` on this host. The PostgreSQL client (`psql`) runs in Docker. Copy
    `pool-postgres.env.template` to `pool-postgres.env`, set its permissions
    to `600`, and fill it with the existing pool's known working PostgreSQL
    connection settings. Obtain these independently of the replica being
-   checked; certificate paths refer to files on this host. Then run:
+   checked. For password authentication, set `PGPASSWORD` in this file;
+   the host's `.pgpass` is not read. Then run:
 
    ```bash
    ./update-devshard.sh --check-storage --reference-env ./pool-postgres.env
    ```
+
+   The client image defaults to `postgres:16-alpine`. To select another image,
+   set `VERSIOND_STORAGE_CHECK_IMAGE` in `pool-postgres.env` or export it in
+   the shell; this mode does not read `config.env`. This setting does not
+   change the PostgreSQL server image. Preload the image with `docker pull`
+   for offline operation; otherwise the checker downloads it with a
+   five-minute timeout before acquiring the deployment lock.
+
+   Use Linux Docker Engine with host networking. `PGHOST` must be a TCP
+   endpoint reachable from the client container. Host Unix sockets and TLS
+   certificate files are not mounted. Rootless Docker before Engine 29.5
+   isolates the container's host network; Docker Desktop needs host networking
+   enabled. In those environments, host loopback reachability alone is insufficient.
 
    Continue only when it prints `Storage check passed` and exits with code 0.
    It checks the running `versiond` container without requiring the network


### PR DESCRIPTION
`update-devshard.sh --check-storage` required a PostgreSQL client installed on the host. Run reference queries in temporary Docker containers so the check can work without host `psql`.

Select the client with `VERSIOND_STORAGE_CHECK_IMAGE` in the reference file or shell (default `postgres:16-alpine`), independently of the production database image. Download missing images before acquiring the deployment lock, with a five-minute timeout. Remove client containers and their anonymous volumes on failure, and keep the Docker CLI in the caller's process group so interrupts reach it.

Update the release guide, reference template, help, and CI. The Docker client requires a reachable TCP endpoint and does not use host `.pgpass`, Unix sockets, or certificate files. Explicit TLS settings other than `PGSSLMODE=disable` are rejected; this narrows the previous standalone client's capabilities. Do not disable provider-required TLS to use this check.

Validation:
- 23 storage tests passed against real PostgreSQL with host `psql` absent from `PATH`.
- Added checks for default and overridden client images, unchanged Compose server image, bounded image download without holding the lock, and container/volume cleanup after timeout and process-group SIGINT/SIGTERM.
- The new regression checks fail on the previous implementation.
- Updater tests, ShellCheck, and Markdown rendering passed.

This PR remains a draft for later consideration. The current release's setup instructions in #1744 retain the host `psql` requirement and do not depend on this change.
