### PR TITLE
fix(dapi): send Content-Type: application/json on JSON POSTs to MLNode

### DIFF
--- a/common/utils/http.go
+++ b/common/utils/http.go
@@ -32,6 +32,10 @@ func SendPostJsonRequest(ctx context.Context, client *http.Client, url string, p
 			return nil, err
 		}
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	if err != nil {

--- a/common/utils/http.go
+++ b/common/utils/http.go
@@ -26,7 +26,8 @@ func SendPostJsonRequest(ctx context.Context, client *http.Client, url string, p
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	} else {
 		// Marshal the payload to JSON.
-		jsonData, err := json.Marshal(payload)
+		var jsonData []byte
+		jsonData, err = json.Marshal(payload)
 		if err != nil {
 			return nil, err
 		}
@@ -34,10 +35,7 @@ func SendPostJsonRequest(ctx context.Context, client *http.Client, url string, p
 	}
 
 	if err != nil {
-		return nil, err
-	}
-	if req == nil {
-		logging.Error("SendPostJsonRequest. Failed to create HTTP request", types.Server, "url", url, "payload", payload)
+		logging.Error("SendPostJsonRequest. Failed to create HTTP request", types.Server, "url", url, "error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Two commits in `SendPostJsonRequest`, `common/utils/http.go`.

1. **Stop shadowing `err`.** `jsonData, err := json.Marshal(...)` declared a new `err` inside the else block, so a `NewRequestWithContext` error in that branch never reached the check after the block: the function returned `(nil, nil)` and the caller dereferenced a nil response. The `req == nil` guard below logged the symptom and returned a nil error with it. Assign to the outer `err`, drop the guard, log the error instead of the payload.

2. **Send `Content-Type: application/json`.** The payload was marshalled but the header never set, so `inference/up`, `pow/init/generate` and the model endpoints reach mlnode with a header-less JSON body. FastAPI 0.115 (mlnode's current pin) tolerates it; from 0.132 `strict_content_type` rejects the request with 422 before the handler runs. Nil-payload requests are unchanged.

Replaces [#1590](https://github.com/gonka-ai/gonka/pull/1590), which patched the receiving side instead.
